### PR TITLE
cobalt/metrics: Implement granular memory breakdown and performance optimizations

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -284,6 +284,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/global_features_unittest.cc",
     "//cobalt/browser/h5vcc_metrics/histogram_fetcher_test.cc",
     "//cobalt/browser/h5vcc_runtime/deep_link_manager_unittest.cc",
+    "//cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc",
     "//cobalt/browser/metrics/cobalt_enabled_state_provider_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_log_uploader_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_service_client_test.cc",

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -286,6 +286,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/h5vcc_runtime/deep_link_manager_unittest.cc",
     "//cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc",
     "//cobalt/browser/metrics/cobalt_enabled_state_provider_test.cc",
+    "//cobalt/browser/metrics/cobalt_memory_metrics_emitter_unittest.cc",
     "//cobalt/browser/metrics/cobalt_metrics_log_uploader_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_service_client_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_services_manager_client_test.cc",

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -165,6 +165,8 @@ source_set("metrics") {
   sources = [
     "metrics/cobalt_cpu_metrics_emitter.cc",
     "metrics/cobalt_cpu_metrics_emitter.h",
+    "metrics/cobalt_detailed_metrics_delegate.cc",
+    "metrics/cobalt_detailed_metrics_delegate.h",
     "metrics/cobalt_enabled_state_provider.cc",
     "metrics/cobalt_enabled_state_provider.h",
     "metrics/cobalt_memory_metrics_emitter.cc",

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -19,6 +19,7 @@
 #include "base/path_service.h"
 #include "base/trace_event/memory_dump_manager.h"
 #include "cobalt/browser/global_features.h"
+#include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
 #include "cobalt/shell/common/shell_paths.h"
 #include "components/metrics/metrics_service.h"
@@ -47,6 +48,8 @@ CobaltBrowserMainParts::CobaltBrowserMainParts(const std::string& deep_link,
     : ShellBrowserMainParts(deep_link, is_visible) {}
 
 namespace {
+
+std::unique_ptr<CobaltDetailedMetricsDelegate> g_detailed_metrics_delegate;
 
 void InitializeBrowserMemoryInstrumentationClient() {
   if (memory_instrumentation::MemoryInstrumentation::GetInstance()) {
@@ -79,6 +82,11 @@ void InitializeBrowserMemoryInstrumentationClient() {
   memory_instrumentation::ClientProcessImpl::CreateInstance(
       std::move(process_receiver), std::move(coordinator),
       /*is_browser_process=*/true);
+
+  g_detailed_metrics_delegate =
+      std::make_unique<CobaltDetailedMetricsDelegate>();
+  memory_instrumentation::ClientProcessImpl::SetDetailedMetricsDelegate(
+      g_detailed_metrics_delegate.get());
 }
 
 }  // namespace

--- a/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.cc
+++ b/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.cc
@@ -63,39 +63,23 @@ constexpr char kAnonPrefix[] = "[anon:";
 CobaltDetailedMetricsDelegate::CobaltDetailedMetricsDelegate() = default;
 CobaltDetailedMetricsDelegate::~CobaltDetailedMetricsDelegate() = default;
 
-void CobaltDetailedMetricsDelegate::OnSmapsLine(absl::string_view line) {
+void CobaltDetailedMetricsDelegate::OnSmapsHeader(absl::string_view line) {
   if (line.empty()) {
     return;
   }
+  current_category_ = GetCategory(line);
+}
 
-  // Check if it's a header line (starts with hex address range).
-  if (base::IsHexDigit(static_cast<unsigned char>(line[0]))) {
-    current_category_ = GetCategory(line);
-    return;
-  }
-
+void CobaltDetailedMetricsDelegate::OnSmapsCounter(absl::string_view name,
+                                                   uint64_t value_kb) {
   if (current_category_ == Category::kNone) {
     return;
   }
 
-  // Parse counter line. Format: "Name:  Value kB"
-  bool is_pss = absl::StartsWith(line, "Pss:");
-  bool is_rss = absl::StartsWith(line, "Rss:");
+  bool is_pss = (name == "Pss");
+  bool is_rss = (name == "Rss");
 
   if (!is_pss && !is_rss) {
-    return;
-  }
-
-  std::vector<absl::string_view> tokens = base::SplitStringPiece(
-      line, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-
-  // Expected tokens: ["Pss:", "12", "kB"] or ["Rss:", "12", "kB"]
-  if (tokens.size() < 3 || tokens.back() != "kB") {
-    return;
-  }
-
-  uint64_t value_kb = 0;
-  if (!absl::SimpleAtoi(tokens[1], &value_kb)) {
     return;
   }
 

--- a/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.cc
+++ b/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.cc
@@ -1,0 +1,266 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
+
+#include <string>
+#include <vector>
+
+#include "base/numerics/safe_conversions.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
+#include "third_party/abseil-cpp/absl/strings/match.h"
+#include "third_party/abseil-cpp/absl/strings/numbers.h"
+
+namespace cobalt {
+
+namespace {
+
+// Pattern constants for categorization.
+constexpr char kLibCobaltPattern[] = "libcobalt.so";
+constexpr char kLibChrobaltPattern[] = "libchrobalt.so";
+constexpr char kCobaltCorePattern[] = "CobaltCore";
+constexpr char kV8Pattern[] = "v8";
+constexpr char kPartitionAllocPattern[] = "partition_alloc";
+constexpr char kScudoPattern[] = "[anon:scudo]";
+constexpr char kHeapPattern[] = "[heap]";
+constexpr char kJemallocPattern[] = "jemalloc";
+constexpr char kDalvikPrefix[] = "[anon:dalvik-";
+constexpr char kArtExtension[] = ".art";
+constexpr char kOatExtension[] = ".oat";
+constexpr char kVdexExtension[] = ".vdex";
+constexpr char kOdexExtension[] = ".odex";
+constexpr char kKgslPattern[] = "/dev/kgsl-3d0";
+constexpr char kMaliPattern[] = "/dev/mali0";
+constexpr char kNvgpuPattern[] = "/dev/nvgpu";
+constexpr char kPvrPattern[] = "/dev/pvr";
+constexpr char kDriPattern[] = "/dev/dri/";
+constexpr char kTtfExtension[] = ".ttf";
+constexpr char kTtcExtension[] = ".ttc";
+constexpr char kFontsPath[] = "fonts/";
+constexpr char kAshmemPath[] = "/dev/ashmem/";
+constexpr char kMemfdJitPattern[] = "memfd:jit";
+constexpr char kStackPattern[] = "[stack]";
+constexpr char kStackAndTlsPattern[] = "stack_and_tls";
+constexpr char kSoExtension[] = ".so";
+constexpr char kApkExtension[] = ".apk";
+constexpr char kDexExtension[] = ".dex";
+constexpr char kAnonPrefix[] = "[anon:";
+
+}  // namespace
+
+CobaltDetailedMetricsDelegate::CobaltDetailedMetricsDelegate() = default;
+CobaltDetailedMetricsDelegate::~CobaltDetailedMetricsDelegate() = default;
+
+void CobaltDetailedMetricsDelegate::OnSmapsLine(absl::string_view line) {
+  if (line.empty()) {
+    return;
+  }
+
+  // Check if it's a header line (starts with hex address range).
+  if (base::IsHexDigit(static_cast<unsigned char>(line[0]))) {
+    current_category_ = GetCategory(line);
+    return;
+  }
+
+  if (current_category_ == Category::kNone) {
+    return;
+  }
+
+  // Parse counter line. Format: "Name:  Value kB"
+  bool is_pss = absl::StartsWith(line, "Pss:");
+  bool is_rss = absl::StartsWith(line, "Rss:");
+
+  if (!is_pss && !is_rss) {
+    return;
+  }
+
+  std::vector<absl::string_view> tokens = base::SplitStringPiece(
+      line, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+
+  // Expected tokens: ["Pss:", "12", "kB"] or ["Rss:", "12", "kB"]
+  if (tokens.size() < 3 || tokens.back() != "kB") {
+    return;
+  }
+
+  uint64_t value_kb = 0;
+  if (!absl::SimpleAtoi(tokens[1], &value_kb)) {
+    return;
+  }
+
+  Stats* stats = nullptr;
+  switch (current_category_) {
+    case Category::kCobaltCore:
+      stats = &cobalt_core_;
+      break;
+    case Category::kV8:
+      stats = &v8_;
+      break;
+    case Category::kPartitionAlloc:
+      stats = &partition_alloc_;
+      break;
+    case Category::kMalloc:
+      stats = &malloc_;
+      break;
+    case Category::kAndroidRuntime:
+      stats = &android_runtime_;
+      break;
+    case Category::kGraphics:
+      stats = &graphics_;
+      break;
+    case Category::kFonts:
+      stats = &fonts_;
+      break;
+    case Category::kAshmemJit:
+      stats = &ashmem_jit_;
+      break;
+    case Category::kStacks:
+      stats = &stacks_;
+      break;
+    case Category::kCodeOther:
+      stats = &code_other_;
+      break;
+    case Category::kAnonymousOther:
+      stats = &anonymous_other_;
+      break;
+    case Category::kOther:
+      stats = &other_;
+      break;
+    default:
+      break;
+  }
+
+  if (stats) {
+    if (is_pss) {
+      stats->pss_kb += value_kb;
+    } else {
+      stats->rss_kb += value_kb;
+    }
+  }
+}
+
+base::flat_map<std::string, uint32_t>
+CobaltDetailedMetricsDelegate::GetAndResetStats() {
+  base::flat_map<std::string, uint32_t> result;
+
+  auto add_stats = [&](const std::string& name, Stats& stats) {
+    result["pss:" + name] = base::saturated_cast<uint32_t>(stats.pss_kb);
+    result["rss:" + name] = base::saturated_cast<uint32_t>(stats.rss_kb);
+    stats.pss_kb = 0;
+    stats.rss_kb = 0;
+  };
+
+  add_stats("cobalt_core", cobalt_core_);
+  add_stats("v8", v8_);
+  add_stats("partition_alloc", partition_alloc_);
+  add_stats("malloc", malloc_);
+  add_stats("android_runtime", android_runtime_);
+  add_stats("graphics", graphics_);
+  add_stats("fonts", fonts_);
+  add_stats("ashmem_jit", ashmem_jit_);
+  add_stats("stacks", stacks_);
+  add_stats("code_other", code_other_);
+  add_stats("anonymous_other", anonymous_other_);
+  add_stats("other", other_);
+
+  current_category_ = Category::kNone;
+  return result;
+}
+
+CobaltDetailedMetricsDelegate::Category
+CobaltDetailedMetricsDelegate::GetCategory(absl::string_view line) {
+  // Optimized check for anonymous mappings.
+  if (absl::StrContains(line, kAnonPrefix)) {
+    if (absl::StrContains(line, kV8Pattern)) {
+      return Category::kV8;
+    }
+    if (absl::StrContains(line, kPartitionAllocPattern)) {
+      return Category::kPartitionAlloc;
+    }
+    if (absl::StrContains(line, kScudoPattern)) {
+      return Category::kMalloc;
+    }
+    if (absl::StrContains(line, kDalvikPrefix)) {
+      return Category::kAndroidRuntime;
+    }
+    return Category::kAnonymousOther;
+  }
+
+  // Optimized check for common file-backed mappings.
+  if (absl::StrContains(line, kSoExtension)) {
+    if (absl::StrContains(line, kLibCobaltPattern) ||
+        absl::StrContains(line, kLibChrobaltPattern)) {
+      return Category::kCobaltCore;
+    }
+    return Category::kCodeOther;
+  }
+
+  // Precedence 1: cobalt_core (additional patterns)
+  if (absl::StrContains(line, kCobaltCorePattern)) {
+    return Category::kCobaltCore;
+  }
+
+  // Precedence 2: malloc (heap)
+  if (absl::StrContains(line, kHeapPattern) ||
+      absl::StrContains(line, kJemallocPattern)) {
+    return Category::kMalloc;
+  }
+
+  // Precedence 3: android_runtime (additional extensions)
+  if (absl::StrContains(line, kArtExtension) ||
+      absl::StrContains(line, kOatExtension) ||
+      absl::StrContains(line, kVdexExtension) ||
+      absl::StrContains(line, kOdexExtension)) {
+    return Category::kAndroidRuntime;
+  }
+
+  // Precedence 4: graphics
+  if (absl::StrContains(line, kKgslPattern) ||
+      absl::StrContains(line, kMaliPattern) ||
+      absl::StrContains(line, kNvgpuPattern) ||
+      absl::StrContains(line, kPvrPattern) ||
+      absl::StrContains(line, kDriPattern)) {
+    return Category::kGraphics;
+  }
+
+  // Precedence 5: fonts
+  if (absl::StrContains(line, kTtfExtension) ||
+      absl::StrContains(line, kTtcExtension) ||
+      absl::StrContains(line, kFontsPath)) {
+    return Category::kFonts;
+  }
+
+  // Precedence 6: ashmem_jit
+  if (absl::StrContains(line, kAshmemPath) ||
+      absl::StrContains(line, kMemfdJitPattern)) {
+    return Category::kAshmemJit;
+  }
+
+  // Precedence 7: stacks
+  if (absl::StrContains(line, kStackPattern) ||
+      absl::StrContains(line, kStackAndTlsPattern)) {
+    return Category::kStacks;
+  }
+
+  // Precedence 8: code_other (additional extensions)
+  if (absl::StrContains(line, kApkExtension) ||
+      absl::StrContains(line, kDexExtension)) {
+    return Category::kCodeOther;
+  }
+
+  // Precedence 10: other
+  return Category::kOther;
+}
+
+}  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h
+++ b/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h
@@ -33,7 +33,8 @@ class CobaltDetailedMetricsDelegate
   ~CobaltDetailedMetricsDelegate() override;
 
   // DetailedMetricsDelegate implementation.
-  void OnSmapsLine(absl::string_view line) override;
+  void OnSmapsHeader(absl::string_view line) override;
+  void OnSmapsCounter(absl::string_view name, uint64_t value_kb) override;
   base::flat_map<std::string, uint32_t> GetAndResetStats() override;
 
  private:

--- a/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h
+++ b/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h
@@ -1,0 +1,81 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_METRICS_COBALT_DETAILED_METRICS_DELEGATE_H_
+#define COBALT_BROWSER_METRICS_COBALT_DETAILED_METRICS_DELEGATE_H_
+
+#include <cstdint>
+#include <string>
+
+#include "base/containers/flat_map.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "third_party/abseil-cpp/absl/strings/string_view.h"
+
+namespace cobalt {
+
+// Cobalt-specific implementation of the DetailedMetricsDelegate.
+// Categorizes /proc/self/smaps mappings into Cobalt-specific categories.
+class CobaltDetailedMetricsDelegate
+    : public memory_instrumentation::DetailedMetricsDelegate {
+ public:
+  CobaltDetailedMetricsDelegate();
+  ~CobaltDetailedMetricsDelegate() override;
+
+  // DetailedMetricsDelegate implementation.
+  void OnSmapsLine(absl::string_view line) override;
+  base::flat_map<std::string, uint32_t> GetAndResetStats() override;
+
+ private:
+  enum class Category {
+    kNone,
+    kCobaltCore,
+    kV8,
+    kPartitionAlloc,
+    kMalloc,
+    kAndroidRuntime,
+    kGraphics,
+    kFonts,
+    kAshmemJit,
+    kStacks,
+    kCodeOther,
+    kAnonymousOther,
+    kOther
+  };
+
+  struct Stats {
+    uint64_t pss_kb = 0;
+    uint64_t rss_kb = 0;
+  };
+
+  Category GetCategory(absl::string_view line);
+
+  Category current_category_ = Category::kNone;
+
+  Stats cobalt_core_;
+  Stats v8_;
+  Stats partition_alloc_;
+  Stats malloc_;
+  Stats android_runtime_;
+  Stats graphics_;
+  Stats fonts_;
+  Stats ashmem_jit_;
+  Stats stacks_;
+  Stats code_other_;
+  Stats anonymous_other_;
+  Stats other_;
+};
+
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_METRICS_COBALT_DETAILED_METRICS_DELEGATE_H_

--- a/cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc
+++ b/cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc
@@ -24,15 +24,15 @@ class CobaltDetailedMetricsDelegateTest : public testing::Test {
 };
 
 TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesCobaltCore) {
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "00400000-00421000 r-xp 00000000 fc:01 1234  /path/libcobalt.so");
-  delegate_.OnSmapsLine("Pss:                  100 kB");
-  delegate_.OnSmapsLine("Rss:                  200 kB");
+  delegate_.OnSmapsCounter("Pss", 100);
+  delegate_.OnSmapsCounter("Rss", 200);
 
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "00500000-00521000 r-xp 00000000 fc:01 1235  CobaltCore");
-  delegate_.OnSmapsLine("Pss:                   50 kB");
-  delegate_.OnSmapsLine("Rss:                   60 kB");
+  delegate_.OnSmapsCounter("Pss", 50);
+  delegate_.OnSmapsCounter("Rss", 60);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:cobalt_core"], 150u);
@@ -40,9 +40,9 @@ TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesCobaltCore) {
 }
 
 TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesV8) {
-  delegate_.OnSmapsLine("00580000-005a1000 rw-p 00000000 00:00 0 [anon:v8]");
-  delegate_.OnSmapsLine("Pss:                   100 kB");
-  delegate_.OnSmapsLine("Rss:                   200 kB");
+  delegate_.OnSmapsHeader("00580000-005a1000 rw-p 00000000 00:00 0 [anon:v8]");
+  delegate_.OnSmapsCounter("Pss", 100);
+  delegate_.OnSmapsCounter("Rss", 200);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:v8"], 100u);
@@ -50,10 +50,10 @@ TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesV8) {
 }
 
 TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesPartitionAlloc) {
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "005b0000-005d1000 rw-p 00000000 00:00 0 [anon:partition_alloc]");
-  delegate_.OnSmapsLine("Pss:                   150 kB");
-  delegate_.OnSmapsLine("Rss:                   300 kB");
+  delegate_.OnSmapsCounter("Pss", 150);
+  delegate_.OnSmapsCounter("Rss", 300);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:partition_alloc"], 150u);
@@ -61,13 +61,14 @@ TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesPartitionAlloc) {
 }
 
 TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesMalloc) {
-  delegate_.OnSmapsLine("00600000-00621000 rw-p 00000000 00:00 0 [anon:scudo]");
-  delegate_.OnSmapsLine("Pss:                   10 kB");
-  delegate_.OnSmapsLine("Rss:                   20 kB");
+  delegate_.OnSmapsHeader(
+      "00600000-00621000 rw-p 00000000 00:00 0 [anon:scudo]");
+  delegate_.OnSmapsCounter("Pss", 10);
+  delegate_.OnSmapsCounter("Rss", 20);
 
-  delegate_.OnSmapsLine("00700000-00721000 rw-p 00000000 00:00 0 [heap]");
-  delegate_.OnSmapsLine("Pss:                   5 kB");
-  delegate_.OnSmapsLine("Rss:                   10 kB");
+  delegate_.OnSmapsHeader("00700000-00721000 rw-p 00000000 00:00 0 [heap]");
+  delegate_.OnSmapsCounter("Pss", 5);
+  delegate_.OnSmapsCounter("Rss", 10);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:malloc"], 15u);
@@ -75,15 +76,15 @@ TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesMalloc) {
 }
 
 TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesAndroidRuntime) {
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "00800000-00821000 r--p 00000000 fc:01 1236  /path/boot.art");
-  delegate_.OnSmapsLine("Pss:                   20 kB");
-  delegate_.OnSmapsLine("Rss:                   40 kB");
+  delegate_.OnSmapsCounter("Pss", 20);
+  delegate_.OnSmapsCounter("Rss", 40);
 
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "00900000-00921000 r-xp 00000000 fc:01 1237  /path/base.odex");
-  delegate_.OnSmapsLine("Pss:                   30 kB");
-  delegate_.OnSmapsLine("Rss:                   50 kB");
+  delegate_.OnSmapsCounter("Pss", 30);
+  delegate_.OnSmapsCounter("Rss", 50);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:android_runtime"], 50u);
@@ -91,10 +92,10 @@ TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesAndroidRuntime) {
 }
 
 TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesGraphics) {
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "00a00000-00a21000 rw-p 00000000 00:00 0 /dev/kgsl-3d0");
-  delegate_.OnSmapsLine("Pss:                   40 kB");
-  delegate_.OnSmapsLine("Rss:                   80 kB");
+  delegate_.OnSmapsCounter("Pss", 40);
+  delegate_.OnSmapsCounter("Rss", 80);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:graphics"], 40u);
@@ -102,10 +103,10 @@ TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesGraphics) {
 }
 
 TEST_F(CobaltDetailedMetricsDelegateTest, HandlesBrittleFormats) {
-  // Test irregular spacing
-  delegate_.OnSmapsLine("00b00000-00b21000 rw-p 00000000 00:00 0 [stack]");
-  delegate_.OnSmapsLine("Pss: 12 kB");
-  delegate_.OnSmapsLine("Rss:   24    kB");
+  // Test irregular spacing (no longer an issue as categorizer handles it)
+  delegate_.OnSmapsHeader("00b00000-00b21000 rw-p 00000000 00:00 0 [stack]");
+  delegate_.OnSmapsCounter("Pss", 12);
+  delegate_.OnSmapsCounter("Rss", 24);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:stacks"], 12u);
@@ -115,14 +116,14 @@ TEST_F(CobaltDetailedMetricsDelegateTest, HandlesBrittleFormats) {
 TEST_F(CobaltDetailedMetricsDelegateTest, RespectsPrecedence) {
   // libcobalt.so should be cobalt_core even if it has .so extension
   // (code_other)
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "00c00000-00c21000 r-xp 00000000 fc:01 1238  /path/libcobalt.so");
-  delegate_.OnSmapsLine("Pss:                   10 kB");
+  delegate_.OnSmapsCounter("Pss", 10);
 
   // some other .so should be code_other
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "00d00000-00d21000 r-xp 00000000 fc:01 1239  /path/libother.so");
-  delegate_.OnSmapsLine("Pss:                   20 kB");
+  delegate_.OnSmapsCounter("Pss", 20);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:cobalt_core"], 10u);
@@ -131,13 +132,13 @@ TEST_F(CobaltDetailedMetricsDelegateTest, RespectsPrecedence) {
 
 TEST_F(CobaltDetailedMetricsDelegateTest, HandlesUnknownAndOther) {
   // Anonymous mapping not starting with scudo or dalvik
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "00e00000-00e21000 rw-p 00000000 00:00 0 [anon:something]");
-  delegate_.OnSmapsLine("Pss:                   5 kB");
+  delegate_.OnSmapsCounter("Pss", 5);
 
   // Something completely different
-  delegate_.OnSmapsLine("00f00000-00f21000 rw-p 00000000 00:00 0 /some/file");
-  delegate_.OnSmapsLine("Pss:                   7 kB");
+  delegate_.OnSmapsHeader("00f00000-00f21000 rw-p 00000000 00:00 0 /some/file");
+  delegate_.OnSmapsCounter("Pss", 7);
 
   auto stats = delegate_.GetAndResetStats();
   EXPECT_EQ(stats["pss:anonymous_other"], 5u);
@@ -145,9 +146,9 @@ TEST_F(CobaltDetailedMetricsDelegateTest, HandlesUnknownAndOther) {
 }
 
 TEST_F(CobaltDetailedMetricsDelegateTest, ResetsCorrectly) {
-  delegate_.OnSmapsLine(
+  delegate_.OnSmapsHeader(
       "01000000-01021000 r-xp 00000000 fc:01 1240  CobaltCore");
-  delegate_.OnSmapsLine("Pss:                   10 kB");
+  delegate_.OnSmapsCounter("Pss", 10);
 
   delegate_.GetAndResetStats();
 

--- a/cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc
+++ b/cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc
@@ -1,0 +1,158 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+
+class CobaltDetailedMetricsDelegateTest : public testing::Test {
+ protected:
+  CobaltDetailedMetricsDelegate delegate_;
+};
+
+TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesCobaltCore) {
+  delegate_.OnSmapsLine(
+      "00400000-00421000 r-xp 00000000 fc:01 1234  /path/libcobalt.so");
+  delegate_.OnSmapsLine("Pss:                  100 kB");
+  delegate_.OnSmapsLine("Rss:                  200 kB");
+
+  delegate_.OnSmapsLine(
+      "00500000-00521000 r-xp 00000000 fc:01 1235  CobaltCore");
+  delegate_.OnSmapsLine("Pss:                   50 kB");
+  delegate_.OnSmapsLine("Rss:                   60 kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:cobalt_core"], 150u);
+  EXPECT_EQ(stats["rss:cobalt_core"], 260u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesV8) {
+  delegate_.OnSmapsLine("00580000-005a1000 rw-p 00000000 00:00 0 [anon:v8]");
+  delegate_.OnSmapsLine("Pss:                   100 kB");
+  delegate_.OnSmapsLine("Rss:                   200 kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:v8"], 100u);
+  EXPECT_EQ(stats["rss:v8"], 200u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesPartitionAlloc) {
+  delegate_.OnSmapsLine(
+      "005b0000-005d1000 rw-p 00000000 00:00 0 [anon:partition_alloc]");
+  delegate_.OnSmapsLine("Pss:                   150 kB");
+  delegate_.OnSmapsLine("Rss:                   300 kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:partition_alloc"], 150u);
+  EXPECT_EQ(stats["rss:partition_alloc"], 300u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesMalloc) {
+  delegate_.OnSmapsLine("00600000-00621000 rw-p 00000000 00:00 0 [anon:scudo]");
+  delegate_.OnSmapsLine("Pss:                   10 kB");
+  delegate_.OnSmapsLine("Rss:                   20 kB");
+
+  delegate_.OnSmapsLine("00700000-00721000 rw-p 00000000 00:00 0 [heap]");
+  delegate_.OnSmapsLine("Pss:                   5 kB");
+  delegate_.OnSmapsLine("Rss:                   10 kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:malloc"], 15u);
+  EXPECT_EQ(stats["rss:malloc"], 30u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesAndroidRuntime) {
+  delegate_.OnSmapsLine(
+      "00800000-00821000 r--p 00000000 fc:01 1236  /path/boot.art");
+  delegate_.OnSmapsLine("Pss:                   20 kB");
+  delegate_.OnSmapsLine("Rss:                   40 kB");
+
+  delegate_.OnSmapsLine(
+      "00900000-00921000 r-xp 00000000 fc:01 1237  /path/base.odex");
+  delegate_.OnSmapsLine("Pss:                   30 kB");
+  delegate_.OnSmapsLine("Rss:                   50 kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:android_runtime"], 50u);
+  EXPECT_EQ(stats["rss:android_runtime"], 90u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, CategorizesGraphics) {
+  delegate_.OnSmapsLine(
+      "00a00000-00a21000 rw-p 00000000 00:00 0 /dev/kgsl-3d0");
+  delegate_.OnSmapsLine("Pss:                   40 kB");
+  delegate_.OnSmapsLine("Rss:                   80 kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:graphics"], 40u);
+  EXPECT_EQ(stats["rss:graphics"], 80u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, HandlesBrittleFormats) {
+  // Test irregular spacing
+  delegate_.OnSmapsLine("00b00000-00b21000 rw-p 00000000 00:00 0 [stack]");
+  delegate_.OnSmapsLine("Pss: 12 kB");
+  delegate_.OnSmapsLine("Rss:   24    kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:stacks"], 12u);
+  EXPECT_EQ(stats["rss:stacks"], 24u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, RespectsPrecedence) {
+  // libcobalt.so should be cobalt_core even if it has .so extension
+  // (code_other)
+  delegate_.OnSmapsLine(
+      "00c00000-00c21000 r-xp 00000000 fc:01 1238  /path/libcobalt.so");
+  delegate_.OnSmapsLine("Pss:                   10 kB");
+
+  // some other .so should be code_other
+  delegate_.OnSmapsLine(
+      "00d00000-00d21000 r-xp 00000000 fc:01 1239  /path/libother.so");
+  delegate_.OnSmapsLine("Pss:                   20 kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:cobalt_core"], 10u);
+  EXPECT_EQ(stats["pss:code_other"], 20u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, HandlesUnknownAndOther) {
+  // Anonymous mapping not starting with scudo or dalvik
+  delegate_.OnSmapsLine(
+      "00e00000-00e21000 rw-p 00000000 00:00 0 [anon:something]");
+  delegate_.OnSmapsLine("Pss:                   5 kB");
+
+  // Something completely different
+  delegate_.OnSmapsLine("00f00000-00f21000 rw-p 00000000 00:00 0 /some/file");
+  delegate_.OnSmapsLine("Pss:                   7 kB");
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:anonymous_other"], 5u);
+  EXPECT_EQ(stats["pss:other"], 7u);
+}
+
+TEST_F(CobaltDetailedMetricsDelegateTest, ResetsCorrectly) {
+  delegate_.OnSmapsLine(
+      "01000000-01021000 r-xp 00000000 fc:01 1240  CobaltCore");
+  delegate_.OnSmapsLine("Pss:                   10 kB");
+
+  delegate_.GetAndResetStats();
+
+  auto stats = delegate_.GetAndResetStats();
+  EXPECT_EQ(stats["pss:cobalt_core"], 0u);
+}
+
+}  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
@@ -388,7 +388,7 @@ void CobaltMemoryMetricsEmitter::CollateResults() {
             ".SharedMemoryFootprint",
         static_cast<int>(pmd.os_dump().shared_footprint_kb / kKiB));
 
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_ANDROID)
     base::UmaHistogramMemoryLargeMB(
         std::string(kMemoryHistogramPrefix) + process_name + ".LibChrobaltPss",
         static_cast<int>(pmd.os_dump().libchrobalt_pss_kb / kKiB));

--- a/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
@@ -55,126 +55,216 @@ const CobaltMemoryMetricsEmitter::Metric kAllocatorDumpNamesForMetrics[] = {
      "BlinkGC",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"blink_gc",
      "BlinkGC.AllocatedObjects",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kAllocatedObjectsSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"blink_gc",
      "BlinkGC.Fragmentation",
      CobaltMemoryMetricsEmitter::MetricSize::kPercentage,
-     "fragmentation",
+     kEffectiveSize,
+     kAllocatedObjectsSize,
+     CobaltMemoryMetricsEmitter::CalculationType::kFragmentation,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
      {}},
     {"blink_gc/main",
      "BlinkGC.Main.Heap.Fragmentation",
      CobaltMemoryMetricsEmitter::MetricSize::kPercentage,
-     "fragmentation",
+     kEffectiveSize,
+     kAllocatedObjectsSize,
+     CobaltMemoryMetricsEmitter::CalculationType::kFragmentation,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
      {}},
     {"blink_objects/Document",
      "NumberOfDocuments",
      CobaltMemoryMetricsEmitter::MetricSize::kTiny,
      MemoryAllocatorDump::kNameObjectCount,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kCountsInUkmAndSizeInUma,
      {}},
     {"blink_objects/Frame",
      "NumberOfFrames",
      CobaltMemoryMetricsEmitter::MetricSize::kTiny,
      MemoryAllocatorDump::kNameObjectCount,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kCountsInUkmAndSizeInUma,
      {}},
     {"blink_objects/LayoutObject",
      "NumberOfLayoutObjects",
      CobaltMemoryMetricsEmitter::MetricSize::kTiny,
      MemoryAllocatorDump::kNameObjectCount,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kCountsInUkmAndSizeInUma,
      {}},
     {"blink_objects/Node",
      "NumberOfNodes",
      CobaltMemoryMetricsEmitter::MetricSize::kSmall,
      MemoryAllocatorDump::kNameObjectCount,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kCountsInUkmAndSizeInUma,
      {}},
     {"font_caches/shape_caches",
      "FontCaches",
      CobaltMemoryMetricsEmitter::MetricSize::kSmall,
      "size",
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"java_heap",
      "JavaHeap",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"leveldatabase",
      "LevelDatabase",
      CobaltMemoryMetricsEmitter::MetricSize::kSmall,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"malloc",
      "Malloc",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"malloc",
      "Malloc.AllocatedObjects",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kAllocatedObjectsSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
+     {}},
+    {"malloc/partitions/allocator/thread_cache",
+     "Malloc.ThreadCache",
+     CobaltMemoryMetricsEmitter::MetricSize::kSmall,
+     kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
+     {}},
+    {"malloc/metadata_fragmentation_caches",
+     "Malloc.Metadata",
+     CobaltMemoryMetricsEmitter::MetricSize::kSmall,
+     kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"partition_alloc",
      "PartitionAlloc",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"partition_alloc/allocated_objects",
      "PartitionAlloc.AllocatedObjects",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
+     {}},
+    {"partition_alloc/partitions/fast_malloc",
+     "PartitionAlloc.Partitions.FastMalloc",
+     CobaltMemoryMetricsEmitter::MetricSize::kLarge,
+     kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
+     {}},
+    {"partition_alloc/partitions/fast_malloc",
+     "PartitionAlloc.Fragmentation.FastMalloc",
+     CobaltMemoryMetricsEmitter::MetricSize::kPercentage,
+     kEffectiveSize,
+     kAllocatedObjectsSize,
+     CobaltMemoryMetricsEmitter::CalculationType::kFragmentation,
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
+     {}},
+    {"partition_alloc/partitions/buffer",
+     "PartitionAlloc.Partitions.Buffer",
+     CobaltMemoryMetricsEmitter::MetricSize::kLarge,
+     kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
+     {}},
+    {"partition_alloc/partitions/array_buffer",
+     "PartitionAlloc.Partitions.ArrayBuffer",
+     CobaltMemoryMetricsEmitter::MetricSize::kLarge,
+     kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"skia",
      "Skia",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"skia/sk_glyph_cache",
      "Skia.SkGlyphCache",
      CobaltMemoryMetricsEmitter::MetricSize::kSmall,
      "size",
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"sqlite",
      "Sqlite",
      CobaltMemoryMetricsEmitter::MetricSize::kSmall,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"ui",
      "UI",
      CobaltMemoryMetricsEmitter::MetricSize::kSmall,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"v8",
      "V8",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kEffectiveSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
     {"v8",
      "V8.AllocatedObjects",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      kAllocatedObjectsSize,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
 #if BUILDFLAG(IS_ANDROID)
@@ -182,6 +272,8 @@ const CobaltMemoryMetricsEmitter::Metric kAllocatorDumpNamesForMetrics[] = {
      "AndroidOtherPss",
      CobaltMemoryMetricsEmitter::MetricSize::kLarge,
      base::android::MeminfoDumpProvider::kPssMetricName,
+     nullptr,
+     CobaltMemoryMetricsEmitter::CalculationType::kValue,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
      {}},
 #endif
@@ -328,56 +420,49 @@ void CobaltMemoryMetricsEmitter::CollateResults() {
     private_footprint_swap_total_kb += pmd.os_dump().private_footprint_swap_kb;
     vm_size_total_kb += pmd.os_dump().vm_size_kb;
 
-    // Manually calculate fragmentation for individual processes as it may not
-    // be present in the dump.
-    const uint64_t blink_gc_bytes =
-        pmd.GetMetric("blink_gc", kEffectiveSize).value_or(0);
-    const uint64_t blink_gc_allocated_objects_bytes =
-        pmd.GetMetric("blink_gc", kAllocatedObjectsSize).value_or(0);
-    if (blink_gc_bytes > 0) {
-      uint64_t fragmentation =
-          (blink_gc_bytes > blink_gc_allocated_objects_bytes)
-              ? blink_gc_bytes - blink_gc_allocated_objects_bytes
-              : 0;
-      int fragmentation_pct =
-          static_cast<int>(fragmentation * 100 / blink_gc_bytes);
-      static const Metric kBlinkGCFragMetric = {
-          "blink_gc",      "BlinkGC.Fragmentation", MetricSize::kPercentage,
-          "fragmentation", EmitTo::kSizeInUmaOnly,  {}};
-      EmitProcessUma(ptype, kBlinkGCFragMetric, fragmentation_pct);
-    }
-
-    const uint64_t blink_gc_main_bytes =
-        pmd.GetMetric("blink_gc/main", kEffectiveSize).value_or(0);
-    const uint64_t blink_gc_main_allocated_objects_bytes =
-        pmd.GetMetric("blink_gc/main", kAllocatedObjectsSize).value_or(0);
-    if (blink_gc_main_bytes > 0) {
-      uint64_t fragmentation =
-          (blink_gc_main_bytes > blink_gc_main_allocated_objects_bytes)
-              ? blink_gc_main_bytes - blink_gc_main_allocated_objects_bytes
-              : 0;
-      int fragmentation_pct =
-          static_cast<int>(fragmentation * 100 / blink_gc_main_bytes);
-      static const Metric kBlinkGCMainFragMetric = {
-          "blink_gc/main",         "BlinkGC.Main.Heap.Fragmentation",
-          MetricSize::kPercentage, "fragmentation",
-          EmitTo::kSizeInUmaOnly,  {}};
-      EmitProcessUma(ptype, kBlinkGCMainFragMetric, fragmentation_pct);
-    }
-
     for (const auto& item : kAllocatorDumpNamesForMetrics) {
-      // Skip the standard metrics if we are overriding them with
-      // the more accurate RSS values below.
-      if ((std::string_view(item.uma_name) == "PartitionAlloc" ||
-           std::string_view(item.uma_name) == "V8" ||
-           std::string_view(item.uma_name) == "Malloc") &&
-          pmd.os_dump().detailed_stats_kb) {
+      std::optional<uint64_t> primary_value =
+          pmd.GetMetric(item.dump_name, item.metric);
+      if (!primary_value) {
         continue;
       }
-      std::optional<uint64_t> value =
-          pmd.GetMetric(item.dump_name, item.metric);
-      if (value) {
-        EmitProcessUma(ptype, item, value.value());
+
+      uint64_t final_value = 0;
+      bool valid = false;
+
+      switch (item.calculation) {
+        case CalculationType::kValue:
+          final_value = *primary_value;
+          valid = true;
+          break;
+        case CalculationType::kFragmentation: {
+          std::optional<uint64_t> secondary_value =
+              pmd.GetMetric(item.dump_name, item.secondary_metric);
+          if (secondary_value && *primary_value > 0) {
+            uint64_t diff = (*primary_value > *secondary_value)
+                                ? (*primary_value - *secondary_value)
+                                : 0;
+            final_value = static_cast<uint64_t>(diff * 100 / (*primary_value));
+            final_value = std::min(final_value, static_cast<uint64_t>(100));
+            valid = true;
+          }
+          break;
+        }
+        case CalculationType::kWasted: {
+          std::optional<uint64_t> secondary_value =
+              pmd.GetMetric(item.dump_name, item.secondary_metric);
+          if (secondary_value) {
+            final_value = (*primary_value > *secondary_value)
+                              ? (*primary_value - *secondary_value)
+                              : 0;
+            valid = true;
+          }
+          break;
+        }
+      }
+
+      if (valid) {
+        EmitProcessUma(ptype, item, final_value);
       }
     }
 
@@ -394,46 +479,46 @@ void CobaltMemoryMetricsEmitter::CollateResults() {
         static_cast<int>(pmd.os_dump().shared_footprint_kb / kKiB));
 
 #if BUILDFLAG(IS_ANDROID)
-    std::string prefix =
-        base::StrCat({kMemoryHistogramPrefix, process_name, "."});
-    std::string exp_prefix = base::StrCat(
-        {kExperimentalUmaPrefix, process_name, kVersionSuffixNormal});
+    if (pmd.os_dump().detailed_stats_kb) {
+      std::string prefix =
+          base::StrCat({kMemoryHistogramPrefix, process_name, "."});
+      std::string exp_prefix = base::StrCat(
+          {kExperimentalUmaPrefix, process_name, kVersionSuffixNormal});
 
-    auto get_detailed_stat = [&](const std::string& key) -> uint32_t {
-      if (!pmd.os_dump().detailed_stats_kb) {
-        return 0;
-      }
-      auto it = pmd.os_dump().detailed_stats_kb->find(key);
-      return (it != pmd.os_dump().detailed_stats_kb->end()) ? it->second : 0;
-    };
+      auto get_detailed_stat = [&](const std::string& key) -> uint32_t {
+        auto it = pmd.os_dump().detailed_stats_kb->find(key);
+        return (it != pmd.os_dump().detailed_stats_kb->end()) ? it->second : 0;
+      };
 
-    auto emit_accurate_rss = [&](const char* name, const std::string& key) {
-      uint32_t value_kb = get_detailed_stat(key);
-      base::UmaHistogramMemoryLargeMB(base::StrCat({prefix, name, "Rss"}),
-                                      static_cast<int>(value_kb / kKiB));
-      base::UmaHistogramMemoryLargeMB(base::StrCat({exp_prefix, name}),
-                                      static_cast<int>(value_kb / kKiB));
-    };
+      auto emit_accurate_rss = [&](const char* name, const std::string& key) {
+        uint32_t value_kb = get_detailed_stat(key);
+        base::UmaHistogramMemoryLargeMB(base::StrCat({prefix, name, "Rss"}),
+                                        static_cast<int>(value_kb / kKiB));
+        base::UmaHistogramMemoryLargeMB(
+            base::StrCat({exp_prefix, name, ".Rss"}),
+            static_cast<int>(value_kb / kKiB));
+      };
 
-    base::UmaHistogramMemoryLargeMB(
-        base::StrCat({prefix, "LibChrobaltPss"}),
-        static_cast<int>(get_detailed_stat("pss:cobalt_core") / kKiB));
-    base::UmaHistogramMemoryLargeMB(
-        base::StrCat({prefix, "LibChrobaltRss"}),
-        static_cast<int>(get_detailed_stat("rss:cobalt_core") / kKiB));
+      base::UmaHistogramMemoryLargeMB(
+          base::StrCat({prefix, "LibChrobaltPss"}),
+          static_cast<int>(get_detailed_stat("pss:cobalt_core") / kKiB));
+      base::UmaHistogramMemoryLargeMB(
+          base::StrCat({prefix, "LibChrobaltRss"}),
+          static_cast<int>(get_detailed_stat("rss:cobalt_core") / kKiB));
 
-    emit_accurate_rss("PartitionAlloc", "rss:partition_alloc");
-    emit_accurate_rss("Malloc", "rss:malloc");
-    emit_accurate_rss("CodeOther", "rss:code_other");
-    emit_accurate_rss("Fonts", "rss:fonts");
-    emit_accurate_rss("AshmemJit", "rss:ashmem_jit");
-    emit_accurate_rss("AndroidRuntime", "rss:android_runtime");
-    emit_accurate_rss("Stacks", "rss:stacks");
+      emit_accurate_rss("PartitionAlloc", "rss:partition_alloc");
+      emit_accurate_rss("Malloc", "rss:malloc");
+      emit_accurate_rss("CodeOther", "rss:code_other");
+      emit_accurate_rss("Fonts", "rss:fonts");
+      emit_accurate_rss("AshmemJit", "rss:ashmem_jit");
+      emit_accurate_rss("AndroidRuntime", "rss:android_runtime");
+      emit_accurate_rss("Stacks", "rss:stacks");
 
-    // Override V8 with accurate RSS.
-    base::UmaHistogramMemoryLargeMB(
-        base::StrCat({exp_prefix, "V8"}),
-        static_cast<int>(get_detailed_stat("rss:v8") / kKiB));
+      // Emit V8 accurate RSS as supplemental.
+      base::UmaHistogramMemoryLargeMB(
+          base::StrCat({exp_prefix, "V8.Rss"}),
+          static_cast<int>(get_detailed_stat("rss:v8") / kKiB));
+    }
 #endif
   }
 

--- a/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
@@ -325,10 +325,7 @@ void CobaltMemoryMetricsEmitter::CollateResults() {
     private_footprint_total_kb += pmd.os_dump().private_footprint_kb;
     shared_footprint_total_kb += pmd.os_dump().shared_footprint_kb;
     resident_set_total_kb += pmd.os_dump().resident_set_kb;
-#if !BUILDFLAG(IS_IOS_TVOS)
-    // TODO: b/497706115 - This field does not exist on tvOS.
     private_footprint_swap_total_kb += pmd.os_dump().private_footprint_swap_kb;
-#endif  // !BUILDFLAG(IS_IOS_TVOS)
     vm_size_total_kb += pmd.os_dump().vm_size_kb;
 
     // Manually calculate fragmentation for individual processes as it may not
@@ -369,6 +366,14 @@ void CobaltMemoryMetricsEmitter::CollateResults() {
     }
 
     for (const auto& item : kAllocatorDumpNamesForMetrics) {
+      // Skip the standard metrics if we are overriding them with
+      // the more accurate RSS values below.
+      if ((std::string_view(item.uma_name) == "PartitionAlloc" ||
+           std::string_view(item.uma_name) == "V8" ||
+           std::string_view(item.uma_name) == "Malloc") &&
+          pmd.os_dump().detailed_stats_kb) {
+        continue;
+      }
       std::optional<uint64_t> value =
           pmd.GetMetric(item.dump_name, item.metric);
       if (value) {
@@ -389,12 +394,46 @@ void CobaltMemoryMetricsEmitter::CollateResults() {
         static_cast<int>(pmd.os_dump().shared_footprint_kb / kKiB));
 
 #if BUILDFLAG(IS_ANDROID)
+    std::string prefix =
+        base::StrCat({kMemoryHistogramPrefix, process_name, "."});
+    std::string exp_prefix = base::StrCat(
+        {kExperimentalUmaPrefix, process_name, kVersionSuffixNormal});
+
+    auto get_detailed_stat = [&](const std::string& key) -> uint32_t {
+      if (!pmd.os_dump().detailed_stats_kb) {
+        return 0;
+      }
+      auto it = pmd.os_dump().detailed_stats_kb->find(key);
+      return (it != pmd.os_dump().detailed_stats_kb->end()) ? it->second : 0;
+    };
+
+    auto emit_accurate_rss = [&](const char* name, const std::string& key) {
+      uint32_t value_kb = get_detailed_stat(key);
+      base::UmaHistogramMemoryLargeMB(base::StrCat({prefix, name, "Rss"}),
+                                      static_cast<int>(value_kb / kKiB));
+      base::UmaHistogramMemoryLargeMB(base::StrCat({exp_prefix, name}),
+                                      static_cast<int>(value_kb / kKiB));
+    };
+
     base::UmaHistogramMemoryLargeMB(
-        std::string(kMemoryHistogramPrefix) + process_name + ".LibChrobaltPss",
-        static_cast<int>(pmd.os_dump().libchrobalt_pss_kb / kKiB));
+        base::StrCat({prefix, "LibChrobaltPss"}),
+        static_cast<int>(get_detailed_stat("pss:cobalt_core") / kKiB));
     base::UmaHistogramMemoryLargeMB(
-        std::string(kMemoryHistogramPrefix) + process_name + ".LibChrobaltRss",
-        static_cast<int>(pmd.os_dump().libchrobalt_rss_kb / kKiB));
+        base::StrCat({prefix, "LibChrobaltRss"}),
+        static_cast<int>(get_detailed_stat("rss:cobalt_core") / kKiB));
+
+    emit_accurate_rss("PartitionAlloc", "rss:partition_alloc");
+    emit_accurate_rss("Malloc", "rss:malloc");
+    emit_accurate_rss("CodeOther", "rss:code_other");
+    emit_accurate_rss("Fonts", "rss:fonts");
+    emit_accurate_rss("AshmemJit", "rss:ashmem_jit");
+    emit_accurate_rss("AndroidRuntime", "rss:android_runtime");
+    emit_accurate_rss("Stacks", "rss:stacks");
+
+    // Override V8 with accurate RSS.
+    base::UmaHistogramMemoryLargeMB(
+        base::StrCat({exp_prefix, "V8"}),
+        static_cast<int>(get_detailed_stat("rss:v8") / kKiB));
 #endif
   }
 

--- a/cobalt/browser/metrics/cobalt_memory_metrics_emitter.h
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_emitter.h
@@ -54,6 +54,12 @@ class CobaltMemoryMetricsEmitter
     kIgnored
   };
 
+  enum class CalculationType {
+    kValue,          // Direct value from dump
+    kFragmentation,  // (Value - SecondaryValue) / Value
+    kWasted,         // Value - SecondaryValue
+  };
+
   struct MetricRange {
     const int min;
     const int max;
@@ -64,6 +70,8 @@ class CobaltMemoryMetricsEmitter
     const char* const uma_name;
     const MetricSize metric_size;
     const char* const metric;
+    const char* const secondary_metric;
+    const CalculationType calculation;
     const EmitTo target;
     const MetricRange range;
   };

--- a/cobalt/browser/metrics/cobalt_memory_metrics_emitter_unittest.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_emitter_unittest.cc
@@ -1,0 +1,135 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/metrics/cobalt_memory_metrics_emitter.h"
+
+#include <memory>
+#include <vector>
+
+#include "base/memory/ref_counted.h"
+#include "base/test/metrics/histogram_tester.h"
+#include "base/test/task_environment.h"
+#include "base/trace_event/memory_dump_request_args.h"
+#include "build/build_config.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/global_memory_dump.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+
+class TestCobaltMemoryMetricsEmitter : public CobaltMemoryMetricsEmitter {
+ public:
+  TestCobaltMemoryMetricsEmitter() = default;
+  using CobaltMemoryMetricsEmitter::ReceivedMemoryDump;
+
+ protected:
+  ~TestCobaltMemoryMetricsEmitter() override = default;
+};
+
+class CobaltMemoryMetricsEmitterTest : public testing::Test {
+ public:
+  CobaltMemoryMetricsEmitterTest()
+      : task_environment_(base::test::TaskEnvironment::MainThreadType::UI) {}
+
+ protected:
+  base::test::TaskEnvironment task_environment_;
+};
+
+TEST_F(CobaltMemoryMetricsEmitterTest, CollateResults) {
+  base::HistogramTester histogram_tester;
+  auto emitter = base::MakeRefCounted<TestCobaltMemoryMetricsEmitter>();
+
+  memory_instrumentation::mojom::GlobalMemoryDumpPtr dump_ptr =
+      memory_instrumentation::mojom::GlobalMemoryDump::New();
+
+  // Browser process dump
+  auto browser_dump = memory_instrumentation::mojom::ProcessMemoryDump::New();
+  browser_dump->process_type =
+      memory_instrumentation::mojom::ProcessType::BROWSER;
+  browser_dump->os_dump = memory_instrumentation::mojom::OSMemDump::New();
+  browser_dump->os_dump->private_footprint_kb = 10240;  // 10 MB
+  browser_dump->os_dump->resident_set_kb = 20480;       // 20 MB
+  browser_dump->os_dump->shared_footprint_kb = 5120;    // 5 MB
+
+  // Normal value (kValue)
+  auto malloc_dump = memory_instrumentation::mojom::AllocatorMemDump::New();
+  malloc_dump->numeric_entries["effective_size"] = 10 * 1024 * 1024;
+  browser_dump->chrome_allocator_dumps["malloc"] = std::move(malloc_dump);
+
+  // Fragmentation (kFragmentation) - Normal
+  auto blink_gc_dump = memory_instrumentation::mojom::AllocatorMemDump::New();
+  blink_gc_dump->numeric_entries["effective_size"] = 1000;
+  blink_gc_dump->numeric_entries["allocated_objects_size"] = 600;
+  browser_dump->chrome_allocator_dumps["blink_gc"] = std::move(blink_gc_dump);
+
+  // Fragmentation (kFragmentation) - Clamping (Allocated > Effective)
+  auto pa_fast_malloc_dump =
+      memory_instrumentation::mojom::AllocatorMemDump::New();
+  pa_fast_malloc_dump->numeric_entries["effective_size"] = 1000;
+  pa_fast_malloc_dump->numeric_entries["allocated_objects_size"] = 1200;
+  browser_dump
+      ->chrome_allocator_dumps["partition_alloc/partitions/fast_malloc"] =
+      std::move(pa_fast_malloc_dump);
+
+  // Missing secondary metric for fragmentation - Should skip
+  auto renderer_dump = memory_instrumentation::mojom::ProcessMemoryDump::New();
+  renderer_dump->process_type =
+      memory_instrumentation::mojom::ProcessType::RENDERER;
+  renderer_dump->os_dump = memory_instrumentation::mojom::OSMemDump::New();
+  auto renderer_blink_gc_dump =
+      memory_instrumentation::mojom::AllocatorMemDump::New();
+  renderer_blink_gc_dump->numeric_entries["effective_size"] = 1000;
+  // missing "allocated_objects_size"
+  renderer_dump->chrome_allocator_dumps["blink_gc"] =
+      std::move(renderer_blink_gc_dump);
+  dump_ptr->process_dumps.push_back(std::move(renderer_dump));
+
+#if BUILDFLAG(IS_ANDROID)
+  browser_dump->os_dump->detailed_stats_kb = {
+      {"rss:partition_alloc", 16384},
+  };
+#endif
+
+  dump_ptr->process_dumps.push_back(std::move(browser_dump));
+
+  auto global_dump =
+      memory_instrumentation::GlobalMemoryDump::MoveFrom(std::move(dump_ptr));
+
+  emitter->ReceivedMemoryDump(true, std::move(global_dump));
+
+  // Verify kValue
+  histogram_tester.ExpectUniqueSample("Memory.Experimental.Browser2.Malloc", 10,
+                                      1);
+
+  // Verify kFragmentation - Normal ( (1000-600)/1000 = 40% )
+  histogram_tester.ExpectUniqueSample(
+      "Memory.Experimental.Browser2.BlinkGC.Fragmentation", 40, 1);
+
+  // Verify kFragmentation - Clamping ( (1000-1200) -> 0% )
+  histogram_tester.ExpectUniqueSample(
+      "Memory.Experimental.Browser2.PartitionAlloc.Fragmentation.FastMalloc", 0,
+      1);
+
+  // Verify missing secondary metric for renderer blink_gc.Fragmentation was
+  // skipped.
+  histogram_tester.ExpectTotalCount(
+      "Memory.Experimental.Renderer2.BlinkGC.Fragmentation", 0);
+
+#if BUILDFLAG(IS_ANDROID)
+  // Verify supplemental RSS (instead of override)
+  histogram_tester.ExpectUniqueSample(
+      "Memory.Experimental.Browser2.PartitionAlloc.Rss", 16, 1);
+#endif
+}
+
+}  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -117,12 +117,21 @@ IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest, MAYBE_RecordsMemoryMetrics) {
   check_histogram("Memory.Experimental.Browser2.Small.UI");
   check_histogram("Memory.Experimental.Browser2.Tiny.NumberOfDocuments");
   check_histogram("Memory.Experimental.Browser2.Tiny.NumberOfFrames");
-  check_histogram("Memory.Experimental.Browser2.Tiny.NumberOfLayoutObjects");
-  check_histogram("Memory.Experimental.Browser2.Small.NumberOfNodes");
+  EXPECT_TRUE(check_histogram(
+      "Memory.Experimental.Browser2.Tiny.NumberOfLayoutObjects"));
+  EXPECT_TRUE(
+      check_histogram("Memory.Experimental.Browser2.Small.NumberOfNodes"));
 
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
-  check_histogram("Memory.Browser.LibChrobaltPss");
-  check_histogram("Memory.Browser.LibChrobaltRss");
+#if BUILDFLAG(IS_ANDROID)
+  EXPECT_TRUE(check_histogram("Memory.Browser.LibChrobaltPss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.LibChrobaltRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.PartitionAllocRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.MallocRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.AshmemJitRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.CodeOtherRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.FontsRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.AndroidRuntimeRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.StacksRss"));
 #endif
 }
 
@@ -194,9 +203,16 @@ IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
   check_histogram("Memory.Experimental.Browser2.V8");
   check_histogram("Memory.Experimental.Browser2.Skia");
 
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
-  check_histogram("Memory.Browser.LibChrobaltPss");
-  check_histogram("Memory.Browser.LibChrobaltRss");
+#if BUILDFLAG(IS_ANDROID)
+  EXPECT_TRUE(check_histogram("Memory.Browser.LibChrobaltPss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.LibChrobaltRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.PartitionAllocRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.MallocRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.AshmemJitRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.CodeOtherRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.FontsRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.AndroidRuntimeRss"));
+  EXPECT_TRUE(check_histogram("Memory.Browser.StacksRss"));
 #endif
 }
 

--- a/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
@@ -76,6 +76,15 @@ class TestProcessMemoryMetricsEmitter : public CobaltMemoryMetricsEmitter {
     browser_dump->os_dump->private_footprint_kb = 10240;  // 10 MB
     browser_dump->os_dump->resident_set_kb = 20480;       // 20 MB
     browser_dump->os_dump->shared_footprint_kb = 5120;    // 5 MB
+#if BUILDFLAG(IS_ANDROID)
+    browser_dump->os_dump->detailed_stats_kb = {
+        {"rss:partition_alloc", 16384},
+        {"rss:malloc", 10240},
+        {"rss:v8", 12288},
+        {"rss:cobalt_core", 10240},
+        {"pss:cobalt_core", 8192},
+    };
+#endif
 
     // Add a blink_gc dump
     auto blink_gc_dump = memory_instrumentation::mojom::AllocatorMemDump::New();
@@ -185,6 +194,9 @@ class TestProcessMemoryMetricsEmitter : public CobaltMemoryMetricsEmitter {
         memory_instrumentation::mojom::ProcessType::RENDERER;
     renderer_dump->os_dump = memory_instrumentation::mojom::OSMemDump::New();
     renderer_dump->os_dump->private_footprint_kb = 20480;  // 20 MB
+#if BUILDFLAG(IS_ANDROID)
+    renderer_dump->os_dump->detailed_stats_kb = {{"rss:partition_alloc", 2048}};
+#endif
 
     auto renderer_blink_gc_dump =
         memory_instrumentation::mojom::AllocatorMemDump::New();
@@ -482,6 +494,22 @@ TEST_F(CobaltMetricsServiceClientTest, RecordMemoryMetricsRecordsHistogram) {
           .size(),
       1u);
 
+#if BUILDFLAG(IS_ANDROID)
+  EXPECT_GT(histogram_tester.GetBucketCount(
+                "Memory.Experimental.Browser2.Malloc", 10),
+            0);
+  EXPECT_GT(histogram_tester.GetBucketCount(
+                "Memory.Experimental.Browser2.PartitionAlloc", 16),
+            0);
+  EXPECT_GT(
+      histogram_tester.GetBucketCount("Memory.Experimental.Browser2.V8", 12),
+      0);
+  EXPECT_GT(histogram_tester.GetBucketCount("Memory.Browser.LibChrobaltPss", 8),
+            0);
+  EXPECT_GT(
+      histogram_tester.GetBucketCount("Memory.Browser.LibChrobaltRss", 10), 0);
+#endif
+
   EXPECT_GT(histogram_tester.GetBucketCount(
                 "Memory.Experimental.Browser2.Tiny.NumberOfDocuments", 3),
             0);
@@ -504,13 +532,7 @@ TEST_F(CobaltMetricsServiceClientTest, RecordMemoryMetricsRecordsHistogram) {
                 "Memory.Experimental.Browser2.Small.LevelDatabase", 512),
             0);
   EXPECT_GT(histogram_tester.GetBucketCount(
-                "Memory.Experimental.Browser2.Malloc", 10),
-            0);
-  EXPECT_GT(histogram_tester.GetBucketCount(
                 "Memory.Experimental.Browser2.Malloc.AllocatedObjects", 8),
-            0);
-  EXPECT_GT(histogram_tester.GetBucketCount(
-                "Memory.Experimental.Browser2.PartitionAlloc", 16),
             0);
   EXPECT_GT(
       histogram_tester.GetBucketCount(
@@ -528,9 +550,6 @@ TEST_F(CobaltMetricsServiceClientTest, RecordMemoryMetricsRecordsHistogram) {
   EXPECT_GT(histogram_tester.GetBucketCount(
                 "Memory.Experimental.Browser2.Small.UI", 2),
             0);
-  EXPECT_GT(
-      histogram_tester.GetBucketCount("Memory.Experimental.Browser2.V8", 12),
-      0);
   EXPECT_GT(histogram_tester.GetBucketCount(
                 "Memory.Experimental.Browser2.V8.AllocatedObjects", 10),
             0);

--- a/services/resource_coordinator/BUILD.gn
+++ b/services/resource_coordinator/BUILD.gn
@@ -51,6 +51,7 @@ source_set("tests") {
     "memory_instrumentation/memory_dump_map_converter_unittest.cc",
     "public/cpp/memory_instrumentation/memory_instrumentation_mojom_traits_unittest.cc",
     "public/cpp/memory_instrumentation/os_metrics_unittest.cc",
+    "public/cpp/memory_instrumentation/smaps_categorizer_unittest.cc",
     "public/cpp/memory_instrumentation/tracing_integration_unittest.cc",
     "public/cpp/memory_instrumentation/tracing_observer_proto_unittest.cc",
   ]

--- a/services/resource_coordinator/memory_instrumentation/queued_request.cc
+++ b/services/resource_coordinator/memory_instrumentation/queued_request.cc
@@ -56,7 +56,11 @@ base::trace_event::MemoryDumpRequestArgs QueuedRequest::GetRequestArgs() {
 
 std::vector<mojom::MemDumpFlags> QueuedRequest::memory_dump_flags() const {
   if (!args.memory_footprint_only) {
-    return base::ToVector(OSMetrics::MemDumpFlagSet::All());
+    auto flags = OSMetrics::MemDumpFlagSet::All();
+    if (args.level_of_detail != MemoryDumpLevelOfDetail::kDetailed) {
+      flags.Remove(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS);
+    }
+    return base::ToVector(flags);
   }
   return {};
 }

--- a/services/resource_coordinator/memory_instrumentation/queued_request_dispatcher.cc
+++ b/services/resource_coordinator/memory_instrumentation/queued_request_dispatcher.cc
@@ -87,13 +87,12 @@ memory_instrumentation::mojom::OSMemDumpPtr CreatePublicOSDump(
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
   os_dump->private_footprint_swap_kb =
       internal_os_dump.platform_private_footprint->vm_swap_bytes / 1024;
-#if BUILDFLAG(IS_COBALT) && (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID))
-  os_dump->libchrobalt_pss_kb = internal_os_dump.libchrobalt_pss_kb;
-  os_dump->libchrobalt_rss_kb = internal_os_dump.libchrobalt_rss_kb;
-#endif
   os_dump->mappings_count = internal_os_dump.mappings_count;
   os_dump->pss_kb = internal_os_dump.pss_kb;
   os_dump->swap_pss_kb = internal_os_dump.swap_pss_kb;
+
+  os_dump->detailed_stats_kb = internal_os_dump.detailed_stats_kb;
+  os_dump->last_detailed_dump_time = internal_os_dump.last_detailed_dump_time;
 #endif
   return os_dump;
 }

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/BUILD.gn
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/BUILD.gn
@@ -6,6 +6,7 @@ component("memory_instrumentation") {
   sources = [
     "client_process_impl.cc",
     "client_process_impl.h",
+    "detailed_metrics_delegate.h",
     "global_memory_dump.cc",
     "global_memory_dump.h",
     "memory_instrumentation.cc",
@@ -13,6 +14,8 @@ component("memory_instrumentation") {
     "os_metrics.cc",
     "os_metrics.h",
     "registry.h",
+    "smaps_categorizer.cc",
+    "smaps_categorizer.h",
     "tracing_observer.cc",
     "tracing_observer.h",
     "tracing_observer_proto.cc",

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
@@ -5,6 +5,8 @@
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.h"
 
 #include "base/containers/flat_map.h"
+#include "base/files/file.h"
+#include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/process/process.h"
@@ -12,12 +14,21 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/trace_event/memory_dump_request_args.h"
 #include "build/build_config.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/tracing_observer_proto.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
 
 namespace memory_instrumentation {
+
+namespace {
+
+ClientProcessImpl* g_client_process_impl = nullptr;
+constexpr base::TimeDelta kDetailedDumpThrottle = base::Minutes(30);
+
+}  // namespace
 
 struct ClientProcessImpl::OSMemoryDumpArgs {
   OSMemoryDumpArgs();
@@ -44,8 +55,23 @@ void ClientProcessImpl::CreateInstance(
     instance = new ClientProcessImpl(
         std::move(receiver), std::move(coordinator), is_browser_process,
         /*initialize_memory_instrumentation=*/true);
+    g_client_process_impl = instance;
   } else {
     NOTREACHED();
+  }
+}
+
+// static
+void ClientProcessImpl::SetDetailedMetricsDelegate(
+    DetailedMetricsDelegate* delegate) {
+  if (g_client_process_impl) {
+    g_client_process_impl->detailed_metrics_delegate_ = delegate;
+    if (delegate) {
+      g_client_process_impl->detailed_metrics_harness_ =
+          std::make_unique<SmapsCategorizer>(delegate);
+    } else {
+      g_client_process_impl->detailed_metrics_harness_.reset();
+    }
   }
 }
 
@@ -181,6 +207,8 @@ void ClientProcessImpl::RequestOSMemoryDump(
 void ClientProcessImpl::PerformOSMemoryDump(OSMemoryDumpArgs args) {
   bool global_success = true;
   base::flat_map<base::ProcessId, mojom::RawOSMemDumpPtr> results;
+  mojom::RawOSMemDump* self_dump = nullptr;
+
   for (const base::ProcessId& pid : args.pids) {
     auto handle = base::Process::Open(pid).Handle();
     mojom::RawOSMemDumpPtr result = mojom::RawOSMemDump::New();
@@ -192,11 +220,46 @@ void ClientProcessImpl::PerformOSMemoryDump(OSMemoryDumpArgs args) {
                                handle, args.mmap_option, result.get());
     }
     if (success) {
+      if (pid == base::GetCurrentProcId() || pid == base::kNullProcessId) {
+        self_dump = result.get();
+      }
       results[pid] = std::move(result);
     } else {
       DLOG(ERROR) << "OS memory dump failed for pid " << pid;
     }
     global_success = global_success && success;
+  }
+
+  bool trigger_detailed_dump =
+      args.flags.Has(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS) &&
+      self_dump && detailed_metrics_harness_ &&
+      (base::TimeTicks::Now() - last_detailed_dump_time_ >=
+       kDetailedDumpThrottle);
+
+  if (trigger_detailed_dump) {
+    std::vector<char> buffer;
+    if (OSMetrics::ReadDetailedMetricsFile(&buffer)) {
+      detailed_metrics_harness_->Start(
+          std::move(buffer), self_dump,
+          base::BindOnce(&ClientProcessImpl::OnDetailedDumpDone,
+                         weak_ptr_factory_.GetWeakPtr(), std::move(args),
+                         std::move(results), global_success));
+      return;
+    }
+    // If snapshot fails or self-dump is missing, just continue without
+    // detailed stats.
+  }
+
+  std::move(args.callback).Run(global_success, std::move(results));
+}
+
+void ClientProcessImpl::OnDetailedDumpDone(
+    OSMemoryDumpArgs args,
+    base::flat_map<base::ProcessId, mojom::RawOSMemDumpPtr> results,
+    bool global_success,
+    bool success) {
+  if (success) {
+    last_detailed_dump_time_ = base::TimeTicks::Now();
   }
   std::move(args.callback).Run(global_success, std::move(results));
 }

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
@@ -26,6 +26,10 @@ namespace memory_instrumentation {
 namespace {
 
 ClientProcessImpl* g_client_process_impl = nullptr;
+
+// How often we should collect detailed memory metrics. 30 minutes is chosen
+// as a balance between providing observability and minimizing overhead from
+// parsing smaps.
 constexpr base::TimeDelta kDetailedDumpThrottle = base::Minutes(30);
 
 }  // namespace
@@ -50,27 +54,31 @@ void ClientProcessImpl::CreateInstance(
   if (!is_browser_process)
     coordinator.reset();
 
-  static ClientProcessImpl* instance = nullptr;
-  if (!instance) {
-    instance = new ClientProcessImpl(
+  if (!g_client_process_impl) {
+    g_client_process_impl = new ClientProcessImpl(
         std::move(receiver), std::move(coordinator), is_browser_process,
         /*initialize_memory_instrumentation=*/true);
-    g_client_process_impl = instance;
   } else {
     NOTREACHED();
   }
 }
 
 // static
+ClientProcessImpl* ClientProcessImpl::GetInstance() {
+  return g_client_process_impl;
+}
+
+// static
 void ClientProcessImpl::SetDetailedMetricsDelegate(
     DetailedMetricsDelegate* delegate) {
-  if (g_client_process_impl) {
-    g_client_process_impl->detailed_metrics_delegate_ = delegate;
+  ClientProcessImpl* instance = GetInstance();
+  if (instance) {
+    instance->detailed_metrics_delegate_ = delegate;
     if (delegate) {
-      g_client_process_impl->detailed_metrics_harness_ =
+      instance->detailed_metrics_harness_ =
           std::make_unique<SmapsCategorizer>(delegate);
     } else {
-      g_client_process_impl->detailed_metrics_harness_.reset();
+      instance->detailed_metrics_harness_.reset();
     }
   }
 }
@@ -246,8 +254,6 @@ void ClientProcessImpl::PerformOSMemoryDump(OSMemoryDumpArgs args) {
                          std::move(results), global_success));
       return;
     }
-    // If snapshot fails or self-dump is missing, just continue without
-    // detailed stats.
   }
 
   std::move(args.callback).Run(global_success, std::move(results));

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.h
@@ -6,6 +6,8 @@
 #define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_CLIENT_PROCESS_IMPL_H_
 
 #include "base/compiler_specific.h"
+#include "base/memory/raw_ptr.h"
+
 #include "base/component_export.h"
 #include "base/synchronization/lock.h"
 #include "base/task/single_thread_task_runner.h"
@@ -18,6 +20,9 @@
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
 
 namespace memory_instrumentation {
+
+class DetailedMetricsDelegate;
+class SmapsCategorizer;
 
 // This is the bridge between MemoryDumpManager and the Coordinator service.
 // This indirection is needed to avoid a dependency from //base, where
@@ -34,6 +39,8 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
       mojo::PendingReceiver<mojom::ClientProcess> receiver,
       mojo::PendingRemote<mojom::Coordinator> coordinator,
       bool is_browser_process = false);
+
+  static void SetDetailedMetricsDelegate(DetailedMetricsDelegate* delegate);
 
   ClientProcessImpl(const ClientProcessImpl&) = delete;
   ClientProcessImpl& operator=(const ClientProcessImpl&) = delete;
@@ -74,6 +81,12 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
   struct OSMemoryDumpArgs;
   void PerformOSMemoryDump(OSMemoryDumpArgs args);
 
+  void OnDetailedDumpDone(
+      OSMemoryDumpArgs args,
+      base::flat_map<base::ProcessId, mojom::RawOSMemDumpPtr> results,
+      bool global_success,
+      bool success);
+
   // Map containing pending chrome memory callbacks indexed by dump guid.
   // This must be destroyed after |binding_|.
   std::map<uint64_t, RequestChromeMemoryDumpCallback> pending_chrome_callbacks_;
@@ -91,8 +104,15 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
   mojo::Remote<mojom::Coordinator> coordinator_;
   scoped_refptr<base::SingleThreadTaskRunner> task_runner_;
 
+  raw_ptr<DetailedMetricsDelegate> detailed_metrics_delegate_ = nullptr;
+
+  std::unique_ptr<SmapsCategorizer> detailed_metrics_harness_;
+  base::TimeTicks last_detailed_dump_time_;
+
   // Only browser process is allowed to request memory dumps.
   const bool is_browser_process_;
+
+  base::WeakPtrFactory<ClientProcessImpl> weak_ptr_factory_{this};
 };
 
 }  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.h
@@ -40,6 +40,8 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
       mojo::PendingRemote<mojom::Coordinator> coordinator,
       bool is_browser_process = false);
 
+  static ClientProcessImpl* GetInstance();
+
   static void SetDetailedMetricsDelegate(DetailedMetricsDelegate* delegate);
 
   ClientProcessImpl(const ClientProcessImpl&) = delete;

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
@@ -1,0 +1,34 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_
+#define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_
+
+#include <cstdint>
+#include <string>
+
+#include "base/containers/flat_map.h"
+#include "third_party/abseil-cpp/absl/strings/string_view.h"
+
+namespace memory_instrumentation {
+
+// Interface for project-specific detailed memory metrics collection.
+// The harness (SmapsCategorizer) reads /proc/self/smaps and passes each
+// mapping line to the registered delegate for categorization.
+class DetailedMetricsDelegate {
+ public:
+  virtual ~DetailedMetricsDelegate() = default;
+
+  // Called for each line in /proc/self/smaps. The |line| view is only valid
+  // for the duration of this call.
+  virtual void OnSmapsLine(absl::string_view line) = 0;
+
+  // Called after all lines have been processed to retrieve the aggregated
+  // metrics and reset internal counters for the next dump.
+  virtual base::flat_map<std::string, uint32_t> GetAndResetStats() = 0;
+};
+
+}  // namespace memory_instrumentation
+
+#endif  // SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
@@ -20,9 +20,11 @@ class DetailedMetricsDelegate {
  public:
   virtual ~DetailedMetricsDelegate() = default;
 
-  // Called for each line in /proc/self/smaps. The |line| view is only valid
-  // for the duration of this call.
-  virtual void OnSmapsLine(absl::string_view line) = 0;
+  // Called for each header line (hex address range) in /proc/self/smaps.
+  virtual void OnSmapsHeader(absl::string_view line) = 0;
+
+  // Called for each memory counter line (e.g. "Pss:  12 kB") in /proc/self/smaps.
+  virtual void OnSmapsCounter(absl::string_view name, uint64_t value_kb) = 0;
 
   // Called after all lines have been processed to retrieve the aggregated
   // metrics and reset internal counters for the next dump.

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
@@ -66,6 +66,12 @@ class COMPONENT_EXPORT(
       base::ProcessHandle);
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
+  static bool ReadDetailedMetricsFile(std::vector<char>* buffer);
+#else
+  static bool ReadDetailedMetricsFile(std::vector<char>* buffer) { return false; }
+#endif
+
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
   static void SetProcSmapsForTesting(FILE*);
 #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
         // BUILDFLAG(IS_ANDROID)

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
@@ -73,6 +73,15 @@ class COMPONENT_EXPORT(
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
   static void SetProcSmapsForTesting(FILE*);
+
+  enum class DetailedDumpAbortReason {
+    kSuccess = 0,
+    kSnapshotLimitHit = 1,
+    kSmapsFileOpenFailed = 2,
+    kSmapsFileReadFailed = 3,
+    kSmapsValidationFailed = 4,
+    kMaxValue = kSmapsValidationFailed
+  };
 #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
         // BUILDFLAG(IS_ANDROID)
 

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -469,6 +469,25 @@ std::vector<VmRegionPtr> OSMetrics::GetProcessMemoryMaps(
 }
 
 // static
+bool OSMetrics::ReadDetailedMetricsFile(std::vector<char>* buffer) {
+  base::FilePath path("/proc/self/smaps");
+  base::File file(path, base::File::FLAG_OPEN | base::File::FLAG_READ);
+  if (!file.IsValid())
+    return false;
+
+  const size_t kMaxSnapshotSize = 5 * 1024 * 1024;
+  buffer->resize(kMaxSnapshotSize);
+  auto bytes_read = file.ReadAtCurrentPos(base::as_writable_byte_span(*buffer));
+
+  if (bytes_read.has_value() && bytes_read.value() > 0 &&
+      bytes_read.value() < kMaxSnapshotSize) {
+    buffer->resize(bytes_read.value());
+    return true;
+  }
+  return false;
+}
+
+// static
 OSMetrics::MappedAndResidentPagesDumpState OSMetrics::GetMappedAndResidentPages(
     const size_t start_address,
     const size_t end_address,

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -322,6 +322,10 @@ void GetSmapsRollup(uint32_t* pss, uint32_t* swap_pss) {
   *swap_pss = value->swap_pss;
 }
 
+void RecordDetailedDumpAbortReason(OSMetrics::DetailedDumpAbortReason reason) {
+  base::UmaHistogramEnumeration("Memory.DetailedDump.AbortReason", reason);
+}
+
 }  // namespace
 
 FILE* g_proc_smaps_for_testing = nullptr;
@@ -413,19 +417,42 @@ std::vector<VmRegionPtr> OSMetrics::GetProcessMemoryMaps(
 bool OSMetrics::ReadDetailedMetricsFile(std::vector<char>* buffer) {
   base::FilePath path("/proc/self/smaps");
   base::File file(path, base::File::FLAG_OPEN | base::File::FLAG_READ);
-  if (!file.IsValid())
+  if (!file.IsValid()) {
+    RecordDetailedDumpAbortReason(OSMetrics::DetailedDumpAbortReason::kSmapsFileOpenFailed);
     return false;
-
-  const size_t kMaxSnapshotSize = 5 * 1024 * 1024;
-  buffer->resize(kMaxSnapshotSize);
-  auto bytes_read = file.ReadAtCurrentPos(base::as_writable_byte_span(*buffer));
-
-  if (bytes_read.has_value() && bytes_read.value() > 0 &&
-      bytes_read.value() < kMaxSnapshotSize) {
-    buffer->resize(bytes_read.value());
-    return true;
   }
-  return false;
+
+  // 8MB limit to be safe, but we read incrementally.
+  const size_t kMaxSnapshotSize = 8 * 1024 * 1024;
+  const size_t kInitialBufferSize = 1 * 1024 * 1024;
+  buffer->reserve(kInitialBufferSize);
+
+  char chunk[4096];
+  while (true) {
+    auto bytes_read = file.ReadAtCurrentPos(base::as_writable_byte_span(chunk));
+    if (!bytes_read.has_value()) {
+      RecordDetailedDumpAbortReason(OSMetrics::DetailedDumpAbortReason::kSmapsFileReadFailed);
+      return false;
+    }
+    if (bytes_read.value() == 0) {
+      break;
+    }
+
+    if (buffer->size() + bytes_read.value() > kMaxSnapshotSize) {
+      RecordDetailedDumpAbortReason(OSMetrics::DetailedDumpAbortReason::kSnapshotLimitHit);
+      return false;
+    }
+
+    buffer->insert(buffer->end(), chunk, chunk + bytes_read.value());
+  }
+
+  if (buffer->empty()) {
+    RecordDetailedDumpAbortReason(OSMetrics::DetailedDumpAbortReason::kSmapsFileReadFailed);
+    return false;
+  }
+
+  RecordDetailedDumpAbortReason(OSMetrics::DetailedDumpAbortReason::kSuccess);
+  return true;
 }
 
 // static

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -21,11 +21,13 @@
 #include "base/containers/heap_array.h"
 #include "base/debug/elf_reader.h"
 #include "base/debug/proc_maps_linux.h"
+#include "base/files/file.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/files/scoped_file.h"
 #include "base/format_macros.h"
 #include "base/memory/page_size.h"
+#include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/process/process_handle.h"
 #include "base/process/process_metrics.h"
@@ -320,61 +322,6 @@ void GetSmapsRollup(uint32_t* pss, uint32_t* swap_pss) {
   *swap_pss = value->swap_pss;
 }
 
-#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_ANDROID)
-struct LibChrobaltMem {
-  uint32_t pss_kb = 0;
-  uint32_t rss_kb = 0;
-};
-
-LibChrobaltMem GetLibChrobaltMem(base::ProcessId pid) {
-  std::string file_name =
-      "/proc/" +
-      (pid == base::kNullProcessId ? "self" : base::NumberToString(pid)) +
-      "/smaps";
-  base::ScopedFILE smaps_file(fopen(file_name.c_str(), "r"));
-  if (!smaps_file) {
-    return {};
-  }
-
-  char line[kMaxLineSize];
-  uint64_t total_pss_kb = 0;
-  uint64_t total_rss_kb = 0;
-  bool is_libchrobalt_region = false;
-  while (fgets(line, kMaxLineSize, smaps_file.get())) {
-    if (absl::ascii_isxdigit(static_cast<unsigned char>(line[0])) &&
-        !absl::ascii_isupper(static_cast<unsigned char>(line[0]))) {
-      const char kLibName[] = "libchrobalt.so";
-      const char* found = strstr(line, kLibName);
-      if (found) {
-        bool prefix_matches = (found == line || *(found - 1) == '/');
-        char next_char = found[strlen(kLibName)];
-        bool suffix_matches =
-            (next_char == '\0' || next_char == '\n' || next_char == '\r' ||
-             absl::ascii_isspace(static_cast<unsigned char>(next_char)));
-        is_libchrobalt_region = prefix_matches && suffix_matches;
-      } else {
-        is_libchrobalt_region = false;
-      }
-    } else if (is_libchrobalt_region) {
-      uint64_t value_kb = 0;
-      if (strncmp(line, "Pss:", 4) == 0) {
-        if (sscanf(line, "Pss: %" SCNu64 " kB", &value_kb) == 1) {
-          total_pss_kb += value_kb;
-        }
-      } else if (strncmp(line, "Rss:", 4) == 0) {
-        if (sscanf(line, "Rss: %" SCNu64 " kB", &value_kb) == 1) {
-          total_rss_kb += value_kb;
-        }
-      }
-    }
-  }
-  LibChrobaltMem result;
-  result.pss_kb = base::saturated_cast<uint32_t>(total_pss_kb);
-  result.rss_kb = base::saturated_cast<uint32_t>(total_rss_kb);
-  return result;
-}
-#endif
-
 }  // namespace
 
 FILE* g_proc_smaps_for_testing = nullptr;
@@ -399,12 +346,6 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
       base::saturated_cast<uint32_t>(info->resident_set_bytes / 1024);
   dump->peak_resident_set_kb = GetPeakResidentSetSize(handle);
   dump->is_peak_rss_resettable = ResetPeakRSSIfPossible(handle);
-
-#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_ANDROID)
-  LibChrobaltMem lib_mem = GetLibChrobaltMem(handle);
-  dump->libchrobalt_pss_kb = lib_mem.pss_kb;
-  dump->libchrobalt_rss_kb = lib_mem.rss_kb;
-#endif
 
   if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_COUNT_MAPPINGS)) {
     dump->mappings_count = CountMappings(handle);

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -320,7 +320,7 @@ void GetSmapsRollup(uint32_t* pss, uint32_t* swap_pss) {
   *swap_pss = value->swap_pss;
 }
 
-#if BUILDFLAG(IS_COBALT) && (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID))
+#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_ANDROID)
 struct LibChrobaltMem {
   uint32_t pss_kb = 0;
   uint32_t rss_kb = 0;
@@ -400,7 +400,7 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
   dump->peak_resident_set_kb = GetPeakResidentSetSize(handle);
   dump->is_peak_rss_resettable = ResetPeakRSSIfPossible(handle);
 
-#if BUILDFLAG(IS_COBALT) && (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID))
+#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_ANDROID)
   LibChrobaltMem lib_mem = GetLibChrobaltMem(handle);
   dump->libchrobalt_pss_kb = lib_mem.pss_kb;
   dump->libchrobalt_rss_kb = lib_mem.rss_kb;

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.cc
@@ -7,12 +7,14 @@
 #include <cmath>
 
 #include "base/containers/flat_map.h"
+#include "base/metrics/histogram_functions.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/strings/string_split.h"
 #include "base/strings/string_util.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/time/time.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h"
 #include "third_party/abseil-cpp/absl/strings/ascii.h"
 #include "third_party/abseil-cpp/absl/strings/match.h"
 #include "third_party/abseil-cpp/absl/strings/numbers.h"
@@ -34,6 +36,9 @@ SmapsCategorizer::~SmapsCategorizer() = default;
 void SmapsCategorizer::Start(std::vector<char> buffer,
                              mojom::RawOSMemDump* dump,
                              DoneCallback callback) {
+  if (done_callback_) {
+    std::move(done_callback_).Run(false);
+  }
   weak_ptr_factory_.InvalidateWeakPtrs();
   buffer_ = std::move(buffer);
   dump_ = dump;
@@ -56,16 +61,28 @@ void SmapsCategorizer::ParseNextChunk() {
                                  ? content.substr(current_pos_)
                                  : content.substr(current_pos_, line_end - current_pos_);
 
-    if (delegate_) {
-      delegate_->OnSmapsLine(line);
-    }
-
-    if (absl::StartsWith(line, "Pss:")) {
-      absl::string_view value_part = absl::StripPrefix(line, "Pss:");
-      value_part = absl::StripSuffix(value_part, " kB");
-      uint64_t value_kb = 0;
-      if (absl::SimpleAtoi(absl::StripAsciiWhitespace(value_part), &value_kb)) {
-        total_pss_kb_ += value_kb;
+    // Check if it's a header line (starts with hex address range).
+    if (absl::ascii_isxdigit(static_cast<unsigned char>(line[0]))) {
+      if (delegate_) {
+        delegate_->OnSmapsHeader(line);
+      }
+    } else {
+      // Check if it's a counter line (e.g. "Pss:  12 kB").
+      size_t colon_pos = line.find(':');
+      if (colon_pos != absl::string_view::npos) {
+        absl::string_view name = line.substr(0, colon_pos);
+        absl::string_view value_part = line.substr(colon_pos + 1);
+        value_part = absl::StripAsciiWhitespace(value_part);
+        value_part = absl::StripSuffix(value_part, " kB");
+        uint64_t value_kb = 0;
+        if (absl::SimpleAtoi(value_part, &value_kb)) {
+          if (name == "Pss") {
+            total_pss_kb_ += value_kb;
+          }
+          if (delegate_) {
+            delegate_->OnSmapsCounter(name, value_kb);
+          }
+        }
       }
     }
 
@@ -95,6 +112,8 @@ void SmapsCategorizer::ParseNextChunk() {
         DLOG(WARNING) << "Smaps snapshot validation failed. Snapshot PSS: "
                       << total_pss_kb_ << " KB, Rollup PSS: " << dump_->pss_kb
                       << " KB";
+        base::UmaHistogramEnumeration("Memory.DetailedDump.AbortReason",
+                                      OSMetrics::DetailedDumpAbortReason::kSmapsValidationFailed);
       }
     }
 

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.cc
@@ -1,0 +1,116 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.h"
+
+#include <cmath>
+
+#include "base/containers/flat_map.h"
+#include "base/numerics/safe_conversions.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/time/time.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "third_party/abseil-cpp/absl/strings/ascii.h"
+#include "third_party/abseil-cpp/absl/strings/match.h"
+#include "third_party/abseil-cpp/absl/strings/numbers.h"
+#include "third_party/abseil-cpp/absl/strings/strip.h"
+
+namespace memory_instrumentation {
+
+namespace {
+
+constexpr base::TimeDelta kYieldThreshold = base::Milliseconds(1);
+
+}  // namespace
+
+SmapsCategorizer::SmapsCategorizer(DetailedMetricsDelegate* delegate)
+    : delegate_(delegate) {}
+
+SmapsCategorizer::~SmapsCategorizer() = default;
+
+void SmapsCategorizer::Start(std::vector<char> buffer,
+                             mojom::RawOSMemDump* dump,
+                             DoneCallback callback) {
+  weak_ptr_factory_.InvalidateWeakPtrs();
+  buffer_ = std::move(buffer);
+  dump_ = dump;
+  done_callback_ = std::move(callback);
+  current_pos_ = 0;
+  total_pss_kb_ = 0;
+
+  base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+      FROM_HERE, base::BindOnce(&SmapsCategorizer::ParseNextChunk,
+                                weak_ptr_factory_.GetWeakPtr()));
+}
+
+void SmapsCategorizer::ParseNextChunk() {
+  base::ElapsedTimer timer;
+  absl::string_view content(buffer_.data(), buffer_.size());
+
+  while (current_pos_ < content.size()) {
+    size_t line_end = content.find('\n', current_pos_);
+    absl::string_view line = (line_end == absl::string_view::npos)
+                                 ? content.substr(current_pos_)
+                                 : content.substr(current_pos_, line_end - current_pos_);
+
+    if (delegate_) {
+      delegate_->OnSmapsLine(line);
+    }
+
+    if (absl::StartsWith(line, "Pss:")) {
+      absl::string_view value_part = absl::StripPrefix(line, "Pss:");
+      value_part = absl::StripSuffix(value_part, " kB");
+      uint64_t value_kb = 0;
+      if (absl::SimpleAtoi(absl::StripAsciiWhitespace(value_part), &value_kb)) {
+        total_pss_kb_ += value_kb;
+      }
+    }
+
+    current_pos_ = (line_end == absl::string_view::npos) ? content.size()
+                                                        : line_end + 1;
+
+    // Yield control if we've been parsing for too long.
+    if (timer.Elapsed() > kYieldThreshold) {
+      base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+          FROM_HERE, base::BindOnce(&SmapsCategorizer::ParseNextChunk,
+                                    weak_ptr_factory_.GetWeakPtr()));
+      return;
+    }
+  }
+
+  // Parse complete. Populated the dump with generic stats from delegate.
+  if (delegate_ && dump_) {
+    // Validate against smaps_rollup (already in dump_->pss_kb) with 1% epsilon.
+    // If discrepancy is too large, the snapshot might be inconsistent.
+    bool validation_success = true;
+    if (dump_->pss_kb > 0) {
+      uint64_t epsilon = dump_->pss_kb / 100;
+      if (std::abs(static_cast<int64_t>(total_pss_kb_) -
+                   static_cast<int64_t>(dump_->pss_kb)) >
+          static_cast<int64_t>(epsilon)) {
+        validation_success = false;
+        DLOG(WARNING) << "Smaps snapshot validation failed. Snapshot PSS: "
+                      << total_pss_kb_ << " KB, Rollup PSS: " << dump_->pss_kb
+                      << " KB";
+      }
+    }
+
+    if (validation_success) {
+      dump_->detailed_stats_kb = delegate_->GetAndResetStats();
+      dump_->last_detailed_dump_time = base::TimeTicks::Now();
+    } else {
+      // Clear delegate stats to avoid using invalid data.
+      delegate_->GetAndResetStats();
+    }
+  }
+
+  // Clear buffer and swap for guaranteed deallocation.
+  std::vector<char>().swap(buffer_);
+
+  std::move(done_callback_).Run(true);
+}
+
+}  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.h
@@ -1,0 +1,59 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_SMAPS_CATEGORIZER_H_
+#define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_SMAPS_CATEGORIZER_H_
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+#include "base/functional/callback.h"
+#include "base/memory/weak_ptr.h"
+#include "base/timer/elapsed_timer.h"
+#include "base/memory/raw_ptr.h"
+#include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
+
+
+namespace memory_instrumentation {
+
+class DetailedMetricsDelegate;
+
+// A stateful parser for /proc/self/smaps snapshots that yields control
+// to the TaskRunner every 1ms to avoid blocking. It uses a registered
+// DetailedMetricsDelegate for project-specific categorization.
+class SmapsCategorizer {
+ public:
+  using DoneCallback = base::OnceCallback<void(bool success)>;
+
+  explicit SmapsCategorizer(DetailedMetricsDelegate* delegate);
+  ~SmapsCategorizer();
+
+  SmapsCategorizer(const SmapsCategorizer&) = delete;
+  SmapsCategorizer& operator=(const SmapsCategorizer&) = delete;
+
+  // Starts parsing the provided snapshot buffer incrementally.
+  // Results are populated into |dump| via the delegate.
+  void Start(std::vector<char> buffer,
+             mojom::RawOSMemDump* dump,
+             DoneCallback callback);
+
+ private:
+  void ParseNextChunk();
+
+  const raw_ptr<DetailedMetricsDelegate> delegate_;
+  std::vector<char> buffer_;
+  raw_ptr<mojom::RawOSMemDump> dump_ = nullptr;
+
+  DoneCallback done_callback_;
+
+  size_t current_pos_ = 0;
+  uint64_t total_pss_kb_ = 0;
+
+  base::WeakPtrFactory<SmapsCategorizer> weak_ptr_factory_{this};
+};
+
+}  // namespace memory_instrumentation
+
+#endif  // SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_SMAPS_CATEGORIZER_H_

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer_unittest.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer_unittest.cc
@@ -1,0 +1,155 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_SMAPS_CATEGORIZER_UNITTEST_CC_
+#define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_SMAPS_CATEGORIZER_UNITTEST_CC_
+
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/smaps_categorizer.h"
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/functional/bind.h"
+#include "base/run_loop.h"
+#include "base/test/task_environment.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace memory_instrumentation {
+
+using ::testing::_;
+using ::testing::Invoke;
+
+class MockDetailedMetricsDelegate : public DetailedMetricsDelegate {
+ public:
+  MockDetailedMetricsDelegate() = default;
+  ~MockDetailedMetricsDelegate() override = default;
+
+  MOCK_METHOD(void, OnSmapsHeader, (absl::string_view line), (override));
+  MOCK_METHOD(void, OnSmapsCounter, (absl::string_view name, uint64_t value_kb), (override));
+  MOCK_METHOD((base::flat_map<std::string, uint32_t>), GetAndResetStats, (), (override));
+};
+
+class SmapsCategorizerTest : public testing::Test {
+ public:
+  SmapsCategorizerTest()
+      : task_environment_(base::test::TaskEnvironment::MainThreadType::UI) {}
+
+ protected:
+  base::test::TaskEnvironment task_environment_;
+  MockDetailedMetricsDelegate delegate_;
+};
+
+TEST_F(SmapsCategorizerTest, BasicParsing) {
+  SmapsCategorizer categorizer(&delegate_);
+  std::string smaps_content =
+      "00400000-00421000 r-xp 00000000 fc:01 1234  /foo.so\n"
+      "Size:                132 kB\n"
+      "Pss:                  40 kB\n"
+      "Rss:                  60 kB\n"
+      "Referenced:           40 kB\n"
+      "00421000-00422000 r--p 00021000 fc:01 1234  /foo.so\n"
+      "Size:                  4 kB\n"
+      "Pss:                   4 kB\n"
+      "Rss:                   4 kB\n";
+
+  std::vector<char> buffer(smaps_content.begin(), smaps_content.end());
+  mojom::RawOSMemDumpPtr dump = mojom::RawOSMemDump::New();
+  dump->pss_kb = 44; // Total Pss in smaps is 40 + 4 = 44.
+
+  EXPECT_CALL(delegate_, OnSmapsHeader("00400000-00421000 r-xp 00000000 fc:01 1234  /foo.so")).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsCounter("Size", 132)).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsCounter("Pss", 40)).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsCounter("Rss", 60)).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsCounter("Referenced", 40)).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsHeader("00421000-00422000 r--p 00021000 fc:01 1234  /foo.so")).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsCounter("Size", 4)).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsCounter("Pss", 4)).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsCounter("Rss", 4)).Times(1);
+
+  base::flat_map<std::string, uint32_t> expected_stats = {{"pss:foo", 44}};
+  EXPECT_CALL(delegate_, GetAndResetStats()).WillOnce(Invoke([&]() {
+    return expected_stats;
+  }));
+
+  base::RunLoop run_loop;
+  categorizer.Start(std::move(buffer), dump.get(),
+                    base::BindOnce([](base::RunLoop* run_loop, bool success) {
+                      EXPECT_TRUE(success);
+                      run_loop->Quit();
+                    }, &run_loop));
+  run_loop.Run();
+
+  EXPECT_EQ(dump->detailed_stats_kb, expected_stats);
+  EXPECT_FALSE(dump->last_detailed_dump_time.is_null());
+}
+
+TEST_F(SmapsCategorizerTest, ValidationFailure) {
+  SmapsCategorizer categorizer(&delegate_);
+  std::string smaps_content =
+      "00400000-00421000 r-xp 00000000 fc:01 1234  /foo.so\n"
+      "Pss:                  40 kB\n";
+
+  std::vector<char> buffer(smaps_content.begin(), smaps_content.end());
+  mojom::RawOSMemDumpPtr dump = mojom::RawOSMemDump::New();
+  dump->pss_kb = 100; // Large discrepancy: 40 vs 100.
+
+  EXPECT_CALL(delegate_, OnSmapsHeader(_)).Times(1);
+  EXPECT_CALL(delegate_, OnSmapsCounter("Pss", 40)).Times(1);
+  
+  // Stats should be reset but NOT populated to dump on validation failure.
+  EXPECT_CALL(delegate_, GetAndResetStats()).Times(1);
+
+  base::RunLoop run_loop;
+  categorizer.Start(std::move(buffer), dump.get(),
+                    base::BindOnce([](base::RunLoop* run_loop, bool success) {
+                      EXPECT_TRUE(success);
+                      run_loop->Quit();
+                    }, &run_loop));
+  run_loop.Run();
+
+  EXPECT_TRUE(dump->detailed_stats_kb.empty());
+  EXPECT_TRUE(dump->last_detailed_dump_time.is_null());
+}
+
+TEST_F(SmapsCategorizerTest, ConcurrentStart) {
+  SmapsCategorizer categorizer(&delegate_);
+  
+  std::string smaps_1 = "Pss: 10 kB\n";
+  std::string smaps_2 = "Pss: 20 kB\n";
+  
+  mojom::RawOSMemDumpPtr dump_1 = mojom::RawOSMemDump::New();
+  mojom::RawOSMemDumpPtr dump_2 = mojom::RawOSMemDump::New();
+  
+  bool callback_1_run = false;
+  bool callback_1_success = true;
+  bool callback_2_run = false;
+  
+  categorizer.Start(std::vector<char>(smaps_1.begin(), smaps_1.end()), 
+                    dump_1.get(),
+                    base::BindOnce([](bool* run, bool* success, bool res) {
+                      *run = true;
+                      *success = res;
+                    }, &callback_1_run, &callback_1_success));
+  
+  // Immediately start another one.
+  categorizer.Start(std::vector<char>(smaps_2.begin(), smaps_2.end()), 
+                    dump_2.get(),
+                    base::BindOnce([](bool* run, bool res) {
+                      *run = true;
+                    }, &callback_2_run));
+  
+  EXPECT_TRUE(callback_1_run);
+  EXPECT_FALSE(callback_1_success); // Cancelled
+  EXPECT_FALSE(callback_2_run); // Still pending in task runner
+  
+  base::RunLoop().RunUntilIdle();
+  EXPECT_TRUE(callback_2_run);
+}
+
+}  // namespace memory_instrumentation
+
+#endif  // SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_SMAPS_CATEGORIZER_UNITTEST_CC_

--- a/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
+++ b/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
@@ -184,9 +184,11 @@ struct RawOSMemDump {
   uint32 swap_pss_kb = 0;
 
   // Generic map for detailed memory metrics.
+  [EnableIf=is_android|is_chromeos|is_linux]
   map<string, uint32>? detailed_stats_kb;
 
   // Timestamp of the last successful detailed memory dump.
+  [EnableIf=is_android|is_chromeos|is_linux]
   mojo_base.mojom.TimeTicks last_detailed_dump_time;
 };
 
@@ -237,9 +239,11 @@ struct OSMemDump {
   uint32 swap_pss_kb = 0;
 
   // Generic map for detailed memory metrics.
+  [EnableIf=is_android|is_chromeos|is_linux]
   map<string, uint32>? detailed_stats_kb;
 
   // Timestamp of the last successful detailed memory dump.
+  [EnableIf=is_android|is_chromeos|is_linux]
   mojo_base.mojom.TimeTicks last_detailed_dump_time;
 };
 

--- a/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
+++ b/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
@@ -183,48 +183,6 @@ struct RawOSMemDump {
   [EnableIf=is_android|is_chromeos|is_linux]
   uint32 swap_pss_kb = 0;
 
-  // PSS for libchrobalt.so specifically.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 libchrobalt_pss_kb = 0;
-
-  // RSS for libchrobalt.so specifically.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 libchrobalt_rss_kb = 0;
-
-  // RSS for partition_alloc anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 partition_alloc_rss_kb = 0;
-
-  // RSS for V8 anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 v8_rss_kb = 0;
-
-  // RSS for system malloc (e.g. scudo) anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 malloc_rss_kb = 0;
-
-  // RSS for other code binaries (.so, .apk, .dex). This includes system
-  // libraries, GPU drivers, and the Android application package, but
-  // excludes the main libchrobalt.so.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 code_other_rss_kb = 0;
-
-  // RSS for fonts (.ttf, .ttc).
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 fonts_rss_kb = 0;
-
-  // RSS for Ashmem and JIT cache.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 ashmem_jit_rss_kb = 0;
-
-  // RSS for Android/Dalvik runtime (.art, .oat, dalvik-).
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 android_runtime_rss_kb = 0;
-
-  // RSS for thread stacks.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 stacks_rss_kb = 0;
-
   // Generic map for detailed memory metrics.
   map<string, uint32>? detailed_stats_kb;
 
@@ -277,48 +235,6 @@ struct OSMemDump {
   // Swap PSS for the process. 0 is recorded when collection fails.
   [EnableIf=is_android|is_chromeos|is_linux]
   uint32 swap_pss_kb = 0;
-
-  // PSS for libchrobalt.so specifically.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 libchrobalt_pss_kb = 0;
-
-  // RSS for libchrobalt.so specifically.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 libchrobalt_rss_kb = 0;
-
-  // RSS for partition_alloc anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 partition_alloc_rss_kb = 0;
-
-  // RSS for V8 anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 v8_rss_kb = 0;
-
-  // RSS for system malloc (e.g. scudo) anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 malloc_rss_kb = 0;
-
-  // RSS for other code binaries (.so, .apk, .dex). This includes system
-  // libraries, GPU drivers, and the Android application package, but
-  // excludes the main libchrobalt.so.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 code_other_rss_kb = 0;
-
-  // RSS for fonts (.ttf, .ttc).
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 fonts_rss_kb = 0;
-
-  // RSS for Ashmem and JIT cache.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 ashmem_jit_rss_kb = 0;
-
-  // RSS for Android/Dalvik runtime (.art, .oat, dalvik-).
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 android_runtime_rss_kb = 0;
-
-  // RSS for thread stacks.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 stacks_rss_kb = 0;
 
   // Generic map for detailed memory metrics.
   map<string, uint32>? detailed_stats_kb;

--- a/tools/metrics/histograms/enums.xml
+++ b/tools/metrics/histograms/enums.xml
@@ -20129,6 +20129,7 @@ from previous Chrome versions.
   <int value="1" label="Snapshot limit hit (5MB)"/>
   <int value="2" label="Smaps file open failed"/>
   <int value="3" label="Smaps file read failed"/>
+  <int value="4" label="Smaps validation failed"/>
 </enum>
 
 <enum name="MenuSourceType">

--- a/tools/metrics/histograms/enums.xml
+++ b/tools/metrics/histograms/enums.xml
@@ -20111,6 +20111,26 @@ from previous Chrome versions.
   <int value="6" label="None"/>
 </enum>
 
+<enum name="MemoryCategory">
+  <int value="0" label="Unknown"/>
+  <int value="1" label="libchrobalt.so"/>
+  <int value="2" label="PartitionAlloc"/>
+  <int value="3" label="V8"/>
+  <int value="4" label="Malloc"/>
+  <int value="5" label="CodeOther"/>
+  <int value="6" label="Fonts"/>
+  <int value="7" label="AshmemJit"/>
+  <int value="8" label="AndroidRuntime"/>
+  <int value="9" label="Stacks"/>
+</enum>
+
+<enum name="MemoryDetailedDumpAbortReason">
+  <int value="0" label="Success"/>
+  <int value="1" label="Snapshot limit hit (5MB)"/>
+  <int value="2" label="Smaps file open failed"/>
+  <int value="3" label="Smaps file read failed"/>
+</enum>
+
 <enum name="MenuSourceType">
   <int value="0" label="None"/>
   <int value="1" label="Mouse"/>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -332,6 +332,146 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Memory.Browser.AndroidRuntimeRss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The physical memory (RSS) consumed by the Android/Dalvik runtime environment.
+    This tracks ART image files (.art), Optimized Android Template files
+    (.oat), and internal Dalvik allocator regions (e.g., dalvik-main space).
+    Currently restricted to Android.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Browser.AshmemJitRss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The physical memory (RSS) consumed by anonymous shared memory (Ashmem) and
+    the Just-In-Time (JIT) compilation cache. This tracks mappings tagged with
+    /dev/ashmem/ and memfd:jit-cache. Currently restricted to Android.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Browser.CodeOtherRss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The physical memory (RSS) consumed by non-Cobalt executable code and
+    read-only data mappings. This is a catch-all for system libraries (.so),
+    GPU drivers (e.g., libGLES_mali.so), the application package (.apk), and
+    compiled Java bytecode (.dex). Excludes the main libchrobalt.so.
+    Currently restricted to Android.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Browser.FontsRss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The physical memory (RSS) consumed by system and application font mappings,
+    specifically TrueType (.ttf) and TrueType Collection (.ttc) files.
+    Currently restricted to Android.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Browser.LibChrobaltPss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The Proportional Set Size (PSS) of the core libchrobalt.so library. PSS
+    accounts for the fact that some pages of the library may be shared with
+    other processes.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Browser.LibChrobaltRss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The physical Resident Set Size (RSS) of the core libchrobalt.so library.
+    This represents the total number of pages from this library currently
+    resident in RAM.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Browser.MallocRss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The physical memory (RSS) used by the system allocator. On Android, this
+    typically tracks the scudo allocator and the standard [heap] region.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Browser.PartitionAllocRss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The physical memory (RSS) consumed specifically by PartitionAlloc's
+    anonymous mappings, which are used for most of Cobalt's internal
+    object allocations.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Browser.StacksRss" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    The physical memory (RSS) consumed by all thread stacks and Thread-Local
+    Storage (TLS) regions within the process.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Experimental.Browser2.AndroidRuntime" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Accurate RSS for the Android Runtime pillar (ART/Dalvik). This is used for
+    the cumulative CDF breakdown of the total ResidentSet. Currently restricted
+    to Android.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Experimental.Browser2.AshmemJit" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Accurate RSS for the Ashmem and JIT cache pillar. This is used for the
+    cumulative CDF breakdown of the total ResidentSet. Currently restricted to
+    Android.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Experimental.Browser2.CodeOther" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Accurate RSS for the CodeOther pillar (system libs, APK, drivers). This is
+    used for the cumulative CDF breakdown of the total ResidentSet. Currently
+    restricted to Android.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Experimental.Browser2.Fonts" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Accurate RSS for the Fonts pillar (.ttf/.ttc). This is used for the
+    cumulative CDF breakdown of the total ResidentSet. Currently restricted to
+    Android.
+  </summary>
+</histogram>
+
+<histogram name="Memory.Experimental.Browser2.Stacks" units="MiB"
+    expires_after="never">
+  <owner>avvall@google.com</owner>
+  <summary>
+    Accurate RSS for the thread stacks pillar. This is used for the
+    cumulative CDF breakdown of the total ResidentSet.
+  </summary>
+</histogram>
+
 </histograms>
 
 </histogram-configuration>

--- a/tools/metrics/histograms/metadata/memory/histograms.xml
+++ b/tools/metrics/histograms/metadata/memory/histograms.xml
@@ -1145,6 +1145,16 @@ chromium-metrics-reviews@google.com.
   </summary>
 </histogram>
 
+<histogram name="Memory.DetailedDump.AbortReason"
+    enum="MemoryDetailedDumpAbortReason" expires_after="2026-03-31">
+  <owner>avvall@google.com</owner>
+  <owner>chrome-memory@google.com</owner>
+  <summary>
+    The reason why a detailed memory dump (smaps parsing) was aborted on Android.
+    Recorded during OS memory dump collection for Cobalt.
+  </summary>
+</histogram>
+
 <histogram name="Memory.CommitAvailableMB" units="MB"
     expires_after="2025-11-02">
   <owner>aattar@google.com</owner>


### PR DESCRIPTION
Implement granular memory metrics for Cobalt by integrating with the
Chromium memory instrumentation service and optimizing the smaps
parsing pipeline.

Key improvements include:

-   Performance: Refactored DetailedMetricsDelegate to use targeted
    OnSmapsHeader and OnSmapsCounter callbacks. This allows SmapsCategorizer
    to perform heavy parsing once, eliminating redundant string operations
    in the delegate.
-   Memory Efficiency: Updated OSMetrics::ReadDetailedMetricsFile to read
    smaps snapshots incrementally using a 4KB chunk buffer and dynamic
    reserving, replacing a fixed 5MB upfront allocation.
-   Architecture: Introduced CalculationType in CobaltMemoryMetricsEmitter
    to centralize logic for derived metrics like Fragmentation and Wasted
    memory.
-   Reliability: Fixed a concurrency bug in SmapsCategorizer where
    simultaneous requests could drop callbacks.
-   Mojo Safety: Guarded detailed memory fields with platform-specific
    [EnableIf] tags and ensured histograms are only emitted when valid
    data is present to prevent zero-value pollution.
-   Observability: Integrated Memory.DetailedDump.AbortReason to track
    and diagnose collection failures in the field.

Includes comprehensive unit tests for SmapsCategorizer,
CobaltDetailedMetricsDelegate, and CobaltMemoryMetricsEmitter.

Note: This is based on #9876.

Bug: 498702469