### PR TITLE
[loader] Add debugging code for FetcherCache crash

### DIFF
--- a/cobalt/loader/loader_factory.cc
+++ b/cobalt/loader/loader_factory.cc
@@ -31,7 +31,13 @@ LoaderFactory::LoaderFactory(const char* name, FetcherFactory* fetcher_factory,
       debugger_hooks_(debugger_hooks),
       resource_provider_(resource_provider) {
   if (encoded_image_cache_capacity > 0) {
-    fetcher_cache_.reset(new FetcherCache(name, encoded_image_cache_capacity));
+    fetcher_cache_ = new FetcherCache(name, encoded_image_cache_capacity);
+  }
+}
+
+LoaderFactory::~LoaderFactory() {
+  if (fetcher_cache_) {
+    fetcher_cache_->DestroySoon();
   }
 }
 

--- a/cobalt/loader/loader_factory.h
+++ b/cobalt/loader/loader_factory.h
@@ -47,6 +47,7 @@ class LoaderFactory : public ScriptLoaderFactory {
                 const base::DebuggerHooks& debugger_hooks,
                 size_t encoded_image_cache_capacity,
                 base::ThreadPriority loader_thread_priority);
+  ~LoaderFactory();
 
   // Creates a loader that fetches and decodes an image.
   std::unique_ptr<Loader> CreateImageLoader(
@@ -108,7 +109,7 @@ class LoaderFactory : public ScriptLoaderFactory {
   // Used to cache the fetched raw data.  Note that currently the cache is only
   // used to cache Image data.  We may introduce more caches once we want to
   // cache fetched data for other resource types.
-  std::unique_ptr<FetcherCache> fetcher_cache_;
+  scoped_refptr<FetcherCache> fetcher_cache_;
 
   // Used with CLOG to report errors with the image source.
   const base::DebuggerHooks& debugger_hooks_;


### PR DESCRIPTION
The CHECK for consistency in linked_hash_map::erase() fails in production, where we are unable to find an obvious cause.

Now FetcherCache is ref counted to ensure that there isn't any life time issue, and extra CHECKs are added so we can have more information about the crash once released.

b/270993319