### PR TITLE
Stop setting retry_level to ERROR

### DIFF
--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -122,8 +122,12 @@ def _get_test_args_and_dimensions(
       f'job_timeout_sec={args.job_timeout_sec}',
       f'test_timeout_sec={args.test_timeout_sec}',
       f'start_timeout_sec={args.start_timeout_sec}',
-      f'retry_level={args.retry_level}',
   ]
+
+  if args.retry_level:
+    test_args.extend([
+        f'retry_level={args.retry_level}',
+    ])
 
   if args.test_attempts:
     test_args.extend([
@@ -357,7 +361,6 @@ def main() -> int:
   trigger_args.add_argument(
       '--retry_level',
       type=str,
-      default='ERROR',
       choices=['ERROR', 'FAIL'],
       help='Retry level for failed tests.',
   )


### PR DESCRIPTION
test: Stop setting default retry level in test client

Remove the default 'ERROR' retry_level from the on-device tests
gateway client script. This change allows for external test deflaking
mechanisms, such as those provided by GitHub, to manage test retries
without interference from the client. The retry_level will now only
be passed if explicitly specified.

Bug: 507140857