### PR TITLE
Create POSIX emulation for htonl, htons, ntohl, ntohs

### DIFF
--- a/cobalt/network/dial/dial_udp_server.cc
+++ b/cobalt/network/dial/dial_udp_server.cc
@@ -14,11 +14,8 @@
 
 #include "cobalt/network/dial/dial_udp_server.h"
 
-#if defined(STARBOARD)
-#include "starboard/client_porting/poem/inet_poem.h"
-#else
 #include <arpa/inet.h>
-#endif
+
 #include <memory>
 #include <utility>
 #include <vector>

--- a/net/dns/address_sorter_posix.cc
+++ b/net/dns/address_sorter_posix.cc
@@ -4,11 +4,7 @@
 
 #include "net/dns/address_sorter_posix.h"
 
-#if defined(STARBOARD)
-#include "starboard/client_porting/poem/inet_poem.h"
-#else
 #include <netinet/in.h>
-#endif
 
 #include <memory>
 #include <utility>

--- a/net/third_party/quiche/src/http2/tools/http2_frame_builder.cc
+++ b/net/third_party/quiche/src/http2/tools/http2_frame_builder.cc
@@ -4,16 +4,12 @@
 
 #include "net/third_party/quiche/src/http2/tools/http2_frame_builder.h"
 
-#ifdef STARBOARD
-#include "starboard/client_porting/poem/inet_poem.h"
-#else
 #ifdef WIN32
 #include <winsock2.h>  // for htonl() functions
 #else
 #include <arpa/inet.h>
 #include <netinet/in.h>  // for htonl, htons
 #endif
-#endif  // STARBOARD
 
 #include "testing/gtest/include/gtest/gtest.h"
 #include "net/third_party/quiche/src/http2/platform/api/http2_string_utils.h"

--- a/starboard/client_porting/poem/inet_poem.h
+++ b/starboard/client_porting/poem/inet_poem.h
@@ -18,6 +18,9 @@
 #define STARBOARD_CLIENT_PORTING_POEM_INET_POEM_H_
 
 #if defined(STARBOARD)
+
+#if SB_API_VERSION < 16
+
 #include "starboard/common/byte_swap.h"
 
 #undef htonl
@@ -32,6 +35,12 @@
 #undef ntohs
 #define ntohs(x) SB_NET_TO_HOST_U16(x)
 
-#endif  // STARBOARD
+#else  // SB_API_VERSION < 16
+
+#include <arpa/inet.h>
+
+#endif  // SB_API_VERSION < 16
+
+#endif  // defined(STARBOARD)
 
 #endif  // STARBOARD_CLIENT_PORTING_POEM_INET_POEM_H_

--- a/starboard/shared/win32/posix_emu/include/arpa/inet.h
+++ b/starboard/shared/win32/posix_emu/include/arpa/inet.h
@@ -1,0 +1,58 @@
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_ARPA_INET_H_
+#define STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_ARPA_INET_H_
+
+#if defined(STARBOARD) && defined(_MSC_VER)
+
+#include <stdlib.h>
+
+#include "starboard/configuration.h"
+
+inline uint32_t htonl(uint32_t in) {
+#if SB_IS(BIG_ENDIAN)
+  return in;
+#else
+  return _byteswap_ulong(in);
+#endif
+}
+
+inline uint16_t htons(uint16_t in) {
+#if SB_IS(BIG_ENDIAN)
+  return in;
+#else
+  return _byteswap_ushort(in);
+#endif
+}
+
+inline uint32_t ntohl(uint32_t in) {
+#if SB_IS(BIG_ENDIAN)
+  return in;
+#else
+  return _byteswap_ulong(in);
+#endif
+}
+
+inline uint16_t ntohs(uint16_t in) {
+#if SB_IS(BIG_ENDIAN)
+  return in;
+#else
+  return _byteswap_ushort(in);
+#endif
+}
+
+#endif  // defined(STARBOARD) && defined(_MSC_VER)
+
+#endif  // STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_ARPA_INET_H_

--- a/starboard/shared/win32/posix_emu/include/netinet/in.h
+++ b/starboard/shared/win32/posix_emu/include/netinet/in.h
@@ -1,0 +1,20 @@
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_NETINET_IN_H_
+#define STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_NETINET_IN_H_
+
+#include <arpa/inet.h>
+
+#endif  // STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_NETINET_IN_H_

--- a/third_party/musl/BUILD.gn
+++ b/third_party/musl/BUILD.gn
@@ -365,6 +365,10 @@ static_library("c_internal") {
     "src/multibyte/wcsrtombs.c",
     "src/multibyte/wcstombs.c",
     "src/multibyte/wctob.c",
+    "src/network/htonl.c",
+    "src/network/htons.c",
+    "src/network/ntohl.c",
+    "src/network/ntohs.c",
     "src/prng/rand.c",
 
     # Starboardized implementations


### PR DESCRIPTION
- Adds <arpa/inet.h> and <netinet/in.h> headers for win32
- Removes usages of inet_poem

b/317437129

Test-On-Device: true