### PR TITLE
Fix typo in HTMLMediaElement::GetSupportsType()

### DIFF
--- a/third_party/blink/renderer/core/html/media/html_media_element.cc
+++ b/third_party/blink/renderer/core/html/media/html_media_element.cc
@@ -432,7 +432,7 @@ bool IsProgressiveFormat(const ContentType& content_type) {
 MIMETypeRegistry::SupportsType HTMLMediaElement::GetSupportsType(
     const ContentType& content_type) {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  // Interupt Chromium's IsTypeSupported() from here for better performance.
+  // Interrupt Chromium's IsTypeSupported() from here for better performance.
   MIMETypeRegistry::SupportsType result;
   if (!base::FeatureList::IsEnabled(media::kCobaltProgressivePlayback) &&
       IsProgressiveFormat(content_type)) {


### PR DESCRIPTION
Replace "interupt" with "interrupt".

b/276483058