### PR TITLE
evergreen: add Cobalt updater

### DIFF
--- a/cobalt/browser/switches.h
+++ b/cobalt/browser/switches.h
@@ -36,6 +36,14 @@ constexpr char kEnforceHTTPS[] = "https-enforcement";
 // Specify the initial window size: --window-size=w,h
 constexpr char kWindowSize[] = "window-size";
 
+// Whether to request, download, and install uncompressed (rather than
+// compressed) Evergreen binaries.
+constexpr char kUseUncompressedUpdates[] = "use_uncompressed_updates";
+
+// Uses the QA update server to test the changes to the configuration of the
+// PROD update server.
+constexpr char kUseQAUpdateServer[] = "use_qa_update_server";
+
 }  // namespace switches
 }  // namespace cobalt
 

--- a/cobalt/updater/BUILD.gn
+++ b/cobalt/updater/BUILD.gn
@@ -1,0 +1,55 @@
+# Copyright 2025 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+static_library("updater") {
+  sources = [
+    "configurator.cc",
+    "configurator.h",
+    "network_fetcher.cc",
+    "network_fetcher.h",
+    "patcher.cc",
+    "patcher.h",
+    "prefs.cc",
+    "prefs.h",
+    "unzipper.cc",
+    "unzipper.h",
+    "updater_module.cc",
+    "updater_module.h",
+    "util.cc",
+    "util.h",
+  ]
+
+  deps = [
+    "//base",
+    "//cobalt/browser:switches",
+    "//components/crx_file",
+    "//components/prefs",
+    "//components/update_client",
+    "//components/update_client:buildflags",
+    "//courgette:bsdiff",
+    "//courgette:courgette_lib",
+    "//crypto",
+    "//net",
+    "//net/third_party/quiche",
+    "//services/network/public/cpp",
+    "//services/network/public/mojom",
+    "//starboard:starboard_headers_only",
+    "//starboard/common",
+    "//starboard/loader_app:app_key_files",
+    "//starboard/loader_app:drain_file",
+    "//third_party/zlib/google:zip",
+    "//url",
+  ]
+}
+# TODO(b/446745795): add unit tests

--- a/cobalt/updater/DEPS
+++ b/cobalt/updater/DEPS
@@ -1,0 +1,7 @@
+include_rules = [
+  "+components/crx_file",
+  "+components/prefs",
+  "+components/update_client",
+  "+courgette",
+  "+third_party/zlib/google",
+]

--- a/cobalt/updater/configurator.cc
+++ b/cobalt/updater/configurator.cc
@@ -1,0 +1,419 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/updater/configurator.h"
+
+#include <regex>
+#include <set>
+#include <utility>
+#include "base/command_line.h"
+#include "base/version.h"
+#include "cobalt/browser/switches.h"
+#include "cobalt/updater/network_fetcher.h"
+#include "cobalt/updater/patcher.h"
+#include "cobalt/updater/prefs.h"
+#include "cobalt/updater/unzipper.h"
+#include "cobalt/updater/util.h"
+#include "cobalt/version.h"
+#include "components/prefs/pref_service.h"
+#include "components/update_client/crx_downloader_factory.h"
+#include "components/update_client/network.h"
+#include "components/update_client/patcher.h"
+#include "components/update_client/protocol_handler.h"
+#include "components/update_client/unzipper.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "starboard/common/system_property.h"
+#include "starboard/system.h"
+#include "url/gurl.h"
+
+using starboard::kSystemPropertyMaxLength;
+
+namespace {
+
+const char kDefaultUpdaterChannel[] = "prod";
+const char kUpdaterJSONDefaultUrlQA[] =
+    "https://omaha-qa.sandbox.google.com/service/update2/json";
+const char kUpdaterJSONDefaultUrl[] =
+    "https://tools.google.com/service/update2/json";
+
+std::string GetDeviceProperty(SbSystemPropertyId id) {
+  char value[kSystemPropertyMaxLength];
+  if (SbSystemGetProperty(id, value, kSystemPropertyMaxLength)) {
+    return std::string(value);
+  }
+  return std::string();
+}
+
+}  // namespace
+
+namespace cobalt {
+namespace updater {
+
+Configurator::Configurator(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
+    : pref_service_(CreatePrefService()),
+      persisted_data_(
+          std::make_unique<update_client::PersistedData>(pref_service_.get(),
+                                                         nullptr)),
+      network_fetcher_factory_(
+          base::MakeRefCounted<NetworkFetcherFactoryCobalt>(
+              url_loader_factory)),
+      crx_downloader_factory_(
+          update_client::MakeCrxDownloaderFactory(network_fetcher_factory_)),
+      unzip_factory_(base::MakeRefCounted<UnzipperFactory>()),
+      patch_factory_(base::MakeRefCounted<PatcherFactory>()),
+      is_forced_update_(0),
+      min_free_space_bytes_(48 * 1024 * 1024),  // 48MB
+      allow_self_signed_packages_(false),
+      require_network_encryption_(true) {
+  LOG(INFO) << "Configurator::Configurator";
+
+  const std::string persisted_channel = persisted_data_->GetLatestChannel();
+  if (persisted_channel.empty()) {
+    SetChannel(kDefaultUpdaterChannel);
+  } else {
+    SetChannel(persisted_channel);
+  }
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kUseUncompressedUpdates)) {
+    use_compressed_updates_.store(false);
+  } else {
+    use_compressed_updates_.store(true);
+  }
+}
+Configurator::~Configurator() {
+  LOG(INFO) << "Configurator::~Configurator";
+}
+
+base::TimeDelta Configurator::InitialDelay() const {
+  return base::Seconds(0);
+}
+
+base::TimeDelta Configurator::NextCheckDelay() const {
+  return base::Hours(5);
+}
+
+base::TimeDelta Configurator::OnDemandDelay() const {
+  return base::Seconds(0);
+}
+
+base::TimeDelta Configurator::UpdateDelay() const {
+  return base::Seconds(0);
+}
+
+std::vector<GURL> Configurator::UpdateUrl() const {
+#if !defined(COBALT_BUILD_TYPE_GOLD)
+  if (allow_self_signed_packages_ && !update_server_url_.empty()) {
+    return std::vector<GURL>{GURL(update_server_url_)};
+  }
+#endif  // !defined(COBALT_BUILD_TYPE_GOLD)
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kUseQAUpdateServer)) {
+    return std::vector<GURL>{GURL(kUpdaterJSONDefaultUrlQA)};
+  } else {
+    return std::vector<GURL>{GURL(kUpdaterJSONDefaultUrl)};
+  }
+}
+
+std::vector<GURL> Configurator::PingUrl() const {
+  return UpdateUrl();
+}
+
+std::string Configurator::GetProdId() const {
+  return "cobalt";
+}
+
+base::Version Configurator::GetBrowserVersion() const {
+  return base::Version(COBALT_MAJOR_VERSION);
+}
+
+std::string Configurator::GetBrand() const {
+  return {};
+}
+
+std::string Configurator::GetLang() const {
+  const char* locale_id = SbSystemGetLocaleId();
+  if (!locale_id) {
+    // If Starboard failed to determine the locale, return a hardcoded, but
+    // valid BCP 47 language tag as required by
+    // https://html.spec.whatwg.org/commit-snapshots/e2f08b4e56d9a098038fb16c7ff6bb820a57cfab/#language-preferences
+    return "en-US";
+  }
+  std::string locale_string(locale_id);
+  // POSIX platforms put time zone id at the end of the locale id, like
+  // |en_US.UTF8|. We remove the time zone id.
+  int first_dot = locale_string.find_first_of(".");
+  if (first_dot != std::string::npos) {
+    return locale_string.substr(0, first_dot);
+  }
+  return locale_string;
+}
+
+std::string Configurator::GetOSLongName() const {
+  return GetDeviceProperty(kSbSystemPropertyPlatformName);
+}
+
+base::flat_map<std::string, std::string> Configurator::ExtraRequestParams()
+    const {
+  base::flat_map<std::string, std::string> params;
+  params.insert(std::make_pair("SABI", SB_SABI_JSON_ID));
+  params.insert(std::make_pair("sbversion", std::to_string(SB_API_VERSION)));
+
+  // The flag name to force an update is changed to `is_forced_update_` to
+  // cover the cases where update is requested by client but channel stays the
+  // same, but the flag name sent to Omaha remains `updaterchannelchanged` to
+  // isolate the changes to Omaha configs. If it's decided to change this flag
+  // name on Omaha, it'll be done in a separate PR after the Omaha configs are
+  // updated.
+  params.insert(std::make_pair(
+      "updaterchannelchanged",
+      std::atomic_load(&is_forced_update_) == 1 ? "True" : "False"));
+  // Brand name
+  params.insert(
+      std::make_pair("brand", GetDeviceProperty(kSbSystemPropertyBrandName)));
+
+  // Model name
+  params.insert(
+      std::make_pair("model", GetDeviceProperty(kSbSystemPropertyModelName)));
+
+  // Original Design manufacturer name
+  params.insert(
+      std::make_pair("manufacturer",
+                     GetDeviceProperty(kSbSystemPropertySystemIntegratorName)));
+
+  // Chipset model number
+  params.insert(std::make_pair(
+      "chipset", GetDeviceProperty(kSbSystemPropertyChipsetModelNumber)));
+
+  // Firmware version
+  params.insert(std::make_pair(
+      "firmware", GetDeviceProperty(kSbSystemPropertyFirmwareVersion)));
+
+  // Model year
+  params.insert(
+      std::make_pair("year", GetDeviceProperty(kSbSystemPropertyModelYear)));
+
+  // User Agent String
+  params.insert(std::make_pair("uastring", user_agent_string_));
+
+  // Certification scope
+  params.insert(std::make_pair(
+      "certscope", GetDeviceProperty(kSbSystemPropertyCertificationScope)));
+
+  // Compression status
+  params.insert(std::make_pair("usecompressedupdates",
+                               GetUseCompressedUpdates() ? "True" : "False"));
+
+  return params;
+}
+
+std::string Configurator::GetDownloadPreference() const {
+  return {};
+}
+
+// TODO(b/449022872): consider snake case names
+scoped_refptr<update_client::NetworkFetcherFactory>
+Configurator::GetNetworkFetcherFactory() {
+  return network_fetcher_factory_;
+}
+
+scoped_refptr<update_client::CrxDownloaderFactory>
+Configurator::GetCrxDownloaderFactory() {
+  return crx_downloader_factory_;
+}
+
+scoped_refptr<update_client::UnzipperFactory>
+Configurator::GetUnzipperFactory() {
+  return unzip_factory_;
+}
+
+scoped_refptr<update_client::PatcherFactory> Configurator::GetPatcherFactory() {
+  return patch_factory_;
+}
+
+bool Configurator::EnabledDeltas() const {
+  return false;
+}
+
+bool Configurator::EnabledBackgroundDownloader() const {
+  return false;
+}
+
+bool Configurator::EnabledCupSigning() const {
+  return false;
+}
+
+PrefService* Configurator::GetPrefService() const {
+  return pref_service_.get();
+}
+
+update_client::ActivityDataService* Configurator::GetActivityDataService()
+    const {
+  return nullptr;
+}
+
+bool Configurator::IsPerUserInstall() const {
+  return true;
+}
+
+absl::optional<bool> Configurator::IsMachineExternallyManaged() const {
+  return false;
+}
+
+update_client::UpdaterStateProvider Configurator::GetUpdaterStateProvider()
+    const {
+  return base::BindRepeating([](bool /*is_machine*/) {
+    return update_client::UpdaterStateAttributes();
+  });
+}
+
+std::string Configurator::GetAppGuidHelper(const std::string& updater_channel,
+                                           const std::string& version,
+                                           const int sb_version) {
+  if (updater_channel == "ltsnightly" || updater_channel == "ltsnightlyqa") {
+    return kOmahaCobaltLTSNightlyAppID;
+  }
+  if (version.find(".lts.") == std::string::npos &&
+      version.find(".master.") != std::string::npos) {
+    return kOmahaCobaltTrunkAppID;
+  }
+  std::string channel(updater_channel);
+  // This regex matches to all static channels for C25 and newer in the format
+  // of XXltsY.
+  if (std::regex_match(updater_channel,
+                       std::regex("(2[5-9]|[3-9][0-9])lts\\d+"))) {
+    channel = "static";
+  }
+  auto it = kChannelAndSbVersionToOmahaIdMap.find(channel +
+                                                  std::to_string(sb_version));
+  if (it != kChannelAndSbVersionToOmahaIdMap.end()) {
+    return it->second;
+  }
+  LOG(INFO) << "Configurator::GetAppGuidHelper updater channel and starboard "
+            << "combination is undefined with the new Omaha configs.";
+
+  // All undefined channel requests go to prod configs except for static
+  // channel requestsf for C24 and older.
+  // TODO(b/449024263): Replace regex matchers with substring_set_matcher or re2
+  if (!std::regex_match(updater_channel, std::regex("2[0-4]lts\\d+")) &&
+      sb_version >= 14 && sb_version <= 16) {
+    const auto it = kChannelAndSbVersionToOmahaIdMap.find(
+        "prod" + std::to_string(sb_version));
+    if (it != kChannelAndSbVersionToOmahaIdMap.end()) {
+      return it->second;
+    }
+  }
+  LOG(INFO) << __func__ << " starboard version is invalid.";
+  return kOmahaCobaltAppID;
+}
+
+std::string Configurator::GetAppGuid() const {
+  const std::string version(COBALT_VERSION);
+  return GetAppGuidHelper(updater_channel_, version, SB_API_VERSION);
+}
+
+std::unique_ptr<update_client::ProtocolHandlerFactory>
+Configurator::GetProtocolHandlerFactory() const {
+  return std::make_unique<update_client::ProtocolHandlerFactoryJSON>();
+}
+
+void Configurator::CompareAndSwapForcedUpdate(int old_value, int new_value) {
+  is_forced_update_.compare_exchange_weak(old_value, new_value);
+}
+
+// The updater channel is get and set by main web module thread and update
+// client thread. The getter and set use a lock to prevent synchronization
+// issue.
+std::string Configurator::GetChannel() const {
+  base::AutoLock auto_lock(const_cast<base::Lock&>(updater_channel_lock_));
+  return updater_channel_;
+}
+
+void Configurator::SetChannel(const std::string& updater_channel) {
+  LOG(INFO) << "Configurator::SetChannel updater_channel=" << updater_channel;
+  base::AutoLock auto_lock(updater_channel_lock_);
+  updater_channel_ = updater_channel;
+}
+
+// The updater status is get by main web module thread and set by the updater
+// thread. The getter and set use a lock to prevent synchronization issue.
+std::string Configurator::GetUpdaterStatus() const {
+  base::AutoLock auto_lock(const_cast<base::Lock&>(updater_status_lock_));
+  return updater_status_;
+}
+
+void Configurator::SetUpdaterStatus(const std::string& status) {
+  base::AutoLock auto_lock(updater_status_lock_);
+  updater_status_ = status;
+}
+
+void Configurator::SetMinFreeSpaceBytes(uint64_t bytes) {
+  base::AutoLock auto_lock(const_cast<base::Lock&>(min_free_space_bytes_lock_));
+  min_free_space_bytes_ = bytes;
+}
+
+uint64_t Configurator::GetMinFreeSpaceBytes() {
+  base::AutoLock auto_lock(const_cast<base::Lock&>(min_free_space_bytes_lock_));
+  return min_free_space_bytes_;
+}
+
+std::string Configurator::GetPreviousUpdaterStatus() const {
+  base::AutoLock auto_lock(
+      const_cast<base::Lock&>(previous_updater_status_lock_));
+  return previous_updater_status_;
+}
+
+void Configurator::SetPreviousUpdaterStatus(const std::string& status) {
+  base::AutoLock auto_lock(previous_updater_status_lock_);
+  previous_updater_status_ = status;
+}
+
+bool Configurator::GetUseCompressedUpdates() const {
+  return use_compressed_updates_.load();
+}
+
+void Configurator::SetUseCompressedUpdates(bool use_compressed_updates) {
+  use_compressed_updates_.store(use_compressed_updates);
+}
+
+bool Configurator::GetAllowSelfSignedPackages() const {
+  return allow_self_signed_packages_.load();
+}
+
+void Configurator::SetAllowSelfSignedPackages(bool allow_self_signed_packages) {
+  allow_self_signed_packages_.store(allow_self_signed_packages);
+}
+
+std::string Configurator::GetUpdateServerUrl() const {
+  base::AutoLock auto_lock(const_cast<base::Lock&>(update_server_url_lock_));
+  return update_server_url_;
+}
+
+void Configurator::SetUpdateServerUrl(const std::string& update_server_url) {
+  LOG(INFO) << "Configurator::SetUpdateServerUrl update_server_url="
+            << update_server_url;
+  base::AutoLock auto_lock(update_server_url_lock_);
+  update_server_url_ = update_server_url;
+}
+
+bool Configurator::GetRequireNetworkEncryption() const {
+  return require_network_encryption_.load();
+}
+void Configurator::SetRequireNetworkEncryption(
+    bool require_network_encryption) {
+  require_network_encryption_.store(require_network_encryption);
+}
+
+}  // namespace updater
+}  // namespace cobalt

