### PR TITLE
[Rebase M138] Remove source_list from CSP conversion_util

### DIFF
--- a/third_party/blink/renderer/core/frame/csp/conversion_util.cc
+++ b/third_party/blink/renderer/core/frame/csp/conversion_util.cc
@@ -13,12 +13,7 @@ namespace {
 network::mojom::blink::CSPSourcePtr ConvertSource(const WebCSPSource& source) {
   return network::mojom::blink::CSPSource::New(
       source.scheme, source.host, source.port, source.path,
-#if BUILDFLAG(IS_COBALT)
-      source.is_host_wildcard, source.is_port_wildcard,
-      source_list.cobalt_insecure_local_network);
-#else
       source.is_host_wildcard, source.is_port_wildcard);
-#endif
 }
 
 network::mojom::blink::CSPHashSourcePtr ConvertHashSource(


### PR DESCRIPTION
Bug: 418842688

this was from a wrongly applied cherry-pick.  
There was a major refactor in https://chromium-review.googlesource.com/c/chromium/src/+/6181032

Previously we used IS_COBALT in ConvertToMojoBlink and ConvertToPublic (https://source.corp.google.com/h/lbshell-internal/cobalt_src/+/main:third_party/blink/renderer/core/frame/csp/conversion_util.cc?q=csp%2Fconversion_util.cc&sq=git:lbshell-internal%2Fcobalt_src@main)

ConvertToPublic was moved to third_party/blink/renderer/core/frame/csp/test_util.cc 
ConvertToMojoBlink was renamed to ConvertSourceList which has the correct IS_COBALT
