### PR TITLE
starboard/android: Refactor MediaCodecDecoder to use factory method

### DIFF
--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -27,6 +27,7 @@
 #include "starboard/android/shared/drm_system.h"
 #include "starboard/android/shared/media_codec_bridge.h"
 #include "starboard/common/ref_counted.h"
+#include "starboard/common/result.h"
 #include "starboard/common/thread.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
@@ -73,6 +74,32 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
     ~Host() {}
   };
 
+  static NonNullResult<std::unique_ptr<MediaCodecDecoder>> Create(
+      Host* host,
+      const AudioStreamInfo& audio_stream_info,
+      SbDrmSystem drm_system);
+  static NonNullResult<std::unique_ptr<MediaCodecDecoder>> Create(
+      Host* host,
+      SbMediaVideoCodec video_codec,
+      // `width_hint` and `height_hint` are used to create the
+      // Android video format, which don't have to be directly
+      // related to the resolution of the video.
+      int width_hint,
+      int height_hint,
+      std::optional<int> max_width,
+      std::optional<int> max_height,
+      int fps,
+      jobject j_output_surface,
+      SbDrmSystem drm_system,
+      const SbMediaColorMetadata* color_metadata,
+      bool require_software_codec,
+      const FrameRenderedCB& frame_rendered_cb,
+      const FirstTunnelFrameReadyCB& first_tunnel_frame_ready_cb,
+      int tunnel_mode_audio_session_id,
+      bool force_big_endian_hdr_metadata,
+      int max_video_input_size,
+      int64_t flush_delay_usec);
+
   MediaCodecDecoder(Host* host,
                     const AudioStreamInfo& audio_stream_info,
                     SbDrmSystem drm_system);
@@ -95,8 +122,7 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
                     int tunnel_mode_audio_session_id,
                     bool force_big_endian_hdr_metadata,
                     int max_video_input_size,
-                    int64_t flush_delay_usec,
-                    std::string* error_message);
+                    int64_t flush_delay_usec);
   ~MediaCodecDecoder();
 
   void Initialize(const ErrorCB& error_cb);
@@ -108,8 +134,6 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
   size_t GetNumberOfPendingInputs() const {
     return number_of_pending_inputs_.load();
   }
-
-  bool is_valid() const { return media_codec_bridge_ != NULL; }
 
   bool Flush();
 

--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -93,8 +93,8 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
       SbDrmSystem drm_system,
       const SbMediaColorMetadata* color_metadata,
       bool require_software_codec,
-      const FrameRenderedCB& frame_rendered_cb,
-      const FirstTunnelFrameReadyCB& first_tunnel_frame_ready_cb,
+      FrameRenderedCB frame_rendered_cb,
+      FirstTunnelFrameReadyCB first_tunnel_frame_ready_cb,
       int tunnel_mode_audio_session_id,
       bool force_big_endian_hdr_metadata,
       int max_video_input_size,
@@ -117,8 +117,8 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
                     SbDrmSystem drm_system,
                     const SbMediaColorMetadata* color_metadata,
                     bool require_software_codec,
-                    const FrameRenderedCB& frame_rendered_cb,
-                    const FirstTunnelFrameReadyCB& first_tunnel_frame_ready_cb,
+                    FrameRenderedCB frame_rendered_cb,
+                    FirstTunnelFrameReadyCB first_tunnel_frame_ready_cb,
                     int tunnel_mode_audio_session_id,
                     bool force_big_endian_hdr_metadata,
                     int max_video_input_size,
@@ -210,8 +210,8 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
   DrmSystem* const drm_system_;
   const FrameRenderedCB frame_rendered_cb_;
   const FirstTunnelFrameReadyCB first_tunnel_frame_ready_cb_;
-  const bool tunnel_mode_enabled_;
-  const int64_t flush_delay_usec_;
+  const bool tunnel_mode_enabled_ = false;
+  const int64_t flush_delay_usec_ = 0;
 
   ErrorCB error_cb_;
 
@@ -238,7 +238,8 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
 
   // Working thread to avoid lengthy decoding work block the player thread.
   std::unique_ptr<Thread> decoder_thread_;
-  std::unique_ptr<MediaCodecBridge> media_codec_bridge_;
+  std::string creation_error_message_;
+  const std::unique_ptr<MediaCodecBridge> media_codec_bridge_;
 };
 
 }  // namespace starboard


### PR DESCRIPTION
This change refactors MediaCodecDecoder to use static Create() factory methods that return NonNullResult<std::unique_ptr<MediaCodecDecoder>>. This improves error handling during instantiation by allowing the caller to receive a detailed error message on failure.

Key changes:
- Added static Create() methods to MediaCodecDecoder.
- Updated MediaCodecDecoder constructors and removed the error_message parameter from the video constructor, storing it internally instead.
- Updated MediaCodecAudioDecoder and MediaCodecVideoDecoder to use the new factory pattern.
- Removed is_valid() checks in favor of direct pointer/Result checks.
- Updated PlayerComponentsFactory to align with the new MediaCodecVideoDecoder constructor signature.
- Fixed a typo in audio_decoder.cc (medai_decoder -> media_decoder).

Bug: 1234