### PR TITLE
Initialize ShellManager withou View

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -135,17 +135,8 @@ public abstract class CobaltActivity extends Activity {
       getStarboardBridge().handleDeepLink(startDeepLink);
     }
 
-    mShellManager = new ShellManager(this);
-    final boolean listenToActivityState = true;
     mIntentRequestTracker = IntentRequestTracker.createFromActivity(this);
-    mWindowAndroid = new ActivityWindowAndroid(this, listenToActivityState, mIntentRequestTracker);
     mIntentRequestTracker.restoreInstanceState(savedInstanceState);
-    mShellManager.setWindow(mWindowAndroid);
-    setContentView(mShellManager.getContentViewRenderView());
-    // Set up the animation placeholder to be the SurfaceView. This disables the
-    // SurfaceView's 'hole' clipping during animations that are notified to the window.
-    mWindowAndroid.setAnimationPlaceholderView(
-        mShellManager.getContentViewRenderView().getSurfaceView());
 
     if (mStartupUrl == null || mStartupUrl.isEmpty()) {
       String[] args = getStarboardBridge().getArgs();
@@ -155,9 +146,6 @@ public abstract class CobaltActivity extends Activity {
               .findAny()
               .map(arg -> arg.substring(arg.indexOf(URL_ARG) + URL_ARG.length()))
               .orElse(null);
-    }
-    if (!TextUtils.isEmpty(mStartupUrl)) {
-      mShellManager.setStartupUrl(Shell.sanitizeUrl(mStartupUrl));
     }
 
     // TODO(b/377025559): Bring back WebTests launch capability
@@ -185,6 +173,19 @@ public abstract class CobaltActivity extends Activity {
 
   // Initially copied from ContentShellActiviy.java
   private void finishInitialization(Bundle savedInstanceState) {
+    mShellManager = new ShellManager(this);
+    final boolean listenToActivityState = true;
+    mWindowAndroid = new ActivityWindowAndroid(this, listenToActivityState, mIntentRequestTracker);
+    mShellManager.setWindow(mWindowAndroid);
+    setContentView(mShellManager.getContentViewRenderView());
+    // Set up the animation placeholder to be the SurfaceView. This disables the
+    // SurfaceView's 'hole' clipping during animations that are notified to the window.
+    mWindowAndroid.setAnimationPlaceholderView(
+        mShellManager.getContentViewRenderView().getSurfaceView());
+    if (!TextUtils.isEmpty(mStartupUrl)) {
+      mShellManager.setStartupUrl(Shell.sanitizeUrl(mStartupUrl));
+    }
+
     // Load an empty page to let shell create WebContents.
     mShellManager.launchShell("");
     // Inject JavaBridge objects to the WebContents.

--- a/cobalt/shell/android/browsertests/src/org/chromium/content_shell/browsertests/ContentShellBrowserTestActivity.java
+++ b/cobalt/shell/android/browsertests/src/org/chromium/content_shell/browsertests/ContentShellBrowserTestActivity.java
@@ -68,12 +68,12 @@ public abstract class ContentShellBrowserTestActivity extends NativeBrowserTestA
         }
 
         ContentUriUtils.setFileProviderUtil(new FileProviderHelper());
-        setContentView(getTestActivityViewId());
-        mShellManager = (ShellManager) findViewById(getShellManagerViewId());
+        mShellManager = new ShellManager(this);
         IntentRequestTracker intentRequestTracker = IntentRequestTracker.createFromActivity(this);
         mWindowAndroid = new ActivityWindowAndroid(
                 this, /* listenToActivityState= */ true, intentRequestTracker);
         mShellManager.setWindow(mWindowAndroid);
+        setContentView(mShellManager.getContentViewRenderView());
 
         Window wind = this.getWindow();
         wind.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);
@@ -112,7 +112,5 @@ public abstract class ContentShellBrowserTestActivity extends NativeBrowserTestA
     protected String getUserDataDirectoryCommandLineSwitch() {
         return "data-path";
     }
-    protected abstract int getTestActivityViewId();
 
-    protected abstract int getShellManagerViewId();
 }

--- a/cobalt/testing/browser_tests/browsertests_apk/src/org/chromium/content_browsertests_apk/ContentBrowserTestsActivity.java
+++ b/cobalt/testing/browser_tests/browsertests_apk/src/org/chromium/content_browsertests_apk/ContentBrowserTestsActivity.java
@@ -42,14 +42,4 @@ public class ContentBrowserTestsActivity extends ContentShellBrowserTestActivity
                 ContentBrowserTestsApplication.PRIVATE_DATA_DIRECTORY_SUFFIX);
     }
 
-    @Override
-    protected int getTestActivityViewId() {
-        return R.layout.test_activity;
-    }
-
-    @Override
-    protected int getShellManagerViewId() {
-        return R.id.shell_container;
-    }
-
 }


### PR DESCRIPTION
The error is:
```
07-24 18:47:00.755  7062  7062 F cobalt  : [FATAL:compositor_dependencies_android.cc(81)] Check failed: ::content::BrowserThread::CurrentlyOn(BrowserThread::UI). Must be called on Chrome_UIThread; actually called on Unknown Thread.
```.

The cobalt_browsertests fails because it cannot set up the compositor, connect to the graphics service, or
  manage the GPU's lifecycle, which are all fundamental requirements for rendering a web page.

Caused by https://groups.google.com/a/google.com/g/cobalt-eng/c/Nz_L5VlcfQQ/m/SKqrk-GgAQAJ.

Bug: 433568263