### PR TITLE
starboard/tests: wire test_opus_padding target

### DIFF
--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -18,8 +18,7 @@
       "gl:gl_unittests_loader",
       "gl:ozone_gl_unittests_loader",
       "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
-      "third_party/ipcz/src:ipcz_tests_loader",
-      "third_party/opus:test_opus_padding_loader"
+      "third_party/ipcz/src:ipcz_tests_loader"
     ]
   },
   {
@@ -109,5 +108,9 @@
   {
     "target": "third_party/opus:test_opus_decode_loader",
     "executable": "out/evergreen-arm-hardfp-rdk_devel/test_opus_decode_loader.py"
+  },
+  {
+    "target": "third_party/opus:test_opus_padding_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/test_opus_padding_loader.py"
   }
 ]

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/test_opus_padding_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/test_opus_padding_loader_filter.json
@@ -1,0 +1,9 @@
+{
+  "comment": [
+    "TODO(b/509842816): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+    "See the TODO comment in cobalt/testing/filters/evergreen-arm-hardfp-rdk/cc_unittests_loader_filter.json"
+  ],
+  "failing_tests": [
+    "*"
+  ]
+}

--- a/third_party/opus/BUILD.gn
+++ b/third_party/opus/BUILD.gn
@@ -583,6 +583,9 @@ test("test_opus_padding") {
   ]
 
   deps = [ ":opus" ]
+  if (is_starboard) {
+    deps += [ ":sbeventhandle_opus_tests" ]
+  }
 }
 
 # Not all checkouts have a //base directory.


### PR DESCRIPTION
Split per target for easier review.

Includes:
- target-specific Starboard wiring commit(s)
- target-specific CI commit that enables target resolution and adds that same target to disabled in the same commit

Bug: 486053350