### PR TITLE
media: Move GetAudioRendererParams to AudioRendererSink

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -135,6 +135,50 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
     return tunnel_mode_audio_session_id_ != -1;
   }
 
+  void GetAudioRendererParams(const AudioStreamInfo& audio_stream_info,
+                              int* max_cached_frames,
+                              int* min_frames_per_append) const override {
+    SB_CHECK(max_cached_frames);
+    SB_CHECK(min_frames_per_append);
+    SB_DCHECK(AudioRendererSink::kDefaultAudioSinkMinFramesPerAppend %
+                  AudioRendererSink::kAudioSinkFramesAlignment ==
+              0);
+    *min_frames_per_append =
+        AudioRendererSink::kDefaultAudioSinkMinFramesPerAppend;
+
+    // AudioRenderer prefers to use kSbMediaAudioSampleTypeFloat32 and only uses
+    // kSbMediaAudioSampleTypeInt16Deprecated when float32 is not supported.
+    const auto sample_type =
+        SbAudioSinkIsAudioSampleTypeSupported(kSbMediaAudioSampleTypeFloat32)
+            ? kSbMediaAudioSampleTypeFloat32
+            : kSbMediaAudioSampleTypeInt16Deprecated;
+
+    int min_frames_required = SbAudioSinkGetMinBufferSizeInFrames(
+        audio_stream_info.number_of_channels, sample_type,
+        audio_stream_info.samples_per_second);
+
+    if (tunnel_mode_audio_session_id_ != -1) {
+      // AudioTrack.setPlaybackParams() might need extra buffer to support
+      // playback speed greater than 1.0x.
+      const double kMaxPlaybackSpeed = 2.0;
+      JNIEnv* env = AttachCurrentThread();
+      min_frames_required = std::max<int>(
+          min_frames_required,
+          AudioOutputManager::GetInstance()->GetMinBufferSizeInFrames(
+              env, sample_type, audio_stream_info.number_of_channels,
+              audio_stream_info.samples_per_second) *
+              kMaxPlaybackSpeed);
+    }
+
+    // On Android 5.0, the size of audio renderer sink buffer need to be two
+    // times larger than AudioTrack minBufferSize. Otherwise, AudioTrack may
+    // stop working after pause.
+    *max_cached_frames = min_frames_required * 2 +
+                         AudioRendererSink::kDefaultAudioSinkMinFramesPerAppend;
+    *max_cached_frames = AlignUp(*max_cached_frames,
+                                 AudioRendererSink::kAudioSinkFramesAlignment);
+  }
+
  private:
   bool IsAudioSampleTypeSupported(
       SbMediaAudioSampleType audio_sample_type) const override {
@@ -203,13 +247,6 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     SB_LOG_IF(INFO, force_platform_opus_decoder_)
         << "kForcePlatformOpusDecoder is set to true, force using platform opus"
         << " codec instead of libopus.";
-  }
-
-  const int kAudioSinkFramesAlignment = 256;
-  const int kDefaultAudioSinkMinFramesPerAppend = 1024;
-
-  static int AlignUp(int value, int alignment) {
-    return (value + alignment - 1) / alignment * alignment;
   }
 
   NonNullResult<std::unique_ptr<PlayerComponents>> CreateComponents(
@@ -479,57 +516,6 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     }
 
     return components;
