### PR TITLE
Skeleton of AudioStreamSink, which use NDK AAudio APIs

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -163,6 +163,8 @@ static_library("starboard_platform") {
     "android_media_session_client.cc",
     "application_android.cc",
     "application_android.h",
+    "audio_stream_sink.cc",
+    "audio_stream_sink.h",
 
     # TODO: b/374300500 - posix_emu things should not be used on Android anymore
     # "asset_manager.cc",

--- a/starboard/android/shared/audio_stream_sink.cc
+++ b/starboard/android/shared/audio_stream_sink.cc
@@ -1,0 +1,253 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/audio_stream_sink.h"
+
+#include <unistd.h>
+#include <algorithm>
+#include <string>
+#include <vector>
+
+#include <math.h>
+#include "starboard/android/shared/audio_stream.h"
+#include "starboard/common/string.h"
+#include "starboard/common/time.h"
+#include "starboard/shared/pthread/thread_create_priority.h"
+#include "starboard/shared/starboard/media/media_util.h"
+#include "starboard/shared/starboard/player/filter/common.h"
+
+namespace starboard::android::shared {
+
+using ::starboard::shared::starboard::media::GetBytesPerSample;
+
+AudioStreamSink::AudioStreamSink(
+    Type* type,
+    int channels,
+    int sampling_frequency_hz,
+    SbMediaAudioSampleType sample_type,
+    SbAudioSinkFrameBuffers frame_buffers,
+    int frames_per_channel,
+    int preferred_buffer_size_in_bytes,
+    SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
+    ConsumeFramesFunc consume_frames_func,
+    SbAudioSinkPrivate::ErrorFunc error_func,
+    int64_t start_time,
+    // TODO: b/428008986 - Use is_web_audio when creating AudioStream.
+    bool is_web_audio,
+    void* context)
+    : type_(type),
+      channels_(channels),
+      sample_rate_(sampling_frequency_hz),
+      frame_bytes_(GetBytesPerSample(sample_type) * channels_),
+      frame_buffer_(static_cast<uint8_t*>(frame_buffers[0])),
+      frames_per_channel_(frames_per_channel),
+      update_source_status_func_(update_source_status_func),
+      consume_frames_func_(consume_frames_func),
+      error_func_(error_func),
+      start_time_(start_time),
+      context_(context),
+      stream_(AudioStream::Create(sample_type,
+                                  channels,
+                                  sampling_frequency_hz,
+                                  frames_per_channel,
+                                  [this](void* data, int num_frames) {
+                                    return OnReadData(data, num_frames);
+                                  })) {
+  SB_DCHECK(stream_ != nullptr);
+  SB_DCHECK(update_source_status_func_);
+  SB_DCHECK(consume_frames_func_);
+  SB_DCHECK(frame_buffer_);
+
+  SB_LOG(INFO) << "Creating continuous audio sink: start_time=" << start_time_
+               << ", source_buffer_size(frames)=" << frames_per_channel_
+               << ", source_buffer_size(msec)="
+               << (frames_per_channel_ * 1'000 / sample_rate_)
+               << ", frame_bytes=" << frame_bytes_
+               << ", preferred_buffer_size_in_bytes="
+               << preferred_buffer_size_in_bytes << ", preferred_frames="
+               << (preferred_buffer_size_in_bytes /
+                   GetBytesPerSample(sample_type) / channels_);
+}
+
+AudioStreamSink::~AudioStreamSink() {
+  SB_LOG(INFO) << "Destroying AudioStreamSink";
+}
+
+AudioStreamSink::SourceState AudioStreamSink::GetSourceState() {
+  int available_frames;
+  int frame_offset;
+  bool is_playing;
+  bool is_eos_reached;
+  update_source_status_func_(&available_frames, &frame_offset, &is_playing,
+                             &is_eos_reached, context_);
+  return {
+      .available_frames = available_frames,
+      .frame_offset = frame_offset,
+      .is_playing = is_playing,
+      .is_eos_reached = is_eos_reached,
+  };
+}
+
+void AudioStreamSink::SetPlaybackRate(double playback_rate) {
+  SB_DCHECK(playback_rate >= 0.0);
+  if (playback_rate != 0.0 && playback_rate != 1.0) {
+    SB_NOTIMPLEMENTED() << "TODO: Only playback rates of 0.0 and 1.0 are "
+                           "currently supported.";
+    playback_rate = (playback_rate > 0.0) ? 1.0 : 0.0;
+  }
+  if (playback_rate > 0.5) {
+    SB_LOG(INFO) << __func__
+                 << ": Call play with playback_rate=" << playback_rate;
+    stream_->Play();
+  } else {
+    SB_LOG(INFO) << __func__
+                 << ": Call pause with playback_rate=" << playback_rate;
+    stream_->Pause();
+  }
+  SB_LOG(INFO) << __func__ << ": completed";
+}
+
+void AudioStreamSink::ReportPlayedFrames() {
+  auto latest_timestamp = stream_->GetTimestamp();
+  if (!latest_timestamp.has_value()) {
+    return;
+  }
+
+  const AudioStream::Timestamp& timestamp = *latest_timestamp;
+
+  auto SanitizePosition = [&](int64_t frame_position) {
+    return std::max<int64_t>(0, frame_position - initial_silence_frames_);
+  };
+
+  int frames_consumed = SanitizePosition(timestamp.frame_position) -
+                        SanitizePosition(last_timestamp_.frame_position);
+  if (frames_consumed <= 0) {
+    return;
+  }
+
+  SB_DCHECK(frames_consumed >= 0) << "new_timestamp: " << timestamp
+                                  << ", last_timestamp: " << last_timestamp_;
+  last_timestamp_ = timestamp;
+
+  SB_DCHECK(pending_frames_in_platform_buffer_ >= frames_consumed)
+      << "pending_frames_in_platform_buffer_="
+      << pending_frames_in_platform_buffer_
+      << ", frames_consumed=" << frames_consumed;
+  pending_frames_in_platform_buffer_ -= frames_consumed;
+
+  consume_frames_func_(frames_consumed, timestamp.system_time_us, context_);
+}
+
+bool AudioStreamSink::OnReadData(void* data, int num_frames_to_read) {
+  ReportPlayedFrames();
+
+  return ReadMoreFrames(data, num_frames_to_read);
+}
+
+bool AudioStreamSink::ReadMoreFrames(void* data, int num_frames_to_read) {
+  const int frame_buffer_size = frames_per_channel_;
+  int source_available_frames;
+  int frame_offset;
+  bool is_playing;
+  bool is_eos_reached;
+  update_source_status_func_(&source_available_frames, &frame_offset,
+                             &is_playing, &is_eos_reached, context_);
+  SB_CHECK(source_available_frames >= pending_frames_in_platform_buffer_)
+      << "source_availabe_frames=" << source_available_frames
+      << ", pending_frames_in_platform_buffer="
+      << pending_frames_in_platform_buffer_;
+
+  frame_offset =
+      (frame_offset + pending_frames_in_platform_buffer_) % frame_buffer_size;
+  const int available_frames =
+      std::max(0, source_available_frames - pending_frames_in_platform_buffer_);
+  if (available_frames == 0 && is_eos_reached) {
+    return false;
+  }
+
+  if (!data_has_arrived_) {
+    if (available_frames > 0) {
+      SB_LOG(INFO) << "First batch of data arrived: frames="
+                   << available_frames;
+      data_has_arrived_ = true;
+    } else {
+      initial_silence_frames_ += num_frames_to_read;
+    }
+  }
+
+  int frames_read = 0;
+  const int available_frames_to_read =
+      std::min(num_frames_to_read, available_frames);
+  const int first_chunk_frames =
+      std::min(available_frames_to_read, frame_buffer_size - frame_offset);
+  memcpy(data, frame_buffer_ + frame_offset * frame_bytes_,
+         first_chunk_frames * frame_bytes_);
+  frames_read += first_chunk_frames;
+
+  if (frames_read < available_frames_to_read) {
+    const int remaining_frames = available_frames_to_read - frames_read;
+    memcpy(static_cast<uint8_t*>(data) + frames_read * frame_bytes_,
+           frame_buffer_, remaining_frames * frame_bytes_);
+    frames_read += remaining_frames;
+  }
+
+  pending_frames_in_platform_buffer_ += frames_read;
+  SB_CHECK(pending_frames_in_platform_buffer_ <= frame_buffer_size)
+      << "pending_frames_in_platform_buffer_="
+      << pending_frames_in_platform_buffer_
+      << ", frame_buffer_size=" << frame_buffer_size;
+
+  SB_DCHECK(frames_read <= num_frames_to_read)
+      << ": frames_read=" << frames_read
+      << ", num_frames_to_read=" << num_frames_to_read;
+
+  const int underrun_frames = num_frames_to_read - frames_read;
+  if (underrun_frames > 0) {
+    memset(static_cast<uint8_t*>(data) + frames_read * frame_bytes_, 0,
+           underrun_frames * frame_bytes_);
+    if (data_has_arrived_) {
+      SB_LOG(INFO) << "Underrun: underrun frames=" << underrun_frames
+                   << ", frames_read=" << frames_read
+                   << ", num_frames_to_read=" << num_frames_to_read
+                   << ", available_frames=" << available_frames
+                   << ", source_available_frames=" << source_available_frames
+                   << ", pending_frames_in_platform_buffer_="
+                   << pending_frames_in_platform_buffer_;
+    }
+  }
+
+  return true;
+}
+
+void AudioStreamSink::ReportError(bool capability_changed,
+                                  const std::string& error_message) {
+  SB_LOG(INFO) << "AudioStreamSink error: " << error_message;
+  if (error_func_) {
+    error_func_(capability_changed, error_message, context_);
+  }
+}
+
+void AudioStreamSink::SetVolume(double volume) {
+  SB_LOG(WARNING) << __func__ << ": not implemented: volume=" << volume;
+}
+
+int AudioStreamSink::GetUnderrunCount() {
+  return stream_->GetUnderrunCount();
+}
+
+int AudioStreamSink::GetStartThresholdInFrames() {
+  return stream_->GetFramesPerBurst();
+}
+
+}  // namespace starboard::android::shared

--- a/starboard/android/shared/audio_stream_sink.h
+++ b/starboard/android/shared/audio_stream_sink.h
@@ -1,0 +1,97 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_AUDIO_STREAM_SINK_H_
+#define STARBOARD_ANDROID_SHARED_AUDIO_STREAM_SINK_H_
+
+#include <atomic>
+#include <functional>
+#include <mutex>
+#include <string>
+
+#include "starboard/android/shared/audio_stream.h"
+#include "starboard/audio_sink.h"
+#include "starboard/common/log.h"
+#include "starboard/configuration.h"
+#include "starboard/shared/internal_only.h"
+#include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
+
+namespace starboard::android::shared {
+
+class AudioStreamSink
+    : public ::starboard::shared::starboard::audio_sink::SbAudioSinkImpl {
+ public:
+  AudioStreamSink(Type* type,
+                  int channels,
+                  int sampling_frequency_hz,
+                  SbMediaAudioSampleType sample_type,
+                  SbAudioSinkFrameBuffers frame_buffers,
+                  int frames_per_channel,
+                  int preferred_buffer_size,
+                  SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
+                  ConsumeFramesFunc consume_frames_func,
+                  SbAudioSinkPrivate::ErrorFunc error_func,
+                  int64_t start_media_time,
+                  bool is_web_audio,
+                  void* context);
+  ~AudioStreamSink() override;
+
+  bool IsAudioTrackValid() const { return stream_ != nullptr; }
+  bool IsType(Type* type) override { return type_ == type; }
+  void SetPlaybackRate(double playback_rate) override;
+
+  void SetVolume(double volume) override;
+  int GetUnderrunCount();
+  int GetStartThresholdInFrames();
+
+ private:
+  struct SourceState {
+    int available_frames;
+    int frame_offset;
+    bool is_playing;
+    bool is_eos_reached;
+  };
+  SourceState GetSourceState();
+
+  bool OnReadData(void* buffer, int num_frames_to_read);
+
+  void ReportError(bool capability_changed, const std::string& error_message);
+  void ReportPlayedFrames();
+  bool ReadMoreFrames(void* data, int num_frames_to_read);
+
+  Type* const type_;
+
+  const int channels_;
+  const int sample_rate_;
+  const int frame_bytes_;
+  uint8_t* frame_buffer_;
+  const int frames_per_channel_;
+  const SbAudioSinkUpdateSourceStatusFunc update_source_status_func_;
+  const ConsumeFramesFunc consume_frames_func_;
+  const SbAudioSinkPrivate::ErrorFunc error_func_;
+  const int64_t start_time_;  // microseconds
+  void* const context_;
+
+  const std::unique_ptr<AudioStream> stream_;
+
+  int pending_frames_in_platform_buffer_ = 0;
+  AudioStream::Timestamp last_timestamp_{0, 0};
+
+  bool data_has_arrived_ = false;
+  int initial_silence_frames_ = 0;
+};
+
+}  // namespace starboard::android::shared
+
+#endif  // STARBOARD_ANDROID_SHARED_AUDIO_STREAM_SINK_H_

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "starboard/android/shared/audio_output_manager.h"
+#include "starboard/android/shared/audio_stream_sink.h"
 #include "starboard/android/shared/continuous_audio_track_sink.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/common/string.h"
@@ -43,6 +44,9 @@ using ::starboard::shared::starboard::media::GetBytesPerSample;
 // data and actual data.
 // TODO: b/186660620: Replace this constant with feature flag.
 constexpr bool kUseContinuousAudioTrackSink = false;
+
+// Whether to use AudioStreamSink, which uses NDK AAudio APIs.
+constexpr bool kUseAudioStreamSink = false;
 
 // The maximum number of frames that can be written to android audio track per
 // write request. If we don't set this cap for writing frames to audio track,
@@ -503,6 +507,20 @@ SbAudioSink AudioTrackAudioSinkType::Create(
       SB_LOG(INFO) << "Cannot use ContinuousAudioTrack with tunnel mode. "
                       "will Create normal AudioTrackAudioSink instead.";
     }
+  }
+  if (kUseAudioStreamSink) {
+    SB_LOG(INFO) << "Use AudioStreamSink";
+    auto audio_sink = new AudioStreamSink(
+        this, channels, sampling_frequency_hz, audio_sample_type, frame_buffers,
+        frames_per_channel, preferred_buffer_size_in_bytes,
+        update_source_status_func, consume_frames_func, error_func,
+        start_media_time, is_web_audio, context);
+    if (!continuous_sink->IsAudioTrackValid()) {
+      SB_LOG(ERROR) << "Failed to create AudioStreamSink";
+      Destroy(audio_sink);
+      return kSbAudioSinkInvalid;
+    }
+    return audio_sink;
   }
 
   AudioTrackAudioSink* audio_sink = new AudioTrackAudioSink(


### PR DESCRIPTION
this is a skeleton implementation of AudioStreamSink, which uses NDK AAudio APIs. This is not a full implement yet, though this is the foundation for PRs that will follow to make this audio sink work.

This PR needs #6182 


Bug: 428008986