### PR TITLE
cobalt: Unify H5vccSettings processing

### DIFF
--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -14,8 +14,7 @@
 
 #include "third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.h"
 
-#include "base/functional/callback.h"
-#include "base/no_destructor.h"
+#include "base/types/expected.h"
 #include "cobalt/browser/h5vcc_settings/public/mojom/h5vcc_settings.mojom-blink.h"
 #include "media/base/decoder_buffer.h"
 #include "media/base/stream_parser.h"
@@ -32,7 +31,6 @@
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap/persistent.h"
 #include "third_party/blink/renderer/platform/wtf/functional.h"
-#include "third_party/blink/renderer/platform/wtf/hash_map.h"
 #include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
 
 namespace blink {
@@ -70,7 +68,16 @@ ScriptPromise ProcessSettingAs(const ScriptContext& context,
         "The value for '" + name + "' must be a number."));
     return resolver->Promise();
   }
-  callback(resolver, static_cast<T>(value->GetAsLong()));
+
+  base::expected<void, String> result =
+      callback(static_cast<T>(value->GetAsLong()));
+  if (result.has_value()) {
+    resolver->Resolve();
+  } else {
+    resolver->Reject(V8ThrowException::CreateTypeError(
+        context.script_state->GetIsolate(), result.error()));
+  }
+
   return resolver->Promise();
 }
 
