### PR TITLE
tvOS: Handle missing UIWindow in GetPlatformWindow()

### DIFF
--- a/starboard/tvos/shared/media/av_sample_buffer_video_renderer.mm
+++ b/starboard/tvos/shared/media/av_sample_buffer_video_renderer.mm
@@ -132,6 +132,11 @@ const int kRequiredBuffersInDisplayLayer = 16;
 UIWindow* GetPlatformWindow() {
   NSSet<UIScene*>* connected_scenes =
       UIApplication.sharedApplication.connectedScenes;
+  if (connected_scenes.count == 0) {
+    return nil;
+  }
+  // We don't expect multiple scenes on tvOS. This will assert if that
+  // assumption is violated.
   SB_CHECK_EQ(connected_scenes.count, 1U);
   UIWindowScene* scene =
       base::apple::ObjCCastStrict<UIWindowScene>(connected_scenes.anyObject);


### PR DESCRIPTION
Browser tests on tvOS may run without a connected UIWindowScene,
as the test shell does not participate in the normal UIKit scene
lifecycle.

GetPlatformWindow() previously assumed exactly one scene was always
available, leading to an assert when connectedScenes was empty. This
change updates GetPlatformWindow() to return nil in such cases and
modifies call sites to safely handle the absence of a UIWindow.

This prevents crashes in browser test environments that do not have
an active UIWindowScene.

Bug: 489556129