### PR TITLE
android: Log Android dreaming mode state changes

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltSystemConfigChangeReceiver.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltSystemConfigChangeReceiver.java
@@ -36,6 +36,8 @@ final class CobaltSystemConfigChangeReceiver extends BroadcastReceiver {
     filter.addAction(Intent.ACTION_TIMEZONE_CHANGED);
     filter.addAction(Intent.ACTION_TIME_CHANGED);
     filter.addAction(Intent.ACTION_DATE_CHANGED);
+    filter.addAction("android.intent.action.DREAMING_STARTED");
+    filter.addAction("android.intent.action.DREAMING_STOPPED");
     appContext.registerReceiver(this, filter);
   }
 
@@ -55,6 +57,12 @@ final class CobaltSystemConfigChangeReceiver extends BroadcastReceiver {
       case Intent.ACTION_LOCALE_CHANGED:
         Log.w(TAG, "System locale settings have changed.");
         mStopRequester.run();
+        break;
+      case "android.intent.action.DREAMING_STARTED":
+        Log.w(TAG, "Screensaver started.");
+        break;
+      case "android.intent.action.DREAMING_STOPPED":
+        Log.w(TAG, "Screensaver stopped.");
         break;
       default:
         Log.w(TAG, "Unknown intent.");


### PR DESCRIPTION
Register CobaltSystemConfigChangeReceiver to listen for
ACTION_DREAMING_STARTED and ACTION_DREAMING_STOPPED intents.
Log a warning message when the Android device enters or exits
dreaming mode (screensaver).

This enables observation of system screensaver state, which can be
valuable for debugging power management, understanding user
engagement, and as a foundation for future features that might
need to respond to these state transitions.

Bug: 418827536