### PR TITLE
cobalt: Record legacy storage deletion result

### DIFF
--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -106,6 +106,8 @@ constexpr char kLocalStorageCountHistogram[] =
 constexpr char kDurationHistogram[] = "Cobalt.StorageMigration.Duration";
 constexpr char kSentinelWriteResultHistogram[] =
     "Cobalt.StorageMigration.SentinelWriteResult";
+constexpr char kDeleteLegacyRecordResultHistogram[] =
+    "Cobalt.StorageMigration.DeleteLegacyRecordResult";
 
 // ============================================================================
 // General File / Cache Utilities
@@ -191,12 +193,15 @@ void DeleteLegacyStorageFilesAsync() {
     std::string partition_key = GetApplicationKey(initial_url);
     auto record =
         std::make_unique<starboard::StorageRecord>(partition_key.c_str());
-    DeleteLegacyStorageRecord(record.get());
+    bool success = DeleteLegacyStorageRecord(record.get());
+    base::UmaHistogramBoolean(kDeleteLegacyRecordResultHistogram, success);
   }
 
   // Also attempt to delete the fallback default record.
   auto fallback_record = std::make_unique<starboard::StorageRecord>();
-  DeleteLegacyStorageRecord(fallback_record.get());
+  bool fallback_success = DeleteLegacyStorageRecord(fallback_record.get());
+  base::UmaHistogramBoolean(kDeleteLegacyRecordResultHistogram,
+                            fallback_success);
 }
 
 // Deletes legacy cache subdirectories asynchronously to free up disk space.

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -96,11 +96,12 @@ Always run the pretty print utility on this file after editing:
     Records the number of times a platform error was raised due to a navigation
     timeout or other network error. This is logged every time RaisePlatformError
     is called; each logged count is the cumulative number of times the error has
-    been raised. The actual number of sessions with a specific number of platform
-    errors raised can be raised by subtracting the values of counts larger than
-    said number. For example, sessions with 2 calls to RaisePlatformError would be
-    (count for 2 calls) - (count for 3 calls) - ... (count for max calls).
-    This value is reset to 0 on a successful navigation/app load.
+    been raised. The actual number of sessions with a specific number of
+    platform errors raised can be raised by subtracting the values of counts
+    larger than said number. For example, sessions with 2 calls to
+    RaisePlatformError would be (count for 2 calls) - (count for 3 calls) - ...
+    (count for max calls). This value is reset to 0 on a successful
+    navigation/app load.
   </summary>
 </histogram>
 
@@ -158,20 +159,8 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
-<histogram name="Cobalt.Storage.Exit.LocalStorageFlushSchedulingDuration" units="ms"
-    expires_after="never">
-  <owner>charleykim@google.com</owner>
-  <summary>
-    Records the time it takes to initiate the flush of local storage during a
-    graceful application exit (e.g., via window.h5vcc.system.exit()). As
-    `Flush()` is an asynchronous operation, this metric captures the time until
-    the commit is scheduled, not the completion of the data write to persistent
-    storage.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.Storage.Exit.LocalStorageFlushSchedulingDuration" units="ms"
-    expires_after="never">
+<histogram name="Cobalt.Storage.Exit.LocalStorageFlushSchedulingDuration"
+    units="ms" expires_after="never">
   <owner>charleykim@google.com</owner>
   <summary>
     Records the time it takes to initiate the flush of local storage during a
@@ -190,6 +179,104 @@ Always run the pretty print utility on this file after editing:
     onPause event on Android. This helps to understand if the operation
     completes within the short window granted by the OS before the app is
     killed.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.CookieInjectionResult"
