### PR TITLE
media: Allow extra MIME attributes with DRM contents

### DIFF
--- a/third_party/blink/renderer/modules/encryptedmedia/media_key_system_access_initializer_base.cc
+++ b/third_party/blink/renderer/modules/encryptedmedia/media_key_system_access_initializer_base.cc
@@ -19,6 +19,9 @@
 #include "third_party/blink/renderer/platform/network/parsed_content_type.h"
 #include "third_party/blink/renderer/platform/wtf/wtf_size_t.h"
 
+// For BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "build/build_config.h"
+
 namespace blink {
 
 namespace {
@@ -60,7 +63,11 @@ static WebVector<WebMediaKeySystemMediaCapability> ConvertCapabilities(
       // present. Chromium expects "codecs" to be provided, so this capability
       // will be skipped if codecs is not the only parameter specified.
       result[i].mime_type = type.MimeType();
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+      if (type.GetParameters().ParameterCount() >= 1u)
+#else  // BUILDFLAG(USE_STARBOARD_MEDIA)
       if (type.GetParameters().ParameterCount() == 1u)
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
         result[i].codecs = type.ParameterValueForName("codecs");
     }
 


### PR DESCRIPTION
For contentType with DRM contents, Chromium currently only accepts a single MIME attribute (i.e., `codecs`). However, extra MIME attributes may be appended for feature experiments (e.g., tunnel mode on ATV, https://github.com/youtube/cobalt/pull/7099).

Modify blink to accept extra MIME attributes with DRM contents, and this is for Cobalt media only.

Issue: 444260849