### PR TITLE
Refactor OpenMaxVideoDecoder to use starboard::Thread

### DIFF
--- a/starboard/raspi/shared/open_max/video_decoder.cc
+++ b/starboard/raspi/shared/open_max/video_decoder.cc
@@ -31,6 +31,16 @@ const int64_t kUpdateIntervalUsec = 5'000;
 
 }  // namespace
 
+class OpenMaxVideoDecoder::DecoderThread : public Thread {
+ public:
+  explicit DecoderThread(OpenMaxVideoDecoder* decoder)
+      : Thread("omx_video_dec"), decoder_(decoder) {}
+  void Run() override { decoder_->RunLoop(); }
+
+ private:
+  OpenMaxVideoDecoder* decoder_;
+};
+
 OpenMaxVideoDecoder::OpenMaxVideoDecoder(SbMediaVideoCodec video_codec)
     : resource_pool_(new DispmanxResourcePool(kResourcePoolSize)),
       eos_written_(false),

--- a/starboard/raspi/shared/open_max/video_decoder.h
+++ b/starboard/raspi/shared/open_max/video_decoder.h
@@ -93,7 +93,7 @@ class OpenMaxVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
   bool eos_written_;
   bool first_input_written_ = false;
 
-  std::unique_ptr<Thread> thread_;
+  std::unique_ptr<DecoderThread> thread_;
   bool request_thread_termination_;
   Queue<Event*> queue_;
 

--- a/starboard/raspi/shared/open_max/video_decoder.h
+++ b/starboard/raspi/shared/open_max/video_decoder.h
@@ -72,7 +72,7 @@ class OpenMaxVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
   class DecoderThread : public Thread {
    public:
     explicit DecoderThread(OpenMaxVideoDecoder* decoder)
-        : Thread("omx_video_decoder"), decoder_(decoder) {}
+        : Thread("omx_video_dec"), decoder_(decoder) {}
     void Run() override { decoder_->RunLoop(); }
 
    private:


### PR DESCRIPTION
Refactor the OpenMax video decoder to utilize the starboard::Thread
abstraction instead of direct POSIX pthread API calls. This improves
consistency with other platform-agnostic components and enhances
portability across Starboard implementations.

Bug: 468356861