### PR TITLE
Ozone: Only use Starboard platform

### DIFF
--- a/cobalt/build/configs/linux-x64x11/args.gn
+++ b/cobalt/build/configs/linux-x64x11/args.gn
@@ -2,9 +2,11 @@ import("//cobalt/build/configs/chromium_linux-x64x11/args.gn")
 import("//cobalt/build/configs/common.gn")
 
 use_ozone = true
+ozone_auto_platforms = false
+ozone_platform = "starboard"
 
 # Vulkan is a new rendering (and presentation, and more) API intended to replace
-# E/GL(ES). Partners are only required to support upto GLES 2.0 : https://developers.google.com/youtube/cobalt/docs/reference/starboard/modules/16/gles#gles_version
+# E/GL(ES). Partners are only required to support up to GLES 2.0 : https://developers.google.com/youtube/cobalt/docs/reference/starboard/modules/16/gles#gles_version
 # Disable Vulkan until we formally decide to support it.
 enable_vulkan = false
 
@@ -18,6 +20,10 @@ enable_nacl = false
 
 # Overriding the flag from //ui/gl/features.gni
 use_static_angle = true
+
+# Angle supports multiple backends. If Vulkan is engaged (for tests, SwAngle),
+# then we don't want to have a real display.
+angle_use_vulkan_null_display = true
 
 # Disable udev
 use_udev = false

--- a/ui/ozone/platform/starboard/ozone_platform_starboard.cc
+++ b/ui/ozone/platform/starboard/ozone_platform_starboard.cc
@@ -173,8 +173,6 @@ OzonePlatform* CreateOzonePlatformStarboard() {
     CHECK_EQ(cmd->GetSwitchValueASCII(switches::kUseGL),
              gl::kGLImplementationANGLEName)
         << " Unsupported " << switches::kUseGL << " implementation";
-  } else {
-    cmd->AppendSwitchASCII(switches::kUseGL, gl::kGLImplementationANGLEName);
   }
 
   return new OzonePlatformStarboard();


### PR DESCRIPTION
This CL removes Ozone auto platforms and leaves only Starboard.

This in turn removes Angle X11 support (see [GN logic here](https://source.chromium.org/chromium/chromium/src/+/main:third_party/angle/gni/angle.gni;l=73;drc=e7833a01ab43a31d617335c03e11b81e2881f592)). Many unittests that are passing on ToT start failing as consequence, concretely I tried `cc_unittests`, `viz_unittests`, `gpu_unittests`, `gl_unittests` and `ozone_unittests`.

The first reason for failing is that `ozone_platform_starboard.cc` starts failing due to injecting the flag which hits this [DCHECK](https://source.chromium.org/chromium/chromium/src/+/main:ui/gl/test/gl_surface_test_support.cc;l=66-67;drc=eae2dfb04527c1c491806bc3094181c0af76734d). Once that injection is removed, then the `InitializeOneOffHelper()` logic (which is only used for tests) tries to initialize Angle Sw backend, SwANGLE, which is what we want for _unit_ tests (of course not for integration tests).

This SwANGLE in turn fails due to trying to initialize the actual machine Display. We don't want that for unit tests, so a new GN flag needs to be added to tell Angle to not draw on the screen when using SwANGLE: `angle_use_vulkan_null_display` is also set in this CL (SwANGLE uses vulkan behind the scenes).

With this CL `cc_unittests`, `viz_unittests`, `gpu_unittests`, `gl_unittests` and `ozone_unittests` are passing on my gLinux (amd, mesa radeon etc).


