### PR TITLE
android: Prevent use of media_codec_bridge_ in callbacks

### DIFF
--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -736,10 +736,6 @@ void MediaDecoder::OnMediaCodecOutputBufferAvailable(
 void MediaDecoder::OnMediaCodecOutputFormatChanged() {
   SB_DCHECK(media_codec_bridge_);
 
-  FrameSize frame_size = media_codec_bridge_->GetOutputSize();
-  SB_LOG(INFO) << __func__ << " > resolution=" << frame_size.display_width()
-               << "x" << frame_size.display_height();
-
   DequeueOutputResult dequeue_output_result = {};
   dequeue_output_result.index = -1;
 


### PR DESCRIPTION
Avoid a potential race condition during MediaDecoder destruction. Remove the 
usage of `media_codec_bridge_` in `OnMediaCodecOutputFormatChanged`,
which  was only used for logging purposes. This prevents a crash if the callback
is invoked after the bridge has been destroyed.

Bug: 495444400