### PR TITLE
Fix: Align non-public, non-static field names to Chromium style

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CrashContext.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CrashContext.java
@@ -23,21 +23,21 @@ public enum CrashContext {
   // TODO(cobalt, b/383301493): at time of writing all clients of this class are on the same thread.
   // But as johnx@ suggested we should either enforce this assumption or use a mutex to guard
   // concurrent access from different threads.
-  private final HashMap<String, String> crashContext = new HashMap<>();
-  private CrashContextUpdateHandler crashContextUpdateHandler;
+  private final HashMap<String, String> mCrashContext = new HashMap<>();
+  private CrashContextUpdateHandler mCrashContextUpdateHandler;
 
   public void setCrashContext(String key, String value) {
-    crashContext.put(key, value);
-    if (this.crashContextUpdateHandler != null) {
-      this.crashContextUpdateHandler.onCrashContextUpdate();
+    mCrashContext.put(key, value);
+    if (this.mCrashContextUpdateHandler != null) {
+      this.mCrashContextUpdateHandler.onCrashContextUpdate();
     }
   }
 
   HashMap<String, String> getCrashContext() {
-    return this.crashContext;
+    return this.mCrashContext;
   }
 
   void registerCrashContextUpdateHandler(CrashContextUpdateHandler handler) {
-    this.crashContextUpdateHandler = handler;
+    this.mCrashContextUpdateHandler = handler;
   }
 }


### PR DESCRIPTION
This is a fix for chromium pre-commit checks to match the same pre-commit checks Chromium would have run in an effort to better align our code to Chromium's. You are being asked to review because you were the last person to touch this file(s). If you think there's someone better to review please add them. Please the review the changes and if they look good please approve the PR.

Precommit error message:

cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CrashContext.java:26:41: Non-public, non-static field names start with m.
cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CrashContext.java:27:37: Non-public, non-static field names start with m.

Bug: 435503470