### PR TITLE
android: Remove deprecated AImageReader flag

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -100,9 +100,6 @@ public final class CommandLineOverrideHelper {
     public static StringJoiner getDefaultDisableFeatureOverridesList() {
         StringJoiner paramOverrides = new StringJoiner(",");
 
-        // Use SurfaceTexture for decode-to-texture mode.
-        paramOverrides.add("AImageReader");
-
         // Disable BackupRefPtr and have shim allocator tracked by MemoryReclaimer.
         paramOverrides.add("PartitionAllocBackupRefPtr");
 


### PR DESCRIPTION
Remove the explicit disabling of the AImageReader feature on Android.
Chromium on Android now uses AImageReader for texture mode by default,
deprecating the SurfaceTexture-based texture mode.

See https://chromium-review.git.corp.google.com/c/chromium/src/+/6701329.

Issue: 500463665