### PR TITLE
media: Refactor DecoderBuffer strategy control

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -24,6 +24,7 @@
 #include "media/base/renderer_factory.h"
 #include "media/mojo/clients/starboard/starboard_renderer_client_factory.h"
 #include "media/starboard/decoder_buffer_allocator.h"
+#include "mojo/public/cpp/bindings/generic_pending_receiver.h"
 #include "starboard/media.h"
 #include "starboard/player.h"
 #include "third_party/blink/public/platform/web_string.h"
@@ -209,9 +210,7 @@ ExperimentalFeatures ProcessH5vccSettings(
   if (auto* val = GetSettingValue<int64_t>(
           settings, kH5vccSettingsKeyMediaEnableAllocateOnDemand)) {
     bool enable_allocate_on_demand = *val != 0;
-    auto* allocator = media::DecoderBufferAllocator::Get();
-    CHECK(allocator);
-    allocator->SetAllocateOnDemand(enable_allocate_on_demand);
+    media::DecoderBuffer::EnableAllocateOnDemand(enable_allocate_on_demand);
   }
   if (auto* val = GetSettingValue<int64_t>(
           settings, kH5vccSettingsKeyMediaEnableFlushDuringSeek)) {

--- a/media/base/decoder_buffer.cc
+++ b/media/base/decoder_buffer.cc
@@ -22,17 +22,30 @@ DecoderBuffer::Allocator* s_allocator = nullptr;
 }  // namespace
 
 // static
-DecoderBuffer::Allocator* DecoderBuffer::Allocator::Get() {
-  return s_allocator;
-}
-
-// static
 void DecoderBuffer::Allocator::Set(Allocator* allocator) {
   // One of them has to be nullptr, i.e. either setting a valid allocator, or
   // resetting an existing allocator.  Setting an allocator while another
   // allocator is in place will fail.
   DCHECK(s_allocator == nullptr || allocator == nullptr);
   s_allocator = allocator;
+}
+
+// static
+void DecoderBuffer::EnableAllocateOnDemand(bool enabled) {
+  CHECK(s_allocator);
+  s_allocator->SetAllocateOnDemand(enabled);
+}
+
+// static
+void DecoderBuffer::EnableMediaBufferPoolStrategy() {
+  CHECK(s_allocator);
+  s_allocator->EnableMediaBufferPoolStrategy();
+}
+
+// static
+void DecoderBuffer::EnableInPlaceReuseAllocatorBase() {
+  CHECK(s_allocator);
+  s_allocator->EnableInPlaceReuseAllocatorBase();
 }
 
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/base/decoder_buffer.h
+++ b/media/base/decoder_buffer.h
@@ -96,7 +96,6 @@ class MEDIA_EXPORT DecoderBuffer
     // nullptr.
     static constexpr Handle kInvalidHandle = 0;
 
-    static Allocator* Get();
     static void Set(Allocator* allocator);
 
     // The function should never return kInvalidHandle.  It may terminate the
@@ -111,9 +110,17 @@ class MEDIA_EXPORT DecoderBuffer
     virtual base::TimeDelta GetBufferGarbageCollectionDurationThreshold()
         const = 0;
 
+    virtual void SetAllocateOnDemand(bool enabled) = 0;
+    virtual void EnableMediaBufferPoolStrategy() = 0;
+    virtual void EnableInPlaceReuseAllocatorBase() = 0;
+
    protected:
     ~Allocator() {}
   };
+
+  static void EnableAllocateOnDemand(bool enabled);
+  static void EnableMediaBufferPoolStrategy();
+  static void EnableInPlaceReuseAllocatorBase();
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Allocates buffer with |size| >= 0. |is_key_frame_| will default to false.

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -17,7 +17,6 @@
 #include <algorithm>
 
 #include "base/feature_list.h"
-#include "base/functional/bind.h"
 #include "base/logging.h"
 #include "build/build_config.h"
 #include "media/base/media_switches.h"
