### PR TITLE
tvos: Add browser tests for IFA

### DIFF
--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h
@@ -38,6 +38,12 @@ class H5vccSystemImpl : public content::DocumentService<mojom::H5vccSystem> {
   static void Create(content::RenderFrameHost* render_frame_host,
                      mojo::PendingReceiver<mojom::H5vccSystem> receiver);
 
+#if BUILDFLAG(IS_IOS_TVOS)
+  static void ResetTestState();
+  static void SetTrackingAuthorizationForTest(bool authorized);
+  static void SetAdvertisingIdForTest(const std::string& id);
+#endif
+
   H5vccSystemImpl(const H5vccSystemImpl&) = delete;
   H5vccSystemImpl& operator=(const H5vccSystemImpl&) = delete;
 

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_tvos.mm
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_tvos.mm
@@ -32,14 +32,26 @@ namespace h5vcc_system {
 
 namespace {
 
+bool g_tracking_authorized_for_test = false;
+std::string g_advertising_id_for_test;
+
 void GetAdvertisingIdShared(
     H5vccSystemImpl::GetAdvertisingIdCallback callback) {
+  if (g_tracking_authorized_for_test) {
+    std::move(callback).Run(g_advertising_id_for_test);
+    return;
+  }
+
   NSString* advertising_id =
       [[ASIdentifierManager sharedManager].advertisingIdentifier UUIDString];
   std::move(callback).Run(base::SysNSStringToUTF8(advertising_id));
 }
 
 bool GetLimitAdTrackingShared() {
+  if (g_tracking_authorized_for_test) {
+    return false;
+  }
+
   return [ATTrackingManager trackingAuthorizationStatus] !=
          ATTrackingManagerAuthorizationStatusAuthorized;
 }
@@ -61,6 +73,19 @@ std::string GetTrackingAuthorizationStatusShared() {
 }
 
 }  // namespace
+
+void H5vccSystemImpl::ResetTestState() {
+  g_tracking_authorized_for_test = false;
+  g_advertising_id_for_test.clear();
+}
+
+void H5vccSystemImpl::SetTrackingAuthorizationForTest(bool authorized) {
+  g_tracking_authorized_for_test = authorized;
+}
+
+void H5vccSystemImpl::SetAdvertisingIdForTest(const std::string& id) {
+  g_advertising_id_for_test = id;
+}
 
 void H5vccSystemImpl::GetAdvertisingId(GetAdvertisingIdCallback callback) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);

--- a/cobalt/browser/h5vcc_system_browsertest.cc
+++ b/cobalt/browser/h5vcc_system_browsertest.cc
@@ -19,12 +19,24 @@
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
 
+#if BUILDFLAG(IS_IOS_TVOS)
+#include "cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h"  // nogncheck
+#endif
+
 namespace cobalt {
 
 class H5vccSystemBrowserTest : public content::ContentBrowserTest {
  public:
   H5vccSystemBrowserTest() = default;
   ~H5vccSystemBrowserTest() override = default;
+
+#if BUILDFLAG(IS_IOS_TVOS)
+ protected:
+  void TearDown() override {
+    h5vcc_system::H5vccSystemImpl::ResetTestState();
+    content::ContentBrowserTest::TearDown();
+  }
+#endif
 };
 
 IN_PROC_BROWSER_TEST_F(H5vccSystemBrowserTest, VerifyApiPresence) {
@@ -71,5 +83,52 @@ IN_PROC_BROWSER_TEST_F(H5vccSystemBrowserTest, VerifySystemProperties) {
   EXPECT_TRUE(
       content::EvalJs(shell()->web_contents(), check_strategy).ExtractBool());
 }
+
+#if BUILDFLAG(IS_IOS_TVOS)
+IN_PROC_BROWSER_TEST_F(H5vccSystemBrowserTest, GetAdvertisingId) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), url));
+
+  static const std::string fallback_id = "00000000-0000-0000-0000-000000000000";
+  static const std::string test_id = "12345678-1234-1234-1234-123456789000";
+
+  // Verify that advertisingId returns the fallback value when the tracking
+  // authorization is not granted.
+  EXPECT_EQ(fallback_id, content::EvalJs(shell()->web_contents(),
+                                         "window.h5vcc.system.advertisingId")
+                             .ExtractString());
+
+  // Allow tracking authorization and set the test value.
+  h5vcc_system::H5vccSystemImpl::SetTrackingAuthorizationForTest(true);
+  h5vcc_system::H5vccSystemImpl::SetAdvertisingIdForTest(test_id);
+
+  // Check if advertisingId matches the test value.
+  EXPECT_EQ(test_id, content::EvalJs(shell()->web_contents(),
+                                     "window.h5vcc.system.advertisingId")
+                         .ExtractString());
+}
+
+IN_PROC_BROWSER_TEST_F(H5vccSystemBrowserTest, GetLimitAdTracking) {
+  ASSERT_TRUE(embedded_test_server()->Start());
+  GURL url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), url));
+
+  // Verify that limitAdTracking returns true when  when the tracking
+  // authorization is not granted.
+  EXPECT_TRUE(content::EvalJs(shell()->web_contents(),
+                              "window.h5vcc.system.limitAdTracking")
+                  .ExtractBool());
+
+  // Allow the tracking authorization for testing.
+  h5vcc_system::H5vccSystemImpl::SetTrackingAuthorizationForTest(true);
+
+  // Check if limitAdTracking returns false after the tracking authorization is
+  // granted.
+  EXPECT_FALSE(content::EvalJs(shell()->web_contents(),
+                               "window.h5vcc.system.limitAdTracking")
+                   .ExtractBool());
+}
+#endif
 
 }  // namespace cobalt

--- a/cobalt/testing/browser_tests/BUILD.gn
+++ b/cobalt/testing/browser_tests/BUILD.gn
@@ -396,7 +396,10 @@ test("cobalt_browsertests") {
       ":cobalt_shell_pak_bundle_data",
       ":cobalt_test_bundle_data",
     ]
-    deps += [ "//starboard/common:common" ]
+    deps += [
+      "//cobalt/browser/h5vcc_system",
+      "//starboard/common:common",
+    ]
   }
 
   if (is_android) {


### PR DESCRIPTION
Add browser tests to verify the GetAdvertisingID and GetLimitAdTracking
Web APIs for IFA on tvOS.

The native tvOS APIs to retrieve advertising ID and tracking authorization
status do not function correctly on the simulator. To enable testing in
this environment, test hooks are introduced to simulate API responses,
allowing comprehensive validation of the Web APIs.

Bug: 453538923