### PR TITLE
Refactor media dependencies in Blink modules (#8528)

### DIFF
--- a/third_party/blink/renderer/modules/BUILD.gn
+++ b/third_party/blink/renderer/modules/BUILD.gn
@@ -178,10 +178,17 @@ component("modules") {
       "//third_party/blink/renderer/modules/cobalt/h5vcc_accessibility",
       "//third_party/blink/renderer/modules/cobalt/h5vcc_experiments",
       "//third_party/blink/renderer/modules/cobalt/h5vcc_metrics",
-      "//third_party/blink/renderer/modules/cobalt/h5vcc_system",
       "//third_party/blink/renderer/modules/cobalt/h5vcc_runtime",
       "//third_party/blink/renderer/modules/cobalt/h5vcc_storage",
+      "//third_party/blink/renderer/modules/cobalt/h5vcc_system",
     ]
+
+    if (use_starboard_media) {
+      sub_modules += [
+        "//third_party/blink/renderer/modules/cobalt/encryptedmedia",
+        "//third_party/blink/renderer/modules/cobalt/mediasource",
+      ]
+    }
   }
 
   # This uses target_os rather than current_os (which is what is_android is set
@@ -758,9 +765,7 @@ source_set("unit_tests") {
   ]
 
   if (is_cobalt) {
-    deps += [
-      "//third_party/blink/renderer/modules/cobalt/h5vcc_experiments:experiments_utils"
-    ]
+    deps += [ "//third_party/blink/renderer/modules/cobalt/h5vcc_experiments:experiments_utils" ]
   }
 
   # This uses target_os rather than current_os (which is what is_android is set

--- a/third_party/blink/renderer/modules/cobalt/BUILD.gn
+++ b/third_party/blink/renderer/modules/cobalt/BUILD.gn
@@ -29,11 +29,4 @@ blink_modules_sources("h_5_vcc") {
     "//third_party/blink/renderer/modules/cobalt/h5vcc_storage",
     "//third_party/blink/renderer/modules/cobalt/h5vcc_system",
   ]
-
-  if (use_starboard_media) {
-    deps += [
-      "//third_party/blink/renderer/modules/cobalt/encryptedmedia",
-      "//third_party/blink/renderer/modules/cobalt/mediasource",
-    ]
-  }
 }


### PR DESCRIPTION
Refer to the original PR: https://github.com/youtube/cobalt/pull/8528

Move 'encryptedmedia' and 'mediasource' dependencies from the 'h_5_vcc' target to the main 'modules' component in Cobalt. This reorganization addresses dependency issues and prepares the build system for future changes.

The changed BUILD.gn are also formatted.

Bug: 381298846
Bug: 395658866