### PR TITLE
[Ozone] Fix crash in monolithic QA build

### DIFF
--- a/ui/ozone/platform/starboard/gl_ozone_egl_starboard.cc
+++ b/ui/ozone/platform/starboard/gl_ozone_egl_starboard.cc
@@ -261,6 +261,7 @@ bool GLOzoneEGLStarboard::LoadGLES2Bindings(
     const gl::GLImplementationParts& implementation) {
   DCHECK_EQ(implementation.gl, gl::kGLImplementationEGLANGLE)
       << "Not supported: " << implementation.ToString();
+#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
   gl::GLGetProcAddressProc gl_proc =
       [](const char* name) -> gl::GLFunctionPointerType {
     gl::GLFunctionPointerType proc =
@@ -283,13 +284,12 @@ bool GLOzoneEGLStarboard::LoadGLES2Bindings(
     // If still not found, try to retrieve GLES2 functions directly from the
     // SbGlesInterface as a fallback.
     const SbGlesInterface* gles = SbGetGlesInterface();
-    proc = GetGlesInterfaceProcAddress(name, gles);
-    if (proc) {
-      return proc;
-    }
-
-    return nullptr;
+    return GetGlesInterfaceProcAddress(name, gles);
   };
+#else
+  gl::GLGetProcAddressProc gl_proc = reinterpret_cast<gl::GLGetProcAddressProc>(
+      SbGetEglInterface()->eglGetProcAddress);
+#endif
 
   if (!gl_proc) {
     LOG(ERROR) << "GLOzoneEglStarboard::LoadGLES2Bindings no gl_proc";


### PR DESCRIPTION
This change fixes a crash that was happening in the monolithic QA build by adding a build flag to handle the GLES2 bindings.

Bug: 433776005