### PR TITLE
rdk: update tar command in deploy_rdk.py

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -154,11 +154,12 @@ def package_and_deploy(
     print("=== Packaging & Deploying artifacts ===")
     archive_name = "archive.tar.gz"
 
+    tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "-T", str(deps_file)]
     if mode == "plugin":
-        tar_cmd = ["tar", "-czf", archive_name, "-C", str(out_dir), "-T", deps_file.name, "libloader_app.so"]
-    else:
-        tar_cmd = ["tar", "-czf", archive_name, "-C", str(out_dir), "-T", deps_file.name]
+        tar_cmd.append("libloader_app.so")
+    tar_cmd.extend(["gen/build_info.json", "."])
 
+    print(f"Packaging with: {' '.join(tar_cmd)}")
     run_command(tar_cmd)
     run_command(["adb", "-s", device_id, "shell", f"mkdir -p {remote_dir}"])
     run_command(["adb", "-s", device_id, "push", archive_name, f"{remote_dir}/"])


### PR DESCRIPTION
This PR updates the tar command in the RDK deployment script to match the required production format:
- Uses -czvf (verbose mode)
- Explicitly includes gen/build_info.json and the current directory (.)
- Ensures the runtime_deps file path is correctly passed with the -T flag.
- Adds a print statement to display the full command before execution.