### PR TITLE
android: Add startup diagnosis for network errors

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -772,4 +772,9 @@ public class StarboardBridge {
   protected void setStartupMilestone(int milestone) {
     StartupGuard.getInstance().setStartupMilestone(milestone);
   }
+
+  @CalledByNative
+  protected void setStartupDiagnosisInfo(String key, String value) {
+    StartupGuard.getInstance().setDiagnosisInfo(key, value);
+  }
 }

--- a/cobalt/browser/cobalt_web_contents_observer.cc
+++ b/cobalt/browser/cobalt_web_contents_observer.cc
@@ -89,7 +89,8 @@ void CobaltWebContentsObserver::DidFinishNavigation(
                              -net_error_code);
     LOG(INFO) << "DidFinishNavigation: Raising platform error with code: "
               << net::ErrorToString(net_error_code);
-    SetStartupDiagnosisInfo("navigation_error", net::ErrorToString(net_error_code).c_str());
+    SetStartupDiagnosisInfo("navigation_error",
+                            net::ErrorToString(net_error_code).c_str());
     RaisePlatformError();
   } else if (net_error_code == net::OK) {
     base::UmaHistogramBoolean("Cobalt.WebContentsObserver.FailedNavigation",
@@ -100,9 +101,11 @@ void CobaltWebContentsObserver::DidFinishNavigation(
   }
 }
 
-void CobaltWebContentsObserver::SetStartupDiagnosisInfo(const char* key, const char* value) {
+void CobaltWebContentsObserver::SetStartupDiagnosisInfo(const char* key,
+                                                        const char* value) {
 #if BUILDFLAG(IS_ANDROID)
-  starboard::StarboardBridge::GetInstance()->SetStartupDiagnosisInfo(key, value);
+  starboard::StarboardBridge::GetInstance()->SetStartupDiagnosisInfo(key,
+                                                                     value);
 #endif
 }
 

--- a/cobalt/browser/cobalt_web_contents_observer.cc
+++ b/cobalt/browser/cobalt_web_contents_observer.cc
@@ -89,7 +89,7 @@ void CobaltWebContentsObserver::DidFinishNavigation(
                              -net_error_code);
     LOG(INFO) << "DidFinishNavigation: Raising platform error with code: "
               << net::ErrorToString(net_error_code);
-#if BUILDFLAG(IS_ANDROIDTV)
+#if BUILDFLAG(IS_ANDROID)
     starboard::StarboardBridge::GetInstance()->SetStartupDiagnosisInfo(
         "navigation_error", net::ErrorToString(net_error_code).c_str());
 #endif

--- a/cobalt/browser/cobalt_web_contents_observer.cc
+++ b/cobalt/browser/cobalt_web_contents_observer.cc
@@ -89,10 +89,7 @@ void CobaltWebContentsObserver::DidFinishNavigation(
                              -net_error_code);
     LOG(INFO) << "DidFinishNavigation: Raising platform error with code: "
               << net::ErrorToString(net_error_code);
-#if BUILDFLAG(IS_ANDROID)
-    starboard::StarboardBridge::GetInstance()->SetStartupDiagnosisInfo(
-        "navigation_error", net::ErrorToString(net_error_code).c_str());
-#endif
+    SetStartupDiagnosisInfo("navigation_error", net::ErrorToString(net_error_code).c_str());
     RaisePlatformError();
   } else if (net_error_code == net::OK) {
     base::UmaHistogramBoolean("Cobalt.WebContentsObserver.FailedNavigation",
@@ -101,6 +98,12 @@ void CobaltWebContentsObserver::DidFinishNavigation(
     platform_error_raised_count_ = 0;
 #endif
   }
+}
+
+void CobaltWebContentsObserver::SetStartupDiagnosisInfo(const char* key, const char* value) {
+#if BUILDFLAG(IS_ANDROID)
+  starboard::StarboardBridge::GetInstance()->SetStartupDiagnosisInfo(key, value);
+#endif
 }
 
 void CobaltWebContentsObserver::RaisePlatformError() {

--- a/cobalt/browser/cobalt_web_contents_observer.cc
+++ b/cobalt/browser/cobalt_web_contents_observer.cc
@@ -89,6 +89,10 @@ void CobaltWebContentsObserver::DidFinishNavigation(
                              -net_error_code);
     LOG(INFO) << "DidFinishNavigation: Raising platform error with code: "
               << net::ErrorToString(net_error_code);
+#if BUILDFLAG(IS_ANDROIDTV)
+    starboard::StarboardBridge::GetInstance()->SetStartupDiagnosisInfo(
+        "navigation_error", net::ErrorToString(net_error_code).c_str());
+#endif
     RaisePlatformError();
   } else if (net_error_code == net::OK) {
     base::UmaHistogramBoolean("Cobalt.WebContentsObserver.FailedNavigation",

--- a/cobalt/browser/cobalt_web_contents_observer.h
+++ b/cobalt/browser/cobalt_web_contents_observer.h
@@ -42,6 +42,7 @@ class CobaltWebContentsObserver : public content::WebContentsObserver {
   void DidFinishNavigation(
       content::NavigationHandle* navigation_handle) override;
   virtual void RaisePlatformError();
+  virtual void SetStartupDiagnosisInfo(const char* key, const char* value);
 
  protected:
   void SetTimerForTestInternal(std::unique_ptr<base::OneShotTimer> timer);
@@ -49,9 +50,9 @@ class CobaltWebContentsObserver : public content::WebContentsObserver {
  private:
   std::unique_ptr<base::OneShotTimer> timeout_timer_;
   base::WeakPtrFactory<CobaltWebContentsObserver> weak_factory_{this};
-#if BUILDFLAG(IS_ANDROIDTV)
+#if BUILDFLAG(IS_ANDROID)
   int platform_error_raised_count_ = 0;
-#endif  // BUILDFLAG(IS_ANDROIDTV)
+#endif  // BUILDFLAG(IS_ANDROID)
 };
 
 }  // namespace cobalt

--- a/cobalt/browser/cobalt_web_contents_observer.h
+++ b/cobalt/browser/cobalt_web_contents_observer.h
@@ -50,9 +50,9 @@ class CobaltWebContentsObserver : public content::WebContentsObserver {
  private:
   std::unique_ptr<base::OneShotTimer> timeout_timer_;
   base::WeakPtrFactory<CobaltWebContentsObserver> weak_factory_{this};
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROIDTV)
   int platform_error_raised_count_ = 0;
-#endif  // BUILDFLAG(IS_ANDROID)
+#endif  // BUILDFLAG(IS_ANDROIDTV)
 };
 
 }  // namespace cobalt

--- a/cobalt/browser/cobalt_web_contents_observer_unittest.cc
+++ b/cobalt/browser/cobalt_web_contents_observer_unittest.cc
@@ -44,6 +44,10 @@ class TestCobaltWebContentsObserver : public CobaltWebContentsObserver {
     RaisePlatformErrorProxy();
   }
 
+  void SetStartupDiagnosisInfo(const char* key, const char* value) override {
+    // Do nothing in tests to avoid JNI calls.
+  }
+
   void SetTimerForTestInternal(std::unique_ptr<base::OneShotTimer> timer) {
     CobaltWebContentsObserver::SetTimerForTestInternal(std::move(timer));
   }

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/StartupGuard.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/StartupGuard.java
@@ -18,8 +18,6 @@ import java.util.concurrent.atomic.AtomicLong;
  * restart the application, rather than leaving the user stuck on an unresponsive black screen.
  */
 public class StartupGuard {
-    public static final String NAVIGATION_ERROR = "navigation_error";
-
     private final Handler handler;
     private final Runnable crashRunnable;
     private final AtomicLong startupStatus = new AtomicLong(0L);

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/StartupGuard.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/StartupGuard.java
@@ -3,6 +3,8 @@ package dev.cobalt.shell;
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 /**
@@ -16,9 +18,12 @@ import java.util.concurrent.atomic.AtomicLong;
  * restart the application, rather than leaving the user stuck on an unresponsive black screen.
  */
 public class StartupGuard {
+    public static final String NAVIGATION_ERROR = "navigation_error";
+
     private final Handler handler;
     private final Runnable crashRunnable;
     private final AtomicLong startupStatus = new AtomicLong(0L);
+    private final Map<String, String> diagnosisInfo = new HashMap<>();
 
     private static class LazyHolder {
         private static final StartupGuard INSTANCE = new StartupGuard();
@@ -35,9 +40,23 @@ public class StartupGuard {
             @Override
             public void run() {
                 throw new RuntimeException(
-                        "Application startup may not have succeeded, crash triggered by StartupGuard. Status: 0x" + Long.toHexString(startupStatus.get()));
+                        "Application startup may not have succeeded, crash triggered by StartupGuard. "
+                                + getStartupStatusAndDiagnosisInfo());
             }
         };
+    }
+
+    private String getStartupStatusAndDiagnosisInfo() {
+        StringBuilder message = new StringBuilder();
+        message.append("Status: 0x");
+        message.append(Long.toHexString(startupStatus.get()));
+        synchronized (diagnosisInfo) {
+            if (!diagnosisInfo.isEmpty()) {
+                message.append(", Diagnosis Info: ");
+                message.append(diagnosisInfo.toString());
+            }
+        }
+        return message.toString();
     }
 
     /**
@@ -63,6 +82,18 @@ public class StartupGuard {
     }
 
     /**
+     * Sets startup diagnosis info.
+     * @param key The key for the diagnosis info.
+     * @param value The value for the diagnosis info.
+     */
+    public void setDiagnosisInfo(String key, String value) {
+        synchronized (diagnosisInfo) {
+            Log.v(TAG, "StartupGuard setDiagnosisInfo: " + key + "=" + value);
+            diagnosisInfo.put(key, value);
+        }
+    }
+
+    /**
      * Schedules the forced crash to happen after the specified delay.
      * @param delaySeconds The delay in seconds before the crash is triggered.
      */
@@ -81,7 +112,7 @@ public class StartupGuard {
     public void disarm() {
         if (handler.hasCallbacks(crashRunnable)) {
             handler.removeCallbacks(crashRunnable);
-            Log.i(TAG, "StartupGuard cancelled crash. Status: 0x" + Long.toHexString(startupStatus.get()));
+            Log.i(TAG, "StartupGuard cancelled crash. " + getStartupStatusAndDiagnosisInfo());
         }
     }
 }

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -419,4 +419,12 @@ void StarboardBridge::SetStartupMilestone(jint milestone) const {
   Java_StarboardBridge_setStartupMilestone(env, j_starboard_bridge_, milestone);
 }
 
+void StarboardBridge::SetStartupDiagnosisInfo(const char* key,
+                                              const char* value) const {
+  JNIEnv* env = base::android::AttachCurrentThread();
+  Java_StarboardBridge_setStartupDiagnosisInfo(
+      env, j_starboard_bridge_, ConvertUTF8ToJavaString(env, key),
+      ConvertUTF8ToJavaString(env, value));
+}
+
 }  // namespace starboard

--- a/starboard/android/shared/starboard_bridge.h
+++ b/starboard/android/shared/starboard_bridge.h
@@ -104,6 +104,7 @@ class StarboardBridge {
   void HideSplashScreen(JNIEnv* env) const;
 
   void SetStartupMilestone(jint milestone) const;
+  void SetStartupDiagnosisInfo(const char* key, const char* value) const;
 
  private:
   StarboardBridge() = default;


### PR DESCRIPTION
Introduce a mechanism to capture and report network navigation errors to the
StartupGuard on Android. Previously, if a navigation error occurred
during startup, StartupGuard would only report a generic crash.

This change enhances the StartupGuard crash message to include specific
network error codes (e.g., -2 for ERR_FAILED) when a DidFinishNavigation
failure triggers the StartupGuard timeout. This provides critical
diagnostic information to pinpoint the root cause of startup issues.

Bug: 492247862