### PR TITLE
cobalt/metrics: refractor MetricsPollingState class

### DIFF
--- a/cobalt/browser/metrics/cobalt_cpu_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_cpu_metrics_emitter.cc
@@ -23,7 +23,9 @@
 
 namespace cobalt {
 
-CobaltCpuMetricsEmitter::CobaltCpuMetricsEmitter() = default;
+CobaltCpuMetricsEmitter::CobaltCpuMetricsEmitter() {
+  DETACH_FROM_SEQUENCE(sequence_checker_);
+}
 
 CobaltCpuMetricsEmitter::~CobaltCpuMetricsEmitter() = default;
 

--- a/cobalt/browser/metrics/cobalt_cpu_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_cpu_metrics_emitter.cc
@@ -27,17 +27,17 @@ CobaltCpuMetricsEmitter::CobaltCpuMetricsEmitter() = default;
 
 CobaltCpuMetricsEmitter::~CobaltCpuMetricsEmitter() = default;
 
-void CobaltCpuMetricsEmitter::FetchAndEmitCpuMetrics(
-    base::ProcessMetrics* process_metrics) {
+void CobaltCpuMetricsEmitter::FetchAndEmitCpuMetrics() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  if (!process_metrics) {
-    return;
+
+  if (!process_metrics_) {
+    process_metrics_ = base::ProcessMetrics::CreateCurrentProcessMetrics();
   }
 
   // Total CPU utilization in percentage of all cores in between every call.
   constexpr double kInvalidCPUUsageValue = 0.0;
   const double cpu_usage =
-      process_metrics->GetPlatformIndependentCPUUsage().value_or(
+      process_metrics_->GetPlatformIndependentCPUUsage().value_or(
           kInvalidCPUUsageValue);
 
   const int num_processors = base::SysInfo::NumberOfProcessors();

--- a/cobalt/browser/metrics/cobalt_cpu_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_cpu_metrics_emitter.cc
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 
-#include "base/check_op.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/system/sys_info.h"
@@ -24,6 +23,9 @@
 namespace cobalt {
 
 CobaltCpuMetricsEmitter::CobaltCpuMetricsEmitter() {
+  // The emitter is created on the main thread but will be used
+  // on a background sequence maintained by base::SequenceBound
+  // in CobaltMetricsServiceClient.
   DETACH_FROM_SEQUENCE(sequence_checker_);
 }
 
@@ -34,6 +36,10 @@ void CobaltCpuMetricsEmitter::FetchAndEmitCpuMetrics() {
 
   if (!process_metrics_) {
     process_metrics_ = base::ProcessMetrics::CreateCurrentProcessMetrics();
+  }
+
+  if (!process_metrics_) {
+    return;
   }
 
   // Total CPU utilization in percentage of all cores in between every call.

--- a/cobalt/browser/metrics/cobalt_cpu_metrics_emitter.h
+++ b/cobalt/browser/metrics/cobalt_cpu_metrics_emitter.h
@@ -25,10 +25,9 @@ namespace cobalt {
 
 // This class fetches CPU metrics for the current process and its threads and
 // records the average per-core CPU usage as a percentage in a UMA histogram.
-// It relies on a persistent base::ProcessMetrics object (tracked by
-// CobaltMetricsServiceClient::CpuPollingState) to maintain stateful CPU usage
-// tracking across multiple calls. This class is not thread-safe and must be
-// called from the same Sequence it was created on.
+// It relies on a persistent base::ProcessMetrics object to maintain stateful
+// CPU usage tracking across multiple calls. This class is not thread-safe and
+// must be called from the same Sequence it was created on.
 class CobaltCpuMetricsEmitter
     : public base::RefCountedThreadSafe<CobaltCpuMetricsEmitter> {
  public:
@@ -37,7 +36,7 @@ class CobaltCpuMetricsEmitter
   CobaltCpuMetricsEmitter(const CobaltCpuMetricsEmitter&) = delete;
   CobaltCpuMetricsEmitter& operator=(const CobaltCpuMetricsEmitter&) = delete;
 
-  void FetchAndEmitCpuMetrics(base::ProcessMetrics* process_metrics);
+  void FetchAndEmitCpuMetrics();
 
  protected:
   // TODO(b/492251096): add tests for CPU metrics emitter class
@@ -45,6 +44,8 @@ class CobaltCpuMetricsEmitter
 
  private:
   friend class base::RefCountedThreadSafe<CobaltCpuMetricsEmitter>;
+
+  std::unique_ptr<base::ProcessMetrics> process_metrics_;
 
   SEQUENCE_CHECKER(sequence_checker_);
 };

--- a/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
@@ -211,7 +211,9 @@ static const char* MetricSizeToVersionSuffix(
 
 }  // namespace
 
-CobaltMemoryMetricsEmitter::CobaltMemoryMetricsEmitter() = default;
+CobaltMemoryMetricsEmitter::CobaltMemoryMetricsEmitter() {
+  DETACH_FROM_SEQUENCE(sequence_checker_);
+}
 
 void CobaltMemoryMetricsEmitter::FetchAndEmitProcessMemoryMetrics() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);

--- a/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
@@ -212,6 +212,9 @@ static const char* MetricSizeToVersionSuffix(
 }  // namespace
 
 CobaltMemoryMetricsEmitter::CobaltMemoryMetricsEmitter() {
+  // The emitter is created on the main thread but will be used
+  // on a background sequence maintained by base::SequenceBound
+  // in CobaltMetricsServiceClient.
   DETACH_FROM_SEQUENCE(sequence_checker_);
 }
 

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.cc
@@ -19,9 +19,6 @@
 
 #include "base/command_line.h"
 #include "base/logging.h"
-#include "base/memory/raw_ptr.h"
-#include "base/notreached.h"
-#include "base/posix/file_descriptor_shuffle.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.cc
@@ -100,7 +100,6 @@ class CobaltMetricsServiceClient::CpuPollingState : public MetricsPollingState {
   scoped_refptr<CobaltCpuMetricsEmitter> cpu_emitter_;
 };
 
-
 CobaltMetricsServiceClient::CobaltMetricsServiceClient(
     metrics::MetricsStateManager* state_manager,
     std::unique_ptr<variations::SyntheticTrialRegistry>

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.cc
@@ -25,7 +25,8 @@
 #include "base/strings/string_number_conversions.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
-#include "base/time/time.h"
+#include "base/threading/sequence_bound.h"
+#include "base/timer/timer.h"
 #include "base/version.h"
 #include "cobalt/browser/metrics/cobalt_cpu_metrics_emitter.h"
 #include "cobalt/browser/metrics/cobalt_memory_metrics_emitter.h"
@@ -41,28 +42,12 @@
 
 namespace cobalt {
 
-// TODO(b/495528560): Fix ownership model in MetricsPollingState to separate CPU
-// and memory metrics polling
-class MetricsPollingState
-    : public base::RefCountedThreadSafe<MetricsPollingState> {
+class MetricsPollingState {
  public:
-  explicit MetricsPollingState(CobaltMetricsServiceClient* parent)
-      : parent_(parent) {}
-
-  // Parent pointer.
-  raw_ptr<CobaltMetricsServiceClient> parent_;
-
-  // Task runner for background metrics collection.
-  scoped_refptr<base::SequencedTaskRunner> task_runner;
-
-  // Flag to stop logging.
-  bool stop_logging = false;
+  MetricsPollingState() = default;
+  virtual ~MetricsPollingState() = default;
 
   void RecordMetricsAfterDelay() {
-    if (stop_logging) {
-      return;
-    }
-
     base::TimeDelta delay = memory_instrumentation::GetDelayForNextMemoryLog();
     const base::CommandLine* command_line =
         base::CommandLine::ForCurrentProcess();
@@ -77,55 +62,44 @@ class MetricsPollingState
       }
     }
 
-    task_runner->PostDelayedTask(
-        FROM_HERE,
-        base::BindOnce(&MetricsPollingState::RequestMetrics,
-                       base::RetainedRef(this)),
-        delay);
+    timer_.Start(FROM_HERE, delay, this, &MetricsPollingState::RequestMetrics);
   }
 
   virtual void RequestMetrics() = 0;
 
- protected:
-  friend class base::RefCountedThreadSafe<MetricsPollingState>;
-  virtual ~MetricsPollingState() = default;
+ private:
+  base::OneShotTimer timer_;
 };
 
 class CobaltMetricsServiceClient::MemoryPollingState
     : public MetricsPollingState {
  public:
-  using MetricsPollingState::MetricsPollingState;
+  explicit MemoryPollingState(
+      scoped_refptr<CobaltMemoryMetricsEmitter> memory_emitter)
+      : memory_emitter_(std::move(memory_emitter)) {}
 
   void RequestMetrics() override {
-    if (stop_logging) {
-      return;
-    }
-
-    parent_->CreateMemoryMetricsEmitter()->FetchAndEmitProcessMemoryMetrics();
+    memory_emitter_->FetchAndEmitProcessMemoryMetrics();
     RecordMetricsAfterDelay();
   }
-};
 
+ private:
+  scoped_refptr<CobaltMemoryMetricsEmitter> memory_emitter_;
+};
 class CobaltMetricsServiceClient::CpuPollingState : public MetricsPollingState {
  public:
-  using MetricsPollingState::MetricsPollingState;
-
-  std::unique_ptr<base::ProcessMetrics> process_metrics_;
+  explicit CpuPollingState(scoped_refptr<CobaltCpuMetricsEmitter> cpu_emitter)
+      : cpu_emitter_(std::move(cpu_emitter)) {}
 
   void RequestMetrics() override {
-    if (stop_logging) {
-      return;
-    }
-
-    if (!process_metrics_) {
-      process_metrics_ = base::ProcessMetrics::CreateCurrentProcessMetrics();
-    }
-
-    parent_->CreateCpuMetricsEmitter()->FetchAndEmitCpuMetrics(
-        process_metrics_.get());
+    cpu_emitter_->FetchAndEmitCpuMetrics();
     RecordMetricsAfterDelay();
   }
+
+ private:
+  scoped_refptr<CobaltCpuMetricsEmitter> cpu_emitter_;
 };
+
 
 CobaltMetricsServiceClient::CobaltMetricsServiceClient(
     metrics::MetricsStateManager* state_manager,
@@ -153,20 +127,16 @@ void CobaltMetricsServiceClient::Initialize() {
 
 void CobaltMetricsServiceClient::StartMemoryMetricsLogger() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  memory_state_ = base::MakeRefCounted<MemoryPollingState>(this);
-  memory_state_->task_runner = base::ThreadPool::CreateSequencedTaskRunner({});
-  memory_state_->task_runner->PostTask(
-      FROM_HERE, base::BindOnce(&MemoryPollingState::RecordMetricsAfterDelay,
-                                base::RetainedRef(memory_state_)));
+  memory_state_.emplace(base::ThreadPool::CreateSequencedTaskRunner({}),
+                        CreateMemoryMetricsEmitter());
+  memory_state_.AsyncCall(&MemoryPollingState::RecordMetricsAfterDelay);
 }
 
 void CobaltMetricsServiceClient::StartCpuMetricsLogger() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  cpu_state_ = base::MakeRefCounted<CpuPollingState>(this);
-  cpu_state_->task_runner = base::ThreadPool::CreateSequencedTaskRunner({});
-  cpu_state_->task_runner->PostTask(
-      FROM_HERE, base::BindOnce(&CpuPollingState::RecordMetricsAfterDelay,
-                                base::RetainedRef(cpu_state_)));
+  cpu_state_.emplace(base::ThreadPool::CreateSequencedTaskRunner({}),
+                     CreateCpuMetricsEmitter());
+  cpu_state_.AsyncCall(&CpuPollingState::RecordMetricsAfterDelay);
 }
 
 void CobaltMetricsServiceClient::StartIdleRefreshTimer() {
@@ -366,16 +336,7 @@ void CobaltMetricsServiceClient::SetUploadInterval(base::TimeDelta interval) {
   StartIdleRefreshTimer();
 }
 
-CobaltMetricsServiceClient::~CobaltMetricsServiceClient() {
-  if (memory_state_) {
-    memory_state_->stop_logging = true;
-    memory_state_->parent_ = nullptr;
-  }
-  if (cpu_state_) {
-    cpu_state_->stop_logging = true;
-    cpu_state_->parent_ = nullptr;
-  }
-}
+CobaltMetricsServiceClient::~CobaltMetricsServiceClient() = default;
 
 void CobaltMetricsServiceClient::SetMetricsListener(
     ::mojo::PendingRemote<::h5vcc_metrics::mojom::MetricsListener> listener) {

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.h
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.h
@@ -19,6 +19,7 @@
 #include <string_view>
 
 #include "base/memory/weak_ptr.h"
+#include "base/threading/sequence_bound.h"
 #include "base/time/time.h"
 #include "cobalt/browser/metrics/cobalt_cpu_metrics_emitter.h"
 #include "cobalt/browser/metrics/cobalt_memory_metrics_emitter.h"
@@ -171,8 +172,8 @@ class CobaltMetricsServiceClient : public metrics::MetricsServiceClient {
   base::TimeDelta min_idle_refresh_interval_ = kMinIdleRefreshInterval;
 
   // State objects for background metrics collection.
-  scoped_refptr<MemoryPollingState> memory_state_;
-  scoped_refptr<CpuPollingState> cpu_state_;
+  base::SequenceBound<MemoryPollingState> memory_state_;
+  base::SequenceBound<CpuPollingState> cpu_state_;
 
   // Usually `log_uploader_` would be created lazily in CreateUploader() (during
   // first metrics upload), however there's a race condition of many seconds


### PR DESCRIPTION
Refactor the MetricsPollingState and its derived classes to improve
ownership and thread-safety.
- Make MetricsPollingState objects base::SequenceBound
- Move ownership of metrics emitters to MetricPollingState subclasses
- Maintain state of ProcessMetrics instance inside cpu emitter class
- Emitters are now created once with the initialization of 
CobaltMetricsServiceClient object instead of creating every time when 
metrics are requested.

Bug: 495528560