### PR TITLE
Implement ContinunousAudioTrackSink

### DIFF
--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -43,7 +43,7 @@ using ::starboard::shared::starboard::media::GetBytesPerSample;
 // into AudioTrack. Instead of callnig pause/play, it switches between silence
 // data and actual data.
 // TODO: b/186660620: Replace this constant with feature flag.
-constexpr bool kUseContinuousAudioTrackSink = false;
+constexpr bool kUseContinuousAudioTrackSink = true;
 
 // The maximum number of frames that can be written to android audio track per
 // write request. If we don't set this cap for writing frames to audio track,

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -43,7 +43,7 @@ using ::starboard::shared::starboard::media::GetBytesPerSample;
 // into AudioTrack. Instead of callnig pause/play, it switches between silence
 // data and actual data.
 // TODO: b/186660620: Replace this constant with feature flag.
-constexpr bool kUseContinuousAudioTrackSink = true;
+constexpr bool kUseContinuousAudioTrackSink = false;
 
 // The maximum number of frames that can be written to android audio track per
 // write request. If we don't set this cap for writing frames to audio track,

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -163,6 +163,15 @@ void AudioTrackBridge::Stop(JniEnvExt* env /*= JniEnvExt::Get()*/) {
   SB_LOG(INFO) << "AudioTrackBridge stopped.";
 }
 
+void AudioTrackBridge::Flush(JniEnvExt* env /*= JniEnvExt::Get()*/) {
+  SB_DCHECK(env);
+  SB_DCHECK(is_valid());
+
+  // Flushes the audio data currently queued for playback. Any data that has
+  // been written but not yet presented will be discarded.
+  env->CallVoidMethodOrAbort(j_audio_track_bridge_, "flush", "()V");
+}
+
 void AudioTrackBridge::PauseAndFlush(JniEnvExt* env /*= JniEnvExt::Get()*/) {
   SB_DCHECK(env);
   SB_DCHECK(is_valid());

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -163,15 +163,6 @@ void AudioTrackBridge::Stop(JniEnvExt* env /*= JniEnvExt::Get()*/) {
   SB_LOG(INFO) << "AudioTrackBridge stopped.";
 }
 
-void AudioTrackBridge::Flush(JniEnvExt* env /*= JniEnvExt::Get()*/) {
-  SB_DCHECK(env);
-  SB_DCHECK(is_valid());
-
-  // Flushes the audio data currently queued for playback. Any data that has
-  // been written but not yet presented will be discarded.
-  env->CallVoidMethodOrAbort(j_audio_track_bridge_, "flush", "()V");
-}
-
 void AudioTrackBridge::PauseAndFlush(JniEnvExt* env /*= JniEnvExt::Get()*/) {
   SB_DCHECK(env);
   SB_DCHECK(is_valid());

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -56,6 +56,7 @@ class AudioTrackBridge {
   void Play(JniEnvExt* env = JniEnvExt::Get());
   void Pause(JniEnvExt* env = JniEnvExt::Get());
   void Stop(JniEnvExt* env = JniEnvExt::Get());
+  void Flush(JniEnvExt* env = JniEnvExt::Get());
   void PauseAndFlush(JniEnvExt* env = JniEnvExt::Get());
 
   // Returns zero or the positive number of samples written, or a negative error

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -56,7 +56,6 @@ class AudioTrackBridge {
   void Play(JniEnvExt* env = JniEnvExt::Get());
   void Pause(JniEnvExt* env = JniEnvExt::Get());
   void Stop(JniEnvExt* env = JniEnvExt::Get());
-  void Flush(JniEnvExt* env = JniEnvExt::Get());
   void PauseAndFlush(JniEnvExt* env = JniEnvExt::Get());
 
   // Returns zero or the positive number of samples written, or a negative error

--- a/starboard/android/shared/continuous_audio_track_sink.cc
+++ b/starboard/android/shared/continuous_audio_track_sink.cc
@@ -39,6 +39,11 @@ using ::starboard::shared::starboard::media::GetBytesPerSample;
 // audio track completely.
 const int kMaxFramesPerRequest = 64 * 1024;
 
+// We need to wait some time for flush operation to complete. Otherwise, the
+// data that is written immediately after flush seems to be lost.
+// TODO: b/415819457 - Replace time-wait with event-wait.
+constexpr int64_t kFlushCompleteWaitUs = 10'000;
+
 constexpr int kSilenceFramesPerAppend = 1024;
 static_assert(kSilenceFramesPerAppend <= kMaxFramesPerRequest);
 
@@ -228,6 +233,9 @@ void ContinuousAudioTrackSink::AudioThreadFunc() {
       } else {
         SB_LOG(INFO) << "Switching to play silence";
       }
+
+      usleep(kFlushCompleteWaitUs);
+      continue;
     }
 
     if (!is_playing) {


### PR DESCRIPTION
- `ContinousAudioTrackSink` continuously feeds audio data into `AudioTrackSink`. Instead of calling `Play`/`Pause`, it switches the souce of data between audio source and silence buffer. This is because `AudioTrackSink::Play()` needs 100+ msec of lead time, which interrupts scheduling of video rendering.

- `ContinuousAudioTrackSink` reports `consumed frame` to `AudioSource`, calculating only consumed frames from audio source, not including silence data.

- Verified this change work using [test cases](https://docs.google.com/document/d/1PvxJvqLmQT5RFfFDtMFQ-ifxeUwqE6Repu3pvOUzYLs/edit?resourcekey=0-TT0tc4eoq8-KIFnRiBALwg&tab=t.0#heading=h.awqtjvc225a6)
  - resolved initial video freeze
  - AV is in sync, during play/seek/pause with x1/x0.5/x2.0 playback speed.
 

b/186660620