### PR TITLE
Cherry pick PR #9621: android: exit Cobalt upon StarboardBridge.java::requestStop()

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -284,8 +284,14 @@ public class StarboardBridge {
     }
   }
 
-  // TODO(cobalt): remove when Kimono fully switches to Chrobalt.
-  public void requestStop(int errorLevel) {}
+  /* Immediate shutdown, used at least by StandalonePlayerActivity. */
+  public void requestStop(int errorLevel) {
+    applicationStopping();
+    Activity activity = mActivityHolder.get();
+    if (activity != null) {
+      activity.finishAndRemoveTask();
+    }
+  }
 
   public boolean onSearchRequested() {
     return false;


### PR DESCRIPTION
refer to original PR: #9621 

Ensure Cobalt explicitly exits the Android process when StarboardBridge.requestStop() is invoked. Previously, the application process only suspends to the background since the applicationStopped flag is unset. So this change sets the corresponding boolean values by calling applicationStopping to indicate application shutdown and adds System.exit() to guarantee a full application exit.

Bug: 470853890