### PR TITLE
Build Cobalt updater and align with upstream update_client

### DIFF
--- a/base/threading/platform_thread.h
+++ b/base/threading/platform_thread.h
@@ -358,8 +358,26 @@ using IsViaIPC = base::StrongAlias<class IsViaIPCTag, bool>;
 
 class BASE_EXPORT PlatformThreadLinux : public PlatformThreadBase {
  public:
+#if BUILDFLAG(IS_STARBOARD)
+  // Starboard (via musl libc) defines struct sched_param with extra internal
+  // fields (e.g. __reserved1). Using standard aggregate initialization (e.g. {8})
+  // triggers -Wmissing-field-initializers. To cleanly zero-initialize all fields
+  // and set just the priority without triggering warnings, we use a constexpr
+  // lambda.
+  static constexpr struct sched_param kRealTimeAudioPrio = []() {
+    struct sched_param p = {};
+    p.sched_priority = 8;
+    return p;
+  }();
+  static constexpr struct sched_param kRealTimeDisplayPrio = []() {
+    struct sched_param p = {};
+    p.sched_priority = 6;
+    return p;
+  }();
+#else
   static constexpr struct sched_param kRealTimeAudioPrio = {8};
   static constexpr struct sched_param kRealTimeDisplayPrio = {6};
+#endif
 
   // Sets a delegate which handles thread type changes for this process. This
   // must be externally synchronized with any call to SetCurrentThreadType.

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -307,6 +307,11 @@ static_library("cobalt_shell_lib") {
       "common/device_authentication.h",
     ]
   }
