### PR TITLE
[Rebase M138] - add unreachable break to cflags

### DIFF
--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -22,8 +22,10 @@ import("//media/media_options.gni")
 import("//starboard/build/buildflags.gni")
 
 config("disable_unreachable_warnings") {
-  cflags = [ "-Wno-unreachable-code-return",
-             "-Wno-unreachable-code-break" ]
+  cflags = [
+    "-Wno-unreachable-code-return",
+    "-Wno-unreachable-code-break",
+  ]
 }
 
 source_set("starboard") {


### PR DESCRIPTION
Bug: 418842688

Similar error to the unreachable return:

../../media/starboard/progressive/mp4_map.cc:483:7: error: 'break' will never be executed [-Werror,-Wunreachable-code-break]
  483 |       break;                                                                                                 
      |       ^~~~~                                                                                                  
1 error generated.                                                                                                   
ninja: build stopped: subcommand failed.     