### PR TITLE
posix: Improve reliability of statvfs usage test

### DIFF
--- a/cobalt/testing/filters/evergreen-x64/nplb_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-x64/nplb_loader_filter.json
@@ -1,5 +1,3 @@
 {
-  "failing_tests": [
-    "PosixSysStatvfsTest.UsageChanges"
-  ]
+  "failing_tests": []
 }

--- a/cobalt/testing/filters/linux-x64x11-modular/nplb_loader_filter.json
+++ b/cobalt/testing/filters/linux-x64x11-modular/nplb_loader_filter.json
@@ -1,5 +1,3 @@
 {
-  "failing_tests": [
-    "PosixSysStatvfsTest.UsageChanges"
-  ]
+  "failing_tests": []
 }

--- a/cobalt/testing/filters/linux-x64x11/nplb_filter.json
+++ b/cobalt/testing/filters/linux-x64x11/nplb_filter.json
@@ -1,5 +1,3 @@
 {
-  "failing_tests": [
-    "PosixSysStatvfsTest.UsageChanges"
-  ]
+  "failing_tests": []
 }


### PR DESCRIPTION
The `PosixStatvfsTest.UsageChanges` test can be flaky because filesystem usage may not be updated immediately after file operations.
    
This change adds `fdatasync` and `fsync` calls to encourage the filesystem to write changes to disk sooner. It also adds a tolerance to the final block comparison to account for minor filesystem fluctuations and improves debug output.

The fix is via `gemini-cli`.

Issue: 412650854