### PR TITLE
media: Connect InPlaceReuseAllocatorBase to H5VCC

### DIFF
--- a/media/base/decoder_buffer.cc
+++ b/media/base/decoder_buffer.cc
@@ -42,6 +42,12 @@ void DecoderBuffer::EnableMediaBufferPoolStrategy() {
   s_allocator->EnableMediaBufferPoolStrategy();
 }
 
+// static
+void DecoderBuffer::EnableInPlaceReuseAllocatorBase() {
+  CHECK(s_allocator);
+  s_allocator->EnableInPlaceReuseAllocatorBase();
+}
+
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 DecoderBuffer::TimeInfo::TimeInfo() = default;

--- a/media/base/decoder_buffer.h
+++ b/media/base/decoder_buffer.h
@@ -112,6 +112,7 @@ class MEDIA_EXPORT DecoderBuffer
 
     virtual void SetAllocateOnDemand(bool enabled) = 0;
     virtual void EnableMediaBufferPoolStrategy() = 0;
+    virtual void EnableInPlaceReuseAllocatorBase() = 0;
 
    protected:
     ~Allocator() {}
@@ -119,6 +120,7 @@ class MEDIA_EXPORT DecoderBuffer
 
   static void EnableAllocateOnDemand(bool enabled);
   static void EnableMediaBufferPoolStrategy();
+  static void EnableInPlaceReuseAllocatorBase();
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Allocates buffer with |size| >= 0. |is_key_frame_| will default to false.

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -77,9 +77,16 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
   void SetAllocateOnDemand(bool enabled) override;
   void EnableMediaBufferPoolStrategy() override;
