### PR TITLE
[Android. 26] Change 'device type' field in UA string from ATV to TV|STB|OTT

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -99,6 +99,8 @@ public class StarboardBridge {
   private final boolean isAmatiDevice;
   private static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone("America/Los_Angeles");
   private final long timeNanosecondsPerMicrosecond = 1000;
+  private static final String FEATURE_OPERATOR_TIER = "com.google.android.tv.operator_tier";
+  private final boolean isOperatorTier;
 
   public StarboardBridge(
       Context appContext,
@@ -129,6 +131,7 @@ public class StarboardBridge {
     this.advertisingId = new AdvertisingId(appContext);
     this.volumeStateReceiver = new VolumeStateReceiver(appContext);
     this.isAmatiDevice = appContext.getPackageManager().hasSystemFeature(AMATI_EXPERIENCE_FEATURE);
+    this.isOperatorTier = appContext.getPackageManager().hasSystemFeature(FEATURE_OPERATOR_TIER);
 
     nativeApp = StarboardBridgeJni.get().startNativeStarboard();
 
@@ -732,6 +735,13 @@ public class StarboardBridge {
   protected boolean getIsAmatiDevice() {
     return this.isAmatiDevice;
   }
+
+  @SuppressWarnings("unused")
+  @CalledByNative
+  protected boolean getOperatorTier() {
+    return this.isOperatorTier;
+  }
+
 
   @CalledByNative
   protected String getBuildFingerprint() {

--- a/starboard/android/shared/system_get_property.cc
+++ b/starboard/android/shared/system_get_property.cc
@@ -162,9 +162,22 @@ bool SbSystemGetProperty(SbSystemPropertyId property_id,
       return CopyStringAndTestIfSuccess(out_value, value_length,
                                         limit_ad_tracking_enabled ? "1" : "0");
     }
-    case kSbSystemPropertyDeviceType:
-      return CopyStringAndTestIfSuccess(out_value, value_length,
-                                        starboard::kSystemDeviceTypeAndroidTV);
+    case kSbSystemPropertyDeviceType: {
+      char key1[PROP_VALUE_MAX] = "";
+      const char* device_type = starboard::kSystemDeviceTypeUnknown;
+      JniEnvExt* env = JniEnvExt::Get();
+
+      if (GetAndroidSystemProperty("ro.oem.key1", key1, PROP_VALUE_MAX, "") &&
+          key1[0]) {
+        device_type = starboard::kSystemDeviceTypeTV;
+      } else if (env->CallStarboardBooleanMethodOrAbort("getOperatorTier",
+                                                        "()Z") == JNI_TRUE) {
+        device_type = starboard::kSystemDeviceTypeSetTopBox;
+      } else {
+        device_type = starboard::kSystemDeviceTypeOverTheTopBox;
+      }
+      return CopyStringAndTestIfSuccess(out_value, value_length, device_type);
+    }
     default:
       SB_DLOG(WARNING) << __FUNCTION__
                        << ": Unrecognized property: " << property_id;


### PR DESCRIPTION
Changes device type in User-Agent from "ATV" to more detailed "TV" (has a display), "OTT" (no display), or "STB" (operator devices, disregard required to have a tuner).

> [!NOTE]
> This is an adaptation of PR #4981 to the "Cobalt 26".

b/130328173
