### PR TITLE
media: Allow audio writing on pause to reduce latency

### DIFF
--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -133,7 +133,7 @@ void MinRequiredFramesTester::TesterThreadFunc() {
             GetSampleSize(task.sample_type),
         &MinRequiredFramesTester::UpdateSourceStatusFunc,
         &MinRequiredFramesTester::ConsumeFramesFunc,
-        &MinRequiredFramesTester::ErrorFunc, 0, -1, false, false, this);
+        &MinRequiredFramesTester::ErrorFunc, 0, -1, false, false, false, this);
     {
       std::unique_lock lock(mutex_);
       bool notified = test_complete_cv_.wait_for(

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -134,6 +134,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
     int64_t start_time,
     int tunnel_mode_audio_session_id,
     bool is_web_audio,
+    bool allow_audio_writing_on_pause,
     bool pause_using_audio_track_state,
     void* context)
     : type_(type),
@@ -146,12 +147,13 @@ AudioTrackAudioSink::AudioTrackAudioSink(
       consume_frames_func_(consume_frames_func),
       error_func_(error_func),
       start_time_(start_time),
-      pause_using_audio_track_state_(pause_using_audio_track_state),
       max_frames_per_request_(
           tunnel_mode_audio_session_id == -1
               ? kMaxFramesPerRequest
               : GetMaxFramesPerRequestForTunnelMode(sampling_frequency_hz_)),
       context_(context),
+      allow_audio_writing_on_pause_(allow_audio_writing_on_pause),
+      pause_using_audio_track_state_(pause_using_audio_track_state),
       bridge_(kSbMediaAudioCodingTypePcm,
               sample_type,
               channels,
@@ -325,7 +327,10 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       }
     }
 
-    if (!is_playing || frames_in_buffer == 0) {
+    // When |allow_audio_writing_on_pause| feature is enabled, continue writing
+    // audio regardless of whether audio is playing.
+    if ((!is_playing && !allow_audio_writing_on_pause_) ||
+        frames_in_buffer == 0) {
       usleep(10'000);
       continue;
     }
@@ -504,12 +509,13 @@ SbAudioSink AudioTrackAudioSinkType::Create(
   // Disable tunnel mode.
   const int kTunnelModeAudioSessionId = -1;
   const bool kIsWebAudio = true;
+  const bool kAllowAudioWritingOnPause = false;
   const bool kPauseUsingAudioTrackState = false;
   return Create(channels, sampling_frequency_hz, audio_sample_type,
                 audio_frame_storage_type, frame_buffers, frames_per_channel,
                 update_source_status_func, consume_frames_func, error_func,
                 kStartTime, kTunnelModeAudioSessionId, kIsWebAudio,
-                kPauseUsingAudioTrackState, context);
+                kAllowAudioWritingOnPause, kPauseUsingAudioTrackState, context);
 }
 
 SbAudioSink AudioTrackAudioSinkType::Create(
@@ -525,6 +531,7 @@ SbAudioSink AudioTrackAudioSinkType::Create(
     int64_t start_media_time,
     int tunnel_mode_audio_session_id,
     bool is_web_audio,
+    bool allow_audio_writing_on_pause,
     bool pause_using_audio_track_state,
     void* context) {
   int min_required_frames = SbAudioSinkGetMinBufferSizeInFrames(
@@ -538,7 +545,7 @@ SbAudioSink AudioTrackAudioSinkType::Create(
       frames_per_channel, preferred_buffer_size_in_bytes,
       update_source_status_func, consume_frames_func, error_func,
       start_media_time, tunnel_mode_audio_session_id, is_web_audio,
-      pause_using_audio_track_state, context);
+      allow_audio_writing_on_pause, pause_using_audio_track_state, context);
   if (!audio_sink->IsAudioTrackValid()) {
     SB_DLOG(ERROR)
         << "AudioTrackAudioSinkType::Create failed to create audio track";

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -76,6 +76,7 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
       int64_t start_time,
       int tunnel_mode_audio_session_id,
       bool is_web_audio,
+      bool allow_audio_writing_on_pause,
       bool pause_using_audio_track_state,
       void* context);
 
@@ -123,6 +124,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       int64_t start_media_time,
       int tunnel_mode_audio_session_id,
       bool is_web_audio,
+      bool allow_audio_writing_on_pause,
       bool pause_using_audio_track_state,
       void* context);
   ~AudioTrackAudioSink() override;
@@ -156,9 +158,11 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const ConsumeFramesFunc consume_frames_func_;
   const SbAudioSinkPrivate::ErrorFunc error_func_;
   const int64_t start_time_;  // microseconds
-  const bool pause_using_audio_track_state_;
   const int max_frames_per_request_;
   void* const context_;
+
+  const bool allow_audio_writing_on_pause_;
+  const bool pause_using_audio_track_state_;
 
   AudioTrackBridge bridge_;
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -68,6 +68,7 @@ bool UseLibopusDecoder(SbMediaAudioCodec codec,
 class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
  public:
   explicit AudioRendererSinkAndroid(int tunnel_mode_audio_session_id = -1,
+                                    bool allow_audio_writing_on_pause = false,
                                     bool pause_using_audio_track_state = false)
       : AudioRendererSinkImpl(
             [=](int64_t start_media_time,
@@ -90,7 +91,8 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
                   frame_buffers_size_in_frames, update_source_status_func,
                   consume_frames_func, error_func, start_media_time,
                   tunnel_mode_audio_session_id, false, /* is_web_audio */
-                  pause_using_audio_track_state, context);
+                  allow_audio_writing_on_pause, pause_using_audio_track_state,
+                  context);
             }),
         tunnel_mode_audio_session_id_(tunnel_mode_audio_session_id) {}
 
@@ -418,6 +420,13 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       SB_LOG_IF(INFO, pause_using_audio_track_state)
           << "kPauseUsingAudioTrackState is set to true, force using "
           << "AudioTrackState while pausing playback.";
+
+      // TODO: b/500811542 - Connect to H5VCC.
+      const bool allow_audio_writing_on_pause =
+          experimental_features.allow_audio_writing_on_pause;
+      SB_LOG_IF(INFO, allow_audio_writing_on_pause)
+          << "allow_audio_writing_on_pause is set to true.";
+
       const bool force_platform_opus_decoder = force_platform_opus_decoder_;
       auto decoder_creator =
           [enable_flush_during_seek, force_platform_opus_decoder, job_queue](
@@ -452,7 +461,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
 
       components.audio.renderer_sink =
           std::make_unique<AudioRendererSinkAndroid>(
-              tunnel_mode_audio_session_id, pause_using_audio_track_state);
+              tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
+              pause_using_audio_track_state);
     }
 
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone) {

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -27,6 +27,7 @@ namespace starboard {
 // dedicated function.
 struct ExperimentalFeatures {
   // The fields should be in alphabetical order.
+  bool allow_audio_writing_on_pause = false;
   bool disable_low_performance_sw_decoder = false;
   bool enable_av1_startup_optimization = false;
   bool enable_codec_output_checker = false;

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -397,7 +397,7 @@ void AudioRendererPcm::GetSourceStatus(int* frames_in_buffer,
   *is_eos_reached = is_eos_reached_on_sink_thread_;
   *is_playing = is_playing_on_sink_thread_;
 
-  if (*is_playing) {
+  if (*is_playing || experimental_features_.allow_audio_writing_on_pause) {
     *frames_in_buffer =
         frames_in_buffer_on_sink_thread_ - frames_consumed_on_sink_thread_;
     *offset_in_frames =


### PR DESCRIPTION
Introduce an experimental feature to allow the audio sink to continue
writing audio data even when the media pipeline is paused. This is
particularly beneficial during seeking, where the player pauses until
both audio and video are prerolled. Pre-writing audio ensures the
audio pipeline is ready for immediate playback resumption,
reducing perceived startup latency.

Bug: 500811542