### PR TITLE
android: Report player render status via extension

### DIFF
--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -515,6 +515,10 @@ const base::FeatureParam<base::TimeDelta> kAudioWriteDurationRemote{
 BASE_FEATURE(kCobaltDecoderBufferAllocatorWithInPlaceMetadata,
              "CobaltDecoderBufferAllocatorWithInPlaceMetadata",
              base::FEATURE_DISABLED_BY_DEFAULT);
+// When enabled, Cobalt pauses playback when audio/video underflow.
+BASE_FEATURE(kCobaltPausePlaybackWhenUnderflow,
+             "CobaltPausePlaybackWhenUnderflow",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 // When disabled, Cobalt rejects progressive video formats.
 BASE_FEATURE(kCobaltProgressivePlayback,
              "CobaltProgressivePlayback",

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -185,6 +185,7 @@ MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltAudioWriteDuration);
 MEDIA_EXPORT extern const base::FeatureParam<base::TimeDelta> kAudioWriteDurationLocal;
 MEDIA_EXPORT extern const base::FeatureParam<base::TimeDelta> kAudioWriteDurationRemote;
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltDecoderBufferAllocatorWithInPlaceMetadata);
+MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltPausePlaybackWhenUnderflow);
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltProgressivePlayback);
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltReportBufferingStateDuringFlush);
 #if BUILDFLAG(IS_ANDROID)

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -32,6 +32,7 @@
 #if COBALT_MEDIA_ENABLE_FORMAT_SUPPORT_QUERY_METRICS
 #include "cobalt/media/base/format_support_query_metrics.h"
 #endif  // COBALT_MEDIA_ENABLE_FORMAT_SUPPORT_QUERY_METRICS
+#include "media/base/media_switches.h"
 #include "media/starboard/starboard_utils.h"
 #include "starboard/common/media.h"
 #include "starboard/common/once.h"
@@ -39,6 +40,7 @@
 #include "starboard/common/string.h"
 #include "starboard/configuration.h"
 #include "starboard/extension/experimental_features.h"
+#include "starboard/extension/player_get_render_status.h"
 #if COBALT_MEDIA_ENABLE_PLAYER_SET_MAX_VIDEO_INPUT_SIZE
 #include "starboard/extension/player_set_max_video_input_size.h"
 #endif  // COBALT_MEDIA_ENABLE_PLAYER_SET_MAX_VIDEO_INPUT_SIZE
@@ -144,6 +146,22 @@ void SbPlayerBridge::CallbackHelper::OnPlayerError(void* player,
   CHECK(player_bridge_->task_runner_->RunsTasksInCurrentSequence());
 
   player_bridge_->OnPlayerError(static_cast<SbPlayer>(player), error, message);
+}
+
+void SbPlayerBridge::CallbackHelper::OnRenderStatus(void* player,
+                                                    bool is_audio_playing,
+                                                    bool has_video_renderer,
+                                                    int number_of_frames,
+                                                    bool is_video_eos_received,
+                                                    bool has_enough_video_data,
+                                                    bool has_audio_renderer,
+                                                    bool is_audio_underflow) {
+  if (player_bridge_) {
+    player_bridge_->OnRenderStatus(
+        static_cast<SbPlayer>(player), is_audio_playing, has_video_renderer,
+        number_of_frames, is_video_eos_received, has_enough_video_data,
+        has_audio_renderer, is_audio_underflow);
+  }
 }
 
 void SbPlayerBridge::CallbackHelper::OnDeallocateSample(
@@ -857,6 +875,22 @@ void SbPlayerBridge::CreatePlayer() {
         ->SetVideoSurfaceViewForCurrentThread(surface_view_);
   }
 #endif  // BUILDFLAG(IS_ANDROID)
+  if (base::FeatureList::IsEnabled(media::kCobaltPausePlaybackWhenUnderflow)) {
+    LOG(INFO) << "Enable Pausing Playback When Underflow.";
+    const StarboardExtensionPlayerGetRenderStatusApi*
+        player_get_render_status_extension =
+            static_cast<const StarboardExtensionPlayerGetRenderStatusApi*>(
+                SbSystemGetExtension(
+                    kStarboardExtensionPlayerGetRenderStatusName));
+    if (player_get_render_status_extension &&
+        strcmp(player_get_render_status_extension->name,
+               kStarboardExtensionPlayerGetRenderStatusName) == 0 &&
+        player_get_render_status_extension->version >= 1) {
+      player_get_render_status_extension->SetRenderStatusCBForCurrentThread(
+          &SbPlayerBridge::RenderStatusCB);
+    }
+  }
+
   player_ = sbplayer_interface_->Create(
       window_, &creation_param, &SbPlayerBridge::DeallocateSampleCB,
       &SbPlayerBridge::DecoderStatusCB, &SbPlayerBridge::PlayerStatusCB,
@@ -1245,6 +1279,24 @@ void SbPlayerBridge::OnDeallocateSample(const void* sample_buffer) {
   }
 }
 
+void SbPlayerBridge::OnRenderStatus(SbPlayer player,
+                                    bool is_audio_playing,
+                                    bool has_video_renderer,
+                                    int number_of_frames,
+                                    bool is_video_eos_received,
+                                    bool has_enough_video_data,
+                                    bool has_audio_renderer,
+                                    bool is_audio_underflow) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+
+  if (player_ != player) {
+    return;
+  }
+  host_->OnRenderStatus(is_audio_playing, has_video_renderer, number_of_frames,
+                        is_video_eos_received, has_enough_video_data,
+                        has_audio_renderer, is_audio_underflow);
+}
+
 bool SbPlayerBridge::TryToSetPlayerCreationErrorMessage(
     const std::string& message) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
@@ -1313,6 +1365,26 @@ void SbPlayerBridge::DeallocateSampleCB(SbPlayer player,
       FROM_HERE,
       base::BindOnce(&SbPlayerBridge::CallbackHelper::OnDeallocateSample,
                      helper->callback_helper_, sample_buffer));
