### PR TITLE
Make AvcParameterSets::Create return only valid AvcParameterSets or

### DIFF
--- a/starboard/shared/starboard/media/avc_util.h
+++ b/starboard/shared/starboard/media/avc_util.h
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "starboard/common/log.h"
+#include "starboard/common/optional.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 #include "starboard/types.h"
@@ -49,11 +50,12 @@ class AvcParameterSets {
   static const uint8_t kSpsStartCode = 0x67;
   static const uint8_t kPpsStartCode = 0x68;
 
-  // Only |format == kAnnexB| is supported, which is checked in the ctor.
-  AvcParameterSets(Format format, const uint8_t* data, size_t size);
-
+  // Creates an AvcParameterSets instance if the provided data is valid for the
+  // given format. Otherwise, returns nullopt.
+  static optional<AvcParameterSets> Create(Format format,
+                                           const uint8_t* data,
+                                           size_t size);
   Format format() const { return format_; }
-  bool is_valid() const { return is_valid_; }
   bool has_sps_and_pps() const {
     return first_sps_index_ != -1 && first_pps_index_ != -1;
   }
@@ -92,6 +94,9 @@ class AvcParameterSets {
   bool operator!=(const AvcParameterSets& that) const;
 
  private:
+  // Only |format == kAnnexB| is supported, which is checked in the ctor.
+  AvcParameterSets(Format format, const uint8_t* data, size_t size);
+
   Format format_ = kAnnexB;
   bool is_valid_ = false;
   int first_sps_index_ = -1;

--- a/starboard/shared/starboard/media/avc_util_test.cc
+++ b/starboard/shared/starboard/media/avc_util_test.cc
@@ -85,7 +85,6 @@ std::vector<uint8_t> ConvertAnnexBToAvcc(
 void VerifyConvertTo(const AvcParameterSets& parameter_sets_in_annex_b) {
   auto parameter_sets_headless = parameter_sets_in_annex_b.ConvertTo(kHeadless);
 
-  ASSERT_TRUE(parameter_sets_headless.is_valid());
   ASSERT_EQ(parameter_sets_headless.format(), kHeadless);
   ASSERT_EQ(parameter_sets_headless.has_sps_and_pps(),
             parameter_sets_in_annex_b.has_sps_and_pps());
@@ -120,10 +119,9 @@ void VerifyAnnexB(const std::vector<uint8_t>& nalus_in_annex_b,
                   const std::vector<uint8_t>& first_sps_in_annex_b,
                   const std::vector<uint8_t>& first_pps_in_annex_b,
                   const std::vector<uint8_t>& parameter_sets_in_annex_b) {
-  AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                  nalus_in_annex_b.size());
+  auto parameter_sets = *AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
-  ASSERT_TRUE(parameter_sets.is_valid());
   ASSERT_EQ(parameter_sets.format(), kAnnexB);
   ASSERT_TRUE(parameter_sets.has_sps_and_pps());
   ASSERT_EQ(parameter_sets.first_sps(), first_sps_in_annex_b);
@@ -150,8 +148,8 @@ void VerifyAnnexB(const std::vector<uint8_t>& nalus_in_annex_b,
 }
 
 void VerifyAllEmpty(const std::vector<uint8_t>& nalus_in_annex_b) {
-  AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                  nalus_in_annex_b.size());
+  auto parameter_sets = *AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
   ASSERT_EQ(parameter_sets.format(), kAnnexB);
 
@@ -160,7 +158,6 @@ void VerifyAllEmpty(const std::vector<uint8_t>& nalus_in_annex_b) {
       parameter_sets = parameter_sets.ConvertTo(kHeadless);
       ASSERT_EQ(parameter_sets.format(), kHeadless);
     }
-    ASSERT_TRUE(parameter_sets.is_valid());
     ASSERT_FALSE(parameter_sets.has_sps_and_pps());
     ASSERT_TRUE(parameter_sets.GetAddresses().empty());
     ASSERT_TRUE(parameter_sets.GetSizesInBytes().empty());
@@ -172,10 +169,10 @@ void VerifyAllEmpty(const std::vector<uint8_t>& nalus_in_annex_b) {
 
 bool HasEqualParameterSets(const std::vector<uint8_t>& nalus_in_annex_b_1,
                            const std::vector<uint8_t>& nalus_in_annex_b_2) {
-  AvcParameterSets parameter_sets_1(kAnnexB, nalus_in_annex_b_1.data(),
-                                    nalus_in_annex_b_1.size());
-  AvcParameterSets parameter_sets_2(kAnnexB, nalus_in_annex_b_2.data(),
-                                    nalus_in_annex_b_2.size());
+  auto parameter_sets_1 = *AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b_1.data(), nalus_in_annex_b_1.size());
+  auto parameter_sets_2 = *AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b_2.data(), nalus_in_annex_b_2.size());
 
   SB_CHECK((parameter_sets_1 == parameter_sets_2) !=
            (parameter_sets_1 != parameter_sets_2));
@@ -184,17 +181,17 @@ bool HasEqualParameterSets(const std::vector<uint8_t>& nalus_in_annex_b_1,
 }
 
 TEST(AvcParameterSetsTest, Ctor) {
-  AvcParameterSets parameter_sets_1(kAnnexB, nullptr, 0);
-  AvcParameterSets parameter_sets_2(kAnnexB, kSpsInAnnexB.data(),
-                                    kSpsInAnnexB.size());
-  AvcParameterSets parameter_sets_3(kAnnexB, kPpsInAnnexB.data(),
-                                    kPpsInAnnexB.size());
-  AvcParameterSets parameter_sets_4(kAnnexB, kIdrInAnnexB.data(),
-                                    kIdrInAnnexB.size());
+  auto parameter_sets_1 = *AvcParameterSets::Create(kAnnexB, nullptr, 0);
+  auto parameter_sets_2 = *AvcParameterSets::Create(
+      kAnnexB, kSpsInAnnexB.data(), kSpsInAnnexB.size());
+  auto parameter_sets_3 = *AvcParameterSets::Create(
+      kAnnexB, kPpsInAnnexB.data(), kPpsInAnnexB.size());
+  auto parameter_sets_4 = *AvcParameterSets::Create(
+      kAnnexB, kIdrInAnnexB.data(), kIdrInAnnexB.size());
 
   auto nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
-  AvcParameterSets parameter_sets_5(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
+  auto parameter_sets_5 = *AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
 }
 
 TEST(AvcParameterSetsTest, SingleSpsAndPps) {
@@ -247,10 +244,9 @@ TEST(AvcParameterSetsTest, SpsWithoutPps) {
   for (int i = 0; i < 5; ++i) {
     auto nalus_in_annex_b = leading_sps_nalus + kIdrInAnnexB;
 
-    AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
+    auto parameter_sets = *AvcParameterSets::Create(
+        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
-    ASSERT_TRUE(parameter_sets.is_valid());
     ASSERT_FALSE(parameter_sets.has_sps_and_pps());
     ASSERT_EQ(kSpsInAnnexB, parameter_sets.first_sps());
     ASSERT_EQ(parameter_sets.combined_size_in_bytes(),
@@ -272,10 +268,9 @@ TEST(AvcParameterSetsTest, PpsWithoutSps) {
   for (int i = 0; i < 5; ++i) {
     auto nalus_in_annex_b = leading_pps_nalus + kIdrInAnnexB;
 
-    AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
+    auto parameter_sets = *AvcParameterSets::Create(
+        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
-    ASSERT_TRUE(parameter_sets.is_valid());
     ASSERT_FALSE(parameter_sets.has_sps_and_pps());
     ASSERT_EQ(kPpsInAnnexB, parameter_sets.first_pps());
     ASSERT_EQ(parameter_sets.combined_size_in_bytes(),
@@ -314,8 +309,9 @@ TEST(AvcParameterSetsTest, MultipleSpsAndPpsWithoutPayload) {
         break;
     }
 
-    AvcParameterSets parameter_sets(kAnnexB, parameter_sets_in_annex_b.data(),
-                                    parameter_sets_in_annex_b.size());
+    auto parameter_sets =
+        *AvcParameterSets::Create(kAnnexB, parameter_sets_in_annex_b.data(),
+                                  parameter_sets_in_annex_b.size());
 
     VerifyAnnexB(parameter_sets_in_annex_b, kSpsInAnnexB, kPpsInAnnexB,
                  parameter_sets_in_annex_b);
@@ -353,9 +349,8 @@ TEST(AvcParameterSetsTest, SpsAndPpsAfterIdrWithoutSpsAndPps) {
 }
 
 TEST(AvcParameterSetsTest, Nullptr) {
-  AvcParameterSets parameter_sets(kAnnexB, nullptr, 0);
+  auto parameter_sets = *AvcParameterSets::Create(kAnnexB, nullptr, 0);
 
-  ASSERT_TRUE(parameter_sets.is_valid());
   ASSERT_EQ(parameter_sets.format(), kAnnexB);
   ASSERT_FALSE(parameter_sets.has_sps_and_pps());
   ASSERT_TRUE(parameter_sets.GetAddresses().empty());
@@ -365,10 +360,10 @@ TEST(AvcParameterSetsTest, Nullptr) {
 
 TEST(AvcParameterSetsTest, NaluHeaderWithoutType) {
   {
-    AvcParameterSets parameter_sets(kAnnexB, kNaluHeaderOnlyInAnnexB.data(),
-                                    kNaluHeaderOnlyInAnnexB.size());
+    auto parameter_sets =
+        *AvcParameterSets::Create(kAnnexB, kNaluHeaderOnlyInAnnexB.data(),
+                                  kNaluHeaderOnlyInAnnexB.size());
 
-    ASSERT_TRUE(parameter_sets.is_valid());
     ASSERT_EQ(parameter_sets.format(), kAnnexB);
     ASSERT_FALSE(parameter_sets.has_sps_and_pps());
     ASSERT_TRUE(parameter_sets.GetAddresses().empty());
@@ -413,9 +408,9 @@ TEST(AvcParameterSetsTest, InvalidNaluHeader) {
         parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
     nalus_in_annex_b.erase(nalus_in_annex_b.begin());  // One less 0
 
-    AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
-    ASSERT_FALSE(parameter_sets.is_valid());
+    auto parameter_sets = AvcParameterSets::Create(
+        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+    ASSERT_FALSE(parameter_sets.has_engaged());
   }
   {
     auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
@@ -423,9 +418,9 @@ TEST(AvcParameterSetsTest, InvalidNaluHeader) {
         parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
     nalus_in_annex_b.insert(nalus_in_annex_b.begin(), 0);  // One extra 0
 
-    AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
-    ASSERT_FALSE(parameter_sets.is_valid());
+    auto parameter_sets = AvcParameterSets::Create(
+        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+    ASSERT_FALSE(parameter_sets.has_engaged());
   }
 }
 

--- a/starboard/shared/starboard/media/codec_util.cc
+++ b/starboard/shared/starboard/media/codec_util.cc
@@ -39,9 +39,10 @@ VideoConfig::VideoConfig(SbMediaVideoCodec video_codec,
   } else if (video_codec == kSbMediaVideoCodecAv1) {
     video_codec_ = video_codec;
   } else if (video_codec == kSbMediaVideoCodecH264) {
-    avc_parameter_sets_ =
-        AvcParameterSets(AvcParameterSets::kAnnexB, data, size);
-    if (avc_parameter_sets_->is_valid()) {
+    auto avc_parameter_sets =
+        AvcParameterSets::Create(AvcParameterSets::kAnnexB, data, size);
+    if (avc_parameter_sets) {
+      avc_parameter_sets_ = std::move(avc_parameter_sets);
       video_codec_ = video_codec;
     }
   } else {

--- a/starboard/shared/starboard/media/codec_util_test.cc
+++ b/starboard/shared/starboard/media/codec_util_test.cc
@@ -160,9 +160,9 @@ TEST(VideoConfigTest, H264MultiSpsPps) {
                                   nalus_in_annex_b.size());
   EXPECT_TRUE(config_single_sps_pps != config_dual_sps_pps);
   EXPECT_FALSE(config_single_sps_pps == config_dual_sps_pps);
-  EXPECT_TRUE(config_dual_sps_pps.avc_parameter_sets() ==
-              AvcParameterSets(kAnnexB, nalus_in_annex_b.data(),
-                               nalus_in_annex_b.size()));
+  EXPECT_EQ(config_dual_sps_pps.avc_parameter_sets(),
+            *AvcParameterSets::Create(kAnnexB, nalus_in_annex_b.data(),
+                                      nalus_in_annex_b.size()));
 
   // Same resolution, different parameter sets.
   nalus_in_annex_b =


### PR DESCRIPTION
- This is to improve readability of the code and NO-OP change

b/414009070