### PR TITLE
[XB1] Fix crash on shader compilation

### DIFF
--- a/starboard/shared/uwp/extended_resources_manager.cc
+++ b/starboard/shared/uwp/extended_resources_manager.cc
@@ -181,6 +181,7 @@ void ExtendedResourcesManager::Quit() {
 }
 
 void ExtendedResourcesManager::ReleaseBuffersHeap() {
+  ScopedLock scoped_lock(mutex_);
   d3d12FrameBuffersHeap_.Reset();
 }
 


### PR DESCRIPTION
GOOGAMCONS-258

This change fixes a race condition between ReleaseBuffersHeap() and CompileShadersAsynchronously().