### PR TITLE
Add musl statx

### DIFF
--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -256,6 +256,7 @@ _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
     'sprintf',
     'srand',
     'statvfs',
+    'statx',
     'strftime_l',
     'symlink',
     'sysconf',

--- a/starboard/tools/api_leak_detector/evergreen/dev_manifest
+++ b/starboard/tools/api_leak_detector/evergreen/dev_manifest
@@ -17,4 +17,3 @@ inotify_rm_watch
 ioctl
 memfd_create
 sched_setscheduler
-statx

--- a/starboard/tools/api_leak_detector/evergreen/manifest
+++ b/starboard/tools/api_leak_detector/evergreen/manifest
@@ -17,4 +17,3 @@ inotify_rm_watch
 ioctl
 memfd_create
 sched_setscheduler
-statx

--- a/third_party/musl/BUILD.gn
+++ b/third_party/musl/BUILD.gn
@@ -542,6 +542,7 @@ static_library("c_internal") {
     "src/internal/syscall_ret.c",
     "src/legacy/futimes.c",
     "src/legacy/getpagesize.c",
+    "src/linux/statx.c",
     "src/linux/utimes.c",
     "src/locale/strcoll.c",
     "src/locale/strxfrm.c",

--- a/third_party/musl/include/sys/stat.h
+++ b/third_party/musl/include/sys/stat.h
@@ -18,6 +18,13 @@ extern "C" {
 #define __NEED_blkcnt_t
 #define __NEED_struct_timespec
 
+#ifdef _GNU_SOURCE
+#define __NEED_int64_t
+#define __NEED_uint64_t
+#define __NEED_uint32_t
+#define __NEED_uint16_t
+#endif
+
 #include <bits/alltypes.h>
 
 #include <bits/stat.h>
@@ -96,6 +103,79 @@ int lchmod(const char *, mode_t);
 #define S_IREAD S_IRUSR
 #define S_IWRITE S_IWUSR
 #define S_IEXEC S_IXUSR
+#endif
+
+#if defined(_GNU_SOURCE)
+#define STATX_TYPE 1U
+#define STATX_MODE 2U
+#define STATX_NLINK 4U
+#define STATX_UID 8U
+#define STATX_GID 0x10U
+#define STATX_ATIME 0x20U
+#define STATX_MTIME 0x40U
+#define STATX_CTIME 0x80U
+#define STATX_INO 0x100U
+#define STATX_SIZE 0x200U
+#define STATX_BLOCKS 0x400U
+#define STATX_BASIC_STATS 0x7ffU
+#define STATX_BTIME 0x800U
+#define STATX_ALL 0xfffU
+#define STATX_MNT_ID 0x1000U
+#define STATX_DIOALIGN 0x2000U
+#define STATX_MNT_ID_UNIQUE 0x4000U
+#define STATX_SUBVOL 0x8000U
+#define STATX_WRITE_ATOMIC 0x10000U
+
+#define STATX_ATTR_COMPRESSED 0x4
+#define STATX_ATTR_IMMUTABLE 0x10
+#define STATX_ATTR_APPEND 0x20
+#define STATX_ATTR_NODUMP 0x40
+#define STATX_ATTR_ENCRYPTED 0x800
+#define STATX_ATTR_AUTOMOUNT 0x1000
+#define STATX_ATTR_MOUNT_ROOT 0x2000
+#define STATX_ATTR_VERITY 0x100000
+#define STATX_ATTR_DAX 0x200000
+#define STATX_ATTR_WRITE_ATOMIC 0x400000
+
+struct statx_timestamp {
+	int64_t tv_sec;
+	uint32_t tv_nsec, __pad;
+};
+
+struct statx {
+	uint32_t stx_mask;
+	uint32_t stx_blksize;
+	uint64_t stx_attributes;
+	uint32_t stx_nlink;
+	uint32_t stx_uid;
+	uint32_t stx_gid;
+	uint16_t stx_mode;
+	uint16_t __pad0[1];
+	uint64_t stx_ino;
+	uint64_t stx_size;
+	uint64_t stx_blocks;
+	uint64_t stx_attributes_mask;
+	struct statx_timestamp stx_atime;
+	struct statx_timestamp stx_btime;
+	struct statx_timestamp stx_ctime;
+	struct statx_timestamp stx_mtime;
+	uint32_t stx_rdev_major;
+	uint32_t stx_rdev_minor;
+	uint32_t stx_dev_major;
+	uint32_t stx_dev_minor;
+	uint64_t stx_mnt_id;
+	uint32_t stx_dio_mem_align;
+	uint32_t stx_dio_offset_align;
+	uint64_t stx_subvol;
+	uint32_t stx_atomic_write_unit_min;
+	uint32_t stx_atomic_write_unit_max;
+	uint32_t stx_atomic_write_segments_max;
+	uint32_t __pad1[1];
+	uint64_t __pad2[9];
+
+};
+
+int statx(int, const char *__restrict, int, unsigned, struct statx *__restrict);
 #endif
 
 #if defined(_LARGEFILE64_SOURCE)

--- a/third_party/musl/src/linux/statx.c
+++ b/third_party/musl/src/linux/statx.c
@@ -16,7 +16,7 @@ int statx(int dirfd, const char *restrict path, int flags, unsigned mask, struct
 
 	if (ret != -ENOSYS) return __syscall_ret(ret);
 #else  // defined(STARBOARD)
-  int ret = 0;
+	int ret = 0;
 #endif  // if !defined(STARBOARD)
 
 	struct stat st;

--- a/third_party/musl/src/linux/statx.c
+++ b/third_party/musl/src/linux/statx.c
@@ -1,0 +1,48 @@
+#define _GNU_SOURCE
+#include <sys/stat.h>
+#include <string.h>
+#include <syscall.h>
+#include <sys/sysmacros.h>
+#include <errno.h>
+
+int statx(int dirfd, const char *restrict path, int flags, unsigned mask, struct statx *restrict stx)
+{
+#if !defined(STARBOARD)
+	int ret = __syscall(SYS_statx, dirfd, path, flags, mask, stx);
+
+#ifndef SYS_fstatat
+	return __syscall_ret(ret);
+#endif
+
+	if (ret != -ENOSYS) return __syscall_ret(ret);
+#else  // defined(STARBOARD)
+  int ret = 0;
+#endif  // if !defined(STARBOARD)
+
+	struct stat st;
+	ret = fstatat(dirfd, path, &st, flags);
+	if (ret) return ret;
+
+	*stx = (struct statx){0};
+	stx->stx_dev_major = major(st.st_dev);
+	stx->stx_dev_minor = minor(st.st_dev);
+	stx->stx_rdev_major = major(st.st_rdev);
+	stx->stx_rdev_minor = minor(st.st_rdev);
+	stx->stx_ino = st.st_ino;
+	stx->stx_mode = st.st_mode;
+	stx->stx_nlink = st.st_nlink;
+	stx->stx_uid = st.st_uid;
+	stx->stx_gid = st.st_gid;
+	stx->stx_size = st.st_size;
+	stx->stx_blksize = st.st_blksize;
+	stx->stx_blocks = st.st_blocks;
+	stx->stx_atime.tv_sec = st.st_atim.tv_sec;
+	stx->stx_atime.tv_nsec = st.st_atim.tv_nsec;
+	stx->stx_mtime.tv_sec = st.st_mtim.tv_sec;
+	stx->stx_mtime.tv_nsec = st.st_mtim.tv_nsec;
+	stx->stx_ctime.tv_sec = st.st_ctim.tv_sec;
+	stx->stx_ctime.tv_nsec = st.st_ctim.tv_nsec;
+	stx->stx_mask = STATX_BASIC_STATS;
+
+	return 0;
+}


### PR DESCRIPTION
This adds the upstream musl implemenation of statx from

  * https://git.musl-libc.org/cgit/musl/tree/include/sys/stat.h
  * https://git.musl-libc.org/cgit/musl/tree/src/linux/statx.c

with a minor Starboard customization to always use fstatat intead of trying the statx syscall first, since SB already has an fstatat wrapper.

Bug: 500417876