### PR TITLE
Audio latency/continuous 2

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
@@ -410,6 +410,21 @@ public class AudioTrackBridge {
   }
 
   @CalledByNative
+  private AudioTimestamp getRawAudioTimestamp() {
+    if (mAudioTrack == null) {
+      Log.e(TAG, "Unable to getRawAudioTimestamp with NULL audio track.");
+      return null;
+    }
+    AudioTimestamp audioTimestamp = new AudioTimestamp();
+    if (!mAudioTrack.getTimestamp(audioTimestamp)) {
+      // AudioTrack is not ready to return timestamp.
+      return null;
+    }
+
+    return audioTimestamp;
+  }
+
+  @CalledByNative
   private int getUnderrunCount() {
     if (mAudioTrack == null) {
       Log.e(TAG, "Unable to call getUnderrunCount() with NULL audio track.");

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -40,7 +40,7 @@ using ::base::android::AttachCurrentThread;
 // into AudioTrack. Instead of callnig pause/play, it switches between silence
 // data and actual data.
 // TODO: b/186660620: Replace this constant with feature flag.
-constexpr bool kUseContinuousAudioTrackSink = false;
+constexpr bool kUseContinuousAudioTrackSink = true;
 
 // The maximum number of frames that can be written to android audio track per
 // write request. If we don't set this cap for writing frames to audio track,
@@ -494,7 +494,7 @@ SbAudioSink AudioTrackAudioSinkType::Create(
           this, channels, sampling_frequency_hz, audio_sample_type,
           frame_buffers, frames_per_channel, preferred_buffer_size_in_bytes,
           update_source_status_func, consume_frames_func, error_func,
-          start_media_time, is_web_audio, context);
+          is_web_audio, context);
       if (!continuous_sink->IsAudioTrackValid()) {
         SB_LOG(ERROR) << "Failed to create ContinuousAudioTrackSink";
         Destroy(continuous_sink);

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -76,6 +76,13 @@ class AudioTrackBridge {
   // return.  It can be nullptr.
   int64_t GetAudioTimestamp(int64_t* updated_at,
                             JNIEnv* env = base::android::AttachCurrentThread());
+
+  struct AudioTimestamp {
+    int64_t frame_position;
+    int64_t rendered_at_us;
+  };
+  std::optional<AudioTimestamp> GetRawAudioTimestamp(JNIEnv* env);
+
   bool GetAndResetHasAudioDeviceChanged(
       JNIEnv* env = base::android::AttachCurrentThread());
   int GetUnderrunCount(JNIEnv* env = base::android::AttachCurrentThread());
@@ -91,6 +98,9 @@ class AudioTrackBridge {
   // avoids an array being allocated repeatedly.
   base::android::ScopedJavaGlobalRef<jobject> j_audio_data_;
 };
+
+std::ostream& operator<<(std::ostream& os,
+                         const AudioTrackBridge::AudioTimestamp& timestamp);
 
 }  // namespace starboard
 

--- a/starboard/android/shared/continuous_audio_track_sink.cc
+++ b/starboard/android/shared/continuous_audio_track_sink.cc
@@ -21,6 +21,7 @@
 
 #include "base/android/jni_android.h"
 #include "starboard/common/check_op.h"
+#include "starboard/common/scoped_timer.h"
 #include "starboard/common/string.h"
 #include "starboard/common/time.h"
 #include "starboard/shared/starboard/media/media_util.h"
@@ -30,20 +31,29 @@
 namespace starboard {
 namespace {
 
-using ::base::android::AttachCurrentThread;
+using AudioTimestamp = AudioTrackBridge::AudioTimestamp;
 
 // The maximum number of frames that can be written to android audio track per
-// write request. If we don't set this cap for writing frames to audio track,
 // we will repeatedly allocate a large byte array which cannot be consumed by
 // audio track completely.
-const int kMaxFramesPerRequest = 64 * 1024;
+constexpr int kMaxFramesPerRequest = 64 * 1024;
+
+constexpr int kSilenceIntervalUs = 10'000;
 
 constexpr int kSilenceFramesPerAppend = 1024;
 static_assert(kSilenceFramesPerAppend <= kMaxFramesPerRequest);
 
-void* IncrementPointerByBytes(void* pointer, size_t offset) {
-  return static_cast<uint8_t*>(pointer) + offset;
+void HandleNoFramesToWrite(JNIEnv* env,
+                           const AudioSourceState& source_state,
+                           int frame_bytes,
+                           ContinuousAudioTrackSink* sink) {
+  if (source_state.is_eos_reached) {
+    std::vector<uint8_t> silence_buffer(frame_bytes * kSilenceFramesPerAppend);
+    sink->WriteData(env, silence_buffer.data(), kSilenceFramesPerAppend);
+  }
+  usleep(10'000);
 }
+
 }  // namespace
 
 ContinuousAudioTrackSink::ContinuousAudioTrackSink(
@@ -52,24 +62,23 @@ ContinuousAudioTrackSink::ContinuousAudioTrackSink(
     int sampling_frequency_hz,
     SbMediaAudioSampleType sample_type,
     SbAudioSinkFrameBuffers frame_buffers,
-    int frames_per_channel,
+    int source_buffer_frames,
     int preferred_buffer_size_in_bytes,
     SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
     ConsumeFramesFunc consume_frames_func,
     SbAudioSinkPrivate::ErrorFunc error_func,
-    int64_t start_time,
     bool is_web_audio,
     void* context)
     : type_(type),
       channels_(channels),
       sampling_frequency_hz_(sampling_frequency_hz),
       sample_type_(sample_type),
-      frame_buffer_(frame_buffers[0]),
-      frames_per_channel_(frames_per_channel),
+      frame_bytes_(channels_ * GetBytesPerSample(sample_type)),
+      frame_buffer_(static_cast<uint8_t*>(frame_buffers[0])),
+      source_buffer_frames_(source_buffer_frames),
       update_source_status_func_(update_source_status_func),
       consume_frames_func_(consume_frames_func),
       error_func_(error_func),
-      start_time_(start_time),
       context_(context),
       bridge_(kSbMediaAudioCodingTypePcm,
               sample_type,
@@ -77,12 +86,18 @@ ContinuousAudioTrackSink::ContinuousAudioTrackSink(
               sampling_frequency_hz,
               preferred_buffer_size_in_bytes,
               /*tunnel_mode_audio_session_id=*/-1,
-              is_web_audio) {
-  SB_DCHECK(update_source_status_func_);
-  SB_DCHECK(consume_frames_func_);
-  SB_DCHECK(frame_buffer_);
+              is_web_audio),
+      initial_frames_(bridge_.GetStartThresholdInFrames()),
+      silence_buffer_frames_(kSilenceIntervalUs * sampling_frequency_hz_ /
+                             1'000'000),
+      silence_buffer_(silence_buffer_frames_ * frame_bytes_) {
+  SB_CHECK(update_source_status_func_);
+  SB_CHECK(consume_frames_func_);
+  SB_CHECK(frame_buffer_);
 
-  SB_LOG(INFO) << "Creating continuous audio sink starts at " << start_time_;
+  SB_LOG(INFO) << "Creating continuous audio sink: initial_frames="
+               << initial_frames_
+               << ", initial_frames(msec)=" << GetFramesMs(initial_frames_);
 
   if (!bridge_.is_valid()) {
     // One of the cases that this may hit is when output happened to be switched
@@ -124,176 +139,264 @@ void ContinuousAudioTrackSink::SetPlaybackRate(double playback_rate) {
 // static
 void* ContinuousAudioTrackSink::ThreadEntryPoint(void* context) {
   pthread_setname_np(pthread_self(), "continous_audio_track_sink");
-  SB_DCHECK(context);
   SbThreadSetPriority(kSbThreadPriorityRealTime);
 
+  SB_CHECK(context);
   ContinuousAudioTrackSink* sink =
       reinterpret_cast<ContinuousAudioTrackSink*>(context);
   sink->AudioThreadFunc();
 
-  return NULL;
+  return nullptr;
 }
 
-// TODO: Break down the function into manageable pieces.
+int64_t ContinuousAudioTrackSink::EstimateFramePosition(
+    const std::optional<AudioTimestamp>& timestamp,
+    int64_t time_us) const {
+  if (!timestamp) {
+    // head_frame of 0 means that playback didn't start yet.
+    return 0;
+  }
+  int64_t elapsed_us = time_us - timestamp->rendered_at_us;
+  return timestamp->frame_position + GetFrames(elapsed_us);
+}
+
+std::optional<AudioTimestamp>
+ContinuousAudioTrackSink::ReportConsumedFramesToSource(
+    JNIEnv* env,
+    AudioSinkState* sink_state,
+    const std::optional<AudioTimestamp> new_timestamp,
+    const std::optional<AudioTimestamp> last_timestamp) {
+  if (!last_timestamp && new_timestamp) {
+    SB_CHECK_LE(new_timestamp->frame_position, initial_silence_frames_)
+        << "Timestamp should start from 0";
+  }
+  if (!new_timestamp) {
+    // In this iteration, we don't report any new timestamp.
+    return last_timestamp;
+  }
+
+  int64_t last_frame_position =
+      last_timestamp ? last_timestamp->frame_position : 0;
+  int64_t new_frame_position = new_timestamp->frame_position;
+
+  last_frame_position =
+      std::max(0LL, last_frame_position - initial_silence_frames_);
+  new_frame_position =
+      std::max(0LL, new_frame_position - initial_silence_frames_);
+
+  SB_CHECK_GE(new_frame_position, last_frame_position);
+  const int frames_consumed = new_frame_position - last_frame_position;
+
+  sink_state->frames_in_audio_track -= frames_consumed;
+  consume_frames_func_(frames_consumed, new_timestamp->rendered_at_us,
+                       context_);
+  return new_timestamp;
+}
+
+AudioSourceState ContinuousAudioTrackSink::GetAudioSourceState() {
+  int frames_in_buffer;
+  int offset_in_frames;
+  bool is_playing;
+  bool is_eos_reached;
+
+  update_source_status_func_(&frames_in_buffer, &offset_in_frames, &is_playing,
+                             &is_eos_reached, context_);
+  {
+    std::lock_guard lock(mutex_);
+    if (playback_rate_ == 0.0) {
+      is_playing = false;
+    }
+  }
+
+  return AudioSourceState{
+      frames_in_buffer,
+      offset_in_frames,
+      is_playing,
+      is_eos_reached,
+  };
+}
+
+void ContinuousAudioTrackSink::UpdatePlaybackState(
+    JNIEnv* env,
+    const AudioSourceState& source_state,
+    AudioSinkState* sink_state) {
+  SB_CHECK(sink_state);
+  if (source_state.is_playing == sink_state->is_playing) {
+    return;
+  }
+
+  if (source_state.is_playing) {
+    bridge_.Play();
+  } else {
+    bridge_.Pause();
+  }
+  sink_state->is_playing = source_state.is_playing;
+}
+
+std::optional<int64_t> ContinuousAudioTrackSink::WriteAudioData(
+    JNIEnv* env,
+    const AudioSourceState& source_state,
+    AudioSinkState* sink_state) {
+  SB_CHECK(sink_state);
+
+  const int total_frames_to_write =
+      source_state.frames_in_buffer - sink_state->frames_in_audio_track;
+  int total_frames_written = 0;
+
+  while (total_frames_written < total_frames_to_write) {
+    const int offset =
+        (source_state.offset_in_frames + sink_state->frames_in_audio_track) %
+        source_buffer_frames_;
+    const int frames_to_write =
+        std::min(source_buffer_frames_ - offset,
+                 std::min(total_frames_to_write - total_frames_written,
+                          kMaxFramesPerRequest));
+
+    SB_CHECK_GT(frames_to_write, 0);
+    SB_CHECK_LE(offset + frames_to_write, source_buffer_frames_)
+        << "frames_in_buffer: " << source_state.frames_in_buffer
+        << ", frames_in_audio_track: " << sink_state->frames_in_audio_track
+        << ", offset_in_frames: " << source_state.offset_in_frames;
+
+    const int frames_written = WriteData(
+        env, frame_buffer_ + (offset * frame_bytes_), frames_to_write);
+    if (frames_written == AudioTrackBridge::kAudioTrackErrorDeadObject) {
+      ReportError(/*capability_changed=*/true,
+                  "Failed to write data and received dead object error.");
+      return std::nullopt;
+    } else if (frames_written < 0) {
+      ReportError(/*capability_changed=*/false,
+                  FormatString("Failed to write data and received %d.",
+                               frames_written));
+      return std::nullopt;
+    }
+
+    sink_state->frames_in_audio_track += frames_written;
+    total_frames_written += frames_written;
+    if (frames_written < frames_to_write) {
+      // WriteSample only partially wrote given frames, which means that buffer
+      // is full.
+      return 10'000;
+    }
+  }
+
+  return 0;
+}
+
+void ContinuousAudioTrackSink::PrimeSilenceBuffer(JNIEnv* env) {
+  while (initial_silence_frames_ < initial_frames_) {
+    int frames_to_feed = std::min(silence_buffer_frames_,
+                                  initial_frames_ - initial_silence_frames_);
+    int written = WriteData(env, silence_buffer_.data(), frames_to_feed);
+    initial_silence_frames_ += written;
+  }
+  SB_LOG(INFO) << __func__ << " > initial_silence(msec)="
+               << GetFramesMs(initial_silence_frames_);
+}
+
+void ContinuousAudioTrackSink::AppendSilence(
+    JNIEnv* env,
+    std::optional<AudioTimestamp> last_timestamp) {
+  const int64_t silence_frame_head =
+      EstimateFramePosition(last_timestamp, CurrentMonotonicTime());
+  const int64_t current_silence_us = GetFramesUs(silence_frame_head);
+
+  const int64_t initial_silence_us = GetFramesUs(initial_silence_frames_);
+
+  const int64_t silence_to_play_us = initial_silence_us - current_silence_us;
+  if (silence_to_play_us > 10'000) {
+    return;
+  }
+
+  int written_frames =
+      WriteData(env, silence_buffer_.data(), silence_buffer_frames_);
+  initial_silence_frames_ += written_frames;
+
+  SB_LOG(INFO) << "Feeds silences: silence_to_play(msec)="
+               << silence_to_play_us / 1'000
+               << ", new silences(msec)=" << GetFramesMs(written_frames)
+               << ", current_media(msec)=" << current_silence_us / 1'000
+               << ", current silences fed(msec)="
+               << GetFramesMs(initial_silence_frames_);
+}
+
 void ContinuousAudioTrackSink::AudioThreadFunc() {
   JNIEnv* env = base::android::AttachCurrentThread();
-  bool was_playing = false;
-  int frames_in_audio_track = 0;
 
   SB_LOG(INFO) << "ContinuousAudioTrackSink thread started.";
 
-  int64_t last_playback_head_event_at = -1;  // microseconds
-  int last_playback_head_position = 0;
+  AudioSourceState source_state;
+  AudioSinkState sink_state;
+  std::optional<AudioTimestamp> last_reported_timestamp;
 
+  PrimeSilenceBuffer(env);
+  {
+    ScopedTimer timer("Initial Play");
+    bridge_.Play();
+  }
+  sink_state.is_playing = true;
+  sink_state.is_playing_silence = true;
+
+  bool is_first_audio_written = false;
   while (!quit_) {
-    int playback_head_position = 0;
-    int64_t frames_consumed_at = 0;
     if (bridge_.GetAndResetHasAudioDeviceChanged(env)) {
       SB_LOG(INFO) << "Audio device changed, raising a capability changed "
                       "error to restart playback.";
-      ReportError(true, "Audio device capability changed");
+      ReportError(/*capability_changed=*/true,
+                  "Audio device capability changed");
       break;
     }
 
-    if (was_playing) {
-      playback_head_position =
-          bridge_.GetAudioTimestamp(&frames_consumed_at, env);
-      SB_DCHECK_GE(playback_head_position, last_playback_head_position);
-
-      int frames_consumed =
-          playback_head_position - last_playback_head_position;
-      int64_t now = CurrentMonotonicTime();
-
-      if (last_playback_head_event_at == -1) {
-        last_playback_head_event_at = now;
+    std::optional<AudioTimestamp> timestamp = bridge_.GetRawAudioTimestamp(env);
+    if (timestamp) {
+      if (!playback_started_ &&
+          playback_frame_head_ != timestamp->frame_position) {
+        SB_LOG(INFO) << "Playback started";
+        playback_started_ = true;
       }
-      if (last_playback_head_position == playback_head_position) {
-        int64_t elapsed = now - last_playback_head_event_at;
-        if (elapsed > 5'000'000LL) {
-          last_playback_head_event_at = now;
-          SB_LOG(INFO) << "last playback head position is "
-                       << last_playback_head_position
-                       << " and it hasn't been updated for " << elapsed
-                       << " microseconds.";
-        }
-      } else {
-        last_playback_head_event_at = now;
-      }
+      playback_frame_head_ = timestamp->frame_position;
 
-      last_playback_head_position = playback_head_position;
-      frames_consumed = std::min(frames_consumed, frames_in_audio_track);
-
-      if (frames_consumed != 0) {
-        SB_DCHECK_GE(frames_consumed, 0);
-        consume_frames_func_(frames_consumed, frames_consumed_at, context_);
-        frames_in_audio_track -= frames_consumed;
+      if (source_state.is_playing) {
+        last_reported_timestamp = ReportConsumedFramesToSource(
+            env, &sink_state, timestamp, last_reported_timestamp);
       }
     }
+    source_state = GetAudioSourceState();
 
-    int frames_in_buffer;
-    int offset_in_frames;
-    bool is_playing;
-    bool is_eos_reached;
-    update_source_status_func_(&frames_in_buffer, &offset_in_frames,
-                               &is_playing, &is_eos_reached, context_);
-    {
-      std::lock_guard lock(mutex_);
-      if (playback_rate_ == 0.0) {
-        is_playing = false;
-      }
+    if (sink_state.is_playing_silence && source_state.is_playing) {
+      SB_LOG(INFO) << "Source started";
+      sink_state.is_playing_silence = false;
     }
-
-    if (was_playing && !is_playing) {
-      was_playing = false;
-      bridge_.Pause();
-    } else if (!was_playing && is_playing) {
-      was_playing = true;
-      last_playback_head_event_at = -1;
-      bridge_.Play();
-    }
-
-    if (!is_playing || frames_in_buffer == 0) {
+    if (sink_state.is_playing_silence) {
+      AppendSilence(env, timestamp);
       usleep(10'000);
       continue;
     }
 
-    int start_position =
-        (offset_in_frames + frames_in_audio_track) % frames_per_channel_;
-    int expected_written_frames = 0;
-    if (frames_per_channel_ > offset_in_frames + frames_in_audio_track) {
-      expected_written_frames = std::min(
-          frames_per_channel_ - (offset_in_frames + frames_in_audio_track),
-          frames_in_buffer - frames_in_audio_track);
-    } else {
-      expected_written_frames = frames_in_buffer - frames_in_audio_track;
-    }
-
-    expected_written_frames =
-        std::min(expected_written_frames, kMaxFramesPerRequest);
-
-    if (expected_written_frames == 0) {
-      // It is possible that all the frames in buffer are written to the
-      // soundcard, but those are not being consumed. If eos is reached,
-      // write silence to make sure audio track start working and avoid
-      // underflow. Android audio track would not start working before
-      // its buffer is fully filled once.
-      if (is_eos_reached) {
-        // Currently AudioDevice and AudioRenderer will write tail silence.
-        // It should be reached only in tests. It's not ideal to allocate
-        // a new silence buffer every time.
-        std::vector<uint8_t> silence_buffer(channels_ *
-                                            GetBytesPerSample(sample_type_) *
-                                            kSilenceFramesPerAppend);
-        // Not necessary to handle error of WriteData(), as the audio has
-        // reached the end of stream.
-        WriteData(env, silence_buffer.data(), kSilenceFramesPerAppend);
-      }
-
+    UpdatePlaybackState(env, source_state, &sink_state);
+    if (!source_state.is_playing || source_state.frames_in_buffer == 0) {
       usleep(10'000);
       continue;
     }
-    SB_DCHECK_GT(expected_written_frames, 0);
-    SB_DCHECK(start_position + expected_written_frames <= frames_per_channel_)
-        << "start_position: " << start_position
-        << ", expected_written_frames: " << expected_written_frames
-        << ", frames_per_channel_: " << frames_per_channel_
-        << ", frames_in_buffer: " << frames_in_buffer
-        << ", frames_in_audio_track: " << frames_in_audio_track
-        << ", offset_in_frames: " << offset_in_frames;
 
-    int written_frames =
-        WriteData(env,
-                  IncrementPointerByBytes(frame_buffer_,
-                                          start_position * channels_ *
-                                              GetBytesPerSample(sample_type_)),
-                  expected_written_frames);
-    int64_t now = CurrentMonotonicTime();
+    if (!is_first_audio_written) {
+      const int64_t frame_head =
+          EstimateFramePosition(timestamp, CurrentMonotonicTime());
 
-    if (written_frames < 0) {
-      if (written_frames == AudioTrackBridge::kAudioTrackErrorDeadObject) {
-        // There might be an audio device change, try to recreate the player.
-        ReportError(true,
-                    "Failed to write data and received dead object error.");
-      } else {
-        ReportError(false, FormatString("Failed to write data and received %d.",
-                                        written_frames));
-      }
+      SB_LOG(INFO) << "Now writing real audio: frame_head(msec)= "
+                   << GetFramesMs(frame_head) << ", silences fed(msec)="
+                   << GetFramesMs(initial_silence_frames_) << ", gap(msec)="
+                   << GetFramesMs(initial_silence_frames_ - frame_head);
+      is_first_audio_written = true;
+    }
+    std::optional<int64_t> continue_latency =
+        WriteAudioData(env, source_state, &sink_state);
+    if (!continue_latency) {
+      SB_LOG(INFO) << "WriteAudioData failed";
       break;
     }
-    frames_in_audio_track += written_frames;
-
-    bool written_fully = (written_frames == expected_written_frames);
-    auto unplayed_frames_in_time =
-        GetFramesDurationUs(frames_in_audio_track) - (now - frames_consumed_at);
-    // As long as there is enough data in the buffer, run the loop in lower
-    // frequency to avoid taking too much CPU.  Note that the threshold should
-    // be big enough to account for the unstable playback head reported at the
-    // beginning of the playback and during underrun.
-    if (playback_head_position > 0 && unplayed_frames_in_time > 500'000) {
-      usleep(40'000);
-    } else if (!written_fully) {
-      // Only sleep if the buffer is nearly full and the last write is partial.
-      usleep(10'000);
+    if (*continue_latency > 0) {
+      usleep(*continue_latency);
     }
   }
 
@@ -302,8 +405,8 @@ void ContinuousAudioTrackSink::AudioThreadFunc() {
 
 int ContinuousAudioTrackSink::WriteData(JNIEnv* env,
                                         const void* buffer,
-                                        int expected_written_frames) {
-  const int samples_to_write = expected_written_frames * channels_;
+                                        int frames_to_write) {
+  const int samples_to_write = frames_to_write * channels_;
   int samples_written = 0;
   if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
     samples_written = bridge_.WriteSample(static_cast<const float*>(buffer),
@@ -317,9 +420,10 @@ int ContinuousAudioTrackSink::WriteData(JNIEnv* env,
   }
   if (samples_written < 0) {
     // Error code returned as negative value, like kAudioTrackErrorDeadObject.
+    SB_LOG(ERROR) << "WriteSample failed: ret=" << samples_written;
     return samples_written;
   }
-  SB_DCHECK_EQ(samples_written % channels_, 0);
+  SB_CHECK_EQ(samples_written % channels_, 0);
   return samples_written / channels_;
 }
 
@@ -331,8 +435,12 @@ void ContinuousAudioTrackSink::ReportError(bool capability_changed,
   }
 }
 
-int64_t ContinuousAudioTrackSink::GetFramesDurationUs(int frames) const {
+int64_t ContinuousAudioTrackSink::GetFramesUs(int64_t frames) const {
   return frames * 1'000'000LL / sampling_frequency_hz_;
+}
+
+int64_t ContinuousAudioTrackSink::GetFrames(int64_t duration_us) const {
+  return duration_us * sampling_frequency_hz_ / 1'000'000;
 }
 
 void ContinuousAudioTrackSink::SetVolume(double volume) {
@@ -341,10 +449,6 @@ void ContinuousAudioTrackSink::SetVolume(double volume) {
 
 int ContinuousAudioTrackSink::GetUnderrunCount() {
   return bridge_.GetUnderrunCount();
-}
-
-int ContinuousAudioTrackSink::GetStartThresholdInFrames() {
-  return bridge_.GetStartThresholdInFrames();
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/continuous_audio_track_sink.h
+++ b/starboard/android/shared/continuous_audio_track_sink.h
@@ -22,6 +22,7 @@
 #include <mutex>
 #include <optional>
 #include <string>
+#include <vector>
 
 #include "starboard/android/shared/audio_track_bridge.h"
 #include "starboard/android/shared/jni_env_ext.h"
@@ -33,6 +34,19 @@
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 
 namespace starboard {
+
+struct AudioSinkState {
+  int frames_in_audio_track = 0;
+  bool is_playing = false;
+  bool is_playing_silence = false;
+};
+
+struct AudioSourceState {
+  int frames_in_buffer = 0;
+  int offset_in_frames = 0;
+  bool is_playing = false;
+  bool is_eos_reached = false;
+};
 
 class ContinuousAudioTrackSink : public SbAudioSinkImpl {
  public:
@@ -47,7 +61,6 @@ class ContinuousAudioTrackSink : public SbAudioSinkImpl {
       SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
       ConsumeFramesFunc consume_frames_func,
       SbAudioSinkPrivate::ErrorFunc error_func,
-      int64_t start_media_time,
       bool is_web_audio,
       void* context);
   ~ContinuousAudioTrackSink() override;
@@ -60,35 +73,80 @@ class ContinuousAudioTrackSink : public SbAudioSinkImpl {
   int GetUnderrunCount();
   int GetStartThresholdInFrames();
 
+  int WriteData(JNIEnv* env, const void* buffer, int size);
+
  private:
   static void* ThreadEntryPoint(void* context);
   void AudioThreadFunc();
 
-  int WriteData(JNIEnv* env, const void* buffer, int size);
+  void PrimeSilenceBuffer(JNIEnv* env);
+  void AppendSilence(
+      JNIEnv* env,
+      std::optional<AudioTrackBridge::AudioTimestamp> last_timestamp);
+
+  std::optional<AudioTrackBridge::AudioTimestamp> ReportConsumedFramesToSource(
+      JNIEnv* env,
+      AudioSinkState* state,
+      const std::optional<AudioTrackBridge::AudioTimestamp> new_timestamp,
+      const std::optional<AudioTrackBridge::AudioTimestamp> last_timestamp);
+
+  AudioSourceState GetAudioSourceState();
+
+  void UpdatePlaybackState(JNIEnv* env,
+                           const AudioSourceState& source_state,
+                           AudioSinkState* sink_state);
+  void HandleInitialSilenceFeeding(
+      JNIEnv* env,
+      int* initial_silence_frames,
+      int64_t* silence_fed_at_us,
+      const std::optional<AudioTrackBridge::AudioTimestamp>& last_timestamp,
+      const std::vector<uint8_t>& silence_frames);
+  std::optional<int64_t> WriteAudioData(JNIEnv* env,
+                                        const AudioSourceState& source_state,
+                                        AudioSinkState* sink_state);
+  void CheckForPlaybackStart(JNIEnv* env,
+                             int64_t* last_real_frame_head,
+                             int64_t silence_fed_at_us);
 
   void ReportError(bool capability_changed, const std::string& error_message);
 
-  int64_t GetFramesDurationUs(int frames) const;
+  int64_t EstimateFramePosition(
+      const std::optional<AudioTrackBridge::AudioTimestamp>& timestamp,
+      int64_t time_us) const;
+
+  int64_t GetFramesUs(int64_t frames) const;
+  int64_t GetFramesMs(int64_t frames) const {
+    return GetFramesUs(frames) / 1'000;
+  }
+  int64_t GetFrames(int64_t duration_us) const;
 
   Type* const type_;
   const int channels_;
   const int sampling_frequency_hz_;
   const SbMediaAudioSampleType sample_type_;
-  void* frame_buffer_;
-  const int frames_per_channel_;
+  const int frame_bytes_;
+  uint8_t* frame_buffer_;
+  const int source_buffer_frames_;
   const SbAudioSinkUpdateSourceStatusFunc update_source_status_func_;
   const ConsumeFramesFunc consume_frames_func_;
   const SbAudioSinkPrivate::ErrorFunc error_func_;
-  const int64_t start_time_;  // microseconds
   void* const context_;
 
   AudioTrackBridge bridge_;
+  const int initial_frames_;
 
-  volatile bool quit_ = false;
+  bool quit_ = false;
   std::optional<pthread_t> audio_out_thread_;
 
   std::mutex mutex_;
-  double playback_rate_ = 1.0;
+  double playback_rate_ = 1.0;  // Guared by |mutex_|.
+
+  int initial_silence_frames_ = 0;
+  const int silence_buffer_frames_;
+  const std::vector<uint8_t> silence_buffer_;
+
+  bool playback_started_ = false;
+  int playback_frame_head_ = 0;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -184,6 +184,22 @@ std::unique_ptr<MediaCodecBridge> MediaCodecBridge::CreateVideoMediaCodecBridge(
     bool force_big_endian_hdr_metadata,
     int max_video_input_size,
     std::string* error_message) {
+  SB_LOG(INFO)
+      << __func__ << ": video_codec=" << video_codec
+      << ", width_hint=" << width_hint << ", height_hint=" << height_hint
+      << ", fps=" << fps << ", max_width="
+      << (max_width.has_value() ? std::to_string(max_width.value()) : "(n/a)")
+      << ", max_height="
+      << (max_height.has_value() ? std::to_string(max_height.value()) : "(n/a)")
+      << ", has_color_metadata=" << (color_metadata ? "true" : "false")
+      << ", require_secured_decoder="
+      << (require_secured_decoder ? "true" : "false")
+      << ", require_software_codec="
+      << (require_software_codec ? "true" : "false")
+      << ", tunnel_mode_audio_session_id=" << tunnel_mode_audio_session_id
+      << ", force_big_endian_hdr_metadata="
+      << (force_big_endian_hdr_metadata ? "true" : "false")
+      << ", max_video_input_size=" << max_video_input_size;
   SB_DCHECK(error_message);
   SB_DCHECK_EQ(max_width.has_value(), max_height.has_value());
   SB_DCHECK_GT(max_width.value_or(1920), 0);
@@ -498,6 +514,14 @@ void MediaCodecBridge::OnMediaCodecFrameRendered(
     jlong presentation_time_us,
     jlong render_at_system_time_ns) {
   handler_->OnMediaCodecFrameRendered(presentation_time_us);
+
+  int64_t rendered_ms = render_at_system_time_ns / 1'000'000;
+  if (rendered_frame_count_ < 10 && last_rendered_ms_) {
+    SB_LOG(INFO) << __func__
+                 << ": gap(msec)=" << (rendered_ms - *last_rendered_ms_);
+  }
+  last_rendered_ms_ = rendered_ms;
+  rendered_frame_count_++;
 }
 
 void MediaCodecBridge::OnMediaCodecFirstTunnelFrameReady(JNIEnv* env) {

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -239,6 +239,9 @@ class MediaCodecBridge {
   base::android::ScopedJavaGlobalRef<jobject>
       j_reused_get_output_format_result_ = NULL;
 
+  int rendered_frame_count_ = 0;
+  std::optional<int64_t> last_rendered_ms_;
+
   MediaCodecBridge(const MediaCodecBridge&) = delete;
   void operator=(const MediaCodecBridge&) = delete;
 };

--- a/starboard/android/shared/video_render_algorithm.h
+++ b/starboard/android/shared/video_render_algorithm.h
@@ -52,6 +52,8 @@ class VideoRenderAlgorithmAndroid : public VideoRenderAlgorithm {
   double playback_rate_ = 1.0;
   VideoFrameReleaseTimeHelper video_frame_release_time_helper_;
   int dropped_frames_ = 0;
+
+  int index_ = 0;
 };
 
 }  // namespace starboard


### PR DESCRIPTION
    This change enables the `ContinuousAudioTrackSink` by default and refactors it to be more robust.
    
    Key changes:
    - `kUseContinuousAudioTrackSink` is now `true`.
    - `AudioTrackBridge` now has a `GetRawAudioTimestamp` method to get the raw timestamp from the audio track.
    - `ContinuousAudioTrackSink` is refactored to:
      - Use the raw audio timestamp.
      - Prime the audio track with silence before playback.
      - Handle playback state transitions more explicitly.
    - Added more detailed logging to `MediaCodecBridge` and `VideoRenderAlgorithm` to help debug A/V sync issues.

Bug: 1234