### PR TITLE
[media] Rename SbMediaIs*Supported() functions

### DIFF
--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -50,6 +50,13 @@ It was only used by win32 platforms
 ### Removed starboad/atomic.h support for C.
 The existing code was migrated to C11 atomics.
 
+### Renamed `SbMediaIs*Supported()` functions
+`SbMediaIsAudioSupported()`, `SbMediaIsSupported()`, and
+`SbMediaIsVideoSupported()` were never part of the Starboard interface.
+Their Sb prefixes were removed and renamed to `MediaIsAudioSupported()`,
+`MediaIsSupported()`, and `MediaIsVideoSupported()`.  They are also moved from
+the global namespace into ::starboard::shared::starboard::media.
+
 ## Version 16
 A key update in Starboard version 16 is the adoption of POSIX APIs.
 For a full overview of Starboard POSIX migrations, please refer to

--- a/starboard/android/shared/media_is_audio_supported.cc
+++ b/starboard/android/shared/media_is_audio_supported.cc
@@ -22,13 +22,17 @@
 #include "starboard/configuration_constants.h"
 #include "starboard/media.h"
 
-using starboard::android::shared::MediaCapabilitiesCache;
-using starboard::android::shared::SupportedAudioCodecToMimeType;
-using starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsAudioSupported(SbMediaAudioCodec audio_codec,
-                             const MimeType* mime_type,
-                             int64_t bitrate) {
+using ::starboard::android::shared::MediaCapabilitiesCache;
+using ::starboard::android::shared::SupportedAudioCodecToMimeType;
+
+bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
+                           const MimeType* mime_type,
+                           int64_t bitrate) {
   if (bitrate >= kSbMediaMaxAudioBitrateInBitsPerSecond) {
     return false;
   }
@@ -80,3 +84,8 @@ bool SbMediaIsAudioSupported(SbMediaAudioCodec audio_codec,
   return MediaCapabilitiesCache::GetInstance()->IsPassthroughSupported(
       audio_codec);
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/android/shared/media_is_supported.cc
+++ b/starboard/android/shared/media_is_supported.cc
@@ -21,13 +21,17 @@
 #include "starboard/media.h"
 #include "starboard/shared/starboard/media/mime_type.h"
 
-bool SbMediaIsSupported(SbMediaVideoCodec video_codec,
-                        SbMediaAudioCodec audio_codec,
-                        const char* key_system) {
-  using starboard::android::shared::IsWidevineL1;
-  using starboard::android::shared::IsWidevineL3;
-  using starboard::android::shared::MediaCapabilitiesCache;
-  using starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
+
+bool MediaIsSupported(SbMediaVideoCodec video_codec,
+                      SbMediaAudioCodec audio_codec,
+                      const char* key_system) {
+  using ::starboard::android::shared::IsWidevineL1;
+  using ::starboard::android::shared::IsWidevineL3;
+  using ::starboard::android::shared::MediaCapabilitiesCache;
 
   // It is possible that the |key_system| comes with extra attributes, like
   // `com.widevine.alpha; encryptionscheme="cenc"`. We prepend "key_system/"
@@ -64,3 +68,8 @@ bool SbMediaIsSupported(SbMediaVideoCodec video_codec,
 
   return true;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/android/shared/media_is_video_supported.cc
+++ b/starboard/android/shared/media_is_video_supported.cc
@@ -21,25 +21,28 @@
 #include "starboard/media.h"
 #include "starboard/shared/starboard/media/media_util.h"
 
-using starboard::android::shared::MaxMediaCodecOutputBuffersLookupTable;
-using starboard::android::shared::MediaCapabilitiesCache;
-using starboard::android::shared::SupportedVideoCodecToMimeType;
-using starboard::shared::starboard::media::IsSDRVideo;
-using starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
-                             const MimeType* mime_type,
-                             int profile,
-                             int level,
-                             int bit_depth,
-                             SbMediaPrimaryId primary_id,
-                             SbMediaTransferId transfer_id,
-                             SbMediaMatrixId matrix_id,
-                             int frame_width,
-                             int frame_height,
-                             int64_t bitrate,
-                             int fps,
-                             bool decode_to_texture_required) {
+using ::starboard::android::shared::MaxMediaCodecOutputBuffersLookupTable;
+using ::starboard::android::shared::MediaCapabilitiesCache;
+using ::starboard::android::shared::SupportedVideoCodecToMimeType;
+
+bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
+                           const MimeType* mime_type,
+                           int profile,
+                           int level,
+                           int bit_depth,
+                           SbMediaPrimaryId primary_id,
+                           SbMediaTransferId transfer_id,
+                           SbMediaMatrixId matrix_id,
+                           int frame_width,
+                           int frame_height,
+                           int64_t bitrate,
+                           int fps,
+                           bool decode_to_texture_required) {
   const bool must_support_hdr =
       !IsSDRVideo(bit_depth, primary_id, transfer_id, matrix_id);
   if (must_support_hdr &&
@@ -115,3 +118,8 @@ bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
       mime, require_secure_playback, must_support_hdr, must_support_tunnel_mode,
       frame_width, frame_height, bitrate, fps);
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/linux/shared/media_is_audio_supported.cc
+++ b/starboard/linux/shared/media_is_audio_supported.cc
@@ -19,11 +19,14 @@
 #include "starboard/configuration_constants.h"
 #include "starboard/media.h"
 
-using ::starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsAudioSupported(SbMediaAudioCodec audio_codec,
-                             const MimeType* mime_type,
-                             int64_t bitrate) {
+bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
+                           const MimeType* mime_type,
+                           int64_t bitrate) {
   if (audio_codec == kSbMediaAudioCodecAac) {
     return bitrate <= kSbMediaMaxAudioBitrateInBitsPerSecond;
   }
@@ -52,3 +55,8 @@ bool SbMediaIsAudioSupported(SbMediaAudioCodec audio_codec,
 
   return false;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/linux/shared/media_is_video_supported.cc
+++ b/starboard/linux/shared/media_is_video_supported.cc
@@ -22,23 +22,26 @@
 #include "starboard/shared/libde265/de265_library_loader.h"
 #include "starboard/shared/starboard/media/media_util.h"
 
-using ::starboard::shared::de265::is_de265_supported;
-using ::starboard::shared::starboard::media::IsSDRVideo;
-using ::starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
-                             const MimeType* mime_type,
-                             int profile,
-                             int level,
-                             int bit_depth,
-                             SbMediaPrimaryId primary_id,
-                             SbMediaTransferId transfer_id,
-                             SbMediaMatrixId matrix_id,
-                             int frame_width,
-                             int frame_height,
-                             int64_t bitrate,
-                             int fps,
-                             bool decode_to_texture_required) {
+using ::starboard::shared::de265::is_de265_supported;
+
+bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
+                           const MimeType* mime_type,
+                           int profile,
+                           int level,
+                           int bit_depth,
+                           SbMediaPrimaryId primary_id,
+                           SbMediaTransferId transfer_id,
+                           SbMediaMatrixId matrix_id,
+                           int frame_width,
+                           int frame_height,
+                           int64_t bitrate,
+                           int fps,
+                           bool decode_to_texture_required) {
   if (!IsSDRVideo(bit_depth, primary_id, transfer_id, matrix_id)) {
     if (bit_depth != 10 && bit_depth != 12) {
       return false;
@@ -68,3 +71,8 @@ bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
          frame_width <= 1920 && frame_height <= 1080 &&
          bitrate <= kSbMediaMaxVideoBitrateInBitsPerSecond && fps <= 60;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/raspi/shared/media_is_video_supported.cc
+++ b/starboard/raspi/shared/media_is_video_supported.cc
@@ -19,22 +19,24 @@
 #include "starboard/media.h"
 #include "starboard/shared/starboard/media/media_util.h"
 
-using ::starboard::shared::starboard::media::IsSDRVideo;
-using ::starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
-                             const MimeType* mime_type,
-                             int profile,
-                             int level,
-                             int bit_depth,
-                             SbMediaPrimaryId primary_id,
-                             SbMediaTransferId transfer_id,
-                             SbMediaMatrixId matrix_id,
-                             int frame_width,
-                             int frame_height,
-                             int64_t bitrate,
-                             int fps,
-                             bool decode_to_texture_required) {
+bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
+                           const MimeType* mime_type,
+                           int profile,
+                           int level,
+                           int bit_depth,
+                           SbMediaPrimaryId primary_id,
+                           SbMediaTransferId transfer_id,
+                           SbMediaMatrixId matrix_id,
+                           int frame_width,
+                           int frame_height,
+                           int64_t bitrate,
+                           int fps,
+                           bool decode_to_texture_required) {
   if (!IsSDRVideo(bit_depth, primary_id, transfer_id, matrix_id)) {
     return false;
   }
@@ -46,3 +48,8 @@ bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
          frame_height <= 1080 &&
          bitrate <= kSbMediaMaxVideoBitrateInBitsPerSecond && fps <= 30;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/starboard/media/media_is_audio_supported_aac_and_opus.cc
+++ b/starboard/shared/starboard/media/media_is_audio_supported_aac_and_opus.cc
@@ -18,11 +18,14 @@
 #include "starboard/configuration_constants.h"
 #include "starboard/media.h"
 
-using ::starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsAudioSupported(SbMediaAudioCodec audio_codec,
-                             const MimeType* mime_type,
-                             int64_t bitrate) {
+bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
+                           const MimeType* mime_type,
+                           int64_t bitrate) {
   if (audio_codec == kSbMediaAudioCodecAac) {
     return bitrate <= kSbMediaMaxAudioBitrateInBitsPerSecond;
   }
@@ -33,3 +36,8 @@ bool SbMediaIsAudioSupported(SbMediaAudioCodec audio_codec,
 
   return false;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/starboard/media/media_is_audio_supported_aac_only.cc
+++ b/starboard/shared/starboard/media/media_is_audio_supported_aac_only.cc
@@ -18,11 +18,19 @@
 #include "starboard/configuration_constants.h"
 #include "starboard/media.h"
 
-using ::starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsAudioSupported(SbMediaAudioCodec audio_codec,
-                             const MimeType* mime_type,
-                             int64_t bitrate) {
+bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
+                           const MimeType* mime_type,
+                           int64_t bitrate) {
   return audio_codec == kSbMediaAudioCodecAac &&
          bitrate <= kSbMediaMaxAudioBitrateInBitsPerSecond;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/starboard/media/media_support_internal.h
+++ b/starboard/shared/starboard/media/media_support_internal.h
@@ -20,9 +20,10 @@
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/media/mime_type.h"
 
-#ifdef __cplusplus
-extern "C" {
-#endif
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
 // Indicates whether this platform supports decoding |video_codec| and
 // |audio_codec| along with decrypting using |key_system|. If |video_codec| is
@@ -35,9 +36,9 @@ extern "C" {
 // |audio_codec|: The |SbMediaAudioCodec| being checked for platform
 //                compatibility.
 // |key_system|: The key system being checked for platform compatibility.
-SB_EXPORT bool SbMediaIsSupported(SbMediaVideoCodec video_codec,
-                                  SbMediaAudioCodec audio_codec,
-                                  const char* key_system);
+SB_EXPORT bool MediaIsSupported(SbMediaVideoCodec video_codec,
+                                SbMediaAudioCodec audio_codec,
+                                const char* key_system);
 
 // Indicates whether a given combination of (|frame_width| x |frame_height|)
 // frames at |bitrate| and |fps| is supported on this platform with
@@ -73,20 +74,19 @@ SB_EXPORT bool SbMediaIsSupported(SbMediaVideoCodec video_codec,
 //        it indicates that the fps shouldn't be considered.
 // |decode_to_texture_required|: Whether or not the resulting video frames can
 //                               be decoded and used as textures by the GPU.
-bool SbMediaIsVideoSupported(
-    SbMediaVideoCodec video_codec,
-    const starboard::shared::starboard::media::MimeType* mime_type,
-    int profile,
-    int level,
-    int bit_depth,
-    SbMediaPrimaryId primary_id,
-    SbMediaTransferId transfer_id,
-    SbMediaMatrixId matrix_id,
-    int frame_width,
-    int frame_height,
-    int64_t bitrate,
-    int fps,
-    bool decode_to_texture_required);
+bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
+                           const MimeType* mime_type,
+                           int profile,
+                           int level,
+                           int bit_depth,
+                           SbMediaPrimaryId primary_id,
+                           SbMediaTransferId transfer_id,
+                           SbMediaMatrixId matrix_id,
+                           int frame_width,
+                           int frame_height,
+                           int64_t bitrate,
+                           int fps,
+                           bool decode_to_texture_required);
 
 // Indicates whether this platform supports |audio_codec| at |bitrate|.
 // If |audio_codec| is not supported under any condition, this function
@@ -96,13 +96,13 @@ bool SbMediaIsVideoSupported(
 // |mime_type|: The parsed mime type passed to the corresponding interface.
 //              Note that |mime_type| can be NULL.
 // |bitrate|: The media's bitrate.
-bool SbMediaIsAudioSupported(
-    SbMediaAudioCodec audio_codec,
-    const starboard::shared::starboard::media::MimeType* mime_type,
-    int64_t bitrate);
+bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
+                           const MimeType* mime_type,
+                           int64_t bitrate);
 
-#ifdef __cplusplus
-}  // extern "C"
-#endif
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_STARBOARD_MEDIA_MEDIA_SUPPORT_INTERNAL_H_

--- a/starboard/shared/starboard/media/mime_util.cc
+++ b/starboard/shared/starboard/media/mime_util.cc
@@ -59,7 +59,7 @@ bool IsSupportedKeySystem(SbMediaAudioCodec codec, const char* key_system) {
   // |key_system|, so here it should always be non empty.
   SB_DCHECK(strlen(key_system) > 0);
 
-  return SbMediaIsSupported(kSbMediaVideoCodecNone, codec, key_system);
+  return MediaIsSupported(kSbMediaVideoCodecNone, codec, key_system);
 }
 
 bool IsSupportedKeySystem(SbMediaVideoCodec codec, const char* key_system) {
@@ -68,7 +68,7 @@ bool IsSupportedKeySystem(SbMediaVideoCodec codec, const char* key_system) {
   // |key_system|, so here it should always be non empty.
   SB_DCHECK(strlen(key_system) > 0);
 
-  return SbMediaIsSupported(codec, kSbMediaAudioCodecNone, key_system);
+  return MediaIsSupported(codec, kSbMediaAudioCodecNone, key_system);
 }
 
 bool IsSupportedAudioCodec(const ParsedMimeInfo& mime_info) {
@@ -123,8 +123,8 @@ bool IsSupportedAudioCodec(const ParsedMimeInfo& mime_info) {
     return false;
   }
 
-  return SbMediaIsAudioSupported(audio_info.codec, &mime_type,
-                                 audio_info.bitrate);
+  return MediaIsAudioSupported(audio_info.codec, &mime_type,
+                               audio_info.bitrate);
 }
 
 bool IsSupportedVideoCodec(const ParsedMimeInfo& mime_info) {
@@ -175,7 +175,7 @@ bool IsSupportedVideoCodec(const ParsedMimeInfo& mime_info) {
     }
   }
 
-  return SbMediaIsVideoSupported(
+  return MediaIsVideoSupported(
       video_info.codec, &mime_type, video_info.profile, video_info.level,
       video_info.bit_depth, video_info.primary_id, video_info.transfer_id,
       video_info.matrix_id, video_info.frame_width, video_info.frame_height,

--- a/starboard/shared/starboard/media/mime_util_test.cc
+++ b/starboard/shared/starboard/media/mime_util_test.cc
@@ -35,8 +35,7 @@ TEST(MimeUtilTest, ChecksSupportedMp3Containers) {
   const MimeType valid_mp3_mime_1(valid_mp3_mime_str_1);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_mp3_mime_str_1.c_str(), kEmptyKeySystem),
-      SbMediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_mp3_mime_1,
-                              kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_mp3_mime_1, kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 
@@ -45,8 +44,7 @@ TEST(MimeUtilTest, ChecksSupportedMp3Containers) {
   const MimeType valid_mp3_mime_2(valid_mp3_mime_str_2);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_mp3_mime_str_2.c_str(), kEmptyKeySystem),
-      SbMediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_mp3_mime_2,
-                              kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_mp3_mime_2, kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 }
@@ -67,8 +65,7 @@ TEST(MimeUtilTest, ChecksSupportedFlacContainers) {
   const MimeType valid_flac_mime_1(valid_flac_mime_str_1);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_flac_mime_str_1.c_str(), kEmptyKeySystem),
-      SbMediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_flac_mime_1,
-                              kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_flac_mime_1, kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 
@@ -77,8 +74,7 @@ TEST(MimeUtilTest, ChecksSupportedFlacContainers) {
   const MimeType valid_flac_mime_2(valid_flac_mime_str_2);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_flac_mime_str_2.c_str(), kEmptyKeySystem),
-      SbMediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_flac_mime_2,
-                              kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_flac_mime_2, kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 }
@@ -99,7 +95,7 @@ TEST(MimeUtilTest, ChecksSupportedPcmContainers) {
   const MimeType valid_pcm_mime(valid_pcm_mime_str);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_pcm_mime_str.c_str(), kEmptyKeySystem),
-      SbMediaIsAudioSupported(kSbMediaAudioCodecPcm, &valid_pcm_mime, kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecPcm, &valid_pcm_mime, kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 }

--- a/starboard/shared/starboard/player/filter/testing/test_util.cc
+++ b/starboard/shared/starboard/player/filter/testing/test_util.cc
@@ -143,8 +143,8 @@ std::vector<const char*> GetSupportedAudioTestFiles(
     const std::string audio_mime = GetContentTypeFromAudioCodec(
         audio_file_info.audio_codec, extra_mime_attributes);
     const MimeType audio_mime_type(audio_mime.c_str());
-    if (!SbMediaIsAudioSupported(audio_file_info.audio_codec, &audio_mime_type,
-                                 audio_file_info.bitrate)) {
+    if (!MediaIsAudioSupported(audio_file_info.audio_codec, &audio_mime_type,
+                               audio_file_info.bitrate)) {
       continue;
     }
 
@@ -186,7 +186,7 @@ std::vector<VideoTestParam> GetSupportedVideoTests() {
       const auto& video_stream_info = dmp_reader.video_stream_info();
       const std::string video_mime = dmp_reader.video_mime_type();
       const MimeType video_mime_type(video_mime.c_str());
-      // SbMediaIsVideoSupported may return false for gpu based decoder that in
+      // MediaIsVideoSupported may return false for gpu based decoder that in
       // fact supports av1 or/and vp9 because the system can make async
       // initialization at startup.
       // To minimize probability of false negative we check result few times
@@ -196,7 +196,7 @@ std::vector<VideoTestParam> GetSupportedVideoTests() {
       bool need_to_check_with_wait = video_codec == kSbMediaVideoCodecAv1 ||
                                      video_codec == kSbMediaVideoCodecVp9;
       do {
-        if (SbMediaIsVideoSupported(
+        if (MediaIsVideoSupported(
                 video_codec, video_mime.size() > 0 ? &video_mime_type : nullptr,
                 -1, -1, 8, kSbMediaPrimaryIdUnspecified,
                 kSbMediaTransferIdUnspecified, kSbMediaMatrixIdUnspecified,

--- a/starboard/shared/starboard/player/player_create.cc
+++ b/starboard/shared/starboard/player/player_create.cc
@@ -132,7 +132,7 @@ SbPlayer SbPlayerCreate(SbWindow window,
   const int64_t kDefaultBitRate = 0;
   if (audio_codec != kSbMediaAudioCodecNone) {
     const MimeType audio_mime_type(audio_mime);
-    if (!SbMediaIsAudioSupported(
+    if (!MediaIsAudioSupported(
             audio_codec, strlen(audio_mime) > 0 ? &audio_mime_type : nullptr,
             kDefaultBitRate)) {
       SB_LOG(ERROR) << "Unsupported audio codec "
@@ -154,7 +154,7 @@ SbPlayer SbPlayerCreate(SbWindow window,
   const int kDefaultFrameRate = 0;
   if (video_codec != kSbMediaVideoCodecNone) {
     const MimeType video_mime_type(video_mime);
-    if (!SbMediaIsVideoSupported(
+    if (!MediaIsVideoSupported(
             video_codec, strlen(video_mime) > 0 ? &video_mime_type : nullptr,
             kDefaultProfile, kDefaultLevel, kDefaultColorDepth,
             kSbMediaPrimaryIdUnspecified, kSbMediaTransferIdUnspecified,

--- a/starboard/shared/stub/media_is_audio_supported.cc
+++ b/starboard/shared/stub/media_is_audio_supported.cc
@@ -16,10 +16,18 @@
 
 #include "starboard/media.h"
 
-using ::starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsAudioSupported(SbMediaAudioCodec audio_codec,
-                             const MimeType* mime_type,
-                             int64_t bitrate) {
+bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
+                           const MimeType* mime_type,
+                           int64_t bitrate) {
   return false;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/stub/media_is_supported.cc
+++ b/starboard/shared/stub/media_is_supported.cc
@@ -16,8 +16,18 @@
 
 #include "starboard/media.h"
 
-bool SbMediaIsSupported(SbMediaVideoCodec video_codec,
-                        SbMediaAudioCodec audio_codec,
-                        const char* key_system) {
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
+
+bool MediaIsSupported(SbMediaVideoCodec video_codec,
+                      SbMediaAudioCodec audio_codec,
+                      const char* key_system) {
   return false;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/stub/media_is_video_supported.cc
+++ b/starboard/shared/stub/media_is_video_supported.cc
@@ -16,20 +16,28 @@
 
 #include "starboard/media.h"
 
-using ::starboard::shared::starboard::media::MimeType;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
 
-bool SbMediaIsVideoSupported(SbMediaVideoCodec video_codec,
-                             const MimeType* mime_type,
-                             int profile,
-                             int level,
-                             int bit_depth,
-                             SbMediaPrimaryId primary_id,
-                             SbMediaTransferId transfer_id,
-                             SbMediaMatrixId matrix_id,
-                             int frame_width,
-                             int frame_height,
-                             int64_t bitrate,
-                             int fps,
-                             bool decode_to_texture_required) {
+bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
+                           const MimeType* mime_type,
+                           int profile,
+                           int level,
+                           int bit_depth,
+                           SbMediaPrimaryId primary_id,
+                           SbMediaTransferId transfer_id,
+                           SbMediaMatrixId matrix_id,
+                           int frame_width,
+                           int frame_height,
+                           int64_t bitrate,
+                           int fps,
+                           bool decode_to_texture_required) {
   return false;
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/widevine/media_is_supported.cc
+++ b/starboard/shared/widevine/media_is_supported.cc
@@ -17,10 +17,20 @@
 #include "starboard/media.h"
 #include "starboard/shared/widevine/drm_system_widevine.h"
 
-bool SbMediaIsSupported(SbMediaVideoCodec video_codec,
-                        SbMediaAudioCodec audio_codec,
-                        const char* key_system) {
-  using starboard::shared::widevine::DrmSystemWidevine;
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace media {
+
+bool MediaIsSupported(SbMediaVideoCodec video_codec,
+                      SbMediaAudioCodec audio_codec,
+                      const char* key_system) {
+  using ::starboard::shared::widevine::DrmSystemWidevine;
 
   return DrmSystemWidevine::IsKeySystemSupported(key_system);
 }
+
+}  // namespace media
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard


### PR DESCRIPTION
`SbMediaIsAudioSupported()`, `SbMediaIsSupported()`, and `SbMediaIsVideoSupported()` were never part of the Starboard interface.

Their Sb prefixes were removed and renamed to `MediaIsAudioSupported()`, `MediaIsSupported()`, and `MediaIsVideoSupported()`.  They are also moved from the global namespace into ::starboard::shared::starboard::media.

There are no functional changes in this PR.

b/327287075