### PR TITLE
cobalt: Guard storage migration with integrity cookie

### DIFF
--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -20,13 +20,20 @@
 #include "base/run_loop.h"
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
+#include "cobalt/browser/switches.h"
+#include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
+#include "cobalt/shell/browser/shell.h"
 #include "cobalt/shell/browser/shell_paths.h"
+#include "cobalt/shell/common/shell_switches.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
 #include "content/public/browser/browser_context.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/storage_partition.h"
+#include "content/public/browser/web_contents.h"
 #include "services/network/public/mojom/cookie_manager.mojom.h"
+#include "url/gurl.h"
 
 #if BUILDFLAG(IS_ANDROIDTV)
 #include "base/android/memory_pressure_listener_android.h"
@@ -43,7 +50,8 @@ namespace cobalt {
 
 int CobaltBrowserMainParts::PreCreateThreads() {
 #if BUILDFLAG(IS_ANDROIDTV)
-  starboard::android::shared::StarboardBridge::GetInstance()->SetStartupMilestone(17);
+  starboard::android::shared::StarboardBridge::GetInstance()
+      ->SetStartupMilestone(17);
 #endif
   SetupMetrics();
 #if BUILDFLAG(IS_ANDROIDTV)
@@ -55,7 +63,43 @@ int CobaltBrowserMainParts::PreCreateThreads() {
 
 int CobaltBrowserMainParts::PreMainMessageLoopRun() {
   StartMetricsRecording();
-  return ShellBrowserMainParts::PreMainMessageLoopRun();
+  int result = ShellBrowserMainParts::PreMainMessageLoopRun();
+
+  LOG(INFO) << "ColinL: CobaltBrowserMainParts::PreMainMessageLoopRun started.";
+
+  // FIX: Perform migration before the first URL load happens.
+  // Using the static accessor content::Shell::windows() as GetShells() is not
+  // available on context.
+  if (!content::Shell::windows().empty()) {
+    LOG(INFO)
+        << "ColinL: Shell window detected. Preparing for storage migration.";
+    content::WebContents* web_contents =
+        content::Shell::windows()[0]->web_contents();
+
+    // 1. Kill any default navigation that might have started automatically.
+    web_contents->Stop();
+
+    // 2. Block the UI thread until migration completes.
+    // base::RunLoop run_loop;
+    migrate_storage_record::MigrationManager::EnsureMigrationDone(
+        web_contents, base::DoNothing());
+    // run_loop.Run();
+
+    // 3. Perform the actual navigation now that storage is ready.
+    // FIX: Using explicit GURL constructor call to satisfy 'explicit' keyword
+    // in gurl.h and avoiding vexing parse by using copy-initialization from a
+    // temporary. GURL initial_url =
+    // GURL(::cobalt::switches::GetInitialURL(*base::CommandLine::ForCurrentProcess()));
+    // content::NavigationController::LoadURLParams params(initial_url);
+
+    // // Use AUTO_TOPLEVEL as this is the automated "Home Page" load of the
+    // app.
+    // // Standard Chromium apps use this for the initial startup navigation.
+    // params.transition_type = ui::PAGE_TRANSITION_AUTO_TOPLEVEL;
+    // web_contents->GetController().LoadURLWithParams(params);
+  }
+
+  return result;
 }
 
 void CobaltBrowserMainParts::PostMainMessageLoopRun() {

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -67,39 +67,27 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
 
   LOG(INFO) << "ColinL: CobaltBrowserMainParts::PreMainMessageLoopRun started.";
 
-  // FIX: Perform migration before the first URL load happens.
-  // Using the static accessor content::Shell::windows() as GetShells() is not
-  // available on context.
-  if (!content::Shell::windows().empty()) {
-    LOG(INFO)
-        << "ColinL: Shell window detected. Preparing for storage migration.";
-    content::WebContents* web_contents =
-        content::Shell::windows()[0]->web_contents();
+  // Use the public accessor browser_context() instead of the private member.
+  content::StoragePartition* partition =
+      browser_context()->GetDefaultStoragePartition();
 
-    // 1. Kill any default navigation that might have started automatically.
-    web_contents->Stop();
-
-    // 2. Block the UI thread until migration completes.
-    // base::RunLoop run_loop;
-    migrate_storage_record::MigrationManager::EnsureMigrationDone(
-        web_contents, base::DoNothing());
-    // run_loop.Run();
-
-    // 3. Perform the actual navigation now that storage is ready.
-    // FIX: Using explicit GURL constructor call to satisfy 'explicit' keyword
-    // in gurl.h and avoiding vexing parse by using copy-initialization from a
-    // temporary. GURL initial_url =
-    // GURL(::cobalt::switches::GetInitialURL(*base::CommandLine::ForCurrentProcess()));
-    // content::NavigationController::LoadURLParams params(initial_url);
-
-    // // Use AUTO_TOPLEVEL as this is the automated "Home Page" load of the
-    // app.
-    // // Standard Chromium apps use this for the initial startup navigation.
-    // params.transition_type = ui::PAGE_TRANSITION_AUTO_TOPLEVEL;
-    // web_contents->GetController().LoadURLWithParams(params);
+  if (partition) {
+    cobalt::migrate_storage_record::MigrationManager::RunMigration(
+        partition, base::BindOnce(&CobaltBrowserMainParts::OnMigrationComplete,
+                                  base::Unretained(this)));
+  } else {
+    LOG(ERROR) << "ColinL: BrowserContext not available for migration.";
   }
 
   return result;
+}
+
+void CobaltBrowserMainParts::OnMigrationComplete() {
+  LOG(INFO)
+      << "ColinL: Migration complete. Proceeding with WebContents creation.";
+  // Trigger your WebContents creation / Navigate to Initial URL here
+  base::BindOnce(&CobaltBrowserMainParts::OnMigrationComplete,
+                 base::Unretained(this));
 }
 
 void CobaltBrowserMainParts::PostMainMessageLoopRun() {

--- a/cobalt/browser/cobalt_browser_main_parts.h
+++ b/cobalt/browser/cobalt_browser_main_parts.h
@@ -71,6 +71,8 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
 
   // Starts metrics recording.
   void StartMetricsRecording();
+
+  void OnMigrationComplete();
 };
 
 }  // namespace cobalt

--- a/cobalt/shell/browser/migrate_storage_record/BUILD.gn
+++ b/cobalt/shell/browser/migrate_storage_record/BUILD.gn
@@ -10,6 +10,8 @@ source_set("migrate_storage_record") {
   sources = [
     "migration_manager.cc",
     "migration_manager.h",
+    "task_sequence_runner.cc",
+    "task_sequence_runner.h",
   ]
   deps = [
     ":storage_proto",
@@ -20,6 +22,7 @@ source_set("migrate_storage_record") {
     "//net",
     "//services/network/public/mojom:cookies_mojom",
     "//starboard/common",
+    "//third_party/blink/public/mojom:mojom_platform",
     "//url",
   ]
   public_deps = [

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -45,17 +45,6 @@ namespace migrate_storage_record {
 
 namespace {
 
-constexpr char kStorageIntegrityCookieName[] = "yt-dev.storage-integrity";
-
-bool HasIntegrityCookie(const std::vector<net::CanonicalCookie>& cookies) {
-  for (const auto& cookie : cookies) {
-    if (cookie.Name() == kStorageIntegrityCookieName) {
-      return true;
-    }
-  }
-  return false;
-}
-
 std::string GetApplicationKey(const GURL& url) {
   std::string encoded_url;
   base::Base64UrlEncode(url_matcher::util::Normalize(url).spec(),
@@ -273,11 +262,10 @@ void MigrationManager::DoMigrationTasksOnce(
       ->GetAllCookies(base::BindOnce(
           [](content::WebContents* web_contents,
              const std::vector<net::CanonicalCookie>& existing_cookies) {
-            if (HasIntegrityCookie(existing_cookies)) {
-              LOG(INFO) << "MigrationManager: Storage integrity cookie from "
-                           "Cobalt 26+ already exists. Skipping migration of "
-                           "old records to avoid removing existing cookies "
-                           "and localStorage.";
+            if (!existing_cookies.empty()) {
+              LOG(INFO) << "MigrationManager: Cookies already exist. "
+                           "Skipping migration to prevent overwriting "
+                           "existing session data.";
               return;
             }
             RunMigrationTasks(web_contents);

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -40,10 +40,39 @@
 #include "starboard/system.h"
 #include "url/gurl.h"
 
+#include "components/services/storage/public/mojom/local_storage_control.mojom.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/dom_storage_context.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "third_party/blink/public/common/storage_key/storage_key.h"
+
+#include "components/services/storage/public/mojom/storage_service.mojom.h"
+#include "third_party/blink/public/mojom/dom_storage/storage_area.mojom.h"
+
 namespace cobalt {
 namespace migrate_storage_record {
 
+using StorageAreaRemote = mojo::Remote<blink::mojom::StorageArea>;
+
 namespace {
+
+// Helper to get CookieManager from Partition
+network::mojom::CookieManager* GetCookieManager(
+    content::StoragePartition* partition) {
+  return partition->GetCookieManagerForBrowserProcess();
+}
+
+// Helper to get LocalStorage Area for a specific origin
+
+void GetLocalStorageArea(content::StoragePartition* partition,
+                         const url::Origin& origin,
+                         StorageAreaRemote& out_area) {
+  // 1. Get the Local Storage Control from the partition's Storage Service
+  // This bypasses the limited DOMStorageContext interface.
+  partition->GetLocalStorageControl()->BindStorageArea(
+      blink::StorageKey::CreateFirstParty(origin),
+      out_area.BindNewPipeAndPassReceiver());
+}
 
 std::string GetApplicationKey(const GURL& url) {
   std::string encoded_url;
@@ -228,7 +257,10 @@ void DeleteOldCacheDirectoryAsync() {
 Task DeleteOldCacheDirectoryTask() {
   return base::BindOnce([](base::OnceClosure callback) {
     DeleteOldCacheDirectoryAsync();
-    std::move(callback).Run();
+    // Don't just run the callback; post it to the current sequence
+    // to give the ThreadPool a head start and clear the stack.
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE, std::move(callback));
   });
 }
 
@@ -251,162 +283,197 @@ Task MigrationManager::GroupTasks(std::vector<Task> tasks) {
       std::move(tasks));
 }
 
-// TODO(b/399165612): Add metrics.
-// TODO(b/399165796): Disable and delete migration code when possible.
-// TODO(b/399166308): Add unit and/or integration tests for migration.
-void MigrationManager::EnsureMigrationDone(content::WebContents* web_contents,
-                                           base::OnceClosure done_callback) {
-  LOG(INFO) << "ColinL: EnsureMigrationDone started.";
-  if (migration_attempted_.test_and_set()) {
-    LOG(INFO) << "ColinL: Migration already attempted this session.";
+void MigrationManager::RunMigration(content::StoragePartition* partition,
+                                    base::OnceClosure done_callback) {
+  LOG(INFO) << "ColinL: Starting Pre-MainLoop Migration.";
+
+  // 2. Get the target URL (to determine the Origin/StorageKey)
+  GURL initial_url(
+      switches::GetInitialURL(*base::CommandLine::ForCurrentProcess()));
+  if (!initial_url.is_valid()) {
     std::move(done_callback).Run();
     return;
   }
+  url::Origin origin = url::Origin::Create(initial_url);
 
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  if (command_line->HasSwitch(switches::kDisableStorageMigration)) {
-    LOG(INFO) << "ColinL: Storage migration disabled via switch.";
-    std::move(done_callback).Run();
-    return;
-  }
-
-  auto* rfh = web_contents->GetPrimaryMainFrame();
-  if (!rfh) {
-    LOG(ERROR) << "ColinL: No PrimaryMainFrame available for migration.";
-    std::move(done_callback).Run();
-    return;
-  }
-  auto weak_document_ptr = rfh->GetWeakDocumentPtr();
-
-  LOG(INFO) << "ColinL: Checking for existing cookies before migration...";
-  CookieManager(weak_document_ptr)
-      ->GetAllCookies(base::BindOnce(
-          [](content::WebContents* web_contents,
-             base::OnceClosure done_callback,
-             const std::vector<net::CanonicalCookie>& existing_cookies) {
-            if (!existing_cookies.empty()) {
-              LOG(INFO) << "ColinL: Found " << existing_cookies.size()
-                        << " existing cookies. Skipping migration.";
-              for (const auto& cookie : existing_cookies) {
-                VLOG(1) << "ColinL: Existing Cookie: " << cookie.Name();
-              }
-              std::move(done_callback).Run();
-              return;
-            }
-            LOG(INFO)
-                << "ColinL: No cookies found. Triggering RunMigrationTasks.";
-            RunMigrationTasks(web_contents, std::move(done_callback));
-          },
-          web_contents, std::move(done_callback)));
-}
-
-void MigrationManager::RunMigrationTasks(content::WebContents* web_contents,
-                                         base::OnceClosure done_callback) {
-  LOG(INFO) << "ColinL: RunMigrationTasks started.";
+  // 3. Read the legacy storage record
   auto storage = ReadStorage();
   if (!storage ||
       (storage->cookies_size() == 0 && storage->local_storages_size() == 0)) {
-    LOG(INFO) << "ColinL: Legacy storage empty or null. Nothing to migrate.";
+    LOG(INFO) << "ColinL: Nothing to migrate.";
     std::move(done_callback).Run();
     return;
   }
 
-  GURL url = web_contents->GetLastCommittedURL();
-  LOG(INFO) << "ColinL: Stopping WebContents for migration. Last URL: "
-            << url.spec();
-  web_contents->Stop();
-
-  auto* render_frame_host = web_contents->GetPrimaryMainFrame();
-  CHECK(render_frame_host);
-  auto weak_document_ptr = render_frame_host->GetWeakDocumentPtr();
-
+  // 4. Build and Run Task Group
   std::vector<Task> tasks;
-  LOG(INFO) << "ColinL: Queueing Cookie and LocalStorage tasks...";
-  tasks.push_back(CookieTask(weak_document_ptr, ToCanonicalCookies(*storage)));
-  const url::Origin& origin = render_frame_host->GetLastCommittedOrigin();
-  tasks.push_back(LocalStorageTask(weak_document_ptr,
+  tasks.push_back(CookieTask(partition, ToCanonicalCookies(*storage)));
+  tasks.push_back(LocalStorageTask(partition, origin,
                                    ToLocalStorageItems(origin, *storage)));
-#if !defined(COBALT_IS_RELEASE_BUILD)
-  tasks.push_back(LogElapsedTimeTask());
-#endif
   tasks.push_back(DeleteOldCacheDirectoryTask());
-  tasks.push_back(ReloadTask(weak_document_ptr, url));
 
-  LOG(INFO) << "ColinL: Executing task group.";
   std::move(GroupTasks(std::move(tasks))).Run(std::move(done_callback));
 }
 
+// TODO(b/399165612): Add metrics.
+// TODO(b/399165796): Disable and delete migration code when possible.
+// TODO(b/399166308): Add unit and/or integration tests for migration.
+// void MigrationManager::EnsureMigrationDone(content::WebContents*
+// web_contents,
+//                                            base::OnceClosure done_callback) {
+//   LOG(INFO) << "ColinL: EnsureMigrationDone started.";
+//   if (migration_attempted_.test_and_set()) {
+//     LOG(INFO) << "ColinL: Migration already attempted this session.";
+//     std::move(done_callback).Run();
+//     return;
+//   }
+
+//   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+//   if (command_line->HasSwitch(switches::kDisableStorageMigration)) {
+//     LOG(INFO) << "ColinL: Storage migration disabled via switch.";
+//     std::move(done_callback).Run();
+//     return;
+//   }
+
+//   auto* rfh = web_contents->GetPrimaryMainFrame();
+//   if (!rfh) {
+//     LOG(ERROR) << "ColinL: No PrimaryMainFrame available for migration.";
+//     std::move(done_callback).Run();
+//     return;
+//   }
+//   auto weak_document_ptr = rfh->GetWeakDocumentPtr();
+
+//   LOG(INFO) << "ColinL: Checking for existing cookies before migration...";
+//   CookieManager(weak_document_ptr)
+//       ->GetAllCookies(base::BindOnce(
+//           [](content::WebContents* web_contents,
+//              base::OnceClosure done_callback,
+//              const std::vector<net::CanonicalCookie>& existing_cookies) {
+//             if (!existing_cookies.empty()) {
+//               LOG(INFO) << "ColinL: Found " << existing_cookies.size()
+//                         << " existing cookies. Skipping migration.";
+//               for (const auto& cookie : existing_cookies) {
+//                 VLOG(1) << "ColinL: Existing Cookie: " << cookie.Name();
+//               }
+//               std::move(done_callback).Run();
+//               return;
+//             }
+//             LOG(INFO)
+//                 << "ColinL: No cookies found. Triggering RunMigrationTasks.";
+//             RunMigrationTasks(web_contents, std::move(done_callback));
+//           },
+//           web_contents, std::move(done_callback)));
+// }
+
+// void MigrationManager::RunMigrationTasks(content::WebContents* web_contents,
+//                                          base::OnceClosure done_callback) {
+//   LOG(INFO) << "ColinL: RunMigrationTasks started.";
+//   auto storage = ReadStorage();
+//   if (!storage ||
+//       (storage->cookies_size() == 0 && storage->local_storages_size() == 0))
+//       {
+//     LOG(INFO) << "ColinL: Legacy storage empty or null. Nothing to migrate.";
+//     std::move(done_callback).Run();
+//     return;
+//   }
+
+//   GURL url = web_contents->GetLastCommittedURL();
+//   LOG(INFO) << "ColinL: Stopping WebContents for migration. Last URL: "
+//             << url.spec();
+//   web_contents->Stop();
+
+//   auto* render_frame_host = web_contents->GetPrimaryMainFrame();
+//   CHECK(render_frame_host);
+//   auto weak_document_ptr = render_frame_host->GetWeakDocumentPtr();
+
+//   std::vector<Task> tasks;
+//   LOG(INFO) << "ColinL: Queueing Cookie and LocalStorage tasks...";
+//   tasks.push_back(CookieTask(partition, ToCanonicalCookies(*storage)));
+//   url::Origin origin = url::Origin::Create(initial_url);
+//   tasks.push_back(LocalStorageTask(partition, origin,
+//                                    ToLocalStorageItems(origin, *storage)));
+// #if !defined(COBALT_IS_RELEASE_BUILD)
+//   tasks.push_back(LogElapsedTimeTask());
+// #endif
+//   tasks.push_back(DeleteOldCacheDirectoryTask());
+//   // tasks.push_back(ReloadTask(weak_document_ptr, url));
+
+//   LOG(INFO) << "ColinL: Executing task group.";
+//   std::move(GroupTasks(std::move(tasks))).Run(std::move(done_callback));
+// }
+
 // static
 Task MigrationManager::CookieTask(
-    content::WeakDocumentPtr weak_document_ptr,
+    content::StoragePartition* partition,
     std::vector<std::unique_ptr<net::CanonicalCookie>> cookies) {
   LOG(INFO) << "ColinL: Creating CookieTask for " << cookies.size()
             << " cookies.";
-  std::vector<Task> tasks;
-  tasks.push_back(base::BindOnce(
-      [](content::WeakDocumentPtr weak_document_ptr,
+  return base::BindOnce(
+      [](content::StoragePartition* partition,
+         std::vector<std::unique_ptr<net::CanonicalCookie>> cookies,
          base::OnceClosure callback) {
-        CookieManager(weak_document_ptr)
-            ->DeleteCookies(network::mojom::CookieDeletionFilter::New(),
-                            base::IgnoreArgs<uint32_t>(std::move(callback)));
-      },
-      weak_document_ptr));
-  for (auto& cookie : cookies) {
-    tasks.push_back(base::BindOnce(
-        [](content::WeakDocumentPtr weak_document_ptr,
-           std::unique_ptr<net::CanonicalCookie> cookie,
-           base::OnceClosure callback) {
+        auto* cookie_manager = GetCookieManager(partition);
+
+        // 1. Clear existing cookies
+        cookie_manager->DeleteCookies(
+            network::mojom::CookieDeletionFilter::New(),
+            base::BindOnce([](uint32_t) { /* ignored */ }));
+
+        // 2. Inject new cookies
+        for (auto& cookie : cookies) {
           GURL source_url("https://" + cookie->Domain() + cookie->Path());
-          CookieManager(weak_document_ptr)
-              ->SetCanonicalCookie(*cookie, source_url,
-                                   net::CookieOptions::MakeAllInclusive(),
-                                   base::IgnoreArgs<net::CookieAccessResult>(
-                                       std::move(callback)));
-        },
-        weak_document_ptr, std::move(cookie)));
-  }
-  tasks.push_back(base::BindOnce(
-      [](content::WeakDocumentPtr weak_document_ptr,
-         base::OnceClosure callback) {
-        CookieManager(weak_document_ptr)->FlushCookieStore(std::move(callback));
+          cookie_manager->SetCanonicalCookie(
+              *cookie, source_url, net::CookieOptions::MakeAllInclusive(),
+              base::DoNothing());
+        }
+
+        // 3. Flush and continue
+        cookie_manager->FlushCookieStore(std::move(callback));
       },
-      weak_document_ptr));
-  return GroupTasks(std::move(tasks));
+      partition, std::move(cookies));
 }
 
 // static
 Task MigrationManager::LocalStorageTask(
-    content::WeakDocumentPtr weak_document_ptr,
+    content::StoragePartition* partition,
+    const url::Origin& origin,
     std::vector<std::unique_ptr<std::pair<std::string, std::string>>> pairs) {
-  LOG(INFO) << "ColinL: Creating LocalStorageTask for " << pairs.size()
-            << " items.";
-  std::vector<Task> tasks;
-  tasks.push_back(base::BindOnce(
-      [](content::WeakDocumentPtr weak_document_ptr,
+  return base::BindOnce(
+      [](content::StoragePartition* partition, url::Origin origin,
+         std::vector<std::unique_ptr<std::pair<std::string, std::string>>>
+             pairs,
          base::OnceClosure callback) {
-        RenderFrameHost(weak_document_ptr)
-            ->ExecuteJavaScriptMethod(
-                base::ASCIIToUTF16(std::string("localStorage")),
-                base::ASCIIToUTF16(std::string("clear")), base::Value::List(),
-                base::IgnoreArgs<base::Value>(std::move(callback)));
-      },
-      weak_document_ptr));
+        StorageAreaRemote area;
+        GetLocalStorageArea(partition, origin, area);
 
-  for (auto& pair : pairs) {
-    tasks.push_back(base::BindOnce(
-        [](content::WeakDocumentPtr weak_document_ptr,
-           std::unique_ptr<std::pair<std::string, std::string>> pair,
-           base::OnceClosure callback) {
-          RenderFrameHost(weak_document_ptr)
-              ->ExecuteJavaScriptMethod(
-                  base::ASCIIToUTF16(std::string("localStorage")),
-                  base::ASCIIToUTF16(std::string("setItem")),
-                  base::Value::List().Append(pair->first).Append(pair->second),
-                  base::IgnoreArgs<base::Value>(std::move(callback)));
-        },
-        weak_document_ptr, std::move(pair)));
-  }
-  return GroupTasks(std::move(tasks));
+        // Your mojom: DeleteAll(string source,
+        // pending_remote<StorageAreaObserver>? observer) => (bool success) We
+        // use BindOnce with IgnoreArgs because we don't care about the bool
+        // result.
+        area->DeleteAll("migration", mojo::NullRemote(),
+                        base::BindOnce([](bool success) {}));
+
+        absl::optional<std::vector<uint8_t>> empty_old_value;
+        for (const auto& pair : pairs) {
+          std::vector<uint8_t> key(pair->first.begin(), pair->first.end());
+          std::vector<uint8_t> value(pair->second.begin(), pair->second.end());
+
+          // Your mojom: Put(array<uint8> key, array<uint8> value, array<uint8>?
+          // old, string source) => (bool success)
+          area->Put(key, value, empty_old_value, "migration",
+                    base::BindOnce([](bool success) {}));
+        }
+
+        // In your version of Mojo, FlushForTesting is synchronous and takes NO
+        // arguments. It blocks the current thread until all previous calls
+        // (DeleteAll, Put) have been dispatched to the Storage Service.
+        area.FlushForTesting();
+
+        // Now that the pipe is flushed, we can safely allow the task chain to
+        // continue.
+        std::move(callback).Run();
+      },
+      partition, origin, std::move(pairs));
 }
 
 // static

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -43,6 +43,8 @@
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/web_contents.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "net/base/registry_controlled_domains/registry_controlled_domain.h"
+#include "net/base/schemeful_site.h"
 #include "net/cookies/canonical_cookie.h"
 #include "net/cookies/cookie_access_result.h"
 #include "net/cookies/cookie_options.h"
@@ -70,9 +72,16 @@ network::mojom::CookieManager* GetCookieManager(
 void GetLocalStorageArea(content::StoragePartition* partition,
                          const url::Origin& origin,
                          mojo::Remote<blink::mojom::StorageArea>& out_area) {
+  auto storage_key = blink::StorageKey::CreateFirstParty(origin);
+
+  LOG(INFO) << "ColinL: [Migration-V10-Verify] Binding LocalStorage";
+  LOG(INFO) << "ColinL:   Origin: " << origin.Serialize();
+  LOG(INFO) << "ColinL:   StorageKey Debug: " << storage_key.GetDebugString();
+  LOG(INFO) << "ColinL:   SerializedKey: "
+            << storage_key.SerializeForLocalStorage();
+
   partition->GetLocalStorageControl()->BindStorageArea(
-      blink::StorageKey::CreateFirstParty(origin),
-      out_area.BindNewPipeAndPassReceiver());
+      storage_key, out_area.BindNewPipeAndPassReceiver());
 }
 
 std::string GetApplicationKey(const GURL& url) {
@@ -148,28 +157,36 @@ std::unique_ptr<cobalt::storage::Storage> ReadStorage() {
     LOG(ERROR) << "ColinL: Failed to parse Storage protobuf.";
     return nullptr;
   }
+
+  // Log all origins found in the storage record to debug "lost user" issues.
+  for (const auto& local_storage_group : storage->local_storages()) {
+    LOG(INFO) << "ColinL: Found legacy LocalStorage group for origin: "
+              << local_storage_group.serialized_origin();
+  }
+
   LOG(INFO) << "ColinL: Successfully parsed storage. Cookies: "
             << storage->cookies_size()
             << ", LocalStorage groups: " << storage->local_storages_size();
   return storage;
 }
 
-content::RenderFrameHost* RenderFrameHost(
-    content::WeakDocumentPtr weak_document_ptr) {
-  auto* render_frame_host = weak_document_ptr.AsRenderFrameHostIfValid();
-  CHECK(render_frame_host);
-  return render_frame_host;
-}
+// content::RenderFrameHost* RenderFrameHost(
+//     content::WeakDocumentPtr weak_document_ptr) {
+//   auto* render_frame_host = weak_document_ptr.AsRenderFrameHostIfValid();
+//   CHECK(render_frame_host);
+//   return render_frame_host;
+// }
 
-network::mojom::CookieManager* CookieManager(
-    content::WeakDocumentPtr weak_document_ptr) {
-  auto* storage_partition =
-      RenderFrameHost(weak_document_ptr)->GetStoragePartition();
-  CHECK(storage_partition);
-  auto* cookie_manager = storage_partition->GetCookieManagerForBrowserProcess();
-  CHECK(cookie_manager);
-  return cookie_manager;
-}
+// network::mojom::CookieManager* CookieManager(
+//     content::WeakDocumentPtr weak_document_ptr) {
+//   auto* storage_partition =
+//       RenderFrameHost(weak_document_ptr)->GetStoragePartition();
+//   CHECK(storage_partition);
+//   auto* cookie_manager =
+//   storage_partition->GetCookieManagerForBrowserProcess();
+//   CHECK(cookie_manager);
+//   return cookie_manager;
+// }
 
 #if !defined(COBALT_IS_RELEASE_BUILD)
 Task LogElapsedTimeTask() {
@@ -184,24 +201,26 @@ Task LogElapsedTimeTask() {
 }
 #endif  // !defined(COBALT_IS_RELEASE_BUILD)
 
-Task ReloadTask(content::WeakDocumentPtr weak_document_ptr, const GURL& url) {
-  return base::BindOnce(
-      [](content::WeakDocumentPtr weak_document_ptr, const GURL& url,
-         base::OnceClosure callback) {
-        auto* rfh = RenderFrameHost(weak_document_ptr);
-        content::WebContents* web_contents =
-            content::WebContents::FromRenderFrameHost(rfh);
-        if (web_contents) {
-          LOG(INFO) << "ColinL: MigrationManager Reloading URL: " << url.spec();
-          content::NavigationController::LoadURLParams params(url);
-          params.transition_type = ui::PageTransitionFromInt(
-              ui::PAGE_TRANSITION_TYPED | ui::PAGE_TRANSITION_FROM_ADDRESS_BAR);
-          web_contents->GetController().LoadURLWithParams(params);
-        }
-        std::move(callback).Run();
-      },
-      weak_document_ptr, url);
-}
+// Task ReloadTask(content::WeakDocumentPtr weak_document_ptr, const GURL& url)
+// {
+//   return base::BindOnce(
+//       [](content::WeakDocumentPtr weak_document_ptr, const GURL& url,
+//          base::OnceClosure callback) {
+//         auto* rfh = RenderFrameHost(weak_document_ptr);
+//         content::WebContents* web_contents =
+//             content::WebContents::FromRenderFrameHost(rfh);
+//         if (web_contents) {
+//           LOG(INFO) << "ColinL: MigrationManager Reloading URL: " <<
+//           url.spec(); content::NavigationController::LoadURLParams
+//           params(url); params.transition_type = ui::PageTransitionFromInt(
+//               ui::PAGE_TRANSITION_TYPED |
+//               ui::PAGE_TRANSITION_FROM_ADDRESS_BAR);
+//           web_contents->GetController().LoadURLWithParams(params);
+//         }
+//         std::move(callback).Run();
+//       },
+//       weak_document_ptr, url);
+// }
 
 base::FilePath GetOldCachePath() {
   std::vector<char> path(kSbFileMaxPath, 0);
@@ -268,7 +287,7 @@ Task DeleteOldCacheDirectoryTask() {
 }  // namespace
 
 // static
-std::atomic_flag MigrationManager::migration_attempted_ = ATOMIC_FLAG_INIT;
+// std::atomic_flag MigrationManager::migration_attempted_ = ATOMIC_FLAG_INIT;
 
 // static
 Task MigrationManager::GroupTasks(std::vector<Task> tasks) {
@@ -286,9 +305,9 @@ Task MigrationManager::GroupTasks(std::vector<Task> tasks) {
 
 void MigrationManager::RunMigration(content::StoragePartition* partition,
                                     base::OnceClosure done_callback) {
-  LOG(INFO) << "ColinL: Starting Pre-MainLoop Migration.";
+  LOG(INFO)
+      << "ColinL: [Migration-V10-Verify] Starting Pre-MainLoop Migration.";
 
-  // 2. Get the target URL (to determine the Origin/StorageKey)
   GURL initial_url(
       switches::GetInitialURL(*base::CommandLine::ForCurrentProcess()));
   if (!initial_url.is_valid()) {
@@ -297,7 +316,6 @@ void MigrationManager::RunMigration(content::StoragePartition* partition,
   }
   url::Origin origin = url::Origin::Create(initial_url);
 
-  // 3. Read the legacy storage record
   auto storage = ReadStorage();
   if (!storage ||
       (storage->cookies_size() == 0 && storage->local_storages_size() == 0)) {
@@ -306,7 +324,6 @@ void MigrationManager::RunMigration(content::StoragePartition* partition,
     return;
   }
 
-  // 4. Build and Run Task Group
   std::vector<Task> tasks;
   tasks.push_back(CookieTask(partition, ToCanonicalCookies(*storage)));
   tasks.push_back(LocalStorageTask(partition, origin,
@@ -330,17 +347,18 @@ Task MigrationManager::CookieTask(
         }
 
         auto* cookie_manager = GetCookieManager(partition);
-
         base::RepeatingClosure barrier =
             base::BarrierClosure(cookies.size(), std::move(callback));
 
         for (auto& cookie : cookies) {
+          std::string name = cookie->Name();
           GURL source_url("https://" + cookie->Domain() + cookie->Path());
           cookie_manager->SetCanonicalCookie(
               *cookie, source_url, net::CookieOptions::MakeAllInclusive(),
-              base::BindOnce([](base::RepeatingClosure barrier,
-                                net::CookieAccessResult) { barrier.Run(); },
-                             barrier));
+              base::BindOnce(
+                  [](base::RepeatingClosure barrier, std::string cookie_name,
+                     net::CookieAccessResult result) { barrier.Run(); },
+                  barrier, name));
         }
       },
       partition, std::move(cookies));
@@ -359,52 +377,100 @@ Task MigrationManager::LocalStorageTask(
         auto area = std::make_unique<mojo::Remote<blink::mojom::StorageArea>>();
         GetLocalStorageArea(partition, origin, *area);
 
-        // area is a unique_ptr to a mojo::Remote. To call DeleteAll, we need
-        // to dereference the unique_ptr to get the Remote, then use -> to
-        // access the interface.
-        (*area)->DeleteAll(
-            "migration", mojo::NullRemote(),
-            base::BindOnce(
-                [](std::unique_ptr<mojo::Remote<blink::mojom::StorageArea>>
-                       area,
-                   std::vector<std::unique_ptr<
-                       std::pair<std::string, std::string>>> pairs,
-                   base::OnceClosure callback, bool success) {
-                  if (pairs.empty()) {
-                    std::move(callback).Run();
-                    return;
-                  }
+        if (pairs.empty()) {
+          std::move(callback).Run();
+          return;
+        }
 
-                  // Pointer for the loop before ownership is transferred to
-                  // final_task. We dereference the unique_ptr to get a raw
-                  // pointer to the Remote.
-                  auto* raw_remote_ptr = area.get();
+        auto* raw_remote_ptr = area.get();
 
-                  base::OnceClosure final_task = base::BindOnce(
-                      [](std::unique_ptr<
-                             mojo::Remote<blink::mojom::StorageArea>> area,
-                         base::OnceClosure cb) { std::move(cb).Run(); },
-                      std::move(area), std::move(callback));
+        base::OnceClosure on_all_puts_done = base::BindOnce(
+            [](std::unique_ptr<mojo::Remote<blink::mojom::StorageArea>> area,
+               content::StoragePartition* partition, url::Origin origin,
+               base::OnceClosure cb) {
+              LOG(INFO) << "ColinL: [Migration-V10-Verify] LocalStorage Puts "
+                           "complete. Flushing...";
 
-                  base::RepeatingClosure barrier =
-                      base::BarrierClosure(pairs.size(), std::move(final_task));
+              partition->GetLocalStorageControl()->Flush(base::BindOnce(
+                  [](std::unique_ptr<mojo::Remote<blink::mojom::StorageArea>>
+                         area,
+                     content::StoragePartition* partition, url::Origin origin,
+                     base::OnceClosure final_cb) {
+                    LOG(INFO)
+                        << "ColinL: [Migration-V10-Verify] Flush complete. "
+                           "Performing Browser-side read-back check...";
 
-                  for (const auto& pair : pairs) {
-                    std::vector<uint8_t> key(pair->first.begin(),
-                                             pair->first.end());
-                    std::vector<uint8_t> value(pair->second.begin(),
-                                               pair->second.end());
+                    // Independent verification read.
+                    auto verify_remote = std::make_unique<
+                        mojo::Remote<blink::mojom::StorageArea>>();
+                    GetLocalStorageArea(partition, origin, *verify_remote);
 
-                    // Use the raw pointer to the Remote to call Put.
-                    (*raw_remote_ptr)
-                        ->Put(
-                            key, value, absl::nullopt, "migration",
-                            base::BindOnce([](base::RepeatingClosure barrier,
-                                              bool success) { barrier.Run(); },
-                                           barrier));
-                  }
-                },
-                std::move(area), std::move(pairs), std::move(callback)));
+                    auto* raw_verify = verify_remote->get();
+                    std::vector<uint8_t> key_vec;
+                    std::string target_key =
+                        "yt.leanback.default::last-identity-used";
+                    key_vec.assign(target_key.begin(), target_key.end());
+
+                    raw_verify->Get(
+                        key_vec,
+                        base::BindOnce(
+                            [](std::unique_ptr<mojo::Remote<
+                                   blink::mojom::StorageArea>> area_hold,
+                               std::unique_ptr<mojo::Remote<
+                                   blink::mojom::StorageArea>> verify_hold,
+                               content::StoragePartition* partition,
+                               base::OnceClosure done_cb, bool success,
+                               const std::vector<uint8_t>& value) {
+                              std::string val_str(value.begin(), value.end());
+                              if (val_str.empty()) {
+                                LOG(ERROR)
+                                    << "ColinL: [PROOF] Browser read-back "
+                                       "FAILED. Data missing in memory.";
+                              } else {
+                                LOG(INFO) << "ColinL: [PROOF] Browser "
+                                             "read-back SUCCESS. Value: "
+                                          << val_str.substr(0, 40) << "...";
+                              }
+
+                              // NEW FIX: Force the Storage Service to drop its
+                              // handle for this origin.
+                              LOG(INFO) << "ColinL: [FIX] Purging Storage "
+                                           "Service handles to force Renderer "
+                                           "synchronization.";
+                              partition->GetLocalStorageControl()
+                                  ->PurgeMemory();
+
+                              // TEST: Add a 10-second delay before continuing
+                              // to unblock the browser startup.
+                              LOG(INFO) << "ColinL: [TEST] Delaying migration "
+                                           "completion by 10 seconds to test "
+                                           "timing race...";
+                              base::SequencedTaskRunner::GetCurrentDefault()
+                                  ->PostDelayedTask(FROM_HERE,
+                                                    std::move(done_cb),
+                                                    base::Seconds(10));
+                            },
+                            std::move(area), std::move(verify_remote),
+                            base::Unretained(partition), std::move(final_cb)));
+                  },
+                  std::move(area), base::Unretained(partition), origin,
+                  std::move(cb)));
+            },
+            std::move(area), base::Unretained(partition), origin,
+            std::move(callback));
+
+        base::RepeatingClosure barrier =
+            base::BarrierClosure(pairs.size(), std::move(on_all_puts_done));
+
+        for (const auto& pair : pairs) {
+          std::vector<uint8_t> key(pair->first.begin(), pair->first.end());
+          std::vector<uint8_t> value(pair->second.begin(), pair->second.end());
+          (*raw_remote_ptr)
+              ->Put(key, value, absl::nullopt, "migration",
+                    base::BindOnce([](base::RepeatingClosure barrier,
+                                      bool success) { barrier.Run(); },
+                                   barrier));
+        }
       },
       partition, origin, std::move(pairs));
 }
@@ -432,10 +498,46 @@ std::vector<std::unique_ptr<std::pair<std::string, std::string>>>
 MigrationManager::ToLocalStorageItems(const url::Origin& page_origin,
                                       const cobalt::storage::Storage& storage) {
   std::vector<std::unique_ptr<std::pair<std::string, std::string>>> entries;
+
+  // Get the registrable domain for the current page (e.g., "youtube.com").
+  std::string target_domain =
+      net::registry_controlled_domains::GetDomainAndRegistry(
+          page_origin.GetURL(),
+          net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
+
   for (const auto& local_storages : storage.local_storages()) {
-    GURL local_storage_origin(local_storages.serialized_origin());
-    if (!local_storage_origin.SchemeIs("https") ||
-        !page_origin.IsSameOriginWith(local_storage_origin)) {
+    std::string legacy_origin_str = local_storages.serialized_origin();
+    GURL legacy_gurl(legacy_origin_str);
+
+    LOG(INFO) << "ColinL: Examining legacy storage group for origin: "
+              << legacy_origin_str;
+
+    if (!legacy_gurl.is_valid()) {
+      LOG(WARNING) << "ColinL: Skipping invalid legacy origin: "
+                   << legacy_origin_str;
+      continue;
+    }
+
+    // Relaxed matching: If strict origin matching fails, check if the
+    // registrable domains match. This allows migration from http to https or
+    // between subdomains.
+    bool match = page_origin.IsSameOriginWith(legacy_gurl);
+    if (!match && !target_domain.empty()) {
+      std::string legacy_domain =
+          net::registry_controlled_domains::GetDomainAndRegistry(
+              legacy_gurl,
+              net::registry_controlled_domains::INCLUDE_PRIVATE_REGISTRIES);
+      if (target_domain == legacy_domain) {
+        LOG(INFO) << "ColinL: Strict origin mismatch but Domain match found: "
+                  << legacy_domain;
+        match = true;
+      }
+    }
+
+    if (!match) {
+      LOG(WARNING) << "ColinL: Domain Mismatch! Legacy: " << legacy_origin_str
+                   << " vs Target: " << page_origin.Serialize()
+                   << ". Skipping migration.";
       continue;
     }
 

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -251,6 +251,10 @@ void MigrationManager::DoMigrationTasksOnce(
     return;
   }
 
+  RunMigrationTasks(web_contents);
+}
+
+void MigrationManager::RunMigrationTasks(content::WebContents* web_contents) {
   auto storage = ReadStorage();
   if (!storage ||
       (storage->cookies_size() == 0 && storage->local_storages_size() == 0)) {

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -14,40 +14,46 @@
 
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "base/barrier_closure.h"
 #include "base/base64url.h"
 #include "base/command_line.h"
 #include "base/containers/adapters.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
 #include "base/path_service.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
 #include "base/timer/elapsed_timer.h"
 #include "cobalt/browser/switches.h"
 #include "cobalt/shell/common/shell_switches.h"
+#include "components/services/storage/public/mojom/local_storage_control.mojom.h"
 #include "components/url_matcher/url_util.h"
-#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/storage_partition.h"
+#include "content/public/browser/web_contents.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "net/cookies/canonical_cookie.h"
 #include "net/cookies/cookie_access_result.h"
 #include "net/cookies/cookie_options.h"
 #include "services/network/public/mojom/cookie_manager.mojom.h"
 #include "starboard/common/storage.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/system.h"
-#include "url/gurl.h"
-
-#include "components/services/storage/public/mojom/local_storage_control.mojom.h"
-#include "content/public/browser/browser_context.h"
-#include "content/public/browser/dom_storage_context.h"
-#include "mojo/public/cpp/bindings/remote.h"
 #include "third_party/blink/public/common/storage_key/storage_key.h"
-
-#include "components/services/storage/public/mojom/storage_service.mojom.h"
 #include "third_party/blink/public/mojom/dom_storage/storage_area.mojom.h"
+#include "url/gurl.h"
+#include "url/origin.h"
 
 namespace cobalt {
 namespace migrate_storage_record {
@@ -56,19 +62,14 @@ using StorageAreaRemote = mojo::Remote<blink::mojom::StorageArea>;
 
 namespace {
 
-// Helper to get CookieManager from Partition
 network::mojom::CookieManager* GetCookieManager(
     content::StoragePartition* partition) {
   return partition->GetCookieManagerForBrowserProcess();
 }
 
-// Helper to get LocalStorage Area for a specific origin
-
 void GetLocalStorageArea(content::StoragePartition* partition,
                          const url::Origin& origin,
-                         StorageAreaRemote& out_area) {
-  // 1. Get the Local Storage Control from the partition's Storage Service
-  // This bypasses the limited DOMStorageContext interface.
+                         mojo::Remote<blink::mojom::StorageArea>& out_area) {
   partition->GetLocalStorageControl()->BindStorageArea(
       blink::StorageKey::CreateFirstParty(origin),
       out_area.BindNewPipeAndPassReceiver());
@@ -315,120 +316,32 @@ void MigrationManager::RunMigration(content::StoragePartition* partition,
   std::move(GroupTasks(std::move(tasks))).Run(std::move(done_callback));
 }
 
-// TODO(b/399165612): Add metrics.
-// TODO(b/399165796): Disable and delete migration code when possible.
-// TODO(b/399166308): Add unit and/or integration tests for migration.
-// void MigrationManager::EnsureMigrationDone(content::WebContents*
-// web_contents,
-//                                            base::OnceClosure done_callback) {
-//   LOG(INFO) << "ColinL: EnsureMigrationDone started.";
-//   if (migration_attempted_.test_and_set()) {
-//     LOG(INFO) << "ColinL: Migration already attempted this session.";
-//     std::move(done_callback).Run();
-//     return;
-//   }
-
-//   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-//   if (command_line->HasSwitch(switches::kDisableStorageMigration)) {
-//     LOG(INFO) << "ColinL: Storage migration disabled via switch.";
-//     std::move(done_callback).Run();
-//     return;
-//   }
-
-//   auto* rfh = web_contents->GetPrimaryMainFrame();
-//   if (!rfh) {
-//     LOG(ERROR) << "ColinL: No PrimaryMainFrame available for migration.";
-//     std::move(done_callback).Run();
-//     return;
-//   }
-//   auto weak_document_ptr = rfh->GetWeakDocumentPtr();
-
-//   LOG(INFO) << "ColinL: Checking for existing cookies before migration...";
-//   CookieManager(weak_document_ptr)
-//       ->GetAllCookies(base::BindOnce(
-//           [](content::WebContents* web_contents,
-//              base::OnceClosure done_callback,
-//              const std::vector<net::CanonicalCookie>& existing_cookies) {
-//             if (!existing_cookies.empty()) {
-//               LOG(INFO) << "ColinL: Found " << existing_cookies.size()
-//                         << " existing cookies. Skipping migration.";
-//               for (const auto& cookie : existing_cookies) {
-//                 VLOG(1) << "ColinL: Existing Cookie: " << cookie.Name();
-//               }
-//               std::move(done_callback).Run();
-//               return;
-//             }
-//             LOG(INFO)
-//                 << "ColinL: No cookies found. Triggering RunMigrationTasks.";
-//             RunMigrationTasks(web_contents, std::move(done_callback));
-//           },
-//           web_contents, std::move(done_callback)));
-// }
-
-// void MigrationManager::RunMigrationTasks(content::WebContents* web_contents,
-//                                          base::OnceClosure done_callback) {
-//   LOG(INFO) << "ColinL: RunMigrationTasks started.";
-//   auto storage = ReadStorage();
-//   if (!storage ||
-//       (storage->cookies_size() == 0 && storage->local_storages_size() == 0))
-//       {
-//     LOG(INFO) << "ColinL: Legacy storage empty or null. Nothing to migrate.";
-//     std::move(done_callback).Run();
-//     return;
-//   }
-
-//   GURL url = web_contents->GetLastCommittedURL();
-//   LOG(INFO) << "ColinL: Stopping WebContents for migration. Last URL: "
-//             << url.spec();
-//   web_contents->Stop();
-
-//   auto* render_frame_host = web_contents->GetPrimaryMainFrame();
-//   CHECK(render_frame_host);
-//   auto weak_document_ptr = render_frame_host->GetWeakDocumentPtr();
-
-//   std::vector<Task> tasks;
-//   LOG(INFO) << "ColinL: Queueing Cookie and LocalStorage tasks...";
-//   tasks.push_back(CookieTask(partition, ToCanonicalCookies(*storage)));
-//   url::Origin origin = url::Origin::Create(initial_url);
-//   tasks.push_back(LocalStorageTask(partition, origin,
-//                                    ToLocalStorageItems(origin, *storage)));
-// #if !defined(COBALT_IS_RELEASE_BUILD)
-//   tasks.push_back(LogElapsedTimeTask());
-// #endif
-//   tasks.push_back(DeleteOldCacheDirectoryTask());
-//   // tasks.push_back(ReloadTask(weak_document_ptr, url));
-
-//   LOG(INFO) << "ColinL: Executing task group.";
-//   std::move(GroupTasks(std::move(tasks))).Run(std::move(done_callback));
-// }
-
 // static
 Task MigrationManager::CookieTask(
     content::StoragePartition* partition,
     std::vector<std::unique_ptr<net::CanonicalCookie>> cookies) {
-  LOG(INFO) << "ColinL: Creating CookieTask for " << cookies.size()
-            << " cookies.";
   return base::BindOnce(
       [](content::StoragePartition* partition,
          std::vector<std::unique_ptr<net::CanonicalCookie>> cookies,
          base::OnceClosure callback) {
+        if (cookies.empty()) {
+          std::move(callback).Run();
+          return;
+        }
+
         auto* cookie_manager = GetCookieManager(partition);
 
-        // 1. Clear existing cookies
-        cookie_manager->DeleteCookies(
-            network::mojom::CookieDeletionFilter::New(),
-            base::BindOnce([](uint32_t) { /* ignored */ }));
+        base::RepeatingClosure barrier =
+            base::BarrierClosure(cookies.size(), std::move(callback));
 
-        // 2. Inject new cookies
         for (auto& cookie : cookies) {
           GURL source_url("https://" + cookie->Domain() + cookie->Path());
           cookie_manager->SetCanonicalCookie(
               *cookie, source_url, net::CookieOptions::MakeAllInclusive(),
-              base::DoNothing());
+              base::BindOnce([](base::RepeatingClosure barrier,
+                                net::CookieAccessResult) { barrier.Run(); },
+                             barrier));
         }
-
-        // 3. Flush and continue
-        cookie_manager->FlushCookieStore(std::move(callback));
       },
       partition, std::move(cookies));
 }
@@ -443,35 +356,55 @@ Task MigrationManager::LocalStorageTask(
          std::vector<std::unique_ptr<std::pair<std::string, std::string>>>
              pairs,
          base::OnceClosure callback) {
-        StorageAreaRemote area;
-        GetLocalStorageArea(partition, origin, area);
+        auto area = std::make_unique<mojo::Remote<blink::mojom::StorageArea>>();
+        GetLocalStorageArea(partition, origin, *area);
 
-        // Your mojom: DeleteAll(string source,
-        // pending_remote<StorageAreaObserver>? observer) => (bool success) We
-        // use BindOnce with IgnoreArgs because we don't care about the bool
-        // result.
-        area->DeleteAll("migration", mojo::NullRemote(),
-                        base::BindOnce([](bool success) {}));
+        // area is a unique_ptr to a mojo::Remote. To call DeleteAll, we need
+        // to dereference the unique_ptr to get the Remote, then use -> to
+        // access the interface.
+        (*area)->DeleteAll(
+            "migration", mojo::NullRemote(),
+            base::BindOnce(
+                [](std::unique_ptr<mojo::Remote<blink::mojom::StorageArea>>
+                       area,
+                   std::vector<std::unique_ptr<
+                       std::pair<std::string, std::string>>> pairs,
+                   base::OnceClosure callback, bool success) {
+                  if (pairs.empty()) {
+                    std::move(callback).Run();
+                    return;
+                  }
 
-        absl::optional<std::vector<uint8_t>> empty_old_value;
-        for (const auto& pair : pairs) {
-          std::vector<uint8_t> key(pair->first.begin(), pair->first.end());
-          std::vector<uint8_t> value(pair->second.begin(), pair->second.end());
+                  // Pointer for the loop before ownership is transferred to
+                  // final_task. We dereference the unique_ptr to get a raw
+                  // pointer to the Remote.
+                  auto* raw_remote_ptr = area.get();
 
-          // Your mojom: Put(array<uint8> key, array<uint8> value, array<uint8>?
-          // old, string source) => (bool success)
-          area->Put(key, value, empty_old_value, "migration",
-                    base::BindOnce([](bool success) {}));
-        }
+                  base::OnceClosure final_task = base::BindOnce(
+                      [](std::unique_ptr<
+                             mojo::Remote<blink::mojom::StorageArea>> area,
+                         base::OnceClosure cb) { std::move(cb).Run(); },
+                      std::move(area), std::move(callback));
 
-        // In your version of Mojo, FlushForTesting is synchronous and takes NO
-        // arguments. It blocks the current thread until all previous calls
-        // (DeleteAll, Put) have been dispatched to the Storage Service.
-        area.FlushForTesting();
+                  base::RepeatingClosure barrier =
+                      base::BarrierClosure(pairs.size(), std::move(final_task));
 
-        // Now that the pipe is flushed, we can safely allow the task chain to
-        // continue.
-        std::move(callback).Run();
+                  for (const auto& pair : pairs) {
+                    std::vector<uint8_t> key(pair->first.begin(),
+                                             pair->first.end());
+                    std::vector<uint8_t> value(pair->second.begin(),
+                                               pair->second.end());
+
+                    // Use the raw pointer to the Remote to call Put.
+                    (*raw_remote_ptr)
+                        ->Put(
+                            key, value, absl::nullopt, "migration",
+                            base::BindOnce([](base::RepeatingClosure barrier,
+                                              bool success) { barrier.Run(); },
+                                           barrier));
+                  }
+                },
+                std::move(area), std::move(pairs), std::move(callback)));
       },
       partition, origin, std::move(pairs));
 }

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -45,6 +45,17 @@ namespace migrate_storage_record {
 
 namespace {
 
+constexpr char kStorageIntegrityCookieName[] = "yt-dev.storage-integrity";
+
+bool HasIntegrityCookie(const std::vector<net::CanonicalCookie>& cookies) {
+  for (const auto& cookie : cookies) {
+    if (cookie.Name() == kStorageIntegrityCookieName) {
+      return true;
+    }
+  }
+  return false;
+}
+
 std::string GetApplicationKey(const GURL& url) {
   std::string encoded_url;
   base::Base64UrlEncode(url_matcher::util::Normalize(url).spec(),
@@ -251,7 +262,27 @@ void MigrationManager::DoMigrationTasksOnce(
     return;
   }
 
-  RunMigrationTasks(web_contents);
+  auto* rfh = web_contents->GetPrimaryMainFrame();
+  if (!rfh) {
+    return;
+  }
+  auto weak_document_ptr = rfh->GetWeakDocumentPtr();
+
+  // Check for existing integrity cookie before running any migration logic.
+  CookieManager(weak_document_ptr)
+      ->GetAllCookies(base::BindOnce(
+          [](content::WebContents* web_contents,
+             const std::vector<net::CanonicalCookie>& existing_cookies) {
+            if (HasIntegrityCookie(existing_cookies)) {
+              LOG(INFO) << "MigrationManager: Storage integrity cookie from "
+                           "Cobalt 26+ already exists. Skipping migration of "
+                           "old records to avoid removing existing cookies "
+                           "and localStorage.";
+              return;
+            }
+            RunMigrationTasks(web_contents);
+          },
+          web_contents));
 }
 
 void MigrationManager::RunMigrationTasks(content::WebContents* web_contents) {

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -61,23 +61,30 @@ std::unique_ptr<cobalt::storage::Storage> ReadStorage() {
       switches::GetInitialURL(*base::CommandLine::ForCurrentProcess()));
   CHECK(initial_url.is_valid());
   std::string partition_key = GetApplicationKey(initial_url);
+  LOG(INFO) << "ColinL: ReadStorage attempting to open key: " << partition_key;
+
   auto record =
       std::make_unique<starboard::StorageRecord>(partition_key.c_str());
   if (!record->IsValid()) {
+    LOG(INFO)
+        << "ColinL: StorageRecord invalid for partition, trying fallback.";
     record->Delete();
     bool fallback = partition_key == GetApplicationKey(GURL(kDefaultURL));
     if (!fallback) {
+      LOG(WARNING) << "ColinL: No fallback available. ReadStorage failed.";
       return nullptr;
     }
 
     record = std::make_unique<starboard::StorageRecord>();
     if (!record->IsValid()) {
+      LOG(ERROR) << "ColinL: Fallback StorageRecord also invalid.";
       record->Delete();
       return nullptr;
     }
   }
 
   if (record->GetSize() < kRecordHeaderSize) {
+    LOG(WARNING) << "ColinL: Record size too small: " << record->GetSize();
     record->Delete();
     return nullptr;
   }
@@ -85,6 +92,9 @@ std::unique_ptr<cobalt::storage::Storage> ReadStorage() {
   auto bytes = std::vector<uint8_t>(record->GetSize());
   const int read_result =
       record->Read(reinterpret_cast<char*>(bytes.data()), bytes.size());
+
+  LOG(INFO) << "ColinL: Read " << read_result << " bytes from legacy storage.";
+
   if (!record->Delete()) {
     LOG(ERROR) << "Failed to delete legacy storage record. Aborting migration "
                   "to prevent overwrite loop.";
@@ -97,6 +107,7 @@ std::unique_ptr<cobalt::storage::Storage> ReadStorage() {
   std::string version(reinterpret_cast<const char*>(bytes.data()),
                       kRecordHeaderSize);
   if (version != kRecordHeader) {
+    LOG(ERROR) << "ColinL: Version mismatch. Expected SAV1, got: " << version;
     return nullptr;
   }
 
@@ -104,8 +115,12 @@ std::unique_ptr<cobalt::storage::Storage> ReadStorage() {
   if (!storage->ParseFromArray(
           reinterpret_cast<const char*>(bytes.data() + kRecordHeaderSize),
           bytes.size() - kRecordHeaderSize)) {
+    LOG(ERROR) << "ColinL: Failed to parse Storage protobuf.";
     return nullptr;
   }
+  LOG(INFO) << "ColinL: Successfully parsed storage. Cookies: "
+            << storage->cookies_size()
+            << ", LocalStorage groups: " << storage->local_storages_size();
   return storage;
 }
 
@@ -147,7 +162,7 @@ Task ReloadTask(content::WeakDocumentPtr weak_document_ptr, const GURL& url) {
         content::WebContents* web_contents =
             content::WebContents::FromRenderFrameHost(rfh);
         if (web_contents) {
-          LOG(INFO) << "MigrationManager: Reloading URL: " << url.spec();
+          LOG(INFO) << "ColinL: MigrationManager Reloading URL: " << url.spec();
           content::NavigationController::LoadURLParams params(url);
           params.transition_type = ui::PageTransitionFromInt(
               ui::PAGE_TRANSITION_TYPED | ui::PAGE_TRANSITION_FROM_ADDRESS_BAR);
@@ -239,48 +254,66 @@ Task MigrationManager::GroupTasks(std::vector<Task> tasks) {
 // TODO(b/399165612): Add metrics.
 // TODO(b/399165796): Disable and delete migration code when possible.
 // TODO(b/399166308): Add unit and/or integration tests for migration.
-void MigrationManager::DoMigrationTasksOnce(
-    content::WebContents* web_contents) {
+void MigrationManager::EnsureMigrationDone(content::WebContents* web_contents,
+                                           base::OnceClosure done_callback) {
+  LOG(INFO) << "ColinL: EnsureMigrationDone started.";
   if (migration_attempted_.test_and_set()) {
+    LOG(INFO) << "ColinL: Migration already attempted this session.";
+    std::move(done_callback).Run();
     return;
   }
 
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kDisableStorageMigration)) {
-    LOG(INFO) << "Storage migration disabled via switch.";
+    LOG(INFO) << "ColinL: Storage migration disabled via switch.";
+    std::move(done_callback).Run();
     return;
   }
 
   auto* rfh = web_contents->GetPrimaryMainFrame();
   if (!rfh) {
+    LOG(ERROR) << "ColinL: No PrimaryMainFrame available for migration.";
+    std::move(done_callback).Run();
     return;
   }
   auto weak_document_ptr = rfh->GetWeakDocumentPtr();
 
-  // Check for existing integrity cookie before running any migration logic.
+  LOG(INFO) << "ColinL: Checking for existing cookies before migration...";
   CookieManager(weak_document_ptr)
       ->GetAllCookies(base::BindOnce(
           [](content::WebContents* web_contents,
+             base::OnceClosure done_callback,
              const std::vector<net::CanonicalCookie>& existing_cookies) {
             if (!existing_cookies.empty()) {
-              LOG(INFO) << "MigrationManager: Cookies already exist. "
-                           "Skipping migration to prevent overwriting "
-                           "existing session data.";
+              LOG(INFO) << "ColinL: Found " << existing_cookies.size()
+                        << " existing cookies. Skipping migration.";
+              for (const auto& cookie : existing_cookies) {
+                VLOG(1) << "ColinL: Existing Cookie: " << cookie.Name();
+              }
+              std::move(done_callback).Run();
               return;
             }
-            RunMigrationTasks(web_contents);
+            LOG(INFO)
+                << "ColinL: No cookies found. Triggering RunMigrationTasks.";
+            RunMigrationTasks(web_contents, std::move(done_callback));
           },
-          web_contents));
+          web_contents, std::move(done_callback)));
 }
 
-void MigrationManager::RunMigrationTasks(content::WebContents* web_contents) {
+void MigrationManager::RunMigrationTasks(content::WebContents* web_contents,
+                                         base::OnceClosure done_callback) {
+  LOG(INFO) << "ColinL: RunMigrationTasks started.";
   auto storage = ReadStorage();
   if (!storage ||
       (storage->cookies_size() == 0 && storage->local_storages_size() == 0)) {
+    LOG(INFO) << "ColinL: Legacy storage empty or null. Nothing to migrate.";
+    std::move(done_callback).Run();
     return;
   }
 
   GURL url = web_contents->GetLastCommittedURL();
+  LOG(INFO) << "ColinL: Stopping WebContents for migration. Last URL: "
+            << url.spec();
   web_contents->Stop();
 
   auto* render_frame_host = web_contents->GetPrimaryMainFrame();
@@ -288,22 +321,27 @@ void MigrationManager::RunMigrationTasks(content::WebContents* web_contents) {
   auto weak_document_ptr = render_frame_host->GetWeakDocumentPtr();
 
   std::vector<Task> tasks;
+  LOG(INFO) << "ColinL: Queueing Cookie and LocalStorage tasks...";
   tasks.push_back(CookieTask(weak_document_ptr, ToCanonicalCookies(*storage)));
   const url::Origin& origin = render_frame_host->GetLastCommittedOrigin();
   tasks.push_back(LocalStorageTask(weak_document_ptr,
                                    ToLocalStorageItems(origin, *storage)));
 #if !defined(COBALT_IS_RELEASE_BUILD)
   tasks.push_back(LogElapsedTimeTask());
-#endif  // !defined(COBALT_IS_RELEASE_BUILD)
+#endif
   tasks.push_back(DeleteOldCacheDirectoryTask());
   tasks.push_back(ReloadTask(weak_document_ptr, url));
-  std::move(GroupTasks(std::move(tasks))).Run(base::DoNothing());
+
+  LOG(INFO) << "ColinL: Executing task group.";
+  std::move(GroupTasks(std::move(tasks))).Run(std::move(done_callback));
 }
 
 // static
 Task MigrationManager::CookieTask(
     content::WeakDocumentPtr weak_document_ptr,
     std::vector<std::unique_ptr<net::CanonicalCookie>> cookies) {
+  LOG(INFO) << "ColinL: Creating CookieTask for " << cookies.size()
+            << " cookies.";
   std::vector<Task> tasks;
   tasks.push_back(base::BindOnce(
       [](content::WeakDocumentPtr weak_document_ptr,
@@ -340,6 +378,8 @@ Task MigrationManager::CookieTask(
 Task MigrationManager::LocalStorageTask(
     content::WeakDocumentPtr weak_document_ptr,
     std::vector<std::unique_ptr<std::pair<std::string, std::string>>> pairs) {
+  LOG(INFO) << "ColinL: Creating LocalStorageTask for " << pairs.size()
+            << " items.";
   std::vector<Task> tasks;
   tasks.push_back(base::BindOnce(
       [](content::WeakDocumentPtr weak_document_ptr,

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.h
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.h
@@ -36,6 +36,7 @@ using Task = base::OnceCallback<void(base::OnceClosure)>;
 class MigrationManager {
  public:
   static void DoMigrationTasksOnce(content::WebContents* web_contents);
+  static void RunMigrationTasks(content::WebContents* web_contents);
 
  private:
   friend class MigrationManagerTest;

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.h
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.h
@@ -35,10 +35,12 @@ using Task = base::OnceCallback<void(base::OnceClosure)>;
 
 class MigrationManager {
  public:
-  static void EnsureMigrationDone(content::WebContents* web_contents,
-                                  base::OnceClosure done_callback);
-  static void RunMigrationTasks(content::WebContents* web_contents,
-                                base::OnceClosure done_callback);
+  //   static void EnsureMigrationDone(content::WebContents* web_contents,
+  //                                   base::OnceClosure done_callback);
+  //   static void RunMigrationTasks(content::WebContents* web_contents,
+  //                                 base::OnceClosure done_callback);
+  static void RunMigration(content::StoragePartition* partition,
+                           base::OnceClosure done_callback);
 
  private:
   friend class MigrationManagerTest;
@@ -46,10 +48,11 @@ class MigrationManager {
   // Returns a task. When invoked, the grouped |tasks| are run sequentially.
   static Task GroupTasks(std::vector<Task> tasks);
   static Task CookieTask(
-      content::WeakDocumentPtr weak_document_ptr,
+      content::StoragePartition* partition,
       std::vector<std::unique_ptr<net::CanonicalCookie>> cookies);
   static Task LocalStorageTask(
-      content::WeakDocumentPtr weak_document_ptr,
+      content::StoragePartition* partition,
+      const url::Origin& origin,
       std::vector<std::unique_ptr<std::pair<std::string, std::string>>> pairs);
   static std::vector<std::unique_ptr<std::pair<std::string, std::string>>>
   ToLocalStorageItems(const url::Origin& page_origin,

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.h
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.h
@@ -35,8 +35,10 @@ using Task = base::OnceCallback<void(base::OnceClosure)>;
 
 class MigrationManager {
  public:
-  static void DoMigrationTasksOnce(content::WebContents* web_contents);
-  static void RunMigrationTasks(content::WebContents* web_contents);
+  static void EnsureMigrationDone(content::WebContents* web_contents,
+                                  base::OnceClosure done_callback);
+  static void RunMigrationTasks(content::WebContents* web_contents,
+                                base::OnceClosure done_callback);
 
  private:
   friend class MigrationManagerTest;

--- a/cobalt/shell/browser/migrate_storage_record/task_sequence_runner.cc
+++ b/cobalt/shell/browser/migrate_storage_record/task_sequence_runner.cc
@@ -1,0 +1,52 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/shell/browser/migrate_storage_record/task_sequence_runner.h"
+
+#include "base/functional/bind.h"
+
+namespace cobalt {
+namespace migrate_storage_record {
+
+TaskSequenceRunner::TaskSequenceRunner(base::OnceClosure done_callback)
+    : final_callback_(std::move(done_callback)) {}
+
+TaskSequenceRunner::~TaskSequenceRunner() = default;
+
+void TaskSequenceRunner::AddTask(Task task) {
+  tasks_.push(std::move(task));
+}
+
+void TaskSequenceRunner::RunNext() {
+  if (tasks_.empty()) {
+    if (final_callback_) {
+      std::move(final_callback_).Run();
+    }
+    // Delete this instance as it has finished its lifecycle.
+    delete this;
+    return;
+  }
+
+  Task next = std::move(tasks_.front());
+  tasks_.pop();
+
+  // Bind RunNext to the completion of the current task.
+  // We use base::Unretained(this) because the class instance is responsible
+  // for its own deletion only after the queue is empty.
+  std::move(next).Run(
+      base::BindOnce(&TaskSequenceRunner::RunNext, base::Unretained(this)));
+}
+
+}  // namespace migrate_storage_record
+}  // namespace cobalt

--- a/cobalt/shell/browser/migrate_storage_record/task_sequence_runner.h
+++ b/cobalt/shell/browser/migrate_storage_record/task_sequence_runner.h
@@ -1,0 +1,55 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_SHELL_BROWSER_MIGRATE_STORAGE_RECORD_TASK_SEQUENCE_RUNNER_H_
+#define COBALT_SHELL_BROWSER_MIGRATE_STORAGE_RECORD_TASK_SEQUENCE_RUNNER_H_
+
+#include <queue>
+#include <utility>
+
+#include "base/functional/callback.h"
+
+namespace cobalt {
+namespace migrate_storage_record {
+
+// Used to define a task that accepts a completion closure.
+using Task = base::OnceCallback<void(base::OnceClosure)>;
+
+// Helper class to run a sequence of move-only tasks safely.
+// This class is self-managed and deletes itself once the task queue is empty
+// and the final callback has been invoked.
+class TaskSequenceRunner {
+ public:
+  explicit TaskSequenceRunner(base::OnceClosure done_callback);
+
+  TaskSequenceRunner(const TaskSequenceRunner&) = delete;
+  TaskSequenceRunner& operator=(const TaskSequenceRunner&) = delete;
+
+  ~TaskSequenceRunner();
+
+  // Adds a task to the back of the execution queue.
+  void AddTask(Task task);
+
+  // Begins or continues execution of the queued tasks.
+  void RunNext();
+
+ private:
+  std::queue<Task> tasks_;
+  base::OnceClosure final_callback_;
+};
+
+}  // namespace migrate_storage_record
+}  // namespace cobalt
+
+#endif  // COBALT_SHELL_BROWSER_MIGRATE_STORAGE_RECORD_TASK_SEQUENCE_RUNNER_H_

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -398,8 +398,6 @@ void Shell::PrimaryMainDocumentElementAvailable() {
   starboard::android::shared::StarboardBridge::GetInstance()
       ->SetStartupMilestone(27);
 #endif
-  cobalt::migrate_storage_record::MigrationManager::DoMigrationTasksOnce(
-      web_contents());
 }
 
 void Shell::DidFinishLoad(RenderFrameHost* render_frame_host,

--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -5849,7 +5849,9 @@ String Document::cookie(ExceptionState& exception_state) const {
     CountUse(WebFeature::kFileAccessedCookies);
   }
 
-  return cookie_jar_->Cookies();
+  String value = cookie_jar_->Cookies();
+  LOG(INFO) << "ColinL: sm telemetry: [JS Cookie] GET result: " << value.Utf8();
+  return value;
 }
 
 void Document::setCookie(const String& value, ExceptionState& exception_state) {

--- a/third_party/blink/renderer/core/dom/document.cc
+++ b/third_party/blink/renderer/core/dom/document.cc
@@ -33,6 +33,7 @@
 #include <utility>
 
 #include "base/auto_reset.h"
+#include "base/logging.h"
 #include "base/containers/adapters.h"
 #include "base/containers/contains.h"
 #include "base/debug/dump_without_crashing.h"
@@ -5822,6 +5823,7 @@ void Document::WillChangeFrameOwnerProperties(
 }
 
 String Document::cookie(ExceptionState& exception_state) const {
+  LOG(INFO) << "ColinL: sm telemetry: [JS Cookie] GET";
   if (!dom_window_ || !GetSettings()->GetCookieEnabled())
     return String();
 
@@ -5851,6 +5853,7 @@ String Document::cookie(ExceptionState& exception_state) const {
 }
 
 void Document::setCookie(const String& value, ExceptionState& exception_state) {
+  LOG(INFO) << "ColinL: sm telemetry: [JS Cookie] SET: " << value.Utf8();
   if (!dom_window_ || !GetSettings()->GetCookieEnabled())
     return;
 

--- a/third_party/blink/renderer/modules/storage/storage_area.cc
+++ b/third_party/blink/renderer/modules/storage/storage_area.cc
@@ -102,19 +102,35 @@ String StorageArea::key(unsigned index, ExceptionState& exception_state) const {
 
 String StorageArea::getItem(const String& key,
                             ExceptionState& exception_state) const {
+  // Use this version in storage_area.cc to avoid the ExecutionContext error
+  // Correct logging for third_party/blink/renderer/modules/storage/storage_area.cc
+  if (GetExecutionContext()) {
+      // Convert SecurityOrigin to url::Origin for StorageKey consumption
+      url::Origin renderer_origin = GetExecutionContext()->GetSecurityOrigin()->ToUrlOrigin();
+      
+      // Create the StorageKey used by the renderer locally for debug output
+      blink::StorageKey renderer_key = blink::StorageKey::CreateFirstParty(renderer_origin);
+      
+      LOG(INFO) << "ColinL: [JS LocalStorage] Renderer Origin: " << renderer_origin.Serialize();
+      LOG(INFO) << "ColinL: [JS LocalStorage] Renderer Key Debug: " << renderer_key.GetDebugString();
+      LOG(INFO) << "ColinL: [JS LocalStorage] Renderer Key Serialized: " << renderer_key.SerializeForLocalStorage();
+  }
+
   LOG(INFO) << "ColinL: sm telemetry: [JS LocalStorage] getItem: " << key.Utf8();
   if (!CanAccessStorage()) {
     exception_state.ThrowSecurityError("access is denied for this document.");
     return String();
   }
-  return cached_area_->GetItem(key);
+  String value = cached_area_->GetItem(key);
+  LOG(INFO) << "ColinL: sm telemetry: [JS LocalStorage] getItem: " << key.Utf8() << " = " << value.Utf8();
+  return value;
 }
 
 NamedPropertySetterResult StorageArea::setItem(
     const String& key,
     const String& value,
     ExceptionState& exception_state) {
-  LOG(INFO) << "ColinL: sm telemetry: [JS LocalStorage] setItem: " << key.Utf8();
+  LOG(INFO) << "ColinL: sm telemetry: [JS LocalStorage] setItem: " << key.Utf8() << " = " << value.Utf8();
   if (!CanAccessStorage()) {
     exception_state.ThrowSecurityError("access is denied for this document.");
     return NamedPropertySetterResult::kIntercepted;

--- a/third_party/blink/renderer/modules/storage/storage_area.cc
+++ b/third_party/blink/renderer/modules/storage/storage_area.cc
@@ -26,6 +26,7 @@
 #include "third_party/blink/renderer/modules/storage/storage_area.h"
 
 #include "base/feature_list.h"
+#include "base/logging.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/trace_event/trace_event.h"
@@ -101,6 +102,7 @@ String StorageArea::key(unsigned index, ExceptionState& exception_state) const {
 
 String StorageArea::getItem(const String& key,
                             ExceptionState& exception_state) const {
+  LOG(INFO) << "ColinL: sm telemetry: [JS LocalStorage] getItem: " << key.Utf8();
   if (!CanAccessStorage()) {
     exception_state.ThrowSecurityError("access is denied for this document.");
     return String();
@@ -112,6 +114,7 @@ NamedPropertySetterResult StorageArea::setItem(
     const String& key,
     const String& value,
     ExceptionState& exception_state) {
+  LOG(INFO) << "ColinL: sm telemetry: [JS LocalStorage] setItem: " << key.Utf8();
   if (!CanAccessStorage()) {
     exception_state.ThrowSecurityError("access is denied for this document.");
     return NamedPropertySetterResult::kIntercepted;


### PR DESCRIPTION
Introduce a mechanism to prevent storage migration tasks from
re-executing on a profile that has already been processed by
Cobalt 26+. Before running the migration logic, check for the
presence of the "yt-dev.storage-integrity" cookie. If this
cookie exists, it indicates that a previous Cobalt 26+ instance
has already performed the migration. Skipping further migration
in such cases prevents unintended removal of existing cookies
and localStorage data.

Bug: 487739842