### PR TITLE
Revert "cobalt/android: Remove treat_warnings_as_errors=false provision"

### DIFF
--- a/cobalt/build/configs/android_common.gn
+++ b/cobalt/build/configs/android_common.gn
@@ -1,5 +1,9 @@
 import("//cobalt/build/configs/common.gn")
 
+# This flag comes from build/config/compiler/compiler.gni
+# TODO(b/380339614): Remove this flag after resolving build errors.
+treat_warnings_as_errors = false
+
 # hashed jni names make build artifact opaque for Kimono build.
 use_hashed_jni_names = false
 use_errorprone_java_compiler = false


### PR DESCRIPTION
Reverts youtube/cobalt#6400

There are still a number of warnings that cause build failures on android without this flag set.

Bug: 380339614