### PR TITLE
Default enable Client Hint Headers if not explicitly set

### DIFF
--- a/cobalt/network/network_module.cc
+++ b/cobalt/network/network_module.cc
@@ -112,10 +112,11 @@ void NetworkModule::SetEnableQuicFromPersistentSettings() {
 
 void NetworkModule::SetEnableClientHintHeadersFlagsFromPersistentSettings() {
   // Called on initialization and when the persistent setting is changed.
+  // If persistent setting is not set, will default to kCallTypeLoader.
   if (options_.persistent_settings != nullptr) {
     enable_client_hint_headers_flags_.store(
         options_.persistent_settings->GetPersistentSettingAsInt(
-            kClientHintHeadersEnabledPersistentSettingsKey, 0));
+            kClientHintHeadersEnabledPersistentSettingsKey, kCallTypeLoader));
   }
 }
 


### PR DESCRIPTION
Kabuki has launched the experiment to 100%, so it should be safe to set this as default enabled for new installations.

b/285656784