@@ -36,14 +35,6 @@
 namespace media {
 
 namespace {
-
-using DefaultReuseAllocatorStrategy =
-    BidirectionalFitDecoderBufferAllocatorStrategy<
-        starboard::common::ReuseAllocatorBase>;
-using InPlaceReuseAllocatorStrategy =
-    BidirectionalFitDecoderBufferAllocatorStrategy<
-        starboard::common::InPlaceReuseAllocatorBase>;
-using starboard::common::experimental::MediaBufferPool;
 
 // Used to determine if the memory allocated is large. The underlying logic can
 // be different.
@@ -76,6 +67,12 @@ DecoderBufferAllocator::DecoderBufferAllocator(
   }
 
   base::AutoLock scoped_lock(mutex_);
+
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+  // Uncomment the following line to default enable MediaBufferPoolStrategy.
+  // media_buffer_pool_strategy_state_ = MediaBufferPoolStrategyState::kEnabled;
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+
   EnsureStrategyIsCreated();
 }
 
@@ -86,12 +83,6 @@ DecoderBufferAllocator::~DecoderBufferAllocator() {
     DCHECK_EQ(strategy_->GetAllocated(), 0);
     strategy_.reset();
   }
-}
-
-// static
-DecoderBufferAllocator* DecoderBufferAllocator::Get() {
-  return static_cast<DecoderBufferAllocator*>(
-      DecoderBuffer::Allocator::Get());
 }
 
 void DecoderBufferAllocator::Suspend() {
@@ -163,8 +154,12 @@ void DecoderBufferAllocator::Free(DemuxerStream::Type type,
   }
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
-  bool should_reset_strategy = is_strategy_switch_pending_ ||
-                               is_memory_pool_allocated_on_demand_;
+  bool should_reset_strategy =
+      media_buffer_pool_strategy_state_ ==
+          MediaBufferPoolStrategyState::kPendingEnabling ||
+      in_place_reuse_allocator_base_strategy_state_ ==
+          InPlaceReuseAllocatorBaseStrategyState::kPendingEnabling ||
+      is_memory_pool_allocated_on_demand_;
 
   if (should_reset_strategy && strategy_->GetAllocated() == 0) {
     // `strategy_->PrintAllocations()` will be called inside the dtor when
@@ -226,23 +221,6 @@ size_t DecoderBufferAllocator::GetMaximumMemoryCapacity() const {
   return 0;
 }
 
-void DecoderBufferAllocator::UpdateAllocatorStrategy(
-    StrategyCreateCB create_cb) {
-  DCHECK(!create_cb.is_null());
-
-  base::AutoLock scoped_lock(mutex_);
-  experimental_strategy_create_cb_ = std::move(create_cb);
-  is_strategy_switch_pending_ = true;
-
-  if (strategy_ && strategy_->GetAllocated() > 0) {
-    LOG(INFO) << "Strategy switch pending. Waiting for memory to drain.";
-    return;
-  }
-  if (strategy_) {
-    strategy_.reset();
-  }
-}
-
 void DecoderBufferAllocator::SetAllocateOnDemand(bool enabled) {
   base::AutoLock scoped_lock(mutex_);
   if (is_memory_pool_allocated_on_demand_ == enabled) {
@@ -265,38 +243,52 @@ void DecoderBufferAllocator::SetAllocateOnDemand(bool enabled) {
   }
 }
 
-// static
-void DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase() {
-  auto* allocator = Get();
-  CHECK(allocator);
-  allocator->UpdateAllocatorStrategy(base::BindRepeating(
-      [](int initial_capacity, int allocation_unit)
-          -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
-        LOG(INFO)
-            << "DecoderBufferAllocator is using InPlaceReuseAllocatorBase.";
-        return std::make_unique<InPlaceReuseAllocatorStrategy>(
-            initial_capacity, allocation_unit);
-      }));
+void DecoderBufferAllocator::EnableMediaBufferPoolStrategy() {
+  base::AutoLock scoped_lock(mutex_);
+
+  if (media_buffer_pool_strategy_state_ !=
+      MediaBufferPoolStrategyState::kDisabled) {
+    return;
+  }
+
+  if (strategy_ && strategy_->GetAllocated() > 0) {
+    // There is another strategy being used, we have to wait until all
+    // allocations are freed before switching to MediaBufferPool based strategy.
+    media_buffer_pool_strategy_state_ =
+        MediaBufferPoolStrategyState::kPendingEnabling;
+    return;
+  }
+
+  if (strategy_) {
+    strategy_.reset();
+  }
+
+  media_buffer_pool_strategy_state_ = MediaBufferPoolStrategyState::kEnabled;
 }
 
-// static
-void DecoderBufferAllocator::EnableMediaBufferPoolStrategy() {
-  auto* allocator = Get();
-  CHECK(allocator);
-  allocator->UpdateAllocatorStrategy(base::BindRepeating(
-      [](int initial_capacity, int allocation_unit)
-          -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
-        auto pool = MediaBufferPool::Acquire();
-        if (pool) {
-          LOG(INFO) << "DecoderBufferAllocator is using MediaBufferPool.";
-          return std::make_unique<
-              MediaBufferPoolDecoderBufferAllocatorStrategy>(
-                  pool, initial_capacity, allocation_unit);
-        }
-        LOG(INFO) << "DecoderBufferAllocator failed to enable MediaBufferPool"
-                  << " as MediaBufferPool::Acquire() returns nullptr.";
-        return nullptr;
-      }));
+void DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase() {
+  base::AutoLock scoped_lock(mutex_);
+
+  if (in_place_reuse_allocator_base_strategy_state_ !=
+      InPlaceReuseAllocatorBaseStrategyState::kDisabled) {
+    return;
+  }
+
+  // There is another strategy being used, we have to wait until all
+  // allocations are freed before switching to InPlaceReuseAllocatorBase based
+  // strategy.
+  if (strategy_ && strategy_->GetAllocated() > 0) {
+    in_place_reuse_allocator_base_strategy_state_ =
+        InPlaceReuseAllocatorBaseStrategyState::kPendingEnabling;
+    return;
+  }
+
+  if (strategy_) {
+    strategy_.reset();
+  }
+
+  in_place_reuse_allocator_base_strategy_state_ =
+      InPlaceReuseAllocatorBaseStrategyState::kEnabled;
 }
 
 void DecoderBufferAllocator::EnsureStrategyIsCreated() {
@@ -305,31 +297,44 @@ void DecoderBufferAllocator::EnsureStrategyIsCreated() {
     return;
   }
 
-  is_strategy_switch_pending_ = false;
-
-  if (!experimental_strategy_create_cb_.is_null()) {
-    strategy_ = experimental_strategy_create_cb_.Run(
-        initial_capacity_, allocation_unit_);
-    if (strategy_) {
-      LOG(INFO) << "Allocated " << initial_capacity_
-                << " bytes for decoder buffer pool.";
-      return;
-    }
-    LOG(WARNING) << "Failed to create the requested DecoderBufferAllocator "
-                    "strategy. Falling back to default.";
+  if (media_buffer_pool_strategy_state_ ==
+      MediaBufferPoolStrategyState::kPendingEnabling) {
+    media_buffer_pool_strategy_state_ = MediaBufferPoolStrategyState::kEnabled;
   }
 
-  // Keep the existing feature based logic as is, as the h5vcc settings based
-  // logic will be deprecated once Finch is ready.
+  if (in_place_reuse_allocator_base_strategy_state_ ==
+      InPlaceReuseAllocatorBaseStrategyState::kPendingEnabling) {
+    in_place_reuse_allocator_base_strategy_state_ =
+        InPlaceReuseAllocatorBaseStrategyState::kEnabled;
+  }
+
+  if (media_buffer_pool_strategy_state_ ==
+      MediaBufferPoolStrategyState::kEnabled) {
+    auto pool = starboard::common::experimental::MediaBufferPool::Acquire();
+    if (pool) {
+      strategy_.reset(new MediaBufferPoolDecoderBufferAllocatorStrategy(
+          pool, initial_capacity_, allocation_unit_));
+      LOG(INFO) << "DecoderBufferAllocator is using MediaBufferPool.";
+      return;
+    } else {
+      LOG(INFO) << "DecoderBufferAllocator failed to enable MediaBufferPool as"
+                << " MediaBufferPool::Acquire() returns nullptr.";
+    }
+  }
+
   if (base::FeatureList::IsEnabled(
-          kCobaltDecoderBufferAllocatorWithInPlaceMetadata)) {
-    strategy_ = std::make_unique<InPlaceReuseAllocatorStrategy>(
-        initial_capacity_, allocation_unit_);
+          kCobaltDecoderBufferAllocatorWithInPlaceMetadata) ||
+      in_place_reuse_allocator_base_strategy_state_ ==
+          InPlaceReuseAllocatorBaseStrategyState::kEnabled) {
+    strategy_.reset(new BidirectionalFitDecoderBufferAllocatorStrategy<
+                    starboard::common::InPlaceReuseAllocatorBase>(
+        initial_capacity_, allocation_unit_));
     LOG(INFO) << "DecoderBufferAllocator is using InPlaceReuseAllocatorBase.";
   } else {
-    strategy_ = std::make_unique<DefaultReuseAllocatorStrategy>(
-        initial_capacity_, allocation_unit_);
-    LOG(INFO) << "DecoderBufferAllocator is using DefaultReuseAllocatorStrategy.";
+    strategy_.reset(new BidirectionalFitDecoderBufferAllocatorStrategy<
+                    starboard::common::ReuseAllocatorBase>(initial_capacity_,
+                                                           allocation_unit_));
+    LOG(INFO) << "DecoderBufferAllocator is using ReuseAllocatorBase.";
   }
 
   LOG(INFO) << "Allocated " << initial_capacity_

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -19,7 +19,6 @@
 #include <sstream>
 
 #include "base/compiler_specific.h"
-#include "base/functional/callback.h"
 #include "base/synchronization/lock.h"
 #include "base/thread_annotations.h"
 #include "base/time/time.h"
@@ -51,16 +50,11 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
     virtual size_t GetAllocated() const = 0;
   };
 
-  using StrategyCreateCB = base::RepeatingCallback<
-      std::unique_ptr<Strategy>(int initial_capacity, int allocation_unit)>;
-
   explicit DecoderBufferAllocator();
   DecoderBufferAllocator(bool is_memory_pool_allocated_on_demand,
                          int initial_capacity,
                          int allocation_unit);
   ~DecoderBufferAllocator() override;
-
-  static DecoderBufferAllocator* Get();
 
   void Suspend();
   void Resume();
@@ -81,15 +75,23 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   size_t GetCurrentMemoryCapacity() const override LOCKS_EXCLUDED(mutex_);
   size_t GetMaximumMemoryCapacity() const override LOCKS_EXCLUDED(mutex_);
 
-  void UpdateAllocatorStrategy(StrategyCreateCB create_cb);
-
-  // Utility functions for h5vcc settings.
-  // TODO(b/460292554): To be deprecated with h5vcc settings.
-  void SetAllocateOnDemand(bool enabled);
-  static void EnableInPlaceReuseAllocatorBase();
-  static void EnableMediaBufferPoolStrategy();
+  void SetAllocateOnDemand(bool enabled) override;
+  void EnableMediaBufferPoolStrategy() override;
+  void EnableInPlaceReuseAllocatorBase() override;
 
  private:
+  enum class MediaBufferPoolStrategyState {
+    kDisabled,
+    kEnabled,
+    kPendingEnabling,
+  };
+
+  enum class InPlaceReuseAllocatorBaseStrategyState {
+    kDisabled,
+    kEnabled,
+    kPendingEnabling,
+  };
+
   void EnsureStrategyIsCreated() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
@@ -102,8 +104,11 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
   mutable base::Lock mutex_;
   std::unique_ptr<Strategy> strategy_ GUARDED_BY(mutex_);
-  bool is_strategy_switch_pending_ GUARDED_BY(mutex_) = false;
-  StrategyCreateCB experimental_strategy_create_cb_ GUARDED_BY(mutex_);
+  MediaBufferPoolStrategyState media_buffer_pool_strategy_state_
+      GUARDED_BY(mutex_) = MediaBufferPoolStrategyState::kDisabled;
+  InPlaceReuseAllocatorBaseStrategyState
+      in_place_reuse_allocator_base_strategy_state_ GUARDED_BY(mutex_) =
+          InPlaceReuseAllocatorBaseStrategyState::kDisabled;
 
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   // The following variables are used for comprehensive logging of allocation

--- a/media/starboard/decoder_buffer_allocator_strategy_test.cc
+++ b/media/starboard/decoder_buffer_allocator_strategy_test.cc
@@ -34,13 +34,13 @@ using InPlaceReuseAllocatorStrategy =
 // is instantiated, allowing tests to verify exactly when and how many times
 // the strategy creation logic is triggered.
 void UpdateStrategyWithCreationCounter(DecoderBufferAllocator* allocator,
-                                       int* creation_count) {
+                               int* creation_count) {
   allocator->UpdateAllocatorStrategy(base::BindRepeating(
       [](int* creation_count_ptr, int initial_capacity, int allocation_unit)
           -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
         (*creation_count_ptr)++;
-        return std::make_unique<InPlaceReuseAllocatorStrategy>(initial_capacity,
-                                                               allocation_unit);
+        return std::make_unique<InPlaceReuseAllocatorStrategy>(
+            initial_capacity, allocation_unit);
       },
       base::Unretained(creation_count)));
 }
@@ -136,18 +136,18 @@ TEST(DecoderBufferAllocatorStrategyTest, RepeatedEnableDoesNothing) {
 
   // 3. Enable Strategy B again (repeated enable)
   UpdateStrategyWithCreationCounter(&allocator, &creation_count_b);
-
+  
   // Freeing the allocations will trigger the pending reset.
   allocator.Free(DemuxerStream::VIDEO, handle, 1024);
 
   // Next allocation should recreate the strategy (Strategy B)
   handle = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle, DecoderBuffer::Allocator::kInvalidHandle);
-
+  
   // creation_count_a remains 1, creation_count_b becomes 1
   EXPECT_EQ(creation_count_a, 1);
   EXPECT_EQ(creation_count_b, 1);
-
+  
   allocator.Free(DemuxerStream::VIDEO, handle, 1024);
 }
 
@@ -167,7 +167,7 @@ TEST(DecoderBufferAllocatorStrategyTest,
   // default strategy.
   auto handle = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle, DecoderBuffer::Allocator::kInvalidHandle);
-
+  
   // The fallback strategies (ReuseAllocatorBase/InPlaceReuseAllocatorBase)
   // do not produce annotated pointers.
   EXPECT_GT(allocator.GetAllocatedMemory(), 0u);
@@ -192,7 +192,7 @@ TEST(DecoderBufferAllocatorStrategyTest,
   EXPECT_EQ(creation_count, 1);
 
   allocator.Free(DemuxerStream::VIDEO, handle1, 1024);
-
+  
   auto handle2 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle2, DecoderBuffer::Allocator::kInvalidHandle);
   EXPECT_EQ(creation_count, 2);
@@ -215,7 +215,7 @@ TEST(DecoderBufferAllocatorStrategyTest,
   EXPECT_EQ(creation_count, 1);
 
   allocator.Free(DemuxerStream::VIDEO, handle1, 1024);
-
+  
   auto handle2 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle2, DecoderBuffer::Allocator::kInvalidHandle);
   EXPECT_EQ(creation_count, 1);

--- a/media/starboard/decoder_buffer_allocator_strategy_test.cc
+++ b/media/starboard/decoder_buffer_allocator_strategy_test.cc
@@ -15,8 +15,7 @@
 #include "media/starboard/decoder_buffer_allocator.h"
 
 #include "media/base/demuxer_stream.h"
-#include "media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h"
-#include "starboard/common/in_place_reuse_allocator_base.h"
+#include "starboard/common/experimental/media_buffer_pool.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 // TODO(b/369245553): Remove this file once Finch is ready, as we no longer need
@@ -25,202 +24,108 @@
 namespace media {
 namespace {
 
-using InPlaceReuseAllocatorStrategy =
-    BidirectionalFitDecoderBufferAllocatorStrategy<
-        starboard::common::InPlaceReuseAllocatorBase>;
-
-// Helper function that updates the allocator's strategy.
-// The provided callback increments `creation_count` each time a new strategy
-// is instantiated, allowing tests to verify exactly when and how many times
-// the strategy creation logic is triggered.
-void UpdateStrategyWithCreationCounter(DecoderBufferAllocator* allocator,
-                               int* creation_count) {
-  allocator->UpdateAllocatorStrategy(base::BindRepeating(
-      [](int* creation_count_ptr, int initial_capacity, int allocation_unit)
-          -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
-        (*creation_count_ptr)++;
-        return std::make_unique<InPlaceReuseAllocatorStrategy>(
-            initial_capacity, allocation_unit);
-      },
-      base::Unretained(creation_count)));
-}
+using starboard::common::experimental::IsPointerAnnotated;
+using starboard::common::experimental::MediaBufferPool;
 
 TEST(DecoderBufferAllocatorStrategyTest, SwitchStrategyImmediatelyWhenIdle) {
+  if (!MediaBufferPool::Acquire()) {
+    return;
+  }
+
   DecoderBufferAllocator allocator;
   const size_t alignment = allocator.GetBufferAlignment();
-
-  int creation_count_a = 0;
-  int creation_count_b = 0;
-
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count_a);
 
   // Allocate and free to ensure a strategy is created and then idle.
   auto handle = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count_a, 1);
-  EXPECT_EQ(creation_count_b, 0);
+  EXPECT_FALSE(IsPointerAnnotated(reinterpret_cast<void*>(handle)));
+  EXPECT_GT(allocator.GetAllocatedMemory(), 0u);
 
   allocator.Free(DemuxerStream::VIDEO, handle, 1024);
+  EXPECT_EQ(allocator.GetAllocatedMemory(), 0u);
 
-  // Switch strategy. It should immediately reset the current
-  // strategy because it's idle.
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count_b);
+  // Enable media buffer pool strategy. It should immediately reset the current
+  // strategy.
+  allocator.EnableMediaBufferPoolStrategy();
+  EXPECT_EQ(allocator.GetAllocatedMemory(), 0u);
 
