### PR TITLE
Align POSIX API in SB modular

### DIFF
--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -277,6 +277,7 @@ ExportedSymbols::ExportedSymbols() {
     map_["__errno_location"] = reinterpret_cast<const void*>(__errno_location);
   }
   map_["fstat"] = reinterpret_cast<const void*>(&__abi_wrap_fstat);
+  map_["ftruncate"] = reinterpret_cast<const void*>(&__abi_wrap_ftruncate);
   map_["gettimeofday"] =
       reinterpret_cast<const void*>(&__abi_wrap_gettimeofday);
   map_["gmtime_r"] = reinterpret_cast<const void*>(&__abi_wrap_gmtime_r);
@@ -361,6 +362,7 @@ ExportedSymbols::ExportedSymbols() {
       reinterpret_cast<const void*>(&__abi_wrap_freeaddrinfo);
   map_["getifaddrs"] = reinterpret_cast<const void*>(&__abi_wrap_getifaddrs);
   map_["setsockopt"] = reinterpret_cast<const void*>(&__abi_wrap_setsockopt);
+  map_["write"] = reinterpret_cast<const void*>(&__abi_wrap_write);
 
   REGISTER_SYMBOL(vswprintf);
 


### PR DESCRIPTION
Add and export __abi_wrap_ftruncate and __abi_wrap_write
These two APIs are wrapped in SB modular but missing in exported_symbols.cc