### PR TITLE
Use feature flag for cobalt metrics collection

### DIFF
--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -181,7 +181,6 @@ source_set("metrics") {
   ]
   deps = [
     ":features",
-    ":switches",
     "//cobalt/browser/h5vcc_metrics/public/mojom",
     "//components/metrics",
     "//components/metrics_services_manager",

--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -34,16 +34,20 @@ BASE_FEATURE(kHangReporting,
              "HangReporting",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
-BASE_FEATURE(kCobaltMetricsIntervalFeature,
-             "CobaltMetricsInterval",
-             base::FEATURE_DISABLED_BY_DEFAULT);
-
 BASE_FEATURE(kUseIPv4ForDNS,
              "UseIPv4ForDNS",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
-const base::FeatureParam<int> kCobaltMetricsIntervalParam{
-    &kCobaltMetricsIntervalFeature, "cobalt-metrics-interval", 300};
+BASE_FEATURE(kCobaltMetricsIntervalFeature,
+             "CobaltMetricsInterval",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+const base::FeatureParam<int> kCpuMetricsIntervalParam{
+    &kCobaltMetricsIntervalFeature, "cpu-metrics-interval", 300};
+
+const base::FeatureParam<int> kMemoryMetricsIntervalParam{
+    &kCobaltMetricsIntervalFeature, "memory-metrics-interval", 300};
+
 
 }  // namespace features
 }  // namespace cobalt

--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -48,6 +48,5 @@ const base::FeatureParam<int> kCpuMetricsIntervalParam{
 const base::FeatureParam<int> kMemoryMetricsIntervalParam{
     &kCobaltMetricsIntervalFeature, "memory-metrics-interval", 300};
 
-
 }  // namespace features
 }  // namespace cobalt

--- a/cobalt/browser/features.h
+++ b/cobalt/browser/features.h
@@ -35,15 +35,18 @@ extern const base::FeatureParam<std::string> kTestFinchFeatureParam;
 // Enables native hang reporting via Crashpad.
 extern const base::Feature kHangReporting;
 
+// Use IPv4 for system host resolution.
+extern const base::Feature kUseIPv4ForDNS;
+
 // Enables overriding the default metrics collection interval with a fixed
 // value.
 extern const base::Feature kCobaltMetricsIntervalFeature;
 
-// Sets the interval for memory and CPU metrics collection in seconds.
-extern const base::FeatureParam<int> kCobaltMetricsIntervalParam;
+// Sets CPU metrics collection interval in seconds (default 5 min).
+extern const base::FeatureParam<int> kCpuMetricsIntervalParam;
 
-// Use IPv4 for system host resolution.
-extern const base::Feature kUseIPv4ForDNS;
+// Sets memory metrics collection interval in seconds (default 5 min).
+extern const base::FeatureParam<int> kMemoryMetricsIntervalParam;
 
 }  // namespace features
 }  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -36,9 +36,13 @@ class CobaltMetricsBrowserTest : public content::ContentBrowserTest {
   void SetUpCommandLine(base::CommandLine* command_line) override {
     content::ContentBrowserTest::SetUpCommandLine(command_line);
     // Set a short interval for memory metrics to verify periodic recording.
-    command_line->AppendSwitchASCII("
-        enable-features",
-        "CobaltMetricsInterval:memory-metrics-interval/1, CobaltMetricsInterval:cpu-metrics-interval/1");
+    command_line->AppendSwitchASCII(
+        "
+        enable -
+        features
+        ",
+        "CobaltMetricsInterval:memory-metrics-interval/1, "
+        "CobaltMetricsInterval:cpu-metrics-interval/1");
   }
 };
 

--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -37,10 +37,7 @@ class CobaltMetricsBrowserTest : public content::ContentBrowserTest {
     content::ContentBrowserTest::SetUpCommandLine(command_line);
     // Set a short interval for memory metrics to verify periodic recording.
     command_line->AppendSwitchASCII(
-        "
-        enable -
-        features
-        ",
+        "enable-features",
         "CobaltMetricsInterval:memory-metrics-interval/1, "
         "CobaltMetricsInterval:cpu-metrics-interval/1");
   }

--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -38,7 +38,7 @@ class CobaltMetricsBrowserTest : public content::ContentBrowserTest {
     // Set a short interval for memory metrics to verify periodic recording.
     command_line->AppendSwitchASCII(
         "enable-features",
-        "CobaltMetricsInterval:memory-metrics-interval/1, "
+        "CobaltMetricsInterval:memory-metrics-interval/1,"
         "CobaltMetricsInterval:cpu-metrics-interval/1");
   }
 };

