### PR TITLE
[android] Change 'device type' field in UA string from ATV to TV|STB|OTT

### DIFF
--- a/starboard/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -110,6 +110,8 @@ public class StarboardBridge {
   private final boolean isAmatiDevice;
   private static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone("America/Los_Angeles");
   private final long timeNanosecondsPerMicrosecond = 1000;
+  private static final String FEATURE_OPERATOR_TIER = "com.google.android.tv.operator_tier";
+  private final boolean isOperatorTier;
 
   public StarboardBridge(
       Context appContext,
@@ -139,6 +141,7 @@ public class StarboardBridge {
     this.advertisingId = new AdvertisingId(appContext);
     this.volumeStateReceiver = new VolumeStateReceiver(appContext);
     this.isAmatiDevice = appContext.getPackageManager().hasSystemFeature(AMATI_EXPERIENCE_FEATURE);
+    this.isOperatorTier = appContext.getPackageManager().hasSystemFeature(FEATURE_OPERATOR_TIER);
   }
 
   private native boolean nativeInitialize();
@@ -793,6 +796,12 @@ public class StarboardBridge {
   @UsedByNative
   protected boolean getIsAmatiDevice() {
     return this.isAmatiDevice;
+  }
+
+  @SuppressWarnings("unused")
+  @UsedByNative
+  protected boolean getOperatorTier() {
+    return this.isOperatorTier;
   }
 
   @SuppressWarnings("unused")


### PR DESCRIPTION
Changes device type in User-Agent from "ATV" to more detailed "TV" (has a display), "OTT" (no display), or "STB" (operator devices, disregard required to have a tuner).

b/130328173