### PR TITLE
aosp: create a minimal sockaddr utils source set

### DIFF
--- a/mojo/public/cpp/platform/BUILD.gn
+++ b/mojo/public/cpp/platform/BUILD.gn
@@ -60,7 +60,7 @@ component("platform") {
 
   if (is_posix && !is_nacl && !is_minimal_toolchain && !is_mac) {
     sources += [ "named_platform_channel_posix.cc" ]
-    deps += [ "//net" ]
+    deps += [ "//net:sockaddr_util" ]
   }
 
   if (is_mac) {

--- a/net/BUILD.gn
+++ b/net/BUILD.gn
@@ -297,8 +297,6 @@ component("net") {
     "base/schemeful_site.cc",
     "base/schemeful_site.h",
     "base/session_usage.h",
-    "base/sockaddr_storage.cc",
-    "base/sockaddr_storage.h",
     "base/sys_addrinfo.h",
     "base/trace_event_stub.h",
     "base/tracing.h",
@@ -1159,6 +1157,7 @@ component("net") {
   public_deps = [
     ":net_export_header",
     ":net_public_deps",
+    ":sockaddr_util",
     "//base",
     "//net/dns",
     "//net/dns:dns_client",
@@ -1463,8 +1462,6 @@ component("net") {
       "base/file_stream_context_posix.cc",
       "base/network_interfaces_posix.cc",
       "base/network_interfaces_posix.h",
-      "base/sockaddr_util_posix.cc",
-      "base/sockaddr_util_posix.h",
       "disk_cache/cache_util_posix.cc",
       "disk_cache/simple/simple_util_posix.cc",
       "http/url_security_manager_posix.cc",
@@ -1821,6 +1818,25 @@ component("net") {
 # net_nqe_proto) can use it without depending on the whole of //net.
 source_set("net_export_header") {
   sources = [ "base/net_export.h" ]
+}
+
+# Minimal sockaddr utilities. Split out so that mojo/public/cpp/platform
+# can use it without depending on //net.
+component("sockaddr_util") {
+  sources = [
+    "base/sockaddr_storage.cc",
+    "base/sockaddr_storage.h",
+  ]
+
+  if (is_posix) {
+    sources += [
+      "base/sockaddr_util_posix.cc",
+      "base/sockaddr_util_posix.h",
+    ]
+  }
+
+  deps = [ "//base" ]
+  public_deps = [ ":net_export_header" ]
 }
 
 # Private dependencies for the //net component and for any build targets (e.g.


### PR DESCRIPTION
//components/open_from_clipboard has an assert_no_deps entry that prevents adding i18n and causes a gen failure. This change creates a small source set containing only the sockadd utils sources that are needed by //mojo/public/cpp/platform.

Full dependency path that leads to the assert_no_deps:
  //components/open_from_clipboard:open_from_clipboard_impl ->
  //base:base ->
  //starboard:starboard_group ->
  //starboard:starboard ->
  //starboard/aosp/arm:starboard_platform ->
  //starboard/aosp/shared:starboard_platform ->
  //starboard/android/shared:starboard_platform ->
  //cobalt/browser/h5vcc_accessibility:manager ->
  //cobalt/browser/h5vcc_accessibility/public/mojom:mojom ->
  //cobalt/browser/h5vcc_accessibility/public/mojom:mojom_shared ->
  //cobalt/browser/h5vcc_accessibility/public/mojom:mojom_shared_cpp_sources ->
  //mojo/public/cpp/bindings:bindings ->
  //mojo/public/cpp/bindings:bindings_base ->
  //mojo/public/cpp/system:system ->
  //mojo/core/embedder:embedder ->
  //mojo/core:embedder_internal ->
  //mojo/core:impl_for_embedder ->
  //mojo/public/cpp/platform:platform ->
  //net:net ->
  //net:net_public_deps ->
  //net/third_party/quiche:quiche ->
  //url:url ->
  //base:i18n

Bug: 495203133