### PR TITLE
patch fix  Functional Tests EME Basic getMetrics fail 

### DIFF
--- a/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
+++ b/starboard/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
@@ -361,6 +361,9 @@ public class MediaDrmBridge {
       Log.e(TAG, "Failed to retrieve DRM Metrics.");
       return null;
     }
+    if (metrics.length == 0) {
+      metrics = "None".getBytes();
+    }
     return Base64.encode(metrics, Base64.NO_PADDING | Base64.NO_WRAP | Base64.URL_SAFE);
   }
 


### PR DESCRIPTION
b/389180717

Problem:
Functional Tests EME Basic getMetrics fail

Solution:
workround for widevine cdm metrics maybe return Null case

A timing issue between the createMediaCryptoSession and getMetricsInBase64 functions in Cobalt's MediaDrmBridge.
If getMetricsInBase64 call first the metrics return null, then we can ignore this case first.

Change-Id: I04d77cced24ce5bc036f975d0907eee66ca6c735