### PR TITLE
android: Remove extra spaces in CobaltActivity.java

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -394,7 +394,7 @@ public abstract class CobaltActivity extends Activity {
     MemoryPressureMonitor.INSTANCE.registerComponentCallbacks();
     NetworkChangeNotifier.init();
     NetworkChangeNotifier.setAutoDetectConnectivityState(true);
-    
+
     if (!mIsCobaltUsingAndroidOverlay) {
       videoSurfaceView = new VideoSurfaceView(this);
       addContentView(


### PR DESCRIPTION
The CobaltActivity.java file contained an unnecessary blank line,
violating established code style guidelines. This change removes
the extraneous whitespace, improving code consistency and
readability without altering behavior.

Issue: 480420397