### PR TITLE
starboard: Reset unsupported EGL attribs

### DIFF
--- a/ui/ozone/platform/starboard/BUILD.gn
+++ b/ui/ozone/platform/starboard/BUILD.gn
@@ -49,6 +49,7 @@ source_set("starboard") {
     "//ui/display",
     "//ui/events/ozone/layout:layout",
     "//ui/gfx:native_widget_types",
+    "//ui/gl",
     "//ui/ozone:ozone_base",
     "//ui/ozone/common",
     "//ui/platform_window",

--- a/ui/ozone/platform/starboard/gl_ozone_egl_starboard.cc
+++ b/ui/ozone/platform/starboard/gl_ozone_egl_starboard.cc
@@ -18,6 +18,8 @@
 
 #include "starboard/egl.h"
 #include "starboard/gles.h"
+#include "ui/gl/gl_context.h"
+#include "ui/gl/gl_context_egl.h"
 
 namespace ui {
 
@@ -233,6 +235,24 @@ gl::GLFunctionPointerType GetGlesInterfaceProcAddress(
 GLOzoneEGLStarboard::GLOzoneEGLStarboard() = default;
 
 GLOzoneEGLStarboard::~GLOzoneEGLStarboard() = default;
+
+scoped_refptr<gl::GLContext> GLOzoneEGLStarboard::CreateGLContext(
+    gl::GLShareGroup* share_group,
+    gl::GLSurface* compatible_surface,
+    const gl::GLContextAttribs& attribs) {
+  // Starboard EGL does not support the ANGLE extensions that back these
+  // attribs. Setting unsupported attributes to false so 
+  // GLContextEGL::InitializeImpl does not DCHECK on the mismatch.
+  gl::GLContextAttribs sb_attribs = attribs;
+  sb_attribs.bind_generates_resource = false;
+  sb_attribs.webgl_compatibility_context = false;
+  sb_attribs.global_texture_share_group = false;
+  sb_attribs.global_semaphore_share_group = false;
+  sb_attribs.allow_client_arrays = false;
+  sb_attribs.robust_resource_initialization = false;
+  return gl::InitializeGLContext(new gl::GLContextEGL(share_group),
+                                 compatible_surface, sb_attribs);
+}
 
 scoped_refptr<gl::GLSurface> GLOzoneEGLStarboard::CreateViewGLSurface(
     gl::GLDisplay* display,

--- a/ui/ozone/platform/starboard/gl_ozone_egl_starboard.h
+++ b/ui/ozone/platform/starboard/gl_ozone_egl_starboard.h
@@ -28,6 +28,10 @@ class GLOzoneEGLStarboard : public GLOzoneEGL {
 
   ~GLOzoneEGLStarboard() override;
 
+  scoped_refptr<gl::GLContext> CreateGLContext(
+      gl::GLShareGroup* share_group,
+      gl::GLSurface* compatible_surface,
+      const gl::GLContextAttribs& attribs) override;
   scoped_refptr<gl::GLSurface> CreateViewGLSurface(
       gl::GLDisplay* display,
       gfx::AcceleratedWidget window) override;


### PR DESCRIPTION
Override `CreateGLContext` to reset EGL context attributes unsupported by the Starboard EGL backend to their default values, so the caller does not request non-default behavior for those attributes.

This avoids DCHECK failures in `GLContextEGL::InitializeImpl`, which asserts that callers must not request ANGLE extensions that are not implemented for Starboard.

The fix is implemented entirely within the Starboard platform layer (inside the `ui/ozone/platform/starboard/` directory), leaving the upstream https://github.com/youtube/cobalt/tree/main/ui/gl/gl_context_egl.cc unmodified.

Bug: 486053854