### PR TITLE
cobalt/metrics: Add interfaces and stubs for granular memory tracking.

### DIFF
--- a/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
@@ -1,6 +1,16 @@
-// Copyright 2026 The Chromium Authors
-// Use of this source code is governed by a BSD-style license that can be
-// found in the LICENSE file.
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 #ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_
 #define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
@@ -1,0 +1,52 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_
+#define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "base/component_export.h"
+#include "base/containers/flat_map.h"
+#include "base/memory/weak_ptr.h"
+
+namespace memory_instrumentation {
+
+// Optimized structure for smaps metrics.
+struct COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
+    SmapsMetrics {
+  uint64_t rss_kb = 0;
+  uint64_t pss_kb = 0;
+  uint64_t private_dirty_kb = 0;
+  uint64_t private_clean_kb = 0;
+  uint64_t shared_dirty_kb = 0;
+  uint64_t shared_clean_kb = 0;
+  uint64_t swap_kb = 0;
+  uint64_t swap_pss_kb = 0;
+};
+
+// Interface for project-specific detailed memory metrics collection.
+class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
+    DetailedMetricsDelegate {
+ public:
+  virtual ~DetailedMetricsDelegate() = default;
+
+  // Called for each parsed entry. |name| is transient and must be copied if
+  // needed. Implementations must be thread-safe.
+  virtual void OnSmapsEntry(std::string_view name,
+                            const SmapsMetrics& metrics) = 0;
+
+  // Swaps the internal results map with an empty one and returns it via |stats|.
+  virtual void GetAndResetStats(
+      base::flat_map<std::string, uint64_t>* stats) = 0;
+
+  virtual base::WeakPtr<DetailedMetricsDelegate> GetWeakPtr() = 0;
+};
+
+}  // namespace memory_instrumentation
+
+#endif  // SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_
+

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h
@@ -7,10 +7,15 @@
 
 #include "base/component_export.h"
 #include "base/functional/callback_forward.h"
+#include "base/memory/weak_ptr.h"
 #include "base/trace_event/memory_dump_request_args.h"
 #include "mojo/public/cpp/bindings/shared_remote.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/global_memory_dump.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
+#if BUILDFLAG(IS_COBALT)
+#include "base/synchronization/lock.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#endif
 
 namespace memory_instrumentation {
 
@@ -99,6 +104,18 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
       MemoryDumpLevelOfDetail,
       MemoryDumpDeterminism,
       RequestGlobalMemoryDumpAndAppendToTraceCallback);
+#if BUILDFLAG(IS_COBALT)
+  void SetDetailedMetricsDelegate(DetailedMetricsDelegate* delegate) {
+    base::AutoLock lock(detailed_metrics_delegate_lock_);
+    detailed_metrics_delegate_ = delegate ? delegate->GetWeakPtr() : nullptr;
+  }
+
+  base::WeakPtr<DetailedMetricsDelegate> GetDetailedMetricsDelegate() const {
+    base::AutoLock lock(detailed_metrics_delegate_lock_);
+    return detailed_metrics_delegate_;
+  }
+#endif
+  base::WeakPtr<MemoryInstrumentation> GetWeakPtr() { return weak_ptr_factory_.GetWeakPtr(); }
 
  private:
   explicit MemoryInstrumentation(
@@ -112,6 +129,11 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
 
   // Only browser process is allowed to request memory dumps.
   const bool is_browser_process_;
+#if BUILDFLAG(IS_COBALT)
+  mutable base::Lock detailed_metrics_delegate_lock_;
+  base::WeakPtr<DetailedMetricsDelegate> detailed_metrics_delegate_;
+#endif
+  base::WeakPtrFactory<MemoryInstrumentation> weak_ptr_factory_{this};
 };
 
 }  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h
@@ -114,8 +114,9 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
     base::AutoLock lock(detailed_metrics_delegate_lock_);
     return detailed_metrics_delegate_;
   }
-#endif
+
   base::WeakPtr<MemoryInstrumentation> GetWeakPtr() { return weak_ptr_factory_.GetWeakPtr(); }
