### PR TITLE
cobalt: Fix initial deep link for multiple webContents

### DIFF
--- a/third_party/blink/renderer/modules/cobalt/h5vcc_runtime/h_5_vcc_runtime.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_runtime/h_5_vcc_runtime.cc
@@ -24,11 +24,7 @@ namespace blink {
 H5vccRuntime::H5vccRuntime(LocalDOMWindow& window)
     : ExecutionContextLifecycleObserver(window.GetExecutionContext()),
       remote_h5vcc_runtime_(window.GetExecutionContext()),
-      deep_link_receiver_(this, window.GetExecutionContext()) {
-  EnsureRemoteIsBound();
-  remote_h5vcc_runtime_->GetAndClearInitialDeepLinkSync(&initial_deep_link_);
-  LOG(INFO) << "H5vccRuntime initial DeepLink: " << initial_deep_link_;
-}
+      deep_link_receiver_(this, window.GetExecutionContext()) {}
 
 void H5vccRuntime::ContextDestroyed() {
   remote_h5vcc_runtime_.reset();
@@ -36,6 +32,11 @@ void H5vccRuntime::ContextDestroyed() {
 }
 
 String H5vccRuntime::initialDeepLink() {
+  if (initial_deep_link_.IsNull()) {
+    EnsureRemoteIsBound();
+    remote_h5vcc_runtime_->GetAndClearInitialDeepLinkSync(&initial_deep_link_);
+    LOG(INFO) << "H5vccRuntime initial DeepLink: " << initial_deep_link_;
+  }
   return initial_deep_link_;
 }
 


### PR DESCRIPTION
The initial deep link URL retrieval is now performed within the
initialDeepLink() getter method. Previously, it was fetched during
H5vccRuntime construction.

This change addresses an issue with multiple WebContents instances.
When a splash screen WebContent was present, it would consume the
initial deep link, preventing the main application WebContent (Kabuki)
from receiving it. Fetching on demand ensures each WebContent gets its
correct initial deep link.

Bug: 475657034