--- a/cobalt/updater/configurator.h
+++ b/cobalt/updater/configurator.h
@@ -1,0 +1,163 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_UPDATER_CONFIGURATOR_H_
+#define COBALT_UPDATER_CONFIGURATOR_H_
+
+#include <stdint.h>
+
+#include <atomic>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/containers/flat_map.h"
+#include "base/memory/ref_counted.h"
+#include "base/synchronization/lock.h"
+#include "base/thread_annotations.h"
+#include "components/update_client/configurator.h"
+#include "components/update_client/persisted_data.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+class GURL;
+class PrefService;
+
+namespace base {
+class Version;
+}  // namespace base
+
+namespace service_manager {
+class Connector;
+}  // namespace service_manager
+
+namespace update_client {
+class ActivityDataService;
+class NetworkFetcherFactory;
+class ProtocolHandlerFactory;
+}  // namespace update_client
+
+namespace cobalt {
+namespace updater {
+// Configurator class for the Cobalt updater.
+// It implements the update_client::Configurator interface and provides
+// Cobalt-specific configuration parameters for the update process.
+//
+// Provides Cobalt-specific configurations to the update client, such as update
+// URLs, version information, and other settings required for the update
+// process.
+// Exists for the duration of the application's runtime, destroyed when app is
+// suspended or exits.
+// TODO: (b/451696797) Adding a thread_checker for each TaskRunner accessing
+// the Configurator instance.
+// Accessed by both the updater thread and the main thread. Synchronization
+// mechanisms (locks, atomics) are used to ensure thread safety.
+class Configurator : public update_client::Configurator {
+ public:
+  explicit Configurator(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+
+  // Configurator for update_client::Configurator.
+  base::TimeDelta InitialDelay() const override;
+  base::TimeDelta NextCheckDelay() const override;
+  base::TimeDelta OnDemandDelay() const override;
+  base::TimeDelta UpdateDelay() const override;
+  std::vector<GURL> UpdateUrl() const override;
+  std::vector<GURL> PingUrl() const override;
+  std::string GetProdId() const override;
+  base::Version GetBrowserVersion() const override;
+  std::string GetChannel() const override;
+  std::string GetBrand() const override;
+  std::string GetLang() const override;
+  std::string GetOSLongName() const override;
+  base::flat_map<std::string, std::string> ExtraRequestParams() const override;
+  std::string GetDownloadPreference() const override;
+  scoped_refptr<update_client::NetworkFetcherFactory> GetNetworkFetcherFactory()
+      override;
+  scoped_refptr<update_client::CrxDownloaderFactory> GetCrxDownloaderFactory()
+      override;
+  scoped_refptr<update_client::UnzipperFactory> GetUnzipperFactory() override;
+  scoped_refptr<update_client::PatcherFactory> GetPatcherFactory() override;
+  bool EnabledDeltas() const override;
+  bool EnabledBackgroundDownloader() const override;
+  bool EnabledCupSigning() const override;
+  PrefService* GetPrefService() const override;
+  update_client::ActivityDataService* GetActivityDataService() const override;
+  absl::optional<bool> IsMachineExternallyManaged() const override;
+  bool IsPerUserInstall() const override;
+  std::string GetAppGuid() const override;
+  std::unique_ptr<update_client::ProtocolHandlerFactory>
+  GetProtocolHandlerFactory() const override;
+  update_client::UpdaterStateProvider GetUpdaterStateProvider() const override;
+
+  void SetChannel(const std::string& updater_channel) override;
+
+  void CompareAndSwapForcedUpdate(int old_value, int new_value) override;
+
+  std::string GetUpdaterStatus() const override;
+  void SetUpdaterStatus(const std::string& status) override;
+
+  std::string GetPreviousUpdaterStatus() const override;
+  void SetPreviousUpdaterStatus(const std::string& status) override;
+
+  void SetMinFreeSpaceBytes(uint64_t bytes) override;
+  uint64_t GetMinFreeSpaceBytes() override;
+
+  bool GetUseCompressedUpdates() const override;
+  void SetUseCompressedUpdates(bool use_compressed_updates) override;
+  static std::string GetAppGuidHelper(const std::string& updater_channel,
+                                      const std::string& version,
+                                      const int sb_version);
+
+  bool GetAllowSelfSignedPackages() const override;
+  void SetAllowSelfSignedPackages(bool allow_self_signed_packages) override;
+
+  std::string GetUpdateServerUrl() const override;
+  void SetUpdateServerUrl(const std::string& update_server_url) override;
+
+  bool GetRequireNetworkEncryption() const override;
+  void SetRequireNetworkEncryption(bool require_network_encryption) override;
+
+ private:
+  friend class base::RefCountedThreadSafe<Configurator>;
+  ~Configurator() override;
+
+  std::unique_ptr<PrefService> pref_service_;
+  std::unique_ptr<update_client::PersistedData> persisted_data_;
+  scoped_refptr<update_client::NetworkFetcherFactory> network_fetcher_factory_;
+  scoped_refptr<update_client::CrxDownloaderFactory> crx_downloader_factory_;
+  scoped_refptr<update_client::UnzipperFactory> unzip_factory_;
+  scoped_refptr<update_client::PatcherFactory> patch_factory_;
+  // TODO(b/449220798): Consider using PostTask and thread checker
+  std::string updater_channel_ GUARDED_BY(updater_channel_lock_);
+  base::Lock updater_channel_lock_;
+  std::atomic<int32_t> is_forced_update_;
+  std::string updater_status_ GUARDED_BY(updater_status_lock_);
+  base::Lock updater_status_lock_;
+  std::string previous_updater_status_
+      GUARDED_BY(previous_updater_status_lock_);
+  base::Lock previous_updater_status_lock_;
+  std::string user_agent_string_;
+  uint64_t min_free_space_bytes_ GUARDED_BY(min_free_space_bytes_lock_);
+  base::Lock min_free_space_bytes_lock_;
+  std::atomic_bool use_compressed_updates_;
+  std::atomic_bool allow_self_signed_packages_;
+  std::string update_server_url_ GUARDED_BY(update_server_url_lock_);
+  base::Lock update_server_url_lock_;
+  std::atomic_bool require_network_encryption_;
+};
+
+}  // namespace updater
+}  // namespace cobalt
+
+#endif  // COBALT_UPDATER_CONFIGURATOR_H_

--- a/cobalt/updater/network_fetcher.cc
+++ b/cobalt/updater/network_fetcher.cc
@@ -1,0 +1,236 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/updater/network_fetcher.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/functional/callback_helpers.h"
+#include "base/strings/stringprintf.h"
+#include "net/base/net_errors.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+
+#include "base/check.h"
+#include "base/functional/bind.h"
+#include "base/notreached.h"
+#include "base/numerics/safe_conversions.h"
+#include "net/base/load_flags.h"
+#include "net/http/http_response_headers.h"
+#include "net/traffic_annotation/network_traffic_annotation.h"
+#include "services/network/public/cpp/is_potentially_trustworthy.h"
+#include "services/network/public/cpp/resource_request.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "services/network/public/cpp/simple_url_loader.h"
+#include "services/network/public/cpp/simple_url_loader_throttle.h"
+#include "services/network/public/mojom/url_response_head.mojom.h"
+#include "url/gurl.h"
+
+// TODO(b/448186580): consider Replace LOG with D(V)LOG throughout this file
+// TODO(b/449223391): Revist and document the usage of base::Unretained()
+
+namespace {
+
+constexpr net::NetworkTrafficAnnotationTag traffic_annotation =
+    net::DefineNetworkTrafficAnnotation("cobalt_updater_network_fetcher",
+                                        "cobalt_updater_network_fetcher");
+
+std::string GetStringHeader(const network::SimpleURLLoader* simple_url_loader,
+                            const char* header_name) {
+  CHECK(simple_url_loader);
+
+  const auto* response_info = simple_url_loader->ResponseInfo();
+  if (!response_info || !response_info->headers) {
+    return {};
+  }
+
+  std::string header_value;
+  return response_info->headers->EnumerateHeader(nullptr, header_name,
+                                                 &header_value)
+             ? header_value
+             : std::string{};
+}
+
+int64_t GetInt64Header(const network::SimpleURLLoader* simple_url_loader,
+                       const char* header_name) {
+  CHECK(simple_url_loader);
+
+  const auto* response_info = simple_url_loader->ResponseInfo();
+  if (!response_info || !response_info->headers) {
+    return -1;
+  }
+
+  return response_info->headers->GetInt64HeaderValue(header_name);
+}
+
+}  // namespace
+
+namespace cobalt {
+namespace updater {
+
+NetworkFetcher::NetworkFetcher(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
+    : url_loader_factory_(std::move(url_loader_factory)) {
+  LOG(INFO) << "cobalt::updater::NetworkFetcher::NetworkFetcher";
+}
+
+NetworkFetcher::~NetworkFetcher() {
+  LOG(INFO) << "cobalt::updater::NetworkFetcher::~NetworkFetcher";
+}
+
+void NetworkFetcher::PostRequest(
+    const GURL& url,
+    const std::string& post_data,
+    const std::string& content_type,
+    const base::flat_map<std::string, std::string>& post_additional_headers,
+    ResponseStartedCallback response_started_callback,
+    ProgressCallback progress_callback,
+    PostRequestCompleteCallback post_request_complete_callback) {
+  CHECK(!simple_url_loader_);
+
+  LOG(INFO) << "NetworkFetcher::PostRequest";
+  LOG(INFO) << "PostRequest url = " << url;
+  LOG(INFO) << "PostRequest post_data = " << post_data;
+
+  auto resource_request = std::make_unique<network::ResourceRequest>();
+  resource_request->url = url;
+  resource_request->method = "POST";
+  resource_request->load_flags = net::LOAD_DISABLE_CACHE;
+  resource_request->credentials_mode = network::mojom::CredentialsMode::kOmit;
+  for (const auto& header : post_additional_headers) {
+    resource_request->headers.SetHeader(header.first, header.second);
+  }
+  simple_url_loader_ = network::SimpleURLLoader::Create(
+      std::move(resource_request), traffic_annotation);
+  if (network::SimpleURLLoaderThrottle::IsBatchingEnabled(traffic_annotation)) {
+    simple_url_loader_->SetAllowBatching();
+  }
+  simple_url_loader_->SetRetryOptions(
+      kMaxRetriesOnNetworkChange,
+      network::SimpleURLLoader::RETRY_ON_NETWORK_CHANGE);
+  // The `Content-Type` header set by |AttachStringForUpload| overwrites any
+  // `Content-Type` header present in the |ResourceRequest| above.
+  simple_url_loader_->AttachStringForUpload(post_data, content_type);
+  simple_url_loader_->SetOnResponseStartedCallback(base::BindOnce(
+      &NetworkFetcher::OnResponseStartedCallback, base::Unretained(this),
+      std::move(response_started_callback)));
+  simple_url_loader_->SetOnDownloadProgressCallback(base::BindRepeating(
+      &NetworkFetcher::OnProgressCallback, base::Unretained(this),
+      std::move(progress_callback)));
+  constexpr size_t kMaxResponseSize = 1024 * 1024;
+  simple_url_loader_->DownloadToString(
+      url_loader_factory_.get(),
+      base::BindOnce(
+          [](const network::SimpleURLLoader* simple_url_loader,
+             PostRequestCompleteCallback post_request_complete_callback,
+             std::unique_ptr<std::string> response_body) {
+            LOG(INFO) << "post_request_complete_callback, response_body="
+                      << response_body->c_str();
+            std::move(post_request_complete_callback)
+                .Run(std::move(response_body), simple_url_loader->NetError(),
+                     GetStringHeader(simple_url_loader, kHeaderEtag),
+                     GetStringHeader(simple_url_loader, kHeaderXCupServerProof),
+                     GetInt64Header(simple_url_loader, kHeaderXRetryAfter));
+          },
+          simple_url_loader_.get(), std::move(post_request_complete_callback)),
+      kMaxResponseSize);
+}
+
+#if defined(IN_MEMORY_UPDATES)
+void NetworkFetcher::DownloadToString(
+    const GURL& url,
+    std::string* dst,
+    ResponseStartedCallback response_started_callback,
+    ProgressCallback progress_callback,
+    DownloadToStringCompleteCallback download_to_string_complete_callback) {
+  LOG(INFO) << "NetworkFetcher::DownloadToString, url = " << url;
+  // TODO(b/444006168): implement this to support in-memory updates
+  NOTIMPLEMENTED();
+}
+
+#else
+void NetworkFetcher::DownloadToFile(
+    const GURL& url,
+    const base::FilePath& file_path,
+    ResponseStartedCallback response_started_callback,
+    ProgressCallback progress_callback,
+    DownloadToFileCompleteCallback download_to_file_complete_callback) {
+  LOG(INFO) << "NetworkFetcher::DownloadToFile, file_path = "
+            << file_path.value().c_str() << ", url = " << url;
+  CHECK(!simple_url_loader_);
+  auto resource_request = std::make_unique<network::ResourceRequest>();
+  resource_request->url = url;
+  resource_request->method = "GET";
+  resource_request->load_flags = net::LOAD_DISABLE_CACHE;
+  simple_url_loader_ = network::SimpleURLLoader::Create(
+      std::move(resource_request), traffic_annotation);
+  simple_url_loader_->SetRetryOptions(
+      kMaxRetriesOnNetworkChange,
+      network::SimpleURLLoader::RetryMode::RETRY_ON_NETWORK_CHANGE);
+  simple_url_loader_->SetAllowPartialResults(true);
+  simple_url_loader_->SetOnResponseStartedCallback(base::BindOnce(
+      &NetworkFetcher::OnResponseStartedCallback, base::Unretained(this),
+      std::move(response_started_callback)));
+  simple_url_loader_->SetOnDownloadProgressCallback(base::BindRepeating(
+      &NetworkFetcher::OnProgressCallback, base::Unretained(this),
+      std::move(progress_callback)));
+  simple_url_loader_->DownloadToFile(
+      url_loader_factory_.get(),
+      base::BindOnce(
+          [](const network::SimpleURLLoader* simple_url_loader,
+             DownloadToFileCompleteCallback
+                 download_to_file_complete_callback) {
+            std::move(download_to_file_complete_callback)
+                .Run(simple_url_loader->NetError(),
+                     simple_url_loader->GetContentSize());
+          },
+          simple_url_loader_.get(),
+          std::move(download_to_file_complete_callback)),
+      file_path);
+}
+#endif
+
+void NetworkFetcher::Cancel() {
+  LOG(INFO) << "cobalt::updater::NetworkFetcher::Cancel";
+  simple_url_loader_.reset();
+}
+
+void NetworkFetcher::OnResponseStartedCallback(
+    ResponseStartedCallback response_started_callback,
+    const GURL& final_url,
+    const network::mojom::URLResponseHead& response_head) {
+  LOG(INFO) << "NetworkFetcher::OnResponseStartedCallback";
+  std::move(response_started_callback)
+      .Run(response_head.headers ? response_head.headers->response_code() : -1,
+           response_head.content_length);
+}
+
+void NetworkFetcher::OnProgressCallback(ProgressCallback progress_callback,
+                                        uint64_t current) {
+  progress_callback.Run(base::saturated_cast<int64_t>(current));
+}
+
+NetworkFetcherFactoryCobalt::NetworkFetcherFactoryCobalt(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
+    : url_loader_factory_(std::move(url_loader_factory)) {}
+
+NetworkFetcherFactoryCobalt::~NetworkFetcherFactoryCobalt() = default;
+
+std::unique_ptr<update_client::NetworkFetcher>
+NetworkFetcherFactoryCobalt::Create() const {
+  return std::make_unique<NetworkFetcher>(url_loader_factory_);
+}
+
+}  // namespace updater
+}  // namespace cobalt

--- a/cobalt/updater/network_fetcher.h
+++ b/cobalt/updater/network_fetcher.h
@@ -1,0 +1,146 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_UPDATER_NETWORK_FETCHER_H_
+#define COBALT_UPDATER_NETWORK_FETCHER_H_
+
+#include <stdint.h>
+
+#include <memory>
+#include <string>
+
+#include "base/memory/ref_counted.h"
+#include "base/threading/thread_checker.h"
+#include "components/update_client/network.h"
+
+#include "services/network/public/mojom/url_response_head.mojom-forward.h"
+
+namespace base {
+
+class FilePath;
+class SequencedTaskRunner;
+
+}  // namespace base
+
+namespace network {
+class SharedURLLoaderFactory;
+class SimpleURLLoader;
+}  // namespace network
+
+namespace cobalt {
+namespace updater {
+// The NetworkFetcher class provides an implementation of the
+// update_client::NetworkFetcher interface, tailored for Cobalt's updater.
+//
+// This class is responsible for performing network operations required by
+// the updater, such as downloading update payloads or posting update
+// requests. It acts as a bridge between the updater logic and the underlying
+// network stack, encapsulating the details of network requests and
+// responses, and providing a consistent interface for the updater.
+//
+// A NetworkFetcher instance is created when the updater configurator is
+// created, and its lifetime is managed by the updater configurator.
+//
+// NetworkFetcher is used on a single thread - the updater thread when a
+// request (e.g., a file download or a POST request) is made
+class NetworkFetcher : public update_client::NetworkFetcher {
+ public:
+  using ResponseStartedCallback =
+      update_client::NetworkFetcher::ResponseStartedCallback;
+  using ProgressCallback = update_client::NetworkFetcher::ProgressCallback;
+  using PostRequestCompleteCallback =
+      update_client::NetworkFetcher::PostRequestCompleteCallback;
+#if defined(IN_MEMORY_UPDATES)
+  using DownloadToStringCompleteCallback =
+      update_client::NetworkFetcher::DownloadToStringCompleteCallback;
+#else
+  using DownloadToFileCompleteCallback =
+      update_client::NetworkFetcher::DownloadToFileCompleteCallback;
+#endif
+
+  explicit NetworkFetcher(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+  ~NetworkFetcher() override;
+
+  // update_client::NetworkFetcher interface.
+  void PostRequest(
+      const GURL& url,
+      const std::string& post_data,
+      const std::string& content_type,
+      const base::flat_map<std::string, std::string>& post_additional_headers,
+      ResponseStartedCallback response_started_callback,
+      ProgressCallback progress_callback,
+      PostRequestCompleteCallback post_request_complete_callback) override;
+#if defined(IN_MEMORY_UPDATES)
+  // Does not take ownership of |dst|, which must refer to a valid string that
+  // outlives this object.
+  void DownloadToString(const GURL& url,
+                        std::string* dst,
+                        ResponseStartedCallback response_started_callback,
+                        ProgressCallback progress_callback,
+                        DownloadToStringCompleteCallback
+                            download_to_string_complete_callback) override;
+#else
+  void DownloadToFile(const GURL& url,
+                      const base::FilePath& file_path,
+                      ResponseStartedCallback response_started_callback,
+                      ProgressCallback progress_callback,
+                      DownloadToFileCompleteCallback
+                          download_to_file_complete_callback) override;
+#endif
+  void Cancel() override;
+
+ private:
+  // TODO(b/449228491): add thread checker
+  // Empty struct to ensure the caller of |HandleError()| knows that |this|
+  // may have been destroyed and handles it appropriately.
+  struct ReturnWrapper {
+    void InvalidateThis() {}
+  };
+
+  void OnResponseStartedCallback(
+      ResponseStartedCallback response_started_callback,
+      const GURL& final_url,
+      const network::mojom::URLResponseHead& response_head);
+
+  void OnProgressCallback(ProgressCallback response_started_callback,
+                          uint64_t current);
+
+  static constexpr int kMaxRetriesOnNetworkChange = 3;
+
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  std::unique_ptr<network::SimpleURLLoader> simple_url_loader_;
+};
+
+// This class is needed because NetworkFetcherFactory class needs
+// an implementation.
+class NetworkFetcherFactoryCobalt
+    : public update_client::NetworkFetcherFactory {
+ public:
+  explicit NetworkFetcherFactoryCobalt(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_);
+
+  std::unique_ptr<update_client::NetworkFetcher> Create() const override;
+
+ protected:
+  ~NetworkFetcherFactoryCobalt() override;
+
+ private:
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+};
+
+}  // namespace updater
+}  // namespace cobalt
+
+#endif  // COBALT_UPDATER_NETWORK_FETCHER_H_

--- a/cobalt/updater/patcher.cc
+++ b/cobalt/updater/patcher.cc
@@ -1,0 +1,104 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cobalt/updater/patcher.h"
+
+#include <utility>
+#include "base/files/file.h"
+#include "base/files/file_path.h"
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/notreached.h"
+#include "components/update_client/buildflags.h"
+#include "courgette/courgette.h"
+#include "courgette/third_party/bsdiff/bsdiff.h"
+#if BUILDFLAG(ENABLE_PUFFIN_PATCHES)
+// TODO(crbug.com/1349060) once Puffin patches are fully implemented,
+// we should remove this #if.
+#include "third_party/puffin/src/include/puffin/puffpatch.h"
+#endif
+
+// TODO(b/174699165): Investigate differential updates
+
+namespace cobalt {
+namespace updater {
+
+namespace {
+
+class PatcherImpl : public update_client::Patcher {
+ public:
+  PatcherImpl() = default;
+
+  void PatchBsdiff(const base::FilePath& input_path,
+                   const base::FilePath& patch_path,
+                   const base::FilePath& output_path,
+                   PatchCompleteCallback callback) const override {
+    base::File input_file(input_path,
+                          base::File::FLAG_OPEN | base::File::FLAG_READ);
+    base::File patch_file(patch_path,
+                          base::File::FLAG_OPEN | base::File::FLAG_READ);
+    base::File output_file(output_path,
+                           base::File::FLAG_CREATE | base::File::FLAG_WRITE |
+                               base::File::FLAG_WIN_EXCLUSIVE_WRITE);
+    if (!input_file.IsValid() || !patch_file.IsValid() ||
+        !output_file.IsValid()) {
+      std::move(callback).Run(-1);
+      return;
+    }
+    std::move(callback).Run(bsdiff::ApplyBinaryPatch(
+        std::move(input_file), std::move(patch_file), std::move(output_file)));
+  }
+
+  // TODO(crbug.com/1349158): Remove this function once PatchPuffPatch is
+  // implemented as this becomes obsolete.
+  void PatchCourgette(const base::FilePath& input_path,
+                      const base::FilePath& patch_path,
+                      const base::FilePath& output_path,
+                      PatchCompleteCallback callback) const override {
+    base::File input_file(input_path,
+                          base::File::FLAG_OPEN | base::File::FLAG_READ);
+    base::File patch_file(patch_path,
+                          base::File::FLAG_OPEN | base::File::FLAG_READ);
+    base::File output_file(output_path,
+                           base::File::FLAG_CREATE | base::File::FLAG_WRITE |
+                               base::File::FLAG_WIN_EXCLUSIVE_WRITE);
+    if (!input_file.IsValid() || !patch_file.IsValid() ||
+        !output_file.IsValid()) {
+      std::move(callback).Run(-1);
+      return;
+    }
+    std::move(callback).Run(courgette::ApplyEnsemblePatch(
+        std::move(input_file), std::move(patch_file), std::move(output_file)));
+  }
+
+  void PatchPuffPatch(base::File input_file,
+                      base::File patch_file,
+                      base::File output_file,
+                      PatchCompleteCallback callback) const override {
+#if BUILDFLAG(ENABLE_PUFFIN_PATCHES)
+    // TODO(crbug.com/1349060) once Puffin patches are fully implemented,
+    // we should remove this #if.
+    std::move(callback).Run(puffin::ApplyPuffPatch(
+        std::move(input_file), std::move(patch_file), std::move(output_file)));
+#else
+    NOTREACHED();
+#endif
+  }
+
+ protected:
+  ~PatcherImpl() override = default;
+};
+
+}  // namespace
+
+PatcherFactory::PatcherFactory() = default;
+
+scoped_refptr<update_client::Patcher> PatcherFactory::Create() const {
+  return base::MakeRefCounted<PatcherImpl>();
+}
+
+PatcherFactory::~PatcherFactory() = default;
+
+}  // namespace updater
+}  // namespace cobalt

--- a/cobalt/updater/patcher.h
+++ b/cobalt/updater/patcher.h
@@ -1,0 +1,36 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COBALT_UPDATER_PATCHER_H_
+#define COBALT_UPDATER_PATCHER_H_
+
+#include <memory>
+
+#include "base/memory/scoped_refptr.h"
+
+#include "base/memory/ref_counted.h"
+#include "components/update_client/patcher.h"
+
+// TODO(b/174699165): Investigate differential updates later.
+// This is a skeleton class for now.
+
+namespace cobalt {
+namespace updater {
+
+class PatcherFactory : public update_client::PatcherFactory {
+ public:
+  PatcherFactory();
+  PatcherFactory(const PatcherFactory&) = delete;
+  PatcherFactory& operator=(const PatcherFactory&) = delete;
+
+  scoped_refptr<update_client::Patcher> Create() const override;
+
+ protected:
+  ~PatcherFactory() override;
+};
+
+}  // namespace updater
+}  // namespace cobalt
+
+#endif  // COBALT_UPDATER_PATCHER_H_

--- a/cobalt/updater/prefs.cc
+++ b/cobalt/updater/prefs.cc
@@ -1,0 +1,69 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/updater/prefs.h"
+
+#include <string>
+
+#include "base/files/file_path.h"
+#include "base/logging.h"
+#include "base/memory/scoped_refptr.h"
+#include "cobalt/updater/util.h"
+#include "components/prefs/json_pref_store.h"
+#include "components/prefs/pref_registry_simple.h"
+#include "components/prefs/pref_service.h"
+#include "components/prefs/pref_service_factory.h"
+#include "components/update_client/update_client.h"
+#include "starboard/extension/installation_manager.h"
+
+namespace cobalt {
+namespace updater {
+
+std::unique_ptr<PrefService> CreatePrefService() {
+  base::FilePath product_data_dir;
+  if (!CreateProductDirectory(&product_data_dir)) {
+    return nullptr;
+  }
+
+  const CobaltExtensionInstallationManagerApi* installation_api =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+  if (!installation_api) {
+    LOG(ERROR) << "Failed to get installation manager api.";
+    return nullptr;
+  }
+  std::string app_key;
+  app.key.reserve(IM_EXT_MAX_APP_KEY_LENGTH);
+  if (installation_api->GetAppKey(app_key.data(), app_key.capacity()) ==
+      IM_EXT_ERROR) {
+    LOG(ERROR) << "Failed to get app key.";
+    return nullptr;
+  }
+
+  LOG(INFO) << "Updater: prefs app_key=" << app_key;
+  PrefServiceFactory pref_service_factory;
+  std::string file_name = "prefs_";
+  file_name += app_key;
+  file_name += ".json";
+  pref_service_factory.set_user_prefs(base::MakeRefCounted<JsonPrefStore>(
+      product_data_dir.Append(FILE_PATH_LITERAL(file_name))));
+
+  auto pref_registry = base::MakeRefCounted<PrefRegistrySimple>();
+  update_client::RegisterPrefs(pref_registry.get());
+
+  return pref_service_factory.Create(pref_registry);
+}
+
+}  // namespace updater
+}  // namespace cobalt

--- a/cobalt/updater/prefs.h
+++ b/cobalt/updater/prefs.h
@@ -1,0 +1,31 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_UPDATER_PREFS_H_
+#define COBALT_UPDATER_PREFS_H_
+
+#include <memory>
+
+class PrefService;
+
+namespace cobalt {
+namespace updater {
+
+// Initializes prefs settings including the prefs file path.
+std::unique_ptr<PrefService> CreatePrefService();
+
+}  // namespace updater
+}  // namespace cobalt
+
+#endif  // COBALT_UPDATER_PREFS_H_

--- a/cobalt/updater/unzipper.cc
+++ b/cobalt/updater/unzipper.cc
@@ -1,0 +1,71 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/updater/unzipper.h"
+
+#include <string>
+#include <utility>
+#include "base/files/file_path.h"
+#include "base/logging.h"
+#include "base/time/time.h"
+#include "third_party/zlib/google/zip.h"
+
+namespace cobalt {
+namespace updater {
+
+namespace {
+
+class UnzipperImpl : public update_client::Unzipper {
+ public:
+  UnzipperImpl() = default;
+
+  void Unzip(const base::FilePath& zip_path,
+             const base::FilePath& output_path,
+             UnzipCompleteCallback callback) override {
+    auto time_before_unzip = base::TimeTicks::Now();
+    std::move(callback).Run(zip::Unzip(zip_path, output_path));
+    auto time_unzip_took_usec =
+        (base::TimeTicks::Now() - time_before_unzip).InMilliseconds();
+    LOG(INFO) << "Unzip file path = " << zip_path;
+    LOG(INFO) << "output_path = " << output_path;
+    LOG(INFO) << "Unzip took " << time_unzip_took_usec << " milliseconds.";
+  }
+
+#if defined(IN_MEMORY_UPDATES)
+  void Unzip(const std::string& zip_str,
+             const base::FilePath& output_path,
+             UnzipCompleteCallback callback) override {
+    auto time_before_unzip = base::TimeTicks::Now();
+    std::move(callback).Run(zip::Unzip(zip_str, output_path));
+    auto time_unzip_took_usec =
+        (base::TimeTicks::Now() - time_before_unzip).InMilliseconds();
+    LOG(INFO) << "Unzip from string";
+    LOG(INFO) << "output_path = " << output_path;
+    LOG(INFO) << "Unzip took " << time_unzip_took_usec << " milliseconds.";
+  }
+#endif
+};
+
+}  // namespace
+
+UnzipperFactory::UnzipperFactory() = default;
+
+std::unique_ptr<update_client::Unzipper> UnzipperFactory::Create() const {
+  return std::make_unique<UnzipperImpl>();
+}
+
+UnzipperFactory::~UnzipperFactory() = default;
+
+}  // namespace updater
+}  // namespace cobalt

--- a/cobalt/updater/unzipper.h
+++ b/cobalt/updater/unzipper.h
@@ -1,0 +1,39 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_UPDATER_UNZIPPER_H_
+#define COBALT_UPDATER_UNZIPPER_H_
+
+#include <memory>
+
+#include "base/memory/ref_counted.h"
+#include "components/update_client/unzipper.h"
+
+namespace cobalt {
+namespace updater {
+
+class UnzipperFactory : public update_client::UnzipperFactory {
+ public:
+  UnzipperFactory();
+
+  std::unique_ptr<update_client::Unzipper> Create() const override;
+
+ protected:
+  ~UnzipperFactory() override;
+};
+
+}  // namespace updater
+}  // namespace cobalt
+
+#endif  // COBALT_UPDATER_UNZIPPER_H_

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -1,0 +1,563 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/updater/updater_module.h"
+
+#include <utility>
+#include <vector>
+#include "third_party/abseil-cpp/absl/types/optional.h"
+
+#include "base/files/file_path.h"
+#include "base/functional/bind.h"
+#include "base/functional/callback_forward.h"
+#include "base/functional/callback_helpers.h"
+#include "base/logging.h"
+#include "base/rand_util.h"
+#include "base/run_loop.h"
+#include "base/stl_util.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/task/task_runner.h"
+#include "base/threading/scoped_blocking_call.h"
+#include "base/threading/thread.h"
+#include "base/time/time.h"
+#include "base/version.h"
+#include "cobalt/browser/switches.h"
+#include "cobalt/updater/util.h"
+#include "components/crx_file/crx_verifier.h"
+#include "components/update_client/cobalt_slot_management.h"
+#include "components/update_client/update_client_errors.h"
+#include "components/update_client/utils.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "starboard/common/file.h"
+#include "starboard/configuration_constants.h"
+#include "starboard/extension/installation_manager.h"
+
+namespace {
+
+using update_client::CobaltSlotManagement;
+using update_client::ComponentState;
+using update_client::UpdateCheckError;
+
+// The SHA256 hash of the "cobalt_evergreen_public" key.
+constexpr uint8_t kCobaltPublicKeyHash[] = {
+    0x51, 0xa8, 0xc0, 0x90, 0xf8, 0x1a, 0x14, 0xb0, 0xda, 0x7a, 0xfb,
+    0x9e, 0x8b, 0x2d, 0x22, 0x65, 0x19, 0xb1, 0xfa, 0xba, 0x02, 0x04,
+    0x3a, 0xb2, 0x7a, 0xf6, 0xfe, 0xd5, 0x35, 0xa1, 0x19, 0xd9};
+
+CobaltExtensionUpdaterNotificationState
+ComponentStateToCobaltExtensionUpdaterNotificationState(
+    ComponentState component_state) {
+  switch (component_state) {
+    case ComponentState::kChecking:
+      return kCobaltExtensionUpdaterNotificationStateChecking;
+    case ComponentState::kCanUpdate:
+      return kCobaltExtensionUpdaterNotificationStateUpdateAvailable;
+    case ComponentState::kDownloading:
+      return kCobaltExtensionUpdaterNotificationStateDownloading;
+    case ComponentState::kDownloaded:
+      return kCobaltExtensionUpdaterNotificationStateDownloaded;
+    case ComponentState::kUpdating:
+      return kCobaltExtensionUpdaterNotificationStateInstalling;
+    case ComponentState::kUpdated:
+      return kCobaltExtensionUpdaterNotificationStateUpdated;
+    case ComponentState::kUpToDate:
+      return kCobaltExtensionUpdaterNotificationStateUpToDate;
+    case ComponentState::kUpdateError:
+      return kCobaltExtensionUpdaterNotificationStateUpdateFailed;
+    case ComponentState::kNew:
+    case ComponentState::kDownloadingDiff:
+    case ComponentState::kUpdatingDiff:
+    case ComponentState::kUninstalled:
+    case ComponentState::kRegistration:
+    case ComponentState::kRun:
+    case ComponentState::kLastStatus:
+      return kCobaltExtensionUpdaterNotificationStateNone;
+  }
+}
+
+}  // namespace
+
+namespace cobalt {
+namespace updater {
+
+// The delay before the first update check.
+const base::TimeDelta kDefaultUpdateCheckDelay =
+    base::TimeDelta::FromSeconds(30);
+
+void Observer::OnEvent(Events event, const std::string& id) {
+  std::string status;
+  if (update_client_->GetCrxUpdateState(id, &crx_update_item_)) {
+    auto status_iterator =
+        component_to_updater_status_map.find(crx_update_item_.state);
+    if (status_iterator == component_to_updater_status_map.end()) {
+      status = "Status is unknown.";
+    } else if (crx_update_item_.state == ComponentState::kUpToDate &&
+               updater_configurator_->GetPreviousUpdaterStatus() ==
+                   updater_status_string_map.at(UpdaterStatus::kUpdated)) {
+      status = updater_status_string_map.at(UpdaterStatus::kUpdated);
+    } else {
+      status = updater_status_string_map.find(status_iterator->second)->second;
+    }
+    if (crx_update_item_.state == ComponentState::kUpdateError) {
+      // `QUICK_ROLL_FORWARD` update, adjust the message to "Updated locally,
+      // pending restart".
+      if (crx_update_item_.error_code ==
+          static_cast<int>(UpdateCheckError::QUICK_ROLL_FORWARD)) {
+        status = updater_status_string_map.at(UpdaterStatus::kRolledForward);
+      } else {
+        status +=
+            ", error category is " +
+            std::to_string(static_cast<int>(crx_update_item_.error_category)) +
+            ",  error code is " + std::to_string(crx_update_item_.error_code);
+      }
+    }
+    if (updater_notification_ext_ != nullptr) {
+      updater_notification_ext_->UpdaterState(
+          ComponentStateToCobaltExtensionUpdaterNotificationState(
+              crx_update_item_.state),
+          GetCurrentEvergreenVersion().c_str());
+    }
+  } else {
+    status = "No status available";
+  }
+  updater_configurator_->SetUpdaterStatus(status);
+  LOG_IF(INFO, status != "Downloading update") << "Updater status is" << status;
+}
+
+UpdaterModule::UpdaterModule(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    base::TimeDelta update_check_delay)
+    : url_loader_factory_(std::move(url_loader_factory)),
+      update_check_delay_(update_check_delay) {
+  LOG(INFO) << "UpdaterModule::UpdaterModule";
+  // TODO(b/453693299): investigate using sequence to replace base::Thread
+  updater_thread_.reset(new base::Thread("Updater"));
+  updater_thread_->StartWithOptions(
+      base::Thread::Options(base::MessagePumpType::IO, 0));
+
+  updater_thread_->DetachFromSequence();
+  // Initialize the underlying update client.
+  is_updater_running_ = true;
+  updater_thread_->task_runner()->PostTask(
+      FROM_HERE,
+      base::BindOnce(&UpdaterModule::Initialize, base::Unretained(this),
+                     url_loader_factory_->Clone()));
+}
+
+UpdaterModule::~UpdaterModule() {
+  LOG(INFO) << "UpdaterModule::~UpdaterModule";
+  if (is_updater_running_) {
+    is_updater_running_ = false;
+    // TODO(b/452142372): Investigate UpdaterModule destruction sequence
+    {
+      base::ScopedBlockingCall scoped_blocking_call(
+          FROM_HERE, base::BlockingType::MAY_BLOCK);
+      updater_thread_->task_runner()->PostTask(
+          FROM_HERE,
+          base::BindOnce(&UpdaterModule::Finalize, base::Unretained(this)));
+    }
+  }
+
+  // Upon destruction the thread will allow all queued tasks to complete before
+  // the thread is terminated. The thread is destroyed before returning from
+  // this destructor to prevent one of the thread's tasks from accessing member
+  // fields after they are destroyed.
+  updater_thread_.reset();
+}
+
+void UpdaterModule::Suspend() {
+  if (is_updater_running_) {
+    is_updater_running_ = false;
+    {
+      base::ScopedBlockingCall scoped_blocking_call(
+          FROM_HERE, base::BlockingType::MAY_BLOCK);
+      updater_thread_->task_runner()->PostTask(
+          FROM_HERE,
+          base::BindOnce(&UpdaterModule::Finalize, base::Unretained(this)));
+    }
+  }
+}
+
+void UpdaterModule::Resume() {
+  if (!is_updater_running_) {
+    is_updater_running_ = true;
+    updater_thread_->task_runner()->PostTask(
+        FROM_HERE,
+        base::BindOnce(&UpdaterModule::Initialize, base::Unretained(this),
+                       url_loader_factory_->Clone()));
+  }
+}
+
+void UpdaterModule::Initialize(
+    std::unique_ptr<network::PendingSharedURLLoaderFactory> pending_factory) {
+  DCHECK(updater_thread_->GetDefaultTaskRunner()->BelongsToCurrentThread());
+  LOG(INFO) << "UpdaterModule::Initialize";
+
+  updater_configurator_ = base::MakeRefCounted<Configurator>(
+      network::SharedURLLoaderFactory::Create(std::move(pending_factory)));
+  update_client_ = update_client::UpdateClientFactory(updater_configurator_);
+
+  updater_observer_.reset(new Observer(update_client_, updater_configurator_));
+  update_client_->AddObserver(updater_observer_.get());
+
+  // Schedule the first update check.
+
+  LOG(INFO) << "Scheduling UpdateCheck with delay "
+            << update_check_delay_.InSeconds() << " seconds";
+  updater_thread_->task_runner()->PostDelayedTask(
+      FROM_HERE, base::BindOnce(&UpdaterModule::Update, base::Unretained(this)),
+      update_check_delay_);
+}
+
+void UpdaterModule::Finalize() {
+  DCHECK(updater_thread_->GetDefaultTaskRunner()->BelongsToCurrentThread());
+  LOG(INFO) << "UpdaterModule::Finalize begin";
+  update_client_->RemoveObserver(updater_observer_.get());
+  updater_observer_.reset();
+  update_client_->Stop();
+  update_client_ = nullptr;
+
+  if (updater_configurator_ != nullptr) {
+    auto pref_service = updater_configurator_->GetPrefService();
+    if (pref_service != nullptr) {
+      pref_service->CommitPendingWrite(base::DoNothing());
+    }
+  }
+
+  updater_configurator_ = nullptr;
+
+  // Cleanup drain files
+  const auto installation_manager =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+  if (installation_manager) {
+    CobaltSlotManagement cobalt_slot_management;
+    if (cobalt_slot_management.Init(installation_manager)) {
+      cobalt_slot_management.CleanupAllDrainFiles();
+    }
+  }
+  LOG(INFO) << "UpdaterModule::Finalize end";
+}
+
+void UpdaterModule::MarkSuccessful() {
+  updater_thread_->task_runner()->PostTask(
+      FROM_HERE, base::BindOnce(&UpdaterModule::MarkSuccessfulImpl,
+                                base::Unretained(this)));
+}
+
+void UpdaterModule::MarkSuccessfulImpl() {
+  DCHECK(updater_thread_->GetDefaultTaskRunner()->BelongsToCurrentThread());
+  LOG(INFO) << "UpdaterModule::MarkSuccessfulImpl";
+
+  auto installation_manager =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+  if (!installation_manager) {
+    LOG(ERROR) << "Updater failed to get installation manager extension.";
+    return;
+  }
+  int index = installation_manager->GetCurrentInstallationIndex();
+  if (index == IM_EXT_ERROR) {
+    LOG(ERROR) << "Updater failed to get current installation index.";
+    return;
+  }
+  if (installation_manager->MarkInstallationSuccessful(index) !=
+      IM_EXT_SUCCESS) {
+    LOG(ERROR) << "Updater failed to mark the current installation successful";
+  }
+}
+
+void UpdaterModule::Update() {
+  DCHECK(updater_thread_->GetDefaultTaskRunner()->BelongsToCurrentThread());
+  LOG(INFO) << "UpdaterModule::Update";
+
+  // If updater_configurator_ is nullptr, the updater is suspended.
+  if (updater_configurator_ == nullptr) {
+    return;
+  }
+  const std::vector<std::string> app_ids = {
+      updater_configurator_->GetAppGuid()};
+
+  const base::Version manifest_version(GetCurrentEvergreenVersion());
+  if (!manifest_version.IsValid()) {
+    LOG(ERROR) << "Updater failed to get the current update version.";
+    return;
+  }
+
+#if !defined(COBALT_BUILD_TYPE_GOLD)
+  bool skip_verify_public_key_hash = GetAllowSelfSignedPackages();
+  bool require_network_encryption = GetRequireNetworkEncryption();
+#else
+  bool skip_verify_public_key_hash = false;
+  bool require_network_encryption = true;
+#endif  // defined(COBALT_BUILD_TYPE_GOLD)
+
+  update_client_->Update(
+      app_ids,
+      base::BindOnce(
+          [](base::Version manifest_version, bool skip_verify_public_key_hash,
+             bool require_network_encryption,
+             const std::vector<std::string>& ids)
+              -> std::vector<absl::optional<update_client::CrxComponent>> {
+            update_client::CrxComponent component;
+            component.name = "cobalt";
+            component.app_id = ids[0];
+            component.version = manifest_version;
+            component.pk_hash.assign(std::begin(kCobaltPublicKeyHash),
+                                     std::end(kCobaltPublicKeyHash));
+            component.requires_network_encryption = true;
+#if !defined(COBALT_BUILD_TYPE_GOLD)
+            if (skip_verify_public_key_hash) {
+              component.pk_hash.clear();
+            }
+            component.requires_network_encryption = require_network_encryption;
+#endif  // !defined(COBALT_BUILD_TYPE_GOLD)
+            component.crx_format_requirement = crx_file::VerifierFormat::CRX3;
+            return {component};
+          },
+          manifest_version, skip_verify_public_key_hash,
+          require_network_encryption),
+      {}, false, base::DoNothing());
+
+  IncrementUpdateCheckCount();
+
+  int kNextUpdateCheckHours = 0;
+  if (GetUpdateCheckCount() == 1) {
+    // Update check ran once. The next check will be scheduled at a randomized
+    // time between 1 and 24 hours.
+    kNextUpdateCheckHours = base::RandInt(1, 24);
+  } else {
+    // Update check ran at least twice. The next check will be scheduled in 24
+    // hours.
+    kNextUpdateCheckHours = 24;
+  }
+  updater_thread_->task_runner()->PostDelayedTask(
+      FROM_HERE, base::BindOnce(&UpdaterModule::Update, base::Unretained(this)),
+      base::TimeDelta(base::Hours(kNextUpdateCheckHours)));
+}
+
+// The following methods are called by other threads than the updater_thread_.
+
+void UpdaterModule::CompareAndSwapForcedUpdate(int old_value, int new_value) {
+  auto config = updater_configurator_;
+  if (config) {
+    config->CompareAndSwapForcedUpdate(old_value, new_value);
+  }
+}
+
+std::string UpdaterModule::GetUpdaterChannel() const {
+  LOG(INFO) << "UpdaterModule::GetUpdaterChannel";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR) << "UpdaterModule::GetUpdaterChannel: missing configurator";
+    return "";
+  }
+
+  std::string channel = config->GetChannel();
+  LOG(INFO) << "UpdaterModule::GetUpdaterChannel channel=" << channel;
+  return channel;
+}
+
+void UpdaterModule::SetUpdaterChannel(const std::string& updater_channel) {
+  LOG(INFO) << "UpdaterModule::SetUpdaterChannel updater_channel="
+            << updater_channel;
+  auto config = updater_configurator_;
+  if (config) {
+    config->SetChannel(updater_channel);
+  }
+}
+
+std::string UpdaterModule::GetUpdaterStatus() const {
+  LOG(INFO) << "UpdaterModule::GetUpdaterStatus";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR) << "UpdaterModule::GetUpdaterStatus: missing configurator";
+    return "";
+  }
+
+  std::string updater_status = config->GetUpdaterStatus();
+  LOG(INFO) << "UpdaterModule::GetUpdaterStatus updater_status="
+            << updater_status;
+  return updater_status;
+}
+
+void UpdaterModule::RunUpdateCheck() {
+  updater_thread_->task_runner()->PostTask(
+      FROM_HERE,
+      base::BindOnce(&UpdaterModule::Update, base::Unretained(this)));
+}
+
+void UpdaterModule::ResetInstallations() {
+  auto installation_manager =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+  if (!installation_manager) {
+    LOG(ERROR) << "Updater failed to get installation manager extension.";
+    return;
+  }
+  if (installation_manager->Reset() == IM_EXT_ERROR) {
+    LOG(ERROR) << "Updater failed to reset installations.";
+    return;
+  }
+  base::FilePath product_data_dir;
+  if (!GetProductDirectoryPath(&product_data_dir)) {
+    LOG(ERROR) << "Updater failed to get product directory path.";
+    return;
+  }
+  if (!starboard::SbFileDeleteRecursive(product_data_dir.value().c_str(),
+                                        true)) {
+    LOG(ERROR) << "Updater failed to clean the product directory.";
+    return;
+  }
+}
+
+int UpdaterModule::GetInstallationIndex() const {
+  auto installation_manager =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+  if (!installation_manager) {
+    LOG(ERROR) << "Updater failed to get installation manager extension.";
+    return -1;
+  }
+  int index = installation_manager->GetCurrentInstallationIndex();
+  if (index == IM_EXT_ERROR) {
+    LOG(ERROR) << "Updater failed to get current installation index.";
+    return -1;
+  }
+  return index;
+}
+
+void UpdaterModule::SetMinFreeSpaceBytes(uint64_t bytes) {
+  LOG(INFO) << "UpdaterModule::SetMinFreeSpaceBytes bytes=" << bytes;
+  if (updater_configurator_) {
+    updater_configurator_->SetMinFreeSpaceBytes(bytes);
+  }
+}
+
+// TODO(b/244367569): refactor similar getter and setter methods in this class
+// to share common code.
+bool UpdaterModule::GetUseCompressedUpdates() const {
+  LOG(INFO) << "UpdaterModule::GetUseCompressedUpdates";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR) << "UpdaterModule::GetUseCompressedUpdates: missing "
+               << "configurator";
+    return false;
+  }
+
+  bool use_compressed_updates = config->GetUseCompressedUpdates();
+  LOG(INFO) << "UpdaterModule::GetUseCompressedUpdates use_compressed_updates="
+            << use_compressed_updates;
+  return use_compressed_updates;
+}
+
+void UpdaterModule::SetUseCompressedUpdates(bool use_compressed_updates) {
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR) << "UpdaterModule::SetUseCompressedUpdates: missing "
+               << "configurator";
+    return;
+  }
+
+  LOG(INFO) << "UpdaterModule::SetUseCompressedUpdates use_compressed_updates="
+            << use_compressed_updates;
+  config->SetUseCompressedUpdates(use_compressed_updates);
+}
+
+bool UpdaterModule::GetAllowSelfSignedPackages() const {
+  LOG(INFO) << "UpdaterModule::GetAllowSelfSignedPackages";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR)
+        << "UpdaterModule::GetAllowSelfSignedPackages: missing configurator";
+    return false;
+  }
+
+  bool allow_self_signed_builds = config->GetAllowSelfSignedPackages();
+  LOG(INFO)
+      << "UpdaterModule::GetAllowSelfSignedPackages allow_self_signed_builds="
+      << allow_self_signed_builds;
+  return allow_self_signed_builds;
+}
+
+void UpdaterModule::SetAllowSelfSignedPackages(bool allow_self_signed_builds) {
+  LOG(INFO) << "UpdaterModule::SetAllowSelfSignedPackages";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR)
+        << "UpdaterModule::SetAllowSelfSignedPackages: missing configurator";
+    return;
+  }
+
+  config->SetAllowSelfSignedPackages(allow_self_signed_builds);
+}
+
+std::string UpdaterModule::GetUpdateServerUrl() const {
+  LOG(INFO) << "UpdaterModule::GetUpdateServerUrl";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR) << "UpdaterModule::GetUpdateServerUrl: missing configurator";
+    return "";
+  }
+
+  std::string update_server_url = config->GetUpdateServerUrl();
+  LOG(INFO) << "UpdaterModule::GetUpdateServerUrl update_server_url="
+            << update_server_url;
+  return update_server_url;
+}
+
+void UpdaterModule::SetUpdateServerUrl(const std::string& update_server_url) {
+  LOG(INFO) << "UpdaterModule::SetUpdateServerUrl";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR) << "UpdaterModule::SetUpdateServerUrl: missing configurator";
+    return;
+  }
+
+  config->SetUpdateServerUrl(update_server_url);
+}
+
+bool UpdaterModule::GetRequireNetworkEncryption() const {
+  LOG(INFO) << "UpdaterModule::GetRequireNetworkEncryption";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR)
+        << "UpdaterModule::GetRequireNetworkEncryption: missing configurator";
+    return true;
+  }
+
+  bool require_network_encryption = config->GetRequireNetworkEncryption();
+  LOG(INFO) << "UpdaterModule::GetRequireNetworkEncryption "
+               "require_network_encryption="
+            << require_network_encryption;
+  return require_network_encryption;
+}
+
+void UpdaterModule::SetRequireNetworkEncryption(
+    bool require_network_encryption) {
+  LOG(INFO) << "UpdaterModule::SetRequireNetworkEncryption";
+  auto config = updater_configurator_;
+  if (!config) {
+    LOG(ERROR)
+        << "UpdaterModule::SetRequireNetworkEncryption: missing configurator";
+    return;
+  }
+
+  config->SetRequireNetworkEncryption(require_network_encryption);
+}
+
+}  // namespace updater
+}  // namespace cobalt

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -1,0 +1,205 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_UPDATER_UPDATER_MODULE_H_
+#define COBALT_UPDATER_UPDATER_MODULE_H_
+
+#include <map>
+#include <memory>
+#include <string>
+
+#include "base/memory/scoped_refptr.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/threading/thread.h"
+#include "base/threading/thread_checker.h"
+#include "base/time/time.h"
+#include "cobalt/updater/configurator.h"
+#include "components/prefs/pref_service.h"
+#include "components/update_client/crx_update_item.h"
+#include "components/update_client/update_client.h"
+#include "services/network/public/cpp/shared_url_loader_factory.h"
+#include "starboard/event.h"
+#include "starboard/extension/updater_notification.h"
+
+// TODO(b/449223391): Revist and document the usage of base::Unretained()
+
+namespace cobalt {
+namespace updater {
+
+using update_client::ComponentState;
+
+enum class UpdaterStatus {
+  kNewUpdate,
+  kChecking,
+  kUpdateAvailable,
+  kDownloadingDiff,
+  kDownloading,
+  kSlotLocked,
+  kDownloaded,
+  kUpdatingDiff,
+  kUpdating,
+  kUpdated,
+  kRolledForward,
+  kUpToDate,
+  kUpdateError,
+  kUninstalled,
+  kRun
+};
+
+// Mapping a component state to an updater status. Used when logging and
+// processing the updater status.
+// clang-format off
+const std::map<ComponentState, UpdaterStatus> component_to_updater_status_map = {
+        // clang-format on
+        {ComponentState::kNew, UpdaterStatus::kNewUpdate},
+        {ComponentState::kChecking, UpdaterStatus::kChecking},
+        {ComponentState::kCanUpdate, UpdaterStatus::kUpdateAvailable},
+        {ComponentState::kDownloadingDiff, UpdaterStatus::kDownloadingDiff},
+        {ComponentState::kDownloading, UpdaterStatus::kDownloading},
+        {ComponentState::kDownloaded, UpdaterStatus::kDownloaded},
+        {ComponentState::kUpdatingDiff, UpdaterStatus::kUpdatingDiff},
+        {ComponentState::kUpdating, UpdaterStatus::kUpdating},
+        {ComponentState::kUpdated, UpdaterStatus::kUpdated},
+        {ComponentState::kUpToDate, UpdaterStatus::kUpToDate},
+        {ComponentState::kUpdateError, UpdaterStatus::kUpdateError},
+        {ComponentState::kUninstalled, UpdaterStatus::kUninstalled},
+        {ComponentState::kRun, UpdaterStatus::kRun},
+};
+
+// Translating an updater status to a status string. Used when logging the
+// status and passing the status to the app to show in the UI.
+const std::map<UpdaterStatus, const char*> updater_status_string_map = {
+    {UpdaterStatus::kNewUpdate, "Will check for update soon"},
+    {UpdaterStatus::kChecking, "Checking for update"},
+    {UpdaterStatus::kUpdateAvailable, "Update is available"},
+    {UpdaterStatus::kDownloadingDiff, "Downloading delta update"},
+    {UpdaterStatus::kDownloading, "Downloading update"},
+    {UpdaterStatus::kSlotLocked, "Slot is locked"},
+    {UpdaterStatus::kDownloaded, "Update is downloaded"},
+    {UpdaterStatus::kUpdatingDiff, "Installing delta update"},
+    {UpdaterStatus::kUpdating, "Installing update"},
+    {UpdaterStatus::kUpdated, "Update installed, pending restart"},
+    {UpdaterStatus::kRolledForward, "Updated locally, pending restart"},
+    {UpdaterStatus::kUpToDate, "App is up to date"},
+    {UpdaterStatus::kUpdateError, "Failed to update"},
+    {UpdaterStatus::kUninstalled, "Update uninstalled"},
+    {UpdaterStatus::kRun, "Transitioning..."},
+};
+
+// Default delay the first update check.
+extern const base::TimeDelta kDefaultUpdateCheckDelay;
+
+// An interface that observes the updater. It provides notifications when the
+// updater changes status.
+class Observer : public update_client::UpdateClient::Observer {
+ public:
+  Observer(scoped_refptr<update_client::UpdateClient> update_client,
+           scoped_refptr<Configurator> updater_configurator)
+      : update_client_(update_client),
+        updater_configurator_(updater_configurator) {
+    const CobaltExtensionUpdaterNotificationApi* updater_notification_ext =
+        static_cast<const CobaltExtensionUpdaterNotificationApi*>(
+            SbSystemGetExtension(kCobaltExtensionUpdaterNotificationName));
+    if (updater_notification_ext &&
+        strcmp(updater_notification_ext->name,
+               kCobaltExtensionUpdaterNotificationName) == 0 &&
+        updater_notification_ext->version >= 1) {
+      updater_notification_ext_ = updater_notification_ext;
+    } else {
+      updater_notification_ext_ = nullptr;
+    }
+  }
+
+  // Overrides for update_client::UpdateClient::Observer.
+  void OnEvent(Events event, const std::string& id) override;
+
+ private:
+  scoped_refptr<update_client::UpdateClient> update_client_;
+  scoped_refptr<Configurator> updater_configurator_;
+  update_client::CrxUpdateItem crx_update_item_;
+  const CobaltExtensionUpdaterNotificationApi* updater_notification_ext_;
+};
+
+// UpdaterModule checks for available Cobalt update and downloads the update
+// that matches the underlying Starboard ABI (SABI) configuration. Then
+// the update is unpacked to a dedicated location for installation. The update
+// checks run according to a schedule defined by the Cobalt application.
+//
+// Manages the update process for Cobalt, including checking for updates,
+// downloading them, and preparing them for installation.
+// Exists for the duration of the application's runtime.
+// The update checks and downloads are performed on a dedicated updater
+// thread.
+class UpdaterModule {
+ public:
+  explicit UpdaterModule(scoped_refptr<network::SharedURLLoaderFactory>,
+                         base::TimeDelta update_check_delay);
+  ~UpdaterModule();
+
+  void Suspend();
+  void Resume();
+
+  std::string GetUpdaterChannel() const;
+  void SetUpdaterChannel(const std::string& updater_channel);
+
+  void CompareAndSwapForcedUpdate(int old_value, int new_value);
+
+  void RunUpdateCheck();
+
+  std::string GetUpdaterStatus() const;
+
+  void ResetInstallations();
+
+  int GetInstallationIndex() const;
+
+  void SetMinFreeSpaceBytes(uint64_t bytes);
+
+  bool GetUseCompressedUpdates() const;
+  void SetUseCompressedUpdates(bool use_compressed_updates);
+
+  bool GetAllowSelfSignedPackages() const;
+  void SetAllowSelfSignedPackages(bool allow_self_signed_packages);
+
+  std::string GetUpdateServerUrl() const;
+  void SetUpdateServerUrl(const std::string& update_server_url);
+
+  bool GetRequireNetworkEncryption() const;
+  void SetRequireNetworkEncryption(bool require_network_encryption);
+
+  void MarkSuccessful();
+
+ private:
+  std::unique_ptr<base::Thread> updater_thread_;
+  scoped_refptr<update_client::UpdateClient> update_client_;
+  std::unique_ptr<Observer> updater_observer_;
+  scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
+  scoped_refptr<Configurator> updater_configurator_;
+  int update_check_count_ = 0;
+  bool is_updater_running_;
+  base::TimeDelta update_check_delay_ = kDefaultUpdateCheckDelay;
+
+  int GetUpdateCheckCount() { return update_check_count_; }
+  void IncrementUpdateCheckCount() { update_check_count_++; }
+
+  void Initialize(
+      std::unique_ptr<network::PendingSharedURLLoaderFactory> pending_factory);
+  void Finalize();
+  void MarkSuccessfulImpl();
+  void Update();
+};
+
+}  // namespace updater
+}  // namespace cobalt
+
+#endif  // COBALT_UPDATER_UPDATER_MODULE_H_

