### PR TITLE
starboard/tests: wire opus_tests target

### DIFF
--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -19,7 +19,6 @@
       "gl:gl_unittests_loader",
       "gl:ozone_gl_unittests_loader",
       "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
-      "third_party/boringssl:boringssl_pki_tests_loader",
       "third_party/ipcz/src:ipcz_tests_loader",
       "third_party/opus:opus_tests_loader",
       "third_party/opus:test_opus_decode_loader",
@@ -94,5 +93,9 @@
   {
     "target": "ui/views/examples:views_examples_unittests_loader",
     "executable": "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_pki_tests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/boringssl_pki_tests_loader.py"
   }
 ]

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -19,7 +19,6 @@
       "gl:ozone_gl_unittests_loader",
       "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
       "third_party/ipcz/src:ipcz_tests_loader",
-      "third_party/opus:opus_tests_loader",
       "third_party/opus:test_opus_decode_loader",
       "third_party/opus:test_opus_encode_loader",
       "third_party/opus:test_opus_padding_loader"
@@ -100,5 +99,9 @@
   {
     "target": "ui/compositor:compositor_unittests_loader",
     "executable": "out/evergreen-arm-hardfp-rdk_devel/compositor_unittests_loader.py"
+  },
+  {
+    "target": "third_party/opus:opus_tests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/opus_tests_loader.py"
   }
 ]

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -16,7 +16,6 @@
     ],
     "TODO(b/486053350): Crashes on missing SbEventHandle": [
       "compositor:compositor_unittests_loader",
-      "examples:views_examples_unittests_loader",
       "gl:gl_unittests_loader",
       "gl:ozone_gl_unittests_loader",
       "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
@@ -91,5 +90,9 @@
     "executable": "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py",
     "runs_on": "device",
     "test_type": "gtest"
+  },
+  {
+    "target": "ui/views/examples:views_examples_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/views_examples_unittests_loader.py"
   }
 ]

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -15,7 +15,6 @@
       "third_party/zlib:zlib_unittests_loader"
     ],
     "TODO(b/486053350): Crashes on missing SbEventHandle": [
-      "compositor:compositor_unittests_loader",
       "gl:gl_unittests_loader",
       "gl:ozone_gl_unittests_loader",
       "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
@@ -97,5 +96,9 @@
   {
     "target": "third_party/boringssl:boringssl_pki_tests_loader",
     "executable": "out/evergreen-arm-hardfp-rdk_devel/boringssl_pki_tests_loader.py"
+  },
+  {
+    "target": "ui/compositor:compositor_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/compositor_unittests_loader.py"
   }
 ]

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/boringssl_pki_tests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/boringssl_pki_tests_loader_filter.json
@@ -1,0 +1,6 @@
+{
+  "comment": "TODO(b/509955465): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+  "failing_tests": [
+    "*"
+  ]
+}

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/compositor_unittests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/compositor_unittests_loader_filter.json
@@ -1,0 +1,6 @@
+{
+  "comment": "TODO(b/509842815): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+  "failing_tests": [
+    "*"
+  ]
+}

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/opus_tests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/opus_tests_loader_filter.json
@@ -1,0 +1,9 @@
+{
+  "comment": [
+    "TODO(b/509842816): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+    "See the TODO comment in cobalt/testing/filters/evergreen-arm-hardfp-rdk/cc_unittests_loader_filter.json"
+  ],
+  "failing_tests": [
+    "*"
+  ]
+}

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/views_examples_unittests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/views_examples_unittests_loader_filter.json
@@ -1,0 +1,6 @@
+{
+  "comment": "TODO(b/509862973): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+  "failing_tests": [
+    "*"
+  ]
+}

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -377,9 +377,15 @@ group("loader_app_rdk_plugin") {
 }
 
 if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
-  target("shared_library", "loader_app") {
-    output_dir = root_build_dir
-    deps = [ "//starboard/loader_app:loader_app_sources" ]
-    data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+  if (starboard_level_final_executable_type == "shared_library") {
+    group("loader_app") {
+      deps = [ "//starboard/loader_app:loader_app" ]
+    }
+  } else {
+    target("shared_library", "loader_app") {
+      output_dir = root_build_dir
+      deps = [ "//starboard/loader_app:loader_app_sources" ]
+      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+    }
   }
 }

--- a/third_party/boringssl/BUILD.gn
+++ b/third_party/boringssl/BUILD.gn
@@ -284,7 +284,11 @@ if (build_with_chromium) {
 
     # Chromium infrastructure does not support GTest, only the //base wrapper.
     sources -= [ "src/crypto/test/gtest_main.cc" ]
-    sources += [ "gtest_main_chromium.cc" ]
+    if (is_cobalt_hermetic_build) {
+      sources += [ "starboard/gtest_main_chromium.cc" ]
+    } else {
+      sources += [ "gtest_main_chromium.cc" ]
+    }
     deps += [ "//base/test:test_support" ]
   }
 

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -517,6 +517,12 @@ executable("opus_demo") {
   ]
 }
 
+if (is_starboard) {
+  source_set("sbeventhandle_opus_tests") {
+    sources = [ "starboard/sbeventhandle_opus_tests.cc" ]
+  }
+}
+
 test("test_opus_api") {
   sources = [ "src/tests/test_opus_api.c" ]
 

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -534,6 +534,9 @@ test("test_opus_api") {
   ]
 
   deps = [ ":opus" ]
+  if (is_starboard) {
+    deps += [ ":sbeventhandle_opus_tests" ]
+  }
 }
 
 test("test_opus_encode") {

--- a/third_party/opus/starboard/sbeventhandle_opus_tests.cc
+++ b/third_party/opus/starboard/sbeventhandle_opus_tests.cc
@@ -1,0 +1,30 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/client_porting/wrap_main/wrap_main.h"
+
+int main(int argc, char** argv);
+
+namespace {
+
+int RunMainWithoutLoaderArgs(int argc, char** argv) {
+  char fallback_name[] = "opus_test";
+  char* filtered_argv[] = {(argc > 0 && argv && argv[0]) ? argv[0] : fallback_name,
+                           nullptr};
+  return main(1, filtered_argv);
+}
+
+}  // namespace
+
+SB_EXPORT STARBOARD_WRAP_SIMPLE_MAIN(RunMainWithoutLoaderArgs)


### PR DESCRIPTION
Split per target for easier review.

Includes:
- target-specific Starboard wiring commit(s)
- target-specific CI commit that enables target resolution and adds that same target to disabled in the same commit

Bug: 486053350