### PR TITLE
android: Optimize av1 codec initialization

### DIFF
--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -445,6 +445,14 @@ bool MediaCapabilitiesCache::IsPassthroughSupported(SbMediaAudioCodec codec) {
   return supported;
 }
 
+bool MediaCapabilitiesCache::IsAv18kCappedAt30() {
+  if (!is_enabled_) {
+    // When the cache is not enabled, always checks video fps.
+    return true;
+  }
+  return is_av1_8k_capped_at_30_;
+}
+
 bool MediaCapabilitiesCache::GetAudioConfiguration(
     int index,
     SbMediaAudioConfiguration* configuration) {
@@ -619,6 +627,7 @@ void MediaCapabilitiesCache::UpdateMediaCapabilities_Locked() {
     supported_transfer_ids_ = GetSupportedHdrTypes();
     LoadCodecInfos_Locked();
     LoadAudioConfigurations_Locked();
+    LoadIsAv18kCappedAt30_Locked();
   }
 }
 
@@ -683,6 +692,30 @@ void MediaCapabilitiesCache::LoadAudioConfigurations_Locked() {
          ::starboard::android::shared::GetAudioConfiguration(
              audio_configurations_.size(), &configuration)) {
     audio_configurations_.push_back(configuration);
+  }
+}
+
+void MediaCapabilitiesCache::LoadIsAv18kCappedAt30_Locked() {
+  const bool enable_av1_startup_optimization =
+      starboard::features::FeatureList::IsEnabled(
+          starboard::features::kEnableAv1StartupOptimization);
+  if (!enable_av1_startup_optimization) {
+    return;
+  }
+
+  is_av1_8k_capped_at_30_ = false;
+  for (const auto& video_capability :
+       video_codec_capabilities_map_[SupportedVideoCodecToMimeType(
+           kSbMediaVideoCodecAv1)]) {
+    constexpr int kWidth8K = 7680;
+    constexpr int kHeight8K = 4320;
+    if (video_capability->AreResolutionAndRateSupported(kWidth8K, kHeight8K,
+                                                        /*fps=*/0) &&
+        !video_capability->AreResolutionAndRateSupported(kWidth8K, kHeight8K,
+                                                         /*fps=*/60)) {
+      is_av1_8k_capped_at_30_ = true;
+      break;
+    }
   }
 }
 

