### PR TITLE
Setting build path to prefix src/.

### DIFF
--- a/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
@@ -5,7 +5,7 @@
 import '../../common.gcl' as common
 
 build = common.build {
-  build_file = 'cobalt/devinfra/kokoro/bin/build_mac.sh'
+  build_file = 'src/cobalt/devinfra/kokoro/bin/build_mac.sh'
   timeout_mins = 300
   before_action = [
     {


### PR DESCRIPTION
Kokoro was not able to find the build script during its run and all other kokoro build configs have a prefixed src/.

Bug: 495549526