### PR TITLE
Launch `HTMLMediaElement.buffered` optimization

### DIFF
--- a/cobalt/dom/media_settings.cc
+++ b/cobalt/dom/media_settings.cc
@@ -83,12 +83,6 @@ bool MediaSettingsImpl::Set(const std::string& name, int value) {
       LOG(INFO) << name << ": set to " << value;
       return true;
     }
-  } else if (name == "MediaElement.EnableUsingMediaSourceBufferedRange") {
-    if (value == 0 || value == 1) {
-      is_media_element_using_media_source_buffered_range_enabled_ = value != 0;
-      LOG(INFO) << name << ": set to " << value;
-      return true;
-    }
   } else if (name == "MediaElement.EnableUsingMediaSourceAttachmentMethods") {
     if (value == 0 || value == 1) {
       is_media_element_using_media_source_attachment_methods_enabled_ =

--- a/cobalt/dom/media_settings.h
+++ b/cobalt/dom/media_settings.h
@@ -43,8 +43,6 @@ class MediaSettings {
   GetMediaElementTimeupdateEventIntervalInMilliseconds() const = 0;
   virtual base::Optional<bool> IsPaintingVideoBackgroundToBlack() const = 0;
   virtual base::Optional<bool>
-  IsMediaElementUsingMediaSourceBufferedRangeEnabled() const = 0;
-  virtual base::Optional<bool>
   IsMediaElementUsingMediaSourceAttachmentMethodsEnabled() const = 0;
 
  protected:
@@ -97,11 +95,6 @@ class MediaSettingsImpl : public MediaSettings {
   base::Optional<bool> IsPaintingVideoBackgroundToBlack() const override {
     return is_painting_video_background_to_black_;
   }
-  base::Optional<bool> IsMediaElementUsingMediaSourceBufferedRangeEnabled()
-      const override {
-    base::AutoLock auto_lock(lock_);
-    return is_media_element_using_media_source_buffered_range_enabled_;
-  }
   base::Optional<bool> IsMediaElementUsingMediaSourceAttachmentMethodsEnabled()
       const override {
     base::AutoLock auto_lock(lock_);
@@ -124,8 +117,6 @@ class MediaSettingsImpl : public MediaSettings {
   base::Optional<int> max_source_buffer_append_size_in_bytes_;
 
   base::Optional<int> media_element_timeupdate_event_interval_in_milliseconds_;
-  base::Optional<bool>
-      is_media_element_using_media_source_buffered_range_enabled_;
   base::Optional<bool>
       is_media_element_using_media_source_attachment_methods_enabled_;
 

--- a/cobalt/dom/media_settings_test.cc
+++ b/cobalt/dom/media_settings_test.cc
@@ -48,7 +48,6 @@ TEST(MediaSettingsImplTest, SunnyDay) {
   ASSERT_TRUE(
       impl.Set("MediaElement.TimeupdateEventIntervalInMilliseconds", 100001));
   ASSERT_TRUE(impl.Set("MediaElement.PaintingVideoBackgroundToBlack", 1));
-  ASSERT_TRUE(impl.Set("MediaElement.EnableUsingMediaSourceBufferedRange", 1));
   ASSERT_TRUE(
       impl.Set("MediaElement.EnableUsingMediaSourceAttachmentMethods", 1));
 
@@ -62,8 +61,6 @@ TEST(MediaSettingsImplTest, SunnyDay) {
   EXPECT_EQ(impl.GetMediaElementTimeupdateEventIntervalInMilliseconds().value(),
             100001);
   EXPECT_TRUE(impl.IsPaintingVideoBackgroundToBlack().value());
-  EXPECT_TRUE(
-      impl.IsMediaElementUsingMediaSourceBufferedRangeEnabled().value());
   EXPECT_TRUE(
       impl.IsMediaElementUsingMediaSourceAttachmentMethodsEnabled().value());
 }
@@ -83,8 +80,6 @@ TEST(MediaSettingsImplTest, RainyDay) {
       impl.Set("MediaElement.TimeupdateEventIntervalInMilliseconds", 0));
   ASSERT_FALSE(impl.Set("MediaElement.PaintingVideoBackgroundToBlack", 2));
   ASSERT_FALSE(
-      impl.Set("MediaElement.EnableUsingMediaSourceBufferedRange", -101));
-  ASSERT_FALSE(
       impl.Set("MediaElement.EnableUsingMediaSourceAttachmentMethods", -101));
 
   EXPECT_FALSE(impl.GetSourceBufferEvictExtraInBytes());
@@ -96,7 +91,6 @@ TEST(MediaSettingsImplTest, RainyDay) {
   EXPECT_FALSE(impl.GetMaxSourceBufferAppendSizeInBytes());
   EXPECT_FALSE(impl.GetMediaElementTimeupdateEventIntervalInMilliseconds());
   EXPECT_FALSE(impl.IsPaintingVideoBackgroundToBlack());
-  EXPECT_FALSE(impl.IsMediaElementUsingMediaSourceBufferedRangeEnabled());
   EXPECT_FALSE(impl.IsMediaElementUsingMediaSourceAttachmentMethodsEnabled());
 }
 
@@ -114,7 +108,6 @@ TEST(MediaSettingsImplTest, ZeroValuesWork) {
   // O is an invalid value for
   // "MediaElement.TimeupdateEventIntervalInMilliseconds".
   ASSERT_TRUE(impl.Set("MediaElement.PaintingVideoBackgroundToBlack", 0));
-  ASSERT_TRUE(impl.Set("MediaElement.EnableUsingMediaSourceBufferedRange", 0));
   ASSERT_TRUE(
       impl.Set("MediaElement.EnableUsingMediaSourceAttachmentMethods", 0));
 
@@ -125,8 +118,6 @@ TEST(MediaSettingsImplTest, ZeroValuesWork) {
   EXPECT_FALSE(impl.IsCallingEndedWhenClosedEnabled().value());
   EXPECT_EQ(impl.GetMaxSizeForImmediateJob().value(), 0);
   EXPECT_FALSE(impl.IsPaintingVideoBackgroundToBlack().value());
-  EXPECT_FALSE(
-      impl.IsMediaElementUsingMediaSourceBufferedRangeEnabled().value());
   EXPECT_FALSE(
       impl.IsMediaElementUsingMediaSourceAttachmentMethodsEnabled().value());
 }
@@ -145,7 +136,6 @@ TEST(MediaSettingsImplTest, Updatable) {
   ASSERT_TRUE(
       impl.Set("MediaElement.TimeupdateEventIntervalInMilliseconds", 1));
   ASSERT_TRUE(impl.Set("MediaElement.PaintingVideoBackgroundToBlack", 0));
-  ASSERT_TRUE(impl.Set("MediaElement.EnableUsingMediaSourceBufferedRange", 0));
   ASSERT_TRUE(
       impl.Set("MediaElement.EnableUsingMediaSourceAttachmentMethods", 0));
 
@@ -160,7 +150,6 @@ TEST(MediaSettingsImplTest, Updatable) {
   ASSERT_TRUE(
       impl.Set("MediaElement.TimeupdateEventIntervalInMilliseconds", 2));
   ASSERT_TRUE(impl.Set("MediaElement.PaintingVideoBackgroundToBlack", 1));
-  ASSERT_TRUE(impl.Set("MediaElement.EnableUsingMediaSourceBufferedRange", 1));
   ASSERT_TRUE(
       impl.Set("MediaElement.EnableUsingMediaSourceAttachmentMethods", 1));
 
@@ -174,8 +163,6 @@ TEST(MediaSettingsImplTest, Updatable) {
   EXPECT_EQ(impl.GetMediaElementTimeupdateEventIntervalInMilliseconds().value(),
             2);
   EXPECT_TRUE(impl.IsPaintingVideoBackgroundToBlack().value());
-  EXPECT_TRUE(
-      impl.IsMediaElementUsingMediaSourceBufferedRangeEnabled().value());
   EXPECT_TRUE(
       impl.IsMediaElementUsingMediaSourceAttachmentMethodsEnabled().value());
 }

--- a/cobalt/dom/media_source.cc
+++ b/cobalt/dom/media_source.cc
@@ -133,18 +133,6 @@ int GetMaxSizeForImmediateJob(web::EnvironmentSettings* settings) {
   return max_size;
 }
 
-// If this function returns true, MediaSource::GetSeekable() will short-circuit
-// getting the buffered range from HTMLMediaElement by directly calling to
-// MediaSource::GetBufferedRange(). This reduces potential cross-object,
-// cross-thread calls between MediaSource and HTMLMediaElement.
-// The default value is false.
-bool IsMediaElementUsingMediaSourceBufferedRangeEnabled(
-    web::EnvironmentSettings* settings) {
-  return GetMediaSettings(settings)
-      .IsMediaElementUsingMediaSourceBufferedRangeEnabled()
-      .value_or(false);
-}
-
 }  // namespace
 
 MediaSource::MediaSource(script::EnvironmentSettings* settings)
@@ -566,16 +554,7 @@ scoped_refptr<TimeRanges> MediaSource::GetSeekable() const {
 
   if (source_duration == std::numeric_limits<double>::infinity()) {
     scoped_refptr<TimeRanges> buffered = nullptr;
-    if (IsMediaElementUsingMediaSourceBufferedRangeEnabled(
-            environment_settings())) {
-      buffered = GetBufferedRange();
-    } else {
-      if (is_using_media_source_attachment_methods_) {
-        buffered = media_source_attachment_->media_element()->buffered();
-      } else {
-        buffered = attached_element_->buffered();
-      }
-    }
+    buffered = GetBufferedRange();
 
     if (live_seekable_range_->length() != 0) {
       if (buffered->length() == 0) {


### PR DESCRIPTION
This is needed for MSE-in-Workers support. See context in the linked bug.

b/338452286