### PR TITLE
media: Add max video size calculation experiment

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -417,6 +417,7 @@ class MediaCodecBridge {
       ColorInfo colorInfo,
       int tunnelModeAudioSessionId,
       int maxVideoInputSize,
+      boolean maxVideoInputSizeExperiment,
       CreateMediaCodecBridgeResult outCreateMediaCodecBridgeResult) {
     MediaCodec mediaCodec = null;
     outCreateMediaCodecBridgeResult.mMediaCodecBridge = null;
@@ -589,7 +590,7 @@ class MediaCodecBridge {
       }
     }
     if (!bridge.configureVideo(
-        mediaFormat, surface, crypto, 0, maxWidth, maxHeight, outCreateMediaCodecBridgeResult)) {
+        mediaFormat, surface, crypto, 0, maxWidth, maxHeight, maxVideoInputSizeExperiment, outCreateMediaCodecBridgeResult)) {
       Log.e(TAG, "Failed to configure video codec.");
       bridge.release();
       // outCreateMediaCodecBridgeResult.mErrorMessage is set inside configureVideo() on error.
@@ -831,6 +832,7 @@ class MediaCodecBridge {
       int flags,
       int maxSupportedWidth,
       int maxSupportedHeight,
+      boolean maxVideoInputSizeExperiment,
       CreateMediaCodecBridgeResult outCreateMediaCodecBridgeResult) {
     try {
       // Since we haven't passed the properties of the stream we're playing down to this level, from
@@ -848,7 +850,7 @@ class MediaCodecBridge {
         format.setInteger(MediaFormat.KEY_MAX_HEIGHT, Math.min(2160, maxSupportedHeight));
       }
 
-      maybeSetMaxVideoInputSize(format);
+      maybeSetMaxVideoInputSize(format, crypto, maxVideoInputSizeExperiment);
       mMediaCodec.get().configure(format, surface, crypto, flags);
       mFrameRateEstimator = new FrameRateEstimator();
       return true;
@@ -884,11 +886,19 @@ class MediaCodecBridge {
     int ceilDivide = (size + alignment - 1) / alignment;
     return ceilDivide * alignment;
   }
-
+  /**
+   * Returns the maximum sample size assuming three channel 4:2:0 subsampled input frames with the
+   * specified {@code minCompressionRatio}
+   * @param pixelCount The number of pixels
+   * @param minCompressionRatio The minimum compression ratio
+   */
+  private static int getMaxSampleSize(int pixelCount, int minCompressionRatio) {
+    return (pixelCount * 3) / (2 * minCompressionRatio);
+  }
   // Use some heuristics to set KEY_MAX_INPUT_SIZE (the size of the input buffers).
   // Taken from ExoPlayer:
   // https://github.com/google/ExoPlayer/blob/8595c65678a181296cdf673eacb93d8135479340/library/src/main/java/com/google/android/exoplayer/MediaCodecVideoTrackRenderer.java
-  private void maybeSetMaxVideoInputSize(MediaFormat format) {
+  private void maybeSetMaxVideoInputSize(MediaFormat format, MediaCrypto crypto, boolean maxVideoInputSizeExperiment) {
     if (format.containsKey(android.media.MediaFormat.KEY_MAX_INPUT_SIZE)) {
       try {
         Log.i(
@@ -910,36 +920,75 @@ class MediaCodecBridge {
     if (format.containsKey(MediaFormat.KEY_MAX_WIDTH)) {
       maxWidth = Math.max(maxWidth, format.getInteger(MediaFormat.KEY_MAX_WIDTH));
     }
-    int maxPixels;
+    int pixelCount;
     int minCompressionRatio;
-    switch (format.getString(MediaFormat.KEY_MIME)) {
-      case MimeTypes.VIDEO_H264:
-        if ("BRAVIA 4K 2015".equals(Build.MODEL)) {
-          // The Sony BRAVIA 4k TV has input buffers that are too small for the calculated
-          // 4k video maximum input size, so use the default value.
+    // If |maxVideoInputSizeExperiment| is true, we'll calculate the input size
+    // according to the latest exoplayer code from cl/467641494.
+    // If set to false, we'll use our original calculation method.
+    if (maxVideoInputSizeExperiment) {
+      switch (mimeType) {
+        case MimeTypes.VIDEO_H264:
+          if ("BRAVIA 4K 2015".equals(Build.MODEL) // Sony Bravia 4K
+              || ("Amazon".equals(Build.MANUFACTURER)
+                  && ("KFSOWI".equals(Build.MODEL) // Kindle Soho
+                      || ("AFTS".equals(Build.MODEL) && crypto != null)))) { // Fire TV Gen 2
+            // Use the default value for cases where platform limitations may prevent buffers of the
+            // calculated maximum input size from being allocated.
+            return;
+          }
+          // Round up width/height to an integer number of macroblocks.
+          pixelCount = alignDimension(maxWidth, 16) * alignDimension(maxHeight, 16);
+          minCompressionRatio = 2;
+          break;
+        case MimeTypes.VIDEO_AV1:
+        // Assume a min compression of 2 similar to the platform's C2SoftAomDec.cpp.
+        case MimeTypes.VIDEO_VP8:
+        // Assume a min compression of 2 similar to the platform's SoftVPX.cpp.
+        case MimeTypes.VIDEO_H265:
+          // Assume a min compression of 2 similar to the platform's C2SoftHevcDec.cpp, but restrict
+          // the minimum size.
+          pixelCount = maxWidth * maxHeight;
+          minCompressionRatio = 2;
+          break;
+        case MimeTypes.VIDEO_VP9:
+          pixelCount = maxWidth * maxHeight;
+          minCompressionRatio = 4;
+          break;
+        default:
+          // Leave the default max input size.
           return;
-        }
-        // Round up width/height to an integer number of macroblocks.
-        maxPixels = ((maxWidth + 15) / 16) * ((maxHeight + 15) / 16) * 16 * 16;
-        minCompressionRatio = 2;
-        break;
-      case MimeTypes.VIDEO_VP8:
-        // VPX does not specify a ratio so use the values from the platform's SoftVPX.cpp.
-        maxPixels = maxWidth * maxHeight;
-        minCompressionRatio = 2;
-        break;
-      case MimeTypes.VIDEO_H265:
-      case MimeTypes.VIDEO_VP9:
-      case MimeTypes.VIDEO_AV1:
-        maxPixels = maxWidth * maxHeight;
-        minCompressionRatio = 4;
-        break;
-      default:
-        // Leave the default max input size.
-        return;
+      }
+    }
+    else {
+      switch (mimeType) {
+        case MimeTypes.VIDEO_H264:
+          if ("BRAVIA 4K 2015".equals(Build.MODEL)) {
+            // The Sony BRAVIA 4k TV has input buffers that are too small for the calculated
+            // 4k video maximum input size, so use the default value.
+            return;
+          }
+          // Round up width/height to an integer number of macroblocks.
+          pixelCount = alignDimension(maxWidth, 16) * alignDimension(maxHeight, 16);
+          minCompressionRatio = 2;
+          break;
+        case MimeTypes.VIDEO_VP8:
+          // VPX does not specify a ratio so use the values from the platform's SoftVPX.cpp.
+          pixelCount = maxWidth * maxHeight;
+          minCompressionRatio = 2;
+          break;
+        case MimeTypes.VIDEO_H265:
+        case MimeTypes.VIDEO_VP9:
+        case MimeTypes.VIDEO_AV1:
+          pixelCount = maxWidth * maxHeight;
+          minCompressionRatio = 4;
+          break;
+        default:
+          // Leave the default max input size.
+          return;
+      }
     }
     // Estimate the maximum input size assuming three channel 4:2:0 subsampled input frames.
-    int maxVideoInputSize = (maxPixels * 3) / (2 * minCompressionRatio);
+    int maxVideoInputSize = getMaxSampleSize(pixelCount, minCompressionRatio);
     format.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxVideoInputSize);
     try {
       Log.i(

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -287,7 +287,7 @@ std::unique_ptr<MediaCodecBridge> MediaCodecBridge::CreateVideoMediaCodecBridge(
       max_height.value_or(-1), j_surface_local, j_media_crypto_local,
       j_color_info, tunnel_mode_audio_session_id, max_video_input_size,
       starboard::features::FeatureList::IsEnabled(
-          starboard::features::kMaxVideoInputSizeExperiment),
+          starboard::features::kExperimentalVideoSizeCalculation),
       j_create_media_codec_bridge_result);
 
   ScopedJavaLocalRef<jobject> j_media_codec_bridge(

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -18,6 +18,7 @@
 #include "base/android/jni_string.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/common/string.h"
+#include "starboard/shared/starboard/features.h"
 
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wunused-function"
@@ -285,6 +286,8 @@ std::unique_ptr<MediaCodecBridge> MediaCodecBridge::CreateVideoMediaCodecBridge(
       j_decoder_name, width_hint, height_hint, fps, max_width.value_or(-1),
       max_height.value_or(-1), j_surface_local, j_media_crypto_local,
       j_color_info, tunnel_mode_audio_session_id, max_video_input_size,
+      starboard::features::FeatureList::IsEnabled(
+          starboard::features::kMaxVideoInputSizeExperiment),
       j_create_media_codec_bridge_result);
 
   ScopedJavaLocalRef<jobject> j_media_codec_bridge(

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -128,6 +128,10 @@ STARBOARD_FEATURE(kUseStubVideoDecoder, "UseStubVideoDecoder", false)
 STARBOARD_FEATURE(kVideoDecoderDelayUsecOverride,
                   "VideoDecoderDelayUsecOverride",
                   false)
+#if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
+STARBOARD_FEATURE(kMaxVideoInputSizeExperiment,
+                  "MaxVideoInputSizeExperiment",
+                  false)
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 FEATURE_LIST_END
 

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -128,9 +128,12 @@ STARBOARD_FEATURE(kUseStubVideoDecoder, "UseStubVideoDecoder", false)
 STARBOARD_FEATURE(kVideoDecoderDelayUsecOverride,
                   "VideoDecoderDelayUsecOverride",
                   false)
-#if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
-STARBOARD_FEATURE(kMaxVideoInputSizeExperiment,
-                  "MaxVideoInputSizeExperiment",
+
+// By default, Cobalt calculates the maximum video size for videos using
+// calculations as old as 2018. Set the following variable to true to force use
+// calculations from the latest exoplayer code found in cl/467641494.
+STARBOARD_FEATURE(kExperimentalVideoSizeCalculation,
+                  "ExperimentalVideoSizeCalculation",
                   false)
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 FEATURE_LIST_END


### PR DESCRIPTION
This PR aims to re-add the code from [pr/5565](https://github.com/youtube/cobalt/pull/5565), which was closed due to needing to be guarded by an experiment. With the ability to place feature experiments inside Starboard now possible, we guard the code from pr/5565 with a Starboard experiment.

When the starboard feature is enabled, we will calculate the max video input size according to the latest exoplayer code from cl/467641494. When the feature is disabled, we will use our current method of calculating the max video input size. This will allow us to do some A/B testing to see which implementation is better.

Bug: 413696596