+#endif
 
  private:
   explicit MemoryInstrumentation(
@@ -132,8 +133,8 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
 #if BUILDFLAG(IS_COBALT)
   mutable base::Lock detailed_metrics_delegate_lock_;
   base::WeakPtr<DetailedMetricsDelegate> detailed_metrics_delegate_;
-#endif
   base::WeakPtrFactory<MemoryInstrumentation> weak_ptr_factory_{this};
+#endif
 };
 
 }  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h
@@ -7,12 +7,12 @@
 
 #include "base/component_export.h"
 #include "base/functional/callback_forward.h"
-#include "base/memory/weak_ptr.h"
 #include "base/trace_event/memory_dump_request_args.h"
 #include "mojo/public/cpp/bindings/shared_remote.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/global_memory_dump.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
 #if BUILDFLAG(IS_COBALT)
+#include "base/memory/weak_ptr.h"
 #include "base/synchronization/lock.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
 #endif

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
@@ -53,8 +53,13 @@ class COMPONENT_EXPORT(
   // the current process is used
   static bool FillOSMemoryDump(base::ProcessHandle handle,
                                const MemDumpFlagSet& flags,
+                               mojom::RawOSMemDump* dump);
+#if BUILDFLAG(IS_COBALT)
+  static bool FillOSMemoryDump(base::ProcessHandle handle,
+                               const MemDumpFlagSet& flags,
                                mojom::RawOSMemDump* dump,
-                               base::WeakPtr<DetailedMetricsDelegate> delegate = nullptr);
+                               base::WeakPtr<DetailedMetricsDelegate> delegate);
+#endif
 #if BUILDFLAG(IS_APPLE)
   static bool FillOSMemoryDump(base::ProcessHandle handle,
                                const MemDumpFlagSet& flags,

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
@@ -1,6 +1,7 @@
 // Copyright 2017 The Chromium Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 #ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_OS_METRICS_H_
 #define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_OS_METRICS_H_
 
@@ -24,7 +25,7 @@ FORWARD_DECLARE_TEST(ProfilingJsonExporterTest, MemoryMaps);
 }
 
 namespace memory_instrumentation {
-
+class DetailedMetricsDelegate;
 // This class provides synchronous access to memory metrics for a process with a
 // given |pid|. These interfaces have platform-specific restrictions:
 //  * On Android, due to sandboxing restrictions, processes can only access
@@ -52,7 +53,8 @@ class COMPONENT_EXPORT(
   // the current process is used
   static bool FillOSMemoryDump(base::ProcessHandle handle,
                                const MemDumpFlagSet& flags,
-                               mojom::RawOSMemDump* dump);
+                               mojom::RawOSMemDump* dump,
+                               base::WeakPtr<DetailedMetricsDelegate> delegate = nullptr);
 #if BUILDFLAG(IS_APPLE)
   static bool FillOSMemoryDump(base::ProcessHandle handle,
                                const MemDumpFlagSet& flags,
@@ -67,10 +69,21 @@ class COMPONENT_EXPORT(
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
   static void SetProcSmapsForTesting(FILE*);
+#if BUILDFLAG(IS_COBALT)
+  static void SetDetailedMetricsDelegate(base::WeakPtr<DetailedMetricsDelegate> delegate);
+#endif
 #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
         // BUILDFLAG(IS_ANDROID)
 
  private:
+#if BUILDFLAG(IS_COBALT)
+  static bool FillDetailedMetrics(base::ProcessHandle handle,
+                                  const MemDumpFlagSet& flags,
+                                  mojom::RawOSMemDump* dump,
+                                  base::WeakPtr<DetailedMetricsDelegate> delegate) { return false; }
+  static bool ReadDetailedMetricsFile(base::ProcessHandle handle,
+                                      base::WeakPtr<DetailedMetricsDelegate> delegate) { return false; }
+#endif
   FRIEND_TEST_ALL_PREFIXES(OSMetricsTest, ParseProcSmaps);
   FRIEND_TEST_ALL_PREFIXES(OSMetricsTest, TestWinModuleReading);
   FRIEND_TEST_ALL_PREFIXES(OSMetricsTest, TestMachOReading);

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
@@ -1,7 +1,6 @@
 // Copyright 2017 The Chromium Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
-
 #ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_OS_METRICS_H_
 #define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_OS_METRICS_H_
 
@@ -25,7 +24,9 @@ FORWARD_DECLARE_TEST(ProfilingJsonExporterTest, MemoryMaps);
 }
 
 namespace memory_instrumentation {
+#if BUILDFLAG(IS_COBALT)
 class DetailedMetricsDelegate;
+#endif  // BUILDFLAG(IS_COBALT)
 // This class provides synchronous access to memory metrics for a process with a
 // given |pid|. These interfaces have platform-specific restrictions:
 //  * On Android, due to sandboxing restrictions, processes can only access

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -535,8 +535,7 @@ void OSMetrics::SetProcSmapsForTesting(FILE* f) {
 
 bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
                                  const MemDumpFlagSet& flags,
-                                 mojom::RawOSMemDump* dump,
-                                 base::WeakPtr<DetailedMetricsDelegate> delegate) {
+                                 mojom::RawOSMemDump* dump) {
   auto info = GetMemoryInfo(handle);
   if (!info.has_value()) {
     return false;
@@ -548,11 +547,6 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
       base::saturated_cast<uint32_t>(info->resident_set_bytes / 1024);
   dump->peak_resident_set_kb = GetPeakResidentSetSize(handle);
   dump->is_peak_rss_resettable = ResetPeakRSSIfPossible(handle);
-
-#if BUILDFLAG(IS_COBALT)
-  if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS))
-    FillDetailedMetrics(handle, flags, dump, std::move(delegate));
-#endif
 
   if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_COUNT_MAPPINGS)) {
     dump->mappings_count = CountMappings(handle);
@@ -592,6 +586,23 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
 
   return true;
 }
+
+#if BUILDFLAG(IS_COBALT)
+bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
+                                 const MemDumpFlagSet& flags,
+                                 mojom::RawOSMemDump* dump,
+                                 base::WeakPtr<DetailedMetricsDelegate> delegate) {
+  if (!FillOSMemoryDump(handle, flags, dump)) {
+    return false;
+  }
+
+  if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS)) {
+    FillDetailedMetrics(handle, flags, dump, std::move(delegate));
+  }
+
+  return true;
+}
+#endif
 
 // static
 std::vector<VmRegionPtr> OSMetrics::GetProcessMemoryMaps(

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -328,65 +328,9 @@ void GetSmapsRollup(uint32_t* pss, uint32_t* swap_pss) {
 
 #if BUILDFLAG(IS_COBALT)
 #if !BUILDFLAG(IS_ANDROID)
-struct LibChrobaltMem {
-  uint32_t pss_kb = 0;
-  uint32_t rss_kb = 0;
-};
 
-struct SmapsRollup {
-  uint32_t pss_kb = 0;
-  uint32_t rss_kb = 0;
-};
 
-void GetSmapsRollup(base::ProcessId pid,
-                    const char* needle,
-                    SmapsRollup* rollup) {
-  std::string file_name =
-      "/proc/" +
-      (pid == base::kNullProcessId ? "self" : base::NumberToString(pid)) +
-      "/smaps";
-  base::ScopedFILE smaps_file(fopen(file_name.c_str(), "r"));
-  if (!smaps_file) {
-    return;
-  }
 
-  char line[kMaxLineSize];
-  uint64_t total_pss_kb = 0;
-  uint64_t total_rss_kb = 0;
-  bool is_matching_region = false;
-  while (fgets(line, kMaxLineSize, smaps_file.get())) {
-    if (base::IsHexDigit(static_cast<unsigned char>(line[0])) &&
-        !base::IsAsciiUpper(static_cast<unsigned char>(line[0]))) {
-      const char* found = strstr(line, needle);
-      is_matching_region = (found != nullptr);
-    } else if (is_matching_region) {
-      uint64_t value_kb = 0;
-      if (strncmp(line, "Pss:", 4) == 0) {
-        if (sscanf(line, "Pss: %" SCNu64 " kB", &value_kb) == 1) {
-          total_pss_kb += value_kb;
-        }
-      } else if (strncmp(line, "Rss:", 4) == 0) {
-        if (sscanf(line, "Rss: %" SCNu64 " kB", &value_kb) == 1) {
-          total_rss_kb += value_kb;
-        }
-      }
-    }
-  }
-  rollup->pss_kb = base::saturated_cast<uint32_t>(total_pss_kb);
-  rollup->rss_kb = base::saturated_cast<uint32_t>(total_rss_kb);
-}
-
-LibChrobaltMem GetLibChrobaltMem(base::ProcessId pid) {
-  SmapsRollup rollup;
-  GetSmapsRollup(pid, "libchrobalt.so", &rollup);
-  return {rollup.pss_kb, rollup.rss_kb};
-}
-
-uint32_t GetPartitionAllocRss(base::ProcessId pid) {
-  SmapsRollup rollup;
-  GetSmapsRollup(pid, "<anon:partition_alloc>", &rollup);
-  return rollup.rss_kb;
-}
 #else  // BUILDFLAG(IS_ANDROID)
 namespace {
 constexpr char kLibChrobaltPattern[] = "libchrobalt.so";

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -328,9 +328,65 @@ void GetSmapsRollup(uint32_t* pss, uint32_t* swap_pss) {
 
 #if BUILDFLAG(IS_COBALT)
 #if !BUILDFLAG(IS_ANDROID)
+struct LibChrobaltMem {
+  uint32_t pss_kb = 0;
+  uint32_t rss_kb = 0;
+};
 
+struct SmapsRollup {
+  uint32_t pss_kb = 0;
+  uint32_t rss_kb = 0;
+};
 
+void GetSmapsRollup(base::ProcessId pid,
+                    const char* needle,
+                    SmapsRollup* rollup) {
+  std::string file_name =
+      "/proc/" +
+      (pid == base::kNullProcessId ? "self" : base::NumberToString(pid)) +
+      "/smaps";
+  base::ScopedFILE smaps_file(fopen(file_name.c_str(), "r"));
+  if (!smaps_file) {
+    return;
+  }
 
+  char line[kMaxLineSize];
+  uint64_t total_pss_kb = 0;
+  uint64_t total_rss_kb = 0;
+  bool is_matching_region = false;
+  while (fgets(line, kMaxLineSize, smaps_file.get())) {
+    if (base::IsHexDigit(static_cast<unsigned char>(line[0])) &&
+        !base::IsAsciiUpper(static_cast<unsigned char>(line[0]))) {
+      const char* found = strstr(line, needle);
+      is_matching_region = (found != nullptr);
+    } else if (is_matching_region) {
+      uint64_t value_kb = 0;
+      if (strncmp(line, "Pss:", 4) == 0) {
+        if (sscanf(line, "Pss: %" SCNu64 " kB", &value_kb) == 1) {
+          total_pss_kb += value_kb;
+        }
+      } else if (strncmp(line, "Rss:", 4) == 0) {
+        if (sscanf(line, "Rss: %" SCNu64 " kB", &value_kb) == 1) {
+          total_rss_kb += value_kb;
+        }
+      }
+    }
+  }
+  rollup->pss_kb = base::saturated_cast<uint32_t>(total_pss_kb);
+  rollup->rss_kb = base::saturated_cast<uint32_t>(total_rss_kb);
+}
+
+LibChrobaltMem GetLibChrobaltMem(base::ProcessId pid) {
+  SmapsRollup rollup;
+  GetSmapsRollup(pid, "libchrobalt.so", &rollup);
+  return {rollup.pss_kb, rollup.rss_kb};
+}
+
+uint32_t GetPartitionAllocRss(base::ProcessId pid) {
+  SmapsRollup rollup;
+  GetSmapsRollup(pid, "<anon:partition_alloc>", &rollup);
+  return rollup.rss_kb;
+}
 #else  // BUILDFLAG(IS_ANDROID)
 namespace {
 constexpr char kLibChrobaltPattern[] = "libchrobalt.so";
@@ -547,6 +603,18 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
       base::saturated_cast<uint32_t>(info->resident_set_bytes / 1024);
   dump->peak_resident_set_kb = GetPeakResidentSetSize(handle);
   dump->is_peak_rss_resettable = ResetPeakRSSIfPossible(handle);
+
+#if BUILDFLAG(IS_COBALT)
+  // TODO(cleanup): Remove this legacy code when appropriate.
+#if BUILDFLAG(IS_ANDROID)
+  PopulateCobaltSmapsMetrics(handle, dump);
+#else  // BUILDFLAG(IS_LINUX)
+  LibChrobaltMem lib_mem = GetLibChrobaltMem(handle);
+  dump->libchrobalt_pss_kb = lib_mem.pss_kb;
+  dump->libchrobalt_rss_kb = lib_mem.rss_kb;
+  dump->partition_alloc_rss_kb = GetPartitionAllocRss(handle);
+#endif  // BUILDFLAG(IS_LINUX)
+#endif  // BUILDFLAG(IS_COBALT)
 
   if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_COUNT_MAPPINGS)) {
     dump->mappings_count = CountMappings(handle);

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -591,7 +591,8 @@ void OSMetrics::SetProcSmapsForTesting(FILE* f) {
 
 bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
                                  const MemDumpFlagSet& flags,
-                                 mojom::RawOSMemDump* dump) {
+                                 mojom::RawOSMemDump* dump,
+                                 base::WeakPtr<DetailedMetricsDelegate> delegate) {
   auto info = GetMemoryInfo(handle);
   if (!info.has_value()) {
     return false;
@@ -605,15 +606,9 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
   dump->is_peak_rss_resettable = ResetPeakRSSIfPossible(handle);
 
 #if BUILDFLAG(IS_COBALT)
-#if BUILDFLAG(IS_ANDROID)
-  PopulateCobaltSmapsMetrics(handle, dump);
-#else  // BUILDFLAG(IS_LINUX)
-  LibChrobaltMem lib_mem = GetLibChrobaltMem(handle);
-  dump->libchrobalt_pss_kb = lib_mem.pss_kb;
-  dump->libchrobalt_rss_kb = lib_mem.rss_kb;
-  dump->partition_alloc_rss_kb = GetPartitionAllocRss(handle);
-#endif  // BUILDFLAG(IS_LINUX)
-#endif  // BUILDFLAG(IS_COBALT)
+  if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS))
+    FillDetailedMetrics(handle, flags, dump, std::move(delegate));
+#endif
 
   if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_COUNT_MAPPINGS)) {
     dump->mappings_count = CountMappings(handle);

--- a/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
+++ b/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
@@ -223,7 +223,7 @@ struct RawOSMemDump {
   // Cobalt-specific memory metrics end
 
   // Generic map for detailed memory metrics.
-  map<string, uint32>? detailed_stats_kb;
+  map<string, uint64>? detailed_stats_kb;
 
   // Timestamp of the last successful detailed memory dump.
   mojo_base.mojom.TimeTicks last_detailed_dump_time;
@@ -315,7 +315,7 @@ struct OSMemDump {
   // Cobalt-specific memory metrics end
 
   // Generic map for detailed memory metrics.
-  map<string, uint32>? detailed_stats_kb;
+  map<string, uint64>? detailed_stats_kb;
 
   // Timestamp of the last successful detailed memory dump.
   mojo_base.mojom.TimeTicks last_detailed_dump_time;

--- a/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
+++ b/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
@@ -223,7 +223,7 @@ struct RawOSMemDump {
   // Cobalt-specific memory metrics end
 
   // Generic map for detailed memory metrics.
-  map<string, uint64>? detailed_stats_kb;
+  map<string, uint32>? detailed_stats_kb;
 
   // Timestamp of the last successful detailed memory dump.
   mojo_base.mojom.TimeTicks last_detailed_dump_time;
@@ -315,7 +315,7 @@ struct OSMemDump {
   // Cobalt-specific memory metrics end
 
   // Generic map for detailed memory metrics.
-  map<string, uint64>? detailed_stats_kb;
+  map<string, uint32>? detailed_stats_kb;
 
   // Timestamp of the last successful detailed memory dump.
   mojo_base.mojom.TimeTicks last_detailed_dump_time;


### PR DESCRIPTION
This commit introduces the `DetailedMetricsDelegate` interface and necessary
stubs in `OSMetrics` to support custom memory categorization in Cobalt.
It also includes a Starboard wrapper for `prctl` to support VMA naming.
This is based on the design specified in http://shortn/_Pw4G7chyR2.

- Add `DetailedMetricsDelegate` interface.
- Add stubs in `OSMetrics` for delegate interaction.
- Add Starboard wrapper for `prctl` (VMA naming).


Bug: 494004530