### PR TITLE
aosp: Use android_toolchain in missing places

### DIFF
--- a/gin/BUILD.gn
+++ b/gin/BUILD.gn
@@ -4,6 +4,7 @@
 
 if (is_android) {
   import("//build/config/android/rules.gni")
+  import("//starboard/build/config/android_toolchain.gni")
 }
 import("//base/allocator/partition_allocator/partition_alloc.gni")
 import("//testing/test.gni")
@@ -131,7 +132,7 @@ executable("gin_shell") {
 }
 
 if (is_android && enable_java_templates &&
-    current_toolchain == default_toolchain) {
+    current_toolchain == android_toolchain) {
   android_assets("v8_snapshot_assets") {
     if (v8_use_external_startup_data) {
       disable_compression = true

--- a/services/media_session/public/cpp/android/BUILD.gn
+++ b/services/media_session/public/cpp/android/BUILD.gn
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/android/rules.gni")
+import("//starboard/build/config/android_toolchain.gni")
 import("//third_party/jni_zero/jni_zero.gni")
 
 _jni_sources = [
@@ -15,7 +16,7 @@ generate_jni("media_session_jni_headers") {
   sources = _jni_sources
 }
 
-if (current_toolchain == default_toolchain) {
+if (current_toolchain == android_toolchain) {
   android_library("media_session_java") {
     deps = [
       "//third_party/androidx:androidx_annotation_annotation_java",

--- a/url/BUILD.gn
+++ b/url/BUILD.gn
@@ -12,6 +12,7 @@ import("//third_party/jni_zero/jni_zero.gni")
 
 if (is_android) {
   import("//build/config/android/rules.gni")
+  import("//starboard/build/config/android_toolchain.gni")
 }
 
 buildflag_header("buildflags") {
@@ -131,7 +132,7 @@ if (is_android || is_robolectric) {
     }
   }
 }
-if (is_android && current_toolchain == default_toolchain) {
+if (is_android && current_toolchain == android_toolchain) {
   # TODO(agrieve): Remove alias once usages are removed.
   java_group("gurl_java") {
     deps = [ ":url_java" ]


### PR DESCRIPTION
Replace `default_toolchain` with `android_toolchain` in several more
places. This is a follow-up of
https://github.com/youtube/cobalt/pull/9923 where these changes were
missing.

Bug: 495203133