### PR TITLE
Fix TCPSocketTest.IsConnected race condition on Starboard

### DIFF
--- a/net/socket/tcp_socket_unittest.cc
+++ b/net/socket/tcp_socket_unittest.cc
@@ -14,6 +14,8 @@
 #include "base/functional/bind.h"
 #include "base/memory/ref_counted.h"
 #include "base/test/bind.h"
+#include "base/test/test_timeouts.h"
+#include "base/threading/platform_thread.h"
 #include "base/time/time.h"
 #include "build/build_config.h"
 #include "net/base/address_list.h"
@@ -662,6 +664,18 @@ TEST_F(TCPSocketTest, IsConnected) {
   FD_SET(connecting_fd, &read_fds);
   ASSERT_EQ(select(FD_SETSIZE, &read_fds, nullptr, nullptr, nullptr), 1);
   ASSERT_TRUE(FD_ISSET(connecting_fd, &read_fds));
+#else
+  // Wait until data arrives on the socket (no longer idle).
+  {
+    const base::TimeTicks deadline =
+        base::TimeTicks::Now() + TestTimeouts::action_timeout();
+    while (connecting_socket.IsConnectedAndIdle() &&
+           base::TimeTicks::Now() < deadline) {
+      base::PlatformThread::Sleep(base::Milliseconds(10));
+    }
+    ASSERT_FALSE(connecting_socket.IsConnectedAndIdle())
+        << "Timed out waiting for data to arrive";
+  }
 #endif
 
   // It should now be reported as connected, but not as idle.


### PR DESCRIPTION
The test writes data from accepted_socket and immediately checks IsConnectedAndIdle() on connecting_socket. On non-Starboard platforms, select() is used to wait for data arrival. On Starboard this wait was skipped entirely (#if !defined(STARBOARD)), causing a race condition where IsConnectedAndIdle() returns true because data has not yet arrived at the socket.

Add a polling loop with timeout for Starboard that waits until IsConnectedAndIdle() returns false (data available) or 1 second elapses.