### PR TITLE
Restore cobalt/browser/device_authentication.{cc/h} and unit test

### DIFF
--- a/cobalt/browser/device_authentication.cc
+++ b/cobalt/browser/device_authentication.cc
@@ -1,0 +1,184 @@
+// Copyright 2019 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/device_authentication.h"
+
+#include <algorithm>
+#include <map>
+
+#include "base/base64.h"
+#include "base/base64url.h"
+#include "base/logging.h"
+#include "base/strings/escape.h"
+#include "base/time/time.h"
+#include "crypto/hmac.h"
+#include "starboard/system.h"
+
+namespace cobalt {
+namespace browser {
+
+namespace {
+
+constexpr size_t kSHA256DigestSize = 32;
+
+bool ComputeSignatureFromSignAPI(const std::string& message,
+                                 uint8_t* signature) {
+  return SbSystemSignWithCertificationSecretKey(
+      reinterpret_cast<const uint8_t*>(message.data()), message.size(),
+      signature, kSHA256DigestSize);
+}
+
+// Check to see if we can query the platform for the secret key.  If so,
+// go ahead and use it to sign the message, otherwise try to use the
+// SbSystemSignWithCertificationSecretKey() method to sign the message.  If
+// both methods fail, return an empty string.
+std::string ComputeBase64Signature(const std::string& message) {
+  uint8_t signature[kSHA256DigestSize];
+
+  if (ComputeSignatureFromSignAPI(message, signature)) {
+    DLOG(INFO) << "Using certification signature provided by "
+               << "SbSystemSignWithCertificationSecretKey().";
+  } else {
+    return std::string();
+  }
+
+  std::string base_64_url_signature;
+  base::Base64UrlEncode(std::string(signature, signature + kSHA256DigestSize),
+                        base::Base64UrlEncodePolicy::OMIT_PADDING,
+                        &base_64_url_signature);
+  return base_64_url_signature;
+}
+
+std::string NumberToFourByteString(size_t n) {
+  std::string str;
+  str += static_cast<char>(((n & 0xff000000) >> 24));
+  str += static_cast<char>(((n & 0x00ff0000) >> 16));
+  str += static_cast<char>(((n & 0x0000ff00) >> 8));
+  str += static_cast<char>((n & 0x000000ff));
+  return str;
+}
+
+// Used by ComputeMessage() to create a message component as a string.
+std::string BuildMessageFragment(const std::string& key,
+                                 const std::string& value) {
+  std::string msg_fragment = NumberToFourByteString(key.length()) + key +
+                             NumberToFourByteString(value.length()) + value;
+  return msg_fragment;
+}
+
+// Returns the certification scope provided by the platform to use with device
+// authentication.
+std::string GetCertScopeFromPlatform() {
+  // Get cert_scope and base_64_secret
+  const size_t kCertificationScopeLength = 1023;
+  char cert_scope_property[kCertificationScopeLength + 1] = {0};
+  bool result =
+      SbSystemGetProperty(kSbSystemPropertyCertificationScope,
+                          cert_scope_property, kCertificationScopeLength);
+  if (!result) {
+    DLOG(ERROR) << "Unable to get kSbSystemPropertyCertificationScope";
+    return std::string();
+  }
+
+  return cert_scope_property;
+}
+
+// Returns the start time provided by the platform for use with device
+// authentication.
+std::string GetStartTime() {
+  return std::to_string(static_cast<int64_t>(base::Time::Now().ToDoubleT()));
+}
+
+}  // namespace
+
+std::string GetDeviceAuthenticationSignedURLQueryString() {
+  std::string cert_scope = GetCertScopeFromPlatform();
+  if (cert_scope.empty()) {
+    LOG(WARNING) << "Error retrieving certification scope required for "
+                 << "device authentication.";
+    return std::string();
+  }
+  std::string start_time = GetStartTime();
+  CHECK(!start_time.empty());
+
+  std::string base64_signature =
+      ComputeBase64Signature(ComputeMessage(cert_scope, start_time));
+
+  return GetDeviceAuthenticationSignedURLQueryStringFromComponents(
+      cert_scope, start_time, base64_signature);
+}
+
+std::string GetDeviceAuthenticationSignedURLQueryStringFromComponents(
+    const std::string& cert_scope,
+    const std::string& start_time,
+    const std::string& base64_signature) {
+  CHECK(!cert_scope.empty());
+  CHECK(!start_time.empty());
+
+  if (base64_signature.empty()) {
+    return std::string();
+  }
+
+  std::map<std::string, std::string> signed_query_components;
+  signed_query_components["cert_scope"] = cert_scope;
+  signed_query_components["start_time"] = start_time;
+  signed_query_components["sig"] = base64_signature;
+
+  std::string query;
+  for (const auto& query_component : signed_query_components) {
+    const std::string& key = query_component.first;
+    const std::string& value = query_component.second;
+
+    if (!query.empty()) {
+      query += "&";
+    }
+    query += base::EscapeQueryParamValue(key, true);
+    if (!value.empty()) {
+      query += "=" + base::EscapeQueryParamValue(value, true);
+    }
+  }
+
+  return query;
+}
+
+// Combine multiple message components into a string that will be used as the
+// message that we will sign.
+std::string ComputeMessage(const std::string& cert_scope,
+                           const std::string& start_time) {
+  // Build message from cert_scope and start_time.
+  return BuildMessageFragment("cert_scope", cert_scope) +
+         BuildMessageFragment("start_time", start_time);
+}
+
+void ComputeHMACSHA256SignatureWithProvidedKey(const std::string& message,
+                                               const std::string& base64_key,
+                                               uint8_t* signature,
+                                               size_t signature_size_in_bytes) {
+  CHECK_GE(signature_size_in_bytes, 32U);
+
+  std::string key;
+  base::Base64Decode(base64_key, &key);
+
+  // Generate signature from message using HMAC-SHA256.
+  crypto::HMAC hmac(crypto::HMAC::SHA256);
+  if (!hmac.Init(key)) {
+    DLOG(ERROR) << "Unable to initialize HMAC-SHA256.";
+  }
+  if (!hmac.Sign(message, signature, signature_size_in_bytes)) {
+    DLOG(ERROR) << "Unable to sign HMAC-SHA256.";
+  }
+}
+
+}  // namespace browser
+}  // namespace cobalt

