### PR TITLE
Deprecate SbTime APIs (partial)

### DIFF
--- a/base/files/file_enumerator_starboard.cc
+++ b/base/files/file_enumerator_starboard.cc
@@ -43,7 +43,8 @@ int64_t FileEnumerator::FileInfo::GetSize() const {
 }
 
 base::Time FileEnumerator::FileInfo::GetLastModifiedTime() const {
-  return base::Time::FromSbTime(sb_info_.last_modified);
+  return base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(sb_info_.last_modified));
 }
 
 // FileEnumerator --------------------------------------------------------------

--- a/base/files/file_starboard.cc
+++ b/base/files/file_starboard.cc
@@ -256,9 +256,12 @@ bool File::GetInfo(Info* info) {
   info->is_directory = file_info.is_directory;
   info->is_symbolic_link = file_info.is_symbolic_link;
   info->size = file_info.size;
-  info->last_modified = base::Time::FromSbTime(file_info.last_modified);
-  info->last_accessed = base::Time::FromSbTime(file_info.last_accessed);
-  info->creation_time = base::Time::FromSbTime(file_info.creation_time);
+  info->last_modified = base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(file_info.last_modified));
+  info->last_accessed = base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(file_info.last_accessed));
+  info->creation_time = base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(file_info.creation_time));
   return true;
 }
 

--- a/base/files/file_util_starboard.cc
+++ b/base/files/file_util_starboard.cc
@@ -374,9 +374,12 @@ bool GetFileInfo(const FilePath &file_path, File::Info *results) {
 
   results->is_directory = info.is_directory;
   results->size = info.size;
-  results->last_modified = base::Time::FromSbTime(info.last_modified);
-  results->last_accessed = base::Time::FromSbTime(info.last_accessed);
-  results->creation_time = base::Time::FromSbTime(info.creation_time);
+  results->last_modified = base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(info.last_modified));
+  results->last_accessed = base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(info.last_accessed));
+  results->creation_time = base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(info.creation_time));
   return true;
 }
 

--- a/base/logging.cc
+++ b/base/logging.cc
@@ -15,11 +15,11 @@
 #include "starboard/client_porting/eztime/eztime.h"
 #include "starboard/common/log.h"
 #include "starboard/common/mutex.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/file.h"
 #include "starboard/system.h"
-#include "starboard/time.h"
 typedef SbFile FileHandle;
 typedef SbMutex MutexHandle;
 #else
