### PR TITLE
[media] Turn SbPlayerPrivate into an interface

### DIFF
--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -29,6 +29,7 @@
 #include "starboard/shared/starboard/player/player_worker.h"
 
 using starboard::shared::starboard::player::PlayerWorker;
+using starboard::shared::starboard::player::SbPlayerPrivateImpl;
 using starboard::shared::starboard::player::filter::
     FilterBasedPlayerWorkerHandler;
 
@@ -203,7 +204,7 @@ SbPlayer SbPlayerCreate(SbWindow window,
       new FilterBasedPlayerWorkerHandler(creation_param, provider));
   handler->SetMaxVideoInputSize(
       starboard::android::shared::GetMaxVideoInputSizeForCurrentThread());
-  SbPlayer player = SbPlayerPrivate::CreateInstance(
+  SbPlayer player = SbPlayerPrivateImpl::CreateInstance(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
       player_status_func, player_error_func, context, std::move(handler));
 
@@ -218,9 +219,9 @@ SbPlayer SbPlayerCreate(SbWindow window,
   }
 
   SB_LOG(ERROR)
-      << "Invalid player returned by SbPlayerPrivate::CreateInstance().";
+      << "Invalid player returned by SbPlayerPrivateImpl::CreateInstance().";
   player_error_func(
       kSbPlayerInvalid, context, kSbPlayerErrorDecode,
-      "Invalid player returned by SbPlayerPrivate::CreateInstance()");
+      "Invalid player returned by SbPlayerPrivateImpl::CreateInstance()");
   return kSbPlayerInvalid;
 }

--- a/starboard/shared/starboard/player/player_create.cc
+++ b/starboard/shared/starboard/player/player_create.cc
@@ -38,6 +38,7 @@ using ::starboard::shared::media_session::
     UpdateActiveSessionPlatformPlaybackState;
 using ::starboard::shared::starboard::media::MimeType;
 using ::starboard::shared::starboard::player::PlayerWorker;
+using ::starboard::shared::starboard::player::SbPlayerPrivateImpl;
 using ::starboard::shared::starboard::player::filter::
     FilterBasedPlayerWorkerHandler;
 
@@ -208,7 +209,7 @@ SbPlayer SbPlayerCreate(SbWindow window,
   std::unique_ptr<PlayerWorker::Handler> handler(
       new FilterBasedPlayerWorkerHandler(creation_param, provider));
 
-  SbPlayer player = SbPlayerPrivate::CreateInstance(
+  SbPlayer player = SbPlayerPrivateImpl::CreateInstance(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
       player_status_func, player_error_func, context, std::move(handler));
 


### PR DESCRIPTION
This allows us to move the implementation to a sub-class named SbPlayerPrivateImpl in namespace starboard::shared::starboard::player, which has the following benefits:

1. It allows the implementation to use symbols inside the starboard namespace directly.
2. By moving concrete implementation from the global namespace into a nested namespace, a binary can make use of two implementations (each in their own namespaces), e.g. experimenting on them.

b/327287075