### PR TITLE
Build RDK plugin related binaries

### DIFF
--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -16,7 +16,7 @@
   "targets": [
     "cobalt:gn_all",
     "loader_app",
-    "libloader_app.so"
+    "loader_app_rdk_plugin"
   ],
   "includes": [
     {

--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -15,7 +15,8 @@
   },
   "targets": [
     "cobalt:gn_all",
-    "loader_app"
+    "loader_app",
+    "libloader_app.so"
   ],
   "includes": [
     {

--- a/cobalt/build/evergreen-arm-hardfp-rdk/package.json
+++ b/cobalt/build/evergreen-arm-hardfp-rdk/package.json
@@ -16,7 +16,7 @@
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
                 "loader_app",
-                "libloader_app.so"
+                "libloader_app.so",
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"

--- a/cobalt/build/evergreen-arm-hardfp-rdk/package.json
+++ b/cobalt/build/evergreen-arm-hardfp-rdk/package.json
@@ -16,6 +16,7 @@
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
                 "loader_app",
+                "libloader_app.so"
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -386,3 +386,34 @@ copy("rdk_cobalt_keymap") {
   sources = [ "cobalt/content/etc/keymapping.json" ]
   outputs = [ "$root_out_dir/app/cobalt/content/etc/keymapping.json" ]
 }
+
+# These changes are temporary for backward compatibility.
+# TODO: b/499089012 - Remove this group once we fully transition to the new
+# plugin method (libloader_app.so) as part of b/491573728.
+group("loader_app_rdk_plugin") {
+  data_deps = [":loader_app($starboard_toolchain)"]
+}
+
+if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+# These changes are temporary for backward compatibility.
+# TODO: b/499089012 - Remove once we move to the new plugin method (libloader_app.so).
+  target("shared_library", "loader_app") {
+    output_dir = root_build_dir
+    if (target_cpu == "x64" || target_cpu == "arm" || target_cpu == "arm64") {
+      sources = [
+        "//starboard/loader_app/loader_app.cc",
+        "//starboard/loader_app/loader_app_switches.cc",
+        "//starboard/loader_app/loader_app_switches.h",
+        "//starboard/loader_app/system_get_extension_shim.cc",
+        "//starboard/loader_app/system_get_extension_shim.h",
+      ]
+      deps = [
+        "//starboard/loader_app:common_loader_app_dependencies",
+        "//starboard:starboard_with_main",
+        "//starboard/content/fonts:copy_font_data",
+        "//starboard/elf_loader",
+      ]
+      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+    }
+  }
+}

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -387,33 +387,14 @@ copy("rdk_cobalt_keymap") {
   outputs = [ "$root_out_dir/app/cobalt/content/etc/keymapping.json" ]
 }
 
-# These changes are temporary for backward compatibility.
-# TODO: b/499089012 - Remove this group once we fully transition to the new
-# plugin method (libloader_app.so) as part of b/491573728.
 group("loader_app_rdk_plugin") {
   data_deps = [":loader_app($starboard_toolchain)"]
 }
 
 if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
-# These changes are temporary for backward compatibility.
-# TODO: b/499089012 - Remove once we move to the new plugin method (libloader_app.so).
   target("shared_library", "loader_app") {
     output_dir = root_build_dir
-    if (target_cpu == "x64" || target_cpu == "arm" || target_cpu == "arm64") {
-      sources = [
-        "//starboard/loader_app/loader_app.cc",
-        "//starboard/loader_app/loader_app_switches.cc",
-        "//starboard/loader_app/loader_app_switches.h",
-        "//starboard/loader_app/system_get_extension_shim.cc",
-        "//starboard/loader_app/system_get_extension_shim.h",
-      ]
-      deps = [
-        "//starboard/loader_app:common_loader_app_dependencies",
-        "//starboard:starboard_with_main",
-        "//starboard/content/fonts:copy_font_data",
-        "//starboard/elf_loader",
-      ]
-      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
-    }
+    deps = [ "//starboard/loader_app:loader_app_sources" ]
+    data_deps = [ "//starboard/content/fonts:copy_font_data" ]
   }
 }

--- a/starboard/loader_app/BUILD.gn
+++ b/starboard/loader_app/BUILD.gn
@@ -61,8 +61,8 @@ if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
     sources = _common_loader_app_sources
     deps = [
       ":common_loader_app_dependencies",
-      "//starboard/content/fonts:copy_font_data",
       "//starboard:starboard_with_main",
+      "//starboard/content/fonts:copy_font_data",
       "//starboard/elf_loader",
     ]
   }
@@ -322,7 +322,7 @@ if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
     ]
     deps = [
       "//starboard:starboard_group",
-      "//starboard/common:common",
+      "//starboard/common",
     ]
   }
 

--- a/starboard/loader_app/BUILD.gn
+++ b/starboard/loader_app/BUILD.gn
@@ -57,16 +57,20 @@ static_library("record_loader_app_status") {
 }
 
 if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+  source_set("loader_app_sources") {
+    sources = _common_loader_app_sources
+    deps = [
+      ":common_loader_app_dependencies",
+      "//starboard/content/fonts:copy_font_data",
+      "//starboard:starboard_with_main",
+      "//starboard/elf_loader",
+    ]
+  }
+
   target(starboard_level_final_executable_type, "loader_app") {
     output_dir = root_build_dir
     if (target_cpu == "x64" || target_cpu == "arm" || target_cpu == "arm64") {
-      sources = _common_loader_app_sources
-      deps = [
-        ":common_loader_app_dependencies",
-        "//starboard:starboard_with_main",
-        "//starboard/content/fonts:copy_font_data",
-        "//starboard/elf_loader",
-      ]
+      deps = [ ":loader_app_sources" ]
       data_deps = [ "//starboard/content/fonts:copy_font_data" ]
     }
   }


### PR DESCRIPTION
Build RDK plugin related binaries (libloader_app.so).

- Refactor `loader_app` target to reuse sources from `starboard/loader_app/BUILD.gn` via a new `loader_app_sources` source_set.
- Adds libloader_app.so to package and GitHub config.

Bug: 491573728