+}
+
+// static
+void SbPlayerBridge::RenderStatusCB(SbPlayer player,
+                                    void* context,
+                                    bool is_audio_playing,
+                                    bool has_video_renderer,
+                                    int number_of_frames,
+                                    bool is_video_eos_received,
+                                    bool has_enough_video_data,
+                                    bool has_audio_renderer,
+                                    bool is_audio_underflow) {
+  SbPlayerBridge* helper = static_cast<SbPlayerBridge*>(context);
+  helper->task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(&SbPlayerBridge::CallbackHelper::OnRenderStatus,
+                     helper->callback_helper_, static_cast<void*>(player),
+                     is_audio_playing, has_video_renderer, number_of_frames,
+                     is_video_eos_received, has_enough_video_data,
+                     has_audio_renderer, is_audio_underflow));
 }
 
 #if SB_HAS(PLAYER_WITH_URL)

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -61,6 +61,13 @@ class SbPlayerBridge {
     virtual void OnPlayerStatus(SbPlayerState state) = 0;
     virtual void OnPlayerError(SbPlayerError error,
                                const std::string& message) = 0;
+    virtual void OnRenderStatus(bool is_audio_playing,
+                                bool has_video_renderer,
+                                int number_of_frames,
+                                bool is_video_eos_received,
+                                bool has_enough_video_data,
+                                bool has_audio_renderer,
+                                bool is_audio_underflow) = 0;
 
    protected:
     ~Host() {}
@@ -199,6 +206,14 @@ class SbPlayerBridge {
                        SbPlayerError error,
                        const std::string& message);
     void OnDeallocateSample(const void* sample_buffer);
+    void OnRenderStatus(void* player,
+                        bool is_audio_playing,
+                        bool has_video_renderer,
+                        int number_of_frames,
+                        bool is_video_eos_received,
+                        bool has_enough_video_data,
+                        bool has_audio_renderer,
+                        bool is_audio_underflow);
 
     void ResetPlayer();
 
@@ -255,6 +270,14 @@ class SbPlayerBridge {
                      SbPlayerError error,
                      const std::string& message);
   void OnDeallocateSample(const void* sample_buffer);
+  void OnRenderStatus(SbPlayer player,
+                      bool is_audio_playing,
+                      bool has_video_renderer,
+                      int number_of_frames,
+                      bool is_video_eos_received,
+                      bool has_enough_video_data,
+                      bool has_audio_renderer,
+                      bool is_audio_underflow);
 
   static void DecoderStatusCB(SbPlayer player,
                               void* context,
@@ -272,6 +295,15 @@ class SbPlayerBridge {
   static void DeallocateSampleCB(SbPlayer player,
                                  void* context,
                                  const void* sample_buffer);
+  static void RenderStatusCB(SbPlayer player,
+                             void* context,
+                             bool is_audio_playing,
+                             bool has_video_renderer,
+                             int number_of_frames,
+                             bool is_video_eos_received,
+                             bool has_enough_video_data,
+                             bool has_audio_renderer,
+                             bool is_audio_underflow);
 
 #if SB_HAS(PLAYER_WITH_URL)
   SbPlayerOutputMode ComputeSbUrlPlayerOutputMode(

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -139,6 +139,8 @@ StarboardRenderer::StarboardRenderer(
       set_bounds_helper_(new SbPlayerSetBoundsHelper),
       cdm_context_(nullptr),
       buffering_state_(BUFFERING_HAVE_NOTHING),
+      audio_buffering_state_(BUFFERING_HAVE_NOTHING),
+      video_buffering_state_(BUFFERING_HAVE_NOTHING),
       audio_write_duration_local_(audio_write_duration_local),
       audio_write_duration_remote_(audio_write_duration_remote),
       max_video_capabilities_(max_video_capabilities),
@@ -331,13 +333,16 @@ void StarboardRenderer::Flush(base::OnceClosure flush_cb) {
 
   if (buffering_state_ != BUFFERING_HAVE_NOTHING) {
     buffering_state_ = BUFFERING_HAVE_NOTHING;
+    audio_buffering_state_ = BUFFERING_HAVE_NOTHING;
+    video_buffering_state_ = BUFFERING_HAVE_NOTHING;
     if (base::FeatureList::IsEnabled(
             media::kCobaltReportBufferingStateDuringFlush) ||
         experimental_features_.report_buffering_state_during_flush) {
       task_runner_->PostTask(
           FROM_HERE,
           base::BindOnce(&StarboardRenderer::OnBufferingStateChange,
-                         weak_factory_.GetWeakPtr(), buffering_state_));
+                         weak_factory_.GetWeakPtr(), buffering_state_,
+                         BUFFERING_CHANGE_REASON_UNKNOWN));
     }
   }
 
@@ -966,10 +971,13 @@ void StarboardRenderer::OnPlayerStatus(SbPlayerState state) {
     case kSbPlayerStatePresenting:
       DCHECK(player_bridge_initialized_);
       buffering_state_ = BUFFERING_HAVE_ENOUGH;
+      audio_buffering_state_ = BUFFERING_HAVE_ENOUGH;
+      video_buffering_state_ = BUFFERING_HAVE_ENOUGH;
       task_runner_->PostTask(
           FROM_HERE,
           base::BindOnce(&StarboardRenderer::OnBufferingStateChange,
-                         weak_factory_.GetWeakPtr(), buffering_state_));
+                         weak_factory_.GetWeakPtr(), buffering_state_,
+                         BUFFERING_CHANGE_REASON_UNKNOWN));
       audio_write_duration_for_preroll_ = audio_write_duration_ =
           HasRemoteAudioOutputs(player_bridge_->GetAudioConfigurations())
               ? audio_write_duration_remote_
@@ -1016,6 +1024,58 @@ void StarboardRenderer::OnPlayerError(SbPlayerError error,
       NOTREACHED();
       break;
   }
+}
+
+void StarboardRenderer::OnRenderStatus(bool is_audio_playing,
+                                       bool has_video_renderer,
+                                       int number_of_frames,
+                                       bool is_video_eos_received,
+                                       bool has_enough_video_data,
+                                       bool has_audio_renderer,
+                                       bool is_audio_underflow) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  if (state_ != STATE_PLAYING) {
+    return;
+  }
+
+  has_video_renderer_ = has_video_renderer;
+  has_audio_renderer_ = has_audio_renderer;
+  // Transit to BUFFERING_HAVE_ENOUGH when:
+  //   1. |state_| is in STATE_PLAYING,
+  //   2. |buffering_state_| is BUFFERING_HAVE_NOTHING.
+  // Additionally, both of the following meet:
+  //   1. audio is not underflow, and
+  //   2. have enough video frames.
+  if (buffering_state_ == BUFFERING_HAVE_NOTHING) {
+    if (has_audio_renderer_ && !is_audio_underflow) {
+      UpdateUnderflow(DemuxerStream::AUDIO, BUFFERING_HAVE_ENOUGH);
+    }
+    if (has_video_renderer_ && number_of_frames > 0 && has_enough_video_data) {
+      UpdateUnderflow(DemuxerStream::VIDEO, BUFFERING_HAVE_ENOUGH);
+    }
+    was_audio_playing_ = is_audio_playing;
+    return;
+  }
+
+  // Transit to BUFFERING_HAVE_NOTHING when
+  //   1. |state_| is in STATE_PLAYING,
+  //   2. |buffering_state_| is not BUFFERING_HAVE_NOTHING.
+  // Additionally, for audio, underflow is determined by:
+  //   1. audio was playing, and
+  //   2. audio is underflow.
+  // For video, underflow is determined by:
+  //   1. don't have frames available, and
+  //   2. haven't received end of stream.
+  if (buffering_state_ != BUFFERING_HAVE_NOTHING) {
+    if (has_audio_renderer_ && was_audio_playing_ && is_audio_underflow) {
+      UpdateUnderflow(DemuxerStream::AUDIO, BUFFERING_HAVE_NOTHING);
+    }
+    if (has_video_renderer_ && number_of_frames == 0 &&
+        !is_video_eos_received) {
+      UpdateUnderflow(DemuxerStream::VIDEO, BUFFERING_HAVE_NOTHING);
+    }
+  }
+  was_audio_playing_ = is_audio_playing;
 }
 
 void StarboardRenderer::DelayedNeedData(int max_number_of_buffers_to_write) {
@@ -1112,10 +1172,84 @@ int StarboardRenderer::GetEstimatedMaxBuffers(TimeDelta write_duration,
   return estimated_max_buffers > 0 ? estimated_max_buffers : 1;
 }
 
-void StarboardRenderer::OnBufferingStateChange(BufferingState buffering_state) {
+void StarboardRenderer::OnBufferingStateChange(
+    BufferingState buffering_state,
+    media::BufferingStateChangeReason reason) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
-  client_->OnBufferingStateChange(buffering_state,
-                                  BUFFERING_CHANGE_REASON_UNKNOWN);
+  client_->OnBufferingStateChange(buffering_state, reason);
+}
+
+bool StarboardRenderer::WaitingForEnoughData() const {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  if (state_ != STATE_PLAYING) {
+    return false;
+  }
+  if (has_audio_renderer_ && audio_buffering_state_ != BUFFERING_HAVE_ENOUGH) {
+    return true;
+  }
+  if (has_video_renderer_ && video_buffering_state_ != BUFFERING_HAVE_ENOUGH) {
+    return true;
+  }
+  return false;
+}
+
+void StarboardRenderer::UpdateUnderflow(DemuxerStream::Type type,
+                                        BufferingState new_buffering_state) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  DCHECK((type == DemuxerStream::AUDIO) || (type == DemuxerStream::VIDEO));
+  BufferingState* buffering_state = type == DemuxerStream::AUDIO
+                                        ? &audio_buffering_state_
+                                        : &video_buffering_state_;
+  BufferingStateChangeReason reason = BUFFERING_CHANGE_REASON_UNKNOWN;
+  bool was_waiting_for_enough_data = WaitingForEnoughData();
+  *buffering_state = new_buffering_state;
+  // Renderer underflowed.
+  if (!was_waiting_for_enough_data && WaitingForEnoughData()) {
+    if (type == DemuxerStream::AUDIO) {
+      if (audio_stream_) {
+        reason =
+            audio_read_in_progress_ ? DEMUXER_UNDERFLOW : DECODER_UNDERFLOW;
+      }
+    } else {
+      if (video_stream_) {
+        reason =
+            video_read_in_progress_ ? DEMUXER_UNDERFLOW : DECODER_UNDERFLOW;
+      }
+    }
+    LOG(INFO) << __func__ << " "
+              << (type == DemuxerStream::AUDIO ? "audio " : "video ")
+              << "underflow, changed from "
+              << BufferingStateToString(buffering_state_) << " to "
+              << BufferingStateToString(BUFFERING_HAVE_NOTHING, reason);
+    playback_rate_before_underflow_ = playback_rate_;
+    task_runner_->PostTask(FROM_HERE,
+                           base::BindOnce(&StarboardRenderer::SetPlaybackRate,
+                                          weak_factory_.GetWeakPtr(), 0.0f));
+    buffering_state_ = BUFFERING_HAVE_NOTHING;
+    task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&StarboardRenderer::OnBufferingStateChange,
+                       weak_factory_.GetWeakPtr(), buffering_state_, reason));
+    return;
+  }
+  // Renderer prerolled.
+  if (was_waiting_for_enough_data && !WaitingForEnoughData()) {
+    LOG(INFO) << __func__ << " "
+              << (type == DemuxerStream::AUDIO ? "audio " : "video ")
+              << "prerolled, changed from "
+              << BufferingStateToString(buffering_state_) << " to "
+              << BufferingStateToString(BUFFERING_HAVE_ENOUGH);
+    task_runner_->PostTask(FROM_HERE,
+                           base::BindOnce(&StarboardRenderer::SetPlaybackRate,
+                                          weak_factory_.GetWeakPtr(),
+                                          playback_rate_before_underflow_));
+    buffering_state_ = BUFFERING_HAVE_ENOUGH;
+    task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&StarboardRenderer::OnBufferingStateChange,
+                       weak_factory_.GetWeakPtr(), buffering_state_, reason));
+    return;
+  }
 }
 
 }  // namespace media

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -163,6 +163,13 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
                   int max_number_of_buffers_to_write) override;
   void OnPlayerStatus(SbPlayerState state) override;
   void OnPlayerError(SbPlayerError error, const std::string& message) override;
