### PR TITLE
Add log to StarboardRenderer::OnPlayerError()

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -674,6 +674,8 @@ void StarboardRenderer::OnPlayerStatus(SbPlayerState state) {
 void StarboardRenderer::OnPlayerError(SbPlayerError error,
                                       const std::string& message) {
   // TODO(b/375271948): Implement and verify error reporting.
+  LOG(ERROR) << "StarboardRenderer::OnPlayerError() called with code " << error
+             << " and message \"" << message << "\"";
   NOTIMPLEMENTED();
 }
 


### PR DESCRIPTION
Log error code and message in StarboardRenderer::OnPlayerError().  This isn't proper error handling, but helps with debugging.

b/375271948