### PR TITLE
Fix incorrect BUILDFLAG logic for DCHECKs

### DIFF
--- a/components/viz/host/host_gpu_memory_buffer_manager.cc
+++ b/components/viz/host/host_gpu_memory_buffer_manager.cc
@@ -190,7 +190,7 @@ void HostGpuMemoryBufferManager::AllocateGpuMemoryBuffer(
                                                                  format)) {
     buffer_handle = gpu::GpuMemoryBufferImplSharedMemory::CreateGpuMemoryBuffer(
         id, size, format, usage);
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
+#if !BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
     DCHECK_EQ(gfx::SHARED_MEMORY_BUFFER, buffer_handle.type);
 #endif
     AllocatedBufferInfo buffer_info(buffer_handle, size, format);

--- a/gpu/command_buffer/client/gpu_memory_buffer_manager.cc
+++ b/gpu/command_buffer/client/gpu_memory_buffer_manager.cc
@@ -23,7 +23,7 @@ GpuMemoryBufferManager::AllocatedBufferInfo::AllocatedBufferInfo(
     : buffer_id_(handle.id),
       type_(handle.type),
       size_in_bytes_(gfx::BufferSizeForBufferFormat(size, format)) {
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
+#if !BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
   DCHECK_NE(gfx::EMPTY_BUFFER, type_);
 #endif
 


### PR DESCRIPTION
This change corrects the BUILDFLAG logic for two DCHECKs that were disabled to fix a crash in the modular_devel build. The previous logic was inverted, causing the checks to be enabled when they should have been disabled.

Bug: 430968699