### PR TITLE
[media] Move concrete SbAudioSink impl to namespace

### DIFF
--- a/starboard/android/shared/application_android.cc
+++ b/starboard/android/shared/application_android.cc
@@ -68,7 +68,7 @@ ApplicationAndroid::ApplicationAndroid(
       "getResourceOverlay", "()Ldev/cobalt/coat/ResourceOverlay;");
   resource_overlay_ = env->ConvertLocalRefToGlobalRef(local_ref);
 
-  SbAudioSinkPrivate::Initialize();
+  ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::Initialize();
 
   app_start_timestamp_ = starboard_bridge_->GetAppStartTimestamp();
 

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -561,20 +561,30 @@ int AudioTrackAudioSinkType::GetMinBufferSizeInFramesInternal(
 }  // namespace android
 }  // namespace starboard
 
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace audio_sink {
+
 // static
-void SbAudioSinkPrivate::PlatformInitialize() {
+void SbAudioSinkImpl::PlatformInitialize() {
   SB_DCHECK(!audio_track_audio_sink_type_);
   audio_track_audio_sink_type_ =
-      new starboard::android::shared::AudioTrackAudioSinkType;
+      new ::starboard::android::shared::AudioTrackAudioSinkType;
   SetPrimaryType(audio_track_audio_sink_type_);
   EnableFallbackToStub();
   audio_track_audio_sink_type_->TestMinRequiredFrames();
 }
 
 // static
-void SbAudioSinkPrivate::PlatformTearDown() {
+void SbAudioSinkImpl::PlatformTearDown() {
   SB_DCHECK(audio_track_audio_sink_type_ == GetPrimaryType());
   SetPrimaryType(NULL);
   delete audio_track_audio_sink_type_;
   audio_track_audio_sink_type_ = NULL;
 }
+
+}  // namespace audio_sink
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -100,7 +100,8 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
   bool has_remote_audio_output_ = false;
 };
 
-class AudioTrackAudioSink : public SbAudioSinkPrivate {
+class AudioTrackAudioSink
+    : public ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl {
  public:
   AudioTrackAudioSink(
       Type* type,

--- a/starboard/android/shared/player_components_factory.h
+++ b/starboard/android/shared/player_components_factory.h
@@ -99,7 +99,8 @@ class AudioRendererSinkAndroid : public ::starboard::shared::starboard::player::
                 SbAudioSinkPrivate::ErrorFunc error_func,
                 void* context) {
               auto type = static_cast<AudioTrackAudioSinkType*>(
-                  SbAudioSinkPrivate::GetPreferredType());
+                  ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::
+                      GetPreferredType());
 
               return type->Create(
                   channels, sampling_frequency_hz, audio_sample_type,

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -27,7 +27,7 @@ namespace android {
 namespace shared {
 
 extern "C" SB_EXPORT_PLATFORM void JNI_StarboardBridge_OnStop(JNIEnv* env) {
-  SbAudioSinkPrivate::TearDown();
+  ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::TearDown();
   SbFileAndroidTeardown();
 }
 

--- a/starboard/linux/shared/audio_sink_type_dispatcher.cc
+++ b/starboard/linux/shared/audio_sink_type_dispatcher.cc
@@ -17,28 +17,38 @@
 #include "starboard/shared/pulse/pulse_audio_sink_type.h"
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace audio_sink {
 namespace {
 bool is_fallback_to_alsa = false;
-}
+}  // namespace
 
 // static
-void SbAudioSinkPrivate::PlatformInitialize() {
-  starboard::shared::pulse::PlatformInitialize();
+void SbAudioSinkImpl::PlatformInitialize() {
+  ::starboard::shared::pulse::PlatformInitialize();
   if (GetPrimaryType()) {
     SB_LOG(INFO) << "Use PulseAudio";
   } else {
     SB_LOG(INFO) << "Use ALSA";
-    starboard::shared::alsa::PlatformInitialize();
+    ::starboard::shared::alsa::PlatformInitialize();
     is_fallback_to_alsa = true;
   }
-  SbAudioSinkPrivate::EnableFallbackToStub();
+  ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::
+      EnableFallbackToStub();
 }
 
 // static
-void SbAudioSinkPrivate::PlatformTearDown() {
+void SbAudioSinkImpl::PlatformTearDown() {
   if (is_fallback_to_alsa) {
-    starboard::shared::alsa::PlatformTearDown();
+    ::starboard::shared::alsa::PlatformTearDown();
   } else {
-    starboard::shared::pulse::PlatformTearDown();
+    ::starboard::shared::pulse::PlatformTearDown();
   }
 }
+
+}  // namespace audio_sink
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/raspi/shared/application_dispmanx.cc
+++ b/starboard/raspi/shared/application_dispmanx.cc
@@ -68,12 +68,12 @@ bool ApplicationDispmanx::DestroyWindow(SbWindow window) {
 }
 
 void ApplicationDispmanx::Initialize() {
-  SbAudioSinkPrivate::Initialize();
+  ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::Initialize();
 }
 
 void ApplicationDispmanx::Teardown() {
   ShutdownDispmanx();
-  SbAudioSinkPrivate::TearDown();
+  ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::TearDown();
 }
 
 void ApplicationDispmanx ::OnSuspend() {

--- a/starboard/raspi/shared/audio_sink_type_dispatcher.cc
+++ b/starboard/raspi/shared/audio_sink_type_dispatcher.cc
@@ -15,13 +15,23 @@
 #include "starboard/shared/alsa/alsa_audio_sink_type.h"
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace audio_sink {
+
 // static
-void SbAudioSinkPrivate::PlatformInitialize() {
-  starboard::shared::alsa::PlatformInitialize();
+void SbAudioSinkImpl::PlatformInitialize() {
+  ::starboard::shared::alsa::PlatformInitialize();
   SbAudioSinkPrivate::EnableFallbackToStub();
 }
 
 // static
-void SbAudioSinkPrivate::PlatformTearDown() {
-  starboard::shared::alsa::PlatformTearDown();
+void SbAudioSinkImpl::PlatformTearDown() {
+  ::starboard::shared::alsa::PlatformTearDown();
 }
+
+}  // namespace audio_sink
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/pulse/pulse_audio_sink_type.cc
+++ b/starboard/shared/pulse/pulse_audio_sink_type.cc
@@ -53,6 +53,7 @@ namespace pulse {
 namespace {
 
 using starboard::media::GetBytesPerSample;
+using ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl;
 
 const int64_t kAudioIdleSleepIntervalUsec = 15'000;    // 15ms
 const int64_t kAudioRunningSleepIntervalUsec = 5'000;  // 5ms
@@ -65,7 +66,7 @@ const size_t kPulseBufferSizeInFrames = 8192;
 
 class PulseAudioSinkType;
 
-class PulseAudioSink : public SbAudioSinkPrivate {
+class PulseAudioSink : public SbAudioSinkImpl {
  public:
   PulseAudioSink(PulseAudioSinkType* type,
                  int channels,
@@ -554,7 +555,7 @@ void PulseAudioSinkType::StateCallback(pa_context* context, void* userdata) {
 void* PulseAudioSinkType::ThreadEntryPoint(void* context) {
   pthread_setname_np(pthread_self(), "pulse_audio");
 
-  shared::pthread::ThreadSetPriority(kSbThreadPriorityRealTime);
+  ::starboard::shared::pthread::ThreadSetPriority(kSbThreadPriorityRealTime);
 
   SB_DCHECK(context);
   PulseAudioSinkType* type = static_cast<PulseAudioSinkType*>(context);
@@ -602,16 +603,16 @@ void PlatformInitialize() {
       std::unique_ptr<PulseAudioSinkType>(new PulseAudioSinkType());
   if (audio_sink_type->Initialize()) {
     pulse_audio_sink_type_ = audio_sink_type.release();
-    SbAudioSinkPrivate::SetPrimaryType(pulse_audio_sink_type_);
+    SbAudioSinkImpl::SetPrimaryType(pulse_audio_sink_type_);
   }
 }
 
 // static
 void PlatformTearDown() {
   SB_DCHECK(pulse_audio_sink_type_);
-  SB_DCHECK(pulse_audio_sink_type_ == SbAudioSinkPrivate::GetPrimaryType());
+  SB_DCHECK(pulse_audio_sink_type_ == SbAudioSinkImpl::GetPrimaryType());
 
-  SbAudioSinkPrivate::SetPrimaryType(NULL);
+  SbAudioSinkImpl::SetPrimaryType(NULL);
   delete pulse_audio_sink_type_;
   pulse_audio_sink_type_ = NULL;
   pulse_unload_library();

--- a/starboard/shared/starboard/audio_sink/audio_sink_create.cc
+++ b/starboard/shared/starboard/audio_sink/audio_sink_create.cc
@@ -27,7 +27,7 @@ SbAudioSink SbAudioSinkCreate(
     SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
     SbAudioSinkConsumeFramesFunc consume_frames_func,
     void* context) {
-  return SbAudioSinkPrivate::Create(
+  return ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::Create(
       channels, sampling_frequency_hz, audio_sample_type,
       audio_frame_storage_type, frame_buffers, frame_buffers_size_in_frames,
       update_source_status_func, consume_frames_func, NULL /*error_func*/,

--- a/starboard/shared/starboard/audio_sink/audio_sink_destroy.cc
+++ b/starboard/shared/starboard/audio_sink/audio_sink_destroy.cc
@@ -18,16 +18,18 @@
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 
 void SbAudioSinkDestroy(SbAudioSink audio_sink) {
+  using ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl;
+
   if (audio_sink == kSbAudioSinkInvalid) {
     return;
   }
 
-  SbAudioSinkPrivate::Type* type = SbAudioSinkPrivate::GetPrimaryType();
+  SbAudioSinkPrivate::Type* type = SbAudioSinkImpl::GetPrimaryType();
   if (type && type->IsValid(audio_sink)) {
     type->Destroy(audio_sink);
     return;
   }
-  type = SbAudioSinkPrivate::GetFallbackType();
+  type = SbAudioSinkImpl::GetFallbackType();
   if (type && type->IsValid(audio_sink)) {
     type->Destroy(audio_sink);
     return;

--- a/starboard/shared/starboard/audio_sink/audio_sink_internal.cc
+++ b/starboard/shared/starboard/audio_sink/audio_sink_internal.cc
@@ -21,6 +21,10 @@
 #include "starboard/shared/starboard/audio_sink/stub_audio_sink_type.h"
 #include "starboard/shared/starboard/command_line.h"
 
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace audio_sink {
 namespace {
 
 using std::placeholders::_1;
@@ -28,8 +32,8 @@ using std::placeholders::_2;
 using std::placeholders::_3;
 
 bool is_fallback_to_stub_enabled;
-SbAudioSinkPrivate::Type* primary_audio_sink_type;
-SbAudioSinkPrivate::Type* fallback_audio_sink_type;
+SbAudioSinkImpl::Type* primary_audio_sink_type;
+SbAudioSinkImpl::Type* fallback_audio_sink_type;
 
 // Command line switch that controls whether we default to the stub audio sink,
 // even when the primary audio sink may be available.
@@ -45,36 +49,34 @@ void WrapConsumeFramesFunc(SbAudioSinkConsumeFramesFunc sb_consume_frames_func,
 
 }  // namespace
 
-using starboard::shared::starboard::audio_sink::StubAudioSinkType;
-
 // static
-void SbAudioSinkPrivate::Initialize() {
+void SbAudioSinkImpl::Initialize() {
   fallback_audio_sink_type = new StubAudioSinkType;
   PlatformInitialize();
 }
 
 // static
-void SbAudioSinkPrivate::TearDown() {
+void SbAudioSinkImpl::TearDown() {
   PlatformTearDown();
   delete fallback_audio_sink_type;
   fallback_audio_sink_type = NULL;
 }
 
 // static
-void SbAudioSinkPrivate::SetPrimaryType(Type* type) {
+void SbAudioSinkImpl::SetPrimaryType(Type* type) {
   primary_audio_sink_type = type;
 }
 
 // static
-SbAudioSinkPrivate::Type* SbAudioSinkPrivate::GetPrimaryType() {
+SbAudioSinkImpl::Type* SbAudioSinkImpl::GetPrimaryType() {
   return primary_audio_sink_type;
 }
 // static
-void SbAudioSinkPrivate::EnableFallbackToStub() {
+void SbAudioSinkImpl::EnableFallbackToStub() {
   is_fallback_to_stub_enabled = true;
 }
 // static
-SbAudioSinkPrivate::Type* SbAudioSinkPrivate::GetFallbackType() {
+SbAudioSinkImpl::Type* SbAudioSinkImpl::GetFallbackType() {
   if (is_fallback_to_stub_enabled) {
     return fallback_audio_sink_type;
   }
@@ -82,17 +84,16 @@ SbAudioSinkPrivate::Type* SbAudioSinkPrivate::GetFallbackType() {
 }
 
 // static
-SbAudioSinkPrivate::Type* SbAudioSinkPrivate::GetPreferredType() {
-  SbAudioSinkPrivate::Type* audio_sink_type = NULL;
-  auto command_line =
-      starboard::shared::starboard::Application::Get()->GetCommandLine();
+SbAudioSinkImpl::Type* SbAudioSinkImpl::GetPreferredType() {
+  SbAudioSinkImpl::Type* audio_sink_type = NULL;
+  auto command_line = Application::Get()->GetCommandLine();
   if (!command_line->HasSwitch(kUseStubAudioSink)) {
-    audio_sink_type = SbAudioSinkPrivate::GetPrimaryType();
+    audio_sink_type = SbAudioSinkImpl::GetPrimaryType();
   }
   if (!audio_sink_type) {
     SB_LOG(WARNING) << "Primary audio sink type not selected or missing, "
                        "opting to use Fallback instead.";
-    audio_sink_type = SbAudioSinkPrivate::GetFallbackType();
+    audio_sink_type = SbAudioSinkImpl::GetFallbackType();
   }
   if (audio_sink_type == NULL) {
     SB_LOG(WARNING) << "Fallback audio sink type is not enabled.";
@@ -100,7 +101,7 @@ SbAudioSinkPrivate::Type* SbAudioSinkPrivate::GetPreferredType() {
   return audio_sink_type;
 }
 
-SbAudioSink SbAudioSinkPrivate::Create(
+SbAudioSink SbAudioSinkImpl::Create(
     int channels,
     int sampling_frequency_hz,
     SbMediaAudioSampleType audio_sample_type,
@@ -169,7 +170,7 @@ SbAudioSink SbAudioSinkPrivate::Create(
   }
 
   SB_LOG(WARNING) << "Try to create AudioSink using fallback type.";
-  if (auto fallback_type = SbAudioSinkPrivate::GetFallbackType()) {
+  if (auto fallback_type = SbAudioSinkImpl::GetFallbackType()) {
     auto audio_sink = fallback_type->Create(
         channels, sampling_frequency_hz, audio_sample_type,
         audio_frame_storage_type, frame_buffers, frame_buffers_size_in_frames,
@@ -186,7 +187,7 @@ SbAudioSink SbAudioSinkPrivate::Create(
 }
 
 // static
-SbAudioSink SbAudioSinkPrivate::Create(
+SbAudioSink SbAudioSinkImpl::Create(
     int channels,
     int sampling_frequency_hz,
     SbMediaAudioSampleType audio_sample_type,
@@ -201,8 +202,13 @@ SbAudioSink SbAudioSinkPrivate::Create(
                 audio_frame_storage_type, frame_buffers,
                 frame_buffers_size_in_frames, update_source_status_func,
                 sb_consume_frames_func
-                    ? std::bind(&::WrapConsumeFramesFunc,
-                                sb_consume_frames_func, _1, _2, _3)
+                    ? std::bind(&WrapConsumeFramesFunc, sb_consume_frames_func,
+                                _1, _2, _3)
                     : ConsumeFramesFunc(),
                 error_func, context);
 }
+
+}  // namespace audio_sink
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/starboard/audio_sink/audio_sink_internal.h
+++ b/starboard/shared/starboard/audio_sink/audio_sink_internal.h
@@ -56,12 +56,19 @@ struct SbAudioSinkPrivate {
   };
 
   virtual ~SbAudioSinkPrivate() {}
+
   virtual void SetPlaybackRate(double playback_rate) = 0;
-
   virtual void SetVolume(double volume) = 0;
-
   virtual bool IsType(Type* type) = 0;
+};
 
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace audio_sink {
+
+class SbAudioSinkImpl : public SbAudioSinkPrivate {
+ public:
   // The following two functions will be called during application startup and
   // termination.
   static void Initialize();
@@ -111,5 +118,10 @@ struct SbAudioSinkPrivate {
   static void PlatformInitialize();
   static void PlatformTearDown();
 };
+
+}  // namespace audio_sink
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_STARBOARD_AUDIO_SINK_AUDIO_SINK_INTERNAL_H_

--- a/starboard/shared/starboard/audio_sink/audio_sink_is_valid.cc
+++ b/starboard/shared/starboard/audio_sink/audio_sink_is_valid.cc
@@ -17,11 +17,13 @@
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 
 bool SbAudioSinkIsValid(SbAudioSink audio_sink) {
-  SbAudioSinkPrivate::Type* type = SbAudioSinkPrivate::GetPrimaryType();
+  using ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl;
+
+  SbAudioSinkPrivate::Type* type = SbAudioSinkImpl::GetPrimaryType();
   if (type && type->IsValid(audio_sink)) {
     return true;
   }
-  type = SbAudioSinkPrivate::GetFallbackType();
+  type = SbAudioSinkImpl::GetFallbackType();
   if (type && type->IsValid(audio_sink)) {
     return true;
   }

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -39,7 +39,7 @@ AudioRendererSinkImpl::AudioRendererSinkImpl()
              SbAudioSinkPrivate::ConsumeFramesFunc consume_frames_func,
              SbAudioSinkPrivate::ErrorFunc error_func,
              void* context) {
-            return SbAudioSinkPrivate::Create(
+            return audio_sink::SbAudioSinkImpl::Create(
                 channels, sampling_frequency_hz, audio_sample_type,
                 audio_frame_storage_type, frame_buffers,
                 frame_buffers_size_in_frames, update_source_status_func,

--- a/starboard/shared/x11/application_x11.cc
+++ b/starboard/shared/x11/application_x11.cc
@@ -701,12 +701,12 @@ ApplicationX11::ApplicationX11(SbEventHandleCallback sb_event_handle_callback)
       composite_event_id_(kSbEventIdInvalid),
       display_(NULL),
       paste_buffer_key_release_pending_(false) {
-  SbAudioSinkPrivate::Initialize();
+  ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::Initialize();
   NetworkNotifier::GetOrCreateInstance();
 }
 
 ApplicationX11::~ApplicationX11() {
-  SbAudioSinkPrivate::TearDown();
+  ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl::TearDown();
 }
 
 SbWindow ApplicationX11::CreateWindow(const SbWindowOptions* options) {


### PR DESCRIPTION
SbAudioSink is a typedef to SbAudioSinkPrivate*, and the concrete implementation of SbAudioSinkPrivate was in the global namespace.  Now it's moved into a new class named SbAudioSinkImpl in the namespace starboard::shared::starboard::audio_sink, and it's derived from SbAudioSinkPrivate, which is now an interface.

This allows to have multiple SbAudioSink implementations in different namespaces.

b/327287075