### PR TITLE
Deprecate Sb system properties for IFA and migrate to Starboard IFA e…

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -481,16 +481,14 @@ public class StarboardBridge {
   }
 
   // TODO: (cobalt b/372559388) remove or migrate JNI?
-  // Used in starboard/android/shared/system_get_property.cc
-  /** Returns string for kSbSystemPropertyAdvertisingId */
+  // Used in cobalt/browser/h5vcc_system/h5vcc_system_impl_android.cc
   @CalledByNative
   protected String getAdvertisingId() {
     return mAdvertisingId.getId();
   }
 
   // TODO: (cobalt b/372559388) remove or migrate JNI?
-  // Used in starboard/android/shared/system_get_property.cc
-  /** Returns boolean for kSbSystemPropertyLimitAdTracking */
+  // Used in cobalt/browser/h5vcc_system/h5vcc_system_impl_android.cc
   @CalledByNative
   protected boolean getLimitAdTracking() {
     return mAdvertisingId.isLimitAdTrackingEnabled();

--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -8,6 +8,8 @@ since the version previous to it.
 **NOTE: Starboard versions 16 and older are no longer supported.**
 
 ## Version 17
+### Removed kSbSystemPropertyAdvertisingId and kSbSystemPropertyLimitAdTracking
+The functionality is migrated to the IFA extension.
 Starboard 17 fully switches to POSIX APIs.
 
 ### Removed SbCPUFeaturesGet

--- a/starboard/android/shared/system_get_property.cc
+++ b/starboard/android/shared/system_get_property.cc
@@ -142,19 +142,6 @@ bool SbSystemGetProperty(SbSystemPropertyId property_id,
           out_value, value_length,
           StarboardBridge::GetInstance()->GetUserAgentAuxField(env).c_str());
     }
