### PR TITLE
cobalt: Force double buffering

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -75,6 +75,8 @@ public final class CommandLineOverrideHelper {
         paramOverrides.add("--disable-accelerated-video-encode");
         // Rasterize Tiles directly to GPU memory.
         paramOverrides.add("--enable-zero-copy");
+        // Force double buffering ISO triple or even deeper queueing.
+        paramOverrides.add("--double-buffer-compositing");
 
         return paramOverrides;
     }

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -18,6 +18,7 @@
 #include "base/files/file_path.h"
 #include "cobalt/browser/switches.h"
 #include "cobalt/shell/common/shell_switches.h"
+#include "components/viz/common/switches.h"
 #include "content/public/common/content_switches.h"
 #include "gpu/command_buffer/service/gpu_switches.h"
 #include "gpu/config/gpu_switches.h"
@@ -72,6 +73,8 @@ static constexpr auto kCobaltToggleSwitches = std::to_array<const char*>({
       // Cobalt doesn't use Chrome's accelerated video decoding/encoding.
       switches::kDisableAcceleratedVideoDecode,
       switches::kDisableAcceleratedVideoEncode,
+      // Force double buffering ISO triple or even deeper queueing.
+      switches::kDoubleBufferCompositing,
 });
 
 // Map of switches with parameters and their defaults.


### PR DESCRIPTION
WIP WIP

This CL forces double buffering in the Compositor's Buffer Queue, as
opposed to triple buffering (or even deeper in some high refresh rate
cases which we shouldn't hit). This should not have much effect on
Cobalt since there's not much scrolling, but it'll save a full frame
buffer allocation (1080p -> ~8MB fully packed RGBA).

Bug: TBD