### PR TITLE
starboard: Refactor FakeGraphicsContextProvider to use JobThread

### DIFF
--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -43,8 +43,6 @@ test("nplb") {
 
   # TODO(b/432821616): Move |media_sources| to a source_set.
   media_sources = [
-    "//starboard/testing/fake_graphics_context_provider.cc",
-    "//starboard/testing/fake_graphics_context_provider.h",
     "audio_sink_create_test.cc",
     "audio_sink_destroy_test.cc",
     "audio_sink_get_max_channels_test.cc",
@@ -339,6 +337,7 @@ test("nplb") {
     "//starboard/shared/starboard/media:media_util",
     "//starboard/shared/starboard/player:player_test_data",
     "//starboard/shared/starboard/player:video_dmp",
+    "//starboard/testing:fake_graphics_context_provider",
     "//testing/gmock",
     "//testing/gtest",
   ]

--- a/starboard/shared/starboard/player/filter/testing/BUILD.gn
+++ b/starboard/shared/starboard/player/filter/testing/BUILD.gn
@@ -18,8 +18,6 @@ if (current_toolchain == starboard_toolchain) {
     testonly = true
 
     sources = [
-      "//starboard/testing/fake_graphics_context_provider.cc",
-      "//starboard/testing/fake_graphics_context_provider.h",
       "adaptive_audio_decoder_test.cc",
       "audio_channel_layout_mixer_test.cc",
       "audio_decoder_test.cc",
@@ -50,6 +48,7 @@ if (current_toolchain == starboard_toolchain) {
       "//starboard/egl_and_gles:buildflags",
       "//starboard/shared/starboard/player:player_test_data",
       "//starboard/shared/starboard/player/filter:filter_based_player_sources",
+      "//starboard/testing:fake_graphics_context_provider",
     ]
   }
 

--- a/starboard/testing/BUILD.gn
+++ b/starboard/testing/BUILD.gn
@@ -1,0 +1,29 @@
+# Copyright 2024 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+static_library("fake_graphics_context_provider") {
+  testonly = true
+  sources = [
+    "fake_graphics_context_provider.cc",
+    "fake_graphics_context_provider.h",
+  ]
+  deps = [
+    "//$starboard_path:starboard_platform",
+    "//starboard:starboard_headers_only",
+    "//starboard/common",
+    "//starboard/egl_and_gles:buildflags",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
+}

--- a/starboard/testing/fake_graphics_context_provider.h
+++ b/starboard/testing/fake_graphics_context_provider.h
@@ -15,15 +15,14 @@
 #ifndef STARBOARD_TESTING_FAKE_GRAPHICS_CONTEXT_PROVIDER_H_
 #define STARBOARD_TESTING_FAKE_GRAPHICS_CONTEXT_PROVIDER_H_
 
-#include <pthread.h>
-
 #include <functional>
+#include <memory>
 
-#include "starboard/common/queue.h"
 #include "starboard/configuration.h"
 #include "starboard/decode_target.h"
 #include "starboard/egl.h"
 #include "starboard/gles.h"
+#include "starboard/shared/starboard/player/job_thread.h"
 #include "starboard/window.h"
 
 namespace starboard {
@@ -47,9 +46,6 @@ class FakeGraphicsContextProvider {
   void Render();
 
  private:
-  static void* ThreadEntryPoint(void* context);
-  void RunLoop();
-
   void InitializeEGL();
 
   void OnDecodeTargetGlesContextRunner(
@@ -68,8 +64,7 @@ class FakeGraphicsContextProvider {
   SbEglDisplay display_;
   SbEglSurface surface_;
   SbEglContext context_;
-  Queue<std::function<void()>> functor_queue_;
-  pthread_t decode_target_context_thread_;
+  std::unique_ptr<JobThread> job_thread_;
 
   SbDecodeTargetGraphicsContextProvider decoder_target_provider_;
 };


### PR DESCRIPTION
This change replaces the manual pthread and functor queue logic in FakeGraphicsContextProvider with JobThread. This simplifies the threading and synchronization logic, making it more robust and maintainable.

To support this, JobThread and JobQueue have been moved into a dedicated source_set in //starboard/shared/starboard/player:job_thread, allowing them to be shared across the platform implementation and tests without duplicate symbol issues. All relevant platform and test targets have been updated to depend on this new target.

Bug: 468356861