### PR TITLE
Reland "[POSIX] Add getcwd in //third_party/musl"

### DIFF
--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -56,6 +56,7 @@ Starboard 17 fully switches to POSIX APIs.
 * `fchown`
 * `gai_strerror`
 * `getauxval`
+  `getcwd`
 * `geteuid`
 * `getpid`
 * `pathconf`

--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -122,6 +122,7 @@ _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
     'getaddrinfo',
     'getauxval',
     'geteuid',
+    'getcwd',
     'getifaddrs',
     'getpeername',
     'getpid',

--- a/starboard/tools/api_leak_detector/evergreen/manifest
+++ b/starboard/tools/api_leak_detector/evergreen/manifest
@@ -25,7 +25,6 @@ ftell
 ftello
 fwrite
 getc
-getcwd
 getrlimit
 newlocale
 prctl

--- a/third_party/musl/BUILD.gn
+++ b/third_party/musl/BUILD.gn
@@ -398,6 +398,7 @@ static_library("c_internal") {
 
     "src/stat/futimens.c",
     "src/stat/futimesat.c",
+    "src/starboard/unistd/getcwd.c",
     "src/stdio/__toread.c",
     "src/stdio/__uflow.c",
     "src/stdio/perror.c",

--- a/third_party/musl/src/starboard/unistd/getcwd.c
+++ b/third_party/musl/src/starboard/unistd/getcwd.c
@@ -1,0 +1,20 @@
+#include <unistd.h>
+#include <errno.h>
+
+#include "starboard/system.h"
+
+// This function is to replace its musl implementation
+// in //third_party/musl/src/unistd/getcwd.c.
+char *getcwd(char *buf, size_t size) {
+  if (!size) {
+    errno = EINVAL;
+    return 0;
+  }
+  bool got_path =
+      SbSystemGetPath(kSbSystemPathTempDirectory, buf, size);
+  if (!got_path) {
+    errno = ENOENT;
+    return 0;
+  }
+  return buf;
+}


### PR DESCRIPTION
This is a reland of 914cc415f8744e045c21d1156b133217bab5f19a.

This PR was originally closed due to an earlier decision we have made to not support `getcwd()`. We have changed our decision and have decided to support `getcwd()` to support fontconfig. This reland also edits `starboard/CHANGELOG.md` to reflect the addition of `getcwd()`.

Original change's description:

>This PR adds a function of `getcwd` to avoid modifying the implementation
>in //third_party/musl/src/unistd/getcwd.c.
>
>The function uses `SbSystemGetPath` to get directory from Starboard.
>
>Issue: 412650854

Bug: 412650854