### PR TITLE
[tvOS] Remove deprecated pkg_resources

### DIFF
--- a/build/mac_toolchain.py
+++ b/build/mac_toolchain.py
@@ -20,7 +20,7 @@ the full revision, e.g. 9A235.
 
 import argparse
 import os
-import pkg_resources
+from packaging import version
 import platform
 import plistlib
 import shutil
@@ -156,8 +156,8 @@ def InstallXcodeBinaries():
     current_license_plist = LoadPList(current_license_path)
     xcode_version = current_license_plist.get(
         'IDEXcodeVersionForAgreedToGMLicense')
-    if (xcode_version is not None and pkg_resources.parse_version(xcode_version)
-        >= pkg_resources.parse_version(cipd_xcode_version)):
+    if (xcode_version is not None and version.parse(xcode_version)
+        >= version.parse(cipd_xcode_version)):
       should_overwrite_license = False
 
   if not should_overwrite_license:


### PR DESCRIPTION
Bug: 442908995

`gclient runhooks` fails with `ModuleNotFoundError: No module named 'pkg_resources'`. Deprecated in most recent versions of python. Replace with working `packaging` in the mean time to unblock building with existing `mac_toolchain.py` before rebase.