### PR TITLE
Fix race condition in TimeZoneState initialization

### DIFF
--- a/cobalt/common/libc/time/icu_time_support.cc
+++ b/cobalt/common/libc/time/icu_time_support.cc
@@ -18,7 +18,6 @@
 #include <time.h>
 
 #include <cmath>
-#include <functional>
 #include <memory>
 #include <optional>
 
@@ -45,7 +44,7 @@ constexpr time_t kMinTimeValForStructTm =
     -67768040609712422;  // Thu Jan  1 00:00:00 -2147481748
 
 bool ExplodeTime(const time_t* time,
-                 const icu::TimeZone& zone,
+                 std::shared_ptr<const icu::TimeZone> zone,
                  struct tm* out_exploded) {
   if (!time || !out_exploded) {
     return false;
@@ -56,9 +55,8 @@ bool ExplodeTime(const time_t* time,
   }
 
   UErrorCode status = U_ZERO_ERROR;
-  std::unique_ptr<icu::TimeZone> cloned_zone(zone.clone());
   std::unique_ptr<icu::Calendar> calendar(
-      new icu::GregorianCalendar(*cloned_zone, status));
+      new icu::GregorianCalendar(*zone, status));
   if (!calendar || U_FAILURE(status)) {
     return false;
   }
@@ -94,12 +92,12 @@ bool ExplodeTime(const time_t* time,
     out_exploded->tm_isdst = -1;
   }
 
-  if (zone == icu::TimeZone::getUnknown()) {
+  if (*zone == icu::TimeZone::getUnknown()) {
     out_exploded->tm_gmtoff = 0;
     out_exploded->tm_zone = nullptr;
   } else {
     int32_t raw_offset, dst_offset;
-    zone.getOffset(udate, false, raw_offset, dst_offset, status);
+    zone->getOffset(udate, false, raw_offset, dst_offset, status);
     if (U_SUCCESS(status)) {
       out_exploded->tm_gmtoff = (raw_offset + dst_offset) / 1000;
       bool is_daylight = (dst_offset != 0);
@@ -113,15 +111,15 @@ bool ExplodeTime(const time_t* time,
   return U_SUCCESS(status);
 }
 
-time_t ImplodeTime(struct tm* exploded, const icu::TimeZone& zone) {
-  if (!exploded) {
+time_t ImplodeTime(struct tm* exploded,
+                   std::shared_ptr<const icu::TimeZone> zone) {
+  if (!exploded || !zone) {
     return -1;
   }
 
   UErrorCode status = U_ZERO_ERROR;
-  std::unique_ptr<icu::TimeZone> cloned_zone(zone.clone());
   std::unique_ptr<icu::Calendar> calendar(
-      new icu::GregorianCalendar(*cloned_zone, status));
+      new icu::GregorianCalendar(*zone, status));
   if (!calendar || U_FAILURE(status)) {
     return -1;
   }
@@ -166,16 +164,16 @@ void IcuTimeSupport::GetPosixTimezoneGlobals(long& out_timezone,
 
 bool IcuTimeSupport::ExplodeLocalTime(const time_t* time,
                                       struct tm* out_exploded) {
-  bool result = false;
-  state_.WithTimeZone([&](const icu::TimeZone& tz) {
-    result = ExplodeTime(time, tz, out_exploded);
-  });
-  return result;
+  return ExplodeTime(time, state_.GetTimeZone(), out_exploded);
 }
 
 bool IcuTimeSupport::ExplodeGmtTime(const time_t* time,
                                     struct tm* out_exploded) {
-  bool result = ExplodeTime(time, *icu::TimeZone::getGMT(), out_exploded);
+  bool result =
+      ExplodeTime(time,
+                  std::shared_ptr<const icu::TimeZone>(
+                      icu::TimeZone::getGMT(), [](const icu::TimeZone*) {}),
+                  out_exploded);
   if (result) {
     out_exploded->tm_zone = "UTC";
     out_exploded->tm_isdst = 0;  // UTC is never daylight savings time.
@@ -184,17 +182,16 @@ bool IcuTimeSupport::ExplodeGmtTime(const time_t* time,
 }
 
 time_t IcuTimeSupport::ImplodeLocalTime(struct tm* exploded) {
-  time_t result = -1;
-  state_.WithTimeZone(
-      [&](const icu::TimeZone& tz) { result = ImplodeTime(exploded, tz); });
-  return result;
+  return ImplodeTime(exploded, state_.GetTimeZone());
 }
 
 time_t IcuTimeSupport::ImplodeGmtTime(struct tm* exploded) {
   if (exploded) {
     exploded->tm_isdst = 0;  // UTC is never daylight savings time.
   }
-  return ImplodeTime(exploded, *icu::TimeZone::getGMT());
+  return ImplodeTime(exploded,
+                     std::shared_ptr<const icu::TimeZone>(
+                         icu::TimeZone::getGMT(), [](const icu::TimeZone*) {}));
 }
 
 }  // namespace time

--- a/cobalt/common/libc/time/time_zone_state.cc
+++ b/cobalt/common/libc/time/time_zone_state.cc
@@ -19,15 +19,14 @@
 #include "unicode/unistr.h"
 
 #include <limits.h>
-#include <pthread.h>
 #include <string.h>
 #include <time.h>
 
 #include <array>
+#include <atomic>
 #include <charconv>
 #include <chrono>
 #include <ctime>
-#include <functional>
 #include <map>
 #include <memory>
 #include <optional>
@@ -60,18 +59,6 @@ namespace libc {
 namespace time {
 
 namespace {
-
-// A simple scoped locker for pthread_mutex_t.
-class ScopedLocker {
- public:
-  explicit ScopedLocker(pthread_mutex_t* mutex) : mutex_(mutex) {
-    pthread_mutex_lock(mutex_);
-  }
-  ~ScopedLocker() { pthread_mutex_unlock(mutex_); }
-
- private:
-  pthread_mutex_t* mutex_;
-};
 
 // Number of seconds in an hour.
 constexpr int kSecondsInHour = 3600;
@@ -366,34 +353,31 @@ char TimeZoneState::std_name_buffer_[TZNAME_MAX + 1];
 char TimeZoneState::dst_name_buffer_[TZNAME_MAX + 1];
 
 TimeZoneState::TimeZoneState() {
-  pthread_mutex_init(&mutex_, nullptr);
+  EnsureTimeZoneIsCreated();
 }
 
-TimeZoneState::~TimeZoneState() {
-  pthread_mutex_destroy(&mutex_);
-}
+TimeZoneState::~TimeZoneState() = default;
 
-void TimeZoneState::WithTimeZone(
-    std::function<void(const icu::TimeZone&)> func) {
-  ScopedLocker lock(&mutex_);
-  EnsureTimeZoneIsCreatedLocked();
-  func(*current_zone_);
+std::shared_ptr<const icu::TimeZone> TimeZoneState::GetTimeZone() {
+  EnsureTimeZoneIsCreated();
+  return std::atomic_load(&current_zone_);
 }
 
 void TimeZoneState::GetPosixTimezoneGlobals(long& out_timezone,
                                             int& out_daylight,
                                             char** out_tzname) {
-  ScopedLocker lock(&mutex_);
-  EnsureTimeZoneIsCreatedLocked();
-  out_timezone = -(current_zone_->getRawOffset() / 1000);
-  out_daylight = current_zone_->useDaylightTime();
+  EnsureTimeZoneIsCreated();
+  auto tz = std::atomic_load(&current_zone_);
+  out_timezone = -(tz->getRawOffset() / 1000);
+  out_daylight = tz->useDaylightTime();
   SafeCopyToName(std_name_, std_name_buffer_, sizeof(std_name_buffer_));
   SafeCopyToName(dst_name_, dst_name_buffer_, sizeof(dst_name_buffer_));
   out_tzname[0] = std_name_buffer_;
   out_tzname[1] = dst_name_buffer_;
 }
 
-void TimeZoneState::SetTimeZoneFromIanaIdLocked(const std::string& tz_id) {
+std::unique_ptr<icu::TimeZone> TimeZoneState::CreateTimeZoneFromIanaId(
+    const std::string& tz_id) {
   // The Correction struct and kCorrections map are used to handle
   // inconsistencies or missing data in the underlying timezone database for
   // specific zones. This provides a manual override mechanism.
@@ -431,13 +415,14 @@ void TimeZoneState::SetTimeZoneFromIanaIdLocked(const std::string& tz_id) {
 
   icu::UnicodeString time_zone_id = icu::UnicodeString::fromUTF8(tz_id);
   auto* tz = icu::TimeZone::createTimeZone(time_zone_id);
+  std::unique_ptr<icu::TimeZone> new_zone;
 
   // If the provided ID is not recognized, fall back to UTC.
   if (!tz || *tz == icu::TimeZone::getUnknown()) {
     delete tz;
-    current_zone_.reset(icu::TimeZone::createTimeZone("UTC"));
+    new_zone.reset(icu::TimeZone::createTimeZone("UTC"));
   } else {
-    current_zone_.reset(tz);
+    new_zone.reset(tz);
   }
 
   // Check if there's a manual correction for this timezone ID.
@@ -447,7 +432,7 @@ void TimeZoneState::SetTimeZoneFromIanaIdLocked(const std::string& tz_id) {
     std_name_ = correction.std;
     dst_name_ = correction.dst;
 
-    int32_t corrected_raw_offset_ms = current_zone_->getRawOffset();
+    int32_t corrected_raw_offset_ms = new_zone->getRawOffset();
     if (correction.offset) {
       corrected_raw_offset_ms = -(*correction.offset * 1000);
     }
@@ -455,24 +440,25 @@ void TimeZoneState::SetTimeZoneFromIanaIdLocked(const std::string& tz_id) {
     // If DST is not active for this zone, create a SimpleTimeZone without DST
     // rules. Otherwise, apply the corrected offset.
     if (!correction.dst_active) {
-      current_zone_ = std::make_unique<icu::SimpleTimeZone>(
+      new_zone = std::make_unique<icu::SimpleTimeZone>(
           corrected_raw_offset_ms, icu::UnicodeString::fromUTF8(tz_id.c_str()));
     } else {
-      current_zone_->setRawOffset(corrected_raw_offset_ms);
+      new_zone->setRawOffset(corrected_raw_offset_ms);
     }
   } else {
     // If no correction is found, extract names directly from the ICU data.
-    std_name_ = ExtractZoneName(*current_zone_, false, std::nullopt);
-    if (current_zone_->useDaylightTime()) {
-      std::optional<UDate> last_dst_date = FindLastDateWithDst(*current_zone_);
-      dst_name_ = ExtractZoneName(*current_zone_, true, last_dst_date);
+    std_name_ = ExtractZoneName(*new_zone, false, std::nullopt);
+    if (new_zone->useDaylightTime()) {
+      std::optional<UDate> last_dst_date = FindLastDateWithDst(*new_zone);
+      dst_name_ = ExtractZoneName(*new_zone, true, last_dst_date);
     } else {
       dst_name_ = std_name_;
     }
   }
+  return new_zone;
 }
 
-void TimeZoneState::EnsureTimeZoneIsCreatedLocked() {
+void TimeZoneState::EnsureTimeZoneIsCreated() {
   // The TZ environment variable is the primary source for the timezone.
   // If it's not set, fall back to the system's default timezone name.
   const char* timezone_name = getenv("TZ");
@@ -482,36 +468,39 @@ void TimeZoneState::EnsureTimeZoneIsCreatedLocked() {
   // std::string cannot be constructed from nullptr.
   std::string tz_to_process(timezone_name ? timezone_name : "");
 
-  // An empty TZ variable explicitly means UTC.
-  if (tz_to_process.empty()) {
-    std_name_ = "UTC";
-    dst_name_ = "UTC";
-    current_zone_ = std::make_unique<icu::SimpleTimeZone>(
-        0, icu::UnicodeString::fromUTF8("UTC"));
-    icu::TimeZone::setDefault(*current_zone_);
-    return;
-  }
-
-  if (cached_timezone_name_ == tz_to_process) {
+  if (std::atomic_load(&current_zone_) &&
+      cached_timezone_name_ == tz_to_process) {
     // timezone name is set but did not change.
     return;
   }
 
-  // First, try to parse the string as a POSIX-style TZ string. This format
-  // includes rules for DST.
-  auto timezone_data = tz::ParsePosixTz(tz_to_process);
-  if (timezone_data) {
-    std_name_ = timezone_data->std;
-    dst_name_ = timezone_data->dst.value_or(timezone_data->std);
-    current_zone_ = CreateIcuTimezoneFromParsedData(*timezone_data);
+  std::unique_ptr<icu::TimeZone> new_zone;
+  // An empty TZ variable explicitly means UTC.
+  if (tz_to_process.empty()) {
+    std_name_ = "UTC";
+    dst_name_ = "UTC";
+    new_zone = std::make_unique<icu::SimpleTimeZone>(
+        0, icu::UnicodeString::fromUTF8("UTC"));
   } else {
-    // If it's not a POSIX TZ string, treat it as an IANA timezone ID (e.g.,
-    // "America/New_York").
-    SetTimeZoneFromIanaIdLocked(tz_to_process);
+    // First, try to parse the string as a POSIX-style TZ string. This format
+    // includes rules for DST.
+    auto timezone_data = tz::ParsePosixTz(tz_to_process);
+    if (timezone_data) {
+      std_name_ = timezone_data->std;
+      dst_name_ = timezone_data->dst.value_or(timezone_data->std);
+      new_zone = CreateIcuTimezoneFromParsedData(*timezone_data);
+    } else {
+      // If it's not a POSIX TZ string, treat it as an IANA timezone ID (e.g.,
+      // "America/New_York").
+      new_zone = CreateTimeZoneFromIanaId(tz_to_process);
+    }
   }
 
   // Set the processed timezone as the default for the entire application.
-  icu::TimeZone::setDefault(*current_zone_);
+  icu::TimeZone::setDefault(*new_zone);
+  std::atomic_store(&current_zone_,
+                    std::shared_ptr<const icu::TimeZone>(new_zone.release()));
+  cached_timezone_name_ = tz_to_process;
 }
 
 }  // namespace time

--- a/cobalt/common/libc/time/time_zone_state.h
+++ b/cobalt/common/libc/time/time_zone_state.h
@@ -15,8 +15,7 @@
 #ifndef COBALT_COMMON_LIBC_TIME_TIME_ZONE_STATE_H_
 #define COBALT_COMMON_LIBC_TIME_TIME_ZONE_STATE_H_
 
-#include <pthread.h>
-#include <functional>
+#include <atomic>
 #include <memory>
 #include <string>
 #include "unicode/timezone.h"
@@ -35,8 +34,8 @@ class TimeZoneState {
   TimeZoneState();
   ~TimeZoneState();
 
-  // Returns a reference to the currently active ICU timezone object.
-  void WithTimeZone(std::function<void(const icu::TimeZone&)> func);
+  // Returns the currently active ICU timezone object.
+  std::shared_ptr<const icu::TimeZone> GetTimeZone();
 
   // Calculates the values for the global C variables (timezone, daylight,
   // tzname).
@@ -47,18 +46,18 @@ class TimeZoneState {
  private:
   // Parses the TZ environment variable and updates the internal timezone.
   // If TZ is unset or invalid, it falls back to the system default or UTC.
-  void EnsureTimeZoneIsCreatedLocked();
+  void EnsureTimeZoneIsCreated();
 
   // Creates a timezone from a given IANA timezone ID (e.g.,
   // "America/Los_Angeles") and sets the relevant internal state.
-  void SetTimeZoneFromIanaIdLocked(const std::string& tz_id);
+  std::unique_ptr<icu::TimeZone> CreateTimeZoneFromIanaId(
+      const std::string& tz_id);
 
   // Cached values to avoid recalculation.
   std::string cached_timezone_name_;
-  std::unique_ptr<icu::TimeZone> current_zone_;
+  std::shared_ptr<const icu::TimeZone> current_zone_;
   std::string std_name_;
   std::string dst_name_;
-  pthread_mutex_t mutex_;
 
   // Static buffers for tzname to point to, managed by this class.
   // Note: This introduces a global state, but it is a necessary

--- a/cobalt/common/libc/time/time_zone_state_test.cc
+++ b/cobalt/common/libc/time/time_zone_state_test.cc
@@ -367,34 +367,33 @@ TEST_P(TimezoneStateParamTest, TimeZoneIsCorrect) {
   SetTimezone(param.tz.c_str());
 
   TimeZoneState state;
-  state.WithTimeZone([&](const icu::TimeZone& tz) {
-    EXPECT_EQ(param.offset * 1000, tz.getRawOffset());
-    EXPECT_EQ(param.dst_start.has_value(), tz.useDaylightTime());
+  std::shared_ptr<const icu::TimeZone> tz = state.GetTimeZone();
+  EXPECT_EQ(param.offset * 1000, tz->getRawOffset());
+  EXPECT_EQ(param.dst_start.has_value(), tz->useDaylightTime());
 
-    icu::UnicodeString id;
-    tz.getID(id);
-    EXPECT_EQ(param.id, ToString(id));
+  icu::UnicodeString id;
+  tz->getID(id);
+  EXPECT_EQ(param.id, ToString(id));
 
-    if (param.dst_start) {
-      EXPECT_EQ(kSecondsInHour * 1000, tz.getDSTSavings());
+  if (param.dst_start) {
+    EXPECT_EQ(kSecondsInHour * 1000, tz->getDSTSavings());
 
-      VerifyDateOffset(tz, *param.dst_start, param.offset + kSecondsInHour,
-                       "on daylight time start");
+    VerifyDateOffset(*tz, *param.dst_start, param.offset + kSecondsInHour,
+                     "on daylight time start");
 
-      VerifyDateOffset(tz, GetDayBefore(tz, *param.dst_start), param.offset,
-                       "before daylight time start");
+    VerifyDateOffset(*tz, GetDayBefore(*tz, *param.dst_start), param.offset,
+                     "before daylight time start");
 
-      VerifyDateOffset(tz, param.std_start, param.offset,
-                       "on standard time start");
+    VerifyDateOffset(*tz, param.std_start, param.offset,
+                     "on standard time start");
 
-      VerifyDateOffset(tz, GetDayBefore(tz, param.std_start),
-                       param.offset + kSecondsInHour,
-                       "before standard time start");
+    VerifyDateOffset(*tz, GetDayBefore(*tz, param.std_start),
+                     param.offset + kSecondsInHour,
+                     "before standard time start");
 
-    } else {
-      VerifyDateOffset(tz, param.std_start, param.offset, "standard time");
-    }
-  });
+  } else {
+    VerifyDateOffset(*tz, param.std_start, param.offset, "standard time");
+  }
 }
 
 TEST_P(TimezoneStateParamTest, PosixGlobalsAreCorrect) {


### PR DESCRIPTION
A pure virtual function call to `icu::TimeZone::getOffset` would occur when multiple threads tried to access timezone information simultaneously. This lead to a race condition where the `icu::TimeZone` object was not fully constructed before being used.

This was resolved by adding a mutex to `TimeZoneState` to ensure that the creation and access of the `icu::TimeZone` object is thread-safe. The `GetTimeZone()` method has been replaced with `WithTimeZone()` which executes a function within the mutex's protection.

Bug: 406083355