-  }
-
-  void GetAudioRendererParams(const CreationParameters& creation_parameters,
-                              int* max_cached_frames,
-                              int* min_frames_per_append) const override {
-    SB_CHECK(max_cached_frames);
-    SB_CHECK(min_frames_per_append);
-    SB_DCHECK(kDefaultAudioSinkMinFramesPerAppend % kAudioSinkFramesAlignment ==
-              0);
-    *min_frames_per_append = kDefaultAudioSinkMinFramesPerAppend;
-
-    // AudioRenderer prefers to use kSbMediaAudioSampleTypeFloat32 and only uses
-    // kSbMediaAudioSampleTypeInt16Deprecated when float32 is not supported.
-    const auto sample_type =
-        SbAudioSinkIsAudioSampleTypeSupported(kSbMediaAudioSampleTypeFloat32)
-            ? kSbMediaAudioSampleTypeFloat32
-            : kSbMediaAudioSampleTypeInt16Deprecated;
-
-    int min_frames_required = SbAudioSinkGetMinBufferSizeInFrames(
-        creation_parameters.audio_stream_info().number_of_channels, sample_type,
-        creation_parameters.audio_stream_info().samples_per_second);
-
-    // To avoid redundant IsTunnelModeSupported() checks, we simply only check
-    // if tunnel mode is enabled here.
-    if (creation_parameters.audio_codec() != kSbMediaAudioCodecNone &&
-        creation_parameters.video_codec() != kSbMediaVideoCodecNone) {
-      const bool force_tunnel_mode =
-          FeatureList::IsEnabled(features::kForceTunnelMode);
-      MimeType video_mime_type(creation_parameters.video_mime());
-      if (force_tunnel_mode ||
-          video_mime_type.GetParamBoolValue("tunnelmode", false)) {
-        // AudioTrack.setPlaybackParams() might need extra buffer to support
-        // playback speed greater than 1.0x.
-        const double kMaxPlaybackSpeed = 2.0;
-        JNIEnv* env = AttachCurrentThread();
-        min_frames_required = std::max<int>(
-            min_frames_required,
-            AudioOutputManager::GetInstance()->GetMinBufferSizeInFrames(
-                env, sample_type,
-                creation_parameters.audio_stream_info().number_of_channels,
-                creation_parameters.audio_stream_info().samples_per_second) *
-                kMaxPlaybackSpeed);
-      }
-    }
-
-    // On Android 5.0, the size of audio renderer sink buffer need to be two
-    // times larger than AudioTrack minBufferSize. Otherwise, AudioTrack may
-    // stop working after pause.
-    *max_cached_frames =
-        min_frames_required * 2 + kDefaultAudioSinkMinFramesPerAppend;
-    *max_cached_frames = AlignUp(*max_cached_frames, kAudioSinkFramesAlignment);
   }
 
   NonNullResult<std::unique_ptr<MediaCodecVideoDecoder>> CreateVideoDecoder(

--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -386,4 +386,8 @@ int64_t AudioFramesToDuration(int frames, int samples_per_second) {
   return frames * 1'000'000LL / std::max(samples_per_second, 1);
 }
 
+int AlignUp(int value, int alignment) {
+  return (value + alignment - 1) / alignment * alignment;
+}
+
 }  // namespace starboard

--- a/starboard/shared/starboard/media/media_util.h
+++ b/starboard/shared/starboard/media/media_util.h
@@ -150,6 +150,8 @@ bool IsAudioSampleInfoSubstantiallyDifferent(const AudioStreamInfo& left,
 int AudioDurationToFrames(int64_t duration, int samples_per_second);
 int64_t AudioFramesToDuration(int frames, int samples_per_second);
 
+int AlignUp(int value, int alignment);
+
 }  // namespace starboard
 
 #endif  // STARBOARD_SHARED_STARBOARD_MEDIA_MEDIA_UTIL_H_

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink.h
@@ -19,12 +19,16 @@
 
 #include "starboard/audio_sink.h"
 #include "starboard/shared/internal_only.h"
