### PR TITLE
evergreen: Reload web contents on network reconnect

### DIFF
--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -23,6 +23,7 @@
 #include "base/allocator/partition_allocator/memory_reclaimer.h"
 #include "base/at_exit.h"
 #include "base/command_line.h"
+#include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
 #include "base/memory/memory_pressure_listener.h"
@@ -37,6 +38,7 @@
 #include "content/public/app/content_main.h"
 #include "content/public/app/content_main_runner.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/network_service_instance.h"
 #include "net/base/network_change_notifier_passive.h"
 
@@ -255,6 +257,22 @@ class AppEventRunnerImpl : public AppEventRunner {
           event->type == kSbEventTypeOsNetworkConnected
               ? net::NetworkChangeNotifier::SUBTYPE_UNKNOWN
               : net::NetworkChangeNotifier::SUBTYPE_NONE;
+      if (event->type == kSbEventTypeOsNetworkConnected) {
+        passive_notifier->OnIPAddressChanged();
+        content::GetUIThreadTaskRunner({})->PostTask(
+            FROM_HERE, base::BindOnce([]() {
+              for (auto* shell : content::Shell::windows()) {
+                content::NavigationEntry* entry = shell->web_contents()
+                                                      ->GetController()
+                                                      .GetLastCommittedEntry();
+                if (entry &&
+                    (entry->GetPageType() == content::PAGE_TYPE_ERROR ||
+                     entry->IsInitialEntry())) {
+                  shell->Reload();
+                }
+              }
+            }));
+      }
       passive_notifier->OnConnectionChanged(type);
       passive_notifier->OnConnectionSubtypeChanged(type, subtype);
     }

--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -23,7 +23,6 @@
 #include "base/allocator/partition_allocator/memory_reclaimer.h"
 #include "base/at_exit.h"
 #include "base/command_line.h"
-#include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/logging.h"
 #include "base/memory/memory_pressure_listener.h"
@@ -38,7 +37,6 @@
 #include "content/public/app/content_main.h"
 #include "content/public/app/content_main_runner.h"
 #include "content/public/browser/browser_thread.h"
-#include "content/public/browser/navigation_entry.h"
 #include "content/public/browser/network_service_instance.h"
 #include "net/base/network_change_notifier_passive.h"
 
@@ -257,24 +255,11 @@ class AppEventRunnerImpl : public AppEventRunner {
           event->type == kSbEventTypeOsNetworkConnected
               ? net::NetworkChangeNotifier::SUBTYPE_UNKNOWN
               : net::NetworkChangeNotifier::SUBTYPE_NONE;
-      if (event->type == kSbEventTypeOsNetworkConnected) {
-        passive_notifier->OnIPAddressChanged();
-        content::GetUIThreadTaskRunner({})->PostTask(
-            FROM_HERE, base::BindOnce([]() {
-              for (auto* shell : content::Shell::windows()) {
-                content::NavigationEntry* entry = shell->web_contents()
-                                                      ->GetController()
-                                                      .GetLastCommittedEntry();
-                if (entry &&
-                    (entry->GetPageType() == content::PAGE_TYPE_ERROR ||
-                     entry->IsInitialEntry())) {
-                  shell->Reload();
-                }
-              }
-            }));
-      }
       passive_notifier->OnConnectionChanged(type);
       passive_notifier->OnConnectionSubtypeChanged(type, subtype);
+      if (event->type == kSbEventTypeOsNetworkConnected) {
+        passive_notifier->OnIPAddressChanged();
+      }
     }
 #endif
   }

--- a/cobalt/shell/browser/shell_browser_main_parts.cc
+++ b/cobalt/shell/browser/shell_browser_main_parts.cc
@@ -72,9 +72,34 @@
 
 #if BUILDFLAG(IS_STARBOARD)
 #include "cobalt/shell/common/device_authentication.h"
+#include "net/base/network_change_notifier.h"
+#include "net/base/network_change_notifier_factory.h"
+#include "net/base/network_change_notifier_passive.h"
+#include "starboard/system.h"
 #endif
 
 namespace content {
+
+namespace {
+
+#if BUILDFLAG(IS_STARBOARD)
+class NetworkChangeNotifierFactoryStarboard
+    : public net::NetworkChangeNotifierFactory {
+ public:
+  std::unique_ptr<net::NetworkChangeNotifier> CreateInstanceWithInitialTypes(
+      net::NetworkChangeNotifier::ConnectionType initial_type,
+      net::NetworkChangeNotifier::ConnectionSubtype initial_subtype) override {
+    // Override the initial type based on actual Starboard state.
+    initial_type = SbSystemNetworkIsDisconnected()
+                       ? net::NetworkChangeNotifier::CONNECTION_NONE
+                       : net::NetworkChangeNotifier::CONNECTION_UNKNOWN;
+    return std::make_unique<net::NetworkChangeNotifierPassive>(initial_type,
+                                                               initial_subtype);
+  }
+};
+#endif
+
+}  // namespace
 
 GURL ShellBrowserMainParts::GetStartupURL() const {
   base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
@@ -139,6 +164,9 @@ int ShellBrowserMainParts::PreEarlyInitialization() {
 #if BUILDFLAG(IS_ANDROID)
   net::NetworkChangeNotifier::SetFactory(
       new net::NetworkChangeNotifierFactoryAndroid());
+#elif BUILDFLAG(IS_STARBOARD)
+  net::NetworkChangeNotifier::SetFactory(
+      new NetworkChangeNotifierFactoryStarboard());
 #endif
   return RESULT_CODE_NORMAL_EXIT;
 }


### PR DESCRIPTION
On network reconnection (kSbEventTypeOsNetworkConnected), automatically
reload web contents that are currently displaying an error page or
represent an initial failed load. This improves the user experience
by recovering from network interruptions without requiring manual
intervention.

Additionally, implement a Starboard-specific network change notifier
factory to accurately reflect the initial network state. This ensures
Chromium's internal network stack is correctly initialized based on
the Starboard platform's connectivity status.

Bug: 495438901