### PR TITLE
android: Gamepad input onKeyDown

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -275,11 +275,19 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
+    // If input is a from a gamepad button, it shouldn't be dispatched to IME which incorrectly
+    // consumes the event as a VKEY_UNKNOWN
+    if (KeyEvent.isGamepadButton(keyCode)) {
+        return super.onKeyDown(keyCode, event);
+    }
     return dispatchKeyEventToIme(keyCode, KeyEvent.ACTION_DOWN) || super.onKeyDown(keyCode, event);
   }
 
   @Override
   public boolean onKeyUp(int keyCode, KeyEvent event) {
+    if (KeyEvent.isGamepadButton(keyCode)) {
+        return super.onKeyUp(keyCode, event);
+    }
     return dispatchKeyEventToIme(keyCode, KeyEvent.ACTION_UP) || super.onKeyUp(keyCode, event);
   }
 


### PR DESCRIPTION
Nvidia shield button inputs (A/B/X/Y) were not working correctly due to the IME check incorrectly consuming the event and preventing super.onKeyDown()/Up() from being called. If the KeyEvent is a gamepad button, they should just directly call super.onKeyDown()/Up(). 


Bug: 399492613