### PR TITLE
Remove unused Starboard configs

### DIFF
--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -100,6 +100,9 @@ All the allowed device type values are now checked by nplb test:
 ### Deprecated kSbHasAc3Audio
 This constant is no longer used and has been deprecated.
 
+### Removed BILINEAR_FILTERING_SUPPORT config
+The unused macro for SB_HAS_BILINEAR_FILTERING_SUPPORT feature has been removed.
+
 ## Version 14
 ### Add MP3, FLAC, and PCM values to SbMediaAudioCodec.
 This makes it possible to support these codecs in the future.

--- a/starboard/android/shared/configuration_public.h
+++ b/starboard/android/shared/configuration_public.h
@@ -108,11 +108,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 1

--- a/starboard/configuration.h
+++ b/starboard/configuration.h
@@ -596,10 +596,6 @@ struct CompileAssert {};
 #error "New versions of Starboard specify player output mode at runtime."
 #endif
 
-#if !defined(SB_HAS_BILINEAR_FILTERING_SUPPORT)
-#error "Your platform must define SB_HAS_BILINEAR_FILTERING_SUPPORT."
-#endif
-
 #if !defined(SB_HAS_NV12_TEXTURE_SUPPORT)
 #error "Your platform must define SB_HAS_NV12_TEXTURE_SUPPORT."
 #endif

--- a/starboard/evergreen/arm/hardfp/configuration_public.h
+++ b/starboard/evergreen/arm/hardfp/configuration_public.h
@@ -106,11 +106,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 1

--- a/starboard/evergreen/arm/softfp/configuration_public.h
+++ b/starboard/evergreen/arm/softfp/configuration_public.h
@@ -106,11 +106,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 1

--- a/starboard/evergreen/arm64/configuration_public.h
+++ b/starboard/evergreen/arm64/configuration_public.h
@@ -106,11 +106,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 1

--- a/starboard/evergreen/x64/configuration_public.h
+++ b/starboard/evergreen/x64/configuration_public.h
@@ -106,11 +106,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 0

--- a/starboard/evergreen/x86/configuration_public.h
+++ b/starboard/evergreen/x86/configuration_public.h
@@ -106,11 +106,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 1

--- a/starboard/linux/x64x11/configuration_public.h
+++ b/starboard/linux/x64x11/configuration_public.h
@@ -29,11 +29,6 @@
 // available on this platform. For a definitive measure, the application should
 // still call SbSystemGetNumberOfProcessors at runtime.
 
-// Whether the current platform's thread scheduler will automatically balance
-// threads between cores, as opposed to systems where threads will only ever run
-// on the specifically pinned core.
-#define SB_HAS_CROSS_CORE_SCHEDULER 1
-
 // --- Graphics Configuration ------------------------------------------------
 
 // Indicates whether or not the given platform supports rendering of NV12

--- a/starboard/raspi/shared/configuration_public.h
+++ b/starboard/raspi/shared/configuration_public.h
@@ -102,11 +102,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 1

--- a/starboard/stub/configuration_public.h
+++ b/starboard/stub/configuration_public.h
@@ -142,11 +142,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 0

--- a/starboard/win/shared/configuration_public.h
+++ b/starboard/win/shared/configuration_public.h
@@ -112,11 +112,6 @@
 
 // --- Graphics Configuration ------------------------------------------------
 
-// Indicates whether or not the given platform supports bilinear filtering.
-// This can be checked to enable/disable renderer tests that verify that this is
-// working properly.
-#define SB_HAS_BILINEAR_FILTERING_SUPPORT 1
-
 // Indicates whether or not the given platform supports rendering of NV12
 // textures. These textures typically originate from video decoders.
 #define SB_HAS_NV12_TEXTURE_SUPPORT 0


### PR DESCRIPTION
BILINEAR_FILTERING flags is long unused, and can be safely removed at this point.

b/289212354