### PR TITLE
Fix IllegalStateException from PhysicalDisplayAndroid

### DIFF
--- a/ui/android/java/src/org/chromium/ui/display/PhysicalDisplayAndroid.java
+++ b/ui/android/java/src/org/chromium/ui/display/PhysicalDisplayAndroid.java
@@ -324,7 +324,12 @@ import java.util.function.Consumer;
 
         // Note: getMode() and getSupportedModes() can return null in some situations - see
         // crbug.com/1401322.
-        Display.Mode currentMode = display.getMode();
+        Display.Mode currentMode = null;
+        try {
+            currentMode = display.getMode();
+        } catch (IllegalStateException e) {
+            Log.w(TAG, "Could not get display mode.", e);
+        }
         Display.Mode[] modes = display.getSupportedModes();
         List<Display.Mode> supportedModes = null;
         if (modes != null && modes.length > 0) {


### PR DESCRIPTION
The Android OS's Display.getMode() method can throw an [IllegalStateException](https://cs.android.com/android/platform/superproject/+/android-latest-release:frameworks/base/core/java/android/view/DisplayInfo.java;l=793-795?q=DisplayInfo.java)
during HDMI hotplug events. This happens when a display reports a mode ID
not in its list of supported modes.

Wrap the call to getMode() in a try-catch block to prevent application
crashes in these scenarios. The system will recover when a valid
onDisplayChanged event occurs, making this approach safer than crashing.

Bug: 441513616

Change-Id: I0d3e4d0ce2682aaf813996ee434a9db293b26a5c