+    enum="StorageInjectionResult" expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the outcome of attempting to inject a single cookie into the new
+    Chromium-based storage during migration from legacy Starboard storage.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.CookiesCount" units="cookies"
+    expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the total number of cookies found in the legacy Starboard storage
+    record during a migration attempt.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.DeleteLegacyRecordResult"
+    enum="Boolean" expires_after="never">
+  <owner>colinliang@google.com</owner>
+  <summary>
+    Records whether the legacy Starboard storage record was successfully deleted
+    during the migration cleanup step. This is recorded for both the
+    URL-specific record and the fallback default record.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.Duration" units="ms"
+    expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the total time taken to migrate data from the legacy Starboard
+    storage record to the new Chromium-based storage.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.FastPathDuration" units="ms"
+    expires_after="never">
+  <owner>colinliang@google.com</owner>
+  <summary>
+    Records the total time taken to check for the migration fast path during
+    startup.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.LocalStorageCount" units="entries"
+    expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the total number of localStorage entries found in the legacy
+    Starboard storage record during a migration attempt.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.LocalStorageInjectionResult"
+    enum="StorageInjectionResult" expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the outcome of attempting to inject a single localStorage entry into
+    the new Chromium-based storage during migration from legacy Starboard
+    storage.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.Outcome" enum="MigrationOutcome"
+    expires_after="never">
+  <owner>colinliang@google.com</owner>
+  <summary>
+    Records the final outcome of the storage migration process. Tracks whether
+    the migration took the fast path, skipped due to no data, fully succeeded,
+    or failed during read/injection.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.ReadResult" enum="StorageReadResult"
+    expires_after="never">
+  <owner>haozheng@google.com</owner>
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the outcome of attempting to read and parse the legacy Starboard
+    storage record during migration.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.StorageMigration.SentinelWriteResult"
+    enum="SentinelWriteResult" expires_after="never">
+  <owner>colinliang@google.com</owner>
+  <summary>
+    Records the result of writing the migration sentinel file to disk.
   </summary>
 </histogram>
 
@@ -224,96 +311,7 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
-<histogram name="Cobalt.StorageMigration.CookieInjectionResult"
-    enum="StorageInjectionResult" expires_after="never">
-  <owner>haozheng@google.com</owner>
-  <owner>yijiazhang@google.com</owner>
-  <summary>
-    Records the outcome of attempting to inject a single cookie into the new
-    Chromium-based storage during migration from legacy Starboard storage.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.StorageMigration.CookiesCount" units="cookies"
-    expires_after="never">
-  <owner>haozheng@google.com</owner>
-  <owner>yijiazhang@google.com</owner>
-  <summary>
-    Records the total number of cookies found in the legacy Starboard storage
-    record during a migration attempt.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.StorageMigration.FastPathDuration" units="ms"
-    expires_after="never">
-  <owner>colinliang@google.com</owner>
-  <summary>
-    Records the total time taken to check for the migration fast path during
-    startup.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.StorageMigration.Outcome" enum="MigrationOutcome"
-    expires_after="never">
-  <owner>colinliang@google.com</owner>
-  <summary>
-    Records the final outcome of the storage migration process. Tracks whether
-    the migration took the fast path, skipped due to no data, fully succeeded,
-    or failed during read/injection.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.StorageMigration.Duration" units="ms"
-    expires_after="never">
-  <owner>haozheng@google.com</owner>
-  <owner>yijiazhang@google.com</owner>
-  <summary>
-    Records the total time taken to migrate data from the legacy Starboard
-    storage record to the new Chromium-based storage.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.StorageMigration.LocalStorageCount" units="entries"
-    expires_after="never">
-  <owner>haozheng@google.com</owner>
-  <owner>yijiazhang@google.com</owner>
-  <summary>
-    Records the total number of localStorage entries found in the legacy
-    Starboard storage record during a migration attempt.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.StorageMigration.LocalStorageInjectionResult"
-    enum="StorageInjectionResult" expires_after="never">
-  <owner>haozheng@google.com</owner>
-  <owner>yijiazhang@google.com</owner>
-  <summary>
-    Records the outcome of attempting to inject a single localStorage entry into
-    the new Chromium-based storage during migration from legacy Starboard
-    storage.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.StorageMigration.ReadResult" enum="StorageReadResult"
-    expires_after="never">
-  <owner>haozheng@google.com</owner>
-  <owner>yijiazhang@google.com</owner>
-  <summary>
-    Records the outcome of attempting to read and parse the legacy Starboard
-    storage record during migration.
-  </summary>
-</histogram>
-
-<histogram name="Cobalt.StorageMigration.SentinelWriteResult"
-    enum="SentinelWriteResult" expires_after="never">
-  <owner>colinliang@google.com</owner>
-  <summary>
-    Records the result of writing the migration sentinel file to disk.
-  </summary>
-</histogram>
-
-<histogram name="Memory.Media.AllocatedEncodedBuffer"
-    unit="MB" expires_after="never">
+<histogram name="Memory.Media.AllocatedEncodedBuffer" units="MB" expires_after="never">
   <owner>tasunny@google.com</owner>
   <summary>
     Records the memory allocated by media decoder buffer for video and audio.


### PR DESCRIPTION
Introduce a UMA histogram, Cobalt.StorageMigration.DeleteLegacyRecordResult,
to track the success or failure of deleting legacy storage records. This
metric provides insight into the reliability of the cleanup process for
outdated storage formats.

Bug: 489453068