### PR TITLE
evergreen: customize installation of updates

### DIFF
--- a/components/update_client/component.cc
+++ b/components/update_client/component.cc
@@ -219,6 +219,10 @@ void Component::SetUpdateCheckResult(std::optional<ProtocolParser::App> result,
 #if defined(IN_MEMORY_UPDATES)
         &crx_str_,
 #endif
+#if BUILDFLAG(IS_STARBOARD)
+        update_context_->update_checker->GetPersistedData(),
+        next_version_.GetString(),
+#endif
         base::BindRepeating(
             [](base::raw_ref<Component> component, ComponentState state) {
               component->state_hint_ = state;

--- a/components/update_client/component.cc
+++ b/components/update_client/component.cc
@@ -78,7 +78,7 @@ void StartInstallOnBlockingTaskRunner(
 #else
     const base::FilePath& crx_path,
 #endif
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
     int installation_index,
     PersistedData* metadata,
     const std::string& id,
@@ -442,7 +442,7 @@ void Component::StateChecking::DoHandle() {
   auto& component = State::component();
   CHECK(component.crx_component());
 
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
   auto& config = component.update_context_->config;
   auto metadata = component.update_context_->update_checker->GetPersistedData();
   if (metadata) {
@@ -714,7 +714,7 @@ void Component::StateUpdating::DoHandle() {
 #else
               component.payload_path_,
 #endif
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
               component.installation_index_,
               update_context.update_checker->GetPersistedData(),
               component.id_, component.next_version_.GetString(),

--- a/components/update_client/op_install.cc
+++ b/components/update_client/op_install.cc
@@ -39,7 +39,6 @@
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/cobalt_slot_management.h"
 #include "starboard/extension/installation_manager.h"
-#include "starboard/configuration.h"
 #endif
 
 namespace update_client {
@@ -158,9 +157,9 @@ void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
 #else  // defined(IN_MEMORY_UPDATES)
     if (base::DirectoryExists(crx_operation_result.response.DirName())) {
 #endif  // defined(IN_MEMORY_UPDATES)
-      const auto installation_api =
-        static_cast<const CobaltExtensionInstallationManagerApi*>(
-          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+      const auto* installation_api =
+          static_cast<const CobaltExtensionInstallationManagerApi*>(
+              SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
       if (installation_api) {
         CobaltSlotManagement cobalt_slot_management;
         if (cobalt_slot_management.Init(installation_api)) {
@@ -195,8 +194,9 @@ void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
         IM_EXT_ERROR) {
       LOG(ERROR) << "Failed to get app key.";
       install_error = InstallError::GENERIC_ERROR;
-    } else if (CobaltFinishInstallation(installation_api, crx_operation_result.installation_index,
-                                    result.unpack_path.value(), app_key)) {
+    } else if (CobaltFinishInstallation(
+                   installation_api, crx_operation_result.installation_index,
+                   result.unpack_path.value(), app_key)) {
       // Write the version of the unpacked update package to the persisted data.
       if (metadata != nullptr) {
         base::ThreadPool::PostTask(

--- a/components/update_client/op_install.cc
+++ b/components/update_client/op_install.cc
@@ -36,6 +36,12 @@
 #include "components/update_client/update_client_errors.h"
 #include "third_party/puffin/src/include/puffin/puffpatch.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/cobalt_slot_management.h"
+#include "starboard/extension/installation_manager.h"
+#include "starboard/configuration.h"
+#endif
+
 namespace update_client {
 
 namespace {
@@ -117,6 +123,7 @@ void InstallComplete(
 #endif
 }
 
+#if !BUILDFLAG(IS_STARBOARD)
 // Runs in the blocking thread pool.
 void InstallBlocking(
     CrxInstaller::ProgressCallback progress_callback,
@@ -128,14 +135,40 @@ void InstallBlocking(
   installer->Install(unpack_path, public_key, std::move(install_params),
                      progress_callback, std::move(callback));
 }
+#endif  // !BUILDFLAG(IS_STARBOARD)
 
 // Runs on the original sequence.
 void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
              std::unique_ptr<CrxInstaller::InstallParams> install_params,
              scoped_refptr<CrxInstaller> installer,
              CrxInstaller::ProgressCallback progress_callback,
+#if BUILDFLAG(IS_STARBOARD)
+             PersistedData* metadata,
+             const std::string& next_version,
+             const std::string& id,
+             const OperationResult& crx_operation_result,
+#endif
              const Unpacker::Result& result) {
   if (result.error != UnpackerError::kNone) {
+#if BUILDFLAG(IS_STARBOARD)
+    // When there is an error unpacking the downloaded CRX, such as a failure to
+    // verify the package, we clear out any drain files.
+#if defined(IN_MEMORY_UPDATES)
+    if (base::DirectoryExists(crx_operation_result.installation_dir)) {
+#else  // defined(IN_MEMORY_UPDATES)
+    if (base::DirectoryExists(crx_operation_result.response.DirName())) {
+#endif  // defined(IN_MEMORY_UPDATES)
+      const auto installation_api =
+        static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+      if (installation_api) {
+        CobaltSlotManagement cobalt_slot_management;
+        if (cobalt_slot_management.Init(installation_api)) {
+          cobalt_slot_management.CleanupAllDrainFiles();
+        }
+      }
+    }
+#endif  // #if BUILDFLAG(IS_STARBOARD)
     std::move(callback).Run(
         CrxInstaller::Result({.category = ErrorCategory::kUnpack,
                               .code = static_cast<int>(result.error),
@@ -145,6 +178,40 @@ void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
 
   progress_callback.Run(-1);
 
+#if BUILDFLAG(IS_STARBOARD)
+  InstallError install_error = InstallError::NONE;
+  const CobaltExtensionInstallationManagerApi* installation_api =
+      static_cast<const CobaltExtensionInstallationManagerApi*>(
+          SbSystemGetExtension(kCobaltExtensionInstallationManagerName));
+  if (!installation_api) {
+    LOG(ERROR) << "Failed to get installation manager api.";
+    install_error = InstallError::GENERIC_ERROR;
+  } else if (crx_operation_result.installation_index == IM_EXT_INVALID_INDEX) {
+    LOG(ERROR) << "Installation index is invalid.";
+    install_error = InstallError::GENERIC_ERROR;
+  } else {
+    char app_key[IM_EXT_MAX_APP_KEY_LENGTH];
+    if (installation_api->GetAppKey(app_key, IM_EXT_MAX_APP_KEY_LENGTH) ==
+        IM_EXT_ERROR) {
+      LOG(ERROR) << "Failed to get app key.";
+      install_error = InstallError::GENERIC_ERROR;
+    } else if (CobaltFinishInstallation(installation_api, crx_operation_result.installation_index,
+                                    result.unpack_path.value(), app_key)) {
+      // Write the version of the unpacked update package to the persisted data.
+      if (metadata != nullptr) {
+        base::ThreadPool::PostTask(
+            FROM_HERE, base::BindOnce(
+              &PersistedData::SetLastInstalledEgAndSbVersion,
+              base::Unretained(metadata), id, next_version,
+              std::to_string(SB_API_VERSION)));
+      }
+    } else {
+      LOG(ERROR) << "CobaltFinishInstallation failed.";
+      install_error = InstallError::GENERIC_ERROR;
+    }
+  }
+  std::move(callback).Run(CrxInstaller::Result(install_error));
+#else
   // Prepare the callbacks. Delete unpack_path when the completion
   // callback is called.
   auto checker = base::MakeRefCounted<CallbackChecker>(
@@ -171,6 +238,7 @@ void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
                          base::BindOnce(&CallbackChecker::Done, checker)),
                      result.unpack_path, result.public_key,
                      std::move(install_params), installer));
+#endif
 }
 
 // Runs on the original sequence.
@@ -187,18 +255,22 @@ void Unpack(base::OnceCallback<void(const Unpacker::Result&)> callback,
   if (!cache_result.has_value()) {
     // Caching is optional: continue with the install, but add a task to clean
     // up crx_file.
-    callback = base::BindOnce(
 #if BUILDFLAG(IS_STARBOARD)
+#if !defined(IN_MEMORY_UPDATES)
+    callback = base::BindOnce(
         [](const OperationResult& crx_operation_result,
            base::OnceCallback<void(const Unpacker::Result&)> callback,
            const Unpacker::Result& result) {
           base::ThreadPool::PostTaskAndReply(
               FROM_HERE, kTaskTraits,
-              base::BindOnce(IgnoreResult(&base::DeleteFile), crx_operation_result.response),
+              base::BindOnce(IgnoreResult(&base::DeleteFile),
+                             crx_operation_result.response),
               base::BindOnce(std::move(callback), result));
         },
         crx_operation_result, std::move(callback));
-#else
+#endif  // !defined(IN_MEMORY_UPDATES)
+#else  // BUILDFLAG(IS_STARBOARD)
+    callback = base::BindOnce(
         [](const base::FilePath& crx_file,
            base::OnceCallback<void(const Unpacker::Result&)> callback,
            const Unpacker::Result& result) {
@@ -238,6 +310,10 @@ base::OnceClosure InstallOperation(
     const std::vector<uint8_t>& pk_hash,
     scoped_refptr<CrxInstaller> installer,
     std::unique_ptr<CrxInstaller::InstallParams> install_params,
+#if BUILDFLAG(IS_STARBOARD)
+    PersistedData* metadata,
+    const std::string& next_version,
+#endif
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
     base::RepeatingCallback<void(ComponentState)> state_tracker,
     CrxInstaller::ProgressCallback progress_callback,
@@ -259,7 +335,9 @@ base::OnceClosure InstallOperation(
           base::BindOnce(&InstallComplete, std::move(installer_result_callback),
                          std::move(callback), event_adder,
                          crx_operation_result),
-          std::move(install_params), installer, progress_callback),
+          std::move(install_params), installer, progress_callback,
+          metadata, next_version, id,
+          crx_operation_result),
       crx_operation_result, std::move(unzipper), pk_hash, crx_format,
       base::unexpected(UnpackerError::kCrxCacheNotProvided));
 #else

--- a/components/update_client/op_install.h
+++ b/components/update_client/op_install.h
@@ -19,6 +19,7 @@
 
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/pipeline.h"
+#include "components/update_client/persisted_data.h"
 #endif
 
 namespace base {
@@ -42,6 +43,10 @@ base::OnceClosure InstallOperation(
     const std::vector<uint8_t>& pk_hash,
     scoped_refptr<CrxInstaller> installer,
     std::unique_ptr<CrxInstaller::InstallParams> install_params,
+#if BUILDFLAG(IS_STARBOARD)
+    PersistedData* metadata,
+    const std::string& next_version,
+#endif
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
     base::RepeatingCallback<void(ComponentState)> state_tracker,
     CrxInstaller::ProgressCallback progress_callback,

--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -308,6 +308,10 @@ std::queue<Operation> MakeOperations(
 #if defined(IN_MEMORY_UPDATES)
     std::string* crx_str,
 #endif
+#if BUILDFLAG(IS_STARBOARD)
+    PersistedData* metadata,
+    const std::string& next_version,
+#endif
     base::RepeatingCallback<void(ComponentState)> state_tracker,
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
     CrxDownloader::ProgressCallback download_progress_callback,
@@ -384,6 +388,9 @@ std::queue<Operation> MakeOperations(
               ? nullptr
               : std::make_unique<CrxInstaller::InstallParams>(
                     operation.path, operation.arguments, install_data),
+#if BUILDFLAG(IS_STARBOARD)
+          metadata, next_version,
+#endif
           event_adder, state_tracker, install_progress_callback,
           install_complete_callback));
     } else if (operation.type == "run") {
@@ -425,6 +432,10 @@ void MakePipeline(
     scoped_refptr<CrxInstaller> installer,
 #if defined(IN_MEMORY_UPDATES)
     std::string* crx_str,
+#endif
+#if BUILDFLAG(IS_STARBOARD)
+    PersistedData* metadata,
+    const std::string& next_version,
 #endif
     base::RepeatingCallback<void(ComponentState)> state_tracker,
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
@@ -497,6 +508,10 @@ void MakePipeline(
             crx_format, id, pk_hash, install_data_index, installer,
 #if defined(IN_MEMORY_UPDATES)
             crx_str,
+#endif
+#if BUILDFLAG(IS_STARBOARD)
+            metadata,
+            next_version,
 #endif
             state_tracker,
             base::BindRepeating(

--- a/components/update_client/pipeline.h
+++ b/components/update_client/pipeline.h
@@ -21,6 +21,7 @@
 #if BUILDFLAG(IS_STARBOARD)
 #include "base/files/file_path.h"
 #include "base/memory/raw_ptr.h"
+#include "components/update_client/persisted_data.h"
 #include "starboard/extension/installation_manager.h"
 #else
 namespace base {
@@ -82,6 +83,10 @@ void MakePipeline(
     // This function does not take ownership of `crx_str`, which must refer to a
     // valid string that outlives the created pipeline operations.
     std::string* crx_str,
+#endif
+#if BUILDFLAG(IS_STARBOARD)
+    PersistedData* metadata,
+    const std::string& next_version,
 #endif
     base::RepeatingCallback<void(ComponentState)> state_tracker,
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,

--- a/components/update_client/update_checker.cc
+++ b/components/update_client/update_checker.cc
@@ -62,7 +62,7 @@ class UpdateCheckerImpl : public UpdateChecker {
       const base::flat_map<std::string, std::string>& additional_attributes,
       UpdateCheckCallback update_check_callback) override;
 
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
   PersistedData* GetPersistedData() override { return config_->GetPersistedData(); }
   void Cancel() override;
   bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override;
@@ -227,7 +227,7 @@ void UpdateCheckerImpl::CheckForUpdatesHelper(
     for (auto i = range.first; i != range.second; i++) {
       cached_hashes.push_back(i->second);
     }
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
     base::Version current_version = crx_component->version;
 
     // Check if there is an available update already for quick roll-forward
@@ -349,7 +349,7 @@ void UpdateCheckerImpl::CheckForUpdatesHelper(
 #endif
 }
 
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
 void UpdateCheckerImpl::Cancel() {
   // TODO(b/448186580): Replace LOG with D(V)LOG
   LOG(INFO) << "UpdateCheckerImpl::Cancel";

--- a/components/update_client/update_checker.h
+++ b/components/update_client/update_checker.h
@@ -50,7 +50,7 @@ class UpdateChecker {
       const base::flat_map<std::string, std::string>& additional_attributes,
       UpdateCheckCallback update_check_callback) = 0;
 
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
   virtual void Cancel() = 0;
   virtual bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) = 0;
 #endif
@@ -58,7 +58,7 @@ class UpdateChecker {
   static std::unique_ptr<UpdateChecker> Create(
       scoped_refptr<Configurator> config);
 
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
   virtual PersistedData* GetPersistedData() = 0;
 #endif
  protected:

--- a/components/update_client/url_fetcher_downloader.cc
+++ b/components/update_client/url_fetcher_downloader.cc
@@ -83,7 +83,7 @@ UrlFetcherDownloader::UrlFetcherDownloader(
 UrlFetcherDownloader::~UrlFetcherDownloader() = default;
 
 
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
 #if defined(IN_MEMORY_UPDATES)
 void UrlFetcherDownloader::ConfirmSlot(const GURL& url, std::string* dst) {
 #else  // defined(IN_MEMORY_UPDATES)
@@ -151,7 +151,7 @@ base::OnceClosure UrlFetcherDownloader::DoStartDownload(const GURL& url, std::st
 base::OnceClosure UrlFetcherDownloader::DoStartDownload(const GURL& url) {
 #endif  // defined(IN_MEMORY_UPDATES)
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
   LOG(INFO) << "UrlFetcherDownloader::DoStartDownload";
   if (is_cancelled_) {
     LOG(ERROR) << "UrlFetcherDownloader::DoStartDownload: Download already cancelled";
@@ -206,7 +206,7 @@ void UrlFetcherDownloader::CreateDownloadDir() {
 }
 #endif
 
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
 void UrlFetcherDownloader::ReportDownloadFailure(const GURL& url,
                                                  CrxDownloaderError error) {
   LOG(INFO) << "UrlFetcherDownloader::ReportDownloadFailure";                                                
@@ -368,7 +368,7 @@ void UrlFetcherDownloader::OnNetworkFetcherComplete(int net_error,
 #else
     result.response = file_path_;
 #endif
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
     result.installation_index = cobalt_slot_management_.GetInstallationIndex();
 #endif
   }

--- a/components/update_client/url_fetcher_downloader.h
+++ b/components/update_client/url_fetcher_downloader.h
@@ -93,7 +93,7 @@ class UrlFetcherDownloader : public CrxDownloader {
   void OnDownloadProgress(int64_t content_length);
   void Cancel();
 
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
   void ReportDownloadFailure(const GURL& url, CrxDownloaderError error);
 #endif
 
@@ -124,7 +124,7 @@ class UrlFetcherDownloader : public CrxDownloader {
   int64_t total_bytes_ = -1;
 
 #if BUILDFLAG(IS_STARBOARD)
-#if BUILDFLAG(USE_EVERGREEN)
+#if BUILDFLAG(IS_STARBOARD)
   CobaltSlotManagement cobalt_slot_management_;
 #endif
   scoped_refptr<Configurator> config_;

--- a/components/update_client/url_fetcher_downloader.h
+++ b/components/update_client/url_fetcher_downloader.h
@@ -124,9 +124,7 @@ class UrlFetcherDownloader : public CrxDownloader {
   int64_t total_bytes_ = -1;
 
 #if BUILDFLAG(IS_STARBOARD)
-#if BUILDFLAG(IS_STARBOARD)
   CobaltSlotManagement cobalt_slot_management_;
-#endif
   scoped_refptr<Configurator> config_;
   // This variable tracks a Cancel() being called: all subsequent
   // download requests will be ignored.


### PR DESCRIPTION
This change introduces logic to finalize installations using the Starboard
API and ensures proper cleanup of installation artifacts, such as drain
files, if unpacking fails. It also persists the installed Evergreen and
Starboard API versions, enabling better tracking of system state.

Issue: 479816505