### PR TITLE
Fix: Player bounds not updating subsequent calls

### DIFF
--- a/starboard/shared/x11/application_x11.cc
+++ b/starboard/shared/x11/application_x11.cc
@@ -850,9 +850,6 @@ void ApplicationX11::PlayerSetBounds(SbPlayer player,
                                      int height) {
   std::lock_guard lock(frame_mutex_);
 
-  bool player_exists =
-      next_video_bounds_.find(player) != next_video_bounds_.end();
-
   FrameInfo& frame_info = next_video_bounds_[player];
   frame_info.player = player;
   frame_info.z_index = z_index;
@@ -861,13 +858,16 @@ void ApplicationX11::PlayerSetBounds(SbPlayer player,
   frame_info.width = width;
   frame_info.height = height;
 
-  if (player_exists) {
-    return;
+  // The bounds should only take effect once the UI frame is submitted. But we
+  // also apply the bounds immediately so that there is no flicker.
+  for (auto it = current_video_bounds_.begin();
+       it != current_video_bounds_.end(); ++it) {
+    if (it->player == player) {
+      current_video_bounds_.erase(it);
+      break;
+    }
   }
 
-  // The bounds should only take effect once the UI frame is submitted.  But we
-  // apply the bounds immediately if it is the first time the bounds for this
-  // player are set.
   auto position = current_video_bounds_.begin();
   while (position != current_video_bounds_.end()) {
     if (frame_info.z_index < position->z_index) {


### PR DESCRIPTION
The previous implementation of PlayerSetBounds in application_x11 only updated the current video bounds the first time it was called for a given player. Subsequent calls would update the bound for the next frame but would not be reflected in the current frame, causing the player's position and size to appear frozen.

This change removes the conditional check that prevented updates to current_video_bounds_ for existing players. Now, on every call to PlayerSetBounds, the player's existing bounds are removed from current_video_bounds_ and the new bounds are inserted in the correct z-order. This ensures that chang to player bounds are reflected immediately.

Bug: 401006482