### PR TITLE
Fix WebSocketAcceptingTest.SendLongTextFrame write overlap on Starboard

### DIFF
--- a/net/server/http_server_unittest.cc
+++ b/net/server/http_server_unittest.cc
@@ -76,7 +76,14 @@ class TestHttpClient {
   void Send(const std::string& data) {
     write_buffer_ = base::MakeRefCounted<DrainableIOBuffer>(
         base::MakeRefCounted<StringIOBuffer>(data), data.length());
+    write_loop_ = std::make_unique<base::RunLoop>();
     Write();
+    // Wait for all data to be written before returning,
+    // to avoid overlapping writes on platforms with small send buffers.
+    if (write_buffer_->BytesRemaining()) {
+      write_loop_->Run();
+    }
+    write_loop_.reset();
   }
 
   bool Read(std::string* message, int expected_bytes) {
@@ -131,10 +138,21 @@ class TestHttpClient {
   }
 
   void OnWrite(int result) {
-    ASSERT_GT(result, 0);
+    // Ensure the loop is quit even on failure so the test can fail and exit
+    // instead of hanging.
+    if (result <= 0) {
+      if (write_loop_) {
+        write_loop_->Quit();
+      }
+      ASSERT_GT(result, 0);
+      return;
+    }
     write_buffer_->DidConsume(result);
-    if (write_buffer_->BytesRemaining())
+    if (write_buffer_->BytesRemaining()) {
       Write();
+    } else if (write_loop_) {
+      write_loop_->Quit();
+    }
   }
 
   void ReadInternal(TestCompletionCallback* callback) {
@@ -165,6 +183,7 @@ class TestHttpClient {
   scoped_refptr<IOBufferWithSize> read_buffer_;
   scoped_refptr<DrainableIOBuffer> write_buffer_;
   std::unique_ptr<TCPClientSocket> socket_;
+  std::unique_ptr<base::RunLoop> write_loop_;
 };
 
 struct ReceivedRequest {


### PR DESCRIPTION
Make TestHttpClient::Send() blocking — wait for all data to be written before returning. On platforms with small TCP send buffers, large writes (100KB) return ERR_IO_PENDING. Without waiting, the second Send() overwrites write_buffer_ while the first is still pending, causing CHECK(write_callback_.is_null()) to fail.