### PR TITLE
posix: Implement access in Starboard API

### DIFF
--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -306,6 +306,7 @@ ExportedSymbols::ExportedSymbols() {
   // TODO: b/316603042 - Detect via NPLB and only add the wrapper if needed.
 
   REGISTER_WRAPPER(accept);
+  REGISTER_WRAPPER(access);
   REGISTER_WRAPPER(bind);
   REGISTER_WRAPPER(clock_gettime);
   REGISTER_WRAPPER(closedir);

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -240,6 +240,7 @@ test("nplb") {
       "posix_compliance/posix_timezone_test_iana_format.cc",
       "posix_compliance/posix_timezone_test_posix_format.cc",
       "posix_compliance/posix_uname_test.cc",
+      "posix_compliance/posix_unistd_access_test.cc",
       "posix_compliance/posix_unistd_gethostname_test.cc",
       "posix_compliance/posix_unistd_sysconf_test.cc",
       "posix_compliance/posix_usleep_test.cc",

--- a/starboard/nplb/posix_compliance/posix_unistd_access_test.cc
+++ b/starboard/nplb/posix_compliance/posix_unistd_access_test.cc
@@ -1,0 +1,109 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <string>
+
+#include "starboard/common/log.h"
+#include "starboard/configuration_constants.h"
+#include "starboard/system.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace nplb {
+namespace {
+
+class PosixAccessTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    char cache_path[kSbFileMaxPath];
+    ASSERT_TRUE(SbSystemGetPath(kSbSystemPathCacheDirectory, cache_path,
+                                kSbFileMaxPath));
+    test_dir_ = std::string(cache_path) + kSbFileSepString + "access_test";
+    mkdir(test_dir_.c_str(), 0777);
+
+    file_path_ = test_dir_ + kSbFileSepString + "test_file.txt";
+    FILE* fp = fopen(file_path_.c_str(), "w");
+    ASSERT_NE(fp, nullptr);
+    fprintf(fp, "test");
+    fclose(fp);
+
+    readonly_file_path_ = test_dir_ + kSbFileSepString + "readonly.txt";
+    fp = fopen(readonly_file_path_.c_str(), "w");
+    ASSERT_NE(fp, nullptr);
+    fprintf(fp, "test");
+    fclose(fp);
+    chmod(readonly_file_path_.c_str(), S_IRUSR | S_IRGRP | S_IROTH);
+  }
+
+  void TearDown() override {
+    remove(file_path_.c_str());
+    remove(readonly_file_path_.c_str());
+    rmdir(test_dir_.c_str());
+  }
+
+  std::string test_dir_;
+  std::string file_path_;
+  std::string readonly_file_path_;
+};
+
+TEST_F(PosixAccessTest, SunnyDayFileExists) {
+  EXPECT_EQ(access(file_path_.c_str(), F_OK), 0);
+}
+
+TEST_F(PosixAccessTest, SunnyDayFileRead) {
+  EXPECT_EQ(access(file_path_.c_str(), R_OK), 0);
+}
+
+TEST_F(PosixAccessTest, SunnyDayFileWrite) {
+  EXPECT_EQ(access(file_path_.c_str(), W_OK), 0);
+}
+
+TEST_F(PosixAccessTest, SunnyDayFileReadWrite) {
+  EXPECT_EQ(access(file_path_.c_str(), R_OK | W_OK), 0);
+}
+
+TEST_F(PosixAccessTest, RainyDayFileDoesNotExist) {
+  std::string non_existent_file = test_dir_ + kSbFileSepString + "non_existent";
+  errno = 0;
+  EXPECT_EQ(access(non_existent_file.c_str(), F_OK), -1);
+  EXPECT_EQ(errno, ENOENT);
+}
+
+TEST_F(PosixAccessTest, RainyDayFileNoWrite) {
+  if (geteuid() == 0) {
+    GTEST_SKIP() << "Test is not meaningful when run as root.";
+  }
+  errno = 0;
+  EXPECT_EQ(access(readonly_file_path_.c_str(), W_OK), -1);
+  EXPECT_EQ(errno, EACCES);
+}
+
+TEST_F(PosixAccessTest, RainyDayFileNoExecute) {
+  errno = 0;
+  EXPECT_EQ(access(file_path_.c_str(), X_OK), -1);
+  EXPECT_EQ(errno, EACCES);
+}
+
+TEST_F(PosixAccessTest, SunnyDayDirectoryExists) {
+  EXPECT_EQ(access(test_dir_.c_str(), F_OK), 0);
+}
+
+}  // namespace
+}  // namespace nplb
+}  // namespace starboard

