### PR TITLE
cobalt/test: Change browser test docker workflow

### DIFF
--- a/cobalt/build/archive_test_artifacts.py
+++ b/cobalt/build/archive_test_artifacts.py
@@ -79,10 +79,12 @@ def _handle_browsertests(
   collect_script = os.path.join(source_dir, 'cobalt', 'testing',
                                 'browser_tests', 'tools',
                                 'collect_test_artifacts.py')
-  output_name = f'cobalt_browsertests_deps.tar.{compression}'
+  output_name = f'cobalt_browsertests_artifacts.tar.{compression}'
+  runner_name = f'cobalt_browsertests_runner.tar.{compression}'
   cmd = [
       sys.executable, collect_script, out_dir, '-o', output_name,
-      '--output_dir', destination_dir, '--compression', compression
+      '--runner_output', runner_name, '--output_dir', destination_dir,
+      '--compression', compression, '--split'
   ]
   print(f"Running: {' '.join(cmd)}")
   subprocess.check_call(cmd)

--- a/cobalt/build/test_archive_test_artifacts.py
+++ b/cobalt/build/test_archive_test_artifacts.py
@@ -164,7 +164,9 @@ class TestArchiveTestArtifacts(unittest.TestCase):
     collect_cmd = mock_call.call_args_list[0][0][0]
     self.assertIn('collect_test_artifacts.py', collect_cmd[1])
     self.assertIn(self.out_dir, collect_cmd)
-    self.assertIn('cobalt_browsertests_deps.tar.gz', collect_cmd)
+    self.assertIn('cobalt_browsertests_artifacts.tar.gz', collect_cmd)
+    self.assertIn('cobalt_browsertests_runner.tar.gz', collect_cmd)
+    self.assertIn('--split', collect_cmd)
     self.assertIn('--compression', collect_cmd)
     self.assertIn('gz', collect_cmd)
 

--- a/cobalt/testing/browser_tests/tools/Dockerfile
+++ b/cobalt/testing/browser_tests/tools/Dockerfile
@@ -7,14 +7,12 @@ RUN apt-get update && apt-get install -y unzip && rm -rf /var/lib/apt/lists/*
 
 WORKDIR /opt/cobalt_browsertests
 
-# Add and extract the artifacts tarball.
-# Expects the artifacts tarball to be in the build context.
-ADD cobalt/testing/browser_tests/tools/cobalt_browsertests_deps.tar* .
+# Add and extract the runner tarball.
+# Expects the runner tarball to be in the build context.
+ADD cobalt/testing/browser_tests/tools/cobalt_browsertests_runner.tar* .
 
-# Prune unstripped libraries and symbolication tools to keep the image light.
-# We keep the stripped versions which are already at the root of the build dir.
+# Prune symbolication tools to keep the image light.
 # These paths are relative to /opt/cobalt_browsertests/src/
-RUN find src/out/*/lib.unstripped -type f -delete || true
 RUN rm -rf src/third_party/llvm-build \
            src/third_party/android_platform/development/scripts \
            src/tools/python

--- a/cobalt/testing/browser_tests/tools/collect_test_artifacts.py
+++ b/cobalt/testing/browser_tests/tools/collect_test_artifacts.py
@@ -231,11 +231,16 @@ def main():
 
       # Record target info
       target_name = build_dir.name
+      cwd_abs = Path.cwd().resolve()
       target_map[target_name] = {
-          'deps': str(runtime_deps_path.relative_to(build_dir)),
-          'runner': str(test_runner_rel),
-          'is_android': is_android,
-          'build_dir': str(build_dir)
+          'deps':
+              str(runtime_deps_path.resolve().relative_to(cwd_abs)),
+          'runner':
+              str((build_dir / test_runner_rel).resolve().relative_to(cwd_abs)),
+          'is_android':
+              is_android,
+          'build_dir':
+              str(build_dir.resolve().relative_to(cwd_abs))
       }
 
       logging.info('Copying files from %s...', runtime_deps_path)

--- a/cobalt/testing/browser_tests/tools/collect_test_artifacts.py
+++ b/cobalt/testing/browser_tests/tools/collect_test_artifacts.py
@@ -11,8 +11,8 @@ into a portable compressed tarball.
 """
 
 import argparse
+import json
 import logging
-import os
 import shutil
 import subprocess
 import sys
@@ -26,67 +26,64 @@ logging.basicConfig(
     datefmt='%H:%M:%S')
 
 
-def find_runtime_deps(build_dir):
+def find_runtime_deps(build_dir: Path):
   """Finds the runtime_deps file for cobalt_browsertests in the build dir."""
   # Try exact match first
-  exact_deps_file = os.path.join(
-      build_dir, 'gen.runtime/cobalt/testing/browser_tests/'
+  exact_deps_file = build_dir / (
+      'gen.runtime/cobalt/testing/browser_tests/'
       'cobalt_browsertests__test_runner_script.runtime_deps')
-  if os.path.isfile(exact_deps_file):
-    return Path(exact_deps_file)
+  if exact_deps_file.is_file():
+    return exact_deps_file
 
   # Fallback to rglob
   results = list(
-      Path(build_dir).rglob(
-          'cobalt_browsertests__test_runner_script.runtime_deps'))
+      build_dir.rglob('cobalt_browsertests__test_runner_script.runtime_deps'))
   if results:
     return results[0]
   return None
 
 
-def get_test_runner(build_dir, is_android):
+def get_test_runner(build_dir: Path, is_android: bool):
   """Returns the relative path to the test runner within the build dir."""
   if is_android:
-    return os.path.join('bin', 'run_cobalt_browsertests')
+    return Path('bin/run_cobalt_browsertests')
 
   # For Linux/non-android, we will use the binary directly via
   # run_browser_tests.py. However, some platforms might have a runner script.
   runner_names = [
-      os.path.join('bin', 'run_cobalt_browsertests'),
-      'cobalt_browsertests_runner',
-      'cobalt_browsertests',
+      Path('bin/run_cobalt_browsertests'),
+      Path('cobalt_browsertests_runner'),
+      Path('cobalt_browsertests'),
   ]
   for name in runner_names:
-    if os.path.isfile(os.path.join(build_dir, name)):
+    if (build_dir / name).is_file():
       return name
 
-  return 'cobalt_browsertests'
+  return Path('cobalt_browsertests')
 
 
-def copy_fast(src, dst):
+def copy_fast(src: Path, dst: Path):
   """Fast copy using system cp if possible, falling back to shutil."""
-  dst_parent = os.path.dirname(dst)
-  os.makedirs(dst_parent, exist_ok=True)
+  dst.parent.mkdir(parents=True, exist_ok=True)
   try:
-    if os.path.isdir(src):
+    if src.is_dir():
       # Use system cp -af for directories to handle many files efficiently.
       # -a preserves attributes, -f forces overwrite by unlinking if needed.
-      subprocess.run(['cp', '-af', src, dst_parent + '/'], check=True)
+      subprocess.run(['cp', '-af', str(src), str(dst.parent) + '/'], check=True)
     else:
       # Use cp -af for files too.
-      subprocess.run(['cp', '-af', src, dst], check=True)
+      subprocess.run(['cp', '-af', str(src), str(dst)], check=True)
   except (subprocess.CalledProcessError, subprocess.SubprocessError, OSError):
-    if os.path.isdir(src):
+    if src.is_dir():
       shutil.copytree(src, dst, symlinks=True, dirs_exist_ok=True)
     else:
       shutil.copy2(src, dst, follow_symlinks=False)
 
 
-def generate_runner_py(dst_path, target_map):
+def generate_runner_py(dst_path: Path, target_map: dict):
   """Generates the run_tests.py script inside the archive."""
-  template_path = os.path.join(
-      os.path.dirname(__file__), 'run_tests.template.py')
-  with open(template_path, 'r', encoding='utf-8') as f:
+  template_path = Path(__file__).parent / 'run_tests.template.py'
+  with template_path.open('r', encoding='utf-8') as f:
     content = f.read()
 
     # Inject the target map into the template.
@@ -95,28 +92,46 @@ def generate_runner_py(dst_path, target_map):
     content = content.replace('TARGET_MAP = {}',
                               f'TARGET_MAP = {target_map_repr}')
 
-  with open(dst_path, 'w', encoding='utf-8') as f:
+  with dst_path.open('w', encoding='utf-8') as f:
     f.write(content)
-  os.chmod(dst_path, 0o755)
+  dst_path.chmod(0o755)
 
 
-def copy_if_needed(src, dst, copied_sources):
+def copy_if_needed(src: Path, dst: Path, copied_sources: set):
   """Copies src to dst if src (or its parent) hasn't been copied already."""
-  abs_src = os.path.abspath(src)
+  abs_src = src.resolve()
   if abs_src in copied_sources:
     return
 
   # Optimization: If a parent directory of this file/dir was already copied
   # as a directory, we can skip it.
-  parent = os.path.dirname(abs_src)
-  while parent and parent != os.path.dirname(parent):
-    if parent in copied_sources and os.path.isdir(parent):
+  for parent in abs_src.parents:
+    if parent in copied_sources and parent.is_dir():
       return
-    parent = os.path.dirname(parent)
 
-  if os.path.exists(src):
+  if src.exists():
     copy_fast(src, dst)
     copied_sources.add(abs_src)
+
+
+def create_tarball(output: Path, compression: str, source_dir: Path):
+  """Creates a tarball from source_dir."""
+  logging.info('Creating tarball: %s', output)
+  if compression == 'gz':
+    compression_flag = 'gzip -1'
+  elif compression == 'xz':
+    compression_flag = 'xz -T0 -1'
+  elif compression == 'zstd':
+    compression_flag = 'zstd -T0 -1'
+  else:
+    raise ValueError(f'Unsupported compression: {compression}')
+
+  subprocess.run([
+      'tar', '-I', compression_flag, '-C',
+      str(source_dir), '-cf',
+      str(output), '.'
+  ],
+                 check=True)
 
 
 def main():
@@ -145,56 +160,87 @@ def main():
       default=('cobalt/testing/browser_tests/tools/'
                'platform-tools_r33.0.1-linux.zip'),
       help='The zip file to incorporate into the tarball.')
