### PR TITLE
Bring sync chromium branches logic into autoroll.

### DIFF
--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -30,10 +30,10 @@ def get_out(cmd):
   return res.stdout
 
 
-def get_commits(origin, target, start):
-  cmd = ['git', 'rev-list', '--oneline', '--reverse', origin, f'^{target}']
+def get_commits(source, target, start):
+  cmd = ['git', 'rev-list', '--oneline', '--reverse', source, f'^{target}']
   if start:
-    cmd.append(f'{start}^..{origin}')
+    cmd.append(f'{start}^..{source}')
   return get_out(cmd).splitlines()
 
 
@@ -70,7 +70,18 @@ def cherry_pick(sha, num, title):
   ps = get_out(['git', 'show', '-s', '--format=%P', sha]).strip().split()
   if len(ps) > 1:
     cmd.append('--mainline=1')
-  subprocess.run(cmd + [sha], check=True, stdout=sys.stderr)
+  result = subprocess.run(cmd + [sha], check=True, stdout=sys.stderr)
+
+  if result.returncode != 0:
+    status_output = get_out(['git', 'status'])
+    files_to_remove = []
+    for line in status_output.splitlines():
+      if 'deleted by us:' in line:
+        filename = line.split('deleted by us:')[1].strip()
+        files_to_remove.append(filename)
+    if files_to_remove:
+      cmd = ['git', 'rm'] + files_to_remove
+      subprocess.run(cmd, check=True, stdout=sys.stderr)
 
   cmd = [
       'git', 'commit', '--no-verify', f'--author={author}', f'--date={date}',
@@ -81,28 +92,33 @@ def cherry_pick(sha, num, title):
 
 def main():
   p = argparse.ArgumentParser()
+  p.add_argument('--source-branch', required=True)
   p.add_argument('--target-branch', required=True)
   p.add_argument('--start-commit')
-  p.add_argument('--origin-branch', default='main')
   p.add_argument('--max-commits', type=int, default=1000)
+  p.add_argument(
+      '--all-commits',
+      action='store_true',
+      help='Process all commits, not just PRs')
   args = p.parse_args()
 
-  links = []
-  target_prs = get_pr_set(args.target_branch, args.origin_branch)
-  autoroll_prs = get_pr_set('HEAD', args.origin_branch)
+  # All cherry picked PRs on the target branch since the branch point.
+  target_prs = get_pr_set(args.target_branch, args.source_branch)
+  # All cherry picked PRs on the autoroll branch since the branch point.
+  autoroll_prs = get_pr_set('HEAD', args.source_branch)
+  commits_added = []
 
-  # Get the number of unmerged commits on the autoroll branch.
-  commits_added = len(autoroll_prs - target_prs)
-
-  for line in get_commits(args.origin_branch, args.target_branch,
+  for line in get_commits(args.source_branch, args.target_branch,
                           args.start_commit):
-    if commits_added >= args.max_commits:
+    if len(commits_added) >= args.max_commits:
       print(f"Reached commit limit ({args.max_commits}).", file=sys.stderr)
       break
 
     match = re.match(r'^(\w+) (.*) \(#(\d+)\)$', line)
     if match:
       sha, title, pr_num = match.groups()
+
+      # Skip if the PR is in the skip list.
       if any(
           skip_sha.startswith(sha)
           for skip_sha in _SKIP_LIST.get(args.target_branch, [])):
@@ -112,16 +128,15 @@ def main():
       if pr_num in target_prs:
         continue
 
-      # If the PR is not on the current (autoroll) branch, cherry-pick it.
+      # Cherry pick if the PR is not already in the autoroll branch.
       if pr_num not in autoroll_prs:
         cherry_pick(sha, pr_num, title)
         autoroll_prs.add(pr_num)
-        commits_added += 1
 
-      links.append(f'- #{pr_num}')
+      commits_added.append(f'- #{pr_num}')
 
-  if links:
-    print('\n'.join(links))
+  if commits_added:
+    print('\n'.join(commits_added))
 
 
 if __name__ == '__main__':

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -37,19 +37,24 @@ def get_commits(source, target, start):
   return get_out(cmd).splitlines()
 
 
-def get_pr_set(branch, exclude_branch):
-  prs = set()
+def get_change_id_set(branch, exclude_branch, identifier_type):
+  if identifier_type == 'pr':
+    pattern = r'PR #(\d+)'
+  else:
+    pattern = r'commit ([0-9a-f]+)'
+
+  change_ids = set()
   cmd = ['git', 'log', '--reverse', '--format=%s', branch, f'^{exclude_branch}']
   subjects = get_out(cmd).splitlines()
   for subject in subjects:
-    match = re.match(r'^(Revert\s+"?)?Cherry pick PR #(\d+):', subject)
+    match = re.match(fr'^(Revert\s+"?)?Cherry pick {pattern}:', subject)
     if match:
-      revert, pr_num = match.groups()
+      revert, change_id = match.groups()
       if revert:
-        prs.discard(pr_num)
+        change_ids.discard(change_id)
       else:
-        prs.add(pr_num)
-  return prs
+        change_ids.add(change_id)
+  return change_ids
 
 
 def cherry_pick(sha, num, title):
@@ -96,44 +101,69 @@ def main():
   p.add_argument('--target-branch', required=True)
   p.add_argument('--start-commit')
   p.add_argument('--max-commits', type=int, default=1000)
-  p.add_argument(
-      '--all-commits',
-      action='store_true',
-      help='Process all commits, not just PRs')
+  p.add_argument('--identifier-type', default='pr')
   args = p.parse_args()
 
-  # All cherry picked PRs on the target branch since the branch point.
-  target_prs = get_pr_set(args.target_branch, args.source_branch)
-  # All cherry picked PRs on the autoroll branch since the branch point.
-  autoroll_prs = get_pr_set('HEAD', args.source_branch)
+  # All cherry picked changes on the target branch since the branch point.
+  target_change_ids = get_change_id_set(args.target_branch, args.source_branch,
+                                        args.identifier_type)
+  # All cherry picked changes on the autoroll branch since the branch point.
+  autoroll_change_ids = get_change_id_set('HEAD', args.source_branch,
+                                          args.identifier_type)
   commits_added = []
 
+  # All commits on the source branch and not on the target branch (all commits
+  # since the branch point).
   for line in get_commits(args.source_branch, args.target_branch,
                           args.start_commit):
     if len(commits_added) >= args.max_commits:
       print(f"Reached commit limit ({args.max_commits}).", file=sys.stderr)
       break
 
-    match = re.match(r'^(\w+) (.*) \(#(\d+)\)$', line)
-    if match:
-      sha, title, pr_num = match.groups()
+    if args.identifier_type == 'pr':
+      match = re.match(r'^(\w+) (.*) \(#(\d+)\)$', line)
+      if match:
+        sha, title, pr_num = match.groups()
 
-      # Skip if the PR is in the skip list.
-      if any(
-          skip_sha.startswith(sha)
-          for skip_sha in _SKIP_LIST.get(args.target_branch, [])):
-        continue
+        # Skip if the PR is in the skip list.
+        if any(
+            skip_sha.startswith(sha)
+            for skip_sha in _SKIP_LIST.get(args.target_branch, [])):
+          continue
 
-      # Skip if the PR is already in the target branch.
-      if pr_num in target_prs:
-        continue
+        # Skip if the PR is already in the target branch.
+        if pr_num in target_change_ids:
+          continue
 
-      # Cherry pick if the PR is not already in the autoroll branch.
-      if pr_num not in autoroll_prs:
-        cherry_pick(sha, pr_num, title)
-        autoroll_prs.add(pr_num)
+        # Cherry pick if the PR is not already in the autoroll branch.
+        if pr_num not in autoroll_change_ids:
+          cherry_pick(sha, pr_num, title)
+          autoroll_change_ids.add(pr_num)
 
-      commits_added.append(f'- #{pr_num}')
+        commits_added.append(f'- #{pr_num}')
+    else:
+      match = re.match(r'^(\w+) (.*)$', line)
+      if match:
+        sha, title = match.groups()
+
+        # Skip if the commit is in the skip list.
+        if any(
+            skip_sha.startswith(sha)
+            for skip_sha in _SKIP_LIST.get(args.target_branch, [])):
+          continue
+
+        # Skip if the commit is already in the target branch.
+        if any(
+            commit_hash.startswith(sha) for commit_hash in target_change_ids):
+          continue
+
+        # Cherry pick if the commit is not already in the autoroll branch.
+        if not any(
+            commit_hash.startswith(sha) for commit_hash in autoroll_change_ids):
+          cherry_pick(sha, '', title)
+          autoroll_change_ids.add(sha)
+
+        commits_added.append(f'- {sha}')
 
   if commits_added:
     print('\n'.join(commits_added))

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -28,46 +28,50 @@ _SKIP_LIST = {
     ],
 }
 
-# Default commit to start rolling from if none is specified.
-# Pointing to the last release chore.
-_DEFAULT_START_COMMIT = '2079b05a9fee4de18abd188fa4a6aceb01a77d7e'
-
 
 def get_out(cmd):
   res = subprocess.run(cmd, capture_output=True, text=True, check=True)
   return res.stdout
 
 
-def get_commits(origin, target, start):
+def get_commits(source, target, start):
   """Returns a list of commit lines in chronological order.
 
-  Retrieves commits that are present on the origin branch but not on the target
+  Retrieves commits that are present on the source branch but not on the target
   branch, optionally starting from a specific commit.
   """
-  cmd = ['git', 'rev-list', '--oneline', '--reverse', origin, f'^{target}']
+  cmd = [
+      'git', 'rev-list', '--oneline', '--no-abbrev-commit', '--reverse', source,
+      f'^{target}'
+  ]
   if start:
-    cmd.append(f'{start}^..{origin}')
+    cmd.append(f'{start}^..{source}')
   return get_out(cmd).splitlines()
 
 
-def get_pr_set(branch, exclude_branch):
-  """Returns a set of PR numbers that have been merged into the branch.
+def get_change_id_set(branch, exclude_branch, identifier_type):
+  """Returns a set of change IDs that have been merged into the branch.
 
-  Excludes any PRs that exist on the exclude_branch. Automatically accounts for
-  reverted cherry-picks.
+  Excludes any changes that exist on the exclude_branch. Automatically accounts
+  for reverted cherry-picks.
   """
-  prs = set()
+  if identifier_type == 'pr':
+    pattern = r'Cherry pick PR #(\d+)'
+  else:
+    pattern = r'Cherry pick commit ([0-9a-fA-F]{4,40})'
+
+  change_ids = set()
   cmd = ['git', 'log', '--reverse', '--format=%s', branch, f'^{exclude_branch}']
   subjects = get_out(cmd).splitlines()
   for subject in subjects:
-    match = re.match(r"""^(Revert\s+['"]?)?Cherry pick PR #(\d+):""", subject)
+    match = re.match(fr'^(Revert\s+[\'"]?)?{pattern}:', subject)
     if match:
-      revert, pr_num = match.groups()
+      revert, change_id = match.groups()
       if revert:
-        prs.discard(pr_num)
+        change_ids.discard(change_id)
       else:
-        prs.add(pr_num)
-  return prs
+        change_ids.add(change_id)
+  return change_ids
 
 
 def get_unmerged_files():
@@ -147,10 +151,16 @@ def cherry_pick(sha, num, title):
   body = parts[2] if len(parts) > 2 else ''
 
   body_section = f'{body}\n\n' if body else ''
-  msg = (f'Cherry pick PR #{num}: {title}\n\n'
-         f'Refer to original PR: #{num}\n\n'
-         f'{body_section}'
-         f'(cherry picked from commit {sha})')
+  if num is not None:
+    msg = (f'Cherry pick PR #{num}: {title}\n\n'
+           f'Refer to original PR: #{num}\n\n'
+           f'{body_section}'
+           f'(cherry picked from commit {sha})')
+  else:
+    msg = (f'Cherry pick commit {sha}: {title}\n\n'
+           f'Refer to original commit: {sha}\n\n'
+           f'{body_section}'
+           f'(cherry picked from commit {sha})')
 
   cmd = ['git', 'cherry-pick', '--no-commit']
   ps = get_out(['git', 'show', '-s', '--format=%P', sha]).strip().split()
@@ -181,50 +191,59 @@ def cherry_pick(sha, num, title):
 
 def main():
   p = argparse.ArgumentParser()
+  p.add_argument('--source-branch', required=True)
   p.add_argument('--target-branch', required=True)
-  p.add_argument('--start-commit', default=_DEFAULT_START_COMMIT)
-  p.add_argument('--origin-branch', default='main')
+  p.add_argument('--start-commit')
   p.add_argument('--max-commits', type=int, default=1000)
+  p.add_argument('--identifier-type', required=True)
   args = p.parse_args()
 
-  links = []
-  target_prs = get_pr_set(args.target_branch, args.origin_branch)
-  autoroll_prs = get_pr_set('HEAD', args.origin_branch)
+  # All cherry picked changes in target branch since the branch point.
+  target_change_ids = get_change_id_set(args.target_branch, args.source_branch,
+                                        args.identifier_type)
+  # All cherry picked changes in autoroll branch since the branch point.
+  autoroll_change_ids = get_change_id_set('HEAD', args.source_branch,
+                                          args.identifier_type)
+  commits_added = []
 
-  # Get the number of unmerged commits on the autoroll branch.
-  commits_added = len(autoroll_prs - target_prs)
-
-  for line in get_commits(args.origin_branch, args.target_branch,
+  # All commits in source branch and not in target branch (all commits
+  # since the branch point).
+  for line in get_commits(args.source_branch, args.target_branch,
                           args.start_commit):
-    if commits_added >= args.max_commits:
+    if len(commits_added) >= args.max_commits:
       print(f"Reached commit limit ({args.max_commits}).", file=sys.stderr)
       break
 
-    # Match commits that follow standard PR merge commit format:
-    # "<sha> <title> (#<pr_num>)"
-    match = re.match(r'^(\w+) (.*) \(#(\d+)\)$', line)
+    match = re.match(r'^(\w+) (.*?)(?: \(#(\d+)\))?$', line)
+    sha, title, pr_num = match.groups()
     if match:
-      sha, title, pr_num = match.groups()
-      if any(
-          skip_sha.startswith(sha)
-          for skip_sha in _SKIP_LIST.get(args.target_branch, [])):
+      # Skip if in skip list.
+      if sha in _SKIP_LIST.get(args.target_branch, []):
         continue
 
-      # Skip if the PR is already in the target branch.
-      if pr_num in target_prs:
-        continue
-
-      # If the PR is not on the current (autoroll) branch, cherry-pick it.
-      if pr_num not in autoroll_prs:
-        if cherry_pick(sha, pr_num, title):
-          autoroll_prs.add(pr_num)
-          commits_added += 1
-          links.append(f'- #{pr_num}')
+      if args.identifier_type == 'pr':
+        change_id = pr_num
+        prefix = '#'
       else:
-        links.append(f'- #{pr_num}')
+        change_id = sha
+        prefix = ''
 
-  if links:
-    print('\n'.join(links))
+      # Skip if in target branch.
+      if change_id in target_change_ids:
+        continue
+
+      # Skip if in autoroll branch.
+      if change_id in autoroll_change_ids:
+        commits_added.append(f'- {prefix}{change_id}')
+        continue
+
+      # Cherry pick PR.
+      if cherry_pick(sha, pr_num, title):
+        autoroll_change_ids.add(change_id)
+        commits_added.append(f'- {prefix}{change_id}')
+
+  if commits_added:
+    print('\n'.join(commits_added))
 
 
 if __name__ == '__main__':

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -95,7 +95,7 @@ jobs:
               --target-branch "${TARGET_BRANCH}" \
               --start-commit "${{ inputs.m138_start_commit }}" \
               --max-commits "${MAX_COMMITS}" \
-              --all-commits)
+              --identifier-type commits)
           fi
 
           if [[ -n "${PR_LINKS}" ]]; then

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -5,7 +5,10 @@ on:
     - cron: '0 * * * *' # Hourly.
   workflow_dispatch:
     inputs:
-      start_commit:
+      main_start_commit:
+        description: 'The commit to start rolling from, should point to the last release chore'
+        type: string
+      m138_start_commit:
         description: 'The commit to start rolling from, should point to the last release chore'
         type: string
       max_commits:
@@ -22,11 +25,19 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [
+          {source: main, target: 27.lts},
+          {source: chromium/m138, target: main},
+        ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: ${{ matrix.branch.source }}
+          fetch-depth: 1000
           filter: blob:none
           sparse-checkout: |
             .github
@@ -41,15 +52,18 @@ jobs:
 
       - name: Prepare Cherry Pick Branch
         env:
-          TARGET_BRANCH: 27.lts
+          TARGET_BRANCH: ${{ matrix.branch.target }}
         run: |
           set -x
 
-          # Copy the script from the main branch before switching branches.
+          # Copy the script from the main branch.
+          if [ "${{ matrix.branch.source }}" != "main" ]; then
+            git fetch --depth=1 --no-recurse-submodules --filter=blob:none origin main:script
+            git checkout script
+          fi
           cp .github/scripts/autoroll_lts.py "${RUNNER_TEMP}"/
 
-          # Unshallow the repository to ensure all history for all branches is fetched.
-          # Fetch enough history for target branch to find merge base.
+          # Fetch enough history for the target branch to find merge base.
           git fetch --depth=1000 --no-recurse-submodules --filter=blob:none origin "${TARGET_BRANCH}:${TARGET_BRANCH}"
 
           # Use existing branch from remote if it exists, otherwise start from the target branch.
@@ -59,23 +73,30 @@ jobs:
             git checkout --no-recurse-submodules -B "autoroll-to-${TARGET_BRANCH}" "${TARGET_BRANCH}" --no-track
           fi
 
-          # Ensure latest main with enough history.
-          git fetch --depth=1000 --no-recurse-submodules --filter=blob:none origin main:main
-
       - name: Cherry Pick Merged PRs
         id: autoroll
         env:
-          TARGET_BRANCH: 27.lts
-          START_COMMIT: ${{ inputs.start_commit }}
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
           MAX_COMMITS: ${{ inputs.max_commits || 10 }}
         run: |
           set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
-          PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
-            --target-branch "${TARGET_BRANCH}" \
-            --start-commit "${START_COMMIT}" \
-            --max-commits "${MAX_COMMITS}")
+          if [ "${{ matrix.branch.source }}" == "main" ]; then
+            PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
+              --source-branch "${SOURCE_BRANCH}" \
+              --target-branch "${TARGET_BRANCH}" \
+              --start-commit "${{ inputs.main_start_commit }}" \
+              --max-commits "${MAX_COMMITS}")
+          else
+            PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
+              --source-branch "${SOURCE_BRANCH}" \
+              --target-branch "${TARGET_BRANCH}" \
+              --start-commit "${{ inputs.m138_start_commit }}" \
+              --max-commits "${MAX_COMMITS}" \
+              --all-commits)
+          fi
 
           if [[ -n "${PR_LINKS}" ]]; then
             echo "cherry_picked=true" >> "$GITHUB_OUTPUT"