-  // Next allocation should recreate the strategy (Strategy B).
+  // Next allocation should recreate a strategy (potentially the new one).
   handle = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count_a, 1);
-  EXPECT_EQ(creation_count_b, 1);
+  EXPECT_TRUE(IsPointerAnnotated(reinterpret_cast<void*>(handle)));
 
+  EXPECT_GT(allocator.GetAllocatedMemory(), 0u);
   allocator.Free(DemuxerStream::VIDEO, handle, 1024);
 }
 
 TEST(DecoderBufferAllocatorStrategyTest, SwitchStrategyPendingWhenBusy) {
+  if (!MediaBufferPool::Acquire()) {
+    return;
+  }
+
   DecoderBufferAllocator allocator;
   const size_t alignment = allocator.GetBufferAlignment();
-
-  int creation_count_a = 0;
-  int creation_count_b = 0;
-
-  // Start with Strategy A
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count_a);
 
   // Allocate to make it busy.
   auto handle_1 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle_1, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count_a, 1);
-  EXPECT_EQ(creation_count_b, 0);
+  EXPECT_FALSE(IsPointerAnnotated(reinterpret_cast<void*>(handle_1)));
+  EXPECT_GT(allocator.GetAllocatedMemory(), 0u);
 
-  // Attempt to switch to Strategy B. It should be pending since allocator
-  // is busy.
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count_b);
+  // Enable media buffer pool strategy. It should enter kPendingEnabling and NOT
+  // reset yet.
+  allocator.EnableMediaBufferPoolStrategy();
+  // The metrics get into a gray area, so we don't verify their values.  But
+  // they shouldn't crash.
+  allocator.GetCurrentMemoryCapacity();
+  allocator.GetAllocatedMemory();
 
   auto handle_2 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle_2, DecoderBuffer::Allocator::kInvalidHandle);
