### PR TITLE
net/third_party/quiche: Increase ack decimation count to 50

### DIFF
--- a/net/third_party/quiche/src/quiche/quic/core/quic_connection.cc
+++ b/net/third_party/quiche/src/quiche/quic/core/quic_connection.cc
@@ -6190,6 +6190,14 @@ void QuicConnection::set_min_received_before_ack_decimation(size_t new_value) {
       new_value);
 }
 
+#if BUILDFLAG(IS_COBALT)
+void QuicConnection::set_max_retransmittable_packets_before_ack(
+    size_t new_value) {
+  uber_received_packet_manager_.set_max_retransmittable_packets_before_ack(
+      new_value);
+}
+#endif
+
 const QuicAckFrame& QuicConnection::ack_frame() const {
   if (SupportsMultiplePacketNumberSpaces()) {
     return uber_received_packet_manager_.GetAckFrame(

--- a/net/third_party/quiche/src/quiche/quic/core/quic_connection.h
+++ b/net/third_party/quiche/src/quiche/quic/core/quic_connection.h
@@ -1068,6 +1068,9 @@ class QUIC_EXPORT_PRIVATE QuicConnection
 
   size_t min_received_before_ack_decimation() const;
   void set_min_received_before_ack_decimation(size_t new_value);
+#if BUILDFLAG(IS_COBALT)
+  void set_max_retransmittable_packets_before_ack(size_t new_value);
+#endif
 
   // If |defer| is true, configures the connection to defer sending packets in
   // response to an ACK to the SendAlarm. If |defer| is false, packets may be

--- a/net/third_party/quiche/src/quiche/quic/core/quic_connection_test.cc
+++ b/net/third_party/quiche/src/quiche/quic/core/quic_connection_test.cc
@@ -3583,6 +3583,9 @@ TEST_P(QuicConnectionTest, AckDecimationReducesAcks) {
 
   // Start ack decimation from 10th packet.
   connection_.set_min_received_before_ack_decimation(10);
+#if BUILDFLAG(IS_COBALT)
+  connection_.set_max_retransmittable_packets_before_ack(10);
+#endif
 
   EXPECT_CALL(visitor_, OnSuccessfulVersionNegotiation(_));
   EXPECT_CALL(visitor_, OnStreamFrame(_)).Times(30);
@@ -6373,6 +6376,9 @@ TEST_P(QuicConnectionTest, SendDelayedAck) {
 TEST_P(QuicConnectionTest, SendDelayedAckDecimation) {
   EXPECT_CALL(visitor_, OnAckNeedsRetransmittableFrame()).Times(AnyNumber());
 
+#if BUILDFLAG(IS_COBALT)
+  connection_.set_max_retransmittable_packets_before_ack(10);
+#endif
   const size_t kMinRttMs = 40;
   RttStats* rtt_stats = const_cast<RttStats*>(manager_->GetRttStats());
   rtt_stats->UpdateRtt(QuicTime::Delta::FromMilliseconds(kMinRttMs),
@@ -6433,6 +6439,9 @@ TEST_P(QuicConnectionTest, SendDelayedAckDecimationUnlimitedAggregation) {
   EXPECT_CALL(*send_algorithm_, SetFromConfig(_, _));
   QuicConfig config;
   QuicTagVector connection_options;
+#if BUILDFLAG(IS_COBALT)
+  connection_.set_max_retransmittable_packets_before_ack(10);
+#endif
   // No limit on the number of packets received before sending an ack.
   connection_options.push_back(kAKDU);
   config.SetConnectionOptionsToSend(connection_options);
@@ -6490,6 +6499,9 @@ TEST_P(QuicConnectionTest, SendDelayedAckDecimationEighthRtt) {
   EXPECT_CALL(visitor_, OnAckNeedsRetransmittableFrame()).Times(AnyNumber());
   QuicConnectionPeer::SetAckDecimationDelay(&connection_, 0.125);
 
+#if BUILDFLAG(IS_COBALT)
+  connection_.set_max_retransmittable_packets_before_ack(10);
+#endif
   const size_t kMinRttMs = 40;
   RttStats* rtt_stats = const_cast<RttStats*>(manager_->GetRttStats());
   rtt_stats->UpdateRtt(QuicTime::Delta::FromMilliseconds(kMinRttMs),
@@ -13139,6 +13151,9 @@ TEST_P(QuicConnectionTest, SendAckFrequencyFrame) {
   if (!version().HasIetfQuicFrames()) {
     return;
   }
+#if BUILDFLAG(IS_COBALT)
+  connection_.set_max_retransmittable_packets_before_ack(10);
+#endif
   SetQuicReloadableFlag(quic_can_send_ack_frequency, true);
   set_perspective(Perspective::IS_SERVER);
   EXPECT_CALL(*send_algorithm_, OnCongestionEvent(_, _, _, _, _, _, _))

--- a/net/third_party/quiche/src/quiche/quic/core/quic_constants.h
+++ b/net/third_party/quiche/src/quiche/quic/core/quic_constants.h
@@ -294,8 +294,13 @@ inline constexpr int kDefaultIetfLossDelayShift = 3;
 
 // Maximum number of retransmittable packets received before sending an ack.
 inline constexpr QuicPacketCount kDefaultRetransmittablePacketsBeforeAck = 2;
+#if BUILDFLAG(IS_COBALT)
+// Wait for up to 50 retransmittable packets before sending an ack.
+inline constexpr QuicPacketCount kMaxRetransmittablePacketsBeforeAck = 50;
+#else
 // Wait for up to 10 retransmittable packets before sending an ack.
 inline constexpr QuicPacketCount kMaxRetransmittablePacketsBeforeAck = 10;
+#endif
 // Minimum number of packets received before ack decimation is enabled.
 // This intends to avoid the beginning of slow start, when CWNDs may be
 // rapidly increasing.

--- a/net/third_party/quiche/src/quiche/quic/core/quic_received_packet_manager.cc
+++ b/net/third_party/quiche/src/quiche/quic/core/quic_received_packet_manager.cc
@@ -45,6 +45,10 @@ QuicReceivedPacketManager::QuicReceivedPacketManager(QuicConnectionStats* stats)
       num_retransmittable_packets_received_since_last_ack_sent_(0),
       min_received_before_ack_decimation_(kMinReceivedBeforeAckDecimation),
       ack_frequency_(kDefaultRetransmittablePacketsBeforeAck),
+#if BUILDFLAG(IS_COBALT)
+      max_retransmittable_packets_before_ack_(
+          kMaxRetransmittablePacketsBeforeAck),
+#endif  // defined(USE_COBALT_CUSTOMIZATIONS)
       ack_decimation_delay_(kAckDecimationDelay),
       unlimited_ack_decimation_(false),
       one_immediate_ack_(false),
@@ -251,7 +255,11 @@ void QuicReceivedPacketManager::MaybeUpdateAckFrequency(
   }
   ack_frequency_ = unlimited_ack_decimation_
                        ? std::numeric_limits<size_t>::max()
-                       : kMaxRetransmittablePacketsBeforeAck;
+#if BUILDFLAG(IS_COBALT)
+: max_retransmittable_packets_before_ack_;
+#else
+: kMaxRetransmittablePacketsBeforeAck;
+#endif
 }
 
 void QuicReceivedPacketManager::MaybeUpdateAckTimeout(

--- a/net/third_party/quiche/src/quiche/quic/core/quic_received_packet_manager.h
+++ b/net/third_party/quiche/src/quiche/quic/core/quic_received_packet_manager.h
@@ -117,6 +117,11 @@ class QUIC_EXPORT_PRIVATE QuicReceivedPacketManager {
   void set_min_received_before_ack_decimation(size_t new_value) {
     min_received_before_ack_decimation_ = new_value;
   }
+#if BUILDFLAG(IS_COBALT)
+  void set_max_retransmittable_packets_before_ack(size_t new_value) {
+    max_retransmittable_packets_before_ack_ = new_value;
+  }
+#endif
 
   void set_ack_frequency(size_t new_value) {
     QUICHE_DCHECK_GT(new_value, 0u);
@@ -186,6 +191,10 @@ class QUIC_EXPORT_PRIVATE QuicReceivedPacketManager {
   size_t min_received_before_ack_decimation_;
   // Ack every n-th packet.
   size_t ack_frequency_;
+#if BUILDFLAG(IS_COBALT)
+  // Ack at least every n-th packet.
+  size_t max_retransmittable_packets_before_ack_;
+#endif
   // The max delay in fraction of min_rtt to use when sending decimated acks.
   float ack_decimation_delay_;
   // When true, removes ack decimation's max number of packets(10) before

--- a/net/third_party/quiche/src/quiche/quic/core/quic_received_packet_manager_test.cc
+++ b/net/third_party/quiche/src/quiche/quic/core/quic_received_packet_manager_test.cc
@@ -359,6 +359,9 @@ TEST_F(QuicReceivedPacketManagerTest, AckDecimationReducesAcks) {
 
   // Start ack decimation from 10th packet.
   received_manager_.set_min_received_before_ack_decimation(10);
+#if BUILDFLAG(IS_COBALT)
+  received_manager_.set_max_retransmittable_packets_before_ack(10);
+#endif
 
   // Receives packets 1 - 29.
   for (size_t i = 1; i <= 29; ++i) {
@@ -389,6 +392,9 @@ TEST_F(QuicReceivedPacketManagerTest, AckDecimationReducesAcks) {
 
 TEST_F(QuicReceivedPacketManagerTest, SendDelayedAckDecimation) {
   EXPECT_FALSE(HasPendingAck());
+#if BUILDFLAG(IS_COBALT)
+  received_manager_.set_max_retransmittable_packets_before_ack(10);
+#endif
   // The ack time should be based on min_rtt * 1/4, since it's less than the
   // default delayed ack time.
   QuicTime ack_time = clock_.ApproximateNow() + kMinRttMs * 0.25;
@@ -420,6 +426,9 @@ TEST_F(QuicReceivedPacketManagerTest, SendDelayedAckDecimation) {
 
 TEST_F(QuicReceivedPacketManagerTest, SendDelayedAckDecimationMin1ms) {
   EXPECT_FALSE(HasPendingAck());
+#if BUILDFLAG(IS_COBALT)
+  received_manager_.set_max_retransmittable_packets_before_ack(10);
+#endif
   // Seed the min_rtt with a kAlarmGranularity signal.
   rtt_stats_.UpdateRtt(kAlarmGranularity, QuicTime::Delta::Zero(),
                        clock_.ApproximateNow());
@@ -454,6 +463,9 @@ TEST_F(QuicReceivedPacketManagerTest, SendDelayedAckDecimationMin1ms) {
 TEST_F(QuicReceivedPacketManagerTest,
        SendDelayedAckDecimationUnlimitedAggregation) {
   EXPECT_FALSE(HasPendingAck());
+#if BUILDFLAG(IS_COBALT)
+  received_manager_.set_max_retransmittable_packets_before_ack(10);
+#endif
   QuicConfig config;
   QuicTagVector connection_options;
   // No limit on the number of packets received before sending an ack.
@@ -493,6 +505,9 @@ TEST_F(QuicReceivedPacketManagerTest,
 
 TEST_F(QuicReceivedPacketManagerTest, SendDelayedAckDecimationEighthRtt) {
   EXPECT_FALSE(HasPendingAck());
+#if BUILDFLAG(IS_COBALT)
+  received_manager_.set_max_retransmittable_packets_before_ack(10);
+#endif
   QuicReceivedPacketManagerPeer::SetAckDecimationDelay(&received_manager_,
                                                        0.125);
 

--- a/net/third_party/quiche/src/quiche/quic/core/uber_received_packet_manager.cc
+++ b/net/third_party/quiche/src/quiche/quic/core/uber_received_packet_manager.cc
@@ -202,6 +202,15 @@ void UberReceivedPacketManager::set_min_received_before_ack_decimation(
   }
 }
 
+#if BUILDFLAG(IS_COBALT)
+void UberReceivedPacketManager::set_max_retransmittable_packets_before_ack(
+    size_t new_value) {
+  for (auto& received_packet_manager : received_packet_managers_) {
+    received_packet_manager.set_max_retransmittable_packets_before_ack(new_value);
+  }
+}
+#endif
+
 void UberReceivedPacketManager::set_ack_frequency(size_t new_value) {
   for (auto& received_packet_manager : received_packet_managers_) {
     received_packet_manager.set_ack_frequency(new_value);

--- a/net/third_party/quiche/src/quiche/quic/core/uber_received_packet_manager.h
+++ b/net/third_party/quiche/src/quiche/quic/core/uber_received_packet_manager.h
@@ -78,6 +78,9 @@ class QUIC_EXPORT_PRIVATE UberReceivedPacketManager {
 
   size_t min_received_before_ack_decimation() const;
   void set_min_received_before_ack_decimation(size_t new_value);
+#if BUILDFLAG(IS_COBALT)
+  void set_max_retransmittable_packets_before_ack(size_t new_value);
+#endif
 
   void set_ack_frequency(size_t new_value);
 

--- a/net/third_party/quiche/src/quiche/quic/core/uber_received_packet_manager_test.cc
+++ b/net/third_party/quiche/src/quiche/quic/core/uber_received_packet_manager_test.cc
@@ -317,6 +317,9 @@ TEST_F(UberReceivedPacketManagerTest, AckDecimationReducesAcks) {
 
   // Start ack decimation from 10th packet.
   manager_->set_min_received_before_ack_decimation(10);
+#if defined(IS_COBALT)
+  manager_->set_max_retransmittable_packets_before_ack(10);
+#endif
 
   // Receives packets 1 - 29.
   for (size_t i = 1; i <= 29; ++i) {
@@ -347,6 +350,9 @@ TEST_F(UberReceivedPacketManagerTest, AckDecimationReducesAcks) {
 
 TEST_F(UberReceivedPacketManagerTest, SendDelayedAckDecimation) {
   EXPECT_FALSE(HasPendingAck());
+#if defined(IS_COBALT)
+  manager_->set_max_retransmittable_packets_before_ack(10);
+#endif
   // The ack time should be based on min_rtt * 1/4, since it's less than the
   // default delayed ack time.
   QuicTime ack_time = clock_.ApproximateNow() + kMinRttMs * 0.25;
@@ -418,6 +424,9 @@ TEST_F(UberReceivedPacketManagerTest,
 
 TEST_F(UberReceivedPacketManagerTest, SendDelayedAckDecimationEighthRtt) {
   EXPECT_FALSE(HasPendingAck());
+#if defined(IS_COBALT)
+  manager_->set_max_retransmittable_packets_before_ack(10);
+#endif
   UberReceivedPacketManagerPeer::SetAckDecimationDelay(manager_.get(), 0.125);
 
   // The ack time should be based on min_rtt/8, since it's less than the


### PR DESCRIPTION
This was a proven practice in C25 to reduce QUIC overhead.

Bug: 421916650