### PR TITLE
starboard: Use factories for Android Drm classes

### DIFF
--- a/starboard/android/shared/drm_create_system.cc
+++ b/starboard/android/shared/drm_create_system.cc
@@ -40,12 +40,11 @@ SbDrmSystem SbDrmCreateSystem(
     return kSbDrmSystemInvalid;
   }
 
-  DrmSystem* drm_system =
-      new DrmSystem(key_system, context, update_request_callback,
-                    session_updated_callback, key_statuses_changed_callback);
-  if (!drm_system->is_valid()) {
-    delete drm_system;
+  std::unique_ptr<DrmSystem> drm_system = DrmSystem::Create(
+      key_system, context, update_request_callback, session_updated_callback,
+      key_statuses_changed_callback);
+  if (!drm_system) {
     return kSbDrmSystemInvalid;
   }
-  return drm_system;
+  return drm_system.release();
 }

--- a/starboard/android/shared/drm_create_system.cc
+++ b/starboard/android/shared/drm_create_system.cc
@@ -40,9 +40,10 @@ SbDrmSystem SbDrmCreateSystem(
     return kSbDrmSystemInvalid;
   }
 
-  std::unique_ptr<DrmSystem> drm_system = DrmSystem::Create(
-      key_system, context, update_request_callback, session_updated_callback,
-      key_statuses_changed_callback);
+  std::unique_ptr<DrmSystem> drm_system =
+      DrmSystem::Create(key_system, context,
+                        {update_request_callback, session_updated_callback,
+                         key_statuses_changed_callback});
   if (!drm_system) {
     return kSbDrmSystemInvalid;
   }

