### PR TITLE
android: Reinitialize video decoder on format change

### DIFF
--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -38,6 +38,7 @@
 #include "starboard/configuration.h"
 #include "starboard/decode_target.h"
 #include "starboard/drm.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/mime_type.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
 #include "starboard/thread.h"
@@ -412,6 +413,11 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
                                                             : 0),
       skip_flush_on_decoder_teardown_(
           experimental_features.skip_flush_on_decoder_teardown),
+      // TODO: b/496313908 - Connect to experimental flag.
+      reinitialize_decoder_after_output_format_change_(
+          starboard::features::FeatureList::IsEnabled(
+              starboard::features::
+                  kReinitializeDecoderAfterOutputFormatChange)),
       force_reset_surface_(force_reset_surface),
       force_reset_surface_under_tunnel_mode_(
           force_reset_surface_under_tunnel_mode),
@@ -463,6 +469,9 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
                << ", max video capabilities=\"" << max_video_capabilities_
                << "\", and tunnel mode audio session id="
                << tunnel_mode_audio_session_id_;
+  SB_LOG_IF(INFO, reinitialize_decoder_after_output_format_change_)
+      << "`kReinitializeDecoderAfterOutputFormatChange` is set to true, force "
+         "re-init video decoder after seek if output format changes.";
 }
 
 VideoDecoder::~VideoDecoder() {
@@ -540,6 +549,37 @@ void VideoDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
   SB_DCHECK(!input_buffers.empty());
   SB_DCHECK_EQ(input_buffers.front()->sample_type(), kSbMediaTypeVideo);
   SB_DCHECK(decoder_status_cb_);
+
+  if (should_check_output_format_change_after_seek_ &&
+      enable_flush_during_seek_ && last_frame_width_after_seek_ > 0 &&
+      last_frame_height_after_seek_ > 0 &&
+      (input_buffers.front()->video_stream_info().frame_width !=
+           last_frame_width_after_seek_ ||
+       input_buffers.front()->video_stream_info().frame_height !=
+           last_frame_height_after_seek_)) {
+    // Output format changes after flush, re-initialize Codec
+    SB_LOG(INFO) << "Output format changes from "
+                 << last_frame_width_after_seek_ << "x"
+                 << last_frame_height_after_seek_ << " to "
+                 << input_buffers.front()->video_stream_info().frame_width
+                 << "x"
+                 << input_buffers.front()->video_stream_info().frame_height
+                 << ", re-initialize MediaCodec.";
+    last_frame_width_after_seek_ =
+        input_buffers.front()->video_stream_info().frame_width;
+    last_frame_height_after_seek_ =
+        input_buffers.front()->video_stream_info().frame_height;
+    TeardownCodec();
+    if (reset_delay_usec_ > 0) {
+      usleep(reset_delay_usec_);
+    }
+
+    input_buffer_written_ = 0;
+    video_fps_ = 0;
+    should_check_output_format_change_after_seek_ = false;
+  }
+  last_frame_width_ = input_buffers.front()->video_stream_info().frame_width;
+  last_frame_height_ = input_buffers.front()->video_stream_info().frame_height;
 
   if (input_buffer_written_ == 0) {
     SB_DCHECK_EQ(video_fps_, 0);
@@ -665,6 +705,15 @@ void VideoDecoder::ResetInternal(bool skip_flush) {
 
     input_buffer_written_ = 0;
     video_fps_ = 0;
+
+    last_frame_width_after_seek_ = -1;
+    last_frame_height_after_seek_ = -1;
+  } else {
+    last_frame_width_after_seek_ = last_frame_width_;
+    last_frame_height_after_seek_ = last_frame_height_;
+
+    should_check_output_format_change_after_seek_ =
+        reinitialize_decoder_after_output_format_change_;
   }
   CancelPendingJobs();
 

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -171,6 +171,7 @@ class VideoDecoder
   const int64_t reset_delay_usec_;
   const int64_t flush_delay_usec_;
   const bool skip_flush_on_decoder_teardown_;
+  const bool reinitialize_decoder_after_output_format_change_;
 
   // Force resetting the video surface after every playback.
   const bool force_reset_surface_;
@@ -247,6 +248,13 @@ class VideoDecoder
   bool first_output_format_changed_ = false;
   std::optional<VideoOutputFormat> output_format_;
   size_t number_of_preroll_frames_;
+
+  int last_frame_width_after_seek_ = -1;
+  int last_frame_height_after_seek_ = -1;
+  int last_frame_width_ = -1;
+  int last_frame_height_ = -1;
+
+  bool should_check_output_format_change_after_seek_ = false;
 };
 
 }  // namespace starboard::android::shared

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -146,6 +146,14 @@ STARBOARD_FEATURE(kRejectLowPerformanceSoftwareDecoder,
 STARBOARD_FEATURE(kEnableAv1StartupOptimization,
                   "EnableAv1StartupOptimization",
                   false)
+
+// Set the following variable to true to force re-initialize video
+// decoder after output format change during seek when
+// |kForceFlushDecoderDuringReset| and |kForceResetAudioDecoder| is enabled.
+STARBOARD_FEATURE(kReinitializeDecoderAfterOutputFormatChange,
+                  "ReinitializeDecoderAfterOutputFormatChange",
+                  false)
+
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 FEATURE_LIST_END
 


### PR DESCRIPTION
Reinitialize the Android video decoder when the output frame
dimensions change after a seek operation. This addresses cases
where the underlying MediaCodec may fail to adapt to resolution
changes, which can cause rendering artifacts or instability.
A new feature flag, kReinitializeDecoderAfterOutputFormatChange,
controls this behavior. This is enabled alongside
kForceFlushDecoderDuringReset and kForceResetAudioDecoder.

Issue: 496313908