### PR TITLE
cobalt: Treat small storage records as skipped

### DIFF
--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -344,6 +344,8 @@ ReadAndParseLegacyStorageRecord() {
       }
     }
 
+    // Ensure the record is large enough to contain at least the 'SAV1' header.
+    // Small or empty records typically indicate a fresh installation.
     if (record->GetSize() < static_cast<int64_t>(kRecordHeaderSize)) {
       result = StorageReadResult::kSizeTooSmall;
       return;

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.h
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.h
@@ -111,12 +111,14 @@ struct MigrationState : public base::RefCountedThreadSafe<MigrationState> {
 
   MigrationOutcome GetOutcome() const {
     if (!has_data_to_migrate) {
-      if (read_result == StorageReadResult::kSuccess ||
-          read_result == StorageReadResult::kRecordInvalid ||
-          read_result == StorageReadResult::kSizeTooSmall) {
-        return MigrationOutcome::kSkipped;
+      switch (read_result) {
+        case StorageReadResult::kSuccess:
+        case StorageReadResult::kRecordInvalid:
+        case StorageReadResult::kSizeTooSmall:
+          return MigrationOutcome::kSkipped;
+        default:
+          return MigrationOutcome::kFailed;
       }
-      return MigrationOutcome::kFailed;
     }
     InjectionResult c_res = cookie_result.load(std::memory_order_relaxed);
     InjectionResult ls_res =

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.h
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.h
@@ -112,7 +112,8 @@ struct MigrationState : public base::RefCountedThreadSafe<MigrationState> {
   MigrationOutcome GetOutcome() const {
     if (!has_data_to_migrate) {
       if (read_result == StorageReadResult::kSuccess ||
-          read_result == StorageReadResult::kRecordInvalid) {
+          read_result == StorageReadResult::kRecordInvalid ||
+          read_result == StorageReadResult::kSizeTooSmall) {
         return MigrationOutcome::kSkipped;
       }
       return MigrationOutcome::kFailed;


### PR DESCRIPTION
Update storage migration logic to classify records that are too small
to contain the header as skipped.

Previously, these records would result in a migration failure. This change
ensures that effectively empty or fresh installation records are properly
handled without generating an erroneous failure state.

https://screenshot.googleplex.com/6xRsvZ7LnRadzp8
https://screenshot.googleplex.com/7RNJVURKt5EV3BA

Bug: 489453068