### PR TITLE
Allow controlling Client Hint Headers based on request type.

### DIFF
--- a/cobalt/h5vcc/h5vcc_settings.cc
+++ b/cobalt/h5vcc/h5vcc_settings.cc
@@ -95,10 +95,11 @@ bool H5vccSettings::Set(const std::string& name, int32 value) const {
     } else {
       persistent_settings_->SetPersistentSetting(
           network::kClientHintHeadersEnabledPersistentSettingsKey,
-          std::make_unique<base::Value>(value != 0));
+          std::make_unique<base::Value>(value));
       // Tell NetworkModule (if exists) to re-query persistent settings.
       if (network_module_) {
-        network_module_->SetEnableClientHintHeadersFromPersistentSettings();
+        network_module_
+            ->SetEnableClientHintHeadersFlagsFromPersistentSettings();
       }
       return true;
     }

--- a/cobalt/loader/cors_preflight.cc
+++ b/cobalt/loader/cors_preflight.cc
@@ -280,7 +280,8 @@ bool CORSPreflight::Send() {
   url_fetcher_ = net::URLFetcher::Create(url_, net::URLFetcher::OPTIONS, this);
   url_fetcher_->SetRequestContext(
       network_module_->url_request_context_getter().get());
-  network_module_->AddClientHintHeaders(*url_fetcher_);
+  network_module_->AddClientHintHeaders(*url_fetcher_,
+                                        network::kCallTypePreflight);
   url_fetcher_->AddExtraRequestHeader(kOriginheadername + origin_);
   // 3. Let headers be the names of request's header list's headers,
   //    excluding CORS-safelisted request-headers and duplicates, sorted

--- a/cobalt/loader/net_fetcher.cc
+++ b/cobalt/loader/net_fetcher.cc
@@ -135,7 +135,7 @@ NetFetcher::NetFetcher(const GURL& url, bool main_resource,
         net::LOAD_DO_NOT_SEND_COOKIES | net::LOAD_DO_NOT_SEND_AUTH_DATA;
     url_fetcher_->SetLoadFlags(kDisableCookiesLoadFlags);
   }
-  network_module->AddClientHintHeaders(*url_fetcher_);
+  network_module->AddClientHintHeaders(*url_fetcher_, network::kCallTypeLoader);
 
   // Delay the actual start until this function is complete. Otherwise we might
   // call handler's callbacks at an unexpected time- e.g. receiving OnError()

--- a/cobalt/media/url_fetcher_data_source.cc
+++ b/cobalt/media/url_fetcher_data_source.cc
@@ -340,7 +340,7 @@ void URLFetcherDataSource::CreateNewFetcher() {
       std::move(net::URLFetcher::Create(url_, net::URLFetcher::GET, this));
   fetcher_->SetRequestContext(
       network_module_->url_request_context_getter().get());
-  network_module_->AddClientHintHeaders(*fetcher_);
+  network_module_->AddClientHintHeaders(*fetcher_, network::kCallTypeMedia);
   std::unique_ptr<loader::URLFetcherStringWriter> download_data_writer(
       new loader::URLFetcherStringWriter());
   fetcher_->SaveResponseWithWriter(std::move(download_data_writer));

--- a/cobalt/network/net_poster.cc
+++ b/cobalt/network/net_poster.cc
@@ -49,7 +49,7 @@ void NetPoster::Send(const GURL& url, const std::string& content_type,
   url_fetcher->SetStopOnRedirect(true);
   url_fetcher->SetRequestContext(
       network_module_->url_request_context_getter().get());
-  network_module_->AddClientHintHeaders(*url_fetcher);
+  network_module_->AddClientHintHeaders(*url_fetcher, network::kCallTypePost);
 
   if (data.size()) {
     url_fetcher->SetUploadData(content_type, data);

--- a/cobalt/network/network_module.h
+++ b/cobalt/network/network_module.h
@@ -48,6 +48,18 @@ class WaitableEvent;
 namespace cobalt {
 namespace network {
 
+// Used to differentiate type of network call for Client Hint Headers.
+// Values correspond to bit masks against |enable_client_hint_headers_flags_|.
+enum ClientHintHeadersCallType : int32_t {
+  kCallTypeLoader = (1u << 0),
+  kCallTypeMedia = (1u << 1),
+  kCallTypePost = (1u << 2),
+  kCallTypePreflight = (1u << 3),
+  kCallTypeUpdater = (1u << 4),
+  kCallTypeXHR = (1u << 5),
+};
+
+// Holds bit mask flag, read into |enable_client_hint_headers_flags_|.
 const char kClientHintHeadersEnabledPersistentSettingsKey[] =
     "clientHintHeadersEnabled";
 
@@ -116,10 +128,11 @@ class NetworkModule : public base::MessageLoop::DestructionObserver {
   void SetEnableQuic(bool enable_quic);
 
   // Checks persistent settings to determine if Client Hint Headers are enabled.
-  void SetEnableClientHintHeadersFromPersistentSettings();
+  void SetEnableClientHintHeadersFlagsFromPersistentSettings();
 
   // Adds the Client Hint Headers to the provided URLFetcher if enabled.
-  void AddClientHintHeaders(net::URLFetcher& url_fetcher) const;
+  void AddClientHintHeaders(net::URLFetcher& url_fetcher,
+                            ClientHintHeadersCallType call_type) const;
 
   // From base::MessageLoop::DestructionObserver.
   void WillDestroyCurrentMessageLoop() override;
@@ -131,7 +144,7 @@ class NetworkModule : public base::MessageLoop::DestructionObserver {
   std::unique_ptr<network_bridge::NetPoster> CreateNetPoster();
 
   std::vector<std::string> client_hint_headers_;
-  starboard::atomic_bool enable_client_hint_headers_;
+  starboard::atomic_int32_t enable_client_hint_headers_flags_;
   std::unique_ptr<storage::StorageManager> storage_manager_;
   std::unique_ptr<base::Thread> thread_;
   std::unique_ptr<URLRequestContext> url_request_context_;

--- a/cobalt/updater/network_fetcher.cc
+++ b/cobalt/updater/network_fetcher.cc
@@ -189,7 +189,8 @@ void NetworkFetcher::CreateUrlFetcher(
 
   url_fetcher_->SetRequestContext(
       network_module_->url_request_context_getter().get());
-  network_module_->AddClientHintHeaders(*url_fetcher_);
+  network_module_->AddClientHintHeaders(*url_fetcher_,
+                                        network::kCallTypeUpdater);
 
   // Request mode is kCORSModeOmitCredentials.
   const uint32 kDisableCookiesAndCacheLoadFlags =

--- a/cobalt/xhr/xml_http_request.cc
+++ b/cobalt/xhr/xml_http_request.cc
@@ -1424,7 +1424,7 @@ void XMLHttpRequestImpl::StartRequest(const std::string& request_body) {
   // Don't retry, let the caller deal with it.
   url_fetcher_->SetAutomaticallyRetryOn5xx(false);
   url_fetcher_->SetExtraRequestHeaders(request_headers_.ToString());
-  network_module->AddClientHintHeaders(*url_fetcher_);
+  network_module->AddClientHintHeaders(*url_fetcher_, network::kCallTypeXHR);
 
   // We want to do cors check and preflight during redirects
   url_fetcher_->SetStopOnRedirect(true);


### PR DESCRIPTION
The bootstrap request should be all that's needed, and the app we receive in response will handle propagation to subsequent requests it makes.

b/188060079