### PR TITLE
media: Allow to post GPU tasks from StarboardRenderer

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -63,6 +63,7 @@ if (is_win) {
 }
 
 if (is_cobalt) {
+  import("//starboard/build/buildflags.gni")
   import("//starboard/build/config/toolchain_variables.gni")
 }
 

--- a/base/threading/thread_restrictions.h
+++ b/base/threading/thread_restrictions.h
@@ -337,6 +337,9 @@ class GpuMojoMediaClientWin;
 class MailboxVideoFrameConverter;
 class MojoVideoEncodeAccelerator;
 class PaintCanvasVideoRenderer;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+class StarboardRendererWrapper;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 class V4L2DevicePoller;  // TODO(crbug.com/41486289): remove this.
 }  // namespace media
 namespace memory_instrumentation {
@@ -779,6 +782,9 @@ class BASE_EXPORT ScopedAllowBaseSyncPrimitives {
             WorkerStatus StatusWork>
   friend class media::CodecWorkerImpl;
   friend class media::MojoVideoEncodeAccelerator;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  friend class media::StarboardRendererWrapper;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   friend class mojo::core::ScopedIPCSupport;
   friend class net::MultiThreadedCertVerifierScopedAllowBaseSyncPrimitives;
   friend class rlz_lib::FinancialPing;
@@ -864,6 +870,9 @@ class BASE_EXPORT
   friend class media::AudioOutputDevice;
   friend class media::MailboxVideoFrameConverter;
   friend class media::PaintCanvasVideoRenderer;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  friend class media::StarboardRendererWrapper;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   friend class media::V4L2DevicePoller;  // TODO(crbug.com/41486289): remove
                                          // this.
   friend class mojo::SyncCallRestrictions;

--- a/media/gpu/BUILD.gn
+++ b/media/gpu/BUILD.gn
@@ -206,6 +206,8 @@ component("gpu") {
       "starboard/starboard_gpu_factory_impl.cc",
       "starboard/starboard_gpu_factory_impl.h",
     ]
+
+    deps += [ "//starboard/common" ]
   }
 
   if (use_v4l2_codec) {

--- a/media/gpu/starboard/starboard_gpu_factory.h
+++ b/media/gpu/starboard/starboard_gpu_factory.h
@@ -16,8 +16,10 @@
 #define MEDIA_GPU_STARBOARD_STARBOARD_GPU_FACTORY_H_
 
 #include "base/memory/raw_ptr.h"
+#include "base/synchronization/waitable_event.h"
 #include "base/unguessable_token.h"
 #include "gpu/ipc/service/command_buffer_stub.h"
+#include "starboard/decode_target.h"
 
 namespace media {
 // StarboardGpuFactory allows to post tasks on gpu thread.
@@ -39,6 +41,10 @@ class StarboardGpuFactory : public gpu::CommandBufferStub::DestructionObserver {
   virtual void Initialize(base::UnguessableToken channel_token,
                           int32_t route_id,
                           base::OnceClosure callback) = 0;
+  virtual void RunSbDecodeTargetFunctionOnGpu(
+      SbDecodeTargetGlesContextRunnerTarget target_function,
+      void* target_function_context,
+      base::WaitableEvent* done_event) = 0;
 };
 
 }  // namespace media

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -23,6 +23,12 @@
 #include "ui/gl/scoped_restore_texture.h"
 
 namespace media {
+namespace {
+bool MakeContextCurrent(gpu::CommandBufferStub* stub) {
+  return stub && stub->decoder_context() &&
+         stub->decoder_context()->MakeCurrent();
+}
+}  // namespace
 
 StarboardGpuFactoryImpl::StarboardGpuFactoryImpl(GetStubCB get_stub_cb)
     : get_stub_cb_(std::move(get_stub_cb)) {
@@ -45,6 +51,19 @@ void StarboardGpuFactoryImpl::Initialize(base::UnguessableToken channel_token,
     stub_->AddDestructionObserver(this);
   }
   std::move(callback).Run();
+}
+
+void StarboardGpuFactoryImpl::RunSbDecodeTargetFunctionOnGpu(
+    SbDecodeTargetGlesContextRunnerTarget target_function,
+    void* target_function_context,
+    base::WaitableEvent* done_event) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!MakeContextCurrent(stub_)) {
+    done_event->Signal();
+    return;
+  }
+  target_function(target_function_context);
+  done_event->Signal();
 }
 
 void StarboardGpuFactoryImpl::OnWillDestroyStub(bool /*have_context*/) {

--- a/media/gpu/starboard/starboard_gpu_factory_impl.h
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.h
@@ -35,6 +35,10 @@ class StarboardGpuFactoryImpl : public StarboardGpuFactory {
   void Initialize(base::UnguessableToken channel_token,
                   int32_t route_id,
                   base::OnceClosure callback) override;
+  void RunSbDecodeTargetFunctionOnGpu(
+      SbDecodeTargetGlesContextRunnerTarget target_function,
+      void* target_function_context,
+      base::WaitableEvent* done_event) override;
 
  private:
   void OnWillDestroyStub(bool have_context) override;

--- a/media/mojo/services/BUILD.gn
+++ b/media/mojo/services/BUILD.gn
@@ -122,6 +122,7 @@ component("services") {
       "starboard/starboard_renderer_wrapper.h",
     ]
     deps += [
+      "//starboard/common",
       "//starboard:starboard_headers_only",
       "//cobalt/media/service",
       "//cobalt/media/service/mojom",
@@ -360,7 +361,10 @@ source_set("unit_tests") {
 
   if (is_cobalt && use_starboard_media) {
     sources += [ "starboard/starboard_renderer_wrapper_unittest.cc" ]
-    deps += [ "//cobalt/media/service" ]
+    deps += [
+      "//cobalt/media/service",
+      "//starboard/common",
+    ]
   }
 }
 

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -16,6 +16,7 @@
 
 #include <utility>
 
+#include "base/compiler_specific.h"
 #include "base/functional/callback_helpers.h"
 #include "base/task/bind_post_task.h"
 #include "base/time/time.h"
@@ -54,6 +55,7 @@ StarboardRendererWrapper::StarboardRendererWrapper(
       traits.gpu_task_runner,
       std::move(traits.get_starboard_command_buffer_stub_cb));
   gpu_factory_ = std::move(gpu_factory_impl);
+  gpu_task_runner_ = std::move(traits.gpu_task_runner);
 }
 
 StarboardRendererWrapper::~StarboardRendererWrapper() = default;
@@ -218,7 +220,14 @@ void StarboardRendererWrapper::ContinueInitialization(
     PipelineStatusCallback init_cb) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   DCHECK(init_cb);
-  // TODO(b/375070492): add |decode_target_graphics_context_provider_|.
+  is_gpu_factory_initialized_ = true;
+  decode_target_graphics_context_provider_.gles_context_runner_context = this;
+  decode_target_graphics_context_provider_.gles_context_runner =
+      &StarboardRendererWrapper::GraphicsContextRunner;
+  GetRenderer()->set_decode_target_graphics_context_provider(
+      base::BindRepeating(
+          &StarboardRendererWrapper::GetSbDecodeTargetGraphicsContextProvider,
+          base::Unretained(this)));
 
   GetRenderer()->Initialize(media_resource, client, std::move(init_cb));
 }
@@ -253,5 +262,43 @@ void StarboardRendererWrapper::OnRequestOverlayInfoByStarboard(
   client_extension_remote_->RequestOverlayInfo(restart_for_transitions);
 }
 #endif  // BUILDFLAG(IS_ANDROID)
+
+SbDecodeTargetGraphicsContextProvider*
+StarboardRendererWrapper::GetSbDecodeTargetGraphicsContextProvider() {
+  return &decode_target_graphics_context_provider_;
+}
+
+// static
+// Disable CFI checks for this method because it executes function pointers
+// provided by the Starboard library, which cannot be verified across the
+// DSO boundary.
+NO_SANITIZE("cfi-icall")
+void StarboardRendererWrapper::GraphicsContextRunner(
+    SbDecodeTargetGraphicsContextProvider* graphics_context_provider,
+    SbDecodeTargetGlesContextRunnerTarget target_function,
+    void* target_function_context) {
+  auto provider = reinterpret_cast<StarboardRendererWrapper*>(
+      graphics_context_provider->gles_context_runner_context);
+  if (!provider || !provider->is_gpu_factory_initialized_) {
+    return;
+  }
+  if (provider->gpu_task_runner_->RunsTasksInCurrentSequence()) {
+    // If it is on the gpu thread, post target_function() directly on it.
+    target_function(target_function_context);
+  } else if (provider->gpu_factory_) {
+    // If it is not on the gpu thread, post target_function() with
+    // |gpu_factory_|.
+    base::WaitableEvent done_event(
+        base::WaitableEvent::ResetPolicy::MANUAL,
+        base::WaitableEvent::InitialState::NOT_SIGNALED);
+    provider->gpu_factory_
+        .AsyncCall(&StarboardGpuFactory::RunSbDecodeTargetFunctionOnGpu)
+        .WithArgs(target_function, target_function_context, &done_event);
+    // Blocking is okay here to allow SbPlayer to post |target_function|
+    // on gpu thread, and StarboardRenderer waits for the execution.
+    base::ScopedAllowBaseSyncPrimitives allow_wait;
+    done_event.Wait();
+  }
+}
 
 }  // namespace media

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -31,6 +31,7 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "starboard/decode_target.h"
 
 #if BUILDFLAG(IS_ANDROID)
 #include "media/base/android_overlay_mojo_factory.h"
@@ -119,6 +120,13 @@ class StarboardRendererWrapper
                               RendererClient* client,
                               PipelineStatusCallback init_cb);
   bool IsGpuChannelTokenAvailable() const { return !!command_buffer_id_; }
