### PR TITLE
[android] Refine tunnel mode video playback

### DIFF
--- a/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -72,9 +72,12 @@ class MediaCodecBridge {
   private long mLastPresentationTimeUs;
   private final String mMime;
   private double mPlaybackRate = 1.0;
+  private long mSeekToTime = 0;
+  private boolean mTunnelModeEnabled = false;
   private int mFps = 30;
 
   private MediaCodec.OnFrameRenderedListener mFrameRendererListener;
+  private MediaCodec.OnFirstTunnelFrameReadyListener mFirstTunnelFrameReadyListener;
 
   // Functions that require this will be called frequently in a tight loop.
   // Only create one of these and reuse it to avoid excessive allocations,
@@ -447,6 +450,7 @@ class MediaCodecBridge {
     mMediaCodec.set(mediaCodec);
     mMime = mime; // TODO: Delete the unused mMime field
     mLastPresentationTimeUs = 0;
+    mTunnelModeEnabled = (tunnelModeAudioSessionId != -1);
     mFlushed = true;
     mBitrateAdjustmentType = bitrateAdjustmentType;
     mCallback =
@@ -531,6 +535,31 @@ class MediaCodecBridge {
           };
       mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, null);
     }
+
+    if (isFirstTunnelFrameReadyCallbackEnabled() && tunnelModeAudioSessionId != -1) {
+      Bundle b = new Bundle();
+      b.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, 1);
+      try {
+        mMediaCodec.get().setParameters(b);
+      } catch (IllegalStateException e) {
+        Log.e(TAG, "Failed to set MediaCodec tunnel-peek", e);
+      }
+
+      mFirstTunnelFrameReadyListener =
+          new MediaCodec.OnFirstTunnelFrameReadyListener() {
+            @Override
+            public void onFirstTunnelFrameReady(MediaCodec codec) {
+              Log.i(TAG, "First output frame is ready to be rendered.");
+              synchronized (this) {
+                if (mNativeMediaCodecBridge == 0) {
+                  return;
+                }
+                nativeOnMediaCodecFirstTunnelFrameReady(mNativeMediaCodecBridge);
+              }
+            }
+          };
+      mMediaCodec.get().setOnFirstTunnelFrameReadyListener(null, mFirstTunnelFrameReadyListener);
+    }
   }
 
   @UsedByNative
@@ -538,6 +567,17 @@ class MediaCodecBridge {
     // Starting with Android 14, onFrameRendered should be called accurately for each rendered
     // frame.
     return Build.VERSION.SDK_INT >= 34;
+  }
+
+  @UsedByNative
+  public static boolean isFirstTunnelFrameReadyCallbackEnabled() {
+    // OnFirstTunnelFrameReadyListener is added in Android 12
+    return Build.VERSION.SDK_INT >= 31;
+  }
+
+  private boolean isDecodeOnly(long presentationTimeUs) {
+    // BUFFER_FLAG_DECODE_ONLY is added in Android 14
+    return Build.VERSION.SDK_INT >= 34 && mTunnelModeEnabled && (presentationTimeUs < mSeekToTime);
   }
 
   @SuppressWarnings("unused")
@@ -763,6 +803,8 @@ class MediaCodecBridge {
     mMediaCodec.set(null);
   }
 
+  @SuppressWarnings("unused")
+  @UsedByNative
   public boolean start() {
     return start(null);
   }
