### PR TITLE
cobalt: Record lifecycle state as crash annotation

### DIFF
--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -432,6 +432,8 @@ const char* AppEventDelegate::GetStateString(ApplicationState state) {
       return "kFrozen";
     case ApplicationState::kStopped:
       return "kStopped";
+    default:
+      NOTREACHED();
   }
 }
 

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -25,6 +25,8 @@
 #include "base/threading/platform_thread.h"
 #include "cobalt/app/app_event_runner.h"
 #include "content/public/browser/browser_thread.h"
+#include "starboard/extension/crash_handler.h"
+#include "starboard/system.h"
 
 namespace cobalt {
 
@@ -61,8 +63,11 @@ AppEventDelegate::ApplicationState SbEventToTargetApplicationState(
 }
 }  // namespace
 
-AppEventDelegate::AppEventDelegate(std::unique_ptr<AppEventRunner> runner)
-    : runner_(std::move(runner)) {
+AppEventDelegate::AppEventDelegate(
+    std::unique_ptr<AppEventRunner> runner,
+    const CobaltExtensionCrashHandlerApi* crash_handler_extension)
+    : runner_(std::move(runner)),
+      crash_handler_extension_(crash_handler_extension) {
   base::AutoLock lock(lock_);
   application_state_ = ApplicationState::kInitial;
   target_state_ = ApplicationState::kInitial;
@@ -70,6 +75,13 @@ AppEventDelegate::AppEventDelegate(std::unique_ptr<AppEventRunner> runner)
     // If a special runner wasn't provided, use the default.
     runner_ = AppEventRunner::Create();
   }
+  if (!crash_handler_extension_) {
+    // If a special extension implementation wasn't provided, use the default.
+    crash_handler_extension_ =
+        static_cast<const CobaltExtensionCrashHandlerApi*>(
+            SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
+  }
+  SetApplicationStateAnnotation(application_state_);
 }
 
 AppEventDelegate::~AppEventDelegate() {}
@@ -145,6 +157,7 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
         runner_->OnStart(event);
         application_state_ = SbEventToTargetApplicationState(event->type);
         target_state_ = application_state_;
+        SetApplicationStateAnnotation(application_state_);
         return;
       default:
         // Robustly handle events received before the application has started or
@@ -220,6 +233,7 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
       runner_->OnStop();
       application_state_ = ApplicationState::kStopped;
       target_state_ = ApplicationState::kStopped;
+      SetApplicationStateAnnotation(application_state_);
       break;
     case kSbEventTypeInput:
       runner_->OnInput(event);
@@ -317,6 +331,7 @@ void AppEventDelegate::ExecuteNextStepOnUIThreadLocked(
   }
 
   application_state_ = next_state;
+  SetApplicationStateAnnotation(application_state_);
 
   if (schedule_next_step) {
     content::GetUIThreadTaskRunner({})->PostTask(
@@ -399,6 +414,37 @@ void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {
         }
       }
     }
+  }
+}
+
+// static
+const char* AppEventDelegate::GetStateString(ApplicationState state) {
+  switch (state) {
+    case ApplicationState::kInitial:
+      return "kInitial";
+    case ApplicationState::kStarted:
+      return "kStarted";
+    case ApplicationState::kBlurred:
+      return "kBlurred";
+    case ApplicationState::kConcealed:
+      return "kConcealed";
+    case ApplicationState::kFrozen:
+      return "kFrozen";
+    case ApplicationState::kStopped:
+      return "kStopped";
+  }
+}
+
+void AppEventDelegate::SetApplicationStateAnnotation(ApplicationState state) {
+  if (!crash_handler_extension_ || crash_handler_extension_->version < 2) {
+    LOG(WARNING)
+        << "Crash handler extension not implemented or version too low.";
+    return;
+  }
+
+  if (!crash_handler_extension_->SetString("application_state",
+                                           GetStateString(state))) {
+    LOG(WARNING) << "Failed to set application_state annotation.";
   }
 }
 

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -68,20 +68,20 @@ AppEventDelegate::AppEventDelegate(
     const CobaltExtensionCrashHandlerApi* crash_handler_extension)
     : runner_(std::move(runner)),
       crash_handler_extension_(crash_handler_extension) {
-  base::AutoLock lock(lock_);
-  application_state_ = ApplicationState::kInitial;
-  target_state_ = ApplicationState::kInitial;
-  if (!runner_) {
-    // If a special runner wasn't provided, use the default.
-    runner_ = AppEventRunner::Create();
-  }
   if (!crash_handler_extension_) {
     // If a special extension implementation wasn't provided, use the default.
     crash_handler_extension_ =
         static_cast<const CobaltExtensionCrashHandlerApi*>(
             SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
   }
-  SetApplicationStateAnnotation(application_state_);
+
+  base::AutoLock lock(lock_);
+  SetApplicationState(ApplicationState::kInitial);
+  target_state_ = ApplicationState::kInitial;
+  if (!runner_) {
+    // If a special runner wasn't provided, use the default.
+    runner_ = AppEventRunner::Create();
+  }
 }
 
 AppEventDelegate::~AppEventDelegate() {}
@@ -155,9 +155,8 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
       case kSbEventTypeStart:
       case kSbEventTypePreload:
         runner_->OnStart(event);
-        application_state_ = SbEventToTargetApplicationState(event->type);
+        SetApplicationState(SbEventToTargetApplicationState(event->type));
         target_state_ = application_state_;
-        SetApplicationStateAnnotation(application_state_);
         return;
       default:
         // Robustly handle events received before the application has started or
@@ -231,9 +230,8 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
           << "kSbEventTypeStop must be delivered on the UI thread.";
 
       runner_->OnStop();
-      application_state_ = ApplicationState::kStopped;
+      SetApplicationState(ApplicationState::kStopped);
       target_state_ = ApplicationState::kStopped;
-      SetApplicationStateAnnotation(application_state_);
       break;
     case kSbEventTypeInput:
       runner_->OnInput(event);
@@ -330,8 +328,7 @@ void AppEventDelegate::ExecuteNextStepOnUIThreadLocked(
     }
   }
 
