### PR TITLE
Clean up use of android.util.Log in //cobalt.

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java
@@ -17,7 +17,6 @@ import android.graphics.Rect;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
-import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
@@ -27,6 +26,7 @@ import androidx.customview.widget.ExploreByTouchHelper;
 import java.lang.ref.WeakReference;
 import java.util.BitSet;
 import java.util.List;
+import org.chromium.base.Log;
 import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.base.ViewAndroidDelegate;
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java
@@ -7,8 +7,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.SystemClock;
-import android.util.Log;
 import android.view.KeyEvent;
+import org.chromium.base.Log;
 import org.chromium.content.browser.input.ImeAdapterImpl;
 import org.chromium.content_public.browser.WebContents;
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/javabridge/AmatiDeviceInspector.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/javabridge/AmatiDeviceInspector.java
@@ -17,7 +17,7 @@ package dev.cobalt.coat.javabridge;
 import static dev.cobalt.util.Log.TAG;
 
 import android.content.Context;
-import android.util.Log;
+import org.chromium.base.Log;
 
 /**
  * A simple example to implement CobaltJavaScriptAndroidObject.

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
@@ -32,7 +32,6 @@ import android.os.Build;
 import android.util.Base64;
 import androidx.annotation.RequiresApi;
 import dev.cobalt.coat.CobaltHttpHelper;
-import dev.cobalt.util.Log;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -40,6 +39,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
+import org.chromium.base.Log;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
@@ -124,11 +124,11 @@ public class MediaDrmBridge {
     }
 
     public static OperationResult operationFailed(String errorMessage, Throwable e) {
-      return operationFailed(String.format("%s StackTrace: %s", errorMessage, android.util.Log.getStackTraceString(e)));
+      return operationFailed(String.format("%s StackTrace: %s", errorMessage, Log.getStackTraceString(e)));
     }
 
     public static OperationResult notProvisioned(Throwable e) {
-      return new OperationResult(DrmOperationStatus.NOT_PROVISIONED, String.format("Device is not provisioned. StackTrace: %s", android.util.Log.getStackTraceString(e)));
+      return new OperationResult(DrmOperationStatus.NOT_PROVISIONED, String.format("Device is not provisioned. StackTrace: %s", Log.getStackTraceString(e)));
     }
 
     @CalledByNative("OperationResult")

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
@@ -41,19 +41,19 @@ public final class Log {
   private static void initLogging() {
     try {
       sLogV =
-          android.util.Log.class.getDeclaredMethod(
+          org.chromium.base.Log.class.getDeclaredMethod(
               "v", String.class, String.class, Throwable.class);
       sLogD =
-          android.util.Log.class.getDeclaredMethod(
+          org.chromium.base.Log.class.getDeclaredMethod(
               "d", String.class, String.class, Throwable.class);
       sLogI =
-          android.util.Log.class.getDeclaredMethod(
+          org.chromium.base.Log.class.getDeclaredMethod(
               "i", String.class, String.class, Throwable.class);
       sLogW =
-          android.util.Log.class.getDeclaredMethod(
+          org.chromium.base.Log.class.getDeclaredMethod(
               "w", String.class, String.class, Throwable.class);
       sLogE =
-          android.util.Log.class.getDeclaredMethod(
+          org.chromium.base.Log.class.getDeclaredMethod(
               "e", String.class, String.class, Throwable.class);
     } catch (Throwable e) {
       // ignore
@@ -94,21 +94,21 @@ public final class Log {
   }
 
   public static int v(String tag, String messageTemplate, Object... args) {
-    if (android.util.Log.isLoggable(TAG, android.util.Log.VERBOSE)) {
+    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.VERBOSE)) {
       return logWithMethod(sLogV, tag, messageTemplate, args);
     }
     return 0;
   }
 
   public static int d(String tag, String messageTemplate, Object... args) {
-    if (android.util.Log.isLoggable(TAG, android.util.Log.DEBUG)) {
+    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.DEBUG)) {
       return logWithMethod(sLogD, tag, messageTemplate, args);
     }
     return 0;
   }
 
   public static int i(String tag, String messageTemplate, Object... args) {
-    if (android.util.Log.isLoggable(TAG, android.util.Log.INFO)) {
+    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.INFO)) {
       return logWithMethod(sLogI, tag, messageTemplate, args);
     }
     return 0;


### PR DESCRIPTION
Move usage of android.util.Log to org.chromium.base.Log. The new Log class proxies the original Log methods with additional functionality tacked on.

Bug: 472345388