### PR TITLE
feat(starboard): Add prctl wrapper for VMA naming

### DIFF
--- a/base/allocator/dispatcher/tls.cc
+++ b/base/allocator/dispatcher/tls.cc
@@ -16,7 +16,7 @@
 #include "base/immediate_crash.h"
 #include "build/build_config.h"
 
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_ANDROID) || (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_STARBOARD))
 #include <sys/prctl.h>
 #endif
 
@@ -51,7 +51,7 @@ void Swap(std::atomic_bool& lh_op, std::atomic_bool& rh_op) {
 void* MMapAllocator::AllocateMemory(size_t size_in_bytes) {
   void* const mmap_res = mmap(nullptr, size_in_bytes, PROT_READ | PROT_WRITE,
                               MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_ANDROID) || (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_STARBOARD))
 #if defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
   if (mmap_res != MAP_FAILED) {
     // Allow the anonymous memory region allocated by mmap(MAP_ANONYMOUS) to

--- a/base/memory/madv_free_discardable_memory_posix.cc
+++ b/base/memory/madv_free_discardable_memory_posix.cc
@@ -30,7 +30,7 @@
 #include "base/tracing_buildflags.h"
 #include "build/build_config.h"
 
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)
 #include <sys/prctl.h>
 #endif
 
@@ -49,7 +49,7 @@ void* AllocatePages(size_t size_in_pages) {
                     MAP_ANONYMOUS | MAP_PRIVATE, -1, 0);
   PCHECK(data != MAP_FAILED);
 
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)
   prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, data, length,
         "madv-free-discardable");
 #endif

--- a/base/metrics/persistent_memory_allocator.cc
+++ b/base/metrics/persistent_memory_allocator.cc
@@ -35,7 +35,7 @@
 #include "base/win/winbase_shim.h"
 #elif BUILDFLAG(IS_POSIX) || BUILDFLAG(IS_FUCHSIA)
 #include <sys/mman.h>
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)
 #include <sys/prctl.h>
 #endif
 #endif
@@ -1097,7 +1097,7 @@ LocalPersistentMemoryAllocator::AllocateLocalMemory(size_t size,
   address = ::mmap(nullptr, size, PROT_READ | PROT_WRITE, MAP_ANON | MAP_SHARED,
                    -1, 0);
   if (address != MAP_FAILED) {
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_STARBOARD)
     // Allow the anonymous memory region allocated by mmap(MAP_ANON) to be
     // identified in /proc/$PID/smaps.  This helps improve visibility into
     // Chrome's memory usage on Android.

--- a/copied_base/base/allocator/partition_allocator/page_allocator_internals_posix.h
+++ b/copied_base/base/allocator/partition_allocator/page_allocator_internals_posix.h
@@ -35,7 +35,7 @@
 #include <Security/Security.h>
 #include <mach/mach.h>
 #endif
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_ANDROID) || (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_STARBOARD))
 #include <sys/prctl.h>
 #endif
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS)
@@ -62,7 +62,7 @@ namespace partition_alloc::internal {
 
 namespace {
 
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_ANDROID) || (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_STARBOARD))
 #if defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
 const char* PageTagToName(PageTag tag) {
   // Important: All the names should be string literals. As per prctl.h in
@@ -86,7 +86,7 @@ const char* PageTagToName(PageTag tag) {
   }
 }
 #endif
-#endif  // BUILDFLAG(IS_ANDROID)
+#endif  // BUILDFLAG(IS_ANDROID) || (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_STARBOARD))
 
 #if BUILDFLAG(IS_MAC)
 // Tests whether the version of macOS supports the MAP_JIT flag and if the
@@ -197,7 +197,7 @@ uintptr_t SystemAllocPagesInternal(uintptr_t hint,
     ret = nullptr;
   }
 
-#if BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_ANDROID) || (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_STARBOARD))
 #if defined(PR_SET_VMA) && defined(PR_SET_VMA_ANON_NAME)
   // On Android and Linux, anonymous mappings can have a name attached to them.
   // This is useful for debugging, and double-checking memory attribution.

