### PR TITLE
BACKPORT: Don't set dirty bits for attribs that are out of range.

### DIFF
--- a/third_party/angle/include/platform/FrontendFeatures_autogen.h
+++ b/third_party/angle/include/platform/FrontendFeatures_autogen.h
@@ -116,6 +116,13 @@ struct FrontendFeatures : FeatureSetBase
     FeatureInfo disableProgramCaching = {"disableProgramCaching", FeatureCategory::FrontendFeatures,
                                          "Disables saving programs to the cache", &members,
                                          "http://anglebug.com/1423136"};
+
+    FeatureInfo forceMinimumMaxVertexAttributes = {
+        "forceMinimumMaxVertexAttributes",
+        FeatureCategory::FrontendFeatures,
+        "Force the minimum GL_MAX_VERTEX_ATTRIBS that the context's client version allows.",
+        &members, ""
+    };
 };
 
 inline FrontendFeatures::FrontendFeatures()  = default;

--- a/third_party/angle/include/platform/frontend_features.json
+++ b/third_party/angle/include/platform/frontend_features.json
@@ -145,6 +145,14 @@
                 "Disables saving programs to the cache"
             ],
             "issue": "http://anglebug.com/1423136"
+        },
+        {
+            "name": "force_minimum_max_vertex_attributes",
+            "category": "Features",
+            "description": [
+                "Force the minimum GL_MAX_VERTEX_ATTRIBS that the context's client version allows."
+            ],
+            "issue": ""
         }
     ]
 }

--- a/third_party/angle/src/libANGLE/Context.cpp
+++ b/third_party/angle/src/libANGLE/Context.cpp
@@ -4009,6 +4009,14 @@ void Context::initCaps()
     ANGLE_LIMIT_CAP(mState.mCaps.maxDrawBuffers, IMPLEMENTATION_MAX_DRAW_BUFFERS);
     ANGLE_LIMIT_CAP(mState.mCaps.maxColorAttachments, IMPLEMENTATION_MAX_DRAW_BUFFERS);
     ANGLE_LIMIT_CAP(mState.mCaps.maxVertexAttributes, MAX_VERTEX_ATTRIBS);
+    if (mDisplay->getFrontendFeatures().forceMinimumMaxVertexAttributes.enabled &&
+        getClientVersion() <= Version(2, 0))
+    {
+        // Only limit GL_MAX_VERTEX_ATTRIBS on ES2 or lower, the ES3+ cap is already at the minimum
+        // (16)
+        static_assert(MAX_VERTEX_ATTRIBS == 16);
+        ANGLE_LIMIT_CAP(mState.mCaps.maxVertexAttributes, 8);
+    }
     ANGLE_LIMIT_CAP(mState.mCaps.maxVertexAttribStride,
                     static_cast<GLint>(limits::kMaxVertexAttribStride));
 

--- a/third_party/angle/src/libANGLE/Display.cpp
+++ b/third_party/angle/src/libANGLE/Display.cpp
@@ -2243,6 +2243,8 @@ void Display::initializeFrontendFeatures()
     // Togglable until work on the extension is complete - anglebug.com/7279.
     ANGLE_FEATURE_CONDITION(&mFrontendFeatures, emulatePixelLocalStorage, true);
 
+    ANGLE_FEATURE_CONDITION(&mFrontendFeatures, forceMinimumMaxVertexAttributes, false);
+
     mImplementation->initializeFrontendFeatures(&mFrontendFeatures);
 
     rx::ApplyFeatureOverrides(&mFrontendFeatures, mState);

--- a/third_party/angle/src/libANGLE/State.cpp
+++ b/third_party/angle/src/libANGLE/State.cpp
@@ -494,6 +494,8 @@ void State::initialize(Context *context)
         SetComponentTypeMask(ComponentType::Float, i, &mCurrentValuesTypeMask);
     }
 
