### PR TITLE
cobalt: Limit deep link URL parser depth

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -275,6 +275,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/metrics/cobalt_metrics_services_manager_client_test.cc",
     "//cobalt/browser/user_agent/user_agent_platform_info_test.cc",
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_unittest.cc",
+    "//cobalt/shell/browser/shell_unittest.cc",
   ]
 
   if (is_starboard) {

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -94,9 +94,18 @@ namespace {
 
 constexpr char kMusicTopic[] = "music";
 
+// The maximum number of redirects to follow when parsing a deep link.
+constexpr int kMaxDeepLinkRedirectDepth = 10;
+
 // Helper function to check if a URL is a valid deep link for a specific topic.
 // It requires both a "launch" parameter and a matching "topic" parameter.
-bool IsDeepLinkTopic(const GURL& link_url, std::string_view target_topic) {
+bool IsDeepLinkTopic(const GURL& link_url,
+                     std::string_view target_topic,
+                     int depth = 0) {
+  if (depth > kMaxDeepLinkRedirectDepth) {
+    return false;
+  }
+
   if (!link_url.is_valid() || !link_url.has_query()) {
     return false;
   }
@@ -131,7 +140,8 @@ bool IsDeepLinkTopic(const GURL& link_url, std::string_view target_topic) {
   // Check for nested deep link in "redirect" parameter.
   for (net::QueryIterator it(link_url); !it.IsAtEnd(); it.Advance()) {
     if (it.GetKey() == "redirect") {
-      if (IsDeepLinkTopic(GURL(it.GetUnescapedValue()), target_topic)) {
+      if (IsDeepLinkTopic(GURL(it.GetUnescapedValue()), target_topic,
+                          depth + 1)) {
         return true;
       }
     }
@@ -336,6 +346,12 @@ void Shell::SetShellCreatedCallback(
 bool Shell::ShouldHideToolbar() {
   return base::CommandLine::ForCurrentProcess()->HasSwitch(
       switches::kContentShellHideToolbar);
+}
+
+// static
+bool Shell::IsDeepLinkTopicForTesting(const GURL& link_url,
+                                      std::string_view target_topic) {
+  return IsDeepLinkTopic(link_url, target_topic);
 }
 
 // static

--- a/cobalt/shell/browser/shell.h
+++ b/cobalt/shell/browser/shell.h
@@ -19,6 +19,7 @@
 
 #include <memory>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "base/functional/callback_forward.h"
@@ -118,6 +119,9 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
       base::OnceCallback<void(Shell*)> shell_created_callback);
 
   static bool ShouldHideToolbar();
+
+  static bool IsDeepLinkTopicForTesting(const GURL& link_url,
+                                        std::string_view target_topic);
 
   WebContents* web_contents() const { return web_contents_.get(); }
 

--- a/cobalt/shell/browser/shell_unittest.cc
+++ b/cobalt/shell/browser/shell_unittest.cc
@@ -1,0 +1,82 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/shell/browser/shell.h"
+
+#include "net/base/url_util.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace content {
+
+TEST(ShellTest, IsDeepLinkTopicBasic) {
+  // Test basic true case.
+  EXPECT_TRUE(Shell::IsDeepLinkTopicForTesting(
+      GURL("http://example.com?launch=true&topic=music"), "music"));
+
+  // Test different order.
+  EXPECT_TRUE(Shell::IsDeepLinkTopicForTesting(
+      GURL("http://example.com?topic=music&launch=true"), "music"));
+
+  // Test multiple topics.
+  EXPECT_TRUE(Shell::IsDeepLinkTopicForTesting(
+      GURL("http://example.com?topic=foo&topic=music&launch=true"), "music"));
+
+  // Test missing launch.
+  EXPECT_FALSE(Shell::IsDeepLinkTopicForTesting(
+      GURL("http://example.com?topic=music"), "music"));
+
+  // Test missing topic.
+  EXPECT_FALSE(Shell::IsDeepLinkTopicForTesting(
+      GURL("http://example.com?launch=true"), "music"));
+
+  // Test incorrect topic.
+  EXPECT_FALSE(Shell::IsDeepLinkTopicForTesting(
+      GURL("http://example.com?launch=true&topic=video"), "music"));
+}
+
+TEST(ShellTest, IsDeepLinkTopicRedirect) {
+  // Test single redirect
+  GURL inner_url("http://example.com?launch=true&topic=music");
+  GURL redirect_url = net::AppendQueryParameter(GURL("http://example.com"),
+                                                "redirect", inner_url.spec());
+  EXPECT_TRUE(Shell::IsDeepLinkTopicForTesting(redirect_url, "music"));
+
+  // Test escaped redirect url
+  EXPECT_TRUE(Shell::IsDeepLinkTopicForTesting(
+      GURL("http://"
+           "example.com?loader=example&redirect=http%3A%2F%2Fexample.com%"
+           "3Flaunch%3Dmenu%26topic%3Dmusic"),
+      "music"));
+}
+
+TEST(ShellTest, IsDeepLinkTopicMaxDepth) {
+  GURL url("http://example.com?launch=true&topic=music");
+
+  // Create a URL with 10 layers of redirects
+  for (int i = 0; i < 10; ++i) {
+    url = net::AppendQueryParameter(GURL("http://example.com"), "redirect",
+                                    url.spec());
+  }
+  // Depth 10 should be allowed.
+  EXPECT_TRUE(Shell::IsDeepLinkTopicForTesting(url, "music"));
+
+  // Add 1 more layer of redirect to exceed max depth (11).
+  url = net::AppendQueryParameter(GURL("http://example.com"), "redirect",
+                                  url.spec());
+  // Should fail because depth exceeds kMaxDeepLinkRedirectDepth (10).
+  EXPECT_FALSE(Shell::IsDeepLinkTopicForTesting(url, "music"));
+}
+
+}  // namespace content


### PR DESCRIPTION
Introduce a maximum recursion depth for parsing deep link URLs that
contain nested "redirect" parameters. This prevents excessive resource
consumption or potential infinite loops when processing malformed or
maliciously crafted deep links. A new unit test verifies the depth
limit functionality.

Issue: 490412410
Issue: 489756553