+  void OnRenderStatus(bool is_audio_playing,
+                      bool has_video_renderer,
+                      int number_of_frames,
+                      bool is_video_eos_received,
+                      bool has_enough_video_data,
+                      bool has_audio_renderer,
+                      bool is_audio_underflow) override;
 
   // Used to make a delayed call to OnNeedData() if |audio_read_delayed_| is
   // true. If |audio_read_delayed_| is false, that means the delayed call has
@@ -187,7 +194,11 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
                              TimeDelta time_ahead_of_playback,
                              bool is_preroll);
 
-  void OnBufferingStateChange(BufferingState state);
+  void OnBufferingStateChange(BufferingState state,
+                              media::BufferingStateChangeReason reason);
+  bool WaitingForEnoughData() const;
+  void UpdateUnderflow(DemuxerStream::Type type,
+                       BufferingState new_buffering_state);
 
   State state_;
   const scoped_refptr<base::SequencedTaskRunner> task_runner_;
@@ -195,6 +206,8 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   const scoped_refptr<SbPlayerSetBoundsHelper> set_bounds_helper_;
   raw_ptr<CdmContext> cdm_context_;
   BufferingState buffering_state_;
+  BufferingState audio_buffering_state_;
+  BufferingState video_buffering_state_;
   const TimeDelta audio_write_duration_local_;
   const TimeDelta audio_write_duration_remote_;
   const std::string max_video_capabilities_;
@@ -273,6 +286,11 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
 
   uint32_t last_video_frames_decoded_ = 0;
   uint32_t last_video_frames_dropped_ = 0;
