### PR TITLE
Force-throw an exception

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -368,7 +368,7 @@ public abstract class CobaltActivity extends Activity {
     Log.i(TAG, "initializeJavaBridge");
 
     WebContents webContents = getActiveWebContents();
-    if (webContents == null) {
+    if (true) {
       throw new RuntimeException(
           "webContents is null in initializeJavaBridge. This should never happen.");
     }


### PR DESCRIPTION
This code results in the crash stack, very close to the one reported in b/439066169
```
Abort message: '[23343:23343:0904/120933.000715:FATAL:jni_android.cc(364)] JNI exception: CobaltActivity.java:372'


Stack Trace:
  RELADDR   FUNCTION                                                                          FILE:LINE
  v------>  base::ImmediateCrash()                                                            ../../base/immediate_crash.h:153:3
  03500b18  logging::LogMessage::~LogMessage()                                                ../../base/logging.cc:1031:7
  035bae0b  base::android::CheckException(_JNIEnv*)                                           ../../base/android/jni_android.cc:364:3
  0126fb87  jni_generator::JniJavaCallContextChecked::~JniJavaCallContextChecked()            ../../base/android/jni_generator/jni_generator_helper.h:118:5
  v------>  content::Java_BrowserStartupControllerImpl_browserStartupComplete(_JNIEnv*, int)  gen/jni_headers/content/public/android/content_jni_headers/BrowserStartupControllerImpl_jni.h:84:1
  02150387  content::BrowserStartupComplete(int)                                              ../../content/browser/android/browser_startup_controller.cc:19:3
  0127010f  base::OnceCallback<void (scoped_refptr<blink::UrlData> const&)>::Run(scoped_refptr<blink::UrlData> const&) &&  ../../base/functional/callback.h:348:12
  020d419b  content::StartupTaskRunner::WrappedTask()                                         ../../content/browser/startup_task_runner.cc:73:45
  v------>  base::OnceCallback<void ()>::Run() &&                                             ../../base/functional/callback.h:152:12
  03542bd7  base::TaskAnnotator::RunTaskImpl(base::PendingTask&)                              ../../base/task/common/task_annotator.cc:186:34

```