-  application_state_ = next_state;
-  SetApplicationStateAnnotation(application_state_);
+  SetApplicationState(next_state);
 
   if (schedule_next_step) {
     content::GetUIThreadTaskRunner({})->PostTask(
@@ -435,6 +432,11 @@ const char* AppEventDelegate::GetStateString(ApplicationState state) {
     default:
       NOTREACHED();
   }
+}
+
+void AppEventDelegate::SetApplicationState(ApplicationState state) {
+  application_state_ = state;
+  SetApplicationStateAnnotation(state);
 }
 
 void AppEventDelegate::SetApplicationStateAnnotation(ApplicationState state) {

--- a/cobalt/app/app_event_delegate.h
+++ b/cobalt/app/app_event_delegate.h
@@ -27,6 +27,7 @@
 #include "build/build_config.h"
 #include "cobalt/app/app_event_runner.h"
 #include "starboard/event.h"
+#include "starboard/extension/crash_handler.h"
 
 #if BUILDFLAG(IS_STARBOARD)
 #include "ui/ozone/platform/starboard/platform_event_source_starboard.h"
@@ -60,7 +61,9 @@ class AppEventDelegate {
     kStopped = 5
   };
 
-  explicit AppEventDelegate(std::unique_ptr<AppEventRunner> runner = nullptr);
+  explicit AppEventDelegate(
+      std::unique_ptr<AppEventRunner> runner = nullptr,
+      const CobaltExtensionCrashHandlerApi* crash_handler_extension = nullptr);
   ~AppEventDelegate();
 
   AppEventDelegate(const AppEventDelegate&) = delete;
@@ -77,8 +80,12 @@ class AppEventDelegate {
   ApplicationState GetState() const;
 
  private:
+  static const char* GetStateString(ApplicationState state);
+
   void HandleEventLocked(const SbEvent* event);
   void TransitionToLifeCycleState(ApplicationState state);
+
+  void SetApplicationStateAnnotation(ApplicationState state);
 
   // Helper that executes a single lifecycle step on the UI thread and then
   // schedules the next step if the target state has not yet been reached.
@@ -94,6 +101,7 @@ class AppEventDelegate {
   mutable base::Lock lock_;
 
   std::unique_ptr<AppEventRunner> runner_;
+  const CobaltExtensionCrashHandlerApi* crash_handler_extension_ = nullptr;
   ApplicationState application_state_ = ApplicationState::kInitial;
   ApplicationState target_state_ = ApplicationState::kInitial;
   bool is_transitioning_ = false;

--- a/cobalt/app/app_event_delegate.h
+++ b/cobalt/app/app_event_delegate.h
@@ -110,7 +110,8 @@ class AppEventDelegate {
   mutable base::Lock lock_;
 
   std::unique_ptr<AppEventRunner> runner_;
-  raw_ptr<const CobaltExtensionCrashHandlerApi> crash_handler_extension_ = nullptr;
+  raw_ptr<const CobaltExtensionCrashHandlerApi> crash_handler_extension_ =
+      nullptr;
   ApplicationState application_state_ = ApplicationState::kInitial;
   ApplicationState target_state_ = ApplicationState::kInitial;
   bool is_transitioning_ = false;

--- a/cobalt/app/app_event_delegate.h
+++ b/cobalt/app/app_event_delegate.h
@@ -20,6 +20,7 @@
 #include <optional>
 
 #include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/synchronization/lock.h"
 #include "base/synchronization/waitable_event.h"
@@ -61,6 +62,8 @@ class AppEventDelegate {
     kStopped = 5
   };
 
+  // TODO: b/486236529 - As suggested by jellefoks@, consider using factories to
+  // improve code clarity and decouple |AppEventDelegate| from its dependencies.
   explicit AppEventDelegate(
       std::unique_ptr<AppEventRunner> runner = nullptr,
       const CobaltExtensionCrashHandlerApi* crash_handler_extension = nullptr);
@@ -85,6 +88,12 @@ class AppEventDelegate {
   void HandleEventLocked(const SbEvent* event);
   void TransitionToLifeCycleState(ApplicationState state);
 
+  // Wrapper that sets |application_state_| with the side effect of recording
+  // this new state as a crash annotation.
+  // TODO: b/486236529 - Consider enforcing that |application_state_| can only
+  // be modified from within this method. This would prevent developers from
+  // inadvertently updating the member variable but not the crash annotation.
+  void SetApplicationState(ApplicationState state);
   void SetApplicationStateAnnotation(ApplicationState state);
 
   // Helper that executes a single lifecycle step on the UI thread and then
@@ -101,7 +110,7 @@ class AppEventDelegate {
   mutable base::Lock lock_;
 
   std::unique_ptr<AppEventRunner> runner_;
-  const CobaltExtensionCrashHandlerApi* crash_handler_extension_ = nullptr;
+  raw_ptr<const CobaltExtensionCrashHandlerApi> crash_handler_extension_ = nullptr;
   ApplicationState application_state_ = ApplicationState::kInitial;
   ApplicationState target_state_ = ApplicationState::kInitial;
   bool is_transitioning_ = false;

--- a/cobalt/app/app_event_delegate_unittest.cc
+++ b/cobalt/app/app_event_delegate_unittest.cc
@@ -128,8 +128,8 @@ class AppEventDelegateTest : public ::testing::Test {
     }));
 
     // The constructor calls SetApplicationStateAnnotation(kInitial).
-    // We set a baseline expectation that ignores the exact count of SetString calls
-    // globally, so individual tests can focus on specific transitions.
+    // We set a baseline expectation that ignores the exact count of SetString
+    // calls globally, so individual tests can focus on specific transitions.
     EXPECT_CALL(mock_crash_handler_, SetString(testing::_, testing::_))
         .Times(testing::AnyNumber());
 
@@ -411,19 +411,25 @@ TEST_F(AppEventDelegateTest,
        SynthesisStopFromStartedReflectedInCrashAnnotations) {
   delegate_.reset();  // Restart lifecycle to verify the kInitial transition.
   InSequence s;
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kInitial")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kInitial")));
   CreateDelegate(/*nice_runner=*/true);
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kStarted")));
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kBlurred")));
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kConcealed")));
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kFrozen")));
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kStopped")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kStarted")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kBlurred")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kConcealed")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kFrozen")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kStopped")));
 
   SendEvent(kSbEventTypeStart);
   SendEvent(kSbEventTypeStop);
