### PR TITLE
media: Fix null pointer crash in MojoRenderer during initialization

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -830,7 +830,8 @@ void StarboardRenderer::OnDemuxerStreamRead(
         base::BindOnce(&StarboardRenderer::OnDemuxerStreamRead,
                        weak_factory_.GetWeakPtr(), stream, max_buffers));
   } else if (status == DemuxerStream::kError) {
-    client_->OnError(PIPELINE_ERROR_READ);
+    state_ = STATE_ERROR;
+    NotifyError(PIPELINE_ERROR_READ);
   }
 }
 
@@ -1007,7 +1008,7 @@ void StarboardRenderer::OnPlayerError(SbPlayerError error,
   switch (error) {
     case kSbPlayerErrorDecode:
       MEDIA_LOG(ERROR, media_log_) << message;
-      client_->OnError(PIPELINE_ERROR_DECODE);
+      NotifyError(PIPELINE_ERROR_DECODE);
       break;
     case kSbPlayerErrorCapabilityChanged:
       MEDIA_LOG(ERROR, media_log_)
@@ -1016,11 +1017,26 @@ void StarboardRenderer::OnPlayerError(SbPlayerError error,
                   : base::StringPrintf("%s: %s",
                                        kSbPlayerCapabilityChangedErrorMessage,
                                        message.c_str()));
-      client_->OnError(PIPELINE_ERROR_DECODE);
+      NotifyError(PIPELINE_ERROR_DECODE);
       break;
     case kSbPlayerErrorMax:
       NOTREACHED();
       break;
+  }
+}
+
+void StarboardRenderer::NotifyError(PipelineStatus status) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  // MojoRenderer in the renderer process delays assigning its `client_` pointer
+  // until the initialization callback resolves. If we encounter an error during
+  // initialization, we must resolve `init_cb_` with the error status instead of
+  // firing an asynchronous `client_->OnError()` event. Firing
+  // `client_->OnError()` before `init_cb_` is resolved will cause a null
+  // pointer dereference in `MojoRenderer::OnError()`.
+  if (init_cb_) {
+    std::move(init_cb_).Run(status);
+  } else {
+    client_->OnError(status);
   }
 }
 

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -187,6 +187,8 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
 
   void OnBufferingStateChange(BufferingState state);
 
+  void NotifyError(PipelineStatus status);
+
   State state_;
   const scoped_refptr<base::SequencedTaskRunner> task_runner_;
   const std::unique_ptr<MediaLog> media_log_;

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -334,6 +334,71 @@ TEST_F(StarboardRendererTest, OnPlayerErrorCallback) {
   task_environment_.RunUntilIdle();
 }
 
