### PR TITLE
posix: Register mincore in Starboard API 

### DIFF
--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -250,6 +250,7 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(madvise);
   REGISTER_SYMBOL(malloc);
   REGISTER_SYMBOL(malloc_usable_size);
+  REGISTER_SYMBOL(mincore);
   REGISTER_SYMBOL(mkdir);
   REGISTER_SYMBOL(mkdtemp);
   REGISTER_SYMBOL(mkostemp);

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -177,6 +177,7 @@ test("nplb") {
     "posix_compliance/posix_string_format_test.cc",
     "posix_compliance/posix_string_format_wide_test.cc",
     "posix_compliance/posix_string_scan_test.cc",
+    "posix_compliance/posix_sys_mincore_test.cc",
     "posix_compliance/posix_sys_statvfs_test.cc",
     "posix_compliance/posix_thread_attr_test.cc",
     "posix_compliance/posix_thread_create_test.cc",

--- a/starboard/nplb/posix_compliance/posix_sys_mincore_test.cc
+++ b/starboard/nplb/posix_compliance/posix_sys_mincore_test.cc
@@ -1,0 +1,56 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <sys/mman.h>
+#include <unistd.h>
+
+#include <errno.h>
+#include <string.h>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace nplb {
+namespace {
+
+TEST(PosixSysMincoreTest, SucceedsForValidAddress) {
+  void* mem =
+      mmap(NULL, 1, PROT_READ | PROT_WRITE, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+  ASSERT_NE(mem, MAP_FAILED);
+
+  static_cast<char*>(mem)[0] = 'A';
+
+  unsigned char vec;
+  errno = 0;
+  int result = mincore(mem, 1, &vec);
+
+  EXPECT_EQ(result, 0) << "mincore failed with error: " << strerror(errno);
+  EXPECT_EQ(vec & 1, 1) << "Page not in core.";
+
+  EXPECT_EQ(munmap(mem, 1), 0);
+}
+
+TEST(PosixSysMincoreTest, FailsForInvalidAddress) {
+  void* invalid_addr = reinterpret_cast<void*>(1);
+  unsigned char vec;
+
+  errno = 0;
+  int result = mincore(invalid_addr, 1, &vec);
+
+  EXPECT_EQ(result, -1);
+  EXPECT_EQ(errno, EINVAL);
+}
+
+}  // namespace
+}  // namespace nplb
+}  // namespace starboard

--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -131,6 +131,7 @@ _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
     'madvise',
     'malloc',
     'malloc_usable_size',
+    'mincore',
     'mkdir',
     'mkdtemp',
     'mkostemp',

--- a/starboard/tools/api_leak_detector/evergreen/manifest
+++ b/starboard/tools/api_leak_detector/evergreen/manifest
@@ -58,7 +58,6 @@ localeconv
 localtime
 localtime_r
 lstat
-mincore
 mktime
 mremap
 newlocale


### PR DESCRIPTION
Register `mincore` in Starboard API , as it doesn't need a wrapper.

Issue: 412650854