### PR TITLE
[media] Turn SbPlayerPrivate into an interface

### DIFF
--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -30,6 +30,7 @@
 #include "starboard/string.h"
 
 using starboard::shared::starboard::player::PlayerWorker;
+using starboard::shared::starboard::player::SbPlayerPrivateImpl;
 using starboard::shared::starboard::player::filter::
     FilterBasedPlayerWorkerHandler;
 
@@ -211,7 +212,7 @@ SbPlayer SbPlayerCreate(SbWindow window,
       new FilterBasedPlayerWorkerHandler(creation_param, provider));
   handler->SetMaxVideoInputSize(
       starboard::android::shared::GetMaxVideoInputSizeForCurrentThread());
-  SbPlayer player = SbPlayerPrivate::CreateInstance(
+  SbPlayer player = SbPlayerPrivateImpl::CreateInstance(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
       player_status_func, player_error_func, context, std::move(handler));
 

--- a/starboard/shared/starboard/player/player_create.cc
+++ b/starboard/shared/starboard/player/player_create.cc
@@ -38,6 +38,7 @@ using ::starboard::shared::media_session::
     UpdateActiveSessionPlatformPlaybackState;
 using ::starboard::shared::starboard::media::MimeType;
 using ::starboard::shared::starboard::player::PlayerWorker;
+using ::starboard::shared::starboard::player::SbPlayerPrivateImpl;
 using ::starboard::shared::starboard::player::filter::
     FilterBasedPlayerWorkerHandler;
 
@@ -215,7 +216,7 @@ SbPlayer SbPlayerCreate(SbWindow window,
   std::unique_ptr<PlayerWorker::Handler> handler(
       new FilterBasedPlayerWorkerHandler(creation_param, provider));
 
-  SbPlayer player = SbPlayerPrivate::CreateInstance(
+  SbPlayer player = SbPlayerPrivateImpl::CreateInstance(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
       player_status_func, player_error_func, context, std::move(handler));
 

--- a/starboard/shared/starboard/player/player_internal.cc
+++ b/starboard/shared/starboard/player/player_internal.cc
@@ -26,6 +26,10 @@
 #include SB_PLAYER_DMP_WRITER_INCLUDE_PATH
 #endif  // SB_PLAYER_ENABLE_VIDEO_DUMPER
 
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace player {
 namespace {
 
 using std::placeholders::_1;
@@ -36,15 +40,15 @@ using std::placeholders::_4;
 int64_t CalculateMediaTime(int64_t media_time,
                            int64_t media_time_update_time,
                            double playback_rate) {
-  int64_t elapsed = starboard::CurrentMonotonicTime() - media_time_update_time;
+  int64_t elapsed = CurrentMonotonicTime() - media_time_update_time;
   return media_time + static_cast<int64_t>(elapsed * playback_rate);
 }
 
 }  // namespace
 
-int SbPlayerPrivate::number_of_players_ = 0;
+int SbPlayerPrivateImpl::number_of_players_ = 0;
 
-SbPlayerPrivate::SbPlayerPrivate(
+SbPlayerPrivateImpl::SbPlayerPrivateImpl(
     SbMediaAudioCodec audio_codec,
     SbMediaVideoCodec video_codec,
     SbPlayerDeallocateSampleFunc sample_deallocate_func,
@@ -55,20 +59,20 @@ SbPlayerPrivate::SbPlayerPrivate(
     std::unique_ptr<PlayerWorker::Handler> player_worker_handler)
     : sample_deallocate_func_(sample_deallocate_func),
       context_(context),
-      media_time_updated_at_(starboard::CurrentMonotonicTime()) {
+      media_time_updated_at_(CurrentMonotonicTime()) {
   worker_ = std::unique_ptr<PlayerWorker>(PlayerWorker::CreateInstance(
       audio_codec, video_codec, std::move(player_worker_handler),
-      std::bind(&SbPlayerPrivate::UpdateMediaInfo, this, _1, _2, _3, _4),
+      std::bind(&SbPlayerPrivateImpl::UpdateMediaInfo, this, _1, _2, _3, _4),
       decoder_status_func, player_status_func, player_error_func, this,
       context));
 
   ++number_of_players_;
-  SB_DLOG(INFO) << "Creating SbPlayerPrivate. There are " << number_of_players_
-                << " players.";
+  SB_DLOG(INFO) << "Creating SbPlayerPrivateImpl. There are "
+                << number_of_players_ << " players.";
 }
 
 // static
-SbPlayerPrivate* SbPlayerPrivate::CreateInstance(
+SbPlayerPrivate* SbPlayerPrivateImpl::CreateInstance(
     SbMediaAudioCodec audio_codec,
     SbMediaVideoCodec video_codec,
     SbPlayerDeallocateSampleFunc sample_deallocate_func,
@@ -77,7 +81,7 @@ SbPlayerPrivate* SbPlayerPrivate::CreateInstance(
     SbPlayerErrorFunc player_error_func,
     void* context,
     std::unique_ptr<PlayerWorker::Handler> player_worker_handler) {
-  SbPlayerPrivate* ret = new SbPlayerPrivate(
+  SbPlayerPrivateImpl* ret = new SbPlayerPrivateImpl(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
       player_status_func, player_error_func, context,
       std::move(player_worker_handler));
@@ -89,12 +93,12 @@ SbPlayerPrivate* SbPlayerPrivate::CreateInstance(
   return nullptr;
 }
 
-void SbPlayerPrivate::Seek(int64_t seek_to_time, int ticket) {
+void SbPlayerPrivateImpl::Seek(int64_t seek_to_time, int ticket) {
   {
-    starboard::ScopedLock lock(mutex_);
+    ScopedLock lock(mutex_);
     SB_DCHECK(ticket_ != ticket);
     media_time_ = seek_to_time;
-    media_time_updated_at_ = starboard::CurrentMonotonicTime();
+    media_time_updated_at_ = CurrentMonotonicTime();
     is_progressing_ = false;
     ticket_ = ticket;
   }
@@ -102,28 +106,28 @@ void SbPlayerPrivate::Seek(int64_t seek_to_time, int ticket) {
   worker_->Seek(seek_to_time, ticket);
 }
 
-void SbPlayerPrivate::WriteEndOfStream(SbMediaType stream_type) {
+void SbPlayerPrivateImpl::WriteEndOfStream(SbMediaType stream_type) {
   worker_->WriteEndOfStream(stream_type);
 }
 
-void SbPlayerPrivate::SetBounds(int z_index,
-                                int x,
-                                int y,
-                                int width,
-                                int height) {
+void SbPlayerPrivateImpl::SetBounds(int z_index,
+                                    int x,
+                                    int y,
+                                    int width,
+                                    int height) {
   PlayerWorker::Bounds bounds = {z_index, x, y, width, height};
   worker_->SetBounds(bounds);
   // TODO: Wait until a frame is rendered with the updated bounds.
 }
 
 #if SB_API_VERSION >= 15
-void SbPlayerPrivate::GetInfo(SbPlayerInfo* out_player_info) {
+void SbPlayerPrivateImpl::GetInfo(SbPlayerInfo* out_player_info) {
 #else   // SB_API_VERSION >= 15
-void SbPlayerPrivate::GetInfo(SbPlayerInfo2* out_player_info) {
+void SbPlayerPrivateImpl::GetInfo(SbPlayerInfo2* out_player_info) {
 #endif  // SB_API_VERSION >= 15
   SB_DCHECK(out_player_info != NULL);
 
-  starboard::ScopedLock lock(mutex_);
+  ScopedLock lock(mutex_);
   out_player_info->duration = SB_PLAYER_NO_DURATION;
   if (is_paused_ || !is_progressing_) {
     out_player_info->current_media_timestamp = media_time_;
@@ -142,49 +146,49 @@ void SbPlayerPrivate::GetInfo(SbPlayerInfo2* out_player_info) {
   out_player_info->playback_rate = playback_rate_;
 }
 
-void SbPlayerPrivate::SetPause(bool pause) {
+void SbPlayerPrivateImpl::SetPause(bool pause) {
   is_paused_ = pause;
   worker_->SetPause(pause);
 }
 
-void SbPlayerPrivate::SetPlaybackRate(double playback_rate) {
+void SbPlayerPrivateImpl::SetPlaybackRate(double playback_rate) {
   playback_rate_ = playback_rate;
   worker_->SetPlaybackRate(playback_rate);
 }
 
-void SbPlayerPrivate::SetVolume(double volume) {
+void SbPlayerPrivateImpl::SetVolume(double volume) {
   volume_ = volume;
   worker_->SetVolume(volume_);
 }
 
-void SbPlayerPrivate::UpdateMediaInfo(int64_t media_time,
-                                      int dropped_video_frames,
-                                      int ticket,
-                                      bool is_progressing) {
-  starboard::ScopedLock lock(mutex_);
+void SbPlayerPrivateImpl::UpdateMediaInfo(int64_t media_time,
+                                          int dropped_video_frames,
+                                          int ticket,
+                                          bool is_progressing) {
+  ScopedLock lock(mutex_);
   if (ticket_ != ticket) {
     return;
   }
   media_time_ = media_time;
   is_progressing_ = is_progressing;
-  media_time_updated_at_ = starboard::CurrentMonotonicTime();
+  media_time_updated_at_ = CurrentMonotonicTime();
   dropped_video_frames_ = dropped_video_frames;
 }
 
-SbDecodeTarget SbPlayerPrivate::GetCurrentDecodeTarget() {
+SbDecodeTarget SbPlayerPrivateImpl::GetCurrentDecodeTarget() {
   return worker_->GetCurrentDecodeTarget();
 }
 
-bool SbPlayerPrivate::GetAudioConfiguration(
+bool SbPlayerPrivateImpl::GetAudioConfiguration(
     int index,
     SbMediaAudioConfiguration* out_audio_configuration) {
   SB_DCHECK(index >= 0);
   SB_DCHECK(out_audio_configuration);
 
-  starboard::ScopedLock lock(audio_configurations_mutex_);
+  ScopedLock lock(audio_configurations_mutex_);
   if (audio_configurations_.empty()) {
 #if !defined(COBALT_BUILD_TYPE_GOLD)
-    int64_t start = starboard::CurrentMonotonicTime();
+    int64_t start = CurrentMonotonicTime();
 #endif  // !defined(COBALT_BUILD_TYPE_GOLD)
     for (int i = 0; i < 32; ++i) {
       SbMediaAudioConfiguration audio_configuration;
@@ -206,14 +210,13 @@ bool SbPlayerPrivate::GetAudioConfiguration(
       }
     }
 #if !defined(COBALT_BUILD_TYPE_GOLD)
-    int64_t elapsed = starboard::CurrentMonotonicTime() - start;
+    int64_t elapsed = CurrentMonotonicTime() - start;
     SB_LOG(INFO)
         << "GetAudioConfiguration(): Updating audio configurations takes "
         << elapsed << " microseconds.";
     for (auto&& audio_configuration : audio_configurations_) {
       SB_LOG(INFO) << "Found audio configuration "
-                   << starboard::GetMediaAudioConnectorName(
-                          audio_configuration.connector)
+                   << GetMediaAudioConnectorName(audio_configuration.connector)
                    << ", channels " << audio_configuration.number_of_channels;
     }
 #endif  // !defined(COBALT_BUILD_TYPE_GOLD)
@@ -226,3 +229,8 @@ bool SbPlayerPrivate::GetAudioConfiguration(
 
   return false;
 }
+
+}  // namespace player
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard


### PR DESCRIPTION
This allows us to move the implementation to a sub-class named SbPlayerPrivateImpl in namespace starboard::shared::starboard::player, which has the following benefits:

1. It allows the implementation to use symbols inside the starboard namespace directly.
2. By moving concrete implementation from the global namespace into a nested namespace, a binary can make use of two implementations (each in their own namespaces), e.g. experimenting on them.

b/327287075