### PR TITLE
media: Support disable-trim-on-seek 

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -309,7 +309,10 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         video_renderer = std::make_unique<VideoRendererImpl>(
             std::unique_ptr<VideoDecoderBase>(std::move(video_decoder)),
             media_time_provider, std::move(video_render_algorithm),
-            video_renderer_sink, GetPrerollParams(creation_parameters));
+            video_renderer_sink,
+            VideoRendererImpl::CreationParameters{
+                GetPrerollParams(creation_parameters),
+                experimental_features.disable_trim_on_seek});
       } else {
         return nullptr;
       }

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -75,6 +75,9 @@ constexpr bool kForceResetSurfaceUnderTunnelMode = true;
 constexpr int64_t kResetDelayUsecOverride = 0;
 constexpr int64_t kFlushDelayUsecOverride = 0;
 
+// TODO: b/491123801 - Connect this to the experiment.
+constexpr bool kDisableTrimOnSeek = false;
+
 std::optional<VideoRendererImpl::PrerollParameters> GetPrerollParams(
     const PlayerComponents::Factory::CreationParameters& creation_parameters) {
   const auto& experimental_features =

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -75,9 +75,6 @@ constexpr bool kForceResetSurfaceUnderTunnelMode = true;
 constexpr int64_t kResetDelayUsecOverride = 0;
 constexpr int64_t kFlushDelayUsecOverride = 0;
 
-// TODO: b/491123801 - Connect this to the experiment.
-constexpr bool kDisableTrimOnSeek = false;
-
 std::optional<VideoRendererImpl::PrerollParameters> GetPrerollParams(
     const PlayerComponents::Factory::CreationParameters& creation_parameters) {
   const auto& experimental_features =
@@ -495,9 +492,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
 
       if (tunnel_mode_audio_session_id != -1) {
         *audio_renderer_sink = std::make_unique<AudioRendererSinkAndroid>(
-          tunnel_mode_audio_session_id);
-      }
-      else {
+            tunnel_mode_audio_session_id);
+      } else {
         *audio_renderer_sink = std::make_unique<AudioRendererSinkAndroid>(
             tunnel_mode_audio_session_id, pause_using_audio_track_state);
       }

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -28,7 +28,7 @@ namespace starboard::shared::starboard {
 struct ExperimentalFeatures {
   // The fields should be in alphabetical order.
   bool flush_decoder_during_reset = false;
-  // TODOO: b/491123801 - Connec this flag to h5vcc.
+  // TODO: b/491123801 - Connect this flag to h5vcc.
   bool disable_trim_on_seek = false;
   std::optional<int> media_codec_reset_delay_ms;
   bool pause_using_audio_track_state = false;

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -28,6 +28,8 @@ namespace starboard::shared::starboard {
 struct ExperimentalFeatures {
   // The fields should be in alphabetical order.
   bool flush_decoder_during_reset = false;
+  // TODOO: b/491123801 - Connec this flag to h5vcc.
+  bool disable_trim_on_seek = false;
   std::optional<int> media_codec_reset_delay_ms;
   bool pause_using_audio_track_state = false;
   bool reset_audio_decoder = false;

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "starboard/common/check_op.h"
+#include "starboard/common/string.h"
 #include "starboard/common/time.h"
 #include "starboard/shared/starboard/media/media_util.h"
 
@@ -68,10 +69,10 @@ AudioRendererPcm::AudioRendererPcm(
     std::unique_ptr<AudioDecoder> decoder,
     std::unique_ptr<AudioRendererSink> audio_renderer_sink,
     const media::AudioStreamInfo& audio_stream_info,
-    int max_cached_frames,
-    int min_frames_per_append)
-    : max_cached_frames_(max_cached_frames),
-      min_frames_per_append_(min_frames_per_append),
+    const CreationParameters& creation_params)
+    : max_cached_frames_(creation_params.max_cached_frames),
+      min_frames_per_append_(creation_params.min_frames_per_append),
+      disable_trim_on_seek_(creation_params.disable_trim_on_seek),
       decoder_(std::move(decoder)),
       frames_consumed_set_at_(CurrentMonotonicTime()),
       channels_(audio_stream_info.number_of_channels),
@@ -620,8 +621,22 @@ void AudioRendererPcm::ProcessAudioData() {
     SB_DCHECK(decoded_audio);
     if (!audio_renderer_sink_->HasStarted()) {
       if (!decoded_audio->is_end_of_stream()) {
-        decoded_audio->AdjustForSeekTime(decoded_audio_sample_rate,
-                                         seeking_to_time_);
+        if (disable_trim_on_seek_) {
+          std::lock_guard lock(mutex_);
+          // When trimming is disabled, we update the seek target to match the
+          // actual timestamp of the first decoded buffer. This ensures that
+          // no data is discarded and that the renderer's internal timeline
+          // starts exactly where the data begins.
+          SB_LOG(INFO) << "Updating seeking_to_time: original target(msec)="
+                       << FormatWithDigitSeparators(seeking_to_time_ / 1'000)
+                       << ", actual(msec)="
+                       << FormatWithDigitSeparators(decoded_audio->timestamp() /
+                                                    1'000);
+          seeking_to_time_ = decoded_audio->timestamp();
+        } else {
+          decoded_audio->AdjustForSeekTime(decoded_audio_sample_rate,
+                                           seeking_to_time_);
+        }
       }
       OnFirstOutput(decoded_audio->sample_type(), decoded_audio->storage_type(),
                     decoded_audio_sample_rate);
@@ -647,7 +662,8 @@ void AudioRendererPcm::ProcessAudioData() {
       resampled_audio = resampler_->WriteEndOfStream();
     } else {
       // Discard any audio data before the seeking target.
-      if (seeking_ && decoded_audio->timestamp() < seeking_to_time_) {
+      if (!disable_trim_on_seek_ && seeking_ &&
+          decoded_audio->timestamp() < seeking_to_time_) {
         continue;
       }
 

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -633,6 +633,7 @@ void AudioRendererPcm::ProcessAudioData() {
                        << FormatWithDigitSeparators(decoded_audio->timestamp() /
                                                     1'000);
           seeking_to_time_ = decoded_audio->timestamp();
+          last_media_time_ = seeking_to_time_;
         } else {
           decoded_audio->AdjustForSeekTime(decoded_audio_sample_rate,
                                            seeking_to_time_);

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -55,6 +55,11 @@ class AudioRendererPcm : public AudioRenderer,
                          private AudioRendererSink::RenderCallback,
                          private JobQueue::JobOwner {
  public:
+  struct CreationParameters {
+    int max_cached_frames;
+    int min_frames_per_append;
+    bool disable_trim_on_seek = false;
+  };
   // |max_cached_frames| is a soft limit for the max audio frames this class can
   // cache so it can:
   // 1. Avoid using too much memory.
@@ -65,8 +70,7 @@ class AudioRendererPcm : public AudioRenderer,
   AudioRendererPcm(std::unique_ptr<AudioDecoder> decoder,
                    std::unique_ptr<AudioRendererSink> audio_renderer_sink,
                    const media::AudioStreamInfo& audio_stream_info,
-                   int max_cached_frames,
-                   int min_frames_per_append);
+                   const CreationParameters& creation_params);
   ~AudioRendererPcm() override;
 
   void Initialize(const ErrorCB& error_cb,
@@ -102,6 +106,7 @@ class AudioRendererPcm : public AudioRenderer,
 
   const int max_cached_frames_;
   const int min_frames_per_append_;
+  const bool disable_trim_on_seek_;
   // |buffered_frames_to_start_| would be initialized in OnFirstOutput().
   // Before it's initialized, set it to a large number.
   int buffered_frames_to_start_ = 48 * 1024;

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -39,9 +39,6 @@ namespace {
 const int kAudioSinkFramesAlignment = 256;
 const int kDefaultAudioSinkMinFramesPerAppend = 1024;
 
-// TODO: b/491123801 - Connect this to the experiment.
-constexpr bool kDisableTrimOnSeek = false;
-
 typedef MediaTimeProviderImpl::MonotonicSystemTimeProvider
     MonotonicSystemTimeProvider;
 
@@ -203,6 +200,8 @@ std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
   std::unique_ptr<AudioRendererPcm> audio_renderer;
   std::unique_ptr<VideoRendererImpl> video_renderer;
 
+  const auto& experimental_features =
+      creation_parameters.experimental_features();
   if (creation_parameters.audio_codec() != kSbMediaAudioCodecNone) {
     SB_DCHECK(audio_decoder);
     SB_DCHECK(audio_renderer_sink);
@@ -215,16 +214,21 @@ std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
         std::move(audio_decoder), std::move(audio_renderer_sink),
         creation_parameters.audio_stream_info(),
         AudioRendererPcm::CreationParameters{
-            max_cached_frames, min_frames_per_append, kDisableTrimOnSeek});
+            max_cached_frames, min_frames_per_append,
+            experimental_features.disable_trim_on_seek});
   }
 
   if (creation_parameters.video_codec() != kSbMediaVideoCodecNone) {
     SB_DCHECK(video_decoder);
     SB_DCHECK(video_render_algorithm);
 
+    bool disable_trim_on_seek = false;
     MediaTimeProvider* media_time_provider = nullptr;
     if (audio_renderer) {
       media_time_provider = audio_renderer.get();
+      // We can support disable_trim_on_seek, only when content has both audio
+      // and video.
+      disable_trim_on_seek = experimental_features.disable_trim_on_seek;
     } else {
       media_time_provider_impl = std::make_unique<MediaTimeProviderImpl>(
           std::make_unique<MonotonicSystemTimeProviderImpl>());
@@ -243,7 +247,7 @@ std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
         std::move(video_decoder), media_time_provider,
         std::move(video_render_algorithm), video_renderer_sink,
         VideoRendererImpl::CreationParameters{preroll_params,
-                                              kDisableTrimOnSeek});
+                                              disable_trim_on_seek});
   }
 
   SB_DCHECK(audio_renderer || video_renderer);

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -39,6 +39,9 @@ namespace {
 const int kAudioSinkFramesAlignment = 256;
 const int kDefaultAudioSinkMinFramesPerAppend = 1024;
 
+// TODO: b/491123801 - Connect this to the experiment.
+constexpr bool kDisableTrimOnSeek = false;
+
 typedef MediaTimeProviderImpl::MonotonicSystemTimeProvider
     MonotonicSystemTimeProvider;
 
@@ -210,8 +213,9 @@ std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
 
     audio_renderer = std::make_unique<AudioRendererPcm>(
         std::move(audio_decoder), std::move(audio_renderer_sink),
-        creation_parameters.audio_stream_info(), max_cached_frames,
-        min_frames_per_append);
+        creation_parameters.audio_stream_info(),
+        AudioRendererPcm::CreationParameters{
+            max_cached_frames, min_frames_per_append, kDisableTrimOnSeek});
   }
 
   if (creation_parameters.video_codec() != kSbMediaVideoCodecNone) {
@@ -237,7 +241,9 @@ std::unique_ptr<PlayerComponents> PlayerComponents::Factory::CreateComponents(
     }
     video_renderer = std::make_unique<VideoRendererImpl>(
         std::move(video_decoder), media_time_provider,
-        std::move(video_render_algorithm), video_renderer_sink, preroll_params);
+        std::move(video_render_algorithm), video_renderer_sink,
+        VideoRendererImpl::CreationParameters{preroll_params,
+                                              kDisableTrimOnSeek});
   }
 
   SB_DCHECK(audio_renderer || video_renderer);

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -900,8 +900,8 @@ TEST_F(AudioRendererTest, DisableTrimOnSeek) {
     return;
   }
 
-  const int64_t kSeekTime = 500'000;
-  const int64_t kFirstAudioTimestamp = 600'000;
+  const int64_t kSeekTime = 1'000'000;
+  const int64_t kFirstAudioTimestamp = 0;
   const int kFramesPerBuffer = 1024;
 
   auto creation_params = GetDefaultCreationParameters();
@@ -924,21 +924,10 @@ TEST_F(AudioRendererTest, DisableTrimOnSeek) {
   WriteSample(CreateInputBuffer(kFirstAudioTimestamp));
   CallConsumedCB();
 
-  // Send decoder output with timestamp > seek time.
+  // Send decoder output with timestamp < seek time.
   // With disable_trim_on_seek = true, seeking_to_time_ should be updated to
   // kFirstAudioTimestamp and frames should NOT be trimmed.
   SendDecoderOutput(CreateDecodedAudio(kFirstAudioTimestamp, kFramesPerBuffer));
-
-  bool is_playing;
-  bool is_eos_played;
-  bool is_underflow;
-  double playback_rate = -1.0;
-
-  // GetCurrentMediaTime should return kFirstAudioTimestamp as it's the new
-  // seek target.
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
-            kFirstAudioTimestamp);
 
   // Write EOS to finish preroll.
   WriteEndOfStream();
@@ -946,16 +935,31 @@ TEST_F(AudioRendererTest, DisableTrimOnSeek) {
 
   EXPECT_TRUE(prerolled_);
 
+  bool is_playing;
+  bool is_eos_played;
+  bool is_underflow;
+  double playback_rate = -1.0;
+
+  // GetCurrentMediaTime should return kFirstAudioTimestamp (0) as it's the new
+  // seek target.
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
+                                                 &is_underflow, &playback_rate),
+            kFirstAudioTimestamp);
+
   audio_renderer_->Play();
 
-  int frames_in_buffer;
-  int offset_in_frames;
-  bool is_eos_reached;
-  renderer_callback_->GetSourceStatus(&frames_in_buffer, &offset_in_frames,
-                                      &is_playing, &is_eos_reached);
+  // Consume some frames.
+  const int kFramesToConsume = 512;
+  renderer_callback_->ConsumeFrames(kFramesToConsume, CurrentMonotonicTime());
 
-  // Frames should NOT have been trimmed, so we expect kFramesPerBuffer.
-  EXPECT_EQ(frames_in_buffer, kFramesPerBuffer);
+  int64_t media_time = audio_renderer_->GetCurrentMediaTime(
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+
+  // If frames were NOT trimmed, media_time should be > kFirstAudioTimestamp.
+  // If frames WERE trimmed, media_time would stay at kFirstAudioTimestamp (0)
+  // or be at kSeekTime (1,000,000).
+  EXPECT_GT(media_time, kFirstAudioTimestamp);
+  EXPECT_LT(media_time, kSeekTime);
 }
 
 }  // namespace

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -54,13 +54,23 @@ class AudioRendererTest : public ::testing::Test {
 
   AudioRendererTest() {
     ResetToFormat(kSbMediaAudioSampleTypeFloat32,
-                  kSbMediaAudioFrameStorageTypeInterleaved);
+                  kSbMediaAudioFrameStorageTypeInterleaved,
+                  GetDefaultCreationParameters());
+  }
+
+  static AudioRendererPcm::CreationParameters GetDefaultCreationParameters() {
+    AudioRendererPcm::CreationParameters creation_params;
+    creation_params.max_cached_frames = 256 * 1024;
+    creation_params.min_frames_per_append = 16 * 1024;
+    return creation_params;
   }
 
   // This function should be called in the fixture before any other functions
   // to set the desired format of the decoder.
-  void ResetToFormat(SbMediaAudioSampleType sample_type,
-                     SbMediaAudioFrameStorageType storage_type) {
+  void ResetToFormat(
+      SbMediaAudioSampleType sample_type,
+      SbMediaAudioFrameStorageType storage_type,
+      const AudioRendererPcm::CreationParameters& creation_params) {
     audio_renderer_.reset(NULL);
     sample_type_ = sample_type;
     storage_type_ = storage_type;
@@ -108,9 +118,6 @@ class AudioRendererTest : public ::testing::Test {
     EXPECT_CALL(*audio_decoder_, Initialize(_, _))
         .WillOnce(SaveArg<0>(&output_cb_));
 
-    AudioRendererPcm::CreationParameters creation_params;
-    creation_params.max_cached_frames = 256 * 1024;
-    creation_params.min_frames_per_append = 16 * 1024;
     audio_renderer_ = std::make_unique<AudioRendererPcm>(
         std::unique_ptr<AudioDecoder>(audio_decoder_),
         std::unique_ptr<AudioRendererSink>(audio_renderer_sink_),
@@ -388,7 +395,8 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
   // Resets |audio_renderer_sink_|, so all the gtest codes need to be below
   // this line.
   ResetToFormat(kSbMediaAudioSampleTypeInt16Deprecated,
-                kSbMediaAudioFrameStorageTypeInterleaved);
+                kSbMediaAudioFrameStorageTypeInterleaved,
+                GetDefaultCreationParameters());
 
   {
     ::testing::InSequence seq;
@@ -886,7 +894,69 @@ TEST_F(AudioRendererTest, Seek) {
   EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());
 }
 
-// TODO: Add more Seek tests.
+TEST_F(AudioRendererTest, DisableTrimOnSeek) {
+  if (HasAsyncAudioFramesReporting()) {
+    SB_LOG(INFO) << "Platform has async audio frames reporting. Test skipped.";
+    return;
+  }
+
+  const int64_t kSeekTime = 500'000;
+  const int64_t kFirstAudioTimestamp = 600'000;
+  const int kFramesPerBuffer = 1024;
+
+  auto creation_params = GetDefaultCreationParameters();
+  creation_params.disable_trim_on_seek = true;
+  ResetToFormat(kSbMediaAudioSampleTypeFloat32,
+                kSbMediaAudioFrameStorageTypeInterleaved, creation_params);
+
+  {
+    ::testing::InSequence seq;
+    EXPECT_CALL(*audio_renderer_sink_,
+                Start(kFirstAudioTimestamp, kDefaultNumberOfChannels,
+                      kDefaultSamplesPerSecond, kDefaultAudioSampleType,
+                      kDefaultAudioFrameStorageType, _, _, _));
+  }
+
+  // Set to prerolled so we can call Seek().
+  prerolled_ = true;
+  Seek(kSeekTime);
+
+  WriteSample(CreateInputBuffer(kFirstAudioTimestamp));
+  CallConsumedCB();
+
+  // Send decoder output with timestamp > seek time.
+  // With disable_trim_on_seek = true, seeking_to_time_ should be updated to
+  // kFirstAudioTimestamp and frames should NOT be trimmed.
+  SendDecoderOutput(CreateDecodedAudio(kFirstAudioTimestamp, kFramesPerBuffer));
+
+  bool is_playing;
+  bool is_eos_played;
+  bool is_underflow;
+  double playback_rate = -1.0;
+
+  // GetCurrentMediaTime should return kFirstAudioTimestamp as it's the new
+  // seek target.
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
+                                                 &is_underflow, &playback_rate),
+            kFirstAudioTimestamp);
+
+  // Write EOS to finish preroll.
+  WriteEndOfStream();
+  SendDecoderOutput(new DecodedAudio);
+
+  EXPECT_TRUE(prerolled_);
+
+  audio_renderer_->Play();
+
+  int frames_in_buffer;
+  int offset_in_frames;
+  bool is_eos_reached;
+  renderer_callback_->GetSourceStatus(&frames_in_buffer, &offset_in_frames,
+                                      &is_playing, &is_eos_reached);
+
+  // Frames should NOT have been trimmed, so we expect kFramesPerBuffer.
+  EXPECT_EQ(frames_in_buffer, kFramesPerBuffer);
+}
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -108,12 +108,13 @@ class AudioRendererTest : public ::testing::Test {
     EXPECT_CALL(*audio_decoder_, Initialize(_, _))
         .WillOnce(SaveArg<0>(&output_cb_));
 
-    const int kMaxCachedFrames = 256 * 1024;
-    const int kMaxFramesPerAppend = 16384;
-    audio_renderer_.reset(new AudioRendererPcm(
+    AudioRendererPcm::CreationParameters creation_params;
+    creation_params.max_cached_frames = 256 * 1024;
+    creation_params.min_frames_per_append = 16 * 1024;
+    audio_renderer_ = std::make_unique<AudioRendererPcm>(
         std::unique_ptr<AudioDecoder>(audio_decoder_),
         std::unique_ptr<AudioRendererSink>(audio_renderer_sink_),
-        GetDefaultAudioStreamInfo(), kMaxCachedFrames, kMaxFramesPerAppend));
+        GetDefaultAudioStreamInfo(), creation_params);
     audio_renderer_->Initialize(
         std::bind(&AudioRendererTest::OnError, this),
         std::bind(&AudioRendererTest::OnPrerolled, this),

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -48,12 +48,13 @@ VideoRendererImpl::VideoRendererImpl(
     MediaTimeProvider* media_time_provider,
     std::unique_ptr<VideoRenderAlgorithm> algorithm,
     scoped_refptr<VideoRendererSink> sink,
-    const std::optional<PrerollParameters>& preroll_params)
+    const CreationParameters& creation_params)
     : media_time_provider_(media_time_provider),
       algorithm_(std::move(algorithm)),
       sink_(sink),
       decoder_(std::move(decoder)),
-      preroll_params_(preroll_params) {
+      preroll_params_(creation_params.preroll),
+      disable_trim_on_seek_(creation_params.disable_trim_on_seek) {
   SB_CHECK(decoder_);
   SB_CHECK(algorithm_);
   SB_DCHECK_GT(decoder_->GetMaxNumberOfCachedFrames(), 1U);
@@ -73,7 +74,8 @@ VideoRendererImpl::VideoRendererImpl(
   SB_LOG(INFO) << "VideoRendererImpl is created: "
                << (preroll_params_
                        ? "preroll_params=" + ToString(*preroll_params_)
-                       : "using default preroll logic");
+                       : "using default preroll logic")
+               << ", disable_trim_on_seek_=" << ToString(disable_trim_on_seek_);
 }
 
 VideoRendererImpl::~VideoRendererImpl() {
@@ -278,7 +280,8 @@ void VideoRendererImpl::OnDecoderStatus(
         Schedule(prerolled_cb_);
       }
       end_of_stream_decoded_.store(true);
-    } else if (seeking_.load() && frame->timestamp() < seeking_to_time_) {
+    } else if (!disable_trim_on_seek_ && seeking_.load() &&
+               frame->timestamp() < seeking_to_time_) {
       frame_too_early = true;
     }
 

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -49,13 +49,18 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   friend std::ostream& operator<<(std::ostream& os,
                                   const PrerollParameters& params);
 
+  struct CreationParameters {
+    std::optional<PrerollParameters> preroll;
+    bool disable_trim_on_seek = false;
+  };
+
   // All of the functions are called on the PlayerWorker thread unless marked
   // otherwise.
   VideoRendererImpl(std::unique_ptr<VideoDecoder> decoder,
                     MediaTimeProvider* media_time_provider,
                     std::unique_ptr<VideoRenderAlgorithm> algorithm,
                     scoped_refptr<VideoRendererSink> sink,
-                    const std::optional<PrerollParameters>& preroll_params);
+                    const CreationParameters& creation_params);
   ~VideoRendererImpl() override;
 
   void Initialize(const ErrorCB& error_cb,
@@ -94,6 +99,7 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   scoped_refptr<VideoRendererSink> sink_;
   std::unique_ptr<VideoDecoder> decoder_;
   const std::optional<PrerollParameters> preroll_params_;
+  const bool disable_trim_on_seek_;
 
   PrerolledCB prerolled_cb_;
   EndedCB ended_cb_;


### PR DESCRIPTION
Introduce a flag to disable trim-on-seek. When enabled, the audio and video renderers will no longer discard frames that arrive with timestamps earlier than the current seeking target, nor will they adjust frame timestamps
relative to the seek point. 

Local test showed that by disabling trim-on-seek, we can improve the latency on seek by ~70 msec (. For the test result, see http://b/491123801#comment4


Metric | Default | DoNotTrim = true | Difference
-- | -- | -- | --
Average Time | 316.14 ms | 247.44 ms | -68.70 ms
Best Time | 284 ms | 165 ms | -119 ms
Worst Time | 382 ms | 369 ms | -13 ms


Bug: 491123801