### PR TITLE
Initialize ICU correctly when ICU is not bundled with the binary

### DIFF
--- a/cobalt/common/icu_init/init.cc
+++ b/cobalt/common/icu_init/init.cc
@@ -31,6 +31,10 @@
 #include "unicode/putil.h"
 #include "unicode/udata.h"
 
+#define UNSUPPORTED_ICU_CONFIG_ERROR_MSG                           \
+  "Initialize ICU properly in this case. Ensure the GN flags and " \
+  "corresponding C++ macros related to ICU are set correctly."
+
 namespace cobalt {
 namespace common {
 namespace icu_init {
@@ -146,7 +150,10 @@ bool IcuInit() {
 // guaranteed to be early enough for ICU to be used by other global
 // initializers.
 static bool g_icu_is_initialized = IcuInit();
-#endif  // (ICU_UTIL_DATA_IMPL == ICU_UTIL_DATA_FILE)
+
+#else
+#error UNSUPPORTED_ICU_CONFIG_ERROR_MSG
+#endif
 
 void EnsureInitialized() {
 #if (ICU_UTIL_DATA_IMPL == ICU_UTIL_DATA_STATIC)
@@ -165,9 +172,7 @@ void EnsureInitialized() {
     g_icu_is_initialized = IcuInit();
   }
 #else
-  SB_CHECK(false)
-      << "Initialize ICU properly in this case. Ensure the GN flags and "
-         "corresponding C++ macros related to ICU are set correctly.";
+#error UNSUPPORTED_ICU_CONFIG_ERROR_MSG
 #endif
 }
 


### PR DESCRIPTION
Issue: 437151583

When the ICU file is bundled separately, ensure ICU initialization works correctly
This code was initially introduced in #6048 and removed in #6817 . 
Re-adding it here after discussion with team members. We might have some use cases in the future
where we need ICU bundled separately and hence would like to keep the complex initialization alive for that case.