### PR TITLE
media: Implement incremental parse look-ahead for WebM and MP4

### DIFF
--- a/media/base/stream_parser.cc
+++ b/media/base/stream_parser.cc
@@ -14,7 +14,7 @@ namespace media {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 namespace {
-std::atomic<bool> s_enable_incremental_parse_look_ahead{false};
+std::atomic<bool> g_enable_incremental_parse_look_ahead{false};
 }  // namespace
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
@@ -31,18 +31,15 @@ StreamParser::~StreamParser() = default;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 // static
 void StreamParser::SetEnableIncrementalParseLookAhead(bool enable) {
-  if (enable) {
-    LOG(INFO) << "Enable incremental parse look ahead.";
-  } else {
-    LOG(INFO) << "Disable incremental parse look ahead.";
-  }
-  s_enable_incremental_parse_look_ahead.store(enable,
+  LOG(INFO) << "Set incremental parse look ahead: "
+            << (enable ? "enabled" : "disabled");
+  g_enable_incremental_parse_look_ahead.store(enable,
                                               std::memory_order_relaxed);
 }
 
 // static
 bool StreamParser::IsIncrementalParseLookAheadEnabled() {
-  return s_enable_incremental_parse_look_ahead.load(std::memory_order_relaxed);
+  return g_enable_incremental_parse_look_ahead.load(std::memory_order_relaxed);
 }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/media/formats/mp4/mp4_stream_parser.cc
+++ b/media/formats/mp4/mp4_stream_parser.cc
@@ -33,6 +33,7 @@
 #include "media/formats/mp4/es_descriptor.h"
 #include "media/formats/mp4/rcheck.h"
 #include "media/formats/mpeg/adts_constants.h"
+#include "media/media_buildflags.h"
 
 namespace media::mp4 {
 
@@ -168,8 +169,36 @@ bool MP4StreamParser::AppendToParseBuffer(const uint8_t* buf, size_t size) {
   return true;
 }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
 StreamParser::ParseStatus MP4StreamParser::Parse(
     int max_pending_bytes_to_inspect) {
+  if (!StreamParser::IsIncrementalParseLookAheadEnabled() ||
+      max_pending_bytes_to_inspect == 0) {
+    return ParseInternal(max_pending_bytes_to_inspect);
+  }
+
+  // Safe guard to avoid looping infinitely.
+  constexpr int kMaxLoopCount = 128;
+
+  buffers_parsed_ = false;
+
+  for (int loop_count = 0;;++loop_count) {
+    ParseStatus result = ParseInternal(max_pending_bytes_to_inspect);
+
+    if (result == ParseStatus::kFailed || max_parse_offset_ == queue_.tail() ||
+        buffers_parsed_ || loop_count == kMaxLoopCount) {
+      return result;
+    }
+  }
+}
+
+StreamParser::ParseStatus MP4StreamParser::ParseInternal(
+    int max_pending_bytes_to_inspect) {
+#else  // BUILDFLAG(USE_STARBOARD_MEDIA)
+StreamParser::ParseStatus MP4StreamParser::Parse(
+    int max_pending_bytes_to_inspect) {
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   DCHECK_NE(state_, kWaitingForInit);
   DCHECK_GE(max_pending_bytes_to_inspect, 0);
 
@@ -1078,6 +1107,9 @@ ParseResult MP4StreamParser::EnqueueSample(BufferQueueMap* buffers) {
 bool MP4StreamParser::SendAndFlushSamples(BufferQueueMap* buffers) {
   if (buffers->empty())
     return true;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  buffers_parsed_ = true;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   bool success = new_buffers_cb_.Run(*buffers);
   buffers->clear();
   return success;

--- a/media/formats/mp4/mp4_stream_parser.cc
+++ b/media/formats/mp4/mp4_stream_parser.cc
@@ -183,9 +183,12 @@ StreamParser::ParseStatus MP4StreamParser::Parse(
   buffers_parsed_ = false;
 
   for (int loop_count = 0;;++loop_count) {
+    auto previous_max_parse_offset = max_parse_offset_;
+
     ParseStatus result = ParseInternal(max_pending_bytes_to_inspect);
 
     if (result == ParseStatus::kFailed || max_parse_offset_ == queue_.tail() ||
+        previous_max_parse_offset == max_parse_offset_ ||
         buffers_parsed_ || loop_count == kMaxLoopCount) {
       return result;
     }

--- a/media/formats/mp4/mp4_stream_parser.h
+++ b/media/formats/mp4/mp4_stream_parser.h
@@ -55,6 +55,16 @@ class MEDIA_EXPORT MP4StreamParser : public StreamParser {
   [[nodiscard]] bool AppendToParseBuffer(const uint8_t* buf,
                                          size_t size) override;
   [[nodiscard]] ParseStatus Parse(int max_pending_bytes_to_inspect) override;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+ private:
+  // The following function and variable should technically be moved down.  They
+  // are kept here to make the new feature easy to review and maintain.
+  [[nodiscard]] ParseStatus ParseInternal(int max_pending_bytes_to_inspect);
+
+  bool buffers_parsed_ = false;
+
+ public:
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Calculates the rotation value from the track header display matricies.
   VideoTransformation CalculateRotation(const TrackHeader& track,

--- a/media/formats/webm/webm_stream_parser.cc
+++ b/media/formats/webm/webm_stream_parser.cc
@@ -127,9 +127,12 @@ StreamParser::ParseStatus WebMStreamParser::Parse(
   buffers_parsed_ = false;
 
   for (int loop_count = 0;;++loop_count) {
+    auto previous_uninspected_pending_bytes = uninspected_pending_bytes_;
+
     ParseStatus result = ParseInternal(max_pending_bytes_to_inspect);
 
     if (result == ParseStatus::kFailed || uninspected_pending_bytes_ == 0 ||
+        previous_uninspected_pending_bytes == uninspected_pending_bytes_ ||
         buffers_parsed_ || loop_count == kMaxLoopCount) {
       return result;
     }

--- a/media/formats/webm/webm_stream_parser.h
+++ b/media/formats/webm/webm_stream_parser.h
@@ -43,6 +43,14 @@ class MEDIA_EXPORT WebMStreamParser : public StreamParser {
   [[nodiscard]] bool AppendToParseBuffer(const uint8_t* buf,
                                          size_t size) override;
   [[nodiscard]] ParseStatus Parse(int max_pending_bytes_to_inspect) override;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+ private:
+  // The following function and variable should technically be moved down.  They
+  // are kept here to make the new feature easy to review and maintain.
+  [[nodiscard]] ParseStatus ParseInternal(int max_pending_bytes_to_inspect);
+
+  bool buffers_parsed_ = false;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
  private:
   enum State {

--- a/third_party/blink/renderer/modules/mediasource/media_source.cc
+++ b/third_party/blink/renderer/modules/mediasource/media_source.cc
@@ -393,13 +393,12 @@ void MediaSource::AddSourceBuffer_Locked(
   // parse look ahead enabled and disabled, to analize its statistical
   // significance.
   constexpr bool kEnableIncrementalParseLookAheadMetrics = false;
-  if (kEnableIncrementalParseLookAheadMetrics) {
-    if (source_buffers_->length() == 0) {
-      static bool enable = true;
+  if (kEnableIncrementalParseLookAheadMetrics &&
+      source_buffers_->length() == 0) {
+    static bool enable = true;
 
-      media::StreamParser::SetEnableIncrementalParseLookAhead(enable);
-      enable = !enable;
-    }
+    media::StreamParser::SetEnableIncrementalParseLookAhead(enable);
+    enable = !enable;
   }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/third_party/blink/renderer/modules/mediasource/media_source.cc
+++ b/third_party/blink/renderer/modules/mediasource/media_source.cc
@@ -17,6 +17,7 @@
 #include "media/base/media_switches.h"
 #include "media/base/media_types.h"
 #include "media/base/mime_util.h"
+#include "media/base/stream_parser.h"
 #include "media/base/supported_types.h"
 #include "media/base/video_decoder_config.h"
 #include "media/media_buildflags.h"
@@ -385,6 +386,22 @@ void MediaSource::AddSourceBuffer_Locked(
 
   bool generate_timestamps_flag =
       web_source_buffer->GetGenerateTimestampsFlag();
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // TODO(b/484617192): Remove once the feature is launched.
+  // Code to allow collecting metrics in the same app instance with incremental
+  // parse look ahead enabled and disabled, to analize its statistical
+  // significance.
+  constexpr bool kEnableIncrementalParseLookAheadMetrics = false;
+  if (kEnableIncrementalParseLookAheadMetrics) {
+    if (source_buffers_->length() == 0) {
+      static bool enable = true;
+
+      media::StreamParser::SetEnableIncrementalParseLookAhead(enable);
+      enable = !enable;
+    }
+  }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   auto* buffer = MakeGarbageCollected<SourceBuffer>(
       std::move(web_source_buffer), this, async_event_queue_.Get());


### PR DESCRIPTION
Introduce incremental parse look-ahead optimization for WebM and MP4
stream parsers. This feature adds a global toggle and an outer retry
loop to authorize additional data chunks when no parsing progress is
made but more data is available.

This improves efficiency when processing large media elements that
exceed initial inspection limits, reducing redundant
return-and-re-entry cycles. It also fixes a potential pointer stalling
bug in WebM parsing.

This change is guarded by BUILDFLAG(USE_STARBOARD_MEDIA).

Bug: 484617192