### PR TITLE
media: Implement madvise for idle buffer memory

### DIFF
--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -138,6 +138,7 @@ source_set("unit_tests") {
       "decoder_buffer_allocator_strategy_test.cc",
       "decoder_buffer_allocator_test.cc",
       "media_buffer_pool_decoder_buffer_allocator_strategy_test.cc",
+      "starboard_memory_allocator_test.cc",
       "starboard_renderer_unittest.cc",
       "starboard_utils_test.cc",
     ]

--- a/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
@@ -27,11 +27,14 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
  public:
   BidirectionalFitDecoderBufferAllocatorStrategy(
       std::size_t initial_capacity,
-      std::size_t allocation_increment)
-      : birectional_fit_allocator_(&fallback_allocator_,
+      std::size_t allocation_increment,
+      bool enable_decommit_on_idle)
+      : fallback_allocator_(enable_decommit_on_idle),
+        birectional_fit_allocator_(&fallback_allocator_,
                                    initial_capacity,
                                    kSmallAllocationThreshold,
-                                   allocation_increment) {}
+                                   allocation_increment,
+                                   enable_decommit_on_idle) {}
 
   void* Allocate(DemuxerStream::Type type,
                  size_t size,

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -90,8 +90,7 @@ DecoderBufferAllocator::~DecoderBufferAllocator() {
 
 // static
 DecoderBufferAllocator* DecoderBufferAllocator::Get() {
-  return static_cast<DecoderBufferAllocator*>(
-      DecoderBuffer::Allocator::Get());
+  return static_cast<DecoderBufferAllocator*>(DecoderBuffer::Allocator::Get());
 }
 
 void DecoderBufferAllocator::Suspend() {
@@ -163,8 +162,8 @@ void DecoderBufferAllocator::Free(DemuxerStream::Type type,
   }
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
-  bool should_reset_strategy = is_strategy_switch_pending_ ||
-                               is_memory_pool_allocated_on_demand_;
+  bool should_reset_strategy =
+      is_strategy_switch_pending_ || is_memory_pool_allocated_on_demand_;
 
   if (should_reset_strategy && strategy_->GetAllocated() == 0) {
     // `strategy_->PrintAllocations()` will be called inside the dtor when
@@ -266,6 +265,32 @@ void DecoderBufferAllocator::SetAllocateOnDemand(bool enabled) {
 }
 
 // static
+void DecoderBufferAllocator::EnableDecommitableAllocatorStrategy() {
+  auto* allocator = Get();
+  CHECK(allocator);
+  allocator->UpdateAllocatorStrategy(base::BindRepeating(
+      [](int initial_capacity, int allocation_unit)
+          -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
+        // The default values of initial_capacity and allocation_unit are often
+        // 4 MB, which in the extreme case aren't enough to hold a key frame.
+        // Increase them to 8 MB to accommodate all known key frames without
+        // special allocations in the underlying allocator.
+        constexpr int kAllocationUnit = 8 * 1024 * 1024;
+
+        LOG(INFO) << "DecoderBufferAllocator is using "
+                     "DefaultReuseAllocatorStrategy with decommit enabled. "
+                  << "initial_capacity (" << initial_capacity
+                  << ") and allocation_unit (" << allocation_unit
+                  << ") are ignored and set to " << kAllocationUnit
+                  << " bytes.";
+
+        return std::make_unique<DefaultReuseAllocatorStrategy>(
+            kAllocationUnit, kAllocationUnit,
+            /*enable_decommit_on_idle=*/true);
+      }));
+}
+
+// static
 void DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase() {
   auto* allocator = Get();
   CHECK(allocator);
@@ -275,7 +300,8 @@ void DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase() {
         LOG(INFO)
             << "DecoderBufferAllocator is using InPlaceReuseAllocatorBase.";
         return std::make_unique<InPlaceReuseAllocatorStrategy>(
-            initial_capacity, allocation_unit);
+            initial_capacity, allocation_unit,
+            /*enable_decommit_on_idle=*/false);
       }));
 }
 
@@ -291,7 +317,7 @@ void DecoderBufferAllocator::EnableMediaBufferPoolStrategy() {
           LOG(INFO) << "DecoderBufferAllocator is using MediaBufferPool.";
           return std::make_unique<
               MediaBufferPoolDecoderBufferAllocatorStrategy>(
-                  pool, initial_capacity, allocation_unit);
+              pool, initial_capacity, allocation_unit);
         }
         LOG(INFO) << "DecoderBufferAllocator failed to enable MediaBufferPool"
                   << " as MediaBufferPool::Acquire() returns nullptr.";
