### PR TITLE
cobalt: Fix failing memory metrics unit test

### DIFF
--- a/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
@@ -74,9 +74,12 @@ class TestProcessMemoryMetricsEmitter : public CobaltMemoryMetricsEmitter {
     browser_dump->process_type =
         memory_instrumentation::mojom::ProcessType::BROWSER;
     browser_dump->os_dump = memory_instrumentation::mojom::OSMemDump::New();
-    browser_dump->os_dump->private_footprint_kb = 10240;  // 10 MB
-    browser_dump->os_dump->resident_set_kb = 20480;       // 20 MB
-    browser_dump->os_dump->shared_footprint_kb = 5120;    // 5 MB
+    browser_dump->os_dump->private_footprint_kb = 10240;    // 10 MB
+    browser_dump->os_dump->resident_set_kb = 20480;         // 20 MB
+    browser_dump->os_dump->shared_footprint_kb = 5120;      // 5 MB
+    browser_dump->os_dump->partition_alloc_rss_kb = 16384;  // 16 MB
+    browser_dump->os_dump->libchrobalt_rss_kb = 10240;      // 10 MB
+    browser_dump->os_dump->libchrobalt_pss_kb = 8192;       // 8 MB
 
     // Add a blink_gc dump
     auto blink_gc_dump = memory_instrumentation::mojom::AllocatorMemDump::New();
@@ -185,7 +188,8 @@ class TestProcessMemoryMetricsEmitter : public CobaltMemoryMetricsEmitter {
     renderer_dump->process_type =
         memory_instrumentation::mojom::ProcessType::RENDERER;
     renderer_dump->os_dump = memory_instrumentation::mojom::OSMemDump::New();
-    renderer_dump->os_dump->private_footprint_kb = 20480;  // 20 MB
+    renderer_dump->os_dump->private_footprint_kb = 20480;   // 20 MB
+    renderer_dump->os_dump->partition_alloc_rss_kb = 2048;  // 2 MB
 
     auto renderer_blink_gc_dump =
         memory_instrumentation::mojom::AllocatorMemDump::New();


### PR DESCRIPTION
The RecordMemoryMetricsRecordsHistogram unit test was failing due
to incomplete mock OS memory dumps. New memory metrics fields were
added to the system, but the test's TestProcessMemoryMetricsEmitter
was not updated to provide values for these fields.

This change updates the simulated OSMemDump objects to include
partition_alloc_rss_kb, libchrobalt_rss_kb, and libchrobalt_pss_kb.
By providing these values, the test can now accurately simulate a
complete memory report, allowing the metrics recording logic to
execute and validate correctly. This ensures the unit test passes.

Test: `run_cobalt_unittests -v -f "*RecordMemoryMetricsRecordsHistogram*"`
Bug: 496297035