### PR TITLE
android: Remove transparent format for SurfaceView

### DIFF
--- a/content/public/android/java/src/org/chromium/content/browser/androidoverlay/SurfaceViewOverlayCore.java
+++ b/content/public/android/java/src/org/chromium/content/browser/androidoverlay/SurfaceViewOverlayCore.java
@@ -56,10 +56,7 @@ class SurfaceViewOverlayCore implements OverlayCore {
         if (config.secure) {
             mSurfaceView.setSecure(true);
         }
-        // Emulate how AndroidOverlay typically works: Punch a hole
         mSurfaceView.setBackgroundColor(android.graphics.Color.TRANSPARENT);
-        
-        mSurfaceView.getHolder().setFormat(PixelFormat.TRANSPARENT);
 
         // Initialize with MATCH_PARENT so the Android view system considers it valid
         // and creates the surface. The exact bounds will be set in layoutSurface().
@@ -87,7 +84,6 @@ class SurfaceViewOverlayCore implements OverlayCore {
 
         mCallbacks = new Callbacks();
         mSurfaceView.getHolder().addCallback(mCallbacks);
-
     }
 
     @Override


### PR DESCRIPTION
Remove the explicit setting of PixelFormat.TRANSPARENT for the SurfaceView's
holder. The desired overlay effect, often referred to as "punching a hole,"
is handled by setting the background color to transparent and proper
layering, not by explicitly making the surface format transparent. This change
prevents potential rendering artifacts or incorrect behavior with hardware
surfaces on Android.

This aligns with the setting to VideoSurfaceView as C25.

Issue: 490696746