### PR TITLE
starboard: Use common AlignUp implementation from pointer_arithmetic.h

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -32,6 +32,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/common/media.h"
+#include "starboard/common/pointer_arithmetic.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/opus/opus_audio_decoder.h"
@@ -158,10 +159,6 @@ class PlayerComponentsPassthrough : public PlayerComponents {
 class PlayerComponentsFactory : public PlayerComponents::Factory {
   const int kAudioSinkFramesAlignment = 256;
   const int kDefaultAudioSinkMinFramesPerAppend = 1024;
-
-  static int AlignUp(int value, int alignment) {
-    return (value + alignment - 1) / alignment * alignment;
-  }
 
   NonNullResult<std::unique_ptr<PlayerComponents>> CreateComponents(
       const CreationParameters& creation_parameters) override {

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
@@ -22,6 +22,7 @@
 #include <string>
 
 #include "starboard/common/check_op.h"
+#include "starboard/common/pointer_arithmetic.h"
 #include "starboard/common/string.h"
 #include "starboard/linux/shared/decode_target_internal.h"
 
@@ -34,11 +35,6 @@ namespace {
 // http://ffmpeg.org/doxygen/trunk/structAVFrame.html#aa52bfc6605f6a3059a0c3226cc0f6567
 // that the alignment on most modern desktop systems are 16 or 32.
 static const int kAlignment = 32;
-
-size_t AlignUp(size_t size, int alignment) {
-  SB_DCHECK_EQ((alignment & (alignment - 1)), 0);
-  return (size + alignment - 1) & ~(alignment - 1);
-}
 
 size_t GetYV12SizeInBytes(int32_t width, int32_t height) {
   return width * height * 3 / 2;

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -19,6 +19,7 @@
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/command_line.h"
+#include "starboard/common/pointer_arithmetic.h"
 #include "starboard/common/time.h"
 #include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/features.h"
@@ -73,10 +74,6 @@ class PlayerComponentsImpl : public PlayerComponents {
   std::unique_ptr<AudioRendererPcm> audio_renderer_;
   std::unique_ptr<VideoRendererImpl> video_renderer_;
 };
-
-int AlignUp(int value, int alignment) {
-  return (value + alignment - 1) / alignment * alignment;
-}
 
 }  // namespace
 


### PR DESCRIPTION
Refactor player components and video decoder to use the central AlignUp helper instead of local redundant definitions.

Issue: 484299147