### PR TITLE
media: Remove Android overlay factory callback

### DIFF
--- a/media/mojo/services/gpu_mojo_media_client.cc
+++ b/media/mojo/services/gpu_mojo_media_client.cc
@@ -103,8 +103,7 @@ StarboardRendererTraits::StarboardRendererTraits(
         renderer_extension_receiver,
     mojo::PendingRemote<mojom::StarboardRendererClientExtension>
         client_extension_remote,
-    GetStarboardCommandBufferStubCB get_starboard_command_buffer_stub_cb,
-    AndroidOverlayMojoFactoryCB android_overlay_factory_cb)
+    GetStarboardCommandBufferStubCB get_starboard_command_buffer_stub_cb)
     : task_runner(std::move(task_runner)),
       gpu_task_runner(std::move(gpu_task_runner)),
       media_log_remote(std::move(media_log_remote)),
@@ -118,8 +117,7 @@ StarboardRendererTraits::StarboardRendererTraits(
       renderer_extension_receiver(std::move(renderer_extension_receiver)),
       client_extension_remote(std::move(client_extension_remote)),
       get_starboard_command_buffer_stub_cb(
-          std::move(get_starboard_command_buffer_stub_cb)),
-      android_overlay_factory_cb(std::move(android_overlay_factory_cb)) {}
+          std::move(get_starboard_command_buffer_stub_cb)) {}
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 GpuMojoMediaClientTraits::~GpuMojoMediaClientTraits() = default;
@@ -164,7 +162,6 @@ GpuMojoMediaClient::GpuMojoMediaClient(GpuMojoMediaClientTraits& traits)
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
       video_geometry_setter_service_(traits.video_geometry_setter_service),
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-      android_overlay_factory_cb_(std::move(traits.android_overlay_factory_cb)),
       gpu_preferences_(std::move(traits.gpu_preferences)),
       gpu_workarounds_(std::move(traits.gpu_workarounds)),
       gpu_feature_info_(std::move(traits.gpu_feature_info)),
@@ -310,8 +307,7 @@ std::unique_ptr<Renderer> GpuMojoMediaClient::CreateStarboardRenderer(
       config.viewport_size, std::move(renderer_extension_receiver),
       std::move(client_extension_remote),
       base::BindRepeating(&GetCommandBufferStub, gpu_task_runner_,
-                          media_gpu_channel_manager_),
-      android_overlay_factory_cb_);
+                          media_gpu_channel_manager_));
   return CreatePlatformStarboardRenderer(std::move(traits));
 }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/mojo/services/gpu_mojo_media_client.h
+++ b/media/mojo/services/gpu_mojo_media_client.h
@@ -112,8 +112,7 @@ struct StarboardRendererTraits {
       mojo::PendingRemote<mojom::StarboardRendererClientExtension>
           client_extension_remote,
       GetStarboardCommandBufferStubCB
-          get_starboard_command_buffer_stub_cb,
-      AndroidOverlayMojoFactoryCB android_overlay_factory_cb);
+          get_starboard_command_buffer_stub_cb);
   StarboardRendererTraits(StarboardRendererTraits&& that) = default;
   ~StarboardRendererTraits();
 };
@@ -275,7 +274,6 @@ class MEDIA_MOJO_EXPORT GpuMojoMediaClient : public MojoMediaClient {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   cobalt::media::VideoGeometrySetterService* video_geometry_setter_service_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-  AndroidOverlayMojoFactoryCB android_overlay_factory_cb_;
   const gpu::GpuPreferences gpu_preferences_;
   const gpu::GpuDriverBugWorkarounds gpu_workarounds_;
   const gpu::GpuFeatureInfo gpu_feature_info_;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -187,8 +187,7 @@ class StarboardRendererWrapperTest : public testing::Test {
         base::UnguessableToken::Create(), base::Seconds(1), base::Seconds(1),
         std::string(), StarboardRendererConfig::ExperimentalFeatures{},
         gfx::Size(), std::move(renderer_extension_receiver),
-        std::move(client_extension_remote), base::NullCallback(),
-        AndroidOverlayMojoFactoryCB());
+        std::move(client_extension_remote), base::NullCallback());
     renderer_wrapper_ =
         std::make_unique<StarboardRendererWrapper>(std::move(traits));
     renderer_wrapper_->SetRendererForTesting(mock_renderer_.get());


### PR DESCRIPTION
https://github.com/youtube/cobalt/pull/9986 made a regression of adding android_overlay_factory_cb_ during CP. 

This resulted in the crash.

Issue: 505825897