+  parser.add_argument(
+      '--split',
+      action='store_true',
+      help='Split artifacts into runner and dynamic build artifacts.')
+  parser.add_argument(
+      '--runner_output',
+      default='cobalt_browsertests_runner.tar.gz',
+      help='Output filename for the runner part when --split is used.')
+
   args = parser.parse_args()
 
+  output_path = Path(args.output)
+  runner_output_path = Path(args.runner_output)
+
   if args.output_dir:
-    if os.path.isabs(args.output):
+    output_dir = Path(args.output_dir)
+    if output_path.is_absolute():
       parser.error('--output cannot be an absolute path when --output_dir is '
                    'specified.')
-    os.makedirs(args.output_dir, exist_ok=True)
-    args.output = os.path.join(args.output_dir, args.output)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    output_path = output_dir / output_path
+    if args.runner_output:
+      runner_output_path = output_dir / runner_output_path
 
   target_map = {}
   copied_sources = set()
 
-  with tempfile.TemporaryDirectory() as stage_dir:
-    src_stage = os.path.join(stage_dir, 'src')
-    os.makedirs(src_stage)
+  with tempfile.TemporaryDirectory() as stage_dir_str:
+    stage_dir = Path(stage_dir_str)
+    # Use separate staging areas if splitting.
+    if args.split:
+      runner_stage = stage_dir / 'runner'
+      artifacts_stage = stage_dir / 'artifacts'
+      runner_stage.mkdir()
+      artifacts_stage.mkdir()
+      runner_src_stage = runner_stage / 'src'
+      artifacts_src_stage = artifacts_stage / 'src'
+      runner_src_stage.mkdir()
+      artifacts_src_stage.mkdir()
+    else:
+      # Single stage for everything.
+      artifacts_stage = stage_dir
+      artifacts_src_stage = stage_dir / 'src'
+      artifacts_src_stage.mkdir()
+      runner_stage = stage_dir
+      runner_src_stage = artifacts_src_stage
 
