### PR TITLE
media: Add Reset() function to AudioRendererSink

### DIFF
--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -237,7 +237,7 @@ void AudioRendererPcm::Seek(int64_t seek_to_time) {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK_GE(seek_to_time, 0);
 
-  audio_renderer_sink_->Stop();
+  audio_renderer_sink_->Reset();
 
   {
     // Set the following states under a lock first to ensure that from now on

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink.h
@@ -71,6 +71,7 @@ class AudioRendererSink {
                      int frames_per_channel,
                      RenderCallback* render_callback) = 0;
   virtual void Stop() = 0;
+  virtual void Reset() { Stop(); }
 
   virtual void SetVolume(double volume) = 0;
   virtual void SetPlaybackRate(double playback_rate) = 0;

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -149,6 +149,13 @@ void AudioRendererSinkImpl::Stop() {
   }
 }
 
+void AudioRendererSinkImpl::Reset() {
+  SB_CHECK(thread_checker_.CalledOnValidThread());
+
+  // TODO: b/330793785 - Flush AudioSink on ATV
+  Stop();
+}
+
 void AudioRendererSinkImpl::SetVolume(double volume) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
 

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
@@ -69,6 +69,7 @@ class AudioRendererSinkImpl : public AudioRendererSink {
              int frames_per_channel,
              RenderCallback* render_callback) override;
   void Stop() override;
+  void Reset() override;
 
   void SetVolume(double volume) override;
   void SetPlaybackRate(double playback_rate) override;

--- a/starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h
+++ b/starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h
@@ -49,6 +49,7 @@ class MockAudioRendererSink : public AudioRendererSink {
                     int frames_per_channel,
                     RenderCallback* render_callback));
   MOCK_METHOD0(Stop, void());
+  MOCK_METHOD0(Reset, void());
   MOCK_METHOD1(SetVolume, void(double volume));
   MOCK_METHOD1(SetPlaybackRate, void(double playback_rate));
 

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -82,6 +82,12 @@ class AudioRendererTest : public ::testing::Test {
         }));  // NOLINT
     EXPECT_CALL(*audio_renderer_sink_, Stop()).Times(AnyNumber());
 
+    ON_CALL(*audio_renderer_sink_, Reset())
+        .WillByDefault(InvokeWithoutArgs([this]() {
+          audio_renderer_sink_->SetHasStarted(false);
+        }));  // NOLINT
+    EXPECT_CALL(*audio_renderer_sink_, Reset()).Times(AnyNumber());
+
     ON_CALL(*audio_renderer_sink_, HasStarted())
         .WillByDefault(::testing::ReturnPointee(
             audio_renderer_sink_->HasStartedPointer()));
@@ -809,7 +815,7 @@ TEST_F(AudioRendererTest, Seek) {
         *audio_renderer_sink_,
         Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
               kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
-    EXPECT_CALL(*audio_renderer_sink_, Stop());
+    EXPECT_CALL(*audio_renderer_sink_, Reset());
     EXPECT_CALL(*audio_decoder_, Reset());
     EXPECT_CALL(
         *audio_renderer_sink_,


### PR DESCRIPTION
Introduce a virtual Reset() method to the AudioRendererSink
interface. This provides a dedicated mechanism to fully reset the
audio sink's state, going beyond simply stopping playback by
enabling future platform-specific buffer flushing if required.

Update AudioRendererPcm::Seek to invoke Reset() instead of Stop().
This ensures a more comprehensive cleanup of the audio pipeline
during seek operations, which is crucial for preventing audio
artifacts or stale data, especially for specific platforms like ATV.

This PR doesn't have any functional changes.

Issue: 330793785