### PR TITLE
baseTime: Fix #if BUILDFLAG(IS_APPLE) usage

### DIFF
--- a/base/time/time.h
+++ b/base/time/time.h
@@ -781,7 +781,8 @@ class BASE_EXPORT Time : public time_internal::TimeBase<Time> {
 #if defined(__OBJC__)
   static Time FromNSDate(NSDate* date);
   NSDate* ToNSDate() const;
-#endif
+#endif // defined(__OBJC__)
+#endif // BUILDFLAG(IS_APPLE)
 
 #if BUILDFLAG(IS_WIN)
   static Time FromFileTime(FILETIME ft);
@@ -821,7 +822,6 @@ class BASE_EXPORT Time : public time_internal::TimeBase<Time> {
   static void ResetHighResolutionTimerUsage();
   static double GetHighResolutionTimerUsage();
 #endif  // BUILDFLAG(IS_WIN)
-#endif
 
   // Converts an exploded structure representing either the local time or UTC
   // into a Time class. Returns false on a failure when, for example, a day of


### PR DESCRIPTION
Related #endif was placed incorrectly, so the #if BUILDFLAG(IS_WIN) was nested in the IS_APPLE section.

Bug: 408245835