@@ -308,8 +334,8 @@ void DecoderBufferAllocator::EnsureStrategyIsCreated() {
   is_strategy_switch_pending_ = false;
 
   if (!experimental_strategy_create_cb_.is_null()) {
-    strategy_ = experimental_strategy_create_cb_.Run(
-        initial_capacity_, allocation_unit_);
+    strategy_ = experimental_strategy_create_cb_.Run(initial_capacity_,
+                                                     allocation_unit_);
     if (strategy_) {
       LOG(INFO) << "Allocated " << initial_capacity_
                 << " bytes for decoder buffer pool.";
@@ -324,12 +350,15 @@ void DecoderBufferAllocator::EnsureStrategyIsCreated() {
   if (base::FeatureList::IsEnabled(
           kCobaltDecoderBufferAllocatorWithInPlaceMetadata)) {
     strategy_ = std::make_unique<InPlaceReuseAllocatorStrategy>(
-        initial_capacity_, allocation_unit_);
+        initial_capacity_, allocation_unit_,
+        /*enable_decommit_on_idle=*/false);
     LOG(INFO) << "DecoderBufferAllocator is using InPlaceReuseAllocatorBase.";
   } else {
     strategy_ = std::make_unique<DefaultReuseAllocatorStrategy>(
-        initial_capacity_, allocation_unit_);
-    LOG(INFO) << "DecoderBufferAllocator is using DefaultReuseAllocatorStrategy.";
+        initial_capacity_, allocation_unit_,
+        /*enable_decommit_on_idle=*/false);
+    LOG(INFO) << "DecoderBufferAllocator is using"
+              << " DefaultReuseAllocatorStrategy.";
   }
 
   LOG(INFO) << "Allocated " << initial_capacity_

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -86,6 +86,7 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   // Utility functions for h5vcc settings.
   // TODO(b/460292554): To be deprecated with h5vcc settings.
   void SetAllocateOnDemand(bool enabled);
+  static void EnableDecommitableAllocatorStrategy();
   static void EnableInPlaceReuseAllocatorBase();
   static void EnableMediaBufferPoolStrategy();
 

--- a/media/starboard/decoder_buffer_allocator_strategy_test.cc
+++ b/media/starboard/decoder_buffer_allocator_strategy_test.cc
@@ -39,8 +39,9 @@ void UpdateStrategyWithCreationCounter(DecoderBufferAllocator* allocator,
       [](int* creation_count_ptr, int initial_capacity, int allocation_unit)
           -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
         (*creation_count_ptr)++;
-        return std::make_unique<InPlaceReuseAllocatorStrategy>(initial_capacity,
-                                                               allocation_unit);
+        return std::make_unique<InPlaceReuseAllocatorStrategy>(
+            initial_capacity, allocation_unit,
+            /*enable_decommit_on_idle=*/false);
       },
       base::Unretained(creation_count)));
 }

--- a/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
+++ b/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
@@ -29,13 +29,15 @@ MediaBufferPoolDecoderBufferAllocatorStrategy::
     : media_buffer_pool_(media_buffer_pool),
       video_buffer_initial_capacity_(video_buffer_initial_capacity),
       video_buffer_allocation_increment_(video_buffer_allocation_increment),