+  SbDecodeTargetGraphicsContextProvider*
+  GetSbDecodeTargetGraphicsContextProvider();
+
+  static void GraphicsContextRunner(
+      SbDecodeTargetGraphicsContextProvider* graphics_context_provider,
+      SbDecodeTargetGlesContextRunnerTarget target_function,
+      void* target_function_context);
 
   mojo::Receiver<RendererExtension> renderer_extension_receiver_;
   mojo::Remote<ClientExtension> client_extension_remote_;
@@ -127,6 +135,12 @@ class StarboardRendererWrapper
   StarboardRenderer renderer_;
   mojom::CommandBufferIdPtr command_buffer_id_;
   base::SequenceBound<StarboardGpuFactory> gpu_factory_;
+  scoped_refptr<base::SingleThreadTaskRunner> gpu_task_runner_;
+
+  SbDecodeTargetGraphicsContextProvider
+      decode_target_graphics_context_provider_ = {};
+
+  bool is_gpu_factory_initialized_ = false;
 
   raw_ptr<StarboardRenderer> test_renderer_;
   raw_ptr<base::SequenceBound<StarboardGpuFactory>> test_gpu_factory_;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -21,6 +21,7 @@
 #include "base/functional/callback_helpers.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/task/single_thread_task_runner.h"
