### PR TITLE
adding UMA for local storage DeleteAndRecreateDatabase()

### DIFF
--- a/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/components/services/storage/dom_storage/local_storage_impl.cc
@@ -560,7 +560,7 @@ void LocalStorageImpl::OnDatabaseOpened(leveldb::Status status) {
   if (!status.ok()) {
     // If we failed to open the database, try to delete and recreate the
     // database, or ultimately fallback to an in-memory database.
-    DeleteAndRecreateDatabase();
+    DeleteAndRecreateDatabase(DatabaseResetReason::kOpenFailed);
     return;
   }
 
@@ -588,14 +588,14 @@ void LocalStorageImpl::OnGotDatabaseVersion(leveldb::Status status,
                              &db_version) ||
         db_version < kMinSchemaVersion ||
         db_version > kCurrentLocalStorageSchemaVersion) {
-      DeleteAndRecreateDatabase();
+      DeleteAndRecreateDatabase(DatabaseResetReason::kVersionMismatch);
       return;
     }
 
     database_initialized_ = true;
   } else {
     // Other read error. Possibly database corruption.
-    DeleteAndRecreateDatabase();
+    DeleteAndRecreateDatabase(DatabaseResetReason::kReadError);
     return;
   }
 
@@ -620,7 +620,9 @@ void LocalStorageImpl::OnConnectionFinished() {
   on_database_opened_callbacks_.clear();
 }
 
-void LocalStorageImpl::DeleteAndRecreateDatabase() {
+void LocalStorageImpl::DeleteAndRecreateDatabase(
+    DatabaseResetReason reason /*= DatabaseResetReason::kUnknown*/) {
+  UMA_HISTOGRAM_ENUMERATION("Cobalt.LocalStorage.DatabaseResetReason", reason);
   if (connection_state_ == CONNECTION_SHUTDOWN)
     return;
 
@@ -822,7 +824,7 @@ void LocalStorageImpl::OnCommitResult(leveldb::Status status) {
     // Deleting StorageAreas in here could cause more commits (and commit
     // errors), but those commits won't reach OnCommitResult because the area
     // will have been deleted before the commit finishes.
-    DeleteAndRecreateDatabase();
+    DeleteAndRecreateDatabase(DatabaseResetReason::kCommitError);
   }
 }
 

--- a/components/services/storage/dom_storage/local_storage_impl.h
+++ b/components/services/storage/dom_storage/local_storage_impl.h
@@ -118,7 +118,18 @@ class LocalStorageImpl : public base::trace_event::MemoryDumpProvider,
   void OnGotDatabaseVersion(leveldb::Status status,
                             const std::vector<uint8_t>& value);
   void OnConnectionFinished();
-  void DeleteAndRecreateDatabase();
+
+  enum class DatabaseResetReason {
+    kOpenFailed,
+    kVersionMismatch,
+    kReadError,
+    kCommitError,
+    kUnknown,
+    kMaxValue = kUnknown,
+  };
+
+  void DeleteAndRecreateDatabase(DatabaseResetReason reason =
+                                     DatabaseResetReason::kUnknown);
   void OnDBDestroyed(bool recreate_in_memory, leveldb::Status status);
 
   StorageAreaHolder* GetOrCreateStorageArea(

--- a/tools/metrics/histograms/metadata/cobalt/enums.xml
+++ b/tools/metrics/histograms/metadata/cobalt/enums.xml
@@ -54,6 +54,14 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="7" label="Parse error"/>
 </enum>
 
+<enum name="LocalStorageDatabaseResetReason">
+  <int value="0" label="Failure to open the database"/>
+  <int value="1" label="Schema version mismatch"/>
+  <int value="2" label="Database corruption or read errors"/>
+  <int value="3" label="Excessive commit errors"/>
+  <int value="4" label="Unknown"/>
+</enum>
+
 </enums>
 
 </histogram-configuration>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -145,7 +145,7 @@ Always run the pretty print utility on this file after editing:
 
 <histogram name="Cobalt.LocalStorage.DatabaseResetReason"
     enum="LocalStorageDatabaseResetReason" expires_after="never">
-  <owner>me@chromium.org</owner>
+  <owner>charleykim@google.com</owner>
   <summary>
     Records the reason why the Local Storage database was reset.
   </summary>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -143,6 +143,14 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.LocalStorage.DatabaseResetReason"
+    enum="LocalStorageDatabaseResetReason" expires_after="never">
+  <owner>me@chromium.org</owner>
+  <summary>
+    Records the reason why the Local Storage database was reset.
+  </summary>
+</histogram>
+
 </histograms>
 
 </histogram-configuration>


### PR DESCRIPTION
Adding an enum UMA histogram to `components/services/storage/dom_storage/local_storage_impl.cc` in order to determine the reason `DeleteAndRecreateDatabase()` gets called.

Bug: 489511488