### PR TITLE
cleanup: Remove unused JNI volume control methods

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java
@@ -63,8 +63,4 @@ final class VolumeStateReceiver extends BroadcastReceiver {
       dispatchKeyDownEvent(KeyEvent.KEYCODE_VOLUME_MUTE);
     }
   }
-
-  private native void nativeVolumeChanged(int volumeDelta);
-
-  private native void nativeMuteChanged();
 }

--- a/starboard/android/shared/android_main.cc
+++ b/starboard/android/shared/android_main.cc
@@ -49,23 +49,6 @@ Java_dev_cobalt_coat_StarboardBridge_closeNativeStarboard(JniEnvExt* env,
   delete app;
 }
 
-extern "C" SB_EXPORT_PLATFORM void
-Java_dev_cobalt_coat_VolumeStateReceiver_nativeVolumeChanged(JNIEnv* env,
-                                                             jobject jcaller,
-                                                             jint volumeDelta) {
-  // TODO(cobalt, b/378384110): send volume keys to web app through Content
-  // SbKey key = volumeDelta > 0 ? SbKey::kSbKeyVolumeUp :
-  // SbKey::kSbKeyVolumeDown;
-  // ApplicationAndroid::Get()->SendKeyboardInject(key);
-}
-
-extern "C" SB_EXPORT_PLATFORM void
-Java_dev_cobalt_coat_VolumeStateReceiver_nativeMuteChanged(JNIEnv* env,
-                                                           jobject jcaller) {
-  // TODO(cobalt, b/378384110): send volume keys to web app through Content
-  // ApplicationAndroid::Get()->SendKeyboardInject(SbKey::kSbKeyVolumeMute);
-}
-
 }  // namespace
 
 }  // namespace starboard::android::shared


### PR DESCRIPTION
The JNI functions `nativeVolumeChanged` and `nativeMuteChanged` are not used and their C++ implementations were empty. This commit removes the dead code from both the Java and C++ sides.

Volume controls work without these JNI methods by #5227 


Bug: 413418478