### PR TITLE
script to remove unused dependencies

### DIFF
--- a/cobalt/tools/apply-remove/SKILL.md
+++ b/cobalt/tools/apply-remove/SKILL.md
@@ -1,0 +1,32 @@
+---
+name: apply-remove
+description: Specialized skill for surgically removing components from Cobalt using AI-powered automation. Use this to apply the "Subtraction Method" to BUILD.gn and C++ files at a specific pivot point.
+---
+
+# Apply Remove Skill
+
+This skill provides a high-leverage workflow for removing dependencies from Cobalt by combining local context gathering with Gemini's reasoning.
+
+## When to use
+- You have identified a component to remove (the "target").
+- You have identified where to break the dependency (the "pivot").
+- You want to automatically guard headers and symbols in C++ and update `BUILD.gn`.
+
+## Workflow
+
+### 1. Gather Context
+Run the `gemini_remove.py` script to gather all relevant file context (GN targets and C++ files).
+- **Command:** `python3 cobalt/tools/automate_remove/apply-remove/scripts/gemini_remove.py --pivot //pivot:target --target //target:to_remove`
+
+### 2. Apply Modifications (Automated)
+Once the script outputs the context JSON, the agent (Gemini) will:
+1. **Update BUILD.gn**: Locate the pivot target and add an `if (is_cobalt)` subtraction block.
+   - **Constraint**: Must be placed AFTER the original `deps`/`sources` list to avoid GN errors.
+2. **Guard Headers**: Wrap `#include` statements in the discovered C++ files with `#if !BUILDFLAG(IS_COBALT)`.
+   - **Constraint**: Merge adjacent guards into a single block.
+   - **Constraint**: Append `// nogncheck` to guarded lines.
+   - **Constraint**: Ensure `#include "build/build_config.h"` is present if not already there.
+3. **Guard Symbols**: Identify and wrap usage of the component's symbols (e.g., interface registrations).
+
+## Tooling
+- `scripts/gemini_remove.py`: Context gatherer that identifies relevant files and targets.

--- a/cobalt/tools/apply-remove/scripts/gemini_remove.py
+++ b/cobalt/tools/apply-remove/scripts/gemini_remove.py
@@ -1,0 +1,53 @@
+#!/usr/bin/env python3
+# Copyright 2024 The Cobalt Authors. All Rights Reserved.
+
+"""Gemini-powered surgical component removal context gatherer."""
+
+import argparse
+import os
+import subprocess
+import json
+
+def run_command(cmd):
+    try:
+        return subprocess.check_output(cmd, stderr=subprocess.STDOUT, shell=False).decode('utf-8')
+    except:
+        return ""
+
+def get_build_gn_path(target):
+    base_target = target.split('(')[0]
+    path_part = base_target.split(':')[0].replace('//', '')
+    return os.path.join(path_part, 'BUILD.gn')
+
+def main():
+    parser = argparse.ArgumentParser(description="Gather context for Gemini-powered removal.")
+    parser.add_argument("--pivot", required=True, help="Target where removal happens")
+    parser.add_argument("--target", required=True, help="Target to subtract")
+    parser.add_argument("--header", help="Header pattern to guard")
+    
+    args = parser.parse_args()
+
+    header_pattern = args.header or args.target.split('(')[0].replace('//', '').split(':')[0]
+    pivot_gn = get_build_gn_path(args.pivot)
+    pivot_dir = os.path.dirname(pivot_gn)
+    
+    cpp_files = []
+    if os.path.exists(pivot_dir):
+        cmd = ["git", "grep", "-l", f'#include "{header_pattern}', pivot_dir]
+        output = run_command(cmd)
+        cpp_files = output.splitlines()
+
+    # Output JSON for the agent to process
+    context = {
+        "action": "remove_dependency",
+        "pivot": args.pivot,
+        "target": args.target,
+        "header_pattern": header_pattern,
+        "build_gn": pivot_gn,
+        "cpp_files": cpp_files
+    }
+    
+    print(json.dumps(context, indent=2))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
1. identify components to remove from dependency chain
```
//cobalt:gn_all --[private]-->
//cobalt/android:cobalt_apk --[public]-->
//cobalt/android:cobalt_apk__create --[private]-->
//cobalt/android:libchrobalt --[private]-->
//cobalt:common --[private]-->
//content/public/app:app --[private]-->
//content/app:app --[private]-->
//content/browser:browser --[private]-->
//components/optimization_guide/core:features
```
2. Tell gemini what to do in gemini CLI (need to be in same directory as SKILL.md)
example usage: 
Use the apply-remove skill to remove //components/optimization_guide/core:features from //content/browser:browser.