### PR TITLE
starboard: Add ToString helpers for bool and std::optional

### DIFF
--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -179,10 +179,8 @@ MediaDecoder::MediaDecoder(
     return;
   }
   SB_LOG(INFO) << "MediaDecoder is created: tunnel_mode_enabled="
-               << (tunnel_mode_enabled_ ? "true" : "false")
-               << ", initial_max_frames="
-               << (initial_max_frames ? std::to_string(*initial_max_frames)
-                                      : "(nullopt)")
+               << ToString(tunnel_mode_enabled_)
+               << ", initial_max_frames=" << ToString(initial_max_frames)
                << ", video_decoder_poll_interval(msec)="
                << video_decoder_poll_interval_us_ / 1'000;
 }

--- a/starboard/common/string.h
+++ b/starboard/common/string.h
@@ -60,6 +60,10 @@ std::string ToString(const T& val) {
   return ss.str();
 }
 
+inline std::string ToString(const std::string& val) {
+  return val;
+}
+
 inline std::string ToString(bool val) {
   return val ? "true" : "false";
 }

--- a/starboard/common/string.h
+++ b/starboard/common/string.h
@@ -23,6 +23,7 @@
 #include <stdio.h>
 
 #include <cstring>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -57,6 +58,18 @@ std::string ToString(const T& val) {
   std::stringstream ss;
   ss << val;
   return ss.str();
+}
+
+inline std::string ToString(bool val) {
+  return val ? "true" : "false";
+}
+
+template <typename T>
+std::string ToString(const std::optional<T>& val) {
+  if (!val) {
+    return "(nullopt)";
+  }
+  return ToString(*val);
 }
 
 std::string HexEncode(const void* data,

--- a/starboard/common/string_test.cc
+++ b/starboard/common/string_test.cc
@@ -172,5 +172,40 @@ TEST(StringTest, FormatWithDigitSeparators_Negative) {
   EXPECT_EQ("-123'456'789", FormatWithDigitSeparators(-123456789));
 }
 
+TEST(StringTest, ToString_Bool) {
+  EXPECT_EQ("true", ToString(true));
+  EXPECT_EQ("false", ToString(false));
+}
+
+TEST(StringTest, ToString_Optional) {
+  std::optional<int> opt_int;
+  EXPECT_EQ("(nullopt)", ToString(opt_int));
+
+  opt_int = 42;
+  EXPECT_EQ("42", ToString(opt_int));
+
+  std::optional<std::string> opt_str;
+  EXPECT_EQ("(nullopt)", ToString(opt_str));
+
+  opt_str = "hello";
+  EXPECT_EQ("hello", ToString(opt_str));
+
+  std::optional<bool> opt_bool;
+  EXPECT_EQ("(nullopt)", ToString(opt_bool));
+
+  opt_bool = true;
+  EXPECT_EQ("true", ToString(opt_bool));
+
+  opt_bool = false;
+  EXPECT_EQ("false", ToString(opt_bool));
+}
+
+TEST(StringTest, ToString_Generic) {
+  EXPECT_EQ("123", ToString(123));
+  EXPECT_EQ("3.14", ToString(3.14));
+  EXPECT_EQ("test", ToString("test"));
+  EXPECT_EQ("test", ToString(std::string("test")));
+}
+
 }  // namespace
 }  // namespace starboard

--- a/starboard/shared/starboard/media/mime_supportability_cache.cc
+++ b/starboard/shared/starboard/media/mime_supportability_cache.cc
@@ -23,6 +23,7 @@
 
 #include "starboard/common/log.h"
 #include "starboard/common/media.h"
+#include "starboard/common/string.h"
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/once.h"
@@ -256,7 +257,7 @@ void MimeSupportabilityCache::DumpCache() {
         ss << "\n    Height : " << video_info.frame_height;
         ss << "\n    Fps : " << video_info.fps;
         ss << "\n    DecodeToTexture : "
-           << (video_info.decode_to_texture_required ? "true" : "false");
+           << ToString(video_info.decode_to_texture_required);
       }
     } else {
       ss << "\n    Mime info is not valid";

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -578,52 +578,40 @@ void FilterBasedPlayerWorkerHandler::SetVideoSurfaceView(void* surface_view) {
 void FilterBasedPlayerWorkerHandler::SetVideoInitialMaxFramesInDecoder(
     int video_initial_max_frames_in_decoder) {
   SB_LOG(INFO) << "Set video_initial_max_frames_in_decoder from "
-               << (video_initial_max_frames_in_decoder_.has_value()
-                       ? std::to_string(
-                             video_initial_max_frames_in_decoder_.value())
-                       : "(nullopt)")
-               << " to " << video_initial_max_frames_in_decoder;
+               << ToString(video_initial_max_frames_in_decoder_) << " to "
+               << video_initial_max_frames_in_decoder;
   video_initial_max_frames_in_decoder_ = video_initial_max_frames_in_decoder;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoMaxPendingInputFrames(
     int video_max_pending_input_frames) {
   SB_LOG(INFO) << "Set video_max_pending_input_frames from "
-               << (video_max_pending_input_frames_.has_value()
-                       ? std::to_string(video_max_pending_input_frames_.value())
-                       : "(nullopt)")
-               << " to " << video_max_pending_input_frames;
+               << ToString(video_max_pending_input_frames_) << " to "
+               << video_max_pending_input_frames;
   video_max_pending_input_frames_ = video_max_pending_input_frames;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoDecoderInitialPrerollCount(
     int video_decoder_initial_preroll_count) {
   SB_LOG(INFO) << "Set video_decoder_initial_preroll_count from "
-               << (video_decoder_initial_preroll_count_.has_value()
-                       ? std::to_string(
-                             video_decoder_initial_preroll_count_.value())
-                       : "(nullopt)")
-               << " to " << video_decoder_initial_preroll_count;
+               << ToString(video_decoder_initial_preroll_count_) << " to "
+               << video_decoder_initial_preroll_count;
   video_decoder_initial_preroll_count_ = video_decoder_initial_preroll_count;
 }
 
 void FilterBasedPlayerWorkerHandler::SetVideoDecoderPollIntervalMs(
     int video_decoder_poll_interval_ms) {
   SB_LOG(INFO) << "Set video_decoder_poll_interval_ms from "
-               << (video_decoder_poll_interval_ms_.has_value()
-                       ? std::to_string(video_decoder_poll_interval_ms_.value())
-                       : "(nullopt)")
-               << " to " << video_decoder_poll_interval_ms;
+               << ToString(video_decoder_poll_interval_ms_) << " to "
+               << video_decoder_poll_interval_ms;
   video_decoder_poll_interval_ms_ = video_decoder_poll_interval_ms;
 }
 
 void FilterBasedPlayerWorkerHandler::SetMediaCodecResetDelayMs(
     int media_codec_reset_delay_ms) {
   SB_LOG(INFO) << "Set media_codec_reset_delay_ms from "
-               << (media_codec_reset_delay_ms_.has_value()
-                       ? std::to_string(media_codec_reset_delay_ms_.value())
-                       : "(nullopt)")
-               << " to " << media_codec_reset_delay_ms;
+               << ToString(media_codec_reset_delay_ms_) << " to "
+               << media_codec_reset_delay_ms;
   media_codec_reset_delay_ms_ = media_codec_reset_delay_ms;
 }
 


### PR DESCRIPTION
Introduce ToString helpers in starboard/common/string.h to simplify logging of boolean and std::optional values. This refactors redundant ternary operators at various logging sites to use the new helpers, improving code readability and consistency across the codebase.

Bug: 490453801