### PR TITLE
aosp: skip bionic futex path on hermetic builds

### DIFF
--- a/third_party/abseil-cpp/absl/synchronization/internal/futex.h
+++ b/third_party/abseil-cpp/absl/synchronization/internal/futex.h
@@ -42,7 +42,7 @@
 
 #ifdef ABSL_INTERNAL_HAVE_FUTEX
 #error ABSL_INTERNAL_HAVE_FUTEX may not be set on the command line
-#elif defined(__BIONIC__)
+#elif defined(__BIONIC__) && !BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
 // Bionic supports all the futex operations we need even when some of the futex
 // definitions are missing.
 #define ABSL_INTERNAL_HAVE_FUTEX


### PR DESCRIPTION
aosp: skip bionic futex path on hermetic builds

ABSL_INTERNAL_HAVE_FUTEX for Android was being guarded only by checking 
for __BIONIC__, so ABSL_INTERNAL_HAVE_FUTEX was being defined for
hermetic builds.

ABSL_INTERNAL_HAVE_FUTEX was enabling a block with platform code that calls
the futex() syscall, causing build issues:

  third_party/abseil-cpp/absl/synchronization/internal/futex.h:
      error: use of undeclared identifier '__NR_futex'
      error: use of undeclared identifier 'FUTEX_WAKE'

This fix ensures that ABSL_INTERNAL_HAVE_FUTEX is only defined for
non-hermetic builds for Android.

Bug: 505627880