-  // Still on Strategy A
-  EXPECT_EQ(creation_count_a, 1);
-  EXPECT_EQ(creation_count_b, 0);
 
   // Free the allocations. This should trigger the reset.
   allocator.Free(DemuxerStream::VIDEO, handle_1, 1024);
   allocator.Free(DemuxerStream::VIDEO, handle_2, 1024);
 
-  // Strategy should have switched to Strategy B.
   // Next allocation should recreate a strategy.
   auto handle_3 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle_3, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count_a, 1);
-  EXPECT_EQ(creation_count_b, 1);
-
+  EXPECT_GT(allocator.GetAllocatedMemory(), 0u);
   allocator.Free(DemuxerStream::VIDEO, handle_3, 1024);
 }
 
 TEST(DecoderBufferAllocatorStrategyTest, RepeatedEnableDoesNothing) {
+  if (!MediaBufferPool::Acquire()) {
+    return;
+  }
+
   DecoderBufferAllocator allocator;
   const size_t alignment = allocator.GetBufferAlignment();
 
-  int creation_count_a = 0;
-  int creation_count_b = 0;
-
-  // 1. Start with Strategy A
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count_a);
+  // Allocate and free to ensure a strategy is created and then idle.
   auto handle = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
   ASSERT_NE(handle, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count_a, 1);
