### PR TITLE
Fix StarboardRenderer::StartPlayingFrom() re-entrant

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -155,6 +155,13 @@ void StarboardRenderer::Flush(base::OnceClosure flush_cb) {
 
   LOG(INFO) << "Flushing StarboardRenderer.";
 
+  // It's possible that Flush() is called immediately after StartPlayingFrom(),
+  // before the underlying SbPlayer is initialized.  Reset
+  // `playing_start_from_time_` here as StartPlayingFrom() checks for
+  // re-entrant.  This also avoids the stale `playing_start_from_time_` to be
+  // used.
+  playing_start_from_time_.reset();
+
   // Prepares the |player_bridge_| for Seek(), the |player_bridge_| won't
   // request more data from us before Seek() is called.
   player_bridge_->PrepareForSeek();


### PR DESCRIPTION
StarboardRenderer::Flush() and 	StarboardRenderer::StartPlayingFrom() can be called immediately after a prior StartPlayingFrom() call, and before the underlying SbPlayer is initialized.

Now `playing_start_from_time_` is resetted inside Flush().  This not only prevents a DCHECK() inside StartPlayingFrom() on `playing_start_from_time_` to check for re-entrant, but also avoids a stale `playing_start_from_time_` to be used when the SbPlayer is initialized.

b/378157844