### PR TITLE
cobalt: Remove leftover dependency on //chrome/common

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -195,7 +195,6 @@ test("cobalt_unittests") {
 
   # All configs that provide definitions for switch constants.
   deps += [
-    "//chrome/common:non_code_constants",
     "//cobalt/browser:switches",
 
     # TODO(cobalt b/375241103) This dependency is large in scope. It would be

--- a/cobalt/DEPS
+++ b/cobalt/DEPS
@@ -1,0 +1,4 @@
+include_rules = [
+  # Code in //cobalt is not allowed to depend on //chrome.
+  "-chrome",
+]


### PR DESCRIPTION
Follow-up to #5960, which removed the dependency on //chrome/common:non_code_constants from //cobalt.

There was a leftover dependency in the cobalt_unittests target that should also have been removed.

Bug: 420684984