### PR TITLE
[Rebase m138] Add gates to fix unused variable warning

### DIFF
--- a/ui/gl/init/gl_display_initializer.cc
+++ b/ui/gl/init/gl_display_initializer.cc
@@ -45,7 +45,13 @@ void GetEGLInitDisplays(bool supports_angle_d3d,
   bool default_angle_metal =
       base::FeatureList::IsEnabled(features::kDefaultANGLEMetal);
   bool default_angle_vulkan = features::IsDefaultANGLEVulkan();
+
+#if BUILDFLAG(IS_STARBOARD)
+  const char* default_software_renderer = kANGLEImplementationOpenGLESEGLName
+#else
   const char* default_software_renderer = kANGLEImplementationSwiftShaderName;
+#endif
+
 #if BUILDFLAG(IS_WIN)
   if (base::FeatureList::IsEnabled(features::kAllowD3D11WarpFallback)) {
     default_software_renderer = kANGLEImplementationD3D11WarpName;
@@ -56,10 +62,6 @@ void GetEGLInitDisplays(bool supports_angle_d3d,
   // GPU
   bool force_software_gl =
       IsSoftwareGLImplementation(GetGLImplementationParts());
-
-#if BUILDFLAG(IS_STARBOARD)
-  default_software_renderer = kANGLEImplementationOpenGLESEGLName
-#endif
 
   std::string requested_renderer =
       force_software_gl


### PR DESCRIPTION
Bug: 418842688

default_software_renderer is unused because of an IS_COBALT flag, so disabled the warning.