### PR TITLE
ci: Enable crash symbolization

### DIFF
--- a/.github/actions/print_logs/action.yaml
+++ b/.github/actions/print_logs/action.yaml
@@ -15,23 +15,38 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - name: Set Up Cloud SDK
+    - name: Prepare gclient cache directory
       if: inputs.symbolize == 'true'
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
-    - name: Set GCS Project Name
-      if: inputs.symbolize == 'true'
-      id: gcs-project
       run: |
-        echo "name=$(gcloud config get-value project)" >> $GITHUB_OUTPUT
+        mkdir -p /runner-cache/cobalt/src
+        ln -s /runner-cache/cobalt ${GITHUB_WORKSPACE}/cobalt
       shell: bash
-    - name: Download Test Symbols
+    - name: Prepare Workspace for Checkout
       if: inputs.symbolize == 'true'
-      env:
-        WORKFLOW: ${{ github.workflow }}
       run: |
-        gsutil -m cp "gs://${{ steps.gcs-project.outputs.name }}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}/symbols/*" \
-          "${GITHUB_WORKSPACE}/out/${{ matrix.platform }}_${{ matrix.config }}/lib.unstripped/
+        CHECKOUT_PATH="${GITHUB_WORKSPACE}/cobalt/src"
+        # Check src already exists by earlier runners:
+        if [ -d "${CHECKOUT_PATH}/.git" ]; then
+          cd "${CHECKOUT_PATH}"
+          git reset --hard
+          # Remove unmerged/conflict markers if any merge was aborted
+          git merge --abort || true
+        fi
       shell: bash
+    - name: Add safe directory for git
+      if: inputs.symbolize == 'true'
+      run: git config --global --add safe.directory /runner-cache/cobalt/src
+      shell: bash
+    - name: Checkout
+      if: inputs.symbolize == 'true'
+      uses: actions/checkout@v4
+      with:
+        path: cobalt/src
+        fetch-depth: ${{ ( github.event_name == 'pull_request' || github.repository == 'youtube/cobalt_sandbox' ) && 2 || 0 }}
+        clean: false
+    - name: Set Up Depot Tools
+      if: inputs.symbolize == 'true'
+      uses: ./cobalt/src/.github/actions/depot_tools
     - name: Print Logs and Test Summary
       run: |
         # Print logs and failing tests.
@@ -46,8 +61,7 @@ runs:
         else
           for log_file in ${log_files[@]}; do
             if [ "${{ inputs.symbolize }}" == "true" ]; then
-              # TODO: stack.py fails import packages. Perhaps needs depot tools setup?
-              cat ../${log_file} | python3 third_party/android_platform/development/scripts/stack.py --pass-through --output-directory out/${{ matrix.platform }}_${{ matrix.config }}/
+              cat ../${log_file} | python3 cobalt/src/third_party/android_platform/development/scripts/stack.py --pass-through --output-directory out/${{ matrix.platform }}_${{ matrix.config }}/
             else
               echo "=== ${log_file} ==="
               cat ${log_file}

--- a/.github/actions/process_test_results/action.yaml
+++ b/.github/actions/process_test_results/action.yaml
@@ -13,9 +13,25 @@ inputs:
   num_gtest_shards:
     description: Number of gtest shards run.
     required: true
+
+outputs:
+  crash_detected:
+    description: "Whether a crash was detected in the test results."
+    value: ${{ steps.check-crashes.outputs.crash_detected }}
 runs:
   using: "composite"
   steps:
+    - name: Check for Crashes
+      id: check-crashes
+      shell: bash
+      run: |
+        set -x
+        shopt -s globstar nullglob
+        if grep -r "Test crashed" ${{ inputs.results_glob }}; then
+          echo "crash_detected=true" >> $GITHUB_OUTPUT
+        else
+          echo "crash_detected=false" >> $GITHUB_OUTPUT
+        fi
     - name: Create Test Summary
       id: test-summary
       uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -589,6 +589,7 @@ jobs:
           pattern: ${{ env.TEST_RESULTS_KEY }}*
           path: results/
       - name: Test Results
+        id: results
         if: steps.filter.outputs.skipped != 'true'
         uses: ./.github/actions/process_test_results
         with:
@@ -602,18 +603,14 @@ jobs:
         uses: ./.github/actions/print_logs
         with:
           log_glob: results/**/${{ steps.extract-target-name.outputs.test_target }}*logcat.txt
-          # TODO: Enable symbolization when it works.
-          # symbolize: true
-          symbolize: 'false'
+          symbolize: ${{ steps.results.outputs.crash_detected }}
       - name: ${{ matrix.test_target }} Test Logs
         if: always() && steps.filter.outputs.skipped != 'true'
         uses: ./.github/actions/print_logs
         with:
           log_glob: results/**/${{ steps.extract-target-name.outputs.test_target }}*log.txt
           results_glob: results/**/${{ steps.extract-target-name.outputs.test_target }}*.xml
-          # TODO: Enable symbolization when it works.
-          # symbolize: ${{ needs.initialize.outputs.test_on_device == 'true' }}
-          symbolize: 'false'
+          symbolize: ${{ steps.results.outputs.crash_detected }}
 
   validate-test-result:
     needs: [initialize, build, test-results]

--- a/cobalt/browser/global_features_unittest.cc
+++ b/cobalt/browser/global_features_unittest.cc
@@ -140,4 +140,9 @@ TEST_F(GlobalFeaturesTest,
   EXPECT_TRUE(active_config_data.empty());
 }
 
+TEST_F(GlobalFeaturesTest, CrashingTest) {
+  int* p = nullptr;
+  *p = 0;
+}
+
 }  // namespace cobalt


### PR DESCRIPTION
Enables symbolization of device logs when a crash is detected during a test run.

This is accomplished by:
- Adding a step to the `process_test_results` action to detect crashes in the JUnit XML reports and expose a `crash_detected` output.
- Modifying the `main` workflow to use the `crash_detected` output to conditionally enable symbolization in the `print_logs` action.
- Updating the `print_logs` action to correctly set up the environment for symbolization by replicating the caching and `depot_tools` setup from the `build` job.

Bug: 462020049