### PR TITLE
starboard: Use factories for Android AudioTrack classes

### DIFF
--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -411,17 +411,16 @@ void AudioRendererPassthrough::CreateAudioTrackAndStartProcessing() {
     return;
   }
 
-  std::unique_ptr<AudioTrackBridge> audio_track_bridge(new AudioTrackBridge(
+  auto audio_track_bridge = AudioTrackBridge::Create(
       audio_stream_info_.codec == kSbMediaAudioCodecAc3
           ? kSbMediaAudioCodingTypeAc3
           : kSbMediaAudioCodingTypeDolbyDigitalPlus,
-      std::optional<SbMediaAudioSampleType>(),  // Not required in passthrough
-                                                // mode
-      audio_stream_info_.number_of_channels,
+      // passthrough mode does not need sample_type
+      /*sample_type=*/std::nullopt, audio_stream_info_.number_of_channels,
       audio_stream_info_.samples_per_second, kPreferredBufferSizeInBytes,
-      kTunnelModeAudioSessionId, false /* is_web_audio */));
+      kTunnelModeAudioSessionId, /*is_web_audio=*/false);
 
-  if (!audio_track_bridge->is_valid()) {
+  if (!audio_track_bridge) {
     error_cb_(kSbPlayerErrorDecode, "Error creating AudioTrackBridge");
     return;
   }
@@ -455,7 +454,7 @@ void AudioRendererPassthrough::FlushAudioTrackAndStopProcessing(
   // silence can be observed after seeking on some audio receivers.
   // TODO: Consider reusing audio sink for non-passthrough playbacks, to see if
   //       it reduces latency after seeking.
-  if (audio_track_bridge_ && audio_track_bridge_->is_valid()) {
+  if (audio_track_bridge_) {
     audio_track_bridge_->PauseAndFlush();
   }
   seek_to_time_ = seek_to_time;

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -126,19 +126,17 @@ void MinRequiredFramesTester::TesterThreadFunc() {
       is_test_complete_ = false;
     }
 
-    audio_sink_ =
-        AudioTrackAudioSink::Create(
-            /*type=*/nullptr, task.number_of_channels, task.sample_rate,
-            task.sample_type, frame_buffers, max_required_frames_,
-            min_required_frames_ * task.number_of_channels *
-                GetSampleSize(task.sample_type),
-            &MinRequiredFramesTester::UpdateSourceStatusFunc,
-            &MinRequiredFramesTester::ConsumeFramesFunc,
-            &MinRequiredFramesTester::ErrorFunc,
-            /*start_media_time=*/0,
-            /*tunnel_mode_audio_session_id=*/-1,
-            /*is_web_audio=*/false, /*context=*/this)
-            .release();
+    audio_sink_ = AudioTrackAudioSink::Create(
+        /*type=*/nullptr, task.number_of_channels, task.sample_rate,
+        task.sample_type, frame_buffers, max_required_frames_,
+        min_required_frames_ * task.number_of_channels *
+            GetSampleSize(task.sample_type),
+        &MinRequiredFramesTester::UpdateSourceStatusFunc,
+        &MinRequiredFramesTester::ConsumeFramesFunc,
+        &MinRequiredFramesTester::ErrorFunc,
+        /*start_media_time=*/0,
+        /*tunnel_mode_audio_session_id=*/-1,
+        /*is_web_audio=*/false, /*context=*/this);
     if (!audio_sink_) {
       SB_LOG(ERROR) << "Failed to create audio sink.";
       // Mark as complete so we can continue with the next task.
@@ -163,8 +161,7 @@ void MinRequiredFramesTester::TesterThreadFunc() {
     // |min_required_frames_| is shared between two threads. Release audio sink
     // to end audio sink thread before access |min_required_frames_| on this
     // thread.
-    delete audio_sink_;
-    audio_sink_ = nullptr;
+    audio_sink_.reset();
 
     if (wait_timeout) {
       SB_LOG(ERROR) << "Audio sink min required frames tester timeout.";

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.h
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.h
@@ -106,7 +106,7 @@ class MinRequiredFramesTester {
   ThreadChecker thread_checker_;
 
   std::vector<TestTask> test_tasks_;
-  AudioTrackAudioSink* audio_sink_ = nullptr;
+  std::unique_ptr<AudioTrackAudioSink> audio_sink_;
   int min_required_frames_;
   std::atomic_bool has_error_;
 

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -99,7 +99,25 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
 
 class AudioTrackAudioSink : public SbAudioSinkImpl {
  public:
+  static std::unique_ptr<AudioTrackAudioSink> Create(
+      Type* type,
+      int channels,
+      int sampling_frequency_hz,
+      SbMediaAudioSampleType sample_type,
+      SbAudioSinkFrameBuffers frame_buffers,
+      int frames_per_channel,
+      int preferred_buffer_size,
+      SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
+      ConsumeFramesFunc consume_frames_func,
+      SbAudioSinkPrivate::ErrorFunc error_func,
+      int64_t start_media_time,
+      int tunnel_mode_audio_session_id,
+      bool is_web_audio,
+      void* context);
+
   AudioTrackAudioSink(
+      PassKey<AudioTrackAudioSink>,
+      std::unique_ptr<AudioTrackBridge> bridge,
       Type* type,
       int channels,
       int sampling_frequency_hz,
@@ -116,7 +134,6 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       void* context);
   ~AudioTrackAudioSink() override;
 
-  bool IsAudioTrackValid() const { return bridge_.is_valid(); }
   bool IsType(Type* type) override { return type_ == type; }
   void SetPlaybackRate(double playback_rate) override;
 
@@ -148,10 +165,10 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const int max_frames_per_request_;
   void* const context_;
 
-  AudioTrackBridge bridge_;
+  const std::unique_ptr<AudioTrackBridge> bridge_;
 
   volatile bool quit_ = false;
-  std::unique_ptr<Thread> audio_out_thread_;
+  const std::unique_ptr<Thread> audio_out_thread_;
 
   std::mutex mutex_;
   double playback_rate_ = 1.0;

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -40,7 +40,8 @@ const jint kNoOffset = 0;
 
 }  // namespace
 
-AudioTrackBridge::AudioTrackBridge(
+// static
+std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
     SbMediaAudioCodingType coding_type,
     std::optional<SbMediaAudioSampleType> sample_type,
     int channels,
@@ -80,23 +81,24 @@ AudioTrackBridge::AudioTrackBridge(
     // TODO: Currently this will be reported as a general decode error,
     //       investigate if this can be reported as a capability changed error.
     SB_LOG(WARNING) << "Failed to create |j_audio_track_bridge|.";
-    return;
+    return nullptr;
   }
 
-  j_audio_track_bridge_.Reset(j_audio_track_bridge);
-
+  int max_samples_per_write = 0;
+  ScopedJavaLocalRef<jobject> j_audio_data;
   if (coding_type != kSbMediaAudioCodingTypePcm) {
     // This must be passthrough.
     SB_DCHECK(!sample_type);
-    max_samples_per_write_ = kMaxFramesPerRequest;
-    j_audio_data_.Reset(env, env->NewByteArray(max_samples_per_write_));
+    max_samples_per_write = kMaxFramesPerRequest;
+    j_audio_data = ScopedJavaLocalRef<jobject>(
+        env, env->NewByteArray(max_samples_per_write));
   } else if (sample_type == kSbMediaAudioSampleTypeFloat32) {
-    max_samples_per_write_ = channels * kMaxFramesPerRequest;
-    j_audio_data_.Reset(env,
-                        env->NewFloatArray(channels * kMaxFramesPerRequest));
+    max_samples_per_write = channels * kMaxFramesPerRequest;
+    j_audio_data = ScopedJavaLocalRef<jobject>(
+        env, env->NewFloatArray(channels * kMaxFramesPerRequest));
   } else if (sample_type == kSbMediaAudioSampleTypeInt16Deprecated) {
-    max_samples_per_write_ = channels * kMaxFramesPerRequest;
-    j_audio_data_.Reset(
+    max_samples_per_write = channels * kMaxFramesPerRequest;
+    j_audio_data = ScopedJavaLocalRef<jobject>(
         env,
         env->NewByteArray(channels * GetBytesPerSample(sample_type.value()) *
                           kMaxFramesPerRequest));
@@ -104,7 +106,27 @@ AudioTrackBridge::AudioTrackBridge(
     SB_NOTREACHED();
   }
 
-  SB_DCHECK(j_audio_data_) << "Failed to allocate |j_audio_data_|";
+  if (j_audio_data.is_null()) {
+    SB_LOG(ERROR) << "Failed to allocate |j_audio_data_|";
+    return nullptr;
+  }
+
+  return std::make_unique<AudioTrackBridge>(
+      PassKey<AudioTrackBridge>(),
+      ScopedJavaGlobalRef<jobject>(env, j_audio_track_bridge),
+      ScopedJavaGlobalRef<jobject>(env, j_audio_data), max_samples_per_write);
+}
+
+AudioTrackBridge::AudioTrackBridge(
+    PassKey<AudioTrackBridge>,
+    ScopedJavaGlobalRef<jobject> j_audio_track_bridge,
+    ScopedJavaGlobalRef<jobject> j_audio_data,
+    int max_samples_per_write)
+    : max_samples_per_write_(max_samples_per_write),
+      j_audio_track_bridge_(std::move(j_audio_track_bridge)),
+      j_audio_data_(std::move(j_audio_data)) {
+  SB_CHECK(j_audio_track_bridge_);
+  SB_CHECK(j_audio_data_);
 }
 
 AudioTrackBridge::~AudioTrackBridge() {
@@ -122,7 +144,6 @@ AudioTrackBridge::~AudioTrackBridge() {
 
 void AudioTrackBridge::Play(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   Java_AudioTrackBridge_play(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge playing.";
@@ -130,7 +151,6 @@ void AudioTrackBridge::Play(JNIEnv* env /*= AttachCurrentThread()*/) {
 
 void AudioTrackBridge::Pause(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   Java_AudioTrackBridge_pause(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge paused.";
@@ -138,7 +158,6 @@ void AudioTrackBridge::Pause(JNIEnv* env /*= AttachCurrentThread()*/) {
 
 void AudioTrackBridge::Stop(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   Java_AudioTrackBridge_stop(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge stopped.";
@@ -146,7 +165,6 @@ void AudioTrackBridge::Stop(JNIEnv* env /*= AttachCurrentThread()*/) {
 
 void AudioTrackBridge::PauseAndFlush(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   // For an immediate stop, use pause(), followed by flush() to discard audio
   // data that hasn't been played back yet.
@@ -160,7 +178,6 @@ int AudioTrackBridge::WriteSample(const float* samples,
                                   int num_of_samples,
                                   JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
   SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
@@ -183,7 +200,6 @@ int AudioTrackBridge::WriteSample(const uint16_t* samples,
                                   int64_t sync_time,
                                   JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
   SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
@@ -215,7 +231,6 @@ int AudioTrackBridge::WriteSample(const uint8_t* samples,
                                   int64_t sync_time,
                                   JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
   SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
@@ -244,7 +259,6 @@ int AudioTrackBridge::WriteSample(const uint8_t* samples,
 void AudioTrackBridge::SetVolume(double volume,
                                  JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   jint status = Java_AudioTrackBridge_setVolume(env, j_audio_track_bridge_,
                                                 static_cast<float>(volume));
@@ -257,7 +271,6 @@ int64_t AudioTrackBridge::GetAudioTimestamp(
     int64_t* updated_at,
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   ScopedJavaLocalRef<jobject> j_audio_timestamp =
       Java_AudioTrackBridge_getAudioTimestamp(env, j_audio_track_bridge_);
@@ -273,7 +286,6 @@ int64_t AudioTrackBridge::GetAudioTimestamp(
 bool AudioTrackBridge::GetAndResetHasAudioDeviceChanged(
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   return AudioOutputManager::GetInstance()->GetAndResetHasAudioDeviceChanged(
       env);
@@ -282,7 +294,6 @@ bool AudioTrackBridge::GetAndResetHasAudioDeviceChanged(
 int AudioTrackBridge::GetUnderrunCount(
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   return Java_AudioTrackBridge_getUnderrunCount(env, j_audio_track_bridge_);
 }
@@ -290,7 +301,6 @@ int AudioTrackBridge::GetUnderrunCount(
 int AudioTrackBridge::GetStartThresholdInFrames(
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   return Java_AudioTrackBridge_getStartThresholdInFrames(env,
                                                          j_audio_track_bridge_);

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -107,7 +107,7 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
   }
 
   if (j_audio_data.is_null()) {
-    SB_LOG(ERROR) << "Failed to allocate |j_audio_data_|";
+    SB_LOG(ERROR) << "Failed to allocate |j_audio_data|";
     return nullptr;
   }
 


### PR DESCRIPTION
Introduce static Create() factory methods for AudioTrackBridge and AudioTrackAudioSink, guaranteeing that instantiated objects are always in a fully valid state upon creation.

This change enforces object invariants at the point of creation, eliminates the need for redundant is_valid() checks, and prevents the existence of partially initialized objects. The PassKey pattern is used to restrict constructor access to the factory methods.

Bug: 479994435