### PR TITLE
Revert "Turn off Evergreen tests until new SB 16 binaries published"

### DIFF
--- a/starboard/evergreen/testing/run_all_tests.sh
+++ b/starboard/evergreen/testing/run_all_tests.sh
@@ -24,8 +24,7 @@ AUTH_METHOD="public-key"
 USE_COMPRESSED_SYSTEM_IMAGE="false"
 SYSTEM_IMAGE_EXTENSION=".so"
 
-# TODO: Enable once the Starboard 16 binaries are published for Evergreen.
-DISABLE_TESTS="true"
+DISABLE_TESTS="false"
 
 while getopts "d:a:c" o; do
     case "${o}" in


### PR DESCRIPTION
Reverts youtube/cobalt#1792

This should be OK to re-enable now.

b/304882604