### PR TITLE
Refine usage of StarboardRenderer in its wrapper

### DIFF
--- a/media/mojo/services/gpu_mojo_media_client.cc
+++ b/media/mojo/services/gpu_mojo_media_client.cc
@@ -291,7 +291,7 @@ std::unique_ptr<Renderer> GpuMojoMediaClient::CreateStarboardRenderer(
       config.max_video_capabilities,
       std::move(renderer_extension_receiver),
       std::move(client_extension_remote));
-  return CreatePlatformStarboardRenderer(traits);
+  return CreatePlatformStarboardRenderer(std::move(traits));
 }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/media/mojo/services/gpu_mojo_media_client.h
+++ b/media/mojo/services/gpu_mojo_media_client.h
@@ -151,13 +151,14 @@ struct StarboardRendererTraits {
           renderer_extension_receiver,
       mojo::PendingRemote<mojom::StarboardRendererClientExtension>
           client_extension_remote);
+  StarboardRendererTraits(StarboardRendererTraits&& that) = default;
   ~StarboardRendererTraits();
 };
 
 // Creates a platform-specific media::StarboardRenderer.
 // This is used on Cobalt (android/linux).
 std::unique_ptr<Renderer> CreatePlatformStarboardRenderer(
-    StarboardRendererTraits& traits);
+    StarboardRendererTraits traits);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 // Creates a CDM factory, right now only used on android and chromeos.

--- a/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
+++ b/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
@@ -50,8 +50,8 @@ std::unique_ptr<AudioEncoder> CreatePlatformAudioEncoder(
 }
 
 std::unique_ptr<Renderer> CreatePlatformStarboardRenderer(
-    StarboardRendererTraits& traits) {
-  return std::make_unique<StarboardRendererWrapper>(traits);
+    StarboardRendererTraits traits) {
+  return std::make_unique<StarboardRendererWrapper>(std::move(traits));
 }
 
 std::unique_ptr<CdmFactory> CreatePlatformCdmFactory(

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -23,20 +23,20 @@
 namespace media {
 
 StarboardRendererWrapper::StarboardRendererWrapper(
-    StarboardRendererTraits& traits)
+    StarboardRendererTraits traits)
     : renderer_extension_receiver_(
           this,
           std::move(traits.renderer_extension_receiver)),
       client_extension_remote_(std::move(traits.client_extension_remote),
                                traits.task_runner),
-      renderer_(std::make_unique<StarboardRenderer>(
+      renderer_(
           std::move(traits.task_runner),
           std::make_unique<MojoMediaLog>(std::move(traits.media_log_remote),
                                          traits.task_runner),
           traits.overlay_plane_id,
           traits.audio_write_duration_local,
           traits.audio_write_duration_remote,
-          traits.max_video_capabilities)) {
+          traits.max_video_capabilities) {
   DETACH_FROM_THREAD(thread_checker_);
 }
 
@@ -55,51 +55,51 @@ void StarboardRendererWrapper::Initialize(MediaResource* media_resource,
     // decode-to-texture mode.
   }
 
-  renderer_->SetStarboardRendererCallbacks(
+  renderer_.SetStarboardRendererCallbacks(
       base::BindRepeating(
           &StarboardRendererWrapper::OnPaintVideoHoleFrameByStarboard,
           weak_factory_.GetWeakPtr()),
       base::BindRepeating(
           &StarboardRendererWrapper::OnUpdateStarboardRenderingModeByStarboard,
           weak_factory_.GetWeakPtr()));
-  renderer_->Initialize(media_resource, client, std::move(init_cb));
+  renderer_.Initialize(media_resource, client, std::move(init_cb));
 }
 
 void StarboardRendererWrapper::Flush(base::OnceClosure flush_cb) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  renderer_->Flush(std::move(flush_cb));
+  renderer_.Flush(std::move(flush_cb));
 }
 
 void StarboardRendererWrapper::StartPlayingFrom(base::TimeDelta time) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  renderer_->StartPlayingFrom(time);
+  renderer_.StartPlayingFrom(time);
 }
 
 void StarboardRendererWrapper::SetPlaybackRate(double playback_rate) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  renderer_->SetPlaybackRate(playback_rate);
+  renderer_.SetPlaybackRate(playback_rate);
 }
 
 void StarboardRendererWrapper::SetVolume(float volume) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  renderer_->SetVolume(volume);
+  renderer_.SetVolume(volume);
 }
 
 void StarboardRendererWrapper::SetCdm(CdmContext* cdm_context,
                                       CdmAttachedCB cdm_attached_cb) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  renderer_->SetCdm(cdm_context, std::move(cdm_attached_cb));
+  renderer_.SetCdm(cdm_context, std::move(cdm_attached_cb));
 }
 
 void StarboardRendererWrapper::SetLatencyHint(
     absl::optional<base::TimeDelta> latency_hint) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  renderer_->SetLatencyHint(latency_hint);
+  renderer_.SetLatencyHint(latency_hint);
 }
 
 base::TimeDelta StarboardRendererWrapper::GetMediaTime() {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  return renderer_->GetMediaTime();
+  return renderer_.GetMediaTime();
 }
 
 RendererType StarboardRendererWrapper::GetRendererType() {
@@ -110,7 +110,7 @@ RendererType StarboardRendererWrapper::GetRendererType() {
 void StarboardRendererWrapper::OnVideoGeometryChange(
     const gfx::Rect& output_rect) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  renderer_->OnVideoGeometryChange(output_rect);
+  renderer_.OnVideoGeometryChange(output_rect);
 }
 
 void StarboardRendererWrapper::OnGpuChannelTokenReady(

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -48,7 +48,7 @@ class StarboardRendererWrapper final
   using RendererExtension = mojom::StarboardRendererExtension;
   using ClientExtension = mojom::StarboardRendererClientExtension;
 
-  StarboardRendererWrapper(StarboardRendererTraits& traits);
+  explicit StarboardRendererWrapper(StarboardRendererTraits traits);
 
   StarboardRendererWrapper(const StarboardRendererWrapper&) = delete;
   StarboardRendererWrapper& operator=(const StarboardRendererWrapper&) = delete;
@@ -80,7 +80,7 @@ class StarboardRendererWrapper final
 
   mojo::Receiver<RendererExtension> renderer_extension_receiver_;
   mojo::Remote<ClientExtension> client_extension_remote_;
-  std::unique_ptr<StarboardRenderer> renderer_;
+  StarboardRenderer renderer_;
   mojom::CommandBufferIdPtr command_buffer_id_;
 
   base::WeakPtrFactory<StarboardRendererWrapper> weak_factory_{this};


### PR DESCRIPTION
1. Let StarboardRendererWrapper contain StarboardRenderer instead of containing a std::unique_ptr<StarboardRenderer>.  It reduces one level of indirection.
2. Add move ctor to StarboardRendererTraits so it can be moved instead of passing by non-const reference.

b/326827007