### PR TITLE
android: Support video frame VSP adjustment

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecFrameRateEstimator.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecFrameRateEstimator.java
@@ -90,7 +90,6 @@ public final class MediaCodecFrameRateEstimator {
     private static final int MINIMUM_REQUIRED_TUNNEL_FRAMES = 8;
     private static final long INVALID_FRAME_TIMESTAMP = -1;
     private final long[] mSortedTimestampsUs = new long[WINDOW_SIZE];
-    private long mMinDeltaUs = INVALID_FRAME_TIMESTAMP;
     private int mCount = 0;
 
     @Override
@@ -99,25 +98,16 @@ public final class MediaCodecFrameRateEstimator {
         return INVALID_FRAME_RATE;
       }
 
-      if (mMinDeltaUs == INVALID_FRAME_TIMESTAMP) {
-        for (int i = 1; i < mCount; i++) {
-          long delta = mSortedTimestampsUs[i] - mSortedTimestampsUs[i - 1];
-          if (mMinDeltaUs == INVALID_FRAME_TIMESTAMP || delta < mMinDeltaUs) {
-            mMinDeltaUs = delta;
-          }
-        }
-      }
-
       int validTimestamps = 1;
+      long previousDelta = mSortedTimestampsUs[1] - mSortedTimestampsUs[0];
       for (; validTimestamps < mCount; validTimestamps++) {
         long delta =
             mSortedTimestampsUs[validTimestamps] - mSortedTimestampsUs[validTimestamps - 1];
-        if (delta < mMinDeltaUs) {
-          mMinDeltaUs = delta;
-        } else if (delta > 2 * mMinDeltaUs) {
+        if (delta > 1.5 * previousDelta) {
           // The delta is too large.
           break;
         }
+        previousDelta = delta;
       }
 
       if (validTimestamps < MINIMUM_REQUIRED_TUNNEL_FRAMES) {
@@ -134,7 +124,6 @@ public final class MediaCodecFrameRateEstimator {
     @Override
     public void reset() {
       mCount = 0;
-      mMinDeltaUs = INVALID_FRAME_TIMESTAMP;
       Arrays.fill(mSortedTimestampsUs, 0);
     }
 

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -81,6 +81,10 @@ class AudioRendererPassthrough : public AudioRenderer,
                               bool* is_eos_played,
                               bool* is_underflow,
                               double* playback_rate) override;
+  int64_t GetAudioWriteHead() override { return 0; }
+  int64_t AdjustTimestampToAudioClock(int64_t timestamp) override {
+    return timestamp;
+  }
 
  private:
   struct AudioTrackState {

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -70,8 +70,10 @@ bool UseLibopusDecoder(SbMediaAudioCodec codec,
 // This class allows us to force int16 sample type when tunnel mode is enabled.
 class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
  public:
-  explicit AudioRendererSinkAndroid(int tunnel_mode_audio_session_id = -1,
-                                    bool allow_audio_writing_on_pause = false)
+  explicit AudioRendererSinkAndroid(
+      int tunnel_mode_audio_session_id = -1,
+      bool allow_audio_writing_on_pause = false,
+      bool enable_video_renderer_vsp_adjustment = false)
       : AudioRendererSinkImpl(
             [=](int64_t start_media_time,
                 int channels,
@@ -96,14 +98,17 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
                   /*is_web_audio=*/false, allow_audio_writing_on_pause,
                   context);
             }),
-        tunnel_mode_audio_session_id_(tunnel_mode_audio_session_id) {}
+        tunnel_mode_audio_session_id_(tunnel_mode_audio_session_id),
+        enable_video_renderer_vsp_adjustment_(
+            enable_video_renderer_vsp_adjustment) {}
 
   bool AllowOverflowAudioSamples() const override {
     return tunnel_mode_audio_session_id_ != -1;
   }
 
   bool AllowDirectPlaybackRateSetting() const override {
-    return tunnel_mode_audio_session_id_ != -1;
+    return tunnel_mode_audio_session_id_ != -1 &&
+           !enable_video_renderer_vsp_adjustment_;
   }
 
   void GetAudioRendererParams(const AudioStreamInfo& audio_stream_info,
@@ -163,6 +168,7 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
   }
 
   const int tunnel_mode_audio_session_id_;
+  const bool enable_video_renderer_vsp_adjustment_;
 };
 
 class AudioRendererSinkCallbackStub : public AudioRendererSink::RenderCallback {
@@ -425,6 +431,11 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       SB_LOG_IF(INFO, allow_audio_writing_on_pause)
           << "allow_audio_writing_on_pause is set to true.";
 
+      const bool enable_video_renderer_vsp_adjustment =
+          experimental_features.enable_video_renderer_vsp_adjustment;
+      SB_LOG_IF(INFO, enable_video_renderer_vsp_adjustment)
+          << "enable_video_renderer_vsp_adjustment is set to true.";
+
       const bool force_platform_opus_decoder = force_platform_opus_decoder_;
       auto decoder_creator =
           [enable_flush_during_seek, force_platform_opus_decoder, job_queue](
@@ -455,7 +466,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
 
       components.audio.renderer_sink =
           std::make_unique<AudioRendererSinkAndroid>(
-              tunnel_mode_audio_session_id, allow_audio_writing_on_pause);
+              tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
+              enable_video_renderer_vsp_adjustment);
     }
 
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone) {
@@ -465,6 +477,13 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       SB_LOG_IF(INFO, max_video_input_size > 0)
           << "The maximum size in bytes of a buffer of data is "
           << max_video_input_size;
+
+      if (experimental_features.enable_video_renderer_vsp_adjustment &&
+          !experimental_features.allow_audio_writing_on_pause) {
+        return Failure(
+            "Video renderer vsp adjustment needs to be enabled with audio "
+            "writing on pause.");
+      }
 
       if (tunnel_mode_audio_session_id == -1) {
         force_secure_pipeline_under_tunnel_mode = false;

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -32,6 +32,7 @@ struct ExperimentalFeatures {
   bool disable_low_performance_sw_decoder = false;
   bool enable_av1_startup_optimization = false;
   bool enable_codec_output_checker = false;
+  bool enable_video_renderer_vsp_adjustment = false;
   bool flush_decoder_during_reset = false;
   bool reset_audio_decoder = false;
   bool skip_flush_on_decoder_teardown = false;

--- a/starboard/shared/starboard/player/filter/audio_frame_tracker.cc
+++ b/starboard/shared/starboard/player/filter/audio_frame_tracker.cc
@@ -15,6 +15,7 @@
 #include "starboard/shared/starboard/player/filter/audio_frame_tracker.h"
 
 #include <queue>
+#include <sstream>
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
@@ -25,8 +26,10 @@ namespace starboard {
 
 void AudioFrameTracker::Reset() {
   frame_records_.clear();
-  frames_played_adjusted_to_playback_rate_ = 0;
+  last_playback_rate_ = 1.0;
   overflowed_frames_ = 0;
+  current_original_frame_head_position_ = 0;
+  current_adjusted_frame_head_position_ = 0;
 }
 
 void AudioFrameTracker::AddFrames(int number_of_frames, double playback_rate) {
@@ -40,7 +43,8 @@ void AudioFrameTracker::AddFrames(int number_of_frames, double playback_rate) {
 
   if (frame_records_.empty() ||
       frame_records_.back().playback_rate != playback_rate) {
-    FrameRecord record = {number_of_frames, playback_rate};
+    FrameRecord record = {number_of_frames, 0 /* number_of_played_frames */,
+                          playback_rate};
     frame_records_.push_back(record);
   } else {
     frame_records_.back().number_of_frames += number_of_frames;
@@ -50,20 +54,40 @@ void AudioFrameTracker::AddFrames(int number_of_frames, double playback_rate) {
 void AudioFrameTracker::RecordPlayedFrames(int number_of_frames) {
   while (number_of_frames > 0 && !frame_records_.empty()) {
     FrameRecord& record = frame_records_.front();
-    if (record.number_of_frames > number_of_frames) {
-      frames_played_adjusted_to_playback_rate_ +=
-          static_cast<int>(number_of_frames * record.playback_rate);
-      record.number_of_frames -= number_of_frames;
+    int64_t unplayed_frames =
+        record.number_of_frames - record.number_of_played_frames;
+    if (unplayed_frames >= number_of_frames) {
+      record.number_of_played_frames += number_of_frames;
       number_of_frames = 0;
     } else {
-      number_of_frames -= record.number_of_frames;
-      frames_played_adjusted_to_playback_rate_ +=
-          static_cast<int>(record.number_of_frames * record.playback_rate);
+      number_of_frames -= unplayed_frames;
+      // Note that since |current_original_frame_head_position_| is an integer,
+      // multiplying by a non-integer |playback_rate| can lead to truncation
+      // errors. These small errors accumulate every time a record is removed,
+      // potentially leading to a slight drift in the original timeline over
+      // long periods of playback. Remove record after it's fully played to
+      // minimize that drift.
+      current_original_frame_head_position_ +=
+          record.number_of_frames * record.playback_rate;
+      current_adjusted_frame_head_position_ += record.number_of_frames;
       frame_records_.erase(frame_records_.begin());
     }
   }
-
   overflowed_frames_ += number_of_frames;
+}
+
+int64_t AudioFrameTracker::GetOverflowedFrames() const {
+  // Overflowed frames calculation uses last playback rate, so any playback rate
+  // change after audio end of stream is ignored.
+  return overflowed_frames_ * last_playback_rate_;
+}
+
+int64_t AudioFrameTracker::GetTotalOriginalFrames() const {
+  int64_t ret = current_original_frame_head_position_;
+  for (auto& record : frame_records_) {
+    ret += record.number_of_frames * record.playback_rate;
+  }
+  return ret;
 }
 
 int64_t AudioFrameTracker::GetFutureFramesPlayedAdjustedToPlaybackRate(
@@ -75,26 +99,86 @@ int64_t AudioFrameTracker::GetFutureFramesPlayedAdjustedToPlaybackRate(
     *playback_rate = last_playback_rate_;
   }
 
-  auto frames_played = frames_played_adjusted_to_playback_rate_;
+  int64_t frames_played = current_original_frame_head_position_;
   for (auto& record : frame_records_) {
     *playback_rate = record.playback_rate;
 
-    if (number_of_frames == 0) {
-      break;
-    }
-
-    if (record.number_of_frames > number_of_frames) {
-      frames_played +=
-          static_cast<int>(number_of_frames * record.playback_rate);
+    int64_t unplayed_frames =
+        record.number_of_frames - record.number_of_played_frames;
+    if (unplayed_frames >= number_of_frames) {
+      frames_played += (number_of_frames + record.number_of_played_frames) *
+                       record.playback_rate;
       number_of_frames = 0;
+      break;
     } else {
-      number_of_frames -= record.number_of_frames;
-      frames_played +=
-          static_cast<int>(record.number_of_frames * record.playback_rate);
+      frames_played += record.number_of_frames * record.playback_rate;
+      number_of_frames -= unplayed_frames;
+    }
+  }
+  return frames_played;
+}
+
+int64_t AudioFrameTracker::ConvertOriginalFramePositionToAdjustedFrames(
+    int64_t frame_position) const {
+  int64_t converted_position = current_adjusted_frame_head_position_;
+  int64_t number_of_frames =
+      frame_position - current_original_frame_head_position_;
+  if (number_of_frames <= 0) {
+    // We don't have records for past audio time, which should rarely happen. We
+    // use the playback rate of first record or last playback rate to give an
+    // estimation.
+    if (!frame_records_.empty()) {
+      converted_position +=
+          number_of_frames / frame_records_.front().playback_rate;
+    } else {
+      converted_position += number_of_frames / last_playback_rate_;
+    }
+  } else {
+    for (auto& record : frame_records_) {
+      if (number_of_frames == 0) {
+        break;
+      }
+      int64_t original_frames_in_record =
+          record.number_of_frames * record.playback_rate;
+      if (original_frames_in_record > number_of_frames) {
+        converted_position += number_of_frames / record.playback_rate;
+        number_of_frames = 0;
+      } else {
+        converted_position += record.number_of_frames;
+        number_of_frames -= original_frames_in_record;
+      }
     }
   }
 
-  return frames_played;
+  if (number_of_frames > 0) {
+    // The original frame position is out of audio record range. The video
+    // stream could be longer than audio stream. Use last playback rate to
+    // calculate adjusted frame position.
+    converted_position += number_of_frames / last_playback_rate_;
+  }
+
+  return converted_position;
 }
+
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+void AudioFrameTracker::DumpDebugInfo() const {
+  std::stringstream ss;
+  ss << "Dump AudioFrameTracker info: "
+     << "\n  last_playback_rate: " << last_playback_rate_
+     << "\n  overflowed_frames: " << overflowed_frames_
+     << "\n  current_original_frame_head_position: "
+     << current_original_frame_head_position_
+     << "\n  current_adjusted_frame_head_position: "
+     << current_adjusted_frame_head_position_;
+  for (size_t i = 0; i < frame_records_.size(); ++i) {
+    ss << "\n    record[" << i
+       << "]: number_of_frames=" << frame_records_[i].number_of_frames
+       << ", number_of_played_frames="
+       << frame_records_[i].number_of_played_frames
+       << ", playback_rate=" << frame_records_[i].playback_rate;
+  }
+  SB_LOG(INFO) << ss.str();
+}
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/audio_frame_tracker.h
+++ b/starboard/shared/starboard/player/filter/audio_frame_tracker.h
@@ -24,6 +24,7 @@
 
 namespace starboard {
 
+// TODO: b/507074472 - add tests for AudioFrameTracker
 // This class helps on tracking how many audio frames have been played with
 // playback rate taking into account.
 //
@@ -36,23 +37,43 @@ class AudioFrameTracker {
   void Reset();
   void AddFrames(int number_of_frames, double playback_rate);
   void RecordPlayedFrames(int number_of_frames);
+
+  int64_t GetOverflowedFrames() const;
+  int64_t GetTotalOriginalFrames() const;
+
+  // Calculates the adjusted frame position after |number_of_frames| additional
+  // frames have been played. |playback_rate| is set to the playback rate of
+  // the last frame played.
   int64_t GetFutureFramesPlayedAdjustedToPlaybackRate(
       int number_of_frames,
       double* playback_rate) const;
-  int64_t GetOverflowedFrames() const { return overflowed_frames_; }
+
+  // Converts a position in the original media timeline (in frames) to the
+  // adjusted timeline that accounts for playback rate changes.
+  int64_t ConvertOriginalFramePositionToAdjustedFrames(
+      int64_t frame_position) const;
+
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+  void DumpDebugInfo() const;
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
  private:
   struct FrameRecord {
-    int number_of_frames;
+    int64_t number_of_frames;
+    int64_t number_of_played_frames;
     double playback_rate;
   };
 
   // Usually there are very few elements, so std::vector<> is efficient enough.
   std::vector<FrameRecord> frame_records_;
-  int64_t frames_played_adjusted_to_playback_rate_ = 0;
   double last_playback_rate_ = 1.0;
-  // A record of overflowed frames.
   int64_t overflowed_frames_ = 0;
+
+  // Cumulative positions in the original and adjusted timelines, used to
+  // handle records that have been fully played and removed from
+  // |frame_records_|.
+  int64_t current_original_frame_head_position_ = 0;
+  int64_t current_adjusted_frame_head_position_ = 0;
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -15,6 +15,7 @@
 #include "starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h"
 
 #include <algorithm>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <utility>
@@ -340,9 +341,6 @@ int64_t AudioRendererPcm::GetCurrentMediaTime(bool* is_playing,
         audio_frame_tracker_.GetFutureFramesPlayedAdjustedToPlaybackRate(
             elapsed_frames, playback_rate);
     if (audio_renderer_sink_->AllowOverflowAudioSamples()) {
-      // A simple workaround to handle silence frames for tunnel mode player.
-      // |playback_rate| is ignored as tunnel mode doesn't support
-      // vsp.
       frames_played += audio_frame_tracker_.GetOverflowedFrames();
     }
     media_time =
@@ -380,6 +378,48 @@ int64_t AudioRendererPcm::GetCurrentMediaTime(bool* is_playing,
 #endif  // SB_LOG_MEDIA_TIME_STATS
 
   return media_time;
+}
+
+int64_t AudioRendererPcm::GetAudioWriteHead() {
+  SB_CHECK(BelongsToCurrentThread());
+
+  if (!audio_renderer_sink_->HasStarted()) {
+    return 0;
+  }
+
+  if (eos_state_ == kEOSSentToSink) {
+    return std::numeric_limits<int64_t>::max();
+  }
+
+  SB_CHECK(decoder_sample_rate_);
+  return seeking_to_time_ + audio_frame_tracker_.GetTotalOriginalFrames() *
+                                1'000'000LL / *decoder_sample_rate_;
+}
+
+int64_t AudioRendererPcm::AdjustTimestampToAudioClock(int64_t timestamp) {
+  SB_CHECK(BelongsToCurrentThread());
+
+  // No need to adjust inputs before seeking to time.
+  if (timestamp <= seeking_to_time_) {
+    return timestamp;
+  }
+
+  if (!audio_renderer_sink_->HasStarted()) {
+    return -1;
+  }
+  SB_CHECK(decoder_sample_rate_);
+
+  int64_t frame_position =
+      (timestamp - seeking_to_time_) * *decoder_sample_rate_ / 1'000'000LL;
+  int64_t adjusted_frame_position =
+      audio_frame_tracker_.ConvertOriginalFramePositionToAdjustedFrames(
+          frame_position);
+  if (adjusted_frame_position < 0) {
+    // Returning a negative value as an error code.
+    return adjusted_frame_position;
+  }
+  return seeking_to_time_ +
+         adjusted_frame_position * 1'000'000LL / *decoder_sample_rate_;
 }
 
 void AudioRendererPcm::GetSourceStatus(int* frames_in_buffer,

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -95,6 +95,8 @@ class AudioRendererPcm : public AudioRenderer,
                               bool* is_eos_played,
                               bool* is_underflow,
                               double* playback_rate) override;
+  int64_t GetAudioWriteHead() override;
+  int64_t AdjustTimestampToAudioClock(int64_t timestamp) override;
 
  private:
   enum EOSState {

--- a/starboard/shared/starboard/player/filter/media_time_provider.h
+++ b/starboard/shared/starboard/player/filter/media_time_provider.h
@@ -33,6 +33,16 @@ class MediaTimeProvider {
                                       bool* is_underflow,
                                       double* playback_rate) = 0;
 
+  // Returns the latest timestamp (in microseconds) that has been written to the
+  // audio sink. This can be used to synchronize video frame submission with the
+  // audio track.
+  virtual int64_t GetAudioWriteHead() = 0;
+
+  // Adjusts a given media |timestamp| (in microseconds) to the current audio
+  // clock. This is used to calculate the adjusted presentation time of a video
+  // frame when variable speed playback or other clock adjustments are active.
+  virtual int64_t AdjustTimestampToAudioClock(int64_t timestamp) = 0;
+
  protected:
   virtual ~MediaTimeProvider() {}
 };

--- a/starboard/shared/starboard/player/filter/media_time_provider_impl.h
+++ b/starboard/shared/starboard/player/filter/media_time_provider_impl.h
@@ -48,6 +48,10 @@ class MediaTimeProviderImpl : public MediaTimeProvider,
                               bool* is_eos_played,
                               bool* is_underflow,
                               double* playback_rate) override;
+  int64_t GetAudioWriteHead() override { return 0; }
+  int64_t AdjustTimestampToAudioClock(int64_t timestamp) override {
+    return timestamp;
+  }
 
  private:
   // When not NULL, |current_time| will be set to the current monotonic time

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -94,6 +94,7 @@ VideoRendererImpl::~VideoRendererImpl() {
   decoder_frames_.clear();
   sink_frames_.clear();
   number_of_frames_.store(0);
+  pending_input_buffers_.clear();
 
   decoder_.reset();
 }
@@ -119,6 +120,7 @@ void VideoRendererImpl::Initialize(const ErrorCB& error_cb,
 
 void VideoRendererImpl::WriteSamples(const InputBuffers& input_buffers) {
   SB_CHECK(BelongsToCurrentThread());
+  SB_CHECK(pending_input_buffers_.empty());
   SB_DCHECK(!input_buffers.empty());
   for (const auto& input_buffer : input_buffers) {
     SB_DCHECK(input_buffer);
@@ -143,21 +145,78 @@ void VideoRendererImpl::WriteSamples(const InputBuffers& input_buffers) {
 #endif  // SB_PLAYER_FILTER_ENABLE_STATE_CHECK
   }
 
-  SB_DCHECK(need_more_input_.load());
   need_more_input_.store(false);
 
-  input_buffers_sent_.fetch_add(static_cast<int32_t>(input_buffers.size()));
-  decoder_->WriteInputBuffers(input_buffers);
+  auto write_to_decoder = [&](const InputBuffers& buffers) {
+    input_buffers_sent_.fetch_add(static_cast<int32_t>(buffers.size()));
+    decoder_->WriteInputBuffers(buffers);
+  };
+
+  if (!experimental_features_.enable_video_renderer_vsp_adjustment ||
+      (!is_vsp_adjustment_enabled_ && seeking_)) {
+    write_to_decoder(input_buffers);
+    return;
+  }
+
+  // When the |enable_video_renderer_vsp_adjustment| feature is enabled and
+  // after playback is prerolled, we hold video frames until the audio head
+  // reaches their presentation time to ensure a smooth playback rate change.
+  int64_t audio_write_head = media_time_provider_->GetAudioWriteHead();
+  auto first_input_after_audio_head_it = input_buffers.end();
+  for (auto it = input_buffers.begin(); it != input_buffers.end(); ++it) {
+    if ((*it)->timestamp() > audio_write_head) {
+      first_input_after_audio_head_it = it;
+      break;
+    } else if (is_vsp_adjustment_enabled_) {
+      // Adjust timestamps of frames that will be sent to the decoder.
+      int64_t adjusted_timestamp =
+          media_time_provider_->AdjustTimestampToAudioClock((*it)->timestamp());
+      SB_CHECK_GE(adjusted_timestamp, 0)
+          << "Failed to adjust frame at " << (*it)->timestamp();
+      (*it)->SetTimestamp(adjusted_timestamp);
+    }
+  }
+
+  if (first_input_after_audio_head_it == input_buffers.end()) {
+    write_to_decoder(input_buffers);
+    return;
+  }
+
+  // Split the input buffers into those ready to be written and those that
+  // need to be delayed.
+  InputBuffers buffers_to_write(input_buffers.begin(),
+                                first_input_after_audio_head_it);
+  pending_input_buffers_.insert(pending_input_buffers_.end(),
+                                first_input_after_audio_head_it,
+                                input_buffers.end());
+  if (!buffers_to_write.empty()) {
+    write_to_decoder(buffers_to_write);
+  }
+  if (!pending_input_buffers_.empty()) {
+    // Check again in 5ms to see if more frames can be sent to the decoder.
+    const int64_t kWritePendingInputsDelay = 5'000;
+    Schedule(std::bind(&VideoRendererImpl::WritePendingInputs, this),
+             kWritePendingInputsDelay);
+  }
 }
 
 void VideoRendererImpl::WriteEndOfStream() {
   SB_CHECK(BelongsToCurrentThread());
 
-  SB_LOG_IF(WARNING, end_of_stream_written_.load())
-      << "Try to write EOS after EOS is reached";
-  if (end_of_stream_written_.load()) {
+  if (end_of_stream_written_.load() || pending_end_of_stream_) {
+    SB_LOG(WARNING) << "Try to write EOS after EOS is reached";
     return;
   }
+
+  if (!pending_input_buffers_.empty()) {
+    // If a playback only have a few video samples, WriteEndOfStream() might
+    // be called very early, even before audio is prerolled. When there're
+    // pending inputs, we need to write eos after all inputs are written into
+    // the decoder.
+    pending_end_of_stream_ = true;
+    return;
+  }
+
   end_of_stream_written_.store(true);
   if (!first_input_written_) {
     first_input_written_ = true;
@@ -185,6 +244,8 @@ void VideoRendererImpl::Seek(int64_t seek_to_time) {
   need_more_input_.store(true);
 
   CancelPendingJobs();
+  pending_input_buffers_.clear();
+  pending_end_of_stream_ = false;
 
   auto preroll_timeout = decoder_->GetPrerollTimeout();
   if (preroll_timeout != std::numeric_limits<int64_t>::max()) {
@@ -209,8 +270,21 @@ void VideoRendererImpl::SetPlaybackRate(double playback_rate) {
   SB_DCHECK(BelongsToCurrentThread());
   SB_DCHECK_GE(playback_rate, 0);
 
+  if (experimental_features_.enable_video_renderer_vsp_adjustment &&
+      playback_rate != 0.0 && playback_rate != 1.0) {
+    // Start vsp adjustment of video input presentation timepstamps in video
+    // renderer after we see a none 0.0x or 1.0x playback rate.
+    is_vsp_adjustment_enabled_ = true;
+  }
+
   if (sink_) {
-    sink_->SetPlaybackRate(playback_rate);
+    if (is_vsp_adjustment_enabled_) {
+      // Force video sink playback rate to be 0.0x or 1.0x when video renderer
+      // vsp adjustment is enabled.
+      sink_->SetPlaybackRate(playback_rate > 0 ? 1.0 : 0.0);
+    } else {
+      sink_->SetPlaybackRate(playback_rate);
+    }
   }
 }
 
@@ -219,7 +293,8 @@ bool VideoRendererImpl::CanAcceptMoreData() const {
   bool can_accept_more_data =
       number_of_frames_.load() <
           static_cast<int32_t>(decoder_->GetMaxNumberOfCachedFrames()) &&
-      !end_of_stream_written_.load() && need_more_input_.load();
+      !end_of_stream_written_.load() && need_more_input_.load() &&
+      pending_input_buffers_.empty() && !pending_end_of_stream_;
 #if SB_PLAYER_FILTER_ENABLE_STATE_CHECK
   if (can_accept_more_data) {
     last_can_accept_more_data = CurrentMonotonicTime();
@@ -406,6 +481,17 @@ void VideoRendererImpl::OnSeekTimeout() {
   } else if (seeking_.load()) {
     Schedule(std::bind(&VideoRendererImpl::OnSeekTimeout, this),
              kSeekTimeoutRetryInterval);
+  }
+}
+
+void VideoRendererImpl::WritePendingInputs() {
+  SB_CHECK(BelongsToCurrentThread());
+  InputBuffers input_buffers = std::move(pending_input_buffers_);
+  WriteSamples(input_buffers);
+  if (pending_end_of_stream_ && pending_input_buffers_.empty()) {
+    // All pending buffers have been sent to the decoder; now it's safe to
+    // send the end-of-stream signal.
+    WriteEndOfStream();
   }
 }
 

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -84,6 +84,7 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
                        const scoped_refptr<VideoFrame>& frame);
   void Render(VideoRendererSink::DrawFrameCB draw_frame_cb);
   void OnSeekTimeout();
+  void WritePendingInputs();
 
   MediaTimeProvider* const media_time_provider_;
   const std::unique_ptr<VideoRenderAlgorithm> algorithm_;
@@ -108,6 +109,13 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   std::atomic_bool seeking_{false};
   std::atomic<int32_t> input_buffers_sent_{0};
   int64_t seeking_to_time_ = 0;  // microseconds
+
+  // When experiment |enable_video_renderer_vsp_adjustment| is enabled and
+  // playabck rate is not 0.0x or 1.0x. Video renderer vsp adjustment will be
+  // enabled. Once it's enabled, it cannot be reset.
+  bool is_vsp_adjustment_enabled_ = false;
+  InputBuffers pending_input_buffers_;
+  bool pending_end_of_stream_ = false;
 
   // |number_of_frames_| = decoder_frames_.size() + sink_frames_.size()
   std::atomic<int32_t> number_of_frames_{0};

--- a/starboard/shared/starboard/player/input_buffer_internal.h
+++ b/starboard/shared/starboard/player/input_buffer_internal.h
@@ -65,7 +65,10 @@ class InputBuffer : public RefCountedThreadSafe<InputBuffer> {
   const SbDrmSampleInfo* drm_info() const {
     return has_drm_info_ ? &drm_info_ : NULL;
   }
+
+  // DO NOT use the set functions below except from drm system and renderers.
   void SetDecryptedContent(std::vector<uint8_t> decrypted_content);
+  void SetTimestamp(int64_t timestamp) { timestamp_ = timestamp; }
 
   friend std::ostream& operator<<(std::ostream& os, const InputBuffer& buffer);
 

--- a/starboard/tvos/shared/media/av_sample_buffer_synchronizer.h
+++ b/starboard/tvos/shared/media/av_sample_buffer_synchronizer.h
@@ -39,6 +39,10 @@ class AVSBSynchronizer : public MediaTimeProvider, private JobQueue::JobOwner {
                               bool* is_eos_played,
                               bool* is_underflow,
                               double* playback_rate) override;
+  int64_t GetAudioWriteHead() override { return 0; }
+  int64_t AdjustTimestampToAudioClock(int64_t timestamp) override {
+    return timestamp;
+  }
 
   void SetRenderer(AVSBAudioRenderer* audio_renderer);
   void SetRenderer(AVSBVideoRenderer* video_renderer);


### PR DESCRIPTION
This change introduces an experimental feature to support video frame
presentation timestamp (PTS) adjustment for varied speed playback (VSP).
Platforms that do not natively support direct video VSP can now rely on the
video renderer to synchronize video frames with the audio clock when playback
speeds deviate from 1.0x. This ensures smoother and more accurate playback.

Key changes include new MediaTimeProvider methods to expose audio clock
information and enable timestamp conversion, implemented in AudioRendererPcm
using a refactored AudioFrameTracker. The VideoRendererImpl now, when the
experimental flag is enabled, delays video frames and adjusts their PTS
based on the audio clock before submission. This allows the audio sink to
operate at a 1.0x playback rate while the video renderer manages the
effective VSP.

Bug: 454305379