+TEST_F(StarboardRendererTest, OnErrorDuringInitialization) {
+  AddStream(DemuxerStream::AUDIO, /*encrypted=*/false);
+  AddStream(DemuxerStream::VIDEO, /*encrypted=*/false);
+
+  SbPlayer player = new SbPlayerPrivate();
+  EXPECT_CALL(mock_sbplayer_interface_, Create(_, _, _, _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<3>(&decoder_status_cb_),
+                      SaveArg<4>(&player_status_cb_),
+                      SaveArg<5>(&player_error_cb_), SaveArg<6>(&context_),
+                      Return(player)));
+
+  // Expect renderer_init_cb_ to be called with an error.
+  EXPECT_CALL(renderer_init_cb_, Run(HasStatusCode(PIPELINE_ERROR_DECODE)));
+  // renderer_client_.OnError should NOT be called because init_cb_ is pending.
+  EXPECT_CALL(renderer_client_, OnError(_)).Times(0);
+
+  renderer_->Initialize(&media_resource_, &renderer_client_,
+                        renderer_init_cb_.Get());
+  task_environment_.RunUntilIdle();
+
+  ASSERT_TRUE(player_error_cb_);
+  // Trigger an error before initialization is complete.
+  player_error_cb_(player, context_, kSbPlayerErrorDecode, "decoding failed");
+  task_environment_.RunUntilIdle();
+}
+
+TEST_F(StarboardRendererTest, OnDemuxerErrorDuringInitialization) {
+  AddStream(DemuxerStream::AUDIO, /*encrypted=*/false);
+  AddStream(DemuxerStream::VIDEO, /*encrypted=*/false);
+
+  SbPlayer player = new SbPlayerPrivate();
+  EXPECT_CALL(mock_sbplayer_interface_, Create(_, _, _, _, _, _, _, _))
+      .WillOnce(DoAll(SaveArg<3>(&decoder_status_cb_),
+                      SaveArg<4>(&player_status_cb_),
+                      SaveArg<5>(&player_error_cb_), SaveArg<6>(&context_),
+                      Return(player)));
+
+  // Expect renderer_init_cb_ to be called with an error.
+  EXPECT_CALL(renderer_init_cb_, Run(HasStatusCode(PIPELINE_ERROR_READ)));
+  // renderer_client_.OnError should NOT be called because init_cb_ is pending.
+  EXPECT_CALL(renderer_client_, OnError(_)).Times(0);
+
+  renderer_->Initialize(&media_resource_, &renderer_client_,
+                        renderer_init_cb_.Get());
+  task_environment_.RunUntilIdle();
+
+  // Now that the player is created (but not initialized), simulate the player
+  // asking for data.
+  DemuxerStream::ReadCB read_cb;
+  EXPECT_CALL(*streams_[0], OnRead(_))
+      .WillOnce(Invoke(
+          [&read_cb](DemuxerStream::ReadCB& cb) { read_cb = std::move(cb); }));
+  EXPECT_CALL(*streams_[1], OnRead(_)).Times(0);
+
+  // Trigger OnNeedData to start a read.
+  decoder_status_cb_(player, context_, kSbMediaTypeAudio,
+                     kSbPlayerDecoderStateNeedsData, SB_PLAYER_INITIAL_TICKET);
+  task_environment_.RunUntilIdle();
+
+  ASSERT_FALSE(read_cb.is_null());
+  // Simulate a demuxer error.
+  std::move(read_cb).Run(DemuxerStream::kError, {});
+  task_environment_.RunUntilIdle();
+}
+
 TEST_F(StarboardRendererTest, RejectCdmSwitching) {
   EXPECT_CALL(set_cdm_cb_, Run(true));
   renderer_->SetCdm(&cdm_context_, set_cdm_cb_.Get());


### PR DESCRIPTION
This change fixes a SIGSEGV crash in `MojoRenderer::OnError` caused by a race condition during the asynchronous initialization phase in `StarboardRenderer`.

In M138, `StarboardRenderer` was updated to defer resolving its initialization callback until the underlying `SbPlayer` is asynchronously initialized. During this window, the `MojoRenderer` (the IPC client in the renderer process) has not yet assigned its internal `client_` pointer.

If `StarboardRenderer` encounters an error (e.g., a capability change or decode error) while initialization is still pending, calling `client_->OnError()` sends an IPC message that `MojoRenderer` cannot safely handle, resulting in a null pointer dereference.

This fix introduces a `NotifyError` helper in `StarboardRenderer` that intercepts errors occurring during initialization. If `init_cb_` is still pending, the error is routed through the callback to fail the initialization gracefully. Otherwise, the error is dispatched to the client as a runtime event.

Changes:
- Added `NotifyError(PipelineStatus status)` helper to `StarboardRenderer`.
- Updated `OnPlayerError` and `OnDemuxerStreamRead` to use the helper.
- Added documentation explaining the `MojoRenderer` initialization lifecycle.
- Added `OnErrorDuringInitialization` and `OnDemuxerErrorDuringInitialization` unit tests to `StarboardRendererTest`.

The crash is introduced by https://github.com/youtube/cobalt/pull/8771.

#vibe-coded

Issue: 508303753
Issue: 505885475