--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -20,7 +20,6 @@
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
-#include "cobalt/browser/switches.h"
 #include "cobalt/testing/browser_tests/content_browser_test.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
@@ -37,8 +36,9 @@ class CobaltMetricsBrowserTest : public content::ContentBrowserTest {
   void SetUpCommandLine(base::CommandLine* command_line) override {
     content::ContentBrowserTest::SetUpCommandLine(command_line);
     // Set a short interval for memory metrics to verify periodic recording.
-    command_line->AppendSwitchASCII(
-        "enable-features", "CobaltMetricsInterval:cobalt-metrics-interval/1");
+    command_line->AppendSwitchASCII("
+        enable-features",
+        "CobaltMetricsInterval:memory-metrics-interval/1, CobaltMetricsInterval:cpu-metrics-interval/1");
   }
 };
 

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.cc
@@ -44,9 +44,9 @@ class MetricsPollingState {
   MetricsPollingState() = default;
   virtual ~MetricsPollingState() = default;
 
-  virtual void RecordMetricsAfterDelay(const base::FeatureParam<int>& interval_param) {
+  void RecordMetricsAfterDelay(const base::FeatureParam<int>& interval_param) {
     base::TimeDelta delay = memory_instrumentation::GetDelayForNextMemoryLog();
-    
+
     if (base::FeatureList::IsEnabled(features::kCobaltMetricsIntervalFeature)) {
       int interval = interval_param.Get();
       if (interval > 0) {
@@ -58,11 +58,11 @@ class MetricsPollingState {
     }
 
     timer_.Start(FROM_HERE, delay, this, &MetricsPollingState::RequestMetrics);
-  };
+  }
 
   virtual void RequestMetrics() = 0;
 
- protected:
+ private:
   base::OneShotTimer timer_;
 };
 
@@ -72,9 +72,10 @@ class CobaltMetricsServiceClient::MemoryPollingState
   explicit MemoryPollingState(
       scoped_refptr<CobaltMemoryMetricsEmitter> memory_emitter)
       : memory_emitter_(std::move(memory_emitter)) {}
-  
+
   void RecordMetricsAfterDelay() {
-    MetricsPollingState::RecordMetricsAfterDelay(features::kMemoryMetricsIntervalParam);
+    MetricsPollingState::RecordMetricsAfterDelay(
+        features::kMemoryMetricsIntervalParam);
   }
 
   void RequestMetrics() override {
@@ -91,7 +92,8 @@ class CobaltMetricsServiceClient::CpuPollingState : public MetricsPollingState {
       : cpu_emitter_(std::move(cpu_emitter)) {}
 
   void RecordMetricsAfterDelay() {
-    MetricsPollingState::RecordMetricsAfterDelay(features::kCpuMetricsIntervalParam);
+    MetricsPollingState::RecordMetricsAfterDelay(
+        features::kCpuMetricsIntervalParam);
   }
 
   void RequestMetrics() override {

--- a/cobalt/browser/metrics/cobalt_metrics_service_client.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client.cc
@@ -29,7 +29,6 @@
 #include "cobalt/browser/metrics/cobalt_cpu_metrics_emitter.h"
 #include "cobalt/browser/metrics/cobalt_memory_metrics_emitter.h"
 #include "cobalt/browser/metrics/cobalt_metrics_log_uploader.h"
-#include "cobalt/browser/switches.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics/metrics_state_manager.h"
 #include "components/prefs/pref_service.h"
@@ -45,25 +44,25 @@ class MetricsPollingState {
   MetricsPollingState() = default;
   virtual ~MetricsPollingState() = default;
 
-  void RecordMetricsAfterDelay() {
+  virtual void RecordMetricsAfterDelay(const base::FeatureParam<int>& interval_param) {
     base::TimeDelta delay = memory_instrumentation::GetDelayForNextMemoryLog();
+    
     if (base::FeatureList::IsEnabled(features::kCobaltMetricsIntervalFeature)) {
-      int interval_int = features::kCobaltMetricsIntervalParam.Get();
-      if (interval_int > 0) {
-        delay = base::Seconds(interval_int);
+      int interval = interval_param.Get();
+      if (interval > 0) {
+        delay = base::Seconds(interval);
       } else {
-        LOG(WARNING) << "Invalid metrics interval from feature: "
-                     << interval_int
+        LOG(WARNING) << "Invalid metrics interval from feature: " << interval
                      << ". Falling back to memory_instrumentation default.";
       }
     }
 
     timer_.Start(FROM_HERE, delay, this, &MetricsPollingState::RequestMetrics);
-  }
+  };
 
   virtual void RequestMetrics() = 0;
 
- private:
+ protected:
   base::OneShotTimer timer_;
 };
 
@@ -73,6 +72,10 @@ class CobaltMetricsServiceClient::MemoryPollingState
   explicit MemoryPollingState(
       scoped_refptr<CobaltMemoryMetricsEmitter> memory_emitter)
       : memory_emitter_(std::move(memory_emitter)) {}
+  
+  void RecordMetricsAfterDelay() {
+    MetricsPollingState::RecordMetricsAfterDelay(features::kMemoryMetricsIntervalParam);
+  }
 
   void RequestMetrics() override {
     memory_emitter_->FetchAndEmitProcessMemoryMetrics();
@@ -86,6 +89,10 @@ class CobaltMetricsServiceClient::CpuPollingState : public MetricsPollingState {
  public:
   explicit CpuPollingState(scoped_refptr<CobaltCpuMetricsEmitter> cpu_emitter)
       : cpu_emitter_(std::move(cpu_emitter)) {}
+
+  void RecordMetricsAfterDelay() {
+    MetricsPollingState::RecordMetricsAfterDelay(features::kCpuMetricsIntervalParam);
+  }
 
   void RequestMetrics() override {
     cpu_emitter_->FetchAndEmitCpuMetrics();

--- a/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
@@ -825,16 +825,16 @@ TEST_F(CobaltMetricsServiceClientBaseTest, CobaltMetricsIntervalFeatureTest) {
   EXPECT_EQ(0u, histogram_tester
                     .GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
                     .size());
-  EXPECT_EQ(0u, histogram_tester
-                    .GetAllSamples("CPU.Total.UsageInPercentage").size());
+  EXPECT_EQ(
+      0u, histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size());
 
   // Fast forward by kCustomInterval - 1 second. Still no metrics.
   task_environment_.FastForwardBy(base::Seconds(kCustomInterval - 1));
   EXPECT_EQ(0u, histogram_tester
                     .GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
                     .size());
-  EXPECT_EQ(0u, histogram_tester
-                    .GetAllSamples("CPU.Total.UsageInPercentage").size());
+  EXPECT_EQ(
+      0u, histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size());
 
   // Fast forward by 1 more second. Now metrics should be recorded.
   task_environment_.FastForwardBy(base::Seconds(1));
@@ -845,8 +845,7 @@ TEST_F(CobaltMetricsServiceClientBaseTest, CobaltMetricsIntervalFeatureTest) {
       1u);
   // CPU metrics should also be recorded.
   EXPECT_GE(
-      histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size(),
-      1u);
+      histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size(), 1u);
 }
 
 TEST_F(CobaltMetricsServiceClientBaseTest,
@@ -874,16 +873,16 @@ TEST_F(CobaltMetricsServiceClientBaseTest,
   EXPECT_EQ(0u, histogram_tester
                     .GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
                     .size());
-  EXPECT_EQ(0u, histogram_tester
-                    .GetAllSamples("CPU.Total.UsageInPercentage").size());
+  EXPECT_EQ(
+      0u, histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size());
 
   // Fast forward by 299 seconds. Still no metrics.
   task_environment_.FastForwardBy(base::Seconds(299));
   EXPECT_EQ(0u, histogram_tester
                     .GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
                     .size());
-  EXPECT_EQ(0u, histogram_tester
-                    .GetAllSamples("CPU.Total.UsageInPercentage").size());
+  EXPECT_EQ(
+      0u, histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size());
 
   // Fast forward by 1 more second (total 300s). Now metrics should be recorded.
   task_environment_.FastForwardBy(base::Seconds(1));
@@ -893,8 +892,7 @@ TEST_F(CobaltMetricsServiceClientBaseTest,
           .size(),
       1u);
   EXPECT_GE(
-      histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size(),
-      1u);
+      histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size(), 1u);
 }
 
 }  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
@@ -807,7 +807,8 @@ TEST_F(CobaltMetricsServiceClientBaseTest, CobaltMetricsIntervalFeatureTest) {
   base::test::ScopedFeatureList feature_list;
   feature_list.InitAndEnableFeatureWithParameters(
       features::kCobaltMetricsIntervalFeature,
-      {{"cobalt-metrics-interval", base::NumberToString(kCustomInterval)}});
+      {{"memory-metrics-interval", base::NumberToString(kCustomInterval)},
+       {"cpu-metrics-interval", base::NumberToString(kCustomInterval)}});
 
   // Re-initialize client to pick up new feature settings if needed,
   // but wait, CobaltMetricsServiceClient::Initialize calls
@@ -824,12 +825,16 @@ TEST_F(CobaltMetricsServiceClientBaseTest, CobaltMetricsIntervalFeatureTest) {
   EXPECT_EQ(0u, histogram_tester
                     .GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
                     .size());
+  EXPECT_EQ(0u, histogram_tester
+                    .GetAllSamples("CPU.Total.UsageInPercentage").size());
 
   // Fast forward by kCustomInterval - 1 second. Still no metrics.
   task_environment_.FastForwardBy(base::Seconds(kCustomInterval - 1));
   EXPECT_EQ(0u, histogram_tester
                     .GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
                     .size());
+  EXPECT_EQ(0u, histogram_tester
+                    .GetAllSamples("CPU.Total.UsageInPercentage").size());
 
   // Fast forward by 1 more second. Now metrics should be recorded.
   task_environment_.FastForwardBy(base::Seconds(1));
@@ -837,6 +842,10 @@ TEST_F(CobaltMetricsServiceClientBaseTest, CobaltMetricsIntervalFeatureTest) {
   EXPECT_GE(
       histogram_tester.GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
           .size(),
+      1u);
+  // CPU metrics should also be recorded.
+  EXPECT_GE(
+      histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size(),
       1u);
 }
 
@@ -865,12 +874,16 @@ TEST_F(CobaltMetricsServiceClientBaseTest,
   EXPECT_EQ(0u, histogram_tester
                     .GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
                     .size());
+  EXPECT_EQ(0u, histogram_tester
+                    .GetAllSamples("CPU.Total.UsageInPercentage").size());
 
   // Fast forward by 299 seconds. Still no metrics.
   task_environment_.FastForwardBy(base::Seconds(299));
   EXPECT_EQ(0u, histogram_tester
                     .GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
                     .size());
+  EXPECT_EQ(0u, histogram_tester
+                    .GetAllSamples("CPU.Total.UsageInPercentage").size());
 
   // Fast forward by 1 more second (total 300s). Now metrics should be recorded.
   task_environment_.FastForwardBy(base::Seconds(1));
@@ -878,6 +891,9 @@ TEST_F(CobaltMetricsServiceClientBaseTest,
   EXPECT_GE(
       histogram_tester.GetAllSamples("Memory.Browser.PrivateMemoryFootprint")
           .size(),
+      1u);
+  EXPECT_GE(
+      histogram_tester.GetAllSamples("CPU.Total.UsageInPercentage").size(),
       1u);
 }
 

--- a/cobalt/browser/metrics/font_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/font_metrics_browsertest.cc
@@ -38,7 +38,8 @@ class FontMetricsBrowserTest : public content::ContentBrowserTest {
   void SetUpCommandLine(base::CommandLine* command_line) override {
     content::ContentBrowserTest::SetUpCommandLine(command_line);
     // Set a short interval for memory metrics to verify periodic recording.
-    command_line->AppendSwitchASCII("enable-features", "CobaltMetricsInterval:memory-metrics-interval/1");
+    command_line->AppendSwitchASCII(
+        "enable-features", "CobaltMetricsInterval:memory-metrics-interval/1");
   }
 };
 

--- a/cobalt/browser/metrics/font_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/font_metrics_browsertest.cc
@@ -19,7 +19,6 @@
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
-#include "cobalt/browser/switches.h"
 #include "cobalt/testing/browser_tests/browser/test_shell.h"
 #include "cobalt/testing/browser_tests/content_browser_test.h"
 #include "components/metrics/metrics_pref_names.h"
@@ -39,8 +38,7 @@ class FontMetricsBrowserTest : public content::ContentBrowserTest {
   void SetUpCommandLine(base::CommandLine* command_line) override {
     content::ContentBrowserTest::SetUpCommandLine(command_line);
     // Set a short interval for memory metrics to verify periodic recording.
-    command_line->AppendSwitchASCII(
-        "enable-features", "CobaltMetricsInterval:cobalt-metrics-interval/1");
+    command_line->AppendSwitchASCII("enable-features", "CobaltMetricsInterval:memory-metrics-interval/1");
   }
 };
 


### PR DESCRIPTION
This change creates two feature params, `kCpuMetricsIntervalParam` 
and `kMemoryMetricsIntervalParam` to provide independent control 
over the collection interval of memory and CPU metrics. Default values
for both flags are 5 minutes and can be manually set when the feature flag
`kCobaltMetricsIntervalFeature` is enabled. 

It allows for easier tuning of the frequency to collect different cobalt metrics, 
could later be used in experiments to determine the optimal value.

Bug: 495528560