--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -77,13 +77,15 @@ DrmSystem::DrmSystem(PassKey<DrmSystem>,
       enable_app_provisioning_(
           features::FeatureList::IsEnabled(features::kEnableAppProvisioning)),
       context_(context),
-      update_request_callback_(callbacks.update_request),
-      session_updated_callback_(callbacks.session_updated),
-      key_statuses_changed_callback_(callbacks.key_statuses_changed),
+      callbacks_(callbacks),
       hdcp_lost_(false),
       session_id_mapper_(enable_app_provisioning_
                              ? std::make_unique<DrmSessionIdMapper>()
                              : nullptr) {
+  SB_CHECK(callbacks_.update_request);
+  SB_CHECK(callbacks_.session_updated);
+  SB_CHECK(callbacks_.key_statuses_changed);
+
   ON_INSTANCE_CREATED(AndroidDrmSystem);
 
   media_drm_bridge_ =
@@ -236,7 +238,7 @@ void DrmSystem::UpdateSession(int ticket,
   MediaDrmBridge::OperationResult result = media_drm_bridge_->UpdateSession(
       ticket, std::string_view(static_cast<const char*>(key), key_size),
       std::string_view(static_cast<const char*>(session_id), session_id_size));
-  session_updated_callback_(
+  callbacks_.session_updated(
       this, context_, ticket,
       result.ok() ? kSbDrmStatusSuccess : kSbDrmStatusUnknownError,
       result.error_message.c_str(), session_id, session_id_size);
@@ -274,7 +276,7 @@ void DrmSystem::UpdateSessionWithAppProvisioning(int ticket,
 
   SB_LOG_IF(ERROR, !result.ok()) << "UpdateSession failed: " << result;
 
-  session_updated_callback_(
+  callbacks_.session_updated(
       this, context_, ticket,
       result.ok() ? kSbDrmStatusSuccess : kSbDrmStatusUnknownError,
       result.error_message.c_str(), session_id.data(), session_id.size());
@@ -357,10 +359,10 @@ void DrmSystem::OnSessionUpdate(int ticket,
     eme_session_id = session_id;
   }
 
-  update_request_callback_(this, context_, ticket, kSbDrmStatusSuccess,
-                           request_type, /*error_message=*/nullptr,
-                           eme_session_id.data(), eme_session_id.size(),
-                           content.data(), content.size(), kNoUrl);
+  callbacks_.update_request(this, context_, ticket, kSbDrmStatusSuccess,
+                            request_type, /*error_message=*/nullptr,
+                            eme_session_id.data(), eme_session_id.size(),
+                            content.data(), content.size(), kNoUrl);
 }
 
 void DrmSystem::OnProvisioningRequest(std::string_view content) {
@@ -380,11 +382,11 @@ void DrmSystem::OnProvisioningRequest(std::string_view content) {
   }
 
   SB_LOG(INFO) << "Return provision request using pending ticket=" << ticket;
-  update_request_callback_(this, context_, ticket, kSbDrmStatusSuccess,
-                           kSbDrmSessionRequestTypeIndividualizationRequest,
-                           /*error_message=*/nullptr, eme_session_id.data(),
-                           eme_session_id.size(), content.data(),
-                           content.size(), kNoUrl);
+  callbacks_.update_request(this, context_, ticket, kSbDrmStatusSuccess,
+                            kSbDrmSessionRequestTypeIndividualizationRequest,
+                            /*error_message=*/nullptr, eme_session_id.data(),
+                            eme_session_id.size(), content.data(),
+                            content.size(), kNoUrl);
 }
 
 void DrmSystem::OnKeyStatusChange(
@@ -412,10 +414,10 @@ void DrmSystem::OnKeyStatusChange(
     }
   }
 
-  key_statuses_changed_callback_(this, context_, eme_session_id.data(),
-                                 eme_session_id.size(),
-                                 static_cast<int>(drm_key_ids.size()),
-                                 drm_key_ids.data(), drm_key_statuses.data());
+  callbacks_.key_statuses_changed(this, context_, eme_session_id.data(),
+                                  eme_session_id.size(),
+                                  static_cast<int>(drm_key_ids.size()),
+                                  drm_key_ids.data(), drm_key_statuses.data());
 }
 
 void DrmSystem::OnInsufficientOutputProtection() {
@@ -436,10 +438,10 @@ void DrmSystem::CallKeyStatusesChangedCallbackWithKeyStatusRestricted_Locked() {
     std::vector<SbDrmKeyStatus> drm_key_statuses(drm_key_ids.size(),
                                                  kSbDrmKeyStatusRestricted);
 
-    key_statuses_changed_callback_(this, context_, session_id.data(),
-                                   session_id.size(),
-                                   static_cast<int>(drm_key_ids.size()),
-                                   drm_key_ids.data(), drm_key_statuses.data());
+    callbacks_.key_statuses_changed(
+        this, context_, session_id.data(), session_id.size(),
+        static_cast<int>(drm_key_ids.size()), drm_key_ids.data(),
+        drm_key_statuses.data());
   }
 }
 

--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -56,7 +56,24 @@ DECLARE_INSTANCE_COUNTER(AndroidDrmSystem)
 
 }  // namespace
 
+// static
+std::unique_ptr<DrmSystem> DrmSystem::Create(
+    std::string_view key_system,
+    void* context,
+    SbDrmSessionUpdateRequestFunc update_request_callback,
+    SbDrmSessionUpdatedFunc session_updated_callback,
+    SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback) {
+  auto drm_system = std::make_unique<DrmSystem>(
+      PassKey<DrmSystem>(), key_system, context, update_request_callback,
+      session_updated_callback, key_statuses_changed_callback);
+  if (!drm_system->media_drm_bridge_) {
+    return nullptr;
+  }
+  return drm_system;
+}
+
 DrmSystem::DrmSystem(
+    PassKey<DrmSystem>,
     std::string_view key_system,
     void* context,
     SbDrmSessionUpdateRequestFunc update_request_callback,
@@ -76,10 +93,10 @@ DrmSystem::DrmSystem(
                              : nullptr) {
   ON_INSTANCE_CREATED(AndroidDrmSystem);
 
-  media_drm_bridge_ = std::make_unique<MediaDrmBridge>(
+  media_drm_bridge_ = MediaDrmBridge::Create(
       base::raw_ref<MediaDrmBridge::Host>(*this), key_system_,
       enable_app_provisioning_);
-  if (!media_drm_bridge_->is_valid()) {
+  if (!media_drm_bridge_) {
     return;
   }
   SB_LOG(INFO) << "Creating DrmSystem: key_system=" << key_system

--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -57,36 +57,29 @@ DECLARE_INSTANCE_COUNTER(AndroidDrmSystem)
 }  // namespace
 
 // static
-std::unique_ptr<DrmSystem> DrmSystem::Create(
-    std::string_view key_system,
-    void* context,
-    SbDrmSessionUpdateRequestFunc update_request_callback,
-    SbDrmSessionUpdatedFunc session_updated_callback,
-    SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback) {
-  auto drm_system = std::make_unique<DrmSystem>(
-      PassKey<DrmSystem>(), key_system, context, update_request_callback,
-      session_updated_callback, key_statuses_changed_callback);
+std::unique_ptr<DrmSystem> DrmSystem::Create(std::string_view key_system,
+                                             void* context,
+                                             Callbacks callbacks) {
+  auto drm_system = std::make_unique<DrmSystem>(PassKey<DrmSystem>(),
+                                                key_system, context, callbacks);
   if (!drm_system->media_drm_bridge_) {
     return nullptr;
   }
   return drm_system;
 }
 
-DrmSystem::DrmSystem(
-    PassKey<DrmSystem>,
-    std::string_view key_system,
-    void* context,
-    SbDrmSessionUpdateRequestFunc update_request_callback,
-    SbDrmSessionUpdatedFunc session_updated_callback,
-    SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback)
+DrmSystem::DrmSystem(PassKey<DrmSystem>,
+                     std::string_view key_system,
+                     void* context,
+                     Callbacks callbacks)
     : Thread("DrmSystemThread"),
       key_system_(key_system),
       enable_app_provisioning_(
           features::FeatureList::IsEnabled(features::kEnableAppProvisioning)),
       context_(context),
-      update_request_callback_(update_request_callback),
-      session_updated_callback_(session_updated_callback),
-      key_statuses_changed_callback_(key_statuses_changed_callback),
+      update_request_callback_(callbacks.update_request),
+      session_updated_callback_(callbacks.session_updated),
+      key_statuses_changed_callback_(callbacks.key_statuses_changed),
       hdcp_lost_(false),
       session_id_mapper_(enable_app_provisioning_
                              ? std::make_unique<DrmSessionIdMapper>()

--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -93,9 +93,9 @@ DrmSystem::DrmSystem(
                              : nullptr) {
   ON_INSTANCE_CREATED(AndroidDrmSystem);
 
-  media_drm_bridge_ = MediaDrmBridge::Create(
-      base::raw_ref<MediaDrmBridge::Host>(*this), key_system_,
-      enable_app_provisioning_);
+  media_drm_bridge_ =
+      MediaDrmBridge::Create(base::raw_ref<MediaDrmBridge::Host>(*this),
+                             key_system_, enable_app_provisioning_);
   if (!media_drm_bridge_) {
     return;
   }

--- a/starboard/android/shared/drm_system.h
+++ b/starboard/android/shared/drm_system.h
@@ -32,6 +32,7 @@
 #include "starboard/android/shared/drm_session_id_mapper.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/media_drm_bridge.h"
+#include "starboard/common/pass_key.h"
 #include "starboard/common/thread.h"
 #include "starboard/shared/starboard/thread_checker.h"
 
@@ -41,7 +42,15 @@ class DrmSystem : public ::SbDrmSystemPrivate,
                   public MediaDrmBridge::Host,
                   private Thread {
  public:
-  DrmSystem(std::string_view key_system,
+  static std::unique_ptr<DrmSystem> Create(
+      std::string_view key_system,
+      void* context,
+      SbDrmSessionUpdateRequestFunc update_request_callback,
+      SbDrmSessionUpdatedFunc session_updated_callback,
+      SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback);
+
+  DrmSystem(PassKey<DrmSystem>,
+            std::string_view key_system,
             void* context,
             SbDrmSessionUpdateRequestFunc update_request_callback,
             SbDrmSessionUpdatedFunc session_updated_callback,
@@ -83,7 +92,6 @@ class DrmSystem : public ::SbDrmSystemPrivate,
 
   void OnInsufficientOutputProtection();
 
-  bool is_valid() const { return media_drm_bridge_->is_valid(); }
   bool require_secured_decoder() const {
     return IsWidevineL1(key_system_.c_str());
   }

--- a/starboard/android/shared/drm_system.h
+++ b/starboard/android/shared/drm_system.h
@@ -42,19 +42,19 @@ class DrmSystem : public ::SbDrmSystemPrivate,
                   public MediaDrmBridge::Host,
                   private Thread {
  public:
-  static std::unique_ptr<DrmSystem> Create(
-      std::string_view key_system,
-      void* context,
-      SbDrmSessionUpdateRequestFunc update_request_callback,
-      SbDrmSessionUpdatedFunc session_updated_callback,
-      SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback);
+  struct Callbacks {
+    SbDrmSessionUpdateRequestFunc update_request;
+    SbDrmSessionUpdatedFunc session_updated;
+    SbDrmSessionKeyStatusesChangedFunc key_statuses_changed;
+  };
+  static std::unique_ptr<DrmSystem> Create(std::string_view key_system,
+                                           void* context,
+                                           Callbacks callbacks);
 
   DrmSystem(PassKey<DrmSystem>,
             std::string_view key_system,
             void* context,
-            SbDrmSessionUpdateRequestFunc update_request_callback,
-            SbDrmSessionUpdatedFunc session_updated_callback,
-            SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback);
+            Callbacks callbacks);
 
   ~DrmSystem() override;
   // SbDrmSystemPrivate override begins

--- a/starboard/android/shared/drm_system.h
+++ b/starboard/android/shared/drm_system.h
@@ -136,10 +136,8 @@ class DrmSystem : public ::SbDrmSystemPrivate,
   const std::string key_system_;
   const bool enable_app_provisioning_;
   void* context_;
-  SbDrmSessionUpdateRequestFunc update_request_callback_;
-  SbDrmSessionUpdatedFunc session_updated_callback_;
   // TODO: Update key statuses to Cobalt.
-  SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback_;
+  const Callbacks callbacks_;
 
   std::mutex mutex_;
 

--- a/starboard/android/shared/media_drm_bridge.h
+++ b/starboard/android/shared/media_drm_bridge.h
@@ -118,6 +118,9 @@ class MediaDrmBridge {
   // Instances are only returned if initialization succeeds; therefore, this
   // member is guaranteed to be valid for the lifetime of the object.
   base::android::ScopedJavaGlobalRef<jobject> j_media_drm_bridge_;
+
+  // |j_media_crypto_| is non-null after initialization, but may be reset
+  // via CreateMediaCryptoSession() if a session creation failure occurs.
   base::android::ScopedJavaGlobalRef<jobject> j_media_crypto_;
 };
 

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -447,9 +447,13 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
     SB_DCHECK(!drm_system_);
     // To create secure pipeline for tunnel mode, we need use
     // L1("com.widevine.alpha").
-    drm_system_to_enforce_tunnel_mode_ = std::make_unique<DrmSystem>(
+    drm_system_to_enforce_tunnel_mode_ = DrmSystem::Create(
         "com.widevine.alpha", nullptr, StubDrmSessionUpdateRequestFunc,
         StubDrmSessionUpdatedFunc, StubDrmSessionKeyStatusesChangedFunc);
+    if (!drm_system_to_enforce_tunnel_mode_) {
+      *error_message = "Failed to create drm_system_to_enforce_tunnel_mode_";
+      return;
+    }
     drm_system_ = drm_system_to_enforce_tunnel_mode_.get();
   }
 

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -451,7 +451,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
         "com.widevine.alpha", nullptr, StubDrmSessionUpdateRequestFunc,
         StubDrmSessionUpdatedFunc, StubDrmSessionKeyStatusesChangedFunc);
     if (!drm_system_to_enforce_tunnel_mode_) {
-      *error_message = "Failed to create drm_system_to_enforce_tunnel_mode_";
+      *error_message = "Failed to create DrmSystem for tunnel mode enforcement.";
       return;
     }
     drm_system_ = drm_system_to_enforce_tunnel_mode_.get();

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -451,7 +451,8 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
         "com.widevine.alpha", nullptr, StubDrmSessionUpdateRequestFunc,
         StubDrmSessionUpdatedFunc, StubDrmSessionKeyStatusesChangedFunc);
     if (!drm_system_to_enforce_tunnel_mode_) {
-      *error_message = "Failed to create DrmSystem for tunnel mode enforcement.";
+      *error_message =
+          "Failed to create DrmSystem for tunnel mode enforcement.";
       return;
     }
     drm_system_ = drm_system_to_enforce_tunnel_mode_.get();

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -14,7 +14,6 @@
 
 #include "starboard/android/shared/video_decoder.h"
 
-#include <android/api-level.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -50,7 +49,6 @@ namespace {
 
 using base::android::AttachCurrentThread;
 using base::android::JavaParamRef;
-using base::android::ScopedJavaLocalRef;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
@@ -268,6 +266,9 @@ void StubDrmSessionKeyStatusesChangedFunc(SbDrmSystem drm_system,
                                           const SbDrmKeyId* key_ids,
                                           const SbDrmKeyStatus* key_statuses) {}
 
+const DrmSystem::Callbacks kStubDrmSystemCallbacks = {
+    StubDrmSessionUpdateRequestFunc, StubDrmSessionUpdatedFunc,
+    StubDrmSessionKeyStatusesChangedFunc};
 }  // namespace
 
 // TODO: Merge this with VideoFrameTracker, maybe?
@@ -448,17 +449,15 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
     // To create secure pipeline for tunnel mode, we need use
     // L1("com.widevine.alpha").
 
-    auto drm_system = DrmSystem::Create(
-        "com.widevine.alpha", /*context=*/nullptr,
-        StubDrmSessionUpdateRequestFunc, StubDrmSessionUpdatedFunc,
-        StubDrmSessionKeyStatusesChangedFunc);
-    if (!drm_system) {
+    auto tunnel_mode_drm_system = DrmSystem::Create(
+        "com.widevine.alpha", /*context=*/nullptr, kStubDrmSystemCallbacks);
+    if (!tunnel_mode_drm_system) {
       *error_message =
           "Failed to create DrmSystem for tunnel mode enforcement.";
       return;
     }
 
-    drm_system_to_enforce_tunnel_mode_ = std::move(drm_system);
+    drm_system_to_enforce_tunnel_mode_ = std::move(tunnel_mode_drm_system);
     drm_system_ = drm_system_to_enforce_tunnel_mode_.get();
   }
 

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -448,8 +448,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
     // To create secure pipeline for tunnel mode, we need use
     // L1("com.widevine.alpha").
     drm_system_to_enforce_tunnel_mode_ = DrmSystem::Create(
-        "com.widevine.alpha", nullptr, StubDrmSessionUpdateRequestFunc,
-        StubDrmSessionUpdatedFunc, StubDrmSessionKeyStatusesChangedFunc);
+        "com.widevine.alpha", /*context=*/nullptr,
+        StubDrmSessionUpdateRequestFunc, StubDrmSessionUpdatedFunc,
+        StubDrmSessionKeyStatusesChangedFunc);
     if (!drm_system_to_enforce_tunnel_mode_) {
       *error_message =
           "Failed to create DrmSystem for tunnel mode enforcement.";

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -447,15 +447,18 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
     SB_DCHECK(!drm_system_);
     // To create secure pipeline for tunnel mode, we need use
     // L1("com.widevine.alpha").
-    drm_system_to_enforce_tunnel_mode_ = DrmSystem::Create(
+
+    auto drm_system = DrmSystem::Create(
         "com.widevine.alpha", /*context=*/nullptr,
         StubDrmSessionUpdateRequestFunc, StubDrmSessionUpdatedFunc,
         StubDrmSessionKeyStatusesChangedFunc);
-    if (!drm_system_to_enforce_tunnel_mode_) {
+    if (!drm_system) {
       *error_message =
           "Failed to create DrmSystem for tunnel mode enforcement.";
       return;
     }
+
+    drm_system_to_enforce_tunnel_mode_ = std::move(drm_system);
     drm_system_ = drm_system_to_enforce_tunnel_mode_.get();
   }
 


### PR DESCRIPTION
Introduce static Create() factory methods for AudioTrackBridge,
AudioTrackAudioSink, DrmSystem, and MediaDrmBridge, using the PassKey
pattern to restrict direct constructor access.

This change guarantees that instantiated objects are always in a fully
valid state upon creation, eliminating the need for redundant is_valid()
checks and preventing partially initialized objects. MediaDrmBridge now
uses a refined two-step initialization within its factory to link with
its Java counterpart.

Bug: 479994435