### PR TITLE
Revert "Revert "Create lean UI library for Cobalt ATV""

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -63,7 +63,7 @@ android_library("cobalt_main_java") {
     "//third_party/androidx:androidx_core_core_java",
     "//third_party/androidx:androidx_customview_customview_java",
     "//third_party/androidx:androidx_media_media_java",
-    "//ui/android:ui_java",
+    "//ui/android:cobalt_ui_full_java",
     "//url:gurl_java",
   ]
 
@@ -236,7 +236,6 @@ android_apk("cobalt_apk") {
     "//media/capture/video/android:capture_java",
     "//net/android:net_java",
     "//third_party/mesa_headers",
-    "//ui/android:ui_java",
   ]
   shared_libraries = [ ":libchrobalt" ]
   include_size_info = is_official_build

--- a/cobalt/shell/android/BUILD.gn
+++ b/cobalt/shell/android/BUILD.gn
@@ -73,14 +73,12 @@ android_library("cobalt_shell_java") {
     "//base:jni_java",
     "//build/android:build_java",
     "//components/download/internal/common:internal_java",
-    "//components/viz/service:service_java",
     "//content/public/android:content_java",
     "//media/base/android:media_java",
     "//media/capture/video/android:capture_java",
     "//mojo/public/java:system_java",
     "//net/android:net_java",
-    "//ui/android:ui_java",
-    "//ui/android:ui_no_recycler_view_java",
+    "//ui/android:cobalt_ui_full_java",
     "//ui/base/cursor/mojom:cursor_type_java",
     "//url:gurl_java",
   ]
@@ -123,7 +121,7 @@ android_library("cobalt_shell_test_apk_java") {
     "//media/capture/video/android:capture_java",
     "//net/android:net_java",
     "//third_party/android_deps:com_google_code_findbugs_jsr305_java",
-    "//ui/android:ui_java",
+    "//ui/android:cobalt_ui_full_java",
     "//url:gurl_java",
   ]
 
@@ -170,7 +168,7 @@ template("cobalt_shell_apk_tmpl") {
       "//net/android:net_java",
       "//services/shape_detection:shape_detection_java",
       "//third_party/mesa_headers",
-      "//ui/android:ui_java",
+      "//ui/android:cobalt_ui_full_java",
     ]
   }
 }
@@ -209,7 +207,7 @@ android_library("cobalt_shell_test_java") {
     "//third_party/androidx:androidx_test_runner_java",
     "//third_party/hamcrest:hamcrest_java",
     "//third_party/junit:junit",
-    "//ui/android:ui_java",
+    "//ui/android:cobalt_ui_full_java",
     "//url:gurl_java",
   ]
   sources = [
@@ -228,7 +226,7 @@ android_library("cobalt_shell_browsertests_java") {
     "//content/public/android:content_java",
     "//testing/android/native_test:native_test_java",
     "//third_party/androidx:androidx_core_core_java",
-    "//ui/android:ui_java",
+    "//ui/android:cobalt_ui_full_java",
   ]
   sources = [ "browsertests/src/org/chromium/content_shell/browsertests/ContentShellBrowserTestActivity.java" ]
 }

--- a/cobalt/shell/android/BUILD.gn
+++ b/cobalt/shell/android/BUILD.gn
@@ -73,6 +73,7 @@ android_library("cobalt_shell_java") {
     "//base:jni_java",
     "//build/android:build_java",
     "//components/download/internal/common:internal_java",
+    "//components/viz/service:service_java",
     "//content/public/android:content_java",
     "//media/base/android:media_java",
     "//media/capture/video/android:capture_java",

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/Shell.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/Shell.java
@@ -16,11 +16,7 @@ package dev.cobalt.shell;
 
 import android.app.Activity;
 import android.content.Context;
-import android.graphics.Rect;
 import android.text.TextUtils;
-import android.view.ActionMode;
-import android.view.Menu;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
@@ -28,10 +24,8 @@ import org.chromium.base.Callback;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.content_public.browser.ActionModeCallbackHelper;
 import org.chromium.content_public.browser.LoadUrlParams;
 import org.chromium.content_public.browser.NavigationController;
-import org.chromium.content_public.browser.SelectionPopupController;
 import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.base.ViewAndroidDelegate;
 import org.chromium.ui.base.WindowAndroid;
@@ -221,43 +215,7 @@ public class Shell {
         }
     }
 
-    /**
-     * {link @ActionMode.Callback} that uses the default implementation in
-     * {@link SelectionPopupController}.
-     */
-    private ActionMode.Callback2 defaultActionCallback() {
-        final ActionModeCallbackHelper helper =
-                SelectionPopupController.fromWebContents(mWebContents)
-                        .getActionModeCallbackHelper();
 
-        return new ActionMode.Callback2() {
-            @Override
-            public boolean onCreateActionMode(ActionMode mode, Menu menu) {
-                helper.onCreateActionMode(mode, menu);
-                return true;
-            }
-
-            @Override
-            public boolean onPrepareActionMode(ActionMode mode, Menu menu) {
-                return helper.onPrepareActionMode(mode, menu);
-            }
-
-            @Override
-            public boolean onActionItemClicked(ActionMode mode, MenuItem item) {
-                return helper.onActionItemClicked(mode, item);
-            }
-
-            @Override
-            public void onDestroyActionMode(ActionMode mode) {
-                helper.onDestroyActionMode();
-            }
-
-            @Override
-            public void onGetContentRect(ActionMode mode, View view, Rect outRect) {
-                helper.onGetContentRect(mode, view, outRect);
-            }
-        };
-    }
 
     @CalledByNative
     public void setOverlayMode(boolean useOverlayMode) {

--- a/components/location/android/BUILD.gn
+++ b/components/location/android/BUILD.gn
@@ -17,6 +17,11 @@ android_library("location_java") {
     "//third_party/androidx:androidx_annotation_annotation_java",
     "//ui/android:ui_no_recycler_view_java",
   ]
+
+  if (is_cobalt) {
+    deps -= [ "//ui/android:ui_no_recycler_view_java" ]
+    deps += [ "//ui/android:cobalt_ui_full_java" ]
+  }
   sources = [ "java/src/org/chromium/components/location/LocationUtils.java" ]
   srcjar_deps = [ ":location_settings_dialog_enums_java" ]
 }

--- a/content/public/android/BUILD.gn
+++ b/content/public/android/BUILD.gn
@@ -124,6 +124,12 @@ android_library("content_main_dex_java") {
     ":generate_sandboxed_service_srcjar",
   ]
   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+
