### PR TITLE
android: Adding platform error dialog "Dismiss" string to xml file

### DIFF
--- a/cobalt/shell/android/java/res/values/strings.xml
+++ b/cobalt/shell/android/java/res/values/strings.xml
@@ -25,6 +25,8 @@
     <string name="starboard_platform_retry">Try again</string>
     <!-- Button label on network connection error to open system network settings. -->
     <string name="starboard_platform_network_settings">Open network settings</string>
+    <!-- Button label to dismiss an error message dialog. -->
+    <string name="starboard_platform_dismiss">Dismiss</string>
     <!-- Toast message when we can't get the device account to sign in. -->
     <string name="starboard_account_picker_error">Account not available.</string>
     <!-- Toast message when we the account can't be authorized. -->


### PR DESCRIPTION
With the addition of a new button in the platform error dialog, it's necessary to include the string in the `strings.xml` file so the "Dismiss" string is translated based on the users' system language settings.

Bug: 478952740