### PR TITLE
tvos: Implement deep link URL handling

### DIFF
--- a/cobalt/app/tvos/main.mm
+++ b/cobalt/app/tvos/main.mm
@@ -26,12 +26,14 @@
 #include "base/task/thread_pool.h"
 #include "cobalt/app/cobalt_main_delegate.h"
 #include "cobalt/app/cobalt_switch_defaults.h"
+#include "cobalt/browser/h5vcc_runtime/deep_link_manager.h"
 #include "cobalt/shell/browser/shell.h"
 #include "components/crash/core/app/crashpad.h"
 #include "content/public/app/content_main.h"
 #include "content/public/app/content_main_runner.h"
 #include "content/public/browser/render_view_host.h"
 #include "content/public/browser/render_widget_host.h"
+#include "net/base/apple/url_conversions.h"
 #include "starboard/common/command_line.h"
 #include "starboard/tvos/shared/application_darwin.h"
 
@@ -48,6 +50,27 @@ static const char** g_argv = nullptr;
   return content::Shell::windows()[0]->web_contents();
 }
 
+- (void)handleDeepLink:(NSSet<UIOpenURLContext*>*)URLContexts {
+  // URLContexts can contain multiple items, but since DeepLinkManager
+  // handles one link at a time, only a single context is used.
+  UIOpenURLContext* context = URLContexts.anyObject;
+  if (!context) {
+    return;
+  }
+  NSURL* url = context.URL;
+  if (!url) {
+    return;
+  }
+
+  GURL parsedURL = net::GURLWithNSURL(url);
+
+  if (!parsedURL.is_valid() || parsedURL.scheme().length() == 0) {
+    return;
+  }
+
+  cobalt::browser::DeepLinkManager::GetInstance()->OnDeepLink(parsedURL.spec());
+}
+
 - (void)scene:(UIScene*)scene
     willConnectToSession:(UISceneSession*)session
                  options:(UISceneConnectionOptions*)connectionOptions {
@@ -62,6 +85,17 @@ static const char** g_argv = nullptr;
   window.windowScene = (UIWindowScene*)scene;
   window.rootViewController = controller;
   [window makeKeyAndVisible];
+
+  // Handle deep link when the app is launched (cold start). The URL is
+  // delivered via connectionOptions.
+  [self handleDeepLink:connectionOptions.URLContexts];
+}
+
+- (void)scene:(UIScene*)scene
+    openURLContexts:(NSSet<UIOpenURLContext*>*)URLContexts {
+  // Handle deep link when the app is already running. (Cold start links are
+  // handled in willConnectToSession.)
+  [self handleDeepLink:URLContexts];
 }
 
 - (void)sceneWillEnterForeground:(UIScene*)scene {

--- a/cobalt/shell/app/tvos-Info.plist
+++ b/cobalt/shell/app/tvos-Info.plist
@@ -33,5 +33,17 @@
   <string>This identifier will be used to deliver personalized ads to you.</string>
   <key>YTApplicationURL</key>
   <string>https://www.youtube.com/tv</string>
+  <key>CFBundleURLTypes</key>
+  <array>
+    <dict>
+      <key>CFBundleURLName</key>
+      <string>${BUNDLE_IDENTIFIER}</string>
+      <key>CFBundleURLSchemes</key>
+      <array>
+        <string>YouTube</string>
+        <string>YouTubeTV</string>
+      </array>
+    </dict>
+  </array>
 </dict>
 </plist>


### PR DESCRIPTION
Configure the tvOS application to register a 'YouTube' URL scheme.
Incoming deep link URLs from scene:openURLContexts (for running apps)
and scene:willConnectToSession (for cold starts) are now routed to the
DeepLinkManager. This enables launching the application and navigating
to specific content using deep links, for example, from the command
line.

Bug: 452302320