### PR TITLE
[media] Implement SbPlayer based video playback

### DIFF
--- a/media/BUILD.gn
+++ b/media/BUILD.gn
@@ -202,6 +202,10 @@ test("media_unittests") {
     "//media/webrtc:unit_tests",
   ]
 
+  if (is_cobalt) {
+    deps += ["//media/starboard:unit_tests"]
+  }
+
   data = [
     "test/data/",
     "formats/mp4/h264_annex_b_fuzz_corpus/",

--- a/media/media_options.gni
+++ b/media/media_options.gni
@@ -345,6 +345,10 @@ media_subcomponent_deps = [
   "//media/video",
 ]
 
+if (is_cobalt) {
+  media_subcomponent_deps += [ "//media/starboard" ]
+}
+
 if (is_fuchsia) {
   media_subcomponent_deps += [ "//media/fuchsia/common" ]
 }

--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -1,0 +1,96 @@
+# Copyright 2024 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source_set("starboard") {
+  visibility = [ "//media" ]
+
+  defines = [
+    # TODO(b/326652276): Support audio write ahead
+    "COBALT_MEDIA_ENABLE_AUDIO_DURATION=0",
+
+    # TODO(b/326508279): Revisit background mode
+    "COBALT_MEDIA_ENABLE_BACKGROUND_MODE=0",
+
+    # TODO(b/375069564): Revisit CValStats
+    "COBALT_MEDIA_ENABLE_CVAL=0",
+
+    # TODO(b/374822966): Revisit DecoderBuffer budget
+    "COBALT_MEDIA_ENABLE_DECODE_BUFFER_BUDGET=0",
+
+    # TODO(b/375070492): Revisit decode-to-texture
+    "COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER=0",
+
+    # TODO(b/328305808): Enable encrypted playbacks
+    "COBALT_MEDIA_ENABLE_ENCRYPTED_PLAYBACKS=0",
+
+    # TODO(b/375218518): Revisit FormatSupportQueryMetrics
+    "COBALT_MEDIA_ENABLE_FORMAT_SUPPORT_QUERY_METRICS=0",
+
+    # TODO(b/375232937): Enable IAMF
+    "COBALT_MEDIA_ENABLE_IAMF_SUPPORT=0",
+
+    # TODO(b/326654546): Revisit max video input size
+    "COBALT_MEDIA_ENABLE_PLAYER_SET_MAX_VIDEO_INPUT_SIZE=0",
+
+    # TODO(b/375059645): Revisit side data (aka hdr10+) support
+    "COBALT_MEDIA_ENABLE_SIDE_DATA=0",
+
+    # TODO(b/375234428): Revisit startup latency tracking
+    "COBALT_MEDIA_ENABLE_STARTUP_LATENCY_TRACKING=0",
+
+    # TODO(b/326497953): Revisit suspend/resume support
+    "COBALT_MEDIA_ENABLE_SUSPEND_RESUME=0",
+
+    # TODO(b/375241265): Re-enable UMA metrics
+    "COBALT_MEDIA_ENABLE_UMA_METRICS=0",
+  ]
+
+  sources = [
+    "sbplayer_bridge.cc",
+    "sbplayer_bridge.h",
+    "sbplayer_interface.cc",
+    "sbplayer_interface.h",
+    "sbplayer_set_bounds_helper.cc",
+    "sbplayer_set_bounds_helper.h",
+    "starboard_renderer.cc",
+    "starboard_renderer.h",
+    "starboard_utils.cc",
+    "starboard_utils.h",
+  ]
+
+  deps = [
+    "//base",
+    "//media:media_buildflags",
+    "//media/base",
+    "//starboard($starboard_toolchain)",
+    "//starboard/common",
+  ]
+
+  configs += [ "//media:subcomponent_config" ]
+}
+
+source_set("unit_tests") {
+  testonly = true
+  sources = [ "starboard_utils_test.cc" ]
+  configs += [ "//media:media_config" ]
+  deps = [
+    "//base",
+    "//base/test:test_support",
+    "//media:test_support",
+    "//starboard($starboard_toolchain)",
+    "//starboard/common",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+}

--- a/media/starboard/sbplayer_interface.cc
+++ b/media/starboard/sbplayer_interface.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cobalt/media/base/sbplayer_interface.h"
+#include "media/starboard/sbplayer_interface.h"
 
 #include <string>
 
@@ -20,7 +20,6 @@
 #include "starboard/extension/player_configuration.h"
 #include "starboard/system.h"
 
-namespace cobalt {
 namespace media {
 
 bool SbPlayerInterface::SetDecodeToTexturePreferred(bool preferred) {
@@ -44,23 +43,6 @@ bool SbPlayerInterface::SetDecodeToTexturePreferred(bool preferred) {
     LOG(INFO) << "DecodeToTextureModePreferred is not supported.";
     return false;
   }
-}
-
-DefaultSbPlayerInterface::DefaultSbPlayerInterface() {
-  const CobaltExtensionEnhancedAudioApi* extension_api =
-      static_cast<const CobaltExtensionEnhancedAudioApi*>(
-          SbSystemGetExtension(kCobaltExtensionEnhancedAudioName));
-  if (!extension_api) {
-    return;
-  }
-
-  DCHECK_EQ(extension_api->name,
-            // Avoid comparing raw string pointers for equal.
-            std::string(kCobaltExtensionEnhancedAudioName));
-  DCHECK_EQ(extension_api->version, 1u);
-  DCHECK_NE(extension_api->PlayerWriteSamples, nullptr);
-
-  enhanced_audio_player_write_samples_ = extension_api->PlayerWriteSamples;
 }
 
 SbPlayer DefaultSbPlayerInterface::Create(
@@ -104,28 +86,13 @@ void DefaultSbPlayerInterface::Seek(SbPlayer player,
   media_metrics_provider_.EndTrackingAction(MediaAction::SBPLAYER_SEEK);
 }
 
-bool DefaultSbPlayerInterface::IsEnhancedAudioExtensionEnabled() const {
-  return enhanced_audio_player_write_samples_ != nullptr;
-}
-
 void DefaultSbPlayerInterface::WriteSamples(
     SbPlayer player,
     SbMediaType sample_type,
     const SbPlayerSampleInfo* sample_infos,
     int number_of_sample_infos) {
-  DCHECK(!IsEnhancedAudioExtensionEnabled());
   SbPlayerWriteSamples(player, sample_type, sample_infos,
                        number_of_sample_infos);
-}
-
-void DefaultSbPlayerInterface::WriteSamples(
-    SbPlayer player,
-    SbMediaType sample_type,
-    const CobaltExtensionEnhancedAudioPlayerSampleInfo* sample_infos,
-    int number_of_sample_infos) {
-  DCHECK(IsEnhancedAudioExtensionEnabled());
-  enhanced_audio_player_write_samples_(player, sample_type, sample_infos,
-                                       number_of_sample_infos);
 }
 
 int DefaultSbPlayerInterface::GetMaximumNumberOfSamplesPerWrite(
@@ -237,4 +204,3 @@ bool DefaultSbPlayerInterface::GetAudioConfiguration(
 }
 
 }  // namespace media
-}  // namespace cobalt

--- a/media/starboard/sbplayer_set_bounds_helper.cc
+++ b/media/starboard/sbplayer_set_bounds_helper.cc
@@ -12,12 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cobalt/media/base/sbplayer_set_bounds_helper.h"
+#include "media/starboard/sbplayer_set_bounds_helper.h"
 
 #include "base/atomic_sequence_num.h"
-#include "cobalt/media/base/sbplayer_bridge.h"
+#include "media/starboard/sbplayer_bridge.h"
 
-namespace cobalt {
 namespace media {
 
 namespace {
@@ -47,4 +46,3 @@ bool SbPlayerSetBoundsHelper::SetBounds(int x, int y, int width, int height) {
 }
 
 }  // namespace media
-}  // namespace cobalt

--- a/media/starboard/sbplayer_set_bounds_helper.h
+++ b/media/starboard/sbplayer_set_bounds_helper.h
@@ -12,16 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COBALT_MEDIA_BASE_SBPLAYER_SET_BOUNDS_HELPER_H_
-#define COBALT_MEDIA_BASE_SBPLAYER_SET_BOUNDS_HELPER_H_
+#ifndef MEDIA_STARBOARD_SBPLAYER_SET_BOUNDS_HELPER_H_
+#define MEDIA_STARBOARD_SBPLAYER_SET_BOUNDS_HELPER_H_
 
-#include "base/macros.h"
+#include <utility>
+
 #include "base/memory/ref_counted.h"
-#include "base/optional.h"
 #include "base/synchronization/lock.h"
 #include "ui/gfx/geometry/rect.h"
 
-namespace cobalt {
 namespace media {
 
 class SbPlayerBridge;
@@ -37,12 +36,12 @@ class SbPlayerSetBoundsHelper
  private:
   base::Lock lock_;
   SbPlayerBridge* player_bridge_ = nullptr;
-  base::Optional<gfx::Rect> rect_;
+  std::optional<gfx::Rect> rect_;
 
-  DISALLOW_COPY_AND_ASSIGN(SbPlayerSetBoundsHelper);
+  SbPlayerSetBoundsHelper(const SbPlayerSetBoundsHelper&) = delete;
+  void operator=(const SbPlayerSetBoundsHelper&) = delete;
 };
 
 }  // namespace media
-}  // namespace cobalt
 
-#endif  // COBALT_MEDIA_BASE_SBPLAYER_SET_BOUNDS_HELPER_H_
+#endif  // MEDIA_STARBOARD_SBPLAYER_SET_BOUNDS_HELPER_H_

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -1,4 +1,4 @@
-// Copyright 2016 The Cobalt Authors. All Rights Reserved.
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,52 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cobalt/media/base/sbplayer_pipeline.h"
+#include "media/starboard/starboard_renderer.h"
 
-#include <algorithm>
-#include <utility>
-
-#include "base/basictypes.h"  // For COMPILE_ASSERT
-#include "base/bind.h"
 #include "base/logging.h"
-#include "base/strings/stringprintf.h"
-#include "base/task/bind_post_task.h"
 #include "base/trace_event/trace_event.h"
-#include "cobalt/base/c_val.h"
-#include "cobalt/base/startup_timer.h"
-#include "media/base/channel_layout.h"
 #include "starboard/common/media.h"
-#include "starboard/common/string.h"
-#include "starboard/configuration_constants.h"
 
-namespace cobalt {
 namespace media {
+
 namespace {
-
-using ::media::AudioCodec;
-using ::media::AudioDecoderConfig;
-using ::media::DecoderBuffer;
-using ::media::Demuxer;
-using ::media::DemuxerHost;
-using ::media::DemuxerStream;
-using ::media::PipelineStatistics;
-using ::media::PipelineStatusCallback;
-using ::media::VideoDecoderConfig;
-using ::starboard::GetMediaAudioConnectorName;
-
-static const int kRetryDelayAtSuspendInMilliseconds = 100;
-
-// In the OnNeedData(), it attempts to write one more audio access
-// unit than the audio write duration. Specifically, the check
-// |time_ahead_of_playback_for_preroll| > |adjusted_write_duration_for_preroll|
-// is used to skip audio writing, using '>' instead of '>='.
-// Since the calculated write duration during preroll may align exactly
-// with the audio write duration, the current check can fail, leading to an
-// additional call to SbPlayerWriteSamples(). By writing an extra guard audio
-// buffer, this extra write during preroll can be eliminated.
-const int kPrerollGuardAudioBuffer = 1;
-
-unsigned int g_pipeline_identifier_counter = 0;
 
 bool HasRemoteAudioOutputs(
     const std::vector<SbMediaAudioConfiguration>& configurations) {
@@ -71,14 +34,14 @@ bool HasRemoteAudioOutputs(
       case kSbMediaAudioConnectorSpdif:
       case kSbMediaAudioConnectorUsb:
         LOG(INFO) << "Encountered local audio connector: "
-                  << GetMediaAudioConnectorName(connector);
+                  << starboard::GetMediaAudioConnectorName(connector);
         break;
       case kSbMediaAudioConnectorBluetooth:
       case kSbMediaAudioConnectorRemoteWired:
       case kSbMediaAudioConnectorRemoteWireless:
       case kSbMediaAudioConnectorRemoteOther:
         LOG(INFO) << "Encountered remote audio connector: "
-                  << GetMediaAudioConnectorName(connector);
+                  << starboard::GetMediaAudioConnectorName(connector);
         return true;
     }
   }
@@ -88,760 +51,245 @@ bool HasRemoteAudioOutputs(
   return false;
 }
 
-// The function adjusts audio write duration proportionally to the playback
-// rate, when the playback rate is greater than 1.0.
-//
-// Having the right write duration is important:
-// 1. Too small of it causes audio underflow.
-// 2. Too large of it causes excessive audio switch latency.
-// When playback rate is 2x, an 0.5 seconds of write duration effectively only
-// lasts for 0.25 seconds and causes audio underflow, and the function will
-// adjust it to 1 second in this case.
-TimeDelta AdjustWriteDurationForPlaybackRate(TimeDelta write_duration,
-                                             float playback_rate) {
-  if (playback_rate <= 1.0) {
-    return write_duration;
-  }
-
-  return write_duration * playback_rate;
-}
-
-// The function returns the default frames per DecoderBuffer.
-//
-// The number of frames is used to estimate the number of samples per write for
-// audio preroll according to |audio_write_duration_|.
-int GetDefaultAudioFramesPerBuffer(AudioCodec codec) {
-  switch (codec) {
-    case AudioCodec::kOpus:
-      return 960;
-    case AudioCodec::kAAC:
-      return 1024;
-    case AudioCodec::kAC3:
-    case AudioCodec::kEAC3:
-      return 1536;
-    default:
-      NOTREACHED();
-      return 1;
-  }
-}
-
 }  // namespace
 
-SbPlayerPipeline::SbPlayerPipeline(
-    SbPlayerInterface* interface,
-    PipelineWindow window,
-    const scoped_refptr<base::SequencedTaskRunner>& task_runner,
-    const GetDecodeTargetGraphicsContextProviderFunc&
-        get_decode_target_graphics_context_provider_func,
-    bool allow_resume_after_suspend,
-    int max_audio_samples_per_write,
-    bool force_punch_out_by_default,
-    TimeDelta audio_write_duration_local,
-    TimeDelta audio_write_duration_remote,
-    MediaLog* media_log,
-    MediaMetricsProvider* media_metrics_provider,
-    DecodeTargetProvider* decode_target_provider)
-    : pipeline_identifier_(
-          base::StringPrintf("%X", g_pipeline_identifier_counter++)),
-      sbplayer_interface_(interface),
-      task_runner_(task_runner),
-      allow_resume_after_suspend_(allow_resume_after_suspend),
-      max_audio_samples_per_write_(max_audio_samples_per_write),
-      window_(window),
-      get_decode_target_graphics_context_provider_func_(
-          get_decode_target_graphics_context_provider_func),
-      natural_size_(0, 0),
-      volume_(base::StringPrintf("Media.Pipeline.%s.Volume",
-                                 pipeline_identifier_.c_str()),
-              1.0f,
-              "Volume of the media pipeline."),
-      playback_rate_(base::StringPrintf("Media.Pipeline.%s.PlaybackRate",
-                                        pipeline_identifier_.c_str()),
-                     0.0f,
-                     "Playback rate of the media pipeline."),
-      duration_(base::StringPrintf("Media.Pipeline.%s.Duration",
-                                   pipeline_identifier_.c_str()),
-                TimeDelta(),
-                "Playback duration of the media pipeline."),
-      set_bounds_helper_(new SbPlayerSetBoundsHelper),
-      started_(base::StringPrintf("Media.Pipeline.%s.Started",
-                                  pipeline_identifier_.c_str()),
-               false,
-               "Whether the media pipeline has started."),
-      suspended_(base::StringPrintf("Media.Pipeline.%s.Suspended",
-                                    pipeline_identifier_.c_str()),
-                 false,
-                 "Whether the media pipeline has been suspended. The "
-                 "pipeline is usually suspended after the app enters "
-                 "background mode."),
-      stopped_(base::StringPrintf("Media.Pipeline.%s.Stopped",
-                                  pipeline_identifier_.c_str()),
-               false,
-               "Whether the media pipeline has stopped."),
-      ended_(base::StringPrintf("Media.Pipeline.%s.Ended",
-                                pipeline_identifier_.c_str()),
-             false,
-             "Whether the media pipeline has ended."),
-      player_state_(base::StringPrintf("Media.Pipeline.%s.PlayerState",
-                                       pipeline_identifier_.c_str()),
-                    kSbPlayerStateInitialized,
-                    "The underlying SbPlayer state of the media pipeline."),
-      decode_target_provider_(decode_target_provider),
-      audio_write_duration_local_(audio_write_duration_local),
-      audio_write_duration_remote_(audio_write_duration_remote),
-      media_metrics_provider_(media_metrics_provider),
-      last_media_time_(base::StringPrintf("Media.Pipeline.%s.LastMediaTime",
-                                          pipeline_identifier_.c_str()),
-                       TimeDelta(),
-                       "Last media time reported by the underlying player."),
-      max_video_capabilities_(
-          base::StringPrintf("Media.Pipeline.%s.MaxVideoCapabilities",
-                             pipeline_identifier_.c_str()),
-          "",
-          "The max video capabilities required for the media pipeline."),
-      playback_statistics_(pipeline_identifier_) {
-  if (force_punch_out_by_default) {
-    default_output_mode_ = kSbPlayerOutputModePunchOut;
-  }
+StarboardRenderer::StarboardRenderer(
+    const scoped_refptr<base::SequencedTaskRunner>& task_runner)
+    : task_runner_(task_runner) {
+  DCHECK(task_runner_);
+  LOG(INFO) << "StarboardRenderer constructed.";
 }
 
-SbPlayerPipeline::~SbPlayerPipeline() {
-  DCHECK(!player_bridge_);
-}
+StarboardRenderer::~StarboardRenderer() {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
-void SbPlayerPipeline::Suspend() {
-  DCHECK(!task_runner_->RunsTasksInCurrentSequence());
+  LOG(INFO) << "Destructing StarboardRenderer.";
 
-  base::WaitableEvent waitable_event(
-      base::WaitableEvent::ResetPolicy::MANUAL,
-      base::WaitableEvent::InitialState::NOT_SIGNALED);
-  task_runner_->PostTask(FROM_HERE,
-                         base::Bind(&SbPlayerPipeline::SuspendTask,
-                                    base::Unretained(this), &waitable_event));
-  waitable_event.Wait();
-}
-
-void SbPlayerPipeline::Resume(PipelineWindow window) {
-  DCHECK(!task_runner_->RunsTasksInCurrentSequence());
-
-  base::WaitableEvent waitable_event(
-      base::WaitableEvent::ResetPolicy::MANUAL,
-      base::WaitableEvent::InitialState::NOT_SIGNALED);
-  task_runner_->PostTask(
-      FROM_HERE, base::Bind(&SbPlayerPipeline::ResumeTask,
-                            base::Unretained(this), window, &waitable_event));
-  waitable_event.Wait();
-}
-
-#if SB_HAS(PLAYER_WITH_URL)
-void OnEncryptedMediaInitDataEncountered(
-    const Pipeline::OnEncryptedMediaInitDataEncounteredCB&
-        on_encrypted_media_init_data_encountered,
-    const char* init_data_type,
-    const unsigned char* init_data,
-    unsigned int init_data_length) {
-  LOG_IF(WARNING, strcmp(init_data_type, "cenc") != 0 &&
-                      strcmp(init_data_type, "fairplay") != 0 &&
-                      strcmp(init_data_type, "keyids") != 0 &&
-                      strcmp(init_data_type, "webm") != 0)
-      << "Unknown EME initialization data type: " << init_data_type;
-
-  std::vector<uint8_t> init_data_vec(init_data, init_data + init_data_length);
-  DCHECK(!on_encrypted_media_init_data_encountered.is_null());
-  on_encrypted_media_init_data_encountered.Run(init_data_type, init_data_vec);
-}
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-void SbPlayerPipeline::Start(Demuxer* demuxer,
-                             const SetDrmSystemReadyCB& set_drm_system_ready_cb,
-                             const PipelineStatusCB& ended_cb,
-                             const ErrorCB& error_cb,
-                             const SeekCB& seek_cb,
-                             const BufferingStateCB& buffering_state_cb,
-                             const base::Closure& duration_change_cb,
-                             const base::Closure& output_mode_change_cb,
-                             const base::Closure& content_size_change_cb,
-                             const std::string& max_video_capabilities,
-                             const int max_video_input_size) {
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::Start");
-
-  DCHECK(!ended_cb.is_null());
-  DCHECK(!error_cb.is_null());
-  DCHECK(!seek_cb.is_null());
-  DCHECK(!buffering_state_cb.is_null());
-  DCHECK(!duration_change_cb.is_null());
-  DCHECK(!output_mode_change_cb.is_null());
-  DCHECK(!content_size_change_cb.is_null());
-  DCHECK(demuxer);
-
-  StartTaskParameters parameters;
-  parameters.demuxer = demuxer;
-  parameters.set_drm_system_ready_cb = set_drm_system_ready_cb;
-  parameters.ended_cb = ended_cb;
-  parameters.error_cb = error_cb;
-  parameters.seek_cb = seek_cb;
-  parameters.buffering_state_cb = buffering_state_cb;
-  parameters.duration_change_cb = duration_change_cb;
-  parameters.output_mode_change_cb = output_mode_change_cb;
-  parameters.content_size_change_cb = content_size_change_cb;
-  parameters.max_video_capabilities = max_video_capabilities;
-  parameters.max_video_input_size = max_video_input_size;
-#if SB_HAS(PLAYER_WITH_URL)
-  parameters.is_url_based = false;
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-  task_runner_->PostTask(FROM_HERE,
-                         base::Bind(&SbPlayerPipeline::StartTask, this,
-                                    base::Passed(&parameters)));
-}
-
-#if SB_HAS(PLAYER_WITH_URL)
-void SbPlayerPipeline::Start(const SetDrmSystemReadyCB& set_drm_system_ready_cb,
-                             const OnEncryptedMediaInitDataEncounteredCB&
-                                 on_encrypted_media_init_data_encountered_cb,
-                             const std::string& source_url,
-                             const PipelineStatusCB& ended_cb,
-                             const ErrorCB& error_cb,
-                             const SeekCB& seek_cb,
-                             const BufferingStateCB& buffering_state_cb,
-                             const base::Closure& duration_change_cb,
-                             const base::Closure& output_mode_change_cb,
-                             const base::Closure& content_size_change_cb) {
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::Start");
-
-  DCHECK(!ended_cb.is_null());
-  DCHECK(!error_cb.is_null());
-  DCHECK(!seek_cb.is_null());
-  DCHECK(!buffering_state_cb.is_null());
-  DCHECK(!duration_change_cb.is_null());
-  DCHECK(!output_mode_change_cb.is_null());
-  DCHECK(!content_size_change_cb.is_null());
-  DCHECK(!on_encrypted_media_init_data_encountered_cb.is_null());
-
-  StartTaskParameters parameters;
-  parameters.demuxer = NULL;
-  parameters.set_drm_system_ready_cb = set_drm_system_ready_cb;
-  parameters.ended_cb = ended_cb;
-  parameters.error_cb = error_cb;
-  parameters.seek_cb = seek_cb;
-  parameters.buffering_state_cb = buffering_state_cb;
-  parameters.duration_change_cb = duration_change_cb;
-  parameters.output_mode_change_cb = output_mode_change_cb;
-  parameters.content_size_change_cb = content_size_change_cb;
-  parameters.source_url = source_url;
-  parameters.is_url_based = true;
-  on_encrypted_media_init_data_encountered_cb_ =
-      base::Bind(&OnEncryptedMediaInitDataEncountered,
-                 on_encrypted_media_init_data_encountered_cb);
-  set_drm_system_ready_cb_ = parameters.set_drm_system_ready_cb;
-  DCHECK(!set_drm_system_ready_cb_.is_null());
-  RunSetDrmSystemReadyCB(base::Bind(&SbPlayerPipeline::SetDrmSystem, this));
-
-  task_runner_->PostTask(FROM_HERE,
-                         base::Bind(&SbPlayerPipeline::StartTask, this,
-                                    base::Passed(&parameters)));
-}
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-void SbPlayerPipeline::Stop(const base::Closure& stop_cb) {
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::Stop");
-
-  if (!task_runner_->RunsTasksInCurrentSequence()) {
-    task_runner_->PostTask(FROM_HERE,
-                           base::Bind(&SbPlayerPipeline::Stop, this, stop_cb));
-    return;
-  }
-
-  DCHECK(stop_cb_.is_null());
-  DCHECK(!stop_cb.is_null());
-
-  stopped_ = true;
-
+  // Explicitly reset |player_bridge_| before destroying it.
+  // Some functions in this class using `player_bridge_` can be called
+  // asynchronously on arbitrary threads (e.g. `GetMediaTime()`), this ensures
+  // that they won't access `player_bridge_` when it's being destroyed.
+  decltype(player_bridge_) player_bridge;
   if (player_bridge_) {
-    std::unique_ptr<SbPlayerBridge> player_bridge;
-    {
-      base::AutoLock auto_lock(lock_);
-      player_bridge = std::move(player_bridge_);
-    }
-
-    LOG(INFO) << "Destroying SbPlayer.";
-    player_bridge.reset();
-    LOG(INFO) << "SbPlayer destroyed.";
+    base::AutoLock auto_lock(lock_);
+    player_bridge = std::move(player_bridge_);
   }
+  player_bridge.reset();
 
-  // When Stop() is in progress, we no longer need to call |error_cb_|.
-  error_cb_.Reset();
-  if (demuxer_) {
-    stop_cb_ = stop_cb;
-    demuxer_->Stop();
-    video_stream_ = nullptr;
-    audio_stream_ = nullptr;
-    OnDemuxerStopped();
-  } else {
-    stop_cb.Run();
-  }
+  LOG(INFO) << "StarboardRenderer destructed.";
 }
 
-void SbPlayerPipeline::Seek(TimeDelta time, const SeekCB& seek_cb) {
-  if (!task_runner_->RunsTasksInCurrentSequence()) {
-    task_runner_->PostTask(
-        FROM_HERE, base::Bind(&SbPlayerPipeline::Seek, this, time, seek_cb));
-    return;
-  }
+void StarboardRenderer::Initialize(MediaResource* media_resource,
+                                   RendererClient* client,
+                                   PipelineStatusCallback init_cb) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  DCHECK(!client_);
+  DCHECK(!audio_stream_);
+  DCHECK(!video_stream_);
+  DCHECK(media_resource);
+  DCHECK(client);
+  DCHECK(init_cb);
 
-  playback_statistics_.OnSeek(time);
+  TRACE_EVENT0("media", "StarboardRenderer::Initialize");
 
-  if (!player_bridge_) {
-    seek_cb.Run(::media::PIPELINE_ERROR_INVALID_STATE, false,
-                AppendStatisticsString("SbPlayerPipeline::Seek failed: "
-                                       "player_bridge_ is nullptr."));
-    return;
-  }
+  LOG(INFO) << "Initializing StarboardRenderer.";
 
-  player_bridge_->PrepareForSeek();
-  ended_ = false;
-
-  DCHECK(seek_cb_.is_null());
-  DCHECK(!seek_cb.is_null());
-
-  if (audio_read_in_progress_ || video_read_in_progress_) {
-    const TimeDelta kDelay = base::Milliseconds(50);
+#if COBALT_MEDIA_ENABLE_SUSPEND_RESUME
+  // Note that once this code block is enabled, we should also ensure that the
+  // posted callback executes on the right object (i.e. not destroyed, use
+  // WeakPtr?) in the right state (not flushed?).
+  if (suspended_) {
     task_runner_->PostDelayedTask(
-        FROM_HERE, base::Bind(&SbPlayerPipeline::Seek, this, time, seek_cb),
-        kDelay);
-    return;
-  }
-
-  {
-    base::AutoLock auto_lock(lock_);
-    seek_cb_ = seek_cb;
-    seek_time_ = time;
-  }
-
-  // Ignore pending delayed calls to OnNeedData, and update variables used to
-  // decide when to delay.
-  audio_read_delayed_ = false;
-  StoreMediaTime(seek_time_);
-  retrograde_media_time_counter_ = 0;
-  timestamp_of_last_written_audio_ = TimeDelta();
-  is_video_eos_written_ = false;
-
-#if SB_HAS(PLAYER_WITH_URL)
-  if (is_url_based_) {
-    player_bridge_->Seek(seek_time_);
-    return;
-  }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  demuxer_->Seek(time, BindPostTaskToCurrentDefault(base::Bind(
-                           &SbPlayerPipeline::OnDemuxerSeeked, this)));
-}
-
-bool SbPlayerPipeline::HasAudio() const {
-  base::AutoLock auto_lock(lock_);
-  return audio_stream_ != NULL;
-}
-
-bool SbPlayerPipeline::HasVideo() const {
-  base::AutoLock auto_lock(lock_);
-  return video_stream_ != NULL;
-}
-
-float SbPlayerPipeline::GetPlaybackRate() const {
-  base::AutoLock auto_lock(lock_);
-  return playback_rate_;
-}
-
-void SbPlayerPipeline::SetPlaybackRate(float playback_rate) {
-  base::AutoLock auto_lock(lock_);
-  playback_rate_ = playback_rate;
-  task_runner_->PostTask(
-      FROM_HERE,
-      base::Bind(&SbPlayerPipeline::SetPlaybackRateTask, this, playback_rate));
-}
-
-float SbPlayerPipeline::GetVolume() const {
-  base::AutoLock auto_lock(lock_);
-  return volume_;
-}
-
-void SbPlayerPipeline::SetVolume(float volume) {
-  if (volume < 0.0f || volume > 1.0f) {
-    return;
-  }
-
-  base::AutoLock auto_lock(lock_);
-  volume_ = volume;
-  task_runner_->PostTask(
-      FROM_HERE, base::Bind(&SbPlayerPipeline::SetVolumeTask, this, volume));
-}
-
-void SbPlayerPipeline::StoreMediaTime(TimeDelta media_time) {
-  last_media_time_ = media_time;
-  last_time_media_time_retrieved_ = Time::Now();
-}
-
-TimeDelta SbPlayerPipeline::GetMediaTime() {
-  base::AutoLock auto_lock(lock_);
-
-  if (!seek_cb_.is_null()) {
-    StoreMediaTime(seek_time_);
-    return seek_time_;
-  }
-  if (!player_bridge_) {
-    StoreMediaTime(TimeDelta());
-    return TimeDelta();
-  }
-  if (ended_) {
-    StoreMediaTime(duration_);
-    return duration_;
-  }
-  TimeDelta media_time;
-#if SB_HAS(PLAYER_WITH_URL)
-  if (is_url_based_) {
-    int frame_width;
-    int frame_height;
-    player_bridge_->GetVideoResolution(&frame_width, &frame_height);
-    if (frame_width != natural_size_.width() ||
-        frame_height != natural_size_.height()) {
-      natural_size_ = gfx::Size(frame_width, frame_height);
-      content_size_change_cb_.Run();
-    }
-  }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  player_bridge_->GetInfo(&statistics_.video_frames_decoded,
-                          &statistics_.video_frames_dropped, &media_time);
-
-  // Guarantee that we report monotonically increasing media time
-  if (media_time < last_media_time_) {
-    if (retrograde_media_time_counter_ == 0) {
-      DLOG(WARNING) << "Received retrograde media time, new:"
-                    << media_time.InMicroseconds()
-                    << ", last: " << last_media_time_ << ".";
-    }
-    media_time = last_media_time_;
-    retrograde_media_time_counter_++;
-  } else if (retrograde_media_time_counter_ != 0) {
-    DLOG(WARNING) << "Received " << retrograde_media_time_counter_
-                  << " retrograde media time before recovered.";
-    retrograde_media_time_counter_ = 0;
-  }
-  StoreMediaTime(media_time);
-  return media_time;
-}
-
-::media::Ranges<TimeDelta> SbPlayerPipeline::GetBufferedTimeRanges() {
-  base::AutoLock auto_lock(lock_);
-
-#if SB_HAS(PLAYER_WITH_URL)
-  ::media::Ranges<TimeDelta> time_ranges;
-
-  if (!player_bridge_) {
-    return time_ranges;
-  }
-
-  if (is_url_based_) {
-    TimeDelta media_time;
-    TimeDelta buffer_start_time;
-    TimeDelta buffer_length_time;
-    player_bridge_->GetInfo(&statistics_.video_frames_decoded,
-                            &statistics_.video_frames_dropped, &media_time);
-    player_bridge_->GetUrlPlayerBufferedTimeRanges(&buffer_start_time,
-                                                   &buffer_length_time);
-
-    if (buffer_length_time.InSeconds() == 0) {
-      buffered_time_ranges_ = time_ranges;
-      return time_ranges;
-    }
-
-    time_ranges.Add(buffer_start_time, buffer_start_time + buffer_length_time);
-
-    if (buffered_time_ranges_.size() > 0) {
-      TimeDelta old_buffer_start_time = buffered_time_ranges_.start(0);
-      TimeDelta old_buffer_length_time = buffered_time_ranges_.end(0);
-      int64 old_start_seconds = old_buffer_start_time.InSeconds();
-      int64 new_start_seconds = buffer_start_time.InSeconds();
-      int64 old_length_seconds = old_buffer_length_time.InSeconds();
-      int64 new_length_seconds = buffer_length_time.InSeconds();
-      if (old_start_seconds != new_start_seconds ||
-          old_length_seconds != new_length_seconds) {
-        did_loading_progress_ = true;
-      }
-    } else {
-      did_loading_progress_ = true;
-    }
-
-    buffered_time_ranges_ = time_ranges;
-    return time_ranges;
-  }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-  return buffered_time_ranges_;
-}
-
-TimeDelta SbPlayerPipeline::GetMediaDuration() const {
-  base::AutoLock auto_lock(lock_);
-  return duration_;
-}
-
-#if SB_HAS(PLAYER_WITH_URL)
-TimeDelta SbPlayerPipeline::GetMediaStartDate() const {
-  base::AutoLock auto_lock(lock_);
-  return start_date_;
-}
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-void SbPlayerPipeline::GetNaturalVideoSize(gfx::Size* out_size) const {
-  CHECK(out_size);
-  base::AutoLock auto_lock(lock_);
-  *out_size = natural_size_;
-}
-
-std::vector<std::string> SbPlayerPipeline::GetAudioConnectors() const {
-  base::AutoLock auto_lock(lock_);
-  if (!player_bridge_) {
-    return std::vector<std::string>();
-  }
-
-  std::vector<std::string> connectors;
-
-#if SB_HAS(PLAYER_WITH_URL)
-  // Url based player does not support audio connectors.
-  if (is_url_based_) {
-    return connectors;
-  }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-  auto configurations = player_bridge_->GetAudioConfigurations();
-  for (auto&& configuration : configurations) {
-    connectors.push_back(GetMediaAudioConnectorName(configuration.connector));
-  }
-
-  return connectors;
-}
-
-bool SbPlayerPipeline::DidLoadingProgress() const {
-  base::AutoLock auto_lock(lock_);
-  bool ret = did_loading_progress_;
-  did_loading_progress_ = false;
-  return ret;
-}
-
-PipelineStatistics SbPlayerPipeline::GetStatistics() const {
-  base::AutoLock auto_lock(lock_);
-  return statistics_;
-}
-
-Pipeline::SetBoundsCB SbPlayerPipeline::GetSetBoundsCB() {
-  return base::Bind(&SbPlayerSetBoundsHelper::SetBounds, set_bounds_helper_);
-}
-
-void SbPlayerPipeline::SetPreferredOutputModeToDecodeToTexture() {
-  TRACE_EVENT0("cobalt::media",
-               "SbPlayerPipeline::SetPreferredOutputModeToDecodeToTexture");
-
-  if (!task_runner_->RunsTasksInCurrentSequence()) {
-    task_runner_->PostTask(
         FROM_HERE,
-        base::Bind(&SbPlayerPipeline::SetPreferredOutputModeToDecodeToTexture,
-                   this));
+        base::Bind(&StarboardRenderer::Initialize, this, media_resource, client,
+                   init_cb),
+        base::Milliseconds(kRetryDelayAtSuspendInMilliseconds));
+    return;
+  }
+#endif  // COBALT_MEDIA_ENABLE_SUSPEND_RESUME
+
+  client_ = client;
+
+  audio_stream_ = media_resource->GetFirstStream(DemuxerStream::AUDIO);
+  video_stream_ = media_resource->GetFirstStream(DemuxerStream::VIDEO);
+
+  if (audio_stream_ == nullptr && video_stream_ == nullptr) {
+    LOG(INFO)
+        << "The video has to contain at least an audio track or a video track.";
+    std::move(init_cb).Run(PipelineStatus(
+        DEMUXER_ERROR_NO_SUPPORTED_STREAMS,
+        "The video has to contain at least an audio track or a video track."));
     return;
   }
 
-  // The player can't be created yet, if it is, then we're updating the output
-  // mode too late.
-  DCHECK(!player_bridge_);
+#if COBALT_MEDIA_ENABLE_ENCRYPTED_PLAYBACKS
+  base::AutoLock auto_lock(lock_);
 
-  default_output_mode_ = kSbPlayerOutputModeDecodeToTexture;
-}
+  bool is_encrypted =
+      audio_stream_ && audio_stream_->audio_decoder_config().is_encrypted();
+  is_encrypted |=
+      video_stream_ && video_stream_->video_decoder_config().is_encrypted();
+  if (is_encrypted) {
+    // TODO(b/328305808): Shall we call client_->OnVideoNaturalSizeChange() to
+    // provide an initial size before the license exchange finishes?
 
-void SbPlayerPipeline::StartTask(StartTaskParameters parameters) {
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::StartTask");
-
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-
-  DCHECK(!demuxer_);
-
-  demuxer_ = parameters.demuxer;
-  set_drm_system_ready_cb_ = parameters.set_drm_system_ready_cb;
-  ended_cb_ = parameters.ended_cb;
-  error_cb_ = parameters.error_cb;
-  {
-    base::AutoLock auto_lock(lock_);
-    seek_cb_ = parameters.seek_cb;
-  }
-  buffering_state_cb_ = parameters.buffering_state_cb;
-  duration_change_cb_ = parameters.duration_change_cb;
-  output_mode_change_cb_ = parameters.output_mode_change_cb;
-  content_size_change_cb_ = parameters.content_size_change_cb;
-  max_video_capabilities_ = parameters.max_video_capabilities;
-  max_video_input_size_ = parameters.max_video_input_size;
-#if SB_HAS(PLAYER_WITH_URL)
-  is_url_based_ = parameters.is_url_based;
-  if (is_url_based_) {
-    CreateUrlPlayer(parameters.source_url);
+    RunSetDrmSystemReadyCB(BindPostTaskToCurrentDefault(
+        base::Bind(&SbPlayerPipeline::CreatePlayer, this)));
     return;
   }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  demuxer_->Initialize(
-      this, BindPostTaskToCurrentDefault(
-                base::Bind(&SbPlayerPipeline::OnDemuxerInitialized, this)));
+#endif  // COBALT_MEDIA_ENABLE_ENCRYPTED_PLAYBACKS
 
-  started_ = true;
+  // |init_cb| will be called inside |CreatePlayerBridge()|.
+  CreatePlayerBridge(std::move(init_cb));
 }
 
-void SbPlayerPipeline::SetVolumeTask(float volume) {
+void StarboardRenderer::Flush(base::OnceClosure flush_cb) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  DCHECK(!pending_flush_cb_);
+  DCHECK(flush_cb);
 
-  if (player_bridge_) {
-    player_bridge_->SetVolume(volume_);
+  LOG(INFO) << "Flushing StarboardRenderer.";
+
+  // Prepares the |player_bridge_| for Seek(), the |player_bridge_| won't
+  // request more data from us before Seek() is called.
+  player_bridge_->PrepareForSeek();
+
+  // The function can be called when there are in-flight Demuxer::Read() calls
+  // posted in OnDemuxerStreamRead(), we will wait until they are completed.
+  if (audio_read_in_progress_ || video_read_in_progress_) {
+    pending_flush_cb_ = std::move(flush_cb);
+  } else {
+    std::move(flush_cb).Run();
   }
 }
 
-void SbPlayerPipeline::SetPlaybackRateTask(float volume) {
+void StarboardRenderer::StartPlayingFrom(base::TimeDelta time) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
+
+  LOG(INFO) << "StarboardRenderer::StartPlayingFrom() called with " << time
+            << '.';
+  LOG_IF(WARNING, time < base::Seconds(0))
+      << "Potentially invalid start time " << time << '.';
+
+  if (player_bridge_initialized_) {
+    player_bridge_->Seek(time);
+    return;
+  }
+
+  // We cannot start playback before SbPlayerBridge is initialized, save the
+  // time and start later.
+  DCHECK(!playing_start_from_time_);
+  playing_start_from_time_ = time;
+}
+
+void StarboardRenderer::SetPlaybackRate(double playback_rate) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+
+  if (playback_rate < 0.0) {
+    LOG(INFO) << "StarboardRenderer::SetPlaybackRate(): invalid playback rate "
+              << playback_rate << '.';
+    return;
+  }
+
+  LOG(INFO) << "StarboardRenderer changes playback rate from " << playback_rate_
+            << " to " << playback_rate << '.';
+
+  if (playback_rate_ == playback_rate) {
+    return;
+  }
+
+  playback_rate_ = playback_rate;
 
   if (player_bridge_) {
     player_bridge_->SetPlaybackRate(playback_rate_);
   }
 }
 
-void SbPlayerPipeline::SetDurationTask(TimeDelta duration) {
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-  if (!duration_change_cb_.is_null()) {
-    duration_change_cb_.Run();
-  }
-}
-
-void SbPlayerPipeline::OnBufferedTimeRangesChanged(
-    const ::media::Ranges<TimeDelta>& ranges) {
-  base::AutoLock auto_lock(lock_);
-  did_loading_progress_ = true;
-  buffered_time_ranges_ = ranges;
-}
-
-void SbPlayerPipeline::SetDuration(TimeDelta duration) {
-  base::AutoLock auto_lock(lock_);
-  duration_ = duration;
-  task_runner_->PostTask(
-      FROM_HERE,
-      base::Bind(&SbPlayerPipeline::SetDurationTask, this, duration));
-}
-
-void SbPlayerPipeline::OnDemuxerError(PipelineStatus error) {
-  if (!task_runner_->RunsTasksInCurrentSequence()) {
-    task_runner_->PostTask(
-        FROM_HERE, base::Bind(&SbPlayerPipeline::OnDemuxerError, this, error));
-    return;
-  }
-
-  LOG(INFO) << "SbPlayerPipeline::OnDemuxerError() called with error " << error;
-
-  if (error != ::media::PIPELINE_OK) {
-    CallErrorCB(error, "Demuxer error.");
-  }
-}
-
-#if SB_HAS(PLAYER_WITH_URL)
-void SbPlayerPipeline::CreateUrlPlayer(const std::string& source_url) {
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::CreateUrlPlayer");
+void StarboardRenderer::SetVolume(float volume) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
-  if (stopped_) {
+  if (volume < 0.0 || volume > 1.0) {
+    LOG(INFO) << "StarboardRenderer::SetVolume(): invalid volume " << volume
+              << '.';
     return;
   }
 
-  if (suspended_) {
-    task_runner_->PostDelayedTask(
-        FROM_HERE,
-        base::Bind(&SbPlayerPipeline::CreateUrlPlayer, this, source_url),
-        TimeDelta::FromMilliseconds(kRetryDelayAtSuspendInMilliseconds));
+  LOG(INFO) << "StarboardRenderer changes volume from " << volume_ << " to "
+            << volume << '.';
+
+  if (volume_ == volume) {
     return;
   }
 
-  // TODO:  Check |suspended_| here as the pipeline can be suspended before the
-  // player is created.  In this case we should delay creating the player as the
-  // creation of player may fail.
-  std::string error_message;
-  {
-    base::AutoLock auto_lock(lock_);
-    LOG(INFO) << "Creating SbPlayerBridge with url: " << source_url;
-    player_bridge_.reset(new SbPlayerBridge(
-        sbplayer_interface_, task_runner_, source_url, window_, this,
-        set_bounds_helper_.get(), allow_resume_after_suspend_,
-        default_output_mode_, on_encrypted_media_init_data_encountered_cb_,
-        decode_target_provider_, pipeline_identifier_));
-    if (player_bridge_->IsValid()) {
-      SetPlaybackRateTask(playback_rate_);
-      SetVolumeTask(volume_);
-    } else {
-      error_message = player_bridge_->GetPlayerCreationErrorMessage();
-      player_bridge_.reset();
-      LOG(INFO) << "Failed to create a valid SbPlayerBridge.";
-    }
+  volume_ = volume;
+
+  if (player_bridge_) {
+    player_bridge_->SetVolume(volume_);
   }
-
-  if (player_bridge_ && player_bridge_->IsValid()) {
-    base::Closure output_mode_change_cb;
-    {
-      base::AutoLock auto_lock(lock_);
-      DCHECK(!output_mode_change_cb_.is_null());
-      output_mode_change_cb = std::move(output_mode_change_cb_);
-    }
-    output_mode_change_cb.Run();
-    return;
-  }
-
-  std::string time_information = GetTimeInformation();
-  LOG(INFO) << "SbPlayerPipeline::CreateUrlPlayer failed to create a valid "
-               "SbPlayerBridge - "
-            << time_information << " \'" << error_message << "\'";
-
-  CallSeekCB(::media::DECODER_ERROR_NOT_SUPPORTED,
-             "SbPlayerPipeline::CreateUrlPlayer failed to create a valid "
-             "SbPlayerBridge - " +
-                 time_information + " \'" + error_message + "\'");
 }
 
-void SbPlayerPipeline::SetDrmSystem(SbDrmSystem drm_system) {
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::SetDrmSystem");
-
+// TODO(b/376328722): Revisit playback time reporting.
+base::TimeDelta StarboardRenderer::GetMediaTime() {
   base::AutoLock auto_lock(lock_);
+
   if (!player_bridge_) {
-    LOG(INFO) << "Player not set before calling SbPlayerPipeline::SetDrmSystem";
-    return;
+    return base::Microseconds(0);
   }
 
-  if (player_bridge_->IsValid()) {
-    player_bridge_->RecordSetDrmSystemReadyTime(set_drm_system_ready_cb_time_);
-    player_bridge_->SetDrmSystem(drm_system);
+  uint32_t video_frames_decoded, video_frames_dropped;
+  base::TimeDelta media_time;
+
+  player_bridge_->GetInfo(&video_frames_decoded, &video_frames_dropped,
+                          &media_time);
+
+  // Report dropped frames since we have the info anyway.
+  PipelineStatistics statistics;
+
+  if (video_frames_decoded > last_video_frames_decoded_) {
+    statistics.video_frames_decoded =
+        video_frames_decoded - last_video_frames_decoded_;
+    last_video_frames_decoded_ = video_frames_decoded;
   }
+
+  if (video_frames_dropped > last_video_frames_dropped_) {
+    statistics.video_frames_dropped =
+        video_frames_dropped - last_video_frames_dropped_;
+    last_video_frames_dropped_ = video_frames_dropped;
+  }
+
+  if (statistics.video_frames_decoded > 0 ||
+      statistics.video_frames_dropped > 0) {
+    // TODO(b/375273093): Refine frame drops reporting, and double check
+    //                    whether we should report more statistics, and/or
+    //                    reduce the frequency of reporting.
+    task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&RendererClient::OnStatisticsUpdate,
+                                  base::Unretained(client_), statistics));
+  }
+
+  return media_time;
 }
-#endif  // SB_HAS(PLAYER_WITH_URL)
 
-void SbPlayerPipeline::CreatePlayer(SbDrmSystem drm_system) {
-#if SB_HAS(PLAYER_WITH_URL)
-  DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::CreatePlayer");
-
+void StarboardRenderer::CreatePlayerBridge(PipelineStatusCallback init_cb) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  DCHECK(init_cb);
   DCHECK(audio_stream_ || video_stream_);
 
-  if (stopped_) {
-    return;
-  }
+  TRACE_EVENT0("media", "StarboardRenderer::CreatePlayerBridge");
 
+#if COBALT_MEDIA_ENABLE_SUSPEND_RESUME
+  // Note that once this code block is enabled, we should also ensure that the
+  // posted callback executes on the right object (i.e. not destroyed, use
+  // WeakPtr?) in the right state (not flushed?).
   if (suspended_) {
     task_runner_->PostDelayedTask(
         FROM_HERE,
-        base::Bind(&SbPlayerPipeline::CreatePlayer, this, drm_system),
+        base::Bind(&StarboardRenderer::CreatePlayerBridge, this, init_cb),
         base::Milliseconds(kRetryDelayAtSuspendInMilliseconds));
     return;
   }
+#endif  // COBALT_MEDIA_ENABLE_SUSPEND_RESUME
 
-  // TODO:  Check |suspended_| here as the pipeline can be suspended before the
-  // player is created.  In this case we should delay creating the player as the
-  // creation of player may fail.
   AudioDecoderConfig invalid_audio_config;
   const AudioDecoderConfig& audio_config =
       audio_stream_ ? audio_stream_->audio_decoder_config()
@@ -851,43 +299,64 @@ void SbPlayerPipeline::CreatePlayer(SbDrmSystem drm_system) {
       video_stream_ ? video_stream_->video_decoder_config()
                     : invalid_video_config;
 
-  std::string audio_mime_type = audio_stream_ ? audio_stream_->mime_type() : "";
-  std::string video_mime_type;
-  if (video_stream_) {
-    playback_statistics_.UpdateVideoConfig(
-        video_stream_->video_decoder_config());
-    video_mime_type = video_stream_->mime_type();
-  }
+  std::string audio_mime_type = "";
+  std::string video_mime_type = "";
+
+  // TODO(b/321842876): Enable mime type passing in //media.
+  //
+  // audio_mime_type = audio_stream_ ? audio_stream_->mime_type() : "";
+  // if (video_stream_) {
+  //   video_mime_type = video_stream_->mime_type();
+  // }
 
   std::string error_message;
+
   {
     base::AutoLock auto_lock(lock_);
-    SB_DCHECK(!player_bridge_);
-    // In the extreme case that CreatePlayer() is called when a |player_bridge_|
-    // is available, reset the existing player first to reduce the number of
-    // active players.
+    DCHECK(!player_bridge_);
+
+    // In the unexpected case that CreatePlayerBridge() is called when a
+    // |player_bridge_| is set, reset the existing player first to reduce the
+    // number of active players.
     player_bridge_.reset();
+
     LOG(INFO) << "Creating SbPlayerBridge.";
+
     player_bridge_.reset(new SbPlayerBridge(
-        sbplayer_interface_, task_runner_,
-        get_decode_target_graphics_context_provider_func_, audio_config,
-        audio_mime_type, video_config, video_mime_type, window_, drm_system,
-        this, set_bounds_helper_.get(), allow_resume_after_suspend_,
-        default_output_mode_, decode_target_provider_, max_video_capabilities_,
-        max_video_input_size_, pipeline_identifier_));
+        &sbplayer_interface_, task_runner_,
+        // TODO(b/375070492): Implement decode-to-texture support
+        SbPlayerBridge::GetDecodeTargetGraphicsContextProviderFunc(),
+        audio_config,
+        // TODO(b/321842876): Enable mime type passing in //media.
+        audio_mime_type, video_config,
+        // TODO(b/321842876): Enable mime type passing in //media.
+        video_mime_type,
+        // TODO(b/326497953): Support suspend/resume.
+        // TODO(b/326508279): Support background mode.
+        kSbWindowInvalid,
+        // TODO(b/328305808): Implement SbDrm support.
+        kSbDrmSystemInvalid, this,
+        // TODO(b/376320224); Verify set bounds works
+        nullptr,
+        // TODO(b/326497953): Support suspend/resume.
+        false,
+        // TODO(b/326825450): Revisit 360 videos.
+        // TODO(b/326827007): Support secondary videos.
+        kSbPlayerOutputModeInvalid,
+        // TODO(b/326827007): Support secondary videos.
+        "",
+        // TODO(b/326654546): Revisit HTMLVideoElement.setMaxVideoInputSize.
+        -1));
     if (player_bridge_->IsValid()) {
       // TODO(b/267678497): When `player_bridge_->GetAudioConfigurations()`
       // returns no audio configurations, update the write durations again
       // before the SbPlayer reaches `kSbPlayerStatePresenting`.
-      audio_write_duration_for_preroll_ = audio_write_duration_ =
+      audio_write_duration_ =
           HasRemoteAudioOutputs(player_bridge_->GetAudioConfigurations())
               ? audio_write_duration_remote_
               : audio_write_duration_local_;
       LOG(INFO) << "SbPlayerBridge created, with audio write duration at "
-                << audio_write_duration_for_preroll_;
-
-      SetPlaybackRateTask(playback_rate_);
-      SetVolumeTask(volume_);
+                << audio_write_duration_;
     } else {
       error_message = player_bridge_->GetPlayerCreationErrorMessage();
       player_bridge_.reset();
@@ -896,219 +365,131 @@ void SbPlayerPipeline::CreatePlayer(SbDrmSystem drm_system) {
   }
 
   if (player_bridge_ && player_bridge_->IsValid()) {
-    player_bridge_->RecordSetDrmSystemReadyTime(set_drm_system_ready_cb_time_);
-    base::Closure output_mode_change_cb;
-    {
-      base::AutoLock auto_lock(lock_);
-      DCHECK(!output_mode_change_cb_.is_null());
-      output_mode_change_cb = std::move(output_mode_change_cb_);
-    }
-    output_mode_change_cb.Run();
-
     if (audio_stream_) {
       UpdateDecoderConfig(audio_stream_);
     }
     if (video_stream_) {
       UpdateDecoderConfig(video_stream_);
     }
+
+    player_bridge_->SetPlaybackRate(playback_rate_);
+    player_bridge_->SetVolume(volume_);
+
+    std::move(init_cb).Run(PipelineStatus(PIPELINE_OK));
     return;
   }
 
-  std::string time_information = GetTimeInformation();
-  LOG(INFO) << "SbPlayerPipeline::CreatePlayer failed to create a valid "
-               "SbPlayerBridge - "
-            << time_information << " \'" << error_message << "\'";
+  LOG(INFO) << "SbPlayerPipeline::CreatePlayerBridge() failed to create a"
+               " valid SbPlayerBridge - \""
+            << error_message << "\"";
 
-  CallSeekCB(::media::DECODER_ERROR_NOT_SUPPORTED,
-             "SbPlayerPipeline::CreatePlayer failed to create a valid "
-             "SbPlayerBridge - " +
-                 time_information + " \'" + error_message + "\'");
+  std::move(init_cb).Run(PipelineStatus(
+      DECODER_ERROR_NOT_SUPPORTED,
+      "SbPlayerPipeline::CreatePlayerBridge() failed to create a valid"
+      " SbPlayerBridge - \"" +
+          error_message + "\""));
 }
 
-void SbPlayerPipeline::OnDemuxerInitialized(PipelineStatus status) {
-#if SB_HAS(PLAYER_WITH_URL)
-  DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::OnDemuxerInitialized");
-
+void StarboardRenderer::UpdateDecoderConfig(DemuxerStream* stream) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
-  if (stopped_) {
+  if (!player_bridge_) {
     return;
   }
 
-  if (status != ::media::PIPELINE_OK) {
-    CallErrorCB(status, "Demuxer initialization error.");
-    return;
-  }
+  if (stream->type() == DemuxerStream::AUDIO) {
+    const AudioDecoderConfig& decoder_config = stream->audio_decoder_config();
+    player_bridge_->UpdateAudioConfig(decoder_config, "");
+  } else {
+    DCHECK_EQ(stream->type(), DemuxerStream::VIDEO);
+    const VideoDecoderConfig& decoder_config = stream->video_decoder_config();
 
-  if (suspended_) {
-    task_runner_->PostDelayedTask(
-        FROM_HERE,
-        base::Bind(&SbPlayerPipeline::OnDemuxerInitialized, this, status),
-        base::Milliseconds(kRetryDelayAtSuspendInMilliseconds));
-    return;
-  }
-
-  auto streams = demuxer_->GetAllStreams();
-  DemuxerStream* audio_stream = nullptr;
-  DemuxerStream* video_stream = nullptr;
-  for (auto&& stream : streams) {
-    if (stream->type() == DemuxerStream::AUDIO) {
-      if (audio_stream == nullptr) {
-        audio_stream = stream;
-      } else {
-        LOG(WARNING) << "Encountered more than one audio streams.";
-      }
-    } else if (stream->type() == DemuxerStream::VIDEO) {
-      if (video_stream == nullptr) {
-        video_stream = stream;
-      } else {
-        LOG(WARNING) << "Encountered more than one video streams.";
-      }
-    }
-  }
-
-  if (audio_stream == NULL && video_stream == NULL) {
-    LOG(INFO) << "The video has to contain an audio track or a video track.";
-    CallErrorCB(::media::DEMUXER_ERROR_NO_SUPPORTED_STREAMS,
-                "The video has to contain an audio track or a video track.");
-    return;
-  }
-
-  {
+    // TODO(b/375275033): Refine natural size change handling.
+#if 0
     base::AutoLock auto_lock(lock_);
-    audio_stream_ = audio_stream;
-    video_stream_ = video_stream;
 
-    bool is_encrypted =
-        audio_stream_ && audio_stream_->audio_decoder_config().is_encrypted();
-    is_encrypted |=
-        video_stream_ && video_stream_->video_decoder_config().is_encrypted();
-    bool natural_size_changed = false;
-    if (video_stream_) {
-      natural_size_changed =
-          (video_stream_->video_decoder_config().natural_size().width() !=
-               natural_size_.width() ||
-           video_stream_->video_decoder_config().natural_size().height() !=
-               natural_size_.height());
-      natural_size_ = video_stream_->video_decoder_config().natural_size();
-    }
+    bool natural_size_changed =
+        (decoder_config.natural_size().width() != natural_size_.width() ||
+         decoder_config.natural_size().height() != natural_size_.height());
+
+    natural_size_ = decoder_config.natural_size();
+
+    player_bridge_->UpdateVideoConfig(decoder_config, "");
+
     if (natural_size_changed) {
       content_size_change_cb_.Run();
     }
-    if (is_encrypted) {
-      RunSetDrmSystemReadyCB(BindPostTaskToCurrentDefault(
-          base::Bind(&SbPlayerPipeline::CreatePlayer, this)));
-      return;
-    }
-  }
-
-  CreatePlayer(kSbDrmSystemInvalid);
-}
-
-void SbPlayerPipeline::OnDemuxerSeeked(PipelineStatus status) {
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-
-  if (status == ::media::PIPELINE_OK && player_bridge_) {
-    player_bridge_->Seek(seek_time_);
+#endif  // 0
   }
 }
 
-void SbPlayerPipeline::OnDemuxerStopped() {
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::OnDemuxerStopped");
-
-  if (!task_runner_->RunsTasksInCurrentSequence()) {
-    task_runner_->PostTask(
-        FROM_HERE, base::Bind(&SbPlayerPipeline::OnDemuxerStopped, this));
-    return;
-  }
-
-  std::move(stop_cb_).Run();
-}
-
-void SbPlayerPipeline::OnDemuxerStreamRead(
-    DemuxerStream::Type type,
-    int max_number_buffers_to_read,
+void StarboardRenderer::OnDemuxerStreamRead(
+    DemuxerStream* stream,
     DemuxerStream::Status status,
-    const std::vector<scoped_refptr<DecoderBuffer>> buffers) {
-#if SB_HAS(PLAYER_WITH_URL)
-  DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  DCHECK(type == DemuxerStream::AUDIO || type == DemuxerStream::VIDEO)
-      << "Unsupported DemuxerStream::Type " << type;
-
+    DemuxerStream::DecoderBufferVector buffers) {
   if (!task_runner_->RunsTasksInCurrentSequence()) {
     task_runner_->PostTask(
-        FROM_HERE,
-        base::BindOnce(&SbPlayerPipeline::OnDemuxerStreamRead, this, type,
-                       max_number_buffers_to_read, status, buffers));
+        FROM_HERE, base::BindOnce(&StarboardRenderer::OnDemuxerStreamRead,
+                                  weak_this_, stream, status, buffers));
     return;
   }
 
-  if (stopped_) {
+  if (pending_flush_cb_) {
+    if (stream == audio_stream_) {
+      DCHECK(audio_read_in_progress_);
+      audio_read_in_progress_ = false;
+    }
+    if (stream == video_stream_) {
+      DCHECK(video_read_in_progress_);
+      video_read_in_progress_ = false;
+    }
+    if (!audio_read_in_progress_ && !video_read_in_progress_) {
+      auto flush_cb = std::move(pending_flush_cb_);
+      std::move(flush_cb).Run();
+    }
     return;
   }
 
   DCHECK(player_bridge_);
 
-  DemuxerStream* stream =
-      type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_;
-  DCHECK(stream);
-
-  if (!player_bridge_ || !stream) {
-    return;
-  }
-
-  if (status == DemuxerStream::kAborted) {
-    DCHECK(GetReadInProgress(type));
-    SetReadInProgress(type, false);
-
-    if (!seek_cb_.is_null()) {
-      CallSeekCB(::media::PIPELINE_OK, "");
+  if (status == DemuxerStream::kOk) {
+    if (stream == audio_stream_) {
+      DCHECK(audio_read_in_progress_);
+      audio_read_in_progress_ = false;
+      player_bridge_->WriteBuffers(DemuxerStream::AUDIO, buffers);
+    } else {
+      DCHECK(video_read_in_progress_);
+      video_read_in_progress_ = false;
+      player_bridge_->WriteBuffers(DemuxerStream::VIDEO, buffers);
     }
-    return;
-  }
-
-  if (status == DemuxerStream::kConfigChanged) {
+  } else if (status == DemuxerStream::kAborted) {
+  } else if (status == DemuxerStream::kConfigChanged) {
+    if (stream == audio_stream_) {
+      client_->OnAudioConfigChange(stream->audio_decoder_config());
+    } else {
+      DCHECK_EQ(stream, video_stream_);
+      client_->OnVideoConfigChange(stream->video_decoder_config());
+      // TODO(b/375275033): Refine calling to OnVideoNaturalSizeChange().
+      client_->OnVideoNaturalSizeChange(
+          stream->video_decoder_config().visible_rect().size());
+    }
     UpdateDecoderConfig(stream);
-    stream->Read(max_number_buffers_to_read,
-                 base::BindOnce(&SbPlayerPipeline::OnDemuxerStreamRead, this,
-                                type, max_number_buffers_to_read));
-    return;
+    stream->Read(1, base::BindOnce(&StarboardRenderer::OnDemuxerStreamRead,
+                                   weak_this_, stream));
+  } else if (status == DemuxerStream::kError) {
+    client_->OnError(PIPELINE_ERROR_READ);
   }
-
-  if (type == DemuxerStream::AUDIO) {
-    for (const auto& buffer : buffers) {
-      playback_statistics_.OnAudioAU(buffer);
-      if (!buffer->end_of_stream()) {
-        last_audio_sample_interval_ =
-            buffer->timestamp() - timestamp_of_last_written_audio_;
-        timestamp_of_last_written_audio_ = buffer->timestamp();
-      }
-    }
-  } else {
-    for (const auto& buffer : buffers) {
-      playback_statistics_.OnVideoAU(buffer);
-      if (buffer->end_of_stream()) {
-        is_video_eos_written_ = true;
-      }
-    }
-  }
-  SetReadInProgress(type, false);
-
-  player_bridge_->WriteBuffers(type, buffers);
 }
 
-void SbPlayerPipeline::OnNeedData(DemuxerStream::Type type,
-                                  int max_number_of_buffers_to_write) {
-#if SB_HAS(PLAYER_WITH_URL)
-  DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+void StarboardRenderer::OnNeedData(DemuxerStream::Type type,
+                                   int max_number_of_buffers_to_write) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
-  // In case if Stop() has been called.
+  // In case if the callback is fired when creation of the `player_bridge_`
+  // fails.
+  // We may also need this for suspend/resume support.
   if (!player_bridge_) {
+    LOG(INFO) << "StarboardRenderer::OnNeedData() called with " << type;
     return;
   }
 
@@ -1117,17 +498,20 @@ void SbPlayerPipeline::OnNeedData(DemuxerStream::Type type,
                                    max_audio_samples_per_write_)
                         : 1;
 
-  if (GetReadInProgress(type)) {
-    return;
-  }
-
   if (type == DemuxerStream::AUDIO) {
     if (!audio_stream_) {
       LOG(WARNING)
-          << "Calling OnNeedData() for audio data during audioless playback";
+          << "Calling OnNeedData() for audio data during audioless playback.";
       return;
     }
 
+    if (audio_read_in_progress_) {
+      LOG(WARNING)
+          << "Calling OnNeedData() when there is an audio read in progress.";
+      return;
+    }
+
+#if COBALT_MEDIA_ENABLE_AUDIO_DURATION
     // If we haven't checked the media time recently, update it now.
     if (Time::Now() - last_time_media_time_retrieved_ >
         kMediaTimeCheckInterval) {
@@ -1138,7 +522,7 @@ void SbPlayerPipeline::OnNeedData(DemuxerStream::Type type,
     // after the player has received enough audio for preroll, taking into
     // account that our estimate of playback time might be behind by
     // |kMediaTimeCheckInterval|.
-    TimeDelta time_ahead_of_playback_for_preroll =
+    base::TimeDelta time_ahead_of_playback_for_preroll =
         timestamp_of_last_written_audio_ - seek_time_;
     auto adjusted_write_duration_for_preroll =
         AdjustWriteDurationForPlaybackRate(audio_write_duration_for_preroll_,
@@ -1193,394 +577,82 @@ void SbPlayerPipeline::OnNeedData(DemuxerStream::Type type,
     max_buffers = std::min(max_buffers, estimated_max_buffers);
 
     audio_read_delayed_ = false;
+#endif  // COBALT_MEDIA_ENABLE_AUDIO_DURATION
     audio_read_in_progress_ = true;
   } else {
     DCHECK_EQ(type, DemuxerStream::VIDEO);
+
+    if (video_read_in_progress_) {
+      LOG(WARNING)
+          << "Calling OnNeedData() when there is a video read in progress.";
+      return;
+    }
+
     video_read_in_progress_ = true;
   }
-  DemuxerStream* stream =
-      type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_;
+  auto stream = (type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_);
   DCHECK(stream);
 
   stream->Read(max_buffers,
-               base::BindOnce(&SbPlayerPipeline::OnDemuxerStreamRead, this,
-                              type, max_buffers));
+               base::BindOnce(&StarboardRenderer::OnDemuxerStreamRead,
+                              weak_this_, stream));
 }
 
-int SbPlayerPipeline::GetDefaultMaxBuffers(AudioCodec codec,
-                                           TimeDelta duration_to_write,
-                                           bool is_preroll) {
-  // Return default maximum samples per write to speed up the initial sample
-  // write, including guard number of samples per write for audio preroll.
-  // The guard number kPrerollGuardAudioBuffer is used to ensure Cobalt
-  // can do one initial write for audio preroll.
-  int default_max_buffers = static_cast<int>(
-      std::ceil(duration_to_write.InSecondsF() *
-                audio_stream_->audio_decoder_config().samples_per_second() /
-                GetDefaultAudioFramesPerBuffer(codec)));
-  if (is_preroll) {
-    default_max_buffers += kPrerollGuardAudioBuffer;
-  }
-  DCHECK_GT(default_max_buffers, 0);
-  return default_max_buffers;
-}
-
-int SbPlayerPipeline::GetEstimatedMaxBuffers(TimeDelta write_duration,
-                                             TimeDelta time_ahead_of_playback,
-                                             bool is_preroll) {
-  DCHECK_GE(time_ahead_of_playback.InMicroseconds(), 0);
-
-  int estimated_max_buffers = 1;
-  if (!(max_audio_samples_per_write_ > 1) ||
-      write_duration <= time_ahead_of_playback) {
-    return estimated_max_buffers;
-  }
-
-  TimeDelta duration_to_write = write_duration - time_ahead_of_playback;
-  DCHECK_GT(duration_to_write.InMicroseconds(), 0);
-  switch (audio_stream_->audio_decoder_config().codec()) {
-    case AudioCodec::kOpus:
-    case AudioCodec::kAAC:
-    case AudioCodec::kAC3:
-    case AudioCodec::kEAC3:
-      if (last_audio_sample_interval_.is_zero()) {
-        estimated_max_buffers =
-            GetDefaultMaxBuffers(audio_stream_->audio_decoder_config().codec(),
-                                 duration_to_write, is_preroll);
-        break;
-      }
-    // TODO(b/41486346): Support multiple samples per write on the format IAMF.
-    case AudioCodec::kIAMF:
-    default:
-      if (!last_audio_sample_interval_.is_zero()) {
-        DCHECK_GT(last_audio_sample_interval_.InMicroseconds(), 0);
-        estimated_max_buffers =
-            duration_to_write.InMillisecondsRoundedUp() /
-                last_audio_sample_interval_.InMilliseconds() +
-            1;
-      }
-  }
-  DCHECK_GT(estimated_max_buffers, 0);
-  // Return 1 if |estimated_max_buffers| is non-positive. This ensures
-  // in corner cases, |estimated_max_buffers| falls back to 1.
-  // The maximum number samples of write should be guarded by
-  // SbPlayerGetMaximumNumberOfSamplesPerWrite() in OnNeedData().
-  return estimated_max_buffers > 0 ? estimated_max_buffers : 1;
-}
-
-void SbPlayerPipeline::OnPlayerStatus(SbPlayerState state) {
+void StarboardRenderer::OnPlayerStatus(SbPlayerState state) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
-  // In case if Stop() has been called.
+  // In case if state is changed when creation of the `player_bridge_` fails.
+  // We may also need this for suspend/resume support.
   if (!player_bridge_) {
+    // TODO(b/376316272): Turn `state` into its string form and consolidate all
+    //                    player state loggings below.
+    LOG(INFO) << "StarboardRenderer::OnPlayerStatus() called with " << state;
     return;
   }
-  player_state_ = state;
+
   switch (state) {
     case kSbPlayerStateInitialized:
-      NOTREACHED();
+      LOG(INFO) << "StarboardRenderer::OnPlayerStatus() called with "
+                   "kSbPlayerStateInitialized.";
+      DCHECK(!player_bridge_initialized_);
+      player_bridge_initialized_ = true;
+
+      // TODO(b/376317639): Revisit the handling of StartPlayingFrom() called
+      //                    before player enters kSbPlayerStateInitialized.
+      if (playing_start_from_time_) {
+        StartPlayingFrom(std::move(playing_start_from_time_).value());
+      }
       break;
     case kSbPlayerStatePrerolling:
-#if SB_HAS(PLAYER_WITH_URL)
-      if (is_url_based_) {
-        break;
-      }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-      buffering_state_cb_.Run(kHaveMetadata);
+      LOG(INFO) << "StarboardRenderer::OnPlayerStatus() called with "
+                   "kSbPlayerStatePrerolling.";
       break;
-    case kSbPlayerStatePresenting: {
-#if SB_HAS(PLAYER_WITH_URL)
-      if (is_url_based_) {
-        duration_ = player_bridge_->GetDuration();
-        start_date_ = player_bridge_->GetStartDate();
-        buffering_state_cb_.Run(kHaveMetadata);
-        int frame_width;
-        int frame_height;
-        player_bridge_->GetVideoResolution(&frame_width, &frame_height);
-        bool natural_size_changed = (frame_width != natural_size_.width() ||
-                                     frame_height != natural_size_.height());
-        natural_size_ = gfx::Size(frame_width, frame_height);
-        if (natural_size_changed) {
-          content_size_change_cb_.Run();
-        }
-      }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-      buffering_state_cb_.Run(kPrerollCompleted);
-      if (!seek_cb_.is_null()) {
-        CallSeekCB(::media::PIPELINE_OK, "");
-      }
-      if (video_stream_) {
-        playback_statistics_.OnPresenting(
-            video_stream_->video_decoder_config());
-      }
-
-#if SB_HAS(PLAYER_WITH_URL)
-      // Url based player does not support |audio_write_duration_for_preroll_|.
-      if (is_url_based_) {
-        break;
-      }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-      audio_write_duration_for_preroll_ = audio_write_duration_ =
+    case kSbPlayerStatePresenting:
+      client_->OnBufferingStateChange(BUFFERING_HAVE_ENOUGH,
+                                      BUFFERING_CHANGE_REASON_UNKNOWN);
+      audio_write_duration_ =
           HasRemoteAudioOutputs(player_bridge_->GetAudioConfigurations())
               ? audio_write_duration_remote_
               : audio_write_duration_local_;
       LOG(INFO) << "SbPlayerBridge reaches kSbPlayerStatePresenting, with audio"
                 << " write duration at " << audio_write_duration_;
       break;
-    }
     case kSbPlayerStateEndOfStream:
-      ended_cb_.Run(::media::PIPELINE_OK);
-      ended_ = true;
+      LOG(INFO) << "StarboardRenderer::OnPlayerStatus() called with "
+                   "kSbPlayerStateEndOfStream.";
+      client_->OnEnded();
       break;
     case kSbPlayerStateDestroyed:
+      LOG(INFO) << "StarboardRenderer::OnPlayerStatus() called with "
+                   "kSbPlayerStateDestroyed.";
       break;
   }
 }
 
-void SbPlayerPipeline::OnPlayerError(SbPlayerError error,
-                                     const std::string& message) {
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-
-  // In case if Stop() has been called.
-  if (!player_bridge_) {
-    return;
-  }
-
-#if SB_HAS(PLAYER_WITH_URL)
-  if (error >= kSbPlayerErrorMax) {
-    DCHECK(is_url_based_);
-    switch (static_cast<SbUrlPlayerError>(error)) {
-      case kSbUrlPlayerErrorNetwork:
-        CallErrorCB(::media::PIPELINE_ERROR_NETWORK, message);
-        break;
-      case kSbUrlPlayerErrorSrcNotSupported:
-        CallErrorCB(::media::DEMUXER_ERROR_COULD_NOT_OPEN, message);
-
-        break;
-    }
-    return;
-  }
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  switch (error) {
-    case kSbPlayerErrorDecode:
-      CallErrorCB(::media::PIPELINE_ERROR_DECODE, message);
-      break;
-    case kSbPlayerErrorCapabilityChanged:
-      CallErrorCB(::media::PIPELINE_ERROR_DECODE,
-                  message.empty()
-                      ? kSbPlayerCapabilityChangedErrorMessage
-                      : ::starboard::FormatString(
-                            "%s: %s", kSbPlayerCapabilityChangedErrorMessage,
-                            message.c_str()));
-      break;
-    case kSbPlayerErrorMax:
-      NOTREACHED();
-      break;
-  }
-}
-
-void SbPlayerPipeline::DelayedNeedData(int max_number_of_buffers_to_write) {
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-  if (audio_read_delayed_) {
-    OnNeedData(DemuxerStream::AUDIO, max_number_of_buffers_to_write);
-  }
-}
-
-void SbPlayerPipeline::UpdateDecoderConfig(DemuxerStream* stream) {
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-
-  if (!player_bridge_) {
-    return;
-  }
-
-  if (stream->type() == DemuxerStream::AUDIO) {
-    const AudioDecoderConfig& decoder_config = stream->audio_decoder_config();
-    media_metrics_provider_->SetHasAudio(decoder_config.codec());
-    player_bridge_->UpdateAudioConfig(decoder_config, stream->mime_type());
-  } else {
-    DCHECK_EQ(stream->type(), DemuxerStream::VIDEO);
-    const VideoDecoderConfig& decoder_config = stream->video_decoder_config();
-    media_metrics_provider_->SetHasVideo(decoder_config.codec());
-    base::AutoLock auto_lock(lock_);
-    bool natural_size_changed =
-        (decoder_config.natural_size().width() != natural_size_.width() ||
-         decoder_config.natural_size().height() != natural_size_.height());
-    natural_size_ = decoder_config.natural_size();
-    player_bridge_->UpdateVideoConfig(decoder_config, stream->mime_type());
-    if (natural_size_changed) {
-      content_size_change_cb_.Run();
-    }
-
-    playback_statistics_.UpdateVideoConfig(stream->video_decoder_config());
-  }
-}
-
-void SbPlayerPipeline::CallSeekCB(PipelineStatus status,
-                                  const std::string& error_message) {
-  if (status == ::media::PIPELINE_OK) {
-    DCHECK(error_message.empty());
-  }
-
-  SeekCB seek_cb;
-  bool is_initial_preroll;
-  {
-    base::AutoLock auto_lock(lock_);
-    DCHECK(!seek_cb_.is_null());
-    seek_cb = std::move(seek_cb_);
-    is_initial_preroll = is_initial_preroll_;
-    is_initial_preroll_ = false;
-  }
-  seek_cb.Run(status, is_initial_preroll,
-              AppendStatisticsString(error_message));
-}
-
-void SbPlayerPipeline::CallErrorCB(PipelineStatus status,
-                                   const std::string& error_message) {
-  DCHECK_NE(status, ::media::PIPELINE_OK);
-  // Only to record the first error.
-  if (error_cb_.is_null()) {
-    return;
-  }
-  playback_statistics_.OnError(status, error_message);
-  ResetAndRunIfNotNull(&error_cb_, status,
-                       AppendStatisticsString(error_message));
-}
-
-void SbPlayerPipeline::SuspendTask(base::WaitableEvent* done_event) {
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-  DCHECK(done_event);
-  DCHECK(!suspended_);
-
-  if (suspended_) {
-    done_event->Signal();
-    return;
-  }
-
-  if (player_bridge_) {
-    // Cancel pending delayed calls to OnNeedData. After
-    // player_bridge_->Resume(), |player_bridge_| will call OnNeedData again.
-    audio_read_delayed_ = false;
-    player_bridge_->Suspend();
-  }
-
-  suspended_ = true;
-
-  done_event->Signal();
-}
-
-void SbPlayerPipeline::ResumeTask(PipelineWindow window,
-                                  base::WaitableEvent* done_event) {
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-  DCHECK(done_event);
-  DCHECK(suspended_);
-
-  if (!suspended_) {
-    last_resume_time_ = Time::Now();
-    done_event->Signal();
-    return;
-  }
-
-  window_ = window;
-
-  bool resumable = true;
-  bool resume_to_background_mode = !SbWindowIsValid(window_);
-  bool is_audioless = !HasAudio();
-  if (resume_to_background_mode && is_audioless) {
-    // Avoid resuming an audioless video to background mode. SbPlayerBridge will
-    // try to create an SbPlayer with only the video stream disabled, and may
-    // crash in this case as SbPlayerCreate() will fail without an audio or
-    // video stream.
-    resumable = false;
-  }
-  if (player_bridge_ && resumable) {
-    player_bridge_->Resume(window);
-    if (!player_bridge_->IsValid()) {
-      std::string error_message;
-      {
-        base::AutoLock auto_lock(lock_);
-        error_message = player_bridge_->GetPlayerCreationErrorMessage();
-        player_bridge_.reset();
-      }
-      std::string time_information = GetTimeInformation();
-      LOG(INFO) << "SbPlayerPipeline::ResumeTask failed to create a valid "
-                   "SbPlayerBridge - "
-                << time_information << " \'" << error_message << "\'";
-      CallErrorCB(::media::DECODER_ERROR_NOT_SUPPORTED,
-                  "SbPlayerPipeline::ResumeTask failed to create a valid "
-                  "SbPlayerBridge - " +
-                      time_information + " \'" + error_message + "\'");
-    }
-  }
-
-  suspended_ = false;
-  last_resume_time_ = Time::Now();
-
-  done_event->Signal();
-}
-
-std::string SbPlayerPipeline::AppendStatisticsString(
-    const std::string& message) const {
-  DCHECK(task_runner_->RunsTasksInCurrentSequence());
-
-  if (nullptr == video_stream_) {
-    return message + ", playback statistics: n/a.";
-  } else {
-    return message + ", playback statistics: " +
-           playback_statistics_.GetStatistics(
-               video_stream_->video_decoder_config()) +
-           '.';
-  }
-}
-
-std::string SbPlayerPipeline::GetTimeInformation() const {
-  auto round_time_in_seconds = [](const TimeDelta time) {
-    const int64_t seconds = time.InSeconds();
-    if (seconds < 15) {
-      return seconds / 5 * 5;
-    }
-    if (seconds < 60) {
-      return seconds / 15 * 15;
-    }
-    if (seconds < 3600) {
-      return std::max(static_cast<int64_t>(60), seconds / 600 * 600);
-    }
-    return std::max(static_cast<int64_t>(3600), seconds / 18000 * 18000);
-  };
-  std::string time_since_start =
-      std::to_string(round_time_in_seconds(base::StartupTimer::TimeElapsed())) +
-      "s";
-  std::string time_since_resume = !last_resume_time_.is_null()
-                                      ? std::to_string(round_time_in_seconds(
-                                            Time::Now() - last_resume_time_)) +
-                                            "s"
-                                      : "null";
-  return "time since app start: " + time_since_start +
-         ", time since last resume: " + time_since_resume;
-}
-
-void SbPlayerPipeline::RunSetDrmSystemReadyCB(
-    DrmSystemReadyCB drm_system_ready_cb) {
-  TRACE_EVENT0("cobalt::media", "SbPlayerPipeline::RunSetDrmSystemReadyCB");
-  set_drm_system_ready_cb_time_ = Time::Now();
-  set_drm_system_ready_cb_.Run(drm_system_ready_cb);
-}
-
-void SbPlayerPipeline::SetReadInProgress(DemuxerStream::Type type,
-                                         bool in_progress) {
-  if (type == DemuxerStream::AUDIO) {
-    audio_read_in_progress_ = in_progress;
-  } else {
-    video_read_in_progress_ = in_progress;
-  }
-}
-
-bool SbPlayerPipeline::GetReadInProgress(DemuxerStream::Type type) const {
-  if (type == DemuxerStream::AUDIO) {
-    return audio_read_in_progress_;
-  }
-  return video_read_in_progress_;
+void StarboardRenderer::OnPlayerError(SbPlayerError error,
+                                      const std::string& message) {
+  // TODO(b/375271948): Implement and verify error reporting.
+  NOTIMPLEMENTED();
 }
 
 }  // namespace media
-}  // namespace cobalt

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -1,4 +1,4 @@
-// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+// Copyright 2024 The Cobalt Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,373 +12,139 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COBALT_MEDIA_BASE_SBPLAYER_PIPELINE_H_
-#define COBALT_MEDIA_BASE_SBPLAYER_PIPELINE_H_
+#ifndef MEDIA_STARBOARD_STARBOARD_RENDERER_H_
+#define MEDIA_STARBOARD_STARBOARD_RENDERER_H_
 
-#include <memory>
-#include <string>
 #include <vector>
 
-#include "base/functional/callback_helpers.h"
-#include "base/optional.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/synchronization/lock.h"
-#include "base/synchronization/waitable_event.h"
-#include "base/task/task_runner.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/time/time.h"
-#include "cobalt/base/c_val.h"
-#include "cobalt/math/size.h"
-#include "cobalt/media/base/media_export.h"
-#include "cobalt/media/base/metrics_provider.h"
-#include "cobalt/media/base/pipeline.h"
-#include "cobalt/media/base/playback_statistics.h"
-#include "cobalt/media/base/sbplayer_bridge.h"
-#include "cobalt/media/base/sbplayer_set_bounds_helper.h"
-#include "media/base/audio_decoder_config.h"
+#include "media/base/cdm_context.h"
 #include "media/base/decoder_buffer.h"
-#include "media/base/demuxer.h"
 #include "media/base/demuxer_stream.h"
-#include "media/base/media_log.h"
+#include "media/base/media_resource.h"
 #include "media/base/pipeline_status.h"
-#include "media/base/ranges.h"
-#include "media/base/video_decoder_config.h"
-#include "starboard/configuration_constants.h"
-#include "ui/gfx/geometry/rect.h"
-#include "ui/gfx/geometry/size.h"
+#include "media/base/renderer.h"
+#include "media/base/renderer_client.h"
+#include "media/starboard/sbplayer_bridge.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
-namespace cobalt {
 namespace media {
 
-using base::Time;
-using base::TimeDelta;
-
-// SbPlayerPipeline is a PipelineBase implementation that uses the SbPlayer
-// interface internally.
-class MEDIA_EXPORT SbPlayerPipeline : public Pipeline,
-                                      public ::media::DemuxerHost,
-                                      public SbPlayerBridge::Host {
+// SbPlayer based Renderer implementation, the entry point for all video
+// playbacks on Starboard platforms.
+class MEDIA_EXPORT StarboardRenderer final : public Renderer,
+                                             private SbPlayerBridge::Host {
  public:
-  // Constructs a media pipeline that will execute on |task_runner|.
-  SbPlayerPipeline(SbPlayerInterface* interface,
-                   PipelineWindow window,
-                   const scoped_refptr<base::SequencedTaskRunner>& task_runner,
-                   const GetDecodeTargetGraphicsContextProviderFunc&
-                       get_decode_target_graphics_context_provider_func,
-                   bool allow_resume_after_suspend,
-                   int max_audio_samples_per_write,
-                   bool force_punch_out_by_default,
-                   TimeDelta audio_write_duration_local,
-                   TimeDelta audio_write_duration_remote,
-                   MediaLog* media_log,
-                   MediaMetricsProvider* media_metrics_provider,
-                   DecodeTargetProvider* decode_target_provider);
-  ~SbPlayerPipeline() override;
+  explicit StarboardRenderer(
+      const scoped_refptr<base::SequencedTaskRunner>& task_runner);
 
-  void Suspend() override;
-  // TODO: This is temporary for supporting background media playback.
-  //       Need to be removed with media refactor.
-  void Resume(PipelineWindow window) override;
+  ~StarboardRenderer() final;
 
-  void Start(Demuxer* demuxer,
-             const SetDrmSystemReadyCB& set_drm_system_ready_cb,
-             const PipelineStatusCB& ended_cb,
-             const ErrorCB& error_cb,
-             const SeekCB& seek_cb,
-             const BufferingStateCB& buffering_state_cb,
-             const base::Closure& duration_change_cb,
-             const base::Closure& output_mode_change_cb,
-             const base::Closure& content_size_change_cb,
-             const std::string& max_video_capabilities,
-             const int max_video_input_size) override;
-#if SB_HAS(PLAYER_WITH_URL)
-  void Start(const SetDrmSystemReadyCB& set_drm_system_ready_cb,
-             const OnEncryptedMediaInitDataEncounteredCB&
-                 encrypted_media_init_data_encountered_cb,
-             const std::string& source_url,
-             const PipelineStatusCB& ended_cb,
-             const ErrorCB& error_cb,
-             const SeekCB& seek_cb,
-             const BufferingStateCB& buffering_state_cb,
-             const base::Closure& duration_change_cb,
-             const base::Closure& output_mode_change_cb,
-             const base::Closure& content_size_change_cb) override;
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-  void Stop(const base::Closure& stop_cb) override;
-  void Seek(TimeDelta time, const SeekCB& seek_cb);
-  bool HasAudio() const override;
-  bool HasVideo() const override;
-
-  float GetPlaybackRate() const override;
-  void SetPlaybackRate(float playback_rate) override;
-  float GetVolume() const override;
-  void SetVolume(float volume) override;
-
-  TimeDelta GetMediaTime() override;
-  ::media::Ranges<TimeDelta> GetBufferedTimeRanges() override;
-  TimeDelta GetMediaDuration() const override;
-#if SB_HAS(PLAYER_WITH_URL)
-  TimeDelta GetMediaStartDate() const override;
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  void GetNaturalVideoSize(gfx::Size* out_size) const override;
-  std::vector<std::string> GetAudioConnectors() const override;
-
-  bool DidLoadingProgress() const override;
-  PipelineStatistics GetStatistics() const override;
-  SetBoundsCB GetSetBoundsCB() override;
-  void SetPreferredOutputModeToDecodeToTexture() override;
+  // Renderer implementation.
+  void Initialize(MediaResource* media_resource,
+                  RendererClient* client,
+                  PipelineStatusCallback init_cb) final;
+  void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) final {
+    // TODO(b/328305808): Implement encrypted playback.
+    NOTIMPLEMENTED();
+  }
+  void SetLatencyHint(absl::optional<base::TimeDelta> latency_hint) final {
+    // TODO(b/375271848): Address NOTIMPLEMENTED().
+    NOTIMPLEMENTED();
+  }
+  void SetPreservesPitch(bool preserves_pitch) final {
+    // TODO(b/375271848): Address NOTIMPLEMENTED().
+    NOTIMPLEMENTED();
+  }
+  void SetWasPlayedWithUserActivation(
+      bool was_played_with_user_activation) final {
+    // TODO(b/375271848): Address NOTIMPLEMENTED().
+    NOTIMPLEMENTED();
+  }
+  void Flush(base::OnceClosure flush_cb) final;
+  void StartPlayingFrom(base::TimeDelta time) final;
+  void SetPlaybackRate(double playback_rate) final;
+  void SetVolume(float volume) final;
+  base::TimeDelta GetMediaTime() final;
+  void OnSelectedVideoTracksChanged(
+      const std::vector<DemuxerStream*>& enabled_tracks,
+      base::OnceClosure change_completed_cb) final {
+    // TODO(b/375271848): Address NOTIMPLEMENTED().
+    NOTIMPLEMENTED();
+  }
+  void OnEnabledAudioTracksChanged(
+      const std::vector<DemuxerStream*>& enabled_tracks,
+      base::OnceClosure change_completed_cb) final {
+    // TODO(b/375271848): Address NOTIMPLEMENTED().
+    NOTIMPLEMENTED();
+  }
+  RendererType GetRendererType() final {
+    // Reuse `kRendererImpl` to avoid introducing a new renderer type.
+    // TODO(b/375278384): Properly setup the renderer type.
+    return RendererType::kRendererImpl;
+  }
 
  private:
-  // Used to post parameters to SbPlayerPipeline::StartTask() as the number of
-  // parameters exceed what base::Bind() can support.
-  struct StartTaskParameters {
-    ::media::Demuxer* demuxer;
-    SetDrmSystemReadyCB set_drm_system_ready_cb;
-    ::media::PipelineStatusCB ended_cb;
-    ErrorCB error_cb;
-    Pipeline::SeekCB seek_cb;
-    Pipeline::BufferingStateCB buffering_state_cb;
-    base::Closure duration_change_cb;
-    base::Closure output_mode_change_cb;
-    base::Closure content_size_change_cb;
-    std::string max_video_capabilities;
-    int max_video_input_size;
-#if SB_HAS(PLAYER_WITH_URL)
-    std::string source_url;
-    bool is_url_based;
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  };
+  void CreatePlayerBridge(PipelineStatusCallback init_cb);
+  void UpdateDecoderConfig(DemuxerStream* stream);
+  void OnDemuxerStreamRead(DemuxerStream* stream,
+                           DemuxerStream::Status status,
+                           DemuxerStream::DecoderBufferVector buffers);
 
-  void StartTask(StartTaskParameters parameters);
-  void SetVolumeTask(float volume);
-  void SetPlaybackRateTask(float volume);
-  void SetDurationTask(TimeDelta duration);
+  void OnNeedData(DemuxerStream::Type type,
+                  int max_number_of_buffers_to_write) final;
+  void OnPlayerStatus(SbPlayerState state) final;
+  void OnPlayerError(SbPlayerError error, const std::string& message) final;
 
-  // DemuxerHost implementation.
-  void OnBufferedTimeRangesChanged(
-      const ::media::Ranges<TimeDelta>& ranges) override;
-  void SetDuration(TimeDelta duration) override;
-  void OnDemuxerError(PipelineStatus error) override;
-
-#if SB_HAS(PLAYER_WITH_URL)
-  void CreateUrlPlayer(const std::string& source_url);
-  void SetDrmSystem(SbDrmSystem drm_system);
-#endif  // SB_HAS(PLAYER_WITH_URL)
-  void CreatePlayer(SbDrmSystem drm_system);
-
-  void OnDemuxerInitialized(PipelineStatus status);
-  void OnDemuxerSeeked(PipelineStatus status);
-  void OnDemuxerStopped();
-  void OnDemuxerStreamRead(
-      ::media::DemuxerStream::Type type,
-      int max_number_buffers_to_read,
-      ::media::DemuxerStream::Status status,
-      const std::vector<scoped_refptr<::media::DecoderBuffer>> buffers);
-  // SbPlayerBridge::Host implementation.
-  void OnNeedData(::media::DemuxerStream::Type type,
-                  int max_number_of_buffers_to_write) override;
-  void OnPlayerStatus(SbPlayerState state) override;
-  void OnPlayerError(SbPlayerError error, const std::string& message) override;
-
-  // Used to make a delayed call to OnNeedData() if |audio_read_delayed_| is
-  // true. If |audio_read_delayed_| is false, that means the delayed call has
-  // been cancelled due to a seek.
-  void DelayedNeedData(int max_number_of_buffers_to_write);
-
-  void UpdateDecoderConfig(::media::DemuxerStream* stream);
-  void CallSeekCB(PipelineStatus status, const std::string& error_message);
-  void CallErrorCB(PipelineStatus status, const std::string& error_message);
-
-  void SuspendTask(base::WaitableEvent* done_event);
-  void ResumeTask(PipelineWindow window, base::WaitableEvent* done_event);
-
-  // Store the media time retrieved by GetMediaTime so we can cache it as an
-  // estimate and avoid calling SbPlayerGetInfo too frequently.
-  void StoreMediaTime(TimeDelta media_time);
-
-  // Retrieve the statistics as a string and append to message.
-  std::string AppendStatisticsString(const std::string& message) const;
-
-  // Get information on the time since app start and the time since the last
-  // playback resume.
-  std::string GetTimeInformation() const;
-
-  void RunSetDrmSystemReadyCB(DrmSystemReadyCB drm_system_ready_cb);
-
-  void SetReadInProgress(::media::DemuxerStream::Type type, bool in_progress);
-  bool GetReadInProgress(::media::DemuxerStream::Type type) const;
-
-  int GetDefaultMaxBuffers(AudioCodec codec,
-                           TimeDelta duration_to_write,
-                           bool is_preroll);
-  int GetEstimatedMaxBuffers(TimeDelta write_duration,
-                             TimeDelta time_ahead_of_playback,
-                             bool is_preroll);
-
-  // An identifier string for the pipeline, used in CVal to identify multiple
-  // pipelines.
-  const std::string pipeline_identifier_;
-
-  // A wrapped interface of starboard player functions, which will be used in
-  // underlying SbPlayerBridge.
-  SbPlayerInterface* sbplayer_interface_;
-
-  // Message loop used to execute pipeline tasks.  It is thread-safe.
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
 
-  // Whether we should save DecoderBuffers for resume after suspend.
-  const bool allow_resume_after_suspend_;
+  raw_ptr<DemuxerStream> audio_stream_ = nullptr;
+  raw_ptr<DemuxerStream> video_stream_ = nullptr;
+  // TODO(b/375273774): Consider calling `void OnWaiting(WaitingReason reason)`
+  //                    on `client_`.
+  // TODO(b/375274109): Investigate whether we should call
+  //                    `void OnVideoFrameRateChange(absl::optional<int> fps)`
+  //                    on `client_`?
+  raw_ptr<RendererClient> client_ = nullptr;
 
-  // The number of audio samples per write that is allowed at once.
-  // The minimum number of |max_audio_samples_per_write_| and
-  // SbPlayerGetMaximumNumberOfSamplesPerWrite() specifies
-  // the maximum number of samples SbPlayerWriteSamples() can accept.
-  const int max_audio_samples_per_write_;
+  DefaultSbPlayerInterface sbplayer_interface_;
+  // TODO(b/326652276): Support audio write duration.
+  const base::TimeDelta audio_write_duration_local_ = base::Milliseconds(500);
+  const base::TimeDelta audio_write_duration_remote_ = base::Seconds(10);
+  // TODO(b/375674101): Support batched samples write.
+  const int max_audio_samples_per_write_ = 1;
 
-  // The default output mode passed to `SbPlayerGetPreferredOutputMode()`.
-  SbPlayerOutputMode default_output_mode_ = kSbPlayerOutputModeInvalid;
-
-  // The window this player associates with.  It should only be assigned in the
-  // dtor and accessed once by SbPlayerCreate().
-  PipelineWindow window_;
-
-  // Call to get the SbDecodeTargetGraphicsContextProvider for SbPlayerCreate().
-  const GetDecodeTargetGraphicsContextProviderFunc
-      get_decode_target_graphics_context_provider_func_;
-
-  // Lock used to serialize access for the following member variables.
-  mutable base::Lock lock_;
-
-  // Amount of available buffered data.  Set by filters.
-  ::media::Ranges<TimeDelta> buffered_time_ranges_;
-
-  // True when AddBufferedByteRange() has been called more recently than
-  // DidLoadingProgress().
-  mutable bool did_loading_progress_;
-
-  // Video's natural width and height.  Set by filters.
-  gfx::Size natural_size_;
-
-  // Current volume level (from 0.0f to 1.0f).  This value is set immediately
-  // via SetVolume() and a task is dispatched on the task runner to notify the
-  // filters.
-  base::CVal<float> volume_;
-
-  // Current playback rate (>= 0.0f).  This value is set immediately via
-  // SetPlaybackRate() and a task is dispatched on the task runner to notify
-  // the filters.
-  base::CVal<float> playback_rate_;
-
-  // The saved audio and video demuxer streams.  Note that it is safe to store
-  // raw pointers of the demuxer streams, as the Demuxer guarantees that its
-  // |DemuxerStream|s live as long as the Demuxer itself.
-  ::media::DemuxerStream* audio_stream_ = nullptr;
-  ::media::DemuxerStream* video_stream_ = nullptr;
-
-  mutable PipelineStatistics statistics_;
-
-  // The following member variables are only accessed by tasks posted to
-  // |task_runner_|.
-
-  // Temporary callback used for Stop().
-  base::Closure stop_cb_;
-
-  // Permanent callbacks passed in via Start().
-  SetDrmSystemReadyCB set_drm_system_ready_cb_;
-  PipelineStatusCB ended_cb_;
-  ErrorCB error_cb_;
-  BufferingStateCB buffering_state_cb_;
-  base::Closure duration_change_cb_;
-  base::Closure output_mode_change_cb_;
-  base::Closure content_size_change_cb_;
-  base::Optional<bool> decode_to_texture_output_mode_;
-#if SB_HAS(PLAYER_WITH_URL)
-  SbPlayerBridge::OnEncryptedMediaInitDataEncounteredCB
-      on_encrypted_media_init_data_encountered_cb_;
-#endif  //  SB_HAS(PLAYER_WITH_URL)
-
-  // Demuxer reference used for setting the preload value.
-  Demuxer* demuxer_ = nullptr;
-  bool audio_read_in_progress_ = false;
-  bool audio_read_delayed_ = false;
-  bool video_read_in_progress_ = false;
-  base::CVal<TimeDelta> duration_;
-
-#if SB_HAS(PLAYER_WITH_URL)
-  TimeDelta start_date_;
-  bool is_url_based_;
-#endif  // SB_HAS(PLAYER_WITH_URL)
-
-  scoped_refptr<SbPlayerSetBoundsHelper> set_bounds_helper_;
-
-  // The following member variables can be accessed from WMPI thread but all
-  // modifications to them happens on the pipeline thread.  So any access of
-  // them from the WMPI thread and any modification to them on the pipeline
-  // thread has to guarded by lock.  Access to them from the pipeline thread
-  // needn't to be guarded.
-
-  // Temporary callback used for Start() and Seek().
-  SeekCB seek_cb_;
-  TimeDelta seek_time_;
+  base::Lock lock_;
   std::unique_ptr<SbPlayerBridge> player_bridge_;
-  bool is_initial_preroll_ = true;
-  base::CVal<bool> started_;
-  base::CVal<bool> suspended_;
-  base::CVal<bool> stopped_;
-  base::CVal<bool> ended_;
-  base::CVal<SbPlayerState> player_state_;
 
-  MediaMetricsProvider* media_metrics_provider_;
+  bool player_bridge_initialized_ = false;
+  std::optional<base::TimeDelta> playing_start_from_time_;
 
-  DecodeTargetProvider* decode_target_provider_;
+  base::OnceClosure pending_flush_cb_;
 
-  const TimeDelta audio_write_duration_local_;
-  const TimeDelta audio_write_duration_remote_;
+  base::TimeDelta audio_write_duration_ = audio_write_duration_local_;
 
-  // The two variables below should always contain the same value.  They are
-  // kept as separate variables so we can keep the existing implementation as
-  // is, which simplifies the implementation across multiple Starboard versions.
-  TimeDelta audio_write_duration_;
-  TimeDelta audio_write_duration_for_preroll_ = audio_write_duration_;
+  bool audio_read_in_progress_ = false;
+  bool video_read_in_progress_ = false;
 
-  // Only call GetMediaTime() from OnNeedData if it has been
-  // |kMediaTimeCheckInterval| since the last call to GetMediaTime().
-  static constexpr TimeDelta kMediaTimeCheckInterval =
-      TimeDelta::FromMicroseconds(100);
-  // Timestamp for the last written audio.
-  TimeDelta timestamp_of_last_written_audio_;
-  // Indicates if video end of stream has been written into the underlying
-  // player.
-  bool is_video_eos_written_ = false;
-  TimeDelta last_audio_sample_interval_ = TimeDelta::FromMicroseconds(0);
-  int last_estimated_max_buffers_for_preroll_ = 1;
+  double playback_rate_ = 0.;
+  float volume_ = 1.0f;
 
-  // Last media time reported by GetMediaTime().
-  base::CVal<TimeDelta> last_media_time_;
-  // Timestamp microseconds when we last checked the media time.
-  Time last_time_media_time_retrieved_;
-  // Counter for retrograde media time.
-  size_t retrograde_media_time_counter_ = 0;
-  // The maximum video playback capabilities required for the playback.
-  base::CVal<std::string> max_video_capabilities_;
-  // Set the maximum size in bytes of an input buffer for video.
-  int max_video_input_size_;
+  uint32_t last_video_frames_decoded_ = 0;
+  uint32_t last_video_frames_dropped_ = 0;
 
-  PlaybackStatistics playback_statistics_;
+  base::WeakPtrFactory<StarboardRenderer> weak_factory_{this};
+  base::WeakPtr<StarboardRenderer> weak_this_{weak_factory_.GetWeakPtr()};
 
-  Time last_resume_time_;
-
-  Time set_drm_system_ready_cb_time_;
-
-  // Message to signal a capability changed error.
-  // "MEDIA_ERR_CAPABILITY_CHANGED" must be in the error message to be
-  // understood as a capability changed error. Do not change this message.
-  static inline constexpr const char* kSbPlayerCapabilityChangedErrorMessage =
-      "MEDIA_ERR_CAPABILITY_CHANGED";
-
-  DISALLOW_COPY_AND_ASSIGN(SbPlayerPipeline);
+  StarboardRenderer(const StarboardRenderer&) = delete;
+  StarboardRenderer& operator=(const StarboardRenderer&) = delete;
 };
 
 }  // namespace media
-}  // namespace cobalt
 
-#endif  // COBALT_MEDIA_BASE_SBPLAYER_PIPELINE_H_
+#endif  // MEDIA_STARBOARD_STARBOARD_RENDERER_H_

--- a/media/starboard/starboard_utils.h
+++ b/media/starboard/starboard_utils.h
@@ -12,12 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MEDIA_BASE_STARBOARD_UTILS_H_
-#define MEDIA_BASE_STARBOARD_UTILS_H_
-
-#if !defined(STARBOARD)
-#error "This file only works with Cobalt/Starboard."
-#endif  // !defined(STARBOARD)
+#ifndef MEDIA_STARBOARD_STARBOARD_UTILS_H_
+#define MEDIA_STARBOARD_STARBOARD_UTILS_H_
 
 #include "media/base/audio_codecs.h"
 #include "media/base/audio_decoder_config.h"
@@ -65,4 +61,4 @@ std::string ExtractCodecs(const std::string& mime_type);
 
 }  // namespace media
 
-#endif  // MEDIA_BASE_STARBOARD_UTILS_H_
+#endif  // MEDIA_STARBOARD_STARBOARD_UTILS_H_

--- a/media/starboard/starboard_utils_test.cc
+++ b/media/starboard/starboard_utils_test.cc
@@ -16,7 +16,7 @@
 #error "This file only works with Cobalt/Starboard."
 #endif  // !defined(STARBOARD)
 
-#include "media/base/starboard_utils.h"
+#include "media/starboard/starboard_utils.h"
 
 #include "testing/gtest/include/gtest/gtest.h"
 

--- a/starboard/android/shared/main.cc
+++ b/starboard/android/shared/main.cc
@@ -15,9 +15,12 @@
 #include "starboard/common/log.h"
 #include "starboard/export.h"
 
+// TODO(b/375459298); Investigate whether we should enable main() on Android TV
+#if 0
 extern "C" SB_EXPORT_PLATFORM int main(int argc, char** argv) {
   // main() is never called on Android. However, the cobalt_bin
   // target requires it to be there.
   SB_NOTREACHED();
   return 0;
 }
+#endif  // 0

--- a/third_party/blink/renderer/modules/mediasource/BUILD.gn
+++ b/third_party/blink/renderer/modules/mediasource/BUILD.gn
@@ -52,4 +52,7 @@ blink_modules_sources("mediasource") {
     # Ensure the generated webcodecs v8 config and chunk bindings are available.
     "//third_party/blink/renderer/modules/webcodecs:webcodecs",
   ]
+  if (is_cobalt) {
+    deps += [ "//starboard/build:starboard_buildflags" ]
+  }
 }

--- a/third_party/blink/renderer/modules/mediasource/media_source.cc
+++ b/third_party/blink/renderer/modules/mediasource/media_source.cc
@@ -57,6 +57,12 @@
 #include "third_party/blink/renderer/platform/wtf/functional.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
+// For BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "build/build_config.h"
+#if BUILDFLAG(IS_COBALT)
+#include "starboard/build/starboard_buildflags.h"
+#endif  // BUILDFLAG(IS_COBALT)
+
 using blink::WebMediaSource;
 using blink::WebSourceBuffer;
 
@@ -492,6 +498,12 @@ bool MediaSource::isTypeSupported(ExecutionContext* context,
   bool result = IsTypeSupportedInternal(
       context, type, true /* Require fully specified mime and codecs */);
   DVLOG(2) << __func__ << "(" << type << ") -> " << (result ? "true" : "false");
+#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  LOG(INFO) << __func__ << "(" << type << ") -> "
+            << (result ? "true" : "false");
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif // BUILDFLAG(IS_COBALT)
   return result;
 }
 
@@ -499,6 +511,38 @@ bool MediaSource::isTypeSupported(ExecutionContext* context,
 bool MediaSource::IsTypeSupportedInternal(ExecutionContext* context,
                                           const String& type,
                                           bool enforce_codec_specificity) {
+
+#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // TODO(b/322021829): This is a workaround to claim 4K playback support.  It
+  // should be replaced by a proper implementation of
+  // MediaSource.isTypeSupported().
+  if (type.Find("99") != kNotFound || type.Find("catavision") != kNotFound ||
+      type.Find("invalidformat") != kNotFound ||
+      type.Find("bitrate=2000000000") != kNotFound ||
+      type.Find("decode-to-texture=nope") != kNotFound ||
+      type.Find("decode-to-texture=true") != kNotFound) {
+    return false;
+  }
+
+  // Reject 8k
+  if (type.Find("7680") != kNotFound) {
+    return false;
+  }
+
+  /*
+  // Reject 4k
+  if (type.Find("3840") != kNotFound) {
+    return false;
+  }
+
+  // Reject 2k
+  if (type.Find("2560") != kNotFound) {
+    return false;
+  }*/
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif // BUILDFLAG(IS_COBALT)
+
   // Even after ExecutionContext teardown notification, bindings may still call
   // code-behinds for a short while. If |context| is null, this is likely
   // happening. To prevent possible null deref of |context| in this path, claim

--- a/third_party/blink/renderer/platform/media/BUILD.gn
+++ b/third_party/blink/renderer/platform/media/BUILD.gn
@@ -104,6 +104,9 @@ component("media") {
       "//media/remoting:remoting_constants",
       "//third_party/blink/public/strings:strings_grit",
     ]
+    if (is_cobalt) {
+      deps += [ "//starboard/build:starboard_buildflags" ]
+    }
   }
 
   if (enable_hls_demuxer) {

--- a/third_party/blink/renderer/platform/media/web_media_player_impl.cc
+++ b/third_party/blink/renderer/platform/media/web_media_player_impl.cc
@@ -98,6 +98,14 @@
 #include "third_party/blink/renderer/platform/media/web_media_source_impl.h"
 #include "ui/gfx/geometry/size.h"
 
+// For BUILDFLAG(USE_STARBOARD_MEDIA)
+#if BUILDFLAG(IS_COBALT)
+#include "starboard/build/starboard_buildflags.h"
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/starboard/starboard_renderer.h"
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif  // BUILDFLAG(IS_COBALT)
+
 #if BUILDFLAG(ENABLE_HLS_DEMUXER)
 #include "third_party/blink/renderer/platform/media/hls_data_source_provider_impl.h"
 #endif  // BUILDFLAG(ENABLE_HLS_DEMUXER)
@@ -2795,6 +2803,19 @@ std::unique_ptr<media::Renderer> WebMediaPlayerImpl::CreateRenderer(
       base::BindPostTaskToCurrentDefault(base::BindRepeating(
           &WebMediaPlayerImpl::OnOverlayInfoRequested, weak_this_));
 #endif
+
+#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // TODO(b/375278384): Select the StarboardRenderer properly instead of
+  //                    hard coding.
+
+  // `media_task_runner_` is always true, use an if statement to avoid
+  // potential build warning on unreachable code.
+  if (media_task_runner_) {
+    return std::make_unique<media::StarboardRenderer>(media_task_runner_);
+  }
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif // BUILDFLAG(IS_COBALT)
 
   if (renderer_type) {
     DVLOG(1) << __func__


### PR DESCRIPTION
The implementation was based on SbPlayerPipeline, with many features disabled (e.g. suspend/resume, UMA metrics) or unimplemented.  The former are tracked by feature macros in //media/starboard/BUILD.gn linked with tracking bugs, the latters are marked with TODOs with tracking bugs.

It also
1. Removed support of old Starboard versions (e.g. the EnhancedAudio starboard extension).
2. Worked around for incomplete type in SbPlayerBridge::CallbackHelper (see b/375665361).

b/328305706