### PR TITLE
ci: Add pre-commit folder to sparse checkout

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -43,6 +43,7 @@ jobs:
             .pre-commit-config.yaml
             .clang-format
             .pylintrc
+            cobalt/precommit
       - name: Sparse checkout changed files
         run: |
           git diff --name-only HEAD~1 HEAD | git sparse-checkout add --stdin


### PR DESCRIPTION
Include the cobalt/precommit directory in the sparse checkout for
the lint workflow. This ensures that pre-commit can locate dependencies
and successfully run the checks.

Bug: 503760354