### PR TITLE
Gate test logic in cobalt to official build

### DIFF
--- a/cobalt/renderer/cobalt_render_frame_observer.cc
+++ b/cobalt/renderer/cobalt_render_frame_observer.cc
@@ -19,7 +19,10 @@
 #include "content/public/renderer/render_frame.h"
 #include "starboard/extension/graphics.h"
 #include "starboard/system.h"
-#include "third_party/blink/public/web/web_testing_support.h"
+
+#if defined(RUN_BROWSER_TESTS)
+#include "third_party/blink/public/web/web_testing_support.h"  // nogncheck
+#endif  // defined(RUN_BROWSER_TESTS)
 
 namespace cobalt {
 
@@ -33,6 +36,7 @@ void CobaltRenderFrameObserver::OnDestruct() {
   delete this;
 }
 
+#if defined(RUN_BROWSER_TESTS)
 void CobaltRenderFrameObserver::DidClearWindowObject() {
   const auto& cmd = *base::CommandLine::ForCurrentProcess();
   if (cmd.HasSwitch(switches::kExposeInternalsForTesting)) {
@@ -44,6 +48,7 @@ void CobaltRenderFrameObserver::DidClearWindowObject() {
         render_frame()->GetWebFrame());
   }
 }
+#endif  // defined(RUN_BROWSER_TESTS)
 
 void CobaltRenderFrameObserver::DidMeaningfulLayout(
     blink::WebMeaningfulLayout meaningful_layout) {

--- a/cobalt/renderer/cobalt_render_frame_observer.h
+++ b/cobalt/renderer/cobalt_render_frame_observer.h
@@ -40,10 +40,12 @@ class CobaltRenderFrameObserver : public content::RenderFrameObserver {
   // Overridden so that the observer has the same lifetime as the RenderFrame.
   void OnDestruct() override;
 
+#if defined(RUN_BROWSER_TESTS)
   // Overridden for Cobalt-specific responses to this particular notification.
   // See blink::WebLocalFrameClient.DidClearWindowObject() for details about
   // when it's sent.
   void DidClearWindowObject() override;
+#endif  // defined(RUN_BROWSER_TESTS)
 };
 
 }  // namespace cobalt

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -35,7 +35,6 @@ config("cobalt_shell_lib_warnings") {
 }
 
 source_set("android_shell_descriptors") {
-  testonly = true
   sources = []
   public_deps = [ "//content/public/common:content_descriptors" ]
   if (is_android) {
@@ -44,18 +43,15 @@ source_set("android_shell_descriptors") {
 }
 
 group("cobalt_shell_lib_deps") {
+  testonly = true
   visibility = [
     "//cobalt/shell:*",
     "//cobalt/testing:*",
   ]
-  testonly = true
+
   public_deps = [
     ":android_shell_descriptors",
-
-    # cobalt_shell_lib also exposes all public content APIs.
-    ":browsertests_mojom",
     ":resources",
-    ":shell_controller_mojom",
     "//base",
     "//base:base_static",
     "//base/third_party/dynamic_annotations",
@@ -67,7 +63,6 @@ group("cobalt_shell_lib_deps") {
     "//components/keyed_service/content",
     "//components/metrics",
     "//components/metrics:net",
-    "//components/metrics:test_support",
     "//components/network_hints/browser:browser",
     "//components/network_hints/renderer",
     "//components/network_session_configurator/common",
@@ -79,14 +74,9 @@ group("cobalt_shell_lib_deps") {
     "//components/web_cache/renderer",
     "//content:content_resources",
     "//content:dev_ui_content_resources",
-    "//content/common:main_frame_counter",
     "//content/public/app",
     "//content/public/browser",
-    "//content/public/common",
     "//content/public/gpu",
-    "//content/public/renderer",
-    "//content/public/utility",
-    "//content/test:test_support",
     "//media",
     "//media/mojo:buildflags",
     "//net",
@@ -181,6 +171,8 @@ group("cobalt_shell_lib_deps") {
 source_set("browsertests_sources") {
   testonly = true
   sources = [
+    "common/main_frame_counter_test_impl.cc",
+    "common/main_frame_counter_test_impl.h",
     "common/power_monitor_test_impl.cc",
     "common/power_monitor_test_impl.h",
     "common/shell_test_switches.cc",
@@ -192,10 +184,14 @@ source_set("browsertests_sources") {
     "utility/shell_content_utility_client.cc",
     "utility/shell_content_utility_client.h",
   ]
+
   public_deps = [
     ":browsertests_mojom",
+    ":shell_controller_mojom",
     "//components/custom_handlers:test_support",
+    "//components/metrics:test_support",
     "//components/services/storage/test_api",
+    "//content/common:main_frame_counter",
     "//content/public/child",
     "//content/public/common",
     "//content/public/renderer",
@@ -209,7 +205,6 @@ source_set("browsertests_sources") {
 
 static_library("cobalt_shell_lib") {
   testonly = true
-
   public_deps = [ ":cobalt_shell_lib_deps" ]
   sources = [
     "browser/shell.cc",
@@ -241,8 +236,6 @@ static_library("cobalt_shell_lib") {
     "browser/shell_speech_recognition_manager_delegate.h",
     "browser/shell_web_contents_view_delegate.h",
     "browser/shell_web_contents_view_delegate_creator.h",
-    "common/main_frame_counter_test_impl.cc",
-    "common/main_frame_counter_test_impl.h",
     "common/shell_content_client.cc",
     "common/shell_content_client.h",
     "common/shell_switches.cc",
@@ -284,6 +277,8 @@ static_library("cobalt_shell_lib") {
     "CONTENT_SHELL_MAJOR_VERSION=\"1\"",
   ]
 
+  # TODO(b/440376024): run_browser_tests and RUN_BROWSER_TESTS gate all test logic which should not be in
+  # an official build, including not only browser tests but also web tests or render tests.
   if (run_browser_tests) {
     defines += [ "RUN_BROWSER_TESTS=1" ]
     public_deps += [ ":browsertests_sources" ]
@@ -451,8 +446,6 @@ repack("pak") {
 }
 
 grit("cobalt_shell_resources_grit") {
-  testonly = true
-
   # External code should depend on ":resources" instead.
   visibility = [ ":*" ]
   source = "shell_resources.grd"
@@ -463,8 +456,6 @@ grit("cobalt_shell_resources_grit") {
 }
 
 copy("copy_shell_resources") {
-  testonly = true
-
   sources = [ "$target_gen_dir/cobalt_shell_resources.pak" ]
   outputs = [ "$root_out_dir/cobalt_shell_resources.pak" ]
 
@@ -472,12 +463,11 @@ copy("copy_shell_resources") {
 }
 
 group("resources") {
-  testonly = true
-
   public_deps = [ ":copy_shell_resources" ]
 }
 
 mojom("browsertests_mojom") {
+  testonly = true
   sources = [
     "common/main_frame_counter_test.mojom",
     "common/power_monitor_test.mojom",

--- a/cobalt/shell/browser/shell_content_browser_client.cc
+++ b/cobalt/shell/browser/shell_content_browser_client.cc
@@ -45,13 +45,9 @@
 #include "cobalt/shell/browser/shell_devtools_manager_delegate.h"
 #include "cobalt/shell/browser/shell_paths.h"
 #include "cobalt/shell/browser/shell_web_contents_view_delegate_creator.h"
-#include "cobalt/shell/common/shell_controller.test-mojom.h"
 #include "cobalt/shell/common/shell_switches.h"
 #include "components/custom_handlers/protocol_handler_registry.h"
 #include "components/custom_handlers/protocol_handler_throttle.h"
-#if defined(RUN_BROWSER_TESTS)
-#include "components/custom_handlers/simple_protocol_handler_registry_factory.h"  //nogncheck
-#endif  // defined(RUN_BROWSER_TESTS)
 #include "components/metrics/client_info.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics/metrics_state_manager.h"
@@ -126,7 +122,9 @@
 #endif
 
 #if defined(RUN_BROWSER_TESTS)
-#include "cobalt/shell/common/shell_test_switches.h"              // nogncheck
+#include "cobalt/shell/common/shell_controller.test-mojom.h"  // nogncheck
+#include "cobalt/shell/common/shell_test_switches.h"          // nogncheck
+#include "components/custom_handlers/simple_protocol_handler_registry_factory.h"  //nogncheck
 #include "components/metrics/test/test_enabled_state_provider.h"  // nogncheck
 #endif  // defined(RUN_BROWSER_TESTS)
 
@@ -154,6 +152,7 @@ int GetCrashSignalFD(const base::CommandLine& command_line) {
 }
 #endif
 
+#if defined(RUN_BROWSER_TESTS)
 class ShellControllerImpl : public mojom::ShellController {
  public:
   ShellControllerImpl() = default;
@@ -180,6 +179,7 @@ class ShellControllerImpl : public mojom::ShellController {
 
   void ShutDown() override { Shell::Shutdown(); }
 };
+#endif  // defined(RUN_BROWSER_TESTS)
 
 // TODO(crbug/1219642): Consider not needing VariationsServiceClient just to use
 // VariationsFieldTrialCreator.
@@ -701,6 +701,7 @@ BluetoothDelegate* ShellContentBrowserClient::GetBluetoothDelegate() {
 }
 #endif
 
+#if defined(RUN_BROWSER_TESTS)
 void ShellContentBrowserClient::BindBrowserControlInterface(
     mojo::ScopedMessagePipeHandle pipe) {
   if (!pipe.is_valid()) {
@@ -710,6 +711,7 @@ void ShellContentBrowserClient::BindBrowserControlInterface(
       std::make_unique<ShellControllerImpl>(),
       mojo::PendingReceiver<mojom::ShellController>(std::move(pipe)));
 }
+#endif  // defined(RUN_BROWSER_TESTS)
 
 void ShellContentBrowserClient::set_browser_main_parts(
     ShellBrowserMainParts* parts) {

--- a/cobalt/shell/browser/shell_content_browser_client.h
+++ b/cobalt/shell/browser/shell_content_browser_client.h
@@ -153,7 +153,9 @@ class ShellContentBrowserClient : public ContentBrowserClient {
 #if BUILDFLAG(IS_IOS)
   BluetoothDelegate* GetBluetoothDelegate() override;
 #endif
+#if defined(RUN_BROWSER_TESTS)
   void BindBrowserControlInterface(mojo::ScopedMessagePipeHandle pipe) override;
+#endif  // defined(RUN_BROWSER_TESTS)
   void GetHyphenationDictionary(
       base::OnceCallback<void(const base::FilePath&)>) override;
   bool HasErrorPage(int http_status_code) override;

--- a/cobalt/testing/browser_tests/BUILD.gn
+++ b/cobalt/testing/browser_tests/BUILD.gn
@@ -45,12 +45,6 @@ if (is_ios) {
   import("//build/config/ios/bundle_data_from_filelist.gni")
 }
 
-group("browser_tests") {
-  testonly = true
-
-  deps = [ ":cobalt_browsertests" ]
-}
-
 # browsertest_support can be used by targets that run cobalt_shell based
 # browser tests.
 static_library("browsertest_support") {

--- a/cobalt/testing/browser_tests/media_browsertest.cc
+++ b/cobalt/testing/browser_tests/media_browsertest.cc
@@ -12,6 +12,7 @@
 #include "build/build_config.h"
 #include "cobalt/shell/browser/shell.h"
 #include "cobalt/shell/common/shell_switches.h"
+#include "cobalt/shell/common/shell_test_switches.h"  // nogncheck
 #include "cobalt/testing/browser_tests/content_browser_test_utils.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/common/content_features.h"

--- a/cobalt/testing/browser_tests/site_per_process_browsertest.cc
+++ b/cobalt/testing/browser_tests/site_per_process_browsertest.cc
@@ -52,7 +52,7 @@
 #include "cc/base/math_util.h"
 #include "cc/input/touch_action.h"
 #include "cobalt/shell/browser/shell.h"
-#include "cobalt/shell/common/main_frame_counter_test_impl.h"
+#include "cobalt/shell/common/main_frame_counter_test_impl.h"  // nogncheck
 #include "cobalt/shell/common/shell_switches.h"
 #include "cobalt/testing/browser_tests/content_browser_test_content_browser_client.h"
 #include "cobalt/testing/browser_tests/content_browser_test_utils.h"


### PR DESCRIPTION
This PR gates all the rest test logic to non-official build except ui/aura.
Test: ran CUJ on gold build locally, ran browsertests locally.
Bug: 437981348