### PR TITLE
cleanup: Remove out-of-date comments in StarboardRenderer

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -390,9 +390,8 @@ void StarboardRenderer::SetVolume(float volume) {
   }
 }
 
-// Note: Renderer::GetMediaTime() could be called on both main and media
-// threads.
 TimeDelta StarboardRenderer::GetMediaTime() {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
   base::AutoLock auto_lock(lock_);
 
   if (!player_bridge_) {


### PR DESCRIPTION
As we moved StarboardRenderer as a MojoRenderer, `StarboardRenderer::GetMediaTime()` is called from `MojoRendererService` and it's on a thread from Gpu thread pool.

Remove out-of-date comments and add DCHECK for `StarboardRenderer::GetMediaTime()`.

Issue: 376328722
Issue: 435225475