### PR TITLE
[nplb] Fix failing SbPlayerGetMediaTimeTest

### DIFF
--- a/starboard/android/shared/test_filters.py
+++ b/starboard/android/shared/test_filters.py
@@ -97,10 +97,6 @@ _FILTERED_TESTS = {
 
         # TODO: b/280432564 Make this test work on lab devices consistently.
         'SbAudioSinkTest.ContinuousAppend',
-
-        # TODO: b/347961880 Disable this test due to fail on e/ac3 audio format.
-        'SbPlayerGetMediaTimeTests/SbPlayerGetMediaTimeTest.TimeAfterSeek/*ec3*',
-        'SbPlayerGetMediaTimeTests/SbPlayerGetMediaTimeTest.TimeAfterSeek/*ac3*',
     ],
 }
 # pylint: enable=line-too-long

--- a/starboard/nplb/player_test_fixture.cc
+++ b/starboard/nplb/player_test_fixture.cc
@@ -265,10 +265,19 @@ void SbPlayerTestFixture::Write(const GroupedSamples& grouped_samples) {
 
   ASSERT_FALSE(error_occurred_);
 
-  int max_audio_samples_per_write =
-      SbPlayerGetMaximumNumberOfSamplesPerWrite(player_, kSbMediaTypeAudio);
-  int max_video_samples_per_write =
-      SbPlayerGetMaximumNumberOfSamplesPerWrite(player_, kSbMediaTypeVideo);
+  // TODO: b/347728473 When the platform supports multiple
+  // samples per write to SbPlayer, the following numbers are
+  // sufficient to allow SbPlayer to play 60fps video.
+  // Revisit the maximum numbers if the requirement is changed.
+  const int kMaxAudioSamplesPerWrite = 15;
+  const int kMaxVideoSamplesPerWrite = 60;
+
+  int max_audio_samples_per_write = std::min(
+      kMaxAudioSamplesPerWrite,
+      SbPlayerGetMaximumNumberOfSamplesPerWrite(player_, kSbMediaTypeAudio));
+  int max_video_samples_per_write = std::min(
+      kMaxVideoSamplesPerWrite,
+      SbPlayerGetMaximumNumberOfSamplesPerWrite(player_, kSbMediaTypeVideo));
 
   GroupedSamplesIterator iterator(grouped_samples);
   SB_DCHECK(!iterator.HasMoreAudio() || audio_dmp_reader_);

--- a/starboard/win/win32/test_filters.py
+++ b/starboard/win/win32/test_filters.py
@@ -59,9 +59,6 @@ _FILTERED_TESTS = {
 
         # Enable once verified on the platform.
         'SbMediaCanPlayMimeAndKeySystem.MinimumSupport',
-
-        # TODO: b/349109647 Disable flaky test.
-        'SbPlayerGetMediaTimeTests/*',
     ],
     'player_filter_tests': [
         # These tests fail on our VMs for win-win32 builds due to missing


### PR DESCRIPTION
1. Limit |audio_write_duration_| to 0.5s, as writing audio samples with e/ac3 take more time which causes media time checks fail.
2. Add more log messages to debug build. 

b/347961880
b/349109647

Test-On-Device: true