### PR TITLE
media: Add Media.VideoDecoderInitialPrerollCount experimental feature

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -47,6 +47,8 @@ const char kH5vccSettingsKeyMediaVideoBufferSizeClampMb[] =
     "Media.VideoBufferSizeClampMb";
 const char kH5vccSettingsKeyMediaVideoInitialMaxFramesInDecoder[] =
     "Media.VideoInitialMaxFramesInDecoder";
+const char kH5vccSettingsKeyMediaVideoInitialPrerollCount[] =
+    "Media.VideoInitialPrerollCount";
 const char kH5vccSettingsKeyMediaVideoMaxPendingInputFrames[] =
     "Media.VideoMaxPendingInputFrames";
 const char kH5vccSettingsKeyMediaVideoDecoderPollIntervalMs[] =
@@ -227,6 +229,9 @@ ExperimentalFeatures ProcessH5vccSettings(
       /*min_val=*/1, kMaxFramesInDecoderLimit, kH5vccUnsetSentinel);
   parsed.max_pending_input_frames = ProcessRangedIntH5vccSetting(
       settings, kH5vccSettingsKeyMediaVideoMaxPendingInputFrames, /*min_val=*/1,
+      kMaxFramesInDecoderLimit, kH5vccUnsetSentinel);
+  parsed.video_decoder_initial_preroll_count = ProcessRangedIntH5vccSetting(
+      settings, kH5vccSettingsKeyMediaVideoInitialPrerollCount, /*min_val=*/1,
       kMaxFramesInDecoderLimit, kH5vccUnsetSentinel);
   parsed.video_decoder_poll_interval_ms = ProcessRangedIntH5vccSetting(
       settings, kH5vccSettingsKeyMediaVideoDecoderPollIntervalMs, /*min_val=*/1,

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -232,7 +232,7 @@ ExperimentalFeatures ProcessH5vccSettings(
       kMaxFramesInDecoderLimit, kH5vccUnsetSentinel);
   parsed.video_decoder_initial_preroll_count = ProcessRangedIntH5vccSetting(
       settings, kH5vccSettingsKeyMediaVideoDecoderInitialPrerollCount,
-      /*min_val=*/1, kMaxFramesInDecoderLimit, kH5vccUnsetSentinel);
+      /*min_val=*/1, /*max_val=*/100'000, kH5vccUnsetSentinel);
   parsed.video_decoder_poll_interval_ms = ProcessRangedIntH5vccSetting(
       settings, kH5vccSettingsKeyMediaVideoDecoderPollIntervalMs, /*min_val=*/1,
       kMaxVideoDecoderPollIntervalMs, kH5vccUnsetSentinel);

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -47,10 +47,10 @@ const char kH5vccSettingsKeyMediaVideoBufferSizeClampMb[] =
     "Media.VideoBufferSizeClampMb";
 const char kH5vccSettingsKeyMediaVideoInitialMaxFramesInDecoder[] =
     "Media.VideoInitialMaxFramesInDecoder";
-const char kH5vccSettingsKeyMediaVideoInitialPrerollCount[] =
-    "Media.VideoInitialPrerollCount";
 const char kH5vccSettingsKeyMediaVideoMaxPendingInputFrames[] =
     "Media.VideoMaxPendingInputFrames";
+const char kH5vccSettingsKeyMediaVideoDecoderInitialPrerollCount[] =
+    "Media.VideoDecoderInitialPrerollCount";
 const char kH5vccSettingsKeyMediaVideoDecoderPollIntervalMs[] =
     "Media.VideoDecoderPollIntervalMs";
 const char kH5vccSettingsKeyMediaMaxSamplesPerWrite[] =
@@ -231,8 +231,8 @@ ExperimentalFeatures ProcessH5vccSettings(
       settings, kH5vccSettingsKeyMediaVideoMaxPendingInputFrames, /*min_val=*/1,
       kMaxFramesInDecoderLimit, kH5vccUnsetSentinel);
   parsed.video_decoder_initial_preroll_count = ProcessRangedIntH5vccSetting(
-      settings, kH5vccSettingsKeyMediaVideoInitialPrerollCount, /*min_val=*/1,
-      kMaxFramesInDecoderLimit, kH5vccUnsetSentinel);
+      settings, kH5vccSettingsKeyMediaVideoDecoderInitialPrerollCount,
+      /*min_val=*/1, kMaxFramesInDecoderLimit, kH5vccUnsetSentinel);
   parsed.video_decoder_poll_interval_ms = ProcessRangedIntH5vccSetting(
       settings, kH5vccSettingsKeyMediaVideoDecoderPollIntervalMs, /*min_val=*/1,
       kMaxVideoDecoderPollIntervalMs, kH5vccUnsetSentinel);

