### PR TITLE
cobalt: Inject memory pressure signals every 60s after startup

### DIFF
--- a/base/trace_event/builtin_categories.h
+++ b/base/trace_event/builtin_categories.h
@@ -98,6 +98,7 @@ PERFETTO_DEFINE_CATEGORIES_IN_NAMESPACE_WITH_ATTRS(
     perfetto::Category("cdp.perf"),
     perfetto::Category("chromeos"),
     perfetto::Category("cma"),
+    //perfetto::Category("cobalt"),
     perfetto::Category("compositor"),
     // Config categories do not emit trace events, but are used to configure
     // enabling additional information at runtime, which then is emitted in

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -24,8 +24,8 @@
 #include "content/public/browser/browser_thread.h"
 
 #if BUILDFLAG(IS_ANDROIDTV)
-#include "base/memory/memory_pressure_listener.h"
 #include "base/android/memory_pressure_listener_android.h"
+#include "base/memory/memory_pressure_listener.h"
 #include "cobalt/browser/android/mojo/cobalt_interface_registrar_android.h"
 #endif
 

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -24,6 +24,7 @@
 #include "content/public/browser/browser_thread.h"
 
 #if BUILDFLAG(IS_ANDROIDTV)
+#include "base/memory/memory_pressure_listener.h"
 #include "base/android/memory_pressure_listener_android.h"
 #include "cobalt/browser/android/mojo/cobalt_interface_registrar_android.h"
 #endif
@@ -38,6 +39,7 @@ namespace cobalt {
 constexpr auto kMemoryPressureInjectionDelay = base::Seconds(60);
 
 namespace {
+#if BUILDFLAG(IS_ANDROIDTV)
 // This function injects a MODERATE memory pressure and rearms itself.
 void InjectMemoryPressureNotification() {
   base::MemoryPressureListener::NotifyMemoryPressure(
@@ -47,6 +49,7 @@ void InjectMemoryPressureNotification() {
       FROM_HERE, base::BindOnce(&InjectMemoryPressureNotification),
       kMemoryPressureInjectionDelay);
 }
+#endif
 }  // namespace
 
 int CobaltBrowserMainParts::PreCreateThreads() {

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -36,10 +36,10 @@
 
 namespace cobalt {
 
-constexpr auto kMemoryPressureInjectionDelay = base::Seconds(60);
-
 namespace {
 #if BUILDFLAG(IS_ANDROIDTV)
+constexpr auto kMemoryPressureInjectionDelay = base::Seconds(60);
+
 // This function injects a MODERATE memory pressure and rearms itself.
 void InjectMemoryPressureNotification() {
   base::MemoryPressureListener::NotifyMemoryPressure(


### PR DESCRIPTION
Verified this work via tracing (with an increased frequency of 1s), 
see e.g. https://screenshot.googleplex.com/4zmqHBzczjBrSEe .