### PR TITLE
(DNS) [android] Reduce 8k video buffer budget to 200 MB

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -1101,6 +1101,16 @@ class MediaCodecBridge {
     }
     // Estimate the maximum input size assuming three channel 4:2:0 subsampled input frames.
     int maxVideoInputSize = (maxPixels * 3) / (2 * minCompressionRatio);
+    if (maxVideoInputSize > 8 * 1024 * 1024) {
+      Log.i(
+          TAG,
+          "Cap KEY_MAX_INPUT_SIZE of "
+              + maxVideoInputSize
+              + " to "
+              + 8 * 1024 * 1024
+              + ".");
+      maxVideoInputSize = 8 * 1024 * 1024;
+    }
     format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxVideoInputSize);
     try {
       Log.i(


### PR DESCRIPTION
Reduce video buffer budget for 8K videos from 300 MB to 200 MB on Android TV.  The new value still conforms to the tech requirements.

Note that the video buffer budget for 8K is still set to 300 MB in
  starboard/shared/starboard/media/media_get_video_buffer_budget.cc
to avoid regression on other platforms.  The buffer budgets for other resolutions on Android TV remain unchanged for the same reason.

b/405467220