### PR TITLE
aosp: Fix assumptions about Android

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -1039,15 +1039,19 @@ component("base") {
     ]
   }
 
-  if ((is_linux && !is_starboard) || is_chromeos || is_android) {
+  if (is_linux || is_chromeos || is_android) {
     sources += [
       "files/file_path_watcher_inotify.cc",
       "files/file_path_watcher_inotify.h",
     ]
-  } else if (is_starboard) {
-    sources += [
-      "files/file_path_watcher_stub.cc",
-    ]
+
+    if (is_starboard) {
+      sources -= [
+        "files/file_path_watcher_inotify.cc",
+        "files/file_path_watcher_inotify.h",
+      ]
+      sources += [ "files/file_path_watcher_stub.cc" ]
+    }
   }
 
   all_dependent_configs = []

--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -2628,26 +2628,6 @@ source_set("browser") {
       "//third_party/blink/public/mojom:memory_usage_monitor_linux_mojo_bindings",
     ]
   }
-  if (is_cobalt_hermetic_build) {
-    sources -= [
-      "child_process_launcher_helper_linux.cc",
-      "font_access/font_enumeration_data_source_linux.cc",
-      "font_access/font_enumeration_data_source_linux.h",
-      "font_service.cc",
-      "font_service.h",
-      "sandbox_host_linux.cc",
-      "sandbox_host_linux.h",
-      "sandbox_ipc_linux.cc",
-      "sandbox_ipc_linux.h",
-      "zygote_host/zygote_host_impl_linux.cc",
-      "zygote_host/zygote_host_impl_linux.h",
-    ]
-    sources += [
-      "child_process_launcher_helper_starboard.cc",
-    ]
-    public_deps -= [ "//components/services/font/public/mojom" ]
-    deps -= [ "//components/services/font:lib" ]
-  }
 
   if (is_win) {
     deps += [
@@ -3607,6 +3587,32 @@ source_set("browser") {
       "//media/mojo/mojom:speech_recognition",
       "//ui/base",
     ]
+  }
+
+  if (is_cobalt_hermetic_build) {
+    sources += [ "child_process_launcher_helper_starboard.cc" ]
+
+    if (is_android) {
+      sources -= [ "child_process_launcher_helper_android.cc" ]
+    }
+
+    if (is_linux) {
+      sources -= [
+        "child_process_launcher_helper_linux.cc",
+        "font_access/font_enumeration_data_source_linux.cc",
+        "font_access/font_enumeration_data_source_linux.h",
+        "font_service.cc",
+        "font_service.h",
+        "sandbox_host_linux.cc",
+        "sandbox_host_linux.h",
+        "sandbox_ipc_linux.cc",
+        "sandbox_ipc_linux.h",
+        "zygote_host/zygote_host_impl_linux.cc",
+        "zygote_host/zygote_host_impl_linux.h",
+      ]
+      public_deps -= [ "//components/services/font/public/mojom" ]
+      deps -= [ "//components/services/font:lib" ]
+    }
   }
 
   if (enable_devtools_frontend) {

--- a/device/bluetooth/BUILD.gn
+++ b/device/bluetooth/BUILD.gn
@@ -64,7 +64,7 @@ source_set("deprecated_experimental_mojo") {
   }
 
   # TODO: b/384652502 - Cobalt: Fix linker errors.
-  if (is_starboard) {
+  if (is_starboard && (is_chromeos || is_linux)) {
     sources -= [
       "bluez/metrics_recorder.cc",
       "bluez/metrics_recorder.h",


### PR DESCRIPTION
`is_starboard` and `is_cobalt_hermetic_build` are false on AndroidTV. In AOSP builds, they are true. Fix some BUILD.gn files that didn't take this into accout.

Bug: 495203133