+#include "starboard/shared/starboard/media/media_util.h"
 
 namespace starboard {
 
 // The interface used by AudioRendererPcm to output audio samples.
 class AudioRendererSink {
  public:
+  static const int kAudioSinkFramesAlignment = 256;
+  static const int kDefaultAudioSinkMinFramesPerAppend = 1024;
+
   class RenderCallback {
    public:
     virtual void GetSourceStatus(int* frames_in_buffer,
@@ -45,6 +49,10 @@ class AudioRendererSink {
   };
 
   virtual ~AudioRendererSink() {}
+
+  virtual void GetAudioRendererParams(const AudioStreamInfo& audio_stream_info,
+                                      int* max_cached_frames,
+                                      int* min_frames_per_append) const = 0;
 
   virtual bool IsAudioSampleTypeSupported(
       SbMediaAudioSampleType audio_sample_type) const = 0;

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -14,11 +14,13 @@
 
 #include "starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h"
 
+#include <algorithm>
 #include <string>
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/configuration_constants.h"
+#include "starboard/shared/starboard/media/media_util.h"
 #include "starboard/shared/starboard/thread_checker.h"
 
 namespace starboard {
@@ -68,6 +70,32 @@ bool AudioRendererSinkImpl::IsAudioFrameStorageTypeSupported(
 int AudioRendererSinkImpl::GetNearestSupportedSampleFrequency(
     int sampling_frequency_hz) const {
   return SbAudioSinkGetNearestSupportedSampleFrequency(sampling_frequency_hz);
+}
+
+void AudioRendererSinkImpl::GetAudioRendererParams(
+    const AudioStreamInfo& audio_stream_info,
+    int* max_cached_frames,
+    int* min_frames_per_append) const {
+  SB_CHECK(max_cached_frames);
+  SB_CHECK(min_frames_per_append);
+  SB_DCHECK(kDefaultAudioSinkMinFramesPerAppend % kAudioSinkFramesAlignment ==
+            0);
+  *min_frames_per_append = kDefaultAudioSinkMinFramesPerAppend;
+  // AudioRenderer prefers to use kSbMediaAudioSampleTypeFloat32 and only uses
+  // kSbMediaAudioSampleTypeInt16Deprecated when float32 is not supported.
+  int min_frames_required = SbAudioSinkGetMinBufferSizeInFrames(
+      audio_stream_info.number_of_channels,
+      SbAudioSinkIsAudioSampleTypeSupported(kSbMediaAudioSampleTypeFloat32)
+          ? kSbMediaAudioSampleTypeFloat32
+          : kSbMediaAudioSampleTypeInt16Deprecated,
+      audio_stream_info.samples_per_second);
+  // Audio renderer would sleep for a while if it thinks there're enough
+  // frames in the sink. The sleeping time is 1/4 of |max_cached_frames|. So, to
+  // maintain required min buffer size of audio sink, the |max_cached_frames|
+  // need to be larger than |min_frames_required| * 4/3.
+  *max_cached_frames = static_cast<int>(min_frames_required * 1.4) +
+                       kDefaultAudioSinkMinFramesPerAppend;
+  *max_cached_frames = AlignUp(*max_cached_frames, kAudioSinkFramesAlignment);
 }
 
 bool AudioRendererSinkImpl::HasStarted() const {

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
@@ -46,6 +46,10 @@ class AudioRendererSinkImpl : public AudioRendererSink {
   explicit AudioRendererSinkImpl(CreateAudioSinkFunc create_audio_sink_func);
   ~AudioRendererSinkImpl() override;
 
+  void GetAudioRendererParams(const AudioStreamInfo& audio_stream_info,
+                              int* max_cached_frames,
+                              int* min_frames_per_append) const override;
+
  private:
   // AudioRendererSink methods
   bool IsAudioSampleTypeSupported(

--- a/starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h
@@ -27,6 +27,10 @@ namespace starboard {
 
 class MockAudioRendererSink : public AudioRendererSink {
  public:
+  MOCK_CONST_METHOD3(GetAudioRendererParams,
+                     void(const AudioStreamInfo& audio_stream_info,
+                          int* max_cached_frames,
+                          int* min_frames_per_append));
   MOCK_CONST_METHOD1(IsAudioSampleTypeSupported,
                      bool(SbMediaAudioSampleType audio_sample_type));
   MOCK_CONST_METHOD1(

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -36,9 +36,6 @@ namespace starboard {
 
 namespace {
 
-const int kAudioSinkFramesAlignment = 256;
-const int kDefaultAudioSinkMinFramesPerAppend = 1024;
-
 typedef MediaTimeProviderImpl::MonotonicSystemTimeProvider
     MonotonicSystemTimeProvider;
 
@@ -73,10 +70,6 @@ class PlayerComponentsImpl : public PlayerComponents {
   std::unique_ptr<AudioRendererPcm> audio_renderer_;
   std::unique_ptr<VideoRendererImpl> video_renderer_;
 };
-
-int AlignUp(int value, int alignment) {
-  return (value + alignment - 1) / alignment * alignment;
-}
 
 }  // namespace
 
@@ -204,8 +197,9 @@ PlayerComponents::Factory::CreateComponents(
     SB_DCHECK(components.audio.renderer_sink);
 
     int max_cached_frames, min_frames_per_append;
-    GetAudioRendererParams(creation_parameters, &max_cached_frames,
-                           &min_frames_per_append);
+    components.audio.renderer_sink->GetAudioRendererParams(
+        creation_parameters.audio_stream_info(), &max_cached_frames,
+        &min_frames_per_append);
 
     audio_renderer = std::make_unique<AudioRendererPcm>(
         creation_parameters.job_queue(), std::move(components.audio.decoder),
@@ -279,32 +273,6 @@ PlayerComponents::Factory::CreateStubVideoComponents(
   components.renderer_sink = make_scoped_refptr<PunchoutVideoRendererSink>(
       creation_parameters.player(), kVideoSinkRenderIntervalUsec);
   return components;
-}
-
-void PlayerComponents::Factory::GetAudioRendererParams(
-    const CreationParameters& creation_parameters,
-    int* max_cached_frames,
-    int* min_frames_per_append) const {
-  SB_CHECK(max_cached_frames);
-  SB_CHECK(min_frames_per_append);
-  SB_DCHECK(kDefaultAudioSinkMinFramesPerAppend % kAudioSinkFramesAlignment ==
-            0);
-  *min_frames_per_append = kDefaultAudioSinkMinFramesPerAppend;
-  // AudioRenderer prefers to use kSbMediaAudioSampleTypeFloat32 and only uses
-  // kSbMediaAudioSampleTypeInt16Deprecated when float32 is not supported.
-  int min_frames_required = SbAudioSinkGetMinBufferSizeInFrames(
-      creation_parameters.audio_stream_info().number_of_channels,
-      SbAudioSinkIsAudioSampleTypeSupported(kSbMediaAudioSampleTypeFloat32)
-          ? kSbMediaAudioSampleTypeFloat32
-          : kSbMediaAudioSampleTypeInt16Deprecated,
-      creation_parameters.audio_stream_info().samples_per_second);
-  // Audio renderer would sleep for a while if it thinks there're enough
-  // frames in the sink. The sleeping time is 1/4 of |max_cached_frames|. So, to
-  // maintain required min buffer size of audio sink, the |max_cached_frames|
-  // need to be larger than |min_frames_required| * 4/3.
-  *max_cached_frames = static_cast<int>(min_frames_required * 1.4) +
-                       kDefaultAudioSinkMinFramesPerAppend;
-  *max_cached_frames = AlignUp(*max_cached_frames, kAudioSinkFramesAlignment);
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/player_components.h
+++ b/starboard/shared/starboard/player/filter/player_components.h
@@ -208,12 +208,6 @@ class PlayerComponents {
     VideoComponents CreateStubVideoComponents(
         const CreationParameters& creation_parameters);
 
-    // Check AudioRenderer ctor for more details on the parameters.
-    virtual void GetAudioRendererParams(
-        const CreationParameters& creation_parameters,
-        int* max_cached_frames,
-        int* min_frames_per_append) const;
-
    private:
     Factory(const Factory&) = delete;
     void operator=(const Factory&) = delete;


### PR DESCRIPTION
Move the logic for determining audio renderer buffer parameters from
PlayerComponents::Factory to AudioRendererSink. This refactors
GetAudioRendererParams into a virtual method on AudioRendererSink,
with specific implementations in AudioRendererSinkImpl and
AudioRendererSinkAndroid.

This change encapsulates platform-specific audio buffering logic directly
within the respective AudioRendererSink implementations. It removes
platform-specific details, such as Android's tunnel mode calculations and
AudioOutputManager interactions, from the generic PlayerComponents::Factory.
This improves modularity and ensures each audio sink can correctly calculate
its own required buffer sizes.

Bug: 500811542