### PR TITLE
android: Fix SbDecodeTarget memory corruption and GL crash during seek

### DIFF
--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -795,6 +795,11 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
 
       std::lock_guard lock(decode_target_mutex_);
       decode_target_ = decode_target;
+      // We manually call AddRef() here because `decode_target_` is stored as a
+      // raw pointer. This ensures Starboard claims its initial ownership of the
+      // target, preventing it from stealing Chromium's reference and deleting
+      // the texture prematurely during TeardownCodec().
+      decode_target_->AddRef();
     } break;
     case kSbPlayerOutputModeInvalid: {
       SB_NOTREACHED();


### PR DESCRIPTION
This commit fixes a severe Use-After-Free/Double-Free and GL_INVALID_OPERATION crash that occurred when seeking video on Android in Decode-to-Texture mode.

Root Cause:
In commit 1f79302 (b/327287075), SbDecodeTargetPrivate was refactored into an interface that inherits from RefCounted. However, the Android implementation (`MediaCodecVideoDecoder`) failed to claim its own initial reference count when creating the `DecodeTarget`.

Because Starboard's internal reference count initialized to 0, handing the target to Chromium (which increments the count to 1) meant Chromium held the ONLY active reference. When a seek occurred, Starboard's `TeardownCodec()` erroneously called `SbDecodeTargetRelease()`, instantly dropping the count from 1 to 0. This prematurely destroyed the decode target and its OpenGL textures out from under Chromium's active `SharedImage`.

This resulted in:
1. `GL_INVALID_OPERATION` when Chromium's compositor attempted to draw the deleted texture.
2. `partition_alloc::internal::FreelistCorruptionDetected` when Chromium eventually destroyed its `SharedImage` and attempted to release its reference to the already-deleted object.

Fix:
We explicitly call `AddRef()` immediately after creating the `DecodeTarget` in `InitializeCodec()`. This ensures Starboard correctly claims its own ownership reference (Initial Count = 1).
- When handed to Chromium, the count correctly increments to 2.
- During a seek, Starboard releases its own reference (Count drops to 1), keeping the texture safely alive for Chromium.
- Chromium releases its reference when the `SharedImage` goes out of scope (Count drops to 0), ensuring safe and correct destruction of the GL resources.

Issue: 506205547
Issue: 327287075