### PR TITLE
android: Switch to main shell after splash ends

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -246,7 +246,7 @@ public abstract class CobaltActivity extends Activity {
                     synchronized(lock) {
                       if (isMainFrameLoaded == false) {
                         // Main app loaded in App shell, switch to it.
-                        Log.i(TAG, "main shell is loaded");
+                        Log.i(TAG, "NativeSplash: main shell is loaded with splash screen is finished: " + mShellManager.getSplashAppShell().isDestroyed() + ".");
                         isMainFrameLoaded = true;
                         mShellManager.showAppShell();
                       }
@@ -274,10 +274,21 @@ public abstract class CobaltActivity extends Activity {
                   @Override
                   public void run() {
                     synchronized(lock) {
+                      // If main is loaded, this is no-op due to it is switched
+                      // to main shell.
                       if (isMainFrameLoaded == false) {
-                        Log.i(TAG, "switch to main shell after timeout " + mSplashTimeoutMs + "ms");
-                        isMainFrameLoaded = true;
-                        mShellManager.showAppShell();
+                        if (mShellManager.getSplashAppShell().isDestroyed()) {
+                          // Switch to main shell if splash screen is finished
+                          // (splash screen use window.close() to close
+                          // WebContents and Shell).
+                          Log.i(TAG, "NativeSplash: switch to main shell after " + mSplashTimeoutMs + "ms and video is finished.");
+                          isMainFrameLoaded = true;
+                          mShellManager.showAppShell();
+                        } else {
+                          // Both splash screen and loading main app haven't finished.
+                          // Leave main shell to switch it.
+                          Log.i(TAG, "NativeSplash: splash shell hasn't finished yet after timeout " + mSplashTimeoutMs + "ms.");
+                        }
                       }
                     }
                   }

--- a/cobalt/browser/cobalt_web_contents_observer.cc
+++ b/cobalt/browser/cobalt_web_contents_observer.cc
@@ -81,4 +81,9 @@ enum {
 };
 }  // namespace
 
+void CobaltWebContentsObserver::DidFinishNavigation(
+    content::NavigationHandle* navigation_handle) {
+  LOG(INFO) << "Navigated to: " << navigation_handle->GetURL();
+}
+
 }  // namespace cobalt

--- a/cobalt/browser/cobalt_web_contents_observer.h
+++ b/cobalt/browser/cobalt_web_contents_observer.h
@@ -28,6 +28,9 @@ class CobaltWebContentsObserver : public content::WebContentsObserver {
 
   void PrimaryMainDocumentElementAvailable() override;
 
+  void DidFinishNavigation(
+      content::NavigationHandle* navigation_handle) override;
+
  private:
   void RegisterInjectedJavaScript();
 

--- a/cobalt/shell/embedded_resources/splash.html
+++ b/cobalt/shell/embedded_resources/splash.html
@@ -38,6 +38,7 @@ function animate(onAnimationEnd) {
   videoEl.addEventListener('ended', () => {
     maybeDestroyVideoInstance();
     onAnimationEnd && onAnimationEnd();
+    window.close();
   });
 
   const showPlaceholderImage = () => {
@@ -62,7 +63,7 @@ function playSplashAnimation(afterVideoStart) {
   const mediaSource = new MediaSource();
   mediaSource.addEventListener('sourceopen', () => {
     var binaryData;
-    if (MediaSource.isTypeSupported("video/webm; codecs=\"vp09.00.51.08\"; width=3840; height=2160;")) {
+    if (MediaSource.isTypeSupported("video/webm; codecs=\"vp9\"; width=3840; height=2160;")) {
       // 4k device uses 1080p splash screen.
       binaryData = atob(VIDEO_DATA_STR);
     } else {


### PR DESCRIPTION
Synchronize the transition from the splash screen to the main application
shell. Previously, the main shell could be shown based purely on a
timeout, leading to potential race conditions where the splash screen
had not fully completed or torn down.

This change modifies CobaltActivity to check if the splash app shell has
been destroyed before showing the main shell. The splash.html now
explicitly calls window.close() when its video finishes, allowing the
splash shell to be properly destroyed. A slight delay is added to
the main shell load timer to account for this.

Also updates the MediaSource VP9 codec string in splash.html for
improved capability detection. The default splash timeout in the
AndroidManifest is also adjusted.

Issue: 441738743