--- a/starboard/android/shared/media_capabilities_cache.h
+++ b/starboard/android/shared/media_capabilities_cache.h
@@ -123,6 +123,13 @@ class MediaCapabilitiesCache {
 
   bool IsPassthroughSupported(SbMediaAudioCodec codec);
 
+  // Some android devices support av1 up to 8k30 and 4k60. In that case, we
+  // cannot ask it to always use max supported width and height, which would
+  // lead 8k60 being used and exceed system resource limit. See b/173575800.
+  // When IsAv18kCappedAt30() returns true, the device needs extra check of
+  // video fps to prevent 8k60 is used unexpectedly.
+  bool IsAv18kCappedAt30();
+
   bool GetAudioConfiguration(int index,
                              SbMediaAudioConfiguration* configuration);
 
@@ -161,8 +168,9 @@ class MediaCapabilitiesCache {
   MediaCapabilitiesCache& operator=(const MediaCapabilitiesCache&) = delete;
 
   void UpdateMediaCapabilities_Locked();
-  void LoadAudioConfigurations_Locked();
   void LoadCodecInfos_Locked();
+  void LoadAudioConfigurations_Locked();
+  void LoadIsAv18kCappedAt30_Locked();
 
   std::mutex mutex_;
 
@@ -179,6 +187,7 @@ class MediaCapabilitiesCache {
   std::vector<SbMediaAudioConfiguration> audio_configurations_;
   bool is_widevine_supported_ = false;
   bool is_cbcs_supported_ = false;
+  bool is_av1_8k_capped_at_30_ = true;
 
   std::atomic_bool is_enabled_{true};
   std::atomic_bool capabilities_is_dirty_{true};

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -28,6 +28,7 @@
 #include "build/build_config.h"
 #include "starboard/android/shared/jni_env_ext.h"
 #include "starboard/android/shared/jni_utils.h"
+#include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/video_render_algorithm.h"
 #include "starboard/common/log.h"
@@ -406,6 +407,9 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
       force_reset_surface_(force_reset_surface),
       force_reset_surface_under_tunnel_mode_(
           force_reset_surface_under_tunnel_mode),
+      needs_fps_to_initialize_codec_(
+          video_codec_ == kSbMediaVideoCodecAv1 &&
+          MediaCapabilitiesCache::GetInstance()->IsAv18kCappedAt30()),
       is_video_frame_tracker_enabled_(IsFrameRenderedCallbackEnabled() ||
                                       tunnel_mode_audio_session_id != -1),
       has_new_texture_available_(false),
@@ -435,7 +439,7 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
     SB_DCHECK_EQ(output_mode_, kSbPlayerOutputModeDecodeToTexture);
   }
 
-  if (video_codec_ != kSbMediaVideoCodecAv1) {
+  if (!needs_fps_to_initialize_codec_) {
     if (!InitializeCodec(video_stream_info, error_message)) {
       *error_message =
           "Failed to initialize video decoder with error: " + *error_message;
@@ -547,7 +551,7 @@ void VideoDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
 
     // Re-initialize the codec now if it was torn down either in |Reset| or
     // because we need to change the color metadata.
-    if (video_codec_ != kSbMediaVideoCodecAv1 && media_decoder_ == NULL) {
+    if (!needs_fps_to_initialize_codec_ && media_decoder_ == NULL) {
       std::string error_message;
       if (!InitializeCodec(input_buffers.front()->video_stream_info(),
                            &error_message)) {
@@ -568,7 +572,7 @@ void VideoDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
 
   input_buffer_written_ += input_buffers.size();
 
-  if (video_codec_ == kSbMediaVideoCodecAv1 && video_fps_ == 0) {
+  if (needs_fps_to_initialize_codec_ && video_fps_ == 0) {
     SB_DCHECK(!media_decoder_);
 
     pending_input_buffers_.insert(pending_input_buffers_.end(),
@@ -612,7 +616,7 @@ void VideoDecoder::WriteEndOfStream() {
     return;
   }
 
-  if (video_codec_ == kSbMediaVideoCodecAv1 && video_fps_ == 0) {
+  if (needs_fps_to_initialize_codec_ && video_fps_ == 0) {
     SB_DCHECK(!media_decoder_);
     SB_DCHECK_EQ(pending_input_buffers_.size(),
                  static_cast<size_t>(input_buffer_written_));
@@ -647,7 +651,7 @@ void VideoDecoder::Reset() {
   SB_CHECK(BelongsToCurrentThread());
 
   // If fail to flush |media_decoder_| or |media_decoder_| is null, then
-  // re-create |media_decoder_|. If the codec is kSbMediaVideoCodecAv1,
+  // re-create |media_decoder_|. If |needs_fps_to_initialize_codec_| is true,
   // set video_fps_ to 0 will call InitializeCodec(),
   // which we do not need if flush the codec.
   if (!enable_flush_during_seek_ || !media_decoder_ ||
@@ -684,7 +688,7 @@ bool VideoDecoder::InitializeCodec(const VideoStreamInfo& video_stream_info,
   SB_CHECK(BelongsToCurrentThread());
   SB_CHECK(error_message);
 
-  if (video_stream_info.codec == kSbMediaVideoCodecAv1) {
+  if (needs_fps_to_initialize_codec_) {
     SB_DCHECK_GT(pending_input_buffers_.size(), 0u);
 
     // Guesstimate the video fps.
@@ -763,7 +767,7 @@ bool VideoDecoder::InitializeCodec(const VideoStreamInfo& video_stream_info,
     return false;
   }
 
-  if (video_stream_info.codec == kSbMediaVideoCodecAv1) {
+  if (needs_fps_to_initialize_codec_) {
     SB_DCHECK_GT(video_fps_, 0);
   } else {
     SB_DCHECK_EQ(video_fps_, 0);
@@ -792,7 +796,7 @@ bool VideoDecoder::InitializeCodec(const VideoStreamInfo& video_stream_info,
     }
     media_decoder_->SetPlaybackRate(playback_rate_);
 
-    if (video_stream_info.codec == kSbMediaVideoCodecAv1) {
+    if (needs_fps_to_initialize_codec_) {
       SB_DCHECK(!pending_input_buffers_.empty());
     } else {
       SB_DCHECK(pending_input_buffers_.empty());

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -183,6 +183,10 @@ class VideoDecoder
   // prevents video distortion on some devices.
   const bool force_reset_surface_under_tunnel_mode_;
 
+  // Codec initialization will be delayed until the decoder receives enough
+  // inputs to estimate video fps when |needs_fps_to_initialize_codec_| is true.
+  const bool needs_fps_to_initialize_codec_;
+
   // On some platforms tunnel mode is only supported in the secure pipeline.  So
   // we create a dummy drm system to force the video playing in secure pipeline
   // to enable tunnel mode.

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -141,6 +141,11 @@ STARBOARD_FEATURE(kPauseUsingAudioTrackState,
 STARBOARD_FEATURE(kRejectLowPerformanceSoftwareDecoder,
                   "RejectLowPerformanceSoftwareDecoder",
                   false)
+
+// Set the following variable to true to enable av1 startup optimization.
+STARBOARD_FEATURE(kEnableAv1StartupOptimization,
+                  "EnableAv1StartupOptimization",
+                  false)
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 FEATURE_LIST_END
 


### PR DESCRIPTION
Introduce a feature flag to enable optimized AV1 codec initialization.
When enabled, detect if the device supports AV1 only up to 8K30.
If so, defer codec initialization until the video's actual frame rate
is known.

Bug: 486980027