### PR TITLE
[Rebase M138] Fix Mojo Decoder Buffer Converter

### DIFF
--- a/media/mojo/common/mojo_decoder_buffer_converter.cc
+++ b/media/mojo/common/mojo_decoder_buffer_converter.cc
@@ -130,7 +130,7 @@ void MojoDecoderBufferReader::ReadDecoderBuffer(
     // Release its ref-count that was increased manually during
     // DecoderBuffer and DecoderBufferPtr conversion.
     scoped_refptr<media::DecoderBuffer> buffer(
-        reinterpret_cast<media::DecoderBuffer*>(mojo_buffer->address));
+        reinterpret_cast<media::DecoderBuffer*>(mojo_buffer->get_data()->address));
     buffer->Release();
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
     return;


### PR DESCRIPTION
Bug: 418842688

Minor adjustment to media/mojo/common/mojo_decoder_buffer_converter.cc
very similar change to https://github.com/youtube/cobalt/pull/7364

DecoderBuffer Mojo transport was split into EOS and data types via a Union:
https://chromium-review.googlesource.com/c/chromium/src/+/5918375
so we need to access the (starboard specific) address field via get_data() on the union to ensure we have a DecoderBuffer data type.