### PR TITLE
Add stdbuf in runfile to work around log lines appearing out of order

### DIFF
--- a/starboard/build/util/generate_runfile.py
+++ b/starboard/build/util/generate_runfile.py
@@ -12,6 +12,7 @@ import subprocess
 import sys
 
 command = [
+    'stdbuf', '-i0', '-o0', '-e0',
     os.path.join(os.path.dirname(__file__), 'elf_loader_sandbox'),
     '--evergreen_content=.', '--evergreen_library={library}.so'
 ] + sys.argv[1:]


### PR DESCRIPTION
There is a bug in gtest starboardization causing output appearing out of order in CI. This is due to output buffering affecting the streams (stdout/err) differently.

Bug: 458084372