-    for build_dir in args.build_dirs:
-      build_dir = os.path.normpath(build_dir)
-      if not os.path.isdir(build_dir):
+    for build_dir_str in args.build_dirs:
+      build_dir = Path(build_dir_str)
+      if not build_dir.is_dir():
         logging.warning('Build directory %s not found. Skipping.', build_dir)
         continue
 
-      is_android = 'android' in os.path.basename(build_dir).lower()
+      is_android = 'android' in build_dir.name.lower()
       runtime_deps_path = find_runtime_deps(build_dir)
       if not runtime_deps_path:
         logging.warning('Could not find runtime_deps in %s. Skipping.',
                         build_dir)
         continue
 
-      adb_platform_tools = args.adb_platform_tools
+      adb_platform_tools = Path(args.adb_platform_tools)
       if is_android and adb_platform_tools:
         copy_if_needed(adb_platform_tools,
-                       os.path.join(stage_dir, 'tools/platform-tools.zip'),
+                       runner_stage / 'tools/platform-tools.zip',
                        copied_sources)
 
       test_runner_rel = get_test_runner(build_dir, is_android)
       logging.info('Processing build directory: %s', build_dir)
 
       # Record target info
-      target_name = os.path.basename(build_dir)
+      target_name = build_dir.name
       target_map[target_name] = {
-          'deps': str(runtime_deps_path),
-          'runner': os.path.join(build_dir, test_runner_rel),
+          'deps': str(runtime_deps_path.relative_to(build_dir)),
+          'runner': str(test_runner_rel),
           'is_android': is_android,
-          'build_dir': build_dir
+          'build_dir': str(build_dir)
       }
 
       logging.info('Copying files from %s...', runtime_deps_path)
       modified_deps_lines = []
-      with open(runtime_deps_path, 'r', encoding='utf-8') as f:
+      with runtime_deps_path.open('r', encoding='utf-8') as f:
         for line in f:
           line = line.strip()
           if not line or line.startswith('#'):
@@ -204,98 +250,104 @@ def main():
           # We copy BOTH unstripped (to tarball) and stripped (to root).
           # We patch the archived runtime_deps to point to stripped root.
           original_rel_path = line
-          full_path = os.path.normpath(os.path.join(build_dir, line))
+          full_path = (build_dir / line).resolve()
 
           if is_android and 'lib.unstripped' in line and line.endswith('.so'):
-            stripped_name = os.path.basename(line)
-            stripped_path = os.path.join(build_dir, stripped_name)
-            if os.path.isfile(stripped_path):
+            stripped_name = Path(line).name
+            stripped_path = build_dir / stripped_name
+            if stripped_path.is_file():
               logging.info('Including stripped library: %s', stripped_name)
               # Copy the stripped version to the build root in stage.
               copy_if_needed(stripped_path,
-                             os.path.join(src_stage, build_dir, stripped_name),
+                             artifacts_src_stage / build_dir / stripped_name,
                              copied_sources)
               # Use the stripped path in our patched deps file.
               original_rel_path = stripped_name
 
           # Copy the original file (might be unstripped) to its intended path.
-          copy_if_needed(full_path, os.path.join(src_stage, full_path),
-                         copied_sources)
+          copy_if_needed(
+              full_path,
+              artifacts_src_stage / full_path.relative_to(Path.cwd().resolve()),
+              copied_sources)
           modified_deps_lines.append(original_rel_path + '\n')
 
       # Write the patched runtime_deps to the archive.
-      archived_deps_path = os.path.join(src_stage, str(runtime_deps_path))
-      os.makedirs(os.path.dirname(archived_deps_path), exist_ok=True)
-      with open(archived_deps_path, 'w', encoding='utf-8') as f:
+      archived_deps_path = artifacts_src_stage / runtime_deps_path.resolve(
+      ).relative_to(Path.cwd().resolve())
+      archived_deps_path.parent.mkdir(parents=True, exist_ok=True)
+      with archived_deps_path.open('w', encoding='utf-8') as f:
         f.writelines(modified_deps_lines)
-      copied_sources.add(os.path.abspath(archived_deps_path))
+      copied_sources.add(archived_deps_path.resolve())
 
       # Ensure the test runner is included
-      test_runner_full = os.path.join(build_dir, test_runner_rel)
-      copy_if_needed(test_runner_full,
-                     os.path.join(src_stage, test_runner_full), copied_sources)
+      test_runner_full = build_dir / test_runner_rel
+      copy_if_needed(test_runner_full, artifacts_src_stage / test_runner_full,
+                     copied_sources)
 
     if not target_map:
       logging.error('No valid build directories processed.')
       sys.exit(1)
 
     # Add run_browser_tests.py specifically