+    mAllAttribsMask = AttributesMask(angle::BitMask<uint32_t>(mCaps.maxVertexAttributes));
+
     mUniformBuffers.resize(mCaps.maxUniformBufferBindings);
 
     mSamplerTextures[TextureType::_2D].resize(mCaps.maxCombinedTextureImageUnits);

--- a/third_party/angle/src/libANGLE/State.h
+++ b/third_party/angle/src/libANGLE/State.h
@@ -768,7 +768,7 @@ class State : angle::NonCopyable
     {
         mDirtyBits.set();
         mExtendedDirtyBits.set();
-        mDirtyCurrentValues.set();
+        mDirtyCurrentValues = mAllAttribsMask;
     }
 
     using ExtendedDirtyBits = angle::BitSet32<EXTENDED_DIRTY_BIT_MAX>;
@@ -1119,6 +1119,9 @@ class State : angle::NonCopyable
     VertexAttribVector mVertexAttribCurrentValues;  // From glVertexAttrib
     VertexArray *mVertexArray;
     ComponentTypeMask mCurrentValuesTypeMask;
+
+    // Mask of all attributes that are available to this context: [0, maxVertexAttributes)
+    AttributesMask mAllAttribsMask;
 
     // Texture and sampler bindings
     GLint mActiveSampler;  // Active texture unit selector - GL_TEXTURE0

