### PR TITLE
starboard: Move player classes into flattened namespace

### DIFF
--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -28,11 +28,6 @@
 #include "starboard/shared/starboard/player/player_internal.h"
 #include "starboard/shared/starboard/player/player_worker.h"
 
-using starboard::shared::starboard::player::PlayerWorker;
-using starboard::shared::starboard::player::SbPlayerPrivateImpl;
-using starboard::shared::starboard::player::filter::
-    FilterBasedPlayerWorkerHandler;
-
 SbPlayer SbPlayerCreate(SbWindow /*window*/,
                         const SbPlayerCreationParam* creation_param,
                         SbPlayerDeallocateSampleFunc sample_deallocate_func,
@@ -200,11 +195,12 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
     }
   }
 
-  std::unique_ptr<PlayerWorker::Handler> handler(
-      new FilterBasedPlayerWorkerHandler(creation_param, provider));
+  std::unique_ptr<starboard::PlayerWorker::Handler> handler =
+      std::make_unique<starboard::FilterBasedPlayerWorkerHandler>(
+          creation_param, provider);
   handler->SetMaxVideoInputSize(
       starboard::android::shared::GetMaxVideoInputSizeForCurrentThread());
-  SbPlayer player = SbPlayerPrivateImpl::CreateInstance(
+  SbPlayer player = starboard::SbPlayerPrivateImpl::CreateInstance(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
       player_status_func, player_error_func, context, std::move(handler));
 

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -31,16 +31,14 @@
 #include "starboard/shared/starboard/player/filter/video_decoder_internal.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 
-namespace starboard::shared::starboard::player::filter {
+namespace starboard {
 
 namespace {
 
-using ::starboard::GetPlayerStateName;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
-typedef shared::starboard::player::PlayerWorker::Handler::HandlerResult
-    HandlerResult;
+using HandlerResult = PlayerWorker::Handler::HandlerResult;
 
 // TODO: Make this configurable inside SbPlayerCreate().
 const int64_t kUpdateIntervalUsec = 200'000;  // 200ms
@@ -550,4 +548,4 @@ void FilterBasedPlayerWorkerHandler::SetMaxVideoInputSize(
   max_video_input_size_ = max_video_input_size;
 }
 
-}  // namespace starboard::shared::starboard::player::filter
+}  // namespace starboard

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -34,7 +34,7 @@
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "starboard/shared/starboard/player/player_worker.h"
 
-namespace starboard::shared::starboard::player::filter {
+namespace starboard {
 
 class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
                                        private JobQueue::JobOwner {
@@ -114,6 +114,6 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   const VideoStreamInfo video_stream_info_;
 };
 
-}  // namespace starboard::shared::starboard::player::filter
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_FILTER_BASED_PLAYER_WORKER_HANDLER_H_

--- a/starboard/shared/starboard/player/player_internal.cc
+++ b/starboard/shared/starboard/player/player_internal.cc
@@ -28,7 +28,7 @@
 #include SB_PLAYER_DMP_WRITER_INCLUDE_PATH
 #endif  // SB_PLAYER_ENABLE_VIDEO_DUMPER
 
-namespace starboard::shared::starboard::player {
+namespace starboard {
 namespace {
 
 using std::placeholders::_1;
@@ -255,4 +255,4 @@ SbPlayerPrivateImpl::~SbPlayerPrivateImpl() {
                << number_of_players_ << " players.";
 }
 
-}  // namespace starboard::shared::starboard::player
+}  // namespace starboard

--- a/starboard/shared/starboard/player/player_internal.h
+++ b/starboard/shared/starboard/player/player_internal.h
@@ -59,7 +59,7 @@ struct SbPlayerPrivate {
       SbMediaAudioConfiguration* out_audio_configuration) = 0;
 };
 
-namespace starboard::shared::starboard::player {
+namespace starboard {
 
 class SbPlayerPrivateImpl final : public SbPlayerPrivate {
  public:
@@ -131,6 +131,6 @@ class SbPlayerPrivateImpl final : public SbPlayerPrivate {
   static int number_of_players_;
 };
 
-}  // namespace starboard::shared::starboard::player
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_STARBOARD_PLAYER_PLAYER_INTERNAL_H_

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -28,17 +28,15 @@
 #include "starboard/common/player.h"
 #include "starboard/thread.h"
 
-namespace starboard::shared::starboard::player {
+namespace starboard {
 
 namespace {
 
-using ::starboard::GetPlayerStateName;
 using std::placeholders::_1;
 using std::placeholders::_2;
 using std::placeholders::_3;
 
-typedef shared::starboard::player::PlayerWorker::Handler::HandlerResult
-    HandlerResult;
+using HandlerResult = PlayerWorker::Handler::HandlerResult;
 
 #ifdef SB_MEDIA_PLAYER_THREAD_STACK_SIZE
 const int kPlayerStackSize = SB_MEDIA_PLAYER_THREAD_STACK_SIZE;
@@ -434,4 +432,4 @@ void PlayerWorker::UpdateDecoderState(SbMediaType type,
   decoder_status_func_(player_, context_, type, state, ticket_);
 }
 
-}  // namespace starboard::shared::starboard::player
+}  // namespace starboard

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -33,7 +33,7 @@
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "starboard/window.h"
 
-namespace starboard::shared::starboard::player {
+namespace starboard {
 
 // This class creates a thread that executes events posted to an internally
 // created queue. This guarantees that all such events are processed on the same
@@ -233,6 +233,6 @@ class PlayerWorker {
   JobQueue::JobToken write_pending_sample_job_token_;
 };
 
-}  // namespace starboard::shared::starboard::player
+}  // namespace starboard
 
 #endif  // STARBOARD_SHARED_STARBOARD_PLAYER_PLAYER_WORKER_H_


### PR DESCRIPTION
[go/cobalt-flatten-starboard-namespace](http://go/cobalt-flatten-starboard-namespace)

This change moves the core player and filter-based player classes from the `starboard::shared::starboard::player` and `starboard::shared::starboard::player::filter` namespaces into the top-level `starboard` namespace.

This refactoring is part of the ongoing effort to simplify the Starboard namespace structure. It removes unnecessary nesting and makes the player implementation more accessible and consistent with the flattened namespace design.

Bug: 441955897