+      audio_fallback_allocator_(/*enable_decommit_on_idle=*/false),
       audio_allocator_(
           &audio_fallback_allocator_,
           // Pre-allocate sufficient capacity for audio buffers to
           // avoid expansions in most scenarios.
           SbMediaGetAudioBufferBudget() + kAudioAllocationIncrement,
           kSmallAllocationThreshold,
-          kAudioAllocationIncrement),
+          kAudioAllocationIncrement,
+          /*enable_decommit_on_idle=*/false),
       video_allocator_(new MediaBufferPoolBidirectionalReuseAllocator(
           media_buffer_pool_,
           video_buffer_initial_capacity,

--- a/media/starboard/starboard_memory_allocator.h
+++ b/media/starboard/starboard_memory_allocator.h
@@ -16,31 +16,74 @@
 #define MEDIA_STARBOARD_STARBOARD_MEMORY_ALLOCATOR_H_
 
 #include <stdlib.h>
+#include <sys/mman.h>
+#include <unistd.h>
 
 #include <algorithm>
 
+#include "base/check.h"
+#include "base/check_op.h"
+#include "base/logging.h"
+#include "build/build_config.h"
 #include "starboard/common/allocator.h"
+#include "starboard/common/memory.h"
+#include "starboard/common/pointer_arithmetic.h"
 #include "starboard/configuration.h"
+#include "starboard/configuration_constants.h"
 
 namespace media {
+
+using starboard::common::AlignDown;
+using starboard::common::AlignUp;
 
 // StarboardMemoryAllocator is an allocator that allocates and frees memory
 // using posix_memalign() and free().
 class StarboardMemoryAllocator : public starboard::common::Allocator {
  public:
-  void* Allocate(std::size_t size) override { return Allocate(size, 1); }
+  explicit StarboardMemoryAllocator(bool enable_decommit)
+      : enable_decommit_(enable_decommit),
+        page_size_(static_cast<size_t>(sysconf(_SC_PAGESIZE))) {
+    LOG(INFO) << "StarboardMemoryAllocator: decommit is "
+              << (enable_decommit_ ? "enabled" : "disabled") << ".";
+  }
+
+  void* Allocate(std::size_t size) override {
+    return AllocateForAlignment(&size, 1);
+  }
 
   void* Allocate(std::size_t size, std::size_t alignment) override {
-    void* p = nullptr;
-    posix_memalign(&p, std::max(alignment, sizeof(void*)), size);
-    return p;
+    return AllocateForAlignment(&size, alignment);
   }
 
   void* AllocateForAlignment(std::size_t* size,
                              std::size_t alignment) override {
-    return Allocate(*size, alignment);
+    if (enable_decommit_) {
+      alignment = std::max(alignment, page_size_);
+      *size = AlignUp(*size, page_size_);
+    }
+    void* p = nullptr;
+    posix_memalign(&p, std::max(alignment, sizeof(void*)), *size);
+    return p;
   }
   void Free(void* memory) override { free(memory); }
+
+  void Decommit(void* memory, std::size_t size) override {
+    uintptr_t start = reinterpret_cast<uintptr_t>(memory);
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+    CHECK(enable_decommit_);
+    CHECK_EQ(start % page_size_, 0U);
+    CHECK_EQ(size % page_size_, 0U);
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+
+    // Align down the size to prevent decommitting past the end just in case
+    // the user explicitly passes an altered, unaligned size block.
+    size_t aligned_size = AlignDown(size, page_size_);
+
+    if (aligned_size > 0) {
+      madvise(memory, aligned_size, MADV_DONTNEED);
+    }
+  }
+
   std::size_t GetCapacity() const override {
     // Returns 0 here to avoid tracking the allocated memory.
     return 0;
@@ -51,6 +94,10 @@ class StarboardMemoryAllocator : public starboard::common::Allocator {
   }
   void PrintAllocations(bool align_allocated_size,
                         int max_allocations_to_print) const override {}
+
+ private:
+  const bool enable_decommit_;
+  const size_t page_size_;
 };
 
 }  // namespace media

--- a/media/starboard/starboard_memory_allocator_test.cc
+++ b/media/starboard/starboard_memory_allocator_test.cc
@@ -1,0 +1,113 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/starboard/starboard_memory_allocator.h"
+
+#include <string.h>
+#include <unistd.h>
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace media {
+namespace {
+
+class StarboardMemoryAllocatorTest : public ::testing::TestWithParam<bool> {
+ protected:
+  StarboardMemoryAllocatorTest() : allocator_(GetParam()) {}
+  StarboardMemoryAllocator allocator_;
+};
+
+TEST_P(StarboardMemoryAllocatorTest, AllocateAndFree) {
+  void* p = allocator_.Allocate(1024);
+  EXPECT_NE(p, nullptr);
+  // Write to the memory to ensure it's valid.
+  memset(p, 0xAB, 1024);
+  allocator_.Free(p);
+}
+
+TEST_P(StarboardMemoryAllocatorTest, AllocateZeroSize) {
+  void* p = allocator_.Allocate(0);
+  // Allocate(0) can return a nullptr or a unique non-null pointer.
+  // In either case, it should be possible to free it.
+  if (p) {
+    allocator_.Free(p);
+  }
+}
+
+TEST_P(StarboardMemoryAllocatorTest, AllocateWithAlignment) {
+  const size_t alignment = 256;
+  void* p = allocator_.Allocate(1024, alignment);
+  EXPECT_NE(p, nullptr);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(p) % alignment, 0);
+  allocator_.Free(p);
+}
+
+TEST_P(StarboardMemoryAllocatorTest, AllocateWithZeroAlignment) {
+  const size_t alignment = 0;
+  void* p = allocator_.Allocate(1024, alignment);
+  EXPECT_NE(p, nullptr);
+  EXPECT_EQ(reinterpret_cast<uintptr_t>(p) % sizeof(void*), 0);
+  allocator_.Free(p);
+}
+
+TEST_P(StarboardMemoryAllocatorTest, GetCapacityAndAllocatedShouldBeZero) {
+  EXPECT_EQ(allocator_.GetCapacity(), 0);
+  EXPECT_EQ(allocator_.GetAllocated(), 0);
+  void* p = allocator_.Allocate(1024);
+  EXPECT_NE(p, nullptr);
+  // Should still be zero as this allocator doesn't track allocations.
+  EXPECT_EQ(allocator_.GetCapacity(), 0);
+  EXPECT_EQ(allocator_.GetAllocated(), 0);
+  allocator_.Free(p);
+}
+
+INSTANTIATE_TEST_SUITE_P(EnableDecommit,
+                         StarboardMemoryAllocatorTest,
+                         ::testing::Bool());
+
+TEST(StarboardMemoryAllocatorDecommitSpecificTest,
+     AllocateForAlignmentUpdatesSizeWhenDecommitEnabled) {
+  StarboardMemoryAllocator allocator(/*enable_decommit=*/true);
+
+  const size_t page_size = sysconf(_SC_PAGESIZE);
+  const size_t initial_size = page_size / 2;  // A size smaller than page size
+
+  size_t size = initial_size;
+  size_t alignment = 1;
+  void* ptr = allocator.AllocateForAlignment(&size, alignment);
+
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ(size, page_size);  // Should be aligned up to page size
+
+  allocator.Free(ptr);
+}
+
+TEST(StarboardMemoryAllocatorDecommitSpecificTest,
+     AllocateForAlignmentDoesNotUpdateSizeWhenDecommitDisabled) {
+  StarboardMemoryAllocator allocator(/*enable_decommit=*/false);
+
+  const size_t page_size = sysconf(_SC_PAGESIZE);
+  const size_t initial_size = page_size / 2;
+
+  size_t size = initial_size;
+  size_t alignment = 1;
+  void* ptr = allocator.AllocateForAlignment(&size, alignment);
+
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_EQ(size, initial_size);  // Should remain unchanged
+
+  allocator.Free(ptr);
+}
+
+}  // namespace
+}  // namespace media

--- a/starboard/common/allocator.h
+++ b/starboard/common/allocator.h
@@ -77,6 +77,10 @@ class Allocator {
   // Frees memory with a size. By default it will delegate to Free().
   virtual void FreeWithSize(void* memory, size_t /*size*/) { Free(memory); }
 
+  // Hints to the allocator that the physical memory backing this range is no
+  // longer needed, but the virtual address space should remain reserved.
+  virtual void Decommit(void* memory, size_t size) {}
+
   // Returns the allocator's total capacity for allocations.  It will always
   // be true that GetSize() <= GetCapacity(), though it is possible for
   // capacity to grow and change over time.  It is also possible that due to,

--- a/starboard/common/bidirectional_fit_reuse_allocator.h
+++ b/starboard/common/bidirectional_fit_reuse_allocator.h
@@ -50,10 +50,13 @@ class BidirectionalFitReuseAllocator : public ReuseAllocatorBase {
       starboard::common::Allocator* fallback_allocator,
       std::size_t initial_capacity,
       std::size_t small_allocation_threshold,
-      std::size_t allocation_increment)
+      std::size_t allocation_increment,
+      bool enable_decommit_on_idle)
       : ReuseAllocatorBase(fallback_allocator,
                            initial_capacity,
-                           allocation_increment),
+                           allocation_increment,
+                           /*max_capacity=*/0,
+                           enable_decommit_on_idle),
         small_allocation_threshold_(small_allocation_threshold) {}
 
   FreeBlockIterator FindFreeBlock(std::size_t size,

--- a/starboard/common/bidirectional_fit_reuse_allocator_test.cc
+++ b/starboard/common/bidirectional_fit_reuse_allocator_test.cc
@@ -26,6 +26,8 @@
 #include "starboard/types.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
+using starboard::common::FixedNoFreeAllocator;
+
 namespace starboard {
 namespace common {
 
@@ -33,7 +35,7 @@ struct AlignedMemoryDeleter {
   void operator()(uint8_t* p) { free(p); }
 };
 
-static constexpr int kBufferSize = 1 * 1024 * 1024;
+static constexpr int kBufferSize = 8 * 1024 * 1024;
 
 template <typename ReuseAllocatorBase>
 class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
@@ -41,6 +43,78 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
   BidirectionalFitReuseAllocatorTest() { ResetAllocator(); }
 
  protected:
+  class MockDecommitAllocator : public FixedNoFreeAllocator {
+   public:
+    MockDecommitAllocator(void* memory_start, size_t memory_size)
+        : FixedNoFreeAllocator(memory_start, memory_size), decommit_count(0) {}
+
+    void* Allocate(std::size_t size) override {
+      void* ptr = FixedNoFreeAllocator::Allocate(size);
+      if (ptr) {
+        active_allocations_[ptr] = size;
+      }
+      return ptr;
+    }
+
+    void* Allocate(std::size_t size, std::size_t alignment) override {
+      void* ptr = FixedNoFreeAllocator::Allocate(size, alignment);
+      if (ptr) {
+        active_allocations_[ptr] = size;
+      }
+      return ptr;
+    }
+
+    void* AllocateForAlignment(std::size_t* size,
+                               std::size_t alignment) override {
+      void* ptr = FixedNoFreeAllocator::AllocateForAlignment(size, alignment);
+      if (ptr) {
+        active_allocations_[ptr] = *size;
+      }
+      return ptr;
+    }
+
+    void Free(void* memory) override {
+      auto it = active_allocations_.find(memory);
+      EXPECT_NE(it, active_allocations_.end())
+          << "Freeing a pointer not allocated by this fallback allocator, or "
+             "already freed.";
+      if (it != active_allocations_.end()) {
+        active_allocations_.erase(it);
+      }
+      FixedNoFreeAllocator::Free(memory);
+    }
+
+    void FreeWithSize(void* memory, size_t size) override {
+      auto it = active_allocations_.find(memory);
+      EXPECT_NE(it, active_allocations_.end())
+          << "Freeing a pointer not allocated by this fallback allocator, or "
+             "already freed.";
+      if (it != active_allocations_.end()) {
+        EXPECT_EQ(it->second, size)
+            << "Free size does not exactly match the allocated size.";
+        active_allocations_.erase(it);
+      }
+      FixedNoFreeAllocator::FreeWithSize(memory, size);
+    }
+
+    void Decommit(void* memory, size_t size) override {
+      auto it = active_allocations_.find(memory);
+      EXPECT_NE(it, active_allocations_.end())
+          << "Decommitting a pointer not allocated by this fallback allocator.";
+      if (it != active_allocations_.end()) {
+        EXPECT_EQ(it->second, size)
+            << "Decommit size does not exactly match the allocated size.";
+      }
+
+      decommits.push_back({memory, size});
+      decommit_count++;
+    }
+
+    int decommit_count;
+    std::vector<std::pair<void*, size_t>> decommits;
+    std::map<void*, size_t> active_allocations_;
+  };
+
   void ResetAllocator(std::size_t initial_capacity = 0,
                       std::size_t small_allocation_threshold = 0,
                       std::size_t allocation_increment = 0) {
@@ -49,18 +123,36 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
                    kBufferSize);
     buffer_.reset(static_cast<uint8_t*>(tmp));
 
-    std::unique_ptr<starboard::common::FixedNoFreeAllocator> fallback_allocator(
-        new starboard::common::FixedNoFreeAllocator(buffer_.get(),
-                                                    kBufferSize));
+    std::unique_ptr<FixedNoFreeAllocator> fallback_allocator(
+        new FixedNoFreeAllocator(buffer_.get(), kBufferSize));
     allocator_.reset(new BidirectionalFitReuseAllocator<ReuseAllocatorBase>(
         fallback_allocator.get(), initial_capacity, small_allocation_threshold,
-        allocation_increment));
+        allocation_increment, false));
 
     fallback_allocator_.swap(fallback_allocator);
   }
 
+  void ResetAllocatorWithDecommitSupport() {
+    void* tmp = nullptr;
+    posix_memalign(&tmp, starboard::common::Allocator::kMinAlignment,
+                   kBufferSize);
+    buffer_.reset(static_cast<uint8_t*>(tmp));
+
+    std::unique_ptr<MockDecommitAllocator> fallback_allocator(
+        new MockDecommitAllocator(buffer_.get(), kBufferSize));
+
+    // Store pointer before move/swap
+    mock_fallback_allocator_ = fallback_allocator.get();
+
+    allocator_.reset(new BidirectionalFitReuseAllocator<ReuseAllocatorBase>(
+        mock_fallback_allocator_, 0, 0, 0, true));
+
+    fallback_allocator_.reset(fallback_allocator.release());
+  }
+
   std::unique_ptr<uint8_t, AlignedMemoryDeleter> buffer_;
-  std::unique_ptr<starboard::common::FixedNoFreeAllocator> fallback_allocator_;
+  std::unique_ptr<FixedNoFreeAllocator> fallback_allocator_;
+  MockDecommitAllocator* mock_fallback_allocator_ = nullptr;
   std::unique_ptr<BidirectionalFitReuseAllocator<ReuseAllocatorBase>>
       allocator_;
 };
