### PR TITLE
starboard: Fix Widevine and tvOS DRM compiler warnings

### DIFF
--- a/starboard/shared/widevine/drm_system_widevine.cc
+++ b/starboard/shared/widevine/drm_system_widevine.cc
@@ -49,7 +49,7 @@ const char kWidevineStorageFileName[] = "wvcdm.dat";
 // get HDCP authentication complete. We set a timeout of 6 seconds for retries.
 const int64_t kUnblockKeyRetryTimeoutUsec = 6'000'000;
 
-DECLARE_INSTANCE_COUNTER(DrmSystemWidevine);
+DECLARE_INSTANCE_COUNTER(DrmSystemWidevine)
 
 class WidevineClock : public wv3cdm::IClock {
  public:
@@ -449,12 +449,13 @@ SbDrmSystemPrivate::DecryptStatus DrmSystemWidevine::Decrypt(
   size_t block_counter = 0;
   size_t encrypted_offset = 0;
 
-  for (size_t i = 0; i < buffer->drm_info()->subsample_count; i++) {
+  const int32_t subsample_count = buffer->drm_info()->subsample_count;
+  for (int32_t i = 0; i < subsample_count; i++) {
     const SbDrmSubSampleMapping& subsample =
         buffer->drm_info()->subsample_mapping[i];
     if (subsample.clear_byte_count) {
-      input.last_subsample = i + 1 == buffer->drm_info()->subsample_count &&
-                             subsample.encrypted_byte_count == 0;
+      input.last_subsample =
+          i + 1 == subsample_count && subsample.encrypted_byte_count == 0;
       input.encryption_scheme = wv3cdm::EncryptionScheme::kClear;
       input.data_length = subsample.clear_byte_count;
 
@@ -479,7 +480,7 @@ SbDrmSystemPrivate::DecryptStatus DrmSystemWidevine::Decrypt(
     }
 
     if (subsample.encrypted_byte_count) {
-      input.last_subsample = i + 1 == buffer->drm_info()->subsample_count;
+      input.last_subsample = i + 1 == subsample_count;
       input.encryption_scheme = wv3cdm::EncryptionScheme::kAesCtr;
       if (drm_info->encryption_scheme == kSbDrmEncryptionSchemeAesCbc) {
         input.encryption_scheme = wv3cdm::EncryptionScheme::kAesCbc;

--- a/starboard/shared/widevine/widevine_storage.cc
+++ b/starboard/shared/widevine/widevine_storage.cc
@@ -16,6 +16,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/file.h"
@@ -68,8 +69,16 @@ bool WriteFile(const std::string& path_name,
     return false;
   }
 
-  if (file.WriteAll(reinterpret_cast<const char*>(content.data()),
-                    static_cast<int>(content.size())) != content.size()) {
+  // Fail early if content size would overflow int.
+  if (content.size() > static_cast<size_t>(std::numeric_limits<int>::max())) {
+    SB_LOG(ERROR) << "Content size " << content.size()
+                  << " exceeds maximum writable size for " << path_name << '.';
+    return false;
+  }
+
+  const int size = static_cast<int>(content.size());
+  if (file.WriteAll(reinterpret_cast<const char*>(content.data()), size) !=
+      size) {
     SB_LOG(INFO) << "Failed to write content to " << path_name << '.';
     return false;
   }

--- a/starboard/tvos/shared/media/drm_generate_session_update_request.mm
+++ b/starboard/tvos/shared/media/drm_generate_session_update_request.mm
@@ -34,7 +34,7 @@ namespace {
  */
 NSArray<NSData*>* unpackData(NSData* input) {
   NSMutableArray<NSData*>* unpackedData = [NSMutableArray array];
-  NSInteger offset = 0;
+  NSUInteger offset = 0;
   UInt32 recordSize;
   for (NSInteger i = 0; i < 3; i++) {
     if (offset + sizeof(recordSize) > input.length) {

--- a/starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm
+++ b/starboard/tvos/shared/media/oemcrypto_engine_device_properties_uikit.mm
@@ -76,7 +76,7 @@ class CryptoEngineDeviceProperties {
 };
 
 SB_ONCE_INITIALIZE_FUNCTION(CryptoEngineDeviceProperties,
-                            GetCryptoEngineDeviceProperties);
+                            GetCryptoEngineDeviceProperties)
 
 }  // namespace
 


### PR DESCRIPTION
This commit addresses compiler warnings related to signed/unsigned
comparison mismatches and API usage in Widevine and tvOS DRM
implementations exposed after treat_warnings_as_errors was enabled in
GN configuration (83fedaf216c0d).

Specifically, it caches subsample_count as size_t in Widevine's decrypt
loop, casts content.size() for SbFile::WriteAll comparison, and casts
offset+recordSize to NSUInteger in tvOS DRM session parsing. It also
corrects AVContentKeySession initialization and removes trailing
semicolons from macro invocations.

Bug: 471365322