### PR TITLE
media: Fix potential crash on SbPlayerBridge

### DIFF
--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -388,6 +388,8 @@ class SbPlayerBridge {
   CValStats* cval_stats_;
   std::string pipeline_identifier_;
 #endif  // COBALT_MEDIA_ENABLE_CVAL
+  base::WeakPtr<SbPlayerBridge> weak_this_;
+  base::WeakPtrFactory<SbPlayerBridge> weak_factory_{this};
 };
 
 }  // namespace media


### PR DESCRIPTION
This PR replaces to pass the pointer of `media::SbPlayerBridge` with `base::WeakPtr` to ensure the lifecycle during callbacks.

Issue: 431050750