### PR TITLE
Fix the crash on shutdown

### DIFF
--- a/cobalt/app/app_lifecycle_delegate.cc
+++ b/cobalt/app/app_lifecycle_delegate.cc
@@ -81,13 +81,25 @@ class DefaultAppLifecycleRunner : public cobalt::AppLifecycleRunner {
 
   void ShutDown() override {
     content::Shell::Shutdown();
+
+    if (content_main_delegate_) {
+      content_main_delegate_->Shutdown();
+    }
+
+    // Must be called after content_main_delegate_->Shutdown() to prevent
+    // unregistering the main thread from the SequenceManager which
+    // happens with the destruction of the BrowserTaskExecutor. If the order
+    // is reversed the SequenceManager complains (fails DCHECK) that the
+    // ContentMainRunnerImpl::Shutdown() is happening on the wrong thread as
+    // no longer recognizes the main thread as a valid TaskEnvironment.
     if (main_runner_) {
       main_runner_->Shutdown();
     }
-    if (content_main_delegate_) {
-      content_main_delegate_->Shutdown();
-      content_main_delegate_.reset();
-    }
+
+    // Destroy only after main_runner_/ContentMainRunnerImpl is shutdown
+    // as the delegate is used internally.
+    content_main_delegate_.reset();
+
     // We intentionally do not null main_runner_ here to enforce the one-shot
     // rule: once stopped, the process cannot be re-started.
     exit_manager_.reset();

--- a/starboard/shared/signal/crash_signals.cc
+++ b/starboard/shared/signal/crash_signals.cc
@@ -31,6 +31,8 @@ const int kCrashSignalsToTrap[] = {
 
 const int kStopSignalsToTrap[] = {
     SIGHUP,
+    SIGINT,
+    SIGTERM,
 };
 
 void Crash(int signal_id) {

--- a/starboard/shared/signal/crash_signals_sigaction.cc
+++ b/starboard/shared/signal/crash_signals_sigaction.cc
@@ -31,6 +31,8 @@ const int kCrashSignalsToTrap[] = {
 
 const int kStopSignalsToTrap[] = {
     SIGHUP,
+    SIGINT,
+    SIGTERM,
 };
 
 void SetSignalHandler(int signal_id, SignalHandlerFunction handler) {


### PR DESCRIPTION
Fixed the shutdown order for the delegates to prevent the SequenceManager failing to recognized the main thread and crashing the app on shutdown.

Added support for SIGINT and SIGTERM for graceful shutdown. The signals are already used by YTS.

Applies thee fixes resolves the YTS cookie test.

Issue: 444451968
Issue: 489414212