-  EXPECT_EQ(creation_count_b, 0);
-
-  // 2. Switch to Strategy B (pending because busy)
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count_b);
-  EXPECT_EQ(creation_count_a, 1);
-  EXPECT_EQ(creation_count_b, 0);
-
-  // 3. Enable Strategy B again (repeated enable)
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count_b);
-  
-  // Freeing the allocations will trigger the pending reset.
-  allocator.Free(DemuxerStream::VIDEO, handle, 1024);
-
-  // Next allocation should recreate the strategy (Strategy B)
-  handle = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
-  ASSERT_NE(handle, DecoderBuffer::Allocator::kInvalidHandle);
-  
-  // creation_count_a remains 1, creation_count_b becomes 1
-  EXPECT_EQ(creation_count_a, 1);
-  EXPECT_EQ(creation_count_b, 1);
-  
-  allocator.Free(DemuxerStream::VIDEO, handle, 1024);
-}
-
-TEST(DecoderBufferAllocatorStrategyTest,
-     FallbackToDefaultWhenStrategyCreateCBReturnsNull) {
-  DecoderBufferAllocator allocator;
-  const size_t alignment = allocator.GetBufferAlignment();
-
-  // Inject a strategy callback that always returns nullptr.
-  allocator.UpdateAllocatorStrategy(base::BindRepeating(
-      [](int initial_capacity, int allocation_unit)
-          -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
-        return nullptr;
-      }));
-
-  // This should not crash, it should log a warning and fallback to the
-  // default strategy.
-  auto handle = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
-  ASSERT_NE(handle, DecoderBuffer::Allocator::kInvalidHandle);
-  
-  // The fallback strategies (ReuseAllocatorBase/InPlaceReuseAllocatorBase)
-  // do not produce annotated pointers.
+  EXPECT_FALSE(IsPointerAnnotated(reinterpret_cast<void*>(handle)));
   EXPECT_GT(allocator.GetAllocatedMemory(), 0u);
 
   allocator.Free(DemuxerStream::VIDEO, handle, 1024);
