### PR TITLE
Re-enable media unitttests, previously disabled due to missing ffmpeg.

### DIFF
--- a/cobalt/testing/filters/linux-x64x11-evergreen/nplb_filter.json
+++ b/cobalt/testing/filters/linux-x64x11-evergreen/nplb_filter.json
@@ -1,7 +1,3 @@
 {
-  "failing_tests": [
-    "SbMediaSetAudioWriteDurationTests/SbMediaSetAudioWriteDurationTest.*",
-    "MultiplePlayerTest.*",
-    "VerticalVideoTests/VerticalVideoTest.*"
-  ]
+  "failing_tests": []
 }

--- a/cobalt/testing/filters/linux-x64x11/nplb_filter.json
+++ b/cobalt/testing/filters/linux-x64x11/nplb_filter.json
@@ -1,7 +1,3 @@
 {
-  "failing_tests": [
-    "SbMediaSetAudioWriteDurationTests/SbMediaSetAudioWriteDurationTest.*",
-    "MultiplePlayerTest.*",
-    "VerticalVideoTests/VerticalVideoTest.*"
-  ]
+  "failing_tests": []
 }

--- a/starboard/shared/starboard/player/filter/testing/BUILD.gn
+++ b/starboard/shared/starboard/player/filter/testing/BUILD.gn
@@ -28,14 +28,8 @@ if (current_toolchain == starboard_toolchain) {
       "audio_resampler_test.cc",
       "file_cache_reader_test.cc",
       "media_time_provider_impl_test.cc",
-
-      # These two below end up crashing in the Renderer X11 output destruction
-      # sequence. That should not happen because unit tests should not interact
-      # so deeply with the system (there're NPLB tests for that). For the time
-      # being, disable.
-      # TODO(b/384819454): Audit tests are re-enabled as unit tests.
-      #"player_components_test.cc",
-      #"video_decoder_test.cc",
+      "player_components_test.cc",
+      "video_decoder_test.cc",
       "video_decoder_test_fixture.cc",
       "video_decoder_test_fixture.h",
       "video_frame_cadence_pattern_generator_test.cc",


### PR DESCRIPTION
#5717 added ffmpeg to unittest docker image.

We can run the those tests, previously disabled due to missing ffmpeg
 
b/402459390
b/411115002
b/416533504