### PR TITLE
media: Make preroll logic consider pending input

### DIFF
--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -19,11 +19,16 @@
 #include <limits>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <utility>
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/string.h"
 #include "starboard/common/time.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include <sys/system_properties.h>
+#endif
 
 namespace starboard::shared::starboard::player::filter {
 
@@ -44,7 +49,9 @@ VideoRendererImpl::VideoRendererImpl(
     : media_time_provider_(media_time_provider),
       algorithm_(std::move(algorithm)),
       sink_(sink),
-      decoder_(std::move(decoder)) {
+      decoder_(std::move(decoder)),
+      // TODO: b/485225923 - Connect this to h5vcc settings.
+      preroll_params_(std::nullopt) {
   SB_CHECK(decoder_);
   SB_CHECK(algorithm_);
   SB_DCHECK_GT(decoder_->GetMaxNumberOfCachedFrames(), 1U);
@@ -130,6 +137,7 @@ void VideoRendererImpl::WriteSamples(const InputBuffers& input_buffers) {
   SB_DCHECK(need_more_input_.load());
   need_more_input_.store(false);
 
+  input_buffers_sent_.fetch_add(static_cast<int32_t>(input_buffers.size()));
   decoder_->WriteInputBuffers(input_buffers);
 }
 
@@ -161,6 +169,7 @@ void VideoRendererImpl::Seek(int64_t seek_to_time) {
   // WriteSample().  So it is safe to modify |seeking_to_time_| here.
   seeking_to_time_ = std::max<int64_t>(seek_to_time, 0);
   seeking_.store(true);
+  input_buffers_sent_.store(0);
   end_of_stream_written_.store(false);
   end_of_stream_decoded_.store(false);
   ended_cb_called_.store(false);
@@ -281,14 +290,25 @@ void VideoRendererImpl::OnDecoderStatus(
       }
     }
 
-    if (number_of_frames_.load() >=
-            static_cast<int32_t>(decoder_->GetPrerollFrameCount()) &&
-        seeking_.exchange(false)) {
+    bool preroll_completed = false;
+    if (preroll_params_) {
+      preroll_completed =
+          input_buffers_sent_.load() >= preroll_params_->min_input_buffers &&
+          number_of_frames_.load() >= preroll_params_->min_decoded_frames;
+    } else {
+      preroll_completed =
+          number_of_frames_.load() >=
+          static_cast<int32_t>(decoder_->GetPrerollFrameCount());
+    }
+
+    if (preroll_completed && seeking_.exchange(false)) {
 #if SB_PLAYER_FILTER_ENABLE_STATE_CHECK
-      SB_LOG(INFO) << "Video preroll takes "
-                   << FormatWithDigitSeparators(CurrentMonotonicTime() -
-                                                first_input_written_at_)
-                   << " microseconds.";
+      SB_LOG(INFO) << "Video preroll complete: elapsed(msec)="
+                   << FormatWithDigitSeparators(
+                          (CurrentMonotonicTime() - first_input_written_at_) /
+                          1'000)
+                   << ", input_buffers_sent=" << input_buffers_sent_.load()
+                   << ", decoded_frames=" << number_of_frames_.load();
 #endif  // SB_PLAYER_FILTER_ENABLE_STATE_CHECK
       Schedule(prerolled_cb_);
     }
@@ -355,6 +375,11 @@ void VideoRendererImpl::OnSeekTimeout() {
   SB_DCHECK(BelongsToCurrentThread());
   if (number_of_frames_.load() > 0) {
     if (seeking_.exchange(false)) {
+#if SB_PLAYER_FILTER_ENABLE_STATE_CHECK
+      SB_LOG(INFO) << "Video preroll timeout:"
+                   << " input_buffers_sent=" << input_buffers_sent_.load()
+                   << ", decoded_frames=" << number_of_frames_.load();
+#endif  // SB_PLAYER_FILTER_ENABLE_STATE_CHECK
       Schedule(prerolled_cb_);
     }
   } else if (seeking_.load()) {

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -26,10 +26,6 @@
 #include "starboard/common/string.h"
 #include "starboard/common/time.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include <sys/system_properties.h>
-#endif
-
 namespace starboard::shared::starboard::player::filter {
 
 namespace {

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -85,8 +85,8 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   scoped_refptr<VideoRendererSink> sink_;
   std::unique_ptr<VideoDecoder> decoder_;
   struct PrerollParameters {
-    int min_input_buffers;
-    int min_decoded_frames;
+    int32_t min_input_buffers;
+    int32_t min_decoded_frames;
   };
   const std::optional<PrerollParameters> preroll_params_;
 

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -19,6 +19,7 @@
 #include <list>
 #include <memory>
 #include <mutex>
+#include <optional>
 
 #include "starboard/common/log.h"
 #include "starboard/common/ref_counted.h"
@@ -83,6 +84,11 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   const std::unique_ptr<VideoRenderAlgorithm> algorithm_;
   scoped_refptr<VideoRendererSink> sink_;
   std::unique_ptr<VideoDecoder> decoder_;
+  struct PrerollParameters {
+    int min_input_buffers;
+    int min_decoded_frames;
+  };
+  const std::optional<PrerollParameters> preroll_params_;
 
   PrerolledCB prerolled_cb_;
   EndedCB ended_cb_;
@@ -99,6 +105,7 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
 
   std::atomic_bool need_more_input_{true};
   std::atomic_bool seeking_{false};
+  std::atomic<int32_t> input_buffers_sent_{0};
   int64_t seeking_to_time_ = 0;  // microseconds
 
   // |number_of_frames_| = decoder_frames_.size() + sink_frames_.size()


### PR DESCRIPTION
Modify video preroll completion criteria to consider both the number of input buffers provided to the decoder and the count of decoded frames.

Previously, preroll completed solely based on the number of decoded frames. This change introduces new configuration options to require a minimum number of input buffers alongside decoded frames, offering
a more robust and flexible preroll readiness check. This helps ensure sufficient data has been processed before playback begins.

Local test showed, by considering pending input, we can achieve the better Time-to-first-frame time. For the test result, see http://b/485225923#comment2

Bug: 485225923