### PR TITLE
starboard: Move `FakeGraphicsContextProvider` to flattened namespace

### DIFF
--- a/starboard/nplb/maximum_player_configuration_explorer.cc
+++ b/starboard/nplb/maximum_player_configuration_explorer.cc
@@ -152,8 +152,7 @@ MaximumPlayerConfigurationExplorer::MaximumPlayerConfigurationExplorer(
     const std::vector<SbPlayerTestConfig>& player_configs,
     int max_instances_per_config,
     int max_total_instances,
-    starboard::testing::FakeGraphicsContextProvider*
-        fake_graphics_context_provider)
+    starboard::FakeGraphicsContextProvider* fake_graphics_context_provider)
     : player_configs_(player_configs),
       max_instances_per_config_(max_instances_per_config),
       max_total_instances_(max_total_instances),

--- a/starboard/nplb/maximum_player_configuration_explorer.h
+++ b/starboard/nplb/maximum_player_configuration_explorer.h
@@ -49,8 +49,7 @@ class MaximumPlayerConfigurationExplorer {
       const std::vector<SbPlayerTestConfig>& player_configs,
       int max_instances_per_config,
       int max_total_instances,
-      starboard::testing::FakeGraphicsContextProvider*
-          fake_graphics_context_provider);
+      starboard::FakeGraphicsContextProvider* fake_graphics_context_provider);
   ~MaximumPlayerConfigurationExplorer();
 
   std::vector<SbPlayerMultiplePlayerTestConfig> CalculateMaxTestConfigs();
