### PR TITLE
posix: guard FNONBLOCK/FASYNC/FNDELAY asserts for bionic

### DIFF
--- a/starboard/shared/modular/starboard_layer_posix_fcntl_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_fcntl_abi_wrappers.h
@@ -36,7 +36,8 @@ static_assert(O_SYNC == 04010000,
               "The Starboard layer wrapper expects this value from musl");
 static_assert(O_ASYNC == 020000,
               "The Starboard layer wrapper expects this value from musl");
-#if defined(_GNU_SOURCE) || defined(_BSD_SOURCE)
+// FNONBLOCK, FASYNC, and FNDELAY are defined in musl but not in Bionic
+#if (defined(_GNU_SOURCE) || defined(_BSD_SOURCE)) && !defined(__BIONIC__)
 static_assert(FASYNC == O_ASYNC,
               "The Starboard layer wrapper expects this value from musl");
 static_assert(FNONBLOCK == O_NONBLOCK,

--- a/starboard/shared/modular/starboard_layer_posix_fcntl_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_fcntl_abi_wrappers.h
@@ -36,7 +36,7 @@ static_assert(O_SYNC == 04010000,
               "The Starboard layer wrapper expects this value from musl");
 static_assert(O_ASYNC == 020000,
               "The Starboard layer wrapper expects this value from musl");
-// FNONBLOCK, FASYNC, and FNDELAY are defined in musl but not in Bionic
+// FNONBLOCK, FASYNC, and FNDELAY are defined in musl but not in Bionic.
 #if (defined(_GNU_SOURCE) || defined(_BSD_SOURCE)) && !defined(__BIONIC__)
 static_assert(FASYNC == O_ASYNC,
               "The Starboard layer wrapper expects this value from musl");


### PR DESCRIPTION
Bionic doesn't define those constants.

Bug: 495203133