### PR TITLE
nplb: Use consistent temporary directory for tests

### DIFF
--- a/starboard/nplb/file_helpers.cc
+++ b/starboard/nplb/file_helpers.cc
@@ -171,6 +171,23 @@ bool DirectoryExists(const char* path) {
   return stat(path, &info) == 0 && S_ISDIR(info.st_mode);
 }
 
+ScopedTempDir::ScopedTempDir() {
+  std::string temp_dir = GetTempDir();
+  if (temp_dir.empty()) {
+    return;
+  }
+  path_ = temp_dir + kSbFileSepString + "scoped_dir_XXXXXX";
+  if (!mkdtemp(&path_[0])) {
+    path_.clear();
+  }
+}
+
+ScopedTempDir::~ScopedTempDir() {
+  if (IsValid()) {
+    RemoveFileOrDirectoryRecursively(path_);
+  }
+}
+
 // static
 std::string ScopedRandomFile::MakeRandomFilePath() {
   std::ostringstream filename_stream;

--- a/starboard/nplb/file_helpers.h
+++ b/starboard/nplb/file_helpers.h
@@ -47,6 +47,23 @@ bool FileExists(const char* path);
 
 bool DirectoryExists(const char* path);
 
+// Creates a random directory, and deletes it and its contents when the instance
+// falls out of scope.
+class ScopedTempDir {
+ public:
+  ScopedTempDir();
+  ~ScopedTempDir();
+
+  // Returns the path to the created directory.
+  const std::string& path() const { return path_; }
+
+  // Returns whether the directory was successfully created.
+  bool IsValid() const { return !path_.empty(); }
+
+ private:
+  std::string path_;
+};
+
 // Creates a random file of the given length, and deletes it when the instance
 // falls out of scope.
 class ScopedRandomFile {

--- a/starboard/nplb/file_helpers.h
+++ b/starboard/nplb/file_helpers.h
@@ -54,6 +54,9 @@ class ScopedTempDir {
   ScopedTempDir();
   ~ScopedTempDir();
 
+  ScopedTempDir(const ScopedTempDir&) = delete;
+  ScopedTempDir& operator=(const ScopedTempDir&) = delete;
+
   // Returns the path to the created directory.
   const std::string& path() const { return path_; }
 

--- a/starboard/nplb/posix_compliance/posix_file_get_info_test.cc
+++ b/starboard/nplb/posix_compliance/posix_file_get_info_test.cc
@@ -86,11 +86,10 @@ TEST(PosixFileGetInfoTest, WorksOnStaticContentFiles) {
 }
 
 TEST(PosixFileGetInfoTest, WorksOnADirectory) {
-  char dir_template[] = "/tmp/fstat_test_dir.XXXXXX";
-  char* dir_path = mkdtemp(dir_template);
-  ASSERT_NE(dir_path, nullptr);
+  ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.IsValid());
 
-  int fd = open(dir_path, O_RDONLY);
+  int fd = open(temp_dir.path().c_str(), O_RDONLY);
   ASSERT_NE(fd, -1);
 
   struct stat info;
@@ -98,7 +97,6 @@ TEST(PosixFileGetInfoTest, WorksOnADirectory) {
   EXPECT_TRUE(S_ISDIR(info.st_mode));
 
   EXPECT_EQ(close(fd), 0);
-  EXPECT_EQ(rmdir(dir_path), 0);
 }
 
 TEST(PosixFileGetInfoTest, FollowsSymbolicLink) {
@@ -106,11 +104,10 @@ TEST(PosixFileGetInfoTest, FollowsSymbolicLink) {
   ScopedRandomFile target_file(file_size);
   std::string target_path = target_file.filename();
 
-  char dir_template[] = "/tmp/fstat_test_dir.XXXXXX";
-  char* dir_path = mkdtemp(dir_template);
-  ASSERT_NE(dir_path, nullptr);
+  ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.IsValid());
 
-  std::string link_path = std::string(dir_path) + "/symlink";
+  std::string link_path = temp_dir.path() + "/symlink";
   ASSERT_EQ(symlink(target_path.c_str(), link_path.c_str()), 0);
 
   // Open the symbolic link.
@@ -124,19 +121,16 @@ TEST(PosixFileGetInfoTest, FollowsSymbolicLink) {
   EXPECT_TRUE(S_ISREG(info.st_mode));  // Should be a regular file.
 
   EXPECT_EQ(close(fd), 0);
-  EXPECT_EQ(unlink(link_path.c_str()), 0);
-  EXPECT_EQ(rmdir(dir_path), 0);
 }
 
 TEST(PosixFileGetInfoTest, ReportsHardLinkCount) {
   ScopedRandomFile file;
   std::string path1 = file.filename();
 
-  char dir_template[] = "/tmp/fstat_test_dir.XXXXXX";
-  char* dir_path = mkdtemp(dir_template);
-  ASSERT_NE(dir_path, nullptr);
+  ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.IsValid());
 
-  std::string path2 = std::string(dir_path) + "/hardlink";
+  std::string path2 = temp_dir.path() + "/hardlink";
 
   // Create a hard link.
   ASSERT_EQ(link(path1.c_str(), path2.c_str()), 0);
@@ -150,8 +144,6 @@ TEST(PosixFileGetInfoTest, ReportsHardLinkCount) {
   EXPECT_EQ(info.st_nlink, 2u);
 
   EXPECT_EQ(close(fd), 0);
-  EXPECT_EQ(unlink(path2.c_str()), 0);
-  EXPECT_EQ(rmdir(dir_path), 0);
 }
 
 }  // namespace

--- a/starboard/nplb/posix_compliance/posix_lstat_test.cc
+++ b/starboard/nplb/posix_compliance/posix_lstat_test.cc
@@ -54,34 +54,31 @@ TEST(PosixLstatTest, LstatOnExistingFile) {
 }
 
 TEST(PosixLstatTest, LstatOnExistingDirectory) {
-  const char* dir_path = "test_dir.tmp";
-  ASSERT_EQ(mkdir(dir_path, 0755), 0);
+  ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.IsValid());
 
   struct stat sb;
-  EXPECT_EQ(lstat(dir_path, &sb), 0);
+  EXPECT_EQ(lstat(temp_dir.path().c_str(), &sb), 0);
   EXPECT_TRUE(S_ISDIR(sb.st_mode));
   // Modern filesystems might have just one link.
   EXPECT_GE(sb.st_nlink, 1u);
-  rmdir(dir_path);
 }
 
 TEST(PosixLstatTest, DirectoryWithSubdirectory) {
-  char template_name[] = "/tmp/lstat_test_XXXXXX";
-  char* parent_dir_path = mkdtemp(template_name);
-  std::string child_dir_path_str = std::string(parent_dir_path) + "/child";
+  ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.IsValid());
+  std::string child_dir_path_str = temp_dir.path() + "/child";
 
   ASSERT_EQ(mkdir(child_dir_path_str.c_str(), 0755), 0);
 
   struct stat sb;
-  EXPECT_EQ(lstat(parent_dir_path, &sb), 0);
+  EXPECT_EQ(lstat(temp_dir.path().c_str(), &sb), 0);
   EXPECT_TRUE(S_ISDIR(sb.st_mode));
   // A directory with one subdirectory has 3 links:
   // 1. Its own entry in the parent directory.
   // 2. The "." entry within itself.
   // 3. The ".." entry within the subdirectory pointing back to it.
   EXPECT_EQ(sb.st_nlink, 3u);
-  rmdir(child_dir_path_str.c_str());
-  rmdir(parent_dir_path);
 }
 
 TEST(PosixLstatTest, LstatOnSymbolicLinkToFile) {

--- a/starboard/nplb/posix_compliance/posix_mkdir_test.cc
+++ b/starboard/nplb/posix_compliance/posix_mkdir_test.cc
@@ -41,19 +41,13 @@ namespace {
 class PosixMkdirTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    char template_name[] = "/tmp/mkdir_test_XXXXXX";
-    char* dir_name = mkdtemp(template_name);
-    ASSERT_NE(dir_name, nullptr) << "mkdtemp failed: " << strerror(errno);
-    test_dir_ = dir_name;
+    ASSERT_TRUE(temp_dir_.IsValid())
+        << "ScopedTempDir failed to create directory";
   }
 
-  void TearDown() override {
-    if (!test_dir_.empty()) {
-      RemoveFileOrDirectoryRecursively(test_dir_.c_str());
-    }
-  }
+  void TearDown() override {}
 
-  std::string test_dir_;
+  ScopedTempDir temp_dir_;
 };
 
 TEST_F(PosixMkdirTest, FailsWithEmptyPath) {
@@ -63,7 +57,7 @@ TEST_F(PosixMkdirTest, FailsWithEmptyPath) {
 }
 
 TEST_F(PosixMkdirTest, SuccessfulCreation) {
-  std::string dir_path = test_dir_ + "/new_dir";
+  std::string dir_path = temp_dir_.path() + "/new_dir";
   const mode_t mode = kUserRwx;
 
   ASSERT_EQ(mkdir(dir_path.c_str(), mode), 0);
@@ -100,7 +94,7 @@ TEST_F(PosixMkdirTest, FailsOnEmptyPath) {
 }
 
 TEST_F(PosixMkdirTest, HandlesTrailingSeparators) {
-  std::string dir_base = test_dir_ + "/new_dir";
+  std::string dir_base = temp_dir_.path() + "/new_dir";
   std::string path_with_separators = dir_base + "//";
 
   errno = 0;
@@ -114,7 +108,7 @@ TEST_F(PosixMkdirTest, HandlesTrailingSeparators) {
 }
 
 TEST_F(PosixMkdirTest, FailsIfPathExistsAsFile) {
-  std::string file_path = test_dir_ + "/a_file";
+  std::string file_path = temp_dir_.path() + "/a_file";
   int fd = open(file_path.c_str(), O_CREAT | O_WRONLY, 0600);
   ASSERT_NE(fd, -1);
   close(fd);
@@ -124,7 +118,7 @@ TEST_F(PosixMkdirTest, FailsIfPathExistsAsFile) {
 }
 
 TEST_F(PosixMkdirTest, FailsIfPathExistsAsDirectory) {
-  std::string dir_path = test_dir_ + "/existing_dir";
+  std::string dir_path = temp_dir_.path() + "/existing_dir";
   ASSERT_EQ(mkdir(dir_path.c_str(), kUserRwx), 0);
 
   EXPECT_EQ(mkdir(dir_path.c_str(), kUserRwx), -1);
@@ -132,8 +126,8 @@ TEST_F(PosixMkdirTest, FailsIfPathExistsAsDirectory) {
 }
 
 TEST_F(PosixMkdirTest, FailsIfPathIsSymbolicLink) {
-  std::string target_path = test_dir_ + "/target";
-  std::string link_path = test_dir_ + "/the_link";
+  std::string target_path = temp_dir_.path() + "/target";
+  std::string link_path = temp_dir_.path() + "/the_link";
   ASSERT_EQ(mkdir(target_path.c_str(), kUserRwx), 0);
   ASSERT_EQ(symlink(target_path.c_str(), link_path.c_str()), 0);
 
@@ -143,13 +137,13 @@ TEST_F(PosixMkdirTest, FailsIfPathIsSymbolicLink) {
 }
 
 TEST_F(PosixMkdirTest, FailsIfParentDoesNotExist) {
-  std::string path = test_dir_ + "/non_existent_parent/new_dir";
+  std::string path = temp_dir_.path() + "/non_existent_parent/new_dir";
   EXPECT_EQ(mkdir(path.c_str(), kUserRwx), -1);
   EXPECT_EQ(errno, ENOENT);
 }
 
 TEST_F(PosixMkdirTest, FailsIfPathComponentIsNotDirectory) {
-  std::string file_path = test_dir_ + "/a_file";
+  std::string file_path = temp_dir_.path() + "/a_file";
   int fd = open(file_path.c_str(), O_CREAT | O_WRONLY, 0600);
   ASSERT_NE(fd, -1);
   close(fd);
@@ -161,13 +155,13 @@ TEST_F(PosixMkdirTest, FailsIfPathComponentIsNotDirectory) {
 }
 
 TEST_F(PosixMkdirTest, FailsWithSymbolicLinkLoop) {
-  std::string link_a_path = test_dir_ + "/link_a";
-  std::string link_b_path = test_dir_ + "/link_b";
+  std::string link_a_path = temp_dir_.path() + "/link_a";
+  std::string link_b_path = temp_dir_.path() + "/link_b";
 
   ASSERT_EQ(symlink("link_b", link_a_path.c_str()), 0);
   ASSERT_EQ(symlink("link_a", link_b_path.c_str()), 0);
 
-  std::string path_in_loop = test_dir_ + "/link_a/new_dir";
+  std::string path_in_loop = temp_dir_.path() + "/link_a/new_dir";
   errno = 0;
   EXPECT_EQ(mkdir(path_in_loop.c_str(), kUserRwx), -1);
   EXPECT_EQ(errno, ELOOP);
@@ -175,7 +169,7 @@ TEST_F(PosixMkdirTest, FailsWithSymbolicLinkLoop) {
 
 TEST_F(PosixMkdirTest, FailsOnPathTooLong) {
   std::string long_name(kSbFileMaxPath + 1, 'b');
-  std::string long_path = test_dir_ + "/" + long_name;
+  std::string long_path = temp_dir_.path() + "/" + long_name;
   errno = 0;
   EXPECT_EQ(mkdir(long_path.c_str(), kUserRwx), -1);
   EXPECT_EQ(errno, ENAMETOOLONG);

--- a/starboard/nplb/posix_compliance/posix_readlink_test.cc
+++ b/starboard/nplb/posix_compliance/posix_readlink_test.cc
@@ -42,26 +42,20 @@ namespace {
 class PosixReadlinkTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    char template_name[] = "/tmp/readlink_test_XXXXXX";
-    char* dir_name = mkdtemp(template_name);
-    ASSERT_NE(dir_name, nullptr) << "mkdtemp failed: " << strerror(errno);
-    test_dir_ = dir_name;
+    ASSERT_TRUE(temp_dir_.IsValid())
+        << "ScopedTempDir failed to create directory";
 
     link_target_content_ = "a/relative/path/to/a/file.txt";
-    link_path_ = test_dir_ + "/the_link";
+    link_path_ = temp_dir_.path() + "/the_link";
 
     int res = symlink(link_target_content_.c_str(), link_path_.c_str());
     ASSERT_EQ(res, 0) << "Failed to create symlink in setup: "
                       << strerror(errno);
   }
 
-  void TearDown() override {
-    if (!test_dir_.empty()) {
-      ASSERT_TRUE(RemoveFileOrDirectoryRecursively(test_dir_.c_str()));
-    }
-  }
+  void TearDown() override {}
 
-  std::string test_dir_;
+  ScopedTempDir temp_dir_;
   std::string link_path_;
   std::string link_target_content_;
 };
@@ -97,7 +91,7 @@ TEST_F(PosixReadlinkTest, DoesNotNullTerminate) {
 }
 
 TEST_F(PosixReadlinkTest, PathIsNotSymlinkFails) {
-  std::string regular_file = test_dir_ + "/regular.txt";
+  std::string regular_file = temp_dir_.path() + "/regular.txt";
   int fd = open(regular_file.c_str(), O_CREAT | O_WRONLY, kUserRw);
   ASSERT_NE(fd, -1) << "Failed to create test file: " << strerror(errno);
   ASSERT_EQ(write(fd, "hello", 5), 5);
@@ -110,7 +104,7 @@ TEST_F(PosixReadlinkTest, PathIsNotSymlinkFails) {
 }
 
 TEST_F(PosixReadlinkTest, NonExistentPathFails) {
-  std::string non_existent_path = test_dir_ + "/does_not_exist";
+  std::string non_existent_path = temp_dir_.path() + "/does_not_exist";
   char buf[PATH_MAX];
   errno = 0;
   EXPECT_EQ(readlink(non_existent_path.c_str(), buf, sizeof(buf)), -1);
@@ -125,7 +119,7 @@ TEST_F(PosixReadlinkTest, EmptyPathFails) {
 }
 
 TEST_F(PosixReadlinkTest, PathComponentNotDirectoryFails) {
-  std::string file_as_dir = test_dir_ + "/file_as_dir";
+  std::string file_as_dir = temp_dir_.path() + "/file_as_dir";
   int fd = open(file_as_dir.c_str(), O_CREAT | O_WRONLY, kUserRw);
   ASSERT_NE(fd, -1);
   close(fd);
@@ -145,7 +139,7 @@ TEST_F(PosixReadlinkTest, PermissionDeniedFails) {
   }
 
   constexpr mode_t user_rwx = S_IRUSR | S_IWUSR | S_IXUSR;
-  std::string protected_dir = test_dir_ + "/protected";
+  std::string protected_dir = temp_dir_.path() + "/protected";
   std::string link_in_protected = protected_dir + "/inner_link";
 
   ASSERT_EQ(mkdir(protected_dir.c_str(), user_rwx), 0);
@@ -176,8 +170,8 @@ TEST_F(PosixReadlinkTest, InvalidBufferSizeFails) {
 }
 
 TEST_F(PosixReadlinkTest, SymlinkLoopFails) {
-  std::string link_a_path = test_dir_ + "/link_a";
-  std::string link_b_path = test_dir_ + "/link_b";
+  std::string link_a_path = temp_dir_.path() + "/link_a";
+  std::string link_b_path = temp_dir_.path() + "/link_b";
 
   ASSERT_EQ(symlink(link_b_path.c_str(), link_a_path.c_str()), 0);
   ASSERT_EQ(symlink(link_a_path.c_str(), link_b_path.c_str()), 0);
@@ -195,7 +189,7 @@ TEST_F(PosixReadlinkTest, SymlinkLoopFails) {
 
 TEST_F(PosixReadlinkTest, PathTooLongFails) {
   std::string long_name(PATH_MAX + 1, 'a');
-  std::string long_path = test_dir_ + "/" + long_name;
+  std::string long_path = temp_dir_.path() + "/" + long_name;
 
   char buf[PATH_MAX];
   errno = 0;

--- a/starboard/nplb/posix_compliance/posix_realpath_test.cc
+++ b/starboard/nplb/posix_compliance/posix_realpath_test.cc
@@ -37,13 +37,11 @@ const mode_t kUserRwx = S_IRWXU;
 class PosixRealpathTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    char template_name[] = "/tmp/realpath_test_XXXXXX";
-    char* dir_name = mkdtemp(template_name);
-    ASSERT_NE(dir_name, nullptr) << "mkdtemp failed: " << strerror(errno);
-    test_dir_ = dir_name;
+    ASSERT_TRUE(temp_dir_.IsValid())
+        << "ScopedTempDir failed to create directory";
 
     // Create a known file/directory structure for tests:
-    // test_dir_
+    // temp_dir_.path()
     // |-- file1
     // |-- subdir1
     // |   `-- file2
@@ -58,13 +56,13 @@ class PosixRealpathTest : public ::testing::Test {
     // `-- loop_b -> "loop_a"
 
     // Create file1
-    std::string file1_path = test_dir_ + "/file1";
+    std::string file1_path = temp_dir_.path() + "/file1";
     int fd = open(file1_path.c_str(), O_CREAT | O_WRONLY, 0600);
     ASSERT_NE(fd, -1);
     ASSERT_EQ(close(fd), 0);
 
     // Create subdir1 and file2
-    std::string subdir1_path = test_dir_ + "/subdir1";
+    std::string subdir1_path = temp_dir_.path() + "/subdir1";
     ASSERT_EQ(mkdir(subdir1_path.c_str(), kUserRwx), 0);
     std::string file2_path = subdir1_path + "/file2";
     fd = open(file2_path.c_str(), O_CREAT | O_WRONLY, 0600);
@@ -72,17 +70,13 @@ class PosixRealpathTest : public ::testing::Test {
     ASSERT_EQ(close(fd), 0);
   }
 
-  void TearDown() override {
-    if (!test_dir_.empty()) {
-      RemoveFileOrDirectoryRecursively(test_dir_.c_str());
-    }
-  }
+  void TearDown() override {}
 
-  std::string test_dir_;
+  ScopedTempDir temp_dir_;
 };
 
 TEST_F(PosixRealpathTest, ResolvesBasicPath) {
-  std::string original_path = test_dir_ + "/file1";
+  std::string original_path = temp_dir_.path() + "/file1";
   std::string expected_path = original_path;
   char resolved_path[PATH_MAX];
 
@@ -94,8 +88,8 @@ TEST_F(PosixRealpathTest, ResolvesBasicPath) {
 }
 
 TEST_F(PosixRealpathTest, ResolvesPathWithDot) {
-  std::string original_path = test_dir_ + "/./file1";
-  std::string expected_path = test_dir_ + "/file1";
+  std::string original_path = temp_dir_.path() + "/./file1";
+  std::string expected_path = temp_dir_.path() + "/file1";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -105,8 +99,8 @@ TEST_F(PosixRealpathTest, ResolvesPathWithDot) {
 }
 
 TEST_F(PosixRealpathTest, ResolvesPathWithDotDot) {
-  std::string original_path = test_dir_ + "/subdir1/../file1";
-  std::string expected_path = test_dir_ + "/file1";
+  std::string original_path = temp_dir_.path() + "/subdir1/../file1";
+  std::string expected_path = temp_dir_.path() + "/file1";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -116,8 +110,8 @@ TEST_F(PosixRealpathTest, ResolvesPathWithDotDot) {
 }
 
 TEST_F(PosixRealpathTest, ResolvesPathWithMultipleSlashes) {
-  std::string original_path = test_dir_ + "///subdir1//file2";
-  std::string expected_path = test_dir_ + "/subdir1/file2";
+  std::string original_path = temp_dir_.path() + "///subdir1//file2";
+  std::string expected_path = temp_dir_.path() + "/subdir1/file2";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -127,8 +121,8 @@ TEST_F(PosixRealpathTest, ResolvesPathWithMultipleSlashes) {
 }
 
 TEST_F(PosixRealpathTest, ResolvesPathWithTrailingSlash) {
-  std::string original_path = test_dir_ + "/subdir1/";
-  std::string expected_path = test_dir_ + "/subdir1";
+  std::string original_path = temp_dir_.path() + "/subdir1/";
+  std::string expected_path = temp_dir_.path() + "/subdir1";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -146,12 +140,12 @@ TEST_F(PosixRealpathTest, ResolvesRootPath) {
 }
 
 TEST_F(PosixRealpathTest, ResolvesPathEndingInSymlink) {
-  std::string file1_path = test_dir_ + "/file1";
-  ASSERT_EQ(
-      symlink(file1_path.c_str(), (test_dir_ + "/symlink_to_file1").c_str()),
-      0);
-  std::string original_path = test_dir_ + "/symlink_to_file1";
-  std::string expected_path = test_dir_ + "/file1";
+  std::string file1_path = temp_dir_.path() + "/file1";
+  ASSERT_EQ(symlink(file1_path.c_str(),
+                    (temp_dir_.path() + "/symlink_to_file1").c_str()),
+            0);
+  std::string original_path = temp_dir_.path() + "/symlink_to_file1";
+  std::string expected_path = temp_dir_.path() + "/file1";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -161,12 +155,12 @@ TEST_F(PosixRealpathTest, ResolvesPathEndingInSymlink) {
 }
 
 TEST_F(PosixRealpathTest, ResolvesPathContainingSymlink) {
-  std::string subdir1_path = test_dir_ + "/subdir1";
+  std::string subdir1_path = temp_dir_.path() + "/subdir1";
   ASSERT_EQ(symlink(subdir1_path.c_str(),
-                    (test_dir_ + "/symlink_to_subdir1").c_str()),
+                    (temp_dir_.path() + "/symlink_to_subdir1").c_str()),
             0);
-  std::string original_path = test_dir_ + "/symlink_to_subdir1/file2";
-  std::string expected_path = test_dir_ + "/subdir1/file2";
+  std::string original_path = temp_dir_.path() + "/symlink_to_subdir1/file2";
+  std::string expected_path = temp_dir_.path() + "/subdir1/file2";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -190,7 +184,7 @@ TEST_F(PosixRealpathTest, FailsWithNullFileName) {
 }
 
 TEST_F(PosixRealpathTest, FailsIfComponentDoesNotExist) {
-  std::string original_path = test_dir_ + "/non_existent/file";
+  std::string original_path = temp_dir_.path() + "/non_existent/file";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -199,9 +193,10 @@ TEST_F(PosixRealpathTest, FailsIfComponentDoesNotExist) {
 }
 
 TEST_F(PosixRealpathTest, FailsWithDanglingSymlink) {
-  ASSERT_EQ(symlink("non_existent", (test_dir_ + "/dangling_symlink").c_str()),
-            0);
-  std::string original_path = test_dir_ + "/dangling_symlink";
+  ASSERT_EQ(
+      symlink("non_existent", (temp_dir_.path() + "/dangling_symlink").c_str()),
+      0);
+  std::string original_path = temp_dir_.path() + "/dangling_symlink";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -210,7 +205,7 @@ TEST_F(PosixRealpathTest, FailsWithDanglingSymlink) {
 }
 
 TEST_F(PosixRealpathTest, FailsIfPathComponentIsNotDirectory) {
-  std::string original_path = test_dir_ + "/file1/some_other_file";
+  std::string original_path = temp_dir_.path() + "/file1/some_other_file";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -220,9 +215,9 @@ TEST_F(PosixRealpathTest, FailsIfPathComponentIsNotDirectory) {
 
 TEST_F(PosixRealpathTest, FailsWithSymbolicLinkLoop) {
   // Create a symlink loop. Targets are relative as they are in the same dir.
-  ASSERT_EQ(symlink("loop_b", (test_dir_ + "/loop_a").c_str()), 0);
-  ASSERT_EQ(symlink("loop_a", (test_dir_ + "/loop_b").c_str()), 0);
-  std::string original_path = test_dir_ + "/loop_a";
+  ASSERT_EQ(symlink("loop_b", (temp_dir_.path() + "/loop_a").c_str()), 0);
+  ASSERT_EQ(symlink("loop_a", (temp_dir_.path() + "/loop_b").c_str()), 0);
+  std::string original_path = temp_dir_.path() + "/loop_a";
   char resolved_path[PATH_MAX];
 
   errno = 0;
@@ -232,7 +227,7 @@ TEST_F(PosixRealpathTest, FailsWithSymbolicLinkLoop) {
 
 TEST_F(PosixRealpathTest, FailsOnPathComponentTooLong) {
   std::string long_component(PATH_MAX, 'b');
-  std::string long_path = test_dir_ + "/" + long_component;
+  std::string long_path = temp_dir_.path() + "/" + long_component;
 
   char resolved_path[PATH_MAX];
   errno = 0;

--- a/starboard/nplb/posix_compliance/posix_stat_test.cc
+++ b/starboard/nplb/posix_compliance/posix_stat_test.cc
@@ -38,13 +38,11 @@ constexpr char kTestFileContent[] = "Hello, stat!";
 class PosixStatTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    char template_name[] = "/tmp/stat_test_XXXXXX";
-    char* dir_name = mkdtemp(template_name);
-    ASSERT_NE(dir_name, nullptr) << "mkdtemp failed: " << strerror(errno);
-    test_dir_ = dir_name;
+    ASSERT_TRUE(temp_dir_.IsValid())
+        << "ScopedTempDir failed to create directory";
 
     // Create a file within the test directory.
-    file_path_ = test_dir_ + "/the_file.txt";
+    file_path_ = temp_dir_.path() + "/the_file.txt";
     int fd = open(file_path_.c_str(), O_CREAT | O_WRONLY, kUserRw);
     ASSERT_NE(fd, -1) << "Failed to create test file: " << strerror(errno);
     ssize_t write_res = write(fd, kTestFileContent, strlen(kTestFileContent));
@@ -52,17 +50,13 @@ class PosixStatTest : public ::testing::Test {
     ASSERT_EQ(0, close(fd));
 
     // Create a symbolic link to the file.
-    symlink_path_ = test_dir_ + "/the_symlink";
+    symlink_path_ = temp_dir_.path() + "/the_symlink";
     ASSERT_EQ(symlink(file_path_.c_str(), symlink_path_.c_str()), 0);
   }
 
-  void TearDown() override {
-    if (!test_dir_.empty()) {
-      RemoveFileOrDirectoryRecursively(test_dir_.c_str());
-    }
-  }
+  void TearDown() override {}
 
-  std::string test_dir_;
+  ScopedTempDir temp_dir_;
   std::string file_path_;
   std::string symlink_path_;
 };
@@ -81,7 +75,7 @@ TEST_F(PosixStatTest, SuccessForFile) {
 TEST_F(PosixStatTest, SuccessForDirectory) {
   struct stat statbuf;
   errno = 0;
-  ASSERT_EQ(stat(test_dir_.c_str(), &statbuf), 0)
+  ASSERT_EQ(stat(temp_dir_.path().c_str(), &statbuf), 0)
       << "stat failed: " << strerror(errno);
 
   EXPECT_TRUE(S_ISDIR(statbuf.st_mode));
@@ -112,7 +106,7 @@ TEST_F(PosixStatTest, AllFieldsArePopulated) {
 
   // Get parent directory info to compare device ID.
   struct stat parent_statbuf;
-  ASSERT_EQ(stat(test_dir_.c_str(), &parent_statbuf), 0);
+  ASSERT_EQ(stat(temp_dir_.path().c_str(), &parent_statbuf), 0);
 
   // Check device and inode numbers.
   EXPECT_GT(statbuf.st_dev, 0u);
@@ -154,7 +148,7 @@ TEST_F(PosixStatTest, AllFieldsArePopulated) {
 
 TEST_F(PosixStatTest, NonExistentPathFails) {
   struct stat statbuf;
-  std::string non_existent_path = test_dir_ + "/does_not_exist";
+  std::string non_existent_path = temp_dir_.path() + "/does_not_exist";
   errno = 0;
   EXPECT_EQ(stat(non_existent_path.c_str(), &statbuf), -1);
   EXPECT_EQ(errno, ENOENT);
@@ -183,7 +177,7 @@ TEST_F(PosixStatTest, PermissionDeniedFails) {
   }
 
   struct stat statbuf;
-  std::string protected_dir = test_dir_ + "/protected";
+  std::string protected_dir = temp_dir_.path() + "/protected";
   ASSERT_EQ(mkdir(protected_dir.c_str(), kUserRwx), 0);
 
   std::string file_in_protected = protected_dir + "/inner_file";
@@ -205,7 +199,7 @@ TEST_F(PosixStatTest, PermissionDeniedFails) {
 TEST_F(PosixStatTest, PathTooLongFails) {
   struct stat statbuf;
   std::string long_name(kSbFileMaxPath + 1, 'c');
-  std::string long_path = test_dir_ + "/" + long_name;
+  std::string long_path = temp_dir_.path() + "/" + long_name;
 
   errno = 0;
   EXPECT_EQ(stat(long_path.c_str(), &statbuf), -1);
@@ -214,8 +208,8 @@ TEST_F(PosixStatTest, PathTooLongFails) {
 
 TEST_F(PosixStatTest, SymlinkLoopFails) {
   struct stat statbuf;
-  std::string link_a_path = test_dir_ + "/link_a";
-  std::string link_b_path = test_dir_ + "/link_b";
+  std::string link_a_path = temp_dir_.path() + "/link_a";
+  std::string link_b_path = temp_dir_.path() + "/link_b";
 
   ASSERT_EQ(symlink(link_b_path.c_str(), link_a_path.c_str()), 0);
   ASSERT_EQ(symlink(link_a_path.c_str(), link_b_path.c_str()), 0);


### PR DESCRIPTION
Some tests would hardcode the temporary directory to /tmp, which is not usable on some platforms.

Bug: 500888154