### PR TITLE
android: allow overflow audio samples for tunnel mode

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -95,6 +95,10 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
             }),
         tunnel_mode_audio_session_id_(tunnel_mode_audio_session_id) {}
 
+  bool AllowOverflowAudioSamples() const override {
+    return tunnel_mode_audio_session_id_ != -1;
+  }
+
  private:
   bool IsAudioSampleTypeSupported(
       SbMediaAudioSampleType audio_sample_type) const override {

--- a/starboard/shared/starboard/player/filter/audio_frame_tracker.cc
+++ b/starboard/shared/starboard/player/filter/audio_frame_tracker.cc
@@ -26,6 +26,7 @@ namespace starboard {
 void AudioFrameTracker::Reset() {
   frame_records_.clear();
   frames_played_adjusted_to_playback_rate_ = 0;
+  overflowed_frames_ = 0;
 }
 
 void AudioFrameTracker::AddFrames(int number_of_frames, double playback_rate) {
@@ -61,8 +62,8 @@ void AudioFrameTracker::RecordPlayedFrames(int number_of_frames) {
       frame_records_.erase(frame_records_.begin());
     }
   }
-  SB_LOG_IF(ERROR, number_of_frames != 0)
-      << "played frames overflow " << number_of_frames;
+
+  overflowed_frames_ += number_of_frames;
 }
 
 int64_t AudioFrameTracker::GetFutureFramesPlayedAdjustedToPlaybackRate(

--- a/starboard/shared/starboard/player/filter/audio_frame_tracker.h
+++ b/starboard/shared/starboard/player/filter/audio_frame_tracker.h
@@ -39,6 +39,7 @@ class AudioFrameTracker {
   int64_t GetFutureFramesPlayedAdjustedToPlaybackRate(
       int number_of_frames,
       double* playback_rate) const;
+  int64_t GetOverflowedFrames() const { return overflowed_frames_; }
 
  private:
   struct FrameRecord {
@@ -50,6 +51,8 @@ class AudioFrameTracker {
   std::vector<FrameRecord> frame_records_;
   int64_t frames_played_adjusted_to_playback_rate_ = 0;
   double last_playback_rate_ = 1.0;
+  // A record of overflowed frames.
+  int64_t overflowed_frames_ = 0;
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink.h
@@ -66,6 +66,8 @@ class AudioRendererSink {
 
   virtual void SetVolume(double volume) = 0;
   virtual void SetPlaybackRate(double playback_rate) = 0;
+
+  virtual bool AllowOverflowAudioSamples() const { return false; }
 };
 
 }  // namespace starboard


### PR DESCRIPTION
Add AllowOverflowAudioSamples() function to AudioRendererSink to make
AudioRendererPcm accept overflow audio sample for tunnel mode.

Bug: 423676458