@@ -254,6 +346,93 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, AllocationsWithThreshold) {
   this->allocator_->Free(large_allocation_1);
   this->allocator_->Free(small_allocation_1);
   this->allocator_->Free(small_allocation_3);
+}
+
+TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitExactFallbackBlocks) {
+  const std::size_t kAlignment = sizeof(void*);
+
+  this->ResetAllocatorWithDecommitSupport();
+
+  // Make two allocations. Because the initial capacity is 0, each allocate call
+  // will force the reuse allocator to expand and grab a distinct block from the
+  // fallback allocator. We use sizes large enough (multiples of 64KB) to ensure
+  // that even if the fallback allocator aligns the allocated size up to a page
+  // boundary, the second allocation will not fit in any leftover space.
+  const size_t size1 = 64 * 1024;
+  const size_t size2 = 128 * 1024;
+  void* block1 = this->allocator_->Allocate(size1, kAlignment);
+  void* block2 = this->allocator_->Allocate(size2, kAlignment);
+
+  EXPECT_TRUE(block1 != nullptr);
+  EXPECT_TRUE(block2 != nullptr);
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0);
+
+  // Free them. The allocator may merge the free blocks internally,
+  // but it must still decommit the original exact fallback blocks.
+  this->allocator_->Free(block1);
+  this->allocator_->Free(block2);
+
+  // We should have exactly 2 decommits matching the original blocks.
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 2);
+
+  // They might be decommitted in any order, so check if both exist.
+  // Note: For InPlaceReuseAllocatorBase, `block1` and `block2` are offset from
+  // the raw fallback memory pointer by `sizeof(BlockMetadata)`. Thus, we check
+  // if the original fallback block `contains` the user pointer, rather than
+  // checking for exact pointer equality.
+  bool found_block1 = false;
+  bool found_block2 = false;
+  for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
+    uint8_t* fallback_ptr = static_cast<uint8_t*>(decommit.first);
+    size_t fallback_size = decommit.second;
+    uint8_t* ptr1 = static_cast<uint8_t*>(block1);
+    uint8_t* ptr2 = static_cast<uint8_t*>(block2);
+
+    if (ptr1 >= fallback_ptr && ptr1 < fallback_ptr + fallback_size &&
+        fallback_size >= size1) {
+      found_block1 = true;
+    }
+    if (ptr2 >= fallback_ptr && ptr2 < fallback_ptr + fallback_size &&
+        fallback_size >= size2) {
+      found_block2 = true;
+    }
+  }
+
+  EXPECT_TRUE(found_block1);
+  EXPECT_TRUE(found_block2);
+}
+
+TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitOnBatchedFree) {
+  const std::size_t kAlignment = sizeof(void*);
+  const size_t kBlockSize = 1024;
+  const int kNumBlocks = 4096;
+
+  this->ResetAllocatorWithDecommitSupport();
+
+  std::vector<void*> blocks;
+  // Allocate a large number of blocks to trigger the batched free threshold
+  // (the class currently requires > 32).
+  for (int i = 0; i < kNumBlocks; ++i) {
+    void* block = this->allocator_->Allocate(kBlockSize, kAlignment);
+    EXPECT_TRUE(block != nullptr);
+    blocks.push_back(block);
+  }
+
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0);
+
+  for (void* block : blocks) {
+    this->allocator_->Free(block);
+  }
+
+  // InPlaceReuseAllocatorBase batches frees and processes them all at once when
+  // idle.
+  EXPECT_GT(this->mock_fallback_allocator_->decommits.size(), 0);
+
+  size_t total_decommitted_size = 0;
+  for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
+    total_decommitted_size += decommit.second;
+  }
+  EXPECT_GE(total_decommitted_size, kBlockSize * kNumBlocks);
 }
 
 }  // namespace common

