### PR TITLE
media: Add BASE feature for Android Overlay

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -558,6 +558,11 @@ public abstract class CobaltActivity extends Activity {
   }
 
   public void resetVideoSurface() {
+    if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
+      // VideoSurfaceView will be null if Cobalt is using Android Overlay.
+      return;
+    }
+
     runOnUiThread(
         new Runnable() {
           @Override
@@ -568,10 +573,17 @@ public abstract class CobaltActivity extends Activity {
   }
 
   public void setVideoSurfaceBounds(final int x, final int y, final int width, final int height) {
+    if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
+      // VideoSurfaceView will be null if Cobalt is using Android Overlay.
+      return;
+    }
+
     if (width == 0 || height == 0) {
       // The SurfaceView should be covered by our UI layer in this case.
       return;
     }
+
+
     runOnUiThread(
         new Runnable() {
           @Override
@@ -600,6 +612,16 @@ public abstract class CobaltActivity extends Activity {
   }
 
   private void createNewSurfaceView() {
+    if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
+      // VideoSurfaceView will be null if Cobalt is using Android Overlay.
+      return;
+    }
+
+    if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
+      // VideoSurfaceView will be null if Cobalt is using Android Overlay.
+      return;
+    }
+
     ViewParent parent = videoSurfaceView.getParent();
     if (parent instanceof FrameLayout) {
       FrameLayout frameLayout = (FrameLayout) parent;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -56,6 +56,7 @@ import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.components.version_info.VersionInfo;
 import org.chromium.content.browser.input.ImeAdapterImpl;
 import org.chromium.content_public.browser.BrowserStartupController;
+import org.chromium.content_public.browser.ContentFeatureList;
 import org.chromium.content_public.browser.DeviceUtils;
 import org.chromium.content_public.browser.JavascriptInjector;
 import org.chromium.content_public.browser.WebContents;
@@ -320,13 +321,22 @@ public abstract class CobaltActivity extends Activity {
     super.onCreate(savedInstanceState);
     createContent(savedInstanceState);
 
-    videoSurfaceView = new VideoSurfaceView(this);
-    a11yHelper = new CobaltA11yHelper(this, videoSurfaceView);
-    addContentView(videoSurfaceView, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+    if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
+      Log.d(TAG, "Using Android Overlay for Cobalt.");
 
-    Log.i(TAG, "CobaltActivity onCreate, all Layout Views:");
-    View rootView = getWindow().getDecorView().getRootView();
-    Util.printRootViewHierarchy(rootView);
+    } else {
+      videoSurfaceView = new VideoSurfaceView(this);
+
+      // TODO: b/408279606 - Set this to app theme primary color once we fix
+      // error with it being unresolvable.
+      videoSurfaceView.setBackgroundColor(Color.BLACK);
+      a11yHelper = new CobaltA11yHelper(this, videoSurfaceView);
+      addContentView(videoSurfaceView, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
+
+      Log.i(TAG, "CobaltActivity onCreate, all Layout Views:");
+      View rootView = getWindow().getDecorView().getRootView();
+      Util.printRootViewHierarchy(rootView);
+    }
   }
 
   /**

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -323,20 +323,17 @@ public abstract class CobaltActivity extends Activity {
 
     if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
       Log.d(TAG, "Using Android Overlay for Cobalt.");
+      // TODO: b/431317298 - Add SurfaceView for |a11yHelper|.
 
     } else {
       videoSurfaceView = new VideoSurfaceView(this);
-
-      // TODO: b/408279606 - Set this to app theme primary color once we fix
-      // error with it being unresolvable.
-      videoSurfaceView.setBackgroundColor(Color.BLACK);
       a11yHelper = new CobaltA11yHelper(this, videoSurfaceView);
       addContentView(videoSurfaceView, new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT));
-
-      Log.i(TAG, "CobaltActivity onCreate, all Layout Views:");
-      View rootView = getWindow().getDecorView().getRootView();
-      Util.printRootViewHierarchy(rootView);
     }
+
+    Log.i(TAG, "CobaltActivity onCreate, all Layout Views:");
+    View rootView = getWindow().getDecorView().getRootView();
+    Util.printRootViewHierarchy(rootView);
   }
 
   /**
@@ -391,7 +388,7 @@ public abstract class CobaltActivity extends Activity {
       getStarboardBridge().getAudioOutputManager().dumpAllOutputDevices();
       MediaCodecCapabilitiesLogger.dumpAllDecoders();
     }
-    if (forceCreateNewVideoSurfaceView) {
+    if (forceCreateNewVideoSurfaceView && !ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
       Log.w(TAG, "Force to create a new video surface.");
       createNewSurfaceView();
     }
@@ -558,23 +555,21 @@ public abstract class CobaltActivity extends Activity {
   }
 
   public void resetVideoSurface() {
-    if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
-      // VideoSurfaceView will be null if Cobalt is using Android Overlay.
-      return;
-    }
-
-    runOnUiThread(
+    // VideoSurfaceView will be null if Cobalt is using Android Overlay.
+    if (!ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
+      runOnUiThread(
         new Runnable() {
           @Override
           public void run() {
             createNewSurfaceView();
           }
         });
+    }
   }
 
   public void setVideoSurfaceBounds(final int x, final int y, final int width, final int height) {
     if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
-      // VideoSurfaceView will be null if Cobalt is using Android Overlay.
+      // Using AndroidOverlay doesn't update the bounds of VideoSurfaceView.
       return;
     }
 
@@ -582,8 +577,6 @@ public abstract class CobaltActivity extends Activity {
       // The SurfaceView should be covered by our UI layer in this case.
       return;
     }
-
-
     runOnUiThread(
         new Runnable() {
           @Override
@@ -612,11 +605,6 @@ public abstract class CobaltActivity extends Activity {
   }
 
   private void createNewSurfaceView() {
-    if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
-      // VideoSurfaceView will be null if Cobalt is using Android Overlay.
-      return;
-    }
-
     if (ContentFeatureList.isEnabled(ContentFeatureList.COBALT_USING_ANDROID_OVERLAY)) {
       // VideoSurfaceView will be null if Cobalt is using Android Overlay.
       return;

--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -27,6 +27,11 @@ import("//tools/ipc_fuzzer/ipc_fuzzer.gni")
 if (is_mac) {
   import("//content/public/app/mac_helpers.gni")
 }
+
+if (is_cobalt) {
+  import("//starboard/build/buildflags.gni")
+}
+
 import("//cobalt/build/configs/hacks.gni")
 
 buildflag_header("buildflags") {

--- a/content/browser/android/content_feature_list.cc
+++ b/content/browser/android/content_feature_list.cc
@@ -46,7 +46,9 @@ const base::Feature* const kFeaturesExposedToJava[] = {
     &features::kWebBluetoothNewPermissionsBackend,
     &features::kWebNfc,
     &features::kDoNotGenerateChromiumA11yTree,
-    &kCobaltUsingAndroidOverlay,
+    #if BUILDFLAG(USE_STARBOARD_MEDIA)
+    &media::kCobaltUsingAndroidOverlay,
+    #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 const base::Feature* FindFeatureExposedToJava(const std::string& feature_name) {

--- a/content/browser/android/content_feature_list.cc
+++ b/content/browser/android/content_feature_list.cc
@@ -11,6 +11,10 @@
 #include "third_party/blink/public/common/features.h"
 #include "ui/accessibility/accessibility_features.h"
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/base/media_switches.h"
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 using base::android::ConvertJavaStringToUTF8;
 using base::android::JavaParamRef;
 
@@ -42,6 +46,7 @@ const base::Feature* const kFeaturesExposedToJava[] = {
     &features::kWebBluetoothNewPermissionsBackend,
     &features::kWebNfc,
     &features::kDoNotGenerateChromiumA11yTree,
+    &kCobaltUsingAndroidOverlay,
 };
 
 const base::Feature* FindFeatureExposedToJava(const std::string& feature_name) {

--- a/content/public/android/java/src/org/chromium/content_public/browser/ContentFeatureList.java
+++ b/content/public/android/java/src/org/chromium/content_public/browser/ContentFeatureList.java
@@ -73,6 +73,8 @@ public class ContentFeatureList {
     public static final String BACKGROUND_MEDIA_RENDERER_HAS_MODERATE_BINDING =
             "BackgroundMediaRendererHasModerateBinding";
 
+    public static final String COBALT_USING_ANDROID_OVERLAY = "CobaltUsingAndroidOverlay";
+
     public static final String DO_NOT_GENERATE_CHROMIUM_A11Y_TREE = "DoNotGenerateChromiumA11yTree";
 
     public static final String ON_DEMAND_ACCESSIBILITY_EVENTS = "OnDemandAccessibilityEvents";

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -1566,3 +1566,11 @@ uint32_t GetPassthroughAudioFormats() {
 }
 
 }  // namespace media
+
+#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+BASE_FEATURE(kCobaltUsingAndroidOverlay,
+             "CobaltUsingAndroidOverlay",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif  // BUILDFLAG(IS_ANDROID)

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -494,6 +494,12 @@ BASE_FEATURE(kCobaltProgressivePlayback,
 BASE_FEATURE(kCobaltReportBufferingStateDuringFlush,
              "CobaltReportBufferingStateDuringFlush",
              base::FEATURE_DISABLED_BY_DEFAULT);
+// When enabled, Cobalt uses Android Overlay, otherwise VideoSurfaceView.
+#if BUILDFLAG(IS_ANDROID)
+BASE_FEATURE(kCobaltUsingAndroidOverlay,
+             "CobaltUsingAndroidOverlay",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#endif  // BUILDFLAG(IS_ANDROID)
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #if BUILDFLAG(IS_CHROMEOS)
@@ -1566,11 +1572,3 @@ uint32_t GetPassthroughAudioFormats() {
 }
 
 }  // namespace media
-
-#if BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-BASE_FEATURE(kCobaltUsingAndroidOverlay,
-             "CobaltUsingAndroidOverlay",
-             base::FEATURE_DISABLED_BY_DEFAULT);
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-#endif  // BUILDFLAG(IS_ANDROID)

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -180,6 +180,9 @@ MEDIA_EXPORT extern const base::FeatureParam<int>
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltDecoderBufferAllocatorWithInPlaceMetadata);
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltProgressivePlayback);
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltReportBufferingStateDuringFlush);
+#if BUILDFLAG(IS_ANDROID)
+MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingAndroidOverlay);
+#endif  // BUILDFLAG(IS_ANDROID)
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 #if BUILDFLAG(IS_CHROMEOS)
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCrOSSystemAEC);
@@ -466,11 +469,4 @@ MEDIA_EXPORT extern const base::FeatureParam<kCrosGlobalMediaControlsPinOptions>
 MEDIA_EXPORT uint32_t GetPassthroughAudioFormats();
 
 }  // namespace media
-
 #endif  // MEDIA_BASE_MEDIA_SWITCHES_H_
-
-#if BUILDFLAG(IS_ANDROID)
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingAndroidOverlay);
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-#endif  // BUILDFLAG(IS_ANDROID)

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -468,3 +468,9 @@ MEDIA_EXPORT uint32_t GetPassthroughAudioFormats();
 }  // namespace media
 
 #endif  // MEDIA_BASE_MEDIA_SWITCHES_H_
+
+#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingAndroidOverlay);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif  // BUILDFLAG(IS_ANDROID)


### PR DESCRIPTION
Implements a BASE Feature, `CobaltUsingAndroidOverlay`, for SbPlayer using `AndroidOverlay`, and this is disabled by default.

This feature is used to enable `StarboardRenderer` to create `AndroidOverlay`, so SbPlayer can use the SurfaceView of `AndroidOverlay`, instead of VideoSurfaceView from StarboardBridge.

This ensures the life cycle of SurfaceView is managed by StarboardRenderer, instead of in StarboardBridge.

Issue: 428017363