### PR TITLE
rdk: Update kokoro targets

### DIFF
--- a/cobalt/devinfra/kokoro/build/evergreen/arm-hardfp-rdk/common.gcl
+++ b/cobalt/devinfra/kokoro/build/evergreen/arm-hardfp-rdk/common.gcl
@@ -17,7 +17,7 @@ build = common.build {
     },
     {
       key = 'GN_TARGET'
-      value = 'cobalt:gn_all'
+      value = 'cobalt:gn_all loader_app loader_app_rdk_plugin'
     },
     {
       key = 'TARGET_CPU'


### PR DESCRIPTION
Add the 'loader_app' and 'loader_app_rdk_plugin' targets to the internal builds
to match the GitHib configuration.

Bug: 499089012