### PR TITLE
starboard: Migrate MediaCodecDecoder to use sb::Thread

### DIFF
--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -90,7 +90,32 @@ class MediaCodecDecoder::DecoderThread : public Thread {
   }
 
  private:
-  MediaCodecDecoder* decoder_;
+  MediaCodecDecoder* const decoder_;
+};
+
+class MediaCodecDecoder::VideoInputThread : public Thread {
+ public:
+  explicit VideoInputThread(MediaCodecDecoder* decoder)
+      : Thread("VidDecIn"), decoder_(decoder) {}
+
+  void Run() override { decoder_->InputThreadFunc(); }
+
+ private:
+  MediaCodecDecoder* const decoder_;
+};
+
+class MediaCodecDecoder::VideoOutputThread : public Thread {
+ public:
+  explicit VideoOutputThread(MediaCodecDecoder* decoder)
+      : Thread("VidDecOut"), decoder_(decoder) {}
+
+  void Run() override {
+    SbThreadSetPriority(kSbThreadPriorityHigh);
+    decoder_->OutputThreadFunc();
+  }
+
+ private:
+  MediaCodecDecoder* const decoder_;
 };
 
 // static
@@ -293,13 +318,11 @@ void MediaCodecDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
 
   if (use_dual_threads_) {
     SB_DCHECK_EQ(media_type_, kSbMediaTypeVideo);
-    if (video_input_thread_ == 0) {
-      pthread_create(&video_input_thread_, nullptr,
-                     &MediaCodecDecoder::InputThreadEntryPoint, this);
-      pthread_create(&video_output_thread_, nullptr,
-                     &MediaCodecDecoder::OutputThreadEntryPoint, this);
-      SB_DCHECK_NE(video_input_thread_, 0);
-      SB_DCHECK_NE(video_output_thread_, 0);
+    if (!video_input_thread_) {
+      video_input_thread_ = std::make_unique<VideoInputThread>(this);
+      video_input_thread_->Start();
+      video_output_thread_ = std::make_unique<VideoOutputThread>(this);
+      video_output_thread_->Start();
     }
   } else if (!decoder_thread_) {
     decoder_thread_ = std::make_unique<DecoderThread>(this);
@@ -343,7 +366,6 @@ void MediaCodecDecoder::SetPlaybackRate(double playback_rate) {
 }
 
 // TODO(b/329686979): Abstract common code of thread creation functions.
-// TODO(b/329686979): Implement thread logic using //starboard/common/thread.h.
 void MediaCodecDecoder::DecoderThreadFunc() {
   // Initialize() should be called before creating the thread, where `error_cb_`
   // is set.  Check `error_cb_` here to ensure Initialize() has been called.
@@ -485,17 +507,6 @@ void MediaCodecDecoder::DecoderThreadFunc() {
   SB_LOG(INFO) << "Destroying decoder thread.";
 }
 
-// static
-void* MediaCodecDecoder::InputThreadEntryPoint(void* context) {
-  SB_CHECK(context);
-  MediaCodecDecoder* decoder = static_cast<MediaCodecDecoder*>(context);
-  pthread_setname_np(pthread_self(), "VidDecIn");
-
-  decoder->InputThreadFunc();
-  base::android::DetachFromVM();
-  return nullptr;
-}
-
 void MediaCodecDecoder::InputThreadFunc() {
   // Initialize() should be called before creating the thread, where `error_cb_`
   // is set.  Check `error_cb_` here to ensure Initialize() has been called.
@@ -534,18 +545,6 @@ void MediaCodecDecoder::InputThreadFunc() {
       CollectPendingInputData_Locked(&pending_inputs, &input_buffer_indices);
     }
   }
-}
-
-// static
-void* MediaCodecDecoder::OutputThreadEntryPoint(void* context) {
-  SB_CHECK(context);
-  MediaCodecDecoder* decoder = static_cast<MediaCodecDecoder*>(context);
-  pthread_setname_np(pthread_self(), "VidDecOut");
-  SbThreadSetPriority(kSbThreadPriorityHigh);
-
-  decoder->OutputThreadFunc();
-  base::android::DetachFromVM();
-  return nullptr;
 }
 
 void MediaCodecDecoder::OutputThreadFunc() {
@@ -603,16 +602,16 @@ void MediaCodecDecoder::TerminateDecoderThread() {
     }
   }
 
-  if (video_input_thread_ != 0) {
+  if (video_input_thread_) {
     SB_DCHECK(use_dual_threads_);
-    SB_CHECK_EQ(pthread_join(video_input_thread_, nullptr), 0);
-    video_input_thread_ = 0;
+    video_input_thread_->Join();
+    video_input_thread_.reset();
   }
 
-  if (video_output_thread_ != 0) {
+  if (video_output_thread_) {
     SB_DCHECK(use_dual_threads_);
-    SB_CHECK_EQ(pthread_join(video_output_thread_, nullptr), 0);
-    video_output_thread_ = 0;
+    video_output_thread_->Join();
+    video_output_thread_.reset();
   }
 
   if (decoder_thread_) {
@@ -912,7 +911,7 @@ void MediaCodecDecoder::OnMediaCodecOutputBufferAvailable(
 
   // TODO(b/291959069): After the output thread is destroyed, it may still
   // receive output buffer, discard this invalid output buffer.
-  if (destroying_.load() || (!decoder_thread_ && video_output_thread_ == 0)) {
+  if (destroying_.load() || (!decoder_thread_ && !video_output_thread_)) {
     return;
   }
 

--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -79,43 +79,23 @@ const char* GetDecoderName(SbMediaType media_type) {
 
 class MediaCodecDecoder::DecoderThread : public Thread {
  public:
-  explicit DecoderThread(MediaCodecDecoder* decoder)
-      : Thread(GetDecoderName(decoder->media_type_)), decoder_(decoder) {}
+  DecoderThread(std::string_view name,
+                std::function<void()> runnable,
+                std::optional<SbThreadPriority> priority = std::nullopt)
+      : Thread(name), runnable_(std::move(runnable)), priority_(priority) {
+    SB_CHECK(runnable_);
+  }
 
   void Run() override {
-    SbThreadSetPriority(decoder_->media_type_ == kSbMediaTypeAudio
-                            ? kSbThreadPriorityNormal
-                            : kSbThreadPriorityHigh);
-    decoder_->DecoderThreadFunc();
+    if (priority_) {
+      SbThreadSetPriority(priority_.value());
+    }
+    runnable_();
   }
 
  private:
-  MediaCodecDecoder* const decoder_;
-};
-
-class MediaCodecDecoder::VideoInputThread : public Thread {
- public:
-  explicit VideoInputThread(MediaCodecDecoder* decoder)
-      : Thread("VidDecIn"), decoder_(decoder) {}
-
-  void Run() override { decoder_->InputThreadFunc(); }
-
- private:
-  MediaCodecDecoder* const decoder_;
-};
-
-class MediaCodecDecoder::VideoOutputThread : public Thread {
- public:
-  explicit VideoOutputThread(MediaCodecDecoder* decoder)
-      : Thread("VidDecOut"), decoder_(decoder) {}
-
-  void Run() override {
-    SbThreadSetPriority(kSbThreadPriorityHigh);
-    decoder_->OutputThreadFunc();
-  }
-
- private:
-  MediaCodecDecoder* const decoder_;
+  const std::function<void()> runnable_;
+  const std::optional<SbThreadPriority> priority_;
 };
 
 // static
@@ -319,13 +299,18 @@ void MediaCodecDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
   if (use_dual_threads_) {
     SB_DCHECK_EQ(media_type_, kSbMediaTypeVideo);
     if (!video_input_thread_) {
-      video_input_thread_ = std::make_unique<VideoInputThread>(this);
+      video_input_thread_ = std::make_unique<DecoderThread>(
+          "VidDecIn", [this] { InputThreadFunc(); });
       video_input_thread_->Start();
-      video_output_thread_ = std::make_unique<VideoOutputThread>(this);
+      video_output_thread_ = std::make_unique<DecoderThread>(
+          "VidDecOut", [this] { OutputThreadFunc(); }, kSbThreadPriorityHigh);
       video_output_thread_->Start();
     }
   } else if (!decoder_thread_) {
-    decoder_thread_ = std::make_unique<DecoderThread>(this);
+    decoder_thread_ = std::make_unique<DecoderThread>(
+        GetDecoderName(media_type_), [this] { DecoderThreadFunc(); },
+        media_type_ == kSbMediaTypeAudio ? kSbThreadPriorityNormal
+                                         : kSbThreadPriorityHigh);
     decoder_thread_->Start();
   }
 

--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -15,8 +15,6 @@
 #ifndef STARBOARD_ANDROID_SHARED_MEDIA_DECODER_H_
 #define STARBOARD_ANDROID_SHARED_MEDIA_DECODER_H_
 
-#include <jni.h>
-
 #include <atomic>
 #include <deque>
 #include <memory>
@@ -186,10 +184,10 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
   // TODO(b/329686979): Consider turning MediaDecoder into a class hierarchy to
   // simplify the handling of threading, including the difference of a/v
   // threading in the original implementation in DecoderThreadFunc() above.
-  static void* InputThreadEntryPoint(void* context);
+  class VideoInputThread;
   void InputThreadFunc();
 
-  static void* OutputThreadEntryPoint(void* context);
+  class VideoOutputThread;
   void OutputThreadFunc();
 
   void TerminateDecoderThread();
@@ -267,9 +265,9 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
   // Working threads to avoid lengthy decoding work block the player thread.
   std::unique_ptr<Thread> decoder_thread_;
   // Only used when |use_dual_threads_| is true.
-  pthread_t video_input_thread_ = 0;
+  std::unique_ptr<Thread> video_input_thread_;
   // Only used when |use_dual_threads_| is true.
-  pthread_t video_output_thread_ = 0;
+  std::unique_ptr<Thread> video_output_thread_;
 
   std::unique_ptr<MediaCodecBridge> media_codec_bridge_;
 };

--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -178,7 +178,6 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
   };
 
   class DecoderThread;
-
   void DecoderThreadFunc();
 
   // TODO(b/329686979): Consider turning MediaDecoder into a class hierarchy to

--- a/starboard/android/shared/media_decoder.h
+++ b/starboard/android/shared/media_decoder.h
@@ -183,10 +183,8 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
   // TODO(b/329686979): Consider turning MediaDecoder into a class hierarchy to
   // simplify the handling of threading, including the difference of a/v
   // threading in the original implementation in DecoderThreadFunc() above.
-  class VideoInputThread;
   void InputThreadFunc();
 
-  class VideoOutputThread;
   void OutputThreadFunc();
 
   void TerminateDecoderThread();


### PR DESCRIPTION
Migrate MediaCodecDecoder's video input and output threads from raw
pthreads to the Starboard Thread abstraction. This change implements
VideoInputThread and VideoOutputThread as nested classes inheriting
from Thread, replacing pthread_t handles with std::unique_ptr<Thread>.

This improves consistency with the existing decoder_thread_, simplifies
thread lifecycle management by using Thread::Start() and Thread::Join(),
and removes redundant base::android::DetachFromVM() calls, as these are
now handled by sb::Thread's TerminateOnThread on Android. The change
also cleans up unnecessary headers and updates back-pointers to be const.

Bug: 468356861