### PR TITLE
Improve Nested Flexboxes.

### DIFF
--- a/cobalt/layout/box.h
+++ b/cobalt/layout/box.h
@@ -116,7 +116,9 @@ inline std::ostream& operator<<(std::ostream& stream,
   stream << "{shrink_to_fit_width_forced=" << params.shrink_to_fit_width_forced
          << " freeze_width=" << params.freeze_width
          << " freeze_height=" << params.freeze_height
-         << " containing_block_size=" << params.containing_block_size << "}";
+         << " containing_block_size=" << params.containing_block_size
+         << " containing_block_direction=" << params.containing_block_direction
+         << "}";
   return stream;
 }
 

--- a/cobalt/layout/container_box.cc
+++ b/cobalt/layout/container_box.cc
@@ -52,9 +52,6 @@ Boxes::iterator ContainerBox::RemoveConst(Boxes* container,
 }
 
 void ContainerBox::PushBackDirectChild(const scoped_refptr<Box>& child_box) {
-  // Verify that the child doesn't have a pre-existing parent.
-  DCHECK(!child_box->parent());
-
   // Verify that this container hasn't had its sizes and cross references
   // already updated. This is because children should only ever be added to
   // containers created during the current box generation run.

--- a/cobalt/layout/flex_container_box.cc
+++ b/cobalt/layout/flex_container_box.cc
@@ -20,7 +20,9 @@
 
 #include "cobalt/cssom/computed_style.h"
 #include "cobalt/cssom/keyword_value.h"
+#include "cobalt/cssom/property_value_visitor.h"
 #include "cobalt/layout/anonymous_block_box.h"
+#include "cobalt/layout/block_formatting_block_container_box.h"
 #include "cobalt/layout/text_box.h"
 #include "cobalt/layout/used_style.h"
 
@@ -398,11 +400,109 @@ bool FlexContainerBox::TryAddChild(const scoped_refptr<Box>& child_box) {
   return true;
 }
 
+namespace {
+class ComputedLengthIsDefiniteProvider
+    : public cssom::DefaultingPropertyValueVisitor {
+ public:
+  ComputedLengthIsDefiniteProvider() : computed_length_is_definite_(false) {}
+
+  void VisitLength(cssom::LengthValue* length_value) override {
+    computed_length_is_definite_ = true;
+  }
+
+  void VisitDefault(cssom::PropertyValue* property_value) override {}
+
+  bool computed_length_is_definite() { return computed_length_is_definite_; }
+
+ private:
+  bool computed_length_is_definite_;
+};
+
+bool LengthIsDefinite(cssom::PropertyValue* length) {
+  ComputedLengthIsDefiniteProvider computed_length_is_definite_provider;
+  length->Accept(&computed_length_is_definite_provider);
+  return computed_length_is_definite_provider.computed_length_is_definite();
+}
+}  // namespace
+
+void FlexContainerBox::PushBackBloxBoxAndChild(
+    const scoped_refptr<Box>& child_box) {
+  // Special handling of a box that is both a flex item and a flex container:
+  // . Add a Block container with the child's style.
+  // . Add a Flex container with:
+  //   . 100% width, and
+  //   . 100% height if the child's height is definite, and
+  //   . with any style from the child that applies to flex containers, and
+  //   . add the grandchildren.
+
+  // Add a Block container.
+  scoped_refptr<cssom::CSSComputedStyleDeclaration> block_style_declaration =
+      new cssom::CSSComputedStyleDeclaration();
+  scoped_refptr<cssom::MutableCSSComputedStyleData> block_style =
+      new cssom::MutableCSSComputedStyleData();
+
+  // Add the child's style.
+  block_style->AssignFrom(*child_box->computed_style());
+  block_style_declaration->SetData(block_style);
+  block_style_declaration->set_animations(new web_animations::AnimationSet());
+
+  scoped_refptr<BlockLevelBlockContainerBox> new_block_container(
+      new BlockLevelBlockContainerBox(block_style_declaration, base_direction(),
+                                      used_style_provider(),
+                                      layout_stat_tracker()));
+
+  // Add a Flex container.
+  scoped_refptr<cssom::CSSComputedStyleDeclaration> flex_style_declaration =
+      new cssom::CSSComputedStyleDeclaration();
+  scoped_refptr<cssom::MutableCSSComputedStyleData> flex_style =
+      new cssom::MutableCSSComputedStyleData();
+
+  // Size the container width at 100% of the block box width.
+  flex_style->set_width(new cssom::PercentageValue(1.0f));
+  // Size the container height at 100% of the block box height if that is
+  // definite.
+  if (LengthIsDefinite(block_style->height().get())) {
+    flex_style->set_height(new cssom::PercentageValue(1.0f));
+  }
+
+  // Add all style that apply to flex containers from the child box.
+  cssom::PropertyKey flex_properties[] = {
+      cssom::kFlexDirectionProperty, cssom::kFlexWrapProperty,
+      cssom::kJustifyContentProperty, cssom::kAlignItemsProperty,
+      cssom::kAlignContentProperty};
+  for (const auto& key : flex_properties) {
+    if (child_box->computed_style()->IsDeclared(key)) {
+      flex_style->SetPropertyValue(
+          key, child_box->computed_style()->GetPropertyValue(key));
+    }
+  }
+  flex_style_declaration->SetData(flex_style);
+  flex_style_declaration->set_animations(new web_animations::AnimationSet());
+
+  scoped_refptr<BlockLevelFlexContainerBox> new_flex_container(
+      new BlockLevelFlexContainerBox(flex_style_declaration, base_direction(),
+                                     used_style_provider(),
+                                     layout_stat_tracker()));
+
+  // Add the grandchildren.
+  for (const auto& box : child_box->AsContainerBox()->child_boxes()) {
+    new_flex_container->PushBackDirectChild(box);
+  }
+
+  new_block_container->PushBackDirectChild(new_flex_container);
+  PushBackDirectChild(new_block_container);
+}
+
 void FlexContainerBox::AddChild(const scoped_refptr<Box>& child_box) {
   TextBox* text_box = child_box->AsTextBox();
   switch (child_box->GetLevel()) {
     case kBlockLevel:
-      PushBackDirectChild(child_box);
+      if (child_box->computed_style()->display() ==
+          cssom::KeywordValue::GetFlex()) {
+        PushBackBloxBoxAndChild(child_box);
+      } else {
+        PushBackDirectChild(child_box);
+      }
       break;
     case kInlineLevel:
       if (text_box && !text_box->HasNonCollapsibleText()) {

--- a/cobalt/layout/flex_container_box.h
+++ b/cobalt/layout/flex_container_box.h
@@ -131,6 +131,8 @@ class FlexContainerBox : public BlockContainerBox {
   AnonymousBlockBox* GetLastChildAsAnonymousBlockBox();
   AnonymousBlockBox* GetOrAddAnonymousBlockBox();
 
+  void PushBackBloxBoxAndChild(const scoped_refptr<Box>& child_box);
+
   DISALLOW_COPY_AND_ASSIGN(FlexContainerBox);
 };
 

--- a/cobalt/layout/flex_formatting_context.h
+++ b/cobalt/layout/flex_formatting_context.h
@@ -83,6 +83,17 @@ class FlexFormattingContext : public FormattingContext {
 
   std::vector<std::unique_ptr<FlexLine>> lines_;
 
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const FlexFormattingContext& data) {
+    os << "layout_params=" << data.layout_params_
+       << " main_direction_is_horizontal=" << data.main_direction_is_horizontal_
+       << " direction_is_reversed=" << data.direction_is_reversed_
+       << " multi_line=" << data.multi_line_
+       << " cross_size=" << data.cross_size_
+       << " fit_content_main_size_=" << data.fit_content_main_size_;
+    return os;
+  }
+
   DISALLOW_COPY_AND_ASSIGN(FlexFormattingContext);
 };
 

--- a/cobalt/layout/flex_item.cc
+++ b/cobalt/layout/flex_item.cc
@@ -256,8 +256,9 @@ void MainAxisVerticalFlexItem::DetermineHypotheticalCrossSize(
   //   https://www.w3.org/TR/css-flexbox-1/#algo-cross-item
   LayoutParams child_layout_params(layout_params);
   child_layout_params.shrink_to_fit_width_forced = true;
-  box()->UpdateSize(child_layout_params);
+  child_layout_params.freeze_height = true;
   box()->set_height(target_main_size());
+  box()->UpdateSize(child_layout_params);
 }
 
 LayoutUnit MainAxisVerticalFlexItem::GetContentBoxMainSize() const {
@@ -454,8 +455,8 @@ base::Optional<LayoutUnit> FlexItem::GetContentBasedMinimumSize(
       base::Optional<LayoutUnit> maybe_height =
           GetUsedHeightIfNotAuto(computed_style(), containing_block_size, NULL);
       content_size_suggestion =
-          box()->AsBlockContainerBox()->GetShrinkToFitWidth(
-              containing_block_size.width(), maybe_height);
+          box()->AsBlockContainerBox()->GetShrinkToFitWidth(LayoutUnit(),
+                                                            maybe_height);
     } else {
       content_size_suggestion = GetContentBoxMainSize();
     }


### PR DESCRIPTION
This fixes calculation for the main direction length and position of flex
items in horizontal flex containers that are themselves also flex containers
in vertical direction.

Further related improvements and tests will be added in a separate commit.

b/197582262