### PR TITLE
[Rebase m138] Fix scriptpromise types in crash_log

### DIFF
--- a/third_party/blink/renderer/modules/cobalt/crash_log/crash_log.cc
+++ b/third_party/blink/renderer/modules/cobalt/crash_log/crash_log.cc
@@ -32,11 +32,11 @@ CrashLog::CrashLog(LocalDOMWindow& window)
 
 void CrashLog::ContextDestroyed() {}
 
-ScriptPromise CrashLog::setString(ScriptState* script_state,
+ScriptPromise<IDLBoolean> CrashLog::setString(ScriptState* script_state,
                                   const String& key,
                                   const String& value,
                                   ExceptionState& exception_state) {
-  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLBoolean>>(
       script_state, exception_state.GetContext());
 
   EnsureReceiverIsBound();
@@ -49,7 +49,7 @@ ScriptPromise CrashLog::setString(ScriptState* script_state,
   return resolver->Promise();
 }
 
-void CrashLog::OnSetString(ScriptPromiseResolver* resolver, bool result) {
+void CrashLog::OnSetString(ScriptPromiseResolver<IDLBoolean>* resolver, bool result) {
   resolver->Resolve(result);
 }
 

--- a/third_party/blink/renderer/modules/cobalt/crash_log/crash_log.h
+++ b/third_party/blink/renderer/modules/cobalt/crash_log/crash_log.h
@@ -17,6 +17,7 @@
 
 #include "cobalt/browser/crash_annotator/public/mojom/crash_annotator.mojom-blink.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
+#include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
 #include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
 #include "third_party/blink/renderer/modules/modules_export.h"
 #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
@@ -29,7 +30,6 @@ namespace blink {
 
 class ExecutionContext;
 class LocalDOMWindow;
-class ScriptPromiseResolver;
 class ScriptState;
 
 class MODULES_EXPORT CrashLog final : public ScriptWrappable,
@@ -42,7 +42,7 @@ class MODULES_EXPORT CrashLog final : public ScriptWrappable,
   void ContextDestroyed() override;
 
   // Web-exposed interface:
-  ScriptPromise setString(ScriptState*,
+  ScriptPromise<IDLBoolean> setString(ScriptState*,
                           const String& key,
                           const String& value,
                           ExceptionState&);
@@ -51,7 +51,7 @@ class MODULES_EXPORT CrashLog final : public ScriptWrappable,
   void Trace(Visitor*) const override;
 
  private:
-  void OnSetString(ScriptPromiseResolver*, bool);
+  void OnSetString(ScriptPromiseResolver<IDLBoolean>*, bool);
   void EnsureReceiverIsBound();
 
   // TODO(cobalt, b/383301493): consider renaming the web interface and


### PR DESCRIPTION
Bug: 418842688

Upstream converted ScriptPromise and ScriptPromiseResolver to typed templates:
[chromium-review.googlesource.com/c/chromium/src/+/5381805](https://chromium-review.googlesource.com/c/chromium/src/+/5381805)