### PR TITLE
[android] Reject low performance software video decoders

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecUtil.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecUtil.java
@@ -510,7 +510,9 @@ public class MediaCodecUtil {
   /** Return true if and only if info belongs to a software decoder. */
   public static boolean isSoftwareDecoder(MediaCodecInfo codecInfo) {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) {
-      return !codecInfo.isHardwareAccelerated();
+      if (!codecInfo.isHardwareAccelerated() || codecInfo.isSoftwareOnly()) {
+        return true;
+      }
     }
     String name = codecInfo.getName().toLowerCase(Locale.ROOT);
     // This is taken from libstagefright/OMXCodec.cpp for pre codec2.

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -25,6 +25,7 @@
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/log.h"
 #include "starboard/common/once.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/key_system_supportability_cache.h"
 #include "starboard/shared/starboard/media/mime_supportability_cache.h"
 #include "starboard/thread.h"
@@ -560,17 +561,28 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
     if (require_software_codec && !video_capability->is_software_decoder()) {
       continue;
     }
+    // Reject low performance software codec if software codec is not required.
+    const bool reject_low_performance_software_deocder =
+        features::FeatureList::IsEnabled(
+            starboard::features::kRejectLowPerformanceSoftwareDecoder);
+    if (reject_low_performance_software_deocder && !require_software_codec &&
+        video_capability->is_software_decoder()) {
+      const int kMinimumWidth = 1920;
+      const int kMinimumHeight = 1080;
+      if (!video_capability->AreResolutionAndRateSupported(kMinimumWidth,
+                                                           kMinimumHeight, 0)) {
+        continue;
+      }
+    }
     // Reject if hdr is required but codec doesn't support it.
     if (must_support_hdr && !video_capability->is_hdr_capable()) {
       continue;
     }
-
     // Reject if resolution or frame rate is not supported.
     if (!video_capability->AreResolutionAndRateSupported(frame_width,
                                                          frame_height, fps)) {
       continue;
     }
-
     // Reject if bitrate is not supported.
     if (bitrate != 0 && !video_capability->IsBitrateSupported(bitrate)) {
       continue;

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -126,6 +126,14 @@ STARBOARD_FEATURE(kUseStubVideoDecoder, "UseStubVideoDecoder", false)
 // By default, the platform Opus decoder is only enabled for encrypted playback.
 // Set the following variable to true to force it for clear playback.
 STARBOARD_FEATURE(kForcePlatformOpusDecoder, "ForcePlatformOpusDecoder", false)
+
+// By default, software video codec can be selected when software codec is not
+// required. Set the following variable to true to prevent using low performance
+// software video decoder in MediaCapabilitiesCache when software codec is not
+// explicitly required.
+STARBOARD_FEATURE(kRejectLowPerformanceSoftwareDecoder,
+                  "RejectLowPerformanceSoftwareDecoder",
+                  false)
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 FEATURE_LIST_END
 


### PR DESCRIPTION
1. Reject low performance software decoders if software codec is not explicitly required.
2. Update MediaCodecUtil.isSoftwareDecoder() to match latest Chromium implementation.

Bug: 435204402