-}
+  EXPECT_EQ(allocator.GetAllocatedMemory(), 0u);
 
-TEST(DecoderBufferAllocatorStrategyTest,
-     AllocateOnDemandRecreatesStrategyWhenAllocationsReachZero) {
-  constexpr bool kIsAllocatedOnDemand = true;
-  DecoderBufferAllocator allocator(kIsAllocatedOnDemand, 10 * 1024 * 1024,
-                                   512 * 1024);
-  const size_t alignment = allocator.GetBufferAlignment();
+  // Enable media buffer pool strategy. It should immediately reset the current
+  // strategy.
+  allocator.EnableMediaBufferPoolStrategy();
+  EXPECT_EQ(allocator.GetAllocatedMemory(), 0u);
 
-  int creation_count = 0;
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count);
+  // Next allocation should recreate a strategy (potentially the new one).
+  handle = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
+  ASSERT_NE(handle, DecoderBuffer::Allocator::kInvalidHandle);
+  EXPECT_TRUE(IsPointerAnnotated(reinterpret_cast<void*>(handle)));
 
-  EXPECT_EQ(creation_count, 0);
+  // This is no-op.
+  allocator.EnableMediaBufferPoolStrategy();
 
-  auto handle1 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
-  ASSERT_NE(handle1, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count, 1);
-
-  allocator.Free(DemuxerStream::VIDEO, handle1, 1024);
-  
-  auto handle2 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
-  ASSERT_NE(handle2, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count, 2);
-
-  allocator.Free(DemuxerStream::VIDEO, handle2, 1024);
-}
-
-TEST(DecoderBufferAllocatorStrategyTest,
-     NoAllocateOnDemandKeepsStrategyWhenAllocationsReachZero) {
-  constexpr bool kIsAllocatedOnDemand = false;
-  DecoderBufferAllocator allocator(kIsAllocatedOnDemand, 10 * 1024 * 1024,
-                                   512 * 1024);
-  const size_t alignment = allocator.GetBufferAlignment();
-
-  int creation_count = 0;
-  UpdateStrategyWithCreationCounter(&allocator, &creation_count);
-
-  auto handle1 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
-  ASSERT_NE(handle1, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count, 1);
-
-  allocator.Free(DemuxerStream::VIDEO, handle1, 1024);
-  
-  auto handle2 = allocator.Allocate(DemuxerStream::VIDEO, 1024, alignment);
-  ASSERT_NE(handle2, DecoderBuffer::Allocator::kInvalidHandle);
-  EXPECT_EQ(creation_count, 1);
-
-  allocator.Free(DemuxerStream::VIDEO, handle2, 1024);
+  EXPECT_GT(allocator.GetAllocatedMemory(), 0u);
+  allocator.Free(DemuxerStream::VIDEO, handle, 1024);
 }
 
 }  // namespace

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -19,7 +19,6 @@
 #include "cobalt/browser/h5vcc_settings/public/mojom/h5vcc_settings.mojom-blink.h"
 #include "media/base/decoder_buffer.h"
 #include "media/filters/source_buffer_state.h"
