### PR TITLE
starboard: Use factories for Android audio track creation

### DIFF
--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -411,17 +411,18 @@ void AudioRendererPassthrough::CreateAudioTrackAndStartProcessing() {
     return;
   }
 
-  std::unique_ptr<AudioTrackBridge> audio_track_bridge(new AudioTrackBridge(
-      audio_stream_info_.codec == kSbMediaAudioCodecAc3
-          ? kSbMediaAudioCodingTypeAc3
-          : kSbMediaAudioCodingTypeDolbyDigitalPlus,
-      std::optional<SbMediaAudioSampleType>(),  // Not required in passthrough
-                                                // mode
-      audio_stream_info_.number_of_channels,
-      audio_stream_info_.samples_per_second, kPreferredBufferSizeInBytes,
-      kTunnelModeAudioSessionId, false /* is_web_audio */));
+  std::unique_ptr<AudioTrackBridge> audio_track_bridge =
+      AudioTrackBridge::Create(
+          audio_stream_info_.codec == kSbMediaAudioCodecAc3
+              ? kSbMediaAudioCodingTypeAc3
+              : kSbMediaAudioCodingTypeDolbyDigitalPlus,
+          std::optional<SbMediaAudioSampleType>(),  // Not required in
+                                                    // passthrough mode
+          audio_stream_info_.number_of_channels,
+          audio_stream_info_.samples_per_second, kPreferredBufferSizeInBytes,
+          kTunnelModeAudioSessionId, /*is_web_audio=*/false);
 
