### PR TITLE
[Demo] decouple UI and trim

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -46,6 +46,7 @@ android_library("cobalt_main_java") {
     "//cobalt/shell/android:cobalt_shell_java",
     "//cobalt/shell/android:cobalt_shell_java_resources",
     "//cobalt/shell/android:cobalt_shell_jni_headers",
+    "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java",
     "//components/version_info/android:version_constants_java",
     "//content/public/android:content_java",
     "//media/capture/video/android:capture_java",
@@ -59,7 +60,6 @@ android_library("cobalt_main_java") {
     "//third_party/androidx:androidx_core_core_java",
     "//third_party/androidx:androidx_customview_customview_java",
     "//third_party/androidx:androidx_media_media_java",
-    "//ui/android:ui_java",
     "//url:gurl_java",
   ]
 
@@ -218,13 +218,13 @@ android_apk("cobalt_apk") {
     ":cobalt_apk_java",
     "//cobalt/shell/android:cobalt_shell_assets",
     "//cobalt/shell/android:cobalt_shell_java",
+    "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java",
     "//components/metrics:metrics_java",
     "//content/public/android:content_java",
     "//media/capture/video/android:capture_java",
     "//net/android:net_java",
     "//services/shape_detection:shape_detection_java",
     "//third_party/mesa_headers",
-    "//ui/android:ui_java",
   ]
   shared_libraries = [ ":libchrobalt" ]
   include_size_info = is_official_build

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java
@@ -28,7 +28,7 @@ import java.lang.ref.WeakReference;
 import java.util.BitSet;
 import java.util.List;
 import org.chromium.content_public.browser.WebContents;
-import org.chromium.ui.base.ViewAndroidDelegate;
+import dev.cobalt.ui.base.ViewAndroidDelegate;
 
 /**
  * An ExploreByTouchHelper that create a virtual d-pad grid, so that Cobalt

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -59,8 +59,8 @@ import org.chromium.content_public.browser.BrowserStartupController;
 import org.chromium.content_public.browser.DeviceUtils;
 import org.chromium.content_public.browser.JavascriptInjector;
 import org.chromium.content_public.browser.WebContents;
-import org.chromium.ui.base.ActivityWindowAndroid;
-import org.chromium.ui.base.IntentRequestTracker;
+import dev.cobalt.ui.base.ActivityWindowAndroid;
+import dev.cobalt.ui.base.IntentRequestTracker;
 
 /** Native activity that has the required JNI methods called by the Starboard implementation. */
 public abstract class CobaltActivity extends Activity {

--- a/cobalt/shell/android/BUILD.gn
+++ b/cobalt/shell/android/BUILD.gn
@@ -72,15 +72,15 @@ android_library("cobalt_shell_java") {
     "//base:base_java",
     "//base:jni_java",
     "//build/android:build_java",
+    "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java",
     "//components/download/internal/common:internal_java",
-    "//components/viz/service:service_java",
+
+    #"//components/viz/service:service_java",
     "//content/public/android:content_java",
     "//media/base/android:media_java",
     "//media/capture/video/android:capture_java",
     "//mojo/public/java:system_java",
     "//net/android:net_java",
-    "//ui/android:ui_java",
-    "//ui/android:ui_no_recycler_view_java",
     "//ui/base/cursor/mojom:cursor_type_java",
     "//url:gurl_java",
   ]
@@ -118,12 +118,12 @@ android_library("cobalt_shell_test_apk_java") {
     "//base:base_java",
     "//base:process_launcher_java",
     "//build/android:build_java",
+    "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java",
     "//components/embedder_support/android:view_java",
     "//content/public/android:content_java",
     "//media/capture/video/android:capture_java",
     "//net/android:net_java",
     "//third_party/android_deps:com_google_code_findbugs_jsr305_java",
-    "//ui/android:ui_java",
     "//url:gurl_java",
   ]
 
@@ -163,6 +163,7 @@ template("cobalt_shell_apk_tmpl") {
       ":cobalt_shell_java",
       ":cobalt_shell_test_apk_java",
       "//base:base_java_test_support",
+      "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java",
       "//components/metrics:metrics_java",
       "//content/public/android:content_java",
       "//content/public/test/android:android_test_message_pump_support_java",
@@ -170,7 +171,6 @@ template("cobalt_shell_apk_tmpl") {
       "//net/android:net_java",
       "//services/shape_detection:shape_detection_java",
       "//third_party/mesa_headers",
-      "//ui/android:ui_java",
     ]
   }
 }
@@ -202,6 +202,7 @@ android_library("cobalt_shell_test_java") {
     ":cobalt_shell_test_apk_java",
     "//base:base_java",
     "//base:base_java_test_support",
+    "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java",
     "//content/public/android:content_java",
     "//content/public/test/android:content_java_test_support",
     "//mojo/public/java/system:test_support_java",
@@ -209,7 +210,6 @@ android_library("cobalt_shell_test_java") {
     "//third_party/androidx:androidx_test_runner_java",
     "//third_party/hamcrest:hamcrest_java",
     "//third_party/junit:junit",
-    "//ui/android:ui_java",
     "//url:gurl_java",
   ]
   sources = [
@@ -225,10 +225,10 @@ android_library("cobalt_shell_browsertests_java") {
   deps = [
     ":cobalt_shell_java",
     "//base:base_java",
+    "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java",
     "//content/public/android:content_java",
     "//testing/android/native_test:native_test_java",
     "//third_party/androidx:androidx_core_core_java",
-    "//ui/android:ui_java",
   ]
   sources = [ "browsertests/src/org/chromium/content_shell/browsertests/ContentShellBrowserTestActivity.java" ]
 }

--- a/cobalt/shell/android/browsertests/src/org/chromium/content_shell/browsertests/ContentShellBrowserTestActivity.java
+++ b/cobalt/shell/android/browsertests/src/org/chromium/content_shell/browsertests/ContentShellBrowserTestActivity.java
@@ -31,9 +31,9 @@ import org.chromium.content_public.browser.BrowserStartupController;
 import org.chromium.content_public.browser.BrowserStartupController.StartupCallback;
 import org.chromium.native_test.NativeBrowserTest;
 import org.chromium.native_test.NativeBrowserTestActivity;
-import org.chromium.ui.base.ActivityWindowAndroid;
-import org.chromium.ui.base.IntentRequestTracker;
-import org.chromium.ui.base.WindowAndroid;
+import dev.cobalt.ui.base.ActivityWindowAndroid;
+import dev.cobalt.ui.base.IntentRequestTracker;
+import dev.cobalt.ui.base.WindowAndroid;
 
 import java.io.File;
 

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
@@ -16,7 +16,7 @@ import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
 import org.chromium.content_public.browser.WebContents;
-import org.chromium.ui.base.WindowAndroid;
+import dev.cobalt.ui.base.WindowAndroid;
 
 /***
  * This view is used by a ContentView to render its content.

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/Shell.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/Shell.java
@@ -33,8 +33,8 @@ import org.chromium.content_public.browser.LoadUrlParams;
 import org.chromium.content_public.browser.NavigationController;
 import org.chromium.content_public.browser.SelectionPopupController;
 import org.chromium.content_public.browser.WebContents;
-import org.chromium.ui.base.ViewAndroidDelegate;
-import org.chromium.ui.base.WindowAndroid;
+import dev.cobalt.ui.base.ViewAndroidDelegate;
+import dev.cobalt.ui.base.WindowAndroid;
 
 /**
  *  Copied from org.chromium.content_shell.Shell.

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ShellManager.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ShellManager.java
@@ -20,7 +20,7 @@ import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
 import org.chromium.content_public.browser.WebContents;
-import org.chromium.ui.base.WindowAndroid;
+import dev.cobalt.ui.base.WindowAndroid;
 
 /**
  * Copied from org.chromium.content_shell.ShellManager.

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ShellViewAndroidDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ShellViewAndroidDelegate.java
@@ -16,7 +16,7 @@ package dev.cobalt.shell;
 
 import android.graphics.Bitmap;
 import android.view.ViewGroup;
-import org.chromium.ui.base.ViewAndroidDelegate;
+import dev.cobalt.ui.base.ViewAndroidDelegate;
 import org.chromium.ui.mojom.CursorType;
 
 /**

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/BUILD.gn
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/BUILD.gn
@@ -1,0 +1,76 @@
+import("//build/config/android/rules.gni")
+
+generate_jni("ui_android_jni_headers") {
+  sources = [
+    "base/ViewAndroidDelegate.java",
+    "widget/ToastManager.java",
+  ]
+}
+
+android_library("ui_view_java") {
+  sources = [
+    "KeyboardVisibilityDelegate.java",
+    "UiSwitches.java",
+    "base/ActivityIntentRequestTrackerDelegate.java",
+    "base/ActivityKeyboardVisibilityDelegate.java",
+    "base/ActivityWindowAndroid.java",
+    "base/ApplicationViewportInsetSupplier.java",
+    "base/ImmutableWeakReference.java",
+    "base/IntentRequestTracker.java",
+    "base/IntentRequestTrackerImpl.java",
+    "base/OverlayTransformApiHelper.java",
+    "base/ViewAndroidDelegate.java",
+    "base/ViewUtils.java",
+    "base/ViewportInsets.java",
+    "base/WindowAndroid.java",
+    "display/DisplayAndroid.java",
+    "display/DisplayAndroidManager.java",
+    "display/DisplaySwitches.java",
+    "display/PhysicalDisplayAndroid.java",
+    "dragdrop/AnimatedImageDragShadowBuilder.java",
+    "dragdrop/DragAndDropBrowserDelegate.java",
+    "dragdrop/DragAndDropDelegate.java",
+    "dragdrop/DragAndDropDelegateImpl.java",
+    "dragdrop/DragStateTracker.java",
+    "dragdrop/DropDataAndroid.java",
+    "dragdrop/DropDataProviderImpl.java",
+    "dragdrop/DropDataProviderUtils.java",
+    "modaldialog/DialogDismissalCause.java",
+    "modaldialog/ModalDialogManager.java",
+    "modaldialog/ModalDialogProperties.java",
+    "modaldialog/PendingDialogContainer.java",
+    "modelutil/PropertyKey.java",
+    "modelutil/PropertyModel.java",
+    "modelutil/PropertyObservable.java",
+    "permissions/ActivityAndroidPermissionDelegate.java",
+    "permissions/AndroidPermissionDelegate.java",
+    "permissions/AndroidPermissionDelegateWithRequester.java",
+    "permissions/PermissionCallback.java",
+    "permissions/PermissionConstants.java",
+    "permissions/PermissionPrefs.java",
+    "util/TokenHolder.java",
+    "widget/Toast.java",
+    "widget/ToastManager.java",
+    "widget/UiWidgetFactory.java",
+  ]
+
+  deps = [
+    ":ui_android_jni_headers",
+    "//base:base_java",
+    "//base:jni_java",
+    "//third_party/androidx:androidx_activity_activity_java",
+    "//third_party/androidx:androidx_annotation_annotation_experimental_java",
+    "//third_party/androidx:androidx_annotation_annotation_java",
+    "//third_party/androidx:androidx_appcompat_appcompat_java",
+    "//third_party/androidx:androidx_appcompat_appcompat_resources_java",
+    "//third_party/androidx:androidx_core_core_java",
+    "//ui/android:ui_java_resources",
+    "//ui/base/cursor/mojom:cursor_type_java",
+    "//ui/base/ime/mojom:mojom_java",
+    "//url:gurl_java",
+  ]
+
+  srcjar_deps = [ "//ui/android:java_enums_srcjar" ]
+  annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+  resources_package = "dev.cobalt.ui"
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/KeyboardVisibilityDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/KeyboardVisibilityDelegate.java
@@ -1,0 +1,228 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Rect;
+import android.os.Handler;
+import android.os.StrictMode;
+import android.view.View;
+import android.view.WindowInsets;
+import android.view.inputmethod.InputMethodManager;
+
+import org.chromium.base.Log;
+import org.chromium.base.ObserverList;
+import org.chromium.base.TraceEvent;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+/**
+ * A delegate that can be overridden to change the methods to figure out and change the current
+ * state of Android's soft keyboard.
+ */
+public class KeyboardVisibilityDelegate {
+    private static final String TAG = "KeyboardVisibility";
+
+    /** Number of retries after a failed attempt of bringing up the keyboard. */
+    private static final int KEYBOARD_RETRY_ATTEMPTS = 10;
+
+    /** Waiting time between attempts to show the keyboard. */
+    private static final long KEYBOARD_RETRY_DELAY_MS = 100;
+
+    /** The delegate to determine keyboard visibility. */
+    private static KeyboardVisibilityDelegate sInstance = new KeyboardVisibilityDelegate();
+
+    /**
+     * An interface to notify listeners of changes in the soft keyboard's visibility.
+     */
+    public interface KeyboardVisibilityListener {
+        /**
+         * Called whenever the keyboard might have changed.
+         * @param isShowing A boolean that's true if the keyboard is now visible.
+         */
+        void keyboardVisibilityChanged(boolean isShowing);
+    }
+    private final ObserverList<KeyboardVisibilityListener> mKeyboardVisibilityListeners =
+            new ObserverList<>();
+
+    protected void registerKeyboardVisibilityCallbacks() {}
+    protected void unregisterKeyboardVisibilityCallbacks() {}
+
+    /**
+     * Allows setting a new strategy to override the default {@link KeyboardVisibilityDelegate}.
+     * Caution while using it as it will take precedence over the currently set strategy.
+     * If two delegates are added, the newer one will try to handle any call. If it can't an older
+     * one is called. New delegates can call |method| of a predecessor with {@code super.|method|}.
+     * @param delegate A {@link KeyboardVisibilityDelegate} instance.
+     */
+    public static void setInstance(KeyboardVisibilityDelegate delegate) {
+        sInstance = delegate;
+    }
+
+    /**
+     * Prefer using {@link dev.cobalt.ui.base.WindowAndroid#getKeyboardDelegate()} over this
+     * method. Both return a delegate which allows checking and influencing the keyboard state.
+     * @return the global {@link KeyboardVisibilityDelegate}.
+     */
+    public static KeyboardVisibilityDelegate getInstance() {
+        return sInstance;
+    }
+
+    /**
+     * Only classes that override the delegate may instantiate it and set it using
+     * {@link #setInstance(KeyboardVisibilityDelegate)}.
+     */
+    protected KeyboardVisibilityDelegate() {}
+
+    /**
+     * Tries to show the soft keyboard by using the {@link Context#INPUT_METHOD_SERVICE}.
+     * @param view The currently focused {@link View}, which would receive soft keyboard input.
+     */
+    @SuppressLint("NewApi")
+    public void showKeyboard(View view) {
+        final Handler handler = new Handler();
+        final AtomicInteger attempt = new AtomicInteger();
+        Runnable openRunnable = new Runnable() {
+            @Override
+            public void run() {
+                // Not passing InputMethodManager.SHOW_IMPLICIT as it does not trigger the
+                // keyboard in landscape mode.
+                InputMethodManager imm = (InputMethodManager) view.getContext().getSystemService(
+                        Context.INPUT_METHOD_SERVICE);
+                // Third-party touches disk on showSoftInput call.
+                // http://crbug.com/619824, http://crbug.com/635118
+                StrictMode.ThreadPolicy oldPolicy = StrictMode.allowThreadDiskWrites();
+                try {
+                    imm.showSoftInput(view, 0);
+                } catch (IllegalArgumentException e) {
+                    if (attempt.incrementAndGet() <= KEYBOARD_RETRY_ATTEMPTS) {
+                        handler.postDelayed(this, KEYBOARD_RETRY_DELAY_MS);
+                    } else {
+                        Log.e(TAG, "Unable to open keyboard.  Giving up.", e);
+                    }
+                } finally {
+                    StrictMode.setThreadPolicy(oldPolicy);
+                }
+            }
+        };
+        openRunnable.run();
+    }
+
+    /**
+     * Hides the soft keyboard.
+     * @param view The {@link View} that is currently accepting input.
+     * @return Whether the keyboard was visible before.
+     */
+    public boolean hideKeyboard(View view) {
+        return hideAndroidSoftKeyboard(view);
+    }
+
+    /**
+     * Hides the soft keyboard by using the {@link Context#INPUT_METHOD_SERVICE}.
+     * This template method simplifies mocking and the access to the soft keyboard in subclasses.
+     * @param view The {@link View} that is currently accepting input.
+     * @return Whether the keyboard was visible before.
+     */
+    protected boolean hideAndroidSoftKeyboard(View view) {
+        InputMethodManager imm = (InputMethodManager) view.getContext().getSystemService(
+                Context.INPUT_METHOD_SERVICE);
+        return imm.hideSoftInputFromWindow(view.getWindowToken(), 0);
+    }
+
+    /**
+     * Calculates the keyboard height based on the bottom margin it causes for the given
+     * rootView. It is used to determine whether the keyboard is visible.
+     * @param rootView A {@link View}.
+     * @return The size of the bottom margin which most likely is exactly the keyboard size.
+     */
+    public int calculateKeyboardHeight(View rootView) {
+        try (TraceEvent te =
+                        TraceEvent.scoped("KeyboardVisibilityDelegate.calculateKeyboardHeight")) {
+            Rect appRect = new Rect();
+            rootView.getWindowVisibleDisplayFrame(appRect);
+
+            // Assume status bar is always at the top of the screen.
+            final int statusBarHeight = appRect.top;
+
+            int bottomMargin = rootView.getHeight() - (appRect.height() + statusBarHeight);
+
+            // If there is no bottom margin, the keyboard is not showing.
+            if (bottomMargin <= 0) return 0;
+            WindowInsets insets = rootView.getRootWindowInsets();
+            if (insets != null) { // Either not supported or the rootView isn't attached.
+                bottomMargin -= insets.getStableInsetBottom();
+            }
+
+            return bottomMargin; // This might include a bottom navigation.
+        }
+    }
+
+    /**
+     * Returns the total keyboard widget height.
+     *
+     * In addition to the keyboard itself, this may include accessory bars and related widgets that
+     * behave as-if they're part of the keyboard if the embedder supports them.
+     */
+    public int calculateTotalKeyboardHeight(View rootView) {
+        return calculateKeyboardHeight(rootView);
+    }
+
+    /**
+     * Returns whether the keyboard is showing.
+     * @param context A {@link Context} instance.
+     * @param view    A {@link View}.
+     * @return        Whether or not the software keyboard is visible.
+     */
+    public boolean isKeyboardShowing(Context context, View view) {
+        return isAndroidSoftKeyboardShowing(context, view);
+    }
+
+    /**
+     * Detects whether or not the keyboard is showing. This is a best guess based on the height
+     * of the keyboard as there is no standardized/foolproof way to do this.
+     * This template method simplifies mocking and the access to the soft keyboard in subclasses.
+     * @param context A {@link Context} instance.
+     * @param view    A {@link View}.
+     * @return        Whether or not the software keyboard is visible.
+     */
+    protected boolean isAndroidSoftKeyboardShowing(Context context, View view) {
+        View rootView = view.getRootView();
+        return rootView != null && calculateKeyboardHeight(rootView) > 0;
+    }
+
+    /**
+     * To be called when the keyboard visibility state might have changed. Informs listeners of the
+     * state change IFF there actually was a change.
+     * @param isShowing The current (guesstimated) state of the keyboard.
+     */
+    protected void notifyListeners(boolean isShowing) {
+        for (KeyboardVisibilityListener listener : mKeyboardVisibilityListeners) {
+            listener.keyboardVisibilityChanged(isShowing);
+        }
+    }
+
+    /**
+     * Adds a listener that is updated of keyboard visibility changes. This works as a best guess.
+     *
+     * @see dev.cobalt.ui.KeyboardVisibilityDelegate#isKeyboardShowing(Context, View)
+     */
+    public void addKeyboardVisibilityListener(KeyboardVisibilityListener listener) {
+        if (mKeyboardVisibilityListeners.isEmpty()) {
+            registerKeyboardVisibilityCallbacks();
+        }
+        mKeyboardVisibilityListeners.addObserver(listener);
+    }
+
+    /**
+     * @see #addKeyboardVisibilityListener(KeyboardVisibilityListener)
+     */
+    public void removeKeyboardVisibilityListener(KeyboardVisibilityListener listener) {
+        mKeyboardVisibilityListeners.removeObserver(listener);
+        if (mKeyboardVisibilityListeners.isEmpty()) {
+            unregisterKeyboardVisibilityCallbacks();
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/UiSwitches.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/UiSwitches.java
@@ -1,0 +1,18 @@
+// Copyright 2019 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui;
+
+/**
+ * Contains all of the command line switches that are specific to the ui/ portion of Chromium on
+ * Android.
+ */
+public abstract class UiSwitches {
+    // Enables the screenshot mode, which disables certain UI elements (e.g. dialogs) to facilitate
+    // more easily scripting screenshots of web content.
+    public static final String ENABLE_SCREENSHOT_UI_MODE = "enable-screenshot-ui-mode";
+
+    // Prevent instantiation.
+    private UiSwitches() {}
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/ActivityIntentRequestTrackerDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/ActivityIntentRequestTrackerDelegate.java
@@ -1,0 +1,68 @@
+// Copyright 2021 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import android.app.Activity;
+import android.content.ActivityNotFoundException;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.content.IntentSender.SendIntentException;
+
+import dev.cobalt.ui.base.IntentRequestTracker.Delegate;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Chrome's implementation of the delegate of a IntentRequestTracker.
+ */
+public class ActivityIntentRequestTrackerDelegate implements Delegate {
+    // Just create one ImmutableWeakReference object to avoid gc churn.
+    private final ImmutableWeakReference<Activity> mActivityWeakRefHolder;
+
+    /**
+     * Create an instance of delegate for the given activity that will own the IntentRequestTracker.
+     * @param activity The activity to own the IntentRequestTracker.
+     */
+    public ActivityIntentRequestTrackerDelegate(Activity activity) {
+        assert activity != null;
+        mActivityWeakRefHolder = new ImmutableWeakReference<>(activity);
+    }
+
+    @Override
+    public boolean startActivityForResult(Intent intent, int requestCode) {
+        Activity activity = mActivityWeakRefHolder.get();
+        if (activity == null) return false;
+        try {
+            activity.startActivityForResult(intent, requestCode);
+        } catch (ActivityNotFoundException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public boolean startIntentSenderForResult(IntentSender intentSender, int requestCode) {
+        Activity activity = mActivityWeakRefHolder.get();
+        if (activity == null) return false;
+        try {
+            activity.startIntentSenderForResult(intentSender, requestCode, new Intent(), 0, 0, 0);
+        } catch (SendIntentException e) {
+            return false;
+        }
+        return true;
+    }
+
+    @Override
+    public void finishActivity(int requestCode) {
+        Activity activity = mActivityWeakRefHolder.get();
+        if (activity == null) return;
+        activity.finishActivity(requestCode);
+    }
+
+    @Override
+    public final WeakReference<Activity> getActivity() {
+        return mActivityWeakRefHolder;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/ActivityKeyboardVisibilityDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/ActivityKeyboardVisibilityDelegate.java
@@ -1,0 +1,65 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import android.app.Activity;
+import android.view.View;
+
+import androidx.annotation.Nullable;
+
+import dev.cobalt.ui.KeyboardVisibilityDelegate;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * A {@link KeyboardVisibilityDelegate} that listens to a given activity for layout changes. It
+ * notifies {@link KeyboardVisibilityDelegate.KeyboardVisibilityListener} whenever the layout change
+ * is suspected to be caused by a keyboard.
+ */
+public class ActivityKeyboardVisibilityDelegate
+        extends KeyboardVisibilityDelegate implements View.OnLayoutChangeListener {
+    private boolean mIsKeyboardShowing;
+    private WeakReference<Activity> mActivity;
+
+    /**
+     * Creates a new delegate listening to the given activity. If the activity is destroyed, it will
+     * continue to work as a regular {@link KeyboardVisibilityDelegate}.
+     * @param activity A {@link WeakReference} to an {@link Activity}.
+     */
+    public ActivityKeyboardVisibilityDelegate(WeakReference<Activity> activity) {
+        mActivity = activity;
+    }
+
+    public @Nullable Activity getActivity() {
+        return mActivity.get();
+    }
+
+    @Override
+    public void registerKeyboardVisibilityCallbacks() {
+        Activity activity = getActivity();
+        if (activity == null) return;
+        View content = activity.findViewById(android.R.id.content);
+        mIsKeyboardShowing = isKeyboardShowing(activity, content);
+        content.addOnLayoutChangeListener(this);
+    }
+
+    @Override
+    public void unregisterKeyboardVisibilityCallbacks() {
+        Activity activity = getActivity();
+        if (activity == null) return;
+        activity.findViewById(android.R.id.content).removeOnLayoutChangeListener(this);
+    }
+
+    @Override
+    public void onLayoutChange(View v, int left, int top, int right, int bottom, int oldLeft,
+            int oldTop, int oldRight, int oldBottom) {
+        Activity activity = getActivity();
+        if (activity == null) return;
+        boolean isShowing = isKeyboardShowing(activity, v);
+        if (mIsKeyboardShowing == isShowing) return;
+        mIsKeyboardShowing = isShowing;
+        notifyListeners(isShowing);
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/ActivityWindowAndroid.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/ActivityWindowAndroid.java
@@ -1,0 +1,131 @@
+// Copyright 2013 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import android.app.Activity;
+import android.content.Context;
+
+import androidx.annotation.NonNull;
+
+import org.chromium.base.ActivityState;
+import org.chromium.base.ApplicationStatus;
+import org.chromium.base.ContextUtils;
+import dev.cobalt.ui.permissions.ActivityAndroidPermissionDelegate;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * The class provides the WindowAndroid's implementation which requires
+ * Activity Instance.
+ * Only instantiate this class when you need the implemented features.
+ */
+public class ActivityWindowAndroid
+        extends WindowAndroid implements ApplicationStatus.ActivityStateListener,
+                                         ApplicationStatus.WindowFocusChangedListener {
+    private final boolean mListenToActivityState;
+
+    // Just create one ImmutableWeakReference object to avoid gc churn.
+    private ImmutableWeakReference<Activity> mActivityWeakRefHolder;
+
+    /**
+     * Creates an Activity-specific WindowAndroid with associated intent functionality.
+     * @param context Context wrapping an activity associated with the WindowAndroid.
+     * @param listenToActivityState Whether to listen to activity state changes.
+     * @param intentRequestTracker The {@link IntentRequestTracker} of the current activity.
+     */
+    public ActivityWindowAndroid(Context context, boolean listenToActivityState,
+            IntentRequestTracker intentRequestTracker) {
+        this(context, listenToActivityState,
+                new ActivityAndroidPermissionDelegate(
+                        new WeakReference<Activity>(ContextUtils.activityFromContext(context))),
+                new ActivityKeyboardVisibilityDelegate(
+                        new WeakReference<Activity>(ContextUtils.activityFromContext(context))),
+                intentRequestTracker);
+    }
+
+    /**
+     * Creates an Activity-specific WindowAndroid with associated intent functionality.
+     * @param context Context wrapping an activity associated with the WindowAndroid.
+     * @param listenToActivityState Whether to listen to activity state changes.
+     * @param keyboardVisibilityDelegate Delegate which handles keyboard visibility.
+     * @param intentRequestTracker The {@link IntentRequestTracker} of the current activity.
+     */
+    public ActivityWindowAndroid(Context context, boolean listenToActivityState,
+            @NonNull ActivityKeyboardVisibilityDelegate keyboardVisibilityDelegate,
+            IntentRequestTracker intentRequestTracker) {
+        this(context, listenToActivityState,
+                new ActivityAndroidPermissionDelegate(
+                        new WeakReference<Activity>(ContextUtils.activityFromContext(context))),
+                keyboardVisibilityDelegate, intentRequestTracker);
+    }
+
+    /**
+     * Creates an Activity-specific WindowAndroid with associated intent functionality.
+     * @param context Context wrapping an activity associated with the WindowAndroid.
+     * @param listenToActivityState Whether to listen to activity state changes.
+     * @param activityAndroidPermissionDelegate Delegates which handles android permissions.
+     * @param intentRequestTracker The {@link IntentRequestTracker} of the current activity.
+     */
+    private ActivityWindowAndroid(Context context, boolean listenToActivityState,
+            ActivityAndroidPermissionDelegate activityAndroidPermissionDelegate,
+            ActivityKeyboardVisibilityDelegate activityKeyboardVisibilityDelegate,
+            IntentRequestTracker intentRequestTracker) {
+        super(context, intentRequestTracker);
+        Activity activity = ContextUtils.activityFromContext(context);
+        if (activity == null) {
+            throw new IllegalArgumentException("Context is not and does not wrap an Activity");
+        }
+        mListenToActivityState = listenToActivityState;
+        if (listenToActivityState) {
+            ApplicationStatus.registerStateListenerForActivity(this, activity);
+            ApplicationStatus.registerWindowFocusChangedListener(this);
+        }
+
+        setKeyboardDelegate(activityKeyboardVisibilityDelegate);
+        setAndroidPermissionDelegate(activityAndroidPermissionDelegate);
+    }
+
+    @Override
+    public ActivityKeyboardVisibilityDelegate getKeyboardDelegate() {
+        return (ActivityKeyboardVisibilityDelegate) super.getKeyboardDelegate();
+    }
+
+    @Override
+    public WeakReference<Activity> getActivity() {
+        if (mActivityWeakRefHolder == null) {
+            mActivityWeakRefHolder = new ImmutableWeakReference<>(
+                    ContextUtils.activityFromContext(getContext().get()));
+        }
+        return mActivityWeakRefHolder;
+    }
+
+    @Override
+    public void onActivityStateChange(Activity activity, int newState) {
+        if (newState == ActivityState.STOPPED) {
+            onActivityStopped();
+        } else if (newState == ActivityState.STARTED) {
+            onActivityStarted();
+        } else if (newState == ActivityState.PAUSED) {
+            onActivityPaused();
+        } else if (newState == ActivityState.RESUMED) {
+            onActivityResumed();
+        } else if (newState == ActivityState.DESTROYED) {
+            onActivityDestroyed();
+            ApplicationStatus.unregisterWindowFocusChangedListener(this);
+        }
+    }
+
+    @Override
+    @ActivityState
+    public int getActivityState() {
+        return mListenToActivityState ? ApplicationStatus.getStateForActivity(getActivity().get())
+                                      : super.getActivityState();
+    }
+
+    @Override
+    public void onWindowFocusChanged(Activity activity, boolean hasFocus) {
+        if (getActivity().get() == activity) onWindowFocusChanged(hasFocus);
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/ApplicationViewportInsetSupplier.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/ApplicationViewportInsetSupplier.java
@@ -1,0 +1,190 @@
+// Copyright 2020 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.Callback;
+import org.chromium.base.lifetime.Destroyable;
+import org.chromium.base.supplier.ObservableSupplier;
+import org.chromium.base.supplier.ObservableSupplierImpl;
+import org.chromium.ui.mojom.VirtualKeyboardMode;
+
+/**
+ * A class responsible for managing multiple users of UI insets over the application viewport.
+ *
+ * UI insets are complicated. The application viewport is provided by CompositorViewHolder but the
+ * browser provides various UI controls which overlay the viewport. How these UI controls interact
+ * with the underlying WebContents varies between controls and can depend on web-APIs.
+ *
+ * For example, browser controls cause the WebContents to resize so that the web page reflows in
+ * response to showing/hiding (although the timing of when this happens is non-straightforward). On
+ * the other hand, the virtual keyboard should resize only the page's visualViewport, without
+ * affecting layout. Chrome provides "keyboard accessories" that appear to the user to be part of
+ * the keyboard but are actually separate UI components. To make matters even more complicated, the
+ * page can change how the virtual keyboard affects the page (to affect page layout).
+ *
+ * This class aims to centralize and encapsulate all these complex interactions so clients don't
+ * have to worry about the details. This class currently handles only the keyboard and keyboard
+ * accessory but there are plans to move browser controls into here as well
+ * (https://crbug.com/1211066).
+ *
+ * Features needing to know if anything is obscuring part of the screen listen to this class via
+ * {@link #addObserver(Callback)} which observes changes to a {@link ViewportInsets} object which
+ * has various inset types clients can use. See that class for more detials about the inset types.
+ *
+ * In general:
+ *  - Features that want to modify the inset should pass around the {@link
+ *    ApplicationViewportInsetSupplier} object.
+ *  - Features only interested in what the current inset is should pass around an {@link
+ *    ObservableSupplier<ViewportInsets>} object.
+ */
+public class ApplicationViewportInsetSupplier
+        extends ObservableSupplierImpl<ViewportInsets> implements Destroyable {
+    /** Keyboard related suppliers */
+    private ObservableSupplier<Integer> mKeyboardInsetSupplier;
+    private ObservableSupplier<Integer> mKeyboardAccessoryInsetSupplier;
+
+    /** The observer that gets attached to all keyboard inset suppliers. */
+    private final Callback<Integer> mInsetSupplierObserver = (unused) -> computeInsets();
+
+    /**
+     * By default, the virtual keyboard overlays content, only resizing the visual viewport.
+     *
+     * Web content has APIs that change how the virtual keyboard interacts with content. This class
+     * needs to know which mode we're in to determine how different kinds of insets are computed.
+     */
+    @VirtualKeyboardMode.EnumType
+    private int mVirtualKeyboardMode = VirtualKeyboardMode.RESIZES_VISUAL;
+
+    /** Default constructor. */
+    ApplicationViewportInsetSupplier() {
+        super();
+        // Make sure this is initialized to 0 since "Integer" is an object and would be null
+        // otherwise.
+        super.set(new ViewportInsets());
+    }
+
+    @VisibleForTesting
+    public static ApplicationViewportInsetSupplier createForTests() {
+        return new ApplicationViewportInsetSupplier();
+    }
+
+    @Override
+    public void set(ViewportInsets value) {
+        throw new IllegalStateException(
+                "#set(...) should not be called directly on ApplicationViewportInsetSupplier.");
+    }
+
+    /** Clean up observers and suppliers. */
+    @Override
+    public void destroy() {
+        setKeyboardInsetSupplier(null);
+        setKeyboardAccessoryInsetSupplier(null);
+    }
+
+    /**
+     * Notifies this object when the VirtualKeyboardMode of the currently active WebContents is
+     * changed.
+     *
+     * This can happen as a result of a web content API call or swapping a WebContents or Tab.
+     */
+    public void setVirtualKeyboardMode(@VirtualKeyboardMode.EnumType int mode) {
+        if (mVirtualKeyboardMode == mode) return;
+
+        @VirtualKeyboardMode.EnumType
+        int oldMode = mVirtualKeyboardMode;
+        mVirtualKeyboardMode = mode;
+
+        computeInsets();
+    }
+
+    /**
+     * Sets the inset supplier for the soft keyboard itself.
+     *
+     * Pass null to unset the current supplier.
+     */
+    public void setKeyboardInsetSupplier(ObservableSupplier<Integer> insetSupplier) {
+        boolean didRemove = false;
+
+        if (mKeyboardInsetSupplier != null) {
+            mKeyboardInsetSupplier.removeObserver(mInsetSupplierObserver);
+            didRemove = true;
+        }
+
+        mKeyboardInsetSupplier = insetSupplier;
+
+        if (mKeyboardInsetSupplier != null) {
+            mKeyboardInsetSupplier.addObserver(mInsetSupplierObserver);
+        } else if (didRemove) {
+            // If a supplier was removed, removeObserver will not have notified observers (unlike
+            // addObserver) so make sure insets get recomputed in this case.
+            computeInsets();
+        }
+    }
+
+    /**
+     * Sets the inset supplier for the keyboard accessory.
+     *
+     * Pass null to unset the current supplier.
+     */
+    public void setKeyboardAccessoryInsetSupplier(ObservableSupplier<Integer> insetSupplier) {
+        boolean didRemove = false;
+        if (mKeyboardAccessoryInsetSupplier != null) {
+            mKeyboardAccessoryInsetSupplier.removeObserver(mInsetSupplierObserver);
+            didRemove = true;
+        }
+
+        mKeyboardAccessoryInsetSupplier = insetSupplier;
+
+        if (mKeyboardAccessoryInsetSupplier != null) {
+            mKeyboardAccessoryInsetSupplier.addObserver(mInsetSupplierObserver);
+        } else if (didRemove) {
+            // If a supplier was removed, removeObserver will not have notified observers (unlike
+            // addObserver) so make sure insets get recomputed in this case.
+            computeInsets();
+        }
+    }
+
+    /** Compute the new total inset based on all registered suppliers. */
+    private void computeInsets() {
+        ViewportInsets newValues = new ViewportInsets();
+
+        int keyboardInset = intFromSupplier(mKeyboardInsetSupplier);
+        int accessoryInset = intFromSupplier(mKeyboardAccessoryInsetSupplier);
+        int totalKeyboardInset = keyboardInset + accessoryInset;
+
+        newValues.viewVisibleHeightInset = accessoryInset;
+        newValues.visualViewportBottomInset =
+                mVirtualKeyboardMode == VirtualKeyboardMode.RESIZES_VISUAL ? totalKeyboardInset : 0;
+
+        // If the VirtualKeyboardMode is set to OVERLAYS_CONTENT or RESIZES_VISUAL, the
+        // WebContents size will not match the View size when the keyboard is showing (these
+        // modes mean "keyboard doesn't resize web content"). In that case, *outset* by the shown
+        // keyboard height to keep the WebContents from being resized.
+        boolean vkModeOutsetsWebContentsHeight =
+                mVirtualKeyboardMode == VirtualKeyboardMode.OVERLAYS_CONTENT
+                || mVirtualKeyboardMode == VirtualKeyboardMode.RESIZES_VISUAL;
+        int webContentsInset = 0;
+        if (vkModeOutsetsWebContentsHeight) {
+            // Avoid insetting by the accessory and outset by the keyboard to counter the View
+            // resize.
+            webContentsInset = -keyboardInset;
+        } else {
+            // The keyboard should cause the WebContents to resize. The keyboard itself is already
+            // accounted for in the View height so just add the accessory.
+            webContentsInset = accessoryInset;
+        }
+
+        newValues.webContentsHeightInset = webContentsInset;
+
+        super.set(newValues);
+    }
+
+    private int intFromSupplier(ObservableSupplier<Integer> supplier) {
+        if (supplier == null || supplier.get() == null) return 0;
+        return supplier.get();
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/ImmutableWeakReference.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/ImmutableWeakReference.java
@@ -1,0 +1,23 @@
+// Copyright 2020 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * A WeakReference sublcass that's immutable.
+ * This is so that it's safe to pass the same instance to multiple
+ * clients without worrying about modification.
+ */
+public class ImmutableWeakReference<T> extends WeakReference<T> {
+    public ImmutableWeakReference(T referent) {
+        super(referent);
+    }
+
+    @Override
+    public final void clear() {
+        throw new UnsupportedOperationException("clear WeakReference banned");
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/IntentRequestTracker.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/IntentRequestTracker.java
@@ -1,0 +1,105 @@
+// Copyright 2021 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.content.IntentSender;
+import android.os.Bundle;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * The interface for a helper class that keeps track of the intent requests for an Activity. Its
+ * implementation should be hidden in ui/base. No implementation should be made outside of ui/base.
+ */
+public interface IntentRequestTracker {
+    /**
+     * A delegate of this class's intent sending.
+     */
+    interface Delegate {
+        /**
+         * Starts an activity for the provided intent.
+         * @see Activity#startActivityForResult
+         */
+        boolean startActivityForResult(Intent intent, int requestCode);
+
+        /**
+         * Uses the provided intent sender to start the intent.
+         * @see Activity#startIntentSenderForResult
+         */
+        boolean startIntentSenderForResult(IntentSender intentSender, int requestCode);
+
+        /**
+         * Force finish an activity that you had previously started with startActivityForResult or
+         * startIntentSenderForResult.
+         * @param requestCode The request code returned from showCancelableIntent.
+         */
+        void finishActivity(int requestCode);
+
+        /**
+         * @return A reference to owning Activity.  The returned WeakReference will never be null,
+         *         but the contained Activity can be null (if it has been garbage collected). The
+         *         returned WeakReference is immutable and calling clear will throw an exception.
+         */
+        WeakReference<Activity> getActivity();
+
+        /**
+         * Invoked from {@link #onActivityResult} when an intent's callback is not found.
+         * @param error The error message that was set when "showing an intent" was requested.
+         * @return True if the error has been handled. Otherwise, the caller needs to handle the
+         *         unhandled error.
+         */
+        default boolean onCallbackNotFoundError(String error) {
+            return false;
+        }
+    }
+
+    /**
+     * Creates an instance of the class from a given delegate.
+     * @param delegate A delegate that will be responsible for intent sending.
+     * @return an instance of the class.
+     */
+    static IntentRequestTracker createFromDelegate(Delegate delegate) {
+        return new IntentRequestTrackerImpl(delegate);
+    }
+
+    /**
+     * Creates an instance of the class from a given activity. This is a pure convenience method to
+     * create with an ActivityIntentRequestTrackerDelegate. Clients that needs to customize the
+     * Delegate should use {@link #createFromDelegate} instead.
+     * @param activity The activity who will be used as the intent sender and whose intent requests
+     *        to be tracked.
+     * @return an instance of the class.
+     */
+    static IntentRequestTracker createFromActivity(Activity activity) {
+        return new IntentRequestTrackerImpl(new ActivityIntentRequestTrackerDelegate(activity));
+    }
+
+    /**
+     * Responds to the intent result.
+     * @param requestCode Request code of the requested intent.
+     * @param resultCode Result code of the requested intent.
+     * @param data The data returned by the intent.
+     * @return Boolean value of whether the intent.
+     */
+    boolean onActivityResult(int requestCode, int resultCode, Intent data);
+
+    WeakReference<Activity> getActivity();
+
+    /**
+     * Saves the error messages that should be shown if any pending intents would return
+     * after the application has been put onPause.
+     * @param bundle The bundle to save the information in onPause
+     */
+    void saveInstanceState(Bundle bundle);
+
+    /**
+     * Restores the error messages that should be shown if any pending intents would return
+     * after the application has been put onPause.
+     * @param bundle The bundle to restore the information from onResume
+     */
+    void restoreInstanceState(Bundle bundle);
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/IntentRequestTrackerImpl.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/IntentRequestTrackerImpl.java
@@ -1,0 +1,149 @@
+// Copyright 2021 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import static dev.cobalt.ui.base.WindowAndroid.START_INTENT_FAILURE;
+
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.content.Intent;
+import android.os.Bundle;
+import android.util.SparseArray;
+
+import org.chromium.base.Callback;
+import org.chromium.base.ContextUtils;
+import dev.cobalt.ui.base.WindowAndroid.IntentCallback;
+
+import java.lang.ref.WeakReference;
+import java.util.HashMap;
+
+/**
+ * The implementation of IntentRequestTracker.
+ */
+/* package */ final class IntentRequestTrackerImpl implements IntentRequestTracker {
+    // Constants used for intent request code bounding.
+    private static final int REQUEST_CODE_PREFIX = 1000;
+    private static final int REQUEST_CODE_RANGE_SIZE = 100;
+
+    private final SparseArray<IntentCallback> mOutstandingIntents;
+    private int mNextRequestCode;
+    private final Delegate mDelegate;
+
+    // Ideally, this would be a SparseArray<String>, but there's no easy way to store a
+    // SparseArray<String> in a bundle during saveInstanceState(). So we use a HashMap and suppress
+    // the Android lint warning "UseSparseArrays".
+    private HashMap<Integer, String> mIntentErrors;
+
+    /**
+     * Creates an instance of the class.
+     * @param delegate The delegate that wraps the activity that owns the tracker.
+     */
+    /* package */ IntentRequestTrackerImpl(Delegate delegate) {
+        mOutstandingIntents = new SparseArray<>();
+        mIntentErrors = new HashMap<>();
+        mDelegate = delegate;
+    }
+
+    /* package */ int showCancelableIntent(
+            PendingIntent intent, IntentCallback callback, Integer errorId) {
+        int requestCode = generateNextRequestCode();
+
+        if (!mDelegate.startIntentSenderForResult(intent.getIntentSender(), requestCode)) {
+            return START_INTENT_FAILURE;
+        }
+
+        storeCallbackData(requestCode, callback, errorId);
+        return requestCode;
+    }
+
+    /* package */ int showCancelableIntent(
+            Intent intent, IntentCallback callback, Integer errorId) {
+        int requestCode = generateNextRequestCode();
+
+        if (!mDelegate.startActivityForResult(intent, requestCode)) {
+            return START_INTENT_FAILURE;
+        }
+
+        storeCallbackData(requestCode, callback, errorId);
+        return requestCode;
+    }
+
+    /* package */ int showCancelableIntent(
+            Callback<Integer> intentTrigger, IntentCallback callback, Integer errorId) {
+        int requestCode = generateNextRequestCode();
+
+        intentTrigger.onResult(requestCode);
+
+        storeCallbackData(requestCode, callback, errorId);
+        return requestCode;
+    }
+
+    /* package */ void cancelIntent(int requestCode) {
+        mDelegate.finishActivity(requestCode);
+    }
+
+    /* package */ boolean removeIntentCallback(IntentCallback callback) {
+        int requestCode = getOutstandingIntents().indexOfValue(callback);
+        if (requestCode < 0) return false;
+        getOutstandingIntents().remove(requestCode);
+        mIntentErrors.remove(requestCode);
+        return true;
+    }
+
+    @Override
+    public boolean onActivityResult(int requestCode, int resultCode, Intent data) {
+        IntentCallback callback = getOutstandingIntents().get(requestCode);
+        getOutstandingIntents().delete(requestCode);
+        String errorMessage = mIntentErrors.remove(requestCode);
+
+        if (callback != null) {
+            callback.onIntentCompleted(resultCode, data);
+            return true;
+        } else {
+            if (errorMessage != null && !mDelegate.onCallbackNotFoundError(errorMessage)) {
+                WindowAndroid.showError(errorMessage);
+            }
+        }
+        return false;
+    }
+
+    @Override
+    public WeakReference<Activity> getActivity() {
+        return mDelegate.getActivity();
+    }
+
+    @Override
+    public void saveInstanceState(Bundle bundle) {
+        bundle.putSerializable(WindowAndroid.WINDOW_CALLBACK_ERRORS, mIntentErrors);
+    }
+
+    @Override
+    public void restoreInstanceState(Bundle bundle) {
+        if (bundle == null) return;
+
+        Object errors = bundle.getSerializable(WindowAndroid.WINDOW_CALLBACK_ERRORS);
+        if (errors instanceof HashMap) {
+            @SuppressWarnings("unchecked")
+            HashMap<Integer, String> intentErrors = (HashMap<Integer, String>) errors;
+            mIntentErrors = intentErrors;
+        }
+    }
+
+    private int generateNextRequestCode() {
+        int requestCode = REQUEST_CODE_PREFIX + mNextRequestCode;
+        mNextRequestCode = (mNextRequestCode + 1) % REQUEST_CODE_RANGE_SIZE;
+        return requestCode;
+    }
+
+    private void storeCallbackData(int requestCode, IntentCallback callback, Integer errorId) {
+        mOutstandingIntents.put(requestCode, callback);
+        mIntentErrors.put(requestCode,
+                errorId == null ? null : ContextUtils.getApplicationContext().getString(errorId));
+    }
+
+    private SparseArray<IntentCallback> getOutstandingIntents() {
+        return mOutstandingIntents;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/OverlayTransformApiHelper.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/OverlayTransformApiHelper.java
@@ -1,0 +1,157 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
+import android.view.AttachedSurfaceControl;
+import android.view.FrameMetrics;
+import android.view.SurfaceControl;
+import android.view.Window;
+
+import androidx.annotation.RequiresApi;
+
+import org.chromium.ui.gfx.OverlayTransform;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * Helper class to avoid fail of ART's class verification for S_V2 APIs in old device.
+ */
+@RequiresApi(Build.VERSION_CODES.S_V2)
+final class OverlayTransformApiHelper
+        implements AttachedSurfaceControl.OnBufferTransformHintChangedListener,
+                   Window.OnFrameMetricsAvailableListener {
+    private final WindowAndroid mWindowAndroid;
+    private final WeakReference<Window> mWindow;
+    private boolean mBufferTransformListenerAdded;
+    private boolean mFrameMetricsListenerAdded;
+
+    static OverlayTransformApiHelper create(WindowAndroid windowAndroid) {
+        if (windowAndroid.getWindow() == null) return null;
+        return new OverlayTransformApiHelper(windowAndroid);
+    }
+
+    private OverlayTransformApiHelper(WindowAndroid windowAndroid) {
+        mWindowAndroid = windowAndroid;
+        mWindow = new WeakReference<>(mWindowAndroid.getWindow());
+        addOnBufferTransformHintChangedListener();
+    }
+
+    void destroy() {
+        removeOnFrameMetricsAvailableListener();
+        removeOnBufferTransformHintChangedListener();
+    }
+
+    private void addOnBufferTransformHintChangedListener() {
+        Window window = mWindow.get();
+        if (window == null) return;
+        AttachedSurfaceControl surfacecontrol = window.getRootSurfaceControl();
+        if (surfacecontrol == null) {
+            // If AttachedSurfaceControl is not available yet, wait until it's ready and set the
+            // listener.
+            addOnFrameMetricsAvailableListener();
+        } else {
+            doAddOnBufferTransformHintChangedListener();
+        }
+    }
+
+    @Override
+    public void onBufferTransformHintChanged(int hint) {
+        mWindowAndroid.onOverlayTransformUpdated();
+    }
+
+    private void doAddOnBufferTransformHintChangedListener() {
+        if (mBufferTransformListenerAdded) return;
+        Window window = mWindow.get();
+        if (window == null) return;
+        AttachedSurfaceControl surfacecontrol = window.getRootSurfaceControl();
+        if (surfacecontrol != null) {
+            surfacecontrol.addOnBufferTransformHintChangedListener(this);
+            mBufferTransformListenerAdded = true;
+        }
+    }
+
+    private void removeOnBufferTransformHintChangedListener() {
+        if (!mBufferTransformListenerAdded) return;
+
+        Window window = mWindow.get();
+        if (window == null) return;
+        AttachedSurfaceControl surfacecontrol = window.getRootSurfaceControl();
+        if (surfacecontrol != null) {
+            surfacecontrol.removeOnBufferTransformHintChangedListener(this);
+            mBufferTransformListenerAdded = false;
+        }
+    }
+
+    @Override
+    public void onFrameMetricsAvailable(Window window, FrameMetrics frameMetrics, int dropCount) {
+        // AttachedSurfaceControl is available after setContentView is called and 1st draw happen.
+        AttachedSurfaceControl surfaceControl = window.getRootSurfaceControl();
+        if (surfaceControl != null) {
+            removeOnFrameMetricsAvailableListener();
+            doAddOnBufferTransformHintChangedListener();
+        }
+    }
+
+    private void addOnFrameMetricsAvailableListener() {
+        if (mFrameMetricsListenerAdded) return;
+        Window window = mWindow.get();
+        if (window == null) return;
+        window.addOnFrameMetricsAvailableListener(this, new Handler(Looper.myLooper()));
+        mFrameMetricsListenerAdded = true;
+    }
+
+    private void removeOnFrameMetricsAvailableListener() {
+        if (!mFrameMetricsListenerAdded) return;
+        Window window = mWindow.get();
+        if (window == null) return;
+        window.removeOnFrameMetricsAvailableListener(this);
+        mFrameMetricsListenerAdded = false;
+    }
+
+    @OverlayTransform
+    int getOverlayTransform() {
+        Window window = mWindow.get();
+        if (window == null) return OverlayTransform.INVALID;
+        AttachedSurfaceControl surfacecontrol = window.getRootSurfaceControl();
+        if (surfacecontrol == null) {
+            return OverlayTransform.INVALID;
+        }
+        int bufferTransform;
+        try {
+            bufferTransform = surfacecontrol.getBufferTransformHint();
+        } catch (NullPointerException e) {
+            // Can throw exception from implementation of getBufferTransformHint.
+            // See crbug.com/1358898.
+            return OverlayTransform.INVALID;
+        }
+        return toOverlayTransform(bufferTransform);
+    }
+
+    private static @OverlayTransform int toOverlayTransform(int bufferTransform) {
+        switch (bufferTransform) {
+            case SurfaceControl.BUFFER_TRANSFORM_IDENTITY:
+                return OverlayTransform.NONE;
+            case SurfaceControl.BUFFER_TRANSFORM_MIRROR_HORIZONTAL:
+                return OverlayTransform.FLIP_HORIZONTAL;
+            case SurfaceControl.BUFFER_TRANSFORM_MIRROR_VERTICAL:
+                return OverlayTransform.FLIP_VERTICAL;
+            case SurfaceControl.BUFFER_TRANSFORM_ROTATE_90:
+                return OverlayTransform.ROTATE_90;
+            case SurfaceControl.BUFFER_TRANSFORM_ROTATE_180:
+                return OverlayTransform.ROTATE_180;
+            case SurfaceControl.BUFFER_TRANSFORM_ROTATE_270:
+                return OverlayTransform.ROTATE_270;
+            // Combination cases between BUFFER_TRANSFORM_MIRROR_HORIZONTAL,
+            // BUFFER_TRANSFORM_MIRROR_VERTICAL, BUFFER_TRANSFORM_ROTATE_90 are not handled
+            // because expected behavior is under-specified by android APIs
+            default:
+                // INVALID makes WindowAndroid fallback to display rotation
+                return OverlayTransform.INVALID;
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/ViewAndroidDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/ViewAndroidDelegate.java
@@ -1,0 +1,623 @@
+// Copyright 2012 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import android.content.ClipData;
+import android.graphics.Bitmap;
+import android.os.Bundle;
+import android.view.MotionEvent;
+import android.view.PointerIcon;
+import android.view.View;
+import android.view.View.DragShadowBuilder;
+import android.view.ViewGroup;
+import android.view.ViewGroup.MarginLayoutParams;
+import android.view.inputmethod.InputConnection;
+
+import androidx.annotation.CallSuper;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.core.view.MarginLayoutParamsCompat;
+
+import org.chromium.base.ObserverList;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import dev.cobalt.ui.dragdrop.DragAndDropDelegate;
+import dev.cobalt.ui.dragdrop.DragAndDropDelegateImpl;
+import dev.cobalt.ui.dragdrop.DragStateTracker;
+import dev.cobalt.ui.dragdrop.DropDataAndroid;
+import org.chromium.ui.mojom.CursorType;
+
+/**
+ * Class to acquire, position, and remove anchor views from the implementing View.
+ */
+@JNINamespace("ui")
+public class ViewAndroidDelegate {
+    private static DragAndDropDelegate sDragAndDropTestDelegate;
+    private final DragAndDropDelegateImpl mDragAndDropDelegateImpl;
+
+    /**
+     * The current container view. This view can be updated with
+     * {@link #setContainerView()}.
+     */
+    protected ViewGroup mContainerView;
+
+    // Temporary storage for use as a parameter of getLocationOnScreen().
+    private int[] mTemporaryContainerLocation = new int[2];
+
+    /**
+     * Notifies the observer when container view is updated.
+     */
+    public interface ContainerViewObserver { void onUpdateContainerView(ViewGroup view); }
+
+    private ObserverList<ContainerViewObserver> mContainerViewObservers = new ObserverList<>();
+
+    /**
+     * Notifies the listener of vertical scroll direction changes.
+     */
+    public interface VerticalScrollDirectionChangeListener {
+        /**
+         * Called when the vertical scroll direction changes.
+         * @param directionUp Whether the scroll direction is up, i.e. swiping down.
+         * @param currentScrollRatio The current scroll ratio of the page.
+         */
+        void onVerticalScrollDirectionChanged(boolean directionUp, float currentScrollRatio);
+    }
+
+    private final ObserverList<VerticalScrollDirectionChangeListener>
+            mVerticalScrollDirectionChangeListeners = new ObserverList<>();
+
+    /**
+     * Handles cursor updates for stylus writing.
+     */
+    public interface StylusWritingCursorHandler {
+        /**
+         * @param currentView the current view to set the cursor.
+         * @return true if cursor update was handled.
+         */
+        boolean didHandleCursorUpdate(View currentView);
+
+        /**
+         * Notify that stylus writing icon is removed and not shown.
+         */
+        default void notifyStylusWritingCursorRemoved() {}
+    }
+
+    private StylusWritingCursorHandler mStylusWritingCursorHandler;
+
+    // Cache the last Pointer Icon calculated for cursor type received from blink. Pointer is reset
+    // to this icon when once cursor stops being overridden.
+    private PointerIcon mPointerIconForLastCursor;
+
+    // Whether the cursor received from blink has been overridden to set specific cursor.
+    // Ex: Stylus writing cursor.
+    private boolean mCursorOverridden;
+
+    /**
+     * Sets a handler to handle the stylus writing cursor updates.
+     *
+     * @param handler the handler object.
+     */
+    public void setStylusWritingCursorHandler(StylusWritingCursorHandler handler) {
+        mStylusWritingCursorHandler = handler;
+    }
+
+    /**
+     * Create and return a basic implementation of {@link ViewAndroidDelegate}.
+     * @param containerView {@link ViewGroup} to be used as a container view.
+     * @return a new instance of {@link ViewAndroidDelegate}.
+     */
+    public static ViewAndroidDelegate createBasicDelegate(ViewGroup containerView) {
+        return new ViewAndroidDelegate(containerView);
+    }
+
+    protected ViewAndroidDelegate(ViewGroup containerView) {
+        mContainerView = containerView;
+        mDragAndDropDelegateImpl = new DragAndDropDelegateImpl();
+    }
+
+    /**
+     * Adds observer that needs notification when container view is updated. Note that
+     * there is no {@code removObserver} since the added observers are all supposed to
+     * go away with this object together.
+     * @param observer {@link ContainerViewObserver} object. The object should have
+     *        the lifetime same as this {@link ViewAndroidDelegate} to avoid gc issues.
+     */
+    public final void addObserver(ContainerViewObserver observer) {
+        mContainerViewObservers.addObserver(observer);
+    }
+
+    /** Adds the provided {@link VerticalScrollDirectionChangeListener}. */
+    public final void addVerticalScrollDirectionChangeListener(
+            VerticalScrollDirectionChangeListener listener) {
+        mVerticalScrollDirectionChangeListeners.addObserver(listener);
+    }
+
+    /** Removes the provided {@link VerticalScrollDirectionChangeListener}. */
+    public final void removeVerticalScrollDirectionChangeListener(
+            VerticalScrollDirectionChangeListener listener) {
+        mVerticalScrollDirectionChangeListeners.removeObserver(listener);
+    }
+
+    /**
+     * Updates the current container view to which this class delegates.
+     *
+     * <p>WARNING: This method can also be used to replace the existing container view,
+     * but you should only do it if you have a very good reason to. Replacing the
+     * container view has been designed to support fullscreen in the Webview so it
+     * might not be appropriate for other use cases.
+     *
+     * <p>This method only performs a small part of replacing the container view and
+     * embedders are responsible for:
+     * <ul>
+     *     <li>Disconnecting the old container view from all the references</li>
+     *     <li>Updating the InternalAccessDelegate</li>
+     *     <li>Reconciling the state with the new container view</li>
+     *     <li>Tearing down and recreating the native GL rendering where appropriate</li>
+     *     <li>etc.</li>
+     * </ul>
+     */
+    public final void setContainerView(ViewGroup containerView) {
+        ViewGroup oldContainerView = mContainerView;
+        mContainerView = containerView;
+        updateAnchorViews(oldContainerView);
+        for (ContainerViewObserver observer : mContainerViewObservers) {
+            observer.onUpdateContainerView(containerView);
+        }
+    }
+
+    protected DragAndDropDelegate getDragAndDropDelegate() {
+        return sDragAndDropTestDelegate != null ? sDragAndDropTestDelegate
+                                                : mDragAndDropDelegateImpl;
+    }
+
+    /**
+     * Get the tracker that records the drag event on the view this delegate attached to. Will
+     * return null if there's no {@link DragStateTracker} set up.
+     */
+    public @Nullable DragStateTracker getDragStateTracker() {
+        return null;
+    }
+
+    /** Return the {@link DragAndDropDelegateImpl} instance for this delegate class. */
+    protected DragStateTracker getDragStateTrackerInternal() {
+        return mDragAndDropDelegateImpl;
+    }
+
+    /**
+     * Transfer existing anchor views from the old to the new container view. Called by
+     * {@link setContainerView} only.
+     * @param oldContainerView Old container view just replaced by a new one.
+     */
+    public void updateAnchorViews(ViewGroup oldContainerView) {}
+
+    /**
+     * @return An anchor view that can be used to anchor decoration views like Autofill popup.
+     */
+    @CalledByNative
+    public View acquireView() {
+        ViewGroup containerView = getContainerViewGroup();
+        if (containerView == null || containerView.getParent() == null) return null;
+        View anchorView = new View(containerView.getContext());
+        containerView.addView(anchorView);
+        return anchorView;
+    }
+
+    /**
+     * Release given anchor view.
+     * @param anchorView The anchor view that needs to be released.
+     */
+    @CalledByNative
+    public void removeView(View anchorView) {
+        ViewGroup containerView = getContainerViewGroup();
+        if (containerView == null) return;
+        containerView.removeView(anchorView);
+    }
+
+    /**
+     * Set the anchor view to specified position and size (all units in px).
+     * @param anchorView The view that needs to be positioned. This must be the result of a previous
+     *         call to {@link acquireView} which has not yet been removed via {@link removeView}.
+     * @param x X coordinate of the top left corner of the anchor view.
+     * @param y Y coordinate of the top left corner of the anchor view.
+     * @param width The width of the anchor view.
+     * @param height The height of the anchor view.
+     */
+    @CalledByNative
+    public void setViewPosition(View anchorView, float x, float y, float width, float height,
+            int leftMargin, int topMargin) {
+        ViewGroup containerView = getContainerViewGroup();
+        if (containerView == null) return;
+        assert anchorView.getParent() == containerView;
+
+        int widthInt = Math.round(width);
+        int heightInt = Math.round(height);
+        int startMargin;
+
+        if (containerView.getLayoutDirection() == View.LAYOUT_DIRECTION_RTL) {
+            startMargin = containerView.getMeasuredWidth() - Math.round(width + x);
+        } else {
+            startMargin = leftMargin;
+        }
+        if (widthInt + startMargin > containerView.getWidth()) {
+            widthInt = containerView.getWidth() - startMargin;
+        }
+        MarginLayoutParams mlp = (MarginLayoutParams) anchorView.getLayoutParams();
+        mlp.width = widthInt;
+        mlp.height = heightInt;
+        MarginLayoutParamsCompat.setMarginStart(mlp, startMargin);
+        mlp.topMargin = topMargin;
+        anchorView.setLayoutParams(mlp);
+    }
+
+    /**
+     * Start {@link View#startDragAndDrop(ClipData, DragShadowBuilder, Object, int)} with
+     * {@link DropDataAndroid} from the web content.
+     *
+     * @param shadowImage The shadow image for the dragged object.
+     * @param dropData The drop data presenting the drag target.
+     * @param cursorOffsetX The x offset of the cursor w.r.t. to top-left corner of the drag-image.
+     * @param cursorOffsetY The y offset of the cursor w.r.t. to top-left corner of the drag-image.
+     * @param dragObjRectWidth The width of the drag object.
+     * @param dragObjRectHeight The height of the drag object.
+     */
+    @CalledByNative
+    private boolean startDragAndDrop(Bitmap shadowImage, DropDataAndroid dropData,
+            int cursorOffsetX, int cursorOffsetY, int dragObjRectWidth, int dragObjRectHeight) {
+        ViewGroup containerView = getContainerViewGroup();
+        if (containerView == null) return false;
+
+        return getDragAndDropDelegate().startDragAndDrop(containerView, shadowImage, dropData,
+                cursorOffsetX, cursorOffsetY, dragObjRectWidth, dragObjRectHeight);
+    }
+
+    @VisibleForTesting
+    @CalledByNative
+    public void onCursorChangedToCustom(Bitmap customCursorBitmap, int hotspotX, int hotspotY) {
+        PointerIcon icon = PointerIcon.create(customCursorBitmap, hotspotX, hotspotY);
+        mPointerIconForLastCursor = icon;
+        if (mCursorOverridden) return;
+
+        getContainerViewGroup().setPointerIcon(icon);
+    }
+
+    @VisibleForTesting
+    @CalledByNative
+    public void onCursorChanged(int cursorType) {
+        int pointerIconType = PointerIcon.TYPE_ARROW;
+        switch (cursorType) {
+            case CursorType.NONE:
+                pointerIconType = PointerIcon.TYPE_NULL;
+                break;
+            case CursorType.POINTER:
+                pointerIconType = PointerIcon.TYPE_ARROW;
+                break;
+            case CursorType.CONTEXT_MENU:
+                pointerIconType = PointerIcon.TYPE_CONTEXT_MENU;
+                break;
+            case CursorType.HAND:
+                pointerIconType = PointerIcon.TYPE_HAND;
+                break;
+            case CursorType.HELP:
+                pointerIconType = PointerIcon.TYPE_HELP;
+                break;
+            case CursorType.WAIT:
+                pointerIconType = PointerIcon.TYPE_WAIT;
+                break;
+            case CursorType.CELL:
+                pointerIconType = PointerIcon.TYPE_CELL;
+                break;
+            case CursorType.CROSS:
+                pointerIconType = PointerIcon.TYPE_CROSSHAIR;
+                break;
+            case CursorType.I_BEAM:
+                pointerIconType = PointerIcon.TYPE_TEXT;
+                break;
+            case CursorType.VERTICAL_TEXT:
+                pointerIconType = PointerIcon.TYPE_VERTICAL_TEXT;
+                break;
+            case CursorType.ALIAS:
+                pointerIconType = PointerIcon.TYPE_ALIAS;
+                break;
+            case CursorType.COPY:
+                pointerIconType = PointerIcon.TYPE_COPY;
+                break;
+            case CursorType.NO_DROP:
+                pointerIconType = PointerIcon.TYPE_NO_DROP;
+                break;
+            case CursorType.COLUMN_RESIZE:
+                pointerIconType = PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW;
+                break;
+            case CursorType.ROW_RESIZE:
+                pointerIconType = PointerIcon.TYPE_VERTICAL_DOUBLE_ARROW;
+                break;
+            case CursorType.NORTH_EAST_SOUTH_WEST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_TOP_RIGHT_DIAGONAL_DOUBLE_ARROW;
+                break;
+            case CursorType.NORTH_WEST_SOUTH_EAST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_TOP_LEFT_DIAGONAL_DOUBLE_ARROW;
+                break;
+            case CursorType.ZOOM_IN:
+                pointerIconType = PointerIcon.TYPE_ZOOM_IN;
+                break;
+            case CursorType.ZOOM_OUT:
+                pointerIconType = PointerIcon.TYPE_ZOOM_OUT;
+                break;
+            case CursorType.GRAB:
+                pointerIconType = PointerIcon.TYPE_GRAB;
+                break;
+            case CursorType.GRABBING:
+                pointerIconType = PointerIcon.TYPE_GRABBING;
+                break;
+            // TODO(jaebaek): set types correctly
+            // after fixing http://crbug.com/584424.
+            case CursorType.EAST_WEST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW;
+                break;
+            case CursorType.NORTH_SOUTH_RESIZE:
+                pointerIconType = PointerIcon.TYPE_VERTICAL_DOUBLE_ARROW;
+                break;
+            case CursorType.EAST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW;
+                break;
+            case CursorType.NORTH_RESIZE:
+                pointerIconType = PointerIcon.TYPE_VERTICAL_DOUBLE_ARROW;
+                break;
+            case CursorType.NORTH_EAST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_TOP_RIGHT_DIAGONAL_DOUBLE_ARROW;
+                break;
+            case CursorType.NORTH_WEST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_TOP_LEFT_DIAGONAL_DOUBLE_ARROW;
+                break;
+            case CursorType.SOUTH_RESIZE:
+                pointerIconType = PointerIcon.TYPE_VERTICAL_DOUBLE_ARROW;
+                break;
+            case CursorType.SOUTH_EAST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_TOP_LEFT_DIAGONAL_DOUBLE_ARROW;
+                break;
+            case CursorType.SOUTH_WEST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_TOP_RIGHT_DIAGONAL_DOUBLE_ARROW;
+                break;
+            case CursorType.WEST_RESIZE:
+                pointerIconType = PointerIcon.TYPE_HORIZONTAL_DOUBLE_ARROW;
+                break;
+            case CursorType.PROGRESS:
+                pointerIconType = PointerIcon.TYPE_WAIT;
+                break;
+            case CursorType.NOT_ALLOWED:
+                pointerIconType = PointerIcon.TYPE_NO_DROP;
+                break;
+            case CursorType.MOVE:
+            case CursorType.MIDDLE_PANNING:
+                pointerIconType = PointerIcon.TYPE_ALL_SCROLL;
+                break;
+            case CursorType.EAST_PANNING:
+            case CursorType.NORTH_PANNING:
+            case CursorType.NORTH_EAST_PANNING:
+            case CursorType.NORTH_WEST_PANNING:
+            case CursorType.SOUTH_PANNING:
+            case CursorType.SOUTH_EAST_PANNING:
+            case CursorType.SOUTH_WEST_PANNING:
+            case CursorType.WEST_PANNING:
+                assert false : "These pointer icon types are not supported";
+                break;
+            case CursorType.CUSTOM:
+                assert false : "onCursorChangedToCustom must be called instead";
+                break;
+        }
+        ViewGroup containerView = getContainerViewGroup();
+        PointerIcon icon = PointerIcon.getSystemIcon(containerView.getContext(), pointerIconType);
+        mPointerIconForLastCursor = icon;
+        if (mCursorOverridden) return;
+
+        containerView.setPointerIcon(icon);
+    }
+
+    @CalledByNative
+    private void notifyHoverActionStylusWritable(boolean stylusWritable) {
+        // Set stylus writing icon when hover action under pointer is writable.
+        if (stylusWritable && didHandleStylusWritingCursorUpdate()) {
+            mCursorOverridden = true;
+            return;
+        }
+
+        // If the hover action becomes not writable, then blink may not send another cursor update
+        // as the element under pointer is still same. Then reset to last cached icon from blink.
+        if (mCursorOverridden && !stylusWritable) {
+            getContainerViewGroup().setPointerIcon(mPointerIconForLastCursor);
+            if (mStylusWritingCursorHandler != null) {
+                mStylusWritingCursorHandler.notifyStylusWritingCursorRemoved();
+            }
+        }
+        mCursorOverridden = false;
+    }
+
+    private boolean didHandleStylusWritingCursorUpdate() {
+        return mStylusWritingCursorHandler != null
+                && mStylusWritingCursorHandler.didHandleCursorUpdate(getContainerViewGroup());
+    }
+
+    /**
+     * Called whenever the background color of the page changes as notified by Blink.
+     * @param color The new ARGB color of the page background.
+     */
+    @CalledByNative
+    public void onBackgroundColorChanged(int color) {}
+
+    /**
+     * Notify the client of the position of the top controls.
+     * @param topControlsOffsetY The Y offset of the top controls in physical pixels.
+     * @param topContentOffsetY The Y offset of the content in physical pixels.
+     * @param topControlsMinHeightOffsetY The current top controls min-height in physical pixels.
+     */
+    @CalledByNative
+    public void onTopControlsChanged(
+            int topControlsOffsetY, int topContentOffsetY, int topControlsMinHeightOffsetY) {}
+
+    /**
+     * Notify the client of the position of the bottom controls.
+     * @param bottomControlsOffsetY The Y offset of the bottom controls in physical pixels.
+     * @param bottomControlsMinHeightOffsetY The current bottom controls min-height in physical
+     *                                       pixels.
+     */
+    @CalledByNative
+    public void onBottomControlsChanged(
+            int bottomControlsOffsetY, int bottomControlsMinHeightOffsetY) {}
+
+    /**
+     * @return The Visual Viewport bottom inset in pixels.
+     */
+    @CalledByNative
+    protected int getViewportInsetBottom() {
+        return 0;
+    }
+
+    /**
+     * Called when root scroll direction changes.
+     * @param directionUp whether the new scroll direction is up (true) or down (false).
+     * @param current_scroll_ratio the ratio of vertical scroll in [0, 1] range.
+     * Scroll at top of page is 0, and bottom of page is 1. It is defined as 0
+     * if page is not scrollable, though this should not be called in that case.
+     */
+    @CalledByNative
+    @CallSuper
+    protected void onVerticalScrollDirectionChanged(boolean directionUp, float currentScrollRatio) {
+        notifyVerticalScrollDirectionChangeListeners(directionUp, currentScrollRatio);
+    }
+
+    /**
+     * While ViewAndroidDelegate takes a ViewGroup, and internally adds Views to it, all other
+     * consumers should *not* be manipulating child Views. This is particularly important as the
+     * container view is usually ContentView, and ContentView only supports children directly added
+     * by this class. See ContentView for details on this.
+     *
+     * @return container view that the anchor views are added to. May be null.
+     */
+    @CalledByNative
+    public final View getContainerView() {
+        return mContainerView;
+    }
+
+    protected final ViewGroup getContainerViewGroup() {
+        return mContainerView;
+    }
+
+    /**
+     * Return the X location of our container view.
+     */
+    @CalledByNative
+    private int getXLocationOfContainerViewInWindow() {
+        View container = getContainerView();
+        if (container == null) return 0;
+
+        container.getLocationInWindow(mTemporaryContainerLocation);
+        return mTemporaryContainerLocation[0];
+    }
+
+    /**
+     * Return the Y location of our container view.
+     */
+    @CalledByNative
+    private int getYLocationOfContainerViewInWindow() {
+        View container = getContainerView();
+        if (container == null) return 0;
+
+        container.getLocationInWindow(mTemporaryContainerLocation);
+        return mTemporaryContainerLocation[1];
+    }
+
+    /**
+     * Return the X location of our container view on screen.
+     */
+    @CalledByNative
+    private int getXLocationOnScreen() {
+        View container = getContainerView();
+        if (container == null) return 0;
+
+        container.getLocationOnScreen(mTemporaryContainerLocation);
+        return mTemporaryContainerLocation[0];
+    }
+
+    /**
+     * Return the Y location of our container view on screen.
+     */
+    @CalledByNative
+    private int getYLocationOnScreen() {
+        View container = getContainerView();
+        if (container == null) return 0;
+
+        container.getLocationOnScreen(mTemporaryContainerLocation);
+        return mTemporaryContainerLocation[1];
+    }
+
+    @CalledByNative
+    private void requestDisallowInterceptTouchEvent() {
+        ViewGroup container = getContainerViewGroup();
+        if (container != null) container.requestDisallowInterceptTouchEvent(true);
+    }
+
+    @CalledByNative
+    private void requestUnbufferedDispatch(MotionEvent event) {
+        ViewGroup container = getContainerViewGroup();
+        if (container != null) {
+            for (int i = 0; i < event.getPointerCount(); i++) {
+                // This is a workaround for crbug.com/1064161.
+                // TODO(smaier) remove this if LG fixes the stylus bug.
+                if (event.getToolType(i) == MotionEvent.TOOL_TYPE_STYLUS) {
+                    return;
+                }
+            }
+            container.requestUnbufferedDispatch(event);
+        }
+    }
+
+    @CalledByNative
+    private boolean hasFocus() {
+        View containerView = getContainerView();
+        return containerView == null ? false : ViewUtils.hasFocus(containerView);
+    }
+
+    @CalledByNative
+    private void requestFocus() {
+        View containerView = getContainerViewGroup();
+        if (containerView != null) ViewUtils.requestFocus(containerView);
+    }
+
+    /**
+     * @see InputConnection#performPrivateCommand(java.lang.String, android.os.Bundle)
+     */
+    public void performPrivateImeCommand(String action, Bundle data) {}
+
+    /**
+     * @return Array of ints with 4 values, the top, left, right, and bottom of
+     *         the display feature. A display feature is a distinctive physical attribute
+     *         located within the display panel of the device that creates a logical or
+     *         physical separation of the Window's space. The display feature is expressed
+     *         in physical pixels, with coordinates relative to the Window. If no
+     *         DisplayFeature exists, or if it is not currently available, returns null.
+     */
+    @CalledByNative
+    protected int[] getDisplayFeature() {
+        return null;
+    }
+
+    private void notifyVerticalScrollDirectionChangeListeners(
+            boolean directionUp, float currentScrollRatio) {
+        for (VerticalScrollDirectionChangeListener listener :
+                mVerticalScrollDirectionChangeListeners) {
+            listener.onVerticalScrollDirectionChanged(directionUp, currentScrollRatio);
+        }
+    }
+
+    /** Destroy and clean up dependencies (e.g. drag state tracker if set). */
+    public void destroy() {
+        // TODO(https://crbug.com/1297354): Call this in when destroying WebContents.
+        mDragAndDropDelegateImpl.destroy();
+    }
+
+    @VisibleForTesting
+    public static void setDragAndDropDelegateForTest(DragAndDropDelegate testDelegate) {
+        sDragAndDropTestDelegate = testDelegate;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/ViewUtils.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/ViewUtils.java
@@ -1,0 +1,248 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Region;
+import android.util.DisplayMetrics;
+import android.util.TypedValue;
+import android.view.View;
+import android.view.ViewGroup;
+
+import androidx.core.graphics.drawable.RoundedBitmapDrawable;
+import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
+
+import org.chromium.base.TraceEvent;
+
+/**
+ * A utility class that has helper methods for Android view.
+ */
+public final class ViewUtils {
+    private static final int[] sLocationTmp = new int[2];
+
+    // Prevent instantiation.
+    private ViewUtils() {}
+
+    /**
+     * @return {@code true} if the given view has a focus.
+     */
+    public static boolean hasFocus(View view) {
+        // If the container view is not focusable, we consider it always focused from
+        // Chromium's point of view.
+        return !isFocusable(view) ? true : view.hasFocus();
+    }
+
+    /**
+     * Requests focus on the given view.
+     *
+     * @param view A {@link View} to request focus on.
+     */
+    public static void requestFocus(View view) {
+        if (isFocusable(view) && !view.isFocused()) view.requestFocus();
+    }
+
+    private static boolean isFocusable(View view) {
+        return view.isInTouchMode() ? view.isFocusableInTouchMode() : view.isFocusable();
+    }
+
+    /**
+     * Invalidates a view and all of its descendants.
+     */
+    private static void recursiveInvalidate(View view) {
+        view.invalidate();
+        if (view instanceof ViewGroup) {
+            ViewGroup group = (ViewGroup) view;
+            int childCount = group.getChildCount();
+            for (int i = 0; i < childCount; i++) {
+                View child = group.getChildAt(i);
+                if (child.getVisibility() == View.VISIBLE) {
+                    recursiveInvalidate(child);
+                }
+            }
+        }
+    }
+
+    /**
+     * Sets the enabled property of a View and all of its descendants.
+     */
+    public static void setEnabledRecursive(View view, boolean enabled) {
+        view.setEnabled(enabled);
+        if (view instanceof ViewGroup) {
+            ViewGroup group = (ViewGroup) view;
+            for (int i = 0; i < group.getChildCount(); i++) {
+                setEnabledRecursive(group.getChildAt(i), enabled);
+            }
+        }
+    }
+
+    /**
+     * Captures a bitmap of a View and draws it to a Canvas.
+     */
+    public static void captureBitmap(View view, Canvas canvas) {
+        // Invalidate all the descendants of view, before calling view.draw(). Otherwise, some of
+        // the descendant views may optimize away their drawing. http://crbug.com/415251
+        recursiveInvalidate(view);
+        view.draw(canvas);
+    }
+
+    /**
+     * Return the position of {@code childView} relative to {@code rootView}.  {@code childView}
+     * must be a child of {@code rootView}.  This returns the relative layout position, which does
+     * not include translations.
+     * @param rootView    The parent of {@code childView} to calculate the position relative to.
+     * @param childView   The {@link View} to calculate the position of.
+     * @param outPosition The resulting position with the format [x, y].
+     */
+    public static void getRelativeLayoutPosition(View rootView, View childView, int[] outPosition) {
+        assert outPosition.length == 2;
+        outPosition[0] = 0;
+        outPosition[1] = 0;
+        if (rootView == null || childView == rootView) return;
+        while (childView != null) {
+            outPosition[0] += childView.getLeft();
+            outPosition[1] += childView.getTop();
+            if (childView.getParent() == rootView) break;
+            childView = (View) childView.getParent();
+        }
+    }
+
+    /**
+     * Return the position of {@code childView} relative to {@code rootView}.  {@code childView}
+     * must be a child of {@code rootView}.  This returns the relative draw position, which includes
+     * translations.
+     * @param rootView    The parent of {@code childView} to calculate the position relative to.
+     * @param childView   The {@link View} to calculate the position of.
+     * @param outPosition The resulting position with the format [x, y].
+     */
+    public static void getRelativeDrawPosition(View rootView, View childView, int[] outPosition) {
+        assert outPosition.length == 2;
+        outPosition[0] = 0;
+        outPosition[1] = 0;
+        if (rootView == null || childView == rootView) return;
+        while (childView != null) {
+            outPosition[0] = (int) (outPosition[0] + childView.getX());
+            outPosition[1] = (int) (outPosition[1] + childView.getY());
+            if (childView.getParent() == rootView) break;
+            childView = (View) childView.getParent();
+        }
+    }
+
+    /**
+     * Helper for overriding {@link ViewGroup#gatherTransparentRegion} for views that are fully
+     * opaque and have children extending beyond their bounds. If the transparent region
+     * optimization is turned on (which is the case whenever the view hierarchy contains a
+     * SurfaceView somewhere), the children might otherwise confuse the SurfaceFlinger.
+     */
+    public static void gatherTransparentRegionsForOpaqueView(View view, Region region) {
+        view.getLocationInWindow(sLocationTmp);
+        region.op(sLocationTmp[0], sLocationTmp[1],
+                sLocationTmp[0] + view.getRight() - view.getLeft(),
+                sLocationTmp[1] + view.getBottom() - view.getTop(), Region.Op.DIFFERENCE);
+    }
+
+    /**
+     *  Converts density-independent pixels (dp) to pixels on the screen (px).
+     *
+     *  @param dp Density-independent pixels are based on the physical density of the screen.
+     *  @return   The physical pixels on the screen which correspond to this many
+     *            density-independent pixels for this screen.
+     */
+    public static int dpToPx(Context context, float dp) {
+        return dpToPx(context.getResources().getDisplayMetrics(), dp);
+    }
+
+    /**
+     *  Converts density-independent pixels (dp) to pixels on the screen (px).
+     *
+     *  @param dp Density-independent pixels are based on the physical density of the screen.
+     *  @return   The physical pixels on the screen which correspond to this many
+     *            density-independent pixels for this screen.
+     */
+    public static int dpToPx(DisplayMetrics metrics, float dp) {
+        return Math.round(TypedValue.applyDimension(TypedValue.COMPLEX_UNIT_DIP, dp, metrics));
+    }
+
+    /**
+     * Sets clip children for the provided ViewGroup and all of its ancestors.
+     * @param view The ViewGroup whose children should (not) be clipped.
+     * @param clip Whether to clip children to the parent bounds.
+     */
+    public static void setAncestorsShouldClipChildren(ViewGroup view, boolean clip) {
+        ViewGroup parent = view;
+        while (parent != null) {
+            parent.setClipChildren(clip);
+            if (!(parent.getParent() instanceof ViewGroup)) break;
+            if (parent.getId() == android.R.id.content) break;
+            parent = (ViewGroup) parent.getParent();
+        }
+    }
+
+    /**
+     * Creates a {@link RoundedBitmapDrawable} using the provided {@link Bitmap} and cornerRadius.
+     * @param resources The {@link Resources}.
+     * @param icon The {@link Bitmap} to round.
+     * @param cornerRadius The corner radius.
+     * @return A {@link RoundedBitmapDrawable} for the provided {@link Bitmap}.
+     */
+    public static RoundedBitmapDrawable createRoundedBitmapDrawable(
+            Resources resources, Bitmap icon, int cornerRadius) {
+        RoundedBitmapDrawable roundedIcon = RoundedBitmapDrawableFactory.create(resources, icon);
+        roundedIcon.setCornerRadius(cornerRadius);
+        return roundedIcon;
+    }
+
+    /**
+     * Translates the canvas to ensure the specified view's coordinates are at 0, 0.
+     *
+     * @param from The view the canvas is currently translated to.
+     * @param to The view to translate to.
+     * @param canvas The canvas to be translated.
+     *
+     * @throws IllegalArgumentException if {@code from} is not an ancestor of {@code to}.
+     */
+    public static void translateCanvasToView(View from, View to, Canvas canvas)
+            throws IllegalArgumentException {
+        assert from != null;
+        assert to != null;
+        while (to != from) {
+            canvas.translate(to.getLeft(), to.getTop());
+            if (!(to.getParent() instanceof View)) {
+                throw new IllegalArgumentException("View 'to' was not a desendent of 'from'.");
+            }
+            to = (View) to.getParent();
+        }
+    }
+
+    /**
+     * A wrapper that calls android.view.requestLayout() immediately after emitting an instant trace
+     * event with information about the caller. This helps jank investigations, as there are traces
+     * with lots of re-layouts, but we don't know where these layouts are coming from.
+     *
+     * Do not include any identifying information in {@code caller}! Only constant string literals
+     * about code execution should be included.
+     *
+     * Examples of useful {@code caller} values:
+     * "MyClass.myMethod" when requestLayout is called in myMethod in MyClass.
+     * "MyClass.MyInnerClass.myMethod" when requestLayout is called in an inner class.
+     * "MyClass.myMethod.MyInnerClass.innerMethod" when requestLayout is called in an inner class
+     * defined in a method.
+     * "MyClass.myMethod other_helpful_information" when requestLayout is called more than once in
+     * the same method.
+     * "MyClass.myMethod Runnable" when requestLayout is posted somewhere to be executed later.
+     *
+     * @param view The view to call requestLayout on.
+     * @param caller Some queryable information about the caller.
+     */
+    // The trace event name is always a method/class name literal.
+    @SuppressWarnings("NoDynamicStringsInTraceEventCheck")
+    public static void requestLayout(View view, String caller) {
+        assert view != null;
+        TraceEvent.instant("requestLayout caller: " + caller);
+        view.requestLayout();
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/ViewportInsets.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/ViewportInsets.java
@@ -1,0 +1,99 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+/**
+ * Information about various kinds of insets on the application viewport.
+ *
+ * Objects of this class are vended by ApplicationViewportInsetSupplier. Here's a diagram explaining
+ * each inset type and its purpose:
+ *
+ *
+ *                            ┌─     ┌─ ┌─────────────────────────┐ ─┐
+ *                            │    ┌─┤  │                         │  │
+ *           ┌──────────────► │    │ │  │       Top Controls      │  │
+ *           │ (inset)        └─   │ └─ ├─────────────────────────┤  │  ─┐
+ *           │                     │    │                         │  │   │
+ *           │                     │    │                         │  │
+ *           │         viewVisible │    │                         │  │◄─CompositorViewHolder
+ *           │         HeightInset │    │         Content         │  │         height
+ *                                 │    │                         │  │   │
+ *        webContents              │    │                         │  │   │
+ *        HeightInset          ┌─  │ ┌─ ├┬───────────────────────┬┤  │   │
+ *                             │   └─┤  ││                       ││  │   │
+ *           │                 │     │  ││  Keyboard Accessory   ││  │   │
+ *           │      ┌─         │     └─ │┼───────────────────────┼│ ─┘   │ WebContents
+ *           │      │   visualViewport  ││                       ││      │ height
+ *           └─────►│    BottomInset    ││       Keyboard        ││      │
+ *         (outset) │          │        ││                       ││      │
+ *                  │          │        │┼───────────────────────┼│      │
+ *                  └─         └─       └─────────────────────────┘    ──┘
+ *
+ * The right side shows the size of the CompositorViewHolder,
+ * which is part of the View hierarchy, as well as the WebContents, whose size is set from
+ * CompositorViewHolder. (This picture shows the desired sizes in the RESIZES_VISUAL
+ * VirtualKeyboardMode).
+ *
+ * viewVisibleHeightInset - This is the total vertical inset applied to the CompositorViewHolder
+ * View height by any UI controls. Note that the keyboard is *not* included because it already
+ * resizes the CompositorViewHolder as part of View layout. This inset describes what part of the
+ * CompositorViewHolder is obscured to the user. It is unaffected by the VirtualKeyboardMode.
+ *
+ * webContentsHeightInset - This is the total  vertical inset applied to the CompositorViewHolder
+ * View height to derive the WebContents' height. Which controls apply depends on the
+ * VirtualKeyboardMode. In RESIZES_VISUAL and OVERLAYS_CONTENT modes, the keyboard should not resize
+ * the WebContents so we *outset* CompositorViewHolder by the keyboard height (thus,
+ * webContentsHeightInset is negative). The keyboard accessory is overlaying the
+ * CompositorViewHolder so it has no effect.
+ *
+ * visualViewportBottomInset - This is the inset applied to the WebContents' bottom to derive the
+ * visual viewport rect as provided by the window.visualViewport web API. In RESIZES_VISUAL the
+ * keyboard resizes the visual viewport (rather than the full page contents) so this value will
+ * inset by both the keyboard and the keyboard accessory.
+ *
+ * In RESIZES_CONTENT mode, the keyboard and accessory are expected to resize the web content so the
+ * CompositorViewHolder height can simply be insetted by all the View-insetting UI - this is the
+ * same value as viewVisibleInset.
+ *
+ *                           ┌─ ┌─────────────────────────┐        ─┐
+ *                         ┌─┤  │                         │         │
+ *                         │ │  │       Top Controls      │         │
+ *                         │ └─ ├─────────────────────────┤ ─┐      │
+ *                         │    │                         │  │      │
+ *             viewVisible │    │                         │  │      │CompositorViewHolder
+ *             HeightInset │    │         Content         │  │◄──┐  │       height
+ *                         │    │                         │  │   │  │
+ *             webContents │    │                         │  │   │  │
+ *             HeightInset │    │                         │  │   │  │
+ *                         │ ┌─ ├┬───────────────────────┬┤ ─┘   │  │
+ *                         └─┤  ││                       ││      │  │
+ *                           │  ││  Keyboard Accessory   ││      │  │
+ *                           └─ │┼───────────────────────┼│      │ ─┘
+ *                              ││                       ││    WebContents
+ *                              ││       Keyboard        ││     height
+ *                              ││                       ││
+ *                              │┼───────────────────────┼│
+ *                              └─────────────────────────┘
+ */
+public class ViewportInsets {
+    /**
+     * The total vertical inset on the application viewport coming from all visible UI controls.
+     * TODO(bokan): This will have to be split up into top/bottom when browser controls are
+     * added.
+     */
+    public int viewVisibleHeightInset;
+
+    /**
+     * The inset applied to the view height to derive the WebContents height.
+     * TODO(bokan): If we can prevent the keyboard from resizing ContentViewHolder this can be
+     * removed.
+     */
+    public int webContentsHeightInset;
+
+    /**
+     * The bottom inset applied to the WebContents to derive the visual viewport rect.
+     */
+    public int visualViewportBottomInset;
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/base/WindowAndroid.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/base/WindowAndroid.java
@@ -1,0 +1,1094 @@
+// Copyright 2012 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.base;
+
+import android.animation.Animator;
+import android.animation.AnimatorListenerAdapter;
+import android.annotation.SuppressLint;
+import android.app.Activity;
+import android.app.PendingIntent;
+import android.app.UiModeManager;
+import android.content.Context;
+import android.content.Intent;
+import android.content.pm.ActivityInfo;
+import android.content.pm.PackageManager;
+import android.content.res.Configuration;
+import android.os.Build;
+import android.os.IBinder;
+import android.os.Process;
+import android.util.TypedValue;
+import android.view.Display;
+import android.view.Surface;
+import android.view.View;
+import android.view.Window;
+import android.view.WindowManager;
+import android.view.accessibility.AccessibilityManager;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.ActivityState;
+import org.chromium.base.ApiCompatibilityUtils;
+import org.chromium.base.Callback;
+import org.chromium.base.ContextUtils;
+import org.chromium.base.LifetimeAssert;
+import org.chromium.base.Log;
+import org.chromium.base.ObserverList;
+import org.chromium.base.PackageManagerUtils;
+import org.chromium.base.StrictModeContext;
+import org.chromium.base.UnownedUserDataHost;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.base.compat.ApiHelperForO;
+import org.chromium.base.compat.ApiHelperForOMR1;
+import dev.cobalt.ui.KeyboardVisibilityDelegate;
+import dev.cobalt.ui.display.DisplayAndroid;
+import dev.cobalt.ui.display.DisplayAndroid.DisplayAndroidObserver;
+import org.chromium.ui.gfx.OverlayTransform;
+import dev.cobalt.ui.modaldialog.ModalDialogManager;
+import dev.cobalt.ui.permissions.AndroidPermissionDelegate;
+import dev.cobalt.ui.permissions.PermissionCallback;
+import dev.cobalt.ui.widget.Toast;
+
+import java.lang.ref.WeakReference;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+
+/**
+ * The window base class that has the minimum functionality.
+ */
+@JNINamespace("ui")
+public class WindowAndroid implements AndroidPermissionDelegate, DisplayAndroidObserver {
+    private static final String TAG = "WindowAndroid";
+    private static final ImmutableWeakReference<Activity> NULL_ACTIVITY_WEAK_REF =
+            new ImmutableWeakReference<>(null);
+
+    // Arbitrary error margin to account for cases where the display's refresh rate might not
+    // exactly match the target rate.
+    private static final float MAX_REFRESH_RATE_DELTA = 2.f;
+
+    private final LifetimeAssert mLifetimeAssert;
+    private IntentRequestTrackerImpl mIntentRequestTracker;
+
+    private KeyboardVisibilityDelegate mKeyboardVisibilityDelegate =
+            KeyboardVisibilityDelegate.getInstance();
+
+    private class TouchExplorationMonitor {
+        // Listener that tells us when touch exploration is enabled or disabled.
+        private AccessibilityManager.TouchExplorationStateChangeListener mTouchExplorationListener;
+
+        TouchExplorationMonitor() {
+            mTouchExplorationListener =
+                    new AccessibilityManager.TouchExplorationStateChangeListener() {
+                @Override
+                public void onTouchExplorationStateChanged(boolean enabled) {
+                    mIsTouchExplorationEnabled =
+                            mAccessibilityManager.isTouchExplorationEnabled();
+                    refreshWillNotDraw();
+                }
+            };
+            mAccessibilityManager.addTouchExplorationStateChangeListener(mTouchExplorationListener);
+        }
+
+        void destroy() {
+            mAccessibilityManager.removeTouchExplorationStateChangeListener(
+                    mTouchExplorationListener);
+        }
+    }
+
+    // Native pointer to the c++ WindowAndroid object.
+    private long mNativeWindowAndroid;
+    private final DisplayAndroid mDisplayAndroid;
+
+    // A string used as a key to store intent errors in a bundle
+    static final String WINDOW_CALLBACK_ERRORS = "window_callback_errors";
+
+    // Error code returned when an Intent fails to start an Activity.
+    public static final int START_INTENT_FAILURE = -1;
+
+    private boolean mWindowisWideColorGamut;
+
+    // We use a weak reference here to prevent this from leaking in WebView.
+    private final ImmutableWeakReference<Context> mContextRef;
+
+    // We track all animations over content and provide a drawing placeholder for them.
+    private HashSet<Animator> mAnimationsOverContent = new HashSet<>();
+    private View mAnimationPlaceholderView;
+
+    // System accessibility service.
+    private final AccessibilityManager mAccessibilityManager;
+
+    /** A mechanism for observing and updating the application window's bottom inset. */
+    private ApplicationViewportInsetSupplier mApplicationBottomInsetSupplier =
+            new ApplicationViewportInsetSupplier();
+
+    // Whether touch exploration is enabled.
+    private boolean mIsTouchExplorationEnabled;
+
+    // A class that monitors the touch exploration state.
+    private TouchExplorationMonitor mTouchExplorationMonitor;
+
+    private AndroidPermissionDelegate mPermissionDelegate;
+
+    // Note that this state lives in Java, rather than in the native BeginFrameSource because
+    // clients may pause VSync before the native WindowAndroid is created.
+    private boolean mVSyncPaused;
+
+    // List of display modes with the same dimensions as the current mode but varying refresh rate.
+    private List<Display.Mode> mSupportedRefreshRateModes;
+
+    // A container for UnownedUserData objects that are not owned by, but can be accessed through
+    // WindowAndroid.
+    private final UnownedUserDataHost mUnownedUserDataHost = new UnownedUserDataHost();
+
+    private float mRefreshRate;
+    private boolean mHasFocus = true;
+    private OverlayTransformApiHelper mOverlayTransformApiHelper;
+
+    /**
+     * An interface to notify listeners that a context menu is closed.
+     */
+    public interface OnCloseContextMenuListener {
+        /**
+         * Called when a context menu has been closed.
+         */
+        void onContextMenuClosed();
+    }
+
+    /**
+     * An interface to notify listeners of the changes in activity state.
+     */
+    public interface ActivityStateObserver {
+        /**
+         * Called when the activity goes into paused state.
+         */
+
+        void onActivityPaused();
+        /**
+         * Called when the activity goes into resumed state.
+         */
+        void onActivityResumed();
+
+        /**
+         * Called when the activity goes into destroyed state.
+         */
+        void onActivityDestroyed();
+    }
+
+    private ObserverList<ActivityStateObserver> mActivityStateObservers = new ObserverList<>();
+
+    /**
+     * An interface to notify listeners of the changes in selection handles state.
+     */
+    public interface SelectionHandlesObserver {
+        /**
+         * Called when the selection handles state changes.
+         */
+        void onSelectionHandlesStateChanged(boolean active);
+    }
+
+    private boolean mSelectionHandlesActive;
+    private ObserverList<SelectionHandlesObserver> mSelectionHandlesObservers =
+            new ObserverList<>();
+
+    private final boolean mAllowChangeRefreshRate;
+
+    /**
+     * Gets the view for readback.
+     */
+    public View getReadbackView() {
+        return null;
+    }
+
+    private final ObserverList<OnCloseContextMenuListener> mContextMenuCloseListeners =
+            new ObserverList<>();
+
+    /**
+     * @param context The application {@link Context}.
+     */
+    public WindowAndroid(Context context) {
+        this(context, DisplayAndroid.getNonMultiDisplay(context));
+    }
+
+    protected WindowAndroid(Context context, IntentRequestTracker tracker) {
+        this(context, DisplayAndroid.getNonMultiDisplay(context));
+        mIntentRequestTracker = (IntentRequestTrackerImpl) tracker;
+    }
+
+    /**
+     * @param context The application {@link Context}.
+     * @param display The application {@link DisplayAndroid}.
+     */
+    @SuppressLint("UseSparseArrays")
+    protected WindowAndroid(Context context, DisplayAndroid display) {
+        mLifetimeAssert = LifetimeAssert.create(this);
+        // context does not have the same lifetime guarantees as an application context so we can't
+        // hold a strong reference to it.
+        mContextRef = new ImmutableWeakReference<>(context);
+        mDisplayAndroid = display;
+        mDisplayAndroid.addObserver(this);
+
+        // Using this setting is gated to Q due to bugs on Razer phones which can freeze the device
+        // if the API is used. See crbug.com/990646.
+        // Disable refresh rate change on TV platforms, as it may cause black screen flicker due to
+        // display mode changes.
+        mAllowChangeRefreshRate = Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q && !isTv(context);
+
+        // Multiple refresh rate support is only available on M+.
+        recomputeSupportedRefreshRates();
+
+        // Temporary solution for flaky tests, see https://crbug.com/767624 for context
+        try (StrictModeContext ignored = StrictModeContext.allowDiskReads()) {
+            mAccessibilityManager =
+                    (AccessibilityManager) ContextUtils.getApplicationContext().getSystemService(
+                            Context.ACCESSIBILITY_SERVICE);
+        }
+        // Configuration.isDisplayServerWideColorGamut must be queried from the window's context.
+        // Because of crbug.com/756180, many devices report true for isScreenWideColorGamut in
+        // 8.0.0, even when they don't actually support wide color gamut.
+        // TODO(boliu): Observe configuration changes to update the value of isScreenWideColorGamut.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O && !Build.VERSION.RELEASE.equals("8.0.0")
+                && ContextUtils.activityFromContext(context) != null) {
+            Configuration configuration = context.getResources().getConfiguration();
+            boolean isScreenWideColorGamut = ApiHelperForO.isScreenWideColorGamut(configuration);
+            display.updateIsDisplayServerWideColorGamut(isScreenWideColorGamut);
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
+            mOverlayTransformApiHelper = OverlayTransformApiHelper.create(this);
+        }
+    }
+
+    private static boolean isTv(Context context) {
+        UiModeManager uiModeManager =
+                (UiModeManager) context.getSystemService(Context.UI_MODE_SERVICE);
+        return uiModeManager != null
+                && uiModeManager.getCurrentModeType() == Configuration.UI_MODE_TYPE_TELEVISION;
+    }
+
+    @CalledByNative
+    private static long createForTesting() {
+        WindowAndroid windowAndroid = new WindowAndroid(ContextUtils.getApplicationContext());
+        // |windowAndroid.getNativePointer()| creates native WindowAndroid object
+        // which stores a global ref to |windowAndroid|. Therefore |windowAndroid|
+        // is not immediately eligible for gc.
+        return windowAndroid.getNativePointer();
+    }
+
+    @CalledByNative
+    private void clearNativePointer() {
+        mNativeWindowAndroid = 0;
+    }
+
+    /**
+     * Set the delegate that will handle android permissions requests.
+     */
+    public void setAndroidPermissionDelegate(AndroidPermissionDelegate delegate) {
+        mPermissionDelegate = delegate;
+    }
+
+    /**
+     * Gets the {@link IntentRequestTracker} associated with the WindowAndroid's activity.
+     */
+    @Nullable
+    public final IntentRequestTracker getIntentRequestTracker() {
+        if (mIntentRequestTracker == null) {
+            Log.w(TAG,
+                    "Cannot get IntentRequestTracker as the WindowAndroid is neither "
+                            + "a ActivityWindowAndroid or a FragmentWindowAndroid.");
+        }
+        return mIntentRequestTracker;
+    }
+
+    /**
+     * Shows an intent and returns the results to the callback object.
+     * @param intent   The PendingIntent that needs to be shown.
+     * @param callback The object that will receive the results for the intent.
+     * @param errorId  The ID of error string to be shown if activity is paused before intent
+     *                 results, or null if no message is required.
+     * @return Whether the intent was shown.
+     */
+    public boolean showIntent(PendingIntent intent, IntentCallback callback, Integer errorId) {
+        if (mIntentRequestTracker == null) {
+            Log.d(TAG, "Can't show intent as context is not an Activity: " + intent);
+            return false;
+        }
+        return mIntentRequestTracker.showCancelableIntent(intent, callback, errorId) >= 0;
+    }
+
+    /**
+     * Shows an intent and returns the results to the callback object.
+     * @param intent   The intent that needs to be shown.
+     * @param callback The object that will receive the results for the intent.
+     * @param errorId  The ID of error string to be shown if activity is paused before intent
+     *                 results, or null if no message is required.
+     * @return Whether the intent was shown.
+     */
+    public boolean showIntent(Intent intent, IntentCallback callback, Integer errorId) {
+        if (mIntentRequestTracker == null) {
+            Log.d(TAG, "Can't show intent as context is not an Activity: " + intent);
+            return false;
+        }
+        return mIntentRequestTracker.showCancelableIntent(intent, callback, errorId) >= 0;
+    }
+
+    /**
+     * Shows an intent that could be canceled and returns the results to the callback object.
+     * @param  intent   The PendingIntent that needs to be shown.
+     * @param  callback The object that will receive the results for the intent.
+     * @param  errorId  The ID of error string to be shown if activity is paused before intent
+     *                  results, or null if no message is required.
+     * @return A non-negative request code that could be used for finishActivity, or
+     *         START_INTENT_FAILURE if failed.
+     */
+    public int showCancelableIntent(
+            PendingIntent intent, IntentCallback callback, Integer errorId) {
+        if (mIntentRequestTracker == null) {
+            Log.d(TAG, "Can't show intent as context is not an Activity: " + intent);
+            return START_INTENT_FAILURE;
+        }
+        return mIntentRequestTracker.showCancelableIntent(intent, callback, errorId);
+    }
+
+    /**
+     * Shows an intent that could be canceled and returns the results to the callback object.
+     * @param  intent   The intent that needs to be shown.
+     * @param  callback The object that will receive the results for the intent.
+     * @param  errorId  The ID of error string to be shown if activity is paused before intent
+     *                  results, or null if no message is required.
+     * @return A non-negative request code that could be used for finishActivity, or
+     *         START_INTENT_FAILURE if failed.
+     */
+    public int showCancelableIntent(Intent intent, IntentCallback callback, Integer errorId) {
+        if (mIntentRequestTracker == null) {
+            Log.d(TAG, "Can't show intent as context is not an Activity: " + intent);
+            return START_INTENT_FAILURE;
+        }
+        return mIntentRequestTracker.showCancelableIntent(intent, callback, errorId);
+    }
+
+    public int showCancelableIntent(Callback<Integer> intentTrigger, IntentCallback callback,
+            Integer errorId) {
+        if (mIntentRequestTracker == null) {
+            Log.d(TAG, "Can't show intent as context is not an Activity");
+            return START_INTENT_FAILURE;
+        }
+        return mIntentRequestTracker.showCancelableIntent(intentTrigger, callback, errorId);
+    }
+
+    /**
+     * Force finish another activity that you had previously started with showCancelableIntent.
+     * @param requestCode The request code returned from showCancelableIntent.
+     */
+    public void cancelIntent(int requestCode) {
+        if (mIntentRequestTracker == null) {
+            Log.d(TAG, "Can't cancel intent as context is not an Activity: " + requestCode);
+            return;
+        }
+        mIntentRequestTracker.cancelIntent(requestCode);
+    }
+
+    /**
+     * Removes a callback from the list of pending intents, so that nothing happens if/when the
+     * result for that intent is received.
+     * @param callback The object that should have received the results
+     * @return True if the callback was removed, false if it was not found.
+    */
+    public boolean removeIntentCallback(IntentCallback callback) {
+        if (mIntentRequestTracker == null) return false;
+        return mIntentRequestTracker.removeIntentCallback(callback);
+    }
+
+    /**
+     * Determine whether access to a particular permission is granted.
+     * @param permission The permission whose access is to be checked.
+     * @return Whether access to the permission is granted.
+     */
+    @CalledByNative
+    @Override
+    public boolean hasPermission(String permission) {
+        if (mPermissionDelegate != null) return mPermissionDelegate.hasPermission(permission);
+
+        return ApiCompatibilityUtils.checkPermission(ContextUtils.getApplicationContext(),
+                       permission, Process.myPid(), Process.myUid())
+                == PackageManager.PERMISSION_GRANTED;
+    }
+
+    /**
+     * Determine whether the specified permission can be requested.
+     *
+     * <p>
+     * A permission can be requested in the following states:
+     * 1.) Default un-granted state, permission can be requested
+     * 2.) Permission previously requested but denied by the user, but the user did not select
+     *     "Never ask again".
+     *
+     * @param permission The permission name.
+     * @return Whether the requesting the permission is allowed.
+     */
+    @CalledByNative
+    @Override
+    public boolean canRequestPermission(String permission) {
+        if (mPermissionDelegate != null) {
+            return mPermissionDelegate.canRequestPermission(permission);
+        }
+
+        Log.w(TAG, "Cannot determine the request permission state as the context "
+                + "is not an Activity");
+        assert false : "Failed to determine the request permission state using a WindowAndroid "
+                + "without an Activity";
+        return false;
+    }
+
+    /**
+     * Determine whether the specified permission is revoked by policy.
+     *
+     * @param permission The permission name.
+     * @return Whether the permission is revoked by policy and the user has no ability to change it.
+     */
+    @Override
+    public boolean isPermissionRevokedByPolicy(String permission) {
+        if (mPermissionDelegate != null) {
+            return mPermissionDelegate.isPermissionRevokedByPolicy(permission);
+        }
+
+        Log.w(TAG, "Cannot determine the policy permission state as the context "
+                + "is not an Activity");
+        assert false : "Failed to determine the policy permission state using a WindowAndroid "
+                + "without an Activity";
+        return false;
+    }
+
+    /**
+     * Requests the specified permissions are granted for further use.
+     * @param permissions The list of permissions to request access to.
+     * @param callback The callback to be notified whether the permissions were granted.
+     */
+    @Override
+    public void requestPermissions(String[] permissions, PermissionCallback callback) {
+        if (mPermissionDelegate != null) {
+            mPermissionDelegate.requestPermissions(permissions, callback);
+            return;
+        }
+
+        Log.w(TAG, "Cannot request permissions as the context is not an Activity");
+        assert false : "Failed to request permissions using a WindowAndroid without an Activity";
+    }
+
+    @Override
+    public boolean handlePermissionResult(
+            int requestCode, String[] permissions, int[] grantResults) {
+        if (mPermissionDelegate != null) {
+            return mPermissionDelegate.handlePermissionResult(
+                    requestCode, permissions, grantResults);
+        }
+        return false;
+    }
+
+    @Override
+    public boolean shouldShowRequestPermissionRationale(String permission) {
+        return mPermissionDelegate != null
+                && mPermissionDelegate.shouldShowRequestPermissionRationale(permission);
+    }
+
+    /**
+     * Displays an error message with a provided error message string.
+     * @param error The error message string to be displayed.
+     */
+    public static void showError(String error) {
+        if (error != null) {
+            Toast.makeText(ContextUtils.getApplicationContext(), error, Toast.LENGTH_SHORT).show();
+        }
+    }
+
+    /**
+     * Displays an error message from the given resource id.
+     * @param resId The error message string's resource id.
+     */
+    public static void showError(int resId) {
+        showError(ContextUtils.getApplicationContext().getString(resId));
+    }
+
+    /**
+     * Broadcasts the given intent to all interested BroadcastReceivers.
+     */
+    public void sendBroadcast(Intent intent) {
+        ContextUtils.getApplicationContext().sendBroadcast(intent);
+    }
+
+    /**
+     * @return DisplayAndroid instance belong to this window.
+     */
+    public DisplayAndroid getDisplay() {
+        return mDisplayAndroid;
+    }
+
+    /**
+     * @return A reference to owning Activity.  The returned WeakReference will never be null, but
+     *         the contained Activity can be null (either if it has been garbage collected or if
+     *         this is in the context of a WebView that was not created using an Activity).
+     *         The returned WeakReference is immutable and calling clear will throw an exception.
+     */
+    public WeakReference<Activity> getActivity() {
+        return NULL_ACTIVITY_WEAK_REF;
+    }
+
+    /**
+     * @return The application context for this activity.
+     */
+    public Context getApplicationContext() {
+        return ContextUtils.getApplicationContext();
+    }
+
+    /**
+     * Notify any observers that the visibility of the Android Window associated
+     * with this Window has changed.
+     * @param visible whether the View is visible.
+     */
+    public void onVisibilityChanged(boolean visible) {
+        if (mNativeWindowAndroid == 0) return;
+        WindowAndroidJni.get().onVisibilityChanged(
+                mNativeWindowAndroid, WindowAndroid.this, visible);
+    }
+
+    /**
+     * For window instances associated with an activity, notifies any listeners
+     * that the activity has been stopped.
+     */
+    protected void onActivityStopped() {
+        if (mNativeWindowAndroid == 0) return;
+        WindowAndroidJni.get().onActivityStopped(mNativeWindowAndroid, WindowAndroid.this);
+    }
+
+    /**
+     * For window instances associated with an activity, notifies any listeners
+     * that the activity has been started.
+     */
+    protected void onActivityStarted() {
+        if (mNativeWindowAndroid == 0) return;
+        WindowAndroidJni.get().onActivityStarted(mNativeWindowAndroid, WindowAndroid.this);
+    }
+
+    protected void onActivityPaused() {
+        for (ActivityStateObserver observer : mActivityStateObservers) observer.onActivityPaused();
+    }
+
+    protected void onActivityResumed() {
+        for (ActivityStateObserver observer : mActivityStateObservers) observer.onActivityResumed();
+    }
+
+    protected void onActivityDestroyed() {
+        for (ActivityStateObserver observer : mActivityStateObservers) {
+            observer.onActivityDestroyed();
+        }
+    }
+
+    /**
+     * Adds a new {@link ActivityStateObserver} instance.
+     */
+    public void addActivityStateObserver(ActivityStateObserver observer) {
+        assert !mActivityStateObservers.hasObserver(observer);
+        mActivityStateObservers.addObserver(observer);
+    }
+
+    /**
+     * Removes a new {@link ActivityStateObserver} instance.
+     */
+    public void removeActivityStateObserver(ActivityStateObserver observer) {
+        assert mActivityStateObservers.hasObserver(observer);
+        mActivityStateObservers.removeObserver(observer);
+    }
+
+    public void addSelectionHandlesObserver(SelectionHandlesObserver observer) {
+        assert !mSelectionHandlesObservers.hasObserver(observer);
+        mSelectionHandlesObservers.addObserver(observer);
+        observer.onSelectionHandlesStateChanged(mSelectionHandlesActive);
+    }
+
+    public void removeSelectionHandlesObserver(SelectionHandlesObserver observer) {
+        assert mSelectionHandlesObservers.hasObserver(observer);
+        mSelectionHandlesObservers.removeObserver(observer);
+    }
+
+    /**
+     * Removes a new {@link ActivityStateObserver} instance.
+     */
+    @CalledByNative
+    private void onSelectionHandlesStateChanged(boolean active) {
+        mSelectionHandlesActive = active;
+        for (SelectionHandlesObserver observer : mSelectionHandlesObservers) {
+            observer.onSelectionHandlesStateChanged(active);
+        }
+    }
+
+    /**
+     * @return Current state of the associated {@link Activity}. Can be overridden
+     *         to return the correct state. {@code ActivityState.DESTROYED} by default.
+     */
+    @ActivityState
+    public int getActivityState() {
+        return ActivityState.DESTROYED;
+    }
+
+    /**
+     * An interface that intent callback objects have to implement.
+     */
+    public interface IntentCallback {
+        /**
+         * Handles the data returned by the requested intent.
+         * @param resultCode Result code of the requested intent.
+         * @param data The data returned by the intent.
+         */
+        void onIntentCompleted(int resultCode, Intent data);
+    }
+
+    /**
+     * Tests that an activity is available to handle the passed in intent.
+     * @param  intent The intent to check.
+     * @return True if an activity is available to process this intent when started, meaning that
+     *         Context.startActivity will not throw ActivityNotFoundException.
+     */
+    public boolean canResolveActivity(Intent intent) {
+        return PackageManagerUtils.canResolveActivity(intent);
+    }
+
+    /**
+     * Returns the ModalDialogManager to be used with this window.
+     * @return a {@link ModalDialogManager} for this window, or null if there is none.
+     */
+    public @Nullable ModalDialogManager getModalDialogManager() {
+        return null;
+    }
+
+    /**
+     * Destroys the c++ WindowAndroid object if one has been created.
+     */
+    @CalledByNative
+    public void destroy() {
+        LifetimeAssert.setSafeToGc(mLifetimeAssert, true);
+        if (mNativeWindowAndroid != 0) {
+            // Native code clears |mNativeWindowAndroid|.
+            WindowAndroidJni.get().destroy(mNativeWindowAndroid, WindowAndroid.this);
+        }
+
+        mUnownedUserDataHost.destroy();
+
+        if (mTouchExplorationMonitor != null) mTouchExplorationMonitor.destroy();
+
+        mApplicationBottomInsetSupplier.destroy();
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {
+            if (mOverlayTransformApiHelper != null) {
+                mOverlayTransformApiHelper.destroy();
+            }
+        }
+    }
+
+    /**
+     * Returns a pointer to the c++ AndroidWindow object and calls the initializer if
+     * the object has not been previously initialized.
+     * @return A pointer to the c++ AndroidWindow.
+     */
+    @CalledByNative
+    private long getNativePointer() {
+        if (mNativeWindowAndroid == 0) {
+            mNativeWindowAndroid =
+                    WindowAndroidJni.get().init(WindowAndroid.this, mDisplayAndroid.getDisplayId(),
+                            getMouseWheelScrollFactor(), getWindowIsWideColorGamut());
+            WindowAndroidJni.get().setVSyncPaused(
+                    mNativeWindowAndroid, WindowAndroid.this, mVSyncPaused);
+        }
+        return mNativeWindowAndroid;
+    }
+
+    /**
+     * Returns current wheel scroll factor (physical pixels per mouse scroll click).
+     * @return wheel scroll factor or zero if attr retrieval fails.
+     */
+    private float getMouseWheelScrollFactor() {
+        TypedValue outValue = new TypedValue();
+        Context context = getContext().get();
+        if (context != null
+                && context.getTheme().resolveAttribute(
+                           android.R.attr.listPreferredItemHeight, outValue, true)) {
+            // This is the same attribute used by Android Views to scale wheel
+            // event motion into scroll deltas.
+            return outValue.getDimension(context.getResources().getDisplayMetrics());
+        }
+        return 0;
+    }
+
+    // Helper to get the android Window. Always null for application context. Need to null check
+    // result returning value.
+    Window getWindow() {
+        Activity activity = ContextUtils.activityFromContext(mContextRef.get());
+        if (activity == null || activity.isFinishing()) return null;
+        return activity.getWindow();
+    }
+
+    // This is android.view.Window.isWideColorGamut, which is only set if the passed in Context is
+    // an Activity. This is normally not needed for apps which can decide whether to enable wide
+    // gamut (on supported hardware and os). However it is important for embedders like WebView
+    // which do not make the wide gamut decision to check this at run time.
+    private boolean getWindowIsWideColorGamut() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) return false;
+        Window window = getWindow();
+        if (window == null) return false;
+        return ApiHelperForOMR1.isWideColorGamut(window);
+    }
+
+    /**
+     * Set the animation placeholder view, which we set to 'draw' during animations, such that
+     * animations aren't clipped by the SurfaceView 'hole'. This can be the SurfaceView itself
+     * or a view directly on top of it. This could be extended to many views if we ever need it.
+     */
+    public void setAnimationPlaceholderView(View view) {
+        mAnimationPlaceholderView = view;
+
+        // The accessibility focus ring also gets clipped by the SurfaceView 'hole', so
+        // make sure the animation placeholder view is in place if touch exploration is on.
+        mIsTouchExplorationEnabled = mAccessibilityManager.isTouchExplorationEnabled();
+        refreshWillNotDraw();
+        mTouchExplorationMonitor = new TouchExplorationMonitor();
+    }
+
+    /**
+     * The returned {@link KeyboardVisibilityDelegate} can read and influence the soft keyboard.
+     * @return a {@link KeyboardVisibilityDelegate} specific for this window.
+     */
+    public KeyboardVisibilityDelegate getKeyboardDelegate() {
+        return mKeyboardVisibilityDelegate;
+    }
+
+    /** @return A mechanism for updating and observing the bottom inset of the browser window. */
+    public ApplicationViewportInsetSupplier getApplicationBottomInsetSupplier() {
+        return mApplicationBottomInsetSupplier;
+    }
+
+    public void setKeyboardDelegate(KeyboardVisibilityDelegate keyboardDelegate) {
+        mKeyboardVisibilityDelegate = keyboardDelegate;
+        // TODO(fhorschig): Remove - every caller should use the window to get the delegate.
+        KeyboardVisibilityDelegate.setInstance(keyboardDelegate);
+    }
+
+    /**
+     * Adds a listener that will be notified whenever a ContextMenu is closed.
+     */
+    public void addContextMenuCloseListener(OnCloseContextMenuListener listener) {
+        mContextMenuCloseListeners.addObserver(listener);
+    }
+
+    /**
+     * Removes a listener from the list of listeners that will be notified when a
+     * ContextMenu is closed.
+     */
+    public void removeContextMenuCloseListener(OnCloseContextMenuListener listener) {
+        mContextMenuCloseListeners.removeObserver(listener);
+    }
+
+    /**
+     * This hook is called whenever the context menu is being closed (either by
+     * the user canceling the menu with the back/menu button, or when an item is
+     * selected).
+     */
+    public void onContextMenuClosed() {
+        for (OnCloseContextMenuListener listener : mContextMenuCloseListeners) {
+            listener.onContextMenuClosed();
+        }
+    }
+
+    /**
+     * Start a post-layout animation on top of web content.
+     *
+     * By default, Android optimizes what it shows on top of SurfaceViews (saves power).
+     * Effectively, layouts determine what gets drawn and post-layout animations outside
+     * of this area may be 'clipped'. Using this method to start such animations will
+     * ensure that nothing is clipped during the animation, and restore the optimal
+     * state when the animation ends.
+     */
+    public void startAnimationOverContent(Animator animation) {
+        // We may not need an animation placeholder (eg. Webview doesn't use SurfaceView)
+        if (mAnimationPlaceholderView == null) return;
+        if (animation.isStarted()) throw new IllegalArgumentException("Already started.");
+        boolean added = mAnimationsOverContent.add(animation);
+        if (!added) throw new IllegalArgumentException("Already Added.");
+
+        // We start the animation in this method to help guarantee that we never get stuck in this
+        // state or leak objects into the set. Starting the animation here should guarantee that we
+        // get an onAnimationEnd callback, and remove this animation.
+        animation.start();
+
+        // When the first animation starts, make the placeholder 'draw' itself.
+        refreshWillNotDraw();
+
+        // When the last animation ends, remove the placeholder view,
+        // returning to the default optimized state.
+        animation.addListener(new AnimatorListenerAdapter() {
+            @Override
+            public void onAnimationEnd(Animator animation) {
+                animation.removeListener(this);
+                mAnimationsOverContent.remove(animation);
+                refreshWillNotDraw();
+            }
+        });
+    }
+
+    /**
+     * Getter for the current context (not necessarily the application context).
+     * Make no assumptions regarding what type of Context is returned here, it could be for example
+     * an Activity or a Context created specifically to target an external display.
+     * The returned WeakReference is immutable and calling clear will throw an exception.
+     */
+    public WeakReference<Context> getContext() {
+        return mContextRef;
+    }
+
+    /**
+     * Return the current window token, or null.
+     */
+    public IBinder getWindowToken() {
+        Window window = getWindow();
+        if (window == null) return null;
+        View decorView = window.peekDecorView();
+        if (decorView == null) return null;
+        return decorView.getWindowToken();
+    }
+
+    /**
+     * Update whether the placeholder is 'drawn' based on whether an animation is running
+     * or touch exploration is enabled - if either of those are true, we call
+     * setWillNotDraw(false) to ensure that the animation is drawn over the SurfaceView,
+     * and otherwise we call setWillNotDraw(true).
+     */
+    private void refreshWillNotDraw() {
+        boolean willNotDraw = !mIsTouchExplorationEnabled && mAnimationsOverContent.isEmpty();
+        if (mAnimationPlaceholderView.willNotDraw() != willNotDraw) {
+            mAnimationPlaceholderView.setWillNotDraw(willNotDraw);
+            Log.i(TAG, "WindowAndroid mAnimationPlaceholderView.setWillNotDraw:" + willNotDraw);
+        }
+    }
+
+    /**
+     * As long as there are still animations which haven't ended, this will return false.
+     * @return True if all known animations have ended.
+     */
+    @VisibleForTesting
+    public boolean haveAnimationsEnded() {
+        return mAnimationsOverContent.isEmpty();
+    }
+
+    /**
+     * Pauses/Unpauses VSync. When VSync is paused the compositor for this window will idle, and
+     * requestAnimationFrame callbacks won't fire, etc.
+     */
+    public void setVSyncPaused(boolean paused) {
+        if (mVSyncPaused == paused) return;
+        mVSyncPaused = paused;
+        if (mNativeWindowAndroid != 0) {
+            WindowAndroidJni.get().setVSyncPaused(mNativeWindowAndroid, WindowAndroid.this, paused);
+        }
+    }
+
+    @Override
+    public void onRefreshRateChanged(float refreshRate) {
+        if (mNativeWindowAndroid != 0) {
+            WindowAndroidJni.get().onUpdateRefreshRate(
+                    mNativeWindowAndroid, WindowAndroid.this, refreshRate);
+        }
+    }
+
+    protected void onWindowFocusChanged(boolean hasFocus) {
+        mHasFocus = hasFocus;
+        if (!mHasFocus) {
+            // `preferredDisplayModeId` affects other windows even when this window is not in focus,
+            // so reset to no preference when not in focus.
+            doSetPreferredRefreshRate(0);
+        } else {
+            doSetPreferredRefreshRate(mRefreshRate);
+        }
+    }
+
+    @Override
+    public void onCurrentModeChanged(Display.Mode currentMode) {
+        recomputeSupportedRefreshRates();
+    }
+
+    @Override
+    public void onDisplayModesChanged(List<Display.Mode> supportedModes) {
+        recomputeSupportedRefreshRates();
+    }
+
+    @RequiresApi(Build.VERSION_CODES.O)
+    @CalledByNative
+    public void setWideColorEnabled(boolean enabled) {
+        // Although this API was added in Android O, it was buggy.
+        // Restrict to Android Q, where it was fixed.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
+            assert !enabled;
+            return;
+        }
+        Window window = getWindow();
+        if (window == null) return;
+
+        int colorMode = enabled ? ActivityInfo.COLOR_MODE_WIDE_COLOR_GAMUT
+                                : ActivityInfo.COLOR_MODE_DEFAULT;
+        ApiHelperForO.setColorMode(window, colorMode);
+    }
+
+    private void recomputeSupportedRefreshRates() {
+        Display.Mode currentMode = mDisplayAndroid.getCurrentMode();
+        List<Display.Mode> supportedModes = mDisplayAndroid.getSupportedModes();
+        // Note: getCurrentMode() and getSupportedModes() can return null in some situations - see
+        // crbug.com/1401514.
+        if (currentMode == null || supportedModes == null || supportedModes.size() == 0) {
+            return;
+        }
+
+        List<Display.Mode> supportedRefreshRateModes = new ArrayList<Display.Mode>();
+        for (int i = 0; i < supportedModes.size(); ++i) {
+            if (currentMode.equals(supportedModes.get(i))) {
+                supportedRefreshRateModes.add(supportedModes.get(i));
+                continue;
+            }
+
+            // Only advertise refresh rates which wouldn't change other configurations on the
+            // Display.
+            if (currentMode.getPhysicalWidth() == supportedModes.get(i).getPhysicalWidth()
+                    && currentMode.getPhysicalHeight() == supportedModes.get(i).getPhysicalHeight()
+                    && currentMode.getRefreshRate() != supportedModes.get(i).getRefreshRate()) {
+                supportedRefreshRateModes.add(supportedModes.get(i));
+                continue;
+            }
+        }
+
+        boolean changed = !supportedRefreshRateModes.equals(mSupportedRefreshRateModes);
+        if (changed) {
+            mSupportedRefreshRateModes = supportedRefreshRateModes;
+            if (mNativeWindowAndroid != 0) {
+                WindowAndroidJni.get().onSupportedRefreshRatesUpdated(
+                        mNativeWindowAndroid, WindowAndroid.this, getSupportedRefreshRates());
+            }
+        }
+    }
+
+    @CalledByNative
+    private float getRefreshRate() {
+        return mDisplayAndroid.getRefreshRate();
+    }
+
+    @SuppressLint("NewApi")
+    // mSupportedRefreshRateModes should only be set if Display.Mode is available.
+    @CalledByNative
+    private float[] getSupportedRefreshRates() {
+        if (mSupportedRefreshRateModes == null || !mAllowChangeRefreshRate) return null;
+
+        float[] supportedRefreshRates = new float[mSupportedRefreshRateModes.size()];
+        for (int i = 0; i < mSupportedRefreshRateModes.size(); ++i) {
+            supportedRefreshRates[i] = mSupportedRefreshRateModes.get(i).getRefreshRate();
+        }
+        return supportedRefreshRates;
+    }
+
+    @SuppressLint("NewApi")
+    @CalledByNative
+    private void setPreferredRefreshRate(float preferredRefreshRate) {
+        mRefreshRate = preferredRefreshRate;
+        if (mHasFocus) doSetPreferredRefreshRate(preferredRefreshRate);
+    }
+
+    private void doSetPreferredRefreshRate(float preferredRefreshRate) {
+        if (mSupportedRefreshRateModes == null || !mAllowChangeRefreshRate) return;
+
+        int preferredModeId = getPreferredModeId(preferredRefreshRate);
+        Window window = getWindow();
+        if (window == null) return;
+        WindowManager.LayoutParams params = window.getAttributes();
+        if (params.preferredDisplayModeId == preferredModeId) return;
+
+        params.preferredDisplayModeId = preferredModeId;
+        window.setAttributes(params);
+    }
+
+    @SuppressLint("NewApi")
+    // mSupportedRefreshRateModes should only be set if Display.Mode is available.
+    private int getPreferredModeId(float preferredRefreshRate) {
+        if (preferredRefreshRate == 0) return 0;
+
+        Display.Mode preferredMode = null;
+        float preferredModeDelta = Float.MAX_VALUE;
+
+        for (int i = 0; i < mSupportedRefreshRateModes.size(); ++i) {
+            Display.Mode mode = mSupportedRefreshRateModes.get(i);
+            float delta = Math.abs(preferredRefreshRate - mode.getRefreshRate());
+            if (delta < preferredModeDelta) {
+                preferredModeDelta = delta;
+                preferredMode = mode;
+            }
+        }
+
+        if (preferredModeDelta > MAX_REFRESH_RATE_DELTA) {
+            Log.e(TAG, "Refresh rate not supported : " + preferredRefreshRate);
+            return 0;
+        }
+
+        return preferredMode.getModeId();
+    }
+
+    /**
+     * @return The {@link UnownedUserDataHost} attached to the current {@link WindowAndroid}.
+     */
+    public UnownedUserDataHost getUnownedUserDataHost() {
+        return mUnownedUserDataHost;
+    }
+
+    void onOverlayTransformUpdated() {
+        if (mNativeWindowAndroid != 0) {
+            WindowAndroidJni.get().onOverlayTransformUpdated(mNativeWindowAndroid, this);
+        }
+    }
+
+    @CalledByNative
+    private @OverlayTransform int getOverlayTransform() {
+        int overlayTransform = OverlayTransform.INVALID;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2
+                && mOverlayTransformApiHelper != null) {
+            overlayTransform = mOverlayTransformApiHelper.getOverlayTransform();
+        }
+        // Fallback to display rotation
+        if (overlayTransform == OverlayTransform.INVALID) {
+            switch (mDisplayAndroid.getRotation()) {
+                case Surface.ROTATION_0:
+                    return OverlayTransform.NONE;
+                case Surface.ROTATION_90:
+                    return OverlayTransform.ROTATE_90;
+                case Surface.ROTATION_180:
+                    return OverlayTransform.ROTATE_180;
+                case Surface.ROTATION_270:
+                    return OverlayTransform.ROTATE_270;
+                default:
+                    return OverlayTransform.NONE;
+            }
+        }
+        return overlayTransform;
+    }
+
+    @NativeMethods
+    interface Natives {
+        long init(WindowAndroid caller, int displayId, float scrollFactor,
+                boolean windowIsWideColorGamut);
+        void onVisibilityChanged(long nativeWindowAndroid, WindowAndroid caller, boolean visible);
+        void onActivityStopped(long nativeWindowAndroid, WindowAndroid caller);
+        void onActivityStarted(long nativeWindowAndroid, WindowAndroid caller);
+        void setVSyncPaused(long nativeWindowAndroid, WindowAndroid caller, boolean paused);
+        void onUpdateRefreshRate(long nativeWindowAndroid, WindowAndroid caller, float refreshRate);
+        void destroy(long nativeWindowAndroid, WindowAndroid caller);
+        void onSupportedRefreshRatesUpdated(
+                long nativeWindowAndroid, WindowAndroid caller, float[] supportedRefreshRates);
+        void onOverlayTransformUpdated(long nativeWindowAndroid, WindowAndroid caller);
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/display/DisplayAndroid.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/display/DisplayAndroid.java
@@ -1,0 +1,367 @@
+// Copyright 2016 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.display;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Point;
+import android.view.Display;
+import android.view.Surface;
+
+import java.util.List;
+import java.util.WeakHashMap;
+
+/**
+ * Chromium's object for android.view.Display. Instances of this object should be obtained
+ * from WindowAndroid.
+ * This class is designed to avoid leaks. It is ok to hold a strong ref of this class from
+ * anywhere, as long as the corresponding WindowAndroids are destroyed. The observers are
+ * held weakly so to not lead to leaks.
+ */
+public class DisplayAndroid {
+    /**
+     * DisplayAndroidObserver interface for changes to this Display.
+     */
+    public interface DisplayAndroidObserver {
+        /**
+         * Called whenever the screen orientation changes.
+         *
+         * @param rotation One of Surface.ROTATION_* values.
+         */
+        default void onRotationChanged(int rotation) {}
+
+        /**
+         * Called whenever the screen density changes.
+         *
+         * @param dipScale Density Independent Pixel scale.
+         */
+        default void onDIPScaleChanged(float dipScale) {}
+
+        /**
+         * Called whenever the attached display's refresh rate changes.
+         *
+         * @param refreshRate the display's refresh rate in frames per second.
+         */
+        default void onRefreshRateChanged(float refreshRate) {}
+
+        /**
+         * Called whenever the attached display's supported Display.Modes are changed.
+         *
+         * @param supportedModes the array of supported modes.
+         */
+        default void onDisplayModesChanged(List<Display.Mode> supportedModes) {}
+
+        /**
+         * Called whenever the attached display's current mode is changed.
+         *
+         * @param currentMode the current display mode.
+         */
+        default void onCurrentModeChanged(Display.Mode currentMode) {}
+    }
+
+    private static final DisplayAndroidObserver[] EMPTY_OBSERVER_ARRAY =
+            new DisplayAndroidObserver[0];
+
+    private final WeakHashMap<DisplayAndroidObserver, Object /* null */> mObservers;
+    // Do NOT add strong references to objects with potentially complex lifetime, like Context.
+
+    private final int mDisplayId;
+    private Point mSize;
+    private float mDipScale;
+    private float mXdpi;
+    private float mYdpi;
+    private int mBitsPerPixel;
+    private int mBitsPerComponent;
+    private int mRotation;
+    private float mRefreshRate;
+    private Display.Mode mCurrentDisplayMode;
+    private List<Display.Mode> mDisplayModes;
+    private float mHdrMaxLuminanceRatio = 1.0f;
+    protected boolean mIsDisplayWideColorGamut;
+    protected boolean mIsDisplayServerWideColorGamut;
+
+    protected static DisplayAndroidManager getManager() {
+        return DisplayAndroidManager.getInstance();
+    }
+
+    /**
+     * Get the non-multi-display DisplayAndroid for the given context. It's safe to call this with
+     * any type of context, including the Application.
+     *
+     * To support multi-display, obtain DisplayAndroid from WindowAndroid instead.
+     *
+     * This function is intended to be analogous to GetPrimaryDisplay() for other platforms.
+     * However, Android has historically had no real concept of a Primary Display, and instead uses
+     * the notion of a default display for an Activity. Under normal circumstances, this function,
+     * called with the correct context, will return the expected display for an Activity. However,
+     * virtual, or "fake", displays that are not associated with any context may be used in special
+     * cases, like Virtual Reality, and will lead to this function returning the incorrect display.
+     *
+     * @return What the Android WindowManager considers to be the default display for this context.
+     */
+    public static DisplayAndroid getNonMultiDisplay(Context context) {
+        Display display = DisplayAndroidManager.getDefaultDisplayForContext(context);
+        return getManager().getDisplayAndroid(display);
+    }
+
+    /**
+     * @return Display id that does not necessarily match the one defined in Android's Display.
+     */
+    public int getDisplayId() {
+        return mDisplayId;
+    }
+
+    /**
+     * Note: For JB pre-MR1, this can sometimes return values smaller than the actual screen.
+     * https://crbug.com/829318
+     * @return Display height in physical pixels.
+     */
+    public int getDisplayHeight() {
+        return mSize.y;
+    }
+
+    /**
+     * Note: For JB pre-MR1, this can sometimes return values smaller than the actual screen.
+     * @return Display width in physical pixels.
+     */
+    public int getDisplayWidth() {
+        return mSize.x;
+    }
+
+    /**
+     * @return current orientation. One of Surface.ORIENTATION_* values.
+     */
+    public int getRotation() {
+        return mRotation;
+    }
+
+    /**
+     * @return current orientation in degrees. One of the values 0, 90, 180, 270.
+     */
+    public int getRotationDegrees() {
+        switch (getRotation()) {
+            case Surface.ROTATION_0:
+                return 0;
+            case Surface.ROTATION_90:
+                return 90;
+            case Surface.ROTATION_180:
+                return 180;
+            case Surface.ROTATION_270:
+                return 270;
+        }
+
+        // This should not happen.
+        assert false;
+        return 0;
+    }
+
+    /**
+     * @return A scaling factor for the Density Independent Pixel unit.
+     */
+    public float getDipScale() {
+        return mDipScale;
+    }
+
+    /**
+     * @return The exact physical pixels per inch of the screen in the X dimension.
+     */
+    public float getXdpi() {
+        return mXdpi;
+    }
+
+    /**
+     * @return The exact physical pixels per inch of the screen in the Y dimension.
+     */
+    public float getYdpi() {
+        return mYdpi;
+    }
+
+    /**
+     * @return Number of bits per pixel.
+     */
+    /* package */ int getBitsPerPixel() {
+        return mBitsPerPixel;
+    }
+
+    /**
+     * @return Number of bits per each color component.
+     */
+    @SuppressWarnings("deprecation")
+    /* package */ int getBitsPerComponent() {
+        return mBitsPerComponent;
+    }
+
+    /**
+     * @return Whether or not it is possible to use wide color gamut rendering with this display.
+     */
+    public boolean getIsWideColorGamut() {
+        return mIsDisplayWideColorGamut && mIsDisplayServerWideColorGamut;
+    }
+
+    /**
+     * @return Display's refresh rate in frames per second.
+     */
+    public float getRefreshRate() {
+        return mRefreshRate;
+    }
+
+    /*
+     * @return Display.Modes supported by this Display.
+     */
+    public List<Display.Mode> getSupportedModes() {
+        return mDisplayModes;
+    }
+
+    /*
+     * @return Current Display.Mode for the display.
+     */
+    public Display.Mode getCurrentMode() {
+        return mCurrentDisplayMode;
+    }
+
+    /**
+     * Max luminance HDR content can display, represented as a multiple of the SDR white luminance
+     * (so a display that is incapable of HDR would have a value of 1.0).
+     */
+    // Package private only because no client needs to access this from java.
+    float getHdrMaxLuminanceRatio() {
+        return mHdrMaxLuminanceRatio;
+    }
+
+    /**
+     * Return window context for display android. Implemented by @{@link PhysicalDisplayAndroid}
+     * @return window context.
+     */
+    public Context getWindowContext() {
+        return null;
+    }
+
+    /**
+     * Add observer. Note repeat observers will be called only one.
+     * Observers are held only weakly by Display.
+     */
+    public void addObserver(DisplayAndroidObserver observer) {
+        mObservers.put(observer, null);
+    }
+
+    /**
+     * Remove observer.
+     */
+    public void removeObserver(DisplayAndroidObserver observer) {
+        mObservers.remove(observer);
+    }
+
+    protected DisplayAndroid(int displayId) {
+        mDisplayId = displayId;
+        mObservers = new WeakHashMap<>();
+        mSize = new Point();
+    }
+
+    private DisplayAndroidObserver[] getObservers() {
+        // Makes a copy to allow concurrent edit.
+        return mObservers.keySet().toArray(EMPTY_OBSERVER_ARRAY);
+    }
+
+    public void updateIsDisplayServerWideColorGamut(Boolean isDisplayServerWideColorGamut) {
+        update(null, null, null, null, null, null, null, null, isDisplayServerWideColorGamut, null,
+                null, null, /*hdrMaxLuminanceRatio=*/null);
+    }
+
+    /**
+     * Update the display to the provided parameters. Null values leave the parameter unchanged.
+     */
+    @SuppressLint("NewApi")
+    protected void update(Point size, Float dipScale, Integer bitsPerPixel,
+            Integer bitsPerComponent, Integer rotation, Boolean isDisplayWideColorGamut,
+            Boolean isDisplayServerWideColorGamut, Float refreshRate, Display.Mode currentMode,
+            List<Display.Mode> supportedModes) {
+        update(size, dipScale, null, null, bitsPerPixel, bitsPerComponent, rotation,
+                isDisplayWideColorGamut, isDisplayServerWideColorGamut, refreshRate, currentMode,
+                supportedModes, /*hdrMaxLuminanceRatio=*/null);
+    }
+
+    /**
+     * Update the display to the provided parameters. Null values leave the parameter unchanged.
+     */
+    @SuppressLint("NewApi")
+    protected void update(Point size, Float dipScale, Float xdpi, Float ydpi, Integer bitsPerPixel,
+            Integer bitsPerComponent, Integer rotation, Boolean isDisplayWideColorGamut,
+            Boolean isDisplayServerWideColorGamut, Float refreshRate, Display.Mode currentMode,
+            List<Display.Mode> supportedModes, Float hdrMaxLuminanceRatio) {
+        boolean sizeChanged = size != null && !mSize.equals(size);
+        // Intentional comparison of floats: we assume that if scales differ, they differ
+        // significantly.
+        boolean dipScaleChanged = dipScale != null && mDipScale != dipScale;
+        boolean xdpiChanged = xdpi != null && mXdpi != xdpi;
+        boolean ydpiChanged = ydpi != null && mYdpi != ydpi;
+        boolean bitsPerPixelChanged = bitsPerPixel != null && mBitsPerPixel != bitsPerPixel;
+        boolean bitsPerComponentChanged =
+                bitsPerComponent != null && mBitsPerComponent != bitsPerComponent;
+        boolean rotationChanged = rotation != null && mRotation != rotation;
+        boolean isDisplayWideColorGamutChanged = isDisplayWideColorGamut != null
+                && mIsDisplayWideColorGamut != isDisplayWideColorGamut;
+        boolean isDisplayServerWideColorGamutChanged = isDisplayServerWideColorGamut != null
+                && mIsDisplayServerWideColorGamut != isDisplayServerWideColorGamut;
+        boolean isRefreshRateChanged = refreshRate != null && mRefreshRate != refreshRate;
+        boolean displayModesChanged = supportedModes != null
+                && (mDisplayModes == null ? true : mDisplayModes.equals(supportedModes));
+        boolean currentModeChanged =
+                currentMode != null && !currentMode.equals(mCurrentDisplayMode);
+        boolean hdrMaxLuninanceRatioChanged =
+                hdrMaxLuminanceRatio != null && hdrMaxLuminanceRatio != mHdrMaxLuminanceRatio;
+        boolean changed = sizeChanged || dipScaleChanged || bitsPerPixelChanged
+                || bitsPerComponentChanged || rotationChanged || isDisplayWideColorGamutChanged
+                || isDisplayServerWideColorGamutChanged || isRefreshRateChanged
+                || displayModesChanged || currentModeChanged || hdrMaxLuninanceRatioChanged;
+        if (!changed) return;
+
+        if (sizeChanged) mSize = size;
+        if (dipScaleChanged) mDipScale = dipScale;
+        if (xdpiChanged) mXdpi = xdpi;
+        if (ydpiChanged) mYdpi = ydpi;
+        if (bitsPerPixelChanged) mBitsPerPixel = bitsPerPixel;
+        if (bitsPerComponentChanged) mBitsPerComponent = bitsPerComponent;
+        if (rotationChanged) mRotation = rotation;
+        if (isDisplayWideColorGamutChanged) mIsDisplayWideColorGamut = isDisplayWideColorGamut;
+        if (isDisplayServerWideColorGamutChanged) {
+            mIsDisplayServerWideColorGamut = isDisplayServerWideColorGamut;
+        }
+        if (isRefreshRateChanged) mRefreshRate = refreshRate;
+        if (displayModesChanged) mDisplayModes = supportedModes;
+        if (currentModeChanged) mCurrentDisplayMode = currentMode;
+
+        getManager().updateDisplayOnNativeSide(this);
+        if (rotationChanged) {
+            DisplayAndroidObserver[] observers = getObservers();
+            for (DisplayAndroidObserver o : observers) {
+                o.onRotationChanged(mRotation);
+            }
+        }
+        if (dipScaleChanged) {
+            DisplayAndroidObserver[] observers = getObservers();
+            for (DisplayAndroidObserver o : observers) {
+                o.onDIPScaleChanged(mDipScale);
+            }
+        }
+        if (isRefreshRateChanged) {
+            DisplayAndroidObserver[] observers = getObservers();
+            for (DisplayAndroidObserver o : observers) {
+                o.onRefreshRateChanged(mRefreshRate);
+            }
+        }
+        if (displayModesChanged) {
+            DisplayAndroidObserver[] observers = getObservers();
+            for (DisplayAndroidObserver o : observers) {
+                o.onDisplayModesChanged(mDisplayModes);
+            }
+        }
+        if (currentModeChanged) {
+            DisplayAndroidObserver[] observers = getObservers();
+            for (DisplayAndroidObserver o : observers) {
+                o.onCurrentModeChanged(mCurrentDisplayMode);
+            }
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/display/DisplayAndroidManager.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/display/DisplayAndroidManager.java
@@ -1,0 +1,220 @@
+// Copyright 2016 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.display;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.hardware.display.DisplayManager;
+import android.hardware.display.DisplayManager.DisplayListener;
+import android.os.Build;
+import android.util.SparseArray;
+import android.view.Display;
+import android.view.WindowManager;
+
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.ContextUtils;
+import org.chromium.base.ThreadUtils;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.base.compat.ApiHelperForR;
+import org.chromium.build.annotations.MainDex;
+
+/**
+ * DisplayAndroidManager is a class that informs its observers Display changes.
+ */
+@JNINamespace("ui")
+@MainDex
+public class DisplayAndroidManager {
+    /**
+     * DisplayListenerBackend is used to handle the actual listening of display changes. It handles
+     * it via the Android DisplayListener API.
+     */
+    private class DisplayListenerBackend implements DisplayListener {
+        public void startListening() {
+            getDisplayManager().registerDisplayListener(this, null);
+        }
+
+        // DisplayListener implementation:
+
+        @Override
+        public void onDisplayAdded(int sdkDisplayId) {
+            // DisplayAndroid is added lazily on first use. This is to workaround corner case
+            // bug where DisplayManager.getDisplay(sdkDisplayId) returning null here.
+        }
+
+        @Override
+        public void onDisplayRemoved(int sdkDisplayId) {
+            // Never remove the primary display.
+            if (sdkDisplayId == mMainSdkDisplayId) return;
+
+            PhysicalDisplayAndroid displayAndroid =
+                    (PhysicalDisplayAndroid) mIdMap.get(sdkDisplayId);
+            if (displayAndroid == null) return;
+
+            displayAndroid.onDisplayRemoved();
+            if (mNativePointer != 0) {
+                DisplayAndroidManagerJni.get().removeDisplay(
+                        mNativePointer, DisplayAndroidManager.this, sdkDisplayId);
+            }
+            mIdMap.remove(sdkDisplayId);
+        }
+
+        @Override
+        public void onDisplayChanged(int sdkDisplayId) {
+            PhysicalDisplayAndroid displayAndroid =
+                    (PhysicalDisplayAndroid) mIdMap.get(sdkDisplayId);
+            Display display = getDisplayManager().getDisplay(sdkDisplayId);
+            // Note display null check here is needed because there appear to be an edge case in
+            // android display code, similar to onDisplayAdded.
+            if (displayAndroid != null && display != null) {
+                displayAndroid.updateFromDisplay(display);
+            }
+        }
+    }
+
+    private static DisplayAndroidManager sDisplayAndroidManager;
+
+    // Real displays (as in, displays backed by an Android Display and recognized by the OS, though
+    // not necessarily physical displays) on Android start at ID 0, and increment indefinitely as
+    // displays are added. Display IDs are never reused until reboot. To avoid any overlap, start
+    // virtual display ids at a much higher number, and increment them in the same way.
+    private static final int VIRTUAL_DISPLAY_ID_BEGIN = Integer.MAX_VALUE / 2;
+
+    private long mNativePointer;
+    private int mMainSdkDisplayId;
+    private final SparseArray<DisplayAndroid> mIdMap = new SparseArray<>();
+    private DisplayListenerBackend mBackend = new DisplayListenerBackend();
+
+    /* package */ static DisplayAndroidManager getInstance() {
+        ThreadUtils.assertOnUiThread();
+        if (sDisplayAndroidManager == null) {
+            // Split between creation and initialization to allow for calls from DisplayAndroid to
+            // reference sDisplayAndroidManager during initialize().
+            sDisplayAndroidManager = new DisplayAndroidManager();
+            sDisplayAndroidManager.initialize();
+        }
+        return sDisplayAndroidManager;
+    }
+
+    public static Display getDefaultDisplayForContext(Context context) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            Display display = null;
+            try {
+                display = ApiHelperForR.getDisplay(context);
+            } catch (UnsupportedOperationException e) {
+                // Context is not associated with a display.
+            }
+            if (display != null) return display;
+            return getGlobalDefaultDisplay();
+        }
+        return getDisplayForContextNoChecks(context);
+    }
+
+    private static Display getGlobalDefaultDisplay() {
+        return getDisplayManager().getDisplay(Display.DEFAULT_DISPLAY);
+    }
+
+    // Passing a non-window display may cause problems on newer android versions.
+    private static Display getDisplayForContextNoChecks(Context context) {
+        WindowManager windowManager =
+                (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
+        return windowManager.getDefaultDisplay();
+    }
+
+    private static Context getContext() {
+        // Using the global application context is probably ok.
+        // The DisplayManager API observers all display updates, so in theory it should not matter
+        // which context is used to obtain it. If this turns out not to be true in practice, it's
+        // possible register from all context used though quite complex.
+        return ContextUtils.getApplicationContext();
+    }
+
+    @SuppressLint("NewApi")
+    private static DisplayManager getDisplayManager() {
+        return (DisplayManager) getContext().getSystemService(Context.DISPLAY_SERVICE);
+    }
+
+    @CalledByNative
+    private static void onNativeSideCreated(long nativePointer) {
+        DisplayAndroidManager singleton = getInstance();
+        singleton.setNativePointer(nativePointer);
+    }
+
+    private DisplayAndroidManager() {}
+
+    private void initialize() {
+        // Make sure the display map contains the built-in primary display.
+        // The primary display is never removed.
+        Display display = getGlobalDefaultDisplay();
+
+        // Android documentation on Display.DEFAULT_DISPLAY suggests that the above
+        // method might return null. In that case we retrieve the default display
+        // from the application context and take it as the primary display.
+        if (display == null) display = getDisplayForContextNoChecks(getContext());
+
+        mMainSdkDisplayId = display.getDisplayId();
+        addDisplay(display); // Note this display is never removed.
+
+        mBackend.startListening();
+    }
+
+    private void setNativePointer(long nativePointer) {
+        mNativePointer = nativePointer;
+        DisplayAndroidManagerJni.get().setPrimaryDisplayId(
+                mNativePointer, DisplayAndroidManager.this, mMainSdkDisplayId);
+
+        for (int i = 0; i < mIdMap.size(); ++i) {
+            updateDisplayOnNativeSide(mIdMap.valueAt(i));
+        }
+    }
+
+    /* package */ DisplayAndroid getDisplayAndroid(Display display) {
+        int sdkDisplayId = display.getDisplayId();
+        DisplayAndroid displayAndroid = mIdMap.get(sdkDisplayId);
+        if (displayAndroid == null) {
+            displayAndroid = addDisplay(display);
+        }
+        return displayAndroid;
+    }
+
+    private DisplayAndroid addDisplay(Display display) {
+        int sdkDisplayId = display.getDisplayId();
+        PhysicalDisplayAndroid displayAndroid = new PhysicalDisplayAndroid(display);
+        assert mIdMap.get(sdkDisplayId) == null;
+        mIdMap.put(sdkDisplayId, displayAndroid);
+        displayAndroid.updateFromDisplay(display);
+        return displayAndroid;
+    }
+
+    /* package */ void updateDisplayOnNativeSide(DisplayAndroid displayAndroid) {
+        if (mNativePointer == 0) return;
+        DisplayAndroidManagerJni.get().updateDisplay(mNativePointer, DisplayAndroidManager.this,
+                displayAndroid.getDisplayId(), displayAndroid.getDisplayWidth(),
+                displayAndroid.getDisplayHeight(), displayAndroid.getDipScale(),
+                displayAndroid.getRotationDegrees(), displayAndroid.getBitsPerPixel(),
+                displayAndroid.getBitsPerComponent(), displayAndroid.getIsWideColorGamut(),
+                displayAndroid.getHdrMaxLuminanceRatio());
+    }
+
+    @NativeMethods
+    interface Natives {
+        void updateDisplay(long nativeDisplayAndroidManager, DisplayAndroidManager caller,
+                int sdkDisplayId, int width, int height, float dipScale, int rotationDegrees,
+                int bitsPerPixel, int bitsPerComponent, boolean isWideColorGamut,
+                float hdrMaxLuminanceRatio);
+        void removeDisplay(
+                long nativeDisplayAndroidManager, DisplayAndroidManager caller, int sdkDisplayId);
+        void setPrimaryDisplayId(
+                long nativeDisplayAndroidManager, DisplayAndroidManager caller, int sdkDisplayId);
+    }
+
+    /** Clears the object returned by {@link #getInstance()} */
+    @VisibleForTesting
+    public static void resetInstanceForTesting() {
+        sDisplayAndroidManager = null;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/display/DisplaySwitches.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/display/DisplaySwitches.java
@@ -1,0 +1,16 @@
+// Copyright 2016 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.display;
+
+/**
+ * Contains all of the command line switches that are specific to the display.
+ */
+public abstract class DisplaySwitches {
+    // Native switch - display_switches::kForceDeviceScaleFactor
+    public static final String FORCE_DEVICE_SCALE_FACTOR = "force-device-scale-factor";
+
+    // Prevent instantiation.
+    private DisplaySwitches() {}
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/display/PhysicalDisplayAndroid.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/display/PhysicalDisplayAndroid.java
@@ -1,0 +1,344 @@
+// Copyright 2016 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.display;
+
+import android.content.ComponentCallbacks;
+import android.content.Context;
+import android.content.res.Configuration;
+import android.graphics.PixelFormat;
+import android.graphics.Point;
+import android.graphics.Rect;
+import android.os.Build;
+import android.util.DisplayMetrics;
+import android.view.Display;
+import android.view.WindowManager;
+
+import androidx.annotation.OptIn;
+import androidx.core.os.BuildCompat;
+
+import org.chromium.base.CommandLine;
+import org.chromium.base.ContextUtils;
+import org.chromium.base.Log;
+import org.chromium.base.StrictModeContext;
+import org.chromium.base.ThreadUtils;
+import org.chromium.base.compat.ApiHelperForO;
+import org.chromium.base.compat.ApiHelperForR;
+import org.chromium.base.compat.ApiHelperForS;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.function.Consumer;
+
+/**
+ * A DisplayAndroid implementation tied to a physical Display.
+ */
+/* package */ class PhysicalDisplayAndroid extends DisplayAndroid {
+    private static final String TAG = "DisplayAndroid";
+
+    // The behavior of observing window configuration changes using ComponentCallbacks is new in S.
+    private static final boolean USE_CONFIGURATION = Build.VERSION.SDK_INT >= Build.VERSION_CODES.S;
+
+    // When this object exists, a positive value means that the forced DIP scale is set and
+    // the zero means it is not. The non existing object (i.e. null reference) means that
+    // the existence and value of the forced DIP scale has not yet been determined.
+    private static Float sForcedDIPScale;
+
+    private static boolean sLookupMethodSucceeded;
+    private static boolean sLookupMethodFailed;
+    private static Method sIsHdrSdrRatioAvailableMethod;
+    private static Method sGetHdrSdrRatioMethod;
+    private static Method sRegisterHdrSdrRatioChangedListenerMethod;
+    private static Method sUnregisterHdrSdrRatioChangedListenerMethod;
+
+    @OptIn(markerClass = androidx.core.os.BuildCompat.PrereleaseSdkCheck.class)
+    private static boolean lookupHdrSdrRatioMethods() {
+        if (sLookupMethodFailed) return false;
+        if (sLookupMethodSucceeded) return true;
+        if (!BuildCompat.isAtLeastU()) {
+            sLookupMethodSucceeded = false;
+            return false;
+        }
+        try {
+            sIsHdrSdrRatioAvailableMethod =
+                    Display.class.getDeclaredMethod("isHdrSdrRatioAvailable");
+            sGetHdrSdrRatioMethod = Display.class.getDeclaredMethod("getHdrSdrRatio");
+            sRegisterHdrSdrRatioChangedListenerMethod = Display.class.getDeclaredMethod(
+                    "registerHdrSdrRatioChangedListener", Executor.class, Consumer.class);
+            sUnregisterHdrSdrRatioChangedListenerMethod = Display.class.getDeclaredMethod(
+                    "unregisterHdrSdrRatioChangedListener", Consumer.class);
+        } catch (NoSuchMethodException e) {
+            sLookupMethodFailed = true;
+            return false;
+        }
+        sLookupMethodSucceeded = true;
+        return true;
+    }
+
+    private static Float getHdrSdrRatio(Display display) {
+        if (!lookupHdrSdrRatioMethods()) return null;
+        try {
+            return (Float) sGetHdrSdrRatioMethod.invoke(display);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            Log.w(TAG, "getHdrSdrRatioMethod failed", e);
+            return null;
+        }
+    }
+
+    private static boolean isHdrSdrRatioAvailable(Display display) {
+        if (!lookupHdrSdrRatioMethods()) return false;
+        try {
+            return (Boolean) sIsHdrSdrRatioAvailableMethod.invoke(display);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            Log.w(TAG, "isHdrSdrRatioAvailable failed", e);
+            return false;
+        }
+    }
+
+    private static boolean registerHdrSdrRatioChangedListener(
+            Display display, Executor executor, Consumer<Display> listener) {
+        if (!lookupHdrSdrRatioMethods()) return false;
+        try {
+            sRegisterHdrSdrRatioChangedListenerMethod.invoke(display, executor, listener);
+            return true;
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            Log.w(TAG, "registerHdrSdrRatioChangedListener failed", e);
+            return false;
+        }
+    }
+
+    private static void unregisterHdrSdrRatioChangedListener(
+            Display display, Consumer<Display> listener) {
+        if (!lookupHdrSdrRatioMethods()) return;
+        try {
+            sUnregisterHdrSdrRatioChangedListenerMethod.invoke(display, listener);
+        } catch (IllegalAccessException | InvocationTargetException e) {
+            Log.w(TAG, "unregisterHdrSdrRatioChangedListener failed", e);
+        }
+    }
+
+    private static boolean hasForcedDIPScale() {
+        if (sForcedDIPScale == null) {
+            String forcedScaleAsString = CommandLine.getInstance().getSwitchValue(
+                    DisplaySwitches.FORCE_DEVICE_SCALE_FACTOR);
+            if (forcedScaleAsString == null) {
+                sForcedDIPScale = Float.valueOf(0.0f);
+            } else {
+                boolean isInvalid = false;
+                try {
+                    sForcedDIPScale = Float.valueOf(forcedScaleAsString);
+                    // Negative values are discarded.
+                    if (sForcedDIPScale.floatValue() <= 0.0f) isInvalid = true;
+                } catch (NumberFormatException e) {
+                    // Strings that do not represent numbers are discarded.
+                    isInvalid = true;
+                }
+
+                if (isInvalid) {
+                    Log.w(TAG, "Ignoring invalid forced DIP scale '" + forcedScaleAsString + "'");
+                    sForcedDIPScale = Float.valueOf(0.0f);
+                }
+            }
+        }
+        return sForcedDIPScale.floatValue() > 0;
+    }
+
+    /**
+     * This method returns the bitsPerPixel without the alpha channel, as this is the value expected
+     * by Chrome and the CSS media queries.
+     */
+    @SuppressWarnings("deprecation")
+    private static int bitsPerPixel(int pixelFormatId) {
+        // For JB-MR1 and above, this is the only value, so we can hard-code the result.
+        if (pixelFormatId == PixelFormat.RGBA_8888) return 24;
+
+        PixelFormat pixelFormat = new PixelFormat();
+        PixelFormat.getPixelFormatInfo(pixelFormatId, pixelFormat);
+        if (!PixelFormat.formatHasAlpha(pixelFormatId)) return pixelFormat.bitsPerPixel;
+
+        switch (pixelFormatId) {
+            case PixelFormat.RGBA_1010102:
+                return 30;
+
+            case PixelFormat.RGBA_4444:
+                return 12;
+
+            case PixelFormat.RGBA_5551:
+                return 15;
+
+            case PixelFormat.RGBA_8888:
+                assert false;
+            // fall through
+            // RGBX_8888 does not have an alpha channel even if it has 8 reserved bits at the end.
+            case PixelFormat.RGBX_8888:
+            case PixelFormat.RGB_888:
+            default:
+                return 24;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    private static int bitsPerComponent(int pixelFormatId) {
+        switch (pixelFormatId) {
+            case PixelFormat.RGBA_4444:
+                return 4;
+
+            case PixelFormat.RGBA_5551:
+                return 5;
+
+            case PixelFormat.RGBA_8888:
+            case PixelFormat.RGBX_8888:
+            case PixelFormat.RGB_888:
+                return 8;
+
+            case PixelFormat.RGB_332:
+                return 2;
+
+            case PixelFormat.RGB_565:
+                return 5;
+
+            // Non-RGB formats.
+            case PixelFormat.A_8:
+            case PixelFormat.LA_88:
+            case PixelFormat.L_8:
+                return 0;
+
+            // Unknown format. Use 8 as a sensible default.
+            default:
+                return 8;
+        }
+    }
+
+    private final Context mWindowContext;
+    private final ComponentCallbacks mComponentCallbacks;
+    private final Display mDisplay;
+    private Consumer<Display> mHdrSdrRatioCallback;
+
+    /* package */ PhysicalDisplayAndroid(Display display) {
+        super(display.getDisplayId());
+        if (USE_CONFIGURATION) {
+            Context appContext = ContextUtils.getApplicationContext();
+            // `createWindowContext` on some devices writes to disk. See crbug.com/1408587.
+            try (StrictModeContext ignored = StrictModeContext.allowAllThreadPolicies()) {
+                mWindowContext = ApiHelperForS.createWindowContext(
+                        appContext, display, WindowManager.LayoutParams.TYPE_APPLICATION, null);
+            }
+            assert display.getDisplayId()
+                    == ApiHelperForR.getDisplay(mWindowContext).getDisplayId();
+            mComponentCallbacks = new ComponentCallbacks() {
+                @Override
+                public void onLowMemory() {}
+
+                @Override
+                public void onConfigurationChanged(Configuration newConfig) {
+                    updateFromConfiguration();
+                }
+            };
+            mWindowContext.registerComponentCallbacks(mComponentCallbacks);
+            mDisplay = ApiHelperForR.getDisplay(mWindowContext);
+            updateFromConfiguration();
+        } else {
+            mWindowContext = null;
+            mComponentCallbacks = null;
+            mDisplay = display;
+        }
+
+        if (isHdrSdrRatioAvailable(mDisplay)) {
+            mHdrSdrRatioCallback = this::hdrSdrRatioChanged;
+            if (!registerHdrSdrRatioChangedListener(mDisplay, (Runnable runnable) -> {
+                    ThreadUtils.getUiThreadHandler().post(runnable);
+                }, mHdrSdrRatioCallback)) {
+                mHdrSdrRatioCallback = null;
+            }
+        } else {
+            mHdrSdrRatioCallback = null;
+        }
+    }
+
+    @Override
+    public Context getWindowContext() {
+        return mWindowContext;
+    }
+
+    private void updateFromConfiguration() {
+        Point size = new Point();
+        WindowManager windowManager = mWindowContext.getSystemService(WindowManager.class);
+        Rect rect = ApiHelperForR.getMaximumWindowMetricsBounds(windowManager);
+        size.set(rect.width(), rect.height());
+        DisplayMetrics displayMetrics = mWindowContext.getResources().getDisplayMetrics();
+        updateCommon(size, displayMetrics.density, displayMetrics.xdpi, displayMetrics.ydpi,
+                ApiHelperForR.getDisplay(mWindowContext));
+    }
+
+    /* package */ void onDisplayRemoved() {
+        if (USE_CONFIGURATION) {
+            mWindowContext.unregisterComponentCallbacks(mComponentCallbacks);
+        }
+        if (mHdrSdrRatioCallback != null) {
+            unregisterHdrSdrRatioChangedListener(mDisplay, mHdrSdrRatioCallback);
+            mHdrSdrRatioCallback = null;
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    /* package */ void updateFromDisplay(Display display) {
+        if (USE_CONFIGURATION) {
+            assert display.getDisplayId() == mDisplay.getDisplayId();
+            // Needed to update non-configuration info such as refresh rate.
+            updateFromConfiguration();
+            return;
+        }
+        Point size = new Point();
+        DisplayMetrics displayMetrics = new DisplayMetrics();
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
+            display.getRealSize(size);
+            display.getRealMetrics(displayMetrics);
+        } else {
+            display.getSize(size);
+            display.getMetrics(displayMetrics);
+        }
+        updateCommon(
+                size, displayMetrics.density, displayMetrics.xdpi, displayMetrics.ydpi, display);
+    }
+
+    private void hdrSdrRatioChanged(Display display) {
+        assert display.getDisplayId() == mDisplay.getDisplayId();
+        super.update(null, null, null, null, null, null, null, null, null, null, null, null,
+                getHdrSdrRatio(mDisplay));
+    }
+
+    private void updateCommon(Point size, float density, float xdpi, float ydpi, Display display) {
+        if (hasForcedDIPScale()) density = sForcedDIPScale.floatValue();
+        boolean isWideColorGamut = false;
+        // Although this API was added in Android O, it was buggy.
+        // Restrict to Android Q, where it was fixed.
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
+            isWideColorGamut = ApiHelperForO.isWideColorGamut(display);
+        }
+
+        int pixelFormatId = PixelFormat.RGBA_8888;
+
+        // Note: getMode() and getSupportedModes() can return null in some situations - see
+        // crbug.com/1401322.
+        // Can also throw when modeId=-1 (b/441513616).
+        Display.Mode currentMode = null;
+        try {
+            currentMode = display.getMode();
+        } catch (Exception e) {
+            Log.w(TAG, "Invalid display mode", e);
+        }
+        Display.Mode[] modes = display.getSupportedModes();
+        List<Display.Mode> supportedModes = null;
+        if (modes != null && modes.length > 0) {
+            supportedModes = Arrays.asList(modes);
+        }
+
+        super.update(size, density, xdpi, ydpi, bitsPerPixel(pixelFormatId),
+                bitsPerComponent(pixelFormatId), display.getRotation(), isWideColorGamut, null,
+                display.getRefreshRate(), currentMode, supportedModes, getHdrSdrRatio(display));
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/AnimatedImageDragShadowBuilder.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/AnimatedImageDragShadowBuilder.java
@@ -1,0 +1,304 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.dragdrop;
+
+import android.animation.ObjectAnimator;
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.BitmapShader;
+import android.graphics.Canvas;
+import android.graphics.Matrix;
+import android.graphics.Paint;
+import android.graphics.Point;
+import android.graphics.RectF;
+import android.graphics.Shader;
+import android.media.ThumbnailUtils;
+import android.util.FloatProperty;
+import android.view.View;
+
+import androidx.core.content.res.ResourcesCompat;
+
+import dev.cobalt.ui.R;
+
+/**
+ * A {@link View.DragShadowBuilder} that animate the drag shadow from the original image in the web
+ * to the center of the touch point.
+ * See go/animated-image-drag-shadow-corner-cases for known edge cases.
+ */
+class AnimatedImageDragShadowBuilder extends View.DragShadowBuilder {
+    /**
+     * Animatable progress for the drag shadow. When the progress is 0, the drag shadow is full
+     * size and the touch point of the original view matches the touch point in the shadow. As
+     * the progress animates to 1, the drag shadow shrinks and translates to have the users
+     * finger in the center of the drag shadow.
+     */
+    private final FloatProperty<AnimatedImageDragShadowBuilder> mProgressProperty =
+            new FloatProperty<AnimatedImageDragShadowBuilder>("progress") {
+                @Override
+                public void setValue(
+                        AnimatedImageDragShadowBuilder animatedImageDragShadowBuilder, float v) {
+                    animatedImageDragShadowBuilder.mProgress = v;
+                    animatedImageDragShadowBuilder.mContainerView.updateDragShadow(
+                            animatedImageDragShadowBuilder);
+                }
+
+                @Override
+                public Float get(AnimatedImageDragShadowBuilder animatedImageDragShadowBuilder) {
+                    return animatedImageDragShadowBuilder.mProgress;
+                }
+            };
+
+    private static final int ANIMATION_DURATION_MS = 300;
+    private static final int MAX_ALPHA_VALUE = 255;
+    private static final float TARGET_ALPHA_RATIO = 0.6f;
+
+    private final float mEndCornerRadius;
+    private final float mStartCornerRadius;
+    private final Paint mPaint;
+    private final Paint mPaintBorder;
+    private final RectF mBitmapRect;
+    private final Matrix mTransformMatrix;
+    private final View mContainerView;
+    private final int mBorderSize;
+
+    private final RectF mStartBounds = new RectF();
+    private final RectF mEndBounds = new RectF();
+    private final RectF mCurrentBounds = new RectF();
+    private final RectF mBorderBounds = new RectF();
+    private final RectF mCanvasRect = new RectF();
+
+    private float mProgress;
+
+    /**
+     * @param containerView The container view where the drag starts.
+     * @param bitmap The bitmap which represents the shadow image.
+     * @param startX The x offset of the touch point relative to the top left corner of the original
+     *         image in the web.
+     * @param startY The y offset of the touch point relative to the top left corner of the original
+     *         image in the web.
+     * @param dragShadowSpec The spec of the drag shadow including its size.
+     */
+    public AnimatedImageDragShadowBuilder(View containerView, Bitmap bitmap, float startX,
+            float startY, DragShadowSpec dragShadowSpec) {
+        this.mContainerView = containerView;
+        Bitmap croppedDragShadow =
+                ThumbnailUtils.extractThumbnail(bitmap, dragShadowSpec.startWidth,
+                        dragShadowSpec.startHeight, ThumbnailUtils.OPTIONS_RECYCLE_INPUT);
+        float resizeRatio = (float) dragShadowSpec.targetWidth / dragShadowSpec.startWidth;
+        Resources res = containerView.getResources();
+        mProgress = 0f;
+
+        mStartBounds.set(0, 0, dragShadowSpec.startWidth, dragShadowSpec.startHeight);
+
+        // End bounds have a different scale, and centered at the users touch point.
+        mEndBounds.set(0, 0, dragShadowSpec.targetWidth, dragShadowSpec.targetHeight);
+        centerRectAtPoint(mEndBounds, startX, startY);
+
+        // The canvas must include the start and end bounds to avoid clipping.
+        mCanvasRect.set(mStartBounds);
+        mCanvasRect.union(mEndBounds);
+
+        // Reserve space for the border.
+        mBorderSize = res.getDimensionPixelSize(R.dimen.drag_shadow_border_size);
+        mCanvasRect.left -= mBorderSize;
+        mCanvasRect.top -= mBorderSize;
+        mCanvasRect.right += mBorderSize;
+        mCanvasRect.bottom += mBorderSize;
+
+        // Normalize everything into positive coordinates because we can't draw at negative
+        // values on the canvas.
+        float canvasOffsetX = -mCanvasRect.left;
+        float canvasOffsetY = -mCanvasRect.top;
+        mCanvasRect.offset(canvasOffsetX, canvasOffsetY);
+        mStartBounds.offset(canvasOffsetX, canvasOffsetY);
+        mEndBounds.offset(canvasOffsetX, canvasOffsetY);
+
+        mEndCornerRadius = res.getDimensionPixelSize(R.dimen.drag_shadow_border_corner_radius);
+        mStartCornerRadius = mEndCornerRadius / resizeRatio;
+
+        mBitmapRect = new RectF(0, 0, croppedDragShadow.getWidth(), croppedDragShadow.getHeight());
+
+        BitmapShader shader =
+                new BitmapShader(croppedDragShadow, Shader.TileMode.CLAMP, Shader.TileMode.CLAMP);
+        mPaint = new Paint();
+        mPaint.setShader(shader);
+        mPaintBorder = new Paint();
+        mPaintBorder.setStyle(Paint.Style.STROKE);
+        mPaintBorder.setStrokeWidth(mBorderSize);
+        mPaintBorder.setColor(res.getColor(R.color.baseline_neutral_variant_100_alpha_20));
+        mTransformMatrix = new Matrix();
+    }
+
+    @Override
+    public void onProvideShadowMetrics(Point outShadowSize, Point outShadowTouchPoint) {
+        outShadowSize.set(Math.round(mCanvasRect.width()), Math.round(mCanvasRect.height()));
+        outShadowTouchPoint.set(Math.round(mEndBounds.centerX()), Math.round(mEndBounds.centerY()));
+        ObjectAnimator animator = ObjectAnimator.ofFloat(this, mProgressProperty, 1f);
+        animator.setAutoCancel(true);
+        animator.setDuration(ANIMATION_DURATION_MS);
+        animator.start();
+    }
+
+    @Override
+    public void onDrawShadow(Canvas canvas) {
+        mCurrentBounds.set(lerp(mStartBounds.left, mEndBounds.left, mProgress),
+                lerp(mStartBounds.top, mEndBounds.top, mProgress),
+                lerp(mStartBounds.right, mEndBounds.right, mProgress),
+                lerp(mStartBounds.bottom, mEndBounds.bottom, mProgress));
+
+        mTransformMatrix.setRectToRect(mBitmapRect, mCurrentBounds, Matrix.ScaleToFit.CENTER);
+        mPaint.getShader().setLocalMatrix(mTransformMatrix);
+
+        float cornerRadius = lerp(mStartCornerRadius, mEndCornerRadius, mProgress);
+        mPaint.setAlpha(Math.round(MAX_ALPHA_VALUE * (1f - mProgress * (1 - TARGET_ALPHA_RATIO))));
+        canvas.drawRoundRect(mCurrentBounds, cornerRadius, cornerRadius, mPaint);
+        // The border stroke is centered at the bounds. To avoid overlap with the shadow, the
+        // stroke should be shifted outward half of the border size.
+        mBorderBounds.set(mCurrentBounds.left - mBorderSize / 2f,
+                mCurrentBounds.top - mBorderSize / 2f, mCurrentBounds.right + mBorderSize / 2f,
+                mCurrentBounds.bottom + mBorderSize / 2f);
+        canvas.drawRoundRect(mBorderBounds, cornerRadius, cornerRadius, mPaintBorder);
+    }
+
+    private static void centerRectAtPoint(RectF centerThisRect, float atX, float atY) {
+        centerThisRect.offset(atX - centerThisRect.centerX(), atY - centerThisRect.centerY());
+    }
+
+    /** Linear interpolate from start value to stop value by amount [0..1] */
+    private static float lerp(float start, float stop, float amount) {
+        return start + (stop - start) * amount;
+    }
+
+    /**
+     * Return the {@link DragShadowSpec} based on the image size and window size.
+     * TODO(crbug.com/1295868): Scale image in C++ before passing into Java.
+     */
+    static DragShadowSpec getDragShadowSpec(
+            Context context, int imageWidth, int imageHeight, int windowWidth, int windowHeight) {
+        Resources resources = context.getResources();
+        float startWidth = imageWidth;
+        float startHeight = imageHeight;
+        float targetWidth = startWidth;
+        float targetHeight = startHeight;
+        float truncatedWidth = 0f;
+        float truncatedHeight = 0f;
+
+        // Calculate the default scaled width / height.
+        final float resizeRatio =
+                ResourcesCompat.getFloat(resources, R.dimen.drag_shadow_resize_ratio);
+        targetWidth *= resizeRatio;
+        targetHeight *= resizeRatio;
+
+        // Scale down if the width / height exceeded the max width / height, estimated based on the
+        // window size, while maintaining the width-to-height ratio.
+        final float maxSizeRatio =
+                ResourcesCompat.getFloat(resources, R.dimen.drag_shadow_max_size_to_window_ratio);
+        final float maxHeightPx = windowHeight * maxSizeRatio;
+        final float maxWidthPx = windowWidth * maxSizeRatio;
+        if (targetWidth > maxWidthPx || targetHeight > maxHeightPx) {
+            final float downScaleRatio =
+                    Math.min(maxHeightPx / targetHeight, maxWidthPx / targetWidth);
+            targetWidth *= downScaleRatio;
+            targetHeight *= downScaleRatio;
+        }
+
+        // Scale up with respect to the short side if the width or height is smaller than the min
+        // size. Truncate the long side to stay within the max width / height as applicable.
+        final int minSizePx = getDragShadowMinSize(resources);
+        if (targetWidth <= targetHeight && targetWidth < minSizePx) {
+            final float scaleUpRatio = minSizePx / targetWidth;
+            targetHeight *= scaleUpRatio;
+            targetWidth *= scaleUpRatio;
+            if (targetHeight > maxHeightPx) {
+                targetHeight = maxHeightPx;
+                startHeight = targetHeight / targetWidth * startWidth;
+                truncatedHeight = (imageHeight - startHeight) / 2;
+            }
+        } else if (targetHeight < minSizePx) {
+            float scaleUpRatio = minSizePx / targetHeight;
+            targetHeight *= scaleUpRatio;
+            targetWidth *= scaleUpRatio;
+            if (targetWidth > maxWidthPx) {
+                targetWidth = maxWidthPx;
+                startWidth = targetWidth / targetHeight * startHeight;
+                truncatedWidth = (imageWidth - startWidth) / 2;
+            }
+        }
+        return new DragShadowSpec(Math.round(startWidth), Math.round(startHeight),
+                Math.round(targetWidth), Math.round(targetHeight), Math.round(truncatedWidth),
+                Math.round(truncatedHeight));
+    }
+
+    /**
+     * Return the adjusted {@link CursorOffset} based on the drag object size and shadow size.
+     */
+    static CursorOffset adjustCursorOffset(float cursorOffsetX, float cursorOffsetY,
+            int dragObjRectWidth, int dragObjRectHeight, DragShadowSpec dragShadowSpec) {
+        assert dragShadowSpec.truncatedHeight == 0
+                || dragShadowSpec.truncatedWidth
+                        == 0 : "Drag shadow should not be truncated in both dimensions";
+        float adjustedOffsetX = cursorOffsetX;
+        float adjustedOffsetY = cursorOffsetY;
+        if (dragShadowSpec.truncatedHeight != 0) {
+            float scaleFactor = (float) dragShadowSpec.startWidth / dragObjRectWidth;
+            adjustedOffsetX *= scaleFactor;
+            adjustedOffsetY *= scaleFactor;
+            adjustedOffsetY -= dragShadowSpec.truncatedHeight;
+            adjustedOffsetY = Math.max(0, adjustedOffsetY);
+            adjustedOffsetY = Math.min(dragShadowSpec.startHeight, adjustedOffsetY);
+            return new CursorOffset(adjustedOffsetX, adjustedOffsetY);
+        }
+        if (dragShadowSpec.truncatedWidth != 0) {
+            float scaleFactor = (float) dragShadowSpec.startHeight / dragObjRectHeight;
+            adjustedOffsetX *= scaleFactor;
+            adjustedOffsetY *= scaleFactor;
+            adjustedOffsetX -= dragShadowSpec.truncatedWidth;
+            adjustedOffsetX = Math.max(0, adjustedOffsetX);
+            adjustedOffsetX = Math.min(dragShadowSpec.startWidth, adjustedOffsetX);
+            return new CursorOffset(adjustedOffsetX, adjustedOffsetY);
+        }
+        float scaleFactor = (float) dragShadowSpec.startWidth / dragObjRectWidth;
+        adjustedOffsetX *= scaleFactor;
+        adjustedOffsetY *= scaleFactor;
+        return new CursorOffset(adjustedOffsetX, adjustedOffsetY);
+    }
+
+    /**
+     * Return the minimum size of the drag shadow image.
+     */
+    static int getDragShadowMinSize(Resources resources) {
+        return resources.getDimensionPixelSize(R.dimen.drag_shadow_min_size);
+    }
+
+    static class DragShadowSpec {
+        public final int startWidth;
+        public final int startHeight;
+        public final int targetWidth;
+        public final int targetHeight;
+        public final int truncatedWidth;
+        public final int truncatedHeight;
+
+        DragShadowSpec(int startWidth, int startHeight, int targetWidth, int targetHeight,
+                int truncatedWidth, int truncatedHeight) {
+            this.startWidth = startWidth;
+            this.startHeight = startHeight;
+            this.targetWidth = targetWidth;
+            this.targetHeight = targetHeight;
+            this.truncatedWidth = truncatedWidth;
+            this.truncatedHeight = truncatedHeight;
+        }
+    }
+
+    static class CursorOffset {
+        public final float x;
+        public final float y;
+
+        CursorOffset(float x, float y) {
+            this.x = x;
+            this.y = y;
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DragAndDropBrowserDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DragAndDropBrowserDelegate.java
@@ -1,0 +1,26 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.dragdrop;
+
+import android.content.Intent;
+import android.view.DragAndDropPermissions;
+import android.view.DragEvent;
+
+/**
+ * Delegate for browser related functions used by Drag and Drop.
+ */
+public interface DragAndDropBrowserDelegate {
+    /** Get whether to support the image drop into Chrome. */
+    boolean getSupportDropInChrome();
+
+    /** Get whether to support the image drag shadow animation. */
+    boolean getSupportAnimatedImageDragShadow();
+
+    /** Request DragAndDropPermissions. */
+    DragAndDropPermissions getDragAndDropPermissions(DragEvent dropEvent);
+
+    /** Create an intent from a dragged text link. */
+    Intent createLinkIntent(String urlString);
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DragAndDropDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DragAndDropDelegate.java
@@ -1,0 +1,35 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.dragdrop;
+
+import android.graphics.Bitmap;
+import android.os.Build;
+import android.view.View;
+
+/**
+ * Delegate to facilitate Drag and Drop operations, for example re-routing the call to {@link
+ * #startDragAndDrop(Bitmap, DropDataAndroid).}
+ */
+public interface DragAndDropDelegate {
+    /**
+     * General feature switch whether drag and drop is enabled for the current Android OS.
+     */
+    static boolean isDragAndDropSupportedForOs() {
+        // Only enabled on Android O+ to mitigate known issue for drag and drop in Android system.
+        // See b/245614280.
+        return (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O);
+    }
+
+    /** @see View#startDragAndDrop */
+    boolean startDragAndDrop(View containerView, Bitmap shadowImage, DropDataAndroid dropData,
+            int cursorOffsetX, int cursorOffsetY, int dragObjRectWidth, int dragObjRectHeight);
+
+    /**
+     * Set the {@link DragAndDropBrowserDelegate} that will be used to facilitate browser related
+     * tasks required for Drag and Drop.
+     * @param delegate The {@link DragAndDropBrowserDelegate} that will be used by this class.
+     */
+    default void setDragAndDropBrowserDelegate(DragAndDropBrowserDelegate delegate) {}
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DragAndDropDelegateImpl.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DragAndDropDelegateImpl.java
@@ -1,0 +1,447 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.dragdrop;
+
+import android.content.ClipData;
+import android.content.ClipData.Item;
+import android.content.ClipDescription;
+import android.content.Context;
+import android.content.Intent;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.media.ThumbnailUtils;
+import android.net.Uri;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.os.SystemClock;
+import android.text.TextUtils;
+import android.view.DragAndDropPermissions;
+import android.view.DragEvent;
+import android.view.View;
+import android.view.View.DragShadowBuilder;
+import android.view.ViewGroup;
+import android.view.accessibility.AccessibilityManager;
+import android.widget.ImageView;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.graphics.drawable.RoundedBitmapDrawable;
+import androidx.core.graphics.drawable.RoundedBitmapDrawableFactory;
+
+import org.chromium.base.ContextUtils;
+import org.chromium.base.MathUtils;
+import org.chromium.base.compat.ApiHelperForN;
+import org.chromium.base.compat.ApiHelperForO;
+import org.chromium.base.metrics.RecordHistogram;
+import dev.cobalt.ui.R;
+import dev.cobalt.ui.dragdrop.AnimatedImageDragShadowBuilder.CursorOffset;
+import dev.cobalt.ui.dragdrop.AnimatedImageDragShadowBuilder.DragShadowSpec;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Drag and drop helper class in charge of building the clip data, wrapping calls to
+ * {@link android.view.View#startDragAndDrop}. Also used for mocking out real function calls to
+ * Android.
+ */
+public class DragAndDropDelegateImpl implements DragAndDropDelegate, DragStateTracker {
+    /**
+     * Java Enum of AndroidDragTargetType used for histogram recording for
+     * Android.DragDrop.FromWebContent.TargetType. This is used for histograms and should therefore
+     * be treated as append-only.
+     */
+    @IntDef({DragTargetType.INVALID, DragTargetType.TEXT, DragTargetType.IMAGE, DragTargetType.LINK,
+            DragTargetType.NUM_ENTRIES})
+    @Retention(RetentionPolicy.SOURCE)
+    @interface DragTargetType {
+        int INVALID = 0;
+        int TEXT = 1;
+        int IMAGE = 2;
+        int LINK = 3;
+
+        int NUM_ENTRIES = 4;
+    }
+
+    private int mShadowWidth;
+    private int mShadowHeight;
+    private boolean mIsDragStarted;
+
+    /**
+     * Whether the current drop has happened on top of the view this object tracks.
+     */
+    private boolean mIsDropOnView;
+
+    /**
+     * The type of drag target from the view this object tracks.
+     */
+    private @DragTargetType int mDragTargetType;
+
+    private float mDragStartXDp;
+    private float mDragStartYDp;
+
+    private long mDragStartSystemElapsedTime;
+
+    private @Nullable DragAndDropBrowserDelegate mDragAndDropBrowserDelegate;
+
+    // Implements ViewAndroidDelegate.DragAndDropDelegate
+
+    /**
+     * Create DragShadowBuilder and start {@link View#startDragAndDrop(ClipData, DragShadowBuilder,
+     * Object, int)}.
+     *
+     * @param containerView The container view where the drag starts.
+     * @param shadowImage The bitmap which represents the shadow image.
+     * @param dropData The drop data presenting the drag target.
+     * @param cursorOffsetX The x offset of the cursor w.r.t. to top-left corner of the drag-image.
+     * @param cursorOffsetY The y offset of the cursor w.r.t. to top-left corner of the drag-image.
+     * @param dragObjRectWidth The width of the drag object.
+     * @param dragObjRectHeight The height of the drag object.
+     */
+    @Override
+    public boolean startDragAndDrop(@NonNull View containerView, @NonNull Bitmap shadowImage,
+            @NonNull DropDataAndroid dropData, int cursorOffsetX, int cursorOffsetY,
+            int dragObjRectWidth, int dragObjRectHeight) {
+        // Drag and drop is disabled when gesture related a11y service is enabled.
+        // See https://crbug.com/1250067.
+        AccessibilityManager a11yManager =
+                (AccessibilityManager) containerView.getContext().getSystemService(
+                        Context.ACCESSIBILITY_SERVICE);
+        if (a11yManager.isEnabled() && a11yManager.isTouchExplorationEnabled()) return false;
+
+        ClipData clipdata = buildClipData(dropData);
+        if (clipdata == null) {
+            return false;
+        }
+
+        mIsDragStarted = true;
+        mDragStartSystemElapsedTime = SystemClock.elapsedRealtime();
+        mDragTargetType = getDragTargetType(dropData);
+        int windowWidth = containerView.getRootView().getWidth();
+        int windowHeight = containerView.getRootView().getHeight();
+        Object myLocalState = null;
+        if (mDragAndDropBrowserDelegate != null
+                && mDragAndDropBrowserDelegate.getSupportDropInChrome()) {
+            myLocalState = dropData;
+        }
+        View.DragShadowBuilder dragShadowBuilder = createDragShadowBuilder(containerView,
+                shadowImage, dropData.hasImage(), windowWidth, windowHeight, cursorOffsetX,
+                cursorOffsetY, dragObjRectWidth, dragObjRectHeight);
+        return ApiHelperForN.startDragAndDrop(
+                containerView, clipdata, dragShadowBuilder, myLocalState, buildFlags(dropData));
+    }
+
+    @Override
+    public void setDragAndDropBrowserDelegate(DragAndDropBrowserDelegate delegate) {
+        mDragAndDropBrowserDelegate = delegate;
+    }
+
+    // Implements DragStateTracker
+    @Override
+    public boolean isDragStarted() {
+        return mIsDragStarted;
+    }
+
+    @Override
+    public int getDragShadowWidth() {
+        return mShadowWidth;
+    }
+
+    @Override
+    public int getDragShadowHeight() {
+        return mShadowHeight;
+    }
+
+    @Override
+    public void destroy() {
+        reset();
+    }
+
+    // Implements View.OnDragListener
+    @Override
+    public boolean onDrag(View view, DragEvent dragEvent) {
+        if (!mIsDragStarted) {
+            if (mDragAndDropBrowserDelegate != null
+                    && mDragAndDropBrowserDelegate.getSupportDropInChrome()
+                    && dragEvent.getAction() == DragEvent.ACTION_DROP) {
+                onDropFromOutside(dragEvent);
+            }
+            return false;
+        }
+
+        switch (dragEvent.getAction()) {
+            case DragEvent.ACTION_DRAG_STARTED:
+                onDragStarted(dragEvent);
+                break;
+            case DragEvent.ACTION_DROP:
+                onDrop(dragEvent);
+                break;
+            case DragEvent.ACTION_DRAG_ENDED:
+                onDragEnd(dragEvent);
+                reset();
+                break;
+            default:
+                // No action needed for other types of drag actions.
+                break;
+        }
+        // Return false so this listener does not consume the drag event of the view it listened to.
+        return false;
+    }
+
+    /**
+     * Builds the clipData from the dragged data based on the data's type, it will return null when
+     * the input DropData cannot be converted into ClipData (e.g. dragged item is image and there's
+     * no content provider to handle it)
+     *
+     * @param dropData The data to be dropped.
+     * @return ClipData based on the dropData type.
+     */
+    @Nullable
+    protected ClipData buildClipData(DropDataAndroid dropData) {
+        @DragTargetType
+        int type = getDragTargetType(dropData);
+        switch (type) {
+            case DragTargetType.TEXT:
+                return ClipData.newPlainText(null, dropData.text);
+            case DragTargetType.IMAGE:
+                Uri cachedUri = DropDataProviderUtils.cacheImageData(dropData);
+                // If there's no content provider we shouldn't start the drag.
+                if (cachedUri == null) {
+                    return null;
+                }
+                ClipData clipData = ClipData.newUri(
+                        ContextUtils.getApplicationContext().getContentResolver(), null, cachedUri);
+                // Add image link URL to the ClipData if present. Since the ClipData MIME types for
+                // the items are different, this will not be supported for O- versions where {@link
+                // ClipData#addItem(ContentResolver, Item)} is not available.
+                if (VERSION.SDK_INT >= VERSION_CODES.O && dropData.hasLink()) {
+                    ApiHelperForO.addItem(clipData,
+                            ContextUtils.getApplicationContext().getContentResolver(),
+                            new Item(dropData.gurl.getSpec()));
+                }
+                return clipData;
+            case DragTargetType.LINK:
+                if (mDragAndDropBrowserDelegate != null) {
+                    Intent intent =
+                            mDragAndDropBrowserDelegate.createLinkIntent(dropData.gurl.getSpec());
+                    if (intent != null) {
+                        return new ClipData(null,
+                                new String[] {ClipDescription.MIMETYPE_TEXT_PLAIN,
+                                        ClipDescription.MIMETYPE_TEXT_INTENT},
+                                new Item(getTextForLinkData(dropData), intent, null));
+                    }
+                }
+                return ClipData.newPlainText(null, getTextForLinkData(dropData));
+            case DragTargetType.INVALID:
+                return null;
+            case DragTargetType.NUM_ENTRIES:
+            default:
+                assert false : "Should not be reached!";
+                return null;
+        }
+    }
+
+    protected int buildFlags(DropDataAndroid dropData) {
+        if (dropData.isPlainText()) {
+            return View.DRAG_FLAG_GLOBAL;
+        } else if (dropData.hasImage()) {
+            int flag = View.DRAG_FLAG_GLOBAL | View.DRAG_FLAG_GLOBAL_URI_READ;
+            if (mDragAndDropBrowserDelegate != null
+                    && mDragAndDropBrowserDelegate.getSupportAnimatedImageDragShadow()) {
+                flag |= View.DRAG_FLAG_OPAQUE;
+            }
+            return flag;
+        } else if (dropData.hasLink()) {
+            return View.DRAG_FLAG_GLOBAL;
+        } else {
+            return 0;
+        }
+    }
+
+    protected View.DragShadowBuilder createDragShadowBuilder(View containerView, Bitmap shadowImage,
+            boolean isImage, int windowWidth, int windowHeight, int cursorOffsetX,
+            int cursorOffsetY, int dragObjRectWidth, int dragObjRectHeight) {
+        Context context = containerView.getContext();
+        ImageView imageView = new ImageView(context);
+        if (isImage) {
+            // If drag shadow image is an 1*1 image, it is not considered as a valid drag shadow.
+            // In such cases, use a globe icon as placeholder instead. See
+            // https://crbug.com/1304433.
+            if (shadowImage.getHeight() <= 1 && shadowImage.getWidth() <= 1) {
+                Drawable globeIcon =
+                        AppCompatResources.getDrawable(context, R.drawable.ic_globe_24dp);
+                assert globeIcon != null;
+
+                final int minSize =
+                        AnimatedImageDragShadowBuilder.getDragShadowMinSize(context.getResources());
+                mShadowWidth = minSize;
+                mShadowHeight = minSize;
+                imageView.setLayoutParams(new ViewGroup.LayoutParams(minSize, minSize));
+                imageView.setScaleType(ImageView.ScaleType.FIT_CENTER);
+                imageView.setImageDrawable(globeIcon);
+            } else {
+                DragShadowSpec dragShadowSpec = AnimatedImageDragShadowBuilder.getDragShadowSpec(
+                        context, shadowImage.getWidth(), shadowImage.getHeight(), windowWidth,
+                        windowHeight);
+                updateShadowSizeWithBorder(
+                        context, dragShadowSpec.targetWidth, dragShadowSpec.targetHeight);
+                if (mDragAndDropBrowserDelegate != null
+                        && mDragAndDropBrowserDelegate.getSupportAnimatedImageDragShadow()) {
+                    assert dragObjRectWidth != 0;
+                    assert dragObjRectHeight != 0;
+                    CursorOffset cursorOffset = AnimatedImageDragShadowBuilder.adjustCursorOffset(
+                            cursorOffsetX, cursorOffsetY, dragObjRectWidth, dragObjRectHeight,
+                            dragShadowSpec);
+                    return new AnimatedImageDragShadowBuilder(containerView, shadowImage,
+                            cursorOffset.x, cursorOffset.y, dragShadowSpec);
+                } else {
+                    updateShadowImage(context, shadowImage, imageView, dragShadowSpec.targetWidth,
+                            dragShadowSpec.targetHeight);
+                }
+            }
+        } else {
+            mShadowWidth = shadowImage.getWidth();
+            mShadowHeight = shadowImage.getHeight();
+            imageView.setImageBitmap(shadowImage);
+        }
+        imageView.layout(0, 0, mShadowWidth, mShadowHeight);
+
+        return new DragShadowBuilder(imageView);
+    }
+
+    /**
+     * Helper function to update the drag shadow:
+     * 1. Resize and center crop shadowImage to target size;
+     * 2. Round corners to 8dp;
+     * 3. Add 1dp border.
+     */
+    private void updateShadowImage(Context context, Bitmap shadowImage, ImageView imageView,
+            int targetWidth, int targetHeight) {
+        Resources res = context.getResources();
+        shadowImage = ThumbnailUtils.extractThumbnail(
+                shadowImage, targetWidth, targetHeight, ThumbnailUtils.OPTIONS_RECYCLE_INPUT);
+        RoundedBitmapDrawable drawable = RoundedBitmapDrawableFactory.create(res, shadowImage);
+        drawable.setCornerRadius(
+                res.getDimensionPixelSize(R.dimen.drag_shadow_border_corner_radius));
+        imageView.setImageDrawable(drawable);
+        imageView.setBackgroundResource(R.drawable.drag_shadow_background);
+        int borderSize = res.getDimensionPixelSize(R.dimen.drag_shadow_border_size);
+        imageView.setPadding(borderSize, borderSize, borderSize, borderSize);
+    }
+
+    // Enlarge the shadow image by twice the size of the border.
+    private void updateShadowSizeWithBorder(Context context, int targetWidth, int targetHeight) {
+        Resources res = context.getResources();
+        int borderSize = res.getDimensionPixelSize(R.dimen.drag_shadow_border_size);
+        mShadowWidth = targetWidth + borderSize * 2;
+        mShadowHeight = targetHeight + borderSize * 2;
+    }
+
+    private void onDragStarted(DragEvent dragStartEvent) {
+        mDragStartXDp = dragStartEvent.getX();
+        mDragStartYDp = dragStartEvent.getY();
+    }
+
+    private void onDrop(DragEvent dropEvent) {
+        mIsDropOnView = true;
+
+        final int dropDistance = Math.round(MathUtils.distance(
+                mDragStartXDp, mDragStartYDp, dropEvent.getX(), dropEvent.getY()));
+        RecordHistogram.recordExactLinearHistogram(
+                "Android.DragDrop.FromWebContent.DropInWebContent.DistanceDip", dropDistance, 51);
+
+        long dropDuration = SystemClock.elapsedRealtime() - mDragStartSystemElapsedTime;
+        RecordHistogram.recordMediumTimesHistogram(
+                "Android.DragDrop.FromWebContent.DropInWebContent.Duration", dropDuration);
+    }
+
+    private void onDropFromOutside(DragEvent dropEvent) {
+        if (mDragAndDropBrowserDelegate == null) {
+            return;
+        }
+        DragAndDropPermissions dragAndDropPermissions =
+                mDragAndDropBrowserDelegate.getDragAndDropPermissions(dropEvent);
+        if (dragAndDropPermissions == null) {
+            return;
+        }
+        // TODO(shuyng): Read image data in background thread.
+        dragAndDropPermissions.release();
+    }
+
+    private void onDragEnd(DragEvent dragEndEvent) {
+        boolean dragResult = dragEndEvent.getResult();
+
+        // Only record metrics when drop does not happen for ContentView.
+        if (!mIsDropOnView) {
+            assert mDragStartSystemElapsedTime > 0;
+            assert mDragTargetType != DragTargetType.INVALID;
+            long dragDuration = SystemClock.elapsedRealtime() - mDragStartSystemElapsedTime;
+            recordDragDurationAndResult(dragDuration, dragResult);
+            recordDragTargetType(mDragTargetType);
+        }
+
+        DropDataProviderUtils.clearImageCache(!mIsDropOnView && dragResult);
+    }
+
+    /**
+     * Return the {@link DragTargetType} based on the content of DropDataAndroid. The result will
+     * bias plain text > image > link.
+     * TODO(https://crbug.com/1299994): Manage the ClipData bias with EventForwarder in one place.
+     */
+    static @DragTargetType int getDragTargetType(DropDataAndroid dropDataAndroid) {
+        if (dropDataAndroid.isPlainText()) {
+            return DragTargetType.TEXT;
+        } else if (dropDataAndroid.hasImage()) {
+            return DragTargetType.IMAGE;
+        } else if (dropDataAndroid.hasLink()) {
+            return DragTargetType.LINK;
+        } else {
+            return DragTargetType.INVALID;
+        }
+    }
+
+    /**
+     * Return the text to be dropped when {@link DropDataAndroid} contains a link.
+     */
+    static String getTextForLinkData(DropDataAndroid dropData) {
+        assert dropData.hasLink();
+        if (TextUtils.isEmpty(dropData.text)) return dropData.gurl.getSpec();
+        return dropData.text + "\n" + dropData.gurl.getSpec();
+    }
+
+    private void reset() {
+        mShadowHeight = 0;
+        mShadowWidth = 0;
+        mDragTargetType = DragTargetType.INVALID;
+        mIsDragStarted = false;
+        mIsDropOnView = false;
+        mDragStartSystemElapsedTime = -1;
+    }
+
+    private void recordDragTargetType(@DragTargetType int type) {
+        RecordHistogram.recordEnumeratedHistogram(
+                "Android.DragDrop.FromWebContent.TargetType", type, DragTargetType.NUM_ENTRIES);
+    }
+
+    private void recordDragDurationAndResult(long duration, boolean result) {
+        String histogramPrefix = "Android.DragDrop.FromWebContent.Duration.";
+        String suffix = result ? "Success" : "Canceled";
+        RecordHistogram.recordMediumTimesHistogram(histogramPrefix + suffix, duration);
+    }
+
+    @VisibleForTesting
+    float getDragStartXDp() {
+        return mDragStartXDp;
+    }
+
+    @VisibleForTesting
+    float getDragStartYDp() {
+        return mDragStartYDp;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DragStateTracker.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DragStateTracker.java
@@ -1,0 +1,34 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.dragdrop;
+
+import android.view.View;
+
+/** Helper class the listen and track the latest drag event for the view. */
+public interface DragStateTracker extends View.OnDragListener {
+    /** Return whether there's an active drag process started. */
+    default boolean isDragStarted() {
+        return false;
+    }
+
+    /**
+     * Return the width of the active drag shadow. Returns 0 if the tracker is not active, or an
+     * active drag process is not started.
+     */
+    default int getDragShadowWidth() {
+        return 0;
+    }
+
+    /**
+     * Return the height of the active drag shadow. Returns 0 if the tracker is not active, or an
+     * active drag process is not started.
+     */
+    default int getDragShadowHeight() {
+        return 0;
+    }
+
+    /** Clean up and release the memory of this drag state tracker. */
+    default void destroy() {}
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DropDataAndroid.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DropDataAndroid.java
@@ -1,0 +1,58 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.dragdrop;
+
+import android.text.TextUtils;
+
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.url.GURL;
+
+/**
+ * Bare minimal wrapper class of native content::DropData.
+ */
+@JNINamespace("ui")
+public class DropDataAndroid {
+    public final String text;
+    public final GURL gurl;
+    public final byte[] imageContent;
+    public final String imageContentExtension;
+    public final String imageFilename;
+
+    /** Not generated from java */
+    private DropDataAndroid(String text, GURL gurl, byte[] imageContent,
+            String imageContentExtension, String imageFilename) {
+        this.text = text;
+        this.gurl = gurl;
+        this.imageContent = imageContent;
+        this.imageContentExtension = imageContentExtension;
+        this.imageFilename = imageFilename;
+    }
+
+    @VisibleForTesting
+    @CalledByNative
+    static DropDataAndroid create(String text, GURL gurl, byte[] imageContent,
+            String imageContentExtension, String imageFilename) {
+        return new DropDataAndroid(text, gurl, imageContent, imageContentExtension, imageFilename);
+    }
+
+    /** Return whether this data presents a plain of text. */
+    public boolean isPlainText() {
+        return GURL.isEmptyOrInvalid(gurl) && !TextUtils.isEmpty(text);
+    }
+
+    /** Return whether this data presents a link. */
+    public boolean hasLink() {
+        return !GURL.isEmptyOrInvalid(gurl);
+    }
+
+    /** Return whether this data presents an image. */
+    public boolean hasImage() {
+        return imageContent != null && !TextUtils.isEmpty(imageContentExtension)
+                && !TextUtils.isEmpty(imageFilename);
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DropDataProviderImpl.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DropDataProviderImpl.java
@@ -1,0 +1,423 @@
+// Copyright 2022 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.dragdrop;
+
+import android.content.ContentProvider;
+import android.content.ContentResolver;
+import android.database.Cursor;
+import android.database.MatrixCursor;
+import android.net.Uri;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Looper;
+import android.os.ParcelFileDescriptor;
+import android.os.SystemClock;
+import android.provider.OpenableColumns;
+import android.webkit.MimeTypeMap;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.ContextUtils;
+import org.chromium.base.metrics.RecordHistogram;
+import org.chromium.build.annotations.UsedByReflection;
+
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.OutputStream;
+
+/**
+ * This class is the core implementation of Drag/Drop, we access it from the content provider for
+ * each class loader, the chromium one {@link DropDataContentProvider}.
+ *
+ * @see DropDataProviderImpl#FULL_AUTH_URI
+ *
+ * TODO(https://crbug.com/1353048): Add the reference to //android_webview/support_library content
+ * provider to this java doc.
+ */
+@UsedByReflection("Webview Support Lib")
+public class DropDataProviderImpl {
+    public static final String CACHE_METHOD_NAME = "cache";
+    public static final String SET_INTERVAL_METHOD_NAME = "setClearCachedDataIntervalMs";
+    public static final String ON_DRAG_END_METHOD_NAME = "onDragEnd";
+
+    public static final String CLEAR_CACHE_PARAM = "clearCacheDelayedMs";
+    public static final String IMAGE_USAGE_PARAM = "imageIsInUse";
+    public static final String BYTES_PARAM = "bytes";
+    public static final String IMAGE_CONTENT_EXTENSION_PARAM = "imageContentExtension";
+    public static final String IMAGE_FILE_PARAM = "imageFilename";
+    public static final int DEFAULT_CLEAR_CACHED_DATA_INTERVAL_MS = 60_000;
+
+    /**
+     * This variable is being used to be able to access the correct content provider, any content
+     * provider using this class should declare the same authority in order for it to work.
+     */
+    public static final Uri FULL_AUTH_URI =
+            Uri.parse("content://" + ContextUtils.getApplicationContext().getPackageName()
+                    + DropDataProviderImpl.URI_AUTHORITY_SUFFIX);
+
+    /**
+     * Implement {@link ContentProvider.PipeDataWriter} to be used by {@link
+     * ContentProvider#openPipeHelper}, in order to stream image data to drop target.
+     */
+    private static class DropPipeDataWriter implements ContentProvider.PipeDataWriter<byte[]> {
+        @Override
+        public void writeDataToPipe(ParcelFileDescriptor output, Uri uri, String mimeType,
+                Bundle opts, byte[] imageBytes) {
+            try (OutputStream out = new FileOutputStream(output.getFileDescriptor())) {
+                if (imageBytes != null) {
+                    out.write(imageBytes);
+                } else {
+                    // TODO: add error handle here
+                }
+                out.flush();
+            } catch (Exception e) {
+            }
+        }
+    }
+
+    // TODO: move ConversionUtils.java to //ui/android/ to use ConversionUtils.BYTES_PER_KILOBYTE
+    private static final int BYTES_PER_KILOBYTE = 1024;
+    private static final String[] COLUMNS = {OpenableColumns.DISPLAY_NAME, OpenableColumns.SIZE};
+    private static final String URI_AUTHORITY_SUFFIX = ".DropDataProvider";
+    private static final Object LOCK = new Object();
+
+    private int mClearCachedDataIntervalMs = DEFAULT_CLEAR_CACHED_DATA_INTERVAL_MS;
+    private byte[] mImageBytes;
+    private String mEncodingFormat;
+    private String mImageFilename;
+    private String mMimeType;
+    /**
+     * The URI handled by this content provider.
+     */
+    private Uri mContentProviderUri;
+    private Handler mHandler;
+    private long mDragEndTime;
+    private long mOpenFileLastAccessTime;
+    private Uri mLastUri;
+    private long mLastUriClearedTimestamp;
+    private long mLastUriCreatedTimestamp;
+    private boolean mLastUriRecorded;
+
+    private DropPipeDataWriter mDropPipeDataWriter;
+
+    /**
+     * This constructor is being used to initialize the pipeWriter.
+     */
+    public DropDataProviderImpl() {
+        initPipeWriter();
+    }
+
+    /**
+     * Update the delayed time before clearing the image cache.
+     */
+    public void setClearCachedDataIntervalMs(int milliseconds) {
+        synchronized (LOCK) {
+            mClearCachedDataIntervalMs = milliseconds;
+        }
+    }
+
+    private Uri generateUri() {
+        String timestamp = String.valueOf(System.currentTimeMillis());
+        return new Uri.Builder()
+                .scheme(ContentResolver.SCHEME_CONTENT)
+                .authority(ContextUtils.getApplicationContext().getPackageName()
+                        + URI_AUTHORITY_SUFFIX)
+                .path(timestamp)
+                .build();
+    }
+
+    /**
+     * Cache the passed-in image data of Drag and Drop. It is expected for filename to be non-empty.
+     */
+    public Uri cache(byte[] imageBytes, String encodingFormat, String filename) {
+        long elapsedRealtime = SystemClock.elapsedRealtime();
+        long lastUriCreatedTimestamp = mLastUriCreatedTimestamp;
+        String mimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(encodingFormat);
+        Uri newUri = generateUri();
+
+        synchronized (LOCK) {
+            // Clear out any old data.
+            clearCacheData();
+            // Set new data.
+            mLastUriCreatedTimestamp = elapsedRealtime;
+            this.mImageBytes = imageBytes;
+            this.mEncodingFormat = encodingFormat;
+            mImageFilename = filename;
+            mMimeType = mimeType;
+            mDragEndTime = 0;
+            mOpenFileLastAccessTime = 0;
+            mContentProviderUri = newUri;
+        }
+
+        if (lastUriCreatedTimestamp > 0) {
+            long duration = elapsedRealtime - lastUriCreatedTimestamp;
+            RecordHistogram.recordMediumTimesHistogram(
+                    "Android.DragDrop.Image.UriCreatedInterval", duration);
+        }
+        int sizeInKB = imageBytes.length / BYTES_PER_KILOBYTE;
+        RecordHistogram.recordCustomCountHistogram(
+                "Android.DragDrop.Image.Size", sizeInKB, 1, 100_000, 50);
+        return newUri;
+    }
+
+    /**
+     * Clear the image data of Drag and Drop when event ACTION_DRAG_ENDED is received.
+     *
+     * @param imageInUse Indicate if the image is needed by the drop target app. This is true when
+     *        the image is dropped outside of Chrome AND the drop target app returns true for event
+     *        ACTION_DROP.
+     */
+    public void onDragEnd(boolean imageInUse) {
+        if (!imageInUse) {
+            // Clear the image data immediately when:
+            // 1. Image is dropped within Clank and we know it is not used;
+            // 2. Image is dropped outside of Clank and the drop target app rejects the data.
+            clearCache();
+        } else {
+            // Otherwise, clear it with a delay to allow asynchronous data transfer.
+            synchronized (LOCK) {
+                clearCacheWithDelay();
+                mDragEndTime = SystemClock.elapsedRealtime();
+            }
+        }
+    }
+
+    /**
+     * Clear the image data of Drag and Drop and record histogram.
+     */
+    void clearCache() {
+        synchronized (LOCK) {
+            clearCacheData();
+            if (mDragEndTime > 0 && mOpenFileLastAccessTime > 0) {
+                // If ContentProvider#openFile is received before Android Drag End event, set the
+                // duration to 0 to avoid negative value.
+                long duration = Math.max(0, mOpenFileLastAccessTime - mDragEndTime);
+                RecordHistogram.recordMediumTimesHistogram(
+                        "Android.DragDrop.Image.OpenFileTime.LastAttempt", duration);
+            }
+        }
+    }
+
+    /**
+     * Clear the image data of Drag and Drop.
+     */
+    private void clearCacheData() {
+        mImageBytes = null;
+        mEncodingFormat = null;
+        mImageFilename = null;
+        mMimeType = null;
+        if (mContentProviderUri != null) {
+            mLastUri = mContentProviderUri;
+            mLastUriClearedTimestamp = SystemClock.elapsedRealtime();
+            mLastUriRecorded = false;
+        }
+        mContentProviderUri = null;
+        if (mHandler != null) {
+            mHandler.removeCallbacksAndMessages(null);
+            mHandler = null;
+        }
+    }
+
+    /**
+     * Clear the image data of Drag and Drop with delay.
+     */
+    private void clearCacheWithDelay() {
+        if (mHandler == null) {
+            mHandler = new Handler(Looper.getMainLooper());
+        }
+        mHandler.postDelayed(this::clearCache, mClearCachedDataIntervalMs);
+    }
+
+    /**
+     * A static initializer for the class.
+     */
+    @UsedByReflection("DropDataContentProvider")
+    public static DropDataProviderImpl onCreate() {
+        // TODO(crbug.com/1302383): Lazily create DropPipeDataWriter in #openFile.
+        return new DropDataProviderImpl();
+    }
+
+    /**
+     * @see android.content.ContentProvider.PipeDataWriter
+     */
+    public void initPipeWriter() {
+        mDropPipeDataWriter = new DropPipeDataWriter();
+    }
+
+    /**
+     * @see ContentProvider#getType(Uri)
+     */
+    public String getType(Uri uri) {
+        synchronized (LOCK) {
+            if (uri == null || !uri.equals(mContentProviderUri)) {
+                return null;
+            }
+            return mMimeType;
+        }
+    }
+
+    /**
+     * @see ContentProvider#getStreamTypes(Uri, String)
+     */
+    public String[] getStreamTypes(Uri uri, String mimeTypeFilter) {
+        String mimeType;
+        synchronized (LOCK) {
+            if (uri == null || !uri.equals(mContentProviderUri)) {
+                return null;
+            }
+            mimeType = mMimeType;
+        }
+        return matchMimeType(mimeType, mimeTypeFilter) ? new String[] {mimeType} : null;
+    }
+
+    private boolean matchMimeType(String mimeType, String mimeTypeFilter) {
+        if (mimeType == null || mimeTypeFilter == null) {
+            return false;
+        }
+
+        int idx1 = mimeType.indexOf('/');
+        String type = mimeType.substring(0, idx1);
+        String subtype = mimeType.substring(idx1 + 1);
+        int idx2 = mimeTypeFilter.indexOf('/');
+        String typeFilter = mimeTypeFilter.substring(0, idx2);
+        String subtypeFilter = mimeTypeFilter.substring(idx2 + 1);
+        if (!typeFilter.equals("*") && !typeFilter.equals(type)) {
+            return false;
+        }
+        return subtypeFilter.equals("*") || subtypeFilter.equals(subtype);
+    }
+
+    /**
+     * @see ContentProvider#openFile(Uri, String)
+     */
+    public ParcelFileDescriptor openFile(ContentProvider providerWrapper, Uri uri)
+            throws FileNotFoundException {
+        if (uri == null) {
+            return null;
+        }
+        byte[] imageBytes;
+        long elapsedRealtime = SystemClock.elapsedRealtime();
+        synchronized (LOCK) {
+            if (!uri.equals(mContentProviderUri)) {
+                if (uri.equals(mLastUri)) {
+                    long duration = elapsedRealtime - mLastUriClearedTimestamp;
+                    RecordHistogram.recordMediumTimesHistogram(
+                            "Android.DragDrop.Image.OpenFileTime.AllExpired", duration);
+                    if (!mLastUriRecorded) {
+                        RecordHistogram.recordMediumTimesHistogram(
+                                "Android.DragDrop.Image.OpenFileTime.FirstExpired", duration);
+                        mLastUriRecorded = true;
+                    }
+                }
+                return null;
+            }
+            if (mOpenFileLastAccessTime == 0) {
+                // If Android Drag End event has not been received yet, treat the duration as 0 ms.
+                long duration = mDragEndTime == 0 ? 0 : elapsedRealtime - mDragEndTime;
+                RecordHistogram.recordMediumTimesHistogram(
+                        "Android.DragDrop.Image.OpenFileTime.FirstAttempt", duration);
+            }
+            mOpenFileLastAccessTime = elapsedRealtime;
+            imageBytes = this.mImageBytes;
+        }
+        return providerWrapper.openPipeHelper(
+                uri, getType(uri), null, imageBytes, mDropPipeDataWriter);
+    }
+
+    /**
+     * @see ContentProvider#query(Uri, String[], String, String[], String)
+     */
+    public Cursor query(Uri uri, String[] projection) {
+        byte[] imageBytes;
+        String imageFilename;
+        synchronized (LOCK) {
+            if (uri == null || !uri.equals(mContentProviderUri)) {
+                return new MatrixCursor(COLUMNS, 0);
+            }
+            imageBytes = this.mImageBytes;
+            imageFilename = mImageFilename;
+        }
+        if (projection == null) {
+            projection = COLUMNS;
+        }
+
+        boolean hasDisplayName = false;
+        boolean hasSize = false;
+        int length = 0;
+        for (String col : projection) {
+            if (OpenableColumns.DISPLAY_NAME.equals(col)) {
+                hasDisplayName = true;
+                length++;
+            } else if (OpenableColumns.SIZE.equals(col)) {
+                hasSize = true;
+                length++;
+            }
+        }
+
+        String[] cols = new String[length];
+        Object[] values = new Object[length];
+        int index = 0;
+        if (hasDisplayName) {
+            cols[index] = OpenableColumns.DISPLAY_NAME;
+            values[index] = imageFilename;
+            index++;
+        }
+        if (hasSize) {
+            cols[index] = OpenableColumns.SIZE;
+            values[index] = imageBytes.length;
+        }
+        MatrixCursor cursor = new MatrixCursor(cols, 1);
+        cursor.addRow(values);
+        return cursor;
+    }
+
+    /**
+     * @see ContentProvider#call(String, String, Bundle)
+     */
+    @Nullable
+    public Bundle call(@NonNull String method, @Nullable String arg, @Nullable Bundle extras) {
+        switch (method) {
+            case CACHE_METHOD_NAME:
+                Bundle bundleToReturn = new Bundle();
+                Uri uri = cache((byte[]) extras.getSerializable(BYTES_PARAM),
+                        extras.getString(IMAGE_CONTENT_EXTENSION_PARAM),
+                        extras.getString(IMAGE_FILE_PARAM));
+                bundleToReturn.putParcelable("uri", uri);
+                return bundleToReturn;
+            case SET_INTERVAL_METHOD_NAME:
+                setClearCachedDataIntervalMs(extras.getInt(CLEAR_CACHE_PARAM,
+                        DropDataProviderImpl.DEFAULT_CLEAR_CACHED_DATA_INTERVAL_MS));
+                break;
+            case ON_DRAG_END_METHOD_NAME:
+                onDragEnd(extras.getBoolean(IMAGE_USAGE_PARAM));
+                break;
+        }
+
+        return null;
+    }
+
+    @VisibleForTesting
+    byte[] getImageBytesForTesting() {
+        synchronized (LOCK) {
+            return mImageBytes;
+        }
+    }
+
+    @VisibleForTesting
+    Handler getHandlerForTesting() {
+        synchronized (LOCK) {
+            return mHandler;
+        }
+    }
+
+    @VisibleForTesting
+    void clearLastUriCreatedTimestampForTesting() {
+        synchronized (LOCK) {
+            mLastUriCreatedTimestamp = 0;
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DropDataProviderUtils.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/dragdrop/DropDataProviderUtils.java
@@ -1,0 +1,77 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.dragdrop;
+
+import static dev.cobalt.ui.dragdrop.DropDataProviderImpl.CACHE_METHOD_NAME;
+import static dev.cobalt.ui.dragdrop.DropDataProviderImpl.ON_DRAG_END_METHOD_NAME;
+import static dev.cobalt.ui.dragdrop.DropDataProviderImpl.SET_INTERVAL_METHOD_NAME;
+
+import android.net.Uri;
+import android.os.Bundle;
+
+import androidx.annotation.Nullable;
+
+import org.chromium.base.ContextUtils;
+
+/**
+ * This class wraps all the calls to ContentResolver#call.
+ *
+ * TODO(https://crbug.com/1353048): Return a boolean with the result for each method.
+ */
+public class DropDataProviderUtils {
+    /**
+     * Wraps the call to onDragEnd in the provider, we call it to clear the cached image data after
+     * dragging ends
+     */
+    static void clearImageCache(boolean imageIsInUse) {
+        Bundle bundle = new Bundle();
+        bundle.putBoolean("imageIsInUse", imageIsInUse);
+        try {
+            ContextUtils.getApplicationContext().getContentResolver().call(
+                    DropDataProviderImpl.FULL_AUTH_URI, ON_DRAG_END_METHOD_NAME, "", bundle);
+        } catch (NullPointerException | IllegalArgumentException exception) {
+            // TODO(https://crbug.com/1353048): Return a boolean with the result to let the caller
+            // know.
+        }
+    }
+
+    /**
+     * Wraps the call to setClearCachedDataIntervalMs in the provider.
+     */
+    public static void setClearCachedDataIntervalMs(int delay) {
+        Bundle bundle = new Bundle();
+        bundle.putInt(DropDataProviderImpl.CLEAR_CACHE_PARAM, delay);
+        try {
+            ContextUtils.getApplicationContext().getContentResolver().call(
+                    DropDataProviderImpl.FULL_AUTH_URI, SET_INTERVAL_METHOD_NAME, "", bundle);
+        } catch (NullPointerException | IllegalArgumentException exception) {
+            // TODO(https://crbug.com/1353048): Return a boolean with the result to let the caller
+            // know.
+        }
+    }
+
+    /**
+     * Wraps the call to cache in the provider and returns the cached Uri or null if it failed to
+     * call the content provider.
+     */
+    @Nullable
+    static Uri cacheImageData(DropDataAndroid dropData) {
+        Bundle bundle = new Bundle();
+        bundle.putSerializable(DropDataProviderImpl.BYTES_PARAM, dropData.imageContent);
+        bundle.putString(
+                DropDataProviderImpl.IMAGE_CONTENT_EXTENSION_PARAM, dropData.imageContentExtension);
+
+        bundle.putString(DropDataProviderImpl.IMAGE_FILE_PARAM, dropData.imageFilename);
+        try {
+            Bundle cachedUriBundle = ContextUtils.getApplicationContext().getContentResolver().call(
+                    DropDataProviderImpl.FULL_AUTH_URI, CACHE_METHOD_NAME, "", bundle);
+            return cachedUriBundle.getParcelable("uri");
+        } catch (NullPointerException | IllegalArgumentException exception) {
+            // TODO(https://crbug.com/1353048): Return a boolean with the result to let the caller
+            // know.
+            return null;
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/modaldialog/DialogDismissalCause.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/modaldialog/DialogDismissalCause.java
@@ -1,0 +1,75 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.modaldialog;
+
+import androidx.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@IntDef({DialogDismissalCause.UNKNOWN, DialogDismissalCause.POSITIVE_BUTTON_CLICKED,
+        DialogDismissalCause.NEGATIVE_BUTTON_CLICKED, DialogDismissalCause.ACTION_ON_CONTENT,
+        DialogDismissalCause.DISMISSED_BY_NATIVE,
+        DialogDismissalCause.NAVIGATE_BACK_OR_TOUCH_OUTSIDE, DialogDismissalCause.TAB_SWITCHED,
+        DialogDismissalCause.TAB_DESTROYED, DialogDismissalCause.ACTIVITY_DESTROYED,
+        DialogDismissalCause.NOT_ATTACHED_TO_WINDOW, DialogDismissalCause.NAVIGATE,
+        DialogDismissalCause.WEB_CONTENTS_DESTROYED,
+        DialogDismissalCause.DIALOG_INTERACTION_DEFERRED,
+        DialogDismissalCause.ACTION_ON_DIALOG_COMPLETED,
+        DialogDismissalCause.ACTION_ON_DIALOG_NOT_POSSIBLE, DialogDismissalCause.CLIENT_TIMEOUT})
+@Retention(RetentionPolicy.SOURCE)
+public @interface DialogDismissalCause {
+    // Dismissal causes that are fully controlled by clients (i.e. are not used inside the
+    // dialog manager or the dialog presenters) are marked "Controlled by client" on comments.
+
+    /** No specified reason for the dialog dismissal. */
+    int UNKNOWN = 0;
+    /** Controlled by client: Positive button (e.g. OK button) is clicked by the user. */
+    int POSITIVE_BUTTON_CLICKED = 1;
+    /** Controlled by client: Negative button (e.g. Cancel button) is clicked by the user. */
+    int NEGATIVE_BUTTON_CLICKED = 2;
+    /** Controlled by client: Action taken on the dialog content triggers the dialog dismissal. */
+    int ACTION_ON_CONTENT = 3;
+    /** Controlled by client: Dialog is dismissed by native c++ objects. */
+    int DISMISSED_BY_NATIVE = 4;
+    /** User clicks the navigate back button or touches the scrim outside the dialog. */
+    int NAVIGATE_BACK_OR_TOUCH_OUTSIDE = 5;
+    /** User switches away the tab associated with the dialog. */
+    int TAB_SWITCHED = 6;
+    /** The Tab associated with the dialog is destroyed. */
+    int TAB_DESTROYED = 7;
+    /** The activity associated with the dialog is destroyed. */
+    int ACTIVITY_DESTROYED = 8;
+    /** The content view of the activity associated with the dialog is not attached to window. */
+    int NOT_ATTACHED_TO_WINDOW = 9;
+    /** User has navigated, e.g. by typing a URL in the location bar. */
+    int NAVIGATE = 10;
+    /** Controlled by client: The web contents associated with the dialog is destroyed. */
+    int WEB_CONTENTS_DESTROYED = 11;
+
+    /**
+     * Controlled by client: The dialog interaction is deferred due to user engaging with other
+     * UI surfaces outside of dialog or they clicked on a content of the dialog that allows
+     * to defer.
+     *
+     * Note that deferred would indicate that the dialog would be shown again later on
+     * unless the user has completed the interaction successfully.
+     */
+    int DIALOG_INTERACTION_DEFERRED = 12;
+    /**
+     * Controlled by client: Action taken on the dialog content that the client
+     * validates and triggers dismissal, if satisfied.
+     */
+    int ACTION_ON_DIALOG_COMPLETED = 13;
+    /**
+     * Controlled by client: The dialog was dismissed because it's not possible for client to
+     * validate after the action was taken on the dialog content.
+     */
+    int ACTION_ON_DIALOG_NOT_POSSIBLE = 14;
+    /**
+     * Controlled by client: The dialog was automatically dismissed after a timeout.
+     */
+    int CLIENT_TIMEOUT = 15;
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/modaldialog/ModalDialogManager.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/modaldialog/ModalDialogManager.java
@@ -1,0 +1,561 @@
+// Copyright 2017 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.modaldialog;
+
+import android.util.SparseArray;
+
+import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.Callback;
+import org.chromium.base.CommandLine;
+import org.chromium.base.ObserverList;
+import dev.cobalt.ui.UiSwitches;
+import dev.cobalt.ui.modelutil.PropertyModel;
+import dev.cobalt.ui.util.TokenHolder;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Manager for managing the display of a queue of {@link PropertyModel}s.
+ */
+public class ModalDialogManager {
+    /**
+     * An observer of the ModalDialogManager intended to broadcast notifications about any dialog
+     * being shown. Observers will know if something is overlaying the screen.
+     */
+    public interface ModalDialogManagerObserver {
+        /**
+         * A notification that the manager queues a dialog to be shown.
+         * @param model The model that describes the dialog that was added.
+         */
+        default void onDialogAdded(PropertyModel model) {}
+
+        /**
+         * A notification that the manager dismisses a modal dialog.
+         * @param model The model that describes the dialog that was dismissed.
+         */
+        default void onDialogDismissed(PropertyModel model) {}
+
+        /** A notification that the manager has dismissed all queued modal dialog. */
+        default void onLastDialogDismissed() {}
+    }
+
+    /**
+     * Present a {@link PropertyModel} in a container.
+     */
+    public abstract static class Presenter {
+        private Callback<Integer> mDismissCallback;
+        private PropertyModel mDialogModel;
+
+        /**
+         * @param model The dialog model that's currently showing in this presenter.
+         *              If null, no dialog is currently showing.
+         */
+        private void setDialogModel(
+                @Nullable PropertyModel model, @Nullable Callback<Integer> dismissCallback) {
+            if (model == null) {
+                removeDialogView(mDialogModel);
+                mDialogModel = null;
+                mDismissCallback = null;
+            } else {
+                assert mDialogModel
+                        == null : "Should call setDialogModel(null) before setting a dialog model.";
+                mDialogModel = model;
+                mDismissCallback = dismissCallback;
+                addDialogView(model);
+            }
+        }
+
+        /**
+         * Run the cached cancel callback and reset the cached callback.
+         */
+        public final void dismissCurrentDialog(@DialogDismissalCause int dismissalCause) {
+            if (mDismissCallback == null) return;
+
+            // Set #mCancelCallback to null before calling the callback to avoid it being
+            // updated during the callback.
+            Callback<Integer> callback = mDismissCallback;
+            mDismissCallback = null;
+            callback.onResult(dismissalCause);
+        }
+
+        /**
+         * @return The dialog model that this presenter is showing.
+         */
+        public final PropertyModel getDialogModel() {
+            return mDialogModel;
+        }
+
+        /**
+         * @param model The dialog model from which the properties should be obtained.
+         * @return The property value for {@link ModalDialogProperties#CONTENT_DESCRIPTION}, or a
+         *         fallback content description if it is not set.
+         */
+        protected static String getContentDescription(PropertyModel model) {
+            String description = model.get(ModalDialogProperties.CONTENT_DESCRIPTION);
+            if (description == null) description = model.get(ModalDialogProperties.TITLE);
+            return description;
+        }
+
+        /**
+         * Creates a view for the specified dialog model and puts the view in a container.
+         * @param model The dialog model that needs to be shown.
+         */
+        protected abstract void addDialogView(PropertyModel model);
+
+        /**
+         * Removes the view created for the specified model from a container.
+         * @param model The dialog model that needs to be removed.
+         */
+        protected abstract void removeDialogView(PropertyModel model);
+    }
+
+    // This affects only the dialog style. To define a priority, call showDialog with {@link
+    // ModalDialogPriority} instead.
+    @IntDef({ModalDialogType.TAB, ModalDialogType.APP})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ModalDialogType {
+        // If priority is not specified then the integer values here represent the default
+        // priorities where a lower value indicates a lower priority.
+        int TAB = 0;
+        int APP = 1;
+
+        int RANGE_MIN = TAB;
+        int RANGE_MAX = APP;
+        int NUM_ENTRIES = RANGE_MAX - RANGE_MIN + 1;
+    }
+
+    /**
+     * This signifies the priority of the dialog. A priority of the dialog influences
+     * which dialog will be shown or hidden if there's more than one dialog in the queue of dialogs
+     * in {@link PendingDialogContainer}.
+     */
+    @IntDef({ModalDialogPriority.LOW, ModalDialogPriority.HIGH, ModalDialogPriority.VERY_HIGH})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ModalDialogPriority {
+        int LOW = 1;
+        int HIGH = 2;
+
+        // This is intended to be used only by those dialogs which are meant to block any access to
+        // a subset of Chrome features when they are being shown. This also decouples the dialog
+        // from any suspend calls! For example, incognito re-auth feature uses this to gate the
+        // user's access to Incognito feature unless they re-authenticate successfully and it
+        // ensures that the dialog doesn't get removed because of any other Chrome clients.
+        // STOP: Other Chrome clients should just rely on HIGH instead! Check with the existing
+        // clients if you still intend on using this.
+        int VERY_HIGH = 3;
+
+        int RANGE_MIN = LOW;
+        // Please note that the max value of {@link ModalDialogPriority} should never exceed 9
+        // because of how {@link PendingDialogContainer} is built.
+        int RANGE_MAX = VERY_HIGH;
+        int NUM_ENTRIES = RANGE_MAX - RANGE_MIN + 1;
+    }
+
+    /** Mapping of the {@link Presenter}s and the type of dialogs they are showing. */
+    private final SparseArray<Presenter> mPresenters = new SparseArray<>();
+
+    /**
+     * The list of suspended types of dialogs. The dialogs of types in the list will be suspended
+     * from showing and will only be shown after {@link #resumeType(int)} is called.
+     */
+    private final Set<Integer> mSuspendedTypes = new HashSet<>();
+
+    /** The default presenter to be used if a specified type is not supported. */
+    private final Presenter mDefaultPresenter;
+
+    /**
+     * The presenter of the type of the dialog that is currently showing. Note that if there is no
+     * matching {@link Presenter} for {@link #mCurrentType}, this will be the default presenter.
+     */
+    private Presenter mCurrentPresenter;
+
+    /**
+     * The type of the current dialog. This can be different from the type of the current
+     * {@link Presenter} if there is no registered presenter for this type.
+     */
+    private @ModalDialogType int mCurrentType;
+
+    /**
+     * The priority of the current dialog.
+     */
+    private @ModalDialogPriority int mCurrentPriority;
+
+    /**
+     * True if the current dialog is in the process of being dismissed.
+     */
+    private boolean mDismissingCurrentDialog;
+
+    /** Observers of this manager. */
+    private final ObserverList<ModalDialogManagerObserver> mObserverList = new ObserverList<>();
+
+    /** Tokens for features temporarily suppressing dialogs. */
+    private final Map<Integer, TokenHolder> mTokenHolders = new HashMap<>();
+
+    /**
+     * A container to insert pending dialogs on both {@link ModalDialogType} and {@link
+     * ModalDialogPriority} attributes.
+     */
+    private final PendingDialogContainer mPendingDialogContainer = new PendingDialogContainer();
+
+    /**
+     * Constructor for initializing default {@link Presenter}.
+     * @param defaultPresenter The default presenter to be used when no presenter specified.
+     * @param defaultType The dialog type of the default presenter.
+     */
+    public ModalDialogManager(
+            @NonNull Presenter defaultPresenter, @ModalDialogType int defaultType) {
+        mDefaultPresenter = defaultPresenter;
+        registerPresenter(defaultPresenter, defaultType);
+
+        mTokenHolders.put(ModalDialogType.APP,
+                new TokenHolder(() -> resumeTypeInternal(ModalDialogType.APP)));
+        mTokenHolders.put(ModalDialogType.TAB,
+                new TokenHolder(() -> resumeTypeInternal(ModalDialogType.TAB)));
+    }
+
+    /** Clears any dependencies on the showing or pending dialogs. */
+    public void destroy() {
+        dismissAllDialogs(DialogDismissalCause.ACTIVITY_DESTROYED);
+        mObserverList.clear();
+    }
+
+    /**
+     * Add an observer to this manager.
+     * @param observer The observer to add.
+     */
+    public void addObserver(ModalDialogManagerObserver observer) {
+        mObserverList.addObserver(observer);
+    }
+
+    /**
+     * Remove an observer of this manager.
+     * @param observer The observer to remove.
+     */
+    public void removeObserver(ModalDialogManagerObserver observer) {
+        mObserverList.removeObserver(observer);
+    }
+
+    /**
+     * Register a {@link Presenter} that shows a specific type of dialog. Note that only one
+     * presenter of each type can be registered.
+     * @param presenter The {@link Presenter} to be registered.
+     * @param dialogType The type of the dialog shown by the specified presenter.
+     */
+    public void registerPresenter(Presenter presenter, @ModalDialogType int dialogType) {
+        assert mPresenters.get(dialogType)
+                == null : "Only one presenter can be registered for each type.";
+        mPresenters.put(dialogType, presenter);
+    }
+
+    /**
+     * @return Whether a dialog is currently showing.
+     */
+    public boolean isShowing() {
+        return mCurrentPresenter != null;
+    }
+
+    /**
+     * @return The type of dialog showing, or last type that was shown.
+     */
+    public @ModalDialogType int getCurrentType() {
+        return mCurrentType;
+    }
+
+    /**
+     * Show the specified dialog. If another dialog of higher priority is currently showing, the
+     * specified dialog will be added to the end of the pending dialog list of the specified type.
+     *
+     * @param model The dialog model to be shown or added to pending list.
+     * @param dialogType The type of the dialog to be shown.
+     */
+    public void showDialog(PropertyModel model, @ModalDialogType int dialogType) {
+        showDialog(model, dialogType, false);
+    }
+
+    /**
+     * Show the specified dialog. If another dialog of higher priority is currently showing, the
+     * specified dialog will be added to the end of the pending dialog list of the specified type.
+     *
+     * @param model The dialog model to be shown or added to pending list.
+     * @param dialogType The type of the dialog to be shown.
+     * @param dialogPriority The priority of the dialog to be shown.
+     */
+    public void showDialog(PropertyModel model, @ModalDialogType int dialogType,
+            @ModalDialogPriority int dialogPriority) {
+        showDialog(model, dialogType, dialogPriority, false);
+    }
+
+    /**
+     * Show the specified dialog. If another dialog of higher priority is currently showing, the
+     * specified dialog will be added to the pending dialog list. If showNext is set to true, the
+     * dialog will be added to the top of the pending list of its type, otherwise it will be added
+     * to the end. The priority of the specified dialog is inferred from the type of the dialog.
+     *
+     * @param model The dialog model to be shown or added to pending list.
+     * @param dialogType The type of the dialog to be shown.
+     * @param showAsNext Whether the specified dialog should be set highest priority of its type.
+     */
+    public void showDialog(
+            PropertyModel model, @ModalDialogType int dialogType, boolean showAsNext) {
+        showDialog(model, dialogType, getDefaultPriorityByType(dialogType), showAsNext);
+    }
+
+    /**
+     * Show the specified dialog. If another dialog of higher priority is currently showing, the
+     * specified dialog will be added to the pending dialog list. If showNext is set to true, the
+     * dialog will be added to the top of the pending list of its type, otherwise it will be added
+     * to the end.
+     *
+     * @param model The dialog model to be shown or added to pending list.
+     * @param dialogType The type of the dialog to be shown.
+     * @param dialogPriority The priority of the dialog to be shown.
+     * @param showAsNext Whether the specified dialog should be set highest priority of its type.
+     */
+    public void showDialog(PropertyModel model, @ModalDialogType int dialogType,
+            @ModalDialogPriority int dialogPriority, boolean showAsNext) {
+        if (CommandLine.getInstance().hasSwitch(UiSwitches.ENABLE_SCREENSHOT_UI_MODE)) {
+            return;
+        }
+
+        // The requested dialog is of very high priority. This needs special treatment when
+        // considering to put in pending list or not.
+        if (dialogPriority == ModalDialogPriority.VERY_HIGH) {
+            // We only put the requested dialog in pending list if the currently shown dialog
+            // also has a VERY_HIGH priority.
+            if (isShowing() && mCurrentPriority >= dialogPriority) {
+                assert mCurrentPriority
+                        == ModalDialogPriority.VERY_HIGH : "Higher priority is not supported.";
+                mPendingDialogContainer.put(dialogType, dialogPriority, model, showAsNext);
+                return;
+            }
+        } else {
+            // Put the new dialog in pending list if the dialog type is suspended or the current
+            // dialog is of higher priority.
+            if ((mSuspendedTypes.contains(dialogType))
+                    || (isShowing() && mCurrentPriority >= dialogPriority)) {
+                mPendingDialogContainer.put(dialogType, dialogPriority, model, showAsNext);
+                return;
+            }
+        }
+
+        if (isShowing()) suspendCurrentDialog();
+
+        assert !isShowing();
+        mCurrentType = dialogType;
+        mCurrentPriority = dialogPriority;
+        mCurrentPresenter = mPresenters.get(dialogType, mDefaultPresenter);
+        mCurrentPresenter.setDialogModel(
+                model, (dismissalCause) -> dismissDialog(model, dismissalCause));
+        for (ModalDialogManagerObserver o : mObserverList) o.onDialogAdded(model);
+    }
+
+    /**
+     * Dismiss the specified dialog. If the dialog is not currently showing, it will be removed from
+     * the pending dialog list. If the dialog is currently being dismissed this function does
+     * nothing.
+     * @param model The dialog model to be dismissed or removed from pending list.
+     * @param dismissalCause The {@link DialogDismissalCause} that describes why the dialog is
+     *                       dismissed.
+     */
+    public void dismissDialog(PropertyModel model, @DialogDismissalCause int dismissalCause) {
+        if (model == null) return;
+        if (mCurrentPresenter == null || model != mCurrentPresenter.getDialogModel()) {
+            if (mPendingDialogContainer.remove(model)) {
+                model.get(ModalDialogProperties.CONTROLLER).onDismiss(model, dismissalCause);
+                for (ModalDialogManagerObserver o : mObserverList) {
+                    o.onDialogDismissed(model);
+                }
+                dispatchOnLastDialogDismissedIfEmpty();
+                return;
+            }
+            // If the specified dialog is not found, return without any callbacks.
+            return;
+        }
+
+        if (!isShowing()) return;
+        assert model == mCurrentPresenter.getDialogModel();
+        if (mDismissingCurrentDialog) return;
+        mDismissingCurrentDialog = true;
+        model.get(ModalDialogProperties.CONTROLLER).onDismiss(model, dismissalCause);
+        mCurrentPresenter.setDialogModel(null, null);
+        for (ModalDialogManagerObserver o : mObserverList) o.onDialogDismissed(model);
+        mCurrentPresenter = null;
+        mCurrentPriority = ModalDialogPriority.LOW;
+        mDismissingCurrentDialog = false;
+        dispatchOnLastDialogDismissedIfEmpty();
+        showNextDialog();
+    }
+
+    /**
+     * Dismiss the dialog currently shown and remove all pending dialogs.
+     * @param dismissalCause The {@link DialogDismissalCause} that describes why the dialogs are
+     *                       dismissed.
+     */
+    public void dismissAllDialogs(@DialogDismissalCause int dismissalCause) {
+        for (@ModalDialogType int dialogType = ModalDialogType.RANGE_MIN;
+                dialogType <= ModalDialogType.RANGE_MAX; ++dialogType) {
+            dismissPendingDialogsOfType(dialogType, dismissalCause);
+        }
+
+        if (isShowing()) dismissDialog(mCurrentPresenter.getDialogModel(), dismissalCause);
+        assert mPendingDialogContainer.isEmpty();
+    }
+
+    /**
+     * Dismiss the dialog currently shown and remove all pending dialogs of the specified type.
+     * @param dialogType The specified type of dialog.
+     * @param dismissalCause The {@link DialogDismissalCause} that describes why the dialogs are
+     *                       dismissed.
+     */
+    public void dismissDialogsOfType(
+            @ModalDialogType int dialogType, @DialogDismissalCause int dismissalCause) {
+        dismissPendingDialogsOfType(dialogType, dismissalCause);
+        dismissActiveDialogOfType(dialogType, dismissalCause);
+    }
+
+    /**
+     * Dismiss the dialog currently shown if it is of the specified type.
+     *
+     * Any pending dialogs will then be shown.
+     *
+     * @param dialogType The specified type of dialog.
+     * @param dismissalCause The {@link DialogDismissalCause} that describes why the dialogs are
+     *                       dismissed.
+     * @return true if a dialog was showing and was dismissed.
+     */
+    public boolean dismissActiveDialogOfType(
+            @ModalDialogType int dialogType, @DialogDismissalCause int dismissalCause) {
+        if (isShowing() && dialogType == mCurrentType) {
+            dismissDialog(mCurrentPresenter.getDialogModel(), dismissalCause);
+            return true;
+        }
+        return false;
+    }
+
+    /** Helper method to dismiss pending dialogs of the specified type. */
+    private void dismissPendingDialogsOfType(
+            @ModalDialogType int dialogType, @DialogDismissalCause int dismissalCause) {
+        mPendingDialogContainer.remove(dialogType, model -> {
+            ModalDialogProperties.Controller controller =
+                    model.get(ModalDialogProperties.CONTROLLER);
+            controller.onDismiss(model, dismissalCause);
+            for (ModalDialogManagerObserver o : mObserverList) o.onDialogDismissed(model);
+            dispatchOnLastDialogDismissedIfEmpty();
+        });
+    }
+
+    /**
+     * Suspend all dialogs of the specified type, including the one currently shown. The currently
+     * shown dialog would be suspended if its priority is not VERY_HIGH.
+     *
+     * These dialogs will be prevented from showing unless {@link #resumeType(int, int)} is called
+     * after the suspension. If the current dialog is suspended, it will be moved back to the first
+     * dialog in the pending list. Any dialogs of the specified type in the pending list will be
+     * skipped.
+     *
+     * @param dialogType The specified type of dialogs to be suspended.
+     * @return A token to use when resuming the suspended type.
+     */
+    public int suspendType(@ModalDialogType int dialogType) {
+        mSuspendedTypes.add(dialogType);
+        if (isShowing() && dialogType == mCurrentType
+                && mCurrentPriority != ModalDialogPriority.VERY_HIGH) {
+            suspendCurrentDialog();
+            showNextDialog();
+        }
+        return mTokenHolders.get(dialogType).acquireToken();
+    }
+
+    /**
+     * Resume the specified type of dialogs after suspension. This method does not resume showing
+     * the dialog until after all held tokens are released.
+     * @param dialogType The specified type of dialogs to be resumed.
+     * @param token The token generated from suspending the dialog type.
+     */
+    public void resumeType(@ModalDialogType int dialogType, int token) {
+        mTokenHolders.get(dialogType).releaseToken(token);
+    }
+
+    /**
+     * Actually resumes showing the type of dialog after all tokens are released.
+     * @param dialogType The specified type of dialogs to be resumed.
+     */
+    private void resumeTypeInternal(@ModalDialogType int dialogType) {
+        if (mTokenHolders.get(dialogType).hasTokens()) return;
+        mSuspendedTypes.remove(dialogType);
+        if (!isShowing()) showNextDialog();
+    }
+
+    /** Hide the current dialog and put it back to the front of the pending list. */
+    private void suspendCurrentDialog() {
+        assert isShowing();
+        PropertyModel dialogView = mCurrentPresenter.getDialogModel();
+        mCurrentPresenter.setDialogModel(null, null);
+        mCurrentPresenter = null;
+        mPendingDialogContainer.put(
+                mCurrentType, mCurrentPriority, dialogView, /*showAsNext=*/true);
+    }
+
+    /** Helper method for showing the next available dialog in the pending dialog list. */
+    private void showNextDialog() {
+        assert !isShowing();
+        PendingDialogContainer.PendingDialogType nextDialog =
+                mPendingDialogContainer.getNextPendingDialog(mSuspendedTypes);
+        if (nextDialog == null) return;
+        showDialog(nextDialog.propertyModel, nextDialog.dialogType, nextDialog.dialogPriority);
+    }
+
+    // This calls onLastDialogDismissed() if there are no pending dialogs.
+    private void dispatchOnLastDialogDismissedIfEmpty() {
+        if (mPendingDialogContainer.isEmpty()) {
+            for (ModalDialogManagerObserver o : mObserverList) {
+                o.onLastDialogDismissed();
+            }
+        }
+    }
+
+    private @ModalDialogPriority int getDefaultPriorityByType(@ModalDialogType int dialogType) {
+        if (dialogType == ModalDialogType.TAB) {
+            return ModalDialogPriority.LOW;
+        } else if (dialogType == ModalDialogType.APP) {
+            return ModalDialogPriority.HIGH;
+        } else {
+            assert false : "Default priority not set for given dialog type.";
+            return ModalDialogPriority.LOW;
+        }
+    }
+
+    @VisibleForTesting
+    public PropertyModel getCurrentDialogForTest() {
+        return mCurrentPresenter == null ? null : mCurrentPresenter.getDialogModel();
+    }
+
+    @VisibleForTesting
+    public @Nullable List<PropertyModel> getPendingDialogsForTest(@ModalDialogType int dialogType) {
+        @ModalDialogPriority
+        int priority = getDefaultPriorityByType(dialogType);
+        return mPendingDialogContainer.get(dialogType, priority);
+    }
+
+    @VisibleForTesting
+    public Presenter getPresenterForTest(@ModalDialogType int dialogType) {
+        return mPresenters.get(dialogType);
+    }
+
+    @VisibleForTesting
+    public Presenter getCurrentPresenterForTest() {
+        return mCurrentPresenter;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/modaldialog/ModalDialogProperties.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/modaldialog/ModalDialogProperties.java
@@ -1,0 +1,209 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.modaldialog;
+
+import android.graphics.drawable.Drawable;
+import android.view.View;
+
+import androidx.activity.OnBackPressedCallback;
+import androidx.annotation.IntDef;
+
+import dev.cobalt.ui.modelutil.PropertyKey;
+import dev.cobalt.ui.modelutil.PropertyModel;
+import dev.cobalt.ui.modelutil.PropertyModel.ReadableBooleanPropertyKey;
+import dev.cobalt.ui.modelutil.PropertyModel.ReadableIntPropertyKey;
+import dev.cobalt.ui.modelutil.PropertyModel.ReadableObjectPropertyKey;
+import dev.cobalt.ui.modelutil.PropertyModel.WritableBooleanPropertyKey;
+import dev.cobalt.ui.modelutil.PropertyModel.WritableIntPropertyKey;
+import dev.cobalt.ui.modelutil.PropertyModel.WritableLongPropertyKey;
+import dev.cobalt.ui.modelutil.PropertyModel.WritableObjectPropertyKey;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * The model properties for a modal dialog.
+ */
+public class ModalDialogProperties {
+    /**
+     * Interface that controls the actions on the modal dialog.
+     */
+    public interface Controller {
+        /**
+         * Handle click event of the buttons on the dialog.
+         * @param model The dialog model that is associated with this click event.
+         * @param buttonType The type of the button.
+         */
+        void onClick(PropertyModel model, @ButtonType int buttonType);
+
+        /**
+         * Handle dismiss event when the dialog is dismissed by actions on the dialog. Note that it
+         * can be dangerous to the {@code dismissalCause} for business logic other than metrics
+         * recording, unless the dismissal cause is fully controlled by the client (e.g. button
+         * clicked), because the dismissal cause can be different values depending on modal dialog
+         * type and mode of presentation (e.g. it could be unknown on VR but a specific value on
+         * non-VR).
+         * @param model The dialog model that is associated with this dismiss event.
+         * @param dismissalCause The reason of the dialog being dismissed.
+         * @see DialogDismissalCause
+         */
+        void onDismiss(PropertyModel model, @DialogDismissalCause int dismissalCause);
+    }
+
+    @IntDef({ModalDialogProperties.ButtonType.POSITIVE, ModalDialogProperties.ButtonType.NEGATIVE,
+            ModalDialogProperties.ButtonType.TITLE_ICON})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ButtonType {
+        int POSITIVE = 0;
+        int NEGATIVE = 1;
+        int TITLE_ICON = 2;
+    }
+
+    /**
+     * Styles of the primary and negative button. Only one of them can be filled at the same time.
+     */
+    @IntDef({ModalDialogProperties.ButtonStyles.PRIMARY_OUTLINE_NEGATIVE_OUTLINE,
+            ModalDialogProperties.ButtonStyles.PRIMARY_FILLED_NEGATIVE_OUTLINE,
+            ModalDialogProperties.ButtonStyles.PRIMARY_OUTLINE_NEGATIVE_FILLED})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ButtonStyles {
+        int PRIMARY_OUTLINE_NEGATIVE_OUTLINE = 0;
+        int PRIMARY_FILLED_NEGATIVE_OUTLINE = 1;
+        int PRIMARY_OUTLINE_NEGATIVE_FILLED = 2;
+    }
+
+    /** The {@link Controller} that handles events on user actions. */
+    public static final ReadableObjectPropertyKey<Controller> CONTROLLER =
+            new ReadableObjectPropertyKey<>();
+
+    /** The content description of the dialog for accessibility. */
+    public static final ReadableObjectPropertyKey<String> CONTENT_DESCRIPTION =
+            new ReadableObjectPropertyKey<>();
+
+    /** The title of the dialog. */
+    public static final WritableObjectPropertyKey<String> TITLE = new WritableObjectPropertyKey<>();
+
+    /** The maximum number of lines that the title can take. */
+    public static final WritableIntPropertyKey TITLE_MAX_LINES = new WritableIntPropertyKey();
+
+    /** The title icon of the dialog. */
+    public static final WritableObjectPropertyKey<Drawable> TITLE_ICON =
+            new WritableObjectPropertyKey<>();
+
+    /** The message paragraph 1 of the dialog. */
+    public static final WritableObjectPropertyKey<CharSequence> MESSAGE_PARAGRAPH_1 =
+            new WritableObjectPropertyKey<>();
+
+    /** The message paragraph 2 of the dialog. Shown below the paragraph 1 when both are set. */
+    public static final WritableObjectPropertyKey<CharSequence> MESSAGE_PARAGRAPH_2 =
+            new WritableObjectPropertyKey<>();
+
+    /** The customized content view of the dialog. */
+    public static final WritableObjectPropertyKey<View> CUSTOM_VIEW =
+            new WritableObjectPropertyKey<>();
+
+    /** The customized view replacing the button bar of the dialog. */
+    public static final WritableObjectPropertyKey<View> CUSTOM_BUTTON_BAR_VIEW =
+            new WritableObjectPropertyKey<>();
+
+    /** The text on the positive button. */
+    public static final WritableObjectPropertyKey<String> POSITIVE_BUTTON_TEXT =
+            new WritableObjectPropertyKey<>();
+
+    /** Content description for the positive button. */
+    public static final WritableObjectPropertyKey<String> POSITIVE_BUTTON_CONTENT_DESCRIPTION =
+            new WritableObjectPropertyKey<>();
+
+    /** The enabled state on the positive button. */
+    public static final WritableBooleanPropertyKey POSITIVE_BUTTON_DISABLED =
+            new WritableBooleanPropertyKey();
+
+    /** The text on the negative button. */
+    public static final WritableObjectPropertyKey<String> NEGATIVE_BUTTON_TEXT =
+            new WritableObjectPropertyKey<>();
+
+    /** Content description for the negative button. */
+    public static final WritableObjectPropertyKey<String> NEGATIVE_BUTTON_CONTENT_DESCRIPTION =
+            new WritableObjectPropertyKey<>();
+
+    /** The enabled state on the negative button. */
+    public static final WritableBooleanPropertyKey NEGATIVE_BUTTON_DISABLED =
+            new WritableBooleanPropertyKey();
+
+    /** The message on the dialog footer. */
+    public static final WritableObjectPropertyKey<CharSequence> FOOTER_MESSAGE =
+            new WritableObjectPropertyKey<>();
+
+    /** Whether the dialog should be dismissed on user tapping the scrim. */
+    public static final WritableBooleanPropertyKey CANCEL_ON_TOUCH_OUTSIDE =
+            new WritableBooleanPropertyKey();
+
+    /**
+     * Whether button touch events should be filtered when buttons are obscured by another visible
+     * window.
+     */
+    public static final ReadableBooleanPropertyKey FILTER_TOUCH_FOR_SECURITY =
+            new ReadableBooleanPropertyKey();
+
+    /**
+     * Callback to be called when the modal dialog filters touch events because the buttons are
+     * obscured by another window.
+     */
+    public static final ReadableObjectPropertyKey<Runnable> TOUCH_FILTERED_CALLBACK =
+            new ReadableObjectPropertyKey<>();
+
+    /** Whether the title is scrollable with the message. */
+    public static final WritableBooleanPropertyKey TITLE_SCROLLABLE =
+            new WritableBooleanPropertyKey();
+
+    /** Whether the primary (positive) or negative button should be a filled button */
+    public static final ReadableIntPropertyKey BUTTON_STYLES = new ReadableIntPropertyKey();
+
+    /**
+     * Whether the dialog is of fullscreen style. Both {@code FULLSCREEN_DIALOG} and
+     * {@code DIALOG_WHEN_LARGE} cannot be set to true.
+     */
+    public static final ReadableBooleanPropertyKey FULLSCREEN_DIALOG =
+            new ReadableBooleanPropertyKey();
+
+    /**
+     * Whether the dialog is of DialogWhenLarge style i.e. fullscreen on phone, and dialog on large
+     * screen. Both {@code FULLSCREEN_DIALOG} and {@code DIALOG_WHEN_LARGE} cannot be set to true.
+     */
+    public static final ReadableBooleanPropertyKey DIALOG_WHEN_LARGE =
+            new ReadableBooleanPropertyKey();
+
+    /** Whether the dialog should be focused for accessibility. */
+    public static final WritableBooleanPropertyKey FOCUS_DIALOG = new WritableBooleanPropertyKey();
+
+    /** Whether the dialog contents can be larger than the specs prefer (e.g. in fullscreen). */
+    public static final WritableBooleanPropertyKey EXCEED_MAX_HEIGHT =
+            new WritableBooleanPropertyKey();
+
+    /**
+     * The handler for back presses done on a {@ModalDialogType.APP}. By default, a back press
+     * dismisses the dialog.
+     */
+    public static final WritableObjectPropertyKey<OnBackPressedCallback>
+            APP_MODAL_DIALOG_BACK_PRESS_HANDLER = new WritableObjectPropertyKey();
+
+    /**
+     * Duration of initial tap protection period after dialog is displayed to user. During this
+     * period, none of dialog buttons will respond to any click event; i.e.:
+     * {@link Controller#onClick(PropertyModel, int)} won't be triggered until it is elapsed.
+     */
+    public static final WritableLongPropertyKey BUTTON_TAP_PROTECTION_PERIOD_MS =
+            new WritableLongPropertyKey();
+
+    public static final PropertyKey[] ALL_KEYS = new PropertyKey[] {CONTROLLER, CONTENT_DESCRIPTION,
+            TITLE, TITLE_MAX_LINES, TITLE_ICON, MESSAGE_PARAGRAPH_1, MESSAGE_PARAGRAPH_2,
+            CUSTOM_VIEW, CUSTOM_BUTTON_BAR_VIEW, POSITIVE_BUTTON_TEXT,
+            POSITIVE_BUTTON_CONTENT_DESCRIPTION, POSITIVE_BUTTON_DISABLED, NEGATIVE_BUTTON_TEXT,
+            NEGATIVE_BUTTON_CONTENT_DESCRIPTION, NEGATIVE_BUTTON_DISABLED, FOOTER_MESSAGE,
+            CANCEL_ON_TOUCH_OUTSIDE, FILTER_TOUCH_FOR_SECURITY, TOUCH_FILTERED_CALLBACK,
+            TITLE_SCROLLABLE, BUTTON_STYLES, FULLSCREEN_DIALOG, DIALOG_WHEN_LARGE, FOCUS_DIALOG,
+            EXCEED_MAX_HEIGHT, APP_MODAL_DIALOG_BACK_PRESS_HANDLER,
+            BUTTON_TAP_PROTECTION_PERIOD_MS};
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/modaldialog/PendingDialogContainer.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/modaldialog/PendingDialogContainer.java
@@ -1,0 +1,223 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.modaldialog;
+
+import androidx.annotation.Nullable;
+
+import dev.cobalt.ui.modaldialog.ModalDialogManager.ModalDialogPriority;
+import dev.cobalt.ui.modaldialog.ModalDialogManager.ModalDialogType;
+import dev.cobalt.ui.modelutil.PropertyModel;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.Consumer;
+
+/**
+ * A container class to provide basic operations for pending dialogs with attributes {@link
+ * ModalDialogType} and {@link ModalDialogPriority}.
+ */
+class PendingDialogContainer {
+    /**
+     *  A class representing the attributes of a pending dialog.
+     */
+    class PendingDialogType {
+        public final PropertyModel propertyModel;
+        public final @ModalDialogType int dialogType;
+        public final @ModalDialogPriority int dialogPriority;
+
+        PendingDialogType(
+                PropertyModel model, @ModalDialogType int type, @ModalDialogPriority int priority) {
+            propertyModel = model;
+            dialogType = type;
+            dialogPriority = priority;
+        }
+    }
+
+    /**
+     * Mapping of the lists of pending dialogs based on {@link ModalDialogType} and {@link
+     * ModalDialogPriority} of the dialogs.
+     *
+     * The key of this map is 10 * {@link ModalDialogType} + {@link ModalDialogPriority}.
+     * This allows for efficient retrievals of pending dialogs sliced on {@link ModalDialogType}
+     * or {@link ModalDialogType}.
+     *
+     * Iterating over pending dialogs based on {@link ModalDialogType} is useful when suspending
+     * dialogs for certain types.
+     *
+     * Iterating over pending dialogs based on {@link ModalDialogPriority} is useful when
+     * choosing the next dialog to be shown.
+     *
+     * Please note, this only works if the MAX_RANGE of {@link ModalDialogPriority} is <= 9,
+     * otherwise we can have situations where two different dialogs on either {@link
+     * ModalDialogType} or {@link ModalDialogPriority} can be mapped to the same key.
+     *
+     * For example:
+     * 10 * (ModalDialogType: 2) + (ModalDialogPriority: 9) = 10 * (ModalDialogType: 1) +
+     * (ModalDialogPriority: 19) would map to the same key 29.
+     */
+    private final HashMap<Integer, List<PropertyModel>> mPendingDialogs = new HashMap<>();
+
+    /**
+     * Queues the {@link PropertyModel} model in the container based on the {@link
+     * ModalDialogPriority} and {@link ModalDialogType}.
+     *
+     * @param dialogType The {@link ModalDialogType} of the {@link PropertyModel}.
+     * @param dialogPriority The {@link ModalDialogPriority} of the {@link PropertyModel}.
+     * @param model The {@link PropertyModel} which contains the {@link ModalDialogProperties}
+     *         to launch a dialog.
+     * @param showAsNext If set to true, the {@link PropertyModel} |model| would be put as first
+     *         in its list of dialog.
+     */
+    void put(@ModalDialogType int dialogType, @ModalDialogPriority int dialogPriority,
+            PropertyModel model, boolean showAsNext) {
+        Integer key = computeKey(dialogType, dialogPriority);
+        List<PropertyModel> dialogs = mPendingDialogs.get(key);
+        if (dialogs == null) mPendingDialogs.put(key, dialogs = new ArrayList<>());
+        dialogs.add(showAsNext ? 0 : dialogs.size(), model);
+    }
+
+    /**
+     * @param dialogType The {@link ModalDialogType} of the list of pending dialog to fetch.
+     * @param dialogPriority The {@link ModalDialogPriority} of the list of pending dialog to fetch.
+     *
+     * @return Returns the list of {@link PropertyModel} with matching {@link ModalDialogType} *and*
+     *         {@link ModalDialogPriority}, null otherwise.
+     */
+    @Nullable
+    List<PropertyModel> get(
+            @ModalDialogType int dialogType, @ModalDialogPriority int dialogPriority) {
+        Integer key = computeKey(dialogType, dialogPriority);
+        return mPendingDialogs.get(key);
+    }
+
+    /**
+     * @param model The {@link PropertyModel} model to check if it contains in the list of
+     *         pending dialogs.
+     *
+     * @return Returns true if model found, otherwise false.
+     */
+    boolean contains(PropertyModel model) {
+        for (Map.Entry<Integer, List<PropertyModel>> entry : mPendingDialogs.entrySet()) {
+            List<PropertyModel> dialogs = entry.getValue();
+            for (int i = 0; i < dialogs.size(); ++i) {
+                if (dialogs.get(i) == model) return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * @return True, if there are no pending dialogs, false otherwise.
+     */
+    boolean isEmpty() {
+        for (Map.Entry<Integer, List<PropertyModel>> entry : mPendingDialogs.entrySet()) {
+            if (!entry.getValue().isEmpty()) return false;
+        }
+        return true;
+    }
+
+    /**
+     * @return Total number of list of pending dialogs.
+     */
+    int size() {
+        return mPendingDialogs.size();
+    }
+
+    /**
+     * @param model The {@link PropertyModel} model to remove from pending dialogs.
+     *
+     * @return True, if the |model| was found and removed, false otherwise.
+     */
+    boolean remove(PropertyModel model) {
+        Iterator<Map.Entry<Integer, List<PropertyModel>>> iterator =
+                mPendingDialogs.entrySet().iterator();
+        while (iterator.hasNext()) {
+            Map.Entry<Integer, List<PropertyModel>> entry = iterator.next();
+            List<PropertyModel> dialogs = entry.getValue();
+            for (int i = 0; i < dialogs.size(); ++i) {
+                if (dialogs.get(i) == model) {
+                    dialogs.remove(i);
+                    if (dialogs.isEmpty()) {
+                        mPendingDialogs.remove(entry.getKey());
+                    }
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Removes the pending dialogs matching the |dialogType| and applies the operation provided by
+     * |consumer| before removing.
+     *
+     * @param dialogType The {@link ModalDialogType} of the dialog to be removed from the list
+     *         of pending dialogs.
+     * @param consumer The {@link Consumer <PropertyModel>} which would be performed before
+     *         removing the {@link PropertyModel} matching the |dialogType| from the pending
+     *         dialog list.
+     *
+     * @return True, if any dialogs were removed, false otherwise.
+     */
+    boolean remove(@ModalDialogType int dialogType, Consumer<PropertyModel> consumer) {
+        boolean dialogRemoved = false;
+        for (@ModalDialogPriority int priority = ModalDialogPriority.RANGE_MIN;
+                priority <= ModalDialogPriority.RANGE_MAX; ++priority) {
+            Integer key = computeKey(dialogType, priority);
+            List<PropertyModel> dialogs = mPendingDialogs.get(key);
+            // No matching dialogs of type |dialogType| found with |priority|, continue searching
+            // with other priorities.
+            if (dialogs == null) continue;
+
+            for (int i = 0; i < dialogs.size(); ++i) {
+                dialogRemoved = true;
+                consumer.accept(dialogs.get(i));
+            }
+            mPendingDialogs.remove(key);
+        }
+        return dialogRemoved;
+    }
+
+    /**
+     * Returns the next dialog whose {@link ModalDialogType} is not suspended from showing and also
+     * removes it from the pending dialogs.
+     *
+     * @return The {@link PropertyModel}, the {@link ModalDialogType} and the {@link
+     *         ModalDialogPriority} of the model associated with the next dialog to be shown,
+     *         otherwise null if not found.
+     */
+    @Nullable
+    PendingDialogType getNextPendingDialog(Set<Integer> suspendedTypes) {
+        for (@ModalDialogPriority int priority = ModalDialogPriority.RANGE_MAX;
+                priority >= ModalDialogPriority.RANGE_MIN; --priority) {
+            for (@ModalDialogType int type = ModalDialogType.RANGE_MAX;
+                    type >= ModalDialogType.RANGE_MIN; --type) {
+                if (suspendedTypes.contains(type)) continue;
+                Integer key = computeKey(type, priority);
+                List<PropertyModel> dialogs = mPendingDialogs.get(key);
+                if (dialogs != null && !dialogs.isEmpty()) {
+                    PropertyModel model = dialogs.get(0);
+                    dialogs.remove(0);
+                    if (dialogs.isEmpty()) {
+                        mPendingDialogs.remove(key);
+                    }
+                    return new PendingDialogType(model, type, priority);
+                }
+            }
+        }
+        return null;
+    }
+
+    // A method for computing the key of the mPendingDialog HashMap.
+    private Integer computeKey(
+            @ModalDialogType int dialogType, @ModalDialogPriority int dialogPriority) {
+        assert dialogPriority >= 1 && dialogPriority <= 9;
+        return dialogType * 10 + dialogPriority;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/modelutil/PropertyKey.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/modelutil/PropertyKey.java
@@ -1,0 +1,10 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+package dev.cobalt.ui.modelutil;
+
+/**
+ * Place holder interface to allow key definitions.  Should not be used directly and only exposed
+ * to allow use as generic placeholders.
+ */
+public interface PropertyKey {}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/modelutil/PropertyModel.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/modelutil/PropertyModel.java
@@ -1,0 +1,641 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.modelutil;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.drawable.Drawable;
+
+import androidx.annotation.DrawableRes;
+import androidx.annotation.Nullable;
+import androidx.annotation.StringRes;
+import androidx.appcompat.content.res.AppCompatResources;
+import androidx.core.util.ObjectsCompat;
+
+import org.chromium.build.BuildConfig;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Generic property model that aims to provide an extensible and efficient model for ease of use.
+ */
+public class PropertyModel extends PropertyObservable<PropertyKey> {
+    /**
+     * A PropertyKey implementation that associates a name with the property for easy debugging.
+     */
+    private static class NamedPropertyKey implements PropertyKey {
+        private final String mPropertyName;
+
+        public NamedPropertyKey(@Nullable String propertyName) {
+            mPropertyName = propertyName;
+        }
+
+        @Override
+        public String toString() {
+            if (mPropertyName == null) return super.toString();
+            return mPropertyName;
+        }
+    }
+
+    /** The key type for read-ony boolean model properties. */
+    public static class ReadableBooleanPropertyKey extends NamedPropertyKey {
+        /**
+         * Constructs a new unnamed read-only boolean property key.
+         */
+        public ReadableBooleanPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named read-only boolean property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public ReadableBooleanPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /** The key type for mutable boolean model properties. */
+    public static final class WritableBooleanPropertyKey extends ReadableBooleanPropertyKey {
+        /**
+         * Constructs a new unnamed writable boolean property key.
+         */
+        public WritableBooleanPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named writable boolean property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public WritableBooleanPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /** The key type for read-only float model properties. */
+    public static class ReadableFloatPropertyKey extends NamedPropertyKey {
+        /**
+         * Constructs a new unnamed read-only float property key.
+         */
+        public ReadableFloatPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named read-only float property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public ReadableFloatPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /** The key type for mutable float model properties. */
+    public static final class WritableFloatPropertyKey extends ReadableFloatPropertyKey {
+        /**
+         * Constructs a new unnamed writable float property key.
+         */
+        public WritableFloatPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named writable float property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public WritableFloatPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /** The key type for read-only int model properties. */
+    public static class ReadableIntPropertyKey extends NamedPropertyKey {
+        /**
+         * Constructs a new unnamed read-only integer property key.
+         */
+        public ReadableIntPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named read-only integer property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public ReadableIntPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /** The key type for mutable int model properties. */
+    public static final class WritableIntPropertyKey extends ReadableIntPropertyKey {
+        /**
+         * Constructs a new unnamed writable integer property key.
+         */
+        public WritableIntPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named writable integer property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public WritableIntPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /** The key type for read-only long model properties. */
+    public static class ReadableLongPropertyKey extends NamedPropertyKey {
+        /**
+         * Constructs a new unnamed read-only long property key.
+         */
+        public ReadableLongPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named read-only long property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public ReadableLongPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /** The key type for mutable int model properties. */
+    public static final class WritableLongPropertyKey extends ReadableLongPropertyKey {
+        /**
+         * Constructs a new unnamed writable long property key.
+         */
+        public WritableLongPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named writable long property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public WritableLongPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /**
+     * The key type for read-only Object model properties.
+     *
+     * @param <T> The type of the Object being tracked by the key.
+     */
+    public static class ReadableObjectPropertyKey<T> extends NamedPropertyKey {
+        /**
+         * Constructs a new unnamed read-only object property key.
+         */
+        public ReadableObjectPropertyKey() {
+            this(null);
+        }
+
+        /**
+         * Constructs a new named read-only object property key, e.g. for use in debugging.
+         * @param name The optional name of the property.
+         */
+        public ReadableObjectPropertyKey(@Nullable String name) {
+            super(name);
+        }
+    }
+
+    /**
+     * The key type for mutable Object model properties.
+     *
+     * @param <T> The type of the Object being tracked by the key.
+     */
+    public static final class WritableObjectPropertyKey<T> extends ReadableObjectPropertyKey<T> {
+        private final boolean mSkipEquality;
+
+        /** Default constructor for an unnamed writable object property. */
+        public WritableObjectPropertyKey() {
+            this(false);
+        }
+
+        /**
+         * Constructs a new unnamed writable object property.
+         * @param skipEquality Whether the equality check should be bypassed for this key.
+         */
+        public WritableObjectPropertyKey(boolean skipEquality) {
+            this(skipEquality, null);
+        }
+
+        /**
+         * Constructs a new named writable object property key bypassing equality checks.
+         * @param name The optional name of the property.
+         */
+        public WritableObjectPropertyKey(@Nullable String name) {
+            this(false, name);
+        }
+
+        /**
+         * Constructs a new writable, named object property.
+         * @param skipEquality Whether the equality check should be bypassed for this key.
+         * @param name Name of the property -- used while debugging.
+         */
+        public WritableObjectPropertyKey(boolean skipEquality, @Nullable String name) {
+            super(name);
+            mSkipEquality = skipEquality;
+        }
+    }
+
+    private final Map<PropertyKey, ValueContainer> mData;
+
+    /**
+     * Constructs a model for the given list of keys.
+     *
+     * @param keys The key types supported by this model.
+     */
+    public PropertyModel(PropertyKey... keys) {
+        this(buildData(keys));
+    }
+
+    /**
+     * Constructs a model with a generic collection of existing keys.
+     *
+     * @param keys The key types supported by this model.
+     */
+    public PropertyModel(Collection<PropertyKey> keys) {
+        this(buildData(keys.toArray(new PropertyKey[keys.size()])));
+    }
+
+    private PropertyModel(Map<PropertyKey, ValueContainer> startingValues) {
+        mData = startingValues;
+    }
+
+    private void validateKey(PropertyKey key) {
+        if (BuildConfig.ENABLE_ASSERTS && !mData.containsKey(key)) {
+            throw new IllegalArgumentException(
+                    "Invalid key passed in: " + key + ". Current data is: " + mData.toString());
+        }
+    }
+
+    /**
+     * Get the current value from the float based key.
+     */
+    public float get(ReadableFloatPropertyKey key) {
+        validateKey(key);
+        FloatContainer container = (FloatContainer) mData.get(key);
+        return container == null ? 0f : container.value;
+    }
+
+    /**
+     * Set the value for the float based key.
+     */
+    public void set(WritableFloatPropertyKey key, float value) {
+        validateKey(key);
+        FloatContainer container = (FloatContainer) mData.get(key);
+        if (container == null) {
+            container = new FloatContainer();
+            mData.put(key, container);
+        } else if (container.value == value) {
+            return;
+        }
+
+        container.value = value;
+        notifyPropertyChanged(key);
+    }
+
+    /**
+     * Get the current value from the int based key.
+     */
+    public int get(ReadableIntPropertyKey key) {
+        validateKey(key);
+        IntContainer container = (IntContainer) mData.get(key);
+        return container == null ? 0 : container.value;
+    }
+
+    /**
+     * Set the value for the int based key.
+     */
+    public void set(WritableIntPropertyKey key, int value) {
+        validateKey(key);
+        IntContainer container = (IntContainer) mData.get(key);
+        if (container == null) {
+            container = new IntContainer();
+            mData.put(key, container);
+        } else if (container.value == value) {
+            return;
+        }
+
+        container.value = value;
+        notifyPropertyChanged(key);
+    }
+
+    /**
+     * Get the current value from the long based key.
+     */
+    public long get(ReadableLongPropertyKey key) {
+        validateKey(key);
+        LongContainer container = (LongContainer) mData.get(key);
+        return container == null ? 0 : container.value;
+    }
+
+    /**
+     * Set the value for the long based key.
+     */
+    public void set(WritableLongPropertyKey key, long value) {
+        validateKey(key);
+        LongContainer container = (LongContainer) mData.get(key);
+        if (container == null) {
+            container = new LongContainer();
+            mData.put(key, container);
+        } else if (container.value == value) {
+            return;
+        }
+
+        container.value = value;
+        notifyPropertyChanged(key);
+    }
+
+    /**
+     * Get the current value from the boolean based key.
+     */
+    public boolean get(ReadableBooleanPropertyKey key) {
+        validateKey(key);
+        BooleanContainer container = (BooleanContainer) mData.get(key);
+        return container == null ? false : container.value;
+    }
+
+    /**
+     * Set the value for the boolean based key.
+     */
+    public void set(WritableBooleanPropertyKey key, boolean value) {
+        validateKey(key);
+        BooleanContainer container = (BooleanContainer) mData.get(key);
+        if (container == null) {
+            container = new BooleanContainer();
+            mData.put(key, container);
+        } else if (container.value == value) {
+            return;
+        }
+
+        container.value = value;
+        notifyPropertyChanged(key);
+    }
+
+    /**
+     * Get the current value from the object based key.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> T get(ReadableObjectPropertyKey<T> key) {
+        validateKey(key);
+        ObjectContainer<T> container = (ObjectContainer<T>) mData.get(key);
+        return container == null ? null : container.value;
+    }
+
+    /**
+     * Set the value for the Object based key.
+     */
+    @SuppressWarnings("unchecked")
+    public <T> void set(WritableObjectPropertyKey<T> key, T value) {
+        validateKey(key);
+        ObjectContainer<T> container = (ObjectContainer<T>) mData.get(key);
+        if (container == null) {
+            container = new ObjectContainer<T>();
+            mData.put(key, container);
+        } else if (!key.mSkipEquality && ObjectsCompat.equals(container.value, value)) {
+            return;
+        }
+
+        container.value = value;
+        notifyPropertyChanged(key);
+    }
+
+    @Override
+    public Collection<PropertyKey> getAllSetProperties() {
+        List<PropertyKey> properties = new ArrayList<>();
+        for (Map.Entry<PropertyKey, ValueContainer> entry : mData.entrySet()) {
+            if (entry.getValue() != null) properties.add(entry.getKey());
+        }
+        return properties;
+    }
+
+    @Override
+    public Collection<PropertyKey> getAllProperties() {
+        List<PropertyKey> properties = new ArrayList<>();
+        for (Map.Entry<PropertyKey, ValueContainer> entry : mData.entrySet()) {
+            properties.add(entry.getKey());
+        }
+        return properties;
+    }
+
+    /**
+     * Determines whether the value for the provided key is the same in this model and a different
+     * model.
+     * @param otherModel The other {@link PropertyModel} to check.
+     * @param key The {@link PropertyKey} to check.
+     * @return Whether this model and {@code otherModel} have the same value set for {@code key}.
+     */
+    public boolean compareValue(PropertyModel otherModel, PropertyKey key) {
+        validateKey(key);
+        otherModel.validateKey(key);
+        if (!mData.containsKey(key) || !otherModel.mData.containsKey(key)) return false;
+
+        if (key instanceof WritableObjectPropertyKey
+                && ((WritableObjectPropertyKey) key).mSkipEquality) {
+            return false;
+        }
+
+        return ObjectsCompat.equals(mData.get(key), otherModel.mData.get(key));
+    }
+
+    /**
+     * Allows constructing a new {@link PropertyModel} with read-only properties.
+     */
+    public static class Builder {
+        private final Map<PropertyKey, ValueContainer> mData;
+
+        public Builder(PropertyKey... keys) {
+            this(buildData(keys));
+        }
+
+        private Builder(Map<PropertyKey, ValueContainer> values) {
+            mData = values;
+        }
+
+        private void validateKey(PropertyKey key) {
+            if (BuildConfig.ENABLE_ASSERTS && !mData.containsKey(key)) {
+                throw new IllegalArgumentException("Invalid key passed in: " + key);
+            }
+        }
+
+        public Builder with(ReadableFloatPropertyKey key, float value) {
+            validateKey(key);
+            FloatContainer container = new FloatContainer();
+            container.value = value;
+            mData.put(key, container);
+            return this;
+        }
+
+        public Builder with(ReadableIntPropertyKey key, int value) {
+            validateKey(key);
+            IntContainer container = new IntContainer();
+            container.value = value;
+            mData.put(key, container);
+            return this;
+        }
+
+        public Builder with(ReadableLongPropertyKey key, long value) {
+            validateKey(key);
+            LongContainer container = new LongContainer();
+            container.value = value;
+            mData.put(key, container);
+            return this;
+        }
+
+        public Builder with(ReadableBooleanPropertyKey key, boolean value) {
+            validateKey(key);
+            BooleanContainer container = new BooleanContainer();
+            container.value = value;
+            mData.put(key, container);
+            return this;
+        }
+
+        public <T> Builder with(ReadableObjectPropertyKey<T> key, T value) {
+            validateKey(key);
+            ObjectContainer<T> container = new ObjectContainer<>();
+            container.value = value;
+            mData.put(key, container);
+            return this;
+        }
+
+        /**
+         * @param key The key of the specified {@link ReadableObjectPropertyKey<String>}.
+         * @param resources The {@link Resources} for obtaining the specified string resource.
+         * @param resId The specified string resource id.
+         * @return The {@link Builder} with the specified key and string resource set.
+         */
+        public Builder with(
+                ReadableObjectPropertyKey<String> key, Resources resources, @StringRes int resId) {
+            if (resId != 0) with(key, resources.getString(resId));
+            return this;
+        }
+
+        /**
+         * @param key The key of the specified {@link ReadableObjectPropertyKey<Drawable>}.
+         * @param context The {@link Context} for obtaining the specified drawable resource.
+         * @param resId The specified drawable resource id.
+         * @return The {@link Builder} with the specified key and drawable resource set.
+         */
+        public Builder with(
+                ReadableObjectPropertyKey<Drawable> key, Context context, @DrawableRes int resId) {
+            if (resId != 0) with(key, AppCompatResources.getDrawable(context, resId));
+            return this;
+        }
+
+        public PropertyModel build() {
+            return new PropertyModel(mData);
+        }
+    }
+
+    /**
+     * Merge lists of property keys.
+     * @param k1 The first list of keys.
+     * @param k2 The second list of keys.
+     * @return A concatenated list of property keys.
+     */
+    public static PropertyKey[] concatKeys(PropertyKey[] k1, PropertyKey[] k2) {
+        PropertyKey[] outList = new PropertyKey[k1.length + k2.length];
+        System.arraycopy(k1, 0, outList, 0, k1.length);
+        System.arraycopy(k2, 0, outList, k1.length, k2.length);
+        return outList;
+    }
+
+    private static Map<PropertyKey, ValueContainer> buildData(PropertyKey[] keys) {
+        Map<PropertyKey, ValueContainer> data = new HashMap<>();
+        for (PropertyKey key : keys) {
+            if (data.containsKey(key)) {
+                throw new IllegalArgumentException("Duplicate key: " + key);
+            }
+            data.put(key, null);
+        }
+        return data;
+    }
+
+    private static class ValueContainer {}
+    private static class FloatContainer extends ValueContainer {
+        public float value;
+
+        @Override
+        public String toString() {
+            return value + " in " + super.toString();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other != null && other instanceof FloatContainer
+                    && ((FloatContainer) other).value == value;
+        }
+    }
+
+    private static class IntContainer extends ValueContainer {
+        public int value;
+
+        @Override
+        public String toString() {
+            return value + " in " + super.toString();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other != null && other instanceof IntContainer
+                    && ((IntContainer) other).value == value;
+        }
+    }
+
+    private static class LongContainer extends ValueContainer {
+        public long value;
+
+        @Override
+        public String toString() {
+            return value + " in " + super.toString();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other != null && other instanceof LongContainer
+                    && ((LongContainer) other).value == value;
+        }
+    }
+
+    private static class BooleanContainer extends ValueContainer {
+        public boolean value;
+
+        @Override
+        public String toString() {
+            return value + " in " + super.toString();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other != null && other instanceof BooleanContainer
+                    && ((BooleanContainer) other).value == value;
+        }
+    }
+
+    private static class ObjectContainer<T> extends ValueContainer {
+        public T value;
+
+        @Override
+        public String toString() {
+            return value + " in " + super.toString();
+        }
+
+        @Override
+        public boolean equals(Object other) {
+            return other != null && other instanceof ObjectContainer
+                    && ObjectsCompat.equals(((ObjectContainer) other).value, value);
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/modelutil/PropertyObservable.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/modelutil/PropertyObservable.java
@@ -1,0 +1,71 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.modelutil;
+
+import androidx.annotation.Nullable;
+
+import org.chromium.base.ObserverList;
+
+import java.util.Collection;
+
+/**
+ * A base class for models maintaining a set of properties.
+ *
+ * @param <T> The type of the property key used for uniquely identifying properties.
+ */
+public abstract class PropertyObservable<T> {
+    /**
+     * An observer to be notified of changes to a {@link PropertyObservable}.
+     *
+     * @param <T> The type of the property key used for uniquely identifying properties.
+     */
+    public interface PropertyObserver<T> {
+        /**
+         * Notifies that the given {@code property} of the observed {@code source} has changed.
+         * @param source The object whose property has changed
+         * @param propertyKey The key of the property that has changed.
+         */
+        void onPropertyChanged(PropertyObservable<T> source, @Nullable T propertyKey);
+    }
+
+    private final ObserverList<PropertyObserver<T>> mObservers = new ObserverList<>();
+
+    /**
+     * @param observer An observer to be notified of changes to the model.
+     */
+    public void addObserver(PropertyObserver<T> observer) {
+        mObservers.addObserver(observer);
+    }
+
+    /**
+     * @param observer The observer to remove.
+     */
+    public void removeObserver(PropertyObserver<T> observer) {
+        mObservers.removeObserver(observer);
+    }
+
+    /**
+     * @return A collection of all properties of this model that have been set. The returned
+     *         collection should not be modified.
+     */
+    public abstract Collection<T> getAllSetProperties();
+
+    /**
+     * @return A collection of all properties of this model. The returned collection should not be
+     *         modified.
+     */
+    public abstract Collection<T> getAllProperties();
+
+    /**
+     * Notifies observers that the property identified by {@code propertyKey} has changed.
+     *
+     * @param propertyKey The key of the property that has changed.
+     */
+    protected void notifyPropertyChanged(T propertyKey) {
+        for (PropertyObserver<T> observer : mObservers) {
+            observer.onPropertyChanged(this, propertyKey);
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/ActivityAndroidPermissionDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/ActivityAndroidPermissionDelegate.java
@@ -1,0 +1,44 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.permissions;
+
+import android.app.Activity;
+
+import org.chromium.base.compat.ApiHelperForM;
+
+import java.lang.ref.WeakReference;
+
+/**
+ * AndroidPermissionDelegate implementation for Activity.
+ */
+public class ActivityAndroidPermissionDelegate extends AndroidPermissionDelegateWithRequester {
+    private WeakReference<Activity> mActivity;
+
+    public ActivityAndroidPermissionDelegate(WeakReference<Activity> activity) {
+        mActivity = activity;
+    }
+
+    @Override
+    public final boolean shouldShowRequestPermissionRationale(String permission) {
+        Activity activity = mActivity.get();
+        if (activity == null) return false;
+        return ApiHelperForM.shouldShowRequestPermissionRationale(activity, permission);
+    }
+
+    @Override
+    protected final boolean isPermissionRevokedByPolicyInternal(String permission) {
+        Activity activity = mActivity.get();
+        if (activity == null) return false;
+        return ApiHelperForM.isPermissionRevokedByPolicy(activity, permission);
+    }
+
+    @Override
+    protected boolean requestPermissionsFromRequester(String[] permissions, int requestCode) {
+        Activity activity = mActivity.get();
+        if (activity == null) return false;
+        ApiHelperForM.requestActivityPermissions(activity, permissions, requestCode);
+        return true;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/AndroidPermissionDelegate.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/AndroidPermissionDelegate.java
@@ -1,0 +1,68 @@
+// Copyright 2015 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.permissions;
+
+/**
+ * Contains the functionality for interacting with the android permissions system.
+ */
+public interface AndroidPermissionDelegate {
+    /**
+     * Determine whether access to a particular permission is granted.
+     *
+     * @param permission The permission whose access is to be checked.
+     * @return Whether access to the permission is granted.
+     */
+    boolean hasPermission(String permission);
+
+    /**
+     * Determine whether the specified permission can be requested.
+     * <p>
+     * A permission can not be requested in the following states:
+     * <ul>
+     *   <li>Permission is denied by policy.
+     *   <li>Permission previously denied and the user selected "Never ask again".
+     * </ul>
+     *
+     * @param permission The permission name.
+     * @return Whether the permission can be requested.
+     */
+    boolean canRequestPermission(String permission);
+
+    /**
+     * Determine whether the specified permission is revoked by policy.
+     *
+     * @param permission The permission name.
+     * @return Whether the permission is revoked by policy and the user has no ability to change it.
+     */
+    boolean isPermissionRevokedByPolicy(String permission);
+
+    /**
+     * Requests the specified permissions are granted for further use.
+     *
+     * @param permissions The list of permissions to request access to.
+     * @param callback The callback to be notified whether the permissions were granted.
+     */
+    void requestPermissions(String[] permissions, PermissionCallback callback);
+
+    /**
+     * Handle the result from requesting permissions.
+     *
+     * @param requestCode The request code passed in requestPermissions.
+     * @param permissions The list of requested permissions.
+     * @param grantResults The grant results for the corresponding permissions which is either
+     *         {@link android.content.pm.PackageManager#PERMISSION_GRANTED} or {@link
+     *         android.content.pm.PackageManager#PERMISSION_DENIED}.
+     * @return True if the result was handled.
+     */
+    boolean handlePermissionResult(int requestCode, String[] permissions, int[] grantResults);
+
+    /**
+     * Called to determine whether android suggests showing a promo rationale.
+     * @see {@link Activity#shouldShowRequestPermissionRationale(String)}.
+     */
+    default boolean shouldShowRequestPermissionRationale(String permission) {
+        return false;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/AndroidPermissionDelegateWithRequester.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/AndroidPermissionDelegateWithRequester.java
@@ -1,0 +1,199 @@
+// Copyright 2019 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.permissions;
+
+import android.content.pm.PackageManager;
+import android.os.Build;
+import android.os.Handler;
+import android.os.Process;
+import android.util.SparseArray;
+
+import org.chromium.base.ApiCompatibilityUtils;
+import org.chromium.base.ContextUtils;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * AndroidPermissionDelegate that implements much of the logic around requesting permissions.
+ * Subclasses need to implement only the basic permissions checking and requesting methods.
+ */
+public abstract class AndroidPermissionDelegateWithRequester implements AndroidPermissionDelegate {
+    private Handler mHandler;
+    private SparseArray<PermissionRequestInfo> mOutstandingPermissionRequests;
+    private int mNextRequestCode;
+
+    // Constants used for permission request code bounding.
+    private static final int REQUEST_CODE_PREFIX = 1000;
+    private static final int REQUEST_CODE_RANGE_SIZE = 100;
+
+    public AndroidPermissionDelegateWithRequester() {
+        mHandler = new Handler();
+        mOutstandingPermissionRequests = new SparseArray<PermissionRequestInfo>();
+    }
+
+    @Override
+    public final boolean hasPermission(String permission) {
+        boolean isGranted =
+                ApiCompatibilityUtils.checkPermission(ContextUtils.getApplicationContext(),
+                        permission, Process.myPid(), Process.myUid())
+                == PackageManager.PERMISSION_GRANTED;
+        if (isGranted) {
+            PermissionPrefs.clearPermissionWasDenied(permission);
+        }
+        return isGranted;
+    }
+
+    @Override
+    public final boolean canRequestPermission(String permission) {
+        if (hasPermission(permission)) {
+            // There is no need to call clearPermissionWasDenied - hasPermission already cleared
+            // the shared pref if needed.
+            return true;
+        }
+
+        if (isPermissionRevokedByPolicy(permission)) {
+            return false;
+        }
+
+        if (shouldShowRequestPermissionRationale(permission)) {
+            // This information from Android suggests we should not assume the user will always deny
+            // the permission.
+            PermissionPrefs.clearPermissionWasDenied(permission);
+            return true;
+        }
+
+        // Check whether we have been denied this permission by checking whether we saved
+        // a preference associated with it before. This is to identify the cases where the app never
+        // requested for the permission before.
+        return !PermissionPrefs.wasPermissionDenied(permission);
+    }
+
+    /** @see PackageManager#isPermissionRevokedByPolicy(String, String) */
+    protected abstract boolean isPermissionRevokedByPolicyInternal(String permission);
+
+    @Override
+    public final boolean isPermissionRevokedByPolicy(String permission) {
+        return isPermissionRevokedByPolicyInternal(permission);
+    }
+
+    @Override
+    public final void requestPermissions(
+            final String[] permissions, final PermissionCallback callback) {
+        if (requestPermissionsInternal(permissions, callback)) {
+            PermissionPrefs.onAndroidPermissionRequestUiShown(permissions);
+            return;
+        }
+
+        // If the permission request was not sent successfully, just post a response to the
+        // callback with whatever the current permission state is for all the requested
+        // permissions.  The response is posted to keep the async behavior of this method
+        // consistent.
+        mHandler.post(new Runnable() {
+            @Override
+            public void run() {
+                int[] results = new int[permissions.length];
+                for (int i = 0; i < permissions.length; i++) {
+                    results[i] = hasPermission(permissions[i]) ? PackageManager.PERMISSION_GRANTED
+                                                               : PackageManager.PERMISSION_DENIED;
+                }
+                callback.onRequestPermissionsResult(permissions, results);
+            }
+        });
+    }
+
+    @Override
+    public final boolean handlePermissionResult(
+            int requestCode, String[] permissions, int[] grantResults) {
+        PermissionRequestInfo requestInfo = mOutstandingPermissionRequests.get(requestCode);
+        mOutstandingPermissionRequests.delete(requestCode);
+
+        List<String> permissionsGranted = new ArrayList<>();
+        List<String> permissionsDenied = new ArrayList<>();
+        for (int i = 0; i < permissions.length; i++) {
+            if (grantResults[i] == PackageManager.PERMISSION_GRANTED) {
+                permissionsGranted.add(permissions[i]);
+            } else if (shouldPersistDenial(requestInfo, permissions[i])) {
+                permissionsDenied.add(permissions[i]);
+            }
+        }
+        PermissionPrefs.editPermissionsPref(permissionsGranted, permissionsDenied);
+
+        if (requestInfo == null || requestInfo.callback == null) return false;
+        requestInfo.callback.onRequestPermissionsResult(permissions, grantResults);
+        return true;
+    }
+
+    /**
+     * Returns if an information about permission denial should be stored. Denial should not be
+     * stored iff:
+     * <ul>
+     *   <li> Android version >= Android.R
+     *   <li> The information about initial @see Activity.shouldShowRequestPermissionRationale is
+     *        present and the value is false
+     *   <li> The current value of @see Activity.shouldShowRequestPermissionRationale is false as
+     *        well
+     * </ul>
+     */
+    private boolean shouldPersistDenial(PermissionRequestInfo requestInfo, String permission) {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) return true;
+
+        boolean initialShowRationaleState = false;
+        if (requestInfo != null) {
+            initialShowRationaleState = requestInfo.getInitialShowRationaleStateFor(permission);
+        }
+
+        return initialShowRationaleState || shouldShowRequestPermissionRationale(permission);
+    }
+
+    /** @see Activity.requestPermissions */
+    protected abstract boolean requestPermissionsFromRequester(
+            String[] permissions, int requestCode);
+
+    /**
+     * Issues the permission request and returns whether it was sent successfully.
+     */
+    private boolean requestPermissionsInternal(String[] permissions, PermissionCallback callback) {
+        int requestCode = REQUEST_CODE_PREFIX + mNextRequestCode;
+        mNextRequestCode = (mNextRequestCode + 1) % REQUEST_CODE_RANGE_SIZE;
+        mOutstandingPermissionRequests.put(
+                requestCode, new PermissionRequestInfo(permissions, callback));
+        if (!requestPermissionsFromRequester(permissions, requestCode)) {
+            mOutstandingPermissionRequests.delete(requestCode);
+            return false;
+        }
+        return true;
+    }
+
+    /** Wrapper holding information relevant to a permission request. */
+    private class PermissionRequestInfo {
+        public final PermissionCallback callback;
+        public final Map<String, Boolean> initialShowRationaleState;
+
+        public PermissionRequestInfo(String[] permissions, PermissionCallback callback) {
+            initialShowRationaleState = new HashMap<>();
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                for (String permission : permissions) {
+                    initialShowRationaleState.put(
+                            permission, shouldShowRequestPermissionRationale(permission));
+                }
+            }
+            this.callback = callback;
+        }
+
+        /**
+         * Returns initial value of @see Activity.shouldShowRequestPermissionRationale
+         * for the given {@code permission} or false if not found.
+         */
+        public boolean getInitialShowRationaleStateFor(String permission) {
+            assert initialShowRationaleState.get(permission) != null;
+            return initialShowRationaleState.get(permission) != null
+                    ? initialShowRationaleState.get(permission)
+                    : false;
+        }
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/PermissionCallback.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/PermissionCallback.java
@@ -1,0 +1,20 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.permissions;
+
+/**
+ * Callback for permission requests.
+ */
+public interface PermissionCallback {
+    /**
+     * Called upon completing a permission request.
+     *
+     * @param permissions The list of permissions in the result.
+     * @param grantResults The grant results for the corresponding permissions which is either
+     *         {@link android.content.pm.PackageManager#PERMISSION_GRANTED} or {@link
+     *         android.content.pm.PackageManager#PERMISSION_DENIED}.
+     */
+    void onRequestPermissionsResult(String[] permissions, int[] grantResults);
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/PermissionConstants.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/PermissionConstants.java
@@ -1,0 +1,19 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.permissions;
+
+/**
+ * Utility class with constants related to permissions.
+ */
+public final class PermissionConstants {
+    /** The permission string for notification permission. */
+    // TODO(shaktisahu): Replace this with permission constant from {@link Manifest.permission}.
+    public static final String NOTIFICATION_PERMISSION = "android.permission.POST_NOTIFICATIONS";
+
+    // TODO(finnur): Replace this with permission constant from {@link Manifest.permission}.
+    public static final String READ_MEDIA_AUDIO = "android.permission.READ_MEDIA_AUDIO";
+    public static final String READ_MEDIA_IMAGES = "android.permission.READ_MEDIA_IMAGES";
+    public static final String READ_MEDIA_VIDEO = "android.permission.READ_MEDIA_VIDEO";
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/PermissionPrefs.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/permissions/PermissionPrefs.java
@@ -1,0 +1,151 @@
+// Copyright 2022 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.permissions;
+
+import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
+import android.content.pm.PackageManager.NameNotFoundException;
+import android.content.pm.PermissionInfo;
+import android.os.Build;
+import android.text.TextUtils;
+
+import org.chromium.base.ContextUtils;
+
+import java.util.List;
+
+/**
+ * Provides helper methods for shared preference access to store permission request related info.
+ */
+public class PermissionPrefs {
+    /**
+     * Shared preference key prefix for remembering Android permissions denied by the user.
+     * <p>
+     * <b>NOTE:</b> As of M86 the semantics of shared prefs using this key prefix has changed:
+     * <ul>
+     *   <li>Previously: {@code true} if the user was ever asked for a permission, otherwise absent.
+     *   <li>M86+: {@code true} if the user most recently has denied permission access,
+     *     otherwise absent.
+     * </ul>
+     */
+    private static final String PERMISSION_WAS_DENIED_KEY_PREFIX =
+            "HasRequestedAndroidPermission::";
+
+    /**
+     * Shared preference key prefix for storing the timestamp of when the permission request was
+     * shown. Only used for notification permission currently.
+     */
+    private static final String ANDROID_PERMISSION_REQUEST_TIMESTAMP_KEY_PREFIX =
+            "AndroidPermissionRequestTimestamp::";
+
+    /**
+     * Returns normalized permission name for the given permission considering OS versions.
+     * @param permission The permission name.
+     * @return Normalized permission name.
+     */
+    public static String normalizePermissionName(String permission) {
+        // Prior to O, permissions were granted at the group level.  Post O, each permission is
+        // granted individually.
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.O) {
+            try {
+                // Runtime permissions are controlled at the group level.  So when determining
+                // whether we have requested a particular permission before, we should check whether
+                // we have requested any permission in that group as that mimics the logic in the
+                // Android framework.
+                //
+                // e.g. Requesting first the permission ACCESS_FINE_LOCATION will result in Chrome
+                //      treating ACCESS_COARSE_LOCATION as if it had already been requested as well.
+                PermissionInfo permissionInfo =
+                        ContextUtils.getApplicationContext().getPackageManager().getPermissionInfo(
+                                permission, PackageManager.GET_META_DATA);
+
+                if (!TextUtils.isEmpty(permissionInfo.group)) {
+                    return permissionInfo.group;
+                }
+            } catch (NameNotFoundException e) {
+                // Unknown permission.  Default back to the permission name instead of the group.
+            }
+        }
+
+        return permission;
+    }
+
+    /**
+     * NOTE: Use this method with caution. The pref is aggressively cleared on
+     * permission grant, or on shouldShowRequestPermissionRationale returning true.
+     * @return Whether the request was denied by the user for the given {@code permission}
+     */
+    static boolean wasPermissionDenied(String permission) {
+        SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
+        return prefs.getBoolean(getPermissionWasDeniedKey(permission), false);
+    }
+
+    /**
+     * Clear the shared pref indicating that {@code permission} was denied by the user.
+     */
+    static void clearPermissionWasDenied(String permission) {
+        SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
+        SharedPreferences.Editor editor = prefs.edit();
+        editor.remove(getPermissionWasDeniedKey(permission));
+        editor.apply();
+    }
+
+    /**
+     * Saves/deletes the given list of permissions from shared prefs. Permission entries are deleted
+     * on permission grant and added on denial.
+     * @param permissionsGranted The list of permissions to delete entries.
+     * @param permissionsDenied The list of permissions to add/update entries.
+     */
+    static void editPermissionsPref(
+            List<String> permissionsGranted, List<String> permissionsDenied) {
+        SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
+        SharedPreferences.Editor editor = prefs.edit();
+        for (String permission : permissionsGranted) {
+            editor.remove(getPermissionWasDeniedKey(permission));
+        }
+        for (String permission : permissionsDenied) {
+            editor.putBoolean(getPermissionWasDeniedKey(permission), true);
+        }
+        editor.apply();
+    }
+
+    /**
+     * @return The timestamp when the notification permission request was shown last.
+     */
+    public static long getAndroidNotificationPermissionRequestTimestamp() {
+        String prefName = ANDROID_PERMISSION_REQUEST_TIMESTAMP_KEY_PREFIX
+                + PermissionPrefs.normalizePermissionName(
+                        PermissionConstants.NOTIFICATION_PERMISSION);
+        SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
+        return prefs.getLong(prefName, 0);
+    }
+
+    /**
+     * Called when the android permission prompt was shown.
+     */
+    static void onAndroidPermissionRequestUiShown(String[] permissions) {
+        boolean isNotification = false;
+        for (String permission : permissions) {
+            if (TextUtils.equals(permission, PermissionConstants.NOTIFICATION_PERMISSION)) {
+                isNotification = true;
+                break;
+            }
+        }
+        if (!isNotification) return;
+
+        String prefName = ANDROID_PERMISSION_REQUEST_TIMESTAMP_KEY_PREFIX
+                + PermissionPrefs.normalizePermissionName(
+                        PermissionConstants.NOTIFICATION_PERMISSION);
+        SharedPreferences prefs = ContextUtils.getAppSharedPreferences();
+        prefs.edit().putLong(prefName, System.currentTimeMillis()).apply();
+    }
+
+    /**
+     * Returns the name of a shared preferences key used to store whether Chrome was denied
+     * {@code permission}.
+     */
+    private static String getPermissionWasDeniedKey(String permission) {
+        return PERMISSION_WAS_DENIED_KEY_PREFIX + normalizePermissionName(permission);
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/util/TokenHolder.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/util/TokenHolder.java
@@ -1,0 +1,50 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.util;
+
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Helper class for holding tokens, useful when multiple entities need to manipulate the same
+ * boolean state, e.g. visibility of a view.
+ */
+public class TokenHolder {
+    /** An invalid token; this can be used to indicate no token is being held. */
+    public static final int INVALID_TOKEN = -1;
+
+    private int mNextToken;
+
+    private final Set<Integer> mAcquiredTokens = new HashSet<>();
+    private final Runnable mCallback;
+
+    /**
+     * @param callback is run when the token set becomes empty or non-empty.
+     */
+    public TokenHolder(Runnable callback) {
+        mCallback = callback;
+    }
+
+    public int acquireToken() {
+        int token = mNextToken++;
+        mAcquiredTokens.add(token);
+        if (mAcquiredTokens.size() == 1) mCallback.run();
+        return token;
+    }
+
+    public void releaseToken(int token) {
+        if (mAcquiredTokens.remove(token) && mAcquiredTokens.isEmpty()) {
+            mCallback.run();
+        }
+    }
+
+    public boolean hasTokens() {
+        return !mAcquiredTokens.isEmpty();
+    }
+
+    public boolean containsOnly(int token) {
+        return mAcquiredTokens.size() == 1 && mAcquiredTokens.contains(token);
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/widget/Toast.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/widget/Toast.java
@@ -1,0 +1,358 @@
+// Copyright 2015 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.widget;
+
+import static android.view.ViewGroup.LayoutParams.WRAP_CONTENT;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.content.pm.ApplicationInfo;
+import android.view.Gravity;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.FrameLayout;
+import android.widget.TextView;
+
+import androidx.annotation.ColorInt;
+import androidx.annotation.IntDef;
+import androidx.annotation.StringRes;
+import androidx.annotation.StyleRes;
+
+import org.chromium.base.SysUtils;
+import dev.cobalt.ui.R;
+import dev.cobalt.ui.display.DisplayAndroid;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+/**
+ * Toast wrapper, makes sure toasts are not HW accelerated on low-end devices and presented
+ * correctly (i.e. use VrToast while in virtual reality).
+ *
+ * Can (and should) also be used for Chromium-related additions and extensions.
+ *
+ * When {@link ToastManager} is enabled, priority {@code HIGH} can be used when it is critical
+ * that the toast be shown sooner than those of priority {@code NORMAL} queued for their turn.
+ * See {@link ToastManager} for more details.
+ */
+public class Toast {
+
+    public static final int LENGTH_SHORT = android.widget.Toast.LENGTH_SHORT;
+    public static final int LENGTH_LONG = android.widget.Toast.LENGTH_LONG;
+
+    private static int sExtraYOffset;
+
+    /** The different priorities that a toast can have. */
+    @IntDef({ToastPriority.HIGH, ToastPriority.NORMAL})
+    @Retention(RetentionPolicy.SOURCE)
+    public @interface ToastPriority {
+        int HIGH = 0;
+        int NORMAL = 1;
+    }
+
+    private android.widget.Toast mToast;
+    private ViewGroup mSWLayout;
+    private @ToastPriority int mPriority;
+    private CharSequence mText;
+
+    public Toast(Context context, View toastView) {
+        if (SysUtils.isLowEndDevice()) {
+            // Don't HW accelerate Toasts. Unfortunately the only way to do that is to make
+            // toast.getView().getContext().getApplicationInfo() return lies to prevent
+            // WindowManagerGlobal.addView() from adding LayoutParams.FLAG_HARDWARE_ACCELERATED.
+            mSWLayout = new FrameLayout(new ContextWrapper(context) {
+                @Override
+                public ApplicationInfo getApplicationInfo() {
+                    ApplicationInfo info = new ApplicationInfo(super.getApplicationInfo());
+
+                    // On M+ the condition we need to fail is
+                    // "flags & ApplicationInfo.FLAG_HARDWARE_ACCELERATED"
+                    info.flags &= ~ApplicationInfo.FLAG_HARDWARE_ACCELERATED;
+                    return info;
+                }
+            });
+        }
+
+        mToast = UiWidgetFactory.getInstance().createToast(context);
+        setView(toastView);
+        mToast.setGravity(
+                mToast.getGravity(), mToast.getXOffset(), mToast.getYOffset() + sExtraYOffset);
+    }
+
+    public void show() {
+        if (ToastManager.isEnabled()) {
+            ToastManager.getInstance().requestShow(this);
+        } else {
+            mToast.show();
+        }
+    }
+
+    public void cancel() {
+        if (ToastManager.isEnabled()) {
+            ToastManager.getInstance().cancel(this);
+        } else {
+            mToast.cancel();
+        }
+    }
+
+    public void setView(View view) {
+        if (mSWLayout != null) {
+            mSWLayout.removeAllViews();
+            if (view != null) {
+                mSWLayout.addView(view, WRAP_CONTENT, WRAP_CONTENT);
+                mToast.setView(mSWLayout);
+            } else {
+                // When null view is set we propagate it to the toast to trigger appropriate
+                // handling (for example show() throws an exception when view is null).
+                mToast.setView(null);
+            }
+        } else {
+            mToast.setView(view);
+        }
+    }
+
+    public View getView() {
+        if (mToast.getView() == null) {
+            return null;
+        }
+        if (mSWLayout != null) {
+            return mSWLayout.getChildAt(0);
+        } else {
+            return mToast.getView();
+        }
+    }
+
+    public void setDuration(int duration) {
+        mToast.setDuration(duration);
+    }
+
+    int getDuration() {
+        return mToast.getDuration();
+    }
+
+    void setPriority(@ToastPriority int priority) {
+        mPriority = priority;
+    }
+
+    @ToastPriority
+    int getPriority() {
+        return mPriority;
+    }
+
+    void setText(CharSequence text) {
+        mText = text;
+    }
+
+    CharSequence getText() {
+        return mText;
+    }
+
+    android.widget.Toast getAndroidToast() {
+        return mToast;
+    }
+
+    @SuppressLint("RtlHardcoded")
+    private void anchor(Context context, View anchoredView) {
+        // TODO(https://crbug.com/1313565): The follow logic has several problems, especially that
+        // Toast#setGravity requires screen coordinates. Would probably be better if reworked to use
+        // something like AnchoredPopupWindow.
+
+        // Use screen coordinates/size because Toast#setGravity takes screen coordinates, not
+        // window coordinates.
+        DisplayAndroid displayAndroid = DisplayAndroid.getNonMultiDisplay(context);
+        final int screenWidth = displayAndroid.getDisplayWidth();
+        final int screenHeight = displayAndroid.getDisplayHeight();
+        final int[] screenPos = new int[2];
+        anchoredView.getLocationOnScreen(screenPos);
+
+        // This is incorrect to use the view size. The logic below really wants to use the toast
+        // size, but at this point it hasn't measured yet. Use the view instead as a poor proxy.
+        final int width = anchoredView.getWidth();
+        final int height = anchoredView.getHeight();
+
+        // Depending on which size of the screen the view is closer to, use gravity on that side,
+        // and offset a little extra from that side.
+        final boolean viewOnLeftHalf = screenPos[0] < screenWidth / 2;
+        final int horizontalGravity = viewOnLeftHalf ? Gravity.LEFT : Gravity.RIGHT;
+        final int xOffset =
+                viewOnLeftHalf ? screenPos[0] + width / 2 : screenWidth - screenPos[0] - width / 2;
+        // Similar to xOffset, only always use Gravity.TOP. This seems to usually cause overlap with
+        // the anchor view on the bottom half of the screen.
+        final boolean viewOnTopHalf = screenPos[1] < screenHeight / 2;
+        final int yOffset =
+                viewOnTopHalf ? screenPos[1] + height / 2 : screenPos[1] - height * 3 / 2;
+
+        // There seems to be a host of issues that cause this to not be exactly correct. It's
+        // unclear which measurements above are taking into account bezels and status/nav bars, and
+        // which are not.
+        setGravity(Gravity.TOP | horizontalGravity, xOffset, yOffset);
+    }
+
+    public void setMargin(float horizontalMargin, float verticalMargin) {
+        mToast.setMargin(horizontalMargin, verticalMargin);
+    }
+
+    public float getHorizontalMargin() {
+        return mToast.getHorizontalMargin();
+    }
+
+    public float getVerticalMargin() {
+        return mToast.getVerticalMargin();
+    }
+
+    public void setGravity(int gravity, int xOffset, int yOffset) {
+        mToast.setGravity(gravity, xOffset, yOffset);
+    }
+
+    public int getGravity() {
+        return mToast.getGravity();
+    }
+
+    public int getXOffset() {
+        return mToast.getXOffset();
+    }
+
+    public int getYOffset() {
+        return mToast.getYOffset();
+    }
+
+    @SuppressLint("ShowToast")
+    public static Toast makeText(Context context, CharSequence text, int duration) {
+        return new Builder(context).withText(text).withDuration(duration).build();
+    }
+
+    public static Toast makeText(Context context, int resId, int duration) {
+        return new Builder(context).withTextStringRes(resId).withDuration(duration).build();
+    }
+
+    /**
+     * Create a new {@link Toast} with a given priority. See Javadoc for when to use it.
+     * @param context {@link Context} in which the toast is created.
+     * @param resId Resource of for the text message.
+     * @param duration Duration of the toast. Either {@link android.widget.Toast#LENGTH_SHORT}
+     *        or {@link android.widget.Toast#LENGTH_LONG}.
+     * @param priority {@link ToastPriority} to be assigned to the toast.
+     */
+    public static Toast makeTextWithPriority(
+            Context context, int resId, int duration, int priority) {
+        return new Builder(context)
+                .withTextStringRes(resId)
+                .withDuration(duration)
+                .withPriority(priority)
+                .build();
+    }
+
+    /**
+     * Shows a toast anchored on a view.
+     * @param context The context to use for the toast.
+     * @param anchoredView The view to anchor the toast.
+     * @param description The string shown in the toast.
+     * @return Whether a toast has been shown successfully.
+     */
+    public static boolean showAnchoredToast(
+            Context context, View anchoredView, CharSequence description) {
+        return new Builder(context)
+                .withAnchoredView(anchoredView)
+                .withText(description)
+                .buildAndShow();
+    }
+
+    /** Builder pattern class to construct {@link Toast} with various arguments. */
+    public static class Builder {
+        private final Context mContext;
+        private CharSequence mText;
+        private View mAnchoredView;
+        private Integer mBackgroundColor;
+        private Integer mTextAppearance;
+        private int mDuration = LENGTH_SHORT;
+        private @ToastPriority int mPriority = ToastPriority.NORMAL;
+
+        public Builder(Context context) {
+            mContext = context;
+        }
+
+        public Builder withText(CharSequence text) {
+            mText = text;
+            return this;
+        }
+
+        public Builder withTextStringRes(@StringRes int textResId) {
+            mText = mContext.getResources().getText(textResId);
+            return this;
+        }
+
+        public Builder withAnchoredView(View anchoredView) {
+            mAnchoredView = anchoredView;
+            return this;
+        }
+
+        public Builder withBackgroundColor(@ColorInt int backgroundColor) {
+            mBackgroundColor = backgroundColor;
+            return this;
+        }
+
+        public Builder withTextAppearance(@StyleRes int textAppearance) {
+            mTextAppearance = textAppearance;
+            return this;
+        }
+
+        public Builder withDuration(int duration) {
+            mDuration = duration;
+            return this;
+        }
+
+        public Builder withPriority(@ToastPriority int priority) {
+            mPriority = priority;
+            return this;
+        }
+
+        private TextView inflateTextView() {
+            LayoutInflater inflater = LayoutInflater.from(mContext);
+            TextView textView = (TextView) inflater.inflate(R.layout.custom_toast_layout, null);
+            if (mText != null) {
+                textView.setText(mText);
+                textView.announceForAccessibility(mText);
+            }
+            if (mBackgroundColor != null) {
+                textView.getBackground().setTint(mBackgroundColor);
+            }
+            if (mTextAppearance != null) {
+                textView.setTextAppearance(mTextAppearance);
+            }
+            return textView;
+        }
+
+        /** Builds and returns a toast, but does not show it. */
+        public Toast build() {
+            TextView textView = inflateTextView();
+            Toast toast = new Toast(mContext, textView);
+            if (mAnchoredView != null) {
+                toast.anchor(mContext, mAnchoredView);
+            }
+            toast.setDuration(mDuration);
+            toast.setPriority(mPriority);
+            toast.setText(mText);
+            return toast;
+        }
+
+        /** Builds and shows a toast, returning if it was successful. */
+        public boolean buildAndShow() {
+            if (mText == null) return false;
+            build().show();
+            return true;
+        }
+    }
+
+    /**
+     * Set extra Y offset for toasts all toasts created with this class. This can be overridden by
+     * calling {@link Toast#setGravity(int, int, int)} on an individual toast.
+     * @param yOffsetPx The Y offset from the normal toast position in px.
+     */
+    public static void setGlobalExtraYOffset(int yOffsetPx) {
+        sExtraYOffset = yOffsetPx;
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/widget/ToastManager.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/widget/ToastManager.java
@@ -1,0 +1,219 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.widget;
+
+import android.os.Build;
+import android.os.Handler;
+import android.text.TextUtils;
+
+import androidx.annotation.RequiresApi;
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.base.library_loader.LibraryLoader;
+
+import java.util.Iterator;
+import java.util.PriorityQueue;
+
+/**
+ * Manages Android toasts based on their priorities.
+ * <ul>
+ * <li>Queues the requested toasts and shows them one by one in the order of the requested
+ *     time if they have the same priority.</li>
+ * <li>Shows the toast with high priority ahead of other queued normal priority ones.</li>
+ * <li>Does not show the requested one again if it is already in the queue or currently
+ *     showing. Toasts of same text content are regarded as duplicated.</li>
+ * </ul>
+ */
+@JNINamespace("ui")
+public class ToastManager {
+    private static final int DURATION_SHORT_MS = 2000;
+    private static final int DURATION_LONG_MS = 3500;
+
+    private static Boolean sIsEnabled;
+    private static ToastManager sInstance;
+
+    // A queue for toasts waiting to be shown.
+    private final PriorityQueue<Toast> mToastQueue =
+            new PriorityQueue<>((toast1, toast2) -> toast1.getPriority() - toast2.getPriority());
+
+    // Handles toast events per SDK version.
+    private interface ToastEvent {
+        void onShow(Toast toast);
+        void onCancel();
+    }
+
+    private final ToastEvent mToastEvent;
+
+    // Toast currently showing. {@code null} if none is showing.
+    private Toast mToast;
+
+    static boolean isEnabled() {
+        if (Boolean.FALSE.equals(sIsEnabled) || !LibraryLoader.getInstance().isInitialized()) {
+            return false;
+        }
+        if (sIsEnabled == null) {
+            sIsEnabled = ToastManagerJni.get().isEnabled();
+        }
+        return sIsEnabled;
+    }
+
+    static ToastManager getInstance() {
+        assert sIsEnabled : "ToastManager should be enabled first.";
+        if (sInstance == null) sInstance = new ToastManager();
+        return sInstance;
+    }
+
+    private ToastManager() {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.R) {
+            mToastEvent = new ToastEventPreR(this::showNextToast);
+        } else {
+            mToastEvent = new ToastEventR(this::showNextToast);
+        }
+    }
+
+    /**
+     * Request to show a toast.
+     * @param toast {@link Toast} object to show.
+     */
+    public void requestShow(Toast toast) {
+        if (toast == null || isDuplicatedToast(toast)) return;
+
+        mToastQueue.add(toast);
+
+        if (getCurrentToast() == null) showNextToast();
+    }
+
+    /**
+     * Cancel a toast if it is showing now, or removes it from the queue if found in it.
+     * @param toast {@link Toast} to cancel.
+     */
+    public void cancel(Toast toast) {
+        if (toast == getCurrentToast()) {
+            cancelAndShowNextToast();
+        } else {
+            Iterator it = mToastQueue.iterator();
+            Toast toastToRemove = null;
+            while (it.hasNext()) {
+                Toast t = (Toast) it.next();
+                if (TextUtils.equals(t.getText(), toast.getText())) {
+                    toastToRemove = t;
+                    break;
+                }
+            }
+            if (toastToRemove != null) mToastQueue.remove(toastToRemove);
+        }
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    Toast getCurrentToast() {
+        return mToast;
+    }
+
+    /**
+     * Check if we already have the same Toast object showing on the screen or in the queue.
+     */
+    private boolean isDuplicatedToast(Toast toast) {
+        assert toast != null;
+        Toast ct = getCurrentToast();
+        if (ct != null && (ct == toast || TextUtils.equals(ct.getText(), toast.getText()))) {
+            return true;
+        }
+
+        CharSequence text = toast.getText();
+        Iterator it = mToastQueue.iterator();
+        while (it.hasNext()) {
+            Toast t = (Toast) it.next();
+            if (t == toast || TextUtils.equals(t.getText(), toast.getText())) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    private void showNextToast() {
+        mToast = mToastQueue.poll(); // Retrieves and removes head of the queue.
+        if (mToast != null) {
+            mToast.getAndroidToast().show();
+            mToastEvent.onShow(mToast);
+        }
+    }
+
+    private void cancelAndShowNextToast() {
+        assert mToast != null : "Current toast cannot be null";
+        mToast.getAndroidToast().cancel();
+        mToast = null;
+        mToastEvent.onCancel();
+    }
+
+    private class ToastEventPreR implements ToastEvent {
+        private final Handler mHandler = new Handler();
+        private final Runnable mPostToastRunnable;
+
+        ToastEventPreR(Runnable finishRunnable) {
+            mPostToastRunnable = finishRunnable;
+        }
+
+        @Override
+        public void onShow(Toast toast) {
+            int durationMs = (mToast.getDuration() == Toast.LENGTH_SHORT) ? DURATION_SHORT_MS
+                                                                          : DURATION_LONG_MS;
+            mHandler.postDelayed(mPostToastRunnable, durationMs);
+        }
+
+        @Override
+        public void onCancel() {
+            mHandler.removeCallbacks(mPostToastRunnable);
+            mPostToastRunnable.run();
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private class ToastEventR implements ToastEvent {
+        private final android.widget.Toast.Callback mToastCallback;
+
+        ToastEventR(Runnable finishRunnable) {
+            mToastCallback = new android.widget.Toast.Callback() {
+                @Override
+                public void onToastHidden() {
+                    finishRunnable.run();
+                }
+            };
+        }
+
+        @Override
+        public void onShow(Toast toast) {
+            toast.getAndroidToast().addCallback(mToastCallback);
+        }
+
+        @Override
+        public void onCancel() {
+            // On R+, Callback#onToastHidden handles |showNextToast| when canceled.
+        }
+    }
+
+    public static void resetForTesting() {
+        if (isEnabled()) getInstance().resetInternalForTesting(); // IN-TEST
+    }
+
+    private void resetInternalForTesting() {
+        mToastQueue.clear();
+        mToast = null;
+    }
+
+    boolean isShowingForTesting() {
+        return mToast != null;
+    }
+
+    public static void setEnabledForTesting(Boolean enabled) {
+        sIsEnabled = enabled;
+    }
+
+    @NativeMethods
+    public interface Natives {
+        boolean isEnabled();
+    }
+}

--- a/cobalt/shell/android/java/src/dev/cobalt/ui/widget/UiWidgetFactory.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/ui/widget/UiWidgetFactory.java
@@ -1,0 +1,80 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package dev.cobalt.ui.widget;
+
+import android.annotation.SuppressLint;
+import android.app.AlertDialog;
+import android.content.Context;
+import android.widget.PopupWindow;
+
+/**
+ * The factory that creates UI widgets. Instead of direct creation of Android popups
+ * we should ask this factory to create the object for us.
+ */
+public class UiWidgetFactory {
+    private static UiWidgetFactory sFactory;
+
+    protected UiWidgetFactory() {}
+
+    /**
+     * returns a UiWidgetFactory.
+     */
+    public static UiWidgetFactory getInstance() {
+        if (sFactory == null) sFactory = new UiWidgetFactory();
+        return sFactory;
+    }
+
+    /**
+     * Sets a new instance for UiWidgetFactory. This can be used to replace the
+     * factory with a new one that supports different set of widgets.
+     *
+     * @param widgetFactory The new UiWidgetFactory that can be accessed via {@link getInstance}
+     */
+    public static void setInstance(UiWidgetFactory widgetFactory) {
+        sFactory = widgetFactory;
+    }
+
+    /**
+     * Returns a new PopupWindow using the given context.
+     *
+     * @param context The Context that is used to create a new PopupWindow.
+     * @return a new PopupWindow.
+     */
+    public PopupWindow createPopupWindow(Context context) {
+        return new PopupWindow(context);
+    }
+
+    /**
+     * Returns a new android.app.AlertDialog using the given context.
+     *
+     * @param context The Context that is used to create a new AlertDialog.
+     * @return a new AlertDialog.
+     */
+    public AlertDialog createAlertDialog(Context context) {
+        return new AlertDialog.Builder(context).create();
+    }
+
+    /**
+     * Returns a new android.widget.Toast using the given context.
+     *
+     * @param context The Context that is used to create a new android.widget.Toast.
+     * @return a new android.widget.Toast.
+     */
+    @SuppressLint("ShowToast")
+    public android.widget.Toast createToast(Context context) {
+        return new android.widget.Toast(context);
+    }
+
+    /**
+     * Returns a new android.widget.Toast using the given context.
+     *
+     * @param context The Context that is used to create a new android.widget.Toast.
+     * @return a new android.widget.Toast.
+     */
+    @SuppressLint("ShowToast")
+    public android.widget.Toast makeToast(Context context, CharSequence text, int duration) {
+        return android.widget.Toast.makeText(context, text, duration);
+    }
+}

--- a/cobalt/testing/browser_tests/BUILD.gn
+++ b/cobalt/testing/browser_tests/BUILD.gn
@@ -154,13 +154,13 @@ if (is_android) {
       "//base:base_java_test_support",
       "//base:jni_java",
       "//cobalt/shell/android:cobalt_shell_browsertests_java",
+      "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java",
       "//components/download/internal/common:internal_java",
       "//components/metrics:metrics_java",
       "//components/viz/service:service_java",
       "//content/public/android:content_java",
       "//content/public/test/android:content_java_test_support",
       "//testing/android/native_test:native_test_java",
-      "//ui/android:ui_java",
     ]
   }
 

--- a/cobalt/testing/browser_tests/browsertests_apk/src/org/chromium/content_browsertests_apk/ContentBrowserTestsApplication.java
+++ b/cobalt/testing/browser_tests/browsertests_apk/src/org/chromium/content_browsertests_apk/ContentBrowserTestsApplication.java
@@ -18,7 +18,7 @@ import android.content.Context;
 
 import org.chromium.base.PathUtils;
 import org.chromium.native_test.NativeBrowserTestApplication;
-import org.chromium.ui.base.ResourceBundle;
+import dev.cobalt.ui.base.ResourceBundle;
 
 /**
  * A basic content_public.browser.tests {@link android.app.Application}.

--- a/content/public/android/BUILD.gn
+++ b/content/public/android/BUILD.gn
@@ -124,6 +124,14 @@ android_library("content_main_dex_java") {
     ":generate_sandboxed_service_srcjar",
   ]
   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+
+  if (is_cobalt) {
+    deps -= [
+      "//ui/android:ui_no_recycler_view_java",
+    ]
+
+    deps += [ "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java", ]
+  }
 }
 
 android_library("content_full_java") {
@@ -384,6 +392,16 @@ android_library("content_full_java") {
   ]
   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
   proguard_configs = [ "proguard.flags" ]
+
+  if (is_cobalt) {
+    deps -= [
+      "//device/bluetooth:java",
+      "//services/device:java",
+      "//ui/android:ui_no_recycler_view_java",
+    ]
+
+    deps += [ "//cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java", ]
+  }
 }
 
 java_strings_grd("content_strings_grd") {


### PR DESCRIPTION
Chrobalt really only depends on a small set of files under `//ui/android`.

This is only documenting my experiment on decoupling Chrobalt from //ui/android and make it depend on exactly what it needs to in a newly created //cobalt/shell/android/java/src/dev/cobalt/ui:ui_view_java.

However content public APIs also depend on //ui/android, and I double we will decouple from content public APIs, so abandon my experiment and just keep this as a doc here.