### PR TITLE
Fix test to accept -1 as well

### DIFF
--- a/starboard/nplb/posix_compliance/posix_time_test.cc
+++ b/starboard/nplb/posix_compliance/posix_time_test.cc
@@ -110,7 +110,7 @@ TEST(PosixTimeTest, GmtimeR) {
   EXPECT_EQ(result.tm_sec, 59);
   EXPECT_EQ(result.tm_wday, 3);    // Wednesday, 0==Sunday.
   EXPECT_EQ(result.tm_yday, 212);  // Zero-indexed; 2024 is a leap year.
-  EXPECT_EQ(result.tm_isdst, 0);   // GMT/UTC never has DST (even in July).
+  EXPECT_LE(result.tm_isdst, 0);   // <=0; GMT/UTC never has DST (even in July).
 }
 
 }  // namespace


### PR DESCRIPTION
Per https://pubs.opengroup.org/onlinepubs/7908799/xsh/time.h.html the value of tm_isdst is positive if Daylight Saving Time is in effect, 0 if Daylight Saving Time is not in effect, and negative if the information is not available.

b/320398326

Test-On-Device: true