### PR TITLE
media: Replace absl::optional with std::optional

### DIFF
--- a/cobalt/testing/browser_tests/media_session_browsertest.cc
+++ b/cobalt/testing/browser_tests/media_session_browsertest.cc
@@ -14,6 +14,8 @@
 
 #include "content/public/browser/media_session.h"
 
+#include <optional>
+
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/functional/callback_helpers.h"
@@ -40,7 +42,6 @@
 #include "services/media_session/public/cpp/features.h"
 #include "services/media_session/public/cpp/test/audio_focus_test_util.h"
 #include "services/media_session/public/cpp/test/mock_media_session.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace content {
 
@@ -83,7 +84,7 @@ class MediaImageGetterHelper {
   }
 
   base::RunLoop run_loop_;
-  absl::optional<SkBitmap> bitmap_;
+  std::optional<SkBitmap> bitmap_;
 };
 
 // Integration tests for content::MediaSession that do not take into

--- a/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
@@ -14,6 +14,8 @@
 
 #include "media/mojo/clients/starboard/starboard_renderer_client.h"
 
+#include <optional>
+
 #include "base/functional/callback_helpers.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/test/gmock_callback_support.h"
@@ -60,7 +62,7 @@ class FakeMojomRenderer : public mojom::Renderer {
   MOCK_METHOD1(SetPlaybackRate, void(double));
   void SetVolume(float volume) override {}
   MOCK_METHOD2(SetCdm,
-               void(const absl::optional<base::UnguessableToken>&,
+               void(const std::optional<base::UnguessableToken>&,
                     SetCdmCallback));
   void SetLatencyHint(std::optional<::base::TimeDelta> latency_hint) override {}
 };
@@ -107,7 +109,7 @@ class MockRendererClientStarboard : public RendererClient {
   MOCK_METHOD1(OnVideoConfigChange, void(const VideoDecoderConfig&));
   MOCK_METHOD1(OnVideoNaturalSizeChange, void(const gfx::Size&));
   MOCK_METHOD1(OnVideoOpacityChange, void(bool));
-  MOCK_METHOD1(OnVideoFrameRateChange, void(absl::optional<int>));
+  MOCK_METHOD1(OnVideoFrameRateChange, void(std::optional<int>));
   MOCK_METHOD0(IsVideoStreamAvailable, bool());
 };
 

--- a/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
+++ b/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <optional>
+
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/single_thread_task_runner.h"
 #include "media/base/audio_decoder.h"
@@ -40,7 +42,7 @@ class GpuMojoMediaClientStarboard final : public GpuMojoMediaClient {
     return nullptr;
   }
 
-  absl::optional<SupportedVideoDecoderConfigs>
+  std::optional<SupportedVideoDecoderConfigs>
   GetPlatformSupportedVideoDecoderConfigs() final {
     return {};
   }

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -129,7 +129,7 @@ void StarboardRendererWrapper::SetCdm(CdmContext* cdm_context,
 }
 
 void StarboardRendererWrapper::SetLatencyHint(
-    absl::optional<base::TimeDelta> latency_hint) {
+    std::optional<base::TimeDelta> latency_hint) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   GetRenderer()->SetLatencyHint(latency_hint);
 }

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -15,6 +15,8 @@
 #ifndef MEDIA_MOJO_SERVICES_STARBOARD_STARBOARD_RENDERER_WRAPPER_H_
 #define MEDIA_MOJO_SERVICES_STARBOARD_STARBOARD_RENDERER_WRAPPER_H_
 
+#include <optional>
+
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/threading/sequence_bound.h"
@@ -67,7 +69,7 @@ class StarboardRendererWrapper : public Renderer,
                   RendererClient* client,
                   PipelineStatusCallback init_cb) override;
   void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
-  void SetLatencyHint(absl::optional<base::TimeDelta> latency_hint) override;
+  void SetLatencyHint(std::optional<base::TimeDelta> latency_hint) override;
   void Flush(base::OnceClosure flush_cb) override;
   void StartPlayingFrom(base::TimeDelta time) override;
   void SetPlaybackRate(double playback_rate) override;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -15,6 +15,7 @@
 #include "media/mojo/services/starboard/starboard_renderer_wrapper.h"
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "base/functional/bind.h"
@@ -87,7 +88,7 @@ class MockStarboardRenderer : public StarboardRenderer {
                void(MediaResource* media_resource,
                     RendererClient* client,
                     PipelineStatusCallback& init_cb));
