### PR TITLE
android: Refactor surface reset and clearing

### DIFF
--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -152,10 +152,12 @@ class StarboardRendererWrapper
   mojo::Remote<ClientExtension> client_extension_remote_;
   cobalt::media::VideoGeometrySetterService* video_geometry_setter_service_;
   const base::UnguessableToken overlay_plane_id_;
-  StarboardRenderer renderer_;
   mojom::CommandBufferIdPtr command_buffer_id_;
   base::SequenceBound<StarboardGpuFactory> gpu_factory_;
   scoped_refptr<base::SingleThreadTaskRunner> gpu_task_runner_;
+  // |renderer_| must be declared after |gpu_task_runner_| as |renderer|'s dtor
+  // may make use of |gpu_task_runner_|.
+  StarboardRenderer renderer_;
 
   SbDecodeTargetGraphicsContextProvider
       decode_target_graphics_context_provider_ = {};

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -319,7 +319,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
                             : 0),
       skip_flush_on_decoder_teardown_(
           pipeline_config.experimental_features.skip_flush_on_decoder_teardown),
-      force_reset_surface_(platform_options.force_reset_surface),
+      force_clear_surface_(platform_options.force_clear_surface),
       needs_fps_to_initialize_codec_(
           video_codec_ == kSbMediaVideoCodecAv1 &&
           MediaCapabilitiesCache::GetInstance()->IsAv18kCappedAt30()),
@@ -395,13 +395,11 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
 
 MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {
   TeardownCodec();
-  if (tunnel_mode_audio_session_id_) {
-    // Forces video surface to reset after tunnel mode playbacks. This prevents
-    // video distortion on some platforms. For details, see http://b/182610842.
-    ClearVideoWindow(/*force_reset_surface=*/true);
-  } else {
-    ClearVideoWindow(force_reset_surface_);
-  }
+  // The video surface must be reset after tunnel mode playbacks. This prevents
+  // video distortion on some platforms. For details, see http://b/182610842.
+  bool force_clear =
+      !tunnel_mode_audio_session_id_.has_value() && force_clear_surface_;
+  CleanUpVideoWindow(force_clear, decode_target_graphics_context_provider_);
 }
 
 scoped_refptr<VideoRendererSink> MediaCodecVideoDecoder::GetSink() {

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -399,6 +399,8 @@ MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {
   // video distortion on some platforms. For details, see http://b/182610842.
   bool force_clear =
       !tunnel_mode_audio_session_id_.has_value() && force_clear_surface_;
+  // TODO: b/429021006 - Connect |decode_target_graphics_context_provider_| to
+  // H5VCC.
   CleanUpVideoWindow(force_clear, decode_target_graphics_context_provider_);
 }
 

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -78,7 +78,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   };
 
   struct PlatformOptions {
-    bool force_reset_surface = false;
+    bool force_clear_surface = false;
     bool force_big_endian_hdr_metadata = false;
     int64_t reset_delay_usec = 0;
     int64_t flush_delay_usec = 0;
@@ -200,8 +200,9 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   const int64_t flush_delay_usec_;
   const bool skip_flush_on_decoder_teardown_;
 
-  // Force resetting the video surface after every playback.
-  const bool force_reset_surface_;
+  // By default, we reset the surface view after every playback. This flag
+  // enables clearing the surface view, instead of resetting it.
+  const bool force_clear_surface_;
 
   // Codec initialization will be delayed until the decoder receives enough
   // inputs to estimate video fps when |needs_fps_to_initialize_codec_| is true.

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -584,8 +584,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     int64_t flush_delay_usec = features::kFlushDelayUsec.Get();
     int64_t reset_delay_usec = features::kResetDelayUsec.Get();
 
-    // The default value of |force_reset_surface| would be true.
-    bool force_reset_surface = true;
+    // TODO: b/429021006 - Connect this flag to H5VCC.
+    bool force_clear_surface = false;
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone &&
         !creation_parameters.video_mime().empty()) {
       // Use mime param to determine endianness of HDR metadata. If param is
@@ -597,11 +597,6 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
             video_mime_type->GetParamStringValue("hdrinfoendianness",
                                                  /*default=*/"little");
         force_big_endian_hdr_metadata = hdr_info_endianness == "big";
-      }
-      if (video_mime_type &&
-          video_mime_type->ValidateBoolParameter("forceresetsurface")) {
-        force_reset_surface =
-            video_mime_type->GetParamBoolValue("forceresetsurface", true);
       }
       if (video_mime_type &&
           video_mime_type->ValidateBoolParameter("enableflushduringseek")) {
@@ -645,7 +640,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
          creation_parameters.max_video_capabilities()},
         {tunnel_mode_audio_session_id, force_secure_pipeline_under_tunnel_mode},
         {max_video_input_size, enable_flush_during_seek, experimental_features},
