### PR TITLE
Remove EZTime for SB logging

### DIFF
--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -22,7 +22,6 @@ group("gn_all") {
   deps = [
     ":default",
     "//starboard/client_porting/cwrappers:cwrappers_test",
-    "//starboard/client_porting/eztime",
     "//starboard/client_porting/eztime:eztime_test",
     "//starboard/client_porting/icu_init",
     "//starboard/examples/glclear:starboard_glclear_example",

--- a/starboard/build/config/starboard_target_type.gni
+++ b/starboard/build/config/starboard_target_type.gni
@@ -45,7 +45,6 @@ template("starboard_platform_target") {
     }
     public_deps = [
       "//starboard/client_porting/cwrappers",
-      "//starboard/client_porting/eztime",
       "//starboard/common",
       "//starboard/egl_and_gles",
     ]


### PR DESCRIPTION
Starboard logging will now use UTC time via gmtime_r.

b/320398326

Test-On-Device: true