### PR TITLE
android: Load splash screen before main app URL to fix race condition

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -297,12 +297,12 @@ public abstract class CobaltActivity extends Activity {
             initializeJavaBridge();
             getStarboardBridge().setWebContents(getActiveWebContents());
 
+            // Load splash screen.
+            mShellManager.getActiveShell().loadSplashScreenWebContents();
+
             // Load the `url` with the same shell we created above.
             Log.i(TAG, "shellManager load url:" + mStartupUrl);
             mShellManager.getActiveShell().loadUrl(mStartupUrl);
-
-            // Load splash screen.
-            mShellManager.getActiveShell().loadSplashScreenWebContents();
           }
         });
   }


### PR DESCRIPTION
On cold starts with high system load, the main app's URL load can finish before the splash screen initializes its internal WebContents. This triggers Cobalt's logic to skip or immediately hide the splash screen.

By swapping the initialization order, we ensure the splash screen state is moved out of UNINITIALIZED before the main app navigation can possibly finish, ensuring the splash animation is correctly displayed even during laggy startups.

Bug: 485979436