### PR TITLE
android: Remove tunnel mode preroll timeout fallback

### DIFF
--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -239,9 +239,10 @@ const int64_t kNeedMoreInputCheckIntervalInTunnelMode = 50'000;  // 50ms
 
 const int kInitialPrerollFrameCount = 8;
 const int kNonInitialPrerollFrameCount = 1;
-
-const int kSeekingPrerollPendingWorkSizeInTunnelMode =
-    16 + kInitialPrerollFrameCount;
+// According to b/487397946#comment3, after the first non-DECODE_ONLY frame is
+// rendered, the rest of the playback should play without frame drops. So,
+// tunnel mode prerolling only needs 1 frame.
+const int kTunnelModePrerollFrameCount = 1;
 const int kDefaultMaxPendingInputsSize = 128;
 
 const int kFpsGuesstimateRequiredInputBufferCount = 3;
@@ -518,6 +519,10 @@ size_t VideoDecoder::GetPrerollFrameCount() const {
 }
 
 int64_t VideoDecoder::GetPrerollTimeout() const {
+  // Tunnel mode uses its own preroll logic.
+  if (tunnel_mode_audio_session_id_ != -1) {
+    return std::numeric_limits<int64_t>::max();
+  }
   if (input_buffer_written_ > 0 && first_buffer_timestamp_ != 0) {
     return std::numeric_limits<int64_t>::max();
   }
@@ -558,11 +563,6 @@ void VideoDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
         ReportError(kSbPlayerErrorDecode, error_message);
         return;
       }
-    }
-
-    if (tunnel_mode_audio_session_id_ != -1) {
-      Schedule(std::bind(&VideoDecoder::OnTunnelModePrerollTimeout, this),
-               kInitialPrerollTimeout);
     }
   }
 
