### PR TITLE
android: Support decode-to-texture Mode

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -58,6 +58,10 @@ if (is_win) {
   import("//build/config/win/control_flow_guard.gni")
 }
 
+if (is_cobalt) {
+  import("//starboard/build/buildflags.gni")
+}
+
 declare_args() {
   # Unsafe developer build. Has developer-friendly features that may weaken or
   # disable security measures like sandboxing or ASLR.

--- a/base/threading/thread_restrictions.h
+++ b/base/threading/thread_restrictions.h
@@ -313,6 +313,9 @@ class AudioOutputDevice;
 class BlockingUrlProtocol;
 class FileVideoCaptureDeviceFactory;
 class MojoVideoEncodeAccelerator;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+class StarboardRendererWrapper;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 class PaintCanvasVideoRenderer;
 }  // namespace media
 namespace memory_instrumentation {
@@ -770,6 +773,9 @@ class BASE_EXPORT [[maybe_unused, nodiscard]] ScopedAllowBaseSyncPrimitives {
   friend class media::AudioOutputDevice;
   friend class media::BlockingUrlProtocol;
   friend class media::MojoVideoEncodeAccelerator;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  friend class media::StarboardRendererWrapper;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   friend class mojo::core::ScopedIPCSupport;
   friend class net::MultiThreadedCertVerifierScopedAllowBaseSyncPrimitives;
   friend class rlz_lib::FinancialPing;
@@ -853,6 +859,9 @@ class BASE_EXPORT
   friend class media::AudioInputDevice;
   friend class media::AudioOutputDevice;
   friend class media::PaintCanvasVideoRenderer;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  friend class media::StarboardRendererWrapper;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   friend class mojo::SyncCallRestrictions;
   friend class mojo::core::ipcz_driver::MojoTrap;
   friend class net::NetworkConfigWatcherMacThread;

--- a/gpu/command_buffer/service/BUILD.gn
+++ b/gpu/command_buffer/service/BUILD.gn
@@ -9,6 +9,10 @@ import("//third_party/dawn/scripts/dawn_features.gni")
 import("//third_party/protobuf/proto_library.gni")
 import("//ui/gl/features.gni")
 
+if (is_cobalt) {
+  import("//starboard/build/buildflags.gni")
+}
+
 group("service") {
   if (is_component_build) {
     public_deps = [ "//gpu" ]
@@ -302,6 +306,13 @@ target(link_target_type, "gles2_sources") {
       "validating_abstract_texture_impl.cc",
       "validating_abstract_texture_impl.h",
     ]
+
+    if (is_cobalt && use_starboard_media) {
+      sources += [
+        "shared_image/starboard/starboard_video_image_backing.cc",
+        "shared_image/starboard/starboard_video_image_backing.h",
+      ]
+    }
   } else {
     sources += [
       "abstract_texture_android.cc",

--- a/gpu/command_buffer/service/shared_image/starboard/starboard_video_image_backing.cc
+++ b/gpu/command_buffer/service/shared_image/starboard/starboard_video_image_backing.cc
@@ -1,0 +1,155 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gpu/command_buffer/service/shared_image/starboard/starboard_video_image_backing.h"
+
+#include "base/task/single_thread_task_runner.h"
+#include "components/viz/common/resources/resource_sizes.h"
+#include "gpu/command_buffer/common/shared_image_usage.h"
+#include "gpu/command_buffer/service/memory_tracking.h"
+#include "gpu/command_buffer/service/shared_context_state.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_representation.h"
+#include "gpu/command_buffer/service/shared_image/skia_gl_image_representation.h"
+#include "gpu/command_buffer/service/skia_utils.h"
+#include "gpu/command_buffer/service/texture_manager.h"
+#include "ui/gl/gl_utils.h"
+
+namespace gpu {
+
+// Representation of StarboardVideoImageBacking as a GL Texture.
+class StarboardVideoImageBacking::GLTexturePassthroughVideoImageRepresentation
+    : public GLTexturePassthroughImageRepresentation {
+ public:
+  GLTexturePassthroughVideoImageRepresentation(
+      SharedImageManager* manager,
+      StarboardVideoImageBacking* backing,
+      MemoryTypeTracker* tracker,
+      std::vector<scoped_refptr<gpu::gles2::TexturePassthrough>> textures)
+      : GLTexturePassthroughImageRepresentation(manager, backing, tracker),
+        passthrough_textures_(std::move(textures)) {
+    for (auto& passthrough_texture : passthrough_textures_) {
+      CHECK(passthrough_texture);
+    }
+  }
+
+  ~GLTexturePassthroughVideoImageRepresentation() override {}
+
+  // Disallow copy and assign.
+  GLTexturePassthroughVideoImageRepresentation(
+      const GLTexturePassthroughVideoImageRepresentation&) = delete;
+  GLTexturePassthroughVideoImageRepresentation& operator=(
+      const GLTexturePassthroughVideoImageRepresentation&) = delete;
+
+  const scoped_refptr<gles2::TexturePassthrough>& GetTexturePassthrough(
+      int plane_index) override {
+    DCHECK_LT(static_cast<size_t>(plane_index), passthrough_textures_.size());
+    return passthrough_textures_[plane_index];
+  }
+
+  bool BeginAccess(GLenum mode) override {
+    // This representation should only be called for read.
+    DCHECK(mode == GL_SHARED_IMAGE_ACCESS_MODE_READ_CHROMIUM);
+    return true;
+  }
+
+  void EndAccess() override {}
+
+ private:
+  std::vector<scoped_refptr<gles2::TexturePassthrough>> passthrough_textures_;
+};
+
+StarboardVideoImageBacking::StarboardVideoImageBacking(
+    const Mailbox& mailbox,
+    const gfx::Size& size,
+    const gfx::ColorSpace& color_space,
+    GrSurfaceOrigin surface_origin,
+    SkAlphaType alpha_type,
+    std::vector<scoped_refptr<gpu::gles2::TexturePassthrough>> textures,
+    scoped_refptr<SharedContextState> context_state)
+    : ClearTrackingSharedImageBacking(
+          mailbox,
+          viz::MultiPlaneFormat::kYV12,
+          size,
+          color_space,
+          surface_origin,
+          alpha_type,
+          (SHARED_IMAGE_USAGE_DISPLAY_READ | SHARED_IMAGE_USAGE_GLES2),
+          viz::MultiPlaneFormat::kYV12.EstimatedSizeInBytes(size),
+          false),
+      textures_(std::move(textures)),
+      context_state_(std::move(context_state)),
+      gpu_main_task_runner_(base::SingleThreadTaskRunner::GetCurrentDefault()) {
+}
+
+StarboardVideoImageBacking::~StarboardVideoImageBacking() {
+  DCHECK(gpu_main_task_runner_->RunsTasksInCurrentSequence());
+
+  if (context_state_) {
+    context_state_->RemoveContextLostObserver(this);
+  }
+  context_state_.reset();
+}
+
+void StarboardVideoImageBacking::OnContextLost() {
+  DCHECK(gpu_main_task_runner_->RunsTasksInCurrentSequence());
+
+  context_state_->RemoveContextLostObserver(this);
+  context_state_ = nullptr;
+}
+
+SharedImageBackingType StarboardVideoImageBacking::GetType() const {
+  return SharedImageBackingType::kVideo;
+}
+
+std::unique_ptr<SkiaGaneshImageRepresentation>
+StarboardVideoImageBacking::ProduceSkiaGanesh(
+    SharedImageManager* manager,
+    MemoryTypeTracker* tracker,
+    scoped_refptr<SharedContextState> context_state) {
+  DCHECK(gpu_main_task_runner_->RunsTasksInCurrentSequence());
+  DCHECK(context_state);
+
+  if (!context_state->GrContextIsGL()) {
+    DCHECK(false);
+    return nullptr;
+  }
+
+  DCHECK(context_state->GrContextIsGL());
+  DCHECK_EQ(textures_.size(), 3u);
+  auto* texture_base = textures_[0].get();
+  DCHECK(texture_base);
+  const bool passthrough =
+      (texture_base->GetType() == gpu::TextureBase::Type::kPassthrough);
+  DCHECK(passthrough);
+
+  std::vector<scoped_refptr<gles2::TexturePassthrough>> textures;
+  for (auto& texture : textures_) {
+    auto passthrough_texture = base::MakeRefCounted<gles2::TexturePassthrough>(
+        texture->service_id(), GL_TEXTURE_EXTERNAL_OES);
+    if (!passthrough_texture) {
+      return nullptr;
+    }
+    textures.push_back(passthrough_texture);
+  }
+
+  std::unique_ptr<gpu::GLTextureImageRepresentationBase> gl_representation;
+  gl_representation =
+      std::make_unique<GLTexturePassthroughVideoImageRepresentation>(
+          manager, this, tracker, std::move(textures));
+  return SkiaGLImageRepresentation::Create(std::move(gl_representation),
+                                           std::move(context_state), manager,
+                                           this, tracker);
+}
+
+}  // namespace gpu

--- a/gpu/command_buffer/service/shared_image/starboard/starboard_video_image_backing.h
+++ b/gpu/command_buffer/service/shared_image/starboard/starboard_video_image_backing.h
@@ -1,0 +1,76 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPU_COMMAND_BUFFER_SERVICE_SHARED_IMAGE_STARBOARD_STARBOARD_VIDEO_IMAGE_BACKING_H_
+#define GPU_COMMAND_BUFFER_SERVICE_SHARED_IMAGE_STARBOARD_STARBOARD_VIDEO_IMAGE_BACKING_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/memory/scoped_refptr.h"
+#include "base/task/single_thread_task_runner.h"
+#include "gpu/command_buffer/service/shared_context_state.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_backing.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_representation.h"
+#include "gpu/gpu_gles2_export.h"
+
+namespace gpu {
+struct Mailbox;
+
+// Implementation of ClearTrackingSharedImageBacking to allow
+// StarboardRenderer to work in decode-to-texture mode for non-android
+// platforms.
+// TODO(b/427230150): Implement decode-to-texture mode on Linux.
+class GPU_GLES2_EXPORT StarboardVideoImageBacking
+    : public ClearTrackingSharedImageBacking,
+      public SharedContextState::ContextLostObserver {
+ public:
+  StarboardVideoImageBacking(
+      const Mailbox& mailbox,
+      const gfx::Size& size,
+      const gfx::ColorSpace& color_space,
+      GrSurfaceOrigin surface_origin,
+      SkAlphaType alpha_type,
+      std::vector<scoped_refptr<gpu::gles2::TexturePassthrough>> textures,
+      scoped_refptr<SharedContextState> context_state);
+
+  ~StarboardVideoImageBacking() override;
+
+  StarboardVideoImageBacking(const StarboardVideoImageBacking&) = delete;
+  StarboardVideoImageBacking& operator=(const StarboardVideoImageBacking&) =
+      delete;
+
+  // SharedImageBacking implementation.
+  SharedImageBackingType GetType() const override;
+
+  // SharedContextState::ContextLostObserver implementation.
+  void OnContextLost() override;
+
+ protected:
+  std::unique_ptr<SkiaGaneshImageRepresentation> ProduceSkiaGanesh(
+      SharedImageManager* manager,
+      MemoryTypeTracker* tracker,
+      scoped_refptr<SharedContextState> context_state) override;
+
+ private:
+  class GLTexturePassthroughVideoImageRepresentation;
+
+  std::vector<scoped_refptr<gles2::TexturePassthrough>> textures_;
+  scoped_refptr<SharedContextState> context_state_;
+  scoped_refptr<base::SingleThreadTaskRunner> gpu_main_task_runner_;
+};
+
+}  // namespace gpu
+
+#endif  // GPU_COMMAND_BUFFER_SERVICE_SHARED_IMAGE_STARBOARD_STARBOARD_VIDEO_IMAGE_BACKING_H_

--- a/media/gpu/BUILD.gn
+++ b/media/gpu/BUILD.gn
@@ -188,6 +188,12 @@ component("gpu") {
     if (enable_vulkan) {
       deps += [ "//gpu/vulkan:vulkan" ]
     }
+    if (is_cobalt && use_starboard_media) {
+      sources += [
+        "android/starboard/starboard_codec_image.cc",
+        "android/starboard/starboard_codec_image.h",
+      ]
+    }
   }
 
   if (is_cobalt && use_starboard_media) {
@@ -197,6 +203,8 @@ component("gpu") {
       "starboard/starboard_gpu_factory_impl.cc",
       "starboard/starboard_gpu_factory_impl.h",
     ]
+
+    deps += [ "//starboard/common" ]
   }
 
   if (use_v4l2_codec) {

--- a/media/gpu/android/starboard/starboard_codec_image.cc
+++ b/media/gpu/android/starboard/starboard_codec_image.cc
@@ -1,0 +1,78 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/gpu/android/starboard/starboard_codec_image.h"
+
+#include "base/functional/callback.h"
+#include "gpu/command_buffer/service/ref_counted_lock.h"
+
+namespace media {
+
+StarboardCodecImage::StarboardCodecImage(
+    scoped_refptr<gpu::gles2::TexturePassthrough> texture,
+    scoped_refptr<gpu::RefCountedLock> drdc_lock)
+    : RefCountedLockHelperDrDc(std::move(drdc_lock)),
+      texture_passthrough_(std::move(texture)) {}
+
+StarboardCodecImage::~StarboardCodecImage() {
+  DCHECK_CALLED_ON_VALID_THREAD(gpu_main_thread_checker_);
+  AssertAcquiredDrDcLock();
+}
+
+void StarboardCodecImage::ReleaseResources() {
+  DCHECK_CALLED_ON_VALID_THREAD(gpu_main_thread_checker_);
+}
+
+bool StarboardCodecImage::IsUsingGpuMemory() const {
+  DCHECK_CALLED_ON_VALID_THREAD(gpu_main_thread_checker_);
+  AssertAcquiredDrDcLock();
+  return true;
+}
+
+void StarboardCodecImage::UpdateAndBindTexImage(GLuint service_id) {
+  AssertAcquiredDrDcLock();
+}
+
+bool StarboardCodecImage::HasTextureOwner() const {
+  return !!texture_passthrough_;
+}
+
+gpu::TextureBase* StarboardCodecImage::GetTextureBase() const {
+  if (texture_passthrough_) {
+    return texture_passthrough_.get();
+  }
+  return nullptr;
+}
+
+void StarboardCodecImage::NotifyOverlayPromotion(bool promotion,
+                                                 const gfx::Rect& bounds) {
+  AssertAcquiredDrDcLock();
+}
+
+bool StarboardCodecImage::RenderToOverlay() {
+  return false;
+}
+
+std::unique_ptr<base::android::ScopedHardwareBufferFenceSync>
+StarboardCodecImage::GetAHardwareBuffer() {
+  NOTREACHED() << "Don't use AHardwareBuffers with StarboardCodecImage";
+  return nullptr;
+}
+
+bool StarboardCodecImage::TextureOwnerBindsTextureOnUpdate() {
+  AssertAcquiredDrDcLock();
+  return true;
+}
+
+}  // namespace media

--- a/media/gpu/android/starboard/starboard_codec_image.h
+++ b/media/gpu/android/starboard/starboard_codec_image.h
@@ -1,0 +1,60 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_GPU_ANDROID_STARBOARD_STARBOARD_CODEC_IMAGE_H_
+#define MEDIA_GPU_ANDROID_STARBOARD_STARBOARD_CODEC_IMAGE_H_
+
+#include "base/threading/thread_checker.h"
+#include "gpu/command_buffer/service/ref_counted_lock.h"
+#include "gpu/command_buffer/service/stream_texture_shared_image_interface.h"
+#include "gpu/command_buffer/service/texture_manager.h"
+#include "media/gpu/media_gpu_export.h"
+
+namespace media {
+
+// Wrap TexturePassthrough to SharedImage, and allow
+// AndroidVideoImageBacking to handle the texture.
+class MEDIA_GPU_EXPORT StarboardCodecImage
+    : public gpu::StreamTextureSharedImageInterface,
+      gpu::RefCountedLockHelperDrDc {
+ public:
+  StarboardCodecImage(scoped_refptr<gpu::gles2::TexturePassthrough> texture,
+                      scoped_refptr<gpu::RefCountedLock> drdc_lock);
+
+  StarboardCodecImage(const StarboardCodecImage&) = delete;
+  StarboardCodecImage& operator=(const StarboardCodecImage&) = delete;
+
+  // gpu::StreamTextureSharedImageInterface implementation.
+  void ReleaseResources() override;
+  bool IsUsingGpuMemory() const override;
+  void UpdateAndBindTexImage(GLuint service_id) override;
+  bool HasTextureOwner() const override;
+  gpu::TextureBase* GetTextureBase() const override;
+  void NotifyOverlayPromotion(bool promotion, const gfx::Rect& bounds) override;
+  bool RenderToOverlay() override;
+  std::unique_ptr<base::android::ScopedHardwareBufferFenceSync>
+  GetAHardwareBuffer() override;
+  bool TextureOwnerBindsTextureOnUpdate() override;
+
+ protected:
+  ~StarboardCodecImage() override;
+
+ private:
+  scoped_refptr<gpu::gles2::TexturePassthrough> texture_passthrough_;
+  THREAD_CHECKER(gpu_main_thread_checker_);
+};
+
+}  // namespace media
+
+#endif  // MEDIA_GPU_ANDROID_STARBOARD_STARBOARD_CODEC_IMAGE_H_

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -15,6 +15,8 @@
 #include "media/gpu/starboard/starboard_gpu_factory_impl.h"
 
 #include "base/memory/scoped_refptr.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_factory.h"
+#include "gpu/command_buffer/service/texture_manager.h"
 #include "gpu/ipc/service/gpu_channel.h"
 #include "gpu/ipc/service/gpu_channel_manager.h"
 #include "ui/gl/gl_bindings.h"
@@ -22,7 +24,21 @@
 #include "ui/gl/scoped_make_current.h"
 #include "ui/gl/scoped_restore_texture.h"
 
+#if BUILDFLAG(IS_ANDROID)
+#include "gpu/command_buffer/service/shared_image/android_video_image_backing.h"
+#include "media/gpu/android/starboard/starboard_codec_image.h"
+#else  // BUILDFLAG(IS_ANDROID)
+#include "gpu/command_buffer/service/shared_image/starboard/starboard_video_image_backing.h"
+#endif  // BUILDFLAG(IS_ANDROID)
+
 namespace media {
+namespace {
+
+bool MakeContextCurrent(gpu::CommandBufferStub* stub) {
+  return stub && stub->decoder_context()->MakeCurrent();
+}
+
+}  // namespace
 
 StarboardGpuFactoryImpl::StarboardGpuFactoryImpl(GetStubCB get_stub_cb)
     : get_stub_cb_(std::move(get_stub_cb)) {
@@ -45,6 +61,92 @@ void StarboardGpuFactoryImpl::Initialize(base::UnguessableToken channel_token,
     stub_->AddDestructionObserver(this);
   }
   std::move(callback).Run();
+}
+
+void StarboardGpuFactoryImpl::RunSbDecodeTargetFunctionOnGpu(
+    SbDecodeTargetGlesContextRunnerTarget target_function,
+    void* target_function_context,
+    base::WaitableEvent* done_event) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!MakeContextCurrent(stub_)) {
+    done_event->Signal();
+    return;
+  }
+  target_function(target_function_context);
+  done_event->Signal();
+}
+
+void StarboardGpuFactoryImpl::RunCallbackOnGpu(
+    base::OnceCallback<void()> callback,
+    base::WaitableEvent* done_event) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!MakeContextCurrent(stub_)) {
+    done_event->Signal();
+    return;
+  }
+  std::move(callback).Run();
+
+  // Notify ANGLE that the External texture binding has changed
+  if (gl::g_current_gl_driver->ext.b_GL_ANGLE_texture_external_update) {
+    glInvalidateTextureANGLE(GL_TEXTURE_EXTERNAL_OES);
+  }
+
+  done_event->Signal();
+}
+
+void StarboardGpuFactoryImpl::CreateImageOnGpu(
+    const gfx::Size& coded_size,
+    const gfx::ColorSpace& color_space,
+    int plane_count,
+    std::vector<gpu::Mailbox>& mailboxes,
+    std::vector<uint32_t>& texture_service_ids,
+#if BUILDFLAG(IS_ANDROID)
+    scoped_refptr<gpu::RefCountedLock> drdc_lock,
+#endif  // BUILDFLAG(IS_ANDROID)
+    base::WaitableEvent* done_event) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!MakeContextCurrent(stub_)) {
+    done_event->Signal();
+    return;
+  }
+
+  gpu::ContextResult result;
+  auto shared_context =
+      stub_->channel()->gpu_channel_manager()->GetSharedContextState(&result);
+  if (result != gpu::ContextResult::kSuccess) {
+    done_event->Signal();
+    return;
+  }
+
+  DCHECK_EQ(static_cast<size_t>(plane_count), texture_service_ids.size());
+  std::vector<scoped_refptr<gpu::gles2::TexturePassthrough>> textures;
+  for (int plane = 0; plane < plane_count; plane++) {
+    auto mailbox = gpu::Mailbox::GenerateForSharedImage();
+    auto texture = base::MakeRefCounted<gpu::gles2::TexturePassthrough>(
+        texture_service_ids[plane], GL_TEXTURE_EXTERNAL_OES);
+    mailboxes.push_back(mailbox);
+    textures.push_back(texture);
+  }
+#if BUILDFLAG(IS_ANDROID)
+  // Android uses only the single plane.
+  DCHECK_EQ(mailboxes.size(), 1u);
+  DCHECK_EQ(textures.size(), 1u);
+  auto starboard_codec_image = base::MakeRefCounted<StarboardCodecImage>(
+      std::move(textures[0]), drdc_lock);
+  auto shared_image = gpu::AndroidVideoImageBacking::Create(
+      mailboxes[0], coded_size, color_space, kTopLeft_GrSurfaceOrigin,
+      kPremul_SkAlphaType, std::move(starboard_codec_image),
+      std::move(shared_context), std::move(drdc_lock));
+#else   // BUILDFLAG(IS_ANDROID)
+  // TODO(b/427230150): Implement decode-to-texture mode on Linux.
+  auto shared_image = std::make_unique<gpu::StarboardVideoImageBacking>(
+      mailboxes[0], coded_size, color_space, kTopLeft_GrSurfaceOrigin,
+      kPremul_SkAlphaType, std::move(textures), std::move(shared_context));
+#endif  // BUILDFLAG(IS_ANDROID)
+  DCHECK(stub_->channel()->gpu_channel_manager()->shared_image_manager());
+  stub_->channel()->shared_image_stub()->factory()->RegisterBacking(
+      std::move(shared_image));
+  done_event->Signal();
 }
 
 void StarboardGpuFactoryImpl::OnWillDestroyStub(bool /*have_context*/) {

--- a/media/gpu/starboard/starboard_gpu_factory_impl.h
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.h
@@ -15,16 +15,11 @@
 #ifndef MEDIA_GPU_STARBOARD_STARBOARD_GPU_FACTORY_IMPL_H_
 #define MEDIA_GPU_STARBOARD_STARBOARD_GPU_FACTORY_IMPL_H_
 
-#include <vector>
-
-#include "base/memory/raw_ptr.h"
 #include "base/threading/thread_checker.h"
 #include "media/gpu/starboard/starboard_gpu_factory.h"
 
 namespace media {
 // Implement StarboardGpuFactory class.
-// TODO(b/375070492): wire the rest of the functionality with
-// decode-to-texture.
 class StarboardGpuFactoryImpl : public StarboardGpuFactory {
  public:
   explicit StarboardGpuFactoryImpl(GetStubCB get_stub_cb);
@@ -37,6 +32,21 @@ class StarboardGpuFactoryImpl : public StarboardGpuFactory {
   void Initialize(base::UnguessableToken channel_token,
                   int32_t route_id,
                   base::OnceClosure callback) override;
+  void RunSbDecodeTargetFunctionOnGpu(
+      SbDecodeTargetGlesContextRunnerTarget target_function,
+      void* target_function_context,
+      base::WaitableEvent* done_event) override;
+  void RunCallbackOnGpu(base::OnceCallback<void()> callback,
+                        base::WaitableEvent* done_event) override;
+  void CreateImageOnGpu(const gfx::Size& coded_size,
+                        const gfx::ColorSpace& color_space,
+                        int plane_count,
+                        std::vector<gpu::Mailbox>& mailboxes,
+                        std::vector<uint32_t>& texture_service_ids,
+#if BUILDFLAG(IS_ANDROID)
+                        scoped_refptr<gpu::RefCountedLock> drdc_lock,
+#endif  // BUILDFLAG(IS_ANDROID)
+                        base::WaitableEvent* done_event) override;
 
  private:
   void OnWillDestroyStub(bool have_context) override;

--- a/media/mojo/services/BUILD.gn
+++ b/media/mojo/services/BUILD.gn
@@ -120,7 +120,8 @@ component("services") {
       "starboard/starboard_renderer_wrapper.cc",
       "starboard/starboard_renderer_wrapper.h",
     ]
-    deps += [ "//starboard:starboard_headers_only" ]
+    deps += [ "//starboard/common",
+    "//starboard:starboard_headers_only" ]
   } else if (is_android) {
     sources += [ "gpu_mojo_media_client_android.cc" ]
   } else if (is_mac) {
@@ -318,6 +319,8 @@ source_set("unit_tests") {
 
   if (is_cobalt && use_starboard_media) {
     sources += [ "starboard/starboard_renderer_wrapper_unittest.cc" ]
+
+    deps += [ "//starboard/common" ]
   }
 }
 

--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -31,9 +31,6 @@ source_set("starboard") {
     # TODO(b/375069564): Revisit CValStats
     "COBALT_MEDIA_ENABLE_CVAL=0",
 
-    # TODO(b/375070492): Revisit decode-to-texture
-    "COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER=0",
-
     # TODO(b/375218518): Revisit FormatSupportQueryMetrics
     "COBALT_MEDIA_ENABLE_FORMAT_SUPPORT_QUERY_METRICS=0",
 

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -31,10 +31,6 @@
 #include "cobalt/media/base/cval_stats.h"
 #endif  // COBALT_MEDIA_ENABLE_CVAL
 
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-#include "cobalt/media/base/decode_target_provider.h"
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-
 #if COBALT_MEDIA_ENABLE_SUSPEND_RESUME
 #include "cobalt/media/base/decoder_buffer_cache.h"
 #endif  // COBALT_MEDIA_ENABLE_SUSPEND_RESUME
@@ -93,7 +89,6 @@ class SbPlayerBridge {
                  SbPlayerOutputMode default_output_mode,
                  const OnEncryptedMediaInitDataEncounteredCB&
                      encrypted_media_init_data_encountered_cb,
-                 DecodeTargetProvider* const decode_target_provider,
                  std::string pipeline_identifier);
 #endif  // SB_HAS(PLAYER_WITH_URL)
   // Create a SbPlayerBridge with normal player
@@ -111,9 +106,6 @@ class SbPlayerBridge {
                  SbPlayerSetBoundsHelper* set_bounds_helper,
                  bool allow_resume_after_suspend,
                  SbPlayerOutputMode default_output_mode,
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-                 DecodeTargetProvider* const decode_target_provider,
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
                  const std::string& max_video_capabilities,
                  int max_video_input_size
 #if COBALT_MEDIA_ENABLE_CVAL
@@ -346,10 +338,6 @@ class SbPlayerBridge {
 
   // Keep track of the output mode we are supposed to output to.
   SbPlayerOutputMode output_mode_;
-
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-  DecodeTargetProvider* const decode_target_provider_;
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
 
   // Keep copies of the mime type strings instead of using the ones in the
   // DemuxerStreams to ensure that the strings are always valid.

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -34,6 +34,7 @@
 #include "media/starboard/sbplayer_bridge.h"
 #include "media/starboard/sbplayer_set_bounds_helper.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
+#include "ui/gfx/color_space.h"
 
 #if BUILDFLAG(IS_ANDROID)
 #include "media/base/android_overlay_mojo_factory.h"
@@ -127,6 +128,14 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
 #if BUILDFLAG(IS_ANDROID)
   void OnOverlayInfoChanged(const OverlayInfo& overlay_info);
 #endif  // BUILDFLAG(IS_ANDROID)
+  SbDecodeTarget GetSbDecodeTarget();
+  // Call to get the SbDecodeTargetGraphicsContextProvider for SbPlayerCreate().
+  typedef base::RepeatingCallback<SbDecodeTargetGraphicsContextProvider*()>
+      GetDecodeTargetGraphicsContextProviderFunc;
+  void set_decode_target_graphics_context_provider(
+      const GetDecodeTargetGraphicsContextProviderFunc&
+          get_decode_target_graphics_context_provider_func);
+  const gfx::ColorSpace& color_space() const { return color_space_; }
 
   SbPlayerInterface* GetSbPlayerInterface();
 
@@ -257,6 +266,12 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   // understood as a capability changed error. Do not change this message.
   static inline constexpr const char* kSbPlayerCapabilityChangedErrorMessage =
       "MEDIA_ERR_CAPABILITY_CHANGED";
+
+  // Call to get the SbDecodeTargetGraphicsContextProvider for SbPlayerCreate().
+  GetDecodeTargetGraphicsContextProviderFunc
+      get_decode_target_graphics_context_provider_func_;
+
+  gfx::ColorSpace color_space_ = gfx::ColorSpace::CreateSRGB();
 
   // WeakPtrFactory should be defined last (after all member variables).
   base::WeakPtrFactory<StarboardRenderer> weak_factory_{this};

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -130,6 +130,12 @@ class StarboardRendererTest : public testing::Test {
         /*request_overlay_info_cb=*/base::DoNothing()
 #endif  // BUILDFLAG(IS_ANDROID)
     );
+    StarboardRenderer::GetDecodeTargetGraphicsContextProviderFunc
+        get_decode_target_graphics_context_provider_func = base::BindRepeating(
+            &StarboardRendererTest::GetSbDecodeTargetGraphicsContextProvider,
+            base::Unretained(this));
+    renderer_->set_decode_target_graphics_context_provider(
+        get_decode_target_graphics_context_provider_func);
 
     EXPECT_CALL(media_resource_, GetAllStreams())
         .WillRepeatedly(Invoke(this, &StarboardRendererTest::GetAllStreams));
@@ -173,6 +179,11 @@ class StarboardRendererTest : public testing::Test {
     return player;
   }
 
+  SbDecodeTargetGraphicsContextProvider*
+  GetSbDecodeTargetGraphicsContextProvider() {
+    return &decode_target_graphics_context_provider_;
+  }
+
   base::test::TaskEnvironment task_environment_;
   const std::unique_ptr<StarboardRenderer> renderer_ =
       std::make_unique<StarboardRenderer>(
@@ -198,6 +209,8 @@ class StarboardRendererTest : public testing::Test {
   SbPlayerStatusFunc player_status_cb_ = nullptr;
   SbPlayerErrorFunc player_error_cb_ = nullptr;
   void* context_ = nullptr;
+  SbDecodeTargetGraphicsContextProvider
+      decode_target_graphics_context_provider_;
 };
 
 TEST_F(StarboardRendererTest, InitializeWithClearContent) {


### PR DESCRIPTION
Bring up decode-to-texture mode on android, where SbarboardRenderer gets `SbDecodeTarget` from SbPlayer, and assigns it with `gpu::Mailbox` that is used to bind a SharedImage, so Chromium can get the textures from Starboard.

For Chromium, texture mode works as:
decoder generates a texture --> associate with a unique `gpu::Mailbox` --> Renderer creates a SharedImage with the generated `gpu::Mailbox` --> Renderer puts the SharedImage to the rendering pipeline via Render() --> Chromium gets the texture from the SharedImage with the generated `gpu::Mailbox`.

Specifically, `StarboardCodecImage` is to bind a SharedImage with `AndroidVideoImageBacking` on android, so Chromium rendering pipeline can get the texture from SbPlayer, and render it.

Note this PR also adds `StarboardVideoImageBacking` to allow to build it on Linux, but it is not supported yet.

Issue: 375070492