+#include "base/task/thread_pool.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/task_environment.h"
@@ -30,6 +31,7 @@
 #include "media/base/test_helpers.h"
 #include "media/gpu/starboard/starboard_gpu_factory_impl.h"
 #include "media/mojo/mojom/renderer_extensions.mojom.h"
+#include "starboard/decode_target.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -136,6 +138,13 @@ class MockStarboardGpuFactory : public StarboardGpuFactory {
     std::move(callback).Run();
   }
 
+  void RunSbDecodeTargetFunctionOnGpu(
+      SbDecodeTargetGlesContextRunnerTarget target_function,
+      void* target_function_context,
+      base::WaitableEvent* done_event) override {
+    done_event->Signal();
+  }
+
  private:
   void OnWillDestroyStub(bool have_context) override {}
 };
@@ -160,7 +169,7 @@ class StarboardRendererWrapperTest : public testing::Test {
             AndroidOverlayMojoFactoryCB()
 #endif  // BUILDFLAG(IS_ANDROID)
                 )),
-        mock_gpu_factory_(task_environment_.GetMainThreadTaskRunner()) {
+        mock_gpu_factory_(dedicated_task_runner) {
     // Setup MockStarboardGpuFactory as StarboardGpuFactory so
     // it can overwrite |gpu_factory_| in StarboardRendererWrapper
     // via SetGpuFactoryForTesting().
@@ -208,6 +217,10 @@ class StarboardRendererWrapperTest : public testing::Test {
   }
 
   base::test::TaskEnvironment task_environment_;
+  scoped_refptr<base::SequencedTaskRunner> dedicated_task_runner =
+      base::ThreadPool::CreateSingleThreadTaskRunner(
+          /*traits=*/{},
+          base::SingleThreadTaskRunnerThreadMode::DEDICATED);
   cobalt::media::VideoGeometrySetterService video_geometry_setter_service_;
   std::unique_ptr<StrictMock<MockStarboardRenderer>> mock_renderer_;
   base::SequenceBound<StrictMock<MockStarboardGpuFactory>> mock_gpu_factory_;

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -117,7 +117,6 @@ SbPlayerBridge::SbPlayerBridge(
     SbPlayerOutputMode default_output_mode,
     const OnEncryptedMediaInitDataEncounteredCB&
         on_encrypted_media_init_data_encountered_cb,
-    DecodeTargetProvider* const decode_target_provider,
     std::string pipeline_identifier)
     : url_(url),
       sbplayer_interface_(interface),
@@ -129,7 +128,6 @@ SbPlayerBridge::SbPlayerBridge(
 #endif
       on_encrypted_media_init_data_encountered_cb_(
           on_encrypted_media_init_data_encountered_cb),
-      decode_target_provider_(decode_target_provider),
       cval_stats_(&interface->cval_stats_),
       pipeline_identifier_(pipeline_identifier),
       is_url_based_(true) {
@@ -161,9 +159,6 @@ SbPlayerBridge::SbPlayerBridge(
     Host* host,
     bool allow_resume_after_suspend,
     SbPlayerOutputMode default_output_mode,
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-    DecodeTargetProvider* const decode_target_provider,
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
     const std::string& max_video_capabilities,
     int max_video_input_size,
     const ExperimentalFeatures& experimental_features
@@ -188,9 +183,6 @@ SbPlayerBridge::SbPlayerBridge(
 #endif  // COBALT_MEDIA_ENABLE_SUSPEND_RESUME
       audio_config_(audio_config),
       video_config_(video_config),
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-      decode_target_provider_(decode_target_provider),
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
 #if COBALT_MEDIA_ENABLE_PLAYER_SET_MAX_VIDEO_INPUT_SIZE
       // TODO: b/326654546 - Reorder this variable once enabled.
       max_video_input_size_(max_video_input_size),
@@ -209,14 +201,8 @@ SbPlayerBridge::SbPlayerBridge(
       surface_view_(surface_view)
 #endif  // BUILDFLAG(IS_ANDROID)
 {
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-  DCHECK(!get_decode_target_graphics_context_provider_func_.is_null());
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
   DCHECK(audio_config.IsValidConfig() || video_config.IsValidConfig());
   DCHECK(host_);
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-  DCHECK(decode_target_provider_);
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
 
   audio_stream_info_.codec = kSbMediaAudioCodecNone;
   video_stream_info_.codec = kSbMediaVideoCodecNone;
@@ -246,12 +232,6 @@ SbPlayerBridge::~SbPlayerBridge() {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
   weak_factory_.InvalidateWeakPtrs();
-
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-  decode_target_provider_->SetOutputMode(
-      DecodeTargetProvider::kOutputModeInvalid);
-  decode_target_provider_->ResetGetCurrentSbDecodeTargetFunction();
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
 
   if (SbPlayerIsValid(player_)) {
 #if COBALT_MEDIA_ENABLE_CVAL
@@ -555,12 +535,6 @@ void SbPlayerBridge::Suspend() {
 
   state_ = kSuspended;
 
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-  decode_target_provider_->SetOutputMode(
-      DecodeTargetProvider::kOutputModeInvalid);
-  decode_target_provider_->ResetGetCurrentSbDecodeTargetFunction();
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-
 #if COBALT_MEDIA_ENABLE_CVAL
   cval_stats_->StartTimer(MediaTiming::SbPlayerDestroy, pipeline_identifier_);
 #endif  // COBALT_MEDIA_ENABLE_CVAL
@@ -606,29 +580,6 @@ void SbPlayerBridge::Resume(SbWindow window) {
   }
 }
 
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-
-namespace {
-
-DecodeTargetProvider::OutputMode ToVideoFrameProviderOutputMode(
-    SbPlayerOutputMode output_mode) {
-  switch (output_mode) {
-    case kSbPlayerOutputModeDecodeToTexture:
-      return DecodeTargetProvider::kOutputModeDecodeToTexture;
-    case kSbPlayerOutputModePunchOut:
-      return DecodeTargetProvider::kOutputModePunchOut;
-    case kSbPlayerOutputModeInvalid:
-      return DecodeTargetProvider::kOutputModeInvalid;
-  }
-
-  NOTREACHED();
-  return DecodeTargetProvider::kOutputModeInvalid;
-}
-
-}  // namespace
-
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-
 #if SB_HAS(PLAYER_WITH_URL)
 // static
 void SbPlayerBridge::EncryptedMediaInitDataEncounteredCB(
@@ -666,17 +617,10 @@ void SbPlayerBridge::CreateUrlPlayer(const std::string& url) {
   DCHECK(SbPlayerIsValid(player_));
 
   if (output_mode_ == kSbPlayerOutputModeDecodeToTexture) {
-    // If the player is setup to decode to texture, then provide Cobalt with
-    // a method of querying that texture.
-    decode_target_provider_->SetGetCurrentSbDecodeTargetFunction(base::Bind(
-        &SbPlayerBridge::GetCurrentSbDecodeTarget, base::Unretained(this)));
     LOG(INFO) << "Playing in decode-to-texture mode.";
   } else {
     LOG(INFO) << "Playing in punch-out mode.";
   }
-
-  decode_target_provider_->SetOutputMode(
-      ToVideoFrameProviderOutputMode(output_mode_));
 
   UpdateBounds();
 }
@@ -800,11 +744,11 @@ void SbPlayerBridge::CreatePlayer() {
       window_, &creation_param, &SbPlayerBridge::DeallocateSampleCB,
       &SbPlayerBridge::DecoderStatusCB, &SbPlayerBridge::PlayerStatusCB,
       &SbPlayerBridge::PlayerErrorCB, this,
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-      get_decode_target_graphics_context_provider_func_.Run());
-#else   // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-      nullptr);
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
+      // TODO: b/429021006 - Add H5vcc flag to post egl calls on gpu thread to
+      // clear SurfaceView.
+      output_mode_ == kSbPlayerOutputModeDecodeToTexture
+          ? get_decode_target_graphics_context_provider_func_.Run()
+          : nullptr);
 #if COBALT_MEDIA_ENABLE_CVAL
   cval_stats_->StopTimer(MediaTiming::SbPlayerCreate, pipeline_identifier_);
 #endif  // COBALT_MEDIA_ENABLE_CVAL
@@ -816,21 +760,10 @@ void SbPlayerBridge::CreatePlayer() {
   }
 
   if (output_mode_ == kSbPlayerOutputModeDecodeToTexture) {
-    // If the player is setup to decode to texture, then provide Cobalt with
-    // a method of querying that texture.
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-    decode_target_provider_->SetGetCurrentSbDecodeTargetFunction(base::Bind(
-        &SbPlayerBridge::GetCurrentSbDecodeTarget, base::Unretained(this)));
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
     LOG(INFO) << "Playing in decode-to-texture mode.";
   } else {
     LOG(INFO) << "Playing in punch-out mode.";
   }
-
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-  decode_target_provider_->SetOutputMode(
-      ToVideoFrameProviderOutputMode(output_mode_));
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
 
   UpdateBounds();
 }

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -32,10 +32,6 @@
 #include "cobalt/media/base/cval_stats.h"
 #endif  // COBALT_MEDIA_ENABLE_CVAL
 
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-#include "cobalt/media/base/decode_target_provider.h"
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-
 #if COBALT_MEDIA_ENABLE_SUSPEND_RESUME
 #include "cobalt/media/base/decoder_buffer_cache.h"
 #endif  // COBALT_MEDIA_ENABLE_SUSPEND_RESUME
@@ -93,7 +89,6 @@ class SbPlayerBridge {
                  SbPlayerOutputMode default_output_mode,
                  const OnEncryptedMediaInitDataEncounteredCB&
                      encrypted_media_init_data_encountered_cb,
-                 DecodeTargetProvider* const decode_target_provider,
                  std::string pipeline_identifier);
 #endif  // SB_HAS(PLAYER_WITH_URL)
   using ExperimentalFeatures = StarboardRendererConfig::ExperimentalFeatures;
@@ -111,9 +106,6 @@ class SbPlayerBridge {
                  Host* host,
                  bool allow_resume_after_suspend,
                  SbPlayerOutputMode default_output_mode,
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-                 DecodeTargetProvider* const decode_target_provider,
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
                  const std::string& max_video_capabilities,
                  int max_video_input_size,
                  const ExperimentalFeatures& experimental_features
@@ -329,10 +321,6 @@ class SbPlayerBridge {
 
   // Keep track of the output mode we are supposed to output to.
   SbPlayerOutputMode output_mode_;
-
-#if COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
-  DecodeTargetProvider* const decode_target_provider_;
-#endif  // COBALT_MEDIA_ENABLE_DECODE_TARGET_PROVIDER
 
   // Keep copies of the mime type strings instead of using the ones in the
   // DemuxerStreams to ensure that the strings are always valid.

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -618,9 +618,8 @@ void StarboardRenderer::CreatePlayerBridge() {
 
   player_bridge_.reset(new SbPlayerBridge(
       GetSbPlayerInterface(), task_runner_,
-      // TODO(b/375070492): Implement decode-to-texture support
-      SbPlayerBridge::GetDecodeTargetGraphicsContextProviderFunc(),
-      audio_config, audio_mime_type, video_config, video_mime_type,
+      get_decode_target_graphics_context_provider_func_, audio_config,
+      audio_mime_type, video_config, video_mime_type,
       // TODO(b/326497953): Support suspend/resume.
       // TODO(b/326508279): Support background mode.
       sb_window_, drm_system_, this,
@@ -1123,6 +1122,13 @@ void StarboardRenderer::OnBufferingStateChange(BufferingState buffering_state) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
   client_->OnBufferingStateChange(buffering_state,
                                   BUFFERING_CHANGE_REASON_UNKNOWN);
+}
+
+void StarboardRenderer::set_decode_target_graphics_context_provider(
+    const GetDecodeTargetGraphicsContextProviderFunc&
+        get_decode_target_graphics_context_provider_func) {
+  get_decode_target_graphics_context_provider_func_ =
+      get_decode_target_graphics_context_provider_func;
 }
 
 }  // namespace media

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -124,6 +124,12 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
 #if BUILDFLAG(IS_ANDROID)
   void OnOverlayInfoChanged(const OverlayInfo& overlay_info);
 #endif  // BUILDFLAG(IS_ANDROID)
+  // Call to get the SbDecodeTargetGraphicsContextProvider for SbPlayerCreate().
+  using GetDecodeTargetGraphicsContextProviderFunc =
+      base::RepeatingCallback<SbDecodeTargetGraphicsContextProvider*()>;
+  void set_decode_target_graphics_context_provider(
+      const GetDecodeTargetGraphicsContextProviderFunc&
+          get_decode_target_graphics_context_provider_func);
 
   SbPlayerInterface* GetSbPlayerInterface();
 
@@ -267,6 +273,10 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   SbWindow sb_window_ = kSbWindowInvalid;
 
   raw_ptr<SbPlayerInterface> test_sbplayer_interface_;
+
+  // Call to get the SbDecodeTargetGraphicsContextProvider for SbPlayerCreate().
+  GetDecodeTargetGraphicsContextProviderFunc
+      get_decode_target_graphics_context_provider_func_;
 
   // Message to signal a capability changed error.
   // "MEDIA_ERR_CAPABILITY_CHANGED" must be in the error message to be

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -131,6 +131,12 @@ class StarboardRendererTest : public testing::Test {
         /*request_overlay_info_cb=*/base::DoNothing()
 #endif  // BUILDFLAG(IS_ANDROID)
     );
+    StarboardRenderer::GetDecodeTargetGraphicsContextProviderFunc
+        get_decode_target_graphics_context_provider_func = base::BindRepeating(
+            &StarboardRendererTest::GetSbDecodeTargetGraphicsContextProvider,
+            base::Unretained(this));
+    renderer_->set_decode_target_graphics_context_provider(
+        get_decode_target_graphics_context_provider_func);
 
     EXPECT_CALL(media_resource_, GetAllStreams())
         .WillRepeatedly(Invoke(this, &StarboardRendererTest::GetAllStreams));
@@ -172,6 +178,11 @@ class StarboardRendererTest : public testing::Test {
     return player;
   }
 
+  SbDecodeTargetGraphicsContextProvider*
+  GetSbDecodeTargetGraphicsContextProvider() {
+    return &decode_target_graphics_context_provider_;
+  }
+
   base::test::TaskEnvironment task_environment_;
   base::MockOnceCallback<void(bool)> set_cdm_cb_;
   base::MockOnceCallback<void(PipelineStatus)> renderer_init_cb_;
@@ -184,6 +195,8 @@ class StarboardRendererTest : public testing::Test {
   SbPlayerStatusFunc player_status_cb_ = nullptr;
   SbPlayerErrorFunc player_error_cb_ = nullptr;
   void* context_ = nullptr;
+  SbDecodeTargetGraphicsContextProvider
+      decode_target_graphics_context_provider_;
   const std::unique_ptr<StarboardRenderer> renderer_ =
       std::make_unique<StarboardRenderer>(
           task_environment_.GetMainThreadTaskRunner(),


### PR DESCRIPTION
Integrates SbDecodeTargetGraphicsContextProvider to enable
Starboard's native player to execute GLES context operations
on the GPU thread. The StarboardRendererWrapper now provides
a mechanism to marshal these tasks via StarboardGpuFactory,
blocking the calling thread until completion.

This change is essential for proper video rendering in
decode-to-texture mode by ensuring that graphics context
operations required by SbPlayer are performed on the correct
GPU thread. The existing DecodeTargetProvider abstraction
is no longer needed and has been removed.

Issue: 505067564