### PR TITLE
starboard/tests: wire views_examples_unittests target

### DIFF
--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -16,7 +16,6 @@
     ],
     "TODO(b/486053350): Crashes on missing SbEventHandle": [
       "compositor:compositor_unittests_loader",
-      "examples:views_examples_unittests_loader",
       "gl:gl_unittests_loader",
       "gl:ozone_gl_unittests_loader",
       "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
@@ -91,5 +90,9 @@
     "executable": "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py",
     "runs_on": "device",
     "test_type": "gtest"
+  },
+  {
+    "target": "ui/views/examples:views_examples_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py"
   }
 ]

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/views_examples_unittests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/views_examples_unittests_loader_filter.json
@@ -1,0 +1,6 @@
+{
+  "comment": "TODO(b/509862973): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+  "failing_tests": [
+    "*"
+  ]
+}

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -377,9 +377,15 @@ group("loader_app_rdk_plugin") {
 }
 
 if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
-  target("shared_library", "loader_app") {
-    output_dir = root_build_dir
-    deps = [ "//starboard/loader_app:loader_app_sources" ]
-    data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+  if (starboard_level_final_executable_type == "shared_library") {
+    group("loader_app") {
+      deps = [ "//starboard/loader_app:loader_app" ]
+    }
+  } else {
+    target("shared_library", "loader_app") {
+      output_dir = root_build_dir
+      deps = [ "//starboard/loader_app:loader_app_sources" ]
+      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+    }
   }
 }


### PR DESCRIPTION
Split per target for easier review.

Includes:
- target-specific Starboard wiring commit(s)
- target-specific CI commit that enables target resolution and adds that same target to disabled in the same commit

Bug: 486053350