### PR TITLE
ci: Ensure enough history is available to run autoroller

### DIFF
--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -35,11 +35,9 @@ jobs:
           git config --global user.email "github@google.com"
           git config --global submodule.recurse false
 
-      - name: Cherry Pick merged PRs
-        id: autoroll
+      - name: Prepare Cherry Pick Branch
         env:
           TARGET_BRANCH: 27.lts
-          START_COMMIT: ${{ inputs.start_commit }}
         run: |
           set -x
 
@@ -59,6 +57,14 @@ jobs:
 
           # Ensure latest main with enough history.
           git fetch --depth=1000 --no-recurse-submodules --filter=blob:none origin main:main
+
+      - name: Cherry Pick Merged PRs
+        id: autoroll
+        env:
+          TARGET_BRANCH: 27.lts
+          START_COMMIT: ${{ inputs.start_commit }}
+        run: |
+          set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
@@ -101,7 +107,7 @@ jobs:
 
           if [[ "$PR_STATE" == "OPEN" ]]; then
             PR_NUMBER=$(gh pr view "autoroll-to-${TARGET_BRANCH}" --json number --jq .number)
-            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f title="${PR_TITLE}" -f body="$(cat "${PR_BODY_FILE}")"
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f title="${PR_TITLE}" -f body="$(cat "${PR_BODY_FILE}")" --jq .html_url
           else
             gh pr create --base "${TARGET_BRANCH}" --head "autoroll-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}"
           fi

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -46,8 +46,9 @@ jobs:
           # Copy the script from the main branch before switching branches.
           cp .github/scripts/autoroll_lts.py "${RUNNER_TEMP}"/
 
-          # Ensure we have local branches for the target branch.
-          git fetch --no-recurse-submodules --filter=blob:none origin "${TARGET_BRANCH}:${TARGET_BRANCH}"
+          # Unshallow the repository to ensure all history for all branches is fetched.
+          # Fetch enough history for target branch to find merge base.
+          git fetch --depth=1000 --no-recurse-submodules --filter=blob:none origin "${TARGET_BRANCH}:${TARGET_BRANCH}"
 
           # Use existing branch from remote if it exists, otherwise start from the target branch.
           if git fetch --no-recurse-submodules --filter=blob:none origin "autoroll-to-${TARGET_BRANCH}"; then
@@ -56,8 +57,8 @@ jobs:
             git checkout --no-recurse-submodules -B "autoroll-to-${TARGET_BRANCH}" "${TARGET_BRANCH}" --no-track
           fi
 
-          # Ensure latest main.
-          git fetch --no-recurse-submodules --filter=blob:none origin main:main
+          # Ensure latest main with enough history.
+          git fetch --depth=1000 --no-recurse-submodules --filter=blob:none origin main:main
 
           # Run the Python script to perform cherry-picks and get all PR links.
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -109,5 +109,5 @@ jobs:
             PR_NUMBER=$(gh pr view "autoroll-to-${TARGET_BRANCH}" --json number --jq .number)
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f title="${PR_TITLE}" -f body="$(cat "${PR_BODY_FILE}")" --jq .html_url
           else
-            gh pr create --base "${TARGET_BRANCH}" --head "autoroll-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}"
+            gh pr create --base "${TARGET_BRANCH}" --head "autoroll-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}" --reviewer linxinan-chops,oxve
           fi


### PR DESCRIPTION
Fetch last 1000 commits on source and target branches to ensure the merge base is present in history.
Also: re-org code slightly, automatically add reviewers to created autoroll PR.

Bug: 484351320