### PR TITLE
Refactor on-host tests to use test_runner_script wrappers

### DIFF
--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -85,7 +85,7 @@ runs:
           # Check if a wrapper script was generated for the test (e.g. by test_runner_script).
           # If so, use it as the entrypoint to run tests.
           wrapper_path="$(dirname "${test_binary_path}")/bin/run_${test_binary}"
-          if [ -f "${wrapper_path}" ]; then
+          if [[ -x "${wrapper_path}" ]]; then
             ENTRYPOINT="./${wrapper_path}"
           else
             ENTRYPOINT="./${test_binary_path}"

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -16,6 +16,10 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Set Up Depot Tools
+      uses: ./.github/actions/depot_tools
+      with:
+        run_sync: 'false'
     - name: Download Artifacts
       uses: actions/download-artifact@v5
       with:

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -82,10 +82,13 @@ runs:
           log_path="${test_output}/${test_binary}_log.txt"
           # TODO: Investigate test_runner.py
 
-          if [ -f "$(dirname "${test_binary_path}")/bin/run_${test_binary}" ]; then
-            ENTRYPOINT="./$(dirname "${test_binary_path}")/bin/run_${test_binary}"
+          # Check if a wrapper script was generated for the test (e.g. by test_runner_script).
+          # If so, use it as the entrypoint to run tests.
+          wrapper_path="$(dirname "${test_binary_path}")/bin/run_${test_binary}"
+          if [ -f "${wrapper_path}" ]; then
+            ENTRYPOINT="./${wrapper_path}"
           else
-            ENTRYPOINT=./"${test_binary_path}"
+            ENTRYPOINT="./${test_binary_path}"
           fi
 
           if [ "${test_filter}" == "-*" ]; then

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -82,7 +82,11 @@ runs:
           log_path="${test_output}/${test_binary}_log.txt"
           # TODO: Investigate test_runner.py
 
-          ENTRYPOINT="./$(dirname "${test_binary_path}")/bin/run_${test_binary}"
+          if [ -f "$(dirname "${test_binary_path}")/bin/run_${test_binary}" ]; then
+            ENTRYPOINT="./$(dirname "${test_binary_path}")/bin/run_${test_binary}"
+          else
+            ENTRYPOINT=./"${test_binary_path}"
+          fi
 
           if [ "${test_filter}" == "-*" ]; then
             echo "Skipped due to test filter." >  ${log_path}

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -78,7 +78,7 @@ runs:
           log_path="${test_output}/${test_binary}_log.txt"
           # TODO: Investigate test_runner.py
 
-          ENTRYPOINT=./"${test_binary_path}"
+          ENTRYPOINT="./$(dirname "${test_binary_path}")/bin/run_${test_binary}"
 
           if [ "${test_filter}" == "-*" ]; then
             echo "Skipped due to test filter." >  ${log_path}

--- a/.github/actions/overlay_workspace/action.yaml
+++ b/.github/actions/overlay_workspace/action.yaml
@@ -63,8 +63,7 @@ runs:
 
           gclient config \
             --name=src \
-            --custom-var="rbe_instance=\"projects/cobalt-actions-prod/instances/default_instance\"" \
-            "https://github.com/youtube/$REPO_URL"
+            --custom-var="rbe_instance=\"projects/cobalt-actions-prod/instances/default_instance\"" "$REPO_URL"
           echo "target_os=['android', 'linux']" >> .gclient
           echo "target_cpu=['x64', 'arm', 'arm64']" >> .gclient
           gclient sync -D --no-history

--- a/.github/actions/overlay_workspace/action.yaml
+++ b/.github/actions/overlay_workspace/action.yaml
@@ -21,7 +21,7 @@ runs:
       id: prepare
       shell: bash
       env:
-        REPO_URL: ${{ github.server_url }}/${{ github.repository }}
+        REPO_URL: ${{ github.server_url }}/${{ github.repository }}.git
       run: |
         # LOWER_DIR (Read-Only): The pristine golden workspace (tip of tree) on the node's SSD. All pods read from this.
         LOWER_DIR="/runner-cache/golden-workspace"
@@ -56,7 +56,7 @@ runs:
           mkdir -p "$LOWER_DIR"
           cd "$LOWER_DIR"
 
-          git clone $REPO_URL src
+          git clone "$REPO_URL" src
           # Clone depot_tools
           git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools
           export PATH="$LOWER_DIR/depot_tools:$PATH"

