### PR TITLE
android: Fix Build Error with ShellManagerTest

### DIFF
--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java
@@ -23,7 +23,7 @@ import android.widget.FrameLayout;
 
 import dev.cobalt.shell.Shell;
 import dev.cobalt.shell.ShellManager;
-import org.chromium.components.embedder_support.view.ContentViewRenderView;
+import dev.cobalt.shell.ContentViewRenderView;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;


### PR DESCRIPTION
Currently, if we try to build `cobalt_coat_junit_tests` off of main, we are met with this compile error:

```
../../cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java:64: error: incompatible types: org.chromium.components.embedder_support.view.ContentViewRenderView cannot be converted to dev.cobalt.shell.ContentViewRenderView
    shell.setContentViewRenderView(mockContentViewRenderView);
```

Changing the import in ShellManagerTest to use Cobalt's `ContentViewRenderView` instead of Chromium's fixes the issue.

Bug: 433568263