### PR TITLE
ci: Fix nightly_trigger_27.lts.yaml ref arg

### DIFF
--- a/.github/workflows/nightly_trigger_27.lts.yaml
+++ b/.github/workflows/nightly_trigger_27.lts.yaml
@@ -20,8 +20,8 @@ jobs:
       - name: Trigger Nightly
         run: |
           set -x
-          gh workflow run android_27.lts --ref main -f nightly=true --repo "${GITHUB_REPO}"
-          gh workflow run evergreen_27.lts --ref main -f nightly=true --repo "${GITHUB_REPO}"
-          gh workflow run linux_27.lts --ref main -f nightly=true --repo "${GITHUB_REPO}"
+          gh workflow run android_27.lts --ref 27.lts -f nightly=true --repo "${GITHUB_REPO}"
+          gh workflow run evergreen_27.lts --ref 27.lts -f nightly=true --repo "${GITHUB_REPO}"
+          gh workflow run linux_27.lts --ref 27.lts -f nightly=true --repo "${GITHUB_REPO}"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
The ref arg was never updated when the trigger file was copied from main.

Bug: 484351320