### PR TITLE
media: Support decode-to-texture mode for video

### DIFF
--- a/gpu/BUILD.gn
+++ b/gpu/BUILD.gn
@@ -12,6 +12,10 @@ import("//third_party/angle/gni/angle.gni")
 import("//third_party/protobuf/proto_library.gni")
 import("//ui/gl/features.gni")
 
+if (is_cobalt) {
+  import("//starboard/build/buildflags.gni")
+}
+
 if (is_android) {
   # Pull in enable_chrome_android_internal.
   import("//build/config/android/config.gni")
@@ -533,6 +537,11 @@ test("gpu_unittests") {
     "ipc/service/gpu_channel_test_common.h",
     "ipc/service/gpu_watchdog_thread_unittest.cc",
   ]
+
+  if (is_cobalt && use_starboard_media) {
+    sources += [ "command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing_unittest.cc" ]
+  }
+
   if (is_cobalt_hermetic_build) {
     sources += [ "command_buffer/common/starboard/unittest_main.cc" ]
     sources -= [ "command_buffer/common/unittest_main.cc" ]
@@ -667,6 +676,10 @@ test("gpu_unittests") {
     "//ui/gl:test_support",
     "//url",
   ]
+
+  if (is_cobalt && use_starboard_media) {
+    deps += [ "//starboard:starboard_headers_only" ]
+  }
 
   deps += [ "//third_party/angle:translator" ]
 

--- a/gpu/command_buffer/service/BUILD.gn
+++ b/gpu/command_buffer/service/BUILD.gn
@@ -9,6 +9,10 @@ import("//third_party/dawn/scripts/dawn_features.gni")
 import("//third_party/protobuf/proto_library.gni")
 import("//ui/gl/features.gni")
 
+if (is_cobalt) {
+  import("//starboard/build/buildflags.gni")
+}
+
 group("service") {
   if (is_component_build) {
     public_deps = [ "//gpu" ]
@@ -327,6 +331,14 @@ target(link_target_type, "gles2_sources") {
       "abstract_texture_android.cc",
       "abstract_texture_android.h",
     ]
+  }
+
+  if (is_cobalt && use_starboard_media) {
+    sources += [
+      "shared_image/starboard/starboard_gl_texture_image_backing.cc",
+      "shared_image/starboard/starboard_gl_texture_image_backing.h",
+    ]
+    deps += [ "//starboard:starboard_headers_only" ]
   }
 
   if (use_dawn) {

--- a/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.cc
+++ b/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.cc
@@ -1,0 +1,180 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h"
+
+#include "build/build_config.h"
+#include "components/viz/common/resources/resource_sizes.h"
+#include "gpu/command_buffer/common/shared_image_usage.h"
+#include "gpu/command_buffer/service/memory_tracking.h"
+#include "gpu/command_buffer/service/shared_context_state.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_representation.h"
+#include "gpu/command_buffer/service/shared_image/skia_gl_image_representation.h"
+#include "gpu/command_buffer/service/skia_utils.h"
+#include "gpu/command_buffer/service/texture_manager.h"
+#include "ui/gl/gl_utils.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "gpu/command_buffer/service/ref_counted_lock.h"
+#endif
+
+namespace gpu {
+
+class StarboardGLTextureBacking::
+    GLTexturePassthroughStarboardImageRepresentation
+    : public GLTexturePassthroughImageRepresentation
+#if BUILDFLAG(IS_ANDROID)
+    ,
+      public RefCountedLockHelperDrDc
+#endif
+{
+ public:
+  GLTexturePassthroughStarboardImageRepresentation(
+      SharedImageManager* manager,
+      StarboardGLTextureBacking* backing,
+      MemoryTypeTracker* tracker,
+      std::vector<scoped_refptr<gpu::gles2::TexturePassthrough>> textures
+#if BUILDFLAG(IS_ANDROID)
+      ,
+      scoped_refptr<RefCountedLock> drdc_lock
+#endif
+      )
+      : GLTexturePassthroughImageRepresentation(manager, backing, tracker),
+#if BUILDFLAG(IS_ANDROID)
+        RefCountedLockHelperDrDc(std::move(drdc_lock)),
+#endif
+        passthrough_textures_(std::move(textures)) {
+    for (auto& passthrough_texture : passthrough_textures_) {
+      CHECK(passthrough_texture);
+    }
+  }
+
+  ~GLTexturePassthroughStarboardImageRepresentation() override = default;
+
+  const scoped_refptr<gles2::TexturePassthrough>& GetTexturePassthrough(
+      int plane_index) override {
+    CHECK_LT(static_cast<size_t>(plane_index), passthrough_textures_.size());
+    return passthrough_textures_[plane_index];
+  }
+
+  bool BeginAccess(GLenum mode) override NO_THREAD_SAFETY_ANALYSIS {
+    // This representation should only be called for read.
+    DCHECK(mode == GL_SHARED_IMAGE_ACCESS_MODE_READ_CHROMIUM);
+#if BUILDFLAG(IS_ANDROID)
+    if (GetDrDcLockPtr()) {
+      GetDrDcLockPtr()->Acquire();
+    }
+#endif
+    return true;
+  }
+
+  void EndAccess() override NO_THREAD_SAFETY_ANALYSIS {
+#if BUILDFLAG(IS_ANDROID)
+    if (GetDrDcLockPtr()) {
+      GetDrDcLockPtr()->Release();
+    }
+#endif
+  }
+
+ private:
+  std::vector<scoped_refptr<gles2::TexturePassthrough>> passthrough_textures_;
+};
+
+StarboardGLTextureBacking::StarboardGLTextureBacking(
+    const Mailbox& mailbox,
+    viz::SharedImageFormat format,
+    const gfx::Size& size,
+    const gfx::ColorSpace& color_space,
+    GrSurfaceOrigin surface_origin,
+    SkAlphaType alpha_type,
+    SharedImageUsageSet usage,
+    std::vector<GLuint> texture_ids,
+    std::vector<uint32_t> texture_targets,
+    uint64_t decode_target
+#if BUILDFLAG(IS_ANDROID)
+    ,
+    scoped_refptr<gpu::RefCountedLock> drdc_lock
+#endif
+    )
+    : ClearTrackingSharedImageBacking(mailbox,
+                                      format,
+                                      size,
+                                      color_space,
+                                      surface_origin,
+                                      alpha_type,
+                                      usage,
+                                      "StarboardGLTexture",
+                                      format.EstimatedSizeInBytes(size),
+                                      /*is_thread_safe=*/false),
+      decode_target_(reinterpret_cast<SbDecodeTarget>(decode_target)) {
+  for (size_t i = 0; i < texture_ids.size(); i++) {
+    passthrough_textures_.push_back(
+        base::MakeRefCounted<gpu::gles2::TexturePassthrough>(
+            texture_ids[i], texture_targets[i]));
+  }
+#if BUILDFLAG(IS_ANDROID)
+  drdc_lock_ = std::move(drdc_lock);
+#endif
+  SetCleared();
+}
+
+StarboardGLTextureBacking::~StarboardGLTextureBacking() {
+  // Mark context as lost to prevent glDeleteTextures calls.
+  // The actual deletion of the underlying textures is handled by
+  // SbDecodeTargetRelease below, since Starboard owns the texture resources.
+  for (auto& passthrough_texture : passthrough_textures_) {
+    if (passthrough_texture) {
+      passthrough_texture->MarkContextLost();
+    }
+  }
+  if (SbDecodeTargetIsValid(decode_target_)) {
+    SbDecodeTargetRelease(decode_target_);
+  }
+}
+
+SharedImageBackingType StarboardGLTextureBacking::GetType() const {
+  return SharedImageBackingType::kGLTexture;
+}
+
+void StarboardGLTextureBacking::Update(
+    std::unique_ptr<gfx::GpuFence> in_fence) {}
+
+std::unique_ptr<GLTexturePassthroughImageRepresentation>
+StarboardGLTextureBacking::ProduceGLTexturePassthrough(
+    SharedImageManager* manager,
+    MemoryTypeTracker* tracker) {
+  return std::make_unique<GLTexturePassthroughStarboardImageRepresentation>(
+      manager, this, tracker, passthrough_textures_
+#if BUILDFLAG(IS_ANDROID)
+      ,
+      drdc_lock_
+#endif
+  );
+}
+
+std::unique_ptr<SkiaGaneshImageRepresentation>
+StarboardGLTextureBacking::ProduceSkiaGanesh(
+    SharedImageManager* manager,
+    MemoryTypeTracker* tracker,
+    scoped_refptr<SharedContextState> context_state) {
+  auto gl_representation = ProduceGLTexturePassthrough(manager, tracker);
+  if (!gl_representation) {
+    return nullptr;
+  }
+  return SkiaGLImageRepresentation::Create(std::move(gl_representation),
+                                           std::move(context_state), manager,
+                                           this, tracker);
+}
+
+}  // namespace gpu

--- a/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h
+++ b/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h
@@ -1,0 +1,87 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef GPU_COMMAND_BUFFER_SERVICE_SHARED_IMAGE_STARBOARD_STARBOARD_GL_TEXTURE_IMAGE_BACKING_H_
+#define GPU_COMMAND_BUFFER_SERVICE_SHARED_IMAGE_STARBOARD_STARBOARD_GL_TEXTURE_IMAGE_BACKING_H_
+
+#include <memory>
+#include <vector>
+
+#include "build/build_config.h"
+#include "gpu/command_buffer/service/shared_context_state.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_backing.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_representation.h"
+#include "gpu/gpu_gles2_export.h"
+#include "starboard/decode_target.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "gpu/command_buffer/service/ref_counted_lock.h"
+#endif
+
+namespace gpu {
+
+class GPU_GLES2_EXPORT StarboardGLTextureBacking
+    : public ClearTrackingSharedImageBacking {
+ public:
+  StarboardGLTextureBacking(const Mailbox& mailbox,
+                            viz::SharedImageFormat format,
+                            const gfx::Size& size,
+                            const gfx::ColorSpace& color_space,
+                            GrSurfaceOrigin surface_origin,
+                            SkAlphaType alpha_type,
+                            SharedImageUsageSet usage,
+                            std::vector<GLuint> texture_ids,
+                            std::vector<uint32_t> texture_targets,
+                            uint64_t decode_target
+#if BUILDFLAG(IS_ANDROID)
+                            ,
+                            scoped_refptr<gpu::RefCountedLock> drdc_lock
+#endif
+  );
+
+  ~StarboardGLTextureBacking() override;
+
+  StarboardGLTextureBacking(const StarboardGLTextureBacking&) = delete;
+  StarboardGLTextureBacking& operator=(const StarboardGLTextureBacking&) =
+      delete;
+
+  SharedImageBackingType GetType() const override;
+  void Update(std::unique_ptr<gfx::GpuFence> in_fence) override;
+
+ protected:
+  std::unique_ptr<GLTexturePassthroughImageRepresentation>
+  ProduceGLTexturePassthrough(SharedImageManager* manager,
+                              MemoryTypeTracker* tracker) override;
+
+  std::unique_ptr<SkiaGaneshImageRepresentation> ProduceSkiaGanesh(
+      SharedImageManager* manager,
+      MemoryTypeTracker* tracker,
+      scoped_refptr<SharedContextState> context_state) override;
+
+ private:
+  class GLTexturePassthroughStarboardImageRepresentation;
+
+  std::vector<scoped_refptr<gpu::gles2::TexturePassthrough>>
+      passthrough_textures_;
+
+  SbDecodeTarget decode_target_ = kSbDecodeTargetInvalid;
+
+#if BUILDFLAG(IS_ANDROID)
+  scoped_refptr<gpu::RefCountedLock> drdc_lock_;
+#endif
+};
+
+}  // namespace gpu
+
+#endif  // GPU_COMMAND_BUFFER_SERVICE_SHARED_IMAGE_STARBOARD_STARBOARD_GL_TEXTURE_IMAGE_BACKING_H_

--- a/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing_unittest.cc
+++ b/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing_unittest.cc
@@ -1,0 +1,178 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h"
+
+#include <vector>
+
+#include "base/memory/ptr_util.h"
+#include "components/viz/common/resources/shared_image_format.h"
+#include "gpu/command_buffer/common/shared_image_usage.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_manager.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_representation.h"
+#include "gpu/command_buffer/service/test_memory_tracker.h"
+#include "gpu/command_buffer/service/texture_manager.h"
+#include "starboard/decode_target.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/skia/include/core/SkAlphaType.h"
+#include "ui/gfx/color_space.h"
+#include "ui/gfx/geometry/size.h"
+
+// Mock Starboard functions
+extern "C" {
+static int g_release_count = 0;
+void SbDecodeTargetRelease(SbDecodeTarget decode_target) {
+  g_release_count++;
+}
+
+bool SbDecodeTargetGetInfo(SbDecodeTarget decode_target,
+                           SbDecodeTargetInfo* out_info) {
+  if (!decode_target || !out_info) {
+    return false;
+  }
+  return true;
+}
+}
+
+namespace gpu {
+namespace {
+
+class StarboardGLTextureBackingTest : public testing::Test {
+ public:
+  StarboardGLTextureBackingTest()
+      : memory_tracker_(), tracker_(&memory_tracker_) {}
+
+  void SetUp() override { g_release_count = 0; }
+
+ protected:
+  SharedImageManager manager_;
+  TestMemoryTracker memory_tracker_;
+  MemoryTypeTracker tracker_;
+};
+
+TEST_F(StarboardGLTextureBackingTest, Basic) {
+  Mailbox mailbox = Mailbox::Generate();
+  viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
+  gfx::Size size(100, 100);
+  gfx::ColorSpace color_space = gfx::ColorSpace::CreateSRGB();
+  GrSurfaceOrigin surface_origin = kTopLeft_GrSurfaceOrigin;
+  SkAlphaType alpha_type = kOpaque_SkAlphaType;
+  SharedImageUsageSet usage = SHARED_IMAGE_USAGE_GLES2_READ;
+  std::vector<uint32_t> texture_ids = {1};
+  std::vector<uint32_t> texture_targets = {0x0DE1};  // GL_TEXTURE_2D
+  uint64_t decode_target = 0xdeadbeef;
+
+  auto backing = std::make_unique<StarboardGLTextureBacking>(
+      mailbox, format, size, color_space, surface_origin, alpha_type, usage,
+      texture_ids, texture_targets, decode_target);
+
+  EXPECT_EQ(backing->mailbox(), mailbox);
+  EXPECT_EQ(backing->size(), size);
+  EXPECT_EQ(backing->format(), format);
+  EXPECT_EQ(backing->color_space(), color_space);
+  EXPECT_EQ(backing->surface_origin(), surface_origin);
+  EXPECT_EQ(backing->alpha_type(), alpha_type);
+  EXPECT_EQ(backing->usage(), usage);
+  EXPECT_EQ(backing->GetType(), SharedImageBackingType::kGLTexture);
+
+  auto factory_rep = manager_.Register(std::move(backing), &tracker_);
+
+  auto gl_rep = manager_.ProduceGLTexturePassthrough(mailbox, &tracker_);
+  ASSERT_NE(gl_rep, nullptr);
+  EXPECT_EQ(gl_rep->GetTexturePassthrough()->service_id(), 1u);
+
+  // Test Begin/End access.
+  {
+    auto scoped_access = gl_rep->BeginScopedAccess(
+        GL_SHARED_IMAGE_ACCESS_MODE_READ_CHROMIUM,
+        SharedImageRepresentation::AllowUnclearedAccess::kNo);
+    EXPECT_TRUE(scoped_access);
+  }
+
+  gl_rep.reset();
+  factory_rep.reset();
+
+  EXPECT_EQ(g_release_count, 1);
+}
+
+TEST_F(StarboardGLTextureBackingTest, Multiplanar) {
+  Mailbox mailbox = Mailbox::Generate();
+  viz::SharedImageFormat format = viz::MultiPlaneFormat::kNV12;
+  gfx::Size size(100, 100);
+  gfx::ColorSpace color_space = gfx::ColorSpace::CreateREC709();
+  GrSurfaceOrigin surface_origin = kTopLeft_GrSurfaceOrigin;
+  SkAlphaType alpha_type = kOpaque_SkAlphaType;
+  SharedImageUsageSet usage = SHARED_IMAGE_USAGE_GLES2_READ;
+  // NV12 has two planes.
+  std::vector<uint32_t> texture_ids = {1, 2};
+  std::vector<uint32_t> texture_targets = {0x0DE1, 0x0DE1};
+  uint64_t decode_target = 0xbeefdead;
+
+  auto backing = std::make_unique<StarboardGLTextureBacking>(
+      mailbox, format, size, color_space, surface_origin, alpha_type, usage,
+      texture_ids, texture_targets, decode_target);
+
+  auto factory_rep = manager_.Register(std::move(backing), &tracker_);
+
+  auto gl_rep = manager_.ProduceGLTexturePassthrough(mailbox, &tracker_);
+  ASSERT_NE(gl_rep, nullptr);
+  EXPECT_EQ(gl_rep->GetTexturePassthrough(0)->service_id(), 1u);
+  EXPECT_EQ(gl_rep->GetTexturePassthrough(1)->service_id(), 2u);
+
+  gl_rep.reset();
+  factory_rep.reset();
+
+  EXPECT_EQ(g_release_count, 1);
+}
+
+#if BUILDFLAG(IS_ANDROID)
+TEST_F(StarboardGLTextureBackingTest, DrDcLock) {
+  Mailbox mailbox = Mailbox::Generate();
+  viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
+  gfx::Size size(100, 100);
+  gfx::ColorSpace color_space = gfx::ColorSpace::CreateSRGB();
+  GrSurfaceOrigin surface_origin = kTopLeft_GrSurfaceOrigin;
+  SkAlphaType alpha_type = kOpaque_SkAlphaType;
+  SharedImageUsageSet usage = SHARED_IMAGE_USAGE_GLES2_READ;
+  std::vector<uint32_t> texture_ids = {1};
+  std::vector<uint32_t> texture_targets = {0x0DE1};
+  uint64_t decode_target = 0x12345678;
+
+  auto drdc_lock = base::MakeRefCounted<gpu::RefCountedLock>();
+
+  auto backing = std::make_unique<StarboardGLTextureBacking>(
+      mailbox, format, size, color_space, surface_origin, alpha_type, usage,
+      texture_ids, texture_targets, decode_target, drdc_lock);
+
+  auto factory_rep = manager_.Register(std::move(backing), &tracker_);
+  auto gl_rep = manager_.ProduceGLTexturePassthrough(mailbox, &tracker_);
+
+  // BeginAccess should acquire the lock.
+  // In a real scenario, we'd check if the lock is held, but RefCountedLock
+  // doesn't expose that easily. We just verify it doesn't crash.
+  {
+    auto scoped_access = gl_rep->BeginScopedAccess(
+        GL_SHARED_IMAGE_ACCESS_MODE_READ_CHROMIUM,
+        SharedImageRepresentation::AllowUnclearedAccess::kNo);
+    EXPECT_TRUE(scoped_access);
+  }
+
+  gl_rep.reset();
+  factory_rep.reset();
+  EXPECT_EQ(g_release_count, 1);
+}
+#endif
+
+}  // namespace
+}  // namespace gpu

--- a/gpu/ipc/service/gpu_channel_shared_image_interface.cc
+++ b/gpu/ipc/service/gpu_channel_shared_image_interface.cc
@@ -21,6 +21,10 @@
 #include "gpu/command_buffer/service/stream_texture_shared_image_interface.h"
 #endif
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h"
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 namespace gpu {
 
 namespace {
@@ -149,6 +153,57 @@ GpuChannelSharedImageInterface::CreateSharedImageForD3D11Video(
                             GL_TEXTURE_EXTERNAL_OES));
 }
 #endif
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+scoped_refptr<ClientSharedImage>
+GpuChannelSharedImageInterface::CreateSharedImageForStarboardGLTexture(
+    viz::SharedImageFormat format,
+    const gfx::Size& size,
+    const gfx::ColorSpace& color_space,
+    const std::vector<uint32_t>& texture_service_ids,
+    const std::vector<uint32_t>& texture_targets,
+    uint64_t decode_target
+#if BUILDFLAG(IS_ANDROID)
+    ,
+    scoped_refptr<RefCountedLock> drdc_lock
+#endif
+) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(gpu_sequence_checker_);
+
+  if (!shared_image_stub_) {
+    return nullptr;
+  }
+
+  auto mailbox = Mailbox::Generate();
+
+  auto backing = std::make_unique<StarboardGLTextureBacking>(
+      mailbox, format, size, color_space,
+      kTopLeft_GrSurfaceOrigin, kPremul_SkAlphaType,
+      SHARED_IMAGE_USAGE_DISPLAY_READ | SHARED_IMAGE_USAGE_GLES2_READ,
+      texture_service_ids, texture_targets, decode_target
+#if BUILDFLAG(IS_ANDROID)
+      , std::move(drdc_lock)
+#endif
+      );
+  
+  SharedImageMetadata metadata{backing->format(),
+                               backing->size(),
+                               backing->color_space(),
+                               backing->surface_origin(),
+                               backing->alpha_type(),
+                               backing->usage()};
+
+  DCHECK(shared_image_stub_->channel()
+             ->gpu_channel_manager()
+             ->shared_image_manager());
+  shared_image_stub_->factory()->RegisterBacking(std::move(backing));
+
+  return base::WrapRefCounted<ClientSharedImage>(
+      new ClientSharedImage(mailbox, metadata, GenVerifiedSyncToken(), holder_,
+                            texture_targets.empty() ? GL_TEXTURE_2D
+                                                    : texture_targets[0]));
+}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 bool GpuChannelSharedImageInterface::MakeContextCurrent(bool needs_gl) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(gpu_sequence_checker_);

--- a/gpu/ipc/service/gpu_channel_shared_image_interface.h
+++ b/gpu/ipc/service/gpu_channel_shared_image_interface.h
@@ -128,6 +128,21 @@ class GPU_IPC_SERVICE_EXPORT GpuChannelSharedImageInterface
       const bool is_thread_safe);
 #endif
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  scoped_refptr<ClientSharedImage> CreateSharedImageForStarboardGLTexture(
+      viz::SharedImageFormat format,
+      const gfx::Size& size,
+      const gfx::ColorSpace& color_space,
+      const std::vector<uint32_t>& texture_service_ids,
+      const std::vector<uint32_t>& texture_targets,
+      uint64_t decode_target
+#if BUILDFLAG(IS_ANDROID)
+      ,
+      scoped_refptr<RefCountedLock> drdc_lock
+#endif
+  );
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   SequenceId sequence() { return sequence_; }
 
  protected:

--- a/media/gpu/starboard/starboard_gpu_factory.h
+++ b/media/gpu/starboard/starboard_gpu_factory.h
@@ -15,17 +15,24 @@
 #ifndef MEDIA_GPU_STARBOARD_STARBOARD_GPU_FACTORY_H_
 #define MEDIA_GPU_STARBOARD_STARBOARD_GPU_FACTORY_H_
 
+#include <vector>
+
 #include "base/memory/raw_ptr.h"
 #include "base/synchronization/waitable_event.h"
 #include "base/unguessable_token.h"
 #include "gpu/ipc/service/command_buffer_stub.h"
+#include "gpu/ipc/service/gpu_channel_shared_image_interface.h"
 #include "starboard/decode_target.h"
+#include "ui/gfx/color_space.h"
+#include "ui/gfx/geometry/size.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "gpu/command_buffer/service/ref_counted_lock.h"
+#endif  // BUILDFLAG(IS_ANDROID)
 
 namespace media {
 // StarboardGpuFactory allows to post tasks on gpu thread.
 // StarboardRenderer uses this class to post graphical tasks.
-// TODO(b/375070492): wire the rest of the functionality with
-// decode-to-texture.
 class StarboardGpuFactory : public gpu::CommandBufferStub::DestructionObserver {
  public:
   using GetStubCB =
@@ -44,6 +51,21 @@ class StarboardGpuFactory : public gpu::CommandBufferStub::DestructionObserver {
   virtual void RunSbDecodeTargetFunctionOnGpu(
       SbDecodeTargetGlesContextRunnerTarget target_function,
       void* target_function_context,
+      base::WaitableEvent* done_event) = 0;
+  virtual void RunCallbackOnGpu(base::OnceCallback<void()> callback,
+                                base::WaitableEvent* done_event) = 0;
+  virtual void PostCallbackToGpu(base::OnceCallback<void()> callback) = 0;
+  virtual void CreateImageOnGpu(
+      const gfx::Size& coded_size,
+      const gfx::ColorSpace& color_space,
+      viz::SharedImageFormat format,
+      scoped_refptr<gpu::ClientSharedImage>& shared_image,
+      const std::vector<uint32_t>& texture_service_ids,
+      const std::vector<uint32_t>& texture_targets,
+      uint64_t decode_target,
+#if BUILDFLAG(IS_ANDROID)
+      scoped_refptr<gpu::RefCountedLock> drdc_lock,
+#endif  // BUILDFLAG(IS_ANDROID)
       base::WaitableEvent* done_event) = 0;
 };
 

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -15,8 +15,11 @@
 #include "media/gpu/starboard/starboard_gpu_factory_impl.h"
 
 #include "base/memory/scoped_refptr.h"
+#include "gpu/command_buffer/service/shared_image/shared_image_factory.h"
+#include "gpu/command_buffer/service/texture_manager.h"
 #include "gpu/ipc/service/gpu_channel.h"
 #include "gpu/ipc/service/gpu_channel_manager.h"
+#include "gpu/ipc/service/shared_image_stub.h"
 #include "ui/gl/gl_bindings.h"
 #include "ui/gl/scoped_binders.h"
 #include "ui/gl/scoped_make_current.h"
@@ -58,11 +61,61 @@ void StarboardGpuFactoryImpl::RunSbDecodeTargetFunctionOnGpu(
     void* target_function_context,
     base::WaitableEvent* done_event) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (MakeContextCurrent(stub_)) {
+    target_function(target_function_context);
+  }
+  done_event->Signal();
+}
+
+void StarboardGpuFactoryImpl::RunCallbackOnGpu(
+    base::OnceCallback<void()> callback,
+    base::WaitableEvent* done_event) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (MakeContextCurrent(stub_)) {
+    std::move(callback).Run();
+  }
+  done_event->Signal();
+}
+
+void StarboardGpuFactoryImpl::PostCallbackToGpu(
+    base::OnceCallback<void()> callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   if (!MakeContextCurrent(stub_)) {
-    done_event->Signal();
     return;
   }
-  target_function(target_function_context);
+  std::move(callback).Run();
+}
+
+void StarboardGpuFactoryImpl::CreateImageOnGpu(
+    const gfx::Size& coded_size,
+    const gfx::ColorSpace& color_space,
+    viz::SharedImageFormat format,
+    scoped_refptr<gpu::ClientSharedImage>& shared_image,
+    const std::vector<uint32_t>& texture_service_ids,
+    const std::vector<uint32_t>& texture_targets,
+    uint64_t decode_target,
+#if BUILDFLAG(IS_ANDROID)
+    scoped_refptr<gpu::RefCountedLock> drdc_lock,
+#endif  // BUILDFLAG(IS_ANDROID)
+    base::WaitableEvent* done_event) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (MakeContextCurrent(stub_)) {
+    DCHECK_EQ(texture_service_ids.size(), texture_targets.size());
+
+    scoped_refptr<gpu::GpuChannelSharedImageInterface>
+        gpu_channel_shared_image_interface =
+            stub_->channel()->shared_image_stub()->shared_image_interface();
+
+    shared_image = gpu_channel_shared_image_interface
+                       ->CreateSharedImageForStarboardGLTexture(
+                           format, coded_size, color_space, texture_service_ids,
+                           texture_targets, decode_target
+#if BUILDFLAG(IS_ANDROID)
+                           ,
+                           std::move(drdc_lock)
+#endif
+                       );
+  }
   done_event->Signal();
 }
 

--- a/media/gpu/starboard/starboard_gpu_factory_impl.h
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.h
@@ -21,8 +21,6 @@
 
 namespace media {
 // Implement StarboardGpuFactory class.
-// TODO(b/375070492): wire the rest of the functionality with
-// decode-to-texture.
 class StarboardGpuFactoryImpl : public StarboardGpuFactory {
  public:
   explicit StarboardGpuFactoryImpl(GetStubCB get_stub_cb);
@@ -39,6 +37,20 @@ class StarboardGpuFactoryImpl : public StarboardGpuFactory {
       SbDecodeTargetGlesContextRunnerTarget target_function,
       void* target_function_context,
       base::WaitableEvent* done_event) override;
+  void RunCallbackOnGpu(base::OnceCallback<void()> callback,
+                        base::WaitableEvent* done_event) override;
+  void PostCallbackToGpu(base::OnceCallback<void()> callback) override;
+  void CreateImageOnGpu(const gfx::Size& coded_size,
+                        const gfx::ColorSpace& color_space,
+                        viz::SharedImageFormat format,
+                        scoped_refptr<gpu::ClientSharedImage>& shared_image,
+                        const std::vector<uint32_t>& texture_service_ids,
+                        const std::vector<uint32_t>& texture_targets,
+                        uint64_t decode_target,
+#if BUILDFLAG(IS_ANDROID)
+                        scoped_refptr<gpu::RefCountedLock> drdc_lock,
+#endif  // BUILDFLAG(IS_ANDROID)
+                        base::WaitableEvent* done_event) override;
 
  private:
   void OnWillDestroyStub(bool have_context) override;

--- a/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
+++ b/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
@@ -14,6 +14,7 @@
 
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/single_thread_task_runner.h"
+#include "gpu/config/gpu_finch_features.h"
 #include "media/base/audio_decoder.h"
 #include "media/base/audio_encoder.h"
 #include "media/base/media_log.h"
@@ -21,6 +22,10 @@
 #include "media/mojo/services/gpu_mojo_media_client.h"
 #include "media/mojo/services/starboard/starboard_renderer_wrapper.h"
 #include "media/starboard/starboard_cdm_factory.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "gpu/command_buffer/service/ref_counted_lock.h"
+#endif  // BUILDFLAG(IS_ANDROID)
 
 namespace media {
 
@@ -64,8 +69,16 @@ class GpuMojoMediaClientStarboard final : public GpuMojoMediaClient {
       StarboardRendererTraits traits) final {
 #if BUILDFLAG(IS_ANDROID)
     traits.android_overlay_factory_cb = android_overlay_factory_cb_;
-#endif  // BUILDFLAG(IS_ANDROID)
+    scoped_refptr<gpu::RefCountedLock> ref_counted_lock;
+
+    if (features::NeedThreadSafeAndroidMedia()) {
+      ref_counted_lock = base::MakeRefCounted<gpu::RefCountedLock>();
+    }
+    return std::make_unique<StarboardRendererWrapper>(std::move(traits),
+                                                      ref_counted_lock);
+#else   // BUILDFLAG(IS_ANDROID)
     return std::make_unique<StarboardRendererWrapper>(std::move(traits));
+#endif  // BUILDFLAG(IS_ANDROID)
   }
 
   std::unique_ptr<CdmFactory> CreatePlatformCdmFactory(

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -23,12 +23,21 @@
 #include "media/base/starboard/starboard_rendering_mode.h"
 #include "media/mojo/services/mojo_media_log.h"
 #include "ui/gfx/geometry/rect_conversions.h"
+#include "ui/gl/gl_bindings.h"
 
 namespace media {
 
 StarboardRendererWrapper::StarboardRendererWrapper(
-    StarboardRendererTraits traits)
-    : renderer_extension_receiver_(
+    StarboardRendererTraits traits
+#if BUILDFLAG(IS_ANDROID)
+    ,
+    scoped_refptr<gpu::RefCountedLock> drdc_lock)
+    : gpu::RefCountedLockHelperDrDc(std::move(drdc_lock)),
+#else   // BUILDFLAG(IS_ANDROID)
+    )
+    :
+#endif  // BUILDFLAG(IS_ANDROID)
+      renderer_extension_receiver_(
           this,
           std::move(traits.renderer_extension_receiver)),
       client_extension_remote_(std::move(traits.client_extension_remote),
@@ -170,9 +179,146 @@ void StarboardRendererWrapper::OnGpuChannelTokenReady(
 void StarboardRendererWrapper::GetCurrentVideoFrame(
     GetCurrentVideoFrameCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  // TODO(b/375070492): get SbDecodeTarget from
-  // SbPlayerBridge::GetCurrentSbDecodeTarget().
-  std::move(callback).Run(nullptr);
+  {
+    // Post GetRenderer()->GetSbDecodeTarget() on the gpu thread.
+    base::OnceCallback<void()> get_current_decode_target_cb =
+        base::BindOnce(&StarboardRendererWrapper::GetCurrentDecodeTarget,
+                       base::Unretained(this));
+    base::WaitableEvent done_event(
+        base::WaitableEvent::ResetPolicy::MANUAL,
+        base::WaitableEvent::InitialState::NOT_SIGNALED);
+    GetGpuFactory()
+        ->AsyncCall(&StarboardGpuFactory::RunCallbackOnGpu)
+        .WithArgs(std::move(get_current_decode_target_cb), &done_event);
+    // This call blocks because the underlying Starboard API
+    // (SbPlayerGetCurrentFrame) is synchronous and needs to be executed on the
+    // GPU thread.
+    base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_wait;
+    done_event.Wait();
+  }
+  if (SbDecodeTargetIsValid(decode_target_)) {
+    auto info = std::make_unique<SbDecodeTargetInfo>();
+    *info = {};
+    if (!SbDecodeTargetGetInfo(decode_target_, info.get())) {
+      LOG(ERROR) << "SbDecodeTargetGetInfo failed";
+      GetGpuFactory()
+          ->AsyncCall(&StarboardGpuFactory::PostCallbackToGpu)
+          .WithArgs(base::BindOnce(
+              [](void* target) {
+                SbDecodeTarget decode_target =
+                    reinterpret_cast<SbDecodeTarget>(target);
+                if (SbDecodeTargetIsValid(decode_target)) {
+                  SbDecodeTargetRelease(decode_target);
+                }
+              },
+              reinterpret_cast<void*>(decode_target_)));
+      decode_target_ = kSbDecodeTargetInvalid;
+      std::move(callback).Run(nullptr);
+      return;
+    }
+
+    VideoPixelFormat format;
+    viz::SharedImageFormat viz_format;
+    std::vector<uint32_t> texture_service_ids;
+    std::vector<uint32_t> texture_targets;
+    scoped_refptr<gpu::ClientSharedImage> shared_image;
+    int plane_count = SbDecodeTargetNumberOfPlanesForFormat(info.get()->format);
+    DCHECK_GE(plane_count, 1);
+    const SbDecodeTargetInfoPlane& plane = info.get()->planes[0];
+    auto coded_size = gfx::Size(info.get()->width, info.get()->height);
+    auto visible_rect = gfx::Rect(
+        gfx::Point(
+            static_cast<int>(std::round(std::min(plane.content_region.left,
+                                                 plane.content_region.right))),
+            static_cast<int>(std::round(std::min(
+                plane.content_region.top, plane.content_region.bottom)))),
+        gfx::Size(
+            static_cast<int>(std::round(std::abs(plane.content_region.right -
+                                                 plane.content_region.left))),
+            static_cast<int>(std::round(std::abs(
+                plane.content_region.top - plane.content_region.bottom)))));
+    auto natural_size = visible_rect.size();
+
+    if (info.get()->format == kSbDecodeTargetFormat1PlaneRGBA) {
+      DCHECK_EQ(static_cast<size_t>(plane_count), 1u);
+      format = PIXEL_FORMAT_ABGR;
+      viz_format = viz::SinglePlaneFormat::kRGBA_8888;
+    } else if (info.get()->format == kSbDecodeTargetFormat3PlaneYUVI420) {
+      DCHECK_EQ(static_cast<size_t>(plane_count), 3u);
+      format = PIXEL_FORMAT_I420;
+      viz_format = viz::MultiPlaneFormat::kI420;
+    } else {
+      LOG(ERROR) << "Unsupported SbDecodeTargetFormat: "
+                 << static_cast<int>(info.get()->format);
+      GetGpuFactory()
+          ->AsyncCall(&StarboardGpuFactory::PostCallbackToGpu)
+          .WithArgs(base::BindOnce(
+              [](void* target) {
+                SbDecodeTarget decode_target =
+                    reinterpret_cast<SbDecodeTarget>(target);
+                if (SbDecodeTargetIsValid(decode_target)) {
+                  SbDecodeTargetRelease(decode_target);
+                }
+              },
+              reinterpret_cast<void*>(decode_target_)));
+      decode_target_ = kSbDecodeTargetInvalid;
+      std::move(callback).Run(nullptr);
+      return;
+    }
+
+    for (int plane_index = 0; plane_index < plane_count; plane_index++) {
+      texture_service_ids.push_back(info.get()->planes[plane_index].texture);
+      texture_targets.push_back(
+          info.get()->planes[plane_index].gl_texture_target);
+    }
+    DCHECK_EQ(texture_service_ids.size(), static_cast<size_t>(plane_count));
+    DCHECK_EQ(texture_targets.size(), static_cast<size_t>(plane_count));
+
+    if (current_shared_image_ &&
+        texture_service_ids == last_texture_service_ids_) {
+      shared_image = current_shared_image_;
+      GetGpuFactory()
+          ->AsyncCall(&StarboardGpuFactory::PostCallbackToGpu)
+          .WithArgs(base::BindOnce(
+              [](void* target) {
+                SbDecodeTarget decode_target =
+                    reinterpret_cast<SbDecodeTarget>(target);
+                if (SbDecodeTargetIsValid(decode_target)) {
+                  SbDecodeTargetRelease(decode_target);
+                }
+              },
+              reinterpret_cast<void*>(decode_target_)));
+      decode_target_ = kSbDecodeTargetInvalid;
+    } else {
+      base::WaitableEvent done_event(
+          base::WaitableEvent::ResetPolicy::MANUAL,
+          base::WaitableEvent::InitialState::NOT_SIGNALED);
+      GetGpuFactory()
+          ->AsyncCall(&StarboardGpuFactory::CreateImageOnGpu)
+          .WithArgs(coded_size, GetRenderer()->color_space(), viz_format,
+                    std::ref(shared_image), std::ref(texture_service_ids),
+                    std::ref(texture_targets),
+                    reinterpret_cast<uint64_t>(decode_target_),
+#if BUILDFLAG(IS_ANDROID)
+                    GetDrDcLock(),
+#endif  // BUILDFLAG(IS_ANDROID)
+                    &done_event);
+      // Blocking is okay here to create image from textures on gpu thread.
+      base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_wait;
+      done_event.Wait();
+      if (shared_image) {
+        current_shared_image_ = shared_image;
+        last_texture_service_ids_ = texture_service_ids;
+        decode_target_ = kSbDecodeTargetInvalid;
+      }
+    }
+
+    if (shared_image) {
+      CreateVideoFrame_OnImageReady(format, coded_size, visible_rect,
+                                    natural_size, std::move(shared_image));
+    }
+  }
+  std::move(callback).Run(current_frame_);
 }
 
 void StarboardRendererWrapper::OnSbWindowHandleReady(
@@ -299,6 +445,37 @@ void StarboardRendererWrapper::GraphicsContextRunner(
     base::ScopedAllowBaseSyncPrimitives allow_wait;
     done_event.Wait();
   }
+}
+
+void StarboardRendererWrapper::GetCurrentDecodeTarget() {
+  decode_target_ = GetRenderer()->GetSbDecodeTarget();
+}
+
+void StarboardRendererWrapper::CreateVideoFrame_OnImageReady(
+    VideoPixelFormat format,
+    const gfx::Size& coded_size,
+    const gfx::Rect& visible_rect,
+    const gfx::Size& natural_size,
+    scoped_refptr<gpu::ClientSharedImage> shared_image) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+
+  auto release_cb = base::BindOnce(
+      [](scoped_refptr<gpu::ClientSharedImage> shared_image,
+         const gpu::SyncToken& sync_token) {
+        if (sync_token.HasData()) {
+          shared_image->BackingWasExternallyUpdated(sync_token);
+        }
+      },
+      shared_image);
+
+  auto frame = VideoFrame::WrapSharedImage(
+      format, std::move(shared_image), gpu::SyncToken(), std::move(release_cb),
+      coded_size, visible_rect, natural_size, base::TimeDelta());
+  if (!frame) {
+    LOG(ERROR) << __func__ << " failed to create video frame";
+    return;
+  }
+  current_frame_ = std::move(frame);
 }
 
 }  // namespace media

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -15,6 +15,9 @@
 #ifndef MEDIA_MOJO_SERVICES_STARBOARD_STARBOARD_RENDERER_WRAPPER_H_
 #define MEDIA_MOJO_SERVICES_STARBOARD_STARBOARD_RENDERER_WRAPPER_H_
 
+#include <functional>
+#include <vector>
+
 #include "base/memory/raw_ptr.h"
 #include "base/memory/weak_ptr.h"
 #include "base/threading/sequence_bound.h"
@@ -34,6 +37,7 @@
 #include "starboard/decode_target.h"
 
 #if BUILDFLAG(IS_ANDROID)
+#include "gpu/command_buffer/service/ref_counted_lock.h"
 #include "media/base/android_overlay_mojo_factory.h"
 #endif  // BUILDFLAG(IS_ANDROID)
 
@@ -55,12 +59,21 @@ class StarboardGpuFactory;
 class StarboardRendererWrapper
     : public Renderer,
       public mojom::StarboardRendererExtension,
+#if BUILDFLAG(IS_ANDROID)
+      public gpu::RefCountedLockHelperDrDc,
+#endif  // BUILDFLAG(IS_ANDROID)
       public cobalt::media::mojom::VideoGeometryChangeClient {
  public:
   using RendererExtension = mojom::StarboardRendererExtension;
   using ClientExtension = mojom::StarboardRendererClientExtension;
+  using GetStarboardCommandBufferStubCB = StarboardGpuFactory::GetStubCB;
 
+#if BUILDFLAG(IS_ANDROID)
+  StarboardRendererWrapper(StarboardRendererTraits traits,
+                           scoped_refptr<gpu::RefCountedLock> drdc_lock);
+#else   // BUILDFLAG(IS_ANDROID)
   explicit StarboardRendererWrapper(StarboardRendererTraits traits);
+#endif  // BUILDFLAG(IS_ANDROID)
 
   StarboardRendererWrapper(const StarboardRendererWrapper&) = delete;
   StarboardRendererWrapper& operator=(const StarboardRendererWrapper&) = delete;
@@ -122,6 +135,13 @@ class StarboardRendererWrapper
   bool IsGpuChannelTokenAvailable() const { return !!command_buffer_id_; }
   SbDecodeTargetGraphicsContextProvider*
   GetSbDecodeTargetGraphicsContextProvider();
+  void GetCurrentDecodeTarget();
+  void CreateVideoFrame_OnImageReady(
+      VideoPixelFormat format,
+      const gfx::Size& coded_size,
+      const gfx::Rect& visible_rect,
+      const gfx::Size& natural_size,
+      scoped_refptr<gpu::ClientSharedImage> shared_image);
 
   static void GraphicsContextRunner(
       SbDecodeTargetGraphicsContextProvider* graphics_context_provider,
@@ -141,6 +161,10 @@ class StarboardRendererWrapper
       decode_target_graphics_context_provider_ = {};
 
   bool is_gpu_factory_initialized_ = false;
+  scoped_refptr<VideoFrame> current_frame_;
+  scoped_refptr<gpu::ClientSharedImage> current_shared_image_;
+  std::vector<uint32_t> last_texture_service_ids_;
+  SbDecodeTarget decode_target_ = kSbDecodeTargetInvalid;
 
   raw_ptr<StarboardRenderer> test_renderer_;
   raw_ptr<base::SequenceBound<StarboardGpuFactory>> test_gpu_factory_;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -145,6 +145,27 @@ class MockStarboardGpuFactory : public StarboardGpuFactory {
     done_event->Signal();
   }
 
+  void RunCallbackOnGpu(base::OnceCallback<void()> callback,
+                        base::WaitableEvent* done_event) override {
+    done_event->Signal();
+  }
+
+  void PostCallbackToGpu(base::OnceCallback<void()> callback) override {}
+
+  void CreateImageOnGpu(const gfx::Size& coded_size,
+                        const gfx::ColorSpace& color_space,
+                        viz::SharedImageFormat format,
+                        scoped_refptr<gpu::ClientSharedImage>& shared_image,
+                        const std::vector<uint32_t>& texture_service_ids,
+                        const std::vector<uint32_t>& texture_targets,
+                        uint64_t decode_target,
+#if BUILDFLAG(IS_ANDROID)
+                        scoped_refptr<gpu::RefCountedLock> drdc_lock,
+#endif  // BUILDFLAG(IS_ANDROID)
+                        base::WaitableEvent* done_event) override {
+    done_event->Signal();
+  }
+
  private:
   void OnWillDestroyStub(bool have_context) override {}
 };
@@ -189,7 +210,12 @@ class StarboardRendererWrapperTest : public testing::Test {
         gfx::Size(), std::move(renderer_extension_receiver),
         std::move(client_extension_remote), base::NullCallback());
     renderer_wrapper_ =
-        std::make_unique<StarboardRendererWrapper>(std::move(traits));
+        std::make_unique<StarboardRendererWrapper>(std::move(traits)
+#if BUILDFLAG(IS_ANDROID)
+                                                       ,
+                                                   /*ref_counted_lock=*/nullptr
+#endif  // BUILDFLAG(IS_ANDROID)
+        );
     renderer_wrapper_->SetRendererForTesting(mock_renderer_.get());
     renderer_wrapper_->SetGpuFactoryForTesting(&gpu_factory_);
 

--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -119,9 +119,6 @@ buildflag_header("buildflags") {
     # TODO(b/375069564): Revisit CValStats
     "COBALT_MEDIA_ENABLE_CVAL=0",
 
-    # TODO(b/375070492): Revisit decode-to-texture
-    "COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER=0",
-
     # TODO(b/375218518): Revisit FormatSupportQueryMetrics
     "COBALT_MEDIA_ENABLE_FORMAT_SUPPORT_QUERY_METRICS=0",
 

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -739,6 +739,7 @@ void StarboardRenderer::UpdateDecoderConfig(DemuxerStream* stream) {
       content_size_change_cb_.Run();
     }
 #endif  // 0
+    color_space_ = decoder_config.color_space_info().ToGfxColorSpace();
     paint_video_hole_frame_cb_.Run(
         stream->video_decoder_config().visible_rect().size());
   }
@@ -1139,6 +1140,17 @@ void StarboardRenderer::OnBufferingStateChange(BufferingState buffering_state) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
   client_->OnBufferingStateChange(buffering_state,
                                   BUFFERING_CHANGE_REASON_UNKNOWN);
+}
+
+SbDecodeTarget StarboardRenderer::GetSbDecodeTarget() {
+  // This function might be called from a different thread (e.g. GPU thread)
+  // to get the decode target for rendering.
+  if (player_bridge_ && player_bridge_->IsValid()) {
+    CHECK(player_bridge_->GetSbPlayerOutputMode() ==
+          kSbPlayerOutputModeDecodeToTexture);
+    return player_bridge_->GetCurrentSbDecodeTarget();
+  }
+  return kSbDecodeTargetInvalid;
 }
 
 void StarboardRenderer::set_decode_target_graphics_context_provider(

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -34,6 +34,7 @@
 #include "media/base/starboard/starboard_rendering_mode.h"
 #include "media/starboard/sbplayer_bridge.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
+#include "ui/gfx/color_space.h"
 
 #if BUILDFLAG(IS_ANDROID)
 #include "media/base/android_overlay_mojo_factory.h"
@@ -124,12 +125,14 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
 #if BUILDFLAG(IS_ANDROID)
   void OnOverlayInfoChanged(const OverlayInfo& overlay_info);
 #endif  // BUILDFLAG(IS_ANDROID)
+  SbDecodeTarget GetSbDecodeTarget();
   // Call to get the SbDecodeTargetGraphicsContextProvider for SbPlayerCreate().
   using GetDecodeTargetGraphicsContextProviderFunc =
       base::RepeatingCallback<SbDecodeTargetGraphicsContextProvider*()>;
   void set_decode_target_graphics_context_provider(
       const GetDecodeTargetGraphicsContextProviderFunc&
           get_decode_target_graphics_context_provider_func);
+  const gfx::ColorSpace& color_space() const { return color_space_; }
 
   SbPlayerInterface* GetSbPlayerInterface();
 
@@ -279,6 +282,9 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   // Call to get the SbDecodeTargetGraphicsContextProvider for SbPlayerCreate().
   GetDecodeTargetGraphicsContextProviderFunc
       get_decode_target_graphics_context_provider_func_;
+
+  // TODO: b/508699637 - Check if HDR is supported.
+  gfx::ColorSpace color_space_ = gfx::ColorSpace::CreateSRGB();
 
   // Message to signal a capability changed error.
   // "MEDIA_ERR_CAPABILITY_CHANGED" must be in the error message to be


### PR DESCRIPTION
Enable video playback using the decode-to-texture output mode. This
introduces a new GL texture image backing for Starboard decode targets,
allowing GPU-side rendering and composition of video frames.

The StarboardRendererWrapper now orchestrates the creation of ClientSharedImage
from SbDecodeTargets received from the Starboard player. This involves
communicating with the GPU thread to create and manage the necessary GL
textures and shared image representations. The SbPlayerBridge dynamically
registers its graphics context provider when in decode-to-texture mode.

This provides a flexible mechanism for integrating video output with
Cobalt's rendering pipeline, enabling advanced compositing effects.

The unit tests were generated with assistance from `gemini-cli` and refined
for correctness.

#vibe-coded

Issue: 500367083