### PR TITLE
aosp: Add missing jni_android.h includes

### DIFF
--- a/copied_base/base/android/callback_android.cc
+++ b/copied_base/base/android/callback_android.cc
@@ -4,11 +4,14 @@
 
 #include "base/android/callback_android.h"
 
+#include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
 #include "base/android/scoped_java_ref.h"
-#include "base/base_jni/Callback_jni.h"
 #include "base/time/time.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
+#include "base/base_jni/Callback_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/early_trace_event_binding.cc
+++ b/copied_base/base/android/early_trace_event_binding.cc
@@ -6,12 +6,15 @@
 
 #include <stdint.h>
 
+#include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
 #include "base/android/trace_event_binding.h"
-#include "base/base_jni/EarlyTraceEvent_jni.h"
 #include "base/time/time.h"
 #include "base/trace_event/base_tracing.h"
 #include "base/tracing_buildflags.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
+#include "base/base_jni/EarlyTraceEvent_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/event_log.cc
+++ b/copied_base/base/android/event_log.cc
@@ -3,6 +3,10 @@
 // found in the LICENSE file.
 
 #include "base/android/event_log.h"
+
+#include "base/android/jni_android.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
 #include "base/base_jni/EventLog_jni.h"
 
 namespace base {

--- a/copied_base/base/android/int_string_callback.cc
+++ b/copied_base/base/android/int_string_callback.cc
@@ -10,7 +10,10 @@
 
 #include <jni.h>
 
+#include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
 #include "base/base_jni/IntStringCallback_jni.h"
 
 namespace base {

--- a/copied_base/base/android/java_heap_dump_generator.cc
+++ b/copied_base/base/android/java_heap_dump_generator.cc
@@ -6,7 +6,10 @@
 
 #include <jni.h>
 
+#include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
 #include "base/base_jni/JavaHeapDumpGenerator_jni.h"
 
 namespace base {

--- a/copied_base/base/android/java_runtime.cc
+++ b/copied_base/base/android/java_runtime.cc
@@ -4,8 +4,11 @@
 
 #include "base/android/java_runtime.h"
 
-#include "base/android_runtime_jni_headers/Runtime_jni.h"
+#include "base/android/jni_android.h"
 #include "base/numerics/safe_conversions.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
+#include "base/android_runtime_jni_headers/Runtime_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/android/task_scheduler/post_task_android.cc
+++ b/copied_base/base/android/task_scheduler/post_task_android.cc
@@ -4,6 +4,9 @@
 
 #include "base/android/task_scheduler/post_task_android.h"
 
+#include "base/android/jni_android.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
 #include "base/base_jni/PostTask_jni.h"
 
 namespace base {

--- a/copied_base/base/android/task_scheduler/task_runner_android.cc
+++ b/copied_base/base/android/task_scheduler/task_runner_android.cc
@@ -8,9 +8,8 @@
 #include <string>
 #include <utility>
 
+#include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/android_runtime_unchecked_jni_headers/Runnable_jni.h"
-#include "base/base_jni/TaskRunnerImpl_jni.h"
 #include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/functional/bind.h"
@@ -23,6 +22,10 @@
 #include "base/task/thread_pool/thread_pool_instance.h"
 #include "base/time/time.h"
 #include "base/trace_event/base_tracing.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
+#include "base/android_runtime_unchecked_jni_headers/Runnable_jni.h"
+#include "base/base_jni/TaskRunnerImpl_jni.h"
 
 namespace base {
 

--- a/copied_base/base/android/trace_event_binding.cc
+++ b/copied_base/base/android/trace_event_binding.cc
@@ -2,13 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "base/android/trace_event_binding.h"
+
 #include <jni.h>
 
 #include <set>
 
+#include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
 #include "base/android/trace_event_binding.h"
-#include "base/base_jni/TraceEvent_jni.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/trace_event/base_tracing.h"
 #include "base/tracing_buildflags.h"
@@ -16,6 +18,9 @@
 #if BUILDFLAG(ENABLE_BASE_TRACING)
 #include "base/trace_event/trace_event_impl.h"  // no-presubmit-check
 #endif  // BUILDFLAG(ENABLE_BASE_TRACING)
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
+#include "base/base_jni/TraceEvent_jni.h"
 
 namespace base {
 namespace android {

--- a/copied_base/base/power_monitor/power_monitor_device_source_android.cc
+++ b/copied_base/base/power_monitor/power_monitor_device_source_android.cc
@@ -2,11 +2,15 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
-#include "base/base_jni/PowerMonitor_jni.h"
-#include "base/power_monitor/power_monitor.h"
 #include "base/power_monitor/power_monitor_device_source.h"
+
+#include "base/android/jni_android.h"
+#include "base/power_monitor/power_monitor.h"
 #include "base/power_monitor/power_monitor_source.h"
 #include "base/power_monitor/power_observer.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
+#include "base/base_jni/PowerMonitor_jni.h"
 
 namespace base {
 

--- a/copied_base/base/profiler/stack_sampling_profiler_java_test_util.cc
+++ b/copied_base/base/profiler/stack_sampling_profiler_java_test_util.cc
@@ -4,8 +4,11 @@
 
 #include "base/profiler/stack_sampling_profiler_java_test_util.h"
 
-#include "base/base_profiler_test_support_jni_headers/TestSupport_jni.h"
+#include "base/android/jni_android.h"
 #include "base/location.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
+#include "base/base_profiler_test_support_jni_headers/TestSupport_jni.h"
 
 namespace base {
 

--- a/copied_base/base/test/android/java_handler_thread_helpers.cc
+++ b/copied_base/base/test/android/java_handler_thread_helpers.cc
@@ -5,8 +5,11 @@
 #include "base/test/android/java_handler_thread_helpers.h"
 
 #include "base/android/java_handler_thread.h"
+#include "base/android/jni_android.h"
 #include "base/synchronization/waitable_event.h"
 #include "base/task/current_thread.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
 #include "base/test/base_unittests_jni_headers/JavaHandlerThreadHelpers_jni.h"
 
 namespace base {

--- a/copied_base/base/test/android/url_utils.cc
+++ b/copied_base/base/test/android/url_utils.cc
@@ -4,8 +4,11 @@
 
 #include "base/test/android/url_utils.h"
 
+#include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
 #include "base/android/scoped_java_ref.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
 #include "base/test/test_support_jni_headers/UrlUtils_jni.h"
 
 namespace base {


### PR DESCRIPTION
In AOSP, //copied_base/base uses jni_zero, but it's still using the
compatibility namespace `base::android::` without including the proper
header file.

Bug: 495203133