### PR TITLE
tvOS: Add stub decode_target_get_info.cc to the build

### DIFF
--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -76,6 +76,7 @@ static_library("starboard_platform") {
     "//starboard/shared/starboard/queue_application.h",
     "//starboard/shared/starboard/system_request_stop.cc",
     "//starboard/shared/starboard/window_set_default_options.cc",
+    "//starboard/shared/stub/decode_target_get_info.cc",
     "//starboard/shared/stub/storage_write_record.cc",
     "//starboard/shared/stub/system_symbolize.cc",
     "accessibility_extension.cc",


### PR DESCRIPTION
Prepare for #9979 by adding a stub implementation for `SbDecodeTargetGetInfo()` to prevent a build failure when that PR lands.

Bug: 447334535