### PR TITLE
Deprecate SbTime APIs

### DIFF
--- a/base/time/time_now_starboard.cc
+++ b/base/time/time_now_starboard.cc
@@ -22,7 +22,6 @@
 #include "starboard/client_porting/poem/eztime_poem.h"
 #include "starboard/common/log.h"
 #include "starboard/common/time.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 namespace base {

--- a/base/time/time_starboard.cc
+++ b/base/time/time_starboard.cc
@@ -16,7 +16,6 @@
 
 #include "base/logging.h"
 #include "starboard/client_porting/eztime/eztime.h"
-#include "starboard/time.h"
 
 namespace base {
 

--- a/components/update_client/unzip/unzip_impl_cobalt.cc
+++ b/components/update_client/unzip/unzip_impl_cobalt.cc
@@ -9,7 +9,6 @@
 
 #include "base/callback.h"
 #include "base/files/file_path.h"
-#include "starboard/time.h"
 #include "third_party/zlib/google/zip.h"
 
 namespace update_client {

--- a/starboard/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -151,7 +151,7 @@ public class StarboardBridge {
 
   private native boolean nativeInitialize();
 
-  private native long nativeSbTimeGetMonotonicNow();
+  private native long nativeCurrentMonotonicTime();
 
   protected void onActivityStart(Activity activity, KeyboardEditor keyboardEditor) {
     activityHolder.set(activity);
@@ -800,7 +800,7 @@ public class StarboardBridge {
     Activity activity = activityHolder.get();
     if (activity instanceof CobaltActivity) {
       long javaStartTimestamp = ((CobaltActivity) activity).getAppStartTimestamp();
-      long cppTimestamp = nativeSbTimeGetMonotonicNow();
+      long cppTimestamp = nativeCurrentMonotonicTime();
       long javaStopTimestamp = System.nanoTime();
       return cppTimestamp
           - (javaStartTimestamp - javaStopTimestamp) / timeNanosecondsPerMicrosecond;

--- a/starboard/android/shared/android_media_session_client.cc
+++ b/starboard/android/shared/android_media_session_client.cc
@@ -225,15 +225,15 @@ void OnMediaSessionStateChanged(
   }
 
   jlong durationInMilliseconds;
-  if (session_state.duration == kSbTimeMax) {
+  if (session_state.duration == kSbInt64Max) {
     // Set duration to negative if duration is unknown or infinite, as with live
     // playback.
     // https://developer.android.com/reference/android/support/v4/media/MediaMetadataCompat#METADATA_KEY_DURATION
     durationInMilliseconds = -1;
   } else {
-    // SbTime is measured in microseconds while Android MediaSession expects
-    // duration in milliseconds.
-    durationInMilliseconds = session_state.duration / kSbTimeMillisecond;
+    // Starboard time is measured in microseconds while Android MediaSession
+    // expects duration in milliseconds.
+    durationInMilliseconds = session_state.duration / 1000;
   }
 
   env->CallStarboardVoidMethodOrAbort(
@@ -241,7 +241,7 @@ void OnMediaSessionStateChanged(
       "(IJJFLjava/lang/String;Ljava/lang/String;Ljava/lang/String;"
       "[Ldev/cobalt/media/MediaImage;J)V",
       playback_state, playback_state_actions,
-      session_state.current_playback_position / kSbTimeMillisecond,
+      session_state.current_playback_position / 1000,
       static_cast<jfloat>(session_state.actual_playback_rate), j_title.Get(),
       j_artist.Get(), j_album.Get(), j_artwork.Get(), durationInMilliseconds);
 }

--- a/starboard/android/shared/application_android.h
+++ b/starboard/android/shared/application_android.h
@@ -103,7 +103,7 @@ class ApplicationAndroid
   void SbWindowSendInputEvent(const char* input_text, bool is_composing);
   void SendLowMemoryEvent();
   void OsNetworkStatusChange(bool became_online);
-  SbTimeMonotonic GetAppStartTimestamp();
+  int64_t GetAppStartTimestamp();  // microseconds
 
   void SendDateTimeConfigurationChangedEvent();
 
@@ -129,7 +129,7 @@ class ApplicationAndroid
 
   // --- QueueApplication overrides ---
   bool MayHaveSystemEvents() override { return handle_system_events_; }
-  Event* WaitForSystemEventWithTimeout(SbTime time) override;
+  Event* WaitForSystemEventWithTimeout(int64_t time) override;
   void WakeSystemEventWait() override;
 
  private:

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -36,7 +36,6 @@
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "starboard/shared/starboard/player/job_thread.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace android {
@@ -76,11 +75,11 @@ class AudioRendererPassthrough
   void Play() override;
   void Pause() override;
   void SetPlaybackRate(double playback_rate) override;
-  void Seek(SbTime seek_to_time) override;
-  SbTime GetCurrentMediaTime(bool* is_playing,
-                             bool* is_eos_played,
-                             bool* is_underflow,
-                             double* playback_rate) override;
+  void Seek(int64_t seek_to_time) override;
+  int64_t GetCurrentMediaTime(bool* is_playing,
+                              bool* is_eos_played,
+                              bool* is_underflow,
+                              double* playback_rate) override;
 
  private:
   typedef ::starboard::shared::starboard::player::DecodedAudio DecodedAudio;
@@ -96,7 +95,7 @@ class AudioRendererPassthrough
   };
 
   void CreateAudioTrackAndStartProcessing();
-  void FlushAudioTrackAndStopProcessing(SbTime seek_to_time);
+  void FlushAudioTrackAndStopProcessing(int64_t seek_to_time);
   void UpdateStatusAndWriteData(const AudioTrackState previous_state);
   void OnDecoderConsumed();
   void OnDecoderOutput();
@@ -126,9 +125,9 @@ class AudioRendererPassthrough
   bool stop_called_ = false;
   int64_t total_frames_written_ = 0;
   int64_t playback_head_position_when_stopped_ = 0;
-  SbTimeMonotonic stopped_at_ = 0;
-  SbTime seek_to_time_ = 0;
-  SbTime first_audio_timestamp_ = -1;
+  int64_t stopped_at_ = 0;              // microseconds
+  int64_t seek_to_time_ = 0;            // microseconds
+  int64_t first_audio_timestamp_ = -1;  // microseconds
   double volume_ = 1.0;
   bool paused_ = true;
   double playback_rate_ = 1.0;

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -129,7 +129,7 @@ void MinRequiredFramesTester::TesterThreadFunc() {
         &MinRequiredFramesTester::ErrorFunc, 0, -1, false, this);
     {
       ScopedLock scoped_lock(mutex_);
-      wait_timeout = !condition_variable_.WaitTimed(kSbTimeSecond * 5);
+      wait_timeout = !condition_variable_.WaitTimed(5'000'000);
     }
 
     // Get start threshold before release the audio sink.
@@ -191,7 +191,7 @@ void MinRequiredFramesTester::UpdateSourceStatusFunc(int* frames_in_buffer,
 
 // static
 void MinRequiredFramesTester::ConsumeFramesFunc(int frames_consumed,
-                                                SbTime frames_consumed_at,
+                                                int64_t frames_consumed_at,
                                                 void* context) {
   MinRequiredFramesTester* tester =
       static_cast<MinRequiredFramesTester*>(context);

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.h
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.h
@@ -84,7 +84,7 @@ class MinRequiredFramesTester {
                                      bool* is_eos_reached,
                                      void* context);
   static void ConsumeFramesFunc(int frames_consumed,
-                                SbTime frames_consumed_at,
+                                int64_t frames_consumed_at,
                                 void* context);
   static void ErrorFunc(bool capability_changed,
                         const std::string& error_message,

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -67,7 +67,7 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
       SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
       SbAudioSinkPrivate::ConsumeFramesFunc consume_frames_func,
       SbAudioSinkPrivate::ErrorFunc error_func,
-      SbTime start_time,
+      int64_t start_time,
       int tunnel_mode_audio_session_id,
       bool is_web_audio,
       void* context);
@@ -111,7 +111,7 @@ class AudioTrackAudioSink : public SbAudioSinkPrivate {
       SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
       ConsumeFramesFunc consume_frames_func,
       SbAudioSinkPrivate::ErrorFunc error_func,
-      SbTime start_media_time,
+      int64_t start_media_time,
       int tunnel_mode_audio_session_id,
       bool is_web_audio,
       void* context);
@@ -129,7 +129,10 @@ class AudioTrackAudioSink : public SbAudioSinkPrivate {
   static void* ThreadEntryPoint(void* context);
   void AudioThreadFunc();
 
-  int WriteData(JniEnvExt* env, const void* buffer, int size, SbTime sync_time);
+  int WriteData(JniEnvExt* env,
+                const void* buffer,
+                int size,
+                int64_t sync_time);
 
   void ReportError(bool capability_changed, const std::string& error_message);
 
@@ -142,7 +145,7 @@ class AudioTrackAudioSink : public SbAudioSinkPrivate {
   const SbAudioSinkUpdateSourceStatusFunc update_source_status_func_;
   const ConsumeFramesFunc consume_frames_func_;
   const SbAudioSinkPrivate::ErrorFunc error_func_;
-  const SbTime start_time_;
+  const int64_t start_time_;  // microseconds
   const int tunnel_mode_audio_session_id_;
   const int max_frames_per_request_;
   void* const context_;

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -191,7 +191,7 @@ int AudioTrackBridge::WriteSample(const float* samples,
 
 int AudioTrackBridge::WriteSample(const uint16_t* samples,
                                   int num_of_samples,
-                                  SbTime sync_time,
+                                  int64_t sync_time,
                                   JniEnvExt* env /*= JniEnvExt::Get()*/) {
   SB_DCHECK(env);
   SB_DCHECK(is_valid());
@@ -215,7 +215,7 @@ int AudioTrackBridge::WriteSample(const uint16_t* samples,
 
 int AudioTrackBridge::WriteSample(const uint8_t* samples,
                                   int num_of_samples,
-                                  SbTime sync_time,
+                                  int64_t sync_time,
                                   JniEnvExt* env /*= JniEnvExt::Get()*/) {
   SB_DCHECK(env);
   SB_DCHECK(is_valid());
@@ -250,7 +250,7 @@ void AudioTrackBridge::SetVolume(double volume,
 }
 
 int64_t AudioTrackBridge::GetAudioTimestamp(
-    SbTime* updated_at,
+    int64_t* updated_at,
     JniEnvExt* env /*= JniEnvExt::Get()*/) {
   SB_DCHECK(env);
   SB_DCHECK(is_valid());
@@ -261,7 +261,7 @@ int64_t AudioTrackBridge::GetAudioTimestamp(
   if (updated_at) {
     *updated_at =
         env->GetLongFieldOrAbort(j_audio_timestamp.Get(), "nanoTime", "J") /
-        kSbTimeNanosecondsPerMicrosecond;
+        1000;
   }
   return env->GetLongFieldOrAbort(j_audio_timestamp.Get(), "framePosition",
                                   "J");

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -20,7 +20,6 @@
 #include "starboard/android/shared/jni_env_ext.h"
 #include "starboard/common/optional.h"
 #include "starboard/media.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 namespace starboard {
@@ -66,21 +65,21 @@ class AudioTrackBridge {
                   JniEnvExt* env = JniEnvExt::Get());
   int WriteSample(const uint16_t* samples,
                   int num_of_samples,
-                  SbTime sync_time,
+                  int64_t sync_time,
                   JniEnvExt* env = JniEnvExt::Get());
   // This is used by passthrough, it treats samples as if they are in bytes.
   // Returns zero or the positive number of samples written, or a negative error
   // code.
   int WriteSample(const uint8_t* buffer,
                   int num_of_samples,
-                  SbTime sync_time,
+                  int64_t sync_time,
                   JniEnvExt* env = JniEnvExt::Get());
 
   void SetVolume(double volume, JniEnvExt* env = JniEnvExt::Get());
 
   // |updated_at| contains the timestamp when the audio timstamp is updated on
   // return.  It can be nullptr.
-  int64_t GetAudioTimestamp(SbTime* updated_at,
+  int64_t GetAudioTimestamp(int64_t* updated_at,
                             JniEnvExt* env = JniEnvExt::Get());
   bool GetAndResetHasAudioDeviceChanged(JniEnvExt* env = JniEnvExt::Get());
   int GetUnderrunCount(JniEnvExt* env = JniEnvExt::Get());

--- a/starboard/android/shared/log_internal.cc
+++ b/starboard/android/shared/log_internal.cc
@@ -21,7 +21,7 @@
 
 namespace {
 const char kLogSleepTimeSwitch[] = "android_log_sleep_time";
-SbTime g_log_sleep_time = 0;
+int64_t g_log_sleep_time = 0;  // microseconds
 }  // namespace
 
 namespace starboard {
@@ -36,7 +36,7 @@ void LogInit(const starboard::shared::starboard::CommandLine& command_line) {
   }
 }
 
-SbTime GetLogSleepTime() {
+int64_t GetLogSleepTime() {
   return g_log_sleep_time;
 }
 

--- a/starboard/android/shared/log_internal.h
+++ b/starboard/android/shared/log_internal.h
@@ -19,14 +19,13 @@
 #define STARBOARD_ANDROID_SHARED_LOG_INTERNAL_H_
 
 #include "starboard/shared/starboard/command_line.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace android {
 namespace shared {
 
 void LogInit(const starboard::shared::starboard::CommandLine& command_line);
-SbTime GetLogSleepTime();
+int64_t GetLogSleepTime();  // Returns microseconds
 
 }  // namespace shared
 }  // namespace android

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -515,7 +515,7 @@ void MediaCodecBridge::OnMediaCodecOutputFormatChanged() {
   handler_->OnMediaCodecOutputFormatChanged();
 }
 
-void MediaCodecBridge::OnMediaCodecFrameRendered(SbTime frame_timestamp) {
+void MediaCodecBridge::OnMediaCodecFrameRendered(int64_t frame_timestamp) {
   handler_->OnMediaCodecFrameRendered(frame_timestamp);
 }
 

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -138,7 +138,7 @@ class MediaCodecBridge {
                                                    int size) = 0;
     virtual void OnMediaCodecOutputFormatChanged() = 0;
     // This is only called on video decoder when tunnel mode is enabled.
-    virtual void OnMediaCodecFrameRendered(SbTime frame_timestamp) = 0;
+    virtual void OnMediaCodecFrameRendered(int64_t frame_timestamp) = 0;
 
    protected:
     ~Handler() {}
@@ -211,7 +211,7 @@ class MediaCodecBridge {
                                          int64_t presentation_time_us,
                                          int size);
   void OnMediaCodecOutputFormatChanged();
-  void OnMediaCodecFrameRendered(SbTime frame_timestamp);
+  void OnMediaCodecFrameRendered(int64_t frame_timestamp);
 
  private:
   // |MediaCodecBridge|s must only be created through its factory methods.

--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -36,7 +36,7 @@ const jint kNoSize = 0;
 const jint kNoBufferFlags = 0;
 
 // Delay to use after a retryable error has been encountered.
-const SbTime kErrorRetryDelay = 50 * kSbTimeMillisecond;
+const int64_t kErrorRetryDelay = 50'000;  // 50ms
 
 const char* GetNameForMediaCodecStatus(jint status) {
   switch (status) {
@@ -258,7 +258,7 @@ void MediaDecoder::DecoderThreadFunc() {
         bool can_process_input =
             pending_queue_input_buffer_task_ || (has_input && has_input_buffer);
         if (dequeue_output_results_.empty() && !can_process_input) {
-          if (!condition_variable_.WaitTimed(5 * kSbTimeSecond)) {
+          if (!condition_variable_.WaitTimed(5'000'000LL)) {
             SB_LOG_IF(ERROR, !stream_ended_.load())
                 << GetDecoderName(media_type_) << ": Wait() hits timeout.";
           }
@@ -355,7 +355,7 @@ void MediaDecoder::DecoderThreadFunc() {
         can_process_input =
             !pending_tasks.empty() && !input_buffer_indices.empty();
         if (!can_process_input && dequeue_output_results.empty()) {
-          condition_variable_.WaitTimed(kSbTimeMillisecond);
+          condition_variable_.WaitTimed(1000);
         }
       }
     }
@@ -639,7 +639,7 @@ void MediaDecoder::OnMediaCodecOutputFormatChanged() {
   condition_variable_.Signal();
 }
 
-void MediaDecoder::OnMediaCodecFrameRendered(SbTime frame_timestamp) {
+void MediaDecoder::OnMediaCodecFrameRendered(int64_t frame_timestamp) {
   SB_DCHECK(tunnel_mode_enabled_);
   frame_rendered_cb_(frame_timestamp);
 }

--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -51,7 +51,7 @@ class MediaDecoder
   typedef ::starboard::shared::starboard::player::filter::ErrorCB ErrorCB;
   typedef ::starboard::shared::starboard::player::InputBuffer InputBuffer;
   typedef ::starboard::shared::starboard::player::InputBuffers InputBuffers;
-  typedef std::function<void(SbTime)> FrameRenderedCB;
+  typedef std::function<void(int64_t)> FrameRenderedCB;
 
   // This class should be implemented by the users of MediaDecoder to receive
   // various notifications.  Note that all such functions are called on the
@@ -168,7 +168,7 @@ class MediaDecoder
                                          int64_t presentation_time_us,
                                          int size) override;
   void OnMediaCodecOutputFormatChanged() override;
-  void OnMediaCodecFrameRendered(SbTime frame_timestamp) override;
+  void OnMediaCodecFrameRendered(int64_t frame_timestamp) override;
 
   ::starboard::shared::starboard::ThreadChecker thread_checker_;
 

--- a/starboard/android/shared/player_components_factory.h
+++ b/starboard/android/shared/player_components_factory.h
@@ -76,7 +76,7 @@ class AudioRendererSinkAndroid : public ::starboard::shared::starboard::player::
  public:
   explicit AudioRendererSinkAndroid(int tunnel_mode_audio_session_id = -1)
       : AudioRendererSinkImpl(
-            [=](SbTime start_media_time,
+            [=](int64_t start_media_time,
                 int channels,
                 int sampling_frequency_hz,
                 SbMediaAudioSampleType audio_sample_type,
@@ -130,7 +130,7 @@ class AudioRendererSinkCallbackStub
     *is_playing = true;
     *is_eos_reached = false;
   }
-  void ConsumeFrames(int frames_consumed, SbTime frames_consumed_at) override {
+  void ConsumeFrames(int frames_consumed, int64_t frames_consumed_at) override {
     SB_DCHECK(frames_consumed == 0);
   }
 

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -79,7 +79,7 @@ class VideoDecoder
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) override;
   size_t GetPrerollFrameCount() const override;
-  SbTime GetPrerollTimeout() const override;
+  int64_t GetPrerollTimeout() const override;
   // As we hold output buffers received from MediaCodec, the max number of
   // cached frames depends on the max number of output buffers in MediaCodec,
   // which is device dependent. The media decoder may stall if we hold all
@@ -115,7 +115,7 @@ class VideoDecoder
   void OnFlushing() override;
 
   void TryToSignalPrerollForTunnelMode();
-  void OnTunnelModeFrameRendered(SbTime frame_timestamp);
+  void OnTunnelModeFrameRendered(int64_t frame_timestamp);
   void OnTunnelModePrerollTimeout();
   void OnTunnelModeCheckForNeedMoreInput();
 
@@ -188,7 +188,7 @@ class VideoDecoder
   int input_buffer_written_ = 0;
   bool first_texture_received_ = false;
   bool end_of_stream_written_ = false;
-  volatile SbTime first_buffer_timestamp_;
+  volatile int64_t first_buffer_timestamp_;  // microseconds
   atomic_bool has_new_texture_available_;
 
   // Use |owns_video_surface_| only on decoder thread, to avoid unnecessary

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -21,22 +21,21 @@
 
 #include "starboard/common/log.h"
 #include "starboard/common/mutex.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace android {
 namespace shared {
 namespace {
 
-const SbTime kMaxAllowedSkew = 5000;
+const int64_t kMaxAllowedSkew = 5'000;  // 5ms
 
 }  // namespace
 
-SbTime VideoFrameTracker::seek_to_time() const {
+int64_t VideoFrameTracker::seek_to_time() const {
   return seek_to_time_;
 }
 
-void VideoFrameTracker::OnInputBuffer(SbTime timestamp) {
+void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
   SB_DCHECK(thread_checker_.CalledOnValidThread());
 
   if (frames_to_be_rendered_.empty()) {
@@ -72,7 +71,7 @@ void VideoFrameTracker::OnFrameRendered(int64_t frame_timestamp) {
   rendered_frames_on_decoder_thread_.push_back(frame_timestamp);
 }
 
-void VideoFrameTracker::Seek(SbTime seek_to_time) {
+void VideoFrameTracker::Seek(int64_t seek_to_time) {
   SB_DCHECK(thread_checker_.CalledOnValidThread());
 
   // Ensure that all dropped frames before seeking are captured.

--- a/starboard/android/shared/video_frame_tracker.h
+++ b/starboard/android/shared/video_frame_tracker.h
@@ -20,7 +20,6 @@
 
 #include "starboard/common/mutex.h"
 #include "starboard/shared/starboard/thread_checker.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace android {
@@ -31,13 +30,13 @@ class VideoFrameTracker {
   explicit VideoFrameTracker(int max_pending_frames_size)
       : max_pending_frames_size_(max_pending_frames_size) {}
 
-  SbTime seek_to_time() const;
+  int64_t seek_to_time() const;
 
-  void OnInputBuffer(SbTime timestamp);
+  void OnInputBuffer(int64_t timestamp);
 
   void OnFrameRendered(int64_t frame_timestamp);
 
-  void Seek(SbTime seek_to_time);
+  void Seek(int64_t seek_to_time);
 
   int UpdateAndGetDroppedFrames();
 
@@ -46,15 +45,15 @@ class VideoFrameTracker {
 
   ::starboard::shared::starboard::ThreadChecker thread_checker_;
 
-  std::list<SbTime> frames_to_be_rendered_;
+  std::list<int64_t> frames_to_be_rendered_;
 
   const int max_pending_frames_size_;
   int dropped_frames_ = 0;
-  SbTime seek_to_time_ = 0;
+  int64_t seek_to_time_ = 0;  // microseconds
 
   Mutex rendered_frames_mutex_;
-  std::vector<SbTime> rendered_frames_on_tracker_thread_;
-  std::vector<SbTime> rendered_frames_on_decoder_thread_;
+  std::vector<int64_t> rendered_frames_on_tracker_thread_;  // microseconds
+  std::vector<int64_t> rendered_frames_on_decoder_thread_;  // microseconds
 };
 
 }  // namespace shared

--- a/starboard/android/shared/video_frame_tracker_test.cc
+++ b/starboard/android/shared/video_frame_tracker_test.cc
@@ -15,7 +15,6 @@
 #include <string>
 
 #include "starboard/android/shared/video_frame_tracker.h"
-#include "starboard/time.h"
 
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -114,7 +113,7 @@ TEST(VideoFrameTrackerTest, RenderQueueIsClearedOnSeek) {
   video_frame_tracker.OnFrameRendered(30000);
   // Frames 40000, 50000, 60000 were never rendered.
 
-  const SbTime kSeekToTime = 90000;
+  const int64_t kSeekToTime = 90'000;  // 90ms
   video_frame_tracker.Seek(kSeekToTime);
   ASSERT_EQ(kSeekToTime, video_frame_tracker.seek_to_time());
 

--- a/starboard/android/shared/video_render_algorithm.h
+++ b/starboard/android/shared/video_render_algorithm.h
@@ -33,7 +33,7 @@ class VideoRenderAlgorithm : public ::starboard::shared::starboard::player::
   void Render(MediaTimeProvider* media_time_provider,
               std::list<scoped_refptr<VideoFrame>>* frames,
               VideoRendererSink::DrawFrameCB draw_frame_cb) override;
-  void Seek(SbTime seek_to_time) override {}
+  void Seek(int64_t seek_to_time) override {}
   int GetDroppedFrames() override { return dropped_frames_; }
 
  private:

--- a/starboard/client_porting/eztime/eztime.cc
+++ b/starboard/client_porting/eztime/eztime.cc
@@ -18,9 +18,9 @@
 
 #include "starboard/client_porting/icu_init/icu_init.h"
 #include "starboard/common/log.h"
+#include "starboard/common/time.h"
 #include "starboard/once.h"
 #include "starboard/system.h"
-#include "starboard/time.h"
 
 #include "third_party/icu/source/common/unicode/udata.h"
 #include "third_party/icu/source/common/unicode/uloc.h"
@@ -78,14 +78,16 @@ void Initialize() {
 
 // Converts from an SbTime to an ICU UDate (non-fractional milliseconds since
 // POSIX epoch, as a double).
-SbTime UDateToSbTime(UDate udate) {
-  return SbTimeFromPosix(static_cast<int64_t>(udate * kSbTimeMillisecond));
+int64_t UDateToSbTime(UDate udate) {
+  return starboard::PosixTimeToWindowsTime(
+      static_cast<int64_t>(udate * 1000LL));
 }
 
 // Converts from an ICU UDate to an SbTime. NOTE: This is LOSSY.
-UDate SbTimeToUDate(SbTime sb_time) {
-  return static_cast<UDate>(
-      SbTimeNarrow(SbTimeToPosix(sb_time), kSbTimeMillisecond));
+UDate SbTimeToUDate(int64_t sb_time) {
+  int64_t posix_time = sb_time - 11644473600000000ULL;
+  return static_cast<UDate>(posix_time >= 0 ? posix_time / 1000
+                                            : (posix_time - 1000 + 1) / 1000);
 }
 
 // Gets the cached TimeZone ID from |g_timezones| for the given EzTimeZone
@@ -132,7 +134,7 @@ bool EzTimeValueExplode(const EzTimeValue* SB_RESTRICT value,
     return false;
   }
 
-  SbTime sb_time = EzTimeValueToSbTime(value);
+  int64_t sb_time = EzTimeValueToSbTime(value);
   UDate udate = SbTimeToUDate(sb_time);
   ucal_setMillis(calendar, udate, &status);
   out_exploded->tm_year = ucal_get(calendar, UCAL_YEAR, &status) - 1900;
@@ -207,12 +209,14 @@ EzTimeValue EzTimeValueImplode(EzTimeExploded* SB_RESTRICT exploded,
 int EzTimeValueGetNow(EzTimeValue* out_tp, void* tzp) {
   SB_DCHECK(tzp == NULL);
   SB_DCHECK(out_tp != NULL);
-  *out_tp = EzTimeValueFromSbTime(SbTimeGetNow());
+  *out_tp = EzTimeValueFromSbTime(
+      starboard::PosixTimeToWindowsTime(starboard::CurrentPosixTime()));
   return 0;
 }
 
 EzTimeT EzTimeTGetNow(EzTimeT* out_now) {
-  EzTimeT result = EzTimeTFromSbTime(SbTimeGetNow());
+  EzTimeT result = EzTimeTFromSbTime(
+      starboard::PosixTimeToWindowsTime(starboard::CurrentPosixTime()));
   if (out_now) {
     *out_now = result;
   }

--- a/starboard/client_porting/eztime/eztime_test.cc
+++ b/starboard/client_porting/eztime/eztime_test.cc
@@ -14,6 +14,7 @@
 
 #include "starboard/client_porting/eztime/eztime.h"
 #include "starboard/client_porting/eztime/test_constants.h"
+#include "starboard/common/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -22,7 +23,7 @@ namespace eztime {
 namespace {
 
 TEST(EzTimeTFromSbTime, IsTransitive) {
-  SbTime sb_time = EzTimeTToSbTime(kTestTimePositive);
+  int64_t sb_time = EzTimeTToSbTime(kTestTimePositive);
   EzTimeT ez_time = EzTimeTFromSbTime(sb_time);
   EXPECT_EQ(kTestTimePositive, ez_time);
 
@@ -49,7 +50,7 @@ TEST(EzTimeTFromSbTime, IsTransitive) {
 
 TEST(EzTimeValueFromSbTime, IsTransitive) {
   EzTimeValue time_value = EzTimeTToEzTimeValue(kTestTimePositive);
-  SbTime sb_time = EzTimeValueToSbTime(&time_value);
+  int64_t sb_time = EzTimeValueToSbTime(&time_value);
   EzTimeValue time_value2 = EzTimeValueFromSbTime(sb_time);
   EXPECT_EQ(time_value.tv_sec, time_value2.tv_sec);
   EXPECT_EQ(time_value.tv_usec, time_value2.tv_usec);
@@ -63,11 +64,11 @@ TEST(EzTimeValueFromSbTime, IsTransitive) {
 
 TEST(EzTimeTGetNowTest, IsKindOfSane) {
   EzTimeT ez_time = EzTimeTGetNow(NULL);
-  SbTime sb_time = SbTimeGetNow();
+  int64_t sb_time = PosixTimeToWindowsTime(CurrentPosixTime());
 
   // They should be within a second of each other.
-  EXPECT_GT(kSbTimeSecond, sb_time - EzTimeTToSbTime(ez_time));
-  EXPECT_GT(kSbTimeSecond, EzTimeTToSbTime(ez_time) - sb_time);
+  EXPECT_GT(1'000'000LL, sb_time - EzTimeTToSbTime(ez_time));
+  EXPECT_GT(1'000'000LL, EzTimeTToSbTime(ez_time) - sb_time);
 
   // Now should be after the time I wrote this test.
   EXPECT_LE(kTestTimeWritten, ez_time);
@@ -84,11 +85,11 @@ TEST(EzTimeTGetNowTest, IsKindOfSane) {
 TEST(EzTimeValueGetNowTest, IsKindOfSane) {
   EzTimeValue time_value = {0};
   EXPECT_EQ(0, EzTimeValueGetNow(&time_value, NULL));
-  SbTime sb_time = SbTimeGetNow();
+  int64_t sb_time = PosixTimeToWindowsTime(CurrentPosixTime());
 
   // They should be within a second of each other.
-  EXPECT_GT(kSbTimeSecond, sb_time - EzTimeValueToSbTime(&time_value));
-  EXPECT_GT(kSbTimeSecond, EzTimeValueToSbTime(&time_value) - sb_time);
+  EXPECT_GT(1'000'000LL, sb_time - EzTimeValueToSbTime(&time_value));
+  EXPECT_GT(1'000'000LL, EzTimeValueToSbTime(&time_value) - sb_time);
 
   // Now should be after the time I wrote this test.
   EzTimeT ez_time = EzTimeTFromSbTime(EzTimeValueToSbTime(&time_value));

--- a/starboard/common/condition_variable.cc
+++ b/starboard/common/condition_variable.cc
@@ -31,7 +31,7 @@ void ConditionVariable::Wait() const {
   mutex_->debugSetAcquired();
 }
 
-bool ConditionVariable::WaitTimed(SbTime duration) const {
+bool ConditionVariable::WaitTimed(int64_t duration) const {
   mutex_->debugSetReleased();
   bool was_signaled = SbConditionVariableIsSignaled(
       SbConditionVariableWaitTimed(&condition_, mutex_->mutex(), duration));

--- a/starboard/common/condition_variable.h
+++ b/starboard/common/condition_variable.h
@@ -22,7 +22,6 @@
 
 #include "starboard/common/mutex.h"
 #include "starboard/condition_variable.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 namespace starboard {
@@ -39,8 +38,9 @@ class ConditionVariable {
 
   // Returns |true| if this condition variable was signaled. Otherwise |false|
   // means that the condition variable timed out. In either case the
-  // mutex has been re-acquired once this function returns.
-  bool WaitTimed(SbTime duration) const;
+  // mutex has been re-acquired once this function returns. The |duration| is
+  // microseconds.
+  bool WaitTimed(int64_t duration) const;
 
   void Broadcast() const;
   void Signal() const;

--- a/starboard/common/experimental/concurrency_debug.cc
+++ b/starboard/common/experimental/concurrency_debug.cc
@@ -23,7 +23,6 @@
 #include "starboard/atomic.h"
 #include "starboard/common/log.h"
 #include "starboard/common/mutex.h"
-#include "starboard/shared/posix/time_internal.h"
 #include "starboard/system.h"
 
 namespace starboard {

--- a/starboard/common/log.cc
+++ b/starboard/common/log.cc
@@ -24,7 +24,6 @@
 #include "starboard/common/string.h"
 #include "starboard/system.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace logging {

--- a/starboard/common/queue.h
+++ b/starboard/common/queue.h
@@ -26,8 +26,8 @@
 
 #include "starboard/common/condition_variable.h"
 #include "starboard/common/mutex.h"
+#include "starboard/common/time.h"
 #include "starboard/export.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 namespace starboard {
@@ -76,19 +76,19 @@ class Queue {
   }
 
   // Gets the item at the front of the queue, blocking until there is such an
-  // item, or the given timeout duration expires, or the queue is woken up. If
-  // there are multiple waiters, this Queue guarantees that only one waiter will
-  // receive any given queue item.
-  T GetTimed(SbTime duration) {
+  // item, or the given timeout duration (in microseconds) expires, or the queue
+  // is woken up. If there are multiple waiters, this Queue guarantees that only
+  // one waiter will receive any given queue item.
+  T GetTimed(int64_t duration) {
     ScopedLock lock(mutex_);
-    SbTimeMonotonic start = SbTimeGetMonotonicNow();
+    int64_t start = CurrentMonotonicTime();
     while (queue_.empty()) {
       if (wake_) {
         wake_ = false;
         return T();
       }
 
-      SbTimeMonotonic elapsed = SbTimeGetMonotonicNow() - start;
+      int64_t elapsed = CurrentMonotonicTime() - start;
       if (elapsed >= duration) {
         return T();
       }

--- a/starboard/common/recursive_mutex.cc
+++ b/starboard/common/recursive_mutex.cc
@@ -14,7 +14,6 @@
 
 #include "starboard/common/recursive_mutex.h"
 #include "starboard/common/log.h"
-#include "starboard/time.h"
 
 namespace starboard {
 

--- a/starboard/common/semaphore.cc
+++ b/starboard/common/semaphore.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "starboard/common/semaphore.h"
+#include "starboard/common/time.h"
 
 namespace starboard {
 
@@ -46,14 +47,14 @@ bool Semaphore::TakeTry() {
   return true;
 }
 
-bool Semaphore::TakeWait(SbTime wait_us) {
+bool Semaphore::TakeWait(int64_t wait_us) {
   if (wait_us <= 0) {
     return TakeTry();
   }
-  SbTime expire_time = SbTimeGetMonotonicNow() + wait_us;
+  int64_t expire_time = CurrentMonotonicTime() + wait_us;
   ScopedLock lock(mutex_);
   while (permits_ <= 0) {
-    SbTime remaining_wait_time = expire_time - SbTimeGetMonotonicNow();
+    int64_t remaining_wait_time = expire_time - CurrentMonotonicTime();
     if (remaining_wait_time <= 0) {
       return false;  // Timed out.
     }

--- a/starboard/common/semaphore.h
+++ b/starboard/common/semaphore.h
@@ -18,7 +18,6 @@
 #include "starboard/common/condition_variable.h"
 #include "starboard/common/mutex.h"
 #include "starboard/configuration.h"
-#include "starboard/time.h"
 
 namespace starboard {
 
@@ -43,9 +42,9 @@ class Semaphore {
   // is returned then the effects are the same as if Take() had been invoked.
   bool TakeTry();
 
-  // Same as Take(), but will wait at most, wait_us microseconds.
+  // Same as Take(), but will wait at most |wait_us| microseconds.
   // Returns |false| if the semaphore timed out, |true| otherwise.
-  bool TakeWait(SbTime wait_us);
+  bool TakeWait(int64_t wait_us);
 
  private:
   Mutex mutex_;

--- a/starboard/common/socket.cc
+++ b/starboard/common/socket.cc
@@ -144,7 +144,7 @@ bool Socket::SetSendBufferSize(int32_t size) {
   return SbSocketSetSendBufferSize(socket_, size);
 }
 
-bool Socket::SetTcpKeepAlive(bool value, SbTime period) {
+bool Socket::SetTcpKeepAlive(bool value, int64_t period) {
   return SbSocketSetTcpKeepAlive(socket_, value, period);
 }
 

--- a/starboard/common/socket.h
+++ b/starboard/common/socket.h
@@ -68,7 +68,7 @@ class Socket {
   bool SetReuseAddress(bool value);
   bool SetReceiveBufferSize(int32_t size);
   bool SetSendBufferSize(int32_t size);
-  bool SetTcpKeepAlive(bool value, SbTime period);
+  bool SetTcpKeepAlive(bool value, int64_t period);  // period in microseconds.
   bool SetTcpNoDelay(bool value);
   bool SetTcpWindowScaling(bool value);
   bool JoinMulticastGroup(const SbSocketAddress* address);

--- a/starboard/common/thread.cc
+++ b/starboard/common/thread.cc
@@ -64,15 +64,15 @@ void Thread::Start(const Options& options) {
   SB_DCHECK(d_->thread_ != kSbThreadInvalid);
 }
 
-void Thread::Sleep(SbTime microseconds) {
+void Thread::Sleep(int64_t microseconds) {
   SbThreadSleep(microseconds);
 }
 
 void Thread::SleepMilliseconds(int value) {
-  return Sleep(value * kSbTimeMillisecond);
+  return Sleep(static_cast<int64_t>(value) * 1000);
 }
 
-bool Thread::WaitForJoin(SbTime timeout) {
+bool Thread::WaitForJoin(int64_t timeout) {
   bool joined = d_->join_sema_.TakeWait(timeout);
   if (joined) {
     SB_DCHECK(d_->join_called_.load());

--- a/starboard/common/thread.h
+++ b/starboard/common/thread.h
@@ -23,7 +23,6 @@
 #include "starboard/common/scoped_ptr.h"
 #include "starboard/configuration.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 namespace starboard {
@@ -65,12 +64,12 @@ class Thread {
 
  protected:
   static void* ThreadEntryPoint(void* context);
-  static void Sleep(SbTime microseconds);
+  static void Sleep(int64_t microseconds);
   static void SleepMilliseconds(int value);
 
   // Waits at most |timeout| microseconds for Join() to be called. If
   // Join() was called then return |true|, else |false|.
-  bool WaitForJoin(SbTime timeout);
+  bool WaitForJoin(int64_t timeout);
   Semaphore* join_sema();
   atomic_bool* joined_bool();
 

--- a/starboard/condition_variable.h
+++ b/starboard/condition_variable.h
@@ -21,7 +21,6 @@
 
 #include "starboard/export.h"
 #include "starboard/mutex.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus
@@ -96,13 +95,13 @@ SbConditionVariableWait(SbConditionVariable* condition, SbMutex* mutex);
 // undefined if |mutex| is not held.
 //
 // |timeout_duration|: The maximum amount of time that function should wait
-// for |condition|. If the |timeout_duration| value is less than or equal to
-// zero, the function returns as quickly as possible with a
+// for |condition|, in microseconds. If the |timeout_duration| value is less
+// than or equal to zero, the function returns as quickly as possible with a
 // kSbConditionVariableTimedOut result.
 SB_EXPORT SbConditionVariableResult
 SbConditionVariableWaitTimed(SbConditionVariable* condition,
                              SbMutex* mutex,
-                             SbTime timeout_duration);
+                             int64_t timeout_duration);
 
 // Broadcasts to all current waiters of |condition| to stop waiting. This
 // function wakes all of the threads waiting on |condition| while

--- a/starboard/doc/style.md
+++ b/starboard/doc/style.md
@@ -120,9 +120,6 @@ the guidelines follow thusly as follows.
     casting the handle back and forth to the pointer type.
   * If a word in the name of a type is redundant with the module name, it is
     omitted.
-        * A monotonic time type in the Time module is `SbTimeMonotonic`, not
-          ~~`SbMonotonicTime`, `SbTimeMonotonicTime`, or
-          `SbTimeMonotonicSbTime`~~.
 
 ### Functions
 
@@ -188,10 +185,8 @@ namespace at the starboard repository root.
   * After the `k`, all constants have `Sb`, the Starboard namespace.
       * `kSb`
   * After `kSb`, all constants then have the module name.
-      * `kSbTime`
       * `kSbFile`
   * After `kSb<module>` comes the rest of the name of the constant.
-      * `kSbTimeMillisecond`
       * `kSbFileInvalid`
   * Enum entries are prefixed with the full name of the enum.
       * The enum `SbSystemDeviceType` contains entries like

--- a/starboard/elf_loader/elf_loader.cc
+++ b/starboard/elf_loader/elf_loader.cc
@@ -19,6 +19,7 @@
 #include "starboard/atomic.h"
 #include "starboard/common/log.h"
 #include "starboard/common/paths.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/elf_loader/elf_loader_impl.h"
 #include "starboard/elf_loader/evergreen_config.h"
@@ -78,12 +79,11 @@ bool ElfLoader::Load(const std::string& library_path,
   EvergreenConfig::Create(library_path_.c_str(), content_path_.c_str(),
                           custom_get_extension);
   SB_LOG(INFO) << "evergreen_config: content_path=" << content_path_;
-  SbTime start_time = SbTimeGetMonotonicNow();
+  int64_t start_time = CurrentMonotonicTime();
   bool res = impl_->Load(library_path_.c_str(), use_compression,
                          use_memory_mapped_file);
-  SbTime end_time = SbTimeGetMonotonicNow();
-  SB_LOG(INFO) << "Loading took: "
-               << (end_time - start_time) / kSbTimeMillisecond << " ms";
+  int64_t end_time = CurrentMonotonicTime();
+  SB_LOG(INFO) << "Loading took: " << (end_time - start_time) / 1000 << " ms";
   return res;
 }
 

--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -53,6 +53,9 @@
 #include "starboard/string.h"
 #include "starboard/system.h"
 #include "starboard/thread.h"
+#if SB_API_VERSION < 16
+#include "starboard/time.h"
+#endif  // SB_API_VERSION < 16
 #include "starboard/time_zone.h"
 #if SB_API_VERSION < 16
 #include "starboard/ui_navigation.h"
@@ -371,12 +374,10 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(SbThreadSetName);
   REGISTER_SYMBOL(SbThreadSleep);
   REGISTER_SYMBOL(SbThreadYield);
+#if SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeGetMonotonicNow);
-#if SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeGetMonotonicThreadNow);
-#endif  // SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeGetNow);
-#if SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeIsTimeThreadNowSupported);
 #endif  // SB_API_VERSION < 16
   REGISTER_SYMBOL(SbTimeZoneGetCurrent);

--- a/starboard/event.h
+++ b/starboard/event.h
@@ -92,7 +92,6 @@
 
 #include "starboard/configuration.h"
 #include "starboard/export.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 #include "starboard/window.h"
 
@@ -302,7 +301,7 @@ typedef enum SbEventType {
 // Structure representing a Starboard event and its data.
 typedef struct SbEvent {
   SbEventType type;
-  SbTimeMonotonic timestamp;
+  int64_t timestamp;  // Monotonic time in microseconds.
   void* data;
 } SbEvent;
 
@@ -377,7 +376,7 @@ SB_IMPORT void SbEventHandle(const SbEvent* event);
 // possible.
 SB_EXPORT SbEventId SbEventSchedule(SbEventCallback callback,
                                     void* context,
-                                    SbTime delay);
+                                    int64_t delay);
 
 // Cancels the specified |event_id|. Note that this function is a no-op
 // if the event already fired. This function can be safely called from any

--- a/starboard/extension/demuxer.h
+++ b/starboard/extension/demuxer.h
@@ -22,8 +22,6 @@
 #include <stdint.h>
 #include <string.h>
 
-#include "starboard/time.h"
-
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -284,9 +282,9 @@ typedef struct CobaltExtensionDemuxerBuffer {
   // Number of elements in |side_data|.
   int64_t side_data_elements;
   // Playback time in microseconds.
-  SbTime pts;
+  int64_t pts;
   // Duration of this buffer in microseconds.
-  SbTime duration;
+  int64_t duration;
   // True if this buffer contains a keyframe.
   bool is_keyframe;
   // Signifies the end of the stream. If this is true, the other fields will be
@@ -310,15 +308,16 @@ typedef struct CobaltExtensionDemuxer {
   // fail.
   CobaltExtensionDemuxerStatus (*Initialize)(void* user_data);
 
-  CobaltExtensionDemuxerStatus (*Seek)(SbTime seek_time, void* user_data);
+  CobaltExtensionDemuxerStatus (*Seek)(int64_t seek_time, void* user_data);
 
-  // Returns the starting time for the media file; it is always positive.
-  SbTime (*GetStartTime)(void* user_data);
+  // Returns the starting time -- in microseconds since Windows epoch -- for the
+  // media file; it is always positive.
+  int64_t (*GetStartTime)(void* user_data);
 
   // Returns the time -- in microseconds since Windows epoch -- represented by
   // presentation timestamp 0. If the timestamps are not associated with a time,
   // returns 0.
-  SbTime (*GetTimelineOffset)(void* user_data);
+  int64_t (*GetTimelineOffset)(void* user_data);
 
   // Calls |read_cb| with a buffer of type |type| and the user data provided by
   // |read_cb_user_data|. |read_cb| is a synchronous function, so the data
@@ -346,7 +345,7 @@ typedef struct CobaltExtensionDemuxer {
                          void* user_data);
 
   // Returns the duration, in microseconds.
-  SbTime (*GetDuration)(void* user_data);
+  int64_t (*GetDuration)(void* user_data);
 
   // Will be passed to all functions.
   void* user_data;

--- a/starboard/extension/enhanced_audio.h
+++ b/starboard/extension/enhanced_audio.h
@@ -19,7 +19,6 @@
 #include "starboard/drm.h"
 #include "starboard/media.h"
 #include "starboard/player.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus
@@ -48,8 +47,8 @@ typedef struct CobaltExtensionEnhancedAudioMediaAudioStreamInfo {
 // comment of `SbMediaAudioSampleInfo` in `media.h` for more details.
 typedef struct CobaltExtensionEnhancedAudioMediaAudioSampleInfo {
   CobaltExtensionEnhancedAudioMediaAudioStreamInfo stream_info;
-  SbTime discarded_duration_from_front;
-  SbTime discarded_duration_from_back;
+  int64_t discarded_duration_from_front;  // in microseconds.
+  int64_t discarded_duration_from_back;   // in microseconds.
 } CobaltExtensionEnhancedAudioMediaAudioSampleInfo;
 
 // The structure has the same binary layout as `SbMediaVideoStreamInfo` in the
@@ -82,7 +81,7 @@ typedef struct CobaltExtensionEnhancedAudioPlayerSampleInfo {
   SbMediaType type;
   const void* buffer;
   int buffer_size;
-  SbTime timestamp;
+  int64_t timestamp;  // Microseconds since Windows epoch UTC.
   SbPlayerSampleSideData* side_data;
   int side_data_count;
   union {

--- a/starboard/extension/media_session.h
+++ b/starboard/extension/media_session.h
@@ -16,7 +16,7 @@
 #define STARBOARD_EXTENSION_MEDIA_SESSION_H_
 
 #include "starboard/configuration.h"
-#include "starboard/time.h"
+#include "starboard/types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -84,12 +84,12 @@ typedef void (*CobaltExtensionMediaSessionInvokeActionCallback)(
 // valid within the scope of that function. Any data inside must be copied if it
 // will be referenced later.
 typedef struct CobaltExtensionMediaSessionState {
-  SbTimeMonotonic duration;
+  int64_t duration;  // Monotonic time in microseconds.
   CobaltExtensionMediaSessionPlaybackState actual_playback_state;
   bool available_actions[kCobaltExtensionMediaSessionActionNumActions];
   CobaltExtensionMediaMetadata* metadata;
   double actual_playback_rate;
-  SbTimeMonotonic current_playback_position;
+  int64_t current_playback_position;  // Monotonic time in microseconds.
   bool has_position_state;
 } CobaltExtensionMediaSessionState;
 

--- a/starboard/file.h
+++ b/starboard/file.h
@@ -20,7 +20,6 @@
 #define STARBOARD_FILE_H_
 
 #include "starboard/export.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus
@@ -110,14 +109,14 @@ typedef struct SbFileInfo {
   // Whether the file corresponds to a symbolic link.
   bool is_symbolic_link;
 
-  // The last modified time of a file.
-  SbTime last_modified;
+  // The last modified time of a file - microseconds since Windows epoch UTC.
+  int64_t last_modified;
 
-  // The last accessed time of a file.
-  SbTime last_accessed;
+  // The last accessed time of a file - microseconds since Windows epoch UTC.
+  int64_t last_accessed;
 
-  // The creation time of a file.
-  SbTime creation_time;
+  // The creation time of a file - microseconds since Windows epoch UTC.
+  int64_t creation_time;
 } SbFileInfo;
 
 // Well-defined value for an invalid file handle.

--- a/starboard/input.h
+++ b/starboard/input.h
@@ -22,7 +22,6 @@
 #include "starboard/configuration.h"
 #include "starboard/export.h"
 #include "starboard/key.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 #include "starboard/window.h"
 

--- a/starboard/linux/shared/player_components_factory.cc
+++ b/starboard/linux/shared/player_components_factory.cc
@@ -110,7 +110,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       typedef ::starboard::shared::openh264::VideoDecoder
           Openh264VideoDecoderImpl;
 
-      const SbTime kVideoSinkRenderInterval = 10 * kSbTimeMillisecond;
+      const int64_t kVideoSinkRenderIntervalUsec = 10'000;
 
       SB_DCHECK(video_decoder);
       SB_DCHECK(video_render_algorithm);
@@ -170,7 +170,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         *video_renderer_sink = NULL;
       } else {
         *video_renderer_sink = new PunchoutVideoRendererSink(
-            creation_parameters.player(), kVideoSinkRenderInterval);
+            creation_parameters.player(), kVideoSinkRenderIntervalUsec);
       }
     }
 

--- a/starboard/loader_app/drain_file.h
+++ b/starboard/loader_app/drain_file.h
@@ -15,18 +15,17 @@
 #ifndef STARBOARD_LOADER_APP_DRAIN_FILE_H_
 #define STARBOARD_LOADER_APP_DRAIN_FILE_H_
 
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-// The units of time that the drain file age is represented in.
-extern const SbTime kDrainFileAgeUnit;
+// The units of time that the drain file age is represented in, in microseconds.
+extern const int64_t kDrainFileAgeUnitUsec;
 
-// The amount of time of which a drain file is valid.
-extern const SbTime kDrainFileMaximumAge;
+// The amount of time of which a drain file is valid, in microseconds.
+extern const int64_t kDrainFileMaximumAgeUsec;
 
 // The prefix that all drain file names will have.
 extern const char kDrainFilePrefix[];

--- a/starboard/loader_app/drain_file_helper.cc
+++ b/starboard/loader_app/drain_file_helper.cc
@@ -23,7 +23,7 @@ namespace loader_app {
 
 ScopedDrainFile::ScopedDrainFile(const std::string& dir,
                                  const std::string& app_key,
-                                 SbTime timestamp) {
+                                 int64_t timestamp) {
   app_key_.assign(app_key);
 
   path_.assign(dir);
@@ -31,7 +31,7 @@ ScopedDrainFile::ScopedDrainFile(const std::string& dir,
   path_.append(kDrainFilePrefix);
   path_.append(app_key);
   path_.append("_");
-  path_.append(std::to_string(timestamp / kDrainFileAgeUnit));
+  path_.append(std::to_string(timestamp / kDrainFileAgeUnitUsec));
 
   CreateFile();
 }

--- a/starboard/loader_app/drain_file_helper.h
+++ b/starboard/loader_app/drain_file_helper.h
@@ -17,8 +17,6 @@
 
 #include <string>
 
-#include "starboard/time.h"
-
 namespace starboard {
 namespace loader_app {
 
@@ -27,11 +25,12 @@ namespace loader_app {
 // convenient way of bundling the information and state of the file. This class
 // is very similar in concept to the starboard::nplb::ScopedRandomFile, except
 // that it allows you to choose where to create the file.
+// |timestamp| is microseconds from Windows epoch UTC.
 class ScopedDrainFile {
  public:
   ScopedDrainFile(const std::string& dir,
                   const std::string& app_key,
-                  SbTime timestamp);
+                  int64_t timestamp);
   ~ScopedDrainFile();
 
   // Whether or not the created file still exists.

--- a/starboard/media.h
+++ b/starboard/media.h
@@ -22,7 +22,6 @@
 
 #include "starboard/drm.h"
 #include "starboard/export.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus
@@ -526,7 +525,7 @@ typedef struct SbMediaAudioConfiguration {
 
   // The expected latency of audio over this output, in microseconds, or |0| if
   // this device cannot provide this information.
-  SbTime latency;
+  int64_t latency;
 
   // The type of audio coding used over this connection.
   SbMediaAudioCodingType coding_type;
@@ -572,8 +571,8 @@ typedef struct SbMediaAudioStreamInfo {
 typedef struct SbMediaAudioSampleInfo {
   // The set of information of the video stream associated with this sample.
   SbMediaAudioStreamInfo stream_info;
-  SbTime discarded_duration_from_front;
-  SbTime discarded_duration_from_back;
+  int64_t discarded_duration_from_front;  // in microseconds.
+  int64_t discarded_duration_from_back;   // in microseconds.
 } SbMediaAudioSampleInfo;
 
 #else  // SB_API_VERSION >= 15
@@ -731,15 +730,16 @@ SB_EXPORT int SbMediaGetBufferAllocationUnit();
 // difficulty if this value is too low.
 SB_EXPORT int SbMediaGetAudioBufferBudget();
 
-// Specifies the duration threshold of media source garbage collection.  When
-// the accumulated duration in a source buffer exceeds this value, the media
-// source implementation will try to eject existing buffers from the cache. This
-// is usually triggered when the video being played has a simple content and the
-// encoded data is small.  In such case this can limit how much is allocated for
-// the book keeping data of the media buffers and avoid OOM of system heap. This
-// should return 170 seconds for most of the platforms.  But it can be further
-// reduced on systems with extremely low memory.
-SB_EXPORT SbTime SbMediaGetBufferGarbageCollectionDurationThreshold();
+// Specifies the duration threshold of media source garbage collection in
+// microseconds.  When the accumulated duration in a source buffer exceeds this
+// value, the media source implementation will try to eject existing buffers
+// from the cache. This is usually triggered when the video being played has a
+// simple content and the encoded data is small.  In such case this can limit
+// how much is allocated for the book keeping data of the media buffers and
+// avoid OOM of system heap. This should return 170 seconds for most of the
+// platforms.  But it can be further reduced on systems with extremely low
+// memory.
+SB_EXPORT int64_t SbMediaGetBufferGarbageCollectionDurationThreshold();
 
 // The amount of memory that will be used to store media buffers allocated
 // during system startup.  To allocate a large chunk at startup helps with
@@ -834,14 +834,14 @@ SB_EXPORT int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
 // Communicate to the platform how far past |current_playback_position| the app
 // will write audio samples. The app will write all samples between
 // |current_playback_position| and |current_playback_position| + |duration|, as
-// soon as they are available. The app may sometimes write more samples than
-// that, but the app only guarantees to write |duration| past
-// |current_playback_position| in general. The platform is responsible for
+// soon as they are available (during is in microseconds). The app may sometimes
+// write more samples than that, but the app only guarantees to write |duration|
+// past |current_playback_position| in general. The platform is responsible for
 // guaranteeing that when only |duration| audio samples are written at a time,
 // no playback issues occur (such as transient or indefinite hanging). The
 // platform may assume |duration| >= 0.5 seconds.
 #if SB_API_VERSION < 15
-SB_EXPORT void SbMediaSetAudioWriteDuration(SbTime duration);
+SB_EXPORT void SbMediaSetAudioWriteDuration(int64_t duration);
 #endif  // SB_API_VERSION < 15
 
 #ifdef __cplusplus

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -139,6 +139,7 @@ target(gtest_target_type, "nplb") {
     "posix_compliance/posix_string_compare_no_case_test.cc",
     "posix_compliance/posix_string_format_test.cc",
     "posix_compliance/posix_string_format_wide_test.cc",
+    "posix_compliance/posix_time_test.cc",
     "random_helpers.cc",
     "recursive_mutex_test.cc",
     "rwlock_test.cc",

--- a/starboard/nplb/arpa_inet_test.cc
+++ b/starboard/nplb/arpa_inet_test.cc
@@ -38,7 +38,7 @@ TEST(ArpaInet, BigEndian) {
   EXPECT_EQ(kTestU32, ntohl(kTestU32));
 }
 #else
-TEST(SbByteSwapTest, LittleEndian) {
+TEST(ArpaInet, LittleEndian) {
   EXPECT_EQ(kExpectedU16, htons(kTestU16));
   EXPECT_EQ(kExpectedU16, ntohs(kTestU16));
 

--- a/starboard/nplb/atomic_test.cc
+++ b/starboard/nplb/atomic_test.cc
@@ -17,7 +17,6 @@
 #include "starboard/common/atomic.h"
 #include "starboard/memory.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -340,7 +339,7 @@ template <class SbAtomicType>
 void* TestOnceEntryPoint(void* raw_context) {
   // Force every thread to sleep immediately so the first thread doesn't always
   // just win.
-  SbThreadSleep(kSbTimeMillisecond);
+  SbThreadSleep(1000);
   TestOnceContext<SbAtomicType>* context =
       reinterpret_cast<TestOnceContext<SbAtomicType>*>(raw_context);
   SetData(context->state, context->out_data, context->data, context->size);

--- a/starboard/nplb/audio_sink_helpers.cc
+++ b/starboard/nplb/audio_sink_helpers.cc
@@ -17,6 +17,7 @@
 #include <algorithm>
 
 #include "starboard/common/log.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 
 namespace starboard {
@@ -124,13 +125,13 @@ int AudioSinkTestEnvironment::GetFrameBufferFreeSpaceInFrames() const {
 bool AudioSinkTestEnvironment::WaitUntilUpdateStatusCalled() {
   ScopedLock lock(mutex_);
   int update_source_status_call_count = update_source_status_call_count_;
-  SbTimeMonotonic start = SbTimeGetMonotonicNow();
+  int64_t start = CurrentMonotonicTime();
   while (update_source_status_call_count == update_source_status_call_count_) {
-    SbTime time_elapsed = SbTimeGetMonotonicNow() - start;
+    int64_t time_elapsed = CurrentMonotonicTime() - start;
     if (time_elapsed >= kTimeToTry) {
       return false;
     }
-    SbTime time_to_wait = kTimeToTry - time_elapsed;
+    int64_t time_to_wait = kTimeToTry - time_elapsed;
     condition_variable_.WaitTimed(time_to_wait);
   }
   return true;
@@ -139,13 +140,13 @@ bool AudioSinkTestEnvironment::WaitUntilUpdateStatusCalled() {
 bool AudioSinkTestEnvironment::WaitUntilSomeFramesAreConsumed() {
   ScopedLock lock(mutex_);
   int frames_consumed = frames_consumed_;
-  SbTimeMonotonic start = SbTimeGetMonotonicNow();
+  int64_t start = CurrentMonotonicTime();
   while (frames_consumed == frames_consumed_) {
-    SbTime time_elapsed = SbTimeGetMonotonicNow() - start;
+    int64_t time_elapsed = CurrentMonotonicTime() - start;
     if (time_elapsed >= kTimeToTry) {
       return false;
     }
-    SbTime time_to_wait = kTimeToTry - time_elapsed;
+    int64_t time_to_wait = kTimeToTry - time_elapsed;
     condition_variable_.WaitTimed(time_to_wait);
   }
   return true;
@@ -157,15 +158,15 @@ bool AudioSinkTestEnvironment::WaitUntilAllFramesAreConsumed() {
   ScopedLock lock(mutex_);
   is_eos_reached_ = true;
   int frames_appended_before_eos = frames_appended_;
-  SbTimeMonotonic start = SbTimeGetMonotonicNow();
+  int64_t start = CurrentMonotonicTime();
   int silence_frames_appended = 0;
 
   while (frames_consumed_ < frames_appended_before_eos) {
-    SbTime time_elapsed = SbTimeGetMonotonicNow() - start;
+    int64_t time_elapsed = CurrentMonotonicTime() - start;
     if (time_elapsed >= kTimeToTry) {
       return false;
     }
-    SbTime time_to_wait = kTimeToTry - time_elapsed;
+    int64_t time_to_wait = kTimeToTry - time_elapsed;
 
     // Append silence as some audio sink implementations won't be able to finish
     // playback to the last frames filled.

--- a/starboard/nplb/audio_sink_helpers.h
+++ b/starboard/nplb/audio_sink_helpers.h
@@ -21,7 +21,6 @@
 #include "starboard/common/condition_variable.h"
 #include "starboard/common/mutex.h"
 #include "starboard/media.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace nplb {
@@ -67,7 +66,7 @@ class AudioSinkTestFrameBuffers {
 class AudioSinkTestEnvironment {
  public:
   static const int kSampleRateCD = 44100;
-  static const SbTimeMonotonic kTimeToTry = kSbTimeSecond;
+  static const int64_t kTimeToTry = 1'000'000;  // 1 second
 
   explicit AudioSinkTestEnvironment(
       const AudioSinkTestFrameBuffers& frame_buffers);

--- a/starboard/nplb/audio_sink_test.cc
+++ b/starboard/nplb/audio_sink_test.cc
@@ -18,7 +18,6 @@
 
 #include "starboard/nplb/audio_sink_helpers.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -100,7 +99,7 @@ TEST(SbAudioSinkTest, Underflow) {
   environment.AppendFrame(frames_to_append);
 
   EXPECT_TRUE(environment.WaitUntilSomeFramesAreConsumed());
-  SbThreadSleep(250 * kSbTimeMillisecond);
+  SbThreadSleep(250'000);
   ASSERT_GT(environment.GetFrameBufferFreeSpaceInFrames(), 0);
   environment.AppendFrame(environment.GetFrameBufferFreeSpaceInFrames());
   EXPECT_TRUE(environment.WaitUntilAllFramesAreConsumed());

--- a/starboard/nplb/drm_session_test.cc
+++ b/starboard/nplb/drm_session_test.cc
@@ -20,14 +20,13 @@
 #include "starboard/common/log.h"
 #include "starboard/common/queue.h"
 #include "starboard/nplb/drm_helpers.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
 namespace nplb {
 namespace {
 
-constexpr SbTimeMonotonic kDefaultWaitForCallbackTimeout = kSbTimeSecond;
+constexpr int64_t kDefaultWaitForCallbackTimeout = 1'000'000;  // 1 second
 constexpr char kWidevineKeySystem[] = "com.widevine.alpha";
 constexpr char kCencInitDataType[] = "cenc";
 constexpr int kInitialTicket = kSbDrmTicketInvalid + 1;

--- a/starboard/nplb/extern_c_test.cc
+++ b/starboard/nplb/extern_c_test.cc
@@ -52,7 +52,9 @@ extern "C" {
 #include "starboard/string.h"
 #include "starboard/system.h"
 #include "starboard/thread.h"
+#if SB_API_VERSION < 16
 #include "starboard/time.h"
+#endif  // SB_API_VERSION < 16
 #include "starboard/time_zone.h"
 #include "starboard/types.h"
 #if SB_API_VERSION < 16

--- a/starboard/nplb/file_get_info_test.cc
+++ b/starboard/nplb/file_get_info_test.cc
@@ -16,10 +16,10 @@
 
 #include <string>
 
+#include "starboard/common/time.h"
 #include "starboard/file.h"
 #include "starboard/nplb/file_helpers.h"
 #include "starboard/system.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -39,12 +39,16 @@ TEST(SbFileGetInfoTest, WorksOnARegularFile) {
   for (int i = 0; i < kTrials; ++i) {
     // We can't assume filesystem timestamp precision, so go back a minute
     // for a better chance to contain the imprecision and rounding errors.
-    SbTime time = SbTimeGetNow() - kSbTimeMinute;
+    const int64_t kOneMinuteInMicroseconds = 60'000'000;
+    int64_t time =
+        PosixTimeToWindowsTime(CurrentPosixTime()) - kOneMinuteInMicroseconds;
 #if !SB_HAS_QUIRK(FILESYSTEM_ZERO_FILEINFO_TIME)
 #if SB_HAS_QUIRK(FILESYSTEM_COARSE_ACCESS_TIME)
     // On platforms with coarse access time, we assume 1 day precision and go
     // back 2 days to avoid rounding issues.
-    SbTime coarse_time = SbTimeGetNow() - (2 * kSbTimeDay);
+    const int64_t kOneDayInMicroseconds = 1'000'000LL * 60LL * 60LL * 24LL;
+    int64_t coarse_time = PosixTimeToWindowsTime(CurrentPosixTime()) -
+                          (2 * kOneDayInMicroseconds);
 #endif  // FILESYSTEM_COARSE_ACCESS_TIME
 #endif  // FILESYSTEM_ZERO_FILEINFO_TIME
 

--- a/starboard/nplb/file_get_path_info_test.cc
+++ b/starboard/nplb/file_get_path_info_test.cc
@@ -16,11 +16,11 @@
 
 #include <string>
 
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/file.h"
 #include "starboard/nplb/file_helpers.h"
 #include "starboard/system.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -52,12 +52,16 @@ TEST(SbFileGetPathInfoTest, WorksOnARegularFile) {
   for (int i = 0; i < kTrials; ++i) {
     // We can't assume filesystem timestamp precision, so go back a minute
     // for a better chance to contain the imprecision and rounding errors.
-    SbTime time = SbTimeGetNow() - kSbTimeMinute;
+    const int64_t kOneMinuteInMicroseconds = 60'000'000;
+    int64_t time =
+        PosixTimeToWindowsTime(CurrentPosixTime()) - kOneMinuteInMicroseconds;
 #if !SB_HAS_QUIRK(FILESYSTEM_ZERO_FILEINFO_TIME)
 #if SB_HAS_QUIRK(FILESYSTEM_COARSE_ACCESS_TIME)
     // On platforms with coarse access time, we assume 1 day precision and go
     // back 2 days to avoid rounding issues.
-    SbTime coarse_time = SbTimeGetNow() - (2 * kSbTimeDay);
+    const int64_t kOneDayInMicroseconds = 1'000'000LL * 60LL * 60LL * 24LL;
+    int64_t coarse_time = PosixTimeToWindowsTime(CurrentPosixTime()) -
+                          (2 * kOneDayInMicroseconds);
 #endif  // FILESYSTEM_COARSE_ACCESS_TIME
 #endif  // FILESYSTEM_ZERO_FILEINFO_TIME
 

--- a/starboard/nplb/include_all.c
+++ b/starboard/nplb/include_all.c
@@ -51,7 +51,9 @@
 #include "starboard/string.h"
 #include "starboard/system.h"
 #include "starboard/thread.h"
+#if SB_API_VERSION < 16
 #include "starboard/time.h"
+#endif  // SB_API_VERSION < 16
 #include "starboard/time_zone.h"
 #include "starboard/types.h"
 #if SB_API_VERSION < 16

--- a/starboard/nplb/media_buffer_test.cc
+++ b/starboard/nplb/media_buffer_test.cc
@@ -236,8 +236,8 @@ TEST(SbMediaBufferTest, AudioBudget) {
 }
 
 TEST(SbMediaBufferTest, GarbageCollectionDurationThreshold) {
-  int kMinGarbageCollectionDurationThreshold = 30 * kSbTimeSecond;
-  int kMaxGarbageCollectionDurationThreshold = 240 * kSbTimeSecond;
+  int kMinGarbageCollectionDurationThreshold = 30'000'000LL;   // 30 seconds
+  int kMaxGarbageCollectionDurationThreshold = 240'000'000LL;  // 240 seconds
   int threshold = SbMediaGetBufferGarbageCollectionDurationThreshold();
   EXPECT_GE(threshold, kMinGarbageCollectionDurationThreshold);
   EXPECT_LE(threshold, kMaxGarbageCollectionDurationThreshold);

--- a/starboard/nplb/media_can_play_mime_and_key_system_test.cc
+++ b/starboard/nplb/media_can_play_mime_and_key_system_test.cc
@@ -18,11 +18,11 @@
 
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 #include "starboard/media.h"
 #include "starboard/nplb/drm_helpers.h"
 #include "starboard/nplb/media_can_play_mime_and_key_system_test_helpers.h"
 #include "starboard/nplb/performance_helpers.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -915,15 +915,15 @@ TEST(SbMediaCanPlayMimeAndKeySystem, VerifyMaxBitrate) {
 TEST(SbMediaCanPlayMimeAndKeySystem, FLAKY_ValidatePerformance) {
   auto test_sequential_function_calls =
       [](const SbMediaCanPlayMimeAndKeySystemParam* mime_params,
-         int num_function_calls, SbTimeMonotonic max_time_delta_per_call,
+         int num_function_calls, int64_t max_time_delta_per_call,
          const char* query_type) {
-        const SbTimeMonotonic time_start = SbTimeGetMonotonicNow();
+        const int64_t time_start = CurrentMonotonicTime();
         for (int i = 0; i < num_function_calls; ++i) {
           SbMediaCanPlayMimeAndKeySystem(mime_params[i].mime,
                                          mime_params[i].key_system);
         }
-        const SbTimeMonotonic time_last = SbTimeGetMonotonicNow();
-        const SbTimeMonotonic time_delta = time_last - time_start;
+        const int64_t time_last = CurrentMonotonicTime();
+        const int64_t time_delta = time_last - time_start;
         const double time_per_call =
             static_cast<double>(time_delta) / num_function_calls;
 
@@ -937,8 +937,8 @@ TEST(SbMediaCanPlayMimeAndKeySystem, FLAKY_ValidatePerformance) {
 
   // Warmup the cache.
   test_sequential_function_calls(kWarmupQueryParams,
-                                 SB_ARRAY_SIZE_INT(kWarmupQueryParams),
-                                 100 * kSbTimeMillisecond, "Warmup queries");
+                                 SB_ARRAY_SIZE_INT(kWarmupQueryParams), 100'000,
+                                 "Warmup queries");
 
   // First round of the queries.
   test_sequential_function_calls(

--- a/starboard/nplb/media_configuration_test.cc
+++ b/starboard/nplb/media_configuration_test.cc
@@ -15,7 +15,6 @@
 #include "starboard/media.h"
 
 #include "starboard/nplb/performance_helpers.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -28,10 +27,10 @@ TEST(SbMediaConfigurationTest, ValidatePerformance) {
   const int count_audio_output = SbMediaGetAudioOutputCount();
   for (int i = 0; i < count_audio_output; ++i) {
     constexpr int kNumberOfCalls = 100;
-    constexpr SbTime kMaxAverageTimePerCall = 500;
+    constexpr int64_t kMaxAverageTimePerCallUsec = 500;
 
     SbMediaAudioConfiguration configuration;
-    TEST_PERF_FUNCWITHARGS_EXPLICIT(kNumberOfCalls, kMaxAverageTimePerCall,
+    TEST_PERF_FUNCWITHARGS_EXPLICIT(kNumberOfCalls, kMaxAverageTimePerCallUsec,
                                     SbMediaGetAudioConfiguration, i,
                                     &configuration);
   }

--- a/starboard/nplb/microphone_read_test.cc
+++ b/starboard/nplb/microphone_read_test.cc
@@ -88,7 +88,7 @@ TEST(SbMicrophoneReadTest, SunnyDayOpenSleepCloseAndOpenRead) {
 
     EXPECT_TRUE(SbMicrophoneOpen(microphone));
 
-    SbThreadSleep(50 * kSbTimeMillisecond);
+    SbThreadSleep(50'000);
 
     EXPECT_TRUE(SbMicrophoneClose(microphone));
     EXPECT_TRUE(SbMicrophoneOpen(microphone));

--- a/starboard/nplb/multiple_player_test.cc
+++ b/starboard/nplb/multiple_player_test.cc
@@ -100,7 +100,7 @@ void WriteSamples(const SbPlayerTestConfig& player_config,
     return;
   }
 
-  const SbTime kDurationToPlay = kSbTimeMillisecond * 200;
+  const int64_t kDurationToPlay = 200'000;  // 200ms
 
   GroupedSamples samples;
   if (player_fixture.HasAudio()) {

--- a/starboard/nplb/performance_helpers.h
+++ b/starboard/nplb/performance_helpers.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_NPLB_PERFORMANCE_HELPERS_H_
 #define STARBOARD_NPLB_PERFORMANCE_HELPERS_H_
 
+#include "starboard/common/time.h"
 #include "starboard/types.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -24,19 +25,18 @@ namespace nplb {
 // Default for parameter |count_calls| of TestPerformanceOfFunction.
 constexpr int kDefaultTestPerformanceCountCalls = 1000;
 // Default for parameter |max_time_per_call| of TestPerformanceOfFunction.
-constexpr SbTimeMonotonic kDefaultTestPerformanceMaxTimePerCall =
-    kSbTimeMillisecond / 2;
+constexpr int64_t kDefaultTestPerformanceMaxTimePerCall = 500;  // 0.5ms
 
 // Helper function for testing function call time performance.
 template <const size_t count_calls,
-          const SbTimeMonotonic max_time_per_call,
+          const int64_t max_time_per_call,
           typename R,
           typename... Args>
 void TestPerformanceOfFunction(const char* const name_of_f,
                                R (*const f)(Args...),
                                Args... args) {
   // Measure time pre calls to |f|.
-  const SbTimeMonotonic time_start = SbTimeGetMonotonicNow();
+  const int64_t time_start = CurrentMonotonicTime();
 
   SbLogPriority initial_log_level = starboard::logging::GetMinLogLevel();
   starboard::logging::SetMinLogLevel(kSbLogPriorityFatal);
@@ -49,8 +49,8 @@ void TestPerformanceOfFunction(const char* const name_of_f,
   starboard::logging::SetMinLogLevel(initial_log_level);
 
   // Measure time post calls to |f|.
-  const SbTimeMonotonic time_last = SbTimeGetMonotonicNow();
-  const SbTimeMonotonic time_delta = time_last - time_start;
+  const int64_t time_last = CurrentMonotonicTime();
+  const int64_t time_delta = time_last - time_start;
   const double time_per_call = static_cast<double>(time_delta) / count_calls;
 
   // Pretty printing.
@@ -62,7 +62,7 @@ void TestPerformanceOfFunction(const char* const name_of_f,
 
   // Compare |time_delta| to |max_time_delta|.
   // Using the aggregate time avoids loss of precision at the us range.
-  const SbTimeMonotonic max_time_delta = max_time_per_call * count_calls;
+  const int64_t max_time_delta = max_time_per_call * count_calls;
   EXPECT_LT(time_delta, max_time_delta);
 }
 

--- a/starboard/nplb/player_create_test.cc
+++ b/starboard/nplb/player_create_test.cc
@@ -19,13 +19,13 @@
 #include "starboard/common/media.h"
 #include "starboard/common/mutex.h"
 #include "starboard/common/optional.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/decode_target.h"
 #include "starboard/nplb/player_creation_param_helpers.h"
 #include "starboard/nplb/player_test_util.h"
 #include "starboard/player.h"
 #include "starboard/testing/fake_graphics_context_provider.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -93,12 +93,12 @@ class SbPlayerTest : public ::testing::Test {
   }
 
   void WaitForPlayerInitializedOrError(bool* error_occurred) {
-    const SbTime kWaitTimeout = kSbTimeSecond * 5;
+    const int64_t kWaitTimeout = 5'000'000LL;  // 5 seconds
 
     SB_DCHECK(error_occurred);
     *error_occurred = false;
 
-    const SbTimeMonotonic wait_end = SbTimeGetMonotonicNow() + kWaitTimeout;
+    const int64_t wait_end = CurrentMonotonicTime() + kWaitTimeout;
 
     for (;;) {
       ScopedLock scoped_lock(mutex_);
@@ -113,7 +113,7 @@ class SbPlayerTest : public ::testing::Test {
         return;
       }
 
-      auto now = SbTimeGetMonotonicNow();
+      auto now = CurrentMonotonicTime();
       if (now > wait_end) {
         break;
       }

--- a/starboard/nplb/player_get_audio_configuration_test.cc
+++ b/starboard/nplb/player_get_audio_configuration_test.cc
@@ -230,7 +230,7 @@ TEST_P(SbPlayerGetAudioConfigurationTest, MultipleSeeks) {
     ASSERT_EQ(initial_configs, configs_after_presenting);
   }
 
-  const SbTime seek_to_time = kSbTimeSecond;
+  const int64_t seek_to_time = 1'000'000;  // 1 second
   ASSERT_NO_FATAL_FAILURE(player_fixture.Seek(seek_to_time));
 
   std::vector<SbMediaAudioConfiguration> configs_after_seek;

--- a/starboard/nplb/player_test_fixture.h
+++ b/starboard/nplb/player_test_fixture.h
@@ -42,9 +42,9 @@ class SbPlayerTestFixture {
     struct AudioSamplesDescriptor {
       int start_index = 0;
       int samples_count = 0;
-      SbTime timestamp_offset = 0;
-      SbTime discarded_duration_from_front = 0;
-      SbTime discarded_duration_from_back = 0;
+      int64_t timestamp_offset = 0;
+      int64_t discarded_duration_from_front = 0;
+      int64_t discarded_duration_from_back = 0;
       bool is_end_of_stream = false;
     };
 
@@ -57,9 +57,9 @@ class SbPlayerTestFixture {
     GroupedSamples& AddAudioSamples(int start_index, int number_of_samples);
     GroupedSamples& AddAudioSamples(int start_index,
                                     int number_of_samples,
-                                    SbTime timestamp_offset,
-                                    SbTime discarded_duration_from_front,
-                                    SbTime discarded_duration_from_back);
+                                    int64_t timestamp_offset,
+                                    int64_t discarded_duration_from_front,
+                                    int64_t discarded_duration_from_back);
     GroupedSamples& AddAudioEOS();
     GroupedSamples& AddVideoSamples(int start_index, int number_of_samples);
     GroupedSamples& AddVideoEOS();
@@ -76,7 +76,7 @@ class SbPlayerTestFixture {
       testing::FakeGraphicsContextProvider* fake_graphics_context_provider);
   ~SbPlayerTestFixture();
 
-  void Seek(const SbTime time);
+  void Seek(const int64_t time);
   // Write audio and video samples. It waits for
   // |kSbPlayerDecoderStateNeedsData| internally. When writing EOS are
   // requested, the function will write EOS after all samples of the same type
@@ -86,22 +86,21 @@ class SbPlayerTestFixture {
   void WaitForPlayerPresenting();
   // Wait until kSbPlayerStateEndOfStream received.
   void WaitForPlayerEndOfStream();
-  SbTime GetCurrentMediaTime() const;
+  int64_t GetCurrentMediaTime() const;
 
-  void SetAudioWriteDuration(SbTime duration);
+  void SetAudioWriteDuration(int64_t duration);
 
   SbPlayer GetPlayer() const { return player_; }
   bool HasAudio() const { return audio_dmp_reader_; }
   bool HasVideo() const { return video_dmp_reader_; }
 
-  SbTime GetAudioSampleTimestamp(int index) const;
-  int ConvertDurationToAudioBufferCount(SbTime duration) const;
-  int ConvertDurationToVideoBufferCount(SbTime duration) const;
+  int64_t GetAudioSampleTimestamp(int index) const;
+  int ConvertDurationToAudioBufferCount(int64_t duration) const;
+  int ConvertDurationToVideoBufferCount(int64_t duration) const;
 
  private:
-  static constexpr SbTime kDefaultWaitForPlayerStateTimeout = 5 * kSbTimeSecond;
-  static constexpr SbTime kDefaultWaitForCallbackEventTimeout =
-      15 * kSbTimeMillisecond;
+  static constexpr int64_t kDefaultWaitForPlayerStateTimeout = 5'000'000LL;
+  static constexpr int64_t kDefaultWaitForCallbackEventTimeout = 15'000;
 
   typedef shared::starboard::player::video_dmp::VideoDmpReader VideoDmpReader;
 
@@ -160,9 +159,9 @@ class SbPlayerTestFixture {
 
   void WriteAudioSamples(int start_index,
                          int samples_to_write,
-                         SbTime timestamp_offset,
-                         SbTime discarded_duration_from_front,
-                         SbTime discarded_duration_from_back);
+                         int64_t timestamp_offset,
+                         int64_t discarded_duration_from_front,
+                         int64_t discarded_duration_from_back);
   void WriteVideoSamples(int start_index, int samples_to_write);
   void WriteEndOfStream(SbMediaType media_type);
 
@@ -172,16 +171,16 @@ class SbPlayerTestFixture {
   // * |player_state_set_| for SbPlayerState updates.
   // Executes a blocking wait for any new CallbackEvents to be enqueued.
   void WaitAndProcessNextEvent(
-      SbTime timeout = kDefaultWaitForCallbackEventTimeout);
+      int64_t timeout = kDefaultWaitForCallbackEventTimeout);
 
   // Waits for |kSbPlayerDecoderStateNeedsData| to be sent.
   void WaitForDecoderStateNeedsData(
-      const SbTime timeout = kDefaultWaitForCallbackEventTimeout);
+      const int64_t timeout = kDefaultWaitForCallbackEventTimeout);
 
   // Waits for desired player state update to be sent.
   void WaitForPlayerState(
       const SbPlayerState desired_state,
-      const SbTime timeout = kDefaultWaitForPlayerStateTimeout);
+      const int64_t timeout = kDefaultWaitForPlayerStateTimeout);
 
   // When the |output_mode| is decoding to texture, then this method is used to
   // advance the decoded frames.
@@ -214,9 +213,9 @@ class SbPlayerTestFixture {
   bool can_accept_more_video_data_ = false;
 
   // The duration of how far past the current playback position we will write
-  // audio samples.
-  SbTime audio_write_duration_ = 0;
-  SbTime last_written_audio_timestamp_ = 0;
+  // audio samples, in microseconds.
+  int64_t audio_write_duration_ = 0;
+  int64_t last_written_audio_timestamp_ = 0;
 
   // Set of received player state updates from the underlying player. This is
   // used to check that the state updates occur in a valid order during normal

--- a/starboard/nplb/player_test_util.cc
+++ b/starboard/nplb/player_test_util.cc
@@ -254,9 +254,9 @@ void CallSbPlayerWriteSamples(
     shared::starboard::player::video_dmp::VideoDmpReader* dmp_reader,
     int start_index,
     int number_of_samples_to_write,
-    SbTime timestamp_offset,
-    const std::vector<SbTime>& discarded_durations_from_front,
-    const std::vector<SbTime>& discarded_durations_from_back) {
+    int64_t timestamp_offset,
+    const std::vector<int64_t>& discarded_durations_from_front,
+    const std::vector<int64_t>& discarded_durations_from_back) {
   SB_DCHECK(start_index >= 0);
   SB_DCHECK(number_of_samples_to_write > 0);
 

--- a/starboard/nplb/player_test_util.h
+++ b/starboard/nplb/player_test_util.h
@@ -107,9 +107,9 @@ void CallSbPlayerWriteSamples(
     shared::starboard::player::video_dmp::VideoDmpReader* dmp_reader,
     int start_index,
     int number_of_samples_to_write,
-    SbTime timestamp_offset = 0,
-    const std::vector<SbTime>& discarded_durations_from_front = {},
-    const std::vector<SbTime>& discarded_durations_from_back = {});
+    int64_t timestamp_offset = 0,
+    const std::vector<int64_t>& discarded_durations_from_front = {},
+    const std::vector<int64_t>& discarded_durations_from_back = {});
 
 bool IsOutputModeSupported(SbPlayerOutputMode output_mode,
                            SbMediaAudioCodec audio_codec,

--- a/starboard/nplb/player_write_sample_test.cc
+++ b/starboard/nplb/player_write_sample_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "starboard/common/time.h"
 #include "starboard/nplb/drm_helpers.h"
 #include "starboard/nplb/player_creation_param_helpers.h"
 #include "starboard/nplb/player_test_fixture.h"
@@ -42,7 +43,7 @@ TEST_P(SbPlayerWriteSampleTest, SeekAndDestroy) {
   if (HasFatalFailure()) {
     return;
   }
-  ASSERT_NO_FATAL_FAILURE(player_fixture.Seek(kSbTimeSecond));
+  ASSERT_NO_FATAL_FAILURE(player_fixture.Seek(1'000'000));
 }
 
 TEST_P(SbPlayerWriteSampleTest, NoInput) {
@@ -135,17 +136,17 @@ TEST_P(SbPlayerWriteSampleTest, LimitedAudioInput) {
 
   // TODO: we simply set audio write duration to 0.5 second. Ideally, we should
   // set the audio write duration to 10 seconds if audio connectors are remote.
-  player_fixture.SetAudioWriteDuration(kSbTimeSecond / 2);
+  player_fixture.SetAudioWriteDuration(500'000);
 
   GroupedSamples samples;
   if (player_fixture.HasAudio()) {
     samples.AddAudioSamples(
-        0, player_fixture.ConvertDurationToAudioBufferCount(kSbTimeSecond));
+        0, player_fixture.ConvertDurationToAudioBufferCount(1'000'000));
     samples.AddAudioEOS();
   }
   if (player_fixture.HasVideo()) {
     samples.AddVideoSamples(
-        0, player_fixture.ConvertDurationToVideoBufferCount(kSbTimeSecond));
+        0, player_fixture.ConvertDurationToVideoBufferCount(1'000'000));
     samples.AddVideoEOS();
   }
 
@@ -172,7 +173,7 @@ TEST_P(SbPlayerWriteSampleTest, PartialAudio) {
     return;
   }
 
-  const SbTime kDurationToPlay = kSbTimeSecond;
+  const int64_t kDurationToPlay = 1'000'000;  // 1 second
   const float kSegmentSize = 0.3f;
 
   GroupedSamples samples;
@@ -185,11 +186,11 @@ TEST_P(SbPlayerWriteSampleTest, PartialAudio) {
   int total_buffers_to_write =
       player_fixture.ConvertDurationToAudioBufferCount(kDurationToPlay);
   for (int i = 0; i < total_buffers_to_write; i++) {
-    SbTime current_timestamp = player_fixture.GetAudioSampleTimestamp(i);
-    SbTime next_timestamp = player_fixture.GetAudioSampleTimestamp(i + 1);
-    SbTime buffer_duration = next_timestamp - current_timestamp;
-    SbTime segment_duration = buffer_duration * kSegmentSize;
-    SbTime written_duration = 0;
+    int64_t current_timestamp = player_fixture.GetAudioSampleTimestamp(i);
+    int64_t next_timestamp = player_fixture.GetAudioSampleTimestamp(i + 1);
+    int64_t buffer_duration = next_timestamp - current_timestamp;
+    int64_t segment_duration = buffer_duration * kSegmentSize;
+    int64_t written_duration = 0;
     while (written_duration < buffer_duration) {
       samples.AddAudioSamples(
           i, 1, written_duration, written_duration,
@@ -203,15 +204,15 @@ TEST_P(SbPlayerWriteSampleTest, PartialAudio) {
   ASSERT_NO_FATAL_FAILURE(player_fixture.Write(samples));
   ASSERT_NO_FATAL_FAILURE(player_fixture.WaitForPlayerPresenting());
 
-  SbTime start_system_time = SbTimeGetMonotonicNow();
-  SbTime start_media_time = player_fixture.GetCurrentMediaTime();
+  int64_t start_system_time = CurrentMonotonicTime();
+  int64_t start_media_time = player_fixture.GetCurrentMediaTime();
 
   ASSERT_NO_FATAL_FAILURE(player_fixture.WaitForPlayerEndOfStream());
 
-  SbTime end_system_time = SbTimeGetMonotonicNow();
-  SbTime end_media_time = player_fixture.GetCurrentMediaTime();
+  int64_t end_system_time = CurrentMonotonicTime();
+  int64_t end_media_time = player_fixture.GetCurrentMediaTime();
 
-  const SbTime kDurationDifferenceAllowance = 500 * kSbTimeMillisecond;
+  const int64_t kDurationDifferenceAllowance = 500'000;  // 500ms;
   EXPECT_NEAR(end_media_time, kDurationToPlay, kDurationDifferenceAllowance);
   EXPECT_NEAR(end_system_time - start_system_time + start_media_time,
               kDurationToPlay, kDurationDifferenceAllowance);
@@ -248,9 +249,9 @@ TEST_P(SbPlayerWriteSampleTest, PartialAudioDiscardAll) {
     return;
   }
 
-  const SbTime kDurationToPlay = kSbTimeSecond;
-  const SbTime kDurationPerWrite = 100 * kSbTimeMillisecond;
-  const SbTime kNumberOfBuffersToDiscard = 20;
+  const int64_t kDurationToPlay = 1'000'000;  // 1 second
+  const int64_t kDurationPerWrite = 100'000;  // 100ms
+  const int64_t kNumberOfBuffersToDiscard = 20;
 
   GroupedSamples samples;
   if (player_fixture.HasVideo()) {
@@ -260,13 +261,13 @@ TEST_P(SbPlayerWriteSampleTest, PartialAudioDiscardAll) {
   }
 
   int written_buffer_index = 0;
-  SbTime current_time_offset = 0;
+  int64_t current_time_offset = 0;
   int num_of_buffers_per_write =
       player_fixture.ConvertDurationToAudioBufferCount(kDurationPerWrite);
   int count = 0;
   while (current_time_offset < kDurationToPlay) {
-    const SbTime kDurationToDiscard =
-        count % 2 == 0 ? kSbTimeSecond : kSbTimeMax;
+    const int64_t kDurationToDiscard =
+        count % 2 == 0 ? 1'000'000LL : kSbInt64Max;
     count++;
     // Discard from front.
     for (int i = 0; i < kNumberOfBuffersToDiscard; i++) {
@@ -289,16 +290,16 @@ TEST_P(SbPlayerWriteSampleTest, PartialAudioDiscardAll) {
   ASSERT_NO_FATAL_FAILURE(player_fixture.Write(samples));
   ASSERT_NO_FATAL_FAILURE(player_fixture.WaitForPlayerPresenting());
 
-  SbTime start_system_time = SbTimeGetMonotonicNow();
-  SbTime start_media_time = player_fixture.GetCurrentMediaTime();
+  int64_t start_system_time = CurrentMonotonicTime();
+  int64_t start_media_time = player_fixture.GetCurrentMediaTime();
 
   ASSERT_NO_FATAL_FAILURE(player_fixture.WaitForPlayerEndOfStream());
 
-  SbTime end_system_time = SbTimeGetMonotonicNow();
-  SbTime end_media_time = player_fixture.GetCurrentMediaTime();
+  int64_t end_system_time = CurrentMonotonicTime();
+  int64_t end_media_time = player_fixture.GetCurrentMediaTime();
 
-  const SbTime kDurationDifferenceAllowance = 500 * kSbTimeMillisecond;
-  SbTime total_written_duration =
+  const int64_t kDurationDifferenceAllowance = 500'000;  // 500ms
+  int64_t total_written_duration =
       player_fixture.GetAudioSampleTimestamp(written_buffer_index);
   EXPECT_NEAR(end_media_time, total_written_duration,
               kDurationDifferenceAllowance);
@@ -333,7 +334,7 @@ class SecondaryPlayerTestThread : public AbstractTestThread {
       return;
     }
 
-    const SbTime kDurationToPlay = kSbTimeMillisecond * 200;
+    const int64_t kDurationToPlay = 200'000;  // 200ms
 
     GroupedSamples samples;
     if (player_fixture.HasAudio()) {

--- a/starboard/nplb/posix_compliance/posix_time_test.cc
+++ b/starboard/nplb/posix_compliance/posix_time_test.cc
@@ -1,0 +1,84 @@
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#if SB_API_VERSION >= 16
+
+#include "starboard/common/time.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace nplb {
+namespace {
+
+TEST(PosixTimeTest, TimeIsKindOfSane) {
+  int64_t now_usec = CurrentPosixTime();
+
+  // Now should be after 2024-01-01 UTC (the past).
+  int64_t past_usec = 1704067200000000LL;
+  EXPECT_GT(now_usec, past_usec);
+
+  // Now should be before 2044-01-01 UTC (the future).
+  int64_t future_usec = 2335219200000000LL;
+  EXPECT_LT(now_usec, future_usec);
+}
+
+TEST(PosixTimeTest, HasDecentResolution) {
+  const int kNumIterations = 100;
+  for (int i = 0; i < kNumIterations; ++i) {
+    int64_t timerStart = CurrentMonotonicTime();
+    int64_t initialTime = CurrentPosixTime();
+
+    // Spin tightly until time increments.
+    while (CurrentPosixTime() == initialTime) {
+      // If time hasn't changed within a second, that's beyond low resolution.
+      if ((CurrentMonotonicTime() - timerStart) >= 1'000'000) {
+        GTEST_FAIL() << "CurrentPosixTime() hasn't changed within a second.";
+        break;
+      }
+    }
+  }
+}
+
+TEST(PosixTimeTest, MonotonickIsMonotonic) {
+  const int kTrials = 100;
+  for (int trial = 0; trial < kTrials; ++trial) {
+    int64_t timerStart = CurrentPosixTime();
+    int64_t initialMonotonic = CurrentMonotonicTime();
+
+    // Spin tightly until time changes.
+    int64_t newMonotonic = 0;
+    while (true) {
+      newMonotonic = CurrentMonotonicTime();
+      if (initialMonotonic != newMonotonic) {
+        EXPECT_GT(newMonotonic, initialMonotonic);
+        EXPECT_LT(newMonotonic - initialMonotonic, 1'000'000);  // Less than 1s
+        return;
+      }
+
+      // If time hasn't increased within a second, our "high-resolution"
+      // monotonic timer is broken.
+      if (CurrentPosixTime() - timerStart >= 1'000'000) {
+        GTEST_FAIL() << "CurrentMonotonicTime() hasn't changed within a "
+                     << "second.";
+        return;
+      }
+    }
+  }
+}
+
+}  // namespace
+}  // namespace nplb
+}  // namespace starboard
+
+#endif  // SB_API_VERSION >= 16

--- a/starboard/nplb/socket_accept_test.cc
+++ b/starboard/nplb/socket_accept_test.cc
@@ -17,7 +17,6 @@
 
 #include "starboard/common/socket.h"
 #include "starboard/nplb/socket_helpers.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {

--- a/starboard/nplb/socket_is_connected_and_idle_test.cc
+++ b/starboard/nplb/socket_is_connected_and_idle_test.cc
@@ -16,6 +16,7 @@
 
 #include "starboard/common/log.h"
 #include "starboard/common/socket.h"
+#include "starboard/common/time.h"
 #include "starboard/nplb/socket_helpers.h"
 #include "starboard/thread.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -38,9 +39,9 @@ class PairSbSocketIsConnectedAndIdleTest
   SbSocketAddressType GetClientAddressType() { return GetParam().second; }
 };
 
-bool IsNonIdleWithin(SbSocket socket, SbTimeMonotonic timeout) {
-  SbTimeMonotonic deadline = SbTimeGetMonotonicNow() + timeout;
-  while (SbTimeGetMonotonicNow() < deadline) {
+bool IsNonIdleWithin(SbSocket socket, int64_t timeout) {
+  int64_t deadline = CurrentMonotonicTime() + timeout;
+  while (CurrentMonotonicTime() < deadline) {
     if (!SbSocketIsConnectedAndIdle(socket)) {
       return true;
     }

--- a/starboard/nplb/socket_join_multicast_group_test.cc
+++ b/starboard/nplb/socket_join_multicast_group_test.cc
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #include "starboard/common/socket.h"
+#include "starboard/common/time.h"
 #include "starboard/nplb/socket_helpers.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -83,16 +83,16 @@ TEST(SbSocketJoinMulticastGroupTest, SunnyDay) {
   }
 
   SbSocketAddress receive_address;
-  SbTimeMonotonic stop_time = SbTimeGetMonotonicNow() + kSbTimeSecond;
+  int64_t stop_time = CurrentMonotonicTime() + 1'000'000LL;
   while (true) {
     // Breaks the case where the test will hang in a loop when
     // SbSocketReceiveFrom() always returns kSbSocketPending.
-    ASSERT_LE(SbTimeGetMonotonicNow(), stop_time) << "Multicast timed out.";
+    ASSERT_LE(CurrentMonotonicTime(), stop_time) << "Multicast timed out.";
     int received = SbSocketReceiveFrom(
         receive_socket, buf, SB_ARRAY_SIZE_INT(buf), &receive_address);
     if (received < 0 &&
         SbSocketGetLastError(receive_socket) == kSbSocketPending) {
-      SbThreadSleep(kSbTimeMillisecond);
+      SbThreadSleep(1000);
       continue;
     }
     EXPECT_EQ(SB_ARRAY_SIZE_INT(kBuf), received);

--- a/starboard/nplb/socket_receive_from_test.cc
+++ b/starboard/nplb/socket_receive_from_test.cc
@@ -16,7 +16,6 @@
 
 #include "starboard/common/socket.h"
 #include "starboard/nplb/socket_helpers.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {

--- a/starboard/nplb/socket_set_options_test.cc
+++ b/starboard/nplb/socket_set_options_test.cc
@@ -14,7 +14,6 @@
 
 #include "starboard/common/socket.h"
 #include "starboard/nplb/socket_helpers.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -33,7 +32,7 @@ TEST_P(SbSocketSetOptionsTest, TryThemAllTCP) {
   EXPECT_TRUE(SbSocketSetReuseAddress(socket, true));
   EXPECT_TRUE(SbSocketSetReceiveBufferSize(socket, 16 * 1024));
   EXPECT_TRUE(SbSocketSetSendBufferSize(socket, 16 * 1024));
-  EXPECT_TRUE(SbSocketSetTcpKeepAlive(socket, true, 30 * kSbTimeSecond));
+  EXPECT_TRUE(SbSocketSetTcpKeepAlive(socket, true, 30'000'000));
   EXPECT_TRUE(SbSocketSetTcpNoDelay(socket, true));
 
   // Returns false on unsupported platforms, so we can't check the return value
@@ -58,8 +57,7 @@ TEST_P(SbSocketSetOptionsTest, RainyDayInvalidSocket) {
   EXPECT_FALSE(SbSocketSetReuseAddress(kSbSocketInvalid, true));
   EXPECT_FALSE(SbSocketSetReceiveBufferSize(kSbSocketInvalid, 16 * 1024));
   EXPECT_FALSE(SbSocketSetSendBufferSize(kSbSocketInvalid, 16 * 1024));
-  EXPECT_FALSE(
-      SbSocketSetTcpKeepAlive(kSbSocketInvalid, true, 30 * kSbTimeSecond));
+  EXPECT_FALSE(SbSocketSetTcpKeepAlive(kSbSocketInvalid, true, 30'000'000));
   EXPECT_FALSE(SbSocketSetTcpNoDelay(kSbSocketInvalid, true));
   EXPECT_FALSE(SbSocketSetTcpWindowScaling(kSbSocketInvalid, true));
 }

--- a/starboard/nplb/socket_waiter_wait_test.cc
+++ b/starboard/nplb/socket_waiter_wait_test.cc
@@ -20,7 +20,6 @@
 #include "starboard/nplb/thread_helpers.h"
 #include "starboard/socket_waiter.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {

--- a/starboard/nplb/socket_waiter_wait_timed_test.cc
+++ b/starboard/nplb/socket_waiter_wait_timed_test.cc
@@ -18,7 +18,6 @@
 #include "starboard/common/socket.h"
 #include "starboard/nplb/socket_helpers.h"
 #include "starboard/socket_waiter.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {

--- a/starboard/nplb/socket_waiter_wake_up_test.cc
+++ b/starboard/nplb/socket_waiter_wake_up_test.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "starboard/common/time.h"
 #include "starboard/nplb/socket_helpers.h"
 #include "starboard/nplb/thread_helpers.h"
 #include "starboard/socket_waiter.h"
@@ -125,10 +126,10 @@ TEST(SbSocketWaiterWakeUpTest, CallFromOtherThreadWakesUp) {
     context.waiter = waiter;
 
     SbThread thread = Spawn(&context, &WakeUpSleepEntryPoint);
-    SbTimeMonotonic start = SbTimeGetMonotonicNow();
+    int64_t start = CurrentMonotonicTime();
     context.semaphore.Put();
     TimedWait(waiter);
-    SbTimeMonotonic duration = SbTimeGetMonotonicNow() - start;
+    int64_t duration = CurrentMonotonicTime() - start;
     EXPECT_GT(kSocketTimeout * 2, duration);
     EXPECT_LE(kSocketTimeout, duration);
     Join(thread);

--- a/starboard/nplb/socket_wrapper_test.cc
+++ b/starboard/nplb/socket_wrapper_test.cc
@@ -16,7 +16,6 @@
 
 #include "starboard/common/socket.h"
 #include "starboard/nplb/socket_helpers.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {

--- a/starboard/nplb/system_get_path_test.cc
+++ b/starboard/nplb/system_get_path_test.cc
@@ -18,11 +18,11 @@
 
 #include "starboard/common/file.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/memory.h"
 #include "starboard/nplb/file_helpers.h"
 #include "starboard/system.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -206,7 +206,7 @@ TEST(SbSystemGetPath, ExecutableFileCreationTimeIsSound) {
   result = SbFileGetPathInfo(path.data(), &executable_file_info);
   ASSERT_TRUE(result);
 
-  SbTime now = SbTimeGetNow();
+  int64_t now = PosixTimeToWindowsTime(CurrentPosixTime());
   EXPECT_GT(now, executable_file_info.creation_time);
 }
 

--- a/starboard/nplb/thread_helpers.h
+++ b/starboard/nplb/thread_helpers.h
@@ -20,7 +20,6 @@
 #include "starboard/common/semaphore.h"
 #include "starboard/configuration.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #include "testing/gtest/include/gtest/gtest.h"
@@ -143,7 +142,7 @@ struct TakeThenSignalContext {
   TestSemaphore do_signal;
   SbMutex mutex;
   SbConditionVariable condition;
-  SbTime delay_after_signal;
+  int64_t delay_after_signal;
 };
 
 // AbstractTestThread that is a bare bones class wrapper around Starboard

--- a/starboard/nplb/thread_join_test.cc
+++ b/starboard/nplb/thread_join_test.cc
@@ -38,7 +38,7 @@ TEST(SbThreadLocalValueTest, ThreadJoinWaitsForFunctionRun) {
   struct LocalStatic {
     static void* ThreadEntryPoint(void* input) {
       int* value = static_cast<int*>(input);
-      static const SbTime kSleepTime = 10 * kSbTimeMillisecond;  // 10 ms.
+      static const int64_t kSleepTime = 10'000;  // 10 ms.
       // Wait to write the value to increase likelihood of catching
       // a race condition.
       SbThreadSleep(kSleepTime);

--- a/starboard/nplb/thread_sleep_test.cc
+++ b/starboard/nplb/thread_sleep_test.cc
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "starboard/common/time.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -21,7 +21,7 @@ namespace nplb {
 namespace {
 
 // Allow millisecond-level precision.
-const SbTime kPrecision = kSbTimeMillisecond;
+const int64_t kPrecision = 1000;  // 1ms
 
 TEST(SbThreadSleepTest, SunnyDay) {
   SbThreadSleep(0);
@@ -36,10 +36,10 @@ TEST(SbThreadSleepTest, SunnyDayAtLeastDelay) {
   const int64_t one = 1;
   for (int trial = 0; trial < kTrials; ++trial) {
     // This tests several delays, between about 15 to about 4 milliseconds.
-    const SbTime kDelay = kSbTimeSecond / (one << ((trial % 3) + 6));
-    SbTimeMonotonic start = SbTimeGetMonotonicNow();
+    const int64_t kDelay = 1'000'000LL / (one << ((trial % 3) + 6));
+    int64_t start = CurrentMonotonicTime();
     SbThreadSleep(kDelay);
-    SbTimeMonotonic end = SbTimeGetMonotonicNow();
+    int64_t end = CurrentMonotonicTime();
     EXPECT_LE(start + kDelay, end + kPrecision)
         << "Trial " << trial << ", kDelay=" << kDelay;
   }
@@ -48,10 +48,9 @@ TEST(SbThreadSleepTest, SunnyDayAtLeastDelay) {
 TEST(SbThreadSleepTest, RainyDayNegativeDuration) {
   const int kTrials = 128;
   for (int trial = 0; trial < kTrials; ++trial) {
-    SbTimeMonotonic start = SbTimeGetMonotonicNow();
-    SbThreadSleep(-kSbTimeSecond);
-    EXPECT_GT(kSbTimeSecond / 5, SbTimeGetMonotonicNow() - start)
-        << "Trial " << trial;
+    int64_t start = CurrentMonotonicTime();
+    SbThreadSleep(-1'000'000);
+    EXPECT_GT(200'000, CurrentMonotonicTime() - start) << "Trial " << trial;
   }
 }
 

--- a/starboard/nplb/thread_test.cc
+++ b/starboard/nplb/thread_test.cc
@@ -28,7 +28,7 @@ class TestRunThread : public Thread {
   TestRunThread() : Thread("TestThread"), finished_(false) {}
 
   void Run() override {
-    while (!WaitForJoin(kSbTimeMillisecond)) {
+    while (!WaitForJoin(1000)) {
     }
     finished_.store(true);
   }

--- a/starboard/nplb/thread_yield_test.cc
+++ b/starboard/nplb/thread_yield_test.cc
@@ -12,9 +12,9 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "starboard/common/time.h"
 #include "starboard/nplb/thread_helpers.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -35,8 +35,8 @@ void* YieldingEntryPoint(void* context) {
     SbThreadYield();
   }
 
-  SbTimeMonotonic* end_time = static_cast<SbTimeMonotonic*>(context);
-  *end_time = SbTimeGetMonotonicNow();
+  int64_t* end_time = static_cast<int64_t*>(context);
+  *end_time = CurrentMonotonicTime();
   return NULL;
 }
 
@@ -45,8 +45,8 @@ void* UnyieldingEntryPoint(void* context) {
     DoNotYield();
   }
 
-  SbTimeMonotonic* end_time = static_cast<SbTimeMonotonic*>(context);
-  *end_time = SbTimeGetMonotonicNow();
+  int64_t* end_time = static_cast<int64_t*>(context);
+  *end_time = CurrentMonotonicTime();
   return NULL;
 }
 
@@ -76,7 +76,7 @@ TEST(SbThreadYieldTest, SunnyDayRace) {
     // and enough data for the averages to be consistently divergent.
     const int64_t kRacers = 32;
     SbThread threads[kRacers];
-    SbTimeMonotonic end_times[kRacers] = {0};
+    int64_t end_times[kRacers] = {0};
     for (int i = 0; i < kRacers; ++i) {
       threads[i] = SbThreadCreate(
           0, kSbThreadNoPriority, affinity, true, NULL,
@@ -93,8 +93,8 @@ TEST(SbThreadYieldTest, SunnyDayRace) {
     }
 
     // On average, Unyielders should finish sooner than Yielders.
-    SbTimeMonotonic average_yielder = 0;
-    SbTimeMonotonic average_unyielder = 0;
+    int64_t average_yielder = 0;
+    int64_t average_unyielder = 0;
     const int64_t kRacersPerGroup = kRacers / 2;
     for (int i = 0; i < kRacers; ++i) {
       if (IsYielder(trial, i)) {

--- a/starboard/nplb/time_constants.h
+++ b/starboard/nplb/time_constants.h
@@ -15,6 +15,8 @@
 #ifndef STARBOARD_NPLB_TIME_CONSTANTS_H_
 #define STARBOARD_NPLB_TIME_CONSTANTS_H_
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 namespace starboard {
@@ -59,5 +61,7 @@ static const SbTime kTestTimePastWritten =
 
 }  // namespace nplb
 }  // namespace starboard
+
+#endif  // SB_API_VERSION < 16
 
 #endif  // STARBOARD_NPLB_TIME_CONSTANTS_H_

--- a/starboard/nplb/time_get_monotonic_now_test.cc
+++ b/starboard/nplb/time_get_monotonic_now_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/nplb/time_constants.h"
 #include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -50,3 +52,5 @@ TEST(SbTimeGetMonotonicNowTest, IsMonotonic) {
 }  // namespace
 }  // namespace nplb
 }  // namespace starboard
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/nplb/time_get_now_test.cc
+++ b/starboard/nplb/time_get_now_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/nplb/time_constants.h"
 #include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -58,3 +60,5 @@ TEST(SbTimeGetNowTest, HasDecentResolution) {
 }  // namespace
 }  // namespace nplb
 }  // namespace starboard
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/nplb/time_narrow_test.cc
+++ b/starboard/nplb/time_narrow_test.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 #include "testing/gtest/include/gtest/gtest.h"
@@ -37,3 +39,5 @@ TEST(SbTimeNarrowTest, SunnyDay) {
 }  // namespace
 }  // namespace nplb
 }  // namespace starboard
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/nplb/time_zone_get_current_test.cc
+++ b/starboard/nplb/time_zone_get_current_test.cc
@@ -13,7 +13,6 @@
 // limitations under the License.
 
 #include "starboard/extension/time_zone.h"
-#include "starboard/nplb/time_constants.h"
 #include "starboard/system.h"
 #include "starboard/time_zone.h"
 #include "testing/gtest/include/gtest/gtest.h"

--- a/starboard/nplb/time_zone_get_name_test.cc
+++ b/starboard/nplb/time_zone_get_name_test.cc
@@ -16,7 +16,6 @@
 
 #include "starboard/common/log.h"
 #include "starboard/extension/time_zone.h"
-#include "starboard/nplb/time_constants.h"
 #include "starboard/system.h"
 #include "starboard/time_zone.h"
 #include "testing/gmock/include/gmock/gmock.h"

--- a/starboard/nplb/vertical_video_test.cc
+++ b/starboard/nplb/vertical_video_test.cc
@@ -23,7 +23,6 @@
 #include "starboard/player.h"
 #include "starboard/shared/starboard/player/video_dmp_reader.h"
 #include "starboard/testing/fake_graphics_context_provider.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -130,10 +129,10 @@ TEST_P(VerticalVideoTest, WriteSamples) {
   SB_DCHECK(player_fixture.HasVideo());
   SB_DCHECK(player_fixture.HasAudio());
 
-  int audio_samples_to_write = player_fixture.ConvertDurationToAudioBufferCount(
-      200 * kSbTimeMillisecond);
-  int video_samples_to_write = player_fixture.ConvertDurationToVideoBufferCount(
-      200 * kSbTimeMillisecond);
+  int audio_samples_to_write =
+      player_fixture.ConvertDurationToAudioBufferCount(200'000);
+  int video_samples_to_write =
+      player_fixture.ConvertDurationToVideoBufferCount(200'000);
 
   GroupedSamples samples;
   samples.AddVideoSamples(0, audio_samples_to_write);

--- a/starboard/player.h
+++ b/starboard/player.h
@@ -25,7 +25,6 @@
 #include "starboard/drm.h"
 #include "starboard/export.h"
 #include "starboard/media.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 #include "starboard/window.h"
 
@@ -171,8 +170,8 @@ typedef struct SbPlayerSampleInfo {
   const void* buffer;
   // Size of the data pointed to by |buffer|.
   int buffer_size;
-  // The timestamp of the sample in SbTime.
-  SbTime timestamp;
+  // The timestamp of the sample in microseconds since Windows epoch UTC.
+  int64_t timestamp;
 
   // Points to an array of side data for the input, when available.
   SbPlayerSampleSideData* side_data;
@@ -202,14 +201,14 @@ typedef struct SbPlayerInfo2 {
 #endif  // SB_API_VERSION >= 15
   // The position of the playback head, as precisely as possible, in
   // microseconds.
-  SbTime current_media_timestamp;
+  int64_t current_media_timestamp;
 
   // The known duration of the currently playing media stream, in microseconds.
-  SbTime duration;
+  int64_t duration;
 
   // The result of getStartDate for the currently playing media stream, in
   // microseconds since the epoch of January 1, 1601 UTC.
-  SbTime start_date;
+  int64_t start_date;
 
   // The width of the currently displayed frame, in pixels, or 0 if not provided
   // by this player.
@@ -314,11 +313,11 @@ typedef void (*SbPlayerDeallocateSampleFunc)(SbPlayer player,
 #if SB_API_VERSION >= 15
 
 // The audio write duration when all the audio connectors are local.
-#define kSbPlayerWriteDurationLocal (kSbTimeSecond / 2)
+#define kSbPlayerWriteDurationLocal (1000000 / 2)  // 0.5 seconds
 
 // The audio write duration when at least one of the audio connectors are
 // remote.
-#define kSbPlayerWriteDurationRemote (kSbTimeSecond * 10)
+#define kSbPlayerWriteDurationRemote (1000000 * 10)  // 10 seconds
 
 #endif  // SB_API_VERSION >= 15
 
@@ -498,11 +497,11 @@ SB_EXPORT void SbPlayerDestroy(SbPlayer player);
 
 #if SB_API_VERSION >= 15
 SB_EXPORT void SbPlayerSeek(SbPlayer player,
-                            SbTime seek_to_timestamp,
+                            int64_t seek_to_timestamp,
                             int ticket);
 #else   // SB_API_VERSION >= 15
 SB_EXPORT void SbPlayerSeek2(SbPlayer player,
-                             SbTime seek_to_timestamp,
+                             int64_t seek_to_timestamp,
                              int ticket);
 #endif  // SB_API_VERSION >= 15
 

--- a/starboard/raspi/shared/application_dispmanx.cc
+++ b/starboard/raspi/shared/application_dispmanx.cc
@@ -26,9 +26,7 @@
 #include "starboard/memory.h"
 #include "starboard/raspi/shared/window_internal.h"
 #include "starboard/shared/linux/dev_input/dev_input.h"
-#include "starboard/shared/posix/time_internal.h"
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace raspi {
@@ -119,7 +117,7 @@ ApplicationDispmanx::PollNextSystemEvent() {
 }
 
 ::starboard::shared::starboard::Application::Event*
-ApplicationDispmanx::WaitForSystemEventWithTimeout(SbTime duration) {
+ApplicationDispmanx::WaitForSystemEventWithTimeout(int64_t duration) {
   SB_DCHECK(input_);
   Event* event = input_->WaitForSystemEventWithTimeout(duration);
   return event;

--- a/starboard/raspi/shared/application_dispmanx.h
+++ b/starboard/raspi/shared/application_dispmanx.h
@@ -68,7 +68,7 @@ class ApplicationDispmanx
   // --- QueueApplication overrides ---
   bool MayHaveSystemEvents() override;
   Event* PollNextSystemEvent() override;
-  Event* WaitForSystemEventWithTimeout(SbTime duration) override;
+  Event* WaitForSystemEventWithTimeout(int64_t duration) override;
   void WakeSystemEventWait() override;
 
   bool IsStartImmediate() override { return !HasPreloadSwitch(); }

--- a/starboard/raspi/shared/dispmanx_util.h
+++ b/starboard/raspi/shared/dispmanx_util.h
@@ -149,7 +149,7 @@ class DispmanxElement {
 class DispmanxVideoFrame
     : public starboard::shared::starboard::player::filter::VideoFrame {
  public:
-  DispmanxVideoFrame(SbTime time,
+  DispmanxVideoFrame(int64_t time,
                      DispmanxYUV420Resource* resource,
                      std::function<void(DispmanxYUV420Resource*)> release_cb)
       : VideoFrame(time), resource_(resource), release_cb_(release_cb) {

--- a/starboard/raspi/shared/open_max/open_max_component.cc
+++ b/starboard/raspi/shared/open_max/open_max_component.cc
@@ -83,7 +83,7 @@ void OpenMaxComponent::Flush() {
 int OpenMaxComponent::WriteData(const void* data,
                                 int size,
                                 DataType type,
-                                SbTime timestamp) {
+                                int64_t timestamp) {
   int offset = 0;
 
   while (offset < size) {

--- a/starboard/raspi/shared/open_max/open_max_component.h
+++ b/starboard/raspi/shared/open_max/open_max_component.h
@@ -22,7 +22,6 @@
 #include "starboard/common/mutex.h"
 #include "starboard/raspi/shared/open_max/open_max_component_base.h"
 #include "starboard/shared/internal_only.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace raspi {
@@ -53,7 +52,7 @@ class OpenMaxComponent : protected OpenMaxComponentBase {
   // Write data to the input buffer. Returns the number of bytes written or
   // -1 if an error occurred.
   // This will return immediately once no more buffers are available.
-  int WriteData(const void* data, int size, DataType type, SbTime timestamp);
+  int WriteData(const void* data, int size, DataType type, int64_t timestamp);
 
   // Write an empty buffer that is flagged as the end of the input stream.
   // This will block until a buffer is available.

--- a/starboard/raspi/shared/open_max/open_max_image_decode_component.cc
+++ b/starboard/raspi/shared/open_max/open_max_image_decode_component.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 
+#include "starboard/common/time.h"
 #include "starboard/configuration.h"
 #include "starboard/memory.h"
 #include "starboard/raspi/shared/open_max/decode_target_create.h"
@@ -85,7 +86,7 @@ SbDecodeTarget OpenMaxImageDecodeComponent::Decode(
     if (write_size > 0) {
       write_size =
           WriteData(reinterpret_cast<const uint8_t*>(data) + data_size_written,
-                    write_size, kDataEOS, SbTimeGetMonotonicNow());
+                    write_size, kDataEOS, CurrentMonotonicTime());
       SB_DCHECK(write_size >= 0);
       data_size_written += write_size;
     }
@@ -94,7 +95,7 @@ SbDecodeTarget OpenMaxImageDecodeComponent::Decode(
       break;
     } else if (write_size == 0 && output_size == 0) {
       // Wait for buffers to become available.
-      SbThreadSleep(kSbTimeMillisecond);
+      SbThreadSleep(1000);
     }
   }
 

--- a/starboard/raspi/shared/open_max/video_decoder.h
+++ b/starboard/raspi/shared/open_max/video_decoder.h
@@ -48,7 +48,7 @@ class VideoDecoder
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) override;
   size_t GetPrerollFrameCount() const override { return 1; }
-  SbTime GetPrerollTimeout() const override { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const override { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override { return 12; }
   void WriteInputBuffers(const InputBuffers& input_buffers) override;
   void WriteEndOfStream() override;

--- a/starboard/raspi/shared/video_renderer_sink_impl.cc
+++ b/starboard/raspi/shared/video_renderer_sink_impl.cc
@@ -17,7 +17,6 @@
 #include "starboard/common/log.h"
 #include "starboard/configuration.h"
 #include "starboard/shared/starboard/application.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace raspi {
@@ -62,9 +61,10 @@ void VideoRendererSinkImpl::SetBounds(int z_index,
 }
 
 void VideoRendererSinkImpl::Update() {
-  const SbTime kUpdateInterval = 5 * kSbTimeMillisecond;
+  const int64_t kUpdateIntervalUsec = 5'000;
   render_cb_(std::bind(&VideoRendererSinkImpl::DrawFrame, this, _1, _2));
-  Schedule(std::bind(&VideoRendererSinkImpl::Update, this), kUpdateInterval);
+  Schedule(std::bind(&VideoRendererSinkImpl::Update, this),
+           kUpdateIntervalUsec);
 }
 
 VideoRendererSinkImpl::DrawFrameStatus VideoRendererSinkImpl::DrawFrame(

--- a/starboard/shared/ffmpeg/ffmpeg_demuxer.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_demuxer.cc
@@ -17,7 +17,6 @@
 #include <memory>
 
 #include "starboard/shared/ffmpeg/ffmpeg_dispatch.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -34,11 +33,11 @@ CobaltExtensionDemuxerStatus FFmpegDemuxer_Seek(int64_t seek_time_us,
   return static_cast<FFmpegDemuxer*>(user_data)->Seek(seek_time_us);
 }
 
-SbTime FFmpegDemuxer_GetStartTime(void* user_data) {
+int64_t FFmpegDemuxer_GetStartTime(void* user_data) {
   return static_cast<FFmpegDemuxer*>(user_data)->GetStartTime();
 }
 
-SbTime FFmpegDemuxer_GetTimelineOffset(void* user_data) {
+int64_t FFmpegDemuxer_GetTimelineOffset(void* user_data) {
   return static_cast<FFmpegDemuxer*>(user_data)->GetTimelineOffset();
 }
 
@@ -72,7 +71,7 @@ bool FFmpegDemuxer_GetVideoConfig(
   return true;
 }
 
-SbTime FFmpegDemuxer_GetDuration(void* user_data) {
+int64_t FFmpegDemuxer_GetDuration(void* user_data) {
   return static_cast<FFmpegDemuxer*>(user_data)->GetDuration();
 }
 

--- a/starboard/shared/ffmpeg/ffmpeg_demuxer.h
+++ b/starboard/shared/ffmpeg/ffmpeg_demuxer.h
@@ -47,9 +47,9 @@ class FFmpegDemuxer {
       const = 0;
   virtual const CobaltExtensionDemuxerVideoDecoderConfig& GetVideoConfig()
       const = 0;
-  virtual SbTime GetDuration() const = 0;
-  virtual SbTime GetStartTime() const = 0;
-  virtual SbTime GetTimelineOffset() const = 0;
+  virtual int64_t GetDuration() const = 0;        // microseconds
+  virtual int64_t GetStartTime() const = 0;       // microseconds
+  virtual int64_t GetTimelineOffset() const = 0;  // microseconds
   virtual void Read(CobaltExtensionDemuxerStreamType type,
                     CobaltExtensionDemuxerReadCB read_cb,
                     void* read_cb_user_data) = 0;

--- a/starboard/shared/ffmpeg/ffmpeg_demuxer_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_demuxer_impl.cc
@@ -353,13 +353,13 @@ int64_t AVIOSeekOperation(void* opaque, int64_t offset, int whence) {
 
 int64_t ConvertFromTimeBaseToMicros(AVRational time_base, int64_t timestamp) {
   return FFmpegDemuxer::GetDispatch()->av_rescale_rnd(
-      timestamp, time_base.num * kSbTimeSecond, time_base.den,
+      timestamp, time_base.num * 1'000'000LL, time_base.den,
       static_cast<int>(AV_ROUND_NEAR_INF));
 }
 
 int64_t ConvertMicrosToTimeBase(AVRational time_base, int64_t timestamp_us) {
   return FFmpegDemuxer::GetDispatch()->av_rescale_rnd(
-      timestamp_us, time_base.den, time_base.num * kSbTimeSecond,
+      timestamp_us, time_base.den, time_base.num * 1'000'000LL,
       static_cast<int>(AV_ROUND_NEAR_INF));
 }
 
@@ -618,15 +618,15 @@ FFmpegDemuxerImpl<FFMPEG>::GetVideoConfig() const {
   return video_config_;
 }
 
-SbTime FFmpegDemuxerImpl<FFMPEG>::GetDuration() const {
+int64_t FFmpegDemuxerImpl<FFMPEG>::GetDuration() const {
   return duration_us_;
 }
 
-SbTime FFmpegDemuxerImpl<FFMPEG>::GetStartTime() const {
+int64_t FFmpegDemuxerImpl<FFMPEG>::GetStartTime() const {
   return start_time_;
 }
 
-SbTime FFmpegDemuxerImpl<FFMPEG>::GetTimelineOffset() const {
+int64_t FFmpegDemuxerImpl<FFMPEG>::GetTimelineOffset() const {
   return timeline_offset_us_;
 }
 

--- a/starboard/shared/ffmpeg/ffmpeg_demuxer_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_demuxer_impl.h
@@ -23,7 +23,6 @@
 #include "starboard/shared/ffmpeg/ffmpeg_common.h"
 #include "starboard/shared/ffmpeg/ffmpeg_demuxer.h"
 #include "starboard/shared/ffmpeg/ffmpeg_demuxer_impl_interface.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -54,9 +53,9 @@ class FFmpegDemuxerImpl<FFMPEG> : public FFmpegDemuxer {
       const override;
   const CobaltExtensionDemuxerVideoDecoderConfig& GetVideoConfig()
       const override;
-  SbTime GetDuration() const override;
-  SbTime GetStartTime() const override;
-  SbTime GetTimelineOffset() const override;
+  int64_t GetDuration() const override;
+  int64_t GetStartTime() const override;
+  int64_t GetTimelineOffset() const override;
   void Read(CobaltExtensionDemuxerStreamType type,
             CobaltExtensionDemuxerReadCB read_cb,
             void* read_cb_user_data) override;

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
@@ -60,7 +60,7 @@ class VideoDecoderImpl<FFMPEG> : public VideoDecoder {
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) override;
   size_t GetPrerollFrameCount() const override { return 8; }
-  SbTime GetPrerollTimeout() const override { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const override { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override { return 12; }
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;

--- a/starboard/shared/libaom/aom_video_decoder.cc
+++ b/starboard/shared/libaom/aom_video_decoder.cc
@@ -195,7 +195,7 @@ void VideoDecoder::DecodeOneBuffer(
 
   SB_DCHECK(context_);
 
-  SbTime timestamp = input_buffer->timestamp();
+  int64_t timestamp = input_buffer->timestamp();
   aom_codec_err_t status = aom_codec_decode(
       context_.get(), input_buffer->data(), input_buffer->size(), &timestamp);
   if (status != AOM_CODEC_OK) {

--- a/starboard/shared/libaom/aom_video_decoder.h
+++ b/starboard/shared/libaom/aom_video_decoder.h
@@ -45,7 +45,7 @@ class VideoDecoder : public starboard::player::filter::VideoDecoder,
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) override;
   size_t GetPrerollFrameCount() const override { return 8; }
-  SbTime GetPrerollTimeout() const override { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const override { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override { return 12; }
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;

--- a/starboard/shared/libdav1d/dav1d_video_decoder.h
+++ b/starboard/shared/libdav1d/dav1d_video_decoder.h
@@ -46,7 +46,7 @@ class VideoDecoder : public starboard::player::filter::VideoDecoder,
 
   // TODO: Verify if these values are correct.
   size_t GetPrerollFrameCount() const override { return 8; }
-  SbTime GetPrerollTimeout() const override { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const override { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override { return 12; }
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;
@@ -68,7 +68,7 @@ class VideoDecoder : public starboard::player::filter::VideoDecoder,
   void InitializeCodec();
   void TeardownCodec();
   void DecodeOneBuffer(const scoped_refptr<InputBuffer>& input_buffer);
-  void DecodeEndOfStream(SbTime timeout);
+  void DecodeEndOfStream(int64_t timeout);
 
   // Sends all available decoded frames from dav1d for outputting. Returns the
   // number of frames decoded. The output argument tracks whether an

--- a/starboard/shared/libde265/de265_video_decoder.cc
+++ b/starboard/shared/libde265/de265_video_decoder.cc
@@ -180,7 +180,7 @@ void VideoDecoder::DecodeOneBuffer(
 
   SB_DCHECK(context_);
 
-  SbTime timestamp = input_buffer->timestamp();
+  int64_t timestamp = input_buffer->timestamp();
   de265_error status = de265_push_data(context_, input_buffer->data(),
                                        input_buffer->size(), timestamp, 0);
   if (status != DE265_OK) {

--- a/starboard/shared/libde265/de265_video_decoder.h
+++ b/starboard/shared/libde265/de265_video_decoder.h
@@ -47,7 +47,7 @@ class VideoDecoder : public starboard::player::filter::VideoDecoder,
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) override;
   size_t GetPrerollFrameCount() const override { return 8; }
-  SbTime GetPrerollTimeout() const override { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const override { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override { return 12; }
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;

--- a/starboard/shared/libevent/socket_waiter_internal.h
+++ b/starboard/shared/libevent/socket_waiter_internal.h
@@ -38,7 +38,7 @@ struct SbSocketWaiterPrivate {
            bool persistent);
   bool Remove(SbSocket socket);
   void Wait();
-  SbSocketWaiterResult WaitTimed(SbTime duration);
+  SbSocketWaiterResult WaitTimed(int64_t duration_usec);
   void WakeUp(bool timeout);
 
  private:

--- a/starboard/shared/libevent/socket_waiter_wait_timed.cc
+++ b/starboard/shared/libevent/socket_waiter_wait_timed.cc
@@ -17,7 +17,7 @@
 #include "starboard/shared/libevent/socket_waiter_internal.h"
 
 SbSocketWaiterResult SbSocketWaiterWaitTimed(SbSocketWaiter waiter,
-                                             SbTime duration) {
+                                             int64_t duration) {
   if (!SbSocketWaiterIsValid(waiter)) {
     return kSbSocketWaiterResultInvalid;
   }

--- a/starboard/shared/libvpx/vpx_video_decoder.cc
+++ b/starboard/shared/libvpx/vpx_video_decoder.cc
@@ -194,7 +194,7 @@ void VideoDecoder::DecodeOneBuffer(
 
   SB_DCHECK(context_);
 
-  SbTime timestamp = input_buffer->timestamp();
+  int64_t timestamp = input_buffer->timestamp();
   vpx_codec_err_t status =
       vpx_codec_decode(context_.get(), input_buffer->data(),
                        input_buffer->size(), &timestamp, 0);

--- a/starboard/shared/libvpx/vpx_video_decoder.h
+++ b/starboard/shared/libvpx/vpx_video_decoder.h
@@ -47,7 +47,7 @@ class VideoDecoder : public starboard::player::filter::VideoDecoder,
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) override;
   size_t GetPrerollFrameCount() const override { return 8; }
-  SbTime GetPrerollTimeout() const override { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const override { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override { return 12; }
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;

--- a/starboard/shared/linux/dev_input/dev_input.h
+++ b/starboard/shared/linux/dev_input/dev_input.h
@@ -17,7 +17,6 @@
 
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/application.h"
-#include "starboard/time.h"
 #include "starboard/window.h"
 
 namespace starboard {
@@ -36,10 +35,10 @@ class DevInput {
   // responsible for deleting the returned event.
   virtual Event* PollNextSystemEvent() = 0;
 
-  // Waits for an event until the timeout |time| runs out. If an event occurs in
-  // this time, it is returned, otherwise NULL is returned. The caller is
-  // responsible for deleting the returned event.
-  virtual Event* WaitForSystemEventWithTimeout(SbTime duration) = 0;
+  // Waits for an event until the timeout |duration| (in microseconds) runs out.
+  // If an event occurs in this time, it is returned, otherwise NULL is
+  // returned. The caller is responsible for deleting the returned event.
+  virtual Event* WaitForSystemEventWithTimeout(int64_t duration) = 0;
 
   // Wakes up any thread waiting within a call to
   // WaitForSystemEventWithTimeout().

--- a/starboard/shared/modular/posix_time_wrappers.h
+++ b/starboard/shared/modular/posix_time_wrappers.h
@@ -89,8 +89,13 @@ struct musl_timeval {
   int64_t /* time_t */ tv_sec;
   int64_t /* suseconds_t */ tv_usec;
 };
+// Copying macro constants from //third_party/musl/include/time.h
+#define MUSL_CLOCK_REALTIME 0
+#define MUSL_CLOCK_MONOTONIC 1
+#define MUSL_CLOCK_PROCESS_CPUTIME_ID 2
+#define MUSL_CLOCK_THREAD_CPUTIME_ID 3
 
-SB_EXPORT int __wrap_clock_gettime(int /*clockid_t */ clock_id,
+SB_EXPORT int __wrap_clock_gettime(int /*clockid_t */ musl_clock_id,
                                    struct musl_timespec* mts);
 
 SB_EXPORT int __wrap_gettimeofday(struct musl_timeval* mtv, void* tzp);

--- a/starboard/shared/openh264/openh264_video_decoder.h
+++ b/starboard/shared/openh264/openh264_video_decoder.h
@@ -50,7 +50,7 @@ class VideoDecoder : public starboard::player::filter::VideoDecoder,
 
   // TODO: Verify if these values are correct.
   size_t GetPrerollFrameCount() const override { return 8; }
-  SbTime GetPrerollTimeout() const override { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const override { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override { return 12; }
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;

--- a/starboard/shared/posix/impl/file_get_info.h
+++ b/starboard/shared/posix/impl/file_get_info.h
@@ -20,8 +20,7 @@
 #include "starboard/file.h"
 
 #include <sys/stat.h>
-
-#include "starboard/shared/posix/time_internal.h"
+#include <time.h>
 
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/posix/impl/file_impl.h"
@@ -42,11 +41,11 @@ bool FileGetInfo(SbFile file, SbFileInfo* out_info) {
     return false;
   }
 
-  out_info->creation_time = FromTimeT(stat.st_ctime);
+  out_info->creation_time = TimeTToWindowsUsec(stat.st_ctime);
   out_info->is_directory = S_ISDIR(stat.st_mode);
   out_info->is_symbolic_link = S_ISLNK(stat.st_mode);
-  out_info->last_accessed = FromTimeT(stat.st_atime);
-  out_info->last_modified = FromTimeT(stat.st_mtime);
+  out_info->last_accessed = TimeTToWindowsUsec(stat.st_atime);
+  out_info->last_modified = TimeTToWindowsUsec(stat.st_mtime);
   out_info->size = stat.st_size;
   return true;
 }

--- a/starboard/shared/posix/impl/file_get_path_info.h
+++ b/starboard/shared/posix/impl/file_get_path_info.h
@@ -20,8 +20,7 @@
 #include "starboard/file.h"
 
 #include <sys/stat.h>
-
-#include "starboard/shared/posix/time_internal.h"
+#include <time.h>
 
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/posix/impl/file_impl.h"
@@ -42,11 +41,11 @@ bool FileGetPathInfo(const char* path, SbFileInfo* out_info) {
     return false;
   }
 
-  out_info->creation_time = FromTimeT(file_info.st_ctime);
+  out_info->creation_time = TimeTToWindowsUsec(file_info.st_ctime);
   out_info->is_directory = S_ISDIR(file_info.st_mode);
   out_info->is_symbolic_link = S_ISLNK(file_info.st_mode);
-  out_info->last_accessed = FromTimeT(file_info.st_atime);
-  out_info->last_modified = FromTimeT(file_info.st_mtime);
+  out_info->last_accessed = TimeTToWindowsUsec(file_info.st_atime);
+  out_info->last_modified = TimeTToWindowsUsec(file_info.st_mtime);
   out_info->size = file_info.st_size;
   return true;
 }

--- a/starboard/shared/posix/impl/file_impl.h
+++ b/starboard/shared/posix/impl/file_impl.h
@@ -17,6 +17,7 @@
 #ifndef STARBOARD_SHARED_POSIX_IMPL_FILE_IMPL_H_
 #define STARBOARD_SHARED_POSIX_IMPL_FILE_IMPL_H_
 
+#include "starboard/common/time.h"
 #include "starboard/configuration.h"
 #include "starboard/file.h"
 
@@ -25,5 +26,20 @@
 // Ensure SbFile is typedef'd to a SbFilePrivate* that has a descriptor field.
 SB_COMPILE_ASSERT(sizeof(((SbFile)0)->descriptor),
                   SbFilePrivate_must_have_descriptor);
+
+namespace starboard {
+namespace shared {
+namespace posix {
+namespace impl {
+
+inline int64_t TimeTToWindowsUsec(time_t time) {
+  int64_t posix_usec = static_cast<int64_t>(time) * 1000000;
+  return PosixTimeToWindowsTime(posix_usec);
+}
+
+}  // namespace impl
+}  // namespace posix
+}  // namespace shared
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_POSIX_IMPL_FILE_IMPL_H_

--- a/starboard/shared/posix/socket_set_tcp_keep_alive.cc
+++ b/starboard/shared/posix/socket_set_tcp_keep_alive.cc
@@ -21,14 +21,14 @@
 
 namespace sbposix = starboard::shared::posix;
 
-bool SbSocketSetTcpKeepAlive(SbSocket socket, bool value, SbTime period) {
+bool SbSocketSetTcpKeepAlive(SbSocket socket, bool value, int64_t period) {
   bool result = sbposix::SetBooleanSocketOption(
       socket, SOL_SOCKET, SO_KEEPALIVE, "SO_KEEPALIVE", value);
   if (!result) {
     return false;
   }
 
-  int period_seconds = static_cast<int>(period / kSbTimeSecond);
+  int period_seconds = static_cast<int>(period / 1'000'000);
   result = sbposix::SetIntegerSocketOption(socket, SOL_TCP, TCP_KEEPIDLE,
                                            "TCP_KEEPIDLE", period_seconds);
   if (!result) {

--- a/starboard/shared/posix/thread_sleep.cc
+++ b/starboard/shared/posix/thread_sleep.cc
@@ -16,13 +16,11 @@
 
 #include <unistd.h>
 
-#include "starboard/time.h"
-
-void SbThreadSleep(SbTime duration) {
+void SbThreadSleep(int64_t duration) {
   if (duration <= 0) {
     return;
   }
 
-  // SbTime is microseconds, so this is easy.
+  // duration is microseconds, so this is easy.
   usleep(duration);
 }

--- a/starboard/shared/posix/time_get_monotonic_now.cc
+++ b/starboard/shared/posix/time_get_monotonic_now.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 #include <time.h>
@@ -28,3 +30,5 @@ SbTimeMonotonic SbTimeGetMonotonicNow() {
 
   return FromTimespecDelta(&time);
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/posix/time_get_now.cc
+++ b/starboard/shared/posix/time_get_now.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 #include <sys/time.h>
@@ -28,3 +30,5 @@ SbTime SbTimeGetNow() {
 
   return FromTimeval(&time);
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/posix/time_internal.h
+++ b/starboard/shared/posix/time_internal.h
@@ -15,19 +15,17 @@
 #ifndef STARBOARD_SHARED_POSIX_TIME_INTERNAL_H_
 #define STARBOARD_SHARED_POSIX_TIME_INTERNAL_H_
 
+#if SB_API_VERSION < 16
+
 #include <sys/time.h>
 #include <time.h>
 
 #include "starboard/shared/internal_only.h"
 #include "starboard/time.h"
 
-namespace {
+namespace {  // NOLINT(build/namespaces_headers)
 const int64_t kMillisecondsPerSecond = kSbTimeSecond / kSbTimeMillisecond;
 const int64_t kNanosecondsPerMicrosecond = 1000;
-
-inline SbTime FromMilliseconds(int64_t ms) {
-  return ms * kSbTimeMillisecond;
-}
 
 inline SbTime FromSeconds(int64_t secs) {
   return secs * kSbTimeSecond;
@@ -43,25 +41,11 @@ inline int64_t FromTimespecDelta(struct timespec* time) {
          FromNanoseconds(static_cast<int64_t>(time->tv_nsec));
 }
 
-// Converts the number of microseconds in |time_us| into a POSIX timespec,
-// placing the result in |out_time|.
-inline void ToTimespec(struct timespec* out_time, int64_t time_us) {
-  out_time->tv_sec = time_us / kSbTimeSecond;
-  int64_t remainder_us = time_us - (out_time->tv_sec * kSbTimeSecond);
-  out_time->tv_nsec = remainder_us * kNanosecondsPerMicrosecond;
-}
-
 // Converts a timeval (relative to POSIX epoch) into microseconds since the
 // Windows epoch (1601).
 inline int64_t FromTimeval(const struct timeval* time) {
   return SbTimeFromPosix(FromSeconds(static_cast<int64_t>(time->tv_sec)) +
                          time->tv_usec);
-}
-
-// Converts a number of microseconds into a timeval.
-inline void ToTimevalDuration(int64_t microseconds, struct timeval* out_time) {
-  out_time->tv_sec = microseconds / kSbTimeSecond;
-  out_time->tv_usec = microseconds % kSbTimeSecond;
 }
 
 // Converts a time_t (relative to POSIX epoch) into microseconds since the
@@ -70,5 +54,7 @@ inline int64_t FromTimeT(time_t time) {
   return SbTimeFromPosix(FromSeconds(time));
 }
 }  // namespace
+
+#endif  // SB_API_VERSION < 16
 
 #endif  // STARBOARD_SHARED_POSIX_TIME_INTERNAL_H_

--- a/starboard/shared/pthread/condition_variable_wait_timed.cc
+++ b/starboard/shared/pthread/condition_variable_wait_timed.cc
@@ -19,7 +19,6 @@
 #include <time.h>
 
 #include "starboard/common/time.h"
-#include "starboard/shared/posix/time_internal.h"
 #include "starboard/shared/pthread/is_success.h"
 #include "starboard/shared/pthread/types_internal.h"
 #include "starboard/shared/starboard/lazy_initialization_internal.h"
@@ -39,21 +38,22 @@ SbConditionVariableResult SbConditionVariableWaitTimed(
   }
 
 #if !SB_HAS_QUIRK(NO_CONDATTR_SETCLOCK_SUPPORT)
-  int64_t timeout_time = starboard::CurrentMonotonicTime() + timeout;
+  int64_t timeout_time_usec = starboard::CurrentMonotonicTime() + timeout;
 #else   // !SB_HAS_QUIRK(NO_CONDATTR_SETCLOCK_SUPPORT)
-  int64_t timeout_time = starboard::CurrentPosixTime() + timeout;
+  int64_t timeout_time_usec = starboard::CurrentPosixTime() + timeout;
 #endif  // !SB_HAS_QUIRK(NO_CONDATTR_SETCLOCK_SUPPORT)
 
   // Detect overflow if timeout is near kSbInt64Max. Since timeout can't be
   // negative at this point, if it goes negative after adding now, we know we've
   // gone over. Especially posix now, which has a 400 year advantage over
   // Chromium (Windows) now.
-  if (timeout_time < 0) {
-    timeout_time = kSbInt64Max;
+  if (timeout_time_usec < 0) {
+    timeout_time_usec = kSbInt64Max;
   }
 
   struct timespec timeout_ts;
-  ToTimespec(&timeout_ts, timeout_time);
+  timeout_ts.tv_sec = timeout_time_usec / 1'000'000;
+  timeout_ts.tv_nsec = (timeout_time_usec % 1'000'000) * 1000;
 
   if (!EnsureInitialized(
           &(SB_PTHREAD_INTERNAL_CONDITION(condition)->initialized_state))) {

--- a/starboard/shared/signal/suspend_signals.cc
+++ b/starboard/shared/signal/suspend_signals.cc
@@ -117,7 +117,7 @@ class SignalHandlerThread : public ::starboard::Thread {
 
   void Run() override {
     SignalMask(kAllSignals, SIG_UNBLOCK);
-    while (!WaitForJoin(kSbTimeMax)) {
+    while (!WaitForJoin(kSbInt64Max)) {
     }
   }
 };

--- a/starboard/shared/starboard/audio_sink/audio_sink_internal.cc
+++ b/starboard/shared/starboard/audio_sink/audio_sink_internal.cc
@@ -37,7 +37,7 @@ const char kUseStubAudioSink[] = "use_stub_audio_sink";
 
 void WrapConsumeFramesFunc(SbAudioSinkConsumeFramesFunc sb_consume_frames_func,
                            int frames_consumed,
-                           SbTime frames_consumed_at,
+                           int64_t frames_consumed_at,
                            void* context) {
   SB_UNREFERENCED_PARAMETER(frames_consumed_at);
   sb_consume_frames_func(frames_consumed, context);

--- a/starboard/shared/starboard/audio_sink/audio_sink_internal.h
+++ b/starboard/shared/starboard/audio_sink/audio_sink_internal.h
@@ -32,7 +32,7 @@ struct SbAudioSinkPrivate {
                             void* context);
 
   typedef std::function<
-      void(int frames_consumed, SbTime frames_consumed_at, void* context)>
+      void(int frames_consumed, int64_t frames_consumed_at, void* context)>
       ConsumeFramesFunc;
 
   class Type {

--- a/starboard/shared/starboard/audio_sink/stub_audio_sink_type.cc
+++ b/starboard/shared/starboard/audio_sink/stub_audio_sink_type.cc
@@ -17,10 +17,10 @@
 #include <algorithm>
 
 #include "starboard/common/mutex.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -113,12 +113,11 @@ void StubAudioSink::AudioThreadFunc() {
       int frames_to_consume =
           std::min(kMaxFramesToConsumePerRequest, frames_in_buffer);
 
-      SbThreadSleep(frames_to_consume * kSbTimeSecond / sampling_frequency_hz_);
-      consume_frames_func_(frames_to_consume, SbTimeGetMonotonicNow(),
-                           context_);
+      SbThreadSleep(frames_to_consume * 1'000'000LL / sampling_frequency_hz_);
+      consume_frames_func_(frames_to_consume, CurrentMonotonicTime(), context_);
     } else {
       // Wait for five millisecond if we are paused.
-      SbThreadSleep(kSbTimeMillisecond * 5);
+      SbThreadSleep(5'000);
     }
   }
 }

--- a/starboard/shared/starboard/event_schedule.cc
+++ b/starboard/shared/starboard/event_schedule.cc
@@ -18,7 +18,7 @@
 
 SbEventId SbEventSchedule(SbEventCallback callback,
                           void* context,
-                          SbTime delay) {
+                          int64_t delay) {
   return starboard::shared::starboard::Application::Get()->Schedule(
       callback, context, delay);
 }

--- a/starboard/shared/starboard/media/media_get_buffer_garbage_collection_duration_threshold.cc
+++ b/starboard/shared/starboard/media/media_get_buffer_garbage_collection_duration_threshold.cc
@@ -14,6 +14,6 @@
 
 #include "starboard/media.h"
 
-SbTime SbMediaGetBufferGarbageCollectionDurationThreshold() {
-  return 170 * kSbTimeSecond;
+int64_t SbMediaGetBufferGarbageCollectionDurationThreshold() {
+  return 170'000'000;  // 170 seconds
 }

--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -452,18 +452,18 @@ bool IsAudioSampleInfoSubstantiallyDifferent(const AudioStreamInfo& left,
          left.audio_specific_config != right.audio_specific_config;
 }
 
-int AudioDurationToFrames(SbTime duration, int samples_per_second) {
+int AudioDurationToFrames(int64_t duration, int samples_per_second) {
   SB_DCHECK(samples_per_second > 0)
       << "samples_per_second has to be greater than 0";
-  // The same as `frames = (duration / kSbTimeSecond) * samples_per_second`,
+  // The same as `frames = (duration / 1'000'000) * samples_per_second`,
   // switch order to avoid precision loss due to integer division.
-  return duration * samples_per_second / kSbTimeSecond;
+  return duration * samples_per_second / 1'000'000LL;
 }
 
-SbTime AudioFramesToDuration(int frames, int samples_per_second) {
+int64_t AudioFramesToDuration(int frames, int samples_per_second) {
   SB_DCHECK(samples_per_second > 0)
       << "samples_per_second has to be greater than 0";
-  return frames * kSbTimeSecond / std::max(samples_per_second, 1);
+  return frames * 1'000'000LL / std::max(samples_per_second, 1);
 }
 
 }  // namespace media

--- a/starboard/shared/starboard/media/media_util.h
+++ b/starboard/shared/starboard/media/media_util.h
@@ -83,8 +83,8 @@ struct AudioSampleInfo {
   // `SbMediaAudioSampleInfo` defined in `media.h`.  Please refer to the comment
   // of `SbMediaAudioSampleInfo` for more details.
   AudioStreamInfo stream_info;
-  SbTime discarded_duration_from_front = 0;
-  SbTime discarded_duration_from_back = 0;
+  int64_t discarded_duration_from_front = 0;  // in microseconds.
+  int64_t discarded_duration_from_back = 0;   // in microseconds.
 };
 
 // Encapsulates all information contained in `SbMediaVideoStreamInfo`.  It
@@ -164,8 +164,9 @@ std::string GetMixedRepresentation(const uint8_t* data,
 bool IsAudioSampleInfoSubstantiallyDifferent(const AudioStreamInfo& left,
                                              const AudioStreamInfo& right);
 
-int AudioDurationToFrames(SbTime duration, int samples_per_second);
-SbTime AudioFramesToDuration(int frames, int samples_per_second);
+// Durations are in microseconds.
+int AudioDurationToFrames(int64_t duration, int samples_per_second);
+int64_t AudioFramesToDuration(int frames, int samples_per_second);
 
 }  // namespace media
 }  // namespace starboard

--- a/starboard/shared/starboard/media/media_util_test.cc
+++ b/starboard/shared/starboard/media/media_util_test.cc
@@ -299,16 +299,16 @@ TEST(VideoSampleInfoTest, CobaltExtensionEnhancedAudioMediaVideoSampleInfo) {
 
 TEST(MediaUtilTest, AudioDurationToFrames) {
   EXPECT_EQ(AudioDurationToFrames(0, 48000), 0);
-  EXPECT_EQ(AudioDurationToFrames(kSbTimeSecond / 2, 48000), 48000 / 2);
-  EXPECT_EQ(AudioDurationToFrames(kSbTimeSecond, 48000), 48000);
-  EXPECT_EQ(AudioDurationToFrames(kSbTimeSecond * 2, 48000), 48000 * 2);
+  EXPECT_EQ(AudioDurationToFrames(1'000'000LL / 2, 48000), 48000 / 2);
+  EXPECT_EQ(AudioDurationToFrames(1'000'000LL, 48000), 48000);
+  EXPECT_EQ(AudioDurationToFrames(1'000'000LL * 2, 48000), 48000 * 2);
 }
 
 TEST(MediaUtilTest, AudioFramesToDuration) {
   EXPECT_EQ(AudioFramesToDuration(0, 48000), 0);
-  EXPECT_EQ(AudioFramesToDuration(48000 / 2, 48000), kSbTimeSecond / 2);
-  EXPECT_EQ(AudioFramesToDuration(48000, 48000), kSbTimeSecond);
-  EXPECT_EQ(AudioFramesToDuration(48000 * 2, 48000), kSbTimeSecond * 2);
+  EXPECT_EQ(AudioFramesToDuration(48000 / 2, 48000), 1'000'000LL / 2);
+  EXPECT_EQ(AudioFramesToDuration(48000, 48000), 1'000'000LL);
+  EXPECT_EQ(AudioFramesToDuration(48000 * 2, 48000), 1'000'000LL * 2);
 }
 
 }  // namespace

--- a/starboard/shared/starboard/net_args.h
+++ b/starboard/shared/starboard/net_args.h
@@ -37,8 +37,6 @@
 #include <string>
 #include <vector>
 
-#include "starboard/time.h"
-
 namespace starboard {
 namespace shared {
 namespace starboard {
@@ -48,8 +46,9 @@ namespace starboard {
 extern const char kNetArgsCommandSwitchWait[];
 
 // Waits until args stream in with a socket connection and data reception.
-// A timeout value of < 0 will signal infinite timeout.
-std::vector<std::string> NetArgsWaitForPayload(SbTime timeout);
+// Timeout is in microseconds. A timeout value of < 0 will signal infinite
+// timeout.
+std::vector<std::string> NetArgsWaitForPayload(int64_t timeout);
 
 }  // namespace starboard
 }  // namespace shared

--- a/starboard/shared/starboard/net_log.h
+++ b/starboard/shared/starboard/net_log.h
@@ -36,7 +36,6 @@
 
 #include "starboard/common/scoped_ptr.h"
 #include "starboard/common/socket.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -47,8 +46,9 @@ namespace starboard {
 extern const char kNetLogCommandSwitchWait[];
 
 // Optional - Pauses execution of the current thread until a client has
-// connected. A timeout value of < 0 will signal infinite timeout.
-void NetLogWaitForClientConnected(SbTime timeout);
+// connected. Timeout is in microseconds. A timeout value of < 0 will signal
+// infinite timeout.
+void NetLogWaitForClientConnected(int64_t timeout);
 
 // Writes to the netlog buffer socket stream.
 // Note that the NetLog is completely disabled for official

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -57,7 +57,7 @@ DecodedAudio::DecodedAudio()
 DecodedAudio::DecodedAudio(int channels,
                            SbMediaAudioSampleType sample_type,
                            SbMediaAudioFrameStorageType storage_type,
-                           SbTime timestamp,
+                           int64_t timestamp,
                            int size_in_bytes)
     : channels_(channels),
       sample_type_(sample_type),
@@ -76,7 +76,7 @@ DecodedAudio::DecodedAudio(int channels,
 DecodedAudio::DecodedAudio(int channels,
                            SbMediaAudioSampleType sample_type,
                            SbMediaAudioFrameStorageType storage_type,
-                           SbTime timestamp,
+                           int64_t timestamp,
                            int size_in_bytes,
                            Buffer&& storage)
     : channels_(channels),
@@ -108,7 +108,7 @@ void DecodedAudio::ShrinkTo(int new_size_in_bytes) {
   size_in_bytes_ = new_size_in_bytes;
 }
 
-void DecodedAudio::AdjustForSeekTime(int sample_rate, SbTime seeking_to_time) {
+void DecodedAudio::AdjustForSeekTime(int sample_rate, int64_t seeking_to_time) {
   SB_DCHECK(!is_end_of_stream());
   SB_DCHECK(sample_rate != 0);
 
@@ -155,8 +155,8 @@ void DecodedAudio::AdjustForSeekTime(int sample_rate, SbTime seeking_to_time) {
 
 void DecodedAudio::AdjustForDiscardedDurations(
     int sample_rate,
-    SbTime discarded_duration_from_front,
-    SbTime discarded_duration_from_back) {
+    int64_t discarded_duration_from_front,
+    int64_t discarded_duration_from_back) {
   SB_DCHECK(discarded_duration_from_front >= 0);
   SB_DCHECK(discarded_duration_from_back >= 0);
   SB_DCHECK(storage_type() == kSbMediaAudioFrameStorageTypeInterleaved);

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -39,13 +39,13 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
   DecodedAudio(int channels,
                SbMediaAudioSampleType sample_type,
                SbMediaAudioFrameStorageType storage_type,
-               SbTime timestamp,
+               int64_t timestamp,
                int size_in_bytes);
 
   DecodedAudio(int channels,
                SbMediaAudioSampleType sample_type,
                SbMediaAudioFrameStorageType storage_type,
-               SbTime timestamp,
+               int64_t timestamp,
                int size_in_bytes,
                Buffer&& storage);
 
@@ -54,7 +54,7 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
   SbMediaAudioFrameStorageType storage_type() const { return storage_type_; }
 
   bool is_end_of_stream() const { return channels_ == 0; }
-  SbTime timestamp() const { return timestamp_; }
+  int64_t timestamp() const { return timestamp_; }
   const uint8_t* data() const { return storage_.data() + offset_in_bytes_; }
   const int16_t* data_as_int16() const {
     return reinterpret_cast<const int16_t*>(storage_.data() + offset_in_bytes_);
@@ -78,10 +78,10 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
   // During seeking, the target time can be in the middle of the DecodedAudio
   // object.  This function will adjust the object to the seek target time by
   // removing the frames in the beginning that are before the seek target time.
-  void AdjustForSeekTime(int sample_rate, SbTime seeking_to_time);
+  void AdjustForSeekTime(int sample_rate, int64_t seeking_to_time);
   void AdjustForDiscardedDurations(int sample_rate,
-                                   SbTime discarded_duration_from_front,
-                                   SbTime discarded_duration_from_back);
+                                   int64_t discarded_duration_from_front,
+                                   int64_t discarded_duration_from_back);
 
   bool IsFormat(SbMediaAudioSampleType sample_type,
                 SbMediaAudioFrameStorageType storage_type) const;
@@ -101,8 +101,8 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
   const int channels_;
   const SbMediaAudioSampleType sample_type_;
   const SbMediaAudioFrameStorageType storage_type_;
-  // The timestamp of the first audio frame.
-  SbTime timestamp_;
+  // The timestamp of the first audio frame in microseconds.
+  int64_t timestamp_;
   Buffer storage_;
   // The audio samples to be played are stored in the memory region starts from
   // `storage_.data() + offset_in_bytes_`, `size_in_bytes_` bytes in total.

--- a/starboard/shared/starboard/player/filter/audio_frame_discarder.cc
+++ b/starboard/shared/starboard/player/filter/audio_frame_discarder.cc
@@ -69,9 +69,9 @@ void AudioFrameDiscarder::AdjustForDiscardedDurations(
   // We accept a small offset due to the precision of computation. If the
   // outputs have different timestamps than inputs, discarded durations will be
   // ignored.
-  const SbTimeMonotonic kTimestampOffset = 10;
+  const int64_t kTimestampOffsetUsec = 10;
   if (std::abs(input_info.timestamp - (*decoded_audio)->timestamp()) >
-      kTimestampOffset) {
+      kTimestampOffsetUsec) {
     SB_LOG(WARNING) << "Inconsistent timestamps between InputBuffer (@"
                     << input_info.timestamp << ") and DecodedAudio (@"
                     << (*decoded_audio)->timestamp() << ").";

--- a/starboard/shared/starboard/player/filter/audio_frame_discarder.h
+++ b/starboard/shared/starboard/player/filter/audio_frame_discarder.h
@@ -22,7 +22,6 @@
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/decoded_audio_internal.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -47,9 +46,9 @@ class AudioFrameDiscarder {
 
  private:
   struct InputBufferInfo {
-    SbTime timestamp;
-    SbTime discarded_duration_from_front;
-    SbTime discarded_duration_from_back;
+    int64_t timestamp;                      // microseconds
+    int64_t discarded_duration_from_front;  // microseconds
+    int64_t discarded_duration_from_back;   // microseconds
   };
 
   static constexpr size_t kMaxNumberOfPendingInputBufferInfos = 128;

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink.h
@@ -19,7 +19,6 @@
 
 #include "starboard/audio_sink.h"
 #include "starboard/shared/internal_only.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -37,7 +36,7 @@ class AudioRendererSink {
                                  bool* is_playing,
                                  bool* is_eos_reached) = 0;
     virtual void ConsumeFrames(int frames_consumed,
-                               SbTime frames_consumed_at) = 0;
+                               int64_t frames_consumed_at) = 0;
 
     // When |capability_changed| is true, it hints that the error is caused by a
     // a transient capability on the platform.  The app should retry playback
@@ -59,7 +58,7 @@ class AudioRendererSink {
       int sampling_frequency_hz) const = 0;
 
   virtual bool HasStarted() const = 0;
-  virtual void Start(SbTime media_start_time,
+  virtual void Start(int64_t media_start_time,
                      int channels,
                      int sampling_frequency_hz,
                      SbMediaAudioSampleType audio_sample_type,

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -28,7 +28,7 @@ namespace filter {
 
 AudioRendererSinkImpl::AudioRendererSinkImpl()
     : create_audio_sink_func_(
-          [](SbTime start_media_time,
+          [](int64_t start_media_time,
              int channels,
              int sampling_frequency_hz,
              SbMediaAudioSampleType audio_sample_type,
@@ -78,7 +78,7 @@ bool AudioRendererSinkImpl::HasStarted() const {
 }
 
 void AudioRendererSinkImpl::Start(
-    SbTime media_start_time,
+    int64_t media_start_time,
     int channels,
     int sampling_frequency_hz,
     SbMediaAudioSampleType audio_sample_type,
@@ -167,7 +167,7 @@ void AudioRendererSinkImpl::UpdateSourceStatusFunc(int* frames_in_buffer,
 
 // static
 void AudioRendererSinkImpl::ConsumeFramesFunc(int frames_consumed,
-                                              SbTime frames_consumed_at,
+                                              int64_t frames_consumed_at,
                                               void* context) {
   AudioRendererSinkImpl* audio_renderer_sink =
       static_cast<AudioRendererSinkImpl*>(context);

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
@@ -33,7 +33,7 @@ namespace filter {
 class AudioRendererSinkImpl : public AudioRendererSink {
  public:
   typedef std::function<SbAudioSink(
-      SbTime media_start_time,
+      int64_t media_start_time,
       int channels,
       int sampling_frequency_hz,
       SbMediaAudioSampleType audio_sample_type,
@@ -60,7 +60,7 @@ class AudioRendererSinkImpl : public AudioRendererSink {
       int sampling_frequency_hz) const override;
 
   bool HasStarted() const override;
-  void Start(SbTime media_start_time,
+  void Start(int64_t media_start_time,
              int channels,
              int sampling_frequency_hz,
              SbMediaAudioSampleType audio_sample_type,
@@ -80,7 +80,7 @@ class AudioRendererSinkImpl : public AudioRendererSink {
                                      bool* is_eos_reached,
                                      void* context);
   static void ConsumeFramesFunc(int frames_consumed,
-                                SbTime frames_consumed_at,
+                                int64_t frames_consumed_at,
                                 void* context);
   static void ErrorFunc(bool capability_changed,
                         const std::string& error_message,

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -271,8 +271,7 @@ bool AudioTimeStretcher::CanPerformWsola() const {
 }
 
 int AudioTimeStretcher::ConvertMillisecondsToFrames(int ms) const {
-  const double kMillisecondsPerSeconds =
-      static_cast<double>(kSbTimeSecond / kSbTimeMillisecond);
+  const double kMillisecondsPerSeconds = 1000;
   return static_cast<int>(ms * (samples_per_second_ / kMillisecondsPerSeconds));
 }
 

--- a/starboard/shared/starboard/player/filter/cpu_video_frame.cc
+++ b/starboard/shared/starboard/player/filter/cpu_video_frame.cc
@@ -185,7 +185,7 @@ scoped_refptr<CpuVideoFrame> CpuVideoFrame::CreateYV12Frame(
     int height,
     int source_y_pitch_in_bytes,
     int source_uv_pitch_in_bytes,
-    SbTime timestamp,
+    int64_t timestamp,
     const uint8_t* y,
     const uint8_t* u,
     const uint8_t* v) {

--- a/starboard/shared/starboard/player/filter/cpu_video_frame.h
+++ b/starboard/shared/starboard/player/filter/cpu_video_frame.h
@@ -55,7 +55,7 @@ class CpuVideoFrame : public VideoFrame {
     const uint8_t* data;
   };
 
-  explicit CpuVideoFrame(SbTime timestamp) : VideoFrame(timestamp) {}
+  explicit CpuVideoFrame(int64_t timestamp) : VideoFrame(timestamp) {}
 
   Format format() const { return format_; }
   int width() const { return width_; }
@@ -72,7 +72,7 @@ class CpuVideoFrame : public VideoFrame {
       int height,
       int source_y_pitch_in_bytes,
       int source_uv_pitch_in_bytes,
-      SbTime timestamp,
+      int64_t timestamp,  // microseconds
       const uint8_t* y,
       const uint8_t* u,
       const uint8_t* v);

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -26,7 +26,6 @@
 #include "starboard/shared/starboard/player/filter/audio_decoder_internal.h"
 #include "starboard/shared/starboard/player/filter/video_decoder_internal.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -43,7 +42,7 @@ typedef shared::starboard::player::PlayerWorker::Handler::HandlerResult
     HandlerResult;
 
 // TODO: Make this configurable inside SbPlayerCreate().
-const SbTimeMonotonic kUpdateInterval = 200 * kSbTimeMillisecond;
+const int64_t kUpdateIntervalUsec = 200'000;  // 200ms
 
 #if defined(COBALT_BUILD_TYPE_GOLD)
 
@@ -187,12 +186,12 @@ HandlerResult FilterBasedPlayerWorkerHandler::Init(
                   kSbMediaTypeVideo));
   }
 
-  update_job_token_ = Schedule(update_job_, kUpdateInterval);
+  update_job_token_ = Schedule(update_job_, kUpdateIntervalUsec);
 
   return HandlerResult{true};
 }
 
-HandlerResult FilterBasedPlayerWorkerHandler::Seek(SbTime seek_to_time,
+HandlerResult FilterBasedPlayerWorkerHandler::Seek(int64_t seek_to_time,
                                                    int ticket) {
   SB_DCHECK(BelongsToCurrentThread());
 
@@ -507,7 +506,7 @@ void FilterBasedPlayerWorkerHandler::Update() {
   }
 
   RemoveJobByToken(update_job_token_);
-  update_job_token_ = Schedule(update_job_, kUpdateInterval);
+  update_job_token_ = Schedule(update_job_, kUpdateIntervalUsec);
 }
 
 void FilterBasedPlayerWorkerHandler::Stop() {

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -32,7 +32,6 @@
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "starboard/shared/starboard/player/player_worker.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -53,7 +52,7 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
                      GetPlayerStateCB get_player_state_cb,
                      UpdatePlayerStateCB update_player_state_cb,
                      UpdatePlayerErrorCB update_player_error_cb) override;
-  HandlerResult Seek(SbTime seek_to_time, int ticket) override;
+  HandlerResult Seek(int64_t seek_to_time, int ticket) override;
   HandlerResult WriteSamples(const InputBuffers& input_buffers,
                              int* samples_written) override;
   HandlerResult WriteEndOfStream(SbMediaType sample_type) override;

--- a/starboard/shared/starboard/player/filter/media_time_provider.h
+++ b/starboard/shared/starboard/player/filter/media_time_provider.h
@@ -30,12 +30,12 @@ class MediaTimeProvider {
   virtual void Play() = 0;
   virtual void Pause() = 0;
   virtual void SetPlaybackRate(double playback_rate) = 0;
-  virtual void Seek(SbTime seek_to_pts) = 0;
+  virtual void Seek(int64_t seek_to_pts) = 0;
   // This function can be called from *any* thread.
-  virtual SbTime GetCurrentMediaTime(bool* is_playing,
-                                     bool* is_eos_played,
-                                     bool* is_underflow,
-                                     double* playback_rate) = 0;
+  virtual int64_t GetCurrentMediaTime(bool* is_playing,
+                                      bool* is_eos_played,
+                                      bool* is_underflow,
+                                      double* playback_rate) = 0;
 
  protected:
   virtual ~MediaTimeProvider() {}

--- a/starboard/shared/starboard/player/filter/media_time_provider_impl.cc
+++ b/starboard/shared/starboard/player/filter/media_time_provider_impl.cc
@@ -64,7 +64,7 @@ void MediaTimeProviderImpl::SetPlaybackRate(double playback_rate) {
   playback_rate_ = playback_rate;
 }
 
-void MediaTimeProviderImpl::Seek(SbTime seek_to_time) {
+void MediaTimeProviderImpl::Seek(int64_t seek_to_time) {
   SB_DCHECK(BelongsToCurrentThread());
 
   ScopedLock scoped_lock(mutex_);
@@ -77,13 +77,13 @@ void MediaTimeProviderImpl::Seek(SbTime seek_to_time) {
   CancelPendingJobs();
 }
 
-SbTime MediaTimeProviderImpl::GetCurrentMediaTime(bool* is_playing,
-                                                  bool* is_eos_played,
-                                                  bool* is_underflow,
-                                                  double* playback_rate) {
+int64_t MediaTimeProviderImpl::GetCurrentMediaTime(bool* is_playing,
+                                                   bool* is_eos_played,
+                                                   bool* is_underflow,
+                                                   double* playback_rate) {
   ScopedLock scoped_lock(mutex_);
 
-  SbTime current = GetCurrentMediaTime_Locked();
+  int64_t current = GetCurrentMediaTime_Locked();
 
   *is_playing = is_playing_;
   *is_eos_played = false;
@@ -93,11 +93,11 @@ SbTime MediaTimeProviderImpl::GetCurrentMediaTime(bool* is_playing,
   return current;
 }
 
-SbTime MediaTimeProviderImpl::GetCurrentMediaTime_Locked(
-    SbTimeMonotonic* current_time /*= NULL*/) {
+int64_t MediaTimeProviderImpl::GetCurrentMediaTime_Locked(
+    int64_t* current_time /*= NULL*/) {
   mutex_.DCheckAcquired();
 
-  SbTimeMonotonic now = system_time_provider_->GetMonotonicNow();
+  int64_t now = system_time_provider_->GetMonotonicNow();
 
   if (!is_playing_ || playback_rate_ == 0.0) {
     if (current_time) {
@@ -106,7 +106,7 @@ SbTime MediaTimeProviderImpl::GetCurrentMediaTime_Locked(
     return seek_to_time_;
   }
 
-  SbTimeMonotonic elapsed = (now - seek_to_time_set_at_) * playback_rate_;
+  int64_t elapsed = (now - seek_to_time_set_at_) * playback_rate_;
   if (current_time) {
     *current_time = now;
   }

--- a/starboard/shared/starboard/player/filter/media_time_provider_impl.h
+++ b/starboard/shared/starboard/player/filter/media_time_provider_impl.h
@@ -17,11 +17,11 @@
 
 #include "starboard/common/mutex.h"
 #include "starboard/common/scoped_ptr.h"
+#include "starboard/common/time.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/filter/media_time_provider.h"
 #include "starboard/shared/starboard/player/job_queue.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -36,7 +36,7 @@ class MediaTimeProviderImpl : public MediaTimeProvider,
   class MonotonicSystemTimeProvider {
    public:
     virtual ~MonotonicSystemTimeProvider() {}
-    virtual SbTimeMonotonic GetMonotonicNow() const = 0;
+    virtual int64_t GetMonotonicNow() const = 0;
   };
 
   explicit MediaTimeProviderImpl(
@@ -45,18 +45,18 @@ class MediaTimeProviderImpl : public MediaTimeProvider,
   void Play() override;
   void Pause() override;
   void SetPlaybackRate(double playback_rate) override;
-  void Seek(SbTime seek_to_time) override;
-  SbTime GetCurrentMediaTime(bool* is_playing,
-                             bool* is_eos_played,
-                             bool* is_underflow,
-                             double* playback_rate) override;
+  void Seek(int64_t seek_to_time) override;
+  int64_t GetCurrentMediaTime(bool* is_playing,
+                              bool* is_eos_played,
+                              bool* is_underflow,
+                              double* playback_rate) override;
 
  private:
   // When not NULL, |current_time| will be set to the current monotonic time
   // used to calculate the returned media time.  Note that it is possible that
   // |current_time| points to |seek_to_time_set_at_| and the implementation
   // should handle this properly.
-  SbTime GetCurrentMediaTime_Locked(SbTimeMonotonic* current_time = NULL);
+  int64_t GetCurrentMediaTime_Locked(int64_t* current_time = NULL);
 
   scoped_ptr<MonotonicSystemTimeProvider> system_time_provider_;
 
@@ -64,8 +64,8 @@ class MediaTimeProviderImpl : public MediaTimeProvider,
 
   double playback_rate_ = 0.0;
   bool is_playing_ = false;
-  SbTime seek_to_time_ = 0;
-  SbTimeMonotonic seek_to_time_set_at_ = SbTimeGetMonotonicNow();
+  int64_t seek_to_time_ = 0;  // microseconds
+  int64_t seek_to_time_set_at_ = CurrentMonotonicTime();
 };
 
 }  // namespace filter

--- a/starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h
@@ -38,7 +38,7 @@ class MockAudioRendererSink : public AudioRendererSink {
                      int(int sampling_frequency_hz));
   MOCK_CONST_METHOD0(HasStarted, bool());
   MOCK_METHOD8(Start,
-               void(SbTime media_start_time,
+               void(int64_t media_start_time,
                     int channels,
                     int sampling_frequency_hz,
                     SbMediaAudioSampleType audio_sample_type,

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -15,6 +15,7 @@
 #include "starboard/shared/starboard/player/filter/player_components.h"
 
 #include "starboard/common/scoped_ptr.h"
+#include "starboard/common/time.h"
 #include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/command_line.h"
 #include "starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.h"
@@ -44,9 +45,7 @@ typedef MediaTimeProviderImpl::MonotonicSystemTimeProvider
     MonotonicSystemTimeProvider;
 
 class MonotonicSystemTimeProviderImpl : public MonotonicSystemTimeProvider {
-  SbTimeMonotonic GetMonotonicNow() const override {
-    return SbTimeGetMonotonicNow();
-  }
+  int64_t GetMonotonicNow() const override { return CurrentMonotonicTime(); }
 };
 
 class PlayerComponentsImpl : public PlayerComponents {
@@ -252,7 +251,7 @@ void PlayerComponents::Factory::CreateStubVideoComponents(
     scoped_ptr<VideoDecoder>* video_decoder,
     scoped_ptr<VideoRenderAlgorithm>* video_render_algorithm,
     scoped_refptr<VideoRendererSink>* video_renderer_sink) {
-  const SbTime kVideoSinkRenderInterval = 10 * kSbTimeMillisecond;
+  const int64_t kVideoSinkRenderIntervalUsec = 10'000;  // 10ms
 
   SB_DCHECK(video_decoder);
   SB_DCHECK(video_render_algorithm);
@@ -261,7 +260,7 @@ void PlayerComponents::Factory::CreateStubVideoComponents(
   video_decoder->reset(new StubVideoDecoder);
   video_render_algorithm->reset(new VideoRenderAlgorithmImpl);
   *video_renderer_sink = new PunchoutVideoRendererSink(
-      creation_parameters.player(), kVideoSinkRenderInterval);
+      creation_parameters.player(), kVideoSinkRenderIntervalUsec);
 }
 
 void PlayerComponents::Factory::GetAudioRendererParams(

--- a/starboard/shared/starboard/player/filter/punchout_video_renderer_sink.cc
+++ b/starboard/shared/starboard/player/filter/punchout_video_renderer_sink.cc
@@ -28,7 +28,7 @@ using std::placeholders::_1;
 using std::placeholders::_2;
 
 PunchoutVideoRendererSink::PunchoutVideoRendererSink(SbPlayer player,
-                                                     SbTime render_interval)
+                                                     int64_t render_interval)
     : player_(player),
       render_interval_(render_interval),
       thread_(kSbThreadInvalid),

--- a/starboard/shared/starboard/player/filter/punchout_video_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/punchout_video_renderer_sink.h
@@ -21,7 +21,6 @@
 #include "starboard/player.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/filter/video_renderer_sink.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 namespace starboard {
@@ -32,7 +31,7 @@ namespace filter {
 
 class PunchoutVideoRendererSink : public VideoRendererSink {
  public:
-  PunchoutVideoRendererSink(SbPlayer player, SbTime render_interval);
+  PunchoutVideoRendererSink(SbPlayer player, int64_t render_interval);
   ~PunchoutVideoRendererSink() override;
 
  private:
@@ -46,7 +45,7 @@ class PunchoutVideoRendererSink : public VideoRendererSink {
   static void* ThreadEntryPoint(void* context);
 
   SbPlayer player_;
-  SbTime render_interval_;
+  int64_t render_interval_;  // microseconds
   RenderCB render_cb_;
   SbThread thread_;
   atomic_bool stop_requested_;

--- a/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
@@ -46,7 +46,7 @@ int CalculateFramesPerInputBuffer(int sample_rate,
   SB_DCHECK(first);
   SB_DCHECK(second);
 
-  SbTime duration = second->timestamp() - first->timestamp();
+  int64_t duration = second->timestamp() - first->timestamp();
   if (duration <= 0) {
     SB_LOG(ERROR) << "Duration (" << duration << ") for InputBuffer@ "
                   << first->timestamp() << " is invalid.";
@@ -57,7 +57,7 @@ int CalculateFramesPerInputBuffer(int sample_rate,
 }
 
 scoped_refptr<DecodedAudio> CreateDecodedAudio(
-    SbTime timestamp,
+    int64_t timestamp,
     SbMediaAudioSampleType sample_type,
     int number_of_channels,
     int frames) {
@@ -216,7 +216,7 @@ void StubAudioDecoder::DecodeOneBuffer(
 
         auto offset_in_frames =
             offset_in_bytes / (sample_size * number_of_channels_);
-        SbTime timestamp =
+        int64_t timestamp =
             decoded_audio->timestamp() +
             AudioDurationToFrames(offset_in_frames, samples_per_second_);
 

--- a/starboard/shared/starboard/player/filter/stub_video_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_video_decoder.cc
@@ -37,8 +37,8 @@ size_t StubVideoDecoder::GetPrerollFrameCount() const {
   return 1;
 }
 
-SbTime StubVideoDecoder::GetPrerollTimeout() const {
-  return kSbTimeMax;
+int64_t StubVideoDecoder::GetPrerollTimeout() const {
+  return kSbInt64Max;
 }
 
 size_t StubVideoDecoder::GetMaxNumberOfCachedFrames() const {
@@ -132,7 +132,7 @@ void StubVideoDecoder::DecodeEndOfStream() {
 }
 
 scoped_refptr<VideoFrame> StubVideoDecoder::CreateOutputFrame(
-    SbTime timestamp) const {
+    int64_t timestamp) const {
   int bits_per_channel = video_stream_info_.color_metadata.bits_per_channel;
   if (bits_per_channel == 0) {
     // Assume 8 bits when |bits_per_channel| is unknown (0).

--- a/starboard/shared/starboard/player/filter/stub_video_decoder.h
+++ b/starboard/shared/starboard/player/filter/stub_video_decoder.h
@@ -37,7 +37,7 @@ class StubVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
                   const ErrorCB& error_cb) override;
 
   size_t GetPrerollFrameCount() const override;
-  SbTime GetPrerollTimeout() const override;
+  int64_t GetPrerollTimeout() const override;
   size_t GetMaxNumberOfCachedFrames() const override;
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;
@@ -50,14 +50,14 @@ class StubVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
   void DecodeBuffers(const InputBuffers& input_buffers);
   void DecodeEndOfStream();
 
-  scoped_refptr<VideoFrame> CreateOutputFrame(SbTime timestamp) const;
+  scoped_refptr<VideoFrame> CreateOutputFrame(int64_t timestamp) const;
 
   DecoderStatusCB decoder_status_cb_;
   media::VideoStreamInfo video_stream_info_;
 
   scoped_ptr<starboard::player::JobThread> decoder_thread_;
   // std::set<> keeps frame timestamps sorted in ascending order.
-  std::set<SbTime> output_frame_timestamps_;
+  std::set<int64_t> output_frame_timestamps_;
   // Used to determine when to send kBufferFull in DecodeOneBuffer().
   int total_input_count_ = 0;
 };

--- a/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
@@ -22,7 +22,6 @@
 #include "starboard/shared/starboard/player/filter/testing/test_util.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 #include "starboard/shared/starboard/player/video_dmp_reader.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -45,7 +44,7 @@ class AudioFrameDiscarderTest : public ::testing::TestWithParam<const char*> {
   VideoDmpReader dmp_reader_;
 };
 
-scoped_refptr<DecodedAudio> MakeDecodedAudio(int channels, SbTime timestamp) {
+scoped_refptr<DecodedAudio> MakeDecodedAudio(int channels, int64_t timestamp) {
   scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
       channels, kSbMediaAudioSampleTypeFloat32,
       kSbMediaAudioFrameStorageTypeInterleaved, timestamp,
@@ -105,7 +104,7 @@ TEST_P(AudioFrameDiscarderTest, PartialAudio) {
   InputBuffers input_buffers;
   std::vector<scoped_refptr<DecodedAudio>> decoded_audios;
   const auto& audio_stream_info = dmp_reader_.audio_stream_info();
-  const SbTime duration = media::AudioFramesToDuration(
+  const int64_t duration = media::AudioFramesToDuration(
       MakeDecodedAudio(audio_stream_info.number_of_channels, 0)->frames(),
       audio_stream_info.samples_per_second);
 

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -19,6 +19,7 @@
 
 #include "starboard/common/log.h"
 #include "starboard/common/scoped_ptr.h"
+#include "starboard/common/time.h"
 #include "starboard/media.h"
 #include "starboard/memory.h"
 #include "starboard/shared/starboard/media/media_util.h"
@@ -128,14 +129,14 @@ class AudioRendererTest : public ::testing::Test {
   // until the renderer reaches its preroll threshold.
   // Once the renderer is "full", an EndOfStream is written.
   // Returns the number of frames written.
-  int FillRendererWithDecodedAudioAndWriteEOS(SbTime start_timestamp) {
+  int FillRendererWithDecodedAudioAndWriteEOS(int64_t start_timestamp) {
     const int kFramesPerBuffer = 1024;
 
     int frames_written = 0;
 
     while (!prerolled_) {
-      SbTime timestamp = start_timestamp + frames_written * kSbTimeSecond /
-                                               kDefaultSamplesPerSecond;
+      int64_t timestamp = start_timestamp + frames_written * 1'000'000LL /
+                                                kDefaultSamplesPerSecond;
       scoped_refptr<InputBuffer> input_buffer = CreateInputBuffer(timestamp);
       WriteSample(input_buffer);
       CallConsumedCB();
@@ -170,7 +171,7 @@ class AudioRendererTest : public ::testing::Test {
     audio_renderer_->WriteEndOfStream();
     job_queue_.RunUntilIdle();
   }
-  void Seek(SbTime seek_to_time) {
+  void Seek(int64_t seek_to_time) {
     EXPECT_TRUE(prerolled_);
     prerolled_ = false;
     audio_renderer_->Seek(seek_to_time);
@@ -195,7 +196,7 @@ class AudioRendererTest : public ::testing::Test {
     job_queue_.RunUntilIdle();
   }
 
-  scoped_refptr<InputBuffer> CreateInputBuffer(SbTime timestamp) {
+  scoped_refptr<InputBuffer> CreateInputBuffer(int64_t timestamp) {
     const int kInputBufferSize = 4;
     SbPlayerSampleInfo sample_info = {};
     sample_info.buffer = malloc(kInputBufferSize);
@@ -207,7 +208,8 @@ class AudioRendererTest : public ::testing::Test {
     return new InputBuffer(DeallocateSampleCB, NULL, this, sample_info);
   }
 
-  scoped_refptr<DecodedAudio> CreateDecodedAudio(SbTime timestamp, int frames) {
+  scoped_refptr<DecodedAudio> CreateDecodedAudio(int64_t timestamp,
+                                                 int frames) {
     scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
         kDefaultNumberOfChannels, sample_type_, storage_type_, timestamp,
         frames * kDefaultNumberOfChannels *
@@ -336,7 +338,7 @@ TEST_F(AudioRendererTest, SunnyDay) {
 
   SendDecoderOutput(new DecodedAudio);
 
-  SbTime media_time = audio_renderer_->GetCurrentMediaTime(
+  int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
@@ -355,11 +357,11 @@ TEST_F(AudioRendererTest, SunnyDay) {
   // Consume frames in two batches, so we can test if |GetCurrentMediaTime()|
   // is incrementing in an expected manner.
   const int frames_to_consume = std::min(frames_written, frames_in_buffer) / 2;
-  SbTime new_media_time;
+  int64_t new_media_time;
 
   EXPECT_FALSE(audio_renderer_->IsEndOfStreamPlayed());
 
-  renderer_callback_->ConsumeFrames(frames_to_consume, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_TRUE(is_playing);
@@ -369,7 +371,7 @@ TEST_F(AudioRendererTest, SunnyDay) {
   media_time = new_media_time;
 
   const int remaining_frames = frames_in_buffer - frames_to_consume;
-  renderer_callback_->ConsumeFrames(remaining_frames, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_TRUE(is_playing);
@@ -427,7 +429,7 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
 
   SendDecoderOutput(new DecodedAudio);
 
-  SbTime media_time = audio_renderer_->GetCurrentMediaTime(
+  int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
 
   int frames_in_buffer;
@@ -445,18 +447,18 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
   // is incrementing in an expected manner.
   const int frames_to_consume =
       std::min(frames_written / kPlaybackRate, frames_in_buffer) / 2;
-  SbTime new_media_time;
+  int64_t new_media_time;
 
   EXPECT_FALSE(audio_renderer_->IsEndOfStreamPlayed());
 
-  renderer_callback_->ConsumeFrames(frames_to_consume, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_GT(new_media_time, media_time);
   media_time = new_media_time;
 
   const int remaining_frames = frames_in_buffer - frames_to_consume;
-  renderer_callback_->ConsumeFrames(remaining_frames, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_GT(new_media_time, media_time);
@@ -492,7 +494,7 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
   bool is_eos_played = true;
   bool is_underflow = true;
   double playback_rate = -1.0;
-  SbTime media_time = audio_renderer_->GetCurrentMediaTime(
+  int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
 
   int frames_in_buffer;
@@ -508,11 +510,11 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
   // Consume frames in two batches, so we can test if |GetCurrentMediaTime()|
   // is incrementing in an expected manner.
   const int frames_to_consume = std::min(frames_written, frames_in_buffer) / 2;
-  SbTime new_media_time;
+  int64_t new_media_time;
 
   EXPECT_FALSE(audio_renderer_->IsEndOfStreamPlayed());
 
-  renderer_callback_->ConsumeFrames(frames_to_consume, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_TRUE(is_playing);
@@ -522,7 +524,7 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
   media_time = new_media_time;
 
   const int remaining_frames = frames_in_buffer - frames_to_consume;
-  renderer_callback_->ConsumeFrames(remaining_frames, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_TRUE(is_playing);
@@ -649,13 +651,12 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
   int frames_written = 0;
 
   while (!prerolled_) {
-    SbTime timestamp =
-        frames_written * kSbTimeSecond / kDefaultSamplesPerSecond;
+    int64_t timestamp = frames_written * 1'000'000LL / kDefaultSamplesPerSecond;
     WriteSample(CreateInputBuffer(timestamp));
     CallConsumedCB();
     SendDecoderOutput(CreateDecodedAudio(timestamp, kFramesPerBuffer / 2));
     frames_written += kFramesPerBuffer / 2;
-    timestamp = frames_written * kSbTimeSecond / kDefaultSamplesPerSecond;
+    timestamp = frames_written * 1'000'000LL / kDefaultSamplesPerSecond;
     SendDecoderOutput(CreateDecodedAudio(timestamp, kFramesPerBuffer / 2));
     frames_written += kFramesPerBuffer / 2;
   }
@@ -678,7 +679,7 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
 
   SendDecoderOutput(new DecodedAudio);
 
-  SbTime media_time = audio_renderer_->GetCurrentMediaTime(
+  int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
 
   int frames_in_buffer;
@@ -695,11 +696,11 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
   // Consume frames in two batches, so we can test if |GetCurrentMediaTime()|
   // is incrementing in an expected manner.
   const int frames_to_consume = std::min(frames_written, frames_in_buffer) / 2;
-  SbTime new_media_time;
+  int64_t new_media_time;
 
   EXPECT_FALSE(audio_renderer_->IsEndOfStreamPlayed());
 
-  renderer_callback_->ConsumeFrames(frames_to_consume, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_TRUE(is_playing);
@@ -709,7 +710,7 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
   media_time = new_media_time;
 
   const int remaining_frames = frames_in_buffer - frames_to_consume;
-  renderer_callback_->ConsumeFrames(remaining_frames, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_TRUE(is_playing);
@@ -747,13 +748,12 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
   int frames_written = 0;
 
   while (!prerolled_) {
-    SbTime timestamp =
-        frames_written * kSbTimeSecond / kDefaultSamplesPerSecond;
-    SbTime output_time = timestamp;
+    int64_t timestamp = frames_written * 1'000'000LL / kDefaultSamplesPerSecond;
+    int64_t output_time = timestamp;
     WriteSample(CreateInputBuffer(timestamp));
     CallConsumedCB();
     frames_written += kFramesPerBuffer / 2;
-    timestamp = frames_written * kSbTimeSecond / kDefaultSamplesPerSecond;
+    timestamp = frames_written * 1'000'000LL / kDefaultSamplesPerSecond;
     WriteSample(CreateInputBuffer(timestamp));
     CallConsumedCB();
     frames_written += kFramesPerBuffer / 2;
@@ -775,7 +775,7 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
 
   SendDecoderOutput(new DecodedAudio);
 
-  SbTime media_time = audio_renderer_->GetCurrentMediaTime(
+  int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
 
   int frames_in_buffer;
@@ -791,18 +791,18 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
   // Consume frames in two batches, so we can test if |GetCurrentMediaTime()|
   // is incrementing in an expected manner.
   const int frames_to_consume = std::min(frames_written, frames_in_buffer) / 2;
-  SbTime new_media_time;
+  int64_t new_media_time;
 
   EXPECT_FALSE(audio_renderer_->IsEndOfStreamPlayed());
 
-  renderer_callback_->ConsumeFrames(frames_to_consume, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_GE(new_media_time, media_time);
   media_time = new_media_time;
 
   const int remaining_frames = frames_in_buffer - frames_to_consume;
-  renderer_callback_->ConsumeFrames(remaining_frames, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_GE(new_media_time, media_time);
@@ -816,7 +816,7 @@ TEST_F(AudioRendererTest, Seek) {
     return;
   }
 
-  const double kSeekTime = 0.5 * kSbTimeSecond;
+  const double kSeekTime = 0.5 * 1'000'000LL;
 
   {
     ::testing::InSequence seq;
@@ -850,7 +850,7 @@ TEST_F(AudioRendererTest, Seek) {
 
   SendDecoderOutput(new DecodedAudio);
 
-  SbTime media_time = audio_renderer_->GetCurrentMediaTime(
+  int64_t media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
 
   int frames_in_buffer;
@@ -866,11 +866,11 @@ TEST_F(AudioRendererTest, Seek) {
   // Consume frames in multiple batches, so we can test if
   // |GetCurrentMediaTime()| is incrementing in an expected manner.
   const int frames_to_consume = std::min(frames_written, frames_in_buffer) / 10;
-  SbTime new_media_time;
+  int64_t new_media_time;
 
   EXPECT_FALSE(audio_renderer_->IsEndOfStreamPlayed());
 
-  renderer_callback_->ConsumeFrames(frames_to_consume, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_GE(new_media_time, media_time);
@@ -892,7 +892,7 @@ TEST_F(AudioRendererTest, Seek) {
   EXPECT_GE(offset_in_frames, 0);
   EXPECT_TRUE(is_playing);
   EXPECT_TRUE(is_eos_reached);
-  renderer_callback_->ConsumeFrames(frames_in_buffer, SbTimeGetMonotonicNow());
+  renderer_callback_->ConsumeFrames(frames_in_buffer, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
       &is_playing, &is_eos_played, &is_underflow, &playback_rate);
   EXPECT_GE(new_media_time, kSeekTime);

--- a/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
@@ -100,7 +100,7 @@ class AudioResamplerTest
       int audio_size = kSamplesPerInput * channels_ * sample_size;
       scoped_refptr<DecodedAudio> input = new DecodedAudio(
           channels_, source_sample_type_, source_storage_type_,
-          kSbTimeSecond * total_frames / source_sample_rate_, audio_size);
+          1'000'000LL * total_frames / source_sample_rate_, audio_size);
       total_frames += kSamplesPerInput;
       inputs_.push_back(input);
     }

--- a/starboard/shared/starboard/player/filter/testing/test_util.cc
+++ b/starboard/shared/starboard/player/filter/testing/test_util.cc
@@ -200,7 +200,7 @@ std::vector<VideoTestParam> GetSupportedVideoTests() {
           test_params.push_back(std::make_tuple(filename, output_mode));
           break;
         } else if (need_to_check_with_wait && !decoder_has_been_checked_once) {
-          SbThreadSleep(kSbTimeSecond);
+          SbThreadSleep(1'000'000);
         } else {
           break;
         }
@@ -246,9 +246,9 @@ bool CreateAudioComponents(bool using_stub_decoder,
   return false;
 }
 
-AssertionResult AlmostEqualTime(SbTime time1, SbTime time2) {
-  const SbTime kEpsilon = kSbTimeSecond / 1000;
-  SbTime diff = time1 - time2;
+AssertionResult AlmostEqualTime(int64_t time1, int64_t time2) {
+  const int64_t kEpsilon = 1000;  // 1ms
+  int64_t diff = time1 - time2;
   if (-kEpsilon <= diff && diff <= kEpsilon) {
     return AssertionSuccess();
   }
@@ -296,8 +296,8 @@ scoped_refptr<InputBuffer> GetAudioInputBuffer(
 scoped_refptr<InputBuffer> GetAudioInputBuffer(
     video_dmp::VideoDmpReader* dmp_reader,
     size_t index,
-    SbTime discarded_duration_from_front,
-    SbTime discarded_duration_from_back) {
+    int64_t discarded_duration_from_front,
+    int64_t discarded_duration_from_back) {
   SB_DCHECK(dmp_reader);
   auto player_sample_info =
       dmp_reader->GetPlayerSampleInfo(kSbMediaTypeAudio, index);

--- a/starboard/shared/starboard/player/filter/testing/test_util.h
+++ b/starboard/shared/starboard/player/filter/testing/test_util.h
@@ -27,7 +27,6 @@
 #include "starboard/shared/starboard/player/filter/audio_renderer_sink.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 #include "starboard/shared/starboard/player/video_dmp_reader.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -62,7 +61,7 @@ bool CreateAudioComponents(bool using_stub_decoder,
                            scoped_ptr<AudioDecoder>* audio_decoder,
                            scoped_ptr<AudioRendererSink>* audio_renderer_sink);
 
-::testing::AssertionResult AlmostEqualTime(SbTime time1, SbTime time2);
+::testing::AssertionResult AlmostEqualTime(int64_t time1, int64_t time2);
 
 media::VideoStreamInfo CreateVideoStreamInfo(SbMediaVideoCodec codec);
 
@@ -75,8 +74,8 @@ scoped_refptr<InputBuffer> GetAudioInputBuffer(
 scoped_refptr<InputBuffer> GetAudioInputBuffer(
     video_dmp::VideoDmpReader* dmp_reader,
     size_t index,
-    SbTime discarded_duration_from_front,
-    SbTime discarded_duration_from_back);
+    int64_t discarded_duration_from_front,
+    int64_t discarded_duration_from_back);
 
 }  // namespace testing
 }  // namespace filter

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
@@ -24,6 +24,7 @@
 #include "starboard/common/mutex.h"
 #include "starboard/common/scoped_ptr.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/drm.h"
 #include "starboard/media.h"
@@ -37,7 +38,6 @@
 #include "starboard/shared/starboard/player/video_dmp_reader.h"
 #include "starboard/testing/fake_graphics_context_provider.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -402,8 +402,8 @@ TEST_P(VideoDecoderTest, MultipleInputs) {
 }
 
 TEST_P(VideoDecoderTest, Preroll) {
-  SbTimeMonotonic start = SbTimeGetMonotonicNow();
-  SbTime preroll_timeout = fixture_.video_decoder()->GetPrerollTimeout();
+  int64_t start = CurrentMonotonicTime();
+  int64_t preroll_timeout = fixture_.video_decoder()->GetPrerollTimeout();
   bool error_occurred = false;
   ASSERT_NO_FATAL_FAILURE(fixture_.WriteMultipleInputs(
       0, fixture_.dmp_reader().number_of_video_buffers(),
@@ -418,7 +418,7 @@ TEST_P(VideoDecoderTest, Preroll) {
           *continue_process = false;
           return;
         }
-        if (SbTimeGetMonotonicNow() - start >= preroll_timeout) {
+        if (CurrentMonotonicTime() - start >= preroll_timeout) {
           // After preroll timeout, we should get at least 1 decoded frame.
           ASSERT_GT(fixture_.GetDecodedFramesCount(), 0);
           *continue_process = false;

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
@@ -27,6 +27,7 @@
 #include "starboard/common/mutex.h"
 #include "starboard/common/scoped_ptr.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/drm.h"
 #include "starboard/media.h"
@@ -39,7 +40,6 @@
 #include "starboard/shared/starboard/player/video_dmp_reader.h"
 #include "starboard/testing/fake_graphics_context_provider.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -157,11 +157,10 @@ void VideoDecoderTestFixture::AssertInvalidDecodeTarget() {
 }
 #endif  // SB_HAS(GLES2)
 
-void VideoDecoderTestFixture::WaitForNextEvent(Event* event,
-                                               SbTimeMonotonic timeout) {
+void VideoDecoderTestFixture::WaitForNextEvent(Event* event, int64_t timeout) {
   ASSERT_TRUE(event);
 
-  SbTimeMonotonic start = SbTimeGetMonotonicNow();
+  int64_t start = CurrentMonotonicTime();
   do {
     job_queue_->RunUntilIdle();
     GetDecodeTargetWhenSupported();
@@ -180,15 +179,14 @@ void VideoDecoderTestFixture::WaitForNextEvent(Event* event,
         return;
       }
     }
-    SbThreadSleep(kSbTimeMillisecond);
-  } while (SbTimeGetMonotonicNow() - start < timeout);
+    SbThreadSleep(1000);
+  } while (CurrentMonotonicTime() - start < timeout);
   event->status = kTimeout;
   SB_LOG(WARNING) << "WaitForNextEvent() timeout.";
 }
 
 bool VideoDecoderTestFixture::HasPendingEvents() {
-  const SbTime kDelay = 5 * kSbTimeMillisecond;
-  SbThreadSleep(kDelay);
+  SbThreadSleep(5000);
   ScopedLock scoped_lock(mutex_);
   return !event_queue_.empty();
 }

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.h
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.h
@@ -37,7 +37,6 @@
 #include "starboard/shared/starboard/player/video_dmp_reader.h"
 #include "starboard/testing/fake_graphics_context_provider.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 // This has to be defined in the global namespace as its instance will be used
@@ -53,8 +52,7 @@ namespace testing {
 
 class VideoDecoderTestFixture {
  public:
-  static const SbTimeMonotonic kDefaultWaitForNextEventTimeOut =
-      5 * kSbTimeSecond;
+  static const int64_t kDefaultWaitForNextEventTimeOut = 5'000'000;  // 5sec
 
   enum Status {
     kNeedMoreInput = VideoDecoder::kNeedMoreInput,
@@ -105,9 +103,8 @@ class VideoDecoderTestFixture {
   void AssertInvalidDecodeTarget();
 #endif  // SB_HAS(GLES2)
 
-  void WaitForNextEvent(
-      Event* event,
-      SbTimeMonotonic timeout = kDefaultWaitForNextEventTimeOut);
+  void WaitForNextEvent(Event* event,
+                        int64_t timeout = kDefaultWaitForNextEventTimeOut);
 
   bool HasPendingEvents();
 
@@ -165,7 +162,7 @@ class VideoDecoderTestFixture {
   scoped_ptr<VideoDecoder> video_decoder_;
 
   bool need_more_input_ = true;
-  std::set<SbTime> outstanding_inputs_;
+  std::set<int64_t> outstanding_inputs_;
   std::deque<scoped_refptr<VideoFrame>> decoded_frames_;
 
   SbPlayerPrivate player_;

--- a/starboard/shared/starboard/player/filter/testing/video_frame_rate_estimator_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_frame_rate_estimator_test.cc
@@ -20,7 +20,6 @@
 #include "starboard/common/ref_counted.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
 #include "starboard/shared/starboard/player/filter/video_frame_rate_estimator.h"
-#include "starboard/time.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -50,7 +49,7 @@ void SkipFrames(size_t frames_to_skip,
   }
 }
 
-Frames CreateFrames(const std::initializer_list<SbTime>& timestamps) {
+Frames CreateFrames(const std::initializer_list<int64_t>& timestamps) {
   Frames frames;
   for (auto timestamp : timestamps) {
     frames.push_back(new VideoFrame(timestamp));

--- a/starboard/shared/starboard/player/filter/tools/audio_dmp_player.cc
+++ b/starboard/shared/starboard/player/filter/tools/audio_dmp_player.cc
@@ -46,7 +46,7 @@ scoped_ptr<VideoDmpReader> s_video_dmp_reader;
 scoped_ptr<PlayerComponents> s_player_components;
 int s_audio_sample_index;
 scoped_ptr<JobThread> s_job_thread;
-SbTime s_duration;
+int64_t s_duration;
 
 static void DeallocateSampleFunc(SbPlayer player,
                                  void* context,
@@ -60,7 +60,7 @@ starboard::scoped_refptr<InputBuffer> GetAudioInputBuffer(size_t index) {
 
 void OnTimer() {
   if (!s_player_components->GetAudioRenderer()->CanAcceptMoreData()) {
-    s_job_thread->job_queue()->Schedule(std::bind(OnTimer), kSbTimeMillisecond);
+    s_job_thread->job_queue()->Schedule(std::bind(OnTimer), 1000);
     return;
   }
 

--- a/starboard/shared/starboard/player/filter/video_decoder_internal.h
+++ b/starboard/shared/starboard/player/filter/video_decoder_internal.h
@@ -69,12 +69,12 @@ class VideoDecoder {
   // is considered to be complete.
   virtual size_t GetPrerollFrameCount() const = 0;
 
-  // Returns the timeout that preroll is considered to be finished.  Once the
-  // first frame is decoded and the timeout has passed, the preroll will be
-  // considered as finished even if there isn't enough frames decoded as
-  // suggested by GetPrerollFrameCount().
-  // On most platforms this can be simply set to |kSbTimeMax|.
-  virtual SbTime GetPrerollTimeout() const = 0;
+  // Returns the timeout (in microseconds) that preroll is considered to be
+  // finished.  Once the first frame is decoded and the timeout has passed, the
+  // preroll will be considered as finished even if there isn't enough frames
+  // decoded as suggested by GetPrerollFrameCount().
+  // On most platforms this can be simply set to |kSbInt64Max|.
+  virtual int64_t GetPrerollTimeout() const = 0;
 
   // Returns a soft limit of the maximum number of frames the user of this class
   // (usually the VideoRenderer) should cache, i.e. the user won't write more

--- a/starboard/shared/starboard/player/filter/video_frame_internal.h
+++ b/starboard/shared/starboard/player/filter/video_frame_internal.h
@@ -31,13 +31,13 @@ namespace filter {
 class VideoFrame : public RefCountedThreadSafe<VideoFrame> {
  public:
   // An invalid media timestamp to indicate end of stream.
-  static const SbTime kMediaTimeEndOfStream = -1;
+  static const int64_t kMediaTimeEndOfStream = -1;
 
-  explicit VideoFrame(SbTime timestamp) : timestamp_(timestamp) {}
+  explicit VideoFrame(int64_t timestamp) : timestamp_(timestamp) {}
   virtual ~VideoFrame() {}
 
   bool is_end_of_stream() const { return timestamp_ == kMediaTimeEndOfStream; }
-  SbTime timestamp() const {
+  int64_t timestamp() const {
     SB_DCHECK(!is_end_of_stream());
     return timestamp_;
   }
@@ -47,7 +47,7 @@ class VideoFrame : public RefCountedThreadSafe<VideoFrame> {
   }
 
  private:
-  SbTime timestamp_;
+  int64_t timestamp_;  // microseconds
 
   VideoFrame(const VideoFrame&) = delete;
   void operator=(const VideoFrame&) = delete;

--- a/starboard/shared/starboard/player/filter/video_frame_rate_estimator.cc
+++ b/starboard/shared/starboard/player/filter/video_frame_rate_estimator.cc
@@ -54,7 +54,7 @@ void VideoFrameRateEstimator::Reset() {
 
 void VideoFrameRateEstimator::CalculateInitialFrameRate(
     const Frames& frames,
-    SbTime previous_frame_duration) {
+    int64_t previous_frame_duration) {
   SB_DCHECK(frame_rate_ == kInvalidFrameRate);
   SB_DCHECK(!frames.empty());
   SB_DCHECK(frames.size() >= 2 || previous_frame_duration > 0);
@@ -102,7 +102,7 @@ void VideoFrameRateEstimator::CalculateInitialFrameRate(
   }
   auto average_frame_duration =
       accumulated_frame_durations_ / number_of_frame_durations_accumulated_;
-  frame_rate_ = static_cast<double>(kSbTimeSecond) / average_frame_duration;
+  frame_rate_ = static_cast<double>(1'000'000) / average_frame_duration;
 
   // Snap the frame rate to the nearest integer, so 29.97 will become 30.
   if (frame_rate_ - std::floor(frame_rate_) < kFrameRateEpsilon) {

--- a/starboard/shared/starboard/player/filter/video_frame_rate_estimator.h
+++ b/starboard/shared/starboard/player/filter/video_frame_rate_estimator.h
@@ -20,7 +20,6 @@
 #include "starboard/common/ref_counted.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -60,13 +59,13 @@ class VideoFrameRateEstimator {
   static constexpr double kFrameRateEpsilon = 0.1;
 
   void CalculateInitialFrameRate(const Frames& frames,
-                                 SbTime previous_frame_duration = 0);
+                                 int64_t previous_frame_duration = 0);
   void RefineFrameRate(const Frames& frames);
 
   double frame_rate_ = kInvalidFrameRate;
-  SbTime accumulated_frame_durations_;
+  int64_t accumulated_frame_durations_;  // microseconds
   int number_of_frame_durations_accumulated_;
-  SbTime last_checked_frame_timestamp_;
+  int64_t last_checked_frame_timestamp_;  // microseconds
 };
 
 }  // namespace filter

--- a/starboard/shared/starboard/player/filter/video_render_algorithm.h
+++ b/starboard/shared/starboard/player/filter/video_render_algorithm.h
@@ -23,7 +23,6 @@
 #include "starboard/shared/starboard/player/filter/media_time_provider.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
 #include "starboard/shared/starboard/player/filter/video_renderer_sink.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -50,8 +49,8 @@ class VideoRenderAlgorithm {
                       std::list<scoped_refptr<VideoFrame>>* frames,
                       VideoRendererSink::DrawFrameCB draw_frame_cb) = 0;
   // Called during seek to reset the internal states of VideoRenderAlgorithm.
-  // |seek_to_time| will be set to the seek target.
-  virtual void Seek(SbTime seek_to_time) = 0;
+  // |seek_to_time| (microseconds) will be set to the seek target.
+  virtual void Seek(int64_t seek_to_time) = 0;
   virtual int GetDroppedFrames() = 0;
 };
 

--- a/starboard/shared/starboard/player/filter/video_render_algorithm_impl.h
+++ b/starboard/shared/starboard/player/filter/video_render_algorithm_impl.h
@@ -28,7 +28,6 @@
 #include "starboard/shared/starboard/player/filter/video_frame_rate_estimator.h"
 #include "starboard/shared/starboard/player/filter/video_render_algorithm.h"
 #include "starboard/shared/starboard/player/filter/video_renderer_sink.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -46,7 +45,7 @@ class VideoRenderAlgorithmImpl : public VideoRenderAlgorithm {
   void Render(MediaTimeProvider* media_time_provider,
               std::list<scoped_refptr<VideoFrame>>* frames,
               VideoRendererSink::DrawFrameCB draw_frame_cb) override;
-  void Seek(SbTime seek_to_time) override;
+  void Seek(int64_t seek_to_time) override;
   int GetDroppedFrames() override { return dropped_frames_; }
 
  private:
@@ -63,11 +62,11 @@ class VideoRenderAlgorithmImpl : public VideoRenderAlgorithm {
   static constexpr int kMaxLogPerPlaybackSession = 32;
 
   int times_logged_ = 0;
-  SbTime media_time_of_last_render_call_;
-  SbTime system_time_of_last_render_call_;
+  int64_t media_time_of_last_render_call_;   // microseconds
+  int64_t system_time_of_last_render_call_;  // microseconds
 #endif  // SB_PLAYER_FILTER_ENABLE_STATE_CHECK
 
-  SbTime last_frame_timestamp_ = -1;
+  int64_t last_frame_timestamp_ = -1;  // microseconds
   int current_frame_rendered_times_ = -1;
   int dropped_frames_ = 0;
 };

--- a/starboard/shared/starboard/player/filter/video_renderer_internal.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal.h
@@ -20,7 +20,6 @@
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/filter/common.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -43,7 +42,8 @@ class VideoRenderer {
 
   virtual void WriteEndOfStream() = 0;
 
-  virtual void Seek(SbTime seek_to_time) = 0;
+  // |seek_to_time| is microseconds.
+  virtual void Seek(int64_t seek_to_time) = 0;
 
   virtual bool IsEndOfStreamWritten() const = 0;
   virtual bool CanAcceptMoreData() const = 0;

--- a/starboard/shared/starboard/player/input_buffer_internal.h
+++ b/starboard/shared/starboard/player/input_buffer_internal.h
@@ -48,7 +48,7 @@ class InputBuffer : public RefCountedThreadSafe<InputBuffer> {
 
   const std::vector<uint8_t>& side_data() const { return side_data_; }
 
-  SbTime timestamp() const { return timestamp_; }
+  int64_t timestamp() const { return timestamp_; }
   const media::AudioSampleInfo& audio_sample_info() const {
     SB_DCHECK(sample_type_ == kSbMediaTypeAudio);
     return audio_sample_info_;
@@ -83,7 +83,7 @@ class InputBuffer : public RefCountedThreadSafe<InputBuffer> {
   const uint8_t* data_;
   int size_;
   std::vector<uint8_t> side_data_;
-  SbTime timestamp_;
+  int64_t timestamp_;  // microseconds
 
   media::AudioSampleInfo audio_sample_info_;
   media::VideoSampleInfo video_sample_info_;

--- a/starboard/shared/starboard/player/job_thread.h
+++ b/starboard/shared/starboard/player/job_thread.h
@@ -50,16 +50,16 @@ class JobThread {
   }
 
   JobQueue::JobToken Schedule(const JobQueue::Job& job,
-                              SbTimeMonotonic delay = 0) {
+                              int64_t delay_usec = 0) {
     SB_DCHECK(job_queue_);
 
-    return job_queue_->Schedule(job, delay);
+    return job_queue_->Schedule(job, delay_usec);
   }
 
-  JobQueue::JobToken Schedule(JobQueue::Job&& job, SbTimeMonotonic delay = 0) {
+  JobQueue::JobToken Schedule(JobQueue::Job&& job, int64_t delay_usec = 0) {
     SB_DCHECK(job_queue_);
 
-    return job_queue_->Schedule(std::move(job), delay);
+    return job_queue_->Schedule(std::move(job), delay_usec);
   }
 
   void ScheduleAndWait(const JobQueue::Job& job) {

--- a/starboard/shared/starboard/player/player_get_audio_configuration.cc
+++ b/starboard/shared/starboard/player/player_get_audio_configuration.cc
@@ -17,7 +17,6 @@
 #include "starboard/common/log.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/player/player_internal.h"
-#include "starboard/time.h"
 
 #if SB_API_VERSION >= 15
 

--- a/starboard/shared/starboard/player/player_internal.h
+++ b/starboard/shared/starboard/player/player_internal.h
@@ -26,7 +26,6 @@
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "starboard/shared/starboard/player/player_worker.h"
-#include "starboard/time.h"
 #include "starboard/window.h"
 
 #if SB_PLAYER_ENABLE_VIDEO_DUMPER
@@ -48,7 +47,7 @@ struct SbPlayerPrivate {
       void* context,
       starboard::scoped_ptr<PlayerWorker::Handler> player_worker_handler);
 
-  void Seek(SbTime seek_to_time, int ticket);
+  void Seek(int64_t seek_to_time, int ticket);
   template <typename PlayerSampleInfo>
   void WriteSamples(const PlayerSampleInfo* sample_infos,
                     int number_of_sample_infos);
@@ -89,7 +88,7 @@ struct SbPlayerPrivate {
   SbPlayerPrivate(const SbPlayerPrivate&) = delete;
   SbPlayerPrivate& operator=(const SbPlayerPrivate&) = delete;
 
-  void UpdateMediaInfo(SbTime media_time,
+  void UpdateMediaInfo(int64_t media_time,
                        int dropped_video_frames,
                        int ticket,
                        bool is_progressing);
@@ -99,8 +98,8 @@ struct SbPlayerPrivate {
 
   starboard::Mutex mutex_;
   int ticket_ = SB_PLAYER_INITIAL_TICKET;
-  SbTime media_time_ = 0;
-  SbTimeMonotonic media_time_updated_at_;
+  int64_t media_time_ = 0;         // microseconds
+  int64_t media_time_updated_at_;  // microseconds
   int frame_width_ = 0;
   int frame_height_ = 0;
   bool is_paused_ = false;

--- a/starboard/shared/starboard/player/player_seek.cc
+++ b/starboard/shared/starboard/player/player_seek.cc
@@ -18,9 +18,9 @@
 #include "starboard/shared/starboard/player/player_internal.h"
 
 #if SB_API_VERSION >= 15
-void SbPlayerSeek(SbPlayer player, SbTime seek_to_timestamp, int ticket) {
+void SbPlayerSeek(SbPlayer player, int64_t seek_to_timestamp, int ticket) {
 #else   // SB_API_VERSION >= 15
-void SbPlayerSeek2(SbPlayer player, SbTime seek_to_timestamp, int ticket) {
+void SbPlayerSeek2(SbPlayer player, int64_t seek_to_timestamp, int ticket) {
 #endif  // SB_API_VERSION >= 15
   if (!SbPlayerIsValid(player)) {
     SB_DLOG(WARNING) << "player is invalid.";

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -47,7 +47,7 @@ const int kPlayerStackSize = 0;
 // TODO: Reduce this as there should be enough frames caches in the renderers.
 //       Also this should be configurable for platforms with very limited video
 //       backlogs.
-const SbTimeMonotonic kWritePendingSampleDelay = 8 * kSbTimeMillisecond;
+const int64_t kWritePendingSampleDelayUsec = 8'000;  // 8ms
 
 DECLARE_INSTANCE_COUNTER(PlayerWorker);
 
@@ -138,7 +138,7 @@ PlayerWorker::PlayerWorker(SbMediaAudioCodec audio_codec,
   SB_DCHECK(job_queue_);
 }
 
-void PlayerWorker::UpdateMediaInfo(SbTime time,
+void PlayerWorker::UpdateMediaInfo(int64_t time,
                                    int dropped_video_frames,
                                    bool is_progressing) {
   if (player_state_ == kSbPlayerStatePresenting) {
@@ -222,7 +222,7 @@ void PlayerWorker::DoInit() {
   }
 }
 
-void PlayerWorker::DoSeek(SbTime seek_to_time, int ticket) {
+void PlayerWorker::DoSeek(int64_t seek_to_time, int ticket) {
   SB_DCHECK(job_queue_->BelongsToCurrentThread());
 
   SB_DCHECK(player_state_ != kSbPlayerStateDestroyed);
@@ -309,7 +309,7 @@ void PlayerWorker::DoWriteSamples(InputBuffers input_buffers) {
     if (!write_pending_sample_job_token_.is_valid()) {
       write_pending_sample_job_token_ = job_queue_->Schedule(
           std::bind(&PlayerWorker::DoWritePendingSamples, this),
-          kWritePendingSampleDelay);
+          kWritePendingSampleDelayUsec);
     }
   }
 }

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -30,7 +30,6 @@
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 #include "starboard/window.h"
 
 namespace starboard {
@@ -46,7 +45,7 @@ namespace player {
 // they needn't maintain the thread and queue internally.
 class PlayerWorker {
  public:
-  typedef std::function<void(SbTime media_time,
+  typedef std::function<void(int64_t media_time,
                              int dropped_video_frames,
                              int ticket,
                              bool is_progressing)>
@@ -75,7 +74,7 @@ class PlayerWorker {
     typedef ::starboard::shared::starboard::player::InputBuffers InputBuffers;
 
     typedef std::function<
-        void(SbTime media_time, int dropped_video_frames, bool is_progressing)>
+        void(int64_t media_time, int dropped_video_frames, bool is_progressing)>
         UpdateMediaInfoCB;
     typedef std::function<SbPlayerState()> GetPlayerStateCB;
     typedef std::function<void(SbPlayerState player_state)> UpdatePlayerStateCB;
@@ -94,7 +93,7 @@ class PlayerWorker {
                                GetPlayerStateCB get_player_state_cb,
                                UpdatePlayerStateCB update_player_state_cb,
                                UpdatePlayerErrorCB update_player_error_cb) = 0;
-    virtual HandlerResult Seek(SbTime seek_to_time, int ticket) = 0;
+    virtual HandlerResult Seek(int64_t seek_to_time, int ticket) = 0;
     virtual HandlerResult WriteSamples(const InputBuffers& input_buffers,
                                        int* samples_written) = 0;
     virtual HandlerResult WriteEndOfStream(SbMediaType sample_type) = 0;
@@ -129,7 +128,7 @@ class PlayerWorker {
 
   ~PlayerWorker();
 
-  void Seek(SbTime seek_to_time, int ticket) {
+  void Seek(int64_t seek_to_time, int ticket) {
     job_queue_->Schedule(
         std::bind(&PlayerWorker::DoSeek, this, seek_to_time, ticket));
   }
@@ -191,7 +190,7 @@ class PlayerWorker {
   PlayerWorker(const PlayerWorker&) = delete;
   PlayerWorker& operator=(const PlayerWorker&) = delete;
 
-  void UpdateMediaInfo(SbTime time, int dropped_video_frames, bool underflow);
+  void UpdateMediaInfo(int64_t time, int dropped_video_frames, bool underflow);
 
   SbPlayerState player_state() const { return player_state_; }
   void UpdatePlayerState(SbPlayerState player_state);
@@ -202,7 +201,7 @@ class PlayerWorker {
   static void* ThreadEntryPoint(void* context);
   void RunLoop();
   void DoInit();
-  void DoSeek(SbTime seek_to_time, int ticket);
+  void DoSeek(int64_t seek_to_time, int ticket);
   void DoWriteSamples(InputBuffers input_buffers);
   void DoWritePendingSamples();
   void DoWriteEndOfStream(SbMediaType sample_type);

--- a/starboard/shared/starboard/player/video_dmp_common.h
+++ b/starboard/shared/starboard/player/video_dmp_common.h
@@ -49,7 +49,7 @@ namespace video_dmp {
 //
 //     audio/video access unit:
 //       fourcc type: 'adat'/'vdat'
-//       <8 bytes time stamp in SbTime>
+//       <8 bytes time stamp int64_t>
 //       <1 byte of drm_sample_info_present in bool>
 //         <4 bytes size of key_id> + |size| bytes of key id
 //         <4 bytes size of iv> + |size| bytes of iv

--- a/starboard/shared/starboard/player/video_dmp_reader.cc
+++ b/starboard/shared/starboard/player/video_dmp_reader.cc
@@ -36,7 +36,7 @@ int64_t CalculateAverageBitrate(const std::vector<AccessUnit>& access_units) {
     return 1024;
   }
 
-  SbTime duration =
+  int64_t duration =
       access_units.back().timestamp() - access_units.front().timestamp();
 
   SB_DCHECK(duration > 0);
@@ -46,7 +46,7 @@ int64_t CalculateAverageBitrate(const std::vector<AccessUnit>& access_units) {
     total_bitrate += au.data().size();
   }
 
-  return total_bitrate * 8 * kSbTimeSecond / duration;
+  return total_bitrate * 8 * 1'000'000LL / duration;
 }
 
 static void DeallocateSampleFunc(SbPlayer player,
@@ -305,8 +305,8 @@ void VideoDmpReader::Parse() {
   }
   // Guestimate the video fps.
   if (video_access_units_.size() > 1) {
-    SbTime first_timestamp = video_access_units_.front().timestamp();
-    SbTime second_timestamp = video_access_units_.back().timestamp();
+    int64_t first_timestamp = video_access_units_.front().timestamp();
+    int64_t second_timestamp = video_access_units_.back().timestamp();
     for (const auto& au : video_access_units_) {
       if (au.timestamp() != first_timestamp &&
           au.timestamp() < second_timestamp) {
@@ -314,10 +314,10 @@ void VideoDmpReader::Parse() {
       }
     }
     SB_DCHECK(first_timestamp < second_timestamp);
-    SbTime frame_duration = second_timestamp - first_timestamp;
-    dmp_info_.video_fps = kSbTimeSecond / frame_duration;
+    int64_t frame_duration = second_timestamp - first_timestamp;
+    dmp_info_.video_fps = 1'000'000LL / frame_duration;
 
-    SbTime last_frame_timestamp = video_access_units_.back().timestamp();
+    int64_t last_frame_timestamp = video_access_units_.back().timestamp();
     for (auto it = video_access_units_.rbegin();
          it != video_access_units_.rend(); it++) {
       if (it->timestamp() > last_frame_timestamp) {
@@ -351,7 +351,7 @@ void VideoDmpReader::EnsureSampleLoaded(SbMediaType type, size_t index) {
 }
 
 VideoDmpReader::AudioAccessUnit VideoDmpReader::ReadAudioAccessUnit() {
-  SbTime timestamp;
+  int64_t timestamp;
   Read(read_cb_, reverse_byte_order_.value(), &timestamp);
 
   bool drm_sample_info_present;
@@ -376,7 +376,7 @@ VideoDmpReader::AudioAccessUnit VideoDmpReader::ReadAudioAccessUnit() {
 }
 
 VideoDmpReader::VideoAccessUnit VideoDmpReader::ReadVideoAccessUnit() {
-  SbTime timestamp;
+  int64_t timestamp;
   Read(read_cb_, reverse_byte_order_.value(), &timestamp);
 
   bool drm_sample_info_present;

--- a/starboard/shared/starboard/player/video_dmp_reader.h
+++ b/starboard/shared/starboard/player/video_dmp_reader.h
@@ -47,7 +47,7 @@ class VideoDmpReader {
 
   class AccessUnit {
    public:
-    AccessUnit(SbTime timestamp,
+    AccessUnit(int64_t timestamp,
                const SbDrmSampleInfoWithSubSampleMapping* drm_sample_info,
                std::vector<uint8_t> data)
         : timestamp_(timestamp),
@@ -56,14 +56,14 @@ class VideoDmpReader {
                                ? SbDrmSampleInfoWithSubSampleMapping()
                                : *drm_sample_info),
           data_(std::move(data)) {}
-    SbTime timestamp() const { return timestamp_; }
+    int64_t timestamp() const { return timestamp_; }
     const SbDrmSampleInfo* drm_sample_info() const {
       return drm_sample_info_present_ ? &drm_sample_info_ : NULL;
     }
     const std::vector<uint8_t>& data() const { return data_; }
 
    private:
-    SbTime timestamp_;
+    int64_t timestamp_;  // microseconds
     bool drm_sample_info_present_;
     SbDrmSampleInfoWithSubSampleMapping drm_sample_info_;
     std::vector<uint8_t> data_;
@@ -71,7 +71,7 @@ class VideoDmpReader {
 
   class AudioAccessUnit : public AccessUnit {
    public:
-    AudioAccessUnit(SbTime timestamp,
+    AudioAccessUnit(int64_t timestamp,
                     const SbDrmSampleInfoWithSubSampleMapping* drm_sample_info,
                     std::vector<uint8_t> data,
                     media::AudioSampleInfo audio_sample_info)
@@ -87,7 +87,7 @@ class VideoDmpReader {
 
   class VideoAccessUnit : public AccessUnit {
    public:
-    VideoAccessUnit(SbTime timestamp,
+    VideoAccessUnit(int64_t timestamp,
                     const SbDrmSampleInfoWithSubSampleMapping* drm_sample_info,
                     std::vector<uint8_t> data,
                     media::VideoSampleInfo video_sample_info)
@@ -117,13 +117,13 @@ class VideoDmpReader {
   }
   int64_t audio_bitrate() const { return dmp_info_.audio_bitrate; }
   std::string audio_mime_type() const;
-  SbTime audio_duration() const { return dmp_info_.audio_duration; }
+  int64_t audio_duration() const { return dmp_info_.audio_duration; }
 
   SbMediaVideoCodec video_codec() const { return dmp_info_.video_codec; }
   int64_t video_bitrate() const { return dmp_info_.video_bitrate; }
   int video_fps() const { return dmp_info_.video_fps; }
   std::string video_mime_type();
-  SbTime video_duration() const { return dmp_info_.video_duration; }
+  int64_t video_duration() const { return dmp_info_.video_duration; }
 
   size_t number_of_audio_buffers() const {
     return dmp_info_.audio_access_units_size;

--- a/starboard/shared/starboard/player/video_dmp_writer.cc
+++ b/starboard/shared/starboard/player/video_dmp_writer.cc
@@ -154,7 +154,7 @@ void VideoDmpWriter::DumpAccessUnit(
   const SbMediaType& sample_type = input_buffer->sample_type();
   const void* sample_buffer = static_cast<const void*>(input_buffer->data());
   const int& sample_buffer_size = input_buffer->size();
-  const SbTime& sample_timestamp = input_buffer->timestamp();
+  const int64_t& sample_timestamp = input_buffer->timestamp();
   const SbDrmSampleInfo* drm_sample_info = input_buffer->drm_info();
 
   if (sample_type == kSbMediaTypeAudio) {

--- a/starboard/shared/starboard/queue_application.h
+++ b/starboard/shared/starboard/queue_application.h
@@ -53,7 +53,7 @@ class QueueApplication : public Application {
   void InjectTimedEvent(TimedEvent* timed_event) override;
   void CancelTimedEvent(SbEventId event_id) override;
   TimedEvent* GetNextDueTimedEvent() override;
-  SbTimeMonotonic GetNextTimedEventTargetTime() override;
+  int64_t GetNextTimedEventTargetTime() override;
 
   // Add the given event onto the event queue, then process the queue until the
   // event is handled. This is similar to DispatchAndDelete but will process
@@ -68,13 +68,14 @@ class QueueApplication : public Application {
 
   // Returns an event if one exists, otherwise returns NULL.
   virtual Event* PollNextSystemEvent() {
-    return WaitForSystemEventWithTimeout(SbTime());
+    return WaitForSystemEventWithTimeout(0);
   }
 
-  // Waits for an event until the timeout |time| runs out.  If an event occurs
-  // in this time, it is returned, otherwise NULL is returned. If |time| is zero
-  // or negative, then this should function effectively like a no-wait poll.
-  virtual Event* WaitForSystemEventWithTimeout(SbTime time) = 0;
+  // Waits for an event until the timeout |time| (in microseconds) runs out. If
+  // an event occurs in this time, it is returned, otherwise NULL is returned.
+  // If |time| is zero or negative, then this should function effectively like
+  // a no-wait poll.
+  virtual Event* WaitForSystemEventWithTimeout(int64_t time) = 0;
 
   // Wakes up any thread waiting within a call to
   // WaitForSystemEventWithTimeout().
@@ -110,10 +111,10 @@ class QueueApplication : public Application {
     bool Inject(TimedEvent* timed_event);
     void Cancel(SbEventId event_id);
     TimedEvent* Get();
-    SbTimeMonotonic GetTime();
+    int64_t GetTime();
 
    private:
-    SbTimeMonotonic GetTimeLocked();
+    int64_t GetTimeLocked();
     typedef bool (*TimedEventComparator)(const TimedEvent* lhs,
                                          const TimedEvent* rhs);
     static bool IsLess(const TimedEvent* lhs, const TimedEvent* rhs);

--- a/starboard/shared/starboard/socket/socket_tracker.h
+++ b/starboard/shared/starboard/socket/socket_tracker.h
@@ -26,7 +26,6 @@
 #include "starboard/memory.h"
 #include "starboard/socket_waiter.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 
 // TODO: Move this to starboard/socket.h.
 inline bool operator<(const SbSocketAddress& left,
@@ -84,7 +83,7 @@ class SocketTracker {
   State GetState(SbSocket socket);
 
   void LogTrackedSockets();
-  std::multimap<SbTimeMonotonic, SbSocket> ComputeIdleTimePerSocketForThreadId(
+  std::multimap<int64_t, SbSocket> ComputeIdleTimePerSocketForThreadId(
       SbThreadId thread_id);
 
  private:
@@ -93,7 +92,7 @@ class SocketTracker {
     SbSocketProtocol protocol;
     optional<SbSocketAddress> local_address;
     optional<SbSocketAddress> remote_address;
-    SbTime last_activity;
+    int64_t last_activity;
     SbSocketWaiter waiter = kSbSocketWaiterInvalid;
     SbThreadId thread_id;
     State state;
@@ -101,7 +100,7 @@ class SocketTracker {
 
   std::string ConvertToString_Locked(SbSocketAddress address) const;
   std::string ConvertToString_Locked(const SocketRecord& record) const;
-  static SbTimeMonotonic ComputeTimeIdle(const SocketRecord& record);
+  static int64_t ComputeTimeIdle(const SocketRecord& record);
 
   Mutex mutex_;
   std::map<SbSocket, SocketRecord> sockets_;

--- a/starboard/shared/stub/condition_variable_wait_timed.cc
+++ b/starboard/shared/stub/condition_variable_wait_timed.cc
@@ -17,6 +17,6 @@
 SbConditionVariableResult SbConditionVariableWaitTimed(
     SbConditionVariable* condition,
     SbMutex* mutex,
-    SbTime timeout) {
+    int64_t timeout) {
   return kSbConditionVariableFailed;
 }

--- a/starboard/shared/stub/media_get_buffer_garbage_collection_duration_threshold.cc
+++ b/starboard/shared/stub/media_get_buffer_garbage_collection_duration_threshold.cc
@@ -14,6 +14,6 @@
 
 #include "starboard/media.h"
 
-SbTime SbMediaGetBufferGarbageCollectionDurationThreshold() {
+int64_t SbMediaGetBufferGarbageCollectionDurationThreshold() {
   return 0;
 }

--- a/starboard/shared/stub/media_set_audio_write_duration.cc
+++ b/starboard/shared/stub/media_set_audio_write_duration.cc
@@ -18,10 +18,10 @@
 
 #if SB_API_VERSION < 15
 
-void SbMediaSetAudioWriteDuration(SbTime duration) {
+void SbMediaSetAudioWriteDuration(int64_t duration) {
   // The stub implementation assumes no further action is needed from the
   // platform to be compatible with limits >= 0.5 second.
-  SB_DCHECK(duration >= kSbTimeSecond / 2)
+  SB_DCHECK(duration >= 500'000)
       << "Limiting audio to less than 0.5 seconds is unexpected.";
 }
 

--- a/starboard/shared/stub/player_seek.cc
+++ b/starboard/shared/stub/player_seek.cc
@@ -15,7 +15,7 @@
 #include "starboard/player.h"
 
 #if SB_API_VERSION >= 15
-void SbPlayerSeek(SbPlayer player, SbTime seek_to_timestamp, int ticket) {}
+void SbPlayerSeek(SbPlayer player, int64_t seek_to_timestamp, int ticket) {}
 #else   // SB_API_VERSION >= 15
-void SbPlayerSeek2(SbPlayer player, SbTime seek_to_timestamp, int ticket) {}
+void SbPlayerSeek2(SbPlayer player, int64_t seek_to_timestamp, int ticket) {}
 #endif  // SB_API_VERSION >= 15

--- a/starboard/shared/stub/socket_set_tcp_keep_alive.cc
+++ b/starboard/shared/stub/socket_set_tcp_keep_alive.cc
@@ -14,6 +14,6 @@
 
 #include "starboard/common/socket.h"
 
-bool SbSocketSetTcpKeepAlive(SbSocket socket, bool value, SbTime period) {
+bool SbSocketSetTcpKeepAlive(SbSocket socket, bool value, int64_t period) {
   return false;
 }

--- a/starboard/shared/stub/socket_waiter_wait_timed.cc
+++ b/starboard/shared/stub/socket_waiter_wait_timed.cc
@@ -15,6 +15,6 @@
 #include "starboard/socket_waiter.h"
 
 SbSocketWaiterResult SbSocketWaiterWaitTimed(SbSocketWaiter waiter,
-                                             SbTime duration) {
+                                             int64_t duration) {
   return kSbSocketWaiterResultInvalid;
 }

--- a/starboard/shared/stub/thread_sleep.cc
+++ b/starboard/shared/stub/thread_sleep.cc
@@ -14,4 +14,4 @@
 
 #include "starboard/thread.h"
 
-void SbThreadSleep(SbTime duration) {}
+void SbThreadSleep(int64_t duration) {}

--- a/starboard/shared/stub/time_get_monotonic_now.cc
+++ b/starboard/shared/stub/time_get_monotonic_now.cc
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 SbTimeMonotonic SbTimeGetMonotonicNow() {
   return SbTimeMonotonic();
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/stub/time_get_now.cc
+++ b/starboard/shared/stub/time_get_now.cc
@@ -12,8 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 SbTime SbTimeGetNow() {
   return SbTime();
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/uwp/analog_thumbstick_input_thread.cc
+++ b/starboard/shared/uwp/analog_thumbstick_input_thread.cc
@@ -44,7 +44,7 @@ class AnalogThumbstickThread::Impl : public Thread {
     while (!join_called()) {
       Update();
       // 120hz to provide smooth 60fps playback.
-      SbThreadSleep(kSbTimeSecond / kPollingFrequency);
+      SbThreadSleep(1'000'000LL / kPollingFrequency);
     }
   }
 

--- a/starboard/shared/uwp/application_uwp.h
+++ b/starboard/shared/uwp/application_uwp.h
@@ -72,7 +72,7 @@ class ApplicationUwp : public shared::starboard::Application,
 
   bool DestroyWindow(SbWindow window);
 
-  void DispatchStart(SbTimeMonotonic timestamp) {
+  void DispatchStart(int64_t timestamp) {
     shared::starboard::Application::DispatchStart(timestamp);
   }
 
@@ -177,7 +177,7 @@ class ApplicationUwp : public shared::starboard::Application,
   void InjectTimedEvent(TimedEvent* timed_event) override;
   void CancelTimedEvent(SbEventId event_id) override;
   TimedEvent* GetNextDueTimedEvent() override;
-  SbTimeMonotonic GetNextTimedEventTargetTime() override;
+  int64_t GetNextTimedEventTargetTime() override;
 
   int device_id() const { return device_id_; }
   void OnJoystickUpdate(SbKey key, SbInputVector value) override;

--- a/starboard/shared/uwp/audio_renderer_passthrough.h
+++ b/starboard/shared/uwp/audio_renderer_passthrough.h
@@ -31,7 +31,6 @@
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "starboard/shared/uwp/wasapi_audio_sink.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 namespace starboard {
@@ -70,11 +69,11 @@ class AudioRendererPassthrough : public AudioRenderer,
   void Play() override;
   void Pause() override;
   void SetPlaybackRate(double playback_rate) override;
-  void Seek(SbTime seek_to_time) override;
-  SbTime GetCurrentMediaTime(bool* is_playing,
-                             bool* is_eos_played,
-                             bool* is_underflow,
-                             double* playback_rate) override;
+  void Seek(int64_t seek_to_time) override;
+  int64_t GetCurrentMediaTime(bool* is_playing,
+                              bool* is_eos_played,
+                              bool* is_underflow,
+                              double* playback_rate) override;
 
  private:
   void OnDecoderConsumed();
@@ -87,11 +86,11 @@ class AudioRendererPassthrough : public AudioRenderer,
   // output.
   void TryToEndStream();
 
-  // Calculates the playback time elapsed since the last time the timestamp was
-  // queried using WASAPIAudioSink::GetCurrentPlaybackTime().
-  SbTime CalculateElapsedPlaybackTime(uint64_t update_time);
-  // Calculates the final output timestamp of a DecodedAudio.
-  SbTime CalculateLastOutputTime(scoped_refptr<DecodedAudio>& decoded_audio);
+  // Calculates the playback time elapsed (microseconds) since the last time the
+  // timestamp was queried using WASAPIAudioSink::GetCurrentPlaybackTime().
+  int64_t CalculateElapsedPlaybackTime(uint64_t update_time);
+  // Calculates the final output timestamp (microseconds) of a DecodedAudio.
+  int64_t CalculateLastOutputTime(scoped_refptr<DecodedAudio>& decoded_audio);
 
   const int kMaxDecodedAudios = 16;
   // About 250 ms of (E)AC3 audio.
@@ -105,7 +104,7 @@ class AudioRendererPassthrough : public AudioRenderer,
   bool paused_ = true;
   bool seeking_ = false;
   double playback_rate_ = 1.0;
-  SbTime seeking_to_time_ = 0;
+  int64_t seeking_to_time_ = 0;
 
   atomic_bool end_of_stream_written_{false};
   atomic_bool end_of_stream_played_{false};

--- a/starboard/shared/uwp/decoder_utils.h
+++ b/starboard/shared/uwp/decoder_utils.h
@@ -21,7 +21,6 @@
 #include <algorithm>
 
 #include "starboard/media.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -33,7 +32,7 @@ Microsoft::WRL::ComPtr<ID3D11Device> GetDirectX11Device(void* display);
 // in containers. Useful in decoders for getting data from buffers keeped in
 // input queues;
 template <typename Container>
-const auto FindByTimestamp(const Container& container, SbTime timestamp) {
+const auto FindByTimestamp(const Container& container, int64_t timestamp) {
   return std::find_if(container.begin(), container.end(),
                       [=](const typename Container::value_type& value) {
                         return value->timestamp() == timestamp;
@@ -44,7 +43,7 @@ const auto FindByTimestamp(const Container& container, SbTime timestamp) {
 // from containers. Useful in decoders for cleaning up input and output queues
 // from expired buffers.
 template <typename Container>
-void RemoveByTimestamp(Container* container, SbTime timestamp) {
+void RemoveByTimestamp(Container* container, int64_t timestamp) {
   auto to_remove =
       std::find_if(container->begin(), container->end(),
                    [=](const typename Container::value_type& value) {

--- a/starboard/shared/uwp/wasapi_audio_sink.h
+++ b/starboard/shared/uwp/wasapi_audio_sink.h
@@ -31,7 +31,6 @@
 #include "starboard/shared/starboard/player/job_thread.h"
 #include "starboard/shared/starboard/thread_checker.h"
 #include "starboard/shared/win32/wasapi_include.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {

--- a/starboard/shared/uwp/watchdog_log.cc
+++ b/starboard/shared/uwp/watchdog_log.cc
@@ -43,7 +43,7 @@ class WatchDogThread : public Thread {
   ~WatchDogThread() { Join(); }
 
   void Run() override {
-    static const SbTime kSleepTime = kSbTimeMillisecond * 250;
+    static const int64_t kSleepTime = 250'000;  // 250ms
     int counter = 0;
     bool created_ok = false;
     SbFileError out_error = kSbFileOk;
@@ -68,7 +68,7 @@ class WatchDogThread : public Thread {
         SbFileWrite(file_handle, kDone, static_cast<int>(strlen(kDone)));
     RecordFileWriteStat(result);
     SbFileFlush(file_handle);
-    SbThreadSleep(50 * kSbTimeMillisecond);
+    SbThreadSleep(50'000);
     bool closed = SbFileClose(file_handle);
     SB_LOG_IF(ERROR, closed) << "Could not close file " << file_path_;
   }

--- a/starboard/shared/uwp/window_internal.h
+++ b/starboard/shared/uwp/window_internal.h
@@ -18,7 +18,6 @@
 #include <EGL/egl.h>
 
 #include "starboard/atomic.h"
-#include "starboard/time.h"
 #include "starboard/window.h"
 
 struct SbWindowPrivate {

--- a/starboard/shared/widevine/drm_system_widevine.h
+++ b/starboard/shared/widevine/drm_system_widevine.h
@@ -192,7 +192,7 @@ class DrmSystemWidevine : public SbDrmSystemPrivate,
   volatile bool quitting_ = false;
 
   Mutex unblock_key_retry_mutex_;
-  optional<SbTimeMonotonic> unblock_key_retry_start_time_;
+  optional<int64_t> unblock_key_retry_start_time_;
 
 #if !defined(COBALT_BUILD_TYPE_GOLD)
   int number_of_session_updates_sent_ = 0;

--- a/starboard/shared/widevine/widevine_timer.cc
+++ b/starboard/shared/widevine/widevine_timer.cc
@@ -15,7 +15,6 @@
 #include "starboard/shared/widevine/widevine_timer.h"
 
 #include "starboard/common/log.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -62,7 +61,7 @@ void WidevineTimer::setTimeout(int64_t delay_in_milliseconds,
   }
 
   iter->second->Schedule([=]() { client->onTimerExpired(context); },
-                         delay_in_milliseconds * kSbTimeMillisecond);
+                         delay_in_milliseconds * 1000);
 }
 
 void WidevineTimer::cancel(IClient* client) {

--- a/starboard/shared/win32/application_win32.cc
+++ b/starboard/shared/win32/application_win32.cc
@@ -203,7 +203,7 @@ bool ApplicationWin32::OnSbSystemRaisePlatformError(
 }
 
 Application::Event* ApplicationWin32::WaitForSystemEventWithTimeout(
-    SbTime time) {
+    int64_t time) {
   ProcessNextSystemMessage();
   if (pending_event_) {
     Event* out = pending_event_;
@@ -212,7 +212,7 @@ Application::Event* ApplicationWin32::WaitForSystemEventWithTimeout(
   }
 
   ScopedLock lock(stop_waiting_for_system_events_mutex_);
-  if (time <= SbTimeGetMonotonicNow() || stop_waiting_for_system_events_) {
+  if (time <= CurrentMonotonicTime() || stop_waiting_for_system_events_) {
     stop_waiting_for_system_events_ = false;
     return nullptr;
   }

--- a/starboard/shared/win32/application_win32.h
+++ b/starboard/shared/win32/application_win32.h
@@ -23,6 +23,7 @@
 #include <unordered_map>
 
 #include "starboard/common/mutex.h"
+#include "starboard/common/time.h"
 #include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/localized_strings.h"
 #include "starboard/shared/starboard/queue_application.h"
@@ -52,7 +53,7 @@ class ApplicationWin32 : public starboard::QueueApplication {
 
   bool DestroyWindow(SbWindow window);
 
-  void DispatchStart(SbTimeMonotonic timestamp) {
+  void DispatchStart(int64_t timestamp) {
     shared::starboard::Application::DispatchStart(timestamp);
   }
 
@@ -71,10 +72,11 @@ class ApplicationWin32 : public starboard::QueueApplication {
   // Returns true if it is valid to poll/query for system events.
   bool MayHaveSystemEvents() override { return true; }
 
-  // Waits for an event until the timeout |time| runs out.  If an event occurs
-  // in this time, it is returned, otherwise NULL is returned. If |time| is zero
-  // or negative, then this should function effectively like a no-wait poll.
-  Event* WaitForSystemEventWithTimeout(SbTime time) override;
+  // Waits for an event until the timeout |time| runs out (in microseconds).  If
+  // an event occurs in this time, it is returned, otherwise NULL is returned.
+  // If |time| is zero or negative, then this should function effectively like a
+  // no-wait poll.
+  Event* WaitForSystemEventWithTimeout(int64_t time) override;
 
   // Wakes up any thread waiting within a call to
   // WaitForSystemEventWithTimeout().
@@ -96,8 +98,8 @@ class ApplicationWin32 : public starboard::QueueApplication {
   void Teardown() override {}
 
   void ProcessNextSystemMessage();
-  SbTimeMonotonic GetNextTimedEventTargetTime() override {
-    return SbTimeGetMonotonicNow();
+  int64_t GetNextTimedEventTargetTime() override {
+    return CurrentMonotonicTime();
   }
 
   // Processes window key events, returning a corresponding Event instance.

--- a/starboard/shared/win32/audio_decoder_thread.cc
+++ b/starboard/shared/win32/audio_decoder_thread.cc
@@ -111,7 +111,7 @@ void AudioDecoderThread::Run() {
     }
 
     if (!work_done) {
-      semaphore_.TakeWait(kSbTimeMillisecond);
+      semaphore_.TakeWait(1000);
     }
   }
 }

--- a/starboard/shared/win32/audio_sink.cc
+++ b/starboard/shared/win32/audio_sink.cc
@@ -24,12 +24,12 @@
 #include "starboard/common/condition_variable.h"
 #include "starboard/common/log.h"
 #include "starboard/common/mutex.h"
+#include "starboard/common/time.h"
 #include "starboard/configuration.h"
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 #include "starboard/shared/starboard/player/job_thread.h"
 #include "starboard/shared/starboard/thread_checker.h"
 #include "starboard/thread.h"
-#include "starboard/time.h"
 
 namespace starboard {
 namespace shared {
@@ -362,7 +362,7 @@ void XAudioAudioSink::Process() {
   SB_DCHECK(consumed_frames <= std::numeric_limits<int>::max());
   int consumed_frames_int = static_cast<int>(consumed_frames);
 
-  consume_frames_func_(consumed_frames_int, SbTimeGetMonotonicNow(), context_);
+  consume_frames_func_(consumed_frames_int, CurrentMonotonicTime(), context_);
   submitted_frames_ -= consumed_frames_int;
   samples_played_ = voice_state.SamplesPlayed;
   queued_buffers_ = voice_state.BuffersQueued;

--- a/starboard/shared/win32/condition_variable_wait_timed.cc
+++ b/starboard/shared/win32/condition_variable_wait_timed.cc
@@ -19,12 +19,12 @@
 #include "starboard/shared/win32/time_utils.h"
 #include "starboard/shared/win32/types_internal.h"
 
-using starboard::shared::win32::ConvertSbTimeToMillisRoundUp;
+using starboard::shared::win32::ConvertUsecToMillisRoundUp;
 
 SbConditionVariableResult SbConditionVariableWaitTimed(
     SbConditionVariable* condition,
     SbMutex* mutex,
-    SbTime timeout) {
+    int64_t timeout) {
   if (!condition || !mutex) {
     return kSbConditionVariableFailed;
   }
@@ -34,7 +34,7 @@ SbConditionVariableResult SbConditionVariableWaitTimed(
   }
   bool result = SleepConditionVariableSRW(
       SB_WIN32_INTERNAL_CONDITION(condition), SB_WIN32_INTERNAL_MUTEX(mutex),
-      ConvertSbTimeToMillisRoundUp(timeout), 0);
+      ConvertUsecToMillisRoundUp(timeout), 0);
 
   if (timeout == 0) {
     // Per documentation, "If the |timeout_duration| value is less than

--- a/starboard/shared/win32/decrypting_decoder.cc
+++ b/starboard/shared/win32/decrypting_decoder.cc
@@ -148,7 +148,7 @@ bool DecryptingDecoder::TryWriteInputBuffer(
     int size = input_buffer->size() - bytes_to_skip_in_sample;
 
     std::int64_t win32_timestamp =
-        ConvertToWin32Time(input_buffer->timestamp());
+        ConvertUsecToWin32Time(input_buffer->timestamp());
     const uint8_t* iv = NULL;
     int iv_size = 0;
     const SbDrmSubSampleMapping* subsample_mapping = NULL;

--- a/starboard/shared/win32/file_get_info.cc
+++ b/starboard/shared/win32/file_get_info.cc
@@ -43,14 +43,13 @@ bool SbFileGetInfo(SbFile file, SbFileInfo* out_info) {
   out_info->size = standard_info.EndOfFile.QuadPart;
   SB_DCHECK(out_info->size >= 0);
 
-  using starboard::shared::win32::ConvertFileTimeTicksToSbTime;
+  using starboard::shared::win32::ConvertFileTimeTicksToUsec;
 
-  out_info->creation_time =
-      ConvertFileTimeTicksToSbTime(basic_info.CreationTime);
+  out_info->creation_time = ConvertFileTimeTicksToUsec(basic_info.CreationTime);
   out_info->last_accessed =
-      ConvertFileTimeTicksToSbTime(basic_info.LastAccessTime);
+      ConvertFileTimeTicksToUsec(basic_info.LastAccessTime);
   out_info->last_modified =
-      ConvertFileTimeTicksToSbTime(basic_info.LastWriteTime);
+      ConvertFileTimeTicksToUsec(basic_info.LastWriteTime);
 
   out_info->is_symbolic_link = false;
   out_info->is_directory = standard_info.Directory;

--- a/starboard/shared/win32/file_get_path_info.cc
+++ b/starboard/shared/win32/file_get_path_info.cc
@@ -87,14 +87,14 @@ bool SbFileGetPathInfo(const char* path, SbFileInfo* out_info) {
                    attribute_data.nFileSizeLow;
   SB_DCHECK(out_info->size >= 0);
 
-  using starboard::shared::win32::ConvertFileTimeToSbTime;
+  using starboard::shared::win32::ConvertFileTimeToUsec;
 
   out_info->creation_time =
-      ConvertFileTimeToSbTime(attribute_data.ftCreationTime);
+      ConvertFileTimeToUsec(attribute_data.ftCreationTime);
   out_info->last_accessed =
-      ConvertFileTimeToSbTime(attribute_data.ftLastAccessTime);
+      ConvertFileTimeToUsec(attribute_data.ftLastAccessTime);
   out_info->last_modified =
-      ConvertFileTimeToSbTime(attribute_data.ftLastWriteTime);
+      ConvertFileTimeToUsec(attribute_data.ftLastWriteTime);
 
   out_info->is_symbolic_link = false;
   out_info->is_directory =

--- a/starboard/shared/win32/media_common.cc
+++ b/starboard/shared/win32/media_common.cc
@@ -36,15 +36,15 @@ namespace shared {
 namespace win32 {
 
 // Converts microseconds to 10Mhz (100ns time).
-int64_t ConvertToWin32Time(SbTime input) {
+int64_t ConvertUsecToWin32Time(int64_t input) {
   int64_t out = input;
   out *= 10;
   return out;
 }
 
 // Convert the other way around.
-SbTime ConvertToSbTime(int64_t input) {
-  SbTime out = input;
+int64_t ConvertWin32TimeToUsec(int64_t input) {
+  int64_t out = input;
   out /= 10;
   return out;
 }

--- a/starboard/shared/win32/media_common.h
+++ b/starboard/shared/win32/media_common.h
@@ -51,10 +51,10 @@ using VideoFramePtr = ::starboard::scoped_refptr<VideoFrame>;
 using Microsoft::WRL::ComPtr;
 
 // Converts microseconds to 10Mhz (100ns time).
-int64_t ConvertToWin32Time(SbTime input);
+int64_t ConvertUsecToWin32Time(int64_t input);
 
 // Convert the other way around.
-SbTime ConvertToSbTime(int64_t input);
+int64_t ConvertWin32TimeToUsec(int64_t input);
 
 std::vector<ComPtr<IMFMediaType>> GetAllOutputMediaTypes(int stream_id,
                                                          IMFTransform* decoder);

--- a/starboard/shared/win32/socket_set_tcp_keep_alive.cc
+++ b/starboard/shared/win32/socket_set_tcp_keep_alive.cc
@@ -21,7 +21,7 @@
 
 namespace sbwin32 = starboard::shared::win32;
 
-bool SbSocketSetTcpKeepAlive(SbSocket socket, bool value, SbTime period) {
+bool SbSocketSetTcpKeepAlive(SbSocket socket, bool value, int64_t period) {
   bool result = sbwin32::SetBooleanSocketOption(
       socket, SOL_SOCKET, SO_KEEPALIVE, "SO_KEEPALIVE", value);
   return result;

--- a/starboard/shared/win32/socket_waiter_internal.h
+++ b/starboard/shared/win32/socket_waiter_internal.h
@@ -55,7 +55,7 @@ class SbSocketWaiterPrivate {
            bool persistent);
   bool Remove(SbSocket socket);
   void Wait();
-  SbSocketWaiterResult WaitTimed(SbTime duration);
+  SbSocketWaiterResult WaitTimed(int64_t duration_usec);
   void WakeUp();
   void HandleWakeUpRead();
 

--- a/starboard/shared/win32/socket_waiter_wait_timed.cc
+++ b/starboard/shared/win32/socket_waiter_wait_timed.cc
@@ -17,7 +17,7 @@
 #include "starboard/shared/win32/socket_waiter_internal.h"
 
 SbSocketWaiterResult SbSocketWaiterWaitTimed(SbSocketWaiter waiter,
-                                             SbTime duration) {
+                                             int64_t duration) {
   if (!SbSocketWaiterIsValid(waiter)) {
     return kSbSocketWaiterResultInvalid;
   }

--- a/starboard/shared/win32/starboard_main.cc
+++ b/starboard/shared/win32/starboard_main.cc
@@ -40,12 +40,12 @@ namespace {
 
 void WaitForNetLogIfNecessary(const CommandLine& cmd_line) {
   if (cmd_line.HasSwitch(kNetLogCommandSwitchWait)) {
-    SbTime timeout = kSbTimeSecond * 2;
+    int64_t timeout_usec = 2'000'000;  // 2 seconds.
     std::string val = cmd_line.GetSwitchValue(kNetLogCommandSwitchWait);
     if (!val.empty()) {
-      timeout = atoi(val.c_str());
+      timeout_usec = atoi(val.c_str());
     }
-    NetLogWaitForClientConnected(timeout);
+    NetLogWaitForClientConnected(timeout_usec);
   }
 }
 

--- a/starboard/shared/win32/thread_sleep.cc
+++ b/starboard/shared/win32/thread_sleep.cc
@@ -18,11 +18,11 @@
 
 #include "starboard/shared/win32/time_utils.h"
 
-using starboard::shared::win32::ConvertSbTimeToMillisRoundUp;
+using starboard::shared::win32::ConvertUsecToMillisRoundUp;
 
-void SbThreadSleep(SbTime duration) {
+void SbThreadSleep(int64_t duration) {
   if (duration < 0) {
     return;
   }
-  Sleep(ConvertSbTimeToMillisRoundUp(duration));
+  Sleep(ConvertUsecToMillisRoundUp(duration));
 }

--- a/starboard/shared/win32/time_get_monotonic_now.cc
+++ b/starboard/shared/win32/time_get_monotonic_now.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 #include <windows.h>
@@ -45,3 +47,5 @@ SbTimeMonotonic SbTimeGetMonotonicNow() {
 
   return static_cast<SbTimeMonotonic>(result);
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/win32/time_get_now.cc
+++ b/starboard/shared/win32/time_get_now.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if SB_API_VERSION < 16
+
 #include "starboard/time.h"
 
 #include <windows.h>
@@ -28,3 +30,5 @@ SbTime SbTimeGetNow() {
   large_int.HighPart = file_time.dwHighDateTime;
   return static_cast<SbTime>(large_int.QuadPart) / 10;
 }
+
+#endif  // SB_API_VERSION < 16

--- a/starboard/shared/win32/time_utils.h
+++ b/starboard/shared/win32/time_utils.h
@@ -21,7 +21,7 @@ namespace starboard {
 namespace shared {
 namespace win32 {
 
-inline SbTime ConvertFileTimeTicksToSbTime(const LARGE_INTEGER ticks) {
+inline int64_t ConvertFileTimeTicksToUsec(const LARGE_INTEGER ticks) {
   // According to
   // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
   // FILETIME format is "Contains a 64-bit value representing the number of
@@ -30,7 +30,7 @@ inline SbTime ConvertFileTimeTicksToSbTime(const LARGE_INTEGER ticks) {
   return ticks.QuadPart / kNumber100nanosecondTicksInMicrosecond;
 }
 
-inline SbTime ConvertFileTimeToSbTime(const FILETIME file_time) {
+inline int64_t ConvertFileTimeToUsec(const FILETIME file_time) {
   // According to
   // https://msdn.microsoft.com/en-us/library/windows/desktop/ms724284(v=vs.85).aspx
   // FILETIME format is "Contains a 64-bit value representing the number of
@@ -38,21 +38,14 @@ inline SbTime ConvertFileTimeToSbTime(const FILETIME file_time) {
   LARGE_INTEGER ticks;
   ticks.QuadPart = (static_cast<LONGLONG>(file_time.dwHighDateTime) << 32) |
                    file_time.dwLowDateTime;
-  return ConvertFileTimeTicksToSbTime(ticks);
+  return ConvertFileTimeTicksToUsec(ticks);
 }
 
-inline SbTime ConvertSystemTimeToSbTime(const SYSTEMTIME system_time) {
-  FILETIME file_time = {0};
-  SystemTimeToFileTime(&system_time, &file_time);
-  return ConvertFileTimeToSbTime(file_time);
-}
-
-// Many Win32 calls take millis, but SbTime is microseconds.
+// Many Win32 calls take millis, but Starboard uses microseconds.
 // Many nplb tests assume waits are at least as long as requested, so
 // round up.
-inline DWORD ConvertSbTimeToMillisRoundUp(SbTime duration) {
-  const int64_t milliseconds_to_sleep =
-      (duration + kSbTimeMillisecond - 1) / kSbTimeMillisecond;
+inline DWORD ConvertUsecToMillisRoundUp(int64_t duration_usec) {
+  const int64_t milliseconds_to_sleep = (duration_usec + 1000 - 1) / 1000;
   return static_cast<DWORD>(milliseconds_to_sleep);
 }
 

--- a/starboard/shared/win32/video_decoder.h
+++ b/starboard/shared/win32/video_decoder.h
@@ -58,7 +58,7 @@ class VideoDecoder
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) override;
   size_t GetPrerollFrameCount() const override;
-  SbTime GetPrerollTimeout() const override { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const override { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override;
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;
@@ -83,11 +83,11 @@ class VideoDecoder
   };
 
   struct Output {
-    Output(SbTime time,
+    Output(int64_t time,
            const RECT& video_area,
            const ComPtr<IMFSample>& video_sample)
         : time(time), video_area(video_area), video_sample(video_sample) {}
-    SbTime time;
+    int64_t time;
     RECT video_area;
     ComPtr<IMFSample> video_sample;
   };

--- a/starboard/shared/win32/win32_audio_decoder.cc
+++ b/starboard/shared/win32/win32_audio_decoder.cc
@@ -129,9 +129,10 @@ class AbstractWin32AudioDecoderImpl : public AbstractWin32AudioDecoder {
       SB_DCHECK(decoded_data_size == kEac3BufferSize);
     }
 
-    DecodedAudioPtr data_ptr(new DecodedAudio(
-        number_of_channels_, sample_type_, audio_frame_fmt_,
-        ConvertToSbTime(win32_timestamp), static_cast<int>(decoded_data_size)));
+    DecodedAudioPtr data_ptr(
+        new DecodedAudio(number_of_channels_, sample_type_, audio_frame_fmt_,
+                         ConvertWin32TimeToUsec(win32_timestamp),
+                         static_cast<int>(decoded_data_size)));
 
     std::copy(data, data + data_size, data_ptr->data());
     std::memset(data_ptr->data() + data_size, 0, decoded_data_size - data_size);

--- a/starboard/shared/win32/window_internal.h
+++ b/starboard/shared/win32/window_internal.h
@@ -21,7 +21,6 @@
 #include <windows.h>
 
 #include "starboard/atomic.h"
-#include "starboard/time.h"
 #include "starboard/window.h"
 
 struct SbWindowPrivate {

--- a/starboard/shared/x11/application_x11.cc
+++ b/starboard/shared/x11/application_x11.cc
@@ -36,11 +36,9 @@
 #include "starboard/key.h"
 #include "starboard/player.h"
 #include "starboard/shared/linux/system_network_status.h"
-#include "starboard/shared/posix/time_internal.h"
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 #include "starboard/shared/starboard/player/filter/cpu_video_frame.h"
 #include "starboard/shared/x11/window_internal.h"
-#include "starboard/time.h"
 
 namespace {
 const char kTouchscreenPointerSwitch[] = "touchscreen_pointer";
@@ -805,7 +803,7 @@ void ApplicationX11::Composite() {
     }
   }
   composite_event_id_ =
-      SbEventSchedule(&CompositeCallback, this, kSbTimeSecond / 60);
+      SbEventSchedule(&CompositeCallback, this, 1'000'000 / 60);
 }
 
 void ApplicationX11::AcceptFrame(SbPlayer player,
@@ -911,7 +909,7 @@ bool ApplicationX11::MayHaveSystemEvents() {
 }
 
 shared::starboard::Application::Event*
-ApplicationX11::WaitForSystemEventWithTimeout(SbTime time) {
+ApplicationX11::WaitForSystemEventWithTimeout(int64_t time) {
   SB_DCHECK(display_);
 
   shared::starboard::Application::Event* pending_event = GetPendingEvent();

--- a/starboard/shared/x11/application_x11.h
+++ b/starboard/shared/x11/application_x11.h
@@ -91,7 +91,7 @@ class ApplicationX11 : public shared::starboard::QueueApplication {
 
   // --- QueueApplication overrides ---
   bool MayHaveSystemEvents() override;
-  Event* WaitForSystemEventWithTimeout(SbTime time) override;
+  Event* WaitForSystemEventWithTimeout(int64_t time) override;
   void WakeSystemEventWait() override;
 
  private:

--- a/starboard/socket.h
+++ b/starboard/socket.h
@@ -34,7 +34,6 @@
 #define STARBOARD_SOCKET_H_
 
 #include "starboard/export.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus
@@ -356,14 +355,14 @@ SB_EXPORT bool SbSocketSetSendBufferSize(SbSocket socket, int32_t size);
 // return value indicates whether the option was actually set.
 //
 // |socket|: The SbSocket for which the option is set.
-// |value|: If set to |true|, then |period| specifies the minimum time
-//   (SbTime) is always in microseconds) between keep-alive packets. If
-//   set to |false|, |period| is ignored.
-// |period|: The time between keep-alive packets. This value is only relevant
-//   if |value| is |true|.
+// |value|: If set to |true|, then |period| specifies the minimum time in
+//   microseconds between keep-alive packets. If set to |false|, |period|
+//   is ignored.
+// |period|: The time in microseconds between keep-alive packets. This value
+//   is only relevant if |value| is |true|.
 SB_EXPORT bool SbSocketSetTcpKeepAlive(SbSocket socket,
                                        bool value,
-                                       SbTime period);
+                                       int64_t period);
 
 // Sets the |TCP_NODELAY|, or equivalent, option to |value| on |socket|. The
 // return value indicates whether the option was actually set.

--- a/starboard/socket_waiter.h
+++ b/starboard/socket_waiter.h
@@ -36,7 +36,6 @@
 
 #include "starboard/export.h"
 #include "starboard/socket.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus
@@ -164,12 +163,12 @@ SB_EXPORT void SbSocketWaiterWait(SbSocketWaiter waiter);
 // The return value indicates the reason that the socket waiter exited.
 // This function should only be called on the thread that waits on this waiter.
 //
-// |duration|: The minimum amount of time after which the socket waiter should
-//   exit if it is not woken up before then. As with SbThreadSleep() (see
-//   thread.h), this function may wait longer than |duration|, such as if the
-//   timeout expires while a callback is being fired.
+// |duration|: The minimum amount of time in microseconds after which the socket
+//   waiter should exit if it is not woken up before then. As with
+//   SbThreadSleep() (see thread.h), this function may wait longer than
+//   |duration|, such as if the timeout expires while a callback is being fired.
 SB_EXPORT SbSocketWaiterResult SbSocketWaiterWaitTimed(SbSocketWaiter waiter,
-                                                       SbTime duration);
+                                                       int64_t duration);
 
 // Wakes up |waiter| once. This is the only thread-safe waiter function.
 // It can can be called from a SbSocketWaiterCallback to wake up its own waiter,

--- a/starboard/stub/application_stub.cc
+++ b/starboard/stub/application_stub.cc
@@ -42,7 +42,7 @@ shared::starboard::Application::Event* ApplicationStub::PollNextSystemEvent() {
 }
 
 shared::starboard::Application::Event*
-ApplicationStub::WaitForSystemEventWithTimeout(SbTime time) {
+ApplicationStub::WaitForSystemEventWithTimeout(int64_t time) {
   return NULL;
 }
 

--- a/starboard/stub/application_stub.h
+++ b/starboard/stub/application_stub.h
@@ -47,7 +47,7 @@ class ApplicationStub : public shared::starboard::QueueApplication {
   // --- QueueApplication overrides ---
   bool MayHaveSystemEvents() override;
   Event* PollNextSystemEvent() override;
-  Event* WaitForSystemEventWithTimeout(SbTime time) override;
+  Event* WaitForSystemEventWithTimeout(int64_t time) override;
   void WakeSystemEventWait() override;
 };
 

--- a/starboard/thread.h
+++ b/starboard/thread.h
@@ -21,7 +21,6 @@
 
 #include "starboard/configuration.h"
 #include "starboard/export.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus
@@ -199,7 +198,7 @@ SB_EXPORT void SbThreadYield();
 // |duration|: The minimum amount of time, in microseconds, that the currently
 //   executing thread should sleep. The function is a no-op if this value is
 //   negative or |0|.
-SB_EXPORT void SbThreadSleep(SbTime duration);
+SB_EXPORT void SbThreadSleep(int64_t duration);
 
 // Returns the handle of the currently executing thread.
 SB_EXPORT SbThread SbThreadGetCurrent();

--- a/starboard/time.h
+++ b/starboard/time.h
@@ -19,6 +19,8 @@
 #ifndef STARBOARD_TIME_H_
 #define STARBOARD_TIME_H_
 
+#if SB_API_VERSION < 16
+
 #include "starboard/export.h"
 #include "starboard/types.h"
 
@@ -91,8 +93,6 @@ SB_EXPORT SbTime SbTimeGetNow();
 // Gets a monotonically increasing time representing right now.
 SB_EXPORT SbTimeMonotonic SbTimeGetMonotonicNow();
 
-#if SB_API_VERSION < 16
-
 // Returns whether the current platform supports time thread now
 SB_EXPORT bool SbTimeIsTimeThreadNowSupported();
 
@@ -103,10 +103,14 @@ SB_EXPORT bool SbTimeIsTimeThreadNowSupported();
 // available then SbTimeGetMonotonicNow() should be used.
 SB_EXPORT SbTimeMonotonic SbTimeGetMonotonicThreadNow();
 
-#endif  // SB_API_VERSION < 16
-
 #ifdef __cplusplus
 }  // extern "C"
 #endif
+
+#else  // SB_API_VERSION < 16
+
+#error This file is deprecated with SB_API_VERSION 16.
+
+#endif  // SB_API_VERSION < 16
 
 #endif  // STARBOARD_TIME_H_

--- a/starboard/user.h
+++ b/starboard/user.h
@@ -28,7 +28,6 @@
 #if SB_API_VERSION < 16
 
 #include "starboard/export.h"
-#include "starboard/time.h"
 #include "starboard/types.h"
 
 #ifdef __cplusplus

--- a/starboard/xb1/shared/gpu_base_video_decoder.cc
+++ b/starboard/xb1/shared/gpu_base_video_decoder.cc
@@ -209,7 +209,7 @@ class GpuVideoDecoderBase::GPUDecodeTargetPrivate
     }
   }
 
-  SbTime timestamp() { return image_->timestamp(); }
+  int64_t timestamp() { return image_->timestamp(); }
 
   void ReleaseImage() {
     // Release the codec resource, while the D3D textures are still safe to use.
@@ -551,7 +551,7 @@ int GpuVideoDecoderBase::OnOutputRetrieved(
     return 0;
   }
 
-  SbTime timestamp = image->timestamp();
+  int64_t timestamp = image->timestamp();
   {
     ScopedLock input_queue_lock(written_inputs_mutex_);
     const auto iter = FindByTimestamp(written_inputs_, timestamp);
@@ -669,8 +669,7 @@ void GpuVideoDecoderBase::DecodeEndOfStream() {
     ScopedLock pending_inputs_lock(pending_inputs_mutex_);
     if (!pending_inputs_.empty()) {
       decoder_thread_->job_queue()->Schedule(
-          std::bind(&GpuVideoDecoderBase::DecodeEndOfStream, this),
-          kSbTimeMillisecond);
+          std::bind(&GpuVideoDecoderBase::DecodeEndOfStream, this), 1000);
       return;
     }
   }
@@ -784,7 +783,7 @@ GpuVideoDecoderBase::GetAvailableFrameBuffer(uint16_t width, uint16_t height) {
         return nullptr;
       }
       is_resetting = decoder_behavior_.load() == kResettingDecoder;
-      frame_buffers_condition_.WaitTimed(50 * kSbTimeMillisecond);
+      frame_buffers_condition_.WaitTimed(50'000);  // 50ms
       continue;
     }
   }

--- a/starboard/xb1/shared/gpu_base_video_decoder.h
+++ b/starboard/xb1/shared/gpu_base_video_decoder.h
@@ -131,7 +131,7 @@ class GpuVideoDecoderBase
       SB_DCHECK(index < kNumberOfPlanes);
       return strides_[index];
     }
-    SbTime timestamp() const { return timestamp_; }
+    int64_t timestamp() const { return timestamp_; }
     const SbMediaColorMetadata& color_metadata() const {
       return color_metadata_;
     }
@@ -152,7 +152,7 @@ class GpuVideoDecoderBase
     int texture_corner_top_[kNumberOfPlanes];
     Microsoft::WRL::ComPtr<ID3D11Texture2D> textures_[kNumberOfPlanes];
     int strides_[kNumberOfPlanes];
-    SbTime timestamp_;
+    int64_t timestamp_;  // microseconds
     SbMediaColorMetadata color_metadata_;
     const std::function<void(void)> release_cb_;
   };
@@ -178,7 +178,7 @@ class GpuVideoDecoderBase
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) final;
   size_t GetPrerollFrameCount() const final;
-  SbTime GetPrerollTimeout() const final { return kSbTimeMax; }
+  int64_t GetPrerollTimeout() const final { return kSbInt64Max; }
   size_t GetMaxNumberOfCachedFrames() const override;
 
   void WriteInputBuffers(const InputBuffers& input_buffers) final;

--- a/starboard/xb1/shared/video_frame_impl.h
+++ b/starboard/xb1/shared/video_frame_impl.h
@@ -29,7 +29,7 @@ class VideoFrameImpl
  public:
   typedef ::starboard::shared::starboard::player::filter::VideoFrame VideoFrame;
 
-  VideoFrameImpl(SbTime timestamp, std::function<void(VideoFrame*)> release_cb)
+  VideoFrameImpl(int64_t timestamp, std::function<void(VideoFrame*)> release_cb)
       : VideoFrame(timestamp), release_cb_(release_cb) {
     SB_DCHECK(release_cb_);
   }

--- a/third_party/v8/src/base/platform/platform-starboard.cc
+++ b/third_party/v8/src/base/platform/platform-starboard.cc
@@ -22,7 +22,6 @@
 #include "starboard/configuration.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/memory.h"
-#include "starboard/time.h"
 #include "starboard/time_zone.h"
 
 namespace v8 {

--- a/third_party/v8/src/base/platform/time.cc
+++ b/third_party/v8/src/base/platform/time.cc
@@ -31,7 +31,6 @@
 
 #if V8_OS_STARBOARD
 #include "starboard/common/time.h"
-#include "starboard/time.h"
 #endif
 
 namespace {


### PR DESCRIPTION
- Replace all remaining usages of SbTime
- Deprecate the APIs in starboard/time.h

b/302733082

Test-On-Device: true