### PR TITLE
android: Disable unused Blink/content features

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -110,6 +110,34 @@ public final class CommandLineOverrideHelper {
 
         // Use SurfaceTexture for decode-to-texture mode.
         paramOverrides.add("AImageReader");
+        // Disables the BackForwardCache to save memory.
+        paramOverrides.add("BackForwardCache");
+        // Disables the Digital Goods API for in-app purchases.
+        paramOverrides.add("DigitalGoodsApi");
+        // Disables drawing cutouts edge to edge.
+        paramOverrides.add("DrawCutoutEdgeToEdge");
+        // Disables Federated Credential Management API.
+        paramOverrides.add("FedCm");
+        // Disables FedCM alternative identifiers.
+        paramOverrides.add("FedCmAlternativeIdentifiers");
+        // Disables FedCM iframe origin.
+        paramOverrides.add("FedCmIframeOrigin");
+        // Disables the Installed App API.
+        paramOverrides.add("InstalledApp");
+        // Disables the Installed App Provider.
+        paramOverrides.add("InstalledAppProvider");
+        // Disables Secure Payment Confirmation.
+        paramOverrides.add("SecurePaymentConfirmation");
+        // Disables the WebOTP API for SMS-based authentication.
+        paramOverrides.add("WebOTP");
+        // Disables Web Payments API.
+        paramOverrides.add("WebPayments");
+        // Disables the Web Permissions API.
+        paramOverrides.add("WebPermissionsApi");
+        // Disables the WebUSB API for accessing USB devices.
+        paramOverrides.add("WebUSB");
+        // Disables the WebXR API for VR and AR.
+        paramOverrides.add("WebXR");
 
         return paramOverrides;
     }
@@ -127,6 +155,63 @@ public final class CommandLineOverrideHelper {
         return paramOverrides;
     }
 
