### PR TITLE
ci: Add max-commits option to autoroll workflow

### DIFF
--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -81,11 +81,15 @@ def main():
   p.add_argument('--target-branch', required=True)
   p.add_argument('--start-commit')
   p.add_argument('--origin-branch', default='main')
+  p.add_argument('--max-commits', type=int)
   args = p.parse_args()
 
   links = []
   target_prs = get_pr_set(args.target_branch, args.origin_branch)
   autoroll_prs = get_pr_set('HEAD', args.origin_branch)
+
+  current_pr_commits = len(autoroll_prs - target_prs)
+  commits_added = 0
 
   for line in get_commits(args.origin_branch, args.target_branch,
                           args.start_commit):
@@ -103,8 +107,15 @@ def main():
 
       # If the PR is not on the current (autoroll) branch, cherry-pick it.
       if num not in autoroll_prs:
+        if (args.max_commits is not None and
+            current_pr_commits + commits_added >= args.max_commits):
+          print(
+              f"::warning::Reached max commits limit ({args.max_commits}).",
+              file=sys.stderr)
+          break
         cherry_pick(sha, num, title)
         autoroll_prs.add(num)
+        commits_added += 1
 
       links.append(f'- #{num}')
 

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -81,18 +81,22 @@ def main():
   p.add_argument('--target-branch', required=True)
   p.add_argument('--start-commit')
   p.add_argument('--origin-branch', default='main')
-  p.add_argument('--max-commits', type=int)
+  p.add_argument('--max-commits', type=int, default=1000)
   args = p.parse_args()
 
   links = []
   target_prs = get_pr_set(args.target_branch, args.origin_branch)
   autoroll_prs = get_pr_set('HEAD', args.origin_branch)
 
-  current_pr_commits = len(autoroll_prs - target_prs)
-  commits_added = 0
+  # Get the number of unmerged commits on the autoroll branch.
+  commits_added = len(autoroll_prs - target_prs)
 
   for line in get_commits(args.origin_branch, args.target_branch,
                           args.start_commit):
+    if commits_added >= args.max_commits:
+      print(f"Reached commit limit ({args.max_commits}).", file=sys.stderr)
+      break
+
     match = re.match(r'^(\w+) (.*) \(#(\d+)\)$', line)
     if match:
       sha, title, pr_num = match.groups()
@@ -107,12 +111,6 @@ def main():
 
       # If the PR is not on the current (autoroll) branch, cherry-pick it.
       if pr_num not in autoroll_prs:
-        if (args.max_commits is not None and
-            current_pr_commits + commits_added >= args.max_commits):
-          print(
-              f"::warning::Reached max commits limit ({args.max_commits}).",
-              file=sys.stderr)
-          break
         cherry_pick(sha, pr_num, title)
         autoroll_prs.add(pr_num)
         commits_added += 1

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -15,9 +15,10 @@ _SKIP_LIST = {
         # Skia import commits, already applied in #9625 (#9624).
         'b77e86a96022541455c239778a4a62462d790c73',
         '8ed51696a04da8b51b82d6540b3b314347c43794',
-        # Change to deleted workflow file (#9670, #9934).
+        # Change to deleted workflow file (#9670, #9934, #10080).
         'f69b1d1e21f3340d9c963846ed4e1cbef8fa2fb9',
         '478e5c52cf4872407ed855a100165e93b02d9eee',
+        '00531389e019a835f49fb3bf56364b244a0d3acd',
     ],
 }
 

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -95,29 +95,29 @@ def main():
                           args.start_commit):
     match = re.match(r'^(\w+) (.*) \(#(\d+)\)$', line)
     if match:
-      sha, title, num = match.groups()
+      sha, title, pr_num = match.groups()
       if any(
           skip_sha.startswith(sha)
           for skip_sha in _SKIP_LIST.get(args.target_branch, [])):
         continue
 
       # Skip if the PR is already in the target branch.
-      if num in target_prs:
+      if pr_num in target_prs:
         continue
 
       # If the PR is not on the current (autoroll) branch, cherry-pick it.
-      if num not in autoroll_prs:
+      if pr_num not in autoroll_prs:
         if (args.max_commits is not None and
             current_pr_commits + commits_added >= args.max_commits):
           print(
               f"::warning::Reached max commits limit ({args.max_commits}).",
               file=sys.stderr)
           break
-        cherry_pick(sha, num, title)
-        autoroll_prs.add(num)
+        cherry_pick(sha, pr_num, title)
+        autoroll_prs.add(pr_num)
         commits_added += 1
 
-      links.append(f'- #{num}')
+      links.append(f'- #{pr_num}')
 
   if links:
     print('\n'.join(links))

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -8,6 +8,10 @@ on:
       start_commit:
         description: 'The commit to start rolling from, should point to the last release chore'
         type: string
+      max_commits:
+        description: 'Max number of commits to include on a single PR'
+        type: number
+        default: 10
 
 permissions:
   contents: read
@@ -63,13 +67,15 @@ jobs:
         env:
           TARGET_BRANCH: 27.lts
           START_COMMIT: ${{ inputs.start_commit }}
+          MAX_COMMITS: ${{ inputs.max_commits || 10 }}
         run: |
           set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
             --target-branch "${TARGET_BRANCH}" \
-            --start-commit "${START_COMMIT}")
+            --start-commit "${START_COMMIT}" \
+            --max-commits "${MAX_COMMITS}")
 
           if [[ -n "${PR_LINKS}" ]]; then
             echo "cherry_picked=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Adds a --max-commits flag to autoroll_lts.py to limit the number of PRs included in a single roll.
Updates the GitHub workflow to support this new parameter.

Bug: 484351320