### PR TITLE
Resolve circular dependency for updater

### DIFF
--- a/cobalt/browser/switches.h
+++ b/cobalt/browser/switches.h
@@ -35,14 +35,6 @@ constexpr char kEnforceHTTPS[] = "https-enforcement";
 // Specify the initial window size: --window-size=w,h
 constexpr char kWindowSize[] = "window-size";
 
-// Whether to request, download, and install uncompressed (rather than
-// compressed) Evergreen binaries.
-constexpr char kUseUncompressedUpdates[] = "use_uncompressed_updates";
-
-// Uses the QA update server to test the changes to the configuration of the
-// PROD update server.
-constexpr char kUseQAUpdateServer[] = "use_qa_update_server";
-
 }  // namespace switches
 }  // namespace cobalt
 

--- a/cobalt/updater/BUILD.gn
+++ b/cobalt/updater/BUILD.gn
@@ -30,7 +30,6 @@ static_library("updater") {
 
   deps = [
     "//base",
-    "//cobalt/browser:switches",
     "//components/crx_file",
     "//components/prefs",
     "//components/update_client",

--- a/cobalt/updater/configurator.cc
+++ b/cobalt/updater/configurator.cc
@@ -19,8 +19,9 @@
 #include <utility>
 
 #include "base/command_line.h"
+#include "base/functional/bind.h"
+#include "base/time/time.h"
 #include "base/version.h"
-#include "cobalt/browser/switches.h"
 #include "cobalt/updater/network_fetcher.h"
 #include "cobalt/updater/patcher.h"
 #include "cobalt/updater/prefs.h"
@@ -48,6 +49,14 @@ const char kUpdaterJSONDefaultUrlQA[] =
 const char kUpdaterJSONDefaultUrl[] =
     "https://tools.google.com/service/update2/json";
 
+// Whether to request, download, and install uncompressed (rather than
+// compressed) Evergreen binaries.
+constexpr char kUseUncompressedUpdates[] = "use_uncompressed_updates";
+
+// Uses the QA update server to test the changes to the configuration of the
+// PROD update server.
+constexpr char kUseQAUpdateServer[] = "use_qa_update_server";
+
 std::string GetDeviceProperty(SbSystemPropertyId id) {
   char value[kSystemPropertyMaxLength];
   if (SbSystemGetProperty(id, value, kSystemPropertyMaxLength)) {
@@ -64,9 +73,9 @@ namespace updater {
 Configurator::Configurator(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
     : pref_service_(CreatePrefService()),
-      persisted_data_(
-          std::make_unique<update_client::PersistedData>(pref_service_.get(),
-                                                         nullptr)),
+      persisted_data_(update_client::CreatePersistedData(
+          base::BindRepeating([](PrefService* p) { return p; }, pref_service_.get()),
+          nullptr)),
       network_fetcher_factory_(
           base::MakeRefCounted<NetworkFetcherFactoryCobalt>(
               url_loader_factory)),
@@ -87,7 +96,7 @@ Configurator::Configurator(
     SetChannel(persisted_channel);
   }
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kUseUncompressedUpdates)) {
+          kUseUncompressedUpdates)) {
     use_compressed_updates_.store(false);
   } else {
     use_compressed_updates_.store(true);
@@ -114,13 +123,13 @@ base::TimeDelta Configurator::UpdateDelay() const {
 }
 
 std::vector<GURL> Configurator::UpdateUrl() const {
-#if !defined(COBALT_BUILD_TYPE_GOLD)
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+  base::AutoLock auto_lock(const_cast<base::Lock&>(update_server_url_lock_));
   if (allow_self_signed_packages_ && !update_server_url_.empty()) {
     return std::vector<GURL>{GURL(update_server_url_)};
   }
-#endif  // !defined(COBALT_BUILD_TYPE_GOLD)
-  if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kUseQAUpdateServer)) {
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch(kUseQAUpdateServer)) {
     return std::vector<GURL>{GURL(kUpdaterJSONDefaultUrlQA)};
   } else {
     return std::vector<GURL>{GURL(kUpdaterJSONDefaultUrl)};
@@ -300,11 +309,11 @@ std::string Configurator::GetAppGuidHelper(const std::string& updater_channel,
             << "combination is undefined with the new Omaha configs.";
 
   // All undefined channel requests go to prod configs except for static
-  // channel requestsf for C24 and older.
+  // channel requests for C24 and older.
   // TODO(b/449024263): Replace regex matchers with substring_set_matcher or re2
   if (!std::regex_match(updater_channel, std::regex("2[0-4]lts\\d+")) &&
       sb_version >= 14 && sb_version <= 16) {
-    const auto it = kChannelAndSbVersionToOmahaIdMap.find(
+    it = kChannelAndSbVersionToOmahaIdMap.find(
         "prod" + std::to_string(sb_version));
     if (it != kChannelAndSbVersionToOmahaIdMap.end()) {
       return it->second;
@@ -315,6 +324,7 @@ std::string Configurator::GetAppGuidHelper(const std::string& updater_channel,
 }
 
 std::string Configurator::GetAppGuid() const {
+  base::AutoLock auto_lock(const_cast<base::Lock&>(updater_channel_lock_));
   const std::string version(COBALT_VERSION);
   return GetAppGuidHelper(updater_channel_, version, SB_API_VERSION);
 }

--- a/cobalt/updater/configurator.cc
+++ b/cobalt/updater/configurator.cc
@@ -74,7 +74,8 @@ Configurator::Configurator(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
     : pref_service_(CreatePrefService()),
       persisted_data_(update_client::CreatePersistedData(
-          base::BindRepeating([](PrefService* p) { return p; }, pref_service_.get()),
+          base::BindRepeating([](PrefService* p) { return p; },
+                              pref_service_.get()),
           nullptr)),
       network_fetcher_factory_(
           base::MakeRefCounted<NetworkFetcherFactoryCobalt>(
@@ -124,7 +125,7 @@ base::TimeDelta Configurator::UpdateDelay() const {
 
 std::vector<GURL> Configurator::UpdateUrl() const {
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
-  base::AutoLock auto_lock(const_cast<base::Lock&>(update_server_url_lock_));
+  base::AutoLock auto_lock(update_server_url_lock_);
   if (allow_self_signed_packages_ && !update_server_url_.empty()) {
     return std::vector<GURL>{GURL(update_server_url_)};
   }
@@ -313,8 +314,8 @@ std::string Configurator::GetAppGuidHelper(const std::string& updater_channel,
   // TODO(b/449024263): Replace regex matchers with substring_set_matcher or re2
   if (!std::regex_match(updater_channel, std::regex("2[0-4]lts\\d+")) &&
       sb_version >= 14 && sb_version <= 16) {
-    it = kChannelAndSbVersionToOmahaIdMap.find(
-        "prod" + std::to_string(sb_version));
+    it = kChannelAndSbVersionToOmahaIdMap.find("prod" +
+                                               std::to_string(sb_version));
     if (it != kChannelAndSbVersionToOmahaIdMap.end()) {
       return it->second;
     }
@@ -324,7 +325,7 @@ std::string Configurator::GetAppGuidHelper(const std::string& updater_channel,
 }
 
 std::string Configurator::GetAppGuid() const {
-  base::AutoLock auto_lock(const_cast<base::Lock&>(updater_channel_lock_));
+  base::AutoLock auto_lock(updater_channel_lock_);
   const std::string version(COBALT_VERSION);
   return GetAppGuidHelper(updater_channel_, version, SB_API_VERSION);
 }
@@ -342,7 +343,7 @@ void Configurator::CompareAndSwapForcedUpdate(int old_value, int new_value) {
 // client thread. The getter and set use a lock to prevent synchronization
 // issue.
 std::string Configurator::GetChannel() const {
-  base::AutoLock auto_lock(const_cast<base::Lock&>(updater_channel_lock_));
+  base::AutoLock auto_lock(updater_channel_lock_);
   return updater_channel_;
 }
 
@@ -355,7 +356,7 @@ void Configurator::SetChannel(const std::string& updater_channel) {
 // The updater status is get by main web module thread and set by the updater
 // thread. The getter and set use a lock to prevent synchronization issue.
 std::string Configurator::GetUpdaterStatus() const {
-  base::AutoLock auto_lock(const_cast<base::Lock&>(updater_status_lock_));
+  base::AutoLock auto_lock(updater_status_lock_);
   return updater_status_;
 }
 
@@ -365,18 +366,17 @@ void Configurator::SetUpdaterStatus(const std::string& status) {
 }
 
 void Configurator::SetMinFreeSpaceBytes(uint64_t bytes) {
-  base::AutoLock auto_lock(const_cast<base::Lock&>(min_free_space_bytes_lock_));
+  base::AutoLock auto_lock(min_free_space_bytes_lock_);
   min_free_space_bytes_ = bytes;
 }
 
-uint64_t Configurator::GetMinFreeSpaceBytes() {
-  base::AutoLock auto_lock(const_cast<base::Lock&>(min_free_space_bytes_lock_));
+uint64_t Configurator::GetMinFreeSpaceBytes() const {
+  base::AutoLock auto_lock(min_free_space_bytes_lock_);
   return min_free_space_bytes_;
 }
 
 std::string Configurator::GetPreviousUpdaterStatus() const {
-  base::AutoLock auto_lock(
-      const_cast<base::Lock&>(previous_updater_status_lock_));
+  base::AutoLock auto_lock(previous_updater_status_lock_);
   return previous_updater_status_;
 }
 
@@ -402,7 +402,7 @@ void Configurator::SetAllowSelfSignedPackages(bool allow_self_signed_packages) {
 }
 
 std::string Configurator::GetUpdateServerUrl() const {
-  base::AutoLock auto_lock(const_cast<base::Lock&>(update_server_url_lock_));
+  base::AutoLock auto_lock(update_server_url_lock_);
   return update_server_url_;
 }
 

--- a/cobalt/updater/configurator.h
+++ b/cobalt/updater/configurator.h
@@ -140,20 +140,20 @@ class Configurator : public update_client::Configurator {
   scoped_refptr<update_client::PatcherFactory> patch_factory_;
   // TODO(b/449220798): Consider using PostTask and thread checker
   std::string updater_channel_ GUARDED_BY(updater_channel_lock_);
-  base::Lock updater_channel_lock_;
+  mutable base::Lock updater_channel_lock_;
   std::atomic<int32_t> is_forced_update_;
   std::string updater_status_ GUARDED_BY(updater_status_lock_);
-  base::Lock updater_status_lock_;
+  mutable base::Lock updater_status_lock_;
   std::string previous_updater_status_
       GUARDED_BY(previous_updater_status_lock_);
-  base::Lock previous_updater_status_lock_;
+  mutable base::Lock previous_updater_status_lock_;
   std::string user_agent_string_;
-  uint64_t min_free_space_bytes_ GUARDED_BY(min_free_space_bytes_lock_);
-  base::Lock min_free_space_bytes_lock_;
+  uint64_t min_free_space_bytes_GUARDED_BY(min_free_space_bytes_lock_);
+  mutable base::Lock min_free_space_bytes_lock_;
   std::atomic_bool use_compressed_updates_;
   std::atomic_bool allow_self_signed_packages_;
   std::string update_server_url_ GUARDED_BY(update_server_url_lock_);
-  base::Lock update_server_url_lock_;
+  mutable base::Lock update_server_url_lock_;
   std::atomic_bool require_network_encryption_;
 };
 

--- a/cobalt/updater/network_fetcher.cc
+++ b/cobalt/updater/network_fetcher.cc
@@ -187,8 +187,8 @@ void NetworkFetcher::DownloadToFile(
       url_loader_factory_.get(),
       base::BindOnce(
           [](const network::SimpleURLLoader* simple_url_loader,
-             DownloadToFileCompleteCallback
-                 download_to_file_complete_callback) {
+             DownloadToFileCompleteCallback download_to_file_complete_callback,
+             base::FilePath file_path) {
             std::move(download_to_file_complete_callback)
                 .Run(simple_url_loader->NetError(),
                      simple_url_loader->GetContentSize());

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -100,22 +100,22 @@ void Observer::OnEvent(Events event, const std::string& id) {
   std::string status;
   if (update_client_->GetCrxUpdateState(id, &crx_update_item_)) {
     auto status_iterator =
-        component_to_updater_status_map.find(crx_update_item_.state);
-    if (status_iterator == component_to_updater_status_map.end()) {
+        update_client::GetComponentToUpdaterStatusMap().find(crx_update_item_.state);
+    if (status_iterator == update_client::GetComponentToUpdaterStatusMap().end()) {
       status = "Status is unknown.";
     } else if (crx_update_item_.state == ComponentState::kUpToDate &&
                updater_configurator_->GetPreviousUpdaterStatus() ==
-                   updater_status_string_map.at(UpdaterStatus::kUpdated)) {
-      status = updater_status_string_map.at(UpdaterStatus::kUpdated);
+                   update_client::GetUpdaterStatusStringMap().at(UpdaterStatus::kUpdated)) {
+      status = update_client::GetUpdaterStatusStringMap().at(UpdaterStatus::kUpdated);
     } else {
-      status = updater_status_string_map.find(status_iterator->second)->second;
+      status = update_client::GetUpdaterStatusStringMap().find(status_iterator->second)->second;
     }
     if (crx_update_item_.state == ComponentState::kUpdateError) {
       // `QUICK_ROLL_FORWARD` update, adjust the message to "Updated locally,
       // pending restart".
       if (crx_update_item_.error_code ==
           static_cast<int>(UpdateCheckError::QUICK_ROLL_FORWARD)) {
-        status = updater_status_string_map.at(UpdaterStatus::kRolledForward);
+        status = update_client::GetUpdaterStatusStringMap().at(UpdaterStatus::kRolledForward);
       } else {
         status +=
             ", error category is " +

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -99,23 +99,29 @@ const base::TimeDelta kDefaultUpdateCheckDelay =
 void Observer::OnEvent(Events event, const std::string& id) {
   std::string status;
   if (update_client_->GetCrxUpdateState(id, &crx_update_item_)) {
-    auto status_iterator =
-        update_client::GetComponentToUpdaterStatusMap().find(crx_update_item_.state);
-    if (status_iterator == update_client::GetComponentToUpdaterStatusMap().end()) {
+    auto status_iterator = update_client::GetComponentToUpdaterStatusMap().find(
+        crx_update_item_.state);
+    if (status_iterator ==
+        update_client::GetComponentToUpdaterStatusMap().end()) {
       status = "Status is unknown.";
     } else if (crx_update_item_.state == ComponentState::kUpToDate &&
                updater_configurator_->GetPreviousUpdaterStatus() ==
-                   update_client::GetUpdaterStatusStringMap().at(UpdaterStatus::kUpdated)) {
-      status = update_client::GetUpdaterStatusStringMap().at(UpdaterStatus::kUpdated);
+                   update_client::GetUpdaterStatusStringMap().at(
+                       UpdaterStatus::kUpdated)) {
+      status = update_client::GetUpdaterStatusStringMap().at(
+          UpdaterStatus::kUpdated);
     } else {
-      status = update_client::GetUpdaterStatusStringMap().find(status_iterator->second)->second;
+      status = update_client::GetUpdaterStatusStringMap()
+                   .find(status_iterator->second)
+                   ->second;
     }
     if (crx_update_item_.state == ComponentState::kUpdateError) {
       // `QUICK_ROLL_FORWARD` update, adjust the message to "Updated locally,
       // pending restart".
       if (crx_update_item_.error_code ==
           static_cast<int>(UpdateCheckError::QUICK_ROLL_FORWARD)) {
-        status = update_client::GetUpdaterStatusStringMap().at(UpdaterStatus::kRolledForward);
+        status = update_client::GetUpdaterStatusStringMap().at(
+            UpdaterStatus::kRolledForward);
       } else {
         status +=
             ", error category is " +

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -33,7 +33,6 @@
 #include "base/threading/thread.h"
 #include "base/time/time.h"
 #include "base/version.h"
-#include "cobalt/browser/switches.h"
 #include "cobalt/updater/util.h"
 #include "components/crx_file/crx_verifier.h"
 #include "components/update_client/cobalt_slot_management.h"
@@ -297,13 +296,13 @@ void UpdaterModule::Update() {
     return;
   }
 
-#if !defined(COBALT_BUILD_TYPE_GOLD)
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   bool skip_verify_public_key_hash = GetAllowSelfSignedPackages();
   bool require_network_encryption = GetRequireNetworkEncryption();
 #else
   bool skip_verify_public_key_hash = false;
   bool require_network_encryption = true;
-#endif  // defined(COBALT_BUILD_TYPE_GOLD)
+#endif  // BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
   update_client_->Update(
       app_ids,
@@ -319,12 +318,12 @@ void UpdaterModule::Update() {
             component.pk_hash.assign(std::begin(kCobaltPublicKeyHash),
                                      std::end(kCobaltPublicKeyHash));
             component.requires_network_encryption = true;
-#if !defined(COBALT_BUILD_TYPE_GOLD)
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
             if (skip_verify_public_key_hash) {
               component.pk_hash.clear();
             }
             component.requires_network_encryption = require_network_encryption;
-#endif  // !defined(COBALT_BUILD_TYPE_GOLD)
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
             component.crx_format_requirement = crx_file::VerifierFormat::CRX3;
             return {component};
           },

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -37,66 +37,6 @@
 namespace cobalt {
 namespace updater {
 
-using update_client::ComponentState;
-
-enum class UpdaterStatus {
-  kNewUpdate,
-  kChecking,
-  kUpdateAvailable,
-  kDownloadingDiff,
-  kDownloading,
-  kSlotLocked,
-  kDownloaded,
-  kUpdatingDiff,
-  kUpdating,
-  kUpdated,
-  kRolledForward,
-  kUpToDate,
-  kUpdateError,
-  kUninstalled,
-  kRun
-};
-
-// Mapping a component state to an updater status. Used when logging and
-// processing the updater status.
-// clang-format off
-const std::map<ComponentState, UpdaterStatus> component_to_updater_status_map = {
-    // clang-format on
-    {ComponentState::kNew, UpdaterStatus::kNewUpdate},
-    {ComponentState::kChecking, UpdaterStatus::kChecking},
-    {ComponentState::kCanUpdate, UpdaterStatus::kUpdateAvailable},
-    {ComponentState::kDownloadingDiff, UpdaterStatus::kDownloadingDiff},
-    {ComponentState::kDownloading, UpdaterStatus::kDownloading},
-    {ComponentState::kDownloaded, UpdaterStatus::kDownloaded},
-    {ComponentState::kUpdatingDiff, UpdaterStatus::kUpdatingDiff},
-    {ComponentState::kUpdating, UpdaterStatus::kUpdating},
-    {ComponentState::kUpdated, UpdaterStatus::kUpdated},
-    {ComponentState::kUpToDate, UpdaterStatus::kUpToDate},
-    {ComponentState::kUpdateError, UpdaterStatus::kUpdateError},
-    {ComponentState::kUninstalled, UpdaterStatus::kUninstalled},
-    {ComponentState::kRun, UpdaterStatus::kRun},
-};
-
-// Translating an updater status to a status string. Used when logging the
-// status and passing the status to the app to show in the UI.
-const std::map<UpdaterStatus, const char*> updater_status_string_map = {
-    {UpdaterStatus::kNewUpdate, "Will check for update soon"},
-    {UpdaterStatus::kChecking, "Checking for update"},
-    {UpdaterStatus::kUpdateAvailable, "Update is available"},
-    {UpdaterStatus::kDownloadingDiff, "Downloading delta update"},
-    {UpdaterStatus::kDownloading, "Downloading update"},
-    {UpdaterStatus::kSlotLocked, "Slot is locked"},
-    {UpdaterStatus::kDownloaded, "Update is downloaded"},
-    {UpdaterStatus::kUpdatingDiff, "Installing delta update"},
-    {UpdaterStatus::kUpdating, "Installing update"},
-    {UpdaterStatus::kUpdated, "Update installed, pending restart"},
-    {UpdaterStatus::kRolledForward, "Updated locally, pending restart"},
-    {UpdaterStatus::kUpToDate, "App is up to date"},
-    {UpdaterStatus::kUpdateError, "Failed to update"},
-    {UpdaterStatus::kUninstalled, "Update uninstalled"},
-    {UpdaterStatus::kRun, "Transitioning..."},
-};
-
 // Default delay the first update check.
 extern const base::TimeDelta kDefaultUpdateCheckDelay;
 

--- a/components/update_client/cobalt_slot_management.cc
+++ b/components/update_client/cobalt_slot_management.cc
@@ -22,7 +22,6 @@
 #include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/values.h"
-#include "cobalt/updater/util.h"
 #include "components/update_client/utils.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/file.h"
@@ -126,7 +125,7 @@ bool CobaltSlotManagement::SelectSlot(base::FilePath* dir) {
       continue;
     }
 
-    SB_DLOG(INFO) << "CobaltSlotManagement::SelectSlot: installation_path = "
+    SB_LOG(INFO) << "CobaltSlotManagement::SelectSlot: installation_path = "
                   << installation_path.data();
 
     base::FilePath installation_dir(
@@ -138,8 +137,7 @@ bool CobaltSlotManagement::SelectSlot(base::FilePath* dir) {
     // Cleanup all drain files from the current app.
     DrainFileClearForApp(installation_dir.value().c_str(), app_key_.c_str());
 
-    base::Version version =
-        cobalt::updater::ReadEvergreenVersion(installation_dir);
+    base::Version version = ReadEvergreenVersion(installation_dir);
     if (!version.IsValid()) {
       LOG(INFO) << "CobaltSlotManagement::SelectSlot installed version invalid";
       if (!DrainFileIsAnotherAppDraining(installation_dir.value().c_str(),
@@ -189,7 +187,7 @@ bool CobaltSlotManagement::ConfirmSlot(const base::FilePath& dir) {
   if (!initialized_) {
     return false;
   }
-  LOG(INFO) << "CobaltSlotManagement::ConfirmSlot ";
+  LOG(INFO) << "CobaltSlotManagement::ConfirmSlot, dir = " << dir.value().c_str();
   if (!DrainFileRankAndCheck(dir.value().c_str(), app_key_.c_str())) {
     LOG(INFO) << "CobaltSlotManagement::ConfirmSlot: failed to lock slot ";
     return false;
@@ -315,14 +313,14 @@ bool CobaltQuickUpdate(
       continue;
     }
 
-    SB_DLOG(INFO) << "CobaltQuickInstallation: installation_path = "
+    SB_LOG(INFO) << "CobaltQuickInstallation: installation_path = "
                   << installation_path.data();
 
     base::FilePath installation_dir = base::FilePath(
         std::string(installation_path.begin(), installation_path.end()));
 
     base::Version installed_version =
-        cobalt::updater::ReadEvergreenVersion(installation_dir);
+        ReadEvergreenVersion(installation_dir);
 
     std::string good_app_key_file_path =
         loader_app::GetGoodAppKeyFilePath(

--- a/components/update_client/component.cc
+++ b/components/update_client/component.cc
@@ -405,6 +405,12 @@ void Component::StateNew::DoHandle() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 
   auto& component = State::component();
+
+#if BUILDFLAG(IS_STARBOARD)
+  auto& config = component.update_context_->config;
+  config->SetPreviousUpdaterStatus(config->GetUpdaterStatus());
+#endif
+
   if (component.crx_component()) {
     TransitionState(std::make_unique<StateChecking>(&component));
 

--- a/components/update_client/network.h
+++ b/components/update_client/network.h
@@ -85,7 +85,11 @@ class NetworkFetcher {
       ProgressCallback progress_callback,
       DownloadToFileCompleteCallback download_to_file_complete_callback) = 0;
 
- protected:
+#if BUILDFLAG(IS_STARBOARD)
+  virtual void Cancel() = 0;
+#endif
+
+protected:
   NetworkFetcher() = default;
 };
 

--- a/components/update_client/request_sender.cc
+++ b/components/update_client/request_sender.cc
@@ -137,12 +137,9 @@ void RequestSender::SendInternal() {
 #if BUILDFLAG(IS_STARBOARD)
 void RequestSender::Cancel() {
   LOG(INFO) << "RequestSender::Cancel";
-  // TODO(b/431862767): enable this in a follow-up PR with the Cobalt network
-  // fetcher implementation
-  NOTIMPLEMENTED();
-  // if (network_fetcher_.get()) {
-  //   network_fetcher_->Cancel();
-  // }
+  if (network_fetcher_.get()) {
+    network_fetcher_->Cancel();
+  }
 }
 #endif
 

--- a/components/update_client/update_checker.cc
+++ b/components/update_client/update_checker.cc
@@ -44,6 +44,8 @@
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/cobalt_slot_management.h"
 #include "starboard/extension/free_space.h"
+#include "starboard/extension/installation_manager.h"
+#include "starboard/system.h"  // nogncheck
 #endif
 
 namespace update_client {

--- a/components/update_client/url_fetcher_downloader.cc
+++ b/components/update_client/url_fetcher_downloader.cc
@@ -133,7 +133,7 @@ void UrlFetcherDownloader::SelectSlot(const GURL& url) {
     return;
   }
   config_->SetUpdaterStatus(std::string(
-      updater_status_string_map.find(UpdaterStatus::kSlotLocked)->second));
+      GetUpdaterStatusStringMap().find(UpdaterStatus::kSlotLocked)->second));
   // Use 15 sec delay to allow for other updaters/loaders to settle down.
   base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE,

--- a/components/update_client/url_fetcher_downloader.cc
+++ b/components/update_client/url_fetcher_downloader.cc
@@ -33,7 +33,7 @@
 
 namespace {
 
-#if BUILDFLAG(IS_STARBOARD)
+#if BUILDFLAG(IS_STARBOARD) && !defined(IN_MEMORY_UPDATES)
 // Can't simply use base::DeletePathRecursively() because the empty dirs
 // need to be preserved.
 void CleanupDirectory(base::FilePath& dir) {
@@ -132,6 +132,8 @@ void UrlFetcherDownloader::SelectSlot(const GURL& url) {
     ReportDownloadFailure(url, CrxDownloaderError::SLOT_UNAVAILABLE);
     return;
   }
+  config_->SetUpdaterStatus(std::string(
+      updater_status_string_map.find(UpdaterStatus::kSlotLocked)->second));
   // Use 15 sec delay to allow for other updaters/loaders to settle down.
   base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
       FROM_HERE,
@@ -191,11 +193,9 @@ void UrlFetcherDownloader::DoCancelDownload() {
   LOG(INFO) << "UrlFetcherDownloader::DoCancelDownload";
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   is_cancelled_ = true;
-  // TODO(b/431862767): enable this in a follow-up PR with the Cobalt network fetcher implementation
-  NOTIMPLEMENTED();
-  // if (network_fetcher_.get()) {
-  //   network_fetcher_->Cancel();
-  // }
+  if (network_fetcher_.get()) {
+    network_fetcher_->Cancel();
+  }
 }
 #endif
 
@@ -272,6 +272,7 @@ void UrlFetcherDownloader::StartURLFetch(const GURL& url) {
       base::BindOnce(&UrlFetcherDownloader::OnNetworkFetcherComplete, this));
 #else
   file_path_ = download_dir_.AppendASCII(url.ExtractFileName());
+  LOG(INFO) << "UrlFetcherDownloader::StartURLFetch, file_path_ =" << file_path_.value().c_str();
   network_fetcher_->DownloadToFile(
       url, file_path_,
       base::BindRepeating(&UrlFetcherDownloader::OnResponseStarted, this),

--- a/components/update_client/utils.cc
+++ b/components/update_client/utils.cc
@@ -89,6 +89,85 @@ std::string GetCrxIdFromPublicKeyHash(base::span<const uint8_t> pk_hash) {
   return result;
 }
 
+#if BUILDFLAG(IS_STARBOARD)
+#if defined(IN_MEMORY_UPDATES)
+
+bool VerifyHash256(const std::string* content,
+                   const std::string& expected_hash_str) {
+  std::vector<uint8_t> expected_hash;
+  if (!base::HexStringToBytes(expected_hash_str, &expected_hash) ||
+      expected_hash.size() != crypto::kSHA256Length) {
+    return false;
+  }
+
+  uint8_t actual_hash[crypto::kSHA256Length] = {0};
+  std::unique_ptr<crypto::SecureHash> hasher(
+      crypto::SecureHash::Create(crypto::SecureHash::SHA256));
+
+  hasher->Update(content->c_str(), content->size());
+  hasher->Finish(actual_hash, sizeof(actual_hash));
+
+  return memcmp(actual_hash, &expected_hash[0], sizeof(actual_hash)) == 0;
+}
+#else  // defined(IN_MEMORY_UPDATES)
+bool VerifyFileHash256(const base::FilePath& filepath,
+                       const std::string& expected_hash_str) {
+  std::vector<uint8_t> expected_hash;
+  if (!base::HexStringToBytes(expected_hash_str, &expected_hash) ||
+      expected_hash.size() != crypto::kSHA256Length) {
+    return false;
+  }
+
+  base::File source_file(filepath,
+                         base::File::FLAG_OPEN | base::File::FLAG_READ);
+  if (!source_file.IsValid()) {
+    DPLOG(ERROR) << "VerifyFileHash256(): Unable to open source file: "
+                 << filepath.value();
+    return false;
+  }
+
+  const size_t kBufferSize = 32768;
+  std::vector<char> buffer(kBufferSize);
+  uint8_t actual_hash[crypto::kSHA256Length] = {0};
+  std::unique_ptr<crypto::SecureHash> hasher(
+      crypto::SecureHash::Create(crypto::SecureHash::SHA256));
+
+  while (true) {
+    int bytes_read = source_file.ReadAtCurrentPos(&buffer[0], buffer.size());
+    if (bytes_read < 0) {
+      DPLOG(ERROR) << "VerifyFileHash256(): error reading from source file: "
+                   << filepath.value();
+
+      return false;
+    }
+
+    if (bytes_read == 0) {
+      break;
+    }
+
+    hasher->Update(&buffer[0], bytes_read);
+  }
+
+  hasher->Finish(actual_hash, sizeof(actual_hash));
+
+  return memcmp(actual_hash, &expected_hash[0], sizeof(actual_hash)) == 0;
+}
+#endif  // defined(IN_MEMORY_UPDATES)
+
+base::Version ReadEvergreenVersion(base::FilePath installation_dir) {
+  auto manifest = ReadManifest(installation_dir);
+  if (manifest) {
+    auto version = manifest->Find("version");
+    if (version) {
+      return base::Version(version->GetString());
+    }
+  }
+  LOG(WARNING) << "ReadEvergreenVersion: unable to read version from "
+               << installation_dir.value();
+  return base::Version();
+}
+#else  // BUILDFLAG(IS_STARBOARD)
+
 bool VerifyFileHash256(const base::FilePath& filepath,
                        const std::string& expected_hash_str) {
   std::vector<uint8_t> expected_hash;
@@ -120,6 +199,8 @@ bool VerifyFileHash256(const base::FilePath& filepath,
 
   return base::span(sha256_hash) == base::span(expected_hash);
 }
+
+#endif  // BUILDFLAG(IS_STARBOARD)
 
 bool IsValidBrand(const std::string& brand) {
   const size_t kMaxBrandSize = 4;

--- a/components/update_client/utils.cc
+++ b/components/update_client/utils.cc
@@ -52,6 +52,11 @@
 #include "base/win/windows_version.h"
 #endif  // BUILDFLAG(IS_WIN)
 
+#if BUILDFLAG(IS_STARBOARD)
+#include <map>
+#include "base/no_destructor.h"
+#endif
+
 namespace update_client {
 
 const char kArchAmd64[] = "x86_64";
@@ -107,7 +112,7 @@ bool VerifyHash256(const std::string* content,
   hasher->Update(content->c_str(), content->size());
   hasher->Finish(actual_hash, sizeof(actual_hash));
 
-  return memcmp(actual_hash, &expected_hash[0], sizeof(actual_hash)) == 0;
+  return base::span(actual_hash) == base::span(expected_hash);
 }
 #else  // defined(IN_MEMORY_UPDATES)
 bool VerifyFileHash256(const base::FilePath& filepath,
@@ -150,7 +155,7 @@ bool VerifyFileHash256(const base::FilePath& filepath,
 
   hasher->Finish(actual_hash, sizeof(actual_hash));
 
-  return memcmp(actual_hash, &expected_hash[0], sizeof(actual_hash)) == 0;
+  return base::span(actual_hash) == base::span(expected_hash);
 }
 #endif  // defined(IN_MEMORY_UPDATES)
 
@@ -165,6 +170,44 @@ base::Version ReadEvergreenVersion(base::FilePath installation_dir) {
   LOG(WARNING) << "ReadEvergreenVersion: unable to read version from "
                << installation_dir.value();
   return base::Version();
+}
+
+const std::map<ComponentState, UpdaterStatus>& GetComponentToUpdaterStatusMap() {
+  static const base::NoDestructor<std::map<ComponentState, UpdaterStatus>> map({
+      {ComponentState::kNew, UpdaterStatus::kNewUpdate},
+      {ComponentState::kChecking, UpdaterStatus::kChecking},
+      {ComponentState::kCanUpdate, UpdaterStatus::kUpdateAvailable},
+      {ComponentState::kDownloadingDiff, UpdaterStatus::kDownloadingDiff},
+      {ComponentState::kDownloading, UpdaterStatus::kDownloading},
+      {ComponentState::kUpdatingDiff, UpdaterStatus::kUpdatingDiff},
+      {ComponentState::kUpdating, UpdaterStatus::kUpdating},
+      {ComponentState::kUpdated, UpdaterStatus::kUpdated},
+      {ComponentState::kUpToDate, UpdaterStatus::kUpToDate},
+      {ComponentState::kUpdateError, UpdaterStatus::kUpdateError},
+      {ComponentState::kRun, UpdaterStatus::kRun},
+  });
+  return *map;
+}
+
+const std::map<UpdaterStatus, const char*>& GetUpdaterStatusStringMap() {
+  static const base::NoDestructor<std::map<UpdaterStatus, const char*>> map({
+      {UpdaterStatus::kNewUpdate, "Will check for update soon"},
+      {UpdaterStatus::kChecking, "Checking for update"},
+      {UpdaterStatus::kUpdateAvailable, "Update is available"},
+      {UpdaterStatus::kDownloadingDiff, "Downloading delta update"},
+      {UpdaterStatus::kDownloading, "Downloading update"},
+      {UpdaterStatus::kSlotLocked, "Slot is locked"},
+      {UpdaterStatus::kDownloaded, "Update is downloaded"},
+      {UpdaterStatus::kUpdatingDiff, "Installing delta update"},
+      {UpdaterStatus::kUpdating, "Installing update"},
+      {UpdaterStatus::kUpdated, "Update installed, pending restart"},
+      {UpdaterStatus::kRolledForward, "Updated locally, pending restart"},
+      {UpdaterStatus::kUpToDate, "App is up to date"},
+      {UpdaterStatus::kUpdateError, "Failed to update"},
+      {UpdaterStatus::kUninstalled, "Update uninstalled"},
+      {UpdaterStatus::kRun, "Transitioning..."},
+  });
+  return *map;
 }
 #else  // BUILDFLAG(IS_STARBOARD)
 

--- a/components/update_client/utils.h
+++ b/components/update_client/utils.h
@@ -46,40 +46,10 @@ enum class UpdaterStatus {
 };
 
 // Mapping a component state to an updater status.
-// clang-format off
-const std::map<ComponentState, UpdaterStatus> component_to_updater_status_map = {
-        // clang-format on
-        {ComponentState::kNew, UpdaterStatus::kNewUpdate},
-        {ComponentState::kChecking, UpdaterStatus::kChecking},
-        {ComponentState::kCanUpdate, UpdaterStatus::kUpdateAvailable},
-        {ComponentState::kDownloadingDiff, UpdaterStatus::kDownloadingDiff},
-        {ComponentState::kDownloading, UpdaterStatus::kDownloading},
-        {ComponentState::kUpdatingDiff, UpdaterStatus::kUpdatingDiff},
-        {ComponentState::kUpdating, UpdaterStatus::kUpdating},
-        {ComponentState::kUpdated, UpdaterStatus::kUpdated},
-        {ComponentState::kUpToDate, UpdaterStatus::kUpToDate},
-        {ComponentState::kUpdateError, UpdaterStatus::kUpdateError},
-        {ComponentState::kRun, UpdaterStatus::kRun},
-};
+const std::map<ComponentState, UpdaterStatus>& GetComponentToUpdaterStatusMap();
 
 // Translating an updater status to a status string.
-const std::map<UpdaterStatus, const char*> updater_status_string_map = {
-    {UpdaterStatus::kNewUpdate, "Will check for update soon"},
-    {UpdaterStatus::kChecking, "Checking for update"},
-    {UpdaterStatus::kUpdateAvailable, "Update is available"},
-    {UpdaterStatus::kDownloadingDiff, "Downloading delta update"},
-    {UpdaterStatus::kDownloading, "Downloading update"},
-    {UpdaterStatus::kSlotLocked, "Slot is locked"},
-    {UpdaterStatus::kDownloaded, "Update is downloaded"},
-    {UpdaterStatus::kUpdatingDiff, "Installing delta update"},
-    {UpdaterStatus::kUpdating, "Installing update"},
-    {UpdaterStatus::kUpdated, "Update installed, pending restart"},
-    {UpdaterStatus::kRolledForward, "Updated locally, pending restart"},
-    {UpdaterStatus::kUpToDate, "App is up to date"},
-    {UpdaterStatus::kUpdateError, "Failed to update"},
-    {UpdaterStatus::kUninstalled, "Update uninstalled"},
-    {UpdaterStatus::kRun, "Transitioning..."},
-};
+const std::map<UpdaterStatus, const char*>& GetUpdaterStatusStringMap();
 #endif // BUILDFLAG(IS_STARBOARD)
 
 // Defines a name-value pair that represents an installer attribute.

--- a/components/update_client/utils.h
+++ b/components/update_client/utils.h
@@ -26,6 +26,62 @@ extern const char kArchAmd64[];
 extern const char kArchIntel[];
 extern const char kArchArm64[];
 
+#if BUILDFLAG(IS_STARBOARD)
+enum class UpdaterStatus {
+  kNewUpdate,
+  kChecking,
+  kUpdateAvailable,
+  kDownloadingDiff,
+  kDownloading,
+  kSlotLocked,
+  kDownloaded,
+  kUpdatingDiff,
+  kUpdating,
+  kUpdated,
+  kRolledForward,
+  kUpToDate,
+  kUpdateError,
+  kUninstalled,
+  kRun
+};
+
+// Mapping a component state to an updater status.
+// clang-format off
+const std::map<ComponentState, UpdaterStatus> component_to_updater_status_map = {
+        // clang-format on
+        {ComponentState::kNew, UpdaterStatus::kNewUpdate},
+        {ComponentState::kChecking, UpdaterStatus::kChecking},
+        {ComponentState::kCanUpdate, UpdaterStatus::kUpdateAvailable},
+        {ComponentState::kDownloadingDiff, UpdaterStatus::kDownloadingDiff},
+        {ComponentState::kDownloading, UpdaterStatus::kDownloading},
+        {ComponentState::kUpdatingDiff, UpdaterStatus::kUpdatingDiff},
+        {ComponentState::kUpdating, UpdaterStatus::kUpdating},
+        {ComponentState::kUpdated, UpdaterStatus::kUpdated},
+        {ComponentState::kUpToDate, UpdaterStatus::kUpToDate},
+        {ComponentState::kUpdateError, UpdaterStatus::kUpdateError},
+        {ComponentState::kRun, UpdaterStatus::kRun},
+};
+
+// Translating an updater status to a status string.
+const std::map<UpdaterStatus, const char*> updater_status_string_map = {
+    {UpdaterStatus::kNewUpdate, "Will check for update soon"},
+    {UpdaterStatus::kChecking, "Checking for update"},
+    {UpdaterStatus::kUpdateAvailable, "Update is available"},
+    {UpdaterStatus::kDownloadingDiff, "Downloading delta update"},
+    {UpdaterStatus::kDownloading, "Downloading update"},
+    {UpdaterStatus::kSlotLocked, "Slot is locked"},
+    {UpdaterStatus::kDownloaded, "Update is downloaded"},
+    {UpdaterStatus::kUpdatingDiff, "Installing delta update"},
+    {UpdaterStatus::kUpdating, "Installing update"},
+    {UpdaterStatus::kUpdated, "Update installed, pending restart"},
+    {UpdaterStatus::kRolledForward, "Updated locally, pending restart"},
+    {UpdaterStatus::kUpToDate, "App is up to date"},
+    {UpdaterStatus::kUpdateError, "Failed to update"},
+    {UpdaterStatus::kUninstalled, "Update uninstalled"},
+    {UpdaterStatus::kRun, "Transitioning..."},
+};
+#endif // BUILDFLAG(IS_STARBOARD)
+
 // Defines a name-value pair that represents an installer attribute.
 // Installer attributes are component-specific metadata, which may be serialized
 // in an update check request.
@@ -54,10 +110,23 @@ std::string GetCrxComponentID(const CrxComponent& component);
 // Returns a CRX id from a public key hash.
 std::string GetCrxIdFromPublicKeyHash(base::span<const uint8_t> pk_hash);
 
+#if defined(IN_MEMORY_UPDATES)
+// Returns true if the actual SHA-256 hash of |content| matches the
+// |expected_hash|.
+// |content| must refer to a valid string.
+bool VerifyHash256(const std::string* content,
+                   const std::string& expected_hash);
+#else
 // Returns true if the actual SHA-256 hash of the |filepath| matches the
 // |expected_hash|.
 bool VerifyFileHash256(const base::FilePath& filepath,
                        const std::string& expected_hash);
+#endif   
+
+#if BUILDFLAG(IS_STARBOARD)
+// Reads the Evergreen version of the installation dir.
+base::Version ReadEvergreenVersion(base::FilePath installation_dir);
+#endif  // BUILDFLAG(IS_STARBOARD)
 
 // Returns true if the |brand| parameter matches ^[a-zA-Z]{4}?$ .
 bool IsValidBrand(const std::string& brand);


### PR DESCRIPTION
Move updater-specific command line switches from cobalt/browser/switches.h
to cobalt/updater/configurator.cc. This eliminates a circular dependency
where the updater component was dependent on the browser component.
Centralize UpdaterStatus definitions and Evergreen version
reading into the components/update_client module. This further streamlines
dependencies and places common update-related utilities in a shared,
lower-level component. 

Most of these changes are reviewed, approved and merged to EAP via #7811. The reason I can't cherry-pick to main is because of many conflicts, and the original PR was even larger. Besides, there are a few small fixes identified during building.

Issue: 479816505