### PR TITLE
keymapping: add Lima M1 RDK defaults and JSON override (#8933)

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -108,6 +108,7 @@ if (rdk_enable_ocdm) {
 
 group("starboard_platform") {
   public_deps = [ ":starboard_platform_sources" ]
+  data_deps = [ ":rdk_cobalt_content" ]
 }
 
 static_library("starboard_platform_sources") {
@@ -369,4 +370,13 @@ static_library("starboard_platform_sources") {
   if (sb_evergreen_compatible_use_libunwind) {
     deps = [ "//third_party/llvm-project/libunwind:unwind_starboard" ]
   }
+}
+
+group("rdk_cobalt_content") {
+  data_deps = [ ":rdk_cobalt_keymap($default_toolchain)" ]
+}
+
+copy("rdk_cobalt_keymap") {
+  sources = [ "cobalt/content/etc/keymapping.json" ]
+  outputs = [ "$root_out_dir/app/cobalt/content/etc/keymapping.json" ]
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/cobalt/content/etc/keymapping.json
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/cobalt/content/etc/keymapping.json
@@ -1,0 +1,19 @@
+{
+  "description": "This struct overrides default key mapping (Lima M1 RDK, t4h) at runtime without rebuilding Cobalt. Use for testing or another remote.",
+  "keymappings": [
+    {
+      "description": "OK/SELECT (KEY_SELECT=353)",
+      "keycode": 353,
+      "mapped": {
+        "keycode": 28
+      }
+    },
+    {
+      "description": "Escape/Back (remote sends KEY_BACKSPACE=14)",
+      "keycode": 14,
+      "mapped": {
+        "keycode": 1
+      }
+    }
+  ]
+}

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/linux_key_mapping.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/linux_key_mapping.cc
@@ -131,6 +131,9 @@ struct LinuxKeyMappingImpl {
     SbKeyModifiers mapped_modifiers;
   };
 
+  // Default mapping for the Lima M1 RDK remote (t4h). It can be overridden at
+  // runtime via keymapping.json ($COBALT_CONTENT_DIR/app/cobalt/content/etc/keymapping.json)
+  // without rebuilding Cobalt—e.g. for testing or to use a different remote.
   std::vector<KeyMapping> key_mappings_ = {
     { KEY_M, kSbKeyModifiersCtrl, KEY_UNKNOWN,     kSbKeyModifiersNone },  // Menu
     { KEY_G, kSbKeyModifiersCtrl, KEY_UNKNOWN,     kSbKeyModifiersNone },  // Guide
@@ -159,6 +162,8 @@ struct LinuxKeyMappingImpl {
 
     { KEY_PAGEDOWN, kSbKeyModifiersNone, KEY_NEXTSONG,   kSbKeyModifiersNone },
     { KEY_PAGEUP, kSbKeyModifiersNone, KEY_PREVIOUSSONG, kSbKeyModifiersNone },
+    { KEY_BACKSPACE, kSbKeyModifiersNone, KEY_ESC, kSbKeyModifiersNone },
+    { KEY_SELECT, kSbKeyModifiersNone, KEY_ENTER, kSbKeyModifiersNone },
   };
 
   void UpdateKeyMapping(


### PR DESCRIPTION
starboard: Add Lima M1 RDK key mapping defaults (#8933)

This change introduces default key mappings for the Lima M1 RDK remote,
mapping `KEY_BACKSPACE` to `ESC` and `KEY_SELECT` to `ENTER`.

These default mappings can be overridden at runtime by providing a
keymapping.json file in the application's content directory, allowing
for flexible customization without rebuilding Cobalt. The build system
is updated to install this configuration file.

Issue: 448459059