### PR TITLE
Deprecate SbUserGetProperty, SbUserGetPropertySize SB API

### DIFF
--- a/cobalt/site/docs/reference/starboard/modules/user.md
+++ b/cobalt/site/docs/reference/starboard/modules/user.md
@@ -16,28 +16,6 @@ thread, or perform proper synchronization around all calls.
 
 Well-defined value for an invalid user.
 
-## Enums ##
-
-### SbUserPropertyId ###
-
-A set of string properties that can be queried on a user.
-
-#### Values ####
-
-*   `kSbUserPropertyAvatarUrl`
-
-    The URL to the avatar for a user. Avatars are not provided on all platforms.
-*   `kSbUserPropertyHomeDirectory`
-
-    The path to a user's home directory, if supported on this platform.
-*   `kSbUserPropertyUserName`
-
-    The username of a user, which may be the same as the User ID, or it may be
-    friendlier.
-*   `kSbUserPropertyUserId`
-
-    A unique user ID of a user.
-
 ## Typedefs ##
 
 ### SbUser ###
@@ -67,41 +45,6 @@ the referenced objects will persist for the lifetime of the app.
 
 ```
 SbUser SbUserGetCurrent()
-```
-
-### SbUserGetProperty ###
-
-Retrieves the value of `property_id` for `user` and places it in `out_value`.
-The function returns:
-
-*   `true` if the property value is retrieved successfully
-
-*   `false` if `user` is invalid; if `property_id` isn't recognized, supported,
-    or set for `user`; or if `value_size` is too small.
-
-`user`: The user for which property size data is being retrieved. `property_id`:
-The property for which the data is requested. `out_value`: The retrieved
-property value. `value_size`: The size of the retrieved property value.
-
-#### Declaration ####
-
-```
-bool SbUserGetProperty(SbUser user, SbUserPropertyId property_id, char *out_value, int value_size)
-```
-
-### SbUserGetPropertySize ###
-
-Returns the size of the value of `property_id` for `user`, INCLUDING the
-terminating null character. The function returns `0` if `user` is invalid or if
-`property_id` is not recognized, supported, or set for the user.
-
-`user`: The user for which property size data is being retrieved. `property_id`:
-The property for which the data is requested.
-
-#### Declaration ####
-
-```
-int SbUserGetPropertySize(SbUser user, SbUserPropertyId property_id)
 ```
 
 ### SbUserIsValid ###

--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -21,8 +21,9 @@ The `SbStorageOpenRecord` and `SbStorageDeleteRecord` APIs defined in
 `starboard/storage.h` no longer have a parameter for `SbUser` as the APIs are
 user-agnostic.
 
-### Removed SbUserGetSignedIn
-The API is no longer used and has been deprecated.
+### Removed SbUserGetSignedIn, SbUserGetProperty, and SbUserGetPropertySize
+The APIs defined in `starboard/user.h` are no longer used and have been
+deprecated.
 
 ### Removed SbByteSwapS16, SbByteSwapS32, SbByteSwapS64, SbByteSwapU16, SbByteSwapU32, and SbByteSwapU64
 The APIs defined in `starboard/byte_swap.h` are no longer used and have been

--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -349,9 +349,9 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(SbTimeZoneGetName);
   REGISTER_SYMBOL(SbUiNavGetInterface);
   REGISTER_SYMBOL(SbUserGetCurrent);
+#if SB_API_VERSION < 16
   REGISTER_SYMBOL(SbUserGetProperty);
   REGISTER_SYMBOL(SbUserGetPropertySize);
-#if SB_API_VERSION < 16
   REGISTER_SYMBOL(SbUserGetSignedIn);
 #endif
   REGISTER_SYMBOL(SbWindowBlurOnScreenKeyboard);

--- a/starboard/nplb/user_get_property_test.cc
+++ b/starboard/nplb/user_get_property_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/memory.h"
 #include "starboard/user.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -80,3 +82,5 @@ TEST(SbUserGetPropertyTest, MultipleTimes) {
 }  // namespace
 }  // namespace nplb
 }  // namespace starboard