@@ -91,7 +112,8 @@ jobs:
       - name: Push and Create PR
         if: steps.autoroll.outputs.pr_links != ''
         env:
-          TARGET_BRANCH: 27.lts
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
           GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
           PR_LINKS: ${{ steps.autoroll.outputs.pr_links }}
         run: |
@@ -107,7 +129,7 @@ jobs:
             echo "${PR_LINKS}"
           } > "${PR_BODY_FILE}"
 
-          PR_TITLE="Autoroll from main to ${TARGET_BRANCH}"
+          PR_TITLE="Autoroll from ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
 
           PR_STATE=$(gh pr view "autoroll-to-${TARGET_BRANCH}" --json state --template '{{.state}}' 2>/dev/null || echo "NOT_FOUND")
 
@@ -115,5 +137,5 @@ jobs:
             PR_NUMBER=$(gh pr view "autoroll-to-${TARGET_BRANCH}" --json number --jq .number)
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f title="${PR_TITLE}" -f body="$(cat "${PR_BODY_FILE}")" --jq .html_url
           else
-            gh pr create --base "${TARGET_BRANCH}" --head "autoroll-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}" --reviewer linxinan-chops,oxve
+            gh pr create --base "${TARGET_BRANCH}" --head "autoroll-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}" --reviewer linxinan-chops,oxve,briantting
           fi

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -5,10 +5,6 @@ on:
     - cron: '0 * * * *' # Hourly.
   workflow_dispatch:
     inputs:
