### PR TITLE
build: fix condition for removing NetworkChangeNotifier on hermetic builds

### DIFF
--- a/net/BUILD.gn
+++ b/net/BUILD.gn
@@ -1319,21 +1319,12 @@ component("net") {
 
   if (is_linux) {
     sources += [
-      "base/network_change_notifier_linux.cc",
-      "base/network_change_notifier_linux.h",
       "proxy_resolution/proxy_config_service_linux.cc",
       "proxy_resolution/proxy_config_service_linux.h",
     ]
     if (use_glib) {
       deps += [ "//ui/base/glib" ]
     }
-  }
-
-  if (is_cobalt_hermetic_build) {
-    sources -= [
-      "base/network_change_notifier_linux.cc",
-      "base/network_change_notifier_linux.h",
-    ]
   }
 
   if ((is_linux || is_chromeos || is_android) && !is_cobalt_hermetic_build) {
@@ -1352,6 +1343,8 @@ component("net") {
     sources += [
       "base/address_map_cache_linux.cc",
       "base/address_map_cache_linux.h",
+      "base/network_change_notifier_linux.cc",
+      "base/network_change_notifier_linux.h",
     ]
   }
 


### PR DESCRIPTION
The base/network_change_notifier_linux.* files are added to the sources only for linux builds, but should be removed for hermetic builds. Add the same is_linux guard to check if the files should be removed from source to fix the following gn gen issue:

ERROR at //net/BUILD.gn:1334:7: Item not found
      "base/network_change_notifier_linux.cc"

Bug: 495203133