-    browser_test_runner = 'cobalt/testing/browser_tests/run_browser_tests.py'
-    copy_if_needed(browser_test_runner,
-                   os.path.join(src_stage, browser_test_runner), copied_sources)
+    browser_test_runner = Path(
+        'cobalt/testing/browser_tests/run_browser_tests.py')
+    copy_if_needed(browser_test_runner, runner_src_stage / browser_test_runner,
+                   copied_sources)
 
     # Add essential directories manually (shared across all targets)
     essential_dirs = [
-        'build/android', 'build/util', 'build/skia_gold_common', 'testing',
-        'third_party/android_build_tools', 'third_party/catapult/common',
-        'third_party/catapult/dependency_manager', 'third_party/catapult/devil',
-        'third_party/catapult/third_party', 'third_party/logdog',
-        'third_party/android_sdk/public/platform-tools',
-        'third_party/android_sdk/public/build-tools',
-        'third_party/android_platform/development/scripts', 'tools/python',
-        'third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer',
-        'third_party/llvm-build/Release+Asserts/bin/llvm-objdump'
+        Path('build/android'),
+        Path('build/util'),
+        Path('build/skia_gold_common'),
+        Path('testing'),
+        Path('third_party/android_build_tools'),
+        Path('third_party/catapult/common'),
+        Path('third_party/catapult/dependency_manager'),
+        Path('third_party/catapult/devil'),
+        Path('third_party/catapult/third_party'),
+        Path('third_party/logdog'),
+        Path('third_party/android_sdk/public/platform-tools'),
+        Path('third_party/android_sdk/public/build-tools'),
+        Path('third_party/android_platform/development/scripts'),
+        Path('tools/python'),
+        Path('third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer'),
+        Path('third_party/llvm-build/Release+Asserts/bin/llvm-objdump')
     ]
     for d in essential_dirs:
-      copy_if_needed(d, os.path.join(src_stage, d), copied_sources)
+      copy_if_needed(d, runner_src_stage / d, copied_sources)
 
     # Add top-level build scripts
-    os.makedirs(os.path.join(src_stage, 'build'), exist_ok=True)
+    (runner_src_stage / 'build').mkdir(exist_ok=True)
     for f in Path('build').glob('*.py'):
-      copy_if_needed(
-          str(f), os.path.join(src_stage, 'build', f.name), copied_sources)
+      copy_if_needed(f, runner_src_stage / 'build' / f.name, copied_sources)
 
     # Add depot_tools
-    vpython_path = shutil.which('vpython3')
-    if vpython_path:
-      depot_tools_src = os.path.dirname(vpython_path)
+    vpython_path_str = shutil.which('vpython3')
+    if vpython_path_str:
+      vpython_path = Path(vpython_path_str)
+      depot_tools_src = vpython_path.parent
       logging.info('Bundling depot_tools from %s', depot_tools_src)
