### PR TITLE
Avoid using #define in POSIX emu

### DIFF
--- a/starboard/shared/win32/posix_emu/include/posix_force_include.h
+++ b/starboard/shared/win32/posix_emu/include/posix_force_include.h
@@ -15,12 +15,10 @@
 #ifndef STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_POSIX_FORCE_INCLUDE_H_
 #define STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_POSIX_FORCE_INCLUDE_H_
 
+#if defined(STARBOARD)
+
 // MSVC deprecated strdup() in favor of _strdup()
 #define strdup _strdup
-#define strcasecmp _stricmp
-#define strncasecmp _strnicmp
-
-#if defined(STARBOARD)
 
 #define free sb_free
 
@@ -45,8 +43,14 @@ struct tm* gmtime_r(const time_t* timer, struct tm* result);
 
 int posix_memalign(void** res, size_t alignment, size_t size);
 
+// https://pubs.opengroup.org/onlinepubs/9699919799/functions/strcasecmp.html
+int strcasecmp(const char* s1, const char* s2);
+int strncasecmp(const char* s1, const char* s2, size_t n);
+
 #ifdef __cplusplus
 }
 #endif  // __cplusplus
+
 #endif  // defined(STARBOARD)
+
 #endif  // STARBOARD_SHARED_WIN32_POSIX_EMU_INCLUDE_POSIX_FORCE_INCLUDE_H_

--- a/starboard/shared/win32/posix_emu/string.cc
+++ b/starboard/shared/win32/posix_emu/string.cc
@@ -1,0 +1,31 @@
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <string.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+int strcasecmp(const char* s1, const char* s2) {
+  return _stricmp(s1, s2);
+}
+
+int strncasecmp(const char* s1, const char* s2, size_t n) {
+  return _strnicmp(s1, s2, n);
+}
+
+#ifdef __cplusplus
+}
+#endif

--- a/starboard/win/shared/BUILD.gn
+++ b/starboard/win/shared/BUILD.gn
@@ -236,6 +236,7 @@ static_library("starboard_platform") {
     "//starboard/shared/win32/posix_emu/mman.cc",
     "//starboard/shared/win32/posix_emu/posix_memalign.cc",
     "//starboard/shared/win32/posix_emu/pthread.cc",
+    "//starboard/shared/win32/posix_emu/string.cc",
     "//starboard/shared/win32/posix_emu/time.cc",
     "//starboard/shared/win32/set_non_blocking_internal.cc",
     "//starboard/shared/win32/set_non_blocking_internal.h",


### PR DESCRIPTION
Using #defines is brittle and can cause issues with other files, especially if they are put in the "posix_force_include.h" that is included in every single file being compiled.

b/305768669

Test-On-Device: true