### PR TITLE
Fix thread cleanup on AOSP

### DIFF
--- a/starboard/android/shared/jni_env_ext.cc
+++ b/starboard/android/shared/jni_env_ext.cc
@@ -29,9 +29,9 @@ JavaVM* g_vm = NULL;
 jobject g_application_class_loader = NULL;
 jobject g_starboard_bridge = NULL;
 
-void Destroy(void* value) {
-  if (value != NULL) {
-    starboard::android::shared::JniEnvExt::OnThreadShutdown();
+void Destroy(void* p) {
+  if (p) {
+    g_vm->DetachCurrentThread();
   }
 }
 


### PR DESCRIPTION
Use the tls value provided in the destructor to detach the JNI environment from the current thread.

Bug: 452721942