### PR TITLE
media: Make InPlace allocator the default

### DIFF
--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -291,21 +291,6 @@ void DecoderBufferAllocator::EnableDecommitableAllocatorStrategy() {
 }
 
 // static
-void DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase() {
-  auto* allocator = Get();
-  CHECK(allocator);
-  allocator->UpdateAllocatorStrategy(base::BindRepeating(
-      [](int initial_capacity, int allocation_unit)
-          -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
-        LOG(INFO)
-            << "DecoderBufferAllocator is using InPlaceReuseAllocatorBase.";
-        return std::make_unique<InPlaceReuseAllocatorStrategy>(
-            initial_capacity, allocation_unit,
-            /*enable_decommit_on_idle=*/false);
-      }));
-}
-
-// static
 void DecoderBufferAllocator::EnableMediaBufferPoolStrategy() {
   auto* allocator = Get();
   CHECK(allocator);
@@ -345,21 +330,13 @@ void DecoderBufferAllocator::EnsureStrategyIsCreated() {
                     "strategy. Falling back to default.";
   }
 
-  // Keep the existing feature based logic as is, as the h5vcc settings based
-  // logic will be deprecated once Finch is ready.
-  if (base::FeatureList::IsEnabled(
-          kCobaltDecoderBufferAllocatorWithInPlaceMetadata)) {
-    strategy_ = std::make_unique<InPlaceReuseAllocatorStrategy>(
-        initial_capacity_, allocation_unit_,
-        /*enable_decommit_on_idle=*/false);
-    LOG(INFO) << "DecoderBufferAllocator is using InPlaceReuseAllocatorBase.";
-  } else {
-    strategy_ = std::make_unique<DefaultReuseAllocatorStrategy>(
-        initial_capacity_, allocation_unit_,
-        /*enable_decommit_on_idle=*/false);
-    LOG(INFO) << "DecoderBufferAllocator is using"
-              << " DefaultReuseAllocatorStrategy.";
-  }
+  // Through experimentation, we have found that the
+  // InPlaceReuseAllocatorStrategy has better performance than the previous
+  // DefaultReuseAllocatorStrategy. See b/487332929 for more info.
+  strategy_ = std::make_unique<InPlaceReuseAllocatorStrategy>(
+      initial_capacity_, allocation_unit_,
+      /*enable_decommit_on_idle=*/false);
+  LOG(INFO) << "DecoderBufferAllocator is using InPlaceReuseAllocatorBase.";
 
   LOG(INFO) << "Allocated " << initial_capacity_
             << " bytes for decoder buffer pool.";

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -51,8 +51,9 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
     virtual size_t GetAllocated() const = 0;
   };
 
-  using StrategyCreateCB = base::RepeatingCallback<
-      std::unique_ptr<Strategy>(int initial_capacity, int allocation_unit)>;
+  using StrategyCreateCB =
+      base::RepeatingCallback<std::unique_ptr<Strategy>(int initial_capacity,
+                                                        int allocation_unit)>;
 
   explicit DecoderBufferAllocator();
   DecoderBufferAllocator(bool is_memory_pool_allocated_on_demand,
@@ -87,7 +88,6 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   // TODO(b/460292554): To be deprecated with h5vcc settings.
   void SetAllocateOnDemand(bool enabled);
   static void EnableDecommitableAllocatorStrategy();
-  static void EnableInPlaceReuseAllocatorBase();
   static void EnableMediaBufferPoolStrategy();
 
  private:

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -140,11 +140,6 @@ ScriptPromise H5vccSettings::set(ScriptState* script_state,
       ::media::DecoderBufferAllocator::EnableMediaBufferPoolStrategy();
     });
   }
-  if (name == "DecoderBuffer.EnableInPlaceReuseAllocatorBase") {
-    return ProcessSettingAsEnableOnly(context, [] {
-      ::media::DecoderBufferAllocator::EnableInPlaceReuseAllocatorBase();
-    });
-  }
   // "DecoderBuffer." settings must be handled before this catch-all block.
   if (name.StartsWith("DecoderBuffer.")) {
     return Reject(context, name + " isn't a supported setting.");


### PR DESCRIPTION
Through experimentation, we have seen that the InPlaceReuseAllocatorBase has better performance when compared to the DefaultReuseAllocatorBase. This PR explicitly enables this strategy by default, and cleans up H5VCC code that was calling it.

Bug: 487332929