### PR TITLE
starboard/tests: wire test_opus_decode target

### DIFF
--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -19,7 +19,6 @@
       "gl:ozone_gl_unittests_loader",
       "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
       "third_party/ipcz/src:ipcz_tests_loader",
-      "third_party/opus:test_opus_decode_loader",
       "third_party/opus:test_opus_padding_loader"
     ]
   },
@@ -106,5 +105,9 @@
   {
     "target": "third_party/opus:test_opus_encode_loader",
     "executable": "out/evergreen-arm-hardfp-rdk_devel/test_opus_encode_loader.py"
+  },
+  {
+    "target": "third_party/opus:test_opus_decode_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/test_opus_decode_loader.py"
   }
 ]

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -20,7 +20,6 @@
       "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
       "third_party/ipcz/src:ipcz_tests_loader",
       "third_party/opus:test_opus_decode_loader",
-      "third_party/opus:test_opus_encode_loader",
       "third_party/opus:test_opus_padding_loader"
     ]
   },
@@ -103,5 +102,9 @@
   {
     "target": "third_party/opus:opus_tests_loader",
     "executable": "out/evergreen-arm-hardfp-rdk_devel/opus_tests_loader.py"
+  },
+  {
+    "target": "third_party/opus:test_opus_encode_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/test_opus_encode_loader.py"
   }
 ]

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/test_opus_decode_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/test_opus_decode_loader_filter.json
@@ -1,0 +1,9 @@
+{
+  "comment": [
+    "TODO(b/509842816): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+    "See the TODO comment in cobalt/testing/filters/evergreen-arm-hardfp-rdk/cc_unittests_loader_filter.json"
+  ],
+  "failing_tests": [
+    "*"
+  ]
+}

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/test_opus_encode_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/test_opus_encode_loader_filter.json
@@ -1,0 +1,9 @@
+{
+  "comment": [
+    "TODO(b/509842816): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+    "See the TODO comment in cobalt/testing/filters/evergreen-arm-hardfp-rdk/cc_unittests_loader_filter.json"
+  ],
+  "failing_tests": [
+    "*"
+  ]
+}

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -552,6 +552,9 @@ test("test_opus_encode") {
   ]
 
   deps = [ ":opus" ]
+  if (is_starboard) {
+    deps += [ ":sbeventhandle_opus_tests" ]
+  }
 }
 
 test("test_opus_decode") {

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -568,6 +568,9 @@ test("test_opus_decode") {
   ]
 
   deps = [ ":opus" ]
+  if (is_starboard) {
+    deps += [ ":sbeventhandle_opus_tests" ]
+  }
 }
 
 test("test_opus_padding") {


### PR DESCRIPTION
Split per target for easier review.

Includes:
- target-specific Starboard wiring commit(s)
- target-specific CI commit that enables target resolution and adds that same target to disabled in the same commit

Bug: 486053350