### PR TITLE
Deprecate SbTime APIs (partial)

### DIFF
--- a/third_party/musl/include/time.h
+++ b/third_party/musl/include/time.h
@@ -132,7 +132,9 @@ time_t timegm(struct tm *);
 #endif
 
 #if _REDIR_TIME64
+#if !defined(STARBOARD)
 __REDIR(time, __time64);
+#endif  // !defined(STARBOARD)
 __REDIR(difftime, __difftime64);
 __REDIR(mktime, __mktime64);
 __REDIR(gmtime, __gmtime64);


### PR DESCRIPTION
- Avoid musl redirection to __time64

b/302733082

Test-On-Device: true