### PR TITLE
evergreen: Render OpenGL texture in red channel

### DIFF
--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -7,6 +7,13 @@ since the version previous to it.
 
 **NOTE: Starboard versions 16 and older are no longer supported.**
 
+## Version 18
+
+### Support decode-to-texture mode
+Implementations of `DecodeTarget` for YUV planes should ensure they use
+`GL_RED_EXT` or `GL_LUMINANCE` instead of `GL_ALPHA` to avoid green-screen
+rendering issues caused by Chromium's shader expectations.
+
 ## Version 17
 Starboard 17 fully switches to POSIX APIs.
 

--- a/starboard/linux/shared/decode_target_internal.cc
+++ b/starboard/linux/shared/decode_target_internal.cc
@@ -88,7 +88,7 @@ void CreateTargetFromVideoFrameWithContextRunner(void* context) {
         target_info.planes[plane_index].height == video_frame_plane.height) {
       // No need to reallocate texture object, only update pixels.
       GL_CALL(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, video_frame_plane.width,
-                              video_frame_plane.height, GL_ALPHA,
+                              video_frame_plane.height, GL_RED_EXT,
                               GL_UNSIGNED_BYTE, video_frame_plane.data));
 
     } else {
@@ -100,9 +100,10 @@ void CreateTargetFromVideoFrameWithContextRunner(void* context) {
       GL_CALL(
           glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
 
-      GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_ALPHA, video_frame_plane.width,
-                           video_frame_plane.height, 0, GL_ALPHA,
-                           GL_UNSIGNED_BYTE, video_frame_plane.data));
+      GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RED_EXT,
+                           video_frame_plane.width, video_frame_plane.height, 0,
+                           GL_RED_EXT, GL_UNSIGNED_BYTE,
+                           video_frame_plane.data));
     }
 
     GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0));


### PR DESCRIPTION
This change updates the OpenGL texture format from GL_ALPHA to GL_RED_EXT
when creating and updating single-channel textures for video frames.
Previously, single-plane video data was incorrectly interpreted as alpha,
leading to improper rendering within Chromium display pipeline.
Using GL_RED_EXT ensures that the texture data is correctly
interpreted as brightness, facilitating proper color mapping and display
of video content.

This is required for decode-to-texture mode on 3P devices.
See https://github.com/youtube/cobalt/pull/9979.

Issue: 501495783