--- a/.github/actions/overlay_workspace/action.yaml
+++ b/.github/actions/overlay_workspace/action.yaml
@@ -20,6 +20,8 @@ runs:
     - name: Prepare OverlayFS Workspace
       id: prepare
       shell: bash
+      env:
+        REPO_URL: ${{ github.server_url }}/${{ github.repository }}
       run: |
         # LOWER_DIR (Read-Only): The pristine golden workspace (tip of tree) on the node's SSD. All pods read from this.
         LOWER_DIR="/runner-cache/golden-workspace"
@@ -54,7 +56,7 @@ runs:
           mkdir -p "$LOWER_DIR"
           cd "$LOWER_DIR"
 
-          git clone https://github.com/youtube/cobalt.git src
+          git clone $REPO_URL src
           # Clone depot_tools
           git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools
           export PATH="$LOWER_DIR/depot_tools:$PATH"
@@ -62,7 +64,7 @@ runs:
           gclient config \
             --name=src \
             --custom-var="rbe_instance=\"projects/cobalt-actions-prod/instances/default_instance\"" \
-            "https://github.com/youtube/cobalt.git"
+            "https://github.com/youtube/$REPO_URL"
           echo "target_os=['android', 'linux']" >> .gclient
           echo "target_cpu=['x64', 'arm', 'arm64']" >> .gclient
           gclient sync -D --no-history

--- a/cobalt/docker/unittest/Dockerfile
+++ b/cobalt/docker/unittest/Dockerfile
@@ -4,6 +4,7 @@ FROM marketplace.gcr.io/google/debian12@${BASE_IMAGE_SHA}
 
 # Install any necessary dependencies
 RUN apt-get update && apt-get install -y \
+    curl \
     ffmpeg \
     git \
     jq \

--- a/cobalt/docker/unittest/Dockerfile
+++ b/cobalt/docker/unittest/Dockerfile
@@ -21,6 +21,7 @@ RUN apt-get update && apt-get install -y \
     libglib2.0-0 \
     libnss3 \
     libxcomposite-dev \
+    openbox \
     xcvt \
     xserver-xorg-core \
     xserver-xorg-video-dummy \

--- a/cobalt/docker/unittest/Dockerfile
+++ b/cobalt/docker/unittest/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     libnss3 \
     libxcomposite-dev \
     openbox \
+    x11-xserver-utils \
     xcompmgr \
     xcvt \
     xserver-xorg-core \

--- a/cobalt/docker/unittest/Dockerfile
+++ b/cobalt/docker/unittest/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update && apt-get install -y \
     libglib2.0-0 \
     libnss3 \
     libxcomposite-dev \
+    xcvt \
     xvfb \
     xz-utils \
     zstd \

--- a/cobalt/docker/unittest/Dockerfile
+++ b/cobalt/docker/unittest/Dockerfile
@@ -5,6 +5,7 @@ FROM marketplace.gcr.io/google/debian12@${BASE_IMAGE_SHA}
 # Install any necessary dependencies
 RUN apt-get update && apt-get install -y \
     curl \
+    dbus-x11 \
     ffmpeg \
     git \
     jq \
@@ -21,6 +22,8 @@ RUN apt-get update && apt-get install -y \
     libnss3 \
     libxcomposite-dev \
     xcvt \
+    xserver-xorg-core \
+    xserver-xorg-video-dummy \
     xvfb \
     xz-utils \
     zstd \

--- a/cobalt/docker/unittest/Dockerfile
+++ b/cobalt/docker/unittest/Dockerfile
@@ -22,6 +22,7 @@ RUN apt-get update && apt-get install -y \
     libnss3 \
     libxcomposite-dev \
     openbox \
+    xcompmgr \
     xcvt \
     xserver-xorg-core \
     xserver-xorg-video-dummy \


### PR DESCRIPTION
The CI on-host tests are refactored to execute via wrapper scripts
instead of directly invoking test binaries. This standardizes the
test execution process and allows for future enhancements to test
lifecycle management within the CI environment.

Additionally, the overlay workspace action now dynamically determines
the repository URL for cloning and gclient configuration. This removes
hardcoded GitHub URLs, improving flexibility and allowing the CI to
function correctly across various GitHub instances or forks of the
Cobalt repository.

Bug: 431780245