### PR TITLE
 starboard: Wire Starboard-aware entrypoints for test loaders

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -521,9 +521,9 @@ jobs:
       matrix:
         platform: ${{ fromJson(needs.initialize.outputs.platforms) }}
         include: ${{ fromJson(needs.initialize.outputs.includes) }}
-        config: [devel]
+        config: [devel, qa, gold]
     env:
-      TEST_RESULTS_KEY: ${{ matrix.platform }}_${{ matrix.name }}_test_results
+      TEST_RESULTS_KEY: ${{ matrix.platform }}_${{ matrix.name }}_${{ matrix.config }}_test_results
     steps:
       - name: Restore CI Essentials
         uses: actions/checkout@v4
@@ -541,7 +541,7 @@ jobs:
           nightly: ${{ inputs.nightly }}
           test_targets_json: ${{ steps.test-target-json.outputs.test_targets_json }}
           test_results_key: ${{ env.TEST_RESULTS_KEY }}
-          gcs_results_path: gs://cobalt-unittest-storage/results/${{ matrix.name }}/${{ github.run_id }}/${{ github.run_attempt }}
+          gcs_results_path: gs://cobalt-unittest-storage/results/${{ matrix.name }}/${{ matrix.config }}/${{ github.run_id }}/${{ github.run_attempt }}
           test_dimensions: '${{ needs.initialize.outputs.test_dimensions }}'
           test_device_family: '${{ needs.initialize.outputs.test_device_family}}'
           test_attempts: '${{ needs.initialize.outputs.test_attempts }}'

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -18,7 +18,6 @@
     "examples:views_examples_unittests_loader",
     "gl:gl_unittests_loader",
     "gl:ozone_gl_unittests_loader",
-    "third_party/blink/common:blink_common_unittests_loader",
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
     "third_party/boringssl:boringssl_pki_tests_loader",
     "third_party/ipcz/src:ipcz_tests_loader",
@@ -36,7 +35,8 @@
     "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
     "ui/events:events_unittests_loader",
     "ui/ozone:ozone_unittests_loader",
