### PR TITLE
android: Respect VideoDecoderInitialPrerollCount config

### DIFF
--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -422,9 +422,10 @@ VideoDecoder::VideoDecoder(const VideoStreamInfo& video_stream_info,
                                       tunnel_mode_audio_session_id != -1),
       has_new_texture_available_(false),
       surface_condition_variable_(surface_destroy_mutex_),
-      number_of_preroll_frames_(
+      initial_number_of_preroll_frames_(
           experimental_features.video_decoder_initial_preroll_count.value_or(
-              kInitialPrerollFrameCount)) {
+              kInitialPrerollFrameCount)),
+      number_of_preroll_frames_(initial_number_of_preroll_frames_) {
   SB_CHECK(error_message);
 
   if (force_secure_pipeline_under_tunnel_mode) {
@@ -977,8 +978,13 @@ void VideoDecoder::RefreshOutputFormat(MediaCodecBridge* media_codec_bridge) {
   auto max_output_buffers =
       MaxMediaCodecOutputBuffersLookupTable::GetInstance()
           ->GetMaxOutputVideoBuffers(output_format_.value());
-  if (max_output_buffers > 0 &&
-      max_output_buffers < number_of_preroll_frames_) {
+  // When the output format changes, we re-calculate the preroll frame count
+  // (not re-using the existing preroll count). For example, the hardware's
+  // buffer limit for 4K may be much lower than for 720p, and we want to tailor
+  // the preroll specifically to the current format's capabilities.
+  number_of_preroll_frames_ = initial_number_of_preroll_frames_;
+  if (max_output_buffers > 0 && static_cast<size_t>(max_output_buffers) <
+                                    initial_number_of_preroll_frames_) {
     number_of_preroll_frames_ = max_output_buffers;
   }
 }

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -978,7 +978,7 @@ void VideoDecoder::RefreshOutputFormat(MediaCodecBridge* media_codec_bridge) {
       MaxMediaCodecOutputBuffersLookupTable::GetInstance()
           ->GetMaxOutputVideoBuffers(output_format_.value());
   if (max_output_buffers > 0 &&
-      max_output_buffers < kInitialPrerollFrameCount) {
+      max_output_buffers < number_of_preroll_frames_) {
     number_of_preroll_frames_ = max_output_buffers;
   }
 }

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -978,10 +978,6 @@ void VideoDecoder::RefreshOutputFormat(MediaCodecBridge* media_codec_bridge) {
   auto max_output_buffers =
       MaxMediaCodecOutputBuffersLookupTable::GetInstance()
           ->GetMaxOutputVideoBuffers(output_format_.value());
-  // When the output format changes, we re-calculate the preroll frame count
-  // (not re-using the existing preroll count). For example, the hardware's
-  // buffer limit for 4K may be much lower than for 720p, and we want to tailor
-  // the preroll specifically to the current format's capabilities.
   if (max_output_buffers > 0 &&
       max_output_buffers < initial_number_of_preroll_frames_) {
     number_of_preroll_frames_ = max_output_buffers;

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -982,9 +982,8 @@ void VideoDecoder::RefreshOutputFormat(MediaCodecBridge* media_codec_bridge) {
   // (not re-using the existing preroll count). For example, the hardware's
   // buffer limit for 4K may be much lower than for 720p, and we want to tailor
   // the preroll specifically to the current format's capabilities.
-  number_of_preroll_frames_ = initial_number_of_preroll_frames_;
-  if (max_output_buffers > 0 && static_cast<size_t>(max_output_buffers) <
-                                    initial_number_of_preroll_frames_) {
+  if (max_output_buffers > 0 &&
+      max_output_buffers < initial_number_of_preroll_frames_) {
     number_of_preroll_frames_ = max_output_buffers;
   }
 }

--- a/starboard/android/shared/video_decoder.h
+++ b/starboard/android/shared/video_decoder.h
@@ -246,6 +246,7 @@ class VideoDecoder
   int max_buffered_output_frames_ = 0;
   bool first_output_format_changed_ = false;
   std::optional<VideoOutputFormat> output_format_;
+  const size_t initial_number_of_preroll_frames_;
   size_t number_of_preroll_frames_;
 };
 


### PR DESCRIPTION
he VideoDecoder was incorrectly updating the number of preroll frames
in RefreshOutputFormat. It compared the maximum output buffers from the
lookup table against a default constant (kInitialPrerollFrameCount).

This caused lower, experimentally configured VideoDecoderInitialPrerollCount
values to be overwritten and increased. The fix ensures that the lookup
table can only decrease the preroll count for safety reasons, preserving
any lower configured experimental values.

Bug: 485225923