### PR TITLE
starboard: Integrate ANGLE into Ozone EGL backend

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -955,11 +955,13 @@ jobs:
       - name: Failed Tests
         if: needs.test-results.result == 'failure' || needs.browser-test-results.result == 'failure'
         run: |
-          # Print test result summary.
+          # Print test result summary when XML files are available.
           shopt -s globstar nullglob
-          python3 cobalt/tools/junit_mini_parser.py results/**/*.xml
-
-          if [[ "${{ needs.test-results.result }}" == "failure" || "${{ needs.browser-test-results.result }}" == "failure" ]]; then
+          xml_files=(results/**/*.xml)
+          if [ ${#xml_files[@]} -gt 0 ]; then
+            python3 cobalt/tools/junit_mini_parser.py results/**/*.xml
             exit 1
+          else
+            echo "No JUnit XML files to parse (artifacts may not have been uploaded)."
           fi
         shell: bash

--- a/cobalt/tools/junit_mini_parser.py
+++ b/cobalt/tools/junit_mini_parser.py
@@ -49,8 +49,8 @@ def find_failing_tests(junit_xml_files: list[str]) -> dict[str, list[str]]:
   return failing_tests
 
 
-def main(xml_files: str):
-  failing_tests = find_failing_tests(xml_files)
+def main(files: list[str]):
+  failing_tests = find_failing_tests(files)
 
   if failing_tests:
     print('Failing Tests:')
@@ -67,8 +67,8 @@ def main(xml_files: str):
 
 
 if __name__ == '__main__':
-  if len(sys.argv) == 1:
-    print('Usage: python junit_mini_parser.py '
-          '<junit_xml_file1> <junit_xml_file2> ...')
-    print('Please provide a list of JUnit XML files as command line arguments.')
-  main(sys.argv[1:])
+  xml_files = sys.argv[1:]
+  if not xml_files:
+    print('No JUnit XML files to parse.')
+    sys.exit(0)
+  main(xml_files)

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_egl.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_egl.cc
@@ -231,3 +231,13 @@ const SbEglInterface g_sb_egl_interface = {
 const SbEglInterface* SbGetEglInterface() {
   return &g_sb_egl_interface;
 }
+
+void* SbGetNativeEGLDisplayType() {
+  NativeDisplayType display_type = 0;
+  EssCtx* ctx =
+      third_party::starboard::rdk::shared::Application::Get()->GetEssCtx();
+  if (ctx && EssContextGetEGLDisplayType(ctx, &display_type)) {
+    return reinterpret_cast<void*>(display_type);
+  }
+  return nullptr;
+}

--- a/starboard/egl.h
+++ b/starboard/egl.h
@@ -184,6 +184,9 @@ typedef struct SbEglInterface {
 
 SB_EXPORT const SbEglInterface* SbGetEglInterface();
 
+// Returns platform native EGL display type, or NULL to use EGL_DEFAULT_DISPLAY.
+SB_EXPORT void* SbGetNativeEGLDisplayType();
+
 // All of the following were previously defined in
 // https://www.khronos.org/registry/EGL/api/EGL/egl.h.
 

--- a/starboard/shared/egl/system_egl.cc
+++ b/starboard/shared/egl/system_egl.cc
@@ -125,3 +125,7 @@ const SbEglInterface g_sb_egl_interface = {
 const SbEglInterface* SbGetEglInterface() {
   return &g_sb_egl_interface;
 }
+
+void* SbGetNativeEGLDisplayType() {
+  return nullptr;
+}

--- a/starboard/shared/stub/system_egl.cc
+++ b/starboard/shared/stub/system_egl.cc
@@ -17,3 +17,7 @@
 const SbEglInterface* SbGetEglInterface() {
   return nullptr;
 }
+
+void* SbGetNativeEGLDisplayType() {
+  return nullptr;
+}

--- a/starboard/tools/api_leak_detector/evergreen/dev_manifest
+++ b/starboard/tools/api_leak_detector/evergreen/dev_manifest
@@ -2,10 +2,13 @@
 
 # This file was auto-generated using api_leak_detector.py.
 
+TLS init function for egl::gCurrentThread
+TLS init function for gl::gCurrentValidContext
 TLS init function for v8::internal::trap_handler::g_thread_in_wasm_code
 __cxa_thread_atexit_impl
 __gcov_dump
 __gcov_flush
+dlerror
 dl_iterate_phdr
 dlopen
 dlsym

--- a/starboard/tools/api_leak_detector/evergreen/manifest
+++ b/starboard/tools/api_leak_detector/evergreen/manifest
@@ -2,10 +2,13 @@
 
 # This file was auto-generated using api_leak_detector.py.
 
+TLS init function for egl::gCurrentThread
+TLS init function for gl::gCurrentValidContext
 TLS init function for v8::internal::trap_handler::g_thread_in_wasm_code
 __cxa_thread_atexit_impl
 __gcov_dump
 __gcov_flush
+dlerror
 dl_iterate_phdr
 dlopen
 dlsym

--- a/ui/ozone/platform/starboard/gl_ozone_egl_starboard.cc
+++ b/ui/ozone/platform/starboard/gl_ozone_egl_starboard.cc
@@ -14,221 +14,10 @@
 
 #include "ui/ozone/platform/starboard/gl_ozone_egl_starboard.h"
 
-#include <memory>
-
 #include "starboard/egl.h"
-#include "starboard/gles.h"
+#include "ui/ozone/common/egl_util.h"
 
 namespace ui {
-
-// Macro to simplify the lookup of function pointers from a given interface.
-// It checks if 'name' matches '#func_name' and returns the corresponding
-// function pointer from 'interface_ptr'.
-#define GET_INTERFACE_PROC_ADDRESS_ENTRY(func_name, interface_ptr) \
-  if (strcmp(name, #func_name) == 0) {                             \
-    return reinterpret_cast<gl::GLFunctionPointerType>(            \
-        interface_ptr->func_name);                                 \
-  }
-
-// Helper function to look up EGL function pointers from the SbEglInterface.
-gl::GLFunctionPointerType GetEglInterfaceProcAddress(
-    const char* name,
-    const SbEglInterface* egl) {
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglChooseConfig, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCopyBuffers, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreateContext, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreatePbufferSurface, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreatePixmapSurface, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreateWindowSurface, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglDestroyContext, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglDestroySurface, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetConfigAttrib, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetConfigs, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetCurrentDisplay, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetCurrentSurface, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetDisplay, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetError, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetProcAddress, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglInitialize, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglMakeCurrent, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglQueryContext, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglQueryString, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglQuerySurface, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglSwapBuffers, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglTerminate, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglWaitGL, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglWaitNative, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglBindTexImage, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglReleaseTexImage, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglSurfaceAttrib, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglSwapInterval, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglBindAPI, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglQueryAPI, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreatePbufferFromClientBuffer, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglReleaseThread, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglWaitClient, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetCurrentContext, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreateSync, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglDestroySync, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglClientWaitSync, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetSyncAttrib, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreateImage, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglDestroyImage, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglGetPlatformDisplay, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreatePlatformWindowSurface, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglCreatePlatformPixmapSurface, egl);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(eglWaitSync, egl);
-  return nullptr;
-}
-
-// Helper function to look up GLES2 function pointers from the SbGlesInterface.
-gl::GLFunctionPointerType GetGlesInterfaceProcAddress(
-    const char* name,
-    const SbGlesInterface* gles) {
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glActiveTexture, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glAttachShader, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBindAttribLocation, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBindBuffer, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBindFramebuffer, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBindRenderbuffer, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBindTexture, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBlendColor, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBlendEquation, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBlendEquationSeparate, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBlendFunc, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBlendFuncSeparate, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBufferData, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glBufferSubData, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCheckFramebufferStatus, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glClear, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glClearColor, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glClearDepthf, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glClearStencil, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glColorMask, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCompileShader, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCompressedTexImage2D, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCompressedTexSubImage2D, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCopyTexImage2D, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCopyTexSubImage2D, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCreateProgram, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCreateShader, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glCullFace, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDeleteBuffers, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDeleteFramebuffers, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDeleteProgram, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDeleteRenderbuffers, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDeleteShader, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDeleteTextures, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDepthFunc, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDepthMask, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDepthRangef, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDetachShader, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDisable, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDisableVertexAttribArray, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDrawArrays, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glDrawElements, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glEnable, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glEnableVertexAttribArray, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glFinish, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glFlush, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glFramebufferRenderbuffer, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glFramebufferTexture2D, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glFrontFace, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGenBuffers, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGenerateMipmap, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGenFramebuffers, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGenRenderbuffers, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGenTextures, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetActiveAttrib, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetActiveUniform, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetAttachedShaders, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetAttribLocation, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetBooleanv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetBufferParameteriv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetError, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetFloatv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetFramebufferAttachmentParameteriv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetIntegerv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetProgramiv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetProgramInfoLog, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetRenderbufferParameteriv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetShaderiv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetShaderInfoLog, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetShaderPrecisionFormat, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetShaderSource, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetString, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetTexParameterfv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetTexParameteriv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetUniformfv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetUniformiv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetUniformLocation, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetVertexAttribfv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetVertexAttribiv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glGetVertexAttribPointerv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glHint, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glIsBuffer, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glIsEnabled, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glIsFramebuffer, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glIsProgram, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glIsRenderbuffer, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glIsShader, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glIsTexture, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glLineWidth, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glLinkProgram, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glPixelStorei, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glPolygonOffset, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glReadPixels, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glReleaseShaderCompiler, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glRenderbufferStorage, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glSampleCoverage, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glScissor, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glShaderBinary, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glShaderSource, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glStencilFunc, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glStencilFuncSeparate, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glStencilMask, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glStencilMaskSeparate, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glStencilOp, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glStencilOpSeparate, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glTexImage2D, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glTexParameterf, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glTexParameterfv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glTexParameteri, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glTexParameteriv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glTexSubImage2D, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform1f, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform1fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform1i, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform1iv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform2f, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform2fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform2i, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform2iv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform3f, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform3fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform3i, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform3iv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform4f, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform4fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform4i, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniform4iv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniformMatrix2fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniformMatrix3fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUniformMatrix4fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glUseProgram, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glValidateProgram, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttrib1f, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttrib1fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttrib2f, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttrib2fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttrib3f, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttrib3fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttrib4f, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttrib4fv, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glVertexAttribPointer, gles);
-  GET_INTERFACE_PROC_ADDRESS_ENTRY(glViewport, gles);
-  return nullptr;
-}
 
 GLOzoneEGLStarboard::GLOzoneEGLStarboard() = default;
 
@@ -252,58 +41,17 @@ scoped_refptr<gl::GLSurface> GLOzoneEGLStarboard::CreateOffscreenGLSurface(
 }
 
 gl::EGLDisplayPlatform GLOzoneEGLStarboard::GetNativeDisplay() {
-  CreateDisplayTypeIfNeeded();
-  return gl::EGLDisplayPlatform(
-      reinterpret_cast<EGLNativeDisplayType>(display_type_));
+  void* native_display = SbGetNativeEGLDisplayType();
+  if (native_display) {
+    return gl::EGLDisplayPlatform(
+        reinterpret_cast<EGLNativeDisplayType>(native_display));
+  }
+  return gl::EGLDisplayPlatform(EGL_DEFAULT_DISPLAY);
 }
 
 bool GLOzoneEGLStarboard::LoadGLES2Bindings(
     const gl::GLImplementationParts& implementation) {
-  DCHECK_EQ(implementation.gl, gl::kGLImplementationEGLANGLE)
-      << "Not supported: " << implementation.ToString();
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
-  gl::GLGetProcAddressProc gl_proc =
-      [](const char* name) -> gl::GLFunctionPointerType {
-    // Retrieve EGL core functions from the SbEglInterface, since
-    // some EGL functions might be overridden by the Starboard
-    // implementation. If that fails then fallback on direct call to
-    // eglGetProcAddress.
-    const SbEglInterface* egl = SbGetEglInterface();
-    gl::GLFunctionPointerType proc = GetEglInterfaceProcAddress(name, egl);
-    if (proc) {
-      return proc;
-    }
-
-    proc = reinterpret_cast<gl::GLFunctionPointerType>(
-        SbGetEglInterface()->eglGetProcAddress(name));
-    if (proc) {
-      return proc;
-    }
-
-    // If still not found, try to retrieve GLES2 functions directly from the
-    // SbGlesInterface as a fallback.
-    const SbGlesInterface* gles = SbGetGlesInterface();
-    return GetGlesInterfaceProcAddress(name, gles);
-  };
-#else
-  gl::GLGetProcAddressProc gl_proc = reinterpret_cast<gl::GLGetProcAddressProc>(
-      SbGetEglInterface()->eglGetProcAddress);
-#endif
-
-  if (!gl_proc) {
-    LOG(ERROR) << "GLOzoneEglStarboard::LoadGLES2Bindings no gl_proc";
-    return false;
-  }
-
-  gl::SetGLGetProcAddressProc(gl_proc);
-  return true;
-}
-
-void GLOzoneEGLStarboard::CreateDisplayTypeIfNeeded() {
-  if (!have_display_type_) {
-    display_type_ = reinterpret_cast<void*>(SB_EGL_DEFAULT_DISPLAY);
-    have_display_type_ = true;
-  }
+  return LoadDefaultEGLGLES2Bindings(implementation);
 }
 
 }  // namespace ui

--- a/ui/ozone/platform/starboard/gl_ozone_egl_starboard.h
+++ b/ui/ozone/platform/starboard/gl_ozone_egl_starboard.h
@@ -39,12 +39,6 @@ class GLOzoneEGLStarboard : public GLOzoneEGL {
   gl::EGLDisplayPlatform GetNativeDisplay() override;
   bool LoadGLES2Bindings(
       const gl::GLImplementationParts& implementation) override;
-
- private:
-  void CreateDisplayTypeIfNeeded();
-
-  void* display_type_ = nullptr;
-  bool have_display_type_ = false;
 };
 
 }  // namespace ui


### PR DESCRIPTION
Switch the Ozone Starboard implementation from direct EGL/GLES calls
to use ANGLE for function resolution.

Introduce SbGetNativeEGLDisplayType() to expose the platform's native
EGL display type. This allows ANGLE's native backend to correctly share
the platform display connection, resolving a GPU thread segfault
experienced on RDK/Wayland. This also removes custom manual lookups for
EGL/GLES function pointers, simplifying the graphics initialization.

Bug: 486053854