-      start_commit:
-        description: 'The commit to start rolling from, should point to the last release chore'
-        type: string
-        default: '217cc0c75ae4620743cd57d436f5f3a7e10cd289'
       max_commits:
         description: 'Max number of commits to include on a single PR'
         type: number
@@ -23,11 +19,19 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [
+          {source: main, target: 27.lts, start_commit: 2079b05a9fee4de18abd188fa4a6aceb01a77d7e, identifier_type: pr},
+          {source: main, target: staging, start_commit: 4087dbd1a873f1f4bb7ca59a64c8fc0fc1a1dbc7, identifier_type: pr},
+        ]
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          ref: ${{ matrix.branch.source }}
+          fetch-depth: 1000
           filter: blob:none
           sparse-checkout: |
             .github
@@ -42,48 +46,41 @@ jobs:
 
       - name: Prepare Cherry Pick Branch
         env:
-          TARGET_BRANCH: 27.lts
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
           FETCH_DEPTH: 1000
         run: |
           set -x
 
-          # Copy the script from the main branch before switching branches.
-          cp .github/scripts/autoroll_lts.py "${RUNNER_TEMP}"/
+          # Copy script from main branch.
+          git show main:.github/scripts/autoroll_lts.py > "${RUNNER_TEMP}/autoroll_lts.py"
 
           # The autoroller will only ever operate on the lower limit (1k commits).
           # Fetch enough history for target branch to find merge base.
           git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules --filter=blob:none origin "${TARGET_BRANCH}:${TARGET_BRANCH}"
 
