### PR TITLE
aosp: Rename Android message pump

### DIFF
--- a/copied_base/base/android/java_handler_thread.h
+++ b/copied_base/base/android/java_handler_thread.h
@@ -12,13 +12,12 @@
 #include "base/android/scoped_java_ref.h"
 #include "base/dcheck_is_on.h"
 #include "base/memory/raw_ptr.h"
+#include "base/message_loop/message_pump_for_ui.h"
 #include "base/task/sequence_manager/sequence_manager.h"
 #include "base/task/sequence_manager/task_queue.h"
 #include "base/task/single_thread_task_runner.h"
 
 namespace base {
-
-class MessagePumpForUI;
 
 namespace android {
 

--- a/copied_base/base/message_loop/message_pump_android.cc
+++ b/copied_base/base/message_loop/message_pump_android.cc
@@ -39,7 +39,7 @@ STACK_ALIGN int NonDelayedLooperCallback(int fd, int events, void* data) {
     return 0;
 
   DCHECK(events & ALOOPER_EVENT_INPUT);
-  MessagePumpForUI* pump = reinterpret_cast<MessagePumpForUI*>(data);
+  MessagePumpAndroid* pump = reinterpret_cast<MessagePumpAndroid*>(data);
   pump->OnNonDelayedLooperCallback();
   return 1;  // continue listening for events
 }
@@ -49,7 +49,7 @@ STACK_ALIGN int DelayedLooperCallback(int fd, int events, void* data) {
     return 0;
 
   DCHECK(events & ALOOPER_EVENT_INPUT);
-  MessagePumpForUI* pump = reinterpret_cast<MessagePumpForUI*>(data);
+  MessagePumpAndroid* pump = reinterpret_cast<MessagePumpAndroid*>(data);
   pump->OnDelayedLooperCallback();
   return 1;  // continue listening for events
 }
@@ -59,7 +59,7 @@ STACK_ALIGN int DelayedLooperCallback(int fd, int events, void* data) {
 constexpr uint64_t kTryNativeWorkBeforeIdleBit = uint64_t(1) << 32;
 }  // namespace
 
-MessagePumpForUI::MessagePumpForUI()
+MessagePumpAndroid::MessagePumpAndroid()
     : env_(base::android::AttachCurrentThread()) {
   // The Android native ALooper uses epoll to poll our file descriptors and wake
   // us up. We use a simple level-triggered eventfd to signal that non-delayed
@@ -83,7 +83,7 @@ MessagePumpForUI::MessagePumpForUI()
                 &DelayedLooperCallback, reinterpret_cast<void*>(this));
 }
 
-MessagePumpForUI::~MessagePumpForUI() {
+MessagePumpAndroid::~MessagePumpAndroid() {
   DCHECK_EQ(ALooper_forThread(), looper_);
   ALooper_removeFd(looper_, non_delayed_fd_);
   ALooper_removeFd(looper_, delayed_fd_);
@@ -94,7 +94,7 @@ MessagePumpForUI::~MessagePumpForUI() {
   close(delayed_fd_);
 }
 
-void MessagePumpForUI::OnDelayedLooperCallback() {
+void MessagePumpAndroid::OnDelayedLooperCallback() {
   // There may be non-Chromium callbacks on the same ALooper which may have left
   // a pending exception set, and ALooper does not check for this between
   // callbacks. Check here, and if there's already an exception, just skip this
@@ -125,7 +125,7 @@ void MessagePumpForUI::OnDelayedLooperCallback() {
   DoDelayedLooperWork();
 }
 
-void MessagePumpForUI::DoDelayedLooperWork() {
+void MessagePumpAndroid::DoDelayedLooperWork() {
   delayed_scheduled_time_.reset();
 
   Delegate::NextWorkInfo next_work_info = delegate_->DoWork();
@@ -143,7 +143,7 @@ void MessagePumpForUI::DoDelayedLooperWork() {
     ScheduleDelayedWork(next_work_info);
 }
 
-void MessagePumpForUI::OnNonDelayedLooperCallback() {
+void MessagePumpAndroid::OnNonDelayedLooperCallback() {
   // There may be non-Chromium callbacks on the same ALooper which may have left
   // a pending exception set, and ALooper does not check for this between
   // callbacks. Check here, and if there's already an exception, just skip this
@@ -172,7 +172,7 @@ void MessagePumpForUI::OnNonDelayedLooperCallback() {
   DoNonDelayedLooperWork(do_idle_work);
 }
 
-void MessagePumpForUI::DoNonDelayedLooperWork(bool do_idle_work) {
+void MessagePumpAndroid::DoNonDelayedLooperWork(bool do_idle_work) {
   // Note: We can't skip DoWork() even if |do_idle_work| is true here (i.e. no
   // additional ScheduleWork() since yielding to native) as delayed tasks might
   // have come in and we need to re-sample |next_work_info|.
@@ -234,7 +234,7 @@ void MessagePumpForUI::DoNonDelayedLooperWork(bool do_idle_work) {
   }
 }
 
-void MessagePumpForUI::DoIdleWork() {
+void MessagePumpAndroid::DoIdleWork() {
   if (delegate_->DoIdleWork()) {
     // If DoIdleWork() resulted in any work, we're not idle yet. We need to pump
     // the loop here because we may in fact be idle after doing idle work
@@ -243,11 +243,11 @@ void MessagePumpForUI::DoIdleWork() {
   }
 }
 
-void MessagePumpForUI::Run(Delegate* delegate) {
+void MessagePumpAndroid::Run(Delegate* delegate) {
   CHECK(false) << "Unexpected call to Run()";
 }
 
-void MessagePumpForUI::Attach(Delegate* delegate) {
+void MessagePumpAndroid::Attach(Delegate* delegate) {
   DCHECK(!quit_);
 
   // Since the Looper is controlled by the UI thread or JavaHandlerThread, we
@@ -263,7 +263,7 @@ void MessagePumpForUI::Attach(Delegate* delegate) {
     NOTREACHED();
 }
 
-void MessagePumpForUI::Quit() {
+void MessagePumpAndroid::Quit() {
   if (quit_)
     return;
 
@@ -284,11 +284,11 @@ void MessagePumpForUI::Quit() {
   }
 }
 
-void MessagePumpForUI::ScheduleWork() {
+void MessagePumpAndroid::ScheduleWork() {
   ScheduleWorkInternal(/*do_idle_work=*/false);
 }
 
-void MessagePumpForUI::ScheduleWorkInternal(bool do_idle_work) {
+void MessagePumpAndroid::ScheduleWorkInternal(bool do_idle_work) {
   // Write (add) |value| to the eventfd. This tells the Looper to wake up and
   // call our callback, allowing us to run tasks. This also allows us to detect,
   // when we clear the fd, whether additional work was scheduled after we
@@ -309,7 +309,7 @@ void MessagePumpForUI::ScheduleWorkInternal(bool do_idle_work) {
   DPCHECK(ret >= 0);
 }
 
-void MessagePumpForUI::ScheduleDelayedWork(
+void MessagePumpAndroid::ScheduleDelayedWork(
     const Delegate::NextWorkInfo& next_work_info) {
   if (ShouldQuit())
     return;
@@ -334,7 +334,7 @@ void MessagePumpForUI::ScheduleDelayedWork(
   DPCHECK(ret >= 0);
 }
 
-void MessagePumpForUI::QuitWhenIdle(base::OnceClosure callback) {
+void MessagePumpAndroid::QuitWhenIdle(base::OnceClosure callback) {
   DCHECK(!on_quit_callback_);
   DCHECK(run_loop_);
   on_quit_callback_ = std::move(callback);
@@ -343,11 +343,11 @@ void MessagePumpForUI::QuitWhenIdle(base::OnceClosure callback) {
   ScheduleWork();
 }
 
-MessagePump::Delegate* MessagePumpForUI::SetDelegate(Delegate* delegate) {
+MessagePump::Delegate* MessagePumpAndroid::SetDelegate(Delegate* delegate) {
   return std::exchange(delegate_, delegate);
 }
 
-bool MessagePumpForUI::SetQuit(bool quit) {
+bool MessagePumpAndroid::SetQuit(bool quit) {
   return std::exchange(quit_, quit);
 }
 

--- a/copied_base/base/message_loop/message_pump_android.h
+++ b/copied_base/base/message_loop/message_pump_android.h
@@ -25,14 +25,14 @@ class RunLoop;
 
 // This class implements a MessagePump needed for TYPE_UI MessageLoops on
 // OS_ANDROID platform.
-class BASE_EXPORT MessagePumpForUI : public MessagePump {
+class BASE_EXPORT MessagePumpAndroid : public MessagePump {
  public:
-  MessagePumpForUI();
+  MessagePumpAndroid();
 
-  MessagePumpForUI(const MessagePumpForUI&) = delete;
-  MessagePumpForUI& operator=(const MessagePumpForUI&) = delete;
+  MessagePumpAndroid(const MessagePumpAndroid&) = delete;
+  MessagePumpAndroid& operator=(const MessagePumpAndroid&) = delete;
 
-  ~MessagePumpForUI() override;
+  ~MessagePumpAndroid() override;
 
   void Run(Delegate* delegate) override;
   void Quit() override;

--- a/copied_base/base/message_loop/message_pump_for_ui.h
+++ b/copied_base/base/message_loop/message_pump_for_ui.h
@@ -10,12 +10,12 @@
 
 #include "build/build_config.h"
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_STARBOARD)
+#include "base/message_loop/message_pump_ui_starboard.h"
+#elif BUILDFLAG(IS_WIN)
 #include "base/message_loop/message_pump_win.h"
 #elif BUILDFLAG(IS_ANDROID)
 #include "base/message_loop/message_pump_android.h"
-#elif BUILDFLAG(IS_STARBOARD)
-#include "base/message_loop/message_pump_ui_starboard.h"
 #elif BUILDFLAG(IS_APPLE)
 #include "base/message_loop/message_pump.h"
 #elif BUILDFLAG(IS_NACL) || BUILDFLAG(IS_AIX)
@@ -30,14 +30,13 @@
 
 namespace base {
 
-#if BUILDFLAG(IS_WIN)
+#if BUILDFLAG(IS_STARBOARD)
+using MessagePumpForUI = MessagePumpUIStarboard;
+#elif BUILDFLAG(IS_WIN)
 // Windows defines it as-is.
 using MessagePumpForUI = MessagePumpForUI;
 #elif BUILDFLAG(IS_ANDROID)
-// Android defines it as-is.
-using MessagePumpForUI = MessagePumpForUI;
-#elif BUILDFLAG(IS_STARBOARD)
-using MessagePumpForUI = MessagePumpUIStarboard;
+using MessagePumpForUI = MessagePumpAndroid;
 #elif BUILDFLAG(IS_APPLE)
 // MessagePumpForUI isn't bound to a specific impl on Mac. While each impl can
 // be represented by a plain MessagePump: MessagePumpMac::Create() must be used

--- a/copied_base/base/run_loop.h
+++ b/copied_base/base/run_loop.h
@@ -31,10 +31,6 @@ class ScopedRunLoopTimeout;
 class ScopedDisableRunLoopTimeout;
 }  // namespace test
 
-#if BUILDFLAG(IS_ANDROID)
-class MessagePumpForUI;
-#endif
-
 #if BUILDFLAG(IS_IOS)
 class MessagePumpUIApplication;
 #endif
@@ -277,7 +273,7 @@ class BASE_EXPORT RunLoop {
 #if BUILDFLAG(IS_ANDROID)
   // Android doesn't support the blocking RunLoop::Run, so it calls
   // BeforeRun and AfterRun directly.
-  friend class MessagePumpForUI;
+  friend class MessagePumpAndroid;
 #endif
 
 #if BUILDFLAG(IS_IOS)


### PR DESCRIPTION
In AOSP builds, both the Starboard and Android message pumps are
available. Rename the Android message pump to `MessagePumpAndroid` to
avoid a conflict with the Starboard alias declaration.

Bug: 495203133