### PR TITLE
media:  Make SbPlayerBridge use ExperirmentalFeatures struct

### DIFF
--- a/media/base/starboard/starboard_renderer_config.cc
+++ b/media/base/starboard/starboard_renderer_config.cc
@@ -13,8 +13,10 @@
 // limitations under the License.
 
 #include "media/base/starboard/starboard_renderer_config.h"
+#include "starboard/common/string.h"
 
 namespace media {
+using starboard::ToString;
 
 StarboardRendererConfig::StarboardRendererConfig() = default;
 StarboardRendererConfig::StarboardRendererConfig(
@@ -39,32 +41,30 @@ StarboardRendererConfig::StarboardRendererConfig(
 std::ostream& operator<<(
     std::ostream& os,
     const StarboardRendererConfig::ExperimentalFeatures& features) {
-  auto opt_to_string = [](const std::optional<int>& val) {
-    return val ? std::to_string(*val) : "(nullopt)";
-  };
-  return os << "{enable_flush_during_seek=" << features.enable_flush_during_seek
+  return os << "{enable_flush_during_seek="
+            << ToString(features.enable_flush_during_seek)
             << ", enable_reset_audio_decoder="
-            << features.enable_reset_audio_decoder
+            << ToString(features.enable_reset_audio_decoder)
             << ", pause_using_audio_track_state="
-            << features.pause_using_audio_track_state
+            << ToString(features.pause_using_audio_track_state)
             << ", report_buffering_state_during_flush="
-            << features.report_buffering_state_during_flush
+            << ToString(features.report_buffering_state_during_flush)
             << ", initial_max_frames_in_decoder="
-            << opt_to_string(features.initial_max_frames_in_decoder)
+            << ToString(features.initial_max_frames_in_decoder)
             << ", max_pending_input_frames="
-            << opt_to_string(features.max_pending_input_frames)
+            << ToString(features.max_pending_input_frames)
             << ", max_samples_per_write="
-            << opt_to_string(features.max_samples_per_write)
+            << ToString(features.max_samples_per_write)
             << ", video_decoder_initial_preroll_count="
-            << opt_to_string(features.video_decoder_initial_preroll_count)
+            << ToString(features.video_decoder_initial_preroll_count)
             << ", video_decoder_poll_interval_ms="
-            << opt_to_string(features.video_decoder_poll_interval_ms)
+            << ToString(features.video_decoder_poll_interval_ms)
             << ", video_renderer_min_input_buffers="
-            << opt_to_string(features.video_renderer_min_input_buffers)
+            << ToString(features.video_renderer_min_input_buffers)
             << ", video_renderer_min_decoded_frames="
-            << opt_to_string(features.video_renderer_min_decoded_frames)
+            << ToString(features.video_renderer_min_decoded_frames)
             << ", media_codec_reset_delay_ms="
-            << opt_to_string(features.media_codec_reset_delay_ms) << "}";
+            << ToString(features.media_codec_reset_delay_ms) << "}";
 }
 
 }  // namespace media

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -813,34 +813,34 @@ void SbPlayerBridge::CreatePlayer() {
       strcmp(experimental_features_extension->name,
              kStarboardExtensionExperimentalFeaturesConfigurationName) == 0 &&
       experimental_features_extension->version >= 1) {
-    StarboardExtensionExperimentalFeatures experimental_features = {};
+    StarboardExtensionExperimentalFeatures extension_features = {};
 
-    experimental_features.flush_decoder_during_reset =
+    extension_features.flush_decoder_during_reset =
         experimental_features_.enable_flush_during_seek;
-    experimental_features.media_codec_reset_delay_ms =
+    extension_features.media_codec_reset_delay_ms =
         ToIntPointer(experimental_features_.media_codec_reset_delay_ms);
-    experimental_features.pause_using_audio_track_state =
+    extension_features.pause_using_audio_track_state =
         experimental_features_.pause_using_audio_track_state;
-    experimental_features.reset_audio_decoder =
+    extension_features.reset_audio_decoder =
         experimental_features_.enable_reset_audio_decoder;
-    experimental_features.video_decoder_initial_preroll_count =
-        ToIntPointer(experimental_features_.video_decoder_initial_preroll_count);
-    experimental_features.video_decoder_poll_interval_ms =
+    extension_features.video_decoder_initial_preroll_count = ToIntPointer(
+        experimental_features_.video_decoder_initial_preroll_count);
+    extension_features.video_decoder_poll_interval_ms =
         ToIntPointer(experimental_features_.video_decoder_poll_interval_ms);
-    experimental_features.video_initial_max_frames_in_decoder =
+    extension_features.video_initial_max_frames_in_decoder =
         ToIntPointer(experimental_features_.initial_max_frames_in_decoder);
-    experimental_features.video_max_pending_input_frames =
+    extension_features.video_max_pending_input_frames =
         ToIntPointer(experimental_features_.max_pending_input_frames);
-    experimental_features.video_renderer_min_decoded_frames =
+    extension_features.video_renderer_min_decoded_frames =
         ToIntPointer(experimental_features_.video_renderer_min_decoded_frames);
-    experimental_features.video_renderer_min_input_buffers =
+    extension_features.video_renderer_min_input_buffers =
         ToIntPointer(experimental_features_.video_renderer_min_input_buffers);
 
     // Note: `max_samples_per_write` and `report_buffering_state_during_flush`
     // are not mapped here as they are consumed directly by the media layer.
 
     experimental_features_extension->SetExperimentalFeaturesForCurrentThread(
-        &experimental_features);
+        &extension_features);
   }
 
 #if BUILDFLAG(IS_ANDROID)

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -230,7 +230,7 @@ SbPlayerBridge::SbPlayerBridge(
 #endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
     const std::string& max_video_capabilities,
     int max_video_input_size,
-    const StarboardRendererConfig::ExperimentalFeatures& experimental_features
+    const ExperimentalFeatures& experimental_features
 #if BUILDFLAG(IS_ANDROID)
     ,
     jobject surface_view

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -230,16 +230,7 @@ SbPlayerBridge::SbPlayerBridge(
 #endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
     const std::string& max_video_capabilities,
     int max_video_input_size,
-    bool flush_decoder_during_reset,
-    bool reset_audio_decoder,
-    bool pause_using_audio_track_state,
-    std::optional<int> initial_max_frames_in_decoder,
-    std::optional<int> max_pending_input_frames,
-    std::optional<int> video_decoder_initial_preroll_count,
-    std::optional<int> video_decoder_poll_interval_ms,
-    std::optional<int> video_renderer_min_input_buffers,
-    std::optional<int> video_renderer_min_decoded_frames,
-    std::optional<int> media_codec_reset_delay_ms
+    const StarboardRendererConfig::ExperimentalFeatures& experimental_features
 #if BUILDFLAG(IS_ANDROID)
     ,
     jobject surface_view
@@ -266,16 +257,7 @@ SbPlayerBridge::SbPlayerBridge(
 #endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
       max_video_capabilities_(max_video_capabilities),
       max_video_input_size_(max_video_input_size),
-      flush_decoder_during_reset_(flush_decoder_during_reset),
-      reset_audio_decoder_(reset_audio_decoder),
-      pause_using_audio_track_state_(pause_using_audio_track_state),
-      initial_max_frames_in_decoder_(initial_max_frames_in_decoder),
-      max_pending_input_frames_(max_pending_input_frames),
-      video_decoder_initial_preroll_count_(video_decoder_initial_preroll_count),
-      video_decoder_poll_interval_ms_(video_decoder_poll_interval_ms),
-      video_renderer_min_input_buffers_(video_renderer_min_input_buffers),
-      video_renderer_min_decoded_frames_(video_renderer_min_decoded_frames),
-      media_codec_reset_delay_ms_(media_codec_reset_delay_ms)
+      experimental_features_(experimental_features)
 #if BUILDFLAG(IS_ANDROID)
       ,
       surface_view_(surface_view)
@@ -834,24 +816,28 @@ void SbPlayerBridge::CreatePlayer() {
     StarboardExtensionExperimentalFeatures experimental_features = {};
 
     experimental_features.flush_decoder_during_reset =
-        flush_decoder_during_reset_;
+        experimental_features_.enable_flush_during_seek;
     experimental_features.media_codec_reset_delay_ms =
-        ToIntPointer(media_codec_reset_delay_ms_);
+        ToIntPointer(experimental_features_.media_codec_reset_delay_ms);
     experimental_features.pause_using_audio_track_state =
-        pause_using_audio_track_state_;
-    experimental_features.reset_audio_decoder = reset_audio_decoder_;
+        experimental_features_.pause_using_audio_track_state;
+    experimental_features.reset_audio_decoder =
+        experimental_features_.enable_reset_audio_decoder;
     experimental_features.video_decoder_initial_preroll_count =
-        ToIntPointer(video_decoder_initial_preroll_count_);
+        ToIntPointer(experimental_features_.video_decoder_initial_preroll_count);
     experimental_features.video_decoder_poll_interval_ms =
-        ToIntPointer(video_decoder_poll_interval_ms_);
+        ToIntPointer(experimental_features_.video_decoder_poll_interval_ms);
     experimental_features.video_initial_max_frames_in_decoder =
-        ToIntPointer(initial_max_frames_in_decoder_);
+        ToIntPointer(experimental_features_.initial_max_frames_in_decoder);
     experimental_features.video_max_pending_input_frames =
-        ToIntPointer(max_pending_input_frames_);
+        ToIntPointer(experimental_features_.max_pending_input_frames);
     experimental_features.video_renderer_min_decoded_frames =
-        ToIntPointer(video_renderer_min_decoded_frames_);
+        ToIntPointer(experimental_features_.video_renderer_min_decoded_frames);
     experimental_features.video_renderer_min_input_buffers =
-        ToIntPointer(video_renderer_min_input_buffers_);
+        ToIntPointer(experimental_features_.video_renderer_min_input_buffers);
+
+    // Note: `max_samples_per_write` and `report_buffering_state_during_flush`
+    // are not mapped here as they are consumed directly by the media layer.
 
     experimental_features_extension->SetExperimentalFeaturesForCurrentThread(
         &experimental_features);

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -344,7 +344,7 @@ class SbPlayerBridge {
   // Set the maximum size in bytes of an input buffer for video.
   int max_video_input_size_;
 
-  const StarboardRendererConfig::ExperimentalFeatures& experimental_features_;
+  const StarboardRendererConfig::ExperimentalFeatures experimental_features_;
 
 #if BUILDFLAG(IS_ANDROID)
   // Set the surface to Android Overlay's surface view.

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -42,6 +42,7 @@
 #include "media/base/audio_decoder_config.h"
 #include "media/base/decoder_buffer.h"
 #include "media/base/demuxer_stream.h"
+#include "media/base/starboard/starboard_renderer_config.h"
 #include "media/base/video_decoder_config.h"
 #include "media/starboard/sbplayer_interface.h"
 #include "media/starboard/sbplayer_set_bounds_helper.h"
@@ -86,6 +87,7 @@ class SbPlayerBridge {
                  DecodeTargetProvider* const decode_target_provider,
                  std::string pipeline_identifier);
 #endif  // SB_HAS(PLAYER_WITH_URL)
+  using ExperimentalFeatures = StarboardRendererConfig::ExperimentalFeatures;
   // Create a SbPlayerBridge with normal player
   SbPlayerBridge(SbPlayerInterface* interface,
                  const scoped_refptr<base::SequencedTaskRunner>& task_runner,
@@ -106,16 +108,7 @@ class SbPlayerBridge {
 #endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
                  const std::string& max_video_capabilities,
                  int max_video_input_size,
-                 bool flush_decoder_during_reset,
-                 bool reset_audio_decoder,
-                 bool pause_using_audio_track_state,
-                 std::optional<int> initial_max_frames_in_decoder,
-                 std::optional<int> max_pending_input_frames,
-                 std::optional<int> video_decoder_initial_preroll_count,
-                 std::optional<int> video_decoder_poll_interval_ms,
-                 std::optional<int> video_renderer_min_input_buffers,
-                 std::optional<int> video_renderer_min_decoded_frames,
-                 std::optional<int> media_codec_reset_delay_ms
+                 const ExperimentalFeatures& experimental_features
 #if BUILDFLAG(IS_ANDROID)
                  ,
                  jobject surface_view
@@ -351,16 +344,7 @@ class SbPlayerBridge {
   // Set the maximum size in bytes of an input buffer for video.
   int max_video_input_size_;
 
-  const bool flush_decoder_during_reset_;
-  const bool reset_audio_decoder_;
-  const bool pause_using_audio_track_state_;
-  const std::optional<int> initial_max_frames_in_decoder_;
-  const std::optional<int> max_pending_input_frames_;
-  const std::optional<int> video_decoder_initial_preroll_count_;
-  const std::optional<int> video_decoder_poll_interval_ms_;
-  const std::optional<int> video_renderer_min_input_buffers_;
-  const std::optional<int> video_renderer_min_decoded_frames_;
-  const std::optional<int> media_codec_reset_delay_ms_;
+  const StarboardRendererConfig::ExperimentalFeatures& experimental_features_;
 
 #if BUILDFLAG(IS_ANDROID)
   // Set the surface to Android Overlay's surface view.

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -344,7 +344,7 @@ class SbPlayerBridge {
   // Set the maximum size in bytes of an input buffer for video.
   int max_video_input_size_;
 
-  const StarboardRendererConfig::ExperimentalFeatures experimental_features_;
+  const ExperimentalFeatures experimental_features_;
 
 #if BUILDFLAG(IS_ANDROID)
   // Set the surface to Android Overlay's surface view.

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -625,16 +625,7 @@ void StarboardRenderer::CreatePlayerBridge() {
         // TODO(b/326825450): Revisit 360 videos.
         kSbPlayerOutputModeInvalid, max_video_capabilities_,
         // TODO(b/326654546): Revisit HTMLVideoElement.setMaxVideoInputSize.
-        -1, experimental_features_.enable_flush_during_seek,
-        experimental_features_.enable_reset_audio_decoder,
-        experimental_features_.pause_using_audio_track_state,
-        experimental_features_.initial_max_frames_in_decoder,
-        experimental_features_.max_pending_input_frames,
-        experimental_features_.video_decoder_initial_preroll_count,
-        experimental_features_.video_decoder_poll_interval_ms,
-        experimental_features_.video_renderer_min_input_buffers,
-        experimental_features_.video_renderer_min_decoded_frames,
-        experimental_features_.media_codec_reset_delay_ms
+        /*max_video_input_size=*/-1, experimental_features_
 #if BUILDFLAG(IS_ANDROID)
         ,
         // TODO: b/475294958 - Revisit platform-specific codes above starboard.


### PR DESCRIPTION
This change refactors the SbPlayerBridge constructor to consolidate
multiple individual experimental player feature flags and optional
parameters into a single StarboardRendererConfig::ExperimentalFeatures
struct.

This improves code organization, readability, and reduces parameter
sprawl in the constructor signature, making it easier to manage and
extend experimental options for the Starboard media renderer.

Issue: 480134029