### PR TITLE
media: Exclude av1 codec wrapper

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -54,6 +54,8 @@ enable_hls_demuxer = false
 
 # Many of these come from media_options.gni.
 enable_hevc_parser_and_hw_decoder = false
+enable_av1_decoder = true
+enable_dav1d_decoder = false
 enable_libaom = false
 enable_platform_dolby_vision = false
 enable_platform_mpeg_h_audio = false


### PR DESCRIPTION
Disable the building of the AV1 decoder to reduce the overall binary
size of libcobalt. This change removes approximately 12KB from the final
evergreen build output.

```
> du out/evergreen-arm-hardfp-rdk_qa/libcobalt.so
84108   out/evergreen-arm-hardfp-rdk_qa/libcobalt.so

> du out/evergreen-arm-hardfp-rdk_qa/libcobalt.so
84096   out/evergreen-arm-hardfp-rdk_qa/libcobalt.so
```

Issue: 507512007