-      copy_if_needed(depot_tools_src, os.path.join(stage_dir, 'depot_tools'),
+      copy_if_needed(depot_tools_src, runner_stage / 'depot_tools',
                      copied_sources)
 
     # Add .vpython3 files
-    copy_if_needed('.vpython3', os.path.join(src_stage, '.vpython3'),
-                   copied_sources)
-    copy_if_needed('v8/.vpython3', os.path.join(src_stage, 'v8', '.vpython3'),
-                   copied_sources)
+    copy_if_needed(
+        Path('.vpython3'), runner_src_stage / '.vpython3', copied_sources)
+    copy_if_needed(
+        Path('v8/.vpython3'), runner_src_stage / 'v8/.vpython3', copied_sources)
 
-    # Generate runner
-    generate_runner_py(os.path.join(stage_dir, 'run_tests.py'), target_map)
+    # Generate runner and target_map.json
+    generate_runner_py(runner_stage / 'run_tests.py', target_map)
 
-    logging.info('Creating tarball: %s', args.output)
-    if args.compression == 'gz':
-      compression_flag = 'gzip -1'
-    elif args.compression == 'xz':
-      compression_flag = 'xz -T0 -1'
-    elif args.compression == 'zstd':
-      compression_flag = 'zstd -T0 -1'
+    if args.split:
+      target_map_path = artifacts_stage / 'target_map.json'
+      with target_map_path.open('w', encoding='utf-8') as f:
+        json.dump(target_map, f, indent=2)
+
+      create_tarball(runner_output_path, args.compression, runner_stage)
+      create_tarball(output_path, args.compression, artifacts_stage)
     else:
-      raise ValueError(f'Unsupported compression: {args.compression}')
-
-    subprocess.run([
-        'tar', '-I', compression_flag, '-C', stage_dir, '-cf', args.output, '.'
-    ],
-                   check=True)
+      create_tarball(output_path, args.compression, stage_dir)
 
   logging.info('Done!')
 

--- a/cobalt/testing/browser_tests/tools/run_tests.template.py
+++ b/cobalt/testing/browser_tests/tools/run_tests.template.py
@@ -9,14 +9,17 @@ It configures the environment and invokes the appropriate platform runner.
 
 import argparse
 import atexit
+import json
 import logging
 import os
 import shlex
 import shutil
 import subprocess
 import sys
+from pathlib import Path
 
-# TARGET_MAP will be injected by the collection script.
+# TARGET_MAP will be injected by the collection script, or loaded from
+# target_map.json if it exists.
 TARGET_MAP = {}
 SOCAT_CMD = ("socat tcp-listen:5037,bind=127.0.0.1,reuseaddr,fork "
              "tcp-connect:host.docker.internal:5037")
@@ -27,42 +30,64 @@ logging.basicConfig(
     datefmt="%Y-%m-%d %H:%M:%S")
 
 
+def ingest_artifacts(artifacts_path: Path, extract_dir: Path):
+  """Extracts the artifacts tarball into the specified directory."""
+  if not artifacts_path.is_file():
+    logging.error("Artifacts file not found: %s", artifacts_path)
+    sys.exit(1)
+
+  logging.info("Ingesting artifacts from: %s", artifacts_path)
+  # Extract tarball into the target directory.
+  # Artifacts tarball is expected to have 'src/' and 'target_map.json'
+  # at its root.
+  cmd = ["tar", "-xf", str(artifacts_path), "-C", str(extract_dir)]
+  try:
+    subprocess.check_call(cmd)
+  except subprocess.CalledProcessError as e:
+    logging.error("Failed to extract artifacts: %s", e)
+    sys.exit(1)
+
+
+def load_target_map(script_dir: Path):
+  """Loads TARGET_MAP from target_map.json if it exists."""
+  target_map_file = script_dir / "target_map.json"
+  if target_map_file.is_file():
+    logging.info("Loading TARGET_MAP from %s", target_map_file)
+    with target_map_file.open("r", encoding="utf-8") as f:
+      TARGET_MAP.update(json.load(f))
+
+
 def main():
   """Main entrypoint for the portable test runner.
 
   This function performs the following steps:
   1. Sets up the environment (PATH, CHROME_SRC).
-  2. Parses arguments and selects the target platform.
-  3. Executes an optional init-command.
-  4. Resolves paths for runtime dependencies and test runners.
-  5. Configures LD_LIBRARY_PATH for shared library resolution.
-  6. Executes the platform-specific test runner (Android or Linux).
+  2. Parses arguments and handles artifact ingestion.
+  3. Selects the target platform.
+  4. Executes an optional init-command.
+  5. Resolves paths for runtime dependencies and test runners.
+  6. Configures LD_LIBRARY_PATH for shared library resolution.
+  7. Executes the platform-specific test runner (Android or Linux).
 
   Returns:
     The exit code of the test runner process.
   """
-  script_dir = os.path.dirname(os.path.abspath(__file__))
+  script_dir = Path(__file__).resolve().parent
 
-  # 1. Setup Environment
-  logging.info("Configuring environment...")
-  depot_tools_path = os.path.join(script_dir, "depot_tools")
-  os.environ["PATH"] = depot_tools_path + os.pathsep + os.environ.get(
-      "PATH", "")
-  os.environ["DEPOT_TOOLS_UPDATE"] = "0"
-
-  src_dir = os.path.join(script_dir, "src")
-  os.environ["CHROME_SRC"] = src_dir
-
-  # 2. Argument Parsing and Target Selection
-  available_targets = list(TARGET_MAP.keys())
-
+  # 1. Argument Parsing and Artifact Ingestion
   parser = argparse.ArgumentParser(
       description="Portable test runner for Cobalt browser tests.",
       add_help=False)
   parser.add_argument(
       "--init-command", default=SOCAT_CMD, help="Command to run before tests.")
   parser.add_argument(
-      "--socat-timeout", default=5, help="Timeout for socat in seconds.")
+      "--socat-timeout",
+      default=5,
+      type=int,
+      help="Timeout for socat in seconds.")
+  parser.add_argument(
+      "--artifacts",
+      help="Path to a tarball with test artifacts to ingest at runtime.")
   parser.add_argument(
       "target", nargs="?", help="Target platform to run tests for.")
   parser.add_argument(
@@ -70,11 +95,28 @@ def main():
 
   args, runner_args = parser.parse_known_args()
 
+  if args.artifacts:
+    ingest_artifacts(Path(args.artifacts), script_dir)
+
+  load_target_map(script_dir)
+
+  available_targets = list(TARGET_MAP.keys())
+
   if args.help:
     parser.print_help()
     print("\nAvailable targets: " + ", ".join(available_targets))
     print("\nAll other arguments are passed to the underlying test runner.")
     sys.exit(0)
+
+  # 2. Setup Environment
+  logging.info("Configuring environment...")
+  depot_tools_path = script_dir / "depot_tools"
+  os.environ["PATH"] = str(depot_tools_path) + os.pathsep + os.environ.get(
+      "PATH", "")
+  os.environ["DEPOT_TOOLS_UPDATE"] = "0"
+
+  src_dir = script_dir / "src"
+  os.environ["CHROME_SRC"] = str(src_dir)
 
   if args.init_command:
     command_parts = shlex.split(args.init_command)
@@ -116,27 +158,27 @@ def main():
   logging.debug("Target config: %s", target_config)
 
   # 3. Resolve Paths
-  deps_path = os.path.join(src_dir, target_config["deps"])
-  test_runner = os.path.join(src_dir, target_config["runner"])
+  deps_path = src_dir / target_config["deps"]
+  test_runner = src_dir / target_config["runner"]
   logging.info("Resolved test runner to: %s", test_runner)
 
   # Resolve the specific build root for this target.
-  target_build_root_abs = os.path.join(src_dir, target_config["build_dir"])
-  starboard_dir = os.path.join(target_build_root_abs, "starboard")
+  target_build_root_abs = src_dir / target_config["build_dir"]
+  starboard_dir = target_build_root_abs / "starboard"
 
-  if not os.path.isfile(deps_path):
+  if not deps_path.is_file():
     logging.error("runtime_deps file not found at %s", deps_path)
     sys.exit(1)
 
-  if not os.path.isfile(test_runner):
+  if not test_runner.is_file():
     logging.error("test runner not found at %s", test_runner)
     sys.exit(1)
 
   # Add build root and starboard dir to LD_LIBRARY_PATH so shared libraries can
   # be found
   os.environ["LD_LIBRARY_PATH"] = (
-      target_build_root_abs + os.pathsep + starboard_dir + os.pathsep +
-      os.environ.get("LD_LIBRARY_PATH", ""))
+      str(target_build_root_abs) + os.pathsep + str(starboard_dir) +
+      os.pathsep + os.environ.get("LD_LIBRARY_PATH", ""))
   logging.info("LD_LIBRARY_PATH set to: %s", os.environ.get("LD_LIBRARY_PATH"))
 
   # 5. Sanity Checks
@@ -150,10 +192,10 @@ def main():
   # 6. Execute
   logging.info("Executing test runner for '%s': %s", target_name, test_runner)
 
-  if test_runner.endswith(".py"):
-    cmd = [vpython_path, test_runner] + runner_args
+  if test_runner.suffix == ".py":
+    cmd = [vpython_path, str(test_runner)] + runner_args
   else:
-    cmd = [test_runner] + runner_args
+    cmd = [str(test_runner)] + runner_args
 
   try:
     return subprocess.call(cmd)

