### PR TITLE
starboard: Make JobToken opaque

### DIFF
--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -462,8 +462,7 @@ void AudioRendererPassthrough::FlushAudioTrackAndStopProcessing(
   seek_to_time_ = seek_to_time;
   paused_ = true;
   if (update_status_and_write_data_token_.is_valid()) {
-    audio_track_thread_->RemoveJobByToken(update_status_and_write_data_token_);
-    update_status_and_write_data_token_.ResetToInvalid();
+    audio_track_thread_->RemoveJobByToken(&update_status_and_write_data_token_);
   }
 }
 

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -403,7 +403,7 @@ void AudioRendererPassthrough::CreateAudioTrackAndStartProcessing() {
   SB_DCHECK(error_cb_);
 
   if (audio_track_bridge_) {
-    SB_DCHECK(!update_status_and_write_data_token_.is_valid());
+    SB_DCHECK(!update_status_and_write_data_token_);
     AudioTrackState initial_state;
     update_status_and_write_data_token_ = audio_track_thread_->Schedule(
         std::bind(&AudioRendererPassthrough::UpdateStatusAndWriteData, this,
@@ -461,7 +461,7 @@ void AudioRendererPassthrough::FlushAudioTrackAndStopProcessing(
   }
   seek_to_time_ = seek_to_time;
   paused_ = true;
-  if (update_status_and_write_data_token_.is_valid()) {
+  if (update_status_and_write_data_token_) {
     audio_track_thread_->RemoveJobByToken(&update_status_and_write_data_token_);
   }
 }

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -134,7 +134,7 @@ class AudioRendererPassthrough : public AudioRenderer,
   scoped_refptr<DecodedAudio> decoded_audio_writing_in_progress_;
   int decoded_audio_writing_offset_ = 0;
   JobQueue::JobToken update_status_and_write_data_token_ =
-      JobQueue::JobToken::InvalidToken();
+      JobQueue::JobToken::kInvalid;
   int64_t total_frames_written_on_audio_track_thread_ = 0;
 
   std::atomic_bool audio_track_paused_{true};

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -134,7 +134,7 @@ class AudioRendererPassthrough : public AudioRenderer,
   scoped_refptr<DecodedAudio> decoded_audio_writing_in_progress_;
   int decoded_audio_writing_offset_ = 0;
   JobQueue::JobToken update_status_and_write_data_token_ =
-      JobQueue::JobToken::kInvalid;
+      JobQueue::JobToken::kUnscheduled;
   int64_t total_frames_written_on_audio_track_thread_ = 0;
 
   std::atomic_bool audio_track_paused_{true};

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -133,7 +133,8 @@ class AudioRendererPassthrough : public AudioRenderer,
   // after |audio_track_thread_| is destroyed (in Seek()).
   scoped_refptr<DecodedAudio> decoded_audio_writing_in_progress_;
   int decoded_audio_writing_offset_ = 0;
-  JobQueue::JobToken update_status_and_write_data_token_;
+  JobQueue::JobToken update_status_and_write_data_token_ =
+      JobQueue::JobToken::InvalidToken();
   int64_t total_frames_written_on_audio_track_thread_ = 0;
 
   std::atomic_bool audio_track_paused_{true};

--- a/starboard/raspi/shared/open_max/video_decoder.cc
+++ b/starboard/raspi/shared/open_max/video_decoder.cc
@@ -50,7 +50,7 @@ OpenMaxVideoDecoder::~OpenMaxVideoDecoder() {
     }
     pthread_join(*thread_, nullptr);
   }
-  RemoveJobByToken(update_job_token_);
+  RemoveJobByToken(&update_job_token_);
 }
 
 void OpenMaxVideoDecoder::Initialize(const DecoderStatusCB& decoder_status_cb,

--- a/starboard/raspi/shared/open_max/video_decoder.h
+++ b/starboard/raspi/shared/open_max/video_decoder.h
@@ -91,7 +91,7 @@ class OpenMaxVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
   std::queue<OMX_BUFFERHEADERTYPE*> filled_buffers_;
   std::queue<OMX_BUFFERHEADERTYPE*> freed_buffers_;
 
-  JobQueue::JobToken update_job_token_;
+  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::InvalidToken();
   std::function<void()> update_job_;
 };
 

--- a/starboard/raspi/shared/open_max/video_decoder.h
+++ b/starboard/raspi/shared/open_max/video_decoder.h
@@ -91,7 +91,7 @@ class OpenMaxVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
   std::queue<OMX_BUFFERHEADERTYPE*> filled_buffers_;
   std::queue<OMX_BUFFERHEADERTYPE*> freed_buffers_;
 
-  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::kInvalid;
+  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::kUnscheduled;
   std::function<void()> update_job_;
 };
 

--- a/starboard/raspi/shared/open_max/video_decoder.h
+++ b/starboard/raspi/shared/open_max/video_decoder.h
@@ -91,7 +91,7 @@ class OpenMaxVideoDecoder : public VideoDecoder, private JobQueue::JobOwner {
   std::queue<OMX_BUFFERHEADERTYPE*> filled_buffers_;
   std::queue<OMX_BUFFERHEADERTYPE*> freed_buffers_;
 
-  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::InvalidToken();
+  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::kInvalid;
   std::function<void()> update_job_;
 };
 

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -590,7 +590,7 @@ void AudioRendererPcm::OnDecoderOutput() {
 void AudioRendererPcm::ProcessAudioData() {
   SB_CHECK(BelongsToCurrentThread());
 
-  process_audio_data_job_token_ = JobQueue::JobToken::InvalidToken();
+  process_audio_data_job_token_ = JobQueue::JobToken::kInvalid;
 
   // Loop until no audio is appended, i.e. AppendAudioToFrameBuffer() returns
   // false.

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -590,7 +590,7 @@ void AudioRendererPcm::OnDecoderOutput() {
 void AudioRendererPcm::ProcessAudioData() {
   SB_CHECK(BelongsToCurrentThread());
 
-  process_audio_data_job_token_ = JobQueue::JobToken::kInvalid;
+  process_audio_data_job_token_ = JobQueue::JobToken::kUnscheduled;
 
   // Loop until no audio is appended, i.e. AppendAudioToFrameBuffer() returns
   // false.

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -224,10 +224,7 @@ void AudioRendererPcm::SetPlaybackRate(double playback_rate) {
   audio_renderer_sink_->SetPlaybackRate(adjusted_playback_rate);
   if (audio_renderer_sink_->HasStarted()) {
     if (playback_rate_ > 0.0) {
-      if (process_audio_data_job_token_.is_valid()) {
-        RemoveJobByToken(process_audio_data_job_token_);
-        process_audio_data_job_token_.ResetToInvalid();
-      }
+      RemoveJobByToken(&process_audio_data_job_token_);
       process_audio_data_job_token_ = Schedule(process_audio_data_job_);
     }
   }
@@ -264,7 +261,6 @@ void AudioRendererPcm::Seek(int64_t seek_to_time) {
   audio_frame_tracker_.Reset();
   frames_consumed_set_at_ = CurrentMonotonicTime();
   can_accept_more_data_ = true;
-  process_audio_data_job_token_.ResetToInvalid();
 
   is_eos_reached_on_sink_thread_ = false;
   is_playing_on_sink_thread_ = false;
@@ -586,10 +582,7 @@ void AudioRendererPcm::OnDecoderOutput() {
 
   ++pending_decoder_outputs_;
 
-  if (process_audio_data_job_token_.is_valid()) {
-    RemoveJobByToken(process_audio_data_job_token_);
-    process_audio_data_job_token_.ResetToInvalid();
-  }
+  RemoveJobByToken(&process_audio_data_job_token_);
 
   ProcessAudioData();
 }
@@ -597,7 +590,7 @@ void AudioRendererPcm::OnDecoderOutput() {
 void AudioRendererPcm::ProcessAudioData() {
   SB_CHECK(BelongsToCurrentThread());
 
-  process_audio_data_job_token_.ResetToInvalid();
+  process_audio_data_job_token_ = JobQueue::JobToken::InvalidToken();
 
   // Loop until no audio is appended, i.e. AppendAudioToFrameBuffer() returns
   // false.

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -173,7 +173,7 @@ class AudioRendererPcm : public AudioRenderer,
 
   bool can_accept_more_data_ = true;
   JobQueue::JobToken process_audio_data_job_token_ =
-      JobQueue::JobToken::InvalidToken();
+      JobQueue::JobToken::kInvalid;
   std::function<void()> process_audio_data_job_;
 
   // Our owner will attempt to seek to time 0 when playback begins.  In

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -173,7 +173,7 @@ class AudioRendererPcm : public AudioRenderer,
 
   bool can_accept_more_data_ = true;
   JobQueue::JobToken process_audio_data_job_token_ =
-      JobQueue::JobToken::kInvalid;
+      JobQueue::JobToken::kUnscheduled;
   std::function<void()> process_audio_data_job_;
 
   // Our owner will attempt to seek to time 0 when playback begins.  In

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -172,7 +172,8 @@ class AudioRendererPcm : public AudioRenderer,
   int32_t pending_decoder_outputs_ = 0;
 
   bool can_accept_more_data_ = true;
-  JobQueue::JobToken process_audio_data_job_token_;
+  JobQueue::JobToken process_audio_data_job_token_ =
+      JobQueue::JobToken::InvalidToken();
   std::function<void()> process_audio_data_job_;
 
   // Our owner will attempt to seek to time 0 when playback begins.  In

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -505,7 +505,7 @@ void FilterBasedPlayerWorkerHandler::Update() {
     update_media_info_cb_(media_time, dropped_frames, !is_underflow);
   }
 
-  RemoveJobByToken(update_job_token_);
+  RemoveJobByToken(&update_job_token_);
   update_job_token_ = Schedule(update_job_, kUpdateIntervalUsec);
 }
 
@@ -517,7 +517,7 @@ void FilterBasedPlayerWorkerHandler::Stop() {
   audio_preroll_track_.End();
   video_preroll_track_.End();
 
-  RemoveJobByToken(update_job_token_);
+  RemoveJobByToken(&update_job_token_);
 
   std::unique_ptr<PlayerComponents> player_components;
   {

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -105,7 +105,7 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   double playback_rate_ = 1.0;
   double volume_ = 1.0;
   PlayerWorker::Bounds bounds_ = {};
-  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::kInvalid;
+  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::kUnscheduled;
   std::function<void()> update_job_;
 
   bool audio_prerolled_ = false;

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -105,7 +105,7 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   double playback_rate_ = 1.0;
   double volume_ = 1.0;
   PlayerWorker::Bounds bounds_ = {};
-  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::InvalidToken();
+  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::kInvalid;
   std::function<void()> update_job_;
 
   bool audio_prerolled_ = false;

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h
@@ -105,7 +105,7 @@ class FilterBasedPlayerWorkerHandler : public PlayerWorker::Handler,
   double playback_rate_ = 1.0;
   double volume_ = 1.0;
   PlayerWorker::Bounds bounds_ = {};
-  JobQueue::JobToken update_job_token_;
+  JobQueue::JobToken update_job_token_ = JobQueue::JobToken::InvalidToken();
   std::function<void()> update_job_;
 
   bool audio_prerolled_ = false;

--- a/starboard/shared/starboard/player/job_queue.cc
+++ b/starboard/shared/starboard/player/job_queue.cc
@@ -22,6 +22,11 @@ namespace starboard {
 
 const JobQueue::JobToken JobQueue::JobToken::kInvalid = JobQueue::JobToken();
 
+JobQueue::JobToken JobQueue::JobToken::Generate() {
+  static std::atomic<int64_t> s_current_token{0};
+  return JobToken(s_current_token.fetch_add(1, std::memory_order_relaxed) + 1);
+}
+
 JobQueue::JobQueue() = default;
 
 JobQueue::~JobQueue() {
@@ -130,9 +135,7 @@ JobQueue::JobToken JobQueue::Schedule(Job&& job,
     return JobToken::kInvalid;
   }
 
-  ++current_job_token_;
-
-  JobToken job_token(current_job_token_);
+  JobToken job_token = JobToken::Generate();
   JobRecord job_record = {job_token, std::move(job), owner};
 #if ENABLE_JOB_QUEUE_PROFILING
   if (kProfileStackDepth > 0) {

--- a/starboard/shared/starboard/player/job_queue.cc
+++ b/starboard/shared/starboard/player/job_queue.cc
@@ -14,6 +14,7 @@
 
 #include "starboard/shared/starboard/player/job_queue.h"
 
+#include <atomic>
 #include <chrono>
 
 #include "starboard/system.h"

--- a/starboard/shared/starboard/player/job_queue.cc
+++ b/starboard/shared/starboard/player/job_queue.cc
@@ -20,6 +20,8 @@
 
 namespace starboard {
 
+const JobQueue::JobToken JobQueue::JobToken::kInvalid = JobQueue::JobToken();
+
 JobQueue::JobQueue() = default;
 
 JobQueue::~JobQueue() {
@@ -62,7 +64,7 @@ void JobQueue::ScheduleAndWait(Job&& job) {
 void JobQueue::RemoveJobByToken(JobToken* job_token) {
   SB_CHECK(BelongsToCurrentThread());
 
-  if (!job_token->is_valid()) {
+  if (!*job_token) {
     return;
   }
 
@@ -125,7 +127,7 @@ JobQueue::JobToken JobQueue::Schedule(Job&& job,
 
   std::lock_guard lock(mutex_);
   if (stopped_) {
-    return JobToken::InvalidToken();
+    return JobToken::kInvalid;
   }
 
   ++current_job_token_;

--- a/starboard/shared/starboard/player/job_queue.cc
+++ b/starboard/shared/starboard/player/job_queue.cc
@@ -21,7 +21,8 @@
 
 namespace starboard {
 
-const JobQueue::JobToken JobQueue::JobToken::kInvalid = JobQueue::JobToken();
+const JobQueue::JobToken JobQueue::JobToken::kUnscheduled =
+    JobQueue::JobToken();
 
 JobQueue::JobToken JobQueue::JobToken::Generate() {
   static std::atomic<int64_t> s_current_token{0};
@@ -135,7 +136,7 @@ JobQueue::JobToken JobQueue::Schedule(Job&& job,
 
   std::lock_guard lock(mutex_);
   if (stopped_) {
-    return JobToken::kInvalid;
+    return JobToken::kUnscheduled;
   }
 
   JobToken job_token = JobToken::Generate();

--- a/starboard/shared/starboard/player/job_queue.cc
+++ b/starboard/shared/starboard/player/job_queue.cc
@@ -59,18 +59,19 @@ void JobQueue::ScheduleAndWait(Job&& job) {
   condition_.wait(lock, [&] { return job_finished || stopped_; });
 }
 
-void JobQueue::RemoveJobByToken(JobToken job_token) {
+void JobQueue::RemoveJobByToken(JobToken* job_token) {
   SB_CHECK(BelongsToCurrentThread());
 
-  if (!job_token.is_valid()) {
+  if (!job_token->is_valid()) {
     return;
   }
 
   std::lock_guard lock(mutex_);
   for (TimeToJobRecordMap::iterator iter = time_to_job_record_map_.begin();
        iter != time_to_job_record_map_.end(); ++iter) {
-    if (iter->second.job_token == job_token) {
+    if (iter->second.job_token == *job_token) {
       time_to_job_record_map_.erase(iter);
+      job_token->Reset();
       return;
     }
   }
@@ -124,7 +125,7 @@ JobQueue::JobToken JobQueue::Schedule(Job&& job,
 
   std::lock_guard lock(mutex_);
   if (stopped_) {
-    return JobToken();
+    return JobToken::InvalidToken();
   }
 
   ++current_job_token_;

--- a/starboard/shared/starboard/player/job_queue.cc
+++ b/starboard/shared/starboard/player/job_queue.cc
@@ -74,15 +74,17 @@ void JobQueue::RemoveJobByToken(JobToken* job_token) {
     return;
   }
 
-  std::lock_guard lock(mutex_);
-  for (TimeToJobRecordMap::iterator iter = time_to_job_record_map_.begin();
-       iter != time_to_job_record_map_.end(); ++iter) {
-    if (iter->second.job_token == *job_token) {
-      time_to_job_record_map_.erase(iter);
-      job_token->Reset();
-      return;
+  {
+    std::lock_guard lock(mutex_);
+    for (TimeToJobRecordMap::iterator iter = time_to_job_record_map_.begin();
+         iter != time_to_job_record_map_.end(); ++iter) {
+      if (iter->second.job_token == *job_token) {
+        time_to_job_record_map_.erase(iter);
+        break;
+      }
     }
   }
+  job_token->Reset();
 }
 
 void JobQueue::StopSoon() {

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -171,7 +171,7 @@ class JobQueue {
   ThreadChecker thread_checker_;
   std::mutex mutex_;
   std::condition_variable condition_;
-  TimeToJobRecordMap time_to_job_record_map_;
+  TimeToJobRecordMap time_to_job_record_map_;  // Guarded by |mutex_|.
   bool stopped_ = false;
 
 #if ENABLE_JOB_QUEUE_PROFILING

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -48,17 +48,17 @@ class JobQueue {
 
   class JobToken {
    public:
-    static const JobToken kInvalid;
+    static const JobToken kUnscheduled;
 
     explicit operator bool() const { return token_.has_value(); }
 
    private:
     friend class JobQueue;
 
+    static JobToken Generate();
+
     JobToken() = default;
     explicit JobToken(int64_t token) : token_(token) {}
-
-    static JobToken Generate();
 
     void Reset() { token_ = std::nullopt; }
 

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_SHARED_STARBOARD_PLAYER_JOB_QUEUE_H_
 #define STARBOARD_SHARED_STARBOARD_PLAYER_JOB_QUEUE_H_
 
+#include <atomic>
 #include <condition_variable>
 #include <functional>
 #include <map>
@@ -56,6 +57,8 @@ class JobQueue {
 
     JobToken() = default;
     explicit JobToken(int64_t token) : token_(token) {}
+
+    static JobToken Generate();
 
     void Reset() { token_ = std::nullopt; }
 
@@ -168,7 +171,6 @@ class JobQueue {
   ThreadChecker thread_checker_;
   std::mutex mutex_;
   std::condition_variable condition_;
-  int64_t current_job_token_ = 0;
   TimeToJobRecordMap time_to_job_record_map_;
   bool stopped_ = false;
 

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -47,9 +47,9 @@ class JobQueue {
 
   class JobToken {
    public:
-    static JobToken InvalidToken() { return JobToken(); }
+    static const JobToken kInvalid;
 
-    bool is_valid() const { return token_.has_value(); }
+    explicit operator bool() const { return token_.has_value(); }
 
    private:
     friend class JobQueue;

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -15,12 +15,11 @@
 #ifndef STARBOARD_SHARED_STARBOARD_PLAYER_JOB_QUEUE_H_
 #define STARBOARD_SHARED_STARBOARD_PLAYER_JOB_QUEUE_H_
 
-#include <atomic>
-#include <optional>
 #include <condition_variable>
 #include <functional>
 #include <map>
 #include <mutex>
+#include <optional>
 #include <utility>
 
 #include "starboard/common/check_op.h"

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -43,22 +43,27 @@ namespace starboard {
 // A thread can only have one job queue.
 class JobQueue {
  public:
-  typedef std::function<void()> Job;
+  using Job = std::function<void()>;
 
   class JobToken {
    public:
-    static const int64_t kInvalidToken = -1;
+    static JobToken InvalidToken() { return JobToken(); }
 
-    explicit JobToken(int64_t token = kInvalidToken) : token_(token) {}
+    bool is_valid() const { return token_.has_value(); }
 
-    void ResetToInvalid() { token_ = kInvalidToken; }
-    bool is_valid() const { return token_ != kInvalidToken; }
+   private:
+    friend class JobQueue;
+
+    JobToken() = default;
+    explicit JobToken(int64_t token) : token_(token) {}
+
+    void Reset() { token_ = std::nullopt; }
+
     bool operator==(const JobToken& that) const {
       return token_ == that.token_;
     }
 
-   private:
-    int64_t token_;
+    std::optional<int64_t> token_;
   };
 
   class JobOwner {
@@ -80,9 +85,10 @@ class JobQueue {
       return job_queue_->Schedule(std::move(job), this, delay_usec);
     }
 
-    void RemoveJobByToken(JobToken job_token) {
-      return job_queue_->RemoveJobByToken(job_token);
+    void RemoveJobByToken(JobToken* job_token) {
+      job_queue_->RemoveJobByToken(job_token);
     }
+
     void CancelPendingJobs() {
       if (job_queue_) {
         job_queue_->RemoveJobsByOwner(this);
@@ -119,7 +125,7 @@ class JobQueue {
   JobToken Schedule(Job&& job, int64_t delay_usec = 0);
   void ScheduleAndWait(const Job& job);
   void ScheduleAndWait(Job&& job);
-  void RemoveJobByToken(JobToken job_token);
+  void RemoveJobByToken(JobToken* job_token);
 
   // The processing of jobs may not be stopped when this function returns, but
   // it is guaranteed that the processing will be stopped very soon.  So it is
@@ -162,7 +168,7 @@ class JobQueue {
   ThreadChecker thread_checker_;
   std::mutex mutex_;
   std::condition_variable condition_;
-  int64_t current_job_token_ = JobToken::kInvalidToken + 1;
+  int64_t current_job_token_ = 0;
   TimeToJobRecordMap time_to_job_record_map_;
   bool stopped_ = false;
 

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -16,6 +16,7 @@
 #define STARBOARD_SHARED_STARBOARD_PLAYER_JOB_QUEUE_H_
 
 #include <atomic>
+#include <optional>
 #include <condition_variable>
 #include <functional>
 #include <map>

--- a/starboard/shared/starboard/player/job_queue_test.cc
+++ b/starboard/shared/starboard/player/job_queue_test.cc
@@ -98,7 +98,7 @@ TEST_F(JobQueueTest, RemovedJobsAreRemoved) {
   auto job_token_2 = job_queue_.Schedule([&]() { job_2 = true; });
 
   // Cancel job 1.
-  job_queue_.RemoveJobByToken(job_token_1);
+  job_queue_.RemoveJobByToken(&job_token_1);
 
   job_queue_.RunUntilIdle();
 
@@ -107,7 +107,7 @@ TEST_F(JobQueueTest, RemovedJobsAreRemoved) {
   EXPECT_TRUE(job_2);
 
   // Should be a no-op since job 2 already ran.
-  job_queue_.RemoveJobByToken(job_token_2);
+  job_queue_.RemoveJobByToken(&job_token_2);
 }
 
 TEST_F(JobQueueTest, RunUntilStoppedExecutesAllRemainingJobs) {

--- a/starboard/shared/starboard/player/job_thread.h
+++ b/starboard/shared/starboard/player/job_thread.h
@@ -72,8 +72,8 @@ class JobThread {
     job_queue_->ScheduleAndWait(std::move(job));
   }
 
-  void RemoveJobByToken(JobQueue::JobToken job_token) {
-    return job_queue_->RemoveJobByToken(job_token);
+  void RemoveJobByToken(JobQueue::JobToken* job_token) {
+    job_queue_->RemoveJobByToken(job_token);
   }
 
   JobQueue* job_queue() const { return job_queue_.get(); }

--- a/starboard/shared/starboard/player/job_thread_test.cc
+++ b/starboard/shared/starboard/player/job_thread_test.cc
@@ -100,7 +100,8 @@ TEST(JobThreadTest, ScheduledJobsShouldNotExecuteAfterGoingOutOfScope) {
 
 TEST(JobThreadTest, CanceledJobsAreCanceled) {
   std::atomic_int counter_1 = {0}, counter_2 = {0};
-  JobQueue::JobToken job_token_1, job_token_2;
+  JobQueue::JobToken job_token_1 = JobQueue::JobToken::InvalidToken();
+  JobQueue::JobToken job_token_2 = JobQueue::JobToken::InvalidToken();
 
   auto job_thread = JobThread::Create("JobThreadTests");
   std::function<void()> job_1 = [&]() {
@@ -120,7 +121,7 @@ TEST(JobThreadTest, CanceledJobsAreCanceled) {
 
   // Cancel job 1 and grab the current counter values.
   job_thread->ScheduleAndWait(
-      [&]() { job_thread->RemoveJobByToken(job_token_1); });
+      [&]() { job_thread->RemoveJobByToken(&job_token_1); });
   int checkpoint_1 = counter_1;
   int checkpoint_2 = counter_2;
 
@@ -136,7 +137,7 @@ TEST(JobThreadTest, CanceledJobsAreCanceled) {
 
   // Cancel job 2 to avoid it scheduling itself during destruction.
   job_thread->ScheduleAndWait(
-      [&]() { job_thread->RemoveJobByToken(job_token_2); });
+      [&]() { job_thread->RemoveJobByToken(&job_token_2); });
   job_thread->Stop();
 }
 

--- a/starboard/shared/starboard/player/job_thread_test.cc
+++ b/starboard/shared/starboard/player/job_thread_test.cc
@@ -100,8 +100,8 @@ TEST(JobThreadTest, ScheduledJobsShouldNotExecuteAfterGoingOutOfScope) {
 
 TEST(JobThreadTest, CanceledJobsAreCanceled) {
   std::atomic_int counter_1 = {0}, counter_2 = {0};
-  JobQueue::JobToken job_token_1 = JobQueue::JobToken::kInvalid;
-  JobQueue::JobToken job_token_2 = JobQueue::JobToken::kInvalid;
+  JobQueue::JobToken job_token_1 = JobQueue::JobToken::kUnscheduled;
+  JobQueue::JobToken job_token_2 = JobQueue::JobToken::kUnscheduled;
 
   auto job_thread = JobThread::Create("JobThreadTests");
   std::function<void()> job_1 = [&]() {

--- a/starboard/shared/starboard/player/job_thread_test.cc
+++ b/starboard/shared/starboard/player/job_thread_test.cc
@@ -100,8 +100,8 @@ TEST(JobThreadTest, ScheduledJobsShouldNotExecuteAfterGoingOutOfScope) {
 
 TEST(JobThreadTest, CanceledJobsAreCanceled) {
   std::atomic_int counter_1 = {0}, counter_2 = {0};
-  JobQueue::JobToken job_token_1 = JobQueue::JobToken::InvalidToken();
-  JobQueue::JobToken job_token_2 = JobQueue::JobToken::InvalidToken();
+  JobQueue::JobToken job_token_1 = JobQueue::JobToken::kInvalid;
+  JobQueue::JobToken job_token_2 = JobQueue::JobToken::kInvalid;
 
   auto job_thread = JobThread::Create("JobThreadTests");
   std::function<void()> job_1 = [&]() {

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -239,7 +239,7 @@ void PlayerWorker::DoWriteSamples(InputBuffers input_buffers) {
       pending_video_buffers_ = std::move(input_buffers);
       SB_DCHECK_EQ(pending_video_buffers_.size(), num_of_pending_buffers);
     }
-    if (!write_pending_sample_job_token_.is_valid()) {
+    if (!write_pending_sample_job_token_) {
       write_pending_sample_job_token_ = job_thread_->Schedule(
           [this] { DoWritePendingSamples(); }, kWritePendingSampleDelayUsec);
     }
@@ -248,7 +248,7 @@ void PlayerWorker::DoWriteSamples(InputBuffers input_buffers) {
 
 void PlayerWorker::DoWritePendingSamples() {
   SB_CHECK(job_thread_->BelongsToCurrentThread());
-  SB_CHECK(write_pending_sample_job_token_.is_valid());
+  SB_CHECK(write_pending_sample_job_token_);
 
   if (!pending_audio_buffers_.empty()) {
     SB_DCHECK_NE(audio_codec_, kSbMediaAudioCodecNone);

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -253,7 +253,7 @@ void PlayerWorker::DoWritePendingSamples() {
   // We must manually invalidate the token here to signal the pending task has
   // executed. This needs to happen BEFORE calling DoWriteSamples() so that any
   // partial writes can correctly reschedule the next pending job.
-  write_pending_sample_job_token_ = JobQueue::JobToken::kInvalid;
+  write_pending_sample_job_token_ = JobQueue::JobToken::kUnscheduled;
 
   if (!pending_audio_buffers_.empty()) {
     SB_DCHECK_NE(audio_codec_, kSbMediaAudioCodecNone);

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -170,10 +170,7 @@ void PlayerWorker::DoSeek(int64_t seek_to_time, int ticket) {
 
   SB_DLOG(INFO) << "Try to seek to " << seek_to_time << " microseconds.";
 
-  if (write_pending_sample_job_token_.is_valid()) {
-    job_thread_->RemoveJobByToken(write_pending_sample_job_token_);
-    write_pending_sample_job_token_.ResetToInvalid();
-  }
+  job_thread_->RemoveJobByToken(&write_pending_sample_job_token_);
 
   pending_audio_buffers_.clear();
   pending_video_buffers_.clear();
@@ -251,8 +248,7 @@ void PlayerWorker::DoWriteSamples(InputBuffers input_buffers) {
 
 void PlayerWorker::DoWritePendingSamples() {
   SB_CHECK(job_thread_->BelongsToCurrentThread());
-  SB_DCHECK(write_pending_sample_job_token_.is_valid());
-  write_pending_sample_job_token_.ResetToInvalid();
+  SB_CHECK(write_pending_sample_job_token_.is_valid());
 
   if (!pending_audio_buffers_.empty()) {
     SB_DCHECK_NE(audio_codec_, kSbMediaAudioCodecNone);

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -248,7 +248,12 @@ void PlayerWorker::DoWriteSamples(InputBuffers input_buffers) {
 
 void PlayerWorker::DoWritePendingSamples() {
   SB_CHECK(job_thread_->BelongsToCurrentThread());
-  SB_CHECK(write_pending_sample_job_token_);
+  SB_DCHECK(write_pending_sample_job_token_);
+
+  // We must manually invalidate the token here to signal the pending task has
+  // executed. This needs to happen BEFORE calling DoWriteSamples() so that any
+  // partial writes can correctly reschedule the next pending job.
+  write_pending_sample_job_token_ = JobQueue::JobToken::kInvalid;
 
   if (!pending_audio_buffers_.empty()) {
     SB_DCHECK_NE(audio_codec_, kSbMediaAudioCodecNone);

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -219,7 +219,7 @@ class PlayerWorker {
   InputBuffers pending_audio_buffers_;
   InputBuffers pending_video_buffers_;
   JobQueue::JobToken write_pending_sample_job_token_ =
-      JobQueue::JobToken::kInvalid;
+      JobQueue::JobToken::kUnscheduled;
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -219,7 +219,7 @@ class PlayerWorker {
   InputBuffers pending_audio_buffers_;
   InputBuffers pending_video_buffers_;
   JobQueue::JobToken write_pending_sample_job_token_ =
-      JobQueue::JobToken::InvalidToken();
+      JobQueue::JobToken::kInvalid;
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/player_worker.h
+++ b/starboard/shared/starboard/player/player_worker.h
@@ -218,7 +218,8 @@ class PlayerWorker {
   SbPlayerState player_state_;
   InputBuffers pending_audio_buffers_;
   InputBuffers pending_video_buffers_;
-  JobQueue::JobToken write_pending_sample_job_token_;
+  JobQueue::JobToken write_pending_sample_job_token_ =
+      JobQueue::JobToken::InvalidToken();
 };
 
 }  // namespace starboard

--- a/starboard/tvos/shared/media/av_sample_buffer_video_renderer.h
+++ b/starboard/tvos/shared/media/av_sample_buffer_video_renderer.h
@@ -116,7 +116,7 @@ class AVSBVideoRenderer : public VideoRenderer, private JobQueue::JobOwner {
   std::unique_ptr<AVVideoSampleBufferBuilder> sample_buffer_builder_;
   std::queue<scoped_refptr<AVSampleBuffer>> video_sample_buffers_;
   JobQueue::JobToken enqueue_sample_buffers_job_token_ =
-      JobQueue::JobToken::kInvalid;
+      JobQueue::JobToken::kUnscheduled;
 
   int64_t seek_to_time_ = 0;
   int64_t media_time_offset_ = 0;

--- a/starboard/tvos/shared/media/av_sample_buffer_video_renderer.h
+++ b/starboard/tvos/shared/media/av_sample_buffer_video_renderer.h
@@ -116,7 +116,7 @@ class AVSBVideoRenderer : public VideoRenderer, private JobQueue::JobOwner {
   std::unique_ptr<AVVideoSampleBufferBuilder> sample_buffer_builder_;
   std::queue<scoped_refptr<AVSampleBuffer>> video_sample_buffers_;
   JobQueue::JobToken enqueue_sample_buffers_job_token_ =
-      JobQueue::JobToken::InvalidToken();
+      JobQueue::JobToken::kInvalid;
 
   int64_t seek_to_time_ = 0;
   int64_t media_time_offset_ = 0;

--- a/starboard/tvos/shared/media/av_sample_buffer_video_renderer.h
+++ b/starboard/tvos/shared/media/av_sample_buffer_video_renderer.h
@@ -115,7 +115,8 @@ class AVSBVideoRenderer : public VideoRenderer, private JobQueue::JobOwner {
   DrmSystemPlatform* drm_system_ = nullptr;
   std::unique_ptr<AVVideoSampleBufferBuilder> sample_buffer_builder_;
   std::queue<scoped_refptr<AVSampleBuffer>> video_sample_buffers_;
-  JobQueue::JobToken enqueue_sample_buffers_job_token_;
+  JobQueue::JobToken enqueue_sample_buffers_job_token_ =
+      JobQueue::JobToken::InvalidToken();
 
   int64_t seek_to_time_ = 0;
   int64_t media_time_offset_ = 0;

--- a/starboard/tvos/shared/media/av_sample_buffer_video_renderer.mm
+++ b/starboard/tvos/shared/media/av_sample_buffer_video_renderer.mm
@@ -295,7 +295,7 @@ void AVSBVideoRenderer::Seek(int64_t seek_to_time) {
   }
   sample_buffer_builder_->Reset();
   CancelPendingJobs();
-  enqueue_sample_buffers_job_token_.ResetToInvalid();
+  enqueue_sample_buffers_job_token_ = JobQueue::JobToken::kInvalid;
 
   prerolled_frames_ = 0;
   pts_of_first_written_buffer_ = 0;
@@ -601,8 +601,7 @@ void AVSBVideoRenderer::EnqueueSampleBuffers() {
 
     UpdateCachedFramesWatermark();
 
-    if (!video_sample_buffers_.empty() &&
-        !enqueue_sample_buffers_job_token_.is_valid()) {
+    if (!video_sample_buffers_.empty() && !enqueue_sample_buffers_job_token_) {
       enqueue_sample_buffers_job_token_ = Schedule(
           std::bind(&AVSBVideoRenderer::DelayedEnqueueSampleBuffers, this),
           16000);
@@ -620,7 +619,7 @@ void AVSBVideoRenderer::EnqueueSampleBuffers() {
 }
 
 void AVSBVideoRenderer::DelayedEnqueueSampleBuffers() {
-  enqueue_sample_buffers_job_token_.ResetToInvalid();
+  enqueue_sample_buffers_job_token_ = JobQueue::JobToken::kInvalid;
   EnqueueSampleBuffers();
 }
 

--- a/starboard/tvos/shared/media/av_sample_buffer_video_renderer.mm
+++ b/starboard/tvos/shared/media/av_sample_buffer_video_renderer.mm
@@ -295,7 +295,7 @@ void AVSBVideoRenderer::Seek(int64_t seek_to_time) {
   }
   sample_buffer_builder_->Reset();
   CancelPendingJobs();
-  enqueue_sample_buffers_job_token_ = JobQueue::JobToken::kInvalid;
+  enqueue_sample_buffers_job_token_ = JobQueue::JobToken::kUnscheduled;
 
   prerolled_frames_ = 0;
   pts_of_first_written_buffer_ = 0;
@@ -619,7 +619,7 @@ void AVSBVideoRenderer::EnqueueSampleBuffers() {
 }
 
 void AVSBVideoRenderer::DelayedEnqueueSampleBuffers() {
-  enqueue_sample_buffers_job_token_ = JobQueue::JobToken::kInvalid;
+  enqueue_sample_buffers_job_token_ = JobQueue::JobToken::kUnscheduled;
   EnqueueSampleBuffers();
 }
 


### PR DESCRIPTION
Refactored JobQueue::JobToken to fully encapsulate its internal state and align with modern C++ idioms.

Benefits:
- Safety: Eliminates "dangling tokens" by ensuring `RemoveJobByToken` reset internal state of JobToken.
- Simplicity: Reduces boilerplate at the call site, moving the validity check inside the API.
- Modernization: Aligns with RAII-like principles where the object manages its own state transitions.

```
 if (process_audio_data_job_token_.is_valid()) {
    RemoveJobByToken(process_audio_data_job_token_);
    process_audio_data_job_token_.ResetToInvalid();
}
```
-> 

```
RemoveJobByToken(&process_audio_data_job_token_);
```

Issue: 479994435