--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -235,6 +235,7 @@ ExportedSymbols::ExportedSymbols() {
 
   // POSIX APIs
   REGISTER_SYMBOL(aligned_alloc);
+  REGISTER_SYMBOL(atexit);
   REGISTER_SYMBOL(calloc);
   REGISTER_SYMBOL(close);
   REGISTER_SYMBOL(fdatasync);

--- a/starboard/nplb/posix_compliance/posix_prctl_test.cc
+++ b/starboard/nplb/posix_compliance/posix_prctl_test.cc
@@ -12,14 +12,27 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "starboard/shared/modular/starboard_layer_posix_prctl_abi_wrappers.h"
+
 #include <errno.h>
 #include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <string.h>
 #include <sys/prctl.h>
 #include <sys/resource.h>
 #include <unistd.h>
 
+#include "starboard/common/log.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+// From third_party/musl/include/sys/prctl.h
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+#ifndef PR_SET_VMA_ANON_NAME
+#define PR_SET_VMA_ANON_NAME 0
+#endif
 
 namespace nplb {
 namespace {
@@ -525,6 +538,122 @@ TEST_F(PosixPrctlPtracerTests, SetFailsWithInvalidValue) {
   EXPECT_EQ(-1, prctl(PR_SET_PTRACER, -100000));
   EXPECT_EQ(EINVAL, errno) << "Expected EINVAL for invalid value, but got: "
                            << errno << " (" << strerror(errno) << ")";
+}
+
+const char kVmaName[] = "TestVmaName";
+
+// Checks /proc/self/maps to see if the memory mapping containing |addr| has
+// the specified |name|. This is the expected outcome when the kernel supports
+// PR_SET_VMA_ANON_NAME.
+bool VmaIsNamed(void* addr, const char* name) {
+  FILE* fp = fopen("/proc/self/maps", "r");
+  if (!fp) {
+    // If we can't open /proc/self/maps, we can't verify.
+    // Assume it's not named and let the fallback check proceed.
+    return false;
+  }
+
+  char line[1024];
+  bool found = false;
+  unsigned long target_addr = (unsigned long)addr;
+
+  while (fgets(line, sizeof(line), fp)) {
+    unsigned long start, end;
+    if (sscanf(line, "%lx-%lx", &start, &end) != 2) {
+      continue;
+    }
+    if (target_addr >= start && target_addr < end) {
+      if (strstr(line, name)) {
+        found = true;
+      }
+      // We found the mapping containing our address, so we can stop.
+      // If it's not named here, it's not named.
+      break;
+    }
+  }
+
+  fclose(fp);
+  return found;
+}
+
+// Checks for the existence and content of the fallback file. This is the
+// expected outcome when the kernel does NOT support PR_SET_VMA_ANON_NAME.
+bool FallbackFileIsCorrect(unsigned long start,
+                           unsigned long size,
+                           const char* name) {
+  char file_path[256];
+  snprintf(file_path, sizeof(file_path), "/tmp/cobalt_vma_tags_%d.txt",
+           getpid());
+
+  FILE* fp = fopen(file_path, "r");
+  if (!fp) {
+    return false;
+  }
+
+  char line[1024];
+  bool found = false;
+  while (fgets(line, sizeof(line), fp)) {
+    unsigned long file_start, file_end;
+    char file_name[256];
+    // The format is "0x%lx 0x%lx %s\n"
+    if (sscanf(line, "0x%lx 0x%lx %s", &file_start, &file_end, file_name) ==
+        3) {
+      if (file_start == start && file_end == start + size &&
+          strcmp(file_name, name) == 0) {
+        found = true;
+        break;
+      }
+    }
+  }
+
+  fclose(fp);
+  return found;
+}
+
+// This test verifies that __abi_wrap_prctl with PR_SET_VMA and
+// PR_SET_VMA_ANON_NAME correctly names a VMA region, either by calling the
+// underlying prctl syscall or by using the fallback mechanism of writing to a
+// file.
+TEST(PosixPrctlTest, SetVmaAnonName) {
+  const size_t kMapSize = 4096;
+  void* p = malloc(kMapSize);
+  ASSERT_NE(p, nullptr);
+
+  // Ensure we have a clean state by deleting any leftover fallback file.
+  char file_path[256];
+  snprintf(file_path, sizeof(file_path), "/tmp/cobalt_vma_tags_%d.txt",
+           getpid());
+  unlink(file_path);
+
+  int result =
+      __abi_wrap_prctl(PR_SET_VMA, PR_SET_VMA_ANON_NAME, (unsigned long)p,
+                       kMapSize, (unsigned long)kVmaName);
+
+  // The wrapper should return 0 on success, for both the prctl call and the
+  // fallback.
+  EXPECT_EQ(result, 0);
+
+  bool vma_is_named = VmaIsNamed(p, kVmaName);
+  bool fallback_file_is_correct =
+      FallbackFileIsCorrect((unsigned long)p, kMapSize, kVmaName);
+
+  // We expect one of the two mechanisms to have worked.
+  EXPECT_TRUE(vma_is_named || fallback_file_is_correct)
+      << "VMA name was not set via prctl and fallback file was not created or "
+         "is incorrect.";
+
+  if (vma_is_named) {
+    SB_LOG(INFO) << "VMA naming with PR_SET_VMA_ANON_NAME is supported by the "
+                    "kernel.";
+  }
+  if (fallback_file_is_correct) {
+    SB_LOG(INFO) << "VMA naming with PR_SET_VMA_ANON_NAME is NOT supported by "
+                    "the kernel, fallback was used.";
+  }
+
+  free(p);
+  // Clean up the fallback file if it was created.
+  unlink(file_path);
 }
 
 }  // namespace

--- a/starboard/shared/modular/BUILD.gn
+++ b/starboard/shared/modular/BUILD.gn
@@ -67,6 +67,7 @@ if ((sb_is_modular || sb_is_evergreen_compatible) &&
 
     deps = [
       "//starboard:starboard_headers_only",
+      "//starboard/common",
       "//starboard/common:common_headers_only",
     ]
   }

--- a/starboard/shared/modular/cobalt_layer_posix_prctl_abi_wrappers.cc
+++ b/starboard/shared/modular/cobalt_layer_posix_prctl_abi_wrappers.cc
@@ -12,73 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <errno.h>
 #include <stdarg.h>
 #include <sys/prctl.h>
 
 extern "C" {
 
-int __abi_wrap_prctl(int op, ...);
+int __abi_wrap_prctl(int option,
+                     unsigned long arg2,
+                     unsigned long arg3,
+                     unsigned long arg4,
+                     unsigned long arg5);
 
-int prctl(int op, ...) {
-  int result;
-  va_list ap;
-  va_start(ap, op);
-  switch (op) {
-    // The following commands have a long second argument.
-    case PR_SET_PDEATHSIG:
-    case PR_SET_DUMPABLE:
-    case PR_SET_KEEPCAPS:
-    case PR_SET_TIMING:
-
-// The man-pages specify that this operation only exist on x86 platforms.
-#if defined(PR_SET_TSC)
-    case PR_SET_TSC:
-#endif
-    case PR_SET_PTRACER: {
-      result = __abi_wrap_prctl(op, va_arg(ap, long));
-      break;
-    }
-    // The following commands have an unsigned long second argument.
-    case PR_SET_TIMERSLACK: {
-      result = __abi_wrap_prctl(op, va_arg(ap, unsigned long));
-      break;
-    }
-    // The following commands have an int* second argument.
-    case PR_GET_PDEATHSIG:
-// The man-pages specify that this operation only exist on x86 platforms.
-#if defined(PR_GET_TSC)
-    case PR_GET_TSC:
-#endif  // defined(PR_GET_TSC)
-    {
-      result = __abi_wrap_prctl(op, va_arg(ap, int*));
-      break;
-    }
-    // The following commands have a char[] second argument.
-    case PR_SET_NAME:
-    case PR_GET_NAME: {
-      result = __abi_wrap_prctl(op, va_arg(ap, char*));
-      break;
-    }
-    // The following commands have no additional arguments;
-    case PR_GET_DUMPABLE:
-    case PR_GET_KEEPCAPS:
-    case PR_GET_TIMING:
-    case PR_GET_TIMERSLACK:
-    case PR_TASK_PERF_EVENTS_DISABLE:
-    case PR_TASK_PERF_EVENTS_ENABLE: {
-      result = __abi_wrap_prctl(op);
-      break;
-    }
-    // The given operation is not supported. Set errno to EINVAL and return
-    // -1.
-    default: {
-      errno = EINVAL;
-      result = -1;
-    }
-  }
-
-  va_end(ap);
-  return result;
+int prctl(int option, ...) {
+  va_list args;
+  va_start(args, option);
+  unsigned long arg2 = va_arg(args, unsigned long);
+  unsigned long arg3 = va_arg(args, unsigned long);
+  unsigned long arg4 = va_arg(args, unsigned long);
+  unsigned long arg5 = va_arg(args, unsigned long);
+  va_end(args);
+  return __abi_wrap_prctl(option, arg2, arg3, arg4, arg5);
 }
+
 }  // extern "C"

--- a/starboard/shared/modular/starboard_layer_posix_prctl_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_prctl_abi_wrappers.cc
@@ -15,12 +15,40 @@
 #include "starboard/shared/modular/starboard_layer_posix_prctl_abi_wrappers.h"
 
 #include <errno.h>
+#include <fcntl.h>
 #include <linux/prctl.h>
 #include <signal.h>
-#include <stdarg.h>
+#include <stdio.h>
+#include <stdlib.h>
 #include <sys/prctl.h>
+#include <sys/syscall.h>
+#include <unistd.h>
 
 #include "starboard/common/log.h"
+#include "starboard/common/string.h"
+
+// From third_party/musl/include/sys/prctl.h
+#ifndef PR_SET_VMA
+#define PR_SET_VMA 0x53564d41
+#endif
+#ifndef PR_SET_VMA_ANON_NAME
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+
+namespace {
+void VmaTagFileCleanup() {
+  char file_path[256];
+  snprintf(file_path, sizeof(file_path), "/tmp/cobalt_vma_tags_%d.txt",
+           getpid());
+  unlink(file_path);
+}
+
+void VmaTagSignalHandler(int signum) {
+  VmaTagFileCleanup();
+  // Re-raise signal to get default behavior (e.g. core dump).
+  signal(signum, SIG_DFL);
+  raise(signum);
+}
 
 int musl_op_to_platform_op(int musl_op) {
   switch (musl_op) {
@@ -61,6 +89,8 @@ int musl_op_to_platform_op(int musl_op) {
       return PR_TASK_PERF_EVENTS_ENABLE;
     case MUSL_PR_SET_PTRACER:
       return PR_SET_PTRACER;
+    case MUSL_PR_SET_VMA:
+      return PR_SET_VMA;
     default:
       SB_LOG(WARNING) << "Unknown musl prctl operation: " << musl_op;
       errno = EINVAL;
@@ -126,22 +156,24 @@ int platform_tsc_to_musl_tsc(int platform_tsc) {
       return -1;
   }
 }
+}  // namespace
 
-int __abi_wrap_prctl(int op, ...) {
-  int platform_op = musl_op_to_platform_op(op);
+SB_EXPORT int __abi_wrap_prctl(int option,
+                               unsigned long arg2,
+                               unsigned long arg3,
+                               unsigned long arg4,
+                               unsigned long arg5) {
+  int platform_op = musl_op_to_platform_op(option);
 
   if (platform_op == -1) {
     return -1;
   }
 
-  va_list args;
-  va_start(args, op);
-
   int ret = -1;
 
   switch (platform_op) {
     case PR_SET_PDEATHSIG: {
-      long sig = va_arg(args, long);
+      long sig = (long)arg2;
       if (sig >= 0 && sig < NSIG) {
         ret = prctl(platform_op, sig);
       } else {
@@ -150,7 +182,7 @@ int __abi_wrap_prctl(int op, ...) {
       break;
     }
     case PR_GET_PDEATHSIG: {
-      int* sig = va_arg(args, int*);
+      int* sig = (int*)arg2;
       if (sig) {
         ret = prctl(platform_op, sig);
       } else {
@@ -159,7 +191,7 @@ int __abi_wrap_prctl(int op, ...) {
       break;
     }
     case PR_SET_DUMPABLE: {
-      long dumpable = va_arg(args, long);
+      long dumpable = (long)arg2;
       if (dumpable == 0L || dumpable == 1L) {
         ret = prctl(platform_op, dumpable);
       } else {
@@ -172,7 +204,7 @@ int __abi_wrap_prctl(int op, ...) {
       break;
     }
     case PR_SET_KEEPCAPS: {
-      long keepcaps = va_arg(args, long);
+      long keepcaps = (long)arg2;
       if (keepcaps == 0L || keepcaps == 1L) {
         ret = prctl(platform_op, keepcaps);
       } else {
@@ -192,7 +224,7 @@ int __abi_wrap_prctl(int op, ...) {
       break;
     }
     case PR_SET_TIMING: {
-      long flag = va_arg(args, long);
+      long flag = (long)arg2;
       long platform_flag = musl_timing_to_platform_timing(flag);
 
       // According to the man-pages, PR_TIMING_TIMESTAMP is not implemented and
@@ -206,7 +238,7 @@ int __abi_wrap_prctl(int op, ...) {
       break;
     }
     case PR_SET_NAME: {
-      char* name = va_arg(args, char*);
+      char* name = (char*)arg2;
       if (name) {
         ret = prctl(platform_op, name);
       } else {
@@ -218,7 +250,7 @@ int __abi_wrap_prctl(int op, ...) {
     // be "const char name[16]", but this seems incorrect as we need to write
     // into the buffer. For PR_GET_NAME, we use just "char*" instead.
     case PR_GET_NAME: {
-      char* name = va_arg(args, char*);
+      char* name = (char*)arg2;
       if (name) {
         ret = prctl(platform_op, name);
       } else {
@@ -229,7 +261,7 @@ int __abi_wrap_prctl(int op, ...) {
 // The man-pages specify that these operations only exist on x86 platforms.
 #if defined(PR_SET_TSC) && defined(PR_GET_TSC)
     case PR_GET_TSC: {
-      int* tsc = va_arg(args, int*);
+      int* tsc = (int*)arg2;
       if (tsc) {
         int platform_tsc = 0;
         ret = prctl(platform_op, &platform_tsc);
@@ -247,7 +279,7 @@ int __abi_wrap_prctl(int op, ...) {
       break;
     }
     case PR_SET_TSC: {
-      long tsc = va_arg(args, long);
+      long tsc = (long)arg2;
       long platform_tsc = musl_tsc_to_platform_tsc(tsc);
       if (platform_tsc != -1) {
         ret = prctl(platform_op, platform_tsc);
@@ -260,7 +292,7 @@ int __abi_wrap_prctl(int op, ...) {
       break;
     }
     case PR_SET_TIMERSLACK: {
-      unsigned long new_slack = va_arg(args, unsigned long);
+      unsigned long new_slack = arg2;
       ret = prctl(platform_op, new_slack);
       break;
     }
@@ -273,9 +305,44 @@ int __abi_wrap_prctl(int op, ...) {
       break;
     }
     case PR_SET_PTRACER: {
-      long pid = va_arg(args, long);
-      pid = (pid == MUSL_PR_SET_PTRACER_ANY) ? PR_SET_PTRACER_ANY : pid;
+      long pid = (long)arg2;
+      pid = (pid == (long)MUSL_PR_SET_PTRACER_ANY) ? PR_SET_PTRACER_ANY : pid;
       ret = prctl(platform_op, pid);
+      break;
+    }
+    case PR_SET_VMA: {
+      ret = prctl(platform_op, arg2, arg3, arg4, arg5);
+      if (ret == -1 && errno == EINVAL && arg2 == PR_SET_VMA_ANON_NAME) {
+        // Kernel does not support PR_SET_VMA_ANON_NAME. Fallback to writing to a
+        // file.
+        char file_path[256];
+        snprintf(file_path, sizeof(file_path), "/tmp/cobalt_vma_tags_%d.txt",
+                 getpid());
+
+        FILE* file = fopen(file_path, "a");
+        if (file) {
+          static bool cleanup_registered = false;
+          if (!cleanup_registered) {
+            atexit(VmaTagFileCleanup);
+            // Also register signal handlers for common crash signals.
+            // This is not a perfect solution as it can interfere with
+            // application signal handlers and does not handle SIGKILL.
+            signal(SIGSEGV, VmaTagSignalHandler);
+            signal(SIGABRT, VmaTagSignalHandler);
+            signal(SIGTERM, VmaTagSignalHandler);
+            signal(SIGQUIT, VmaTagSignalHandler);
+            signal(SIGINT, VmaTagSignalHandler);
+            cleanup_registered = true;
+          }
+          fprintf(file, "0x%lx 0x%lx %s\n", arg3, arg3 + arg4,
+                  (const char*)arg5);
+          fclose(file);
+          return 0;  // Success for our fallback.
+        } else {
+          SB_LOG(ERROR) << "Failed to open VMA tag file: " << file_path;
+          // Fall through to return original error.
+        }
+      }
       break;
     }
     // This default case shouldn't be reachable; if we weren't able to convert
@@ -289,6 +356,5 @@ int __abi_wrap_prctl(int op, ...) {
     }
   }
 
-  va_end(args);
   return ret;
 }

--- a/starboard/shared/modular/starboard_layer_posix_prctl_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_prctl_abi_wrappers.h
@@ -39,12 +39,18 @@
 #define MUSL_PR_TASK_PERF_EVENTS_ENABLE 32
 #define MUSL_PR_SET_PTRACER 0x59616d61
 #define MUSL_PR_SET_PTRACER_ANY (-1UL)
+#define MUSL_PR_SET_VMA 0x53564d41
+#define MUSL_PR_SET_VMA_ANON_NAME 0
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
-SB_EXPORT int __abi_wrap_prctl(int op, ...);
+SB_EXPORT int __abi_wrap_prctl(int option,
+                               unsigned long arg2,
+                               unsigned long arg3,
+                               unsigned long arg4,
+                               unsigned long arg5);
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/third_party/musl/include/sys/prctl.h
+++ b/third_party/musl/include/sys/prctl.h
@@ -177,6 +177,14 @@ struct prctl_mm_map {
 #define PR_PAC_SET_ENABLED_KEYS 60
 #define PR_PAC_GET_ENABLED_KEYS 61
 
+#if !defined(PR_SET_VMA)
+#define PR_SET_VMA 0x53564d41
+#endif
+
+#if !defined(PR_SET_VMA_ANON_NAME)
+#define PR_SET_VMA_ANON_NAME 0
+#endif
+
 int prctl (int, ...);
 
 #ifdef __cplusplus


### PR DESCRIPTION
This change introduces a wrapper for the `prctl` system call to support naming Virtual Memory Areas (VMAs) using `PR_SET_VMA_ANON_NAME`.

When the underlying kernel does not support this feature, the wrapper provides a fallback mechanism that writes the VMA information to a temporary file (`/tmp/cobalt_vma_tags_<pid>.txt`). This allows for memory debugging and attribution even on systems without the latest kernel features.

A new NPLB test, `PosixPrctlTest.SetVmaAnonName`, has been added to verify both the direct `prctl` call and the fallback mechanism.

The `prctl` wrapper is now used in various parts of the codebase, including the partition allocator and persistent memory allocator, under the `IS_STARBOARD` build flag.

Bug: 443798603