### PR TITLE
Add SbWindowGetDisplayHandle to Starboard Windowing interface

### DIFF
--- a/cobalt/renderer/backend/egl/graphics_system.cc
+++ b/cobalt/renderer/backend/egl/graphics_system.cc
@@ -139,9 +139,18 @@ GraphicsSystemEGL::GraphicsSystemEGL(
   glimp::SetTraceEventImplementation(&s_glimp_to_base_trace_event_bridge);
 #endif  // #if defined(ENABLE_GLIMP_TRACING)
 
+#if STARBOARD >= 16
+  display _ = SbWindowGetDisplayHandle(window_);
+  // Fall back to SB_EGL_DEFAULT_DISPLAY
+  if (SB_EGL_NO_DISPLAY != display_) {
+    display_ = EGL_CALL_SIMPLE(eglGetDisplay(SB_EGL_DEFAULT_DISPLAY));
+    SB_CHECK(SB_EGL_SUCCESS == EGL_CALL_SIMPLE(eglGetError()));
+  }
+#else
   display_ = EGL_CALL_SIMPLE(eglGetDisplay(EGL_DEFAULT_DISPLAY));
-  CHECK_NE(EGL_NO_DISPLAY, display_);
   CHECK_EQ(EGL_SUCCESS, EGL_CALL_SIMPLE(eglGetError()));
+#endif
+  CHECK_NE(EGL_NO_DISPLAY, display_);
 
   {
     // Despite eglTerminate() being used in the destructor, the current

--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -9,6 +9,14 @@ since the version previous to it.
 
 ## Version 16
 
+
+### Added SbWindowGetDisplayHandle
+
+The function retrieves native EGL display handle, simplifying correct EGL
+context initialization on some platforms. This complements
+SbWindowGetPlatformHandle, which retrieves the native window handle.
+
+
 ### Added standard POSIX socket getaddrinfo/freeaddrinfo APIs.
 The standard API `getaddrinfo` and `freeaddrinfo`, can be used from
 <netdb.h>.

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -257,6 +257,7 @@ static_library("starboard_platform") {
     "//starboard/shared/stub/thread_sampler_is_supported.cc",
     "//starboard/shared/stub/thread_sampler_thaw.cc",
     "//starboard/shared/stub/ui_nav_get_interface.cc",
+    "//starboard/shared/stub/window_get_display_handle.cc",
     "accessibility_get_caption_settings.cc",
     "accessibility_get_display_settings.cc",
     "accessibility_get_text_to_speech_settings.cc",

--- a/starboard/examples/glclear/main.cc
+++ b/starboard/examples/glclear/main.cc
@@ -104,8 +104,17 @@ Application::Application() {
   window_ = SbWindowCreate(&options);
   SB_CHECK(SbWindowIsValid(window_));
 
+#if STARBOARD >= 16
+  display _ = SbWindowGetDisplayHandle(window_);
+  // Fall back to SB_EGL_DEFAULT_DISPLAY
+  if (SB_EGL_NO_DISPLAY != display_) {
+    display_ = EGL_CALL_SIMPLE(eglGetDisplay(SB_EGL_DEFAULT_DISPLAY));
+    SB_CHECK(SB_EGL_SUCCESS == EGL_CALL_SIMPLE(eglGetError()));
+  }
+#else
   display_ = EGL_CALL_SIMPLE(eglGetDisplay(SB_EGL_DEFAULT_DISPLAY));
   SB_CHECK(SB_EGL_SUCCESS == EGL_CALL_SIMPLE(eglGetError()));
+#endif
   SB_CHECK(SB_EGL_NO_DISPLAY != display_);
 
   EGL_CALL(eglInitialize(display_, NULL, NULL));

--- a/starboard/linux/x64x11/shared/BUILD.gn
+++ b/starboard/linux/x64x11/shared/BUILD.gn
@@ -41,6 +41,7 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/x11/player_set_bounds.cc",
     "//starboard/shared/x11/window_create.cc",
     "//starboard/shared/x11/window_destroy.cc",
+    "//starboard/shared/x11/window_get_display_handle.cc",
     "//starboard/shared/x11/window_get_platform_handle.cc",
     "//starboard/shared/x11/window_get_size.cc",
     "//starboard/shared/x11/window_internal.cc",

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -264,6 +264,7 @@ target(gtest_target_type, "nplb") {
     "window_create_test.cc",
     "window_destroy_test.cc",
     "window_get_diagonal_size_in_inches_test.cc",
+    "window_get_display_handle_test.cc",
     "window_get_platform_handle_test.cc",
     "window_get_size_test.cc",
   ]

--- a/starboard/nplb/window_get_display_handle_test.cc
+++ b/starboard/nplb/window_get_display_handle_test.cc
@@ -1,0 +1,44 @@
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <EGL/egl.h>
+#include "starboard/configuration.h"
+#include "starboard/window.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+#if SB_API_VERSION >= 16
+namespace starboard {
+namespace nplb {
+namespace {
+
+TEST(SbWindowGetDisplayHandleTest, SunnyDay) {
+  SbWindow window = SbWindowCreate(NULL);
+  ASSERT_TRUE(SbWindowIsValid(window));
+  void* handle = SbWindowGetDisplayHandle(window);
+  // 0 could actually be a valid value here, because we don't know what the
+  // platform uses as its native window handle type, so we can't do any
+  // verification here.
+  ASSERT_TRUE(SbWindowDestroy(window));
+}
+
+TEST(SbWindowGetDisplayHandleTest, RainyDay) {
+  void* handle = SbWindowGetDisplayHandle(kSbWindowInvalid);
+  ASSERT_EQ(handle, EGL_NO_DISPLAY);
+}
+
+}  // namespace
+}  // namespace nplb
+}  // namespace starboard
+
+#endif  // SB_API_VERSION >= 16

--- a/starboard/raspi/shared/BUILD.gn
+++ b/starboard/raspi/shared/BUILD.gn
@@ -324,6 +324,7 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/stub/window_blur_on_screen_keyboard.cc",
     "//starboard/shared/stub/window_focus_on_screen_keyboard.cc",
     "//starboard/shared/stub/window_get_diagonal_size_in_inches.cc",
+    "//starboard/shared/stub/window_get_display_handle.cc",
     "//starboard/shared/stub/window_get_on_screen_keyboard_bounding_rect.cc",
     "//starboard/shared/stub/window_hide_on_screen_keyboard.cc",
     "//starboard/shared/stub/window_is_on_screen_keyboard_shown.cc",

--- a/starboard/shared/stub/window_get_display_handle.cc
+++ b/starboard/shared/stub/window_get_display_handle.cc
@@ -1,0 +1,20 @@
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/window.h"
+
+void* SbWindowGetDisplayHandle(SbWindow window) {
+  // Resolves to EGL_NO_DISPLAY
+  return nullptr;
+}

--- a/starboard/shared/x11/window_get_display_handle.cc
+++ b/starboard/shared/x11/window_get_display_handle.cc
@@ -1,0 +1,31 @@
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <EGL/egl.h>
+#include "starboard/window.h"
+
+#include "starboard/player.h"
+#include "starboard/shared/x11/window_internal.h"
+
+#if SB_API_VERSION >= 16
+
+void* SbWindowGetDisplayHandle(SbWindow window) {
+  if (!SbWindowIsValid(window)) {
+    return EGL_NO_DISPLAY;
+  }
+
+  return reinterpret_cast<void*>(window->display);
+}
+
+#endif  // SB_API_VERSION >= 16

--- a/starboard/stub/BUILD.gn
+++ b/starboard/stub/BUILD.gn
@@ -271,6 +271,7 @@ static_library("stub_sources") {
     "//starboard/shared/stub/window_destroy.cc",
     "//starboard/shared/stub/window_focus_on_screen_keyboard.cc",
     "//starboard/shared/stub/window_get_diagonal_size_in_inches.cc",
+    "//starboard/shared/stub/window_get_display_handle.cc",
     "//starboard/shared/stub/window_get_on_screen_keyboard_bounding_rect.cc",
     "//starboard/shared/stub/window_get_platform_handle.cc",
     "//starboard/shared/stub/window_get_size.cc",

--- a/starboard/win/shared/BUILD.gn
+++ b/starboard/win/shared/BUILD.gn
@@ -138,6 +138,7 @@ static_library("starboard_platform") {
     "//starboard/shared/stub/window_blur_on_screen_keyboard.cc",
     "//starboard/shared/stub/window_focus_on_screen_keyboard.cc",
     "//starboard/shared/stub/window_get_diagonal_size_in_inches.cc",
+    "//starboard/shared/stub/window_get_display_handle.cc",
     "//starboard/shared/stub/window_get_on_screen_keyboard_bounding_rect.cc",
     "//starboard/shared/stub/window_hide_on_screen_keyboard.cc",
     "//starboard/shared/stub/window_is_on_screen_keyboard_shown.cc",

--- a/starboard/window.h
+++ b/starboard/window.h
@@ -137,6 +137,16 @@ SB_EXPORT bool SbWindowGetSize(SbWindow window, SbWindowSize* size);
 // |window|: The SbWindow to retrieve the platform handle for.
 SB_EXPORT void* SbWindowGetPlatformHandle(SbWindow window);
 
+#if SB_API_VERSION >= 16
+// Gets the platform-specific handle for |display|, which can be passed as an
+// EGLNativeDisplayType to initialize EGL/GLES. This return value is entirely
+// platform-specific.
+// A return value of EGL_NO_DISPLAY means failure.
+//
+// |window|: The SbWindow to retrieve the platform display handle for.
+SB_EXPORT void* SbWindowGetDisplayHandle(SbWindow window);
+#endif
+
 // System-triggered OnScreenKeyboard events have ticket value
 // kSbEventOnScreenKeyboardInvalidTicket.
 #define kSbEventOnScreenKeyboardInvalidTicket (-1)


### PR DESCRIPTION
Adding a function to retrieves native EGL display handle, which will simplifying correct EGL context initialization on Windowing systems like GBM or Wayland.
This complements already existing SbWindowGetPlatformHandle.

Our current EGL initialization sequence calls:

    eglGetDisplay(SB_EGL_DEFAULT_DISPLAY)

However, some windowing setups require native display handle to be passed in, instead of passing the default.

b/157237252