### PR TITLE
android: Re-write input after input buffer unavailable error

### DIFF
--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -501,9 +501,13 @@ bool MediaDecoder::ProcessOneInputBuffer(
     ScopedJavaLocalRef<jobject> byte_buffer(
         media_codec_bridge_->GetInputBuffer(dequeue_input_result.index));
     if (byte_buffer.is_null()) {
-      SB_LOG(ERROR) << "Unable to write to MediaCodec buffer, |byte_buffer| is"
+      SB_LOG(ERROR) << "Unable to get MediaCodec input buffer, |byte_buffer| is"
                     << " null.";
-      // TODO: Stop the decoding loop and call error_cb_ on fatal error.
+      // There could be dirty callbacks right after flush, thus the
+      // MediaCodec.InputBuffer could be unavailable. In that case, we should
+      // re-write the input buffer with a different MediaCodec.InputBuffer.
+      pending_inputs->emplace(pending_inputs->begin(), pending_input);
+      number_of_pending_inputs_++;
       return false;
     }
 


### PR DESCRIPTION
When MediaCodec::GetInputBuffer returns null, indicating an input buffer
is unavailable, re-insert the current pending input into the queue for
reprocessing. This addresses scenarios where input buffers might be
temporarily unavailable due to dirty callbacks immediately following a
MediaCodec flush. Re-queueing allows the system to use an available
buffer, preventing decoding stalls or errors.

Bug: 493983265