--- a/third_party/angle/src/libANGLE/renderer/gl/StateManagerGL.cpp
+++ b/third_party/angle/src/libANGLE/renderer/gl/StateManagerGL.cpp
@@ -2115,14 +2115,16 @@ angle::Result StateManagerGL::syncState(const gl::Context *context,
                     gl::VertexArray::DirtyBindingBitsArray dirtBindingBits;
 
                     dirtyBits.set(gl::VertexArray::DIRTY_BIT_ELEMENT_ARRAY_BUFFER);
-                    for (size_t attrib = 0; attrib < mDefaultVAOState.attributes.size(); attrib++)
+                    for (GLint attrib = 0; attrib < context->getCaps().maxVertexAttributes;
+                         attrib++)
                     {
                         dirtyBits.set(gl::VertexArray::DIRTY_BIT_ATTRIB_0 + attrib);
                         dirtyAttribBits[attrib].set(gl::VertexArray::DIRTY_ATTRIB_ENABLED);
                         dirtyAttribBits[attrib].set(gl::VertexArray::DIRTY_ATTRIB_POINTER);
                         dirtyAttribBits[attrib].set(gl::VertexArray::DIRTY_ATTRIB_POINTER_BUFFER);
                     }
-                    for (size_t binding = 0; binding < mDefaultVAOState.bindings.size(); binding++)
+                    for (GLint binding = 0; binding < context->getCaps().maxVertexAttribBindings;
+                         binding++)
                     {
                         dirtyBits.set(gl::VertexArray::DIRTY_BIT_BINDING_0 + binding);
                         dirtBindingBits[binding].set(gl::VertexArray::DIRTY_BINDING_DIVISOR);

--- a/third_party/angle/src/tests/gl_tests/VertexAttributeTest.cpp
+++ b/third_party/angle/src/tests/gl_tests/VertexAttributeTest.cpp
@@ -3682,6 +3682,12 @@ TEST_P(VertexAttributeTest, AliasingVectorAttribLocations)
     // TODO(anglebug.com/5491): iOS GLSL compiler rejects attribute aliasing.
     ANGLE_SKIP_TEST_IF(IsIOS() && IsOpenGLES());
 
+    // This test needs 10 total attributes. All backends support this except some old Android
+    // devices.
+    GLint maxVertexAttribs = 0;
+    glGetIntegerv(GL_MAX_VERTEX_ATTRIBS, &maxVertexAttribs);
+    ANGLE_SKIP_TEST_IF(maxVertexAttribs < 10);
+
     constexpr char kVS[] = R"(attribute vec4 position;
 // 4 aliasing attributes
 attribute float attr0f;
@@ -4075,6 +4081,12 @@ TEST_P(VertexAttributeTest, AliasingVectorAttribLocationsDifferingPrecisions)
 
     // TODO(anglebug.com/5491): iOS GLSL compiler rejects attribute aliasing.
     ANGLE_SKIP_TEST_IF(IsIOS() && IsOpenGLES());
+
+    // This test needs 16 total attributes. All backends support this except some old Android
+    // devices.
+    GLint maxVertexAttribs = 0;
+    glGetIntegerv(GL_MAX_VERTEX_ATTRIBS, &maxVertexAttribs);
+    ANGLE_SKIP_TEST_IF(maxVertexAttribs < 16);
 
     constexpr char kVS[] = R"(attribute vec4 position;
 // aliasing attributes.
@@ -4496,6 +4508,8 @@ ANGLE_INSTANTIATE_TEST_ES2_AND_ES3_AND(
     ES3_VULKAN_SWIFTSHADER().enable(Feature::ForceFallbackFormat),
     ES3_METAL().disable(Feature::HasExplicitMemBarrier).disable(Feature::HasCheapRenderPass),
     ES3_METAL().disable(Feature::HasExplicitMemBarrier).enable(Feature::HasCheapRenderPass),
+    ES2_OPENGL().enable(Feature::ForceMinimumMaxVertexAttributes),
+    ES2_OPENGLES().enable(Feature::ForceMinimumMaxVertexAttributes),
     EMULATED_VAO_CONFIGS);
 
 ANGLE_INSTANTIATE_TEST_ES2_AND_ES3_AND(

--- a/third_party/angle/util/angle_features_autogen.cpp
+++ b/third_party/angle/util/angle_features_autogen.cpp
@@ -154,6 +154,7 @@ constexpr PackedEnumMap<Feature, const char *> kFeatureNames = {{
     {Feature::ForceGlErrorChecking, "forceGlErrorChecking"},
     {Feature::ForceInitShaderVariables, "forceInitShaderVariables"},
     {Feature::ForceMaxUniformBufferSize16KB, "forceMaxUniformBufferSize16KB"},
+    {Feature::ForceMinimumMaxVertexAttributes, "forceMinimumMaxVertexAttributes"},
     {Feature::ForceNearestFiltering, "forceNearestFiltering"},
     {Feature::ForceNearestMipFiltering, "forceNearestMipFiltering"},
     {Feature::ForceNonCSBaseMipmapGeneration, "forceNonCSBaseMipmapGeneration"},

--- a/third_party/angle/util/angle_features_autogen.h
+++ b/third_party/angle/util/angle_features_autogen.h
@@ -146,6 +146,7 @@ enum class Feature
     ForceGlErrorChecking,
     ForceInitShaderVariables,
     ForceMaxUniformBufferSize16KB,
+    ForceMinimumMaxVertexAttributes,
     ForceNearestFiltering,
     ForceNearestMipFiltering,
     ForceNonCSBaseMipmapGeneration,


### PR DESCRIPTION
This CL backports https://chromium-review.googlesource.com/c/angle/angle/+/5008034 to address an out-of-bounds access bug.

I did some minor modifications to resolve conflict. Some of the upstream code has been moving around, for example FrontendFeatures_autogen.h is in include/platform/autogen/FrontendFeatures_autogen.h in the upstream. And in Context.cpp, it calls caps->maxVertexAttributes and there are some dependency on other PR, I keep the minimum change, and fix it by directly call mState.mCaps.maxVertexAttributes.

Bug: 437918195

Original commit description:
PrivateState::setAllDirtyBits sets all bits in mDirtyCurrentValues. When the context has fewer max attibutes than MAX_VERTEX_ATTRIBS, this can cause out-of-bounds access to
PrivateState::mVertexAttribCurrentValues if the dirty bits are iterated over without range validation.