### PR TITLE
Cobalt: Update lifecycle terminology to Activating/Deactivating for clarity

### DIFF
--- a/base/message_loop/message_pump_ui_starboard.cc
+++ b/base/message_loop/message_pump_ui_starboard.cc
@@ -105,7 +105,7 @@ void MessagePumpUIStarboard::Run(Delegate* delegate) {
   //
   // To support this, we implement a standard nested Chromium message
   // loop here. This allows instantiating a nested
-  // `base::RunLoop` during downward transitions, which blocks the OS thread
+  // `base::RunLoop` during deactivating transitions, which blocks the OS thread
   // while simultaneously spinning up this inner `Run()` loop to process the
   // necessary asynchronous teardown tasks.
   SetDelegate(delegate);

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -340,7 +340,11 @@ void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {
 
   target_state_ = state;
 
-  bool is_downward = state > application_state_;
+  // The initial transition from kInitial to kStarted/kPreloaded is an
+  // 'activating' move, but numerically it looks like a deactivation. We
+  // explicitly exclude it here to avoid unnecessary blocking during startup.
+  bool is_deactivating = application_state_ != ApplicationState::kInitial &&
+                         state > application_state_;
 
   if (!is_transitioning_) {
     is_transitioning_ = true;
@@ -349,9 +353,9 @@ void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {
                                   base::Unretained(this)));
   }
 
-  // If this is a downward transition, we MUST block the OS (Starboard) thread
-  // until the target state is reached.
-  if (is_downward) {
+  // If this is a deactivating transition, we MUST block the OS (Starboard)
+  // thread until the target state is reached.
+  if (is_deactivating) {
     if (content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
       // REQUIRED BEHAVIOR:
       // We must block the Starboard OS thread while still pumping Chromium's UI

--- a/cobalt/app/app_event_delegate.h
+++ b/cobalt/app/app_event_delegate.h
@@ -48,8 +48,9 @@ class AppEventDelegate {
   // this monotonic ordering to ensure correct state machine transitions.
   //
   // The enum is ordered such that:
-  //   application_state_ < target_state_ => Moving towards Stopped
-  //   application_state_ > target_state_ => Moving towards Started
+  //   application_state_ < target_state_ => Deactivating
+  //   application_state_ > target_state_ => Activating
+  //   (Note: kInitial -> kStarted/kPreloaded is an exception)
   enum class ApplicationState {
     kInitial = 0,
     kStarted = 1,


### PR DESCRIPTION
cobalt: Update lifecycle terminology for clarity

Rename application lifecycle state transitions from "downward" to
"deactivating" and introduce "activating" where applicable. This
clarifies the application lifecycle state machine, making it easier to
understand the direction of state changes.

Specifically, this update renames the "is_downward" variable to
"is_deactivating" and refines its logic to correctly differentiate
between true deactivating transitions (e.g., kStopped) and initial
activating transitions (kInitial -> kStarted/kPreloaded), which should
not trigger blocking behavior. This ensures that the OS thread is
blocked only during actual deactivation sequences.

Bug: 492166511
Bug: 491841704
Bug: 475990372
Bug: 477170017
Bug: 474496110
Bug: 492693465
Bug: 494002968