### PR TITLE
[Rebase m138] SimpleMenuModel refactor and mojo enum for MenuSourceType

### DIFF
--- a/cobalt/shell/browser/shell_web_contents_view_delegate.h
+++ b/cobalt/shell/browser/shell_web_contents_view_delegate.h
@@ -24,7 +24,7 @@
 #include "content/public/browser/web_contents_view_delegate.h"
 
 #if defined(SHELL_USE_TOOLKIT_VIEWS)
-#include "ui/base/models/simple_menu_model.h"    // nogncheck
+#include "ui/menus/simple_menu_model.h"    // nogncheck
 #include "ui/views/controls/menu/menu_runner.h"  // nogncheck
 #endif
 

--- a/cobalt/shell/browser/shell_web_contents_view_delegate_views.cc
+++ b/cobalt/shell/browser/shell_web_contents_view_delegate_views.cc
@@ -24,7 +24,8 @@
 #include "content/shell/common/shell_switches.h"
 #include "ui/aura/client/screen_position_client.h"
 #include "ui/aura/window.h"
-#include "ui/base/models/simple_menu_model.h"
+#include "ui/menus/simple_menu_model.h"
+#include "ui/base/mojom/menu_source_type.mojom.h"
 #include "ui/views/controls/menu/menu_runner.h"
 #include "ui/views/widget/widget.h"
 
@@ -110,7 +111,7 @@ void ShellWebContentsViewDelegate::ShowContextMenu(
       web_contents_->GetTopLevelNativeWindow());
   context_menu_runner_->RunMenuAt(
       widget, nullptr, gfx::Rect(screen_point, gfx::Size()),
-      views::MenuAnchorPosition::kTopRight, ui::MENU_SOURCE_NONE);
+      views::MenuAnchorPosition::kTopRight, ui::mojom::MenuSourceType::kNone);
 }
 
 }  // namespace content


### PR DESCRIPTION
Bug: 418842688

Chromium changes:
Move SimpleMenuModel out of ui/base | https://chromium-review.googlesource.com/c/chromium/src/+/5892572
[UI] Use mojo enum for `MenuSourceType` in content/ | https://chromium-review.googlesource.com/c/chromium/src/+/5922573