--- a/cobalt/testing/browser_tests/tools/test_collect_test_artifacts.py
+++ b/cobalt/testing/browser_tests/tools/test_collect_test_artifacts.py
@@ -4,126 +4,112 @@
 # Tests for collect_test_artifacts.py.
 """Tests for the collect_test_artifacts script."""
 
-import os
-from pathlib import Path
+import shutil
+import tempfile
 import unittest
+from pathlib import Path
 from unittest import mock
 
 import collect_test_artifacts
 
 
 class TestCollectTestArtifacts(unittest.TestCase):
-  """Unit tests for artifact collection logic."""
+  """Unit tests for the artifact collection script."""
+
+  def setUp(self):
+    self.test_dir = Path(tempfile.mkdtemp())
+
+  def tearDown(self):
+    shutil.rmtree(self.test_dir)
 
   def test_find_runtime_deps_exact_match(self):
-    with mock.patch('collect_test_artifacts.Path.rglob') as mock_rglob:
-      expected_path = Path(
-          'out/dir/gen.runtime/cobalt/testing/browser_tests/'
-          'cobalt_browsertests__test_runner_script.runtime_deps')
-      mock_rglob.return_value = [expected_path]
-      result = collect_test_artifacts.find_runtime_deps('out/dir')
-      self.assertEqual(result, expected_path)
+    build_dir = self.test_dir / 'out/dir'
+    deps_file = build_dir / (
+        'gen.runtime/cobalt/testing/browser_tests/'
+        'cobalt_browsertests__test_runner_script.runtime_deps')
+    deps_file.parent.mkdir(parents=True)
+    deps_file.write_text('dummy content', encoding='utf-8')
+
+    result = collect_test_artifacts.find_runtime_deps(build_dir)
+    self.assertEqual(result, deps_file)
 
   def test_get_test_runner_android(self):
-    result = collect_test_artifacts.get_test_runner('out/dir', is_android=True)
-    self.assertEqual(result, os.path.join('bin', 'run_cobalt_browsertests'))
+    result = collect_test_artifacts.get_test_runner(Path('out/dir'), True)
+    self.assertEqual(result, Path('bin/run_cobalt_browsertests'))
 
   @mock.patch('subprocess.run')
-  @mock.patch('os.makedirs')
-  @mock.patch('os.path.isdir', return_value=True)
-  def test_copy_fast_dir(self, mock_isdir, mock_makedirs, mock_run):
-    del mock_isdir  # Unused argument.
-    collect_test_artifacts.copy_fast('src/dir', 'dst/dir')
-    mock_makedirs.assert_called_once_with('dst', exist_ok=True)
-    mock_run.assert_called_once_with(['cp', '-af', 'src/dir', 'dst/'],
-                                     check=True)
+  def test_copy_fast_dir(self, mock_run):
+    src = self.test_dir / 'src/dir'
+    dst = self.test_dir / 'dst/dir'
+    src.mkdir(parents=True)
+
+    collect_test_artifacts.copy_fast(src, dst)
+    mock_run.assert_called_once()
+    self.assertIn('cp', mock_run.call_args[0][0])
 
   @mock.patch('subprocess.run')
-  @mock.patch('os.makedirs')
-  @mock.patch('os.path.isdir', return_value=False)
-  def test_copy_fast_file(self, mock_isdir, mock_makedirs, mock_run):
-    del mock_isdir  # Unused argument.
-    collect_test_artifacts.copy_fast('src/file.txt', 'dst/file.txt')
-    mock_makedirs.assert_called_once_with('dst', exist_ok=True)
-    mock_run.assert_called_once_with(
-        ['cp', '-af', 'src/file.txt', 'dst/file.txt'], check=True)
+  def test_copy_fast_file(self, mock_run):
+    src = self.test_dir / 'src/file.txt'
+    dst = self.test_dir / 'dst/file.txt'
+    src.parent.mkdir(parents=True)
+    src.write_text('content', encoding='utf-8')
 
-  @mock.patch('collect_test_artifacts.copy_fast')
-  @mock.patch('os.path.exists', return_value=True)
-  @mock.patch('os.path.isdir', return_value=False)
-  def test_copy_if_needed(self, mock_isdir, mock_exists, mock_copy):
-    del mock_exists  # Unused argument.
+    collect_test_artifacts.copy_fast(src, dst)
+    mock_run.assert_called_once()
+    self.assertIn('/src/file.txt', str(mock_run.call_args[0][0]))
+
+  def test_copy_if_needed(self):
     copied_sources = set()
+    src = self.test_dir / 'src/file1'
+    dst = self.test_dir / 'dst/file1'
+    src.parent.mkdir(parents=True)
+    src.write_text('content', encoding='utf-8')
 
-    # First copy should succeed
-    collect_test_artifacts.copy_if_needed('src/file1', 'dst/file1',
-                                          copied_sources)
-    self.assertEqual(mock_copy.call_count, 1)
-    self.assertIn(os.path.abspath('src/file1'), copied_sources)
+    with mock.patch('collect_test_artifacts.copy_fast') as mock_copy:
+      collect_test_artifacts.copy_if_needed(src, dst, copied_sources)
+      mock_copy.assert_called_once()
+      self.assertIn(src.resolve(), copied_sources)
 
-    # Second copy of same file should be skipped
-    collect_test_artifacts.copy_if_needed('src/file1', 'dst/file1',
-                                          copied_sources)
-    self.assertEqual(mock_copy.call_count, 1)
+      mock_copy.reset_mock()
+      collect_test_artifacts.copy_if_needed(src, dst, copied_sources)
+      mock_copy.assert_not_called()
 
-    # Copy of file in already copied directory should be skipped
-    # Simulate that 'src/dir' was already copied as a directory.
-    abs_dir = os.path.abspath('src/dir')
-    copied_sources.add(abs_dir)
+  @mock.patch('subprocess.run')
+  def test_create_tarball(self, mock_run):
+    collect_test_artifacts.create_tarball(Path('out.tar.gz'), 'gz', Path('src'))
+    mock_run.assert_called_once()
+    self.assertIn('tar', mock_run.call_args[0][0])
 
