### PR TITLE
Draft: Missing perfetto init

### DIFF
--- a/base/trace_event/trace_log.cc
+++ b/base/trace_event/trace_log.cc
@@ -853,6 +853,7 @@ void TraceLog::SetEnabled(const TraceConfig& trace_config,
   source_chrome_config->set_convert_to_legacy_json(true);
 
   if (trace_config.GetTraceRecordMode() == base::trace_event::ECHO_TO_CONSOLE) {
+    InitializePerfettoIfNeeded();
     perfetto::ConsoleInterceptor::Register();
     source_config->mutable_interceptor_config()->set_name("console");
   }


### PR DESCRIPTION
Trying to run with 

```
--single-process --enable-tracing  --trace-to-console
```

Needed to add this flag. It's odd that it doesnt "just work"