### PR TITLE
Reduce crashpad ERROR log noise on RDK target

### DIFF
--- a/third_party/crashpad/crashpad/client/crash_report_database.cc
+++ b/third_party/crashpad/crashpad/client/crash_report_database.cc
@@ -122,6 +122,9 @@ FileWriter* CrashReportDatabase::NewReport::AddAttachment(
 
 void CrashReportDatabase::UploadReport::InitializeAttachments() {
   base::FilePath report_attachments_dir = database_->AttachmentsPath(uuid);
+  if (!IsDirectory(report_attachments_dir, /*allow_symlinks=*/false)) {
+    return;
+  }
   DirectoryReader dir_reader;
   if (!dir_reader.Open(report_attachments_dir)) {
     return;

--- a/third_party/crashpad/crashpad/snapshot/elf/elf_image_reader.cc
+++ b/third_party/crashpad/crashpad/snapshot/elf/elf_image_reader.cc
@@ -519,7 +519,7 @@ bool ElfImageReader::SoName(std::string* name) {
   }
 
   VMSize offset;
-  if (!dynamic_array_->GetValue(DT_SONAME, true, &offset)) {
+  if (!dynamic_array_->GetValue(DT_SONAME, false, &offset)) {
     return false;
   }
 


### PR DESCRIPTION
Two small crashpad fixes to avoid spurious ERROR logs when running tests (e.g. `boringssl_ssl_tests`) on the target device.

- **elf_image_reader.cc**: Suppress logging when `DT_SONAME` is missing. This tag is optional for ELF objects (vdso, main executable); the caller already falls back to `entry.name`.
- **crash_report_database.cc**: Check that the per-report attachments directory exists before calling `opendir`. Reports without attachments have no such directory; the code already handles the missing-dir case, so avoid logging an error.

**No behavior change**; tests still pass. Log output is cleaner.

Bug: 486053854