### PR TITLE
Breakdemo

### DIFF
--- a/starboard/linux/x64x11/main.cc
+++ b/starboard/linux/x64x11/main.cc
@@ -72,7 +72,28 @@ int post_starboard() {
 
 extern "C" SB_EXPORT_PLATFORM int main(int argc, char** argv) {
   preinit_starboard(argc, argv);
-  int result = SbRunStarboardMain(argc, argv, SbEventHandle);
+  // Previous code
+  // int result = SbRunStarboardMain(argc, argv, SbEventHandle);
+  int result = 0;
+
+  // Code taken out from SbRunStarboardMain
+  if (false) {
+    // Current/Old version
+    starboard::shared::x11::ApplicationX11 application(SbEventHandle);
+    result = application.Run(argc, argv);
+  } else {
+    // non-blocking version, with loop owned by caller
+    starboard::shared::x11::ApplicationX11 application(SbEventHandle, false);
+    result = application.Run(argc, argv);
+
+    // Loop taken out and broken
+    application.RunLoop_Part0();
+    // This does nothing but DispatchNextEvent()
+    while (application.RunLoop_Part1()) {
+    }
+    application.RunLoop_Part2();
+  }
+
   post_starboard();
   return result;
 }

--- a/starboard/linux/x64x11/main.cc
+++ b/starboard/linux/x64x11/main.cc
@@ -30,7 +30,7 @@
 
 #include "third_party/crashpad/crashpad/wrapper/wrapper.h"
 
-extern "C" SB_EXPORT_PLATFORM int main(int argc, char** argv) {
+int preinit_starboard(int argc, char** argv) {
   // Set M_ARENA_MAX to a low value to slow memory growth due to fragmentation.
   mallopt(M_ARENA_MAX, 2);
 
@@ -61,19 +61,18 @@ extern "C" SB_EXPORT_PLATFORM int main(int argc, char** argv) {
   // crash bugs in glibc, in dlopen()
   SbLogRawDumpStack(3);
 #endif
-
-#if SB_API_VERSION >= 15
-  int result = SbRunStarboardMain(argc, argv, SbEventHandle);
-#else
-  starboard::shared::x11::ApplicationX11 application;
-  int result = 0;
-  {
-    starboard::shared::starboard::LinkReceiver receiver(&application);
-    result = application.Run(argc, argv);
-  }
-#endif  // SB_API_VERSION >= 15
+  return 0;
+}
+int post_starboard() {
   starboard::shared::signal::UninstallSuspendSignalHandlers();
   starboard::shared::signal::UninstallDebugSignalHandlers();
   starboard::shared::signal::UninstallCrashSignalHandlers();
+  return 0;
+}
+
+extern "C" SB_EXPORT_PLATFORM int main(int argc, char** argv) {
+  preinit_starboard(argc, argv);
+  int result = SbRunStarboardMain(argc, argv, SbEventHandle);
+  post_starboard();
   return result;
 }

--- a/starboard/shared/starboard/application.h
+++ b/starboard/shared/starboard/application.h
@@ -157,8 +157,10 @@ class Application {
     int error_level;
   };
 
+  bool m_blocking = true;
 #if SB_API_VERSION >= 15
-  explicit Application(SbEventHandleCallback sb_event_handle_callback);
+  explicit Application(SbEventHandleCallback sb_event_handle_callback,
+                       bool blocking = true);
 #else
   Application();
 #endif  // SB_API_VERSION >= 15
@@ -300,6 +302,10 @@ class Application {
     ScopedLock lock(callbacks_lock_);
     teardown_callbacks_.push_back(callback);
   }
+
+  int RunLoop_Part0();
+  bool RunLoop_Part1();
+  int RunLoop_Part2();
 
  protected:
   // Initializes any systems that need initialization before application

--- a/starboard/shared/starboard/queue_application.h
+++ b/starboard/shared/starboard/queue_application.h
@@ -36,8 +36,9 @@ namespace starboard {
 class QueueApplication : public Application {
  public:
 #if SB_API_VERSION >= 15
-  explicit QueueApplication(SbEventHandleCallback sb_event_handle_callback)
-      : Application(sb_event_handle_callback) {}
+  explicit QueueApplication(SbEventHandleCallback sb_event_handle_callback,
+                            bool blocking = true)
+      : Application(sb_event_handle_callback, blocking) {}
 #else
   QueueApplication() {}
 #endif  // SB_API_VERSION >= 15

--- a/starboard/shared/x11/application_x11.cc
+++ b/starboard/shared/x11/application_x11.cc
@@ -694,7 +694,8 @@ int ErrorHandler(Display* display, XErrorEvent* event) {
 using shared::starboard::player::filter::CpuVideoFrame;
 
 #if SB_API_VERSION >= 15
-ApplicationX11::ApplicationX11(SbEventHandleCallback sb_event_handle_callback)
+ApplicationX11::ApplicationX11(SbEventHandleCallback sb_event_handle_callback,
+                               bool blocking)
 #else
 ApplicationX11::ApplicationX11()
 #endif  // SB_API_VERSION >= 15
@@ -702,7 +703,7 @@ ApplicationX11::ApplicationX11()
       wm_delete_atom_(None),
       wm_change_state_atom_(None),
 #if SB_API_VERSION >= 15
-      QueueApplication(sb_event_handle_callback),
+      QueueApplication(sb_event_handle_callback, blocking),
 #endif  // SB_API_VERSION >= 15
       composite_event_id_(kSbEventIdInvalid),
       display_(NULL),

--- a/starboard/shared/x11/application_x11.h
+++ b/starboard/shared/x11/application_x11.h
@@ -39,7 +39,8 @@ namespace x11 {
 class ApplicationX11 : public shared::starboard::QueueApplication {
  public:
 #if SB_API_VERSION >= 15
-  explicit ApplicationX11(SbEventHandleCallback sb_event_handle_callback);
+  explicit ApplicationX11(SbEventHandleCallback sb_event_handle_callback,
+                          bool blocking = true); // Leave blocking by default
 #else
   ApplicationX11();
 #endif  // SB_API_VERSION >= 15


### PR DESCRIPTION
Quick dumb / simple demo for how to take the loop ownership away from Starboard Application object wrapper.

Intentionally obtuse / simple - we have no reason to have both blocking/nonblocking versions.