### PR TITLE
starboard: Use different pthread_setname_np() on Apple platforms

### DIFF
--- a/starboard/nplb/posix_compliance/posix_thread_helpers.h
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.h
@@ -183,7 +183,11 @@ class AbstractTestThread {
 
  private:
   static void* ThreadEntryPoint(void* ptr) {
+#if defined(__APPLE__)
+    pthread_setname_np("AbstractTestThread");
+#else
     pthread_setname_np(pthread_self(), "AbstractTestThread");
+#endif
     AbstractTestThread* this_ptr = static_cast<AbstractTestThread*>(ptr);
     this_ptr->Run();
     return NULL;

--- a/starboard/shared/starboard/audio_sink/stub_audio_sink_type.cc
+++ b/starboard/shared/starboard/audio_sink/stub_audio_sink_type.cc
@@ -87,7 +87,11 @@ StubAudioSink::~StubAudioSink() {
 
 // static
 void* StubAudioSink::ThreadEntryPoint(void* context) {
+#if defined(__APPLE__)
+  pthread_setname_np("stub_audio_out");
+#else
   pthread_setname_np(pthread_self(), "stub_audio_out");
+#endif
   SbThreadSetPriority(kSbThreadPriorityRealTime);
 
   SB_DCHECK(context);

--- a/starboard/shared/starboard/player/job_thread.cc
+++ b/starboard/shared/starboard/player/job_thread.cc
@@ -76,7 +76,11 @@ void* JobThread::ThreadEntryPoint(void* context) {
   ThreadParam* param = static_cast<ThreadParam*>(context);
   SB_DCHECK(param);
 
+#if defined(__APPLE__)
+  pthread_setname_np(param->thread_name.c_str());
+#else
   pthread_setname_np(pthread_self(), param->thread_name.c_str());
+#endif
   SbThreadSetPriority(param->thread_priority);
 
   JobThread* job_thread = param->job_thread;

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -193,7 +193,11 @@ void PlayerWorker::UpdatePlayerError(SbPlayerError error,
 
 // static
 void* PlayerWorker::ThreadEntryPoint(void* context) {
+#if defined(__APPLE__)
+  pthread_setname_np("player_worker");
+#else
   pthread_setname_np(pthread_self(), "player_worker");
+#endif
   SbThreadSetPriority(kSbThreadPriorityHigh);
   ThreadParam* param = static_cast<ThreadParam*>(context);
   SB_DCHECK(param);

--- a/starboard/testing/fake_graphics_context_provider.cc
+++ b/starboard/testing/fake_graphics_context_provider.cc
@@ -170,7 +170,11 @@ void FakeGraphicsContextProvider::ReleaseDecodeTarget(
 
 // static
 void* FakeGraphicsContextProvider::ThreadEntryPoint(void* context) {
+#if defined(__APPLE__)
+  pthread_setname_np("dt_context");
+#else
   pthread_setname_np(pthread_self(), "dt_context");
+#endif
   auto provider = static_cast<FakeGraphicsContextProvider*>(context);
   provider->RunLoop();
 


### PR DESCRIPTION
`pthread_setname_np()` is not a portable function (that's what the "np" part stands for), and its signature differs between glibc/musl and Apple's libc (the latter takes 1 argument, the former takes 2).

Chromium abstracts this via base's PlatformThread class, but Starboard makes direct `pthread_setname_np()` calls that always assume the glibc/musl signature is being used.

Since in bug 432507888 it was mentioned that it is preferred not to ressurect `SbThreadSetName()`, add some `ifdef`s in code used by both Linux-based platforms and tvOS so that the right function signature is used depending on the build target.

Note that there are other occurrences in `//starboard`, but they are Linux-specific and have not been updated.

Bug: 432507888