+    public static StringJoiner getDefaultBlinkDisableFeatureOverridesList() {
+        StringJoiner paramOverrides = new StringJoiner(",");
+
+        // Disables CSS Typed OM for arithmetic operations.
+        paramOverrides.add("CSSTypedArithmetic");
+        // Disables Federated Credential Management API in Blink.
+        paramOverrides.add("FedCm");
+        // Disables Fenced Frames for embedding content.
+        paramOverrides.add("FencedFrames");
+        // Disables HTML printing artifact annotations.
+        paramOverrides.add("HTMLPrintingArtifactAnnotations");
+        // Disables the Installed App API in Blink.
+        paramOverrides.add("InstalledApp");
+        // Disables the Web Notifications API.
+        paramOverrides.add("Notifications");
+        // Disables Payment Link Detection.
+        paramOverrides.add("PaymentLinkDetection");
+        // Disables the Payment Method Change Event.
+        paramOverrides.add("PaymentMethodChangeEvent");
+        // Disables Periodic Background Sync.
+        paramOverrides.add("PeriodicBackgroundSync");
+        // Disables the Presentation API for second screen experiences.
+        paramOverrides.add("Presentation");
+        // Disables CSS scrollbar-color property.
+        paramOverrides.add("ScrollbarColor");
+        // Disables CSS scrollbar-width property.
+        paramOverrides.add("ScrollbarWidth");
+        // Disables Scroll Top/Left Interop.
+        paramOverrides.add("ScrollTopLeftInterop");
+        // Disables Secure Payment Confirmation Availability API.
+        paramOverrides.add("SecurePaymentConfirmationAvailabilityAPI");
+        // Disables Secure Payment Confirmation Opt Out.
+        paramOverrides.add("SecurePaymentConfirmationOptOut");
+        // Disables the Web Serial API for serial port access.
+        paramOverrides.add("Serial");
+        // Disables the Web App Launch Queue.
+        paramOverrides.add("WebAppLaunchQueue");
+        // Disables the Web Authentication API.
+        paramOverrides.add("WebAuth");
+        // Disables WebGPU Texture Component Swizzle.
+        paramOverrides.add("WebGPUTextureComponentSwizzle");
+        // Disables the Web NFC API.
+        paramOverrides.add("WebNFC");
+        // Disables the WebOTP API in Blink.
+        paramOverrides.add("WebOTP");
+        // Disables the Web Share API.
+        paramOverrides.add("WebShare");
+        // Disables the WebSocket Stream API.
+        paramOverrides.add("WebSocketStream");
+        // Disables the WebUSB API in Blink.
+        paramOverrides.add("WebUSB");
+        // Disables the WebXR API in Blink.
+        paramOverrides.add("WebXR");
+
+        return paramOverrides;
+    }
+
     public static void getFlagOverrides(
         CommandLineOverrideHelperParams params) {
         List<String> cliOverrides =
@@ -139,6 +224,8 @@ public final class CommandLineOverrideHelper {
             getDefaultDisableFeatureOverridesList();
         StringJoiner blinkEnableFeatureOverrides =
             getDefaultBlinkEnableFeatureOverridesList();
+        StringJoiner blinkDisableFeatureOverrides =
+            getDefaultBlinkDisableFeatureOverridesList();
 
         if (params != null) {
             if (params.mShouldSetJNIPrefix) {
@@ -170,6 +257,8 @@ public final class CommandLineOverrideHelper {
                                 disableFeatureOverrides.add(v);
                             } else if (key.equals("--enable-blink-features")) {
                                 blinkEnableFeatureOverrides.add(v);
+                            } else if (key.equals("--disable-blink-features")) {
+                                blinkDisableFeatureOverrides.add(v);
                             } else {
                                 cliOverrides.add(param);
                                 break; // Avoid adding the same param multiple times
@@ -194,5 +283,8 @@ public final class CommandLineOverrideHelper {
         CommandLine.getInstance().appendSwitchesAndArguments(
             new String[]{"--enable-blink-features="
             + blinkEnableFeatureOverrides.toString() });
+        CommandLine.getInstance().appendSwitchesAndArguments(
+            new String[]{"--disable-blink-features="
+            + blinkDisableFeatureOverrides.toString() });
     }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -57,6 +57,20 @@ public class CommandLineOverrideHelperTest {
         String overrides =
             CommandLineOverrideHelper.getDefaultDisableFeatureOverridesList().toString();
         assertThat(overrides.contains("AImageReader")).isTrue();
+        assertThat(overrides.contains("BackForwardCache")).isTrue();
+        assertThat(overrides.contains("DigitalGoodsApi")).isTrue();
+        assertThat(overrides.contains("DrawCutoutEdgeToEdge")).isTrue();
+        assertThat(overrides.contains("FedCm")).isTrue();
+        assertThat(overrides.contains("FedCmAlternativeIdentifiers")).isTrue();
+        assertThat(overrides.contains("FedCmIframeOrigin")).isTrue();
+        assertThat(overrides.contains("InstalledApp")).isTrue();
+        assertThat(overrides.contains("InstalledAppProvider")).isTrue();
+        assertThat(overrides.contains("SecurePaymentConfirmation")).isTrue();
+        assertThat(overrides.contains("WebOTP")).isTrue();
+        assertThat(overrides.contains("WebPayments")).isTrue();
+        assertThat(overrides.contains("WebPermissionsApi")).isTrue();
+        assertThat(overrides.contains("WebUSB")).isTrue();
+        assertThat(overrides.contains("WebXR")).isTrue();
     }
 
     @Test
@@ -65,6 +79,37 @@ public class CommandLineOverrideHelperTest {
             CommandLineOverrideHelper.getDefaultBlinkEnableFeatureOverridesList().toString();
         assertThat(overrides.contains("MediaSourceNewAbortAndDuration")).isTrue();
         assertThat(overrides.contains("PreciseMemoryInfo")).isTrue();
+    }
+
+    @Test
+    public void testDefaultBlinkDisableFeatureOverridesList() {
+        String overrides =
+            CommandLineOverrideHelper.getDefaultBlinkDisableFeatureOverridesList().toString();
+        assertThat(overrides.contains("CSSTypedArithmetic")).isTrue();
+        assertThat(overrides.contains("FedCm")).isTrue();
+        assertThat(overrides.contains("FencedFrames")).isTrue();
+        assertThat(overrides.contains("HTMLPrintingArtifactAnnotations")).isTrue();
+        assertThat(overrides.contains("InstalledApp")).isTrue();
+        assertThat(overrides.contains("Notifications")).isTrue();
+        assertThat(overrides.contains("PaymentLinkDetection")).isTrue();
+        assertThat(overrides.contains("PaymentMethodChangeEvent")).isTrue();
+        assertThat(overrides.contains("PeriodicBackgroundSync")).isTrue();
+        assertThat(overrides.contains("Presentation")).isTrue();
+        assertThat(overrides.contains("ScrollbarColor")).isTrue();
+        assertThat(overrides.contains("ScrollbarWidth")).isTrue();
+        assertThat(overrides.contains("ScrollTopLeftInterop")).isTrue();
+        assertThat(overrides.contains("SecurePaymentConfirmationAvailabilityAPI")).isTrue();
+        assertThat(overrides.contains("SecurePaymentConfirmationOptOut")).isTrue();
+        assertThat(overrides.contains("Serial")).isTrue();
+        assertThat(overrides.contains("WebAppLaunchQueue")).isTrue();
+        assertThat(overrides.contains("WebAuth")).isTrue();
+        assertThat(overrides.contains("WebGPUTextureComponentSwizzle")).isTrue();
+        assertThat(overrides.contains("WebNFC")).isTrue();
+        assertThat(overrides.contains("WebOTP")).isTrue();
+        assertThat(overrides.contains("WebShare")).isTrue();
+        assertThat(overrides.contains("WebSocketStream")).isTrue();
+        assertThat(overrides.contains("WebUSB")).isTrue();
+        assertThat(overrides.contains("WebXR")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
By default disable various Blink and content features that are not
typically used in the Cobalt runtime environment. This reduces
the memory footprint and simplifies the codebase by deactivating
features like BackForwardCache, Web Payments, WebUSB, and WebXR.

Test: `out/android-arm_devel/bin/run_cobalt_coat_junit_tests`
Issue: 453764911