### PR TITLE
android: Fix OnFrameAvailable race condition

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
@@ -16,6 +16,7 @@ package dev.cobalt.media;
 
 import android.graphics.SurfaceTexture;
 import android.view.Surface;
+import androidx.annotation.GuardedBy;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
@@ -26,6 +27,11 @@ import org.jni_zero.NativeMethods;
  */
 @JNINamespace("starboard")
 public class VideoSurfaceTexture extends SurfaceTexture {
+  private final Object mLock = new Object();
+
+  @GuardedBy("mLock")
+  private long mNativeVideoSurfaceTextureBridge;
+
   @CalledByNative
   VideoSurfaceTexture(int texName) {
     super(texName);
@@ -33,17 +39,27 @@ public class VideoSurfaceTexture extends SurfaceTexture {
 
   @CalledByNative
   void setOnFrameAvailableListener(final long nativeVideoSurfaceTextureBridge) {
+    synchronized (mLock) {
+      mNativeVideoSurfaceTextureBridge = nativeVideoSurfaceTextureBridge;
+    }
     super.setOnFrameAvailableListener(
         new SurfaceTexture.OnFrameAvailableListener() {
           @Override
           public void onFrameAvailable(SurfaceTexture surfaceTexture) {
-            VideoSurfaceTextureJni.get().onFrameAvailable(nativeVideoSurfaceTextureBridge);
+            synchronized (mLock) {
+              if (mNativeVideoSurfaceTextureBridge != 0) {
+                VideoSurfaceTextureJni.get().onFrameAvailable(mNativeVideoSurfaceTextureBridge);
+              }
+            }
           }
         });
   }
 
   @CalledByNative
   void removeOnFrameAvailableListener() {
+    synchronized (mLock) {
+      mNativeVideoSurfaceTextureBridge = 0;
+    }
     super.setOnFrameAvailableListener(null);
   }
 


### PR DESCRIPTION
Introduce thread-safe handling for the host object within
VideoSurfaceTextureBridge and its Java counterpart, VideoSurfaceTexture.
This change guards against concurrent access to the host pointer during
attachment, detachment, and frame availability callbacks.

Previously, a race condition could occur where OnFrameAvailable was
called after the native MediaCodecVideoDecoder host was destroyed. This
resulted in a use-after-free crash when invoking host->OnFrameAvailable()
on an invalid pointer. The new locking mechanism ensures the host
pointer is valid or null when accessed, preventing crashes.

#vibe-coded

Issue: 417242469
Issue: 503034869