### PR TITLE
Remove//ui/android:ui_no_recycler_view_java from cobalt/android/BUILD.gn

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -60,7 +60,6 @@ android_library("cobalt_main_java") {
     "//third_party/androidx:androidx_customview_customview_java",
     "//third_party/androidx:androidx_media_media_java",
     "//ui/android:ui_java",
-    "//ui/android:ui_no_recycler_view_java",
     "//url:gurl_java",
   ]
 
@@ -148,7 +147,6 @@ android_library("cobalt_apk_java") {
   deps = [
     ":cobalt_main_java",
     "//base:base_java",
-    "//ui/android:ui_no_recycler_view_java",
   ]
 
   sources = [

--- a/cobalt/android/apk/app/src/app/java/dev/cobalt/app/CobaltApplication.java
+++ b/cobalt/android/apk/app/src/app/java/dev/cobalt/app/CobaltApplication.java
@@ -22,7 +22,6 @@ import org.chromium.base.ContextUtils;
 import org.chromium.base.PathUtils;
 import org.chromium.base.library_loader.LibraryLoader;
 import org.chromium.base.library_loader.LibraryProcessType;
-import org.chromium.ui.base.ResourceBundle;
 
 /** Android Application hosting the Starboard application. */
 public class CobaltApplication extends Application implements StarboardBridge.HostApplication {
@@ -45,7 +44,6 @@ public class CobaltApplication extends Application implements StarboardBridge.Ho
       super.attachBaseContext(base);
       boolean isBrowserProcess = !ContextUtils.getProcessName().contains(":");
       ContextUtils.initApplicationContext(this);
-      ResourceBundle.setNoAvailableLocalePaks();
       LibraryLoader.getInstance().setLibraryProcessType(isBrowserProcess
                       ? LibraryProcessType.PROCESS_BROWSER
                       : LibraryProcessType.PROCESS_CHILD);


### PR DESCRIPTION
Remove //ui/android:ui_no_recycler_view_java dependency from cobalt/android/BUILD.gn.

Test: built Android and ran CUJs locally.
Bug: 442906112