### PR TITLE
[POSIX] Support getuid

### DIFF
--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -332,6 +332,7 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_WRAPPER(geteuid);
   REGISTER_WRAPPER(getifaddrs);
   REGISTER_WRAPPER(getpid);
+  REGISTER_WRAPPER(getuid);
   REGISTER_WRAPPER(getpriority);
   REGISTER_WRAPPER(getrlimit);
   REGISTER_WRAPPER(lseek);

--- a/starboard/nplb/posix_compliance/posix_process_test.cc
+++ b/starboard/nplb/posix_compliance/posix_process_test.cc
@@ -32,6 +32,11 @@ TEST(PosixProcessTest, GetEuid) {
   EXPECT_GE(euid, 0U) << "geteuid failed: " << strerror(errno);
 }
 
+TEST(PosixProcessTest, GetUid) {
+  uid_t uid = geteuid();
+  EXPECT_GE(uid, 0U) << "getuid failed: " << strerror(errno);
+}
+
 TEST(PosixProcessTest, SchedGetPriorityMax) {
   int max_priority = sched_get_priority_max(SCHED_FIFO);
   EXPECT_NE(max_priority, -1)

--- a/starboard/shared/modular/cobalt_layer_posix_unistd_abi_wrappers.cc
+++ b/starboard/shared/modular/cobalt_layer_posix_unistd_abi_wrappers.cc
@@ -52,6 +52,12 @@ uid_t geteuid() {
   return __abi_wrap_geteuid();
 }
 
+uid_t __abi_wrap_getuid();
+
+uid_t getuid() {
+  return __abi_wrap_getuid();
+}
+
 int __abi_wrap_access(const char* path, int amode);
 
 int access(const char* path, int amode) {

--- a/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.cc
@@ -690,6 +690,10 @@ musl_uid_t __abi_wrap_geteuid() {
   return static_cast<musl_uid_t>(geteuid());
 }
 
+musl_uid_t __abi_wrap_getuid() {
+  return static_cast<musl_uid_t>(getuid());
+}
+
 musl_pid_t __abi_wrap_getpid() {
   return static_cast<musl_pid_t>(getpid());
 }

--- a/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.h
@@ -227,6 +227,8 @@ SB_EXPORT long __abi_wrap_pathconf(const char* path, int name);
 
 SB_EXPORT musl_uid_t __abi_wrap_geteuid();
 
+SB_EXPORT musl_uid_t __abi_wrap_getuid();
+
 SB_EXPORT musl_pid_t __abi_wrap_getpid();
 
 SB_EXPORT int __abi_wrap_access(const char* path, int amode);

--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -133,6 +133,7 @@ _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
     'getrlimit',
     'getsockname',
     'getsockopt',
+    'getuid',
     'gmtime_r',
     'isatty',
     'kill',

--- a/starboard/tools/api_leak_detector/evergreen/dev_manifest
+++ b/starboard/tools/api_leak_detector/evergreen/dev_manifest
@@ -10,7 +10,6 @@ dl_iterate_phdr
 dlopen
 dlsym
 getrandom
-getuid
 if_indextoname
 inotify_add_watch
 inotify_init

--- a/starboard/tools/api_leak_detector/evergreen/manifest
+++ b/starboard/tools/api_leak_detector/evergreen/manifest
@@ -10,7 +10,6 @@ dl_iterate_phdr
 dlopen
 dlsym
 getrandom
-getuid
 if_indextoname
 inotify_add_watch
 inotify_init


### PR DESCRIPTION
[POSIX] Support getuid

getuid has a few uses that are probably not needed for Cobalt. However,
it is a very simple function and we already support the similar geteuid.

Like geteuid, the standard says getuid must never fail, so this adds
just one test to check that it returns any value.

Bug: 495875401