### PR TITLE
Fix CobaltMetricsBrowserTest.RecordCpuMetrics

### DIFF
--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -221,6 +221,7 @@ IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
 IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest, MAYBE_RecordsCpuMetrics) {
   base::HistogramTester histogram_tester;
 
+  base::ScopedAllowBlockingForTesting allow_blocking;
   auto* features = GlobalFeatures::GetInstance();
   features->metrics_services_manager()->UpdateUploadPermissions(true);
 

--- a/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_browsertest.cc
@@ -213,7 +213,7 @@ IN_PROC_BROWSER_TEST_F(CobaltMetricsBrowserTest,
 
 // TODO: b/489836051 - Investigate periodic memory metrics recording failures on
 // Starboard.
-#if BUILDFLAG(IS_STARBOARD)
+#if BUILDFLAG(IS_STARBOARD) && !BUILDFLAG(IS_LINUX) && !BUILDFLAG(IS_ANDROID)
 #define MAYBE_RecordsCpuMetrics DISABLED_RecordsCpuMetrics
 #else
 #define MAYBE_RecordsCpuMetrics RecordsCpuMetrics


### PR DESCRIPTION
The CobaltMetricsBrowserTest.RecordsCpuMetrics test was failing or flaky
due to blocking operations on a thread where blocking is disallowed.
Introduce base::ScopedAllowBlockingForTesting to permit these operations,
ensuring the test can execute reliably without failures.

Bug: 507063989