### PR TITLE
Expose cache usage to dev tools

### DIFF
--- a/content/browser/devtools/protocol/storage_handler.cc
+++ b/content/browser/devtools/protocol/storage_handler.cc
@@ -580,9 +580,9 @@ Response StorageHandler::GetStorageKeyForFrame(
 #endif
 }
 
-#if BUILDFLAG(IS_COBALT)
 Response StorageHandler::GetStorageKey(std::optional<std::string> frame_id,
                                        std::string* serialized_storage_key) {
+#if BUILDFLAG(IS_COBALT)
   if (frame_id.has_value()) {
     return GetStorageKeyForFrame(frame_id.value(), serialized_storage_key);
   }
@@ -594,8 +594,10 @@ Response StorageHandler::GetStorageKey(std::optional<std::string> frame_id,
   return Response::ServerError(
       "Could not determine storage key for the target (workers not supported "
       "yet in this implementation).");
-}
+#else
+  return Response::ServerError("Not implemented");
 #endif
+}
 
 namespace {
 uint32_t GetRemoveDataMask(const std::string& storage_types) {

--- a/content/browser/devtools/protocol/storage_handler.cc
+++ b/content/browser/devtools/protocol/storage_handler.cc
@@ -93,7 +93,7 @@ using SetCookiesCallback = Storage::Backend::SetCookiesCallback;
 
 struct UsageListInitializer {
   const char* type;
-  int64_t blink::mojom::UsageBreakdown::*usage_member;
+  int64_t blink::mojom::UsageBreakdown::* usage_member;
 };
 
 UsageListInitializer initializers[] = {
@@ -536,6 +536,19 @@ void StorageHandler::ClearCookies(
                      std::move(callback)));
 }
 
+Response StorageHandler::SerializeStorageKey(
+    RenderFrameHostImpl* rfh,
+    std::string* serialized_storage_key) {
+  const blink::StorageKey& storage_key = rfh->GetStorageKey();
+  if (storage_key.origin().opaque()) {
+    return Response::ServerError(
+        "Frame corresponds to an opaque origin and its storage key cannot be "
+        "serialized");
+  }
+  *serialized_storage_key = storage_key.Serialize();
+  return Response::Success();
+}
+
 Response StorageHandler::GetStorageKeyForFrame(
     const std::string& frame_id,
     std::string* serialized_storage_key) {
@@ -547,14 +560,23 @@ Response StorageHandler::GetStorageKeyForFrame(
   if (!node) {
     return Response::InvalidParams("Frame tree node for given frame not found");
   }
-  RenderFrameHostImpl* rfh = node->current_frame_host();
-  if (rfh->GetStorageKey().origin().opaque()) {
-    return Response::ServerError(
-        "Frame corresponds to an opaque origin and its storage key cannot be "
-        "serialized");
+  return SerializeStorageKey(node->current_frame_host(),
+                             serialized_storage_key);
+}
+
+Response StorageHandler::GetStorageKey(std::optional<std::string> frame_id,
+                                       std::string* serialized_storage_key) {
+  if (frame_id.has_value()) {
+    return GetStorageKeyForFrame(frame_id.value(), serialized_storage_key);
   }
-  *serialized_storage_key = rfh->GetStorageKey().Serialize();
-  return Response::Success();
+
+  if (frame_host_) {
+    return SerializeStorageKey(frame_host_, serialized_storage_key);
+  }
+
+  return Response::ServerError(
+      "Could not determine storage key for the target (workers not supported "
+      "yet in this implementation).");
 }
 
 namespace {

--- a/content/browser/devtools/protocol/storage_handler.cc
+++ b/content/browser/devtools/protocol/storage_handler.cc
@@ -536,9 +536,13 @@ void StorageHandler::ClearCookies(
                      std::move(callback)));
 }
 
+#if BUILDFLAG(IS_COBALT)
 Response StorageHandler::SerializeStorageKey(
     RenderFrameHostImpl* rfh,
-    std::string* serialized_storage_key) {
+    std::string* serialized_storage_key) const {
+  if (!rfh) {
+    return Response::ServerError("Internal error: RenderFrameHost is null");
+  }
   const blink::StorageKey& storage_key = rfh->GetStorageKey();
   if (storage_key.origin().opaque()) {
     return Response::ServerError(
@@ -548,6 +552,7 @@ Response StorageHandler::SerializeStorageKey(
   *serialized_storage_key = storage_key.Serialize();
   return Response::Success();
 }
+#endif
 
 Response StorageHandler::GetStorageKeyForFrame(
     const std::string& frame_id,
@@ -560,10 +565,22 @@ Response StorageHandler::GetStorageKeyForFrame(
   if (!node) {
     return Response::InvalidParams("Frame tree node for given frame not found");
   }
+#if BUILDFLAG(IS_COBALT)
   return SerializeStorageKey(node->current_frame_host(),
                              serialized_storage_key);
+#else
+  RenderFrameHostImpl* rfh = node->current_frame_host();
+  if (rfh->GetStorageKey().origin().opaque()) {
+    return Response::ServerError(
+        "Frame corresponds to an opaque origin and its storage key cannot be "
+        "serialized");
+  }
+  *serialized_storage_key = rfh->GetStorageKey().Serialize();
+  return Response::Success();
+#endif
 }
 
+#if BUILDFLAG(IS_COBALT)
 Response StorageHandler::GetStorageKey(std::optional<std::string> frame_id,
                                        std::string* serialized_storage_key) {
   if (frame_id.has_value()) {
@@ -578,6 +595,7 @@ Response StorageHandler::GetStorageKey(std::optional<std::string> frame_id,
       "Could not determine storage key for the target (workers not supported "
       "yet in this implementation).");
 }
+#endif
 
 namespace {
 uint32_t GetRemoveDataMask(const std::string& storage_types) {

--- a/content/browser/devtools/protocol/storage_handler.h
+++ b/content/browser/devtools/protocol/storage_handler.h
@@ -66,10 +66,8 @@ class StorageHandler
   // content::protocol::storage::Backend
   Response GetStorageKeyForFrame(const std::string& frame_id,
                                  std::string* serialized_storage_key) override;
-#if BUILDFLAG(IS_COBALT)
   Response GetStorageKey(std::optional<std::string> frame_id,
                          std::string* serialized_storage_key) override;
-#endif
   void ClearDataForOrigin(
       const std::string& origin,
       const std::string& storage_types,

--- a/content/browser/devtools/protocol/storage_handler.h
+++ b/content/browser/devtools/protocol/storage_handler.h
@@ -66,8 +66,10 @@ class StorageHandler
   // content::protocol::storage::Backend
   Response GetStorageKeyForFrame(const std::string& frame_id,
                                  std::string* serialized_storage_key) override;
+#if BUILDFLAG(IS_COBALT)
   Response GetStorageKey(std::optional<std::string> frame_id,
                          std::string* serialized_storage_key) override;
+#endif
   void ClearDataForOrigin(
       const std::string& origin,
       const std::string& storage_types,
@@ -275,8 +277,10 @@ class StorageHandler
       std::unique_ptr<Storage::Backend::GetCookiesCallback> callback,
       const std::vector<net::CanonicalCookie>& cookies);
 
+#if BUILDFLAG(IS_COBALT)
   Response SerializeStorageKey(RenderFrameHostImpl* rfh,
-                               std::string* serialized_storage_key);
+                               std::string* serialized_storage_key) const;
+#endif
 
   std::unique_ptr<Storage::Frontend> frontend_;
   raw_ptr<StoragePartition> storage_partition_{nullptr};

--- a/content/browser/devtools/protocol/storage_handler.h
+++ b/content/browser/devtools/protocol/storage_handler.h
@@ -66,6 +66,8 @@ class StorageHandler
   // content::protocol::storage::Backend
   Response GetStorageKeyForFrame(const std::string& frame_id,
                                  std::string* serialized_storage_key) override;
+  Response GetStorageKey(std::optional<std::string> frame_id,
+                         std::string* serialized_storage_key) override;
   void ClearDataForOrigin(
       const std::string& origin,
       const std::string& storage_types,
@@ -272,6 +274,9 @@ class StorageHandler
   void GotAllCookies(
       std::unique_ptr<Storage::Backend::GetCookiesCallback> callback,
       const std::vector<net::CanonicalCookie>& cookies);
+
+  Response SerializeStorageKey(RenderFrameHostImpl* rfh,
+                               std::string* serialized_storage_key);
 
   std::unique_ptr<Storage::Frontend> frontend_;
   raw_ptr<StoragePartition> storage_partition_{nullptr};

--- a/third_party/blink/public/devtools_protocol/browser_protocol.pdl
+++ b/third_party/blink/public/devtools_protocol/browser_protocol.pdl
@@ -10889,9 +10889,18 @@ experimental domain Storage
       StorageBucketsDurability durability
 
   # Returns a storage key given a frame id.
-  command getStorageKeyForFrame
+  # Deprecated. Please use Storage.getStorageKey instead.
+  deprecated command getStorageKeyForFrame
     parameters
       Page.FrameId frameId
+    returns
+      SerializedStorageKey storageKey
+
+  # Returns storage key for the given frame. If no frame ID is provided,
+  # the storage key of the target executing this command is returned.
+  experimental command getStorageKey
+    parameters
+      optional Page.FrameId frameId
     returns
       SerializedStorageKey storageKey
 

--- a/third_party/blink/web_tests/http/tests/inspector-protocol/storage/get-storage-key-expected.txt
+++ b/third_party/blink/web_tests/http/tests/inspector-protocol/storage/get-storage-key-expected.txt
@@ -1,0 +1,2 @@
+SUCCESS: Got storage key
+Storage key is non-empty.

--- a/third_party/blink/web_tests/http/tests/inspector-protocol/storage/get-storage-key.js
+++ b/third_party/blink/web_tests/http/tests/inspector-protocol/storage/get-storage-key.js
@@ -1,0 +1,22 @@
+(async function(testRunner) {
+  const {session, dp} = await testRunner.startBlank('Tests Storage.getStorageKey');
+
+  await dp.Storage.enable();
+
+  const response = await dp.Storage.getStorageKey();
+  
+  if (response.error) {
+    testRunner.log(`FAIL: Error getting storage key: ${response.error.message}`);
+  } else {
+    const storageKey = response.result.storageKey;
+    testRunner.log(`SUCCESS: Got storage key`);
+    
+    if (storageKey) {
+        testRunner.log(`Storage key is non-empty.`);
+    } else {
+        testRunner.log(`FAIL: Storage key is empty.`);
+    }
+  }
+
+  testRunner.completeTest();
+})


### PR DESCRIPTION
Allow the fronted developers to check the storage cache usage via devtool's Application tab. 
See https://screenshot.googleplex.com/Bz3jcdttZXhbMbB
This feature has landed in Chromium by crrev.com/c/6919038 at M142. So I did not land the PR
into our main branch, to reduce the Rebase conflicts in future.
Plus, the source files in this PR do not have any cobalt commit so far. They should not bring
any conflicts between main and 27.lts.

Bug: 484087755