### PR TITLE
Cherry pick Storage Migration Rework to 26.eap

### DIFF
--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -94,13 +94,16 @@ void CobaltBrowserMainParts::InitializeMessageLoopContext() {
   // go/chrobalt-pre-initialization-storage-migration-pipeline
 #if !BUILDFLAG(IS_ANDROID)
   auto create_window_task = base::BindOnce(
-      [](GURL url, std::string deeplink_url,
+      [](std::string deeplink_url,
          content::ShellBrowserContext* browser_context) {
+        base::CommandLine* command_line =
+            base::CommandLine::ForCurrentProcess();
+        GURL url = GURL(switches::GetInitialURL(*command_line));
         content::Shell::CreateNewWindow(
             browser_context, url, nullptr, gfx::Size(),
             ::switches::ShouldCreateSplashScreen(), deeplink_url);
       },
-      GetStartupURL(), deep_link(), browser_context());
+      deep_link(), browser_context());
   PostOrRunIfStorageMigrationFinished(std::move(create_window_task));
 #endif
 }
@@ -161,29 +164,30 @@ void CobaltBrowserMainParts::OnMigrationComplete() {
   CHECK(sequence_checker_.CalledOnValidSequence());
   LOG(INFO) << "Migration complete. Proceeding with deferred launchShell.";
 
-  #if !BUILDFLAG(IS_ANDROIDTV)
+#if !BUILDFLAG(IS_ANDROIDTV)
   // Inject the migration telemetry into the global command line URL.
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   GURL url = GURL(switches::GetInitialURL(*command_line));
-  const std::string status_param = cobalt::migrate_storage_record::MigrationManager::GetMigrationStatusUrlParameter();
-  LOG(INFO) << "Hao: url= " << url.spec();
-  LOG(INFO) << "Hao: status_param= " << status_param;
+  const std::string status_param = cobalt::migrate_storage_record::
+      MigrationManager::GetMigrationStatusUrlParameter();
 
   if (url.is_valid() && !status_param.empty()) {
     GURL::Replacements replacements;
     std::string query = url.query();
     if (!query.empty()) {
-       query += "&";
+      query += "&";
     }
     query += status_param;
     replacements.SetQueryStr(query);
     url = url.ReplaceComponents(replacements);
-  
+
     command_line->RemoveSwitch(switches::kInitialURL);
     command_line->AppendSwitchASCII(switches::kInitialURL, url.spec());
-    LOG(INFO) << "Storage migration status telemetry injected into global startup URL: " << url.spec();
+    LOG(INFO) << "Storage migration status telemetry injected into global "
+                 "startup URL: "
+              << url.spec();
   }
-  #endif  // !BUILDFLAG(IS_ANDROIDTV)
+#endif  // !BUILDFLAG(IS_ANDROIDTV)
 
   migration_finished_ = true;
   if (pending_task_) {

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -94,18 +94,37 @@ void CobaltBrowserMainParts::InitializeMessageLoopContext() {
   // go/chrobalt-pre-initialization-storage-migration-pipeline
 #if !BUILDFLAG(IS_ANDROID)
   auto create_window_task = base::BindOnce(
-      [](std::string deeplink_url,
-         content::ShellBrowserContext* browser_context) {
-        base::CommandLine* command_line =
-            base::CommandLine::ForCurrentProcess();
-        GURL url = GURL(switches::GetInitialURL(*command_line));
-        content::Shell::CreateNewWindow(
-            browser_context, url, nullptr, gfx::Size(),
-            ::switches::ShouldCreateSplashScreen(), deeplink_url);
-      },
-      deep_link(), browser_context());
+      &CobaltBrowserMainParts::CreateWindowWithMigrationStatus,
+      base::Unretained(this), GetStartupURL(), deep_link(), browser_context());
   PostOrRunIfStorageMigrationFinished(std::move(create_window_task));
 #endif
+}
+
+void CobaltBrowserMainParts::CreateWindowWithMigrationStatus(
+    GURL url,
+    std::string deeplink_url,
+    content::ShellBrowserContext* browser_context) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+
+  std::string migration_status = cobalt::migrate_storage_record::
+      MigrationManager::GetMigrationStatusUrlParameter();
+  if (!migration_status.empty() && url.is_valid()) {
+    GURL::Replacements replacements;
+    std::string query = url.query();
+    if (!query.empty()) {
+      query += "&";
+    }
+    query += migration_status;
+    replacements.SetQueryStr(query);
+    url = url.ReplaceComponents(replacements);
+    LOG(INFO)
+        << "Storage migration status telemetry injected into startup URL: "
+        << url.spec();
+  }
+
+  content::Shell::CreateNewWindow(browser_context, url, nullptr, gfx::Size(),
+                                  ::switches::ShouldCreateSplashScreen(),
+                                  deeplink_url);
 }
 
 CobaltBrowserMainParts::CobaltBrowserMainParts(bool is_visible,
@@ -163,31 +182,6 @@ void CobaltBrowserMainParts::OnMigrationComplete() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   CHECK(sequence_checker_.CalledOnValidSequence());
   LOG(INFO) << "Migration complete. Proceeding with deferred launchShell.";
-
-#if !BUILDFLAG(IS_ANDROIDTV)
-  // Inject the migration telemetry into the global command line URL.
-  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
-  GURL url = GURL(switches::GetInitialURL(*command_line));
-  const std::string status_param = cobalt::migrate_storage_record::
-      MigrationManager::GetMigrationStatusUrlParameter();
-
-  if (url.is_valid() && !status_param.empty()) {
-    GURL::Replacements replacements;
-    std::string query = url.query();
-    if (!query.empty()) {
-      query += "&";
-    }
-    query += status_param;
-    replacements.SetQueryStr(query);
-    url = url.ReplaceComponents(replacements);
-
-    command_line->RemoveSwitch(switches::kInitialURL);
-    command_line->AppendSwitchASCII(switches::kInitialURL, url.spec());
-    LOG(INFO) << "Storage migration status telemetry injected into global "
-                 "startup URL: "
-              << url.spec();
-  }
-#endif  // !BUILDFLAG(IS_ANDROIDTV)
 
   migration_finished_ = true;
   if (pending_task_) {

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -23,6 +23,7 @@
 #include "base/trace_event/memory_dump_manager.h"
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
+#include "cobalt/browser/switches.h"
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
 #include "cobalt/shell/browser/shell.h"
 #include "cobalt/shell/browser/shell_content_browser_client.h"
@@ -95,27 +96,9 @@ void CobaltBrowserMainParts::InitializeMessageLoopContext() {
   auto create_window_task = base::BindOnce(
       [](GURL url, std::string deeplink_url,
          content::ShellBrowserContext* browser_context) {
-        const std::string status_param = cobalt::migrate_storage_record::
-            MigrationManager::GetMigrationStatusUrlParameter();
-
-        if (!status_param.empty()) {
-          // If a migration occurred on this launch, append its outcome directly
-          // to the URL's query parameters (e.g. "?migration_status=0-0-0").
-          // This makes the migration telemetry accessible to the loaded web
-          // app.
-          GURL::Replacements replacements;
-          std::string query = url.query();
-          if (!query.empty()) {
-            query += "&";
-          }
-          query += status_param;
-          replacements.SetQueryStr(query);
-          url = url.ReplaceComponents(replacements);
-          LOG(INFO) << "Telemetry injected startup URL: " << url.spec();
-        }
         content::Shell::CreateNewWindow(
             browser_context, url, nullptr, gfx::Size(),
-            switches::ShouldCreateSplashScreen(), deeplink_url);
+            ::switches::ShouldCreateSplashScreen(), deeplink_url);
       },
       GetStartupURL(), deep_link(), browser_context());
   PostOrRunIfStorageMigrationFinished(std::move(create_window_task));
@@ -170,13 +153,38 @@ void CobaltBrowserMainParts::StartStorageMigration() {
   DCHECK(partition);
   cobalt::migrate_storage_record::MigrationManager::RunMigration(
       partition, base::BindOnce(&CobaltBrowserMainParts::OnMigrationComplete,
-                                base::Unretained(this)));
+                                weak_ptr_factory_.GetWeakPtr()));
 }
 
 void CobaltBrowserMainParts::OnMigrationComplete() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   CHECK(sequence_checker_.CalledOnValidSequence());
   LOG(INFO) << "Migration complete. Proceeding with deferred launchShell.";
