### PR TITLE
[android] Create MediaFormatBuilder.java

### DIFF
--- a/starboard/android/apk/apk_sources.gni
+++ b/starboard/android/apk/apk_sources.gni
@@ -47,6 +47,7 @@ apk_sources = [
   "//starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecCapabilitiesLogger.java",
   "//starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecUtil.java",
   "//starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java",
+  "//starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaFormatBuilder.java",
   "//starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaImage.java",
   "//starboard/android/apk/app/src/main/java/dev/cobalt/media/VideoFrameReleaseTimeHelper.java",
   "//starboard/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java",

--- a/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -1,8 +1,4 @@
-// Copyright 2013 The Cobalt Authors. All rights reserved.
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
-//
-// Modifications Copyright 2017 The Cobalt Authors. All Rights Reserved.
+// Copyright 2017 The Cobalt Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,6 +11,10 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+//
+// Copyright 2013 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
 
 package dev.cobalt.media;
 
@@ -1214,32 +1214,6 @@ class MediaCodecBridge {
   }
 
   @SuppressWarnings("unused")
-  @UsedByNative
-  private static void setCodecSpecificData(MediaFormat format, int index, byte[] bytes) {
-    // Codec Specific Data is set in the MediaFormat as ByteBuffer entries with keys csd-0,
-    // csd-1, and so on. See: http://developer.android.com/reference/android/media/MediaCodec.html
-    // for details.
-    String name;
-    switch (index) {
-      case 0:
-        name = "csd-0";
-        break;
-      case 1:
-        name = "csd-1";
-        break;
-      case 2:
-        name = "csd-2";
-        break;
-      default:
-        name = null;
-        break;
-    }
-    if (name != null) {
-      format.setByteBuffer(name, ByteBuffer.wrap(bytes));
-    }
-  }
-
-  @SuppressWarnings("unused")
   private static boolean setOpusConfigurationData(
       MediaFormat format, int sampleRate, @Nullable byte[] configurationData) {
     final int MIN_OPUS_INITIALIZATION_DATA_BUFFER_SIZE = 19;
@@ -1269,15 +1243,13 @@ class MediaCodecBridge {
     long preSkipNanos = (preSkipSamples * NANOSECONDS_IN_ONE_SECOND) / sampleRate;
     long seekPreRollNanos =
         (DEFAULT_SEEK_PRE_ROLL_SAMPLES * NANOSECONDS_IN_ONE_SECOND) / sampleRate;
-    setCodecSpecificData(format, 0, configurationData);
-    setCodecSpecificData(
+    MediaFormatBuilder.setCodecSpecificData(
         format,
-        1,
-        ByteBuffer.allocate(8).order(ByteOrder.nativeOrder()).putLong(preSkipNanos).array());
-    setCodecSpecificData(
-        format,
-        2,
-        ByteBuffer.allocate(8).order(ByteOrder.nativeOrder()).putLong(seekPreRollNanos).array());
+        new byte[][] {
+          configurationData,
+          ByteBuffer.allocate(8).order(ByteOrder.nativeOrder()).putLong(preSkipNanos).array(),
+          ByteBuffer.allocate(8).order(ByteOrder.nativeOrder()).putLong(seekPreRollNanos).array(),
+        });
     return true;
   }
 

--- a/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaFormatBuilder.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaFormatBuilder.java
@@ -1,0 +1,36 @@
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.media;
+
+import android.media.MediaFormat;
+import java.nio.ByteBuffer;
+
+class MediaFormatBuilder {
+  public static void setCodecSpecificData(MediaFormat format, byte[][] csds) {
+    // Codec Specific Data is set in the MediaFormat as ByteBuffer entries with keys csd-0,
+    // csd-1, and so on. See:
+    // http://developer.android.com/reference/android/media/MediaCodec.html for details.
+    for (int i = 0; i < csds.length; ++i) {
+      if (csds[i].length == 0) continue;
+      String name = "csd-" + i;
+      format.setByteBuffer(name, ByteBuffer.wrap(csds[i]));
+    }
+  }
+}
+;


### PR DESCRIPTION
Move `MediaCodecBridge.setCodecSpecificData()` to it as its first method.  The function is refactored to align with the current implementation in Chromium, without any functional change.  It's verified against the AudioDecoderTests with kForcePlatformOpusDecoder set to true.

b/345542000

Change-Id: Ia3a9693fee574f7d9c7cfd16b576fdb569026168