@@ -434,25 +440,31 @@ TEST_F(AppEventDelegateTest,
   delegate_.reset();  // Restart lifecycle to verify the kInitial transition.
   InSequence s;
   // 1. Arrange: get the app into a Frozen state.
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kInitial")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kInitial")));
   CreateDelegate(/*nice_runner=*/true);
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kConcealed")));
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kFrozen")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kConcealed")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kFrozen")));
 
   SendEvent(kSbEventTypePreload);  // kInitial -> kConcealed
   SendEvent(kSbEventTypeFreeze);   // kConcealed -> kFrozen
 
   // 2. Act and verify: transition from Frozen to Started (via Focus).
   // This should trigger: kFrozen -> kConcealed -> kBlurred -> kStarted.
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kConcealed")));
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kBlurred")));
-  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
-                                             testing::StrEq("kStarted")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kConcealed")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kBlurred")));
+  EXPECT_CALL(mock_crash_handler_,
+              SetString(testing::StrEq("application_state"),
+                        testing::StrEq("kStarted")));
 
   SendEvent(kSbEventTypeFocus);
 }

--- a/cobalt/app/app_event_delegate_unittest.cc
+++ b/cobalt/app/app_event_delegate_unittest.cc
@@ -15,9 +15,12 @@
 #include "cobalt/app/app_event_delegate.h"
 
 #include <memory>
