### PR TITLE
Revert checkout action to upstream

### DIFF
--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -61,7 +61,7 @@ jobs:
       CHERRY_PICK_BRANCH: cherry-pick-${{ matrix.target_branch }}-${{ github.event.pull_request.number }}
     steps:
       - name: Checkout repository
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         timeout-minutes: 30
         with:
           ref: ${{ matrix.target_branch }}

--- a/.github/workflows/nightly_trigger.yaml
+++ b/.github/workflows/nightly_trigger.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: 23.lts.1+
@@ -33,7 +33,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: 22.lts.1+
@@ -53,7 +53,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: 21.lts.1+
@@ -72,7 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: 20.lts.1+
@@ -90,7 +90,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: 19.lts.1+
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: rc_11
@@ -126,7 +126,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: COBALT_9

--- a/.github/workflows/nightly_trigger_24.lts.1+.yaml
+++ b/.github/workflows/nightly_trigger_24.lts.1+.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: 24.lts.1+

--- a/.github/workflows/nightly_trigger_25.lts.1+.yaml
+++ b/.github/workflows/nightly_trigger_25.lts.1+.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: 25.lts.1+

--- a/.github/workflows/nightly_trigger_26.android.yaml
+++ b/.github/workflows/nightly_trigger_26.android.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: 26.android

--- a/.github/workflows/nightly_trigger_main.yaml
+++ b/.github/workflows/nightly_trigger_main.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: kaidokert/checkout@v3.5.999
+        uses: actions/checkout@v4
         with:
           fetch-depth: 1
           ref: main


### PR DESCRIPTION
Upstream still hasn't patched the issue, but our builds seem to not trip on submodules at the moment.

b/282361986