### PR TITLE
media: Remove COBALT_MEDIA_ENABLE_IAMF_SUPPORT macro

### DIFF
--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -43,9 +43,6 @@ source_set("starboard") {
     # TODO(b/375218518): Revisit FormatSupportQueryMetrics
     "COBALT_MEDIA_ENABLE_FORMAT_SUPPORT_QUERY_METRICS=0",
 
-    # TODO(b/375232937): Enable IAMF
-    "COBALT_MEDIA_ENABLE_IAMF_SUPPORT=0",
-
     # TODO(b/326654546): Revisit max video input size
     "COBALT_MEDIA_ENABLE_PLAYER_SET_MAX_VIDEO_INPUT_SIZE=0",
 

--- a/media/starboard/starboard_utils.cc
+++ b/media/starboard/starboard_utils.cc
@@ -70,10 +70,8 @@ SbMediaAudioCodec MediaAudioCodecToSbMediaAudioCodec(AudioCodec codec) {
       return kSbMediaAudioCodecFlac;
     case AudioCodec::kPCM:
       return kSbMediaAudioCodecPcm;
-#if COBALT_MEDIA_ENABLE_IAMF_SUPPORT
     case AudioCodec::kIAMF:
       return kSbMediaAudioCodecIamf;
-#endif  // COBALT_MEDIA_ENABLE_IAMF_SUPPORT
     default:
       // Cobalt only supports a subset of audio codecs defined by Chromium.
       LOG(ERROR) << "Unsupported audio codec " << GetCodecName(codec);


### PR DESCRIPTION
Removes `COBALT_MEDIA_ENABLE_IAMF_SUPPORT`, now that Cobalt builds with Chromium m138. As there's no decoder support, IAMF playback may be tested using the stub audio decoder.

Bug: 375232937