--- a/cobalt/updater/util.cc
+++ b/cobalt/updater/util.cc
@@ -1,0 +1,311 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/updater/util.h"
+
+#include <sys/stat.h>
+
+#include <memory>
+#include <vector>
+
+#include "base/base_paths.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/logging.h"
+#include "base/path_service.h"
+#include "base/strings/strcat.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/values.h"
+#include "build/build_config.h"
+#include "components/update_client/utils.h"
+#include "crypto/secure_hash.h"
+#include "crypto/sha2.h"
+#include "starboard/configuration_constants.h"
+#include "starboard/extension/installation_manager.h"
+#include "starboard/file.h"
+#include "starboard/system.h"
+
+#define PRODUCT_FULLNAME_STRING "cobalt_updater"
+
+namespace cobalt {
+namespace updater {
+namespace {
+// Path to compressed Cobalt library, relative to the installation directory.
+const char kCompressedLibraryPath[] = "lib/libcobalt.lz4";
+
+// Path to uncompressed Cobalt library, relative to the installation directory.
+const char kUncompressedLibraryPath[] = "lib/libcobalt.so";
+
+}  // namespace
+
+const std::unordered_map<std::string, std::string>
+    kChannelAndSbVersionToOmahaIdMap = {
+        {"control14", "{5F96FC23-F232-40B6-B283-FAD8DB21E1A7}"},
+        {"control15", "{409F15C9-4E10-4224-9DD1-BEE7E5A2A55B}"},
+        {"control16", "{30061C09-D926-4B82-8D42-600C06B6134C}"},
+        {"experiment14", "{9BCC272B-3F78-43FD-9B34-A3810AE1B85D}"},
+        {"experiment15", "{C412A665-9BAD-4981-93C0-264233720222}"},
+        {"experiment16", "{32B5CF5A-96A4-4F64-AD0E-7C62705222FF}"},
+        {"prod14", "{B3F9BCA2-8AD1-448F-9829-BB9F432815DE}"},
+        {"prod15", "{14ED1D09-DAD2-4FB2-A89B-3ADC82137BCD}"},
+        {"prod16", "{10F11416-0D9C-4CB1-A82A-0168594E8256}"},
+        {"qa14", "{94C5D27F-5981-46E8-BD4F-4645DBB5AFD3}"},
+        {"qa15", "{14ED1D09-DAD2-4FB2-A89B-3ADC82137BCD}"},
+        {"qa16", "{B725A22D-553A-49DC-BD61-F042B07C6B22}"},
+        {"rollback14", "{A83768A9-9556-48C2-8D5E-D7C845C16C19}"},
+        {"rollback15", "{1526831E-B130-43C1-B31A-AEE6E90063ED}"},
+        {"rollback16", "{2A1FCBE4-E4F9-4DC3-9E1A-700FBC1D551B}"},
+        {"static14", "{8001FE2C-F523-4AEC-A753-887B5CC35EBB}"},
+        {"static15", "{F58B7C5F-8DC5-4E32-8CF1-455F1302D609}"},
+        {"static16", "{A68BE0E4-7EE3-451A-9395-A789518FF7C5}"},
+        {"t1app14", "{7C8BCB72-705D-41A6-8189-D8312E795302}"},
+        {"t1app15", "{12A94004-F661-42A7-9DFC-325A4DA72D29}"},
+        {"t1app16", "{B677F645-A8DB-4014-BD95-C6C06715C7CE}"},
+        {"tcrash14", "{328C380E-75B4-4D7A-BF98-9B443ABA8FFF}"},
+        {"tcrash15", "{1A924F1C-A46D-4104-8CCE-E8DB3C6E0ED1}"},
+        {"tcrash16", "{0F876BD6-7C15-4B09-8C95-9FBBA2F93E94}"},
+        {"test14", "{DB2CC00C-4FA9-4DB8-A947-647CEDAEBF29}"},
+        {"test15", "{24A8A3BF-5944-4D5C-A5C4-BE00DF0FB9E1}"},
+        {"test16", "{5EADD81E-A98E-4F8B-BFAA-875509A51991}"},
+        {"tfailv14", "{F06C3516-8706-4579-9493-881F84606E98}"},
+        {"tfailv15", "{36CFD9A7-1A73-4E8A-AC05-E3013CC4F75C}"},
+        {"tfailv16", "{8F9EC6E9-B89D-4C75-9E7E-A5B9B0254844}"},
+        {"tmsabi14", "{87EDA0A7-ED13-4A72-9CD9-EBD4BED081AB}"},
+        {"tmsabi15", "{60296D57-2572-4B16-89EC-C9DA5A558E8A}"},
+        {"tmsabi16", "{1B915523-8ADD-4C66-9E8F-D73FB48A4296}"},
+        {"tnoop14", "{C407CF3F-21A4-47AA-9667-63E7EEA750CB}"},
+        {"tnoop15", "{FC568D82-E608-4F15-95F0-A539AB3F6E9D}"},
+        {"tnoop16", "{5F4E8AD9-067B-443A-8B63-A7CC4C95B264}"},
+        {"tseries114", "{0A8A3F51-3FAB-4427-848E-28590DB75AA1}"},
+        {"tseries115", "{92B7AC78-1B3B-4CE6-BA39-E1F50C4F5F72}"},
+        {"tseries116", "{6E7C6582-3DC4-4B48-97F2-FA43614B2B4D}"},
+        {"tseries214", "{7CB65840-5FA4-4706-BC9E-86A89A56B4E0}"},
+        {"tseries215", "{7CCA7DB3-C27D-4CEB-B6A5-50A4D6DE40DA}"},
+        {"tseries216", "{012BF4F5-8463-490F-B6C8-E9B64D972152}"},
+};
+
+const char kDefaultManifestVersion[] = "1.0.0";
+
+const char kOmahaCobaltAppID[] = "{6D4E53F3-CC64-4CB8-B6BD-AB0B8F300E1C}";
+const char kOmahaCobaltLTSNightlyAppID[] =
+    "{26CD2F67-091F-4680-A9A9-2229635B65A5}";
+const char kOmahaCobaltTrunkAppID[] = "{A9557415-DDCD-4948-8113-C643EFCF710C}";
+
+bool CreateProductDirectory(base::FilePath* path) {
+  if (!GetProductDirectoryPath(path)) {
+    LOG(ERROR) << "Can't get product directory path";
+    return false;
+  }
+  if (!base::CreateDirectory(*path)) {
+    LOG(ERROR) << "Can't create product directory.";
+    return false;
+  }
+  return true;
+}
+
+bool GetProductDirectoryPath(base::FilePath* path) {
+  std::vector<char> storage_dir(kSbFileMaxPath);
+  if (!SbSystemGetPath(kSbSystemPathStorageDirectory, storage_dir.data(),
+                       kSbFileMaxPath)) {
+    LOG(ERROR) << "GetProductDirectoryPath: Failed to get "
+                  "kSbSystemPathStorageDirectory";
+    return false;
+  }
+  base::FilePath app_data_dir(storage_dir.data());
+  const auto product_data_dir =
+      app_data_dir.AppendASCII(PRODUCT_FULLNAME_STRING);
+
+  *path = product_data_dir;
+  return true;
+}
+
+base::Version ReadEvergreenVersion(base::FilePath installation_dir) {
+  auto manifest = update_client::ReadManifest(installation_dir);
+  if (manifest) {
+    auto version = manifest->Find("version");
+    if (version) {
+      return base::Version(version->GetString());
+    }
+  }
+  return base::Version();
+}
+
+const std::string GetEvergreenFileType(const std::string& installation_path) {
+  std::string compressed_library_path = base::StrCat(
+      {installation_path, kSbFileSepString, kCompressedLibraryPath});
+  std::string uncompressed_library_path = base::StrCat(
+      {installation_path, kSbFileSepString, kUncompressedLibraryPath});
+  struct stat file_info;
+  if (stat(compressed_library_path.c_str(), &file_info) == 0) {
+    return "Compressed";
+  }
+  if (stat(uncompressed_library_path.c_str(), &file_info) == 0) {
+    return "Uncompressed";
+  }
+  LOG(ERROR) << "Failed to get Evergreen file type. Defaulting to "
+                "FileTypeUnknown.";
+  return "FileTypeUnknown";
+}
+
+const base::FilePath GetLoadedInstallationPath() {
+  std::vector<char> system_path_content_dir(kSbFileMaxPath);
+  if (!SbSystemGetPath(kSbSystemPathContentDirectory,
+                       system_path_content_dir.data(), kSbFileMaxPath)) {
+    LOG(ERROR) << "Failed to get system path content directory";
+    return base::FilePath();
+  }
+  // Since the Cobalt library has already been loaded,
+  // kSbSystemPathContentDirectory points to the content dir of the running
+  // library and the installation dir is therefore its parent.
+  return base::FilePath(std::string(system_path_content_dir.begin(),
+                                    system_path_content_dir.end()))
+      .DirName();
+}
+
+const base::FilePath FindInstallationPath(
+    std::function<const void*(const char*)> get_extension_fn) {
+  // TODO(b/233914266): consider using base::NoDestructor to give the
+  // installation path static duration once found.
+
+  auto installation_manager =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          get_extension_fn(kCobaltExtensionInstallationManagerName));
+  if (!installation_manager) {
+    LOG(ERROR) << "Failed to get installation manager extension, getting the "
+                  "installation path of the loaded library.";
+    return GetLoadedInstallationPath();
+  }
+  // Get the update version from the manifest file under the current
+  // installation path.
+  int index = installation_manager->GetCurrentInstallationIndex();
+  if (index == IM_EXT_ERROR) {
+    LOG(ERROR) << "Failed to get current installation index, getting the "
+                  "installation path of the loaded library.";
+    return GetLoadedInstallationPath();
+  }
+  std::vector<char> installation_path(kSbFileMaxPath);
+  if (installation_manager->GetInstallationPath(
+          index, installation_path.data(), kSbFileMaxPath) == IM_EXT_ERROR) {
+    LOG(ERROR) << "Failed to get installation path from the installation "
+                  "manager, getting the installation path of the loaded "
+                  "library.";
+    return GetLoadedInstallationPath();
+  }
+  return base::FilePath(
+      std::string(installation_path.begin(), installation_path.end()));
+}
+
+const std::string GetValidOrDefaultEvergreenVersion(
+    const base::FilePath installation_path) {
+  base::Version version = ReadEvergreenVersion(installation_path);
+
+  if (!version.IsValid()) {
+    LOG(ERROR) << "Failed to get the Evergreen version. Defaulting to "
+               << kDefaultManifestVersion << ".";
+    return std::string(kDefaultManifestVersion);
+  }
+  return version.GetString();
+}
+
+const std::string GetCurrentEvergreenVersion(
+    std::function<const void*(const char*)> get_extension_fn) {
+  base::FilePath installation_path = FindInstallationPath(get_extension_fn);
+  return GetValidOrDefaultEvergreenVersion(installation_path);
+}
+
+EvergreenLibraryMetadata GetCurrentEvergreenLibraryMetadata(
+    std::function<const void*(const char*)> get_extension_fn) {
+  EvergreenLibraryMetadata evergreen_library_metadata;
+  base::FilePath installation_path = FindInstallationPath(get_extension_fn);
+
+  evergreen_library_metadata.version =
+      GetValidOrDefaultEvergreenVersion(installation_path);
+  evergreen_library_metadata.file_type =
+      GetEvergreenFileType(installation_path.value());
+
+  return evergreen_library_metadata;
+}
+
+std::string GetLibrarySha256(int index) {
+  base::FilePath filepath;
+  auto installation_manager =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+  if (!installation_manager && index == 0) {
+    // Evergreen Lite
+    std::vector<char> system_path_content_dir(kSbFileMaxPath);
+    if (!SbSystemGetPath(kSbSystemPathContentDirectory,
+                         system_path_content_dir.data(), kSbFileMaxPath)) {
+      LOG(ERROR)
+          << "GetLibrarySha256: Failed to get system path content directory";
+      return "";
+    }
+
+    filepath = base::FilePath(std::string(system_path_content_dir.begin(),
+                                          system_path_content_dir.end()))
+                   .DirName();
+  } else if (!installation_manager && index != 0) {
+    LOG(ERROR) << "GetLibrarySha256: Evergreen lite supports only slot 0";
+    return "";
+  } else {
+    // Evergreen Full
+    std::vector<char> installation_path(kSbFileMaxPath);
+    if (installation_manager->GetInstallationPath(
+            index, installation_path.data(), kSbFileMaxPath) == IM_EXT_ERROR) {
+      LOG(ERROR) << "GetLibrarySha256: Failed to get installation path";
+      return "";
+    }
+
+    filepath = base::FilePath(installation_path.data());
+  }
+
+  filepath = filepath.AppendASCII("lib").AppendASCII("libcobalt.so");
+  base::File source_file(filepath,
+                         base::File::FLAG_OPEN | base::File::FLAG_READ);
+  if (!source_file.IsValid()) {
+    LOG(ERROR) << "GetLibrarySha256(): Unable to open source file: "
+               << filepath.value();
+    return "";
+  }
+
+  const size_t kBufferSize = 32768;
+  // TODO(b/452143961): Fix the discrepancy between char and uint8_t
+  std::vector<char> buffer(kBufferSize);
+  uint8_t actual_hash[crypto::kSHA256Length] = {0};
+  std::unique_ptr<crypto::SecureHash> hasher(
+      crypto::SecureHash::Create(crypto::SecureHash::SHA256));
+
+  while (true) {
+    int bytes_read = source_file.ReadAtCurrentPos(&buffer[0], buffer.size());
+    if (bytes_read < 0) {
+      LOG(ERROR) << "GetLibrarySha256(): error reading from: "
+                 << filepath.value();
+
+      return "";
+    }
+
+    if (bytes_read == 0) {
+      break;
+    }
+
+    hasher->Update(&buffer[0], bytes_read);
+  }
+
+  hasher->Finish(actual_hash, sizeof(actual_hash));
+
+  return base::HexEncode(actual_hash, sizeof(actual_hash));
+}
+
+}  // namespace updater
+}  // namespace cobalt

