### PR TITLE
Revert "Disable chromedriver archive package uploads"

### DIFF
--- a/cobalt/build/linux/package.json
+++ b/cobalt/build/linux/package.json
@@ -2,6 +2,7 @@
     "archive_datas": [
         {
             "files": [
+                "chromedriver",
                 "cobalt.stripped",
                 "content_shell.pak",
                 "gen/build_info.json",


### PR DESCRIPTION
Reverts youtube/cobalt#6427

This should only be merged after https://github.com/youtube/cobalt/pull/6526 is submitted


Bug: 432077378