### PR TITLE
android: Remove JNI prefixing workaround

### DIFF
--- a/base/android/jni_android.cc
+++ b/base/android/jni_android.cc
@@ -20,8 +20,6 @@
 #include "base/base_jni_headers/PiiElider_jni.h"
 #include "base/debug/debugging_buildflags.h"
 #include "base/logging.h"
-#include "base/base_switches.h"
-#include "base/command_line.h"
 #include "build/build_config.h"
 #include "third_party/abseil-cpp/absl/base/attributes.h"
 
@@ -39,52 +37,9 @@ ABSL_CONST_INIT thread_local void* stack_frame_pointer = nullptr;
 
 bool g_fatal_exception_occurred = false;
 
-/* Cobalt specific hack to move Java classes to a custom namespace.
-   For every class org.chromium.foo moves them to cobalt.org.chromium.foo
-   This works around link-time conflicts when building the final
-   package against other Chromium release artifacts. */
-#if BUILDFLAG(IS_COBALT)
-const char* COBALT_ORG_CHROMIUM = "cobalt/org/chromium";
-const char* ORG_CHROMIUM = "org/chromium";
-
-bool g_add_cobalt_prefix = false;
-std::atomic<bool> g_checked_command_line(false);
-
-std::string getRepackagedName(const char* signature) {
-  std::string holder(signature);
-  size_t pos = 0;
-  while ((pos = holder.find(ORG_CHROMIUM, pos)) != std::string::npos) {
-    holder.replace(pos, strlen(ORG_CHROMIUM), COBALT_ORG_CHROMIUM);
-    pos += strlen(COBALT_ORG_CHROMIUM);
-  }
-  return holder;
-}
-
-bool shouldAddCobaltPrefix() {
-  if (!g_checked_command_line && base::CommandLine::InitializedForCurrentProcess()) {
-    g_add_cobalt_prefix = base::CommandLine::ForCurrentProcess()->HasSwitch(switches::kCobaltJniPrefix);
-    g_checked_command_line = true;
-  }
-  return g_add_cobalt_prefix;
-}
-#endif
-
 ScopedJavaLocalRef<jclass> GetClassInternal(JNIEnv* env,
-#if BUILDFLAG(IS_COBALT)
-                                            const char* original_class_name,
-                                            jobject class_loader) {
-  const char* class_name;
-  std::string holder;
-  if (shouldAddCobaltPrefix()) {
-    holder = getRepackagedName(original_class_name);
-    class_name = holder.c_str();
-  } else {
-    class_name = original_class_name;
-  }
-#else
                                             const char* class_name,
                                             jobject class_loader) {
-#endif
   jclass clazz;
   if (class_loader != nullptr) {
     // ClassLoader.loadClass expects a classname with components separated by
@@ -281,17 +236,7 @@ jmethodID MethodID::LazyGet(JNIEnv* env,
   const jmethodID value = atomic_method_id->load(std::memory_order_acquire);
   if (value)
     return value;
-#if BUILDFLAG(IS_COBALT)
-  jmethodID id;
-  if (shouldAddCobaltPrefix()) {
-    std::string holder = getRepackagedName(jni_signature);
-    id = MethodID::Get<type>(env, clazz, method_name, holder.c_str());
-  } else {
-    id = MethodID::Get<type>(env, clazz, method_name, jni_signature);
-  }
-#else
   jmethodID id = MethodID::Get<type>(env, clazz, method_name, jni_signature);
-#endif
   atomic_method_id->store(id, std::memory_order_release);
   return id;
 }

--- a/base/base_switches.cc
+++ b/base/base_switches.cc
@@ -183,8 +183,4 @@ extern const char kEnableCrashpad[] = "enable-crashpad";
 const char kSchedulerBoostUrgent[] = "scheduler-boost-urgent";
 #endif
 
-#if BUILDFLAG(IS_COBALT)
-const char kCobaltJniPrefix[] = "cobalt-jni-prefix";
-#endif
-
 }  // namespace switches

--- a/base/base_switches.h
+++ b/base/base_switches.h
@@ -67,10 +67,6 @@ extern const char kEnableCrashpad[];
 extern const char kSchedulerBoostUrgent[];
 #endif
 
-#if BUILDFLAG(IS_COBALT)
-extern const char kCobaltJniPrefix[];
-#endif
-
 }  // namespace switches
 
 #endif  // BASE_BASE_SWITCHES_H_

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -161,6 +161,10 @@ source_set("common") {
   if (is_starboard) {
     deps += [ "//ui/ozone/platform/starboard:starboard" ]
   }
+
+  if (is_android) {
+    deps += [ "//components/cronet/android:cronet_static" ]
+  }
 }
 
 action("cobalt_build_info") {

--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -46,6 +46,7 @@ android_library("cobalt_main_java") {
     "//cobalt/shell/android:cobalt_shell_java",
     "//cobalt/shell/android:cobalt_shell_java_resources",
     "//cobalt/shell/android:cobalt_shell_jni_headers",
+    "//components/cronet/android:cronet_impl_native_base_java",
     "//components/version_info/android:version_constants_java",
     "//content/public/android:content_java",
     "//media/capture/video/android:capture_java",
@@ -156,6 +157,7 @@ android_library("cobalt_apk_java") {
   deps = [
     ":cobalt_main_java",
     "//base:base_java",
+    "//components/cronet/android:cronet_impl_native_base_java",
   ]
 
   sources = [
@@ -190,11 +192,16 @@ shared_library("libchrobalt") {
     "//cobalt/shell:cobalt_shell_lib",
     "//cobalt/shell:pak",
     "//components/crash/content/browser",
+    "//components/cronet/android:cronet_static",
     "//components/memory_system",
     "//media",
     "//skia",
     "//starboard/android/shared:starboard_jni_state",
     "//third_party/blink/public/common",
+
+    # Add the Cronet source set as a dependency. This links Cronet's C++
+    # code directly into libchrobalt.so.
+    # "//components/cronet/android:cronet_static",
   ]
 
   # Explicit dependency required for JNI registration to be able to

--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -121,6 +121,7 @@ android_library("cobalt_main_java") {
     "apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java",
     "apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java",
     "apk/app/src/main/java/dev/cobalt/util/AssetLoader.java",
+    "apk/app/src/main/java/dev/cobalt/util/BlockingHolder.java",
     "apk/app/src/main/java/dev/cobalt/util/DisplayUtil.java",
     "apk/app/src/main/java/dev/cobalt/util/Holder.java",
     "apk/app/src/main/java/dev/cobalt/util/IsEmulator.java",

--- a/cobalt/android/apk/app/proguard-rules.pro
+++ b/cobalt/android/apk/app/proguard-rules.pro
@@ -70,4 +70,4 @@
 
 # add to keep cronet classes as reflection is used to load cronet library.
 # without this, CronetProvider will fail on Kimono
--keep class org.chromium.net.** { *; }
+-keep class org.chromium.net.impl.NativeCronetProvider { *; }

--- a/cobalt/android/apk/app/proguard-rules.pro
+++ b/cobalt/android/apk/app/proguard-rules.pro
@@ -67,3 +67,7 @@
 # Keeps debugging information for stack traces for the ENTIRE app.
 # Without this dev.cobalt.coat.CobaltActivity.onStart() will be renamed to a.b.c.a()
 -keepattributes SourceFile,LineNumberTable
+
+# add to keep cronet classes as reflection is used to load cronet library.
+# without this, CronetProvider will fail on Kimono
+-keep class org.chromium.net.** { *; }

--- a/cobalt/android/apk/app/src/app/java/dev/cobalt/app/MainActivity.java
+++ b/cobalt/android/apk/app/src/app/java/dev/cobalt/app/MainActivity.java
@@ -54,7 +54,6 @@ public class MainActivity extends CobaltActivity {
 
   @Override
   public void onCreate(Bundle savedInstanceState) {
-    this.shouldSetJNIPrefix = false;
     super.onCreate(savedInstanceState);
   }
 }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -90,7 +90,6 @@ public abstract class CobaltActivity extends Activity {
   private Intent mLastSentIntent;
   private String mStartupUrl;
   private IntentRequestTracker mIntentRequestTracker;
-  protected Boolean shouldSetJNIPrefix = true;
   // Tracks whether we should reload the page on resume, to re-trigger a network error dialog.
   protected Boolean mShouldReloadOnResume = false;
   // Tracks the status of the FLAG_KEEP_SCREEN_ON window flag.
@@ -106,7 +105,7 @@ public abstract class CobaltActivity extends Activity {
       String[] commandLineArgs = getCommandLineParamsFromIntent(getIntent(), COMMAND_LINE_ARGS_KEY);
       CommandLineOverrideHelper.getFlagOverrides(
           new CommandLineOverrideHelper.CommandLineOverrideHelperParams(
-              shouldSetJNIPrefix, VersionInfo.isOfficialBuild(), commandLineArgs));
+              VersionInfo.isOfficialBuild(), commandLineArgs));
     }
 
     DeviceUtils.addDeviceSpecificUserAgentSwitch();

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -59,6 +59,7 @@ import org.chromium.content_public.browser.BrowserStartupController;
 import org.chromium.content_public.browser.DeviceUtils;
 import org.chromium.content_public.browser.JavascriptInjector;
 import org.chromium.content_public.browser.WebContents;
+import org.chromium.net.CronetEngine;
 import org.chromium.ui.base.ActivityWindowAndroid;
 import org.chromium.ui.base.IntentRequestTracker;
 
@@ -95,6 +96,22 @@ public abstract class CobaltActivity extends Activity {
   // Tracks the status of the FLAG_KEEP_SCREEN_ON window flag.
   private Boolean isKeepScreenOnEnabled = false;
   private String diagnosticFinishReason = "Unknown";
+
+  private CronetEngine mCronetEngine;
+
+  private void initializeCronetEngine() {
+    // 1. Create and configure the builder FIRST.
+    CronetEngine.Builder builder = new CronetEngine.Builder(this);
+    builder.enableHttp2(true)
+           .enableQuic(true);
+           // Add any other configuration here (e.g., caching, user-agent)
+
+    mCronetEngine = builder.build();
+  }
+
+  public CronetEngine getCronetEngine() {
+      return mCronetEngine;
+  }
 
   // Initially copied from ContentShellActiviy.java
   protected void createContent(final Bundle savedInstanceState) {
@@ -184,6 +201,7 @@ public abstract class CobaltActivity extends Activity {
                   }
                 }
                 Log.i(TAG, "Browser process init succeeded");
+                initializeCronetEngine();
                 finishInitialization(savedInstanceState);
 
                 if (isFinishing() || isDestroyed()) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -34,15 +34,12 @@ public final class CommandLineOverrideHelper {
     /** Param class to simplify #getFlagOverrides method signature */
     public static class CommandLineOverrideHelperParams {
         public CommandLineOverrideHelperParams(
-            boolean shouldSetJNIPrefix,
             boolean isOfficialBuild,
             String[] commandLineArgs) {
-            mShouldSetJNIPrefix = shouldSetJNIPrefix;
             mIsOfficialBuild = isOfficialBuild;
             mCommandLineArgs = commandLineArgs;
         }
 
-        private boolean mShouldSetJNIPrefix;
         private boolean mIsOfficialBuild;
         private String[] mCommandLineArgs;
     }
@@ -138,10 +135,6 @@ public final class CommandLineOverrideHelper {
             getDefaultBlinkEnableFeatureOverridesList();
 
         if (params != null) {
-            if (params.mShouldSetJNIPrefix) {
-                // Helps Kimono build avoid package name conflict with cronet.
-                cliOverrides.add("--cobalt-jni-prefix");
-            }
             if (!params.mIsOfficialBuild) {
                 cliOverrides.add(
                   "--remote-allow-origins="

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/BlockingHolder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/BlockingHolder.java
@@ -1,0 +1,79 @@
+package dev.cobalt.util;
+
+import androidx.annotation.Nullable;
+import java.util.concurrent.CountDownLatch;
+
+/**
+ * A generic, thread-safe holder for a single object that allows threads to block
+ * until the object is provided.
+ *
+ * <p>This is useful for asynchronous initialization where one thread needs to wait
+ * for a result from another. The {@link #set(T)} method should ideally be called only once.
+ *
+ * @param <T> The type of the object to hold.
+ */
+public class BlockingHolder<T> {
+
+    /**
+     * A latch that starts at 1 and is counted down to 0 when {@link #set(T)} is called.
+     * Threads calling {@link #getBlocking()} will wait on this latch.
+     */
+    private final CountDownLatch latch = new CountDownLatch(1);
+
+    /**
+     * The object being held. It is marked as 'volatile' to ensure that writes to this
+     * variable are immediately visible to other threads once the latch is released.
+     */
+    private volatile T instance;
+
+    /**
+     * Sets the object instance. This will release any threads that are currently
+     * waiting in {@link #getBlocking()}.
+     *
+     * <p>If this method is called more than once, it will overwrite the instance, but it
+     * will not affect threads that have already been released.
+     *
+     * @param instance The object instance to hold.
+     */
+    public void set(@Nullable T instance) {
+        this.instance = instance;
+        // This decrements the latch count to 0, releasing all waiting threads.
+        latch.countDown();
+    }
+
+    /**
+     * Blocks the calling thread until the value has been set, then returns the value.
+     * <p>
+     * <strong>DANGER:</strong> Do not call this from the main/UI thread, as it will
+     * freeze your application and likely cause an "Application Not Responding" (ANR) error.
+     * This method is intended for use on background threads.
+     *
+     * @return The instance held by this holder.
+     * @throws InterruptedException if the current thread is interrupted while waiting.
+     */
+    public T getBlocking() throws InterruptedException {
+        // This causes the current thread to wait until the latch has counted down to 0.
+        latch.await();
+        return instance;
+    }
+
+    /**
+     * Returns the instance immediately without blocking.
+     *
+     * @return The instance if it has been set, or {@code null} otherwise.
+     */
+    @Nullable
+    public T get() {
+        return instance;
+    }
+
+    /**
+     * Checks if the value has been set yet.
+     *
+     * @return {@code true} if the value has been set, {@code false} otherwise.
+     */
+    public boolean isSet() {
+        // The latch count is 0 if and only if countDown() has been called.
+        return latch.getCount() == 0;
+    }
+}

--- a/cobalt/app/cobalt_main_delegate.cc
+++ b/cobalt/app/cobalt_main_delegate.cc
@@ -27,6 +27,11 @@
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/common/content_switches.h"
 #include "gpu/command_buffer/service/gpu_switches.h"
+#if BUILDFLAG(IS_ANDROID)
+#include "components/cronet/android/cronet_integrated_mode_state.h"
+#include "content/public/browser/browser_main_runner.h"
+#include "content/public/browser/browser_thread.h"
+#endif
 
 namespace cobalt {
 
@@ -122,6 +127,16 @@ absl::variant<int, content::MainFunctionParams> CobaltMainDelegate::RunProcess(
       main_runner_->Initialize(std::move(main_function_params));
   DCHECK_LT(initialize_exit_code, 0)
       << "BrowserMainRunner::Initialize failed in ShellMainDelegate";
+
+#if BUILDFLAG(IS_ANDROID)
+  // In Cronet integrated mode, it relies on the host application to
+  // provide the network task runner. The main_runner_->Initialize() call
+  // above starts all the browser threads, so we can now get the IO thread
+  // task runner and pass it to Cronet. This must be done before control
+  // returns to Java, where the CronetEngine will be created.
+  cronet::SetIntegratedModeNetworkTaskRunner(
+      content::GetIOThreadTaskRunner({}).get());
+#endif
 
   // Return 0 as BrowserMain() should not be called after this, bounce up to
   // the system message loop for ContentShell, and we're already done thanks

--- a/cobalt/build/android/package.json
+++ b/cobalt/build/android/package.json
@@ -41,6 +41,7 @@
                 "gen/cobalt/android/cobalt_apk/generated_java/input_srcjars/androidx/fragment",
                 "gen/cobalt/android/cobalt_apk/generated_java/input_srcjars/gen/base_module",
                 "gen/cobalt/android/cobalt_apk/generated_java/input_srcjars/org/chromium",
+                "gen/cobalt/android/cobalt_apk/generated_java/input_srcjars/J",
                 "lib.java"
             ],
             "archive_type": "ARCHIVE_TYPE_ZIP"

--- a/cobalt/build/configs/android_common.gn
+++ b/cobalt/build/configs/android_common.gn
@@ -3,7 +3,3 @@ import("//cobalt/build/configs/common.gn")
 # This flag comes from build/config/compiler/compiler.gni
 # TODO(b/380339614): Remove this flag after resolving build errors.
 treat_warnings_as_errors = false
-
-# hashed jni names make build artifact opaque for Kimono build.
-use_hashed_jni_names = false
-use_errorprone_java_compiler = false

--- a/cobalt/build/configs/android_common.gn
+++ b/cobalt/build/configs/android_common.gn
@@ -3,3 +3,6 @@ import("//cobalt/build/configs/common.gn")
 # This flag comes from build/config/compiler/compiler.gni
 # TODO(b/380339614): Remove this flag after resolving build errors.
 treat_warnings_as_errors = false
+
+# Enable Cronet's integrated mode
+integrated_mode = true

--- a/components/cronet/android/BUILD.gn
+++ b/components/cronet/android/BUILD.gn
@@ -22,15 +22,17 @@ import("//url/features.gni")
 _templates_dir = "$target_gen_dir/templates"
 _gn_path = "//buildtools/linux64/gn"
 
-assert(!is_component_build)
-assert(is_cronet_build)
-
 declare_args() {
   # In integrated mode, CronetEngine will use the shared network task runner by
   # other Chromium-based clients like webview without self-initialization.
   # Besides, the native library would be compiled and loaded together with the
   # native library of host. This mode is only for Android.
   integrated_mode = false
+}
+
+if (!integrated_mode) {
+  assert(!is_component_build)
+  assert(is_cronet_build)
 }
 
 buildflag_header("buildflags") {

--- a/components/cronet/android/api/src/org/chromium/net/UrlRequest.java
+++ b/components/cronet/android/api/src/org/chromium/net/UrlRequest.java
@@ -118,6 +118,21 @@ public abstract class UrlRequest {
         }
 
         /**
+         * Binds the request to the specified network handle. Cronet will send this request only
+         * using the network associated to this handle. If this network disconnects the request will
+         * fail, the exact error will depend on the stage of request processing when the network
+         * disconnects. Network handles can be obtained through {@code Network#getNetworkHandle}.
+         * Only available starting from Android Marshmallow.
+         *
+         * @param networkHandle the network handle to bind the request to. Specify {@link
+         * CronetEngine#UNBIND_NETWORK_HANDLE} to unbind.
+         * @return the builder to facilitate chaining.
+         */
+        public Builder bindToNetwork(long networkHandle) {
+            return this;
+        }
+
+        /**
          * Sets {@link android.net.TrafficStats} tag to use when accounting socket traffic caused by
          * this request. See {@link android.net.TrafficStats} for more information. If no tag is set
          * (e.g. this method isn't called), then Android accounts for the socket traffic caused by


### PR DESCRIPTION
This commit removes the kCobaltJniPrefix command-line flag and all associated
C++ and Java code responsible for renaming JNI methods from org.chromium.* to
cobalt.org.chromium.*. This mechanism was a Cobalt-specific workaround to
prevent link-time conflicts when integrating with other Chromium components
like Cronet on Android.

With the adoption of Cronet's integrated mode, this JNI prefixing is no longer
required. Cronet is now built directly into the Cobalt application, simplifying
the JNI binding layer and enabling a more streamlined integration of network
functionality. It also improves maintainability and reduces code complexity.

Bug: 427296719

Change-Id: I07fad99eeee287e71243e48edd66d6d641c25588