### PR TITLE
Playing around with some LOGs to see what's allocated by graphics.

### DIFF
--- a/cc/slim/layer_tree_cc_wrapper.cc
+++ b/cc/slim/layer_tree_cc_wrapper.cc
@@ -52,6 +52,10 @@ LayerTreeCcWrapper::LayerTreeCcWrapper(InitParams init_params)
     : client_(init_params.client) {
   animation_host_ = cc::AnimationHost::CreateMainInstance();
 
+  LOG(ERROR) << "miguelao, are we using Slim CC for Browser UI";
+  // These |settings| are left to its defaults which means: a large,
+  // desktop-like compositor. That's bad, but if we don't use it, the caches
+  // won't fill up and there would be no memory used... right? To investigate.
   cc::LayerTreeSettings settings;
   settings.use_zero_copy = true;
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();

--- a/cc/trees/layer_tree_host_impl.cc
+++ b/cc/trees/layer_tree_host_impl.cc
@@ -1821,6 +1821,16 @@ void LayerTreeHostImpl::UpdateTileManagerMemoryPolicy(
          settings_.max_memory_for_prepaint_percentage) /
         100;
   }
+
+  LOG(ERROR) << (uint64_t)this << " miguelao policy.bytes_limit_when_visible="
+             << policy.bytes_limit_when_visible
+             << ", settings_.max_memory_for_prepaint_percentage="
+             << settings_.max_memory_for_prepaint_percentage
+             << ", global_tile_state_.hard_memory_limit_in_bytes="
+             << global_tile_state_.hard_memory_limit_in_bytes
+             << ", global_tile_state_.soft_memory_limit_in_bytes="
+             << global_tile_state_.soft_memory_limit_in_bytes;
+
   global_tile_state_.memory_limit_policy =
       ManagedMemoryPolicy::PriorityCutoffToTileMemoryLimitPolicy(
           visible_ ? policy.priority_cutoff_when_visible

--- a/cobalt/android/apk/app/build.gradle
+++ b/cobalt/android/apk/app/build.gradle
@@ -124,6 +124,19 @@ android {
         qa {
             debuggable true
             jniDebuggable true
+            minifyEnabled false
+            shrinkResources false
+            packagingOptions {
+                doNotStrip "**/*.so"
+            }
+            externalNativeBuild {
+                cmake {
+                    cppFlags '-g'
+                }
+                ndkBuild {
+                    cFlags '-g'
+                }
+            }
             externalNativeBuild {
                 cmake.arguments "-DCOBALT_CONFIG=qa"
             }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -76,6 +76,10 @@ public final class CommandLineOverrideHelper {
         // Rasterize Tiles directly to GPU memory.
         paramOverrides.add("--enable-zero-copy");
 
+        // Limit the total amount of memory that may be allocated for GPU
+        // resources. Left to its devices, it's usually 64MB.
+        //paramOverrides.add("--force-gpu-mem-available-mb=48");
+
         return paramOverrides;
     }
 

--- a/third_party/blink/renderer/platform/widget/compositing/layer_tree_settings.cc
+++ b/third_party/blink/renderer/platform/widget/compositing/layer_tree_settings.cc
@@ -91,7 +91,7 @@ cc::ManagedMemoryPolicy GetGpuMemoryPolicy(
   cc::ManagedMemoryPolicy actual = default_policy;
   actual.bytes_limit_when_visible = 0;
   actual.priority_cutoff_when_visible =
-      gpu::MemoryAllocation::CUTOFF_ALLOW_NICE_TO_HAVE;
+      gpu::MemoryAllocation::CUTOFF_ALLOW_REQUIRED_ONLY;
 
   // If the value was overridden on the command line, use the specified value.
   static bool client_hard_limit_bytes_overridden =
@@ -107,6 +107,8 @@ cc::ManagedMemoryPolicy GetGpuMemoryPolicy(
     return actual;
   }
 
+    LOG(ERROR) << "miguelao, actual.bytes_limit_when_visible=" << actual.bytes_limit_when_visible;
+
 #if BUILDFLAG(IS_ANDROID)
   if (base::SysInfo::IsLowEndDevice() ||
       base::SysInfo::AmountOfPhysicalMemoryMB() < 2000) {
@@ -114,6 +116,7 @@ cc::ManagedMemoryPolicy GetGpuMemoryPolicy(
   } else {
     actual.bytes_limit_when_visible = 256 * 1024 * 1024;
   }
+    LOG(ERROR) << "miguelao, actual.bytes_limit_when_visible=" << actual.bytes_limit_when_visible;
 #else
   // Ignore what the system said and give all clients the same maximum
   // allocation on desktop platforms.
@@ -407,13 +410,16 @@ cc::LayerTreeSettings GenerateLayerTreeSettings(
     // On low-end we want to be very careful about killing other
     // apps. So initially we use 50% more memory to avoid flickering
     // or raster-on-demand.
-    settings.max_memory_for_prepaint_percentage = 67;
+    settings.max_memory_for_prepaint_percentage = 25;
   } else {
     // On other devices we have increased memory excessively to avoid
     // raster-on-demand already, so now we reserve 50% _only_ to avoid
     // raster-on-demand, and use 50% of the memory otherwise.
     settings.max_memory_for_prepaint_percentage = 50;
   }
+  LOG(ERROR) << "miguelao, using_low_memory_policy=" << using_low_memory_policy
+             << ", settings.max_memory_for_prepaint_percentage="
+             << settings.max_memory_for_prepaint_percentage;
 
   // TODO(danakj): Only do this on low end devices.
   settings.create_low_res_tiling = true;


### PR DESCRIPTION
With the tweaks in //third_party/blink/.../layer_tree_settings.cc, I see
way less 1920x288 Tiles allocated (5 vs 11). This corresponds to there not
being Tiles for offscreen rastered content (SkewPort). Good?