### PR TITLE
zlib: Fix GzipCompress invalid pointer crash

### DIFF
--- a/cobalt/testing/filters/evergreen-x64/cobalt_unittests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-x64/cobalt_unittests_loader_filter.json
@@ -1,5 +1,4 @@
 {
   "failing_tests": [
-    "CobaltMetricsLogUploaderTest.UploadLogUmaServiceTypeSuccessfulUpload"
   ]
 }

--- a/cobalt/testing/filters/linux-x64x11-modular/cobalt_unittests_loader_filter.json
+++ b/cobalt/testing/filters/linux-x64x11-modular/cobalt_unittests_loader_filter.json
@@ -1,5 +1,4 @@
 {
   "failing_tests": [
-    "CobaltMetricsLogUploaderTest.UploadLogUmaServiceTypeSuccessfulUpload"
   ]
 }

--- a/third_party/zlib/google/compression_utils.cc
+++ b/third_party/zlib/google/compression_utils.cc
@@ -4,6 +4,10 @@
 
 #include "third_party/zlib/google/compression_utils.h"
 
+#if defined(COBALT)
+#include "build/build_config.h"
+#endif
+
 #include "base/bit_cast.h"
 #include "base/check_op.h"
 #include "base/process/memory.h"
@@ -57,22 +61,42 @@ bool GzipCompress(base::span<const uint8_t> input, std::string* output) {
           compressed_data, &compressed_data_size,
           base::bit_cast<const Bytef*>(input.data()), input_size, nullptr,
           nullptr) != Z_OK) {
+#if BUILDFLAG(IS_COBALT)
     base::UncheckedFree(compressed_data);
+#else
+    free(compressed_data);
+#endif
     return false;
   }
 
+#if BUILDFLAG(IS_COBALT)
   output->assign(compressed_data, compressed_data + compressed_data_size);
+#else
+  Bytef* resized_data =
+      reinterpret_cast<Bytef*>(realloc(compressed_data, compressed_data_size));
+  if (!resized_data) {
+    free(compressed_data);
+    return false;
+  }
+  output->assign(resized_data, resized_data + compressed_data_size);
+#endif
+
   DCHECK_EQ(input_size, GetUncompressedSize(*output));
 
+#if BUILDFLAG(IS_COBALT)
   base::UncheckedFree(compressed_data);
+#else
+  free(resized_data);
+#endif
   return true;
 }
 
 bool GzipUncompress(const std::string& input, std::string* output) {
   std::string uncompressed_output;
   uLongf uncompressed_size = static_cast<uLongf>(GetUncompressedSize(input));
-  if (size_t{uncompressed_size} > uncompressed_output.max_size())
+  if (size_t{uncompressed_size} > uncompressed_output.max_size()) {
     return false;
+  }
 
   uncompressed_output.resize(uncompressed_size);
   if (zlib_internal::GzipUncompressHelper(
@@ -93,8 +117,9 @@ bool GzipUncompress(base::span<const char> input,
 bool GzipUncompress(base::span<const uint8_t> input,
                     base::span<const uint8_t> output) {
   uLongf uncompressed_size = GetUncompressedSize(input);
-  if (uncompressed_size > output.size())
+  if (uncompressed_size > output.size()) {
     return false;
+  }
   return zlib_internal::GzipUncompressHelper(
              base::bit_cast<Bytef*>(output.data()), &uncompressed_size,
              base::bit_cast<const Bytef*>(input.data()),

--- a/third_party/zlib/google/compression_utils.cc
+++ b/third_party/zlib/google/compression_utils.cc
@@ -57,20 +57,14 @@ bool GzipCompress(base::span<const uint8_t> input, std::string* output) {
           compressed_data, &compressed_data_size,
           base::bit_cast<const Bytef*>(input.data()), input_size, nullptr,
           nullptr) != Z_OK) {
-    free(compressed_data);
+    base::UncheckedFree(compressed_data);
     return false;
   }
 
-  Bytef* resized_data =
-      reinterpret_cast<Bytef*>(realloc(compressed_data, compressed_data_size));
-  if (!resized_data) {
-    free(compressed_data);
-    return false;
-  }
-  output->assign(resized_data, resized_data + compressed_data_size);
+  output->assign(compressed_data, compressed_data + compressed_data_size);
   DCHECK_EQ(input_size, GetUncompressedSize(*output));
 
-  free(resized_data);
+  base::UncheckedFree(compressed_data);
   return true;
 }
 


### PR DESCRIPTION
GzipCompress crashed in a `CobaltMetricsLogUploaderTest` test 
due to a mismatched memory allocator issue.

The initial buffer was allocated using base::UncheckedMalloc,
which routes through PartitionAlloc. However, subsequent resizing
attempted to use the system realloc(), causing a SIGABRT.

This change avoids realloc() and correctly pairs base::UncheckedFree()
with base::UncheckedMalloc() to resolve the invalid pointer abort.

Bug: 486012022
Bug: 486003653
Bug: 502259405