### PR TITLE
Revert "Cherry pick PR #1909: Use -std=gnu++17 in mac GN configuration"

### DIFF
--- a/starboard/build/config/mac/BUILD.gn
+++ b/starboard/build/config/mac/BUILD.gn
@@ -43,8 +43,8 @@ config("host") {
 
 config("common") {
   arflags = [ "-no_warning_for_no_symbols" ]
-  cflags_cc = [ "-std=gnu++17" ]
-  cflags_objcc = [ "-std=gnu++17" ]
+  cflags_cc = [ "-std=gnu++14" ]
+  cflags_objcc = [ "-std=gnu++14" ]
   cflags = [ "-fno-common" ]
   asmflags = [ "-fno-common" ]
   ldflags = [ "-fno-common" ]


### PR DESCRIPTION
Reverts youtube/cobalt#2033

This is causing a build breakage since a use of `auto_ptr` has been removed in C++17

b/288332442