--- a/starboard/shared/modular/cobalt_layer_posix_unistd_abi_wrappers.cc
+++ b/starboard/shared/modular/cobalt_layer_posix_unistd_abi_wrappers.cc
@@ -52,4 +52,10 @@ uid_t geteuid() {
   return __abi_wrap_geteuid();
 }
 
+int __abi_wrap_access(const char* path, int amode);
+
+int access(const char* path, int amode) {
+  return __abi_wrap_access(path, amode);
+}
+
 }  // extern "C"

--- a/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.cc
@@ -111,6 +111,23 @@ int musl_conf_to_platform_conf(int name) {
       return -1;
   }
 }
+
+int access_helper(int musl_amode) {
+  int platform_amode = 0;
+  if (musl_amode == MUSL_F_OK) {
+    return F_OK;
+  }
+  if (musl_amode & MUSL_R_OK) {
+    platform_amode |= R_OK;
+  }
+  if (musl_amode & MUSL_W_OK) {
+    platform_amode |= W_OK;
+  }
+  if (musl_amode & MUSL_X_OK) {
+    platform_amode |= X_OK;
+  }
+  return platform_amode;
+}
 }  // namespace
 
 int __abi_wrap_ftruncate(int fildes, musl_off_t length) {
@@ -658,4 +675,8 @@ musl_uid_t __abi_wrap_geteuid() {
 
 musl_pid_t __abi_wrap_getpid() {
   return static_cast<musl_pid_t>(getpid());
+}
+
+int __abi_wrap_access(const char* path, int amode) {
+  return access(path, access_helper(amode));
 }

--- a/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.h
@@ -206,6 +206,11 @@ extern "C" {
 #define MUSL_PC_SYMLINK_MAX 19
 #define MUSL_PC_2_SYMLINKS 20
 
+#define MUSL_F_OK 0
+#define MUSL_R_OK 4
+#define MUSL_W_OK 2
+#define MUSL_X_OK 1
+
 SB_EXPORT int __abi_wrap_ftruncate(int fildes, musl_off_t length);
 
 SB_EXPORT musl_off_t __abi_wrap_lseek(int fildes,
@@ -223,6 +228,8 @@ SB_EXPORT long __abi_wrap_pathconf(const char* path, int name);
 SB_EXPORT musl_uid_t __abi_wrap_geteuid();
 
 SB_EXPORT musl_pid_t __abi_wrap_getpid();
+
+SB_EXPORT int __abi_wrap_access(const char* path, int amode);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -91,6 +91,7 @@ _UNKNOWN_SOURCE_FILES = 'unknown_source_file(s)'
 _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
     '__errno_location',
     'accept',
+    'access',
     'aligned_alloc',
     'bind',
     'calloc',

--- a/starboard/tools/api_leak_detector/evergreen/manifest
+++ b/starboard/tools/api_leak_detector/evergreen/manifest
@@ -6,7 +6,6 @@ OPENSSL_memory_alloc
 OPENSSL_memory_free
 OPENSSL_memory_get_size
 __nl_langinfo_l
-access
 chmod
 closelog
 dladdr


### PR DESCRIPTION
This PR implements the `access` function as a direct Starboard wrapper around the native platform API, as its structure is ABI-compatible across target platforms.

The unit tests were generated with assistance from `gemini-cli` and refined for correctness.

Issue: 432312684