### PR TITLE
tvOS: Rename some deprecated app lifecycle functions in main.mm

### DIFF
--- a/cobalt/app/tvos/main.mm
+++ b/cobalt/app/tvos/main.mm
@@ -184,12 +184,12 @@ static const char** g_argv = nullptr;
 }
 
 - (BOOL)application:(UIApplication*)application
-    shouldSaveApplicationState:(NSCoder*)coder {
+    shouldSaveSecureApplicationState:(NSCoder*)coder {
   return YES;
 }
 
 - (BOOL)application:(UIApplication*)application
-    shouldRestoreApplicationState:(NSCoder*)coder {
+    shouldRestoreSecureApplicationState:(NSCoder*)coder {
   // TODO(crbug.com/710329): Make this value configurable in the settings.
   return YES;
 }


### PR DESCRIPTION
Essentially port https://crrev.com/c/1140177 to Cobalt by renaming some deprecated functions to their newer counterparts.

Bug: 506073148