### PR TITLE
Add kokoro config for Chromedriver builds

### DIFF
--- a/cobalt/devinfra/kokoro/build/linux/internal/qa-no-starboard.gcl
+++ b/cobalt/devinfra/kokoro/build/linux/internal/qa-no-starboard.gcl
@@ -1,0 +1,24 @@
+// -*- protobuffer -*
+// proto-file: google3/devtools/kokoro/config/proto/build.proto
+// proto-message: BuildConfig
+// validation: gcl --message=kokoro.BuildConfig --objtype=config group2.gcl appendascii
+
+import 'common.gcl' as common
+
+config build = common.build {
+  build_file = 'src/cobalt/devinfra/kokoro/bin/dind_builder_runner.sh'
+  env_vars = super.env_vars + [
+    {
+      key = 'TARGET'
+      value = 'chromedriver'
+    },
+    {
+      key = 'TARGET_PLATFORM'
+      value = 'linux-x64x11-no-starboard'
+    },
+    {
+      key = 'CONFIG'
+      value = 'qa'
+    },
+  ]
+}


### PR DESCRIPTION
This new config ensures that Chromedriver is built with linux-x64x11-no-starboard.

Bug: 432077378