### PR TITLE
evergreen: more customizations to update_client

### DIFF
--- a/components/update_client/crx_downloader.h
+++ b/components/update_client/crx_downloader.h
@@ -18,6 +18,12 @@
 #include "base/task/sequenced_task_runner.h"
 #include "url/gurl.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include "base/memory/raw_ptr.h"
+#include "components/update_client/configurator.h"
+#include "starboard/extension/installation_manager.h"
+#endif
+
 namespace update_client {
 
 // Defines a download interface for downloading components, with retrying on
@@ -54,8 +60,16 @@ class CrxDownloader : public base::RefCountedThreadSafe<CrxDownloader> {
     // Download error: 0 indicates success.
     int error = 0;
 
+#if BUILDFLAG(IS_STARBOARD)
+    int installation_index = IM_EXT_INVALID_INDEX;
+#endif
+#if defined(IN_MEMORY_UPDATES)
+    // Path where the contents of the downloaded Crx should later be installed.
+    base::FilePath installation_dir;
+#else
     // Path of the downloaded file if the download was successful.
     base::FilePath response;
+#endif
   };
 
   // The callback is posted only once, when the download is handled, regardless
@@ -82,12 +96,32 @@ class CrxDownloader : public base::RefCountedThreadSafe<CrxDownloader> {
   // behavior is undefined. The callback gets invoked if the download can't
   // be started. |expected_hash| represents the SHA256 cryptographic hash of
   // the download payload, represented as a hexadecimal string.
+#if !defined(IN_MEMORY_UPDATES)
   void StartDownloadFromUrl(const GURL& url,
                             const std::string& expected_hash,
                             DownloadCallback download_callback);
   void StartDownload(const std::vector<GURL>& urls,
                      const std::string& expected_hash,
                      DownloadCallback download_callback);
+
+#else
+  // Overloads where |dst| points to a string that the Crx package should be
+  // downloaded to.
+  // These functions do not take ownership of |dst|, which must refer to a valid
+  // string that outlives this object.
+  void StartDownloadFromUrl(const GURL& url,
+                            const std::string& expected_hash,
+                            std::string* dst,
+                            DownloadCallback download_callback);
+  void StartDownload(const std::vector<GURL>& urls,
+                     const std::string& expected_hash,
+                     std::string* dst,
+                     DownloadCallback download_callback);
+#endif                     
+
+#if BUILDFLAG(IS_STARBOARD)
+  void CancelDownload();
+#endif
 
   void set_progress_callback(const ProgressCallback& progress_callback);
 
@@ -122,7 +156,14 @@ class CrxDownloader : public base::RefCountedThreadSafe<CrxDownloader> {
  private:
   friend class base::RefCountedThreadSafe<CrxDownloader>;
 
+#if defined(IN_MEMORY_UPDATES)
+  virtual void DoStartDownload(const GURL& url, std::string* dst) = 0;
+#else
   virtual void DoStartDownload(const GURL& url) = 0;
+#endif
+#if BUILDFLAG(IS_STARBOARD)
+  virtual void DoCancelDownload() = 0;
+#endif
 
   void HandleDownloadError(bool is_handled,
                            const Result& result,
@@ -144,6 +185,11 @@ class CrxDownloader : public base::RefCountedThreadSafe<CrxDownloader> {
   std::vector<GURL>::iterator current_url_;
 
   std::vector<DownloadMetrics> download_metrics_;
+
+#if defined(IN_MEMORY_UPDATES)
+  // TODO(b/449250040): Replace naked pointers
+  base::raw_ptr<std::string> dst_str_;  // not owned, can't be null
+#endif
 };
 
 }  // namespace update_client

--- a/components/update_client/crx_downloader_factory.h
+++ b/components/update_client/crx_downloader_factory.h
@@ -6,6 +6,9 @@
 #define COMPONENTS_UPDATE_CLIENT_CRX_DOWNLOADER_FACTORY_H_
 
 #include "base/memory/ref_counted.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/configurator.h"
+#endif
 
 namespace update_client {
 
@@ -21,8 +24,13 @@ class CrxDownloaderFactory
   CrxDownloaderFactory(const CrxDownloaderFactory&) = delete;
   CrxDownloaderFactory& operator=(const CrxDownloaderFactory&) = delete;
 
+#if BUILDFLAG(IS_STARBOARD)
+  virtual scoped_refptr<CrxDownloader> MakeCrxDownloader(
+      scoped_refptr<Configurator> config) const = 0;
+#else
   virtual scoped_refptr<CrxDownloader> MakeCrxDownloader(
       bool background_download_enabled) const = 0;
+#endif
 
  protected:
   friend class base::RefCountedThreadSafe<CrxDownloaderFactory>;

--- a/components/update_client/request_sender.cc
+++ b/components/update_client/request_sender.cc
@@ -21,6 +21,10 @@
 #include "components/update_client/update_client_errors.h"
 #include "components/update_client/utils.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include "base/notreached.h"
+#endif
+
 namespace update_client {
 
 namespace {
@@ -60,6 +64,10 @@ void RequestSender::Send(
     bool use_signing,
     RequestSenderCallback request_sender_callback) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+#if BUILDFLAG(IS_STARBOARD)
+  // TODO(b/448186580): Replace LOG with D(V)LOG
+  LOG(INFO) << "RequestSender::Send";
+#endif
 
   urls_ = urls;
   request_extra_headers_ = request_extra_headers;
@@ -117,6 +125,19 @@ void RequestSender::SendInternal() {
       base::BindOnce(&RequestSender::OnNetworkFetcherComplete,
                      base::Unretained(this), url));
 }
+
+#if BUILDFLAG(IS_STARBOARD)
+void RequestSender::Cancel() {
+  // TODO(b/448186580): Replace LOG with D(V)LOG
+  LOG(INFO) << "RequestSender::Cancel";
+  // TODO(b/431862767): enable this in a follow-up PR with the Cobalt network
+  // fetcher implementation
+  NOTIMPLEMENTED();
+  // if (network_fetcher_.get()) {
+  //   network_fetcher_->Cancel();
+  // }
+}
+#endif
 
 void RequestSender::SendInternalComplete(
     int error,
@@ -176,6 +197,10 @@ void RequestSender::OnNetworkFetcherComplete(
     const std::string& xheader_cup_server_proof,
     int64_t xheader_retry_after_sec) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+#if BUILDFLAG(IS_STARBOARD)
+  // TODO(b/448186580): Replace LOG with D(V)LOG
+  LOG(INFO) << "RequestSender::OnNetworkFetcherComplete";
+#endif
 
   VLOG(1) << "Request completed from url: " << original_url.spec();
 

--- a/components/update_client/request_sender.h
+++ b/components/update_client/request_sender.h
@@ -61,6 +61,10 @@ class RequestSender {
       bool use_signing,
       RequestSenderCallback request_sender_callback);
 
+#if BUILDFLAG(IS_STARBOARD)
+  void Cancel();
+#endif
+
  private:
   // Combines the |url| and |query_params| parameters.
   static GURL BuildUpdateUrl(const GURL& url, const std::string& query_params);

--- a/components/update_client/update_checker.cc
+++ b/components/update_client/update_checker.cc
@@ -40,6 +40,11 @@
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "url/gurl.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/cobalt_slot_management.h"
+#include "starboard/extension/free_space.h"
+#endif
+
 namespace update_client {
 
 namespace {
@@ -59,6 +64,12 @@ class UpdateCheckerImpl : public UpdateChecker {
       scoped_refptr<UpdateContext> context,
       const base::flat_map<std::string, std::string>& additional_attributes,
       UpdateCheckCallback update_check_callback) override;
+
+#if BUILDFLAG(IS_STARBOARD)
+  PersistedData* GetPersistedData() override { return metadata_; }
+  void Cancel() override;
+  bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override;
+#endif
 
  private:
   UpdaterStateAttributes ReadUpdaterStateAttributes() const;
@@ -187,7 +198,56 @@ void UpdateCheckerImpl::CheckForUpdatesHelper(
       install_source = crx_component->install_source;
     else if (component->is_foreground())
       install_source = "ondemand";
+#if BUILDFLAG(IS_STARBOARD)
+    base::Version current_version = crx_component->version;
 
+    // Check if there is an available update already for quick roll-forward
+    auto installation_api =
+        static_cast<const CobaltExtensionInstallationManagerApi*>(
+            SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+    if (!installation_api) {
+      LOG(ERROR) << "UpdaterChecker: "
+                 << "Failed to get installation manager extension.";
+      return;
+    }
+
+    if (SkipUpdate(installation_api)) {
+      LOG(WARNING) << "UpdaterChecker is skipping";
+      UpdateCheckFailed(ErrorCategory::kUpdateCheck,
+        static_cast<int>(UpdateCheckError::OUT_OF_SPACE),
+        /*retry_after_sec=*/-1);
+      return;
+    }
+
+    if (CobaltQuickUpdate(installation_api, current_version)) {
+      // The last parameter in UpdateCheckFailed below, which is to be passed to
+      // update_check_callback_, indicates a throttling by the update server.
+      // Only non-negative values are valid. Negative values are not trusted
+      // and are ignored.
+      UpdateCheckFailed(ErrorCategory::kUpdateCheck,
+                        static_cast<int>(UpdateCheckError::QUICK_ROLL_FORWARD),
+                        /*retry_after_sec=*/-1);
+
+      return;
+    }
+
+    std::string last_installed_version =
+        GetPersistedData()->GetLastInstalledVersion(app_id);
+    std::string last_installed_starboard =
+        GetPersistedData()->GetLastInstalledSbVersion(app_id);
+    // If the version of the last installed update package is higher than the
+    // version of the running binary and the starboard version of the last
+    // installed update matched the binary currently running, use the last
+    // installed version to indicate the current update version in the update
+    // check request.
+    if (!last_installed_version.empty() &&
+        last_installed_starboard == std::to_string(SB_API_VERSION) &&
+        base::Version(last_installed_version).CompareTo(current_version) > 0) {
+      current_version = base::Version(last_installed_version);
+    }
+// If the quick roll forward update slot candidate doesn't exist, continue
+// with update check.
+#endif
     apps.push_back(MakeProtocolApp(
         app_id, crx_component->version, crx_component->ap, crx_component->brand,
         config_->GetLang(), metadata_->GetInstallDate(app_id), install_source,
@@ -244,7 +304,39 @@ void UpdateCheckerImpl::CheckForUpdatesHelper(
                                additional_attributes, updater_state_attributes,
                                active_ids))
                          : absl::nullopt));
+#if BUILDFLAG(IS_STARBOARD)
+  // Reset |is_forced_update| flag to false if it is true
+  config_->CompareAndSwapForcedUpdate(/*old_value=*/1, /*new_value=*/0);
+#endif
 }
+
+#if BUILDFLAG(IS_STARBOARD)
+void UpdateCheckerImpl::Cancel() {
+  // TODO(b/448186580): Replace LOG with D(V)LOG
+  LOG(INFO) << "UpdateCheckerImpl::Cancel";
+  if (request_sender_.get()) {
+    request_sender_->Cancel();
+  }
+}
+
+bool UpdateCheckerImpl::SkipUpdate(
+  const CobaltExtensionInstallationManagerApi* installation_api) {
+  auto free_space_ext = static_cast<const CobaltExtensionFreeSpaceApi*>(
+      SbSystemGetExtension(kCobaltExtensionFreeSpaceName));
+  if (!installation_api) {
+    LOG(WARNING) << "UpdaterChecker::SkipUpdate: missing installation api";
+    return false;
+  }
+  if (!free_space_ext) {
+    LOG(WARNING) << "UpdaterChecker::SkipUpdate: No FreeSpace Cobalt extension";
+    return false;
+  }
+  //TODO(b/446250454): Use Posix API to measure free storage space for updates.
+  return CobaltSkipUpdate(installation_api, config_->GetMinFreeSpaceBytes(),
+     free_space_ext->MeasureFreeSpace(kSbSystemPathStorageDirectory),
+     CobaltInstallationCleanupSize(installation_api)) ;
+}
+#endif
 
 void UpdateCheckerImpl::OnRequestSenderComplete(
     scoped_refptr<UpdateContext> context,

--- a/components/update_client/update_checker.h
+++ b/components/update_client/update_checker.h
@@ -17,6 +17,10 @@
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "url/gurl.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include "starboard/extension/installation_manager.h"
+#endif
+
 namespace update_client {
 
 class Configurator;
@@ -49,10 +53,17 @@ class UpdateChecker {
       const base::flat_map<std::string, std::string>& additional_attributes,
       UpdateCheckCallback update_check_callback) = 0;
 
+#if BUILDFLAG(IS_STARBOARD)
+  virtual void Cancel() = 0;
+  virtual bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) = 0;
+#endif
+
   static std::unique_ptr<UpdateChecker> Create(
       scoped_refptr<Configurator> config,
       PersistedData* persistent);
-
+#if BUILDFLAG(IS_STARBOARD)
+  virtual PersistedData* GetPersistedData() = 0;
+#endif
  protected:
   UpdateChecker() = default;
 };

--- a/components/update_client/url_fetcher_downloader.cc
+++ b/components/update_client/url_fetcher_downloader.cc
@@ -18,29 +18,267 @@
 #include "components/update_client/utils.h"
 #include "url/gurl.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include <stack>
+#include "base/files/file_enumerator.h"
+#include "base/notreached.h"
+#endif
+
+// TODO(b/449223391): Document the usage of base::Unretained()
+
+namespace {
+
+#if BUILDFLAG(IS_STARBOARD)
+// Can't simply use base::DeletePathRecursively() because the empty dirs
+// need to be preserved.
+void CleanupDirectory(base::FilePath& dir) {
+  std::stack<std::string> directories;
+  base::FileEnumerator file_enumerator(
+      dir, true,
+      base::FileEnumerator::FILES | base::FileEnumerator::DIRECTORIES);
+  for (auto path = file_enumerator.Next(); !path.value().empty();
+       path = file_enumerator.Next()) {
+    base::FileEnumerator::FileInfo info(file_enumerator.GetInfo());
+
+    if (info.IsDirectory()) {
+      directories.push(path.value());
+    } else {
+      unlink(path.value().c_str());
+    }
+  }
+  while (!directories.empty()) {
+    rmdir(directories.top().c_str());
+    directories.pop();
+  }
+}
+
+#endif
+
+}  // namespace
+
 namespace update_client {
 
+#if BUILDFLAG(IS_STARBOARD)
+UrlFetcherDownloader::UrlFetcherDownloader(
+    scoped_refptr<CrxDownloader> successor,
+    scoped_refptr<Configurator> config)
+    : CrxDownloader(std::move(successor)),
+      network_fetcher_factory_(config->GetNetworkFetcherFactory()),
+      config_(std::move(config)) {
+  DLOG(INFO) << "UrlFetcherDownloader::UrlFetcherDownloader";
+}
+#else
 UrlFetcherDownloader::UrlFetcherDownloader(
     scoped_refptr<CrxDownloader> successor,
     scoped_refptr<NetworkFetcherFactory> network_fetcher_factory)
     : CrxDownloader(std::move(successor)),
       network_fetcher_factory_(network_fetcher_factory) {}
+#endif
 
 UrlFetcherDownloader::~UrlFetcherDownloader() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+#if defined(IN_MEMORY_UPDATES)
+void UrlFetcherDownloader::ConfirmSlot(const GURL& url, std::string* dst) {
+#else  // defined(IN_MEMORY_UPDATES)
+void UrlFetcherDownloader::ConfirmSlot(const GURL& url) {
+#endif  // defined(IN_MEMORY_UPDATES)
+  LOG(INFO) << "UrlFetcherDownloader::ConfirmSlot: url=" << url;
+  if (is_cancelled_) {
+    LOG(ERROR) << "UrlFetcherDownloader::ConfirmSlot: Download already cancelled";
+    ReportDownloadFailure(url, CrxDownloaderError::GENERIC_ERROR);
+    return;
+  }
+#if defined(IN_MEMORY_UPDATES)
+  if (!cobalt_slot_management_.ConfirmSlot(installation_dir_)) {
+#else  // defined(IN_MEMORY_UPDATES)
+  if (!cobalt_slot_management_.ConfirmSlot(download_dir_)) {
+#endif  // defined(IN_MEMORY_UPDATES)
+    ReportDownloadFailure(url, CrxDownloaderError::SLOT_UNAVAILABLE);
+    return;
+  }
+
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&UrlFetcherDownloader::StartURLFetch,
+#if defined(IN_MEMORY_UPDATES)
+                                base::Unretained(this), url, dst));
+#else  // defined(IN_MEMORY_UPDATES)
+                                base::Unretained(this), url));
+#endif  // defined(IN_MEMORY_UPDATES)
+}
+
+#if defined(IN_MEMORY_UPDATES)
+void UrlFetcherDownloader::SelectSlot(const GURL& url, std::string* dst) {
+#else  // defined(IN_MEMORY_UPDATES)
+void UrlFetcherDownloader::SelectSlot(const GURL& url) {
+#endif  // defined(IN_MEMORY_UPDATES)
+  LOG(INFO) << "UrlFetcherDownloader::SelectSlot: url=" << url;
+  if (is_cancelled_) {
+    LOG(ERROR) << "UrlFetcherDownloader::SelectSlot: Download already cancelled";
+    ReportDownloadFailure(url, CrxDownloaderError::GENERIC_ERROR);
+    return;
+  }
+#if defined(IN_MEMORY_UPDATES)
+  if (!cobalt_slot_management_.SelectSlot(&installation_dir_)) {
+#else  // defined(IN_MEMORY_UPDATES)
+  if (!cobalt_slot_management_.SelectSlot(&download_dir_)) {
+#endif  // defined(IN_MEMORY_UPDATES)
+    ReportDownloadFailure(url, CrxDownloaderError::SLOT_UNAVAILABLE);
+    return;
+  }
+  // Use 15 sec delay to allow for other updaters/loaders to settle down.
+  base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
+      FROM_HERE,
+      base::BindOnce(&UrlFetcherDownloader::ConfirmSlot, base::Unretained(this),
+#if defined(IN_MEMORY_UPDATES)
+                     url, dst),
+#else  // defined(IN_MEMORY_UPDATES)
+                     url),
+#endif  // defined(IN_MEMORY_UPDATES)
+      base::Seconds(15));
+}
+#endif  // BUILDFLAG(IS_STARBOARD)
+
+#if defined(IN_MEMORY_UPDATES)
+void UrlFetcherDownloader::DoStartDownload(const GURL& url, std::string* dst) {
+#else  // defined(IN_MEMORY_UPDATES)
 void UrlFetcherDownloader::DoStartDownload(const GURL& url) {
+#endif  // defined(IN_MEMORY_UPDATES)
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+#if BUILDFLAG(IS_STARBOARD)
+  // TODO(b/448186580): Replace LOG with D(V)LOG
+  LOG(INFO) << "UrlFetcherDownloader::DoStartDownload";
+  if (is_cancelled_) {
+    LOG(ERROR) << "UrlFetcherDownloader::DoStartDownload: Download already cancelled";
+    ReportDownloadFailure(url, CrxDownloaderError::GENERIC_ERROR);
+    return;
+  }
+  const CobaltExtensionInstallationManagerApi* installation_api =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+  if (!installation_api) {
+    LOG(ERROR) << "Failed to get installation manager";
+    ReportDownloadFailure(url, CrxDownloaderError::GENERIC_ERROR);
+    return;
+  }
+  if (!cobalt_slot_management_.Init(installation_api)) {
+    ReportDownloadFailure(url, CrxDownloaderError::GENERIC_ERROR);
+    return;
+  }
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&UrlFetcherDownloader::SelectSlot,
+#if defined(IN_MEMORY_UPDATES)
+                                base::Unretained(this), url, dst));
+#else  // defined(IN_MEMORY_UPDATES)
+                                base::Unretained(this), url));
+#endif  // defined(IN_MEMORY_UPDATES)
+#else  // BUILDFLAG(IS_STARBOARD)
   base::ThreadPool::PostTaskAndReply(
       FROM_HERE, kTaskTraits,
       base::BindOnce(&UrlFetcherDownloader::CreateDownloadDir, this),
       base::BindOnce(&UrlFetcherDownloader::StartURLFetch, this, url));
+#endif  // BUILDFLAG(IS_STARBOARD)
 }
 
+#if BUILDFLAG(IS_STARBOARD)
+void UrlFetcherDownloader::DoCancelDownload() {
+  // TODO(b/448186580): Replace LOG with D(V)LOG
+  LOG(INFO) << "UrlFetcherDownloader::DoCancelDownload";
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  is_cancelled_ = true;
+  // TODO(b/431862767): enable this in a follow-up PR with the Cobalt network fetcher implementation
+  NOTIMPLEMENTED();
+  // if (network_fetcher_.get()) {
+  //   network_fetcher_->Cancel();
+  // }
+}
+#endif
+
+#if !defined(IN_MEMORY_UPDATES)
 void UrlFetcherDownloader::CreateDownloadDir() {
   base::CreateNewTempDirectory(FILE_PATH_LITERAL("chrome_url_fetcher_"),
                                &download_dir_);
 }
+#endif
 
+#if BUILDFLAG(IS_STARBOARD)
+void UrlFetcherDownloader::ReportDownloadFailure(const GURL& url,
+                                                 CrxDownloaderError error) {
+  // TODO(b/448186580): Replace LOG with D(V)LOG
+  LOG(INFO) << "UrlFetcherDownloader::ReportDownloadFailure";                                                
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  cobalt_slot_management_.CleanupAllDrainFiles();
+  Result result;
+  result.error = static_cast<int>(error);
+
+  DownloadMetrics download_metrics;
+  download_metrics.url = url;
+  download_metrics.downloader = DownloadMetrics::kUrlFetcher;
+  download_metrics.error = -1;
+  download_metrics.downloaded_bytes = -1;
+  download_metrics.total_bytes = -1;
+  download_metrics.download_time_ms = 0;
+
+  main_task_runner()->PostTask(
+      FROM_HERE,
+      base::BindOnce(&UrlFetcherDownloader::OnDownloadComplete,
+                     base::Unretained(this), false, result, download_metrics));
+}
+
+#if defined(IN_MEMORY_UPDATES)
+void UrlFetcherDownloader::StartURLFetch(const GURL& url, std::string* dst) {
+#else
+void UrlFetcherDownloader::StartURLFetch(const GURL& url) {
+#endif
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+#if defined(IN_MEMORY_UPDATES)
+  CHECK(dst != nullptr);
+#endif
+
+  LOG(INFO) << "UrlFetcherDownloader::StartURLFetch: url" << url
+#if defined(IN_MEMORY_UPDATES)
+               << " installation_dir=" << installation_dir_;
+#else  // defined(IN_MEMORY_UPDATES)
+               << " download_dir=" << download_dir_;
+#endif  // defined(IN_MEMORY_UPDATES)
+  if (is_cancelled_) {
+    LOG(ERROR) << "UrlFetcherDownloader::StartURLFetch: Download already cancelled";
+    ReportDownloadFailure(url, CrxDownloaderError::GENERIC_ERROR);
+    return;
+  }
+
+#if defined(IN_MEMORY_UPDATES)
+  if (installation_dir_.empty()) {
+    LOG(ERROR) << "UrlFetcherDownloader::StartURLFetch: failed with empty installation_dir";
+#else
+  if (download_dir_.empty()) {
+    LOG(ERROR) << "UrlFetcherDownloader::StartURLFetch: failed with empty download_dir";
+#endif  // defined(IN_MEMORY_UPDATES)
+    ReportDownloadFailure(url, CrxDownloaderError::GENERIC_ERROR);
+    return;
+  }
+
+  network_fetcher_ = network_fetcher_factory_->Create();
+#if defined(IN_MEMORY_UPDATES)
+  network_fetcher_->DownloadToString(
+      url,
+      dst,
+      base::BindOnce(&UrlFetcherDownloader::OnResponseStarted, this),
+      base::BindRepeating(&UrlFetcherDownloader::OnDownloadProgress, this),
+      base::BindOnce(&UrlFetcherDownloader::OnNetworkFetcherComplete, this));
+#else
+  file_path_ = download_dir_.AppendASCII(url.ExtractFileName());
+  network_fetcher_->DownloadToFile(
+      url, file_path_,
+      base::BindOnce(&UrlFetcherDownloader::OnResponseStarted, this),
+      base::BindRepeating(&UrlFetcherDownloader::OnDownloadProgress, this),
+      base::BindOnce(&UrlFetcherDownloader::OnNetworkFetcherComplete, this));
+#endif
+
+  download_start_time_ = base::TimeTicks::Now();
+}
+
+#else
 void UrlFetcherDownloader::StartURLFetch(const GURL& url) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
@@ -72,11 +310,16 @@ void UrlFetcherDownloader::StartURLFetch(const GURL& url) {
 
   download_start_time_ = base::TimeTicks::Now();
 }
+#endif // BUILDFLAG(IS_STARBOARD)
 
 void UrlFetcherDownloader::OnNetworkFetcherComplete(int net_error,
                                                     int64_t content_size) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
+#if BUILDFLAG(IS_STARBOARD)
+  // TODO(b/448186580): Replace LOG with D(V)LOG
+  LOG(INFO) << "UrlFetcherDownloader::OnNetworkFetcherComplete";
+#endif
   const base::TimeTicks download_end_time(base::TimeTicks::Now());
   const base::TimeDelta download_time =
       download_end_time >= download_start_time_
@@ -87,7 +330,11 @@ void UrlFetcherDownloader::OnNetworkFetcherComplete(int net_error,
   // the request and avoid overloading the server in this case.
   // is not accepting requests for the moment.
   int error = -1;
+#if BUILDFLAG(IS_STARBOARD) && !defined(IN_MEMORY_UPDATES)
+  if (!file_path_.empty() && !net_error && response_code_ == 200)
+#else
   if (!net_error && response_code_ == 200)
+#endif
     error = 0;
   else if (response_code_ != -1)
     error = response_code_;
@@ -98,8 +345,16 @@ void UrlFetcherDownloader::OnNetworkFetcherComplete(int net_error,
 
   Result result;
   result.error = error;
-  if (!error)
+  if (!error) {
+#if defined(IN_MEMORY_UPDATES)
+    result.installation_dir = installation_dir_;
+#else
     result.response = file_path_;
+#endif
+#if BUILDFLAG(IS_STARBOARD)
+    result.installation_index = cobalt_slot_management_.GetInstallationIndex();
+#endif
+  }
 
   DownloadMetrics download_metrics;
   download_metrics.url = url();
@@ -112,15 +367,28 @@ void UrlFetcherDownloader::OnNetworkFetcherComplete(int net_error,
 
   VLOG(1) << "Downloaded " << content_size << " bytes in "
           << download_time.InMilliseconds() << "ms from " << url().spec()
+#if defined(IN_MEMORY_UPDATES)
+          << " to string";
+#else
           << " to " << result.response.value();
+#endif
 
+#if !defined(IN_MEMORY_UPDATES)
+#if !BUILDFLAG(IS_STARBOARD)
   // Delete the download directory in the error cases.
   if (error && !download_dir_.empty()) {
     base::ThreadPool::PostTask(
         FROM_HERE, kTaskTraits,
         base::BindOnce(IgnoreResult(&base::DeletePathRecursively),
                        download_dir_));
+    }
+#else  // BUILDFLAG(IS_STARBOARD)
+  if (error && !download_dir_.empty()) {
+    // Cleanup the download dir.
+    CleanupDirectory(download_dir_);
   }
+#endif  // BUILDFLAG(IS_STARBOARD)
+#endif  // !defined(IN_MEMORY_UPDATES)                      
 
   main_task_runner()->PostTask(
       FROM_HERE, base::BindOnce(&UrlFetcherDownloader::OnDownloadComplete, this,

--- a/components/update_client/url_fetcher_downloader.h
+++ b/components/update_client/url_fetcher_downloader.h
@@ -15,6 +15,11 @@
 #include "base/time/time.h"
 #include "components/update_client/crx_downloader.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/cobalt_slot_management.h"
+#include "components/update_client/update_client_errors.h"
+#endif
+
 namespace update_client {
 
 class NetworkFetcher;
@@ -23,30 +28,86 @@ class NetworkFetcherFactory;
 // Implements a CRX downloader using a NetworkFetcher object.
 class UrlFetcherDownloader : public CrxDownloader {
  public:
+#if BUILDFLAG(IS_STARBOARD)
+  UrlFetcherDownloader(scoped_refptr<CrxDownloader> successor,
+                       scoped_refptr<Configurator> config);
+#else
   UrlFetcherDownloader(
       scoped_refptr<CrxDownloader> successor,
       scoped_refptr<NetworkFetcherFactory> network_fetcher_factory);
+#endif
   UrlFetcherDownloader(const UrlFetcherDownloader&) = delete;
   UrlFetcherDownloader& operator=(const UrlFetcherDownloader&) = delete;
 
  private:
   // Overrides for CrxDownloader.
   ~UrlFetcherDownloader() override;
+#if defined(IN_MEMORY_UPDATES)
+  void DoStartDownload(const GURL& url, std::string* dst) override;
+#else
   void DoStartDownload(const GURL& url) override;
+#endif
+#if BUILDFLAG(IS_STARBOARD)
+  void DoCancelDownload() override;
+#endif
 
+#if !defined(IN_MEMORY_UPDATES)
   void CreateDownloadDir();
+#endif
+#if defined(IN_MEMORY_UPDATES)
+  // Does not take ownership of |dst|, which must refer to a valid string that
+  // outlives this object.
+  void StartURLFetch(const GURL& url, std::string* dst);
+#else
   void StartURLFetch(const GURL& url);
+#endif
+
+#if BUILDFLAG(IS_STARBOARD)
+#if defined(IN_MEMORY_UPDATES)
+  // With in-memory updates it's no longer necessary to select and confirm the
+  // installation slot at download time, and it would likely be more clear to
+  // move this responsibility to the unpack flow. That said, yavor@ requested
+  // that we keep it here for now since there are a number of edge cases to
+  // consider and data races to avoid in this space (e.g., racing updaters). To
+  // limit the scope and risk of the in-memory updates changes we can leave it
+  // here for now and continue passing the installation dir on to the unpack
+  // flow, and consider changing this in a future refactoring.
+
+  // Does not take ownership of |dst|, which must refer to a valid string that
+  // outlives this object.
+  void SelectSlot(const GURL& url, std::string* dst);
+
+  // Does not take ownership of |dst|, which must refer to a valid string that
+  // outlives this object.
+  void ConfirmSlot(const GURL& url, std::string* dst);
+#else  // defined(IN_MEMORY_UPDATES)
+  void SelectSlot(const GURL& url);
+  void ConfirmSlot(const GURL& url);
+#endif  // defined(IN_MEMORY_UPDATES)
+#endif  // BUILDFLAG(IS_STARBOARD)
+
   void OnNetworkFetcherComplete(int net_error, int64_t content_size);
   void OnResponseStarted(int response_code, int64_t content_length);
   void OnDownloadProgress(int64_t content_length);
+
+#if BUILDFLAG(IS_STARBOARD)
+  void ReportDownloadFailure(const GURL& url, CrxDownloaderError error);
+#endif
 
   SEQUENCE_CHECKER(sequence_checker_);
 
   scoped_refptr<NetworkFetcherFactory> network_fetcher_factory_;
   std::unique_ptr<NetworkFetcher> network_fetcher_;
 
+#if defined(IN_MEMORY_UPDATES)
+  // For legacy, file-system based updates the download_dir_ doubles as the
+  // installation dir. But for in-memory updates this directory only serves as
+  // the installation directory and should be named accordingly.
+  base::FilePath installation_dir_;
+#else
   // Contains a temporary download directory for the downloaded file.
   base::FilePath download_dir_;
+#endif
 
   // Contains the file path to the downloaded file.
   base::FilePath file_path_;
@@ -55,6 +116,14 @@ class UrlFetcherDownloader : public CrxDownloader {
 
   int response_code_ = -1;
   int64_t total_bytes_ = -1;
+
+#if BUILDFLAG(IS_STARBOARD)
+  CobaltSlotManagement cobalt_slot_management_;
+  scoped_refptr<Configurator> config_;
+  // This variable tracks a Cancel() being called: all subsequent
+  // download requests will be ignored.
+  bool is_cancelled_ = false;
+#endif
 };
 
 }  // namespace update_client


### PR DESCRIPTION
These customizations support in-memory update and installation slot manipulation. They mostly come from C25, with modifications to work with the new code base. Added a new CrxDownloaderFactoryCobalt class. Unit tests will be included in follow-up PRs.


Issue: 431862767