### PR TITLE
media: Update DefaultReuseStrategy to use InPlace

### DIFF
--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -514,10 +514,6 @@ const base::FeatureParam<base::TimeDelta> kAudioWriteDurationLocal{
     &kCobaltAudioWriteDuration, "AudioWriteDurationLocal", base::Milliseconds(1000)};
 const base::FeatureParam<base::TimeDelta> kAudioWriteDurationRemote{
     &kCobaltAudioWriteDuration, "AudioWriteDurationRemote", base::Microseconds(kSbPlayerWriteDurationRemote)};
-// When enabled, Cobalt stores allocation meta data in place for DecoderBuffers.
-BASE_FEATURE(kCobaltDecoderBufferAllocatorWithInPlaceMetadata,
-             "CobaltDecoderBufferAllocatorWithInPlaceMetadata",
-             base::FEATURE_DISABLED_BY_DEFAULT);
 // When disabled, Cobalt rejects progressive video formats.
 BASE_FEATURE(kCobaltProgressivePlayback,
              "CobaltProgressivePlayback",

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -232,7 +232,6 @@ MEDIA_EXPORT extern const base::FeatureParam<bool>
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltAudioWriteDuration);
 MEDIA_EXPORT extern const base::FeatureParam<base::TimeDelta> kAudioWriteDurationLocal;
 MEDIA_EXPORT extern const base::FeatureParam<base::TimeDelta> kAudioWriteDurationRemote;
-MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltDecoderBufferAllocatorWithInPlaceMetadata);
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltProgressivePlayback);
 #if BUILDFLAG(IS_ANDROID)
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingAndroidOverlay);

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -37,6 +37,8 @@ namespace media {
 
 namespace {
 
+// The current default AllocatorStrategy is InPlaceReuseAllocatorBase.
+// To see more context as to why this is the case, see b/487332929.
 using DefaultReuseAllocatorStrategy =
     BidirectionalFitDecoderBufferAllocatorStrategy<
         starboard::InPlaceReuseAllocatorBase>;
@@ -326,7 +328,8 @@ void DecoderBufferAllocator::EnsureStrategyIsCreated() {
   strategy_ = std::make_unique<DefaultReuseAllocatorStrategy>(
       initial_capacity_, allocation_unit_,
       /*enable_decommit_on_idle=*/false);
-  LOG(INFO) << "DecoderBufferAllocator is using DefaultReuseAllocatorStrategy.";
+  LOG(INFO) << "DecoderBufferAllocator is using "
+               "DefaultReuseAllocatorStrategy.";
 
   LOG(INFO) << "Allocated " << initial_capacity_
             << " bytes for decoder buffer pool.";

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -39,9 +39,6 @@ namespace {
 
 using DefaultReuseAllocatorStrategy =
     BidirectionalFitDecoderBufferAllocatorStrategy<
-        starboard::ReuseAllocatorBase>;
-using InPlaceReuseAllocatorStrategy =
-    BidirectionalFitDecoderBufferAllocatorStrategy<
         starboard::InPlaceReuseAllocatorBase>;
 using starboard::experimental::MediaBufferPool;
 
@@ -326,13 +323,10 @@ void DecoderBufferAllocator::EnsureStrategyIsCreated() {
                     "strategy. Falling back to default.";
   }
 
-  // Through experimentation, we have found that the
-  // InPlaceReuseAllocatorStrategy has better performance than the previous
-  // DefaultReuseAllocatorStrategy. See b/487332929 for more info.
-  strategy_ = std::make_unique<InPlaceReuseAllocatorStrategy>(
+  strategy_ = std::make_unique<DefaultReuseAllocatorStrategy>(
       initial_capacity_, allocation_unit_,
       /*enable_decommit_on_idle=*/false);
-  LOG(INFO) << "DecoderBufferAllocator is using InPlaceReuseAllocatorBase.";
+  LOG(INFO) << "DecoderBufferAllocator is using DefaultReuseAllocatorStrategy.";
 
   LOG(INFO) << "Allocated " << initial_capacity_
             << " bytes for decoder buffer pool.";

--- a/media/starboard/decoder_buffer_allocator_test.cc
+++ b/media/starboard/decoder_buffer_allocator_test.cc
@@ -27,10 +27,8 @@
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
-#include "base/test/scoped_feature_list.h"
 #include "base/time/time.h"
 #include "media/base/demuxer_stream.h"
-#include "media/base/media_switches.h"
 #include "media/base/test_data_util.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -43,8 +41,6 @@ namespace media {
 namespace {
 
 typedef DecoderBufferAllocator::Handle Handle;
-using ::testing::Bool;
-using ::testing::Combine;
 using ::testing::Values;
 
 struct Operation {
@@ -136,19 +132,10 @@ const std::vector<Operation>& ReadAllocationLogFile(const std::string& name) {
 }
 
 class DecoderBufferAllocatorTest
-    : public ::testing::TestWithParam<std::tuple<std::string, bool>> {
- protected:
-  void SetUp() {
-    scoped_list.InitWithFeatureState(
-        kCobaltDecoderBufferAllocatorWithInPlaceMetadata,
-        std::get<1>(GetParam()));
-  }
-
-  base::test::ScopedFeatureList scoped_list;
-};
+    : public ::testing::TestWithParam<std::string> {};
 
 TEST_P(DecoderBufferAllocatorTest, VerifyAndCacheAllocationLogs) {
-  ReadAllocationLogFile(std::get<0>(GetParam()));
+  ReadAllocationLogFile(GetParam());
 }
 
 TEST_P(DecoderBufferAllocatorTest, CapacityUnderLimit) {
@@ -159,7 +146,7 @@ TEST_P(DecoderBufferAllocatorTest, CapacityUnderLimit) {
   base::Time last_allocate_time = start_time;
   int free_operations_since_last_allocate = 0;
 
-  const auto& operations = ReadAllocationLogFile(std::get<0>(GetParam()));
+  const auto& operations = ReadAllocationLogFile(GetParam());
 
   for (auto&& operation : operations) {
     if (operation.operation_type == Operation::Type::kAllocate) {
@@ -231,7 +218,7 @@ TEST_P(DecoderBufferAllocatorTest, CapacityByType) {
       std::unordered_map<std::string, Handle> handle_to_handle_map;
       size_t max_allocated = 0;
       size_t max_capacity = 0;
-      const auto& operations = ReadAllocationLogFile(std::get<0>(GetParam()));
+      const auto& operations = ReadAllocationLogFile(GetParam());
 
       for (auto&& operation : operations) {
         if (operation.buffer_type != buffer_type) {
@@ -268,22 +255,17 @@ TEST_P(DecoderBufferAllocatorTest, CapacityByType) {
   }
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    DecoderBufferAllocatorTests,
-    DecoderBufferAllocatorTest,
-    Combine(Values("starboard/allocations_1La4QzGeaaQ.txt",
-                   "starboard/allocations_8k.txt",
-                   "starboard/allocations_PMwaIrjiz8w.txt"),
-            Bool()),
-    [](const ::testing::TestParamInfo<std::tuple<std::string, bool>>& info) {
-      std::string name = std::get<0>(info.param);
-      std::replace(name.begin(), name.end(), '.', '_');
-      std::replace(name.begin(), name.end(), '/', '_');
-
-      name += std::get<1>(info.param) ? "_in_place_allocator"
-                                      : "_default_allocator";
-      return name;
-    });
+INSTANTIATE_TEST_SUITE_P(DecoderBufferAllocatorTests,
+                         DecoderBufferAllocatorTest,
+                         Values("starboard/allocations_1La4QzGeaaQ.txt",
+                                "starboard/allocations_8k.txt",
+                                "starboard/allocations_PMwaIrjiz8w.txt"),
+                         [](const ::testing::TestParamInfo<std::string>& info) {
+                           std::string name = info.param;
+                           std::replace(name.begin(), name.end(), '.', '_');
+                           std::replace(name.begin(), name.end(), '/', '_');
+                           return name;
+                         });
 
 }  // namespace
 }  // namespace media


### PR DESCRIPTION
This change removes the kCobaltDecoderBufferAllocatorWithInPlaceMetadata
feature switch, which is no longer needed as the InPlaceReuseAllocatorStrategy
has been launched. Since experimentation has proven that 
InPlaceReuseAllocatorStrategy is better than ReuseAllocatorStrategy, we
also update the `DefaultReuseAllocatorStrategy` to use the 
InPlaceReuseAllocatorStrategy.

We also update the corresponding tests to not make use of the switch.

Bug: 505010192