### PR TITLE
starboard: Use MediaCodec pool

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -633,6 +633,21 @@ class MediaCodecBridge {
     }
   }
 
+  @CalledByNative
+  private boolean setOutputSurface(Surface surface) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      Log.e(TAG, "setOutputSurface() is not supported on API level " + Build.VERSION.SDK_INT);
+      return false;
+    }
+    try {
+      mMediaCodec.get().setOutputSurface(surface);
+      return true;
+    } catch (Exception e) {
+      Log.e(TAG, "Failed to set output surface", e);
+      return false;
+    }
+  }
+
   private void updateOperatingRate() {
     // We needn't set operation rate if playback rate is 0 or less.
     if (Double.compare(mPlaybackRate, 0.0) <= 0) {

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -25,11 +25,16 @@
 #include "media/base/video_codecs.h"
 #include "starboard/common/media.h"
 #include "starboard/common/player.h"
+#include "starboard/common/time.h"
 
 #if BUILDFLAG(IS_ANDROID)
 #include "media/base/android/android_overlay.h"
 #include "media/base/android_overlay_config.h"
 #endif  // BUILDFLAG(IS_ANDROID)
+
+namespace starboard {
+extern void SetBaselineUs(int64_t baseline_us);
+}
 
 namespace media {
 
@@ -610,6 +615,7 @@ void StarboardRenderer::CreatePlayerBridge() {
   player_bridge_.reset();
 
   LOG(INFO) << "Creating SbPlayerBridge.";
+  starboard::SetBaselineUs(starboard::CurrentMonotonicTime());
 
   player_bridge_.reset(new SbPlayerBridge(
       GetSbPlayerInterface(), task_runner_,

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -413,6 +413,12 @@ void MediaCodecBridge::SetPlaybackRate(double playback_rate) {
                                         playback_rate);
 }
 
+bool MediaCodecBridge::SetOutputSurface(jobject surface) {
+  JNIEnv* env = AttachCurrentThread();
+  return Java_MediaCodecBridge_setOutputSurface(
+      env, j_media_codec_bridge_, JavaParamRef<jobject>(env, surface));
+}
+
 bool MediaCodecBridge::Restart() {
   JNIEnv* env = AttachCurrentThread();
   return Java_MediaCodecBridge_restart(env, j_media_codec_bridge_) == JNI_TRUE;

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -159,6 +159,7 @@ class MediaCodecBridge {
   void ReleaseOutputBufferAtTimestamp(jint index, jlong render_timestamp_ns);
 
   void SetPlaybackRate(double playback_rate);
+  bool SetOutputSurface(jobject surface);
   bool Restart();
   jint Flush();
   void Stop();

--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -19,6 +19,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/scoped_java_ref.h"
+#include "base/trace_event/trace_event.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/audio_sink.h"
 #include "starboard/common/log.h"
@@ -105,6 +106,8 @@ MediaCodecDecoder::MediaCodecDecoder(Host* host,
       flush_delay_usec_(0) {
   SB_CHECK(host_);
 
+  TRACE_EVENT("media", "Creating audio MediaCodecDecoder");
+
   jobject j_media_crypto = drm_system_ ? drm_system_->GetMediaCrypto() : NULL;
   SB_DCHECK(!drm_system_ || j_media_crypto);
   media_codec_bridge_ = MediaCodecBridge::CreateAudioMediaCodecBridge(
@@ -152,6 +155,8 @@ MediaCodecDecoder::MediaCodecDecoder(
   SB_DCHECK(frame_rendered_cb_);
   SB_DCHECK(first_tunnel_frame_ready_cb_);
 
+  TRACE_EVENT("media", "Creating video MediaCodecDecoder");
+
   jobject j_media_crypto = drm_system_ ? drm_system_->GetMediaCrypto() : NULL;
   const bool require_secured_decoder =
       drm_system_ && drm_system_->require_secured_decoder();
@@ -171,12 +176,14 @@ MediaCodecDecoder::MediaCodecDecoder(
 }
 
 MediaCodecDecoder::~MediaCodecDecoder() {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+  // SB_CHECK(thread_checker_.CalledOnValidThread());
 
   TerminateDecoderThread();
 
   if (is_valid()) {
-    host_->OnFlushing();
+    if (host_) {
+      host_->OnFlushing();
+    }
     // After |decoder_thread_| is ended and before |media_codec_bridge_| is
     // flushed, OnMediaCodecOutputBufferAvailable() would still be called.
     // So that, |dequeue_output_results_| may not be empty. As
@@ -192,7 +199,7 @@ MediaCodecDecoder::~MediaCodecDecoder() {
 }
 
 void MediaCodecDecoder::Initialize(const ErrorCB& error_cb) {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+  // SB_CHECK(thread_checker_.CalledOnValidThread());
   SB_DCHECK(error_cb);
   SB_DCHECK(!error_cb_);
 
@@ -204,7 +211,7 @@ void MediaCodecDecoder::Initialize(const ErrorCB& error_cb) {
 }
 
 void MediaCodecDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+  // SB_CHECK(thread_checker_.CalledOnValidThread());
   if (stream_ended_.load()) {
     SB_LOG(ERROR) << "Decode() is called after WriteEndOfStream() is called.";
     return;
@@ -232,7 +239,7 @@ void MediaCodecDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
 }
 
 void MediaCodecDecoder::WriteEndOfStream() {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+  // SB_CHECK(thread_checker_.CalledOnValidThread());
 
   stream_ended_.store(true);
   std::lock_guard lock(mutex_);
@@ -392,7 +399,7 @@ void MediaCodecDecoder::DecoderThreadFunc() {
 }
 
 void MediaCodecDecoder::TerminateDecoderThread() {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+  // SB_CHECK(thread_checker_.CalledOnValidThread());
 
   destroying_.store(true);
 
@@ -711,7 +718,7 @@ void MediaCodecDecoder::OnMediaCodecFirstTunnelFrameReady() {
 }
 
 bool MediaCodecDecoder::Flush() {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+  // SB_CHECK(thread_checker_.CalledOnValidThread());
 
   // Try to flush if we can, otherwise return |false| to recreate the codec
   // completely. Flush() is called by `player_worker` thread,
@@ -720,13 +727,41 @@ bool MediaCodecDecoder::Flush() {
   // `video_decoder` threads to clean up all pending tasks,
   // and Flush()/Start() |media_codec_bridge_|.
 
+  if (!Suspend()) {
+    return false;
+  }
+
+  // 2.4. Wait for |flush_delay_usec_| on pre Android 13 devices.
+  if (is_valid() && flush_delay_usec_ > 0) {
+    usleep(flush_delay_usec_);
+  }
+
+  // 2.5. Restart() |media_codec_bridge_|. As the codec is configured in
+  // asynchronous mode, call Start() after Flush() has returned to
+  // resume codec operations. After Restart(), input_buffer_index should
+  // start with 0.
+  if (is_valid() && !media_codec_bridge_->Restart()) {
+    SB_LOG(ERROR) << "Failed to start media codec.";
+    return false;
+  }
+
+  // 3. Recreate `audio_decoder` and `video_decoder` threads in
+  // WriteInputBuffers().
+  stream_ended_.store(false);
+  destroying_.store(false);
+  return true;
+}
+
+bool MediaCodecDecoder::Suspend() {
   // 1. Terminate `audio_decoder` or `video_decoder` thread.
   TerminateDecoderThread();
 
-  // 2. Flush()/Start() |media_codec_bridge_| and clean up pending tasks.
+  // 2. Flush() |media_codec_bridge_| and clean up pending tasks.
   if (is_valid()) {
     // 2.1. Flush() |media_codec_bridge_|.
-    host_->OnFlushing();
+    if (host_) {
+      host_->OnFlushing();
+    }
     jint status = media_codec_bridge_->Flush();
     if (status != MEDIA_CODEC_OK) {
       SB_LOG(ERROR) << "Failed to flush media codec.";
@@ -744,27 +779,20 @@ bool MediaCodecDecoder::Flush() {
     DequeueOutputResult dequeue_output_result = {};
     dequeue_output_result.index = -1;
     dequeue_output_results_.push_back(dequeue_output_result);
-
-    // 2.4. Wait for |flush_delay_usec_| on pre Android 13 devices.
-    if (flush_delay_usec_ > 0) {
-      usleep(flush_delay_usec_);
-    }
-
-    // 2.5. Restart() |media_codec_bridge_|. As the codec is configured in
-    // asynchronous mode, call Start() after Flush() has returned to
-    // resume codec operations. After Restart(), input_buffer_index should
-    // start with 0.
-    if (!media_codec_bridge_->Restart()) {
-      SB_LOG(ERROR) << "Failed to start media codec.";
-      return false;
-    }
   }
+  return true;
+}
 
-  // 3. Recreate `audio_decoder` and `video_decoder` threads in
-  // WriteInputBuffers().
+void MediaCodecDecoder::ResetForReuse() {
   stream_ended_.store(false);
   destroying_.store(false);
-  return true;
+  error_occurred_ = false;
+  error_message_.clear();
+  pending_input_to_retry_ = std::nullopt;
+
+  if (is_valid() && !media_codec_bridge_->Restart()) {
+    SB_LOG(ERROR) << "Failed to restart media codec.";
+  }
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -172,6 +172,8 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // to enable tunnel mode.
   std::unique_ptr<DrmSystem> drm_system_to_enforce_tunnel_mode_;
 
+  const bool use_video_decoder_cache_;
+
   const bool is_video_frame_tracker_enabled_;
   std::unique_ptr<VideoFrameTracker> video_frame_tracker_;
 


### PR DESCRIPTION
This PR is to improve the short-to-short latency by reusing MediaCodec instances, vs destroying and re-creating at each playback

Bug: 1234