### PR TITLE
Revert debug commits to storage migration

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -84,11 +84,6 @@ public abstract class CobaltActivity extends Activity {
 
   private static final Pattern URL_PARAM_PATTERN = Pattern.compile("^[a-zA-Z0-9_=]*$");
 
-  // How many seconds before the app exits if it fails to land YouTube home page.
-  private static final int HANG_APP_CRASH_TIMEOUT_SECONDS = 60;
-  public static final String SPLASH_ARGS_KEY = "disableNativeSplash";
-  private boolean disableNativeSplash;
-
   // Maintain the list of JavaScript-exposed objects as a member variable
   // to prevent them from being garbage collected prematurely.
   private List<CobaltJavaScriptAndroidObject> javaScriptAndroidObjectList = new ArrayList<>();
@@ -116,7 +111,6 @@ public abstract class CobaltActivity extends Activity {
   // Initially copied from ContentShellActiviy.java
   protected void createContent(final Bundle savedInstanceState) {
     // Initializing the command line must occur before loading the library.
-    disableNativeSplash = getIntent().getBooleanExtra(SPLASH_ARGS_KEY, false);
     if (!CommandLine.isInitialized()) {
       CommandLine.init(null);
 
@@ -269,10 +263,8 @@ public abstract class CobaltActivity extends Activity {
                   }
                 };
 
-            if (!disableNativeSplash) {
-              // Load splash screen.
-              mShellManager.getActiveShell().loadSplashScreenWebContents();
-            }
+            // Load splash screen.
+            mShellManager.getActiveShell().loadSplashScreenWebContents();
           }
         });
   }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -84,6 +84,9 @@ public abstract class CobaltActivity extends Activity {
 
   private static final Pattern URL_PARAM_PATTERN = Pattern.compile("^[a-zA-Z0-9_=]*$");
 
+  // How many seconds before the app exits if it fails to land YouTube home page.
+  private static final int HANG_APP_CRASH_TIMEOUT_SECONDS = 60;
+
   // Maintain the list of JavaScript-exposed objects as a member variable
   // to prevent them from being garbage collected prematurely.
   private List<CobaltJavaScriptAndroidObject> javaScriptAndroidObjectList = new ArrayList<>();

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -327,11 +327,11 @@ void CobaltContentBrowserClient::OnWebContentsCreated(
       web_contents->GetPrimaryMainFrame()->GetFrameName() ==
           content::kCobaltSplashMainFrameName) {
     // Don't observe WebContents if it's splash screen.
-    LOG(INFO) << "NativeSplash: Skip observing WebContents for "
-                 "kCobaltSplashMainFrameName.";
+    VLOG(1) << "NativeSplash: Skip observing WebContents for "
+               "kCobaltSplashMainFrameName.";
     return;
   }
-  LOG(INFO) << "NativeSplash: Observing main frame WebContents.";
+  VLOG(1) << "NativeSplash: Observing main frame WebContents.";
   web_contents_observer_.reset(new CobaltWebContentsObserver(web_contents));
 }
 

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -226,16 +226,16 @@ Task MigrationManager::GroupTasks(std::vector<Task> tasks) {
 // TODO(b/399165612): Add metrics.
 // TODO(b/399165796): Disable and delete migration code when possible.
 // TODO(b/399166308): Add unit and/or integration tests for migration.
-bool MigrationManager::DoMigrationTasksOnce(
+void MigrationManager::DoMigrationTasksOnce(
     content::WebContents* web_contents) {
   if (migration_attempted_.test_and_set()) {
-    return false;
+    return;
   }
 
   auto storage = ReadStorage();
   if (!storage ||
       (storage->cookies_size() == 0 && storage->local_storages_size() == 0)) {
-    return false;
+    return;
   }
 
   web_contents->Stop();
@@ -255,7 +255,6 @@ bool MigrationManager::DoMigrationTasksOnce(
   tasks.push_back(DeleteOldCacheDirectoryTask());
   tasks.push_back(ReloadTask(weak_document_ptr));
   std::move(GroupTasks(std::move(tasks))).Run(base::DoNothing());
-  return true;
 }
 
 // static

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.h
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.h
@@ -35,7 +35,7 @@ using Task = base::OnceCallback<void(base::OnceClosure)>;
 
 class MigrationManager {
  public:
-  static bool DoMigrationTasksOnce(content::WebContents* web_contents);
+  static void DoMigrationTasksOnce(content::WebContents* web_contents);
 
  private:
   friend class MigrationManagerTest;

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -376,9 +376,8 @@ void Shell::RenderFrameCreated(RenderFrameHost* frame_host) {
 
 void Shell::PrimaryMainDocumentElementAvailable() {
   LOG(INFO) << "PrimaryMainDocumentElementAvailable, do storage migration.";
-  did_storage_migration_ =
-      cobalt::migrate_storage_record::MigrationManager::DoMigrationTasksOnce(
-          web_contents());
+  cobalt::migrate_storage_record::MigrationManager::DoMigrationTasksOnce(
+      web_contents());
   LOG(INFO) << "PrimaryMainDocumentElementAvailable, storage migration done.";
 }
 
@@ -979,7 +978,6 @@ void Shell::ScheduleSwitchToMainWebContents() {
             << "ms, remaining delay: " << remaining_delay.InMilliseconds()
             << "ms.";
   if (web_contents_) {
-    web_contents_->WasHidden();
     content::GetUIThreadTaskRunner({})->PostDelayedTask(
         FROM_HERE,
         base::BindOnce(&Shell::SwitchToMainWebContents,
@@ -1001,15 +999,9 @@ void Shell::SwitchToMainWebContents() {
   // This could be called multiple times.
   if (!has_switched_to_main_frame_) {
     LOG(INFO) << "NativeSplash: Switching to main frame WebContents.";
-    if (did_storage_migration_ && web_contents()) {
-      // TODO: b/474447216 - Temporary workaround to reload main app.
-      LOG(INFO) << "NativeSplash: Reloading URL due to storage migration.";
-      LoadURL(web_contents()->GetLastCommittedURL());
-    }
     has_switched_to_main_frame_ = true;
     if (web_contents_) {
       GetPlatform()->UpdateContents(this);
-      web_contents_->WasShown();
       if (web_contents()->GetRenderWidgetHostView()) {
         web_contents()->GetRenderWidgetHostView()->Focus();
       }

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -375,14 +375,12 @@ void Shell::RenderFrameCreated(RenderFrameHost* frame_host) {
 }
 
 void Shell::PrimaryMainDocumentElementAvailable() {
-  LOG(INFO) << "PrimaryMainDocumentElementAvailable, do storage migration.";
   cobalt::migrate_storage_record::MigrationManager::DoMigrationTasksOnce(
       web_contents());
-  LOG(INFO) << "PrimaryMainDocumentElementAvailable, storage migration done.";
 }
 
 void Shell::DidFinishNavigation(NavigationHandle* navigation_handle) {
-  LOG(INFO) << "NativeSplash: Navigated to " << navigation_handle->GetURL();
+  VLOG(1) << "NativeSplash: Navigated to " << navigation_handle->GetURL();
 }
 
 void Shell::DidStopLoading() {
@@ -393,7 +391,7 @@ void Shell::DidStopLoading() {
 
   if (!is_main_frame_loaded_ &&
       splash_state_ != STATE_SPLASH_SCREEN_UNINITIALIZED) {
-    LOG(INFO) << "NativeSplash: Main frame WebContents DidStopLoading.";
+    VLOG(1) << "NativeSplash: Main frame WebContents DidStopLoading.";
     is_main_frame_loaded_ = true;
 
     if (splash_state_ < STATE_SPLASH_SCREEN_STARTED) {
@@ -435,7 +433,7 @@ void Shell::RegisterInjectedJavaScript() {
 void Shell::LoadSplashScreenWebContents() {
   if (splash_screen_web_contents_) {
     // Display splash screen.
-    LOG(INFO) << "NativeSplash: Loading splash screen WebContents.";
+    VLOG(1) << "NativeSplash: Loading splash screen WebContents.";
     splash_state_ = STATE_SPLASH_SCREEN_STARTED;
     GetPlatform()->LoadSplashScreenContents(this);
 
@@ -448,7 +446,7 @@ void Shell::LoadSplashScreenWebContents() {
 
     if (is_main_frame_loaded_) {
       // Main frame loaded before splash screen started.
-      LOG(INFO) << "NativeSplash: Main frame loaded before splash start.";
+      VLOG(1) << "NativeSplash: Main frame loaded before splash start.";
       ScheduleSwitchToMainWebContents();
     }
   }
@@ -938,7 +936,7 @@ void Shell::LoadProgressChanged(double progress) {
     }
 
     if (splash_state_ >= STATE_SPLASH_SCREEN_ENDED) {
-      LOG(INFO) << "NativeSplash: Main frame WebContents is loaded.";
+      VLOG(1) << "NativeSplash: Main frame WebContents is loaded.";
       SwitchToMainWebContents();
     } else {
       ScheduleSwitchToMainWebContents();
@@ -972,11 +970,11 @@ void Shell::ScheduleSwitchToMainWebContents() {
     remaining_delay = base::TimeDelta();
   }
 
-  LOG(INFO) << "NativeSplash: Main frame WebContents is loaded, splash "
-               "screen elapsed: "
-            << splash_screen_elapsed.InMilliseconds()
-            << "ms, remaining delay: " << remaining_delay.InMilliseconds()
-            << "ms.";
+  VLOG(1) << "NativeSplash: Main frame WebContents is loaded, splash "
+             "screen elapsed: "
+          << splash_screen_elapsed.InMilliseconds()
+          << "ms, remaining delay: " << remaining_delay.InMilliseconds()
+          << "ms.";
   if (web_contents_) {
     web_contents_->WasHidden();
     content::GetUIThreadTaskRunner({})->PostDelayedTask(
@@ -999,7 +997,7 @@ void Shell::SwitchToMainWebContents() {
   // instead of a lock due to it is on a single thread.
   // This could be called multiple times.
   if (!has_switched_to_main_frame_) {
-    LOG(INFO) << "NativeSplash: Switching to main frame WebContents.";
+    VLOG(1) << "NativeSplash: Switching to main frame WebContents.";
     has_switched_to_main_frame_ = true;
     if (web_contents_) {
       GetPlatform()->UpdateContents(this);
@@ -1027,7 +1025,7 @@ void Shell::OnSplashScreenLoadComplete() {
 }
 
 void Shell::ClosingSplashScreenWebContents() {
-  LOG(INFO) << "NativeSplash: Closing splash screen WebContents.";
+  VLOG(1) << "NativeSplash: Closing splash screen WebContents.";
   splash_state_ = STATE_SPLASH_SCREEN_ENDED;
   if (is_main_frame_loaded_) {
     // If main frame WebContents is loaded, switch to it.

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -978,6 +978,7 @@ void Shell::ScheduleSwitchToMainWebContents() {
             << "ms, remaining delay: " << remaining_delay.InMilliseconds()
             << "ms.";
   if (web_contents_) {
+    web_contents_->WasHidden();
     content::GetUIThreadTaskRunner({})->PostDelayedTask(
         FROM_HERE,
         base::BindOnce(&Shell::SwitchToMainWebContents,
@@ -1002,6 +1003,7 @@ void Shell::SwitchToMainWebContents() {
     has_switched_to_main_frame_ = true;
     if (web_contents_) {
       GetPlatform()->UpdateContents(this);
+      web_contents_->WasShown();
       if (web_contents()->GetRenderWidgetHostView()) {
         web_contents()->GetRenderWidgetHostView()->Focus();
       }

--- a/cobalt/shell/browser/shell.h
+++ b/cobalt/shell/browser/shell.h
@@ -274,7 +274,6 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
   bool is_main_frame_loaded_ = false;
   bool has_switched_to_main_frame_ = false;
   base::TimeTicks splash_screen_start_time_;
-  bool did_storage_migration_ = false;
 
   base::WeakPtr<ShellDevToolsFrontend> devtools_frontend_;
 


### PR DESCRIPTION
This commit reverts a set of previous changes introduced for debugging
the storage migration process. These temporary modifications are no
longer required and are being removed. The reverted changes include:
- https://github.com/youtube/cobalt/pull/8648
- https://github.com/youtube/cobalt/pull/8624
- https://github.com/youtube/cobalt/pull/8625
- https://github.com/youtube/cobalt/pull/8607

Issue: 474447216