### PR TITLE
Cherry pick PR #6461: media: Pass AndroidOverlayMojoFactoryCB to StarboardRenderer

### DIFF
--- a/media/mojo/services/gpu_mojo_media_client.cc
+++ b/media/mojo/services/gpu_mojo_media_client.cc
@@ -122,7 +122,9 @@ StarboardRendererTraits::StarboardRendererTraits(
         renderer_extension_receiver,
     mojo::PendingRemote<mojom::StarboardRendererClientExtension>
         client_extension_remote,
-    GetStarboardCommandBufferStubCB get_starboard_command_buffer_stub_cb)
+    GetStarboardCommandBufferStubCB get_starboard_command_buffer_stub_cb,
+    AndroidOverlayMojoFactoryCB android_overlay_factory_cb
+  )
     : task_runner(std::move(task_runner)),
       gpu_task_runner(std::move(gpu_task_runner)),
       media_log_remote(std::move(media_log_remote)),
@@ -135,7 +137,8 @@ StarboardRendererTraits::StarboardRendererTraits(
       renderer_extension_receiver(std::move(renderer_extension_receiver)),
       client_extension_remote(std::move(client_extension_remote)),
       get_starboard_command_buffer_stub_cb(
-          std::move(get_starboard_command_buffer_stub_cb)) {}
+          std::move(get_starboard_command_buffer_stub_cb)),
+      android_overlay_factory_cb(std::move(android_overlay_factory_cb)) {}
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 GpuMojoMediaClient::GpuMojoMediaClient(
@@ -301,7 +304,8 @@ std::unique_ptr<Renderer> GpuMojoMediaClient::CreateStarboardRenderer(
       config.enable_flush_during_seek, config.enable_reset_audio_decoder,
       std::move(renderer_extension_receiver),
       std::move(client_extension_remote), base::BindRepeating(
-        &GetCommandBufferStub, gpu_task_runner_, media_gpu_channel_manager_));
+        &GetCommandBufferStub, gpu_task_runner_, media_gpu_channel_manager_),
+      android_overlay_factory_cb_);
   return CreatePlatformStarboardRenderer(std::move(traits));
 }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/mojo/services/gpu_mojo_media_client.h
+++ b/media/mojo/services/gpu_mojo_media_client.h
@@ -154,6 +154,9 @@ struct StarboardRendererTraits {
 
   // StarboardRenderer uses this to post tasks on gpu thread.
   GetStarboardCommandBufferStubCB get_starboard_command_buffer_stub_cb;
+  
+  // StarboardRenderer uses this to create an AndroidOverlay.
+  AndroidOverlayMojoFactoryCB android_overlay_factory_cb;
 
   StarboardRendererTraits(
       scoped_refptr<base::SequencedTaskRunner> task_runner,
@@ -170,7 +173,9 @@ struct StarboardRendererTraits {
       mojo::PendingRemote<mojom::StarboardRendererClientExtension>
           client_extension_remote,
       GetStarboardCommandBufferStubCB
-          get_starboard_command_buffer_stub_cb);
+          get_starboard_command_buffer_stub_cb,
+      AndroidOverlayMojoFactoryCB android_overlay_factory_cb
+    );
   StarboardRendererTraits(StarboardRendererTraits&& that) = default;
   ~StarboardRendererTraits();
 };

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -40,7 +40,12 @@ StarboardRendererWrapper::StarboardRendererWrapper(
           traits.audio_write_duration_remote,
           traits.max_video_capabilities,
           traits.enable_flush_during_seek,
-          traits.enable_reset_audio_decoder) {
+          traits.enable_reset_audio_decoder
+#if BUILDFLAG(IS_ANDROID)
+          ,
+          std::move(traits.android_overlay_factory_cb)
+#endif  // BUILDFLAG(IS_ANDROID)
+      ) {
   DETACH_FROM_THREAD(thread_checker_);
   base::SequenceBound<StarboardGpuFactoryImpl> gpu_factory_impl(
       traits.gpu_task_runner,

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -32,6 +32,10 @@
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
 
+#if BUILDFLAG(IS_ANDROID)
+#include "media/base/android_overlay_mojo_factory.h"
+#endif  // BUILDFLAG(IS_ANDROID)
+
 namespace base {
 class TimeDelta;
 }  // namespace base

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -37,6 +37,10 @@
 #include "media/starboard/sbplayer_set_bounds_helper.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
+#if BUILDFLAG(IS_ANDROID)
+#include "media/base/android_overlay_mojo_factory.h"
+#endif  // BUILDFLAG(IS_ANDROID)
+
 namespace media {
 using base::Time;
 using base::TimeDelta;
@@ -55,7 +59,12 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
                     TimeDelta audio_write_duration_remote,
                     const std::string& max_video_capabilities,
                     bool enable_flush_during_seek,
-                    bool enable_reset_audio_decoder);
+                    bool enable_reset_audio_decoder
+#if BUILDFLAG(IS_ANDROID)
+                    ,
+                    const AndroidOverlayMojoFactoryCB android_overlay_factory_cb
+#endif  // BUILDFLAG(IS_ANDROID)
+  );
 
   // Disallow copy and assign.
   StarboardRenderer(const StarboardRenderer&) = delete;
@@ -183,6 +192,9 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   const bool enable_flush_during_seek_;
   const bool enable_reset_audio_decoder_;
   const bool notify_memory_pressure_before_playback_;
+#if BUILDFLAG(IS_ANDROID)
+  const AndroidOverlayMojoFactoryCB android_overlay_factory_cb_;
+#endif  // BUILDFLAG(IS_ANDROID)
 
   raw_ptr<DemuxerStream> audio_stream_ = nullptr;
   raw_ptr<DemuxerStream> video_stream_ = nullptr;

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -183,7 +183,12 @@ class StarboardRendererTest : public testing::Test {
           /*audio_write_duration_remote=*/base::Seconds(1),
           /*max_video_capabilities=*/"",
           /*enable_flush_during_seek=*/false,
-          /*enable_reset_audio_decoder=*/false);
+          /*enable_reset_audio_decoder=*/false
+#if BUILDFLAG(IS_ANDROID)
+          ,
+          /*android_overlay_factory_cb=*/AndroidOverlayMojoFactoryCB()
+#endif  // BUILDFLAG(IS_ANDROID)
+      );
   base::MockOnceCallback<void(bool)> set_cdm_cb_;
   base::MockOnceCallback<void(PipelineStatus)> renderer_init_cb_;
   NiceMock<MockCdmContext> cdm_context_;


### PR DESCRIPTION
Refer to the original PR: https://github.com/youtube/cobalt/pull/6461

Passes `AndroidOverlayMojoFactoryCB` to `StarboardRenderer` from `GpuMojoMediaClient` so that `StarboardRenderer` can create `AndroidOverlay`.

Issue: 429257581
Issue: 460831614