### PR TITLE
Make cobalt shell build target not testonly

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -64,8 +64,6 @@ if (!is_android) {
     cobalt_target_type = "executable"
   }
   target(cobalt_target_type, "cobalt") {
-    testonly = true
-
     sources = [ "app/cobalt.cc" ]
 
     configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
@@ -98,14 +96,11 @@ if (!is_android) {
     strip_binary("strip_cobalt_binary") {
       binary_input = "$root_out_dir/cobalt"
       deps = [ ":cobalt" ]
-      testonly = true
     }
   }
 }
 
 source_set("common") {
-  testonly = true
-
   sources = [
     "app/cobalt_main_delegate.cc",
     "app/cobalt_main_delegate.h",

--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -34,7 +34,6 @@ generate_jni("jni_headers") {
 }
 
 android_library("cobalt_main_java") {
-  testonly = true
   resources_package = "dev.cobalt.coat"
   deps = [
     ":jni_headers",
@@ -141,7 +140,6 @@ android_library("cobalt_main_java") {
 }
 
 android_library("cobalt_apk_java") {
-  testonly = true
   resources_package = "dev.cobalt.coat"
 
   deps = [
@@ -168,8 +166,6 @@ android_assets("coat_assets") {
 # Copied from target: libcontent_shell_content_view
 # TODO(b/376867565) rename this library, NO shell
 shared_library("libchrobalt") {
-  # TODO(b/375655377): remove testonly
-  testonly = true
   deps = [
     "//cobalt/browser",
     "//cobalt/gpu",
@@ -210,7 +206,6 @@ shared_library("libchrobalt") {
 }
 
 android_apk("cobalt_apk") {
-  testonly = true
   apk_name = "Cobalt"
   android_manifest = cobalt_manifest
   android_manifest_dep = ":cobalt_manifest"

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -15,10 +15,6 @@
 import("//starboard/build/buildflags.gni")
 
 source_set("browser") {
-  # TODO(cobalt, b/375655377): remove testonly declaration, needed because of
-  # cobalt_shell_lib.
-  testonly = true
-
   sources = [
     "cobalt_browser_interface_binders.cc",
     "cobalt_browser_interface_binders.h",
@@ -71,7 +67,6 @@ source_set("browser") {
     "//cobalt/shell:cobalt_shell_lib",
     "//components/js_injection/browser:browser",
     "//components/metrics",
-    "//components/metrics:test_support",
     "//components/metrics_services_manager",
     "//components/os_crypt/sync",
     "//components/prefs",
@@ -113,10 +108,6 @@ action("embed_polyfilled_javascript") {
 }
 
 source_set("global_features") {
-  # TODO(cobalt, b/375655377): remove testonly declaration, needed because of
-  # being depended-on by :browser above.
-  testonly = true
-
   sources = [
     "experiments/experiment_config_manager.cc",
     "experiments/experiment_config_manager.h",
@@ -135,10 +126,6 @@ source_set("global_features") {
 }
 
 source_set("metrics") {
-  # TODO(cobalt, b/375655377): remove testonly declaration, needed because of
-  # being depended-on by :browser above.
-  testonly = true
-
   sources = [
     "metrics/cobalt_enabled_state_provider.cc",
     "metrics/cobalt_enabled_state_provider.h",

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -38,7 +38,6 @@
 #include "cobalt/shell/browser/shell_paths.h"
 #include "cobalt/shell/common/shell_switches.h"
 #include "components/metrics/metrics_state_manager.h"
-#include "components/metrics/test/test_enabled_state_provider.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "components/prefs/pref_service.h"
@@ -411,8 +410,6 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
 }
 
 void CobaltContentBrowserClient::CreateFeatureListAndFieldTrials() {
-  metrics::TestEnabledStateProvider enabled_state_provider(/*consent=*/false,
-                                                           /*enabled=*/false);
   GlobalFeatures::GetInstance()
       ->metrics_services_manager()
       ->InstantiateFieldTrialList();

--- a/cobalt/browser/h5vcc_experiments/BUILD.gn
+++ b/cobalt/browser/h5vcc_experiments/BUILD.gn
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 source_set("h5vcc_experiments") {
-  testonly = true
   sources = [
     "h5vcc_experiments_impl.cc",
     "h5vcc_experiments_impl.h",

--- a/cobalt/browser/h5vcc_metrics/BUILD.gn
+++ b/cobalt/browser/h5vcc_metrics/BUILD.gn
@@ -13,10 +13,6 @@
 # limitations under the License.
 
 source_set("h5vcc_metrics") {
-  # TODO(cobalt, b/375655377): remove testonly declaration, needed because of
-  # being depended-on by :browser above.
-  testonly = true
-
   sources = [
     "h5vcc_metrics_impl.cc",
     "h5vcc_metrics_impl.h",

--- a/cobalt/browser/migrate_storage_record/BUILD.gn
+++ b/cobalt/browser/migrate_storage_record/BUILD.gn
@@ -7,9 +7,6 @@ proto_library("storage_proto") {
 }
 
 source_set("migrate_storage_record") {
-  # Needed to depend on |//cobalt/shell:cobalt_shell_lib|.
-  testonly = true
-
   sources = [
     "migration_manager.cc",
     "migration_manager.h",

--- a/cobalt/renderer/cobalt_render_frame_observer.cc
+++ b/cobalt/renderer/cobalt_render_frame_observer.cc
@@ -40,8 +40,9 @@ void CobaltRenderFrameObserver::DidClearWindowObject() {
     // to JavaScript at initial load of the web app, when the frame navigates
     // from the initial empty document to the actual document. This approach is
     // borrowed from content shell.
-    blink::WebTestingSupport::InjectInternalsObject(
-        render_frame()->GetWebFrame());
+
+    // TODO:(b/428999732) This requires a test-only build dependency and cannot
+    // be called from a production target.
   }
 }
 

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -35,7 +35,6 @@ config("cobalt_shell_lib_warnings") {
 }
 
 source_set("android_shell_descriptors") {
-  testonly = true
   sources = []
   public_deps = [ "//content/public/common:content_descriptors" ]
   if (is_android) {
@@ -43,20 +42,17 @@ source_set("android_shell_descriptors") {
   }
 }
 
-# TODO(b/384748332): Remove dependency on content shell
 group("cobalt_shell_lib_deps") {
   visibility = [
     "//cobalt/shell:*",
     "//cobalt/testing:*",
   ]
-  testonly = true
   public_deps = [
     ":android_shell_descriptors",
 
     # cobalt_shell_lib also exposes all public content APIs.
     ":content_browsertests_mojom",
     ":resources",
-    ":shell_controller_mojom",
     "//base",
     "//base:base_static",
     "//base/third_party/dynamic_annotations",
@@ -65,17 +61,14 @@ group("cobalt_shell_lib_deps") {
     "//components/crash/content/browser",
     "//components/crash/core/app",
     "//components/custom_handlers",
-    "//components/custom_handlers:test_support",
     "//components/keyed_service/content",
     "//components/metrics",
     "//components/metrics:net",
-    "//components/metrics:test_support",
     "//components/network_hints/browser:browser",
     "//components/network_hints/renderer",
     "//components/network_session_configurator/common",
     "//components/performance_manager",
     "//components/prefs",
-    "//components/services/storage/test_api",
     "//components/url_formatter",
     "//components/variations",
     "//components/variations/service",
@@ -91,13 +84,11 @@ group("cobalt_shell_lib_deps") {
     "//content/public/renderer",
     "//content/public/utility",
     "//content/test:content_test_mojo_bindings",
-    "//content/test:test_support",
     "//media",
     "//media/mojo:buildflags",
     "//net",
     "//net:net_resources",
     "//ppapi/buildflags",
-    "//services/device/public/cpp:test_support",
     "//services/network:network_service",
     "//services/network/public/cpp",
     "//services/test/echo:lib",
@@ -188,7 +179,6 @@ group("cobalt_shell_lib_deps") {
 
 # TODO(b/422171398): Refactor source set to not depend on content shell
 static_library("cobalt_shell_lib") {
-  testonly = true
   public_deps = [ ":cobalt_shell_lib_deps" ]
   sources = [
     "browser/shell.cc",
@@ -319,7 +309,6 @@ static_library("cobalt_shell_lib") {
 # cobalt_shell_lib component will not, to avoid circular deps, as web_test
 # inherits from things in cobalt_shell_lib.
 static_library("cobalt_shell_app") {
-  testonly = true
   sources = [
     "app/shell_crash_reporter_client.cc",
     "app/shell_crash_reporter_client.h",
@@ -344,11 +333,9 @@ group("cobalt_shell_app_deps") {
     "//cobalt/shell:*",
     "//cobalt/testing:*",
   ]
-  testonly = true
   public_deps = [
     ":cobalt_shell_lib",
     "//components/crash/core/app",
-    "//components/crash/core/app:test_support",
     "//components/crash/core/common:crash_key",
     "//components/memory_system",
     "//content/public/app",
@@ -365,8 +352,6 @@ group("cobalt_shell_app_deps") {
 }
 
 repack("pak") {
-  testonly = true
-
   sources = [
     "$root_gen_dir/base/tracing/protos/tracing_proto_resources.pak",
     "$root_gen_dir/cobalt/shell/cobalt_shell_resources.pak",
@@ -433,8 +418,6 @@ repack("pak") {
 }
 
 grit("cobalt_shell_resources_grit") {
-  testonly = true
-
   # External code should depend on ":resources" instead.
   visibility = [ ":*" ]
   source = "shell_resources.grd"
@@ -445,8 +428,6 @@ grit("cobalt_shell_resources_grit") {
 }
 
 copy("copy_shell_resources") {
-  testonly = true
-
   sources = [ "$target_gen_dir/cobalt_shell_resources.pak" ]
   outputs = [ "$root_out_dir/cobalt_shell_resources.pak" ]
 
@@ -454,8 +435,6 @@ copy("copy_shell_resources") {
 }
 
 group("resources") {
-  testonly = true
-
   public_deps = [ ":copy_shell_resources" ]
 }
 
@@ -471,7 +450,7 @@ mojom("content_browsertests_mojom") {
   ]
 }
 
-mojom("shell_controller_mojom") {
+mojom("shell_controller_test_mojom") {
   testonly = true
   sources = [ "common/shell_controller.test-mojom" ]
   public_deps = [ "//mojo/public/mojom/base" ]

--- a/cobalt/shell/android/BUILD.gn
+++ b/cobalt/shell/android/BUILD.gn
@@ -16,6 +16,8 @@ import("//build/config/android/config.gni")
 import("//build/config/android/rules.gni")
 import("//third_party/icu/config.gni")
 
+cobalt_shell_manifest =
+    "$target_gen_dir/cobalt_shell_manifest/AndroidManifest.xml"
 cobalt_shell_test_manifest =
     "$target_gen_dir/cobalt_shell_test_manifest/AndroidManifest.xml"
 
@@ -43,7 +45,6 @@ shared_library("libcobalt_native_test") {
 }
 
 android_resources("cobalt_shell_java_resources") {
-  testonly = true
   sources = [
     "java/res/drawable-xhdpi/app_banner.png",
     "java/res/layout/coat_error_dialog.xml",
@@ -63,12 +64,10 @@ android_resources("cobalt_shell_java_resources") {
 }
 
 android_library("cobalt_shell_java") {
-  testonly = true
-
   resources_package = "dev.cobalt.shell"
   deps = [
     ":cobalt_shell_java_resources",
-    ":cobalt_shell_test_manifest",
+    ":cobalt_shell_manifest",
     "//base:base_java",
     "//base:jni_java",
     "//build/android:build_java",
@@ -92,6 +91,15 @@ android_library("cobalt_shell_java") {
   ]
 
   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+}
+
+jinja_template("cobalt_shell_manifest") {
+  input = "shell_apk/AndroidManifest.xml.jinja2"
+  output = cobalt_shell_manifest
+  variables = [
+    "manifest_package=dev.cobalt.app",
+    "build_type=$build_type",
+  ]
 }
 
 jinja_template("cobalt_shell_test_manifest") {
@@ -140,7 +148,6 @@ android_aidl("content_javatests_aidl") {
 }
 
 android_assets("cobalt_shell_assets") {
-  testonly = true
   sources = [ "$root_out_dir/cobalt_shell.pak" ]
   disable_compression = true
   deps = [
@@ -154,7 +161,6 @@ template("cobalt_shell_apk_tmpl") {
   _target_type = invoker.target_type
   target(_target_type, target_name) {
     forward_variables_from(invoker, "*")
-    testonly = true
     if (!defined(deps)) {
       deps = []
     }

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -37,7 +37,6 @@
 #include "cobalt/shell/common/shell_switches.h"
 #include "components/custom_handlers/protocol_handler.h"
 #include "components/custom_handlers/protocol_handler_registry.h"
-#include "components/custom_handlers/simple_protocol_handler_registry_factory.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/devtools_agent_host.h"
 #include "content/public/browser/file_select_listener.h"
@@ -510,50 +509,8 @@ void Shell::RegisterProtocolHandler(RenderFrameHost* requesting_frame,
                                     const std::string& protocol,
                                     const GURL& url,
                                     bool user_gesture) {
-  BrowserContext* context = requesting_frame->GetBrowserContext();
-  if (context->IsOffTheRecord()) {
-    return;
-  }
-
-  custom_handlers::ProtocolHandler handler =
-      custom_handlers::ProtocolHandler::CreateProtocolHandler(
-          protocol, url, GetProtocolHandlerSecurityLevel(requesting_frame));
-
-  // The parameters's normalization process defined in the spec has been already
-  // applied in the WebContentImpl class, so at this point it shouldn't be
-  // possible to create an invalid handler.
-  // https://html.spec.whatwg.org/multipage/system-state.html#normalize-protocol-handler-parameters
-  DCHECK(handler.IsValid());
-
-  custom_handlers::ProtocolHandlerRegistry* registry = custom_handlers::
-      SimpleProtocolHandlerRegistryFactory::GetForBrowserContext(context, true);
-  DCHECK(registry);
-  if (registry->SilentlyHandleRegisterHandlerRequest(handler)) {
-    return;
-  }
-
-  if (!user_gesture && !windows_.empty()) {
-    // TODO(jfernandez): This is not strictly needed, but we need a way to
-    // inform the observers in browser tests that the request has been
-    // cancelled, to avoid timeouts. Chrome just holds the handler as pending in
-    // the PageContentSettingsDelegate, but we don't have such thing in the
-    // Content Shell.
-    registry->OnDenyRegisterProtocolHandler(handler);
-    return;
-  }
-
-  // FencedFrames can not register to handle any protocols.
-  if (requesting_frame->IsNestedWithinFencedFrame()) {
-    registry->OnIgnoreRegisterProtocolHandler(handler);
-    return;
-  }
-
-  // TODO(jfernandez): Are we interested at all on using the
-  // PermissionRequestManager in the ContentShell ?
-  if (registry->registration_mode() ==
-      custom_handlers::RphRegistrationMode::kAutoAccept) {
-    registry->OnAcceptRegisterProtocolHandler(handler);
-  }
+  // TODO:(b/428999732) This requires a test-only build dependency and cannot
+  // be called from a production target.
 }
 #endif
 

--- a/cobalt/shell/browser/shell_browser_context.cc
+++ b/cobalt/shell/browser/shell_browser_context.cc
@@ -34,12 +34,12 @@
 #include "components/keyed_service/core/simple_factory_key.h"
 #include "components/keyed_service/core/simple_key_map.h"
 #include "components/network_session_configurator/common/network_switches.h"
+#include "content/public/browser/background_sync_controller.h"
 #include "content/public/browser/browser_task_traits.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/reduce_accept_language_controller_delegate.h"
 #include "content/public/browser/storage_partition.h"
 #include "content/public/common/content_switches.h"
-#include "content/test/mock_background_sync_controller.h"
-#include "content/test/mock_reduce_accept_language_controller_delegate.h"
 
 namespace content {
 
@@ -179,11 +179,7 @@ BackgroundFetchDelegate* ShellBrowserContext::GetBackgroundFetchDelegate() {
 }
 
 BackgroundSyncController* ShellBrowserContext::GetBackgroundSyncController() {
-  if (!background_sync_controller_) {
-    background_sync_controller_ =
-        std::make_unique<MockBackgroundSyncController>();
-  }
-  return background_sync_controller_.get();
+  return nullptr;
 }
 
 BrowsingDataRemoverDelegate*
@@ -215,12 +211,7 @@ ShellBrowserContext::GetFederatedIdentityPermissionContext() {
 
 ReduceAcceptLanguageControllerDelegate*
 ShellBrowserContext::GetReduceAcceptLanguageControllerDelegate() {
-  if (!reduce_accept_lang_controller_delegate_) {
-    reduce_accept_lang_controller_delegate_ =
-        std::make_unique<MockReduceAcceptLanguageControllerDelegate>(
-            GetShellLanguage());
-  }
-  return reduce_accept_lang_controller_delegate_.get();
+  return nullptr;
 }
 
 OriginTrialsControllerDelegate*

--- a/cobalt/shell/renderer/shell_content_renderer_client.cc
+++ b/cobalt/shell/renderer/shell_content_renderer_client.cc
@@ -266,7 +266,8 @@ void ShellContentRendererClient::DidInitializeWorkerContextOnWorkerThread(
     v8::Local<v8::Context> context) {
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           switches::kExposeInternalsForTesting)) {
-    blink::WebTestingSupport::InjectInternalsObject(context);
+    // TODO:(b/428999732) This requires a test-only build dependency and cannot
+    // be called from a production target.
   }
 }
 

--- a/cobalt/shell/renderer/shell_render_frame_observer.cc
+++ b/cobalt/shell/renderer/shell_render_frame_observer.cc
@@ -36,8 +36,8 @@ void ShellRenderFrameObserver::OnDestruct() {
 void ShellRenderFrameObserver::DidClearWindowObject() {
   auto& cmd = *base::CommandLine::ForCurrentProcess();
   if (cmd.HasSwitch(switches::kExposeInternalsForTesting)) {
-    blink::WebTestingSupport::InjectInternalsObject(
-        render_frame()->GetWebFrame());
+    // TODO:(b/428999732) This requires a test-only build dependency and cannot
+    // be called from a production target.
   }
 }
 

--- a/cobalt/shell/utility/shell_content_utility_client.cc
+++ b/cobalt/shell/utility/shell_content_utility_client.cc
@@ -34,7 +34,6 @@
 #include "base/task/single_thread_task_runner.h"
 #include "build/build_config.h"
 #include "cobalt/shell/common/power_monitor_test_impl.h"
-#include "components/services/storage/test_api/test_api.h"
 #include "content/public/child/child_thread.h"
 #include "content/public/common/content_switches.h"
 #include "content/public/common/pseudonymization_util.h"
@@ -184,9 +183,6 @@ ShellContentUtilityClient::ShellContentUtilityClient(bool is_browsertest) {
   if (is_browsertest &&
       base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(
           switches::kProcessType) == switches::kUtilityProcess) {
-    network_service_test_helper_ = NetworkServiceTestHelper::Create();
-    audio_service_test_helper_ = std::make_unique<AudioServiceTestHelper>();
-    storage::InjectTestApiImplementation();
     register_sandbox_status_helper_ = true;
   }
 }

--- a/cobalt/shell/utility/shell_content_utility_client.h
+++ b/cobalt/shell/utility/shell_content_utility_client.h
@@ -16,8 +16,6 @@
 #ifndef COBALT_SHELL_UTILITY_SHELL_CONTENT_UTILITY_CLIENT_H_
 #define COBALT_SHELL_UTILITY_SHELL_CONTENT_UTILITY_CLIENT_H_
 
-#include "content/public/test/audio_service_test_helper.h"
-#include "content/public/test/network_service_test_helper.h"
 #include "content/public/utility/content_utility_client.h"
 
 namespace content {
@@ -37,8 +35,6 @@ class ShellContentUtilityClient : public ContentUtilityClient {
   void RegisterIOThreadServices(mojo::ServiceFactory& services) override;
 
  private:
-  std::unique_ptr<NetworkServiceTestHelper> network_service_test_helper_;
-  std::unique_ptr<AudioServiceTestHelper> audio_service_test_helper_;
   bool register_sandbox_status_helper_ = false;
 };
 


### PR DESCRIPTION
We can not simply remove all the testonly targets and dependencies from Cobalt Shell target yet, as it completely fails all the browsertest. The right way to do this is creating another Cobalt Shell test support target for browsertest to depend on.

Bug: 428999732