### PR TITLE
Don't propagate configs in hermetic builds

### DIFF
--- a/cobalt/build/configs/variables.gni
+++ b/cobalt/build/configs/variables.gni
@@ -23,6 +23,8 @@ declare_args() {
 
 sb_is_evergreen = use_evergreen && current_toolchain == default_toolchain
 
+# TODO: b/400818107 - Consider deprecating sb_is_modular, or always set it to
+# true for non-android builds.
 sb_is_modular = use_evergreen || build_with_separate_cobalt_toolchain
 
 declare_args() {

--- a/starboard/elf_loader/BUILD.gn
+++ b/starboard/elf_loader/BUILD.gn
@@ -170,6 +170,7 @@ if (current_toolchain == starboard_toolchain) {
 
     deps = [
       "//starboard:starboard_with_main",
+      "//starboard/common",
       "//testing/gmock",
       "//testing/gtest",
     ]

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -334,6 +334,7 @@ if (current_toolchain == starboard_toolchain) {
     configs += [ "//starboard/build/config:starboard_implementation" ]
 
     deps = [
+      ":starboard_platform",
       "//starboard:starboard_with_main",
       "//starboard/shared/starboard/player/filter/testing:test_util",
       "//testing/gmock",

--- a/starboard/linux/x64x11/toolchain/BUILD.gn
+++ b/starboard/linux/x64x11/toolchain/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build/config/clang/clang.gni")
+import("//cobalt/build/configs/hacks.gni")
 import("//starboard/build/toolchain/cobalt_toolchains.gni")
 import("//starboard/shared/toolchain/overridable_gcc_toolchain.gni")
 
@@ -23,7 +24,7 @@ overridable_clang_toolchain("starboard") {
     current_cpu = "x64"
     is_starboard = true
   }
-  propagates_configs = true
+  propagates_configs = !enable_cobalt_hermetic_hacks
 }
 
 clang_toolchain("native_target") {

--- a/starboard/loader_app/BUILD.gn
+++ b/starboard/loader_app/BUILD.gn
@@ -272,6 +272,7 @@ if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
       ":installation_store_proto",
       ":pending_restart",
       "//starboard:starboard_with_main",
+      "//starboard/common",
       "//testing/gmock",
       "//testing/gtest",
     ]

--- a/starboard/raspi/2/toolchain/BUILD.gn
+++ b/starboard/raspi/2/toolchain/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//build/toolchain/gcc_toolchain.gni")
+import("//cobalt/build/configs/hacks.gni")
 import("//starboard/build/toolchain/cobalt_toolchains.gni")
 import("//starboard/raspi/shared/toolchain/raspi_shared_toolchain.gni")
 
@@ -32,7 +33,7 @@ gcc_toolchain("starboard") {
     sysroot = "$raspi_home/busterroot"
     use_cxx17 = true
   }
-  propagates_configs = true
+  propagates_configs = !enable_cobalt_hermetic_hacks
 }
 
 gcc_toolchain("native_target") {


### PR DESCRIPTION
It's only necessary for non-hermetic builds and could cause unnecessary, confusing, and erroneous configs to be applied for cobalt-level targets.

b/419893744