### PR TITLE
Undefined `NO_ERROR` macro to avoid name conflict

### DIFF
--- a/starboard/shared/win32/posix_emu/include/sys/time.h
+++ b/starboard/shared/win32/posix_emu/include/sys/time.h
@@ -18,6 +18,7 @@
 #if defined(STARBOARD)
 
 #include <winsock2.h>  // For struct timeval
+#undef NO_ERROR        // http://b/302733082#comment15
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
b/302733082

Test-On-Device: true