-          # Use existing branch from remote if it exists, otherwise start from the target branch.
-          if git fetch --no-recurse-submodules --filter=blob:none origin "autoroll-to-${TARGET_BRANCH}"; then
-            git checkout --no-recurse-submodules -B "autoroll-to-${TARGET_BRANCH}" FETCH_HEAD
+          # Use existing branch from remote if it exists, otherwise start from target branch.
+          if git fetch --no-recurse-submodules --filter=blob:none origin "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"; then
+            git checkout --no-recurse-submodules -B "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" FETCH_HEAD
           else
-            git checkout --no-recurse-submodules -B "autoroll-to-${TARGET_BRANCH}" "${TARGET_BRANCH}" --no-track
+            git checkout --no-recurse-submodules -B "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" "${TARGET_BRANCH}" --no-track
           fi
 
-          # Ensure latest main with enough history.
-          git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules --filter=blob:none origin main:main
-
-
+          # Fetch enough history for source branch.
+          git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules --filter=blob:none origin "${SOURCE_BRANCH}:${SOURCE_BRANCH}"
 
       - name: Cherry Pick Merged PRs
         id: autoroll
-        env:
-          TARGET_BRANCH: 27.lts
-          START_COMMIT: ${{ inputs.start_commit }}
-          MAX_COMMITS: ${{ inputs.max_commits || 10 }}
         run: |
           set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
