### PR TITLE
evergreen: Implement lightweight device authentication

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -197,7 +197,10 @@ test("cobalt_unittests") {
   ]
 
   if (is_starboard) {
-    sources += [ "//cobalt/app/cobalt_switch_defaults_starboard_test.cc" ]
+    sources += [
+      "//cobalt/app/cobalt_switch_defaults_starboard_test.cc",
+      "//cobalt/shell/common/device_authentication_test.cc",
+    ]
   }
 
   public_deps = [ "//third_party/zlib/google:compression_utils" ]

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -90,12 +90,17 @@ source_set("browser") {
 }
 
 source_set("switches") {
+  testonly = true
+
   sources = [
     "switches.cc",
     "switches.h",
   ]
 
-  deps = [ "//base" ]
+  deps = [
+    "//base",
+    "//cobalt/shell:cobalt_shell_lib",
+  ]
 }
 
 config("embed_polyfilled_javascript_config") {

--- a/cobalt/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/browser/migrate_storage_record/migration_manager.cc
@@ -64,7 +64,8 @@ std::unique_ptr<cobalt::storage::Storage> ReadStorage() {
       std::make_unique<starboard::StorageRecord>(partition_key.c_str());
   if (!record->IsValid()) {
     record->Delete();
-    bool fallback = partition_key == GetApplicationKey(GURL(kDefaultURL));
+    bool fallback =
+        partition_key == GetApplicationKey(GURL(::switches::kDefaultURL));
     if (!fallback) {
       return nullptr;
     }

--- a/cobalt/browser/switches.cc
+++ b/cobalt/browser/switches.cc
@@ -21,7 +21,7 @@ std::string GetInitialURL(const base::CommandLine& command_line) {
   if (command_line.HasSwitch(kInitialURL)) {
     return command_line.GetSwitchValueASCII(kInitialURL);
   }
-  return kDefaultURL;
+  return ::switches::kDefaultURL;
 }
 
 }  // namespace switches

--- a/cobalt/browser/switches.h
+++ b/cobalt/browser/switches.h
@@ -15,14 +15,12 @@
 #include <string>
 
 #include "base/command_line.h"
+#include "cobalt/shell/common/shell_switches.h"
 
 #ifndef COBALT_BROWSER_SWITCHES_H_
 #define COBALT_BROWSER_SWITCHES_H_
 
 namespace cobalt {
-
-constexpr char kDefaultURL[] = "https://www.youtube.com/tv";
-
 namespace switches {
 
 // Allow the user to override the default URL via a command line parameter.

--- a/cobalt/renderer/BUILD.gn
+++ b/cobalt/renderer/BUILD.gn
@@ -15,6 +15,8 @@ import("//starboard/build/buildflags.gni")
 import("//testing/test.gni")
 
 source_set("renderer") {
+  testonly = true
+
   sources = [
     "cobalt_content_renderer_client.cc",
     "cobalt_content_renderer_client.h",

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -323,6 +323,13 @@ static_library("cobalt_shell_lib") {
       "browser/shell_platform_data_aura.h",
     ]
   }
+
+  if (is_starboard) {
+    sources += [
+      "common/device_authentication.cc",
+      "common/device_authentication.h",
+    ]
+  }
 }
 
 # This component provides a ContentMainDelegate for Content Shell and derived

--- a/cobalt/shell/common/device_authentication.h
+++ b/cobalt/shell/common/device_authentication.h
@@ -12,16 +12,21 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef COBALT_BROWSER_DEVICE_AUTHENTICATION_H_
-#define COBALT_BROWSER_DEVICE_AUTHENTICATION_H_
+#ifndef COBALT_SHELL_COMMON_DEVICE_AUTHENTICATION_H_
+#define COBALT_SHELL_COMMON_DEVICE_AUTHENTICATION_H_
 
 #include <string>
 
 #include "starboard/configuration.h"
 #include "starboard/types.h"
+#include "url/gurl.h"
 
-namespace cobalt {
-namespace browser {
+namespace content {
+
+// Takes a GURL and returns a new GURL with device authentication parameters
+// appended as query strings. These parameters typically include a signature,
+// certification scope, and timestamp to authenticate the device request.
+GURL GetDeviceAuthenticationSignedURL(const GURL& url);
 
 // Returns a base64 encoded SHA256 hash representing the device authentication
 // signature, the device certification scope, and the current time as query
@@ -56,7 +61,6 @@ void ComputeHMACSHA256SignatureWithProvidedKey(
     uint8_t* signature_hash,
     size_t signature_hash_size_in_bytes);
 
-}  // namespace browser
-}  // namespace cobalt
+}  // namespace content
 
-#endif  // COBALT_BROWSER_DEVICE_AUTHENTICATION_H_
+#endif  // COBALT_SHELL_COMMON_DEVICE_AUTHENTICATION_H_

--- a/cobalt/shell/common/device_authentication_test.cc
+++ b/cobalt/shell/common/device_authentication_test.cc
@@ -12,14 +12,13 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "cobalt/browser/device_authentication.h"
+#include "cobalt/shell/common/device_authentication.h"
 
 #include "base/base64.h"
 #include "base/base64url.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-namespace cobalt {
-namespace browser {
+namespace content {
 
 constexpr size_t kSHA256DigestSize = 32;
 
@@ -28,8 +27,7 @@ namespace {
 std::string ToBase64Message(const std::string& cert_scope,
                             const std::string& start_time) {
   std::string base64_message;
-  base::Base64Encode(browser::ComputeMessage(cert_scope, start_time),
-                     &base64_message);
+  base::Base64Encode(ComputeMessage(cert_scope, start_time), &base64_message);
   return base64_message;
 }
 
@@ -144,5 +142,4 @@ TEST(DeviceAuthenticationTest, NoCertSignatureImpliesNoQueryParameters) {
                     "my_cert_scope", "1234", ""));
 }
 
-}  // namespace browser
-}  // namespace cobalt
+}  // namespace content

--- a/cobalt/shell/common/shell_switches.cc
+++ b/cobalt/shell/common/shell_switches.cc
@@ -47,6 +47,11 @@ const char kContentShellDevToolsTabTarget[] =
 // comma-separated list of origins.
 const char kIsolatedContextOrigins[] = "isolated-context-origins";
 
+// When set, no device authentication parameters will be appended to the initial
+// URL."
+const char kOmitDeviceAuthenticationQueryParameters[] =
+    "omit-device-authentication-query-parameters";
+
 // Use the given address instead of the default loopback for accepting remote
 // debugging connections. Note that the remote debugging protocol does not
 // perform any authentication, so exposing it too widely can be a security

--- a/cobalt/shell/common/shell_switches.h
+++ b/cobalt/shell/common/shell_switches.h
@@ -21,6 +21,8 @@
 
 namespace switches {
 
+constexpr char kDefaultURL[] = "https://www.youtube.com/tv";
+
 extern const char kContentShellDataPath[];
 extern const char kCrashDumpsDir[];
 extern const char kDisableSystemFontCheck[];
@@ -30,6 +32,7 @@ extern const char kContentShellHideToolbar[];
 extern const char kContentShellDevToolsTabTarget[];
 #endif
 extern const char kIsolatedContextOrigins[];
+extern const char kOmitDeviceAuthenticationQueryParameters[];
 extern const char kRemoteDebuggingAddress[];
 
 }  // namespace switches


### PR DESCRIPTION
This PR brings the lightweight device authentication from C25 to C26 for 3P platforms.

The signed cert scope is appended to the startup url if available on 3P platforms, which allows WebFE to recognize certified devices. Note this doesn't include AOSP platforms.

Test the unit test with `./out/linux-x64x11_devel/cobalt_unittests --enable-logging=stderr --v=1 --single-process-tests`:
```
[----------] 4 tests from DeviceAuthenticationTest
[ RUN      ] DeviceAuthenticationTest.ComputeMessageTest
[       OK ] DeviceAuthenticationTest.ComputeMessageTest (0 ms)
[ RUN      ] DeviceAuthenticationTest.ComputeSignatureWithProvidedSecretTest
[       OK ] DeviceAuthenticationTest.ComputeSignatureWithProvidedSecretTest (0 ms)
[ RUN      ] DeviceAuthenticationTest.GetDeviceAuthenticationSignedURLQueryStringFromComponentsTest
[       OK ] DeviceAuthenticationTest.GetDeviceAuthenticationSignedURLQueryStringFromComponentsTest (0 ms)
[ RUN      ] DeviceAuthenticationTest.NoCertSignatureImpliesNoQueryParameters
[       OK ] DeviceAuthenticationTest.NoCertSignatureImpliesNoQueryParameters (0 ms)
[----------] 4 tests from DeviceAuthenticationTest (0 ms total)
```

Issue: 442607580