### PR TITLE
Add cobalt_shell_apk target

### DIFF
--- a/content/shell/android/BUILD.gn
+++ b/content/shell/android/BUILD.gn
@@ -215,6 +215,16 @@ content_shell_apk_tmpl("content_shell_apk") {
   command_line_flags_file = "content-shell-command-line"
 }
 
+content_shell_apk_tmpl("cobalt_shell_apk") {
+  target_type = "android_apk"
+  apk_name = "CobaltShell"
+  android_manifest = content_shell_manifest
+  android_manifest_dep = ":content_shell_manifest"
+  shared_libraries = [ ":libcontent_shell_content_view" ]
+  command_line_flags_file = "content-shell-command-line"
+}
+
+
 content_shell_apk_tmpl("content_shell_test_apk") {
   target_type = "instrumentation_test_apk"
   apk_name = "ContentShellTest"

--- a/content/shell/browser/shell_content_browser_client.cc
+++ b/content/shell/browser/shell_content_browser_client.cc
@@ -300,13 +300,15 @@ std::unique_ptr<PrefService> CreateLocalState() {
 }  // namespace
 
 std::string GetShellUserAgent() {
-  if (base::FeatureList::IsEnabled(blink::features::kFullUserAgent))
-    return GetShellFullUserAgent();
+  // TODO: we need a Cobalt UA to load Kabuki. Revert the change here when we figure out the proper UA format and injection method.
+  return "Mozilla/5.0 (LINUX) Cobalt/24.lts.10.1032622-gold (unlike Gecko) v8/8.8.278.8-jit gles Evergreen/4.10.2 Evergreen-Full Evergreen-Uncompressed Starboard/15, odm_TV_chipset_2024/fw-01-23.45 (brand, model)";
+  // if (base::FeatureList::IsEnabled(blink::features::kFullUserAgent))
+  //   return GetShellFullUserAgent();
 
-  if (base::FeatureList::IsEnabled(blink::features::kReduceUserAgent))
-    return GetShellReducedUserAgent();
+  // if (base::FeatureList::IsEnabled(blink::features::kReduceUserAgent))
+  //   return GetShellReducedUserAgent();
 
-  return GetShellFullUserAgent();
+  // return GetShellFullUserAgent();
 }
 
 std::string GetShellLanguage() {


### PR DESCRIPTION
The target builds CobaltShell.apk which is just ContentShell.apk right now. Also hacked User Agent to be a fake Cobalt one so that we can load Kabuki.