### PR TITLE
tvos: Convert DrmSystemPlatform to pure abstract interface

### DIFF
--- a/starboard/tvos/shared/media/drm_system_platform.h
+++ b/starboard/tvos/shared/media/drm_system_platform.h
@@ -22,6 +22,7 @@
 
 namespace starboard {
 
+// DrmSystemPlatform is an abstract interface for tvOS DRM.
 class DrmSystemPlatform : public SbDrmSystemPrivate {
  public:
   static DrmSystemPlatform* Create(
@@ -31,43 +32,43 @@ class DrmSystemPlatform : public SbDrmSystemPrivate {
       SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback,
       SbDrmServerCertificateUpdatedFunc server_certificate_updated_callback,
       SbDrmSessionClosedFunc session_closed_callback);
-  ~DrmSystemPlatform() override;
+  ~DrmSystemPlatform() override = default;
 
   static bool IsKeySystemSupported(const char* key_system);
   static bool IsSupported(SbDrmSystem drm_system);
   static std::string GetName();
   static std::string GetKeySystemName();
 
-  // SbDrmSystemPrivate impl.
+  // SbDrmSystemPrivate overrides
   void GenerateSessionUpdateRequest(int ticket,
                                     const char* type,
                                     const void* initialization_data,
-                                    int initialization_data_size) override;
+                                    int initialization_data_size) override = 0;
   void UpdateSession(int ticket,
                      const void* key,
                      int key_size,
                      const void* session_id,
-                     int session_id_size) override;
-  void CloseSession(const void* session_id, int session_id_size) override;
-  DecryptStatus Decrypt(InputBuffer* buffer) override;
-  bool IsServerCertificateUpdatable() override;
+                     int session_id_size) override = 0;
+  void CloseSession(const void* session_id, int session_id_size) override = 0;
+  DecryptStatus Decrypt(InputBuffer* buffer) override = 0;
+  bool IsServerCertificateUpdatable() override = 0;
   void UpdateServerCertificate(int ticket,
                                const void* certificate,
-                               int certificate_size) override;
-  const void* GetMetrics(int* size) override;
+                               int certificate_size) override = 0;
+  const void* GetMetrics(int* size) override = 0;
 
-  AVContentKey* GetContentKey(const uint8_t* key_id, int key_id_size)
-      API_AVAILABLE(tvos(14.5));
-  void OnOutputObscuredChanged(bool is_obscured);
+  virtual AVContentKey* GetContentKey(const uint8_t* key_id, int key_id_size)
+      API_AVAILABLE(tvos(14.5)) = 0;
+  virtual void OnOutputObscuredChanged(bool is_obscured) = 0;
 
- private:
+ protected:
   DrmSystemPlatform(
       void* context,
       SbDrmSessionUpdateRequestFunc update_request_callback,
       SbDrmSessionUpdatedFunc session_updated_callback,
       SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback,
       SbDrmServerCertificateUpdatedFunc server_certificate_updated_callback,
-      SbDrmSessionClosedFunc session_closed_callback);
+      SbDrmSessionClosedFunc session_closed_callback) {}
 };
 
 }  // namespace starboard

--- a/starboard/tvos/shared/media/drm_system_platform.mm
+++ b/starboard/tvos/shared/media/drm_system_platform.mm
@@ -17,22 +17,6 @@
 namespace starboard {
 
 // static
-DrmSystemPlatform* DrmSystemPlatform::Create(
-    void* context,
-    SbDrmSessionUpdateRequestFunc update_request_callback,
-    SbDrmSessionUpdatedFunc session_updated_callback,
-    SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback,
-    SbDrmServerCertificateUpdatedFunc server_certificate_updated_callback,
-    SbDrmSessionClosedFunc session_closed_callback) {
-  return new DrmSystemPlatform(
-      context, update_request_callback, session_updated_callback,
-      key_statuses_changed_callback, server_certificate_updated_callback,
-      session_closed_callback);
-}
-
-DrmSystemPlatform::~DrmSystemPlatform() = default;
-
-// static
 bool DrmSystemPlatform::IsKeySystemSupported(const char* key_system) {
   return false;
 }
@@ -51,52 +35,5 @@ std::string DrmSystemPlatform::GetName() {
 std::string DrmSystemPlatform::GetKeySystemName() {
   return "";
 }
-
-void DrmSystemPlatform::GenerateSessionUpdateRequest(
-    int ticket,
-    const char* type,
-    const void* initialization_data,
-    int initialization_data_size) {}
-
-void DrmSystemPlatform::UpdateSession(int ticket,
-                                      const void* key,
-                                      int key_size,
-                                      const void* session_id,
-                                      int session_id_size) {}
-
-void DrmSystemPlatform::CloseSession(const void* session_id,
-                                     int session_id_size) {}
-
-SbDrmSystemPrivate::DecryptStatus DrmSystemPlatform::Decrypt(
-    InputBuffer* buffer) {
-  return kFailure;
-}
-
-bool DrmSystemPlatform::IsServerCertificateUpdatable() {
-  return false;
-}
-
-void DrmSystemPlatform::UpdateServerCertificate(int ticket,
-                                                const void* certificate,
-                                                int certificate_size) {}
-
-const void* DrmSystemPlatform::GetMetrics(int* size) {
-  return nullptr;
-}
-
-AVContentKey* DrmSystemPlatform::GetContentKey(const uint8_t* key_id,
-                                               int key_id_size) {
-  return nullptr;
-}
-
-void DrmSystemPlatform::OnOutputObscuredChanged(bool is_obscured) {}
-
-DrmSystemPlatform::DrmSystemPlatform(
-    void* context,
-    SbDrmSessionUpdateRequestFunc update_request_callback,
-    SbDrmSessionUpdatedFunc session_updated_callback,
-    SbDrmSessionKeyStatusesChangedFunc key_statuses_changed_callback,
-    SbDrmServerCertificateUpdatedFunc server_certificate_updated_callback,
-    SbDrmSessionClosedFunc session_closed_callback) {}
 
 }  // namespace starboard


### PR DESCRIPTION
Convert DrmSystemPlatform into a proper abstract interface so that
platform variant must now provide its own concrete DRM implementation.

Bug: 502766471