### PR TITLE
starboard: Adjust more pthread_setname_np() invocations

### DIFF
--- a/starboard/common/thread.cc
+++ b/starboard/common/thread.cc
@@ -79,7 +79,11 @@ std::atomic_bool* Thread::joined_bool() {
 
 void* Thread::ThreadEntryPoint(void* context) {
   Thread* this_ptr = static_cast<Thread*>(context);
+#if defined(__APPLE__)
+  pthread_setname_np(this_ptr->d_->name_.c_str());
+#else
   pthread_setname_np(pthread_self(), this_ptr->d_->name_.c_str());
+#endif
   this_ptr->Run();
   return NULL;
 }

--- a/starboard/shared/starboard/player/filter/punchout_video_renderer_sink.cc
+++ b/starboard/shared/starboard/player/filter/punchout_video_renderer_sink.cc
@@ -93,7 +93,11 @@ PunchoutVideoRendererSink::DrawFrameStatus PunchoutVideoRendererSink::DrawFrame(
 
 // static
 void* PunchoutVideoRendererSink::ThreadEntryPoint(void* context) {
+#if defined(__APPLE__)
+  pthread_setname_np("punchoutvidsink");
+#else
   pthread_setname_np(pthread_self(), "punchoutvidsink");
+#endif
   PunchoutVideoRendererSink* this_ptr =
       static_cast<PunchoutVideoRendererSink*>(context);
   this_ptr->RunLoop();


### PR DESCRIPTION
Follow-up to #7052: there were two other occurrences that were left out of the PR but which are still used by tvOS as well as Linux/Android.

Bug: 432507888