### PR TITLE
Remove use_system_libdrm from args.gn

### DIFF
--- a/cobalt/build/configs/linux-x64x11-modular/args.gn
+++ b/cobalt/build/configs/linux-x64x11-modular/args.gn
@@ -10,9 +10,6 @@ enable_pkeys = false
 # We don't implement the necessary APIs for mdns.
 enable_mdns = false
 
-# This brings in libraries we can't have in hermetic builds.
-use_system_libdrm = false
-
 # This brings in libraries we can't have in hermetic builds, and our decoding
 # is done under Starboard, so we can disable decoders at the Chromium level.
 rtc_use_h264 = false


### PR DESCRIPTION
The variable has no effect when set in the args.gn and our build keeps showing an annoying warning.

Issue: 436647204