@@ -799,6 +841,12 @@ class MediaCodecBridge {
     if (mFrameRateEstimator != null) {
       updateOperatingRate();
     }
+  }
+
+  @SuppressWarnings("unused")
+  @UsedByNative
+  private void seek(long seekToTime) {
+    mSeekToTime = seekToTime;
   }
 
   private void updateOperatingRate() {
@@ -914,6 +962,9 @@ class MediaCodecBridge {
       int index, int offset, int size, long presentationTimeUs, int flags) {
     resetLastPresentationTimeIfNeeded(presentationTimeUs);
     try {
+      if (((flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) == 0) && isDecodeOnly(presentationTimeUs)) {
+        flags |= MediaCodec.BUFFER_FLAG_DECODE_ONLY;
+      }
       mMediaCodec.get().queueInputBuffer(index, offset, size, presentationTimeUs, flags);
     } catch (Exception e) {
       Log.e(TAG, "Failed to queue input buffer", e);
@@ -979,7 +1030,11 @@ class MediaCodecBridge {
         return MediaCodecStatus.ERROR;
       }
 
-      mMediaCodec.get().queueSecureInputBuffer(index, offset, cryptoInfo, presentationTimeUs, 0);
+      int flags = 0;
+      if (isDecodeOnly(presentationTimeUs)) {
+        flags |= MediaCodec.BUFFER_FLAG_DECODE_ONLY;
+      }
+      mMediaCodec.get().queueSecureInputBuffer(index, offset, cryptoInfo, presentationTimeUs, flags);
     } catch (MediaCodec.CryptoException e) {
       int errorCode = e.getErrorCode();
       if (errorCode == MediaCodec.CryptoException.ERROR_NO_KEY) {
@@ -1224,4 +1279,7 @@ class MediaCodecBridge {
 
   private native void nativeOnMediaCodecFrameRendered(
       long nativeMediaCodecBridge, long presentationTimeUs, long renderAtSystemTimeNs);
+
+  private native void nativeOnMediaCodecFirstTunnelFrameReady(
+      long nativeMediaCodecBridge);
 }

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -291,6 +291,8 @@ static_library("starboard_platform") {
     "audio_decoder_passthrough.h",
     "audio_renderer_passthrough.cc",
     "audio_renderer_passthrough.h",
+    "audio_renderer_tunnel_pcm.cc",
+    "audio_renderer_tunnel_pcm.h",
     "audio_sink_get_max_channels.cc",
     "audio_sink_get_min_buffer_size_in_frames.cc",
     "audio_sink_get_nearest_supported_sample_frequency.cc",

--- a/starboard/android/shared/audio_renderer_tunnel_pcm.h
+++ b/starboard/android/shared/audio_renderer_tunnel_pcm.h
@@ -1,0 +1,228 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_AUDIO_RENDERER_TUNNEL_PCM_H_
+#define STARBOARD_ANDROID_SHARED_AUDIO_RENDERER_TUNNEL_PCM_H_
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "starboard/common/log.h"
+#include "starboard/common/mutex.h"
+#include "starboard/common/optional.h"
+#include "starboard/media.h"
+#include "starboard/shared/internal_only.h"
+#include "starboard/shared/starboard/media/media_util.h"
+#include "starboard/shared/starboard/player/decoded_audio_internal.h"
+#include "starboard/shared/starboard/player/filter/audio_decoder_internal.h"
+#include "starboard/shared/starboard/player/filter/audio_frame_tracker.h"
+#include "starboard/shared/starboard/player/filter/audio_renderer_internal.h"
+#include "starboard/shared/starboard/player/filter/audio_renderer_sink.h"
+#include "starboard/shared/starboard/player/filter/audio_resampler.h"
+#include "starboard/shared/starboard/player/filter/audio_time_stretcher.h"
+#include "starboard/shared/starboard/player/filter/media_time_provider.h"
+#include "starboard/shared/starboard/player/input_buffer_internal.h"
+#include "starboard/shared/starboard/player/job_queue.h"
+#include "starboard/types.h"
+
+// Uncomment the following statement to log the media time stats with deviation
+// when GetCurrentMediaTime() is called.
+// #define SB_LOG_MEDIA_TIME_STATS 1
+
+namespace starboard {
+namespace android {
+namespace shared {
+
+const int kFramesInBufferBeginUnderflow = 1024;
+
+// A class that sits in between the audio decoder, the audio sink and the
+// pipeline to coordinate data transfer between these parties.  It also serves
+// as the authority of playback time.
+class AudioRendererTunnelPcm
+    : public starboard::shared::starboard::player::filter::AudioRenderer,
+      public starboard::shared::starboard::player::filter::MediaTimeProvider,
+      private starboard::shared::starboard::player::filter::AudioRendererSink::
+          RenderCallback,
+      private starboard::shared::starboard::player::JobQueue::JobOwner {
+ public:
+  // |max_cached_frames| is a soft limit for the max audio frames this class can
+  // cache so it can:
+  // 1. Avoid using too much memory.
+  // 2. Have the audio cache full to simulate the state that the renderer can no
+  //    longer accept more data.
+  // |min_frames_per_append| is the min number of frames that the audio renderer
+  // tries to append to the sink buffer at once.
+  AudioRendererTunnelPcm(
+      std::unique_ptr<
+          starboard::shared::starboard::player::filter::AudioDecoder> decoder,
+      std::unique_ptr<
+          starboard::shared::starboard::player::filter::AudioRendererSink>
+          audio_renderer_sink,
+      const starboard::shared::starboard::media::AudioStreamInfo&
+          audio_stream_info,
+      int max_cached_frames,
+      int min_frames_per_append);
+  ~AudioRendererTunnelPcm() override;
+
+  void Initialize(const ErrorCB& error_cb,
+                  const PrerolledCB& prerolled_cb,
+                  const EndedCB& ended_cb) override;
+  void WriteSamples(const InputBuffers& input_buffers) override;
+  void WriteEndOfStream() override;
+
+  void SetVolume(double volume) override;
+
+  // TODO: Remove the eos state querying functions and their tests.
+  bool IsEndOfStreamWritten() const override;
+  bool IsEndOfStreamPlayed() const override;
+  bool CanAcceptMoreData() const override;
+
+  // MediaTimeProvider methods
+  void Play() override;
+  void Pause() override;
+  void SetPlaybackRate(double playback_rate) override;
+  void Seek(int64_t seek_to_time) override;
+  int64_t GetCurrentMediaTime(bool* is_playing,
+                              bool* is_eos_played,
+                              bool* is_underflow,
+                              double* playback_rate) override;
+
+ private:
+  enum EOSState {
+    kEOSNotReceived,
+    kEOSWrittenToDecoder,
+    kEOSDecoded,
+    kEOSSentToSink
+  };
+
+  const int max_cached_frames_;
+  const int min_frames_per_append_;
+  // |buffered_frames_to_start_| would be initialized in OnFirstOutput().
+  // Before it's initialized, set it to a large number.
+  int buffered_frames_to_start_ = 48 * 1024;
+
+  ErrorCB error_cb_;
+  PrerolledCB prerolled_cb_;
+  EndedCB ended_cb_;
+
+  Mutex mutex_;
+
+  bool paused_ = true;
+  bool consume_frames_called_ = false;
+  bool seeking_ = false;
+  int64_t seeking_to_time_ = 0;  // microseconds
+  int64_t last_media_time_ = 0;  // microseconds
+  starboard::shared::starboard::player::filter::AudioFrameTracker
+      audio_frame_tracker_;
+  bool ended_cb_called_ = false;
+
+  int64_t total_frames_sent_to_sink_ = 0;
+  int64_t total_frames_consumed_by_sink_ = 0;
+  int32_t frames_consumed_by_sink_since_last_get_current_time_;
+
+  std::unique_ptr<starboard::shared::starboard::player::filter::AudioDecoder>
+      decoder_;
+
+  int64_t frames_consumed_set_at_;
+  double playback_rate_ = 1.0;
+
+  // AudioRendererSink methods
+  void GetSourceStatus(int* frames_in_buffer,
+                       int* offset_in_frames,
+                       bool* is_playing,
+                       bool* is_eos_reached) override;
+  void ConsumeFrames(int frames_consumed, int64_t frames_consumed_at) override;
+  void OnError(bool capability_changed,
+               const std::string& error_message) override;
+
+  void UpdateVariablesOnSinkThread_Locked(
+      int64_t system_time_on_consume_frames);
+
+  void OnFirstOutput(const SbMediaAudioSampleType decoded_sample_type,
+                     const SbMediaAudioFrameStorageType decoded_storage_type,
+                     const int decoded_sample_rate);
+  bool IsEndOfStreamPlayed_Locked() const;
+
+  void OnDecoderConsumed();
+  void OnDecoderOutput();
+  void ProcessAudioData();
+  void FillResamplerAndTimeStretcher();
+  bool AppendAudioToFrameBuffer(bool* is_frame_buffer_full);
+
+  EOSState eos_state_ = kEOSNotReceived;
+  const int channels_;
+  const SbMediaAudioSampleType sink_sample_type_;
+  const int bytes_per_frame_;
+
+  std::unique_ptr<starboard::shared::starboard::player::filter::AudioResampler>
+      resampler_;
+  optional<int> decoder_sample_rate_;
+  starboard::shared::starboard::player::filter::AudioTimeStretcher
+      time_stretcher_;
+
+  std::vector<uint8_t> frame_buffer_;
+  uint8_t* frame_buffers_[1];
+
+  int32_t pending_decoder_outputs_ = 0;
+
+  bool can_accept_more_data_ = true;
+  starboard::shared::starboard::player::JobQueue::JobToken
+      process_audio_data_job_token_;
+  std::function<void()> process_audio_data_job_;
+
+  // Our owner will attempt to seek to time 0 when playback begins.  In
+  // general, seeking could require a full reset of the underlying decoder on
+  // some platforms, so we make an effort to improve playback startup
+  // performance by keeping track of whether we already have a fresh decoder,
+  // and can thus avoid doing a full reset.
+  bool first_input_written_ = false;
+
+  std::unique_ptr<
+      starboard::shared::starboard::player::filter::AudioRendererSink>
+      audio_renderer_sink_;
+  bool is_eos_reached_on_sink_thread_ = false;
+  bool is_playing_on_sink_thread_ = false;
+  int64_t frames_in_buffer_on_sink_thread_ = 0;
+  int64_t offset_in_frames_on_sink_thread_ = 0;
+  int64_t frames_consumed_on_sink_thread_ = 0;
+  int64_t frames_consumed_set_at_on_sink_thread_ = 0;  // microseconds
+  int64_t silence_frames_written_after_eos_on_sink_thread_ = 0;
+
+#if SB_LOG_MEDIA_TIME_STATS
+  int64_t system_and_media_time_offset_ = -1;  // microseconds
+  int64_t min_drift_ = kSbInt64Max;            // microseconds
+  int64_t max_drift_ = 0;                      // microseconds
+  int64_t total_frames_consumed_ = 0;
+#endif  // SB_LOG_MEDIA_TIME_STATS
+
+  // Set to true when there are fewer than |kFramesInBufferBeginUnderflow|
+  // frames in buffer. Set to false when the queue is full or EOS.
+  bool underflow_ = false;
+
+#if SB_PLAYER_FILTER_ENABLE_STATE_CHECK
+  static const int32_t kMaxSinkCallbacksBetweenCheck = 1024;
+  static const int64_t kCheckAudioSinkStatusInterval = 1'000'000;  // 1 second
+  void CheckAudioSinkStatus();
+
+  std::atomic_int32_t sink_callbacks_since_last_check_;
+#endif  // SB_PLAYER_FILTER_ENABLE_STATE_CHECK
+};
+
+}  // namespace shared
+}  // namespace android
+}  // namespace starboard
+
+#endif  // STARBOARD_ANDROID_SHARED_AUDIO_RENDERER_TUNNEL_PCM_H_

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -177,13 +177,11 @@ AudioTrackAudioSink::~AudioTrackAudioSink() {
 
 void AudioTrackAudioSink::SetPlaybackRate(double playback_rate) {
   SB_DCHECK(playback_rate >= 0.0);
-  if (playback_rate != 0.0 && playback_rate != 1.0) {
-    SB_NOTIMPLEMENTED() << "TODO: Only playback rates of 0.0 and 1.0 are "
-                           "currently supported.";
-    playback_rate = (playback_rate > 0.0) ? 1.0 : 0.0;
-  }
   ScopedLock lock(mutex_);
   playback_rate_ = playback_rate;
+  if (playback_rate_ > 0.0) {
+    bridge_.SetPlaybackRate(playback_rate);
+  }
 }
 
 // static

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -249,6 +249,19 @@ void AudioTrackBridge::SetVolume(double volume,
   }
 }
 
+void AudioTrackBridge::SetPlaybackRate(double playback_rate,
+                                       JniEnvExt* env /*= JniEnvExt::Get()*/) {
+  SB_DCHECK(env);
+  SB_DCHECK(is_valid());
+
+  jint status =
+      env->CallIntMethodOrAbort(j_audio_track_bridge_, "setPlaybackRate",
+                                "(F)I", static_cast<float>(playback_rate));
+  if (status == 0) {
+    SB_LOG(ERROR) << "Failed to set playback_rate to " << playback_rate;
+  }
+}
+
 int64_t AudioTrackBridge::GetAudioTimestamp(
     int64_t* updated_at,
     JniEnvExt* env /*= JniEnvExt::Get()*/) {

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -77,6 +77,8 @@ class AudioTrackBridge {
 
   void SetVolume(double volume, JniEnvExt* env = JniEnvExt::Get());
 
+  void SetPlaybackRate(double playback_rate, JniEnvExt* env = JniEnvExt::Get());
+
   // |updated_at| contains the timestamp when the audio timstamp is updated on
   // return.  It can be nullptr.
   int64_t GetAudioTimestamp(int64_t* updated_at,

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -14,6 +14,9 @@
 
 #include "starboard/android/shared/media_codec_bridge.h"
 
+#include <memory>
+#include <string>
+
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_codec_bridge_eradicator.h"
 #include "starboard/common/string.h"

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -99,6 +99,17 @@ Java_dev_cobalt_media_MediaCodecBridge_nativeOnMediaCodecFrameRendered(
 }
 
 extern "C" SB_EXPORT_PLATFORM void
+Java_dev_cobalt_media_MediaCodecBridge_nativeOnMediaCodecFirstTunnelFrameReady(
+    JNIEnv* env,
+    jobject unused_this,
+    jlong native_media_codec_bridge) {
+  MediaCodecBridge* media_codec_bridge =
+      reinterpret_cast<MediaCodecBridge*>(native_media_codec_bridge);
+  SB_DCHECK(media_codec_bridge);
+  media_codec_bridge->OnMediaCodecFirstTunnelFrameReady();
+}
+
+extern "C" SB_EXPORT_PLATFORM void
 Java_dev_cobalt_media_MediaCodecBridge_nativeOnMediaCodecError(
     JniEnvExt* env,
     jobject unused_this,
@@ -495,6 +506,11 @@ void MediaCodecBridge::SetPlaybackRate(double playback_rate) {
       j_media_codec_bridge_, "setPlaybackRate", "(D)V", playback_rate);
 }
 
+void MediaCodecBridge::Seek(int64_t seek_to_time) {
+  JniEnvExt::Get()->CallVoidMethodOrAbort(
+      j_media_codec_bridge_, "seek", "(J)V", seek_to_time);
+}
+
 bool MediaCodecBridge::Restart() {
   return JniEnvExt::Get()->CallBooleanMethodOrAbort(
              j_media_codec_bridge_, "restart", "()Z") == JNI_TRUE;
@@ -572,6 +588,10 @@ void MediaCodecBridge::OnMediaCodecOutputFormatChanged() {
 
 void MediaCodecBridge::OnMediaCodecFrameRendered(int64_t frame_timestamp) {
   handler_->OnMediaCodecFrameRendered(frame_timestamp);
+}
+
+void MediaCodecBridge::OnMediaCodecFirstTunnelFrameReady() {
+  handler_->OnMediaCodecFirstTunnelFrameReady();
 }
 
 MediaCodecBridge::MediaCodecBridge(Handler* handler) : handler_(handler) {

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -141,6 +141,7 @@ class MediaCodecBridge {
     virtual void OnMediaCodecOutputFormatChanged() = 0;
     // This is only called on video decoder when tunnel mode is enabled.
     virtual void OnMediaCodecFrameRendered(int64_t frame_timestamp) = 0;
+    virtual void OnMediaCodecFirstTunnelFrameReady() = 0;
 
    protected:
     ~Handler() {}
@@ -200,6 +201,7 @@ class MediaCodecBridge {
   void ReleaseOutputBufferAtTimestamp(jint index, jlong render_timestamp_ns);
 
   void SetPlaybackRate(double playback_rate);
+  void Seek(int64_t seek_to_time);
   bool Restart();
   jint Flush();
   FrameSize GetOutputSize();
@@ -216,6 +218,7 @@ class MediaCodecBridge {
                                          int size);
   void OnMediaCodecOutputFormatChanged();
   void OnMediaCodecFrameRendered(int64_t frame_timestamp);
+  void OnMediaCodecFirstTunnelFrameReady();
 
  private:
   // |MediaCodecBridge|s must only be created through its factory methods.

--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -53,6 +53,7 @@ class MediaDecoder final
   typedef ::starboard::shared::starboard::player::InputBuffer InputBuffer;
   typedef ::starboard::shared::starboard::player::InputBuffers InputBuffers;
   typedef std::function<void(int64_t)> FrameRenderedCB;
+  typedef std::function<void(void)> FirstTunnelFrameReadyCB;
 
   // This class should be implemented by the users of MediaDecoder to receive
   // various notifications.  Note that all such functions are called on the
@@ -96,6 +97,7 @@ class MediaDecoder final
                const SbMediaColorMetadata* color_metadata,
                bool require_software_codec,
                const FrameRenderedCB& frame_rendered_cb,
+               const FirstTunnelFrameReadyCB& first_tunnel_frame_ready_cb,
                int tunnel_mode_audio_session_id,
                bool force_big_endian_hdr_metadata,
                int max_video_input_size,
@@ -107,6 +109,8 @@ class MediaDecoder final
   void WriteEndOfStream();
 
   void SetPlaybackRate(double playback_rate);
+
+  void Seek(int64_t seek_to_time);
 
   size_t GetNumberOfPendingTasks() const {
     return number_of_pending_tasks_.load();
@@ -173,6 +177,7 @@ class MediaDecoder final
                                          int size) override;
   void OnMediaCodecOutputFormatChanged() override;
   void OnMediaCodecFrameRendered(int64_t frame_timestamp) override;
+  void OnMediaCodecFirstTunnelFrameReady() override;
 
   ::starboard::shared::starboard::ThreadChecker thread_checker_;
 
@@ -181,6 +186,7 @@ class MediaDecoder final
   DrmSystem* const drm_system_;
   const FrameRenderedCB frame_rendered_cb_;
   const bool tunnel_mode_enabled_;
+  const FirstTunnelFrameReadyCB first_tunnel_frame_ready_cb_;
 
   ErrorCB error_cb_;
 

--- a/starboard/android/shared/player_components_factory.h
+++ b/starboard/android/shared/player_components_factory.h
@@ -22,6 +22,7 @@
 
 #include "starboard/android/shared/audio_decoder.h"
 #include "starboard/android/shared/audio_renderer_passthrough.h"
+#include "starboard/android/shared/audio_renderer_tunnel_pcm.h"
 #include "starboard/android/shared/audio_track_audio_sink_type.h"
 #include "starboard/android/shared/drm_system.h"
 #include "starboard/android/shared/jni_env_ext.h"
@@ -41,6 +42,7 @@
 #include "starboard/shared/starboard/player/filter/audio_decoder_internal.h"
 #include "starboard/shared/starboard/player/filter/audio_renderer_sink.h"
 #include "starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h"
+#include "starboard/shared/starboard/player/filter/media_time_provider_impl.h"
 #include "starboard/shared/starboard/player/filter/player_components.h"
 #include "starboard/shared/starboard/player/filter/video_decoder_internal.h"
 #include "starboard/shared/starboard/player/filter/video_render_algorithm.h"
@@ -174,6 +176,27 @@ class PlayerComponentsPassthrough
   std::unique_ptr<VideoRenderer> video_renderer_;
 };
 
+class PlayerComponentsTunnelPcm
+    : public starboard::shared::starboard::player::filter::PlayerComponents {
+ public:
+  PlayerComponentsTunnelPcm(
+      std::unique_ptr<AudioRendererTunnelPcm> audio_renderer,
+      std::unique_ptr<VideoRenderer> video_renderer)
+      : audio_renderer_(std::move(audio_renderer)),
+        video_renderer_(std::move(video_renderer)) {}
+
+ private:
+  // PlayerComponents methods
+  MediaTimeProvider* GetMediaTimeProvider() override {
+    return audio_renderer_.get();
+  }
+  AudioRenderer* GetAudioRenderer() override { return audio_renderer_.get(); }
+  VideoRenderer* GetVideoRenderer() override { return video_renderer_.get(); }
+
+  std::unique_ptr<AudioRendererTunnelPcm> audio_renderer_;
+  std::unique_ptr<VideoRenderer> video_renderer_;
+};
+
 // TODO: Invesigate if the implementation of member functions should be moved
 //       into .cc file.
 class PlayerComponentsFactory : public starboard::shared::starboard::player::
@@ -186,6 +209,8 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
       AudioDecoderBase;
   typedef starboard::shared::starboard::player::filter::AudioRendererSink
       AudioRendererSink;
+  typedef starboard::shared::starboard::player::filter::MediaTimeProviderImpl
+      MediaTimeProviderImpl;
   typedef starboard::shared::starboard::player::filter::AudioRendererSinkImpl
       AudioRendererSinkImpl;
   typedef starboard::shared::starboard::player::filter::PlayerComponents
@@ -194,6 +219,8 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
       VideoDecoderBase;
   typedef starboard::shared::starboard::player::filter::VideoRenderAlgorithm
       VideoRenderAlgorithmBase;
+  typedef starboard::shared::starboard::player::filter::VideoRendererImpl
+      VideoRendererImpl;
   typedef starboard::shared::starboard::player::filter::VideoRendererSink
       VideoRendererSink;
 
@@ -209,11 +236,110 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
       std::string* error_message) override {
     SB_DCHECK(error_message);
 
+    const std::string video_mime =
+        creation_parameters.video_codec() != kSbMediaVideoCodecNone
+            ? creation_parameters.video_mime()
+            : "";
+    MimeType video_mime_type(video_mime);
+
     if (creation_parameters.audio_codec() != kSbMediaAudioCodecAc3 &&
         creation_parameters.audio_codec() != kSbMediaAudioCodecEac3) {
-      SB_LOG(INFO) << "Creating non-passthrough components.";
-      return PlayerComponents::Factory::CreateComponents(creation_parameters,
-                                                         error_message);
+      int tunnel_mode_audio_session_id = -1;
+      bool enable_tunnel_mode = false;
+      if (creation_parameters.audio_codec() != kSbMediaAudioCodecNone &&
+          creation_parameters.video_codec() != kSbMediaVideoCodecNone) {
+        enable_tunnel_mode =
+            video_mime_type.GetParamBoolValue("tunnelmode", false);
+
+        SB_LOG(INFO) << "Tunnel mode is "
+                     << (enable_tunnel_mode ? "enabled. " : "disabled. ")
+                     << "Video mime parameter \"tunnelmode\" value: "
+                     << video_mime_type.GetParamStringValue("tunnelmode",
+                                                            "<not provided>")
+                     << ".";
+      } else {
+        SB_LOG(INFO)
+            << "Tunnel mode requires both an audio and video stream. "
+            << "Audio codec: "
+            << GetMediaAudioCodecName(creation_parameters.audio_codec())
+            << ", Video_codec: "
+            << GetMediaVideoCodecName(creation_parameters.video_codec())
+            << ". Tunnel mode is disabled.";
+      }
+
+      if (kForceTunnelMode && !enable_tunnel_mode) {
+        SB_LOG(INFO)
+            << "`kForceTunnelMode` is set to true, force enabling tunnel"
+            << " mode.";
+        enable_tunnel_mode = true;
+      }
+
+      bool force_secure_pipeline_under_tunnel_mode = false;
+      if (enable_tunnel_mode) {
+        if (IsTunnelModeSupported(creation_parameters,
+                                  &force_secure_pipeline_under_tunnel_mode)) {
+          tunnel_mode_audio_session_id =
+              GenerateAudioSessionId(creation_parameters);
+          SB_LOG(INFO) << "Generated tunnel mode audio session id "
+                       << tunnel_mode_audio_session_id;
+        } else {
+          SB_LOG(INFO)
+              << "IsTunnelModeSupported() failed, disable tunnel mode.";
+        }
+      } else {
+        SB_LOG(INFO) << "Tunnel mode not enabled.";
+      }
+
+      if (tunnel_mode_audio_session_id == -1) {
+        SB_LOG(INFO) << "Creating non-passthrough components.";
+        return PlayerComponents::Factory::CreateComponents(creation_parameters,
+                                                           error_message);
+      } else {
+        SB_LOG(INFO) << "Creating non-passthrough tunnel components.";
+        std::unique_ptr<AudioDecoderBase> audio_decoder;
+        std::unique_ptr<AudioRendererSink> audio_renderer_sink;
+        std::unique_ptr<VideoDecoderBase> video_decoder;
+        std::unique_ptr<VideoRenderAlgorithmBase> video_render_algorithm;
+        scoped_refptr<VideoRendererSink> video_renderer_sink;
+
+        if (!CreateSubComponents(creation_parameters, &audio_decoder,
+                                 &audio_renderer_sink, &video_decoder,
+                                 &video_render_algorithm, &video_renderer_sink,
+                                 error_message)) {
+          return std::unique_ptr<PlayerComponents>();
+        }
+
+        std::unique_ptr<MediaTimeProviderImpl> media_time_provider_impl;
+        std::unique_ptr<AudioRendererTunnelPcm> audio_renderer;
+        std::unique_ptr<VideoRendererImpl> video_renderer;
+
+        if (creation_parameters.audio_codec() != kSbMediaAudioCodecNone) {
+          SB_DCHECK(audio_decoder);
+          SB_DCHECK(audio_renderer_sink);
+
+          int max_cached_frames, min_frames_per_append;
+          GetAudioRendererParams(creation_parameters, &max_cached_frames,
+                                 &min_frames_per_append);
+
+          audio_renderer.reset(new AudioRendererTunnelPcm(
+              std::move(audio_decoder), std::move(audio_renderer_sink),
+              creation_parameters.audio_stream_info(), max_cached_frames,
+              min_frames_per_append));
+        }
+
+        if (creation_parameters.video_codec() != kSbMediaVideoCodecNone) {
+          SB_DCHECK(video_decoder);
+          SB_DCHECK(video_render_algorithm);
+
+          video_renderer.reset(new VideoRendererImpl(
+              std::move(video_decoder), audio_renderer.get(),
+              std::move(video_render_algorithm), video_renderer_sink));
+        }
+
+        SB_DCHECK(audio_renderer || video_renderer);
+        return std::unique_ptr<PlayerComponents>(new PlayerComponentsTunnelPcm(
+            std::move(audio_renderer), std::move(video_renderer)));
+      }
     }
 
     if (!creation_parameters.audio_mime().empty()) {

--- a/starboard/android/shared/player_components_factory.h
+++ b/starboard/android/shared/player_components_factory.h
@@ -55,7 +55,7 @@ namespace shared {
 // Tunnel mode has to be enabled explicitly by the web app via mime attributes
 // "tunnelmode", set the following variable to true to force enabling tunnel
 // mode on all playbacks.
-constexpr bool kForceTunnelMode = false;
+constexpr bool kForceTunnelMode = true;
 
 // By default, the platform Opus decoder is only enabled for encrypted playback.
 // Set the following variable to true to force it for clear playback.
@@ -74,12 +74,12 @@ constexpr bool kForceResetSurfaceUnderTunnelMode = true;
 // By default, Cobalt recreates MediaCodec when Reset() during Seek().
 // Set the following variable to true to force it Flush() MediaCodec
 // during Seek().
-constexpr bool kForceFlushDecoderDuringReset = false;
+constexpr bool kForceFlushDecoderDuringReset = true;
 
 // By default, Cobalt teardowns AudioDecoder during Reset().
 // Set the following variable to true to force it reset audio decoder
 // during Reset(). This should be enabled with kForceFlushDecoderDuringReset.
-constexpr bool kForceResetAudioDecoder = false;
+constexpr bool kForceResetAudioDecoder = true;
 
 // This class allows us to force int16 sample type when tunnel mode is enabled.
 class AudioRendererSinkAndroid : public ::starboard::shared::starboard::player::

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -97,6 +97,8 @@ class VideoDecoder
   void UpdateDecodeTargetSizeAndContentRegion_Locked();
   void SetPlaybackRate(double playback_rate);
 
+  void Seek(int64_t seek_to_time);
+
   void OnNewTextureAvailable();
 
   bool is_decoder_created() const { return media_decoder_ != NULL; }
@@ -118,7 +120,9 @@ class VideoDecoder
 
   void TryToSignalPrerollForTunnelMode();
   bool IsFrameRenderedCallbackEnabled();
+  bool IsFirstTunnelFrameReadyCallbackEnabled();
   void OnFrameRendered(int64_t frame_timestamp);
+  void OnFirstTunnelFrameRendered();
   void OnTunnelModePrerollTimeout();
   void OnTunnelModeCheckForNeedMoreInput();
 
@@ -168,6 +172,8 @@ class VideoDecoder
   // Preroll in tunnel mode is handled in this class instead of in the renderer.
   atomic_bool tunnel_mode_prerolling_{true};
   atomic_bool tunnel_mode_frame_rendered_;
+  atomic_bool first_tunnel_frame_ready_{false};
+  starboard::shared::starboard::player::JobQueue::JobToken job_token_;
 
   // If decode-to-texture is enabled, then we store the decode target texture
   // inside of this |decode_target_| member.
@@ -201,6 +207,7 @@ class VideoDecoder
   bool end_of_stream_written_ = false;
   volatile int64_t first_buffer_timestamp_;  // microseconds
   atomic_bool has_new_texture_available_;
+  int64_t seek_to_time_ = 0;
 
   // Use |owns_video_surface_| only on decoder thread, to avoid unnecessary
   // invocation of ReleaseVideoSurface(), though ReleaseVideoSurface() would

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -31,10 +31,6 @@ const int64_t kMaxAllowedSkew = 5'000;  // 5ms
 
 }  // namespace
 
-int64_t VideoFrameTracker::seek_to_time() const {
-  return seek_to_time_;
-}
-
 void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
   SB_DCHECK(thread_checker_.CalledOnValidThread());
 

--- a/starboard/android/shared/video_frame_tracker.h
+++ b/starboard/android/shared/video_frame_tracker.h
@@ -30,8 +30,6 @@ class VideoFrameTracker {
   explicit VideoFrameTracker(int max_pending_frames_size)
       : max_pending_frames_size_(max_pending_frames_size) {}
 
-  int64_t seek_to_time() const;
-
   void OnInputBuffer(int64_t timestamp);
 
   void OnFrameRendered(int64_t frame_timestamp);

--- a/starboard/android/shared/video_frame_tracker_test.cc
+++ b/starboard/android/shared/video_frame_tracker_test.cc
@@ -115,7 +115,6 @@ TEST(VideoFrameTrackerTest, RenderQueueIsClearedOnSeek) {
 
   const int64_t kSeekToTime = 90'000;  // 90ms
   video_frame_tracker.Seek(kSeekToTime);
-  ASSERT_EQ(kSeekToTime, video_frame_tracker.seek_to_time());
 
   video_frame_tracker.OnInputBuffer(90000);
   video_frame_tracker.OnInputBuffer(100000);

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -196,7 +196,7 @@ scoped_refptr<DecodedAudio> AudioTimeStretcher::Read(int requested_frames,
     // Includes the leftover partial frame from last request. However, we can
     // only skip over complete frames, so a partial frame may remain for next
     // time.
-    muted_partial_frame_ += frames_to_render * playback_rate;
+    muted_partial_frame_ += frames_to_render * 1;
     // Handle the case where muted_partial_frame_ rounds up to
     // audio_buffer_.frames()+1.
     int seek_frames = std::min(static_cast<int>(muted_partial_frame_),
@@ -232,8 +232,7 @@ scoped_refptr<DecodedAudio> AudioTimeStretcher::Read(int requested_frames,
   do {
     rendered_frames += WriteCompletedFramesTo(
         requested_frames - rendered_frames, rendered_frames, dest);
-  } while (rendered_frames < requested_frames &&
-           RunOneWsolaIteration(playback_rate));
+  } while (rendered_frames < requested_frames && RunOneWsolaIteration(1));
   dest->ShrinkTo(rendered_frames * bytes_per_frame_);
   return dest;
 }


### PR DESCRIPTION
We modify some seek/preroll logic using OnFirstTunnelFrameReadyListener and BUFFER_FLAG_DECODE_ONLY.

Change-Id: I056279784b22b8174ec636573756a3bc6e258f96

b/244649793