--- a/starboard/common/experimental/media_buffer_pool_bidirectional_reuse_allocator.h
+++ b/starboard/common/experimental/media_buffer_pool_bidirectional_reuse_allocator.h
@@ -33,15 +33,16 @@ namespace experimental {
 class MediaBufferPoolBidirectionalReuseAllocator : public Allocator {
  public:
   MediaBufferPoolBidirectionalReuseAllocator(
-      MediaBufferPool* pool,
+      MediaBufferPool* media_buffer_pool,
       std::size_t initial_capacity,
       std::size_t small_allocation_threshold,
       std::size_t allocation_increment)
-      : fallback_allocator_(pool),
+      : fallback_allocator_(media_buffer_pool),
         bidirectional_fit_reuse_allocator_(&fallback_allocator_,
                                            initial_capacity,
                                            small_allocation_threshold,
-                                           allocation_increment) {}
+                                           allocation_increment,
+                                           /*enable_decommit_on_idle=*/false) {}
 
   ~MediaBufferPoolBidirectionalReuseAllocator() {
     SB_DCHECK_EQ(GetAllocated(), 0);

--- a/starboard/common/in_place_reuse_allocator_base.cc
+++ b/starboard/common/in_place_reuse_allocator_base.cc
@@ -215,6 +215,16 @@ void InPlaceReuseAllocatorBase::Free(void* memory) {
         AddFreeBlock(MemoryBlock(i, fallback_allocations_[i].address,
                                  fallback_allocations_[i].size));
       }
+
+      if (enable_decommit_on_idle_) {
+        SB_LOG(INFO) << "Batched free triggered idle state, decommitting "
+                     << fallback_allocations_.size()
+                     << " fallback allocations.";
+        for (const auto& fallback_allocation : fallback_allocations_) {
+          fallback_allocator_->Decommit(fallback_allocation.address,
+                                        fallback_allocation.size);
+        }
+      }
     } else {
       for (auto address_to_free : pending_frees_) {
         bool freed = TryFree(address_to_free);
@@ -362,6 +372,15 @@ bool InPlaceReuseAllocatorBase::TryFree(void* memory) {
   total_allocated_in_bytes_ -= block.size();
   --total_allocated_blocks_;
 
+  if (enable_decommit_on_idle_ && total_allocated_in_bytes_ == 0) {
+    SB_LOG(INFO) << "Allocator reached idle state, decommitting "
+                 << fallback_allocations_.size() << " fallback allocations.";
+    for (const auto& fallback_allocation : fallback_allocations_) {
+      fallback_allocator_->Decommit(fallback_allocation.address,
+                                    fallback_allocation.size);
+    }
+  }
+
   return true;
 }
 
@@ -369,10 +388,12 @@ InPlaceReuseAllocatorBase::InPlaceReuseAllocatorBase(
     Allocator* fallback_allocator,
     size_t initial_capacity,
     size_t allocation_increment,
-    size_t max_capacity)
+    size_t max_capacity,
+    bool enable_decommit_on_idle)
     : fallback_allocator_(fallback_allocator),
       allocation_increment_(allocation_increment),
-      max_capacity_in_bytes_(max_capacity) {
+      max_capacity_in_bytes_(max_capacity),
+      enable_decommit_on_idle_(enable_decommit_on_idle) {
   if (initial_capacity > 0) {
     FreeBlockSet::iterator iter = ExpandToFit(initial_capacity, kMinAlignment);
     SB_DCHECK(iter != free_blocks_.end());
@@ -392,7 +413,7 @@ InPlaceReuseAllocatorBase::~InPlaceReuseAllocatorBase() {
   SB_LOG_IF(ERROR, allocated_block_head_ != nullptr)
       << total_allocated_blocks_ << " blocks still allocated.";
 
-  for (auto fallback_allocation : fallback_allocations_) {
+  for (const auto& fallback_allocation : fallback_allocations_) {
     fallback_allocator_->Free(fallback_allocation.address);
   }
 }

--- a/starboard/common/in_place_reuse_allocator_base.h
+++ b/starboard/common/in_place_reuse_allocator_base.h
@@ -136,7 +136,8 @@ class InPlaceReuseAllocatorBase : public Allocator {
   InPlaceReuseAllocatorBase(Allocator* fallback_allocator,
                             size_t initial_capacity,
                             size_t allocation_increment,
-                            size_t max_capacity = 0);
+                            size_t max_capacity,
+                            bool enable_decommit_on_idle);
   ~InPlaceReuseAllocatorBase() override;
 
   // The inherited class should implement this function to inform the base
@@ -181,6 +182,9 @@ class InPlaceReuseAllocatorBase : public Allocator {
   // If non-zero, this is an upper bound on how large we will let the capacity
   // expand.
   const size_t max_capacity_in_bytes_;
+
+  // Whether to decommit memory when the pool becomes idle.
+  const bool enable_decommit_on_idle_ = false;
 
   // A list of allocations made from the fallback allocator.  We keep track of
   // this so that we can free them all upon our destruction.

--- a/starboard/common/reuse_allocator_base.cc
+++ b/starboard/common/reuse_allocator_base.cc
@@ -281,16 +281,28 @@ bool ReuseAllocatorBase::TryFree(void* memory) {
   total_allocated_ -= block.size();
 
   allocated_blocks_.erase(it);
+
+  if (enable_decommit_on_idle_ && total_allocated_ == 0) {
+    SB_LOG(INFO) << "Allocator reached idle state, decommitting "
+                 << fallback_allocations_.size() << " fallback allocations.";
+    for (const auto& fallback_allocation : fallback_allocations_) {
+      fallback_allocator_->Decommit(fallback_allocation.address,
+                                    fallback_allocation.size);
+    }
+  }
+
   return true;
 }
 
 ReuseAllocatorBase::ReuseAllocatorBase(Allocator* fallback_allocator,
                                        size_t initial_capacity,
                                        size_t allocation_increment,
-                                       size_t max_capacity)
+                                       size_t max_capacity,
+                                       bool enable_decommit_on_idle)
     : fallback_allocator_(fallback_allocator),
       allocation_increment_(allocation_increment),
       max_capacity_(max_capacity),
+      enable_decommit_on_idle_(enable_decommit_on_idle),
       capacity_(0),
       total_allocated_(0) {
   if (initial_capacity > 0) {
@@ -310,8 +322,8 @@ ReuseAllocatorBase::~ReuseAllocatorBase() {
   SB_LOG_IF(ERROR, allocated_blocks_.size() != 0)
       << allocated_blocks_.size() << " blocks still allocated.";
 
-  for (auto fallback_allocation : fallback_allocations_) {
-    fallback_allocator_->Free(fallback_allocation);
+  for (const auto& fallback_allocation : fallback_allocations_) {
+    fallback_allocator_->Free(fallback_allocation.address);
   }
 }
 
@@ -352,7 +364,7 @@ ReuseAllocatorBase::FreeBlockSet::iterator ReuseAllocatorBase::ExpandToFit(
     }
   }
   if (ptr != NULL) {
-    fallback_allocations_.push_back(ptr);
+    fallback_allocations_.push_back({ptr, size_to_try});
     capacity_ += size_to_try;
     auto free_block_iter = AddFreeBlock(MemoryBlock(
         static_cast<int>(fallback_allocations_.size() - 1), ptr, size_to_try));
@@ -423,7 +435,7 @@ ReuseAllocatorBase::FreeBlockSet::iterator ReuseAllocatorBase::ExpandToFit(
     return free_blocks_.end();
   }
 
-  fallback_allocations_.push_back(ptr);
+  fallback_allocations_.push_back({ptr, size_to_allocate});
   capacity_ += size_to_allocate;
   AddFreeBlock(MemoryBlock(static_cast<int>(fallback_allocations_.size() - 1),
                            ptr, size_to_allocate));

--- a/starboard/common/reuse_allocator_base.h
+++ b/starboard/common/reuse_allocator_base.h
@@ -124,7 +124,8 @@ class ReuseAllocatorBase : public Allocator {
   ReuseAllocatorBase(Allocator* fallback_allocator,
                      size_t initial_capacity,
                      size_t allocation_increment,
-                     size_t max_capacity = 0);
+                     size_t max_capacity,
+                     bool enable_decommit_on_idle);
   ~ReuseAllocatorBase() override;
 
   // The inherited class should implement this function to inform the base
@@ -140,6 +141,12 @@ class ReuseAllocatorBase : public Allocator {
                                                bool* allocate_from_front) = 0;
 
  private:
+  // Pointer and size of the block allocated from the fallback allocator.
+  struct FallbackAllocation {
+    void* address;
+    size_t size;
+  };
+
   // Map from pointers we returned to the user, back to memory blocks.
   typedef std::map<void*, MemoryBlock> AllocatedBlockMap;
 
@@ -161,9 +168,12 @@ class ReuseAllocatorBase : public Allocator {
   // expand.
   const size_t max_capacity_;
 
+  // Whether to decommit memory when the pool becomes idle.
+  const bool enable_decommit_on_idle_ = false;
+
   // A list of allocations made from the fallback allocator.  We keep track of
   // this so that we can free them all upon our destruction.
-  std::vector<void*> fallback_allocations_;
+  std::vector<FallbackAllocation> fallback_allocations_;
 
   // How much we have allocated from the fallback allocator.
   size_t capacity_;

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -45,10 +45,10 @@ constexpr char kMediaIncrementalParseLookAhead[] =
     "Media.IncrementalParseLookAhead";
 constexpr char kDecoderBufferSettingPrefix[] = "DecoderBuffer.";
 
-constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
-    "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
+constexpr char kEnableDecommitableAllocatorStrategy[] =
+    "DecoderBuffer.EnableDecommitableAllocatorStrategy";
 static_assert(
-    std::string_view(kEnableMediaBufferPoolAllocatorStrategy)
+    std::string_view(kEnableDecommitableAllocatorStrategy)
         .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
     kDecoderBufferSettingPrefix);
 
@@ -59,11 +59,20 @@ static_assert(
         .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
     kDecoderBufferSettingPrefix);
 
+constexpr char kEnableMediaBufferPoolAllocatorStrategy[] =
+    "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy";
+static_assert(
+    std::string_view(kEnableMediaBufferPoolAllocatorStrategy)
+        .substr(0, std::string_view(kDecoderBufferSettingPrefix).size()) ==
+    kDecoderBufferSettingPrefix);
+
 using EnableFunction = void (*)();
 using SettingsMap = WTF::HashMap<WTF::String, EnableFunction>;
 
 const SettingsMap& GetDecoderBufferSettings() {
   static const base::NoDestructor<SettingsMap> settings({
+      {kEnableDecommitableAllocatorStrategy,
+       &::media::DecoderBufferAllocator::EnableDecommitableAllocatorStrategy},
       {kEnableInPlaceReuseAllocatorBase,
        &::media::DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase},
       {kEnableMediaBufferPoolAllocatorStrategy,


### PR DESCRIPTION
Introduce a mechanism to release physical memory associated with
decoder buffers when their allocation pools become idle. This change
adds a Decommit method to the common allocator interface, which is
implemented by StarboardMemoryAllocator using madvise(MADV_DONTNEED).

The ReuseAllocatorBase and InPlaceReuseAllocatorBase now invoke this
Decommit method when all internally managed blocks are freed or
during batched free operations. This effectively signals to the
operating system that the physical pages backing these buffers are
no longer actively needed, allowing them to be reclaimed.

A new DecoderBufferAllocator strategy, enabled via H5VCC settings,
configures the media pipeline to utilize this decommit-capable
allocator, reducing Cobalt's resident set size and improving overall
memory efficiency when media playback is not active.

Bug: 454441375