+  if (is_cobalt) {
+    deps -= [ "//ui/android:ui_no_recycler_view_java" ]
+
+    deps += [ "//ui/android:cobalt_ui_full_java" ]
+  }
 }
 
 android_library("content_full_java") {
@@ -189,10 +195,10 @@ android_library("content_full_java") {
   ]
 
   # TODO(b/443992661): Add a GN flag to conditionally disable or enable shape detection.
-  if(is_cobalt) {
+  if (is_cobalt) {
     deps -= [ "//services/shape_detection:shape_detection_java" ]
   }
-  
+
   srcjar_deps = [
     ":is_ready_to_pay_service_aidl",
     "//content/browser:client_data_json_generated_enum",
@@ -390,6 +396,59 @@ android_library("content_full_java") {
   ]
   annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
   proguard_configs = [ "proguard.flags" ]
+
+  if (is_cobalt) {
+    sources -= [
+      "java/src/org/chromium/content/browser/ContentClassFactory.java",
+      "java/src/org/chromium/content/browser/ContentUiEventHandler.java",
+      "java/src/org/chromium/content/browser/GestureListenerManagerImpl.java",
+      "java/src/org/chromium/content/browser/PopupController.java",
+      "java/src/org/chromium/content/browser/ViewEventSinkImpl.java",
+      "java/src/org/chromium/content/browser/input/ImeAdapterImpl.java",
+      "java/src/org/chromium/content/browser/input/SelectPopup.java",
+      "java/src/org/chromium/content/browser/input/SelectPopupAdapter.java",
+      "java/src/org/chromium/content/browser/input/SelectPopupDialog.java",
+      "java/src/org/chromium/content/browser/input/SelectPopupDropdown.java",
+      "java/src/org/chromium/content/browser/input/SelectPopupItem.java",
+      "java/src/org/chromium/content/browser/input/SpellCheckPopupWindow.java",
+      "java/src/org/chromium/content/browser/input/SuggestionsPopupWindow.java",
+      "java/src/org/chromium/content/browser/input/TextSuggestionHost.java",
+      "java/src/org/chromium/content/browser/input/TextSuggestionsPopupWindow.java",
+      "java/src/org/chromium/content/browser/selection/AdditionalMenuItemProvider.java",
+      "java/src/org/chromium/content/browser/selection/AdditionalMenuItemProviderImpl.java",
+      "java/src/org/chromium/content/browser/selection/FloatingPastePopupMenu.java",
+      "java/src/org/chromium/content/browser/selection/LGEmailActionModeWorkaroundImpl.java",
+      "java/src/org/chromium/content/browser/selection/MagnifierAnimator.java",
+      "java/src/org/chromium/content/browser/selection/MagnifierWrapper.java",
+      "java/src/org/chromium/content/browser/selection/MagnifierWrapperImpl.java",
+      "java/src/org/chromium/content/browser/selection/PastePopupMenu.java",
+      "java/src/org/chromium/content/browser/selection/SelectionIndicesConverter.java",
+      "java/src/org/chromium/content/browser/selection/SelectionPopupControllerImpl.java",
+      "java/src/org/chromium/content/browser/selection/SmartSelectionClient.java",
+      "java/src/org/chromium/content/browser/selection/SmartSelectionEventProcessor.java",
+      "java/src/org/chromium/content/browser/selection/SmartSelectionProvider.java",
+      "java/src/org/chromium/content/browser/webcontents/WebContentsImpl.java",
+      "java/src/org/chromium/content_public/browser/ActionModeCallbackHelper.java",
+      "java/src/org/chromium/content_public/browser/GestureListenerManager.java",
+      "java/src/org/chromium/content_public/browser/LGEmailActionModeWorkaround.java",
+      "java/src/org/chromium/content_public/browser/SelectionClient.java",
+      "java/src/org/chromium/content_public/browser/SelectionPopupController.java",
+    ]
+
+    sources += [
+      "java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/ContentUiEventHandler.java",
+      "java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/ViewEventSinkImpl.java",
+      "java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/input/ImeAdapterImpl.java",
+      "java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/webcontents/WebContentsImpl.java",
+    ]
+    deps -= [
+      "//device/bluetooth:java",
+      "//ui/android:ui_no_recycler_view_java",
+      "//ui/android:ui_utils_java",
+    ]
+
+    deps += [ "//ui/android:cobalt_ui_full_java" ]
+  }
 }
 
 java_strings_grd("content_strings_grd") {

--- a/content/public/android/java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/ContentUiEventHandler.java
+++ b/content/public/android/java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/ContentUiEventHandler.java
@@ -1,0 +1,205 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.content.browser;
+
+import android.os.SystemClock;
+import android.view.InputDevice;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.UserData;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.content.browser.input.ImeAdapterImpl;
+import org.chromium.content.browser.webcontents.WebContentsImpl;
+import org.chromium.content.browser.webcontents.WebContentsImpl.UserDataFactory;
+import org.chromium.content_public.browser.ViewEventSink.InternalAccessDelegate;
+import org.chromium.content_public.browser.WebContents;
+import org.chromium.ui.MotionEventUtils;
+import org.chromium.ui.base.EventForwarder;
+
+/**
+ * Called from native to handle UI events that need access to various Java layer
+ * content components.
+ */
+@JNINamespace("content")
+public class ContentUiEventHandler implements UserData {
+    private final WebContentsImpl mWebContents;
+    private InternalAccessDelegate mEventDelegate;
+    private long mNativeContentUiEventHandler;
+
+    private static final class UserDataFactoryLazyHolder {
+        private static final UserDataFactory<ContentUiEventHandler> INSTANCE =
+                ContentUiEventHandler::new;
+    }
+
+    public static ContentUiEventHandler fromWebContents(WebContents webContents) {
+        return ((WebContentsImpl) webContents)
+                .getOrSetUserData(ContentUiEventHandler.class, UserDataFactoryLazyHolder.INSTANCE);
+    }
+
+    public ContentUiEventHandler(WebContents webContents) {
+        mWebContents = (WebContentsImpl) webContents;
+        mNativeContentUiEventHandler =
+                ContentUiEventHandlerJni.get().init(ContentUiEventHandler.this, webContents);
+    }
+
+    @VisibleForTesting
+    static ContentUiEventHandler createForTesting(
+            WebContents webContents, long nativeContentUiEventHandler) {
+        ContentUiEventHandler contentUiEventHandler = new ContentUiEventHandler(webContents);
+        contentUiEventHandler.mNativeContentUiEventHandler = nativeContentUiEventHandler;
+        return contentUiEventHandler;
+    }
+
+    public void setEventDelegate(InternalAccessDelegate delegate) {
+        mEventDelegate = delegate;
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PRIVATE)
+    @CalledByNative
+    protected boolean onGenericMotionEvent(MotionEvent event) {
+        if (Gamepad.from(mWebContents).onGenericMotionEvent(event)) return true;
+        if (JoystickHandler.fromWebContents(mWebContents).onGenericMotionEvent(event)) return true;
+        if ((event.getSource() & InputDevice.SOURCE_CLASS_POINTER) != 0) {
+            switch (event.getActionMasked()) {
+                case MotionEvent.ACTION_SCROLL:
+                    onMouseWheelEvent(event);
+                    return true;
+                case MotionEvent.ACTION_BUTTON_PRESS:
+                case MotionEvent.ACTION_BUTTON_RELEASE:
+                    // TODO(mustaq): Should we include MotionEvent.TOOL_TYPE_STYLUS here?
+                    // https://crbug.com/592082
+                    if (event.getToolType(0) == MotionEvent.TOOL_TYPE_MOUSE) {
+                        return onMouseEvent(event, false);
+                    }
+            }
+        }
+        if (isTrackpadEventThatNeedsConversion(event)) {
+            return onMouseEvent(event, true);
+        }
+        return mEventDelegate.super_onGenericMotionEvent(event);
+    }
+
+    private boolean isTrackpadEventThatNeedsConversion(MotionEvent event) {
+        return mWebContents.getEventForwarder().isTrackpadToMouseEventConversionEnabled()
+                && EventForwarder.isTrackpadClickOrClickAndDragEvent(event);
+    }
+
+    private void onMouseWheelEvent(MotionEvent event) {
+        assert mNativeContentUiEventHandler != 0;
+        ContentUiEventHandlerJni.get().sendMouseWheelEvent(mNativeContentUiEventHandler,
+                ContentUiEventHandler.this, MotionEventUtils.getEventTimeNano(event), event.getX(),
+                event.getY(), event.getAxisValue(MotionEvent.AXIS_HSCROLL),
+                event.getAxisValue(MotionEvent.AXIS_VSCROLL));
+    }
+
+    private boolean onMouseEvent(MotionEvent event, boolean shouldConvertToMouseEvent) {
+        assert mNativeContentUiEventHandler != 0;
+        EventForwarder eventForwarder = mWebContents.getEventForwarder();
+        boolean didOffsetEvent = false;
+        MotionEvent newEvent = eventForwarder.createOffsetMotionEventIfNeeded(event);
+        if (newEvent != event) {
+            didOffsetEvent = true;
+            event = newEvent;
+        }
+        ContentUiEventHandlerJni.get().sendMouseEvent(mNativeContentUiEventHandler,
+                ContentUiEventHandler.this, MotionEventUtils.getEventTimeNano(event),
+                event.getActionMasked(), event.getX(), event.getY(), event.getPointerId(0),
+                event.getPressure(0), event.getOrientation(0),
+                event.getAxisValue(MotionEvent.AXIS_TILT, 0),
+                EventForwarder.getMouseEventActionButton(event), event.getButtonState(),
+                event.getMetaState(),
+                shouldConvertToMouseEvent ? MotionEvent.TOOL_TYPE_MOUSE : event.getToolType(0));
+        if (didOffsetEvent) event.recycle();
+        return true;
+    }
+
+    @CalledByNative
+    private boolean onKeyUp(int keyCode, KeyEvent event) {
+        return mEventDelegate.super_onKeyUp(keyCode, event);
+    }
+
+    @CalledByNative
+    private boolean dispatchKeyEvent(KeyEvent event) {
+        if (Gamepad.from(mWebContents).dispatchKeyEvent(event)) return true;
+        if (!shouldPropagateKeyEvent(event)) {
+            return mEventDelegate.super_dispatchKeyEvent(event);
+        }
+
+        if (ImeAdapterImpl.fromWebContents(mWebContents).dispatchKeyEvent(event)) return true;
+
+        return mEventDelegate.super_dispatchKeyEvent(event);
+    }
+
+    /**
+     * Check whether a key should be propagated to the embedder or not.
+     * We need to send almost every key to Blink. However:
+     * 1. We don't want to block the device on the renderer for
+     * some keys like menu, home, call.
+     * 2. There are no WebKit equivalents for some of these keys
+     * (see app/keyboard_codes_win.h)
+     * Note that these are not the same set as KeyEvent.isSystemKey:
+     * for instance, AKEYCODE_MEDIA_* will be dispatched to webkit*.
+     * 3. KEYCODE_SYSRQ is the keycode received when Print screen is pressed
+     * on a hardware keyboard. Do not propagate this to allow Android Platform
+     * to take a screenshot.
+     */
+    private static boolean shouldPropagateKeyEvent(KeyEvent event) {
+        int keyCode = event.getKeyCode();
+        if (keyCode == KeyEvent.KEYCODE_MENU || keyCode == KeyEvent.KEYCODE_HOME
+                || keyCode == KeyEvent.KEYCODE_BACK || keyCode == KeyEvent.KEYCODE_CALL
+                || keyCode == KeyEvent.KEYCODE_ENDCALL || keyCode == KeyEvent.KEYCODE_POWER
+                || keyCode == KeyEvent.KEYCODE_HEADSETHOOK || keyCode == KeyEvent.KEYCODE_CAMERA
+                || keyCode == KeyEvent.KEYCODE_FOCUS || keyCode == KeyEvent.KEYCODE_VOLUME_DOWN
+                || keyCode == KeyEvent.KEYCODE_VOLUME_MUTE || keyCode == KeyEvent.KEYCODE_VOLUME_UP
+                || keyCode == KeyEvent.KEYCODE_SYSRQ) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * @see View#scrollBy(int, int)
+     * Currently the ContentView scrolling happens in the native side. In
+     * the Java view system, it is always pinned at (0, 0). scrollBy() and scrollTo()
+     * are overridden, so that View's mScrollX and mScrollY will be unchanged at
+     * (0, 0). This is critical for drawing ContentView correctly.
+     */
+    @CalledByNative
+    private void scrollBy(float dxPix, float dyPix) {
+        if (dxPix == 0 && dyPix == 0) return;
+        long time = SystemClock.uptimeMillis();
+        ContentUiEventHandlerJni.get().sendScrollEvent(
+                mNativeContentUiEventHandler, ContentUiEventHandler.this, time, dxPix, dyPix);
+    }
+
+    @CalledByNative
+    private void scrollTo(float xPix, float yPix) {
+        final float xCurrentPix = mWebContents.getRenderCoordinates().getScrollXPix();
+        final float yCurrentPix = mWebContents.getRenderCoordinates().getScrollYPix();
+        final float dxPix = xPix - xCurrentPix;
+        final float dyPix = yPix - yCurrentPix;
+        scrollBy(dxPix, dyPix);
+    }
+
+    @NativeMethods
+    interface Natives {
+        long init(ContentUiEventHandler caller, WebContents webContents);
+        void sendMouseWheelEvent(long nativeContentUiEventHandler, ContentUiEventHandler caller,
+                long timeNs, float x, float y, float ticksX, float ticksY);
+        void sendMouseEvent(long nativeContentUiEventHandler, ContentUiEventHandler caller,
+                long timeNs, int action, float x, float y, int pointerId, float pressure,
+                float orientation, float tilt, int changedButton, int buttonState, int metaState,
+                int toolType);
+        void sendScrollEvent(long nativeContentUiEventHandler, ContentUiEventHandler caller,
+                long timeMs, float deltaX, float deltaY);
+        void cancelFling(
+                long nativeContentUiEventHandler, ContentUiEventHandler caller, long timeMs);
+    }
+}

--- a/content/public/android/java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/ViewEventSinkImpl.java
+++ b/content/public/android/java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/ViewEventSinkImpl.java
@@ -1,0 +1,170 @@
+// Copyright 2018 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.content.browser;
+
+import android.content.res.Configuration;
+
+import org.chromium.base.TraceEvent;
+import org.chromium.base.UserData;
+import org.chromium.content.browser.webcontents.WebContentsImpl;
+import org.chromium.content.browser.webcontents.WebContentsImpl.UserDataFactory;
+import org.chromium.content_public.browser.ViewEventSink;
+import org.chromium.content_public.browser.WebContents;
+import org.chromium.ui.base.ViewAndroidDelegate;
+import org.chromium.ui.base.ViewUtils;
+import org.chromium.ui.base.WindowAndroid.ActivityStateObserver;
+
+/**
+ * Implementation of the interface {@link ViewEventSink}.
+ */
+public final class ViewEventSinkImpl implements ViewEventSink, ActivityStateObserver, UserData {
+    private final WebContentsImpl mWebContents;
+
+    // Whether the container view has view-level focus.
+    private Boolean mHasViewFocus;
+
+    // This is used in place of window focus on the container view, as we can't actually use window
+    // focus due to issues where content expects to be focused while a popup steals window focus.
+    // See https://crbug.com/686232 for more context.
+    private boolean mPaused;
+
+    // Whether we consider this WebContents to have input focus. This is computed through
+    // mHasViewFocus and mPaused. See the comments on mPaused for how this doesn't exactly match
+    // Android's notion of input focus and why we need to do this.
+    private Boolean mHasInputFocus;
+    private boolean mHideKeyboardOnBlur;
+
+    private static final class UserDataFactoryLazyHolder {
+        private static final UserDataFactory<ViewEventSinkImpl> INSTANCE = ViewEventSinkImpl::new;
+    }
+
+    public static ViewEventSinkImpl from(WebContents webContents) {
+        return ((WebContentsImpl) webContents)
+                .getOrSetUserData(ViewEventSinkImpl.class, UserDataFactoryLazyHolder.INSTANCE);
+    }
+
+    public ViewEventSinkImpl(WebContents webContents) {
+        mWebContents = (WebContentsImpl) webContents;
+    }
+
+    @Override
+    public void setAccessDelegate(ViewEventSink.InternalAccessDelegate accessDelegate) {
+        ContentUiEventHandler.fromWebContents(mWebContents).setEventDelegate(accessDelegate);
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        WindowEventObserverManager.from(mWebContents).onAttachedToWindow();
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+        WindowEventObserverManager.from(mWebContents).onDetachedFromWindow();
+        // Stylus Writing
+        if (mWebContents.getStylusWritingHandler() != null) {
+            ViewAndroidDelegate viewAndroidDelegate = mWebContents.getViewAndroidDelegate();
+            if (viewAndroidDelegate != null) {
+                mWebContents.getStylusWritingHandler().onDetachedFromWindow(
+                        viewAndroidDelegate.getContainerView().getContext());
+            }
+        }
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean hasWindowFocus) {
+        WindowEventObserverManager.from(mWebContents).onWindowFocusChanged(hasWindowFocus);
+    }
+
+    @Override
+    public void onViewFocusChanged(boolean gainFocus) {
+        if (mHasViewFocus != null && mHasViewFocus == gainFocus) return;
+        mHasViewFocus = gainFocus;
+        onFocusChanged();
+
+        // Stylus Writing
+        if (mWebContents.getStylusWritingHandler() != null) {
+            mWebContents.getStylusWritingHandler().onFocusChanged(gainFocus);
+        }
+    }
+
+    @Override
+    public void setHideKeyboardOnBlur(boolean hideKeyboardOnBlur) {
+        mHideKeyboardOnBlur = hideKeyboardOnBlur;
+    }
+
+    @SuppressWarnings("javadoc")
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        try {
+            TraceEvent.begin("ViewEventSink.onConfigurationChanged");
+            WindowEventObserverManager.from(mWebContents).onConfigurationChanged(newConfig);
+            // To request layout has side effect, but it seems OK as it only happen in
+            // onConfigurationChange and layout has to be changed in most case.
+            ViewAndroidDelegate delegate = mWebContents.getViewAndroidDelegate();
+            if (delegate != null) {
+                ViewUtils.requestLayout(
+                        delegate.getContainerView(), "ViewEventSinkImpl.onConfigurationChanged");
+            }
+        } finally {
+            TraceEvent.end("ViewEventSink.onConfigurationChanged");
+        }
+    }
+
+    private void onFocusChanged() {
+        // Wait for view focus to be set before propagating focus changes.
+        if (mHasViewFocus == null) return;
+
+        // See the comments on mPaused for why we use it to compute input focus.
+        boolean hasInputFocus = mHasViewFocus && !mPaused;
+        if (mHasInputFocus != null && mHasInputFocus == hasInputFocus) return;
+        mHasInputFocus = hasInputFocus;
+
+        if (mWebContents == null) {
+            // CVC is on its way to destruction. The rest needs not running as all the states
+            // will be discarded, or WebContentsUserData-based objects are not reachable
+            // any more. Simply return here.
+            return;
+        }
+        WindowEventObserverManager.from(mWebContents)
+                .onViewFocusChanged(mHasInputFocus, mHideKeyboardOnBlur);
+        mWebContents.setFocus(mHasInputFocus);
+    }
+
+    // ActivityStateObserver
+
+    @Override
+    public void onActivityPaused() {
+        // When the activity pauses, the content should lose focus.
+        // TODO(mthiesse): See https://crbug.com/686232 for context. Desktop platforms use keyboard
+        // focus to trigger blur/focus, and the equivalent to this on Android is Window focus.
+        // However, we don't use Window focus because of the complexity around popups stealing
+        // Window focus.
+        if (mPaused) return;
+        mPaused = true;
+        onFocusChanged();
+    }
+
+    @Override
+    public void onActivityResumed() {
+        // When the activity resumes, the View#onFocusChanged may not be called, so we should
+        // restore the View focus state.
+        if (!mPaused) return;
+        mPaused = false;
+        onFocusChanged();
+    }
+
+    @Override
+    public void onActivityDestroyed() {}
+
+    @Override
+    public void onPauseForTesting() {
+        onActivityPaused();
+    }
+
+    @Override
+    public void onResumeForTesting() {
+        onActivityResumed();
+    }
+}

--- a/content/public/android/java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/input/ImeAdapterImpl.java
+++ b/content/public/android/java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/input/ImeAdapterImpl.java
@@ -1,0 +1,1373 @@
+// Copyright 2012 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.content.browser.input;
+
+import android.content.Context;
+import android.content.res.Configuration;
+import android.graphics.Color;
+import android.graphics.Point;
+import android.graphics.Rect;
+import android.graphics.RectF;
+import android.os.Build;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.ResultReceiver;
+import android.os.SystemClock;
+import android.text.SpannableString;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.text.style.BackgroundColorSpan;
+import android.text.style.CharacterStyle;
+import android.text.style.SuggestionSpan;
+import android.text.style.UnderlineSpan;
+import android.util.SparseArray;
+import android.view.KeyCharacterMap;
+import android.view.KeyEvent;
+import android.view.MotionEvent;
+import android.view.View;
+import android.view.inputmethod.BaseInputConnection;
+import android.view.inputmethod.EditorBoundsInfo;
+import android.view.inputmethod.EditorInfo;
+import android.view.inputmethod.ExtractedText;
+import android.view.inputmethod.InputConnection;
+import android.view.inputmethod.InputMethodManager;
+
+import androidx.annotation.VisibleForTesting;
+import androidx.core.view.inputmethod.EditorInfoCompat;
+
+import org.chromium.base.ContextUtils;
+import org.chromium.base.Log;
+import org.chromium.base.TraceEvent;
+import org.chromium.base.UserData;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.blink.mojom.EventType;
+import org.chromium.blink.mojom.FocusType;
+import org.chromium.blink.mojom.HandwritingGestureResult;
+import org.chromium.blink.mojom.StylusWritingGestureData;
+import org.chromium.blink_public.web.WebInputEventModifier;
+import org.chromium.blink_public.web.WebTextInputMode;
+import org.chromium.content.browser.WindowEventObserver;
+import org.chromium.content.browser.WindowEventObserverManager;
+import org.chromium.content.browser.picker.InputDialogContainer;
+import org.chromium.content.browser.webcontents.WebContentsImpl;
+import org.chromium.content.browser.webcontents.WebContentsImpl.UserDataFactory;
+import org.chromium.content_public.browser.ImeAdapter;
+import org.chromium.content_public.browser.ImeEventObserver;
+import org.chromium.content_public.browser.InputMethodManagerWrapper;
+import org.chromium.content_public.browser.StylusWritingImeCallback;
+import org.chromium.content_public.browser.WebContents;
+import org.chromium.ui.base.ViewAndroidDelegate;
+import org.chromium.ui.base.ViewUtils;
+import org.chromium.ui.base.WindowAndroid;
+import org.chromium.ui.base.ime.TextInputAction;
+import org.chromium.ui.base.ime.TextInputType;
+import org.chromium.ui.mojom.VirtualKeyboardPolicy;
+import org.chromium.ui.mojom.VirtualKeyboardVisibilityRequest;
+
+import java.lang.ref.WeakReference;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Implementation of the interface {@link ImeAdapter} providing an interface
+ * in both ways native <-> java:
+ *
+ * 1. InputConnectionAdapter notifies native code of text composition state and
+ *    dispatch key events from java -> WebKit.
+ * 2. Native ImeAdapter notifies java side to clear composition text.
+ *
+ * The basic flow is:
+ * 1. When InputConnectionAdapter gets called with composition or result text:
+ *    If we receive a composition text or a result text, then we just need to
+ *    dispatch a synthetic key event with special keycode 229, and then dispatch
+ *    the composition or result text.
+ * 2. Intercept dispatchKeyEvent() method for key events not handled by IME, we
+ *   need to dispatch them to webkit and check webkit's reply. Then inject a
+ *   new key event for further processing if webkit didn't handle it.
+ *
+ * Note that the native peer object does not take any strong reference onto the
+ * instance of this java object, hence it is up to the client of this class (e.g.
+ * the ViewEmbedder implementor) to hold a strong reference to it for the required
+ * lifetime of the object.
+ */
+@JNINamespace("content")
+public class ImeAdapterImpl
+        implements ImeAdapter, WindowEventObserver, UserData, InputMethodManagerWrapper.Delegate {
+    private static final String TAG = "Ime";
+    private static final boolean DEBUG_LOGS = false;
+
+    private static final float SUGGESTION_HIGHLIGHT_BACKGROUND_TRANSPARENCY = 0.4f;
+
+    public static final int COMPOSITION_KEY_CODE = ImeAdapter.COMPOSITION_KEY_CODE;
+
+    // Color used by AOSP Android for a SuggestionSpan with FLAG_EASY_CORRECT set
+    private static final int DEFAULT_SUGGESTION_SPAN_COLOR = 0x88C8C8C8;
+
+    private long mNativeImeAdapterAndroid;
+    private InputMethodManagerWrapper mInputMethodManagerWrapper;
+    private ChromiumBaseInputConnection mInputConnection;
+    private ChromiumBaseInputConnection.Factory mInputConnectionFactory;
+
+    // NOTE: This object will not be released by Android framework until the matching
+    // ResultReceiver in the InputMethodService (IME app) gets gc'ed.
+    private ShowKeyboardResultReceiver mShowKeyboardResultReceiver;
+
+    private final WebContentsImpl mWebContents;
+    private ViewAndroidDelegate mViewDelegate;
+    private WindowAndroid mWindowAndroid;
+
+    // This holds the information necessary for constructing CursorAnchorInfo, and notifies to
+    // InputMethodManager on appropriate timing, depending on how IME requested the information
+    // via InputConnection. The update request is per InputConnection, hence for each time it is
+    // re-created, the monitoring status will be reset.
+    private final CursorAnchorInfoController mCursorAnchorInfoController;
+
+    private final List<ImeEventObserver> mEventObservers = new ArrayList<>();
+
+    private int mTextInputType = TextInputType.NONE;
+    private int mTextInputFlags;
+    private int mTextInputMode = WebTextInputMode.DEFAULT;
+    private int mTextInputAction = TextInputAction.DEFAULT;
+    private boolean mNodeEditable;
+    private boolean mNodePassword;
+
+    // Viewport rect before the OSK was brought up.
+    // Used to tell View#onSizeChanged to focus a form element.
+    private final Rect mFocusPreOSKViewportRect = new Rect();
+
+    // Keep the current configuration to detect the change when onConfigurationChanged() is called.
+    private Configuration mCurrentConfig;
+
+    private int mLastSelectionStart;
+    private int mLastSelectionEnd;
+    private String mLastText;
+    private int mLastCompositionStart;
+    private int mLastCompositionEnd;
+    private boolean mRestartInputOnNextStateUpdate;
+    // Do not access directly, use getStylusWritingImeCallback() instead.
+    private StylusWritingImeCallback mStylusWritingImeCallback;
+    private SparseArray<OngoingGesture> mOngoingGestures = new SparseArray<>();
+
+    // True if ImeAdapter is connected to render process.
+    private boolean mIsConnected;
+
+    // Whether to force show keyboard during stylus handwriting. We do not show it when writing
+    // system is active and stylus is used to edit input text. This is used to show the soft
+    // keyboard from Direct writing toolbar.
+    private boolean mForceShowKeyboardDuringStylusWriting;
+
+    /**
+     * {@ResultReceiver} passed in InputMethodManager#showSoftInput}. We need this to scroll to the
+     * editable node at the right timing, which is after input method window shows up.
+     */
+    private static class ShowKeyboardResultReceiver extends ResultReceiver {
+        // Unfortunately, the memory life cycle of ResultReceiver object, once passed in
+        // showSoftInput(), is in the control of Android's input method framework and IME app,
+        // so we use a weakref to avoid tying ImeAdapter's lifetime to that of ResultReceiver
+        // object.
+        private final WeakReference<ImeAdapterImpl> mImeAdapter;
+
+        public ShowKeyboardResultReceiver(ImeAdapterImpl imeAdapter, Handler handler) {
+            super(handler);
+            mImeAdapter = new WeakReference<>(imeAdapter);
+        }
+
+        @Override
+        public void onReceiveResult(int resultCode, Bundle resultData) {
+            ImeAdapterImpl imeAdapter = mImeAdapter.get();
+            if (imeAdapter == null) return;
+            imeAdapter.onShowKeyboardReceiveResult(resultCode);
+        }
+    }
+
+    private static final class UserDataFactoryLazyHolder {
+        private static final UserDataFactory<ImeAdapterImpl> INSTANCE = ImeAdapterImpl::new;
+    }
+
+    /**
+     * Get {@link ImeAdapter} object used for the give WebContents.
+     * {@link #create()} should precede any calls to this.
+     * @param webContents {@link WebContents} object.
+     * @return {@link ImeAdapter} object.
+     */
+    public static ImeAdapterImpl fromWebContents(WebContents webContents) {
+        return ((WebContentsImpl) webContents)
+                .getOrSetUserData(ImeAdapterImpl.class, UserDataFactoryLazyHolder.INSTANCE);
+    }
+
+    /**
+     * Returns an instance of the default {@link InputMethodManagerWrapper}
+     */
+    public static InputMethodManagerWrapper createDefaultInputMethodManagerWrapper(Context context,
+            WindowAndroid windowAndroid, InputMethodManagerWrapper.Delegate delegate) {
+        return new InputMethodManagerWrapperImpl(context, windowAndroid, delegate);
+    }
+
+    /**
+     * Create {@link ImeAdapterImpl} instance.
+     * @param webContents WebContents instance.
+     */
+    public ImeAdapterImpl(WebContents webContents) {
+        mWebContents = (WebContentsImpl) webContents;
+        mViewDelegate = mWebContents.getViewAndroidDelegate();
+        assert mViewDelegate != null;
+
+        // Use application context here to avoid leaking the activity context.
+        InputMethodManagerWrapper wrapper = createDefaultInputMethodManagerWrapper(
+                ContextUtils.getApplicationContext(), mWebContents.getTopLevelNativeWindow(), this);
+
+        // Deep copy newConfig so that we can notice the difference.
+        mCurrentConfig = new Configuration(getContainerView().getResources().getConfiguration());
+
+        mCursorAnchorInfoController = CursorAnchorInfoController.create(
+                wrapper, new CursorAnchorInfoController.ComposingTextDelegate() {
+                    @Override
+                    public CharSequence getText() {
+                        return mLastText;
+                    }
+                    @Override
+                    public int getSelectionStart() {
+                        return mLastSelectionStart;
+                    }
+                    @Override
+                    public int getSelectionEnd() {
+                        return mLastSelectionEnd;
+                    }
+                    @Override
+                    public int getComposingTextStart() {
+                        return mLastCompositionStart;
+                    }
+                    @Override
+                    public int getComposingTextEnd() {
+                        return mLastCompositionEnd;
+                    }
+                });
+        mInputMethodManagerWrapper = wrapper;
+        mNativeImeAdapterAndroid = ImeAdapterImplJni.get().init(ImeAdapterImpl.this, mWebContents);
+        WindowEventObserverManager.from(mWebContents).addObserver(this);
+    }
+
+    @Override
+    public InputConnection getActiveInputConnection() {
+        return mInputConnection;
+    }
+
+    @Override
+    public InputConnection onCreateInputConnection(EditorInfo outAttrs) {
+        boolean allowKeyboardLearning = mWebContents != null && !mWebContents.isIncognito();
+        InputConnection inputConnection = onCreateInputConnection(outAttrs, allowKeyboardLearning);
+
+        if (mWebContents.getStylusWritingHandler() != null) {
+            mWebContents.getStylusWritingHandler().updateEditorInfo(outAttrs);
+        }
+
+        return StylusGestureHandler.maybeProxyInputConnection(inputConnection, this::handleGesture);
+    }
+
+    private void handleGesture(OngoingGesture request) {
+        if (request.getGestureData() == null) {
+            request.onGestureHandled(HandwritingGestureResult.UNSUPPORTED);
+            return;
+        }
+        mOngoingGestures.put(request.getId(), request);
+
+        // Offset the gesture rectangles to convert from screen coordinates to window coordinates.
+        int[] screenLocation = new int[2];
+        mWebContents.getViewAndroidDelegate().getContainerView().getLocationOnScreen(
+                screenLocation);
+        request.getGestureData().startRect.x -= screenLocation[0];
+        request.getGestureData().startRect.y -= screenLocation[1];
+        if (request.getGestureData().endRect != null) {
+            request.getGestureData().endRect.x -= screenLocation[0];
+            request.getGestureData().endRect.y -= screenLocation[1];
+        }
+
+        getStylusWritingImeCallback().handleStylusWritingGestureAction(
+                request.getId(), request.getGestureData());
+    }
+
+    @CalledByNative
+    private void onStylusWritingGestureActionCompleted(
+            int id, @HandwritingGestureResult.EnumType int result) {
+        if (mOngoingGestures.get(id) != null) {
+            mOngoingGestures.get(id).onGestureHandled(result);
+            mOngoingGestures.remove(id);
+        } else {
+            assert id == -1;
+        }
+    }
+
+    @Override
+    public boolean onCheckIsTextEditor() {
+        return isTextInputType(mTextInputType);
+    }
+
+    private boolean isHardwareKeyboardAttached() {
+        return mCurrentConfig.keyboard != Configuration.KEYBOARD_NOKEYS;
+    }
+
+    @Override
+    public void addEventObserver(ImeEventObserver eventObserver) {
+        mEventObservers.add(eventObserver);
+    }
+
+    private void createInputConnectionFactory() {
+        if (mInputConnectionFactory != null) return;
+        mInputConnectionFactory = new ThreadedInputConnectionFactory(mInputMethodManagerWrapper);
+    }
+
+    // Tells if the ImeAdapter in valid state (i.e. not in destroyed state), and is
+    // connected to render process. The former check guards against the call via
+    // ThreadedInputConnection from Android framework after ImeAdapter.destroy() is called.
+    private boolean isValid() {
+        return mNativeImeAdapterAndroid != 0 && mIsConnected;
+    }
+
+    // Whether the focused node allows the soft keyboard to be displayed. A content editable
+    // region is editable but may disallow the soft keyboard from being displayed. Composition
+    // should still be allowed with a physical keyboard so mInputConnection will be non-null.
+    private boolean focusedNodeAllowsSoftKeyboard() {
+        return mTextInputType != TextInputType.NONE && mTextInputMode != WebTextInputMode.NONE;
+    }
+
+    // Whether the focused node is editable or not.
+    private boolean focusedNodeEditable() {
+        return mTextInputType != TextInputType.NONE;
+    }
+
+    private View getContainerView() {
+        return mViewDelegate.getContainerView();
+    }
+
+    /**
+     * @see View#onCreateInputConnection(EditorInfo)
+     * @param allowKeyboardLearning Whether to allow keyboard (IME) app to do personalized learning.
+     */
+    public ChromiumBaseInputConnection onCreateInputConnection(
+            EditorInfo outAttrs, boolean allowKeyboardLearning) {
+        // InputMethodService evaluates fullscreen mode even when the new input connection is
+        // null. This makes sure IME doesn't enter fullscreen mode or open custom UI.
+        outAttrs.imeOptions = EditorInfo.IME_FLAG_NO_FULLSCREEN | EditorInfo.IME_FLAG_NO_EXTRACT_UI;
+
+        if (!allowKeyboardLearning) {
+            outAttrs.imeOptions |= EditorInfoCompat.IME_FLAG_NO_PERSONALIZED_LEARNING;
+        }
+
+        // Without this line, some third-party IMEs will try to compose text even when
+        // not on an editable node. Even when we return null here, key events can still go
+        // through ImeAdapter#dispatchKeyEvent().
+        if (!focusedNodeEditable()) {
+            setInputConnection(null);
+            if (DEBUG_LOGS) Log.i(TAG, "onCreateInputConnection returns null.");
+            return null;
+        }
+        if (mInputConnectionFactory == null) return null;
+        View containerView = getContainerView();
+        if (DEBUG_LOGS) Log.i(TAG, "Last text: " + mLastText);
+        setInputConnection(mInputConnectionFactory.initializeAndGet(containerView, this,
+                mTextInputType, mTextInputFlags, mTextInputMode, mTextInputAction,
+                mLastSelectionStart, mLastSelectionEnd, mLastText, outAttrs));
+        if (DEBUG_LOGS) Log.i(TAG, "onCreateInputConnection: " + mInputConnection);
+
+        if (mCursorAnchorInfoController != null) {
+            mCursorAnchorInfoController.onRequestCursorUpdates(false /* not an immediate request */,
+                    false /* disable monitoring */, containerView);
+        }
+        if (isValid()) {
+            ImeAdapterImplJni.get().requestCursorUpdate(mNativeImeAdapterAndroid,
+                    ImeAdapterImpl.this, false /* not an immediate request */,
+                    false /* disable monitoring */);
+        }
+
+        if (mInputConnection != null) mInputMethodManagerWrapper.onInputConnectionCreated();
+        return mInputConnection;
+    }
+
+    private void setInputConnection(ChromiumBaseInputConnection inputConnection) {
+        if (mInputConnection == inputConnection) return;
+        // The previous input connection might be waiting for state update.
+        if (mInputConnection != null) mInputConnection.unblockOnUiThread();
+        mInputConnection = inputConnection;
+    }
+
+    @Override
+    public boolean hasInputConnection() {
+        return mInputConnection != null;
+    }
+
+    @Override
+    public void setInputMethodManagerWrapper(InputMethodManagerWrapper immw) {
+        mInputMethodManagerWrapper = immw;
+        if (mCursorAnchorInfoController != null) {
+            mCursorAnchorInfoController.setInputMethodManagerWrapper(immw);
+        }
+    }
+
+    @VisibleForTesting
+    void setInputConnectionFactory(ChromiumBaseInputConnection.Factory factory) {
+        mInputConnectionFactory = factory;
+    }
+
+    @VisibleForTesting
+    ChromiumBaseInputConnection.Factory getInputConnectionFactoryForTest() {
+        return mInputConnectionFactory;
+    }
+
+    @VisibleForTesting
+    public void setTriggerDelayedOnCreateInputConnectionForTest(boolean trigger) {
+        mInputConnectionFactory.setTriggerDelayedOnCreateInputConnection(trigger);
+    }
+
+    /**
+     * Get the current input connection for testing purposes.
+     */
+    @VisibleForTesting
+    @Override
+    public InputConnection getInputConnectionForTest() {
+        return mInputConnection;
+    }
+
+    @VisibleForTesting
+    @Override
+    public void setComposingTextForTest(final CharSequence text, final int newCursorPosition) {
+        mInputConnection.getHandler().post(
+                () -> mInputConnection.setComposingText(text, newCursorPosition));
+    }
+
+    private static int getModifiers(int metaState) {
+        int modifiers = 0;
+        if ((metaState & KeyEvent.META_SHIFT_ON) != 0) {
+            modifiers |= WebInputEventModifier.SHIFT_KEY;
+        }
+        if ((metaState & KeyEvent.META_ALT_ON) != 0) {
+            modifiers |= WebInputEventModifier.ALT_KEY;
+        }
+        if ((metaState & KeyEvent.META_CTRL_ON) != 0) {
+            modifiers |= WebInputEventModifier.CONTROL_KEY;
+        }
+        if ((metaState & KeyEvent.META_CAPS_LOCK_ON) != 0) {
+            modifiers |= WebInputEventModifier.CAPS_LOCK_ON;
+        }
+        if ((metaState & KeyEvent.META_NUM_LOCK_ON) != 0) {
+            modifiers |= WebInputEventModifier.NUM_LOCK_ON;
+        }
+        return modifiers;
+    }
+
+    private void updateInputStateForStylusWriting() {
+        if (mWebContents.getStylusWritingHandler() == null) return;
+        mWebContents.getStylusWritingHandler().updateInputState(
+                mLastText, mLastSelectionStart, mLastSelectionEnd);
+    }
+
+    /**
+     * Updates internal representation of the text being edited and its selection and composition
+     * properties.
+     *
+     * @param textInputType Text input type for the currently focused field in renderer.
+     * @param textInputFlags Text input flags.
+     * @param textInputMode Text input mode.
+     * @param textInputAction Text input mode action.
+     * @param showIfNeeded Whether the keyboard should be shown if it is currently hidden.
+     * @param alwaysHide Whether the keyboard should be unconditionally hidden.
+     * @param text The String contents of the field being edited.
+     * @param selectionStart The character offset of the selection start, or the caret position if
+     *                       there is no selection.
+     * @param selectionEnd The character offset of the selection end, or the caret position if there
+     *                     is no selection.
+     * @param compositionStart The character offset of the composition start, or -1 if there is no
+     *                         composition.
+     * @param compositionEnd The character offset of the composition end, or -1 if there is no
+     *                       selection.
+     * @param replyToRequest True when the update was requested by IME.
+     * @param lastVkVisibilityRequest VK visibility request type if show/hide APIs are called
+     *         from JS.
+     * @param vkPolicy VK policy type whether it is manual or automatic.
+     */
+    @CalledByNative
+    private void updateState(int textInputType, int textInputFlags, int textInputMode,
+            int textInputAction, boolean showIfNeeded, boolean alwaysHide, String text,
+            int selectionStart, int selectionEnd, int compositionStart, int compositionEnd,
+            boolean replyToRequest, int lastVkVisibilityRequest, int vkPolicy) {
+        TraceEvent.begin("ImeAdapter.updateState");
+        try {
+            if (DEBUG_LOGS) {
+                Log.i(TAG,
+                        "updateState: type [%d->%d], flags [%d], mode[%d], action[%d], show [%b], hide [%b]",
+                        mTextInputType, textInputType, textInputFlags, textInputMode,
+                        textInputAction, showIfNeeded, alwaysHide);
+            }
+            boolean needsRestart = false;
+            boolean hide = false;
+            if (mRestartInputOnNextStateUpdate) {
+                needsRestart = true;
+                mRestartInputOnNextStateUpdate = false;
+            }
+
+            mTextInputFlags = textInputFlags;
+            if (mTextInputMode != textInputMode) {
+                mTextInputMode = textInputMode;
+                hide = textInputMode == WebTextInputMode.NONE && !isHardwareKeyboardAttached();
+                needsRestart = true;
+            }
+            if (mTextInputType != textInputType) {
+                mTextInputType = textInputType;
+                if (textInputType == TextInputType.NONE) {
+                    hide = true;
+                } else {
+                    needsRestart = true;
+                }
+            } else if (textInputType == TextInputType.NONE) {
+                hide = true;
+            }
+            if (mTextInputAction != textInputAction) {
+                mTextInputAction = textInputAction;
+                needsRestart = true;
+            }
+
+            boolean editable = focusedNodeEditable();
+            boolean password = textInputType == TextInputType.PASSWORD;
+            if (mNodeEditable != editable || mNodePassword != password) {
+                for (ImeEventObserver observer : mEventObservers) {
+                    observer.onNodeAttributeUpdated(editable, password);
+                }
+                mNodeEditable = editable;
+                mNodePassword = password;
+            }
+            if (mCursorAnchorInfoController != null
+                    && (!TextUtils.equals(mLastText, text) || mLastSelectionStart != selectionStart
+                               || mLastSelectionEnd != selectionEnd
+                               || mLastCompositionStart != compositionStart
+                               || mLastCompositionEnd != compositionEnd)) {
+                mCursorAnchorInfoController.invalidateLastCursorAnchorInfo();
+            }
+            mLastText = text;
+            mLastSelectionStart = selectionStart;
+            mLastSelectionEnd = selectionEnd;
+            mLastCompositionStart = compositionStart;
+            mLastCompositionEnd = compositionEnd;
+
+            // Check for the visibility request and policy if VK APIs are enabled.
+            if (vkPolicy == VirtualKeyboardPolicy.MANUAL) {
+                // policy is manual.
+                if (lastVkVisibilityRequest == VirtualKeyboardVisibilityRequest.SHOW) {
+                    showSoftKeyboard();
+                } else if (lastVkVisibilityRequest == VirtualKeyboardVisibilityRequest.HIDE) {
+                    hideKeyboard();
+                }
+            } else {
+                if (hide || alwaysHide) {
+                    hideKeyboard();
+                } else {
+                    if (needsRestart) restartInput();
+                    if (showIfNeeded && focusedNodeAllowsSoftKeyboard()) {
+                        // There is no API for us to get notified of user's dismissal of keyboard.
+                        // Therefore, we should try to show keyboard even when text input type
+                        // hasn't changed.
+                        showSoftKeyboard();
+                    }
+                }
+            }
+
+            if (mInputConnection != null) {
+                boolean singleLine = mTextInputType != TextInputType.TEXT_AREA
+                        && mTextInputType != TextInputType.CONTENT_EDITABLE;
+                mInputConnection.updateStateOnUiThread(text, selectionStart, selectionEnd,
+                        compositionStart, compositionEnd, singleLine, replyToRequest);
+            }
+        } finally {
+            TraceEvent.end("ImeAdapter.updateState");
+        }
+
+        // Update input state to stylus writing service.
+        updateInputStateForStylusWriting();
+    }
+
+    /**
+     * Show soft keyboard only if it is the current keyboard configuration.
+     */
+    private void showSoftKeyboard() {
+        if (!isValid()) return;
+        if (DEBUG_LOGS) Log.i(TAG, "showSoftKeyboard");
+        View containerView = getContainerView();
+
+        // Block showing soft keyboard during stylus handwriting.
+        int lastToolType = mWebContents.getEventForwarder().getLastToolType();
+        if (mWebContents.getStylusWritingHandler() != null
+                && !mWebContents.getStylusWritingHandler().canShowSoftKeyboard()
+                && (lastToolType == MotionEvent.TOOL_TYPE_STYLUS
+                        || lastToolType == MotionEvent.TOOL_TYPE_ERASER)
+                && mTextInputType != TextInputType.PASSWORD
+                && !mForceShowKeyboardDuringStylusWriting) {
+            if (DEBUG_LOGS) Log.i(TAG, "showSoftKeyboard: blocked during stylus writing");
+            return;
+        }
+
+        mInputMethodManagerWrapper.showSoftInput(containerView, 0, getNewShowKeyboardReceiver());
+        if (containerView.getResources().getConfiguration().keyboard
+                != Configuration.KEYBOARD_NOKEYS) {
+            mWebContents.scrollFocusedEditableNodeIntoView();
+        }
+    }
+
+    @Override
+    public void onShowKeyboardReceiveResult(int resultCode) {
+        if (!isValid()) return;
+        View containerView = getContainerView();
+        if (resultCode == InputMethodManager.RESULT_SHOWN) {
+            // If OSK is newly shown, delay the form focus until
+            // the onSizeChanged (in order to adjust relative to the
+            // new size).
+            // TODO(jdduke): We should not assume that onSizeChanged will
+            // always be called, crbug.com/294908.
+            containerView.getWindowVisibleDisplayFrame(mFocusPreOSKViewportRect);
+        } else if (ViewUtils.hasFocus(containerView)
+                && resultCode == InputMethodManager.RESULT_UNCHANGED_SHOWN) {
+            // If the OSK was already there, focus the form immediately.
+            // Also, the VR soft keyboard always reports RESULT_UNCHANGED_SHOWN as it
+            // doesn't affect the size of the web contents.
+            mWebContents.scrollFocusedEditableNodeIntoView();
+        }
+    }
+
+    @CalledByNative
+    private void updateOnTouchDown() {
+        cancelRequestToScrollFocusedEditableNodeIntoView();
+    }
+
+    public void cancelRequestToScrollFocusedEditableNodeIntoView() {
+        mFocusPreOSKViewportRect.setEmpty();
+    }
+
+    @Override
+    public ResultReceiver getNewShowKeyboardReceiver() {
+        if (mShowKeyboardResultReceiver == null) {
+            // Note: the returned object will get leaked by Android framework.
+            mShowKeyboardResultReceiver = new ShowKeyboardResultReceiver(this, new Handler());
+        }
+        return mShowKeyboardResultReceiver;
+    }
+
+    /**
+     * Hide soft keyboard.
+     */
+    private void hideKeyboard() {
+        if (!isValid()) return;
+        if (DEBUG_LOGS) Log.i(TAG, "hideKeyboard");
+        View view = mViewDelegate.getContainerView();
+        if (mInputMethodManagerWrapper.isActive(view)) {
+            // NOTE: we should not set ResultReceiver here. Otherwise, IMM will own
+            // ImeAdapter even after input method goes away and result gets received.
+            mInputMethodManagerWrapper.hideSoftInputFromWindow(view.getWindowToken(), 0, null);
+        }
+        // Detach input connection by returning null from onCreateInputConnection().
+        if (!focusedNodeEditable() && mInputConnection != null) {
+            ChromiumBaseInputConnection inputConnection = mInputConnection;
+            restartInput(); // resets mInputConnection
+            // crbug.com/666982: Restart input may not happen if view is detached from window, but
+            // we need to unblock in any case. We want to call this after restartInput() to
+            // ensure that there is no additional IME operation in the queue.
+            inputConnection.unblockOnUiThread();
+        }
+    }
+
+    // WindowEventObserver
+
+    @Override
+    public void onConfigurationChanged(Configuration newConfig) {
+        if (!isValid()) return;
+        // If configuration unchanged, do nothing.
+        if (mCurrentConfig.keyboard == newConfig.keyboard
+                && mCurrentConfig.keyboardHidden == newConfig.keyboardHidden
+                && mCurrentConfig.hardKeyboardHidden == newConfig.hardKeyboardHidden) {
+            return;
+        }
+
+        // Deep copy newConfig so that we can notice the difference.
+        mCurrentConfig = new Configuration(newConfig);
+        if (DEBUG_LOGS) {
+            Log.i(TAG, "onKeyboardConfigurationChanged: mTextInputType [%d]", mTextInputType);
+        }
+        if (focusedNodeAllowsSoftKeyboard()) {
+            restartInput();
+            // By default, we show soft keyboard on keyboard changes. This is useful
+            // when the user switches from hardware keyboard to software keyboard.
+            // TODO(changwan): check if we can skip this for hardware keyboard configurations.
+            showSoftKeyboard();
+        } else if (focusedNodeEditable()) {
+            // The focused node is editable but disllows the virtual keyboard. We may need to
+            // show soft keyboard (for IME composition window only) if a hardware keyboard is
+            // present.
+            restartInput();
+            if (!isHardwareKeyboardAttached()) {
+                hideKeyboard();
+            } else {
+                showSoftKeyboard();
+            }
+        }
+    }
+
+    @Override
+    public void onWindowFocusChanged(boolean gainFocus) {
+        if (mInputConnectionFactory != null) {
+            mInputConnectionFactory.onWindowFocusChanged(gainFocus);
+        }
+    }
+
+    @Override
+    public void onWindowAndroidChanged(WindowAndroid windowAndroid) {
+        if (mInputMethodManagerWrapper != null) {
+            mInputMethodManagerWrapper.onWindowAndroidChanged(windowAndroid);
+        }
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        if (mInputConnectionFactory != null) {
+            mInputConnectionFactory.onViewAttachedToWindow();
+        }
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+        resetAndHideKeyboard();
+        if (mInputConnectionFactory != null) {
+            mInputConnectionFactory.onViewDetachedFromWindow();
+        }
+    }
+
+    @Override
+    public void onViewFocusChanged(boolean gainFocus, boolean hideKeyboardOnBlur) {
+        if (DEBUG_LOGS) Log.i(TAG, "onViewFocusChanged: gainFocus [%b]", gainFocus);
+        if (!gainFocus && hideKeyboardOnBlur) resetAndHideKeyboard();
+        if (mInputConnectionFactory != null) {
+            mInputConnectionFactory.onViewFocusChanged(gainFocus);
+        }
+    }
+
+    private static boolean isTextInputType(int type) {
+        return type != TextInputType.NONE && !InputDialogContainer.isDialogInputType(type);
+    }
+
+    /**
+     * See {@link View#dispatchKeyEvent(KeyEvent)}
+     */
+    public boolean dispatchKeyEvent(KeyEvent event) {
+        if (DEBUG_LOGS) {
+            Log.i(TAG, "dispatchKeyEvent: action [%d], keycode [%d]", event.getAction(),
+                    event.getKeyCode());
+        }
+        if (mInputConnection != null) return mInputConnection.sendKeyEventOnUiThread(event);
+        return sendKeyEvent(event);
+    }
+
+    /**
+     * Resets IME adapter and hides keyboard. Note that this will also unblock input connection.
+     */
+    public void resetAndHideKeyboard() {
+        if (DEBUG_LOGS) Log.i(TAG, "resetAndHideKeyboard");
+        mTextInputType = TextInputType.NONE;
+        mTextInputFlags = 0;
+        mTextInputMode = WebTextInputMode.DEFAULT;
+        mRestartInputOnNextStateUpdate = false;
+        // This will trigger unblocking if necessary.
+        hideKeyboard();
+    }
+
+    @CalledByNative
+    private void onNativeDestroyed() {
+        resetAndHideKeyboard();
+        mNativeImeAdapterAndroid = 0;
+        mIsConnected = false;
+        if (mCursorAnchorInfoController != null) {
+            mCursorAnchorInfoController.focusedNodeChanged(false);
+        }
+    }
+
+    /**
+     * Update selection to input method manager.
+     *
+     * @param selectionStart   The selection start.
+     * @param selectionEnd     The selection end.
+     * @param compositionStart The composition start.
+     * @param compositionEnd   The composition end.
+     */
+    void updateSelection(
+            int selectionStart, int selectionEnd, int compositionStart, int compositionEnd) {
+        mInputMethodManagerWrapper.updateSelection(
+                getContainerView(), selectionStart, selectionEnd, compositionStart, compositionEnd);
+    }
+
+    /**
+     * Update extracted text to input method manager.
+     */
+    void updateExtractedText(int token, ExtractedText extractedText) {
+        mInputMethodManagerWrapper.updateExtractedText(getContainerView(), token, extractedText);
+    }
+
+    /**
+     * Restart input (finish composition and change EditorInfo, such as input type).
+     */
+    void restartInput() {
+        if (!isValid()) return;
+        // This will eventually cause input method manager to call View#onCreateInputConnection().
+        mInputMethodManagerWrapper.restartInput(getContainerView());
+        if (mInputConnection != null) mInputConnection.onRestartInputOnUiThread();
+    }
+
+    /**
+     * @see BaseInputConnection#performContextMenuAction(int)
+     */
+    boolean performContextMenuAction(int id) {
+        if (DEBUG_LOGS) Log.i(TAG, "performContextMenuAction: id [%d]", id);
+        switch (id) {
+            case android.R.id.selectAll:
+                mWebContents.selectAll();
+                return true;
+            case android.R.id.cut:
+                mWebContents.cut();
+                return true;
+            case android.R.id.copy:
+                mWebContents.copy();
+                return true;
+            case android.R.id.paste:
+                mWebContents.paste();
+                return true;
+            default:
+                return false;
+        }
+    }
+
+    public boolean performEditorAction(int actionCode) {
+        if (!isValid()) return false;
+
+        // If mTextInputAction has been specified (indicating an enterKeyHint
+        // has been specified in the HTML) then we do will send the enter key
+        // events. Otherwise we fallback to having the enter key move focus
+        // between the elements.
+        if (mTextInputAction == TextInputAction.DEFAULT) {
+            switch (actionCode) {
+                case EditorInfo.IME_ACTION_NEXT:
+                    advanceFocusForIME(FocusType.FORWARD);
+                    return true;
+                case EditorInfo.IME_ACTION_PREVIOUS:
+                    advanceFocusForIME(FocusType.BACKWARD);
+                    return true;
+            }
+        }
+        sendSyntheticKeyPress(KeyEvent.KEYCODE_ENTER,
+                KeyEvent.FLAG_SOFT_KEYBOARD | KeyEvent.FLAG_KEEP_TOUCH_MODE
+                        | KeyEvent.FLAG_EDITOR_ACTION);
+        return true;
+    }
+
+    /**
+     * @see InputConnection#performPrivateCommand(java.lang.String, android.os.Bundle)
+     */
+    public void performPrivateCommand(String action, Bundle data) {
+        mViewDelegate.performPrivateImeCommand(action, data);
+    }
+
+    @Override
+    public void advanceFocusForIME(int focusType) {
+        if (mNativeImeAdapterAndroid == 0) return;
+        ImeAdapterImplJni.get().advanceFocusForIME(
+                mNativeImeAdapterAndroid, ImeAdapterImpl.this, focusType);
+    }
+
+    public void sendSyntheticKeyPress(int keyCode, int flags) {
+        long eventTime = SystemClock.uptimeMillis();
+        sendKeyEvent(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_DOWN, keyCode, 0, 0,
+                KeyCharacterMap.VIRTUAL_KEYBOARD, 0, flags));
+        sendKeyEvent(new KeyEvent(eventTime, eventTime, KeyEvent.ACTION_UP, keyCode, 0, 0,
+                KeyCharacterMap.VIRTUAL_KEYBOARD, 0, flags));
+    }
+
+    private void onImeEvent() {
+        for (ImeEventObserver observer : mEventObservers) observer.onImeEvent();
+        if (mNodeEditable && mWebContents.getRenderWidgetHostView() != null) {
+            mWebContents.getRenderWidgetHostView().dismissTextHandles();
+        }
+    }
+
+    boolean sendCompositionToNative(
+            CharSequence text, int newCursorPosition, boolean isCommit, int unicodeFromKeyEvent) {
+        if (!isValid()) return false;
+
+        onImeEvent();
+        long timestampMs = SystemClock.uptimeMillis();
+        ImeAdapterImplJni.get().sendKeyEvent(mNativeImeAdapterAndroid, ImeAdapterImpl.this, null,
+                EventType.RAW_KEY_DOWN, 0, timestampMs, COMPOSITION_KEY_CODE, 0, false,
+                unicodeFromKeyEvent);
+
+        if (isCommit) {
+            ImeAdapterImplJni.get().commitText(mNativeImeAdapterAndroid, ImeAdapterImpl.this, text,
+                    text.toString(), newCursorPosition);
+        } else {
+            ImeAdapterImplJni.get().setComposingText(mNativeImeAdapterAndroid, ImeAdapterImpl.this,
+                    text, text.toString(), newCursorPosition);
+        }
+
+        ImeAdapterImplJni.get().sendKeyEvent(mNativeImeAdapterAndroid, ImeAdapterImpl.this, null,
+                EventType.KEY_UP, 0, timestampMs, COMPOSITION_KEY_CODE, 0, false,
+                unicodeFromKeyEvent);
+        return true;
+    }
+
+    boolean finishComposingText() {
+        if (!isValid()) return false;
+        ImeAdapterImplJni.get().finishComposingText(mNativeImeAdapterAndroid, ImeAdapterImpl.this);
+        return true;
+    }
+
+    boolean sendKeyEvent(KeyEvent event) {
+        if (!isValid()) return false;
+
+        int action = event.getAction();
+        int type;
+        if (action == KeyEvent.ACTION_DOWN) {
+            type = EventType.KEY_DOWN;
+        } else if (action == KeyEvent.ACTION_UP) {
+            type = EventType.KEY_UP;
+        } else {
+            // In theory, KeyEvent.ACTION_MULTIPLE is a valid value, but in practice
+            // this seems to have been quietly deprecated and we've never observed
+            // a case where it's sent (holding down physical keyboard key also
+            // sends ACTION_DOWN), so it's fine to silently drop it.
+            return false;
+        }
+
+        for (ImeEventObserver observer : mEventObservers) observer.onBeforeSendKeyEvent(event);
+        onImeEvent();
+
+        return ImeAdapterImplJni.get().sendKeyEvent(mNativeImeAdapterAndroid, ImeAdapterImpl.this,
+                event, type, getModifiers(event.getMetaState()), event.getEventTime(),
+                event.getKeyCode(), event.getScanCode(), /*isSystemKey=*/false,
+                event.getUnicodeChar());
+    }
+
+    /**
+     * Send a request to the native counterpart to delete a given range of characters.
+     * @param beforeLength Number of characters to extend the selection by before the existing
+     *                     selection.
+     * @param afterLength Number of characters to extend the selection by after the existing
+     *                    selection.
+     * @return Whether the native counterpart of ImeAdapter received the call.
+     */
+    boolean deleteSurroundingText(int beforeLength, int afterLength) {
+        onImeEvent();
+        if (!isValid()) return false;
+        ImeAdapterImplJni.get().sendKeyEvent(mNativeImeAdapterAndroid, ImeAdapterImpl.this, null,
+                EventType.RAW_KEY_DOWN, 0, SystemClock.uptimeMillis(), COMPOSITION_KEY_CODE, 0,
+                false, 0);
+        ImeAdapterImplJni.get().deleteSurroundingText(
+                mNativeImeAdapterAndroid, ImeAdapterImpl.this, beforeLength, afterLength);
+        ImeAdapterImplJni.get().sendKeyEvent(mNativeImeAdapterAndroid, ImeAdapterImpl.this, null,
+                EventType.KEY_UP, 0, SystemClock.uptimeMillis(), COMPOSITION_KEY_CODE, 0, false, 0);
+        return true;
+    }
+
+    /**
+     * Send a request to the native counterpart to delete a given range of characters.
+     * @param beforeLength Number of code points to extend the selection by before the existing
+     *                     selection.
+     * @param afterLength Number of code points to extend the selection by after the existing
+     *                    selection.
+     * @return Whether the native counterpart of ImeAdapter received the call.
+     */
+    boolean deleteSurroundingTextInCodePoints(int beforeLength, int afterLength) {
+        onImeEvent();
+        if (!isValid()) return false;
+        ImeAdapterImplJni.get().sendKeyEvent(mNativeImeAdapterAndroid, ImeAdapterImpl.this, null,
+                EventType.RAW_KEY_DOWN, 0, SystemClock.uptimeMillis(), COMPOSITION_KEY_CODE, 0,
+                false, 0);
+        ImeAdapterImplJni.get().deleteSurroundingTextInCodePoints(
+                mNativeImeAdapterAndroid, ImeAdapterImpl.this, beforeLength, afterLength);
+        ImeAdapterImplJni.get().sendKeyEvent(mNativeImeAdapterAndroid, ImeAdapterImpl.this, null,
+                EventType.KEY_UP, 0, SystemClock.uptimeMillis(), COMPOSITION_KEY_CODE, 0, false, 0);
+        return true;
+    }
+
+    /**
+     * Send a request to the native counterpart to set the selection to given range.
+     * @param start Selection start index.
+     * @param end Selection end index.
+     * @return Whether the native counterpart of ImeAdapter received the call.
+     */
+    boolean setEditableSelectionOffsets(int start, int end) {
+        if (!isValid()) return false;
+        ImeAdapterImplJni.get().setEditableSelectionOffsets(
+                mNativeImeAdapterAndroid, ImeAdapterImpl.this, start, end);
+        return true;
+    }
+
+    /**
+     * Send a request to the native counterpart to set composing region to given indices.
+     * @param start The start of the composition.
+     * @param end The end of the composition.
+     * @return Whether the native counterpart of ImeAdapter received the call.
+     */
+    boolean setComposingRegion(int start, int end) {
+        if (!isValid()) return false;
+        if (start <= end) {
+            ImeAdapterImplJni.get().setComposingRegion(
+                    mNativeImeAdapterAndroid, ImeAdapterImpl.this, start, end);
+        } else {
+            ImeAdapterImplJni.get().setComposingRegion(
+                    mNativeImeAdapterAndroid, ImeAdapterImpl.this, end, start);
+        }
+        return true;
+    }
+
+    @CalledByNative
+    private void focusedNodeChanged(boolean isEditable, int nodeLeftDip, int nodeTopDip,
+            int nodeRightDip, int nodeBottomDip) {
+        if (DEBUG_LOGS) Log.i(TAG, "focusedNodeChanged: isEditable [%b]", isEditable);
+
+        // Update controller before the connection is restarted.
+        if (mCursorAnchorInfoController != null) {
+            mCursorAnchorInfoController.focusedNodeChanged(isEditable);
+        }
+
+        if (mTextInputType != TextInputType.NONE && mInputConnection != null && isEditable) {
+            mRestartInputOnNextStateUpdate = true;
+        }
+
+        if (mWebContents.getStylusWritingHandler() != null) {
+            // Update edit bounds to stylus writing service.
+            Rect editableNodeBoundsPixOnScreen;
+            if (isEditable) {
+                float deviceScale = mWebContents.getRenderCoordinates().getDeviceScaleFactor();
+                editableNodeBoundsPixOnScreen = new Rect((int) (nodeLeftDip * deviceScale),
+                        (int) (nodeTopDip * deviceScale), (int) (nodeRightDip * deviceScale),
+                        (int) (nodeBottomDip * deviceScale));
+                editableNodeBoundsPixOnScreen.offset(
+                        0, mWebContents.getRenderCoordinates().getContentOffsetYPixInt());
+            } else {
+                editableNodeBoundsPixOnScreen = new Rect();
+            }
+            mWebContents.getStylusWritingHandler().onFocusedNodeChanged(
+                    editableNodeBoundsPixOnScreen, isEditable, mViewDelegate.getContainerView());
+        }
+    }
+
+    @CalledByNative
+    private boolean requestStartStylusWriting() {
+        if (mWebContents.getStylusWritingHandler() == null) return false;
+
+        // It is possible that current view is not focused when stylus writing is started just after
+        // interaction with some other view like Url bar, or share view. We need to focus it so that
+        // current web page also gets focused, allowing us to commit text into web input elements.
+        View containerView = getContainerView();
+        if (!ViewUtils.hasFocus(containerView)) ViewUtils.requestFocus(containerView);
+
+        updateInputStateForStylusWriting();
+        return mWebContents.getStylusWritingHandler().requestStartStylusWriting(
+                getStylusWritingImeCallback());
+    }
+
+    @CalledByNative
+    void onEditElementFocusedForStylusWriting(int focusedEditLeft, int focusedEditTop,
+            int focusedEditRight, int focusedEditBottom, int caretX, int caretY) {
+        if (mWebContents.getStylusWritingHandler() == null) return;
+        Rect focusedEditBounds =
+                new Rect(focusedEditLeft, focusedEditTop, focusedEditRight, focusedEditBottom);
+        Point cursorPosition = new Point(caretX, caretY);
+        if (!focusedEditBounds.isEmpty()) {
+            int[] screenLocation = new int[2];
+            mWebContents.getViewAndroidDelegate().getContainerView().getLocationOnScreen(
+                    screenLocation);
+            int contentOffsetY = mWebContents.getRenderCoordinates().getContentOffsetYPixInt();
+            focusedEditBounds.offset(0, contentOffsetY);
+            cursorPosition.offset(screenLocation[0], screenLocation[1] + contentOffsetY);
+        }
+
+        // Send focused edit bounds and caret center position to Stylus writing service.
+        mWebContents.getStylusWritingHandler().onEditElementFocusedForStylusWriting(
+                focusedEditBounds, cursorPosition);
+        if (Build.VERSION.SDK_INT > Build.VERSION_CODES.TIRAMISU) {
+            RectF bounds = new RectF(focusedEditBounds);
+            EditorBoundsInfo editorBoundsInfo =
+                    new EditorBoundsInfo.Builder().setHandwritingBounds(bounds).build();
+            mCursorAnchorInfoController.updateWithEditorBoundsInfo(
+                    editorBoundsInfo, getContainerView());
+        }
+    }
+
+    /**
+     * Send a request to the native counterpart to give the latest text input state update.
+     */
+    boolean requestTextInputStateUpdate() {
+        if (!isValid()) return false;
+        // You won't get state update anyways.
+        if (mInputConnection == null) return false;
+        return ImeAdapterImplJni.get().requestTextInputStateUpdate(
+                mNativeImeAdapterAndroid, ImeAdapterImpl.this);
+    }
+
+    /**
+     * Notified when IME requested Chrome to change the cursor update mode.
+     */
+    public boolean onRequestCursorUpdates(int cursorUpdateMode) {
+        final boolean immediateRequest =
+                (cursorUpdateMode & InputConnection.CURSOR_UPDATE_IMMEDIATE) != 0;
+        final boolean monitorRequest =
+                (cursorUpdateMode & InputConnection.CURSOR_UPDATE_MONITOR) != 0;
+
+        if (isValid()) {
+            ImeAdapterImplJni.get().requestCursorUpdate(mNativeImeAdapterAndroid,
+                    ImeAdapterImpl.this, immediateRequest, monitorRequest);
+        }
+        return mCursorAnchorInfoController.onRequestCursorUpdates(
+                immediateRequest, monitorRequest, getContainerView());
+    }
+
+    /** Lazily creates/returns a StylusWritingImeCallback object. */
+    private StylusWritingImeCallback getStylusWritingImeCallback() {
+        if (mStylusWritingImeCallback == null) {
+            mStylusWritingImeCallback = new StylusWritingImeCallback() {
+                @Override
+                public void setEditableSelectionOffsets(int start, int end) {
+                    ImeAdapterImpl.this.setEditableSelectionOffsets(start, end);
+                }
+
+                @Override
+                public void sendCompositionToNative(
+                        CharSequence text, int newCursorPosition, boolean isCommit) {
+                    ImeAdapterImpl.this.sendCompositionToNative(
+                            text, newCursorPosition, isCommit, 0);
+                }
+
+                @Override
+                public void performEditorAction(int actionCode) {
+                    ImeAdapterImpl.this.performEditorAction(actionCode);
+                }
+
+                @Override
+                public void showSoftKeyboard() {
+                    mForceShowKeyboardDuringStylusWriting = true;
+                    ImeAdapterImpl.this.showSoftKeyboard();
+                    mForceShowKeyboardDuringStylusWriting = false;
+                }
+
+                @Override
+                public void hideKeyboard() {
+                    ImeAdapterImpl.this.hideKeyboard();
+                }
+
+                @Override
+                public View getContainerView() {
+                    return mWebContents.getViewAndroidDelegate().getContainerView();
+                }
+
+                @Override
+                public void resetGestureDetection() {}
+
+                @Override
+                public void handleStylusWritingGestureAction(
+                        int id, StylusWritingGestureData gestureData) {
+                    if (mNativeImeAdapterAndroid == 0) return;
+                    int contentOffsetY =
+                            (int) mWebContents.getRenderCoordinates().getContentOffsetYPix();
+                    gestureData.startRect.y -= contentOffsetY;
+                    if (gestureData.endRect != null) {
+                        gestureData.endRect.y -= contentOffsetY;
+                    }
+                    ImeAdapterImplJni.get().handleStylusWritingGestureAction(
+                            mNativeImeAdapterAndroid, ImeAdapterImpl.this, id,
+                            gestureData.serialize());
+                }
+
+                @Override
+                public void finishComposingText() {
+                    ImeAdapterImpl.this.finishComposingText();
+                }
+            };
+        }
+        return mStylusWritingImeCallback;
+    }
+
+    /**
+     * Notified when a frame has been produced by the renderer and all the associated metadata.
+     * @param scaleFactor device scale factor.
+     * @param contentOffsetYPix Y offset below the browser controls.
+     * @param hasInsertionMarker Whether the insertion marker is visible or not.
+     * @param insertionMarkerHorizontal X coordinates (in view-local DIP pixels) of the insertion
+     *                                  marker if it exists. Will be ignored otherwise.
+     * @param insertionMarkerTop Y coordinates (in view-local DIP pixels) of the top of the
+     *                           insertion marker if it exists. Will be ignored otherwise.
+     * @param insertionMarkerBottom Y coordinates (in view-local DIP pixels) of the bottom of
+     *                              the insertion marker if it exists. Will be ignored otherwise.
+     */
+    @CalledByNative
+    private void updateFrameInfo(float scaleFactor, float contentOffsetYPix,
+            boolean hasInsertionMarker, boolean isInsertionMarkerVisible,
+            float insertionMarkerHorizontal, float insertionMarkerTop,
+            float insertionMarkerBottom) {
+        mCursorAnchorInfoController.onUpdateFrameInfo(scaleFactor, contentOffsetYPix,
+                hasInsertionMarker, isInsertionMarkerVisible, insertionMarkerHorizontal,
+                insertionMarkerTop, insertionMarkerBottom, getContainerView());
+    }
+
+    @CalledByNative
+    private void onResizeScrollableViewport(boolean contentsHeightReduced) {
+        if (!contentsHeightReduced) {
+            cancelRequestToScrollFocusedEditableNodeIntoView();
+            return;
+        }
+
+        // Execute a delayed form focus operation because the OSK was brought up earlier.
+        if (!mFocusPreOSKViewportRect.isEmpty()) {
+            Rect rect = new Rect();
+            getContainerView().getWindowVisibleDisplayFrame(rect);
+            if (!rect.equals(mFocusPreOSKViewportRect)) {
+                // Only assume the OSK triggered the onSizeChanged if width was preserved.
+                if (rect.width() == mFocusPreOSKViewportRect.width()) {
+                    assert mWebContents != null;
+                    mWebContents.scrollFocusedEditableNodeIntoView();
+                }
+                // Zero the rect to prevent the above operation from issuing the delayed
+                // form focus event.
+                cancelRequestToScrollFocusedEditableNodeIntoView();
+            }
+        }
+    }
+
+    private int getUnderlineColorForSuggestionSpan(SuggestionSpan suggestionSpan) {
+        try {
+            Method getUnderlineColorMethod = SuggestionSpan.class.getMethod("getUnderlineColor");
+            return (int) getUnderlineColorMethod.invoke(suggestionSpan);
+        } catch (IllegalAccessException e) {
+            return DEFAULT_SUGGESTION_SPAN_COLOR;
+        } catch (InvocationTargetException e) {
+            return DEFAULT_SUGGESTION_SPAN_COLOR;
+        } catch (NoSuchMethodException e) {
+            return DEFAULT_SUGGESTION_SPAN_COLOR;
+        }
+    }
+
+    @CalledByNative
+    private void populateImeTextSpansFromJava(CharSequence text, long imeTextSpans) {
+        if (DEBUG_LOGS) {
+            Log.i(TAG, "populateImeTextSpansFromJava: text [%s], ime_text_spans [%d]", text,
+                    imeTextSpans);
+        }
+        if (!(text instanceof SpannableString)) return;
+
+        SpannableString spannableString = ((SpannableString) text);
+        CharacterStyle spans[] = spannableString.getSpans(0, text.length(), CharacterStyle.class);
+        for (CharacterStyle span : spans) {
+            final int spanFlags = spannableString.getSpanFlags(span);
+            if (span instanceof BackgroundColorSpan) {
+                ImeAdapterImplJni.get().appendBackgroundColorSpan(imeTextSpans,
+                        spannableString.getSpanStart(span), spannableString.getSpanEnd(span),
+                        ((BackgroundColorSpan) span).getBackgroundColor());
+            } else if (span instanceof UnderlineSpan) {
+                ImeAdapterImplJni.get().appendUnderlineSpan(imeTextSpans,
+                        spannableString.getSpanStart(span), spannableString.getSpanEnd(span));
+            } else if (span instanceof SuggestionSpan) {
+                final SuggestionSpan suggestionSpan = (SuggestionSpan) span;
+                // See android.text.Spanned#SPAN_COMPOSING, We are using this flag to determine if
+                // we need to remove the SuggestionSpan after IMEs done with composing state.
+                final boolean removeOnFinishComposing = (spanFlags & Spanned.SPAN_COMPOSING) != 0;
+                // We support all three flags of SuggestionSpans with caveat:
+                // - FLAG_EASY_CORRECT, full support.
+                // - FLAG_MISSPELLED, full support.
+                // - FLAG_AUTO_CORRECTION, no animation support for this flag for
+                //   commitCorrection().
+                // Note that FLAG_AUTO_CORRECTION has precedence than the other two flags.
+
+                // Other cases:
+                // - Some IMEs (e.g. the AOSP keyboard on Jelly Bean) add SuggestionSpans with no
+                //   flags set and no underline color to add suggestions to words marked as
+                //   misspelled (instead of having the spell checker return the suggestions when
+                //   called). We don't support these either.
+                final boolean isEasyCorrectSpan =
+                        (suggestionSpan.getFlags() & SuggestionSpan.FLAG_EASY_CORRECT) != 0;
+                final boolean isMisspellingSpan =
+                        (suggestionSpan.getFlags() & SuggestionSpan.FLAG_MISSPELLED) != 0;
+                final boolean isAutoCorrectionSpan =
+                        (suggestionSpan.getFlags() & SuggestionSpan.FLAG_AUTO_CORRECTION) != 0;
+
+                if (!isEasyCorrectSpan && !isMisspellingSpan && !isAutoCorrectionSpan) continue;
+
+                // Copied from Android's Editor.java so we use the same colors
+                // as the native Android text widget.
+                final int underlineColor = getUnderlineColorForSuggestionSpan(suggestionSpan);
+                final int newAlpha = (int) (Color.alpha(underlineColor)
+                        * SUGGESTION_HIGHLIGHT_BACKGROUND_TRANSPARENCY);
+                final int suggestionHighlightColor =
+                        (underlineColor & 0x00FFFFFF) + (newAlpha << 24);
+
+                // In native side, we treat FLAG_AUTO_CORRECTION span as kMisspellingSuggestion
+                // marker with 0 suggestion.
+                ImeAdapterImplJni.get().appendSuggestionSpan(imeTextSpans,
+                        spannableString.getSpanStart(suggestionSpan),
+                        spannableString.getSpanEnd(suggestionSpan),
+                        isMisspellingSpan || isAutoCorrectionSpan, removeOnFinishComposing,
+                        underlineColor, suggestionHighlightColor,
+                        isAutoCorrectionSpan ? new String[0] : suggestionSpan.getSuggestions());
+            }
+        }
+    }
+
+    @CalledByNative
+    private void cancelComposition() {
+        if (DEBUG_LOGS) Log.i(TAG, "cancelComposition");
+        if (mInputConnection != null) restartInput();
+    }
+
+    @CalledByNative
+    private void setCharacterBounds(float[] characterBounds) {
+        mCursorAnchorInfoController.setCompositionCharacterBounds(
+                characterBounds, getContainerView());
+    }
+
+    @CalledByNative
+    private void onConnectedToRenderProcess() {
+        if (DEBUG_LOGS) Log.i(TAG, "onConnectedToRenderProcess");
+        mIsConnected = true;
+        createInputConnectionFactory();
+        resetAndHideKeyboard();
+    }
+
+    @NativeMethods
+    interface Natives {
+        long init(ImeAdapterImpl caller, WebContents webContents);
+        boolean sendKeyEvent(long nativeImeAdapterAndroid, ImeAdapterImpl caller, KeyEvent event,
+                int type, int modifiers, long timestampMs, int keyCode, int scanCode,
+                boolean isSystemKey, int unicodeChar);
+        void appendUnderlineSpan(long spanPtr, int start, int end);
+        void appendBackgroundColorSpan(long spanPtr, int start, int end, int backgroundColor);
+        void appendSuggestionSpan(long spanPtr, int start, int end, boolean isMisspelling,
+                boolean removeOnFinishComposing, int underlineColor, int suggestionHighlightColor,
+                String[] suggestions);
+        void setComposingText(long nativeImeAdapterAndroid, ImeAdapterImpl caller,
+                CharSequence text, String textStr, int newCursorPosition);
+        void commitText(long nativeImeAdapterAndroid, ImeAdapterImpl caller, CharSequence text,
+                String textStr, int newCursorPosition);
+        void finishComposingText(long nativeImeAdapterAndroid, ImeAdapterImpl caller);
+        void setEditableSelectionOffsets(
+                long nativeImeAdapterAndroid, ImeAdapterImpl caller, int start, int end);
+        void setComposingRegion(
+                long nativeImeAdapterAndroid, ImeAdapterImpl caller, int start, int end);
+        void deleteSurroundingText(
+                long nativeImeAdapterAndroid, ImeAdapterImpl caller, int before, int after);
+        void deleteSurroundingTextInCodePoints(
+                long nativeImeAdapterAndroid, ImeAdapterImpl caller, int before, int after);
+        boolean requestTextInputStateUpdate(long nativeImeAdapterAndroid, ImeAdapterImpl caller);
+        void requestCursorUpdate(long nativeImeAdapterAndroid, ImeAdapterImpl caller,
+                boolean immediateRequest, boolean monitorRequest);
+        void advanceFocusForIME(long nativeImeAdapterAndroid, ImeAdapterImpl caller, int focusType);
+        // Stylus Writing
+        void handleStylusWritingGestureAction(long nativeImeAdapterAndroid, ImeAdapterImpl caller,
+                int id, ByteBuffer gestureData);
+    }
+}

--- a/content/public/android/java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/webcontents/WebContentsImpl.java
+++ b/content/public/android/java/src/org/chromium/content/browser/cobalt/org/chromium/content/browser/webcontents/WebContentsImpl.java
@@ -1,0 +1,1264 @@
+// Copyright 2013 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.content.browser.webcontents;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.Rect;
+import android.os.Bundle;
+import android.os.Handler;
+import android.os.Message;
+import android.os.Parcel;
+import android.os.ParcelUuid;
+import android.os.Parcelable;
+import android.view.MotionEvent;
+import android.view.Surface;
+import android.view.ViewStructure;
+
+import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
+
+import org.chromium.base.JavaExceptionReporter;
+import org.chromium.base.Log;
+import org.chromium.base.ObserverList;
+import org.chromium.base.ThreadUtils;
+import org.chromium.base.UserData;
+import org.chromium.base.UserDataHost;
+import org.chromium.base.annotations.CalledByNative;
+import org.chromium.base.annotations.JNINamespace;
+import org.chromium.base.annotations.NativeMethods;
+import org.chromium.blink_public.input.SelectionGranularity;
+import org.chromium.content.browser.AppWebMessagePort;
+import org.chromium.content.browser.MediaSessionImpl;
+import org.chromium.content.browser.RenderCoordinatesImpl;
+import org.chromium.content.browser.RenderWidgetHostViewImpl;
+import org.chromium.content.browser.ViewEventSinkImpl;
+import org.chromium.content.browser.WindowEventObserver;
+import org.chromium.content.browser.WindowEventObserverManager;
+import org.chromium.content.browser.accessibility.ViewStructureBuilder;
+import org.chromium.content.browser.framehost.RenderFrameHostDelegate;
+import org.chromium.content.browser.framehost.RenderFrameHostImpl;
+import org.chromium.content_public.browser.ChildProcessImportance;
+import org.chromium.content_public.browser.GlobalRenderFrameHostId;
+import org.chromium.content_public.browser.ImageDownloadCallback;
+import org.chromium.content_public.browser.JavaScriptCallback;
+import org.chromium.content_public.browser.MessagePayload;
+import org.chromium.content_public.browser.MessagePort;
+import org.chromium.content_public.browser.NavigationController;
+import org.chromium.content_public.browser.RenderFrameHost;
+import org.chromium.content_public.browser.StylusWritingHandler;
+import org.chromium.content_public.browser.ViewEventSink.InternalAccessDelegate;
+import org.chromium.content_public.browser.Visibility;
+import org.chromium.content_public.browser.WebContents;
+import org.chromium.content_public.browser.WebContentsInternals;
+import org.chromium.content_public.browser.WebContentsObserver;
+import org.chromium.ui.OverscrollRefreshHandler;
+import org.chromium.ui.base.EventForwarder;
+import org.chromium.ui.base.ViewAndroidDelegate;
+import org.chromium.ui.base.WindowAndroid;
+import org.chromium.ui.mojom.VirtualKeyboardMode;
+import org.chromium.url.GURL;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * The WebContentsImpl Java wrapper to allow communicating with the native WebContentsImpl
+ * object.
+ */
+@JNINamespace("content")
+public class WebContentsImpl implements WebContents, RenderFrameHostDelegate, WindowEventObserver {
+    private static final String TAG = "WebContentsImpl";
+
+    private static final String PARCEL_VERSION_KEY = "version";
+    private static final String PARCEL_WEBCONTENTS_KEY = "webcontents";
+    private static final String PARCEL_PROCESS_GUARD_KEY = "processguard";
+
+    private static final long PARCELABLE_VERSION_ID = 0;
+    // Non-final for testing purposes, so resetting of the UUID can happen.
+    private static UUID sParcelableUUID = UUID.randomUUID();
+
+    /**
+     * Used to reset the internal tracking for whether or not a serialized {@link WebContents}
+     * was created in this process or not.
+     */
+    @VisibleForTesting
+    public static void invalidateSerializedWebContentsForTesting() {
+        sParcelableUUID = UUID.randomUUID();
+    }
+
+    /**
+     * A {@link android.os.Parcelable.Creator} instance that is used to build
+     * {@link WebContentsImpl} objects from a {@link Parcel}.
+     */
+    // TODO(crbug.com/635567): Fix this properly.
+    @SuppressLint("ParcelClassLoader")
+    public static final Parcelable.Creator<WebContents> CREATOR =
+            new Parcelable.Creator<WebContents>() {
+                @Override
+                public WebContents createFromParcel(Parcel source) {
+                    Bundle bundle = source.readBundle();
+
+                    // Check the version.
+                    if (bundle.getLong(PARCEL_VERSION_KEY, -1) != 0) return null;
+
+                    // Check that we're in the same process.
+                    ParcelUuid parcelUuid = bundle.getParcelable(PARCEL_PROCESS_GUARD_KEY);
+                    if (sParcelableUUID.compareTo(parcelUuid.getUuid()) != 0) return null;
+
+                    // Attempt to retrieve the WebContents object from the native pointer.
+                    return WebContentsImplJni.get().fromNativePtr(
+                            bundle.getLong(PARCEL_WEBCONTENTS_KEY));
+                }
+
+                @Override
+                public WebContents[] newArray(int size) {
+                    return new WebContents[size];
+                }
+            };
+
+    /**
+     * Factory interface passed to {@link #getOrSetUserData()} for instantiation of
+     * class as user data.
+     *
+     * Constructor method reference comes handy for class Foo to provide the factory.
+     * Use lazy initialization to avoid having to generate too many anonymous references.
+     *
+     * <code>
+     * public class Foo {
+     *     static final class FoofactoryLazyHolder {
+     *         private static final UserDataFactory<Foo> INSTANCE = Foo::new;
+     *     }
+     *     ....
+     *
+     *     webContents.getOrsetUserData(Foo.class, FooFactoryLazyHolder.INSTANCE);
+     *
+     *     ....
+     * }
+     * </code>
+     *
+     * @param <T> Class to instantiate.
+     */
+    public interface UserDataFactory<T> { T create(WebContents webContents); }
+
+    // Note this list may be incomplete. Frames that never had to initialize java side would
+    // not have an entry here. This is here mainly to keep the java RenderFrameHosts alive, since
+    // native side generally cannot safely hold strong references to them.
+    private final List<RenderFrameHostImpl> mFrames = new ArrayList<>();
+
+    private long mNativeWebContentsAndroid;
+    private NavigationController mNavigationController;
+
+    // Lazily created proxy observer for handling all Java-based WebContentsObservers.
+    private WebContentsObserverProxy mObserverProxy;
+
+    // The media session for this WebContents. It is constructed by the native MediaSession and has
+    // the same life time as native MediaSession.
+    private MediaSessionImpl mMediaSession;
+
+    class SmartClipCallback {
+        public SmartClipCallback(final Handler smartClipHandler) {
+            mHandler = smartClipHandler;
+        }
+
+        public void onSmartClipDataExtracted(String text, String html, Rect clipRect) {
+            // The clipRect is in dip scale here. Add the contentOffset in same scale.
+            RenderCoordinatesImpl coordinateSpace = getRenderCoordinates();
+            clipRect.offset(0,
+                    (int) (coordinateSpace.getContentOffsetYPix()
+                            / coordinateSpace.getDeviceScaleFactor()));
+            Bundle bundle = new Bundle();
+            bundle.putString("url", getVisibleUrl().getSpec());
+            bundle.putString("title", getTitle());
+            bundle.putString("text", text);
+            bundle.putString("html", html);
+            bundle.putParcelable("rect", clipRect);
+
+            Message msg = Message.obtain(mHandler, 0);
+            msg.setData(bundle);
+            msg.sendToTarget();
+        }
+
+        final Handler mHandler;
+    }
+    private SmartClipCallback mSmartClipCallback;
+
+    private EventForwarder mEventForwarder;
+
+    private StylusWritingHandler mStylusWritingHandler;
+
+    // Cached copy of all positions and scales as reported by the renderer.
+    private RenderCoordinatesImpl mRenderCoordinates;
+
+    private InternalsHolder mInternalsHolder;
+
+    private String mProductVersion;
+
+    private boolean mInitialized;
+
+    // Remember the stack for clearing native the native stack for debugging use after destroy.
+    private Throwable mNativeDestroyThrowable;
+
+    private ObserverList<Runnable> mTearDownDialogOverlaysHandlers;
+
+    private static class WebContentsInternalsImpl implements WebContentsInternals {
+        public UserDataHost userDataHost;
+        public ViewAndroidDelegate viewAndroidDelegate;
+    }
+
+    private WebContentsImpl(
+            long nativeWebContentsAndroid, NavigationController navigationController) {
+        assert nativeWebContentsAndroid != 0;
+        mNativeWebContentsAndroid = nativeWebContentsAndroid;
+        mNavigationController = navigationController;
+    }
+
+    @CalledByNative
+    @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+    public static WebContentsImpl create(
+            long nativeWebContentsAndroid, NavigationController navigationController) {
+        return new WebContentsImpl(nativeWebContentsAndroid, navigationController);
+    }
+
+    @Override
+    public void initialize(String productVersion, ViewAndroidDelegate viewDelegate,
+            InternalAccessDelegate accessDelegate, WindowAndroid windowAndroid,
+            InternalsHolder internalsHolder) {
+        assert internalsHolder != null;
+
+        mProductVersion = productVersion;
+
+        WebContentsInternalsImpl internals;
+        if (mInternalsHolder != null) {
+            internals = (WebContentsInternalsImpl) mInternalsHolder.get();
+        } else {
+            internals = new WebContentsInternalsImpl();
+            internals.userDataHost = new UserDataHost();
+        }
+        mInternalsHolder = internalsHolder;
+        mInternalsHolder.set(internals);
+
+        if (mRenderCoordinates == null) {
+            mRenderCoordinates = new RenderCoordinatesImpl();
+        }
+
+        mInitialized = true;
+
+        setViewAndroidDelegate(viewDelegate);
+        setTopLevelNativeWindow(windowAndroid);
+
+        if (accessDelegate == null) {
+            accessDelegate = new EmptyInternalAccessDelegate();
+        }
+        ViewEventSinkImpl.from(this).setAccessDelegate(accessDelegate);
+
+        if (windowAndroid != null) {
+            getRenderCoordinates().setDeviceScaleFactor(windowAndroid.getDisplay().getDipScale());
+        }
+    }
+
+    @Override
+    public void clearJavaWebContentsObservers() {
+        // Clear all the Android specific observers.
+        if (mObserverProxy != null) {
+            mObserverProxy.destroy();
+            mObserverProxy = null;
+        }
+    }
+
+    @Nullable
+    public Context getContext() {
+        assert mInitialized;
+
+        WindowAndroid window = getTopLevelNativeWindow();
+        return window != null ? window.getContext().get() : null;
+    }
+
+    public String getProductVersion() {
+        assert mInitialized;
+        return mProductVersion;
+    }
+
+    @CalledByNative
+    @VisibleForTesting
+    void clearNativePtr() {
+        mNativeDestroyThrowable = new RuntimeException("clearNativePtr");
+        mNativeWebContentsAndroid = 0;
+        mNavigationController = null;
+        if (mObserverProxy != null) {
+            mObserverProxy.destroy();
+            mObserverProxy = null;
+        }
+    }
+
+    // =================== RenderFrameHostDelegate overrides ===================
+    @Override
+    public void renderFrameCreated(RenderFrameHostImpl host) {
+        assert !mFrames.contains(host);
+        mFrames.add(host);
+    }
+
+    @Override
+    public void renderFrameDeleted(RenderFrameHostImpl host) {
+        assert mFrames.contains(host);
+        mFrames.remove(host);
+    }
+    // ================= end RenderFrameHostDelegate overrides =================
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        // This is wrapped in a Bundle so that failed deserialization attempts don't corrupt the
+        // overall Parcel.  If we failed a UUID or Version check and didn't read the rest of the
+        // fields it would corrupt the serialized stream.
+        Bundle data = new Bundle();
+        data.putLong(PARCEL_VERSION_KEY, PARCELABLE_VERSION_ID);
+        data.putParcelable(PARCEL_PROCESS_GUARD_KEY, new ParcelUuid(sParcelableUUID));
+        data.putLong(PARCEL_WEBCONTENTS_KEY, mNativeWebContentsAndroid);
+        dest.writeBundle(data);
+    }
+
+    @CalledByNative
+    private long getNativePointer() {
+        return mNativeWebContentsAndroid;
+    }
+
+    @Override
+    public WindowAndroid getTopLevelNativeWindow() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getTopLevelNativeWindow(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void setTopLevelNativeWindow(WindowAndroid windowAndroid) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().setTopLevelNativeWindow(mNativeWebContentsAndroid, windowAndroid);
+        WindowEventObserverManager.from(this).onWindowAndroidChanged(windowAndroid);
+        if (mObserverProxy != null) mObserverProxy.onTopLevelNativeWindowChanged(windowAndroid);
+    }
+
+    @Override
+    public ViewAndroidDelegate getViewAndroidDelegate() {
+        WebContentsInternals internals = mInternalsHolder.get();
+        if (internals == null) return null;
+        return ((WebContentsInternalsImpl) internals).viewAndroidDelegate;
+    }
+
+    private void setViewAndroidDelegate(ViewAndroidDelegate viewDelegate) {
+        checkNotDestroyed();
+        WebContentsInternals internals = mInternalsHolder.get();
+        assert internals != null;
+        WebContentsInternalsImpl impl = (WebContentsInternalsImpl) internals;
+        impl.viewAndroidDelegate = viewDelegate;
+        WebContentsImplJni.get().setViewAndroidDelegate(mNativeWebContentsAndroid, viewDelegate);
+    }
+
+    @Override
+    public void destroy() {
+        // Note that |WebContents.destroy| is not guaranteed to be invoked.
+        // Any resource release relying on this method will likely be leaked.
+
+        if (!ThreadUtils.runningOnUiThread()) {
+            throw new IllegalStateException("Attempting to destroy WebContents on non-UI thread");
+        }
+
+        if (mObserverProxy != null && mObserverProxy.isHandlingObserverCall()) {
+            throw new RuntimeException(
+                    "Attempting to destroy WebContents while handling observer calls");
+        }
+
+        if (mNativeWebContentsAndroid != 0) {
+            WebContentsImplJni.get().destroyWebContents(mNativeWebContentsAndroid);
+        }
+    }
+
+    @Override
+    public boolean isDestroyed() {
+        return mNativeWebContentsAndroid == 0
+                || WebContentsImplJni.get().isBeingDestroyed(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void clearNativeReference() {
+        if (mNativeWebContentsAndroid != 0) {
+            WebContentsImplJni.get().clearNativeReference(mNativeWebContentsAndroid);
+        }
+    }
+
+    @Override
+    public NavigationController getNavigationController() {
+        return mNavigationController;
+    }
+
+    @Override
+    public RenderFrameHost getMainFrame() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getMainFrame(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public RenderFrameHost getFocusedFrame() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getFocusedFrame(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public boolean isFocusedElementEditable() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().isFocusedElementEditable(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public RenderFrameHost getRenderFrameHostFromId(GlobalRenderFrameHostId id) {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getRenderFrameHostFromId(
+                mNativeWebContentsAndroid, id.childId(), id.frameRoutingId());
+    }
+
+    // The RenderFrameHosts that are every RenderFrameHost in this WebContents.
+    // See C++'s WebContents::ForEachRenderFrameHost for details.
+    public List<RenderFrameHost> getAllRenderFrameHosts() {
+        checkNotDestroyed();
+        RenderFrameHost[] frames =
+                WebContentsImplJni.get().getAllRenderFrameHosts(mNativeWebContentsAndroid);
+        return Collections.unmodifiableList(Arrays.asList(frames));
+    }
+
+    @CalledByNative
+    private static RenderFrameHost[] createRenderFrameHostArray(int size) {
+        return new RenderFrameHost[size];
+    }
+
+    @CalledByNative
+    private static void addRenderFrameHostToArray(
+            RenderFrameHost[] frames, int index, RenderFrameHost frame) {
+        frames[index] = frame;
+    }
+
+    /**
+     * Thrown by reportDanglingPtrToBrowserContext(), indicating that WebContentsImpl is deleted
+     * after its BrowserContext.
+     */
+    private static class DanglingPointerException extends RuntimeException {
+        DanglingPointerException(String msg, Throwable causedBy) {
+            super(msg, causedBy);
+        }
+    }
+
+    @CalledByNative
+    private static void reportDanglingPtrToBrowserContext(Throwable creator) {
+        JavaExceptionReporter.reportException(new DanglingPointerException(
+                "Dangling pointer to BrowserContext in WebContents", creator));
+    }
+
+    @Override
+    public @Nullable RenderWidgetHostViewImpl getRenderWidgetHostView() {
+        if (mNativeWebContentsAndroid == 0) return null;
+        RenderWidgetHostViewImpl rwhvi =
+                WebContentsImplJni.get().getRenderWidgetHostView(mNativeWebContentsAndroid);
+        if (rwhvi == null || rwhvi.isDestroyed()) return null;
+
+        return rwhvi;
+    }
+
+    @Override
+    public List<WebContentsImpl> getInnerWebContents() {
+        checkNotDestroyed();
+        WebContentsImpl[] innerWebContents =
+                WebContentsImplJni.get().getInnerWebContents(mNativeWebContentsAndroid);
+        return Collections.unmodifiableList(Arrays.asList(innerWebContents));
+    }
+
+    @Override
+    public @Visibility int getVisibility() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getVisibility(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void updateWebContentsVisibility(@Visibility int visibility) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().updateWebContentsVisibility(mNativeWebContentsAndroid, visibility);
+    }
+
+    @Override
+    public String getTitle() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getTitle(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public GURL getVisibleUrl() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getVisibleURL(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    @VirtualKeyboardMode.EnumType
+    public int getVirtualKeyboardMode() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getVirtualKeyboardMode(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public String getEncoding() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getEncoding(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public boolean isLoading() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().isLoading(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public boolean shouldShowLoadingUI() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().shouldShowLoadingUI(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void dispatchBeforeUnload(boolean autoCancel) {
+        if (mNativeWebContentsAndroid == 0) return;
+        WebContentsImplJni.get().dispatchBeforeUnload(mNativeWebContentsAndroid, autoCancel);
+    }
+
+    @Override
+    public void stop() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().stop(mNativeWebContentsAndroid);
+    }
+
+    /**
+     * Cut the selected content.
+     */
+    public void cut() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().cut(mNativeWebContentsAndroid);
+    }
+
+    /**
+     * Copy the selected content.
+     */
+    public void copy() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().copy(mNativeWebContentsAndroid);
+    }
+
+    /**
+     * Paste content from the clipboard.
+     */
+    public void paste() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().paste(mNativeWebContentsAndroid);
+    }
+
+    /**
+     * Paste content from the clipboard without format.
+     */
+    public void pasteAsPlainText() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().pasteAsPlainText(mNativeWebContentsAndroid);
+    }
+
+    /**
+     * Replace the selected text with the {@code word}.
+     */
+    public void replace(String word) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().replace(mNativeWebContentsAndroid, word);
+    }
+
+    /**
+     * Select all content.
+     */
+    public void selectAll() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().selectAll(mNativeWebContentsAndroid);
+    }
+
+    /**
+     * Collapse the selection to the end of selection range.
+     */
+    public void collapseSelection() {
+        // collapseSelection may get triggered when certain selection-related widgets
+        // are destroyed. As the timing for such destruction is unpredictable,
+        // safely guard against this case.
+        if (isDestroyed()) return;
+        WebContentsImplJni.get().collapseSelection(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void onHide() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().onHide(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void onFreeze() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().onFreeze(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void onResume() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().onResume(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void onShow() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().onShow(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void setImportance(@ChildProcessImportance int primaryMainFrameImportance) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().setImportance(
+                mNativeWebContentsAndroid, primaryMainFrameImportance);
+    }
+
+    @Override
+    public void suspendAllMediaPlayers() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().suspendAllMediaPlayers(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void setAudioMuted(boolean mute) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().setAudioMuted(mNativeWebContentsAndroid, mute);
+    }
+
+    @Override
+    public boolean focusLocationBarByDefault() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().focusLocationBarByDefault(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public boolean isFullscreenForCurrentTab() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().isFullscreenForCurrentTab(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void exitFullscreen() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().exitFullscreen(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void scrollFocusedEditableNodeIntoView() {
+        checkNotDestroyed();
+        // The native side keeps track of whether the zoom and scroll actually occurred. It is
+        // more efficient to do it this way and sometimes fire an unnecessary message rather
+        // than synchronize with the renderer and always have an additional message.
+        WebContentsImplJni.get().scrollFocusedEditableNodeIntoView(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void selectAroundCaret(@SelectionGranularity int granularity, boolean shouldShowHandle,
+            boolean shouldShowContextMenu) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().selectAroundCaret(
+                mNativeWebContentsAndroid, granularity, shouldShowHandle, shouldShowContextMenu);
+    }
+
+    @Override
+    public void adjustSelectionByCharacterOffset(
+            int startAdjust, int endAdjust, boolean showSelectionMenu) {
+        WebContentsImplJni.get().adjustSelectionByCharacterOffset(
+                mNativeWebContentsAndroid, startAdjust, endAdjust, showSelectionMenu);
+    }
+
+    @Override
+    public GURL getLastCommittedUrl() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getLastCommittedURL(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public boolean isIncognito() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().isIncognito(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void resumeLoadingCreatedWebContents() {
+        checkNotDestroyed();
+        WebContentsImplJni.get().resumeLoadingCreatedWebContents(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void evaluateJavaScript(String script, JavaScriptCallback callback) {
+        ThreadUtils.assertOnUiThread();
+        if (isDestroyed() || script == null) return;
+        WebContentsImplJni.get().evaluateJavaScript(mNativeWebContentsAndroid, script, callback);
+    }
+
+    @Override
+    @VisibleForTesting
+    public void evaluateJavaScriptForTests(String script, JavaScriptCallback callback) {
+        ThreadUtils.assertOnUiThread();
+        if (script == null) return;
+        checkNotDestroyed();
+        WebContentsImplJni.get().evaluateJavaScriptForTests(
+                mNativeWebContentsAndroid, script, callback);
+    }
+
+    @Override
+    public void addMessageToDevToolsConsole(int level, String message) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().addMessageToDevToolsConsole(
+                mNativeWebContentsAndroid, level, message);
+    }
+
+    @Override
+    public void postMessageToMainFrame(MessagePayload messagePayload, String sourceOrigin,
+            String targetOrigin, MessagePort[] ports) {
+        if (ports != null) {
+            for (MessagePort port : ports) {
+                if (port.isClosed() || port.isTransferred()) {
+                    throw new IllegalStateException("Port is already closed or transferred");
+                }
+                if (port.isStarted()) {
+                    throw new IllegalStateException("Port is already started");
+                }
+            }
+        }
+        // Treat "*" as a wildcard. Internally, a wildcard is a empty string.
+        if (targetOrigin.equals("*")) {
+            targetOrigin = "";
+        }
+        WebContentsImplJni.get().postMessageToMainFrame(
+                mNativeWebContentsAndroid, messagePayload, sourceOrigin, targetOrigin, ports);
+    }
+
+    @Override
+    public AppWebMessagePort[] createMessageChannel()
+            throws IllegalStateException {
+        return AppWebMessagePort.createPair();
+    }
+
+    @Override
+    public boolean hasAccessedInitialDocument() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().hasAccessedInitialDocument(mNativeWebContentsAndroid);
+    }
+
+    @CalledByNative
+    private static void onEvaluateJavaScriptResult(
+            String jsonResult, JavaScriptCallback callback) {
+        callback.handleJavaScriptResult(jsonResult);
+    }
+
+    @Override
+    public int getThemeColor() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getThemeColor(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public float getLoadProgress() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getLoadProgress(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void requestSmartClipExtract(int x, int y, int width, int height) {
+        if (mSmartClipCallback == null) return;
+        checkNotDestroyed();
+        RenderCoordinatesImpl coordinateSpace = getRenderCoordinates();
+        float dpi = coordinateSpace.getDeviceScaleFactor();
+        y = y - (int) coordinateSpace.getContentOffsetYPix();
+        WebContentsImplJni.get().requestSmartClipExtract(mNativeWebContentsAndroid,
+                mSmartClipCallback, (int) (x / dpi), (int) (y / dpi), (int) (width / dpi),
+                (int) (height / dpi));
+    }
+
+    @Override
+    public void setSmartClipResultHandler(final Handler smartClipHandler) {
+        if (smartClipHandler == null) {
+            mSmartClipCallback = null;
+            return;
+        }
+        mSmartClipCallback = new SmartClipCallback(smartClipHandler);
+    }
+
+    @CalledByNative
+    private static void onSmartClipDataExtracted(String text, String html, int left, int top,
+            int right, int bottom, SmartClipCallback callback) {
+        callback.onSmartClipDataExtracted(text, html, new Rect(left, top, right, bottom));
+    }
+
+    /**
+     * Requests a snapshop of accessibility tree. The result is provided asynchronously
+     * using the callback
+     * @param callback The callback to be called when the snapshot is ready. The callback
+     *                 cannot be null.
+     */
+    public void requestAccessibilitySnapshot(ViewStructure root, Runnable doneCallback) {
+        checkNotDestroyed();
+        ViewStructureBuilder builder = ViewStructureBuilder.create(mRenderCoordinates);
+
+        WebContentsImplJni.get().requestAccessibilitySnapshot(
+                mNativeWebContentsAndroid, root, builder, doneCallback);
+    }
+
+    @VisibleForTesting
+    public void simulateRendererKilledForTesting() {
+        if (mObserverProxy != null) {
+            mObserverProxy.renderProcessGone();
+        }
+    }
+
+    @Override
+    public void setStylusWritingHandler(StylusWritingHandler stylusWritingHandler) {
+        mStylusWritingHandler = stylusWritingHandler;
+        if (mNativeWebContentsAndroid == 0) return;
+        WebContentsImplJni.get().setStylusHandwritingEnabled(
+                mNativeWebContentsAndroid, mStylusWritingHandler != null);
+    }
+
+    public StylusWritingHandler getStylusWritingHandler() {
+        return mStylusWritingHandler;
+    }
+
+    @Override
+    public EventForwarder getEventForwarder() {
+        assert mNativeWebContentsAndroid != 0;
+        if (mEventForwarder == null) {
+            checkNotDestroyed();
+            mEventForwarder =
+                    WebContentsImplJni.get().getOrCreateEventForwarder(mNativeWebContentsAndroid);
+            mEventForwarder.setStylusWritingDelegate(new EventForwarder.StylusWritingDelegate() {
+                @Override
+                public boolean handleTouchEvent(MotionEvent motionEvent) {
+                    return mStylusWritingHandler != null
+                            && mStylusWritingHandler.handleTouchEvent(
+                                    motionEvent, getViewAndroidDelegate().getContainerView());
+                }
+
+                @Override
+                public void handleHoverEvent(MotionEvent motionEvent) {
+                    if (mStylusWritingHandler != null) {
+                        mStylusWritingHandler.handleHoverEvent(
+                                motionEvent, getViewAndroidDelegate().getContainerView());
+                    }
+                }
+            });
+        }
+        return mEventForwarder;
+    }
+
+    @Override
+    public void addObserver(WebContentsObserver observer) {
+        assert mNativeWebContentsAndroid != 0;
+        if (mObserverProxy == null) mObserverProxy = new WebContentsObserverProxy(this);
+        mObserverProxy.addObserver(observer);
+    }
+
+    @Override
+    public void removeObserver(WebContentsObserver observer) {
+        if (mObserverProxy == null) return;
+        mObserverProxy.removeObserver(observer);
+    }
+
+    @Override
+    public void setOverscrollRefreshHandler(OverscrollRefreshHandler handler) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().setOverscrollRefreshHandler(mNativeWebContentsAndroid, handler);
+    }
+
+    @Override
+    public void setSpatialNavigationDisabled(boolean disabled) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().setSpatialNavigationDisabled(mNativeWebContentsAndroid, disabled);
+    }
+
+    @Override
+    public int downloadImage(GURL url, boolean isFavicon, int maxBitmapSize, boolean bypassCache,
+            ImageDownloadCallback callback) {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().downloadImage(
+                mNativeWebContentsAndroid, url, isFavicon, maxBitmapSize, bypassCache, callback);
+    }
+
+    @CalledByNative
+    private void onDownloadImageFinished(ImageDownloadCallback callback, int id, int httpStatusCode,
+            GURL imageUrl, List<Bitmap> bitmaps, List<Rect> sizes) {
+        callback.onFinishDownloadImage(id, httpStatusCode, imageUrl, bitmaps, sizes);
+    }
+
+    @Override
+    public void setHasPersistentVideo(boolean value) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().setHasPersistentVideo(mNativeWebContentsAndroid, value);
+    }
+
+    @Override
+    public boolean hasActiveEffectivelyFullscreenVideo() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().hasActiveEffectivelyFullscreenVideo(
+                mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public boolean isPictureInPictureAllowedForFullscreenVideo() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().isPictureInPictureAllowedForFullscreenVideo(
+                mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public @Nullable Rect getFullscreenVideoSize() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getFullscreenVideoSize(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void setSize(int width, int height) {
+        checkNotDestroyed();
+        WebContentsImplJni.get().setSize(mNativeWebContentsAndroid, width, height);
+    }
+
+    @Override
+    public int getWidth() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getWidth(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public int getHeight() {
+        checkNotDestroyed();
+        return WebContentsImplJni.get().getHeight(mNativeWebContentsAndroid);
+    }
+
+    @CalledByNative
+    private final void setMediaSession(MediaSessionImpl mediaSession) {
+        mMediaSession = mediaSession;
+    }
+
+    @CalledByNative
+    private static List<Bitmap> createBitmapList() {
+        return new ArrayList<Bitmap>();
+    }
+
+    @CalledByNative
+    private static void addToBitmapList(List<Bitmap> bitmaps, Bitmap bitmap) {
+        bitmaps.add(bitmap);
+    }
+
+    @CalledByNative
+    private static List<Rect> createSizeList() {
+        return new ArrayList<Rect>();
+    }
+
+    @CalledByNative
+    private static void createSizeAndAddToList(List<Rect> sizes, int width, int height) {
+        sizes.add(new Rect(0, 0, width, height));
+    }
+
+    @CalledByNative
+    private static Rect createSize(int width, int height) {
+        return new Rect(0, 0, width, height);
+    }
+
+    /**
+     * Returns {@link RenderCoordinatesImpl}.
+     */
+    public RenderCoordinatesImpl getRenderCoordinates() {
+        return mRenderCoordinates;
+    }
+
+    /**
+     * Retrieves or stores a user data object for this WebContents.
+     * @param key Class instance of the object used as the key.
+     * @param userDataFactory Factory that creates an object of the generic class. A new object
+     *        is created if it hasn't been created and non-null factory is given.
+     * @return The created or retrieved user data object. Can be null if the object was
+     *         not created yet, or {@code userDataFactory} is null, or the internal data
+     *         storage is already garbage-collected.
+     */
+    public <T extends UserData> T getOrSetUserData(
+            Class<T> key, UserDataFactory<T> userDataFactory) {
+        // For tests that go without calling |initialize|.
+        if (!mInitialized) return null;
+
+        UserDataHost userDataHost = getUserDataHost();
+
+        // Map can be null after WebView gets gc'ed on its way to destruction.
+        if (userDataHost == null) {
+            Log.d(TAG, "UserDataHost can't be found");
+            return null;
+        }
+
+        T data = userDataHost.getUserData(key);
+        if (data == null && userDataFactory != null) {
+            assert userDataHost.getUserData(key) == null; // Do not allow overwriting
+
+            T object = userDataFactory.create(this);
+            assert key.isInstance(object);
+
+            // Retrieves from the map again to return null in case |setUserData| fails
+            // to store the object.
+            data = userDataHost.setUserData(key, object);
+        }
+        return key.cast(data);
+    }
+
+    /**
+     * Convenience method to initialize test state. Only use for testing.
+     */
+    @VisibleForTesting
+    public void initializeForTesting() {
+        if (mInternalsHolder == null) {
+            mInternalsHolder = WebContents.createDefaultInternalsHolder();
+        }
+        WebContentsInternalsImpl internals = (WebContentsInternalsImpl) mInternalsHolder.get();
+        if (internals == null) {
+            internals = new WebContentsInternalsImpl();
+            internals.userDataHost = new UserDataHost();
+        }
+        mInternalsHolder.set(internals);
+        mInitialized = true;
+    }
+
+    /**
+     * Convenience method to set user data. Only use for testing.
+     */
+    @VisibleForTesting
+    public <T extends UserData> void setUserDataForTesting(Class<T> key, T userData) {
+        // Be sure to call initializeForTesting() first.
+        assert mInitialized;
+
+        WebContentsInternalsImpl internals = (WebContentsInternalsImpl) mInternalsHolder.get();
+        internals.userDataHost.setUserData(key, userData);
+    }
+
+    public <T extends UserData> void removeUserData(Class<T> key) {
+        UserDataHost userDataHost = getUserDataHost();
+        if (userDataHost == null) return;
+        userDataHost.removeUserData(key);
+    }
+
+    /**
+     * @return {@code UserDataHost} that contains internal user data. {@code null} if
+     *         it is already gc'ed.
+     */
+    private UserDataHost getUserDataHost() {
+        if (mInternalsHolder == null) return null;
+        WebContentsInternals internals = mInternalsHolder.get();
+        if (internals == null) return null;
+        return ((WebContentsInternalsImpl) internals).userDataHost;
+    }
+
+    // WindowEventObserver
+
+    @Override
+    public void onRotationChanged(int rotation) {
+        if (mNativeWebContentsAndroid == 0) return;
+        int rotationDegrees = 0;
+        switch (rotation) {
+            case Surface.ROTATION_0:
+                rotationDegrees = 0;
+                break;
+            case Surface.ROTATION_90:
+                rotationDegrees = 90;
+                break;
+            case Surface.ROTATION_180:
+                rotationDegrees = 180;
+                break;
+            case Surface.ROTATION_270:
+                rotationDegrees = -90;
+                break;
+            default:
+                throw new IllegalStateException(
+                        "Display.getRotation() shouldn't return that value");
+        }
+        WebContentsImplJni.get().sendOrientationChangeEvent(
+                mNativeWebContentsAndroid, rotationDegrees);
+    }
+
+    @Override
+    public void onDIPScaleChanged(float dipScale) {
+        if (mNativeWebContentsAndroid == 0) return;
+        mRenderCoordinates.setDeviceScaleFactor(dipScale);
+        WebContentsImplJni.get().onScaleFactorChanged(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void setFocus(boolean hasFocus) {
+        if (mNativeWebContentsAndroid == 0) return;
+        WebContentsImplJni.get().setFocus(mNativeWebContentsAndroid, hasFocus);
+    }
+
+    @Override
+    public void setDisplayCutoutSafeArea(Rect insets) {
+        if (mNativeWebContentsAndroid == 0) return;
+        WebContentsImplJni.get().setDisplayCutoutSafeArea(
+                mNativeWebContentsAndroid, insets.top, insets.left, insets.bottom, insets.right);
+    }
+
+    @Override
+    public void notifyRendererPreferenceUpdate() {
+        if (mNativeWebContentsAndroid == 0) return;
+        WebContentsImplJni.get().notifyRendererPreferenceUpdate(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void notifyBrowserControlsHeightChanged() {
+        if (mNativeWebContentsAndroid == 0) return;
+        WebContentsImplJni.get().notifyBrowserControlsHeightChanged(mNativeWebContentsAndroid);
+    }
+
+    @Override
+    public void tearDownDialogOverlays() {
+        if (mTearDownDialogOverlaysHandlers == null) return;
+        Iterator<Runnable> it = mTearDownDialogOverlaysHandlers.iterator();
+        while (it.hasNext()) {
+            Runnable handler = it.next();
+            handler.run();
+        }
+    }
+
+    @Override
+    public boolean needToFireBeforeUnloadOrUnloadEvents() {
+        if (mNativeWebContentsAndroid == 0) return false;
+        return WebContentsImplJni.get().needToFireBeforeUnloadOrUnloadEvents(
+                mNativeWebContentsAndroid);
+    }
+
+    public void addTearDownDialogOverlaysHandler(Runnable handler) {
+        if (mTearDownDialogOverlaysHandlers == null) {
+            mTearDownDialogOverlaysHandlers = new ObserverList<>();
+        }
+
+        assert !mTearDownDialogOverlaysHandlers.hasObserver(handler);
+        mTearDownDialogOverlaysHandlers.addObserver(handler);
+    }
+
+    public void removeTearDownDialogOverlaysHandler(Runnable handler) {
+        assert mTearDownDialogOverlaysHandlers != null;
+        assert mTearDownDialogOverlaysHandlers.hasObserver(handler);
+
+        mTearDownDialogOverlaysHandlers.removeObserver(handler);
+    }
+
+    private void checkNotDestroyed() {
+        if (mNativeWebContentsAndroid != 0) return;
+        throw new IllegalStateException(
+                "Native WebContents already destroyed", mNativeDestroyThrowable);
+    }
+
+    @VisibleForTesting(otherwise = VisibleForTesting.PACKAGE_PRIVATE)
+    @NativeMethods
+    public interface Natives {
+        // This is static to avoid exposing a public destroy method on the native side of this
+        // class.
+        void destroyWebContents(long webContentsAndroidPtr);
+
+        WebContents fromNativePtr(long webContentsAndroidPtr);
+        void clearNativeReference(long nativeWebContentsAndroid);
+        WindowAndroid getTopLevelNativeWindow(long nativeWebContentsAndroid);
+        void setTopLevelNativeWindow(long nativeWebContentsAndroid, WindowAndroid windowAndroid);
+        RenderFrameHost getMainFrame(long nativeWebContentsAndroid);
+        RenderFrameHost getFocusedFrame(long nativeWebContentsAndroid);
+        boolean isFocusedElementEditable(long nativeWebContentsAndroid);
+        RenderFrameHost getRenderFrameHostFromId(
+                long nativeWebContentsAndroid, int renderProcessId, int renderFrameId);
+        RenderFrameHost[] getAllRenderFrameHosts(long nativeWebContentsAndroid);
+        RenderWidgetHostViewImpl getRenderWidgetHostView(long nativeWebContentsAndroid);
+        WebContentsImpl[] getInnerWebContents(long nativeWebContentsAndroid);
+        @Visibility
+        int getVisibility(long nativeWebContentsAndroid);
+        void updateWebContentsVisibility(long nativeWebContentsAndroid, int visibility);
+        String getTitle(long nativeWebContentsAndroid);
+        GURL getVisibleURL(long nativeWebContentsAndroid);
+        int getVirtualKeyboardMode(long nativeWebContentsAndroid);
+        String getEncoding(long nativeWebContentsAndroid);
+        boolean isLoading(long nativeWebContentsAndroid);
+        boolean shouldShowLoadingUI(long nativeWebContentsAndroid);
+        void dispatchBeforeUnload(long nativeWebContentsAndroid, boolean autoCancel);
+        void stop(long nativeWebContentsAndroid);
+        void cut(long nativeWebContentsAndroid);
+        void copy(long nativeWebContentsAndroid);
+        void paste(long nativeWebContentsAndroid);
+        void pasteAsPlainText(long nativeWebContentsAndroid);
+        void replace(long nativeWebContentsAndroid, String word);
+        void selectAll(long nativeWebContentsAndroid);
+        void collapseSelection(long nativeWebContentsAndroid);
+        void onHide(long nativeWebContentsAndroid);
+        void onShow(long nativeWebContentsAndroid);
+        void onFreeze(long nativeWebContentsAndroid);
+        void onResume(long nativeWebContentsAndroid);
+        void setImportance(long nativeWebContentsAndroid, int importance);
+        void suspendAllMediaPlayers(long nativeWebContentsAndroid);
+        void setAudioMuted(long nativeWebContentsAndroid, boolean mute);
+        boolean focusLocationBarByDefault(long nativeWebContentsAndroid);
+        boolean isFullscreenForCurrentTab(long nativeWebContentsAndroid);
+        void exitFullscreen(long nativeWebContentsAndroid);
+        void scrollFocusedEditableNodeIntoView(long nativeWebContentsAndroid);
+        void selectAroundCaret(long nativeWebContentsAndroid, int granularity,
+                boolean shouldShowHandle, boolean shouldShowContextMenu);
+        void adjustSelectionByCharacterOffset(long nativeWebContentsAndroid, int startAdjust,
+                int endAdjust, boolean showSelectionMenu);
+        GURL getLastCommittedURL(long nativeWebContentsAndroid);
+        boolean isIncognito(long nativeWebContentsAndroid);
+        void resumeLoadingCreatedWebContents(long nativeWebContentsAndroid);
+        void evaluateJavaScript(
+                long nativeWebContentsAndroid, String script, JavaScriptCallback callback);
+        void evaluateJavaScriptForTests(
+                long nativeWebContentsAndroid, String script, JavaScriptCallback callback);
+        void addMessageToDevToolsConsole(long nativeWebContentsAndroid, int level, String message);
+        void postMessageToMainFrame(long nativeWebContentsAndroid, MessagePayload payload,
+                String sourceOrigin, String targetOrigin, MessagePort[] ports);
+        boolean hasAccessedInitialDocument(long nativeWebContentsAndroid);
+        int getThemeColor(long nativeWebContentsAndroid);
+        float getLoadProgress(long nativeWebContentsAndroid);
+        void requestSmartClipExtract(long nativeWebContentsAndroid, SmartClipCallback callback,
+                int x, int y, int width, int height);
+        void requestAccessibilitySnapshot(long nativeWebContentsAndroid,
+                ViewStructure viewStructureRoot, ViewStructureBuilder viewStructureBuilder,
+                Runnable doneCallback);
+        void setOverscrollRefreshHandler(long nativeWebContentsAndroid,
+                OverscrollRefreshHandler nativeOverscrollRefreshHandler);
+        void setSpatialNavigationDisabled(long nativeWebContentsAndroid, boolean disabled);
+        void setStylusHandwritingEnabled(long nativeWebContentsAndroid, boolean enabled);
+        int downloadImage(long nativeWebContentsAndroid, GURL url, boolean isFavicon,
+                int maxBitmapSize, boolean bypassCache, ImageDownloadCallback callback);
+        void setHasPersistentVideo(long nativeWebContentsAndroid, boolean value);
+        boolean hasActiveEffectivelyFullscreenVideo(long nativeWebContentsAndroid);
+        boolean isPictureInPictureAllowedForFullscreenVideo(long nativeWebContentsAndroid);
+        Rect getFullscreenVideoSize(long nativeWebContentsAndroid);
+        void setSize(long nativeWebContentsAndroid, int width, int height);
+        int getWidth(long nativeWebContentsAndroid);
+        int getHeight(long nativeWebContentsAndroid);
+        EventForwarder getOrCreateEventForwarder(long nativeWebContentsAndroid);
+        void setViewAndroidDelegate(
+                long nativeWebContentsAndroid, ViewAndroidDelegate viewDelegate);
+        void sendOrientationChangeEvent(long nativeWebContentsAndroid, int orientation);
+        void onScaleFactorChanged(long nativeWebContentsAndroid);
+        void setFocus(long nativeWebContentsAndroid, boolean focused);
+        void setDisplayCutoutSafeArea(
+                long nativeWebContentsAndroid, int top, int left, int bottom, int right);
+        void notifyRendererPreferenceUpdate(long nativeWebContentsAndroid);
+        void notifyBrowserControlsHeightChanged(long nativeWebContentsAndroid);
+        boolean isBeingDestroyed(long nativeWebContentsAndroid);
+        boolean needToFireBeforeUnloadOrUnloadEvents(long nativeWebContentsAndroid);
+    }
+}

--- a/services/device/screen_orientation/BUILD.gn
+++ b/services/device/screen_orientation/BUILD.gn
@@ -46,5 +46,10 @@ if (is_android) {
       "//base:jni_java",
       "//ui/android:ui_no_recycler_view_java",
     ]
+
+    if (is_cobalt) {
+      deps -= [ "//ui/android:ui_no_recycler_view_java" ]
+      deps += [ "//ui/android:cobalt_ui_full_java" ]
+    }
   }
 }

--- a/ui/android/BUILD.gn
+++ b/ui/android/BUILD.gn
@@ -669,3 +669,103 @@ generate_jni("ui_javatest_jni_headers") {
   sources =
       [ "javatests/src/org/chromium/ui/base/ClipboardAndroidTestSupport.java" ]
 }
+
+if (is_cobalt) {
+  android_library("cobalt_ui_full_java") {
+    sources = [
+      "java/src/org/chromium/ui/KeyboardVisibilityDelegate.java",
+      "java/src/org/chromium/ui/MotionEventUtils.java",
+      "java/src/org/chromium/ui/OverscrollRefreshHandler.java",
+      "java/src/org/chromium/ui/UiSwitches.java",
+      "java/src/org/chromium/ui/base/ActivityIntentRequestTrackerDelegate.java",
+      "java/src/org/chromium/ui/base/ActivityKeyboardVisibilityDelegate.java",
+      "java/src/org/chromium/ui/base/ActivityWindowAndroid.java",
+      "java/src/org/chromium/ui/base/ApplicationViewportInsetSupplier.java",
+      "java/src/org/chromium/ui/base/DeviceFormFactor.java",
+      "java/src/org/chromium/ui/base/EventForwarder.java",
+      "java/src/org/chromium/ui/base/ImmutableWeakReference.java",
+      "java/src/org/chromium/ui/base/IntentRequestTracker.java",
+      "java/src/org/chromium/ui/base/IntentRequestTrackerImpl.java",
+      "java/src/org/chromium/ui/base/OverlayTransformApiHelper.java",
+      "java/src/org/chromium/ui/base/LocalizationUtils.java",
+      "java/src/org/chromium/ui/base/ResourceBundle.java",
+      "java/src/org/chromium/ui/base/SPenSupport.java",
+      "java/src/org/chromium/ui/base/TouchDevice.java",
+      "java/src/org/chromium/ui/base/UiAndroidFeatureList.java",
+      "java/src/org/chromium/ui/base/ViewAndroidDelegate.java",
+      "java/src/org/chromium/ui/base/ViewUtils.java",
+      "java/src/org/chromium/ui/base/ViewportInsets.java",
+      "java/src/org/chromium/ui/base/WindowAndroid.java",
+      "java/src/org/chromium/ui/display/DisplayAndroid.java",
+      "java/src/org/chromium/ui/display/DisplayAndroidManager.java",
+      "java/src/org/chromium/ui/display/DisplaySwitches.java",
+      "java/src/org/chromium/ui/display/DisplayUtil.java",
+      "java/src/org/chromium/ui/display/PhysicalDisplayAndroid.java",
+      "java/src/org/chromium/ui/dragdrop/AnimatedImageDragShadowBuilder.java",
+
+      # TODO(b/444449219): remove dragdrop feature from Cobalt.
+      "java/src/org/chromium/ui/dragdrop/DragAndDropBrowserDelegate.java",
+      "java/src/org/chromium/ui/dragdrop/DragAndDropDelegate.java",
+      "java/src/org/chromium/ui/dragdrop/DragAndDropDelegateImpl.java",
+      "java/src/org/chromium/ui/dragdrop/DragStateTracker.java",
+      "java/src/org/chromium/ui/dragdrop/DropDataAndroid.java",
+      "java/src/org/chromium/ui/dragdrop/DropDataProviderImpl.java",
+      "java/src/org/chromium/ui/dragdrop/DropDataProviderUtils.java",
+      "java/src/org/chromium/ui/events/devices/InputDeviceObserver.java",
+      "java/src/org/chromium/ui/gfx/Animation.java",
+      "java/src/org/chromium/ui/gfx/ViewConfigurationHelper.java",
+      "java/src/org/chromium/ui/modaldialog/DialogDismissalCause.java",
+      "java/src/org/chromium/ui/modaldialog/ModalDialogManager.java",
+      "java/src/org/chromium/ui/modaldialog/ModalDialogProperties.java",
+      "java/src/org/chromium/ui/modaldialog/PendingDialogContainer.java",
+      "java/src/org/chromium/ui/modelutil/PropertyKey.java",
+      "java/src/org/chromium/ui/modelutil/PropertyModel.java",
+      "java/src/org/chromium/ui/modelutil/PropertyObservable.java",
+      "java/src/org/chromium/ui/permissions/ActivityAndroidPermissionDelegate.java",
+      "java/src/org/chromium/ui/permissions/AndroidPermissionDelegate.java",
+      "java/src/org/chromium/ui/permissions/AndroidPermissionDelegateWithRequester.java",
+      "java/src/org/chromium/ui/permissions/PermissionCallback.java",
+      "java/src/org/chromium/ui/permissions/PermissionConstants.java",
+      "java/src/org/chromium/ui/permissions/PermissionPrefs.java",
+      "java/src/org/chromium/ui/resources/LayoutResource.java",
+      "java/src/org/chromium/ui/resources/Resource.java",
+      "java/src/org/chromium/ui/resources/ResourceFactory.java",
+      "java/src/org/chromium/ui/resources/ResourceLoader.java",
+      "java/src/org/chromium/ui/resources/ResourceManager.java",
+      "java/src/org/chromium/ui/resources/async/AsyncPreloadResourceLoader.java",
+      "java/src/org/chromium/ui/resources/dynamics/BitmapDynamicResource.java",
+      "java/src/org/chromium/ui/resources/dynamics/DynamicResource.java",
+      "java/src/org/chromium/ui/resources/dynamics/DynamicResourceLoader.java",
+      "java/src/org/chromium/ui/resources/dynamics/DynamicResourceSnapshot.java",
+      "java/src/org/chromium/ui/resources/statics/NinePatchData.java",
+      "java/src/org/chromium/ui/resources/statics/StaticResource.java",
+      "java/src/org/chromium/ui/resources/statics/StaticResourceLoader.java",
+      "java/src/org/chromium/ui/resources/system/SystemResourceLoader.java",
+      "java/src/org/chromium/ui/util/TokenHolder.java",
+      "java/src/org/chromium/ui/widget/Toast.java",
+      "java/src/org/chromium/ui/widget/ToastManager.java",
+      "java/src/org/chromium/ui/widget/UiWidgetFactory.java",
+    ]
+
+    deps = [
+      ":ui_android_features_java",
+      "//base:base_java",
+      "//base:jni_java",
+      "//third_party/androidx:androidx_activity_activity_java",
+      "//third_party/androidx:androidx_annotation_annotation_experimental_java",
+      "//third_party/androidx:androidx_annotation_annotation_java",
+      "//third_party/androidx:androidx_appcompat_appcompat_java",
+      "//third_party/androidx:androidx_appcompat_appcompat_resources_java",
+      "//third_party/androidx:androidx_core_core_java",
+      "//ui/android:ui_java_resources",
+      "//ui/base/cursor/mojom:cursor_type_java",
+      "//ui/base/ime/mojom:mojom_java",
+      "//ui/gfx",
+      "//url:gurl_java",
+    ]
+
+    srcjar_deps = [ "//ui/android:java_enums_srcjar" ]
+    annotation_processor_deps = [ "//base/android/jni_generator:jni_processor" ]
+    resources_package = "org.chromium.ui"
+  }
+}


### PR DESCRIPTION
Reverts youtube/cobalt#7438

If we were to add back `//components/viz/service:service_java`, we would need to add a bunch of indirect dependencies:
https://paste.googleplex.com/6217903133294592.

Can we investigate if we could disable [the failing Bavia smoke tests](https://fusion2.corp.google.com/ci/guitar/workflows/%2F%2Fvideo%2Fyoutube%2Ftesting%2Fmaneki%2Fcobalt%2Fkimono_tests:kimono_lts_smoke_tests/activity/d993e612-031e-3ac4-95c9-eefe4b1918ab:0/phases), if we are sure that these dependencies are unneeded?

Bug: 448659685