--- a/media/base/ipc/media_param_traits_macros.h
+++ b/media/base/ipc/media_param_traits_macros.h
@@ -232,6 +232,7 @@ IPC_STRUCT_TRAITS_BEGIN(media::StarboardRendererConfig::ExperimentalFeatures)
   IPC_STRUCT_TRAITS_MEMBER(initial_max_frames_in_decoder)
   IPC_STRUCT_TRAITS_MEMBER(max_pending_input_frames)
   IPC_STRUCT_TRAITS_MEMBER(max_samples_per_write)
+  IPC_STRUCT_TRAITS_MEMBER(video_decoder_initial_preroll_count)
   IPC_STRUCT_TRAITS_MEMBER(video_decoder_poll_interval_ms)
 IPC_STRUCT_TRAITS_END()
 

--- a/media/base/starboard/starboard_renderer_config.cc
+++ b/media/base/starboard/starboard_renderer_config.cc
@@ -51,6 +51,8 @@ std::ostream& operator<<(
             << opt_to_string(features.max_pending_input_frames)
             << ", max_samples_per_write="
             << opt_to_string(features.max_samples_per_write)
+            << ", video_decoder_initial_preroll_count="
+            << opt_to_string(features.video_decoder_initial_preroll_count)
             << ", video_decoder_poll_interval_ms="
             << opt_to_string(features.video_decoder_poll_interval_ms) << "}";
 }