--- a/cobalt/updater/util.h
+++ b/cobalt/updater/util.h
@@ -1,0 +1,81 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_UPDATER_UTIL_H_
+#define COBALT_UPDATER_UTIL_H_
+
+#include <functional>
+#include <string>
+#include <unordered_map>
+
+#include "base/version.h"
+#include "starboard/system.h"
+
+namespace base {
+class FilePath;
+}
+
+namespace cobalt {
+namespace updater {
+
+// Map of Omaha config IDs with channel and starboard version as indices.
+extern const std::unordered_map<std::string, std::string>
+    kChannelAndSbVersionToOmahaIdMap;
+
+// The default manifest version to assume when the actual manifest cannot be
+// parsed for any reason. This should not be used for installation manager
+// errors, or any other error unrelated to parsing the manifest.
+extern const char kDefaultManifestVersion[];
+
+// Legacy prod config containing all prod, tests and static channels with all
+// SB versions of C25 and prior.
+extern const char kOmahaCobaltAppID[];
+
+extern const char kOmahaCobaltLTSNightlyAppID[];
+
+extern const char kOmahaCobaltTrunkAppID[];
+
+struct EvergreenLibraryMetadata {
+  std::string version;
+  std::string file_type;
+};
+
+// Create a directory where updater files or its data is stored.
+bool CreateProductDirectory(base::FilePath* path);
+
+// Return the path to the product directory where updater files or its data is
+// stored.
+bool GetProductDirectoryPath(base::FilePath* path);
+
+// Returns the Evergreen library metadata of the current installation.
+EvergreenLibraryMetadata GetCurrentEvergreenLibraryMetadata(
+    std::function<const void*(const char*)> get_extension_fn =
+        &SbSystemGetExtension);
+
+// Returns the Evergreen version of the current installation.
+const std::string GetCurrentEvergreenVersion(
+    std::function<const void*(const char*)> get_extension_fn =
+        &SbSystemGetExtension);
+
+// Reads the Evergreen version of the installation dir.
+base::Version ReadEvergreenVersion(base::FilePath installation_dir);
+
+// Returns the hash of the libcobalt.so binary for the installation
+// at slot |index|.
+std::string GetLibrarySha256(int index);
+
+}  // namespace updater
+}  // namespace cobalt
+
+#endif  // COBALT_UPDATER_UTIL_H_