+
+  bool has_video_renderer_ = false;
+  bool has_audio_renderer_ = false;
+  bool was_audio_playing_ = false;
+  double playback_rate_before_underflow_ = 0.;
 
   raw_ptr<SbPlayerInterface> test_sbplayer_interface_;
 

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -243,12 +243,16 @@ static_library("starboard_platform") {
     "player_destroy.cc",
     "player_get_maximum_number_of_samples_per_write.cc",
     "player_get_preferred_output_mode.cc",
+    "player_get_render_status.cc",
+    "player_get_render_status.h",
     "player_set_bounds.cc",
     "player_set_max_video_input_size.cc",
     "player_set_max_video_input_size.h",
     "player_set_playback_rate.cc",
     "player_set_video_surface_view.cc",
     "player_set_video_surface_view.h",
+    "render_status_func.cc",
+    "render_status_func.h",
 
     # TODO: b/374300500 - posix_emu things should not be used on Android anymore
     # "posix_emu/dirent.cc",

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -295,17 +295,23 @@ void AudioRendererPassthrough::Seek(int64_t seek_to_time) {
 int64_t AudioRendererPassthrough::GetCurrentMediaTime(bool* is_playing,
                                                       bool* is_eos_played,
                                                       bool* is_underflow,
-                                                      double* playback_rate) {
+                                                      double* playback_rate,
+                                                      bool* has_renderer,
+                                                      bool* is_audio_playing) {
   SB_DCHECK(is_playing);
   SB_DCHECK(is_eos_played);
   SB_DCHECK(is_underflow);
   SB_DCHECK(playback_rate);
+  SB_DCHECK(has_renderer);
+  SB_DCHECK(is_audio_playing);
 
   std::lock_guard scoped_lock(mutex_);
   *is_playing = !paused_;
   *is_eos_played = end_of_stream_played_.load();
   *is_underflow = false;  // TODO: Support underflow
   *playback_rate = playback_rate_;
+  *has_renderer = false;
+  *is_audio_playing = false;
 
   if (!audio_track_bridge_) {
     return seek_to_time_;

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -77,7 +77,9 @@ class AudioRendererPassthrough
   int64_t GetCurrentMediaTime(bool* is_playing,
                               bool* is_eos_played,
                               bool* is_underflow,
-                              double* playback_rate) override;
+                              double* playback_rate,
+                              bool* has_renderer,
+                              bool* is_audio_playing) override;
 
  private:
   typedef ::starboard::shared::starboard::player::DecodedAudio DecodedAudio;

--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -19,6 +19,7 @@
 #include <string>
 #include <utility>
 
+#include "starboard/android/shared/render_status_func.h"
 #include "starboard/android/shared/video_max_video_input_size.h"
 #include "starboard/android/shared/video_surface_view.h"
 #include "starboard/android/shared/video_window.h"
@@ -215,7 +216,9 @@ SbPlayer SbPlayerCreate(SbWindow window,
       starboard::android::shared::GetSurfaceViewForCurrentThread());
   SbPlayer player = SbPlayerPrivateImpl::CreateInstance(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
-      player_status_func, player_error_func, context, std::move(handler));
+      player_status_func, player_error_func,
+      starboard::android::shared::GetRenderStatusCBForCurrentThread(), context,
+      std::move(handler));
 
   if (SbPlayerIsValid(player)) {
     if (creation_param->output_mode != kSbPlayerOutputModeDecodeToTexture) {

--- a/starboard/android/shared/player_get_render_status.cc
+++ b/starboard/android/shared/player_get_render_status.cc
@@ -1,0 +1,48 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/player_get_render_status.h"
+
+#include "starboard/android/shared/render_status_func.h"
+#include "starboard/common/log.h"
+#include "starboard/extension/player_get_render_status.h"
+#include "starboard/player.h"
+#include "starboard/shared/starboard/player/player_internal.h"
+
+namespace starboard::android::shared {
+
+namespace {
+
+// Definitions of any functions included as components in the extension
+// are added here.
+
+void SetRenderStatusCBForCurrentThread(
+    SbPlayerRenderStatusFunc render_status_func) {
+  starboard::android::shared::SetRenderStatusCBForCurrentThread(
+      render_status_func);
+}
+
+const StarboardExtensionPlayerGetRenderStatusApi kPlayerGetRenderStatusApi = {
+    kStarboardExtensionPlayerGetRenderStatusName,
+    1,
+    &SetRenderStatusCBForCurrentThread,
+};
+
+}  // namespace
+
+const void* GetPlayerGetRenderStatusApi() {
+  return &kPlayerGetRenderStatusApi;
+}
+
+}  // namespace starboard::android::shared

--- a/starboard/android/shared/player_get_render_status.h
+++ b/starboard/android/shared/player_get_render_status.h
@@ -1,0 +1,24 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_PLAYER_GET_RENDER_STATUS_H_
+#define STARBOARD_ANDROID_SHARED_PLAYER_GET_RENDER_STATUS_H_
+
+namespace starboard::android::shared {
+
+const void* GetPlayerGetRenderStatusApi();
+
+}  // namespace starboard::android::shared
+
+#endif  // STARBOARD_ANDROID_SHARED_PLAYER_GET_RENDER_STATUS_H_

--- a/starboard/android/shared/render_status_func.cc
+++ b/starboard/android/shared/render_status_func.cc
@@ -1,0 +1,51 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/render_status_func.h"
+
+#include <pthread.h>
+
+#include "starboard/common/check_op.h"
+#include "starboard/common/log.h"
+#include "starboard/thread.h"
+
+namespace starboard::android::shared {
+
+pthread_once_t s_render_status_cb_once_flag = PTHREAD_ONCE_INIT;
+pthread_key_t s_render_status_cb_thread_local_key = 0;
+
+void InitRenderStatusCBThreadLocalKey() {
+  [[maybe_unused]] int res =
+      pthread_key_create(&s_render_status_cb_thread_local_key, NULL);
+  SB_DCHECK_EQ(res, 0);
+}
+
+void EnsureRenderStatusCBThreadLocalKeyInited() {
+  pthread_once(&s_render_status_cb_once_flag, InitRenderStatusCBThreadLocalKey);
+}
+
+SbPlayerRenderStatusFunc GetRenderStatusCBForCurrentThread() {
+  EnsureRenderStatusCBThreadLocalKeyInited();
+  return reinterpret_cast<SbPlayerRenderStatusFunc>(
+      pthread_getspecific(s_render_status_cb_thread_local_key));
+}
+
+void SetRenderStatusCBForCurrentThread(
+    SbPlayerRenderStatusFunc render_status_func) {
+  EnsureRenderStatusCBThreadLocalKeyInited();
+  pthread_setspecific(s_render_status_cb_thread_local_key,
+                      reinterpret_cast<void*>(render_status_func));
+}
+
+}  // namespace starboard::android::shared

--- a/starboard/android/shared/render_status_func.h
+++ b/starboard/android/shared/render_status_func.h
@@ -1,0 +1,29 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_RENDER_STATUS_FUNC_H_
+#define STARBOARD_ANDROID_SHARED_RENDER_STATUS_FUNC_H_
+
+#include "starboard/common/player.h"
+
+namespace starboard::android::shared {
+
+SbPlayerRenderStatusFunc GetRenderStatusCBForCurrentThread();
+
+void SetRenderStatusCBForCurrentThread(
+    SbPlayerRenderStatusFunc render_status_func);
+
+}  // namespace starboard::android::shared
+
+#endif  // STARBOARD_ANDROID_SHARED_RENDER_STATUS_FUNC_H_

--- a/starboard/android/shared/system_get_extensions.cc
+++ b/starboard/android/shared/system_get_extensions.cc
@@ -26,6 +26,7 @@
 #include "starboard/android/shared/media_settings_api.h"
 #include "starboard/android/shared/platform_info.h"
 #include "starboard/android/shared/platform_service.h"
+#include "starboard/android/shared/player_get_render_status.h"
 #include "starboard/android/shared/player_set_max_video_input_size.h"
 #include "starboard/android/shared/player_set_video_surface_view.h"
 #include "starboard/android/shared/system_info_api.h"
@@ -39,6 +40,7 @@
 #include "starboard/extension/media_settings.h"
 #include "starboard/extension/platform_info.h"
 #include "starboard/extension/platform_service.h"
+#include "starboard/extension/player_get_render_status.h"
 #include "starboard/extension/player_set_max_video_input_size.h"
 #include "starboard/extension/player_set_video_surface_view.h"
 #include "starboard/extension/system_info.h"
@@ -95,6 +97,9 @@ const void* SbSystemGetExtension(const char* name) {
   }
   if (strcmp(name, kStarboardExtensionSystemInfoName) == 0) {
     return starboard::android::shared::GetSystemInfoApi();
+  }
+  if (strcmp(name, kStarboardExtensionPlayerGetRenderStatusName) == 0) {
+    return starboard::android::shared::GetPlayerGetRenderStatusApi();
   }
   return NULL;
 }

--- a/starboard/android/shared/video_render_algorithm.cc
+++ b/starboard/android/shared/video_render_algorithm.cc
@@ -63,8 +63,11 @@ void VideoRenderAlgorithm::Render(
     bool is_audio_eos_played;
     bool is_underflow;
     double playback_rate;
+    bool has_audio_renderer;
+    bool is_audio_track_playing;
     int64_t playback_time = media_time_provider->GetCurrentMediaTime(
-        &is_audio_playing, &is_audio_eos_played, &is_underflow, &playback_rate);
+        &is_audio_playing, &is_audio_eos_played, &is_underflow, &playback_rate,
+        &has_audio_renderer, &is_audio_track_playing);
     if (!is_audio_playing) {
       break;
     }

--- a/starboard/common/player.h
+++ b/starboard/common/player.h
@@ -17,6 +17,16 @@
 
 #include "starboard/player.h"
 
+typedef void (*SbPlayerRenderStatusFunc)(SbPlayer player,
+                                         void* context,
+                                         bool is_audio_playing,
+                                         bool has_video_renderer,
+                                         int number_of_frames,
+                                         bool is_video_eos_received,
+                                         bool has_enough_video_data,
+                                         bool has_audio_renderer,
+                                         bool is_audio_underflow);
+
 namespace starboard {
 
 const char* GetPlayerOutputModeName(SbPlayerOutputMode output_mode);

--- a/starboard/extension/extension_test.cc
+++ b/starboard/extension/extension_test.cc
@@ -33,6 +33,7 @@
 #include "starboard/extension/platform_info.h"
 #include "starboard/extension/platform_service.h"
 #include "starboard/extension/player_configuration.h"
+#include "starboard/extension/player_get_render_status.h"
 #include "starboard/extension/player_set_max_video_input_size.h"
 #include "starboard/extension/player_set_video_surface_view.h"
 #include "starboard/extension/system_info.h"
@@ -668,6 +669,26 @@ TEST(ExtensionTest, StarboardMediaBufferPoolExtension) {
   EXPECT_NE(extension_api->ShrinkToZero, nullptr);
   EXPECT_NE(extension_api->ExpandTo, nullptr);
   EXPECT_NE(extension_api->Write, nullptr);
+
+  const ExtensionApi* second_extension_api =
+      static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));
+  EXPECT_EQ(second_extension_api, extension_api)
+      << "Extension struct should be a singleton";
+}
+
+TEST(ExtensionTest, PlayerGetRenderStatus) {
+  typedef StarboardExtensionPlayerGetRenderStatusApi ExtensionApi;
+  const char* kExtensionName = kStarboardExtensionPlayerGetRenderStatusName;
+
+  const ExtensionApi* extension_api =
+      static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));
+  if (!extension_api) {
+    return;
+  }
+
+  EXPECT_STREQ(extension_api->name, kExtensionName);
+  EXPECT_EQ(extension_api->version, 1u);
+  EXPECT_NE(extension_api->SetRenderStatusCBForCurrentThread, nullptr);
 
   const ExtensionApi* second_extension_api =
       static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));

