### PR TITLE
Fixing the position of the permissions field in the Chromium sync workflow

### DIFF
--- a/.github/workflows/sync_chromium_branches.yaml
+++ b/.github/workflows/sync_chromium_branches.yaml
@@ -8,6 +8,8 @@ permissions: read-all
 jobs:
   sync:
     runs-on: [self-hosted, chrobalt-linux-runner]
+    permissions:
+      contents: write
     strategy:
       fail-fast: false
       matrix:
@@ -33,8 +35,6 @@ jobs:
           git fetch --depth=1 upstream refs/branch-heads/${{ matrix.branch.branch_num }}:refs/remotes/branch/${{ matrix.branch.branch_num }}
           git diff HEAD branch/${{ matrix.branch.branch_num }} --binary > chromium_diff.patch
       - name: Apply and push diffs
-        permissions:
-          contents: write
         run: |
           if [ test -s chromium_diff.patch ]; then
             echo "Applying diff..."


### PR DESCRIPTION
The workflow is currently not working. See https://github.com/youtube/cobalt/actions/runs/14961045205 for an example.

b/409339952