--- a/media/base/starboard/starboard_renderer_config.h
+++ b/media/base/starboard/starboard_renderer_config.h
@@ -34,6 +34,7 @@ struct MEDIA_EXPORT StarboardRendererConfig {
     std::optional<int> initial_max_frames_in_decoder;
     std::optional<int> max_pending_input_frames;
     std::optional<int> max_samples_per_write;
+    std::optional<int> video_decoder_initial_preroll_count;
     std::optional<int> video_decoder_poll_interval_ms;
   };
 

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -228,6 +228,7 @@ SbPlayerBridge::SbPlayerBridge(
     bool reset_audio_decoder,
     std::optional<int> initial_max_frames_in_decoder,
     std::optional<int> max_pending_input_frames,
+    std::optional<int> video_decoder_initial_preroll_count,
     std::optional<int> video_decoder_poll_interval_ms
 #if BUILDFLAG(IS_ANDROID)
     ,
@@ -259,6 +260,7 @@ SbPlayerBridge::SbPlayerBridge(
       reset_audio_decoder_(reset_audio_decoder),
       initial_max_frames_in_decoder_(initial_max_frames_in_decoder),
       max_pending_input_frames_(max_pending_input_frames),
+      video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
       video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms)
 #if BUILDFLAG(IS_ANDROID)
       ,
@@ -840,6 +842,11 @@ void SbPlayerBridge::CreatePlayer() {
       video_decoder_configuration_extension
           ->SetVideoMaxPendingInputFramesForCurrentThread(
               *max_pending_input_frames_);
+    }
+    if (video_decoder_initial_preroll_count_) {
+      video_decoder_configuration_extension
+          ->SetVideoDecoderInitialPrerollCountForCurrentThread(
+              *video_decoder_initial_preroll_count_);
     }
     if (video_decoder_poll_interval_ms_) {
       video_decoder_configuration_extension

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -110,6 +110,7 @@ class SbPlayerBridge {
                  bool reset_audio_decoder,
                  std::optional<int> initial_max_frames_in_decoder,
                  std::optional<int> max_pending_input_frames,
+                 std::optional<int> video_decoder_initial_preroll_count,
                  std::optional<int> video_decoder_poll_interval_ms
 #if BUILDFLAG(IS_ANDROID)
                  ,
@@ -350,6 +351,7 @@ class SbPlayerBridge {
   const bool reset_audio_decoder_;
   const std::optional<int> initial_max_frames_in_decoder_;
   const std::optional<int> max_pending_input_frames_;
+  const std::optional<int> video_decoder_initial_preroll_count_;
   const std::optional<int> video_decoder_poll_interval_ms_;
 
 #if BUILDFLAG(IS_ANDROID)

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -622,6 +622,7 @@ void StarboardRenderer::CreatePlayerBridge() {
         experimental_features_.enable_reset_audio_decoder,
         experimental_features_.initial_max_frames_in_decoder,
         experimental_features_.max_pending_input_frames,
+        experimental_features_.video_decoder_initial_preroll_count,
         experimental_features_.video_decoder_poll_interval_ms
 #if BUILDFLAG(IS_ANDROID)
         ,

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -530,7 +530,8 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
       const double kMaxPlaybackSpeed = 2.0;
       min_frames_required = std::max<int>(
           min_frames_required,
-          AudioTrackBridge::GetMinBufferSizeInFrames(sample_type,
+          AudioTrackBridge::GetMinBufferSizeInFrames(
+              sample_type,
               creation_parameters.audio_stream_info().number_of_channels,
               creation_parameters.audio_stream_info().samples_per_second) *
               kMaxPlaybackSpeed);
@@ -601,6 +602,8 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
         creation_parameters.video_initial_max_frames_in_decoder();
     experimental_features.max_pending_input_frames =
         creation_parameters.video_max_pending_input_frames();
+    experimental_features.video_decoder_initial_preroll_count =
+        creation_parameters.video_decoder_initial_preroll_count();
     experimental_features.video_decoder_poll_interval_ms =
         creation_parameters.video_decoder_poll_interval_ms();
     auto video_decoder = std::make_unique<VideoDecoder>(
@@ -745,7 +748,7 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
     return nullptr;
   }
 
-private:
+ private:
   bool is_tunnel_mode_used_ = false;
 };
 

--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -223,6 +223,11 @@ SbPlayer SbPlayerCreate(SbWindow window,
           GetVideoMaxPendingInputFramesForCurrentThread()) {
     handler->SetVideoMaxPendingInputFrames(*max_pending_input_frames);
   }
+  if (auto video_decoder_initial_preroll_count = starboard::android::shared::
+          GetVideoDecoderInitialPrerollCountForCurrentThread()) {
+    handler->SetVideoDecoderInitialPrerollCount(
+        *video_decoder_initial_preroll_count);
+  }
   if (auto video_decoder_poll_interval_ms = starboard::android::shared::
           GetVideoDecoderPollIntervalMsForCurrentThread()) {
     handler->SetVideoDecoderPollIntervalMs(*video_decoder_poll_interval_ms);

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -443,12 +443,13 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
     }
   }
 
-  SB_LOG(INFO) << "Created VideoDecoder for codec "
-               << GetMediaVideoCodecName(video_codec_) << ", with output mode "
-               << GetPlayerOutputModeName(output_mode_)
-               << ", max pending input size " << max_pending_inputs_size_
-               << ", max video capabilities \"" << max_video_capabilities_
-               << "\", and tunnel mode audio session id "
+  SB_LOG(INFO) << "Created VideoDecoder for codec="
+               << GetMediaVideoCodecName(video_codec_)
+               << ", with output mode=" << GetPlayerOutputModeName(output_mode_)
+               << ", preroll count=" << number_of_preroll_frames_
+               << ", max pending input size=" << max_pending_inputs_size_
+               << ", max video capabilities=\"" << max_video_capabilities_
+               << "\", and tunnel mode audio session id="
                << tunnel_mode_audio_session_id_;
 }
 

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -409,7 +409,9 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
                                       tunnel_mode_audio_session_id != -1),
       has_new_texture_available_(false),
       surface_condition_variable_(surface_destroy_mutex_),
-      number_of_preroll_frames_(kInitialPrerollFrameCount) {
+      number_of_preroll_frames_(
+          experimental_features.video_decoder_initial_preroll_count.value_or(
+              kInitialPrerollFrameCount)) {
   SB_CHECK(error_message);
 
   if (force_secure_pipeline_under_tunnel_mode) {

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -61,6 +61,7 @@ class VideoDecoder
   struct ExperimentalFeatures {
     std::optional<int> max_pending_input_frames;
     std::optional<int> initial_max_frames_in_decoder;
+    std::optional<int> video_decoder_initial_preroll_count;
     std::optional<int> video_decoder_poll_interval_ms;
   };
 

--- a/starboard/android/shared/video_decoder_configuration.cc
+++ b/starboard/android/shared/video_decoder_configuration.cc
@@ -27,9 +27,10 @@ namespace {
 const StarboardExtensionVideoDecoderConfigurationApi
     kVideoDecoderConfigurationApi = {
         kStarboardExtensionVideoDecoderConfigurationName,
-        1,
+        2,
         &SetVideoInitialMaxFramesInDecoderForCurrentThread,
         &SetVideoMaxPendingInputFramesForCurrentThread,
+        &SetVideoDecoderInitialPrerollCountForCurrentThread,
         &SetVideoDecoderPollIntervalMsForCurrentThread,
 };
 

--- a/starboard/android/shared/video_decoder_configuration_internal.cc
+++ b/starboard/android/shared/video_decoder_configuration_internal.cc
@@ -27,6 +27,7 @@ namespace {
 pthread_once_t g_once_control = PTHREAD_ONCE_INIT;
 pthread_key_t g_initial_max_frames_key = 0;
 pthread_key_t g_max_pending_frames_key = 0;
+pthread_key_t g_video_decoder_initial_preroll_count_key = 0;
 pthread_key_t g_video_decoder_poll_interval_key = 0;
 
 void WriteIntToThreadLocalStorage(pthread_key_t key, int value) {
@@ -55,6 +56,9 @@ void InitializeKeys() {
       pthread_key_create(&g_initial_max_frames_key, /*destructor=*/nullptr);
   SB_CHECK_EQ(res, 0);
   res = pthread_key_create(&g_max_pending_frames_key,
+                           /*destructor=*/nullptr);
+  SB_CHECK_EQ(res, 0);
+  res = pthread_key_create(&g_video_decoder_initial_preroll_count_key,
                            /*destructor=*/nullptr);
   SB_CHECK_EQ(res, 0);
   res = pthread_key_create(&g_video_decoder_poll_interval_key,
@@ -98,6 +102,24 @@ void SetVideoMaxPendingInputFramesForCurrentThread(
   EnsureThreadLocalKeyInitedForDecoderConfig();
   WriteIntToThreadLocalStorage(g_max_pending_frames_key,
                                max_pending_input_frames);
+}
+
+std::optional<int> GetVideoDecoderInitialPrerollCountForCurrentThread() {
+  EnsureThreadLocalKeyInitedForDecoderConfig();
+  return ReadIntFromThreadLocalStorage(
+      g_video_decoder_initial_preroll_count_key);
+}
+
+void SetVideoDecoderInitialPrerollCountForCurrentThread(
+    int video_decoder_initial_preroll_count) {
+  if (video_decoder_initial_preroll_count < 0) {
+    SB_LOG(WARNING) << "Invalid video_decoder_initial_preroll_count: "
+                    << video_decoder_initial_preroll_count;
+    return;
+  }
+  EnsureThreadLocalKeyInitedForDecoderConfig();
+  WriteIntToThreadLocalStorage(g_video_decoder_initial_preroll_count_key,
+                               video_decoder_initial_preroll_count);
 }
 
 std::optional<int> GetVideoDecoderPollIntervalMsForCurrentThread() {

--- a/starboard/android/shared/video_decoder_configuration_internal.h
+++ b/starboard/android/shared/video_decoder_configuration_internal.h
@@ -37,11 +37,17 @@ std::optional<int> GetVideoMaxPendingInputFramesForCurrentThread();
 void SetVideoMaxPendingInputFramesForCurrentThread(
     int max_pending_input_frames);
 
-// Get video_decoder_poll_interval_ms via
-// SetVideoDecoderPollIntervalMsForCurrentThread().
+// Get video_decoder_initial_preroll_count via
+// SetVideoDecoderInitialPrerollCountForCurrentThread().
 std::optional<int> GetVideoDecoderInitialPrerollCountForCurrentThread();
+
+// Specifies the video initial preroll count.
+// |video_decoder_initial_preroll_count| should be non-negative value.
 void SetVideoDecoderInitialPrerollCountForCurrentThread(
     int video_decoder_initial_preroll_count);
+
+// Get video_decoder_poll_interval_ms via
+// SetVideoDecoderPollIntervalMsForCurrentThread().
 std::optional<int> GetVideoDecoderPollIntervalMsForCurrentThread();
 
 // Specifies the video poll interval in milliseconds.

--- a/starboard/android/shared/video_decoder_configuration_internal.h
+++ b/starboard/android/shared/video_decoder_configuration_internal.h
@@ -39,6 +39,9 @@ void SetVideoMaxPendingInputFramesForCurrentThread(
 
 // Get video_decoder_poll_interval_ms via
 // SetVideoDecoderPollIntervalMsForCurrentThread().
+std::optional<int> GetVideoDecoderInitialPrerollCountForCurrentThread();
+void SetVideoDecoderInitialPrerollCountForCurrentThread(
+    int video_decoder_initial_preroll_count);
 std::optional<int> GetVideoDecoderPollIntervalMsForCurrentThread();
 
 // Specifies the video poll interval in milliseconds.

--- a/starboard/extension/video_decoder_configuration.h
+++ b/starboard/extension/video_decoder_configuration.h
@@ -45,6 +45,10 @@ typedef struct StarboardExtensionVideoDecoderConfigurationApi {
 
   // The fields below this point were added in version 2 or later.
 
+  // Specifies the video initial preroll count.
+  void (*SetVideoDecoderInitialPrerollCountForCurrentThread)(
+      int video_decoder_initial_preroll_count);
+
   // Specifies the video poll interval in milliseconds.
   void (*SetVideoDecoderPollIntervalMsForCurrentThread)(
       int video_decoder_poll_interval_ms);

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -134,8 +134,8 @@ HandlerResult FilterBasedPlayerWorkerHandler::Init(
       audio_stream_info_, video_stream_info_, player_, output_mode_,
       max_video_input_size_, flush_decoder_during_reset_, reset_audio_decoder_,
       video_initial_max_frames_in_decoder_, video_max_pending_input_frames_,
-      video_decoder_poll_interval_ms_, surface_view_,
-      decode_target_graphics_context_provider_, drm_system_);
+      video_decoder_initial_preroll_count_, video_decoder_poll_interval_ms_,
+      surface_view_, decode_target_graphics_context_provider_, drm_system_);
 
   {
     std::lock_guard lock(player_components_existence_mutex_);
@@ -593,6 +593,17 @@ void FilterBasedPlayerWorkerHandler::SetVideoMaxPendingInputFrames(
                        : "(nullopt)")
                << " to " << video_max_pending_input_frames;
   video_max_pending_input_frames_ = video_max_pending_input_frames;
+}
+
+void FilterBasedPlayerWorkerHandler::SetVideoDecoderInitialPrerollCount(
+    int video_decoder_initial_preroll_count) {
+  SB_LOG(INFO) << "Set video_decoder_initial_preroll_count from "
+               << (video_decoder_initial_preroll_count_.has_value()
+                       ? std::to_string(
+                             video_decoder_initial_preroll_count_.value())
+                       : "(nullopt)")
+               << " to " << video_decoder_initial_preroll_count;
+  video_decoder_initial_preroll_count_ = video_decoder_initial_preroll_count;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoDecoderPollIntervalMs(

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -65,6 +65,8 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
       int video_initial_max_frames_in_decoder) override;
   void SetVideoMaxPendingInputFrames(
       int video_max_pending_input_frames) override;
+  void SetVideoDecoderInitialPrerollCount(
+      int video_decoder_initial_preroll_count) override;
   void SetVideoDecoderPollIntervalMs(
       int video_decoder_poll_interval_ms) override;
   void Stop() override;
@@ -123,6 +125,7 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   void* surface_view_ = nullptr;
   std::optional<int> video_initial_max_frames_in_decoder_;
   std::optional<int> video_max_pending_input_frames_;
+  std::optional<int> video_decoder_initial_preroll_count_;
   std::optional<int> video_decoder_poll_interval_ms_;
   SbDecodeTargetGraphicsContextProvider*
       decode_target_graphics_context_provider_;

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -96,6 +96,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
     bool reset_audio_decoder,
     std::optional<int> video_initial_max_frames_in_decoder,
     std::optional<int> video_max_pending_input_frames,
+    std::optional<int> video_decoder_initial_preroll_count,
     std::optional<int> video_decoder_poll_interval_ms,
     void* surface_view,
     SbDecodeTargetGraphicsContextProvider*
@@ -109,6 +110,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       reset_audio_decoder_(reset_audio_decoder),
       video_initial_max_frames_in_decoder_(video_initial_max_frames_in_decoder),
       video_max_pending_input_frames_(video_max_pending_input_frames),
+      video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
       video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
       surface_view_(surface_view),
       decode_target_graphics_context_provider_(
@@ -129,6 +131,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
     bool reset_audio_decoder,
     std::optional<int> video_initial_max_frames_in_decoder,
     std::optional<int> video_max_pending_input_frames,
+    std::optional<int> video_decoder_initial_preroll_count,
     std::optional<int> video_decoder_poll_interval_ms,
     void* surface_view,
     SbDecodeTargetGraphicsContextProvider*
@@ -143,6 +146,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       reset_audio_decoder_(reset_audio_decoder),
       video_initial_max_frames_in_decoder_(video_initial_max_frames_in_decoder),
       video_max_pending_input_frames_(video_max_pending_input_frames),
+      video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
       video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
       surface_view_(surface_view),
       decode_target_graphics_context_provider_(
@@ -164,6 +168,8 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
   this->video_initial_max_frames_in_decoder_ =
       that.video_initial_max_frames_in_decoder_;
   this->video_max_pending_input_frames_ = that.video_max_pending_input_frames_;
+  this->video_decoder_initial_preroll_count_ =
+      that.video_decoder_initial_preroll_count_;
   this->video_decoder_poll_interval_ms_ = that.video_decoder_poll_interval_ms_;
   this->surface_view_ = that.surface_view_;
   this->decode_target_graphics_context_provider_ =

--- a/starboard/shared/starboard/player/filter/player_components.h
+++ b/starboard/shared/starboard/player/filter/player_components.h
@@ -70,6 +70,7 @@ class PlayerComponents {
                          bool reset_audio_decoder,
                          std::optional<int> video_initial_max_frames_in_decoder,
                          std::optional<int> video_max_pending_input_frames,
+                         std::optional<int> video_decoder_initial_preroll_count,
                          std::optional<int> video_decoder_poll_interval_ms,
                          void* surface_view,
                          SbDecodeTargetGraphicsContextProvider*
@@ -84,6 +85,7 @@ class PlayerComponents {
                          bool reset_audio_decoder,
                          std::optional<int> video_initial_max_frames_in_decoder,
                          std::optional<int> video_max_pending_input_frames,
+                         std::optional<int> video_decoder_initial_preroll_count,
                          std::optional<int> video_decoder_poll_interval_ms,
                          void* surface_view,
                          SbDecodeTargetGraphicsContextProvider*
@@ -147,6 +149,9 @@ class PlayerComponents {
       std::optional<int> video_max_pending_input_frames() const {
         return video_max_pending_input_frames_;
       }
+      std::optional<int> video_decoder_initial_preroll_count() const {
+        return video_decoder_initial_preroll_count_;
+      }
       std::optional<int> video_decoder_poll_interval_ms() const {
         return video_decoder_poll_interval_ms_;
       }
@@ -174,6 +179,7 @@ class PlayerComponents {
 
       std::optional<int> video_initial_max_frames_in_decoder_;
       std::optional<int> video_max_pending_input_frames_;
+      std::optional<int> video_decoder_initial_preroll_count_;
       std::optional<int> video_decoder_poll_interval_ms_;
 
       // The following member are used by both the audio stream and the video

--- a/starboard/shared/starboard/player/filter/testing/player_components_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/player_components_test.cc
@@ -95,6 +95,7 @@ class PlayerComponentsTest
           /*reset_audio_decoder=*/false,
           /*video_initial_max_frames_in_decoder=*/std::nullopt,
           /*video_max_pending_input_frames=*/std::nullopt,
+          /*video_decoder_initial_preroll_count=*/std::nullopt,
           /*video_decoder_poll_interval_ms=*/std::nullopt, dummy_surface_view_,
           fake_graphics_context_provider_.decoder_target_provider());
       ASSERT_EQ(creation_parameters.max_video_input_size(),
@@ -117,6 +118,7 @@ class PlayerComponentsTest
           /*reset_audio_decoder=*/false,
           /*video_initial_max_frames_in_decoder=*/std::nullopt,
           /*video_max_pending_input_frames=*/std::nullopt,
+          /*video_decoder_initial_preroll_count=*/std::nullopt,
           /*video_decoder_poll_interval_ms=*/std::nullopt, dummy_surface_view_,
           fake_graphics_context_provider_.decoder_target_provider());
       ASSERT_EQ(creation_parameters.max_video_input_size(),

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
@@ -159,6 +159,7 @@ TEST_P(VideoDecoderTest, ThreeMoreDecoders) {
                 /*reset_audio_decoder=*/false,
                 /*video_initial_max_frames_in_decoder=*/std::nullopt,
                 /*video_max_pending_input_frames=*/std::nullopt,
+                /*video_decoder_initial_preroll_count=*/std::nullopt,
                 /*video_decoder_poll_interval_ms=*/std::nullopt,
                 fake_graphics_context_provider_.decoder_target_provider(),
                 nullptr);

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
@@ -89,6 +89,7 @@ void VideoDecoderTestFixture::Initialize() {
       max_video_input_size, flush_decoder_during_reset, reset_audio_decoder,
       /*video_initial_max_frames_in_decoder=*/std::nullopt,
       /*video_max_pending_input_frames=*/std::nullopt,
+      /*video_decoder_initial_preroll_count=*/std::nullopt,
       /*video_decoder_poll_interval_ms=*/std::nullopt,
       fake_graphics_context_provider_->decoder_target_provider(), nullptr);
   ASSERT_EQ(creation_parameters.max_video_input_size(), max_video_input_size);

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -117,6 +117,8 @@ class PlayerWorker {
         int video_initial_max_frames_in_decoder) = 0;
     virtual void SetVideoMaxPendingInputFrames(
         int video_max_pending_input_frames) = 0;
+    virtual void SetVideoDecoderInitialPrerollCount(
+        int video_decoder_initial_preroll_count) = 0;
     virtual void SetVideoDecoderPollIntervalMs(
         int video_decoder_poll_interval_ms) = 0;
 


### PR DESCRIPTION
This change introduces an experimental configuration setting to customize the initial number of frames the video decoder must buffer (preroll) before playback begins on Android. This allows for fine-tuning of startup latency and stability.

This re-applies the logic from ce5045e589c using the current plumbing.

Bug: 487097162