### PR TITLE
Don't hard code the UA string

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -83,18 +83,9 @@ constexpr base::FilePath::CharType kTrustTokenFilename[] =
 }  // namespace
 
 std::string GetCobaltUserAgent() {
-// TODO: (cobalt b/375243230) enable UserAgentPlatformInfo on Linux.
-#if BUILDFLAG(IS_ANDROID)
   const UserAgentPlatformInfo platform_info;
   static const std::string user_agent_str = platform_info.ToString();
   return user_agent_str;
-#else
-  return std::string(
-      "Mozilla/5.0 (X11; Linux x86_64) Cobalt/26.lts.0-qa (unlike Gecko) "
-      "v8/unknown gles Starboard/17, "
-      "SystemIntegratorName_DESKTOP_ChipsetModelNumber_2025/FirmwareVersion "
-      "(BrandName, ModelName)");
-#endif
 }
 
 blink::UserAgentMetadata GetCobaltUserAgentMetadata() {


### PR DESCRIPTION
Switch to the shared infrastructure for generating the UA string. Many of the fields are still not populated but at least the Cobalt version is correct and YTS would parse it correctly.

Issue: 437414261