-    case kSbSystemPropertyAdvertisingId: {
-      JNIEnv* env = AttachCurrentThread();
-      return CopyStringAndTestIfSuccess(
-          out_value, value_length,
-          StarboardBridge::GetInstance()->GetAdvertisingId(env).c_str());
-    }
-    case kSbSystemPropertyLimitAdTracking: {
-      JNIEnv* env = AttachCurrentThread();
-      bool limit_ad_tracking_enabled =
-          StarboardBridge::GetInstance()->GetLimitAdTracking(env);
-      return CopyStringAndTestIfSuccess(out_value, value_length,
-                                        limit_ad_tracking_enabled ? "1" : "0");
-    }
     case kSbSystemPropertyDeviceType:
       return CopyStringAndTestIfSuccess(out_value, value_length,
                                         starboard::kSystemDeviceTypeAndroidTV);

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -287,6 +287,8 @@ static_library("starboard_platform_sources") {
     "speech/speech_synthesis_speak.cc",
     "system/system_egl.cc",
     "system/system_get_extensions.cc",
+    "system/ifa.cc",
+    "system/ifa.h",
     "system/system_get_path.cc",
     "system/system_get_property.cc",
     "system/system_has_capability.cc",

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/ifa.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/ifa.cc
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "starboard/linux/shared/ifa.h"
-
-#include "starboard/common/string.h"
 #include "starboard/extension/ifa.h"
-#include "starboard/shared/environment.h"
+#include "starboard/common/string.h"
+#include "third_party/starboard/rdk/shared/system/advertising_id.h"
 
+namespace third_party {
 namespace starboard {
-
+namespace rdk {
+namespace shared {
 namespace {
 
 bool CopyStringAndTestIfSuccess(char* out_value,
@@ -28,37 +28,31 @@ bool CopyStringAndTestIfSuccess(char* out_value,
   if (strlen(from_value) + 1 > value_length) {
     return false;
   }
-  starboard::strlcpy(out_value, from_value, value_length);
+  ::starboard::strlcpy(out_value, from_value, value_length);
   return true;
 }
 
-// Definitions of any functions included as components in the extension
-// are added here.
-
 bool GetAdvertisingId(char* out_value, int value_length) {
-  return CopyStringAndTestIfSuccess(
-      out_value, value_length,
-      starboard::GetEnvironment("COBALT_ADVERTISING_ID").c_str());
+    std::string prop;
+    if (AdvertisingId::GetIfa(prop)) {
+      return CopyStringAndTestIfSuccess(out_value, value_length, prop.c_str());
+    }
+    return false;
 }
 
 bool GetLimitAdTracking(char* out_value, int value_length) {
-  return CopyStringAndTestIfSuccess(
-      out_value, value_length,
-      GetEnvironment("COBALT_LIMIT_AD_TRACKING").c_str());
-}
-
-bool GetTrackingAuthorizationStatus(char* out_value, int value_length) {
-  return CopyStringAndTestIfSuccess(
-      out_value, value_length,
-      GetEnvironment("COBALT_TRACKING_AUTHORIZATION_STATUS").c_str());
+    std::string prop;
+    if (AdvertisingId::GetLmtAdTracking(prop)) {
+      return CopyStringAndTestIfSuccess(out_value, value_length, prop.c_str());
+    }
+    return false;
 }
 
 const StarboardExtensionIfaApi kIfaApi = {
     kStarboardExtensionIfaName,
-    2,  // API version that's implemented.
+    1,  // API version that's implemented.
     &GetAdvertisingId,
     &GetLimitAdTracking,
-    &GetTrackingAuthorizationStatus,
 };
 
 }  // namespace
@@ -67,4 +61,7 @@ const void* GetIfaApi() {
   return &kIfaApi;
 }
 
+}  // namespace shared
+}  // namespace rdk
 }  // namespace starboard
+}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/ifa.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/ifa.h
@@ -1,0 +1,30 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// you may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef THIRD_PARTY_STARBOARD_RDK_SHARED_SYSTEM_IFA_H_
+#define THIRD_PARTY_STARBOARD_RDK_SHARED_SYSTEM_IFA_H_
+
+namespace third_party {
+namespace starboard {
+namespace rdk {
+namespace shared {
+
+const void* GetIfaApi();
+
+}  // namespace shared
+}  // namespace rdk
+}  // namespace starboard
+}  // namespace third_party
+
+#endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_SYSTEM_IFA_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
@@ -80,6 +80,9 @@ const void* SbSystemGetExtension(const char* name) {
   if (strcmp(name, kStarboardExtensionAccessibilityName) == 0) {
     return third_party::starboard::rdk::shared::GetAccessibilityApi();
   }
+  if (strcmp(name, kStarboardExtensionIfaName) == 0) {
+    return third_party::starboard::rdk::shared::GetIfaApi();
+  }
   return NULL;
 }
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_property.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_property.cc
@@ -238,21 +238,6 @@ bool GetCertificationScope(char* out_value, int value_length) {
   return starboard::strlcpy<char>(out_value, buf.data(), value_length);
 }
 
-bool GetLimitAdTracking(char* out_value, int value_length) {
-    std::string prop;
-    if (AdvertisingId::GetLmtAdTracking(prop)) {
-      return CopyStringAndTestIfSuccess(out_value, value_length, prop.c_str());
-    }
-    return false;
-}
-
-bool GetAdvertisingId(char* out_value, int value_length) {
-    std::string prop;
-    if (AdvertisingId::GetIfa(prop)) {
-      return CopyStringAndTestIfSuccess(out_value, value_length, prop.c_str());
-    }
-    return false;
-}
 
 bool GetDeviceType(char* out_value, int value_length) {
     std::string prop;
@@ -304,12 +289,6 @@ bool SbSystemGetProperty(SbSystemPropertyId property_id,
 
     case kSbSystemPropertyCertificationScope:
       return GetCertificationScope(out_value, value_length);
-
-    case kSbSystemPropertyAdvertisingId:
-      return GetAdvertisingId(out_value, value_length);
-
-    case kSbSystemPropertyLimitAdTracking:
-      return GetLimitAdTracking(out_value, value_length);
 
     case kSbSystemPropertyDeviceType:
       return GetDeviceType(out_value, value_length);

--- a/starboard/extension/ifa.h
+++ b/starboard/extension/ifa.h
@@ -38,16 +38,10 @@ typedef struct StarboardExtensionIfaApi {
   // Advertising ID or IFA, typically a 128-bit UUID
   // Please see https://iabtechlab.com/OTT-IFA for details.
   // Corresponds to 'ifa' field. Note: `ifa_type` field is not provided.
-  // In Starboard 14 this the value is retrieved through the system
-  // property `kSbSystemPropertyAdvertisingId` defined in
-  // `starboard/system.h`.
   bool (*GetAdvertisingId)(char* out_value, int value_length);
 
   // Limit advertising tracking, treated as boolean. Set to nonzero to indicate
   // a true value. Corresponds to 'lmt' field.
-  // In Starboard 14 this the value is retrieved through the system
-  // property `kSbSystemPropertyLimitAdTracking` defined in
-  // `starboard/system.h`.
   bool (*GetLimitAdTracking)(char* out_value, int value_length);
 
   // The fields below this point were added in version 2 or later.

--- a/starboard/linux/shared/system_get_extensions.cc
+++ b/starboard/linux/shared/system_get_extensions.cc
@@ -69,6 +69,9 @@ const void* SbSystemGetExtension(const char* name) {
   if (strcmp(name, kCobaltExtensionFreeSpaceName) == 0) {
     return starboard::GetFreeSpaceApi();
   }
+  if (strcmp(name, kStarboardExtensionIfaName) == 0) {
+    return starboard::GetIfaApi();
+  }
 #if SB_IS(EVERGREEN_COMPATIBLE)
   if (strcmp(name, kStarboardExtensionLoaderAppMetricsName) == 0) {
     return starboard::GetLoaderAppMetricsApi();

--- a/starboard/linux/x64x11/system_get_property_impl.cc
+++ b/starboard/linux/x64x11/system_get_property_impl.cc
@@ -110,15 +110,6 @@ bool GetSystemPropertyLinux(SbSystemPropertyId property_id,
     case kSbSystemPropertySpeechApiKey:
     case kSbSystemPropertyUserAgentAuxField:
       return false;
-    // Implementation provided for testing purposes only
-    case kSbSystemPropertyAdvertisingId:
-      return CopyStringAndTestIfSuccess(
-          out_value, value_length,
-          GetEnvironment("COBALT_ADVERTISING_ID").c_str());
-    case kSbSystemPropertyLimitAdTracking:
-      return CopyStringAndTestIfSuccess(
-          out_value, value_length,
-          GetEnvironment("COBALT_LIMIT_AD_TRACKING").c_str());
     case kSbSystemPropertyDeviceType:
       return CopyStringAndTestIfSuccess(out_value, value_length,
                                         kSystemDeviceTypeDesktopPC);

--- a/starboard/raspi/shared/ifa.cc
+++ b/starboard/raspi/shared/ifa.cc
@@ -12,14 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "starboard/linux/shared/ifa.h"
-
-#include "starboard/common/string.h"
 #include "starboard/extension/ifa.h"
+#include "starboard/common/string.h"
 #include "starboard/shared/environment.h"
 
 namespace starboard {
-
+namespace raspi {
 namespace {
 
 bool CopyStringAndTestIfSuccess(char* out_value,
@@ -32,9 +30,6 @@ bool CopyStringAndTestIfSuccess(char* out_value,
   return true;
 }
 
-// Definitions of any functions included as components in the extension
-// are added here.
-
 bool GetAdvertisingId(char* out_value, int value_length) {
   return CopyStringAndTestIfSuccess(
       out_value, value_length,
@@ -44,21 +39,14 @@ bool GetAdvertisingId(char* out_value, int value_length) {
 bool GetLimitAdTracking(char* out_value, int value_length) {
   return CopyStringAndTestIfSuccess(
       out_value, value_length,
-      GetEnvironment("COBALT_LIMIT_AD_TRACKING").c_str());
-}
-
-bool GetTrackingAuthorizationStatus(char* out_value, int value_length) {
-  return CopyStringAndTestIfSuccess(
-      out_value, value_length,
-      GetEnvironment("COBALT_TRACKING_AUTHORIZATION_STATUS").c_str());
+      starboard::GetEnvironment("COBALT_LIMIT_AD_TRACKING").c_str());
 }
 
 const StarboardExtensionIfaApi kIfaApi = {
     kStarboardExtensionIfaName,
-    2,  // API version that's implemented.
+    1,  // API version that's implemented.
     &GetAdvertisingId,
     &GetLimitAdTracking,
-    &GetTrackingAuthorizationStatus,
 };
 
 }  // namespace
@@ -67,4 +55,5 @@ const void* GetIfaApi() {
   return &kIfaApi;
 }
 
+}  // namespace raspi
 }  // namespace starboard

--- a/starboard/raspi/shared/ifa.h
+++ b/starboard/raspi/shared/ifa.h
@@ -1,0 +1,26 @@
+// Copyright 2023 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// you may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_RASPI_SHARED_IFA_H_
+#define STARBOARD_RASPI_SHARED_IFA_H_
+
+namespace starboard {
+namespace raspi {
+
+const void* GetIfaApi();
+
+}  // namespace raspi
+}  // namespace starboard
+
+#endif  // STARBOARD_RASPI_SHARED_IFA_H_

--- a/starboard/raspi/shared/system_get_extensions.cc
+++ b/starboard/raspi/shared/system_get_extensions.cc
@@ -20,8 +20,10 @@
 #include "starboard/common/string.h"
 #include "starboard/extension/configuration.h"
 #include "starboard/extension/graphics.h"
+#include "starboard/extension/ifa.h"
 #include "starboard/raspi/shared/configuration.h"
 #include "starboard/raspi/shared/graphics.h"
+#include "starboard/raspi/shared/ifa.h"
 
 #if SB_IS(EVERGREEN_COMPATIBLE)
 #include "starboard/elf_loader/evergreen_config.h"
@@ -52,6 +54,9 @@ const void* SbSystemGetExtension(const char* name) {
   }
   if (strcmp(name, kCobaltExtensionGraphicsName) == 0) {
     return starboard::GetGraphicsApi();
+  }
+  if (strcmp(name, kStarboardExtensionIfaName) == 0) {
+    return starboard::raspi::GetIfaApi();
   }
 #if BUILDFLAG(USE_EVERGREEN)
   if (strcmp(name, kCobaltExtensionCrashHandlerName) == 0) {

--- a/starboard/raspi/shared/system_get_property.cc
+++ b/starboard/raspi/shared/system_get_property.cc
@@ -149,15 +149,6 @@ bool SbSystemGetProperty(SbSystemPropertyId property_id,
     case kSbSystemPropertySpeechApiKey:
       return false;
 
-    // Implementation provided for testing purposes only
-    case kSbSystemPropertyAdvertisingId:
-      return CopyStringAndTestIfSuccess(
-          out_value, value_length,
-          starboard::GetEnvironment("COBALT_ADVERTISING_ID").c_str());
-    case kSbSystemPropertyLimitAdTracking:
-      return CopyStringAndTestIfSuccess(
-          out_value, value_length,
-          starboard::GetEnvironment("COBALT_LIMIT_AD_TRACKING").c_str());
 
     case kSbSystemPropertyFriendlyName:
       return CopyStringAndTestIfSuccess(out_value, value_length, kFriendlyName);

--- a/starboard/system.h
+++ b/starboard/system.h
@@ -123,14 +123,7 @@ typedef enum SbSystemPropertyId {
   // A field that, if available, is appended to the user agent
   kSbSystemPropertyUserAgentAuxField,
 
-  // Advertising ID or IFA, typically a 128-bit UUID
-  // Please see https://iabtechlab.com/OTT-IFA for details.
-  // Corresponds to 'ifa' field. Note: `ifa_type` field is not provided.
-  kSbSystemPropertyAdvertisingId,
 
-  // Limit advertising tracking, treated as boolean. Set to nonzero to indicate
-  // a true value. Corresponds to 'lmt' field.
-  kSbSystemPropertyLimitAdTracking,
 
   // Type of the device, e.g. such as "TV", "STB", "OTT"
   // Please see Youtube Technical requirements for a full list of allowed values

--- a/starboard/tvos/shared/system_get_property.mm
+++ b/starboard/tvos/shared/system_get_property.mm
@@ -153,11 +153,6 @@ bool SbSystemGetProperty(SbSystemPropertyId property_id,
         // functionality is clear in Chrobalt.
         SB_NOTIMPLEMENTED();
         return false;
-      case kSbSystemPropertyAdvertisingId:
-      case kSbSystemPropertyLimitAdTracking: {
-        SB_LOG(INFO) << "IFA is not supported via Starboard.";
-        return false;
-      }
       case kSbSystemPropertyDeviceType:
         return CopyStringAndTestIfSuccess(
             out_value, value_length, starboard::kSystemDeviceTypeOverTheTopBox);


### PR DESCRIPTION
starboard: Migrate IFA properties to extension API

Remove kSbSystemPropertyAdvertisingId and kSbSystemPropertyLimitAdTracking from
starboard/system.h and all platform implementations. Implement and register
the Starboard IFA extension for Linux, RasPi, and RDK platforms. The
browser-side H5VCC system implementation is updated to use the IFA extension
exclusively for retrieving Advertising ID and Limit Ad Tracking status. This
change centralizes and standardizes the API for IFA, deprecating the use of
direct system properties for this functionality.

Issue : 487771138
Issue: 445433945