### PR TITLE
starboard: Add Perfetto tracing for media operations

### DIFF
--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -28,6 +28,7 @@
 #include "starboard/configuration.h"
 #include "starboard/decode_target.h"
 #include "starboard/shared/starboard/experimental_features.h"
+#include "starboard/shared/starboard/media/media_tracing.h"
 #include "starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h"
 #include "starboard/shared/starboard/player/player_internal.h"
 #include "starboard/shared/starboard/player/player_worker.h"
@@ -40,6 +41,10 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
                         SbPlayerErrorFunc player_error_func,
                         void* context,
                         SbDecodeTargetGraphicsContextProvider* provider) {
+  // Lazy initialization of media specific event tracing.  See comment in
+  // EnsureMediaTracingIsInitialized() for limitations.
+  EnsureMediaTracingIsInitialized();
+
   if (!player_error_func) {
     SB_LOG(ERROR) << "|player_error_func| cannot be null.";
     return kSbPlayerInvalid;

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -39,6 +39,7 @@
 #include "starboard/configuration.h"
 #include "starboard/decode_target.h"
 #include "starboard/drm.h"
+#include "starboard/shared/starboard/media/media_tracing.h"
 #include "starboard/shared/starboard/media/mime_type.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
 #include "starboard/thread.h"
@@ -561,6 +562,10 @@ void MediaCodecVideoDecoder::WriteInputBuffers(
   SB_DCHECK(!input_buffers.empty());
   SB_DCHECK_EQ(input_buffers.front()->sample_type(), kSbMediaTypeVideo);
   SB_DCHECK(decoder_status_cb_);
+
+  MEDIA_TRACE_EVENT("starboard", "VideoDecoder::WriteInputBuffers", "timestamp",
+                    input_buffers.front()->timestamp(), "size",
+                    input_buffers.size());
 
   if (input_buffer_written_ == 0) {
     SB_DCHECK_EQ(video_fps_, 0);

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -268,6 +268,7 @@ static_library("starboard_platform_sources") {
 
   public_deps = [
     "//starboard:starboard_headers_only",
+    "//starboard/shared/starboard/media:media_util",
     "//starboard/shared/starboard/player/filter:filter_based_player_sources",
   ]
   deps = []

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -19,6 +19,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
+#include "starboard/shared/starboard/media/media_tracing.h"
 
 namespace starboard {
 
@@ -75,6 +76,10 @@ void OpusAudioDecoder::Decode(const InputBuffers& input_buffers,
   SB_DCHECK(!input_buffers.empty());
   SB_DCHECK(pending_audio_buffers_.empty());
   SB_DCHECK(output_cb_);
+
+  MEDIA_TRACE_EVENT("starboard", "OpusAudioDecoder::Decode", "timestamp",
+                    input_buffers.front()->timestamp(), "size",
+                    input_buffers.size());
 
   if (stream_ended_) {
     SB_LOG(ERROR) << "Decode() is called after WriteEndOfStream() is called.";

--- a/starboard/shared/starboard/media/BUILD.gn
+++ b/starboard/shared/starboard/media/BUILD.gn
@@ -12,6 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build_overrides/build.gni")
+
+config("media_tracing_config") {
+  defines = [ "ENABLE_MEDIA_TRACING" ]
+}
+
 static_library("media_util") {
   check_includes = false
   sources = [
@@ -24,6 +30,8 @@ static_library("media_util") {
     "//starboard/shared/starboard/media/key_system_supportability_cache.cc",
     "//starboard/shared/starboard/media/key_system_supportability_cache.h",
     "//starboard/shared/starboard/media/media_support_internal.h",
+    "//starboard/shared/starboard/media/media_tracing.cc",
+    "//starboard/shared/starboard/media/media_tracing.h",
     "//starboard/shared/starboard/media/media_util.cc",
     "//starboard/shared/starboard/media/media_util.h",
     "//starboard/shared/starboard/media/mime_supportability_cache.cc",
@@ -39,5 +47,11 @@ static_library("media_util") {
   ]
 
   public_deps = [ "//starboard/common" ]
+
+  if (!cobalt_is_release_build && enable_base_tracing) {
+    public_deps += [ "//third_party/perfetto:libperfetto" ]
+    public_configs = [ ":media_tracing_config" ]
+  }
+
   configs += [ "//starboard/build/config:starboard_implementation" ]
 }

--- a/starboard/shared/starboard/media/media_tracing.cc
+++ b/starboard/shared/starboard/media/media_tracing.cc
@@ -1,0 +1,19 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/media/media_tracing.h"
+
+#if defined(ENABLE_MEDIA_TRACING)
+PERFETTO_TRACK_EVENT_STATIC_STORAGE();
+#endif  // defined(ENABLE_MEDIA_TRACING)

--- a/starboard/shared/starboard/media/media_tracing.h
+++ b/starboard/shared/starboard/media/media_tracing.h
@@ -1,0 +1,84 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_STARBOARD_MEDIA_MEDIA_TRACING_H_
+#define STARBOARD_SHARED_STARBOARD_MEDIA_MEDIA_TRACING_H_
+
+#include <cstdint>
+#include <mutex>
+#include <optional>
+
+#include "build/build_config.h"
+#include "starboard/common/log.h"
+#include "starboard/configuration.h"
+
+#if defined(ENABLE_MEDIA_TRACING)
+// This cannot be `starboard`, as it conflicts with nested starboard namespaces.
+#define PERFETTO_TRACK_EVENT_NAMESPACE starboard_tracing
+#include "perfetto/tracing.h"
+
+PERFETTO_DEFINE_CATEGORIES(perfetto::Category("starboard"));
+
+#define MEDIA_TRACE_EVENT(...) TRACE_EVENT(__VA_ARGS__)
+#define MEDIA_TRACE_EVENT_BEGIN(...) TRACE_EVENT_BEGIN(__VA_ARGS__)
+#define MEDIA_TRACE_EVENT_END(...) TRACE_EVENT_END(__VA_ARGS__)
+
+// Ideally, this should be called right after perfetto::Tracing::Initialize() in
+// PerfettoTracedProcess::SetupClientLibrary().  However, this would require
+// moving "media_tracing.*" to //starboard/common, and probably being exposed as
+// STARBOARD_TRACE_EVENT.
+// I would limit the scope to media for now, and expand its scope when needed.
+inline void EnsureMediaTracingIsInitialized() {
+  static std::once_flag s_once_flag;
+  std::call_once(s_once_flag,
+                 []() { starboard_tracing::TrackEvent::Register(); });
+}
+
+class MediaEventTracer {
+ public:
+  void Begin(const char* name, void* token) {
+    SB_DCHECK(token);
+    token_ = reinterpret_cast<uintptr_t>(token);
+    MEDIA_TRACE_EVENT_BEGIN("starboard", perfetto::DynamicString(name),
+                            perfetto::Track(*token_));
+  }
+
+  void End() {
+    if (token_.has_value()) {
+      MEDIA_TRACE_EVENT_END("starboard", perfetto::Track(*token_));
+      token_ = std::nullopt;
+    }
+  }
+
+ private:
+  std::optional<uintptr_t> token_;
+};
+
+#else  // defined(ENABLE_MEDIA_TRACING)
+
+#define MEDIA_TRACE_EVENT(...) ((void)0)
+#define MEDIA_TRACE_EVENT_BEGIN(...) ((void)0)
+#define MEDIA_TRACE_EVENT_END(...) ((void)0)
+
+inline void EnsureMediaTracingIsInitialized() {}
+
+class MediaEventTracer {
+ public:
+  void Begin(const char*, void*) {}
+  void End() {}
+};
+
+#endif  // defined(ENABLE_MEDIA_TRACING)
+
+#endif  // STARBOARD_SHARED_STARBOARD_MEDIA_MEDIA_TRACING_H_

--- a/starboard/shared/starboard/player/filter/BUILD.gn
+++ b/starboard/shared/starboard/player/filter/BUILD.gn
@@ -75,5 +75,8 @@ static_library("filter_based_player_sources") {
     "//starboard/shared/starboard/player/filter/wsola_internal.h",
   ]
   configs += [ "//starboard/build/config:starboard_implementation" ]
-  deps = [ "//starboard:starboard_headers_only" ]
+  deps = [
+    "//starboard:starboard_headers_only",
+    "//starboard/shared/starboard/media:media_util",
+  ]
 }

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -28,6 +28,7 @@
 #include "starboard/common/string.h"
 #include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/drm/drm_system_internal.h"
+#include "starboard/shared/starboard/media/media_tracing.h"
 #include "starboard/shared/starboard/player/filter/audio_decoder_internal.h"
 #include "starboard/shared/starboard/player/filter/video_decoder_internal.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
@@ -153,6 +154,8 @@ Result<void> FilterBasedPlayerWorkerHandler::Init(
   if (audio_renderer_) {
     SB_LOG(INFO) << "Initialize audio renderer with volume " << volume_;
 
+    audio_preroll_track_.Begin("Audio Preroll", audio_renderer_);
+
     audio_renderer_->Initialize(
         std::bind(&FilterBasedPlayerWorkerHandler::OnError, this, _1, _2),
         std::bind(&FilterBasedPlayerWorkerHandler::OnPrerolled, this,
@@ -165,6 +168,8 @@ Result<void> FilterBasedPlayerWorkerHandler::Init(
   media_time_provider_->SetPlaybackRate(playback_rate_);
   if (video_renderer_) {
     SB_LOG(INFO) << "Initialize video renderer.";
+
+    video_preroll_track_.Begin("Video Preroll", video_renderer_);
 
     video_renderer_->Initialize(
         std::bind(&FilterBasedPlayerWorkerHandler::OnError, this, _1, _2),
@@ -434,8 +439,10 @@ void FilterBasedPlayerWorkerHandler::OnPrerolled(SbMediaType media_type) {
       << "Invalid player state " << GetPlayerStateName(get_player_state_cb_());
 
   if (media_type == kSbMediaTypeAudio) {
+    audio_preroll_track_.End();
     SB_LOG(INFO) << "Audio prerolled.";
   } else {
+    video_preroll_track_.End();
     SB_LOG(INFO) << "Video prerolled.";
   }
 
@@ -506,6 +513,9 @@ void FilterBasedPlayerWorkerHandler::Stop() {
   SB_CHECK(BelongsToCurrentThread());
 
   SB_LOG(INFO) << "FilterBasedPlayerWorkerHandler stopped.";
+
+  audio_preroll_track_.End();
+  video_preroll_track_.End();
 
   RemoveJobByToken(update_job_token_);
 

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -18,6 +18,7 @@
 #include <functional>
 #include <memory>
 #include <mutex>
+#include <optional>
 #include <string>
 
 #include "starboard/configuration.h"
@@ -25,6 +26,7 @@
 #include "starboard/media.h"
 #include "starboard/player.h"
 #include "starboard/shared/internal_only.h"
+#include "starboard/shared/starboard/media/media_tracing.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "starboard/shared/starboard/player/filter/audio_renderer_internal.h"
 #include "starboard/shared/starboard/player/filter/media_time_provider.h"
@@ -110,6 +112,10 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   bool video_prerolled_ = false;
   bool audio_ended_ = false;
   bool video_ended_ = false;
+
+  // For preroll event tracing.
+  MediaEventTracer audio_preroll_track_;
+  MediaEventTracer video_preroll_track_;
 
   SbPlayerOutputMode output_mode_;
   int max_video_input_size_;


### PR DESCRIPTION
This is to reland https://github.com/youtube/cobalt/pull/9213, with the build issues on evergreen platforms resolved.

Introduce MEDIA_TRACE_EVENT macros to instrument key media pipeline operations. This change integrates libperfetto into Android builds, conditional on non-release configurations, set up the stage for adding comprehensive media event tracing.

A few example tracing events are added for video and audio decoder buffer writes, as well as for audio and video preroll durations. This provides valuable insights into media performance and aids in debugging and optimization.

Bug: 428025465