### PR TITLE
Turn off the plugin support

### DIFF
--- a/cobalt/build/configs/linux_common.gn
+++ b/cobalt/build/configs/linux_common.gn
@@ -110,3 +110,6 @@ use_dbus = false
 
 # Embed ICU data in the cobalt binary
 icu_use_data_file = false
+
+# Disable the Pepper API (PPAPI) plugin support
+enable_ppapi = false

--- a/content/renderer/pepper/plugin_module.cc
+++ b/content/renderer/pepper/plugin_module.cc
@@ -331,10 +331,6 @@ const void* GetInterface(const char* name) {
 // given structure. Returns true on success.
 bool LoadEntryPointsFromLibrary(const base::NativeLibrary& library,
                                 ContentPluginInfo::EntryPoints* entry_points) {
-// TODO: (cobalt b/409755808) Try to turn off pepper entirely with enable_ppapi=false.
-#if BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-  return false;
-#else
   entry_points->get_interface =
       reinterpret_cast<ContentPluginInfo::GetInterfaceFunc>(
           base::GetFunctionPointerFromNativeLibrary(library,
@@ -361,7 +357,6 @@ bool LoadEntryPointsFromLibrary(const base::NativeLibrary& library,
                                                     "PPP_ShutdownModule"));
 
   return true;
-#endif
 }
 
 void CreateHostForInProcessModule(RenderFrameImpl* render_frame,
@@ -427,10 +422,8 @@ PluginModule::~PluginModule() {
   if (entry_points_.shutdown_module)
     entry_points_.shutdown_module();
 
-#if !BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
   if (library_)
     base::UnloadNativeLibrary(library_);
-#endif
 
   // Notifications that we've been deleted should be last.
   HostGlobals::Get()->ModuleDeleted(pp_module_);
@@ -469,9 +462,7 @@ bool PluginModule::InitAsLibrary(const base::FilePath& path) {
 
   if (!LoadEntryPointsFromLibrary(library, &entry_points) ||
       !InitializeModule(entry_points)) {
-#if !BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
     base::UnloadNativeLibrary(library);
-#endif
     return false;
   }
   entry_points_ = entry_points;


### PR DESCRIPTION
This is a cleanup to use the gn
variable instead of guarding the code.

Issue: 409755808