### PR TITLE
Fix: Align field names to Chromium style

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java
@@ -33,15 +33,15 @@ import java.util.Set;
  */
 public class VideoSurfaceView extends SurfaceView {
 
-  private static Surface currentSurface = null;
+  private static Surface sCurrentSurface = null;
 
-  private static final Set<String> needResetSurfaceList = new HashSet<>();
+  private static final Set<String> sNeedResetSurfaceList = new HashSet<>();
 
   static {
-    needResetSurfaceList.add("Nexus Player");
+    sNeedResetSurfaceList.add("Nexus Player");
 
     // Reset video surface on nexus player to avoid b/159073388.
-    if (needResetSurfaceList.contains(Build.MODEL)) {
+    if (sNeedResetSurfaceList.contains(Build.MODEL)) {
       // nativeSetNeedResetSurface();
     }
   }
@@ -81,31 +81,31 @@ public class VideoSurfaceView extends SurfaceView {
 
   private class SurfaceHolderCallback implements SurfaceHolder.Callback {
 
-    boolean sawInitialChange = false;
+    boolean mSawInitialChange = false;
 
     @Override
     public void surfaceCreated(SurfaceHolder holder) {
-      currentSurface = holder.getSurface();
-      nativeOnVideoSurfaceChanged(currentSurface);
+      sCurrentSurface = holder.getSurface();
+      nativeOnVideoSurfaceChanged(sCurrentSurface);
     }
 
     @Override
     public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {
       // We should only ever see the initial change after creation.
-      if (sawInitialChange) {
+      if (mSawInitialChange) {
         Log.e(TAG, "Video surface changed; decoding may break");
       }
-      sawInitialChange = true;
+      mSawInitialChange = true;
     }
 
     @Override
     public void surfaceDestroyed(SurfaceHolder holder) {
-      currentSurface = null;
-      nativeOnVideoSurfaceChanged(currentSurface);
+      sCurrentSurface = null;
+      nativeOnVideoSurfaceChanged(sCurrentSurface);
     }
   }
 
   public static Surface getCurrentSurface() {
-    return currentSurface;
+    return sCurrentSurface;
   }
 }


### PR DESCRIPTION
This is a fix for chromium pre-commit checks to match the same pre-commit checks Chromium would have run in an effort to better align our code to Chromium's. You are being asked to review because you were the last person to touch this file(s). If you think there's someone better to review please add them. Please the review the changes and if they look good please approve the PR.

Precommit error message:

cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java:36:26: Static field names start with s.
cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java:38:36: Static final field names must either be all caps (e.g. int HEIGHT_PX) for true constants, or start with s (e.g. AtomicInteger sNextId or Runnable sSuspendTask) for fields with mutable state or that dont feel like constants.
cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java:84:13: Non-public, non-static field names start with m.

Bug: 435503470