### PR TITLE
Call CallDrmSessionKeyStatusesChangedCallback on MediaDrmBridge::OnKeyStatusChange

### DIFF
--- a/starboard/android/shared/media_drm_bridge.cc
+++ b/starboard/android/shared/media_drm_bridge.cc
@@ -264,6 +264,10 @@ void MediaDrmBridge::OnKeyStatusChange(
       drm_key_statuses[i] = kSbDrmKeyStatusError;
     }
   }
+
+  host_->CallDrmSessionKeyStatusesChangedCallback(
+      session_id_elements, session_id_size, drm_key_ids, drm_key_statuses);
+  env->ReleaseByteArrayElements(sessionId, session_id_elements, JNI_ABORT);
 }
 
 // static


### PR DESCRIPTION
- This is to fix the regression in #5833, which skipped copying the code to call `CallDrmSessionKeyStatusesChangedCallback`.
  - [original code](https://screenshot.googleplex.com/49oHAeeQHbrkVQt)

Bug: 417241844