### PR TITLE
android: Cancel deferred shell callbacks

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -24,6 +24,7 @@ import android.content.pm.PackageManager.NameNotFoundException;
 import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
+import android.os.Handler;
 import android.os.SystemClock;
 import android.text.TextUtils;
 import android.view.KeyEvent;
@@ -110,6 +111,8 @@ public abstract class CobaltActivity extends Activity {
 
   private Boolean isMainFrameLoaded = false;
   private final Object lock = new Object();
+  private Handler mShowAppShellHandler;
+  private Runnable mShowAppShellRunnable;
 
   // Initially copied from ContentShellActiviy.java
   protected void createContent(final Bundle savedInstanceState) {
@@ -246,11 +249,19 @@ public abstract class CobaltActivity extends Activity {
 
           @Override
           public void onWebContentsLoaded() {
-            new android.os.Handler(android.os.Looper.getMainLooper())
-                .postDelayed(
-                    new Runnable() {
+            if (mShowAppShellHandler == null) {
+              mShowAppShellHandler = new android.os.Handler(android.os.Looper.getMainLooper());
+            }
+            if (mShowAppShellRunnable != null) {
+              mShowAppShellHandler.removeCallbacks(mShowAppShellRunnable);
+            }
+            mShowAppShellRunnable = new Runnable() {
                       @Override
                       public void run() {
+                        if (isFinishing() || isDestroyed()) {
+                          Log.w(TAG, "NativeSplash: activity is finishing or destroyed, skipping showAppShell.");
+                          return;
+                        }
                         synchronized (lock) {
                           if (isMainFrameLoaded == false) {
                             // Main app loaded in App shell, switch to it.
@@ -260,8 +271,8 @@ public abstract class CobaltActivity extends Activity {
                           }
                         }
                       }
-                    },
-                    mSplashTimeoutMs);
+                    };
+            mShowAppShellHandler.postDelayed(mShowAppShellRunnable, mSplashTimeoutMs);
           }
         });
     if (mDisableNativeSplash) {
@@ -604,6 +615,9 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   protected void onDestroy() {
+    if (mShowAppShellHandler != null && mShowAppShellRunnable != null) {
+      mShowAppShellHandler.removeCallbacks(mShowAppShellRunnable);
+    }
     if (cobaltConnectivityDetector != null) {
       cobaltConnectivityDetector.destroy();
     }


### PR DESCRIPTION
When CobaltActivity is destroyed, ensure that any pending callbacks
to show the app shell are cancelled. This prevents potential issues
like attempting UI operations on a destroyed activity. A defensive
check is also added within the callback to explicitly guard against
execution if the activity is already finishing or destroyed.

Issue: 459802298 
Issue: 441738743