### PR TITLE
starboard: Use factory for ffmpeg decoders

### DIFF
--- a/starboard/linux/shared/player_components_factory.cc
+++ b/starboard/linux/shared/player_components_factory.cc
@@ -73,9 +73,9 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
           SB_LOG(INFO) << "Playing audio using FdkAacAudioDecoder.";
           return std::make_unique<FdkAacAudioDecoder>(job_queue);
         } else {
-          std::unique_ptr<FfmpegAudioDecoder> ffmpeg_audio_decoder(
-              FfmpegAudioDecoder::Create(job_queue, audio_stream_info));
-          if (ffmpeg_audio_decoder && ffmpeg_audio_decoder->is_valid()) {
+          auto ffmpeg_audio_decoder =
+              FfmpegAudioDecoder::Create(job_queue, audio_stream_info);
+          if (ffmpeg_audio_decoder) {
             SB_LOG(INFO) << "Playing audio using FfmpegAudioDecoder";
             return ffmpeg_audio_decoder;
           } else {
@@ -125,12 +125,11 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
             creation_parameters.output_mode(),
             creation_parameters.decode_target_graphics_context_provider());
       } else {
-        std::unique_ptr<FfmpegVideoDecoder> ffmpeg_video_decoder(
-            FfmpegVideoDecoder::Create(
-                creation_parameters.video_codec(),
-                creation_parameters.output_mode(),
-                creation_parameters.decode_target_graphics_context_provider()));
-        if (ffmpeg_video_decoder && ffmpeg_video_decoder->is_valid()) {
+        auto ffmpeg_video_decoder = FfmpegVideoDecoder::Create(
+            creation_parameters.video_codec(),
+            creation_parameters.output_mode(),
+            creation_parameters.decode_target_graphics_context_provider());
+        if (ffmpeg_video_decoder) {
           SB_LOG(INFO) << "Playing video using ffmpeg::VideoDecoder.";
           components.video.decoder = std::move(ffmpeg_video_decoder);
         } else {

--- a/starboard/raspi/shared/player_components_factory.cc
+++ b/starboard/raspi/shared/player_components_factory.cc
@@ -47,9 +47,9 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
             return opus_audio_decoder;
           }
         } else {
-          auto ffmpeg_audio_decoder = std::unique_ptr<FfmpegAudioDecoder>(
-              FfmpegAudioDecoder::Create(job_queue, audio_stream_info));
-          if (ffmpeg_audio_decoder && ffmpeg_audio_decoder->is_valid()) {
+          auto ffmpeg_audio_decoder =
+              FfmpegAudioDecoder::Create(job_queue, audio_stream_info);
+          if (ffmpeg_audio_decoder) {
             return ffmpeg_audio_decoder;
           }
         }

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder.h
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder.h
@@ -15,6 +15,8 @@
 #ifndef STARBOARD_SHARED_FFMPEG_FFMPEG_AUDIO_DECODER_H_
 #define STARBOARD_SHARED_FFMPEG_FFMPEG_AUDIO_DECODER_H_
 
+#include <memory>
+
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/media/media_util.h"
@@ -26,10 +28,9 @@ namespace starboard {
 class FfmpegAudioDecoder : public AudioDecoder {
  public:
   // Create an audio decoder for the currently loaded ffmpeg library.
-  static FfmpegAudioDecoder* Create(JobQueue* job_queue,
-                                    const AudioStreamInfo& audio_stream_info);
-  // Returns true if the audio decoder is initialized successfully.
-  virtual bool is_valid() const = 0;
+  static std::unique_ptr<FfmpegAudioDecoder> Create(
+      JobQueue* job_queue,
+      const AudioStreamInfo& audio_stream_info);
 };
 
 }  // namespace starboard

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -17,6 +17,7 @@
 
 #include "starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h"
 
+#include <memory>
 #include <string>
 
 #include "starboard/audio_sink.h"
@@ -85,6 +86,7 @@ const bool g_registered =
 }  // namespace
 
 FfmpegAudioDecoderImpl<FFMPEG>::FfmpegAudioDecoderImpl(
+    starboard::PassKey<FfmpegAudioDecoderImpl<FFMPEG>>,
     JobQueue* job_queue,
     const AudioStreamInfo& audio_stream_info)
     : JobOwner(job_queue),
@@ -98,9 +100,6 @@ FfmpegAudioDecoderImpl<FFMPEG>::FfmpegAudioDecoderImpl(
       << "Unsupported audio codec " << audio_stream_info_.codec;
   ffmpeg_ = FFMPEGDispatch::GetInstance();
   SB_DCHECK(ffmpeg_);
-  if ((ffmpeg_->specialization_version()) == FFMPEG) {
-    InitializeCodec();
-  }
 }
 
 FfmpegAudioDecoderImpl<FFMPEG>::~FfmpegAudioDecoderImpl() {
@@ -108,10 +107,17 @@ FfmpegAudioDecoderImpl<FFMPEG>::~FfmpegAudioDecoderImpl() {
 }
 
 // static
-FfmpegAudioDecoder* FfmpegAudioDecoderImpl<FFMPEG>::Create(
+std::unique_ptr<FfmpegAudioDecoder> FfmpegAudioDecoderImpl<FFMPEG>::Create(
     JobQueue* job_queue,
     const AudioStreamInfo& audio_stream_info) {
-  return new FfmpegAudioDecoderImpl<FFMPEG>(job_queue, audio_stream_info);
+  auto decoder = std::make_unique<FfmpegAudioDecoderImpl<FFMPEG>>(
+      starboard::PassKey<FfmpegAudioDecoderImpl<FFMPEG>>(), job_queue,
+      audio_stream_info);
+  if (decoder->ffmpeg_->specialization_version() == FFMPEG &&
+      !decoder->InitializeCodec()) {
+    return nullptr;
+  }
+  return decoder;
 }
 
 void FfmpegAudioDecoderImpl<FFMPEG>::Initialize(const OutputCB& output_cb,
@@ -305,10 +311,6 @@ void FfmpegAudioDecoderImpl<FFMPEG>::Reset() {
   CancelPendingJobs();
 }
 
-bool FfmpegAudioDecoderImpl<FFMPEG>::is_valid() const {
-  return (ffmpeg_ != NULL) && ffmpeg_->is_valid() && (codec_context_ != NULL);
-}
-
 SbMediaAudioSampleType FfmpegAudioDecoderImpl<FFMPEG>::GetSampleType() const {
   SB_CHECK(BelongsToCurrentThread());
 
@@ -342,12 +344,12 @@ SbMediaAudioFrameStorageType FfmpegAudioDecoderImpl<FFMPEG>::GetStorageType()
   return kSbMediaAudioFrameStorageTypeInterleaved;
 }
 
-void FfmpegAudioDecoderImpl<FFMPEG>::InitializeCodec() {
+bool FfmpegAudioDecoderImpl<FFMPEG>::InitializeCodec() {
   codec_context_ = ffmpeg_->avcodec_alloc_context3(NULL);
 
   if (codec_context_ == NULL) {
     SB_LOG(ERROR) << "Unable to allocate ffmpeg codec context";
-    return;
+    return false;
   }
 
   codec_context_->codec_type = AVMEDIA_TYPE_AUDIO;
@@ -395,14 +397,14 @@ void FfmpegAudioDecoderImpl<FFMPEG>::InitializeCodec() {
   if (codec == NULL) {
     SB_LOG(ERROR) << "Unable to allocate ffmpeg codec context";
     TeardownCodec();
-    return;
+    return false;
   }
 
   int rv = ffmpeg_->OpenCodec(codec_context_, codec);
   if (rv < 0) {
     SB_LOG(ERROR) << "Unable to open codec";
     TeardownCodec();
-    return;
+    return false;
   }
 
   if (ffmpeg_->avcodec_version() > kAVCodecSupportsAvFrameAlloc) {
@@ -413,7 +415,9 @@ void FfmpegAudioDecoderImpl<FFMPEG>::InitializeCodec() {
   if (av_frame_ == NULL) {
     SB_LOG(ERROR) << "Unable to allocate audio frame";
     TeardownCodec();
+    return false;
   }
+  return true;
 }
 
 void FfmpegAudioDecoderImpl<FFMPEG>::TeardownCodec() {

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -90,16 +90,13 @@ FfmpegAudioDecoderImpl<FFMPEG>::FfmpegAudioDecoderImpl(
     JobQueue* job_queue,
     const AudioStreamInfo& audio_stream_info)
     : JobOwner(job_queue),
-      codec_context_(NULL),
-      av_frame_(NULL),
-      stream_ended_(false),
+      ffmpeg_(FFMPEGDispatch::GetInstance()),
       audio_stream_info_(audio_stream_info) {
   SB_DCHECK(g_registered) << "Decoder Specialization registration failed.";
   SB_DCHECK_NE(GetFfmpegCodecIdByMediaCodec(audio_stream_info_),
                AV_CODEC_ID_NONE)
       << "Unsupported audio codec " << audio_stream_info_.codec;
-  ffmpeg_ = FFMPEGDispatch::GetInstance();
-  SB_DCHECK(ffmpeg_);
+  SB_CHECK(ffmpeg_);
 }
 
 FfmpegAudioDecoderImpl<FFMPEG>::~FfmpegAudioDecoderImpl() {

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -113,8 +113,8 @@ std::unique_ptr<FfmpegAudioDecoder> FfmpegAudioDecoderImpl<FFMPEG>::Create(
   auto decoder = std::make_unique<FfmpegAudioDecoderImpl<FFMPEG>>(
       starboard::PassKey<FfmpegAudioDecoderImpl<FFMPEG>>(), job_queue,
       audio_stream_info);
-  if (decoder->ffmpeg_->specialization_version() == FFMPEG &&
-      !decoder->InitializeCodec()) {
+  SB_CHECK_EQ(decoder->ffmpeg_->specialization_version(), FFMPEG);
+  if (!decoder->InitializeCodec()) {
     return nullptr;
   }
   return decoder;

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -110,7 +110,6 @@ std::unique_ptr<FfmpegAudioDecoder> FfmpegAudioDecoderImpl<FFMPEG>::Create(
   auto decoder = std::make_unique<FfmpegAudioDecoderImpl<FFMPEG>>(
       starboard::PassKey<FfmpegAudioDecoderImpl<FFMPEG>>(), job_queue,
       audio_stream_info);
-  SB_CHECK_EQ(decoder->ffmpeg_->specialization_version(), FFMPEG);
   if (!decoder->InitializeCodec()) {
     return nullptr;
   }

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
@@ -74,13 +74,14 @@ class FfmpegAudioDecoderImpl<FFMPEG> : public FfmpegAudioDecoder,
 
   static const int kMaxDecodedAudiosSize = 64;
 
-  FFMPEGDispatch* ffmpeg_;
+  // Guaranteed to be non-null.
+  FFMPEGDispatch* const ffmpeg_;
   OutputCB output_cb_;
   ErrorCB error_cb_;
-  AVCodecContext* codec_context_;
-  AVFrame* av_frame_;
+  AVCodecContext* codec_context_ = nullptr;
+  AVFrame* av_frame_ = nullptr;
 
-  bool stream_ended_;
+  bool stream_ended_ = false;
   std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
   AudioStreamInfo audio_stream_info_;
 };

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.h
@@ -15,8 +15,10 @@
 #ifndef STARBOARD_SHARED_FFMPEG_FFMPEG_AUDIO_DECODER_IMPL_H_
 #define STARBOARD_SHARED_FFMPEG_FFMPEG_AUDIO_DECODER_IMPL_H_
 
+#include <memory>
 #include <queue>
 
+#include "starboard/common/pass_key.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/ffmpeg/ffmpeg_audio_decoder.h"
@@ -40,14 +42,15 @@ template <>
 class FfmpegAudioDecoderImpl<FFMPEG> : public FfmpegAudioDecoder,
                                        private JobQueue::JobOwner {
  public:
-  FfmpegAudioDecoderImpl(JobQueue* job_queue,
+  FfmpegAudioDecoderImpl(starboard::PassKey<FfmpegAudioDecoderImpl<FFMPEG>>,
+                         JobQueue* job_queue,
                          const AudioStreamInfo& audio_stream_info);
   ~FfmpegAudioDecoderImpl() override;
 
   // From: FfmpegAudioDecoder
-  static FfmpegAudioDecoder* Create(JobQueue* job_queue,
-                                    const AudioStreamInfo& audio_stream_info);
-  bool is_valid() const override;
+  static std::unique_ptr<FfmpegAudioDecoder> Create(
+      JobQueue* job_queue,
+      const AudioStreamInfo& audio_stream_info);
 
   // From: AudioDecoder
   void Initialize(const OutputCB& output_cb, const ErrorCB& error_cb) override;
@@ -61,7 +64,7 @@ class FfmpegAudioDecoderImpl<FFMPEG> : public FfmpegAudioDecoder,
   SbMediaAudioSampleType GetSampleType() const;
   SbMediaAudioFrameStorageType GetStorageType() const;
 
-  void InitializeCodec();
+  bool InitializeCodec();
   void TeardownCodec();
 
   // Processes decoded (PCM) audio data received from FFmpeg. The audio data is

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl_interface.h
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl_interface.h
@@ -15,6 +15,8 @@
 #ifndef STARBOARD_SHARED_FFMPEG_FFMPEG_AUDIO_DECODER_IMPL_INTERFACE_H_
 #define STARBOARD_SHARED_FFMPEG_FFMPEG_AUDIO_DECODER_IMPL_INTERFACE_H_
 
+#include <memory>
+
 #include "starboard/media.h"
 #include "starboard/shared/ffmpeg/ffmpeg_audio_decoder.h"
 #include "starboard/shared/internal_only.h"
@@ -27,8 +29,9 @@ namespace starboard {
 template <int V>
 class FfmpegAudioDecoderImpl : public FfmpegAudioDecoder {
  public:
-  static FfmpegAudioDecoder* Create(JobQueue* job_queue,
-                                    const AudioStreamInfo& audio_stream_info);
+  static std::unique_ptr<FfmpegAudioDecoder> Create(
+      JobQueue* job_queue,
+      const AudioStreamInfo& audio_stream_info);
 };
 
 }  // namespace starboard

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_test.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_test.cc
@@ -50,29 +50,23 @@ class FfmpegAudioDecoderTest : public ::testing::Test,
 
 TEST_F(FfmpegAudioDecoderTest, SupportsMp3Codec) {
   AudioStreamInfo stream_info = CreateStreamInfoForCodec(kSbMediaAudioCodecMp3);
-  std::unique_ptr<FfmpegAudioDecoder> decoder(
-      FfmpegAudioDecoder::Create(&job_queue_, stream_info));
+  auto decoder = FfmpegAudioDecoder::Create(&job_queue_, stream_info);
   ASSERT_THAT(decoder, NotNull());
-  EXPECT_TRUE(decoder->is_valid());
 }
 
 TEST_F(FfmpegAudioDecoderTest, SupportsFlacCodecFor16BitAudio) {
   AudioStreamInfo stream_info =
       CreateStreamInfoForCodec(kSbMediaAudioCodecFlac);
   stream_info.bits_per_sample = 16;
-  std::unique_ptr<FfmpegAudioDecoder> decoder(
-      FfmpegAudioDecoder::Create(&job_queue_, stream_info));
+  auto decoder = FfmpegAudioDecoder::Create(&job_queue_, stream_info);
   ASSERT_THAT(decoder, NotNull());
-  EXPECT_TRUE(decoder->is_valid());
 }
 
 TEST_F(FfmpegAudioDecoderTest, SupportsPcmCodecFor16BitAudio) {
   AudioStreamInfo stream_info = CreateStreamInfoForCodec(kSbMediaAudioCodecPcm);
   stream_info.bits_per_sample = 16;
-  std::unique_ptr<FfmpegAudioDecoder> decoder(
-      FfmpegAudioDecoder::Create(&job_queue_, stream_info));
+  auto decoder = FfmpegAudioDecoder::Create(&job_queue_, stream_info);
   ASSERT_THAT(decoder, NotNull());
-  EXPECT_TRUE(decoder->is_valid());
 }
 
 }  // namespace

--- a/starboard/shared/ffmpeg/ffmpeg_dispatch.h
+++ b/starboard/shared/ffmpeg/ffmpeg_dispatch.h
@@ -76,8 +76,6 @@ class FFMPEGDispatch {
                                      int avformat,
                                      int avutil);
 
-  bool is_valid() const;
-
   unsigned (*avutil_version)(void);
   void* (*av_malloc)(size_t size);
   void (*av_freep)(void* ptr);

--- a/starboard/shared/ffmpeg/ffmpeg_dynamic_load_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dynamic_load_audio_decoder_impl.cc
@@ -19,6 +19,8 @@
 // This file contains the creation of the specialized AudioDecoderImpl object
 // corresponding to the version of the dynamically loaded ffmpeg library.
 
+#include <memory>
+
 #include "starboard/player.h"
 #include "starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl_interface.h"
 #include "starboard/shared/ffmpeg/ffmpeg_dispatch.h"
@@ -27,12 +29,12 @@
 namespace starboard {
 
 // static
-FfmpegAudioDecoder* FfmpegAudioDecoder::Create(
+std::unique_ptr<FfmpegAudioDecoder> FfmpegAudioDecoder::Create(
     JobQueue* job_queue,
     const AudioStreamInfo& audio_stream_info) {
   FFMPEGDispatch* ffmpeg = FFMPEGDispatch::GetInstance();
-  if (!ffmpeg || !ffmpeg->is_valid()) {
-    return NULL;
+  if (!ffmpeg) {
+    return nullptr;
   }
 
   switch (ffmpeg->specialization_version()) {

--- a/starboard/shared/ffmpeg/ffmpeg_dynamic_load_dispatch_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dynamic_load_dispatch_impl.cc
@@ -66,7 +66,7 @@ class FFMPEGDispatchImpl {
                               int avformat,
                               int avutil);
 
-  bool is_valid() const { return avcodec_ && avformat_ && avutil_; }
+  bool AreLibrariesLoaded() const { return avcodec_ && avformat_ && avutil_; }
 
   FFMPEGDispatch* get_ffmpeg_dispatch();
 
@@ -150,8 +150,9 @@ FFMPEGDispatch* FFMPEGDispatchImpl::get_ffmpeg_dispatch() {
       }
     }
   }
+  FFMPEGDispatch* result = AreLibrariesLoaded() ? ffmpeg_ : nullptr;
   pthread_mutex_unlock(&mutex_);
-  return ffmpeg_;
+  return result;
 }
 
 const int kMaxVersionedLibraryNameLength = 32;
@@ -177,7 +178,7 @@ bool FFMPEGDispatchImpl::OpenLibraries() {
       dlclose(avutil_);
       avutil_ = NULL;
     }
-    SB_DCHECK(!is_valid());
+    SB_DCHECK(!AreLibrariesLoaded());
   };
 
   for (auto version_iterator = versions_.rbegin();
@@ -209,11 +210,11 @@ bool FFMPEGDispatchImpl::OpenLibraries() {
       reset_av_libraries();
       continue;
     }
-    SB_DCHECK(is_valid());
+    SB_DCHECK(AreLibrariesLoaded());
     break;
   }
 
-  if (is_valid()) {
+  if (AreLibrariesLoaded()) {
     return true;
   }
 
@@ -246,12 +247,12 @@ bool FFMPEGDispatchImpl::OpenLibraries() {
     return false;
   }
 
-  SB_DCHECK(is_valid());
+  SB_DCHECK(AreLibrariesLoaded());
   return true;
 }
 
 void FFMPEGDispatchImpl::LoadSymbols() {
-  SB_DCHECK(is_valid());
+  SB_DCHECK(AreLibrariesLoaded());
   // Load the desired symbols from the shared libraries. Note: If a symbol is
   // listed as a '.text' entry in the output of 'objdump -T' on the shared
   // library file, then it is directly available from it.
@@ -347,10 +348,6 @@ bool FFMPEGDispatch::RegisterSpecialization(int specialization,
                                             int avutil) {
   return FFMPEGDispatchImpl::GetInstance()->RegisterSpecialization(
       specialization, avcodec, avformat, avutil);
-}
-
-bool FFMPEGDispatch::is_valid() const {
-  return FFMPEGDispatchImpl::GetInstance()->is_valid();
 }
 
 int FFMPEGDispatch::specialization_version() const {

--- a/starboard/shared/ffmpeg/ffmpeg_dynamic_load_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dynamic_load_video_decoder_impl.cc
@@ -19,6 +19,8 @@
 // This file contains the creation of the specialized VideoDecoderImpl object
 // corresponding to the version of the dynamically loaded ffmpeg library.
 
+#include <memory>
+
 #include "starboard/log.h"
 #include "starboard/player.h"
 #include "starboard/shared/ffmpeg/ffmpeg_dispatch.h"
@@ -27,53 +29,45 @@
 namespace starboard {
 
 // static
-FfmpegVideoDecoder* FfmpegVideoDecoder::Create(
+std::unique_ptr<FfmpegVideoDecoder> FfmpegVideoDecoder::Create(
     SbMediaVideoCodec video_codec,
     SbPlayerOutputMode output_mode,
     SbDecodeTargetGraphicsContextProvider*
         decode_target_graphics_context_provider) {
   FFMPEGDispatch* ffmpeg = FFMPEGDispatch::GetInstance();
-  if (!ffmpeg || !ffmpeg->is_valid()) {
-    return NULL;
+  if (!ffmpeg) {
+    return nullptr;
   }
 
-  FfmpegVideoDecoder* video_decoder = NULL;
   switch (ffmpeg->specialization_version()) {
     case 540:
-      video_decoder = FfmpegVideoDecoderImpl<540>::Create(
+      return FfmpegVideoDecoderImpl<540>::Create(
           video_codec, output_mode, decode_target_graphics_context_provider);
-      break;
     case 550:
     case 560:
-      video_decoder = FfmpegVideoDecoderImpl<560>::Create(
+      return FfmpegVideoDecoderImpl<560>::Create(
           video_codec, output_mode, decode_target_graphics_context_provider);
-      break;
     case 571:
-      video_decoder = FfmpegVideoDecoderImpl<571>::Create(
+      return FfmpegVideoDecoderImpl<571>::Create(
           video_codec, output_mode, decode_target_graphics_context_provider);
-      break;
     case 581:
-      video_decoder = FfmpegVideoDecoderImpl<581>::Create(
+      return FfmpegVideoDecoderImpl<581>::Create(
           video_codec, output_mode, decode_target_graphics_context_provider);
-      break;
     case 591:
-      video_decoder = FfmpegVideoDecoderImpl<591>::Create(
+      return FfmpegVideoDecoderImpl<591>::Create(
           video_codec, output_mode, decode_target_graphics_context_provider);
-      break;
     case 601:
-      video_decoder = FfmpegVideoDecoderImpl<601>::Create(
+      return FfmpegVideoDecoderImpl<601>::Create(
           video_codec, output_mode, decode_target_graphics_context_provider);
-      break;
     case 611:
-      video_decoder = FfmpegVideoDecoderImpl<611>::Create(
+      return FfmpegVideoDecoderImpl<611>::Create(
           video_codec, output_mode, decode_target_graphics_context_provider);
-      break;
     default:
       SB_LOG(WARNING) << "Unsupported FFMPEG version "
                       << ffmpeg->specialization_version();
       break;
   }
-  return video_decoder;
+  return nullptr;
 }
 
 }  // namespace starboard

--- a/starboard/shared/ffmpeg/ffmpeg_linked_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_linked_audio_decoder_impl.cc
@@ -31,7 +31,6 @@ namespace starboard {
 AudioDecoder* AudioDecoder::Create(const AudioStreamInfo& audio_stream_info) {
   FFMPEGDispatch* ffmpeg = FFMPEGDispatch::GetInstance();
   SB_DCHECK(ffmpeg);
-  SB_DCHECK(ffmpeg->is_valid());
   SB_DCHECK_EQ(FFMPEG, ffmpeg->specialization_version());
 
   return AudioDecoderImpl<FFMPEG>::Create(audio_stream_info);

--- a/starboard/shared/ffmpeg/ffmpeg_linked_dispatch_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_linked_dispatch_impl.cc
@@ -41,7 +41,6 @@ void construct_ffmpeg_dispatch() {
 }
 
 void LoadSymbols(FFMPEGDispatch* ffmpeg) {
-  SB_DCHECK(ffmpeg->is_valid());
   // Load the desired symbols from the shared libraries. Note: If a symbol is
   // listed as a '.text' entry in the output of 'objdump -T' on the shared
   // library file, then it is directly available from it.
@@ -121,11 +120,6 @@ bool FFMPEGDispatch::RegisterSpecialization(int specialization,
                                             int avutil) {
   // There is always only a single version of the library linked to the
   // application, so there is no need to explicitly track multiple versions.
-  return true;
-}
-
-bool FFMPEGDispatch::is_valid() const {
-  // Loading of a linked library is always successful.
   return true;
 }
 

--- a/starboard/shared/ffmpeg/ffmpeg_linked_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_linked_video_decoder_impl.cc
@@ -35,7 +35,6 @@ VideoDecoder* VideoDecoder::Create(
         decode_target_graphics_context_provider) {
   FFMPEGDispatch* ffmpeg = FFMPEGDispatch::GetInstance();
   SB_DCHECK(ffmpeg);
-  SB_DCHECK(ffmpeg->is_valid());
   SB_DCHECK_EQ(FFMPEG, ffmpeg->specialization_version());
 
   return VideoDecoderImpl<FFMPEG>::Create(

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder.h
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder.h
@@ -15,6 +15,8 @@
 #ifndef STARBOARD_SHARED_FFMPEG_FFMPEG_VIDEO_DECODER_H_
 #define STARBOARD_SHARED_FFMPEG_FFMPEG_VIDEO_DECODER_H_
 
+#include <memory>
+
 #include "starboard/media.h"
 #include "starboard/player.h"
 #include "starboard/shared/internal_only.h"
@@ -25,14 +27,11 @@ namespace starboard {
 class FfmpegVideoDecoder : public VideoDecoder {
  public:
   // Create a video decoder for the currently loaded ffmpeg library.
-  static FfmpegVideoDecoder* Create(
+  static std::unique_ptr<FfmpegVideoDecoder> Create(
       SbMediaVideoCodec video_codec,
       SbPlayerOutputMode output_mode,
       SbDecodeTargetGraphicsContextProvider*
           decode_target_graphics_context_provider);
-
-  // Returns true if the video decoder is initialized successfully.
-  virtual bool is_valid() const = 0;
 };
 
 }  // namespace starboard

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
@@ -106,18 +106,14 @@ FfmpegVideoDecoderImpl<FFMPEG>::FfmpegVideoDecoderImpl(
     SbPlayerOutputMode output_mode,
     SbDecodeTargetGraphicsContextProvider*
         decode_target_graphics_context_provider)
-    : video_codec_(video_codec),
-      codec_context_(NULL),
-      av_frame_(NULL),
-      stream_ended_(false),
-      error_occurred_(false),
+    : ffmpeg_(FFMPEGDispatch::GetInstance()),
+      video_codec_(video_codec),
       output_mode_(output_mode),
       decode_target_graphics_context_provider_(
           decode_target_graphics_context_provider),
       decode_target_(kSbDecodeTargetInvalid) {
   SB_DCHECK(g_registered) << "Decoder Specialization registration failed.";
-  ffmpeg_ = FFMPEGDispatch::GetInstance();
-  SB_DCHECK(ffmpeg_);
+  SB_CHECK(ffmpeg_);
 }
 
 FfmpegVideoDecoderImpl<FFMPEG>::~FfmpegVideoDecoderImpl() {

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
@@ -101,6 +101,7 @@ const bool g_registered =
 }  // namespace
 
 FfmpegVideoDecoderImpl<FFMPEG>::FfmpegVideoDecoderImpl(
+    starboard::PassKey<FfmpegVideoDecoderImpl<FFMPEG>>,
     SbMediaVideoCodec video_codec,
     SbPlayerOutputMode output_mode,
     SbDecodeTargetGraphicsContextProvider*
@@ -131,7 +132,8 @@ std::unique_ptr<FfmpegVideoDecoder> FfmpegVideoDecoderImpl<FFMPEG>::Create(
     SbDecodeTargetGraphicsContextProvider*
         decode_target_graphics_context_provider) {
   auto decoder = std::make_unique<FfmpegVideoDecoderImpl<FFMPEG>>(
-      video_codec, output_mode, decode_target_graphics_context_provider);
+      starboard::PassKey<FfmpegVideoDecoderImpl<FFMPEG>>(), video_codec,
+      output_mode, decode_target_graphics_context_provider);
   SB_CHECK_EQ(decoder->ffmpeg_->specialization_version(), FFMPEG);
   if (!decoder->InitializeCodec()) {
     return nullptr;

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
@@ -130,7 +130,6 @@ std::unique_ptr<FfmpegVideoDecoder> FfmpegVideoDecoderImpl<FFMPEG>::Create(
   auto decoder = std::make_unique<FfmpegVideoDecoderImpl<FFMPEG>>(
       starboard::PassKey<FfmpegVideoDecoderImpl<FFMPEG>>(), video_codec,
       output_mode, decode_target_graphics_context_provider);
-  SB_CHECK_EQ(decoder->ffmpeg_->specialization_version(), FFMPEG);
   if (!decoder->InitializeCodec()) {
     return nullptr;
   }

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
@@ -19,6 +19,7 @@
 
 #include <stdlib.h>
 
+#include <memory>
 #include <string>
 
 #include "starboard/common/check_op.h"
@@ -116,9 +117,6 @@ FfmpegVideoDecoderImpl<FFMPEG>::FfmpegVideoDecoderImpl(
   SB_DCHECK(g_registered) << "Decoder Specialization registration failed.";
   ffmpeg_ = FFMPEGDispatch::GetInstance();
   SB_DCHECK(ffmpeg_);
-  if ((ffmpeg_->specialization_version()) == FFMPEG) {
-    InitializeCodec();
-  }
 }
 
 FfmpegVideoDecoderImpl<FFMPEG>::~FfmpegVideoDecoderImpl() {
@@ -127,13 +125,19 @@ FfmpegVideoDecoderImpl<FFMPEG>::~FfmpegVideoDecoderImpl() {
 }
 
 // static
-FfmpegVideoDecoder* FfmpegVideoDecoderImpl<FFMPEG>::Create(
+std::unique_ptr<FfmpegVideoDecoder> FfmpegVideoDecoderImpl<FFMPEG>::Create(
     SbMediaVideoCodec video_codec,
     SbPlayerOutputMode output_mode,
     SbDecodeTargetGraphicsContextProvider*
         decode_target_graphics_context_provider) {
-  return new FfmpegVideoDecoderImpl<FFMPEG>(
+  auto decoder = std::make_unique<FfmpegVideoDecoderImpl<FFMPEG>>(
       video_codec, output_mode, decode_target_graphics_context_provider);
+  if (decoder->ffmpeg_->specialization_version() == FFMPEG) {
+    if (!decoder->InitializeCodec()) {
+      return nullptr;
+    }
+  }
+  return decoder;
 }
 
 void FfmpegVideoDecoderImpl<FFMPEG>::Initialize(
@@ -208,10 +212,6 @@ void FfmpegVideoDecoderImpl<FFMPEG>::Reset() {
   std::lock_guard lock(decode_target_and_frames_mutex_);
   decltype(frames_) frames;
   frames_ = std::queue<scoped_refptr<CpuVideoFrame>>();
-}
-
-bool FfmpegVideoDecoderImpl<FFMPEG>::is_valid() const {
-  return (ffmpeg_ != NULL) && ffmpeg_->is_valid() && (codec_context_ != NULL);
 }
 
 void FfmpegVideoDecoderImpl<FFMPEG>::DecoderThreadFunc() {
@@ -379,12 +379,12 @@ void FfmpegVideoDecoderImpl<FFMPEG>::UpdateDecodeTarget_Locked(
   }
 }
 
-void FfmpegVideoDecoderImpl<FFMPEG>::InitializeCodec() {
+bool FfmpegVideoDecoderImpl<FFMPEG>::InitializeCodec() {
   codec_context_ = ffmpeg_->avcodec_alloc_context3(NULL);
 
   if (codec_context_ == NULL) {
     SB_LOG(ERROR) << "Unable to allocate ffmpeg codec context";
-    return;
+    return false;
   }
 
   codec_context_->codec_type = AVMEDIA_TYPE_VIDEO;
@@ -415,14 +415,14 @@ void FfmpegVideoDecoderImpl<FFMPEG>::InitializeCodec() {
   if (codec == NULL) {
     SB_LOG(ERROR) << "Unable to allocate ffmpeg codec context";
     TeardownCodec();
-    return;
+    return false;
   }
 
   int rv = ffmpeg_->OpenCodec(codec_context_, codec);
   if (rv < 0) {
     SB_LOG(ERROR) << "Unable to open codec";
     TeardownCodec();
-    return;
+    return false;
   }
 
 #if LIBAVUTIL_VERSION_INT >= LIBAVUTIL_VERSION_52_8
@@ -433,7 +433,9 @@ void FfmpegVideoDecoderImpl<FFMPEG>::InitializeCodec() {
   if (av_frame_ == NULL) {
     SB_LOG(ERROR) << "Unable to allocate audio frame";
     TeardownCodec();
+    return false;
   }
+  return true;
 }
 
 void FfmpegVideoDecoderImpl<FFMPEG>::TeardownCodec() {

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
@@ -431,7 +431,7 @@ bool FfmpegVideoDecoderImpl<FFMPEG>::InitializeCodec() {
   av_frame_ = ffmpeg_->avcodec_alloc_frame();
 #endif  // LIBAVUTIL_VERSION_INT >= LIBAVUTIL_VERSION_52_8
   if (av_frame_ == NULL) {
-    SB_LOG(ERROR) << "Unable to allocate audio frame";
+    SB_LOG(ERROR) << "Unable to allocate video frame";
     TeardownCodec();
     return false;
   }

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
@@ -132,10 +132,9 @@ std::unique_ptr<FfmpegVideoDecoder> FfmpegVideoDecoderImpl<FFMPEG>::Create(
         decode_target_graphics_context_provider) {
   auto decoder = std::make_unique<FfmpegVideoDecoderImpl<FFMPEG>>(
       video_codec, output_mode, decode_target_graphics_context_provider);
-  if (decoder->ffmpeg_->specialization_version() == FFMPEG) {
-    if (!decoder->InitializeCodec()) {
-      return nullptr;
-    }
+  SB_CHECK_EQ(decoder->ffmpeg_->specialization_version(), FFMPEG);
+  if (!decoder->InitializeCodec()) {
+    return nullptr;
   }
   return decoder;
 }

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
@@ -130,7 +130,8 @@ class FfmpegVideoDecoderImpl<FFMPEG> : public FfmpegVideoDecoder {
   // Returns false if the frame contains invalid data.
   bool ProcessDecodedFrame(const AVFrame& av_frame);
 
-  FFMPEGDispatch* ffmpeg_;
+  // Guaranteed to be non-null.
+  FFMPEGDispatch* const ffmpeg_;
 
   // |video_codec_| will be initialized inside ctor and won't be changed during
   // the life time of this class.
@@ -144,11 +145,11 @@ class FfmpegVideoDecoderImpl<FFMPEG> : public FfmpegVideoDecoder {
 
   // The AV related classes will only be created and accessed on the decoder
   // thread.
-  AVCodecContext* codec_context_;
-  AVFrame* av_frame_;
+  AVCodecContext* codec_context_ = nullptr;
+  AVFrame* av_frame_ = nullptr;
 
-  bool stream_ended_;
-  bool error_occurred_;
+  bool stream_ended_ = false;
+  bool error_occurred_ = false;
 
   // Working thread to avoid lengthy decoding work block the player thread.
   std::unique_ptr<Thread> decoder_thread_;

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
@@ -16,6 +16,7 @@
 #define STARBOARD_SHARED_FFMPEG_FFMPEG_VIDEO_DECODER_IMPL_H_
 
 #include <limits>
+#include <memory>
 #include <mutex>
 #include <optional>
 #include <queue>
@@ -52,12 +53,11 @@ class FfmpegVideoDecoderImpl<FFMPEG> : public FfmpegVideoDecoder {
   ~FfmpegVideoDecoderImpl() override;
 
   // From: FfmpegVideoDecoder
-  static FfmpegVideoDecoder* Create(
+  static std::unique_ptr<FfmpegVideoDecoder> Create(
       SbMediaVideoCodec video_codec,
       SbPlayerOutputMode output_mode,
       SbDecodeTargetGraphicsContextProvider*
           decode_target_graphics_context_provider);
-  bool is_valid() const override;
 
   // From: VideoDecoder
   void Initialize(const DecoderStatusCB& decoder_status_cb,
@@ -116,7 +116,7 @@ class FfmpegVideoDecoderImpl<FFMPEG> : public FfmpegVideoDecoder {
   void DecoderThreadFunc();
 
   bool DecodePacket(AVPacket* packet);
-  void InitializeCodec();
+  bool InitializeCodec();
   void TeardownCodec();
   SbDecodeTarget GetCurrentDecodeTarget() override;
 

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
@@ -23,6 +23,7 @@
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "starboard/common/pass_key.h"
 #include "starboard/common/queue.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/common/thread.h"
@@ -46,7 +47,8 @@ class FfmpegVideoDecoderImpl<FFMPEG>;
 template <>
 class FfmpegVideoDecoderImpl<FFMPEG> : public FfmpegVideoDecoder {
  public:
-  FfmpegVideoDecoderImpl(SbMediaVideoCodec video_codec,
+  FfmpegVideoDecoderImpl(starboard::PassKey<FfmpegVideoDecoderImpl<FFMPEG>>,
+                         SbMediaVideoCodec video_codec,
                          SbPlayerOutputMode output_mode,
                          SbDecodeTargetGraphicsContextProvider*
                              decode_target_graphics_context_provider);

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl_interface.h
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl_interface.h
@@ -15,6 +15,8 @@
 #ifndef STARBOARD_SHARED_FFMPEG_FFMPEG_VIDEO_DECODER_IMPL_INTERFACE_H_
 #define STARBOARD_SHARED_FFMPEG_FFMPEG_VIDEO_DECODER_IMPL_INTERFACE_H_
 
+#include <memory>
+
 #include "starboard/media.h"
 #include "starboard/shared/ffmpeg/ffmpeg_video_decoder.h"
 #include "starboard/shared/internal_only.h"
@@ -26,7 +28,7 @@ namespace starboard {
 template <int V>
 class FfmpegVideoDecoderImpl : public FfmpegVideoDecoder {
  public:
-  static FfmpegVideoDecoder* Create(
+  static std::unique_ptr<FfmpegVideoDecoder> Create(
       SbMediaVideoCodec video_codec,
       SbPlayerOutputMode output_mode,
       SbDecodeTargetGraphicsContextProvider*


### PR DESCRIPTION
Remove explicit is_valid() methods from FFmpeg decoders and their
dispatch mechanisms. Instead, the static Create factory methods
for audio and video decoders now encapsulate the full initialization
logic. These methods return a nullptr if the decoder or underlying
FFmpeg libraries cannot be successfully initialized.

This simplifies client code by ensuring that any successfully returned
decoder object is always valid, eliminating the need for a subsequent
is_valid() check. Similarly, the FFMPEGDispatch::GetInstance()
method now returns nullptr if FFmpeg libraries fail to load, providing
a consistent "fail-fast" approach for FFmpeg component creation.

Issue: 479994435