### PR TITLE
build: Disable memory tagging for all Cobalt builds

### DIFF
--- a/base/allocator/partition_allocator/partition_alloc.gni
+++ b/base/allocator/partition_allocator/partition_alloc.gni
@@ -99,7 +99,7 @@ if (is_nacl) {
 use_large_empty_slot_span_ring = true
 
 has_memory_tagging = current_cpu == "arm64" && is_clang && !is_asan &&
-                     !is_hwasan && (is_linux || is_android) && !is_cobalt_hermetic_build
+                     !is_hwasan && (is_linux || is_android) && !is_cobalt
 
 declare_args() {
   # Debug configuration.


### PR DESCRIPTION
Memory tagging, primarily an ARM MTE feature, is not currently supported
or utilized by Cobalt. Update the build configuration to unconditionally
disable this feature for all Cobalt builds, simplifying the codebase and
avoiding potential overhead or issues from unsupported features.

Bug: 505083702