### PR TITLE
[android] Handle mediacodec callback with a handler thread

### DIFF
--- a/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -31,6 +31,8 @@ import android.media.MediaCrypto;
 import android.media.MediaFormat;
 import android.os.Build;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.HandlerThread;
 import android.view.Surface;
 import androidx.annotation.Nullable;
 import dev.cobalt.util.Log;
@@ -92,6 +94,9 @@ class MediaCodecBridge {
   // Only create one of these and reuse it to avoid excessive allocations,
   // which would cause GC cycles long enough to impact playback.
   private final MediaCodec.BufferInfo info = new MediaCodec.BufferInfo();
+
+  private Handler mHandler = null;
+  private HandlerThread mCallbackThread = null;
 
   // Type of bitrate adjustment for video encoder.
   public enum BitrateAdjustmentTypes {
@@ -451,7 +456,8 @@ class MediaCodecBridge {
       MediaCodec mediaCodec,
       String mime,
       BitrateAdjustmentTypes bitrateAdjustmentType,
-      int tunnelModeAudioSessionId) {
+      int tunnelModeAudioSessionId,
+      boolean useCallbackThread) {
     if (mediaCodec == null) {
       throw new IllegalArgumentException();
     }
@@ -461,6 +467,11 @@ class MediaCodecBridge {
     mLastPresentationTimeUs = 0;
     mFlushed = true;
     mBitrateAdjustmentType = bitrateAdjustmentType;
+    if (useCallbackThread) {
+      mCallbackThread = new HandlerThread("MediaCodec:Callback:Handler");
+      mCallbackThread.start();
+      mHandler = new Handler(mCallbackThread.getLooper());
+    }
     mCallback =
         new MediaCodec.Callback() {
           @Override
@@ -525,7 +536,7 @@ class MediaCodecBridge {
             }
           }
         };
-    mMediaCodec.setCallback(mCallback);
+    mMediaCodec.setCallback(mCallback, mHandler);
 
     if (isFrameRenderedCallbackEnabled() || tunnelModeAudioSessionId != -1) {
       mFrameRendererListener =
@@ -579,7 +590,12 @@ class MediaCodecBridge {
     }
     MediaCodecBridge bridge =
         new MediaCodecBridge(
-            nativeMediaCodecBridge, mediaCodec, mime, BitrateAdjustmentTypes.NO_ADJUSTMENT, -1);
+            nativeMediaCodecBridge,
+            mediaCodec,
+            mime,
+            BitrateAdjustmentTypes.NO_ADJUSTMENT,
+            -1,
+            false);
 
     MediaFormat mediaFormat = createAudioFormat(mime, sampleRate, channelCount);
 
@@ -625,6 +641,7 @@ class MediaCodecBridge {
       ColorInfo colorInfo,
       int tunnelModeAudioSessionId,
       int maxVideoInputSize,
+      boolean useCallbackThread,
       CreateMediaCodecBridgeResult outCreateMediaCodecBridgeResult) {
     MediaCodec mediaCodec = null;
     outCreateMediaCodecBridgeResult.mMediaCodecBridge = null;
@@ -678,7 +695,8 @@ class MediaCodecBridge {
             mediaCodec,
             mime,
             BitrateAdjustmentTypes.NO_ADJUSTMENT,
-            tunnelModeAudioSessionId);
+            tunnelModeAudioSessionId,
+            useCallbackThread);
     MediaFormat mediaFormat =
         createVideoDecoderFormat(mime, widthHint, heightHint, videoCapabilities);
 
@@ -827,6 +845,13 @@ class MediaCodecBridge {
       Log.e(TAG, "Cannot release media codec", e);
     }
     mMediaCodec = null;
+    synchronized (this) {
+      if (mCallbackThread != null) {
+        mCallbackThread.quitSafely();
+        mCallbackThread = null;
+        mHandler = null;
+      }
+    }
   }
 
   @SuppressWarnings("unused")

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -228,6 +228,7 @@ scoped_ptr<MediaCodecBridge> MediaCodecBridge::CreateVideoMediaCodecBridge(
     int tunnel_mode_audio_session_id,
     bool force_big_endian_hdr_metadata,
     int max_video_input_size,
+    bool use_mediacodec_callback_thread,
     std::string* error_message) {
   SB_DCHECK(error_message);
   SB_DCHECK(max_width.has_engaged() == max_height.has_engaged());
@@ -317,14 +318,15 @@ scoped_ptr<MediaCodecBridge> MediaCodecBridge::CreateVideoMediaCodecBridge(
       "(JLjava/lang/String;Ljava/lang/String;IIIIILandroid/view/Surface;"
       "Landroid/media/MediaCrypto;"
       "Ldev/cobalt/media/MediaCodecBridge$ColorInfo;"
-      "II"
+      "IIZ"
       "Ldev/cobalt/media/MediaCodecBridge$CreateMediaCodecBridgeResult;)"
       "V",
       reinterpret_cast<jlong>(native_media_codec_bridge.get()), j_mime.Get(),
       j_decoder_name.Get(), width_hint, height_hint, fps,
       max_width.value_or(-1), max_height.value_or(-1), j_surface,
       j_media_crypto, j_color_info.Get(), tunnel_mode_audio_session_id,
-      max_video_input_size, j_create_media_codec_bridge_result.Get());
+      max_video_input_size, use_mediacodec_callback_thread,
+      j_create_media_codec_bridge_result.Get());
 
   jobject j_media_codec_bridge = env->CallObjectMethodOrAbort(
       j_create_media_codec_bridge_result.Get(), "mediaCodecBridge",

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -174,6 +174,7 @@ class MediaCodecBridge {
       int tunnel_mode_audio_session_id,
       bool force_big_endian_hdr_metadata,
       int max_video_input_size,
+      bool use_mediacodec_callback_thread,
       std::string* error_message);
 
   ~MediaCodecBridge();

--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -172,6 +172,9 @@ MediaDecoder::~MediaDecoder() {
       SB_LOG(ERROR) << "Failed to flush media codec.";
     }
     host_ = NULL;
+    // Clear the native media codec bridge handle in java layer to prevent
+    // calling mediacodec callbacks with an invalid handle.
+    media_codec_bridge_.reset();
   }
 }
 

--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -121,6 +121,7 @@ MediaDecoder::MediaDecoder(Host* host,
                            int tunnel_mode_audio_session_id,
                            bool force_big_endian_hdr_metadata,
                            int max_video_input_size,
+                           bool use_mediacodec_callback_thread,
                            std::string* error_message)
     : media_type_(kSbMediaTypeVideo),
       host_(host),
@@ -138,7 +139,8 @@ MediaDecoder::MediaDecoder(Host* host,
       video_codec, width_hint, height_hint, fps, max_width, max_height, this,
       j_output_surface, j_media_crypto, color_metadata, require_secured_decoder,
       require_software_codec, tunnel_mode_audio_session_id,
-      force_big_endian_hdr_metadata, max_video_input_size, error_message);
+      force_big_endian_hdr_metadata, max_video_input_size,
+      use_mediacodec_callback_thread, error_message);
   if (!media_codec_bridge_) {
     SB_LOG(ERROR) << "Failed to create video media codec bridge with error: "
                   << *error_message;

--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -98,6 +98,7 @@ class MediaDecoder
                int tunnel_mode_audio_session_id,
                bool force_big_endian_hdr_metadata,
                int max_video_input_size,
+               bool use_mediacodec_callback_thread,
                std::string* error_message);
   ~MediaDecoder();
 

