### PR TITLE
[Cherry-pick] Remove freeze event and add flags to reduce background throttling (#9367)

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -513,7 +513,8 @@ public abstract class CobaltActivity extends Activity {
     super.onStart();
 
     WebContents webContents = getActiveWebContents();
-    if (webContents != null) {
+    // If ENABLE_FREEZE is not specified, disable corresponding resume event by default.
+    if (webContents != null && getJavaSwitches().containsKey(JavaSwitches.ENABLE_FREEZE)) {
       // document.onresume event
       webContents.onResume();
     }
@@ -538,7 +539,8 @@ public abstract class CobaltActivity extends Activity {
     // visibility:hidden event
     updateShellActivityVisible(false);
     WebContents webContents = getActiveWebContents();
-    if (webContents != null) {
+    // If ENABLE_FREEZE is not specified, disable freeze event by default.
+    if (webContents != null && getJavaSwitches().containsKey(JavaSwitches.ENABLE_FREEZE)) {
       // document.onfreeze event
       webContents.onFreeze();
     }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -20,4 +20,6 @@ package dev.cobalt.util;
 public class JavaSwitches {
   public static final String ENABLE_QUIC = "EnableQUIC";
   public static final String DISABLE_STARTUP_GUARD = "DisableStartupGuard";
+  /** flag to re-enable freeze and resume events */
+  public static final String ENABLE_FREEZE = "EnableFreeze";
 }


### PR DESCRIPTION
Removing freeze will allow visibilityChange events to be processed
even for async functions like storage flushing or XHRs.

This will also allow web app to execute for some time after
backgrounded.

Note that this does not bring c26 to parity with c25 in terms of
life cycle changes.

Bug: 489533179
Bug: 488071716
(cherry picked from commit 6203f67021626116249e65327f9330e488c3a285)