### PR TITLE
Add build action of RDK platform to Evergreen

### DIFF
--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -1,0 +1,40 @@
+{
+  "docker_service": "build-raspi",
+  "bootloader": "raspi-2",
+  "on_device_test": {
+    "enabled": true,
+    "tests": [
+      "evergreen_test",
+      "0",
+      "1",
+      "2",
+      "3"
+    ],
+    "test_attempts": 2
+  },
+  "platforms": [
+    "evergreen-arm-hardfp",
+    "evergreen-arm-hardfp-sbversion-14"
+  ],
+  "includes": [
+    {
+      "name":"hardfp",
+      "platform":"evergreen-arm-hardfp",
+      "target_platform":"evergreen-arm-hardfp",
+      "target_cpu":"target_cpu=\\\"arm\\\"",
+      "extra_gn_arguments":"use_asan=false",
+      "bootloader_extra_gn_arguments": "use_asan=false is_clang=false",
+      "dimension": "release_version=regex:10.*"
+    },
+    {
+      "name":"sbversion-14",
+      "platform":"evergreen-arm-hardfp-sbversion-14",
+      "target_platform":"evergreen-arm-hardfp",
+      "target_cpu":"target_cpu=\\\"arm\\\"",
+      "extra_gn_arguments":"use_asan=false",
+      "bootloader_extra_gn_arguments":"use_asan=false is_clang=false",
+      "sb_api_version": "sb_api_version=14",
+      "dimension": "release_version=regex:10.*"
+    }
+  ]
+}

--- a/.github/workflows/evergreen.yaml
+++ b/.github/workflows/evergreen.yaml
@@ -40,6 +40,15 @@ jobs:
       platform: evergreen-arm-hardfp
       nightly: ${{ github.event.inputs.nightly }}
       run_api_leak_detector: true
+  evergreen-arm-hardfp-rdk:
+    uses: ./.github/workflows/main.yaml
+    permissions:
+      packages: write
+      pull-requests: write
+    with:
+      platform: evergreen-arm-hardfp-rdk
+      nightly: ${{ github.event.inputs.nightly }}
+      run_api_leak_detector: true
   evergreen-arm-softfp:
     uses: ./.github/workflows/main.yaml
     permissions:


### PR DESCRIPTION
RDK shares the evergreen-arm-hardfp with raspi-2 but since it has
its own pre-installed loader, it doesn't require a loader to be
built. Also it supports SB14 only.
For now it shares the build with raspi-2. Eventually it will
have its own build entry, and this task is logged as b/307558214.


b/293172465