### PR TITLE
[POC] media: increase yield limit to 1MB for 4K stability

### DIFF
--- a/media/filters/source_buffer_state.cc
+++ b/media/filters/source_buffer_state.cc
@@ -212,10 +212,15 @@ StreamParser::ParseStatus SourceBufferState::RunSegmentParserLoop(
   append_window_end_during_append_ = append_window_end;
   timestamp_offset_during_append_ = timestamp_offset;
 
+  // Cobalt override: Increase yield limit from 128KB to 1MB to prevent 4K                                                                   
+  // VP9 fragments from over-yielding and causing Main Thread starvation. 
+  // This is for PoC.
+  constexpr int kMaxPendingBytesPerParseOverride = 1024 * 1024;
+
   // TODO(wolenetz): Curry and pass a NewBuffersCB here bound with append window
   // and timestamp offset pointer. See http://crbug.com/351454.
   StreamParser::ParseStatus result =
-      stream_parser_->Parse(StreamParser::kMaxPendingBytesPerParse);
+      stream_parser_->Parse(kMaxPendingBytesPerParseOverride);
 
   if (result == StreamParser::ParseStatus::kFailed) {
     MEDIA_LOG(ERROR, media_log_)


### PR DESCRIPTION
Override the incremental parse yield limit from 128KB to 1MB in
`SourceBufferState::RunSegmentParserLoop`. This change specifically targets 
MSE appends for high-bitrate 4K VP9 streams where large video chunks 
(e.g., 4MB+) currently require dozens of yield-and-post cycles.

In Cobalt architecture, these frequent 
yields allow heavy JavaScript tasks to "hijack" the thread, trapping 
the demuxer in the task queue and starving the video decoder. This 
starvation was identified as a primary cause of the 6.6s visual freezes 
documented in b/479274687.

By reducing the yield frequency by 8x, we ensure the demuxer finishes 
meaningful work in fewer slices, maintaining consistent data flow to 
the video decoder even during heavy JS activity.

Risk to Verify:
Increasing this limit increases the "atomic" execution time of media 
parsing, which will defer JavaScript and UI task processing. This 
could manifest as:
1. Input Latency: Remote control commands might feel laggy or "sticky" 
   during 4K startup or seeking.
2. UI Jank: Loading spinners or progress bars may stutter if a 1MB parse 
   takes >50ms on lower-spec hardware.
3. Watchdog Triggers: On extremely slow devices, a single 1MB parse 
   might take long enough to trigger "MainThread Hang" warnings.

Issue: 479274687
