### PR TITLE
Reland "android: Enable AndroidOverlay for SbPlayer punch-out mode" (#8783)

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -66,6 +66,9 @@ public final class CommandLineOverrideHelper {
         // causes rendering artifacts when
         // low-end-device-mode is enabled.
         paramOverrides.add("--disable-rgba-4444-textures");
+        // Force CobaltActivity to use AndroidOverlay instead
+        // of VideoSurfaceView.
+        paramOverrides.add("--CobaltUsingAndroidOverlay");
 
         return paramOverrides;
     }
@@ -91,6 +94,8 @@ public final class CommandLineOverrideHelper {
         // It is important to use a feature override instead of the
         // rendering switch, to make sure certain devices are excluded.
         paramOverrides.add("DefaultPassthroughCommandDecoder");
+        // Using AndroidOverlay for punch-out video mode.
+        paramOverrides.add("CobaltUsingAndroidOverlay");
 
         return paramOverrides;
     }


### PR DESCRIPTION
This PR is reverted in https://github.com/youtube/cobalt/pull/8783 due to black screen issue.

Original commit messages:

> Enable the CobaltUsingAndroidOverlay command-line flag and feature
> on Android. This forces CobaltActivity to utilize AndroidOverlay
> instead of VideoSurfaceView for SbPlayer's punch-out mode.
> 
> This change ensures proper hardware accelerated video rendering and
> resolves related playback issues. The explicit SetOverlayMode method
> in Shell is no longer necessary with this new mechanism.

Issue: 460831614
Issue: 476418731
Issue: 476495060