### PR TITLE
DRAFT: Use default starboard loader gn targets for RDK builds

### DIFF
--- a/.github/config/evergreen-rdk-arm-hardfp.json
+++ b/.github/config/evergreen-rdk-arm-hardfp.json
@@ -17,7 +17,6 @@
       "target_cpu":"target_cpu=\\\"arm\\\"",
       "extra_gn_arguments":"use_asan=false",
       "evergreen_loader_extra_gn_arguments":"is_clang=false using_old_compiler=true rdk_build_with_yocto=false rdk_starboard_root=\\\"//starboard/contrib/rdk/src\\\" rdk_enable_securityagent=false",
-      "evergreen_loader_extra_build_targets":"loader_app_bin elf_loader_sandbox_bin",
       "sb_api_version": "14",
       "dimension": "release_version=regex:10.*"
     },
@@ -28,7 +27,6 @@
       "target_cpu":"target_cpu=\\\"arm\\\"",
       "extra_gn_arguments":"use_asan=false",
       "evergreen_loader_extra_gn_arguments":"is_clang=false using_old_compiler=true rdk_build_with_yocto=false rdk_starboard_root=\\\"//starboard/contrib/rdk/src\\\" rdk_enable_securityagent=false",
-      "evergreen_loader_extra_build_targets":"loader_app_bin elf_loader_sandbox_bin",
       "sb_api_version": "15",
       "dimension": "release_version=regex:10.*"
     },
@@ -39,7 +37,6 @@
       "target_cpu":"target_cpu=\\\"arm\\\"",
       "extra_gn_arguments":"use_asan=false",
       "evergreen_loader_extra_gn_arguments":"use_asan=false is_clang=false using_old_compiler=true rdk_build_with_yocto=false rdk_starboard_root=\\\"//starboard/contrib/rdk/src\\\" rdk_enable_securityagent=false",
-      "evergreen_loader_extra_build_targets":"loader_app_bin elf_loader_sandbox_bin",
       "sb_api_version": "16",
       "dimension": "release_version=regex:10.*"
     }

--- a/docker/linux/rdk/Dockerfile
+++ b/docker/linux/rdk/Dockerfile
@@ -41,4 +41,4 @@ RUN cd /tmp \
 
 # TODO(b/402053134): for now we only build evergreen targets, once modular builds are working this needs to updated to build modular by default
 CMD gn gen ${OUTDIR}/${PLATFORM}${SB_API_VERSION:+-sbversion-$SB_API_VERSION}_${CONFIG:-debug} --args="target_platform=\"${PLATFORM}\" build_type=\"${CONFIG:-debug}\" target_cpu=\"arm\" target_os=\"linux\" is_clang=false using_old_compiler=true rdk_build_with_yocto=false rdk_starboard_root=\"//starboard/contrib/rdk/src\" rdk_enable_securityagent=false ${SB_API_VERSION:+sb_api_version=$SB_API_VERSION}" && \
-    ninja -v -j ${NINJA_PARALLEL} -C out/${PLATFORM}_${CONFIG:-debug} loader_app_install loader_app_bin native_target/crashpad_handler elf_loader_sandbox_install elf_loader_sandbox_bin
+    ninja -v -j ${NINJA_PARALLEL} -C out/${PLATFORM}_${CONFIG:-debug} loader_app_install native_target/crashpad_handler elf_loader_sandbox_install

--- a/starboard/evergreen/shared/launcher.py
+++ b/starboard/evergreen/shared/launcher.py
@@ -67,7 +67,7 @@ class Launcher(abstract_launcher.AbstractLauncher):
     if not self.loader_config:
       raise ValueError('|loader_config| cannot be |None|.')
 
-    # RDK uses a fixed loader (elf_loader_sandbox_bin), so we pass down the target
+    # RDK uses a fixed loader (elf_loader_sandbox), so we pass down the target
     # name to the RDK launcher as the loader_target, so it knows what target to
     # run and can prepare the env accordingly
     # TODO(b/415848657): refactor the launcher when porting this code to the main branch
@@ -288,8 +288,8 @@ class Launcher(abstract_launcher.AbstractLauncher):
 
   def _StageTargetsAndContentsRdk(self):
     """Stage targets and their contents for GN builds for RDK platforms."""
-    # RDK will append a _bin suffix to the loader, let's handle it
-    rdk_loader_target = _DEFAULT_LOADER_TARGET + "_bin"
+    # Currently the RDK test launcher only supports a fixed loader (elf_loader_sandbox)
+    rdk_loader_target = _DEFAULT_LOADER_TARGET
 
     # Copy target content and binary.
     target_install_path = os.path.join(self.out_directory, 'install')

--- a/starboard/rdk/launcher.py
+++ b/starboard/rdk/launcher.py
@@ -186,7 +186,7 @@ class Launcher(abstract_launcher.AbstractLauncher):
     self.test_failure_tag = 'failed'
 
     # test command setup
-    rdk_loader_path = os.path.join(rdk_storage_dir, "install", "elf_loader_sandbox_bin")
+    rdk_loader_path = os.path.join(rdk_storage_dir, "install", "elf_loader_sandbox")
     test_base_command = rdk_loader_path + ' ' + escaped_flags
     test_success_output = (f' && echo {self.test_complete_tag} '
                            f'{self.test_success_tag}')


### PR DESCRIPTION
Deends on https://cobalt-review.googlesource.com/c/external/components/generic/cobalt/+/6870.

b/421431143