### PR TITLE
test: Add internal UIKit test sources to nplb build

### DIFF
--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -15,6 +15,10 @@
 import("//cobalt/build/configs/hacks.gni")
 import("//testing/test.gni")
 
+if (is_ios && target_platform == "tvos" && is_internal_build) {
+  import("//cobalt/internal/starboard/shared/uikit/uikit.gni")
+}
+
 declare_args() {
   sb_enable_cast_codec_tests = false
 }
@@ -379,5 +383,9 @@ test("nplb") {
       "//starboard/content/ssl:copy_ssl_certificates_prod_cobalt",
     ]
     deps += [ "//starboard/content/fonts:copy_font_data" ]
+  }
+
+  if (is_ios && target_platform == "tvos" && is_internal_build) {
+    sources += internal_uikit_test_sources
   }
 }


### PR DESCRIPTION
Include internal_uikit_test_sources in the nplb test target when
building with is_internal_build. This allows internal UIKit-specific
tests to be compiled and run as part of the standard nplb test suite.

Bug: 501329482