### PR TITLE
build: Add linux-no-starboard packaging config

### DIFF
--- a/cobalt/build/linux-no-starboard/package.json
+++ b/cobalt/build/linux-no-starboard/package.json
@@ -1,0 +1,10 @@
+{
+    "archive_datas": [
+        {
+            "files": [
+                "chromedriver"
+            ],
+            "archive_type": "ARCHIVE_TYPE_FILES"
+        }
+    ]
+}

--- a/cobalt/devinfra/kokoro/bin/common.sh
+++ b/cobalt/devinfra/kokoro/bin/common.sh
@@ -186,11 +186,7 @@ run_package_release_pipeline () {
     # Create release package
     export PYTHONPATH="${WORKSPACE_COBALT}"
 
-    # IMPORTANT: chromedriver must be built without starboardizations. We ensure
-    # that the biary is built with the linux-x64x11-no-starboard config in a
-    # previous build step. Then copy the file into this out directory to
-    # simulate having built it in-situ (even though that's not possible). This
-    # simplifies the execution of the packaging scripts.
+    # TODO(b/467385779): Remove this once Forge is configured to use new artifacts.
     if [[ "${TARGET_PLATFORM}" =~ "linux" ]]; then
       local src_platform="linux-x64x11-no-starboard"
       local src_out="${WORKSPACE_COBALT}/out/${src_platform}_${CONFIG}"

--- a/cobalt/devinfra/kokoro/build/linux/no-starboard/common.gcl
+++ b/cobalt/devinfra/kokoro/build/linux/no-starboard/common.gcl
@@ -1,0 +1,31 @@
+// -*- protobuffer -*-
+// proto-file: google3/devtools/kokoro/config/proto/build.proto
+// proto-message: BuildConfig
+
+import '../../common.gcl' as common
+
+build = common.build {
+  build_file = 'src/cobalt/devinfra/kokoro/bin/dind_runner.sh'
+  env_vars = super.env_vars + [
+    {
+      key = 'PACKAGE_PLATFORM'
+      value = 'linux-no-starboard'
+    },
+    {
+      key = 'PLATFORM'
+      value = 'linux-x64x11-no-starboard'
+    },
+    {
+      key = 'GN_TARGET'
+      value = 'chromedriver'
+    },
+    {
+      key = 'TARGET_PLATFORM'
+      value = 'linux-x64x11-no-starboard'
+    },
+    {
+      key = 'REGISTRY_IMAGE_NAME'
+      value = 'cobalt-build-linux'
+    },
+  ]
+}

--- a/cobalt/devinfra/kokoro/build/linux/no-starboard/qa.gcl
+++ b/cobalt/devinfra/kokoro/build/linux/no-starboard/qa.gcl
@@ -1,0 +1,16 @@
+// -*- protobuffer -*-
+// proto-file: google3/devtools/kokoro/config/proto/build.proto
+// proto-message: BuildConfig
+// validation: gcl --message=kokoro.BuildConfig --objtype=config group2.gcl appendascii
+
+import 'common.gcl' as common
+
+config build = common.build {
+  build_file = 'src/cobalt/devinfra/kokoro/bin/dind_builder_runner.sh'
+  env_vars = super.env_vars + [
+    {
+      key = 'CONFIG'
+      value = 'qa'
+    },
+  ]
+}


### PR DESCRIPTION
Add package.json and Kokoro GCL configurations for the
linux-no-starboard platform. Update common.sh to with TODO to remove
custom code once downstream consumers of the chromedriver artifact has been updated.

Bug: 467385779