### PR TITLE
android: Connect MediaCodec reset delay to H5vcc

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -55,6 +55,8 @@ const char kH5vccSettingsKeyMediaVideoDecoderPollIntervalMs[] =
     "Media.VideoDecoderPollIntervalMs";
 const char kH5vccSettingsKeyMediaMaxSamplesPerWrite[] =
     "Media.MaxSamplesPerWrite";
+const char kH5vccSettingsKeyMediaMediaCodecResetDelayMs[] =
+    "Media.MediaCodecResetDelayMs";
 
 // Map that stores all current bindings of H5vcc settings to media switches.
 // If a setting has a corresponding switch, we will enable the switch with the
@@ -177,6 +179,7 @@ const T* GetSettingValue(
 
 constexpr int kMaxFramesInDecoderLimit = 10'000;
 constexpr int kMaxVideoDecoderPollIntervalMs = 60'000;  // 1 minute.
+constexpr int kMaxMediaCodecResetDelayMs = 1'000;       // 1 second.
 // Experiment framework uses 0 as the sentinel value for unset.
 // e.g.)
 // http://go/latestexpcl/player_web/features/player_web_cobalt.impl.gcl;l=332;rcl=862772714
@@ -239,6 +242,9 @@ ExperimentalFeatures ProcessH5vccSettings(
   parsed.max_samples_per_write = ProcessRangedIntH5vccSetting(
       settings, kH5vccSettingsKeyMediaMaxSamplesPerWrite, /*min_val=*/1,
       /*max_val=*/100'000, kH5vccUnsetSentinel);
+  parsed.media_codec_reset_delay_ms = ProcessRangedIntH5vccSetting(
+      settings, kH5vccSettingsKeyMediaMediaCodecResetDelayMs,
+      /*min_val=*/0, kMaxMediaCodecResetDelayMs, kH5vccUnsetSentinel);
 
   for (const auto& [setting_name, setting_value] : settings) {
     AppendSettingToSwitch(setting_name, setting_value);

--- a/media/base/ipc/media_param_traits_macros.h
+++ b/media/base/ipc/media_param_traits_macros.h
@@ -234,6 +234,7 @@ IPC_STRUCT_TRAITS_BEGIN(media::StarboardRendererConfig::ExperimentalFeatures)
   IPC_STRUCT_TRAITS_MEMBER(max_samples_per_write)
   IPC_STRUCT_TRAITS_MEMBER(video_decoder_initial_preroll_count)
   IPC_STRUCT_TRAITS_MEMBER(video_decoder_poll_interval_ms)
+  IPC_STRUCT_TRAITS_MEMBER(media_codec_reset_delay_ms)
 IPC_STRUCT_TRAITS_END()
 
 IPC_STRUCT_TRAITS_BEGIN(media::StarboardRendererConfig)

--- a/media/base/starboard/starboard_renderer_config.cc
+++ b/media/base/starboard/starboard_renderer_config.cc
@@ -54,7 +54,9 @@ std::ostream& operator<<(
             << ", video_decoder_initial_preroll_count="
             << opt_to_string(features.video_decoder_initial_preroll_count)
             << ", video_decoder_poll_interval_ms="
-            << opt_to_string(features.video_decoder_poll_interval_ms) << "}";
+            << opt_to_string(features.video_decoder_poll_interval_ms)
+            << ", media_codec_reset_delay_ms="
+            << opt_to_string(features.media_codec_reset_delay_ms) << "}";
 }
 
 }  // namespace media

--- a/media/base/starboard/starboard_renderer_config.h
+++ b/media/base/starboard/starboard_renderer_config.h
@@ -36,6 +36,7 @@ struct MEDIA_EXPORT StarboardRendererConfig {
     std::optional<int> max_samples_per_write;
     std::optional<int> video_decoder_initial_preroll_count;
     std::optional<int> video_decoder_poll_interval_ms;
+    std::optional<int> media_codec_reset_delay_ms;
   };
 
   StarboardRendererConfig();

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -229,7 +229,8 @@ SbPlayerBridge::SbPlayerBridge(
     std::optional<int> initial_max_frames_in_decoder,
     std::optional<int> max_pending_input_frames,
     std::optional<int> video_decoder_initial_preroll_count,
-    std::optional<int> video_decoder_poll_interval_ms
+    std::optional<int> video_decoder_poll_interval_ms,
+    std::optional<int> media_codec_reset_delay_ms
 #if BUILDFLAG(IS_ANDROID)
     ,
     jobject surface_view
@@ -261,7 +262,8 @@ SbPlayerBridge::SbPlayerBridge(
       initial_max_frames_in_decoder_(initial_max_frames_in_decoder),
       max_pending_input_frames_(max_pending_input_frames),
       video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
-      video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms)
+      video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
+      media_codec_reset_delay_ms_(media_codec_reset_delay_ms)
 #if BUILDFLAG(IS_ANDROID)
       ,
       surface_view_(surface_view)
@@ -852,6 +854,11 @@ void SbPlayerBridge::CreatePlayer() {
       video_decoder_configuration_extension
           ->SetVideoDecoderPollIntervalMsForCurrentThread(
               *video_decoder_poll_interval_ms_);
+    }
+    if (media_codec_reset_delay_ms_) {
+      video_decoder_configuration_extension
+          ->SetMediaCodecResetDelayMsForCurrentThread(
+              *media_codec_reset_delay_ms_);
     }
   }
 

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -111,7 +111,8 @@ class SbPlayerBridge {
                  std::optional<int> initial_max_frames_in_decoder,
                  std::optional<int> max_pending_input_frames,
                  std::optional<int> video_decoder_initial_preroll_count,
-                 std::optional<int> video_decoder_poll_interval_ms
+                 std::optional<int> video_decoder_poll_interval_ms,
+                 std::optional<int> media_codec_reset_delay_ms
 #if BUILDFLAG(IS_ANDROID)
                  ,
                  jobject surface_view
@@ -353,6 +354,7 @@ class SbPlayerBridge {
   const std::optional<int> max_pending_input_frames_;
   const std::optional<int> video_decoder_initial_preroll_count_;
   const std::optional<int> video_decoder_poll_interval_ms_;
+  const std::optional<int> media_codec_reset_delay_ms_;
 
 #if BUILDFLAG(IS_ANDROID)
   // Set the surface to Android Overlay's surface view.

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -623,7 +623,8 @@ void StarboardRenderer::CreatePlayerBridge() {
         experimental_features_.initial_max_frames_in_decoder,
         experimental_features_.max_pending_input_frames,
         experimental_features_.video_decoder_initial_preroll_count,
-        experimental_features_.video_decoder_poll_interval_ms
+        experimental_features_.video_decoder_poll_interval_ms,
+        experimental_features_.media_codec_reset_delay_ms
 #if BUILDFLAG(IS_ANDROID)
         ,
         // TODO: b/475294958 - Revisit platform-specific codes above starboard.

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -199,6 +199,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   const TimeDelta audio_write_duration_remote_;
   const std::string max_video_capabilities_;
   const StarboardRendererConfig::ExperimentalFeatures experimental_features_;
+  const int max_samples_per_write_;
   const gfx::Size viewport_size_;
 #if BUILDFLAG(IS_ANDROID)
   const AndroidOverlayMojoFactoryCB android_overlay_factory_cb_;
@@ -252,7 +253,6 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   Time last_time_media_time_retrieved_;
 
   bool audio_read_delayed_ = false;
-  const int max_samples_per_write_;
 
   SbDrmSystem drm_system_{kSbDrmSystemInvalid};
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -586,11 +586,6 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
     SB_LOG_IF(INFO, enable_flush_during_seek)
         << "`kForceFlushDecoderDuringReset` is set to true, force flushing"
         << " video decoder during Reset().";
-    if (kResetDelayUsecOverride > 0) {
-      reset_delay_usec = kResetDelayUsecOverride;
-      SB_LOG(INFO) << "`kResetDelayUsecOverride` is set to > 0, force a delay"
-                   << " of " << reset_delay_usec << "us during Reset().";
-    }
     if (kFlushDelayUsecOverride > 0) {
       flush_delay_usec = kFlushDelayUsecOverride;
       SB_LOG(INFO) << "`kFlushDelayUsecOverride` is set to > 0, force a delay"
@@ -606,6 +601,14 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
         creation_parameters.video_decoder_initial_preroll_count();
     experimental_features.video_decoder_poll_interval_ms =
         creation_parameters.video_decoder_poll_interval_ms();
+    if (creation_parameters.media_codec_reset_delay_ms().has_value()) {
+      reset_delay_usec =
+          static_cast<int64_t>(
+              creation_parameters.media_codec_reset_delay_ms().value()) *
+          1000;
+      SB_LOG(INFO) << "`media_codec_reset_delay_ms` is set, force a delay"
+                   << " of " << reset_delay_usec << "us during Reset().";
+    }
     auto video_decoder = std::make_unique<VideoDecoder>(
         creation_parameters.video_stream_info(),
         creation_parameters.drm_system(), creation_parameters.output_mode(),

--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -232,6 +232,10 @@ SbPlayer SbPlayerCreate(SbWindow window,
           GetVideoDecoderPollIntervalMsForCurrentThread()) {
     handler->SetVideoDecoderPollIntervalMs(*video_decoder_poll_interval_ms);
   }
+  if (auto media_codec_reset_delay_ms = starboard::android::shared::
+          GetMediaCodecResetDelayMsForCurrentThread()) {
+    handler->SetMediaCodecResetDelayMs(*media_codec_reset_delay_ms);
+  }
   handler->SetVideoSurfaceView(
       starboard::android::shared::GetSurfaceViewForCurrentThread());
   SbPlayer player = SbPlayerPrivateImpl::CreateInstance(

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -63,6 +63,7 @@ class VideoDecoder
     std::optional<int> initial_max_frames_in_decoder;
     std::optional<int> video_decoder_initial_preroll_count;
     std::optional<int> video_decoder_poll_interval_ms;
+    std::optional<int> media_codec_reset_delay_ms;
   };
 
   VideoDecoder(const VideoStreamInfo& video_stream_info,

--- a/starboard/android/shared/video_decoder_configuration.cc
+++ b/starboard/android/shared/video_decoder_configuration.cc
@@ -32,6 +32,7 @@ const StarboardExtensionVideoDecoderConfigurationApi
         &SetVideoMaxPendingInputFramesForCurrentThread,
         &SetVideoDecoderInitialPrerollCountForCurrentThread,
         &SetVideoDecoderPollIntervalMsForCurrentThread,
+        &SetMediaCodecResetDelayMsForCurrentThread,
 };
 
 }  // namespace

--- a/starboard/android/shared/video_decoder_configuration_internal.cc
+++ b/starboard/android/shared/video_decoder_configuration_internal.cc
@@ -29,6 +29,7 @@ pthread_key_t g_initial_max_frames_key = 0;
 pthread_key_t g_max_pending_frames_key = 0;
 pthread_key_t g_video_decoder_initial_preroll_count_key = 0;
 pthread_key_t g_video_decoder_poll_interval_key = 0;
+pthread_key_t g_media_codec_reset_delay_key = 0;
 
 void WriteIntToThreadLocalStorage(pthread_key_t key, int value) {
   uintptr_t ptr_val = static_cast<uintptr_t>(value);
@@ -62,6 +63,9 @@ void InitializeKeys() {
                            /*destructor=*/nullptr);
   SB_CHECK_EQ(res, 0);
   res = pthread_key_create(&g_video_decoder_poll_interval_key,
+                           /*destructor=*/nullptr);
+  SB_CHECK_EQ(res, 0);
+  res = pthread_key_create(&g_media_codec_reset_delay_key,
                            /*destructor=*/nullptr);
   SB_CHECK_EQ(res, 0);
 }
@@ -137,6 +141,22 @@ void SetVideoDecoderPollIntervalMsForCurrentThread(
   EnsureThreadLocalKeyInitedForDecoderConfig();
   WriteIntToThreadLocalStorage(g_video_decoder_poll_interval_key,
                                video_decoder_poll_interval_ms);
+}
+
+std::optional<int> GetMediaCodecResetDelayMsForCurrentThread() {
+  EnsureThreadLocalKeyInitedForDecoderConfig();
+  return ReadIntFromThreadLocalStorage(g_media_codec_reset_delay_key);
+}
+
+void SetMediaCodecResetDelayMsForCurrentThread(int media_codec_reset_delay_ms) {
+  if (media_codec_reset_delay_ms < 0) {
+    SB_LOG(WARNING) << "Invalid media_codec_reset_delay_ms: "
+                    << media_codec_reset_delay_ms;
+    return;
+  }
+  EnsureThreadLocalKeyInitedForDecoderConfig();
+  WriteIntToThreadLocalStorage(g_media_codec_reset_delay_key,
+                               media_codec_reset_delay_ms);
 }
 
 }  // namespace starboard::android::shared

--- a/starboard/android/shared/video_decoder_configuration_internal.h
+++ b/starboard/android/shared/video_decoder_configuration_internal.h
@@ -55,6 +55,14 @@ std::optional<int> GetVideoDecoderPollIntervalMsForCurrentThread();
 void SetVideoDecoderPollIntervalMsForCurrentThread(
     int video_decoder_poll_interval_ms);
 
+// Get media_codec_reset_delay_ms via
+// SetMediaCodecResetDelayMsForCurrentThread().
+std::optional<int> GetMediaCodecResetDelayMsForCurrentThread();
+
+// Specifies the MediaCodec delay in milliseconds.
+// |media_codec_reset_delay_ms| should be positive value.
+void SetMediaCodecResetDelayMsForCurrentThread(int media_codec_reset_delay_ms);
+
 }  // namespace starboard::android::shared
 
 #endif  // STARBOARD_ANDROID_SHARED_VIDEO_DECODER_CONFIGURATION_INTERNAL_H_

--- a/starboard/extension/video_decoder_configuration.h
+++ b/starboard/extension/video_decoder_configuration.h
@@ -52,6 +52,10 @@ typedef struct StarboardExtensionVideoDecoderConfigurationApi {
   // Specifies the video poll interval in milliseconds.
   void (*SetVideoDecoderPollIntervalMsForCurrentThread)(
       int video_decoder_poll_interval_ms);
+
+  // Specifies the MediaCodec delay in milliseconds.
+  void (*SetMediaCodecResetDelayMsForCurrentThread)(
+      int media_codec_reset_delay_ms);
 } StarboardExtensionVideoDecoderConfigurationApi;
 
 #ifdef __cplusplus

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -135,7 +135,8 @@ HandlerResult FilterBasedPlayerWorkerHandler::Init(
       max_video_input_size_, flush_decoder_during_reset_, reset_audio_decoder_,
       video_initial_max_frames_in_decoder_, video_max_pending_input_frames_,
       video_decoder_initial_preroll_count_, video_decoder_poll_interval_ms_,
-      surface_view_, decode_target_graphics_context_provider_, drm_system_);
+      media_codec_reset_delay_ms_, surface_view_,
+      decode_target_graphics_context_provider_, drm_system_);
 
   {
     std::lock_guard lock(player_components_existence_mutex_);
@@ -614,6 +615,16 @@ void FilterBasedPlayerWorkerHandler::SetVideoDecoderPollIntervalMs(
                        : "(nullopt)")
                << " to " << video_decoder_poll_interval_ms;
   video_decoder_poll_interval_ms_ = video_decoder_poll_interval_ms;
+}
+
+void FilterBasedPlayerWorkerHandler::SetMediaCodecResetDelayMs(
+    int media_codec_reset_delay_ms) {
+  SB_LOG(INFO) << "Set media_codec_reset_delay_ms from "
+               << (media_codec_reset_delay_ms_.has_value()
+                       ? std::to_string(media_codec_reset_delay_ms_.value())
+                       : "(nullopt)")
+               << " to " << media_codec_reset_delay_ms;
+  media_codec_reset_delay_ms_ = media_codec_reset_delay_ms;
 }
 
 }  // namespace starboard::shared::starboard::player::filter

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -69,6 +69,7 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
       int video_decoder_initial_preroll_count) override;
   void SetVideoDecoderPollIntervalMs(
       int video_decoder_poll_interval_ms) override;
+  void SetMediaCodecResetDelayMs(int media_codec_reset_delay_ms) override;
   void Stop() override;
 
   void Update();
@@ -127,6 +128,7 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   std::optional<int> video_max_pending_input_frames_;
   std::optional<int> video_decoder_initial_preroll_count_;
   std::optional<int> video_decoder_poll_interval_ms_;
+  std::optional<int> media_codec_reset_delay_ms_;
   SbDecodeTargetGraphicsContextProvider*
       decode_target_graphics_context_provider_;
   const media::VideoStreamInfo video_stream_info_;

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -98,6 +98,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
     std::optional<int> video_max_pending_input_frames,
     std::optional<int> video_decoder_initial_preroll_count,
     std::optional<int> video_decoder_poll_interval_ms,
+    std::optional<int> media_codec_reset_delay_ms,
     void* surface_view,
     SbDecodeTargetGraphicsContextProvider*
         decode_target_graphics_context_provider,
@@ -112,6 +113,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       video_max_pending_input_frames_(video_max_pending_input_frames),
       video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
       video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
+      media_codec_reset_delay_ms_(media_codec_reset_delay_ms),
       surface_view_(surface_view),
       decode_target_graphics_context_provider_(
           decode_target_graphics_context_provider),
@@ -133,6 +135,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
     std::optional<int> video_max_pending_input_frames,
     std::optional<int> video_decoder_initial_preroll_count,
     std::optional<int> video_decoder_poll_interval_ms,
+    std::optional<int> media_codec_reset_delay_ms,
     void* surface_view,
     SbDecodeTargetGraphicsContextProvider*
         decode_target_graphics_context_provider,
@@ -148,6 +151,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       video_max_pending_input_frames_(video_max_pending_input_frames),
       video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
       video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
+      media_codec_reset_delay_ms_(media_codec_reset_delay_ms),
       surface_view_(surface_view),
       decode_target_graphics_context_provider_(
           decode_target_graphics_context_provider),
@@ -171,6 +175,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
   this->video_decoder_initial_preroll_count_ =
       that.video_decoder_initial_preroll_count_;
   this->video_decoder_poll_interval_ms_ = that.video_decoder_poll_interval_ms_;
+  this->media_codec_reset_delay_ms_ = that.media_codec_reset_delay_ms_;
   this->surface_view_ = that.surface_view_;
   this->decode_target_graphics_context_provider_ =
       that.decode_target_graphics_context_provider_;

--- a/starboard/shared/starboard/player/filter/player_components.h
+++ b/starboard/shared/starboard/player/filter/player_components.h
@@ -72,6 +72,7 @@ class PlayerComponents {
                          std::optional<int> video_max_pending_input_frames,
                          std::optional<int> video_decoder_initial_preroll_count,
                          std::optional<int> video_decoder_poll_interval_ms,
+                         std::optional<int> media_codec_reset_delay_ms,
                          void* surface_view,
                          SbDecodeTargetGraphicsContextProvider*
                              decode_target_graphics_context_provider,
@@ -87,6 +88,7 @@ class PlayerComponents {
                          std::optional<int> video_max_pending_input_frames,
                          std::optional<int> video_decoder_initial_preroll_count,
                          std::optional<int> video_decoder_poll_interval_ms,
+                         std::optional<int> media_codec_reset_delay_ms,
                          void* surface_view,
                          SbDecodeTargetGraphicsContextProvider*
                              decode_target_graphics_context_provider,
@@ -155,6 +157,9 @@ class PlayerComponents {
       std::optional<int> video_decoder_poll_interval_ms() const {
         return video_decoder_poll_interval_ms_;
       }
+      std::optional<int> media_codec_reset_delay_ms() const {
+        return media_codec_reset_delay_ms_;
+      }
 
       SbDrmSystem drm_system() const { return drm_system_; }
 
@@ -181,6 +186,7 @@ class PlayerComponents {
       std::optional<int> video_max_pending_input_frames_;
       std::optional<int> video_decoder_initial_preroll_count_;
       std::optional<int> video_decoder_poll_interval_ms_;
+      std::optional<int> media_codec_reset_delay_ms_;
 
       // The following member are used by both the audio stream and the video
       // stream, when they are encrypted.

--- a/starboard/shared/starboard/player/filter/testing/player_components_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/player_components_test.cc
@@ -96,7 +96,8 @@ class PlayerComponentsTest
           /*video_initial_max_frames_in_decoder=*/std::nullopt,
           /*video_max_pending_input_frames=*/std::nullopt,
           /*video_decoder_initial_preroll_count=*/std::nullopt,
-          /*video_decoder_poll_interval_ms=*/std::nullopt, dummy_surface_view_,
+          /*video_decoder_poll_interval_ms=*/std::nullopt,
+          /*media_codec_reset_delay_ms=*/std::nullopt, dummy_surface_view_,
           fake_graphics_context_provider_.decoder_target_provider());
       ASSERT_EQ(creation_parameters.max_video_input_size(),
                 max_video_input_size_);
@@ -119,7 +120,8 @@ class PlayerComponentsTest
           /*video_initial_max_frames_in_decoder=*/std::nullopt,
           /*video_max_pending_input_frames=*/std::nullopt,
           /*video_decoder_initial_preroll_count=*/std::nullopt,
-          /*video_decoder_poll_interval_ms=*/std::nullopt, dummy_surface_view_,
+          /*video_decoder_poll_interval_ms=*/std::nullopt,
+          /*media_codec_reset_delay_ms=*/std::nullopt, dummy_surface_view_,
           fake_graphics_context_provider_.decoder_target_provider());
       ASSERT_EQ(creation_parameters.max_video_input_size(),
                 max_video_input_size_);

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
@@ -161,6 +161,7 @@ TEST_P(VideoDecoderTest, ThreeMoreDecoders) {
                 /*video_max_pending_input_frames=*/std::nullopt,
                 /*video_decoder_initial_preroll_count=*/std::nullopt,
                 /*video_decoder_poll_interval_ms=*/std::nullopt,
+                /*media_codec_reset_delay_ms=*/std::nullopt,
                 fake_graphics_context_provider_.decoder_target_provider(),
                 nullptr);
             ASSERT_EQ(creation_parameters.max_video_input_size(),

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
@@ -91,6 +91,7 @@ void VideoDecoderTestFixture::Initialize() {
       /*video_max_pending_input_frames=*/std::nullopt,
       /*video_decoder_initial_preroll_count=*/std::nullopt,
       /*video_decoder_poll_interval_ms=*/std::nullopt,
+      /*media_codec_reset_delay_ms=*/std::nullopt,
       fake_graphics_context_provider_->decoder_target_provider(), nullptr);
   ASSERT_EQ(creation_parameters.max_video_input_size(), max_video_input_size);
   ASSERT_EQ(creation_parameters.flush_decoder_during_reset(),

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -121,6 +121,7 @@ class PlayerWorker {
         int video_decoder_initial_preroll_count) = 0;
     virtual void SetVideoDecoderPollIntervalMs(
         int video_decoder_poll_interval_ms) = 0;
+    virtual void SetMediaCodecResetDelayMs(int media_codec_reset_delay_ms) = 0;
 
    private:
     Handler(const Handler&) = delete;


### PR DESCRIPTION
Add a new H5vcc setting, Media.MediaCodecResetDelayMs, to allow
runtime configuration of the MediaCodec reset delay on Android.
This new setting provides applications with explicit control over
the delay applied during MediaCodec resets, which can impact
media playback stability and performance on various Android
devices. Previously, this delay was an internal constant.

Issue: 489123325