--- a/starboard/extension/player_get_render_status.h
+++ b/starboard/extension/player_get_render_status.h
@@ -1,0 +1,50 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_EXTENSION_PLAYER_GET_RENDER_STATUS_H_
+#define STARBOARD_EXTENSION_PLAYER_GET_RENDER_STATUS_H_
+
+#include <stdint.h>
+
+#include "starboard/common/player.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define kStarboardExtensionPlayerGetRenderStatusName \
+  "dev.starboard.extension.PlayerGetRenderStatus"
+
+typedef struct StarboardExtensionPlayerGetRenderStatusApi {
+  // Name should be the string
+  // |kStarboardExtensionPlayerGetRenderStatusName|. This helps to
+  // validate that the extension API is correct.
+  const char* name;
+
+  // This specifies the version of the API that is implemented.
+  uint32_t version;
+
+  // The fields below this point were added in version 1 or later.
+
+  // Returns the number of frames to be rendered. This can be used
+  // to determine if audio or video is underflow.
+  void (*SetRenderStatusCBForCurrentThread)(
+      SbPlayerRenderStatusFunc render_status_func);
+} StarboardExtensionPlayerGetRenderStatusApi;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // STARBOARD_EXTENSION_PLAYER_GET_RENDER_STATUS_H_

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -286,11 +286,15 @@ void AudioRendererPcm::Seek(int64_t seek_to_time) {
 int64_t AudioRendererPcm::GetCurrentMediaTime(bool* is_playing,
                                               bool* is_eos_played,
                                               bool* is_underflow,
-                                              double* playback_rate) {
+                                              double* playback_rate,
+                                              bool* has_renderer,
+                                              bool* is_audio_playing) {
   SB_DCHECK(is_playing);
   SB_DCHECK(is_eos_played);
   SB_DCHECK(is_underflow);
   SB_DCHECK(playback_rate);
+  SB_DCHECK(has_renderer);
+  SB_DCHECK(is_audio_playing);
 
   int64_t media_time = 0;
   int64_t now = -1;
@@ -304,6 +308,8 @@ int64_t AudioRendererPcm::GetCurrentMediaTime(bool* is_playing,
     *is_playing = !paused_ && !seeking_;
     *is_eos_played = IsEndOfStreamPlayed_Locked();
     *is_underflow = underflow_;
+    *has_renderer = true;
+    *is_audio_playing = is_playing_on_sink_thread_;
 
     if (seeking_ || !decoder_sample_rate_) {
       *playback_rate = playback_rate_;

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -90,7 +90,9 @@ class AudioRendererPcm : public AudioRenderer,
   int64_t GetCurrentMediaTime(bool* is_playing,
                               bool* is_eos_played,
                               bool* is_underflow,
-                              double* playback_rate) override;
+                              double* playback_rate,
+                              bool* has_renderer,
+                              bool* is_audio_playing) override;
 
  private:
   enum EOSState {

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -494,16 +494,28 @@ void FilterBasedPlayerWorkerHandler::Update() {
 
   if (get_player_state_cb_() == kSbPlayerStatePresenting) {
     int dropped_frames = 0;
+    int number_of_frames = 0;
+    bool is_video_eos_received = false;
+    bool has_enough_video_data = false;
     if (video_renderer_) {
       dropped_frames = video_renderer_->GetDroppedFrames();
+      number_of_frames = video_renderer_->GetNumberOfFrames();
+      is_video_eos_received = video_renderer_->IsEndOfStreamWritten();
+      has_enough_video_data = !video_renderer_->CanAcceptMoreData();
     }
     bool is_playing;
     bool is_eos_played;
     bool is_underflow;
     double playback_rate;
+    bool has_audio_renderer;
+    bool is_audio_playing;
     auto media_time = media_time_provider_->GetCurrentMediaTime(
-        &is_playing, &is_eos_played, &is_underflow, &playback_rate);
-    update_media_info_cb_(media_time, dropped_frames, !is_underflow);
+        &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+        &has_audio_renderer, &is_audio_playing);
+    update_media_info_cb_(media_time, dropped_frames, !is_underflow,
+                          is_audio_playing, !!video_renderer_, number_of_frames,
+                          is_video_eos_received, has_enough_video_data,
+                          has_audio_renderer);
   }
 
   RemoveJobByToken(update_job_token_);

--- a/starboard/shared/starboard/player/filter/media_time_provider.h
+++ b/starboard/shared/starboard/player/filter/media_time_provider.h
@@ -31,7 +31,9 @@ class MediaTimeProvider {
   virtual int64_t GetCurrentMediaTime(bool* is_playing,
                                       bool* is_eos_played,
                                       bool* is_underflow,
-                                      double* playback_rate) = 0;
+                                      double* playback_rate,
+                                      bool* has_renderer,
+                                      bool* is_audio_playing) = 0;
 
  protected:
   virtual ~MediaTimeProvider() {}

--- a/starboard/shared/starboard/player/filter/media_time_provider_impl.cc
+++ b/starboard/shared/starboard/player/filter/media_time_provider_impl.cc
@@ -79,7 +79,9 @@ void MediaTimeProviderImpl::Seek(int64_t seek_to_time) {
 int64_t MediaTimeProviderImpl::GetCurrentMediaTime(bool* is_playing,
                                                    bool* is_eos_played,
                                                    bool* is_underflow,
-                                                   double* playback_rate) {
+                                                   double* playback_rate,
+                                                   bool* has_renderer,
+                                                   bool* is_audio_playing) {
   std::lock_guard scoped_lock(mutex_);
 
   int64_t current = GetCurrentMediaTime_Locked();
@@ -88,6 +90,8 @@ int64_t MediaTimeProviderImpl::GetCurrentMediaTime(bool* is_playing,
   *is_eos_played = false;
   *is_underflow = false;
   *playback_rate = playback_rate_;
+  *has_renderer = false;
+  *is_audio_playing = false;
 
   return current;
 }

--- a/starboard/shared/starboard/player/filter/media_time_provider_impl.h
+++ b/starboard/shared/starboard/player/filter/media_time_provider_impl.h
@@ -46,7 +46,9 @@ class MediaTimeProviderImpl : public MediaTimeProvider,
   int64_t GetCurrentMediaTime(bool* is_playing,
                               bool* is_eos_played,
                               bool* is_underflow,
-                              double* playback_rate) override;
+                              double* playback_rate,
+                              bool* has_renderer,
+                              bool* is_audio_playing) override;
 
  private:
   // When not NULL, |current_time| will be set to the current monotonic time

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -290,8 +290,11 @@ TEST_F(AudioRendererTest, StateAfterConstructed) {
   bool is_eos_played = true;
   bool is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             0);
   EXPECT_FALSE(is_playing);
   EXPECT_FALSE(is_eos_played);
@@ -320,8 +323,11 @@ TEST_F(AudioRendererTest, SunnyDay) {
   bool is_eos_played = true;
   bool is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             0);
   EXPECT_FALSE(is_playing);
   EXPECT_FALSE(is_eos_played);
@@ -333,7 +339,8 @@ TEST_F(AudioRendererTest, SunnyDay) {
   SendDecoderOutput(new DecodedAudio);
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_EQ(playback_rate, 1.0);
@@ -357,7 +364,8 @@ TEST_F(AudioRendererTest, SunnyDay) {
 
   renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_EQ(playback_rate, 1.0);
@@ -367,7 +375,8 @@ TEST_F(AudioRendererTest, SunnyDay) {
   const int remaining_frames = frames_in_buffer - frames_to_consume;
   renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_TRUE(is_playing);
   EXPECT_TRUE(is_eos_played);
   EXPECT_EQ(playback_rate, 1.0);
@@ -408,9 +417,12 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
   bool is_eos_played = true;
   bool is_underflow = true;
   double playback_rate = -1.0;
+  bool has_renderer = false;
+  bool is_audio_playing = false;
 
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             0);
   EXPECT_FALSE(is_playing);
   EXPECT_FALSE(is_eos_played);
@@ -422,7 +434,8 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
   SendDecoderOutput(new DecodedAudio);
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
 
   int frames_in_buffer;
   int offset_in_frames;
@@ -445,14 +458,16 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
 
   renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_GT(new_media_time, media_time);
   media_time = new_media_time;
 
   const int remaining_frames = frames_in_buffer - frames_to_consume;
   renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_GT(new_media_time, media_time);
 
   EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());
@@ -484,8 +499,11 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
   bool is_eos_played = true;
   bool is_underflow = true;
   double playback_rate = -1.0;
+  bool has_renderer = false;
+  bool is_audio_playing = false;
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
 
   int frames_in_buffer;
   int offset_in_frames;
@@ -506,7 +524,8 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
 
   renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_EQ(playback_rate, 1.0);
@@ -516,7 +535,8 @@ TEST_F(AudioRendererTest, StartPlayBeforePreroll) {
   const int remaining_frames = frames_in_buffer - frames_to_consume;
   renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_TRUE(is_playing);
   EXPECT_TRUE(is_eos_played);
   EXPECT_EQ(playback_rate, 1.0);
@@ -559,8 +579,11 @@ TEST_F(AudioRendererTest, DecoderReturnsEOSWithoutAnyData) {
   bool is_eos_played = false;
   bool is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             0);
   EXPECT_FALSE(is_playing);
   EXPECT_TRUE(is_eos_played);
@@ -609,8 +632,11 @@ TEST_F(AudioRendererTest, DecoderConsumeAllInputBeforeReturningData) {
   bool is_eos_played = false;
   bool is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             0);
   EXPECT_FALSE(is_playing);
   EXPECT_TRUE(is_eos_played);
@@ -654,8 +680,11 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
   bool is_eos_played = true;
   bool is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             0);
   EXPECT_FALSE(is_playing);
   EXPECT_FALSE(is_eos_played);
@@ -667,7 +696,8 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
   SendDecoderOutput(new DecodedAudio);
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
 
   int frames_in_buffer;
   int offset_in_frames;
@@ -689,7 +719,8 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
 
   renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_EQ(playback_rate, 1.0);
@@ -699,7 +730,8 @@ TEST_F(AudioRendererTest, MoreNumberOfOutputBuffersThanInputBuffers) {
   const int remaining_frames = frames_in_buffer - frames_to_consume;
   renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_TRUE(is_playing);
   EXPECT_TRUE(is_eos_played);
   EXPECT_EQ(playback_rate, 1.0);
@@ -752,8 +784,11 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
   bool is_eos_played;
   bool is_underflow;
   double playback_rate = -1.0;
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             0);
   EXPECT_TRUE(prerolled_);
 
@@ -762,7 +797,8 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
   SendDecoderOutput(new DecodedAudio);
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
 
   int frames_in_buffer;
   int offset_in_frames;
@@ -783,14 +819,16 @@ TEST_F(AudioRendererTest, LessNumberOfOutputBuffersThanInputBuffers) {
 
   renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_GE(new_media_time, media_time);
   media_time = new_media_time;
 
   const int remaining_frames = frames_in_buffer - frames_to_consume;
   renderer_callback_->ConsumeFrames(remaining_frames, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_GE(new_media_time, media_time);
 
   EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());
@@ -826,8 +864,11 @@ TEST_F(AudioRendererTest, Seek) {
   bool is_eos_played;
   bool is_underflow;
   double playback_rate = -1.0;
-  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_EQ(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             0);
   EXPECT_TRUE(prerolled_);
 
@@ -836,7 +877,8 @@ TEST_F(AudioRendererTest, Seek) {
   SendDecoderOutput(new DecodedAudio);
 
   int64_t media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
 
   int frames_in_buffer;
   int offset_in_frames;
@@ -857,14 +899,16 @@ TEST_F(AudioRendererTest, Seek) {
 
   renderer_callback_->ConsumeFrames(frames_to_consume, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_GE(new_media_time, media_time);
   Seek(kSeekTime);
 
   frames_written += FillRendererWithDecodedAudioAndWriteEOS(kSeekTime);
 
-  EXPECT_GE(audio_renderer_->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                 &is_underflow, &playback_rate),
+  EXPECT_GE(audio_renderer_->GetCurrentMediaTime(
+                &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+                &has_renderer, &is_audio_playing),
             kSeekTime);
   EXPECT_TRUE(prerolled_);
 
@@ -879,7 +923,8 @@ TEST_F(AudioRendererTest, Seek) {
   EXPECT_TRUE(is_eos_reached);
   renderer_callback_->ConsumeFrames(frames_in_buffer, CurrentMonotonicTime());
   new_media_time = audio_renderer_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
   EXPECT_GE(new_media_time, kSeekTime);
 
   EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());

--- a/starboard/shared/starboard/player/filter/testing/media_time_provider_impl_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/media_time_provider_impl_test.cc
@@ -93,10 +93,12 @@ class MediaTimeProviderImplTest : public ::testing::Test {
 TEST_F(MediaTimeProviderImplTest, DefaultStates) {
   bool is_playing = true, is_eos_played = true, is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      0));
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          0));
   EXPECT_FALSE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_FALSE(is_underflow);
@@ -108,10 +110,12 @@ TEST_F(MediaTimeProviderImplTest, GetCurrentMediaTimeWhileNotPlaying) {
 
   bool is_playing = true, is_eos_played = true, is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      0));
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          0));
   EXPECT_FALSE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_FALSE(is_underflow);
@@ -123,10 +127,12 @@ TEST_F(MediaTimeProviderImplTest, GetCurrentMediaTimeWhilePlaying) {
 
   bool is_playing = false, is_eos_played = true, is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      0));
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          0));
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_FALSE(is_underflow);
@@ -134,10 +140,10 @@ TEST_F(MediaTimeProviderImplTest, GetCurrentMediaTimeWhilePlaying) {
 
   system_time_provider_->AdvanceTime(kOneSecondInMicroseconds);
 
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kOneSecondInMicroseconds));
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kOneSecondInMicroseconds));
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_FALSE(is_underflow);
@@ -150,28 +156,30 @@ TEST_F(MediaTimeProviderImplTest, SetPlaybackRateWhilePlaying) {
   system_time_provider_->AdvanceTime(kOneSecondInMicroseconds);
   bool is_playing = true, is_eos_played = true, is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kOneSecondInMicroseconds));
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kOneSecondInMicroseconds));
   EXPECT_EQ(playback_rate, 1.0);
   EXPECT_EQ(playback_rate, 1.0);
 
   media_time_provider_impl_.SetPlaybackRate(2.0);
 
   system_time_provider_->AdvanceTime(kOneSecondInMicroseconds);
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kOneSecondInMicroseconds * 3));
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kOneSecondInMicroseconds * 3));
   EXPECT_EQ(playback_rate, 2.0);
 
   media_time_provider_impl_.SetPlaybackRate(0.0);
   system_time_provider_->AdvanceTime(kOneSecondInMicroseconds);
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kOneSecondInMicroseconds * 3));
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kOneSecondInMicroseconds * 3));
   EXPECT_EQ(playback_rate, 0.0);
 }
 
