### PR TITLE
Optimize binary size for evergreen-arm-hardfp-rdk

### DIFF
--- a/cobalt/build/configs/evergreen-arm-hardfp-rdk/args.gn
+++ b/cobalt/build/configs/evergreen-arm-hardfp-rdk/args.gn
@@ -8,3 +8,7 @@ use_evergreen = true
 rdk_build_with_yocto = false
 rdk_starboard_root = "//starboard/contrib/rdk/src"
 rdk_enable_securityagent = false
+v8_enable_webassembly = false
+v8_enable_maglev = false
+icu_use_data_file = true
+enable_dav1d_decoder = false


### PR DESCRIPTION
Sets icu_use_data_file=true to avoid embedding ICU data, and disables WebAssembly, Maglev, and dav1d to reduce the size of `libcobalt.lz4` for the evergreen-arm-hardfp-rdk_gold build from ~51.8 MB to ~46.6 MB.