### PR TITLE
aosp: fix checked_iterators for newer c++ standards

### DIFF
--- a/copied_base/base/containers/checked_iterators.h
+++ b/copied_base/base/containers/checked_iterators.h
@@ -244,9 +244,11 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
 // [3] https://wg21.link/pointer.traits.optmem
 namespace std {
 
+#if _LIBCPP_VERSION <= 170000
 template <typename T>
 struct __is_cpp17_contiguous_iterator<::base::CheckedContiguousIterator<T>>
     : true_type {};
+#endif
 
 template <typename T>
 struct pointer_traits<::base::CheckedContiguousIterator<T>> {


### PR DESCRIPTION
checked_iterators tries to extend __is_cpp17_contiguous_iterator without checking the standard version, causing build issues for builds that uses newer versions of the std. This change adds a guard to ensure this isn't going to be attempted in std versions newer than cpp17.

Bug: 495203133