--- a/starboard/android/shared/media_is_video_supported.cc
+++ b/starboard/android/shared/media_is_video_supported.cc
@@ -92,6 +92,10 @@ bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
                                      false)) {
       MaxMediaCodecOutputBuffersLookupTable::GetInstance()->SetEnabled(false);
     }
+
+    if (!mime_type->ValidateBoolParameter("mediacodeccallbackthread")) {
+      return false;
+    }
   }
 
   if (must_support_tunnel_mode && decode_to_texture_required) {

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -358,6 +358,7 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
                            bool force_big_endian_hdr_metadata,
                            int max_video_input_size,
                            bool enable_flush_during_seek,
+                           bool use_mediacodec_callback_thread,
                            std::string* error_message)
     : video_codec_(video_stream_info.codec),
       drm_system_(static_cast<DrmSystem*>(drm_system)),
@@ -376,7 +377,8 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
       require_software_codec_(IsSoftwareDecodeRequired(max_video_capabilities)),
       force_big_endian_hdr_metadata_(force_big_endian_hdr_metadata),
       number_of_preroll_frames_(kInitialPrerollFrameCount),
-      enable_flush_during_seek_(enable_flush_during_seek) {
+      enable_flush_during_seek_(enable_flush_during_seek),
+      use_mediacodec_callback_thread_(use_mediacodec_callback_thread) {
   SB_DCHECK(error_message);
 
   if (force_secure_pipeline_under_tunnel_mode) {
@@ -731,7 +733,7 @@ bool VideoDecoder::InitializeCodec(const VideoStreamInfo& video_stream_info,
       color_metadata_ ? &*color_metadata_ : nullptr, require_software_codec_,
       std::bind(&VideoDecoder::OnFrameRendered, this, _1),
       tunnel_mode_audio_session_id_, force_big_endian_hdr_metadata_,
-      max_video_input_size_, error_message));
+      max_video_input_size_, use_mediacodec_callback_thread_, error_message));
   if (media_decoder_->is_valid()) {
     if (error_cb_) {
       media_decoder_->Initialize(

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -72,6 +72,7 @@ class VideoDecoder
                bool force_big_endian_hdr_metadata,
                int max_input_size,
                bool enable_flush_during_seek,
+               bool use_mediacodec_callback_thread,
                std::string* error_message);
   ~VideoDecoder() override;
 
@@ -220,6 +221,10 @@ class VideoDecoder
   bool first_output_format_changed_ = false;
   optional<VideoOutputFormat> output_format_;
   size_t number_of_preroll_frames_;
+
+  // Set mediacodec callback with a handler on another thread to avoid running
+  // callbacks on the main thread and being blocked by other main thread tasks.
+  const bool use_mediacodec_callback_thread_;
 };
 
 }  // namespace shared


### PR DESCRIPTION
[android] Handle mediacodec callback with a handler thread

Now the MediaCodec callbacks and the activity lifecycle callbacks
are called on the main thread. When pausing YouTube, the MediaCodec
callbacks may be blocked until the lifecycle callbacks are done.
This may cause frame drops on a resource-limited device when the
MediaCodec callback to notify a newly decoded frame is blocked and
we run out of decoded frames. Running the MediaCodec callbacks on a
handler thread could avoid this problem.

To ensure the callbacks won't be called when the media decoder is
destroyed, clear the native media codec bridge handle in java layer
when destroying MediaDecoder.

b/316008643
