### PR TITLE
Fix NSS and Root Store in non-starboard configs

### DIFF
--- a/cobalt/build/configs/linux-x64x11-no-starboard/args.gn
+++ b/cobalt/build/configs/linux-x64x11-no-starboard/args.gn
@@ -10,3 +10,8 @@ use_starboard_media = false
 
 # TODO(b/376141256): Decide if this flag is needed here or in .gclient file
 chrome_pgo_phase = 0
+
+use_nss_certs = false
+chrome_root_store_optional = false
+chrome_root_store_only = true
+trial_comparison_cert_verifier_supported = false

--- a/net/BUILD.gn
+++ b/net/BUILD.gn
@@ -1630,7 +1630,8 @@ component("net") {
     configs += [ "//build/config/compiler:optimize_max" ]
   }
 
-  if(is_starboard) {
+  # This allows linux-x64x11-no-starboard builds to run without ???
+  if(is_cobalt) {
     sources += [
       "cert/test_root_certs_builtin.cc",
       "cert/internal/system_trust_store_starboard.cc"

--- a/net/cert/internal/system_trust_store_starboard.cc
+++ b/net/cert/internal/system_trust_store_starboard.cc
@@ -11,7 +11,7 @@
 
 #include "net/cert/internal/trust_store_chrome.h"
 
-#if BUILDFLAG(IS_STARBOARD)
+#if BUILDFLAG(IS_COBALT)
 
 namespace net {
 
@@ -48,4 +48,4 @@ std::unique_ptr<SystemTrustStore> CreateSslSystemTrustStoreChromeRoot(
 
 } // namespace net
 
-#endif // BUILDFLAG(IS_STARBOARD)
+#endif // BUILDFLAG(IS_COBALT)


### PR DESCRIPTION
In order to build Chromedriver from the linux-x64x11-no-starboard config, we need to port the following customizations made in the linux-x64x11 config over. This involves disabling NSS from being built into the targets and ensuring it only uses the Chrome Root Store.

Bug: 432077378