-        {force_reset_surface, force_big_endian_hdr_metadata, reset_delay_usec,
+        {force_clear_surface, force_big_endian_hdr_metadata, reset_delay_usec,
          flush_delay_usec});
   }
 

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -47,6 +47,7 @@ ANativeWindow* g_native_video_window = NULL;
 VideoSurfaceHolder* g_video_surface_holder = NULL;
 // Global boolean to indicate if we need to reset SurfaceView after playing
 // vertical video.
+// TODO: b/521503666 - Revisit to see if we need this variable or not.
 bool g_reset_surface_on_clear_window = false;
 
 void ClearNativeWindow(void* raw_context) {
@@ -97,7 +98,7 @@ void ClearNativeWindow(void* raw_context) {
     }
   }
   if (surface == EGL_NO_SURFACE) {
-    SB_LOG(ERROR) << "Found no EGL surface in ClearVideoWindow";
+    SB_LOG(ERROR) << "Found no EGL surface in ClearNativeWindow";
     return;
   }
 
@@ -207,30 +208,26 @@ void VideoSurfaceHolder::CleanUpVideoWindow(
   std::lock_guard lock(*GetViewSurfaceMutex());
 
   if (!g_native_video_window) {
-    SB_LOG(INFO) << "Tried to clear video window when it was null.";
+    SB_LOG(INFO) << "Tried to clean up video window when it was null.";
     return;
   }
 
   JNIEnv* env = AttachCurrentThread();
   if (!env) {
-    SB_LOG(INFO) << "Tried to clear video window when JNIEnv was null.";
+    SB_LOG(INFO) << "Tried to clean up video window when JNIEnv was null.";
     return;
   }
 
   if (force_clear) {
-    if (!gpu_provider) {
-      SB_LOG(WARNING) << "gpu_provider is null in ClearVideoWindow, will force "
-                         "reset surface.";
-    } else {
-      gpu_provider->gles_context_runner(gpu_provider, &ClearNativeWindow,
-                                        g_native_video_window);
-      SB_LOG(INFO) << "Video surface has been cleared.";
-      return;
-    }
+    SB_CHECK(gpu_provider);
+    gpu_provider->gles_context_runner(gpu_provider, &ClearNativeWindow,
+                                      g_native_video_window);
+    SB_LOG(INFO) << "Video surface has been cleared.";
+    return;
   }
 
   StarboardBridge::GetInstance()->ResetVideoSurface(env);
-  SB_LOG(INFO) << "Video surface has been reset.";
+  SB_LOG(INFO) << "Video surface has been reset (default behavior).";
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -21,6 +21,7 @@
 #include <jni.h>
 
 #include <mutex>
+#include <vector>
 
 #include "cobalt/android/jni_headers/VideoSurfaceView_jni.h"
 #include "starboard/android/shared/starboard_bridge.h"
@@ -47,6 +48,89 @@ VideoSurfaceHolder* g_video_surface_holder = NULL;
 // Global boolean to indicate if we need to reset SurfaceView after playing
 // vertical video.
 bool g_reset_surface_on_clear_window = false;
+
+void ClearNativeWindow(void* raw_context) {
+  ANativeWindow* native_window = static_cast<ANativeWindow*>(raw_context);
+  EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
+  if (display == EGL_NO_DISPLAY) {
+    SB_LOG(ERROR) << "Found no EGL display in ClearNativeWindow";
+    return;
+  }
+
+  const EGLint kAttributeList[] = {
+      EGL_RED_SIZE,
+      8,
+      EGL_GREEN_SIZE,
+      8,
+      EGL_BLUE_SIZE,
+      8,
+      EGL_ALPHA_SIZE,
+      8,
+      EGL_RENDERABLE_TYPE,
+      EGL_OPENGL_ES2_BIT,
+      EGL_NONE,
+  };
+  // First, query how many configs match the given attribute list.
+  EGLint num_configs = 0;
+  EGL_CALL(eglChooseConfig(display, kAttributeList, NULL, 0, &num_configs));
+  if (num_configs == 0) {
+    SB_LOG(ERROR) << "No matching EGL configs found in ClearNativeWindow";
+    return;
+  }
+
+  // Allocate space to receive the matching configs and retrieve them.
+  std::vector<EGLConfig> configs(num_configs);
+  EGL_CALL(eglChooseConfig(display, kAttributeList, configs.data(), num_configs,
+                           &num_configs));
+  EGLNativeWindowType egl_native_window =
+      static_cast<EGLNativeWindowType>(native_window);
+  EGLConfig config;
+
+  // Find the first config that successfully allow a window surface to be
+  // created.
+  EGLSurface surface = EGL_NO_SURFACE;
+  for (int config_number = 0; config_number < num_configs; ++config_number) {
+    config = configs[config_number];
+    surface = eglCreateWindowSurface(display, config, egl_native_window, NULL);
+    if (surface != EGL_NO_SURFACE) {
+      break;
+    }
+  }
+  if (surface == EGL_NO_SURFACE) {
+    SB_LOG(ERROR) << "Found no EGL surface in ClearVideoWindow";
+    return;
+  }
+
+  // Create an OpenGL ES 2.0 context.
+  EGLContext context = EGL_NO_CONTEXT;
+  EGLint context_attrib_list[] = {
+      EGL_CONTEXT_CLIENT_VERSION,
+      2,
+      EGL_NONE,
+  };
+  context =
+      eglCreateContext(display, config, EGL_NO_CONTEXT, context_attrib_list);
+  if (context == EGL_NO_CONTEXT) {
+    SB_LOG(ERROR) << "Failed to create EGL context in ClearNativeWindow";
+    EGL_CALL(eglDestroySurface(display, surface));
+    return;
+  }
+
+  /* connect the context to the surface */
+  EGL_CALL(eglMakeCurrent(display, surface, surface, context));
+
+  GL_CALL(glClearColor(0, 0, 0, 1));
+  GL_CALL(glClear(GL_COLOR_BUFFER_BIT));
+  GL_CALL(glFlush());
+
+  EGL_CALL(eglSwapBuffers(display, surface));
+
+  // Cleanup all used resources.
+  EGL_CALL(
+      eglMakeCurrent(display, EGL_NO_SURFACE, EGL_NO_SURFACE, EGL_NO_CONTEXT));
+  EGL_CALL(eglDestroyContext(display, context));
+  EGL_CALL(eglDestroySurface(display, surface));
+}
 
 }  // namespace
 