-    "storage:storage_unittests_loader"
+    "storage:storage_unittests_loader",
+    "third_party/blink/common:blink_common_unittests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -47,9 +47,11 @@
     "out/evergreen-arm-hardfp-rdk_devel/wtf_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/events_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/ozone_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py"
   ],
   "disabled": {
-    "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run"
+    "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
+    "third_party/blink/common:blink_common_unittests_loader": "b/486053350 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -19,7 +19,6 @@
     "gl:gl_unittests_loader",
     "gl:ozone_gl_unittests_loader",
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
-    "third_party/boringssl:boringssl_pki_tests_loader",
     "third_party/ipcz/src:ipcz_tests_loader",
     "third_party/opus:opus_tests_loader",
     "third_party/opus:test_opus_decode_loader",
@@ -36,7 +35,8 @@
     "ui/events:events_unittests_loader",
     "ui/ozone:ozone_unittests_loader",
     "storage:storage_unittests_loader",
-    "third_party/blink/common:blink_common_unittests_loader"
+    "third_party/blink/common:blink_common_unittests_loader",
+    "third_party/boringssl:boringssl_pki_tests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -48,10 +48,12 @@
     "out/evergreen-arm-hardfp-rdk_devel/events_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/ozone_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/boringssl_pki_tests_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
-    "third_party/blink/common:blink_common_unittests_loader": "b/486053350 - Failing in first full CI run"
+    "third_party/blink/common:blink_common_unittests_loader": "b/486053350 - Failing in first full CI run",
+    "third_party/boringssl:boringssl_pki_tests_loader": "b/486053350 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -2,7 +2,6 @@
   "TODO(b/382508397)": "Remove this when list is dynamically generated.",
   "TODO(todo): EGL init issue, needs new image": [],
   "TODO(b/486053854): Tests pass but crashes on exit": [
-    "gpu:gl_tests_loader",
     "gpu:gpu_unittests_loader",
     "ipc:ipc_tests_loader",
     "sql:sql_unittests_loader",
@@ -35,7 +34,8 @@
     "third_party/opus:test_opus_encode_loader",
     "third_party/opus:test_opus_decode_loader",
     "third_party/opus:test_opus_padding_loader",
-    "cc:cc_unittests_loader"
+    "cc:cc_unittests_loader",
+    "gpu:gl_tests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -55,7 +55,8 @@
     "out/evergreen-arm-hardfp-rdk_devel/test_opus_encode_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/test_opus_decode_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/test_opus_padding_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/cc_unittests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/cc_unittests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/gl_tests_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
@@ -67,6 +68,7 @@
     "third_party/opus:test_opus_encode_loader": "b/486053350 - Failing in first full CI run",
     "third_party/opus:test_opus_decode_loader": "b/486053350 - Failing in first full CI run",
     "third_party/opus:test_opus_padding_loader": "b/486053350 - Failing in first full CI run",
-    "cc:cc_unittests_loader": "b/486053854 - Failing in first full CI run"
+    "cc:cc_unittests_loader": "b/486053854 - Failing in first full CI run",
+    "gpu:gl_tests_loader": "b/486053854 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -14,7 +14,6 @@
     "third_party/zlib:zlib_unittests_loader"
   ],
   "TODO(b/486053350): Crashes on missing SbEventHandle": [
-    "examples:views_examples_unittests_loader",
     "gl:gl_unittests_loader",
     "gl:ozone_gl_unittests_loader",
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
@@ -36,7 +35,8 @@
     "storage:storage_unittests_loader",
     "third_party/blink/common:blink_common_unittests_loader",
     "third_party/boringssl:boringssl_pki_tests_loader",
-    "ui/compositor:compositor_unittests_loader"
+    "ui/compositor:compositor_unittests_loader",
+    "ui/views/examples:views_examples_unittests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -50,12 +50,14 @@
     "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/boringssl_pki_tests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/compositor_unittests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/compositor_unittests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/blink/common:blink_common_unittests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/boringssl:boringssl_pki_tests_loader": "b/486053350 - Failing in first full CI run",
-    "ui/compositor:compositor_unittests_loader": "b/486053350 - Failing in first full CI run"
+    "ui/compositor:compositor_unittests_loader": "b/486053350 - Failing in first full CI run",
+    "ui/views/examples:views_examples_unittests_loader": "b/486053350 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -18,7 +18,6 @@
     "gl:ozone_gl_unittests_loader",
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
     "third_party/ipcz/src:ipcz_tests_loader",
-    "third_party/opus:test_opus_decode_loader",
     "third_party/opus:test_opus_padding_loader"
   ],
   "test_targets": [
@@ -36,7 +35,8 @@
     "ui/compositor:compositor_unittests_loader",
     "ui/views/examples:views_examples_unittests_loader",
     "third_party/opus:opus_tests_loader",
-    "third_party/opus:test_opus_encode_loader"
+    "third_party/opus:test_opus_encode_loader",
+    "third_party/opus:test_opus_decode_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -53,7 +53,8 @@
     "out/evergreen-arm-hardfp-rdk_devel/compositor_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/opus_tests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/test_opus_encode_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/test_opus_encode_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/test_opus_decode_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
@@ -62,6 +63,7 @@
     "ui/compositor:compositor_unittests_loader": "b/486053350 - Failing in first full CI run",
     "ui/views/examples:views_examples_unittests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/opus:opus_tests_loader": "b/486053350 - Failing in first full CI run",
-    "third_party/opus:test_opus_encode_loader": "b/486053350 - Failing in first full CI run"
+    "third_party/opus:test_opus_encode_loader": "b/486053350 - Failing in first full CI run",
+    "third_party/opus:test_opus_decode_loader": "b/486053350 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -18,7 +18,6 @@
     "gl:ozone_gl_unittests_loader",
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
     "third_party/ipcz/src:ipcz_tests_loader",
-    "third_party/opus:opus_tests_loader",
     "third_party/opus:test_opus_decode_loader",
     "third_party/opus:test_opus_encode_loader",
     "third_party/opus:test_opus_padding_loader"
@@ -36,7 +35,8 @@
     "third_party/blink/common:blink_common_unittests_loader",
     "third_party/boringssl:boringssl_pki_tests_loader",
     "ui/compositor:compositor_unittests_loader",
-    "ui/views/examples:views_examples_unittests_loader"
+    "ui/views/examples:views_examples_unittests_loader",
+    "third_party/opus:opus_tests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -51,13 +51,15 @@
     "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/boringssl_pki_tests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/compositor_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/opus_tests_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/blink/common:blink_common_unittests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/boringssl:boringssl_pki_tests_loader": "b/486053350 - Failing in first full CI run",
     "ui/compositor:compositor_unittests_loader": "b/486053350 - Failing in first full CI run",
-    "ui/views/examples:views_examples_unittests_loader": "b/486053350 - Failing in first full CI run"
+    "ui/views/examples:views_examples_unittests_loader": "b/486053350 - Failing in first full CI run",
+    "third_party/opus:opus_tests_loader": "b/486053350 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -2,7 +2,6 @@
   "TODO(b/382508397)": "Remove this when list is dynamically generated.",
   "TODO(todo): EGL init issue, needs new image": [],
   "TODO(b/486053854): Tests pass but crashes on exit": [
-    "gpu:gpu_unittests_loader",
     "ipc:ipc_tests_loader",
     "sql:sql_unittests_loader",
     "third_party/boringssl:boringssl_crypto_tests_loader",
@@ -35,7 +34,8 @@
     "third_party/opus:test_opus_decode_loader",
     "third_party/opus:test_opus_padding_loader",
     "cc:cc_unittests_loader",
-    "gpu:gl_tests_loader"
+    "gpu:gl_tests_loader",
+    "gpu:gpu_unittests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -56,7 +56,8 @@
     "out/evergreen-arm-hardfp-rdk_devel/test_opus_decode_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/test_opus_padding_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/cc_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/gl_tests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/gl_tests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/gpu_unittests_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
@@ -69,6 +70,7 @@
     "third_party/opus:test_opus_decode_loader": "b/486053350 - Failing in first full CI run",
     "third_party/opus:test_opus_padding_loader": "b/486053350 - Failing in first full CI run",
     "cc:cc_unittests_loader": "b/486053854 - Failing in first full CI run",
-    "gpu:gl_tests_loader": "b/486053854 - Failing in first full CI run"
+    "gpu:gl_tests_loader": "b/486053854 - Failing in first full CI run",
+    "gpu:gpu_unittests_loader": "b/486053854 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -19,7 +19,6 @@
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
     "third_party/ipcz/src:ipcz_tests_loader",
     "third_party/opus:test_opus_decode_loader",
-    "third_party/opus:test_opus_encode_loader",
     "third_party/opus:test_opus_padding_loader"
   ],
   "test_targets": [
@@ -36,7 +35,8 @@
     "third_party/boringssl:boringssl_pki_tests_loader",
     "ui/compositor:compositor_unittests_loader",
     "ui/views/examples:views_examples_unittests_loader",
-    "third_party/opus:opus_tests_loader"
+    "third_party/opus:opus_tests_loader",
+    "third_party/opus:test_opus_encode_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -52,7 +52,8 @@
     "out/evergreen-arm-hardfp-rdk_devel/boringssl_pki_tests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/compositor_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/opus_tests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/opus_tests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/test_opus_encode_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
@@ -60,6 +61,7 @@
     "third_party/boringssl:boringssl_pki_tests_loader": "b/486053350 - Failing in first full CI run",
     "ui/compositor:compositor_unittests_loader": "b/486053350 - Failing in first full CI run",
     "ui/views/examples:views_examples_unittests_loader": "b/486053350 - Failing in first full CI run",
-    "third_party/opus:opus_tests_loader": "b/486053350 - Failing in first full CI run"
+    "third_party/opus:opus_tests_loader": "b/486053350 - Failing in first full CI run",
+    "third_party/opus:test_opus_encode_loader": "b/486053350 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -14,7 +14,6 @@
     "third_party/zlib:zlib_unittests_loader"
   ],
   "TODO(b/486053350): Crashes on missing SbEventHandle": [
-    "compositor:compositor_unittests_loader",
     "examples:views_examples_unittests_loader",
     "gl:gl_unittests_loader",
     "gl:ozone_gl_unittests_loader",
@@ -36,7 +35,8 @@
     "ui/ozone:ozone_unittests_loader",
     "storage:storage_unittests_loader",
     "third_party/blink/common:blink_common_unittests_loader",
-    "third_party/boringssl:boringssl_pki_tests_loader"
+    "third_party/boringssl:boringssl_pki_tests_loader",
+    "ui/compositor:compositor_unittests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -49,11 +49,13 @@
     "out/evergreen-arm-hardfp-rdk_devel/ozone_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/boringssl_pki_tests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/boringssl_pki_tests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/compositor_unittests_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/blink/common:blink_common_unittests_loader": "b/486053350 - Failing in first full CI run",
-    "third_party/boringssl:boringssl_pki_tests_loader": "b/486053350 - Failing in first full CI run"
+    "third_party/boringssl:boringssl_pki_tests_loader": "b/486053350 - Failing in first full CI run",
+    "ui/compositor:compositor_unittests_loader": "b/486053350 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -18,7 +18,6 @@
     "examples:views_examples_unittests_loader",
     "gl:gl_unittests_loader",
     "gl:ozone_gl_unittests_loader",
-    "storage:storage_unittests_loader",
     "third_party/blink/common:blink_common_unittests_loader",
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
     "third_party/boringssl:boringssl_pki_tests_loader",
@@ -36,7 +35,8 @@
     "third_party/abseil-cpp:absl_hardening_tests_loader",
     "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
     "ui/events:events_unittests_loader",
-    "ui/ozone:ozone_unittests_loader"
+    "ui/ozone:ozone_unittests_loader",
+    "storage:storage_unittests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -46,6 +46,10 @@
     "out/evergreen-arm-hardfp-rdk_devel/absl_hardening_tests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/wtf_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/events_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/ozone_unittests_loader.py"
-  ]
+    "out/evergreen-arm-hardfp-rdk_devel/ozone_unittests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py"
+  ],
+  "disabled": {
+    "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run"
+  }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -1,8 +1,6 @@
 {
   "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "TODO(todo): EGL init issue, needs new image": [
-    "cc:cc_unittests_loader"
-  ],
+  "TODO(todo): EGL init issue, needs new image": [],
   "TODO(b/486053854): Tests pass but crashes on exit": [
     "gpu:gl_tests_loader",
     "gpu:gpu_unittests_loader",
@@ -36,7 +34,8 @@
     "third_party/opus:opus_tests_loader",
     "third_party/opus:test_opus_encode_loader",
     "third_party/opus:test_opus_decode_loader",
-    "third_party/opus:test_opus_padding_loader"
+    "third_party/opus:test_opus_padding_loader",
+    "cc:cc_unittests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -55,7 +54,8 @@
     "out/evergreen-arm-hardfp-rdk_devel/opus_tests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/test_opus_encode_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/test_opus_decode_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/test_opus_padding_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/test_opus_padding_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/cc_unittests_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
@@ -66,6 +66,7 @@
     "third_party/opus:opus_tests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/opus:test_opus_encode_loader": "b/486053350 - Failing in first full CI run",
     "third_party/opus:test_opus_decode_loader": "b/486053350 - Failing in first full CI run",
-    "third_party/opus:test_opus_padding_loader": "b/486053350 - Failing in first full CI run"
+    "third_party/opus:test_opus_padding_loader": "b/486053350 - Failing in first full CI run",
+    "cc:cc_unittests_loader": "b/486053854 - Failing in first full CI run"
   }
 }

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -17,8 +17,7 @@
     "gl:gl_unittests_loader",
     "gl:ozone_gl_unittests_loader",
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
-    "third_party/ipcz/src:ipcz_tests_loader",
-    "third_party/opus:test_opus_padding_loader"
+    "third_party/ipcz/src:ipcz_tests_loader"
   ],
   "test_targets": [
     "crypto:crypto_unittests_loader",
@@ -36,7 +35,8 @@
     "ui/views/examples:views_examples_unittests_loader",
     "third_party/opus:opus_tests_loader",
     "third_party/opus:test_opus_encode_loader",
-    "third_party/opus:test_opus_decode_loader"
+    "third_party/opus:test_opus_decode_loader",
+    "third_party/opus:test_opus_padding_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -54,7 +54,8 @@
     "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/opus_tests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/test_opus_encode_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/test_opus_decode_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/test_opus_decode_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/test_opus_padding_loader.py"
   ],
   "disabled": {
     "storage:storage_unittests_loader": "b/486053350 - Failing in first full CI run",
@@ -64,6 +65,7 @@
     "ui/views/examples:views_examples_unittests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/opus:opus_tests_loader": "b/486053350 - Failing in first full CI run",
     "third_party/opus:test_opus_encode_loader": "b/486053350 - Failing in first full CI run",
-    "third_party/opus:test_opus_decode_loader": "b/486053350 - Failing in first full CI run"
+    "third_party/opus:test_opus_decode_loader": "b/486053350 - Failing in first full CI run",
+    "third_party/opus:test_opus_padding_loader": "b/486053350 - Failing in first full CI run"
   }
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -392,9 +392,15 @@ group("loader_app_rdk_plugin") {
 }
 
 if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
