### PR TITLE
media: Remove redundant size_ from DecoderBuffer

### DIFF
--- a/media/base/decoder_buffer.cc
+++ b/media/base/decoder_buffer.cc
@@ -63,49 +63,58 @@ class ExternalSharedMemoryAdapter : public DecoderBuffer::ExternalMemory {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 // --- Starboard-specific Constructor Implementations ---
-DecoderBuffer::DecoderBuffer(size_t size) {
-  if (size > 0) {
-    CHECK(s_allocator);
-    Initialize(DemuxerStream::UNKNOWN, size);
-  }
-}
+DecoderBuffer::DecoderBuffer(size_t size)
+    : DecoderBuffer(DemuxerStream::UNKNOWN, size) {}
 
 DecoderBuffer::DecoderBuffer(DemuxerStream::Type type,
                              const uint8_t* data,
-                             size_t size) {
+                             size_t size)
+    : DecoderBuffer(type, size) {
   if (!data) {
     CHECK_EQ(size, 0u);
     return;
   }
 
-  CHECK(s_allocator);
-  Initialize(type, size);
   s_allocator->Write(allocator_data_->handle, data, size);
 }
+
 DecoderBuffer::DecoderBuffer(DemuxerStream::Type type,
-                             base::span<const uint8_t> data) {
+                             base::span<const uint8_t> data)
+    : DecoderBuffer(type, data.size()) {
   if (data.empty()) {
     return;
   }
-  CHECK(s_allocator);
-  Initialize(type, data.size());
+
   memcpy(writable_data(), data.data(), data.size());
 }
 
 DecoderBuffer::DecoderBuffer(base::span<const uint8_t> data)
     : DecoderBuffer(DemuxerStream::UNKNOWN, data) {}
 
-DecoderBuffer::DecoderBuffer(base::HeapArray<uint8_t> data) {
+DecoderBuffer::DecoderBuffer(base::HeapArray<uint8_t> data)
+    : DecoderBuffer(DemuxerStream::UNKNOWN, data.size()) {
   if (data.empty()) {
     return;
   }
-  CHECK(s_allocator);
-  Initialize(DemuxerStream::UNKNOWN, data.size());
+
   memcpy(writable_data(), data.data(), data.size());
 }
 
 DecoderBuffer::DecoderBuffer(std::unique_ptr<ExternalMemory> external_memory)
     : DecoderBuffer(DemuxerStream::UNKNOWN, external_memory->Span()) {}
+
+DecoderBuffer::DecoderBuffer(DemuxerStream::Type type, size_t size)
+    : allocator_data_([&]() -> std::optional<AllocatorData> {
+        if (size == 0) {
+          return std::nullopt;
+        }
+        DCHECK(s_allocator);
+        DCHECK_EQ(s_allocator->GetBufferPadding(), 0);
+        return AllocatorData(type,
+                             s_allocator->Allocate(
+                                 type, size, s_allocator->GetBufferAlignment()),
+                             size);
+      }()) {}
 
 #else // BUILDFLAG(USE_STARBOARD_MEDIA)
 
@@ -163,20 +172,6 @@ DecoderBuffer::~DecoderBuffer() {
 }
 #else // BUILDFLAG(USE_STARBOARD_MEDIA)
 DecoderBuffer::~DecoderBuffer() = default;
-#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-void DecoderBuffer::Initialize(DemuxerStream::Type type, size_t size) {
-  DCHECK(s_allocator);
-  DCHECK(data_.empty());
-  DCHECK(!allocator_data_);
-  DCHECK_EQ(s_allocator->GetBufferPadding(), 0);
-
-  int alignment = s_allocator->GetBufferAlignment();
-  allocator_data_.emplace(type,
-                          s_allocator->Allocate(type, size, alignment),
-                          size);
-}
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 // static

--- a/media/base/decoder_buffer.cc
+++ b/media/base/decoder_buffer.cc
@@ -63,47 +63,44 @@ class ExternalSharedMemoryAdapter : public DecoderBuffer::ExternalMemory {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 // --- Starboard-specific Constructor Implementations ---
-DecoderBuffer::DecoderBuffer(size_t size) : size_(size) {
-  if (size_ > 0) {
+DecoderBuffer::DecoderBuffer(size_t size) {
+  if (size > 0) {
     CHECK(s_allocator);
-    Initialize(DemuxerStream::UNKNOWN);
+    Initialize(DemuxerStream::UNKNOWN, size);
   }
 }
 
 DecoderBuffer::DecoderBuffer(DemuxerStream::Type type,
                              const uint8_t* data,
-                             size_t size)
-    : size_(size) {
+                             size_t size) {
   if (!data) {
-    CHECK_EQ(size_, 0u);
+    CHECK_EQ(size, 0u);
     return;
   }
 
   CHECK(s_allocator);
-  Initialize(type);
-  s_allocator->Write(allocator_data_->handle, data, size_);
+  Initialize(type, size);
+  s_allocator->Write(allocator_data_->handle, data, size);
 }
 DecoderBuffer::DecoderBuffer(DemuxerStream::Type type,
-                             base::span<const uint8_t> data)
-    : size_(data.size()) {
+                             base::span<const uint8_t> data) {
   if (data.empty()) {
     return;
   }
   CHECK(s_allocator);
-  Initialize(type);
+  Initialize(type, data.size());
   memcpy(writable_data(), data.data(), data.size());
 }
 
 DecoderBuffer::DecoderBuffer(base::span<const uint8_t> data)
     : DecoderBuffer(DemuxerStream::UNKNOWN, data) {}
 
-DecoderBuffer::DecoderBuffer(base::HeapArray<uint8_t> data)
-    : size_(data.size()) {
+DecoderBuffer::DecoderBuffer(base::HeapArray<uint8_t> data) {
   if (data.empty()) {
     return;
   }
   CHECK(s_allocator);
-  Initialize(DemuxerStream::UNKNOWN);
+  Initialize(DemuxerStream::UNKNOWN, data.size());
   memcpy(writable_data(), data.data(), data.size());
 }
 
@@ -169,7 +166,7 @@ DecoderBuffer::~DecoderBuffer() = default;
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-void DecoderBuffer::Initialize(DemuxerStream::Type type) {
+void DecoderBuffer::Initialize(DemuxerStream::Type type, size_t size) {
   DCHECK(s_allocator);
   DCHECK(data_.empty());
   DCHECK(!allocator_data_);
@@ -177,8 +174,8 @@ void DecoderBuffer::Initialize(DemuxerStream::Type type) {
 
   int alignment = s_allocator->GetBufferAlignment();
   allocator_data_.emplace(type,
-                          s_allocator->Allocate(type, size_, alignment),
-                          size_);
+                          s_allocator->Allocate(type, size, alignment),
+                          size);
 }
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/media/base/decoder_buffer.cc
+++ b/media/base/decoder_buffer.cc
@@ -75,7 +75,9 @@ DecoderBuffer::DecoderBuffer(DemuxerStream::Type type,
     return;
   }
 
-  s_allocator->Write(allocator_data_->handle, data, size);
+  if (size > 0) {
+    s_allocator->Write(allocator_data_->handle, data, size);
+  }
 }
 
 DecoderBuffer::DecoderBuffer(DemuxerStream::Type type,
@@ -108,7 +110,7 @@ DecoderBuffer::DecoderBuffer(DemuxerStream::Type type, size_t size)
         if (size == 0) {
           return std::nullopt;
         }
-        DCHECK(s_allocator);
+        CHECK(s_allocator);
         DCHECK_EQ(s_allocator->GetBufferPadding(), 0);
         return AllocatorData(type,
                              s_allocator->Allocate(

--- a/media/base/decoder_buffer.h
+++ b/media/base/decoder_buffer.h
@@ -412,18 +412,23 @@ class MEDIA_EXPORT DecoderBuffer
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   struct AllocatorData {
+    AllocatorData(DemuxerStream::Type type, Allocator::Handle handle, size_t size)
+        : stream_type_(type), handle(handle), size(size) {}
+
     DemuxerStream::Type stream_type_ = DemuxerStream::UNKNOWN;
     Allocator::Handle handle = Allocator::kInvalidHandle;
     size_t size = 0;
   };
   // Encoded data, allocated from DecoderBuffer::Allocator.
-  std::optional<AllocatorData> allocator_data_;
+  const std::optional<AllocatorData> allocator_data_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Encoded data, if it is stored on the heap.
-  base::HeapArray<uint8_t> data_;
+  const base::HeapArray<uint8_t> data_;
 
  private:
+  DecoderBuffer(DemuxerStream::Type type, size_t size);
+
   // ***************************************************************************
   // WARNING: This is a highly allocated object. Care should be taken when
   // adding any fields to make sure they are absolutely necessary. If a field
@@ -450,10 +455,6 @@ class MEDIA_EXPORT DecoderBuffer
 
   // Whether the buffer represent the end of stream.
   const bool is_end_of_stream_ : 1 = false;
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  void Initialize(DemuxerStream::Type type, size_t size);
-#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 }  // namespace media

--- a/media/base/decoder_buffer.h
+++ b/media/base/decoder_buffer.h
@@ -242,7 +242,7 @@ class MEDIA_EXPORT DecoderBuffer
   size_t size() const {
     DCHECK(!end_of_stream());
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-    return size_;
+    return allocator_data_ ? allocator_data_->size : 0u;
 #else // BUILDFLAG(USE_STARBOARD_MEDIA)
     return external_memory_ ? external_memory_->Span().size() : data_.size();
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
@@ -278,7 +278,7 @@ class MEDIA_EXPORT DecoderBuffer
 
   bool empty() const {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-    return size_ == 0u;
+    return !allocator_data_ || allocator_data_->size == 0u;
 #else   // BUILDFLAG(USE_STARBOARD_MEDIA)
     return external_memory_ ? external_memory_->Span().empty() : data_.empty();
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
@@ -418,7 +418,6 @@ class MEDIA_EXPORT DecoderBuffer
   };
   // Encoded data, allocated from DecoderBuffer::Allocator.
   std::optional<AllocatorData> allocator_data_;
-  size_t size_ = 0;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Encoded data, if it is stored on the heap.
@@ -453,7 +452,7 @@ class MEDIA_EXPORT DecoderBuffer
   const bool is_end_of_stream_ : 1 = false;
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  void Initialize(DemuxerStream::Type type);
+  void Initialize(DemuxerStream::Type type, size_t size);
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 


### PR DESCRIPTION
Removes the redundant size_ field in DecoderBuffer for Starboard builds. The size is already tracked within allocator_data_.

This cleanup is done because #10188  removed the `shrink_to` method, which was the only reason size_ needed to be mutable and separate from the initial allocation size.

Bug: 414009070