### PR TITLE
cobalt/infra: Add Kokoro package steps to GitHub

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -130,7 +130,7 @@ runs:
           upload_on_device_test_artifacts: ${{ inputs.upload_on_device_test_artifacts }}
           test_targets_json_file: ${{ inputs.test_targets_json_file }}
       - name: Run Package Script Test
-        if: ${{ (matrix.config == 'qa' || matrix.config == 'gold') && !contains(matrix.platform, 'chromium') && !contains(matrix.platform, 'evergreen') }}
+        if: ${{ (matrix.config == 'qa' || matrix.config == 'gold') && !contains(matrix.platform, 'chromium') && !contains(matrix.platform, 'evergreen') && !contains(matrix.platform, 'modular') }}
         run: |
           # Use the real variable from your environment
           MATRIX_PLATFORM="${{ matrix.platform }}"


### PR DESCRIPTION
It is possible for GitHub to pass without detecting issues in the packager script run in Kokoro builds. This adds the same steps that runs in Kokoro so that GitHub will not pass bad builds for the packager script.

Fixed: 434759528