--- a/cobalt/updater/version_manifest/BUILD.gn
+++ b/cobalt/updater/version_manifest/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright 2022 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+copy("copy_version_manifest") {
+  install_content = true
+  sources = [ "manifest.json" ]
+  outputs = [ "$root_out_dir/manifest.json" ]
+}

--- a/cobalt/updater/version_manifest/manifest.json
+++ b/cobalt/updater/version_manifest/manifest.json
@@ -1,0 +1,6 @@
+{
+    "manifest_version": 2,
+    "name": "Cobalt",
+    "description": "Cobalt",
+    "version": "1.0.0"
+}

--- a/starboard/evergreen/shared/platform_configuration/BUILD.gn
+++ b/starboard/evergreen/shared/platform_configuration/BUILD.gn
@@ -46,7 +46,9 @@ config("platform_configuration") {
     # existing customizations that enable the legacy behavior for Cobalt builds,
     # change IN_MEMORY_UPDATES references to IS_COBALT references, and remove
     # this macro.
-    "IN_MEMORY_UPDATES",
+    # TODO(b/444006168): Uncomment this once in-memory updates is fully
+    # supported.
+    # "IN_MEMORY_UPDATES",
   ]
 
   if (use_asan) {


### PR DESCRIPTION
Introduces the initial MVP (Minimum Viable Product) of the Cobalt Evergreen updater. The updater is responsible for checking for new versions of the Cobalt application, downloading them, and preparing them for installation.

Key features of this initial implementation include:
   - A new updater module within the cobalt directory, containing all the core updater logic.
   - Configuration management for the update client, allowing for different update channels and servers.
   - Network fetching capabilities to download update packages.
   - Support for unzipping and patching downloaded updates.
   - Integration with the Cobalt build system and addition of new command-line switches for controlling updater behavior.

This is the foundational implementation of the updater, and will be iterated on in future commits.

Issue: 431862767