### PR TITLE
Update sync_chromium_branches workflow

### DIFF
--- a/.github/workflows/sync_chromium_branches.yaml
+++ b/.github/workflows/sync_chromium_branches.yaml
@@ -84,6 +84,12 @@ jobs:
           ref: cherry-pick-main-sync
           fetch-depth: 16
           filter: blob:none
+          token: ${{ secrets.CHERRY_PICK_TOKEN }}
+      - name: Setup Git user
+        if: steps.checkout_cherry_pick_main_sync.outcome == 'success'
+        run: |
+          git config --global user.name "GitHub Release Automation"
+          git config --global user.email "github@google.com"
       - name: Cherry Pick upstream diff to main
         if: steps.checkout_cherry_pick_main_sync.outcome == 'success'
         run: |


### PR DESCRIPTION
The cherry pick PRs generated by the sync_chromium_branches workflow need the correct git user and token to satisfy CLA requirements.

Bug: 481788398