### PR TITLE
cobalt/metrics: Add browser tests for granular memory tracking

### DIFF
--- a/base/debug/proc_maps_linux.cc
+++ b/base/debug/proc_maps_linux.cc
@@ -12,19 +12,22 @@
 #include <fcntl.h>
 #include <stddef.h>
 
-#include <unordered_map>
-
+#include "base/containers/flat_map.h"
 #include "base/files/file_util.h"
 #include "base/files/scoped_file.h"
 #include "base/format_macros.h"
 #include "base/logging.h"
 #include "base/memory/page_size.h"
+#include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
 #include <inttypes.h>
 #endif
+
+#include "base/posix/eintr_wrapper.h"
 
 namespace base::debug {
 
@@ -106,10 +109,9 @@ bool ParseProcMaps(const std::string& input,
   CHECK(regions_out);
   std::vector<MappedMemoryRegion> regions;
 
-  // This isn't async safe nor terribly efficient, but it doesn't need to be at
-  // this point in time.
-  std::vector<std::string> lines =
-      SplitString(input, "\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
+  // Use SplitStringPiece to avoid heap allocations for every line.
+  std::vector<std::string_view> lines = base::SplitStringPiece(
+      input, "\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
 
   for (size_t i = 0; i < lines.size(); ++i) {
     // Due to splitting on '\n' the last line should be empty.
@@ -121,35 +123,36 @@ bool ParseProcMaps(const std::string& input,
       break;
     }
 
-    MappedMemoryRegion region;
-    const char* line = lines[i].c_str();
-    char permissions[5] = {};  // Ensure NUL-terminated string.
-    uint8_t dev_major = 0;
-    uint8_t dev_minor = 0;
-    long inode = 0;
-    int path_index = 0;
-
-    // Sample format from man 5 proc:
-    //
-    // address           perms offset  dev   inode   pathname
-    // 08048000-08056000 r-xp 00000000 03:0c 64593   /usr/sbin/gpm
-    //
-    // The final %n term captures the offset in the input string, which is used
-    // to determine the path name. It *does not* increment the return value.
-    // Refer to man 3 sscanf for details.
-    if (sscanf(line, "%" SCNxPTR "-%" SCNxPTR " %4c %llx %hhx:%hhx %ld %n",
-               &region.start, &region.end, permissions, &region.offset,
-               &dev_major, &dev_minor, &inode, &path_index) < 7) {
-      DPLOG(WARNING) << "sscanf failed for line: " << line;
+    std::vector<std::string_view> tokens = base::SplitStringPiece(
+        lines[i], " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+    if (tokens.size() < 5) {
+      DLOG(WARNING) << "Too few tokens for line: " << lines[i];
       return false;
     }
 
-    region.inode = inode;
-    region.dev_major = dev_major;
-    region.dev_minor = dev_minor;
+    MappedMemoryRegion region;
+
+    // Parse address range: "08048000-08056000"
+    std::vector<std::string_view> addresses = base::SplitStringPiece(
+        tokens[0], "-", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+    if (addresses.size() != 2) {
+      return false;
+    }
+    uint64_t start, end;
+    if (!base::HexStringToUInt64(addresses[0], &start) ||
+        !base::HexStringToUInt64(addresses[1], &end)) {
+      return false;
+    }
+    region.start = static_cast<uintptr_t>(start);
+    region.end = static_cast<uintptr_t>(end);
+
+    // Parse permissions: "r-xp"
+    std::string_view permissions = tokens[1];
+    if (permissions.size() < 4) {
+      return false;
+    }
 
     region.permissions = 0;
-
     if (permissions[0] == 'r') {
       region.permissions |= MappedMemoryRegion::READ;
     } else if (permissions[0] != '-') {
@@ -170,14 +173,56 @@ bool ParseProcMaps(const std::string& input,
 
     if (permissions[3] == 'p') {
       region.permissions |= MappedMemoryRegion::PRIVATE;
-    } else if (permissions[3] != 's' &&
-               permissions[3] != 'S') {  // Shared memory.
+    } else if (permissions[3] != 's' && permissions[3] != 'S') {
       return false;
     }
 
-    // Pushing then assigning saves us a string copy.
-    regions.push_back(region);
-    regions.back().path.assign(line + path_index);
+    // Parse offset: "00000000"
+    uint64_t offset;
+    if (!base::HexStringToUInt64(tokens[2], &offset)) {
+      return false;
+    }
+    region.offset = offset;
+
+    // Parse dev: "03:0c"
+    std::vector<std::string_view> dev = base::SplitStringPiece(
+        tokens[3], ":", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+    if (dev.size() != 2) {
+      return false;
+    }
+    uint32_t dev_major, dev_minor;
+    if (!base::HexStringToUInt(dev[0], &dev_major) ||
+        !base::HexStringToUInt(dev[1], &dev_minor)) {
+      return false;
+    }
+    region.dev_major = static_cast<uint8_t>(dev_major);
+    region.dev_minor = static_cast<uint8_t>(dev_minor);
+
+    // Parse inode: "64593"
+    int64_t inode;
+    if (!base::StringToInt64(tokens[4], &inode)) {
+      return false;
+    }
+    region.inode = static_cast<long>(inode);
+
+    // Parse path: "/usr/sbin/gpm" (optional)
+    if (tokens.size() >= 6) {
+      // The path starts after the inode. However, it might contain spaces.
+      // We find the inode token in the original line, but we must search
+      // after the device token to avoid matching the same string in earlier
+      // fields (e.g. if the offset is the same as the inode).
+      size_t dev_pos = lines[i].find(tokens[3]);
+      size_t inode_pos = lines[i].find(tokens[4], dev_pos + tokens[3].size());
+      if (inode_pos != std::string_view::npos) {
+        size_t path_pos =
+            lines[i].find_first_not_of(' ', inode_pos + tokens[4].size());
+        if (path_pos != std::string_view::npos) {
+          region.path.assign(lines[i].substr(path_pos));
+        }
+      }
+    }
+
+    regions.push_back(std::move(region));
   }
 
   regions_out->swap(regions);
@@ -185,27 +230,39 @@ bool ParseProcMaps(const std::string& input,
 }
 
 std::optional<SmapsRollup> ParseSmapsRollup(const std::string& buffer) {
-  std::vector<std::string> lines =
-      SplitString(buffer, "\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
+  std::vector<std::string_view> lines = base::SplitStringPiece(
+      buffer, "\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
 
-  std::unordered_map<std::string, size_t> tmp;
+  base::flat_map<std::string_view, size_t> tmp;
   for (const auto& line : lines) {
-    // This should be more than enough space for any output we get (but we also
-    // verify the size below).
-    std::string key;
-    key.resize(100);
+    std::vector<std::string_view> tokens = base::SplitStringPiece(
+        line, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+    if (tokens.size() < 3 || tokens[2] != "kB") {
+      continue;
+    }
+
+    std::string_view key = tokens[0];
+    if (key.ends_with(":")) {
+      key.remove_suffix(1);
+    }
+
+    if (key.empty()) {
+      continue;
+    }
+
     size_t val;
-    if (sscanf(line.c_str(), "%99s %" PRIuS " kB", key.data(), &val) == 2) {
-      // sscanf writes a nul-byte at the end of the result, so |strlen| is safe
-      // here. |resize| does not count the length of the nul-byte, and we want
-      // to trim off the trailing colon at the end, so we use |strlen - 1| here.
-      key.resize(strlen(key.c_str()) - 1);
-      tmp[key] = val * 1024;
+    if (base::StringToSizeT(tokens[1], &val)) {
+      base::CheckedNumeric<size_t> val_bytes = val;
+      val_bytes *= 1024;
+      tmp[key] = val_bytes.ValueOrDefault(0);
     }
   }
 
-  SmapsRollup smaps_rollup;
+  if (tmp.empty()) {
+    return std::nullopt;
+  }
 
+  SmapsRollup smaps_rollup;
   smaps_rollup.rss = tmp["Rss"];
   smaps_rollup.pss = tmp["Pss"];
   smaps_rollup.pss_anon = tmp["Pss_Anon"];
@@ -219,30 +276,10 @@ std::optional<SmapsRollup> ParseSmapsRollup(const std::string& buffer) {
 }
 
 std::optional<SmapsRollup> ReadAndParseSmapsRollup() {
-  const size_t read_size = base::GetPageSize();
-
-  base::ScopedFD fd(HANDLE_EINTR(open("/proc/self/smaps_rollup", O_RDONLY)));
-  if (!fd.is_valid()) {
-    DPLOG(ERROR) << "Couldn't open /proc/self/smaps_rollup";
-    return std::nullopt;
-  }
-
   std::string buffer;
-  buffer.resize(read_size);
-
-  ssize_t bytes_read = HANDLE_EINTR(
-      read(fd.get(), static_cast<void*>(buffer.data()), read_size));
-  if (bytes_read < 0) {
-    DPLOG(ERROR) << "Couldn't read /proc/self/smaps_rollup";
+  if (!ReadFileToString(FilePath("/proc/self/smaps_rollup"), &buffer)) {
     return std::nullopt;
   }
-
-  // We expect to read a few hundred bytes, which should be significantly less
-  // the page size.
-  DCHECK(static_cast<size_t>(bytes_read) < read_size);
-
-  buffer.resize(static_cast<size_t>(bytes_read));
-
   return ParseSmapsRollup(buffer);
 }
 

--- a/base/debug/proc_maps_linux.h
+++ b/base/debug/proc_maps_linux.h
@@ -12,6 +12,8 @@
 #include <vector>
 
 #include "base/base_export.h"
+#include "build/buildflag.h"
+#include "build/build_config.h"
 
 namespace base::debug {
 
@@ -114,6 +116,12 @@ struct SmapsRollup {
 
 // Attempts to read /proc/self/smaps_rollup. Returns nullopt on error.
 BASE_EXPORT std::optional<SmapsRollup> ReadAndParseSmapsRollup();
+
+#if BUILDFLAG(IS_COBALT)
+// |smaps_rollup| should be the result of reading /proc/*/smaps_rollup.
+BASE_EXPORT std::optional<SmapsRollup> ParseSmapsRollup(
+    const std::string& smaps_rollup);
+#endif
 
 // |smaps_rollup| should be the result of reading /proc/*/smaps_rollup.
 BASE_EXPORT std::optional<SmapsRollup> ParseSmapsRollupForTesting(

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -335,6 +335,7 @@ test("cobalt_unittests") {
     "//mojo/core/embedder",
     "//net/traffic_annotation:test_support",
     "//services/network/public/cpp",
+    "//services/resource_coordinator:tests",
     "//testing/gmock",
     "//testing/gtest",
     "//third_party/metrics_proto",

--- a/cobalt/testing/browser_tests/BUILD.gn
+++ b/cobalt/testing/browser_tests/BUILD.gn
@@ -229,6 +229,7 @@ test("cobalt_browsertests") {
     #"media_session_browsertest.cc",
     #"media_source_browsertest.cc",
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_browsertest.cc",
+    "//content/browser/memory/granular_memory_browsertest.cc",
     "navigation_browsertest.cc",
 
     #"session_history_browsertest.cc",
@@ -344,6 +345,7 @@ test("cobalt_browsertests") {
     "//services/network:test_support",
     "//services/network/public/mojom",
     "//services/network/trust_tokens:test_support",
+    "//services/resource_coordinator/public/cpp/memory_instrumentation",
     "//services/service_manager/public/cpp",
     "//services/tracing:privacy_check",
     "//services/video_capture/public/cpp",

--- a/content/browser/memory/granular_memory_browsertest.cc
+++ b/content/browser/memory/granular_memory_browsertest.cc
@@ -13,10 +13,12 @@
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
 #include "base/files/file_util.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "base/threading/thread_restrictions.h"
 #include "url/gurl.h"
 
 namespace content {
@@ -46,6 +48,7 @@ const char kTestSmapsRollup[] =
     "SwapPss:               0 kB\n";
 
 void CreateTempFileWithContents(const char* contents, base::ScopedFILE* file) {
+  base::ScopedAllowBlockingForTesting allow_blocking;
   base::FilePath temp_path;
   *file = base::CreateAndOpenTemporaryStream(&temp_path);
   ASSERT_TRUE(*file);
@@ -112,6 +115,7 @@ class GranularMemoryBrowsertest : public ContentBrowserTest {
   }
 
  private:
+
   TestDetailedMetricsDelegate delegate_;
   base::ScopedFILE temp_smaps_;
   base::ScopedFILE temp_rollup_;
@@ -124,6 +128,7 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
 
   RenderProcessHost* rph =
       shell()->web_contents()->GetPrimaryMainFrame()->GetProcess();
+
 
   base::RunLoop run_loop;
   base::ProcessId renderer_pid = rph->GetProcess().Pid();
@@ -160,6 +165,82 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
                 std::move(quit_closure).Run();
               },
               run_loop.QuitClosure(), renderer_pid));
+  run_loop.Run();
+}
+#endif  // BUILDFLAG(IS_LINUX)
+
+#if BUILDFLAG(IS_LINUX)
+IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, CobaltSpecificMetrics) {
+  // Ensure at least one renderer process is active.
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
+
+  RenderProcessHost* rph =
+      shell()->web_contents()->GetPrimaryMainFrame()->GetProcess();
+
+  base::RunLoop run_loop;
+  base::ProcessId renderer_pid = rph->GetProcess().Pid();
+  ASSERT_NE(renderer_pid, base::kNullProcessId);
+
+  // Instantiate the production Cobalt delegate.
+  cobalt::CobaltDetailedMetricsDelegate cobalt_delegate;
+  memory_instrumentation::MemoryInstrumentation::GetInstance()
+      ->SetDetailedMetricsDelegate(&cobalt_delegate);
+
+  // Create mock smaps data that triggers Cobalt categorization.
+  const char kCobaltSmaps[] =
+      "00400000-004be000 r-xp 00000000 fc:01 1234              /path/to/libchrobalt.so\n"
+      "Pss:                 100 kB\n"
+      "Private_Dirty:         0 kB\n"
+      "Private_Clean:         0 kB\n"
+      "Shared_Dirty:          0 kB\n"
+      "Shared_Clean:          0 kB\n"
+      "Swap:                  0 kB\n"
+      "Locked:                0 kB\n"
+      "00500000-005be000 r-xp 00000000 fc:01 1235              /path/to/libcobalt.so\n"
+      "Pss:                  50 kB\n"
+      "Private_Dirty:         0 kB\n"
+      "Private_Clean:         0 kB\n"
+      "Shared_Dirty:          0 kB\n"
+      "Shared_Clean:          0 kB\n"
+      "Swap:                  0 kB\n"
+      "Locked:                0 kB\n";
+
+  base::ScopedFILE temp_smaps;
+  CreateTempFileWithContents(kCobaltSmaps, &temp_smaps);
+  memory_instrumentation::OSMetrics::SetProcSmapsForTesting(temp_smaps.get());
+
+  memory_instrumentation::MemoryInstrumentation::GetInstance()
+      ->GetCoordinator()
+      ->RequestGlobalMemoryDump(
+          base::trace_event::MemoryDumpType::kExplicitlyTriggered,
+          base::trace_event::MemoryDumpLevelOfDetail::kDetailed,
+          base::trace_event::MemoryDumpDeterminism::kNone,
+          {},
+          base::BindOnce(
+              [](base::OnceClosure quit_closure,
+                 base::ProcessId renderer_pid,
+                 base::ScopedFILE file,
+                 bool success,
+                 memory_instrumentation::mojom::GlobalMemoryDumpPtr dump) {
+                EXPECT_TRUE(success);
+                ASSERT_TRUE(dump);
+                bool found_renderer_detailed_stats = false;
+                for (const auto& process_dump : dump->process_dumps) {
+                  if (process_dump->pid == renderer_pid) {
+                    ASSERT_TRUE(process_dump->os_dump->detailed_stats_kb);
+                    if (!process_dump->os_dump->detailed_stats_kb->empty()) {
+                      found_renderer_detailed_stats = true;
+                      // Verify Cobalt categories are present.
+                      EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at("pss:lib_chrobalt"), 100u);
+                      EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at("pss:cobalt_core"), 50u);
+                    }
+                    break;
+                  }
+                }
+                EXPECT_TRUE(found_renderer_detailed_stats);
+                std::move(quit_closure).Run();
+              },
+              run_loop.QuitClosure(), renderer_pid, std::move(temp_smaps)));
   run_loop.Run();
 }
 #endif  // BUILDFLAG(IS_LINUX)

--- a/content/browser/memory/granular_memory_browsertest.cc
+++ b/content/browser/memory/granular_memory_browsertest.cc
@@ -1,0 +1,167 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/run_loop.h"
+#include "base/test/scoped_feature_list.h"
+#include "build/build_config.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "cobalt/testing/browser_tests/content_browser_test.h"
+#include "cobalt/shell/browser/shell.h"
+#include "cobalt/testing/browser_tests/browser/test_shell.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "base/files/file_util.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h"
+#include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace content {
+
+namespace {
+
+const char kTestSmaps[] =
+    "00400000-004be000 r-xp 00000000 fc:01 1234              /file/1\n"
+    "Size:                760 kB\n"
+    "Rss:                 296 kB\n"
+    "Pss:                 162 kB\n"
+    "Shared_Clean:        228 kB\n"
+    "Shared_Dirty:          0 kB\n"
+    "Private_Clean:         0 kB\n"
+    "Private_Dirty:        68 kB\n"
+    "Referenced:          296 kB\n"
+    "Anonymous:            68 kB\n"
+    "AnonHugePages:         0 kB\n"
+    "Swap:                  4 kB\n"
+    "KernelPageSize:        4 kB\n"
+    "MMUPageSize:           4 kB\n"
+    "Locked:                0 kB\n"
+    "VmFlags: rd ex mr mw me dw sd\n";
+
+const char kTestSmapsRollup[] =
+    "Pss:                 162 kB\n"
+    "SwapPss:               0 kB\n";
+
+void CreateTempFileWithContents(const char* contents, base::ScopedFILE* file) {
+  base::FilePath temp_path;
+  *file = base::CreateAndOpenTemporaryStream(&temp_path);
+  ASSERT_TRUE(*file);
+  ASSERT_TRUE(base::WriteFileDescriptor(fileno(file->get()), contents));
+}
+
+class TestDetailedMetricsDelegate
+    : public memory_instrumentation::DetailedMetricsDelegate {
+ public:
+  TestDetailedMetricsDelegate() = default;
+  ~TestDetailedMetricsDelegate() override = default;
+
+  bool OnSmapsBuffer(std::string_view buffer) override {
+    // Just categorize everything as "Test" to satisfy the test requirement
+    // that detailed_stats_kb is not empty.
+    for (const auto& line : base::SplitStringPiece(
+             buffer, "\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
+      if (line.starts_with("Pss:")) {
+        uint64_t pss_kb = 0;
+        if (base::StringToUint64(
+                base::SplitStringPiece(line, " ", base::TRIM_WHITESPACE,
+                                       base::SPLIT_WANT_NONEMPTY)[1],
+                &pss_kb)) {
+          metrics_.categories_kb["Test"] += pss_kb;
+          metrics_.total_pss_kb += pss_kb;
+        }
+      }
+    }
+    return true;
+  }
+
+  memory_instrumentation::DetailedMetrics GetAndResetStats() override {
+    memory_instrumentation::DetailedMetrics result = std::move(metrics_);
+    metrics_ = memory_instrumentation::DetailedMetrics();
+    return result;
+  }
+
+ private:
+  memory_instrumentation::DetailedMetrics metrics_;
+};
+
+}  // namespace
+
+class GranularMemoryBrowsertest : public ContentBrowserTest {
+ public:
+  void SetUpOnMainThread() override {
+    ContentBrowserTest::SetUpOnMainThread();
+    memory_instrumentation::MemoryInstrumentation::GetInstance()
+        ->SetDetailedMetricsDelegate(&delegate_);
+
+    CreateTempFileWithContents(kTestSmaps, &temp_smaps_);
+    CreateTempFileWithContents(kTestSmapsRollup, &temp_rollup_);
+    memory_instrumentation::OSMetrics::SetProcSmapsForTesting(temp_smaps_.get());
+    memory_instrumentation::OSMetrics::SetSmapsRollupForTesting(
+        temp_rollup_.get());
+  }
+
+  void TearDownOnMainThread() override {
+    memory_instrumentation::OSMetrics::SetProcSmapsForTesting(nullptr);
+    memory_instrumentation::OSMetrics::SetSmapsRollupForTesting(nullptr);
+    memory_instrumentation::MemoryInstrumentation::GetInstance()
+        ->SetDetailedMetricsDelegate(nullptr);
+    ContentBrowserTest::TearDownOnMainThread();
+  }
+
+ private:
+  TestDetailedMetricsDelegate delegate_;
+  base::ScopedFILE temp_smaps_;
+  base::ScopedFILE temp_rollup_;
+};
+
+#if BUILDFLAG(IS_LINUX)
+IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
+  // Ensure at least one renderer process is active.
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
+
+  RenderProcessHost* rph =
+      shell()->web_contents()->GetPrimaryMainFrame()->GetProcess();
+
+  base::RunLoop run_loop;
+  base::ProcessId renderer_pid = rph->GetProcess().Pid();
+  ASSERT_NE(renderer_pid, base::kNullProcessId);
+
+  memory_instrumentation::MemoryInstrumentation::GetInstance()
+      ->GetCoordinator()
+      ->RequestGlobalMemoryDump(
+          base::trace_event::MemoryDumpType::kExplicitlyTriggered,
+          base::trace_event::MemoryDumpLevelOfDetail::kDetailed,
+          base::trace_event::MemoryDumpDeterminism::kNone,
+          {},
+          base::BindOnce(
+              [](base::OnceClosure quit_closure,
+                 base::ProcessId renderer_pid,
+                 bool success,
+                 memory_instrumentation::mojom::GlobalMemoryDumpPtr dump) {
+                EXPECT_TRUE(success);
+                ASSERT_TRUE(dump);
+                bool found_renderer_detailed_stats = false;
+                for (const auto& process_dump : dump->process_dumps) {
+                  if (process_dump->pid == renderer_pid) {
+                    ASSERT_TRUE(process_dump->os_dump->detailed_stats_kb);
+                    if (!process_dump->os_dump->detailed_stats_kb->empty()) {
+                      found_renderer_detailed_stats = true;
+                      // Verify the content matches our TestDetailedMetricsDelegate
+                      // which should have accumulated 162 KB from kTestSmaps.
+                      EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at("Test"), 162u);
+                    }
+                    break;
+                  }
+                }
+                EXPECT_TRUE(found_renderer_detailed_stats);
+                std::move(quit_closure).Run();
+              },
+              run_loop.QuitClosure(), renderer_pid));
+  run_loop.Run();
+}
+#endif  // BUILDFLAG(IS_LINUX)
+
+}  // namespace content

--- a/content/browser/memory/granular_memory_browsertest.cc
+++ b/content/browser/memory/granular_memory_browsertest.cc
@@ -13,12 +13,10 @@
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
-#include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
 #include "base/files/file_util.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
 #include "testing/gtest/include/gtest/gtest.h"
-#include "base/threading/thread_restrictions.h"
 #include "url/gurl.h"
 
 namespace content {
@@ -48,7 +46,6 @@ const char kTestSmapsRollup[] =
     "SwapPss:               0 kB\n";
 
 void CreateTempFileWithContents(const char* contents, base::ScopedFILE* file) {
-  base::ScopedAllowBlockingForTesting allow_blocking;
   base::FilePath temp_path;
   *file = base::CreateAndOpenTemporaryStream(&temp_path);
   ASSERT_TRUE(*file);
@@ -115,7 +112,6 @@ class GranularMemoryBrowsertest : public ContentBrowserTest {
   }
 
  private:
-
   TestDetailedMetricsDelegate delegate_;
   base::ScopedFILE temp_smaps_;
   base::ScopedFILE temp_rollup_;
@@ -128,7 +124,6 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
 
   RenderProcessHost* rph =
       shell()->web_contents()->GetPrimaryMainFrame()->GetProcess();
-
 
   base::RunLoop run_loop;
   base::ProcessId renderer_pid = rph->GetProcess().Pid();
@@ -165,82 +160,6 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
                 std::move(quit_closure).Run();
               },
               run_loop.QuitClosure(), renderer_pid));
-  run_loop.Run();
-}
-#endif  // BUILDFLAG(IS_LINUX)
-
-#if BUILDFLAG(IS_LINUX)
-IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, CobaltSpecificMetrics) {
-  // Ensure at least one renderer process is active.
-  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
-
-  RenderProcessHost* rph =
-      shell()->web_contents()->GetPrimaryMainFrame()->GetProcess();
-
-  base::RunLoop run_loop;
-  base::ProcessId renderer_pid = rph->GetProcess().Pid();
-  ASSERT_NE(renderer_pid, base::kNullProcessId);
-
-  // Instantiate the production Cobalt delegate.
-  cobalt::CobaltDetailedMetricsDelegate cobalt_delegate;
-  memory_instrumentation::MemoryInstrumentation::GetInstance()
-      ->SetDetailedMetricsDelegate(&cobalt_delegate);
-
-  // Create mock smaps data that triggers Cobalt categorization.
-  const char kCobaltSmaps[] =
-      "00400000-004be000 r-xp 00000000 fc:01 1234              /path/to/libchrobalt.so\n"
-      "Pss:                 100 kB\n"
-      "Private_Dirty:         0 kB\n"
-      "Private_Clean:         0 kB\n"
-      "Shared_Dirty:          0 kB\n"
-      "Shared_Clean:          0 kB\n"
-      "Swap:                  0 kB\n"
-      "Locked:                0 kB\n"
-      "00500000-005be000 r-xp 00000000 fc:01 1235              /path/to/libcobalt.so\n"
-      "Pss:                  50 kB\n"
-      "Private_Dirty:         0 kB\n"
-      "Private_Clean:         0 kB\n"
-      "Shared_Dirty:          0 kB\n"
-      "Shared_Clean:          0 kB\n"
-      "Swap:                  0 kB\n"
-      "Locked:                0 kB\n";
-
-  base::ScopedFILE temp_smaps;
-  CreateTempFileWithContents(kCobaltSmaps, &temp_smaps);
-  memory_instrumentation::OSMetrics::SetProcSmapsForTesting(temp_smaps.get());
-
-  memory_instrumentation::MemoryInstrumentation::GetInstance()
-      ->GetCoordinator()
-      ->RequestGlobalMemoryDump(
-          base::trace_event::MemoryDumpType::kExplicitlyTriggered,
-          base::trace_event::MemoryDumpLevelOfDetail::kDetailed,
-          base::trace_event::MemoryDumpDeterminism::kNone,
-          {},
-          base::BindOnce(
-              [](base::OnceClosure quit_closure,
-                 base::ProcessId renderer_pid,
-                 base::ScopedFILE file,
-                 bool success,
-                 memory_instrumentation::mojom::GlobalMemoryDumpPtr dump) {
-                EXPECT_TRUE(success);
-                ASSERT_TRUE(dump);
-                bool found_renderer_detailed_stats = false;
-                for (const auto& process_dump : dump->process_dumps) {
-                  if (process_dump->pid == renderer_pid) {
-                    ASSERT_TRUE(process_dump->os_dump->detailed_stats_kb);
-                    if (!process_dump->os_dump->detailed_stats_kb->empty()) {
-                      found_renderer_detailed_stats = true;
-                      // Verify Cobalt categories are present.
-                      EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at("pss:lib_chrobalt"), 100u);
-                      EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at("pss:cobalt_core"), 50u);
-                    }
-                    break;
-                  }
-                }
-                EXPECT_TRUE(found_renderer_detailed_stats);
-                std::move(quit_closure).Run();
-              },
-              run_loop.QuitClosure(), renderer_pid, std::move(temp_smaps)));
   run_loop.Run();
 }
 #endif  // BUILDFLAG(IS_LINUX)

--- a/services/resource_coordinator/BUILD.gn
+++ b/services/resource_coordinator/BUILD.gn
@@ -55,6 +55,12 @@ source_set("tests") {
     "public/cpp/memory_instrumentation/tracing_observer_proto_unittest.cc",
   ]
 
+  if (is_cobalt) {
+    sources += [
+      "public/cpp/memory_instrumentation/detailed_metrics_delegate_unittest.cc",
+    ]
+  }
+
   deps = [
     ":lib",
     "//base",

--- a/services/resource_coordinator/BUILD.gn
+++ b/services/resource_coordinator/BUILD.gn
@@ -38,6 +38,20 @@ source_set("lib") {
     "//services/resource_coordinator/public/cpp:resource_coordinator_cpp",
     "//third_party/perfetto:libperfetto",
   ]
+
+  if (is_cobalt) {
+    public_deps += [ "//services/resource_coordinator/public/mojom" ]
+    deps = [
+      "//services/resource_coordinator/public/cpp/memory_instrumentation",
+      "//services/tracing/public/cpp",
+    ]
+    public_deps -= [
+      "//services/metrics/public/cpp:metrics_cpp",
+      "//services/metrics/public/cpp:ukm_builders",
+      "//services/metrics/public/mojom",
+      "//third_party/perfetto:libperfetto",
+    ]
+  }
 }
 
 source_set("tests") {

--- a/services/resource_coordinator/memory_instrumentation/queued_request.cc
+++ b/services/resource_coordinator/memory_instrumentation/queued_request.cc
@@ -5,6 +5,7 @@
 #include "services/resource_coordinator/memory_instrumentation/queued_request.h"
 
 #include "base/containers/to_vector.h"
+#include "build/build_config.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h"
 
 namespace memory_instrumentation {
@@ -55,10 +56,21 @@ base::trace_event::MemoryDumpRequestArgs QueuedRequest::GetRequestArgs() {
 }
 
 std::vector<mojom::MemDumpFlags> QueuedRequest::memory_dump_flags() const {
+#if BUILDFLAG(IS_COBALT)
+  if (args.memory_footprint_only) {
+    return {};
+  }
+  OSMetrics::MemDumpFlagSet flags = OSMetrics::MemDumpFlagSet::All();
+  if (args.level_of_detail == MemoryDumpLevelOfDetail::kLight) {
+    flags.Remove(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS);
+  }
+  return base::ToVector(flags);
+#else
   if (!args.memory_footprint_only) {
     return base::ToVector(OSMetrics::MemDumpFlagSet::All());
   }
   return {};
+#endif
 }
 
 QueuedVmRegionRequest::Response::Response() = default;

--- a/services/resource_coordinator/memory_instrumentation/queued_request_dispatcher.cc
+++ b/services/resource_coordinator/memory_instrumentation/queued_request_dispatcher.cc
@@ -74,7 +74,7 @@ uint32_t CalculatePrivateFootprintKb(const mojom::RawOSMemDump& os_dump,
 }
 
 memory_instrumentation::mojom::OSMemDumpPtr CreatePublicOSDump(
-    const mojom::RawOSMemDump& internal_os_dump,
+    mojom::RawOSMemDump& internal_os_dump,
     uint32_t shared_resident_kb) {
   mojom::OSMemDumpPtr os_dump = mojom::OSMemDump::New();
 
@@ -94,6 +94,9 @@ memory_instrumentation::mojom::OSMemDumpPtr CreatePublicOSDump(
   os_dump->mappings_count = internal_os_dump.mappings_count;
   os_dump->pss_kb = internal_os_dump.pss_kb;
   os_dump->swap_pss_kb = internal_os_dump.swap_pss_kb;
+#endif
+#if BUILDFLAG(IS_COBALT)
+  os_dump->detailed_stats_kb = std::move(internal_os_dump.detailed_stats_kb);
 #endif
   return os_dump;
 }

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/BUILD.gn
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/BUILD.gn
@@ -19,6 +19,13 @@ component("memory_instrumentation") {
     "tracing_observer_proto.h",
   ]
 
+  if (is_cobalt) {
+    sources += [
+      "detailed_metrics_delegate.cc",
+      "detailed_metrics_delegate.h",
+    ]
+  }
+
   if (is_apple) {
     sources += [ "os_metrics_mac.cc" ]
   }

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
@@ -17,6 +17,13 @@
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/tracing_observer_proto.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
 
+#if BUILDFLAG(IS_COBALT)
+#include "base/task/bind_post_task.h"
+#include "base/task/thread_pool.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.h"
+#endif
+
 namespace memory_instrumentation {
 
 struct ClientProcessImpl::OSMemoryDumpArgs {
@@ -60,8 +67,18 @@ ClientProcessImpl::ClientProcessImpl(
     // Initialize the public-facing MemoryInstrumentation helper.
     MemoryInstrumentation::CreateInstance(std::move(coordinator),
                                           is_browser_process);
+#if BUILDFLAG(IS_COBALT)
+    // Register the memory_instrumentation datasource.
+    TracingObserverProto::GetInstance();
+#endif
   } else {
+#if BUILDFLAG(IS_COBALT)
+    if (coordinator.is_valid()) {
+      coordinator_.Bind(std::move(coordinator));
+    }
+#else
     coordinator_.Bind(std::move(coordinator));
+#endif
   }
 
   task_runner_ = base::SingleThreadTaskRunner::GetCurrentDefault();
@@ -70,6 +87,18 @@ ClientProcessImpl::ClientProcessImpl(
   // base::MemoryDumpManager that it is special and should coordinate periodic
   // dumps for tracing. Remove this once the periodic dump scheduler is moved
   // from base to the service. MDM should not care about being the coordinator.
+#if BUILDFLAG(IS_COBALT)
+  auto* mdm = base::trace_event::MemoryDumpManager::GetInstance();
+  if (!mdm->IsInitialized()) {
+    mdm->Initialize(
+        base::BindPostTask(
+            task_runner_,
+            base::BindRepeating(
+                &ClientProcessImpl::RequestGlobalMemoryDump_NoCallback,
+                weak_ptr_factory_.GetWeakPtr())),
+        is_browser_process);
+  }
+#else
   base::trace_event::MemoryDumpManager::GetInstance()->Initialize(
       base::BindRepeating(
           &ClientProcessImpl::RequestGlobalMemoryDump_NoCallback,
@@ -78,6 +107,7 @@ ClientProcessImpl::ClientProcessImpl(
 
   // Register the memory_instrumentation datasource.
   TracingObserverProto::GetInstance();
+#endif
 }
 
 ClientProcessImpl::~ClientProcessImpl() = default;
@@ -92,7 +122,11 @@ void ClientProcessImpl::RequestChromeMemoryDump(
   DCHECK(it_and_inserted.second) << "Duplicated request id " << args.dump_guid;
   base::trace_event::MemoryDumpManager::GetInstance()->CreateProcessDump(
       args, base::BindOnce(&ClientProcessImpl::OnChromeMemoryDumpDone,
+#if BUILDFLAG(IS_COBALT)
+                           weak_ptr_factory_.GetWeakPtr()));
+#else
                            base::Unretained(this)));
+#endif
 }
 
 void ClientProcessImpl::OnChromeMemoryDumpDone(
@@ -128,6 +162,16 @@ void ClientProcessImpl::RequestGlobalMemoryDump_NoCallback(
     base::trace_event::MemoryDumpLevelOfDetail level_of_detail) {
   CHECK(is_browser_process_);
 
+#if BUILDFLAG(IS_COBALT)
+  if (!task_runner_->RunsTasksInCurrentSequence()) {
+    task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&ClientProcessImpl::RequestGlobalMemoryDump_NoCallback,
+                       weak_ptr_factory_.GetWeakPtr(), dump_type,
+                       level_of_detail));
+    return;
+  }
+#else
   if (!task_runner_->RunsTasksInCurrentSequence()) {
     task_runner_->PostTask(
         FROM_HERE,
@@ -135,6 +179,7 @@ void ClientProcessImpl::RequestGlobalMemoryDump_NoCallback(
                        base::Unretained(this), dump_type, level_of_detail));
     return;
   }
+#endif
 
   // NOTE: If this ClientProcessImpl was responsible for initializing the
   // global MemoryInstrumentation object, its Coordinator pipe was passed along
@@ -178,6 +223,62 @@ void ClientProcessImpl::RequestOSMemoryDump(
   PerformOSMemoryDump(std::move(args));
 }
 
+#if BUILDFLAG(IS_COBALT)
+namespace {
+
+base::flat_map<base::ProcessId, mojom::RawOSMemDumpPtr>
+PerformOSMemoryDumpOnBackgroundThread(mojom::MemoryMapOption mmap_option,
+                                      OSMetrics::MemDumpFlagSet flags,
+                                      std::vector<base::ProcessId> pids,
+                                      base::WeakPtr<MemoryInstrumentation> instrumentation) {
+  DetailedMetricsDelegate* delegate = nullptr;
+  if (instrumentation) {
+    delegate = instrumentation->GetDetailedMetricsDelegate();
+  }
+
+  base::flat_map<base::ProcessId, mojom::RawOSMemDumpPtr> results;
+  for (const base::ProcessId& pid : pids) {
+    auto handle = base::Process::Open(pid).Handle();
+    mojom::RawOSMemDumpPtr result = mojom::RawOSMemDump::New();
+    result->platform_private_footprint = mojom::PlatformPrivateFootprint::New();
+
+    if (!OSMetrics::FillOSMemoryDump(handle, flags, result.get(), delegate)) {
+      DLOG(ERROR) << "OS memory dump failed for pid " << pid
+                  << " (FillOSMemoryDump)";
+    } else if (mmap_option != mojom::MemoryMapOption::NONE &&
+               !OSMetrics::FillProcessMemoryMaps(handle, mmap_option,
+                                                 result.get())) {
+      DLOG(ERROR) << "OS memory dump failed for pid " << pid
+                  << " (FillProcessMemoryMaps)";
+    } else {
+      results[pid] = std::move(result);
+    }
+  }
+  return results;
+}
+
+}  // namespace
+
+void ClientProcessImpl::PerformOSMemoryDump(OSMemoryDumpArgs args) {
+  auto* instance = MemoryInstrumentation::GetInstance();
+  base::WeakPtr<MemoryInstrumentation> weak_instrumentation;
+  if (instance) {
+    weak_instrumentation = instance->GetWeakPtr();
+  }
+
+  base::ThreadPool::PostTaskAndReplyWithResult(
+      FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
+      base::BindOnce(&PerformOSMemoryDumpOnBackgroundThread, args.mmap_option,
+                     args.flags, std::move(args.pids),
+                     std::move(weak_instrumentation)),
+      base::BindOnce(
+          [](RequestOSMemoryDumpCallback callback,
+             base::flat_map<base::ProcessId, mojom::RawOSMemDumpPtr> results) {
+            std::move(callback).Run(true, std::move(results));
+          },
+          std::move(args.callback)));
+}
+#else
 void ClientProcessImpl::PerformOSMemoryDump(OSMemoryDumpArgs args) {
   bool global_success = true;
   base::flat_map<base::ProcessId, mojom::RawOSMemDumpPtr> results;
@@ -200,6 +301,7 @@ void ClientProcessImpl::PerformOSMemoryDump(OSMemoryDumpArgs args) {
   }
   std::move(args.callback).Run(global_success, std::move(results));
 }
+#endif
 
 ClientProcessImpl::OSMemoryDumpArgs::OSMemoryDumpArgs() = default;
 ClientProcessImpl::OSMemoryDumpArgs::OSMemoryDumpArgs(OSMemoryDumpArgs&&) =

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.h
@@ -17,6 +17,10 @@
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
 
+#if BUILDFLAG(IS_COBALT)
+#include "base/memory/weak_ptr.h"
+#endif
+
 namespace memory_instrumentation {
 
 // This is the bridge between MemoryDumpManager and the Coordinator service.
@@ -93,6 +97,10 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
 
   // Only browser process is allowed to request memory dumps.
   const bool is_browser_process_;
+
+#if BUILDFLAG(IS_COBALT)
+  base::WeakPtrFactory<ClientProcessImpl> weak_ptr_factory_{this};
+#endif
 };
 
 }  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.cc
@@ -1,0 +1,14 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+
+namespace memory_instrumentation {
+
+DetailedMetrics::DetailedMetrics() = default;
+DetailedMetrics::~DetailedMetrics() = default;
+DetailedMetrics::DetailedMetrics(DetailedMetrics&&) = default;
+DetailedMetrics& DetailedMetrics::operator=(DetailedMetrics&&) = default;
+
+}  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h
@@ -1,0 +1,56 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_
+#define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+#include "base/component_export.h"
+#include "base/containers/flat_map.h"
+
+namespace memory_instrumentation {
+
+// Results returned by the delegate after parsing.
+struct COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
+    DetailedMetrics {
+  DetailedMetrics();
+  ~DetailedMetrics();
+  DetailedMetrics(DetailedMetrics&&);
+  DetailedMetrics& operator=(DetailedMetrics&&);
+
+  // Map of category names to accumulated metrics (e.g. RSS or PSS) in KB.
+  // Mandate: Keys must be namespaced and PII-free.
+  base::flat_map<std::string, uint32_t> categories_kb;
+
+  // Reported totals for harness-level validation.
+  uint32_t total_pss_kb = 0;
+  uint32_t total_rss_kb = 0;
+};
+
+// Interface for project-specific detailed memory metrics collection.
+// The harness reads /proc/self/smaps and passes each line to the registered
+// delegate for categorization.
+class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
+    DetailedMetricsDelegate {
+ public:
+  virtual ~DetailedMetricsDelegate() = default;
+
+  // Called with a buffer containing a single line from /proc/self/smaps.
+  // The |buffer| view is only valid for the duration of this call.
+  // Returns true if parsing should continue, false if it should abort.
+  virtual bool OnSmapsBuffer(std::string_view buffer) = 0;
+
+  // Called after all lines have been processed to retrieve the aggregated
+  // metrics and reset internal counters for the next dump.
+  // TODO(cobalt): Implement project-specific library tracking (e.g. libchrobalt)
+  // here to avoid redundant scans of /proc/self/smaps.
+  virtual DetailedMetrics GetAndResetStats() = 0;
+};
+
+}  // namespace memory_instrumentation
+
+#endif  // SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_DETAILED_METRICS_DELEGATE_H_

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate_unittest.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate_unittest.cc
@@ -1,0 +1,52 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace memory_instrumentation {
+
+TEST(DetailedMetricsTest, DefaultValues) {
+  DetailedMetrics metrics;
+  EXPECT_TRUE(metrics.categories_kb.empty());
+  EXPECT_EQ(metrics.total_pss_kb, 0u);
+  EXPECT_EQ(metrics.total_rss_kb, 0u);
+}
+
+TEST(DetailedMetricsTest, MoveConstruct) {
+  DetailedMetrics metrics;
+  metrics.categories_kb["cat1"] = 100;
+  metrics.total_pss_kb = 100;
+  metrics.total_rss_kb = 200;
+
+  DetailedMetrics moved_metrics(std::move(metrics));
+  EXPECT_EQ(moved_metrics.categories_kb["cat1"], 100u);
+  EXPECT_EQ(moved_metrics.total_pss_kb, 100u);
+  EXPECT_EQ(moved_metrics.total_rss_kb, 200u);
+}
+
+class MockDetailedMetricsDelegate : public DetailedMetricsDelegate {
+ public:
+  MOCK_METHOD(bool, OnSmapsBuffer, (std::string_view buffer), (override));
+  MOCK_METHOD(DetailedMetrics, GetAndResetStats, (), (override));
+};
+
+TEST(DetailedMetricsDelegateTest, MockUsage) {
+  MockDetailedMetricsDelegate delegate;
+  EXPECT_CALL(delegate, OnSmapsBuffer("test buffer"))
+      .WillOnce(testing::Return(true));
+  EXPECT_TRUE(delegate.OnSmapsBuffer("test buffer"));
+
+  DetailedMetrics metrics;
+  metrics.categories_kb["test"] = 42;
+  EXPECT_CALL(delegate, GetAndResetStats())
+      .WillOnce(testing::Return(testing::ByMove(std::move(metrics))));
+
+  DetailedMetrics result = delegate.GetAndResetStats();
+  EXPECT_EQ(result.categories_kb["test"], 42u);
+}
+
+}  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.cc
@@ -17,6 +17,7 @@ void WrapGlobalMemoryDump(
     mojom::GlobalMemoryDumpPtr dump) {
   std::move(callback).Run(success, GlobalMemoryDump::MoveFrom(std::move(dump)));
 }
+
 }  // namespace
 
 // static
@@ -79,6 +80,24 @@ void MemoryInstrumentation::RequestGlobalDumpAndAppendToTrace(
   CHECK(is_browser_process_);
   coordinator_->RequestGlobalMemoryDumpAndAppendToTrace(
       dump_type, level_of_detail, determinism, std::move(callback));
+}
+
+#if BUILDFLAG(IS_COBALT)
+void MemoryInstrumentation::SetDetailedMetricsDelegate(
+    DetailedMetricsDelegate* delegate) {
+  base::AutoLock lock(detailed_metrics_delegate_lock_);
+  detailed_metrics_delegate_ = delegate;
+}
+
+DetailedMetricsDelegate* MemoryInstrumentation::GetDetailedMetricsDelegate()
+    const {
+  base::AutoLock lock(detailed_metrics_delegate_lock_);
+  return detailed_metrics_delegate_;
+}
+#endif
+
+base::WeakPtr<MemoryInstrumentation> MemoryInstrumentation::GetWeakPtr() {
+  return weak_ptr_factory_.GetWeakPtr();
 }
 
 }  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h
@@ -7,10 +7,15 @@
 
 #include "base/component_export.h"
 #include "base/functional/callback_forward.h"
+#include "base/memory/weak_ptr.h"
 #include "base/trace_event/memory_dump_request_args.h"
 #include "mojo/public/cpp/bindings/shared_remote.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/global_memory_dump.h"
 #include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
+
+#if BUILDFLAG(IS_COBALT)
+#include "base/synchronization/lock.h"
+#endif
 
 namespace memory_instrumentation {
 
@@ -100,6 +105,16 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
       MemoryDumpDeterminism,
       RequestGlobalMemoryDumpAndAppendToTraceCallback);
 
+#if BUILDFLAG(IS_COBALT)
+  // Set the delegate for detailed metrics collection.
+  void SetDetailedMetricsDelegate(class DetailedMetricsDelegate* delegate);
+
+  // Get the registered delegate.
+  class DetailedMetricsDelegate* GetDetailedMetricsDelegate() const;
+#endif
+
+  base::WeakPtr<MemoryInstrumentation> GetWeakPtr();
+
  private:
   explicit MemoryInstrumentation(
       mojo::PendingRemote<memory_instrumentation::mojom::Coordinator>
@@ -112,6 +127,13 @@ class COMPONENT_EXPORT(RESOURCE_COORDINATOR_PUBLIC_MEMORY_INSTRUMENTATION)
 
   // Only browser process is allowed to request memory dumps.
   const bool is_browser_process_;
+
+#if BUILDFLAG(IS_COBALT)
+  mutable base::Lock detailed_metrics_delegate_lock_;
+  class DetailedMetricsDelegate* detailed_metrics_delegate_ = nullptr;
+#endif
+
+  base::WeakPtrFactory<MemoryInstrumentation> weak_ptr_factory_{this};
 };
 
 }  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.cc
@@ -1,0 +1,11 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.h"
+
+namespace memory_instrumentation {
+namespace features {
+
+}  // namespace features
+}  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.h
@@ -1,0 +1,17 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_MEMORY_INSTRUMENTATION_FEATURES_H_
+#define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_MEMORY_INSTRUMENTATION_FEATURES_H_
+
+#include "base/feature_list.h"
+#include "base/time/time.h"
+
+namespace memory_instrumentation {
+namespace features {
+
+}  // namespace features
+}  // namespace memory_instrumentation
+
+#endif  // SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_MEMORY_INSTRUMENTATION_FEATURES_H_

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
@@ -1,6 +1,7 @@
 // Copyright 2017 The Chromium Authors
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
+
 #ifndef SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_OS_METRICS_H_
 #define SERVICES_RESOURCE_COORDINATOR_PUBLIC_CPP_MEMORY_INSTRUMENTATION_OS_METRICS_H_
 
@@ -52,7 +53,8 @@ class COMPONENT_EXPORT(
   // the current process is used
   static bool FillOSMemoryDump(base::ProcessHandle handle,
                                const MemDumpFlagSet& flags,
-                               mojom::RawOSMemDump* dump);
+                               mojom::RawOSMemDump* dump,
+                               class DetailedMetricsDelegate* delegate = nullptr);
 #if BUILDFLAG(IS_APPLE)
   static bool FillOSMemoryDump(base::ProcessHandle handle,
                                const MemDumpFlagSet& flags,
@@ -64,13 +66,31 @@ class COMPONENT_EXPORT(
                                     mojom::RawOSMemDump*);
   static std::vector<mojom::VmRegionPtr> GetProcessMemoryMaps(
       base::ProcessHandle);
+  static std::vector<mojom::VmRegionPtr> GetProcessMemoryMaps(
+      const std::string& smaps_content);
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
   static void SetProcSmapsForTesting(FILE*);
+#if BUILDFLAG(IS_COBALT)
+  static void SetSmapsRollupForTesting(FILE*);
+
+  // Set the delegate for detailed metrics collection. This must be called
+  // before FillOSMemoryDump with MEM_DUMP_DETAILED_STATS.
+  static void SetDetailedMetricsDelegate(
+      class DetailedMetricsDelegate* delegate);
+#endif
 #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
         // BUILDFLAG(IS_ANDROID)
 
  private:
+#if BUILDFLAG(IS_COBALT)
+  static bool FillDetailedMetrics(base::ProcessHandle handle,
+                                  const MemDumpFlagSet& flags,
+                                  mojom::RawOSMemDump* dump,
+                                  class DetailedMetricsDelegate* delegate);
+  static bool ReadDetailedMetricsFile(base::ProcessHandle handle,
+                                      class DetailedMetricsDelegate* delegate);
+#endif
   FRIEND_TEST_ALL_PREFIXES(OSMetricsTest, ParseProcSmaps);
   FRIEND_TEST_ALL_PREFIXES(OSMetricsTest, TestWinModuleReading);
   FRIEND_TEST_ALL_PREFIXES(OSMetricsTest, TestMachOReading);

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h
@@ -73,11 +73,6 @@ class COMPONENT_EXPORT(
   static void SetProcSmapsForTesting(FILE*);
 #if BUILDFLAG(IS_COBALT)
   static void SetSmapsRollupForTesting(FILE*);
-
-  // Set the delegate for detailed metrics collection. This must be called
-  // before FillOSMemoryDump with MEM_DUMP_DETAILED_STATS.
-  static void SetDetailedMetricsDelegate(
-      class DetailedMetricsDelegate* delegate);
 #endif
 #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) ||
         // BUILDFLAG(IS_ANDROID)

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -15,10 +15,12 @@
 #include <stdint.h>
 #include <sys/prctl.h>
 
+#include <atomic>
 #include <memory>
 
 #include "base/android/library_loader/anchor_functions.h"
 #include "base/android/library_loader/anchor_functions_buildflags.h"
+#include "base/containers/contains.h"
 #include "base/containers/heap_array.h"
 #include "base/debug/elf_reader.h"
 #include "base/debug/proc_maps_linux.h"
@@ -35,7 +37,14 @@
 #include "base/strings/string_util.h"
 #include "base/threading/thread_restrictions.h"
 #include "build/build_config.h"
-#include "third_party/abseil-cpp/absl/strings/ascii.h"
+
+#if BUILDFLAG(IS_COBALT)
+#include "base/no_destructor.h"
+#include "base/numerics/safe_conversions.h"
+#include "base/synchronization/lock.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
+#endif
 
 // Symbol with virtual address of the start of ELF header of the current binary.
 extern char __ehdr_start;
@@ -47,8 +56,17 @@ namespace {
 using mojom::VmRegion;
 using mojom::VmRegionPtr;
 
+#if BUILDFLAG(IS_COBALT)
+FILE* g_proc_smaps_rollup_for_testing = nullptr;
+const size_t kPssValidationThresholdKb = 10240;
+#endif
+
+base::Lock& GetTestingGlobalsLock() {
+  static base::NoDestructor<base::Lock> lock;
+  return *lock;
+}
+
 const char kClearPeakRssCommand[] = "5";
-const uint32_t kMaxLineSize = 4096;
 
 // TODO(chiniforooshan): Many of the utility functions in this anonymous
 // namespace should move to base/process/process_metrics_linux.cc to make the
@@ -59,16 +77,64 @@ base::FilePath GetProcPidDir(base::ProcessId pid) {
       pid == base::kNullProcessId ? "self" : base::NumberToString(pid));
 }
 
+void GetSmapsRollup(base::ProcessHandle handle,
+                    size_t* pss,
+                    size_t* swap_pss) {
+  std::string content;
+  bool use_mock = false;
+  {
+    base::AutoLock lock(GetTestingGlobalsLock());
+    if (g_proc_smaps_rollup_for_testing) {
+      use_mock = true;
+      fseek(g_proc_smaps_rollup_for_testing, 0, SEEK_SET);
+      base::ReadStreamToString(g_proc_smaps_rollup_for_testing, &content);
+    }
+  }
+
+  if (!use_mock) {
+    std::string file_name =
+        "/proc/" +
+        (handle == base::kNullProcessHandle ? "self"
+                                            : base::NumberToString(handle)) +
+        "/smaps_rollup";
+    if (!base::ReadFileToString(base::FilePath(file_name), &content)) {
+      *pss = size_t(0);
+      *swap_pss = size_t(0);
+      return;
+    }
+  }
+
+  if (content.empty()) {
+    *pss = size_t(0);
+    *swap_pss = size_t(0);
+    return;
+  }
+
+  auto value = base::debug::ParseSmapsRollup(content);
+  if (!value) {
+    *pss = size_t(0);
+    *swap_pss = size_t(0);
+    return;
+  }
+  *pss = value->pss;
+  *swap_pss = value->swap_pss;
+}
+
 bool ResetPeakRSSIfPossible(base::ProcessId pid) {
-  static bool is_peak_rss_resettable = true;
-  if (!is_peak_rss_resettable)
+  static std::atomic<bool> is_peak_rss_resettable{true};
+  if (!is_peak_rss_resettable.load(std::memory_order_relaxed)) {
     return false;
+  }
   auto clear_refs_file = GetProcPidDir(pid).Append("clear_refs");
   base::ScopedFD clear_refs_fd(open(clear_refs_file.value().c_str(), O_WRONLY));
-  is_peak_rss_resettable =
+
+  bool success =
       clear_refs_fd.get() >= 0 &&
       base::WriteFileDescriptor(clear_refs_fd.get(), kClearPeakRssCommand);
-  return is_peak_rss_resettable;
+  if (!success) {
+    is_peak_rss_resettable.store(false, std::memory_order_relaxed);
+  }
+  return success;
 }
 
 struct ModuleData {
@@ -98,50 +164,70 @@ ModuleData GetMainModuleData() {
   return module_data;
 }
 
-bool ParseSmapsHeader(const char* header_line,
+bool ParseSmapsHeader(std::string_view header_line,
                       const ModuleData& main_module_data,
                       VmRegion* region) {
   // e.g., "00400000-00421000 r-xp 00000000 fc:01 1234  /foo.so\n"
-  bool res = true;  // Whether this region should be appended or skipped.
-  uint64_t end_addr = 0;
-  char protection_flags[5] = {};
-  char mapped_file[kMaxLineSize];
+  std::vector<std::string_view> tokens = base::SplitStringPiece(
+      header_line, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  if (tokens.size() < 5)
+    return false;
 
-  if (sscanf(header_line, "%" SCNx64 "-%" SCNx64 " %4c %*s %*s %*s%4095[^\n]\n",
-             &region->start_address, &end_addr, protection_flags,
-             mapped_file) != 4) {
+  std::vector<std::string_view> addresses = base::SplitStringPiece(
+      tokens[0], "-", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  if (addresses.size() != 2)
+    return false;
+
+  uint64_t start_addr = 0;
+  uint64_t end_addr = 0;
+  if (!base::HexStringToUInt64(addresses[0], &start_addr) ||
+      !base::HexStringToUInt64(addresses[1], &end_addr)) {
+    return false;
+  }
+  region->start_address = start_addr;
+
+  if (end_addr > start_addr) {
+    region->size_in_bytes = end_addr - start_addr;
+  } else {
+    region->size_in_bytes = 0;
     return false;
   }
 
-  if (end_addr > region->start_address) {
-    region->size_in_bytes = end_addr - region->start_address;
-  } else {
-    // This is not just paranoia, it can actually happen (See crbug.com/461237).
-    region->size_in_bytes = 0;
-    res = false;
-  }
+  std::string_view perms = tokens[1];
+  if (perms.size() < 4)
+    return false;
 
   region->protection_flags = 0;
-  if (protection_flags[0] == 'r') {
+  if (perms[0] == 'r') {
     region->protection_flags |= VmRegion::kProtectionFlagsRead;
   }
-  if (protection_flags[1] == 'w') {
+  if (perms[1] == 'w') {
     region->protection_flags |= VmRegion::kProtectionFlagsWrite;
   }
-  if (protection_flags[2] == 'x') {
+  if (perms[2] == 'x') {
     region->protection_flags |= VmRegion::kProtectionFlagsExec;
   }
-  if (protection_flags[3] == 's') {
+  if (perms[3] == 's') {
     region->protection_flags |= VmRegion::kProtectionFlagsMayshare;
   }
 
-  region->mapped_file = mapped_file;
-  base::TrimWhitespaceASCII(region->mapped_file, base::TRIM_ALL,
-                            &region->mapped_file);
+  if (tokens.size() >= 6) {
+    size_t dev_pos = header_line.find(tokens[3]);
+    if (dev_pos != std::string_view::npos) {
+      size_t inode_pos =
+          header_line.find(tokens[4], dev_pos + tokens[3].size());
+      if (inode_pos != std::string_view::npos) {
+        size_t filename_pos =
+            header_line.find_first_not_of(' ', inode_pos + tokens[4].size());
+        if (filename_pos != std::string_view::npos) {
+          region->mapped_file = std::string(header_line.substr(filename_pos));
+          base::TrimWhitespaceASCII(region->mapped_file, base::TRIM_ALL,
+                                    &region->mapped_file);
+        }
+      }
+    }
+  }
 
-  // Build ID is needed to symbolize heap profiles, and is generated only on
-  // official builds. Build ID is only added for the current library (chrome)
-  // since it is racy to read other libraries which can be unmapped any time.
 #if defined(OFFICIAL_BUILD)
   if (!region->mapped_file.empty() &&
       base::StartsWith(main_module_data.path, region->mapped_file,
@@ -149,82 +235,41 @@ bool ParseSmapsHeader(const char* header_line,
       !main_module_data.build_id.empty()) {
     region->module_debugid = main_module_data.build_id;
   }
-#endif  // defined(OFFICIAL_BUILD)
+#endif
 
-  return res;
+  return true;
 }
 
-uint64_t ReadCounterBytes(char* counter_line) {
-  uint64_t counter_value = 0;
-  int res = sscanf(counter_line, "%*s %" SCNu64 " kB", &counter_value);
-  return res == 1 ? counter_value * 1024 : 0;
-}
-
-uint32_t ParseSmapsCounter(char* counter_line, VmRegion* region) {
-  // A smaps counter lines looks as follows: "RSS:  0 Kb\n"
-  uint32_t res = 1;
-  char counter_name[20];
-  int did_read = sscanf(counter_line, "%19[^\n ]", counter_name);
-  if (did_read != 1)
+uint64_t ReadCounterBytes(std::string_view counter_line) {
+  std::vector<std::string_view> tokens = base::SplitStringPiece(
+      counter_line, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  if (tokens.size() < 3 || tokens[2] != "kB")
     return 0;
+  uint64_t counter_value = 0;
+  if (!base::StringToUint64(tokens[1], &counter_value))
+    return 0;
+  return counter_value * 1024;
+}
 
-  if (strcmp(counter_name, "Pss:") == 0) {
+uint32_t ParseSmapsCounter(std::string_view counter_line, VmRegion* region) {
+  if (base::StartsWith(counter_line, "Pss:")) {
     region->byte_stats_proportional_resident = ReadCounterBytes(counter_line);
-  } else if (strcmp(counter_name, "Private_Dirty:") == 0) {
+  } else if (base::StartsWith(counter_line, "Private_Dirty:")) {
     region->byte_stats_private_dirty_resident = ReadCounterBytes(counter_line);
-  } else if (strcmp(counter_name, "Private_Clean:") == 0) {
+  } else if (base::StartsWith(counter_line, "Private_Clean:")) {
     region->byte_stats_private_clean_resident = ReadCounterBytes(counter_line);
-  } else if (strcmp(counter_name, "Shared_Dirty:") == 0) {
+  } else if (base::StartsWith(counter_line, "Shared_Dirty:")) {
     region->byte_stats_shared_dirty_resident = ReadCounterBytes(counter_line);
-  } else if (strcmp(counter_name, "Shared_Clean:") == 0) {
+  } else if (base::StartsWith(counter_line, "Shared_Clean:")) {
     region->byte_stats_shared_clean_resident = ReadCounterBytes(counter_line);
-  } else if (strcmp(counter_name, "Swap:") == 0) {
+  } else if (base::StartsWith(counter_line, "Swap:")) {
     region->byte_stats_swapped = ReadCounterBytes(counter_line);
-  } else if (strcmp(counter_name, "Locked:") == 0) {
+  } else if (base::StartsWith(counter_line, "Locked:")) {
     region->byte_locked = ReadCounterBytes(counter_line);
   } else {
-    res = 0;
-  }
-
-  return res;
-}
-
-uint32_t ReadLinuxProcSmapsFile(FILE* smaps_file,
-                                std::vector<VmRegionPtr>* maps) {
-  if (!smaps_file)
     return 0;
-
-  fseek(smaps_file, 0, SEEK_SET);
-
-  char line[kMaxLineSize];
-  const uint32_t kNumExpectedCountersPerRegion = 7;
-  uint32_t counters_parsed_for_current_region = 0;
-  uint32_t num_valid_regions = 0;
-  bool should_add_current_region = false;
-  VmRegion region;
-  ModuleData main_module_data = GetMainModuleData();
-  for (;;) {
-    line[0] = '\0';
-    if (fgets(line, kMaxLineSize, smaps_file) == nullptr || !strlen(line))
-      break;
-    if (absl::ascii_isxdigit(static_cast<unsigned char>(line[0])) &&
-        !absl::ascii_isupper(static_cast<unsigned char>(line[0]))) {
-      region = VmRegion();
-      counters_parsed_for_current_region = 0;
-      should_add_current_region =
-          ParseSmapsHeader(line, main_module_data, &region);
-    } else if (should_add_current_region) {
-      counters_parsed_for_current_region += ParseSmapsCounter(line, &region);
-      DCHECK_LE(counters_parsed_for_current_region,
-                kNumExpectedCountersPerRegion);
-      if (counters_parsed_for_current_region == kNumExpectedCountersPerRegion) {
-        maps->push_back(VmRegion::New(region));
-        ++num_valid_regions;
-        should_add_current_region = false;
-      }
-    }
   }
-  return num_valid_regions;
+  return 1;
 }
 
 // RAII class making the current process dumpable via prctl(PR_SET_DUMPABLE, 1),
@@ -289,7 +334,7 @@ uint32_t CountMappings(base::ProcessId pid) {
   uint32_t newline_characters = 0;
   while (true) {
     ssize_t bytes_read =
-        HANDLE_EINTR(read(fd.get(), &buffer[0], buffer.size()));
+        HANDLE_EINTR(read(fd.get(), buffer.data(), buffer.size()));
     if (bytes_read < 0) {
       DPLOG(ERROR) << "Couldn't read /proc/PID/maps";
       return 0;
@@ -309,87 +354,29 @@ uint32_t CountMappings(base::ProcessId pid) {
   return newline_characters;
 }
 
-// Get values from smaps_rollup for the current process.
-void GetSmapsRollup(uint32_t* pss, uint32_t* swap_pss) {
-  auto value = base::debug::ReadAndParseSmapsRollup();
-  if (!value) {
-    *pss = 0;
-    *swap_pss = 0;
-    return;
-  }
-  *pss = value->pss;
-  *swap_pss = value->swap_pss;
-}
-
-#if BUILDFLAG(IS_COBALT) && (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID))
-struct LibChrobaltMem {
-  uint32_t pss_kb = 0;
-  uint32_t rss_kb = 0;
-};
-
-LibChrobaltMem GetLibChrobaltMem(base::ProcessId pid) {
-  std::string file_name =
-      "/proc/" +
-      (pid == base::kNullProcessId ? "self" : base::NumberToString(pid)) +
-      "/smaps";
-  base::ScopedFILE smaps_file(fopen(file_name.c_str(), "r"));
-  if (!smaps_file) {
-    return {};
-  }
-
-  char line[kMaxLineSize];
-  uint64_t total_pss_kb = 0;
-  uint64_t total_rss_kb = 0;
-  bool is_libchrobalt_region = false;
-  while (fgets(line, kMaxLineSize, smaps_file.get())) {
-    if (absl::ascii_isxdigit(static_cast<unsigned char>(line[0])) &&
-        !absl::ascii_isupper(static_cast<unsigned char>(line[0]))) {
-      const char kLibName[] = "libchrobalt.so";
-      const char* found = strstr(line, kLibName);
-      if (found) {
-        bool prefix_matches = (found == line || *(found - 1) == '/');
-        char next_char = found[strlen(kLibName)];
-        bool suffix_matches =
-            (next_char == '\0' || next_char == '\n' || next_char == '\r' ||
-             absl::ascii_isspace(static_cast<unsigned char>(next_char)));
-        is_libchrobalt_region = prefix_matches && suffix_matches;
-      } else {
-        is_libchrobalt_region = false;
-      }
-    } else if (is_libchrobalt_region) {
-      uint64_t value_kb = 0;
-      if (strncmp(line, "Pss:", 4) == 0) {
-        if (sscanf(line, "Pss: %" SCNu64 " kB", &value_kb) == 1) {
-          total_pss_kb += value_kb;
-        }
-      } else if (strncmp(line, "Rss:", 4) == 0) {
-        if (sscanf(line, "Rss: %" SCNu64 " kB", &value_kb) == 1) {
-          total_rss_kb += value_kb;
-        }
-      }
-    }
-  }
-  LibChrobaltMem result;
-  result.pss_kb = base::saturated_cast<uint32_t>(total_pss_kb);
-  result.rss_kb = base::saturated_cast<uint32_t>(total_rss_kb);
-  return result;
-}
-#endif
-
 }  // namespace
 
 FILE* g_proc_smaps_for_testing = nullptr;
 
 // static
 void OSMetrics::SetProcSmapsForTesting(FILE* f) {
+  base::AutoLock lock(GetTestingGlobalsLock());
   g_proc_smaps_for_testing = f;
 }
+
+#if BUILDFLAG(IS_COBALT)
+// static
+void OSMetrics::SetSmapsRollupForTesting(FILE* f) {
+  base::AutoLock lock(GetTestingGlobalsLock());
+  g_proc_smaps_rollup_for_testing = f;
+}
+#endif
 
 // static
 bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
                                  const MemDumpFlagSet& flags,
                                  mojom::RawOSMemDump* dump,
-                                 DetailedMetricsDelegate* /*delegate*/) {
+                                 DetailedMetricsDelegate* delegate) {
   auto info = GetMemoryInfo(handle);
   if (!info.has_value()) {
     return false;
@@ -402,18 +389,28 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
   dump->peak_resident_set_kb = GetPeakResidentSetSize(handle);
   dump->is_peak_rss_resettable = ResetPeakRSSIfPossible(handle);
 
-#if BUILDFLAG(IS_COBALT) && (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID))
-  LibChrobaltMem lib_mem = GetLibChrobaltMem(handle);
-  dump->libchrobalt_pss_kb = lib_mem.pss_kb;
-  dump->libchrobalt_rss_kb = lib_mem.rss_kb;
-#endif
-
   if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_COUNT_MAPPINGS)) {
     dump->mappings_count = CountMappings(handle);
   }
   if (flags.Has(mojom::MemDumpFlags::MEM_DUMP_PSS)) {
+#if BUILDFLAG(IS_COBALT)
+    size_t pss, swap_pss;
+    GetSmapsRollup(handle, &pss, &swap_pss);
+    dump->pss_kb = base::saturated_cast<uint32_t>(pss / 1024);
+    dump->swap_pss_kb = base::saturated_cast<uint32_t>(swap_pss / 1024);
+#else
     GetSmapsRollup(&dump->pss_kb, &dump->swap_pss_kb);
+#endif
   }
+
+#if BUILDFLAG(IS_COBALT)
+  // If a delegate is present, always try to fill detailed metrics. This
+  // includes populating legacy libchrobalt fields from the results collected
+  // by the delegate.
+  if (delegate) {
+    FillDetailedMetrics(handle, flags, dump, delegate);
+  }
+#endif
 
 #if BUILDFLAG(IS_ANDROID)
 #if BUILDFLAG(SUPPORTS_CODE_ORDERING)
@@ -451,24 +448,154 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
 std::vector<VmRegionPtr> OSMetrics::GetProcessMemoryMaps(
     base::ProcessHandle handle) {
   std::vector<VmRegionPtr> maps;
-  uint32_t res = 0;
-  if (g_proc_smaps_for_testing) {
-    res = ReadLinuxProcSmapsFile(g_proc_smaps_for_testing, &maps);
-  } else {
+  {
+    base::AutoLock lock(GetTestingGlobalsLock());
+    if (g_proc_smaps_for_testing) {
+      fseek(g_proc_smaps_for_testing, 0, SEEK_SET);
+      std::string smaps;
+      if (base::ReadStreamToString(g_proc_smaps_for_testing, &smaps)) {
+        return OSMetrics::GetProcessMemoryMaps(smaps);
+      }
+      return std::vector<VmRegionPtr>();
+    }
+  }
+
+  std::string file_name =
+      "/proc/" +
+      (handle == base::kNullProcessHandle ? "self"
+                                          : base::NumberToString(handle)) +
+      "/smaps";
+  std::string smaps;
+  if (!base::ReadFileToString(base::FilePath(file_name), &smaps)) {
+    return std::vector<VmRegionPtr>();
+  }
+
+  return OSMetrics::GetProcessMemoryMaps(smaps);
+}
+
+// static
+std::vector<VmRegionPtr> OSMetrics::GetProcessMemoryMaps(
+    const std::string& smaps_content) {
+  std::vector<VmRegionPtr> maps;
+  std::vector<std::string_view> lines = base::SplitStringPiece(
+      smaps_content, "\n", base::TRIM_WHITESPACE, base::SPLIT_WANT_ALL);
+
+  const uint32_t kNumExpectedCountersPerRegion = 7;
+  uint32_t counters_parsed_for_current_region = 0;
+  bool should_add_current_region = false;
+  VmRegion region;
+  ModuleData main_module_data = GetMainModuleData();
+
+  for (const auto& line_view : lines) {
+    if (line_view.empty())
+      continue;
+    if (base::IsHexDigit(line_view[0]) && !base::IsAsciiUpper(line_view[0])) {
+      region = VmRegion();
+      counters_parsed_for_current_region = 0;
+      should_add_current_region =
+          ParseSmapsHeader(line_view, main_module_data, &region);
+    } else if (should_add_current_region) {
+      counters_parsed_for_current_region +=
+          ParseSmapsCounter(line_view, &region);
+      DCHECK_LE(counters_parsed_for_current_region,
+                kNumExpectedCountersPerRegion);
+      if (counters_parsed_for_current_region == kNumExpectedCountersPerRegion) {
+        maps.push_back(VmRegion::New(region));
+        should_add_current_region = false;
+      }
+    }
+  }
+  return maps;
+}
+
+#if BUILDFLAG(IS_COBALT)
+// static
+bool OSMetrics::ReadDetailedMetricsFile(base::ProcessHandle handle,
+                                        DetailedMetricsDelegate* delegate) {
+  std::string content;
+  {
+    base::AutoLock lock(GetTestingGlobalsLock());
+    if (g_proc_smaps_for_testing) {
+      fseek(g_proc_smaps_for_testing, 0, SEEK_SET);
+      if (!base::ReadStreamToString(g_proc_smaps_for_testing, &content)) {
+        return false;
+      }
+      fseek(g_proc_smaps_for_testing, 0, SEEK_SET);
+    }
+  }
+
+  if (content.empty()) {
     std::string file_name =
         "/proc/" +
         (handle == base::kNullProcessHandle ? "self"
                                             : base::NumberToString(handle)) +
         "/smaps";
-    base::ScopedFILE smaps_file(fopen(file_name.c_str(), "r"));
-    res = ReadLinuxProcSmapsFile(smaps_file.get(), &maps);
+    if (!base::ReadFileToString(base::FilePath(file_name), &content)) {
+      DPLOG(ERROR) << "Couldn't read " << file_name;
+      return false;
+    }
   }
 
-  if (!res)
-    return std::vector<VmRegionPtr>();
+  for (std::string_view line : base::SplitStringPiece(
+           content, "\n", base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
+    if (!delegate->OnSmapsBuffer(line)) {
+      return false;
+    }
+  }
 
-  return maps;
+  return true;
 }
+
+// static
+bool OSMetrics::FillDetailedMetrics(base::ProcessHandle handle,
+                                    const MemDumpFlagSet& flags,
+                                    mojom::RawOSMemDump* dump,
+                                    DetailedMetricsDelegate* delegate) {
+  if (!delegate) {
+    return true;
+  }
+
+  if (!ReadDetailedMetricsFile(handle, delegate)) {
+    return false;
+  }
+
+  DetailedMetrics metrics = delegate->GetAndResetStats();
+
+  // Populate legacy libchrobalt fields from the results collected by the delegate.
+  auto it_pss = metrics.categories_kb.find("pss:lib_chrobalt");
+  if (it_pss != metrics.categories_kb.end()) {
+    dump->libchrobalt_pss_kb = it_pss->second;
+  }
+  auto it_rss = metrics.categories_kb.find("rss:lib_chrobalt");
+  if (it_rss != metrics.categories_kb.end()) {
+    dump->libchrobalt_rss_kb = it_rss->second;
+  }
+
+  if (!flags.Has(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS)) {
+    return true;
+  }
+
+  // Validate against smaps_rollup.
+  size_t rollup_pss, rollup_swap_pss;
+  GetSmapsRollup(handle, &rollup_pss, &rollup_swap_pss);
+
+  // If the difference is too large, we might have inconsistent data.
+  size_t pss_kb = metrics.total_pss_kb;
+  size_t rollup_pss_kb = rollup_pss / 1024;
+  size_t abs_diff = (pss_kb > rollup_pss_kb) ? (pss_kb - rollup_pss_kb)
+                                            : (rollup_pss_kb - pss_kb);
+  if (metrics.total_pss_kb > 0 && abs_diff > kPssValidationThresholdKb) {
+    LOG(WARNING) << "Detailed metrics PSS validation failed. "
+                 << "Detailed: " << metrics.total_pss_kb
+                 << " KiB, Rollup: " << rollup_pss / 1024 << " KiB";
+    return false;
+  }
+  dump->detailed_stats_kb = std::move(metrics.categories_kb);
+  dump->last_detailed_dump_time = base::TimeTicks::Now();
+
+  return true;
+}
+#endif
 
 // static
 OSMetrics::MappedAndResidentPagesDumpState OSMetrics::GetMappedAndResidentPages(

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -8,6 +8,7 @@
 #endif
 
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
 
 #include <dlfcn.h>
 #include <fcntl.h>
@@ -387,7 +388,8 @@ void OSMetrics::SetProcSmapsForTesting(FILE* f) {
 // static
 bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
                                  const MemDumpFlagSet& flags,
-                                 mojom::RawOSMemDump* dump) {
+                                 mojom::RawOSMemDump* dump,
+                                 DetailedMetricsDelegate* /*delegate*/) {
   auto info = GetMemoryInfo(handle);
   if (!info.has_value()) {
     return false;

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -44,6 +44,7 @@
 #include "base/synchronization/lock.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
+
 #endif
 
 // Symbol with virtual address of the start of ELF header of the current binary.
@@ -512,35 +513,44 @@ std::vector<VmRegionPtr> OSMetrics::GetProcessMemoryMaps(
 // static
 bool OSMetrics::ReadDetailedMetricsFile(base::ProcessHandle handle,
                                         DetailedMetricsDelegate* delegate) {
-  std::string content;
+  FILE* f = nullptr;
+  bool should_close = false;
   {
     base::AutoLock lock(GetTestingGlobalsLock());
     if (g_proc_smaps_for_testing) {
-      fseek(g_proc_smaps_for_testing, 0, SEEK_SET);
-      if (!base::ReadStreamToString(g_proc_smaps_for_testing, &content)) {
-        return false;
-      }
-      fseek(g_proc_smaps_for_testing, 0, SEEK_SET);
+      f = g_proc_smaps_for_testing;
+      fseek(f, 0, SEEK_SET);
     }
   }
 
-  if (content.empty()) {
+  if (!f) {
     std::string file_name =
         "/proc/" +
         (handle == base::kNullProcessHandle ? "self"
                                             : base::NumberToString(handle)) +
         "/smaps";
-    if (!base::ReadFileToString(base::FilePath(file_name), &content)) {
-      DPLOG(ERROR) << "Couldn't read " << file_name;
+    f = fopen(file_name.c_str(), "r");
+    if (!f) {
+      DPLOG(ERROR) << "Couldn't open " << file_name;
+      return false;
+    }
+    should_close = true;
+  }
+
+  char line[2048];
+  while (fgets(line, sizeof(line), f)) {
+    if (!delegate->OnSmapsBuffer(line)) {
+      if (should_close) {
+        fclose(f);
+      }
       return false;
     }
   }
 
-  for (std::string_view line : base::SplitStringPiece(
-           content, "\n", base::KEEP_WHITESPACE, base::SPLIT_WANT_NONEMPTY)) {
-    if (!delegate->OnSmapsBuffer(line)) {
-      return false;
-    }
+  if (should_close) {
+    fclose(f);
+  } else {
+    fseek(f, 0, SEEK_SET);
   }
 
   return true;
@@ -555,8 +565,12 @@ bool OSMetrics::FillDetailedMetrics(base::ProcessHandle handle,
     return true;
   }
 
+  static base::NoDestructor<base::Lock> detailed_metrics_lock;
+  base::AutoLock lock(*detailed_metrics_lock);
+
   if (!ReadDetailedMetricsFile(handle, delegate)) {
-    return false;
+    LOG(WARNING) << "Failed to read detailed metrics, continuing with basic metrics.";
+    return true;
   }
 
   DetailedMetrics metrics = delegate->GetAndResetStats();

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_unittest.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_unittest.cc
@@ -14,6 +14,8 @@
 #include "base/files/file_util.h"
 #include "base/memory/page_size.h"
 #include "base/process/process_handle.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/string_split.h"
 #include "build/build_config.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -31,6 +33,12 @@
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
 #include <sys/mman.h>
 #include <sys/utsname.h>
+#endif
+
+#if BUILDFLAG(IS_COBALT)
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
+#include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
 #endif
 
 namespace memory_instrumentation {
@@ -446,5 +454,82 @@ TEST(OSMetricsTest, DISABLED_TestMachOReading) {
   CheckMachORegions(maps);
 }
 #endif  // BUILDFLAG(IS_MAC)
+
+#if BUILDFLAG(IS_COBALT)
+namespace {
+class SimpleDetailedMetricsDelegate : public DetailedMetricsDelegate {
+ public:
+  bool OnSmapsBuffer(std::string_view buffer) override {
+    if (buffer.find("/") != std::string_view::npos) {
+      if (buffer.find("/file/1") != std::string_view::npos) {
+        current_category_ = "lib_chrobalt";
+      } else if (buffer.find("/file/name with space") != std::string_view::npos) {
+        current_category_ = "category2";
+      } else {
+        current_category_ = "other";
+      }
+    }
+
+    if (base::StartsWith(buffer, "Pss:")) {
+      std::vector<std::string_view> tokens = base::SplitStringPiece(
+          buffer, " ", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+      uint32_t val = 0;
+      if (tokens.size() >= 2 && base::StringToUint(tokens[1], &val)) {
+        metrics_.categories_kb["pss:" + current_category_] += val;
+        metrics_.total_pss_kb += val;
+      }
+    }
+    return true;
+  }
+
+  DetailedMetrics GetAndResetStats() override {
+    DetailedMetrics results = std::move(metrics_);
+    metrics_ = DetailedMetrics();
+    return results;
+  }
+
+ private:
+  std::string current_category_ = "other";
+  DetailedMetrics metrics_;
+};
+}  // namespace
+
+TEST(OSMetricsTest, DetailedMetricsIntegration) {
+  // Use a dummy coordinator for MemoryInstrumentation.
+  if (!MemoryInstrumentation::GetInstance()) {
+    mojo::PendingRemote<mojom::Coordinator> coordinator_remote;
+    MemoryInstrumentation::CreateInstance(std::move(coordinator_remote), true);
+  }
+
+  SimpleDetailedMetricsDelegate delegate;
+
+  base::ScopedFILE temp_smaps;
+  CreateTempFileWithContents(kTestSmaps1, &temp_smaps);
+  OSMetrics::SetProcSmapsForTesting(temp_smaps.get());
+
+  // Create a smaps_rollup file that matches our expectation (162 + 128 = 290KB PSS).
+  base::ScopedFILE temp_rollup;
+  CreateTempFileWithContents("Pss: 290 kB\nSwapPss: 0 kB\n", &temp_rollup);
+  OSMetrics::SetSmapsRollupForTesting(temp_rollup.get());
+
+  mojom::RawOSMemDump dump;
+  dump.platform_private_footprint = mojom::PlatformPrivateFootprint::New();
+  OSMetrics::MemDumpFlagSet flags;
+  flags.Put(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS);
+
+  EXPECT_TRUE(OSMetrics::FillOSMemoryDump(base::kNullProcessHandle, flags, &dump, &delegate));
+  
+  ASSERT_TRUE(dump.detailed_stats_kb.has_value());
+  EXPECT_EQ(2u, dump.detailed_stats_kb->size());
+  EXPECT_EQ(162u, (*dump.detailed_stats_kb)["pss:lib_chrobalt"]);
+  EXPECT_EQ(128u, (*dump.detailed_stats_kb)["pss:category2"]);
+
+  // Verify legacy fields are also populated.
+  EXPECT_EQ(162u, dump.libchrobalt_pss_kb);
+
+  OSMetrics::SetProcSmapsForTesting(nullptr);
+  OSMetrics::SetSmapsRollupForTesting(nullptr);
+}
+#endif
 
 }  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_unittest.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_unittest.cc
@@ -17,6 +17,9 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "build/build_config.h"
+#include "base/task/thread_pool.h"
+#include "base/synchronization/waitable_event.h"
+#include "base/test/task_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 #if BUILDFLAG(IS_MAC)
@@ -526,6 +529,70 @@ TEST(OSMetricsTest, DetailedMetricsIntegration) {
 
   // Verify legacy fields are also populated.
   EXPECT_EQ(162u, dump.libchrobalt_pss_kb);
+
+  OSMetrics::SetProcSmapsForTesting(nullptr);
+  OSMetrics::SetSmapsRollupForTesting(nullptr);
+}
+
+TEST(OSMetricsTest, DetailedMetricsConcurrency) {
+  base::test::TaskEnvironment task_environment;
+  if (!MemoryInstrumentation::GetInstance()) {
+    mojo::PendingRemote<mojom::Coordinator> coordinator_remote;
+    MemoryInstrumentation::CreateInstance(std::move(coordinator_remote), true);
+  }
+
+  SimpleDetailedMetricsDelegate delegate;
+
+  base::ScopedFILE temp_smaps;
+  CreateTempFileWithContents(kTestSmaps1, &temp_smaps);
+  OSMetrics::SetProcSmapsForTesting(temp_smaps.get());
+
+  base::ScopedFILE temp_rollup;
+  CreateTempFileWithContents("Pss: 290 kB\nSwapPss: 0 kB\n", &temp_rollup);
+  OSMetrics::SetSmapsRollupForTesting(temp_rollup.get());
+
+  const int kNumThreads = 4;
+  
+  struct ThreadArgs {
+    SimpleDetailedMetricsDelegate* delegate;
+    bool success;
+    mojom::RawOSMemDumpPtr dump;
+  } args[kNumThreads];
+
+  for (int i = 0; i < kNumThreads; ++i) {
+    args[i].delegate = &delegate;
+    args[i].success = false;
+    args[i].dump = mojom::RawOSMemDump::New();
+    args[i].dump->platform_private_footprint = mojom::PlatformPrivateFootprint::New();
+  }
+
+  base::WaitableEvent events[kNumThreads];
+  for (int i = 0; i < kNumThreads; ++i) {
+    events[i].Reset();
+  }
+
+  for (int i = 0; i < kNumThreads; ++i) {
+    base::ThreadPool::PostTask(
+        FROM_HERE, {base::MayBlock()},
+        base::BindOnce([](ThreadArgs* args, base::WaitableEvent* event) {
+          OSMetrics::MemDumpFlagSet flags;
+          flags.Put(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS);
+          args->success = OSMetrics::FillOSMemoryDump(base::kNullProcessHandle, flags, args->dump.get(), args->delegate);
+          event->Signal();
+        }, base::Unretained(&args[i]), base::Unretained(&events[i])));
+  }
+
+  for (int i = 0; i < kNumThreads; ++i) {
+    events[i].Wait();
+  }
+
+  for (int i = 0; i < kNumThreads; ++i) {
+    EXPECT_TRUE(args[i].success);
+    ASSERT_TRUE(args[i].dump->detailed_stats_kb.has_value());
+    EXPECT_EQ(2u, args[i].dump->detailed_stats_kb->size());
+    EXPECT_EQ(162u, (*args[i].dump->detailed_stats_kb)["pss:lib_chrobalt"]);
+    EXPECT_EQ(128u, (*args[i].dump->detailed_stats_kb)["pss:category2"]);
+  }
 
   OSMetrics::SetProcSmapsForTesting(nullptr);
   OSMetrics::SetSmapsRollupForTesting(nullptr);

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/tracing_observer_proto_unittest.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/tracing_observer_proto_unittest.cc
@@ -131,14 +131,13 @@ memory_instrumentation::mojom::OSMemDump GetFakeOSMemDump(
     uint32_t resident_set_kb,
     uint32_t private_footprint_kb,
     uint32_t shared_footprint_kb) {
-  return memory_instrumentation::mojom::OSMemDump(
-      resident_set_kb, /*peak_resident_set_kb=*/resident_set_kb,
-      /*is_peak_rss_resettable=*/true, private_footprint_kb, shared_footprint_kb
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
-      ,
-      0, 0, 0, 0
-#endif
-  );
+  memory_instrumentation::mojom::OSMemDump os_dump;
+  os_dump.resident_set_kb = resident_set_kb;
+  os_dump.peak_resident_set_kb = resident_set_kb;
+  os_dump.is_peak_rss_resettable = true;
+  os_dump.private_footprint_kb = private_footprint_kb;
+  os_dump.shared_footprint_kb = shared_footprint_kb;
+  return os_dump;
 }
 
 // crbug.com/1242040: flaky on linux, chromeos

--- a/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
+++ b/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
@@ -226,9 +226,11 @@ struct RawOSMemDump {
   uint32 stacks_rss_kb = 0;
 
   // Generic map for detailed memory metrics.
+  [EnableIf=is_cobalt_with_libchrobalt_metrics]
   map<string, uint32>? detailed_stats_kb;
 
   // Timestamp of the last successful detailed memory dump.
+  [EnableIf=is_cobalt_with_libchrobalt_metrics]
   mojo_base.mojom.TimeTicks last_detailed_dump_time;
 };
 
@@ -321,9 +323,11 @@ struct OSMemDump {
   uint32 stacks_rss_kb = 0;
 
   // Generic map for detailed memory metrics.
+  [EnableIf=is_cobalt_with_libchrobalt_metrics]
   map<string, uint32>? detailed_stats_kb;
 
   // Timestamp of the last successful detailed memory dump.
+  [EnableIf=is_cobalt_with_libchrobalt_metrics]
   mojo_base.mojom.TimeTicks last_detailed_dump_time;
 };
 


### PR DESCRIPTION
This commit adds integration and browser tests to verify that the granular
memory tracking system works as expected in a browser environment.

- Add `GranularMemoryBrowsertest` to verify dump triggering and propagation.
- Include follow-up fixes to stabilize the tests.


Bug: 494004530