### PR TITLE
Use 'cobalt' instead of 'content_shell' for logging and paths.

### DIFF
--- a/base/threading/thread_restrictions.h
+++ b/base/threading/thread_restrictions.h
@@ -211,6 +211,11 @@ namespace chrome_cleaner {
 class ResetShortcutsComponent;
 class SystemReportComponent;
 }  // namespace chrome_cleaner
+#if BUILDFLAG(IS_COBALT)
+namespace cobalt {
+class CobaltPathProvider;
+}  // namespace cobalt
+#endif  // BUILDFLAG(IS_COBALT)
 namespace content {
 class BrowserGpuChannelHostFactory;
 class BrowserMainLoop;
@@ -601,6 +606,9 @@ class BASE_EXPORT [[maybe_unused, nodiscard]] ScopedAllowBlocking {
   friend class base::win::ScopedAllowBlockingForUserAccountControl;
   friend class blink::DiskDataAllocator;
   friend class chromecast::CrashUtil;
+#if BUILDFLAG(IS_COBALT)
+  friend class cobalt::CobaltPathProvider;
+#endif  // BUILDFLAG(IS_COBALT)
   friend class content::BrowserProcessIOThread;
   friend class content::DWriteFontProxyImpl;
   friend class content::NetworkServiceInstancePrivate;

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -39,6 +39,8 @@ if (!is_android) {
       "cobalt.cc",
       "cobalt_main_delegate.cc",
       "cobalt_main_delegate.h",
+      "cobalt_paths.cc",
+      "cobalt_paths.h",
       "cobalt_switch_defaults.cc",
       "cobalt_switch_defaults.h",
       "platform_event_source_starboard.cc",

--- a/cobalt/cobalt_main_delegate.h
+++ b/cobalt/cobalt_main_delegate.h
@@ -31,6 +31,7 @@ class CobaltMainDelegate : public content::ShellMainDelegate {
   CobaltMainDelegate& operator=(const CobaltMainDelegate&) = delete;
 
   // ContentMainDelegate implementation:
+  absl::optional<int> BasicStartupComplete() override;
   content::ContentBrowserClient* CreateContentBrowserClient() override;
   content::ContentGpuClient* CreateContentGpuClient() override;
   content::ContentRendererClient* CreateContentRendererClient() override;

--- a/cobalt/cobalt_paths.cc
+++ b/cobalt/cobalt_paths.cc
@@ -1,0 +1,71 @@
+// Copyright 2021 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cobalt/cobalt_paths.h"
+
+#include "base/base_paths.h"
+#include "base/environment.h"
+#include "base/files/file_util.h"
+#include "base/path_service.h"
+#include "base/threading/thread_restrictions.h"
+#include "build/build_config.h"
+
+#if BUILDFLAG(IS_LINUX)
+#include "base/nix/xdg_util.h"
+#endif
+
+namespace cobalt {
+
+namespace {
+
+bool GetDefaultUserDataDirectory(base::FilePath* result) {
+#if BUILDFLAG(IS_LINUX)
+  std::unique_ptr<base::Environment> env(base::Environment::Create());
+  base::FilePath config_dir(base::nix::GetXDGDirectory(
+      env.get(), base::nix::kXdgConfigHomeEnvVar, base::nix::kDotConfigDir));
+  *result = config_dir.Append("cobalt");
+#elif BUILDFLAG(IS_ANDROID)
+  CHECK(base::PathService::Get(base::DIR_ANDROID_APP_DATA, result));
+  *result = result->Append(FILE_PATH_LITERAL("cobalt"));
+#else
+  NOTIMPLEMENTED();
+  return false;
+#endif
+  return true;
+}
+
+}  // namespace
+
+class CobaltPathProvider {
+ public:
+  static void CreateDir(const base::FilePath& path) {
+    base::ScopedAllowBlocking allow_io;
+    if (!base::PathExists(path)) {
+      base::CreateDirectory(path);
+    }
+  }
+};
+
+bool CobaltPathProvider(int key, base::FilePath* result) {
+  base::FilePath cur;
+
+  switch (key) {
+    case SHELL_DIR_USER_DATA: {
+      bool rv = GetDefaultUserDataDirectory(result);
+      if (rv) {
+        CobaltPathProvider::CreateDir(*result);
+      }
+      return rv;
+    }
+    default:
+      return false;
+  }
+}
+
+void RegisterCobaltPathProvider() {
+  base::PathService::RegisterProvider(CobaltPathProvider, SHELL_PATH_START,
+                                      SHELL_PATH_END);
+}
+
+}  // namespace cobalt

--- a/cobalt/cobalt_paths.h
+++ b/cobalt/cobalt_paths.h
@@ -2,23 +2,26 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#ifndef CONTENT_SHELL_BROWSER_SHELL_PATHS_H_
-#define CONTENT_SHELL_BROWSER_SHELL_PATHS_H_
+#ifndef COBALT_COBALT_PATHS_H_
+#define COBALT_COBALT_PATHS_H_
 
-#include "build/build_config.h"
-
-namespace content {
+namespace cobalt {
 
 enum {
   SHELL_PATH_START = 12000,
+
   // Directory where user data can be written.
   SHELL_DIR_USER_DATA = SHELL_PATH_START,
+
+  // TODO(jam): move from content/common since it's test only.
+  // DIR_TEST_DATA,
+
   SHELL_PATH_END
 };
 
 // Call once to register the provider for the path keys defined above.
-void RegisterShellPathProvider();
+void RegisterCobaltPathProvider();
 
-}  // namespace content
+}  // namespace cobalt
 
-#endif  // CONTENT_SHELL_BROWSER_SHELL_PATHS_H_
+#endif  // COBALT_COBALT_PATHS_H_


### PR DESCRIPTION
This changes the paths and the default log file to 'cobalt' instead of
'content_shell'.

With this PR, the local storage for the `cobalt` target on linux will be
`~/.config/cobalt`

b/375193856
b/374191454