### PR TITLE
starboard: Flatten `starboard::shared::posix` namespace

### DIFF
--- a/starboard/linux/shared/system_get_extensions.cc
+++ b/starboard/linux/shared/system_get_extensions.cc
@@ -61,10 +61,10 @@ const void* SbSystemGetExtension(const char* name) {
     return starboard::GetCrashHandlerApi();
   }
   if (strcmp(name, kCobaltExtensionMemoryMappedFileName) == 0) {
-    return starboard::shared::posix::GetMemoryMappedFileApi();
+    return starboard::GetMemoryMappedFileApi();
   }
   if (strcmp(name, kCobaltExtensionFreeSpaceName) == 0) {
-    return starboard::shared::posix::GetFreeSpaceApi();
+    return starboard::GetFreeSpaceApi();
   }
 #if SB_IS(EVERGREEN_COMPATIBLE)
   if (strcmp(name, kStarboardExtensionLoaderAppMetricsName) == 0) {

--- a/starboard/nplb/multiple_player_test.cc
+++ b/starboard/nplb/multiple_player_test.cc
@@ -37,7 +37,7 @@ typedef std::function<void(const SbPlayerTestConfig&,
                            FakeGraphicsContextProvider*)>
     MultiplePlayerTestFunctor;
 
-class PlayerThread : public posix::AbstractTestThread {
+class PlayerThread : public AbstractTestThread {
  public:
   explicit PlayerThread(const std::function<void()>& functor)
       : functor_(functor) {}

--- a/starboard/nplb/player_write_sample_test.cc
+++ b/starboard/nplb/player_write_sample_test.cc
@@ -329,7 +329,7 @@ TEST_P(SbPlayerWriteSampleTest, DiscardAllAudio) {
                 << ".";
 }
 
-class SecondaryPlayerTestThread : public posix::AbstractTestThread {
+class SecondaryPlayerTestThread : public AbstractTestThread {
  public:
   SecondaryPlayerTestThread(
       const SbPlayerTestConfig& config,

--- a/starboard/nplb/posix_compliance/posix_condition_variable_wait_test.cc
+++ b/starboard/nplb/posix_compliance/posix_condition_variable_wait_test.cc
@@ -24,12 +24,11 @@ namespace nplb {
 namespace {
 
 TEST(PosixConditionVariableWaitTest, SunnyDayAutoInit) {
-  posix::TakeThenSignalContext context = {posix::TestSemaphore(0),
-                                          PTHREAD_MUTEX_INITIALIZER,
-                                          PTHREAD_COND_INITIALIZER};
+  TakeThenSignalContext context = {TestSemaphore(0), PTHREAD_MUTEX_INITIALIZER,
+                                   PTHREAD_COND_INITIALIZER};
   // Start the thread.
   pthread_t thread = 0;
-  pthread_create(&thread, NULL, posix::TakeThenSignalEntryPoint, &context);
+  pthread_create(&thread, nullptr, TakeThenSignalEntryPoint, &context);
 
   EXPECT_EQ(pthread_mutex_lock(&context.mutex), 0);
 
@@ -52,11 +51,11 @@ TEST(PosixConditionVariableWaitTest, SunnyDayAutoInit) {
 
 TEST(PosixConditionVariableWaitTest, SunnyDay) {
   const int kMany = kSbMaxThreads > 64 ? 64 : kSbMaxThreads;
-  posix::WaiterContext context;
+  WaiterContext context;
 
   std::vector<pthread_t> threads(kMany);
   for (int i = 0; i < kMany; ++i) {
-    pthread_create(&threads[i], NULL, posix::WaiterEntryPoint, &context);
+    pthread_create(&threads[i], nullptr, WaiterEntryPoint, &context);
   }
 
   for (int i = 0; i < kMany; ++i) {

--- a/starboard/nplb/posix_compliance/posix_condition_variable_wait_timed_test.cc
+++ b/starboard/nplb/posix_compliance/posix_condition_variable_wait_timed_test.cc
@@ -70,11 +70,11 @@ struct timespec CalculateDelayTimestamp(int64_t delay_us, bool use_monotonic) {
 // makes the tests flaky since none of these actions can be guaranteed to always
 // run within the specified time.
 
-void DoSunnyDay(posix::TakeThenSignalContext* context,
+void DoSunnyDay(TakeThenSignalContext* context,
                 bool check_timeout,
                 bool use_monotonic) {
   pthread_t thread = 0;
-  pthread_create(&thread, NULL, posix::TakeThenSignalEntryPoint, context);
+  pthread_create(&thread, nullptr, TakeThenSignalEntryPoint, context);
 
   const int64_t kDelayUs = 10'000;  // 10ms
   // Allow two-millisecond-level precision.
@@ -132,7 +132,7 @@ void DoSunnyDay(posix::TakeThenSignalContext* context,
 
 // Test marked as flaky because it calls DoSunnyDay().
 TEST(PosixConditionVariableWaitTimedTest, FLAKY_SunnyDay) {
-  posix::TakeThenSignalContext context;
+  TakeThenSignalContext context;
   context.delay_after_signal = 0;
 
   EXPECT_EQ(pthread_mutex_init(&context.mutex, NULL), 0);
@@ -149,9 +149,9 @@ TEST(PosixConditionVariableWaitTimedTest, FLAKY_SunnyDay) {
 // Test marked as flaky because it calls DoSunnyDay().
 TEST(PosixConditionVariableWaitTimedTest, FLAKY_SunnyDayAutoInit) {
   {
-    posix::TakeThenSignalContext context = {posix::TestSemaphore(0),
-                                            PTHREAD_MUTEX_INITIALIZER,
-                                            PTHREAD_COND_INITIALIZER, 0};
+    TakeThenSignalContext context = {TestSemaphore(0),
+                                     PTHREAD_MUTEX_INITIALIZER,
+                                     PTHREAD_COND_INITIALIZER, 0};
 
     DoSunnyDay(&context, true, false);
   }
@@ -161,9 +161,9 @@ TEST(PosixConditionVariableWaitTimedTest, FLAKY_SunnyDayAutoInit) {
   // this mode, hoping to have the auto-initting contend in various ways.
   const int kTrials = 64;
   for (int i = 0; i < kTrials; ++i) {
-    posix::TakeThenSignalContext context = {posix::TestSemaphore(0),
-                                            PTHREAD_MUTEX_INITIALIZER,
-                                            PTHREAD_COND_INITIALIZER, 0};
+    TakeThenSignalContext context = {TestSemaphore(0),
+                                     PTHREAD_MUTEX_INITIALIZER,
+                                     PTHREAD_COND_INITIALIZER, 0};
     DoSunnyDay(&context, false, false);
   }
 }
@@ -172,14 +172,13 @@ TEST(PosixConditionVariableWaitTimedTest, FLAKY_SunnyDayAutoInit) {
 // to DoSunnyDay().
 TEST(PosixConditionVariableWaitTimedTest, FLAKY_SunnyDayNearMaxTime) {
   const int64_t kOtherDelaySec = 3'000'000;  // 3s
-  posix::TakeThenSignalContext context = {
-      posix::TestSemaphore(0), PTHREAD_MUTEX_INITIALIZER,
-      PTHREAD_COND_INITIALIZER, kOtherDelaySec};
+  TakeThenSignalContext context = {TestSemaphore(0), PTHREAD_MUTEX_INITIALIZER,
+                                   PTHREAD_COND_INITIALIZER, kOtherDelaySec};
   EXPECT_EQ(pthread_mutex_init(&context.mutex, NULL), 0);
 
   InitCondition(&context.condition, false /* use_monotonic */);
   pthread_t thread = 0;
-  pthread_create(&thread, NULL, posix::TakeThenSignalEntryPoint, &context);
+  pthread_create(&thread, NULL, TakeThenSignalEntryPoint, &context);
 
   EXPECT_EQ(pthread_mutex_lock(&context.mutex), 0);
 

--- a/starboard/nplb/posix_compliance/posix_mutex_acquire_try_test.cc
+++ b/starboard/nplb/posix_compliance/posix_mutex_acquire_try_test.cc
@@ -32,7 +32,7 @@ struct TestContext {
 };
 
 void* EntryPoint(void* parameter) {
-  pthread_setname_np(pthread_self(), posix::kThreadName);
+  pthread_setname_np(pthread_self(), kThreadName);
   TestContext* context = static_cast<TestContext*>(parameter);
   context->was_locked_ = (pthread_mutex_trylock(context->mutex_) == 0);
   return NULL;

--- a/starboard/nplb/posix_compliance/posix_once_test.cc
+++ b/starboard/nplb/posix_compliance/posix_once_test.cc
@@ -65,7 +65,7 @@ struct RunPosixOnceContext {
     pthread_mutex_destroy(&mutex);
   }
 
-  posix::TestSemaphore semaphore;
+  TestSemaphore semaphore;
   pthread_mutex_t mutex;
   pthread_cond_t condition;
 
@@ -73,7 +73,7 @@ struct RunPosixOnceContext {
 };
 
 void* RunPosixOnceEntryPoint(void* context) {
-  pthread_setname_np(pthread_self(), posix::kThreadName);
+  pthread_setname_np(pthread_self(), kThreadName);
 
   RunPosixOnceContext* run_sbonce_context =
       reinterpret_cast<RunPosixOnceContext*>(context);

--- a/starboard/nplb/posix_compliance/posix_thread_create_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_create_test.cc
@@ -26,35 +26,33 @@ TEST(PosixThreadCreateTest, SunnyDay) {
   const int kTrials = 64;
   for (int i = 0; i < kTrials; ++i) {
     pthread_t thread;
-    EXPECT_EQ(pthread_create(&thread, NULL, posix::AddOneEntryPoint,
-                             posix::kSomeContext),
+    EXPECT_EQ(pthread_create(&thread, nullptr, AddOneEntryPoint, kSomeContext),
               0);
-    void* result = NULL;
+    void* result = nullptr;
     EXPECT_EQ(pthread_join(thread, &result), 0);
-    EXPECT_EQ(posix::kSomeContextPlusOne, result);
+    EXPECT_EQ(kSomeContextPlusOne, result);
   }
 }
 
 TEST(PosixThreadCreateTest, SunnyDayNoContext) {
   pthread_t thread;
-  EXPECT_EQ(pthread_create(&thread, NULL, posix::AddOneEntryPoint, NULL), 0);
-  void* result = NULL;
+  EXPECT_EQ(pthread_create(&thread, nullptr, AddOneEntryPoint, nullptr), 0);
+  void* result = nullptr;
   EXPECT_EQ(pthread_join(thread, &result), 0);
-  EXPECT_EQ(posix::ToVoid(1), result);
+  EXPECT_EQ(ToVoid(1), result);
 }
 
 TEST(PosixThreadCreateTest, Summertime) {
   const int kMany = kSbMaxThreads;
   std::vector<pthread_t> threads(kMany);
   for (int i = 0; i < kMany; ++i) {
-    EXPECT_EQ(pthread_create(&(threads[i]), NULL, posix::AddOneEntryPoint,
-                             posix::ToVoid(i)),
-              0);
+    EXPECT_EQ(
+        pthread_create(&(threads[i]), nullptr, AddOneEntryPoint, ToVoid(i)), 0);
   }
 
   for (int i = 0; i < kMany; ++i) {
-    void* result = NULL;
-    void* const kExpected = posix::ToVoid(i + 1);
+    void* result = nullptr;
+    void* const kExpected = ToVoid(i + 1);
 
     EXPECT_EQ(pthread_join(threads[i], &result), 0);
     EXPECT_EQ(kExpected, result);

--- a/starboard/nplb/posix_compliance/posix_thread_detach_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_detach_test.cc
@@ -23,7 +23,7 @@ namespace {
 
 TEST(PosixThreadDetachTest, SunnyDay) {
   pthread_t thread;
-  EXPECT_EQ(pthread_create(&thread, NULL, posix::AddOneEntryPoint, NULL), 0);
+  EXPECT_EQ(pthread_create(&thread, nullptr, AddOneEntryPoint, nullptr), 0);
 
   EXPECT_EQ(pthread_detach(thread), 0);
   void* result = NULL;

--- a/starboard/nplb/posix_compliance/posix_thread_get_current_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_get_current_test.cc
@@ -38,7 +38,7 @@ TEST(PosixThreadGetCurrentTest, SunnyDay) {
     void* result = NULL;
     EXPECT_EQ(pthread_join(threads[i], &result), 0);
     // NOLINTNEXTLINE(readability/casting)
-    EXPECT_EQ(posix::ToVoid((intptr_t)threads[i]), result);
+    EXPECT_EQ(ToVoid((intptr_t)threads[i]), result);
   }
 }
 

--- a/starboard/nplb/posix_compliance/posix_thread_get_name_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_get_name_test.cc
@@ -23,7 +23,7 @@ namespace nplb {
 namespace {
 
 void* GetThreadNameEntryPoint(void* context) {
-  pthread_setname_np(pthread_self(), posix::kThreadName);
+  pthread_setname_np(pthread_self(), kThreadName);
 
   char name[4096] = {0};
 #if __ANDROID_API__ < 26
@@ -44,7 +44,7 @@ TEST(PosixThreadGetNameTest, SunnyDay) {
 
   EXPECT_TRUE(thread != 0);
   EXPECT_EQ(pthread_join(thread, NULL), 0);
-  EXPECT_EQ(posix::kThreadName, result);
+  EXPECT_EQ(kThreadName, result);
 }
 
 }  // namespace

--- a/starboard/nplb/posix_compliance/posix_thread_helpers.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.cc
@@ -22,7 +22,6 @@
 
 namespace starboard {
 namespace nplb {
-namespace posix {
 
 void DoNotYield() {
   // Nope.
@@ -87,6 +86,5 @@ void WaiterContext::WaitForReturnSignal() {
   EXPECT_EQ(pthread_mutex_unlock(&mutex), 0);
 }
 
-}  // namespace posix
 }  // namespace nplb
 }  // namespace starboard

--- a/starboard/nplb/posix_compliance/posix_thread_helpers.h
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.h
@@ -25,7 +25,6 @@
 
 namespace starboard {
 namespace nplb {
-namespace posix {
 
 class TestSemaphore {
  public:
@@ -199,7 +198,6 @@ class AbstractTestThread {
   void operator=(const AbstractTestThread&) = delete;
 };
 
-}  // namespace posix
 }  // namespace nplb
 }  // namespace starboard
 

--- a/starboard/nplb/posix_compliance/posix_thread_is_equal_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_is_equal_test.cc
@@ -25,7 +25,7 @@ TEST(PosixThreadIsEqualTest, Everything) {
   EXPECT_TRUE(pthread_equal(pthread_self(), pthread_self()));
 
   pthread_t thread;
-  EXPECT_EQ(pthread_create(&thread, NULL, posix::AddOneEntryPoint, NULL), 0);
+  EXPECT_EQ(pthread_create(&thread, nullptr, AddOneEntryPoint, nullptr), 0);
 
   EXPECT_TRUE(pthread_equal(thread, thread));
   EXPECT_FALSE(pthread_equal(pthread_self(), thread));

--- a/starboard/nplb/posix_compliance/posix_thread_set_name_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_set_name_test.cc
@@ -54,14 +54,14 @@ void* SetThreadNameEntryPoint(void* context) {
 
 TEST(PosixThreadSetNameTest, SunnyDay) {
   Context context;
-  context.name_to_set = posix::kAltThreadName;
+  context.name_to_set = kAltThreadName;
   pthread_t thread;
-  EXPECT_EQ(pthread_create(&thread, NULL, SetThreadNameEntryPoint, &context),
+  EXPECT_EQ(pthread_create(&thread, nullptr, SetThreadNameEntryPoint, &context),
             0);
   EXPECT_TRUE(thread != 0);
   EXPECT_EQ(pthread_join(thread, NULL), 0);
-  EXPECT_NE(posix::kAltThreadName, context.got_name1);
-  EXPECT_EQ(posix::kAltThreadName, context.got_name2);
+  EXPECT_NE(kAltThreadName, context.got_name1);
+  EXPECT_EQ(kAltThreadName, context.got_name2);
 }
 
 }  // namespace

--- a/starboard/nplb/posix_compliance/posix_thread_yield_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_yield_test.cc
@@ -44,7 +44,7 @@ void* YieldingEntryPoint(void* context) {
 
 void* UnyieldingEntryPoint(void* context) {
   for (int i = 0; i < kLoops; ++i) {
-    posix::DoNotYield();
+    DoNotYield();
   }
 
   int64_t* end_time = static_cast<int64_t*>(context);

--- a/starboard/nplb/semaphore_test.cc
+++ b/starboard/nplb/semaphore_test.cc
@@ -49,7 +49,7 @@ TEST(Semaphore, InitialValue_One) {
   EXPECT_FALSE(semaphore.TakeTry());
 }
 
-class ThreadTakesSemaphore : public posix::AbstractTestThread {
+class ThreadTakesSemaphore : public AbstractTestThread {
  public:
   explicit ThreadTakesSemaphore(Semaphore* s) : semaphore_(s) {}
   void Run() override { semaphore_->Take(); }
@@ -65,7 +65,7 @@ TEST(Semaphore, ThreadTakes) {
   thread.Join();
 }
 
-class ThreadTakesWaitSemaphore : public posix::AbstractTestThread {
+class ThreadTakesWaitSemaphore : public AbstractTestThread {
  public:
   explicit ThreadTakesWaitSemaphore(int64_t wait_us)
       : thread_started_(false),
@@ -152,7 +152,7 @@ TEST(Semaphore, ThreadTakesWait_TimeExpires) {
   EXPECT_TRUE(false) << "Thread waited, but time exceeded expectations.";
 }
 
-class ThreadPutsSemaphore : public posix::AbstractTestThread {
+class ThreadPutsSemaphore : public AbstractTestThread {
  public:
   explicit ThreadPutsSemaphore(Semaphore* s) : semaphore_(s) {}
   void Run() override { semaphore_->Put(); }

--- a/starboard/nplb/thread_get_id_test.cc
+++ b/starboard/nplb/thread_get_id_test.cc
@@ -24,7 +24,7 @@ namespace {
 
 // Returns the thread's ID.
 void* GetThreadIdEntryPoint(void* context) {
-  return posix::ToVoid(SbThreadGetId());
+  return ToVoid(SbThreadGetId());
 }
 
 TEST(SbThreadGetIdTest, SunnyDay) {
@@ -45,7 +45,7 @@ TEST(SbThreadGetIdTest, SunnyDayDifferentIds) {
   for (int i = 0; i < kThreads; ++i) {
     void* result = NULL;
     EXPECT_EQ(pthread_join(threads[i], &result), 0);
-    SbThreadId id = static_cast<SbThreadId>(posix::FromVoid(result));
+    SbThreadId id = static_cast<SbThreadId>(FromVoid(result));
     EXPECT_NE(id, SbThreadGetId());
     thread_ids[i] = id;
   }

--- a/starboard/nplb/thread_sampler_test.cc
+++ b/starboard/nplb/thread_sampler_test.cc
@@ -27,7 +27,7 @@ namespace starboard {
 namespace nplb {
 namespace {
 
-class CountingThread : public posix::AbstractTestThread {
+class CountingThread : public AbstractTestThread {
  public:
   ~CountingThread() { Stop(); }
 

--- a/starboard/shared/posix/free_space.cc
+++ b/starboard/shared/posix/free_space.cc
@@ -21,7 +21,7 @@
 #include "starboard/configuration_constants.h"
 #include "starboard/extension/free_space.h"
 
-namespace starboard::shared::posix {
+namespace starboard {
 
 namespace {
 
@@ -50,4 +50,4 @@ const void* GetFreeSpaceApi() {
   return &kFreeSpaceApi;
 }
 
-}  // namespace starboard::shared::posix
+}  // namespace starboard

--- a/starboard/shared/posix/free_space.h
+++ b/starboard/shared/posix/free_space.h
@@ -15,10 +15,10 @@
 #ifndef STARBOARD_SHARED_POSIX_FREE_SPACE_H_
 #define STARBOARD_SHARED_POSIX_FREE_SPACE_H_
 
-namespace starboard::shared::posix {
+namespace starboard {
 
 const void* GetFreeSpaceApi();
 
-}  // namespace starboard::shared::posix
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_POSIX_FREE_SPACE_H_

--- a/starboard/shared/posix/memory_mapped_file.cc
+++ b/starboard/shared/posix/memory_mapped_file.cc
@@ -18,7 +18,7 @@
 #include "starboard/extension/memory_mapped_file.h"
 #include "starboard/shared/posix/page_internal.h"
 
-namespace starboard::shared::posix {
+namespace starboard {
 
 namespace {
 
@@ -34,4 +34,4 @@ const void* GetMemoryMappedFileApi() {
   return &kMemoryMappedFileApi;
 }
 
-}  // namespace starboard::shared::posix
+}  // namespace starboard

--- a/starboard/shared/posix/memory_mapped_file.h
+++ b/starboard/shared/posix/memory_mapped_file.h
@@ -15,10 +15,10 @@
 #ifndef STARBOARD_SHARED_POSIX_MEMORY_MAPPED_FILE_H_
 #define STARBOARD_SHARED_POSIX_MEMORY_MAPPED_FILE_H_
 
-namespace starboard::shared::posix {
+namespace starboard {
 
 const void* GetMemoryMappedFileApi();
 
-}  // namespace starboard::shared::posix
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_POSIX_MEMORY_MAPPED_FILE_H_

--- a/starboard/shared/posix/set_non_blocking_internal.cc
+++ b/starboard/shared/posix/set_non_blocking_internal.cc
@@ -16,11 +16,11 @@
 
 #include <fcntl.h>
 
-namespace starboard::shared::posix {
+namespace starboard {
 
 bool SetNonBlocking(int socket_fd) {
   int flags = fcntl(socket_fd, F_GETFL, 0);
   return !(flags < 0 || fcntl(socket_fd, F_SETFL, flags | O_NONBLOCK) == -1);
 }
 
-}  // namespace starboard::shared::posix
+}  // namespace starboard

--- a/starboard/shared/posix/set_non_blocking_internal.h
+++ b/starboard/shared/posix/set_non_blocking_internal.h
@@ -17,11 +17,11 @@
 
 #include "starboard/shared/internal_only.h"
 
-namespace starboard::shared::posix {
+namespace starboard {
 
 // Makes the socket file descriptor non-blocking.
 bool SetNonBlocking(int socket_fd);
 
-}  // namespace starboard::shared::posix
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_POSIX_SET_NON_BLOCKING_INTERNAL_H_


### PR DESCRIPTION
[go/cobalt-flatten-starboard-namespace](http://go/cobalt-flatten-starboard-namespace)

Steps taken
- Run a script to replace exiting namespace
- Fix the build manually with the help of Gemini-CLI

#vibe-coded

Bug: 441955897