+
+#endif

--- a/starboard/shared/nouser/user_get_property.cc
+++ b/starboard/shared/nouser/user_get_property.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/user.h"
 
 #include <vector>
@@ -59,3 +61,5 @@ bool SbUserGetProperty(SbUser user,
       return false;
   }
 }
+
+#endif

--- a/starboard/shared/stub/user_get_property.cc
+++ b/starboard/shared/stub/user_get_property.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/user.h"
 
 int SbUserGetPropertySize(SbUser user, SbUserPropertyId property_id) {
@@ -24,3 +26,5 @@ bool SbUserGetProperty(SbUser user,
                        int value_size) {
   return false;
 }
+
+#endif

--- a/starboard/user.h
+++ b/starboard/user.h
@@ -40,6 +40,7 @@ typedef struct SbUserPrivate SbUserPrivate;
 typedef SbUserPrivate* SbUser;
 
 // A set of string properties that can be queried on a user.
+#if SB_API_VERSION < 16
 typedef enum SbUserPropertyId {
   // The URL to the avatar for a user. Avatars are not provided on all
   // platforms.
@@ -55,6 +56,7 @@ typedef enum SbUserPropertyId {
   // A unique user ID of a user.
   kSbUserPropertyUserId,
 } SbUserPropertyId;
+#endif
 
 // Well-defined value for an invalid user.
 #define kSbUserInvalid (SbUser) NULL
@@ -63,19 +65,6 @@ typedef enum SbUserPropertyId {
 static SB_C_INLINE bool SbUserIsValid(SbUser user) {
   return user != kSbUserInvalid;
 }
-
-// Gets a list of up to |users_size| signed-in users and places the results in
-// |out_users|. The return value identifies the actual number of signed-in
-// users, which may be greater or less than |users_size|.
-//
-// It is expected that there will be a unique |SbUser| per signed-in user and
-// that the referenced objects will persist for the lifetime of the app.
-//
-// |out_users|: Handles for the retrieved users.
-// |users_size|: The maximum number of signed-in users to retrieve.
-#if SB_API_VERSION < 16
-SB_EXPORT int SbUserGetSignedIn(SbUser* out_users, int users_size);
-#endif
 
 // Gets the current primary user, if one exists. This is the user that is
 // determined, in a platform-specific way, to be the primary user controlling
@@ -86,6 +75,19 @@ SB_EXPORT int SbUserGetSignedIn(SbUser* out_users, int users_size);
 // It is expected that there will be a unique SbUser per signed-in user, and
 // that the referenced objects will persist for the lifetime of the app.
 SB_EXPORT SbUser SbUserGetCurrent();
+
+#if SB_API_VERSION < 16
+
+// Gets a list of up to |users_size| signed-in users and places the results in
+// |out_users|. The return value identifies the actual number of signed-in
+// users, which may be greater or less than |users_size|.
+//
+// It is expected that there will be a unique |SbUser| per signed-in user and
+// that the referenced objects will persist for the lifetime of the app.
+//
+// |out_users|: Handles for the retrieved users.
+// |users_size|: The maximum number of signed-in users to retrieve.
+SB_EXPORT int SbUserGetSignedIn(SbUser* out_users, int users_size);
 
 // Returns the size of the value of |property_id| for |user|, INCLUDING the
 // terminating null character. The function returns |0| if |user| is invalid
@@ -109,6 +111,9 @@ SB_EXPORT bool SbUserGetProperty(SbUser user,
                                  SbUserPropertyId property_id,
                                  char* out_value,
                                  int value_size);
+
+#endif
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
As part of a broader effort to eliminate the entire `starboard/user.h`, removing `SbUserGetProperty` and `SbUserGetPropertySize` SB APIs now that their usages in code have been removed.

b/271930936