@@ -181,10 +189,12 @@ TEST_F(MediaTimeProviderImplTest, SeekWhileNotPlaying) {
   media_time_provider_impl_.Seek(kSeekToTime);
   bool is_playing = true, is_eos_played = true, is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kSeekToTime));
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kSeekToTime));
   EXPECT_FALSE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_FALSE(is_underflow);
@@ -192,10 +202,10 @@ TEST_F(MediaTimeProviderImplTest, SeekWhileNotPlaying) {
 
   system_time_provider_->AdvanceTime(kOneSecondInMicroseconds);
 
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kSeekToTime));
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kSeekToTime));
 }
 
 TEST_F(MediaTimeProviderImplTest, SeekForwardWhilePlaying) {
@@ -206,10 +216,12 @@ TEST_F(MediaTimeProviderImplTest, SeekForwardWhilePlaying) {
   media_time_provider_impl_.Seek(kSeekToTime);
   bool is_playing = false, is_eos_played = true, is_underflow = true;
   double playback_rate = -1.0;
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kSeekToTime));
+  bool has_renderer = false;
+  bool is_audio_playing = false;
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kSeekToTime));
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_FALSE(is_underflow);
@@ -217,10 +229,10 @@ TEST_F(MediaTimeProviderImplTest, SeekForwardWhilePlaying) {
 
   system_time_provider_->AdvanceTime(kOneSecondInMicroseconds);
 
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kSeekToTime + kOneSecondInMicroseconds));
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kSeekToTime + kOneSecondInMicroseconds));
   EXPECT_TRUE(is_playing);
   EXPECT_FALSE(is_eos_played);
   EXPECT_FALSE(is_underflow);
@@ -234,16 +246,19 @@ TEST_F(MediaTimeProviderImplTest, SeekBackwardWhilePlaying) {
 
   bool is_playing = true, is_eos_played = true, is_underflow = true;
   double playback_rate = -1.0;
+  bool has_renderer = false;
+  bool is_audio_playing = false;
   // Query for media time and ignore the result.
-  media_time_provider_impl_.GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                &is_underflow, &playback_rate);
+  media_time_provider_impl_.GetCurrentMediaTime(
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
 
   const int64_t kSeekToTime = 0;
   media_time_provider_impl_.Seek(kSeekToTime);
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kSeekToTime));
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kSeekToTime));
 }
 
 TEST_F(MediaTimeProviderImplTest, Pause) {
@@ -253,23 +268,26 @@ TEST_F(MediaTimeProviderImplTest, Pause) {
 
   bool is_playing = true, is_eos_played = true, is_underflow = true;
   double playback_rate = -1.0;
+  bool has_renderer = false;
+  bool is_audio_playing = false;
   // Query for media time and ignore the result.
-  media_time_provider_impl_.GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                &is_underflow, &playback_rate);
+  media_time_provider_impl_.GetCurrentMediaTime(
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate, &has_renderer,
+      &is_audio_playing);
 
   media_time_provider_impl_.Pause();
   system_time_provider_->AdvanceTime(kOneSecondInMicroseconds);
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      kOneSecondInMicroseconds));
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          kOneSecondInMicroseconds));
 
   media_time_provider_impl_.Seek(0);
   system_time_provider_->AdvanceTime(kOneSecondInMicroseconds);
