### PR TITLE
starboard: Consolidate experimental feature into a struct

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -76,10 +76,11 @@ constexpr int64_t kFlushDelayUsecOverride = 0;
 
 std::optional<VideoRendererImpl::PrerollParameters> GetPrerollParams(
     const PlayerComponents::Factory::CreationParameters& creation_parameters) {
+  const auto& experimental_features = creation_parameters.experimental_features();
   const auto& min_input_buffers =
-      creation_parameters.video_renderer_min_input_buffers();
+      experimental_features.video_renderer_min_input_buffers;
   const auto& min_decoded_frames =
-      creation_parameters.video_renderer_min_decoded_frames();
+      experimental_features.video_renderer_min_decoded_frames;
 
   if (!min_input_buffers && !min_decoded_frames) {
     return std::nullopt;
@@ -259,7 +260,7 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
     bool enable_flush_during_seek =
         starboard::features::FeatureList::IsEnabled(
             starboard::features::kForceFlushDecoderDuringReset) ||
-        creation_parameters.flush_decoder_during_reset();
+        creation_parameters.experimental_features().flush_decoder_during_reset;
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone &&
         !creation_parameters.video_mime().empty()) {
       MimeType video_mime_type(creation_parameters.video_mime());
@@ -415,10 +416,12 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
       is_tunnel_mode_used_ = true;
     }
 
+    const PlayerComponents::ExperimentalFeatures& experimental_features =
+        creation_parameters.experimental_features();
     bool enable_reset_audio_decoder =
         starboard::features::FeatureList::IsEnabled(
             starboard::features::kForceResetAudioDecoder) ||
-        creation_parameters.reset_audio_decoder() ||
+        experimental_features.reset_audio_decoder ||
         video_mime_type.GetParamBoolValue("enableresetaudiodecoder", false);
     SB_LOG_IF(INFO, enable_reset_audio_decoder)
         << "`enable_reset_audio_decoder` is set to true, force resetting"
@@ -431,7 +434,7 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
     bool enable_flush_during_seek =
         starboard::features::FeatureList::IsEnabled(
             starboard::features::kForceFlushDecoderDuringReset) ||
-        creation_parameters.flush_decoder_during_reset() ||
+        experimental_features.flush_decoder_during_reset ||
         video_mime_type.GetParamBoolValue("enableflushduringseek", false);
     SB_LOG_IF(INFO, enable_flush_during_seek)
         << "`enable_flush_during_seek` is set to true, force flushing"
@@ -589,7 +592,7 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
     bool enable_flush_during_seek =
         starboard::features::FeatureList::IsEnabled(
             starboard::features::kForceFlushDecoderDuringReset) ||
-        creation_parameters.flush_decoder_during_reset();
+        creation_parameters.experimental_features().flush_decoder_during_reset;
     int64_t reset_delay_usec = 0;
     int64_t flush_delay_usec = 0;
     // The default value of |force_reset_surface| would be true.
@@ -628,17 +631,22 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
 
     VideoDecoder::ExperimentalFeatures experimental_features;
     experimental_features.initial_max_frames_in_decoder =
-        creation_parameters.video_initial_max_frames_in_decoder();
+        creation_parameters.experimental_features()
+            .video_initial_max_frames_in_decoder;
     experimental_features.max_pending_input_frames =
-        creation_parameters.video_max_pending_input_frames();
+        creation_parameters.experimental_features()
+            .video_max_pending_input_frames;
     experimental_features.video_decoder_initial_preroll_count =
-        creation_parameters.video_decoder_initial_preroll_count();
+        creation_parameters.experimental_features()
+            .video_decoder_initial_preroll_count;
     experimental_features.video_decoder_poll_interval_ms =
-        creation_parameters.video_decoder_poll_interval_ms();
-    if (creation_parameters.media_codec_reset_delay_ms().has_value()) {
+        creation_parameters.experimental_features()
+            .video_decoder_poll_interval_ms;
+    if (creation_parameters.experimental_features()
+            .media_codec_reset_delay_ms.has_value()) {
       reset_delay_usec =
-          static_cast<int64_t>(
-              creation_parameters.media_codec_reset_delay_ms().value()) *
+          static_cast<int64_t>(creation_parameters.experimental_features()
+                                   .media_codec_reset_delay_ms.value()) *
           1000;
       SB_LOG(INFO) << "`media_codec_reset_delay_ms` is set, force a delay"
                    << " of " << reset_delay_usec << "us during Reset().";

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -100,6 +100,20 @@ std::optional<VideoRendererImpl::PrerollParameters> GetPrerollParams(
                                               *min_decoded_frames};
 }
 
+VideoDecoder::ExperimentalFeatures GetVideoDecoderExperimentalFeatures(
+    const PlayerComponents::ExperimentalFeatures& features) {
+  VideoDecoder::ExperimentalFeatures video_decoder_features;
+  video_decoder_features.initial_max_frames_in_decoder =
+      features.video_initial_max_frames_in_decoder;
+  video_decoder_features.max_pending_input_frames =
+      features.video_max_pending_input_frames;
+  video_decoder_features.video_decoder_initial_preroll_count =
+      features.video_decoder_initial_preroll_count;
+  video_decoder_features.video_decoder_poll_interval_ms =
+      features.video_decoder_poll_interval_ms;
+  return video_decoder_features;
+}
+
 // This class allows us to force int16 sample type when tunnel mode is enabled.
 class AudioRendererSinkAndroid : public ::starboard::shared::starboard::player::
                                      filter::AudioRendererSinkImpl {
@@ -182,8 +196,7 @@ class AudioRendererSinkCallbackStub
   std::atomic_bool error_occurred_{false};
 };
 
-class PlayerComponentsPassthrough
-    : public starboard::shared::starboard::player::filter::PlayerComponents {
+class PlayerComponentsPassthrough : public PlayerComponents {
  public:
   PlayerComponentsPassthrough(
       std::unique_ptr<AudioRendererPassthrough> audio_renderer,
@@ -203,8 +216,7 @@ class PlayerComponentsPassthrough
   std::unique_ptr<VideoRenderer> video_renderer_;
 };
 
-class PlayerComponentsFactory : public starboard::shared::starboard::player::
-                                    filter::PlayerComponents::Factory {
+class PlayerComponentsFactory : public PlayerComponents::Factory {
   typedef starboard::shared::starboard::media::MimeType MimeType;
   typedef starboard::shared::opus::OpusAudioDecoder OpusAudioDecoder;
   typedef starboard::shared::starboard::player::filter::AdaptiveAudioDecoder
@@ -215,8 +227,6 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
       AudioRendererSink;
   typedef starboard::shared::starboard::player::filter::AudioRendererSinkImpl
       AudioRendererSinkImpl;
-  typedef starboard::shared::starboard::player::filter::PlayerComponents
-      PlayerComponents;
   typedef starboard::shared::starboard::player::filter::VideoDecoder
       VideoDecoderBase;
   typedef starboard::shared::starboard::player::filter::VideoRenderAlgorithm
@@ -629,19 +639,9 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
                    << " of " << flush_delay_usec << "us during Flush().";
     }
 
-    VideoDecoder::ExperimentalFeatures experimental_features;
-    experimental_features.initial_max_frames_in_decoder =
-        creation_parameters.experimental_features()
-            .video_initial_max_frames_in_decoder;
-    experimental_features.max_pending_input_frames =
-        creation_parameters.experimental_features()
-            .video_max_pending_input_frames;
-    experimental_features.video_decoder_initial_preroll_count =
-        creation_parameters.experimental_features()
-            .video_decoder_initial_preroll_count;
-    experimental_features.video_decoder_poll_interval_ms =
-        creation_parameters.experimental_features()
-            .video_decoder_poll_interval_ms;
+    VideoDecoder::ExperimentalFeatures experimental_features =
+        GetVideoDecoderExperimentalFeatures(
+            creation_parameters.experimental_features());
     if (creation_parameters.experimental_features()
             .media_codec_reset_delay_ms.has_value()) {
       reset_delay_usec =

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -63,7 +63,6 @@ class VideoDecoder
     std::optional<int> initial_max_frames_in_decoder;
     std::optional<int> video_decoder_initial_preroll_count;
     std::optional<int> video_decoder_poll_interval_ms;
-    std::optional<int> media_codec_reset_delay_ms;
   };
 
   VideoDecoder(const VideoStreamInfo& video_stream_info,

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -46,6 +46,26 @@ typedef shared::starboard::player::PlayerWorker::Handler::HandlerResult
 // TODO: Make this configurable inside SbPlayerCreate().
 const int64_t kUpdateIntervalUsec = 200'000;  // 200ms
 
+template <typename T>
+std::ostream& operator<<(std::ostream& os, const std::optional<T>& optional) {
+  if (optional) {
+    os << *optional;
+  } else {
+    os << "(nullopt)";
+  }
+  return os;
+}
+
+template <typename T, typename U>
+void LogAndSetExperimentalFeature(const char* name, T& feature, U new_value) {
+  if (feature == new_value) {
+    return;
+  }
+  SB_LOG(INFO) << "Set experimental feature " << name << ": new=\"" << new_value
+               << "\", old=\"" << feature << "\"";
+  feature = new_value;
+}
+
 #if BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
 void DumpInputHash(const InputBuffer* input_buffer) {}
@@ -551,89 +571,41 @@ void FilterBasedPlayerWorkerHandler::SetMaxVideoInputSize(
   max_video_input_size_ = max_video_input_size;
 }
 
-void FilterBasedPlayerWorkerHandler::SetFlushDecoderDuringReset(
-    bool flush_decoder_during_reset) {
-  SB_LOG(INFO) << "Set flush_decoder_during_reset from "
-               << experimental_features_.flush_decoder_during_reset << " to "
-               << flush_decoder_during_reset;
-  experimental_features_.flush_decoder_during_reset =
-      flush_decoder_during_reset;
-}
+#define DEFINE_SET_EXPERIMENTAL_FEATURE(method_name, field_name, type)     \
+  void FilterBasedPlayerWorkerHandler::Set##method_name(type field_name) { \
+    LogAndSetExperimentalFeature(                                          \
+        #field_name, experimental_features_.field_name, field_name);       \
+  }
 
-void FilterBasedPlayerWorkerHandler::SetResetAudioDecoder(
-    bool reset_audio_decoder) {
-  SB_LOG(INFO) << "Set reset_audio_decoder from "
-               << experimental_features_.reset_audio_decoder << " to "
-               << reset_audio_decoder;
-  experimental_features_.reset_audio_decoder = reset_audio_decoder;
-}
+DEFINE_SET_EXPERIMENTAL_FEATURE(FlushDecoderDuringReset,
+                                flush_decoder_during_reset,
+                                bool)
+DEFINE_SET_EXPERIMENTAL_FEATURE(ResetAudioDecoder, reset_audio_decoder, bool)
 
 void FilterBasedPlayerWorkerHandler::SetVideoSurfaceView(void* surface_view) {
-  SB_LOG(INFO) << "Set surface_view from " << surface_view_ << " to "
-               << surface_view;
-  surface_view_ = surface_view;
+  LogAndSetExperimentalFeature("surface_view", surface_view_, surface_view);
 }
 
-void FilterBasedPlayerWorkerHandler::SetVideoInitialMaxFramesInDecoder(
-    int video_initial_max_frames_in_decoder) {
-  SB_LOG(INFO) << "Set video_initial_max_frames_in_decoder from "
-               << ToString(experimental_features_.video_initial_max_frames_in_decoder)
-               << " to " << video_initial_max_frames_in_decoder;
-  experimental_features_.video_initial_max_frames_in_decoder =
-      video_initial_max_frames_in_decoder;
-}
-
-void FilterBasedPlayerWorkerHandler::SetVideoMaxPendingInputFrames(
-    int video_max_pending_input_frames) {
-  SB_LOG(INFO) << "Set video_max_pending_input_frames from "
-               << ToString(experimental_features_.video_max_pending_input_frames)
-               << " to " << video_max_pending_input_frames;
-  experimental_features_.video_max_pending_input_frames =
-      video_max_pending_input_frames;
-}
-
-void FilterBasedPlayerWorkerHandler::SetVideoDecoderInitialPrerollCount(
-    int video_decoder_initial_preroll_count) {
-  SB_LOG(INFO) << "Set video_decoder_initial_preroll_count from "
-               << ToString(experimental_features_.video_decoder_initial_preroll_count)
-               << " to " << video_decoder_initial_preroll_count;
-  experimental_features_.video_decoder_initial_preroll_count =
-      video_decoder_initial_preroll_count;
-}
-
-void FilterBasedPlayerWorkerHandler::SetVideoDecoderPollIntervalMs(
-    int video_decoder_poll_interval_ms) {
-  SB_LOG(INFO) << "Set video_decoder_poll_interval_ms from "
-               << ToString(experimental_features_.video_decoder_poll_interval_ms)
-               << " to " << video_decoder_poll_interval_ms;
-  experimental_features_.video_decoder_poll_interval_ms =
-      video_decoder_poll_interval_ms;
-}
-
-void FilterBasedPlayerWorkerHandler::SetVideoRendererMinInputBuffers(
-    int video_renderer_min_input_buffers) {
-  SB_LOG(INFO) << "Set video_renderer_min_input_buffers from "
-               << ToString(experimental_features_.video_renderer_min_input_buffers)
-               << " to " << video_renderer_min_input_buffers;
-  experimental_features_.video_renderer_min_input_buffers =
-      video_renderer_min_input_buffers;
-}
-
-void FilterBasedPlayerWorkerHandler::SetVideoRendererMinDecodedFrames(
-    int video_renderer_min_decoded_frames) {
-  SB_LOG(INFO) << "Set video_renderer_min_decoded_frames from "
-               << ToString(experimental_features_.video_renderer_min_decoded_frames)
-               << " to " << video_renderer_min_decoded_frames;
-  experimental_features_.video_renderer_min_decoded_frames =
-      video_renderer_min_decoded_frames;
-}
-
-void FilterBasedPlayerWorkerHandler::SetMediaCodecResetDelayMs(
-    int media_codec_reset_delay_ms) {
-  SB_LOG(INFO) << "Set media_codec_reset_delay_ms from "
-               << ToString(experimental_features_.media_codec_reset_delay_ms)
-               << " to " << media_codec_reset_delay_ms;
-  experimental_features_.media_codec_reset_delay_ms = media_codec_reset_delay_ms;
-}
+DEFINE_SET_EXPERIMENTAL_FEATURE(VideoInitialMaxFramesInDecoder,
+                                video_initial_max_frames_in_decoder,
+                                int)
+DEFINE_SET_EXPERIMENTAL_FEATURE(VideoMaxPendingInputFrames,
+                                video_max_pending_input_frames,
+                                int)
+DEFINE_SET_EXPERIMENTAL_FEATURE(VideoDecoderInitialPrerollCount,
+                                video_decoder_initial_preroll_count,
+                                int)
+DEFINE_SET_EXPERIMENTAL_FEATURE(VideoDecoderPollIntervalMs,
+                                video_decoder_poll_interval_ms,
+                                int)
+DEFINE_SET_EXPERIMENTAL_FEATURE(VideoRendererMinInputBuffers,
+                                video_renderer_min_input_buffers,
+                                int)
+DEFINE_SET_EXPERIMENTAL_FEATURE(VideoRendererMinDecodedFrames,
+                                video_renderer_min_decoded_frames,
+                                int)
+DEFINE_SET_EXPERIMENTAL_FEATURE(MediaCodecResetDelayMs,
+                                media_codec_reset_delay_ms,
+                                int)
 
 }  // namespace starboard::shared::starboard::player::filter

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -46,23 +46,13 @@ typedef shared::starboard::player::PlayerWorker::Handler::HandlerResult
 // TODO: Make this configurable inside SbPlayerCreate().
 const int64_t kUpdateIntervalUsec = 200'000;  // 200ms
 
-template <typename T>
-std::ostream& operator<<(std::ostream& os, const std::optional<T>& optional) {
-  if (optional) {
-    os << *optional;
-  } else {
-    os << "(nullopt)";
-  }
-  return os;
-}
-
 template <typename T, typename U>
 void LogAndSetExperimentalFeature(const char* name, T& feature, U new_value) {
   if (feature == new_value) {
     return;
   }
   SB_LOG(INFO) << "Set experimental feature " << name << ": new=\"" << new_value
-               << "\", old=\"" << feature << "\"";
+               << "\", old=\"" << ToString(feature) << "\"";
   feature = new_value;
 }
 

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -608,4 +608,6 @@ DEFINE_SET_EXPERIMENTAL_FEATURE(MediaCodecResetDelayMs,
                                 media_codec_reset_delay_ms,
                                 int)
 
+#undef DEFINE_SET_EXPERIMENTAL_FEATURE
+
 }  // namespace starboard::shared::starboard::player::filter

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -132,11 +132,7 @@ HandlerResult FilterBasedPlayerWorkerHandler::Init(
 
   PlayerComponents::Factory::CreationParameters creation_parameters(
       audio_stream_info_, video_stream_info_, player_, output_mode_,
-      max_video_input_size_, flush_decoder_during_reset_, reset_audio_decoder_,
-      video_initial_max_frames_in_decoder_, video_max_pending_input_frames_,
-      video_decoder_initial_preroll_count_, video_decoder_poll_interval_ms_,
-      video_renderer_min_input_buffers_, video_renderer_min_decoded_frames_,
-      media_codec_reset_delay_ms_, surface_view_,
+      max_video_input_size_, experimental_features_, surface_view_,
       decode_target_graphics_context_provider_, drm_system_);
 
   {
@@ -558,16 +554,18 @@ void FilterBasedPlayerWorkerHandler::SetMaxVideoInputSize(
 void FilterBasedPlayerWorkerHandler::SetFlushDecoderDuringReset(
     bool flush_decoder_during_reset) {
   SB_LOG(INFO) << "Set flush_decoder_during_reset from "
-               << flush_decoder_during_reset_ << " to "
+               << experimental_features_.flush_decoder_during_reset << " to "
                << flush_decoder_during_reset;
-  flush_decoder_during_reset_ = flush_decoder_during_reset;
+  experimental_features_.flush_decoder_during_reset =
+      flush_decoder_during_reset;
 }
 
 void FilterBasedPlayerWorkerHandler::SetResetAudioDecoder(
     bool reset_audio_decoder) {
-  SB_LOG(INFO) << "Set reset_audio_decoder from " << reset_audio_decoder_
-               << " to " << reset_audio_decoder;
-  reset_audio_decoder_ = reset_audio_decoder;
+  SB_LOG(INFO) << "Set reset_audio_decoder from "
+               << experimental_features_.reset_audio_decoder << " to "
+               << reset_audio_decoder;
+  experimental_features_.reset_audio_decoder = reset_audio_decoder;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoSurfaceView(void* surface_view) {
@@ -579,51 +577,63 @@ void FilterBasedPlayerWorkerHandler::SetVideoSurfaceView(void* surface_view) {
 void FilterBasedPlayerWorkerHandler::SetVideoInitialMaxFramesInDecoder(
     int video_initial_max_frames_in_decoder) {
   SB_LOG(INFO) << "Set video_initial_max_frames_in_decoder from "
-               << ToString(video_initial_max_frames_in_decoder_) << " to "
-               << video_initial_max_frames_in_decoder;
-  video_initial_max_frames_in_decoder_ = video_initial_max_frames_in_decoder;
+               << ToString(experimental_features_.video_initial_max_frames_in_decoder)
+               << " to " << video_initial_max_frames_in_decoder;
+  experimental_features_.video_initial_max_frames_in_decoder =
+      video_initial_max_frames_in_decoder;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoMaxPendingInputFrames(
     int video_max_pending_input_frames) {
   SB_LOG(INFO) << "Set video_max_pending_input_frames from "
-               << ToString(video_max_pending_input_frames_) << " to "
-               << video_max_pending_input_frames;
-  video_max_pending_input_frames_ = video_max_pending_input_frames;
+               << ToString(experimental_features_.video_max_pending_input_frames)
+               << " to " << video_max_pending_input_frames;
+  experimental_features_.video_max_pending_input_frames =
+      video_max_pending_input_frames;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoDecoderInitialPrerollCount(
     int video_decoder_initial_preroll_count) {
   SB_LOG(INFO) << "Set video_decoder_initial_preroll_count from "
-               << ToString(video_decoder_initial_preroll_count_) << " to "
-               << video_decoder_initial_preroll_count;
-  video_decoder_initial_preroll_count_ = video_decoder_initial_preroll_count;
+               << ToString(experimental_features_.video_decoder_initial_preroll_count)
+               << " to " << video_decoder_initial_preroll_count;
+  experimental_features_.video_decoder_initial_preroll_count =
+      video_decoder_initial_preroll_count;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoDecoderPollIntervalMs(
     int video_decoder_poll_interval_ms) {
   SB_LOG(INFO) << "Set video_decoder_poll_interval_ms from "
-               << ToString(video_decoder_poll_interval_ms_) << " to "
-               << video_decoder_poll_interval_ms;
-  video_decoder_poll_interval_ms_ = video_decoder_poll_interval_ms;
+               << ToString(experimental_features_.video_decoder_poll_interval_ms)
+               << " to " << video_decoder_poll_interval_ms;
+  experimental_features_.video_decoder_poll_interval_ms =
+      video_decoder_poll_interval_ms;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoRendererMinInputBuffers(
     int video_renderer_min_input_buffers) {
-  video_renderer_min_input_buffers_ = video_renderer_min_input_buffers;
+  SB_LOG(INFO) << "Set video_renderer_min_input_buffers from "
+               << ToString(experimental_features_.video_renderer_min_input_buffers)
+               << " to " << video_renderer_min_input_buffers;
+  experimental_features_.video_renderer_min_input_buffers =
+      video_renderer_min_input_buffers;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoRendererMinDecodedFrames(
     int video_renderer_min_decoded_frames) {
-  video_renderer_min_decoded_frames_ = video_renderer_min_decoded_frames;
+  SB_LOG(INFO) << "Set video_renderer_min_decoded_frames from "
+               << ToString(experimental_features_.video_renderer_min_decoded_frames)
+               << " to " << video_renderer_min_decoded_frames;
+  experimental_features_.video_renderer_min_decoded_frames =
+      video_renderer_min_decoded_frames;
 }
 
 void FilterBasedPlayerWorkerHandler::SetMediaCodecResetDelayMs(
     int media_codec_reset_delay_ms) {
   SB_LOG(INFO) << "Set media_codec_reset_delay_ms from "
-               << ToString(media_codec_reset_delay_ms_) << " to "
-               << media_codec_reset_delay_ms;
-  media_codec_reset_delay_ms_ = media_codec_reset_delay_ms;
+               << ToString(experimental_features_.media_codec_reset_delay_ms)
+               << " to " << media_codec_reset_delay_ms;
+  experimental_features_.media_codec_reset_delay_ms = media_codec_reset_delay_ms;
 }
 
 }  // namespace starboard::shared::starboard::player::filter

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -125,16 +125,8 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
 
   SbPlayerOutputMode output_mode_;
   int max_video_input_size_;
-  bool flush_decoder_during_reset_ = false;
-  bool reset_audio_decoder_ = false;
+  PlayerComponents::ExperimentalFeatures experimental_features_;
   void* surface_view_ = nullptr;
-  std::optional<int> video_initial_max_frames_in_decoder_;
-  std::optional<int> video_max_pending_input_frames_;
-  std::optional<int> video_decoder_initial_preroll_count_;
-  std::optional<int> video_decoder_poll_interval_ms_;
-  std::optional<int> video_renderer_min_input_buffers_;
-  std::optional<int> video_renderer_min_decoded_frames_;
-  std::optional<int> media_codec_reset_delay_ms_;
   SbDecodeTargetGraphicsContextProvider*
       decode_target_graphics_context_provider_;
   const media::VideoStreamInfo video_stream_info_;

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -83,7 +83,9 @@ int AlignUp(int value, int alignment) {
 PlayerComponents::Factory::CreationParameters::CreationParameters(
     const media::AudioStreamInfo& audio_stream_info,
     SbDrmSystem drm_system)
-    : audio_stream_info_(audio_stream_info), drm_system_(drm_system) {
+    : audio_stream_info_(audio_stream_info),
+      experimental_features_(ExperimentalFeatures{}),
+      drm_system_(drm_system) {
   SB_DCHECK_NE(audio_stream_info_.codec, kSbMediaAudioCodecNone);
 }
 
@@ -92,15 +94,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
     SbPlayer player,
     SbPlayerOutputMode output_mode,
     int max_video_input_size,
-    bool flush_decoder_during_reset,
-    bool reset_audio_decoder,
-    std::optional<int> video_initial_max_frames_in_decoder,
-    std::optional<int> video_max_pending_input_frames,
-    std::optional<int> video_decoder_initial_preroll_count,
-    std::optional<int> video_decoder_poll_interval_ms,
-    std::optional<int> video_renderer_min_input_buffers,
-    std::optional<int> video_renderer_min_decoded_frames,
-    std::optional<int> media_codec_reset_delay_ms,
+    const ExperimentalFeatures& experimental_features,
     void* surface_view,
     SbDecodeTargetGraphicsContextProvider*
         decode_target_graphics_context_provider,
@@ -109,15 +103,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       player_(player),
       output_mode_(output_mode),
       max_video_input_size_(max_video_input_size),
-      flush_decoder_during_reset_(flush_decoder_during_reset),
-      reset_audio_decoder_(reset_audio_decoder),
-      video_initial_max_frames_in_decoder_(video_initial_max_frames_in_decoder),
-      video_max_pending_input_frames_(video_max_pending_input_frames),
-      video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
-      video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
-      video_renderer_min_input_buffers_(video_renderer_min_input_buffers),
-      video_renderer_min_decoded_frames_(video_renderer_min_decoded_frames),
-      media_codec_reset_delay_ms_(media_codec_reset_delay_ms),
+      experimental_features_(experimental_features),
       surface_view_(surface_view),
       decode_target_graphics_context_provider_(
           decode_target_graphics_context_provider),
@@ -133,15 +119,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
     SbPlayer player,
     SbPlayerOutputMode output_mode,
     int max_video_input_size,
-    bool flush_decoder_during_reset,
-    bool reset_audio_decoder,
-    std::optional<int> video_initial_max_frames_in_decoder,
-    std::optional<int> video_max_pending_input_frames,
-    std::optional<int> video_decoder_initial_preroll_count,
-    std::optional<int> video_decoder_poll_interval_ms,
-    std::optional<int> video_renderer_min_input_buffers,
-    std::optional<int> video_renderer_min_decoded_frames,
-    std::optional<int> media_codec_reset_delay_ms,
+    const ExperimentalFeatures& experimental_features,
     void* surface_view,
     SbDecodeTargetGraphicsContextProvider*
         decode_target_graphics_context_provider,
@@ -151,47 +129,13 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       player_(player),
       output_mode_(output_mode),
       max_video_input_size_(max_video_input_size),
-      flush_decoder_during_reset_(flush_decoder_during_reset),
-      reset_audio_decoder_(reset_audio_decoder),
-      video_initial_max_frames_in_decoder_(video_initial_max_frames_in_decoder),
-      video_max_pending_input_frames_(video_max_pending_input_frames),
-      video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
-      video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
-      video_renderer_min_input_buffers_(video_renderer_min_input_buffers),
-      video_renderer_min_decoded_frames_(video_renderer_min_decoded_frames),
-      media_codec_reset_delay_ms_(media_codec_reset_delay_ms),
+      experimental_features_(experimental_features),
       surface_view_(surface_view),
       decode_target_graphics_context_provider_(
           decode_target_graphics_context_provider),
       drm_system_(drm_system) {
   SB_DCHECK(audio_stream_info_.codec != kSbMediaAudioCodecNone ||
             video_stream_info_.codec != kSbMediaVideoCodecNone);
-}
-
-PlayerComponents::Factory::CreationParameters::CreationParameters(
-    const CreationParameters& that) {
-  this->audio_stream_info_ = that.audio_stream_info_;
-  this->video_stream_info_ = that.video_stream_info_;
-  this->player_ = that.player_;
-  this->output_mode_ = that.output_mode_;
-  this->max_video_input_size_ = that.max_video_input_size_;
-  this->flush_decoder_during_reset_ = that.flush_decoder_during_reset_;
-  this->reset_audio_decoder_ = that.reset_audio_decoder_;
-  this->video_initial_max_frames_in_decoder_ =
-      that.video_initial_max_frames_in_decoder_;
-  this->video_max_pending_input_frames_ = that.video_max_pending_input_frames_;
-  this->video_decoder_initial_preroll_count_ =
-      that.video_decoder_initial_preroll_count_;
-  this->video_decoder_poll_interval_ms_ = that.video_decoder_poll_interval_ms_;
-  this->video_renderer_min_input_buffers_ =
-      that.video_renderer_min_input_buffers_;
-  this->video_renderer_min_decoded_frames_ =
-      that.video_renderer_min_decoded_frames_;
-  this->media_codec_reset_delay_ms_ = that.media_codec_reset_delay_ms_;
-  this->surface_view_ = that.surface_view_;
-  this->decode_target_graphics_context_provider_ =
-      that.decode_target_graphics_context_provider_;
-  this->drm_system_ = that.drm_system_;
 }
 
 std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
@@ -282,12 +226,13 @@ std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
           std::make_unique<MonotonicSystemTimeProviderImpl>());
       media_time_provider = media_time_provider_impl.get();
     }
+    const auto& experimental_features = creation_parameters.experimental_features();
     std::optional<VideoRendererImpl::PrerollParameters> preroll_params;
-    if (creation_parameters.video_renderer_min_input_buffers() &&
-        creation_parameters.video_renderer_min_decoded_frames()) {
+    if (experimental_features.video_renderer_min_input_buffers &&
+        experimental_features.video_renderer_min_decoded_frames) {
       preroll_params = VideoRendererImpl::PrerollParameters{
-          *creation_parameters.video_renderer_min_input_buffers(),
-          *creation_parameters.video_renderer_min_decoded_frames()};
+          *experimental_features.video_renderer_min_input_buffers,
+          *experimental_features.video_renderer_min_decoded_frames};
     }
     video_renderer = std::make_unique<VideoRendererImpl>(
         std::move(video_decoder), media_time_provider,

--- a/starboard/shared/starboard/player/filter/player_components.h
+++ b/starboard/shared/starboard/player/filter/player_components.h
@@ -54,6 +54,18 @@ class PlayerComponents {
   typedef ::starboard::shared::starboard::player::filter::VideoRenderer
       VideoRenderer;
 
+  struct ExperimentalFeatures {
+    bool flush_decoder_during_reset = false;
+    bool reset_audio_decoder = false;
+    std::optional<int> video_initial_max_frames_in_decoder;
+    std::optional<int> video_max_pending_input_frames;
+    std::optional<int> video_decoder_initial_preroll_count;
+    std::optional<int> video_decoder_poll_interval_ms;
+    std::optional<int> video_renderer_min_input_buffers;
+    std::optional<int> video_renderer_min_decoded_frames;
+    std::optional<int> media_codec_reset_delay_ms;
+  };
+
   // This class creates PlayerComponents.
   class Factory {
    public:
@@ -66,15 +78,7 @@ class PlayerComponents {
                          SbPlayer player,
                          SbPlayerOutputMode output_mode,
                          int max_video_input_size,
-                         bool flush_decoder_during_reset,
-                         bool reset_audio_decoder,
-                         std::optional<int> video_initial_max_frames_in_decoder,
-                         std::optional<int> video_max_pending_input_frames,
-                         std::optional<int> video_decoder_initial_preroll_count,
-                         std::optional<int> video_decoder_poll_interval_ms,
-                         std::optional<int> video_renderer_min_input_buffers,
-                         std::optional<int> video_renderer_min_decoded_frames,
-                         std::optional<int> media_codec_reset_delay_ms,
+                         const ExperimentalFeatures& experimental_features,
                          void* surface_view,
                          SbDecodeTargetGraphicsContextProvider*
                              decode_target_graphics_context_provider,
@@ -84,20 +88,11 @@ class PlayerComponents {
                          SbPlayer player,
                          SbPlayerOutputMode output_mode,
                          int max_video_input_size,
-                         bool flush_decoder_during_reset,
-                         bool reset_audio_decoder,
-                         std::optional<int> video_initial_max_frames_in_decoder,
-                         std::optional<int> video_max_pending_input_frames,
-                         std::optional<int> video_decoder_initial_preroll_count,
-                         std::optional<int> video_decoder_poll_interval_ms,
-                         std::optional<int> video_renderer_min_input_buffers,
-                         std::optional<int> video_renderer_min_decoded_frames,
-                         std::optional<int> media_codec_reset_delay_ms,
+                         const ExperimentalFeatures& experimental_features,
                          void* surface_view,
                          SbDecodeTargetGraphicsContextProvider*
                              decode_target_graphics_context_provider,
                          SbDrmSystem drm_system = kSbDrmSystemInvalid);
-      CreationParameters(const CreationParameters& that);
       void operator=(const CreationParameters& that) = delete;
 
       void reset_audio_codec() {
@@ -139,36 +134,13 @@ class PlayerComponents {
       SbPlayer player() const { return player_; }
       SbPlayerOutputMode output_mode() const { return output_mode_; }
       int max_video_input_size() const { return max_video_input_size_; }
-      bool flush_decoder_during_reset() const {
-        return flush_decoder_during_reset_;
+      const ExperimentalFeatures& experimental_features() const {
+        return experimental_features_;
       }
-      bool reset_audio_decoder() const { return reset_audio_decoder_; }
       void* surface_view() const { return surface_view_; }
       SbDecodeTargetGraphicsContextProvider*
       decode_target_graphics_context_provider() const {
-        SB_DCHECK_NE(video_stream_info_.codec, kSbMediaVideoCodecNone);
         return decode_target_graphics_context_provider_;
-      }
-      std::optional<int> video_initial_max_frames_in_decoder() const {
-        return video_initial_max_frames_in_decoder_;
-      }
-      std::optional<int> video_max_pending_input_frames() const {
-        return video_max_pending_input_frames_;
-      }
-      std::optional<int> video_decoder_initial_preroll_count() const {
-        return video_decoder_initial_preroll_count_;
-      }
-      std::optional<int> video_decoder_poll_interval_ms() const {
-        return video_decoder_poll_interval_ms_;
-      }
-      std::optional<int> video_renderer_min_input_buffers() const {
-        return video_renderer_min_input_buffers_;
-      }
-      std::optional<int> video_renderer_min_decoded_frames() const {
-        return video_renderer_min_decoded_frames_;
-      }
-      std::optional<int> media_codec_reset_delay_ms() const {
-        return media_codec_reset_delay_ms_;
       }
 
       SbDrmSystem drm_system() const { return drm_system_; }
@@ -186,19 +158,10 @@ class PlayerComponents {
       SbPlayer player_ = kSbPlayerInvalid;
       SbPlayerOutputMode output_mode_ = kSbPlayerOutputModeInvalid;
       int max_video_input_size_ = 0;
-      bool flush_decoder_during_reset_ = false;
-      bool reset_audio_decoder_ = false;
+      const ExperimentalFeatures experimental_features_;
       void* surface_view_;
       SbDecodeTargetGraphicsContextProvider*
           decode_target_graphics_context_provider_ = nullptr;
-
-      std::optional<int> video_initial_max_frames_in_decoder_;
-      std::optional<int> video_max_pending_input_frames_;
-      std::optional<int> video_decoder_initial_preroll_count_;
-      std::optional<int> video_decoder_poll_interval_ms_;
-      std::optional<int> video_renderer_min_input_buffers_;
-      std::optional<int> video_renderer_min_decoded_frames_;
-      std::optional<int> media_codec_reset_delay_ms_;
 
       // The following member are used by both the audio stream and the video
       // stream, when they are encrypted.

--- a/starboard/shared/starboard/player/filter/player_components.h
+++ b/starboard/shared/starboard/player/filter/player_components.h
@@ -140,6 +140,7 @@ class PlayerComponents {
       void* surface_view() const { return surface_view_; }
       SbDecodeTargetGraphicsContextProvider*
       decode_target_graphics_context_provider() const {
+        SB_DCHECK_NE(video_stream_info_.codec, kSbMediaVideoCodecNone);
         return decode_target_graphics_context_provider_;
       }
 

--- a/starboard/shared/starboard/player/filter/testing/player_components_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/player_components_test.cc
@@ -90,16 +90,8 @@ class PlayerComponentsTest
       CreationParameters creation_parameters(
           audio_reader_->audio_stream_info(),
           video_reader_->video_stream_info(), kDummyPlayer, output_mode_,
-          max_video_input_size_,
-          /*flush_decoder_during_reset=*/false,
-          /*reset_audio_decoder=*/false,
-          /*video_initial_max_frames_in_decoder=*/std::nullopt,
-          /*video_max_pending_input_frames=*/std::nullopt,
-          /*video_decoder_initial_preroll_count=*/std::nullopt,
-          /*video_decoder_poll_interval_ms=*/std::nullopt,
-          /*video_renderer_min_input_buffers=*/std::nullopt,
-          /*video_renderer_min_decoded_frames=*/std::nullopt,
-          /*media_codec_reset_delay_ms=*/std::nullopt, dummy_surface_view_,
+          max_video_input_size_, PlayerComponents::ExperimentalFeatures{},
+          dummy_surface_view_,
           fake_graphics_context_provider_.decoder_target_provider());
       ASSERT_EQ(creation_parameters.max_video_input_size(),
                 max_video_input_size_);
@@ -116,16 +108,8 @@ class PlayerComponentsTest
       ASSERT_TRUE(video_reader_);
       CreationParameters creation_parameters(
           video_reader_->video_stream_info(), kDummyPlayer, output_mode_,
-          max_video_input_size_,
-          /*flush_decoder_during_reset=*/false,
-          /*reset_audio_decoder=*/false,
-          /*video_initial_max_frames_in_decoder=*/std::nullopt,
-          /*video_max_pending_input_frames=*/std::nullopt,
-          /*video_decoder_initial_preroll_count=*/std::nullopt,
-          /*video_decoder_poll_interval_ms=*/std::nullopt,
-          /*video_renderer_min_input_buffers=*/std::nullopt,
-          /*video_renderer_min_decoded_frames=*/std::nullopt,
-          /*media_codec_reset_delay_ms=*/std::nullopt, dummy_surface_view_,
+          max_video_input_size_, PlayerComponents::ExperimentalFeatures{},
+          dummy_surface_view_,
           fake_graphics_context_provider_.decoder_target_provider());
       ASSERT_EQ(creation_parameters.max_video_input_size(),
                 max_video_input_size_);

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
@@ -155,15 +155,7 @@ TEST_P(VideoDecoderTest, ThreeMoreDecoders) {
             PlayerComponents::Factory::CreationParameters creation_parameters(
                 CreateVideoStreamInfo(fixture_.dmp_reader().video_codec()),
                 &players[i], output_mode, max_video_input_size,
-                /*flush_decoder_during_reset=*/false,
-                /*reset_audio_decoder=*/false,
-                /*video_initial_max_frames_in_decoder=*/std::nullopt,
-                /*video_max_pending_input_frames=*/std::nullopt,
-                /*video_decoder_initial_preroll_count=*/std::nullopt,
-                /*video_decoder_poll_interval_ms=*/std::nullopt,
-                /*video_renderer_min_input_buffers=*/std::nullopt,
-                /*video_renderer_min_decoded_frames=*/std::nullopt,
-                /*media_codec_reset_delay_ms=*/std::nullopt,
+                PlayerComponents::ExperimentalFeatures{},
                 fake_graphics_context_provider_.decoder_target_provider(),
                 nullptr);
             ASSERT_EQ(creation_parameters.max_video_input_size(),

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
@@ -81,24 +81,18 @@ void VideoDecoderTestFixture::Initialize() {
   ASSERT_TRUE(PlayerComponents::Factory::OutputModeSupported(
       output_mode, dmp_reader_.video_codec(), kSbDrmSystemInvalid));
   int max_video_input_size = 0;
-  bool flush_decoder_during_reset = false;
-  bool reset_audio_decoder = false;
+  PlayerComponents::ExperimentalFeatures experimental_features;
+  experimental_features.flush_decoder_during_reset = true;
+  experimental_features.reset_audio_decoder = false;
 
   PlayerComponents::Factory::CreationParameters creation_parameters(
       GetVideoInputBuffer(0)->video_stream_info(), &player_, output_mode,
-      max_video_input_size, flush_decoder_during_reset, reset_audio_decoder,
-      /*video_initial_max_frames_in_decoder=*/std::nullopt,
-      /*video_max_pending_input_frames=*/std::nullopt,
-      /*video_decoder_initial_preroll_count=*/std::nullopt,
-      /*video_decoder_poll_interval_ms=*/std::nullopt,
-      /*video_renderer_min_input_buffers=*/std::nullopt,
-      /*video_renderer_min_decoded_frames=*/std::nullopt,
-      /*media_codec_reset_delay_ms=*/std::nullopt,
-      fake_graphics_context_provider_->decoder_target_provider(), nullptr);
+      max_video_input_size, experimental_features, /*surface_view=*/nullptr,
+      fake_graphics_context_provider_->decoder_target_provider());
   ASSERT_EQ(creation_parameters.max_video_input_size(), max_video_input_size);
-  ASSERT_EQ(creation_parameters.flush_decoder_during_reset(),
-            flush_decoder_during_reset);
-  ASSERT_EQ(creation_parameters.reset_audio_decoder(), reset_audio_decoder);
+  ASSERT_TRUE(
+      creation_parameters.experimental_features().flush_decoder_during_reset);
+  ASSERT_FALSE(creation_parameters.experimental_features().reset_audio_decoder);
 
   std::unique_ptr<PlayerComponents::Factory> factory;
   if (using_stub_decoder_) {


### PR DESCRIPTION
Consolidate various experimental player features into a single
PlayerComponents::ExperimentalFeatures struct. This refactoring groups
parameters such as flush_decoder_during_reset, reset_audio_decoder,
and video decoder input/preroll counts.

This change improves code organization by reducing the number of
individual parameters in constructors and centralizing the management
of experimental player settings.

Bug: 480134029