### PR TITLE
Remove unneeded devTools frontend

### DIFF
--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -380,10 +380,8 @@ group("cobalt_shell_app_deps") {
 repack("pak") {
   sources = [
     "$root_gen_dir/base/tracing/protos/tracing_proto_resources.pak",
-    "$root_gen_dir/cobalt/shell/cobalt_shell_resources.pak",
     "$root_gen_dir/content/browser/resources/media/media_internals_resources.pak",
     "$root_gen_dir/content/browser/webrtc/resources/webrtc_internals_resources.pak",
-    "$root_gen_dir/content/content_resources.pak",
     "$root_gen_dir/content/dev_ui_content_resources.pak",
     "$root_gen_dir/content/gpu_resources.pak",
     "$root_gen_dir/content/histograms_resources.pak",


### PR DESCRIPTION
Remove unneeded devTools frontend per investigation and decision made in [go/cobalt-shell-pak](http://goto.google.com/cobalt-shell-pak).

cobalt_shell.pak size reduced around 40kb in this PR.

Test: Will need to test devtools extensively for ATV and linux. do not have device to test atm.
Bug: 433977010