### PR TITLE
BACKPORT: Improve event listener dispatch

### DIFF
--- a/third_party/blink/renderer/core/dom/events/event_target.cc
+++ b/third_party/blink/renderer/core/dom/events/event_target.cc
@@ -833,9 +833,14 @@ DispatchEventResult EventTarget::FireEventListeners(Event& event) {
   return GetDispatchEventResult(event);
 }
 
+// NOTE: To future Cobalt rebasers, this change to use
+// a copy of listeners_vector can be overriden entirely upon rebasing as
+// long as the code uses EventListenerVectorSnapshot. It's based on
+// an upstream patch in Chromium to fix this crash b/420931375. You should
+// be introducing the more complete fix and this patch is no longer needed.
 bool EventTarget::FireEventListeners(Event& event,
                                      EventTargetData* d,
-                                     EventListenerVector& entry) {
+                                     EventListenerVector entry) {
   // Fire all listeners registered for this event. Don't fire listeners removed
   // during event dispatch. Also, don't fire event listeners added during event
   // dispatch. Conveniently, all new event listeners will be added after or at

--- a/third_party/blink/renderer/core/dom/events/event_target.h
+++ b/third_party/blink/renderer/core/dom/events/event_target.h
@@ -230,7 +230,18 @@ class CORE_EXPORT EventTarget : public ScriptWrappable {
   RegisteredEventListener* GetAttributeRegisteredEventListener(
       const AtomicString& event_type);
 
-  bool FireEventListeners(Event&, EventTargetData*, EventListenerVector&);
+  // NOTE: To future Cobalt rebasers, this local change and associated change in
+  // event_target.cc can be overriden entirely if the new change is passing a
+  // EventListenerVectorSnapshot (i.e., a copy of EventListenerVector). It's
+  // based on an upstream patch in Chromium to fix this crash b/420931375. Upon
+  // rebasing, assuming you're using EventListenerVectorSnapshot, you should be
+  // introducing the more complete fix and this patch is no longer needed.
+  // To add EventListenerVectorSnapshot was a much more invasive change and
+  // required modifying many upstream, core, classes (e.g., vector.h), which I
+  // didn't want  to do. The key to fixing this bug was to create a copy of
+  // EventListenerVector before passing to FireEventListeners, which this change
+  // does.
+  bool FireEventListeners(Event&, EventTargetData*, EventListenerVector);
   void CountLegacyEvents(const AtomicString& legacy_type_name,
                          EventListenerVector*,
                          EventListenerVector*);


### PR DESCRIPTION
This CL backports
https://source.chromium.org/chromium/chromium/src/+/64e91e655faff9bdad2d6f3aefa5542214db265d to address crash in UMA event handling. See
https://b.corp.google.com/issues/420931375#comment4 for the full explanation of why the crash was happening, but TL;DR, when event listeners were fired, there was a bug where the event vector could be modified while firing events, triggering a segfault.

The key change is to make a copy of the event vector (pass by value) before firing events such that it can't be modified while looping over it.

Bug: 420931375

Original commit description:
Improve event listener dispatch

This change makes event dispatching match the HTML spec.
1) Removed attribute is added to the RegisteredEventListener
2) A clone of the EventListeners is made during dispatch and
the FiringEventListeners object that was allocated is removed.
3) RegisteredEventListener is now a GC'd object so it is safe
to copy.

This code greatly simplifies the behavior and is easier to
understand.

Bug: None
Change-Id: [If2e138f4bee6d8861befb57e83531110c4df5262](https://chromium-review.googlesource.com/q/If2e138f4bee6d8861befb57e83531110c4df5262)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/4623037
