### PR TITLE
Move build-id generation to initialize step

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -30,6 +30,17 @@ runs:
           cd src
           cobalt/build/gn.py -p ${{ matrix.platform }} -C ${{ matrix.config }}
         shell: bash
+      - name: Download Build Info Artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: build-id-${{ matrix.platform }}
+          path: src/out/${{ matrix.platform }}_${{ matrix.config }}/
+      - name: Debug Build Info JSON after download
+        shell: bash
+        run: |
+          echo "--- Build Info JSON Content (after download) ---"
+          cat src/out/${{ matrix.platform }}_${{ matrix.config }}/gen/build_info.json
+          echo "--------------------------------------------"
       - name: List GN args
         run: |
           cd src

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -203,6 +203,27 @@ jobs:
           docker_content_sha=$(git log -n 1 --pretty=format:%h -- cobalt/docker docker-compose.yaml)
           git show ${docker_content_sha}
           echo "docker_content_sha=${docker_content_sha}" >> $GITHUB_OUTPUT
+      - name: Generate Build Info
+        shell: bash
+        run: |
+          # Generate build id manually here instead of the build step to avoid
+          # checking out the full git history more than once.
+          mkdir -p build_id/gen/cobalt
+          python3 cobalt/build/build_info.py \
+            --skip-licenses \
+            build_id/gen/cobalt/cobalt_build_id.h \
+            build_id/gen/build_info.json
+      - name: Debug Build Info JSON
+        shell: bash
+        run: |
+          echo "--- Build Info JSON Content ---"
+          cat build_id/gen/build_info.json
+          echo "---------------------------"
+      - name: Upload Build Info Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: build-id-${{ inputs.platform }}
+          path: build_id/
     outputs:
       platforms: ${{ steps.set-platforms.outputs.platforms }}
       targets: ${{ steps.set-targets.outputs.targets }}
@@ -315,8 +336,6 @@ jobs:
         if: ${{ ! (contains(matrix.platform, 'android') && matrix.config == 'debug') }}
         with:
           path: src
-          # Use fetch depth of 0 to get full history for a valid build id.
-          fetch-depth: 0
       - name: Set Up Depot Tools
         uses: ./src/.github/actions/depot_tools
       - name: Build Cobalt

--- a/cobalt/build/build_info.py
+++ b/cobalt/build/build_info.py
@@ -14,6 +14,7 @@
 # limitations under the License.
 """Generates a Cobalt Build Info json."""
 
+import argparse
 import datetime
 import json
 import os
@@ -205,6 +206,22 @@ def write_licenses(txt_path, spdx_path):
 
 
 if __name__ == '__main__':
-  write_build_id_header(sys.argv[1])
-  write_build_json(sys.argv[2])
-  write_licenses(sys.argv[3], sys.argv[4])
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--skip-licenses',
+      action='store_true',
+      help='If set, skips the license generation step.')
+  parser.add_argument('header_path')
+  parser.add_argument('json_path')
+  parser.add_argument('txt_path', nargs='?')
+  parser.add_argument('spdx_path', nargs='?')
+  args = parser.parse_args()
+
+  write_build_id_header(args.header_path)
+  write_build_json(args.json_path)
+  if not args.skip_licenses:
+    if not args.txt_path or not args.spdx_path:
+      print('Error: txt_path and spdx_path are required unless --skip-licenses '
+            'is used.')
+      sys.exit(1)
+    write_licenses(args.txt_path, args.spdx_path)


### PR DESCRIPTION
This is to avoid checking out the full history in the build step, making the step much faster to run (~30%).

Bug: 432613121