-          args=(
-            --target-branch "${TARGET_BRANCH}"
-            --max-commits "${MAX_COMMITS}"
-          )
-          if [[ -n "${START_COMMIT}" ]]; then
-            args+=(--start-commit "${START_COMMIT}")
-          fi
-          PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" "${args[@]}")
+          PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
+            --source-branch "${{ matrix.branch.source }}" \
+            --target-branch "${{ matrix.branch.target }}" \
+            --start-commit "${{ matrix.branch.start_commit }}" \
+            --max-commits "${{ inputs.max_commits }}" \
+            --identifier-type "${{ matrix.branch.identifier_type }}")
 
           if [[ -n "${PR_LINKS}" ]]; then
             echo "cherry_picked=true" >> "$GITHUB_OUTPUT"
@@ -99,13 +96,14 @@ jobs:
       - name: Push and Create PR
         if: steps.autoroll.outputs.pr_links != ''
         env:
-          TARGET_BRANCH: 27.lts
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
           GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
           PR_LINKS: ${{ steps.autoroll.outputs.pr_links }}
         run: |
           set -x
 
-          git push origin "autoroll-to-${TARGET_BRANCH}"
+          git push origin "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"
 
           PR_BODY_FILE=$(mktemp)
           {
@@ -115,13 +113,13 @@ jobs:
             echo "${PR_LINKS}"
           } > "${PR_BODY_FILE}"
 
