### PR TITLE
starboard: Apply const to member variables in DrmSystem

### DIFF
--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -79,6 +79,10 @@ DrmSystem::DrmSystem(PassKey<DrmSystem>,
       context_(context),
       callbacks_(callbacks),
       hdcp_lost_(false),
+      media_drm_bridge_(
+          MediaDrmBridge::Create(base::raw_ref<MediaDrmBridge::Host>(*this),
+                                 key_system_,
+                                 enable_app_provisioning_)),
       session_id_mapper_(enable_app_provisioning_
                              ? std::make_unique<DrmSessionIdMapper>()
                              : nullptr) {
@@ -88,9 +92,6 @@ DrmSystem::DrmSystem(PassKey<DrmSystem>,
 
   ON_INSTANCE_CREATED(AndroidDrmSystem);
 
-  media_drm_bridge_ =
-      MediaDrmBridge::Create(base::raw_ref<MediaDrmBridge::Host>(*this),
-                             key_system_, enable_app_provisioning_);
   if (!media_drm_bridge_) {
     return;
   }

--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -79,13 +79,13 @@ DrmSystem::DrmSystem(PassKey<DrmSystem>,
       context_(context),
       callbacks_(callbacks),
       hdcp_lost_(false),
+      session_id_mapper_(enable_app_provisioning_
+                             ? std::make_unique<DrmSessionIdMapper>()
+                             : nullptr),
       media_drm_bridge_(
           MediaDrmBridge::Create(base::raw_ref<MediaDrmBridge::Host>(*this),
                                  key_system_,
-                                 enable_app_provisioning_)),
-      session_id_mapper_(enable_app_provisioning_
-                             ? std::make_unique<DrmSessionIdMapper>()
-                             : nullptr) {
+                                 enable_app_provisioning_)) {
   SB_CHECK(callbacks_.update_request);
   SB_CHECK(callbacks_.session_updated);
   SB_CHECK(callbacks_.key_statuses_changed);

--- a/starboard/android/shared/drm_system.h
+++ b/starboard/android/shared/drm_system.h
@@ -147,13 +147,6 @@ class DrmSystem : public ::SbDrmSystemPrivate,
   bool hdcp_lost_;
   std::atomic_bool created_media_crypto_session_{false};
 
-  // Guaranteed to be non-null for any instance returned by the factory method.
-  // However, it can be null during destruction if the factory method fails
-  // to create the bridge and destroys the instance.
-  const std::unique_ptr<MediaDrmBridge> media_drm_bridge_;
-
-  ThreadChecker thread_checker_;
-
   // Manages the mapping between the EME session ID in the C++ layer and the
   // MediaDrm session ID in the Java layer. Most of the time, we can use the
   // MediaDrm session ID as the EME session ID. However, there are some cases
@@ -164,6 +157,13 @@ class DrmSystem : public ::SbDrmSystemPrivate,
   // session ID to interact with the Cobalt CDM module.
   const std::unique_ptr<DrmSessionIdMapper>
       session_id_mapper_;  //  Guarded by |mutex_|.
+
+  // Guaranteed to be non-null for any instance returned by the factory method.
+  // However, it can be null during destruction if the factory method fails
+  // to create the bridge and destroys the instance.
+  const std::unique_ptr<MediaDrmBridge> media_drm_bridge_;
+
+  ThreadChecker thread_checker_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/drm_system.h
+++ b/starboard/android/shared/drm_system.h
@@ -29,6 +29,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "starboard/android/shared/drm_session_id_mapper.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/media_drm_bridge.h"
@@ -135,7 +136,7 @@ class DrmSystem : public ::SbDrmSystemPrivate,
 
   const std::string key_system_;
   const bool enable_app_provisioning_;
-  void* const context_;
+  const raw_ptr<void> context_;
   const Callbacks callbacks_;
 
   std::mutex mutex_;

--- a/starboard/android/shared/drm_system.h
+++ b/starboard/android/shared/drm_system.h
@@ -135,8 +135,7 @@ class DrmSystem : public ::SbDrmSystemPrivate,
 
   const std::string key_system_;
   const bool enable_app_provisioning_;
-  void* context_;
-  // TODO: Update key statuses to Cobalt.
+  void* const context_;
   const Callbacks callbacks_;
 
   std::mutex mutex_;
@@ -148,7 +147,10 @@ class DrmSystem : public ::SbDrmSystemPrivate,
   bool hdcp_lost_;
   std::atomic_bool created_media_crypto_session_{false};
 
-  std::unique_ptr<MediaDrmBridge> media_drm_bridge_;
+  // Guaranteed to be non-null for any instance returned by the factory method.
+  // However, it can be null during destruction if the factory method fails
+  // to create the bridge and destroys the instance.
+  const std::unique_ptr<MediaDrmBridge> media_drm_bridge_;
 
   ThreadChecker thread_checker_;
 


### PR DESCRIPTION
Move media_drm_bridge_ initialization to the member initializer list.
This ensures the member is constructed directly, rather than assigned,
improving efficiency and adhering to C++ best practices.

Mark context_ and media_drm_bridge_ as const. This enforces
const-correctness, ensuring these members are initialized once and
remain immutable. This improves code clarity and safety.

Issue: 507923718