### PR TITLE
android: Add test environment for platform tests

### DIFF
--- a/cobalt/testing/filters/android-arm/starboard_platform_tests_filter.json
+++ b/cobalt/testing/filters/android-arm/starboard_platform_tests_filter.json
@@ -1,7 +1,6 @@
 {
   "comment": "TODO: b/450568428 - Investigate these failing tests",
   "failing_tests": [
-    "MediaCapabilitiesCache*",
     "MimeUtilTest.ChecksSupportedFlacContainers",
     "MimeUtilTest.ChecksSupportedMp3Containers",
     "MimeUtilTest.ChecksSupportedPcmContainers",

--- a/cobalt/testing/filters/android-arm64/starboard_platform_tests_filter.json
+++ b/cobalt/testing/filters/android-arm64/starboard_platform_tests_filter.json
@@ -1,7 +1,6 @@
 {
   "comment": "TODO: b/450568428 - Investigate these failing tests",
   "failing_tests": [
-    "MediaCapabilitiesCache*",
     "MimeUtilTest.ChecksSupportedFlacContainers",
     "MimeUtilTest.ChecksSupportedMp3Containers",
     "MimeUtilTest.ChecksSupportedPcmContainers",

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -200,6 +200,10 @@ source_set("starboard_test_main") {
       "//starboard/tvos/shared:test_support",
     ]
   }
+
+  if (is_android) {
+    deps += [ "//starboard/android/shared:test_support" ]
+  }
 }
 
 if (current_toolchain == starboard_toolchain) {

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -379,6 +379,18 @@ static_library("starboard_base_symbolize") {
   check_includes = false
 }
 
+static_library("test_support") {
+  testonly = true
+  public_deps = [ "//testing/gtest" ]
+
+  deps = [ ":starboard_platform" ]
+
+  sources = [
+    "starboard_test_environment.cc",
+    "starboard_test_environment.h",
+  ]
+}
+
 test("starboard_platform_tests") {
   testonly = true
 
@@ -402,6 +414,7 @@ test("starboard_platform_tests") {
 
   deps = [
     ":starboard_platform",
+    ":test_support",
     "//starboard:starboard_group",
     "//starboard/shared/starboard/drm:drm_test_helpers",
     "//starboard/shared/starboard/player/filter/testing:test_util",

--- a/starboard/android/shared/starboard_test_environment.cc
+++ b/starboard/android/shared/starboard_test_environment.cc
@@ -1,0 +1,66 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/starboard_test_environment.h"
+
+#include <cstdint>
+#include <iterator>
+
+#include "starboard/shared/starboard/feature_list.h"
+#include "starboard/shared/starboard/features.h"
+
+namespace starboard {
+// The initialization function accepts an array of SbFeatures and
+// SbFeatureParams as arguments, so these macros help create that array to pass
+// to the initializer. To see more info about how these macros work and how they
+// help initialize the feature list instance, please refer to
+// //starboard/extension/feature_config.h for more info.
+//
+// We disable clang-format here as there are issues between
+// clang-format and cpplint when running pre-commit on this code.
+// clang-format off
+#define FEATURE_LIST_START const SbFeature kStarboardFeatures[] = {
+#define FEATURE_LIST_END };
+#define FEATURE_PARAM_LIST_START const SbFeatureParam kStarboardParams[] = {
+#define FEATURE_PARAM_LIST_END };
+// clang-format on
+
+#define STARBOARD_FEATURE(feature, name, default_state) features::feature,
+
+#define STARBOARD_FEATURE_PARAM(T, param_object_name, feature_object_name, \
+                                param_name, default_value)                 \
+  features::param_object_name,
+
+#define STARBOARD_FEATURE_PARAM_TIME_TYPE int64_t
+
+#include "starboard/extension/feature_config.h"
+
+#undef STARBOARD_FEATURE
+#undef STARBOARD_FEATURE_PARAM
+#undef FEATURE_LIST_START
+#undef FEATURE_LIST_END
+#undef FEATURE_PARAM_LIST_START
+#undef FEATURE_PARAM_LIST_END
+#undef STARBOARD_FEATURE_PARAM_TIME_TYPE
+
+StarboardTestEnvironment::StarboardTestEnvironment() = default;
+
+StarboardTestEnvironment::~StarboardTestEnvironment() = default;
+
+void StarboardTestEnvironment::SetUp() {
+  features::FeatureList::InitializeFeatureList(
+      kStarboardFeatures, std::size(kStarboardFeatures), kStarboardParams,
+      std::size(kStarboardParams));
+}
+}  // namespace starboard

--- a/starboard/android/shared/starboard_test_environment.h
+++ b/starboard/android/shared/starboard_test_environment.h
@@ -1,0 +1,30 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_STARBOARD_TEST_ENVIRONMENT_H_
+#define STARBOARD_ANDROID_SHARED_STARBOARD_TEST_ENVIRONMENT_H_
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+class StarboardTestEnvironment final : public ::testing::Environment {
+ public:
+  StarboardTestEnvironment();
+  ~StarboardTestEnvironment() override;
+
+  void SetUp() override;
+};
+}  // namespace starboard
+
+#endif  // STARBOARD_ANDROID_SHARED_STARBOARD_TEST_ENVIRONMENT_H_

--- a/starboard/common/test_main.cc
+++ b/starboard/common/test_main.cc
@@ -26,7 +26,24 @@
 #include "starboard/tvos/shared/starboard_test_environment.h"
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 
+#if BUILDFLAG(IS_ANDROID)
+#include "starboard/android/shared/starboard_test_environment.h"
+#endif  // BUILDFLAG(IS_ANDROID)
+
 namespace {
+
+int RunTests(int argc, char** argv) {
+#if BUILDFLAG(IS_ANDROID)
+  ::testing::AddGlobalTestEnvironment(
+      new starboard::StarboardTestEnvironment());
+#elif BUILDFLAG(IS_IOS_TVOS)
+  ::testing::AddGlobalTestEnvironment(
+      new starboard::StarboardTestEnvironment(argc, argv));
+#endif  // BUILDFLAG(IS_ANDROID)
+
+  return RUN_ALL_TESTS();
+}
+
 int InitAndRunAllTests(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
 #if BUILDFLAG(IS_IOS_TVOS)
@@ -37,16 +54,10 @@ int InitAndRunAllTests(int argc, char** argv) {
   // This code is based on //base/test/launcher/unit_test_launcher_ios.cc.
   CHECK(base::CommandLine::InitializedForCurrentProcess() ||
         base::CommandLine::Init(argc, argv));
-  base::InitIOSRunHook(base::BindOnce(
-      [](int argc, char** argv) {
-        ::testing::AddGlobalTestEnvironment(
-            new starboard::StarboardTestEnvironment(argc, argv));
-        return RUN_ALL_TESTS();
-      },
-      argc, argv));
+  base::InitIOSRunHook(base::BindOnce(&RunTests, argc, argv));
   return base::RunTestsFromIOSApp();
-#else
-  return RUN_ALL_TESTS();
+#else   // BUILDFLAG(IS_IOS_TVOS)
+  return RunTests(argc, argv);
 #endif  // BUILDFLAG(IS_IOS_TVOS)
 }
 }  // namespace
@@ -61,7 +72,7 @@ int main(int argc, char** argv) {
   return SbRunStarboardMain(argc, argv, SbEventHandle);
 }
 #endif  // !SB_IS(EVERGREEN)
-#else
+#else   // BUILDFLAG(IS_STARBOARD)
 // If the OS is not Starboard use the regular main e.g. ATV.
 int main(int argc, char** argv) {
   return InitAndRunAllTests(argc, argv);


### PR DESCRIPTION
Introduce a StarboardTestEnvironment for Android platform tests.
This environment initializes the starboard feature list, ensuring that
platform-specific features are properly configured during test
execution. This allows previously failing tests, like those for
MediaCapabilitiesCache, to now execute correctly.
(See #10030 for original disabling of the test suite).

This PR also streamlines the Starboard Test Environment
for platforms, to make future additions to the code easier.

Bug: 502956654