### PR TITLE
Switch to caching Gradle wrapper and components

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -239,13 +239,14 @@ jobs:
           # Use fetch depth of 0 to get full history for a valid build id.
           fetch-depth: 0
           persist-credentials: false
-      - name: Setup Gradle
+      - name: Cache Gradle
+        uses: actions/cache@v3
         if: startsWith( matrix.target_platform , 'android')
-        run: |
-          for i in {1..5}; do
-              if starboard/android/apk/gradlew --version; then break ; fi
-              rm -rf ~/.gradle/wrapper
-          done
+        with:
+          key: gradle-cache-${{ hashFiles('starboard/android/apk/**/*gradle*') }}
+          path: |
+            /root/.gradle/caches
+            /root/.gradle/wrapper
       - name: GN
         uses: ./.github/actions/gn
       - name: Build Cobalt


### PR DESCRIPTION
Adds a cache for Gradle components. Cache will be saved on successful build and keyed off Android gradle build files.

b/337337924