### PR TITLE
Fix: Align non-public, non-static field names to Chromium style

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java
@@ -23,7 +23,7 @@ final class VolumeStateReceiver extends BroadcastReceiver {
   public static final String STREAM_MUTE_CHANGED_ACTION =
       "android.media.STREAM_MUTE_CHANGED_ACTION";
 
-  private WebContents webContents;
+  private WebContents mWebContents;
 
   VolumeStateReceiver(Context appContext) {
     IntentFilter filter = new IntentFilter();
@@ -34,10 +34,10 @@ final class VolumeStateReceiver extends BroadcastReceiver {
 
   protected void dispatchKeyDownEvent(int keyCode) {
     long eventTime = SystemClock.uptimeMillis();
-    if (webContents == null) {
+    if (mWebContents == null) {
       return;
     }
-    ImeAdapterImpl imeAdapter = ImeAdapterImpl.fromWebContents(webContents);
+    ImeAdapterImpl imeAdapter = ImeAdapterImpl.fromWebContents(mWebContents);
     if (imeAdapter == null) {
       return;
     }
@@ -45,7 +45,7 @@ final class VolumeStateReceiver extends BroadcastReceiver {
   }
 
   public void setWebContents(WebContents webContents) {
-    this.webContents = webContents;
+    this.mWebContents = webContents;
   }
 
   @Override


### PR DESCRIPTION
This is a fix for chromium pre-commit checks to match the same pre-commit checks Chromium would have run in an effort to better align our code to Chromium's. You are being asked to review because you were the last person to touch this file(s). If you think there's someone better to review please add them. Please the review the changes and if they look good please approve the PR.

Precommit error message:

cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java:26:23: Non-public, non-static field names start with m.

Bug: 435503470