### PR TITLE
tvOS: Report compressed memory as swap on tvOS

### DIFF
--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -61,16 +61,19 @@ void PerformanceImpl::MeasureUsedCpuMemory(
 
 void PerformanceImpl::MeasureUsedSwapMemory(
     MeasureUsedSwapMemoryCallback callback) {
-#if BUILDFLAG(IS_IOS_TVOS)
-  // TODO: b/497682329 - vm_swap_bytes does not exist on tvOS.
-  std::move(callback).Run(0);
-#else
   auto process_metrics = base::ProcessMetrics::CreateProcessMetrics(
       base::GetCurrentProcessHandle());
   auto info = process_metrics->GetMemoryInfo();
-  auto used_swap_memory = info.has_value() ? info->vm_swap_bytes : 0;
-  std::move(callback).Run(used_swap_memory);
+  uint64_t used_memory;
+#if BUILDFLAG(IS_IOS_TVOS)
+  // TODO: b/497682329 - vm_swap_bytes does not exist on tvOS. Instead, use
+  // compressed_bytes as a proxy for swap memory until we have a better
+  // solution.
+  used_memory = info.has_value() ? info->compressed_bytes : 0;
+#else
+  used_memory = info.has_value() ? info->vm_swap_bytes : 0;
 #endif  // BUILDFLAG(IS_IOS_TVOS)
+  std::move(callback).Run(used_memory);
 }
 
 void PerformanceImpl::MeasureReservedVirtualMemory(


### PR DESCRIPTION
tvOS does not provide a direct API to measure swap memory usage. Instead,
it utilizes memory compression under pressure. This change updates
MeasureUsedSwapMemory to return the process's compressed memory bytes
as a proxy for swap memory on tvOS. This provides a more meaningful
metric than always reporting zero, addressing a previous TODO.

Bug: 497682329