### PR TITLE
Guard main func by IS_COBALT_HERMETIC_BUILD

### DIFF
--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -173,6 +173,8 @@ void SbEventHandle(const SbEvent* event) {
   }
 }
 
+#if !BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
 int main(int argc, char** argv) {
   return SbRunStarboardMain(argc, argv, SbEventHandle);
 }
+#endif


### PR DESCRIPTION
For hermetic builds, the main func is defined in the starboard layer.

Issue: 435517623