### PR TITLE
cobalt/test: Remove JSON filter for UserAgentStringTest

### DIFF
--- a/cobalt/testing/filters/android-arm/cobalt_unittests_filter.json
+++ b/cobalt/testing/filters/android-arm/cobalt_unittests_filter.json
@@ -1,5 +1,3 @@
 {
-  "failing_tests": [
-    "UserAgentStringTest.*"
-  ]
+  "failing_tests": []
 }

--- a/cobalt/testing/filters/android-arm64/cobalt_unittests_filter.json
+++ b/cobalt/testing/filters/android-arm64/cobalt_unittests_filter.json
@@ -1,5 +1,3 @@
 {
-  "failing_tests": [
-    "UserAgentStringTest.*"
-  ]
+  "failing_tests": []
 }


### PR DESCRIPTION
gtests were disabled in https://github.com/youtube/cobalt/pull/6698. This removes the redundant JSON filter for the affected tests.

Fixed: 436368441