@@ -210,7 +210,7 @@ int32_t CurrentProcessId() {
 
 uint64_t TickCount() {
 #if defined(STARBOARD)
-  return static_cast<uint64_t>(SbTimeGetMonotonicNow());
+  return starboard::CurrentMonotonicTime();
 #else
 #if defined(OS_WIN)
   return GetTickCount();

--- a/base/message_loop/message_pump_io_starboard.cc
+++ b/base/message_loop/message_pump_io_starboard.cc
@@ -215,7 +215,7 @@ void MessagePumpIOStarboard::Run(Delegate* delegate) {
     } else {
       TimeDelta delay = delayed_work_time_ - TimeTicks::Now();
       if (delay > TimeDelta()) {
-        SbSocketWaiterWaitTimed(waiter_, delay.ToSbTime());
+        SbSocketWaiterWaitTimed(waiter_, delay.InMicroseconds());
       } else {
         // It looks like delayed_work_time_ indicates a time in the past, so we
         // need to call DoDelayedWork now.

--- a/base/message_loop/message_pump_ui_starboard.cc
+++ b/base/message_loop/message_pump_ui_starboard.cc
@@ -120,7 +120,7 @@ void MessagePumpUIStarboard::ScheduleDelayedWork(
     CancelDelayedLocked();
 
     outstanding_delayed_events_.insert(
-        SbEventSchedule(&CallMessagePumpDelayed, this, delay.ToSbTime()));
+        SbEventSchedule(&CallMessagePumpDelayed, this, delay.InMicroseconds()));
   }
 }
 

--- a/base/synchronization/condition_variable_starboard.cc
+++ b/base/synchronization/condition_variable_starboard.cc
@@ -56,7 +56,7 @@ void ConditionVariable::Wait() {
 void ConditionVariable::TimedWait(const TimeDelta& max_time) {
   internal::ScopedBlockingCallWithBaseSyncPrimitives scoped_blocking_call(
       BlockingType::MAY_BLOCK);
-  SbTime duration = max_time.ToSbTime();
+  int64_t duration = max_time.InMicroseconds();
 
 #if !defined(NDEBUG) || defined(DCHECK_ALWAYS_ON)
   user_lock_->CheckHeldAndUnmark();

--- a/base/threading/platform_thread_starboard.cc
+++ b/base/threading/platform_thread_starboard.cc
@@ -101,7 +101,7 @@ void PlatformThread::YieldCurrentThread() {
 
 // static
 void PlatformThread::Sleep(TimeDelta duration) {
-  SbThreadSleep(duration.ToSbTime());
+  SbThreadSleep(duration.InMicroseconds());
 }
 
 // static

--- a/base/time/time.h
+++ b/base/time/time.h
@@ -182,10 +182,6 @@ class BASE_EXPORT TimeDelta {
     return delta_ == std::numeric_limits<int64_t>::min();
   }
 
-#if defined(STARBOARD)
-  SbTime ToSbTime() const;
-#endif
-
 #if defined(OS_POSIX) || defined(OS_FUCHSIA)
   struct timespec ToTimeSpec() const;
 #endif
@@ -577,11 +573,6 @@ class BASE_EXPORT Time : public time_internal::TimeBase<Time> {
   // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/Date/getTime.
   static Time FromJsTime(double ms_since_epoch);
   double ToJsTime() const;
-
-#if defined(STARBOARD)
-  static Time FromSbTime(SbTime t);
-  SbTime ToSbTime() const;
-#endif
 
   // Converts to/from Java convention for times, a number of milliseconds since
   // the epoch. Because the Java format has less resolution, converting to Java

--- a/base/time/time_now_starboard.cc
+++ b/base/time/time_now_starboard.cc
@@ -21,6 +21,7 @@
 
 #include "starboard/client_porting/poem/eztime_poem.h"
 #include "starboard/common/log.h"
+#include "starboard/common/time.h"
 #include "starboard/time.h"
 #include "starboard/types.h"
 
@@ -30,7 +31,8 @@ namespace base {
 
 namespace subtle {
 Time TimeNowIgnoringOverride() {
-  return Time() + TimeDelta::FromMicroseconds(SbTimeGetNow());
+  return Time() + TimeDelta::FromMicroseconds(
+      starboard::PosixTimeToWindowsTime(starboard::CurrentPosixTime()));
 }
 
 Time TimeNowFromSystemTimeIgnoringOverride() {
@@ -43,7 +45,8 @@ Time TimeNowFromSystemTimeIgnoringOverride() {
 
 namespace subtle {
 TimeTicks TimeTicksNowIgnoringOverride() {
-  return TimeTicks() + TimeDelta::FromMicroseconds(SbTimeGetMonotonicNow());
+  return TimeTicks() + TimeDelta::FromMicroseconds(
+      starboard::CurrentMonotonicTime());
 }
 }  // namespace subtle
 

--- a/cobalt/base/statistics.h
+++ b/cobalt/base/statistics.h
@@ -42,7 +42,7 @@ inline int64_t DefaultSampleToValueFunc(int64_t dividend, int64_t divisor) {
 // by `SampleToValueFunc` using its dividend and divisor.
 //
 // Example usages:
-//   1. Set dividends to bytes in int and divisors to SbTime, to track the
+//   1. Set dividends to bytes in int and divisors to int64_t, to track the
 //      statistics of bandwidth.
 //   2. Set the divisor to always be 1, to track the statistics of a count or a
 //      duration.

--- a/cobalt/base/wrap_main.h
+++ b/cobalt/base/wrap_main.h
@@ -42,7 +42,7 @@ typedef int (*MainFunction)(int argc, char** argv);
 // A start-style function.
 typedef void (*StartFunction)(int argc, char** argv, const char* link,
                               const base::Closure& quit_closure,
-                              SbTimeMonotonic timestamp);
+                              int64_t timestamp);
 
 // A function type that can be called at shutdown.
 typedef void (*StopFunction)();
@@ -53,8 +53,7 @@ typedef void (*EventFunction)(const SbEvent* event);
 // No-operation function that can be passed into start_function if no start work
 // is needed.
 void NoopStartFunction(int argc, char** argv, const char* link,
-                       const base::Closure& quit_closure,
-                       SbTimeMonotonic timestamp) {}
+                       const base::Closure& quit_closure, int64_t timestamp) {}
 
 // No-operation function that can be passed into event_function if no other
 // event handling work is needed.

--- a/cobalt/bindings/testing/bindings_sandbox_main.cc
+++ b/cobalt/bindings/testing/bindings_sandbox_main.cc
@@ -29,8 +29,7 @@ namespace {
 cobalt::script::StandaloneJavascriptRunner* g_javascript_runner = NULL;
 
 void StartApplication(int argc, char** argv, const char* link,
-                      const base::Closure& quit_closure,
-                      SbTimeMonotonic timestamp) {
+                      const base::Closure& quit_closure, int64_t timestamp) {
   scoped_refptr<Window> test_window = new Window();
   cobalt::script::JavaScriptEngine::Options javascript_engine_options;
 

--- a/cobalt/browser/application.cc
+++ b/cobalt/browser/application.cc
@@ -83,7 +83,6 @@
 #include "starboard/extension/crash_handler.h"
 #include "starboard/extension/installation_manager.h"
 #include "starboard/system.h"
-#include "starboard/time.h"
 #include "url/gurl.h"
 
 #if SB_IS(EVERGREEN)
@@ -626,7 +625,7 @@ ssize_t Application::available_memory_ = 0;
 int64 Application::lifetime_in_ms_ = 0;
 
 Application::Application(const base::Closure& quit_closure, bool should_preload,
-                         SbTimeMonotonic timestamp)
+                         int64_t timestamp)
     : message_loop_(base::MessageLoop::current()), quit_closure_(quit_closure) {
   DCHECK(!quit_closure_.is_null());
   if (should_preload) {
@@ -1066,7 +1065,7 @@ Application::~Application() {
   network_module_.reset();
 }
 
-void Application::Start(SbTimeMonotonic timestamp) {
+void Application::Start(int64_t timestamp) {
   if (base::MessageLoop::current() != message_loop_) {
     message_loop_->task_runner()->PostTask(
         FROM_HERE,
@@ -1182,7 +1181,7 @@ void Application::HandleStarboardEvent(const SbEvent* starboard_event) {
 }
 
 void Application::OnApplicationEvent(SbEventType event_type,
-                                     SbTimeMonotonic timestamp) {
+                                     int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser", "Application::OnApplicationEvent()");
   DCHECK_CALLED_ON_VALID_THREAD(application_event_thread_checker_);
 
@@ -1462,8 +1461,7 @@ void Application::OnDeepLinkConsumedCallback(const std::string& link) {
   }
 }
 
-void Application::DispatchDeepLink(const char* link,
-                                   SbTimeMonotonic timestamp) {
+void Application::DispatchDeepLink(const char* link, int64_t timestamp) {
   if (!link || *link == 0) {
     return;
   }
@@ -1491,7 +1489,7 @@ void Application::DispatchDeepLink(const char* link,
 
 void Application::DispatchDeepLinkIfNotConsumed() {
   std::string deep_link;
-  SbTimeMonotonic timestamp;
+  int64_t timestamp;
   // This block exists to ensure that the lock is held while accessing
   // unconsumed_deep_link_.
   {

--- a/cobalt/browser/application.h
+++ b/cobalt/browser/application.h
@@ -30,7 +30,6 @@
 #include "cobalt/network/network_module.h"
 #include "cobalt/persistent_storage/persistent_settings.h"
 #include "cobalt/system_window/system_window.h"
-#include "starboard/time.h"
 #if SB_IS(EVERGREEN)
 #include "cobalt/updater/updater_module.h"
 #endif
@@ -55,11 +54,11 @@ class Application {
   // The passed in |quit_closure| can be called internally by the Application
   // to signal that it would like to quit.
   Application(const base::Closure& quit_closure, bool should_preload,
-              SbTimeMonotonic timestamp);
+              int64_t timestamp);
   virtual ~Application();
 
   // Start from a preloaded state.
-  void Start(SbTimeMonotonic timestamp);
+  void Start(int64_t timestamp);
   void Quit();
   void HandleStarboardEvent(const SbEvent* event);
 
@@ -70,7 +69,7 @@ class Application {
   void OnNetworkEvent(const base::Event* event);
 
   // Called to handle an application event.
-  void OnApplicationEvent(SbEventType event_type, SbTimeMonotonic timestamp);
+  void OnApplicationEvent(SbEventType event_type, int64_t timestamp);
 
   // Called to handle a window size change event.
   void OnWindowSizeChangedEvent(const base::Event* event);
@@ -175,8 +174,8 @@ class Application {
   void UpdatePeriodicStats();
   void DispatchEventInternal(base::Event* event);
 
-  base::Optional<SbTimeMonotonic> preload_timestamp_;
-  base::Optional<SbTimeMonotonic> start_timestamp_;
+  base::Optional<int64_t> preload_timestamp_;
+  base::Optional<int64_t> start_timestamp_;
 
   // Json PrefStore used for persistent settings.
   std::unique_ptr<persistent_storage::PersistentSettings> persistent_settings_;
@@ -204,13 +203,13 @@ class Application {
   // Lock for access to unconsumed_deep_link_ from different threads.
   base::Lock unconsumed_deep_link_lock_;
 
-  SbTimeMonotonic deep_link_timestamp_ = 0;
+  int64_t deep_link_timestamp_ = 0;
 
   // Called when deep links are consumed.
   void OnDeepLinkConsumedCallback(const std::string& link);
 
   // Dispatch events for deep links.
-  void DispatchDeepLink(const char* link, SbTimeMonotonic timestamp);
+  void DispatchDeepLink(const char* link, int64_t timestamp);
   void DispatchDeepLinkIfNotConsumed();
 
 

--- a/cobalt/browser/browser_module.h
+++ b/cobalt/browser/browser_module.h
@@ -71,7 +71,6 @@
 #include "cobalt/web/web_settings.h"
 #include "cobalt/webdriver/session_driver.h"
 #include "starboard/configuration.h"
-#include "starboard/time.h"
 #include "starboard/window.h"
 #include "url/gurl.h"
 
@@ -193,12 +192,12 @@ class BrowserModule {
   void SetProxy(const std::string& proxy_rules);
 
   // LifecycleObserver-similar interface.
-  void Blur(SbTimeMonotonic timestamp);
-  void Conceal(SbTimeMonotonic timestamp);
-  void Freeze(SbTimeMonotonic timestamp);
-  void Unfreeze(SbTimeMonotonic timestamp);
-  void Reveal(SbTimeMonotonic timestamp);
-  void Focus(SbTimeMonotonic timestamp);
+  void Blur(int64_t timestamp);
+  void Conceal(int64_t timestamp);
+  void Freeze(int64_t timestamp);
+  void Unfreeze(int64_t timestamp);
+  void Reveal(int64_t timestamp);
+  void Focus(int64_t timestamp);
 
   // Gets current application state.
   base::ApplicationState GetApplicationState();
@@ -242,7 +241,7 @@ class BrowserModule {
                           std::map<std::string, std::string>& map);
 
   // Pass the deeplink timestamp from Starboard.
-  void SetDeepLinkTimestamp(SbTimeMonotonic timestamp);
+  void SetDeepLinkTimestamp(int64_t timestamp);
 
  private:
 #if SB_HAS(CORE_DUMP_HANDLER_SUPPORT)
@@ -456,19 +455,19 @@ class BrowserModule {
 
   // Does all the steps for half of a Conceal that happen prior to
   // the app state update.
-  void ConcealInternal(SbTimeMonotonic timestamp);
+  void ConcealInternal(int64_t timestamp);
 
   // Does all the steps for half of a Freeze that happen prior to
   // the app state update.
-  void FreezeInternal(SbTimeMonotonic timestamp);
+  void FreezeInternal(int64_t timestamp);
 
   // Does all the steps for half of a Reveal that happen prior to
   // the app state update.
-  void RevealInternal(SbTimeMonotonic timestamp);
+  void RevealInternal(int64_t timestamp);
 
   // Does all the steps for half of a Unfreeze that happen prior to
   // the app state update.
-  void UnfreezeInternal(SbTimeMonotonic timestamp);
+  void UnfreezeInternal(int64_t timestamp);
 
   // Check debug console, splash screen and web module if they are
   // ready to freeze at Concealed state. If so, call SystemRequestFreeze

--- a/cobalt/browser/debug_console.h
+++ b/cobalt/browser/debug_console.h
@@ -95,21 +95,21 @@ class DebugConsole : public LifecycleObserver {
   }
 
   // LifecycleObserver implementation.
-  void Blur(SbTimeMonotonic timestamp) override { web_module_->Blur(0); }
+  void Blur(int64_t timestamp) override { web_module_->Blur(0); }
   void Conceal(render_tree::ResourceProvider* resource_provider,
-               SbTimeMonotonic timestamp) override {
+               int64_t timestamp) override {
     web_module_->Conceal(resource_provider, 0);
   }
-  void Freeze(SbTimeMonotonic timestamp) override { web_module_->Freeze(0); }
+  void Freeze(int64_t timestamp) override { web_module_->Freeze(0); }
   void Unfreeze(render_tree::ResourceProvider* resource_provider,
-                SbTimeMonotonic timestamp) override {
+                int64_t timestamp) override {
     web_module_->Unfreeze(resource_provider, 0);
   }
   void Reveal(render_tree::ResourceProvider* resource_provider,
-              SbTimeMonotonic timestamp) override {
+              int64_t timestamp) override {
     web_module_->Reveal(resource_provider, 0);
   }
-  void Focus(SbTimeMonotonic timestamp) override { web_module_->Focus(0); }
+  void Focus(int64_t timestamp) override { web_module_->Focus(0); }
 
   void ReduceMemory() { web_module_->ReduceMemory(); }
 

--- a/cobalt/browser/lifecycle_observer.h
+++ b/cobalt/browser/lifecycle_observer.h
@@ -26,32 +26,32 @@ namespace browser {
 class LifecycleObserver : public base::CheckedObserver {
  public:
   // Blurs from Started, staying visible and retaining graphics resources.
-  virtual void Blur(SbTimeMonotonic timestamp) = 0;
+  virtual void Blur(int64_t timestamp) = 0;
 
   // Conceals from Blurred, transitioning to invisible but background tasks can
   // still be running.
   virtual void Conceal(render_tree::ResourceProvider* resource_provider,
-                       SbTimeMonotonic timestamp) = 0;
+                       int64_t timestamp) = 0;
 
   // Freezes from Concealed, and releases its reference to the ResourceProvider,
   // additionally releasing all references to any resources created from
   // it. This method must only be called if the object has previously been
   // Concealed.
-  virtual void Freeze(SbTimeMonotonic timestamp) = 0;
+  virtual void Freeze(int64_t timestamp) = 0;
 
   // Unfreezes from Frozen, with a new ResourceProvider. This method must only
   // be called if the object has previously been Frozen.
   virtual void Unfreeze(render_tree::ResourceProvider* resource_provider,
-                        SbTimeMonotonic timestamp) = 0;
+                        int64_t timestamp) = 0;
 
   // Reveals from Concealed, going back into partially-obscured state. This
   // method must only be called if the object has previously been Concealed.
   virtual void Reveal(render_tree::ResourceProvider* resource_provider,
-                      SbTimeMonotonic timestamp) = 0;
+                      int64_t timestamp) = 0;
 
   // Focuses, going back to the Started state, and continuing to use the same
   // ResourceProvider and graphics resources.
-  virtual void Focus(SbTimeMonotonic timestamp) = 0;
+  virtual void Focus(int64_t timestamp) = 0;
 
  protected:
   virtual ~LifecycleObserver() {}

--- a/cobalt/browser/main.cc
+++ b/cobalt/browser/main.cc
@@ -57,8 +57,7 @@ bool CheckForAndExecuteStartupSwitches() {
 }
 
 void PreloadApplication(int argc, char** argv, const char* link,
-                        const base::Closure& quit_closure,
-                        SbTimeMonotonic timestamp) {
+                        const base::Closure& quit_closure, int64_t timestamp) {
   if (CheckForAndExecuteStartupSwitches()) {
     SbSystemRequestStop(0);
     return;
@@ -71,8 +70,7 @@ void PreloadApplication(int argc, char** argv, const char* link,
 }
 
 void StartApplication(int argc, char** argv, const char* link,
-                      const base::Closure& quit_closure,
-                      SbTimeMonotonic timestamp) {
+                      const base::Closure& quit_closure, int64_t timestamp) {
   if (CheckForAndExecuteStartupSwitches()) {
     SbSystemRequestStop(0);
     return;

--- a/cobalt/browser/splash_screen.h
+++ b/cobalt/browser/splash_screen.h
@@ -57,21 +57,21 @@ class SplashScreen : public LifecycleObserver {
   }
 
   // LifecycleObserver implementation.
-  void Blur(SbTimeMonotonic timestamp) override { web_module_->Blur(0); }
+  void Blur(int64_t timestamp) override { web_module_->Blur(0); }
   void Conceal(render_tree::ResourceProvider* resource_provider,
-               SbTimeMonotonic timestamp) override {
+               int64_t timestamp) override {
     web_module_->Conceal(resource_provider, 0);
   }
-  void Freeze(SbTimeMonotonic timestamp) override { web_module_->Freeze(0); }
+  void Freeze(int64_t timestamp) override { web_module_->Freeze(0); }
   void Unfreeze(render_tree::ResourceProvider* resource_provider,
-                SbTimeMonotonic timestamp) override {
+                int64_t timestamp) override {
     web_module_->Unfreeze(resource_provider, 0);
   }
   void Reveal(render_tree::ResourceProvider* resource_provider,
-              SbTimeMonotonic timestamp) override {
+              int64_t timestamp) override {
     web_module_->Reveal(resource_provider, 0);
   }
-  void Focus(SbTimeMonotonic timestamp) override { web_module_->Focus(0); }
+  void Focus(int64_t timestamp) override { web_module_->Focus(0); }
 
   void ReduceMemory() { web_module_->ReduceMemory(); }
 

--- a/cobalt/browser/web_module.cc
+++ b/cobalt/browser/web_module.cc
@@ -246,20 +246,19 @@ class WebModule::Impl {
 
   // Sets the application state, asserts preconditions to transition to that
   // state, and dispatches any precipitate web events.
-  void SetApplicationState(base::ApplicationState state,
-                           SbTimeMonotonic timestamp);
+  void SetApplicationState(base::ApplicationState state, int64_t timestamp);
 
   // See LifecycleObserver. These functions do not implement the interface, but
   // have the same basic function.
-  void Blur(SbTimeMonotonic timestamp);
+  void Blur(int64_t timestamp);
   void Conceal(render_tree::ResourceProvider* resource_provider,
-               SbTimeMonotonic timestamp);
-  void Freeze(SbTimeMonotonic timestamp);
+               int64_t timestamp);
+  void Freeze(int64_t timestamp);
   void Unfreeze(render_tree::ResourceProvider* resource_provider,
-                SbTimeMonotonic timestamp);
+                int64_t timestamp);
   void Reveal(render_tree::ResourceProvider* resource_provider,
-              SbTimeMonotonic timestamp);
-  void Focus(SbTimeMonotonic timestamp);
+              int64_t timestamp);
+  void Focus(int64_t timestamp);
 
   void ReduceMemory();
 
@@ -277,8 +276,8 @@ class WebModule::Impl {
       scoped_refptr<render_tree::Node>* render_tree);
 
   void SetApplicationStartOrPreloadTimestamp(bool is_preload,
-                                             SbTimeMonotonic timestamp);
-  void SetDeepLinkTimestamp(SbTimeMonotonic timestamp);
+                                             int64_t timestamp);
+  void SetDeepLinkTimestamp(int64_t timestamp);
 
   void SetUnloadEventTimingInfo(base::TimeTicks start_time,
                                 base::TimeTicks end_time);
@@ -1003,15 +1002,15 @@ void WebModule::Impl::DoSynchronousLayoutAndGetRenderTree(
   if (render_tree) *render_tree = tree;
 }
 
-void WebModule::Impl::SetApplicationStartOrPreloadTimestamp(
-    bool is_preload, SbTimeMonotonic timestamp) {
+void WebModule::Impl::SetApplicationStartOrPreloadTimestamp(bool is_preload,
+                                                            int64_t timestamp) {
   DCHECK(window_);
   DCHECK(window_->performance());
   window_->performance()->SetApplicationStartOrPreloadTimestamp(is_preload,
                                                                 timestamp);
 }
 
-void WebModule::Impl::SetDeepLinkTimestamp(SbTimeMonotonic timestamp) {
+void WebModule::Impl::SetDeepLinkTimestamp(int64_t timestamp) {
   DCHECK(window_);
   window_->performance()->SetDeepLinkTimestamp(timestamp);
 }
@@ -1088,7 +1087,7 @@ void WebModule::Impl::SetMediaModule(media::MediaModule* media_module) {
 }
 
 void WebModule::Impl::SetApplicationState(base::ApplicationState state,
-                                          SbTimeMonotonic timestamp) {
+                                          int64_t timestamp) {
   window_->SetApplicationState(state, timestamp);
 }
 
@@ -1118,13 +1117,13 @@ void WebModule::Impl::OnStopDispatchEvent(
       layout_manager_->IsRenderTreePending());
 }
 
-void WebModule::Impl::Blur(SbTimeMonotonic timestamp) {
+void WebModule::Impl::Blur(int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser", "WebModule::Impl::Blur()");
   SetApplicationState(base::kApplicationStateBlurred, timestamp);
 }
 
 void WebModule::Impl::Conceal(render_tree::ResourceProvider* resource_provider,
-                              SbTimeMonotonic timestamp) {
+                              int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser", "WebModule::Impl::Conceal()");
   SetResourceProvider(resource_provider);
 
@@ -1161,7 +1160,7 @@ void WebModule::Impl::Conceal(render_tree::ResourceProvider* resource_provider,
   }
 }
 
-void WebModule::Impl::Freeze(SbTimeMonotonic timestamp) {
+void WebModule::Impl::Freeze(int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser", "WebModule::Impl::Freeze()");
   SetApplicationState(base::kApplicationStateFrozen, timestamp);
 
@@ -1171,7 +1170,7 @@ void WebModule::Impl::Freeze(SbTimeMonotonic timestamp) {
 }
 
 void WebModule::Impl::Unfreeze(render_tree::ResourceProvider* resource_provider,
-                               SbTimeMonotonic timestamp) {
+                               int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser", "WebModule::Impl::Unfreeze()");
   synchronous_loader_interrupt_->Reset();
   DCHECK(resource_provider);
@@ -1181,7 +1180,7 @@ void WebModule::Impl::Unfreeze(render_tree::ResourceProvider* resource_provider,
 }
 
 void WebModule::Impl::Reveal(render_tree::ResourceProvider* resource_provider,
-                             SbTimeMonotonic timestamp) {
+                             int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser", "WebModule::Impl::Reveal()");
   synchronous_loader_interrupt_->Reset();
   DCHECK(resource_provider);
@@ -1196,7 +1195,7 @@ void WebModule::Impl::Reveal(render_tree::ResourceProvider* resource_provider,
   SetApplicationState(base::kApplicationStateBlurred, timestamp);
 }
 
-void WebModule::Impl::Focus(SbTimeMonotonic timestamp) {
+void WebModule::Impl::Focus(int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser", "WebModule::Impl::Focus()");
   synchronous_loader_interrupt_->Reset();
   SetApplicationState(base::kApplicationStateStarted, timestamp);
@@ -1577,7 +1576,7 @@ void WebModule::SetRemoteTypefaceCacheCapacity(int64_t bytes) {
   impl_->SetRemoteTypefaceCacheCapacity(bytes);
 }
 
-void WebModule::Blur(SbTimeMonotonic timestamp) {
+void WebModule::Blur(int64_t timestamp) {
   synchronous_loader_interrupt_.Signal();
 #if defined(ENABLE_DEBUGGER)
   // We normally need to block here so that the call doesn't return until the
@@ -1602,7 +1601,7 @@ void WebModule::Blur(SbTimeMonotonic timestamp) {
 }
 
 void WebModule::Conceal(render_tree::ResourceProvider* resource_provider,
-                        SbTimeMonotonic timestamp) {
+                        int64_t timestamp) {
   synchronous_loader_interrupt_.Signal();
   // We must block here so that the call doesn't return until the web
   // application has had a chance to process the whole event.
@@ -1611,7 +1610,7 @@ void WebModule::Conceal(render_tree::ResourceProvider* resource_provider,
   impl_->Conceal(resource_provider, timestamp);
 }
 
-void WebModule::Freeze(SbTimeMonotonic timestamp) {
+void WebModule::Freeze(int64_t timestamp) {
   // We must block here so that the call doesn't return until the web
   // application has had a chance to process the whole event.
   POST_AND_BLOCK_TO_ENSURE_IMPL_ON_THREAD(Freeze, timestamp);
@@ -1619,7 +1618,7 @@ void WebModule::Freeze(SbTimeMonotonic timestamp) {
 }
 
 void WebModule::Unfreeze(render_tree::ResourceProvider* resource_provider,
-                         SbTimeMonotonic timestamp) {
+                         int64_t timestamp) {
   // We must block here so that the call doesn't return until the web
   // application has had a chance to process the whole event.
   POST_AND_BLOCK_TO_ENSURE_IMPL_ON_THREAD(Unfreeze, resource_provider,
@@ -1628,14 +1627,14 @@ void WebModule::Unfreeze(render_tree::ResourceProvider* resource_provider,
 }
 
 void WebModule::Reveal(render_tree::ResourceProvider* resource_provider,
-                       SbTimeMonotonic timestamp) {
+                       int64_t timestamp) {
   // We must block here so that the call doesn't return until the web
   // application has had a chance to process the whole event.
   POST_AND_BLOCK_TO_ENSURE_IMPL_ON_THREAD(Reveal, resource_provider, timestamp);
   impl_->Reveal(resource_provider, timestamp);
 }
 
-void WebModule::Focus(SbTimeMonotonic timestamp) {
+void WebModule::Focus(int64_t timestamp) {
   // We must block here so that the call doesn't return until the web
   // application has had a chance to process the whole event.
   POST_AND_BLOCK_TO_ENSURE_IMPL_ON_THREAD(Focus, timestamp);
@@ -1678,8 +1677,8 @@ void WebModule::DoSynchronousLayoutAndGetRenderTree(
   impl_->DoSynchronousLayoutAndGetRenderTree(render_tree);
 }
 
-void WebModule::SetApplicationStartOrPreloadTimestamp(
-    bool is_preload, SbTimeMonotonic timestamp) {
+void WebModule::SetApplicationStartOrPreloadTimestamp(bool is_preload,
+                                                      int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser",
                "WebModule::SetApplicationStartOrPreloadTimestamp()");
   POST_TO_ENSURE_IMPL_ON_THREAD(SetApplicationStartOrPreloadTimestamp,
@@ -1687,7 +1686,7 @@ void WebModule::SetApplicationStartOrPreloadTimestamp(
   impl_->SetApplicationStartOrPreloadTimestamp(is_preload, timestamp);
 }
 
-void WebModule::SetDeepLinkTimestamp(SbTimeMonotonic timestamp) {
+void WebModule::SetDeepLinkTimestamp(int64_t timestamp) {
   TRACE_EVENT0("cobalt::browser", "WebModule::SetDeepLinkTimestamp()");
   POST_AND_BLOCK_TO_ENSURE_IMPL_ON_THREAD(SetDeepLinkTimestamp, timestamp);
   impl_->SetDeepLinkTimestamp(timestamp);

--- a/cobalt/browser/web_module.h
+++ b/cobalt/browser/web_module.h
@@ -364,15 +364,15 @@ class WebModule : public base::MessageLoop::DestructionObserver,
   }
 
   // LifecycleObserver implementation
-  void Blur(SbTimeMonotonic timestamp) override;
+  void Blur(int64_t timestamp) override;
   void Conceal(render_tree::ResourceProvider* resource_provider,
-               SbTimeMonotonic timestamp) override;
-  void Freeze(SbTimeMonotonic timestamp) override;
+               int64_t timestamp) override;
+  void Freeze(int64_t timestamp) override;
   void Unfreeze(render_tree::ResourceProvider* resource_provider,
-                SbTimeMonotonic timestamp) override;
+                int64_t timestamp) override;
   void Reveal(render_tree::ResourceProvider* resource_provider,
-              SbTimeMonotonic timestamp) override;
-  void Focus(SbTimeMonotonic timestamp) override;
+              int64_t timestamp) override;
+  void Focus(int64_t timestamp) override;
 
   // Attempt to reduce overall memory consumption. Called in response to a
   // system indication that memory usage is nearing a critical level.
@@ -394,8 +394,8 @@ class WebModule : public base::MessageLoop::DestructionObserver,
 
   // Pass the application preload or start timestamps from Starboard.
   void SetApplicationStartOrPreloadTimestamp(bool is_preload,
-                                             SbTimeMonotonic timestamp);
-  void SetDeepLinkTimestamp(SbTimeMonotonic timestamp);
+                                             int64_t timestamp);
+  void SetDeepLinkTimestamp(int64_t timestamp);
 
   // From base::MessageLoop::DestructionObserver.
   void WillDestroyCurrentMessageLoop() override;

--- a/cobalt/demos/simple_sandbox/simple_sandbox.cc
+++ b/cobalt/demos/simple_sandbox/simple_sandbox.cc
@@ -30,7 +30,7 @@ class SimpleSandbox {
 
   static void StartApplication(int argc, char** argv, const char* link,
                                const base::Closure& quit_closure,
-                               SbTimeMonotonic timestamp);
+                               int64_t timestamp);
 
   static void StopApplication();
 
@@ -44,7 +44,7 @@ class SimpleSandbox {
 // static
 void SimpleSandbox::StartApplication(int argc, char** argv, const char* link,
                                      const base::Closure& quit_closure,
-                                     SbTimeMonotonic timestamp) {
+                                     int64_t timestamp) {
   LOG(INFO) << "SimpleSandbox::StartApplication";
 
   SimpleSandbox::GetInstance()->thread()->Start();

--- a/cobalt/dom/document.cc
+++ b/cobalt/dom/document.cc
@@ -904,12 +904,12 @@ void Document::UpdateUiNavigation() {
 }
 
 bool Document::TrySetUiNavFocusElement(const void* focus_element,
-                                       SbTimeMonotonic time) {
-  if (ui_nav_focus_element_update_time_ > time) {
+                                       int64_t monotonic_time) {
+  if (ui_nav_focus_element_update_time_ > monotonic_time) {
     // A later focus update was already issued.
     return false;
   }
-  ui_nav_focus_element_update_time_ = time;
+  ui_nav_focus_element_update_time_ = monotonic_time;
   ui_nav_focus_element_ = focus_element;
   return true;
 }

--- a/cobalt/dom/document.h
+++ b/cobalt/dom/document.h
@@ -56,7 +56,6 @@
 #include "cobalt/script/exception_state.h"
 #include "cobalt/script/wrappable.h"
 #include "cobalt/web/event.h"
-#include "starboard/time.h"
 #include "url/gurl.h"
 
 namespace cobalt {
@@ -333,7 +332,8 @@ class Document : public Node,
 
   // Track UI navigation system's focus element.
   const void* ui_nav_focus_element() const { return ui_nav_focus_element_; }
-  bool TrySetUiNavFocusElement(const void* focus_element, SbTimeMonotonic time);
+  bool TrySetUiNavFocusElement(const void* focus_element,
+                               int64_t monotonic_time);
 
   // Track HTML elements that are UI navigation items. This facilitates updating
   // their layout information as needed.
@@ -635,9 +635,9 @@ class Document : public Node,
   // not meant to be dereferenced.
   const void* ui_nav_focus_element_ = nullptr;
 
-  // Since UI navigation involves multiple threads, use a timestamp to help
-  // filter out obsolete focus changes.
-  SbTimeMonotonic ui_nav_focus_element_update_time_ = 0;
+  // Since UI navigation involves multiple threads, use a monotonic timestamp to
+  // help filter out obsolete focus changes.
+  int64_t ui_nav_focus_element_update_time_ = 0;
 
   // Track all HTMLElements in this document which are UI navigation items.
   // These should be raw pointers to avoid affecting the elements' ref counts.

--- a/cobalt/dom/html_element.h
+++ b/cobalt/dom/html_element.h
@@ -45,7 +45,6 @@
 #include "cobalt/dom/pseudo_element.h"
 #include "cobalt/loader/image/image_cache.h"
 #include "cobalt/ui_navigation/nav_item.h"
-#include "starboard/time.h"
 
 namespace cobalt {
 namespace dom {
@@ -459,9 +458,9 @@ class HTMLElement : public Element, public cssom::MutationObserver {
   void InvalidateLayoutBoxes();
 
   // Handle UI navigation events.
-  void OnUiNavBlur(SbTimeMonotonic time);
-  void OnUiNavFocus(SbTimeMonotonic time);
-  void OnUiNavScroll(SbTimeMonotonic time);
+  void OnUiNavBlur(int64_t monotonic_time);
+  void OnUiNavFocus(int64_t monotonic_time);
+  void OnUiNavScroll(int64_t monotonic_time);
 
   bool locked_for_focus_;
 

--- a/cobalt/dom/html_link_element.cc
+++ b/cobalt/dom/html_link_element.cc
@@ -31,6 +31,7 @@
 #include "cobalt/dom/html_element_context.h"
 #include "cobalt/dom/window.h"
 #include "cobalt/web/csp_delegate.h"
+#include "starboard/common/time.h"
 #include "url/gurl.h"
 
 namespace cobalt {
@@ -317,11 +318,11 @@ void HTMLLinkElement::OnSplashscreenLoaded(Document* document,
 
 void HTMLLinkElement::OnStylesheetLoaded(Document* document,
                                          const std::string& content) {
-  auto before_parse_micros = SbTimeGetMonotonicNow();
+  auto before_parse_micros = starboard::CurrentMonotonicTime();
   scoped_refptr<cssom::CSSStyleSheet> css_style_sheet =
       document->html_element_context()->css_parser()->ParseStyleSheet(
           content, base::SourceLocation(href(), 1, 1));
-  auto after_parse_micros = SbTimeGetMonotonicNow();
+  auto after_parse_micros = starboard::CurrentMonotonicTime();
   auto css_kb = content.length() / 1000;
   // Only measure non-trivial CSS sizes and ignore non-HTTP schemes (e.g.,
   // file://), which are primarily used for debug purposes.

--- a/cobalt/dom/html_media_element.cc
+++ b/cobalt/dom/html_media_element.cc
@@ -382,7 +382,7 @@ double HTMLMediaElement::duration() const {
 }
 
 base::Time HTMLMediaElement::GetStartDate() const {
-  MLOG() << start_date_.ToSbTime();
+  MLOG() << start_date_.ToDeltaSinceWindowsEpoch().InMicroseconds();
   return start_date_;
 }
 

--- a/cobalt/dom/html_style_element.cc
+++ b/cobalt/dom/html_style_element.cc
@@ -22,6 +22,7 @@
 #include "cobalt/dom/document.h"
 #include "cobalt/dom/html_element_context.h"
 #include "cobalt/web/csp_delegate.h"
+#include "starboard/common/time.h"
 
 namespace cobalt {
 namespace dom {
@@ -91,11 +92,11 @@ void HTMLStyleElement::Process() {
   const std::string& text = content.value_or(base::EmptyString());
   if (bypass_csp || csp_delegate->AllowInline(web::CspDelegate::kStyle,
                                               inline_style_location_, text)) {
-    auto before_parse_micros = SbTimeGetMonotonicNow();
+    auto before_parse_micros = starboard::CurrentMonotonicTime();
     scoped_refptr<cssom::CSSStyleSheet> css_style_sheet =
         document->html_element_context()->css_parser()->ParseStyleSheet(
             text, inline_style_location_);
-    auto after_parse_micros = SbTimeGetMonotonicNow();
+    auto after_parse_micros = starboard::CurrentMonotonicTime();
     auto css_kb = text.length() / 1000;
     // Only measure non-trivial css sizes and inlined HTML style elements.
     if (css_kb > 0 &&

--- a/cobalt/dom/performance.cc
+++ b/cobalt/dom/performance.cc
@@ -617,17 +617,17 @@ void Performance::CreatePerformanceResourceTiming(
 }
 
 void Performance::SetApplicationState(base::ApplicationState state,
-                                      SbTimeMonotonic timestamp) {
+                                      int64_t timestamp) {
   lifecycle_timing_->SetApplicationState(state, timestamp);
 }
 
-void Performance::SetApplicationStartOrPreloadTimestamp(
-    bool is_preload, SbTimeMonotonic timestamp) {
+void Performance::SetApplicationStartOrPreloadTimestamp(bool is_preload,
+                                                        int64_t timestamp) {
   lifecycle_timing_->SetApplicationStartOrPreloadTimestamp(is_preload,
                                                            timestamp);
 }
 
-void Performance::SetDeepLinkTimestamp(SbTimeMonotonic timestamp) {
+void Performance::SetDeepLinkTimestamp(int64_t timestamp) {
   lifecycle_timing_->SetDeepLinkTimestamp(timestamp);
 }
 

--- a/cobalt/dom/performance.h
+++ b/cobalt/dom/performance.h
@@ -132,13 +132,12 @@ class Performance : public web::EventTarget {
       const scoped_refptr<PerformanceObserver>& observer,
       const PerformanceObserverInit& options);
 
-  void SetApplicationState(base::ApplicationState state,
-                           SbTimeMonotonic timestamp);
+  void SetApplicationState(base::ApplicationState state, int64_t timestamp);
 
   void SetApplicationStartOrPreloadTimestamp(bool is_preload,
-                                             SbTimeMonotonic timestamp);
+                                             int64_t timestamp);
 
-  void SetDeepLinkTimestamp(SbTimeMonotonic timestamp);
+  void SetDeepLinkTimestamp(int64_t timestamp);
 
   void TraceMembers(script::Tracer* tracer) override;
   DEFINE_WRAPPABLE_TYPE(Performance);

--- a/cobalt/dom/performance_lifecycle_timing.h
+++ b/cobalt/dom/performance_lifecycle_timing.h
@@ -51,29 +51,27 @@ class PerformanceLifecycleTiming : public PerformanceEntry {
     return PerformanceEntry::kLifecycle;
   }
 
-  void SetApplicationState(base::ApplicationState state,
-                           SbTimeMonotonic timestamp);
+  void SetApplicationState(base::ApplicationState state, int64_t timestamp);
   void SetApplicationStartOrPreloadTimestamp(bool is_preload,
-                                             SbTimeMonotonic timestamp);
-  void SetDeepLinkTimestamp(SbTimeMonotonic timestamp);
+                                             int64_t timestamp);
+  void SetDeepLinkTimestamp(int64_t timestamp);
 
   DEFINE_WRAPPABLE_TYPE(PerformanceLifecycleTiming);
 
  private:
   void SetLifecycleTimingInfoState(base::ApplicationState state);
-  DOMHighResTimeStamp ReportDOMHighResTimeStamp(
-      SbTimeMonotonic timestamp) const;
+  DOMHighResTimeStamp ReportDOMHighResTimeStamp(int64_t timestamp) const;
   base::ApplicationState GetCurrentState() const;
   struct LifecycleTimingInfo {
-    SbTimeMonotonic app_preload = 0;
-    SbTimeMonotonic app_start = 0;
-    SbTimeMonotonic app_blur = 0;
-    SbTimeMonotonic app_conceal = 0;
-    SbTimeMonotonic app_focus = 0;
-    SbTimeMonotonic app_reveal = 0;
-    SbTimeMonotonic app_freeze = 0;
-    SbTimeMonotonic app_unfreeze = 0;
-    SbTimeMonotonic app_deeplink = 0;
+    int64_t app_preload = 0;
+    int64_t app_start = 0;
+    int64_t app_blur = 0;
+    int64_t app_conceal = 0;
+    int64_t app_focus = 0;
+    int64_t app_reveal = 0;
+    int64_t app_freeze = 0;
+    int64_t app_unfreeze = 0;
+    int64_t app_deeplink = 0;
 
     base::ApplicationState current_state = base::kApplicationStateStopped;
     base::ApplicationState last_state = base::kApplicationStateStopped;

--- a/cobalt/dom/source_buffer_metrics.h
+++ b/cobalt/dom/source_buffer_metrics.h
@@ -15,7 +15,7 @@
 #ifndef COBALT_DOM_SOURCE_BUFFER_METRICS_H_
 #define COBALT_DOM_SOURCE_BUFFER_METRICS_H_
 
-#include "starboard/time.h"
+#include "starboard/types.h"
 
 namespace cobalt {
 namespace dom {
@@ -50,15 +50,15 @@ class SourceBufferMetrics {
   SourceBufferMetrics(const SourceBufferMetrics&) = delete;
   SourceBufferMetrics& operator=(const SourceBufferMetrics&) = delete;
 
-  SbTimeMonotonic wall_start_time_ = 0;
-  SbTimeMonotonic thread_start_time_ = 0;
+  int64_t wall_start_time_ = 0;
+  int64_t thread_start_time_ = 0;
 
   const bool is_primary_video_;
   bool is_tracking_ = false;
 
   size_t total_size_ = 0;
-  SbTime total_thread_time_ = 0;
-  SbTime total_wall_time_ = 0;
+  int64_t total_thread_time_ = 0;
+  int64_t total_wall_time_ = 0;
   int max_thread_bandwidth_ = 0;
   int min_thread_bandwidth_ = INT_MAX;
   int max_wall_bandwidth_ = 0;

--- a/cobalt/dom/window.cc
+++ b/cobalt/dom/window.cc
@@ -479,7 +479,7 @@ void Window::InjectEvent(const scoped_refptr<web::Event>& event) {
 }
 
 void Window::SetApplicationState(base::ApplicationState state,
-                                 SbTimeMonotonic timestamp) {
+                                 int64_t timestamp) {
   html_element_context()->application_lifecycle_state()->SetApplicationState(
       state);
   if (timestamp == 0) return;

--- a/cobalt/dom/window.h
+++ b/cobalt/dom/window.h
@@ -352,8 +352,7 @@ class Window : public web::WindowOrWorkerGlobalScope,
   // Sets the current application state, forwarding on to the
   // ApplicationLifecycleState associated with it and its document, causing
   // precipitate events to be dispatched.
-  void SetApplicationState(base::ApplicationState state,
-                           SbTimeMonotonic timestamp);
+  void SetApplicationState(base::ApplicationState state, int64_t timestamp);
 
   // ApplicationLifecycleState::Observer implementation.
   void OnWindowFocusChanged(bool has_focus) override;

--- a/cobalt/input/input_device_manager_desktop.cc
+++ b/cobalt/input/input_device_manager_desktop.cc
@@ -42,7 +42,7 @@ namespace {
 void UpdateEventInit(const system_window::InputEvent* input_event,
                      web::EventInit* event) {
   if (input_event->timestamp() != 0) {
-    // Convert SbTimeMonotonic to DOMTimeStamp.
+    // Convert monotonic int64_t to DOMTimeStamp.
     event->set_time_stamp(
         cobalt::web::Event::GetEventTime(input_event->timestamp()));
   }

--- a/cobalt/media/base/cval_stats.h
+++ b/cobalt/media/base/cval_stats.h
@@ -47,7 +47,7 @@ class CValContainer {
 
   void StartTimer();
   void StopTimer();
-  void UpdateCVal(SbTime event_time);
+  void UpdateCVal(int64_t event_time_usec);
 
   // for testing only
   size_t GetSampleIndex() { return sample_write_index_; }
@@ -60,19 +60,19 @@ class CValContainer {
   std::string cval_name_;
 
  private:
-  base::CVal<SbTime, base::CValPublic> latest_;
-  base::CVal<SbTime, base::CValPublic> average_;
-  base::CVal<SbTime, base::CValPublic> maximum_;
-  base::CVal<SbTime, base::CValPublic> median_;
-  base::CVal<SbTime, base::CValPublic> minimum_;
+  base::CVal<int64_t, base::CValPublic> latest_;
+  base::CVal<int64_t, base::CValPublic> average_;
+  base::CVal<int64_t, base::CValPublic> maximum_;
+  base::CVal<int64_t, base::CValPublic> median_;
+  base::CVal<int64_t, base::CValPublic> minimum_;
 
-  SbTime samples_[kMaxSamples];
+  int64_t samples_[kMaxSamples];
   size_t sample_write_index_{0};
   size_t accumulated_sample_count_{0};
   bool first_sample_added_{false};
 
-  SbTime latest_time_start_{0};
-  SbTime latest_time_stop_{0};
+  int64_t latest_time_start_{0};
+  int64_t latest_time_stop_{0};
 };
 
 class CValStats {
@@ -90,7 +90,7 @@ class CValStats {
 
  private:
   std::map<MediaTiming, CValContainer> cval_containers_;
-  std::map<std::pair<MediaTiming, std::string>, SbTime> running_timers_;
+  std::map<std::pair<MediaTiming, std::string>, int64_t> running_timers_;
 
   bool enabled_{false};
 };

--- a/cobalt/media/base/cval_stats_test.cc
+++ b/cobalt/media/base/cval_stats_test.cc
@@ -29,7 +29,7 @@ const char kCValnameMinimum[] = "Media.SbPlayerCreateTime.Minimum";
 
 const char kPipelineIdentifier[] = "test_pipeline";
 
-constexpr SbTime kSleepTime = 50;  // 50 microseconds
+constexpr int64_t kSleepTime = 50;  // 50 microseconds
 
 namespace cobalt {
 namespace media {

--- a/cobalt/media/base/format_support_query_metrics.cc
+++ b/cobalt/media/base/format_support_query_metrics.cc
@@ -19,6 +19,7 @@
 #include "base/logging.h"
 #include "base/strings/string_util.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 
 namespace cobalt {
 namespace media {
@@ -31,7 +32,7 @@ std::string CreateQueryDescription(const char* query_name,
                                    const std::string& mime_type,
                                    const std::string& key_system,
                                    SbMediaSupportType support_type,
-                                   SbTimeMonotonic query_duration) {
+                                   int64_t query_duration) {
   auto get_support_type_str = [](SbMediaSupportType support_type) {
     switch (support_type) {
       case kSbMediaSupportTypeNotSupported:
@@ -55,22 +56,22 @@ std::string CreateQueryDescription(const char* query_name,
 }  // namespace
 
 // static
-SbTimeMonotonic FormatSupportQueryMetrics::cached_query_durations_
+int64_t FormatSupportQueryMetrics::cached_query_durations_
     [kMaxCachedQueryDurations] = {};
 char FormatSupportQueryMetrics::max_query_description_
     [kMaxQueryDescriptionLength] = {};
-SbTimeMonotonic FormatSupportQueryMetrics::max_query_duration_ = 0;
-SbTimeMonotonic FormatSupportQueryMetrics::total_query_duration_ = 0;
+int64_t FormatSupportQueryMetrics::max_query_duration_ = 0;
+int64_t FormatSupportQueryMetrics::total_query_duration_ = 0;
 int FormatSupportQueryMetrics::total_num_queries_ = 0;
 
 FormatSupportQueryMetrics::FormatSupportQueryMetrics() {
-  start_time_ = SbTimeGetMonotonicNow();
+  start_time_ = starboard::CurrentMonotonicTime();
 }
 
 void FormatSupportQueryMetrics::RecordAndLogQuery(
     const char* query_name, const std::string& mime_type,
     const std::string& key_system, SbMediaSupportType support_type) {
-  SbTimeMonotonic query_duration = SbTimeGetMonotonicNow() - start_time_;
+  int64_t query_duration = starboard::CurrentMonotonicTime() - start_time_;
   total_query_duration_ += query_duration;
 
   std::string query_description = CreateQueryDescription(

--- a/cobalt/media/base/format_support_query_metrics.h
+++ b/cobalt/media/base/format_support_query_metrics.h
@@ -18,7 +18,6 @@
 #include <string>
 
 #include "starboard/media.h"
-#include "starboard/time.h"
 
 namespace cobalt {
 namespace media {
@@ -52,13 +51,13 @@ class FormatSupportQueryMetrics {
   static constexpr int kMaxCachedQueryDurations = 150;
   static constexpr int kMaxQueryDescriptionLength = 350;
 
-  static SbTimeMonotonic cached_query_durations_[kMaxCachedQueryDurations];
+  static int64_t cached_query_durations_[kMaxCachedQueryDurations];
   static char max_query_description_[kMaxQueryDescriptionLength];
-  static SbTimeMonotonic max_query_duration_;
-  static SbTimeMonotonic total_query_duration_;
+  static int64_t max_query_duration_;
+  static int64_t total_query_duration_;
   static int total_num_queries_;
 
-  SbTimeMonotonic start_time_ = 0;
+  int64_t start_time_ = 0;
 };
 
 #endif  // defined(COBALT_BUILD_TYPE_GOLD)

--- a/cobalt/media/base/sbplayer_bridge.cc
+++ b/cobalt/media/base/sbplayer_bridge.cc
@@ -29,6 +29,7 @@
 #include "starboard/common/media.h"
 #include "starboard/common/player.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration.h"
 #include "starboard/memory.h"
 #include "starboard/once.h"
@@ -45,7 +46,7 @@ using starboard::GetPlayerOutputModeName;
 class StatisticsWrapper {
  public:
   static StatisticsWrapper* GetInstance();
-  base::Statistics<SbTime, int, 1024> startup_latency{
+  base::Statistics<int64_t, int, 1024> startup_latency{
       "Media.PlaybackStartupLatency"};
 };
 
@@ -105,8 +106,10 @@ void SetDiscardPadding(
     CobaltExtensionEnhancedAudioMediaAudioSampleInfo* sample_info) {
   DCHECK(sample_info);
 
-  sample_info->discarded_duration_from_front = discard_padding.first.ToSbTime();
-  sample_info->discarded_duration_from_back = discard_padding.second.ToSbTime();
+  sample_info->discarded_duration_from_front =
+      discard_padding.first.InMicroseconds();
+  sample_info->discarded_duration_from_back =
+      discard_padding.second.InMicroseconds();
 }
 
 void SetDiscardPadding(
@@ -115,8 +118,10 @@ void SetDiscardPadding(
   DCHECK(sample_info);
 
 #if SB_API_VERSION >= 15
-  sample_info->discarded_duration_from_front = discard_padding.first.ToSbTime();
-  sample_info->discarded_duration_from_back = discard_padding.second.ToSbTime();
+  sample_info->discarded_duration_from_front =
+      discard_padding.first.InMicroseconds();
+  sample_info->discarded_duration_from_back =
+      discard_padding.second.InMicroseconds();
 #endif  // SB_API_VERSION >= 15}
 }
 
@@ -693,7 +698,7 @@ void SbPlayerBridge::CreateUrlPlayer(const std::string& url) {
     FormatSupportQueryMetrics::PrintAndResetMetrics();
   }
 
-  player_creation_time_ = SbTimeGetMonotonicNow();
+  player_creation_time_ = starboard::CurrentMonotonicTime();
 
   cval_stats_->StartTimer(MediaTiming::SbPlayerCreate, pipeline_identifier_);
   player_ = sbplayer_interface_->CreateUrlPlayer(
@@ -743,7 +748,7 @@ void SbPlayerBridge::CreatePlayer() {
     FormatSupportQueryMetrics::PrintAndResetMetrics();
   }
 
-  player_creation_time_ = SbTimeGetMonotonicNow();
+  player_creation_time_ = starboard::CurrentMonotonicTime();
 
   SbPlayerCreationParam creation_param = {};
   creation_param.drm_system = drm_system_;
@@ -888,10 +893,10 @@ void SbPlayerBridge::WriteBuffersInternal(
     }
 
     if (sample_type == kSbMediaTypeAudio && first_audio_sample_time_ == 0) {
-      first_audio_sample_time_ = SbTimeGetMonotonicNow();
+      first_audio_sample_time_ = starboard::CurrentMonotonicTime();
     } else if (sample_type == kSbMediaTypeVideo &&
                first_video_sample_time_ == 0) {
-      first_video_sample_time_ = SbTimeGetMonotonicNow();
+      first_video_sample_time_ = starboard::CurrentMonotonicTime();
     }
 
     gathered_sbplayer_sample_infos_drm_info.push_back(SbDrmSampleInfo());
@@ -1099,7 +1104,7 @@ void SbPlayerBridge::OnPlayerStatus(SbPlayer player, SbPlayerState state,
       ++ticket_;
     }
     if (sb_player_state_initialized_time_ == 0) {
-      sb_player_state_initialized_time_ = SbTimeGetMonotonicNow();
+      sb_player_state_initialized_time_ = starboard::CurrentMonotonicTime();
     }
     sbplayer_interface_->Seek(player_, preroll_timestamp_.InMicroseconds(),
                               ticket_);
@@ -1109,10 +1114,10 @@ void SbPlayerBridge::OnPlayerStatus(SbPlayer player, SbPlayerState state,
   }
   if (state == kSbPlayerStatePrerolling &&
       sb_player_state_prerolling_time_ == 0) {
-    sb_player_state_prerolling_time_ = SbTimeGetMonotonicNow();
+    sb_player_state_prerolling_time_ = starboard::CurrentMonotonicTime();
   } else if (state == kSbPlayerStatePresenting &&
              sb_player_state_presenting_time_ == 0) {
-    sb_player_state_presenting_time_ = SbTimeGetMonotonicNow();
+    sb_player_state_presenting_time_ = starboard::CurrentMonotonicTime();
 #if !defined(COBALT_BUILD_TYPE_GOLD)
     LogStartupLatency();
 #endif  // !defined(COBALT_BUILD_TYPE_GOLD)
@@ -1295,20 +1300,20 @@ void SbPlayerBridge::LogStartupLatency() const {
         set_drm_system_ready_cb_time_ - player_creation_time_);
   }
 
-  SbTime first_event_time =
+  int64_t first_event_time =
       std::max(player_creation_time_, set_drm_system_ready_cb_time_);
-  SbTime player_initialization_time_delta =
+  int64_t player_initialization_time_delta =
       sb_player_state_initialized_time_ - first_event_time;
-  SbTime player_preroll_time_delta =
+  int64_t player_preroll_time_delta =
       sb_player_state_prerolling_time_ - sb_player_state_initialized_time_;
-  SbTime first_audio_sample_time_delta = std::max(
-      first_audio_sample_time_ - sb_player_state_prerolling_time_, SbTime(0));
-  SbTime first_video_sample_time_delta = std::max(
-      first_video_sample_time_ - sb_player_state_prerolling_time_, SbTime(0));
-  SbTime player_presenting_time_delta =
+  int64_t first_audio_sample_time_delta = std::max(
+      first_audio_sample_time_ - sb_player_state_prerolling_time_, int64_t());
+  int64_t first_video_sample_time_delta = std::max(
+      first_video_sample_time_ - sb_player_state_prerolling_time_, int64_t());
+  int64_t player_presenting_time_delta =
       sb_player_state_presenting_time_ -
       std::max(first_audio_sample_time_, first_video_sample_time_);
-  SbTime startup_latency = sb_player_state_presenting_time_ - first_event_time;
+  int64_t startup_latency = sb_player_state_presenting_time_ - first_event_time;
 
   StatisticsWrapper::GetInstance()->startup_latency.AddSample(startup_latency,
                                                               1);

--- a/cobalt/media/base/sbplayer_bridge.h
+++ b/cobalt/media/base/sbplayer_bridge.h
@@ -147,7 +147,7 @@ class SbPlayerBridge {
   SbDecodeTarget GetCurrentSbDecodeTarget();
   SbPlayerOutputMode GetSbPlayerOutputMode();
 
-  void RecordSetDrmSystemReadyTime(SbTimeMonotonic timestamp) {
+  void RecordSetDrmSystemReadyTime(int64_t timestamp) {
     set_drm_system_ready_cb_time_ = timestamp;
   }
 
@@ -306,13 +306,13 @@ class SbPlayerBridge {
   std::string player_creation_error_message_;
 
   // Variables related to tracking player startup latencies.
-  SbTimeMonotonic set_drm_system_ready_cb_time_ = -1;
-  SbTimeMonotonic player_creation_time_ = 0;
-  SbTimeMonotonic sb_player_state_initialized_time_ = 0;
-  SbTimeMonotonic sb_player_state_prerolling_time_ = 0;
-  SbTimeMonotonic first_audio_sample_time_ = 0;
-  SbTimeMonotonic first_video_sample_time_ = 0;
-  SbTimeMonotonic sb_player_state_presenting_time_ = 0;
+  int64_t set_drm_system_ready_cb_time_ = -1;
+  int64_t player_creation_time_ = 0;
+  int64_t sb_player_state_initialized_time_ = 0;
+  int64_t sb_player_state_prerolling_time_ = 0;
+  int64_t first_audio_sample_time_ = 0;
+  int64_t first_video_sample_time_ = 0;
+  int64_t sb_player_state_presenting_time_ = 0;
 
 #if SB_HAS(PLAYER_WITH_URL)
   const bool is_url_based_;

--- a/cobalt/media/base/sbplayer_interface.cc
+++ b/cobalt/media/base/sbplayer_interface.cc
@@ -59,7 +59,7 @@ void DefaultSbPlayerInterface::Destroy(SbPlayer player) {
   SbPlayerDestroy(player);
 }
 
-void DefaultSbPlayerInterface::Seek(SbPlayer player, SbTime seek_to_timestamp,
+void DefaultSbPlayerInterface::Seek(SbPlayer player, int64_t seek_to_timestamp,
                                     int ticket) {
 #if SB_API_VERSION >= 15
   SbPlayerSeek(player, seek_to_timestamp, ticket);

--- a/cobalt/media/base/sbplayer_interface.h
+++ b/cobalt/media/base/sbplayer_interface.h
@@ -40,7 +40,7 @@ class SbPlayerInterface {
   virtual SbPlayerOutputMode GetPreferredOutputMode(
       const SbPlayerCreationParam* creation_param) = 0;
   virtual void Destroy(SbPlayer player) = 0;
-  virtual void Seek(SbPlayer player, SbTime seek_to_timestamp, int ticket) = 0;
+  virtual void Seek(SbPlayer player, int64_t seek_to_timestamp, int ticket) = 0;
 
   virtual bool IsEnhancedAudioExtensionEnabled() const = 0;
   virtual void WriteSamples(SbPlayer player, SbMediaType sample_type,
@@ -108,7 +108,7 @@ class DefaultSbPlayerInterface final : public SbPlayerInterface {
   SbPlayerOutputMode GetPreferredOutputMode(
       const SbPlayerCreationParam* creation_param) override;
   void Destroy(SbPlayer player) override;
-  void Seek(SbPlayer player, SbTime seek_to_timestamp, int ticket) override;
+  void Seek(SbPlayer player, int64_t seek_to_timestamp, int ticket) override;
   bool IsEnhancedAudioExtensionEnabled() const override;
   void WriteSamples(SbPlayer player, SbMediaType sample_type,
                     const SbPlayerSampleInfo* sample_infos,

--- a/cobalt/media/base/sbplayer_pipeline.h
+++ b/cobalt/media/base/sbplayer_pipeline.h
@@ -34,7 +34,6 @@
 #include "cobalt/media/base/sbplayer_bridge.h"
 #include "cobalt/media/base/sbplayer_set_bounds_helper.h"
 #include "starboard/configuration_constants.h"
-#include "starboard/time.h"
 #include "third_party/chromium/media/base/audio_decoder_config.h"
 #include "third_party/chromium/media/base/decoder_buffer.h"
 #include "third_party/chromium/media/base/demuxer.h"
@@ -64,7 +63,7 @@ class MEDIA_EXPORT SbPlayerPipeline : public Pipeline,
       bool allow_resume_after_suspend, bool allow_batched_sample_write,
       bool force_punch_out_by_default,
 #if SB_API_VERSION >= 15
-      SbTime audio_write_duration_local, SbTime audio_write_duration_remote,
+      int64_t audio_write_duration_local, int64_t audio_write_duration_remote,
 #endif  // SB_API_VERSION >= 15
       MediaLog* media_log, MediaMetricsProvider* media_metrics_provider,
       DecodeTargetProvider* decode_target_provider);
@@ -312,34 +311,36 @@ class MEDIA_EXPORT SbPlayerPipeline : public Pipeline,
   DecodeTargetProvider* decode_target_provider_;
 
 #if SB_API_VERSION >= 15
-  const SbTime audio_write_duration_local_;
-  const SbTime audio_write_duration_remote_;
+  const int64_t audio_write_duration_local_;
+  const int64_t audio_write_duration_remote_;
 
   // The two variables below should always contain the same value.  They are
   // kept as separate variables so we can keep the existing implementation as
   // is, which simplifies the implementation across multiple Starboard versions.
-  SbTime audio_write_duration_ = 0;
-  SbTime audio_write_duration_for_preroll_ = audio_write_duration_;
+  int64_t audio_write_duration_ = 0;
+  int64_t audio_write_duration_for_preroll_ = audio_write_duration_;
 #else   // SB_API_VERSION >= 15
   // Read audio from the stream if |timestamp_of_last_written_audio_| is less
   // than |seek_time_| + |audio_write_duration_for_preroll_|, this effectively
   // allows 10 seconds of audio to be written to the SbPlayer after playback
   // startup or seek.
-  SbTime audio_write_duration_for_preroll_ = 10 * kSbTimeSecond;
+  int64_t audio_write_duration_for_preroll_ =
+      10 * base::Time::kMicrosecondsPerSecond;
   // Don't read audio from the stream more than |audio_write_duration_| ahead of
   // the current media time during playing.
-  SbTime audio_write_duration_ = kSbTimeSecond;
+  int64_t audio_write_duration_ = 1 * base::Time::kMicrosecondsPerSecond;
 #endif  // SB_API_VERSION >= 15
   // Only call GetMediaTime() from OnNeedData if it has been
   // |kMediaTimeCheckInterval| since the last call to GetMediaTime().
-  static const SbTime kMediaTimeCheckInterval = 0.1 * kSbTimeSecond;
+  static const int64_t kMediaTimeCheckInterval =
+      0.1 * base::Time::kMicrosecondsPerSecond;
   // Timestamp for the last written audio.
-  SbTime timestamp_of_last_written_audio_ = 0;
+  int64_t timestamp_of_last_written_audio_ = 0;
 
   // Last media time reported by GetMediaTime().
-  base::CVal<SbTime> last_media_time_;
-  // Time when we last checked the media time.
-  SbTime last_time_media_time_retrieved_ = 0;
+  base::CVal<int64_t> last_media_time_;
+  // Timestamp microseconds when we last checked the media time.
+  int64_t last_time_media_time_retrieved_ = 0;
   // Counter for retrograde media time.
   size_t retrograde_media_time_counter_ = 0;
   // The maximum video playback capabilities required for the playback.
@@ -347,9 +348,9 @@ class MEDIA_EXPORT SbPlayerPipeline : public Pipeline,
 
   PlaybackStatistics playback_statistics_;
 
-  SbTimeMonotonic last_resume_time_ = -1;
+  int64_t last_resume_time_ = -1;
 
-  SbTimeMonotonic set_drm_system_ready_cb_time_ = -1;
+  int64_t set_drm_system_ready_cb_time_ = -1;
 
   DISALLOW_COPY_AND_ASSIGN(SbPlayerPipeline);
 };

--- a/cobalt/media/decoder_buffer_allocator.cc
+++ b/cobalt/media/decoder_buffer_allocator.cc
@@ -176,7 +176,7 @@ int DecoderBufferAllocator::GetBufferPadding() const {
 #endif  // SB_API_VERSION >= 14
 }
 
-SbTime DecoderBufferAllocator::GetBufferGarbageCollectionDurationThreshold()
+int64_t DecoderBufferAllocator::GetBufferGarbageCollectionDurationThreshold()
     const {
   return SbMediaGetBufferGarbageCollectionDurationThreshold();
 }

--- a/cobalt/media/decoder_buffer_allocator.h
+++ b/cobalt/media/decoder_buffer_allocator.h
@@ -46,7 +46,7 @@ class DecoderBufferAllocator : public ::media::DecoderBuffer::Allocator,
   int GetAudioBufferBudget() const override;
   int GetBufferAlignment() const override;
   int GetBufferPadding() const override;
-  SbTime GetBufferGarbageCollectionDurationThreshold() const override;
+  int64_t GetBufferGarbageCollectionDurationThreshold() const override;
   int GetProgressiveBufferBudget(SbMediaVideoCodec codec, int resolution_width,
                                  int resolution_height,
                                  int bits_per_pixel) const override;

--- a/cobalt/media/media_module.h
+++ b/cobalt/media/media_module.h
@@ -133,8 +133,8 @@ class MediaModule : public WebMediaPlayerFactory,
   bool force_punch_out_by_default_ = false;
 
 #if SB_API_VERSION >= 15
-  SbTime audio_write_duration_local_ = kSbPlayerWriteDurationLocal;
-  SbTime audio_write_duration_remote_ = kSbPlayerWriteDurationRemote;
+  int64_t audio_write_duration_local_ = kSbPlayerWriteDurationLocal;
+  int64_t audio_write_duration_remote_ = kSbPlayerWriteDurationRemote;
 #endif  // SB_API_VERSION >= 15
 
   DecoderBufferAllocator decoder_buffer_allocator_;

--- a/cobalt/media/player/web_media_player_impl.cc
+++ b/cobalt/media/player/web_media_player_impl.cc
@@ -111,7 +111,7 @@ WebMediaPlayerImpl::WebMediaPlayerImpl(
     bool allow_resume_after_suspend, bool allow_batched_sample_write,
     bool force_punch_out_by_default,
 #if SB_API_VERSION >= 15
-    SbTime audio_write_duration_local, SbTime audio_write_duration_remote,
+    int64_t audio_write_duration_local, int64_t audio_write_duration_remote,
 #endif  // SB_API_VERSION >= 15
     ::media::MediaLog* const media_log)
     : pipeline_thread_("media_pipeline"),
@@ -476,7 +476,8 @@ base::Time WebMediaPlayerImpl::GetStartDate() const {
 
   base::TimeDelta start_date = pipeline_->GetMediaStartDate();
 
-  return base::Time::FromSbTime(start_date.InMicroseconds());
+  return base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(start_date.InMicroseconds()));
 }
 #endif  // SB_HAS(PLAYER_WITH_URL)
 

--- a/cobalt/media/player/web_media_player_impl.h
+++ b/cobalt/media/player/web_media_player_impl.h
@@ -113,8 +113,8 @@ class WebMediaPlayerImpl : public WebMediaPlayer,
                      bool allow_batched_sample_write,
                      bool force_punch_out_by_default,
 #if SB_API_VERSION >= 15
-                     SbTime audio_write_duration_local,
-                     SbTime audio_write_duration_remote,
+                     int64_t audio_write_duration_local,
+                     int64_t audio_write_duration_remote,
 #endif  // SB_API_VERSION >= 15
                      ::media::MediaLog* const media_log);
   ~WebMediaPlayerImpl() override;

--- a/cobalt/media/progressive/demuxer_extension_wrapper.cc
+++ b/cobalt/media/progressive/demuxer_extension_wrapper.cc
@@ -626,7 +626,7 @@ base::TimeDelta DemuxerExtensionWrapper::GetStartTime() const {
 }
 
 base::Time DemuxerExtensionWrapper::GetTimelineOffset() const {
-  const SbTime reported_time = impl_->GetTimelineOffset(impl_->user_data);
+  const int64_t reported_time = impl_->GetTimelineOffset(impl_->user_data);
   return reported_time == 0
              ? base::Time()
              : base::Time::FromDeltaSinceWindowsEpoch(

--- a/cobalt/media/progressive/demuxer_extension_wrapper_test.cc
+++ b/cobalt/media/progressive/demuxer_extension_wrapper_test.cc
@@ -108,8 +108,8 @@ class MockCobaltExtensionDemuxer {
  public:
   MOCK_METHOD0(Initialize, CobaltExtensionDemuxerStatus());
   MOCK_METHOD1(Seek, CobaltExtensionDemuxerStatus(int64_t seek_time_us));
-  MOCK_METHOD0(GetStartTime, SbTime());
-  MOCK_METHOD0(GetTimelineOffset, SbTime());
+  MOCK_METHOD0(GetStartTime, int64_t());
+  MOCK_METHOD0(GetTimelineOffset, int64_t());
   MOCK_METHOD3(Read, void(CobaltExtensionDemuxerStreamType type,
                           CobaltExtensionDemuxerReadCB read_cb,
                           void* read_cb_user_data));
@@ -117,7 +117,7 @@ class MockCobaltExtensionDemuxer {
                bool(CobaltExtensionDemuxerAudioDecoderConfig* config));
   MOCK_METHOD1(GetVideoConfig,
                bool(CobaltExtensionDemuxerVideoDecoderConfig* config));
-  MOCK_METHOD0(GetDuration, SbTime());
+  MOCK_METHOD0(GetDuration, int64_t());
 
   // Pure C functions to be used in CobaltExtensionDemuxer. These expect
   // |user_data| to be a pointer to a MockCobaltExtensionDemuxer.
@@ -131,11 +131,11 @@ class MockCobaltExtensionDemuxer {
         seek_time_us);
   }
 
-  static SbTime GetStartTimeImpl(void* user_data) {
+  static int64_t GetStartTimeImpl(void* user_data) {
     return static_cast<MockCobaltExtensionDemuxer*>(user_data)->GetStartTime();
   }
 
-  static SbTime GetTimelineOffsetImpl(void* user_data) {
+  static int64_t GetTimelineOffsetImpl(void* user_data) {
     return static_cast<MockCobaltExtensionDemuxer*>(user_data)
         ->GetTimelineOffset();
   }
@@ -158,7 +158,7 @@ class MockCobaltExtensionDemuxer {
         config);
   }
 
-  static SbTime GetDurationImpl(void* user_data) {
+  static int64_t GetDurationImpl(void* user_data) {
     return static_cast<MockCobaltExtensionDemuxer*>(user_data)->GetDuration();
   }
 };

--- a/cobalt/media/progressive/progressive_demuxer.cc
+++ b/cobalt/media/progressive/progressive_demuxer.cc
@@ -385,7 +385,8 @@ void ProgressiveDemuxer::AllocateBuffer() {
         VideoConfig().visible_rect().size().width(),
         VideoConfig().visible_rect().size().height(), kBitDepth);
     int progressive_duration_cap_in_seconds =
-        SbMediaGetBufferGarbageCollectionDurationThreshold() / kSbTimeSecond;
+        SbMediaGetBufferGarbageCollectionDurationThreshold() /
+        base::Time::kMicrosecondsPerSecond;
     const int kEstimatedBufferCountPerSeconds = 70;
     int progressive_buffer_count_cap =
         progressive_duration_cap_in_seconds * kEstimatedBufferCountPerSeconds;

--- a/cobalt/media/sandbox/web_media_player_sandbox.cc
+++ b/cobalt/media/sandbox/web_media_player_sandbox.cc
@@ -25,6 +25,7 @@
 #include "base/message_loop/message_loop.h"
 #include "base/path_service.h"
 #include "base/threading/platform_thread.h"
+#include "base/time/time.h"
 #include "cobalt/base/wrap_main.h"
 #include "cobalt/media/sandbox/format_guesstimator.h"
 #include "cobalt/media/sandbox/media_sandbox.h"
@@ -196,8 +197,8 @@ class Application {
     media_sandbox_.RegisterFrameCB(
         base::Bind(&Application::FrameCB, base::Unretained(this)));
 
-    timer_event_id_ =
-        SbEventSchedule(Application::OnTimer, this, kSbTimeSecond / 10);
+    timer_event_id_ = SbEventSchedule(Application::OnTimer, this,
+                                      base::Time::kMicrosecondsPerSecond / 10);
   }
 
   void InitializeAdaptivePlayback(
@@ -266,8 +267,8 @@ class Application {
     media_sandbox_.RegisterFrameCB(
         base::Bind(&Application::FrameCB, base::Unretained(this)));
 
-    timer_event_id_ =
-        SbEventSchedule(Application::OnTimer, this, kSbTimeSecond / 10);
+    timer_event_id_ = SbEventSchedule(Application::OnTimer, this,
+                                      base::Time::kMicrosecondsPerSecond / 10);
   }
 
   void InitializeProgressivePlayback(const FormatGuesstimator& guesstimator) {
@@ -283,8 +284,8 @@ class Application {
     media_sandbox_.RegisterFrameCB(
         base::Bind(&Application::FrameCB, base::Unretained(this)));
 
-    timer_event_id_ =
-        SbEventSchedule(Application::OnTimer, this, kSbTimeSecond / 10);
+    timer_event_id_ = SbEventSchedule(Application::OnTimer, this,
+                                      base::Time::kMicrosecondsPerSecond / 10);
   }
 
   static void OnTimer(void* context) {
@@ -317,8 +318,8 @@ class Application {
     }
 
     base::RunLoop().RunUntilIdle();
-    timer_event_id_ =
-        SbEventSchedule(Application::OnTimer, this, kSbTimeSecond / 10);
+    timer_event_id_ = SbEventSchedule(Application::OnTimer, this,
+                                      base::Time::kMicrosecondsPerSecond / 10);
   }
 
   void OnChunkDemuxerOpened(ChunkDemuxer* chunk_demuxer) {

--- a/cobalt/media_session/BUILD.gn
+++ b/cobalt/media_session/BUILD.gn
@@ -37,6 +37,7 @@ static_library("media_session") {
     "//cobalt/math",
     "//cobalt/script",
     "//starboard:starboard_headers_only",
+    "//starboard/common",
   ]
 }
 

--- a/cobalt/media_session/media_session.h
+++ b/cobalt/media_session/media_session.h
@@ -31,7 +31,7 @@
 #include "cobalt/script/callback_function.h"
 #include "cobalt/script/script_value.h"
 #include "cobalt/script/wrappable.h"
-#include "starboard/time.h"
+#include "starboard/common/time.h"
 
 namespace cobalt {
 namespace media_session {
@@ -96,8 +96,8 @@ class MediaSession : public script::Wrappable {
   void OnChanged();
 
   // Returns a time representing right now - may be overridden for testing.
-  virtual SbTimeMonotonic GetMonotonicNow() const {
-    return SbTimeGetMonotonicNow();
+  virtual int64_t GetMonotonicNow() const {
+    return starboard::CurrentMonotonicTime();
   }
 
   ActionMap action_map_;
@@ -106,7 +106,7 @@ class MediaSession : public script::Wrappable {
   MediaSessionPlaybackState playback_state_;
   scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
   bool is_change_task_queued_;
-  SbTimeMonotonic last_position_updated_time_;
+  int64_t last_position_updated_time_;
   base::Optional<MediaPositionState> media_position_state_;
 
   DISALLOW_COPY_AND_ASSIGN(MediaSession);

--- a/cobalt/media_session/media_session_client.cc
+++ b/cobalt/media_session/media_session_client.cc
@@ -22,7 +22,7 @@
 #include "base/logging.h"
 #include "cobalt/media_session/media_image.h"
 #include "cobalt/script/sequence.h"
-#include "starboard/time.h"
+#include "starboard/common/time.h"
 
 namespace cobalt {
 namespace media_session {
@@ -62,17 +62,17 @@ void GuessMediaPositionState(MediaSessionState* session_state,
     if (std::isfinite(duration)) {
       position_state.set_duration(duration);
     } else if (std::isinf(duration)) {
-      position_state.set_duration(kSbTimeMax);
+      position_state.set_duration(kSbInt64Max);
     } else {
       position_state.set_duration(0.0);
     }
     position_state.set_playback_rate((*guess_player)->GetPlaybackRate());
     position_state.set_position((*guess_player)->GetCurrentTime());
 
-    *session_state = MediaSessionState(session_state->metadata(),
-                                       SbTimeGetMonotonicNow(), position_state,
-                                       session_state->actual_playback_state(),
-                                       session_state->available_actions());
+    *session_state = MediaSessionState(
+        session_state->metadata(), starboard::CurrentMonotonicTime(),
+        position_state, session_state->actual_playback_state(),
+        session_state->available_actions());
   }
 }
 }  // namespace

--- a/cobalt/media_session/media_session_client.h
+++ b/cobalt/media_session/media_session_client.h
@@ -26,7 +26,6 @@
 #include "cobalt/media_session/media_session_action_details.h"
 #include "cobalt/media_session/media_session_state.h"
 #include "starboard/extension/media_session.h"
-#include "starboard/time.h"
 
 namespace cobalt {
 namespace media_session {

--- a/cobalt/media_session/media_session_state.h
+++ b/cobalt/media_session/media_session_state.h
@@ -18,11 +18,12 @@
 #include <bitset>
 
 #include "base/optional.h"
+#include "base/time/time.h"
 #include "cobalt/media_session/media_metadata_init.h"
 #include "cobalt/media_session/media_position_state.h"
 #include "cobalt/media_session/media_session_action.h"
 #include "cobalt/media_session/media_session_playback_state.h"
-#include "starboard/time.h"
+#include "starboard/common/time.h"
 
 namespace cobalt {
 namespace media_session {
@@ -36,7 +37,7 @@ class MediaSessionState {
 
   MediaSessionState(
       base::Optional<MediaMetadataInit> metadata,
-      SbTimeMonotonic last_position_updated_time,
+      int64_t last_position_updated_time,
       const base::Optional<MediaPositionState>& media_position_state,
       MediaSessionPlaybackState actual_playback_state,
       AvailableActionsSet available_actions);
@@ -59,14 +60,13 @@ class MediaSessionState {
   // Returns the position of the current playback.
   // https://wicg.github.io/mediasession/#current-playback-position
   // Returns the position
-  SbTimeMonotonic current_playback_position() const {
-    return GetCurrentPlaybackPosition(SbTimeGetMonotonicNow());
+  int64_t current_playback_position() const {
+    return GetCurrentPlaybackPosition(starboard::CurrentMonotonicTime());
   }
 
   // Returns the position of the current playback, given the current time.
-  // This may be used for testing without calling |SbTimeGetMonotonicNow|.
-  SbTimeMonotonic GetCurrentPlaybackPosition(
-      SbTimeMonotonic monotonic_now) const;
+  // This may be used for testing without calling |CurrentMonotonicTime|.
+  int64_t GetCurrentPlaybackPosition(int64_t monotonic_now) const;
 
   // Returns a coefficient of the current playback rate. e.g. 1.0 is normal
   // forward playback, negative for reverse playback, and 0.0 when paused.
@@ -74,10 +74,10 @@ class MediaSessionState {
   double actual_playback_rate() const { return actual_playback_rate_; }
 
   // Returns the duration of the currently playing media. 0 if no media is
-  // playing or the web app has not reported the position state. kSbTimeMax if
+  // playing or the web app has not reported the position state. kSbInt64Max if
   // there is no defined duration such as live playback.
   // https://wicg.github.io/mediasession/#dom-mediapositionstate-duration
-  SbTimeMonotonic duration() const { return duration_; }
+  int64_t duration() const { return duration_usec_; }
 
   // Returns the actual playback state.
   // https://wicg.github.io/mediasession/#actual-playback-state
@@ -95,10 +95,10 @@ class MediaSessionState {
 
  private:
   base::Optional<MediaMetadataInit> metadata_;
-  SbTimeMonotonic last_position_updated_time_ = 0;
-  SbTimeMonotonic last_position_ = 0;
+  int64_t last_position_updated_time_ = 0;
+  int64_t last_position_usec_ = 0;
   double actual_playback_rate_ = 0.0;
-  SbTimeMonotonic duration_ = 0;
+  int64_t duration_usec_ = 0;
   MediaSessionPlaybackState actual_playback_state_ =
       kMediaSessionPlaybackStateNone;
   AvailableActionsSet available_actions_;

--- a/cobalt/network/network_module.cc
+++ b/cobalt/network/network_module.cc
@@ -144,7 +144,7 @@ void NetworkModule::Initialize(const std::string& user_agent_string,
   if (command_line->HasSwitch(switches::kMaxNetworkDelay)) {
     base::StringToInt64(
         command_line->GetSwitchValueASCII(switches::kMaxNetworkDelay),
-        &options_.max_network_delay);
+        &options_.max_network_delay_usec);
   }
 
 #if defined(ENABLE_NETWORK_LOGGING)

--- a/cobalt/network/network_module.h
+++ b/cobalt/network/network_module.h
@@ -76,7 +76,7 @@ class NetworkModule : public base::MessageLoop::DestructionObserver {
           https_requirement(network::kHTTPSRequired),
           cors_policy(network::kCORSRequired),
           preferred_language("en-US"),
-          max_network_delay(0),
+          max_network_delay_usec(0),
           persistent_settings(nullptr) {}
     net::StaticCookiePolicy::Type cookie_policy;
     bool ignore_certificate_errors;
@@ -84,7 +84,7 @@ class NetworkModule : public base::MessageLoop::DestructionObserver {
     network::CORSPolicy cors_policy;
     std::string preferred_language;
     std::string custom_proxy;
-    SbTime max_network_delay;
+    int64_t max_network_delay_usec;
     persistent_storage::PersistentSettings* persistent_settings;
     storage::StorageManager::Options storage_manager_options;
   };
@@ -110,7 +110,9 @@ class NetworkModule : public base::MessageLoop::DestructionObserver {
   const std::string& preferred_language() const {
     return options_.preferred_language;
   }
-  SbTime max_network_delay() const { return options_.max_network_delay; }
+  int64_t max_network_delay_usec() const {
+    return options_.max_network_delay_usec;
+  }
   scoped_refptr<URLRequestContextGetter> url_request_context_getter() const {
     return url_request_context_getter_;
   }

--- a/cobalt/renderer/rasterizer/skia/skia/src/ports/SkTime_cobalt.cc
+++ b/cobalt/renderer/rasterizer/skia/skia/src/ports/SkTime_cobalt.cc
@@ -16,7 +16,7 @@
 #include "SkTime.h"
 #include "SkTypes.h"
 #include "base/time/time.h"
-#include "starboard/time.h"
+#include "starboard/common/time.h"
 
 // Taken from SkTime.cpp.
 void SkTime::DateTime::toISO8601(SkString* dst) const {
@@ -52,5 +52,6 @@ void SkTime::GetDateTime(DateTime* dt) {
 }
 
 double SkTime::GetNSecs() {
-  return SbTimeGetMonotonicNow() * kSbTimeNanosecondsPerMicrosecond;
+  return starboard::CurrentMonotonicTime() *
+         base::Time::kNanosecondsPerMicrosecond;
 }

--- a/cobalt/renderer/sandbox/renderer_sandbox_main.cc
+++ b/cobalt/renderer/sandbox/renderer_sandbox_main.cc
@@ -83,8 +83,7 @@ RendererSandbox::RendererSandbox()
 RendererSandbox* g_renderer_sandbox = NULL;
 
 void StartApplication(int argc, char** argv, const char* link,
-                      const base::Closure& quit_closure,
-                      SbTimeMonotonic timestamp) {
+                      const base::Closure& quit_closure, int64_t timestamp) {
   DCHECK(!g_renderer_sandbox);
   g_renderer_sandbox = new RendererSandbox();
   DCHECK(g_renderer_sandbox);

--- a/cobalt/script/v8c/v8c.cc
+++ b/cobalt/script/v8c/v8c.cc
@@ -76,8 +76,7 @@ void SetupBindings(GlobalEnvironment* global_environment) {
 cobalt::script::StandaloneJavascriptRunner* g_javascript_runner = NULL;
 
 void StartApplication(int argc, char** argv, const char* /*link */,
-                      const base::Closure& quit_closure,
-                      SbTimeMonotonic timestamp) {
+                      const base::Closure& quit_closure, int64_t timestamp) {
   DCHECK(!g_javascript_runner);
   g_javascript_runner = new cobalt::script::StandaloneJavascriptRunner(
       base::ThreadTaskRunnerHandle::Get());

--- a/cobalt/site/docs/codelabs/starboard_extensions/codelab.md
+++ b/cobalt/site/docs/codelabs/starboard_extensions/codelab.md
@@ -559,9 +559,9 @@ typedef struct StarboardExtensionPleasantryApi {
 
 #include <stdlib.h>
 
+#include "starboard/common/time.h"
 #include "starboard/extension/pleasantry.h"
 #include "starboard/system.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -577,7 +577,7 @@ const char* kFarewells[] = {
 };
 
 const char* GetFarewell() {
-  srand (SbTimeGetNow());
+  srand (starboard::CurrentPosixTime());
   int pseudo_random_index = rand() % SB_ARRAY_SIZE_INT(kFarewells);
   return kFarewells[pseudo_random_index];
 }
@@ -629,7 +629,7 @@ const void* GetPleasantryApi() {
 +
  void PreloadApplication(int argc, char** argv, const char* link,
                          const base::Closure& quit_closure,
-                         SbTimeMonotonic timestamp) {
+                         int64_t timestamp) {
 @@ -77,6 +87,14 @@ void StartApplication(int argc, char** argv, const char* link,
      return;
    }

--- a/cobalt/speech/microphone_fake.cc
+++ b/cobalt/speech/microphone_fake.cc
@@ -26,7 +26,6 @@
 #include "cobalt/audio/audio_file_reader.h"
 #include "starboard/common/file.h"
 #include "starboard/memory.h"
-#include "starboard/time.h"
 
 namespace cobalt {
 namespace speech {

--- a/cobalt/speech/sandbox/speech_sandbox_main.cc
+++ b/cobalt/speech/sandbox/speech_sandbox_main.cc
@@ -30,8 +30,7 @@ SpeechSandbox* g_speech_sandbox = NULL;
 // The timeout is optional. If it is not set or set to 0, the application
 // doesn't shut down.
 void StartApplication(int argc, char** argv, const char* link,
-                      const base::Closure& quit_closure,
-                      SbTimeMonotonic timestamp) {
+                      const base::Closure& quit_closure, int64_t timestamp) {
   if (argc != 3 && argc != 2) {
     LOG(ERROR) << "Usage: " << argv[0]
                << " <audio url|path> [timeout in seconds]";

--- a/cobalt/system_window/BUILD.gn
+++ b/cobalt/system_window/BUILD.gn
@@ -25,5 +25,6 @@ static_library("system_window") {
     "//cobalt/base",
     "//cobalt/math",
     "//starboard:starboard_headers_only",
+    "//starboard/common",
   ]
 }

--- a/cobalt/system_window/input_event.h
+++ b/cobalt/system_window/input_event.h
@@ -20,7 +20,6 @@
 #include "cobalt/base/event.h"
 #include "cobalt/math/point_f.h"
 #include "starboard/event.h"
-#include "starboard/time.h"
 
 namespace cobalt {
 namespace system_window {
@@ -59,7 +58,7 @@ class InputEvent : public base::Event {
     kForwardButton = 1 << 8,
   };
 
-  InputEvent(SbTimeMonotonic timestamp, Type type, int device_id, int key_code,
+  InputEvent(int64_t timestamp, Type type, int device_id, int key_code,
              uint32 modifiers, bool is_repeat,
              const math::PointF& position = math::PointF(),
              const math::PointF& delta = math::PointF(), float pressure = 0,
@@ -82,7 +81,7 @@ class InputEvent : public base::Event {
 
   ~InputEvent() {}
 
-  SbTimeMonotonic timestamp() const { return timestamp_; }
+  int64_t timestamp() const { return timestamp_; }
   Type type() const { return type_; }
   int key_code() const { return key_code_; }
   int device_id() const { return device_id_; }
@@ -99,7 +98,7 @@ class InputEvent : public base::Event {
   BASE_EVENT_SUBCLASS(InputEvent);
 
  private:
-  SbTimeMonotonic timestamp_;
+  int64_t timestamp_;  // monotonic timestamp in microseconds.
   Type type_;
   int device_id_;
   int key_code_;

--- a/cobalt/system_window/system_window.cc
+++ b/cobalt/system_window/system_window.cc
@@ -22,6 +22,7 @@
 #include "base/strings/stringprintf.h"
 #include "cobalt/base/event_dispatcher.h"
 #include "cobalt/system_window/input_event.h"
+#include "starboard/common/time.h"
 #include "starboard/system.h"
 
 namespace cobalt {
@@ -120,10 +121,9 @@ void SystemWindow::DispatchInputEvent(const SbEvent* event,
   const SbInputData& data = *input_data;
 
   // Use the current time unless it was overridden.
-  SbTimeMonotonic timestamp = 0;
-  timestamp = event->timestamp;
+  int64_t timestamp = event->timestamp;
   if (timestamp == 0) {
-    timestamp = SbTimeGetMonotonicNow();
+    timestamp = starboard::CurrentMonotonicTime();
   }
   // Starboard handily uses the Microsoft key mapping, which is also what Cobalt
   // uses.

--- a/cobalt/ui_navigation/scroll_engine/scroll_engine.cc
+++ b/cobalt/ui_navigation/scroll_engine/scroll_engine.cc
@@ -395,11 +395,12 @@ void ScrollEngine::ScrollNavItemsWithDecayingScroll() {
   }
 }
 
-void ScrollEngine::Conceal(render_tree::ResourceProvider*, SbTimeMonotonic) {
+void ScrollEngine::Conceal(render_tree::ResourceProvider*,
+                           int64_t /* timestamp */) {
   nav_items_with_decaying_scroll_.clear();
 }
 
-void ScrollEngine::Freeze(SbTimeMonotonic) {
+void ScrollEngine::Freeze(int64_t /* timestamp */) {
   nav_items_with_decaying_scroll_.clear();
 }
 

--- a/cobalt/ui_navigation/scroll_engine/scroll_engine.h
+++ b/cobalt/ui_navigation/scroll_engine/scroll_engine.h
@@ -75,15 +75,15 @@ class ScrollEngine : public browser::LifecycleObserver {
   base::Thread* thread() { return &scroll_engine_; }
 
   // LifecycleObserver implementation.
-  void Blur(SbTimeMonotonic timestamp) override {}
+  void Blur(int64_t timestamp) override {}
   void Conceal(render_tree::ResourceProvider* resource_provider,
-               SbTimeMonotonic timestamp) override;
-  void Freeze(SbTimeMonotonic timestamp) override;
+               int64_t timestamp) override;
+  void Freeze(int64_t timestamp) override;
   void Unfreeze(render_tree::ResourceProvider* resource_provider,
-                SbTimeMonotonic timestamp) override {}
+                int64_t timestamp) override {}
   void Reveal(render_tree::ResourceProvider* resource_provider,
-              SbTimeMonotonic timestamp) override {}
-  void Focus(SbTimeMonotonic timestamp) override {}
+              int64_t timestamp) override {}
+  void Focus(int64_t timestamp) override {}
 
  private:
   base::Thread scroll_engine_{"ScrollEngineThread"};

--- a/cobalt/updater/BUILD.gn
+++ b/cobalt/updater/BUILD.gn
@@ -83,12 +83,16 @@ target(final_executable_type, "crash_sandbox") {
 
 target(final_executable_type, "noop_sandbox") {
   sources = [ "noop_sandbox.cc" ]
-  deps = [ "//starboard:starboard_group", ]
+  deps = [
+    "//base",
+    "//starboard:starboard_group",
+  ]
 }
 
 target(final_executable_type, "one_app_only_sandbox") {
   sources = [ "one_app_only_sandbox.cc" ]
   deps = [
+    "//base",
     "//cobalt/base",
     "//cobalt/browser",
     "//cobalt/browser:browser_switches",

--- a/cobalt/updater/noop_sandbox.cc
+++ b/cobalt/updater/noop_sandbox.cc
@@ -14,13 +14,13 @@
 
 // This is a test app for Evergreen that does nothing.
 
+#include "base/time/time.h"
 #include "starboard/event.h"
 #include "starboard/system.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 
 void SbEventHandle(const SbEvent* event) {
   // No-op app. Exit after 1s.
-  SbThreadSleep(kSbTimeSecond);
+  SbThreadSleep(1 * base::Time::kMicrosecondsPerSecond);
   SbSystemRequestStop(0);
 }

--- a/cobalt/updater/one_app_only_sandbox.cc
+++ b/cobalt/updater/one_app_only_sandbox.cc
@@ -72,7 +72,7 @@ bool CheckForAndExecuteStartupSwitches() {
 
 void PreloadApplication(int argc, char** argv, const char* link,
                         const base::Closure& quit_closure,
-                        SbTimeMonotonic timestamp) {
+                        int64_t timestamp) {
   if (CheckForAndExecuteStartupSwitches()) {
     SbSystemRequestStop(0);
     return;
@@ -86,7 +86,7 @@ void PreloadApplication(int argc, char** argv, const char* link,
 
 void StartApplication(int argc, char** argv, const char* link,
                       const base::Closure& quit_closure,
-                      SbTimeMonotonic timestamp) {
+                      int64_t timestamp) {
   if (CheckForAndExecuteStartupSwitches()) {
     SbSystemRequestStop(0);
     return;

--- a/cobalt/updater/unzipper.cc
+++ b/cobalt/updater/unzipper.cc
@@ -8,7 +8,8 @@
 #include <utility>
 #include "base/callback.h"
 #include "base/files/file_path.h"
-#include "starboard/time.h"
+#include "base/time/time.h"
+#include "starboard/common/time.h"
 #include "third_party/zlib/google/zip.h"
 
 namespace cobalt {
@@ -22,26 +23,28 @@ class UnzipperImpl : public update_client::Unzipper {
 
   void Unzip(const base::FilePath& zip_path, const base::FilePath& output_path,
              UnzipCompleteCallback callback) override {
-    SbTimeMonotonic time_before_unzip = SbTimeGetMonotonicNow();
+    int64_t time_before_unzip = starboard::CurrentMonotonicTime();
     std::move(callback).Run(zip::Unzip(zip_path, output_path));
-    SbTimeMonotonic time_unzip_took =
-        SbTimeGetMonotonicNow() - time_before_unzip;
+    int64_t time_unzip_took_usec =
+        starboard::CurrentMonotonicTime() - time_before_unzip;
     LOG(INFO) << "Unzip file path = " << zip_path;
     LOG(INFO) << "output_path = " << output_path;
-    LOG(INFO) << "Unzip took " << time_unzip_took / kSbTimeMillisecond
+    LOG(INFO) << "Unzip took "
+              << time_unzip_took_usec / base::Time::kMicrosecondsPerMillisecond
               << " milliseconds.";
   }
 
 #if defined(IN_MEMORY_UPDATES)
   void Unzip(const std::string& zip_str, const base::FilePath& output_path,
              UnzipCompleteCallback callback) override {
-    SbTimeMonotonic time_before_unzip = SbTimeGetMonotonicNow();
+    int64_t time_before_unzip = starboard::CurrentMonotonicTime();
     std::move(callback).Run(zip::Unzip(zip_str, output_path));
-    SbTimeMonotonic time_unzip_took =
-        SbTimeGetMonotonicNow() - time_before_unzip;
+    int64_t time_unzip_took_usec =
+        starboard::CurrentMonotonicTime() - time_before_unzip;
     LOG(INFO) << "Unzip from string";
     LOG(INFO) << "output_path = " << output_path;
-    LOG(INFO) << "Unzip took " << time_unzip_took / kSbTimeMillisecond
+    LOG(INFO) << "Unzip took "
+              << time_unzip_took_usec / base::Time::kMicrosecondsPerMillisecond
               << " milliseconds.";
   }
 #endif

--- a/cobalt/watchdog/watchdog.h
+++ b/cobalt/watchdog/watchdog.h
@@ -28,7 +28,6 @@
 #include "starboard/common/condition_variable.h"
 #include "starboard/common/mutex.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 
 namespace cobalt {
 namespace watchdog {
@@ -52,7 +51,7 @@ typedef struct Client {
   int64_t time_registered_microseconds;
   // Monotonically increasing timestamp when client was registered. Used as the
   // start value for time wait calculations.
-  SbTimeMonotonic time_registered_monotonic_microseconds;
+  int64_t time_registered_monotonic_microseconds;
   // Epoch time when client was last pinged. Set by Ping() and Register() when
   // in PING replace mode or set initially by Register().
   int64_t time_last_pinged_microseconds;
@@ -62,7 +61,7 @@ typedef struct Client {
   // violation occurs. Prevents excessive violations as they must occur
   // time_interval_microseconds apart rather than on each monitor loop. Used as
   // the start value for time interval calculations.
-  SbTimeMonotonic time_last_updated_monotonic_microseconds;
+  int64_t time_last_updated_monotonic_microseconds;
 } Client;
 
 // Register behavior with previously registered clients of the same name.
@@ -123,12 +122,12 @@ class Watchdog : public Singleton<Watchdog> {
                                        int64_t time_interval_microseconds,
                                        int64_t time_wait_microseconds,
                                        int64_t current_time,
-                                       SbTimeMonotonic current_monotonic_time);
+                                       int64_t current_monotonic_time);
   static void* Monitor(void* context);
   static bool MonitorClient(void* context, Client* client,
-                            SbTimeMonotonic current_monotonic_time);
+                            int64_t current_monotonic_time);
   static void UpdateViolationsMap(void* context, Client* client,
-                                  SbTimeMonotonic time_delta);
+                                  int64_t time_delta);
   static void EvictWatchdogViolation(void* context);
   static void MaybeWriteWatchdogViolations(void* context);
   static void MaybeTriggerCrash(void* context);
@@ -155,7 +154,7 @@ class Watchdog : public Singleton<Watchdog> {
   bool pending_write_;
   // Monotonically increasing timestamp when Watchdog violations were last
   // written to persistent storage. 0 indicates that it has never been written.
-  SbTimeMonotonic time_last_written_microseconds_ = 0;
+  int64_t time_last_written_microseconds_ = 0;
   // Number of microseconds between writes.
   int64_t write_wait_time_microseconds_;
   // Dictionary of name registered Watchdog clients.
@@ -181,7 +180,7 @@ class Watchdog : public Singleton<Watchdog> {
   std::string delay_name_ = "";
   // Monotonically increasing timestamp when a delay was last injected. 0
   // indicates that it has never been injected.
-  SbTimeMonotonic time_last_delayed_microseconds_ = 0;
+  int64_t time_last_delayed_microseconds_ = 0;
   // Number of microseconds between delays.
   int64_t delay_wait_time_microseconds_ = 0;
   // Number of microseconds to delay.

--- a/cobalt/web/BUILD.gn
+++ b/cobalt/web/BUILD.gn
@@ -37,6 +37,7 @@ static_library("web_events") {
     "//cobalt/script",
     "//cobalt/script:engine",
     "//cobalt/script/v8c:engine",
+    "//starboard/common",
     "//url",
   ]
 

--- a/cobalt/web/event.cc
+++ b/cobalt/web/event.cc
@@ -17,30 +17,35 @@
 #include "base/compiler_specific.h"
 #include "base/time/time.h"
 #include "cobalt/web/event_target.h"
+#include "starboard/common/time.h"
 
 namespace cobalt {
 namespace web {
 
 Event::Event(UninitializedFlag uninitialized_flag)
-    : event_phase_(kNone), time_stamp_(GetEventTime(SbTimeGetMonotonicNow())) {
+    : event_phase_(kNone),
+      time_stamp_(GetEventTime(starboard::CurrentMonotonicTime())) {
   InitEventInternal(base::Token(), false, false);
 }
 
 Event::Event(const char* type) : Event(base::Token(type)) {}
 Event::Event(const std::string& type) : Event(base::Token(type)) {}
 Event::Event(base::Token type)
-    : event_phase_(kNone), time_stamp_(GetEventTime(SbTimeGetMonotonicNow())) {
+    : event_phase_(kNone),
+      time_stamp_(GetEventTime(starboard::CurrentMonotonicTime())) {
   InitEventInternal(type, false, false);
 }
 Event::Event(const std::string& type, const EventInit& init_dict)
     : Event(base::Token(type), init_dict) {}
 Event::Event(base::Token type, Bubbles bubbles, Cancelable cancelable)
-    : event_phase_(kNone), time_stamp_(GetEventTime(SbTimeGetMonotonicNow())) {
+    : event_phase_(kNone),
+      time_stamp_(GetEventTime(starboard::CurrentMonotonicTime())) {
   InitEventInternal(type, bubbles == kBubbles, cancelable == kCancelable);
 }
 
 Event::Event(base::Token type, const EventInit& init_dict)
-    : event_phase_(kNone), time_stamp_(GetEventTime(SbTimeGetMonotonicNow())) {
+    : event_phase_(kNone),
+      time_stamp_(GetEventTime(starboard::CurrentMonotonicTime())) {
   SB_DCHECK(init_dict.has_bubbles());
   SB_DCHECK(init_dict.has_cancelable());
   if (init_dict.time_stamp() != 0) {
@@ -92,12 +97,16 @@ void Event::TraceMembers(script::Tracer* tracer) {
   tracer->Trace(current_target_);
 }
 
-uint64 Event::GetEventTime(SbTimeMonotonic monotonic_time) {
+uint64 Event::GetEventTime(int64_t monotonic_time) {
+  // Current delta from Windows epoch.
+  int64_t time_delta =
+      starboard::PosixTimeToWindowsTime(starboard::CurrentPosixTime()) -
+      starboard::CurrentMonotonicTime();
+  base::Time base_time = base::Time::FromDeltaSinceWindowsEpoch(
+      base::TimeDelta::FromMicroseconds(time_delta + monotonic_time));
   // For now, continue using the old specification which specifies real time
-  // since 1970.
+  // since 1970 by calling the `ToJsTime` method.
   // https://www.w3.org/TR/dom/#dom-event-timestamp
-  SbTimeMonotonic time_delta = SbTimeGetNow() - SbTimeGetMonotonicNow();
-  base::Time base_time = base::Time::FromSbTime(time_delta + monotonic_time);
   return static_cast<uint64>(base_time.ToJsTime());
 }
 

--- a/cobalt/web/event.h
+++ b/cobalt/web/event.h
@@ -132,7 +132,7 @@ class Event : public script::Wrappable {
   // real time. However, the old spec specifies time since 1970. To facilitate
   // the transition to the new spec, use this function to calculate an event's
   // time stamp.
-  static uint64 GetEventTime(SbTimeMonotonic monotonic_time);
+  static uint64 GetEventTime(int64_t monotonic_time);
 
   DEFINE_WRAPPABLE_TYPE(Event);
   void TraceMembers(script::Tracer* tracer) override;

--- a/cobalt/xhr/xml_http_request.cc
+++ b/cobalt/xhr/xml_http_request.cc
@@ -1477,7 +1477,7 @@ void XMLHttpRequestImpl::StartRequest(const std::string& request_body) {
     StartURLFetcher(environment_settings()
                         ->context()
                         ->network_module()
-                        ->max_network_delay(),
+                        ->max_network_delay_usec(),
                     url_fetcher_generation_);
   }
 }
@@ -1525,15 +1525,15 @@ void XMLHttpRequestImpl::PrepareForNewRequest() {
   is_redirect_ = false;
 }
 
-void XMLHttpRequestImpl::StartURLFetcher(const SbTime max_artificial_delay,
-                                         const int url_fetcher_generation) {
-  if (max_artificial_delay > 0) {
+void XMLHttpRequestImpl::StartURLFetcher(
+    const int64_t max_artificial_delay_usec, const int url_fetcher_generation) {
+  if (max_artificial_delay_usec > 0) {
     base::ThreadTaskRunnerHandle::Get()->PostDelayedTask(
         FROM_HERE,
         base::Bind(&XMLHttpRequestImpl::StartURLFetcher, base::Unretained(this),
                    0, url_fetcher_generation_),
         base::TimeDelta::FromMicroseconds(base::RandUint64() %
-                                          max_artificial_delay));
+                                          max_artificial_delay_usec));
     return;
   }
 
@@ -1555,9 +1555,11 @@ void XMLHttpRequestImpl::CORSPreflightErrorCallback() {
 
 void XMLHttpRequestImpl::CORSPreflightSuccessCallback() {
   DCHECK(environment_settings()->context()->network_module());
-  StartURLFetcher(
-      environment_settings()->context()->network_module()->max_network_delay(),
-      url_fetcher_generation_);
+  StartURLFetcher(environment_settings()
+                      ->context()
+                      ->network_module()
+                      ->max_network_delay_usec(),
+                  url_fetcher_generation_);
 }
 
 DOMXMLHttpRequestImpl::DOMXMLHttpRequestImpl(XMLHttpRequest* xhr)

--- a/cobalt/xhr/xml_http_request.h
+++ b/cobalt/xhr/xml_http_request.h
@@ -330,7 +330,7 @@ class XMLHttpRequestImpl
   virtual web::CspDelegate* csp_delegate() const;
 
   // The following method starts "url_fetcher_" with a possible pre-delay.
-  void StartURLFetcher(const SbTime max_artificial_delay,
+  void StartURLFetcher(const int64_t max_artificial_delay_usec,
                        const int url_fetcher_generation);
 
   // Protected members for visibility in derived class.

--- a/glimp/egl/display.cc
+++ b/glimp/egl/display.cc
@@ -28,7 +28,7 @@
 namespace glimp {
 namespace egl {
 
-const SbTime kSubmitDoneDelay = kSbTimeSecond / 60;
+const int64_t kSubmitDoneDelay = 1000000 / 60;  // 1/60 seconds, in microseconds
 
 // Don't repeat the submitDone callback during suspension
 // until specified by eglTerminate.

--- a/net/socket/tcp_socket_starboard.cc
+++ b/net/socket/tcp_socket_starboard.cc
@@ -18,6 +18,7 @@
 #include <utility>
 
 #include "base/callback_helpers.h"
+#include "base/time/time.h"
 #include "net/base/net_errors.h"
 #include "net/base/network_activity_monitor.h"
 #include "net/socket/socket_net_log_params.h"
@@ -163,8 +164,8 @@ int TCPSocketStarboard::SetDefaultOptionsForServer() {
 void TCPSocketStarboard::SetDefaultOptionsForClient() {
   SbSocketSetTcpNoDelay(socket_, true);
 
-  const SbTime kTCPKeepAliveDuration = 45 * kSbTimeSecond;
-  SbSocketSetTcpKeepAlive(socket_, true, kTCPKeepAliveDuration);
+  const int64_t kTCPKeepAliveDurationUsec = 45 * base::Time::kMicrosecondsPerSecond;
+  SbSocketSetTcpKeepAlive(socket_, true, kTCPKeepAliveDurationUsec);
 
   SbSocketSetTcpWindowScaling(socket_, true);
 

--- a/starboard/build/config/modular/BUILD.gn
+++ b/starboard/build/config/modular/BUILD.gn
@@ -170,6 +170,21 @@ config("modular") {
 
     defines += [ "THREAD_SANITIZER" ]
   }
+
+  ldflags = []
+
+  # Wrap underlying POSIX implementations to be cross-compatible with
+  # musl-based types that are used in modular builds. Evergreen builds use
+  # a different map-based wrapping of these POSIX APIs.
+  # Note that the corresponding implementations of these wrappers need to be
+  # compiled into the Starboard shared library, which is handled in
+  # //starboard/build/config/starboard_target_type.gni.
+  if (!sb_is_evergreen && current_toolchain == cobalt_toolchain) {
+    ldflags += [
+      "-Wl,--wrap=clock_gettime",
+      "-Wl,--wrap=gettimeofday",
+    ]
+  }
 }
 
 config("speed") {

--- a/starboard/build/config/starboard_target_type.gni
+++ b/starboard/build/config/starboard_target_type.gni
@@ -57,5 +57,10 @@ template("starboard_platform_target") {
     if (!sb_is_evergreen) {
       public_deps += [ "//$starboard_path:starboard_platform" ]
     }
+    if (sb_is_modular) {
+      # For modular builds (including Evergreen), include POSIX wrappers that
+      # handle cross-compatibility with musl-based Cobalt code.
+      public_deps += [ "//starboard/shared/modular:posix_time_wrappers" ]
+    }
   }
 }

--- a/starboard/common/BUILD.gn
+++ b/starboard/common/BUILD.gn
@@ -97,6 +97,8 @@ static_library("common") {
     "thread.h",
     "thread_collision_warner.cc",
     "thread_collision_warner.h",
+    "time.cc",
+    "time.h",
   ]
 }
 

--- a/starboard/common/time.cc
+++ b/starboard/common/time.cc
@@ -1,0 +1,59 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/common/time.h"
+
+#if SB_API_VERSION >= 16
+
+#include <sys/time.h>
+#include <time.h>
+
+#include "starboard/common/log.h"
+
+#else  // SB_API_VERSION >= 16
+
+#include "starboard/time.h"
+
+#endif  // SB_API_VERSION >= 16
+
+namespace starboard {
+
+int64_t CurrentMonotonicTime() {
+#if SB_API_VERSION >= 16
+  struct timespec ts;
+  if (clock_gettime(CLOCK_MONOTONIC, &ts) != 0) {
+    SB_NOTREACHED() << "clock_gettime(CLOCK_MONOTONIC) failed.";
+    return 0;
+  }
+  return (static_cast<int64_t>(ts.tv_sec) * 1000000) +
+         (static_cast<int64_t>(ts.tv_nsec) / 1000);
+#else   // SB_API_VERSION >= 16
+  return SbTimeGetMonotonicNow();
+#endif  // SB_API_VERSION >= 16
+}
+
+int64_t CurrentPosixTime() {
+#if SB_API_VERSION >= 16
+  struct timeval tv;
+  if (gettimeofday(&tv, NULL) != 0) {
+    SB_NOTREACHED() << "Could not determine time of day.";
+    return 0;
+  }
+  return (static_cast<int64_t>(tv.tv_sec) * 1000000) + tv.tv_usec;
+#else   // SB_API_VERSION >= 16
+  return SbTimeToPosix(SbTimeGetNow());
+#endif  // SB_API_VERSION >= 16
+}
+
+}  // namespace starboard

--- a/starboard/common/time.h
+++ b/starboard/common/time.h
@@ -1,0 +1,37 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_COMMON_TIME_H_
+#define STARBOARD_COMMON_TIME_H_
+
+#include "starboard/configuration.h"
+#include "starboard/types.h"
+
+namespace starboard {
+
+// A convenience helper to get the current Monotonic time in microseconds.
+int64_t CurrentMonotonicTime();
+
+// A convenience helper to get the current POSIX system time in microseconds.
+int64_t CurrentPosixTime();
+
+// Converts a POSIX microseconds timestamp to a Windows microseconds timestamp.
+static SB_C_FORCE_INLINE int64_t PosixTimeToWindowsTime(int64_t posix_time) {
+  // Add number of microseconds since Jan 1, 1601 (UTC) until Jan 1, 1970 (UTC).
+  return posix_time + 11644473600000000ULL;
+}
+
+}  // namespace starboard
+
+#endif  // STARBOARD_COMMON_TIME_H_

--- a/starboard/elf_loader/BUILD.gn
+++ b/starboard/elf_loader/BUILD.gn
@@ -58,6 +58,7 @@ static_library("elf_loader") {
     ":evergreen_info",
     "//starboard:starboard_group",
     "//starboard/common",
+    "//starboard/shared/modular:posix_time_wrappers",
     "//third_party/lz4_lib:lz4",
   ]
 }
@@ -80,6 +81,7 @@ if (sb_is_evergreen_compatible) {
       ":evergreen_info",
       "//starboard:starboard_group",
       "//starboard/common",
+      "//starboard/shared/modular:posix_time_wrappers",
     ]
 
     if (sb_is_evergreen_compatible) {

--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -15,6 +15,7 @@
 #include "starboard/elf_loader/exported_symbols.h"
 
 #include <stdlib.h>
+#include <time.h>
 
 #include "starboard/accessibility.h"
 #include "starboard/audio_sink.h"
@@ -42,6 +43,9 @@
 #include "starboard/mutex.h"
 #include "starboard/once.h"
 #include "starboard/player.h"
+#if SB_API_VERSION >= 16
+#include "starboard/shared/modular/posix_time_wrappers.h"
+#endif  // SB_API_VERSION >= 16
 #include "starboard/socket.h"
 #include "starboard/socket_waiter.h"
 #include "starboard/speech_synthesis.h"
@@ -407,6 +411,15 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(posix_memalign);
   REGISTER_SYMBOL(free);
   REGISTER_SYMBOL(vsscanf);
+  REGISTER_SYMBOL(time);
+
+  // Custom mapped POSIX APIs to compatibility wrappers.
+  // These will rely on Starboard-side implementations that properly translate
+  // Platform-specific types with musl-based types. These wrappers are defined
+  // in //starboard/shared/modular.
+  // TODO: b/316603042 - Detect via NPLB and only add the wrapper if needed.
+  map_["clock_gettime"] = reinterpret_cast<const void*>(&__wrap_clock_gettime);
+  map_["gettimeofday"] = reinterpret_cast<const void*>(&__wrap_gettimeofday);
 #endif  // SB_API_VERSION >= 16
 
 }  // NOLINT

--- a/starboard/shared/modular/BUILD.gn
+++ b/starboard/shared/modular/BUILD.gn
@@ -1,0 +1,24 @@
+# Copyright 2023 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+static_library("posix_time_wrappers") {
+  sources = [
+    "posix_time_wrappers.cc",
+    "posix_time_wrappers.h",
+  ]
+
+  configs += [ "//starboard/build/config:starboard_implementation" ]
+
+  deps = [ "//starboard:starboard_headers_only" ]
+}

--- a/starboard/shared/modular/posix_time_wrappers.cc
+++ b/starboard/shared/modular/posix_time_wrappers.cc
@@ -1,0 +1,38 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/modular/posix_time_wrappers.h"
+
+int __wrap_clock_gettime(int /*clockid_t */ clock_id,
+                         struct musl_timespec* mts) {
+  if (!mts) {
+    return -1;
+  }
+  struct timespec ts;  // The type from platform toolchain.
+  int retval = clock_gettime((clockid_t)clock_id, &ts);
+  mts->tv_sec = ts.tv_sec;
+  mts->tv_nsec = ts.tv_nsec;
+  return retval;
+}
+
+int __wrap_gettimeofday(struct musl_timeval* mtv, void* tzp) {
+  if (!mtv) {
+    return -1;
+  }
+  struct timeval tv;  // The type from platform toolchain.
+  int retval = gettimeofday(&tv, NULL);
+  mtv->tv_sec = tv.tv_sec;
+  mtv->tv_usec = tv.tv_usec;
+  return retval;
+}

--- a/starboard/shared/modular/posix_time_wrappers.h
+++ b/starboard/shared/modular/posix_time_wrappers.h
@@ -1,0 +1,102 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Module Overview: POSIX time wrappers
+//
+// These wrappers are used in modular builds (including Evergreen). They
+// are needed to handle dealing with differences in platform-specific
+// toolchain types and musl-based types. In particular, the `struct timespec`
+// and `struct timeval` types may contain differently sized member fields and
+// when the caller is Cobalt code compiled with musl it will provide argument
+// data that needs to be adjusted when passed to platform-specific system
+// libraries.
+//
+// To do this adjustment across compilation toolchains, this file will be
+// compiled using the platform-specific toolchain (as part of the Starboard
+// shared library), relying on the platform-specific type definitions from
+// <time.h> and <sys/time.h>. It will also define corresponding musl-compatible
+// types (copying the type definitions provided in
+// //third_party/musl/include/alltypes.h.in). It will provide the definition
+// of "wrapper" functions for the underlying POSIX functions, with a naming
+// convention of __wrap_XXX where XXX is the name of the POSIX function.
+//
+// For Evergreen-based modular builds, we will rely on the exported_symbols.cc
+// mapping logic to map calls to the POSIX functions to the corresponding
+// __wrap_XXX functions.
+//
+// For non-Evergreen modular builds, the Cobalt-side shared library will be
+// linked with `--wrap` linker flags to remap the POSIX functions to the
+// corresponding __wrap_XXX functions.
+//
+// In summary, taking `clock_gettime` as an example POSIX function, the
+// following table shows which symbols are remaped, undefined, or defined in
+// each layer for a non-Evergreen modular build:
+//
+// starboard.so:
+//   U clock_gettime@GLIBC_2.17  (undefined reference to platform library)
+//   T __wrap_clock_gettime      (concrete definition of wrapper function)
+//
+// cobalt.so
+//   U __wrap_clock_gettime      (remapped via --wrap linker flag)
+//
+
+#ifndef STARBOARD_SHARED_MODULAR_POSIX_TIME_WRAPPERS_H_
+#define STARBOARD_SHARED_MODULAR_POSIX_TIME_WRAPPERS_H_
+
+#include <stdint.h>
+#include <sys/time.h>  // This should be the headers from the platform toolchain
+#include <time.h>      // This should be the headers from the platform toolchain
+
+#include "starboard/configuration.h"
+#include "starboard/export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// Copying types from //third_party/musl/include/alltypes.h.in
+#if __ARMEB__
+#define __SB_BYTE_ORDER 4321
+#else
+#define __SB_BYTE_ORDER 1234
+#endif
+#if SB_IS(ARCH_ARM64) || SB_IS(ARCH_X64)
+#define __SB_LONG_TYPE int64_t
+#else
+#define __SB_LONG_TYPE int32_t
+#endif
+// Note, these structs need to ABI match the musl definitions.
+struct musl_timespec {
+  int64_t /* time_t */ tv_sec;
+  int : 8 * (sizeof(int64_t) - sizeof(__SB_LONG_TYPE)) *
+      (__SB_BYTE_ORDER == 4321);
+  __SB_LONG_TYPE /* long */ tv_nsec;
+  int : 8 * (sizeof(int64_t) - sizeof(__SB_LONG_TYPE)) *
+      (__SB_BYTE_ORDER != 4321);
+};
+struct musl_timeval {
+  int64_t /* time_t */ tv_sec;
+  int64_t /* suseconds_t */ tv_usec;
+};
+
+SB_EXPORT int __wrap_clock_gettime(int /*clockid_t */ clock_id,
+                                   struct musl_timespec* mts);
+
+SB_EXPORT int __wrap_gettimeofday(struct musl_timeval* mtv, void* tzp);
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // STARBOARD_SHARED_MODULAR_POSIX_TIME_WRAPPERS_H_

--- a/starboard/shared/pthread/condition_variable_wait_timed.cc
+++ b/starboard/shared/pthread/condition_variable_wait_timed.cc
@@ -18,18 +18,18 @@
 #include <pthread.h>
 #include <time.h>
 
+#include "starboard/common/time.h"
 #include "starboard/shared/posix/time_internal.h"
 #include "starboard/shared/pthread/is_success.h"
 #include "starboard/shared/pthread/types_internal.h"
 #include "starboard/shared/starboard/lazy_initialization_internal.h"
-#include "starboard/time.h"
 
 using starboard::shared::starboard::EnsureInitialized;
 
 SbConditionVariableResult SbConditionVariableWaitTimed(
     SbConditionVariable* condition,
     SbMutex* mutex,
-    SbTime timeout) {
+    int64_t timeout) {
   if (!condition || !mutex) {
     return kSbConditionVariableFailed;
   }
@@ -39,12 +39,12 @@ SbConditionVariableResult SbConditionVariableWaitTimed(
   }
 
 #if !SB_HAS_QUIRK(NO_CONDATTR_SETCLOCK_SUPPORT)
-  SbTime timeout_time = SbTimeGetMonotonicNow() + timeout;
+  int64_t timeout_time = starboard::CurrentMonotonicTime() + timeout;
 #else   // !SB_HAS_QUIRK(NO_CONDATTR_SETCLOCK_SUPPORT)
-  int64_t timeout_time = SbTimeToPosix(SbTimeGetNow()) + timeout;
+  int64_t timeout_time = starboard::CurrentPosixTime() + timeout;
 #endif  // !SB_HAS_QUIRK(NO_CONDATTR_SETCLOCK_SUPPORT)
 
-  // Detect overflow if timeout is near kSbTimeMax. Since timeout can't be
+  // Detect overflow if timeout is near kSbInt64Max. Since timeout can't be
   // negative at this point, if it goes negative after adding now, we know we've
   // gone over. Especially posix now, which has a 400 year advantage over
   // Chromium (Windows) now.

--- a/starboard/shared/widevine/drm_system_widevine.cc
+++ b/starboard/shared/widevine/drm_system_widevine.cc
@@ -22,6 +22,7 @@
 #include "starboard/common/log.h"
 #include "starboard/common/mutex.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/memory.h"
 #include "starboard/once.h"
@@ -54,7 +55,7 @@ DECLARE_INSTANCE_COUNTER(DrmSystemWidevine);
 class WidevineClock : public wv3cdm::IClock {
  public:
   int64_t now() override {
-    return SbTimeToPosix(SbTimeGetNow()) / kSbTimeMillisecond;
+    return CurrentPosixTime() / 1000;  // in milliseconds
   }
 };
 

--- a/starboard/shared/win32/posix_emu/include/sys/time.h
+++ b/starboard/shared/win32/posix_emu/include/sys/time.h
@@ -1,0 +1,39 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_SYS_TIME_H_
+#define STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_SYS_TIME_H_
+
+#if defined(STARBOARD)
+
+#include <winsock2.h>  // For struct timeval
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/sys_time.h.html
+// https://learn.microsoft.com/en-us/windows/win32/api/winsock2/ns-winsock2-timeval
+typedef long suseconds_t;  // NOLINT(runtime/int)
+
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/gettimeofday.html
+int gettimeofday(struct timeval* tp, void* tzp);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // defined(STARBOARD)
+
+#endif  // STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_SYS_TIME_H_

--- a/starboard/shared/win32/posix_emu/include/time.h
+++ b/starboard/shared/win32/posix_emu/include/time.h
@@ -1,0 +1,41 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_TIME_H_
+#define STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_TIME_H_
+
+#if defined(STARBOARD)
+
+#include <time.h>  // For struct timespec
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/time.h.html
+typedef int clockid_t;
+#define CLOCK_REALTIME 0
+#define CLOCK_MONOTONIC 1
+#define CLOCK_PROCESS_CPUTIME_ID 2
+
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/clock_gettime.html
+int clock_gettime(clockid_t clock_id, struct timespec* tp);
+
+#ifdef __cplusplus
+}
+#endif  // __cplusplus
+
+#endif  // defined(STARBOARD)
+
+#endif  // STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_TIME_H_

--- a/starboard/shared/win32/posix_emu/time.cc
+++ b/starboard/shared/win32/posix_emu/time.cc
@@ -1,0 +1,98 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sys/time.h>
+#include <time.h>
+#include <windows.h>
+
+#include "starboard/common/log.h"
+#include "starboard/types.h"
+
+extern "C" int gettimeofday(struct timeval* tp, void* tzp) {
+  if (tp == NULL) {
+    return -1;
+  }
+
+  SYSTEMTIME system_time;
+  GetSystemTime(&system_time);
+
+  // Represents number of 100-nanosecond intervals since January 1, 1601 (UTC).
+  FILETIME file_time;
+  SystemTimeToFileTime(&system_time, &file_time);
+
+  ULARGE_INTEGER large_int;
+  large_int.LowPart = file_time.dwLowDateTime;
+  large_int.HighPart = file_time.dwHighDateTime;
+  // Divide by 10 to get microseconds from 100-nanosecond intervals.
+  uint64_t windows_time_micros = large_int.QuadPart / 10;
+  // Remove number of microseconds since Jan 1, 1601 (UTC) until Jan 1, 1970.
+  uint64_t posix_time_micros = windows_time_micros - 11644473600000000ULL;
+
+  tp->tv_sec = static_cast<time_t>(posix_time_micros / 1000000);
+  tp->tv_usec = static_cast<suseconds_t>(system_time.wMilliseconds) * 1000;
+  return 0;
+}
+
+extern "C" int clock_gettime(clockid_t clock_id, struct timespec* tp) {
+  // There are only Windows implementations for realtime and monotonic clocks.
+  // Starboard does optionally support CLOCK_PROCESS_CPUTIME_ID for actual
+  // POSIX systems, but for Windows #if SB_HAS(TIME_THREAD_NOW) should be false.
+  // CLOCK_PROCESS_CPUTIME_ID is potentially used by Cobalt though, so -1 will
+  // be returned to indicate a failure instead of crashing with this DCHECK.
+  SB_DCHECK((clock_id == CLOCK_REALTIME) || (clock_id == CLOCK_MONOTONIC) ||
+            (clock_id == CLOCK_PROCESS_CPUTIME_ID));
+
+  if (tp == NULL) {
+    return -1;
+  }
+
+  if (clock_id == CLOCK_REALTIME) {
+    struct timeval tv;
+    if (gettimeofday(&tv, NULL) != 0) {
+      return -1;
+    }
+    tp->tv_sec = tv.tv_sec;
+    tp->tv_nsec = static_cast<long>(tv.tv_usec) * 1000;  // NOLINT(runtime/int)
+    return 0;
+  } else if (clock_id == CLOCK_MONOTONIC) {
+    LARGE_INTEGER counts;
+    bool success;
+
+    success = QueryPerformanceCounter(&counts);
+
+    // "On systems that run Windows XP or later,
+    // the function will always succeed and will thus never return zero."
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms644904(v=vs.85).aspx
+    SB_DCHECK(success);
+
+    LARGE_INTEGER countsPerSecond;
+    success = QueryPerformanceFrequency(&countsPerSecond);
+    // "On systems that run Windows XP or later,
+    // the function will always succeed and will thus never return zero."
+    // https://msdn.microsoft.com/en-us/library/windows/desktop/ms644905(v=vs.85).aspx
+    SB_DCHECK(success);
+
+    // An observed value of countsPerSecond on a desktop x86 machine is
+    // ~2.5e6. With this frequency, it will take ~37500 days to exceed
+    // 2^53, which is the mantissa precision of a double.
+    // Hence, we can safely convert to a double here without losing precision.
+    double result = static_cast<double>(counts.QuadPart);
+    result *= (1000.0 * 1000.0) / countsPerSecond.QuadPart;
+    int64_t microseconds = static_cast<int64_t>(result);
+    tp->tv_sec = microseconds / 1000000;
+    tp->tv_nsec = (microseconds % 1000000) * 1000;
+    return 0;
+  }
+  return -1;
+}

--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -88,12 +88,15 @@ _UNKNOWN_SOURCE_FILES = 'unknown_source_file(s)'
 # Allowed POSIX symbols in Starboard 16
 _ALLOWED_SB16_POSIX_SYMBOLS = [
     'calloc',
+    'clock_gettime',
     'free',
+    'gettimeofday',
     'malloc',
     'posix_memalign',
     'realloc',
     'strcasecmp',
     'strncasecmp',
+    'time',
 ]
 
 

--- a/starboard/tools/api_leak_detector/stub/debug/docker_debian10_manifest
+++ b/starboard/tools/api_leak_detector/stub/debug/docker_debian10_manifest
@@ -58,7 +58,6 @@ abort
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 dgettext
 exit
 fclose

--- a/starboard/tools/api_leak_detector/stub/debug/gn_built_docker_debian10_manifest
+++ b/starboard/tools/api_leak_detector/stub/debug/gn_built_docker_debian10_manifest
@@ -59,7 +59,6 @@ abort
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 dgettext
 exit
 fclose

--- a/starboard/tools/api_leak_detector/stub/debug/manifest
+++ b/starboard/tools/api_leak_detector/stub/debug/manifest
@@ -54,7 +54,6 @@ abort
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 close
 dgettext
 exit

--- a/starboard/tools/api_leak_detector/stub/devel/docker_debian10_manifest
+++ b/starboard/tools/api_leak_detector/stub/devel/docker_debian10_manifest
@@ -58,7 +58,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 dgettext
 exit
 fclose

--- a/starboard/tools/api_leak_detector/stub/devel/gn_built_docker_debian10_manifest
+++ b/starboard/tools/api_leak_detector/stub/devel/gn_built_docker_debian10_manifest
@@ -59,7 +59,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 dgettext
 exit
 fclose

--- a/starboard/tools/api_leak_detector/stub/devel/manifest
+++ b/starboard/tools/api_leak_detector/stub/devel/manifest
@@ -56,7 +56,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 close
 dgettext
 exit

--- a/starboard/tools/api_leak_detector/stub/gold/docker_debian10_manifest
+++ b/starboard/tools/api_leak_detector/stub/gold/docker_debian10_manifest
@@ -57,7 +57,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 dgettext
 exit
 fclose

--- a/starboard/tools/api_leak_detector/stub/gold/gn_built_docker_debian10_manifest
+++ b/starboard/tools/api_leak_detector/stub/gold/gn_built_docker_debian10_manifest
@@ -58,7 +58,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 dgettext
 exit
 fclose

--- a/starboard/tools/api_leak_detector/stub/gold/manifest
+++ b/starboard/tools/api_leak_detector/stub/gold/manifest
@@ -55,7 +55,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 close
 dgettext
 exit

--- a/starboard/tools/api_leak_detector/stub/qa/docker_debian10_manifest
+++ b/starboard/tools/api_leak_detector/stub/qa/docker_debian10_manifest
@@ -57,7 +57,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 dgettext
 exit
 fclose

--- a/starboard/tools/api_leak_detector/stub/qa/gn_built_docker_debian10_manifest
+++ b/starboard/tools/api_leak_detector/stub/qa/gn_built_docker_debian10_manifest
@@ -58,7 +58,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 dgettext
 exit
 fclose

--- a/starboard/tools/api_leak_detector/stub/qa/manifest
+++ b/starboard/tools/api_leak_detector/stub/qa/manifest
@@ -55,7 +55,6 @@ bcmp
 bind_textdomain_codeset
 bindtextdomain
 btowc
-clock_gettime
 close
 dgettext
 exit

--- a/starboard/win/shared/BUILD.gn
+++ b/starboard/win/shared/BUILD.gn
@@ -234,6 +234,7 @@ static_library("starboard_platform") {
     "//starboard/shared/win32/mutex_release.cc",
     "//starboard/shared/win32/once.cc",
     "//starboard/shared/win32/posix_emu/posix_memalign.cc",
+    "//starboard/shared/win32/posix_emu/time.cc",
     "//starboard/shared/win32/set_non_blocking_internal.cc",
     "//starboard/shared/win32/set_non_blocking_internal.h",
     "//starboard/shared/win32/socket_accept.cc",

--- a/starboard/win/shared/platform_configuration/BUILD.gn
+++ b/starboard/win/shared/platform_configuration/BUILD.gn
@@ -42,8 +42,10 @@ config("platform_configuration") {
   ]
 
   cflags = [
-    # Add POSIX emulation headers
+    # Add POSIX emulation headers (note: sys/time.h cannot be force included)
     "/FI ../../starboard/shared/win32/posix_emu/include/stdlib.h",
+    "/FI ../../starboard/shared/win32/posix_emu/include/time.h",
+    "/I../../starboard/shared/win32/posix_emu/include",
   ]
 
   ldflags = [

--- a/third_party/chromium/media/filters/source_buffer_stream.cc
+++ b/third_party/chromium/media/filters/source_buffer_stream.cc
@@ -848,12 +848,12 @@ bool SourceBufferStream::GarbageCollectIfNeeded(base::TimeDelta media_time,
 #if defined(STARBOARD)
   // Address duration based GC.
   base::TimeDelta duration = GetBufferedDurationForGarbageCollection();
-  const SbTime duration_gc_threadold =
+  const int64_t duration_gc_threadold =
       DecoderBuffer::Allocator::GetInstance()
           ->GetBufferGarbageCollectionDurationThreshold();
-  if (duration.ToSbTime() > duration_gc_threadold) {
+  if (duration.InMicroseconds() > duration_gc_threadold) {
     effective_memory_limit = ranges_size * duration_gc_threadold /
-                             duration.ToSbTime();
+                             duration.InMicroseconds();
   }
 #endif  // defined(STARBOARD)
 

--- a/third_party/musl/BUILD.gn
+++ b/third_party/musl/BUILD.gn
@@ -389,6 +389,7 @@ static_library("c_internal") {
     "src/starboard/stdio/vsscanf.c",
     "src/starboard/stdio/vswprintf.c",
     "src/starboard/stdlib/strtod_l.c",
+    "src/starboard/sys/time/gettimeofday.c",
     "src/starboard/time/__tz.c",
     "src/starboard/time/clock_gettime.c",
     "src/stdio/__toread.c",

--- a/third_party/musl/include/sys/time.h
+++ b/third_party/musl/include/sys/time.h
@@ -57,7 +57,9 @@ int adjtime (const struct timeval *, struct timeval *);
 #endif
 
 #if _REDIR_TIME64
+#if !defined(STARBOARD)
 __REDIR(gettimeofday, __gettimeofday_time64);
+#endif  // !defined(STARBOARD)
 __REDIR(getitimer, __getitimer_time64);
 __REDIR(setitimer, __setitimer_time64);
 __REDIR(utimes, __utimes_time64);

--- a/third_party/musl/include/time.h
+++ b/third_party/musl/include/time.h
@@ -147,7 +147,9 @@ __REDIR(localtime_r, __localtime64_r);
 __REDIR(ctime_r, __ctime64_r);
 __REDIR(nanosleep, __nanosleep_time64);
 __REDIR(clock_getres, __clock_getres_time64);
+#if !defined(STARBOARD)
 __REDIR(clock_gettime, __clock_gettime64);
+#endif  // !defined(STARBOARD)
 __REDIR(clock_settime, __clock_settime64);
 __REDIR(clock_nanosleep, __clock_nanosleep_time64);
 __REDIR(timer_settime, __timer_settime64);

--- a/third_party/musl/src/starboard/sys/time/gettimeofday.c
+++ b/third_party/musl/src/starboard/sys/time/gettimeofday.c
@@ -1,0 +1,22 @@
+#if SB_API_VERSION < 16
+
+#include <stdint.h>
+#include <sys/time.h>
+#include <time.h>
+
+#include "starboard/time.h"
+
+int gettimeofday(struct timeval* tp, void* tzp) {
+  if (tp == NULL) {
+    return -1;
+  }
+
+  int64_t windows_time_micros = SbTimeGetNow();
+  // Handle number of microseconds btw Jan 1, 1601 (UTC) and Jan 1, 1970 (UTC).
+  int64_t posix_time_micros = windows_time_micros - 11644473600000000ULL;
+  tp->tv_sec = (time_t)(posix_time_micros / 1000000);
+  tp->tv_usec = (suseconds_t)(posix_time_micros % 1000000);
+  return 0;
+}
+
+#endif  // SB_API_VERSION < 16

--- a/third_party/musl/src/starboard/time/clock_gettime.c
+++ b/third_party/musl/src/starboard/time/clock_gettime.c
@@ -1,4 +1,7 @@
 #include <time.h>
+
+#if SB_API_VERSION < 16
+
 #include "starboard/common/log.h"
 #include "starboard/time.h"
 
@@ -32,3 +35,5 @@ int clock_gettime(clockid_t clk, struct timespec *ts) {
     return -1;
   }
 }
+
+#endif  // SB_API_VERSION < 16

--- a/third_party/musl/src/starboard/time/time.c
+++ b/third_party/musl/src/starboard/time/time.c
@@ -1,6 +1,11 @@
 #include <time.h>
+
+#if SB_API_VERSION < 16
+
 #include "starboard/client_porting/eztime/eztime.h"
 
 time_t time(time_t *t) {
   return EzTimeTGetNow(t);
 }
+
+#endif  // SB_API_VERSION < 16

--- a/third_party/v8/src/base/platform/time.cc
+++ b/third_party/v8/src/base/platform/time.cc
@@ -14,6 +14,9 @@
 #include <mach/mach_time.h>
 #include <pthread.h>
 #endif
+#if V8_OS_STARBOARD
+#include <sys/time.h>
+#endif  // V8_OS_STARBOARD
 
 #include <cstring>
 #include <ostream>
@@ -373,7 +376,7 @@ FILETIME Time::ToFiletime() const {
   return ft;
 }
 
-#elif V8_OS_POSIX
+#elif V8_OS_POSIX || V8_OS_STARBOARD
 
 Time Time::Now() {
   struct timeval tv;
@@ -453,13 +456,7 @@ struct timeval Time::ToTimeval() const {
   return tv;
 }
 
-#elif V8_OS_STARBOARD
-
-Time Time::Now() { return Time(SbTimeToPosix(SbTimeGetNow())); }
-
-Time Time::NowFromSystemTime() { return Now(); }
-
-#endif  // V8_OS_STARBOARD
+#endif  // V8_OS_POSIX || V8_OS_STARBOARD
 
 // static
 TimeTicks TimeTicks::HighResolutionNow() {


### PR DESCRIPTION
- Add emulation of POSIX APIs for Windows platforms
- Provide common helper functions to simplify getting usec timestamps
- Replace usages of SbTimeGetNow and SbTimeGetMonotonicNow in `cobalt`

b/302733082

Test-On-Device: true