### PR TITLE
Prevent NullPointerException when getting files directory

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -38,6 +38,7 @@ import dev.cobalt.util.DisplayUtil;
 import dev.cobalt.util.Holder;
 import dev.cobalt.util.Log;
 import dev.cobalt.util.UsedByNative;
+import java.io.File;
 import java.lang.reflect.Method;
 import java.util.Calendar;
 import java.util.HashMap;
@@ -333,7 +334,13 @@ public class StarboardBridge {
   @SuppressWarnings("unused")
   @CalledByNative
   protected String getFilesAbsolutePath() {
-    return appContext.getFilesDir().getAbsolutePath();
+    File filesDir = appContext.getFilesDir();
+    if (filesDir != null) {
+      return filesDir.getAbsolutePath();
+    } else {
+      Log.e(TAG, "Application files directory is not available.");
+      return "";
+    }
   }
 
   /**
@@ -343,7 +350,13 @@ public class StarboardBridge {
   @SuppressWarnings("unused")
   @CalledByNative
   protected String getCacheAbsolutePath() {
-    return appContext.getCacheDir().getAbsolutePath();
+    File filesDir = appContext.getCacheDir();
+    if (filesDir != null) {
+      return filesDir.getAbsolutePath();
+    } else {
+      Log.e(TAG, "Application cache directory is not available.");
+      return "";
+    }
   }
 
   // TODO: (cobalt b/372559388) remove or migrate JNI?


### PR DESCRIPTION
getFilesDir() can return null. [code](https://cs.android.com/android/platform/superproject/main/+/main:frameworks/layoutlib/bridge/src/com/android/layoutlib/bridge/android/ApplicationContext.java;l=289-293;drc=61197364367c9e404c7da6900658f1b16c42d0da)

Bug: 416501235

Change-Id: I6cd588c410fd4406024e1509bd3411c1add55e72