### PR TITLE
cobalt: Lower the priority of NetworkService

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -66,6 +66,9 @@ public class JavaSwitches {
   /** flag to enable SkiaFontCache */
   public static final String SKIA_FONT_CACHE = "SkiaFontCache";
 
+  /** flag to lower the priority of the network service thread */
+  public static final String LOWER_NETWORK_SERVICE_THREAD_PRIORITY = "LowerNetworkServiceThreadPriority";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
     if (!javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
@@ -143,6 +146,10 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.SKIA_FONT_CACHE)) {
       extraCommandLineArgs.add("--enable-features=SkiaFontCache");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.LOWER_NETWORK_SERVICE_THREAD_PRIORITY)) {
+      extraCommandLineArgs.add("--enable-features=LowerNetworkServiceThreadPriority");
     }
 
     return extraCommandLineArgs;

--- a/content/browser/network_service_instance_impl.cc
+++ b/content/browser/network_service_instance_impl.cc
@@ -144,6 +144,13 @@ BASE_FEATURE(kNetworkServiceDedicatedThread,
 #endif
 );
 
+#if BUILDFLAG(IS_COBALT)
+BASE_FEATURE(kLowerNetworkServiceThreadPriority,
+             "LowerNetworkServiceThreadPriority",
+             base::FEATURE_DISABLED_BY_DEFAULT
+);
+#endif  // BUILDFLAG(IS_COBALT)
+
 base::Thread& GetNetworkServiceDedicatedThread() {
   static base::NoDestructor<base::Thread> thread{"NetworkService"};
   DCHECK(base::FeatureList::IsEnabled(kNetworkServiceDedicatedThread));
@@ -354,6 +361,11 @@ void CreateInProcessNetworkService(
   scoped_refptr<base::SingleThreadTaskRunner> task_runner;
   if (base::FeatureList::IsEnabled(kNetworkServiceDedicatedThread)) {
     base::Thread::Options options(base::MessagePumpType::IO, 0);
+#if BUILDFLAG(IS_COBALT)
+    if (base::FeatureList::IsEnabled(kLowerNetworkServiceThreadPriority)) {
+      options.thread_type = base::ThreadType::kResourceEfficient;
+    }
+#endif  // BUILDFLAG(IS_COBALT)
     GetNetworkServiceDedicatedThread().StartWithOptions(std::move(options));
     task_runner = GetNetworkServiceDedicatedThread().task_runner();
   } else {


### PR DESCRIPTION
When the NetworkService is configured to run on a dedicated thread,
set its thread priority to kResourceEfficient. This ensures that
network operations do not aggressively compete with higher priority
tasks, which is critical for resource-constrained Cobalt devices.

Issue: 487329029