### PR TITLE
Change SbThreadSampler to void*

### DIFF
--- a/starboard/shared/pthread/thread_sampler_destroy.cc
+++ b/starboard/shared/pthread/thread_sampler_destroy.cc
@@ -18,5 +18,5 @@ void SbThreadSamplerDestroy(SbThreadSampler sampler) {
   if (!SbThreadSamplerIsValid(sampler)) {
     return;
   }
-  delete sampler;
+  delete static_cast<SbThreadSamplerPrivate*>(sampler);
 }

--- a/starboard/shared/pthread/thread_sampler_freeze.cc
+++ b/starboard/shared/pthread/thread_sampler_freeze.cc
@@ -18,5 +18,5 @@ SbThreadContext SbThreadSamplerFreeze(SbThreadSampler sampler) {
   if (!SbThreadSamplerIsValid(sampler)) {
     return kSbThreadContextInvalid;
   }
-  return sampler->Freeze();
+  return static_cast<SbThreadSamplerPrivate*>(sampler)->Freeze();
 }

--- a/starboard/shared/pthread/thread_sampler_internal.cc
+++ b/starboard/shared/pthread/thread_sampler_internal.cc
@@ -100,7 +100,9 @@ SbThreadContext SignalHandler::Freeze(SbThreadSampler sampler) {
     return kSbThreadContextInvalid;
   }
   frozen_sampler_ = sampler;
-  pthread_kill(SB_PTHREAD_INTERNAL_THREAD(sampler->thread()), SIGPROF);
+  pthread_kill(SB_PTHREAD_INTERNAL_THREAD(
+                   static_cast<SbThreadSamplerPrivate*>(sampler)->thread()),
+               SIGPROF);
   sem_wait(&freeze_semaphore_);
   return &sb_context_;
 }

--- a/starboard/shared/pthread/thread_sampler_thaw.cc
+++ b/starboard/shared/pthread/thread_sampler_thaw.cc
@@ -18,5 +18,5 @@ bool SbThreadSamplerThaw(SbThreadSampler sampler) {
   if (!SbThreadSamplerIsValid(sampler)) {
     return false;
   }
-  return sampler->Thaw();
+  return static_cast<SbThreadSamplerPrivate*>(sampler)->Thaw();
 }

--- a/starboard/thread.h
+++ b/starboard/thread.h
@@ -137,11 +137,8 @@ SB_EXPORT bool SbThreadContextGetPointer(SbThreadContext context,
                                          SbThreadContextProperty property,
                                          void** out_value);
 
-// Private structure representing a thread sampler.
-typedef struct SbThreadSamplerPrivate SbThreadSamplerPrivate;
-
 // A handle to a thread sampler.
-typedef SbThreadSamplerPrivate* SbThreadSampler;
+typedef void* SbThreadSampler;
 
 // Well-defined value for an invalid thread sampler.
 #define kSbThreadSamplerInvalid ((SbThreadSampler)NULL)


### PR DESCRIPTION
This allows for a more flexible implementation of the abstract SbThreadSampler type.

Bug: 428710366