-    # We need mock_isdir to return True for the parent 'src/dir'
-    # to trigger the parent directory optimization.
-    def is_dir_side_effect(path):
-      if path == abs_dir:
-        return True
-      return False
-
-    mock_isdir.side_effect = is_dir_side_effect
-
-    collect_test_artifacts.copy_if_needed('src/dir/file2', 'dst/dir/file2',
-                                          copied_sources)
-    self.assertEqual(mock_copy.call_count, 1)
-
-  @mock.patch(
-      'builtins.open',
-      new_callable=mock.mock_open,
-      read_data='content TARGET_MAP = {}')
-  @mock.patch('os.chmod')
-  def test_generate_runner_py(self, mock_chmod, mock_file):
-    target_map = {
-        'target': {
-            'deps': 'deps_path',
-            'runner': 'runner_path',
-            'is_android': False
-        }
-    }
-    collect_test_artifacts.generate_runner_py('run.py', target_map)
-
-    # Verify template was read and output was written
-    mock_file.assert_any_call(mock.ANY, 'r', encoding='utf-8')
-    mock_file.assert_any_call('run.py', 'w', encoding='utf-8')
-
-    handle = mock_file()
-    # Find the write call that matches our expected output
-    written_content = ''
-    for call in handle.write.call_args_list:
-      if 'deps_path' in call[0][0]:
-        written_content = call[0][0]
-
-    self.assertIn('deps_path', written_content)
-    self.assertIn('runner_path', written_content)
-    mock_chmod.assert_called_once_with('run.py', 0o755)
+  @mock.patch.object(Path, 'chmod')
+  def test_generate_runner_py(self, mock_chmod):
+    dst = self.test_dir / 'run.py'
+    target_map = {'target': 'config'}
+    # We need a real run_tests.template.py or mock its read
+    with mock.patch.object(
+        Path,
+        'open',
+        new_callable=mock.mock_open,
+        read_data='TEMPLATE_CONTENT TARGET_MAP = {}') as mock_open:
+      collect_test_artifacts.generate_runner_py(dst, target_map)
+      self.assertEqual(mock_open.call_count, 2)
+      mock_chmod.assert_called_once_with(0o755)
 
 
 class TestCollectTestArtifactsMain(unittest.TestCase):
-  """Tests for the main() entry point and argument parsing."""
+  """Tests for the main function of collect_test_artifacts."""
 
-  @mock.patch('collect_test_artifacts.find_runtime_deps')
-  @mock.patch('os.makedirs')
+  def setUp(self):
+    self.test_dir = Path(tempfile.mkdtemp())
+    self.cwd_patcher = mock.patch.object(
+        Path, 'cwd', return_value=self.test_dir)
+    self.cwd_patcher.start()
+
+  def tearDown(self):
+    self.cwd_patcher.stop()
+    shutil.rmtree(self.test_dir)
+
   @mock.patch('argparse.ArgumentParser.error')
