### PR TITLE
feat: Refactor media decoder and add memory management

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -122,6 +122,37 @@ class MediaCodecBridge {
 
   private FrameRateEstimator mFrameRateEstimator = null;
 
+  private static String bufferFlagsToString(int flags) {
+    if (flags == 0) {
+      return "0";
+    }
+    StringBuilder sb = new StringBuilder();
+    if ((flags & MediaCodec.BUFFER_FLAG_KEY_FRAME) != 0) {
+      sb.append("KEY_FRAME ");
+    }
+    if ((flags & MediaCodec.BUFFER_FLAG_CODEC_CONFIG) != 0) {
+      sb.append("CODEC_CONFIG ");
+    }
+    if ((flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) != 0) {
+      sb.append("END_OF_STREAM ");
+    }
+    if ((flags & MediaCodec.BUFFER_FLAG_PARTIAL_FRAME) != 0) {
+      sb.append("PARTIAL_FRAME ");
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && (flags & 16 /* MediaCodec.BUFFER_FLAG_MUXER_DATA */) != 0) {
+      sb.append("MUXER_DATA ");
+    }
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP) {
+      if ((flags & MediaCodec.BUFFER_FLAG_DECODE_ONLY) != 0) {
+        sb.append("DECODE_ONLY ");
+      }
+    }
+    if (sb.length() > 0) {
+      sb.setLength(sb.length() - 1); // remove trailing space
+    }
+    return sb.toString();
+  }
+
   /** A wrapper around a MediaFormat. */
   private static class GetOutputFormatResult {
     private int mStatus;
@@ -333,6 +364,7 @@ class MediaCodecBridge {
               if (mNativeMediaCodecBridge == 0) {
                 return;
               }
+              Log.i(TAG, "onOutputBufferAvailable: index=" + index + ", flags=" + bufferFlagsToString(info.flags) + ", offset=" + info.offset + ", presentationTimeUs=" + info.presentationTimeUs + ", size=" + info.size);
               MediaCodecBridgeJni.get()
                   .onMediaCodecOutputBufferAvailable(
                       mNativeMediaCodecBridge,
@@ -762,6 +794,7 @@ class MediaCodecBridge {
       long presentationTimeUs) {
     resetLastPresentationTimeIfNeeded(presentationTimeUs);
     try {
+      Log.i(TAG, "media_decoder:queueSecureInputBuffer pts(msec)=" + presentationTimeUs / 1000);
       CryptoInfo cryptoInfo = new CryptoInfo();
       cryptoInfo.set(
           numSubSamples, numBytesOfClearData, numBytesOfEncryptedData, keyId, iv, cipherMode);

--- a/media/filters/source_buffer_stream.cc
+++ b/media/filters/source_buffer_stream.cc
@@ -168,7 +168,8 @@ SourceBufferStream::SourceBufferStream(const AudioDecoderConfig& audio_config,
       memory_limit_(GetDemuxerStreamAudioMemoryLimit(&audio_config)) {
   DCHECK(audio_config.IsValidConfig());
   audio_configs_.push_back(audio_config);
-  DVLOG(2) << __func__ << ": audio_buffer_size= " << memory_limit_;
+  LOG(INFO) << __func__ << "starboard:decoder:allocator: audio_buffer_size= "
+            << memory_limit_;
 }
 
 SourceBufferStream::SourceBufferStream(const VideoDecoderConfig& video_config,
@@ -185,7 +186,8 @@ SourceBufferStream::SourceBufferStream(const VideoDecoderConfig& video_config,
                                            &video_config)) {
   DCHECK(video_config.IsValidConfig());
   video_configs_.push_back(video_config);
-  DVLOG(2) << __func__ << ": video_buffer_size= " << memory_limit_;
+  LOG(INFO) << __func__ << ":starboard:decoder:allocator: video_buffer_size= "
+            << memory_limit_ << ", config=" << video_config.AsHumanReadableString();
 }
 
 SourceBufferStream::SourceBufferStream(const TextTrackConfig& text_config,

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -17,7 +17,9 @@
 #include <algorithm>
 
 #include "base/feature_list.h"
+#include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/threading/thread.h"
 #include "media/base/media_switches.h"
 #include "media/base/video_codecs.h"
 #include "media/starboard/decoder_buffer_allocator_strategy.h"
@@ -30,6 +32,34 @@
 #include "starboard/media.h"
 
 namespace media {
+
+namespace {
+// constexpr int64_t kLoggingIntervalUsec = 1'000'000;  // 1 second
+
+std::string FormatNumber(size_t n) {
+  std::string s = std::to_string(n);
+  int len = s.length();
+  int num_commas = (len - 1) / 3;
+  if (num_commas == 0) {
+    return s;
+  }
+  std::string result = "";
+  result.reserve(len + num_commas);
+  int first_part_len = len % 3;
+  if (first_part_len != 0) {
+    result.append(s, 0, first_part_len);
+    result += ',';
+  }
+  for (int i = first_part_len; i < len; i += 3) {
+    result.append(s, i, 3);
+    if (i + 3 < len) {
+      result += ',';
+    }
+  }
+  return result;
+}
+
+}  // namespace
 
 DecoderBufferAllocator::DecoderBufferAllocator(Type type /*= Type::kGlobal*/)
     : DecoderBufferAllocator(type,
@@ -49,6 +79,11 @@ DecoderBufferAllocator::DecoderBufferAllocator(
   DCHECK_GE(initial_capacity_, 0);
   DCHECK_GE(allocation_unit_, 0);
 
+  LOG(INFO) << "DecoderBufferAllocator: initial_capacity(KB)="
+            << FormatNumber(initial_capacity_ / 1024)
+            << ", allocation_unit(KB)="
+            << FormatNumber(allocation_unit_ / 1024);
+
   if (is_memory_pool_allocated_on_demand_) {
     LOG(INFO) << "Allocated media buffer pool on demand.";
     if (type_ == Type::kGlobal) {
@@ -62,11 +97,22 @@ DecoderBufferAllocator::DecoderBufferAllocator(
   if (type_ == Type::kGlobal) {
     Allocator::Set(this);
   }
+  logging_thread_ = std::make_unique<base::Thread>("media_memory_logger");
+  logging_thread_->Start();
+  logging_thread_->task_runner()->PostDelayedTask(
+      FROM_HERE,
+      base::BindOnce(&DecoderBufferAllocator::LogMemoryUsageAndReschedule,
+                     base::Unretained(this)),
+      base::Seconds(1));
 }
 
 DecoderBufferAllocator::~DecoderBufferAllocator() {
   if (type_ == Type::kGlobal) {
     Allocator::Set(nullptr);
+  }
+
+  if (logging_thread_) {
+    logging_thread_->Stop();
   }
 
   base::AutoLock scoped_lock(mutex_);
@@ -75,6 +121,27 @@ DecoderBufferAllocator::~DecoderBufferAllocator() {
     DCHECK_EQ(strategy_->GetAllocated(), 0u);
     strategy_.reset();
   }
+}
+
+void DecoderBufferAllocator::LogMemoryUsageAndReschedule() {
+  size_t tracked_allocated_size;
+  {
+    base::AutoLock scoped_lock(mutex_);
+    tracked_allocated_size = allocated_size_;
+  }
+  SB_LOG(INFO) << "Media memory usage: "
+               << "allocated(KB)=" << FormatNumber(GetAllocatedMemory() / 1024)
+               << ", capacity(KB)="
+               << FormatNumber(GetCurrentMemoryCapacity() / 1024)
+               << ", allocated_size(KB)="
+               << FormatNumber(tracked_allocated_size / 1024);
+
+  base::AutoLock scoped_lock(mutex_);
+  logging_thread_->task_runner()->PostDelayedTask(
+      FROM_HERE,
+      base::BindOnce(&DecoderBufferAllocator::LogMemoryUsageAndReschedule,
+                     base::Unretained(this)),
+      base::Seconds(1));
 }
 
 void DecoderBufferAllocator::Suspend() {
@@ -104,6 +171,7 @@ void* DecoderBufferAllocator::Allocate(DemuxerStream::Type type,
                                        size_t size,
                                        size_t alignment) {
   base::AutoLock scoped_lock(mutex_);
+  allocated_size_ += size;
 
   EnsureStrategyIsCreated();
 
@@ -129,6 +197,7 @@ void DecoderBufferAllocator::Free(void* p, size_t size) {
   }
 
   base::AutoLock scoped_lock(mutex_);
+  allocated_size_ -= size;
 
   DCHECK(strategy_);
 

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -61,10 +61,12 @@ std::string FormatNumber(size_t n) {
 
 }  // namespace
 
+constexpr int kEnoughSize = 250 * 1024 * 1024;
+
 DecoderBufferAllocator::DecoderBufferAllocator(Type type /*= Type::kGlobal*/)
     : DecoderBufferAllocator(type,
                              SbMediaIsBufferPoolAllocateOnDemand(),
-                             SbMediaGetInitialBufferCapacity(),
+                             250 * 1024 * 1024,
                              SbMediaGetBufferAllocationUnit()) {}
 
 DecoderBufferAllocator::DecoderBufferAllocator(
@@ -81,8 +83,9 @@ DecoderBufferAllocator::DecoderBufferAllocator(
 
   LOG(INFO) << "DecoderBufferAllocator: initial_capacity(KB)="
             << FormatNumber(initial_capacity_ / 1024)
-            << ", allocation_unit(KB)="
-            << FormatNumber(allocation_unit_ / 1024);
+            << ", allocation_unit(KB)=" << FormatNumber(allocation_unit_ / 1024)
+            << ", is_memory_pool_allocated_on_demand="
+            << (is_memory_pool_allocated_on_demand_ ? "true" : "false");
 
   if (is_memory_pool_allocated_on_demand_) {
     LOG(INFO) << "Allocated media buffer pool on demand.";

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -26,6 +26,10 @@
 #include "media/starboard/decoder_buffer_memory_info.h"
 #include "starboard/media.h"
 
+namespace base {
+class Thread;
+}  // namespace base
+
 namespace media {
 
 class DecoderBufferAllocator : public DecoderBuffer::Allocator,
@@ -90,6 +94,7 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
  private:
   void EnsureStrategyIsCreated() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void LogMemoryUsageAndReschedule();
 
 #if !defined(COBALT_BUILD_TYPE_GOLD)
   void TryFlushAllocationLog_Locked() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
@@ -102,6 +107,7 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
   mutable base::Lock mutex_;
   std::unique_ptr<Strategy> strategy_ GUARDED_BY(mutex_);
+  std::unique_ptr<base::Thread> logging_thread_ GUARDED_BY(mutex_);
 
 #if !defined(COBALT_BUILD_TYPE_GOLD)
   // The following variables are used for comprehensive logging of allocation
@@ -110,6 +116,8 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   int pending_allocation_operations_count_ GUARDED_BY(mutex_) = 0;
   int allocation_operation_index_ GUARDED_BY(mutex_) = 0;
 #endif  // !defined(COBALT_BUILD_TYPE_GOLD)
+
+  std::atomic<int> allocated_size_ = 0;
 };
 
 }  // namespace media

--- a/media/starboard/starboard_memory_allocator.h
+++ b/media/starboard/starboard_memory_allocator.h
@@ -19,7 +19,9 @@
 
 #include <algorithm>
 
+#include "base/posix/safe_strerror.h"
 #include "starboard/common/allocator.h"
+#include "starboard/common/log.h"
 #include "starboard/configuration.h"
 
 namespace media {
@@ -32,7 +34,12 @@ class StarboardMemoryAllocator : public starboard::common::Allocator {
 
   void* Allocate(std::size_t size, std::size_t alignment) override {
     void* p = nullptr;
-    std::ignore = posix_memalign(&p, std::max(alignment, sizeof(void*)), size);
+    int err = posix_memalign(&p, std::max(alignment, sizeof(void*)), size);
+    if (err != 0) {
+      SB_LOG(FATAL) << __func__ << " failed: size=" << size
+                    << ", err=" << base::safe_strerror(err);
+    }
+    SB_LOG(INFO) << __func__ << " > size=" << size;
     return p;
   }
 

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -483,7 +483,8 @@ void MediaCodecBridge::OnMediaCodecFrameRendered(
     JNIEnv* env,
     jlong presentation_time_us,
     jlong render_at_system_time_ns) {
-  handler_->OnMediaCodecFrameRendered(presentation_time_us);
+  handler_->OnMediaCodecFrameRendered(presentation_time_us,
+                                      render_at_system_time_ns / 1000);
 }
 
 void MediaCodecBridge::OnMediaCodecFirstTunnelFrameReady(JNIEnv* env) {

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -134,7 +134,8 @@ class MediaCodecBridge {
     virtual void OnMediaCodecOutputFormatChanged() = 0;
     // This is called when tunnel mode is enabled or on Android 14 and newer
     // devices.
-    virtual void OnMediaCodecFrameRendered(int64_t frame_timestamp) = 0;
+    virtual void OnMediaCodecFrameRendered(int64_t frame_timestamp,
+                                           int64_t frame_rendered_us) = 0;
     // This is only called on Android 12 and newer devices for tunnel mode.
     virtual void OnMediaCodecFirstTunnelFrameReady() = 0;
 

--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -25,14 +25,21 @@
 #include "starboard/audio_sink.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 #include "starboard/shared/pthread/thread_create_priority.h"
 
 namespace starboard::android::shared {
 namespace {
 
+using ::starboard::shared::starboard::media::DecoderFlowControl;
+
 // TODO: (cobalt b/372559388) Update namespace to jni_zero.
 using base::android::AttachCurrentThread;
 using base::android::ScopedJavaLocalRef;
+
+constexpr int kMaxFramesInDecoder = 6;
+constexpr bool kForceLimiting = true;
+constexpr int kFrameTrackerLogIntervalUs = 1'000'000;  // 1 sec.
 
 const jint kNoOffset = 0;
 const jlong kNoPts = 0;
@@ -82,7 +89,14 @@ MediaDecoder::MediaDecoder(Host* host,
       drm_system_(static_cast<DrmSystem*>(drm_system)),
       tunnel_mode_enabled_(false),
       flush_delay_usec_(0),
-      condition_variable_(mutex_) {
+      condition_variable_(mutex_),
+      decoder_flow_control_(
+          DecoderFlowControl::CreateThrottling(kMaxFramesInDecoder,
+                                               kFrameTrackerLogIntervalUs,
+                                               [this]() {
+                                                 ScopedLock lock(mutex_);
+                                                 condition_variable_.Signal();
+                                               })) {
   SB_DCHECK(host_);
 
   jobject j_media_crypto = drm_system_ ? drm_system_->GetMediaCrypto() : NULL;
@@ -131,8 +145,14 @@ MediaDecoder::MediaDecoder(
       first_tunnel_frame_ready_cb_(first_tunnel_frame_ready_cb),
       tunnel_mode_enabled_(tunnel_mode_audio_session_id != -1),
       flush_delay_usec_(flush_delay_usec),
-      condition_variable_(mutex_) {
-  SB_DCHECK(frame_rendered_cb_);
+      condition_variable_(mutex_),
+      decoder_flow_control_(
+          DecoderFlowControl::CreateThrottling(kMaxFramesInDecoder,
+                                               kFrameTrackerLogIntervalUs,
+                                               [this]() {
+                                                 ScopedLock lock(mutex_);
+                                                 condition_variable_.Signal();
+                                               })) {
   SB_DCHECK(first_tunnel_frame_ready_cb_);
 
   jobject j_media_crypto = drm_system_ ? drm_system_->GetMediaCrypto() : NULL;
@@ -222,6 +242,18 @@ void MediaDecoder::WriteEndOfStream() {
   ++number_of_pending_inputs_;
   if (pending_inputs_.size() == 1) {
     condition_variable_.Signal();
+  }
+}
+
+void MediaDecoder::SetRenderScheduledTime(int64_t pts_us,
+                                          int64_t scheduled_us) {
+  std::lock_guard lock(frame_timestamps_mutex_);
+  auto it = frame_timestamps_.find(pts_us);
+  if (it != frame_timestamps_.end()) {
+    it->second.render_scheduled_us = scheduled_us;
+  } else {
+    SB_LOG(WARNING) << "Could not find timestamp for PTS " << pts_us
+                    << " to set scheduled render time.";
   }
 }
 
@@ -350,7 +382,7 @@ void MediaDecoder::DecoderThreadFunc() {
       bool can_process_input =
           pending_input_to_retry_ ||
           (!pending_inputs.empty() && !input_buffer_indices.empty());
-      if (can_process_input) {
+      if (decoder_flow_control_->CanAcceptMore() && can_process_input) {
         ProcessOneInputBuffer(&pending_inputs, &input_buffer_indices);
       }
 
@@ -503,8 +535,15 @@ bool MediaDecoder::ProcessOneInputBuffer(
     memcpy(address, data, size);
   }
 
+  if (size > 0) {
+    decoder_flow_control_->AddFrame(input_buffer->timestamp());
+  } else {
+    SB_LOG(WARNING) << __func__ << " > size=" << size;
+  }
+
   jint status;
   if (drm_system_ && !drm_system_->IsReady()) {
+    SB_NOTREACHED();
     // Drm system initialization is asynchronous. If there's a drm system, we
     // should wait until it's initialized to avoid errors.
     status = MEDIA_CODEC_NO_KEY;
@@ -530,6 +569,7 @@ bool MediaDecoder::ProcessOneInputBuffer(
   }
 
   if (status != MEDIA_CODEC_OK) {
+    SB_LOG(FATAL) << "QueueInputBuffer returns status=" << status;
     HandleError("queue(Secure)?InputBuffer", status);
     // TODO: Stop the decoding loop and call error_cb_ on fatal error.
     SB_DCHECK(!pending_input_to_retry_);
@@ -630,6 +670,7 @@ void MediaDecoder::OnMediaCodecError(bool is_recoverable,
 }
 
 void MediaDecoder::OnMediaCodecInputBufferAvailable(int buffer_index) {
+  // SB_LOG(INFO) << __func__ << " > buffer_index=" << buffer_index;
   if (media_type_ == kSbMediaTypeVideo && first_call_on_handler_thread_) {
     // Set the thread priority of the Handler thread to dispatch the async
     // decoder callbacks to high.
@@ -656,6 +697,20 @@ void MediaDecoder::OnMediaCodecOutputBufferAvailable(
   // receive output buffer, discard this invalid output buffer.
   if (destroying_.load() || decoder_thread_ == 0) {
     return;
+  }
+
+  if (size > 0) {
+    if (!decoder_flow_control_->SetFrameDecoded(presentation_time_us)) {
+      SB_LOG(ERROR) << "SetFrameDecoded() called on empty frame tracker.";
+    }
+    {
+      std::lock_guard lock(frame_timestamps_mutex_);
+      frame_timestamps_[presentation_time_us] = {
+          .decoded_us = CurrentMonotonicTime(),
+      };
+    }
+  } else {
+    SB_LOG(INFO) << __func__ << " > size is 0, which may mean EOS";
   }
 
   DequeueOutputResult dequeue_output_result;
@@ -685,8 +740,56 @@ void MediaDecoder::OnMediaCodecOutputFormatChanged() {
   condition_variable_.Signal();
 }
 
-void MediaDecoder::OnMediaCodecFrameRendered(int64_t frame_timestamp) {
-  frame_rendered_cb_(frame_timestamp);
+void MediaDecoder::OnMediaCodecFrameRendered(int64_t frame_timestamp,
+                                             int64_t frame_rendered_us) {
+  int64_t gap_ms = -1;
+  if (last_frame_rendered_us_) {
+    gap_ms = (frame_rendered_us - *last_frame_rendered_us_) / 1'000;
+  }
+  last_frame_rendered_us_ = frame_rendered_us;
+
+  std::optional<int64_t> latency_ms;
+  std::optional<int64_t> decoded_gap_ms;
+  std::optional<int64_t> render_gap_ms;
+  std::optional<int64_t> render_scheduled_ms;
+  [&] {
+    std::lock_guard lock(frame_timestamps_mutex_);
+    auto it = frame_timestamps_.find(frame_timestamp);
+    if (it == frame_timestamps_.end()) {
+      SB_LOG(WARNING) << "Cannot find timestamps for pts="
+                      << (frame_timestamp / 1'000);
+      return;
+    }
+
+    const auto decoded_us = it->second.decoded_us;
+
+    latency_ms = (frame_rendered_us - decoded_us) / 1'000;
+    if (last_decoded_us_ != 0) {
+      decoded_gap_ms = (decoded_us - last_decoded_us_) / 1'000;
+    }
+    last_decoded_us_ = decoded_us;
+
+    if (auto render_scheduled_us = it->second.render_scheduled_us;
+        render_scheduled_us != 0) {
+      render_scheduled_ms = render_scheduled_us / 1'000;
+      render_gap_ms = (frame_rendered_us - render_scheduled_us) / 1'000;
+    }
+    frame_timestamps_.erase(it);
+  }();
+
+  auto ValOrNA = [](std::optional<int64_t> val) {
+    return val.has_value() ? std::to_string(*val) : "(n/a)";
+  };
+
+  SB_LOG(INFO) << "Frame rendered: pts(msec)=" << frame_timestamp / 1'000
+               << ", rendered gap(msec)=" << gap_ms
+               << ", decode_to_render(msec)=" << ValOrNA(latency_ms)
+               << ", render(sceduled - actual in msec)="
+               << ValOrNA(render_gap_ms)
+               << ", pts(msec)=" << (frame_timestamp / 1'000)
+               << ", render/scheduled(msec)=" << ValOrNA(render_scheduled_ms)
+               << ", render/actual(msec)=" << (frame_rendered_us / 1'000)
+               << ", decoded gap(msec)=" << ValOrNA(decoded_gap_ms);
 }
 
 void MediaDecoder::OnMediaCodecFirstTunnelFrameReady() {
@@ -750,6 +853,31 @@ bool MediaDecoder::Flush() {
   stream_ended_.store(false);
   destroying_.store(false);
   return true;
+}
+
+void MediaDecoder::ResetDecoderFlowControl() {
+  if (media_codec_bridge_ != nullptr) {
+    SB_LOG(INFO) << "DecoderFrameControl is already created";
+    return;
+  }
+
+  if (kForceLimiting) {
+    SB_LOG(INFO) << "kForceLimiting=" << (kForceLimiting ? "true" : "false");
+  }
+
+  FrameSize frame_size = media_codec_bridge_->GetOutputSize();
+  constexpr int kArea4k = 3840 * 2160;
+  decoder_flow_control_ =
+      kForceLimiting ||
+              frame_size.texture_size.width * frame_size.texture_size.height >
+                  kArea4k
+          ? DecoderFlowControl::CreateThrottling(kMaxFramesInDecoder,
+                                                 kFrameTrackerLogIntervalUs,
+                                                 [this]() {
+                                                   ScopedLock lock(mutex_);
+                                                   condition_variable_.Signal();
+                                                 })
+          : DecoderFlowControl::CreateNoOp();
 }
 
 }  // namespace starboard::android::shared

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -52,6 +52,8 @@ using VideoRenderAlgorithmBase =
 using std::placeholders::_1;
 using std::placeholders::_2;
 
+constexpr bool kSetReleaseTimeExplicitly = true;
+
 template <typename T>
 inline std::ostream& operator<<(std::ostream& stream,
                                 const std::optional<T>& maybe_value) {
@@ -189,7 +191,8 @@ void ParseMaxResolution(const std::string& max_video_capabilities,
 
 class VideoFrameImpl : public VideoFrame {
  public:
-  typedef std::function<void()> VideoFrameReleaseCallback;
+  typedef std::function<void(std::optional<int64_t> release_us)>
+      VideoFrameReleaseCallback;
 
   VideoFrameImpl(const DequeueOutputResult& dequeue_output_result,
                  MediaCodecBridge* media_codec_bridge,
@@ -210,7 +213,7 @@ class VideoFrameImpl : public VideoFrame {
       media_codec_bridge_->ReleaseOutputBuffer(dequeue_output_result_.index,
                                                false);
       if (!is_end_of_stream()) {
-        release_callback_();
+        release_callback_(std::nullopt);
       }
     }
   }
@@ -219,9 +222,19 @@ class VideoFrameImpl : public VideoFrame {
     SB_DCHECK(!released_);
     SB_DCHECK(!is_end_of_stream());
     released_ = true;
-    media_codec_bridge_->ReleaseOutputBufferAtTimestamp(
-        dequeue_output_result_.index, release_time_in_nanoseconds);
-    release_callback_();
+
+    if (kSetReleaseTimeExplicitly) {
+      media_codec_bridge_->ReleaseOutputBufferAtTimestamp(
+          dequeue_output_result_.index, release_time_in_nanoseconds);
+      release_callback_(release_time_in_nanoseconds / 1'000);
+      return;
+    }
+
+    media_codec_bridge_->ReleaseOutputBuffer(dequeue_output_result_.index,
+                                             true);
+    if (!is_end_of_stream()) {
+      release_callback_(std::nullopt);
+    }
   }
 
  private:
@@ -323,6 +336,10 @@ class VideoRenderAlgorithmTunneled : public VideoRenderAlgorithmBase {
 
 class VideoDecoder::Sink : public VideoDecoder::VideoRendererSink {
  public:
+  explicit Sink(VideoDecoder* video_decoder) : video_decoder_(*video_decoder) {
+    SB_CHECK(video_decoder != nullptr);
+  }
+
   bool Render() {
     SB_DCHECK(render_cb_);
 
@@ -348,8 +365,20 @@ class VideoDecoder::Sink : public VideoDecoder::VideoRendererSink {
     static_cast<VideoFrameImpl*>(frame.get())
         ->Draw(release_time_in_nanoseconds);
 
+    int64_t pts = frame->timestamp();
+    if (video_decoder_.media_decoder_ != nullptr) {
+      auto& media_decoder = *video_decoder_.media_decoder_;
+
+      media_decoder.SetRenderScheduledTime(pts,
+                                           release_time_in_nanoseconds / 1000);
+    } else {
+      SB_LOG(INFO) << "MediaDecoder is null";
+    }
+
     return kReleased;
   }
+
+  VideoDecoder& video_decoder_;
 
   RenderCB render_cb_;
   bool rendered_;
@@ -429,6 +458,8 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
                << ", max video capabilities \"" << max_video_capabilities_
                << "\", and tunnel mode audio session id "
                << tunnel_mode_audio_session_id_;
+  SB_LOG(INFO) << "kSetReleaseTimeExplicitly="
+               << (kSetReleaseTimeExplicitly ? "true" : "false");
 }
 
 VideoDecoder::~VideoDecoder() {
@@ -442,7 +473,7 @@ VideoDecoder::~VideoDecoder() {
 
 scoped_refptr<VideoDecoder::VideoRendererSink> VideoDecoder::GetSink() {
   if (sink_ == NULL) {
-    sink_ = new Sink;
+    sink_ = new Sink(this);
   }
   return sink_;
 }
@@ -928,7 +959,9 @@ void VideoDecoder::ProcessOutputBuffer(
   decoder_status_cb_(
       is_end_of_stream ? kBufferFull : kNeedMoreInput,
       new VideoFrameImpl(dequeue_output_result, media_codec_bridge,
-                         std::bind(&VideoDecoder::OnVideoFrameRelease, this)));
+                         [this](std::optional<int64_t> release_us) {
+                           OnVideoFrameRelease(release_us);
+                         }));
 }
 
 void VideoDecoder::RefreshOutputFormat(MediaCodecBridge* media_codec_bridge) {
@@ -1232,10 +1265,15 @@ void VideoDecoder::OnTunnelModeCheckForNeedMoreInput() {
            kNeedMoreInputCheckIntervalInTunnelMode);
 }
 
-void VideoDecoder::OnVideoFrameRelease() {
+void VideoDecoder::OnVideoFrameRelease(std::optional<int64_t> release_us) {
   if (output_format_) {
     --buffered_output_frames_;
     SB_DCHECK_GE(buffered_output_frames_, 0);
+  }
+  // TODO: check thread correctness.
+  if (media_decoder_ && media_decoder_->decoder_flow_control()) {
+    media_decoder_->decoder_flow_control()->ReleaseFrameAt(
+        release_us.value_or(CurrentMonotonicTime()));
   }
 }
 

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -124,7 +124,7 @@ class VideoDecoder
   void OnTunnelModePrerollTimeout();
   void OnTunnelModeCheckForNeedMoreInput();
 
-  void OnVideoFrameRelease();
+  void OnVideoFrameRelease(std::optional<int64_t> release_us);
 
   void OnSurfaceDestroyed() override;
   void ReportError(SbPlayerError error, const std::string& error_message);

--- a/starboard/shared/starboard/media/BUILD.gn
+++ b/starboard/shared/starboard/media/BUILD.gn
@@ -19,6 +19,8 @@ static_library("media_util") {
     "//starboard/shared/starboard/media/avc_util.h",
     "//starboard/shared/starboard/media/codec_util.cc",
     "//starboard/shared/starboard/media/codec_util.h",
+    "//starboard/shared/starboard/media/decoder_flow_control.cc",
+    "//starboard/shared/starboard/media/decoder_flow_control.h",
     "//starboard/shared/starboard/media/key_system_supportability_cache.cc",
     "//starboard/shared/starboard/media/key_system_supportability_cache.h",
     "//starboard/shared/starboard/media/media_support_internal.h",

--- a/starboard/shared/starboard/media/decoder_flow_control.cc
+++ b/starboard/shared/starboard/media/decoder_flow_control.cc
@@ -1,0 +1,269 @@
+// Copyright 2017 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/media/decoder_flow_control.h"
+
+#include <algorithm>
+#include <deque>
+#include <memory>
+#include <numeric>
+#include <ostream>
+
+#include "starboard/common/check_op.h"
+#include "starboard/common/log.h"
+#include "starboard/common/time.h"
+#include "starboard/shared/starboard/player/job_thread.h"
+
+namespace starboard::shared::starboard::media {
+namespace {
+
+constexpr int kMaxDecodingHistory = 30;
+constexpr int64_t kDecodingTimeWarningThresholdUs = 1'000'000;
+
+class ThrottlingDecoderFlowControl : public DecoderFlowControl {
+ public:
+  ThrottlingDecoderFlowControl(int max_frames,
+                               int64_t log_interval_us,
+                               StateChangedCB state_changed_cb);
+  ~ThrottlingDecoderFlowControl() override = default;
+
+  bool AddFrame(int64_t presentation_time_us) override;
+  bool SetFrameDecoded(int64_t presentation_time_us) override;
+  bool ReleaseFrameAt(int64_t release_us) override;
+
+  State GetCurrentState() const override;
+  bool CanAcceptMore() override;
+
+ private:
+  void UpdateDecodingStat_Locked();
+  void UpdateState_Locked();
+  void LogStateAndReschedule(int64_t log_interval_us);
+
+  const int max_frames_;
+  const StateChangedCB state_changed_cb_;
+
+  mutable std::mutex mutex_;
+  State state_;  // GUARDED_BY mutex_;
+
+  std::deque<int64_t> decoding_start_times_us_;
+  std::deque<int64_t> previous_decoding_times_us_;
+
+  ::starboard::shared::starboard::player::JobThread task_runner_;
+
+  int entering_frame_id_ = 0;
+  int decoded_frame_id_ = 0;
+};
+
+ThrottlingDecoderFlowControl::ThrottlingDecoderFlowControl(
+    int max_frames,
+    int64_t log_interval_us,
+    StateChangedCB state_changed_cb)
+    : max_frames_(max_frames),
+      state_changed_cb_(std::move(state_changed_cb)),
+      state_({}),
+      task_runner_("frame_tracker") {
+  SB_CHECK(state_changed_cb_);
+  if (log_interval_us > 0) {
+    task_runner_.Schedule(
+        [this, log_interval_us]() { LogStateAndReschedule(log_interval_us); },
+        log_interval_us);
+  }
+  SB_LOG(INFO) << "ThrottlingDecoderFlowControl is created: max_frames="
+               << max_frames_
+               << ", log_interval(msec)=" << (log_interval_us / 1'000);
+}
+
+bool ThrottlingDecoderFlowControl::AddFrame(int64_t presentation_time_us) {
+  std::lock_guard lock(mutex_);
+
+  if (state_.total_frames() >= max_frames_) {
+    SB_LOG(WARNING) << __func__ << " accepts no more frames: frames="
+                    << state_.total_frames() << "/" << max_frames_;
+    return false;
+  }
+  state_.decoding_frames++;
+  decoding_start_times_us_.push_back(CurrentMonotonicTime());
+
+  UpdateState_Locked();
+  entering_frame_id_++;
+  SB_LOG(INFO) << "AddFrame: id=" << entering_frame_id_
+               << ", pts(msec)=" << presentation_time_us / 1000
+               << ", decoding=" << state_.decoding_frames
+               << ", decoded=" << state_.decoded_frames;
+  return true;
+}
+
+bool ThrottlingDecoderFlowControl::SetFrameDecoded(
+    int64_t presentation_time_us) {
+  std::lock_guard lock(mutex_);
+
+  if (state_.decoding_frames == 0) {
+    SB_LOG(FATAL) << __func__ << " < no decoding frames"
+                  << ", pts(msec)=" << presentation_time_us / 1000;
+    return false;
+  }
+  state_.decoding_frames--;
+  state_.decoded_frames++;
+  SB_CHECK_GE(state_.decoded_frames, 0);
+
+  SB_CHECK(!decoding_start_times_us_.empty());
+
+  auto start_time = decoding_start_times_us_.front();
+  decoding_start_times_us_.pop_front();
+  auto decoding_time_us = CurrentMonotonicTime() - start_time;
+  decoded_frame_id_++;
+  SB_LOG(INFO) << "SetFrameDecoded: id=" << decoded_frame_id_
+               << ", pts(msec)=" << presentation_time_us / 1000
+               << ", decoding-elapsed time(msec)=" << (decoding_time_us / 1'000)
+               << ", decoding=" << state_.decoding_frames
+               << ", decoded=" << state_.decoded_frames;
+  if (decoding_time_us > kDecodingTimeWarningThresholdUs) {
+    SB_LOG(WARNING) << "Decoding time exceeded threshold: "
+                    << decoding_time_us / 1'000 << " msec";
+  }
+  previous_decoding_times_us_.push_back(decoding_time_us);
+  if (previous_decoding_times_us_.size() > kMaxDecodingHistory) {
+    previous_decoding_times_us_.pop_front();
+  }
+
+  UpdateState_Locked();
+  UpdateDecodingStat_Locked();
+  return true;
+}
+
+bool ThrottlingDecoderFlowControl::ReleaseFrameAt(int64_t release_us) {
+  std::lock_guard lock(mutex_);
+
+  if (state_.decoded_frames == 0) {
+    SB_LOG(FATAL) << __func__ << " < no decoded frames";
+    return false;
+  }
+
+  int64_t delay_us = std::max<int64_t>(release_us - CurrentMonotonicTime(), 0);
+  task_runner_.Schedule(
+      [this] {
+        state_changed_cb_();
+
+        std::lock_guard lock(mutex_);
+        state_.decoded_frames--;
+        UpdateState_Locked();
+      },
+      delay_us);
+
+  return true;
+}
+
+DecoderFlowControl::State ThrottlingDecoderFlowControl::GetCurrentState()
+    const {
+  std::lock_guard lock(mutex_);
+  return state_;
+}
+
+bool ThrottlingDecoderFlowControl::CanAcceptMore() {
+  std::lock_guard lock(mutex_);
+  if (state_.total_frames() < max_frames_) {
+    return true;
+  }
+
+  return false;
+}
+
+void ThrottlingDecoderFlowControl::UpdateDecodingStat_Locked() {
+  if (previous_decoding_times_us_.empty()) {
+    return;
+  }
+  int64_t min_decoding_time_us = previous_decoding_times_us_[0];
+  int64_t max_decoding_time_us = previous_decoding_times_us_[0];
+  int64_t sum = 0;
+  for (auto decoding_us : previous_decoding_times_us_) {
+    min_decoding_time_us = std::min(min_decoding_time_us, decoding_us);
+    max_decoding_time_us = std::max(max_decoding_time_us, decoding_us);
+    sum += decoding_us;
+  }
+
+  state_.min_decoding_time_us = min_decoding_time_us;
+  state_.max_decoding_time_us = max_decoding_time_us;
+  state_.avg_decoding_time_us = sum / previous_decoding_times_us_.size();
+}
+
+void ThrottlingDecoderFlowControl::UpdateState_Locked() {
+  // SB_CHECK_LE(state_.total_frames(), max_frames_);
+  SB_CHECK_GE(state_.decoding_frames, 0);
+  SB_CHECK_GE(state_.decoded_frames, 0);
+
+  state_.decoding_frames_high_water_mark =
+      std::max(state_.decoding_frames_high_water_mark, state_.decoding_frames);
+  state_.decoded_frames_high_water_mark =
+      std::max(state_.decoded_frames_high_water_mark, state_.decoded_frames);
+  state_.total_frames_high_water_mark =
+      std::max(state_.total_frames_high_water_mark,
+               state_.decoding_frames + state_.decoded_frames);
+}
+
+void ThrottlingDecoderFlowControl::LogStateAndReschedule(
+    int64_t log_interval_us) {
+  SB_DCHECK(task_runner_.BelongsToCurrentThread());
+
+  SB_LOG(INFO) << "DecoderFlowControl state: " << GetCurrentState();
+
+  task_runner_.Schedule(
+      [this, log_interval_us]() { LogStateAndReschedule(log_interval_us); },
+      log_interval_us);
+}
+
+class NoOpDecoderFlowControl : public DecoderFlowControl {
+ public:
+  NoOpDecoderFlowControl() {
+    SB_LOG(INFO) << "NoOpDecoderFlowControl is created.";
+  }
+  ~NoOpDecoderFlowControl() override = default;
+
+  bool AddFrame(int64_t presentation_time_us) override { return true; }
+  bool SetFrameDecoded(int64_t presentation_time_us) override { return true; }
+  bool ReleaseFrameAt(int64_t release_us) override { return true; }
+
+  State GetCurrentState() const override { return State(); }
+  bool CanAcceptMore() override { return true; }
+};
+
+}  // namespace
+
+// static
+std::unique_ptr<DecoderFlowControl> DecoderFlowControl::CreateNoOp() {
+  return std::make_unique<NoOpDecoderFlowControl>();
+}
+
+// static
+std::unique_ptr<DecoderFlowControl> DecoderFlowControl::CreateThrottling(
+    int max_frames,
+    int64_t log_interval_us,
+    StateChangedCB state_changed_cb) {
+  return std::make_unique<ThrottlingDecoderFlowControl>(
+      max_frames, log_interval_us, std::move(state_changed_cb));
+}
+
+std::ostream& operator<<(std::ostream& os,
+                         const DecoderFlowControl::State& status) {
+  os << "{decoding: " << status.decoding_frames
+     << ", decoded: " << status.decoded_frames
+     << ", decoding (hw): " << status.decoding_frames_high_water_mark
+     << ", decoded (hw): " << status.decoded_frames_high_water_mark
+     << ", total (hw): " << status.total_frames_high_water_mark
+     << ", min decoding(msec): " << status.min_decoding_time_us / 1'000
+     << ", max decoding(msec): " << status.max_decoding_time_us / 1'000
+     << ", avg decoding(msec): " << status.avg_decoding_time_us / 1'000 << "}";
+  return os;
+}
+
+}  // namespace starboard::shared::starboard::media

--- a/starboard/shared/starboard/media/decoder_flow_control.h
+++ b/starboard/shared/starboard/media/decoder_flow_control.h
@@ -1,0 +1,48 @@
+#ifndef STARBOARD_SHARED_STARBOARD_MEDIA_DECODER_FLOW_CONTROL_H_
+#define STARBOARD_SHARED_STARBOARD_MEDIA_DECODER_FLOW_CONTROL_H_
+
+#include <functional>
+#include <iosfwd>
+#include <memory>
+
+namespace starboard::shared::starboard::media {
+
+class DecoderFlowControl {
+ public:
+  using StateChangedCB = std::function<void()>;
+
+  struct State {
+    int decoding_frames = 0;
+    int decoded_frames = 0;
+    int decoding_frames_high_water_mark = 0;
+    int decoded_frames_high_water_mark = 0;
+    int total_frames_high_water_mark = 0;
+    int64_t min_decoding_time_us = 0;
+    int64_t max_decoding_time_us = 0;
+    int64_t avg_decoding_time_us = 0;
+
+    int total_frames() const { return decoding_frames + decoded_frames; }
+  };
+
+  static std::unique_ptr<DecoderFlowControl> CreateNoOp();
+  static std::unique_ptr<DecoderFlowControl> CreateThrottling(
+      int max_frames,
+      int64_t log_interval_us,
+      StateChangedCB state_changed_cb);
+
+  virtual ~DecoderFlowControl() = default;
+
+  virtual bool AddFrame(int64_t presentation_time_us) = 0;
+  virtual bool SetFrameDecoded(int64_t presentation_time_us) = 0;
+  virtual bool ReleaseFrameAt(int64_t release_us) = 0;
+
+  virtual State GetCurrentState() const = 0;
+  virtual bool CanAcceptMore() = 0;
+};
+
+std::ostream& operator<<(std::ostream& os,
+                         const DecoderFlowControl::State& status);
+
+}  // namespace starboard::shared::starboard::media
+
+#endif  // STARBOARD_SHARED_STARBOARD_MEDIA_DECODER_FLOW_CONTROL_H_

--- a/starboard/shared/starboard/media/decoder_flow_control_test.cc
+++ b/starboard/shared/starboard/media/decoder_flow_control_test.cc
@@ -1,0 +1,201 @@
+#include "starboard/shared/starboard/media/decoder_flow_control.h"
+
+#include <sstream>
+
+#include "starboard/common/time.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard::shared::starboard::media {
+namespace {
+
+constexpr int kMaxFrames = 2;
+
+TEST(ThrottlingDecoderFlowControlTest, InitialState) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 0, [] {});
+
+  DecoderFlowControl::State status = decoder_flow_control->GetCurrentState();
+
+  EXPECT_EQ(status.decoding_frames, 0);
+  EXPECT_EQ(status.decoded_frames, 0);
+  EXPECT_EQ(status.decoding_frames_high_water_mark, 0);
+  EXPECT_EQ(status.decoded_frames_high_water_mark, 0);
+  EXPECT_EQ(status.total_frames_high_water_mark, 0);
+}
+
+TEST(ThrottlingDecoderFlowControlTest, AddFrame) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 0, [] {});
+
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  DecoderFlowControl::State status = decoder_flow_control->GetCurrentState();
+
+  EXPECT_EQ(status.decoding_frames, 1);
+  EXPECT_EQ(status.decoded_frames, 0);
+  EXPECT_EQ(status.decoding_frames_high_water_mark, 1);
+  EXPECT_EQ(status.decoded_frames_high_water_mark, 0);
+  EXPECT_EQ(status.total_frames_high_water_mark, 1);
+}
+
+TEST(ThrottlingDecoderFlowControlTest, AddFrameReturnsFalseWhenFull) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 0, [] {});
+  for (int i = 0; i < kMaxFrames; ++i) {
+    ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  }
+
+  EXPECT_FALSE(decoder_flow_control->CanAcceptMore());
+}
+
+TEST(ThrottlingDecoderFlowControlTest, SetFrameDecoded) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 0, [] {});
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+  DecoderFlowControl::State status = decoder_flow_control->GetCurrentState();
+
+  EXPECT_EQ(status.decoding_frames, 0);
+  EXPECT_EQ(status.decoded_frames, 1);
+  EXPECT_EQ(status.decoding_frames_high_water_mark, 1);
+  EXPECT_EQ(status.decoded_frames_high_water_mark, 1);
+  EXPECT_EQ(status.total_frames_high_water_mark, 1);
+}
+
+TEST(ThrottlingDecoderFlowControlTest, SetFrameDecodedReturnsFalseWhenEmpty) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 0, [] {});
+
+  EXPECT_FALSE(decoder_flow_control->SetFrameDecoded(0));
+}
+
+TEST(ThrottlingDecoderFlowControlTest, HighWaterMark) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 0, [] {});
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+  ASSERT_TRUE(decoder_flow_control->ReleaseFrameAt(CurrentMonotonicTime()));
+
+  usleep(10'000);
+  DecoderFlowControl::State status = decoder_flow_control->GetCurrentState();
+
+  EXPECT_EQ(status.decoding_frames, 0);
+  EXPECT_EQ(status.decoded_frames, 1);
+  EXPECT_EQ(status.decoding_frames_high_water_mark, 2);
+  EXPECT_EQ(status.decoded_frames_high_water_mark, 2);
+  EXPECT_EQ(status.total_frames_high_water_mark, 2);
+}
+
+TEST(ThrottlingDecoderFlowControlTest, StreamInsertionOperator) {
+  DecoderFlowControl::State status;
+  status.decoding_frames = 1;
+  status.decoded_frames = 2;
+  status.decoding_frames_high_water_mark = 3;
+  status.decoded_frames_high_water_mark = 4;
+  status.total_frames_high_water_mark = 5;
+  status.min_decoding_time_us = 10'000;
+  status.max_decoding_time_us = 20'000;
+  status.avg_decoding_time_us = 15'000;
+
+  std::stringstream ss;
+  ss << status;
+
+  EXPECT_EQ(ss.str(),
+            "{decoding: 1, decoded: 2, decoding (hw): 3, decoded (hw): 4, "
+            "total (hw): 5, min decoding(msec): 10, max decoding(msec): 20, "
+            "avg decoding(msec): 15}");
+}
+
+TEST(ThrottlingDecoderFlowControlTest, ReleaseFrameAt) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 0, [] {});
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+
+  ASSERT_FALSE(decoder_flow_control->CanAcceptMore());
+
+  decoder_flow_control->ReleaseFrameAt(CurrentMonotonicTime() + 100'000);
+  decoder_flow_control->ReleaseFrameAt(CurrentMonotonicTime() + 200'000);
+
+  usleep(150'000);
+  DecoderFlowControl::State status = decoder_flow_control->GetCurrentState();
+  EXPECT_EQ(status.decoded_frames, 1);
+  EXPECT_TRUE(decoder_flow_control->CanAcceptMore());
+
+  usleep(100'000);
+  status = decoder_flow_control->GetCurrentState();
+  EXPECT_EQ(status.decoded_frames, 0);
+  EXPECT_TRUE(decoder_flow_control->CanAcceptMore());
+}
+
+TEST(ThrottlingDecoderFlowControlTest, LongIntervalNotBlockDestruction) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 1'000'000'000, [] {});
+}
+
+TEST(ThrottlingDecoderFlowControlTest, DecodingTimeStats) {
+  auto decoder_flow_control =
+      DecoderFlowControl::CreateThrottling(kMaxFrames, 0, [] {});
+
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  usleep(10'000);
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  usleep(20'000);
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+
+  DecoderFlowControl::State status = decoder_flow_control->GetCurrentState();
+  EXPECT_GE(status.min_decoding_time_us, 10'000);
+  EXPECT_LE(status.min_decoding_time_us, 15'000);
+  EXPECT_GE(status.max_decoding_time_us, 20'000);
+  EXPECT_LE(status.max_decoding_time_us, 25'000);
+  EXPECT_GE(status.avg_decoding_time_us, 15'000);
+  EXPECT_LE(status.avg_decoding_time_us, 20'000);
+}
+
+TEST(ThrottlingDecoderFlowControlTest, FrameReleasedCallback) {
+  int counter = 0;
+  auto decoder_flow_control = DecoderFlowControl::CreateThrottling(
+      kMaxFrames, 0, [&counter]() { counter++; });
+
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  ASSERT_TRUE(decoder_flow_control->AddFrame(0));
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+  ASSERT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+  decoder_flow_control->ReleaseFrameAt(CurrentMonotonicTime() + 100'000);
+  decoder_flow_control->ReleaseFrameAt(CurrentMonotonicTime() + 200'000);
+
+  usleep(50'000);  // at 50 msec
+  ASSERT_EQ(counter, 0);
+
+  usleep(100'000);  // at 150 msec
+  EXPECT_EQ(counter, 1);
+
+  usleep(100'000);  // at 250 msec
+  EXPECT_EQ(counter, 2);
+}
+
+TEST(NoOpDecoderFlowControlTest, AllMethodsNoOp) {
+  auto decoder_flow_control = DecoderFlowControl::CreateNoOp();
+  EXPECT_TRUE(decoder_flow_control->AddFrame(0));
+  EXPECT_TRUE(decoder_flow_control->SetFrameDecoded(0));
+  EXPECT_TRUE(decoder_flow_control->ReleaseFrameAt(0));
+  EXPECT_TRUE(decoder_flow_control->CanAcceptMore());
+  auto status = decoder_flow_control->GetCurrentState();
+  EXPECT_EQ(status.decoding_frames, 0);
+  EXPECT_EQ(status.decoded_frames, 0);
+  EXPECT_EQ(status.decoding_frames_high_water_mark, 0);
+  EXPECT_EQ(status.decoded_frames_high_water_mark, 0);
+  EXPECT_EQ(status.total_frames_high_water_mark, 0);
+  EXPECT_EQ(status.min_decoding_time_us, 0);
+  EXPECT_EQ(status.max_decoding_time_us, 0);
+  EXPECT_EQ(status.avg_decoding_time_us, 0);
+}
+
+}  // namespace
+}  // namespace starboard::shared::starboard::media

--- a/starboard/shared/starboard/media/media_tests.gni
+++ b/starboard/shared/starboard/media/media_tests.gni
@@ -15,6 +15,7 @@
 media_tests_sources = [
   "//starboard/shared/starboard/media/avc_util_test.cc",
   "//starboard/shared/starboard/media/codec_util_test.cc",
+  "//starboard/shared/starboard/media/decoder_flow_control_test.cc",
   "//starboard/shared/starboard/media/media_util_test.cc",
   "//starboard/shared/starboard/media/mime_type_test.cc",
   "//starboard/shared/starboard/media/mime_util_test.cc",


### PR DESCRIPTION
This commit introduces a number of significant changes to the media decoding and memory management systems.

The `FrameTracker` has been refactored into a more comprehensive `DecoderFlowControl` system. This new system is designed to provide more granular control over the frame decoding pipeline, with the ability to select different flow control strategies based on video resolution.

Memory management has been improved with the addition of memory usage logging to the `DecoderBufferAllocator`. This provides greater visibility into memory consumption during playback. The encoded frames memory is also limited to 200MB.

Finally, explicit frame release timing has been introduced to better synchronize frame rendering with the display's vsync cycle, which should result in smoother playback.