+  void EnableInPlaceReuseAllocatorBase() override;
 
  private:
   enum class MediaBufferPoolStrategyState {
+    kDisabled,
+    kEnabled,
+    kPendingEnabling,
+  };
+
+  enum class InPlaceReuseAllocatorBaseStrategyState {
     kDisabled,
     kEnabled,
     kPendingEnabling,
@@ -99,6 +106,9 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   std::unique_ptr<Strategy> strategy_ GUARDED_BY(mutex_);
   MediaBufferPoolStrategyState media_buffer_pool_strategy_state_
       GUARDED_BY(mutex_) = MediaBufferPoolStrategyState::kDisabled;
+  InPlaceReuseAllocatorBaseStrategyState
+      in_place_reuse_allocator_base_strategy_state_ GUARDED_BY(mutex_) =
+          InPlaceReuseAllocatorBaseStrategyState::kDisabled;
 
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   // The following variables are used for comprehensive logging of allocation

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -15,6 +15,7 @@
 #include "third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.h"
 
 #include "base/functional/callback.h"
+#include "base/no_destructor.h"
 #include "cobalt/browser/h5vcc_settings/public/mojom/h5vcc_settings.mojom-blink.h"
 #include "media/base/decoder_buffer.h"
 #include "media/base/stream_parser.h"
@@ -29,6 +30,7 @@
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap/persistent.h"
 #include "third_party/blink/renderer/platform/wtf/functional.h"
+#include "third_party/blink/renderer/platform/wtf/hash_map.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
 namespace blink {
@@ -39,6 +41,33 @@ constexpr char kMediaAppendFirstSegmentSynchronously[] =
 constexpr char kMediaIncrementalParseLookAhead[] =
     "Media.IncrementalParseLookAhead";
 constexpr char kDecoderBufferSettingPrefix[] = "DecoderBuffer.";
+
+constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
+    "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
+static_assert(
+    std::string_view(kEnableMediaBufferPoolAllocatorStrategy)
+        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
+    kDecoderBufferSettingPrefix);
+
+constexpr char kEnableInPlaceReuseAllocatorBase[] =
+    "DecoderBuffer.EnableInPlaceReuseAllocatorBase";
+static_assert(
+    std::string_view(kEnableInPlaceReuseAllocatorBase)
+        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
+    kDecoderBufferSettingPrefix);
+
+using EnableFunction = void (*)();
+using SettingsMap = WTF::HashMap<WTF::String, EnableFunction>;
+
+const SettingsMap& GetDecoderBufferSettings() {
+  static const base::NoDestructor<SettingsMap> settings({
+      {kEnableMediaBufferPoolAllocatorStrategy,
+       &::media::DecoderBuffer::EnableMediaBufferPoolStrategy},
+      {kEnableInPlaceReuseAllocatorBase,
+       &::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase},
+  });
+  return *settings;
+}
 
 // Ideally this function should be moved to decoder_buffer.h.  It's kept here as
 // H5vccSettings will soon be deprecated and it's easier to remove from here.
@@ -60,36 +89,19 @@ ScriptPromise ProcessDecoderBufferSettings(ScriptState* script_state,
     return promise;
   }
 
-  if (name == "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy") {
-    bool enable = (value->GetAsLong() != 0);
-    if (enable) {
+  const auto& settings = GetDecoderBufferSettings();
+  auto it = settings.find(name);
+
+  if (it != settings.end()) {
+    if (value->GetAsLong() != 0) {
       LOG(INFO) << "Enabling " << name << ".";
-      ::media::DecoderBuffer::EnableMediaBufferPoolStrategy();
+      it->value();
       resolver->Resolve();
-
-      return promise;
+    } else {
+      LOG(WARNING) << name << " cannot be disabled.";
+      resolver->Reject(V8ThrowException::CreateTypeError(
+          script_state->GetIsolate(), name + " cannot be disabled."));
     }
-
-    LOG(WARNING) << name << " cannot be disabled.";
-    resolver->Reject(V8ThrowException::CreateTypeError(
-        script_state->GetIsolate(), name + " cannot be disabled."));
-
-    return promise;
-  }
-
-  if (name == "DecoderBuffer.EnableInPlaceReuseAllocatorBase") {
-    bool enable = (value->GetAsLong() != 0);
-    if (enable) {
-      LOG(INFO) << "Enabling " << name << ".";
-      ::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase();
-      resolver->Resolve();
-      return promise;
-    }
-
-    LOG(WARNING) << name << " cannot be disabled.";
-    resolver->Reject(V8ThrowException::CreateTypeError(
-        script_state->GetIsolate(), name + " cannot be disabled."));
-
     return promise;
   }
 
@@ -140,7 +152,7 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
       resolver->Reject(V8ThrowException::CreateTypeError(
           script_state->GetIsolate(),
           String("The value for '") + kMediaAppendFirstSegmentSynchronously +
-                 "' must be a number."));
+              "' must be a number."));
     }
     return promise;
   }

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -77,6 +77,22 @@ ScriptPromise ProcessDecoderBufferSettings(ScriptState* script_state,
     return promise;
   }
 
+  if (name == "DecoderBuffer.EnableInPlaceReuseAllocatorBase") {
+    bool enable = (value->GetAsLong() != 0);
+    if (enable) {
+      LOG(INFO) << "Enabling " << name << ".";
+      ::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase();
+      resolver->Resolve();
+      return promise;
+    }
+
+    LOG(WARNING) << name << " cannot be disabled.";
+    resolver->Reject(V8ThrowException::CreateTypeError(
+        script_state->GetIsolate(), name + " cannot be disabled."));
+
+    return promise;
+  }
+
   LOG(WARNING) << name << " isn't a supported setting.";
   // An unknown setting leads to TypeError.
   resolver->Reject(V8ThrowException::CreateTypeError(


### PR DESCRIPTION
Expose the new in-place reuse allocator base strategy for decoder buffers
through an H5VCC setting. This allows applications to dynamically enable
the optimized buffer allocation strategy, potentially improving memory
utilization and performance by handling metadata in-place.

We introduce a new variable, `in_place_reuse_allocator_base_strategy_state_` 
for DecoderBufferAllocator to keep track on the current status of the strategy.
We also ensure that we can safely switch to this strategy if another strategy is
also in place. 

Bug: 470186535