### PR TITLE
Cherry pick PR #10187: Disable memory tagging for all Cobalt builds (#10187)

### DIFF
--- a/base/allocator/partition_allocator/partition_alloc.gni
+++ b/base/allocator/partition_allocator/partition_alloc.gni
@@ -99,7 +99,7 @@ if (is_nacl) {
 use_large_empty_slot_span_ring = true
 
 has_memory_tagging = current_cpu == "arm64" && is_clang && !is_asan &&
-                     !is_hwasan && (is_linux || is_android) && !is_cobalt_hermetic_build
+                     !is_hwasan && (is_linux || is_android) && !is_cobalt
 
 declare_args() {
   # Debug configuration.


### PR DESCRIPTION
Cherry pick PR #10187 Disable memory tagging for all Cobalt builds

Refer to original PR: https://github.com/youtube/cobalt/pull/10187

Update partition_alloc.gni to unconditionally disable
memory tagging for all Cobalt builds. Previously, memory
tagging was only disabled for hermetic Cobalt builds,
allowing it to be enabled for non-hermetic ones. This
change ensures that memory tagging is never enabled
for any Cobalt compilation target.

Bug: 505083702
(cherry picked from commit 43803465ffc3f860edc0d1948028d354a4a457a6)