+#include <string>
+#include <vector>
 
 #include "cobalt/app/app_event_runner.h"
 #include "content/public/test/browser_task_environment.h"
+#include "starboard/extension/crash_handler.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -65,10 +68,49 @@ class MockAppEventRunner : public AppEventRunner {
   MOCK_METHOD(void, DoUnfreeze, (), (override));
 };
 
+// This class provides a bridge to allow gMock to verify calls made through the
+// C-style Starboard extension function pointer interface.
+class MockCrashHandler {
+ public:
+  MockCrashHandler() {
+    ON_CALL(*this, SetString(testing::_, testing::_))
+        .WillByDefault(testing::Return(true));
+  }
+  MOCK_METHOD(bool, SetString, (const char* key, const char* value));
+
+  static bool SetStringStatic(const char* key, const char* value) {
+    return instance_->SetString(key, value);
+  }
+
+  static void SetInstance(MockCrashHandler* instance) { instance_ = instance; }
+
+ private:
+  static MockCrashHandler* instance_;
+};
+
+MockCrashHandler* MockCrashHandler::instance_ = nullptr;
+
 class AppEventDelegateTest : public ::testing::Test {
  public:
   AppEventDelegateTest() {
-    auto runner = std::make_unique<MockAppEventRunner>();
+    MockCrashHandler::SetInstance(&mock_crash_handler_);
+    crash_handler_extension_.name = kCobaltExtensionCrashHandlerName;
+    crash_handler_extension_.version = 2;
+    crash_handler_extension_.SetString = &MockCrashHandler::SetStringStatic;
+
+    CreateDelegate();
+  }
+
+  ~AppEventDelegateTest() override { MockCrashHandler::SetInstance(nullptr); }
+
+ protected:
+  void CreateDelegate(bool nice_runner = false) {
+    std::unique_ptr<MockAppEventRunner> runner;
+    if (nice_runner) {
+      runner = std::make_unique<testing::NiceMock<MockAppEventRunner>>();
+    } else {
+      runner = std::make_unique<MockAppEventRunner>();
+    }
     runner_ = runner.get();
 
     // Use default implementations for state tracking to avoid manual setup.
@@ -85,17 +127,28 @@ class AppEventDelegateTest : public ::testing::Test {
       is_visible_ = false;
     }));
 
