### PR TITLE
[3p] Resolve __stdio_exit_needed link error and enable stdio flush

### DIFF
--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -46,6 +46,8 @@
 #include "ui/ozone/platform/starboard/platform_event_source_starboard.h"
 #endif
 
+#include <cstdio>
+
 #if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
 #include <init_musl.h>
 #if BUILDFLAG(USE_EVERGREEN)
@@ -125,6 +127,9 @@ class AppEventRunnerImpl : public AppEventRunner {
     if (main_runner_) {
       main_runner_->Shutdown();
     }
+
+    // Flush all open stdio streams before the process exits.
+    std::fflush(nullptr);
 
     // Destroy only after main_runner_/ContentMainRunnerImpl is shutdown
     // as the delegate is used internally.

--- a/third_party/musl/BUILD.gn
+++ b/third_party/musl/BUILD.gn
@@ -835,6 +835,7 @@ static_library("c_internal") {
     "src/stdio/__lockfile.c",
     "src/stdio/__overflow.c",
     "src/stdio/__stdio_close.c",
+    "src/stdio/__stdio_exit.c",
     "src/stdio/__stdio_read.c",
     "src/stdio/__stdio_seek.c",
     "src/stdio/__stdio_write.c",

--- a/third_party/musl/src/stdio/__toread.c
+++ b/third_party/musl/src/stdio/__toread.c
@@ -14,9 +14,7 @@ int __toread(FILE *f)
 }
 
 // This function is unused, and leaks __stdio_exit_needed.
-#ifndef STARBOARD
 hidden void __toread_needs_stdio_exit()
 {
 	__stdio_exit_needed();
 }
-#endif // STARBOARD


### PR DESCRIPTION
Included src/stdio/__stdio_exit.c in the musl build to provide the __stdio_exit_needed symbol, which was causing link failures in modular devel builds due to ASan preventing dead code elimination of unused hooks in __towrite.c.

Also enabled explicit stdio flushing by calling fflush(nullptr) during Cobalt's shutdown sequence in AppEventRunnerImpl::DoStop().

Removed the now-unnecessary STARBOARD guard in musl's __toread.c.

Bug: 503814135