### PR TITLE
Revert "aosp: fix checked_iterators for newer c++ standards (#10152)"

### DIFF
--- a/copied_base/base/containers/checked_iterators.h
+++ b/copied_base/base/containers/checked_iterators.h
@@ -244,11 +244,9 @@ using CheckedContiguousConstIterator = CheckedContiguousIterator<const T>;
 // [3] https://wg21.link/pointer.traits.optmem
 namespace std {
 
-#if _LIBCPP_VERSION <= 170000
 template <typename T>
 struct __is_cpp17_contiguous_iterator<::base::CheckedContiguousIterator<T>>
     : true_type {};
-#endif
 
 template <typename T>
 struct pointer_traits<::base::CheckedContiguousIterator<T>> {


### PR DESCRIPTION
Reason for revert:
  AOSP was being built without setting use_cxx17 and
  build_base_with_cpp17, it was defaulting to c++20 instead.

This reverts commit be0b75806c29cd53f209460962400fead34d7c54.

Bug: 495203133