@@ -669,7 +669,8 @@ void VideoDecoder::Reset() {
   output_format_ = std::nullopt;
 
   tunnel_mode_prerolling_.store(true);
-  tunnel_mode_frame_rendered_.store(false);
+  tunnel_mode_first_frame_rendered_.store(false);
+  tunnel_mode_prerolled_frames_.store(0);
   end_of_stream_written_ = false;
   pending_input_buffers_.clear();
 
@@ -855,8 +856,6 @@ void VideoDecoder::OnEndOfStreamWritten(MediaCodecBridge* media_codec_bridge) {
 
   SB_DCHECK(decoder_status_cb_);
 
-  tunnel_mode_prerolling_.store(false);
-
   // TODO: Refactor the VideoDecoder and the VideoRendererImpl to improve the
   //       handling of preroll and EOS for pure punchout decoders.
   decoder_status_cb_(kBufferFull, VideoFrame::CreateEOSFrame());
@@ -895,39 +894,14 @@ void VideoDecoder::WriteInputBuffersInternal(
              kNeedMoreInputCheckIntervalInTunnelMode);
   }
 
-  if (tunnel_mode_audio_session_id_ != -1) {
-    int64_t max_timestamp = input_buffers[0]->timestamp();
+  if (tunnel_mode_audio_session_id_ != -1 && tunnel_mode_prerolling_.load()) {
     for (const auto& input_buffer : input_buffers) {
-      max_timestamp = std::max(max_timestamp, input_buffer->timestamp());
+      if (input_buffer->timestamp() >= video_frame_tracker_->seek_to_time()) {
+        tunnel_mode_prerolled_frames_++;
+      }
     }
-
-    if (tunnel_mode_prerolling_.load()) {
-      // TODO: Refine preroll logic in tunnel mode.
-      bool enough_buffers_written_to_media_codec = false;
-      if (first_buffer_timestamp_ == 0) {
-        // Initial playback.
-        enough_buffers_written_to_media_codec =
-            (input_buffer_written_ -
-             media_decoder_->GetNumberOfPendingInputs()) >
-            kInitialPrerollFrameCount;
-      } else {
-        // Seeking.  Note that this branch can be eliminated once seeking in
-        // tunnel mode is always aligned to the next video key frame.
-        enough_buffers_written_to_media_codec =
-            (input_buffer_written_ -
-             media_decoder_->GetNumberOfPendingInputs()) >
-                kSeekingPrerollPendingWorkSizeInTunnelMode &&
-            max_timestamp >= video_frame_tracker_->seek_to_time();
-      }
-
-      bool cache_full = media_decoder_->GetNumberOfPendingInputs() >=
-                        max_pending_inputs_size_;
-      bool prerolled = tunnel_mode_frame_rendered_.load() > 0 ||
-                       enough_buffers_written_to_media_codec || cache_full;
-
-      if (prerolled) {
-        TryToSignalPrerollForTunnelMode();
-      }
+    if (tunnel_mode_prerolled_frames_ >= kTunnelModePrerollFrameCount) {
+      TryToSignalPrerollForTunnelMode();
     }
   }
 }
@@ -1226,6 +1200,11 @@ void VideoDecoder::OnNewTextureAvailable() {
 }
 
 void VideoDecoder::TryToSignalPrerollForTunnelMode() {
+  if (!tunnel_mode_first_frame_rendered_ ||
+      tunnel_mode_prerolled_frames_ < kTunnelModePrerollFrameCount) {
+    return;
+  }
+
   if (tunnel_mode_prerolling_.exchange(false)) {
     SB_LOG(ERROR) << "Tunnel mode preroll finished.";
     // TODO: Currently the decoder sends a dummy frame to the renderer to signal
@@ -1245,22 +1224,13 @@ void VideoDecoder::OnFrameRendered(int64_t frame_timestamp) {
   SB_DCHECK(is_video_frame_tracker_enabled_);
   SB_DCHECK(video_frame_tracker_);
 
-  if (tunnel_mode_audio_session_id_ != -1) {
-    tunnel_mode_frame_rendered_.store(true);
-  }
   video_frame_tracker_->OnFrameRendered(frame_timestamp);
 }
 
 void VideoDecoder::OnFirstTunnelFrameReady() {
   SB_DCHECK_NE(tunnel_mode_audio_session_id_, -1);
 
-  TryToSignalPrerollForTunnelMode();
-}
-
-void VideoDecoder::OnTunnelModePrerollTimeout() {
-  SB_CHECK(BelongsToCurrentThread());
-  SB_DCHECK_NE(tunnel_mode_audio_session_id_, -1);
-
+  tunnel_mode_first_frame_rendered_.store(true);
   TryToSignalPrerollForTunnelMode();
 }
 

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -127,7 +127,6 @@ class VideoDecoder
   bool IsFrameRenderedCallbackEnabled();
   void OnFrameRendered(int64_t frame_timestamp);
   void OnFirstTunnelFrameReady();
-  void OnTunnelModePrerollTimeout();
   void OnTunnelModeCheckForNeedMoreInput();
 
   void OnVideoFrameRelease(int64_t pts_us, int64_t release_at_us);
@@ -192,7 +191,8 @@ class VideoDecoder
 
   // Preroll in tunnel mode is handled in this class instead of in the renderer.
   std::atomic_bool tunnel_mode_prerolling_{true};
-  std::atomic_bool tunnel_mode_frame_rendered_{false};
+  std::atomic_bool tunnel_mode_first_frame_rendered_{false};
+  std::atomic_int tunnel_mode_prerolled_frames_{0};
 
   // Since GetCurrentDecodeTarget() needs to be called from an arbitrary thread
   // to obtain the current decode target (which ultimately ends up being a


### PR DESCRIPTION
Remove the preroll timeout fallback for tunnel mode video decoding.
The previous preroll completion logic in tunnel mode, which included a
timeout, was unreliable. This change introduces a more robust
mechanism that relies on the first frame being rendered and a
specified number of frames being processed to signal preroll
completion.

Bug: 487397946