### PR TITLE
fix(android): Prevent crash in VideoDecoder constructor

### DIFF
--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -417,6 +417,7 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
           "Failed to initialize video decoder with error: " + *error_message;
       SB_LOG(ERROR) << *error_message;
       TeardownCodec();
+      return;
     }
   }
 


### PR DESCRIPTION
This change fixes a crash that occurs when the Android video decoder is created with an invalid (NULL) surface.

The `VideoDecoder` constructor was not correctly aborting when its helper function, `InitializeCodec`, failed to acquire a valid video surface. This resulted in a `NULL` surface being passed to the `MediaDecoder`, causing a fatal JNI crash.

The fix adds a `return` statement to ensure the `VideoDecoder` constructor exits immediately if `InitializeCodec` returns false, preventing the crash and allowing the error to be propagated correctly.

Bug: 299821357