### PR TITLE
android: Implement flush-less seek optimization for VideoDecoder

### DIFF
--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -567,6 +567,16 @@ void MediaDecoder::TerminateDecoderThread() {
   }
 }
 
+void MediaDecoder::ClearPendingData() {
+  ScopedLock scoped_lock(mutex_);
+  number_of_pending_inputs_.store(0);
+  pending_inputs_.clear();
+  input_buffer_indices_.clear();
+  dequeue_output_results_.clear();
+  // We cannot clear |pending_input_to_retry_| as it's not synchronized by
+  // |mutex_|.
+}
+
 void MediaDecoder::CollectPendingData_Locked(
     std::deque<PendingInput>* pending_inputs,
     std::vector<int>* input_buffer_indices,
@@ -721,9 +731,9 @@ bool MediaDecoder::ProcessOneInputBuffer(
           host_->IsBufferDecodeOnly(input_buffer));
     }
   } else {
+    int eos_flag = enable_flushless_seek_ ? 0 : BUFFER_FLAG_END_OF_STREAM;
     status = media_codec_bridge_->QueueInputBuffer(
-        dequeue_input_result.index, kNoOffset, size, kNoPts,
-        BUFFER_FLAG_END_OF_STREAM, false);
+        dequeue_input_result.index, kNoOffset, size, kNoPts, eos_flag, false);
     host_->OnEndOfStreamWritten(media_codec_bridge_.get());
   }
 

--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -120,6 +120,8 @@ class MediaDecoder final
   bool is_valid() const { return media_codec_bridge_ != NULL; }
 
   bool Flush();
+  void ClearPendingData();
+  void SetEnableFlushlessSeek(bool enable) { enable_flushless_seek_ = enable; }
 
  private:
   // Holding inputs to be processed.  They are mostly InputBuffer objects, but
@@ -219,6 +221,8 @@ class MediaDecoder final
   std::atomic_bool stream_ended_{false};
 
   std::atomic_bool destroying_{false};
+
+  bool enable_flushless_seek_ = false;
 
   std::optional<PendingInputToRetry> pending_input_to_retry_;
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -647,6 +647,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         force_reset_surface, kForceResetSurfaceUnderTunnelMode,
         force_big_endian_hdr_metadata, max_video_input_size,
         creation_parameters.surface_view(), enable_flush_during_seek,
