### PR TITLE
[android] Refine MediaCodec error message

### DIFF
--- a/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -749,10 +749,10 @@ class MediaCodecBridge {
       // outCreateMediaCodecBridgeResult.mErrorMessage is set inside configureVideo() on error.
       return;
     }
-    if (!bridge.start()) {
+    if (!bridge.start(outCreateMediaCodecBridgeResult)) {
       Log.e(TAG, "Failed to start video codec.");
       bridge.release();
-      outCreateMediaCodecBridgeResult.mErrorMessage = "Failed to start video codec";
+      // outCreateMediaCodecBridgeResult.mErrorMessage is set inside start() on error.
       return;
     }
 
@@ -774,13 +774,21 @@ class MediaCodecBridge {
     mMediaCodec = null;
   }
 
+  public boolean start() {
+    return start(null);
+  }
+
   @SuppressWarnings("unused")
   @UsedByNative
-  public boolean start() {
+  public boolean start(CreateMediaCodecBridgeResult outCreateMediaCodecBridgeResult) {
     try {
       mMediaCodec.start();
     } catch (IllegalStateException | IllegalArgumentException e) {
-      Log.e(TAG, "Cannot start the media codec", e);
+      Log.e(TAG, "Failed to start the media codec", e);
+      if (outCreateMediaCodecBridgeResult != null) {
+        outCreateMediaCodecBridgeResult.mErrorMessage =
+            "Failed to start media codec " + e.toString();
+      }
       return false;
     }
     return true;


### PR DESCRIPTION
The exception information is now included as part of the error message, which is forwarded to DOM and can be accessed via `HTMLMediaElement.error.message`.

b/348438829