@@ -77,8 +76,7 @@ class MaximumPlayerConfigurationExplorer {
   const std::vector<SbPlayerTestConfig> player_configs_;
   const int max_instances_per_config_;
   const int max_total_instances_;
-  starboard::testing::FakeGraphicsContextProvider*
-      fake_graphics_context_provider_;
+  starboard::FakeGraphicsContextProvider* fake_graphics_context_provider_;
 
   std::vector<std::vector<PlayerInstance>> player_instances_;
 

--- a/starboard/nplb/maximum_player_configuration_explorer_test.cc
+++ b/starboard/nplb/maximum_player_configuration_explorer_test.cc
@@ -53,8 +53,7 @@ class MaximumPlayerConfigurationExplorerTest
  protected:
   MaximumPlayerConfigurationExplorerTest() {}
 
-  starboard::testing::FakeGraphicsContextProvider
-      fake_graphics_context_provider_;
+  starboard::FakeGraphicsContextProvider fake_graphics_context_provider_;
 };
 
 TEST_P(MaximumPlayerConfigurationExplorerTest, SunnyDay) {

--- a/starboard/nplb/media_set_audio_write_duration_test.cc
+++ b/starboard/nplb/media_set_audio_write_duration_test.cc
@@ -33,8 +33,8 @@
 namespace nplb {
 namespace {
 
+using ::starboard::FakeGraphicsContextProvider;
 using ::starboard::VideoDmpReader;
-using ::starboard::testing::FakeGraphicsContextProvider;
 using ::testing::ValuesIn;
 
 const int64_t kDuration = 500'000;          // 0.5 seconds

--- a/starboard/nplb/multiple_player_test.cc
+++ b/starboard/nplb/multiple_player_test.cc
@@ -27,8 +27,8 @@
 namespace nplb {
 namespace {
 
+using ::starboard::FakeGraphicsContextProvider;
 using ::starboard::VideoDmpReader;
-using ::starboard::testing::FakeGraphicsContextProvider;
 using ::testing::ValuesIn;
 
 typedef SbPlayerTestFixture::GroupedSamples GroupedSamples;

--- a/starboard/nplb/player_create_test.cc
+++ b/starboard/nplb/player_create_test.cc
@@ -31,7 +31,7 @@
 namespace nplb {
 namespace {
 
-using ::starboard::testing::FakeGraphicsContextProvider;
+using ::starboard::FakeGraphicsContextProvider;
 using ::testing::Values;
 
 constexpr SbPlayerOutputMode kOutputModes[] = {

--- a/starboard/nplb/player_get_audio_configuration_test.cc
+++ b/starboard/nplb/player_get_audio_configuration_test.cc
@@ -26,7 +26,7 @@ bool operator==(const SbMediaAudioConfiguration& left,
 namespace nplb {
 namespace {
 
-using ::starboard::testing::FakeGraphicsContextProvider;
+using ::starboard::FakeGraphicsContextProvider;
 using ::testing::ValuesIn;
 
 typedef SbPlayerTestFixture::GroupedSamples GroupedSamples;

--- a/starboard/nplb/player_get_media_time_test.cc
+++ b/starboard/nplb/player_get_media_time_test.cc
@@ -20,7 +20,7 @@
 namespace nplb {
 namespace {
 
-using ::starboard::testing::FakeGraphicsContextProvider;
+using ::starboard::FakeGraphicsContextProvider;
 using ::testing::ValuesIn;
 
 typedef SbPlayerTestFixture::GroupedSamples GroupedSamples;

--- a/starboard/nplb/player_test_fixture.cc
+++ b/starboard/nplb/player_test_fixture.cc
@@ -25,8 +25,8 @@
 
 namespace nplb {
 
+using ::starboard::FakeGraphicsContextProvider;
 using ::starboard::VideoDmpReader;
-using ::starboard::testing::FakeGraphicsContextProvider;
 
 using GroupedSamples = SbPlayerTestFixture::GroupedSamples;
 using AudioSamplesDescriptor = GroupedSamples::AudioSamplesDescriptor;

--- a/starboard/nplb/player_test_fixture.h
+++ b/starboard/nplb/player_test_fixture.h
@@ -70,9 +70,9 @@ class SbPlayerTestFixture {
     std::vector<VideoSamplesDescriptor> video_samples_;
   };
 
-  SbPlayerTestFixture(const SbPlayerTestConfig& config,
-                      starboard::testing::FakeGraphicsContextProvider*
-                          fake_graphics_context_provider);
+  SbPlayerTestFixture(
+      const SbPlayerTestConfig& config,
+      starboard::FakeGraphicsContextProvider* fake_graphics_context_provider);
   ~SbPlayerTestFixture();
 
   void Seek(const int64_t time);
@@ -197,8 +197,7 @@ class SbPlayerTestFixture {
   std::string max_video_capabilities_;
   std::unique_ptr<starboard::VideoDmpReader> audio_dmp_reader_;
   std::unique_ptr<starboard::VideoDmpReader> video_dmp_reader_;
-  starboard::testing::FakeGraphicsContextProvider*
-      fake_graphics_context_provider_;
+  starboard::FakeGraphicsContextProvider* fake_graphics_context_provider_;
 
   SbPlayer player_ = kSbPlayerInvalid;
   SbDrmSystem drm_system_ = kSbDrmSystemInvalid;

--- a/starboard/nplb/player_write_sample_test.cc
+++ b/starboard/nplb/player_write_sample_test.cc
@@ -26,7 +26,7 @@
 namespace nplb {
 namespace {
 
-using ::starboard::testing::FakeGraphicsContextProvider;
+using ::starboard::FakeGraphicsContextProvider;
 using ::testing::ValuesIn;
 
 using GroupedSamples = SbPlayerTestFixture::GroupedSamples;

--- a/starboard/nplb/vertical_video_test.cc
+++ b/starboard/nplb/vertical_video_test.cc
@@ -37,8 +37,7 @@ typedef SbPlayerTestFixture::GroupedSamples GroupedSamples;
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(VerticalVideoTest);
 class VerticalVideoTest : public ::testing::TestWithParam<SbPlayerTestConfig> {
  protected:
-  starboard::testing::FakeGraphicsContextProvider
-      fake_graphics_context_provider_;
+  starboard::FakeGraphicsContextProvider fake_graphics_context_provider_;
 };
 
 void CheckVerticalResolutionSupport(const char* mime) {

--- a/starboard/shared/starboard/player/filter/testing/player_components_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/player_components_test.cc
@@ -36,7 +36,6 @@
 namespace starboard {
 namespace {
 
-using ::starboard::testing::FakeGraphicsContextProvider;
 using std::string;
 using std::unique_ptr;
 using std::vector;

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
@@ -40,7 +40,6 @@
 namespace starboard {
 namespace {
 
-using ::starboard::testing::FakeGraphicsContextProvider;
 using ::std::placeholders::_1;
 using ::std::placeholders::_2;
 using ::testing::Bool;

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
@@ -45,7 +45,6 @@
 namespace starboard {
 namespace {
 
-using ::starboard::testing::FakeGraphicsContextProvider;
 using ::std::placeholders::_1;
 using ::std::placeholders::_2;
 

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.h
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.h
@@ -70,12 +70,12 @@ class VideoDecoderTestFixture {
   // stop further processing.
   typedef std::function<void(const Event&, bool* continue_process)> EventCB;
 
-  VideoDecoderTestFixture(JobQueue* job_queue,
-                          ::starboard::testing::FakeGraphicsContextProvider*
-                              fake_graphics_context_provider,
-                          const char* test_filename,
-                          SbPlayerOutputMode output_mode,
-                          bool using_stub_decoder);
+  VideoDecoderTestFixture(
+      JobQueue* job_queue,
+      FakeGraphicsContextProvider* fake_graphics_context_provider,
+      const char* test_filename,
+      SbPlayerOutputMode output_mode,
+      bool using_stub_decoder);
 
   ~VideoDecoderTestFixture() {
     if (video_decoder_) {
@@ -147,8 +147,7 @@ class VideoDecoderTestFixture {
   // platform-specific VideoDecoderImpl.
   bool using_stub_decoder_;
 
-  ::starboard::testing::FakeGraphicsContextProvider*
-      fake_graphics_context_provider_;
+  FakeGraphicsContextProvider* fake_graphics_context_provider_;
   VideoDmpReader dmp_reader_;
   std::unique_ptr<VideoDecoder> video_decoder_;
 

--- a/starboard/testing/fake_graphics_context_provider.cc
+++ b/starboard/testing/fake_graphics_context_provider.cc
@@ -110,7 +110,6 @@ typedef SbEglDisplay(EGLAPIENTRYP PFNEGLGETPLATFORMDISPLAYEXTPROC)(
   } while (false)
 
 namespace starboard {
-namespace testing {
 
 FakeGraphicsContextProvider::FakeGraphicsContextProvider()
     : display_(EGL_NO_DISPLAY),
@@ -375,5 +374,4 @@ void FakeGraphicsContextProvider::DecodeTargetGlesContextRunner(
                                             target_function_context);
 }
 
-}  // namespace testing
 }  // namespace starboard

--- a/starboard/testing/fake_graphics_context_provider.h
+++ b/starboard/testing/fake_graphics_context_provider.h
@@ -28,7 +28,6 @@
 #include "starboard/gles.h"
 
 namespace starboard {
-namespace testing {
 
 // This class provides a SbDecodeTargetGraphicsContextProvider implementation
 // used by SbPlayer related tests.  It creates a thread and forwards decode
@@ -76,7 +75,6 @@ class FakeGraphicsContextProvider {
   SbDecodeTargetGraphicsContextProvider decoder_target_provider_;
 };
 
-}  // namespace testing
 }  // namespace starboard
 
 #endif  // STARBOARD_TESTING_FAKE_GRAPHICS_CONTEXT_PROVIDER_H_


### PR DESCRIPTION
[go/cobalt-flatten-starboard-namespace](http://go/cobalt-flatten-starboard-namespace)

per [go/totw/151](http://go/totw/151#what-do-i-do) 
> No one should ever introduce a sub-namespace that matches a well-known top-level namespace like std, absl, proto, testing, etc

This refactoring is part of the ongoing effort to simplify the Starboard namespace structure. It removes unnecessary nesting and makes the testing utilities more accessible and consistent with the flattened namespace design.

Bug: 441955897