### PR TITLE
EG: Clean up dlsym fallback

### DIFF
--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -14,14 +14,7 @@
 
 #include "starboard/elf_loader/exported_symbols.h"
 
-#include "build/build_config.h"
-
 #include <dirent.h>
-
-// TODO: Cobalt b/421944504 - Cleanup once we are done with all the symbols.
-#if BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-#include <dlfcn.h>
-#endif  // BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
 
 #include <errno.h>
 #include <fcntl.h>
@@ -421,23 +414,8 @@ ExportedSymbols::ExportedSymbols() {
 }  // NOLINT
 
 const void* ExportedSymbols::Lookup(const char* name) {
-  const void* address = map_[name];
-  // Any symbol that is not registered as part of the Starboard API in the
-  // constructor of this class is a leak, and is an error.
-  if (address) {
-    return address;
-  }
-
-  SB_LOG(ERROR) << "Failed to retrieve the address of '" << name << "'.";
-#if BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-  // TODO: Cobalt b/421944504 - Cleanup once we are done with all the symbols or
-  // potentially keep it behind a flag to help with future maintenance.
-  address = dlsym(RTLD_DEFAULT, name);
-  if (address == nullptr) {
-    SB_LOG(ERROR) << "Fallback dlsym failed for '" << name << "'.";
-  }
-#endif  // BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-  return address;
+  // Don't report an error here, as the symbol might be a valid weak symbol.
+  return map_[name];
 }
 
 }  // namespace elf_loader


### PR DESCRIPTION
Remove the temporary dlsym fallback mechanism and its associated build
flag from the ELF loader's symbol lookup. This change improves symbol
resolution strictness and avoids misleading error logs for valid weak
symbols not found in the explicit map.

Fixed: 421944504