-  def test_main_absolute_output_with_output_dir_fails(self, mock_error,
-                                                      unused_makedirs,
-                                                      unused_find_deps):
+  def test_main_absolute_output_with_output_dir_fails(self, mock_error):
     mock_error.side_effect = SystemExit
     test_args = [
         'collect_test_artifacts.py', 'out/dir', '--output_dir', '/tmp/out',
@@ -133,8 +119,31 @@ class TestCollectTestArtifactsMain(unittest.TestCase):
       with self.assertRaises(SystemExit):
         collect_test_artifacts.main()
 
-      mock_error.assert_called_once()
-      self.assertIn('cannot be an absolute path', mock_error.call_args[0][0])
+  @mock.patch('collect_test_artifacts.create_tarball')
+  @mock.patch('collect_test_artifacts.generate_runner_py')
+  @mock.patch('collect_test_artifacts.copy_if_needed')
+  def test_main_split_mode(self, unused_mock_copy, unused_mock_gen_runner,
+                           mock_create_tar):
+    build_dir = self.test_dir / 'out/dir'
+    deps_file = build_dir / (
+        'gen.runtime/cobalt/testing/browser_tests/'
+        'cobalt_browsertests__test_runner_script.runtime_deps')
+    deps_file.parent.mkdir(parents=True)
+    deps_file.write_text('dep1\n', encoding='utf-8')
+    (build_dir / 'dep1').write_text('content', encoding='utf-8')
+
+    test_args = [
+        'collect_test_artifacts.py',
+        str(build_dir), '--split', '--output', 'artifacts.tar.gz',
+        '--runner_output', 'runner.tar.gz'
+    ]
+    with mock.patch('sys.argv', test_args):
+      collect_test_artifacts.main()
+
+    self.assertEqual(mock_create_tar.call_count, 2)
+    call_args = [str(call[0][0]) for call in mock_create_tar.call_args_list]
+    self.assertIn('artifacts.tar.gz', call_args)
+    self.assertIn('runner.tar.gz', call_args)
 
 
 if __name__ == '__main__':

--- a/cobalt/testing/browser_tests/tools/test_run_tests_template.py
+++ b/cobalt/testing/browser_tests/tools/test_run_tests_template.py
@@ -4,12 +4,14 @@
 # Tests for run_tests.template.py.
 """Tests for the portable test runner template script."""
 
-import os
-import sys
-import unittest
-from unittest import mock
-import tempfile
+import importlib
+import json
 import shutil
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
 
 
 # To test the template, we need to read it, substitute TARGET_MAP,
@@ -18,40 +20,43 @@ class TestRunTestsTemplate(unittest.TestCase):
   """Unit tests for the test runner template logic."""
 
   def setUp(self):
-    self.test_dir = tempfile.mkdtemp()
-    self.template_path = os.path.join(
-        os.path.dirname(__file__), 'run_tests.template.py')
-    self.run_tests_path = os.path.join(self.test_dir, 'run_tests.py')
+    self.test_dir = Path(tempfile.mkdtemp())
+    self.template_path = (Path(__file__).parent /
+                          'run_tests.template.py').resolve()
+    self.run_tests_path = self.test_dir / 'run_tests.py'
 
     # Create a dummy src directory to satisfy path checks
-    self.src_dir = os.path.join(self.test_dir, 'src')
-    os.makedirs(self.src_dir)
-    self.dummy_deps = os.path.join(self.src_dir, 'dummy.runtime_deps')
-    self.dummy_runner = os.path.join(self.src_dir, 'dummy_runner.py')
-    with open(self.dummy_deps, 'w', encoding='utf-8') as f:
-      f.write('# dummy deps')
-    with open(self.dummy_runner, 'w', encoding='utf-8') as f:
-      f.write('#!/usr/bin/env python3\nimport sys\nsys.exit(0)')
-    os.chmod(self.dummy_runner, 0o755)
+    self.src_dir = self.test_dir / 'src'
+    self.src_dir.mkdir()
+    self.dummy_deps = self.src_dir / 'dummy.runtime_deps'
+    self.dummy_runner = self.src_dir / 'dummy_runner.py'
+    self.dummy_deps.write_text('# dummy deps', encoding='utf-8')
+    self.dummy_runner.write_text(
+        '#!/usr/bin/env python3\nimport sys\nsys.exit(0)', encoding='utf-8')
+    self.dummy_runner.chmod(0o755)
 
     # Create a dummy depot_tools
-    self.depot_tools = os.path.join(self.test_dir, 'depot_tools')
-    os.makedirs(self.depot_tools)
-    with open(
-        os.path.join(self.depot_tools, 'vpython3'), 'w', encoding='utf-8') as f:
-      f.write('#!/bin/sh\nexit 0')
-    os.chmod(os.path.join(self.depot_tools, 'vpython3'), 0o755)
+    self.depot_tools = self.test_dir / 'depot_tools'
+    self.depot_tools.mkdir()
+    (self.depot_tools / 'vpython3').write_text(
+        '#!/bin/sh\nexit 0', encoding='utf-8')
+    (self.depot_tools / 'vpython3').chmod(0o755)
 
   def tearDown(self):
     shutil.rmtree(self.test_dir)
 
   def prepare_script(self, target_map):
-    with open(self.template_path, 'r', encoding='utf-8') as f:
-      content = f.read()
+    content = self.template_path.read_text(encoding='utf-8')
     content = content.replace('TARGET_MAP = {}',
                               f'TARGET_MAP = {repr(target_map)}')
-    with open(self.run_tests_path, 'w', encoding='utf-8') as f:
-      f.write(content)
+    self.run_tests_path.write_text(content, encoding='utf-8')
+
+  def load_run_tests(self):
+    if str(self.test_dir) not in sys.path:
+      sys.path.insert(0, str(self.test_dir))
+    if 'run_tests' in sys.modules:
+      return importlib.reload(sys.modules['run_tests'])
+    return importlib.import_module('run_tests')
 
   @mock.patch('subprocess.Popen')
   @mock.patch('subprocess.call', return_value=0)
@@ -66,14 +71,12 @@ class TestRunTestsTemplate(unittest.TestCase):
         }
     }
     self.prepare_script(target_map)
-    mock_which.return_value = os.path.join(self.depot_tools, 'vpython3')
+    mock_which.return_value = str(self.test_dir / 'depot_tools/vpython3')
 
-    # Import the generated script
-    sys.path.insert(0, self.test_dir)
-    if 'run_tests' in sys.modules:
-      del sys.modules['run_tests']
-    # pylint: disable=import-outside-toplevel
-    import run_tests
+    # Create dummy target_map.json to avoid FileNotFoundError
+    (self.test_dir / 'target_map.json').write_text('{}', encoding='utf-8')
+
+    run_tests = self.load_run_tests()
 
     test_args = [
         'run_tests.py', '--init-command', 'socat addr1 addr2',
@@ -89,6 +92,40 @@ class TestRunTestsTemplate(unittest.TestCase):
     mock_popen.assert_called_once()
     args = mock_popen.call_args[0][0]
     self.assertEqual(args, ['socat', '-t', '10', 'addr1', 'addr2'])
+
+  @mock.patch('subprocess.check_call')
+  def test_ingest_artifacts(self, mock_check_call):
+    artifacts_tar = self.test_dir / 'artifacts.tar'
+    artifacts_tar.write_text('fake tar content', encoding='utf-8')
+
+    self.prepare_script({})
+    run_tests = self.load_run_tests()
+    run_tests.ingest_artifacts(artifacts_tar, self.test_dir)
+
+    mock_check_call.assert_called_once()
+    args = mock_check_call.call_args[0][0]
+    self.assertIn('tar', args)
+    self.assertIn(str(artifacts_tar), args)
+    self.assertIn(str(self.test_dir), args)
+
+  def test_load_target_map(self):
+    target_map_data = {
+        'new_target': {
+            'deps': 'new.deps',
+            'runner': 'new_runner',
+            'build_dir': '.'
+        }
+    }
+    (self.test_dir / 'target_map.json').write_text(
+        json.dumps(target_map_data), encoding='utf-8')
+
+    self.prepare_script({})
+    run_tests = self.load_run_tests()
+    # Reset TARGET_MAP for test
+    run_tests.TARGET_MAP = {}
+    run_tests.load_target_map(self.test_dir)
+
+    self.assertEqual(run_tests.TARGET_MAP, target_map_data)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Refactor cobalt_browsertests to support split runner and artifacts tarballs.
    
    - Update archive_test_artifacts.py to support splitting output into a
      static 'runner' tarball and dynamic 'artifacts'.
    - Update Dockerfile to use the static runner tarball, reducing build time
      in CI by avoiding rebuilds for every APK change.

Bug: 493339962
Bug: 483488213