### PR TITLE
No omit frame pointer for devel and debug mode

### DIFF
--- a/build/config/sanitizers/BUILD.gn
+++ b/build/config/sanitizers/BUILD.gn
@@ -337,7 +337,6 @@ config("cfi_flags") {
         cflags += [
           "-fno-inline-functions",
           "-fno-inline",
-          "-fno-omit-frame-pointer",
           "-O1",
         ]
       }

--- a/starboard/build/config/modular/BUILD.gn
+++ b/starboard/build/config/modular/BUILD.gn
@@ -65,6 +65,8 @@ config("modular") {
     cflags += [
       "-O0",
       "-frtti",
+      # Required by sanitize and sceDbgBacktraceSelf (ps5).
+      "-fno-omit-frame-pointer",
     ]
     if (!cobalt_fastbuild) {
       cflags += [
@@ -76,6 +78,8 @@ config("modular") {
     cflags += [
       "-O2",
       "-frtti",
+      # Required by sanitize and sceDbgBacktraceSelf (ps5).
+      "-fno-omit-frame-pointer",
     ]
     if (!cobalt_fastbuild) {
       cflags += [
@@ -87,6 +91,8 @@ config("modular") {
     cflags += [
       "-fno-rtti",
       "-gline-tables-only",
+      # Disable usage of frame pointers.
+      "-fomit-frame-pointer",
     ]
   }
 
@@ -108,9 +114,6 @@ config("modular") {
 
       # Enable unwind tables used by libunwind for stack traces.
       "-funwind-tables",
-
-      # Disable usage of frame pointers.
-      "-fomit-frame-pointer",
 
       # Don"t warn about the "struct foo f = {0};" initialization pattern.
       "-Wno-missing-field-initializers",
@@ -152,7 +155,6 @@ config("modular") {
   if (use_asan) {
     cflags += [
       "-fsanitize=address",
-      "-fno-omit-frame-pointer",
     ]
 
     defines += [ "ADDRESS_SANITIZER" ]
@@ -163,7 +165,6 @@ config("modular") {
   } else if (use_tsan) {
     cflags += [
       "-fsanitize=thread",
-      "-fno-omit-frame-pointer",
     ]
 
     defines += [ "THREAD_SANITIZER" ]


### PR DESCRIPTION
This PR adds the -fno-omit-frame-pointer compiler flag to ensure proper stack frame generation during function calls. Without this flag, the compiler may omit frame pointers for optimization purposes, which breaks tools relying on predictable stack frames.

Specifically, this change addresses an issue where sceDbgBacktraceSelf fails to generate accurate backtraces. By preserving the frame pointer, we restore compatibility with sceDbgBacktraceSelf, enabling correct stack unwinding and debugging.