### PR TITLE
GN hack to make extensions try to build

### DIFF
--- a/apps/ui/views/BUILD.gn
+++ b/apps/ui/views/BUILD.gn
@@ -6,6 +6,7 @@ import("//build/config/ui.gni")
 import("//extensions/buildflags/buildflags.gni")
 
 assert(enable_extensions)
+assert(!is_android)
 
 source_set("views") {
   sources = [

--- a/chrome/browser/BUILD.gn
+++ b/chrome/browser/BUILD.gn
@@ -6981,34 +6981,35 @@ static_library("browser") {
       "sync_file_system/task_logger.h",
     ]
     public_deps += [
-      "//chrome/browser/apps/platform_apps",
-      "//chrome/browser/apps/platform_apps/api",
       "//chrome/browser/extensions",
       "//chrome/browser/extensions/api",
     ]
+    if(!is_android) {
+      public_deps += [
+        "//chrome/browser/apps/platform_apps",
+        "//chrome/browser/apps/platform_apps/api",
+      ]
+    }
     allow_circular_includes_from += [
-      "//chrome/browser/apps/platform_apps",
+      # "//chrome/browser/apps/platform_apps",
 
       # TODO(https://crbug.com/883570): This is unfortunate, but not easy to
       # fix. Ideally, //chrome/browser:browser shouldn't depend on these APIs
       #(though the APIs likely will depend on //chrome/browser), but we need
       # to pull them in here to allow registration of keyed services.
-      "//chrome/browser/apps/platform_apps/api",
+      # "//chrome/browser/apps/platform_apps/api",
 
       "//chrome/browser/extensions",
 
       # TODO(crbug.com/1200215): Remove cycles and simplify all dependencies.
-      "//chrome/browser/web_applications/extensions",
+      # "//chrome/browser/web_applications/extensions",
     ]
     deps += [
-      "//apps",
       "//chrome/browser/sync_file_system/drive_backend:sync_file_system_drive_proto",
-      "//chrome/browser/web_applications/extensions",
       "//chrome/common/extensions/api",
       "//chrome/common/extensions/api:extensions_features",
       "//components/app_constants",
       "//components/drive",
-      "//components/guest_view/browser",
       "//media/cast:sender",
 
       # TODO(crbug.com/879012): mirroring shouldn't depend on enable_extensions.
@@ -7020,6 +7021,13 @@ static_library("browser") {
       "//google_apis/common",
       "//google_apis/drive",
     ]
+    if(!is_android) {
+      deps += [
+        "//apps",
+        "//components/guest_view/browser",
+        "//chrome/browser/web_applications/extensions",
+      ]
+    }
     if (is_chromeos_ash) {
       sources += [
         "accessibility/accessibility_extension_api_chromeos.cc",
@@ -7527,7 +7535,7 @@ static_library("browser") {
     if (enable_gvr_services) {
       public_deps += [ "android/vr:vr_android" ]
       configs += [ "//third_party/gvr-android-sdk:libgvr_config" ]
-      allow_circular_includes_from += [ "android/vr:vr_android" ]
+      # allow_circular_includes_from += [ "android/vr:vr_android" ]
     }
 
     if (is_win) {

--- a/chrome/browser/apps/platform_apps/BUILD.gn
+++ b/chrome/browser/apps/platform_apps/BUILD.gn
@@ -5,6 +5,7 @@
 import("//extensions/buildflags/buildflags.gni")
 
 assert(enable_extensions)
+assert(!is_android)
 
 source_set("platform_apps") {
   sources = [

--- a/chrome/browser/extensions/BUILD.gn
+++ b/chrome/browser/extensions/BUILD.gn
@@ -753,7 +753,7 @@ static_library("extensions") {
     "//chrome/browser/extensions/api:api_registration",
 
     # TODO(crbug.com/1065748): Remove this circular dependency.
-    "//chrome/browser/web_applications/extensions",
+    # "//chrome/browser/web_applications/extensions",
 
     # TODO(crbug/925153): Remove this circular dependency.
     "//chrome/browser/safe_browsing",
@@ -778,7 +778,6 @@ static_library("extensions") {
     "//mojo/public/cpp/bindings",
   ]
   deps = [
-    "//apps",
     "//base",
     "//build:branding_buildflags",
     "//build:chromeos_buildflags",
@@ -794,8 +793,6 @@ static_library("extensions") {
     "//chrome/browser:browser_process",
     "//chrome/browser:ntp_background_proto",
     "//chrome/browser:theme_properties",
-    "//chrome/browser/apps:user_type_filter",
-    "//chrome/browser/apps/app_service:constants",
     "//chrome/browser/autofill",
     "//chrome/browser/bitmap_fetcher",
     "//chrome/browser/browsing_data:constants",
@@ -806,7 +803,6 @@ static_library("extensions") {
     "//chrome/browser/image_decoder",
     "//chrome/browser/media/router",
     "//chrome/browser/media/router:media_router_feature",
-    "//chrome/browser/media/router/discovery",
     "//chrome/browser/profiles",
     "//chrome/browser/profiles:profile",
     "//chrome/browser/resource_coordinator:intervention_policy_database_proto",
@@ -814,7 +810,6 @@ static_library("extensions") {
     "//chrome/browser/safe_browsing",
     "//chrome/browser/safe_browsing:metrics_collector",
     "//chrome/browser/ui/tabs:tab_enums",
-    "//chrome/browser/web_applications",
     "//components/cbor:cbor",
     "//components/commerce/core:pref_names",
     "//components/device_reauth",
@@ -828,7 +823,6 @@ static_library("extensions") {
     "//components/webauthn/json",
 
     # TODO(crbug.com/1065748): Remove this dependency:
-    "//chrome/browser/web_applications/extensions",
     "//chrome/common/extensions/api:extensions_features",
     "//chrome/common/safe_browsing:proto",
     "//chrome/services/file_util/public/mojom:mojom",
@@ -856,8 +850,6 @@ static_library("extensions") {
     "//components/favicon/content",
     "//components/feedback",
     "//components/gcm_driver",
-    "//components/guest_view/browser",
-    "//components/guest_view/common:mojom",
     "//components/history/core/browser",
     "//components/history/core/common",
     "//components/infobars/content",
@@ -920,7 +912,6 @@ static_library("extensions") {
     "//components/url_matcher",
     "//components/user_prefs",
     "//components/vector_icons",
-    "//components/web_modal",
     "//components/zoom",
     "//content/public/common",
     "//crypto",
@@ -982,6 +973,19 @@ static_library("extensions") {
     "//ui/strings",
     "//url",
   ]
+  if (!is_android) {
+    deps += [
+      "//apps",
+      "//chrome/browser/apps:user_type_filter",
+      "//chrome/browser/apps/app_service:constants",
+      "//chrome/browser/media/router/discovery",
+      "//chrome/browser/web_applications",
+      "//chrome/browser/web_applications/extensions",
+      "//components/guest_view/browser",
+      "//components/guest_view/common:mojom",
+      "//components/web_modal",
+    ]
+  }
 
   if (is_linux || is_mac || is_win) {
     sources += [
@@ -1074,7 +1078,7 @@ static_library("extensions") {
       "//chromeos/dbus/power",
       "//remoting/host/it2me:chrome_os_host",
     ]
-  } else {
+  } else if ( !is_android ) {
     sources += [
       "api/enterprise_reporting_private/chrome_desktop_report_request_helper.cc",
       "api/enterprise_reporting_private/chrome_desktop_report_request_helper.h",

--- a/chrome/browser/policy/BUILD.gn
+++ b/chrome/browser/policy/BUILD.gn
@@ -333,9 +333,13 @@ source_set("browser_tests") {
 
     deps += [
       "//chrome/browser/extensions:test_support",
-      "//chrome/browser/web_applications:web_applications_test_support",
       "//components/webapps/browser:browser",
     ]
+    if(!is_android) {
+      deps += [
+        "//chrome/browser/web_applications:web_applications_test_support",
+      ]
+    }
   }
 
   if (is_android) {

--- a/chrome/browser/resources/extensions/BUILD.gn
+++ b/chrome/browser/resources/extensions/BUILD.gn
@@ -94,10 +94,14 @@ build_webui("build") {
   }
   ts_deps = [
     "//third_party/polymer/v3_0:library",
-    "//ui/webui/resources/cr_components/managed_footnote:build_ts",
     "//ui/webui/resources/cr_elements:build_ts",
     "//ui/webui/resources/js:build_ts",
   ]
+  if(!is_android) {
+    ts_deps += [
+      "//ui/webui/resources/cr_components/managed_footnote:build_ts",
+    ]
+  }
 
   optimize = optimize_webui
   if (optimize) {

--- a/chrome/browser/ui/BUILD.gn
+++ b/chrome/browser/ui/BUILD.gn
@@ -5799,16 +5799,11 @@ static_library("ui") {
 
   if (enable_extensions) {
     deps += [
-      "//apps",
       "//chrome/browser/apps:icon_standardizer",
-      "//chrome/browser/apps/platform_apps",
-      "//chrome/browser/apps/platform_apps/api",
       "//chrome/browser/extensions",
-      "//chrome/browser/web_applications",
       "//chrome/browser/web_share_target",
       "//chrome/common/extensions/api",
       "//components/drive",
-      "//components/guest_view/browser",
       "//extensions/browser",
       "//extensions/browser/api/management",
       "//extensions/common:mojom",
@@ -5817,9 +5812,18 @@ static_library("ui") {
       "//ui/base/cursor",
       "//ui/color:color",
     ]
+    if(!is_android) {
+      deps += [
+        "//chrome/browser/apps/platform_apps",
+        "//chrome/browser/apps/platform_apps/api",
+        "//chrome/browser/web_applications",
+        "//apps",
+        "//components/guest_view/browser",
+      ]
+    }
     allow_circular_includes_from += [
-      "//chrome/browser/apps/platform_apps",
-      "//chrome/browser/apps/platform_apps/api",
+      # "//chrome/browser/apps/platform_apps",
+      # "//chrome/browser/apps/platform_apps/api",
       "//chrome/browser/extensions",
     ]
     sources += [
@@ -5948,7 +5952,9 @@ static_library("ui") {
     if (is_mac) {
       sources += [ "views/javascript_app_modal_event_blocker_mac.h" ]
     } else {
-      deps += [ "//apps/ui/views" ]
+      if(!is_android) {
+        deps += [ "//apps/ui/views" ]
+      }
     }
 
     if (use_aura) {

--- a/chrome/browser/ui/web_applications/BUILD.gn
+++ b/chrome/browser/ui/web_applications/BUILD.gn
@@ -4,6 +4,9 @@
 
 import("//build/config/chromeos/ui_mode.gni")
 
+assert(enable_extensions)
+assert(!is_android)
+
 source_set("unit_tests") {
   testonly = true
 

--- a/chrome/browser/web_applications/BUILD.gn
+++ b/chrome/browser/web_applications/BUILD.gn
@@ -6,6 +6,9 @@ import("//build/config/chromeos/ui_mode.gni")
 import("//chrome/browser/buildflags.gni")
 import("//mojo/public/tools/bindings/mojom.gni")
 
+assert(enable_extensions)
+assert(!is_android)
+
 source_set("web_applications") {
   sources = [
     "app_registrar_observer.h",
@@ -374,7 +377,6 @@ source_set("web_applications") {
     "//components/content_settings/core/browser",
     "//components/custom_handlers",
     "//components/device_event_log",
-    "//components/keep_alive_registry:keep_alive_registry",
     "//components/keyed_service/content",
     "//components/password_manager/content/common",
     "//components/performance_manager",
@@ -418,6 +420,11 @@ source_set("web_applications") {
     "//ui/events/devices:devices",
     "//url",
   ]
+  if(!is_android) {
+    deps += [
+      "//components/keep_alive_registry:keep_alive_registry",
+    ]
+  }
 
   # TODO(crbug.com/1225132): Clean up this legacy crx dependency.
   deps += [ "//components/crx_file" ]

--- a/chrome/browser/web_applications/extensions/BUILD.gn
+++ b/chrome/browser/web_applications/extensions/BUILD.gn
@@ -6,6 +6,7 @@ import("//build/config/chromeos/ui_mode.gni")
 import("//extensions/buildflags/buildflags.gni")
 
 assert(enable_extensions)
+assert(!is_android)
 
 # TODO(crbug.com/1065748): Delete web_applications/extensions/ directory.
 source_set("extensions") {

--- a/chrome/renderer/BUILD.gn
+++ b/chrome/renderer/BUILD.gn
@@ -340,12 +340,16 @@ static_library("renderer") {
     ]
     deps += [
       "//chrome/common/extensions/api",
-      "//components/guest_view/renderer",
       "//extensions:extensions_resources",
       "//extensions/common:mojom",
       "//extensions/renderer",
       "//services/network/public/cpp",
     ]
+    if(!is_android) {
+      deps += [
+        "//components/guest_view/renderer",
+      ]
+    }
     public_deps += [ "//ipc" ]
   }
   if (enable_spellcheck) {

--- a/chrome/test/BUILD.gn
+++ b/chrome/test/BUILD.gn
@@ -248,11 +248,15 @@ static_library("test_support") {
     ]
 
     deps += [
-      "//chrome/browser/apps/app_service",
       "//components/media_router/browser:test_support",
       "//components/media_router/common:test_support",
       "//extensions/renderer",
     ]
+    if(!is_android) {
+      deps += [
+        "//chrome/browser/apps/app_service",
+      ]
+    }
   }
 
   if (is_chrome_branded &&
@@ -805,23 +809,31 @@ static_library("test_support") {
     ]
 
     public_deps += [
-      "//apps:test_support",
       "//chrome/common/extensions/api",
-      "//components/guest_view/browser:test_support",
       "//extensions:test_support",
       "//google_apis/common:test_support",
       "//google_apis/drive",
     ]
+    if(!is_android) {
+      public_deps += [
+        "//apps:test_support",
+        "//components/guest_view/browser:test_support",
+      ]
+    }
 
     deps += [
       "//build:chromeos_buildflags",
-      "//chrome/browser/apps/app_service",
-      "//chrome/browser/web_applications:web_applications_test_support",
       "//components/web_package",
       "//components/web_package/test_support",
       "//components/webapps/browser",
       "//third_party/zlib/google:zip",
     ]
+    if(!is_android) {
+      deps += [
+        "//chrome/browser/apps/app_service",
+        "//chrome/browser/web_applications:web_applications_test_support",
+      ]
+    }
   }
 
   if (enable_message_center) {
@@ -8331,17 +8343,13 @@ test("unit_tests") {
     }
 
     allow_circular_includes_from = [
-      "//chrome/browser/web_applications:web_applications_unit_tests",
-      "//chrome/browser/web_applications/extensions:unit_tests",
+      # "//chrome/browser/web_applications:web_applications_unit_tests",
+      # "//chrome/browser/web_applications/extensions:unit_tests",
     ]
 
     deps += [
       "//chrome/browser/extensions:cws_item_service_proto",
       "//chrome/browser/extensions:test_support",
-      "//chrome/browser/ui/web_applications:unit_tests",
-      "//chrome/browser/web_applications:unit_tests",
-      "//chrome/browser/web_applications:web_applications_unit_tests",
-      "//chrome/browser/web_applications/extensions:unit_tests",
       "//chrome/common/apps/platform_apps",
       "//chrome/common/extensions:extension_features_unittest",
       "//chrome/common/extensions/api",
@@ -8352,7 +8360,7 @@ test("unit_tests") {
       "//components/services/unzip:in_process",
       "//components/value_store",
       "//components/value_store:test_support",
-      "//extensions:extensions_resources",
+      # "//extensions:extensions_resources",
       "//extensions/browser:test_support",
       "//extensions/browser/updater",
       "//extensions/buildflags",
@@ -8373,6 +8381,14 @@ test("unit_tests") {
       "//third_party/blink/common/privacy_budget:test_support",
       "//tools/json_schema_compiler/test:unit_tests",
     ]
+    if(!is_android) {
+      deps += [
+        "//chrome/browser/web_applications:unit_tests",
+        "//chrome/browser/web_applications/extensions:unit_tests",
+        "//chrome/browser/ui/web_applications:unit_tests",
+        "//chrome/browser/web_applications:web_applications_unit_tests",
+      ]
+    }
 
     if (enable_service_discovery) {
       sources += [ "../browser/extensions/api/mdns/mdns_api_unittest.cc" ]

--- a/cobalt/build/configs/android-arm/args.gn
+++ b/cobalt/build/configs/android-arm/args.gn
@@ -1,3 +1,4 @@
 target_os = "android"
 target_cpu = "arm"
 treat_warnings_as_errors = false
+enable_extensions = true

--- a/extensions/BUILD.gn
+++ b/extensions/BUILD.gn
@@ -158,7 +158,6 @@ static_library("test_support") {
     "//build:chromeos_buildflags",
     "//chrome/common:buildflags",
     "//components/crx_file",
-    "//components/guest_view/browser:test_support",
     "//components/keyed_service/content",
     "//components/pref_registry",
     "//components/prefs:test_support",
@@ -183,6 +182,11 @@ static_library("test_support") {
     "//third_party/cld_3/src/src:cld_3",
     "//third_party/zlib/google:zip",
   ]
+  if (!is_android) {
+    deps += [
+      "//components/guest_view/browser:test_support",
+    ]
+  }
 
   # Generally, //extensions should not depend on //chromeos. However, a number
   # of the APIs and the extensions shell already do. We should try to avoid
@@ -202,7 +206,7 @@ repack("shell_and_test_pak") {
   testonly = true
 
   sources = [
-    "$root_gen_dir/content/browser/devtools/devtools_resources.pak",
+    # "$root_gen_dir/content/browser/devtools/devtools_resources.pak",
     "$root_gen_dir/content/content_resources.pak",
     "$root_gen_dir/content/dev_ui_content_resources.pak",
     "$root_gen_dir/content/shell/shell_resources.pak",
@@ -228,7 +232,7 @@ repack("shell_and_test_pak") {
     ":extensions_resources",
     "//content:content_resources",
     "//content:dev_ui_content_resources",
-    "//content/browser/devtools:devtools_resources",
+    # "//content/browser/devtools:devtools_resources",
     "//content/shell:resources",
     "//device/bluetooth/strings",
     "//extensions/shell:resources",
@@ -259,7 +263,7 @@ test("extensions_unittests") {
   ]
 
   deps = [
-    ":extensions_resources",
+    # ":extensions_resources",
     ":shell_and_test_pak",
     ":test_support",
     "//base/test:test_support",
@@ -352,7 +356,6 @@ source_set("chrome_extensions_browsertests_sources") {
     "//components/captive_portal/core:test_support",
     "//components/dom_distiller/content/browser",
     "//components/dom_distiller/core:test_support",
-    "//components/guest_view/browser:test_support",
     "//components/javascript_dialogs",
     "//components/resources",
     "//components/strings",
@@ -386,6 +389,11 @@ source_set("chrome_extensions_browsertests_sources") {
     "//ui/web_dialogs:test_support",
     "//v8",
   ]
+  if(!is_android) {
+    deps += [
+      "//components/guest_view/browser:test_support",
+    ]
+  }
 
   if (is_chromeos_ash) {
     deps += [ "//components/user_manager:test_support" ]

--- a/extensions/browser/BUILD.gn
+++ b/extensions/browser/BUILD.gn
@@ -579,7 +579,6 @@ source_set("browser_sources") {
     "//components/content_settings/core/common",
     "//components/crx_file",
     "//components/crx_file:crx_creator",
-    "//components/guest_view/browser",
     "//components/keyed_service/content",
     "//components/keyed_service/content:content",
     "//components/keyed_service/core",
@@ -598,7 +597,6 @@ source_set("browser_sources") {
     "//components/version_info",
     "//components/web_cache/browser",
     "//components/web_cache/browser:browser",
-    "//components/web_modal",
     "//components/zoom",
     "//content/public/browser",
     "//content/public/browser:browser",
@@ -616,7 +614,6 @@ source_set("browser_sources") {
     "//pdf:buildflags",
     "//ppapi/buildflags",
     "//services/data_decoder/public/cpp:cpp",
-    "//services/device/public/cpp/hid",
     "//services/device/public/mojom",
     "//services/metrics/public/cpp:metrics_cpp",
     "//services/metrics/public/cpp:ukm_builders",
@@ -633,6 +630,13 @@ source_set("browser_sources") {
     "//ui/display",
     "//url",
   ]
+  if(!is_android) {
+    deps += [
+      "//components/guest_view/browser",
+      "//components/web_modal",
+      "//services/device/public/cpp/hid",
+    ]
+  }
 
   public_deps = [
     "//base",
@@ -728,7 +732,6 @@ source_set("browser_tests") {
     ":browser",
     "//base",
     "//build:chromeos_buildflags",
-    "//components/guest_view/browser:test_support",
     "//components/storage_monitor:test_support",
     "//content/test:test_support",
     "//device/bluetooth:mocks",
@@ -745,6 +748,11 @@ source_set("browser_tests") {
     "//services/service_manager/public/cpp",
     "//ui/display:test_support",
   ]
+  if(!is_android) {
+    deps += [
+      "//components/guest_view/browser:test_support",
+    ]
+  }
 
   if (is_chromeos_ash) {
     sources += [

--- a/extensions/renderer/BUILD.gn
+++ b/extensions/renderer/BUILD.gn
@@ -257,9 +257,6 @@ source_set("renderer") {
     "//build:chromeos_buildflags",
     "//chrome:resources",
     "//components/crx_file",
-    "//components/guest_view/common",
-    "//components/guest_view/common:mojom",
-    "//components/guest_view/renderer",
     "//components/version_info",
     "//content:content_resources",
     "//content:dev_ui_content_resources",
@@ -279,6 +276,13 @@ source_set("renderer") {
     "//third_party/cld_3/src/src:cld_3",
     "//third_party/zlib/google:compression_utils",
   ]
+  if(!is_android) {
+    deps += [
+      "//components/guest_view/common",
+      "//components/guest_view/common:mojom",
+      "//components/guest_view/renderer",
+    ]
+  }
 
   # Temporarily allow crash_key; see https://crbug.com/1034755
   deps += [ "//components/crash/core/common:crash_key" ]

--- a/extensions/renderer/dispatcher.cc
+++ b/extensions/renderer/dispatcher.cc
@@ -865,7 +865,9 @@ std::vector<Dispatcher::JsResourceInfo> Dispatcher::GetJsResources() {
       {"webViewInternal", IDR_WEB_VIEW_INTERNAL_CUSTOM_BINDINGS_JS},
 
       {"keep_alive", IDR_KEEP_ALIVE_JS},
+#if !BUILDFLAG(IS_ANDROID)
       {"mojo_bindings", IDR_MOJO_MOJO_BINDINGS_JS},
+#endif
 
 #if BUILDFLAG(IS_CHROMEOS)
       {"mojo_bindings_lite", IDR_MOJO_MOJO_BINDINGS_LITE_JS},

--- a/extensions/shell/BUILD.gn
+++ b/extensions/shell/BUILD.gn
@@ -36,15 +36,10 @@ source_set("app_shell_lib") {
   deps = [
     ":resources",
     ":version_header",
-    "//apps",
     "//base",
     "//build:chromeos_buildflags",
     "//components/feedback",
     "//components/feedback/content:factory",
-    "//components/guest_view/browser",
-    "//components/guest_view/common:mojom",
-    "//components/guest_view/renderer",
-    "//components/keep_alive_registry",
     "//components/keyed_service/content:content",
     "//components/nacl/common:buildflags",
     "//components/network_session_configurator/common",
@@ -77,6 +72,15 @@ source_set("app_shell_lib") {
     "//ui/base",
     "//ui/base/ime/init",
   ]
+  if (!is_android) {
+    deps+=[
+    "//apps",
+    "//components/keep_alive_registry",
+    "//components/guest_view/browser",
+    "//components/guest_view/common:mojom",
+    "//components/guest_view/renderer",
+    ]
+  }
 
   # TODO(michaelpg): remove Mac support and always use aura.
   if (use_aura) {
@@ -313,13 +317,11 @@ test("app_shell_unittests") {
 
   deps = [
     ":app_shell_lib",
-    "//apps",
     "//base",
     "//base/test:test_support",
     "//build:chromeos_buildflags",
     "//components/crx_file",
     "//components/feedback",
-    "//components/keep_alive_registry",
     "//components/prefs",
     "//components/user_prefs",
     "//content/test:test_support",
@@ -334,6 +336,12 @@ test("app_shell_unittests") {
     "//ui/gl:test_support",
     "//ui/platform_window",
   ]
+  if (!is_android) {
+    deps += [
+      "//apps",
+      "//components/keep_alive_registry",
+    ]
+  }
 
   data_deps = [
     # "//gin", # TODO(dpranke): Either gin or v8 data is needed ...
@@ -413,7 +421,6 @@ source_set("browser_tests") {
     "//base",
     "//base/test:test_support",
     "//build:chromeos_buildflags",
-    "//components/keep_alive_registry",
     "//components/version_info",
     "//content/shell:content_shell_lib",
     "//content/test:test_support",
@@ -423,6 +430,11 @@ source_set("browser_tests") {
     "//extensions/common",
     "//ui/base",
   ]
+  if(!is_android) {
+    deps += [
+      "//components/keep_alive_registry",
+    ]
+  }
 
   if (is_chromeos_lacros) {
     deps += [ "//chromeos/lacros" ]

--- a/ui/webui/resources/cr_components/managed_footnote/BUILD.gn
+++ b/ui/webui/resources/cr_components/managed_footnote/BUILD.gn
@@ -6,6 +6,8 @@ import("//ui/webui/resources/include_polymer.gni")
 import("//ui/webui/resources/tools/build_webui.gni")
 
 assert(include_polymer)
+assert(enable_extensions)
+assert(!is_android)
 
 build_webui("build") {
   grd_prefix = "cr_components_managed_footnote"


### PR DESCRIPTION
Lots of hacking to see what it would take to try and build extensions for Android.

GN "passes" but lots of parts shouldn't be commented out like this. Does not yet compile.

There are probably lots of runtime-deps that make this nonviable.

I also ran into this https://issues.chromium.org/issues/40603958

I didn't find an explicit bug anywhere for even trying to enable extensions for Android https://issues.chromium.org/issues?q=status:open%20componentid:1363614%2B%20extensions%20android

Fuchsia has them, iOS doesnt,  Cast doesnt, Android doesn't by default