+        true, /* enable_flushless_seek */
         reset_delay_usec, flush_delay_usec, experimental_features,
         error_message);
     if ((*error_message).empty() &&

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -388,6 +388,7 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
                            int max_video_input_size,
                            void* surface_view,
                            bool enable_flush_during_seek,
+                           bool enable_flushless_seek,
                            int64_t reset_delay_usec,
                            int64_t flush_delay_usec,
                            const ExperimentalFeatures& experimental_features,
@@ -406,6 +407,8 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
       max_video_input_size_(max_video_input_size),
       surface_view_(surface_view),
       enable_flush_during_seek_(enable_flush_during_seek),
+      enable_flushless_seek_(enable_flushless_seek &&
+                             tunnel_mode_audio_session_id == -1),
       reset_delay_usec_(android_get_device_api_level() < 34 ? reset_delay_usec
                                                             : 0),
       flush_delay_usec_(android_get_device_api_level() < 34 ? flush_delay_usec
@@ -541,6 +544,15 @@ void VideoDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
   SB_DCHECK_EQ(input_buffers.front()->sample_type(), kSbMediaTypeVideo);
   SB_DCHECK(decoder_status_cb_);
 
+  if (is_flushless_seek_pending_.load()) {
+    // We just did a flush-less Reset(). The first buffer arriving here must be
+    // the new keyframe we are seeking to. We record its PTS so we can drop all
+    // in-flight output frames with a PTS older than or different from this new
+    // stream timeline.
+    seek_target_keyframe_pts_us_.store(input_buffers.front()->timestamp());
+    is_flushless_seek_pending_.store(false);
+  }
+
   if (input_buffer_written_ == 0) {
     SB_DCHECK_EQ(video_fps_, 0);
     first_buffer_timestamp_ = input_buffers.front()->timestamp();
@@ -609,6 +621,7 @@ void VideoDecoder::WriteEndOfStream() {
     return;
   }
   end_of_stream_written_ = true;
+  expected_total_frames_ = input_buffer_written_;
 
   if (input_buffer_written_ == 0) {
     // In this case, |media_decoder_|'s decoder thread is not initialized,
@@ -662,9 +675,29 @@ void VideoDecoder::ResetInternal(bool skip_flush) {
     if (reset_delay_usec_ > 0) {
       usleep(reset_delay_usec_);
     }
+  }
+  if (enable_flushless_seek_ && !pending_destroy && media_decoder_) {
+    // Perform flush-less seek optimization
+    media_decoder_->ClearPendingData();
+    is_flushless_seek_pending_.store(true);
+    seek_target_keyframe_pts_us_.store(
+        kInvalidSeekTargetPts);  // Invalidate any previous target (for double
+                                 // seeks)
+  } else {
+    // If fail to flush |media_decoder_| or |media_decoder_| is null, then
+    // re-create |media_decoder_|. If the codec is kSbMediaVideoCodecAv1,
+    // set video_fps_ to 0 will call InitializeCodec(),
+    // which we do not need if flush the codec.
+    if (!enable_flush_during_seek_ || !media_decoder_ ||
+        !media_decoder_->Flush()) {
+      TeardownCodec();
+      if (reset_delay_usec_ > 0) {
+        usleep(reset_delay_usec_);
+      }
 
-    input_buffer_written_ = 0;
-    video_fps_ = 0;
+      input_buffer_written_ = 0;
+      video_fps_ = 0;
+    }
   }
   CancelPendingJobs();
 
@@ -678,6 +711,7 @@ void VideoDecoder::ResetInternal(bool skip_flush) {
   tunnel_mode_first_frame_rendered_.store(false);
   tunnel_mode_prerolled_frames_.store(0);
   end_of_stream_written_ = false;
+  expected_total_frames_ = -1;
   pending_input_buffers_.clear();
 
   // TODO: We rely on VideoRenderAlgorithmTunneled::Seek() to be called inside
@@ -801,6 +835,7 @@ bool VideoDecoder::InitializeCodec(const VideoStreamInfo& video_stream_info,
       max_video_input_size_, flush_delay_usec_, use_dual_threads_,
       error_message));
   if (media_decoder_->is_valid()) {
+    media_decoder_->SetEnableFlushlessSeek(enable_flushless_seek_);
     if (error_cb_) {
       media_decoder_->Initialize(
           std::bind(&VideoDecoder::ReportError, this, _1, _2));
@@ -926,8 +961,30 @@ void VideoDecoder::ProcessOutputBuffer(
   SB_DCHECK(decoder_status_cb_);
   SB_DCHECK_GE(dequeue_output_result.index, 0);
 
+  if (is_flushless_seek_pending_.load()) {
+    // We are waiting for the first new InputBuffer after a reset, so drop
+    // anything that is currently draining from the codec pipeline.
+    media_codec_bridge->ReleaseOutputBuffer(dequeue_output_result.index, false);
+    return;
+  }
+
+  int64_t target_pts = seek_target_keyframe_pts_us_.load();
+  if (target_pts != kInvalidSeekTargetPts) {
+    if (dequeue_output_result.presentation_time_microseconds != target_pts) {
+      // This frame was already in the hardware pipeline before the flush-less
+      // seek was initiated. Drop it, so it doesn't freeze or glitch the player.
+      media_codec_bridge->ReleaseOutputBuffer(dequeue_output_result.index,
+                                              false);
+      return;
+    }
+    // We have hit the new keyframe. The old pipeline is fully drained.
+    seek_target_keyframe_pts_us_.store(kInvalidSeekTargetPts);
+  }
+
   bool is_end_of_stream =
-      dequeue_output_result.flags & BUFFER_FLAG_END_OF_STREAM;
+      (dequeue_output_result.flags & BUFFER_FLAG_END_OF_STREAM) ||
+      (enable_flushless_seek_ && expected_total_frames_ != -1 &&
+       decoded_output_frames_ + 1 == expected_total_frames_);
   if (!is_end_of_stream) {
     ++decoded_output_frames_;
     if (output_format_) {

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -70,9 +70,10 @@ class VideoDecoder
                bool force_reset_surface,
                bool force_reset_surface_under_tunnel_mode,
                bool force_big_endian_hdr_metadata,
-               int max_input_size,
+               int max_video_input_size,
                void* surface_view,
                bool enable_flush_during_seek,
+               bool enable_flushless_seek,
                int64_t reset_delay_usec,
                int64_t flush_delay_usec,
                const ::starboard::shared::starboard::ExperimentalFeatures&
@@ -238,6 +239,16 @@ class VideoDecoder
 
   std::vector<scoped_refptr<InputBuffer>> pending_input_buffers_;
   int video_fps_ = 0;
+
+  // Variables for flush-less seek optimization
+  const bool enable_flushless_seek_;
+  std::atomic_bool is_flushless_seek_pending_{false};
+  // We use the minimum value of int64_t as a sentinel for 'no value' since
+  // std::atomic doesn't support std::optional.
+  static constexpr int64_t kInvalidSeekTargetPts =
+      std::numeric_limits<int64_t>::min();
+  std::atomic<int64_t> seek_target_keyframe_pts_us_{kInvalidSeekTargetPts};
+  int expected_total_frames_ = -1;  // -1 means EOS not written yet
 
   // The variables below are used to calculate platform max supported MediaCodec
   // output buffers.

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -26,6 +26,7 @@
 #include "starboard/common/murmurhash2.h"
 #include "starboard/common/player.h"
 #include "starboard/common/string.h"
+#include "starboard/common/time.h"
 #include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/drm/drm_system_internal.h"
 #include "starboard/shared/starboard/player/filter/audio_decoder_internal.h"
@@ -201,6 +202,8 @@ HandlerResult FilterBasedPlayerWorkerHandler::Seek(int64_t seek_to_time,
     SB_DLOG(ERROR) << "Try to seek to negative timestamp " << seek_to_time;
     seek_to_time = 0;
   }
+
+  seek_start_time_ = ::starboard::CurrentMonotonicTime();
 
   media_time_provider_->Pause();
   if (video_renderer_) {
@@ -452,6 +455,11 @@ void FilterBasedPlayerWorkerHandler::OnPrerolled(SbMediaType media_type) {
 
   if ((!audio_renderer_ || audio_prerolled_) &&
       (!video_renderer_ || video_prerolled_)) {
+    if (seek_start_time_ != 0) {
+      int64_t latency = ::starboard::CurrentMonotonicTime() - seek_start_time_;
+      SB_LOG(INFO) << "Seek latency: " << latency << "us";
+      seek_start_time_ = 0;
+    }
     update_player_state_cb_(kSbPlayerStatePresenting);
     // The call is required to improve the calculation of media time in
     // PlayerInternal, because it updates the system monotonic time used as the

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -111,6 +111,8 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   bool audio_ended_ = false;
   bool video_ended_ = false;
 
+  int64_t seek_start_time_ = 0;
+
   SbPlayerOutputMode output_mode_;
   int max_video_input_size_;
   ::starboard::shared::starboard::ExperimentalFeatures experimental_features_;

--- a/starboard/shared/starboard/player/filter/stub_video_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_video_decoder.cc
@@ -64,7 +64,7 @@ void StubVideoDecoder::WriteEndOfStream() {
   decoder_status_cb_(kBufferFull, VideoFrame::CreateEOSFrame());
 }
 
-void StubVideoDecoder::Reset() {
+void StubVideoDecoder::Reset(bool pending_destroy) {
   SB_DCHECK(BelongsToCurrentThread());
 
   video_stream_info_ = media::VideoStreamInfo();

--- a/starboard/shared/starboard/player/filter/stub_video_decoder.h
+++ b/starboard/shared/starboard/player/filter/stub_video_decoder.h
@@ -28,7 +28,7 @@ namespace starboard::shared::starboard::player::filter {
 class StubVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
  public:
   StubVideoDecoder() {}
-  ~StubVideoDecoder() { Reset(); }
+  ~StubVideoDecoder() { Reset(true); }
 
   void Initialize(const DecoderStatusCB& decoder_status_cb,
                   const ErrorCB& error_cb) override;
@@ -39,7 +39,7 @@ class StubVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
 
   void WriteInputBuffers(const InputBuffers& input_buffers) override;
   void WriteEndOfStream() override;
-  void Reset() override;
+  void Reset(bool pending_destroy) override;
 
   SbDecodeTarget GetCurrentDecodeTarget() override;
 

--- a/starboard/shared/starboard/player/filter/video_decoder_internal.h
+++ b/starboard/shared/starboard/player/filter/video_decoder_internal.h
@@ -99,7 +99,7 @@ class VideoDecoder {
   // over data from previous buffers.  |decoder_status_cb| won't be called
   // after this function returns unless WriteInputFrame() or WriteEndOfStream()
   // is called again.
-  virtual void Reset() = 0;
+  virtual void Reset(bool pending_destroy) = 0;
 
   // Alternative function to Reset the codec specifically in cases where it is
   // being torn down. By default, this function will be equivalent to the

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -167,7 +167,7 @@ void VideoRendererImpl::Seek(int64_t seek_to_time) {
   SB_DCHECK_GE(seek_to_time, 0);
 
   if (first_input_written_) {
-    decoder_->Reset();
+    decoder_->Reset(false);
     first_input_written_ = false;
   }
 


### PR DESCRIPTION
This change introduces a flush-less seek optimization for Android's MediaCodec, specifically for video decoders. This avoids the high latency associated with blocking JNI flush() calls and destroying the decoder thread during seeks, provided the decoder supports adaptive playback (which is generally true for our target devices) and tunnel mode is disabled.

Key changes:
- MediaDecoder::ClearPendingData() introduced to safely drop cached inputs without performing a full hardware flush.
- VideoDecoder updated with a state machine (is_flushless_seek_pending_, seek_target_keyframe_pts_us_) to bypass flush() and drop stale output frames emitted by the codec pipeline after a seek until the new keyframe emerges.
- VideoDecoder::Reset signature expanded with a pending_destroy flag to differentiate between normal seeks and complete teardowns, guaranteeing hardware is safely freed when the player is destroyed.
- Added latency tracking and logging in FilterBasedPlayerWorkerHandler to measure the time between Seek() and the player returning to the presenting state.

All state transitions between the player worker thread and the decoder thread are synchronized via std::atomic variables to prevent data races.

Bug: 490447770