@@ -81,75 +88,16 @@ ScriptPromise ProcessEnableOnlySetting(const ScriptContext& context,
                                        ActionCallback action) {
   return ProcessSettingAs<bool>(
       context, value, name,
-      [&context, name, action = std::move(action)](
-          ScriptPromiseResolver* resolver, bool enable) {
+      [name, action = std::move(action)](
+          bool enable) -> base::expected<void, String> {
         if (!enable) {
           LOG(WARNING) << name << " cannot be disabled.";
-          resolver->Reject(V8ThrowException::CreateTypeError(
-              context.script_state->GetIsolate(),
-              name + " cannot be disabled."));
-          return;
+          return base::unexpected(name + " cannot be disabled.");
         }
 
         LOG(INFO) << "Enabling " << name << ".";
         action();
-        resolver->Resolve();
-      });
-}
-
-constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
-    "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
-static_assert(
-    std::string_view(kEnableMediaBufferPoolAllocatorStrategy)
-        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
-    kDecoderBufferSettingPrefix);
-
-using EnableFunction = void (*)();
-using SettingsMap = WTF::HashMap<WTF::String, EnableFunction>;
-
-const SettingsMap& GetDecoderBufferSettings() {
-  static const base::NoDestructor<SettingsMap> settings({
-      {kEnableDecommitableAllocatorStrategy,
-       &::media::DecoderBufferAllocator::EnableDecommitableAllocatorStrategy},
-      {kEnableInPlaceReuseAllocatorBase,
-       &::media::DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase},
-      {kEnableMediaBufferPoolAllocatorStrategy,
-       &::media::DecoderBufferAllocator::EnableMediaBufferPoolStrategy},
-  });
-  return *settings;
-}
-
-// Ideally this function should be moved to decoder_buffer.h.  It's kept here as
-// H5vccSettings will soon be deprecated and it's easier to remove from here.
-ScriptPromise ProcessDecoderBufferSettings(const ScriptContext& context,
-                                           const WTF::String& name,
-                                           const V8UnionLongOrString* value) {
-  DCHECK(name.StartsWith(kDecoderBufferSettingPrefix));
-
-  return ProcessSettingAs<bool>(
-      context, value, name, [&](ScriptPromiseResolver* resolver, bool enable) {
-        const auto& settings = GetDecoderBufferSettings();
-        auto it = settings.find(name);
-
-        if (it == settings.end()) {
-          LOG(WARNING) << name << " isn't a supported setting.";
-          // An unknown setting leads to TypeError.
-          resolver->Reject(V8ThrowException::CreateTypeError(
-              context.script_state->GetIsolate(),
-              name + " isn't a supported setting."));
-          return;
-        }
-
-        if (enable) {
-          LOG(INFO) << "Enabling " << name << ".";
-          it->value();
-          resolver->Resolve();
-        } else {
-          LOG(WARNING) << name << " cannot be disabled.";
-          resolver->Reject(V8ThrowException::CreateTypeError(
-              context.script_state->GetIsolate(),
-              name + " cannot be disabled."));
-        }
+        return base::ok();
       });
 }
 
@@ -174,15 +122,25 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
   // sizeof), avoiding runtime length calculations (strlen) during equality
   // checks.
   WTF::StringView name_view(name);
-
-  if (name_view.StartsWith(kDecoderBufferSettingPrefix)) {
-    return ProcessDecoderBufferSettings(context, name, value);
+  if (name_view == kEnableMediaBufferPoolAllocatorStrategy) {
+    return ProcessEnableOnlySetting(context, value, name, [] {
+      ::media::DecoderBuffer::EnableMediaBufferPoolStrategy();
+    });
   }
-
+  if (name_view == kEnableInPlaceReuseAllocatorBase) {
+    return ProcessEnableOnlySetting(context, value, name, [] {
+      ::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase();
+    });
+  }
+  if (name_view == kMediaIncrementalParseLookAhead) {
+    return ProcessEnableOnlySetting(context, value, name, [] {
+      ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);
+    });
+  }
   if (name_view == kMediaAppendFirstSegmentSynchronously) {
     return ProcessSettingAs<bool>(
         context, value, name,
-        [&](ScriptPromiseResolver* resolver, bool enable) {
+        [this](bool enable) -> base::expected<void, String> {
           append_first_segment_synchronously_ = enable;
           if (enable) {
             LOG(INFO)
@@ -191,30 +149,26 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
             LOG(INFO) << "Disable synchronous append of first media source"
                       << " segment.";
           }
-          resolver->Resolve();
+          return base::ok();
         });
   }
-
   if (name_view == kMediaExperimentalMaxPendingBytesPerParse) {
     return ProcessSettingAs<int>(
-        context, value, name, [&](ScriptPromiseResolver* resolver, int value) {
+        context, value, name, [](int value) -> base::expected<void, String> {
           if (value > 0) {
             LOG(INFO) << "Setting " << kMediaExperimentalMaxPendingBytesPerParse
                       << " to " << value << " bytes.";
             ::media::SourceBufferState::SetMaxPendingBytesPerParseOverride(
                 value);
-            resolver->Resolve();
+            return base::ok();
           } else {
             LOG(WARNING) << kMediaExperimentalMaxPendingBytesPerParse
                          << " must be set to a positive integer";
-            resolver->Reject(V8ThrowException::CreateTypeError(
-                context.script_state->GetIsolate(),
-                kMediaExperimentalMaxPendingBytesPerParse +
-                    String(" must be a positive integer.")));
+            return base::unexpected(kMediaExperimentalMaxPendingBytesPerParse +
+                                    String(" must be a positive integer."));
           }
         });
   }
-
   if (name_view == kMediaIncrementalParseLookAhead) {
     return ProcessEnableOnlySetting(context, value, name, [] {
       ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -18,6 +18,7 @@
 #include "base/no_destructor.h"
 #include "cobalt/browser/h5vcc_settings/public/mojom/h5vcc_settings.mojom-blink.h"
 #include "media/base/decoder_buffer.h"
+#include "media/base/stream_parser.h"
 #include "media/filters/source_buffer_state.h"
 #include "media/starboard/decoder_buffer_allocator.h"
 #include "third_party/blink/public/common/browser_interface_broker_proxy.h"

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -47,51 +47,57 @@ constexpr char kMediaExperimentalMaxPendingBytesPerParse[] =
 constexpr char kMediaIncrementalParseLookAhead[] =
     "Media.IncrementalParseLookAhead";
 
-struct ScriptContext {
+struct SettingContext {
   ScriptState* script_state;
   const ExceptionContext& exception_context;
+  const V8UnionLongOrString* value;
+  const String& name;
 };
 
 using Result = base::expected<void, String>;
 
-template <typename T, typename Callback>
-ScriptPromise ProcessSettingAs(const ScriptContext& context,
-                               const V8UnionLongOrString* value,
-                               const String& name,
-                               Callback callback) {
+ScriptPromise Reject(const SettingContext& context, const String& error) {
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
       context.script_state, context.exception_context);
+  resolver->Reject(V8ThrowException::CreateTypeError(
+      context.script_state->GetIsolate(), error));
+  return resolver->Promise();
+}
 
-  if (!value->IsLong()) {
-    LOG(WARNING) << "The value for '" << name << "' must be a number.";
-    resolver->Reject(V8ThrowException::CreateTypeError(
-        context.script_state->GetIsolate(),
-        "The value for '" + name + "' must be a number."));
-    return resolver->Promise();
-  }
-
-  Result result = callback(static_cast<T>(value->GetAsLong()));
-  if (!result.has_value()) {
-    LOG(WARNING) << "Failed to set " << name << " to " << value->GetAsLong()
-                 << ": " << result.error();
-    resolver->Reject(V8ThrowException::CreateTypeError(
-        context.script_state->GetIsolate(), result.error()));
-    return resolver->Promise();
-  }
-
-  LOG(INFO) << name << " is set to " << value->GetAsLong();
+ScriptPromise Resolve(const SettingContext& context) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
+      context.script_state, context.exception_context);
   resolver->Resolve();
   return resolver->Promise();
 }
 
+template <typename T, typename Callback>
+ScriptPromise ProcessSettingAs(const SettingContext& context,
+                               Callback callback) {
+  if (!context.value->IsLong()) {
+    LOG(WARNING) << "The value for '" << context.name << "' must be a number.";
+    return Reject(context,
+                  "The value for '" + context.name + "' must be a number.");
+  }
+  const int32_t value = context.value->GetAsLong();
+
+  Result result = callback(static_cast<T>(value));
+  if (!result.has_value()) {
+    LOG(WARNING) << "Failed to set " << context.name << " to " << value << ": "
+                 << result.error();
+    return Reject(context, result.error());
+  }
+
+  LOG(INFO) << context.name << " is set to " << value;
+  return Resolve(context);
+}
+
 template <typename ActionCallback>
-ScriptPromise ProcessEnableOnlySetting(const ScriptContext& context,
-                                       const V8UnionLongOrString* value,
-                                       const String& name,
+ScriptPromise ProcessEnableOnlySetting(const SettingContext& context,
                                        ActionCallback action) {
   return ProcessSettingAs<bool>(
-      context, value, name,
-      [name, action = std::move(action)](bool enable) -> Result {
+      context,
+      [name = context.name, action = std::move(action)](bool enable) -> Result {
         if (!enable) {
           return base::unexpected(name + " cannot be disabled.");
         }
@@ -115,7 +121,8 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
                                  const WTF::String& name,
                                  const V8UnionLongOrString* value,
                                  ExceptionState& exception_state) {
-  ScriptContext context{script_state, exception_state.GetContext()};
+  SettingContext context{script_state, exception_state.GetContext(), value,
+                         name};
 
   // Use StringView to enable template-based comparison with string literals.
   // This allows the compiler to use the literal's size at compile-time (via
@@ -123,24 +130,23 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
   // checks.
   WTF::StringView name_view(name);
   if (name_view == kEnableMediaBufferPoolAllocatorStrategy) {
-    return ProcessEnableOnlySetting(context, value, name, [] {
+    return ProcessEnableOnlySetting(context, [] {
       ::media::DecoderBuffer::EnableMediaBufferPoolStrategy();
     });
   }
   if (name_view == kEnableInPlaceReuseAllocatorBase) {
-    return ProcessEnableOnlySetting(context, value, name, [] {
+    return ProcessEnableOnlySetting(context, [] {
       ::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase();
     });
   }
   if (name_view == kMediaAppendFirstSegmentSynchronously) {
-    return ProcessSettingAs<bool>(
-        context, value, name, [this](bool enable) -> Result {
-          append_first_segment_synchronously_ = enable;
-          return base::ok();
-        });
+    return ProcessSettingAs<bool>(context, [this](bool enable) -> Result {
+      append_first_segment_synchronously_ = enable;
+      return base::ok();
+    });
   }
   if (name_view == kMediaExperimentalMaxPendingBytesPerParse) {
-    return ProcessSettingAs<int>(context, value, name, [](int value) -> Result {
+    return ProcessSettingAs<int>(context, [](int value) -> Result {
       if (value <= 0) {
         return base::unexpected(kMediaExperimentalMaxPendingBytesPerParse +
                                 String(" must be a positive integer."));
@@ -151,7 +157,7 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
     });
   }
   if (name_view == kMediaIncrementalParseLookAhead) {
-    return ProcessEnableOnlySetting(context, value, name, [] {
+    return ProcessEnableOnlySetting(context, [] {
       ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);
     });
   }

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -36,36 +36,6 @@
 namespace blink {
 namespace {
 
-constexpr char kMediaAppendFirstSegmentSynchronously[] =
-    "Media.AppendFirstSegmentSynchronously";
-constexpr char kMediaExperimentalMaxPendingBytesPerParse[] =
-    "Media.ExperimentalMaxPendingBytesPerParse";
-constexpr char kMediaIncrementalParseLookAhead[] =
-    "Media.IncrementalParseLookAhead";
-constexpr char kDecoderBufferSettingPrefix[] = "DecoderBuffer.";
-
-constexpr char kDecoderBufferEnableMediaBufferPoolAllocatorStrategy[] =
-    "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
-
-constexpr char kDecoderBufferEnableInPlaceReuseAllocatorBase[] =
-    "DecoderBuffer.EnableInPlaceReuseAllocatorBase";
-
-constexpr bool StartsWithLiteral(const char* str, const char* prefix) {
-  while (*prefix != '\0') {
-    if (*str++ != *prefix++) {
-      return false;
-    }
-  }
-  return true;
-}
-
-static_assert(
-    StartsWithLiteral(kDecoderBufferEnableMediaBufferPoolAllocatorStrategy,
-                      kDecoderBufferSettingPrefix));
-
-static_assert(StartsWithLiteral(kDecoderBufferEnableInPlaceReuseAllocatorBase,
-                                kDecoderBufferSettingPrefix));
-
 struct SettingContext {
   ScriptState* script_state;
   const ExceptionContext& exception_context;
@@ -114,8 +84,8 @@ ScriptPromise ProcessSettingAs(const SettingContext& context,
 }
 
 template <typename ActionCallback>
-ScriptPromise ProcessEnableOnlySetting(const SettingContext& context,
-                                       ActionCallback action) {
+ScriptPromise ProcessSettingAsEnableOnly(const SettingContext& context,
+                                         ActionCallback action) {
   return ProcessSettingAs<bool>(
       context,
       [name = context.name, action = std::move(action)](bool enable) -> Result {
@@ -124,6 +94,21 @@ ScriptPromise ProcessEnableOnlySetting(const SettingContext& context,
         }
 
         action();
+        return base::ok();
+      });
+}
+
+template <typename ActionCallback>
+ScriptPromise ProcessSettingAsPositiveInt(const SettingContext& context,
+                                          ActionCallback action) {
+  return ProcessSettingAs<int>(
+      context,
+      [name = context.name, action = std::move(action)](int value) -> Result {
+        if (value <= 0) {
+          return base::unexpected(name + " must be a positive integer.");
+        }
+
+        action(value);
         return base::ok();
       });
 }
@@ -145,39 +130,34 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
   SettingContext context{script_state, exception_state.GetContext(), value,
                          name};
 
-  if (name == kDecoderBufferEnableMediaBufferPoolAllocatorStrategy) {
-    return ProcessEnableOnlySetting(context, [] {
+  if (name == "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy") {
+    return ProcessSettingAsEnableOnly(context, [] {
       ::media::DecoderBufferAllocator::EnableMediaBufferPoolStrategy();
     });
   }
-  if (name == kDecoderBufferEnableInPlaceReuseAllocatorBase) {
-    return ProcessEnableOnlySetting(context, [] {
+  if (name == "DecoderBuffer.EnableInPlaceReuseAllocatorBase") {
+    return ProcessSettingAsEnableOnly(context, [] {
       ::media::DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase();
     });
   }
-  if (name.StartsWith(kDecoderBufferSettingPrefix)) {
+  // "DecoderBuffer." settings must be handled before this catch-all block.
+  if (name.StartsWith("DecoderBuffer.")) {
     return Reject(context, name + " isn't a supported setting.");
   }
 
-  if (name == kMediaAppendFirstSegmentSynchronously) {
+  if (name == "Media.AppendFirstSegmentSynchronously") {
     return ProcessSettingAs<bool>(context, [this](bool enable) -> Result {
       append_first_segment_synchronously_ = enable;
       return base::ok();
     });
   }
-  if (name == kMediaExperimentalMaxPendingBytesPerParse) {
-    return ProcessSettingAs<int>(context, [](int value) -> Result {
-      if (value <= 0) {
-        return base::unexpected(kMediaExperimentalMaxPendingBytesPerParse +
-                                String(" must be a positive integer."));
-      }
-
+  if (name == "Media.ExperimentalMaxPendingBytesPerParse") {
+    return ProcessSettingAsPositiveInt(context, [](int value) {
       ::media::SourceBufferState::SetMaxPendingBytesPerParseOverride(value);
-      return base::ok();
     });
   }
-  if (name == kMediaIncrementalParseLookAhead) {
-    return ProcessEnableOnlySetting(context, [] {
+  if (name == "Media.IncrementalParseLookAhead") {
+    return ProcessSettingAsEnableOnly(context, [] {
       ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);
     });
   }

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -147,12 +147,12 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
 
   if (name == kDecoderBufferEnableMediaBufferPoolAllocatorStrategy) {
     return ProcessEnableOnlySetting(context, [] {
-      ::media::DecoderBuffer::EnableMediaBufferPoolStrategy();
+      ::media::DecoderBufferAllocator::EnableMediaBufferPoolStrategy();
     });
   }
   if (name == kDecoderBufferEnableInPlaceReuseAllocatorBase) {
     return ProcessEnableOnlySetting(context, [] {
-      ::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase();
+      ::media::DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase();
     });
   }
   if (name.StartsWith(kDecoderBufferSettingPrefix)) {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -139,17 +139,16 @@ ScriptPromise ProcessDecoderBufferSettings(const ScriptContext& context,
           return;
         }
 
-        if (!enable) {
+        if (enable) {
+          LOG(INFO) << "Enabling " << name << ".";
+          it->value();
+          resolver->Resolve();
+        } else {
           LOG(WARNING) << name << " cannot be disabled.";
           resolver->Reject(V8ThrowException::CreateTypeError(
               context.script_state->GetIsolate(),
               name + " cannot be disabled."));
-          return;
         }
-
-        LOG(INFO) << "Enabling " << name << ".";
-        it->value();
-        resolver->Resolve();
       });
 }
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -139,16 +139,17 @@ ScriptPromise ProcessDecoderBufferSettings(const ScriptContext& context,
           return;
         }
 
-        if (enable) {
-          LOG(INFO) << "Enabling " << name << ".";
-          it->value();
-          resolver->Resolve();
-        } else {
+        if (!enable) {
           LOG(WARNING) << name << " cannot be disabled.";
           resolver->Reject(V8ThrowException::CreateTypeError(
               context.script_state->GetIsolate(),
               name + " cannot be disabled."));
+          return;
         }
+
+        LOG(INFO) << "Enabling " << name << ".";
+        it->value();
+        resolver->Resolve();
       });
 }
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -37,27 +37,64 @@
 namespace blink {
 namespace {
 
-constexpr char kMediaAppendFirstSegmentSynchronously[] =
-    "Media.AppendFirstSegmentSynchronously";
-constexpr char kMediaExperimentalMaxPendingBytesPerParse[] =
-    "Media.ExperimentalMaxPendingBytesPerParse";
-constexpr char kMediaIncrementalParseLookAhead[] =
-    "Media.IncrementalParseLookAhead";
-constexpr char kDecoderBufferSettingPrefix[] = "DecoderBuffer.";
-
-constexpr char kEnableDecommitableAllocatorStrategy[] =
-    "DecoderBuffer.EnableDecommitableAllocatorStrategy";
-static_assert(
-    std::string_view(kEnableDecommitableAllocatorStrategy)
-        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
-    kDecoderBufferSettingPrefix);
-
-constexpr char kEnableInPlaceReuseAllocatorBase[] =
+static constexpr char kEnableInPlaceReuseAllocatorBase[] =
     "DecoderBuffer.EnableInPlaceReuseAllocatorBase";
-static_assert(
-    std::string_view(kEnableInPlaceReuseAllocatorBase)
-        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
-    kDecoderBufferSettingPrefix);
+static constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
+    "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
+static constexpr char kMediaAppendFirstSegmentSynchronously[] =
+    "Media.AppendFirstSegmentSynchronously";
+static constexpr char kMediaExperimentalMaxPendingBytesPerParse[] =
+    "Media.ExperimentalMaxPendingBytesPerParse";
+static constexpr char kMediaIncrementalParseLookAhead[] =
+    "Media.IncrementalParseLookAhead";
+static constexpr char kDecoderBufferSettingPrefix[] = "DecoderBuffer.";
+
+struct ScriptContext {
+  ScriptState* script_state;
+  const ExceptionContext& exception_context;
+};
+
+template <typename T, typename Callback>
+ScriptPromise ProcessSettingAs(const ScriptContext& context,
+                               const V8UnionLongOrString* value,
+                               const String& name,
+                               Callback callback) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
+      context.script_state, context.exception_context);
+
+  if (!value->IsLong()) {
+    LOG(WARNING) << "The value for '" << name << "' must be a number.";
+    resolver->Reject(V8ThrowException::CreateTypeError(
+        context.script_state->GetIsolate(),
+        "The value for '" + name + "' must be a number."));
+    return resolver->Promise();
+  }
+  callback(resolver, static_cast<T>(value->GetAsLong()));
+  return resolver->Promise();
+}
+
+template <typename ActionCallback>
+ScriptPromise ProcessEnableOnlySetting(const ScriptContext& context,
+                                       const V8UnionLongOrString* value,
+                                       const String& name,
+                                       ActionCallback action) {
+  return ProcessSettingAs<bool>(
+      context, value, name,
+      [&context, name, action = std::move(action)](
+          ScriptPromiseResolver* resolver, bool enable) {
+        if (!enable) {
+          LOG(WARNING) << name << " cannot be disabled.";
+          resolver->Reject(V8ThrowException::CreateTypeError(
+              context.script_state->GetIsolate(),
+              name + " cannot be disabled."));
+          return;
+        }
+
+        LOG(INFO) << "Enabling " << name << ".";
+        action();
+        resolver->Resolve();
+      });
+}
 
 constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
     "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
@@ -83,46 +120,36 @@ const SettingsMap& GetDecoderBufferSettings() {
 
 // Ideally this function should be moved to decoder_buffer.h.  It's kept here as
 // H5vccSettings will soon be deprecated and it's easier to remove from here.
-ScriptPromise ProcessDecoderBufferSettings(ScriptState* script_state,
+ScriptPromise ProcessDecoderBufferSettings(const ScriptContext& context,
                                            const WTF::String& name,
-                                           const V8UnionLongOrString* value,
-                                           ExceptionState& exception_state) {
+                                           const V8UnionLongOrString* value) {
   DCHECK(name.StartsWith(kDecoderBufferSettingPrefix));
 
-  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
-      script_state, exception_state.GetContext());
-  auto promise = resolver->Promise();
+  return ProcessSettingAs<bool>(
+      context, value, name, [&](ScriptPromiseResolver* resolver, bool enable) {
+        const auto& settings = GetDecoderBufferSettings();
+        auto it = settings.find(name);
 
-  if (!value->IsLong()) {
-    LOG(WARNING) << "The value for " << name << " must be a number.";
-    resolver->Reject(V8ThrowException::CreateTypeError(
-        script_state->GetIsolate(),
-        "The value for " + name + " must be a number."));
-    return promise;
-  }
+        if (it == settings.end()) {
+          LOG(WARNING) << name << " isn't a supported setting.";
+          // An unknown setting leads to TypeError.
+          resolver->Reject(V8ThrowException::CreateTypeError(
+              context.script_state->GetIsolate(),
+              name + " isn't a supported setting."));
+          return;
+        }
 
-  const auto& settings = GetDecoderBufferSettings();
-  auto it = settings.find(name);
-
-  if (it != settings.end()) {
-    if (value->GetAsLong() != 0) {
-      LOG(INFO) << "Enabling " << name << ".";
-      it->value();
-      resolver->Resolve();
-    } else {
-      LOG(WARNING) << name << " cannot be disabled.";
-      resolver->Reject(V8ThrowException::CreateTypeError(
-          script_state->GetIsolate(), name + " cannot be disabled."));
-    }
-    return promise;
-  }
-
-  LOG(WARNING) << name << " isn't a supported setting.";
-  // An unknown setting leads to TypeError.
-  resolver->Reject(V8ThrowException::CreateTypeError(
-      script_state->GetIsolate(), name + " isn't a supported setting."));
-
-  return promise;
+        if (enable) {
+          LOG(INFO) << "Enabling " << name << ".";
+          it->value();
+          resolver->Resolve();
+        } else {
+          LOG(WARNING) << name << " cannot be disabled.";
+          resolver->Reject(V8ThrowException::CreateTypeError(
+              context.script_state->GetIsolate(),
+              name + " cannot be disabled."));
+        }
+      });
 }
 
 }  // namespace
@@ -139,84 +166,64 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
                                  const WTF::String& name,
                                  const V8UnionLongOrString* value,
                                  ExceptionState& exception_state) {
-  if (name.StartsWith(kDecoderBufferSettingPrefix)) {
-    return ProcessDecoderBufferSettings(script_state, name, value,
-                                        exception_state);
+  ScriptContext context{script_state, exception_state.GetContext()};
+
+  // Use StringView to enable template-based comparison with string literals.
+  // This allows the compiler to use the literal's size at compile-time (via
+  // sizeof), avoiding runtime length calculations (strlen) during equality
+  // checks.
+  WTF::StringView name_view(name);
+
+  if (name_view.StartsWith(kDecoderBufferSettingPrefix)) {
+    return ProcessDecoderBufferSettings(context, name, value);
   }
 
-  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
-      script_state, exception_state.GetContext());
-  auto promise = resolver->Promise();
-
-  if (name == kMediaAppendFirstSegmentSynchronously) {
-    if (value->IsLong()) {
-      append_first_segment_synchronously_ = (value->GetAsLong() != 0);
-      if (append_first_segment_synchronously_) {
-        LOG(INFO) << "Enable synchronous append of first media source segment.";
-      } else {
-        LOG(INFO) << "Disable synchronous append of first media source"
-                  << " segment.";
-      }
-      resolver->Resolve();
-    } else {
-      LOG(WARNING) << "The value for '" << kMediaAppendFirstSegmentSynchronously
-                   << "' must be a number.";
-      resolver->Reject(V8ThrowException::CreateTypeError(
-          script_state->GetIsolate(),
-          String("The value for '") + kMediaAppendFirstSegmentSynchronously +
-              "' must be a number."));
-    }
-    return promise;
+  if (name_view == kMediaAppendFirstSegmentSynchronously) {
+    return ProcessSettingAs<bool>(
+        context, value, name,
+        [&](ScriptPromiseResolver* resolver, bool enable) {
+          append_first_segment_synchronously_ = enable;
+          if (enable) {
+            LOG(INFO)
+                << "Enable synchronous append of first media source segment.";
+          } else {
+            LOG(INFO) << "Disable synchronous append of first media source"
+                      << " segment.";
+          }
+          resolver->Resolve();
+        });
   }
 
-  if (name == kMediaExperimentalMaxPendingBytesPerParse) {
-    if (value->IsLong()) {
-      int experimental_value = value->GetAsLong();
-      if (experimental_value > 0) {
-        LOG(INFO) << "Setting " << kMediaExperimentalMaxPendingBytesPerParse
-                  << " to " << experimental_value << " bytes.";
-        ::media::SourceBufferState::SetMaxPendingBytesPerParseOverride(
-            experimental_value);
-        resolver->Resolve();
-        return promise;
-      }
-    }
-
-    LOG(WARNING) << kMediaExperimentalMaxPendingBytesPerParse
-                 << " must be set to a positive integer";
-    resolver->Reject(V8ThrowException::CreateTypeError(
-        script_state->GetIsolate(),
-        kMediaExperimentalMaxPendingBytesPerParse +
-            String(" must be a positive integer.")));
-    return promise;
+  if (name_view == kMediaExperimentalMaxPendingBytesPerParse) {
+    return ProcessSettingAs<int>(
+        context, value, name, [&](ScriptPromiseResolver* resolver, int value) {
+          if (value > 0) {
+            LOG(INFO) << "Setting " << kMediaExperimentalMaxPendingBytesPerParse
+                      << " to " << value << " bytes.";
+            ::media::SourceBufferState::SetMaxPendingBytesPerParseOverride(
+                value);
+            resolver->Resolve();
+          } else {
+            LOG(WARNING) << kMediaExperimentalMaxPendingBytesPerParse
+                         << " must be set to a positive integer";
+            resolver->Reject(V8ThrowException::CreateTypeError(
+                context.script_state->GetIsolate(),
+                kMediaExperimentalMaxPendingBytesPerParse +
+                    String(" must be a positive integer.")));
+          }
+        });
   }
 
-  if (name == kMediaIncrementalParseLookAhead) {
-    if (value->IsLong()) {
-      bool enable = (value->GetAsLong() != 0);
-      if (enable) {
-        LOG(INFO) << "Enable incremental parse look ahead.";
-        ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);
-        resolver->Resolve();
-      } else {
-        LOG(WARNING) << kMediaIncrementalParseLookAhead
-                     << " cannot be disabled.";
-        resolver->Reject(V8ThrowException::CreateTypeError(
-            script_state->GetIsolate(),
-            kMediaIncrementalParseLookAhead + String(" cannot be disabled.")));
-      }
-    } else {
-      LOG(WARNING) << "The value for '" << kMediaIncrementalParseLookAhead
-                   << "' must be a number.";
-      resolver->Reject(V8ThrowException::CreateTypeError(
-          script_state->GetIsolate(), String("The value for '") +
-                                          kMediaIncrementalParseLookAhead +
-                                          "' must be a number."));
-    }
-    return promise;
+  if (name_view == kMediaIncrementalParseLookAhead) {
+    return ProcessEnableOnlySetting(context, value, name, [] {
+      ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);
+    });
   }
 
   EnsureReceiverIsBound();
+
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
+      script_state, exception_state.GetContext());
 
   h5vcc_settings::mojom::blink::ValuePtr mojo_value;
   if (value->IsString()) {
@@ -229,7 +236,7 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
     NOTREACHED();
     resolver->Reject(V8ThrowException::CreateTypeError(
         script_state->GetIsolate(), "Unsupported type."));
-    return promise;
+    return resolver->Promise();
   }
 
   ongoing_requests_.insert(resolver);
@@ -237,7 +244,7 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
       name, std::move(mojo_value),
       WTF::BindOnce(&H5vccSettings::OnSetValueFinished, WrapPersistent(this),
                     WrapPersistent(resolver)));
-  return promise;
+  return resolver->Promise();
 }
 
 void H5vccSettings::OnSetValueFinished(ScriptPromiseResolver* resolver) {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -46,17 +46,25 @@ constexpr char kDecoderBufferSettingPrefix[] = "DecoderBuffer.";
 
 constexpr char kDecoderBufferEnableMediaBufferPoolAllocatorStrategy[] =
     "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
-static_assert(
-    std::string_view(kDecoderBufferEnableMediaBufferPoolAllocatorStrategy)
-        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
-    kDecoderBufferSettingPrefix);
 
 constexpr char kDecoderBufferEnableInPlaceReuseAllocatorBase[] =
     "DecoderBuffer.EnableInPlaceReuseAllocatorBase";
+
+constexpr bool StartsWithLiteral(const char* str, const char* prefix) {
+  while (*prefix != '\0') {
+    if (*str++ != *prefix++) {
+      return false;
+    }
+  }
+  return true;
+}
+
 static_assert(
-    std::string_view(kDecoderBufferEnableInPlaceReuseAllocatorBase)
-        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
-    kDecoderBufferSettingPrefix);
+    StartsWithLiteral(kDecoderBufferEnableMediaBufferPoolAllocatorStrategy,
+                      kDecoderBufferSettingPrefix));
+
+static_assert(StartsWithLiteral(kDecoderBufferEnableInPlaceReuseAllocatorBase,
+                                kDecoderBufferSettingPrefix));
 
 struct SettingContext {
   ScriptState* script_state;

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -36,16 +36,27 @@
 namespace blink {
 namespace {
 
-constexpr char kEnableInPlaceReuseAllocatorBase[] =
-    "DecoderBuffer.EnableInPlaceReuseAllocatorBase";
-constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
-    "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
 constexpr char kMediaAppendFirstSegmentSynchronously[] =
     "Media.AppendFirstSegmentSynchronously";
 constexpr char kMediaExperimentalMaxPendingBytesPerParse[] =
     "Media.ExperimentalMaxPendingBytesPerParse";
 constexpr char kMediaIncrementalParseLookAhead[] =
     "Media.IncrementalParseLookAhead";
+constexpr char kDecoderBufferSettingPrefix[] = "DecoderBuffer.";
+
+constexpr char kDecoderBufferEnableMediaBufferPoolAllocatorStrategy[] =
+    "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
+static_assert(
+    std::string_view(kDecoderBufferEnableMediaBufferPoolAllocatorStrategy)
+        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
+    kDecoderBufferSettingPrefix);
+
+constexpr char kDecoderBufferEnableInPlaceReuseAllocatorBase[] =
+    "DecoderBuffer.EnableInPlaceReuseAllocatorBase";
+static_assert(
+    std::string_view(kDecoderBufferEnableInPlaceReuseAllocatorBase)
+        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
+    kDecoderBufferSettingPrefix);
 
 struct SettingContext {
   ScriptState* script_state;
@@ -59,16 +70,18 @@ using Result = base::expected<void, String>;
 ScriptPromise Reject(const SettingContext& context, const String& error) {
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
       context.script_state, context.exception_context);
+  ScriptPromise promise = resolver->Promise();
   resolver->Reject(V8ThrowException::CreateTypeError(
       context.script_state->GetIsolate(), error));
-  return resolver->Promise();
+  return promise;
 }
 
 ScriptPromise Resolve(const SettingContext& context) {
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
       context.script_state, context.exception_context);
+  ScriptPromise promise = resolver->Promise();
   resolver->Resolve();
-  return resolver->Promise();
+  return promise;
 }
 
 template <typename T, typename Callback>
@@ -124,28 +137,27 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
   SettingContext context{script_state, exception_state.GetContext(), value,
                          name};
 
-  // Use StringView to enable template-based comparison with string literals.
-  // This allows the compiler to use the literal's size at compile-time (via
-  // sizeof), avoiding runtime length calculations (strlen) during equality
-  // checks.
-  WTF::StringView name_view(name);
-  if (name_view == kEnableMediaBufferPoolAllocatorStrategy) {
+  if (name == kDecoderBufferEnableMediaBufferPoolAllocatorStrategy) {
     return ProcessEnableOnlySetting(context, [] {
       ::media::DecoderBuffer::EnableMediaBufferPoolStrategy();
     });
   }
-  if (name_view == kEnableInPlaceReuseAllocatorBase) {
+  if (name == kDecoderBufferEnableInPlaceReuseAllocatorBase) {
     return ProcessEnableOnlySetting(context, [] {
       ::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase();
     });
   }
-  if (name_view == kMediaAppendFirstSegmentSynchronously) {
+  if (name.StartsWith(kDecoderBufferSettingPrefix)) {
+    return Reject(context, name + " isn't a supported setting.");
+  }
+
+  if (name == kMediaAppendFirstSegmentSynchronously) {
     return ProcessSettingAs<bool>(context, [this](bool enable) -> Result {
       append_first_segment_synchronously_ = enable;
       return base::ok();
     });
   }
-  if (name_view == kMediaExperimentalMaxPendingBytesPerParse) {
+  if (name == kMediaExperimentalMaxPendingBytesPerParse) {
     return ProcessSettingAs<int>(context, [](int value) -> Result {
       if (value <= 0) {
         return base::unexpected(kMediaExperimentalMaxPendingBytesPerParse +
@@ -156,16 +168,13 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
       return base::ok();
     });
   }
-  if (name_view == kMediaIncrementalParseLookAhead) {
+  if (name == kMediaIncrementalParseLookAhead) {
     return ProcessEnableOnlySetting(context, [] {
       ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);
     });
   }
 
   EnsureReceiverIsBound();
-
-  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
-      script_state, exception_state.GetContext());
 
   h5vcc_settings::mojom::blink::ValuePtr mojo_value;
   if (value->IsString()) {
@@ -176,11 +185,11 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
         h5vcc_settings::mojom::blink::Value::NewIntValue(value->GetAsLong());
   } else {
     NOTREACHED();
-    resolver->Reject(V8ThrowException::CreateTypeError(
-        script_state->GetIsolate(), "Unsupported type."));
-    return resolver->Promise();
+    return Reject(context, "Unsupported type.");
   }
 
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
+      script_state, exception_state.GetContext());
   ongoing_requests_.insert(resolver);
   remote_h5vcc_settings_->SetValue(
       name, std::move(mojo_value),

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -190,12 +190,13 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
 
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver>(
       script_state, exception_state.GetContext());
+  auto promise = resolver->Promise();
   ongoing_requests_.insert(resolver);
   remote_h5vcc_settings_->SetValue(
       name, std::move(mojo_value),
       WTF::BindOnce(&H5vccSettings::OnSetValueFinished, WrapPersistent(this),
                     WrapPersistent(resolver)));
-  return resolver->Promise();
+  return promise;
 }
 
 void H5vccSettings::OnSetValueFinished(ScriptPromiseResolver* resolver) {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -36,22 +36,23 @@
 namespace blink {
 namespace {
 
-static constexpr char kEnableInPlaceReuseAllocatorBase[] =
+constexpr char kEnableInPlaceReuseAllocatorBase[] =
     "DecoderBuffer.EnableInPlaceReuseAllocatorBase";
-static constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
+constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
     "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
-static constexpr char kMediaAppendFirstSegmentSynchronously[] =
+constexpr char kMediaAppendFirstSegmentSynchronously[] =
     "Media.AppendFirstSegmentSynchronously";
-static constexpr char kMediaExperimentalMaxPendingBytesPerParse[] =
+constexpr char kMediaExperimentalMaxPendingBytesPerParse[] =
     "Media.ExperimentalMaxPendingBytesPerParse";
-static constexpr char kMediaIncrementalParseLookAhead[] =
+constexpr char kMediaIncrementalParseLookAhead[] =
     "Media.IncrementalParseLookAhead";
-static constexpr char kDecoderBufferSettingPrefix[] = "DecoderBuffer.";
 
 struct ScriptContext {
   ScriptState* script_state;
   const ExceptionContext& exception_context;
 };
+
+using Result = base::expected<void, String>;
 
 template <typename T, typename Callback>
 ScriptPromise ProcessSettingAs(const ScriptContext& context,
@@ -69,15 +70,17 @@ ScriptPromise ProcessSettingAs(const ScriptContext& context,
     return resolver->Promise();
   }
 
-  base::expected<void, String> result =
-      callback(static_cast<T>(value->GetAsLong()));
-  if (result.has_value()) {
-    resolver->Resolve();
-  } else {
+  Result result = callback(static_cast<T>(value->GetAsLong()));
+  if (!result.has_value()) {
+    LOG(WARNING) << "Failed to set " << name << " to " << value->GetAsLong()
+                 << ": " << result.error();
     resolver->Reject(V8ThrowException::CreateTypeError(
         context.script_state->GetIsolate(), result.error()));
+    return resolver->Promise();
   }
 
+  LOG(INFO) << name << " is set to " << value->GetAsLong();
+  resolver->Resolve();
   return resolver->Promise();
 }
 
@@ -88,14 +91,11 @@ ScriptPromise ProcessEnableOnlySetting(const ScriptContext& context,
                                        ActionCallback action) {
   return ProcessSettingAs<bool>(
       context, value, name,
-      [name, action = std::move(action)](
-          bool enable) -> base::expected<void, String> {
+      [name, action = std::move(action)](bool enable) -> Result {
         if (!enable) {
-          LOG(WARNING) << name << " cannot be disabled.";
           return base::unexpected(name + " cannot be disabled.");
         }
 
-        LOG(INFO) << "Enabling " << name << ".";
         action();
         return base::ok();
       });
@@ -132,42 +132,23 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
       ::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase();
     });
   }
-  if (name_view == kMediaIncrementalParseLookAhead) {
-    return ProcessEnableOnlySetting(context, value, name, [] {
-      ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);
-    });
-  }
   if (name_view == kMediaAppendFirstSegmentSynchronously) {
     return ProcessSettingAs<bool>(
-        context, value, name,
-        [this](bool enable) -> base::expected<void, String> {
+        context, value, name, [this](bool enable) -> Result {
           append_first_segment_synchronously_ = enable;
-          if (enable) {
-            LOG(INFO)
-                << "Enable synchronous append of first media source segment.";
-          } else {
-            LOG(INFO) << "Disable synchronous append of first media source"
-                      << " segment.";
-          }
           return base::ok();
         });
   }
   if (name_view == kMediaExperimentalMaxPendingBytesPerParse) {
-    return ProcessSettingAs<int>(
-        context, value, name, [](int value) -> base::expected<void, String> {
-          if (value > 0) {
-            LOG(INFO) << "Setting " << kMediaExperimentalMaxPendingBytesPerParse
-                      << " to " << value << " bytes.";
-            ::media::SourceBufferState::SetMaxPendingBytesPerParseOverride(
-                value);
-            return base::ok();
-          } else {
-            LOG(WARNING) << kMediaExperimentalMaxPendingBytesPerParse
-                         << " must be set to a positive integer";
-            return base::unexpected(kMediaExperimentalMaxPendingBytesPerParse +
-                                    String(" must be a positive integer."));
-          }
-        });
+    return ProcessSettingAs<int>(context, value, name, [](int value) -> Result {
+      if (value <= 0) {
+        return base::unexpected(kMediaExperimentalMaxPendingBytesPerParse +
+                                String(" must be a positive integer."));
+      }
+
+      ::media::SourceBufferState::SetMaxPendingBytesPerParseOverride(value);
+      return base::ok();
+    });
   }
   if (name_view == kMediaIncrementalParseLookAhead) {
     return ProcessEnableOnlySetting(context, value, name, [] {


### PR DESCRIPTION
This PR is to avoid repeated code by introducing helper methods

Introduce a ProcessLongAs template helper to consolidate
redundant V8 type checking and promise rejection logic for boolean
settings. This streamlines the validation and conversion of
V8UnionLongOrString values, simplifying H5vccSettings::set and
ProcessDecoderBufferSettings. It also standardizes promise handling.

Issue: 480134029