-  EXPECT_TRUE(AlmostEqual(
-      media_time_provider_impl_.GetCurrentMediaTime(
-          &is_playing, &is_eos_played, &is_underflow, &playback_rate),
-      0));
+  EXPECT_TRUE(AlmostEqual(media_time_provider_impl_.GetCurrentMediaTime(
+                              &is_playing, &is_eos_played, &is_underflow,
+                              &playback_rate, &has_renderer, &is_audio_playing),
+                          0));
 }
 
 }  // namespace

--- a/starboard/shared/starboard/player/filter/testing/player_components_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/player_components_test.cc
@@ -216,15 +216,21 @@ class PlayerComponentsTest
   int64_t GetMediaTime() {
     bool is_playing, is_eos_played, is_underflow;
     double playback_rate;
+    bool has_renderer;
+    bool is_audio_playing;
     return GetMediaTimeProvider()->GetCurrentMediaTime(
-        &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+        &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+        &has_renderer, &is_audio_playing);
   }
 
   bool IsPlaying() {
     bool is_playing, is_eos_played, is_underflow;
     double playback_rate;
-    GetMediaTimeProvider()->GetCurrentMediaTime(&is_playing, &is_eos_played,
-                                                &is_underflow, &playback_rate);
+    bool has_renderer;
+    bool is_audio_playing;
+    GetMediaTimeProvider()->GetCurrentMediaTime(
+        &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+        &has_renderer, &is_audio_playing);
     return is_playing;
   }
 

--- a/starboard/shared/starboard/player/filter/video_render_algorithm_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_render_algorithm_impl.cc
@@ -50,8 +50,11 @@ void VideoRenderAlgorithmImpl::Render(
   bool is_audio_eos_played;
   bool is_underflow;
   double playback_rate;
+  bool has_audio_renderer;
+  bool is_audio_track_playing;
   int64_t media_time = media_time_provider->GetCurrentMediaTime(
-      &is_audio_playing, &is_audio_eos_played, &is_underflow, &playback_rate);
+      &is_audio_playing, &is_audio_eos_played, &is_underflow, &playback_rate,
+      &has_audio_renderer, &is_audio_track_playing);
 
   // Video frames are synced to the audio timestamp. However, the audio
   // timestamp is not queried at a consistent interval. For example, if the
