### PR TITLE
[Rebase M138] Disable VLA compiler check

### DIFF
--- a/starboard/linux/shared/platform_configuration/BUILD.gn
+++ b/starboard/linux/shared/platform_configuration/BUILD.gn
@@ -75,6 +75,9 @@ config("compiler_flags") {
 
       # Do not remove null pointer checks.
       "-fno-delete-null-pointer-checks",
+
+      # Do not warn about variable length arrays
+      "-Wno-vla-cxx-extension"
     ]
 
     if (is_gold) {


### PR DESCRIPTION
Bug: 418842688

variable length arrays used in:
starboard/shared/modular/starboard_layer_posix_uio_abi_wrappers.cc
starboard/shared/linux/cpu_features_get.cc
starboard/linux/shared/pre_app_recommendation_service.cc
starboard/linux/shared/soft_mic_platform_service.cc

