### PR TITLE
Migrate AudioTrackBridge to jni_generator

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -40,6 +40,7 @@ generate_jni("jni_headers") {
     "apk/app/src/main/java/dev/cobalt/coat/CobaltTextToSpeechHelper.java",
     "apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java",
     "apk/app/src/main/java/dev/cobalt/media/AudioOutputManager.java",
+    "apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java",
     "apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java",
     "apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java",
     "apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java",

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
@@ -24,15 +24,17 @@ import android.media.AudioTrack;
 import android.os.Build;
 import androidx.annotation.RequiresApi;
 import dev.cobalt.util.Log;
-import dev.cobalt.util.UsedByNative;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.util.Locale;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
 
 /**
  * A wrapper of the android AudioTrack class. Android AudioTrack would not start playing until the
  * buffer is fully filled once.
  */
+@JNINamespace("starboard::android::shared")
 public class AudioTrackBridge {
   // Also used by AudioOutputManager.
   static final int AV_SYNC_HEADER_V1_SIZE = 16;
@@ -215,8 +217,7 @@ public class AudioTrackBridge {
     avSyncPacketBytesRemaining = 0;
   }
 
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   public int setVolume(float gain) {
     if (audioTrack == null) {
       Log.e(TAG, "Unable to setVolume with NULL audio track.");
@@ -226,8 +227,7 @@ public class AudioTrackBridge {
   }
 
   // TODO (b/262608024): Have this method return a boolean and return false on failure.
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   private void play() {
     if (audioTrack == null) {
       Log.e(TAG, "Unable to play with NULL audio track.");
@@ -241,8 +241,7 @@ public class AudioTrackBridge {
   }
 
   // TODO (b/262608024): Have this method return a boolean and return false on failure.
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   private void pause() {
     if (audioTrack == null) {
       Log.e(TAG, "Unable to pause with NULL audio track.");
@@ -256,8 +255,7 @@ public class AudioTrackBridge {
   }
 
   // TODO (b/262608024): Have this method return a boolean and return false on failure.
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   private void stop() {
     if (audioTrack == null) {
       Log.e(TAG, "Unable to stop with NULL audio track.");
@@ -270,8 +268,7 @@ public class AudioTrackBridge {
     }
   }
 
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   private void flush() {
     if (audioTrack == null) {
       Log.e(TAG, "Unable to flush with NULL audio track.");
@@ -287,9 +284,8 @@ public class AudioTrackBridge {
     }
   }
 
-  @SuppressWarnings("unused")
-  @UsedByNative
-  private int write(byte[] audioData, int sizeInBytes, long presentationTimeInMicroseconds) {
+  @CalledByNative
+  private int writeWithPresentationTime(byte[] audioData, int sizeInBytes, long presentationTimeInMicroseconds) {
     if (audioTrack == null) {
       Log.e(TAG, "Unable to write with NULL audio track.");
       return 0;
@@ -362,8 +358,7 @@ public class AudioTrackBridge {
     return ret;
   }
 
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   private int write(float[] audioData, int sizeInFloats) {
     if (audioTrack == null) {
       Log.e(TAG, "Unable to write with NULL audio track.");
@@ -375,8 +370,7 @@ public class AudioTrackBridge {
     return audioTrack.write(audioData, 0, sizeInFloats, AudioTrack.WRITE_NON_BLOCKING);
   }
 
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   private AudioTimestamp getAudioTimestamp() {
     // TODO: Consider calling with TIMEBASE_MONOTONIC and returning that
     // information to the starboard audio sink.
@@ -412,8 +406,7 @@ public class AudioTrackBridge {
     return audioTimestamp;
   }
 
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   private int getUnderrunCount() {
     if (audioTrack == null) {
       Log.e(TAG, "Unable to call getUnderrunCount() with NULL audio track.");
@@ -422,8 +415,7 @@ public class AudioTrackBridge {
     return audioTrack.getUnderrunCount();
   }
 
-  @SuppressWarnings("unused")
-  @UsedByNative
+  @CalledByNative
   private int getStartThresholdInFrames() {
     if (Build.VERSION.SDK_INT >= 31) {
       return getStartThresholdInFramesV31();

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -19,7 +19,7 @@
 #include <optional>
 
 #include "base/android/jni_android.h"
-#include "starboard/android/shared/jni_env_ext.h"
+#include "base/android/scoped_java_ref.h"
 #include "starboard/media.h"
 #include "starboard/types.h"
 
@@ -53,37 +53,37 @@ class AudioTrackBridge {
     return !j_audio_track_bridge_.is_null() && !j_audio_data_.is_null();
   }
 
-  void Play(JniEnvExt* env = JniEnvExt::Get());
-  void Pause(JniEnvExt* env = JniEnvExt::Get());
-  void Stop(JniEnvExt* env = JniEnvExt::Get());
-  void PauseAndFlush(JniEnvExt* env = JniEnvExt::Get());
+  void Play(JNIEnv* env = AttachCurrentThread());
+  void Pause(JNIEnv* env = AttachCurrentThread());
+  void Stop(JNIEnv* env = AttachCurrentThread());
+  void PauseAndFlush(JNIEnv* env = AttachCurrentThread());
 
   // Returns zero or the positive number of samples written, or a negative error
   // code.
   int WriteSample(const float* samples,
                   int num_of_samples,
-                  JniEnvExt* env = JniEnvExt::Get());
+                  JNIEnv* env = AttachCurrentThread());
   int WriteSample(const uint16_t* samples,
                   int num_of_samples,
                   int64_t sync_time,
-                  JniEnvExt* env = JniEnvExt::Get());
+                  JNIEnv* env = AttachCurrentThread());
   // This is used by passthrough, it treats samples as if they are in bytes.
   // Returns zero or the positive number of samples written, or a negative error
   // code.
   int WriteSample(const uint8_t* buffer,
                   int num_of_samples,
                   int64_t sync_time,
-                  JniEnvExt* env = JniEnvExt::Get());
+                  JNIEnv* env = AttachCurrentThread());
 
-  void SetVolume(double volume, JniEnvExt* env = JniEnvExt::Get());
+  void SetVolume(double volume, JNIEnv* env = AttachCurrentThread());
 
   // |updated_at| contains the timestamp when the audio timestamp is updated on
   // return.  It can be nullptr.
   int64_t GetAudioTimestamp(int64_t* updated_at,
-                            JniEnvExt* env = JniEnvExt::Get());
+                            JNIEnv* env = AttachCurrentThread());
   bool GetAndResetHasAudioDeviceChanged(JNIEnv* env = AttachCurrentThread());
-  int GetUnderrunCount(JniEnvExt* env = JniEnvExt::Get());
-  int GetStartThresholdInFrames(JniEnvExt* env = JniEnvExt::Get());
+  int GetUnderrunCount(JNIEnv* env = AttachCurrentThread());
+  int GetStartThresholdInFrames(JNIEnv* env = AttachCurrentThread());
 
  private:
   int max_samples_per_write_;


### PR DESCRIPTION
Now that the constructor and destructer in the class AudioTrackBridge have been refactored to work with modern JNI style in AudioOutputManager, we can migrate the entire class AudioTrackBridge to jni_generator.

Major improvements in this PR include:
Added type checking for ScopedJavaGlobalRef<jobject> j_audio_data_ in different variants of the WriteSample function.
j_audio_data_ can be either a jfloatArray or jbyteArray, depending on the audio type processed by each AudioTrackBridge.

Test: https://paste.googleplex.com/6177463220305920
Bug: 418059619
