### PR TITLE
BACKPORT: [media] Convert std::unique_ptr<T[]> to HeapArray<T> in media/formats/*

### DIFF
--- a/media/filters/chunk_demuxer.h
+++ b/media/filters/chunk_demuxer.h
@@ -352,6 +352,7 @@ class MEDIA_EXPORT ChunkDemuxer : public Demuxer {
   // per the MSE specification. App could use a back-off and retry strategy or
   // otherwise alter their behavior to attempt to buffer media for further
   // playback.
+  // TODO(b/341763066): use base::span instead of a ptr+size.
   [[nodiscard]] bool AppendToParseBuffer(const std::string& id,
                                          const uint8_t* data,
                                          size_t length);

--- a/media/formats/webm/cluster_builder.cc
+++ b/media/formats/webm/cluster_builder.cc
@@ -62,8 +62,8 @@ enum {
   kInitialBufferSize = 32768,
 };
 
-Cluster::Cluster(std::unique_ptr<uint8_t[]> data, int size)
-    : data_(std::move(data)), size_(size) {}
+Cluster::Cluster(base::HeapArray<uint8_t> data, int bytes_used)
+    : data_(std::move(data)), bytes_used_(bytes_used) {}
 Cluster::~Cluster() = default;
 
 ClusterBuilder::ClusterBuilder() { Reset(); }
@@ -75,7 +75,7 @@ void ClusterBuilder::SetClusterTimecode(int64_t cluster_timecode) {
   cluster_timecode_ = cluster_timecode;
 
   // Write the timecode into the header.
-  uint8_t* buf = buffer_.get() + kClusterTimecodeOffset;
+  uint8_t* buf = buffer_.data() + kClusterTimecodeOffset;
   for (int i = 7; i >= 0; --i) {
     buf[i] = cluster_timecode & 0xff;
     cluster_timecode >>= 8;
@@ -88,11 +88,12 @@ void ClusterBuilder::AddSimpleBlock(int track_num,
                                     const uint8_t* data,
                                     int size) {
   int block_size = size + 4;
-  int bytes_needed = sizeof(kSimpleBlockHeader) + block_size;
-  if (bytes_needed > (buffer_size_ - bytes_used_))
+  size_t bytes_needed = sizeof(kSimpleBlockHeader) + block_size;
+  if (bytes_needed > (buffer_.size() - bytes_used_)) {
     ExtendBuffer(bytes_needed);
+  }
 
-  uint8_t* buf = buffer_.get() + bytes_used_;
+  uint8_t* buf = buffer_.data() + bytes_used_;
   int block_offset = bytes_used_;
   memcpy(buf, kSimpleBlockHeader, sizeof(kSimpleBlockHeader));
   UpdateUInt64(block_offset + kSimpleBlockSizeOffset, block_size);
@@ -133,7 +134,7 @@ void ClusterBuilder::AddBlockGroupInternal(int track_num,
                                            const uint8_t* data,
                                            int size) {
   int block_size = size + 4;
-  int bytes_needed = block_size;
+  size_t bytes_needed = block_size;
   if (include_block_duration) {
     bytes_needed += sizeof(kBlockGroupHeader);
   } else {
@@ -145,10 +146,11 @@ void ClusterBuilder::AddBlockGroupInternal(int track_num,
 
   int block_group_size = bytes_needed - 9;
 
-  if (bytes_needed > (buffer_size_ - bytes_used_))
+  if (bytes_needed > (buffer_.size() - bytes_used_)) {
     ExtendBuffer(bytes_needed);
+  }
 
-  uint8_t* buf = buffer_.get() + bytes_used_;
+  uint8_t* buf = buffer_.data() + bytes_used_;
   int block_group_offset = bytes_used_;
   if (include_block_duration) {
     memcpy(buf, kBlockGroupHeader, sizeof(kBlockGroupHeader));
@@ -226,29 +228,27 @@ std::unique_ptr<Cluster> ClusterBuilder::FinishWithUnknownSize() {
 }
 
 void ClusterBuilder::Reset() {
-  buffer_size_ = kInitialBufferSize;
-  buffer_.reset(new uint8_t[buffer_size_]);
-  memcpy(buffer_.get(), kClusterHeader, sizeof(kClusterHeader));
+  buffer_ = base::HeapArray<uint8_t>::Uninit(kInitialBufferSize);
+  memcpy(buffer_.data(), kClusterHeader, sizeof(kClusterHeader));
   bytes_used_ = sizeof(kClusterHeader);
   cluster_timecode_ = -1;
 }
 
-void ClusterBuilder::ExtendBuffer(int bytes_needed) {
-  int new_buffer_size = 2 * buffer_size_;
+void ClusterBuilder::ExtendBuffer(size_t bytes_needed) {
+  size_t new_buffer_size = 2 * buffer_.size();
 
   while ((new_buffer_size - bytes_used_) < bytes_needed)
     new_buffer_size *= 2;
 
-  std::unique_ptr<uint8_t[]> new_buffer(new uint8_t[new_buffer_size]);
+  auto new_buffer = base::HeapArray<uint8_t>::Uninit(new_buffer_size);
 
-  memcpy(new_buffer.get(), buffer_.get(), bytes_used_);
+  memcpy(new_buffer.data(), buffer_.data(), bytes_used_);
   buffer_ = std::move(new_buffer);
-  buffer_size_ = new_buffer_size;
 }
 
 void ClusterBuilder::UpdateUInt64(int offset, int64_t value) {
-  DCHECK_LE(offset + 7, buffer_size_);
-  uint8_t* buf = buffer_.get() + offset;
+  DCHECK_LE(offset + 7u, buffer_.size());
+  uint8_t* buf = buffer_.data() + offset;
 
   // Fill the last 7 bytes of size field in big-endian order.
   for (int i = 7; i > 0; i--) {

--- a/media/formats/webm/cluster_builder.h
+++ b/media/formats/webm/cluster_builder.h
@@ -9,25 +9,29 @@
 
 #include <memory>
 
+#include "base/containers/heap_array.h"
+
 namespace media {
 
 class Cluster {
  public:
   Cluster() = delete;
 
-  Cluster(std::unique_ptr<uint8_t[]> data, int size);
+  // The size of the `bytes_used` might be less size of `data`.
+  Cluster(base::HeapArray<uint8_t> data, int bytes_used);
 
   Cluster(const Cluster&) = delete;
   Cluster& operator=(const Cluster&) = delete;
 
   ~Cluster();
 
-  const uint8_t* data() const { return data_.get(); }
-  int size() const { return size_; }
+  // TODO(frs): This should be changed to return a span.
+  const uint8_t* data() const { return data_.data(); }
+  int bytes_used() const { return bytes_used_; }
 
  private:
-  std::unique_ptr<uint8_t[]> data_;
-  int size_;
+  base::HeapArray<uint8_t> data_;
+  const int bytes_used_;
 };
 
 class ClusterBuilder {
@@ -72,7 +76,7 @@ class ClusterBuilder {
                              const uint8_t* data,
                              int size);
   void Reset();
-  void ExtendBuffer(int bytes_needed);
+  void ExtendBuffer(size_t bytes_needed);
   void UpdateUInt64(int offset, int64_t value);
   void WriteBlock(uint8_t* buf,
                   int track_num,
@@ -81,9 +85,8 @@ class ClusterBuilder {
                   const uint8_t* data,
                   int size);
 
-  std::unique_ptr<uint8_t[]> buffer_;
-  int buffer_size_;
-  int bytes_used_;
+  base::HeapArray<uint8_t> buffer_;
+  size_t bytes_used_;
   int64_t cluster_timecode_;
 };
 

--- a/media/formats/webm/webm_cluster_parser_unittest.cc
+++ b/media/formats/webm/webm_cluster_parser_unittest.cc
@@ -439,16 +439,17 @@ TEST_F(WebMClusterParserTest, HeldBackBufferHoldsBackAllTracks) {
           WebMSimpleBlockDurationEstimated(kExpectedVideoEstimationInMs));
     }
 
-    int result = parser_->Parse(cluster->data(), parse_full_cluster ?
-                                cluster->size() : cluster->size() - 1);
+    int result = parser_->Parse(
+        cluster->data(),
+        parse_full_cluster ? cluster->bytes_used() : cluster->bytes_used() - 1);
     if (parse_full_cluster) {
       DVLOG(1) << "Verifying parse result of full cluster of "
                << blocks_in_cluster << " blocks";
-      EXPECT_EQ(cluster->size(), result);
+      EXPECT_EQ(cluster->bytes_used(), result);
     } else {
       DVLOG(1) << "Verifying parse result of cluster of "
                << blocks_in_cluster << " blocks with last block incomplete";
-      EXPECT_GT(cluster->size(), result);
+      EXPECT_GT(cluster->bytes_used(), result);
       EXPECT_LT(0, result);
     }
 
@@ -466,16 +467,16 @@ TEST_F(WebMClusterParserTest, Reset) {
 
   // Send slightly less than the full cluster so all but the last block is
   // parsed.
-  int result = parser_->Parse(cluster->data(), cluster->size() - 1);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used() - 1);
   EXPECT_GT(result, 0);
-  EXPECT_LT(result, cluster->size());
+  EXPECT_LT(result, cluster->bytes_used());
 
   ASSERT_TRUE(VerifyBuffers(parser_, kDefaultBlockInfo, block_count - 1));
   parser_->Reset();
 
   // Now parse a whole cluster to verify that all the blocks will get parsed.
-  result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kDefaultBlockInfo, block_count));
 }
 
@@ -484,8 +485,8 @@ TEST_F(WebMClusterParserTest, ParseClusterWithSingleCall) {
   std::unique_ptr<Cluster> cluster(
       CreateCluster(0, kDefaultBlockInfo, block_count));
 
-  int result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kDefaultBlockInfo, block_count));
 }
 
@@ -495,7 +496,7 @@ TEST_F(WebMClusterParserTest, ParseClusterWithMultipleCalls) {
       CreateCluster(0, kDefaultBlockInfo, block_count));
 
   const uint8_t* data = cluster->data();
-  int size = cluster->size();
+  int size = cluster->bytes_used();
   int default_parse_size = 3;
   int parse_size = std::min(default_parse_size, size);
 
@@ -568,8 +569,8 @@ TEST_F(WebMClusterParserTest, ParseSimpleBlockAndBlockGroupMixture) {
   int block_count = std::size(kBlockInfo);
   std::unique_ptr<Cluster> cluster(CreateCluster(0, kBlockInfo, block_count));
 
-  int result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));
 }
 
@@ -603,8 +604,8 @@ TEST_F(WebMClusterParserTest, IgnoredTracks) {
 
   EXPECT_MEDIA_LOG(WebMSimpleBlockDurationEstimated(23));
   EXPECT_MEDIA_LOG(WebMSimpleBlockDurationEstimated(34));
-  int result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kOutputBlockInfo, output_block_count));
 }
 
@@ -720,8 +721,8 @@ TEST_F(WebMClusterParserTest, ParseEncryptedBlock) {
   EXPECT_MEDIA_LOG(WebMSimpleBlockDurationEstimated(
       WebMClusterParser::kDefaultVideoBufferDurationInMs));
 
-  int result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   StreamParser::BufferQueueMap buffers;
   parser_->GetBuffers(&buffers);
   EXPECT_EQ(1UL, buffers[kVideoTrackNum].size());
@@ -737,7 +738,7 @@ TEST_F(WebMClusterParserTest, ParseBadEncryptedBlock) {
       std::string(), "video_key_id", AudioCodec::kUnknown));
 
   EXPECT_MEDIA_LOG(HasSubstr("Failed to extract decrypt config"));
-  int result = parser_->Parse(cluster->data(), cluster->size());
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used());
   EXPECT_EQ(-1, result);
 }
 
@@ -809,16 +810,16 @@ TEST_F(WebMClusterParserTest, ParseWithDefaultDurationsSimpleBlocks) {
   // parsed. Though all the blocks are simple blocks, none should be held aside
   // for duration estimation prior to end of cluster detection because all the
   // tracks have DefaultDurations.
-  int result = parser_->Parse(cluster->data(), cluster->size() - 1);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used() - 1);
   EXPECT_GT(result, 0);
-  EXPECT_LT(result, cluster->size());
+  EXPECT_LT(result, cluster->bytes_used());
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count - 1));
 
   parser_->Reset();
 
   // Now parse a whole cluster to verify that all the blocks will get parsed.
-  result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));
 }
 
@@ -851,9 +852,9 @@ TEST_F(WebMClusterParserTest, ParseWithoutAnyDurationsSimpleBlocks) {
   // both missing from the result (parser should hold them aside for duration
   // estimation prior to end of cluster detection in the absence of
   // DefaultDurations.)
-  int result = parser_->Parse(cluster1->data(), cluster1->size() - 1);
+  int result = parser_->Parse(cluster1->data(), cluster1->bytes_used() - 1);
   EXPECT_GT(result, 0);
-  EXPECT_LT(result, cluster1->size());
+  EXPECT_LT(result, cluster1->bytes_used());
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo1, block_count1 - 3));
   StreamParser::BufferQueueMap buffers;
   parser_->GetBuffers(&buffers);
@@ -867,8 +868,8 @@ TEST_F(WebMClusterParserTest, ParseWithoutAnyDurationsSimpleBlocks) {
       WebMSimpleBlockDurationEstimated(kExpectedAudioEstimationInMs));
   EXPECT_MEDIA_LOG(
       WebMSimpleBlockDurationEstimated(kExpectedVideoEstimationInMs));
-  result = parser_->Parse(cluster1->data(), cluster1->size());
-  EXPECT_EQ(cluster1->size(), result);
+  result = parser_->Parse(cluster1->data(), cluster1->bytes_used());
+  EXPECT_EQ(cluster1->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo1, block_count1));
 
   // Verify that the estimated frame duration is tracked across clusters for
@@ -887,8 +888,8 @@ TEST_F(WebMClusterParserTest, ParseWithoutAnyDurationsSimpleBlocks) {
       WebMSimpleBlockDurationEstimated(kExpectedAudioEstimationInMs));
   EXPECT_MEDIA_LOG(
       WebMSimpleBlockDurationEstimated(kExpectedVideoEstimationInMs));
-  result = parser_->Parse(cluster2->data(), cluster2->size());
-  EXPECT_EQ(cluster2->size(), result);
+  result = parser_->Parse(cluster2->data(), cluster2->bytes_used());
+  EXPECT_EQ(cluster2->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo2, block_count2));
 }
 
@@ -923,9 +924,9 @@ TEST_F(WebMClusterParserTest, ParseWithoutAnyDurationsBlockGroups) {
   // both missing from the result (parser should hold them aside for duration
   // estimation prior to end of cluster detection in the absence of
   // DefaultDurations.)
-  int result = parser_->Parse(cluster1->data(), cluster1->size() - 1);
+  int result = parser_->Parse(cluster1->data(), cluster1->bytes_used() - 1);
   EXPECT_GT(result, 0);
-  EXPECT_LT(result, cluster1->size());
+  EXPECT_LT(result, cluster1->bytes_used());
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo1, block_count1 - 3));
   StreamParser::BufferQueueMap buffers;
   parser_->GetBuffers(&buffers);
@@ -939,8 +940,8 @@ TEST_F(WebMClusterParserTest, ParseWithoutAnyDurationsBlockGroups) {
       WebMSimpleBlockDurationEstimated(kExpectedAudioEstimationInMs));
   EXPECT_MEDIA_LOG(
       WebMSimpleBlockDurationEstimated(kExpectedVideoEstimationInMs));
-  result = parser_->Parse(cluster1->data(), cluster1->size());
-  EXPECT_EQ(cluster1->size(), result);
+  result = parser_->Parse(cluster1->data(), cluster1->bytes_used());
+  EXPECT_EQ(cluster1->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo1, block_count1));
 
   // Verify that the estimated frame duration is tracked across clusters for
@@ -959,8 +960,8 @@ TEST_F(WebMClusterParserTest, ParseWithoutAnyDurationsBlockGroups) {
       WebMSimpleBlockDurationEstimated(kExpectedAudioEstimationInMs));
   EXPECT_MEDIA_LOG(
       WebMSimpleBlockDurationEstimated(kExpectedVideoEstimationInMs));
-  result = parser_->Parse(cluster2->data(), cluster2->size());
-  EXPECT_EQ(cluster2->size(), result);
+  result = parser_->Parse(cluster2->data(), cluster2->bytes_used());
+  EXPECT_EQ(cluster2->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo2, block_count2));
 }
 
@@ -996,16 +997,16 @@ TEST_F(WebMClusterParserTest,
   // Send slightly less than the full cluster so all but the last block is
   // parsed. None should be held aside for duration estimation prior to end of
   // cluster detection because all the tracks have DefaultDurations.
-  int result = parser_->Parse(cluster->data(), cluster->size() - 1);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used() - 1);
   EXPECT_GT(result, 0);
-  EXPECT_LT(result, cluster->size());
+  EXPECT_LT(result, cluster->bytes_used());
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count - 1));
 
   parser_->Reset();
 
   // Now parse a whole cluster to verify that all the blocks will get parsed.
-  result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));
 }
 
@@ -1034,16 +1035,16 @@ TEST_F(WebMClusterParserTest,
   // Send slightly less than the full cluster so all but the last block is
   // parsed. None should be held aside for duration estimation prior to end of
   // cluster detection because all blocks have BlockDurations.
-  int result = parser_->Parse(cluster->data(), cluster->size() - 1);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used() - 1);
   EXPECT_GT(result, 0);
-  EXPECT_LT(result, cluster->size());
+  EXPECT_LT(result, cluster->bytes_used());
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count - 1));
 
   parser_->Reset();
 
   // Now parse a whole cluster to verify that all the blocks will get parsed.
-  result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));
 }
 
@@ -1079,9 +1080,9 @@ TEST_F(WebMClusterParserTest,
   // the second video is held back still (not yet at end of cluster) and the
   // first audio is held back still (no second block parsed fully yet and not
   // yet at end of cluster).
-  int result = parser_->Parse(cluster->data(), cluster->size() - 1);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used() - 1);
   EXPECT_GT(result, 0);
-  EXPECT_LT(result, cluster->size());
+  EXPECT_LT(result, cluster->bytes_used());
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count - 3));
 
   parser_->Reset();
@@ -1092,8 +1093,8 @@ TEST_F(WebMClusterParserTest,
   // the cluster, hence the expected order of MEDIA_LOGs here.
   EXPECT_MEDIA_LOG(WebMSimpleBlockDurationEstimated(23));
   EXPECT_MEDIA_LOG(WebMSimpleBlockDurationEstimated(33));
-  result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));
 }
 
@@ -1119,8 +1120,8 @@ TEST_F(WebMClusterParserTest,
       WebMClusterParser::kDefaultAudioBufferDurationInMs));
   EXPECT_MEDIA_LOG(WebMSimpleBlockDurationEstimated(
       WebMClusterParser::kDefaultVideoBufferDurationInMs));
-  int result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));
 }
 
@@ -1135,8 +1136,8 @@ TEST_F(WebMClusterParserTest,
 
   int block_count = std::size(kBlockInfo);
   std::unique_ptr<Cluster> cluster(CreateCluster(0, kBlockInfo, block_count));
-  int result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));
 }
 
@@ -1163,8 +1164,8 @@ TEST_F(WebMClusterParserTest, ReadOpusDurationsSimpleBlockAtEndOfCluster) {
       EXPECT_MEDIA_LOG(OpusPacketDurationTooHigh(duration_ms));
     }
 
-    int result = parser_->Parse(cluster->data(), cluster->size());
-    EXPECT_EQ(cluster->size(), result);
+    int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+    EXPECT_EQ(cluster->bytes_used(), result);
     ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));
 
     // Fail early if any iteration fails to meet the logging expectations.
@@ -1205,8 +1206,8 @@ TEST_F(WebMClusterParserTest, PreferOpusDurationsOverBlockDurations) {
     int block_count = std::size(block_infos);
     std::unique_ptr<Cluster> cluster(
         CreateCluster(0, block_infos, block_count));
-    int result = parser_->Parse(cluster->data(), cluster->size());
-    EXPECT_EQ(cluster->size(), result);
+    int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+    EXPECT_EQ(cluster->bytes_used(), result);
 
     // BlockInfo duration will be used to verify buffer duration, so changing
     // duration to be that of the Opus packet to verify it was preferred.
@@ -1244,8 +1245,8 @@ TEST_F(WebMClusterParserTest, DontReadEncodedDurationWhenEncrypted) {
 
   int block_count = std::size(kBlockInfo);
   std::unique_ptr<Cluster> cluster(CreateCluster(0, kBlockInfo, block_count));
-  int result = parser_->Parse(cluster->data(), cluster->size());
-  EXPECT_EQ(cluster->size(), result);
+  int result = parser_->Parse(cluster->data(), cluster->bytes_used());
+  EXPECT_EQ(cluster->bytes_used(), result);
 
   // Will verify that duration of buffer matches that of BlockDuration.
   ASSERT_TRUE(VerifyBuffers(parser_, kBlockInfo, block_count));

--- a/media/formats/webm/webm_parser_unittest.cc
+++ b/media/formats/webm/webm_parser_unittest.cc
@@ -227,7 +227,8 @@ TEST_F(WebMParserTest, ParseListElementWithSingleCall) {
   CreateClusterExpectations(kBlockCount, true, &client_);
 
   WebMListParser parser(kWebMIdCluster, &client_);
-  EXPECT_EQ(cluster->size(), parser.Parse(cluster->data(), cluster->size()));
+  EXPECT_EQ(cluster->bytes_used(),
+            parser.Parse(cluster->data(), cluster->bytes_used()));
   EXPECT_TRUE(parser.IsParsingComplete());
 }
 
@@ -236,7 +237,7 @@ TEST_F(WebMParserTest, ParseListElementWithMultipleCalls) {
   CreateClusterExpectations(kBlockCount, true, &client_);
 
   const uint8_t* data = cluster->data();
-  int size = cluster->size();
+  int size = cluster->bytes_used();
   int default_parse_size = 3;
   WebMListParser parser(kWebMIdCluster, &client_);
   int parse_size = std::min(default_parse_size, size);
@@ -278,15 +279,16 @@ TEST_F(WebMParserTest, Reset) {
 
   // Send slightly less than the full cluster so all but the last block is
   // parsed.
-  int result = parser.Parse(cluster->data(), cluster->size() - 1);
+  int result = parser.Parse(cluster->data(), cluster->bytes_used() - 1);
   EXPECT_GT(result, 0);
-  EXPECT_LT(result, cluster->size());
+  EXPECT_LT(result, cluster->bytes_used());
   EXPECT_FALSE(parser.IsParsingComplete());
 
   parser.Reset();
 
   // Now parse a whole cluster to verify that all the blocks will get parsed.
-  EXPECT_EQ(cluster->size(), parser.Parse(cluster->data(), cluster->size()));
+  EXPECT_EQ(cluster->bytes_used(),
+            parser.Parse(cluster->data(), cluster->bytes_used()));
   EXPECT_TRUE(parser.IsParsingComplete());
 }
 


### PR DESCRIPTION
This CL backports https://chromium-review.googlesource.com/c/chromium/src/+/5548554 for spanify (Web)SourceBuffer and chunk demuxer. This is needed to address native crash at media::WebMStreamParser::AppendToParseBuffer().

Issue: 437916038

---
Original commit description:

See
https://docs.google.com/document/d/1YsPR8GoN8VTP1ABKCISaQkuBif1Cn80cTxTjsM8QT4s for an explanation on why this is favorable.

(cherry picked from commit f97ba34b9a48dd2ed1aa93cc8b817b29dffdb48d)

Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5548554