### PR TITLE
android: Fix ClientLogInfo and AdvertisingId leaks

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/AdvertisingId.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/AdvertisingId.java
@@ -44,6 +44,10 @@ public class AdvertisingId {
     refresh();
   }
 
+  public void shutdown() {
+    singleThreadExecutor.shutdown();
+  }
+
   public void refresh() {
     singleThreadExecutor.execute(
         () -> {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -207,6 +207,7 @@ public class StarboardBridge {
       Log.i(TAG, "Activity destroyed after shutdown; killing app.");
       StarboardBridgeJni.get().closeNativeStarboard(nativeApp);
       closeAllServices();
+      advertisingId.shutdown();
       activity.finishAndRemoveTask();
     } else {
       Log.i(TAG, "Activity destroyed without shutdown; app suspended in background.");
@@ -679,7 +680,11 @@ public class StarboardBridge {
   }
 
   public void closeCobaltService(String serviceName) {
-    cobaltServices.remove(serviceName);
+    CobaltService service = cobaltServices.get(serviceName);
+    if(service != null) {
+      service.onClose();
+      cobaltServices.remove(serviceName);
+    }
     Log.i(TAG, String.format("Closed platform service %s.", serviceName));
   }
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/libraries/services/clientloginfo/ClientLogInfo.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/libraries/services/clientloginfo/ClientLogInfo.java
@@ -67,7 +67,9 @@ public class ClientLogInfo extends CobaltService {
   }
 
   @Override
-  public void close() {}
+  public void close() {
+    mExecutor.shutdown();
+  }
 
   public static void setClientInfo(String value) {
     sClientInfo = value;


### PR DESCRIPTION
Ensure that executor services in ClientLogInfo and AdvertisingId are
properly shut down when their respective components are closed or
when the application is being destroyed. This prevents thread leaks
and ensures all resources are released, improving application stability
and preventing potential ANRs on shutdown.

Bug: 484183546