### PR TITLE
[Rebase M138] - Disable Unreachable Code warning for //media/starboard

### DIFF
--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -21,6 +21,10 @@ assert(use_starboard_media, "This file is only for use_starboard_media builds")
 import("//media/media_options.gni")
 import("//starboard/build/buildflags.gni")
 
+config("disable_unreachable_return") {
+  cflags = [ "-Wno-unreachable-code-return" ]
+}
+
 source_set("starboard") {
   visibility = [ "//media" ]
 
@@ -119,7 +123,10 @@ source_set("starboard") {
   # TODO(b/380940036): remove the circular dependency.
   allow_circular_includes_from = [ "//media/base" ]
 
-  configs += [ "//media:subcomponent_config" ]
+  configs += [
+    ":disable_unreachable_return",
+    "//media:subcomponent_config",
+  ]
 }
 
 source_set("unit_tests") {


### PR DESCRIPTION
Bug: 418842688

Various targets under //media/starboard were showing this error:

../../media/starboard/starboard_cdm.cc:343:7: error: 'return' will never be executed [-Werror,-Wunreachable-code-return]                                                                                                                   
  343 |       return;                                     
      |       ^~~~~~                                      
1 error generated.

../../media/starboard/progressive/avc_parser.cc:94:12: error: 'return' will never be executed [-Werror,-Wunreachable-code-return]
   94 |     return false;
      |            ^~~~~

All instances I've looked at are preceded by a NOTREACHED() macro, so this seems expected, but needed for compilation.