### PR TITLE
[Cleanup] Make ConstructHwcapFromCPUInfo for arm build only

### DIFF
--- a/starboard/shared/linux/cpu_features_get.cc
+++ b/starboard/shared/linux/cpu_features_get.cc
@@ -368,6 +368,7 @@ bool HasItemInList(const char* list, const char* flag) {
   return false;
 }
 
+#if SB_IS(32_BIT)
 // Construct hwcap bitmask by the feature flags in /proc/cpuinfo
 uint32_t ConstructHwcapFromCPUInfo(ProcCpuInfo* cpu_info,
                                    int16_t architecture_generation,
@@ -412,6 +413,7 @@ uint32_t ConstructHwcapFromCPUInfo(ProcCpuInfo* cpu_info,
   }
   return hwcap_value;
 }
+#endif  // SB_IS(32_BIT)
 
 bool SbCPUFeaturesGet_ARM(SbCPUFeatures* features) {
   memset(features, 0, sizeof(*features));


### PR DESCRIPTION
Make ConstructHwcapFromCPUInfo() only for arm 32-bit build, as this has a warning for compiling arm 64-bit build.

Issue: 430960781