### PR TITLE
YTS guided flow: deep-link timing + session stash

### DIFF
--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -29,6 +29,7 @@
 #include "base/location.h"
 #include "base/no_destructor.h"
 #include "base/run_loop.h"
+#include "base/json/string_escape.h"
 #include "base/strings/escape.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
@@ -128,6 +129,75 @@ bool IsDeepLinkTopic(const GURL& link_url, std::string_view target_topic) {
   }
 
   return false;
+}
+
+bool GetQueryParamValue(const GURL& url,
+                        std::string_view key,
+                        std::string* value) {
+  if (!url.is_valid() || !url.has_query()) {
+    return false;
+  }
+
+  for (net::QueryIterator it(url); !it.IsAtEnd(); it.Advance()) {
+    if (it.GetKey() == key) {
+      *value = it.GetUnescapedValue();
+      return true;
+    }
+  }
+  return false;
+}
+
+bool HasYtsSessionContext(const GURL& url) {
+  std::string value;
+  return GetQueryParamValue(url, "yts_server", &value) &&
+         GetQueryParamValue(url, "yts_agent_id", &value);
+}
+
+bool IsYoutubeTvUrl(const GURL& url) {
+  return url.is_valid() &&
+         (url.host_piece() == "www.youtube.com" ||
+          url.host_piece() == "youtube.com") &&
+         base::StartsWith(url.path_piece(), "/tv");
+}
+
+bool IsYtsAgentPage(const GURL& url) {
+  return url.is_valid() &&
+         url.host_piece() == "yts.devicecertification.youtube" &&
+         base::StartsWith(url.path_piece(), "/agent/");
+}
+
+bool IsYtsStickyCandidate(const GURL& url) {
+  std::string value;
+  return (GetQueryParamValue(url, "loader", &value) && value == "yts") ||
+         (GetQueryParamValue(url, "rloader", &value) && value == "yts") ||
+         GetQueryParamValue(url, "stick", &value) ||
+         GetQueryParamValue(url, "hrld", &value);
+}
+
+GURL MaybeRestoreYtsSessionContext(const GURL& current_url,
+                                   const GURL& previous_url) {
+  if (!IsYtsStickyCandidate(current_url) || !HasYtsSessionContext(previous_url)) {
+    return current_url;
+  }
+
+  if (!IsYoutubeTvUrl(current_url)) {
+    return current_url;
+  }
+
+  GURL updated_url = current_url;
+  for (const char* key : {"loader", "launch", "yts_server", "yts_agent_id"}) {
+    std::string current_value;
+    if (GetQueryParamValue(updated_url, key, &current_value)) {
+      continue;
+    }
+
+    std::string previous_value;
+    if (GetQueryParamValue(previous_url, key, &previous_value)) {
+      updated_url = net::AppendQueryParameter(updated_url, key, previous_value);
+    }
+  }
+
+  return updated_url;
 }
 
 // Null until/unless the default main message loop is running.