@@ -165,8 +168,11 @@ void VideoRenderAlgorithmImpl::RenderWithCadence(
   bool is_audio_eos_played;
   bool is_underflow;
   double playback_rate;
+  bool has_audio_renderer;
+  bool is_audio_track_playing;
   int64_t media_time = media_time_provider->GetCurrentMediaTime(
-      &is_audio_playing, &is_audio_eos_played, &is_underflow, &playback_rate);
+      &is_audio_playing, &is_audio_eos_played, &is_underflow, &playback_rate,
+      &has_audio_renderer, &is_audio_track_playing);
 
   while (frames->size() > 1 && !frames->front()->is_end_of_stream() &&
          frames->front()->timestamp() < media_time) {

--- a/starboard/shared/starboard/player/filter/video_renderer_internal.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal.h
@@ -32,6 +32,7 @@ class VideoRenderer {
                           const PrerolledCB& prerolled_cb,
                           const EndedCB& ended_cb) = 0;
   virtual int GetDroppedFrames() const = 0;
+  virtual int GetNumberOfFrames() const = 0;
 
   virtual void WriteSamples(const InputBuffers& input_buffers) = 0;
 

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -448,8 +448,11 @@ void VideoRendererImpl::CheckForFrameLag(int64_t last_decoded_frame_timestamp) {
   bool is_eos_played;
   bool is_underflow;
   double playback_rate;
+  bool has_audio_renderer;
+  bool is_audio_playing;
   int64_t media_time = media_time_provider_->GetCurrentMediaTime(
-      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate,
+      &has_audio_renderer, &is_audio_playing);
   if (is_eos_played) {
     return;
   }

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -64,6 +64,7 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   int GetDroppedFrames() const override {
     return algorithm_->GetDroppedFrames();
   }
+  int GetNumberOfFrames() const override { return number_of_frames_.load(); }
 
   void WriteSamples(const InputBuffers& input_buffers) override;
 

--- a/starboard/shared/starboard/player/player_create.cc
+++ b/starboard/shared/starboard/player/player_create.cc
@@ -213,7 +213,7 @@ SbPlayer SbPlayerCreate(SbWindow window,
 
   SbPlayer player = SbPlayerPrivateImpl::CreateInstance(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
-      player_status_func, player_error_func, context, std::move(handler));
+      player_status_func, player_error_func, NULL, context, std::move(handler));
 
 #if SB_PLAYER_ENABLE_VIDEO_DUMPER
   using ::starboard::shared::starboard::player::video_dmp::VideoDmpWriter;

--- a/starboard/shared/starboard/player/player_internal.cc
+++ b/starboard/shared/starboard/player/player_internal.cc
@@ -32,9 +32,15 @@ namespace starboard::shared::starboard::player {
 namespace {
 
 using std::placeholders::_1;
+using std::placeholders::_10;
 using std::placeholders::_2;
 using std::placeholders::_3;
 using std::placeholders::_4;
+using std::placeholders::_5;
+using std::placeholders::_6;
+using std::placeholders::_7;
+using std::placeholders::_8;
+using std::placeholders::_9;
 
 int64_t CalculateMediaTime(int64_t media_time,
                            int64_t media_time_update_time,
@@ -54,14 +60,17 @@ SbPlayerPrivateImpl::SbPlayerPrivateImpl(
     SbPlayerDecoderStatusFunc decoder_status_func,
     SbPlayerStatusFunc player_status_func,
     SbPlayerErrorFunc player_error_func,
+    SbPlayerRenderStatusFunc player_render_status_func,
     void* context,
     std::unique_ptr<PlayerWorker::Handler> player_worker_handler)
     : sample_deallocate_func_(sample_deallocate_func),
+      player_render_status_func_(player_render_status_func),
       context_(context),
       media_time_updated_at_(CurrentMonotonicTime()) {
   worker_ = std::unique_ptr<PlayerWorker>(PlayerWorker::CreateInstance(
       audio_codec, video_codec, std::move(player_worker_handler),
-      std::bind(&SbPlayerPrivateImpl::UpdateMediaInfo, this, _1, _2, _3, _4),
+      std::bind(&SbPlayerPrivateImpl::UpdateMediaInfo, this, _1, _2, _3, _4, _5,
+                _6, _7, _8, _9, _10),
       decoder_status_func, player_status_func, player_error_func, this,
       context));
 
@@ -78,11 +87,12 @@ SbPlayerPrivate* SbPlayerPrivateImpl::CreateInstance(
     SbPlayerDecoderStatusFunc decoder_status_func,
     SbPlayerStatusFunc player_status_func,
     SbPlayerErrorFunc player_error_func,
+    SbPlayerRenderStatusFunc player_render_status_func,
     void* context,
     std::unique_ptr<PlayerWorker::Handler> player_worker_handler) {
   SbPlayerPrivateImpl* ret = new SbPlayerPrivateImpl(
       audio_codec, video_codec, sample_deallocate_func, decoder_status_func,
-      player_status_func, player_error_func, context,
+      player_status_func, player_error_func, player_render_status_func, context,
       std::move(player_worker_handler));
 
   if (ret && ret->worker_) {
@@ -185,15 +195,29 @@ void SbPlayerPrivateImpl::SetVolume(double volume) {
 void SbPlayerPrivateImpl::UpdateMediaInfo(int64_t media_time,
                                           int dropped_video_frames,
                                           int ticket,
-                                          bool is_progressing) {
-  std::lock_guard lock(mutex_);
-  if (ticket_ != ticket) {
-    return;
+                                          bool is_progressing,
+                                          bool is_audio_playing,
+                                          bool has_video_renderer,
+                                          int number_of_frames,
+                                          bool is_video_eos_received,
+                                          bool has_enough_video_data,
+                                          bool has_audio_renderer) {
+  {
+    std::lock_guard lock(mutex_);
+    if (ticket_ != ticket) {
+      return;
+    }
+    media_time_ = media_time;
+    is_progressing_ = is_progressing;
+    media_time_updated_at_ = CurrentMonotonicTime();
+    dropped_video_frames_ = dropped_video_frames;
   }
-  media_time_ = media_time;
-  is_progressing_ = is_progressing;
-  media_time_updated_at_ = CurrentMonotonicTime();
-  dropped_video_frames_ = dropped_video_frames;
+  if (player_render_status_func_) {
+    player_render_status_func_(this, context_, is_audio_playing,
+                               has_video_renderer, number_of_frames,
+                               is_video_eos_received, has_enough_video_data,
+                               has_audio_renderer, !is_progressing_);
+  }
 }
 
 SbDecodeTarget SbPlayerPrivateImpl::GetCurrentDecodeTarget() {

--- a/starboard/shared/starboard/player/player_internal.h
+++ b/starboard/shared/starboard/player/player_internal.h
@@ -20,6 +20,7 @@
 #include <utility>
 #include <vector>
 
+#include "starboard/common/player.h"
 #include "starboard/decode_target.h"
 #include "starboard/media.h"
 #include "starboard/player.h"
@@ -72,6 +73,7 @@ class SbPlayerPrivateImpl final : public SbPlayerPrivate {
       SbPlayerDecoderStatusFunc decoder_status_func,
       SbPlayerStatusFunc player_status_func,
       SbPlayerErrorFunc player_error_func,
+      SbPlayerRenderStatusFunc player_render_status_func,
       void* context,
       std::unique_ptr<PlayerWorker::Handler> player_worker_handler);
 
@@ -100,15 +102,23 @@ class SbPlayerPrivateImpl final : public SbPlayerPrivate {
       SbPlayerDecoderStatusFunc decoder_status_func,
       SbPlayerStatusFunc player_status_func,
       SbPlayerErrorFunc player_error_func,
+      SbPlayerRenderStatusFunc player_render_status_func,
       void* context,
       std::unique_ptr<PlayerWorker::Handler> player_worker_handler);
 
   void UpdateMediaInfo(int64_t media_time,
                        int dropped_video_frames,
                        int ticket,
-                       bool is_progressing);
+                       bool is_progressing,
+                       bool is_audio_playing,
+                       bool has_video_renderer,
+                       int number_of_frames,
+                       bool is_video_eos_received,
+                       bool has_enough_video_data,
+                       bool has_audio_renderer);
 
   SbPlayerDeallocateSampleFunc sample_deallocate_func_;
+  SbPlayerRenderStatusFunc player_render_status_func_;
   void* context_;
 
   std::mutex mutex_;

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -39,6 +39,12 @@ using ::starboard::GetPlayerStateName;
 using std::placeholders::_1;
 using std::placeholders::_2;
 using std::placeholders::_3;
+using std::placeholders::_4;
+using std::placeholders::_5;
+using std::placeholders::_6;
+using std::placeholders::_7;
+using std::placeholders::_8;
+using std::placeholders::_9;
 
 typedef shared::starboard::player::PlayerWorker::Handler::HandlerResult
     HandlerResult;
@@ -152,9 +158,18 @@ PlayerWorker::PlayerWorker(SbMediaAudioCodec audio_codec,
 
 void PlayerWorker::UpdateMediaInfo(int64_t time,
                                    int dropped_video_frames,
-                                   bool is_progressing) {
+                                   bool is_progressing,
+                                   bool is_audio_playing,
+                                   bool has_video_renderer,
+                                   int number_of_frames,
+                                   bool is_video_eos_received,
+                                   bool has_enough_video_data,
+                                   bool has_audio_renderer) {
   if (player_state_ == kSbPlayerStatePresenting) {
-    update_media_info_cb_(time, dropped_video_frames, ticket_, is_progressing);
+    update_media_info_cb_(time, dropped_video_frames, ticket_, is_progressing,
+                          is_audio_playing, has_video_renderer,
+                          number_of_frames, is_video_eos_received,
+                          has_enough_video_data, has_audio_renderer);
   }
 }
 
@@ -226,11 +241,13 @@ void PlayerWorker::DoInit() {
   Handler::UpdatePlayerErrorCB update_player_error_cb;
   update_player_error_cb = std::bind(&PlayerWorker::UpdatePlayerError, this, _1,
                                      HandlerResult{false}, _2);
-  HandlerResult result = handler_->Init(
-      player_, std::bind(&PlayerWorker::UpdateMediaInfo, this, _1, _2, _3),
-      std::bind(&PlayerWorker::player_state, this),
-      std::bind(&PlayerWorker::UpdatePlayerState, this, _1),
-      update_player_error_cb);
+  HandlerResult result =
+      handler_->Init(player_,
+                     std::bind(&PlayerWorker::UpdateMediaInfo, this, _1, _2, _3,
+                               _4, _5, _6, _7, _8, _9),
+                     std::bind(&PlayerWorker::player_state, this),
+                     std::bind(&PlayerWorker::UpdatePlayerState, this, _1),
+                     update_player_error_cb);
   if (result.success) {
     UpdatePlayerState(kSbPlayerStateInitialized);
   } else {

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -24,6 +24,7 @@
 #include <utility>
 
 #include "starboard/common/log.h"
+#include "starboard/common/player.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/player.h"
@@ -46,7 +47,13 @@ class PlayerWorker {
   typedef std::function<void(int64_t media_time,
                              int dropped_video_frames,
                              int ticket,
-                             bool is_progressing)>
+                             bool is_progressing,
+                             bool is_audio_playing,
+                             bool has_video_renderer,
+                             int number_of_frames,
+                             bool is_video_eos_received,
+                             bool has_enough_video_data,
+                             bool has_audio_renderer)>
       UpdateMediaInfoCB;
 
   struct Bounds {
@@ -71,8 +78,15 @@ class PlayerWorker {
     typedef ::starboard::shared::starboard::player::InputBuffer InputBuffer;
     typedef ::starboard::shared::starboard::player::InputBuffers InputBuffers;
 
-    typedef std::function<
-        void(int64_t media_time, int dropped_video_frames, bool is_progressing)>
+    typedef std::function<void(int64_t media_time,
+                               int dropped_video_frames,
+                               bool is_progressing,
+                               bool is_audio_playing,
+                               bool has_video_renderer,
+                               int number_of_frames,
+                               bool is_video_eos_received,
+                               bool has_enough_video_data,
+                               bool has_audio_renderer)>
         UpdateMediaInfoCB;
     typedef std::function<SbPlayerState()> GetPlayerStateCB;
     typedef std::function<void(SbPlayerState player_state)> UpdatePlayerStateCB;
@@ -195,7 +209,15 @@ class PlayerWorker {
   PlayerWorker(const PlayerWorker&) = delete;
   PlayerWorker& operator=(const PlayerWorker&) = delete;
 
-  void UpdateMediaInfo(int64_t time, int dropped_video_frames, bool underflow);
+  void UpdateMediaInfo(int64_t time,
+                       int dropped_video_frames,
+                       bool underflow,
+                       bool is_audio_playing,
+                       bool has_video_renderer,
+                       int number_of_frames,
+                       bool is_video_eos_received,
+                       bool has_enough_video_data,
+                       bool has_audio_renderer);
 
   SbPlayerState player_state() const { return player_state_; }
   void UpdatePlayerState(SbPlayerState player_state);


### PR DESCRIPTION
The Starboard layer now exposes detailed player render status information
through a new Starboard Extension (dev.starboard.extension.PlayerGetRenderStatus).
This extension provides callbacks for the number of video frames, audio
and video underflow, and other rendering states.

Cobalt's media pipeline can subscribe to these updates. When the feature
flag "CobaltPausePlaybackWhenUnderflow" is enabled, Cobalt will pause
playback if an audio or video underflow event is reported by the platform.
This improves user experience by preventing stuttering or silent playback
during buffer starvation and allows for more robust playback control.

This PR was https://github.com/youtube/cobalt/pull/6169.

Issue: 307362589