### PR TITLE
cobalt/browser/metrics: Connect CobaltMetricsServiceClient and Mojom

### DIFF
--- a/base/time/time.h
+++ b/base/time/time.h
@@ -133,7 +133,6 @@ class BASE_EXPORT TimeDelta {
  public:
   constexpr TimeDelta() = default;
 
-#if BUILDFLAG(IS_STARBOARD) && 0
   static constexpr int64_t kHoursPerDay = 24;
   static constexpr int64_t kSecondsPerMinute = 60;
   static constexpr int64_t kMinutesPerHour = 60;
@@ -206,7 +205,7 @@ class BASE_EXPORT TimeDelta {
                                             MakeClampedNum(n))
             : TimeDelta::Max();
   }
-#elif BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_WIN)
   static TimeDelta FromQPCValue(LONGLONG qpc_value);
   // TODO(crbug.com/989694): Avoid base::TimeDelta factory functions
   // based on absolute time

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -110,6 +110,7 @@ source_set("metrics") {
     "metrics/cobalt_metrics_service_client.h",
   ]
   deps = [
+    "//cobalt/browser/h5vcc_metrics/public/mojom",
     "//components/metrics",
     "//components/prefs",
     "//components/variations",

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -91,7 +91,7 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
 
   // ShellBrowserMainParts overrides.
   int PreCreateThreads() override {
-    metrics_ = std::make_unique<CobaltMetricsServiceClient>();
+    metrics_ = CobaltMetricsServiceClient::GetInstance();
     // TODO(b/372559349): Double check that this initializes UMA collection,
     // similar to what ChromeBrowserMainParts::StartMetricsRecording() does.
     // It might need to be moved to other parts, e.g. PreMainMessageLoopRun().
@@ -135,7 +135,7 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
 #endif  // BUILDFLAG(IS_LINUX)
 
  private:
-  std::unique_ptr<CobaltMetricsServiceClient> metrics_;
+  CobaltMetricsServiceClient* metrics_;
 };
 
 std::string GetCobaltUserAgent() {

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -18,6 +18,7 @@
 
 #include "base/files/file_path.h"
 #include "base/i18n/rtl.h"
+#include "base/memory/raw_ptr.h"
 #include "cobalt/browser/cobalt_browser_interface_binders.h"
 #include "cobalt/browser/cobalt_web_contents_observer.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
@@ -135,7 +136,7 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
 #endif  // BUILDFLAG(IS_LINUX)
 
  private:
-  CobaltMetricsServiceClient* metrics_;
+  raw_ptr<CobaltMetricsServiceClient> metrics_;
 };
 
 std::string GetCobaltUserAgent() {

--- a/cobalt/browser/h5vcc_metrics/BUILD.gn
+++ b/cobalt/browser/h5vcc_metrics/BUILD.gn
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 source_set("h5vcc_metrics") {
+  # TODO(cobalt, b/375655377): remove testonly declaration, needed because of
+  # being depended-on by :browser above.
+  testonly = true
+
   sources = [
     "h5vcc_metrics_impl.cc",
     "h5vcc_metrics_impl.h",
@@ -20,6 +24,7 @@ source_set("h5vcc_metrics") {
 
   deps = [
     "//base",
+    "//cobalt/browser:metrics",
     "//cobalt/browser/h5vcc_metrics/public/mojom",
     "//content/public/browser",
     "//mojo/public/cpp/bindings",

--- a/cobalt/browser/h5vcc_metrics/h5vcc_metrics_impl.cc
+++ b/cobalt/browser/h5vcc_metrics/h5vcc_metrics_impl.cc
@@ -43,7 +43,8 @@ void H5vccMetricsImpl::Create(
 
 void H5vccMetricsImpl::AddListener(
     ::mojo::PendingRemote<mojom::MetricsListener> listener) {
-  NOTIMPLEMENTED();
+  cobalt::CobaltMetricsServiceClient::GetInstance()->SetMetricsListener(
+      std::move(listener));
 }
 
 void H5vccMetricsImpl::Enable(bool enable, EnableCallback callback) {

--- a/cobalt/browser/h5vcc_metrics/h5vcc_metrics_impl.cc
+++ b/cobalt/browser/h5vcc_metrics/h5vcc_metrics_impl.cc
@@ -16,7 +16,9 @@
 
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
+#include "base/time/time.h"
 #include "build/build_config.h"
+#include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
 
 #if BUILDFLAG(IS_ANDROID)
 #include "starboard/android/shared/starboard_bridge.h"
@@ -45,14 +47,16 @@ void H5vccMetricsImpl::AddListener(
 }
 
 void H5vccMetricsImpl::Enable(bool enable, EnableCallback callback) {
-  NOTIMPLEMENTED();
+  cobalt::CobaltMetricsServiceClient::GetInstance()->set_reporting_enabled(
+      enable);
   std::move(callback).Run();
 }
 
 void H5vccMetricsImpl::SetMetricEventInterval(
     uint64_t interval_seconds,
     SetMetricEventIntervalCallback callback) {
-  NOTIMPLEMENTED();
+  cobalt::CobaltMetricsServiceClient::GetInstance()->set_reporting_interval(
+      base::TimeDelta::FromSeconds(interval_seconds));
   std::move(callback).Run();
 }
 

--- a/cobalt/browser/h5vcc_metrics/h5vcc_metrics_impl.h
+++ b/cobalt/browser/h5vcc_metrics/h5vcc_metrics_impl.h
@@ -20,6 +20,7 @@
 #include "cobalt/browser/h5vcc_metrics/public/mojom/h5vcc_metrics.mojom.h"
 #include "content/public/browser/document_service.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
 
 namespace content {
 class RenderFrameHost;

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.cc
@@ -48,6 +48,12 @@ class CobaltMetricsLogUploader : public metrics::MetricsLogUploader {
 
 }  // namespace
 
+// static
+CobaltMetricsServiceClient* CobaltMetricsServiceClient::GetInstance() {
+  static base::NoDestructor<CobaltMetricsServiceClient> provider;
+  return provider.get();
+}
+
 CobaltMetricsServiceClient::CobaltMetricsServiceClient()
     : synthetic_trial_registry_(new variations::SyntheticTrialRegistry) {
   DETACH_FROM_THREAD(thread_checker_);
@@ -219,10 +225,9 @@ CobaltMetricsServiceClient::CreateUploader(
 
 base::TimeDelta CobaltMetricsServiceClient::GetStandardUploadInterval() {
   // TODO(b/372559349): Wire this to the appropriate Web platform IDL method.
-  const int kStandardUploadIntervalMinutes = 5;
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   DCHECK(IsInitialized());
-  return base::Minutes(kStandardUploadIntervalMinutes);
+  return reporting_interval_;
 }
 
 bool CobaltMetricsServiceClient::IsConsentGiven() const {
@@ -232,10 +237,20 @@ bool CobaltMetricsServiceClient::IsConsentGiven() const {
 }
 
 bool CobaltMetricsServiceClient::IsReportingEnabled() const {
-  // TODO(b/372559349): Usually TOS should be verified accepted here.
-  // TODO(b/372559349): Wire this to the appropriate Web platform IDL.
-  NOTIMPLEMENTED();
-  return false;
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+   // TODO(b/372559349): Usually TOS should be verified accepted here.
+  return is_reporting_enabled_;
+}
+
+void CobaltMetricsServiceClient::set_reporting_enabled(bool enable) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  is_reporting_enabled_ = enable;
+}
+
+void CobaltMetricsServiceClient::set_reporting_interval(
+    base::TimeDelta interval) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  reporting_interval_ = interval;
 }
 
 }  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.cc
@@ -56,7 +56,6 @@ class CobaltMetricsLogUploader : public metrics::MetricsLogUploader {
   }
 
  private:
-
   mojo::Remote<h5vcc_metrics::mojom::MetricsListener> metrics_listener_;
 
   base::WeakPtrFactory<CobaltMetricsLogUploader> weak_factory_{this};
@@ -235,7 +234,7 @@ CobaltMetricsServiceClient::CreateUploader(
     const metrics::MetricsLogUploader::UploadCallback& on_upload_complete) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   DCHECK(IsInitialized());
-  // CraeteUploader() should never be called more than once.
+  // CreateUploader() should never be called more than once.
   CHECK(log_uploader_);
   return std::move(log_uploader_);
 }
@@ -255,7 +254,7 @@ bool CobaltMetricsServiceClient::IsConsentGiven() const {
 
 bool CobaltMetricsServiceClient::IsReportingEnabled() const {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-   // TODO(b/372559349): Usually TOS should be verified accepted here.
+  // TODO(b/372559349): Usually TOS should be verified accepted here.
   return is_reporting_enabled_;
 }
 


### PR DESCRIPTION
This CL connects CobaltMetricsServiceClient, the UMA service
in the browser, with the H5vccMetricsImpl Mojom implementation.

A few things: 
- CobaltMetricsServiceClient turns into a singleton. I think
 this was always the case, this CL just makes it evident so
 that H5vccMetricsImpl can find it.
- CobaltMetricsServiceClient gets a few methods and variables
 to access and manage CobaltMetricsLogUploader lifetime.
- CobaltMetricsLogUploader also gets a few methods and in
 particular learns how to hold on to a h5vcc_metrics's 
 MetricsListener to send UMA logs to.

One twist is that I had to remove a starboard limitation in 
base/time.h because I needed to access time functions to wire
H5vccMetricsImpl::SetMetricEventInterval(). Nothing seemed 
to break (the commented out code only included a few consts
and templates like FromSeconds() etc). We'll see the bots.

Bug: b/372559349 