-    delegate_ = std::make_unique<AppEventDelegate>(std::move(runner));
+    // The constructor calls SetApplicationStateAnnotation(kInitial).
+    // We set a baseline expectation that ignores the exact count of SetString calls
+    // globally, so individual tests can focus on specific transitions.
+    EXPECT_CALL(mock_crash_handler_, SetString(testing::_, testing::_))
+        .Times(testing::AnyNumber());
+
+    delegate_ = std::make_unique<AppEventDelegate>(std::move(runner),
+                                                   &crash_handler_extension_);
   }
 
- protected:
   void SendEvent(SbEventType type, void* data = nullptr) {
+    if (!delegate_) {
+      CreateDelegate();
+    }
     SbEvent event = {type, 0, data};
     delegate_->HandleEvent(&event);
     task_environment_.RunUntilIdle();
   }
 
   content::BrowserTaskEnvironment task_environment_;
+  MockCrashHandler mock_crash_handler_;
+  CobaltExtensionCrashHandlerApi crash_handler_extension_ = {};
   MockAppEventRunner* runner_;
   std::unique_ptr<AppEventDelegate> delegate_;
 
@@ -352,6 +405,56 @@ TEST_F(AppEventDelegateTest, RedundantUnfreezeIgnored) {
   // App is already unfrozen (Concealed).
   EXPECT_CALL(*runner_, DoUnfreeze()).Times(0);
   SendEvent(kSbEventTypeUnfreeze);
+}
+
+TEST_F(AppEventDelegateTest,
+       SynthesisStopFromStartedReflectedInCrashAnnotations) {
+  delegate_.reset();  // Restart lifecycle to verify the kInitial transition.
+  InSequence s;
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kInitial")));
+  CreateDelegate(/*nice_runner=*/true);
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kStarted")));
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kBlurred")));
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kConcealed")));
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kFrozen")));
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kStopped")));
+
+  SendEvent(kSbEventTypeStart);
+  SendEvent(kSbEventTypeStop);
+}
+
+TEST_F(AppEventDelegateTest,
+       FrozenToStartedViaFocusReflectedInCrashAnnotations) {
+  delegate_.reset();  // Restart lifecycle to verify the kInitial transition.
+  InSequence s;
+  // 1. Arrange: get the app into a Frozen state.
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kInitial")));
+  CreateDelegate(/*nice_runner=*/true);
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kConcealed")));
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kFrozen")));
+
+  SendEvent(kSbEventTypePreload);  // kInitial -> kConcealed
+  SendEvent(kSbEventTypeFreeze);   // kConcealed -> kFrozen
+
+  // 2. Act and verify: transition from Frozen to Started (via Focus).
+  // This should trigger: kFrozen -> kConcealed -> kBlurred -> kStarted.
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kConcealed")));
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kBlurred")));
+  EXPECT_CALL(mock_crash_handler_, SetString(testing::StrEq("application_state"),
+                                             testing::StrEq("kStarted")));
+
+  SendEvent(kSbEventTypeFocus);
 }
 
 }  // namespace cobalt


### PR DESCRIPTION
This ports forward this behavior from C25, leveraging Cobalt's new lifecycle state machine. The behavior is only added for platforms that use Starboard and that implement the CrashHandler Starboard extension: so, 3P platforms.

The CrashHandler Starboard extension implementation may be injected into cobalt::AppEventDelegate as a dependency so that unit tests can provide a mock.

#vibe-coded

Issue: 486236529