-#include "media/starboard/decoder_buffer_allocator.h"
 #include "third_party/blink/public/common/browser_interface_broker_proxy.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
@@ -64,10 +63,10 @@ using SettingsMap = WTF::HashMap<WTF::String, EnableFunction>;
 
 const SettingsMap& GetDecoderBufferSettings() {
   static const base::NoDestructor<SettingsMap> settings({
-      {kEnableInPlaceReuseAllocatorBase,
-       &::media::DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase},
       {kEnableMediaBufferPoolAllocatorStrategy,
-       &::media::DecoderBufferAllocator::EnableMediaBufferPoolStrategy},
+       &::media::DecoderBuffer::EnableMediaBufferPoolStrategy},
+      {kEnableInPlaceReuseAllocatorBase,
+       &::media::DecoderBuffer::EnableInPlaceReuseAllocatorBase},
   });
   return *settings;
 }


### PR DESCRIPTION
This commit refactors the API for managing DecoderBuffer allocation
strategies. The previous generic callback-based mechanism to update
allocator strategies has been removed.

Control methods such as EnableMediaBufferPoolStrategy and
EnableInPlaceReuseAllocatorBase are now exposed as static methods
on media::DecoderBuffer. These methods delegate to the active
DecoderBuffer::Allocator instance, which now implements specific
interfaces to manage its internal strategy states.

This change simplifies the public interface for allocator strategy
configuration and improves encapsulation, replacing a more generic,
flexible but potentially complex strategy switching mechanism with a
clearer, more direct control for supported allocation behaviors.

Bug: 488360719