### PR TITLE
[Rebase m138] fix type mismatch in idl file and function impl

### DIFF
--- a/third_party/blink/renderer/modules/cobalt/encryptedmedia/media_keys_get_metrics.cc
+++ b/third_party/blink/renderer/modules/cobalt/encryptedmedia/media_keys_get_metrics.cc
@@ -23,7 +23,7 @@
 namespace blink {
 
 // static
-WebString MediaKeysGetMetrics::getMetrics(MediaKeys& media_keys,
+String MediaKeysGetMetrics::getMetrics(MediaKeys& media_keys,
                                           ExceptionState& exception_state) {
   return media_keys.getMetrics(exception_state);
 }

--- a/third_party/blink/renderer/modules/cobalt/encryptedmedia/media_keys_get_metrics.h
+++ b/third_party/blink/renderer/modules/cobalt/encryptedmedia/media_keys_get_metrics.h
@@ -16,7 +16,6 @@
 #define THIRD_PARTY_BLINK_RENDERER_MODULES_COBALT_ENCRYPTEDMEDIA_MEDIA_KEYS_GET_METRICS_H_
 
 #include "build/build_config.h"
-#include "third_party/blink/public/platform/web_string.h"
 #include "third_party/blink/renderer/platform/bindings/exception_state.h"
 
 namespace blink {
@@ -27,7 +26,7 @@ class MediaKeysGetMetrics {
   STATIC_ONLY(MediaKeysGetMetrics);
 
  public:
-  static WebString getMetrics(MediaKeys&, ExceptionState&);
+  static String getMetrics(MediaKeys&, ExceptionState&);
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/modules/encryptedmedia/media_keys.cc
+++ b/third_party/blink/renderer/modules/encryptedmedia/media_keys.cc
@@ -425,15 +425,15 @@ ScriptPromise<V8MediaKeyStatus> MediaKeys::getStatusForPolicy(
 }
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-WebString MediaKeys::getMetrics(ExceptionState& exception_state) {
+ToString MediaKeys::getMetrics(ExceptionState& exception_state) {
   std::string metrics;
   if (!cdm_ || !cdm_->GetMetrics(metrics)) {
     exception_state.ThrowDOMException(
         DOMExceptionCode::kInvalidStateError,
         !cdm_ ? "No active CDM" : "GetMetrics() failed");
-    return WebString();
+    return String();
   }
-  return WebString::FromUTF8(metrics);
+  return String::FromUTF8(metrics);
 }
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/third_party/blink/renderer/modules/encryptedmedia/media_keys.h
+++ b/third_party/blink/renderer/modules/encryptedmedia/media_keys.h
@@ -86,7 +86,7 @@ class MediaKeys : public ScriptWrappable,
                                                      ExceptionState&);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  WebString getMetrics(ExceptionState&);
+  String getMetrics(ExceptionState&);
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Indicates that the provided HTMLMediaElement wants to use this object.


### PR DESCRIPTION
Bug: 418842688

`third_party/blink/renderer/modules/cobalt/encryptedmedia/media_keys_extensions.idl` specifies the return type of GetMetrics as String, updated Cobalt functions to match.