@@ -115,7 +199,9 @@ bool VideoSurfaceHolder::GetVideoWindowSize(int* width, int* height) {
   }
 }
 
-void VideoSurfaceHolder::ClearVideoWindow(bool force_reset_surface) {
+void VideoSurfaceHolder::CleanUpVideoWindow(
+    bool force_clear,
+    SbDecodeTargetGraphicsContextProvider* gpu_provider) {
   // Lock *GetViewSurfaceMutex() here, to avoid releasing g_native_video_window
   // during painting.
   std::lock_guard lock(*GetViewSurfaceMutex());
@@ -131,18 +217,20 @@ void VideoSurfaceHolder::ClearVideoWindow(bool force_reset_surface) {
     return;
   }
 
-  if (force_reset_surface) {
-    StarboardBridge::GetInstance()->ResetVideoSurface(env);
-    SB_LOG(INFO) << "Video surface has been reset.";
-    return;
-  } else if (g_reset_surface_on_clear_window) {
-    int width = ANativeWindow_getWidth(g_native_video_window);
-    int height = ANativeWindow_getHeight(g_native_video_window);
-    if (width <= height) {
-      StarboardBridge::GetInstance()->ResetVideoSurface(env);
+  if (force_clear) {
+    if (!gpu_provider) {
+      SB_LOG(WARNING) << "gpu_provider is null in ClearVideoWindow, will force "
+                         "reset surface.";
+    } else {
+      gpu_provider->gles_context_runner(gpu_provider, &ClearNativeWindow,
+                                        g_native_video_window);
+      SB_LOG(INFO) << "Video surface has been cleared.";
       return;
     }
   }
+
+  StarboardBridge::GetInstance()->ResetVideoSurface(env);
+  SB_LOG(INFO) << "Video surface has been reset.";
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -18,6 +18,8 @@
 #include <android/native_window.h>
 #include <jni.h>
 
+#include "starboard/decode_target.h"
+
 namespace starboard {
 
 class VideoSurfaceHolder {
@@ -45,8 +47,13 @@ class VideoSurfaceHolder {
   // window.
   bool GetVideoWindowSize(int* width, int* height);
 
-  // Clear the video window by painting it Black.
-  void ClearVideoWindow(bool force_reset_surface);
+  // Cleans up the video surface. If |force_clear| is enabled, we will only
+  // clear the video window, and post the clearing task to |gpu_provider|.
+  // If |force_clear| is false, we will forcefully destroy the surface view,
+  // which will then be recreated.
+  void CleanUpVideoWindow(
+      bool force_clear,
+      SbDecodeTargetGraphicsContextProvider* gpu_provider = nullptr);
 };
 
 }  // namespace starboard


### PR DESCRIPTION
Update MediaCodecVideoDecoder and VideoSurfaceHolder to support
clearing the video surface via EGL. This provides a more robust
cleanup mechanism than forcing a surface reset, which helps prevent
video distortion on certain Android devices.

Also, update StarboardRendererWrapper to manage the renderer via a
unique_ptr. This ensures the renderer is explicitly destroyed before
other members, such as the GPU task runner, are torn down.

This PR also changes the player flag `force_reset_surface` to 
`force_clear_surface` to reflect that by default, we already reset the
surface. All code relating to `force_reset_surface` has been adjusted
to work with the `force_clear_surface` flag.

Currently, these new changes are no-op.Follow-Up PRs will be added 
to connect this code to an experiment.

Bug: 429021006