@@ -498,7 +568,35 @@ void Shell::RenderFrameCreated(RenderFrameHost* frame_host) {
 void Shell::PrimaryMainDocumentElementAvailable() {}
 
 void Shell::DidFinishNavigation(NavigationHandle* navigation_handle) {
-  LOG(INFO) << "Navigated to " << navigation_handle->GetURL();
+  content::RenderFrameHost* render_frame_host =
+      navigation_handle->GetRenderFrameHost();
+
+  // Inject stashed yts.prior_connection into agent pages regardless of whether
+  // they are the primary main frame.  The sticky-loader redirect opens the
+  // agent page in a subframe.
+  if (IsYtsAgentPage(navigation_handle->GetURL()) &&
+      !yts_prior_connection_stash_.empty() && render_frame_host) {
+    std::string escaped;
+    base::EscapeJSONString(yts_prior_connection_stash_, true, &escaped);
+    std::string js =
+        "try { if (!window.localStorage.getItem('yts.prior_connection')) {"
+        " window.localStorage.setItem('yts.prior_connection', " +
+        escaped + ");} } catch(e) {}";
+    render_frame_host->ExecuteJavaScript(base::UTF8ToUTF16(js),
+                                         base::DoNothing());
+  }
+
+  if (!navigation_handle->IsInPrimaryMainFrame()) {
+    return;
+  }
+
+  const GURL updated_url = MaybeRestoreYtsSessionContext(
+      navigation_handle->GetURL(),
+      navigation_handle->GetPreviousPrimaryMainFrameURL());
+  if (updated_url != navigation_handle->GetURL()) {
+    LoadURL(updated_url);
+    return;
+  }
 }
 
 void Shell::DidStopLoading() {
@@ -525,7 +623,6 @@ void Shell::DidStopLoading() {
 }
 
 void Shell::RegisterInjectedJavaScript() {
-  // Get the embedded header resource
   GeneratedResourceMap resource_map;
   CobaltJavaScriptPolyfill::GenerateMap(resource_map);
 
@@ -534,14 +631,12 @@ void Shell::RegisterInjectedJavaScript() {
     std::string js(reinterpret_cast<const char*>(file_contents.data),
                    file_contents.size);
 
-    // Inject a script at document start for all origins
     const std::u16string script(base::UTF8ToUTF16(js));
     const std::vector<std::string> allowed_origins({"*"});
     auto result = js_communication_host_->AddDocumentStartJavaScript(
         script, allowed_origins);
 
     if (result.error_message.has_value()) {
-      // error_message contains a value
       LOG(WARNING) << "Failed to register JS injection for:" << file_name
                    << ", error message: " << result.error_message.value();
     }
@@ -903,6 +998,15 @@ bool Shell::DidAddMessageToConsole(WebContents* source,
                                    const std::u16string& message,
                                    int32_t line_no,
                                    const std::u16string& source_id) {
+  // Fallback when the WebMessageListener bridge is unavailable.
+  static constexpr std::string_view kSetItemPrefix =
+      "[cobalt-yts-bridge] setItem key=yts.prior_connection value=";
+
+  std::string msg = base::UTF16ToUTF8(message);
+  if (msg.starts_with(kSetItemPrefix)) {
+    yts_prior_connection_stash_ = msg.substr(kSetItemPrefix.size());
+    return true;
+  }
   return false;
 }
 

--- a/cobalt/shell/browser/shell.h
+++ b/cobalt/shell/browser/shell.h
@@ -292,6 +292,10 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
 
   std::unique_ptr<js_injection::JsCommunicationHost> js_communication_host_;
 
+  // Stash for yts.prior_connection captured from the session-bridge polyfill
+  // and re-injected after cross-origin sticky-loader navigation.
+  std::string yts_prior_connection_stash_;
+
   // TODO: (cobalt b/468059482) each shell holds a single WebContents.
   std::unique_ptr<SplashScreenWebContentsObserver>
       splash_screen_web_contents_observer_;

--- a/cobalt/shell/embedded_resources/cobalt_java_script_polyfill/yts_session_bridge.js
+++ b/cobalt/shell/embedded_resources/cobalt_java_script_polyfill/yts_session_bridge.js
@@ -1,0 +1,40 @@
+/**
+ * @license
+ * Copyright The Cobalt Authors.
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+// Intercepts localStorage writes to yts.prior_connection so the browser process
+// can stash the value in C++ memory and re-inject it after a cross-origin
+// sticky-loader round trip (where the storage partition changes and the
+// original localStorage entry is lost).
+//
+// Communication is via console.info messages matched by
+// Shell::DidAddMessageToConsole on the browser side.
+(function () {
+  if (typeof window === 'undefined' || typeof Storage === 'undefined') {
+    return;
+  }
+
+  var host = window.location && window.location.hostname || '';
+  if (!/(^|\.)youtube\.com$|(^|\.)devicecertification\.youtube$/.test(host)) {
+    return;
+  }
+
+  if (window.__cobaltYtsSessionBridgeInstalled) {
+    return;
+  }
+  window.__cobaltYtsSessionBridgeInstalled = true;
+
+  var KEY = 'yts.prior_connection';
+  var TAG = '[cobalt-yts-bridge] ';
+  var originalSetItem = Storage.prototype.setItem;
+
+  Storage.prototype.setItem = function (key, value) {
+    var result = originalSetItem.apply(this, arguments);
+    if (String(key) === KEY) {
+      console.info(TAG + 'setItem key=' + KEY + ' value=' + value);
+    }
+    return result;
+  };
+})();

--- a/starboard/contrib/rdk/plugin/CobaltImplementation.cpp
+++ b/starboard/contrib/rdk/plugin/CobaltImplementation.cpp
@@ -95,6 +95,7 @@ private:
     Config()
       : Core::JSON::Container()
       , Url()
+      , LaunchType()
       , ClientIdentifier()
       , Language()
       , ContentDir()
@@ -103,6 +104,7 @@ private:
       , AutoSuspendDelay()
       , SbMainArgs() {
       Add(_T("url"), &Url);
+      Add(_T("launchtype"), &LaunchType);
       Add(_T("clientidentifier"), &ClientIdentifier);
       Add(_T("language"), &Language);
       Add(_T("contentdir"), &ContentDir);
@@ -121,6 +123,7 @@ private:
 
   public:
     Core::JSON::String Url;
+    Core::JSON::String LaunchType;
     Core::JSON::String ClientIdentifier;
     Core::JSON::String Language;
     Core::JSON::String ContentDir;
@@ -250,6 +253,7 @@ private:
     CobaltWindow(CobaltImplementation& parent)
       : Core::Thread(0, _T("Cobalt"))
       , _url("https://www.youtube.com/tv")
+      , _launchType()
       , _parent(parent)
     {
     }
@@ -289,6 +293,13 @@ private:
       if (config.Url.IsSet() == true) {
         _url = config.Url.Value();
       }
+
+      _launchType.clear();
+      if (config.LaunchType.IsSet() == true) {
+        _launchType = config.LaunchType.Value();
+      }
+
+      _url = NormalizeUrl(_url, _T("startup"));
 
       if (config.Language.IsSet() == true) {
         string lang = config.Language.Value();
@@ -385,6 +396,62 @@ private:
 
     string Url() const { return _url; }
 
+    string NormalizeUrl(const string& url, const TCHAR reason[]) const
+    {
+      string normalized(url);
+      if (normalized.empty() == true) {
+        return normalized;
+      }
+
+      const size_t fragmentPosition = normalized.find('#');
+      const size_t queryEnd =
+          (fragmentPosition == string::npos ? normalized.length() : fragmentPosition);
+      const size_t launchPosition = normalized.find("launch=");
+      if ((launchPosition != string::npos) && (launchPosition < queryEnd)) {
+        // launch= is already present; ensure utm_content=m is also set for menu launches.
+        const size_t utmPosition = normalized.find("utm_content=");
+        if ((utmPosition == string::npos) || (utmPosition >= queryEnd)) {
+          const string separator = (normalized[queryEnd - 1] == '?' || normalized[queryEnd - 1] == '&') ? "" : "&";
+          normalized.insert(queryEnd, separator + "utm_content=m");
+          SYSLOG(Logging::Notification,
+                 (_T("Appended utm_content=m to %s URL: %s\n"), reason, normalized.c_str()));
+        }
+        return normalized;
+      }
+
+      string launchType(_launchType);
+      if (launchType.empty() == true) {
+        // Infer a menu launch when there is no explicit launch= already:
+        //   - loader=yts present: YTS-initiated launch, always a menu launch.
+        //   - no v= param: plain home-screen launch (no content video ID).
+        if (normalized.find("loader=yts") != string::npos ||
+            normalized.find("v=") == string::npos) {
+          launchType = "launch=menu&utm_content=m";
+          SYSLOG(Logging::Notification,
+                 (_T("Inferred launchtype for %s URL: %s\n"), reason, launchType.c_str()));
+        }
+      }
+
+      if (launchType.empty() == true) {
+        return normalized;
+      }
+
+      string prefix(normalized.substr(0, queryEnd));
+      string suffix(normalized.substr(queryEnd));
+      if (prefix.find('?') == string::npos) {
+        prefix += '?';
+      } else if ((prefix.back() != '?') && (prefix.back() != '&')) {
+        prefix += '&';
+      }
+      prefix += launchType;
+      normalized = prefix + suffix;
+
+      SYSLOG(Logging::Notification,
+             (_T("Applied launchtype to %s URL: %s\n"), reason, normalized.c_str()));
+
+      return normalized;
+    }
+
     bool IsPreloadEnabled() const { return _preloadEnabled; }
 
     uint16_t AutoSuspendDelayInSeconds() const { return _autoSuspendDelayInSeconds; }
@@ -458,6 +525,7 @@ private:
 
     int _exitCode { 0 };
     string _url;
+    string _launchType;
     CobaltImplementation &_parent;
     bool _preloadEnabled { false };
     uint16_t _autoSuspendDelayInSeconds { 30 };
@@ -496,8 +564,9 @@ public:
   }
 
   virtual void SetURL(const string &URL) override {
-    SYSLOG(Logging::Notification, (_T("deeplink=%s\n"), URL.c_str()));
-    SbRdkHandleDeepLink(URL.c_str());
+    const string normalized = _window.NormalizeUrl(URL, _T("deeplink"));
+    SYSLOG(Logging::Notification, (_T("deeplink=%s\n"), normalized.c_str()));
+    SbRdkHandleDeepLink(normalized.c_str());
   }
 
   virtual string GetURL() const override {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_runtime/h_5_vcc_runtime.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_runtime/h_5_vcc_runtime.cc
@@ -26,8 +26,6 @@ H5vccRuntime::H5vccRuntime(LocalDOMWindow& window)
       remote_h5vcc_runtime_(window.GetExecutionContext()),
       deep_link_receiver_(this, window.GetExecutionContext()) {
   EnsureRemoteIsBound();
-  remote_h5vcc_runtime_->GetAndClearInitialDeepLinkSync(&initial_deep_link_);
-  LOG(INFO) << "H5vccRuntime initial DeepLink: " << initial_deep_link_;
 }
 
 void H5vccRuntime::ContextDestroyed() {
@@ -36,6 +34,14 @@ void H5vccRuntime::ContextDestroyed() {
 }
 
 String H5vccRuntime::initialDeepLink() {
+  if (initial_deep_link_.empty()) {
+    String latest_deep_link;
+    EnsureRemoteIsBound();
+    remote_h5vcc_runtime_->GetAndClearInitialDeepLinkSync(&latest_deep_link);
+    if (!latest_deep_link.empty()) {
+      initial_deep_link_ = latest_deep_link;
+    }
+  }
   return initial_deep_link_;
 }
 


### PR DESCRIPTION
This change addresses issues with YTS guided flow test (`"Params Menu 2026+" --guided`) stalling after a relaunch. The initial deep link was being read too early, preventing proper processing. Additionally, the `yts.prior_connection` session state was lost across cross-origin sticky-loader navigations due to storage partitioning.

To resolve this, the `H5vccRuntime` now retrieves the initial deep link when its accessor is called, ensuring the `DeepLinkManager` is ready. A JavaScript polyfill was added to intercept and stash the `yts.prior_connection` value in the browser process. This stashed value is then reinjected into agent pages upon navigation. 

**Note:** PR [#9908](https://github.com/youtube/cobalt/pull/9908) is not merged into `main` yet. The commits from [#9908](https://github.com/youtube/cobalt/pull/9908) are already included on this branch (this work is stacked on top of them). Until [#9908](https://github.com/youtube/cobalt/pull/9908) lands, the diff against `main` will reflect both sets of changes; when [#9908](https://github.com/youtube/cobalt/pull/9908) merges first, the delta for this PR will narrow to the commits described below.

Bug: 476775163