--- a/cobalt/browser/device_authentication.h
+++ b/cobalt/browser/device_authentication.h
@@ -1,0 +1,62 @@
+// Copyright 2019 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_DEVICE_AUTHENTICATION_H_
+#define COBALT_BROWSER_DEVICE_AUTHENTICATION_H_
+
+#include <string>
+
+#include "starboard/configuration.h"
+#include "starboard/types.h"
+
+namespace cobalt {
+namespace browser {
+
+// Returns a base64 encoded SHA256 hash representing the device authentication
+// signature, the device certification scope, and the current time as query
+// parameters in a string. The signature is the result of signing a message,
+// containing the certification scope and the current time, with a secret key
+// provided by the device.
+std::string GetDeviceAuthenticationSignedURLQueryString();
+
+// The following methods are deterministic helper functions used in the
+// implementation of the public method above.  They are declared here so that
+// they can be tested in (white box) unit tests.
+
+// Similar to the method above, but all platform queries are resolved to make
+// this a deterministic and testable function.
+std::string GetDeviceAuthenticationSignedURLQueryStringFromComponents(
+    const std::string& cert_scope,
+    const std::string& start_time,
+    const std::string& base64_signature);
+
+// Given the certification parameters, computes a message to be used as input
+// to the signing process.
+std::string ComputeMessage(const std::string& cert_scope,
+                           const std::string& start_time);
+
+// Given a message (arbitrary sequence of bytes) and a base64-encoded key
+// key, compute the HMAC-SHA256 signature and store it in the |signature_hash|
+// out parameter.  Note that 32 bytes will be written to the output hash, it is
+// an error if |signature_hash_size_in_bytes| is less than 32.
+void ComputeHMACSHA256SignatureWithProvidedKey(
+    const std::string& message,
+    const std::string& base64_key,
+    uint8_t* signature_hash,
+    size_t signature_hash_size_in_bytes);
+
+}  // namespace browser
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_DEVICE_AUTHENTICATION_H_

--- a/cobalt/browser/device_authentication_test.cc
+++ b/cobalt/browser/device_authentication_test.cc
@@ -1,0 +1,148 @@
+// Copyright 2019 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/device_authentication.h"
+
+#include "base/base64.h"
+#include "base/base64url.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace browser {
+
+constexpr size_t kSHA256DigestSize = 32;
+
+namespace {
+
+std::string ToBase64Message(const std::string& cert_scope,
+                            const std::string& start_time) {
+  std::string base64_message;
+  base::Base64Encode(browser::ComputeMessage(cert_scope, start_time),
+                     &base64_message);
+  return base64_message;
+}
+
+std::string ComputeBase64URLSignatureFromBase64Message(
+    const std::string& base64_message,
+    const std::string& base64_secret_key) {
+  uint8_t signature[kSHA256DigestSize];
+
+  std::string message;
+  CHECK(base::Base64Decode(base64_message, &message));
+  ComputeHMACSHA256SignatureWithProvidedKey(message, base64_secret_key,
+                                            signature, kSHA256DigestSize);
+
+  std::string base_64_url_signature;
+  base::Base64UrlEncode(std::string(signature, signature + kSHA256DigestSize),
+                        base::Base64UrlEncodePolicy::OMIT_PADDING,
+                        &base_64_url_signature);
+  return base_64_url_signature;
+}
+
+std::string CreateSignedURLQueryString(const std::string& cert_scope,
+                                       const std::string& start_time,
+                                       const std::string& base64_secret_key) {
+  return GetDeviceAuthenticationSignedURLQueryStringFromComponents(
+      cert_scope, start_time,
+      ComputeBase64URLSignatureFromBase64Message(
+          ToBase64Message(cert_scope, start_time), base64_secret_key));
+}
+
+}  // namespace
+
+TEST(DeviceAuthenticationTest, ComputeMessageTest) {
+  EXPECT_EQ(
+      "AAAACmNlcnRfc2NvcGUAAAANbXktY2VydC1zY29wZQAAAApzdGFydF90aW1lAAAACjE1NjUx"
+      "NjE1NTY=",
+      ToBase64Message("my-cert-scope", "1565161556"));
+  EXPECT_EQ(
+      "AAAACmNlcnRfc2NvcGUAAAATbXktb3RoZXItY2VydC1zY29wZQAAAApzdGFydF90aW1lAAAA"
+      "CjE1NjUxNjMwNjU=",
+      ToBase64Message("my-other-cert-scope", "1565163065"));
+  EXPECT_EQ(
+      "AAAACmNlcnRfc2NvcGUAAAATbXktb3RoZXItY2VydC1zY29wZQAAAApzdGFydF90aW1lAAAA"
+      "CjE1NjUxNjMyNDU=",
+      ToBase64Message("my-other-cert-scope", "1565163245"));
+  EXPECT_EQ(
+      "AAAACmNlcnRfc2NvcGUAAAATbXktb3RoZXItY2VydC1zY29wZQAAAApzdGFydF90aW1lAAAA"
+      "CjI3OTAzMjY2Mzk=",
+      ToBase64Message("my-other-cert-scope", "2790326639"));
+  EXPECT_EQ(
+      "AAAACmNlcnRfc2NvcGUAAAAEeWFjcwAAAApzdGFydF90aW1lAAAACjEzNDAwMDAzMTI=",
+      ToBase64Message("yacs", "1340000312"));
+}
+
+TEST(DeviceAuthenticationTest, ComputeSignatureWithProvidedSecretTest) {
+  EXPECT_EQ("5duoLo5TELzyMQ6Fz-nmtLH3-nR4GrYfJ5RqTWU33LY",
+            ComputeBase64URLSignatureFromBase64Message(
+                "AAAACmNlcnRfc2NvcGUAAAANbXktY2VydC1zY29wZQAAAApzdGFydF90aW1lAA"
+                "AACjE1NjUxNjE1NTY=",
+                "abcdefghijklmnop1234567890abcdefghijklmnopqr"));
+  EXPECT_EQ("zrHJxDjsg60vF-fnGD9J7QaK2fw2QEZD7PIIfHMYmUg",
+            ComputeBase64URLSignatureFromBase64Message(
+                "AAAACmNlcnRfc2NvcGUAAAATbXktb3RoZXItY2VydC1zY29wZQAAAApzdGFydF"
+                "90aW1lAAAACjE1NjUxNjMwNjU=",
+                "abcdefghijklmnop1234567890abcdefghijklmnopqr"));
+  EXPECT_EQ("FnycnpFnmzgcNBIdJoymQvrS0_1uet_bmCtpuAmQR2s",
+            ComputeBase64URLSignatureFromBase64Message(
+                "AAAACmNlcnRfc2NvcGUAAAATbXktb3RoZXItY2VydC1zY29wZQAAAApzdGFydF"
+                "90aW1lAAAACjE1NjUxNjMyNDU=",
+                "abcdefghi5555nop1234567890abcdef5555klmn6666"));
+  EXPECT_EQ("N-nDY11_8HWFKEZPiQenQrC3SXuuPahs-er-n7Xh6ig",
+            ComputeBase64URLSignatureFromBase64Message(
+                "AAAACmNlcnRfc2NvcGUAAAATbXktb3RoZXItY2VydC1zY29wZQAAAApzdGFydF"
+                "90aW1lAAAACjI3OTAzMjY2Mzk=",
+                "abcdefghi5555nop1234567890abcdef5555klmn6666"));
+  EXPECT_EQ("dX0apAEsG2yWm9da6qTded4qd-mqgExeuJam99z-AHk",
+            ComputeBase64URLSignatureFromBase64Message(
+                "AAAACmNlcnRfc2NvcGUAAAAEeWFjcwAAAApzdGFydF90aW1lAAAACjEzNDAwMD"
+                "AzMTI=",
+                "11111111111111111111111111111111111111111111"));
+}
+
+// This is the main end-to-end test for device authentication.
+TEST(DeviceAuthenticationTest,
+     GetDeviceAuthenticationSignedURLQueryStringFromComponentsTest) {
+  EXPECT_EQ(
+      "cert_scope=my-cert-scope&sig=5duoLo5TELzyMQ6Fz-nmtLH3-"
+      "nR4GrYfJ5RqTWU33LY&start_time=1565161556",
+      CreateSignedURLQueryString(
+          "my-cert-scope", "1565161556",
+          "abcdefghijklmnop1234567890abcdefghijklmnopqr"));
+  EXPECT_EQ(
+      "cert_scope=my-other-cert-scope&sig="
+      "Lf2zunrdhjH8q3ehdUy0tneTtamWigcyTgQl7zxWgnQ&start_time=123456789",
+      CreateSignedURLQueryString(
+          "my-other-cert-scope", "123456789",
+          "abcdefghijklmnop1234567890abcdefghijklmnopqr"));
+  EXPECT_EQ(
+      "cert_scope=my-other-cert-scope&sig="
+      "c5YZB0Rtv8Nf8gLSbE052ZvCUEpouP28nUq77FEgg88&start_time=11111111",
+      CreateSignedURLQueryString(
+          "my-other-cert-scope", "11111111",
+          "11111111111111111111111111111111111111111111"));
+  EXPECT_EQ(
+      "cert_scope=yacs&sig=YKjLEzSl2_ub-05Ajaww0HOOPElxEPUc4SEiQnGAfaE&start_"
+      "time=11111111",
+      CreateSignedURLQueryString(
+          "yacs", "11111111", "11111111111111111111111111111111111111111111"));
+}
+
+TEST(DeviceAuthenticationTest, NoCertSignatureImpliesNoQueryParameters) {
+  EXPECT_EQ("", GetDeviceAuthenticationSignedURLQueryStringFromComponents(
+                    "my_cert_scope", "1234", ""));
+}
+
+}  // namespace browser
+}  // namespace cobalt


### PR DESCRIPTION
Restore device authentication from C25. This will be implemented as the same as C25 for C26 on 3P devices.

Issue: 442607580