### PR TITLE
android: Fix crash at VideoSurfaceTextureBridge::CreateSurface

### DIFF
--- a/starboard/android/shared/decode_target.cc
+++ b/starboard/android/shared/decode_target.cc
@@ -85,9 +85,8 @@ void DecodeTarget::CreateOnContextRunner() {
 
   // We will also need an Android Surface object in order to obtain a
   // ANativeWindow object that we can pass into the AMediaCodec library.
-  surface_ =
-      VideoSurfaceTextureBridge::CreateSurface(env, surface_texture_.obj());
-  SB_CHECK(surface_texture_);
+  surface_ = VideoSurfaceTextureBridge::CreateSurface(env, surface_texture_);
+  SB_CHECK(surface_);
 
   native_window_ = ANativeWindow_fromSurface(env, surface_.obj());
 

--- a/starboard/android/shared/decode_target.h
+++ b/starboard/android/shared/decode_target.h
@@ -32,8 +32,12 @@ class DecodeTarget final : public SbDecodeTargetPrivate {
 
   bool GetInfo(SbDecodeTargetInfo* out_info) final;
 
-  jobject surface_texture() const { return surface_texture_.obj(); }
-  jobject surface() const { return surface_.obj(); }
+  const base::android::ScopedJavaGlobalRef<jobject>& surface_texture() const {
+    return surface_texture_;
+  }
+  const base::android::ScopedJavaGlobalRef<jobject>& surface() const {
+    return surface_;
+  }
 
   void set_dimension(const Size& size) {
     info_.planes[0].width = size.width;

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -758,13 +758,11 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       if (!SbDecodeTargetIsValid(decode_target)) {
         return Failure("Could not acquire a decode target from provider.");
       }
-      j_output_surface = decode_target->surface();
+      j_output_surface = decode_target->surface().obj();
 
       JNIEnv* env = AttachCurrentThread();
-      ScopedJavaLocalRef<jobject> surface_texture(
-          env, decode_target->surface_texture());
-      bridge_->SetOnFrameAvailableListener(
-          env, JavaParamRef<jobject>(env, surface_texture.obj()));
+      bridge_->SetOnFrameAvailableListener(env,
+                                           decode_target->surface_texture());
 
       std::lock_guard lock(decode_target_mutex_);
       decode_target_ = decode_target;
@@ -837,10 +835,8 @@ void MediaCodecVideoDecoder::TeardownCodec() {
       // Remove OnFrameAvailableListener to make sure the callback
       // would not be called.
       JNIEnv* env = AttachCurrentThread();
-      ScopedJavaLocalRef<jobject> surface_texture(
-          env, decode_target_->surface_texture());
       bridge_->RemoveOnFrameAvailableListener(
-          env, JavaParamRef<jobject>(env, surface_texture.obj()));
+          env, decode_target_->surface_texture());
 
       decode_target_to_release = decode_target_;
       decode_target_ = nullptr;
@@ -1050,22 +1046,21 @@ bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
 
 namespace {
 
-void updateTexImage(jobject surface_texture) {
+void updateTexImage(const base::android::JavaRef<jobject>& surface_texture) {
   JNIEnv* env = AttachCurrentThread();
 
-  VideoSurfaceTextureBridge::UpdateTexImage(
-      env, JavaParamRef<jobject>(env, surface_texture));
+  VideoSurfaceTextureBridge::UpdateTexImage(env, surface_texture);
 }
 
-void getTransformMatrix(jobject surface_texture, float* matrix4x4) {
+void getTransformMatrix(const base::android::JavaRef<jobject>& surface_texture,
+                        float* matrix4x4) {
   JNIEnv* env = AttachCurrentThread();
 
   jfloatArray java_array = env->NewFloatArray(16);
   SB_CHECK(java_array);
 
   VideoSurfaceTextureBridge::GetTransformMatrix(
-      env, JavaParamRef<jobject>(env, surface_texture),
-      JavaParamRef<jfloatArray>(env, java_array));
+      env, surface_texture, JavaParamRef<jfloatArray>(env, java_array));
 
   jfloat* array_values = env->GetFloatArrayElements(java_array, 0);
   memcpy(matrix4x4, array_values, sizeof(float) * 16);

--- a/starboard/android/shared/video_surface_texture_bridge.cc
+++ b/starboard/android/shared/video_surface_texture_bridge.cc
@@ -25,14 +25,14 @@ using base::android::ScopedJavaLocalRef;
 
 void VideoSurfaceTextureBridge::SetOnFrameAvailableListener(
     JNIEnv* env,
-    const JavaParamRef<jobject>& surface_texture) const {
+    const base::android::JavaRef<jobject>& surface_texture) const {
   Java_VideoSurfaceTexture_setOnFrameAvailableListener(
       env, surface_texture, reinterpret_cast<jlong>(this));
 }
 
 void VideoSurfaceTextureBridge::RemoveOnFrameAvailableListener(
     JNIEnv* env,
-    const JavaParamRef<jobject>& surface_texture) const {
+    const base::android::JavaRef<jobject>& surface_texture) const {
   Java_VideoSurfaceTexture_removeOnFrameAvailableListener(env, surface_texture);
 }
 
@@ -48,22 +48,22 @@ VideoSurfaceTextureBridge::CreateVideoSurfaceTexture(JNIEnv* env,
 // static
 ScopedJavaGlobalRef<jobject> VideoSurfaceTextureBridge::CreateSurface(
     JNIEnv* env,
-    jobject surface_texture) {
-  return ScopedJavaGlobalRef<jobject>(Java_VideoSurfaceTexture_createSurface(
-      env, ScopedJavaLocalRef<jobject>(env, surface_texture)));
+    const base::android::JavaRef<jobject>& surface_texture) {
+  return ScopedJavaGlobalRef<jobject>(
+      Java_VideoSurfaceTexture_createSurface(env, surface_texture));
 }
 
 // static
 void VideoSurfaceTextureBridge::UpdateTexImage(
     JNIEnv* env,
-    const JavaParamRef<jobject>& surface_texture) {
+    const base::android::JavaRef<jobject>& surface_texture) {
   Java_VideoSurfaceTexture_updateTexImage(env, surface_texture);
 }
 
 // static
 void VideoSurfaceTextureBridge::GetTransformMatrix(
     JNIEnv* env,
-    const JavaParamRef<jobject>& surface_texture,
+    const base::android::JavaRef<jobject>& surface_texture,
     const base::android::JavaParamRef<jfloatArray>& mtx) {
   Java_VideoSurfaceTexture_getTransformMatrix(env, surface_texture, mtx);
 }

--- a/starboard/android/shared/video_surface_texture_bridge.h
+++ b/starboard/android/shared/video_surface_texture_bridge.h
@@ -44,24 +44,24 @@ class VideoSurfaceTextureBridge {
 
   void SetOnFrameAvailableListener(
       JNIEnv* env,
-      const base::android::JavaParamRef<jobject>& surface_texture) const;
+      const base::android::JavaRef<jobject>& surface_texture) const;
   void RemoveOnFrameAvailableListener(
       JNIEnv* env,
-      const base::android::JavaParamRef<jobject>& surface_texture) const;
+      const base::android::JavaRef<jobject>& surface_texture) const;
 
   static base::android::ScopedJavaGlobalRef<jobject> CreateVideoSurfaceTexture(
       JNIEnv* env,
       int gl_texture_id);
   static base::android::ScopedJavaGlobalRef<jobject> CreateSurface(
       JNIEnv* env,
-      jobject surface_texture);
+      const base::android::JavaRef<jobject>& surface_texture);
 
   static void UpdateTexImage(
       JNIEnv* env,
-      const base::android::JavaParamRef<jobject>& surface_texture);
+      const base::android::JavaRef<jobject>& surface_texture);
   static void GetTransformMatrix(
       JNIEnv* env,
-      const base::android::JavaParamRef<jobject>& surface_texture,
+      const base::android::JavaRef<jobject>& surface_texture,
       const base::android::JavaParamRef<jfloatArray>& mtx);
 
   void OnFrameAvailable(JNIEnv*) { host_->OnFrameAvailable(); }


### PR DESCRIPTION
Update JNI calls for SurfaceTexture and Surface objects to use a
persistent global reference. Previously, calls used raw jobject or
temporary local references, which could lead to the underlying Java
object being garbage collected or invalid JNI references. This caused
crashes, particularly during Surface creation.

Ensure Java object references are correctly managed to prevent use-
after-free or null pointer issues in JNI interactions. Also, correct
the SB_CHECK to validate the created surface object itself.

#vibe-coded

Issue: 417242469
Issue: 500429244