-  MOCK_METHOD1(SetLatencyHint, void(absl::optional<TimeDelta>));
+  MOCK_METHOD1(SetLatencyHint, void(std::optional<TimeDelta>));
   MOCK_METHOD1(SetPreservesPitch, void(bool));
   MOCK_METHOD1(SetWasPlayedWithUserActivation, void(bool));
   void Flush(base::OnceClosure flush_cb) override { OnFlush(flush_cb); }

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -15,6 +15,7 @@
 #ifndef MEDIA_STARBOARD_STARBOARD_RENDERER_H_
 #define MEDIA_STARBOARD_STARBOARD_RENDERER_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -32,7 +33,6 @@
 #include "media/base/renderer_client.h"
 #include "media/base/starboard/starboard_rendering_mode.h"
 #include "media/starboard/sbplayer_bridge.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 #if BUILDFLAG(IS_ANDROID)
 #include "media/base/android_overlay_mojo_factory.h"
@@ -73,7 +73,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
                   RendererClient* client,
                   PipelineStatusCallback init_cb) override;
   void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
-  void SetLatencyHint(absl::optional<TimeDelta> latency_hint) override {
+  void SetLatencyHint(std::optional<TimeDelta> latency_hint) override {
     // TODO(b/380935131): Consider to implement `LatencyHint` for SbPlayer.
     NOTIMPLEMENTED();
   }
@@ -198,7 +198,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   raw_ptr<DemuxerStream> audio_stream_ = nullptr;
   raw_ptr<DemuxerStream> video_stream_ = nullptr;
   // TODO(b/375274109): Investigate whether we should call
-  //                    `void OnVideoFrameRateChange(absl::optional<int> fps)`
+  //                    `void OnVideoFrameRateChange(std::optional<int> fps)`
   //                    on `client_`?
   raw_ptr<RendererClient> client_ = nullptr;
   PaintVideoHoleFrameCallback paint_video_hole_frame_cb_;

--- a/media/starboard/starboard_utils.cc
+++ b/media/starboard/starboard_utils.cc
@@ -286,7 +286,7 @@ ENUM_EQ(kSbMediaRangeIdDerived, gfx::ColorSpace::RangeID::DERIVED);
 
 SbMediaColorMetadata MediaToSbMediaColorMetadata(
     const VideoColorSpace& color_space,
-    const absl::optional<gfx::HDRMetadata>& hdr_metadata,
+    const std::optional<gfx::HDRMetadata>& hdr_metadata,
     const std::string& mime_type) {
   SbMediaColorMetadata sb_media_color_metadata = {};
 

--- a/media/starboard/starboard_utils.h
+++ b/media/starboard/starboard_utils.h
@@ -15,6 +15,8 @@
 #ifndef MEDIA_STARBOARD_STARBOARD_UTILS_H_
 #define MEDIA_STARBOARD_STARBOARD_UTILS_H_
 
+#include <optional>
+
 #include "media/base/audio_codecs.h"
 #include "media/base/audio_decoder_config.h"
 #include "media/base/decoder_buffer.h"
@@ -23,7 +25,6 @@
 #include "media/base/video_decoder_config.h"
 #include "starboard/drm.h"
 #include "starboard/media.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/gfx/hdr_metadata.h"
 
 namespace media {
@@ -44,7 +45,7 @@ void FillDrmSampleInfo(const scoped_refptr<DecoderBuffer>& buffer,
 
 SbMediaColorMetadata MediaToSbMediaColorMetadata(
     const VideoColorSpace& color_space,
-    const absl::optional<gfx::HDRMetadata>& hdr_metadata,
+    const std::optional<gfx::HDRMetadata>& hdr_metadata,
     const std::string& mime_type);
 
 // Extract the value of "codecs" parameter from |mime_type|. It will return


### PR DESCRIPTION
This change replaces all remaining occurrences of absl::optional with std::optional in media/starboard and related files to align with the Chromium style guide and Cobalt's coding standards.

Bug: 487283136