### PR TITLE
android: Use Lowercase for AndroidOverlay switch

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -77,6 +77,7 @@ public abstract class CobaltActivity extends Activity {
   private static final String META_DATA_ENABLE_SPLASH_SCREEN = "cobalt.ENABLE_SPLASH_SCREEN";
   private static final String META_DATA_ENABLE_FEATURES = "cobalt.ENABLE_FEATURES";
   private static final String YOUTUBE_URL = "https://www.youtube.com/tv";
+  private static final String COBALT_USING_ANDROID_OVERLAY = "cobalt-using-android-overlay";
 
   // This key differs in naming format for legacy reasons
   public static final String COMMAND_LINE_ARGS_KEY = "commandLineArgs";
@@ -113,7 +114,6 @@ public abstract class CobaltActivity extends Activity {
   private Boolean mIsKeepScreenOnEnabled = false;
 
   private boolean mIsCobaltUsingAndroidOverlay;
-  private static final String COBALT_USING_ANDROID_OVERLAY = "CobaltUsingAndroidOverlay";
 
   private boolean mEnableSplashScreen;
   private String mStartDeepLink;


### PR DESCRIPTION
Standardize the string used for the Cobalt Android overlay switch
to use lowercase and hyphens. This aligns with common naming
conventions for flags and properties, improving consistency and
readability across the codebase.

Issue: 505895356