### PR TITLE
Fix broken workflow diff_chromium_branches.

### DIFF
--- a/.github/workflows/diff_chromium_branches.yaml
+++ b/.github/workflows/diff_chromium_branches.yaml
@@ -15,7 +15,6 @@ on:
   pull_request:
     types:
       - labeled
-      - synchronize
 jobs:
   initialize:
     runs-on: ubuntu-latest
@@ -55,7 +54,7 @@ jobs:
           set -eux
           if [[ -n "${{ inputs.downstream_branch }}" ]]; then
             # Get the trimmed downstream branch directly from inputs
-            DOWNSTREAM_BRANCH=${{ trim(inputs.downstream_branch, ' ') }}
+            DOWNSTREAM_BRANCH=${{ inputs.downstream_branch }}
           else
             # Get the downstream branch from the labelled PR
             DOWNSTREAM_BRANCH="${{ github.ref }}"


### PR DESCRIPTION
Removed the reference to the nonexisting Github actions function 'trim' and stopped triggering on sync.

Bug: 432508006
Change-Id: I5d6b94d47c3258e6f50b4ffefdcbd2f46f12e7ee