+
+  #if !BUILDFLAG(IS_ANDROIDTV)
+  // Inject the migration telemetry into the global command line URL.
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  GURL url = GURL(switches::GetInitialURL(*command_line));
+  const std::string status_param = cobalt::migrate_storage_record::MigrationManager::GetMigrationStatusUrlParameter();
+  LOG(INFO) << "Hao: url= " << url.spec();
+  LOG(INFO) << "Hao: status_param= " << status_param;
+
+  if (url.is_valid() && !status_param.empty()) {
+    GURL::Replacements replacements;
+    std::string query = url.query();
+    if (!query.empty()) {
+       query += "&";
+    }
+    query += status_param;
+    replacements.SetQueryStr(query);
+    url = url.ReplaceComponents(replacements);
+  
+    command_line->RemoveSwitch(switches::kInitialURL);
+    command_line->AppendSwitchASCII(switches::kInitialURL, url.spec());
+    LOG(INFO) << "Storage migration status telemetry injected into global startup URL: " << url.spec();
+  }
+  #endif  // !BUILDFLAG(IS_ANDROIDTV)
+
   migration_finished_ = true;
   if (pending_task_) {
     std::move(pending_task_).Run();

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -97,17 +97,21 @@ void CobaltBrowserMainParts::InitializeMessageLoopContext() {
          content::ShellBrowserContext* browser_context) {
         const std::string status_param = cobalt::migrate_storage_record::
             MigrationManager::GetMigrationStatusUrlParameter();
-        if (!status_param.empty() && !deeplink_url.empty()) {
+
+        if (!status_param.empty()) {
           // If a migration occurred on this launch, append its outcome directly
           // to the URL's query parameters (e.g. "?migration_status=0-0-0").
           // This makes the migration telemetry accessible to the loaded web
           // app.
-          if (deeplink_url.find('?') == std::string::npos) {
-            deeplink_url += "?";
-          } else {
-            deeplink_url += "&";
+          GURL::Replacements replacements;
+          std::string query = url.query();
+          if (!query.empty()) {
+            query += "&";
           }
-          deeplink_url += status_param;
+          query += status_param;
+          replacements.SetQueryStr(query);
+          url = url.ReplaceComponents(replacements);
+          LOG(INFO) << "Telemetry injected startup URL: " << url.spec();
         }
         content::Shell::CreateNewWindow(
             browser_context, url, nullptr, gfx::Size(),

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -17,14 +17,17 @@
 #include <memory>
 
 #include "base/check.h"
+#include "base/functional/bind.h"
 #include "base/path_service.h"
 #include "base/sequence_checker.h"
 #include "base/trace_event/memory_dump_manager.h"
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
+#include "cobalt/shell/browser/shell.h"
 #include "cobalt/shell/browser/shell_content_browser_client.h"
 #include "cobalt/shell/browser/shell_paths.h"
+#include "cobalt/shell/common/shell_switches.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
 #include "content/public/browser/browser_thread.h"
@@ -89,7 +92,29 @@ void CobaltBrowserMainParts::InitializeMessageLoopContext() {
   // On Linux, we might need the base behavior.
   // go/chrobalt-pre-initialization-storage-migration-pipeline
 #if !BUILDFLAG(IS_ANDROID)
-  ShellBrowserMainParts::InitializeMessageLoopContext();
+  auto create_window_task = base::BindOnce(
+      [](GURL url, std::string deeplink_url,
+         content::ShellBrowserContext* browser_context) {
+        const std::string status_param = cobalt::migrate_storage_record::
+            MigrationManager::GetMigrationStatusUrlParameter();
+        if (!status_param.empty() && !deeplink_url.empty()) {
+          // If a migration occurred on this launch, append its outcome directly
+          // to the URL's query parameters (e.g. "?migration_status=0-0-0").
+          // This makes the migration telemetry accessible to the loaded web
+          // app.
+          if (deeplink_url.find('?') == std::string::npos) {
+            deeplink_url += "?";
+          } else {
+            deeplink_url += "&";
+          }
+          deeplink_url += status_param;
+        }
+        content::Shell::CreateNewWindow(
+            browser_context, url, nullptr, gfx::Size(),
+            switches::ShouldCreateSplashScreen(), deeplink_url);
+      },
+      GetStartupURL(), deep_link(), browser_context());
+  PostOrRunIfStorageMigrationFinished(std::move(create_window_task));
 #endif
 }
 

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -16,10 +16,14 @@
 
 #include <memory>
 
+#include "base/check.h"
 #include "base/path_service.h"
+#include "base/sequence_checker.h"
 #include "base/trace_event/memory_dump_manager.h"
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
+#include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
+#include "cobalt/shell/browser/shell_content_browser_client.h"
 #include "cobalt/shell/browser/shell_paths.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
@@ -79,6 +83,16 @@ void InitializeBrowserMemoryInstrumentationClient() {
 
 }  // namespace
 
+void CobaltBrowserMainParts::InitializeMessageLoopContext() {
+  // On Android, we completely defer WebContents creation until the Java layer
+  // invokes ShellManager.launchShell() which reaches C++ via JNI.
+  // On Linux, we might need the base behavior.
+  // go/chrobalt-pre-initialization-storage-migration-pipeline
+#if !BUILDFLAG(IS_ANDROID)
+  ShellBrowserMainParts::InitializeMessageLoopContext();
+#endif
+}
+
 CobaltBrowserMainParts::CobaltBrowserMainParts(bool is_visible,
                                                const std::string& deep_link)
     : ShellBrowserMainParts(is_visible, deep_link) {}
@@ -106,7 +120,53 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
 
 #endif  // !BUILDFLAG(IS_ANDROIDTV)
 
-  return ShellBrowserMainParts::PreMainMessageLoopRun();
+  int result = ShellBrowserMainParts::PreMainMessageLoopRun();
+
+  if (result != 0) {
+    LOG(ERROR) << "PreMainMessageLoopRun failed with result: " << result
+               << ". Aborting storage migration.";
+    return result;
+  }
+
+  StartStorageMigration();
+
+  return result;
+}
+
+void CobaltBrowserMainParts::StartStorageMigration() {
+  LOG(INFO) << "CobaltBrowserMainParts::StartStorageMigration started.";
+  content::StoragePartition* partition =
+      browser_context()->GetDefaultStoragePartition();
+
+  DCHECK(partition);
+  cobalt::migrate_storage_record::MigrationManager::RunMigration(
+      partition, base::BindOnce(&CobaltBrowserMainParts::OnMigrationComplete,
+                                base::Unretained(this)));
+}
+
+void CobaltBrowserMainParts::OnMigrationComplete() {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  CHECK(sequence_checker_.CalledOnValidSequence());
+  LOG(INFO) << "Migration complete. Proceeding with deferred launchShell.";
+  migration_finished_ = true;
+  if (pending_task_) {
+    std::move(pending_task_).Run();
+  }
+}
+
+void CobaltBrowserMainParts::PostOrRunIfStorageMigrationFinished(
+    base::OnceClosure task) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  CHECK(sequence_checker_.CalledOnValidSequence());
+  if (!migration_finished_) {
+    LOG(INFO) << "Deferring launchShell until migration finishes.";
+    CHECK(!pending_task_) << "Only one storage migration task is supported.";
+    pending_task_ = std::move(task);
+  } else {
+    LOG(INFO) << "Migration already finished, running launchShell "
+                 "immediately.";
+    std::move(task).Run();
+  }
 }
 
 void CobaltBrowserMainParts::PostDestroyThreads() {

--- a/cobalt/browser/cobalt_browser_main_parts.h
+++ b/cobalt/browser/cobalt_browser_main_parts.h
@@ -85,6 +85,11 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
   void InitializeMessageLoopContext() override;
 
  private:
+  void CreateWindowWithMigrationStatus(
+      GURL url,
+      std::string deeplink_url,
+      content::ShellBrowserContext* browser_context);
+
   base::SequenceCheckerImpl sequence_checker_;
 
   bool migration_finished_ GUARDED_BY_CONTEXT(sequence_checker_) = false;

--- a/cobalt/browser/cobalt_browser_main_parts.h
+++ b/cobalt/browser/cobalt_browser_main_parts.h
@@ -17,6 +17,7 @@
 
 #include <memory>
 
+#include "base/memory/weak_ptr.h"
 #include "base/sequence_checker_impl.h"
 #include "base/thread_annotations.h"
 
@@ -88,6 +89,8 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
 
   bool migration_finished_ GUARDED_BY_CONTEXT(sequence_checker_) = false;
   base::OnceClosure pending_task_ GUARDED_BY_CONTEXT(sequence_checker_);
+
+  base::WeakPtrFactory<CobaltBrowserMainParts> weak_ptr_factory_{this};
 };
 
 }  // namespace cobalt

--- a/cobalt/browser/cobalt_browser_main_parts.h
+++ b/cobalt/browser/cobalt_browser_main_parts.h
@@ -17,6 +17,9 @@
 
 #include <memory>
 
+#include "base/sequence_checker_impl.h"
+#include "base/thread_annotations.h"
+
 // TODO(b/390021478): Remove this include when CobaltBrowserMainParts stops
 // being a ShellBrowserMainParts.
 #include "cobalt/shell/browser/shell_browser_main_parts.h"
@@ -71,6 +74,20 @@ class CobaltBrowserMainParts : public content::ShellBrowserMainParts {
 
   // Starts metrics recording.
   void StartMetricsRecording();
+
+  // C25 Storage Migration
+  void StartStorageMigration();
+  void OnMigrationComplete();
+  void PostOrRunIfStorageMigrationFinished(base::OnceClosure task) override;
+
+ protected:
+  void InitializeMessageLoopContext() override;
+
+ private:
+  base::SequenceCheckerImpl sequence_checker_;
+
+  bool migration_finished_ GUARDED_BY_CONTEXT(sequence_checker_) = false;
+  base::OnceClosure pending_task_ GUARDED_BY_CONTEXT(sequence_checker_);
 };
 
 }  // namespace cobalt

--- a/cobalt/shell/browser/migrate_storage_record/BUILD.gn
+++ b/cobalt/shell/browser/migrate_storage_record/BUILD.gn
@@ -20,6 +20,7 @@ source_set("migrate_storage_record") {
     "//net",
     "//services/network/public/mojom:cookies_mojom",
     "//starboard/common",
+    "//third_party/blink/public/mojom:mojom_platform",
     "//url",
   ]
   public_deps = [

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -342,7 +342,7 @@ ReadAndParseLegacyStorageRecord() {
       }
     }
 
-    if (record->GetSize() < kRecordHeaderSize) {
+    if (static_cast<size_t>(record->GetSize()) < kRecordHeaderSize) {
       result = StorageReadResult::kSizeTooSmall;
       return;
     }
@@ -351,7 +351,7 @@ ReadAndParseLegacyStorageRecord() {
     const int read_result =
         record->Read(reinterpret_cast<char*>(bytes.data()), bytes.size());
 
-    if (read_result != bytes.size()) {
+    if (static_cast<size_t>(read_result) != bytes.size()) {
       result = StorageReadResult::kReadMismatch;
       return;
     }

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -555,7 +555,9 @@ MigrationManager::ToCanonicalCookies(const cobalt::storage::Storage& storage) {
         base::Time::FromInternalValue(c.expiration_time_us()),
         base::Time::FromInternalValue(c.last_access_time_us()),
         base::Time::FromInternalValue(c.creation_time_us()), c.secure(),
-        c.http_only(), net::CookieSameSite::NO_RESTRICTION,
+        c.http_only(),
+        c.secure() ? net::CookieSameSite::NO_RESTRICTION
+                   : net::CookieSameSite::UNSPECIFIED,
         net::COOKIE_PRIORITY_DEFAULT, false, absl::nullopt,
         net::CookieSourceScheme::kUnset, url::PORT_UNSPECIFIED));
   }

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -14,147 +14,101 @@
 
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
 
+#include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
+#include "base/barrier_closure.h"
 #include "base/base64url.h"
 #include "base/command_line.h"
 #include "base/containers/adapters.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/functional/bind.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/metrics/histogram_functions.h"
 #include "base/path_service.h"
+#include "base/strings/stringprintf.h"
 #include "base/strings/utf_string_conversions.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
 #include "base/timer/elapsed_timer.h"
 #include "cobalt/browser/switches.h"
 #include "cobalt/shell/common/shell_switches.h"
+#include "components/services/storage/public/mojom/local_storage_control.mojom.h"
 #include "components/url_matcher/url_util.h"
-#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/browser_context.h"
+#include "content/public/browser/navigation_controller.h"
 #include "content/public/browser/storage_partition.h"
+#include "content/public/browser/web_contents.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "net/base/registry_controlled_domains/registry_controlled_domain.h"
+#include "net/base/schemeful_site.h"
+#include "net/cookies/canonical_cookie.h"
 #include "net/cookies/cookie_access_result.h"
 #include "net/cookies/cookie_options.h"
 #include "services/network/public/mojom/cookie_manager.mojom.h"
 #include "starboard/common/storage.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/system.h"
+#include "third_party/blink/public/common/storage_key/storage_key.h"
+#include "third_party/blink/public/mojom/dom_storage/storage_area.mojom.h"
 #include "url/gurl.h"
+#include "url/origin.h"
 
 namespace cobalt {
 namespace migrate_storage_record {
 
+using StorageAreaRemote = mojo::Remote<blink::mojom::StorageArea>;
+
 namespace {
 
-std::string GetApplicationKey(const GURL& url) {
-  std::string encoded_url;
-  base::Base64UrlEncode(url_matcher::util::Normalize(url).spec(),
-                        base::Base64UrlEncodePolicy::INCLUDE_PADDING,
-                        &encoded_url);
-  return encoded_url;
-}
+// ============================================================================
+// Shared Utilities
+// ============================================================================
 
-std::unique_ptr<cobalt::storage::Storage> ReadStorage() {
-  constexpr char kRecordHeader[] = "SAV1";
-  constexpr size_t kRecordHeaderSize = 4;
+std::string g_migration_status_param;
 
-  GURL initial_url(
-      switches::GetInitialURL(*base::CommandLine::ForCurrentProcess()));
-  CHECK(initial_url.is_valid());
-  std::string partition_key = GetApplicationKey(initial_url);
-  auto record =
-      std::make_unique<starboard::StorageRecord>(partition_key.c_str());
-  if (!record->IsValid()) {
-    record->Delete();
-    bool fallback =
-        partition_key == GetApplicationKey(GURL(::switches::kDefaultURL));
-    if (!fallback) {
-      return nullptr;
-    }
-
-    record = std::make_unique<starboard::StorageRecord>();
-    if (!record->IsValid()) {
-      record->Delete();
-      return nullptr;
+// A thread-safe, reference-counted wrapper around a base::OnceClosure.
+// This is used to ensure a callback is executed exactly once, even if
+// multiple async paths (like an IPC response and a timeout) attempt to run it.
+struct SharedClosureState : public base::RefCounted<SharedClosureState> {
+  base::OnceClosure cb;
+  void Run() {
+    if (cb) {
+      std::move(cb).Run();
     }
   }
 
-  if (record->GetSize() < static_cast<int64_t>(kRecordHeaderSize)) {
-    record->Delete();
-    return nullptr;
-  }
+ private:
+  friend class base::RefCounted<SharedClosureState>;
+  ~SharedClosureState() = default;
+};
 
-  auto bytes = std::vector<uint8_t>(record->GetSize());
-  const int read_result =
-      record->Read(reinterpret_cast<char*>(bytes.data()), bytes.size());
-  record->Delete();
-  if (static_cast<size_t>(read_result) != bytes.size()) {
-    return nullptr;
-  }
+constexpr char kOutcomeHistogram[] = "Cobalt.StorageMigration.Outcome";
+constexpr char kFastPathDurationHistogram[] =
+    "Cobalt.StorageMigration.FastPathDuration";
+constexpr char kReadResultHistogram[] = "Cobalt.StorageMigration.ReadResult";
+constexpr char kCookieInjectionResultHistogram[] =
+    "Cobalt.StorageMigration.CookieInjectionResult";
+constexpr char kLocalStorageInjectionResultHistogram[] =
+    "Cobalt.StorageMigration.LocalStorageInjectionResult";
+constexpr char kCookiesCountHistogram[] =
+    "Cobalt.StorageMigration.CookiesCount";
+constexpr char kLocalStorageCountHistogram[] =
+    "Cobalt.StorageMigration.LocalStorageCount";
+constexpr char kDurationHistogram[] = "Cobalt.StorageMigration.Duration";
+constexpr char kSentinelWriteResultHistogram[] =
+    "Cobalt.StorageMigration.SentinelWriteResult";
 
-  std::string version(reinterpret_cast<const char*>(bytes.data()),
-                      kRecordHeaderSize);
-  if (version != kRecordHeader) {
-    return nullptr;
-  }
+// ============================================================================
+// General File / Cache Utilities
+// ============================================================================
 
-  auto storage = std::make_unique<cobalt::storage::Storage>();
-  if (!storage->ParseFromArray(
-          reinterpret_cast<const char*>(bytes.data() + kRecordHeaderSize),
-          bytes.size() - kRecordHeaderSize)) {
-    return nullptr;
-  }
-  return storage;
-}
-
-content::RenderFrameHost* RenderFrameHost(
-    content::WeakDocumentPtr weak_document_ptr) {
-  auto* render_frame_host = weak_document_ptr.AsRenderFrameHostIfValid();
-  CHECK(render_frame_host);
-  return render_frame_host;
-}
-
-network::mojom::CookieManager* CookieManager(
-    content::WeakDocumentPtr weak_document_ptr) {
-  auto* storage_partition =
-      RenderFrameHost(weak_document_ptr)->GetStoragePartition();
-  CHECK(storage_partition);
-  auto* cookie_manager = storage_partition->GetCookieManagerForBrowserProcess();
-  CHECK(cookie_manager);
-  return cookie_manager;
-}
-
-#if !defined(COBALT_IS_RELEASE_BUILD)
-Task LogElapsedTimeTask() {
-  return base::BindOnce(
-      [](std::unique_ptr<base::ElapsedTimer> elapsed_timer,
-         base::OnceClosure callback) {
-        LOG(INFO) << "Cookie and localStorage migration completed in "
-                  << elapsed_timer->Elapsed().InMilliseconds() << " ms.";
-        std::move(callback).Run();
-      },
-      std::make_unique<base::ElapsedTimer>());
-}
-#endif  // !defined(COBALT_IS_RELEASE_BUILD)
-
-Task ReloadTask(content::WeakDocumentPtr weak_document_ptr, const GURL& url) {
-  return base::BindOnce(
-      [](content::WeakDocumentPtr weak_document_ptr, const GURL& url,
-         base::OnceClosure callback) {
-        auto* rfh = RenderFrameHost(weak_document_ptr);
-        content::WebContents* web_contents =
-            content::WebContents::FromRenderFrameHost(rfh);
-        if (web_contents) {
-          LOG(INFO) << "MigrationManager: Reloading URL: " << url.spec();
-          content::NavigationController::LoadURLParams params(url);
-          params.transition_type = ui::PageTransitionFromInt(
-              ui::PAGE_TRANSITION_TYPED | ui::PAGE_TRANSITION_FROM_ADDRESS_BAR);
-          web_contents->GetController().LoadURLWithParams(params);
-        }
-        std::move(callback).Run();
-      },
-      weak_document_ptr, url);
-}
-
+// Retrieves the system cache directory used by the legacy Starboard app.
 base::FilePath GetOldCachePath() {
   std::vector<char> path(kSbFileMaxPath, 0);
   bool success =
@@ -165,6 +119,96 @@ base::FilePath GetOldCachePath() {
   return base::FilePath(path.data());
 }
 
+// Retrieves the path to the sentinel file used to fast-path skip the migration.
+// If this file exists, it means the migration was already completed on a prior
+// app launch.
+base::FilePath GetMigrationSentinelPath() {
+  base::FilePath current_cache_path;
+  if (!base::PathService::Get(base::DIR_CACHE, &current_cache_path)) {
+    LOG(ERROR) << "Failed to get cache directory for migration sentinel file.";
+    return base::FilePath();
+  }
+  return current_cache_path.Append("migration_completed.txt");
+}
+
+// Writes the sentinel file `migration_completed.txt` in the background so that
+// future app launches can skip the migration process.
+void WriteMigrationSentinelAsync(scoped_refptr<MigrationState> state) {
+  base::ThreadPool::CreateSequencedTaskRunner(
+      {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+       base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN})
+      ->PostTask(
+          FROM_HERE,
+          base::BindOnce(
+              [](scoped_refptr<MigrationState> state) {
+                base::FilePath sentinel_path = GetMigrationSentinelPath();
+                SentinelWriteResult result = SentinelWriteResult::kSuccess;
+                if (sentinel_path.empty()) {
+                  LOG(ERROR)
+                      << "Sentinel path is empty, cannot write sentinel file.";
+                  result = SentinelWriteResult::kEmptyPath;
+                } else {
+                  if (!base::WriteFile(sentinel_path,
+                                       state->GetStatusString())) {
+                    LOG(ERROR) << "Failed to write migration sentinel file to "
+                               << sentinel_path.value();
+                    result = SentinelWriteResult::kWriteFailed;
+                  }
+                }
+                base::UmaHistogramEnumeration(kSentinelWriteResultHistogram,
+                                              result);
+              },
+              state));
+}
+
+// Generates the Base64 encoded key used to look up the legacy Starboard storage
+// record for the given URL.
+std::string GetApplicationKey(const GURL& url) {
+  std::string encoded_url;
+  base::Base64UrlEncode(url_matcher::util::Normalize(url).spec(),
+                        base::Base64UrlEncodePolicy::INCLUDE_PADDING,
+                        &encoded_url);
+  return encoded_url;
+}
+
+// Deletes the C25 Starboard Storage Record file from disk.
+// Returns true if the deletion was successful or the record was already
+// invalid.
+bool DeleteLegacyStorageRecord(starboard::StorageRecord* record) {
+  if (!record || !record->IsValid()) {
+    return true;  // Nothing to delete if null or not valid.
+  }
+  if (!record->Delete()) {
+    LOG(ERROR) << "Failed to delete legacy storage record.";
+    return false;
+  }
+  return true;
+}
+
+// Deletes the legacy starboard storage files asynchronously.
+void DeleteLegacyStorageFilesAsync() {
+  base::ThreadPool::CreateSequencedTaskRunner(
+      {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+       base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN})
+      ->PostTask(FROM_HERE, base::BindOnce([]() {
+                   GURL initial_url(switches::GetInitialURL(
+                       *base::CommandLine::ForCurrentProcess()));
+                   if (initial_url.is_valid()) {
+                     std::string partition_key = GetApplicationKey(initial_url);
+                     auto record = std::make_unique<starboard::StorageRecord>(
+                         partition_key.c_str());
+                     DeleteLegacyStorageRecord(record.get());
+                   }
+                   // Also attempt to delete the fallback default record.
+                   auto fallback_record =
+                       std::make_unique<starboard::StorageRecord>();
+                   DeleteLegacyStorageRecord(fallback_record.get());
+                 }));
+}
+
+// Deletes legacy cache subdirectories asynchronously to free up disk space.
+// It ensures that it does not accidentally delete the current actively used
+// cache directory.
 void DeleteOldCacheDirectoryAsync() {
   base::ThreadPool::CreateSequencedTaskRunner(
       {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
@@ -177,10 +221,17 @@ void DeleteOldCacheDirectoryAsync() {
             }
 
             base::FilePath current_cache_path;
-            base::PathService::Get(base::DIR_CACHE, &current_cache_path);
+            if (!base::PathService::Get(base::DIR_CACHE, &current_cache_path)) {
+              LOG(ERROR) << "Failed to get current cache directory. Skipping "
+                            "deletion of old cache path.";
+              return;
+            }
             if (!old_cache_path.IsParent(current_cache_path) &&
                 old_cache_path != current_cache_path) {
-              base::DeletePathRecursively(old_cache_path);
+              if (!base::DeletePathRecursively(old_cache_path)) {
+                LOG(ERROR) << "Failed to delete old cache directory: "
+                           << old_cache_path.value();
+              }
               return;
             }
 
@@ -201,25 +252,201 @@ void DeleteOldCacheDirectoryAsync() {
             for (const auto& subpath : old_cache_subpaths) {
               base::FilePath old_cache_subpath = old_cache_path.Append(subpath);
               if (base::PathExists(old_cache_subpath)) {
-                base::DeletePathRecursively(old_cache_subpath);
+                if (!base::DeletePathRecursively(old_cache_subpath)) {
+                  LOG(ERROR) << "Failed to delete old cache subpath: "
+                             << old_cache_subpath.value();
+                }
               }
             }
           }));
 }
 
-Task DeleteOldCacheDirectoryTask() {
-  return base::BindOnce([](base::OnceClosure callback) {
-    DeleteOldCacheDirectoryAsync();
-    std::move(callback).Run();
-  });
+void SetMigrationStatusUrlParameter(scoped_refptr<MigrationState> state) {
+  g_migration_status_param = "migration_status=" + state->GetStatusString();
+}
+
+// Triggers the deletion of old cache directories, deletes the legacy storage
+// files, and writes the migration sentinel file.
+void CleanupLegacyFilesAsync(scoped_refptr<MigrationState> state) {
+  base::UmaHistogramEnumeration(kOutcomeHistogram, state->GetOutcome());
+  SetMigrationStatusUrlParameter(state);
+  DeleteOldCacheDirectoryAsync();
+  DeleteLegacyStorageFilesAsync();
+  WriteMigrationSentinelAsync(state);
+}
+
+// Creates a task that runs the legacy files cleanup and then immediately
+// advances the migration pipeline.
+Task CleanupLegacyFilesTask(scoped_refptr<MigrationState> state) {
+  return base::BindOnce(
+      [](scoped_refptr<MigrationState> state, base::OnceClosure callback) {
+        CleanupLegacyFilesAsync(state);
+        std::move(callback).Run();
+      },
+      state);
+}
+
+// Emits UMA metrics for the total duration of the migration process.
+Task RecordMigrationDurationTask(
+    std::unique_ptr<base::ElapsedTimer> elapsed_timer) {
+  return base::BindOnce(
+      [](std::unique_ptr<base::ElapsedTimer> elapsed_timer,
+         base::OnceClosure callback) {
+        base::TimeDelta elapsed = elapsed_timer->Elapsed();
+        base::UmaHistogramTimes(kDurationHistogram, elapsed);
+        LOG(INFO) << "Cookie and localStorage migration completed in "
+                  << elapsed.InMilliseconds() << " ms.";
+        std::move(callback).Run();
+      },
+      std::move(elapsed_timer));
+}
+
+// ============================================================================
+// Legacy Storage Reader
+// ============================================================================
+
+// Reads the legacy Starboard storage record from disk and parses it into a
+// cobalt::storage::Storage protobuf, alongside the final StorageReadResult.
+std::pair<StorageReadResult, std::unique_ptr<cobalt::storage::Storage>>
+ReadAndParseLegacyStorageRecord() {
+  // Legacy Storage records start with the header 'SAV1'.
+  constexpr char kRecordHeader[] = "SAV1";
+  constexpr size_t kRecordHeaderSize = 4;
+
+  StorageReadResult result = StorageReadResult::kSuccess;
+  std::unique_ptr<cobalt::storage::Storage> storage;
+
+  [&]() {
+    GURL initial_url(
+        switches::GetInitialURL(*base::CommandLine::ForCurrentProcess()));
+    if (!initial_url.is_valid()) {
+      result = StorageReadResult::kRecordInvalid;
+      return;
+    }
+
+    std::string partition_key = GetApplicationKey(initial_url);
+    auto record =
+        std::make_unique<starboard::StorageRecord>(partition_key.c_str());
+    if (!record->IsValid()) {
+      bool fallback =
+          partition_key == GetApplicationKey(GURL(::switches::kDefaultURL));
+      if (!fallback) {
+        result = StorageReadResult::kPartitionKeyNotDefault;
+        return;
+      }
+
+      record = std::make_unique<starboard::StorageRecord>();
+      if (!record->IsValid()) {
+        result = StorageReadResult::kRecordInvalid;
+        return;
+      }
+    }
+
+    if (record->GetSize() < kRecordHeaderSize) {
+      result = StorageReadResult::kSizeTooSmall;
+      return;
+    }
+
+    auto bytes = std::vector<uint8_t>(record->GetSize());
+    const int read_result =
+        record->Read(reinterpret_cast<char*>(bytes.data()), bytes.size());
+
+    if (read_result != bytes.size()) {
+      result = StorageReadResult::kReadMismatch;
+      return;
+    }
+
+    std::string version(reinterpret_cast<const char*>(bytes.data()),
+                        kRecordHeaderSize);
+    if (version != kRecordHeader) {
+      result = StorageReadResult::kHeaderMismatch;
+      return;
+    }
+
+    storage = std::make_unique<cobalt::storage::Storage>();
+    if (!storage->ParseFromArray(
+            reinterpret_cast<const char*>(bytes.data() + kRecordHeaderSize),
+            bytes.size() - kRecordHeaderSize)) {
+      result = StorageReadResult::kParseError;
+      storage.reset();
+      return;
+    }
+  }();
+
+  if (storage) {
+    LOG(INFO) << "Successfully parsed storage. Cookies: "
+              << storage->cookies_size()
+              << ", LocalStorage groups: " << storage->local_storages_size();
+  } else {
+    LOG(INFO) << "Legacy storage was not found or failed to parse.";
+  }
+  return {result, std::move(storage)};
+}
+
+// ============================================================================
+// Cookie Migration Utilities
+// ============================================================================
+
+// Retrieves the CookieManager for the given StoragePartition.
+network::mojom::CookieManager* GetCookieManager(
+    content::StoragePartition* partition) {
+  return partition->GetCookieManagerForBrowserProcess();
+}
+
+// ============================================================================
+// LocalStorage Migration Utilities
+// ============================================================================
+
+// Binds a mojo remote to the StorageArea for the given origin, allowing direct
+// write access to the DOM Storage subsystem.
+void GetLocalStorageArea(content::StoragePartition* partition,
+                         const url::Origin& origin,
+                         mojo::Remote<blink::mojom::StorageArea>& out_area) {
+  auto storage_key = blink::StorageKey::CreateFirstParty(origin);
+  partition->GetLocalStorageControl()->BindStorageArea(
+      storage_key, out_area.BindNewPipeAndPassReceiver());
+}
+
+// Formats a string to match the internal binary layout expected by the
+// Chromium LocalStorage database backend (LevelDB).
+std::vector<uint8_t> FormatStringForLocalStorage(const std::string& input) {
+  std::u16string utf16_str = base::UTF8ToUTF16(input);
+  bool is_latin1 = true;
+  for (char16_t c : utf16_str) {
+    if (c > 0xFF) {
+      is_latin1 = false;
+      break;
+    }
+  }
+
+  std::vector<uint8_t> result;
+  if (is_latin1) {
+    result.reserve(utf16_str.size() + 1);
+    result.push_back(1);  // StorageFormat::Latin1
+    for (char16_t c : utf16_str) {
+      result.push_back(static_cast<uint8_t>(c));
+    }
+  } else {
+    result.reserve(utf16_str.size() * sizeof(char16_t) + 1);
+    result.push_back(0);  // StorageFormat::UTF16
+    const uint8_t* chars = reinterpret_cast<const uint8_t*>(utf16_str.data());
+    result.insert(result.end(), chars,
+                  chars + utf16_str.size() * sizeof(char16_t));
+  }
+  return result;
 }
 
 }  // namespace
 
 // static
-std::atomic_flag MigrationManager::migration_attempted_ = ATOMIC_FLAG_INIT;
+std::string MigrationManager::GetMigrationStatusUrlParameter() {
+  return g_migration_status_param;
+}
 
 // static
+// Groups multiple sequential asynchronous tasks into a single chain of
+// callbacks. When the returned Task is invoked, it will execute the first task,
+// which in turn will trigger the second, and so on, until all tasks are run.
 Task MigrationManager::GroupTasks(std::vector<Task> tasks) {
   return base::BindOnce(
       [](std::vector<Task> tasks, base::OnceClosure callback) {
@@ -233,111 +460,91 @@ Task MigrationManager::GroupTasks(std::vector<Task> tasks) {
       std::move(tasks));
 }
 
-// TODO(b/399165612): Add metrics.
-// TODO(b/399165796): Disable and delete migration code when possible.
-// TODO(b/399166308): Add unit and/or integration tests for migration.
-void MigrationManager::DoMigrationTasksOnce(
-    content::WebContents* web_contents) {
-  if (migration_attempted_.test_and_set()) {
+// Executes the entire one-time migration pipeline.
+// If the migration has already completed on a previous launch (determined by
+// the presence of a sentinel file), this function instantly invokes the
+// done_callback to resume app startup immediately.
+void MigrationManager::RunMigration(content::StoragePartition* partition,
+                                    base::OnceClosure done_callback) {
+  LOG(INFO) << "Starting Pre-MainLoop Migration.";
+
+  base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+  if (command_line->HasSwitch(::switches::kDisableStorageMigration)) {
+    LOG(INFO) << "Storage migration disabled via switch.";
+    std::move(done_callback).Run();
     return;
   }
 
-  auto storage = ReadStorage();
-  if (!storage ||
-      (storage->cookies_size() == 0 && storage->local_storages_size() == 0)) {
+  auto elapsed_timer = std::make_unique<base::ElapsedTimer>();
+
+  // Fast Path: If the sentinel file exists, migration is already done.
+  base::ElapsedTimer sentinel_timer;
+  base::FilePath sentinel_path = GetMigrationSentinelPath();
+  bool sentinel_exists =
+      !sentinel_path.empty() && base::PathExists(sentinel_path);
+  if (sentinel_exists) {
+    LOG(INFO) << "Migration sentinel file found. Skipping migration.";
+    LOG(INFO) << "RunMigration fast path took "
+              << elapsed_timer->Elapsed().InMilliseconds() << " ms.";
+    base::UmaHistogramTimes(kFastPathDurationHistogram,
+                            elapsed_timer->Elapsed());
+    base::UmaHistogramEnumeration(kOutcomeHistogram,
+                                  MigrationOutcome::kFastPath);
+    std::move(done_callback).Run();
     return;
   }
 
-  GURL url = web_contents->GetLastCommittedURL();
-  web_contents->Stop();
-
-  auto* render_frame_host = web_contents->GetPrimaryMainFrame();
-  CHECK(render_frame_host);
-  auto weak_document_ptr = render_frame_host->GetWeakDocumentPtr();
-
-  std::vector<Task> tasks;
-  tasks.push_back(CookieTask(weak_document_ptr, ToCanonicalCookies(*storage)));
-  const url::Origin& origin = render_frame_host->GetLastCommittedOrigin();
-  tasks.push_back(LocalStorageTask(weak_document_ptr,
-                                   ToLocalStorageItems(origin, *storage)));
-#if !defined(COBALT_IS_RELEASE_BUILD)
-  tasks.push_back(LogElapsedTimeTask());
-#endif  // !defined(COBALT_IS_RELEASE_BUILD)
-  tasks.push_back(DeleteOldCacheDirectoryTask());
-  tasks.push_back(ReloadTask(weak_document_ptr, url));
-  std::move(GroupTasks(std::move(tasks))).Run(base::DoNothing());
-}
-
-// static
-Task MigrationManager::CookieTask(
-    content::WeakDocumentPtr weak_document_ptr,
-    std::vector<std::unique_ptr<net::CanonicalCookie>> cookies) {
-  std::vector<Task> tasks;
-  tasks.push_back(base::BindOnce(
-      [](content::WeakDocumentPtr weak_document_ptr,
-         base::OnceClosure callback) {
-        CookieManager(weak_document_ptr)
-            ->DeleteCookies(network::mojom::CookieDeletionFilter::New(),
-                            base::IgnoreArgs<uint32_t>(std::move(callback)));
-      },
-      weak_document_ptr));
-  for (auto& cookie : cookies) {
-    tasks.push_back(base::BindOnce(
-        [](content::WeakDocumentPtr weak_document_ptr,
-           std::unique_ptr<net::CanonicalCookie> cookie,
-           base::OnceClosure callback) {
-          GURL source_url("https://" + cookie->Domain() + cookie->Path());
-          CookieManager(weak_document_ptr)
-              ->SetCanonicalCookie(*cookie, source_url,
-                                   net::CookieOptions::MakeAllInclusive(),
-                                   base::IgnoreArgs<net::CookieAccessResult>(
-                                       std::move(callback)));
-        },
-        weak_document_ptr, std::move(cookie)));
+  // Attempt to read the legacy storage protobuf from disk.
+  GURL initial_url(
+      switches::GetInitialURL(*base::CommandLine::ForCurrentProcess()));
+  if (!initial_url.is_valid()) {
+    LOG(INFO) << "RunMigration invalid URL early exit.";
+    std::move(done_callback).Run();
+    return;
   }
-  tasks.push_back(base::BindOnce(
-      [](content::WeakDocumentPtr weak_document_ptr,
-         base::OnceClosure callback) {
-        CookieManager(weak_document_ptr)->FlushCookieStore(std::move(callback));
-      },
-      weak_document_ptr));
-  return GroupTasks(std::move(tasks));
-}
+  url::Origin origin = url::Origin::Create(initial_url);
 
-// static
-Task MigrationManager::LocalStorageTask(
-    content::WeakDocumentPtr weak_document_ptr,
-    std::vector<std::unique_ptr<std::pair<std::string, std::string>>> pairs) {
-  std::vector<Task> tasks;
-  tasks.push_back(base::BindOnce(
-      [](content::WeakDocumentPtr weak_document_ptr,
-         base::OnceClosure callback) {
-        RenderFrameHost(weak_document_ptr)
-            ->ExecuteJavaScriptMethod(
-                base::ASCIIToUTF16(std::string("localStorage")),
-                base::ASCIIToUTF16(std::string("clear")), base::Value::List(),
-                base::IgnoreArgs<base::Value>(std::move(callback)));
-      },
-      weak_document_ptr));
+  auto parsed_storage = ReadAndParseLegacyStorageRecord();
+  StorageReadResult read_result = parsed_storage.first;
+  auto storage = std::move(parsed_storage.second);
 
-  for (auto& pair : pairs) {
-    tasks.push_back(base::BindOnce(
-        [](content::WeakDocumentPtr weak_document_ptr,
-           std::unique_ptr<std::pair<std::string, std::string>> pair,
-           base::OnceClosure callback) {
-          RenderFrameHost(weak_document_ptr)
-              ->ExecuteJavaScriptMethod(
-                  base::ASCIIToUTF16(std::string("localStorage")),
-                  base::ASCIIToUTF16(std::string("setItem")),
-                  base::Value::List().Append(pair->first).Append(pair->second),
-                  base::IgnoreArgs<base::Value>(std::move(callback)));
-        },
-        weak_document_ptr, std::move(pair)));
+  base::UmaHistogramEnumeration(kReadResultHistogram, read_result);
+
+  auto state = base::MakeRefCounted<MigrationState>();
+  state->read_result = read_result;
+  state->has_data_to_migrate = storage && (storage->cookies_size() > 0 ||
+                                           storage->local_storages_size() > 0);
+
+  if (!state->has_data_to_migrate) {
+    LOG(INFO) << "Nothing to migrate.";
+    CleanupLegacyFilesAsync(state);
+    std::move(done_callback).Run();
+    return;
   }
-  return GroupTasks(std::move(tasks));
+
+  base::UmaHistogramCounts1000(kCookiesCountHistogram, storage->cookies_size());
+  base::UmaHistogramCounts1000(kLocalStorageCountHistogram,
+                               storage->local_storages_size());
+
+  LOG(INFO) << "RunMigration synchronous setup took "
+            << elapsed_timer->Elapsed().InMilliseconds() << " ms.";
+
+  // Build the pipeline of tasks to execute asynchronously.
+  std::vector<Task> tasks;
+  tasks.push_back(CookieTask(partition, ToCanonicalCookies(*storage), state));
+  tasks.push_back(LocalStorageTask(
+      partition, origin, ToLocalStorageItems(origin, *storage), state));
+  tasks.push_back(RecordMigrationDurationTask(std::move(elapsed_timer)));
+  tasks.push_back(CleanupLegacyFilesTask(state));
+
+  // Execute the chained tasks. The done_callback will be invoked when all
+  // steps, including async background work, have completed.
+  std::move(GroupTasks(std::move(tasks))).Run(std::move(done_callback));
 }
 
 // static
+// Converts the legacy protobuf format for cookies into Chromium's
+// CanonicalCookie format.
 std::vector<std::unique_ptr<net::CanonicalCookie>>
 MigrationManager::ToCanonicalCookies(const cobalt::storage::Storage& storage) {
   std::vector<std::unique_ptr<net::CanonicalCookie>> cookies;
@@ -347,16 +554,97 @@ MigrationManager::ToCanonicalCookies(const cobalt::storage::Storage& storage) {
         base::Time::FromInternalValue(c.creation_time_us()),
         base::Time::FromInternalValue(c.expiration_time_us()),
         base::Time::FromInternalValue(c.last_access_time_us()),
-        base::Time::FromInternalValue(c.creation_time_us()), c.secure(),
+        base::Time::FromInternalValue(c.creation_time_us()), true,
         c.http_only(), net::CookieSameSite::NO_RESTRICTION,
-        net::COOKIE_PRIORITY_DEFAULT, false,
-        absl::optional<net::CookiePartitionKey>(),
+        net::COOKIE_PRIORITY_DEFAULT, false, absl::nullopt,
         net::CookieSourceScheme::kUnset, url::PORT_UNSPECIFIED));
   }
   return cookies;
 }
 
 // static
+// Returns an asynchronous task that injects all legacy cookies into the new
+// Chromium Network Service.
+Task MigrationManager::CookieTask(
+    content::StoragePartition* partition,
+    std::vector<std::unique_ptr<net::CanonicalCookie>> cookies,
+    scoped_refptr<MigrationState> state) {
+  return base::BindOnce(
+      [](content::StoragePartition* partition,
+         std::vector<std::unique_ptr<net::CanonicalCookie>> cookies,
+         scoped_refptr<MigrationState> state, base::OnceClosure callback) {
+        if (cookies.empty()) {
+          std::move(callback).Run();
+          return;
+        }
+
+        auto* cookie_manager = GetCookieManager(partition);
+        auto shared_state = base::MakeRefCounted<SharedClosureState>();
+        shared_state->cb = std::move(callback);
+
+        // A barrier closure that executes the 'shared_state' callback only
+        // after all individual cookie Puts have completed.
+        base::RepeatingClosure barrier = base::BarrierClosure(
+            cookies.size(), base::BindOnce(
+                                [](scoped_refptr<SharedClosureState> state) {
+                                  if (state->cb) {
+                                    LOG(INFO) << "Cookie injection complete.";
+                                    state->Run();
+                                  }
+                                },
+                                shared_state));
+
+        for (auto& cookie : cookies) {
+          std::string name = cookie->Name();
+          GURL source_url("https://" + cookie->Domain() + cookie->Path());
+          // Mojo IPC call to the Network Service.
+          cookie_manager->SetCanonicalCookie(
+              *cookie, source_url, net::CookieOptions::MakeAllInclusive(),
+              base::BindOnce(
+                  [](base::RepeatingClosure barrier, std::string cookie_name,
+                     scoped_refptr<MigrationState> state,
+                     net::CookieAccessResult result) {
+                    if (!result.status.IsInclude()) {
+                      LOG(ERROR)
+                          << "SetCanonicalCookie failed for: " << cookie_name
+                          << " with status: " << result.status.GetDebugString();
+                    }
+                    InjectionResult inj_result = result.status.IsInclude()
+                                                     ? InjectionResult::kSuccess
+                                                     : InjectionResult::kError;
+                    base::UmaHistogramEnumeration(
+                        kCookieInjectionResultHistogram, inj_result);
+                    state->UpdateCookieResult(inj_result);
+                    barrier.Run();
+                  },
+                  barrier, name, state));
+        }
+
+        // Hard timeout fallback: if the Network Service IPC drops the callback
+        // or hangs, this task guarantees the app startup resumes after 2
+        // seconds.
+        base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
+            FROM_HERE,
+            base::BindOnce(
+                [](scoped_refptr<SharedClosureState> shared_state,
+                   scoped_refptr<MigrationState> migration_state) {
+                  if (shared_state->cb) {
+                    LOG(ERROR) << "Cookie injection timed out after 2 "
+                                  "seconds. Proceeding anyway.";
+                    migration_state->UpdateCookieResult(
+                        InjectionResult::kTimeout);
+                    shared_state->Run();
+                  }
+                },
+                shared_state, state),
+            base::Seconds(2));
+      },
+      partition, std::move(cookies), state);
+}
+
+// static
+// Filters the legacy protobuf to retrieve only the LocalStorage key-value pairs
+// belonging to the primary URL origin.
 std::vector<std::unique_ptr<std::pair<std::string, std::string>>>
 MigrationManager::ToLocalStorageItems(const url::Origin& page_origin,
                                       const cobalt::storage::Storage& storage) {
@@ -375,6 +663,126 @@ MigrationManager::ToLocalStorageItems(const url::Origin& page_origin,
     }
   }
   return entries;
+}
+
+// static
+// Returns an asynchronous task that injects all legacy LocalStorage key-value
+// pairs into the Chromium Storage Service. This is executed as a multi-step
+// sequence:
+// 1. Send all `Put` commands over Mojo.
+// 2. Call `Flush()` to ensure LevelDB writes the Puts to the physical disk.
+// 3. Call `PurgeMemory()` so that the Renderer fetches fresh data instead of
+// using cached state.
+Task MigrationManager::LocalStorageTask(
+    content::StoragePartition* partition,
+    const url::Origin& origin,
+    std::vector<std::unique_ptr<std::pair<std::string, std::string>>> pairs,
+    scoped_refptr<MigrationState> state) {
+  return base::BindOnce(
+      [](content::StoragePartition* partition, url::Origin origin,
+         std::vector<std::unique_ptr<std::pair<std::string, std::string>>>
+             pairs,
+         scoped_refptr<MigrationState> state, base::OnceClosure callback) {
+        if (pairs.empty()) {
+          std::move(callback).Run();
+          return;
+        }
+
+        auto area = std::make_unique<mojo::Remote<blink::mojom::StorageArea>>();
+        GetLocalStorageArea(partition, origin, *area);
+        auto* raw_remote_ptr = area.get();
+
+        // STEP 3: Purge memory handles.
+        // Force the Storage Service to drop its handle for this origin so that
+        // the newly spawned Renderer process sees the updated disk state.
+        base::OnceClosure purge_memory_step = base::BindOnce(
+            [](std::unique_ptr<mojo::Remote<blink::mojom::StorageArea>> area,
+               content::StoragePartition* partition, base::OnceClosure cb) {
+              LOG(INFO) << "Purging Storage Service handles to force "
+                           "Renderer synchronization.";
+              partition->GetLocalStorageControl()->PurgeMemory();
+              std::move(cb).Run();
+            },
+            std::move(area), base::Unretained(partition), std::move(callback));
+
+        // STEP 2: Flush step.
+        // Tells the Storage Service to commit the LevelDB transactions to disk.
+        base::OnceClosure flush_step = base::BindOnce(
+            [](content::StoragePartition* partition,
+               scoped_refptr<MigrationState> state,
+               base::OnceClosure next_step) {
+              LOG(INFO) << "LocalStorage Puts complete. Flushing...";
+
+              auto shared_state = base::MakeRefCounted<SharedClosureState>();
+              shared_state->cb = std::move(next_step);
+
+              partition->GetLocalStorageControl()->Flush(base::BindOnce(
+                  [](scoped_refptr<SharedClosureState> state) {
+                    if (state->cb) {
+                      LOG(INFO) << "LocalStorage Flush complete callback "
+                                   "executed successfully.";
+                      state->Run();
+                    }
+                  },
+                  shared_state));
+
+              // Hard timeout fallback: if the disk IO hangs or the Storage
+              // Service crashes during flush, resume app startup after 2
+              // seconds.
+              base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
+                  FROM_HERE,
+                  base::BindOnce(
+                      [](scoped_refptr<SharedClosureState> shared_state,
+                         scoped_refptr<MigrationState> migration_state) {
+                        if (shared_state->cb) {
+                          LOG(ERROR) << "LocalStorage Flush timed out "
+                                        "after 2 seconds. Proceeding anyway.";
+                          migration_state->UpdateLocalStorageResult(
+                              InjectionResult::kTimeout);
+                          shared_state->Run();
+                        }
+                      },
+                      shared_state, state),
+                  base::Seconds(2));
+            },
+            base::Unretained(partition), state, std::move(purge_memory_step));
+
+        // STEP 1: Put keys step.
+        // Iterates through all k/v pairs and sends Mojo Put commands.
+        // The `flush_step` runs only when the barrier closes (all Puts have
+        // responded).
+        base::RepeatingClosure barrier =
+            base::BarrierClosure(pairs.size(), std::move(flush_step));
+
+        for (const auto& pair : pairs) {
+          std::string key_str = pair->first;
+          std::vector<uint8_t> key = FormatStringForLocalStorage(pair->first);
+          std::vector<uint8_t> value =
+              FormatStringForLocalStorage(pair->second);
+
+          (*raw_remote_ptr)
+              ->Put(key, value, absl::nullopt, "migration",
+                    base::BindOnce(
+                        [](base::RepeatingClosure barrier, std::string key_str,
+                           scoped_refptr<MigrationState> state, bool success) {
+                          if (success) {
+                            LOG(INFO) << "Put SUCCESS for key: " << key_str;
+                          } else {
+                            LOG(ERROR) << "Put FAILED for key: " << key_str;
+                          }
+                          InjectionResult inj_result =
+                              success ? InjectionResult::kSuccess
+                                      : InjectionResult::kError;
+                          base::UmaHistogramEnumeration(
+                              kLocalStorageInjectionResultHistogram,
+                              inj_result);
+                          state->UpdateLocalStorageResult(inj_result);
+                          barrier.Run();
+                        },
+                        barrier, key_str, state));
+        }
+      },
+      partition, origin, std::move(pairs), state);
 }
 
 }  // namespace migrate_storage_record

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -342,7 +342,7 @@ ReadAndParseLegacyStorageRecord() {
       }
     }
 
-    if (static_cast<size_t>(record->GetSize()) < kRecordHeaderSize) {
+    if (record->GetSize() < static_cast<int64_t>(kRecordHeaderSize)) {
       result = StorageReadResult::kSizeTooSmall;
       return;
     }
@@ -554,7 +554,7 @@ MigrationManager::ToCanonicalCookies(const cobalt::storage::Storage& storage) {
         base::Time::FromInternalValue(c.creation_time_us()),
         base::Time::FromInternalValue(c.expiration_time_us()),
         base::Time::FromInternalValue(c.last_access_time_us()),
-        base::Time::FromInternalValue(c.creation_time_us()), true,
+        base::Time::FromInternalValue(c.creation_time_us()), c.secure(),
         c.http_only(), net::CookieSameSite::NO_RESTRICTION,
         net::COOKIE_PRIORITY_DEFAULT, false, absl::nullopt,
         net::CookieSourceScheme::kUnset, url::PORT_UNSPECIFIED));

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.h
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.h
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "base/functional/bind.h"
+#include "base/memory/ref_counted.h"
 #include "cobalt/shell/browser/migrate_storage_record/storage.pb.h"
 #include "content/public/browser/weak_document_ptr.h"
 #include "content/public/browser/web_contents.h"
@@ -30,12 +31,125 @@
 namespace cobalt {
 namespace migrate_storage_record {
 
+// Tracks the outcome of attempting to read the legacy Starboard storage record.
+enum class StorageReadResult {
+  kSuccess = 0,
+  kPartitionKeyNotDefault = 1,
+  kRecordInvalid = 2,
+  kSizeTooSmall = 3,
+  kDeleteFailed = 4,
+  kReadMismatch = 5,
+  kHeaderMismatch = 6,
+  kParseError = 7,
+  kMaxValue = kParseError,
+};
+
+// Tracks the outcome of individual data injection operations into the new
+// Chromium-based storage partitions.
+enum class InjectionResult {
+  kSuccess = 0,
+  kError = 1,
+  kTimeout = 2,
+  kMaxValue = kTimeout,
+};
+
+// Tracks the overall outcome of the migration process.
+enum class MigrationOutcome {
+  kFastPath = 0,
+  kSkipped = 1,
+  kSuccess = 2,
+  kFailed = 3,
+  kTimeout = 4,
+  kMaxValue = kTimeout,
+};
+
+// These values are persisted to logs. Entries should not be renumbered and
+// numeric values should never be reused.
+enum class SentinelWriteResult {
+  kSuccess = 0,
+  kEmptyPath = 1,
+  kWriteFailed = 2,
+  kMaxValue = kWriteFailed,
+};
+
 // Used to sequence tasks.
 using Task = base::OnceCallback<void(base::OnceClosure)>;
 
+struct MigrationState : public base::RefCountedThreadSafe<MigrationState> {
+  StorageReadResult read_result = StorageReadResult::kSuccess;
+  bool has_data_to_migrate = false;
+  std::atomic<InjectionResult> cookie_result{InjectionResult::kSuccess};
+  std::atomic<InjectionResult> local_storage_result{InjectionResult::kSuccess};
+
+  void UpdateCookieResult(InjectionResult res) {
+    InjectionResult current = cookie_result.load(std::memory_order_relaxed);
+    // Lock-free compare-and-swap loop to ensure the atomic state always
+    // reflects the most severe result (kSuccess < kError < kTimeout) when
+    // evaluated concurrently.
+    while (current < res) {
+      if (cookie_result.compare_exchange_weak(current, res,
+                                              std::memory_order_relaxed)) {
+        break;
+      }
+    }
+  }
+
+  void UpdateLocalStorageResult(InjectionResult res) {
+    InjectionResult current =
+        local_storage_result.load(std::memory_order_relaxed);
+    // Lock-free compare-and-swap loop to ensure the atomic state always
+    // reflects the most severe result (kSuccess < kError < kTimeout) when
+    // evaluated concurrently.
+    while (current < res) {
+      if (local_storage_result.compare_exchange_weak(
+              current, res, std::memory_order_relaxed)) {
+        break;
+      }
+    }
+  }
+
+  MigrationOutcome GetOutcome() const {
+    if (!has_data_to_migrate) {
+      if (read_result == StorageReadResult::kSuccess ||
+          read_result == StorageReadResult::kRecordInvalid) {
+        return MigrationOutcome::kSkipped;
+      }
+      return MigrationOutcome::kFailed;
+    }
+    InjectionResult c_res = cookie_result.load(std::memory_order_relaxed);
+    InjectionResult ls_res =
+        local_storage_result.load(std::memory_order_relaxed);
+    if (c_res == InjectionResult::kTimeout ||
+        ls_res == InjectionResult::kTimeout) {
+      return MigrationOutcome::kTimeout;
+    }
+    if (c_res == InjectionResult::kError || ls_res == InjectionResult::kError) {
+      return MigrationOutcome::kFailed;
+    }
+    return MigrationOutcome::kSuccess;
+  }
+
+  std::string GetStatusString() const {
+    return base::StringPrintf(
+        "%d-%d-%d", static_cast<int>(read_result),
+        static_cast<int>(cookie_result.load(std::memory_order_relaxed)),
+        static_cast<int>(local_storage_result.load(std::memory_order_relaxed)));
+  }
+
+ private:
+  friend class base::RefCountedThreadSafe<MigrationState>;
+  ~MigrationState() = default;
+};
+
 class MigrationManager {
  public:
-  static void DoMigrationTasksOnce(content::WebContents* web_contents);
+  static void RunMigration(content::StoragePartition* partition,
+                           base::OnceClosure done_callback);
+
+  // Returns the url parameter to attach to the launch URL, formatted as
+  // "migration_status=read|cookie|local_storage".
+  // Returns an empty string if the migration fast path was taken.
+  static std::string GetMigrationStatusUrlParameter();
 
  private:
   friend class MigrationManagerTest;
@@ -43,17 +157,19 @@ class MigrationManager {
   // Returns a task. When invoked, the grouped |tasks| are run sequentially.
   static Task GroupTasks(std::vector<Task> tasks);
   static Task CookieTask(
-      content::WeakDocumentPtr weak_document_ptr,
-      std::vector<std::unique_ptr<net::CanonicalCookie>> cookies);
+      content::StoragePartition* partition,
+      std::vector<std::unique_ptr<net::CanonicalCookie>> cookies,
+      scoped_refptr<MigrationState> state);
   static Task LocalStorageTask(
-      content::WeakDocumentPtr weak_document_ptr,
-      std::vector<std::unique_ptr<std::pair<std::string, std::string>>> pairs);
+      content::StoragePartition* partition,
+      const url::Origin& origin,
+      std::vector<std::unique_ptr<std::pair<std::string, std::string>>> pairs,
+      scoped_refptr<MigrationState> state);
   static std::vector<std::unique_ptr<std::pair<std::string, std::string>>>
   ToLocalStorageItems(const url::Origin& page_origin,
                       const cobalt::storage::Storage& storage);
   static std::vector<std::unique_ptr<net::CanonicalCookie>> ToCanonicalCookies(
       const cobalt::storage::Storage& storage);
-  static std::atomic_flag migration_attempted_;
 };
 
 }  // namespace migrate_storage_record

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager_unittest.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager_unittest.cc
@@ -89,11 +89,11 @@ TEST_F(MigrationManagerTest, VerifyGroupTasksRunsCallbacksSequentially) {
   constexpr uint32_t kTaskCount = 100;
   std::vector<Task> tasks;
   std::vector<int> collected_values;
-  for (int i = 0; i < kTaskCount; i++) {
+  for (uint32_t i = 0; i < kTaskCount; i++) {
     tasks.push_back(base::BindOnce(
-        [](std::vector<int>& collected_values, int i,
+        [](std::vector<int>& collected_values, uint32_t i,
            base::OnceClosure callback) {
-          collected_values.push_back(i);
+          collected_values.push_back(static_cast<int>(i));
           std::move(callback).Run();
         },
         std::ref(collected_values), i));
@@ -102,7 +102,7 @@ TEST_F(MigrationManagerTest, VerifyGroupTasksRunsCallbacksSequentially) {
   Task grouped_task = GroupTasks(std::move(tasks));
   std::move(grouped_task).Run(base::DoNothing());
   base::RunLoop().RunUntilIdle();
-  std::vector<int> expected_values(kTaskCount);
+  std::vector<int> expected_values(static_cast<size_t>(kTaskCount));
   std::iota(expected_values.begin(), expected_values.end(), 0);
   EXPECT_THAT(collected_values, ::testing::ElementsAreArray(expected_values));
 }
@@ -135,8 +135,8 @@ TEST_F(MigrationManagerTest, ToCanonicalCookiesTest) {
   source_cookies.push_back(cookie2);
 
   auto cookies = ToCanonicalCookies(storage);
-  EXPECT_EQ(2, cookies.size());
-  for (size_t i = 0; i < 2; i++) {
+  EXPECT_EQ(2u, cookies.size());
+  for (size_t i = 0; i < cookies.size(); i++) {
     EXPECT_EQ(source_cookies[i]->name(), cookies[i]->Name());
     EXPECT_EQ(source_cookies[i]->value(), cookies[i]->Value());
     EXPECT_EQ(source_cookies[i]->domain(), cookies[i]->Domain());
@@ -207,7 +207,7 @@ TEST_F(MigrationManagerTest, ToLocalStorageItemsTest) {
 
   auto actual1 = ToLocalStorageItems(
       url::Origin::Create(GURL("https://example1.com")), storage);
-  EXPECT_EQ(4, actual1.size());
+  EXPECT_EQ(4u, actual1.size());
   EXPECT_EQ("local_storage1_entry1_key", actual1[0]->first);
   EXPECT_EQ("local_storage1_entry1_value", actual1[0]->second);
   EXPECT_EQ("local_storage1_entry2_key", actual1[1]->first);
@@ -219,7 +219,7 @@ TEST_F(MigrationManagerTest, ToLocalStorageItemsTest) {
 
   auto actual2 = ToLocalStorageItems(
       url::Origin::Create(GURL("https://example2.com")), storage);
-  EXPECT_EQ(2, actual2.size());
+  EXPECT_EQ(2u, actual2.size());
   EXPECT_EQ("local_storage2_entry1_key", actual2[0]->first);
   EXPECT_EQ("local_storage2_entry1_value", actual2[0]->second);
   EXPECT_EQ("local_storage2_entry2_key", actual2[1]->first);

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager_unittest.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager_unittest.cc
@@ -51,12 +51,45 @@ class MigrationManagerTest : public testing::Test {
   base::test::SingleThreadTaskEnvironment task_environment_;
 };
 
+TEST_F(MigrationManagerTest, MigrationStateGetOutcomeTest) {
+  // Test no data to migrate.
+  auto state = base::MakeRefCounted<MigrationState>();
+  state->has_data_to_migrate = false;
+  state->read_result = StorageReadResult::kSuccess;
+  EXPECT_EQ(MigrationOutcome::kSkipped, state->GetOutcome());
+
+  state->read_result = StorageReadResult::kRecordInvalid;
+  EXPECT_EQ(MigrationOutcome::kSkipped, state->GetOutcome());
+
+  state->read_result = StorageReadResult::kParseError;
+  EXPECT_EQ(MigrationOutcome::kFailed, state->GetOutcome());
+
+  // Test data to migrate.
+  state->has_data_to_migrate = true;
+
+  // Initial success state.
+  EXPECT_EQ(MigrationOutcome::kSuccess, state->GetOutcome());
+
+  // Error taking precedence over Success.
+  state->UpdateCookieResult(InjectionResult::kError);
+  EXPECT_EQ(MigrationOutcome::kFailed, state->GetOutcome());
+
+  // Timeout taking precedence over Error.
+  state->UpdateLocalStorageResult(InjectionResult::kTimeout);
+  EXPECT_EQ(MigrationOutcome::kTimeout, state->GetOutcome());
+
+  // Verify that an attempt to log a Success doesn't downgrade a Timeout.
+  state->UpdateCookieResult(InjectionResult::kSuccess);
+  state->UpdateLocalStorageResult(InjectionResult::kSuccess);
+  EXPECT_EQ(MigrationOutcome::kTimeout, state->GetOutcome());
+}
+
 // TODO(b/399166308): Add more test cases for specific migration tasks.
 TEST_F(MigrationManagerTest, VerifyGroupTasksRunsCallbacksSequentially) {
   constexpr uint32_t kTaskCount = 100;
   std::vector<Task> tasks;
   std::vector<int> collected_values;
-  for (size_t i = 0; i < kTaskCount; i++) {
+  for (int i = 0; i < kTaskCount; i++) {
     tasks.push_back(base::BindOnce(
         [](std::vector<int>& collected_values, int i,
            base::OnceClosure callback) {
@@ -102,7 +135,7 @@ TEST_F(MigrationManagerTest, ToCanonicalCookiesTest) {
   source_cookies.push_back(cookie2);
 
   auto cookies = ToCanonicalCookies(storage);
-  EXPECT_EQ(2u, cookies.size());
+  EXPECT_EQ(2, cookies.size());
   for (size_t i = 0; i < 2; i++) {
     EXPECT_EQ(source_cookies[i]->name(), cookies[i]->Name());
     EXPECT_EQ(source_cookies[i]->value(), cookies[i]->Value());
@@ -174,7 +207,7 @@ TEST_F(MigrationManagerTest, ToLocalStorageItemsTest) {
 
   auto actual1 = ToLocalStorageItems(
       url::Origin::Create(GURL("https://example1.com")), storage);
-  EXPECT_EQ(4u, actual1.size());
+  EXPECT_EQ(4, actual1.size());
   EXPECT_EQ("local_storage1_entry1_key", actual1[0]->first);
   EXPECT_EQ("local_storage1_entry1_value", actual1[0]->second);
   EXPECT_EQ("local_storage1_entry2_key", actual1[1]->first);
@@ -186,7 +219,7 @@ TEST_F(MigrationManagerTest, ToLocalStorageItemsTest) {
 
   auto actual2 = ToLocalStorageItems(
       url::Origin::Create(GURL("https://example2.com")), storage);
-  EXPECT_EQ(2u, actual2.size());
+  EXPECT_EQ(2, actual2.size());
   EXPECT_EQ("local_storage2_entry1_key", actual2[0]->first);
   EXPECT_EQ("local_storage2_entry1_value", actual2[0]->second);
   EXPECT_EQ("local_storage2_entry2_key", actual2[1]->first);

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -508,8 +508,6 @@ void Shell::RenderFrameCreated(RenderFrameHost* frame_host) {
 }
 
 void Shell::PrimaryMainDocumentElementAvailable() {
-  cobalt::migrate_storage_record::MigrationManager::DoMigrationTasksOnce(
-      web_contents());
 #if BUILDFLAG(USE_EVERGREEN)
   cobalt::updater::UpdaterModule* updater_module =
       cobalt::updater::UpdaterModule::GetInstance();

--- a/cobalt/shell/browser/shell_browser_main_parts.cc
+++ b/cobalt/shell/browser/shell_browser_main_parts.cc
@@ -76,8 +76,7 @@
 
 namespace content {
 
-namespace {
-GURL GetStartupURL() {
+GURL ShellBrowserMainParts::GetStartupURL() const {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
   if (command_line->HasSwitch(switches::kBrowserTest)) {
     return GURL();
@@ -108,6 +107,8 @@ GURL GetStartupURL() {
   return initial_url;
 #endif
 }
+
+namespace {
 
 scoped_refptr<base::RefCountedMemory> PlatformResourceProvider(int key) {
   if (key == IDR_DIR_HEADER_HTML) {

--- a/cobalt/shell/browser/shell_browser_main_parts.cc
+++ b/cobalt/shell/browser/shell_browser_main_parts.cc
@@ -18,15 +18,8 @@
 
 #include "base/base_switches.h"
 #include "base/command_line.h"
-#include "base/files/file_path.h"
 #include "base/files/file_util.h"
-#include "base/functional/bind.h"
-#include "base/functional/callback_helpers.h"
 #include "base/memory/ref_counted_memory.h"
-#include "base/strings/utf_string_conversions.h"
-#include "base/task/current_thread.h"
-#include "base/threading/thread.h"
-#include "base/threading/thread_restrictions.h"
 #include "build/build_config.h"
 #include "cc/base/switches.h"
 #include "cobalt/shell/android/shell_descriptors.h"
@@ -226,6 +219,12 @@ void ShellBrowserMainParts::PostDestroyThreads() {
   device::BluetoothAdapterFactory::Shutdown();
   bluez::DBusBluezManagerWrapperLinux::Shutdown();
 #endif
+}
+
+void ShellBrowserMainParts::PostOrRunIfStorageMigrationFinished(
+    base::OnceClosure task) {
+  // Default implementation doesn't defer tasks.
+  std::move(task).Run();
 }
 
 std::unique_ptr<ShellPlatformDelegate>

--- a/cobalt/shell/browser/shell_browser_main_parts.h
+++ b/cobalt/shell/browser/shell_browser_main_parts.h
@@ -57,6 +57,10 @@ class ShellBrowserMainParts : public BrowserMainParts {
   void PostMainMessageLoopRun() override;
   void PostDestroyThreads() override;
 
+  // Called to defer tasks (e.g. creating WebContents) until migration is
+  // finished.
+  virtual void PostOrRunIfStorageMigrationFinished(base::OnceClosure task);
+
   ShellBrowserContext* browser_context() { return browser_context_.get(); }
   ShellBrowserContext* off_the_record_browser_context() {
     return off_the_record_browser_context_.get();

--- a/cobalt/shell/browser/shell_browser_main_parts.h
+++ b/cobalt/shell/browser/shell_browser_main_parts.h
@@ -67,6 +67,9 @@ class ShellBrowserMainParts : public BrowserMainParts {
   }
 
  protected:
+  virtual GURL GetStartupURL() const;
+  const std::string& deep_link() const { return deep_link_; }
+
   virtual void InitializeBrowserContexts();
   virtual void InitializeMessageLoopContext();
   // Gets the ShellPlatformDelegate to be used. May be a subclass of

--- a/cobalt/shell/common/shell_switches.cc
+++ b/cobalt/shell/common/shell_switches.cc
@@ -33,6 +33,9 @@ const char kDisableSplashScreen[] = "disable-splash-screen";
 // Disables the check for the system font when specified.
 const char kDisableSystemFontCheck[] = "disable-system-font-check";
 
+// Disables storage migration.
+const char kDisableStorageMigration[] = "disable-storage-migration";
+
 // Size for the content_shell's host window (i.e. "800x600").
 const char kContentShellHostWindowSize[] = "content-shell-host-window-size";
 

--- a/cobalt/shell/common/shell_switches.h
+++ b/cobalt/shell/common/shell_switches.h
@@ -33,6 +33,7 @@ extern const char kContentShellDataPath[];
 extern const char kCrashDumpsDir[];
 extern const char kDisableSplashScreen[];
 extern const char kDisableSystemFontCheck[];
+extern const char kDisableStorageMigration[];
 extern const char kContentShellHostWindowSize[];
 extern const char kContentShellHideToolbar[];
 #if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_IOS)

--- a/tools/metrics/histograms/metadata/cobalt/enums.xml
+++ b/tools/metrics/histograms/metadata/cobalt/enums.xml
@@ -49,6 +49,45 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="2" label="Config is missing timestamp"/>
 </enum>
 
+<enum name="StorageInjectionResult">
+  <int value="0" label="Success"/>
+  <int value="1" label="Error"/>
+  <int value="2" label="Timeout"/>
+</enum>
+
+<enum name="MigrationOutcome">
+  <int value="0" label="FastPath"/>
+  <int value="1" label="Skipped"/>
+  <int value="2" label="Success"/>
+  <int value="3" label="Failed"/>
+  <int value="4" label="Timeout"/>
+</enum>
+
+<enum name="SentinelWriteResult">
+  <int value="0" label="Success"/>
+  <int value="1" label="Empty Path"/>
+  <int value="2" label="Write Failed"/>
+</enum>
+
+<enum name="StorageReadResult">
+  <int value="0" label="Success"/>
+  <int value="1" label="Partition key not default"/>
+  <int value="2" label="Record invalid"/>
+  <int value="3" label="Size too small"/>
+  <int value="4" label="Delete failed"/>
+  <int value="5" label="Read mismatch"/>
+  <int value="6" label="Header mismatch"/>
+  <int value="7" label="Parse error"/>
+</enum>
+
+<enum name="LocalStorageDatabaseResetReason">
+  <int value="0" label="Failure to open the database"/>
+  <int value="1" label="Schema version mismatch"/>
+  <int value="2" label="Database corruption or read errors"/>
+  <int value="3" label="Excessive commit errors"/>
+  <int value="4" label="Unknown"/>
+</enum>
+
 </enums>
 
 </histogram-configuration>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -94,6 +94,102 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.LocalStorage.DatabaseResetReason"
+    enum="LocalStorageDatabaseResetReason" expires_after="never">
+  <owner>charleykim@google.com</owner>
+  <summary>
+    Records the reason why the Local Storage database was reset.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.CookieInjectionResult"
+    enum="StorageInjectionResult" expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the outcome of attempting to inject a single cookie into the new
+    Chromium-based storage during migration from legacy Starboard storage.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.CookiesCount" units="cookies"
+    expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the total number of cookies found in the legacy Starboard storage
+    record during a migration attempt.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.FastPathDuration" units="ms"
+    expires_after="never">
+  <owner>colinliang@google.com</owner>
+  <summary>
+    Records the total time taken to check for the migration fast path during
+    startup.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.Outcome" enum="MigrationOutcome"
+    expires_after="never">
+  <owner>colinliang@google.com</owner>
+  <summary>
+    Records the final outcome of the storage migration process. Tracks whether
+    the migration took the fast path, skipped due to no data, fully succeeded,
+    or failed during read/injection.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.Duration" units="ms"
+    expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the total time taken to migrate data from the legacy Starboard
+    storage record to the new Chromium-based storage.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.LocalStorageCount" units="entries"
+    expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the total number of localStorage entries found in the legacy
+    Starboard storage record during a migration attempt.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.LocalStorageInjectionResult"
+    enum="StorageInjectionResult" expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the outcome of attempting to inject a single localStorage entry into
+    the new Chromium-based storage during migration from legacy Starboard
+    storage.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.ReadResult" enum="StorageReadResult"
+    expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the outcome of attempting to read and parse the legacy Starboard
+    storage record during migration.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.SentinelWriteResult"
+    enum="SentinelWriteResult" expires_after="never">
+  <owner>colinliang@google.com</owner>
+  <summary>
+    Records the result of writing the migration sentinel file to disk.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.SplashScreen.FetchedFromCache"
     enum="SplashScreenFetchedState" expires_after="never">
   <owner>tasunny@google.com</owner>


### PR DESCRIPTION
Cherry pick Storage Migration Rework from 26.android to 26.eap, fixed incompatibilities in 26.eap branch, hooked up storage migration trigger in CobaltBrowserMainParts::InitializeMessageLoopContext() and added migration status telemetry, verified the whole workflow on linux-x86x11.

Test: Locally verified storage migration manager on linux-x86x11:
Full Log: https://paste.googleplex.com/5720103317536768#l=1
https://screenshot.googleplex.com/8k4Sc7pTzxreach
Bug: 489453068
