### PR TITLE
media: Propagate experimental features to renderers

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -70,33 +70,6 @@ bool UseLibopusDecoder(SbMediaAudioCodec codec,
          !force_platform_opus_decoder;
 }
 
-std::optional<VideoRendererImpl::PrerollParameters> GetPrerollParams(
-    const PlayerComponents::Factory::CreationParameters& creation_parameters) {
-  const auto& experimental_features =
-      creation_parameters.experimental_features();
-  const auto& min_input_buffers =
-      experimental_features.video_renderer_min_input_buffers;
-  const auto& min_decoded_frames =
-      experimental_features.video_renderer_min_decoded_frames;
-
-  if (!min_input_buffers && !min_decoded_frames) {
-    return std::nullopt;
-  }
-  if (!min_input_buffers) {
-    SB_LOG(WARNING) << "Ignoring video_renderer_min_decoded_frames since "
-                       "video_renderer_min_input_buffers is missing.";
-    return std::nullopt;
-  }
-  if (!min_decoded_frames) {
-    SB_LOG(WARNING) << "Ignoring video_renderer_min_input_buffers since "
-                       "video_renderer_min_decoded_frames is missing.";
-    return std::nullopt;
-  }
-
-  return VideoRendererImpl::PrerollParameters{*min_input_buffers,
-                                              *min_decoded_frames};
-}
-
 // This class allows us to force int16 sample type when tunnel mode is enabled.
 class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
  public:
@@ -294,7 +267,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         video_renderer = std::make_unique<VideoRendererImpl>(
             creation_parameters.job_queue(), std::move(video_decoder_impl),
             media_time_provider, std::move(video_render_algorithm),
-            video_renderer_sink, GetPrerollParams(creation_parameters));
+            video_renderer_sink, creation_parameters.experimental_features());
       } else {
         return Failure("Failed to create video decoder: " +
                        video_decoder.error());

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -70,10 +70,12 @@ AudioRendererPcm::AudioRendererPcm(
     std::unique_ptr<AudioRendererSink> audio_renderer_sink,
     const AudioStreamInfo& audio_stream_info,
     int max_cached_frames,
-    int min_frames_per_append)
+    int min_frames_per_append,
+    const ExperimentalFeatures& experimental_features)
     : JobOwner(job_queue),
       max_cached_frames_(max_cached_frames),
       min_frames_per_append_(min_frames_per_append),
+      experimental_features_(experimental_features),
       decoder_(std::move(decoder)),
       frames_consumed_set_at_(CurrentMonotonicTime()),
       channels_(audio_stream_info.number_of_channels),

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -28,6 +28,7 @@
 #include "starboard/common/log.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
+#include "starboard/shared/starboard/experimental_features.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "starboard/shared/starboard/player/decoded_audio_internal.h"
 #include "starboard/shared/starboard/player/filter/audio_decoder_internal.h"
@@ -68,7 +69,8 @@ class AudioRendererPcm : public AudioRenderer,
                    std::unique_ptr<AudioRendererSink> audio_renderer_sink,
                    const AudioStreamInfo& audio_stream_info,
                    int max_cached_frames,
-                   int min_frames_per_append);
+                   int min_frames_per_append,
+                   const ExperimentalFeatures& experimental_features);
   ~AudioRendererPcm() override;
 
   void Initialize(const ErrorCB& error_cb,
@@ -104,6 +106,7 @@ class AudioRendererPcm : public AudioRenderer,
 
   const int max_cached_frames_;
   const int min_frames_per_append_;
+  const ExperimentalFeatures experimental_features_;
   // |buffered_frames_to_start_| would be initialized in OnFirstOutput().
   // Before it's initialized, set it to a large number.
   int buffered_frames_to_start_ = 48 * 1024;

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -211,7 +211,7 @@ PlayerComponents::Factory::CreateComponents(
         creation_parameters.job_queue(), std::move(components.audio.decoder),
         std::move(components.audio.renderer_sink),
         creation_parameters.audio_stream_info(), max_cached_frames,
-        min_frames_per_append);
+        min_frames_per_append, creation_parameters.experimental_features());
   }
 
   if (creation_parameters.video_codec() != kSbMediaVideoCodecNone) {
@@ -228,20 +228,11 @@ PlayerComponents::Factory::CreateComponents(
       media_time_provider = media_time_provider_impl.get();
     }
 
-    const auto& experimental_features =
-        creation_parameters.experimental_features();
-    std::optional<VideoRendererImpl::PrerollParameters> preroll_params;
-    if (experimental_features.video_renderer_min_input_buffers &&
-        experimental_features.video_renderer_min_decoded_frames) {
-      preroll_params = VideoRendererImpl::PrerollParameters{
-          *experimental_features.video_renderer_min_input_buffers,
-          *experimental_features.video_renderer_min_decoded_frames};
-    }
-
     video_renderer = std::make_unique<VideoRendererImpl>(
         creation_parameters.job_queue(), std::move(components.video.decoder),
         media_time_provider, std::move(components.video.render_algorithm),
-        std::move(components.video.renderer_sink), preroll_params);
+        std::move(components.video.renderer_sink),
+        creation_parameters.experimental_features());
   }
 
   SB_DCHECK(audio_renderer || video_renderer);

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -112,7 +112,8 @@ class AudioRendererTest : public ::testing::Test {
     audio_renderer_.reset(new AudioRendererPcm(
         &job_queue_, std::unique_ptr<AudioDecoder>(audio_decoder_),
         std::unique_ptr<AudioRendererSink>(audio_renderer_sink_),
-        GetDefaultAudioStreamInfo(), kMaxCachedFrames, kMaxFramesPerAppend));
+        GetDefaultAudioStreamInfo(), kMaxCachedFrames, kMaxFramesPerAppend,
+        ExperimentalFeatures()));
     audio_renderer_->Initialize(
         std::bind(&AudioRendererTest::OnError, this),
         std::bind(&AudioRendererTest::OnPrerolled, this),

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -37,25 +37,19 @@ const int64_t kSeekTimeoutRetryInterval = 25'000;  // 25ms
 
 }  // namespace
 