-  if (!audio_track_bridge->is_valid()) {
+  if (!audio_track_bridge) {
     error_cb_(kSbPlayerErrorDecode, "Error creating AudioTrackBridge");
     return;
   }
@@ -455,7 +456,7 @@ void AudioRendererPassthrough::FlushAudioTrackAndStopProcessing(
   // silence can be observed after seeking on some audio receivers.
   // TODO: Consider reusing audio sink for non-passthrough playbacks, to see if
   //       it reduces latency after seeking.
-  if (audio_track_bridge_ && audio_track_bridge_->is_valid()) {
+  if (audio_track_bridge_) {
     audio_track_bridge_->PauseAndFlush();
   }
   seek_to_time_ = seek_to_time;

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -416,8 +416,7 @@ void AudioRendererPassthrough::CreateAudioTrackAndStartProcessing() {
           audio_stream_info_.codec == kSbMediaAudioCodecAc3
               ? kSbMediaAudioCodingTypeAc3
               : kSbMediaAudioCodingTypeDolbyDigitalPlus,
-          std::optional<SbMediaAudioSampleType>(),  // Not required in
-                                                    // passthrough mode
+          /*sample_type=*/std::nullopt,  // Not required in passthrough mode
           audio_stream_info_.number_of_channels,
           audio_stream_info_.samples_per_second, kPreferredBufferSizeInBytes,
           kTunnelModeAudioSessionId, /*is_web_audio=*/false);

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -129,9 +129,8 @@ void MinRequiredFramesTester::TesterThreadFunc() {
         frame_buffers, max_required_frames_,
         min_required_frames_ * task.number_of_channels *
             GetSampleSize(task.sample_type),
-        &MinRequiredFramesTester::UpdateSourceStatusFunc,
-        &MinRequiredFramesTester::ConsumeFramesFunc,
-        &MinRequiredFramesTester::ErrorFunc, 0, -1, false, false, false, this);
+        {UpdateSourceStatusFunc, ConsumeFramesFunc, ErrorFunc}, 0, -1, false,
+        false, false, this);
     {
       std::unique_lock lock(mutex_);
       bool notified = test_complete_cv_.wait_for(

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -124,7 +124,7 @@ void MinRequiredFramesTester::TesterThreadFunc() {
       is_test_complete_ = false;
     }
 
-    auto audio_sink = AudioTrackAudioSink::Create(
+    audio_sink_ = AudioTrackAudioSink::Create(
         NULL, task.number_of_channels, task.sample_rate, task.sample_type,
         frame_buffers, max_required_frames_,
         min_required_frames_ * task.number_of_channels *
@@ -132,7 +132,6 @@ void MinRequiredFramesTester::TesterThreadFunc() {
         &MinRequiredFramesTester::UpdateSourceStatusFunc,
         &MinRequiredFramesTester::ConsumeFramesFunc,
         &MinRequiredFramesTester::ErrorFunc, 0, -1, false, false, false, this);
-    audio_sink_ = audio_sink.release();
     {
       std::unique_lock lock(mutex_);
       bool notified = test_complete_cv_.wait_for(
@@ -148,8 +147,7 @@ void MinRequiredFramesTester::TesterThreadFunc() {
     // |min_required_frames_| is shared between two threads. Release audio sink
     // to end audio sink thread before access |min_required_frames_| on this
     // thread.
-    delete audio_sink_;
-    audio_sink_ = nullptr;
+    audio_sink_.reset();
 
     if (wait_timeout) {
       SB_LOG(ERROR) << "Audio sink min required frames tester timeout.";

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -130,7 +130,7 @@ void MinRequiredFramesTester::TesterThreadFunc() {
         min_required_frames_ * task.number_of_channels *
             GetSampleSize(task.sample_type),
         {UpdateSourceStatusFunc, ConsumeFramesFunc, ErrorFunc}, 0, -1, false,
-        false, false, this);
+        false, this);
     {
       std::unique_lock lock(mutex_);
       bool notified = test_complete_cv_.wait_for(

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -124,14 +124,15 @@ void MinRequiredFramesTester::TesterThreadFunc() {
       is_test_complete_ = false;
     }
 
-    audio_sink_ = new AudioTrackAudioSink(
+    auto audio_sink = AudioTrackAudioSink::Create(
         NULL, task.number_of_channels, task.sample_rate, task.sample_type,
         frame_buffers, max_required_frames_,
         min_required_frames_ * task.number_of_channels *
             GetSampleSize(task.sample_type),
         &MinRequiredFramesTester::UpdateSourceStatusFunc,
         &MinRequiredFramesTester::ConsumeFramesFunc,
-        &MinRequiredFramesTester::ErrorFunc, 0, -1, false, false, this);
+        &MinRequiredFramesTester::ErrorFunc, 0, -1, false, false, false, this);
+    audio_sink_ = audio_sink.release();
     {
       std::unique_lock lock(mutex_);
       bool notified = test_complete_cv_.wait_for(
@@ -141,9 +142,8 @@ void MinRequiredFramesTester::TesterThreadFunc() {
     }
 
     // Get start threshold before release the audio sink.
-    int start_threshold = audio_sink_->IsAudioTrackValid()
-                              ? audio_sink_->GetStartThresholdInFrames()
-                              : 0;
+    int start_threshold =
+        audio_sink_ ? audio_sink_->GetStartThresholdInFrames() : 0;
 
     // |min_required_frames_| is shared between two threads. Release audio sink
     // to end audio sink thread before access |min_required_frames_| on this

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.h
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.h
@@ -24,6 +24,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "starboard/common/thread.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/thread_checker.h"
@@ -106,7 +107,7 @@ class MinRequiredFramesTester {
   ThreadChecker thread_checker_;
 
   std::vector<TestTask> test_tasks_;
-  AudioTrackAudioSink* audio_sink_ = nullptr;
+  raw_ptr<AudioTrackAudioSink> audio_sink_ = nullptr;
   int min_required_frames_;
   std::atomic_bool has_error_;
 

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.h
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.h
@@ -107,7 +107,7 @@ class MinRequiredFramesTester {
   ThreadChecker thread_checker_;
 
   std::vector<TestTask> test_tasks_;
-  raw_ptr<AudioTrackAudioSink> audio_sink_ = nullptr;
+  std::unique_ptr<AudioTrackAudioSink> audio_sink_;
   int min_required_frames_;
   std::atomic_bool has_error_;
 

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -138,7 +138,6 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
       kSbMediaAudioCodingTypePcm, sample_type, channels, sampling_frequency_hz,
       preferred_buffer_size_in_bytes, tunnel_mode_audio_session_id,
       is_web_audio);
-
   if (!bridge) {
     return nullptr;
   }

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -128,9 +128,7 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
     SbAudioSinkFrameBuffers frame_buffers,
     int frames_per_channel,
     int preferred_buffer_size_in_bytes,
-    SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
-    ConsumeFramesFunc consume_frames_func,
-    SbAudioSinkPrivate::ErrorFunc error_func,
+    AudioTrackAudioSinkType::Callbacks callbacks,
     int64_t start_time,
     int tunnel_mode_audio_session_id,
     bool is_web_audio,
@@ -149,10 +147,9 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
   return std::make_unique<AudioTrackAudioSink>(
       PassKey<AudioTrackAudioSink>(), type, channels, sampling_frequency_hz,
       sample_type, frame_buffers, frames_per_channel,
-      preferred_buffer_size_in_bytes, update_source_status_func,
-      consume_frames_func, error_func, start_time, tunnel_mode_audio_session_id,
-      allow_audio_writing_on_pause, pause_using_audio_track_state,
-      std::move(bridge), context);
+      preferred_buffer_size_in_bytes, callbacks, start_time,
+      tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
+      pause_using_audio_track_state, std::move(bridge), context);
 }
 
 AudioTrackAudioSink::AudioTrackAudioSink(
@@ -164,9 +161,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
     SbAudioSinkFrameBuffers frame_buffers,
     int frames_per_channel,
     int preferred_buffer_size_in_bytes,
-    SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
-    ConsumeFramesFunc consume_frames_func,
-    SbAudioSinkPrivate::ErrorFunc error_func,
+    AudioTrackAudioSinkType::Callbacks callbacks,
     int64_t start_time,
     int tunnel_mode_audio_session_id,
     bool allow_audio_writing_on_pause,
@@ -179,9 +174,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
       sample_type_(sample_type),
       frame_buffer_(frame_buffers[0]),
       frames_per_channel_(frames_per_channel),
-      update_source_status_func_(update_source_status_func),
-      consume_frames_func_(consume_frames_func),
-      error_func_(error_func),
+      callbacks_(callbacks),
       start_time_(start_time),
       max_frames_per_request_(
           tunnel_mode_audio_session_id == -1
@@ -192,8 +185,8 @@ AudioTrackAudioSink::AudioTrackAudioSink(
       pause_using_audio_track_state_(pause_using_audio_track_state),
       bridge_(std::move(bridge)),
       audio_out_thread_(std::make_unique<AudioTrackOutThread>(this)) {
-  SB_DCHECK(update_source_status_func_);
-  SB_DCHECK(consume_frames_func_);
+  SB_DCHECK(callbacks_.update_source_status);
+  SB_DCHECK(callbacks_.consume_frames);
   SB_DCHECK(frame_buffer_);
   SB_CHECK(bridge_);
 
@@ -295,7 +288,8 @@ void AudioTrackAudioSink::AudioThreadFunc() {
 
       if (frames_consumed != 0) {
         SB_DCHECK_GE(frames_consumed, 0);
-        consume_frames_func_(frames_consumed, frames_consumed_at, context_);
+        callbacks_.consume_frames(frames_consumed, frames_consumed_at,
+                                  context_);
         frames_in_audio_track -= frames_consumed;
       }
     }
@@ -304,8 +298,8 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     int offset_in_frames;
     bool is_playing;
     bool is_eos_reached;
-    update_source_status_func_(&frames_in_buffer, &offset_in_frames,
-                               &is_playing, &is_eos_reached, context_);
+    callbacks_.update_source_status(&frames_in_buffer, &offset_in_frames,
+                                    &is_playing, &is_eos_reached, context_);
     {
       std::lock_guard lock(mutex_);
       if (playback_rate_ == 0.0) {
@@ -455,8 +449,8 @@ int AudioTrackAudioSink::WriteData(JNIEnv* env,
 void AudioTrackAudioSink::ReportError(bool capability_changed,
                                       const std::string& error_message) {
   SB_LOG(INFO) << "AudioTrackAudioSink error: " << error_message;
-  if (error_func_) {
-    error_func_(capability_changed, error_message, context_);
+  if (callbacks_.error) {
+    callbacks_.error(capability_changed, error_message, context_);
   }
 }
 
@@ -514,7 +508,7 @@ SbAudioSink AudioTrackAudioSinkType::Create(
   const bool kAllowAudioWritingOnPause = false;
   return Create(channels, sampling_frequency_hz, audio_sample_type,
                 audio_frame_storage_type, frame_buffers, frames_per_channel,
-                update_source_status_func, consume_frames_func, error_func,
+                {update_source_status_func, consume_frames_func, error_func},
                 kStartTime, kTunnelModeAudioSessionId, kIsWebAudio,
                 kAllowAudioWritingOnPause, context);
 }
@@ -526,9 +520,7 @@ SbAudioSink AudioTrackAudioSinkType::Create(
     SbMediaAudioFrameStorageType audio_frame_storage_type,
     SbAudioSinkFrameBuffers frame_buffers,
     int frames_per_channel,
-    SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
-    SbAudioSinkPrivate::ConsumeFramesFunc consume_frames_func,
-    SbAudioSinkPrivate::ErrorFunc error_func,
+    Callbacks callbacks,
     int64_t start_media_time,
     int tunnel_mode_audio_session_id,
     bool is_web_audio,
@@ -542,10 +534,10 @@ SbAudioSink AudioTrackAudioSinkType::Create(
 
   auto audio_sink = AudioTrackAudioSink::Create(
       this, channels, sampling_frequency_hz, audio_sample_type, frame_buffers,
-      frames_per_channel, preferred_buffer_size_in_bytes,
-      update_source_status_func, consume_frames_func, error_func,
+      frames_per_channel, preferred_buffer_size_in_bytes, callbacks,
       start_media_time, tunnel_mode_audio_session_id, is_web_audio,
-      allow_audio_writing_on_pause, false /* pause_using_audio_track_state */, context);
+      allow_audio_writing_on_pause, false /* pause_using_audio_track_state */,
+      context);
   if (!audio_sink) {
     SB_DLOG(ERROR)
         << "AudioTrackAudioSinkType::Create failed to create audio track";

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -21,6 +21,7 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "starboard/android/shared/audio_output_manager.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/common/check_op.h"
@@ -116,7 +117,7 @@ class AudioTrackAudioSink::AudioTrackOutThread : public Thread {
   void Run() override { sink_->AudioThreadFunc(); }
 
  private:
-  AudioTrackAudioSink* sink_;
+  const raw_ptr<AudioTrackAudioSink> sink_;
 };
 
 std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -133,7 +133,6 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
     int tunnel_mode_audio_session_id,
     bool is_web_audio,
     bool allow_audio_writing_on_pause,
-    bool pause_using_audio_track_state,
     void* context) {
   std::unique_ptr<AudioTrackBridge> bridge = AudioTrackBridge::Create(
       kSbMediaAudioCodingTypePcm, sample_type, channels, sampling_frequency_hz,
@@ -149,7 +148,7 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
       sample_type, frame_buffers, frames_per_channel,
       preferred_buffer_size_in_bytes, callbacks, start_time,
       tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
-      pause_using_audio_track_state, std::move(bridge), context);
+      std::move(bridge), context);
 }
 
 AudioTrackAudioSink::AudioTrackAudioSink(
@@ -165,7 +164,6 @@ AudioTrackAudioSink::AudioTrackAudioSink(
     int64_t start_time,
     int tunnel_mode_audio_session_id,
     bool allow_audio_writing_on_pause,
-    bool pause_using_audio_track_state,
     std::unique_ptr<AudioTrackBridge> bridge,
     void* context)
     : type_(type),
@@ -182,7 +180,6 @@ AudioTrackAudioSink::AudioTrackAudioSink(
               : GetMaxFramesPerRequestForTunnelMode(sampling_frequency_hz_)),
       context_(context),
       allow_audio_writing_on_pause_(allow_audio_writing_on_pause),
-      pause_using_audio_track_state_(pause_using_audio_track_state),
       bridge_(std::move(bridge)),
       audio_out_thread_(std::make_unique<AudioTrackOutThread>(this)) {
   SB_DCHECK(callbacks_.update_source_status);
@@ -244,16 +241,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       break;
     }
 
-    if (pause_using_audio_track_state_) {
-      // The audio data at the returned position by
-      // |bridge_.GetAudioTimestamp()| may either (1) already have been
-      // presented, or (2) may have not yet been presented but is committed to
-      // be presented. It is possible after |bridge_.Pause()|, the audio data
-      // is still committed to be presented as (2), which causes advancing
-      // media time gap when player resumes and dropping video frames, so
-      // player updates playback head positions when |bridge_| doesn't stop.
-      audio_track_play_state = bridge_->GetPlayState();
-    }
+    audio_track_play_state = bridge_->GetPlayState();
 
     bool should_update_media_time =
         (audio_track_play_state == PLAYSTATE_PLAYING ||
@@ -536,8 +524,7 @@ SbAudioSink AudioTrackAudioSinkType::Create(
       this, channels, sampling_frequency_hz, audio_sample_type, frame_buffers,
       frames_per_channel, preferred_buffer_size_in_bytes, callbacks,
       start_media_time, tunnel_mode_audio_session_id, is_web_audio,
-      allow_audio_writing_on_pause, false /* pause_using_audio_track_state */,
-      context);
+      allow_audio_writing_on_pause, context);
   if (!audio_sink) {
     SB_DLOG(ERROR)
         << "AudioTrackAudioSinkType::Create failed to create audio track";

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -142,12 +142,15 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
     return nullptr;
   }
 
-  return std::make_unique<AudioTrackAudioSink>(
+  auto audio_sink = std::make_unique<AudioTrackAudioSink>(
       PassKey<AudioTrackAudioSink>(), type, channels, sampling_frequency_hz,
       sample_type, frame_buffers, frames_per_channel,
       preferred_buffer_size_in_bytes, callbacks, start_time,
       tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
       std::move(bridge), context);
+
+  audio_sink->SpawnThread();
+  return audio_sink;
 }
 
 AudioTrackAudioSink::AudioTrackAudioSink(
@@ -187,7 +190,9 @@ AudioTrackAudioSink::AudioTrackAudioSink(
   SB_CHECK(bridge_);
 
   SB_LOG(INFO) << "Creating audio sink starts at " << start_time_;
+}
 
+void AudioTrackAudioSink::SpawnThread() {
   audio_out_thread_->Start();
 }
 

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -245,6 +245,13 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       break;
     }
 
+    // The audio data at the returned position by
+    // |bridge_->GetAudioTimestamp()| may either (1) already have been
+    // presented, or (2) may have not yet been presented but is committed to
+    // be presented. It is possible after |bridge_->Pause()|, the audio data
+    // is still committed to be presented as (2), which causes advancing
+    // media time gap when player resumes and dropping video frames, so
+    // player updates playback head positions when |bridge_| doesn't stop.
     audio_track_play_state = bridge_->GetPlayState();
 
     bool should_update_media_time =

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -119,7 +119,7 @@ class AudioTrackAudioSink::AudioTrackOutThread : public Thread {
   AudioTrackAudioSink* sink_;
 };
 
-AudioTrackAudioSink::AudioTrackAudioSink(
+std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
     Type* type,
     int channels,
     int sampling_frequency_hz,
@@ -134,6 +134,43 @@ AudioTrackAudioSink::AudioTrackAudioSink(
     int tunnel_mode_audio_session_id,
     bool is_web_audio,
     bool allow_audio_writing_on_pause,
+    bool pause_using_audio_track_state,
+    void* context) {
+  std::unique_ptr<AudioTrackBridge> bridge = AudioTrackBridge::Create(
+      kSbMediaAudioCodingTypePcm, sample_type, channels, sampling_frequency_hz,
+      preferred_buffer_size_in_bytes, tunnel_mode_audio_session_id,
+      is_web_audio);
+
+  if (!bridge) {
+    return nullptr;
+  }
+
+  return std::make_unique<AudioTrackAudioSink>(
+      PassKey<AudioTrackAudioSink>(), type, channels, sampling_frequency_hz,
+      sample_type, frame_buffers, frames_per_channel,
+      preferred_buffer_size_in_bytes, update_source_status_func,
+      consume_frames_func, error_func, start_time, tunnel_mode_audio_session_id,
+      allow_audio_writing_on_pause, pause_using_audio_track_state,
+      std::move(bridge), context);
+}
+
+AudioTrackAudioSink::AudioTrackAudioSink(
+    PassKey<AudioTrackAudioSink>,
+    Type* type,
+    int channels,
+    int sampling_frequency_hz,
+    SbMediaAudioSampleType sample_type,
+    SbAudioSinkFrameBuffers frame_buffers,
+    int frames_per_channel,
+    int preferred_buffer_size_in_bytes,
+    SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
+    ConsumeFramesFunc consume_frames_func,
+    SbAudioSinkPrivate::ErrorFunc error_func,
+    int64_t start_time,
+    int tunnel_mode_audio_session_id,
+    bool allow_audio_writing_on_pause,
+    bool pause_using_audio_track_state,
+    std::unique_ptr<AudioTrackBridge> bridge,
     void* context)
     : type_(type),
       channels_(channels),
@@ -151,31 +188,15 @@ AudioTrackAudioSink::AudioTrackAudioSink(
               : GetMaxFramesPerRequestForTunnelMode(sampling_frequency_hz_)),
       context_(context),
       allow_audio_writing_on_pause_(allow_audio_writing_on_pause),
-      bridge_(kSbMediaAudioCodingTypePcm,
-              sample_type,
-              channels,
-              sampling_frequency_hz,
-              preferred_buffer_size_in_bytes,
-              tunnel_mode_audio_session_id,
-              is_web_audio) {
+      pause_using_audio_track_state_(pause_using_audio_track_state),
+      bridge_(std::move(bridge)),
+      audio_out_thread_(std::make_unique<AudioTrackOutThread>(this)) {
   SB_DCHECK(update_source_status_func_);
   SB_DCHECK(consume_frames_func_);
   SB_DCHECK(frame_buffer_);
 
   SB_LOG(INFO) << "Creating audio sink starts at " << start_time_;
 
-  if (!bridge_.is_valid()) {
-    // One of the cases that this may hit is when output happened to be switched
-    // to a device that doesn't support tunnel mode.
-    // TODO: Find a way to exclude the device from tunnel mode playback, to
-    //       avoid infinite loop in creating the audio sink on a device
-    //       claims to support tunnel mode but fails to create the audio sink.
-    // TODO: Currently this will be reported as a general decode error,
-    //       investigate if this can be reported as a capability changed error.
-    return;
-  }
-
-  audio_out_thread_ = std::make_unique<AudioTrackOutThread>(this);
   audio_out_thread_->Start();
 }
 
@@ -200,7 +221,7 @@ void AudioTrackAudioSink::SetPlaybackRate(double playback_rate) {
   if (playback_rate > 0.0) {
     // AudioTrackBridge.setPlaybackRate() currently is only enabled for tunnel
     // mode. It will be no-op for non tunnel player.
-    bridge_.SetPlaybackRate(playback_rate);
+    bridge_->SetPlaybackRate(playback_rate);
   }
 }
 
@@ -223,28 +244,30 @@ void AudioTrackAudioSink::AudioThreadFunc() {
   while (!quit_) {
     int playback_head_position = 0;
     int64_t frames_consumed_at = 0;
-    if (bridge_.GetAndResetHasAudioDeviceChanged(env)) {
+    if (bridge_->GetAndResetHasAudioDeviceChanged(env)) {
       SB_LOG(INFO) << "Audio device changed, raising a capability changed "
                       "error to restart playback.";
       ReportError(true, "Audio device capability changed");
       break;
     }
 
-    // The audio data at the returned position by
-    // |bridge_.GetAudioTimestamp()| may either (1) already have been
-    // presented, or (2) may have not yet been presented but is committed to
-    // be presented. It is possible after |bridge_.Pause()|, the audio data
-    // is still committed to be presented as (2), which causes advancing
-    // media time gap when player resumes and dropping video frames, so
-    // player updates playback head positions when |bridge_| doesn't stop.
-    audio_track_play_state = bridge_.GetPlayState();
+    if (pause_using_audio_track_state_) {
+      // The audio data at the returned position by
+      // |bridge_.GetAudioTimestamp()| may either (1) already have been
+      // presented, or (2) may have not yet been presented but is committed to
+      // be presented. It is possible after |bridge_.Pause()|, the audio data
+      // is still committed to be presented as (2), which causes advancing
+      // media time gap when player resumes and dropping video frames, so
+      // player updates playback head positions when |bridge_| doesn't stop.
+      audio_track_play_state = bridge_->GetPlayState();
+    }
 
     bool should_update_media_time =
         (audio_track_play_state == PLAYSTATE_PLAYING ||
          audio_track_play_state == PLAYSTATE_PAUSED);
     if (should_update_media_time) {
       playback_head_position =
-          bridge_.GetAudioTimestamp(&frames_consumed_at, env);
+          bridge_->GetAudioTimestamp(&frames_consumed_at, env);
       SB_DCHECK_GE(playback_head_position, last_playback_head_position);
 
       int frames_consumed =
@@ -293,11 +316,11 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     bool is_currently_playing = (audio_track_play_state == PLAYSTATE_PLAYING);
     if (is_currently_playing && !is_playing) {
       ScopedTimer timer("Pause");
-      bridge_.Pause();
+      bridge_->Pause();
     } else if (!is_currently_playing && is_playing) {
       last_playback_head_event_at = -1;
       ScopedTimer timer("Play");
-      bridge_.Play();
+      bridge_->Play();
       if (release_frames_after_audio_starts) {
         // To promptly re-evaluate and update audio state, we restart the loop
         // after calling AudioTrack.play() on Android, as this operation often
@@ -402,7 +425,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     }
   }
 
-  bridge_.PauseAndFlush();
+  bridge_->PauseAndFlush();
 }
 
 int AudioTrackAudioSink::WriteData(JNIEnv* env,
@@ -412,12 +435,12 @@ int AudioTrackAudioSink::WriteData(JNIEnv* env,
   int samples_written = 0;
   if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
     samples_written =
-        bridge_.WriteSample(static_cast<const float*>(buffer),
-                            expected_written_frames * channels_, env);
+        bridge_->WriteSample(static_cast<const float*>(buffer),
+                             expected_written_frames * channels_, env);
   } else if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated) {
-    samples_written = bridge_.WriteSample(static_cast<const uint16_t*>(buffer),
-                                          expected_written_frames * channels_,
-                                          sync_time, env);
+    samples_written = bridge_->WriteSample(static_cast<const uint16_t*>(buffer),
+                                           expected_written_frames * channels_,
+                                           sync_time, env);
   } else {
     SB_NOTREACHED();
   }
@@ -442,15 +465,15 @@ int64_t AudioTrackAudioSink::GetFramesDurationUs(int frames) const {
 }
 
 void AudioTrackAudioSink::SetVolume(double volume) {
-  bridge_.SetVolume(volume);
+  bridge_->SetVolume(volume);
 }
 
 int AudioTrackAudioSink::GetUnderrunCount() {
-  return bridge_.GetUnderrunCount();
+  return bridge_->GetUnderrunCount();
 }
 
 int AudioTrackAudioSink::GetStartThresholdInFrames() {
-  return bridge_.GetStartThresholdInFrames();
+  return bridge_->GetStartThresholdInFrames();
 }
 
 // static
@@ -517,19 +540,18 @@ SbAudioSink AudioTrackAudioSinkType::Create(
   int preferred_buffer_size_in_bytes =
       min_required_frames * channels * GetBytesPerSample(audio_sample_type);
 
-  AudioTrackAudioSink* audio_sink = new AudioTrackAudioSink(
+  auto audio_sink = AudioTrackAudioSink::Create(
       this, channels, sampling_frequency_hz, audio_sample_type, frame_buffers,
       frames_per_channel, preferred_buffer_size_in_bytes,
       update_source_status_func, consume_frames_func, error_func,
       start_media_time, tunnel_mode_audio_session_id, is_web_audio,
-      allow_audio_writing_on_pause, context);
-  if (!audio_sink->IsAudioTrackValid()) {
+      allow_audio_writing_on_pause, false /* pause_using_audio_track_state */, context);
+  if (!audio_sink) {
     SB_DLOG(ERROR)
         << "AudioTrackAudioSinkType::Create failed to create audio track";
-    Destroy(audio_sink);
     return kSbAudioSinkInvalid;
   }
-  return audio_sink;
+  return audio_sink.release();
 }
 
 void AudioTrackAudioSinkType::TestMinRequiredFrames() {

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -195,6 +195,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
   SB_DCHECK(update_source_status_func_);
   SB_DCHECK(consume_frames_func_);
   SB_DCHECK(frame_buffer_);
+  SB_CHECK(bridge_);
 
   SB_LOG(INFO) << "Creating audio sink starts at " << start_time_;
 
@@ -204,9 +205,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
 AudioTrackAudioSink::~AudioTrackAudioSink() {
   quit_ = true;
 
-  if (audio_out_thread_) {
-    audio_out_thread_->Join();
-  }
+  audio_out_thread_->Join();
 }
 
 void AudioTrackAudioSink::SetPlaybackRate(double playback_rate) {

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -183,6 +183,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const bool allow_audio_writing_on_pause_;
   const bool pause_using_audio_track_state_;
 
+  // Guaranteed to be non-null.
   const std::unique_ptr<AudioTrackBridge> bridge_;
 
   volatile bool quit_ = false;

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -126,7 +126,6 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
                       int64_t start_media_time,
                       int tunnel_mode_audio_session_id,
                       bool allow_audio_writing_on_pause,
-                      bool pause_using_audio_track_state,
                       std::unique_ptr<AudioTrackBridge> bridge,
                       void* context);
 
@@ -143,7 +142,6 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       int tunnel_mode_audio_session_id,
       bool is_web_audio,
       bool allow_audio_writing_on_pause,
-      bool pause_using_audio_track_state,
       void* context);
   ~AudioTrackAudioSink() override;
 
@@ -177,7 +175,6 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const raw_ptr<void> context_;
 
   const bool allow_audio_writing_on_pause_;
-  const bool pause_using_audio_track_state_;
 
   // Guaranteed to be non-null.
   const std::unique_ptr<AudioTrackBridge> bridge_;

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -24,10 +24,12 @@
 #include <string>
 #include <vector>
 
+#include "base/memory/raw_ptr.h"
 #include "starboard/android/shared/audio_sink_min_required_frames_tester.h"
 #include "starboard/android/shared/audio_track_bridge.h"
 #include "starboard/audio_sink.h"
 #include "starboard/common/log.h"
+#include "starboard/common/pass_key.h"
 #include "starboard/common/thread.h"
 #include "starboard/configuration.h"
 #include "starboard/shared/internal_only.h"
@@ -110,6 +112,25 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
 class AudioTrackAudioSink : public SbAudioSinkImpl {
  public:
   AudioTrackAudioSink(
+      PassKey<AudioTrackAudioSink>,
+      Type* type,
+      int channels,
+      int sampling_frequency_hz,
+      SbMediaAudioSampleType sample_type,
+      SbAudioSinkFrameBuffers frame_buffers,
+      int frames_per_channel,
+      int preferred_buffer_size,
+      SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
+      ConsumeFramesFunc consume_frames_func,
+      SbAudioSinkPrivate::ErrorFunc error_func,
+      int64_t start_media_time,
+      int tunnel_mode_audio_session_id,
+      bool allow_audio_writing_on_pause,
+      bool pause_using_audio_track_state,
+      std::unique_ptr<AudioTrackBridge> bridge,
+      void* context);
+
+  static std::unique_ptr<AudioTrackAudioSink> Create(
       Type* type,
       int channels,
       int sampling_frequency_hz,
@@ -124,10 +145,10 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       int tunnel_mode_audio_session_id,
       bool is_web_audio,
       bool allow_audio_writing_on_pause,
+      bool pause_using_audio_track_state,
       void* context);
   ~AudioTrackAudioSink() override;
 
-  bool IsAudioTrackValid() const { return bridge_.is_valid(); }
   bool IsType(Type* type) override { return type_ == type; }
   void SetPlaybackRate(double playback_rate) override;
 
@@ -146,25 +167,26 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
 
   int64_t GetFramesDurationUs(int frames) const;
 
-  Type* const type_;
+  const raw_ptr<Type> type_;
   const int channels_;
   const int sampling_frequency_hz_;
   const SbMediaAudioSampleType sample_type_;
-  void* frame_buffer_;
+  const raw_ptr<void> frame_buffer_;
   const int frames_per_channel_;
   const SbAudioSinkUpdateSourceStatusFunc update_source_status_func_;
   const ConsumeFramesFunc consume_frames_func_;
   const SbAudioSinkPrivate::ErrorFunc error_func_;
   const int64_t start_time_;  // microseconds
   const int max_frames_per_request_;
-  void* const context_;
+  const raw_ptr<void> context_;
 
   const bool allow_audio_writing_on_pause_;
+  const bool pause_using_audio_track_state_;
 
-  AudioTrackBridge bridge_;
+  const std::unique_ptr<AudioTrackBridge> bridge_;
 
   volatile bool quit_ = false;
-  std::unique_ptr<Thread> audio_out_thread_;
+  const std::unique_ptr<Thread> audio_out_thread_;
 
   std::mutex mutex_;
   double playback_rate_ = 1.0;

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -156,6 +156,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   class AudioTrackOutThread;
 
   void AudioThreadFunc();
+  void SpawnThread();
 
   int WriteData(JNIEnv* env, const void* buffer, int size, int64_t sync_time);
 
@@ -180,6 +181,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const std::unique_ptr<AudioTrackBridge> bridge_;
 
   volatile bool quit_ = false;
+  // Guaranteed to be non-null.
   const std::unique_ptr<Thread> audio_out_thread_;
 
   std::mutex mutex_;

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -114,21 +114,6 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
 
 class AudioTrackAudioSink : public SbAudioSinkImpl {
  public:
-  AudioTrackAudioSink(PassKey<AudioTrackAudioSink>,
-                      Type* type,
-                      int channels,
-                      int sampling_frequency_hz,
-                      SbMediaAudioSampleType sample_type,
-                      SbAudioSinkFrameBuffers frame_buffers,
-                      int frames_per_channel,
-                      int preferred_buffer_size,
-                      AudioTrackAudioSinkType::Callbacks callbacks,
-                      int64_t start_media_time,
-                      int tunnel_mode_audio_session_id,
-                      bool allow_audio_writing_on_pause,
-                      std::unique_ptr<AudioTrackBridge> bridge,
-                      void* context);
-
   static std::unique_ptr<AudioTrackAudioSink> Create(
       Type* type,
       int channels,
@@ -143,6 +128,21 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       bool is_web_audio,
       bool allow_audio_writing_on_pause,
       void* context);
+
+  AudioTrackAudioSink(PassKey<AudioTrackAudioSink>,
+                      Type* type,
+                      int channels,
+                      int sampling_frequency_hz,
+                      SbMediaAudioSampleType sample_type,
+                      SbAudioSinkFrameBuffers frame_buffers,
+                      int frames_per_channel,
+                      int preferred_buffer_size,
+                      AudioTrackAudioSinkType::Callbacks callbacks,
+                      int64_t start_media_time,
+                      int tunnel_mode_audio_session_id,
+                      bool allow_audio_writing_on_pause,
+                      std::unique_ptr<AudioTrackBridge> bridge,
+                      void* context);
   ~AudioTrackAudioSink() override;
 
   bool IsType(Type* type) override { return type_ == type; }

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -54,6 +54,12 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
 
   AudioTrackAudioSinkType();
 
+  struct Callbacks {
+    SbAudioSinkUpdateSourceStatusFunc update_source_status;
+    SbAudioSinkPrivate::ConsumeFramesFunc consume_frames;
+    SbAudioSinkPrivate::ErrorFunc error;
+  };
+
   SbAudioSink Create(
       int channels,
       int sampling_frequency_hz,
@@ -65,21 +71,18 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
       SbAudioSinkPrivate::ConsumeFramesFunc consume_frames_func,
       SbAudioSinkPrivate::ErrorFunc error_func,
       void* context) override;
-  SbAudioSink Create(
-      int channels,
-      int sampling_frequency_hz,
-      SbMediaAudioSampleType audio_sample_type,
-      SbMediaAudioFrameStorageType audio_frame_storage_type,
-      SbAudioSinkFrameBuffers frame_buffers,
-      int frames_per_channel,
-      SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
-      SbAudioSinkPrivate::ConsumeFramesFunc consume_frames_func,
-      SbAudioSinkPrivate::ErrorFunc error_func,
-      int64_t start_time,
-      int tunnel_mode_audio_session_id,
-      bool is_web_audio,
-      bool allow_audio_writing_on_pause,
-      void* context);
+  SbAudioSink Create(int channels,
+                     int sampling_frequency_hz,
+                     SbMediaAudioSampleType audio_sample_type,
+                     SbMediaAudioFrameStorageType audio_frame_storage_type,
+                     SbAudioSinkFrameBuffers frame_buffers,
+                     int frames_per_channel,
+                     Callbacks callbacks,
+                     int64_t start_time,
+                     int tunnel_mode_audio_session_id,
+                     bool is_web_audio,
+                     bool allow_audio_writing_on_pause,
+                     void* context);
 
   bool IsValid(SbAudioSink audio_sink) override {
     return audio_sink != kSbAudioSinkInvalid && audio_sink->IsType(this);
@@ -111,24 +114,21 @@ class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
 
 class AudioTrackAudioSink : public SbAudioSinkImpl {
  public:
-  AudioTrackAudioSink(
-      PassKey<AudioTrackAudioSink>,
-      Type* type,
-      int channels,
-      int sampling_frequency_hz,
-      SbMediaAudioSampleType sample_type,
-      SbAudioSinkFrameBuffers frame_buffers,
-      int frames_per_channel,
-      int preferred_buffer_size,
-      SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
-      ConsumeFramesFunc consume_frames_func,
-      SbAudioSinkPrivate::ErrorFunc error_func,
-      int64_t start_media_time,
-      int tunnel_mode_audio_session_id,
-      bool allow_audio_writing_on_pause,
-      bool pause_using_audio_track_state,
-      std::unique_ptr<AudioTrackBridge> bridge,
-      void* context);
+  AudioTrackAudioSink(PassKey<AudioTrackAudioSink>,
+                      Type* type,
+                      int channels,
+                      int sampling_frequency_hz,
+                      SbMediaAudioSampleType sample_type,
+                      SbAudioSinkFrameBuffers frame_buffers,
+                      int frames_per_channel,
+                      int preferred_buffer_size,
+                      AudioTrackAudioSinkType::Callbacks callbacks,
+                      int64_t start_media_time,
+                      int tunnel_mode_audio_session_id,
+                      bool allow_audio_writing_on_pause,
+                      bool pause_using_audio_track_state,
+                      std::unique_ptr<AudioTrackBridge> bridge,
+                      void* context);
 
   static std::unique_ptr<AudioTrackAudioSink> Create(
       Type* type,
@@ -138,9 +138,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       SbAudioSinkFrameBuffers frame_buffers,
       int frames_per_channel,
       int preferred_buffer_size,
-      SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
-      ConsumeFramesFunc consume_frames_func,
-      SbAudioSinkPrivate::ErrorFunc error_func,
+      AudioTrackAudioSinkType::Callbacks callbacks,
       int64_t start_media_time,
       int tunnel_mode_audio_session_id,
       bool is_web_audio,
@@ -173,9 +171,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const SbMediaAudioSampleType sample_type_;
   const raw_ptr<void> frame_buffer_;
   const int frames_per_channel_;
-  const SbAudioSinkUpdateSourceStatusFunc update_source_status_func_;
-  const ConsumeFramesFunc consume_frames_func_;
-  const SbAudioSinkPrivate::ErrorFunc error_func_;
+  const AudioTrackAudioSinkType::Callbacks callbacks_;
   const int64_t start_time_;  // microseconds
   const int max_frames_per_request_;
   const raw_ptr<void> context_;

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -41,7 +41,7 @@ const jint kNoOffset = 0;
 
 }  // namespace
 
-AudioTrackBridge::AudioTrackBridge(
+std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
     SbMediaAudioCodingType coding_type,
     std::optional<SbMediaAudioSampleType> sample_type,
     int channels,
@@ -51,18 +51,13 @@ AudioTrackBridge::AudioTrackBridge(
     bool is_web_audio) {
   if (coding_type == kSbMediaAudioCodingTypePcm) {
     SB_DCHECK(SbAudioSinkIsAudioSampleTypeSupported(sample_type.value()));
-
-    // TODO: Support query if platform supports float type for tunnel mode.
     if (tunnel_mode_audio_session_id != -1) {
       SB_DCHECK_EQ(sample_type.value(), kSbMediaAudioSampleTypeInt16Deprecated);
     }
   } else {
     SB_DCHECK(coding_type == kSbMediaAudioCodingTypeAc3 ||
               coding_type == kSbMediaAudioCodingTypeDolbyDigitalPlus);
-    // TODO: Support passthrough under tunnel mode.
     SB_DCHECK_EQ(tunnel_mode_audio_session_id, -1);
-    // TODO: |sample_type| is not used in passthrough mode, we should make this
-    // explicit.
   }
 
   JNIEnv* env = AttachCurrentThread();
@@ -73,31 +68,22 @@ AudioTrackBridge::AudioTrackBridge(
           tunnel_mode_audio_session_id, is_web_audio);
 
   if (j_audio_track_bridge.is_null()) {
-    // One of the cases that this may hit is when output happened to be switched
-    // to a device that doesn't support tunnel mode.
-    // TODO: Find a way to exclude the device from tunnel mode playback, to
-    //       avoid infinite loop in creating the audio sink on a device
-    //       claims to support tunnel mode but fails to create the audio sink.
-    // TODO: Currently this will be reported as a general decode error,
-    //       investigate if this can be reported as a capability changed error.
     SB_LOG(WARNING) << "Failed to create |j_audio_track_bridge|.";
-    return;
+    return nullptr;
   }
 
-  j_audio_track_bridge_.Reset(j_audio_track_bridge);
-
+  int max_samples_per_write = 0;
+  ScopedJavaGlobalRef<jobject> j_audio_data;
   if (coding_type != kSbMediaAudioCodingTypePcm) {
-    // This must be passthrough.
-    SB_DCHECK(!sample_type);
-    max_samples_per_write_ = kMaxFramesPerRequest;
-    j_audio_data_.Reset(env, env->NewByteArray(max_samples_per_write_));
+    max_samples_per_write = kMaxFramesPerRequest;
+    j_audio_data.Reset(env, env->NewByteArray(max_samples_per_write));
   } else if (sample_type == kSbMediaAudioSampleTypeFloat32) {
-    max_samples_per_write_ = channels * kMaxFramesPerRequest;
-    j_audio_data_.Reset(env,
-                        env->NewFloatArray(channels * kMaxFramesPerRequest));
+    max_samples_per_write = channels * kMaxFramesPerRequest;
+    j_audio_data.Reset(env,
+                       env->NewFloatArray(channels * kMaxFramesPerRequest));
   } else if (sample_type == kSbMediaAudioSampleTypeInt16Deprecated) {
-    max_samples_per_write_ = channels * kMaxFramesPerRequest;
-    j_audio_data_.Reset(
+    max_samples_per_write = channels * kMaxFramesPerRequest;
+    j_audio_data.Reset(
         env,
         env->NewByteArray(channels * GetBytesPerSample(sample_type.value()) *
                           kMaxFramesPerRequest));
@@ -105,8 +91,24 @@ AudioTrackBridge::AudioTrackBridge(
     SB_NOTREACHED();
   }
 
-  SB_DCHECK(j_audio_data_) << "Failed to allocate |j_audio_data_|";
+  if (j_audio_data.is_null()) {
+    SB_LOG(WARNING) << "Failed to allocate |j_audio_data_|";
+    return nullptr;
+  }
+
+  return std::make_unique<AudioTrackBridge>(PassKey<AudioTrackBridge>(),
+                                            max_samples_per_write,
+                                            j_audio_track_bridge, j_audio_data);
 }
+
+AudioTrackBridge::AudioTrackBridge(
+    PassKey<AudioTrackBridge>,
+    int max_samples_per_write,
+    const ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
+    const ScopedJavaGlobalRef<jobject>& j_audio_data)
+    : max_samples_per_write_(max_samples_per_write),
+      j_audio_track_bridge_(j_audio_track_bridge),
+      j_audio_data_(j_audio_data) {}
 
 AudioTrackBridge::~AudioTrackBridge() {
   if (!j_audio_track_bridge_.is_null()) {
@@ -123,7 +125,6 @@ AudioTrackBridge::~AudioTrackBridge() {
 
 void AudioTrackBridge::Play(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   Java_AudioTrackBridge_play(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge playing.";
@@ -131,7 +132,6 @@ void AudioTrackBridge::Play(JNIEnv* env /*= AttachCurrentThread()*/) {
 
 void AudioTrackBridge::Pause(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   Java_AudioTrackBridge_pause(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge paused.";
@@ -139,7 +139,6 @@ void AudioTrackBridge::Pause(JNIEnv* env /*= AttachCurrentThread()*/) {
 
 void AudioTrackBridge::Stop(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   Java_AudioTrackBridge_stop(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge stopped.";
@@ -147,7 +146,6 @@ void AudioTrackBridge::Stop(JNIEnv* env /*= AttachCurrentThread()*/) {
 
 void AudioTrackBridge::PauseAndFlush(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   // For an immediate stop, use pause(), followed by flush() to discard audio
   // data that hasn't been played back yet.
@@ -161,7 +159,7 @@ int AudioTrackBridge::WriteSample(const float* samples,
                                   int num_of_samples,
                                   JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
+
   SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
@@ -184,7 +182,7 @@ int AudioTrackBridge::WriteSample(const uint16_t* samples,
                                   int64_t sync_time,
                                   JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
+
   SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
@@ -216,7 +214,7 @@ int AudioTrackBridge::WriteSample(const uint8_t* samples,
                                   int64_t sync_time,
                                   JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
+
   SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
@@ -246,7 +244,7 @@ void AudioTrackBridge::SetPlaybackRate(
     double playback_rate,
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
+
   // AudioTrack doesn't support playback speed of 0.
   SB_DCHECK_GT(playback_rate, 0.0);
 
@@ -260,7 +258,6 @@ void AudioTrackBridge::SetPlaybackRate(
 void AudioTrackBridge::SetVolume(double volume,
                                  JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   jint status = Java_AudioTrackBridge_setVolume(env, j_audio_track_bridge_,
                                                 static_cast<float>(volume));
@@ -273,7 +270,6 @@ int64_t AudioTrackBridge::GetAudioTimestamp(
     int64_t* updated_at,
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   ScopedJavaLocalRef<jobject> j_audio_timestamp =
       Java_AudioTrackBridge_getAudioTimestamp(env, j_audio_track_bridge_);
@@ -289,7 +285,6 @@ int64_t AudioTrackBridge::GetAudioTimestamp(
 bool AudioTrackBridge::GetAndResetHasAudioDeviceChanged(
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   return AudioOutputManager::GetInstance()->GetAndResetHasAudioDeviceChanged(
       env);
@@ -298,7 +293,6 @@ bool AudioTrackBridge::GetAndResetHasAudioDeviceChanged(
 int AudioTrackBridge::GetUnderrunCount(
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   return Java_AudioTrackBridge_getUnderrunCount(env, j_audio_track_bridge_);
 }
@@ -306,7 +300,6 @@ int AudioTrackBridge::GetUnderrunCount(
 int AudioTrackBridge::GetStartThresholdInFrames(
     JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   return Java_AudioTrackBridge_getStartThresholdInFrames(env,
                                                          j_audio_track_bridge_);
@@ -314,7 +307,6 @@ int AudioTrackBridge::GetStartThresholdInFrames(
 
 int AudioTrackBridge::GetPlayState(JNIEnv* env /*= AttachCurrentThread()*/) {
   SB_DCHECK(env);
-  SB_DCHECK(is_valid());
 
   return Java_AudioTrackBridge_getPlayState(env, j_audio_track_bridge_);
 }

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -51,13 +51,18 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
     bool is_web_audio) {
   if (coding_type == kSbMediaAudioCodingTypePcm) {
     SB_DCHECK(SbAudioSinkIsAudioSampleTypeSupported(sample_type.value()));
+
+    // TODO: Support query if platform supports float type for tunnel mode.
     if (tunnel_mode_audio_session_id != -1) {
       SB_DCHECK_EQ(sample_type.value(), kSbMediaAudioSampleTypeInt16Deprecated);
     }
   } else {
     SB_DCHECK(coding_type == kSbMediaAudioCodingTypeAc3 ||
               coding_type == kSbMediaAudioCodingTypeDolbyDigitalPlus);
+    // TODO: Support passthrough under tunnel mode.
     SB_DCHECK_EQ(tunnel_mode_audio_session_id, -1);
+    // TODO: |sample_type| is not used in passthrough mode, we should make this
+    // explicit.
   }
 
   JNIEnv* env = AttachCurrentThread();
@@ -68,6 +73,13 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
           tunnel_mode_audio_session_id, is_web_audio);
 
   if (j_audio_track_bridge.is_null()) {
+    // One of the cases that this may hit is when output happened to be switched
+    // to a device that doesn't support tunnel mode.
+    // TODO: Find a way to exclude the device from tunnel mode playback, to
+    //       avoid infinite loop in creating the audio sink on a device
+    //       claims to support tunnel mode but fails to create the audio sink.
+    // TODO: Currently this will be reported as a general decode error,
+    //       investigate if this can be reported as a capability changed error.
     SB_LOG(WARNING) << "Failed to create |j_audio_track_bridge|.";
     return nullptr;
   }

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -87,6 +87,7 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
   int max_samples_per_write = 0;
   ScopedJavaGlobalRef<jobject> j_audio_data;
   if (coding_type != kSbMediaAudioCodingTypePcm) {
+    SB_DCHECK(!sample_type);
     max_samples_per_write = kMaxFramesPerRequest;
     j_audio_data.Reset(env, env->NewByteArray(max_samples_per_write));
   } else if (sample_type == kSbMediaAudioSampleTypeFloat32) {

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -36,12 +36,6 @@ class AudioTrackBridge {
   // The same as Android AudioTrack.ERROR_DEAD_OBJECT.
   static constexpr int kAudioTrackErrorDeadObject = -6;
 
-  AudioTrackBridge(
-      PassKey<AudioTrackBridge>,
-      int max_samples_per_write,
-      const base::android::ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
-      const base::android::ScopedJavaGlobalRef<jobject>& j_audio_data);
-
   static std::unique_ptr<AudioTrackBridge> Create(
       SbMediaAudioCodingType coding_type,
       std::optional<SbMediaAudioSampleType> sample_type,
@@ -50,6 +44,12 @@ class AudioTrackBridge {
       int preferred_buffer_size_in_bytes,
       int tunnel_mode_audio_session_id,
       bool is_web_audio);
+
+  AudioTrackBridge(
+      PassKey<AudioTrackBridge>,
+      int max_samples_per_write,
+      const base::android::ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
+      const base::android::ScopedJavaGlobalRef<jobject>& j_audio_data);
   ~AudioTrackBridge();
 
   void Play(JNIEnv* env = jni_zero::AttachCurrentThread());

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -19,6 +19,7 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <memory>
 #include <optional>
 
 #include "starboard/common/pass_key.h"
@@ -48,8 +49,8 @@ class AudioTrackBridge {
   AudioTrackBridge(
       PassKey<AudioTrackBridge>,
       int max_samples_per_write,
-      const base::android::ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
-      const base::android::ScopedJavaGlobalRef<jobject>& j_audio_data);
+      const jni_zero::ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
+      const jni_zero::ScopedJavaGlobalRef<jobject>& j_audio_data);
   ~AudioTrackBridge();
 
   void Play(JNIEnv* env = jni_zero::AttachCurrentThread());
@@ -91,19 +92,11 @@ class AudioTrackBridge {
  private:
   const int max_samples_per_write_;
 
-<<<<<<< HEAD
-  jni_zero::ScopedJavaGlobalRef<jobject> j_audio_track_bridge_;
+  const jni_zero::ScopedJavaGlobalRef<jobject> j_audio_track_bridge_;
   // The audio data has to be copied into a Java Array before writing into the
   // audio track. Allocating a large array and saves as a member variable
   // avoids an array being allocated repeatedly.
-  jni_zero::ScopedJavaGlobalRef<jobject> j_audio_data_;
-=======
-  const base::android::ScopedJavaGlobalRef<jobject> j_audio_track_bridge_;
-  // The audio data has to be copied into a Java Array before writing into the
-  // audio track. Allocating a large array and saves as a member variable
-  // avoids an array being allocated repeatedly.
-  const base::android::ScopedJavaGlobalRef<jobject> j_audio_data_;
->>>>>>> 80f93847c05 (Apply factories to Android audio track)
+  const jni_zero::ScopedJavaGlobalRef<jobject> j_audio_data_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <optional>
 
+#include "starboard/common/pass_key.h"
 #include "starboard/media.h"
 #include "third_party/jni_zero/jni_zero.h"
 
@@ -35,18 +36,21 @@ class AudioTrackBridge {
   // The same as Android AudioTrack.ERROR_DEAD_OBJECT.
   static constexpr int kAudioTrackErrorDeadObject = -6;
 
-  AudioTrackBridge(SbMediaAudioCodingType coding_type,
-                   std::optional<SbMediaAudioSampleType> sample_type,
-                   int channels,
-                   int sampling_frequency_hz,
-                   int preferred_buffer_size_in_bytes,
-                   int tunnel_mode_audio_session_id,
-                   bool is_web_audio);
-  ~AudioTrackBridge();
+  AudioTrackBridge(
+      PassKey<AudioTrackBridge>,
+      int max_samples_per_write,
+      const base::android::ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
+      const base::android::ScopedJavaGlobalRef<jobject>& j_audio_data);
 
-  bool is_valid() const {
-    return !j_audio_track_bridge_.is_null() && !j_audio_data_.is_null();
-  }
+  static std::unique_ptr<AudioTrackBridge> Create(
+      SbMediaAudioCodingType coding_type,
+      std::optional<SbMediaAudioSampleType> sample_type,
+      int channels,
+      int sampling_frequency_hz,
+      int preferred_buffer_size_in_bytes,
+      int tunnel_mode_audio_session_id,
+      bool is_web_audio);
+  ~AudioTrackBridge();
 
   void Play(JNIEnv* env = jni_zero::AttachCurrentThread());
   void Pause(JNIEnv* env = jni_zero::AttachCurrentThread());
@@ -85,13 +89,21 @@ class AudioTrackBridge {
   int GetPlayState(JNIEnv* env = jni_zero::AttachCurrentThread());
 
  private:
-  int max_samples_per_write_;
+  const int max_samples_per_write_;
 
+<<<<<<< HEAD
   jni_zero::ScopedJavaGlobalRef<jobject> j_audio_track_bridge_;
   // The audio data has to be copied into a Java Array before writing into the
   // audio track. Allocating a large array and saves as a member variable
   // avoids an array being allocated repeatedly.
   jni_zero::ScopedJavaGlobalRef<jobject> j_audio_data_;
+=======
+  const base::android::ScopedJavaGlobalRef<jobject> j_audio_track_bridge_;
+  // The audio data has to be copied into a Java Array before writing into the
+  // audio track. Allocating a large array and saves as a member variable
+  // avoids an array being allocated repeatedly.
+  const base::android::ScopedJavaGlobalRef<jobject> j_audio_data_;
+>>>>>>> 80f93847c05 (Apply factories to Android audio track)
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -90,9 +90,10 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
               return type->Create(
                   channels, sampling_frequency_hz, audio_sample_type,
                   audio_frame_storage_type, frame_buffers,
-                  frame_buffers_size_in_frames, update_source_status_func,
-                  consume_frames_func, error_func, start_media_time,
-                  tunnel_mode_audio_session_id, false, /* is_web_audio */
+                  frame_buffers_size_in_frames,
+                  {update_source_status_func, consume_frames_func, error_func},
+                  start_media_time, tunnel_mode_audio_session_id,
+                  false, /* is_web_audio */
                   allow_audio_writing_on_pause, context);
             }),
         tunnel_mode_audio_session_id_(tunnel_mode_audio_session_id) {}

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -93,8 +93,8 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
                   frame_buffers_size_in_frames,
                   {update_source_status_func, consume_frames_func, error_func},
                   start_media_time, tunnel_mode_audio_session_id,
-                  false, /* is_web_audio */
-                  allow_audio_writing_on_pause, context);
+                  /*is_web_audio=*/false, allow_audio_writing_on_pause,
+                  context);
             }),
         tunnel_mode_audio_session_id_(tunnel_mode_audio_session_id) {}
 


### PR DESCRIPTION
Refactor the creation of AudioTrackBridge and AudioTrackAudioSink to
utilize static factory methods returning std::unique_ptr. This improves
object ownership semantics and clarifies resource management.

Error handling is simplified by having factory methods return nullptr on
failure instead of relying on a separate is_valid() check. PassKey is
used to enforce creation via these factory methods. Additionally, some
raw pointers are converted to raw_ptr for improved safety.

Issue: 479994435