### PR TITLE
[tvOS] Update provisioning profiles dir to Xcode 16+

### DIFF
--- a/cobalt/devinfra/kokoro/bin/build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/build_mac.sh
@@ -60,9 +60,9 @@ pipeline () {
 
 setup_mac () {
   # Pull signing profiles.
-  mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+  mkdir -p "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
   cp -f ${KOKORO_PIPER_DIR}/google3/googlemac/iPhone/Shared/ProvisioningProfiles/*.mobileprovision \
-      "$HOME/Library/MobileDevice/Provisioning Profiles"
+      "$HOME/Library/Developer/Xcode/UserData/Provisioning Profiles"
 
   export DEVELOPER_DIR="/Applications/Xcode_${XCODE_VERSION}.app/Contents/Developer"
 


### PR DESCRIPTION
Old dir was for Xcode 15-

Bug: 495549526