### PR TITLE
Deprecate SbTime APIs (partial)

### DIFF
--- a/base/time/time.cc
+++ b/base/time/time.cc
@@ -320,9 +320,7 @@ std::ostream& operator<<(std::ostream& os, TimeTicks time_ticks) {
 
 // static
 ThreadTicks ThreadTicks::Now() {
-  if (SbTimeIsTimeThreadNowSupported())
-    return internal::g_thread_ticks_now_function();
-  return ThreadTicks();
+  return internal::g_thread_ticks_now_function();
 }
 
 std::ostream& operator<<(std::ostream& os, ThreadTicks thread_ticks) {

--- a/base/time/time.h
+++ b/base/time/time.h
@@ -64,7 +64,7 @@
 #include "build/build_config.h"
 
 #if defined(STARBOARD)
-#include "starboard/time.h"
+#include "starboard/common/time.h"
 #endif
 
 #if defined(OS_FUCHSIA)
@@ -1029,7 +1029,7 @@ class BASE_EXPORT ThreadTicks : public time_internal::TimeBase<ThreadTicks> {
   // Returns true if ThreadTicks::Now() is supported on this system.
   static bool IsSupported() WARN_UNUSED_RESULT {
 #if defined(STARBOARD)
-    return SbTimeIsTimeThreadNowSupported();
+    return starboard::CurrentMonotonicThreadTime() != 0;
 #else
 #if (defined(_POSIX_THREAD_CPUTIME) && (_POSIX_THREAD_CPUTIME >= 0)) || \
     (defined(OS_MACOSX) && !defined(OS_IOS)) || defined(OS_ANDROID) ||  \

--- a/base/time/time_now_starboard.cc
+++ b/base/time/time_now_starboard.cc
@@ -65,10 +65,8 @@ bool TimeTicks::IsConsistentAcrossProcesses() {
 
 namespace subtle {
 ThreadTicks ThreadTicksNowIgnoringOverride() {
-  if (SbTimeIsTimeThreadNowSupported())
-    return ThreadTicks() +
-           TimeDelta::FromMicroseconds(SbTimeGetMonotonicThreadNow());
-  return ThreadTicks();
+  return ThreadTicks() + TimeDelta::FromMicroseconds(
+      starboard::CurrentMonotonicThreadTime());
 }
 }  // namespace subtle
 

--- a/base/time/time_unittest.cc
+++ b/base/time/time_unittest.cc
@@ -11,22 +11,21 @@
 #include <limits>
 #include <string>
 
-#include "starboard/types.h"
-
 #include "base/build_time.h"
 #include "base/compiler_specific.h"
 #include "base/logging.h"
 #include "base/macros.h"
 #include "base/strings/stringprintf.h"
-#if defined(STARBOARD)
-#include "base/test/time_helpers.h"
-#endif  // defined(STARBOARD)
 #include "base/threading/platform_thread.h"
 #include "base/time/time_override.h"
 #include "build/build_config.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if defined(OS_ANDROID)
+#if defined(STARBOARD)
+#include "starboard/common/time.h"
+#include "starboard/types.h"
+#include "base/test/time_helpers.h"
+#elif defined(OS_ANDROID)
 #include "base/android/jni_android.h"
 #elif defined(OS_IOS)
 #include "base/ios/ios_util.h"
@@ -1006,7 +1005,7 @@ ThreadTicks ThreadTicksOverride::now_ticks_;
 #define MAYBE_NowOverride NowOverride
 #endif
 TEST(ThreadTicks, MAYBE_NowOverride) {
-  if (!SbTimeIsTimeThreadNowSupported()) {
+  if (starboard::CurrentMonotonicThreadTime() == 0) {
     SB_LOG(INFO) << "Time thread now not supported. Test skipped.";
     return;
   }

--- a/cobalt/dom/source_buffer_metrics.cc
+++ b/cobalt/dom/source_buffer_metrics.cc
@@ -71,8 +71,7 @@ void SourceBufferMetrics::StartTracking() {
   DCHECK(!is_tracking_);
   is_tracking_ = true;
   wall_start_time_ = starboard::CurrentMonotonicTime();
-  thread_start_time_ =
-      SbTimeIsTimeThreadNowSupported() ? SbTimeGetMonotonicThreadNow() : -1;
+  thread_start_time_ = starboard::CurrentMonotonicThreadTime();
 }
 
 void SourceBufferMetrics::EndTracking(std::size_t size_appended) {
@@ -85,9 +84,7 @@ void SourceBufferMetrics::EndTracking(std::size_t size_appended) {
 
   int64_t wall_duration = starboard::CurrentMonotonicTime() - wall_start_time_;
   int64_t thread_duration =
-      SbTimeIsTimeThreadNowSupported()
-          ? SbTimeGetMonotonicThreadNow() - thread_start_time_
-          : 0;
+      starboard::CurrentMonotonicThreadTime() - thread_start_time_;
   total_wall_time_ += wall_duration;
   total_thread_time_ += thread_duration;
 
@@ -95,9 +92,7 @@ void SourceBufferMetrics::EndTracking(std::size_t size_appended) {
 
   if (size_appended > 0) {
     int wall_bandwidth = GetBandwidth(size_appended, wall_duration);
-    int thread_bandwidth = SbTimeIsTimeThreadNowSupported()
-                               ? GetBandwidth(size_appended, thread_duration)
-                               : 0;
+    int thread_bandwidth = GetBandwidth(size_appended, thread_duration);
 
     max_wall_bandwidth_ = std::max(max_wall_bandwidth_, wall_bandwidth);
     min_wall_bandwidth_ = std::min(min_wall_bandwidth_, wall_bandwidth);

--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -9,6 +9,12 @@ since the version previous to it.
 
 ## Version 16
 
+### Decrecated SbTime APIs and migrated to POSIX time APIs
+The time APIs `SbTimeGetNow`, `SbTimeGetMonotonicNow`,
+`SbTimeIsTimeThreadNowSupported` and `SbTimeGetMonotonicThreadNow` are
+deprecated and the standard APIs `gettimeofday` from `<sys/time.h>` and
+`clock_gettime` from `<time.h>` should be used instead.
+
 ### Deprecated SbStringFormat APIs and migrated to POSIX memory APIs
 The StringFormat management APIs `SbStringFormat`, `SbStringFormatF`,
 `SbStringFormatWide`, `SbStringFormatUnsifeF` are deprecated and the

--- a/starboard/common/experimental/concurrency_debug.cc
+++ b/starboard/common/experimental/concurrency_debug.cc
@@ -36,8 +36,8 @@ const int kMaxSymbolNameLength = 1024;
 // few contentions at app startup set by the following constant.
 const int kNumberOfInitialContentionsToIgnore = 50;
 
-const SbTime kMinimumWaitToLog = 5 * kSbTimeMillisecond;
-const SbTime kLoggingInterval = 5 * kSbTimeSecond;
+const int64_t kMinimumWaitToLog = 5000;          // 5ms
+const int64_t kLoggingInterval = 5 * 1'000'000;  // 5s
 const int kStackTraceDepth = 0;
 
 volatile SbAtomic32 s_mutex_acquire_call_counter = 0;
@@ -50,7 +50,7 @@ ScopedMutexWaitTracker::ScopedMutexWaitTracker(SbMutex* mutex)
     : acquired_(SbMutexAcquireTry(mutex) == kSbMutexAcquired) {
   SbAtomicNoBarrier_Increment(&s_mutex_acquire_call_counter, 1);
   if (!acquired_) {
-    wait_start_ = SbTimeGetMonotonicNow();
+    wait_start_ = starboard::CurrentMonotonicTime();
   }
 }
 
@@ -63,7 +63,7 @@ ScopedMutexWaitTracker::~ScopedMutexWaitTracker() {
     return;
   }
 
-  auto elapsed = SbTimeGetMonotonicNow() - wait_start_;
+  auto elapsed = starboard::CurrentMonotonicTime() - wait_start_;
 
   for (;;) {
     SbAtomic32 old_value = s_mutex_max_contention_time;

--- a/starboard/common/experimental/concurrency_debug.h
+++ b/starboard/common/experimental/concurrency_debug.h
@@ -20,10 +20,10 @@
 #if SB_ENABLE_CONCURRENCY_DEBUG
 
 #include "starboard/common/log.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/mutex.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 
 // WARNING: Features inside experimental namespace is strictly experimental and
 // can be changed or removed at any time, even within the same Cobalt/Starboard
@@ -47,7 +47,7 @@ class ScopedMutexWaitTracker {
 
  private:
   const bool acquired_;
-  SbTime wait_start_;
+  int64_t wait_start_;
 };
 
 // The class can be used to track how much CPU the thread consumes periodically.
@@ -57,8 +57,8 @@ class ScopedMutexWaitTracker {
 // thread at interval specified by |interval|.
 class ThreadTracker {
  public:
-  void CheckPoint(SbTime interval) {
-    SbTime wallclock_now = SbTimeGetMonotonicNow();
+  void CheckPoint(int64_t interval) {
+    int64_t wallclock_now = starboard::CurrentMonotonicTime();
 
     if (wallclock_now - last_wallclock_time_ < interval) {
       return;
@@ -67,7 +67,7 @@ class ThreadTracker {
     char name[kSbMaxThreadNameLength + 1];
     SbThreadGetName(name, kSbMaxThreadNameLength);
 
-    SbTime thread_now = SbTimeGetMonotonicThreadNow();
+    int64_t thread_now = starboard::CurrentMonotonicThreadTime();
     SB_LOG(INFO) << "Thread " << name << " uses "
                  << thread_now - last_thread_time_ << " during "
                  << wallclock_now - last_wallclock_time_;
@@ -76,8 +76,8 @@ class ThreadTracker {
   }
 
  private:
-  SbTime last_wallclock_time_ = SbTimeGetMonotonicNow();
-  SbTime last_thread_time_ = SbTimeGetMonotonicThreadNow();
+  int64_t last_wallclock_time_ = starboard::CurrentMonotonicTime();
+  int64_t last_thread_time_ = starboard::CurrentMonotonicThreadTime();
 };
 
 }  // namespace experimental

--- a/starboard/common/time.cc
+++ b/starboard/common/time.cc
@@ -43,6 +43,20 @@ int64_t CurrentMonotonicTime() {
 #endif  // SB_API_VERSION >= 16
 }
 
+int64_t CurrentMonotonicThreadTime() {
+#if SB_API_VERSION >= 16
+  struct timespec ts;
+  if (clock_gettime(CLOCK_THREAD_CPUTIME_ID, &ts) != 0) {
+    // This is expected to happen on some systems, like Windows.
+    return 0;
+  }
+  return (static_cast<int64_t>(ts.tv_sec) * 1000000) +
+         (static_cast<int64_t>(ts.tv_nsec) / 1000);
+#else   // SB_API_VERSION >= 16
+  return SbTimeGetMonotonicThreadNow();
+#endif  // SB_API_VERSION >= 16
+}
+
 int64_t CurrentPosixTime() {
 #if SB_API_VERSION >= 16
   struct timeval tv;

--- a/starboard/common/time.h
+++ b/starboard/common/time.h
@@ -23,6 +23,10 @@ namespace starboard {
 // A convenience helper to get the current Monotonic time in microseconds.
 int64_t CurrentMonotonicTime();
 
+// A convenience helper to get the current thread-specific Monotonic time in
+// microseconds. Returns 0 if the system doesn't support thread-specific clock.
+int64_t CurrentMonotonicThreadTime();
+
 // A convenience helper to get the current POSIX system time in microseconds.
 int64_t CurrentPosixTime();
 

--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -374,9 +374,13 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(SbThreadSleep);
   REGISTER_SYMBOL(SbThreadYield);
   REGISTER_SYMBOL(SbTimeGetMonotonicNow);
+#if SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeGetMonotonicThreadNow);
+#endif  // SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeGetNow);
+#if SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeIsTimeThreadNowSupported);
+#endif  // SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeZoneGetCurrent);
   REGISTER_SYMBOL(SbTimeZoneGetName);
   REGISTER_SYMBOL(SbUiNavGetInterface);

--- a/starboard/shared/posix/time_get_monotonic_thread_now.cc
+++ b/starboard/shared/posix/time_get_monotonic_thread_now.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 #include <time.h>
@@ -28,3 +30,5 @@ SbTimeMonotonic SbTimeGetMonotonicThreadNow() {
 
   return FromTimespecDelta(&time);
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/posix/time_is_time_thread_now_supported.cc
+++ b/starboard/shared/posix/time_is_time_thread_now_supported.cc
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 bool SbTimeIsTimeThreadNowSupported() {
   return true;
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/stub/time_get_monotonic_thread_now.cc
+++ b/starboard/shared/stub/time_get_monotonic_thread_now.cc
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 SbTimeMonotonic SbTimeGetMonotonicThreadNow() {
   return SbTimeMonotonic(0);
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/stub/time_is_time_thread_now_supported.cc
+++ b/starboard/shared/stub/time_is_time_thread_now_supported.cc
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 bool SbTimeIsTimeThreadNowSupported() {
   return false;
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/win32/posix_emu/include/posix_force_include.h
+++ b/starboard/shared/win32/posix_emu/include/posix_force_include.h
@@ -31,6 +31,7 @@ typedef int clockid_t;
 #define CLOCK_REALTIME 0
 #define CLOCK_MONOTONIC 1
 #define CLOCK_PROCESS_CPUTIME_ID 2
+#define CLOCK_THREAD_CPUTIME_ID 3
 
 #ifdef __cplusplus
 extern "C" {

--- a/starboard/shared/win32/posix_emu/time.cc
+++ b/starboard/shared/win32/posix_emu/time.cc
@@ -46,12 +46,13 @@ extern "C" int gettimeofday(struct timeval* tp, void* tzp) {
 
 extern "C" int clock_gettime(clockid_t clock_id, struct timespec* tp) {
   // There are only Windows implementations for realtime and monotonic clocks.
-  // Starboard does optionally support CLOCK_PROCESS_CPUTIME_ID for actual
-  // POSIX systems, but for Windows #if SB_HAS(TIME_THREAD_NOW) should be false.
-  // CLOCK_PROCESS_CPUTIME_ID is potentially used by Cobalt though, so -1 will
-  // be returned to indicate a failure instead of crashing with this DCHECK.
+  // If CLOCK_PROCESS_CPUTIME_ID or CLOCK_THREAD_CPUTIME_ID are passed in,
+  // this will return -1. Code that tries to use one of those should either
+  // be able to detect and handle the -1 return value or be guarded with
+  // #if SB_HAS(TIME_THREAD_NOW).
   SB_DCHECK((clock_id == CLOCK_REALTIME) || (clock_id == CLOCK_MONOTONIC) ||
-            (clock_id == CLOCK_PROCESS_CPUTIME_ID));
+            (clock_id == CLOCK_PROCESS_CPUTIME_ID) ||
+            (clock_id == CLOCK_THREAD_CPUTIME_ID));
 
   if (tp == NULL) {
     return -1;

--- a/starboard/time.h
+++ b/starboard/time.h
@@ -91,6 +91,8 @@ SB_EXPORT SbTime SbTimeGetNow();
 // Gets a monotonically increasing time representing right now.
 SB_EXPORT SbTimeMonotonic SbTimeGetMonotonicNow();
 
+#if SB_API_VERSION < 16
+
 // Returns whether the current platform supports time thread now
 SB_EXPORT bool SbTimeIsTimeThreadNowSupported();
 
@@ -100,6 +102,8 @@ SB_EXPORT bool SbTimeIsTimeThreadNowSupported();
 // measuring thread execution time between two timestamps. If this is not
 // available then SbTimeGetMonotonicNow() should be used.
 SB_EXPORT SbTimeMonotonic SbTimeGetMonotonicThreadNow();
+
+#endif  // SB_API_VERSION < 16
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/third_party/v8/src/base/platform/platform-starboard.cc
+++ b/third_party/v8/src/base/platform/platform-starboard.cc
@@ -85,9 +85,8 @@ void OS::Initialize(bool hard_abort, const char* const gc_fake_mmap) {
 }
 
 int OS::GetUserTime(uint32_t* secs, uint32_t* usecs) {
-  if (!SbTimeIsTimeThreadNowSupported()) return -1;
-
-  int64_t thread_now = SbTimeGetMonotonicThreadNow();
+  int64_t thread_now = starboard::CurrentMonotonicThreadTime();
+  if (thread_now == 0) return -1;
   *secs = thread_now / 1'000'000;
   *usecs = thread_now % 1'000'000;
   return 0;

--- a/third_party/v8/src/base/platform/time.cc
+++ b/third_party/v8/src/base/platform/time.cc
@@ -751,7 +751,7 @@ bool TimeTicks::IsHighResolution() {
 
 bool ThreadTicks::IsSupported() {
 #if V8_OS_STARBOARD
-  return SbTimeIsTimeThreadNowSupported();
+  return starboard::CurrentMonotonicThreadTime() != 0;
 #elif(defined(_POSIX_THREAD_CPUTIME) && (_POSIX_THREAD_CPUTIME >= 0)) || \
     defined(V8_OS_MACOSX) || defined(V8_OS_ANDROID) || defined(V8_OS_SOLARIS)
   return true;
@@ -765,8 +765,9 @@ bool ThreadTicks::IsSupported() {
 
 ThreadTicks ThreadTicks::Now() {
 #if V8_OS_STARBOARD
-  if (SbTimeIsTimeThreadNowSupported())
-    return ThreadTicks(SbTimeGetMonotonicThreadNow());
+  int64_t now = starboard::CurrentMonotonicThreadTime();
+  if (now != 0)
+    return ThreadTicks(now);
   UNREACHABLE();
 #elif V8_OS_MACOSX
   return ThreadTicks(ComputeThreadTicks());


### PR DESCRIPTION
- Fully deprecate `SbTimeIsTimeThreadNowSupported` and `SbTimeGetMonotonicThreadNow`

b/302733082

Test-On-Device: true