### PR TITLE
Flush prefs writes

### DIFF
--- a/components/update_client/persisted_data.cc
+++ b/components/update_client/persisted_data.cc
@@ -26,6 +26,16 @@
 #include "components/update_client/activity_data_service.h"
 #include "components/update_client/update_client_errors.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+namespace {
+void FlushPrefs(PrefService* pref_service) {
+  if (pref_service) {
+    pref_service->CommitPendingWrite(base::DoNothing());
+  }
+}
+}  // namespace
+#endif
+
 namespace update_client {
 
 const char kPersistedDataPreference[] = "updateclientdata";
@@ -236,10 +246,14 @@ void PersistedDataImpl::SetLastInstalledEgAndSbVersion(const std::string& id,
                                                    const std::string& sb_version) {
   SetString(id, "version", eg_version);
   SetString(id, "sbversion", sb_version);
+  PrefService* prefs = pref_service_provider_.Run();
+  FlushPrefs(prefs);
 }
 void PersistedDataImpl::SetUpdaterChannel(const std::string& id,
                                       const std::string& channel) {
   SetString(id, "updaterchannel", channel);
+  PrefService* prefs = pref_service_provider_.Run();
+  FlushPrefs(prefs);
 }
 void PersistedDataImpl::SetLatestChannel(const std::string& channel) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -247,9 +261,12 @@ void PersistedDataImpl::SetLatestChannel(const std::string& channel) {
   if (!pref_service) {
     return;
   }
-  ScopedDictPrefUpdate update(pref_service, kPersistedDataPreference);
-  base::Value::Dict* app_key = GetOrCreateAppKey("latestchannel", update.Get());
-  app_key->Set("latestchannel", channel);
+  {
+    ScopedDictPrefUpdate update(pref_service, kPersistedDataPreference);
+    base::Value::Dict* app_key = GetOrCreateAppKey("latestchannel", update.Get());
+    app_key->Set("latestchannel", channel);
+  }
+  FlushPrefs(pref_service);
 }
 #endif
 

--- a/components/update_client/persisted_data.cc
+++ b/components/update_client/persisted_data.cc
@@ -245,30 +245,17 @@ void PersistedDataImpl::SetLastInstalledEgAndSbVersion(const std::string& id,
                                                    const std::string& eg_version,
                                                    const std::string& sb_version) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  PrefService* pref_service = pref_service_provider_.Run();
-  if (!pref_service) {
-    return;
-  }
-  {
-    ScopedDictPrefUpdate update(pref_service, kPersistedDataPreference);
-    base::Value::Dict* app_key = GetOrCreateAppKey(id, update.Get());
-    app_key->Set("version", eg_version);
-    app_key->Set("sbversion", sb_version);
-  }
-  FlushPrefs(pref_service);
+  SetString(id, "version", eg_version);
+  SetString(id, "sbversion", sb_version);
+  PrefService* prefs = pref_service_provider_.Run();
+  FlushPrefs(prefs);
 }
 void PersistedDataImpl::SetUpdaterChannel(const std::string& id,
                                       const std::string& channel) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
-  PrefService* pref_service = pref_service_provider_.Run();
-  if (!pref_service) {
-    return;
-  }
-  {
-    ScopedDictPrefUpdate update(pref_service, kPersistedDataPreference);
-    GetOrCreateAppKey(id, update.Get())->Set("updaterchannel", channel);
-  }
-  FlushPrefs(pref_service);
+  SetString(id, "updaterchannel", channel);
+  PrefService* prefs = pref_service_provider_.Run();
+  FlushPrefs(prefs);
 }
 void PersistedDataImpl::SetLatestChannel(const std::string& channel) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -278,7 +265,8 @@ void PersistedDataImpl::SetLatestChannel(const std::string& channel) {
   }
   {
     ScopedDictPrefUpdate update(pref_service, kPersistedDataPreference);
-    update.Get()->Set("latestchannel", channel);
+    base::Value::Dict* app_key = GetOrCreateAppKey("latestchannel", update.Get());
+    app_key->Set("latestchannel", channel);
   }
   FlushPrefs(pref_service);
 }

--- a/components/update_client/persisted_data.cc
+++ b/components/update_client/persisted_data.cc
@@ -244,16 +244,31 @@ std::string PersistedDataImpl::GetLatestChannel() const {
 void PersistedDataImpl::SetLastInstalledEgAndSbVersion(const std::string& id,
                                                    const std::string& eg_version,
                                                    const std::string& sb_version) {
-  SetString(id, "version", eg_version);
-  SetString(id, "sbversion", sb_version);
-  PrefService* prefs = pref_service_provider_.Run();
-  FlushPrefs(prefs);
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  PrefService* pref_service = pref_service_provider_.Run();
+  if (!pref_service) {
+    return;
+  }
+  {
+    ScopedDictPrefUpdate update(pref_service, kPersistedDataPreference);
+    base::Value::Dict* app_key = GetOrCreateAppKey(id, update.Get());
+    app_key->Set("version", eg_version);
+    app_key->Set("sbversion", sb_version);
+  }
+  FlushPrefs(pref_service);
 }
 void PersistedDataImpl::SetUpdaterChannel(const std::string& id,
                                       const std::string& channel) {
-  SetString(id, "updaterchannel", channel);
-  PrefService* prefs = pref_service_provider_.Run();
-  FlushPrefs(prefs);
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  PrefService* pref_service = pref_service_provider_.Run();
+  if (!pref_service) {
+    return;
+  }
+  {
+    ScopedDictPrefUpdate update(pref_service, kPersistedDataPreference);
+    GetOrCreateAppKey(id, update.Get())->Set("updaterchannel", channel);
+  }
+  FlushPrefs(pref_service);
 }
 void PersistedDataImpl::SetLatestChannel(const std::string& channel) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
@@ -263,8 +278,7 @@ void PersistedDataImpl::SetLatestChannel(const std::string& channel) {
   }
   {
     ScopedDictPrefUpdate update(pref_service, kPersistedDataPreference);
-    base::Value::Dict* app_key = GetOrCreateAppKey("latestchannel", update.Get());
-    app_key->Set("latestchannel", channel);
+    update.Get()->Set("latestchannel", channel);
   }
   FlushPrefs(pref_service);
 }

--- a/components/update_client/persisted_data.cc
+++ b/components/update_client/persisted_data.cc
@@ -244,7 +244,6 @@ std::string PersistedDataImpl::GetLatestChannel() const {
 void PersistedDataImpl::SetLastInstalledEgAndSbVersion(const std::string& id,
                                                    const std::string& eg_version,
                                                    const std::string& sb_version) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   SetString(id, "version", eg_version);
   SetString(id, "sbversion", sb_version);
   PrefService* prefs = pref_service_provider_.Run();
@@ -252,7 +251,6 @@ void PersistedDataImpl::SetLastInstalledEgAndSbVersion(const std::string& id,
 }
 void PersistedDataImpl::SetUpdaterChannel(const std::string& id,
                                       const std::string& channel) {
-  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   SetString(id, "updaterchannel", channel);
   PrefService* prefs = pref_service_provider_.Run();
   FlushPrefs(prefs);


### PR DESCRIPTION
The update client writes critical data, such as installed Evergreen and Starboard
versions, and updater channel information, to the preference service.
This PR ensure that these changes are
immediately flushed to persistent storage after being written.

Issue: 479816505