### PR TITLE
media: Connect video renderer preroll parameters from H5VCC settings

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -53,6 +53,10 @@ const char kH5vccSettingsKeyMediaVideoDecoderInitialPrerollCount[] =
     "Media.VideoDecoderInitialPrerollCount";
 const char kH5vccSettingsKeyMediaVideoDecoderPollIntervalMs[] =
     "Media.VideoDecoderPollIntervalMs";
+const char kH5vccSettingsKeyMediaVideoRendererMinInputBuffers[] =
+    "Media.VideoRendererMinInputBuffers";
+const char kH5vccSettingsKeyMediaVideoRendererMinDecodedFrames[] =
+    "Media.VideoRendererMinDecodedFrames";
 const char kH5vccSettingsKeyMediaMaxSamplesPerWrite[] =
     "Media.MaxSamplesPerWrite";
 const char kH5vccSettingsKeyMediaMediaCodecResetDelayMs[] =
@@ -239,6 +243,12 @@ ExperimentalFeatures ProcessH5vccSettings(
   parsed.video_decoder_poll_interval_ms = ProcessRangedIntH5vccSetting(
       settings, kH5vccSettingsKeyMediaVideoDecoderPollIntervalMs, /*min_val=*/1,
       kMaxVideoDecoderPollIntervalMs, kH5vccUnsetSentinel);
+  parsed.video_renderer_min_input_buffers = ProcessRangedIntH5vccSetting(
+      settings, kH5vccSettingsKeyMediaVideoRendererMinInputBuffers,
+      /*min_val=*/1, /*max_val=*/100'000, kH5vccUnsetSentinel);
+  parsed.video_renderer_min_decoded_frames = ProcessRangedIntH5vccSetting(
+      settings, kH5vccSettingsKeyMediaVideoRendererMinDecodedFrames,
+      /*min_val=*/1, /*max_val=*/100'000, kH5vccUnsetSentinel);
   parsed.max_samples_per_write = ProcessRangedIntH5vccSetting(
       settings, kH5vccSettingsKeyMediaMaxSamplesPerWrite, /*min_val=*/1,
       /*max_val=*/100'000, kH5vccUnsetSentinel);

--- a/media/base/ipc/media_param_traits_macros.h
+++ b/media/base/ipc/media_param_traits_macros.h
@@ -234,6 +234,8 @@ IPC_STRUCT_TRAITS_BEGIN(media::StarboardRendererConfig::ExperimentalFeatures)
   IPC_STRUCT_TRAITS_MEMBER(max_samples_per_write)
   IPC_STRUCT_TRAITS_MEMBER(video_decoder_initial_preroll_count)
   IPC_STRUCT_TRAITS_MEMBER(video_decoder_poll_interval_ms)
+  IPC_STRUCT_TRAITS_MEMBER(video_renderer_min_input_buffers)
+  IPC_STRUCT_TRAITS_MEMBER(video_renderer_min_decoded_frames)
   IPC_STRUCT_TRAITS_MEMBER(media_codec_reset_delay_ms)
 IPC_STRUCT_TRAITS_END()
 

--- a/media/base/starboard/starboard_renderer_config.cc
+++ b/media/base/starboard/starboard_renderer_config.cc
@@ -55,6 +55,10 @@ std::ostream& operator<<(
             << opt_to_string(features.video_decoder_initial_preroll_count)
             << ", video_decoder_poll_interval_ms="
             << opt_to_string(features.video_decoder_poll_interval_ms)
+            << ", video_renderer_min_input_buffers="
+            << opt_to_string(features.video_renderer_min_input_buffers)
+            << ", video_renderer_min_decoded_frames="
+            << opt_to_string(features.video_renderer_min_decoded_frames)
             << ", media_codec_reset_delay_ms="
             << opt_to_string(features.media_codec_reset_delay_ms) << "}";
 }

--- a/media/base/starboard/starboard_renderer_config.h
+++ b/media/base/starboard/starboard_renderer_config.h
@@ -36,6 +36,8 @@ struct MEDIA_EXPORT StarboardRendererConfig {
     std::optional<int> max_samples_per_write;
     std::optional<int> video_decoder_initial_preroll_count;
     std::optional<int> video_decoder_poll_interval_ms;
+    std::optional<int> video_renderer_min_input_buffers;
+    std::optional<int> video_renderer_min_decoded_frames;
     std::optional<int> media_codec_reset_delay_ms;
   };
 

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -230,6 +230,8 @@ SbPlayerBridge::SbPlayerBridge(
     std::optional<int> max_pending_input_frames,
     std::optional<int> video_decoder_initial_preroll_count,
     std::optional<int> video_decoder_poll_interval_ms,
+    std::optional<int> video_renderer_min_input_buffers,
+    std::optional<int> video_renderer_min_decoded_frames,
     std::optional<int> media_codec_reset_delay_ms
 #if BUILDFLAG(IS_ANDROID)
     ,
@@ -263,6 +265,8 @@ SbPlayerBridge::SbPlayerBridge(
       max_pending_input_frames_(max_pending_input_frames),
       video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
       video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
+      video_renderer_min_input_buffers_(video_renderer_min_input_buffers),
+      video_renderer_min_decoded_frames_(video_renderer_min_decoded_frames),
       media_codec_reset_delay_ms_(media_codec_reset_delay_ms)
 #if BUILDFLAG(IS_ANDROID)
       ,
@@ -854,6 +858,16 @@ void SbPlayerBridge::CreatePlayer() {
       video_decoder_configuration_extension
           ->SetVideoDecoderPollIntervalMsForCurrentThread(
               *video_decoder_poll_interval_ms_);
+    }
+    if (video_renderer_min_input_buffers_) {
+      video_decoder_configuration_extension
+          ->SetVideoRendererMinInputBuffersForCurrentThread(
+              *video_renderer_min_input_buffers_);
+    }
+    if (video_renderer_min_decoded_frames_) {
+      video_decoder_configuration_extension
+          ->SetVideoRendererMinDecodedFramesForCurrentThread(
+              *video_renderer_min_decoded_frames_);
     }
     if (media_codec_reset_delay_ms_) {
       video_decoder_configuration_extension

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -112,6 +112,8 @@ class SbPlayerBridge {
                  std::optional<int> max_pending_input_frames,
                  std::optional<int> video_decoder_initial_preroll_count,
                  std::optional<int> video_decoder_poll_interval_ms,
+                 std::optional<int> video_renderer_min_input_buffers,
+                 std::optional<int> video_renderer_min_decoded_frames,
                  std::optional<int> media_codec_reset_delay_ms
 #if BUILDFLAG(IS_ANDROID)
                  ,
@@ -354,6 +356,8 @@ class SbPlayerBridge {
   const std::optional<int> max_pending_input_frames_;
   const std::optional<int> video_decoder_initial_preroll_count_;
   const std::optional<int> video_decoder_poll_interval_ms_;
+  const std::optional<int> video_renderer_min_input_buffers_;
+  const std::optional<int> video_renderer_min_decoded_frames_;
   const std::optional<int> media_codec_reset_delay_ms_;
 
 #if BUILDFLAG(IS_ANDROID)

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -624,6 +624,8 @@ void StarboardRenderer::CreatePlayerBridge() {
         experimental_features_.max_pending_input_frames,
         experimental_features_.video_decoder_initial_preroll_count,
         experimental_features_.video_decoder_poll_interval_ms,
+        experimental_features_.video_renderer_min_input_buffers,
+        experimental_features_.video_renderer_min_decoded_frames,
         experimental_features_.media_codec_reset_delay_ms
 #if BUILDFLAG(IS_ANDROID)
         ,

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -84,13 +84,11 @@ std::optional<VideoRendererImpl::PrerollParameters> GetPrerollParams(
   if (!min_input_buffers && !min_decoded_frames) {
     return std::nullopt;
   }
-
   if (!min_input_buffers) {
     SB_LOG(WARNING) << "Ignoring video_renderer_min_decoded_frames since "
                        "video_renderer_min_input_buffers is missing.";
     return std::nullopt;
   }
-
   if (!min_decoded_frames) {
     SB_LOG(WARNING) << "Ignoring video_renderer_min_input_buffers since "
                        "video_renderer_min_decoded_frames is missing.";

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -55,6 +55,8 @@
 namespace starboard::android::shared {
 
 namespace {
+using ::starboard::shared::starboard::player::filter::PlayerComponents;
+using ::starboard::shared::starboard::player::filter::VideoRendererImpl;
 
 // On some platforms tunnel mode is only supported in the secure pipeline.  Set
 // the following variable to true to force creating a secure pipeline in tunnel
@@ -71,6 +73,33 @@ constexpr bool kForceResetSurfaceUnderTunnelMode = true;
 // wait during Reset()/Flush().
 constexpr int64_t kResetDelayUsecOverride = 0;
 constexpr int64_t kFlushDelayUsecOverride = 0;
+
+std::optional<VideoRendererImpl::PrerollParameters> GetPrerollParams(
+    const PlayerComponents::Factory::CreationParameters& creation_parameters) {
+  const auto& min_input_buffers =
+      creation_parameters.video_renderer_min_input_buffers();
+  const auto& min_decoded_frames =
+      creation_parameters.video_renderer_min_decoded_frames();
+
+  if (!min_input_buffers && !min_decoded_frames) {
+    return std::nullopt;
+  }
+
+  if (!min_input_buffers) {
+    SB_LOG(WARNING) << "Ignoring video_renderer_min_decoded_frames since "
+                       "video_renderer_min_input_buffers is missing.";
+    return std::nullopt;
+  }
+
+  if (!min_decoded_frames) {
+    SB_LOG(WARNING) << "Ignoring video_renderer_min_input_buffers since "
+                       "video_renderer_min_decoded_frames is missing.";
+    return std::nullopt;
+  }
+
+  return VideoRendererImpl::PrerollParameters{*min_input_buffers,
+                                              *min_decoded_frames};
+}
 
 // This class allows us to force int16 sample type when tunnel mode is enabled.
 class AudioRendererSinkAndroid : public ::starboard::shared::starboard::player::
@@ -273,8 +302,6 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
                              kForceSecurePipelineUnderTunnelMode,
                              max_video_input_size, error_message);
       if (video_decoder) {
-        using starboard::shared::starboard::player::filter::VideoRendererImpl;
-
         auto video_render_algorithm = video_decoder->GetRenderAlgorithm();
         auto video_renderer_sink = video_decoder->GetSink();
         auto media_time_provider = audio_renderer.get();
@@ -282,7 +309,7 @@ class PlayerComponentsFactory : public starboard::shared::starboard::player::
         video_renderer = std::make_unique<VideoRendererImpl>(
             std::unique_ptr<VideoDecoderBase>(std::move(video_decoder)),
             media_time_provider, std::move(video_render_algorithm),
-            video_renderer_sink);
+            video_renderer_sink, GetPrerollParams(creation_parameters));
       } else {
         return nullptr;
       }

--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -232,6 +232,15 @@ SbPlayer SbPlayerCreate(SbWindow window,
           GetVideoDecoderPollIntervalMsForCurrentThread()) {
     handler->SetVideoDecoderPollIntervalMs(*video_decoder_poll_interval_ms);
   }
+  if (auto video_renderer_min_input_buffers = starboard::android::shared::
+          GetVideoRendererMinInputBuffersForCurrentThread()) {
+    handler->SetVideoRendererMinInputBuffers(*video_renderer_min_input_buffers);
+  }
+  if (auto video_renderer_min_decoded_frames = starboard::android::shared::
+          GetVideoRendererMinDecodedFramesForCurrentThread()) {
+    handler->SetVideoRendererMinDecodedFrames(
+        *video_renderer_min_decoded_frames);
+  }
   if (auto media_codec_reset_delay_ms = starboard::android::shared::
           GetMediaCodecResetDelayMsForCurrentThread()) {
     handler->SetMediaCodecResetDelayMs(*media_codec_reset_delay_ms);

--- a/starboard/android/shared/video_decoder_configuration.cc
+++ b/starboard/android/shared/video_decoder_configuration.cc
@@ -27,12 +27,14 @@ namespace {
 const StarboardExtensionVideoDecoderConfigurationApi
     kVideoDecoderConfigurationApi = {
         kStarboardExtensionVideoDecoderConfigurationName,
-        2,
+        3,
         &SetVideoInitialMaxFramesInDecoderForCurrentThread,
         &SetVideoMaxPendingInputFramesForCurrentThread,
         &SetVideoDecoderInitialPrerollCountForCurrentThread,
         &SetVideoDecoderPollIntervalMsForCurrentThread,
         &SetMediaCodecResetDelayMsForCurrentThread,
+        &SetVideoRendererMinInputBuffersForCurrentThread,
+        &SetVideoRendererMinDecodedFramesForCurrentThread,
 };
 
 }  // namespace

--- a/starboard/android/shared/video_decoder_configuration.cc
+++ b/starboard/android/shared/video_decoder_configuration.cc
@@ -27,7 +27,7 @@ namespace {
 const StarboardExtensionVideoDecoderConfigurationApi
     kVideoDecoderConfigurationApi = {
         kStarboardExtensionVideoDecoderConfigurationName,
-        3,
+        2,
         &SetVideoInitialMaxFramesInDecoderForCurrentThread,
         &SetVideoMaxPendingInputFramesForCurrentThread,
         &SetVideoDecoderInitialPrerollCountForCurrentThread,

--- a/starboard/android/shared/video_decoder_configuration_internal.cc
+++ b/starboard/android/shared/video_decoder_configuration_internal.cc
@@ -30,6 +30,8 @@ pthread_key_t g_max_pending_frames_key = 0;
 pthread_key_t g_video_decoder_initial_preroll_count_key = 0;
 pthread_key_t g_video_decoder_poll_interval_key = 0;
 pthread_key_t g_media_codec_reset_delay_key = 0;
+pthread_key_t g_video_renderer_min_input_buffers_key = 0;
+pthread_key_t g_video_renderer_min_decoded_frames_key = 0;
 
 void WriteIntToThreadLocalStorage(pthread_key_t key, int value) {
   uintptr_t ptr_val = static_cast<uintptr_t>(value);
@@ -66,6 +68,12 @@ void InitializeKeys() {
                            /*destructor=*/nullptr);
   SB_CHECK_EQ(res, 0);
   res = pthread_key_create(&g_media_codec_reset_delay_key,
+                           /*destructor=*/nullptr);
+  SB_CHECK_EQ(res, 0);
+  res = pthread_key_create(&g_video_renderer_min_input_buffers_key,
+                           /*destructor=*/nullptr);
+  SB_CHECK_EQ(res, 0);
+  res = pthread_key_create(&g_video_renderer_min_decoded_frames_key,
                            /*destructor=*/nullptr);
   SB_CHECK_EQ(res, 0);
 }
@@ -157,6 +165,40 @@ void SetMediaCodecResetDelayMsForCurrentThread(int media_codec_reset_delay_ms) {
   EnsureThreadLocalKeyInitedForDecoderConfig();
   WriteIntToThreadLocalStorage(g_media_codec_reset_delay_key,
                                media_codec_reset_delay_ms);
+}
+
+std::optional<int> GetVideoRendererMinInputBuffersForCurrentThread() {
+  EnsureThreadLocalKeyInitedForDecoderConfig();
+  return ReadIntFromThreadLocalStorage(g_video_renderer_min_input_buffers_key);
+}
+
+void SetVideoRendererMinInputBuffersForCurrentThread(
+    int video_renderer_min_input_buffers) {
+  if (video_renderer_min_input_buffers < 0) {
+    SB_LOG(WARNING) << "Invalid video_renderer_min_input_buffers: "
+                    << video_renderer_min_input_buffers;
+    return;
+  }
+  EnsureThreadLocalKeyInitedForDecoderConfig();
+  WriteIntToThreadLocalStorage(g_video_renderer_min_input_buffers_key,
+                               video_renderer_min_input_buffers);
+}
+
+std::optional<int> GetVideoRendererMinDecodedFramesForCurrentThread() {
+  EnsureThreadLocalKeyInitedForDecoderConfig();
+  return ReadIntFromThreadLocalStorage(g_video_renderer_min_decoded_frames_key);
+}
+
+void SetVideoRendererMinDecodedFramesForCurrentThread(
+    int video_renderer_min_decoded_frames) {
+  if (video_renderer_min_decoded_frames < 0) {
+    SB_LOG(WARNING) << "Invalid video_renderer_min_decoded_frames: "
+                    << video_renderer_min_decoded_frames;
+    return;
+  }
+  EnsureThreadLocalKeyInitedForDecoderConfig();
+  WriteIntToThreadLocalStorage(g_video_renderer_min_decoded_frames_key,
+                               video_renderer_min_decoded_frames);
 }
 
 }  // namespace starboard::android::shared

--- a/starboard/android/shared/video_decoder_configuration_internal.h
+++ b/starboard/android/shared/video_decoder_configuration_internal.h
@@ -63,6 +63,24 @@ std::optional<int> GetMediaCodecResetDelayMsForCurrentThread();
 // |media_codec_reset_delay_ms| should be positive value.
 void SetMediaCodecResetDelayMsForCurrentThread(int media_codec_reset_delay_ms);
 
+// Get video_renderer_min_input_buffers via
+// SetVideoRendererMinInputBuffersForCurrentThread().
+std::optional<int> GetVideoRendererMinInputBuffersForCurrentThread();
+
+// Specifies the video renderer minimum input buffers.
+// |video_renderer_min_input_buffers| should be non-negative value.
+void SetVideoRendererMinInputBuffersForCurrentThread(
+    int video_renderer_min_input_buffers);
+
+// Get video_renderer_min_decoded_frames via
+// SetVideoRendererMinDecodedFramesForCurrentThread().
+std::optional<int> GetVideoRendererMinDecodedFramesForCurrentThread();
+
+// Specifies the video renderer minimum decoded frames.
+// |video_renderer_min_decoded_frames| should be non-negative value.
+void SetVideoRendererMinDecodedFramesForCurrentThread(
+    int video_renderer_min_decoded_frames);
+
 }  // namespace starboard::android::shared
 
 #endif  // STARBOARD_ANDROID_SHARED_VIDEO_DECODER_CONFIGURATION_INTERNAL_H_

--- a/starboard/extension/video_decoder_configuration.h
+++ b/starboard/extension/video_decoder_configuration.h
@@ -43,8 +43,6 @@ typedef struct StarboardExtensionVideoDecoderConfigurationApi {
   void (*SetVideoMaxPendingInputFramesForCurrentThread)(
       int max_pending_input_frames);
 
-  // The fields below this point were added in version 2 or later.
-
   // Specifies the video initial preroll count.
   void (*SetVideoDecoderInitialPrerollCountForCurrentThread)(
       int video_decoder_initial_preroll_count);
@@ -56,8 +54,6 @@ typedef struct StarboardExtensionVideoDecoderConfigurationApi {
   // Specifies the MediaCodec delay in milliseconds.
   void (*SetMediaCodecResetDelayMsForCurrentThread)(
       int media_codec_reset_delay_ms);
-
-  // The fields below this point were added in version 3 or later.
 
   // Specifies the video renderer minimum input buffers.
   void (*SetVideoRendererMinInputBuffersForCurrentThread)(

--- a/starboard/extension/video_decoder_configuration.h
+++ b/starboard/extension/video_decoder_configuration.h
@@ -56,6 +56,16 @@ typedef struct StarboardExtensionVideoDecoderConfigurationApi {
   // Specifies the MediaCodec delay in milliseconds.
   void (*SetMediaCodecResetDelayMsForCurrentThread)(
       int media_codec_reset_delay_ms);
+
+  // The fields below this point were added in version 3 or later.
+
+  // Specifies the video renderer minimum input buffers.
+  void (*SetVideoRendererMinInputBuffersForCurrentThread)(
+      int video_renderer_min_input_buffers);
+
+  // Specifies the video renderer minimum decoded frames.
+  void (*SetVideoRendererMinDecodedFramesForCurrentThread)(
+      int video_renderer_min_decoded_frames);
 } StarboardExtensionVideoDecoderConfigurationApi;
 
 #ifdef __cplusplus

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -135,6 +135,7 @@ HandlerResult FilterBasedPlayerWorkerHandler::Init(
       max_video_input_size_, flush_decoder_during_reset_, reset_audio_decoder_,
       video_initial_max_frames_in_decoder_, video_max_pending_input_frames_,
       video_decoder_initial_preroll_count_, video_decoder_poll_interval_ms_,
+      video_renderer_min_input_buffers_, video_renderer_min_decoded_frames_,
       media_codec_reset_delay_ms_, surface_view_,
       decode_target_graphics_context_provider_, drm_system_);
 
@@ -605,6 +606,16 @@ void FilterBasedPlayerWorkerHandler::SetVideoDecoderPollIntervalMs(
                << ToString(video_decoder_poll_interval_ms_) << " to "
                << video_decoder_poll_interval_ms;
   video_decoder_poll_interval_ms_ = video_decoder_poll_interval_ms;
+}
+
+void FilterBasedPlayerWorkerHandler::SetVideoRendererMinInputBuffers(
+    int video_renderer_min_input_buffers) {
+  video_renderer_min_input_buffers_ = video_renderer_min_input_buffers;
+}
+
+void FilterBasedPlayerWorkerHandler::SetVideoRendererMinDecodedFrames(
+    int video_renderer_min_decoded_frames) {
+  video_renderer_min_decoded_frames_ = video_renderer_min_decoded_frames;
 }
 
 void FilterBasedPlayerWorkerHandler::SetMediaCodecResetDelayMs(

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -69,6 +69,10 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
       int video_decoder_initial_preroll_count) override;
   void SetVideoDecoderPollIntervalMs(
       int video_decoder_poll_interval_ms) override;
+  void SetVideoRendererMinInputBuffers(
+      int video_renderer_min_input_buffers) override;
+  void SetVideoRendererMinDecodedFrames(
+      int video_renderer_min_decoded_frames) override;
   void SetMediaCodecResetDelayMs(int media_codec_reset_delay_ms) override;
   void Stop() override;
 
@@ -128,6 +132,8 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   std::optional<int> video_max_pending_input_frames_;
   std::optional<int> video_decoder_initial_preroll_count_;
   std::optional<int> video_decoder_poll_interval_ms_;
+  std::optional<int> video_renderer_min_input_buffers_;
+  std::optional<int> video_renderer_min_decoded_frames_;
   std::optional<int> media_codec_reset_delay_ms_;
   SbDecodeTargetGraphicsContextProvider*
       decode_target_graphics_context_provider_;

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -98,6 +98,8 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
     std::optional<int> video_max_pending_input_frames,
     std::optional<int> video_decoder_initial_preroll_count,
     std::optional<int> video_decoder_poll_interval_ms,
+    std::optional<int> video_renderer_min_input_buffers,
+    std::optional<int> video_renderer_min_decoded_frames,
     std::optional<int> media_codec_reset_delay_ms,
     void* surface_view,
     SbDecodeTargetGraphicsContextProvider*
@@ -113,6 +115,8 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       video_max_pending_input_frames_(video_max_pending_input_frames),
       video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
       video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
+      video_renderer_min_input_buffers_(video_renderer_min_input_buffers),
+      video_renderer_min_decoded_frames_(video_renderer_min_decoded_frames),
       media_codec_reset_delay_ms_(media_codec_reset_delay_ms),
       surface_view_(surface_view),
       decode_target_graphics_context_provider_(
@@ -135,6 +139,8 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
     std::optional<int> video_max_pending_input_frames,
     std::optional<int> video_decoder_initial_preroll_count,
     std::optional<int> video_decoder_poll_interval_ms,
+    std::optional<int> video_renderer_min_input_buffers,
+    std::optional<int> video_renderer_min_decoded_frames,
     std::optional<int> media_codec_reset_delay_ms,
     void* surface_view,
     SbDecodeTargetGraphicsContextProvider*
@@ -151,6 +157,8 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       video_max_pending_input_frames_(video_max_pending_input_frames),
       video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
       video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
+      video_renderer_min_input_buffers_(video_renderer_min_input_buffers),
+      video_renderer_min_decoded_frames_(video_renderer_min_decoded_frames),
       media_codec_reset_delay_ms_(media_codec_reset_delay_ms),
       surface_view_(surface_view),
       decode_target_graphics_context_provider_(
@@ -175,6 +183,10 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
   this->video_decoder_initial_preroll_count_ =
       that.video_decoder_initial_preroll_count_;
   this->video_decoder_poll_interval_ms_ = that.video_decoder_poll_interval_ms_;
+  this->video_renderer_min_input_buffers_ =
+      that.video_renderer_min_input_buffers_;
+  this->video_renderer_min_decoded_frames_ =
+      that.video_renderer_min_decoded_frames_;
   this->media_codec_reset_delay_ms_ = that.media_codec_reset_delay_ms_;
   this->surface_view_ = that.surface_view_;
   this->decode_target_graphics_context_provider_ =
@@ -270,9 +282,16 @@ std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
           std::make_unique<MonotonicSystemTimeProviderImpl>());
       media_time_provider = media_time_provider_impl.get();
     }
+    std::optional<VideoRendererImpl::PrerollParameters> preroll_params;
+    if (creation_parameters.video_renderer_min_input_buffers() ||
+        creation_parameters.video_renderer_min_decoded_frames()) {
+      preroll_params = VideoRendererImpl::PrerollParameters{
+          creation_parameters.video_renderer_min_input_buffers().value_or(-1),
+          creation_parameters.video_renderer_min_decoded_frames().value_or(-1)};
+    }
     video_renderer = std::make_unique<VideoRendererImpl>(
         std::move(video_decoder), media_time_provider,
-        std::move(video_render_algorithm), video_renderer_sink);
+        std::move(video_render_algorithm), video_renderer_sink, preroll_params);
   }
 
   SB_DCHECK(audio_renderer || video_renderer);

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -283,11 +283,11 @@ std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
       media_time_provider = media_time_provider_impl.get();
     }
     std::optional<VideoRendererImpl::PrerollParameters> preroll_params;
-    if (creation_parameters.video_renderer_min_input_buffers() ||
+    if (creation_parameters.video_renderer_min_input_buffers() &&
         creation_parameters.video_renderer_min_decoded_frames()) {
       preroll_params = VideoRendererImpl::PrerollParameters{
-          creation_parameters.video_renderer_min_input_buffers().value_or(-1),
-          creation_parameters.video_renderer_min_decoded_frames().value_or(-1)};
+          *creation_parameters.video_renderer_min_input_buffers(),
+          *creation_parameters.video_renderer_min_decoded_frames()};
     }
     video_renderer = std::make_unique<VideoRendererImpl>(
         std::move(video_decoder), media_time_provider,

--- a/starboard/shared/starboard/player/filter/player_components.h
+++ b/starboard/shared/starboard/player/filter/player_components.h
@@ -72,6 +72,8 @@ class PlayerComponents {
                          std::optional<int> video_max_pending_input_frames,
                          std::optional<int> video_decoder_initial_preroll_count,
                          std::optional<int> video_decoder_poll_interval_ms,
+                         std::optional<int> video_renderer_min_input_buffers,
+                         std::optional<int> video_renderer_min_decoded_frames,
                          std::optional<int> media_codec_reset_delay_ms,
                          void* surface_view,
                          SbDecodeTargetGraphicsContextProvider*
@@ -88,6 +90,8 @@ class PlayerComponents {
                          std::optional<int> video_max_pending_input_frames,
                          std::optional<int> video_decoder_initial_preroll_count,
                          std::optional<int> video_decoder_poll_interval_ms,
+                         std::optional<int> video_renderer_min_input_buffers,
+                         std::optional<int> video_renderer_min_decoded_frames,
                          std::optional<int> media_codec_reset_delay_ms,
                          void* surface_view,
                          SbDecodeTargetGraphicsContextProvider*
@@ -157,6 +161,12 @@ class PlayerComponents {
       std::optional<int> video_decoder_poll_interval_ms() const {
         return video_decoder_poll_interval_ms_;
       }
+      std::optional<int> video_renderer_min_input_buffers() const {
+        return video_renderer_min_input_buffers_;
+      }
+      std::optional<int> video_renderer_min_decoded_frames() const {
+        return video_renderer_min_decoded_frames_;
+      }
       std::optional<int> media_codec_reset_delay_ms() const {
         return media_codec_reset_delay_ms_;
       }
@@ -186,6 +196,8 @@ class PlayerComponents {
       std::optional<int> video_max_pending_input_frames_;
       std::optional<int> video_decoder_initial_preroll_count_;
       std::optional<int> video_decoder_poll_interval_ms_;
+      std::optional<int> video_renderer_min_input_buffers_;
+      std::optional<int> video_renderer_min_decoded_frames_;
       std::optional<int> media_codec_reset_delay_ms_;
 
       // The following member are used by both the audio stream and the video

--- a/starboard/shared/starboard/player/filter/testing/player_components_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/player_components_test.cc
@@ -97,6 +97,8 @@ class PlayerComponentsTest
           /*video_max_pending_input_frames=*/std::nullopt,
           /*video_decoder_initial_preroll_count=*/std::nullopt,
           /*video_decoder_poll_interval_ms=*/std::nullopt,
+          /*video_renderer_min_input_buffers=*/std::nullopt,
+          /*video_renderer_min_decoded_frames=*/std::nullopt,
           /*media_codec_reset_delay_ms=*/std::nullopt, dummy_surface_view_,
           fake_graphics_context_provider_.decoder_target_provider());
       ASSERT_EQ(creation_parameters.max_video_input_size(),
@@ -121,6 +123,8 @@ class PlayerComponentsTest
           /*video_max_pending_input_frames=*/std::nullopt,
           /*video_decoder_initial_preroll_count=*/std::nullopt,
           /*video_decoder_poll_interval_ms=*/std::nullopt,
+          /*video_renderer_min_input_buffers=*/std::nullopt,
+          /*video_renderer_min_decoded_frames=*/std::nullopt,
           /*media_codec_reset_delay_ms=*/std::nullopt, dummy_surface_view_,
           fake_graphics_context_provider_.decoder_target_provider());
       ASSERT_EQ(creation_parameters.max_video_input_size(),

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
@@ -161,6 +161,8 @@ TEST_P(VideoDecoderTest, ThreeMoreDecoders) {
                 /*video_max_pending_input_frames=*/std::nullopt,
                 /*video_decoder_initial_preroll_count=*/std::nullopt,
                 /*video_decoder_poll_interval_ms=*/std::nullopt,
+                /*video_renderer_min_input_buffers=*/std::nullopt,
+                /*video_renderer_min_decoded_frames=*/std::nullopt,
                 /*media_codec_reset_delay_ms=*/std::nullopt,
                 fake_graphics_context_provider_.decoder_target_provider(),
                 nullptr);

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
@@ -91,6 +91,8 @@ void VideoDecoderTestFixture::Initialize() {
       /*video_max_pending_input_frames=*/std::nullopt,
       /*video_decoder_initial_preroll_count=*/std::nullopt,
       /*video_decoder_poll_interval_ms=*/std::nullopt,
+      /*video_renderer_min_input_buffers=*/std::nullopt,
+      /*video_renderer_min_decoded_frames=*/std::nullopt,
       /*media_codec_reset_delay_ms=*/std::nullopt,
       fake_graphics_context_provider_->decoder_target_provider(), nullptr);
   ASSERT_EQ(creation_parameters.max_video_input_size(), max_video_input_size);

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -41,13 +41,13 @@ VideoRendererImpl::VideoRendererImpl(
     std::unique_ptr<VideoDecoder> decoder,
     MediaTimeProvider* media_time_provider,
     std::unique_ptr<VideoRenderAlgorithm> algorithm,
-    scoped_refptr<VideoRendererSink> sink)
+    scoped_refptr<VideoRendererSink> sink,
+    const std::optional<PrerollParameters>& preroll_params)
     : media_time_provider_(media_time_provider),
       algorithm_(std::move(algorithm)),
       sink_(sink),
       decoder_(std::move(decoder)),
-      // TODO: b/485225923 - Connect this to h5vcc settings.
-      preroll_params_(std::nullopt) {
+      preroll_params_(preroll_params) {
   SB_CHECK(decoder_);
   SB_CHECK(algorithm_);
   SB_DCHECK_GT(decoder_->GetMaxNumberOfCachedFrames(), 1U);

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -37,6 +37,12 @@ const int64_t kSeekTimeoutRetryInterval = 25'000;  // 25ms
 
 }  // namespace
 
+std::ostream& operator<<(std::ostream& os,
+                         const VideoRendererImpl::PrerollParameters& params) {
+  return os << "{min_input_buffers=" << params.min_input_buffers
+            << ", min_decoded_frames=" << params.min_decoded_frames << "}";
+}
+
 VideoRendererImpl::VideoRendererImpl(
     std::unique_ptr<VideoDecoder> decoder,
     MediaTimeProvider* media_time_provider,
@@ -64,6 +70,10 @@ VideoRendererImpl::VideoRendererImpl(
            kCheckBufferingStateInterval);
   time_of_last_lag_warning_ = CurrentMonotonicTime() - kMinLagWarningInterval;
 #endif  // SB_PLAYER_FILTER_ENABLE_STATE_CHECK
+  SB_LOG(INFO) << "VideoRendererImpl is created: "
+               << (preroll_params_
+                       ? "preroll_params=" + ToString(*preroll_params_)
+                       : "using default preroll logic");
 }
 
 VideoRendererImpl::~VideoRendererImpl() {

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -20,6 +20,7 @@
 #include <memory>
 #include <mutex>
 #include <optional>
+#include <ostream>
 
 #include "starboard/common/log.h"
 #include "starboard/common/ref_counted.h"
@@ -45,6 +46,9 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
     int32_t min_input_buffers;
     int32_t min_decoded_frames;
   };
+  friend std::ostream& operator<<(std::ostream& os,
+                                  const PrerollParameters& params);
+
   // All of the functions are called on the PlayerWorker thread unless marked
   // otherwise.
   VideoRendererImpl(std::unique_ptr<VideoDecoder> decoder,

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -41,12 +41,17 @@ namespace starboard::shared::starboard::player::filter {
 // pipeline to coordinate data transfer between these parties.
 class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
  public:
+  struct PrerollParameters {
+    int32_t min_input_buffers;
+    int32_t min_decoded_frames;
+  };
   // All of the functions are called on the PlayerWorker thread unless marked
   // otherwise.
   VideoRendererImpl(std::unique_ptr<VideoDecoder> decoder,
                     MediaTimeProvider* media_time_provider,
                     std::unique_ptr<VideoRenderAlgorithm> algorithm,
-                    scoped_refptr<VideoRendererSink> sink);
+                    scoped_refptr<VideoRendererSink> sink,
+                    const std::optional<PrerollParameters>& preroll_params);
   ~VideoRendererImpl() override;
 
   void Initialize(const ErrorCB& error_cb,
@@ -84,10 +89,6 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   const std::unique_ptr<VideoRenderAlgorithm> algorithm_;
   scoped_refptr<VideoRendererSink> sink_;
   std::unique_ptr<VideoDecoder> decoder_;
-  struct PrerollParameters {
-    int32_t min_input_buffers;
-    int32_t min_decoded_frames;
-  };
   const std::optional<PrerollParameters> preroll_params_;
 
   PrerolledCB prerolled_cb_;

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -121,6 +121,10 @@ class PlayerWorker {
         int video_decoder_initial_preroll_count) = 0;
     virtual void SetVideoDecoderPollIntervalMs(
         int video_decoder_poll_interval_ms) = 0;
+    virtual void SetVideoRendererMinInputBuffers(
+        int video_renderer_min_input_buffers) = 0;
+    virtual void SetVideoRendererMinDecodedFrames(
+        int video_renderer_min_decoded_frames) = 0;
     virtual void SetMediaCodecResetDelayMs(int media_codec_reset_delay_ms) = 0;
 
    private:

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -121,8 +121,10 @@ class PlayerWorker {
         int video_decoder_initial_preroll_count) = 0;
     virtual void SetVideoDecoderPollIntervalMs(
         int video_decoder_poll_interval_ms) = 0;
+    // TODO: b/491104896 - Remove this method once the experiment is done.
     virtual void SetVideoRendererMinInputBuffers(
         int video_renderer_min_input_buffers) = 0;
+    // TODO: b/491104896 - Remove this method once the experiment is done.
     virtual void SetVideoRendererMinDecodedFrames(
         int video_renderer_min_decoded_frames) = 0;
     virtual void SetMediaCodecResetDelayMs(int media_codec_reset_delay_ms) = 0;


### PR DESCRIPTION
Introduce H5VCC settings for video renderer minimum input buffers
and minimum decoded frames. These parameters are plumbed through
the media and Starboard layers, including updates to the Starboard
VideoDecoderConfiguration extension API, ultimately reaching the
VideoRendererImpl.

This change enables the dynamic configuration of video preroll
settings from H5VCC, laying the groundwork for future platform-
specific tuning to improve video playback startup and buffer
management.

Bug: 491104896

