### PR TITLE
Disable plugins, pdf and printing

### DIFF
--- a/cobalt/build/configs/linux_common.gn
+++ b/cobalt/build/configs/linux_common.gn
@@ -113,3 +113,12 @@ icu_use_data_file = false
 
 # Disable the Pepper API (PPAPI) plugin support
 enable_ppapi = false
+
+# Disable plugin support.
+enable_plugins = false
+
+# Disable PDF support.
+enable_pdf = false
+
+# Disable printing support.
+enable_printing = false


### PR DESCRIPTION
Use the gn variables to disable the
plugins, pdf and printing and reduce the
binary size with ~ 16KB on arm.

Issue: 421171908