### PR TITLE
[tvOS] Replace tvos-arm64 configuration with tvos-arm64-device

### DIFF
--- a/cobalt/build/configs/tvos-arm64-device/args.gn
+++ b/cobalt/build/configs/tvos-arm64-device/args.gn
@@ -1,0 +1,4 @@
+import("//cobalt/build/configs/tvos_common.gn")
+
+target_cpu = "arm64"
+target_environment = "device"

--- a/cobalt/build/configs/tvos-arm64/args.gn
+++ b/cobalt/build/configs/tvos-arm64/args.gn
@@ -1,8 +1,0 @@
-import("//cobalt/build/configs/common.gn")
-
-# TODO: b/443797654 - Temporarily use "ios" until rebase is complete.
-target_os = "ios"
-target_cpu = "arm64"
-
-# System xcode is default in upstream Chromium and CI infra.
-use_system_xcode = true

--- a/cobalt/build/gn.py
+++ b/cobalt/build/gn.py
@@ -70,8 +70,8 @@ _COBALT_ANDROID_PLATFORMS = [
     'android-x86',
 ]
 _COBALT_TVOS_PLATFORMS = [
+    'tvos-arm64-device',
     'tvos-arm64-simulator',
-    'tvos-arm64',
 ]
 
 

--- a/starboard/build/platforms.py
+++ b/starboard/build/platforms.py
@@ -40,6 +40,7 @@ PLATFORMS = {
     'evergreen-arm-hardfp': 'starboard/evergreen/arm/hardfp',
     'evergreen-arm-softfp': 'starboard/evergreen/arm/softfp',
     'evergreen-arm64': 'starboard/evergreen/arm64',
+    'tvos-arm64-device': 'starboard/tvos/arm64/device',
     'tvos-arm64-simulator': 'starboard/tvos/arm64/simulator',
 }
 PLATFORMS.update(INTERNAL_PLATFORMS)

--- a/starboard/tvos/arm64/device/BUILD.gn
+++ b/starboard/tvos/arm64/device/BUILD.gn
@@ -1,0 +1,17 @@
+# Copyright 2025 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+static_library("starboard_platform") {
+  public_deps = [ "//starboard/tvos/shared:starboard_platform" ]
+}

--- a/starboard/tvos/arm64/device/configuration_public.h
+++ b/starboard/tvos/arm64/device/configuration_public.h
@@ -1,0 +1,20 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_TVOS_ARM64_DEVICE_CONFIGURATION_PUBLIC_H_
+#define STARBOARD_TVOS_ARM64_DEVICE_CONFIGURATION_PUBLIC_H_
+
+#include "starboard/tvos/shared/configuration_public.h"
+
+#endif  // STARBOARD_TVOS_ARM64_DEVICE_CONFIGURATION_PUBLIC_H_

--- a/starboard/tvos/arm64/device/platform_configuration/configuration.gni
+++ b/starboard/tvos/arm64/device/platform_configuration/configuration.gni
@@ -1,0 +1,15 @@
+# Copyright 2025 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//starboard/tvos/shared/platform_configuration/configuration.gni")


### PR DESCRIPTION
Follow-up to #7065 now that #7107 has landed:

* Use a suffix so that we now have both "-simulator" and "-device" configurations.
* Make `args.gn` include `tvos_common.gni` and behave like the tvos-arm64-simulator configuration.
* Add the missing bits to starboard/build and starboard/tvos that hook this configuration into the build.

Note that this is not usable yet: actually having a build that works requires more backports, so it is better to just wait for the work on M138 to start. These bits are independent from the Chromium milestone and can be landed now.

Co-authored-by: Julie Jeongeun Kim <jkim@igalia.com>

Bug: 442923940