### PR TITLE
Set up a Shell class entry for Cobalt

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -268,8 +268,19 @@ shared_library("libcobalt_content_shell_content_view") {
     "//cobalt/cobalt_content_browser_client.h",
     "//cobalt/cobalt_main_delegate.cc",
     "//cobalt/cobalt_main_delegate.h",
+    "//cobalt/cobalt_shell.cc",
+    "//cobalt/cobalt_shell.h",
     "cobalt_library_loader.cc",
   ]
+
+  # Content shell Android parts
+  sources += [
+    "//cobalt/android/shell_manager.cc",
+    "//cobalt/android/shell_manager.h",
+    "//cobalt/android/shell_platform_delegate_android.cc",
+    "//cobalt/android/shell_web_contents_view_delegate_android.cc",
+  ]
+
   configs -= [ "//build/config/android:hide_all_but_jni_onload" ]
   configs += [ "//build/config/android:hide_all_but_jni" ]
 }

--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -249,6 +249,7 @@ shared_library("libcobalt_content_shell_content_view") {
     "//content/shell:content_shell_app",
     "//content/shell:content_shell_lib",
     "//content/shell:pak",
+    "//content/shell/android:content_shell_jni_headers",
     "//media",
     "//skia",
     "//starboard/android/shared:starboard_jni_state",

--- a/cobalt/android/shell_manager.cc
+++ b/cobalt/android/shell_manager.cc
@@ -66,6 +66,8 @@ void JNI_ShellManager_LaunchShell(JNIEnv* env,
   content::ShellBrowserContext* browserContext =
       content::ShellContentBrowserClient::Get()->browser_context();
   GURL url(base::android::ConvertJavaStringToUTF8(env, jurl));
+
+  // Cobalt specific shell creation
   cobalt::CobaltShell::CreateNewWindow(browserContext, url, nullptr,
                                        gfx::Size());
 }

--- a/cobalt/android/shell_manager.cc
+++ b/cobalt/android/shell_manager.cc
@@ -1,0 +1,78 @@
+// Copyright 2012 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cobalt/android/shell_manager.h"
+
+#include "base/android/jni_android.h"
+#include "base/android/jni_string.h"
+#include "base/android/scoped_java_ref.h"
+#include "base/functional/bind.h"
+#include "base/lazy_instance.h"
+#include "cobalt/cobalt_shell.h"
+#include "content/public/browser/web_contents.h"
+#include "content/shell/android/content_shell_jni_headers/ShellManager_jni.h"
+#include "content/shell/browser/shell_browser_context.h"
+#include "content/shell/browser/shell_content_browser_client.h"
+#include "url/gurl.h"
+
+// Note: Origin of this file is content/shell/shell_manager.cc from m114
+
+using base::android::JavaParamRef;
+using base::android::JavaRef;
+using base::android::ScopedJavaLocalRef;
+
+namespace {
+
+struct GlobalState {
+  GlobalState() {}
+  base::android::ScopedJavaGlobalRef<jobject> j_shell_manager;
+};
+
+base::LazyInstance<GlobalState>::DestructorAtExit g_global_state =
+    LAZY_INSTANCE_INITIALIZER;
+
+}  // namespace
+
+namespace cobalt {
+
+ScopedJavaLocalRef<jobject> CreateShellView(content::Shell* shell) {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  return content::Java_ShellManager_createShell(
+      env, g_global_state.Get().j_shell_manager,
+      reinterpret_cast<intptr_t>(shell));
+}
+
+void RemoveShellView(const JavaRef<jobject>& shell_view) {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  content::Java_ShellManager_removeShell(
+      env, g_global_state.Get().j_shell_manager, shell_view);
+}
+
+}  // namespace cobalt
+
+// Note: Below tracks generated Java code, which is currently generated
+// in content, not cobalt namespace.
+
+namespace content {
+
+static void JNI_ShellManager_Init(JNIEnv* env,
+                                  const JavaParamRef<jobject>& obj) {
+  g_global_state.Get().j_shell_manager.Reset(obj);
+}
+
+void JNI_ShellManager_LaunchShell(JNIEnv* env,
+                                  const JavaParamRef<jstring>& jurl) {
+  content::ShellBrowserContext* browserContext =
+      content::ShellContentBrowserClient::Get()->browser_context();
+  GURL url(base::android::ConvertJavaStringToUTF8(env, jurl));
+  cobalt::CobaltShell::CreateNewWindow(browserContext, url, nullptr,
+                                       gfx::Size());
+}
+
+void DestroyShellManager() {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  content::Java_ShellManager_destroy(env, g_global_state.Get().j_shell_manager);
+}
+
+}  // namespace content

--- a/cobalt/android/shell_manager.h
+++ b/cobalt/android/shell_manager.h
@@ -1,0 +1,47 @@
+// Copyright 2012 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef CONTENT_SHELL_ANDROID_SHELL_MANAGER_H_
+#define CONTENT_SHELL_ANDROID_SHELL_MANAGER_H_
+
+#include <jni.h>
+
+#include "base/android/jni_android.h"
+#include "base/android/scoped_java_ref.h"
+
+// Note: Origin of this file is content/shell/shell_manager.h from m114
+
+namespace content {
+class Shell;
+}
+
+namespace cc {
+class Layer;
+}
+
+namespace cobalt {
+
+// Creates an Android specific shell view, which is our version of a shell
+// window.  This view holds the controls and content views necessary to
+// render a shell window.  Returns the java object representing the shell view.
+// object.
+base::android::ScopedJavaLocalRef<jobject> CreateShellView(
+    content::Shell* shell);
+
+// Removes a previously created shell view.
+void RemoveShellView(const base::android::JavaRef<jobject>& shell_view);
+
+}  // namespace cobalt
+namespace content {
+
+void ShellAttachLayer(cc::Layer* layer);
+void ShellRemoveLayer(cc::Layer* layer);
+
+// Destroys the ShellManager on app exit. Must not use the above functions
+// after this is called.
+void DestroyShellManager();
+
+}  // namespace content
+
+#endif  // CONTENT_SHELL_ANDROID_SHELL_MANAGER_H_

--- a/cobalt/android/shell_manager.h
+++ b/cobalt/android/shell_manager.h
@@ -35,9 +35,6 @@ void RemoveShellView(const base::android::JavaRef<jobject>& shell_view);
 }  // namespace cobalt
 namespace content {
 
-void ShellAttachLayer(cc::Layer* layer);
-void ShellRemoveLayer(cc::Layer* layer);
-
 // Destroys the ShellManager on app exit. Must not use the above functions
 // after this is called.
 void DestroyShellManager();

--- a/cobalt/android/shell_platform_delegate_android.cc
+++ b/cobalt/android/shell_platform_delegate_android.cc
@@ -24,6 +24,9 @@ using base::android::ConvertUTF8ToJavaString;
 using base::android::JavaParamRef;
 using base::android::ScopedJavaLocalRef;
 
+// Note: Origin of this file is
+//  content/shell/browser/shell_platform_delegate_android.cc from m114
+
 namespace content {
 
 struct ShellPlatformDelegate::ShellData {

--- a/cobalt/android/shell_platform_delegate_android.cc
+++ b/cobalt/android/shell_platform_delegate_android.cc
@@ -1,0 +1,167 @@
+// Copyright 2020 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/shell/browser/shell_platform_delegate.h"
+
+#include <jni.h>
+
+#include "base/android/jni_string.h"
+#include "base/android/scoped_java_ref.h"
+#include "base/command_line.h"
+#include "base/containers/contains.h"
+#include "base/notreached.h"
+#include "base/strings/string_piece.h"
+#include "cobalt/android/shell_manager.h"
+#include "content/public/browser/render_widget_host_view.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/common/content_switches.h"
+#include "content/shell/android/content_shell_jni_headers/Shell_jni.h"
+#include "content/shell/browser/shell.h"
+
+using base::android::AttachCurrentThread;
+using base::android::ConvertUTF8ToJavaString;
+using base::android::JavaParamRef;
+using base::android::ScopedJavaLocalRef;
+
+namespace content {
+
+struct ShellPlatformDelegate::ShellData {
+  base::android::ScopedJavaGlobalRef<jobject> java_object;
+};
+
+struct ShellPlatformDelegate::PlatformData {};
+
+ShellPlatformDelegate::ShellPlatformDelegate() = default;
+
+void ShellPlatformDelegate::Initialize(const gfx::Size& default_window_size) {
+  // |platform_| is not used on this platform.
+}
+
+ShellPlatformDelegate::~ShellPlatformDelegate() {
+  content::DestroyShellManager();
+}
+
+void ShellPlatformDelegate::CreatePlatformWindow(
+    Shell* shell,
+    const gfx::Size& initial_size) {
+  DCHECK(!base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  shell_data.java_object.Reset(cobalt::CreateShellView(shell));
+}
+
+void ShellPlatformDelegate::CleanUp(Shell* shell) {
+  JNIEnv* env = AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  cobalt::RemoveShellView(shell_data.java_object);
+
+  if (!shell_data.java_object.is_null()) {
+    Java_Shell_onNativeDestroyed(env, shell_data.java_object);
+  }
+
+  shell_data_map_.erase(shell);
+}
+
+void ShellPlatformDelegate::SetContents(Shell* shell) {
+  JNIEnv* env = AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  Java_Shell_initFromNativeTabContents(
+      env, shell_data.java_object, shell->web_contents()->GetJavaWebContents());
+}
+
+void ShellPlatformDelegate::ResizeWebContent(Shell* shell,
+                                             const gfx::Size& content_size) {
+  shell->web_contents()->GetRenderWidgetHostView()->SetSize(content_size);
+}
+
+void ShellPlatformDelegate::EnableUIControl(Shell* shell,
+                                            UIControl control,
+                                            bool is_enabled) {
+  JNIEnv* env = AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  if (shell_data.java_object.is_null()) {
+    return;
+  }
+  Java_Shell_enableUiControl(env, shell_data.java_object, control, is_enabled);
+}
+
+void ShellPlatformDelegate::SetAddressBarURL(Shell* shell, const GURL& url) {
+  JNIEnv* env = AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  ScopedJavaLocalRef<jstring> j_url = ConvertUTF8ToJavaString(env, url.spec());
+  Java_Shell_onUpdateUrl(env, shell_data.java_object, j_url);
+}
+
+void ShellPlatformDelegate::SetIsLoading(Shell* shell, bool loading) {
+  JNIEnv* env = AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  Java_Shell_setIsLoading(env, shell_data.java_object, loading);
+}
+
+void ShellPlatformDelegate::SetTitle(Shell* shell,
+                                     const std::u16string& title) {}
+
+void ShellPlatformDelegate::MainFrameCreated(Shell* shell) {}
+
+bool ShellPlatformDelegate::DestroyShell(Shell* shell) {
+  return false;  // Shell destroys itself.
+}
+
+void ShellPlatformDelegate::ToggleFullscreenModeForTab(
+    Shell* shell,
+    WebContents* web_contents,
+    bool enter_fullscreen) {
+  JNIEnv* env = AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  Java_Shell_toggleFullscreenModeForTab(env, shell_data.java_object,
+                                        enter_fullscreen);
+}
+
+bool ShellPlatformDelegate::IsFullscreenForTabOrPending(
+    Shell* shell,
+    const WebContents* web_contents) const {
+  JNIEnv* env = AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  const ShellData& shell_data = shell_data_map_.find(shell)->second;
+
+  return Java_Shell_isFullscreenForTabOrPending(env, shell_data.java_object);
+}
+
+void ShellPlatformDelegate::SetOverlayMode(Shell* shell,
+                                           bool use_overlay_mode) {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  return Java_Shell_setOverlayMode(env, shell_data.java_object,
+                                   use_overlay_mode);
+}
+
+void ShellPlatformDelegate::LoadProgressChanged(Shell* shell, double progress) {
+  JNIEnv* env = AttachCurrentThread();
+  DCHECK(base::Contains(shell_data_map_, shell));
+  ShellData& shell_data = shell_data_map_[shell];
+
+  Java_Shell_onLoadProgressChanged(env, shell_data.java_object, progress);
+}
+
+// static
+void JNI_Shell_CloseShell(JNIEnv* env, jlong shellPtr) {
+  Shell* shell = reinterpret_cast<Shell*>(shellPtr);
+  shell->Close();
+}
+
+}  // namespace content

--- a/cobalt/android/shell_platform_delegate_android.cc
+++ b/cobalt/android/shell_platform_delegate_android.cc
@@ -51,6 +51,7 @@ void ShellPlatformDelegate::CreatePlatformWindow(
   DCHECK(!base::Contains(shell_data_map_, shell));
   ShellData& shell_data = shell_data_map_[shell];
 
+  // Cobalt specific ShellView creation
   shell_data.java_object.Reset(cobalt::CreateShellView(shell));
 }
 
@@ -59,6 +60,7 @@ void ShellPlatformDelegate::CleanUp(Shell* shell) {
   DCHECK(base::Contains(shell_data_map_, shell));
   ShellData& shell_data = shell_data_map_[shell];
 
+  // Cobalt specific ShellView removal
   cobalt::RemoveShellView(shell_data.java_object);
 
   if (!shell_data.java_object.is_null()) {

--- a/cobalt/android/shell_web_contents_view_delegate_android.cc
+++ b/cobalt/android/shell_web_contents_view_delegate_android.cc
@@ -1,0 +1,33 @@
+// Copyright 2013 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "content/shell/browser/shell_web_contents_view_delegate.h"
+
+#include <memory>
+
+#include "base/command_line.h"
+#include "content/public/browser/context_menu_params.h"
+#include "content/public/browser/web_contents.h"
+#include "content/shell/browser/shell_web_contents_view_delegate_creator.h"
+
+namespace content {
+
+std::unique_ptr<WebContentsViewDelegate> CreateShellWebContentsViewDelegate(
+    WebContents* web_contents) {
+  return std::make_unique<ShellWebContentsViewDelegate>(web_contents);
+}
+
+ShellWebContentsViewDelegate::ShellWebContentsViewDelegate(
+    WebContents* web_contents)
+    : web_contents_(web_contents) {
+  DCHECK(web_contents_);  // Avoids 'unused private field' build error.
+}
+
+ShellWebContentsViewDelegate::~ShellWebContentsViewDelegate() {}
+
+void ShellWebContentsViewDelegate::ShowContextMenu(
+    RenderFrameHost& render_frame_host,
+    const ContextMenuParams& params) {}
+
+}  // namespace content

--- a/cobalt/cobalt_shell.cc
+++ b/cobalt/cobalt_shell.cc
@@ -1,3 +1,17 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #include "cobalt/cobalt_shell.h"
 #include "base/command_line.h"
 #include "content/public/browser/presentation_receiver_flags.h"

--- a/cobalt/cobalt_shell.cc
+++ b/cobalt/cobalt_shell.cc
@@ -1,0 +1,10 @@
+#include "cobalt/cobalt_shell.h"
+
+namespace cobalt {
+
+// Placeholder for a WebContentsObserver override
+void CobaltShell::PrimaryMainDocumentElementAvailable() {
+  LOG(INFO) << "Cobalt::PrimaryMainDocumentElementAvailable";
+}
+
+}  // namespace cobalt

--- a/cobalt/cobalt_shell.cc
+++ b/cobalt/cobalt_shell.cc
@@ -1,6 +1,59 @@
 #include "cobalt/cobalt_shell.h"
+#include "base/command_line.h"
+#include "content/public/browser/presentation_receiver_flags.h"
+#include "content/public/common/content_switches.h"
+
+// This file defines a Cobalt specific shell entry point, that delegates most
+// of its functionality to content::Shell. This allows overrides to
+// WebContentsDelegate and WebContentsObserver interfaces.
+//
+// We expect to fully migrate away from depending on content::Shell in the
+// future.
 
 namespace cobalt {
+
+CobaltShell::CobaltShell(std::unique_ptr<content::WebContents> web_contents,
+                         bool should_set_delegate)
+    : content::Shell(std::move(web_contents), should_set_delegate) {}
+
+// static
+content::Shell* CobaltShell::CreateShell(
+    std::unique_ptr<content::WebContents> web_contents,
+    const gfx::Size& initial_size,
+    bool should_set_delegate) {
+  content::WebContents* raw_web_contents = web_contents.get();
+  // Create a Cobalt specific shell instance
+  CobaltShell* shell =
+      new CobaltShell(std::move(web_contents), should_set_delegate);
+  // Delegate the rest of Shell setup to content::Shell
+  return content::Shell::CreateShellFromPointer(
+      shell, raw_web_contents, initial_size, should_set_delegate);
+}
+
+// static
+content::Shell* CobaltShell::CreateNewWindow(
+    content::BrowserContext* browser_context,
+    const GURL& url,
+    const scoped_refptr<content::SiteInstance>& site_instance,
+    const gfx::Size& initial_size) {
+  content::WebContents::CreateParams create_params(browser_context,
+                                                   site_instance);
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kForcePresentationReceiverForTesting)) {
+    create_params.starting_sandbox_flags =
+        content::kPresentationReceiverSandboxFlags;
+  }
+  std::unique_ptr<content::WebContents> web_contents =
+      content::WebContents::Create(create_params);
+  content::Shell* shell =
+      CreateShell(std::move(web_contents), AdjustWindowSize(initial_size),
+                  true /* should_set_delegate */);
+
+  if (!url.is_empty()) {
+    shell->LoadURL(url);
+  }
+  return shell;
+}
 
 // Placeholder for a WebContentsObserver override
 void CobaltShell::PrimaryMainDocumentElementAvailable() {

--- a/cobalt/cobalt_shell.h
+++ b/cobalt/cobalt_shell.h
@@ -1,3 +1,17 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 #ifndef COBALT_COBALT_SHELL_H
 #define COBALT_COBALT_SHELL_H
 

--- a/cobalt/cobalt_shell.h
+++ b/cobalt/cobalt_shell.h
@@ -1,0 +1,15 @@
+#ifndef COBALT_COBALT_SHELL_H
+#define COBALT_COBALT_SHELL_H
+
+#include "content/shell/browser/shell.h"
+
+namespace cobalt {
+
+class CobaltShell : public content::Shell {
+  // WebContentsObserver
+  void PrimaryMainDocumentElementAvailable() override;
+};
+
+}  // namespace cobalt
+
+#endif  // COBALT_COBALT_SHELL_H

--- a/cobalt/cobalt_shell.h
+++ b/cobalt/cobalt_shell.h
@@ -1,12 +1,32 @@
 #ifndef COBALT_COBALT_SHELL_H
 #define COBALT_COBALT_SHELL_H
 
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/web_contents.h"
 #include "content/shell/browser/shell.h"
 
 namespace cobalt {
 
 class CobaltShell : public content::Shell {
-  // WebContentsObserver
+ public:
+  // Override content::Shell entry point
+  static content::Shell* CreateNewWindow(
+      content::BrowserContext* browser_context,
+      const GURL& url,
+      const scoped_refptr<content::SiteInstance>& site_instance,
+      const gfx::Size& initial_size);
+
+ private:
+  CobaltShell(std::unique_ptr<content::WebContents> web_contents,
+              bool should_set_delegate);
+
+  // Overridden from content::Shell
+  static content::Shell* CreateShell(
+      std::unique_ptr<content::WebContents> web_contents,
+      const gfx::Size& initial_size,
+      bool should_set_delegate);
+
+  // WebContentsObserver interface
   void PrimaryMainDocumentElementAvailable() override;
 };
 

--- a/content/shell/BUILD.gn
+++ b/content/shell/BUILD.gn
@@ -192,12 +192,14 @@ static_library("content_shell_lib") {
   ]
 
   if (is_android) {
+    if (!is_cobalt) {
     sources += [
       "android/shell_manager.cc",
       "android/shell_manager.h",
       "browser/shell_platform_delegate_android.cc",
       "browser/shell_web_contents_view_delegate_android.cc",
     ]
+    }
   }
 
   if (is_mac) {

--- a/content/shell/browser/shell.cc
+++ b/content/shell/browser/shell.cc
@@ -108,6 +108,14 @@ Shell* Shell::CreateShell(std::unique_ptr<WebContents> web_contents,
                           bool should_set_delegate) {
   WebContents* raw_web_contents = web_contents.get();
   Shell* shell = new Shell(std::move(web_contents), should_set_delegate);
+#if BUILDFLAG(IS_COBALT)
+  return CreateShellFromPointer(shell, raw_web_contents, initial_size, should_set_delegate);
+}
+
+Shell* Shell::CreateShellFromPointer(Shell* shell, WebContents* raw_web_contents,
+                            const gfx::Size& initial_size,
+                            bool should_set_delegate) {
+#endif
   g_platform->CreatePlatformWindow(shell, initial_size);
 
   // Note: Do not make RenderFrameHost or RenderViewHost specific state changes

--- a/content/shell/browser/shell.h
+++ b/content/shell/browser/shell.h
@@ -196,6 +196,7 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
   class DevToolsWebContentsObserver;
 
 #if BUILDFLAG(IS_COBALT)
+  // TODO: b/87654321 - Cobalt: Remove these hacks as we remove Shell dependency
   // Cobalt Hack: make following members protected to be able to partially
   // customize Shell in a derived class.
 protected:

--- a/content/shell/browser/shell.h
+++ b/content/shell/browser/shell.h
@@ -195,16 +195,32 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
  private:
   class DevToolsWebContentsObserver;
 
+#if BUILDFLAG(IS_COBALT)
+  // Cobalt Hack: make following members protected to be able to partially
+  // customize Shell in a derived class.
+protected:
+#endif
   Shell(std::unique_ptr<WebContents> web_contents, bool should_set_delegate);
 
   // Helper to create a new Shell given a newly created WebContents.
   static Shell* CreateShell(std::unique_ptr<WebContents> web_contents,
                             const gfx::Size& initial_size,
                             bool should_set_delegate);
+#if BUILDFLAG(IS_COBALT)
+  // Cobalt Hack: Splits CreateShell to two parts, so a derived class instance can be
+  //              passed to factory function.
+  static Shell* CreateShellFromPointer(Shell * shell, WebContents* raw_web_contents,
+                            const gfx::Size& initial_size,
+                            bool should_set_delegate);
+#endif
 
   // Adjust the size when Blink sends 0 for width and/or height.
   // This happens when Blink requests a default-sized window.
   static gfx::Size AdjustWindowSize(const gfx::Size& initial_size);
+
+#if BUILDFLAG(IS_COBALT)
+private:
+#endif
 
   // Helper method for the two public LoadData methods.
   void LoadDataWithBaseURLInternal(const GURL& url,


### PR DESCRIPTION
Sets up a Cobalt specific Shell class and necessary wiring to provide an instance of it at startup. It's currently delegating most of the functionality to `content::Shell`.

`content::Shell` itself is currently hacked, as it's not designed or intended for sub-classing. This should be cleaned up in the future and Cobalt should fully own all of the related code to set up the shell.

The main immediate use is to be able to override `WebContentsObserver` events, like `PrimaryMainDocumentElementAvailable`.

b/384979128
b/390021478