-std::ostream& operator<<(std::ostream& os,
-                         const VideoRendererImpl::PrerollParameters& params) {
-  return os << "{min_input_buffers=" << params.min_input_buffers
-            << ", min_decoded_frames=" << params.min_decoded_frames << "}";
-}
-
 VideoRendererImpl::VideoRendererImpl(
     JobQueue* job_queue,
     std::unique_ptr<VideoDecoder> decoder,
     MediaTimeProvider* media_time_provider,
     std::unique_ptr<VideoRenderAlgorithm> algorithm,
     scoped_refptr<VideoRendererSink> sink,
-    const std::optional<PrerollParameters>& preroll_params)
+    const ExperimentalFeatures& experimental_features)
     : JobOwner(job_queue),
       media_time_provider_(media_time_provider),
       algorithm_(std::move(algorithm)),
       sink_(sink),
       decoder_(std::move(decoder)),
-      preroll_params_(preroll_params) {
+      experimental_features_(experimental_features) {
   SB_CHECK(decoder_);
   SB_CHECK(algorithm_);
   SB_DCHECK_GT(decoder_->GetMaxNumberOfCachedFrames(), 1U);
@@ -72,10 +66,17 @@ VideoRendererImpl::VideoRendererImpl(
            kCheckBufferingStateInterval);
   time_of_last_lag_warning_ = CurrentMonotonicTime() - kMinLagWarningInterval;
 #endif  // SB_PLAYER_FILTER_ENABLE_STATE_CHECK
-  SB_LOG(INFO) << "VideoRendererImpl is created: "
-               << (preroll_params_
-                       ? "preroll_params=" + ToString(*preroll_params_)
-                       : "using default preroll logic");
+  if (experimental_features_.video_renderer_min_input_buffers &&
+      experimental_features_.video_renderer_min_decoded_frames) {
+    SB_LOG(INFO) << "VideoRendererImpl is created: preroll_params="
+                 << "{min_input_buffers="
+                 << *experimental_features_.video_renderer_min_input_buffers
+                 << ", min_decoded_frames="
+                 << *experimental_features_.video_renderer_min_decoded_frames
+                 << "}";
+  } else {
+    SB_LOG(INFO) << "VideoRendererImpl is created: using default preroll logic";
+  }
 }
 
 VideoRendererImpl::~VideoRendererImpl() {
@@ -308,10 +309,13 @@ void VideoRendererImpl::OnDecoderStatus(
     }
 
     bool preroll_completed = false;
-    if (preroll_params_) {
+    if (experimental_features_.video_renderer_min_input_buffers &&
+        experimental_features_.video_renderer_min_decoded_frames) {
       preroll_completed =
-          input_buffers_sent_.load() >= preroll_params_->min_input_buffers &&
-          number_of_frames_.load() >= preroll_params_->min_decoded_frames;
+          input_buffers_sent_.load() >=
+              *experimental_features_.video_renderer_min_input_buffers &&
+          number_of_frames_.load() >=
+              *experimental_features_.video_renderer_min_decoded_frames;
     } else {
       preroll_completed =
           number_of_frames_.load() >=

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -26,6 +26,7 @@
 #include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
+#include "starboard/shared/starboard/experimental_features.h"
 #include "starboard/shared/starboard/player/filter/common.h"
 #include "starboard/shared/starboard/player/filter/media_time_provider.h"
 #include "starboard/shared/starboard/player/filter/video_decoder_internal.h"
@@ -42,13 +43,6 @@ namespace starboard {
 // pipeline to coordinate data transfer between these parties.
 class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
  public:
-  struct PrerollParameters {
-    int32_t min_input_buffers;
-    int32_t min_decoded_frames;
-  };
-  friend std::ostream& operator<<(std::ostream& os,
-                                  const PrerollParameters& params);
-
   // All of the functions are called on the PlayerWorker thread unless marked
   // otherwise.
   VideoRendererImpl(JobQueue* job_queue,
@@ -56,7 +50,7 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
                     MediaTimeProvider* media_time_provider,
                     std::unique_ptr<VideoRenderAlgorithm> algorithm,
                     scoped_refptr<VideoRendererSink> sink,
-                    const std::optional<PrerollParameters>& preroll_params);
+                    const ExperimentalFeatures& experimental_features);
   ~VideoRendererImpl() override;
 
   void Initialize(const ErrorCB& error_cb,
@@ -95,7 +89,7 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   const std::unique_ptr<VideoRenderAlgorithm> algorithm_;
   scoped_refptr<VideoRendererSink> sink_;
   std::unique_ptr<VideoDecoder> decoder_;
-  const std::optional<PrerollParameters> preroll_params_;
+  const ExperimentalFeatures experimental_features_;
 
   PrerolledCB prerolled_cb_;
   EndedCB ended_cb_;


### PR DESCRIPTION
Pass the ExperimentalFeatures struct from player creation parameters to
the AudioRendererPcm and VideoRendererImpl constructors. This enables
audio and video renderers to access and configure their behavior based
on the experimental features defined for the player.

Bug: 500811542