### PR TITLE
cobalt: Add avoid CC resource reuse switch

### DIFF
--- a/cc/base/switches.cc
+++ b/cc/base/switches.cc
@@ -5,6 +5,7 @@
 #include "cc/base/switches.h"
 
 #include "base/command_line.h"
+#include "build/build_config.h"
 
 namespace cc {
 namespace switches {
@@ -118,6 +119,11 @@ const char kCCLayerTreeTestLongTimeout[] = "cc-layer-tree-test-long-timeout";
 // Controls the duration of the scroll animation curve.
 const char kCCScrollAnimationDurationForTesting[] =
     "cc-scroll-animation-duration-in-seconds";
+
+#if BUILDFLAG(IS_COBALT)
+// Avoid reuse resource.
+const char kAvoidCCReuseResource[] = "avoid-cc-reuse-resource";
+#endif
 
 }  // namespace switches
 }  // namespace cc

--- a/cc/base/switches.h
+++ b/cc/base/switches.h
@@ -66,6 +66,11 @@ CC_BASE_EXPORT extern const char kEnableClippedImageScaling[];
 
 CC_BASE_EXPORT extern const char kAnimatedImageResume[];
 
+#if BUILDFLAG(IS_COBALT)
+// Avoid reuse resource.
+CC_BASE_EXPORT extern const char kAvoidCCReuseResource[];
+#endif
+
 // Test related.
 CC_BASE_EXPORT extern const char kCCLayerTreeTestNoTimeout[];
 CC_BASE_EXPORT extern const char kCCLayerTreeTestLongTimeout[];

--- a/cc/resources/resource_pool.cc
+++ b/cc/resources/resource_pool.cc
@@ -14,6 +14,7 @@
 #include <utility>
 
 #include "base/atomic_sequence_num.h"
+#include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/format_macros.h"
 #include "base/functional/bind.h"
@@ -24,6 +25,7 @@
 #include "base/trace_event/memory_dump_manager.h"
 #include "build/build_config.h"
 #include "cc/base/container_util.h"
+#include "cc/base/switches.h"
 #include "components/viz/client/client_resource_provider.h"
 #include "components/viz/common/gpu/context_provider.h"
 #include "gpu/command_buffer/client/context_support.h"
@@ -187,9 +189,25 @@ ResourcePool::InUsePoolResource ResourcePool::AcquireResource(
     viz::SharedImageFormat format,
     const gfx::ColorSpace& color_space,
     const std::string& debug_name) {
+#if BUILDFLAG(IS_COBALT)
+  static bool avoid_cc_reuse_resource =
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kAvoidCCReuseResource);
+  PoolResource* resource = avoid_cc_reuse_resource
+                               ? nullptr
+                               : ReuseResource(size, format, color_space);
+#else
   PoolResource* resource = ReuseResource(size, format, color_space);
+#endif
+
   if (!resource)
     resource = CreateResource(size, format, color_space);
+
+#if BUILDFLAG(IS_COBALT)
+  if (avoid_cc_reuse_resource) {
+    resource->mark_avoid_reuse();
+  }
+#endif
   resource->set_debug_name(debug_name);
   return InUsePoolResource(resource, !!context_provider_);
 }
@@ -212,6 +230,13 @@ ResourcePool::TryAcquireResourceForPartialRaster(
     gfx::Rect* total_invalidated_rect,
     const gfx::ColorSpace& raster_color_space,
     const std::string& debug_name) {
+#if BUILDFLAG(IS_COBALT)
+  static bool avoid_cc_reuse_resource =
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kAvoidCCReuseResource);
+  if (avoid_cc_reuse_resource)
+    return InUsePoolResource();
+#endif
   DCHECK(new_content_id);
   DCHECK(previous_content_id);
   *total_invalidated_rect = gfx::Rect();

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -92,6 +92,9 @@ public class JavaSwitches {
   /** Force GPU memory available. Value type: Integer (MB) */
   public static final String FORCE_GPU_MEM_AVAILABLE_MB = "ForceGpuMemAvailableMb";
 
+  /** Avoid reuse resource. */
+  public static final String AVOID_CC_REUSE_RESOURCE = "AvoidCCReuseResource";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
     if (!javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
@@ -208,6 +211,10 @@ public class JavaSwitches {
       extraCommandLineArgs.add(
           "--force-gpu-mem-available-mb="
               + javaSwitches.get(JavaSwitches.FORCE_GPU_MEM_AVAILABLE_MB).replaceAll("[^0-9]", ""));
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.AVOID_CC_REUSE_RESOURCE)) {
+      extraCommandLineArgs.add("--avoid-cc-reuse-resource");
     }
 
     return extraCommandLineArgs;

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
@@ -110,4 +110,14 @@ public class JavaSwitchesTest {
 
     assertThat(args).doesNotContain("--js-flags=--optimize-for-size");
   }
+
+  @Test
+  public void getExtraCommandLineArgs_AvoidCCReuseResource() {
+    Map<String, String> javaSwitches = new HashMap<>();
+    javaSwitches.put(JavaSwitches.AVOID_CC_REUSE_RESOURCE, "true");
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(javaSwitches);
+
+    assertThat(args).contains("--avoid-cc-reuse-resource");
+  }
 }


### PR DESCRIPTION
This change introduces a new command-line switch, "avoid-cc-reuse-resource",
specific to Cobalt builds. When this switch is enabled, resources acquired
from the Chromium Compositor's ResourcePool are marked to prevent their
immediate reuse. This mechanism forces new resource allocations, which
can be valuable for debugging issues related to resource lifecycle,
memory management, or rendering artifacts. The Android JavaSwitches
utility is updated to expose this flag, allowing control from Java.

Bug: 424591313