### PR TITLE
Add the RTLD_DEEPBIND flag when dlopen-ing FFmpeg libraries.

### DIFF
--- a/starboard/shared/ffmpeg/ffmpeg_dynamic_load_dispatch_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dynamic_load_dispatch_impl.cc
@@ -200,7 +200,8 @@ bool FFMPEGDispatchImpl::OpenLibraries() {
 
     library_file =
         GetVersionedLibraryName(kAVFormatLibraryName, versions.avformat);
-    avformat_ = dlopen(library_file.c_str(), RTLD_NOW | RTLD_GLOBAL | RTLD_DEEPBIND);
+    avformat_ =
+        dlopen(library_file.c_str(), RTLD_NOW | RTLD_GLOBAL | RTLD_DEEPBIND);
     if (!avformat_) {
       SB_DLOG(WARNING) << "Unable to open shared library " << library_file;
       reset_av_libraries();

--- a/starboard/shared/ffmpeg/ffmpeg_dynamic_load_dispatch_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dynamic_load_dispatch_impl.cc
@@ -180,7 +180,8 @@ bool FFMPEGDispatchImpl::OpenLibraries() {
     LibraryMajorVersions& versions = version_iterator->second;
     std::string library_file =
         GetVersionedLibraryName(kAVUtilLibraryName, versions.avutil);
-    avutil_ = dlopen(library_file.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    avutil_ =
+        dlopen(library_file.c_str(), RTLD_NOW | RTLD_GLOBAL | RTLD_DEEPBIND);
     if (!avutil_) {
       SB_DLOG(WARNING) << "Unable to open shared library " << library_file;
       reset_av_libraries();
@@ -189,7 +190,8 @@ bool FFMPEGDispatchImpl::OpenLibraries() {
 
     library_file =
         GetVersionedLibraryName(kAVCodecLibraryName, versions.avcodec);
-    avcodec_ = dlopen(library_file.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    avcodec_ =
+        dlopen(library_file.c_str(), RTLD_NOW | RTLD_GLOBAL | RTLD_DEEPBIND);
     if (!avcodec_) {
       SB_DLOG(WARNING) << "Unable to open shared library " << library_file;
       reset_av_libraries();
@@ -198,7 +200,7 @@ bool FFMPEGDispatchImpl::OpenLibraries() {
 
     library_file =
         GetVersionedLibraryName(kAVFormatLibraryName, versions.avformat);
-    avformat_ = dlopen(library_file.c_str(), RTLD_NOW | RTLD_GLOBAL);
+    avformat_ = dlopen(library_file.c_str(), RTLD_NOW | RTLD_GLOBAL | RTLD_DEEPBIND);
     if (!avformat_) {
       SB_DLOG(WARNING) << "Unable to open shared library " << library_file;
       reset_av_libraries();
@@ -219,21 +221,23 @@ bool FFMPEGDispatchImpl::OpenLibraries() {
   // supported library is not available. Additionally, if this results in a
   // library version being loaded that is not supported, then the decoder
   // instantiation can output a more informative log message.
-  avutil_ = dlopen(kAVUtilLibraryName, RTLD_NOW | RTLD_GLOBAL);
+  avutil_ = dlopen(kAVUtilLibraryName, RTLD_NOW | RTLD_GLOBAL | RTLD_DEEPBIND);
   if (!avutil_) {
     SB_DLOG(WARNING) << "Unable to open shared library " << kAVUtilLibraryName;
     reset_av_libraries();
     return false;
   }
 
-  avcodec_ = dlopen(kAVCodecLibraryName, RTLD_NOW | RTLD_GLOBAL);
+  avcodec_ =
+      dlopen(kAVCodecLibraryName, RTLD_NOW | RTLD_GLOBAL | RTLD_DEEPBIND);
   if (!avcodec_) {
     SB_DLOG(WARNING) << "Unable to open shared library " << kAVCodecLibraryName;
     reset_av_libraries();
     return false;
   }
 
-  avformat_ = dlopen(kAVFormatLibraryName, RTLD_NOW | RTLD_GLOBAL);
+  avformat_ =
+      dlopen(kAVFormatLibraryName, RTLD_NOW | RTLD_GLOBAL | RTLD_DEEPBIND);
   if (!avformat_) {
     SB_DLOG(WARNING) << "Unable to open shared library "
                      << kAVFormatLibraryName;


### PR DESCRIPTION
Without this, the cast runtime when built out of chromium will segfault in starboard's FFmpeg decoder. The issue is that chromium builds a newer version of FFmpeg, and (without RTLD_DEEPBIND) some of the symbols in FFmpeg get resolved as the chromium versions. This likely causes a segfault due to struct size changes (in my case, the segfault was in av_buffer_unref). See the bug for more details, including a full stack trace.

Bug: b/313524200