-          PR_TITLE="Autoroll from main to ${TARGET_BRANCH}"
+          PR_TITLE="Autoroll from ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
 
-          PR_STATE=$(gh pr view "autoroll-to-${TARGET_BRANCH}" --json state --template '{{.state}}' 2>/dev/null || echo "NOT_FOUND")
+          PR_STATE=$(gh pr view "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --json state --template '{{.state}}' 2>/dev/null || echo "NOT_FOUND")
 
           if [[ "$PR_STATE" == "OPEN" ]]; then
-            PR_NUMBER=$(gh pr view "autoroll-to-${TARGET_BRANCH}" --json number --jq .number)
+            PR_NUMBER=$(gh pr view "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --json number --jq .number)
             gh api -X PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f title="${PR_TITLE}" -f body="$(cat "${PR_BODY_FILE}")" --jq .html_url
           else
-            gh pr create --base "${TARGET_BRANCH}" --head "autoroll-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}" --reviewer linxinan-chops,oxve
+            gh pr create --base "${TARGET_BRANCH}" --head "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}" --reviewer linxinan-chops,oxve,briantting
           fi

--- a/.github/workflows/sync_chromium_branches.yaml
+++ b/.github/workflows/sync_chromium_branches.yaml
@@ -47,13 +47,11 @@ jobs:
           git remote add upstream https://chromium.googlesource.com/chromium/src
           git fetch --depth=1 upstream "refs/branch-heads/${{ matrix.branch.branch_num }}:refs/remotes/branch/${{ matrix.branch.branch_num }}"
       - name: Create missing Chromium branch
-        id: create_missing_branch
         if: steps.checkout.outcome == 'failure'
         run: |
           git checkout "refs/remotes/branch/${{ matrix.branch.branch_num }}"
           ORIGINAL_TREE_HASH=$(git rev-parse "HEAD^{tree}")
           ORIGINAL_COMMIT_HASH=$(git rev-parse HEAD)
-          echo "original_commit_hash=${ORIGINAL_COMMIT_HASH}" >> "$GITHUB_OUTPUT"
           NEW_ROOT_COMMIT_HASH=$(git commit-tree "${ORIGINAL_TREE_HASH}" -m "First commit for ${{ matrix.branch.milestone }}.")
           git checkout -b "chromium/${{ matrix.branch.milestone }}" "${NEW_ROOT_COMMIT_HASH}"
           git commit --amend --no-edit -c "${ORIGINAL_COMMIT_HASH}"
@@ -77,38 +75,3 @@ jobs:
             echo "No diff to apply."
             echo "main_cherry_pick=false" >> "$GITHUB_OUTPUT"
           fi
-      - uses: actions/checkout@v4
-        id: checkout_cherry_pick_main_sync
-        if: steps.push_diff.outputs.main_cherry_pick == 'true' && contains(matrix.branch.milestone, 'm138')
-        with:
-          ref: cherry-pick-main-sync
-          fetch-depth: 16
-          filter: blob:none
-          token: ${{ secrets.CHERRY_PICK_TOKEN }}
-      - name: Setup Git user
-        if: steps.checkout_cherry_pick_main_sync.outcome == 'success'
-        run: |
-          git config --global user.name "GitHub Release Automation"
-          git config --global user.email "github@google.com"
-      - name: Cherry Pick upstream diff to main
-        if: steps.checkout_cherry_pick_main_sync.outcome == 'success'
-        run: |
-          git pull --rebase origin main
-          if ! git cherry-pick "${{ steps.push_diff.outputs.main_cherry_pick_hash }}"; then
-            git status | sed -n "s/^[[:space:]]*deleted by us:[[:space:]]*//p" | xargs -d "\n" git rm
-            git add .
-            git cherry-pick --continue --no-edit
-          fi
-          echo "LASTCHANGE=${{ steps.create_missing_branch.outputs.original_commit_hash }}" > cobalt/LASTCHANGE.chromium
-          echo "LASTCHANGE_YEAR=$(date +'%Y')" >> cobalt/LASTCHANGE.chromium
-          git add cobalt/LASTCHANGE.chromium
-          git commit -m "Update LASTCHANGE.chromium for ${{ matrix.branch.milestone }}."
-
-          git push origin cherry-pick-main-sync --force
-          if [ -z "$(gh pr list -H cherry-pick-main-sync)" ]; then
-            gh pr create -B main -H cherry-pick-main-sync --fill -r "briantting"
-          else
-            echo "Pull Request already exists."
-          fi
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Generalize the autoroll workflow to support various source and target branches. Specifically this allows the cherry pick logic that brought m138 refresh commits from chromium/m138 to main to be implemented.

Bug: 505073626