-  target("shared_library", "loader_app") {
-    output_dir = root_build_dir
-    deps = [ "//starboard/loader_app:loader_app_sources" ]
-    data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+  if (starboard_level_final_executable_type == "shared_library") {
+    group("loader_app") {
+      public_deps = [ "//starboard/loader_app:loader_app" ]
+    }
+  } else {
+    target("shared_library", "loader_app") {
+      output_dir = root_build_dir
+      deps = [ "//starboard/loader_app:loader_app_sources" ]
+      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+    }
   }
 }

--- a/starboard/testing/sbeventhandle_from_main_no_args.cc
+++ b/starboard/testing/sbeventhandle_from_main_no_args.cc
@@ -1,0 +1,23 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/client_porting/wrap_main/wrap_main.h"
+
+int main(void);
+
+static int MainNoArgs(int argc, char** argv) {
+  return main();
+}
+
+SB_EXPORT STARBOARD_WRAP_SIMPLE_MAIN(MainNoArgs)

--- a/starboard/testing/sbeventhandle_from_main_with_args.cc
+++ b/starboard/testing/sbeventhandle_from_main_with_args.cc
@@ -1,0 +1,19 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/client_porting/wrap_main/wrap_main.h"
+
+int main(int argc, char** argv);
+
+SB_EXPORT STARBOARD_WRAP_SIMPLE_MAIN(main)

