### PR TITLE
Properly set foreground service permissions

### DIFF
--- a/starboard/android/apk/app/src/app/AndroidManifest.xml
+++ b/starboard/android/apk/app/src/app/AndroidManifest.xml
@@ -31,6 +31,7 @@
   <uses-permission android:name="android.permission.RECORD_AUDIO"/>
   <!-- This is needed when targeting API 28+ to use foreground services -->
   <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
+  <uses-permission android:name="android.permission.FOREGROUND_SERVICE_MEDIA_PLAYBACK" />
 
   <!-- https://iabtechlab.com/OTT-IFA, AdvertisingIdClient.Info.getId() -->
   <uses-permission android:name="com.google.android.gms.permission.AD_ID"/>

--- a/starboard/android/apk/app/src/main/java/dev/cobalt/coat/MediaPlaybackService.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/coat/MediaPlaybackService.java
@@ -22,6 +22,7 @@ import android.app.NotificationManager;
 import android.app.Service;
 import android.content.Context;
 import android.content.Intent;
+import android.content.pm.ServiceInfo;
 import android.os.Build.VERSION;
 import android.os.IBinder;
 import android.os.RemoteException;
@@ -82,7 +83,12 @@ public class MediaPlaybackService extends Service {
   public void startService() {
     if (this.channelCreated) {
       try {
-        startForeground(NOTIFICATION_ID, buildNotification());
+        if (VERSION.SDK_INT >= 29) {
+          startForeground(
+              NOTIFICATION_ID, buildNotification(), ServiceInfo.FOREGROUND_SERVICE_TYPE_MANIFEST);
+        } else {
+          startForeground(NOTIFICATION_ID, buildNotification());
+        }
       } catch (IllegalStateException e) {
         Log.e(TAG, "Failed to start Foreground Service", e);
       }


### PR DESCRIPTION
Per https://developer.android.com/about/versions/14/changes/fgs-types-required#media we should be setting that we are using the FOREGROUND_SERVICE_MEDIA_PLAYBACK permission and also passing the corresponding type constants when we start the foreground service.

b/305802411