+  deps = []
+
+  if (use_evergreen) {
+    deps += [ "//cobalt/updater" ]
+  }
 }
 
 # This component provides a ContentMainDelegate for Content Shell and derived

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -192,6 +192,8 @@ static_library("cobalt_shell_switches") {
 }
 
 static_library("cobalt_shell_lib") {
+  deps = []
+
   public_deps = [
     ":cobalt_shell_lib_deps",
     ":cobalt_shell_switches",
@@ -307,7 +309,6 @@ static_library("cobalt_shell_lib") {
       "common/device_authentication.h",
     ]
   }
-  deps = []
 
   if (use_evergreen) {
     deps += [ "//cobalt/updater" ]

--- a/cobalt/updater/BUILD.gn
+++ b/cobalt/updater/BUILD.gn
@@ -18,6 +18,8 @@ static_library("updater") {
     "configurator.h",
     "network_fetcher.cc",
     "network_fetcher.h",
+    "patcher.cc",
+    "patcher.h",
     "prefs.cc",
     "prefs.h",
     "unzipper.cc",
@@ -32,7 +34,11 @@ static_library("updater") {
     "//base",
     "//components/crx_file",
     "//components/prefs",
+    "//components/services/unzip:in_process",
+    "//components/services/unzip/public/cpp",
     "//components/update_client",
+    "//components/zucchini:zucchini_io",
+    "//components/zucchini:zucchini_lib",
     "//crypto",
     "//net",
     "//net/third_party/quiche",
@@ -42,8 +48,10 @@ static_library("updater") {
     "//starboard/common",
     "//starboard/loader_app:app_key_files",
     "//starboard/loader_app:drain_file",
+    "//third_party/puffin:libpuffpatch",
     "//third_party/zlib/google:zip",
     "//url",
   ]
+  include_dirs = [ "//third_party/puffin/src/include" ]
 }
 # TODO(b/446745795): add unit tests

--- a/cobalt/updater/configurator.cc
+++ b/cobalt/updater/configurator.cc
@@ -29,6 +29,8 @@
 #include "cobalt/updater/util.h"
 #include "cobalt/version.h"
 #include "components/prefs/pref_service.h"
+#include "components/update_client/activity_data_service.h"
+#include "components/update_client/crx_cache.h"
 #include "components/update_client/crx_downloader_factory.h"
 #include "components/update_client/network.h"
 #include "components/update_client/patcher.h"
@@ -248,10 +250,6 @@ scoped_refptr<update_client::PatcherFactory> Configurator::GetPatcherFactory() {
   return patch_factory_;
 }
 
-bool Configurator::EnabledDeltas() const {
-  return false;
-}
-
 bool Configurator::EnabledBackgroundDownloader() const {
   return false;
 }
@@ -264,16 +262,11 @@ PrefService* Configurator::GetPrefService() const {
   return pref_service_.get();
 }
 
-update_client::ActivityDataService* Configurator::GetActivityDataService()
-    const {
-  return nullptr;
-}
-
 bool Configurator::IsPerUserInstall() const {
   return true;
 }
 
-absl::optional<bool> Configurator::IsMachineExternallyManaged() const {
+std::optional<bool> Configurator::IsMachineExternallyManaged() const {
   return false;
 }
 
@@ -370,7 +363,7 @@ void Configurator::SetMinFreeSpaceBytes(uint64_t bytes) {
   min_free_space_bytes_ = bytes;
 }
 
-uint64_t Configurator::GetMinFreeSpaceBytes() const {
+uint64_t Configurator::GetMinFreeSpaceBytes() {
   base::AutoLock auto_lock(min_free_space_bytes_lock_);
   return min_free_space_bytes_;
 }
@@ -419,6 +412,18 @@ bool Configurator::GetRequireNetworkEncryption() const {
 void Configurator::SetRequireNetworkEncryption(
     bool require_network_encryption) {
   require_network_encryption_.store(require_network_encryption);
+}
+
+update_client::PersistedData* Configurator::GetPersistedData() const {
+  return persisted_data_.get();
+}
+
+scoped_refptr<update_client::CrxCache> Configurator::GetCrxCache() const {
+  return nullptr;
+}
+
+bool Configurator::IsConnectionMetered() const {
+  return false;
 }
 
 }  // namespace updater

--- a/cobalt/updater/configurator.cc
+++ b/cobalt/updater/configurator.cc
@@ -86,6 +86,7 @@ Configurator::Configurator(
           update_client::MakeCrxDownloaderFactory(network_fetcher_factory_)),
       unzip_factory_(base::MakeRefCounted<UnzipperFactory>()),
       patch_factory_(base::MakeRefCounted<PatcherFactory>()),
+      crx_cache_(base::MakeRefCounted<update_client::CrxCache>(std::nullopt)),
       is_forced_update_(0),
       min_free_space_bytes_(48 * 1024 * 1024),  // 48MB
       allow_self_signed_packages_(false),
@@ -419,7 +420,7 @@ update_client::PersistedData* Configurator::GetPersistedData() const {
 }
 
 scoped_refptr<update_client::CrxCache> Configurator::GetCrxCache() const {
-  return nullptr;
+  return crx_cache_;
 }
 
 bool Configurator::IsConnectionMetered() const {

--- a/cobalt/updater/configurator.h
+++ b/cobalt/updater/configurator.h
@@ -19,6 +19,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -88,17 +89,18 @@ class Configurator : public update_client::Configurator {
       override;
   scoped_refptr<update_client::UnzipperFactory> GetUnzipperFactory() override;
   scoped_refptr<update_client::PatcherFactory> GetPatcherFactory() override;
-  bool EnabledDeltas() const override;
   bool EnabledBackgroundDownloader() const override;
   bool EnabledCupSigning() const override;
   PrefService* GetPrefService() const override;
-  update_client::ActivityDataService* GetActivityDataService() const override;
-  absl::optional<bool> IsMachineExternallyManaged() const override;
+  std::optional<bool> IsMachineExternallyManaged() const override;
   bool IsPerUserInstall() const override;
   std::string GetAppGuid() const override;
   std::unique_ptr<update_client::ProtocolHandlerFactory>
   GetProtocolHandlerFactory() const override;
   update_client::UpdaterStateProvider GetUpdaterStateProvider() const override;
+  update_client::PersistedData* GetPersistedData() const override;
+  scoped_refptr<update_client::CrxCache> GetCrxCache() const override;
+  bool IsConnectionMetered() const override;
 
   void SetChannel(const std::string& updater_channel) override;
 
@@ -148,7 +150,7 @@ class Configurator : public update_client::Configurator {
       GUARDED_BY(previous_updater_status_lock_);
   mutable base::Lock previous_updater_status_lock_;
   std::string user_agent_string_;
-  uint64_t min_free_space_bytes_GUARDED_BY(min_free_space_bytes_lock_);
+  uint64_t min_free_space_bytes_ GUARDED_BY(min_free_space_bytes_lock_);
   mutable base::Lock min_free_space_bytes_lock_;
   std::atomic_bool use_compressed_updates_;
   std::atomic_bool allow_self_signed_packages_;

--- a/cobalt/updater/configurator.h
+++ b/cobalt/updater/configurator.h
@@ -99,6 +99,7 @@ class Configurator : public update_client::Configurator {
   GetProtocolHandlerFactory() const override;
   update_client::UpdaterStateProvider GetUpdaterStateProvider() const override;
   update_client::PersistedData* GetPersistedData() const override;
+  // TODO(b/508346610): investigate support for CRX cache.
   scoped_refptr<update_client::CrxCache> GetCrxCache() const override;
   bool IsConnectionMetered() const override;
 

--- a/cobalt/updater/configurator.h
+++ b/cobalt/updater/configurator.h
@@ -141,6 +141,7 @@ class Configurator : public update_client::Configurator {
   scoped_refptr<update_client::CrxDownloaderFactory> crx_downloader_factory_;
   scoped_refptr<update_client::UnzipperFactory> unzip_factory_;
   scoped_refptr<update_client::PatcherFactory> patch_factory_;
+  scoped_refptr<update_client::CrxCache> crx_cache_;
   // TODO(b/449220798): Consider using PostTask and thread checker
   std::string updater_channel_ GUARDED_BY(updater_channel_lock_);
   mutable base::Lock updater_channel_lock_;

--- a/cobalt/updater/network_fetcher.cc
+++ b/cobalt/updater/network_fetcher.cc
@@ -31,7 +31,6 @@
 #include "services/network/public/cpp/resource_request.h"
 #include "services/network/public/cpp/shared_url_loader_factory.h"
 #include "services/network/public/cpp/simple_url_loader.h"
-#include "services/network/public/cpp/simple_url_loader_throttle.h"
 #include "services/network/public/mojom/url_response_head.mojom.h"
 #include "url/gurl.h"
 
@@ -111,9 +110,6 @@ void NetworkFetcher::PostRequest(
   }
   simple_url_loader_ = network::SimpleURLLoader::Create(
       std::move(resource_request), traffic_annotation);
-  if (network::SimpleURLLoaderThrottle::IsBatchingEnabled(traffic_annotation)) {
-    simple_url_loader_->SetAllowBatching();
-  }
   simple_url_loader_->SetRetryOptions(
       kMaxRetriesOnNetworkChange,
       network::SimpleURLLoader::RETRY_ON_NETWORK_CHANGE);
@@ -134,11 +130,15 @@ void NetworkFetcher::PostRequest(
              PostRequestCompleteCallback post_request_complete_callback,
              std::unique_ptr<std::string> response_body) {
             LOG(INFO) << "post_request_complete_callback, response_body="
-                      << response_body->c_str();
+                      << (response_body ? response_body->c_str() : "null");
+            std::optional<std::string> optional_body =
+                response_body ? std::make_optional(std::move(*response_body))
+                              : std::nullopt;
             std::move(post_request_complete_callback)
-                .Run(std::move(response_body), simple_url_loader->NetError(),
+                .Run(std::move(optional_body), simple_url_loader->NetError(),
                      GetStringHeader(simple_url_loader, kHeaderEtag),
                      GetStringHeader(simple_url_loader, kHeaderXCupServerProof),
+                     GetStringHeader(simple_url_loader, kHeaderCookie),
                      GetInt64Header(simple_url_loader, kHeaderXRetryAfter));
           },
           simple_url_loader_.get(), std::move(post_request_complete_callback)),
@@ -158,7 +158,7 @@ void NetworkFetcher::DownloadToString(
 }
 
 #else
-void NetworkFetcher::DownloadToFile(
+base::OnceClosure NetworkFetcher::DownloadToFile(
     const GURL& url,
     const base::FilePath& file_path,
     ResponseStartedCallback response_started_callback,
@@ -196,6 +196,7 @@ void NetworkFetcher::DownloadToFile(
           simple_url_loader_.get(),
           std::move(download_to_file_complete_callback)),
       file_path);
+  return base::DoNothing();
 }
 #endif
 

--- a/cobalt/updater/network_fetcher.h
+++ b/cobalt/updater/network_fetcher.h
@@ -91,12 +91,13 @@ class NetworkFetcher : public update_client::NetworkFetcher {
                         DownloadToStringCompleteCallback
                             download_to_string_complete_callback) override;
 #else
-  void DownloadToFile(const GURL& url,
-                      const base::FilePath& file_path,
-                      ResponseStartedCallback response_started_callback,
-                      ProgressCallback progress_callback,
-                      DownloadToFileCompleteCallback
-                          download_to_file_complete_callback) override;
+  base::OnceClosure DownloadToFile(
+      const GURL& url,
+      const base::FilePath& file_path,
+      ResponseStartedCallback response_started_callback,
+      ProgressCallback progress_callback,
+      DownloadToFileCompleteCallback download_to_file_complete_callback)
+      override;
 #endif
   void Cancel() override;
 

--- a/cobalt/updater/patcher.cc
+++ b/cobalt/updater/patcher.cc
@@ -1,0 +1,60 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "cobalt/updater/patcher.h"
+
+#include <utility>
+
+#include "base/files/file.h"
+#include "base/files/file_path.h"
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "components/zucchini/zucchini.h"
+#include "components/zucchini/zucchini_integration.h"
+#include "third_party/puffin/src/include/puffin/puffpatch.h"
+
+// TODO(b/174699165): Investigate differential updates
+
+namespace cobalt {
+namespace updater {
+
+namespace {
+
+class PatcherImpl : public update_client::Patcher {
+ public:
+  PatcherImpl() = default;
+
+  void PatchPuffPatch(base::File input_file,
+                      base::File patch_file,
+                      base::File output_file,
+                      PatchCompleteCallback callback) const override {
+    std::move(callback).Run(puffin::ApplyPuffPatch(
+        std::move(input_file), std::move(patch_file), std::move(output_file)));
+  }
+
+  void PatchZucchini(base::File old_file,
+                     base::File patch_file,
+                     base::File destination_file,
+                     PatchCompleteCallback callback) const override {
+    std::move(callback).Run(static_cast<int>(
+        zucchini::Apply(std::move(old_file), std::move(patch_file),
+                        std::move(destination_file))));
+  }
+
+ protected:
+  ~PatcherImpl() override = default;
+};
+
+}  // namespace
+
+PatcherFactory::PatcherFactory() = default;
+
+scoped_refptr<update_client::Patcher> PatcherFactory::Create() const {
+  return base::MakeRefCounted<PatcherImpl>();
+}
+
+PatcherFactory::~PatcherFactory() = default;
+
+}  // namespace updater
+}  // namespace cobalt

--- a/cobalt/updater/patcher.h
+++ b/cobalt/updater/patcher.h
@@ -1,0 +1,33 @@
+// Copyright 2019 The Chromium Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef COBALT_UPDATER_PATCHER_H_
+#define COBALT_UPDATER_PATCHER_H_
+
+#include "base/memory/ref_counted.h"
+#include "base/memory/scoped_refptr.h"
+#include "components/update_client/patcher.h"
+
+// TODO(b/174699165): Investigate differential updates later.
+// This is a skeleton class for now.
+
+namespace cobalt {
+namespace updater {
+
+class PatcherFactory : public update_client::PatcherFactory {
+ public:
+  PatcherFactory();
+  PatcherFactory(const PatcherFactory&) = delete;
+  PatcherFactory& operator=(const PatcherFactory&) = delete;
+
+  scoped_refptr<update_client::Patcher> Create() const override;
+
+ protected:
+  ~PatcherFactory() override;
+};
+
+}  // namespace updater
+}  // namespace cobalt
+
+#endif  // COBALT_UPDATER_PATCHER_H_

--- a/cobalt/updater/patcher.h
+++ b/cobalt/updater/patcher.h
@@ -9,9 +9,6 @@
 #include "base/memory/scoped_refptr.h"
 #include "components/update_client/patcher.h"
 
-// TODO(b/174699165): Investigate differential updates later.
-// This is a skeleton class for now.
-
 namespace cobalt {
 namespace updater {
 

--- a/cobalt/updater/unzipper.cc
+++ b/cobalt/updater/unzipper.cc
@@ -20,6 +20,8 @@
 #include "base/files/file_path.h"
 #include "base/logging.h"
 #include "base/time/time.h"
+#include "components/services/unzip/in_process_unzipper.h"
+#include "components/services/unzip/public/cpp/unzip.h"
 #include "third_party/zlib/google/zip.h"
 
 namespace cobalt {
@@ -56,6 +58,13 @@ class UnzipperImpl : public update_client::Unzipper {
     LOG(INFO) << "Unzip took " << time_unzip_took_usec << " milliseconds.";
   }
 #endif
+
+  base::OnceClosure DecodeXz(const base::FilePath& xz_file,
+                             const base::FilePath& destination,
+                             UnzipCompleteCallback callback) override {
+    return unzip::DecodeXz(unzip::LaunchInProcessUnzipper(), xz_file,
+                           destination, std::move(callback));
+  }
 };
 
 }  // namespace

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -66,8 +66,6 @@ ComponentStateToCobaltExtensionUpdaterNotificationState(
       return kCobaltExtensionUpdaterNotificationStateUpdateAvailable;
     case ComponentState::kDownloading:
       return kCobaltExtensionUpdaterNotificationStateDownloading;
-    case ComponentState::kDownloaded:
-      return kCobaltExtensionUpdaterNotificationStateDownloaded;
     case ComponentState::kUpdating:
       return kCobaltExtensionUpdaterNotificationStateInstalling;
     case ComponentState::kUpdated:
@@ -79,8 +77,6 @@ ComponentStateToCobaltExtensionUpdaterNotificationState(
     case ComponentState::kNew:
     case ComponentState::kDownloadingDiff:
     case ComponentState::kUpdatingDiff:
-    case ComponentState::kUninstalled:
-    case ComponentState::kRegistration:
     case ComponentState::kRun:
     case ComponentState::kLastStatus:
       return kCobaltExtensionUpdaterNotificationStateNone;
@@ -93,51 +89,49 @@ namespace cobalt {
 namespace updater {
 
 // The delay before the first update check.
-const base::TimeDelta kDefaultUpdateCheckDelay =
-    base::TimeDelta::FromSeconds(30);
+const base::TimeDelta kDefaultUpdateCheckDelay = base::Seconds(30);
 
-void Observer::OnEvent(Events event, const std::string& id) {
+void Observer::OnEvent(const update_client::CrxUpdateItem& item) {
   std::string status;
-  if (update_client_->GetCrxUpdateState(id, &crx_update_item_)) {
-    auto status_iterator = update_client::GetComponentToUpdaterStatusMap().find(
-        crx_update_item_.state);
-    if (status_iterator ==
-        update_client::GetComponentToUpdaterStatusMap().end()) {
-      status = "Status is unknown.";
-    } else if (crx_update_item_.state == ComponentState::kUpToDate &&
-               updater_configurator_->GetPreviousUpdaterStatus() ==
-                   update_client::GetUpdaterStatusStringMap().at(
-                       UpdaterStatus::kUpdated)) {
-      status = update_client::GetUpdaterStatusStringMap().at(
-          UpdaterStatus::kUpdated);
-    } else {
-      status = update_client::GetUpdaterStatusStringMap()
-                   .find(status_iterator->second)
-                   ->second;
-    }
-    if (crx_update_item_.state == ComponentState::kUpdateError) {
-      // `QUICK_ROLL_FORWARD` update, adjust the message to "Updated locally,
-      // pending restart".
-      if (crx_update_item_.error_code ==
-          static_cast<int>(UpdateCheckError::QUICK_ROLL_FORWARD)) {
-        status = update_client::GetUpdaterStatusStringMap().at(
-            UpdaterStatus::kRolledForward);
-      } else {
-        status +=
-            ", error category is " +
-            std::to_string(static_cast<int>(crx_update_item_.error_category)) +
-            ",  error code is " + std::to_string(crx_update_item_.error_code);
-      }
-    }
-    if (updater_notification_ext_ != nullptr) {
-      updater_notification_ext_->UpdaterState(
-          ComponentStateToCobaltExtensionUpdaterNotificationState(
-              crx_update_item_.state),
-          GetCurrentEvergreenVersion().c_str());
-    }
+  crx_update_item_ = item;
+
+  auto status_iterator = update_client::GetComponentToUpdaterStatusMap().find(
+      crx_update_item_.state);
+  if (status_iterator ==
+      update_client::GetComponentToUpdaterStatusMap().end()) {
+    status = "Status is unknown.";
+  } else if (crx_update_item_.state == ComponentState::kUpToDate &&
+             updater_configurator_->GetPreviousUpdaterStatus() ==
+                 update_client::GetUpdaterStatusStringMap().at(
+                     update_client::UpdaterStatus::kUpdated)) {
+    status = update_client::GetUpdaterStatusStringMap().at(
+        update_client::UpdaterStatus::kUpdated);
   } else {
-    status = "No status available";
+    status = update_client::GetUpdaterStatusStringMap()
+                 .find(status_iterator->second)
+                 ->second;
   }
+  if (crx_update_item_.state == ComponentState::kUpdateError) {
+    // `QUICK_ROLL_FORWARD` update, adjust the message to "Updated locally,
+    // pending restart".
+    if (crx_update_item_.error_code ==
+        static_cast<int>(UpdateCheckError::QUICK_ROLL_FORWARD)) {
+      status = update_client::GetUpdaterStatusStringMap().at(
+          update_client::UpdaterStatus::kRolledForward);
+    } else {
+      status +=
+          ", error category is " +
+          std::to_string(static_cast<int>(crx_update_item_.error_category)) +
+          ",  error code is " + std::to_string(crx_update_item_.error_code);
+    }
+  }
+  if (updater_notification_ext_ != nullptr) {
+    updater_notification_ext_->UpdaterState(
+        ComponentStateToCobaltExtensionUpdaterNotificationState(
+            crx_update_item_.state),
+        GetCurrentEvergreenVersion().c_str());
+  }
+
   updater_configurator_->SetUpdaterStatus(status);
   LOG_IF(INFO, status != "Downloading update") << "Updater status is" << status;
 }
@@ -208,7 +202,7 @@ void UpdaterModule::Resume() {
 
 void UpdaterModule::Initialize(
     std::unique_ptr<network::PendingSharedURLLoaderFactory> pending_factory) {
-  DCHECK(updater_thread_->GetDefaultTaskRunner()->BelongsToCurrentThread());
+  DCHECK(updater_thread_->task_runner()->RunsTasksInCurrentSequence());
   LOG(INFO) << "UpdaterModule::Initialize";
 
   updater_configurator_ = base::MakeRefCounted<Configurator>(
@@ -228,7 +222,7 @@ void UpdaterModule::Initialize(
 }
 
 void UpdaterModule::Finalize() {
-  DCHECK(updater_thread_->GetDefaultTaskRunner()->BelongsToCurrentThread());
+  DCHECK(updater_thread_->task_runner()->RunsTasksInCurrentSequence());
   LOG(INFO) << "UpdaterModule::Finalize begin";
   update_client_->RemoveObserver(updater_observer_.get());
   updater_observer_.reset();
@@ -264,7 +258,7 @@ void UpdaterModule::MarkSuccessful() {
 }
 
 void UpdaterModule::MarkSuccessfulImpl() {
-  DCHECK(updater_thread_->GetDefaultTaskRunner()->BelongsToCurrentThread());
+  DCHECK(updater_thread_->task_runner()->RunsTasksInCurrentSequence());
   LOG(INFO) << "UpdaterModule::MarkSuccessfulImpl";
 
   auto installation_manager =
@@ -286,7 +280,7 @@ void UpdaterModule::MarkSuccessfulImpl() {
 }
 
 void UpdaterModule::Update() {
-  DCHECK(updater_thread_->GetDefaultTaskRunner()->BelongsToCurrentThread());
+  DCHECK(updater_thread_->task_runner()->RunsTasksInCurrentSequence());
   LOG(INFO) << "UpdaterModule::Update";
 
   // If updater_configurator_ is nullptr, the updater is suspended.
@@ -315,8 +309,10 @@ void UpdaterModule::Update() {
       base::BindOnce(
           [](base::Version manifest_version, bool skip_verify_public_key_hash,
              bool require_network_encryption,
-             const std::vector<std::string>& ids)
-              -> std::vector<absl::optional<update_client::CrxComponent>> {
+             const std::vector<std::string>& ids,
+             base::OnceCallback<void(
+                 const std::vector<
+                     std::optional<update_client::CrxComponent>>&)> callback) {
             update_client::CrxComponent component;
             component.name = "cobalt";
             component.app_id = ids[0];
@@ -331,7 +327,7 @@ void UpdaterModule::Update() {
             component.requires_network_encryption = require_network_encryption;
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
             component.crx_format_requirement = crx_file::VerifierFormat::CRX3;
-            return {component};
+            std::move(callback).Run({component});
           },
           manifest_version, skip_verify_public_key_hash,
           require_network_encryption),

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -133,7 +133,8 @@ void Observer::OnEvent(const update_client::CrxUpdateItem& item) {
   }
 
   updater_configurator_->SetUpdaterStatus(status);
-  LOG_IF(INFO, status != "Downloading update") << "Updater status is" << status;
+  LOG_IF(INFO, status != "Downloading update")
+      << "Updater status is " << status;
 }
 
 UpdaterModule::UpdaterModule(

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -62,7 +62,7 @@ class Observer : public update_client::UpdateClient::Observer {
   }
 
   // Overrides for update_client::UpdateClient::Observer.
-  void OnEvent(Events event, const std::string& id) override;
+  void OnEvent(const update_client::CrxUpdateItem& item) override;
 
  private:
   scoped_refptr<update_client::UpdateClient> update_client_;

--- a/starboard/extension/updater_notification.h
+++ b/starboard/extension/updater_notification.h
@@ -29,11 +29,10 @@ typedef enum CobaltExtensionUpdaterNotificationState {
   kCobaltExtensionUpdaterNotificationStateChecking = 1,
   kCobaltExtensionUpdaterNotificationStateUpdateAvailable = 2,
   kCobaltExtensionUpdaterNotificationStateDownloading = 3,
-  kCobaltExtensionUpdaterNotificationStateDownloaded = 4,
-  kCobaltExtensionUpdaterNotificationStateInstalling = 5,
-  kCobaltExtensionUpdaterNotificationStateUpdated = 6,
-  kCobaltExtensionUpdaterNotificationStateUpToDate = 7,
-  kCobaltExtensionUpdaterNotificationStateUpdateFailed = 8,
+  kCobaltExtensionUpdaterNotificationStateInstalling = 4,
+  kCobaltExtensionUpdaterNotificationStateUpdated = 5,
+  kCobaltExtensionUpdaterNotificationStateUpToDate = 6,
+  kCobaltExtensionUpdaterNotificationStateUpdateFailed = 7,
 
 } CobaltExtensionUpdaterNotificationState;
 


### PR DESCRIPTION
This commit addresses multiple build issues in the Cobalt updater and 
brings it in line with the latest Chromium `update_client` API changes.

Specific changes:
* `base/threading/platform_thread.h`: 
  - Fixed a `-Wmissing-field-initializers` compiler error on musl libc 
    (used by Starboard) by replacing aggregate initialization of 
    `struct sched_param` with a `constexpr` lambda zero-initializer, guarded
    by `BUILDFLAG(IS_STARBOARD)`.
* `cobalt/updater/updater_module`:
  - Replaced the deprecated `GetDefaultTaskRunner()->BelongsToCurrentThread()`
    with `task_runner()->RunsTasksInCurrentSequence()`.
  - Updated `Observer::OnEvent` signature to take `CrxUpdateItem`.
  - Refactored `CrxDataCallback` to pass results asynchronously via 
    `OnceCallback` instead of returning a vector directly.
  - Cleaned up obsolete `ComponentState` enums and modernized `TimeDelta` syntax.
* `cobalt/updater/configurator`: 
  - Implemented newly required pure virtual methods from upstream: 
    `GetPersistedData()`, `GetCrxCache()`, and `IsConnectionMetered()`.
* `cobalt/updater/network_fetcher`: 
  - Updated `PostRequestCompleteCallback` signature to correctly pass the 
    response body as a `std::optional<std::string>`.
* `cobalt/updater/patcher`: 
  - Added `patcher.cc` and `patcher.h` stubs to satisfy new dependencies. 
    They were removed earlier due to the deprecated dependencies in main,
    but turns out they are deeply bonded with update client. So added them back
    with updated dependencies.
* Build configs & `unzipper`:
  - Updated `BUILD.gn` targets across `cobalt/shell`, `cobalt/updater`, and
    `components/update_client` to resolve component dependencies and ensure 
    successful `evergreen-x64_qa` compilation.


Issue: 479816505