### PR TITLE
Rendering/Skia: Experiment with reducing memory

### DIFF
--- a/gpu/config/skia_limits.cc
+++ b/gpu/config/skia_limits.cc
@@ -33,7 +33,7 @@ void DetermineGrCacheLimitsFromAvailableMemory(
   constexpr uint64_t kHighEndMemoryThreshold = 4096ULL * 1024 * 1024;
 
   if (base::SysInfo::IsLowEndDevice()) {
-    *max_resource_cache_bytes = kMaxLowEndGaneshResourceCacheBytes;
+    *max_resource_cache_bytes = kMaxLowEndGaneshResourceCacheBytes / 4;
     *max_glyph_cache_texture_bytes = kMaxLowEndGlyphCacheTextureBytes;
   } else if (base::SysInfo::AmountOfPhysicalMemory() >=
              kHighEndMemoryThreshold) {

--- a/third_party/blink/renderer/platform/widget/compositing/layer_tree_settings.cc
+++ b/third_party/blink/renderer/platform/widget/compositing/layer_tree_settings.cc
@@ -101,6 +101,9 @@ cc::ManagedMemoryPolicy GetGpuMemoryPolicy(
                 ::switches::kForceGpuMemAvailableMb),
             &actual.bytes_limit_when_visible))
       actual.bytes_limit_when_visible *= 1024 * 1024;
+
+    actual.priority_cutoff_when_visible =
+      gpu::MemoryAllocation::CUTOFF_ALLOW_REQUIRED_ONLY;
     return actual;
   }
 


### PR DESCRIPTION
Two tweaks:
- LayerTreeSettings - avoid rastering outside of visible area (viewport);
- Reduce Skia memory usage from 48MB to 12MB - this correlates directly to the memory assigned to Skia in my chrome:tracing-memory runs on gLinux monolithic Chrobalt.