### PR TITLE
build: Add copied_base to libxml visibility filter

### DIFF
--- a/third_party/libxml/BUILD.gn
+++ b/third_party/libxml/BUILD.gn
@@ -82,9 +82,9 @@ static_library("xml_reader") {
   visibility = [
     "//base/test:test_support",
     "//components/policy/core/common:unit_tests",
-    "//copied_base/base/test:test_support",
     # For parsing trusted data from Google origins with public key pinning only.
     "//components/trusted_vault",
+    "//copied_base/base/test:test_support",
     "//services/data_decoder:*",
   ]
   if (is_win) {

--- a/third_party/libxml/BUILD.gn
+++ b/third_party/libxml/BUILD.gn
@@ -82,6 +82,7 @@ static_library("xml_reader") {
   visibility = [
     "//base/test:test_support",
     "//components/policy/core/common:unit_tests",
+    "//copied_base/base/test:test_support",
     # For parsing trusted data from Google origins with public key pinning only.
     "//components/trusted_vault",
     "//services/data_decoder:*",
@@ -123,6 +124,7 @@ static_library("libxml_utils") {
     ":xml_reader",
     ":xml_writer",
     "//base/test:test_support",
+    "//copied_base/base/test:test_support",
     "//services/data_decoder:lib",
     "//services/data_decoder:xml_parser_fuzzer_deps",
   ]


### PR DESCRIPTION
On Android, the `starboard_platform_tests` target depends on
`//base/test:test_support`, which on AOSP is redirected to the
copied_base version. Because of this,
`//copied_base/base/test:test_support` needs to be added to the
visibility of some libxml targets, in the same way the `//base` targets
were added there.

Bug: 495203133