### PR TITLE
android: Make V8 settings configurable

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -254,6 +254,7 @@ robolectric_binary("cobalt_coat_junit_tests") {
     "apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/MockShellManagerNatives.java",
     "apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java",
+    "apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java",
     "apk/app/src/test/java/dev/cobalt/util/StartupGuardTest.java",
   ]
   deps = [

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -146,15 +146,7 @@ public abstract class CobaltActivity extends Activity {
         commandLineArgs = getCommandLineParamsFromIntent(getIntent(), COMMAND_LINE_ARGS_KEY);
       }
 
-      Map<String, String> javaSwitches = getJavaSwitches();
-      List<String> extraCommandLineArgs = new ArrayList<>();
-      if (!javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
-        extraCommandLineArgs.add("--disable-quic");
-      }
-      if (!javaSwitches.containsKey(JavaSwitches.DISABLE_LOW_END_DEVICE_MODE)) {
-        extraCommandLineArgs.add("--enable-low-end-device-mode");
-        extraCommandLineArgs.add("--disable-rgba-4444-textures");
-      }
+      List<String> extraCommandLineArgs = JavaSwitches.getExtraCommandLineArgs(getJavaSwitches());
 
       if (commandLineArgs != null) {
         // Add all array elements to index 0 of the list

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -14,6 +14,10 @@
 
 package dev.cobalt.util;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
 /**
  * Defines the constant names for feature switches used in Kimono.
  */
@@ -21,4 +25,61 @@ public class JavaSwitches {
   public static final String ENABLE_QUIC = "EnableQUIC";
   public static final String DISABLE_STARTUP_GUARD = "DisableStartupGuard";
   public static final String DISABLE_LOW_END_DEVICE_MODE = "DisableLowEndDeviceMode";
+
+  /** V8 flag to enable jitless mode. Value type: Boolean (presence means true) */
+  public static final String V8_JITLESS = "V8Jitless";
+
+  /** V8 flag to enable write protection for code memory. Value type: Boolean (presence means true) */
+  public static final String V8_WRITE_PROTECT_CODE_MEMORY = "V8WriteProtectCodeMemory";
+
+  /** V8 flag to set the GC interval. Value type: Integer */
+  public static final String V8_GC_INTERVAL = "V8GcInterval";
+
+  /** V8 flag to set the initial old space size. Value type: Integer (MiB) */
+  public static final String V8_INITIAL_OLD_SPACE_SIZE = "V8InitialOldSpaceSize";
+
+  /** V8 flag to set the maximum old space size. Value type: Integer (MiB) */
+  public static final String V8_MAX_OLD_SPACE_SIZE = "V8MaxOldSpaceSize";
+
+  /** V8 flag to set the maximum semi space size. Value type: Integer (MiB) */
+  public static final String V8_MAX_SEMI_SPACE_SIZE = "V8MaxSemiSpaceSize";
+
+  public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
+    List<String> extraCommandLineArgs = new ArrayList<>();
+    if (!javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
+      extraCommandLineArgs.add("--disable-quic");
+    }
+    if (!javaSwitches.containsKey(JavaSwitches.DISABLE_LOW_END_DEVICE_MODE)) {
+      extraCommandLineArgs.add("--enable-low-end-device-mode");
+      extraCommandLineArgs.add("--disable-rgba-4444-textures");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.V8_JITLESS)) {
+      extraCommandLineArgs.add("--js-flags=--jitless");
+    }
+    if (javaSwitches.containsKey(JavaSwitches.V8_WRITE_PROTECT_CODE_MEMORY)) {
+      extraCommandLineArgs.add("--js-flags=--write-protect-code-memory");
+    }
+    if (javaSwitches.containsKey(JavaSwitches.V8_GC_INTERVAL)) {
+      extraCommandLineArgs.add(
+          "--js-flags=--gc-interval="
+              + javaSwitches.get(JavaSwitches.V8_GC_INTERVAL).replaceAll("[^0-9]", ""));
+    }
+    if (javaSwitches.containsKey(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE)) {
+      extraCommandLineArgs.add(
+          "--js-flags=--initial-old-space-size="
+              + javaSwitches.get(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE).replaceAll("[^0-9]", ""));
+    }
+    if (javaSwitches.containsKey(JavaSwitches.V8_MAX_OLD_SPACE_SIZE)) {
+      extraCommandLineArgs.add(
+          "--js-flags=--max-old-space-size="
+              + javaSwitches.get(JavaSwitches.V8_MAX_OLD_SPACE_SIZE).replaceAll("[^0-9]", ""));
+    }
+    if (javaSwitches.containsKey(JavaSwitches.V8_MAX_SEMI_SPACE_SIZE)) {
+      extraCommandLineArgs.add(
+          "--js-flags=--max-semi-space-size="
+              + javaSwitches.get(JavaSwitches.V8_MAX_SEMI_SPACE_SIZE).replaceAll("[^0-9]", ""));
+    }
+    return extraCommandLineArgs;
+  }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
@@ -1,0 +1,80 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.util;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+
+/** Tests for JavaSwitches. */
+@RunWith(RobolectricTestRunner.class)
+public class JavaSwitchesTest {
+
+  @Test
+  public void getExtraCommandLineArgs_EmptySwitches() {
+    Map<String, String> javaSwitches = new HashMap<>();
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(javaSwitches);
+
+    // Default switches when none are provided.
+    assertThat(args).contains("--disable-quic");
+    assertThat(args).contains("--enable-low-end-device-mode");
+    assertThat(args).contains("--disable-rgba-4444-textures");
+    assertThat(args).hasSize(3);
+  }
+
+  @Test
+  public void getExtraCommandLineArgs_AllSwitches() {
+    Map<String, String> javaSwitches = new HashMap<>();
+    javaSwitches.put(JavaSwitches.ENABLE_QUIC, "true");
+    javaSwitches.put(JavaSwitches.DISABLE_LOW_END_DEVICE_MODE, "true");
+    javaSwitches.put(JavaSwitches.V8_JITLESS, "true");
+    javaSwitches.put(JavaSwitches.V8_WRITE_PROTECT_CODE_MEMORY, "true");
+    javaSwitches.put(JavaSwitches.V8_GC_INTERVAL, "1000");
+    javaSwitches.put(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE, "128");
+    javaSwitches.put(JavaSwitches.V8_MAX_OLD_SPACE_SIZE, "256");
+    javaSwitches.put(JavaSwitches.V8_MAX_SEMI_SPACE_SIZE, "16");
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(javaSwitches);
+
+    assertThat(args).doesNotContain("--disable-quic");
+    assertThat(args).doesNotContain("--enable-low-end-device-mode");
+    assertThat(args).doesNotContain("--disable-rgba-4444-textures");
+
+    assertThat(args).contains("--js-flags=--jitless");
+    assertThat(args).contains("--js-flags=--write-protect-code-memory");
+    assertThat(args).contains("--js-flags=--gc-interval=1000");
+    assertThat(args).contains("--js-flags=--initial-old-space-size=128");
+    assertThat(args).contains("--js-flags=--max-old-space-size=256");
+    assertThat(args).contains("--js-flags=--max-semi-space-size=16");
+    assertThat(args).hasSize(6);
+  }
+
+  @Test
+  public void getExtraCommandLineArgs_SanitizeValues() {
+    Map<String, String> javaSwitches = new HashMap<>();
+    javaSwitches.put(JavaSwitches.V8_GC_INTERVAL, "1,000ms");
+    javaSwitches.put(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE, "128 MiB");
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(javaSwitches);
+
+    assertThat(args).contains("--js-flags=--gc-interval=1000");
+    assertThat(args).contains("--js-flags=--initial-old-space-size=128");
+  }
+}


### PR DESCRIPTION
This change exposes several V8 engine settings, such as jitless mode and
various garbage collection memory parameters, to be configurable via Java
switches on Android. This provides greater flexibility for embedders to
tune V8's behavior and resource usage based on specific device
requirements and application profiles.

Bug: 477317552