### PR TITLE
cobalt: Enable Image Splash Screen by Default

### DIFF
--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -193,9 +193,8 @@ Shell::Shell(std::unique_ptr<WebContents> web_contents,
       splash_state_(STATE_SPLASH_SCREEN_UNINITIALIZED),
       splash_topic_(topic),
       skip_for_testing_(skip_for_testing),
-      is_video_splash_screen_(
-          !base::CommandLine::ForCurrentProcess()->HasSwitch(
-              switches::kForceImageSplashScreen)) {
+      is_video_splash_screen_(base::CommandLine::ForCurrentProcess()->HasSwitch(
+          switches::kForceVideoSplashScreen)) {
   if (should_set_delegate) {
     web_contents_->SetDelegate(this);
   }

--- a/cobalt/shell/common/shell_switches.cc
+++ b/cobalt/shell/common/shell_switches.cc
@@ -40,8 +40,8 @@ const char kContentShellHostWindowSize[] = "content-shell-host-window-size";
 // Hides toolbar from content_shell's host window.
 const char kContentShellHideToolbar[] = "content-shell-hide-toolbar";
 
-// Force to display a static image as splash screen.
-const char kForceImageSplashScreen[] = "force-image-splash-screen";
+// Forces the display of a video as the splash screen.
+const char kForceVideoSplashScreen[] = "force-video-splash-screen";
 
 // Enables APIs guarded with the [IsolatedContext] IDL attribute for the given
 // comma-separated list of origins.

--- a/cobalt/shell/common/shell_switches.h
+++ b/cobalt/shell/common/shell_switches.h
@@ -35,7 +35,7 @@ extern const char kDisableSplashScreen[];
 extern const char kDisableSystemFontCheck[];
 extern const char kContentShellHostWindowSize[];
 extern const char kContentShellHideToolbar[];
-extern const char kForceImageSplashScreen[];
+extern const char kForceVideoSplashScreen[];
 extern const char kIsolatedContextOrigins[];
 extern const char kOmitDeviceAuthenticationQueryParameters[];
 extern const char kRemoteDebuggingAddress[];


### PR DESCRIPTION
Make the image-based splash screen the default.

Previously, the shell would default to a video splash screen unless the
kForceImageSplashScreen command-line switch was provided. This change
inverts the default behavior, so an image splash screen is now used
unless kForceVideoSplashScreen is explicitly enabled. This aligns with
the goal of providing a consistent and lightweight initial experience.

Issue: 501467378