### PR TITLE
media: Log encoded video/audio budgets as histogram

### DIFF
--- a/media/starboard/decoder_buffer_memory_info.cc
+++ b/media/starboard/decoder_buffer_memory_info.cc
@@ -26,7 +26,7 @@ constexpr int kBytesPerMegabyte = 1024 * 1024;
 
 int GetAudioDecoderBufferLimitBytes() {
   // TODO(mcasas): This value should always be the same on every call, enforce.
-  const auto audio_budget_in_bytes = SbMediaGetAudioBufferBudget()
+  const auto audio_budget_in_bytes = SbMediaGetAudioBufferBudget();
   UMA_HISTOGRAM_MEMORY_MEDIUM_MB("Media.Starboard.AudioBufferBudget",
                                  audio_budget_in_bytes / kBytesPerMegabyte);
   return audio_budget_in_bytes;
@@ -38,7 +38,6 @@ int GetVideoDecoderBufferLimitBytes(VideoCodec codec,
   const auto video_budget_in_bytes = SbMediaGetVideoBufferBudget(
       MediaVideoCodecToSbMediaVideoCodec(codec), resolution.width(),
       resolution.height(), bits_per_pixel);
-
   UMA_HISTOGRAM_MEMORY_MEDIUM_MB("Media.Starboard.VideoBufferBudget",
                                  video_budget_in_bytes / kBytesPerMegabyte);
   return video_budget_in_bytes;

--- a/media/starboard/decoder_buffer_memory_info.cc
+++ b/media/starboard/decoder_buffer_memory_info.cc
@@ -14,6 +14,7 @@
 
 #include "media/starboard/decoder_buffer_memory_info.h"
 
+#include "base/metrics/histogram_macros.h"
 #include "media/base/video_codecs.h"
 #include "media/starboard/starboard_utils.h"
 #include "starboard/media.h"
@@ -21,16 +22,26 @@
 
 namespace media {
 
+constexpr int kBytesPerMegabyte = 1024 * 1024;
+
 int GetAudioDecoderBufferLimitBytes() {
-  return SbMediaGetAudioBufferBudget();
+  // TODO(mcasas): This value should always be the same on every call, enforce.
+  const auto audio_budget_in_bytes = SbMediaGetAudioBufferBudget()
+  UMA_HISTOGRAM_MEMORY_MEDIUM_MB("Media.Starboard.AudioBufferBudget",
+                                 audio_budget_in_bytes / kBytesPerMegabyte);
+  return audio_budget_in_bytes;
 }
 
 int GetVideoDecoderBufferLimitBytes(VideoCodec codec,
                                     const gfx::Size& resolution,
                                     int bits_per_pixel) {
-  return SbMediaGetVideoBufferBudget(MediaVideoCodecToSbMediaVideoCodec(codec),
-                                     resolution.width(), resolution.height(),
-                                     bits_per_pixel);
+  const auto video_budget_in_bytes = SbMediaGetVideoBufferBudget(
+      MediaVideoCodecToSbMediaVideoCodec(codec), resolution.width(),
+      resolution.height(), bits_per_pixel);
+
+  UMA_HISTOGRAM_MEMORY_MEDIUM_MB("Media.Starboard.VideoBufferBudget",
+                                 video_budget_in_bytes / kBytesPerMegabyte);
+  return video_budget_in_bytes;
 }
 
 }  // namespace media


### PR DESCRIPTION
This CL/PR adds UMA-like logging of each video playback 
demuxer's video/audio budgets, which is tantamount to say 
the amount of memory that will be allocated for either of 
those stream types' data pools. 

The numbers are retrieved from //starboard locations like 
e.g. starboard/android/shared/media_get_video_buffer_budget.cc,
and are quantities like e.g. 30MB for video 1080p on Linux.

This was tested locally, see the result e.g. here:
https://i.imgur.com/U4ExHUg.png (ignore the typo).


Bug: 487768963