### PR TITLE
starboard: Add factory methods to MimeType and ParsedMimeInfo

### DIFF
--- a/starboard/android/shared/media_is_audio_supported.cc
+++ b/starboard/android/shared/media_is_audio_supported.cc
@@ -41,10 +41,6 @@ bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
 
   bool enable_audio_passthrough = true;
   if (mime_type) {
-    if (!*mime_type) {
-      return false;
-    }
-
     // Enables audio passthrough if the codec supports it.
     if (!mime_type->ValidateBoolParameter("audiopassthrough")) {
       return false;

--- a/starboard/android/shared/media_is_audio_supported.cc
+++ b/starboard/android/shared/media_is_audio_supported.cc
@@ -41,7 +41,7 @@ bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
 
   bool enable_audio_passthrough = true;
   if (mime_type) {
-    if (!mime_type->is_valid()) {
+    if (!*mime_type) {
       return false;
     }
 

--- a/starboard/android/shared/media_is_key_system_supported.cc
+++ b/starboard/android/shared/media_is_key_system_supported.cc
@@ -29,11 +29,11 @@ bool MediaIsKeySystemSupported(SbMediaVideoCodec video_codec,
                                SbMediaAudioCodec audio_codec,
                                const char* key_system) {
   // It is possible that the |key_system| comes with extra attributes, like
-  // `com.widevine.alpha; encryptionscheme="cenc"`. We prepend "key_system/"
+  // \`com.widevine.alpha; encryptionscheme="cenc"\`. We prepend "key_system/"
   // to it, so it can be parsed by MimeType.
-  MimeType mime_type(std::string("key_system/") + key_system);
-  if (!mime_type || !mime_type.ValidateStringParameter("encryptionscheme",
-                                                       "cenc|cbcs|cbcs-1-9")) {
+  auto mime_type = MimeType::Create(std::string("key_system/") + key_system);
+  if (!mime_type || !mime_type->ValidateStringParameter("encryptionscheme",
+                                                        "cenc|cbcs|cbcs-1-9")) {
     return false;
   }
 
@@ -46,7 +46,7 @@ bool MediaIsKeySystemSupported(SbMediaVideoCodec video_codec,
       audio_codec != kSbMediaAudioCodecEac3) {
     return false;
   }
-  const char* key_system_type = mime_type.subtype().c_str();
+  const char* key_system_type = mime_type->subtype().c_str();
   if (!IsWidevineL1(key_system_type) && !IsWidevineL3(key_system_type)) {
     return false;
   }
@@ -56,7 +56,7 @@ bool MediaIsKeySystemSupported(SbMediaVideoCodec video_codec,
   }
 
   std::string encryption_scheme =
-      mime_type.GetParamStringValue("encryptionscheme", "");
+      mime_type->GetParamStringValue("encryptionscheme", "");
   if (encryption_scheme == "cbcs" || encryption_scheme == "cbcs-1-9") {
     return MediaCapabilitiesCache::GetInstance()->IsCbcsSchemeSupported();
   }

--- a/starboard/android/shared/media_is_key_system_supported.cc
+++ b/starboard/android/shared/media_is_key_system_supported.cc
@@ -29,7 +29,7 @@ bool MediaIsKeySystemSupported(SbMediaVideoCodec video_codec,
                                SbMediaAudioCodec audio_codec,
                                const char* key_system) {
   // It is possible that the |key_system| comes with extra attributes, like
-  // \`com.widevine.alpha; encryptionscheme="cenc"\`. We prepend "key_system/"
+  // `com.widevine.alpha; encryptionscheme="cenc"`. We prepend "key_system/"
   // to it, so it can be parsed by MimeType.
   auto mime_type = MimeType::Create(std::string("key_system/") + key_system);
   if (!mime_type || !mime_type->ValidateStringParameter("encryptionscheme",

--- a/starboard/android/shared/media_is_key_system_supported.cc
+++ b/starboard/android/shared/media_is_key_system_supported.cc
@@ -32,8 +32,8 @@ bool MediaIsKeySystemSupported(SbMediaVideoCodec video_codec,
   // `com.widevine.alpha; encryptionscheme="cenc"`. We prepend "key_system/"
   // to it, so it can be parsed by MimeType.
   MimeType mime_type(std::string("key_system/") + key_system);
-  if (!mime_type.is_valid() || !mime_type.ValidateStringParameter(
-                                   "encryptionscheme", "cenc|cbcs|cbcs-1-9")) {
+  if (!mime_type || !mime_type.ValidateStringParameter("encryptionscheme",
+                                                       "cenc|cbcs|cbcs-1-9")) {
     return false;
   }
 

--- a/starboard/android/shared/media_is_video_supported.cc
+++ b/starboard/android/shared/media_is_video_supported.cc
@@ -50,10 +50,6 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
 
   bool must_support_tunnel_mode = false;
   if (mime_type) {
-    if (!*mime_type) {
-      return false;
-    }
-
     // Allows for enabling tunneled playback. Disabled by default.
     // https://source.android.com/devices/tv/multimedia-tunneling
     if (!mime_type->ValidateBoolParameter("tunnelmode")) {

--- a/starboard/android/shared/media_is_video_supported.cc
+++ b/starboard/android/shared/media_is_video_supported.cc
@@ -50,7 +50,7 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
 
   bool must_support_tunnel_mode = false;
   if (mime_type) {
-    if (!mime_type->is_valid()) {
+    if (!*mime_type) {
       return false;
     }
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -237,7 +237,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
 
     if (!creation_parameters.audio_mime().empty()) {
       MimeType audio_mime_type(creation_parameters.audio_mime());
-      if (!audio_mime_type.is_valid() ||
+      if (!audio_mime_type ||
           !audio_mime_type.ValidateBoolParameter("audiopassthrough")) {
         return Failure("Invalid audio mime type.");
       }
@@ -316,7 +316,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
             : "";
     MimeType audio_mime_type(audio_mime);
     if (!audio_mime.empty()) {
-      if (!audio_mime_type.is_valid()) {
+      if (!audio_mime_type) {
         return Failure("Invalid audio MIME: '" + audio_mime + "'");
       }
     }
@@ -327,7 +327,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
             : "";
     MimeType video_mime_type(video_mime);
     if (!video_mime.empty()) {
-      if (!video_mime_type.is_valid() ||
+      if (!video_mime_type ||
           !video_mime_type.ValidateBoolParameter("tunnelmode") ||
           !video_mime_type.ValidateBoolParameter("enableflushduringseek") ||
           !video_mime_type.ValidateBoolParameter("enableresetaudiodecoder")) {

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -315,11 +315,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         creation_parameters.audio_codec() != kSbMediaAudioCodecNone
             ? creation_parameters.audio_mime()
             : "";
-    auto audio_mime_type = MimeType::Create(audio_mime);
-    if (!audio_mime.empty()) {
-      if (!audio_mime_type) {
-        return Failure("Invalid audio MIME: '" + audio_mime + "'");
-      }
+    if (!audio_mime.empty() && !MimeType::Create(audio_mime)) {
+      return Failure("Invalid audio MIME: '" + audio_mime + "'");
     }
 
     const std::string video_mime =
@@ -327,13 +324,12 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
             ? creation_parameters.video_mime()
             : "";
     auto video_mime_type = MimeType::Create(video_mime);
-    if (!video_mime.empty()) {
-      if (!video_mime_type ||
-          !video_mime_type->ValidateBoolParameter("tunnelmode") ||
-          !video_mime_type->ValidateBoolParameter("enableflushduringseek") ||
-          !video_mime_type->ValidateBoolParameter("enableresetaudiodecoder")) {
-        return Failure("Invalid video MIME: '" + video_mime + "'");
-      }
+    if (!video_mime.empty() &&
+        (!video_mime_type ||
+         !video_mime_type->ValidateBoolParameter("tunnelmode") ||
+         !video_mime_type->ValidateBoolParameter("enableflushduringseek") ||
+         !video_mime_type->ValidateBoolParameter("enableresetaudiodecoder"))) {
+      return Failure("Invalid video MIME: '" + video_mime + "'");
     }
 
     int tunnel_mode_audio_session_id = -1;

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -236,12 +236,12 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     }
 
     if (!creation_parameters.audio_mime().empty()) {
-      MimeType audio_mime_type(creation_parameters.audio_mime());
+      auto audio_mime_type = MimeType::Create(creation_parameters.audio_mime());
       if (!audio_mime_type ||
-          !audio_mime_type.ValidateBoolParameter("audiopassthrough")) {
+          !audio_mime_type->ValidateBoolParameter("audiopassthrough")) {
         return Failure("Invalid audio mime type.");
       }
-      if (!audio_mime_type.GetParamBoolValue("audiopassthrough", true)) {
+      if (!audio_mime_type->GetParamBoolValue("audiopassthrough", true)) {
         SB_LOG(INFO) << "Mime attribute \"audiopassthrough\" is set to: "
                         "false. Passthrough is disabled.";
         return Failure("Passthrough disabled by mime attribute.");
@@ -253,11 +253,12 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         creation_parameters.experimental_features().flush_decoder_during_reset;
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone &&
         !creation_parameters.video_mime().empty()) {
-      MimeType video_mime_type(creation_parameters.video_mime());
-      if (video_mime_type.ValidateBoolParameter("enableflushduringseek")) {
+      auto video_mime_type = MimeType::Create(creation_parameters.video_mime());
+      if (video_mime_type &&
+          video_mime_type->ValidateBoolParameter("enableflushduringseek")) {
         enable_flush_during_seek =
             enable_flush_during_seek ||
-            video_mime_type.GetParamBoolValue("enableflushduringseek", false);
+            video_mime_type->GetParamBoolValue("enableflushduringseek", false);
       }
     }
     SB_LOG_IF(INFO, enable_flush_during_seek)
@@ -314,7 +315,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         creation_parameters.audio_codec() != kSbMediaAudioCodecNone
             ? creation_parameters.audio_mime()
             : "";
-    MimeType audio_mime_type(audio_mime);
+    auto audio_mime_type = MimeType::Create(audio_mime);
     if (!audio_mime.empty()) {
       if (!audio_mime_type) {
         return Failure("Invalid audio MIME: '" + audio_mime + "'");
@@ -325,12 +326,12 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         creation_parameters.video_codec() != kSbMediaVideoCodecNone
             ? creation_parameters.video_mime()
             : "";
-    MimeType video_mime_type(video_mime);
+    auto video_mime_type = MimeType::Create(video_mime);
     if (!video_mime.empty()) {
       if (!video_mime_type ||
-          !video_mime_type.ValidateBoolParameter("tunnelmode") ||
-          !video_mime_type.ValidateBoolParameter("enableflushduringseek") ||
-          !video_mime_type.ValidateBoolParameter("enableresetaudiodecoder")) {
+          !video_mime_type->ValidateBoolParameter("tunnelmode") ||
+          !video_mime_type->ValidateBoolParameter("enableflushduringseek") ||
+          !video_mime_type->ValidateBoolParameter("enableresetaudiodecoder")) {
         return Failure("Invalid video MIME: '" + video_mime + "'");
       }
     }
@@ -343,13 +344,15 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
           FeatureList::IsEnabled(features::kForceTunnelMode);
       enable_tunnel_mode =
           force_tunnel_mode ||
-          video_mime_type.GetParamBoolValue("tunnelmode", false);
+          (video_mime_type &&
+           video_mime_type->GetParamBoolValue("tunnelmode", false));
 
       SB_LOG(INFO) << "Tunnel mode is "
                    << (enable_tunnel_mode ? "enabled. " : "disabled. ")
                    << "Video mime parameter \"tunnelmode\" value: "
-                   << video_mime_type.GetParamStringValue("tunnelmode",
-                                                          "<not provided>")
+                   << (video_mime_type ? video_mime_type->GetParamStringValue(
+                                             "tunnelmode", "<not provided>")
+                                       : "<not provided>")
                    << (force_tunnel_mode ? ", force tunnel mode is on." : ".");
     } else {
       SB_LOG(INFO) << "Tunnel mode requires both an audio and video stream. "
@@ -387,25 +390,29 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     bool enable_reset_audio_decoder =
         FeatureList::IsEnabled(features::kForceResetAudioDecoder) ||
         experimental_features.reset_audio_decoder ||
-        video_mime_type.GetParamBoolValue("enableresetaudiodecoder", false);
+        (video_mime_type &&
+         video_mime_type->GetParamBoolValue("enableresetaudiodecoder", false));
     SB_LOG_IF(INFO, enable_reset_audio_decoder)
         << "`enable_reset_audio_decoder` is set to true, force resetting"
         << " audio decoder during Reset(). Video mime parameter "
         << "\"enableresetaudiodecoder\" value: "
-        << video_mime_type.GetParamStringValue("enableresetaudiodecoder",
-                                               "<not provided>")
+        << (video_mime_type ? video_mime_type->GetParamStringValue(
+                                  "enableresetaudiodecoder", "<not provided>")
+                            : "<not provided>")
         << ".";
 
     bool enable_flush_during_seek =
         FeatureList::IsEnabled(features::kForceFlushDecoderDuringReset) ||
         experimental_features.flush_decoder_during_reset ||
-        video_mime_type.GetParamBoolValue("enableflushduringseek", false);
+        (video_mime_type &&
+         video_mime_type->GetParamBoolValue("enableflushduringseek", false));
     SB_LOG_IF(INFO, enable_flush_during_seek)
         << "`enable_flush_during_seek` is set to true, force flushing"
         << " audio decoder during Reset(). Video mime parameter "
         << "\"enableflushduringseek\" value: "
-        << video_mime_type.GetParamStringValue("enableflushduringseek",
-                                               "<not provided>")
+        << (video_mime_type ? video_mime_type->GetParamStringValue(
+                                  "enableflushduringseek", "<not provided>")
+                            : "<not provided>")
         << ".";
 
     MediaComponents components;
@@ -505,22 +512,24 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         !creation_parameters.video_mime().empty()) {
       // Use mime param to determine endianness of HDR metadata. If param is
       // missing or invalid it defaults to Little Endian.
-      MimeType video_mime_type(creation_parameters.video_mime());
-      if (video_mime_type.ValidateStringParameter("hdrinfoendianness",
-                                                  "big|little")) {
+      auto video_mime_type = MimeType::Create(creation_parameters.video_mime());
+      if (video_mime_type && video_mime_type->ValidateStringParameter(
+                                 "hdrinfoendianness", "big|little")) {
         const std::string& hdr_info_endianness =
-            video_mime_type.GetParamStringValue("hdrinfoendianness",
-                                                /*default=*/"little");
+            video_mime_type->GetParamStringValue("hdrinfoendianness",
+                                                 /*default=*/"little");
         force_big_endian_hdr_metadata = hdr_info_endianness == "big";
       }
-      if (video_mime_type.ValidateBoolParameter("forceresetsurface")) {
+      if (video_mime_type &&
+          video_mime_type->ValidateBoolParameter("forceresetsurface")) {
         force_reset_surface =
-            video_mime_type.GetParamBoolValue("forceresetsurface", true);
+            video_mime_type->GetParamBoolValue("forceresetsurface", true);
       }
-      if (video_mime_type.ValidateBoolParameter("enableflushduringseek")) {
+      if (video_mime_type &&
+          video_mime_type->ValidateBoolParameter("enableflushduringseek")) {
         enable_flush_during_seek =
             enable_flush_during_seek ||
-            video_mime_type.GetParamBoolValue("enableflushduringseek", false);
+            video_mime_type->GetParamBoolValue("enableflushduringseek", false);
       }
     }
 

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -62,15 +62,16 @@ bool IsSoftwareDecodeRequired(const std::string& max_video_capabilities) {
   // `max_video_capabilities` is in the form of mime type attributes, like
   // "width=1920; height=1080; ...".  Prepend valid mime type/subtype and codecs
   // so it can be parsed by MimeType.
-  MimeType mime_type("video/mp4; codecs=\"vp9\"; " + max_video_capabilities);
-  if (!mime_type.is_valid()) {
+  auto mime_type =
+      MimeType::Create("video/mp4; codecs=\"vp9\"; " + max_video_capabilities);
+  if (!mime_type) {
     SB_LOG(INFO) << "Use hardware decoder as `max_video_capabilities` ("
                  << max_video_capabilities << ") is invalid.";
     return false;
   }
 
   std::string software_decoder_expectation =
-      mime_type.GetParamStringValue("softwaredecoder", "");
+      mime_type->GetParamStringValue("softwaredecoder", "");
   if (software_decoder_expectation == "required" ||
       software_decoder_expectation == "preferred") {
     SB_LOG(INFO) << "Use software decoder as `softwaredecoder` is set to \""
@@ -83,9 +84,9 @@ bool IsSoftwareDecodeRequired(const std::string& max_video_capabilities) {
     return false;
   }
 
-  bool is_low_resolution = mime_type.GetParamIntValue("width", 1920) <= 432 &&
-                           mime_type.GetParamIntValue("height", 1080) <= 240;
-  bool is_low_fps = mime_type.GetParamIntValue("framerate", 30) <= 15;
+  bool is_low_resolution = mime_type->GetParamIntValue("width", 1920) <= 432 &&
+                           mime_type->GetParamIntValue("height", 1080) <= 240;
+  bool is_low_fps = mime_type->GetParamIntValue("framerate", 30) <= 15;
 
   if (is_low_resolution && is_low_fps) {
     // Workaround to be compatible with existing backend implementation.
@@ -119,15 +120,16 @@ std::optional<Size> ParseMaxResolution(
   // `max_video_capabilities` is in the form of mime type attributes, like
   // "width=1920; height=1080; ...".  Prepend valid mime type/subtype and codecs
   // so it can be parsed by MimeType.
-  MimeType mime_type("video/mp4; codecs=\"vp9\"; " + max_video_capabilities);
-  if (!mime_type.is_valid()) {
+  auto mime_type =
+      MimeType::Create("video/mp4; codecs=\"vp9\"; " + max_video_capabilities);
+  if (!mime_type) {
     SB_LOG(WARNING) << "Failed to parse max resolutions as "
                        "`max_video_capabilities` is invalid.";
     return std::nullopt;
   }
 
-  int width = mime_type.GetParamIntValue("width", -1);
-  int height = mime_type.GetParamIntValue("height", -1);
+  int width = mime_type->GetParamIntValue("width", -1);
+  int height = mime_type->GetParamIntValue("height", -1);
   if (width <= 0 && height <= 0) {
     SB_LOG(WARNING) << "Failed to parse max resolutions as either width or "
                        "height isn't set.";

--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -274,12 +274,12 @@ bool IsSDRVideo(const char* mime) {
     return true;
   }
 
-  MimeType mime_type(mime);
+  auto mime_type = MimeType::Create(mime);
   if (!mime_type) {
     SB_LOG(WARNING) << mime << " is not a valid mime type, assuming sdr video.";
     return true;
   }
-  const std::vector<std::string> codecs = mime_type.GetCodecs();
+  const std::vector<std::string> codecs = mime_type->GetCodecs();
   if (codecs.empty()) {
     SB_LOG(WARNING) << mime << " contains no codecs, assuming sdr video.";
     return true;

--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -275,7 +275,7 @@ bool IsSDRVideo(const char* mime) {
   }
 
   MimeType mime_type(mime);
-  if (!mime_type.is_valid()) {
+  if (!mime_type) {
     SB_LOG(WARNING) << mime << " is not a valid mime type, assuming sdr video.";
     return true;
   }

--- a/starboard/shared/starboard/media/mime_supportability_cache.cc
+++ b/starboard/shared/starboard/media/mime_supportability_cache.cc
@@ -151,11 +151,9 @@ void StripAndParseBitrate(const char* mime,
 SB_ONCE_INITIALIZE_FUNCTION(MimeSupportabilityCache,
                             MimeSupportabilityCache::GetInstance)
 
-Supportability MimeSupportabilityCache::GetMimeSupportability(
-    const char* mime,
-    ParsedMimeInfo* mime_info) {
+MimeSupportabilityResult MimeSupportabilityCache::GetMimeSupportability(
+    const char* mime) {
   SB_DCHECK(mime);
-  SB_DCHECK(mime_info);
 
   // Strip the bitrate from mime string and check it separately.
   std::string mime_without_bitrate;
@@ -164,26 +162,26 @@ Supportability MimeSupportabilityCache::GetMimeSupportability(
 
   if (bitrate < 0) {
     // The mime string contains an invalid bitrate attribute. In that case, we
-    // return an invalid ParsedMimeInfo with kSbMediaSupportTypeNotSupported.
-    *mime_info = ParsedMimeInfo(mime);
-    return kSupportabilityNotSupported;
+    // return an empty mime_info with kSupportabilityNotSupported.
+    return {kSupportabilityNotSupported, std::nullopt};
   }
 
   std::lock_guard scoped_lock(mutex_);
-  Entry& entry = GetEntry_Locked(mime_without_bitrate);
+  Entry* entry = GetEntry_Locked(mime_without_bitrate);
 
-  // Return cached ParsedMimeInfo with real bitrate.
-  *mime_info = entry.mime_info;
-  mime_info->SetBitrate(bitrate);
-
-  if (!*mime_info) {
-    // Return kSupportabilityNotSupported if we can't get a valid
-    // ParsedMimeInfo.
-    return kSupportabilityNotSupported;
+  if (!entry) {
+    // Failed to parse mime string.
+    return {kSupportabilityNotSupported, std::nullopt};
   }
 
-  return is_enabled_ ? IsBitrateSupported_Locked(entry, bitrate)
-                     : kSupportabilityUnknown;
+  // Return cached ParsedMimeInfo with real bitrate.
+  ParsedMimeInfo mime_info = entry->mime_info.WithBitrate(bitrate);
+
+  Supportability supportability =
+      is_enabled_ ? IsBitrateSupported_Locked(*entry, bitrate)
+                  : kSupportabilityUnknown;
+
+  return {supportability, std::move(mime_info)};
 }
 
 void MimeSupportabilityCache::CacheMimeSupportability(
@@ -207,10 +205,10 @@ void MimeSupportabilityCache::CacheMimeSupportability(
   }
 
   std::lock_guard scoped_lock(mutex_);
-  Entry& entry = GetEntry_Locked(mime_without_bitrate);
+  Entry* entry = GetEntry_Locked(mime_without_bitrate);
 
-  if (entry.mime_info) {
-    UpdateBitrateSupportability_Locked(&entry, bitrate, supportability);
+  if (entry) {
+    UpdateBitrateSupportability_Locked(entry, bitrate, supportability);
   }
 }
 
@@ -231,35 +229,27 @@ void MimeSupportabilityCache::DumpCache() {
     ss << "\nMime: " << entry_iter.first;
     ss << "\n  ParsedMimeInfo:";
     ss << "\n    MimeType : " << mime_info.mime_type();
-    if (mime_info) {
-      if (mime_info.has_audio_info()) {
-        const ParsedMimeInfo::AudioCodecInfo& audio_info =
-            mime_info.audio_info();
-        ss << "\n    Audio Codec : "
-           << GetMediaAudioCodecName(audio_info.codec);
-        ss << "\n    Channels : " << audio_info.channels;
-      }
-      if (mime_info.has_video_info()) {
-        const ParsedMimeInfo::VideoCodecInfo& video_info =
-            mime_info.video_info();
-        ss << "\n    Video Codec : "
-           << GetMediaVideoCodecName(video_info.codec);
-        ss << "\n    Profile : " << video_info.profile;
-        ss << "\n    Level : " << video_info.level;
-        ss << "\n    BitDepth : " << video_info.bit_depth;
-        ss << "\n    PrimaryId : "
-           << GetMediaPrimaryIdName(video_info.primary_id);
-        ss << "\n    TransferId : "
-           << GetMediaTransferIdName(video_info.transfer_id);
-        ss << "\n    MatrixId : " << GetMediaMatrixIdName(video_info.matrix_id);
-        ss << "\n    Width : " << video_info.frame_width;
-        ss << "\n    Height : " << video_info.frame_height;
-        ss << "\n    Fps : " << video_info.fps;
-        ss << "\n    DecodeToTexture : "
-           << ToString(video_info.decode_to_texture_required);
-      }
-    } else {
-      ss << "\n    Mime info is not valid";
+    if (mime_info.has_audio_info()) {
+      const ParsedMimeInfo::AudioCodecInfo& audio_info = mime_info.audio_info();
+      ss << "\n    Audio Codec : " << GetMediaAudioCodecName(audio_info.codec);
+      ss << "\n    Channels : " << audio_info.channels;
+    }
+    if (mime_info.has_video_info()) {
+      const ParsedMimeInfo::VideoCodecInfo& video_info = mime_info.video_info();
+      ss << "\n    Video Codec : " << GetMediaVideoCodecName(video_info.codec);
+      ss << "\n    Profile : " << video_info.profile;
+      ss << "\n    Level : " << video_info.level;
+      ss << "\n    BitDepth : " << video_info.bit_depth;
+      ss << "\n    PrimaryId : "
+         << GetMediaPrimaryIdName(video_info.primary_id);
+      ss << "\n    TransferId : "
+         << GetMediaTransferIdName(video_info.transfer_id);
+      ss << "\n    MatrixId : " << GetMediaMatrixIdName(video_info.matrix_id);
+      ss << "\n    Width : " << video_info.frame_width;
+      ss << "\n    Height : " << video_info.frame_height;
+      ss << "\n    Fps : " << video_info.fps;
+      ss << "\n    DecodeToTexture : "
+         << ToString(video_info.decode_to_texture_required);
     }
 
     ss << "\n  MaxSupportedBitrate: "
@@ -272,16 +262,22 @@ void MimeSupportabilityCache::DumpCache() {
   SB_DLOG(INFO) << ss.str();
 }
 
-MimeSupportabilityCache::Entry& MimeSupportabilityCache::GetEntry_Locked(
+MimeSupportabilityCache::Entry* MimeSupportabilityCache::GetEntry_Locked(
     const std::string& mime_string) {
   auto entry_iter = entries_.find(mime_string);
   if (entry_iter != entries_.end()) {
-    return entry_iter->second;
+    return &entry_iter->second;
   }
 
   // We can't find anything from the cache. Parse mime string and cache
   // parsed ParsedMimeInfo.
-  auto insert_result = entries_.insert({mime_string, Entry(mime_string)});
+  auto mime_info = ParsedMimeInfo::Create(mime_string);
+  if (!mime_info) {
+    return nullptr;
+  }
+
+  auto insert_result =
+      entries_.emplace(mime_string, Entry(std::move(*mime_info)));
 
   // Keep cached items not exceeding max size.
   fifo_queue_.push(insert_result.first);
@@ -291,13 +287,13 @@ MimeSupportabilityCache::Entry& MimeSupportabilityCache::GetEntry_Locked(
   }
   SB_DCHECK_EQ(entries_.size(), fifo_queue_.size());
 
-  return insert_result.first->second;
+  return &insert_result.first->second;
 }
 
 Supportability MimeSupportabilityCache::IsBitrateSupported_Locked(
     const Entry& entry,
     int bitrate) const {
-  SB_DCHECK_GE(bitrate, 0);
+  SB_DCHECK(bitrate >= 0);
 
   if (bitrate <= entry.max_supported_bitrate) {
     return kSupportabilitySupported;
@@ -313,8 +309,8 @@ void MimeSupportabilityCache::UpdateBitrateSupportability_Locked(
     int bitrate,
     Supportability supportability) {
   SB_DCHECK(entry);
-  SB_DCHECK_GE(bitrate, 0);
-  SB_DCHECK_NE(supportability, kSupportabilityUnknown);
+  SB_DCHECK(bitrate >= 0);
+  SB_DCHECK(supportability != kSupportabilityUnknown);
 
   if (supportability == kSupportabilitySupported) {
     SB_DCHECK_LT(bitrate, entry->min_unsupported_bitrate);

--- a/starboard/shared/starboard/media/mime_supportability_cache.cc
+++ b/starboard/shared/starboard/media/mime_supportability_cache.cc
@@ -176,7 +176,7 @@ Supportability MimeSupportabilityCache::GetMimeSupportability(
   *mime_info = entry.mime_info;
   mime_info->SetBitrate(bitrate);
 
-  if (!mime_info->is_valid()) {
+  if (!*mime_info) {
     // Return kSupportabilityNotSupported if we can't get a valid
     // ParsedMimeInfo.
     return kSupportabilityNotSupported;
@@ -209,7 +209,7 @@ void MimeSupportabilityCache::CacheMimeSupportability(
   std::lock_guard scoped_lock(mutex_);
   Entry& entry = GetEntry_Locked(mime_without_bitrate);
 
-  if (entry.mime_info.is_valid()) {
+  if (entry.mime_info) {
     UpdateBitrateSupportability_Locked(&entry, bitrate, supportability);
   }
 }
@@ -231,7 +231,7 @@ void MimeSupportabilityCache::DumpCache() {
     ss << "\nMime: " << entry_iter.first;
     ss << "\n  ParsedMimeInfo:";
     ss << "\n    MimeType : " << mime_info.mime_type();
-    if (mime_info.is_valid()) {
+    if (mime_info) {
       if (mime_info.has_audio_info()) {
         const ParsedMimeInfo::AudioCodecInfo& audio_info =
             mime_info.audio_info();

--- a/starboard/shared/starboard/media/mime_supportability_cache.cc
+++ b/starboard/shared/starboard/media/mime_supportability_cache.cc
@@ -268,7 +268,7 @@ MimeSupportabilityCache::Entry* MimeSupportabilityCache::GetEntry_Locked(
 Supportability MimeSupportabilityCache::IsBitrateSupported_Locked(
     const Entry& entry,
     int bitrate) const {
-  SB_DCHECK_GT(bitrate, 0);
+  SB_DCHECK_GE(bitrate, 0);
 
   if (bitrate <= entry.max_supported_bitrate) {
     return kSupportabilitySupported;

--- a/starboard/shared/starboard/media/mime_supportability_cache.cc
+++ b/starboard/shared/starboard/media/mime_supportability_cache.cc
@@ -151,8 +151,8 @@ void StripAndParseBitrate(const char* mime,
 SB_ONCE_INITIALIZE_FUNCTION(MimeSupportabilityCache,
                             MimeSupportabilityCache::GetInstance)
 
-MimeSupportabilityResult MimeSupportabilityCache::GetMimeSupportability(
-    const char* mime) {
+MimeSupportabilityCache::MimeSupportabilityResult
+MimeSupportabilityCache::GetMimeSupportability(const char* mime) {
   SB_DCHECK(mime);
 
   // Strip the bitrate from mime string and check it separately.
@@ -293,7 +293,7 @@ MimeSupportabilityCache::Entry* MimeSupportabilityCache::GetEntry_Locked(
 Supportability MimeSupportabilityCache::IsBitrateSupported_Locked(
     const Entry& entry,
     int bitrate) const {
-  SB_DCHECK(bitrate >= 0);
+  SB_DCHECK_GT(bitrate, 0);
 
   if (bitrate <= entry.max_supported_bitrate) {
     return kSupportabilitySupported;
@@ -309,8 +309,8 @@ void MimeSupportabilityCache::UpdateBitrateSupportability_Locked(
     int bitrate,
     Supportability supportability) {
   SB_DCHECK(entry);
-  SB_DCHECK(bitrate >= 0);
-  SB_DCHECK(supportability != kSupportabilityUnknown);
+  SB_DCHECK_GE(bitrate, 0);
+  SB_DCHECK_NE(supportability, kSupportabilityUnknown);
 
   if (supportability == kSupportabilitySupported) {
     SB_DCHECK_LT(bitrate, entry->min_unsupported_bitrate);

--- a/starboard/shared/starboard/media/mime_supportability_cache.cc
+++ b/starboard/shared/starboard/media/mime_supportability_cache.cc
@@ -225,33 +225,8 @@ void MimeSupportabilityCache::DumpCache() {
   std::stringstream ss;
   ss << "\n========Dumping MimeSupportabilityCache========";
   for (const auto& entry_iter : entries_) {
-    const ParsedMimeInfo& mime_info = entry_iter.second.mime_info;
     ss << "\nMime: " << entry_iter.first;
-    ss << "\n  ParsedMimeInfo:";
-    ss << "\n    MimeType : " << mime_info.mime_type();
-    if (mime_info.has_audio_info()) {
-      const ParsedMimeInfo::AudioCodecInfo& audio_info = mime_info.audio_info();
-      ss << "\n    Audio Codec : " << GetMediaAudioCodecName(audio_info.codec);
-      ss << "\n    Channels : " << audio_info.channels;
-    }
-    if (mime_info.has_video_info()) {
-      const ParsedMimeInfo::VideoCodecInfo& video_info = mime_info.video_info();
-      ss << "\n    Video Codec : " << GetMediaVideoCodecName(video_info.codec);
-      ss << "\n    Profile : " << video_info.profile;
-      ss << "\n    Level : " << video_info.level;
-      ss << "\n    BitDepth : " << video_info.bit_depth;
-      ss << "\n    PrimaryId : "
-         << GetMediaPrimaryIdName(video_info.primary_id);
-      ss << "\n    TransferId : "
-         << GetMediaTransferIdName(video_info.transfer_id);
-      ss << "\n    MatrixId : " << GetMediaMatrixIdName(video_info.matrix_id);
-      ss << "\n    Width : " << video_info.frame_width;
-      ss << "\n    Height : " << video_info.frame_height;
-      ss << "\n    Fps : " << video_info.fps;
-      ss << "\n    DecodeToTexture : "
-         << ToString(video_info.decode_to_texture_required);
-    }
-
+    ss << "\n  ParsedMimeInfo: " << entry_iter.second.mime_info;
     ss << "\n  MaxSupportedBitrate: "
        << entry_iter.second.max_supported_bitrate;
     ss << "\n  MinUnsupportedBitrate: "

--- a/starboard/shared/starboard/media/mime_supportability_cache.h
+++ b/starboard/shared/starboard/media/mime_supportability_cache.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <mutex>
+#include <optional>
 #include <queue>
 #include <string>
 #include <unordered_map>
@@ -31,6 +32,11 @@ typedef enum Supportability {
   kSupportabilitySupported,
   kSupportabilityNotSupported,
 } Supportability;
+
+struct MimeSupportabilityResult {
+  Supportability supportability;
+  std::optional<ParsedMimeInfo> mime_info;
+};
 
 // MimeSupportabilityCache caches the supportabilities of raw mime strings.
 // To increase cache hit rate, it strips bitrate from the raw mime string, and
@@ -63,12 +69,11 @@ class MimeSupportabilityCache {
   // ParsedMimeInfo, it will parse the mime string and cache the result.
   // If we cannot get a valid ParsedMimeInfo from |mime|,
   // GetMimeSupportability() will return kSupportabilityNotSupported with an
-  // invalid ParsedMimeInfo. Ideally, we should decouple mime parsing and
+  // empty mime_info. Ideally, we should decouple mime parsing and
   // supportability cache, but considering that the cache is only for internal
   // use, to avoid repeated lookups, we do parsing in this function for now.
-  // Note that |mime| and |mime_info| cannot be null.
-  Supportability GetMimeSupportability(const char* mime,
-                                       ParsedMimeInfo* mime_info);
+  // Note that |mime| cannot be null.
+  MimeSupportabilityResult GetMimeSupportability(const char* mime);
 
   // Update cached supportability of the mime string.
   // Note that if |supportability| is kSupportabilityUnknown or we cannot
@@ -91,7 +96,7 @@ class MimeSupportabilityCache {
     int max_supported_bitrate = -1;
     int min_unsupported_bitrate = INT_MAX;
 
-    explicit Entry(const std::string& mime) : mime_info(mime) {}
+    explicit Entry(ParsedMimeInfo info) : mime_info(std::move(info)) {}
   };
 
   // Class can only be instanced via the singleton
@@ -101,7 +106,7 @@ class MimeSupportabilityCache {
   MimeSupportabilityCache(const MimeSupportabilityCache&) = delete;
   MimeSupportabilityCache& operator=(const MimeSupportabilityCache&) = delete;
 
-  Entry& GetEntry_Locked(const std::string& mime_string);
+  Entry* GetEntry_Locked(const std::string& mime_string);
   Supportability IsBitrateSupported_Locked(const Entry& entry,
                                            int bitrate) const;
   void UpdateBitrateSupportability_Locked(Entry* entry,

--- a/starboard/shared/starboard/media/mime_supportability_cache.h
+++ b/starboard/shared/starboard/media/mime_supportability_cache.h
@@ -33,11 +33,6 @@ typedef enum Supportability {
   kSupportabilityNotSupported,
 } Supportability;
 
-struct MimeSupportabilityResult {
-  Supportability supportability;
-  std::optional<ParsedMimeInfo> mime_info;
-};
-
 // MimeSupportabilityCache caches the supportabilities of raw mime strings.
 // To increase cache hit rate, it strips bitrate from the raw mime string, and
 // stores a supported bitrate range for mime strings with same other attributes.
@@ -73,6 +68,10 @@ class MimeSupportabilityCache {
   // supportability cache, but considering that the cache is only for internal
   // use, to avoid repeated lookups, we do parsing in this function for now.
   // Note that |mime| cannot be null.
+  struct MimeSupportabilityResult {
+    Supportability supportability;
+    std::optional<ParsedMimeInfo> mime_info;
+  };
   MimeSupportabilityResult GetMimeSupportability(const char* mime);
 
   // Update cached supportability of the mime string.

--- a/starboard/shared/starboard/media/mime_type.cc
+++ b/starboard/shared/starboard/media/mime_type.cc
@@ -155,8 +155,8 @@ std::optional<MimeType> MimeType::Create(const std::string& content_type) {
       type_and_container[1].empty()) {
     return std::nullopt;
   }
-  std::string type = type_and_container[0];
-  std::string subtype = type_and_container[1];
+  std::string type = std::move(type_and_container[0]);
+  std::string subtype = std::move(type_and_container[1]);
 
   components.erase(components.begin());
 
@@ -164,10 +164,9 @@ std::optional<MimeType> MimeType::Create(const std::string& content_type) {
   Params params;
 
   // 2. Verify the parameters have valid formats, we want to be strict here.
-  for (Strings::iterator iter = components.begin(); iter != components.end();
-       ++iter) {
+  for (const auto& component : components) {
     Param param;
-    if (!ParseParamString(*iter, &param)) {
+    if (!ParseParamString(component, &param)) {
       return std::nullopt;
     }
     // There can only be no more than one codecs parameter and it has to be
@@ -178,7 +177,7 @@ std::optional<MimeType> MimeType::Create(const std::string& content_type) {
       }
       codecs = SplitAndTrim(param.string_value, ',');
     }
-    params.push_back(param);
+    params.push_back(std::move(param));
   }
 
   return MimeType(std::move(type), std::move(subtype), std::move(codecs),

--- a/starboard/shared/starboard/media/mime_type.cc
+++ b/starboard/shared/starboard/media/mime_type.cc
@@ -162,20 +162,26 @@ MimeType::MimeType(const std::string& content_type) {
        ++iter) {
     Param param;
     if (!ParseParamString(*iter, &param)) {
+      type_.clear();
+      subtype_.clear();
+      codecs_.clear();
+      params_.clear();
       return;
     }
     // There can only be no more than one codecs parameter and it has to be
     // the first parameter if it is present.
     if (param.name == "codecs") {
       if (!params_.empty()) {
+        type_.clear();
+        subtype_.clear();
+        codecs_.clear();
+        params_.clear();
         return;
       }
       codecs_ = SplitAndTrim(param.string_value, ',');
     }
     params_.push_back(param);
   }
-
-  is_valid_ = true;
 }
 
 int MimeType::GetParamCount() const {
@@ -275,10 +281,6 @@ bool MimeType::GetParamBoolValue(const char* name, bool default_value) const {
 }
 
 bool MimeType::ValidateIntParameter(const char* name) const {
-  if (!is_valid()) {
-    return false;
-  }
-
   int index = GetParamIndexByName(name);
   if (index == kInvalidParamIndex) {
     return true;
@@ -287,10 +289,6 @@ bool MimeType::ValidateIntParameter(const char* name) const {
 }
 
 bool MimeType::ValidateFloatParameter(const char* name) const {
-  if (!is_valid()) {
-    return false;
-  }
-
   int index = GetParamIndexByName(name);
   if (index == kInvalidParamIndex) {
     return true;
@@ -301,10 +299,6 @@ bool MimeType::ValidateFloatParameter(const char* name) const {
 
 bool MimeType::ValidateStringParameter(const char* name,
                                        const std::string& pattern) const {
-  if (!is_valid()) {
-    return false;
-  }
-
   int index = GetParamIndexByName(name);
   if (pattern.empty() || index == kInvalidParamIndex) {
     return true;
@@ -334,10 +328,6 @@ bool MimeType::ValidateStringParameter(const char* name,
 }
 
 bool MimeType::ValidateBoolParameter(const char* name) const {
-  if (!is_valid()) {
-    return false;
-  }
-
   int index = GetParamIndexByName(name);
   if (index == kInvalidParamIndex) {
     return true;
@@ -347,9 +337,6 @@ bool MimeType::ValidateBoolParameter(const char* name) const {
 }
 
 std::ostream& operator<<(std::ostream& os, const MimeType& mime_type) {
-  if (!mime_type.is_valid()) {
-    return os << "{ InvalidMimeType }; ";
-  }
   os << "{ type: " << mime_type.type();
   os << ", subtype: " << mime_type.subtype();
   os << ", codecs: ";

--- a/starboard/shared/starboard/media/mime_type.cc
+++ b/starboard/shared/starboard/media/mime_type.cc
@@ -20,8 +20,10 @@
 #include <iosfwd>
 #include <locale>
 #include <numeric>
+#include <optional>
 #include <sstream>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "starboard/common/check_op.h"
@@ -134,55 +136,63 @@ bool MimeType::ParseParamString(const std::string& param_string, Param* param) {
   return true;
 }
 
-MimeType::MimeType(const std::string& content_type) {
+// static
+std::optional<MimeType> MimeType::Create(const std::string& content_type) {
   Strings components = SplitAndTrim(content_type, ';');
 
   if (components.empty()) {
-    return;
+    return std::nullopt;
   }
 
   // 1. Verify if there is a valid type/subtype in the very beginning.
   if (ContainsSpace(components.front())) {
-    return;
+    return std::nullopt;
   }
 
   std::vector<std::string> type_and_container =
       SplitAndTrim(components.front(), '/');
   if (type_and_container.size() != 2 || type_and_container[0].empty() ||
       type_and_container[1].empty()) {
-    return;
+    return std::nullopt;
   }
-  type_ = type_and_container[0];
-  subtype_ = type_and_container[1];
+  std::string type = type_and_container[0];
+  std::string subtype = type_and_container[1];
 
   components.erase(components.begin());
+
+  std::vector<std::string> codecs;
+  Params params;
 
   // 2. Verify the parameters have valid formats, we want to be strict here.
   for (Strings::iterator iter = components.begin(); iter != components.end();
        ++iter) {
     Param param;
     if (!ParseParamString(*iter, &param)) {
-      type_.clear();
-      subtype_.clear();
-      codecs_.clear();
-      params_.clear();
-      return;
+      return std::nullopt;
     }
     // There can only be no more than one codecs parameter and it has to be
     // the first parameter if it is present.
     if (param.name == "codecs") {
-      if (!params_.empty()) {
-        type_.clear();
-        subtype_.clear();
-        codecs_.clear();
-        params_.clear();
-        return;
+      if (!params.empty()) {
+        return std::nullopt;
       }
-      codecs_ = SplitAndTrim(param.string_value, ',');
+      codecs = SplitAndTrim(param.string_value, ',');
     }
-    params_.push_back(param);
+    params.push_back(param);
   }
+
+  return MimeType(std::move(type), std::move(subtype), std::move(codecs),
+                  std::move(params));
 }
+
+MimeType::MimeType(std::string type,
+                   std::string subtype,
+                   std::vector<std::string> codecs,
+                   Params params)
+    : type_(std::move(type)),
+      subtype_(std::move(subtype)),
+      codecs_(std::move(codecs)),
+      params_(std::move(params)) {}
 
 int MimeType::GetParamCount() const {
   return static_cast<int>(params_.size());

--- a/starboard/shared/starboard/media/mime_type.h
+++ b/starboard/shared/starboard/media/mime_type.h
@@ -16,6 +16,7 @@
 #define STARBOARD_SHARED_STARBOARD_MEDIA_MIME_TYPE_H_
 
 #include <iosfwd>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -67,10 +68,7 @@ class MimeType {
   // Expose the function as a helper function to parse a mime attribute.
   static bool ParseParamString(const std::string& param_string, Param* param);
 
-  MimeType() = default;
-  explicit MimeType(const std::string& content_type);
-
-  explicit operator bool() const { return !type_.empty(); }
+  static std::optional<MimeType> Create(const std::string& content_type);
 
   const std::string& type() const { return type_; }
   const std::string& subtype() const { return subtype_; }
@@ -112,6 +110,11 @@ class MimeType {
   // Use std::vector as the number of components are usually small and we'd like
   // to keep the order of components.
   typedef std::vector<Param> Params;
+
+  MimeType(std::string type,
+           std::string subtype,
+           std::vector<std::string> codecs,
+           Params params);
 
   std::string type_;
   std::string subtype_;

--- a/starboard/shared/starboard/media/mime_type.h
+++ b/starboard/shared/starboard/media/mime_type.h
@@ -109,7 +109,7 @@ class MimeType {
  private:
   // Use std::vector as the number of components are usually small and we'd like
   // to keep the order of components.
-  typedef std::vector<Param> Params;
+  using Params = std::vector<Param>;
 
   MimeType(std::string type,
            std::string subtype,

--- a/starboard/shared/starboard/media/mime_type.h
+++ b/starboard/shared/starboard/media/mime_type.h
@@ -116,10 +116,10 @@ class MimeType {
            std::vector<std::string> codecs,
            Params params);
 
-  std::string type_;
-  std::string subtype_;
-  std::vector<std::string> codecs_;
-  Params params_;
+  const std::string type_;
+  const std::string subtype_;
+  const std::vector<std::string> codecs_;
+  const Params params_;
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/media/mime_type.h
+++ b/starboard/shared/starboard/media/mime_type.h
@@ -67,9 +67,10 @@ class MimeType {
   // Expose the function as a helper function to parse a mime attribute.
   static bool ParseParamString(const std::string& param_string, Param* param);
 
+  MimeType() = default;
   explicit MimeType(const std::string& content_type);
 
-  bool is_valid() const { return is_valid_; }
+  explicit operator bool() const { return !type_.empty(); }
 
   const std::string& type() const { return type_; }
   const std::string& subtype() const { return subtype_; }
@@ -112,7 +113,6 @@ class MimeType {
   // to keep the order of components.
   typedef std::vector<Param> Params;
 
-  bool is_valid_ = false;
   std::string type_;
   std::string subtype_;
   std::vector<std::string> codecs_;

--- a/starboard/shared/starboard/media/mime_type_test.cc
+++ b/starboard/shared/starboard/media/mime_type_test.cc
@@ -20,311 +20,344 @@ namespace starboard {
 namespace {
 
 TEST(MimeTypeTest, EmptyString) {
-  MimeType mime_type("");
-  EXPECT_FALSE(mime_type.is_valid());
+  auto mime_type = MimeType::Create("");
+  EXPECT_FALSE(mime_type);
 }
 
 // Valid mime type must have a type/subtype without space in between.
 TEST(MimeTypeTest, InvalidMimeType) {
   {
-    MimeType mime_type("video");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video");
+    EXPECT_FALSE(mime_type);
   }
 
   {
-    MimeType mime_type("video/");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video/");
+    EXPECT_FALSE(mime_type);
   }
 
   {
-    MimeType mime_type("/mp4");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("/mp4");
+    EXPECT_FALSE(mime_type);
   }
 
   {
-    MimeType mime_type("video /mp4");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video /mp4");
+    EXPECT_FALSE(mime_type);
   }
 
   {
-    MimeType mime_type("video/ mp4");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video/ mp4");
+    EXPECT_FALSE(mime_type);
   }
 
   {
-    MimeType mime_type("video / mp4");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video / mp4");
+    EXPECT_FALSE(mime_type);
   }
 
   {  // "codecs" parameter isn't the first parameter.
-    MimeType mime_type("audio/mp4;param1=\" value1 \";codecs=\"abc, def\"");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type =
+        MimeType::Create("audio/mp4;param1=\" value1 \";codecs=\"abc, def\"");
+    EXPECT_FALSE(mime_type);
   }
 
   {  // More than one "codecs" parameters.
-    MimeType mime_type(
+    auto mime_type = MimeType::Create(
         "audio/mp4;codecs=\"abc, def\";"
         "param1=\" value1 \";codecs=\"abc, def\"");
-    EXPECT_FALSE(mime_type.is_valid());
+    EXPECT_FALSE(mime_type);
   }
   {
     // Parameter name must not be empty.
-    MimeType mime_type("video/mp4; =value");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video/mp4; =value");
+    EXPECT_FALSE(mime_type);
   }
   {
     // Parameter value must not be empty.
-    MimeType mime_type("video/mp4; name=");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video/mp4; name=");
+    EXPECT_FALSE(mime_type);
   }
   {
     // No '|' allowed.
-    MimeType mime_type("video/mp4; name=ab|c");
-    EXPECT_FALSE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video/mp4; name=ab|c");
+    EXPECT_FALSE(mime_type);
   }
 }
 
 TEST(MimeTypeTest, ValidContentTypeWithTypeAndSubtypeOnly) {
   {
-    MimeType mime_type("video/mp4");
-    EXPECT_TRUE(mime_type.is_valid());
-    EXPECT_EQ("video", mime_type.type());
-    EXPECT_EQ("mp4", mime_type.subtype());
+    auto mime_type = MimeType::Create("video/mp4");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ("video", mime_type->type());
+    EXPECT_EQ("mp4", mime_type->subtype());
   }
 
   {
-    MimeType mime_type("audio/mp4");
-    EXPECT_TRUE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("audio/mp4");
+    EXPECT_TRUE(mime_type);
   }
 
   {
-    MimeType mime_type("abc/xyz");
-    EXPECT_TRUE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("abc/xyz");
+    EXPECT_TRUE(mime_type);
   }
 }
 
 TEST(MimeTypeTest, TypeNotAtBeginning) {
-  MimeType mime_type("codecs=\"abc\"; audio/mp4");
-  EXPECT_FALSE(mime_type.is_valid());
+  auto mime_type = MimeType::Create("codecs=\"abc\"; audio/mp4");
+  EXPECT_FALSE(mime_type);
 }
 
 TEST(MimeTypeTest, ValidContentTypeWithParams) {
   {
-    MimeType mime_type("video/mp4; name=123");
-    EXPECT_TRUE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("video/mp4; name=123");
+    EXPECT_TRUE(mime_type);
   }
 
   {
-    MimeType mime_type("audio/mp4;codecs=\"abc\"");
-    EXPECT_TRUE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("audio/mp4;codecs=\"abc\"");
+    EXPECT_TRUE(mime_type);
   }
 
   {
-    MimeType mime_type("  audio/mp4  ;  codecs   =  \"abc\"  ");
-    EXPECT_TRUE(mime_type.is_valid());
+    auto mime_type = MimeType::Create("  audio/mp4  ;  codecs   =  \"abc\"  ");
+    EXPECT_TRUE(mime_type);
   }
 }
 
 TEST(MimeTypeTest, GetCodecs) {
   {
-    MimeType mime_type("audio/mp4;codecs=\"abc\"");
-    EXPECT_EQ(1U, mime_type.GetCodecs().size());
-    EXPECT_EQ("abc", mime_type.GetCodecs()[0]);
+    auto mime_type = MimeType::Create("audio/mp4;codecs=\"abc\"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(1U, mime_type->GetCodecs().size());
+    EXPECT_EQ("abc", mime_type->GetCodecs()[0]);
   }
 
   {
-    MimeType mime_type("audio/mp4;codecs=\"abc, def\"");
-    EXPECT_EQ(2U, mime_type.GetCodecs().size());
-    EXPECT_EQ("abc", mime_type.GetCodecs()[0]);
-    EXPECT_EQ("def", mime_type.GetCodecs()[1]);
+    auto mime_type = MimeType::Create("audio/mp4;codecs=\"abc, def\"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(2U, mime_type->GetCodecs().size());
+    EXPECT_EQ("abc", mime_type->GetCodecs()[0]);
+    EXPECT_EQ("def", mime_type->GetCodecs()[1]);
   }
 
   {
-    MimeType mime_type("audio/mp4;codecs=\"abc, def\";param1=\" value1 \"");
-    EXPECT_EQ(2U, mime_type.GetCodecs().size());
+    auto mime_type =
+        MimeType::Create("audio/mp4;codecs=\"abc, def\";param1=\" value1 \"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(2U, mime_type->GetCodecs().size());
   }
 }
 
 TEST(MimeTypeTest, ParamCount) {
   {
-    MimeType mime_type("video/mp4");
-    EXPECT_EQ(0, mime_type.GetParamCount());
+    auto mime_type = MimeType::Create("video/mp4");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(0, mime_type->GetParamCount());
   }
 
   {
-    MimeType mime_type("video/mp4; width=1920");
-    EXPECT_EQ(1, mime_type.GetParamCount());
+    auto mime_type = MimeType::Create("video/mp4; width=1920");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(1, mime_type->GetParamCount());
   }
 
   {
-    MimeType mime_type("video/mp4; width=1920; height=1080");
-    EXPECT_EQ(2, mime_type.GetParamCount());
+    auto mime_type = MimeType::Create("video/mp4; width=1920; height=1080");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(2, mime_type->GetParamCount());
   }
 }
 
 TEST(MimeTypeTest, GetParamType) {
   {
-    MimeType mime_type(
+    auto mime_type = MimeType::Create(
         "video/mp4; name0=123; name1=1.2; name2=xyz; name3=true; name4=false");
-    EXPECT_EQ(MimeType::kParamTypeInteger, mime_type.GetParamType(0));
-    EXPECT_EQ(MimeType::kParamTypeFloat, mime_type.GetParamType(1));
-    EXPECT_EQ(MimeType::kParamTypeString, mime_type.GetParamType(2));
-    EXPECT_EQ(MimeType::kParamTypeBoolean, mime_type.GetParamType(3));
-    EXPECT_EQ(MimeType::kParamTypeBoolean, mime_type.GetParamType(4));
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(MimeType::kParamTypeInteger, mime_type->GetParamType(0));
+    EXPECT_EQ(MimeType::kParamTypeFloat, mime_type->GetParamType(1));
+    EXPECT_EQ(MimeType::kParamTypeString, mime_type->GetParamType(2));
+    EXPECT_EQ(MimeType::kParamTypeBoolean, mime_type->GetParamType(3));
+    EXPECT_EQ(MimeType::kParamTypeBoolean, mime_type->GetParamType(4));
   }
 
   {
-    MimeType mime_type("video/mp4; name0=\"123\"; name1=\"abc\"");
-    EXPECT_EQ(MimeType::kParamTypeString, mime_type.GetParamType(0));
-    EXPECT_EQ(MimeType::kParamTypeString, mime_type.GetParamType(1));
+    auto mime_type =
+        MimeType::Create("video/mp4; name0=\"123\"; name1=\"abc\"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(MimeType::kParamTypeString, mime_type->GetParamType(0));
+    EXPECT_EQ(MimeType::kParamTypeString, mime_type->GetParamType(1));
   }
 
   {
-    MimeType mime_type("video/mp4; name1=\" abc \"");
-    EXPECT_EQ(MimeType::kParamTypeString, mime_type.GetParamType(0));
+    auto mime_type = MimeType::Create("video/mp4; name1=\" abc \"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(MimeType::kParamTypeString, mime_type->GetParamType(0));
   }
 }
 
 TEST(MimeTypeTest, GetParamName) {
   {
-    MimeType mime_type("video/mp4; name0=123; name1=1.2; name2=xyz");
-    EXPECT_EQ("name0", mime_type.GetParamName(0));
-    EXPECT_EQ("name1", mime_type.GetParamName(1));
-    EXPECT_EQ("name2", mime_type.GetParamName(2));
+    auto mime_type =
+        MimeType::Create("video/mp4; name0=123; name1=1.2; name2=xyz");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ("name0", mime_type->GetParamName(0));
+    EXPECT_EQ("name1", mime_type->GetParamName(1));
+    EXPECT_EQ("name2", mime_type->GetParamName(2));
   }
 }
 
 TEST(MimeTypeTest, GetParamIntValueWithIndex) {
   {
-    MimeType mime_type("video/mp4; name=123");
-    EXPECT_EQ(123, mime_type.GetParamIntValue(0));
+    auto mime_type = MimeType::Create("video/mp4; name=123");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(123, mime_type->GetParamIntValue(0));
   }
 
   {
-    MimeType mime_type("video/mp4; width=1920; height=1080");
-    EXPECT_EQ(1920, mime_type.GetParamIntValue(0));
-    EXPECT_EQ(1080, mime_type.GetParamIntValue(1));
+    auto mime_type = MimeType::Create("video/mp4; width=1920; height=1080");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(1920, mime_type->GetParamIntValue(0));
+    EXPECT_EQ(1080, mime_type->GetParamIntValue(1));
   }
 
   {
-    MimeType mime_type("audio/mp4; channels=6");
-    EXPECT_EQ(6, mime_type.GetParamIntValue(0));
+    auto mime_type = MimeType::Create("audio/mp4; channels=6");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(6, mime_type->GetParamIntValue(0));
   }
 }
 
 TEST(MimeTypeTest, GetParamFloatValueWithIndex) {
-  MimeType mime_type("video/mp4; name0=123; name1=123.4");
-  EXPECT_FLOAT_EQ(123.f, mime_type.GetParamFloatValue(0));
-  EXPECT_FLOAT_EQ(123.4f, mime_type.GetParamFloatValue(1));
+  auto mime_type = MimeType::Create("video/mp4; name0=123; name1=123.4");
+  ASSERT_TRUE(mime_type);
+  EXPECT_FLOAT_EQ(123.f, mime_type->GetParamFloatValue(0));
+  EXPECT_FLOAT_EQ(123.4f, mime_type->GetParamFloatValue(1));
 }
 
 TEST(MimeTypeTest, GetParamStringValueWithIndex) {
   {
-    MimeType mime_type("video/mp4; name0=123; name1=abc; name2=\"xyz\"");
-    EXPECT_EQ("123", mime_type.GetParamStringValue(0));
-    EXPECT_EQ("abc", mime_type.GetParamStringValue(1));
-    EXPECT_EQ("xyz", mime_type.GetParamStringValue(2));
+    auto mime_type =
+        MimeType::Create("video/mp4; name0=123; name1=abc; name2=\"xyz\"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ("123", mime_type->GetParamStringValue(0));
+    EXPECT_EQ("abc", mime_type->GetParamStringValue(1));
+    EXPECT_EQ("xyz", mime_type->GetParamStringValue(2));
   }
 
   {
-    MimeType mime_type("video/mp4; name=\" xyz  \"");
-    EXPECT_EQ(" xyz  ", mime_type.GetParamStringValue(0));
+    auto mime_type = MimeType::Create("video/mp4; name=\" xyz  \"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(" xyz  ", mime_type->GetParamStringValue(0));
   }
 }
 
 TEST(MimeTypeTest, GetParamBoolValueWithIndex) {
-  MimeType mime_type("video/mp4; name0=true; name1=false");
-  EXPECT_TRUE(mime_type.GetParamBoolValue(0));
-  EXPECT_FALSE(mime_type.GetParamBoolValue(1));
+  auto mime_type = MimeType::Create("video/mp4; name0=true; name1=false");
+  ASSERT_TRUE(mime_type);
+  EXPECT_TRUE(mime_type->GetParamBoolValue(0));
+  EXPECT_FALSE(mime_type->GetParamBoolValue(1));
 }
 
 TEST(MimeTypeTest, GetParamValueInInvalidType) {
-  MimeType mime_type("video/mp4; name0=abc; name1=123.4");
-  EXPECT_FLOAT_EQ(0, mime_type.GetParamIntValue(0));
-  EXPECT_FLOAT_EQ(0.f, mime_type.GetParamFloatValue(0));
-  EXPECT_FLOAT_EQ(0, mime_type.GetParamIntValue(1));
+  auto mime_type = MimeType::Create("video/mp4; name0=abc; name1=123.4");
+  ASSERT_TRUE(mime_type);
+  EXPECT_FLOAT_EQ(0, mime_type->GetParamIntValue(0));
+  EXPECT_FLOAT_EQ(0.f, mime_type->GetParamFloatValue(0));
+  EXPECT_FLOAT_EQ(0, mime_type->GetParamIntValue(1));
 }
 
 TEST(MimeTypeTest, GetParamIntValueWithName) {
   {
-    MimeType mime_type("video/mp4; name=123");
-    EXPECT_EQ(123, mime_type.GetParamIntValue("name", 0));
-    EXPECT_EQ(6, mime_type.GetParamIntValue("channels", 6));
+    auto mime_type = MimeType::Create("video/mp4; name=123");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(123, mime_type->GetParamIntValue("name", 0));
+    EXPECT_EQ(6, mime_type->GetParamIntValue("channels", 6));
   }
 
   {
-    MimeType mime_type("video/mp4; width=1920; height=1080");
-    EXPECT_EQ(1920, mime_type.GetParamIntValue("width", 0));
-    EXPECT_EQ(1080, mime_type.GetParamIntValue("height", 0));
+    auto mime_type = MimeType::Create("video/mp4; width=1920; height=1080");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(1920, mime_type->GetParamIntValue("width", 0));
+    EXPECT_EQ(1080, mime_type->GetParamIntValue("height", 0));
   }
 
   {
-    MimeType mime_type("audio/mp4; channels=6");
-    EXPECT_EQ(6, mime_type.GetParamIntValue("channels", 0));
+    auto mime_type = MimeType::Create("audio/mp4; channels=6");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(6, mime_type->GetParamIntValue("channels", 0));
   }
 }
 
 TEST(MimeTypeTest, GetParamFloatValueWithName) {
   {
-    MimeType mime_type("video/mp4; name0=123; name1=123.4");
-    EXPECT_FLOAT_EQ(123.f, mime_type.GetParamFloatValue("name0", 0.f));
-    EXPECT_FLOAT_EQ(123.4f, mime_type.GetParamFloatValue("name1", 0.f));
-    EXPECT_FLOAT_EQ(59.96f, mime_type.GetParamFloatValue("framerate", 59.96f));
+    auto mime_type = MimeType::Create("video/mp4; name0=123; name1=123.4");
+    ASSERT_TRUE(mime_type);
+    EXPECT_FLOAT_EQ(123.f, mime_type->GetParamFloatValue("name0", 0.f));
+    EXPECT_FLOAT_EQ(123.4f, mime_type->GetParamFloatValue("name1", 0.f));
+    EXPECT_FLOAT_EQ(59.96f, mime_type->GetParamFloatValue("framerate", 59.96f));
   }
 }
 
 TEST(MimeTypeTest, GetParamStringValueWithName) {
   {
-    MimeType mime_type("video/mp4; name0=123; name1=abc; name2=\"xyz\"");
-    EXPECT_EQ("123", mime_type.GetParamStringValue("name0", ""));
-    EXPECT_EQ("abc", mime_type.GetParamStringValue("name1", ""));
-    EXPECT_EQ("xyz", mime_type.GetParamStringValue("name2", ""));
-    EXPECT_EQ("h263", mime_type.GetParamStringValue("codecs", "h263"));
+    auto mime_type =
+        MimeType::Create("video/mp4; name0=123; name1=abc; name2=\"xyz\"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ("123", mime_type->GetParamStringValue("name0", ""));
+    EXPECT_EQ("abc", mime_type->GetParamStringValue("name1", ""));
+    EXPECT_EQ("xyz", mime_type->GetParamStringValue("name2", ""));
+    EXPECT_EQ("h263", mime_type->GetParamStringValue("codecs", "h263"));
   }
 
   {
-    MimeType mime_type("video/mp4; name=\" xyz  \"");
-    EXPECT_EQ(" xyz  ", mime_type.GetParamStringValue("name", ""));
+    auto mime_type = MimeType::Create("video/mp4; name=\" xyz  \"");
+    ASSERT_TRUE(mime_type);
+    EXPECT_EQ(" xyz  ", mime_type->GetParamStringValue("name", ""));
   }
 }
 
 TEST(MimeTypeTest, GetParamBooleanValueWithName) {
-  MimeType mime_type("video/mp4; name0=true; name1=false; name2=trues");
-  EXPECT_TRUE(mime_type.GetParamBoolValue("name0", false));
-  EXPECT_FALSE(mime_type.GetParamBoolValue("name1", true));
+  auto mime_type =
+      MimeType::Create("video/mp4; name0=true; name1=false; name2=trues");
+  ASSERT_TRUE(mime_type);
+  EXPECT_TRUE(mime_type->GetParamBoolValue("name0", false));
+  EXPECT_FALSE(mime_type->GetParamBoolValue("name1", true));
   // Default value
-  EXPECT_FALSE(mime_type.GetParamBoolValue("name2", false));
+  EXPECT_FALSE(mime_type->GetParamBoolValue("name2", false));
 }
 
 TEST(MimeTypeTest, ReadParamOfDifferentTypes) {
   // Ensure that the parameter type is enforced correctly.
-  MimeType mime_type("video/mp4; string=value; int=1; float=1.0; bool=true");
-  ASSERT_TRUE(mime_type.is_valid());
+  auto mime_type =
+      MimeType::Create("video/mp4; string=value; int=1; float=1.0; bool=true");
+  ASSERT_TRUE(mime_type);
   // Read params as their original types.
-  EXPECT_EQ(mime_type.GetParamStringValue("string", ""), "value");
-  EXPECT_EQ(mime_type.GetParamIntValue("int", 0), 1);
-  EXPECT_EQ(mime_type.GetParamFloatValue("float", 0.0), 1.0);
-  EXPECT_EQ(mime_type.GetParamBoolValue("bool", false), true);
+  EXPECT_EQ(mime_type->GetParamStringValue("string", ""), "value");
+  EXPECT_EQ(mime_type->GetParamIntValue("int", 0), 1);
+  EXPECT_EQ(mime_type->GetParamFloatValue("float", 0.0), 1.0);
+  EXPECT_EQ(mime_type->GetParamBoolValue("bool", false), true);
   // All param types can be read as strings.
-  EXPECT_EQ(mime_type.GetParamStringValue("int", ""), "1");
-  EXPECT_EQ(mime_type.GetParamStringValue("float", ""), "1.0");
-  EXPECT_EQ(mime_type.GetParamStringValue("bool", ""), "true");
+  EXPECT_EQ(mime_type->GetParamStringValue("int", ""), "1");
+  EXPECT_EQ(mime_type->GetParamStringValue("float", ""), "1.0");
+  EXPECT_EQ(mime_type->GetParamStringValue("bool", ""), "true");
   // Int can also be read as float.
-  EXPECT_EQ(mime_type.GetParamFloatValue("int", 0.0), 1.0);
+  EXPECT_EQ(mime_type->GetParamFloatValue("int", 0.0), 1.0);
 
   // Test failing validation for ints,
-  EXPECT_EQ(mime_type.GetParamIntValue("string", 0), 0);
-  EXPECT_EQ(mime_type.GetParamIntValue("float", 0), 0);
-  EXPECT_EQ(mime_type.GetParamIntValue("bool", 0), 0);
+  EXPECT_EQ(mime_type->GetParamIntValue("string", 0), 0);
+  EXPECT_EQ(mime_type->GetParamIntValue("float", 0), 0);
+  EXPECT_EQ(mime_type->GetParamIntValue("bool", 0), 0);
 
   // floats,
-  EXPECT_EQ(mime_type.GetParamFloatValue("string", 0.0), 0.0);
-  EXPECT_EQ(mime_type.GetParamFloatValue("bool", 0.0), 0.0);
+  EXPECT_EQ(mime_type->GetParamFloatValue("string", 0.0), 0.0);
+  EXPECT_EQ(mime_type->GetParamFloatValue("bool", 0.0), 0.0);
 
   // and bools.
-  EXPECT_FALSE(mime_type.GetParamBoolValue("string", false));
-  EXPECT_FALSE(mime_type.GetParamBoolValue("int", false));
-  EXPECT_FALSE(mime_type.GetParamBoolValue("float", false));
+  EXPECT_FALSE(mime_type->GetParamBoolValue("string", false));
+  EXPECT_FALSE(mime_type->GetParamBoolValue("int", false));
+  EXPECT_FALSE(mime_type->GetParamBoolValue("float", false));
 }
 
 TEST(MimeTypeTest, ParseInvalidParamString) {
@@ -395,48 +428,52 @@ TEST(MimeTypeTest, ParseValidParamString) {
 }
 
 TEST(MimeTypeTest, ValidateParamsWithPatterns) {
-  MimeType mime_type("video/mp4; string=yes");
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", "yes"));
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", "yes|no"));
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", "no|yes|no"));
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", "no|no|yes"));
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", "noyes|yes"));
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string", "no"));
+  auto mime_type = MimeType::Create("video/mp4; string=yes");
+  ASSERT_TRUE(mime_type);
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", "yes"));
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", "yes|no"));
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", "no|yes|no"));
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", "no|no|yes"));
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", "noyes|yes"));
+  EXPECT_FALSE(mime_type->ValidateStringParameter("string", "no"));
 }
 
 TEST(MimeTypeTest, ValidateParamsWithShortPatterns) {
-  MimeType mime_type("video/mp4; string=y");
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", "y"));
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", "y|n"));
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", "n|y"));
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string", "n"));
+  auto mime_type = MimeType::Create("video/mp4; string=y");
+  ASSERT_TRUE(mime_type);
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", "y"));
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", "y|n"));
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", "n|y"));
+  EXPECT_FALSE(mime_type->ValidateStringParameter("string", "n"));
 }
 
 TEST(MimeTypeTest, ValidateParamsWithPartialMatches) {
-  MimeType mime_type("video/mp4; string=yes");
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string", "yesno|no"));
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string", "noyes|no"));
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string", "no|yesno"));
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string", "no|noyes"));
+  auto mime_type = MimeType::Create("video/mp4; string=yes");
+  ASSERT_TRUE(mime_type);
+  EXPECT_FALSE(mime_type->ValidateStringParameter("string", "yesno|no"));
+  EXPECT_FALSE(mime_type->ValidateStringParameter("string", "noyes|no"));
+  EXPECT_FALSE(mime_type->ValidateStringParameter("string", "no|yesno"));
+  EXPECT_FALSE(mime_type->ValidateStringParameter("string", "no|noyes"));
 }
 
 TEST(MimeTypeTest, ValidateMissingParam) {
-  MimeType mime_type("video/mp4");
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string"));
-  EXPECT_EQ(mime_type.GetParamStringValue("string", "default"), "default");
+  auto mime_type = MimeType::Create("video/mp4");
+  ASSERT_TRUE(mime_type);
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string"));
+  EXPECT_EQ(mime_type->GetParamStringValue("string", "default"), "default");
 }
 
 TEST(MimeTypeTest, ValidateParamsWithEmptyishPattern) {
-  MimeType mime_type("video/mp4; string=yes");
-  EXPECT_TRUE(mime_type.ValidateStringParameter("string", ""));
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string", "|"));
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string", "||"));
+  auto mime_type = MimeType::Create("video/mp4; string=yes");
+  ASSERT_TRUE(mime_type);
+  EXPECT_TRUE(mime_type->ValidateStringParameter("string", ""));
+  EXPECT_FALSE(mime_type->ValidateStringParameter("string", "|"));
+  EXPECT_FALSE(mime_type->ValidateStringParameter("string", "||"));
 }
 
 TEST(MimeTypeTest, ValidateParamWithInvalidMimeType) {
-  MimeType mime_type("video/mp4; string=");
-  ASSERT_FALSE(mime_type.is_valid());
-  EXPECT_FALSE(mime_type.ValidateStringParameter("string"));
+  auto mime_type = MimeType::Create("video/mp4; string=");
+  ASSERT_FALSE(mime_type);
 }
 
 }  // namespace

--- a/starboard/shared/starboard/media/mime_util.cc
+++ b/starboard/shared/starboard/media/mime_util.cc
@@ -189,12 +189,12 @@ SbMediaSupportType CanPlayMimeAndKeySystem(const char* mime,
   // Get cached ParsedMimeInfo with its supportability. If it is not found in
   // the cache, MimeSupportabilityCache would parse the mime string and return
   // the ParsedMimeInfo with kSupportabilityUnknown.
-  ParsedMimeInfo mime_info;
-  Supportability mime_supportability =
-      MimeSupportabilityCache::GetInstance()->GetMimeSupportability(mime,
-                                                                    &mime_info);
+  auto result =
+      MimeSupportabilityCache::GetInstance()->GetMimeSupportability(mime);
+  Supportability mime_supportability = result.supportability;
+  const std::optional<ParsedMimeInfo>& mime_info = result.mime_info;
 
-  if (mime_info.disable_cache()) {
+  if (mime_info && mime_info->disable_cache()) {
     // Disable all caches if required.
     mime_supportability = kSupportabilityUnknown;
     MimeSupportabilityCache::GetInstance()->SetCacheEnabled(false);
@@ -211,7 +211,7 @@ SbMediaSupportType CanPlayMimeAndKeySystem(const char* mime,
   // must be valid here.
   SB_DCHECK(mime_info);
 
-  const MimeType& mime_type = mime_info.mime_type();
+  const MimeType& mime_type = mime_info->mime_type();
   const std::vector<std::string>& codecs = mime_type.GetCodecs();
 
   // Quick check for mp4 format.
@@ -227,40 +227,40 @@ SbMediaSupportType CanPlayMimeAndKeySystem(const char* mime,
   }
 
   // Reject mime if it doesn't have any valid codec info.
-  if (!mime_info.has_audio_info() && !mime_info.has_video_info()) {
+  if (!mime_info->has_audio_info() && !mime_info->has_video_info()) {
     return kSbMediaSupportTypeNotSupported;
   }
 
   // Get cached key system supportability. Note that we check if audio or video
   // codec supports key system separately.
-  if (mime_info.has_audio_info()) {
+  if (mime_info->has_audio_info()) {
     Supportability key_system_supportability =
         KeySystemSupportabilityCache::GetInstance()->GetKeySystemSupportability(
-            mime_info.audio_info().codec, key_system);
+            mime_info->audio_info().codec, key_system);
     if (key_system_supportability == kSupportabilityUnknown) {
       key_system_supportability =
-          IsSupportedKeySystem(mime_info.audio_info().codec, key_system)
+          IsSupportedKeySystem(mime_info->audio_info().codec, key_system)
               ? kSupportabilitySupported
               : kSupportabilityNotSupported;
       KeySystemSupportabilityCache::GetInstance()->CacheKeySystemSupportability(
-          mime_info.audio_info().codec, key_system, key_system_supportability);
+          mime_info->audio_info().codec, key_system, key_system_supportability);
     }
     // Reject mime if audio codec doesn't support the key system.
     if (key_system_supportability == kSupportabilityNotSupported) {
       return kSbMediaSupportTypeNotSupported;
     }
   }
-  if (mime_info.has_video_info()) {
+  if (mime_info->has_video_info()) {
     Supportability key_system_supportability =
         KeySystemSupportabilityCache::GetInstance()->GetKeySystemSupportability(
-            mime_info.video_info().codec, key_system);
+            mime_info->video_info().codec, key_system);
     if (key_system_supportability == kSupportabilityUnknown) {
       key_system_supportability =
-          IsSupportedKeySystem(mime_info.video_info().codec, key_system)
+          IsSupportedKeySystem(mime_info->video_info().codec, key_system)
               ? kSupportabilitySupported
               : kSupportabilityNotSupported;
       KeySystemSupportabilityCache::GetInstance()->CacheKeySystemSupportability(
-          mime_info.video_info().codec, key_system, key_system_supportability);
+          mime_info->video_info().codec, key_system, key_system_supportability);
     }
     // Reject mime if video codec doesn't the key system.
     if (key_system_supportability == kSupportabilityNotSupported) {
@@ -276,9 +276,10 @@ SbMediaSupportType CanPlayMimeAndKeySystem(const char* mime,
   SB_DCHECK_EQ(mime_supportability, kSupportabilityUnknown);
 
   // Call platform functions to check if it's supported.
-  if (mime_info.has_audio_info() && !IsSupportedAudioCodec(mime_info)) {
+  if (mime_info->has_audio_info() && !IsSupportedAudioCodec(*mime_info)) {
     mime_supportability = kSupportabilityNotSupported;
-  } else if (mime_info.has_video_info() && !IsSupportedVideoCodec(mime_info)) {
+  } else if (mime_info->has_video_info() &&
+             !IsSupportedVideoCodec(*mime_info)) {
     mime_supportability = kSupportabilityNotSupported;
   } else {
     mime_supportability = kSupportabilitySupported;

--- a/starboard/shared/starboard/media/mime_util.cc
+++ b/starboard/shared/starboard/media/mime_util.cc
@@ -70,8 +70,6 @@ bool IsSupportedKeySystem(SbMediaVideoCodec codec, const char* key_system) {
 }
 
 bool IsSupportedAudioCodec(const ParsedMimeInfo& mime_info) {
-  SB_DCHECK(mime_info.is_valid());
-  SB_DCHECK(mime_info.mime_type().is_valid());
   SB_DCHECK(mime_info.has_audio_info());
 
   const MimeType& mime_type = mime_info.mime_type();
@@ -126,8 +124,6 @@ bool IsSupportedAudioCodec(const ParsedMimeInfo& mime_info) {
 }
 
 bool IsSupportedVideoCodec(const ParsedMimeInfo& mime_info) {
-  SB_DCHECK(mime_info.is_valid());
-  SB_DCHECK(mime_info.mime_type().is_valid());
   SB_DCHECK(mime_info.has_video_info());
 
   const MimeType& mime_type = mime_info.mime_type();
@@ -213,7 +209,7 @@ SbMediaSupportType CanPlayMimeAndKeySystem(const char* mime,
   // MimeSupportabilityCache::GetMimeSupportability() returns
   // kSupportabilityNotSupported if ParsedMimeInfo is not valid, so |mime_info|
   // must be valid here.
-  SB_DCHECK(mime_info.is_valid());
+  SB_DCHECK(mime_info);
 
   const MimeType& mime_type = mime_info.mime_type();
   const std::vector<std::string>& codecs = mime_type.GetCodecs();

--- a/starboard/shared/starboard/media/mime_util_test.cc
+++ b/starboard/shared/starboard/media/mime_util_test.cc
@@ -29,19 +29,21 @@ constexpr int64_t kBitrate = 44100;
 TEST(MimeUtilTest, ChecksSupportedMp3Containers) {
   const std::string valid_mp3_mime_str_1 =
       "audio/mpeg; codecs=\"mp3\"; bitrate=44100";
-  const MimeType valid_mp3_mime_1(valid_mp3_mime_str_1);
+  auto valid_mp3_mime_1 = MimeType::Create(valid_mp3_mime_str_1);
+  ASSERT_TRUE(valid_mp3_mime_1);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_mp3_mime_str_1.c_str(), kEmptyKeySystem),
-      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_mp3_mime_1, kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &*valid_mp3_mime_1, kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 
   const std::string valid_mp3_mime_str_2 =
       "audio/mp3; codecs=\"mp3\"; bitrate=44100";
-  const MimeType valid_mp3_mime_2(valid_mp3_mime_str_2);
+  auto valid_mp3_mime_2 = MimeType::Create(valid_mp3_mime_str_2);
+  ASSERT_TRUE(valid_mp3_mime_2);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_mp3_mime_str_2.c_str(), kEmptyKeySystem),
-      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_mp3_mime_2, kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &*valid_mp3_mime_2, kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 }
@@ -50,7 +52,8 @@ TEST(MimeUtilTest, ChecksUnsupportedMp3Containers) {
   // Invalid container for MP3 codec.
   const std::string invalid_mp3_mime_str =
       "audio/mp4; codecs=\"mp3\"; bitrate=44100";
-  const MimeType invalid_mp3_mime(invalid_mp3_mime_str);
+  auto invalid_mp3_mime = MimeType::Create(invalid_mp3_mime_str);
+  ASSERT_TRUE(invalid_mp3_mime);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(invalid_mp3_mime_str.c_str(), kEmptyKeySystem),
       kSbMediaSupportTypeNotSupported);
@@ -59,19 +62,23 @@ TEST(MimeUtilTest, ChecksUnsupportedMp3Containers) {
 TEST(MimeUtilTest, ChecksSupportedFlacContainers) {
   const std::string valid_flac_mime_str_1 =
       "audio/ogg; codecs=\"flac\"; bitrate=44100";
-  const MimeType valid_flac_mime_1(valid_flac_mime_str_1);
+  auto valid_flac_mime_1 = MimeType::Create(valid_flac_mime_str_1);
+  ASSERT_TRUE(valid_flac_mime_1);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_flac_mime_str_1.c_str(), kEmptyKeySystem),
-      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_flac_mime_1, kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &*valid_flac_mime_1,
+                            kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 
   const std::string valid_flac_mime_str_2 =
       "audio/flac; codecs=\"flac\"; bitrate=44100";
-  const MimeType valid_flac_mime_2(valid_flac_mime_str_2);
+  auto valid_flac_mime_2 = MimeType::Create(valid_flac_mime_str_2);
+  ASSERT_TRUE(valid_flac_mime_2);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_flac_mime_str_2.c_str(), kEmptyKeySystem),
-      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &valid_flac_mime_2, kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecMp3, &*valid_flac_mime_2,
+                            kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 }
@@ -80,7 +87,8 @@ TEST(MimeUtilTest, ChecksUnsupportedFlacContainers) {
   // Invalid container for FLAC codec.
   const std::string invalid_flac_mime_str =
       "audio/mp4; codecs=\"flac\"; bitrate=44100";
-  const MimeType invalid_flac_mime(invalid_flac_mime_str);
+  auto invalid_flac_mime = MimeType::Create(invalid_flac_mime_str);
+  ASSERT_TRUE(invalid_flac_mime);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(invalid_flac_mime_str.c_str(), kEmptyKeySystem),
       kSbMediaSupportTypeNotSupported);
@@ -89,10 +97,11 @@ TEST(MimeUtilTest, ChecksUnsupportedFlacContainers) {
 TEST(MimeUtilTest, ChecksSupportedPcmContainers) {
   const std::string valid_pcm_mime_str =
       "audio/wav; codecs=\"1\"; bitrate=44100";
-  const MimeType valid_pcm_mime(valid_pcm_mime_str);
+  auto valid_pcm_mime = MimeType::Create(valid_pcm_mime_str);
+  ASSERT_TRUE(valid_pcm_mime);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(valid_pcm_mime_str.c_str(), kEmptyKeySystem),
-      MediaIsAudioSupported(kSbMediaAudioCodecPcm, &valid_pcm_mime, kBitrate)
+      MediaIsAudioSupported(kSbMediaAudioCodecPcm, &*valid_pcm_mime, kBitrate)
           ? kSbMediaSupportTypeProbably
           : kSbMediaSupportTypeNotSupported);
 }
@@ -100,7 +109,8 @@ TEST(MimeUtilTest, ChecksSupportedPcmContainers) {
 TEST(MimeUtilTest, ChecksUnsupportedWavCodecs) {
   const std::string invalid_wav_mime_str =
       "audio/wav; codecs=\"aac\"; bitrate=44100";
-  const MimeType invalid_wav_mime(invalid_wav_mime_str);
+  auto invalid_wav_mime = MimeType::Create(invalid_wav_mime_str);
+  ASSERT_TRUE(invalid_wav_mime);
   EXPECT_EQ(
       CanPlayMimeAndKeySystem(invalid_wav_mime_str.c_str(), kEmptyKeySystem),
       kSbMediaSupportTypeNotSupported);

--- a/starboard/shared/starboard/media/parsed_mime_info.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info.cc
@@ -15,10 +15,12 @@
 #include "starboard/shared/starboard/media/parsed_mime_info.h"
 
 #include <cmath>
+#include <ostream>
 #include <string>
 
 #include "starboard/common/log.h"
 #include "starboard/common/media.h"
+#include "starboard/common/string.h"
 #include "starboard/shared/starboard/media/codec_util.h"
 
 namespace starboard {
@@ -185,6 +187,29 @@ ParsedMimeInfo ParsedMimeInfo::WithBitrate(int bitrate) const {
   video_info.bitrate = bitrate;
 
   return ParsedMimeInfo(mime_type_, disable_cache_, audio_info, video_info);
+}
+
+std::ostream& operator<<(std::ostream& os, const ParsedMimeInfo& mime_info) {
+  os << "ParsedMimeInfo={mime_type=" << mime_info.mime_type();
+  if (mime_info.has_audio_info()) {
+    const auto& audio = mime_info.audio_info();
+    os << ", audio_info={codec=" << GetMediaAudioCodecName(audio.codec)
+       << ", channels=" << audio.channels << "}";
+  }
+  if (mime_info.has_video_info()) {
+    const auto& video = mime_info.video_info();
+    os << ", video_info={codec=" << GetMediaVideoCodecName(video.codec)
+       << ", profile=" << video.profile << ", level=" << video.level
+       << ", bit_depth=" << video.bit_depth
+       << ", primary_id=" << GetMediaPrimaryIdName(video.primary_id)
+       << ", transfer_id=" << GetMediaTransferIdName(video.transfer_id)
+       << ", matrix_id=" << GetMediaMatrixIdName(video.matrix_id)
+       << ", width=" << video.frame_width << ", height=" << video.frame_height
+       << ", fps=" << video.fps << ", decode_to_texture_required="
+       << ToString(video.decode_to_texture_required) << "}";
+  }
+  os << "}";
+  return os;
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/media/parsed_mime_info.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info.cc
@@ -29,10 +29,6 @@ namespace {
 
 const int64_t kDefaultAudioChannels = 2;
 
-// Turns |eotf| into value of SbMediaTransferId.  If |eotf| isn't recognized the
-// function returns kSbMediaTransferIdUnknown.
-// This function supports all eotfs required by YouTube TV HTML5 Technical
-// Requirements.
 SbMediaTransferId GetTransferIdFromString(const std::string& transfer_id) {
   if (transfer_id == "bt709") {
     return kSbMediaTransferIdBt709;
@@ -43,6 +39,82 @@ SbMediaTransferId GetTransferIdFromString(const std::string& transfer_id) {
   }
   return kSbMediaTransferIdUnknown;
 }
+
+bool ParseAudioInfo(const MimeType& mime_type,
+                    const std::string& codec,
+                    ParsedMimeInfo::AudioCodecInfo* audio_info);
+
+bool ParseVideoInfo(const MimeType& mime_type,
+                    const std::string& codec,
+                    ParsedMimeInfo::VideoCodecInfo* video_info);
+
+}  // namespace
+
+// static
+std::optional<ParsedMimeInfo> ParsedMimeInfo::Create(
+    const std::string& mime_string) {
+  auto mime_type = MimeType::Create(mime_string);
+  if (!mime_type) {
+    return std::nullopt;
+  }
+
+  // Read "disablecache".
+  if (!mime_type->ValidateBoolParameter("disablecache")) {
+    return std::nullopt;
+  }
+  bool disable_cache = mime_type->GetParamBoolValue("disablecache", false);
+
+  // We only support audio or video type.
+  if (mime_type->type() != "audio" && mime_type->type() != "video") {
+    return std::nullopt;
+  }
+
+  auto codecs = mime_type->GetCodecs();
+  // We only support up to one audio codec and one video codec.
+  if (codecs.size() > 2) {
+    return std::nullopt;
+  }
+
+  AudioCodecInfo audio_info;
+  VideoCodecInfo video_info;
+
+  for (const auto& codec : codecs) {
+    if (audio_info.codec == kSbMediaAudioCodecNone &&
+        ParseAudioInfo(*mime_type, codec, &audio_info)) {
+      continue;
+    }
+    if (video_info.codec == kSbMediaVideoCodecNone &&
+        ParseVideoInfo(*mime_type, codec, &video_info)) {
+      continue;
+    }
+    // It either has an invalid codec or has two codecs of same type.
+    return std::nullopt;
+  }
+
+  return ParsedMimeInfo(std::move(*mime_type), disable_cache, audio_info,
+                        video_info);
+}
+
+ParsedMimeInfo::ParsedMimeInfo(MimeType mime_type,
+                               bool disable_cache,
+                               AudioCodecInfo audio_info,
+                               VideoCodecInfo video_info)
+    : mime_type_(std::move(mime_type)),
+      disable_cache_(disable_cache),
+      audio_info_(audio_info),
+      video_info_(video_info) {}
+
+ParsedMimeInfo ParsedMimeInfo::WithBitrate(int bitrate) const {
+  AudioCodecInfo audio_info = audio_info_;
+  VideoCodecInfo video_info = video_info_;
+
+  audio_info.bitrate = bitrate;
+  video_info.bitrate = bitrate;
+
+  return ParsedMimeInfo(mime_type_, disable_cache_, audio_info, video_info);
+}
+
+namespace {
 
 bool ParseAudioInfo(const MimeType& mime_type,
                     const std::string& codec,
@@ -124,70 +196,6 @@ bool ParseVideoInfo(const MimeType& mime_type,
 }
 
 }  // namespace
-
-// static
-std::optional<ParsedMimeInfo> ParsedMimeInfo::Create(
-    const std::string& mime_string) {
-  auto mime_type = MimeType::Create(mime_string);
-  if (!mime_type) {
-    return std::nullopt;
-  }
-
-  // Read "disablecache".
-  if (!mime_type->ValidateBoolParameter("disablecache")) {
-    return std::nullopt;
-  }
-  bool disable_cache = mime_type->GetParamBoolValue("disablecache", false);
-
-  // We only support audio or video type.
-  if (mime_type->type() != "audio" && mime_type->type() != "video") {
-    return std::nullopt;
-  }
-
-  auto codecs = mime_type->GetCodecs();
-  // We only support up to one audio codec and one video codec.
-  if (codecs.size() > 2) {
-    return std::nullopt;
-  }
-
-  AudioCodecInfo audio_info;
-  VideoCodecInfo video_info;
-
-  for (const auto& codec : codecs) {
-    if (audio_info.codec == kSbMediaAudioCodecNone &&
-        ParseAudioInfo(*mime_type, codec, &audio_info)) {
-      continue;
-    }
-    if (video_info.codec == kSbMediaVideoCodecNone &&
-        ParseVideoInfo(*mime_type, codec, &video_info)) {
-      continue;
-    }
-    // It either has an invalid codec or has two codecs of same type.
-    return std::nullopt;
-  }
-
-  return ParsedMimeInfo(std::move(*mime_type), disable_cache, audio_info,
-                        video_info);
-}
-
-ParsedMimeInfo::ParsedMimeInfo(MimeType mime_type,
-                               bool disable_cache,
-                               AudioCodecInfo audio_info,
-                               VideoCodecInfo video_info)
-    : mime_type_(std::move(mime_type)),
-      disable_cache_(disable_cache),
-      audio_info_(audio_info),
-      video_info_(video_info) {}
-
-ParsedMimeInfo ParsedMimeInfo::WithBitrate(int bitrate) const {
-  AudioCodecInfo audio_info = audio_info_;
-  VideoCodecInfo video_info = video_info_;
-
-  audio_info.bitrate = bitrate;
-  video_info.bitrate = bitrate;
-
-  return ParsedMimeInfo(mime_type_, disable_cache_, audio_info, video_info);
-}
 
 std::ostream& operator<<(std::ostream& os, const ParsedMimeInfo& mime_info) {
   os << "ParsedMimeInfo={mime_type=" << mime_info.mime_type();

--- a/starboard/shared/starboard/media/parsed_mime_info.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info.cc
@@ -29,6 +29,10 @@ namespace {
 
 const int64_t kDefaultAudioChannels = 2;
 
+// Turns |eotf| into value of SbMediaTransferId.  If |eotf| isn't recognized the
+// function returns kSbMediaTransferIdUnknown.
+// This function supports all eotfs required by YouTube TV HTML5 Technical
+// Requirements.
 SbMediaTransferId GetTransferIdFromString(const std::string& transfer_id) {
   if (transfer_id == "bt709") {
     return kSbMediaTransferIdBt709;

--- a/starboard/shared/starboard/media/parsed_mime_info.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info.cc
@@ -45,8 +45,8 @@ SbMediaTransferId GetTransferIdFromString(const std::string& transfer_id) {
 bool ParseAudioInfo(const MimeType& mime_type,
                     const std::string& codec,
                     ParsedMimeInfo::AudioCodecInfo* audio_info) {
-  SB_DCHECK(audio_info);
-  SB_DCHECK(audio_info->codec == kSbMediaAudioCodecNone);
+  SB_CHECK(audio_info);
+  SB_CHECK_EQ(audio_info->codec, kSbMediaAudioCodecNone);
 
   SbMediaAudioCodec audio_codec =
       GetAudioCodecFromString(codec.c_str(), mime_type.subtype().c_str());

--- a/starboard/shared/starboard/media/parsed_mime_info.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info.cc
@@ -45,7 +45,7 @@ SbMediaTransferId GetTransferIdFromString(const std::string& transfer_id) {
 }  // namespace
 
 ParsedMimeInfo::ParsedMimeInfo(const std::string& mime_string)
-    : mime_type_(mime_string) {
+    : mime_type_(MimeType::Create(mime_string)) {
   ParseMimeInfo();
 }
 
@@ -60,22 +60,22 @@ void ParsedMimeInfo::ParseMimeInfo() {
   }
 
   // Read "disablecache".
-  if (!mime_type_.ValidateBoolParameter("disablecache")) {
-    mime_type_ = MimeType();
+  if (!mime_type_->ValidateBoolParameter("disablecache")) {
+    mime_type_ = std::nullopt;
     return;
   }
-  disable_cache_ = mime_type_.GetParamBoolValue("disablecache", false);
+  disable_cache_ = mime_type_->GetParamBoolValue("disablecache", false);
 
   // We only support audio or video type.
-  if (mime_type_.type() != "audio" && mime_type_.type() != "video") {
-    mime_type_ = MimeType();
+  if (mime_type_->type() != "audio" && mime_type_->type() != "video") {
+    mime_type_ = std::nullopt;
     return;
   }
 
-  auto codecs = mime_type_.GetCodecs();
+  auto codecs = mime_type_->GetCodecs();
   // We only support up to one audio codec and one video codec.
   if (codecs.size() > 2) {
-    mime_type_ = MimeType();
+    mime_type_ = std::nullopt;
     return;
   }
 
@@ -88,7 +88,7 @@ void ParsedMimeInfo::ParseMimeInfo() {
     }
     // It either has an invalid codec or has two codecs of same type.
     ResetCodecInfos();
-    mime_type_ = MimeType();
+    mime_type_ = std::nullopt;
     return;
   }
 }
@@ -98,18 +98,18 @@ bool ParsedMimeInfo::ParseAudioInfo(const std::string& codec) {
   SB_DCHECK(!has_audio_info());
 
   SbMediaAudioCodec audio_codec =
-      GetAudioCodecFromString(codec.c_str(), mime_type_.subtype().c_str());
+      GetAudioCodecFromString(codec.c_str(), mime_type_->subtype().c_str());
   if (audio_codec == kSbMediaAudioCodecNone) {
     return false;
   }
-  if (!mime_type_.ValidateIntParameter("channels") ||
-      !mime_type_.ValidateIntParameter("bitrate")) {
+  if (!mime_type_->ValidateIntParameter("channels") ||
+      !mime_type_->ValidateIntParameter("bitrate")) {
     return false;
   }
   audio_info_.codec = audio_codec;
   audio_info_.channels =
-      mime_type_.GetParamIntValue("channels", kDefaultAudioChannels);
-  audio_info_.bitrate = mime_type_.GetParamIntValue("bitrate", 0);
+      mime_type_->GetParamIntValue("channels", kDefaultAudioChannels);
+  audio_info_.bitrate = mime_type_->GetParamIntValue("bitrate", 0);
 
   return audio_info_.channels >= 0 && audio_info_.bitrate >= 0;
 }
@@ -129,7 +129,7 @@ bool ParsedMimeInfo::ParseVideoInfo(const std::string& codec) {
     return false;
   }
 
-  std::string eotf = mime_type_.GetParamStringValue("eotf", "");
+  std::string eotf = mime_type_->GetParamStringValue("eotf", "");
   if (!eotf.empty()) {
     SbMediaTransferId transfer_id_from_eotf = GetTransferIdFromString(eotf);
     if (transfer_id_from_eotf == kSbMediaTransferIdUnknown) {
@@ -146,23 +146,23 @@ bool ParsedMimeInfo::ParseVideoInfo(const std::string& codec) {
     video_info_.transfer_id = transfer_id_from_eotf;
   }
 
-  if (!mime_type_.ValidateIntParameter("width") ||
-      !mime_type_.ValidateIntParameter("height") ||
-      !mime_type_.ValidateFloatParameter("framerate") ||
-      !mime_type_.ValidateIntParameter("bitrate") ||
-      !mime_type_.ValidateBoolParameter("decode-to-texture")) {
+  if (!mime_type_->ValidateIntParameter("width") ||
+      !mime_type_->ValidateIntParameter("height") ||
+      !mime_type_->ValidateFloatParameter("framerate") ||
+      !mime_type_->ValidateIntParameter("bitrate") ||
+      !mime_type_->ValidateBoolParameter("decode-to-texture")) {
     return false;
   }
 
-  video_info_.frame_width = mime_type_.GetParamIntValue("width", 0);
-  video_info_.frame_height = mime_type_.GetParamIntValue("height", 0);
+  video_info_.frame_width = mime_type_->GetParamIntValue("width", 0);
+  video_info_.frame_height = mime_type_->GetParamIntValue("height", 0);
   // TODO: Support float framerate. Our starboard implementation only supports
   // integer framerate, but framerate could be float and we should support it.
-  float framerate = mime_type_.GetParamFloatValue("framerate", 0.0f);
+  float framerate = mime_type_->GetParamFloatValue("framerate", 0.0f);
   video_info_.fps = std::round(framerate);
-  video_info_.bitrate = mime_type_.GetParamIntValue("bitrate", 0);
+  video_info_.bitrate = mime_type_->GetParamIntValue("bitrate", 0);
   video_info_.decode_to_texture_required =
-      mime_type_.GetParamBoolValue("decode-to-texture", false);
+      mime_type_->GetParamBoolValue("decode-to-texture", false);
 
   return video_info_.frame_width >= 0 && video_info_.frame_height >= 0 &&
          video_info_.fps >= 0 && video_info_.bitrate >= 0;

--- a/starboard/shared/starboard/media/parsed_mime_info.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info.cc
@@ -42,94 +42,47 @@ SbMediaTransferId GetTransferIdFromString(const std::string& transfer_id) {
   return kSbMediaTransferIdUnknown;
 }
 
-}  // namespace
-
-ParsedMimeInfo::ParsedMimeInfo(const std::string& mime_string)
-    : mime_type_(MimeType::Create(mime_string)) {
-  ParseMimeInfo();
-}
-
-void ParsedMimeInfo::SetBitrate(int bitrate) {
-  audio_info_.bitrate = bitrate;
-  video_info_.bitrate = bitrate;
-}
-
-void ParsedMimeInfo::ParseMimeInfo() {
-  if (!mime_type_) {
-    return;
-  }
-
-  // Read "disablecache".
-  if (!mime_type_->ValidateBoolParameter("disablecache")) {
-    mime_type_ = std::nullopt;
-    return;
-  }
-  disable_cache_ = mime_type_->GetParamBoolValue("disablecache", false);
-
-  // We only support audio or video type.
-  if (mime_type_->type() != "audio" && mime_type_->type() != "video") {
-    mime_type_ = std::nullopt;
-    return;
-  }
-
-  auto codecs = mime_type_->GetCodecs();
-  // We only support up to one audio codec and one video codec.
-  if (codecs.size() > 2) {
-    mime_type_ = std::nullopt;
-    return;
-  }
-
-  for (const auto& codec : codecs) {
-    if (!has_audio_info() && ParseAudioInfo(codec)) {
-      continue;
-    }
-    if (!has_video_info() && ParseVideoInfo(codec)) {
-      continue;
-    }
-    // It either has an invalid codec or has two codecs of same type.
-    ResetCodecInfos();
-    mime_type_ = std::nullopt;
-    return;
-  }
-}
-
-bool ParsedMimeInfo::ParseAudioInfo(const std::string& codec) {
-  SB_DCHECK(mime_type_);
-  SB_DCHECK(!has_audio_info());
+bool ParseAudioInfo(const MimeType& mime_type,
+                    const std::string& codec,
+                    ParsedMimeInfo::AudioCodecInfo* audio_info) {
+  SB_DCHECK(audio_info);
+  SB_DCHECK(audio_info->codec == kSbMediaAudioCodecNone);
 
   SbMediaAudioCodec audio_codec =
-      GetAudioCodecFromString(codec.c_str(), mime_type_->subtype().c_str());
+      GetAudioCodecFromString(codec.c_str(), mime_type.subtype().c_str());
   if (audio_codec == kSbMediaAudioCodecNone) {
     return false;
   }
-  if (!mime_type_->ValidateIntParameter("channels") ||
-      !mime_type_->ValidateIntParameter("bitrate")) {
+  if (!mime_type.ValidateIntParameter("channels") ||
+      !mime_type.ValidateIntParameter("bitrate")) {
     return false;
   }
-  audio_info_.codec = audio_codec;
-  audio_info_.channels =
-      mime_type_->GetParamIntValue("channels", kDefaultAudioChannels);
-  audio_info_.bitrate = mime_type_->GetParamIntValue("bitrate", 0);
+  audio_info->codec = audio_codec;
+  audio_info->channels =
+      mime_type.GetParamIntValue("channels", kDefaultAudioChannels);
+  audio_info->bitrate = mime_type.GetParamIntValue("bitrate", 0);
 
-  return audio_info_.channels >= 0 && audio_info_.bitrate >= 0;
+  return audio_info->channels >= 0 && audio_info->bitrate >= 0;
 }
 
-bool ParsedMimeInfo::ParseVideoInfo(const std::string& codec) {
-  SB_DCHECK(mime_type_);
-  SB_DCHECK(!has_video_info());
+bool ParseVideoInfo(const MimeType& mime_type,
+                    const std::string& codec,
+                    ParsedMimeInfo::VideoCodecInfo* video_info) {
+  SB_DCHECK(video_info);
+  SB_DCHECK(video_info->codec == kSbMediaVideoCodecNone);
 
-  if (!ParseVideoCodec(codec.c_str(), &video_info_.codec, &video_info_.profile,
-                       &video_info_.level, &video_info_.bit_depth,
-                       &video_info_.primary_id, &video_info_.transfer_id,
-                       &video_info_.matrix_id)) {
+  if (!ParseVideoCodec(codec.c_str(), &video_info->codec, &video_info->profile,
+                       &video_info->level, &video_info->bit_depth,
+                       &video_info->primary_id, &video_info->transfer_id,
+                       &video_info->matrix_id)) {
     return false;
   }
 
-  if (video_info_.codec == kSbMediaVideoCodecNone) {
+  if (video_info->codec == kSbMediaVideoCodecNone) {
     return false;
   }
 
-  std::string eotf = mime_type_->GetParamStringValue("eotf", "");
+  std::string eotf = mime_type.GetParamStringValue("eotf", "");
   if (!eotf.empty()) {
     SbMediaTransferId transfer_id_from_eotf = GetTransferIdFromString(eotf);
     if (transfer_id_from_eotf == kSbMediaTransferIdUnknown) {
@@ -138,39 +91,100 @@ bool ParsedMimeInfo::ParseVideoInfo(const std::string& codec) {
       return false;
     }
     SB_LOG_IF(WARNING,
-              video_info_.transfer_id != kSbMediaTransferIdUnspecified &&
-                  video_info_.transfer_id != transfer_id_from_eotf)
-        << "transfer_id " << video_info_.transfer_id
-        << " set by the codec string \"" << video_info_.codec
+              video_info->transfer_id != kSbMediaTransferIdUnspecified &&
+                  video_info->transfer_id != transfer_id_from_eotf)
+        << "transfer_id " << video_info->transfer_id
+        << " set by the codec string \"" << video_info->codec
         << "\" will be overwritten by the eotf attribute " << eotf;
-    video_info_.transfer_id = transfer_id_from_eotf;
+    video_info->transfer_id = transfer_id_from_eotf;
   }
 
-  if (!mime_type_->ValidateIntParameter("width") ||
-      !mime_type_->ValidateIntParameter("height") ||
-      !mime_type_->ValidateFloatParameter("framerate") ||
-      !mime_type_->ValidateIntParameter("bitrate") ||
-      !mime_type_->ValidateBoolParameter("decode-to-texture")) {
+  if (!mime_type.ValidateIntParameter("width") ||
+      !mime_type.ValidateIntParameter("height") ||
+      !mime_type.ValidateFloatParameter("framerate") ||
+      !mime_type.ValidateIntParameter("bitrate") ||
+      !mime_type.ValidateBoolParameter("decode-to-texture")) {
     return false;
   }
 
-  video_info_.frame_width = mime_type_->GetParamIntValue("width", 0);
-  video_info_.frame_height = mime_type_->GetParamIntValue("height", 0);
+  video_info->frame_width = mime_type.GetParamIntValue("width", 0);
+  video_info->frame_height = mime_type.GetParamIntValue("height", 0);
   // TODO: Support float framerate. Our starboard implementation only supports
   // integer framerate, but framerate could be float and we should support it.
-  float framerate = mime_type_->GetParamFloatValue("framerate", 0.0f);
-  video_info_.fps = std::round(framerate);
-  video_info_.bitrate = mime_type_->GetParamIntValue("bitrate", 0);
-  video_info_.decode_to_texture_required =
-      mime_type_->GetParamBoolValue("decode-to-texture", false);
+  float framerate = mime_type.GetParamFloatValue("framerate", 0.0f);
+  video_info->fps = std::round(framerate);
+  video_info->bitrate = mime_type.GetParamIntValue("bitrate", 0);
+  video_info->decode_to_texture_required =
+      mime_type.GetParamBoolValue("decode-to-texture", false);
 
-  return video_info_.frame_width >= 0 && video_info_.frame_height >= 0 &&
-         video_info_.fps >= 0 && video_info_.bitrate >= 0;
+  return video_info->frame_width >= 0 && video_info->frame_height >= 0 &&
+         video_info->fps >= 0 && video_info->bitrate >= 0;
 }
 
-void ParsedMimeInfo::ResetCodecInfos() {
-  audio_info_.codec = kSbMediaAudioCodecNone;
-  video_info_.codec = kSbMediaVideoCodecNone;
+}  // namespace
+
+// static
+std::optional<ParsedMimeInfo> ParsedMimeInfo::Create(
+    const std::string& mime_string) {
+  auto mime_type = MimeType::Create(mime_string);
+  if (!mime_type) {
+    return std::nullopt;
+  }
+
+  // Read "disablecache".
+  if (!mime_type->ValidateBoolParameter("disablecache")) {
+    return std::nullopt;
+  }
+  bool disable_cache = mime_type->GetParamBoolValue("disablecache", false);
+
+  // We only support audio or video type.
+  if (mime_type->type() != "audio" && mime_type->type() != "video") {
+    return std::nullopt;
+  }
+
+  auto codecs = mime_type->GetCodecs();
+  // We only support up to one audio codec and one video codec.
+  if (codecs.size() > 2) {
+    return std::nullopt;
+  }
+
+  AudioCodecInfo audio_info;
+  VideoCodecInfo video_info;
+
+  for (const auto& codec : codecs) {
+    if (audio_info.codec == kSbMediaAudioCodecNone &&
+        ParseAudioInfo(*mime_type, codec, &audio_info)) {
+      continue;
+    }
+    if (video_info.codec == kSbMediaVideoCodecNone &&
+        ParseVideoInfo(*mime_type, codec, &video_info)) {
+      continue;
+    }
+    // It either has an invalid codec or has two codecs of same type.
+    return std::nullopt;
+  }
+
+  return ParsedMimeInfo(std::move(*mime_type), disable_cache, audio_info,
+                        video_info);
+}
+
+ParsedMimeInfo::ParsedMimeInfo(MimeType mime_type,
+                               bool disable_cache,
+                               AudioCodecInfo audio_info,
+                               VideoCodecInfo video_info)
+    : mime_type_(std::move(mime_type)),
+      disable_cache_(disable_cache),
+      audio_info_(audio_info),
+      video_info_(video_info) {}
+
+ParsedMimeInfo ParsedMimeInfo::WithBitrate(int bitrate) const {
+  AudioCodecInfo audio_info = audio_info_;
+  VideoCodecInfo video_info = video_info_;
+
+  audio_info.bitrate = bitrate;
+  video_info.bitrate = bitrate;
+
+  return ParsedMimeInfo(mime_type_, disable_cache_, audio_info, video_info);
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/media/parsed_mime_info.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info.cc
@@ -55,28 +55,27 @@ void ParsedMimeInfo::SetBitrate(int bitrate) {
 }
 
 void ParsedMimeInfo::ParseMimeInfo() {
-  if (!mime_type_.is_valid()) {
-    is_valid_ = false;
+  if (!mime_type_) {
     return;
   }
 
   // Read "disablecache".
   if (!mime_type_.ValidateBoolParameter("disablecache")) {
-    is_valid_ = false;
+    mime_type_ = MimeType();
     return;
   }
   disable_cache_ = mime_type_.GetParamBoolValue("disablecache", false);
 
   // We only support audio or video type.
   if (mime_type_.type() != "audio" && mime_type_.type() != "video") {
-    is_valid_ = false;
+    mime_type_ = MimeType();
     return;
   }
 
   auto codecs = mime_type_.GetCodecs();
   // We only support up to one audio codec and one video codec.
   if (codecs.size() > 2) {
-    is_valid_ = false;
+    mime_type_ = MimeType();
     return;
   }
 
@@ -89,13 +88,13 @@ void ParsedMimeInfo::ParseMimeInfo() {
     }
     // It either has an invalid codec or has two codecs of same type.
     ResetCodecInfos();
-    is_valid_ = false;
+    mime_type_ = MimeType();
     return;
   }
 }
 
 bool ParsedMimeInfo::ParseAudioInfo(const std::string& codec) {
-  SB_DCHECK(mime_type_.is_valid());
+  SB_DCHECK(mime_type_);
   SB_DCHECK(!has_audio_info());
 
   SbMediaAudioCodec audio_codec =
@@ -116,7 +115,7 @@ bool ParsedMimeInfo::ParseAudioInfo(const std::string& codec) {
 }
 
 bool ParsedMimeInfo::ParseVideoInfo(const std::string& codec) {
-  SB_DCHECK(mime_type_.is_valid());
+  SB_DCHECK(mime_type_);
   SB_DCHECK(!has_video_info());
 
   if (!ParseVideoCodec(codec.c_str(), &video_info_.codec, &video_info_.profile,

--- a/starboard/shared/starboard/media/parsed_mime_info.h
+++ b/starboard/shared/starboard/media/parsed_mime_info.h
@@ -51,9 +51,12 @@ class ParsedMimeInfo {
   ParsedMimeInfo() = default;
   explicit ParsedMimeInfo(const std::string& mime_string);
 
-  explicit operator bool() const { return static_cast<bool>(mime_type_); }
+  explicit operator bool() const { return mime_type_.has_value(); }
 
-  const MimeType& mime_type() const { return mime_type_; }
+  const MimeType& mime_type() const {
+    SB_DCHECK(mime_type_);
+    return *mime_type_;
+  }
 
   // A switch in the mime string to disable caches.
   bool disable_cache() const { return disable_cache_; }
@@ -87,7 +90,7 @@ class ParsedMimeInfo {
   bool ParseVideoInfo(const std::string& codec);
   void ResetCodecInfos();
 
-  MimeType mime_type_;
+  std::optional<MimeType> mime_type_;
   bool disable_cache_ = false;
   AudioCodecInfo audio_info_;
   VideoCodecInfo video_info_;

--- a/starboard/shared/starboard/media/parsed_mime_info.h
+++ b/starboard/shared/starboard/media/parsed_mime_info.h
@@ -48,12 +48,12 @@ class ParsedMimeInfo {
     bool decode_to_texture_required;
   };
 
-  ParsedMimeInfo() : mime_type_("") {}
+  ParsedMimeInfo() = default;
   explicit ParsedMimeInfo(const std::string& mime_string);
 
-  const MimeType& mime_type() const { return mime_type_; }
+  explicit operator bool() const { return static_cast<bool>(mime_type_); }
 
-  bool is_valid() const { return is_valid_; }
+  const MimeType& mime_type() const { return mime_type_; }
 
   // A switch in the mime string to disable caches.
   bool disable_cache() const { return disable_cache_; }
@@ -85,11 +85,9 @@ class ParsedMimeInfo {
   void ParseMimeInfo();
   bool ParseAudioInfo(const std::string& codec);
   bool ParseVideoInfo(const std::string& codec);
-
   void ResetCodecInfos();
 
   MimeType mime_type_;
-  bool is_valid_ = true;
   bool disable_cache_ = false;
   AudioCodecInfo audio_info_;
   VideoCodecInfo video_info_;

--- a/starboard/shared/starboard/media/parsed_mime_info.h
+++ b/starboard/shared/starboard/media/parsed_mime_info.h
@@ -24,7 +24,6 @@
 
 namespace starboard {
 
-// TODO: add unit tests for ParsedMimeInfo
 class ParsedMimeInfo {
  public:
   struct AudioCodecInfo {
@@ -89,6 +88,8 @@ class ParsedMimeInfo {
   const AudioCodecInfo audio_info_;
   const VideoCodecInfo video_info_;
 };
+
+std::ostream& operator<<(std::ostream& os, const ParsedMimeInfo& mime_info);
 
 }  // namespace starboard
 

--- a/starboard/shared/starboard/media/parsed_mime_info.h
+++ b/starboard/shared/starboard/media/parsed_mime_info.h
@@ -48,15 +48,9 @@ class ParsedMimeInfo {
     bool decode_to_texture_required;
   };
 
-  ParsedMimeInfo() = default;
-  explicit ParsedMimeInfo(const std::string& mime_string);
+  static std::optional<ParsedMimeInfo> Create(const std::string& mime_string);
 
-  explicit operator bool() const { return mime_type_.has_value(); }
-
-  const MimeType& mime_type() const {
-    SB_DCHECK(mime_type_);
-    return *mime_type_;
-  }
+  const MimeType& mime_type() const { return mime_type_; }
 
   // A switch in the mime string to disable caches.
   bool disable_cache() const { return disable_cache_; }
@@ -81,19 +75,19 @@ class ParsedMimeInfo {
     return video_info_;
   }
 
-  // Allow to overwrite the bitrate.
-  void SetBitrate(int bitrate);
+  // Returns a new ParsedMimeInfo with the bitrate updated.
+  ParsedMimeInfo WithBitrate(int bitrate) const;
 
  private:
-  void ParseMimeInfo();
-  bool ParseAudioInfo(const std::string& codec);
-  bool ParseVideoInfo(const std::string& codec);
-  void ResetCodecInfos();
+  ParsedMimeInfo(MimeType mime_type,
+                 bool disable_cache,
+                 AudioCodecInfo audio_info,
+                 VideoCodecInfo video_info);
 
-  std::optional<MimeType> mime_type_;
-  bool disable_cache_ = false;
-  AudioCodecInfo audio_info_;
-  VideoCodecInfo video_info_;
+  const MimeType mime_type_;
+  const bool disable_cache_;
+  const AudioCodecInfo audio_info_;
+  const VideoCodecInfo video_info_;
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/media/parsed_mime_info_test.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info_test.cc
@@ -23,63 +23,72 @@ namespace {
 const bool kCheckAc3Audio = true;
 
 TEST(ParsedMimeInfoTest, ParsesAacLowComplexityCodec) {
-  ParsedMimeInfo mime_info("audio/mp4; codecs=\"mp4a.40.2\"");
-  ASSERT_TRUE(mime_info.has_audio_info());
-  EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecAac);
+  auto mime_info = ParsedMimeInfo::Create("audio/mp4; codecs=\"mp4a.40.2\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_TRUE(mime_info->has_audio_info());
+  EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecAac);
 }
 
 TEST(ParsedMimeInfoTest, ParsesAacHighEfficiencyCodec) {
-  ParsedMimeInfo mime_info("audio/mp4; codecs=\"mp4a.40.5\"");
-  ASSERT_TRUE(mime_info.has_audio_info());
-  EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecAac);
+  auto mime_info = ParsedMimeInfo::Create("audio/mp4; codecs=\"mp4a.40.5\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_TRUE(mime_info->has_audio_info());
+  EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecAac);
 }
 
 TEST(ParsedMimeInfoTest, ParsesAc3Codec) {
-  ParsedMimeInfo mime_info("audio/mp4; codecs=\"ac-3\"");
-  ASSERT_EQ(mime_info.has_audio_info(), kCheckAc3Audio);
+  auto mime_info = ParsedMimeInfo::Create("audio/mp4; codecs=\"ac-3\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_EQ(mime_info->has_audio_info(), kCheckAc3Audio);
 
   if (kCheckAc3Audio) {
-    EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecAc3);
+    EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecAc3);
   }
 }
 
 TEST(ParsedMimeInfoTest, ParsesEac3Codec) {
-  ParsedMimeInfo mime_info("audio/mp4; codecs=\"ec-3\"");
-  ASSERT_EQ(mime_info.has_audio_info(), kCheckAc3Audio);
+  auto mime_info = ParsedMimeInfo::Create("audio/mp4; codecs=\"ec-3\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_EQ(mime_info->has_audio_info(), kCheckAc3Audio);
 
   if (kCheckAc3Audio) {
-    EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecEac3);
+    EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecEac3);
   }
 }
 
 TEST(ParsedMimeInfoTest, ParsesOpusCodec) {
-  ParsedMimeInfo mime_info("audio/webm; codecs=\"opus\"");
-  ASSERT_TRUE(mime_info.has_audio_info());
-  EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecOpus);
+  auto mime_info = ParsedMimeInfo::Create("audio/webm; codecs=\"opus\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_TRUE(mime_info->has_audio_info());
+  EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecOpus);
 }
 
 TEST(ParsedMimeInfoTest, ParsesVorbisCodec) {
-  ParsedMimeInfo mime_info("audio/webm; codecs=\"vorbis\"");
-  ASSERT_TRUE(mime_info.has_audio_info());
-  EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecVorbis);
+  auto mime_info = ParsedMimeInfo::Create("audio/webm; codecs=\"vorbis\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_TRUE(mime_info->has_audio_info());
+  EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecVorbis);
 }
 
 TEST(ParsedMimeInfoTest, ParsesMp3Codec) {
-  ParsedMimeInfo mime_info("audio/mpeg; codecs=\"mp3\"");
-  ASSERT_TRUE(mime_info.has_audio_info());
-  EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecMp3);
+  auto mime_info = ParsedMimeInfo::Create("audio/mpeg; codecs=\"mp3\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_TRUE(mime_info->has_audio_info());
+  EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecMp3);
 }
 
 TEST(ParsedMimeInfoTest, ParsesFlacCodec) {
-  ParsedMimeInfo mime_info("audio/ogg; codecs=\"flac\"");
-  ASSERT_TRUE(mime_info.has_audio_info());
-  EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecFlac);
+  auto mime_info = ParsedMimeInfo::Create("audio/ogg; codecs=\"flac\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_TRUE(mime_info->has_audio_info());
+  EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecFlac);
 }
 
 TEST(ParsedMimeInfoTest, ParsesPcmCodec) {
-  ParsedMimeInfo mime_info("audio/wav; codecs=\"1\"");
-  ASSERT_TRUE(mime_info.has_audio_info());
-  EXPECT_EQ(mime_info.audio_info().codec, kSbMediaAudioCodecPcm);
+  auto mime_info = ParsedMimeInfo::Create("audio/wav; codecs=\"1\"");
+  ASSERT_TRUE(mime_info);
+  ASSERT_TRUE(mime_info->has_audio_info());
+  EXPECT_EQ(mime_info->audio_info().codec, kSbMediaAudioCodecPcm);
 }
 
 }  // namespace

--- a/starboard/shared/starboard/player/filter/testing/test_util.cc
+++ b/starboard/shared/starboard/player/filter/testing/test_util.cc
@@ -135,8 +135,9 @@ std::vector<const char*> GetSupportedAudioTestFiles(
     // Filter files of unsupported codec.
     const std::string audio_mime = GetContentTypeFromAudioCodec(
         audio_file_info.audio_codec, extra_mime_attributes);
-    const MimeType audio_mime_type(audio_mime.c_str());
-    if (!MediaIsAudioSupported(audio_file_info.audio_codec, &audio_mime_type,
+    auto audio_mime_type = MimeType::Create(audio_mime);
+    if (!audio_mime_type ||
+        !MediaIsAudioSupported(audio_file_info.audio_codec, &*audio_mime_type,
                                audio_file_info.bitrate)) {
       continue;
     }
@@ -178,7 +179,7 @@ std::vector<VideoTestParam> GetSupportedVideoTests() {
 
       const auto& video_stream_info = dmp_reader.video_stream_info();
       const std::string video_mime = dmp_reader.video_mime_type();
-      const MimeType video_mime_type(video_mime.c_str());
+      auto video_mime_type = MimeType::Create(video_mime);
       // MediaIsVideoSupported may return false for gpu based decoder that in
       // fact supports av1 or/and vp9 because the system can make async
       // initialization at startup.
@@ -190,8 +191,8 @@ std::vector<VideoTestParam> GetSupportedVideoTests() {
                                      video_codec == kSbMediaVideoCodecVp9;
       do {
         if (MediaIsVideoSupported(
-                video_codec, video_mime.size() > 0 ? &video_mime_type : nullptr,
-                -1, -1, 8, kSbMediaPrimaryIdUnspecified,
+                video_codec, video_mime_type ? &*video_mime_type : nullptr, -1,
+                -1, 8, kSbMediaPrimaryIdUnspecified,
                 kSbMediaTransferIdUnspecified, kSbMediaMatrixIdUnspecified,
                 video_stream_info.frame_size.width,
                 video_stream_info.frame_size.height, dmp_reader.video_bitrate(),

--- a/starboard/shared/starboard/player/player_create.cc
+++ b/starboard/shared/starboard/player/player_create.cc
@@ -125,10 +125,7 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
   if (audio_codec != kSbMediaAudioCodecNone) {
     auto audio_mime_type = MimeType::Create(audio_mime);
     if (strlen(audio_mime) > 0 && !audio_mime_type) {
-      SB_LOG(ERROR) << "Invalid audio mime type: " << audio_mime;
-      player_error_func(kSbPlayerInvalid, context, kSbPlayerErrorDecode,
-                        "Invalid audio mime type");
-      return kSbPlayerInvalid;
+      SB_LOG(WARNING) << "Invalid audio mime type: " << audio_mime;
     }
     if (!MediaIsAudioSupported(audio_codec,
                                audio_mime_type ? &*audio_mime_type : nullptr,
@@ -153,13 +150,14 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
   if (video_codec != kSbMediaVideoCodecNone) {
     auto video_mime_type = MimeType::Create(video_mime);
     if (strlen(video_mime) > 0 && !video_mime_type) {
-      SB_LOG(ERROR) << "Invalid video mime type: " << video_mime;
-      player_error_func(kSbPlayerInvalid, context, kSbPlayerErrorDecode,
-                        "Invalid video mime type");
-      return kSbPlayerInvalid;
+      SB_LOG(WARNING) << "Invalid video mime type: " << video_mime;
     }
+    MimeType legacy_video_mime =
+        video_mime_type ? *video_mime_type : MimeType();
     if (!MediaIsVideoSupported(
-            video_codec, video_mime_type ? &*video_mime_type : nullptr,
+            video_codec,
+            (strlen(video_mime) > 0 || video_mime_type) ? &legacy_video_mime
+                                                        : nullptr,
             kDefaultProfile, kDefaultLevel, kDefaultColorDepth,
             kSbMediaPrimaryIdUnspecified, kSbMediaTransferIdUnspecified,
             kSbMediaMatrixIdUnspecified, kDefaultFrameWidth,

--- a/starboard/shared/starboard/player/player_create.cc
+++ b/starboard/shared/starboard/player/player_create.cc
@@ -125,7 +125,10 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
   if (audio_codec != kSbMediaAudioCodecNone) {
     auto audio_mime_type = MimeType::Create(audio_mime);
     if (strlen(audio_mime) > 0 && !audio_mime_type) {
-      SB_LOG(WARNING) << "Invalid audio mime type: " << audio_mime;
+      SB_LOG(ERROR) << "Invalid audio mime type: " << audio_mime;
+      player_error_func(kSbPlayerInvalid, context, kSbPlayerErrorDecode,
+                        "Invalid audio mime type.");
+      return kSbPlayerInvalid;
     }
     if (!MediaIsAudioSupported(audio_codec,
                                audio_mime_type ? &*audio_mime_type : nullptr,
@@ -150,14 +153,13 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
   if (video_codec != kSbMediaVideoCodecNone) {
     auto video_mime_type = MimeType::Create(video_mime);
     if (strlen(video_mime) > 0 && !video_mime_type) {
-      SB_LOG(WARNING) << "Invalid video mime type: " << video_mime;
+      SB_LOG(ERROR) << "Invalid video mime type: " << video_mime;
+      player_error_func(kSbPlayerInvalid, context, kSbPlayerErrorDecode,
+                        "Invalid video mime type.");
+      return kSbPlayerInvalid;
     }
-    MimeType legacy_video_mime =
-        video_mime_type ? *video_mime_type : MimeType();
     if (!MediaIsVideoSupported(
-            video_codec,
-            (strlen(video_mime) > 0 || video_mime_type) ? &legacy_video_mime
-                                                        : nullptr,
+            video_codec, video_mime_type ? &*video_mime_type : nullptr,
             kDefaultProfile, kDefaultLevel, kDefaultColorDepth,
             kSbMediaPrimaryIdUnspecified, kSbMediaTransferIdUnspecified,
             kSbMediaMatrixIdUnspecified, kDefaultFrameWidth,

--- a/starboard/shared/starboard/player/player_create.cc
+++ b/starboard/shared/starboard/player/player_create.cc
@@ -123,10 +123,16 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
 
   const int64_t kDefaultBitRate = 0;
   if (audio_codec != kSbMediaAudioCodecNone) {
-    const MimeType audio_mime_type(audio_mime);
-    if (!MediaIsAudioSupported(
-            audio_codec, strlen(audio_mime) > 0 ? &audio_mime_type : nullptr,
-            kDefaultBitRate)) {
+    auto audio_mime_type = MimeType::Create(audio_mime);
+    if (strlen(audio_mime) > 0 && !audio_mime_type) {
+      SB_LOG(ERROR) << "Invalid audio mime type: " << audio_mime;
+      player_error_func(kSbPlayerInvalid, context, kSbPlayerErrorDecode,
+                        "Invalid audio mime type");
+      return kSbPlayerInvalid;
+    }
+    if (!MediaIsAudioSupported(audio_codec,
+                               audio_mime_type ? &*audio_mime_type : nullptr,
+                               kDefaultBitRate)) {
       SB_LOG(ERROR) << "Unsupported audio codec "
                     << starboard::GetMediaAudioCodecName(audio_codec) << ".";
       player_error_func(kSbPlayerInvalid, context, kSbPlayerErrorDecode,
@@ -145,9 +151,15 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
   const int kDefaultFrameHeight = 0;
   const int kDefaultFrameRate = 0;
   if (video_codec != kSbMediaVideoCodecNone) {
-    const MimeType video_mime_type(video_mime);
+    auto video_mime_type = MimeType::Create(video_mime);
+    if (strlen(video_mime) > 0 && !video_mime_type) {
+      SB_LOG(ERROR) << "Invalid video mime type: " << video_mime;
+      player_error_func(kSbPlayerInvalid, context, kSbPlayerErrorDecode,
+                        "Invalid video mime type");
+      return kSbPlayerInvalid;
+    }
     if (!MediaIsVideoSupported(
-            video_codec, strlen(video_mime) > 0 ? &video_mime_type : nullptr,
+            video_codec, video_mime_type ? &*video_mime_type : nullptr,
             kDefaultProfile, kDefaultLevel, kDefaultColorDepth,
             kSbMediaPrimaryIdUnspecified, kSbMediaTransferIdUnspecified,
             kSbMediaMatrixIdUnspecified, kDefaultFrameWidth,

--- a/starboard/shared/widevine/drm_system_widevine.cc
+++ b/starboard/shared/widevine/drm_system_widevine.cc
@@ -269,18 +269,19 @@ bool DrmSystemWidevine::IsKeySystemSupported(const char* key_system) {
   // It is possible that the |key_system| comes with extra attributes, like
   // `com.widevine.alpha; encryptionscheme="cenc"`.  We prepend "key_system/"
   // to it, so it can be parsed by MimeType.
-  starboard::MimeType mime_type(std::string("key_system/") + key_system);
+  auto mime_type =
+      starboard::MimeType::Create(std::string("key_system/") + key_system);
 
-  if (!mime_type.is_valid()) {
+  if (!mime_type) {
     return false;
   }
-  SB_DCHECK_EQ(mime_type.type(), "key_system");
+  SB_DCHECK_EQ(mime_type->type(), "key_system");
 
   for (auto wv_key_system : kWidevineKeySystems) {
-    if (mime_type.subtype() == wv_key_system) {
-      for (int i = 0; i < mime_type.GetParamCount(); ++i) {
-        if (mime_type.GetParamName(i) == "encryptionscheme") {
-          auto value = mime_type.GetParamStringValue(i);
+    if (mime_type->subtype() == wv_key_system) {
+      for (int i = 0; i < mime_type->GetParamCount(); ++i) {
+        if (mime_type->GetParamName(i) == "encryptionscheme") {
+          auto value = mime_type->GetParamStringValue(i);
           if (value != "cenc" && value != "cbcs" && value != "cbcs-1-9") {
             return false;
           }

--- a/starboard/tvos/shared/media_can_play_mime_and_key_system.mm
+++ b/starboard/tvos/shared/media_can_play_mime_and_key_system.mm
@@ -93,10 +93,13 @@ SbMediaSupportType SbMediaCanPlayMimeAndKeySystem(const char* mime,
   // "application/x-mpegURL" is for hls content and will use UrlPlayer. The
   // supported types are different from SbPlayer.
   if (strncmp(kUrlPlayerMimeType, mime, kUrlPlayerMimeTypeLength) == 0) {
-    starboard::MimeType mime_type(mime);
-    auto codecs = mime_type.GetCodecs();
+    auto mime_type = starboard::MimeType::Create(mime);
+    if (!mime_type) {
+      return kSbMediaSupportTypeNotSupported;
+    }
+    auto codecs = mime_type->GetCodecs();
     for (const auto& codec : codecs) {
-      if (!IsAudioCodecSupportedByUrlPlayer(mime_type, codec) &&
+      if (!IsAudioCodecSupportedByUrlPlayer(*mime_type, codec) &&
           !IsVideoCodecSupportedByUrlPlayer(codec)) {
         return kSbMediaSupportTypeNotSupported;
       }


### PR DESCRIPTION
Migrates `MimeType` and `ParsedMimeInfo` from constructor initialization with internal boolean `is_valid()` states to modern, safer C++ factory methods  utilizing `std::optional`.

https://abseil.io/tips/42

Issue: 479994435