### PR TITLE
BACKPORT: jni_generator: Allow stub GEN_JNI generation from .py instead of annotation processor

### DIFF
--- a/copied_base/base/BUILD.gn
+++ b/copied_base/base/BUILD.gn
@@ -1377,7 +1377,11 @@ component("base") {
       "android/trace_event_binding.cc",
       "android/trace_event_binding.h",
     ]
-    deps += [":base_jni_headers"]
+
+    deps += [
+      ":base_jni",
+      ":process_launcher_jni",
+    ]
   }  # is_android || is_robolectric
 
   # Chromeos.
@@ -2990,7 +2994,7 @@ source_set("base_stack_sampling_profiler_test_util") {
       "profiler/stack_sampling_profiler_java_test_util.h",
     ]
     deps += [
-      ":base_profiler_test_support_jni_headers",
+      ":base_profiler_test_support_jni",
       ":native_unwinder_android",
     ]
   }
@@ -3794,7 +3798,7 @@ test("base_unittests") {
       deps += [
         ":base_profiler_reparsing_test_support_library",
         ":base_profiler_test_support_java",
-        ":base_profiler_test_support_jni_headers",
+        ":base_profiler_test_support_jni",
         ":base_profiler_test_support_library",
         ":native_unwinder_android",
       ]
@@ -4193,7 +4197,7 @@ action("build_date") {
 }
 
 if (is_android || is_robolectric) {
-  generate_jni("base_jni_headers") {
+  generate_jni("base_jni") {
     sources = [
       "android/java/src/org/chromium/base/ApkAssets.java",
       "android/java/src/org/chromium/base/ApplicationStatus.java",
@@ -4233,7 +4237,6 @@ if (is_android || is_robolectric) {
       "android/java/src/org/chromium/base/memory/MemoryInfoBridge.java",
       "android/java/src/org/chromium/base/metrics/NativeUmaRecorder.java",
       "android/java/src/org/chromium/base/metrics/StatisticsRecorderAndroid.java",
-      "android/java/src/org/chromium/base/process_launcher/ChildProcessService.java",
       "android/java/src/org/chromium/base/task/PostTask.java",
       "android/java/src/org/chromium/base/task/TaskRunnerImpl.java",
     ]
@@ -4251,6 +4254,12 @@ if (is_android || is_robolectric) {
   generate_jar_jni("android_runtime_unchecked_jni_headers") {
     classes = [ "java/lang/Runnable.class" ]
     unchecked_exceptions = true
+  }
+
+  generate_jni("process_launcher_jni") {
+    sources = [
+      "android/java/src/org/chromium/base/process_launcher/ChildProcessService.java",
+    ]
   }
 }  # is_android || is_robolectric
 
@@ -4295,7 +4304,10 @@ if (is_android) {
   }
 
   android_library("process_launcher_java") {
-    srcjar_deps = [ ":process_launcher_aidl" ]
+    srcjar_deps = [
+      ":process_launcher_aidl",
+      ":process_launcher_jni",
+    ]
     deps = [
       ":base_java",
       ":jni_java",
@@ -4320,13 +4332,12 @@ if (is_android) {
       "android/java/src/org/chromium/base/process_launcher/ChildServiceConnectionImpl.java",
       "android/java/src/org/chromium/base/process_launcher/FileDescriptorInfo.java",
     ]
-
-    annotation_processor_deps = [ "//copied_base/base/android/jni_generator:jni_processor" ]
   }
 
   android_library("base_java") {
     srcjar_deps = [
       ":base_android_java_enums_srcjar",
+      ":base_jni",
       ":java_features_srcjar",
       ":java_switches_srcjar",
     ]
@@ -4465,8 +4476,6 @@ if (is_android) {
       sources += [ "android/java/src/org/chromium/base/IntentUtils.java" ]
     }
 
-    annotation_processor_deps = [ "//copied_base/base/android/jni_generator:jni_processor" ]
-
     resources_package = "org.chromium.base"
 
     proguard_configs = [
@@ -4531,19 +4540,19 @@ if (is_android) {
       "android/javatests/src/org/chromium/base/util/GarbageCollectionTestUtilsTest.java",
     ]
 
-    annotation_processor_deps = [ "//copied_base/base/android/jni_generator:jni_processor" ]
+    srcjar_deps = [ ":base_javatests_jni" ]
   }
 
   source_set("base_javatests_lib") {
     testonly = true
     deps = [
       ":base",
-      ":base_javatests_jni_headers",
+      ":base_javatests_jni",
     ]
     sources = [ "test/library_loader/early_native_test_helper.cc" ]
   }
 
-  generate_jni("base_javatests_jni_headers") {
+  generate_jni("base_javatests_jni") {
     testonly = true
     sources = [ "android/javatests/src/org/chromium/base/library_loader/EarlyNativeTest.java" ]
   }
@@ -4561,7 +4570,6 @@ if (is_android) {
       "//third_party/androidx:androidx_annotation_annotation_java",
       "//third_party/junit:junit",
     ]
-    annotation_processor_deps = [ "//copied_base/base/android/jni_generator:jni_processor" ]
   }
 
   android_library("base_java_test_support") {
@@ -4662,7 +4670,14 @@ if (is_android) {
       "test/android/javatests/src/org/chromium/base/test/util/TimeoutTimer.java",
       "test/android/javatests/src/org/chromium/base/test/util/UserActionTester.java",
     ]
-    annotation_processor_deps = [ "//copied_base/base/android/jni_generator:jni_processor" ]
+  }
+
+  generate_jni("base_java_test_support_uncommon_jni") {
+    testonly = true
+    sources = [
+      "test/android/javatests/src/org/chromium/base/test/ReachedCodeProfiler.java",
+      "test/android/javatests/src/org/chromium/base/test/task/ThreadPoolTestHelpers.java",
+    ]
   }
 
   android_library("base_java_test_support_uncommon") {
@@ -4677,6 +4692,7 @@ if (is_android) {
       "//third_party/junit:junit",
     ]
 
+    srcjar_deps = [ ":base_java_test_support_uncommon_jni" ]
     sources = [
       "test/android/javatests/src/org/chromium/base/FakeTimeTestRule.java",
       "test/android/javatests/src/org/chromium/base/test/BundleTestRule.java",
@@ -4689,8 +4705,6 @@ if (is_android) {
       "test/android/javatests/src/org/chromium/base/test/util/InstrumentationUtils.java",
       "test/android/javatests/src/org/chromium/base/test/util/Matchers.java",
     ]
-
-    annotation_processor_deps = [ "//copied_base/base/android/jni_generator:jni_processor" ]
   }
 
   android_library("base_java_process_launcher_test_support") {
@@ -4809,7 +4823,7 @@ if (is_android) {
     }
   }
 
-  generate_jni("base_profiler_test_support_jni_headers") {
+  generate_jni("base_profiler_test_support_jni") {
     testonly = true
     sources =
         [ "android/javatests/src/org/chromium/base/profiler/TestSupport.java" ]
@@ -4820,7 +4834,7 @@ if (is_android) {
     sources =
         [ "android/javatests/src/org/chromium/base/profiler/TestSupport.java" ]
 
-    annotation_processor_deps = [ "//copied_base/base/android/jni_generator:jni_processor" ]
+    srcjar_deps = [ ":base_profiler_test_support_jni" ]
 
     deps = [
       "//copied_base/base:jni_java",

--- a/copied_base/base/android/apk_assets.cc
+++ b/copied_base/base/android/apk_assets.cc
@@ -9,7 +9,7 @@
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
 #include "base/android/scoped_java_ref.h"
-#include "base/base_jni_headers/ApkAssets_jni.h"
+#include "base/base_jni/ApkAssets_jni.h"
 #include "base/file_descriptor_store.h"
 
 namespace base {

--- a/copied_base/base/android/application_status_listener.cc
+++ b/copied_base/base/android/application_status_listener.cc
@@ -6,7 +6,7 @@
 
 #include <jni.h>
 
-#include "base/base_jni_headers/ApplicationStatus_jni.h"
+#include "base/base_jni/ApplicationStatus_jni.h"
 #include "base/functional/callback.h"
 #include "base/lazy_instance.h"
 #include "base/metrics/user_metrics.h"

--- a/copied_base/base/android/base_feature_list.cc
+++ b/copied_base/base/android/base_feature_list.cc
@@ -4,7 +4,7 @@
 
 #include "base/android/base_features.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/BaseFeatureList_jni.h"
+#include "base/base_jni/BaseFeatureList_jni.h"
 #include "base/feature_list.h"
 #include "base/notreached.h"
 

--- a/copied_base/base/android/build_info.cc
+++ b/copied_base/base/android/build_info.cc
@@ -9,7 +9,7 @@
 #include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "base/android/scoped_java_ref.h"
-#include "base/base_jni_headers/BuildInfo_jni.h"
+#include "base/base_jni/BuildInfo_jni.h"
 #include "base/check_op.h"
 #include "base/memory/singleton.h"
 #include "base/notreached.h"

--- a/copied_base/base/android/bundle_utils.cc
+++ b/copied_base/base/android/bundle_utils.cc
@@ -9,7 +9,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/BundleUtils_jni.h"
+#include "base/base_jni/BundleUtils_jni.h"
 #include "base/check.h"
 #include "base/files/file_path.h"
 #include "base/notreached.h"

--- a/copied_base/base/android/callback_android.cc
+++ b/copied_base/base/android/callback_android.cc
@@ -7,7 +7,7 @@
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
 #include "base/android/scoped_java_ref.h"
-#include "base/base_jni_headers/Callback_jni.h"
+#include "base/base_jni/Callback_jni.h"
 #include "base/time/time.h"
 
 namespace base {

--- a/copied_base/base/android/child_process_service.cc
+++ b/copied_base/base/android/child_process_service.cc
@@ -5,11 +5,11 @@
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
 #include "base/android/library_loader/library_loader_hooks.h"
-#include "base/base_jni_headers/ChildProcessService_jni.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/file_descriptor_store.h"
 #include "base/logging.h"
 #include "base/posix/global_descriptors.h"
+#include "base/process_launcher_jni/ChildProcessService_jni.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 using base::android::JavaIntArrayToIntVector;

--- a/copied_base/base/android/command_line_android.cc
+++ b/copied_base/base/android/command_line_android.cc
@@ -4,7 +4,7 @@
 
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/CommandLine_jni.h"
+#include "base/base_jni/CommandLine_jni.h"
 #include "base/command_line.h"
 
 using base::android::ConvertUTF8ToJavaString;

--- a/copied_base/base/android/content_uri_utils.cc
+++ b/copied_base/base/android/content_uri_utils.cc
@@ -6,7 +6,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/ContentUriUtils_jni.h"
+#include "base/base_jni/ContentUriUtils_jni.h"
 
 using base::android::ConvertUTF8ToJavaString;
 using base::android::ScopedJavaLocalRef;

--- a/copied_base/base/android/cpu_features.cc
+++ b/copied_base/base/android/cpu_features.cc
@@ -5,7 +5,7 @@
 #include <cpu-features.h>
 
 #include "base/android/jni_android.h"
-#include "base/base_jni_headers/CpuFeatures_jni.h"
+#include "base/base_jni/CpuFeatures_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/early_trace_event_binding.cc
+++ b/copied_base/base/android/early_trace_event_binding.cc
@@ -8,7 +8,7 @@
 
 #include "base/android/jni_string.h"
 #include "base/android/trace_event_binding.h"
-#include "base/base_jni_headers/EarlyTraceEvent_jni.h"
+#include "base/base_jni/EarlyTraceEvent_jni.h"
 #include "base/time/time.h"
 #include "base/trace_event/base_tracing.h"
 #include "base/tracing_buildflags.h"

--- a/copied_base/base/android/event_log.cc
+++ b/copied_base/base/android/event_log.cc
@@ -3,7 +3,7 @@
 // found in the LICENSE file.
 
 #include "base/android/event_log.h"
-#include "base/base_jni_headers/EventLog_jni.h"
+#include "base/base_jni/EventLog_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/feature_list_jni.cc
+++ b/copied_base/base/android/feature_list_jni.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "base/base_jni_headers/FeatureList_jni.h"
+#include "base/base_jni/FeatureList_jni.h"
 #include "base/feature_list.h"
 
 namespace base {

--- a/copied_base/base/android/features_jni.cc
+++ b/copied_base/base/android/features_jni.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "base/base_jni_headers/Features_jni.h"
+#include "base/base_jni/Features_jni.h"
 #include "base/android/jni_string.h"
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"

--- a/copied_base/base/android/field_trial_list.cc
+++ b/copied_base/base/android/field_trial_list.cc
@@ -8,7 +8,7 @@
 #include <string>
 
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/FieldTrialList_jni.h"
+#include "base/base_jni/FieldTrialList_jni.h"
 #include "base/lazy_instance.h"
 #include "base/metrics/field_trial.h"
 #include "base/metrics/field_trial_list_including_low_anonymity.h"

--- a/copied_base/base/android/important_file_writer_android.cc
+++ b/copied_base/base/android/important_file_writer_android.cc
@@ -6,7 +6,7 @@
 
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/ImportantFileWriterAndroid_jni.h"
+#include "base/base_jni/ImportantFileWriterAndroid_jni.h"
 #include "base/files/important_file_writer.h"
 #include "base/threading/thread_restrictions.h"
 

--- a/copied_base/base/android/int_string_callback.cc
+++ b/copied_base/base/android/int_string_callback.cc
@@ -11,7 +11,7 @@
 #include <jni.h>
 
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/IntStringCallback_jni.h"
+#include "base/base_jni/IntStringCallback_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/java_exception_reporter.cc
+++ b/copied_base/base/android/java_exception_reporter.cc
@@ -7,7 +7,7 @@
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
 #include "base/android/scoped_java_ref.h"
-#include "base/base_jni_headers/JavaExceptionReporter_jni.h"
+#include "base/base_jni/JavaExceptionReporter_jni.h"
 #include "base/debug/dump_without_crashing.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"

--- a/copied_base/base/android/java_handler_thread.cc
+++ b/copied_base/base/android/java_handler_thread.cc
@@ -8,7 +8,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/JavaHandlerThread_jni.h"
+#include "base/base_jni/JavaHandlerThread_jni.h"
 #include "base/functional/bind.h"
 #include "base/message_loop/message_pump.h"
 #include "base/message_loop/message_pump_type.h"

--- a/copied_base/base/android/java_heap_dump_generator.cc
+++ b/copied_base/base/android/java_heap_dump_generator.cc
@@ -7,7 +7,7 @@
 #include <jni.h>
 
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/JavaHeapDumpGenerator_jni.h"
+#include "base/base_jni/JavaHeapDumpGenerator_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/jni_android.cc
+++ b/copied_base/base/android/jni_android.cc
@@ -17,7 +17,7 @@
 #include "base/android/java_exception_reporter.h"
 #include "base/android/jni_string.h"
 #include "base/android/jni_utils.h"
-#include "base/base_jni_headers/PiiElider_jni.h"
+#include "base/base_jni/PiiElider_jni.h"
 #include "base/debug/debugging_buildflags.h"
 #include "base/logging.h"
 #include "base/base_switches.h"

--- a/copied_base/base/android/jni_utils.cc
+++ b/copied_base/base/android/jni_utils.cc
@@ -10,7 +10,7 @@
 #include "base/no_destructor.h"
 #include "base/synchronization/lock.h"
 
-#include "base/base_jni_headers/JNIUtils_jni.h"
+#include "base/base_jni/JNIUtils_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/library_loader/library_loader_hooks.cc
+++ b/copied_base/base/android/library_loader/library_loader_hooks.cc
@@ -12,7 +12,7 @@
 #include "base/android/orderfile/orderfile_buildflags.h"
 #include "base/android/sys_utils.h"
 #include "base/at_exit.h"
-#include "base/base_jni_headers/LibraryLoader_jni.h"
+#include "base/base_jni/LibraryLoader_jni.h"
 #include "base/base_switches.h"
 #include "base/metrics/histogram.h"
 #include "base/metrics/histogram_functions.h"

--- a/copied_base/base/android/library_loader/library_prefetcher_hooks.cc
+++ b/copied_base/base/android/library_loader/library_prefetcher_hooks.cc
@@ -10,7 +10,7 @@
 #include "base/android/library_loader/library_loader_hooks.h"
 #include "base/android/library_loader/library_prefetcher.h"
 #include "base/android/scoped_java_ref.h"
-#include "base/base_jni_headers/LibraryPrefetcher_jni.h"
+#include "base/base_jni/LibraryPrefetcher_jni.h"
 #include "base/logging.h"
 
 namespace base {

--- a/copied_base/base/android/locale_utils.cc
+++ b/copied_base/base/android/locale_utils.cc
@@ -6,7 +6,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/LocaleUtils_jni.h"
+#include "base/base_jni/LocaleUtils_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/meminfo_dump_provider.cc
+++ b/copied_base/base/android/meminfo_dump_provider.cc
@@ -10,7 +10,7 @@
 #include "base/trace_event/base_tracing.h"
 
 #if BUILDFLAG(ENABLE_BASE_TRACING)
-#include "base/base_jni_headers/MemoryInfoBridge_jni.h"
+#include "base/base_jni/MemoryInfoBridge_jni.h"
 #endif  // BUILDFLAG(ENABLE_BASE_TRACING)
 
 namespace base::android {

--- a/copied_base/base/android/memory_pressure_listener_android.cc
+++ b/copied_base/base/android/memory_pressure_listener_android.cc
@@ -4,7 +4,7 @@
 
 #include "base/android/memory_pressure_listener_android.h"
 
-#include "base/base_jni_headers/MemoryPressureListener_jni.h"
+#include "base/base_jni/MemoryPressureListener_jni.h"
 #include "base/memory/memory_pressure_listener.h"
 
 using base::android::JavaParamRef;

--- a/copied_base/base/android/native_uma_recorder.cc
+++ b/copied_base/base/android/native_uma_recorder.cc
@@ -6,7 +6,7 @@
 #include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/NativeUmaRecorder_jni.h"
+#include "base/base_jni/NativeUmaRecorder_jni.h"
 #include "base/format_macros.h"
 #include "base/metrics/histogram.h"
 #include "base/metrics/histogram_base.h"

--- a/copied_base/base/android/path_service_android.cc
+++ b/copied_base/base/android/path_service_android.cc
@@ -4,7 +4,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/PathService_jni.h"
+#include "base/base_jni/PathService_jni.h"
 #include "base/files/file_path.h"
 #include "base/path_service.h"
 

--- a/copied_base/base/android/path_utils.cc
+++ b/copied_base/base/android/path_utils.cc
@@ -10,7 +10,7 @@
 #include "base/android/scoped_java_ref.h"
 #include "base/files/file_path.h"
 
-#include "base/base_jni_headers/PathUtils_jni.h"
+#include "base/base_jni/PathUtils_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/radio_utils.cc
+++ b/copied_base/base/android/radio_utils.cc
@@ -4,7 +4,7 @@
 
 #include "base/android/radio_utils.h"
 
-#include "base/base_jni_headers/RadioUtils_jni.h"
+#include "base/base_jni/RadioUtils_jni.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace base {

--- a/copied_base/base/android/statistics_recorder_android.cc
+++ b/copied_base/base/android/statistics_recorder_android.cc
@@ -5,7 +5,7 @@
 #include <string>
 
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/StatisticsRecorderAndroid_jni.h"
+#include "base/base_jni/StatisticsRecorderAndroid_jni.h"
 #include "base/metrics/histogram_base.h"
 #include "base/metrics/statistics_recorder.h"
 #include "base/system/sys_info.h"

--- a/copied_base/base/android/sys_utils.cc
+++ b/copied_base/base/android/sys_utils.cc
@@ -7,7 +7,7 @@
 #include <memory>
 
 #include "base/android/build_info.h"
-#include "base/base_jni_headers/SysUtils_jni.h"
+#include "base/base_jni/SysUtils_jni.h"
 #include "base/process/process_metrics.h"
 #include "base/system/sys_info.h"
 #include "base/trace_event/base_tracing.h"

--- a/copied_base/base/android/task_scheduler/post_task_android.cc
+++ b/copied_base/base/android/task_scheduler/post_task_android.cc
@@ -4,7 +4,7 @@
 
 #include "base/android/task_scheduler/post_task_android.h"
 
-#include "base/base_jni_headers/PostTask_jni.h"
+#include "base/base_jni/PostTask_jni.h"
 
 namespace base {
 

--- a/copied_base/base/android/task_scheduler/task_runner_android.cc
+++ b/copied_base/base/android/task_scheduler/task_runner_android.cc
@@ -10,7 +10,7 @@
 
 #include "base/android/jni_string.h"
 #include "base/android_runtime_unchecked_jni_headers/Runnable_jni.h"
-#include "base/base_jni_headers/TaskRunnerImpl_jni.h"
+#include "base/base_jni/TaskRunnerImpl_jni.h"
 #include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/functional/bind.h"

--- a/copied_base/base/android/timezone_utils.cc
+++ b/copied_base/base/android/timezone_utils.cc
@@ -8,7 +8,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/TimezoneUtils_jni.h"
+#include "base/base_jni/TimezoneUtils_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/trace_event_binding.cc
+++ b/copied_base/base/android/trace_event_binding.cc
@@ -8,7 +8,7 @@
 
 #include "base/android/jni_string.h"
 #include "base/android/trace_event_binding.h"
-#include "base/base_jni_headers/TraceEvent_jni.h"
+#include "base/base_jni/TraceEvent_jni.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/trace_event/base_tracing.h"
 #include "base/tracing_buildflags.h"

--- a/copied_base/base/android/unguessable_token_android.cc
+++ b/copied_base/base/android/unguessable_token_android.cc
@@ -4,7 +4,7 @@
 
 #include "base/android/unguessable_token_android.h"
 
-#include "base/base_jni_headers/UnguessableToken_jni.h"
+#include "base/base_jni/UnguessableToken_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/files/file_util_android.cc
+++ b/copied_base/base/files/file_util_android.cc
@@ -6,7 +6,7 @@
 
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/base_jni_headers/FileUtils_jni.h"
+#include "base/base_jni/FileUtils_jni.h"
 #include "base/files/file_path.h"
 #include "base/path_service.h"
 

--- a/copied_base/base/power_monitor/power_monitor_device_source_android.cc
+++ b/copied_base/base/power_monitor/power_monitor_device_source_android.cc
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "base/base_jni_headers/PowerMonitor_jni.h"
+#include "base/base_jni/PowerMonitor_jni.h"
 #include "base/power_monitor/power_monitor.h"
 #include "base/power_monitor/power_monitor_device_source.h"
 #include "base/power_monitor/power_monitor_source.h"

--- a/copied_base/base/threading/platform_thread_android.cc
+++ b/copied_base/base/threading/platform_thread_android.cc
@@ -11,7 +11,7 @@
 #include <unistd.h>
 
 #include "base/android/jni_android.h"
-#include "base/base_jni_headers/ThreadUtils_jni.h"
+#include "base/base_jni/ThreadUtils_jni.h"
 #include "base/lazy_instance.h"
 #include "base/logging.h"
 #include "base/threading/platform_thread_internal_posix.h"


### PR DESCRIPTION
This change backports part of https://crrev.com/c/4544941, applied to copied_base only; it removes the annotation_processor_deps that was using :jni_processor because :jni_processor depended on auto_service_processor and //copied_base/base is already using jni_zero.

//copied_base/base/android/jni_generator was kept because it is still referenced by WebRTC. But it's no longer used by copied_base.

Bug: 495203133