--- a/storage/BUILD.gn
+++ b/storage/BUILD.gn
@@ -10,6 +10,11 @@ test("storage_unittests") {
     "//storage/common:unittests",
   ]
 
+  sources = []
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_with_args.cc" ]
+  }
+
   if (is_ios) {
     deps += [ "//storage/test:test_bundle_data" ]
   } else {

--- a/third_party/abseil-cpp/absl/base/BUILD.gn
+++ b/third_party/abseil-cpp/absl/base/BUILD.gn
@@ -212,6 +212,13 @@ if (absl_build_tests) {
       ":config",
       ":core_headers",
     ]
+    if (is_cobalt_hermetic_build) {
+      sources += [ "//starboard/testing/sbeventhandle_from_main_no_args.cc" ]
+      deps += [
+        "//starboard/common",
+        "//starboard/elf_loader:sabi_string",
+      ]
+    }
   }
 }
 

--- a/third_party/blink/common/BUILD.gn
+++ b/third_party/blink/common/BUILD.gn
@@ -352,6 +352,10 @@ source_set("common") {
 
 test("blink_common_unittests") {
   visibility = [ "*" ]
+  sources = []
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_with_args.cc" ]
+  }
   deps = [
     ":common_unittests_sources",
     "//services/metrics/public/cpp:metrics_cpp",

--- a/third_party/blink/renderer/platform/heap/BUILD.gn
+++ b/third_party/blink/renderer/platform/heap/BUILD.gn
@@ -130,6 +130,10 @@ source_set("test_support") {
 }
 
 test("blink_heap_unittests") {
+  sources = []
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_with_args.cc" ]
+  }
   deps = [ ":blink_heap_unittests_sources" ]
 
   if (is_android) {

--- a/third_party/boringssl/BUILD.gn
+++ b/third_party/boringssl/BUILD.gn
@@ -284,7 +284,11 @@ if (build_with_chromium) {
 
     # Chromium infrastructure does not support GTest, only the //base wrapper.
     sources -= [ "src/crypto/test/gtest_main.cc" ]
-    sources += [ "gtest_main_chromium.cc" ]
+    if (is_cobalt_hermetic_build) {
+      sources += [ "starboard/gtest_main_chromium.cc" ]
+    } else {
+      sources += [ "gtest_main_chromium.cc" ]
+    }
     deps += [ "//base/test:test_support" ]
   }
 

--- a/third_party/ipcz/src/BUILD.gn
+++ b/third_party/ipcz/src/BUILD.gn
@@ -436,6 +436,9 @@ ipcz_source_set("ipcz_tests_sources") {
 # that it gets compile coverage from Chromium infrastructure.
 test("ipcz_tests") {
   sources = [ "test/run_all_tests.cc" ]
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_with_args.cc" ]
+  }
   deps = [
     ":ipcz_tests_sources_standalone",
     ":test_buildflags",

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -568,6 +568,10 @@ test("test_opus_encode") {
 test("test_opus_decode") {
   sources = [ "src/tests/test_opus_decode.c" ]
 
+  if (is_cobalt_hermetic_build) {
+    sources += [ "starboard/sbeventhandle_main_no_loader_args.cc" ]
+  }
+
   configs -= [ "//build/config/compiler:chromium_code" ]
   configs += [
     "//build/config/compiler:no_chromium_code",
@@ -576,6 +580,12 @@ test("test_opus_decode") {
   ]
 
   deps = [ ":opus" ]
+  if (is_cobalt_hermetic_build) {
+    deps += [
+      "//starboard/common",
+      "//starboard/elf_loader:sabi_string",
+    ]
+  }
 }
 
 test("test_opus_padding") {

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -520,6 +520,10 @@ executable("opus_demo") {
 test("test_opus_api") {
   sources = [ "src/tests/test_opus_api.c" ]
 
+  if (is_cobalt_hermetic_build) {
+    sources += [ "starboard/sbeventhandle_main_no_loader_args.cc" ]
+  }
+
   configs -= [ "//build/config/compiler:chromium_code" ]
   configs += [
     "//build/config/compiler:no_chromium_code",
@@ -528,6 +532,12 @@ test("test_opus_api") {
   ]
 
   deps = [ ":opus" ]
+  if (is_cobalt_hermetic_build) {
+    deps += [
+      "//starboard/common",
+      "//starboard/elf_loader:sabi_string",
+    ]
+  }
 }
 
 test("test_opus_encode") {

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -546,6 +546,10 @@ test("test_opus_encode") {
     "src/tests/test_opus_encode.c",
   ]
 
+  if (is_cobalt_hermetic_build) {
+    sources += [ "starboard/sbeventhandle_main_no_loader_args.cc" ]
+  }
+
   configs -= [ "//build/config/compiler:chromium_code" ]
   configs += [
     "//build/config/compiler:no_chromium_code",
@@ -553,6 +557,12 @@ test("test_opus_encode") {
   ]
 
   deps = [ ":opus" ]
+  if (is_cobalt_hermetic_build) {
+    deps += [
+      "//starboard/common",
+      "//starboard/elf_loader:sabi_string",
+    ]
+  }
 }
 
 test("test_opus_decode") {

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -591,6 +591,10 @@ test("test_opus_decode") {
 test("test_opus_padding") {
   sources = [ "src/tests/test_opus_padding.c" ]
 
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_no_args.cc" ]
+  }
+
   configs -= [ "//build/config/compiler:chromium_code" ]
   configs += [
     "//build/config/compiler:no_chromium_code",
@@ -598,6 +602,12 @@ test("test_opus_padding") {
   ]
 
   deps = [ ":opus" ]
+  if (is_cobalt_hermetic_build) {
+    deps += [
+      "//starboard/common",
+      "//starboard/elf_loader:sabi_string",
+    ]
+  }
 }
 
 # Not all checkouts have a //base directory.

--- a/third_party/opus/starboard/sbeventhandle_main_no_loader_args.cc
+++ b/third_party/opus/starboard/sbeventhandle_main_no_loader_args.cc
@@ -1,0 +1,30 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/client_porting/wrap_main/wrap_main.h"
+
+int main(int argc, char** argv);
+
+namespace {
+
+int RunMainWithoutLoaderArgs(int argc, char** argv) {
+  char fallback_name[] = "opus_test";
+  char* filtered_argv[] = { (argc > 0 && argv && argv[0]) ? argv[0] : fallback_name,
+                            nullptr };
+  return main(1, filtered_argv);
+}
+
+}  // namespace
+
+SB_EXPORT STARBOARD_WRAP_SIMPLE_MAIN(RunMainWithoutLoaderArgs)

--- a/ui/compositor/BUILD.gn
+++ b/ui/compositor/BUILD.gn
@@ -242,6 +242,10 @@ test("compositor_unittests") {
     "transform_animation_curve_adapter_unittest.cc",
   ]
 
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_with_args.cc" ]
+  }
+
   data = [ "//ui/gfx/test/data/compositor/" ]
 
   deps = [

--- a/ui/gl/BUILD.gn
+++ b/ui/gl/BUILD.gn
@@ -535,6 +535,10 @@ test("gl_unittests") {
     "test/egl_initialization_displays_unittest.cc",
   ]
 
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_with_args.cc" ]
+  }
+
   if (!use_ozone) {
     sources += [ "gl_surface_egl_unittest.cc" ]
   }

--- a/ui/ozone/gl/BUILD.gn
+++ b/ui/ozone/gl/BUILD.gn
@@ -7,6 +7,10 @@ import("//testing/test.gni")
 test("ozone_gl_unittests") {
   sources = [ "native_pixmap_gl_binding_unittest.cc" ]
 
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_with_args.cc" ]
+  }
+
   deps = [
     "//base/test:test_support",
     "//testing/gtest",

--- a/ui/views/examples/BUILD.gn
+++ b/ui/views/examples/BUILD.gn
@@ -317,6 +317,10 @@ test("views_examples_unittests") {
     "examples_unittest_main.cc",
   ]
 
+  if (is_cobalt_hermetic_build) {
+    sources += [ "//starboard/testing/sbeventhandle_from_main_with_args.cc" ]
+  }
+
   deps = [
     ":views_examples_lib",
     ":views_examples_proc",


### PR DESCRIPTION
This PR implements the in-scope loader test suites with a two-commit sequence:

1. Fix a `loader_app` output-conflict in RDK.
2. Wire Starboard-aware entrypoints for the targeted hermetic test suites.

## What this PR does

- Keeps the `loader_app` output-conflict remediation in its own commit: See the patch on  `starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn`
- Ensures in-scope test loader libraries export and use Starboard entrypoint wiring (`SbEventHandle` path).
- Adds reusable Starboard entrypoint wrapper sources for C/C++ test mains.
- Switches `boringssl_pki_tests` to Starboard gtest main under hermetic build.
- Updates affected BUILD files to select Starboard-aware entrypoints for the test-suite targets.

## Scope

This PR is intentionally limited to **Starboard-aware entrypoint wiring** for ticket test suites; it does not attempt to solve unrelated functional test failures.

Bug: 486053350