### PR TITLE
starboard: Flatten loader_app namespace

### DIFF
--- a/starboard/loader_app/app_key.cc
+++ b/starboard/loader_app/app_key.cc
@@ -19,7 +19,6 @@
 #include "starboard/configuration_constants.h"
 #include "starboard/loader_app/app_key_internal.h"
 
-namespace starboard {
 namespace loader_app {
 namespace {
 
@@ -43,4 +42,3 @@ std::string GetAppKey(const std::string& url) {
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/app_key.h
+++ b/starboard/loader_app/app_key.h
@@ -17,13 +17,11 @@
 
 #include <string>
 
-namespace starboard {
 namespace loader_app {
 
 // Returns an app key generated from the provided |url|.
 std::string GetAppKey(const std::string& url);
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_APP_KEY_H_

--- a/starboard/loader_app/app_key_files.cc
+++ b/starboard/loader_app/app_key_files.cc
@@ -24,7 +24,6 @@
 #include "starboard/common/string.h"
 #include "starboard/configuration_constants.h"
 
-namespace starboard {
 namespace loader_app {
 
 namespace {
@@ -124,4 +123,3 @@ bool AnyGoodAppKeyFile(const std::string& dir) {
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/app_key_files.h
+++ b/starboard/loader_app/app_key_files.h
@@ -17,7 +17,6 @@
 
 #include <string>
 
-namespace starboard {
 namespace loader_app {
 
 // Gets the file path for a good app key file in the |dir| directory.
@@ -40,6 +39,5 @@ bool CreateAppKeyFile(const std::string& file_name_path);
 bool AnyGoodAppKeyFile(const std::string& dir);
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_APP_KEY_FILES_H_

--- a/starboard/loader_app/app_key_files_test.cc
+++ b/starboard/loader_app/app_key_files_test.cc
@@ -24,7 +24,6 @@
 #include "starboard/system.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-namespace starboard {
 namespace loader_app {
 namespace {
 
@@ -103,4 +102,3 @@ TEST_F(AppKeyFilesTest, TestAnyGoodKeyFile) {
 
 }  // namespace
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/app_key_internal.cc
+++ b/starboard/loader_app/app_key_internal.cc
@@ -20,7 +20,6 @@
 #include "starboard/types.h"
 #include "third_party/modp_b64/modp_b64.h"
 
-namespace starboard {
 namespace loader_app {
 namespace {
 
@@ -131,4 +130,3 @@ std::string EncodeAppKey(const std::string& app_key) {
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/app_key_internal.h
+++ b/starboard/loader_app/app_key_internal.h
@@ -17,7 +17,6 @@
 
 #include <string>
 
-namespace starboard {
 namespace loader_app {
 
 // Returns an application key extracted from |url|. This function is not meant
@@ -29,6 +28,5 @@ std::string ExtractAppKey(const std::string& url);
 std::string EncodeAppKey(const std::string& app_key);
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_APP_KEY_INTERNAL_H_

--- a/starboard/loader_app/app_key_test.cc
+++ b/starboard/loader_app/app_key_test.cc
@@ -18,7 +18,6 @@
 
 #include "testing/gtest/include/gtest/gtest.h"
 
-namespace starboard {
 namespace loader_app {
 
 typedef struct URLWithExtractedAndEncoded {
@@ -686,4 +685,3 @@ TEST(AppKeyTest, SunnyDayExtractAppKeySanitizesResult) {
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/drain_file.cc
+++ b/starboard/loader_app/drain_file.cc
@@ -42,9 +42,9 @@ const char kDrainFilePrefix[] = "d_";
 }  // extern "C"
 #endif
 
-namespace starboard {
 namespace loader_app {
 namespace {
+using ::starboard::CurrentPosixTime;
 
 std::string ExtractAppKey(const std::string& str) {
   const size_t begin = str.find_first_of('_') + 1;
@@ -153,10 +153,6 @@ void Rank(const char* dir, char* app_key, size_t len) {
   }
 }
 
-}  // namespace
-
-namespace drain_file {
-
 bool TryDrain(const char* dir, const char* app_key) {
   SB_DCHECK(dir);
   SB_DCHECK(app_key);
@@ -255,7 +251,7 @@ void PrepareDirectory(const char* dir, const char* app_key) {
     path.append(kSbFileSepString);
     path.append(entry);
 
-    SbFileDeleteRecursive(path.c_str(), false);
+    starboard::SbFileDeleteRecursive(path.c_str(), false);
   }
 }
 
@@ -295,40 +291,39 @@ bool IsAnotherAppDraining(const char* dir, const char* app_key) {
   return false;
 }
 
-}  // namespace drain_file
+}  // namespace
 }  // namespace loader_app
-}  // namespace starboard
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 bool DrainFileTryDrain(const char* dir, const char* app_key) {
-  return starboard::loader_app::drain_file::TryDrain(dir, app_key);
+  return loader_app::TryDrain(dir, app_key);
 }
 
 bool DrainFileRankAndCheck(const char* dir, const char* app_key) {
-  return starboard::loader_app::drain_file::RankAndCheck(dir, app_key);
+  return loader_app::RankAndCheck(dir, app_key);
 }
 
 void DrainFileClearExpired(const char* dir) {
-  starboard::loader_app::drain_file::ClearExpired(dir);
+  loader_app::ClearExpired(dir);
 }
 
 void DrainFileClearForApp(const char* dir, const char* app_key) {
-  starboard::loader_app::drain_file::ClearForApp(dir, app_key);
+  loader_app::ClearForApp(dir, app_key);
 }
 
 void DrainFilePrepareDirectory(const char* dir, const char* app_key) {
-  starboard::loader_app::drain_file::PrepareDirectory(dir, app_key);
+  loader_app::PrepareDirectory(dir, app_key);
 }
 
 bool DrainFileIsAppDraining(const char* dir, const char* app_key) {
-  return starboard::loader_app::drain_file::IsAppDraining(dir, app_key);
+  return loader_app::IsAppDraining(dir, app_key);
 }
 
 bool DrainFileIsAnotherAppDraining(const char* dir, const char* app_key) {
-  return starboard::loader_app::drain_file::IsAnotherAppDraining(dir, app_key);
+  return loader_app::IsAnotherAppDraining(dir, app_key);
 }
 
 #ifdef __cplusplus

--- a/starboard/loader_app/drain_file_helper.cc
+++ b/starboard/loader_app/drain_file_helper.cc
@@ -22,7 +22,6 @@
 #include "starboard/loader_app/drain_file.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-namespace starboard {
 namespace loader_app {
 
 ScopedDrainFile::ScopedDrainFile(const std::string& dir,
@@ -67,4 +66,3 @@ void ScopedDrainFile::CreateFile() {
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/drain_file_helper.h
+++ b/starboard/loader_app/drain_file_helper.h
@@ -17,7 +17,6 @@
 
 #include <string>
 
-namespace starboard {
 namespace loader_app {
 
 // Creates and removes a file within its own lifetime. This class maintains the
@@ -47,6 +46,5 @@ class ScopedDrainFile {
 };
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_DRAIN_FILE_HELPER_H_

--- a/starboard/loader_app/drain_file_test.cc
+++ b/starboard/loader_app/drain_file_test.cc
@@ -29,9 +29,10 @@
 #include "starboard/types.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-namespace starboard {
 namespace loader_app {
 namespace {
+using ::starboard::CurrentPosixTime;
+using ::starboard::ScopedFile;
 
 const char kAppKeyOne[] = "b25lDQo=";
 const char kAppKeyTwo[] = "dHdvDQo=";
@@ -268,4 +269,3 @@ TEST_F(DrainFileTest, RainyDayDrainFileAlreadyExists) {
 
 }  // namespace
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/installation_manager.cc
+++ b/starboard/loader_app/installation_manager.cc
@@ -38,9 +38,7 @@
 #include "starboard/common/once.h"
 #include "starboard/loader_app/record_loader_app_status.h"
 
-namespace starboard {
 namespace loader_app {
-namespace installation_manager {
 
 class InstallationManager {
  public:
@@ -734,34 +732,29 @@ bool InstallationManager::CleanInstallationDirs() {
     if (!GetInstallationPathInternal(i, path.data(), kSbFileMaxPath)) {
       return false;
     }
-    if (!SbFileDeleteRecursive(path.data(), true)) {
+    if (!starboard::SbFileDeleteRecursive(path.data(), true)) {
       return false;
     }
   }
   return true;
 }
 
-}  // namespace installation_manager
 }  // namespace loader_app
-}  // namespace starboard
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-std::unique_ptr<
-    starboard::loader_app::installation_manager::InstallationManager>
-    g_installation_manager_;
+std::unique_ptr<loader_app::InstallationManager> g_installation_manager_;
 
 // Global Installation Manager Mutex.
 SB_ONCE_INITIALIZE_FUNCTION(std::mutex, GetImMutex)
 
 int ImInitialize(int max_num_installations, const char* app_key) {
   std::lock_guard lock(*GetImMutex());
-  if (g_installation_manager_.get() == NULL) {
-    g_installation_manager_.reset(
-        new starboard::loader_app::installation_manager::InstallationManager(
-            max_num_installations, app_key));
+  if (g_installation_manager_ == nullptr) {
+    g_installation_manager_ = std::make_unique<loader_app::InstallationManager>(
+        max_num_installations, app_key);
   }
   return g_installation_manager_->Initialize();
 }

--- a/starboard/loader_app/installation_manager_test.cc
+++ b/starboard/loader_app/installation_manager_test.cc
@@ -33,9 +33,7 @@
 
 #define NUMBER_INSTALLS_PARAMS ::testing::Values(2, 3, 4, 5, 6)
 
-namespace starboard {
 namespace loader_app {
-namespace installation_manager {
 
 namespace {
 
@@ -647,8 +645,6 @@ INSTANTIATE_TEST_CASE_P(NumberOfMaxInstallations,
                         InstallationManagerTest,
                         NUMBER_INSTALLS_PARAMS);
 
-}  // namespace installation_manager
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // SB_IS(EVERGREEN_COMPATIBLE)

--- a/starboard/loader_app/loader_app.cc
+++ b/starboard/loader_app/loader_app.cc
@@ -62,14 +62,14 @@ starboard::elf_loader::ElfLoader g_elf_loader;
 // Cobalt binary.
 void (*g_sb_event_func)(const SbEvent*) = NULL;
 
-class CobaltLibraryLoader : public starboard::loader_app::LibraryLoader {
+class CobaltLibraryLoader : public loader_app::LibraryLoader {
  public:
   virtual bool Load(const std::string& library_path,
                     const std::string& content_path,
                     bool use_compression,
                     bool use_memory_mapped_file) {
     return g_elf_loader.Load(library_path, content_path, false,
-                             &starboard::loader_app::SbSystemGetExtensionShim,
+                             &loader_app::SbSystemGetExtensionShim,
                              use_compression, use_memory_mapped_file);
   }
   virtual void* Resolve(const std::string& symbol) {
@@ -202,41 +202,40 @@ void SbEventHandle(const SbEvent* event) {
     const starboard::CommandLine command_line(
         data->argument_count, const_cast<const char**>(data->argument_values));
 
-    if (command_line.HasSwitch(starboard::loader_app::kResetEvergreenUpdate)) {
+    if (command_line.HasSwitch(loader_app::kResetEvergreenUpdate)) {
       SB_LOG(INFO) << "Resetting the Evergreen Update";
-      starboard::loader_app::ResetEvergreenUpdate();
+      loader_app::ResetEvergreenUpdate();
       SbSystemRequestStop(0);
       SB_CHECK_EQ(pthread_mutex_unlock(&mutex), 0);
       return;
     }
 
-    if (command_line.HasSwitch(starboard::loader_app::kLoaderAppVersion)) {
+    if (command_line.HasSwitch(loader_app::kLoaderAppVersion)) {
       std::string versiong_msg = "Loader app version: ";
       versiong_msg += COBALT_VERSION;
       versiong_msg += "\n";
       SbLogRaw(versiong_msg.c_str());
     }
 
-    bool is_evergreen_lite =
-        command_line.HasSwitch(starboard::loader_app::kEvergreenLite);
+    bool is_evergreen_lite = command_line.HasSwitch(loader_app::kEvergreenLite);
     SB_LOG(INFO) << "is_evergreen_lite=" << is_evergreen_lite;
 
-    if (command_line.HasSwitch(starboard::loader_app::kShowSABI)) {
+    if (command_line.HasSwitch(loader_app::kShowSABI)) {
       std::string sabi = "SABI=";
       sabi += SB_SABI_JSON_ID;
       SbLogRaw(sabi.c_str());
     }
 
     std::string alternative_content =
-        command_line.GetSwitchValue(starboard::loader_app::kContent);
+        command_line.GetSwitchValue(loader_app::kContent);
     SB_LOG(INFO) << "alternative_content=" << alternative_content;
 
     bool use_compressed_updates =
         !is_evergreen_lite &&
-        !command_line.HasSwitch(starboard::loader_app::kUseUncompressedUpdates);
+        !command_line.HasSwitch(loader_app::kUseUncompressedUpdates);
 
-    bool use_memory_mapped_file = command_line.HasSwitch(
-        starboard::loader_app::kLoaderUseMemoryMappedFile);
+    bool use_memory_mapped_file =
+        command_line.HasSwitch(loader_app::kLoaderUseMemoryMappedFile);
     SB_LOG(INFO) << "use_memory_mapped_file=" << use_memory_mapped_file;
 
     if (use_compressed_updates && use_memory_mapped_file) {
@@ -247,41 +246,39 @@ void SbEventHandle(const SbEvent* event) {
       return;
     }
 
-    if (command_line.HasSwitch(starboard::loader_app::kLoaderTrackMemory)) {
-      std::string period = command_line.GetSwitchValue(
-          starboard::loader_app::kLoaderTrackMemory);
+    if (command_line.HasSwitch(loader_app::kLoaderTrackMemory)) {
+      std::string period =
+          command_line.GetSwitchValue(loader_app::kLoaderTrackMemory);
       if (period.empty()) {
-        static starboard::loader_app::MemoryTrackerThread memory_tracker_thread;
+        static loader_app::MemoryTrackerThread memory_tracker_thread;
         memory_tracker_thread.Start();
       } else {
-        static starboard::loader_app::MemoryTrackerThread memory_tracker_thread(
+        static loader_app::MemoryTrackerThread memory_tracker_thread(
             atoi(period.c_str()));
         memory_tracker_thread.Start();
       }
     }
 
     if (is_evergreen_lite) {
-      starboard::loader_app::RecordSlotSelectionStatus(
-          SlotSelectionStatus::kEGLite);
+      loader_app::RecordSlotSelectionStatus(SlotSelectionStatus::kEGLite);
       LoadLibraryAndInitialize(alternative_content, use_memory_mapped_file);
     } else {
-      std::string url =
-          command_line.GetSwitchValue(starboard::loader_app::kURL);
+      std::string url = command_line.GetSwitchValue(loader_app::kURL);
       if (url.empty()) {
         url = kCobaltDefaultUrl;
       }
-      std::string app_key = starboard::loader_app::GetAppKey(url);
+      std::string app_key = loader_app::GetAppKey(url);
       SB_CHECK(!app_key.empty());
 
       g_sb_event_func = reinterpret_cast<void (*)(const SbEvent*)>(
-          starboard::loader_app::LoadSlotManagedLibrary(
-              app_key, alternative_content, &g_cobalt_library_loader,
-              use_memory_mapped_file));
+          loader_app::LoadSlotManagedLibrary(app_key, alternative_content,
+                                             &g_cobalt_library_loader,
+                                             use_memory_mapped_file));
 
       if (g_sb_event_func == NULL) {
         SB_LOG(ERROR) << "Failed to initialize Installation Manager. Loading "
                          "system image instead.";
-        starboard::loader_app::RecordSlotSelectionStatus(
+        loader_app::RecordSlotSelectionStatus(
             SlotSelectionStatus::kLoadSysImgFailedToInitInstallationManager);
         LoadLibraryAndInitialize(alternative_content, use_memory_mapped_file);
       }

--- a/starboard/loader_app/loader_app_switches.cc
+++ b/starboard/loader_app/loader_app_switches.cc
@@ -14,7 +14,6 @@
 
 #include "starboard/loader_app/loader_app_switches.h"
 
-namespace starboard {
 namespace loader_app {
 
 const char kContent[] = "content";
@@ -28,4 +27,3 @@ const char kLoaderTrackMemory[] = "loader_track_memory";
 const char kResetEvergreenUpdate[] = "reset_evergreen_update";
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/loader_app_switches.h
+++ b/starboard/loader_app/loader_app_switches.h
@@ -17,7 +17,6 @@
 
 #include "starboard/configuration.h"
 
-namespace starboard {
 namespace loader_app {
 
 // Absolute path to the alternative content directory to be used.
@@ -52,6 +51,5 @@ extern const char kLoaderTrackMemory[];
 // Reset the Evergreen update for the app based on the the initial URL.
 extern const char kResetEvergreenUpdate[];
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_LOADER_APP_SWITCHES_H_

--- a/starboard/loader_app/memory_tracker_thread.cc
+++ b/starboard/loader_app/memory_tracker_thread.cc
@@ -16,7 +16,6 @@
 
 #include "starboard/common/log.h"
 
-namespace starboard {
 namespace loader_app {
 
 MemoryTrackerThread::MemoryTrackerThread(int period_in_millis)
@@ -43,4 +42,3 @@ void MemoryTrackerThread::Run() {
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/memory_tracker_thread.h
+++ b/starboard/loader_app/memory_tracker_thread.h
@@ -18,7 +18,6 @@
 #include "starboard/common/thread.h"
 #include "starboard/types.h"
 
-namespace starboard {
 namespace loader_app {
 
 // Periodically queries for and logs process memory usage when enabled.
@@ -35,6 +34,5 @@ class MemoryTrackerThread : public starboard::Thread {
 };
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_MEMORY_TRACKER_THREAD_H_

--- a/starboard/loader_app/pending_restart.cc
+++ b/starboard/loader_app/pending_restart.cc
@@ -16,7 +16,6 @@
 
 #include <atomic>
 
-namespace starboard {
 namespace loader_app {
 
 namespace {
@@ -32,4 +31,3 @@ void SetPendingRestart(bool value) {
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/pending_restart.h
+++ b/starboard/loader_app/pending_restart.h
@@ -15,7 +15,6 @@
 #ifndef STARBOARD_LOADER_APP_PENDING_RESTART_H_
 #define STARBOARD_LOADER_APP_PENDING_RESTART_H_
 
-namespace starboard {
 namespace loader_app {
 
 // Checks whether there is a pending restart.
@@ -26,6 +25,5 @@ bool IsPendingRestart();
 void SetPendingRestart(bool value);
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_PENDING_RESTART_H_

--- a/starboard/loader_app/pending_restart_test.cc
+++ b/starboard/loader_app/pending_restart_test.cc
@@ -19,7 +19,6 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 #if SB_IS(EVERGREEN_COMPATIBLE)
-namespace starboard {
 namespace loader_app {
 namespace {
 
@@ -49,5 +48,4 @@ TEST_F(PendingRestartTest, PendingRestart) {
 }  // namespace
 
 }  // namespace loader_app
-}  // namespace starboard
 #endif  //  SB_IS(EVERGREEN_COMPATIBLE)

--- a/starboard/loader_app/record_loader_app_status.cc
+++ b/starboard/loader_app/record_loader_app_status.cc
@@ -18,7 +18,6 @@
 
 #include "starboard/system.h"
 
-namespace starboard {
 namespace loader_app {
 
 void RecordSlotSelectionStatus(SlotSelectionStatus status) {
@@ -34,4 +33,3 @@ void RecordSlotSelectionStatus(SlotSelectionStatus status) {
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/record_loader_app_status.h
+++ b/starboard/loader_app/record_loader_app_status.h
@@ -19,13 +19,11 @@
 
 #include "starboard/extension/loader_app_metrics.h"
 
-namespace starboard {
 namespace loader_app {
 
 // Persist the slot selection status so that it can be read in the Cobalt layer
 void RecordSlotSelectionStatus(SlotSelectionStatus status);
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_RECORD_LOADER_APP_STATUS_H_

--- a/starboard/loader_app/reset_evergreen_update.cc
+++ b/starboard/loader_app/reset_evergreen_update.cc
@@ -21,7 +21,6 @@
 #include "starboard/common/log.h"
 #include "starboard/configuration_constants.h"
 
-namespace starboard {
 namespace loader_app {
 
 bool ResetEvergreenUpdate() {
@@ -33,8 +32,7 @@ bool ResetEvergreenUpdate() {
     return false;
   }
 
-  return SbFileDeleteRecursive(storage_dir.data(), true);
+  return starboard::SbFileDeleteRecursive(storage_dir.data(), true);
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/reset_evergreen_update.h
+++ b/starboard/loader_app/reset_evergreen_update.h
@@ -17,13 +17,11 @@
 
 #include <string>
 
-namespace starboard {
 namespace loader_app {
 
 // Reset the Evergreen Update Storage
 bool ResetEvergreenUpdate();
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_RESET_EVERGREEN_UPDATE_H_

--- a/starboard/loader_app/reset_evergreen_update_test.cc
+++ b/starboard/loader_app/reset_evergreen_update_test.cc
@@ -25,7 +25,6 @@
 
 #if SB_IS(EVERGREEN_COMPATIBLE)
 
-namespace starboard {
 namespace loader_app {
 namespace {
 
@@ -92,6 +91,5 @@ TEST(ResetEvergreenUpdateTest, TestSunnyDaySubdir) {
 }
 }  // namespace
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  //  SB_IS(EVERGREEN_COMPATIBLE)

--- a/starboard/loader_app/slot_management.cc
+++ b/starboard/loader_app/slot_management.cc
@@ -42,7 +42,6 @@
 #include "third_party/jsoncpp/source/include/json/reader.h"
 #include "third_party/jsoncpp/source/include/json/value.h"
 
-namespace starboard {
 namespace loader_app {
 namespace {
 
@@ -128,8 +127,8 @@ bool ReadEvergreenVersion(std::vector<char>* manifest_file_path,
     return false;
   }
 
-  ScopedFile manifest_file(manifest_file_path->data(), O_RDONLY,
-                           S_IRWXU | S_IRGRP);
+  starboard::ScopedFile manifest_file(manifest_file_path->data(), O_RDONLY,
+                                      S_IRWXU | S_IRGRP);
   int64_t file_size = manifest_file.GetSize();
   std::vector<char> file_data(file_size);
   int read_size = manifest_file.ReadAll(file_data.data(), file_size);
@@ -184,14 +183,13 @@ int RevertBack(int current_installation,
     if (ImGetInstallationPath(current_installation, installation_path.data(),
                               kSbFileMaxPath) != IM_ERROR) {
       std::string bad_app_key_file_path =
-          starboard::loader_app::GetBadAppKeyFilePath(installation_path.data(),
-                                                      app_key);
+          loader_app::GetBadAppKeyFilePath(installation_path.data(), app_key);
       if (bad_app_key_file_path.empty()) {
         SB_LOG(WARNING) << "Failed to get bad app key file path for path="
                         << installation_path.data()
                         << " and app_key=" << app_key;
       } else {
-        if (!starboard::loader_app::CreateAppKeyFile(bad_app_key_file_path)) {
+        if (!loader_app::CreateAppKeyFile(bad_app_key_file_path)) {
           SB_LOG(WARNING) << "Failed to create bad app key file: "
                           << bad_app_key_file_path;
         }
@@ -207,7 +205,7 @@ int RevertBack(int current_installation,
 
 bool CheckBadFileExists(const char* installation_path, const char* app_key) {
   std::string bad_app_key_file_path =
-      starboard::loader_app::GetBadAppKeyFilePath(installation_path, app_key);
+      loader_app::GetBadAppKeyFilePath(installation_path, app_key);
   SB_DCHECK(!bad_app_key_file_path.empty());
   struct stat info;
   bool file_exists = stat(bad_app_key_file_path.c_str(), &info) == 0;
@@ -229,7 +227,7 @@ bool AdoptInstallation(int current_installation,
     return false;
   }
   std::string good_app_key_file_path =
-      starboard::loader_app::GetGoodAppKeyFilePath(installation_path, app_key);
+      loader_app::GetGoodAppKeyFilePath(installation_path, app_key);
   if (good_app_key_file_path.empty()) {
     SB_LOG(WARNING) << "Failed to get good app key file path for app_key="
                     << app_key;
@@ -237,7 +235,7 @@ bool AdoptInstallation(int current_installation,
   }
   struct stat info;
   if (stat(good_app_key_file_path.c_str(), &info) != 0) {
-    if (!starboard::loader_app::CreateAppKeyFile(good_app_key_file_path)) {
+    if (!loader_app::CreateAppKeyFile(good_app_key_file_path)) {
       SB_LOG(WARNING) << "Failed to create good app key file";
       return false;
     }
@@ -511,4 +509,3 @@ void* LoadSlotManagedLibrary(const std::string& app_key,
 }
 
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/slot_management.h
+++ b/starboard/loader_app/slot_management.h
@@ -17,7 +17,6 @@
 
 #include <string>
 
-namespace starboard {
 namespace loader_app {
 
 // Interface for loading a library.
@@ -54,6 +53,5 @@ void* LoadSlotManagedLibrary(const std::string& app_key,
                              bool use_memory_mapped_file);
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_SLOT_MANAGEMENT_H_

--- a/starboard/loader_app/slot_management_test.cc
+++ b/starboard/loader_app/slot_management_test.cc
@@ -39,9 +39,9 @@
 
 #if SB_IS(EVERGREEN_COMPATIBLE)
 
-namespace starboard {
 namespace loader_app {
 namespace {
+using ::starboard::SbFileDeleteRecursive;
 
 const char kTestAppKey[] = "1234";
 const char kTestApp2Key[] = "ABCD";
@@ -125,10 +125,9 @@ class SlotManagementTest : public testing::TestWithParam<bool> {
     ASSERT_EQ(IM_SUCCESS, ImGetInstallationPath(index, installation_path.data(),
                                                 kSbFileMaxPath));
     std::string bad_app_key_file_path =
-        starboard::loader_app::GetBadAppKeyFilePath(installation_path.data(),
-                                                    app_key);
+        loader_app::GetBadAppKeyFilePath(installation_path.data(), app_key);
     ASSERT_TRUE(!bad_app_key_file_path.empty());
-    ASSERT_TRUE(starboard::loader_app::CreateAppKeyFile(bad_app_key_file_path));
+    ASSERT_TRUE(loader_app::CreateAppKeyFile(bad_app_key_file_path));
   }
 
   void CreateGoodFile(int index, const std::string& app_key) {
@@ -136,19 +135,16 @@ class SlotManagementTest : public testing::TestWithParam<bool> {
     ASSERT_EQ(IM_SUCCESS, ImGetInstallationPath(index, installation_path.data(),
                                                 kSbFileMaxPath));
     std::string good_app_key_file_path =
-        starboard::loader_app::GetGoodAppKeyFilePath(installation_path.data(),
-                                                     app_key);
+        loader_app::GetGoodAppKeyFilePath(installation_path.data(), app_key);
     ASSERT_TRUE(!good_app_key_file_path.empty());
-    ASSERT_TRUE(
-        starboard::loader_app::CreateAppKeyFile(good_app_key_file_path));
+    ASSERT_TRUE(loader_app::CreateAppKeyFile(good_app_key_file_path));
   }
 
   void VerifyGoodFile(int index, const std::string& app_key, bool exists) {
     std::vector<char> installation_path(kSbFileMaxPath);
     ImGetInstallationPath(index, installation_path.data(), kSbFileMaxPath);
     std::string good_app_key_file_path =
-        starboard::loader_app::GetGoodAppKeyFilePath(installation_path.data(),
-                                                     app_key);
+        loader_app::GetGoodAppKeyFilePath(installation_path.data(), app_key);
     ASSERT_TRUE(!good_app_key_file_path.empty());
     ASSERT_EQ(exists, FileExists(good_app_key_file_path.c_str()));
   }
@@ -157,8 +153,7 @@ class SlotManagementTest : public testing::TestWithParam<bool> {
     std::vector<char> installation_path(kSbFileMaxPath);
     ImGetInstallationPath(index, installation_path.data(), kSbFileMaxPath);
     std::string bad_app_key_file_path =
-        starboard::loader_app::GetBadAppKeyFilePath(installation_path.data(),
-                                                    app_key);
+        loader_app::GetBadAppKeyFilePath(installation_path.data(), app_key);
     ASSERT_TRUE(!bad_app_key_file_path.empty());
     SB_LOG(INFO) << "bad_app_key_file_path=" << bad_app_key_file_path;
     ASSERT_EQ(exists, FileExists(bad_app_key_file_path.c_str()));
@@ -569,5 +564,4 @@ INSTANTIATE_TEST_CASE_P(SlotManagementTests,
 
 }  // namespace
 }  // namespace loader_app
-}  // namespace starboard
 #endif  // #if SB_IS(EVERGREEN_COMPATIBLE)

--- a/starboard/loader_app/system_get_extension_shim.cc
+++ b/starboard/loader_app/system_get_extension_shim.cc
@@ -37,7 +37,6 @@ const CobaltExtensionInstallationManagerApi kInstallationManagerApi = {
     &ImReset,
 };
 }  // namespace
-namespace starboard {
 namespace loader_app {
 
 const void* SbSystemGetExtensionShim(const char* name) {
@@ -47,4 +46,3 @@ const void* SbSystemGetExtensionShim(const char* name) {
   return NULL;
 }
 }  // namespace loader_app
-}  // namespace starboard

--- a/starboard/loader_app/system_get_extension_shim.h
+++ b/starboard/loader_app/system_get_extension_shim.h
@@ -22,7 +22,6 @@
 
 #include "starboard/system.h"
 
-namespace starboard {
 namespace loader_app {
 
 // Adds the |kCobaltExtensionInstallationManagerName| to the list of extensions
@@ -34,6 +33,5 @@ namespace loader_app {
 const void* SbSystemGetExtensionShim(const char* name);
 
 }  // namespace loader_app
-}  // namespace starboard
 
 #endif  // STARBOARD_LOADER_APP_SYSTEM_GET_EXTENSION_SHIM_H_

--- a/starboard/shared/signal/system_request_freeze.cc
+++ b/starboard/shared/signal/system_request_freeze.cc
@@ -32,7 +32,7 @@ void FreezeDone(void* /*context*/) {
 
 void SbSystemRequestFreeze() {
 #if SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
-  if (starboard::loader_app::IsPendingRestart()) {
+  if (::loader_app::IsPendingRestart()) {
     SbLogRawFormatF("\nPending update restart . Stopping.\n");
     SbLogFlush();
     starboard::Application::Get()->Stop(0);


### PR DESCRIPTION
[go/cobalt-flatten-starboard-namespace](http://go/cobalt-flatten-starboard-namespace)

This change moves the loader_app classes from the
`starboard::loader_app` namespace into the top-level `loader_app` namespace.

This refactoring is part of the ongoing effort to simplify the Starboard namespace structure. It removes unnecessary nesting and makes the loader_app utilities more accessible and consistent with the flattened namespace design.

Bug: 441955897