### PR TITLE
Cherry pick PR #9990: Build RDK plugin related binaries

### DIFF
--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -18,7 +18,8 @@
     "loader_app",
     "crash_sandbox_loaded_content",
     "noop_sandbox_loaded_content",
-    "one_app_only_sandbox_loaded_content"
+    "one_app_only_sandbox_loaded_content",
+    "loader_app_rdk_plugin"
   ],
   "includes": [
     {

--- a/cobalt/build/evergreen-arm-hardfp-rdk/package.json
+++ b/cobalt/build/evergreen-arm-hardfp-rdk/package.json
@@ -19,6 +19,7 @@
                 "app/noop_sandbox/lib/libnoop_sandbox.lz4",
                 "app/one_app_only_sandbox/lib/libone_app_only_sandbox.lz4",
                 "loader_app",
+                "libloader_app.so",
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -387,3 +387,15 @@ copy("rdk_cobalt_keymap") {
   sources = [ "cobalt/content/etc/keymapping.json" ]
   outputs = [ "$root_out_dir/app/cobalt/content/etc/keymapping.json" ]
 }
+
+group("loader_app_rdk_plugin") {
+  data_deps = [ ":loader_app($starboard_toolchain)" ]
+}
+
+if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+  target("shared_library", "loader_app") {
+    output_dir = root_build_dir
+    deps = [ "//starboard/loader_app:loader_app_sources" ]
+    data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+  }
+}

--- a/starboard/loader_app/BUILD.gn
+++ b/starboard/loader_app/BUILD.gn
@@ -96,16 +96,20 @@ static_library("record_loader_app_status") {
 }
 
 if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+  source_set("loader_app_sources") {
+    sources = _common_loader_app_sources
+    deps = [
+      ":common_loader_app_dependencies",
+      "//starboard:starboard_with_main",
+      "//starboard/content/fonts:copy_font_data",
+      "//starboard/elf_loader",
+    ]
+  }
+
   target(starboard_level_final_executable_type, "loader_app") {
     output_dir = root_build_dir
     if (target_cpu == "x64" || target_cpu == "arm" || target_cpu == "arm64") {
-      sources = _common_loader_app_sources
-      deps = [
-        ":common_loader_app_dependencies",
-        "//starboard:starboard_with_main",
-        "//starboard/content/fonts:copy_font_data",
-        "//starboard/elf_loader",
-      ]
+      deps = [ ":loader_app_sources" ]
       data_deps = [ "//starboard/content/fonts:copy_font_data" ]
       if (sb_is_evergreen_compatible && sb_evergreen_compatible_package) {
         data_deps += [
@@ -370,7 +374,7 @@ if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
     ]
     deps = [
       "//starboard:starboard_group",
-      "//starboard/common:common",
+      "//starboard/common",
     ]
   }
 


### PR DESCRIPTION
Refer to the original PR: https://github.com/youtube/cobalt/pull/9990

Build RDK plugin related binaries (libloader_app.so).

Refactor loader_app target to reuse sources from starboard/loader_app/BUILD.gn via a new loader_app_sources source_set.
Adds libloader_app.so to package and GitHub config.

Bug: 491573728