### PR TITLE
android: Use jni_zero types and methods directly

### DIFF
--- a/starboard/android/shared/accessibility_get_caption_settings.cc
+++ b/starboard/android/shared/accessibility_get_caption_settings.cc
@@ -16,7 +16,6 @@
 #include <cstdlib>
 #include <string>
 
-#include "base/android/jni_android.h"
 #include "cobalt/android/jni_headers/CaptionSettings_jni.h"
 #include "starboard/android/shared/accessibility_extension.h"
 #include "starboard/android/shared/starboard_bridge.h"
@@ -24,6 +23,7 @@
 #include "starboard/common/memory.h"
 #include "starboard/configuration.h"
 #include "starboard/shared/starboard/accessibility_internal.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -78,7 +78,7 @@ bool GetCaptionSettings(SbAccessibilityCaptionSettings* caption_settings) {
     return false;
   }
 
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
 
   auto j_caption_settings =
       StarboardBridge::GetInstance()->GetCaptionSettings(env);

--- a/starboard/android/shared/application_android.cc
+++ b/starboard/android/shared/application_android.cc
@@ -16,6 +16,7 @@
 
 #include <android/looper.h>
 #include <android/native_activity.h>
+#include <jni.h>
 #include <time.h>
 #include <unistd.h>
 
@@ -24,7 +25,6 @@
 #include <string>
 #include <vector>
 
-#include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
 #include "cobalt/android/jni_headers/CobaltSystemConfigChangeReceiver_jni.h"
 #include "cobalt/android/jni_headers/HTMLMediaElementExtension_jni.h"
@@ -39,14 +39,15 @@
 #include "starboard/key.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
 using base::android::ConvertJavaStringToUTF8;
 using base::android::ConvertUTF8ToJavaString;
-using base::android::JavaParamRef;
-using base::android::ScopedJavaGlobalRef;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::JavaParamRef;
+using jni_zero::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaLocalRef;
 
 // TODO(cobalt, b/378708359): Remove this dummy init.
 void stubSbEventHandle(const SbEvent* event) {
@@ -75,14 +76,14 @@ ApplicationAndroid::ApplicationAndroid(
   // class.
   RuntimeResourceOverlay::GetInstance();
 
-  JNIEnv* jni_env = base::android::AttachCurrentThread();
+  JNIEnv* jni_env = jni_zero::AttachCurrentThread();
   app_start_timestamp_ = starboard_bridge_->GetAppStartTimestamp(jni_env);
 
   starboard_bridge_->ApplicationStarted(jni_env);
 }
 
 ApplicationAndroid::~ApplicationAndroid() {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   starboard_bridge_->ApplicationStopping(env);
 }
 

--- a/starboard/android/shared/application_android.cc
+++ b/starboard/android/shared/application_android.cc
@@ -45,6 +45,7 @@ namespace starboard {
 
 using base::android::ConvertJavaStringToUTF8;
 using base::android::ConvertUTF8ToJavaString;
+using jni_zero::AttachCurrentThread;
 using jni_zero::JavaParamRef;
 using jni_zero::ScopedJavaGlobalRef;
 using jni_zero::ScopedJavaLocalRef;
@@ -76,14 +77,14 @@ ApplicationAndroid::ApplicationAndroid(
   // class.
   RuntimeResourceOverlay::GetInstance();
 
-  JNIEnv* jni_env = jni_zero::AttachCurrentThread();
+  JNIEnv* jni_env = AttachCurrentThread();
   app_start_timestamp_ = starboard_bridge_->GetAppStartTimestamp(jni_env);
 
   starboard_bridge_->ApplicationStarted(jni_env);
 }
 
 ApplicationAndroid::~ApplicationAndroid() {
-  JNIEnv* env = jni_zero::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
   starboard_bridge_->ApplicationStopping(env);
 }
 

--- a/starboard/android/shared/application_android.h
+++ b/starboard/android/shared/application_android.h
@@ -19,6 +19,7 @@
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/command_line.h"
 #include "starboard/shared/starboard/application.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -27,7 +28,7 @@ using ::starboard::CommandLine;
 class ApplicationAndroid : public Application {
  public:
   ApplicationAndroid(std::unique_ptr<CommandLine> command_line,
-                     base::android::ScopedJavaGlobalRef<jobject> asset_manager,
+                     jni_zero::ScopedJavaGlobalRef<jobject> asset_manager,
                      const std::string& files_dir,
                      const std::string& cache_dir,
                      const std::string& native_library_dir);

--- a/starboard/android/shared/audio_decoder.cc
+++ b/starboard/android/shared/audio_decoder.cc
@@ -50,7 +50,6 @@
 namespace starboard {
 namespace {
 
-using jni_zero::AttachCurrentThread;
 using jni_zero::ScopedJavaLocalRef;
 using std::placeholders::_1;
 using std::placeholders::_2;
@@ -247,7 +246,7 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
       return;
     }
 
-    JNIEnv* env = AttachCurrentThread();
+    JNIEnv* env = jni_zero::AttachCurrentThread();
     void* address = env->GetDirectBufferAddress(byte_buffer.obj());
     int16_t* data = static_cast<int16_t*>(
         IncrementPointerByBytes(address, dequeue_output_result.offset));

--- a/starboard/android/shared/audio_decoder.cc
+++ b/starboard/android/shared/audio_decoder.cc
@@ -14,12 +14,11 @@
 
 #include "starboard/android/shared/audio_decoder.h"
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/audio_sink.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // Can be locally set to |1| for verbose audio decoding.  Verbose audio
 // decoding will log the following transitions that take place for each audio
@@ -51,9 +50,8 @@
 namespace starboard {
 namespace {
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaLocalRef;
 using std::placeholders::_1;
 using std::placeholders::_2;
 

--- a/starboard/android/shared/audio_output_manager.cc
+++ b/starboard/android/shared/audio_output_manager.cc
@@ -30,7 +30,6 @@ namespace starboard {
 namespace {
 
 using jni_zero::JavaParamRef;
-using jni_zero::ScopedJavaGlobalRef;
 using jni_zero::ScopedJavaLocalRef;
 
 // Constants for output types from

--- a/starboard/android/shared/audio_output_manager.cc
+++ b/starboard/android/shared/audio_output_manager.cc
@@ -29,7 +29,6 @@ namespace starboard {
 
 namespace {
 
-using jni_zero::AttachCurrentThread;
 using jni_zero::JavaParamRef;
 using jni_zero::ScopedJavaGlobalRef;
 using jni_zero::ScopedJavaLocalRef;
@@ -142,7 +141,7 @@ SbMediaAudioConnector GetConnectorFromAndroidOutputType(
 }  // namespace
 
 AudioOutputManager::AudioOutputManager() {
-  JNIEnv* env = AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   SB_DCHECK(env);
   j_audio_output_manager_ =
       StarboardBridge::GetInstance()->GetAudioOutputManager(env);

--- a/starboard/android/shared/audio_output_manager.cc
+++ b/starboard/android/shared/audio_output_manager.cc
@@ -29,10 +29,10 @@ namespace starboard {
 
 namespace {
 
-using base::android::AttachCurrentThread;
-using base::android::JavaParamRef;
-using base::android::ScopedJavaGlobalRef;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::JavaParamRef;
+using jni_zero::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaLocalRef;
 
 // Constants for output types from
 // https://developer.android.com/reference/android/media/AudioDeviceInfo.

--- a/starboard/android/shared/audio_output_manager.h
+++ b/starboard/android/shared/audio_output_manager.h
@@ -17,10 +17,9 @@
 
 #include <jni.h>
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
 #include "base/memory/singleton.h"
 #include "starboard/media.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -29,7 +28,7 @@ class AudioOutputManager {
   // Returns the singleton.
   static AudioOutputManager* GetInstance();
 
-  base::android::ScopedJavaLocalRef<jobject> CreateAudioTrackBridge(
+  jni_zero::ScopedJavaLocalRef<jobject> CreateAudioTrackBridge(
       JNIEnv* env,
       int sample_type,
       int sample_rate,
@@ -39,11 +38,11 @@ class AudioOutputManager {
       jboolean is_web_audio);
 
   void DestroyAudioTrackBridge(JNIEnv* env,
-                               base::android::ScopedJavaLocalRef<jobject>& obj);
+                               jni_zero::ScopedJavaLocalRef<jobject>& obj);
 
   bool GetOutputDeviceInfo(JNIEnv* env,
                            jint index,
-                           base::android::ScopedJavaLocalRef<jobject>& obj);
+                           jni_zero::ScopedJavaLocalRef<jobject>& obj);
 
   int GetMinBufferSize(JNIEnv* env,
                        jint sample_type,
@@ -78,7 +77,7 @@ class AudioOutputManager {
   friend struct base::DefaultSingletonTraits<AudioOutputManager>;
 
   // Java AudioOutputManager instance.
-  base::android::ScopedJavaGlobalRef<jobject> j_audio_output_manager_;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_audio_output_manager_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/audio_permission_requester.cc
+++ b/starboard/android/shared/audio_permission_requester.cc
@@ -14,17 +14,15 @@
 
 #include "starboard/android/shared/audio_permission_requester.h"
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
 #include "starboard/android/shared/starboard_bridge.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "cobalt/android/jni_headers/AudioPermissionRequester_jni.h"
 
 namespace starboard {
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaLocalRef;
 
 bool RequestRecordAudioPermission(JNIEnv* env) {
   ScopedJavaLocalRef<jobject> j_audio_permission_requester =

--- a/starboard/android/shared/audio_permission_requester.cc
+++ b/starboard/android/shared/audio_permission_requester.cc
@@ -21,11 +21,9 @@
 #include "cobalt/android/jni_headers/AudioPermissionRequester_jni.h"
 
 namespace starboard {
-using jni_zero::AttachCurrentThread;
-using jni_zero::ScopedJavaLocalRef;
 
 bool RequestRecordAudioPermission(JNIEnv* env) {
-  ScopedJavaLocalRef<jobject> j_audio_permission_requester =
+  jni_zero::ScopedJavaLocalRef<jobject> j_audio_permission_requester =
       StarboardBridge::GetInstance()->GetAudioPermissionRequester(env);
 
   jboolean j_permission =

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -28,8 +28,6 @@
 namespace starboard {
 namespace {
 
-using jni_zero::ScopedJavaLocalRef;
-
 // Soft limit to ensure that the user of AudioRendererPassthrough won't keep
 // pushing data when there are enough decoded audio buffers.
 constexpr int kMaxDecodedAudios = 64;

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -23,11 +23,12 @@
 #include "starboard/common/string.h"
 #include "starboard/common/thread_options.h"
 #include "starboard/common/time.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 namespace {
 
-using base::android::ScopedJavaLocalRef;
+using jni_zero::ScopedJavaLocalRef;
 
 // Soft limit to ensure that the user of AudioRendererPassthrough won't keep
 // pushing data when there are enough decoded audio buffers.

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -22,12 +22,13 @@
 #include "starboard/android/shared/audio_track_audio_sink_type.h"
 #include "starboard/common/check_op.h"
 #include "starboard/thread.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
 namespace {
 
-using base::android::ScopedJavaLocalRef;
+using jni_zero::ScopedJavaLocalRef;
 
 const int kCheckpointFramesInterval = 1024;
 

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -28,8 +28,6 @@ namespace starboard {
 
 namespace {
 
-using jni_zero::ScopedJavaLocalRef;
-
 const int kCheckpointFramesInterval = 1024;
 
 // Helper function to compute the size of the two valid starboard audio sample

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -21,7 +21,6 @@
 #include <string>
 #include <vector>
 
-#include "base/android/jni_android.h"
 #include "starboard/android/shared/audio_output_manager.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/common/check_op.h"
@@ -32,11 +31,12 @@
 #include "starboard/shared/starboard/media/media_util.h"
 #include "starboard/shared/starboard/player/filter/common.h"
 #include "starboard/thread.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 namespace {
 
-using ::base::android::AttachCurrentThread;
+using jni_zero::AttachCurrentThread;
 
 // The maximum number of frames that can be written to android audio track per
 // write request. If we don't set this cap for writing frames to audio track,
@@ -206,7 +206,7 @@ void AudioTrackAudioSink::SetPlaybackRate(double playback_rate) {
 
 // TODO: Break down the function into manageable pieces.
 void AudioTrackAudioSink::AudioThreadFunc() {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
   int frames_in_audio_track = 0;
   int audio_track_play_state = PLAYSTATE_STOPPED;
 

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -22,6 +22,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/starboard/media/media_util.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "cobalt/android/jni_headers/AudioTrackBridge_jni.h"
@@ -31,11 +32,10 @@ namespace starboard {
 
 namespace {
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using ::base::android::AttachCurrentThread;
-using ::base::android::JavaParamRef;
-using ::base::android::ScopedJavaGlobalRef;
-using ::base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::JavaParamRef;
+using jni_zero::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaLocalRef;
 
 const jint kNoOffset = 0;
 

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -21,9 +21,8 @@
 #include <cstdint>
 #include <optional>
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
 #include "starboard/media.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -49,52 +48,50 @@ class AudioTrackBridge {
     return !j_audio_track_bridge_.is_null() && !j_audio_data_.is_null();
   }
 
-  void Play(JNIEnv* env = base::android::AttachCurrentThread());
-  void Pause(JNIEnv* env = base::android::AttachCurrentThread());
-  void Stop(JNIEnv* env = base::android::AttachCurrentThread());
-  void PauseAndFlush(JNIEnv* env = base::android::AttachCurrentThread());
+  void Play(JNIEnv* env = jni_zero::AttachCurrentThread());
+  void Pause(JNIEnv* env = jni_zero::AttachCurrentThread());
+  void Stop(JNIEnv* env = jni_zero::AttachCurrentThread());
+  void PauseAndFlush(JNIEnv* env = jni_zero::AttachCurrentThread());
 
   // Returns zero or the positive number of samples written, or a negative error
   // code.
   int WriteSample(const float* samples,
                   int num_of_samples,
-                  JNIEnv* env = base::android::AttachCurrentThread());
+                  JNIEnv* env = jni_zero::AttachCurrentThread());
   int WriteSample(const uint16_t* samples,
                   int num_of_samples,
                   int64_t sync_time,
-                  JNIEnv* env = base::android::AttachCurrentThread());
+                  JNIEnv* env = jni_zero::AttachCurrentThread());
   // This is used by passthrough, it treats samples as if they are in bytes.
   // Returns zero or the positive number of samples written, or a negative error
   // code.
   int WriteSample(const uint8_t* buffer,
                   int num_of_samples,
                   int64_t sync_time,
-                  JNIEnv* env = base::android::AttachCurrentThread());
+                  JNIEnv* env = jni_zero::AttachCurrentThread());
 
   void SetPlaybackRate(double playback_rate,
-                       JNIEnv* env = base::android::AttachCurrentThread());
-  void SetVolume(double volume,
-                 JNIEnv* env = base::android::AttachCurrentThread());
+                       JNIEnv* env = jni_zero::AttachCurrentThread());
+  void SetVolume(double volume, JNIEnv* env = jni_zero::AttachCurrentThread());
 
   // |updated_at| contains the timestamp when the audio timestamp is updated on
   // return.  It can be nullptr.
   int64_t GetAudioTimestamp(int64_t* updated_at,
-                            JNIEnv* env = base::android::AttachCurrentThread());
+                            JNIEnv* env = jni_zero::AttachCurrentThread());
   bool GetAndResetHasAudioDeviceChanged(
-      JNIEnv* env = base::android::AttachCurrentThread());
-  int GetUnderrunCount(JNIEnv* env = base::android::AttachCurrentThread());
-  int GetStartThresholdInFrames(
-      JNIEnv* env = base::android::AttachCurrentThread());
-  int GetPlayState(JNIEnv* env = base::android::AttachCurrentThread());
+      JNIEnv* env = jni_zero::AttachCurrentThread());
+  int GetUnderrunCount(JNIEnv* env = jni_zero::AttachCurrentThread());
+  int GetStartThresholdInFrames(JNIEnv* env = jni_zero::AttachCurrentThread());
+  int GetPlayState(JNIEnv* env = jni_zero::AttachCurrentThread());
 
  private:
   int max_samples_per_write_;
 
-  base::android::ScopedJavaGlobalRef<jobject> j_audio_track_bridge_;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_audio_track_bridge_;
   // The audio data has to be copied into a Java Array before writing into the
   // audio track. Allocating a large array and saves as a member variable
   // avoids an array being allocated repeatedly.
-  base::android::ScopedJavaGlobalRef<jobject> j_audio_data_;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_audio_data_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/crash_handler.cc
+++ b/starboard/android/shared/crash_handler.cc
@@ -14,9 +14,9 @@
 
 #include "starboard/extension/crash_handler.h"
 
-#include "base/android/jni_android.h"
 #include "starboard/android/shared/crash_handler.h"
 #include "starboard/android/shared/starboard_bridge.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -25,7 +25,7 @@ bool OverrideCrashpadAnnotations(CrashpadAnnotations* crashpad_annotations) {
 }
 
 bool SetString(const char* key, const char* value) {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   StarboardBridge::GetInstance()->SetCrashContext(env, key, value);
   return true;
 }

--- a/starboard/android/shared/decode_target.cc
+++ b/starboard/android/shared/decode_target.cc
@@ -32,8 +32,6 @@
 namespace starboard {
 namespace {
 
-using jni_zero::AttachCurrentThread;
-
 void RunOnContextRunner(void* context) {
   std::function<void()>* closure = static_cast<std::function<void()>*>(context);
   (*closure)();
@@ -78,7 +76,7 @@ void DecodeTarget::CreateOnContextRunner() {
   GL_CALL(glTexParameteri(GL_TEXTURE_EXTERNAL_OES, GL_TEXTURE_WRAP_T,
                           GL_CLAMP_TO_EDGE));
 
-  JNIEnv* env = AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   // Wrap the GL texture in an Android SurfaceTexture object.
   surface_texture_ =
       VideoSurfaceTextureBridge::CreateVideoSurfaceTexture(env, texture);

--- a/starboard/android/shared/decode_target.cc
+++ b/starboard/android/shared/decode_target.cc
@@ -27,11 +27,12 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/gles/gl_call.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 namespace {
 
-using base::android::AttachCurrentThread;
+using jni_zero::AttachCurrentThread;
 
 void RunOnContextRunner(void* context) {
   std::function<void()>* closure = static_cast<std::function<void()>*>(context);

--- a/starboard/android/shared/decode_target.h
+++ b/starboard/android/shared/decode_target.h
@@ -19,10 +19,10 @@
 #include <android/native_window.h>
 #include <jni.h>
 
-#include "base/android/jni_android.h"
 #include "starboard/common/size.h"
 #include "starboard/decode_target.h"
 #include "starboard/shared/starboard/decode_target/decode_target_internal.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -32,10 +32,10 @@ class DecodeTarget final : public SbDecodeTargetPrivate {
 
   bool GetInfo(SbDecodeTargetInfo* out_info) final;
 
-  const base::android::ScopedJavaGlobalRef<jobject>& surface_texture() const {
+  const jni_zero::ScopedJavaGlobalRef<jobject>& surface_texture() const {
     return surface_texture_;
   }
-  const base::android::ScopedJavaGlobalRef<jobject>& surface() const {
+  const jni_zero::ScopedJavaGlobalRef<jobject>& surface() const {
     return surface_;
   }
 
@@ -58,8 +58,8 @@ class DecodeTarget final : public SbDecodeTargetPrivate {
 
   // Java objects which wrap the texture.  We hold on to global references
   // to these objects.
-  base::android::ScopedJavaGlobalRef<jobject> surface_texture_;
-  base::android::ScopedJavaGlobalRef<jobject> surface_;
+  jni_zero::ScopedJavaGlobalRef<jobject> surface_texture_;
+  jni_zero::ScopedJavaGlobalRef<jobject> surface_;
   ANativeWindow* native_window_;
 
   SbDecodeTargetInfo info_;

--- a/starboard/android/shared/display_util.cc
+++ b/starboard/android/shared/display_util.cc
@@ -14,16 +14,16 @@
 
 #include "starboard/android/shared/display_util.h"
 
-#include "base/android/jni_android.h"
 #include "cobalt/android/jni_headers/DisplayUtil_jni.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/shared/starboard/media/mime_supportability_cache.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
-using base::android::ScopedJavaLocalRef;
+using jni_zero::ScopedJavaLocalRef;
 
 DisplayUtil::Dpi DisplayUtil::GetDisplayDpi() {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
 
   ScopedJavaLocalRef<jobject> display_dpi_obj =
       Java_DisplayUtil_getDisplayDpi(env);

--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -20,6 +20,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -41,7 +42,8 @@ const char* g_app_cache_dir = NULL;
 const char* g_app_lib_dir = NULL;
 
 namespace {
-using ::base::android::ScopedJavaGlobalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaGlobalRef;
 
 // A ScopedJavaGlobalRef<jobject> representing the Android AssetManager
 // instance. This global reference ensures the AssetManager Java object
@@ -55,7 +57,7 @@ void SbFileAndroidInitialize(ScopedJavaGlobalRef<jobject> asset_manager,
                              const std::string& files_dir,
                              const std::string& cache_dir,
                              const std::string& native_library_dir) {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
 
   SB_DCHECK(g_java_asset_manager.is_null());
   SB_DCHECK_EQ(g_asset_manager, nullptr);

--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -42,7 +42,6 @@ const char* g_app_cache_dir = NULL;
 const char* g_app_lib_dir = NULL;
 
 namespace {
-using jni_zero::AttachCurrentThread;
 using jni_zero::ScopedJavaGlobalRef;
 
 // A ScopedJavaGlobalRef<jobject> representing the Android AssetManager
@@ -57,7 +56,7 @@ void SbFileAndroidInitialize(ScopedJavaGlobalRef<jobject> asset_manager,
                              const std::string& files_dir,
                              const std::string& cache_dir,
                              const std::string& native_library_dir) {
-  JNIEnv* env = AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
 
   SB_DCHECK(g_java_asset_manager.is_null());
   SB_DCHECK_EQ(g_asset_manager, nullptr);

--- a/starboard/android/shared/file_internal.h
+++ b/starboard/android/shared/file_internal.h
@@ -23,6 +23,7 @@
 
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/shared/internal_only.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 struct SbFilePrivate {
   // Note: Only one of these two fields will be valid for any given file.
@@ -44,7 +45,7 @@ extern const char* g_app_cache_dir;
 extern const char* g_app_lib_dir;
 
 void SbFileAndroidInitialize(
-    base::android::ScopedJavaGlobalRef<jobject> asset_manager,
+    jni_zero::ScopedJavaGlobalRef<jobject> asset_manager,
     const std::string& files_dir,
     const std::string& cache_dir,
     const std::string& native_library_dir);

--- a/starboard/android/shared/get_home_directory.cc
+++ b/starboard/android/shared/get_home_directory.cc
@@ -26,8 +26,6 @@
 
 namespace starboard {
 
-using ::jni_zero::ScopedJavaGlobalRef;
-
 bool GetHomeDirectory(char* out_path, int path_size) {
   int len = ::starboard::strlcpy(out_path, g_app_files_dir, path_size);
   return len < path_size;

--- a/starboard/android/shared/get_home_directory.cc
+++ b/starboard/android/shared/get_home_directory.cc
@@ -22,10 +22,11 @@
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
-using ::base::android::ScopedJavaGlobalRef;
+using ::jni_zero::ScopedJavaGlobalRef;
 
 bool GetHomeDirectory(char* out_path, int path_size) {
   int len = ::starboard::strlcpy(out_path, g_app_files_dir, path_size);

--- a/starboard/android/shared/graphics.cc
+++ b/starboard/android/shared/graphics.cc
@@ -21,8 +21,6 @@
 
 namespace starboard {
 
-using jni_zero::AttachCurrentThread;
-
 namespace {
 
 float GetMaximumFrameIntervalInMilliseconds() {
@@ -71,7 +69,7 @@ bool DefaultGetRenderRootTransform(float* m00,
 }
 
 void ReportFullyDrawn() {
-  JNIEnv* env = AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   StarboardBridge::GetInstance()->ReportFullyDrawn(env);
 }
 

--- a/starboard/android/shared/graphics.cc
+++ b/starboard/android/shared/graphics.cc
@@ -17,11 +17,11 @@
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/log.h"
 #include "starboard/extension/graphics.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
+using jni_zero::AttachCurrentThread;
 
 namespace {
 

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -19,10 +19,8 @@
 #include <mutex>
 #include <utility>
 
-#include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
-#include "base/android/scoped_java_ref.h"
 #include "cobalt/android/jni_headers/MediaCodecUtil_jni.h"
 #include "starboard/android/shared/audio_output_manager.h"
 #include "starboard/android/shared/media_common.h"
@@ -35,17 +33,18 @@
 #include "starboard/shared/starboard/media/key_system_supportability_cache.h"
 #include "starboard/shared/starboard/media/mime_supportability_cache.h"
 #include "starboard/thread.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 namespace {
 
-using base::android::AttachCurrentThread;
 using base::android::ConvertJavaStringToUTF8;
 using base::android::ConvertUTF8ToJavaString;
-using base::android::JavaParamRef;
-using base::android::ScopedJavaGlobalRef;
-using base::android::ScopedJavaLocalRef;
 using features::FeatureList;
+using jni_zero::AttachCurrentThread;
+using jni_zero::JavaParamRef;
+using jni_zero::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaLocalRef;
 
 // https://developer.android.com/reference/android/view/Display.HdrCapabilities.html#HDR_TYPE_HDR10
 const jint HDR_TYPE_DOLBY_VISION = 1;
@@ -71,7 +70,7 @@ Range ConvertJavaRangeToRange(JNIEnv* env, jobject j_range) {
 
 template <typename GetRangeFunc>
 Range GetRange(JNIEnv* env,
-               const base::android::JavaRef<jobject>& j_capabilities,
+               const jni_zero::JavaRef<jobject>& j_capabilities,
                GetRangeFunc get_range_func) {
   SB_CHECK(env);
   SB_CHECK(j_capabilities);
@@ -285,7 +284,7 @@ VideoCodecCapability::VideoCodecCapability(
     bool is_tunnel_sup,
     bool is_software_decoder,
     bool is_hdr_capable,
-    base::android::ScopedJavaGlobalRef<jobject> j_video_cap,
+    jni_zero::ScopedJavaGlobalRef<jobject> j_video_cap,
     Range supported_widths,
     Range supported_heights,
     Range supported_bitrates,

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -284,7 +284,7 @@ VideoCodecCapability::VideoCodecCapability(
     bool is_tunnel_sup,
     bool is_software_decoder,
     bool is_hdr_capable,
-    jni_zero::ScopedJavaGlobalRef<jobject> j_video_cap,
+    ScopedJavaGlobalRef<jobject> j_video_cap,
     Range supported_widths,
     Range supported_heights,
     Range supported_bitrates,

--- a/starboard/android/shared/media_capabilities_cache.h
+++ b/starboard/android/shared/media_capabilities_cache.h
@@ -25,9 +25,9 @@
 #include <string>
 #include <vector>
 
-#include "base/android/jni_android.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -44,7 +44,7 @@ struct Range {
 class CodecCapability {
  public:
   CodecCapability(JNIEnv* env,
-                  base::android::ScopedJavaLocalRef<jobject>& j_codec_info);
+                  jni_zero::ScopedJavaLocalRef<jobject>& j_codec_info);
   virtual ~CodecCapability() {}
 
   const std::string& name() const { return name_; }
@@ -75,8 +75,8 @@ class AudioCodecCapability : public CodecCapability {
  public:
   AudioCodecCapability(
       JNIEnv* env,
-      base::android::ScopedJavaLocalRef<jobject>& j_codec_info,
-      base::android::ScopedJavaLocalRef<jobject>& j_audio_capabilities);
+      jni_zero::ScopedJavaLocalRef<jobject>& j_codec_info,
+      jni_zero::ScopedJavaLocalRef<jobject>& j_audio_capabilities);
   ~AudioCodecCapability() override {}
 
   bool IsBitrateSupported(int bitrate) const;
@@ -100,8 +100,8 @@ class VideoCodecCapability : public CodecCapability {
  public:
   VideoCodecCapability(
       JNIEnv* env,
-      base::android::ScopedJavaLocalRef<jobject>& j_codec_info,
-      base::android::ScopedJavaLocalRef<jobject>& j_video_capabilities);
+      jni_zero::ScopedJavaLocalRef<jobject>& j_codec_info,
+      jni_zero::ScopedJavaLocalRef<jobject>& j_video_capabilities);
   ~VideoCodecCapability() override {}
 
   bool is_software_decoder() const { return is_software_decoder_; }
@@ -125,7 +125,7 @@ class VideoCodecCapability : public CodecCapability {
                        bool is_tunnel_sup,
                        bool is_software_decoder,
                        bool is_hdr_capable,
-                       base::android::ScopedJavaGlobalRef<jobject> j_video_cap,
+                       jni_zero::ScopedJavaGlobalRef<jobject> j_video_cap,
                        Range supported_widths,
                        Range supported_heights,
                        Range supported_bitrates,
@@ -137,7 +137,7 @@ class VideoCodecCapability : public CodecCapability {
 
   const bool is_software_decoder_;
   const bool is_hdr_capable_;
-  const base::android::ScopedJavaGlobalRef<jobject> j_video_capabilities_;
+  const jni_zero::ScopedJavaGlobalRef<jobject> j_video_capabilities_;
   const Range supported_widths_;
   const Range supported_heights_;
   const Range supported_bitrates_;

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -19,6 +19,7 @@
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/common/media.h"
 #include "starboard/common/string.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "cobalt/android/jni_headers/MediaCodecBridgeBuilder_jni.h"
@@ -28,11 +29,11 @@ namespace starboard {
 namespace {
 
 using base::android::ConvertJavaStringToUTF8;
-using base::android::JavaParamRef;
-using base::android::ScopedJavaLocalRef;
 using base::android::ToJavaByteArray;
 using base::android::ToJavaIntArray;
 using jni_zero::AttachCurrentThread;
+using jni_zero::JavaParamRef;
+using jni_zero::ScopedJavaLocalRef;
 
 // See
 // https://developer.android.com/reference/android/media/MediaFormat.html#COLOR_RANGE_FULL.
@@ -457,7 +458,7 @@ void MediaCodecBridge::OnMediaCodecError(
     JNIEnv* env,
     jboolean is_recoverable,
     jboolean is_transient,
-    const base::android::JavaParamRef<jstring>& diagnostic_info) {
+    const jni_zero::JavaParamRef<jstring>& diagnostic_info) {
   std::string diagnostic_info_in_str =
       ConvertJavaStringToUTF8(env, diagnostic_info);
   handler_->OnMediaCodecError(is_recoverable, is_transient,

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -458,7 +458,7 @@ void MediaCodecBridge::OnMediaCodecError(
     JNIEnv* env,
     jboolean is_recoverable,
     jboolean is_transient,
-    const jni_zero::JavaParamRef<jstring>& diagnostic_info) {
+    const JavaParamRef<jstring>& diagnostic_info) {
   std::string diagnostic_info_in_str =
       ConvertJavaStringToUTF8(env, diagnostic_info);
   handler_->OnMediaCodecError(is_recoverable, is_transient,

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -19,12 +19,12 @@
 #include <optional>
 #include <string>
 
-#include "base/android/scoped_java_ref.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/result.h"
 #include "starboard/common/size.h"
 #include "starboard/shared/starboard/media/media_util.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -140,7 +140,7 @@ class MediaCodecBridge {
 
   // It is the responsibility of the client to manage the lifetime of the
   // jobject that |GetInputBuffer| returns.
-  base::android::ScopedJavaLocalRef<jobject> GetInputBuffer(jint index);
+  jni_zero::ScopedJavaLocalRef<jobject> GetInputBuffer(jint index);
   jint QueueInputBuffer(jint index,
                         jint offset,
                         jint size,
@@ -155,7 +155,7 @@ class MediaCodecBridge {
 
   // It is the responsibility of the client to manage the lifetime of the
   // jobject that |GetOutputBuffer| returns.
-  base::android::ScopedJavaLocalRef<jobject> GetOutputBuffer(jint index);
+  jni_zero::ScopedJavaLocalRef<jobject> GetOutputBuffer(jint index);
   void ReleaseOutputBuffer(jint index, jboolean render);
   void ReleaseOutputBufferAtTimestamp(jint index, jlong render_timestamp_ns);
 
@@ -169,7 +169,7 @@ class MediaCodecBridge {
       JNIEnv* env,
       jboolean is_recoverable,
       jboolean is_transient,
-      const base::android::JavaParamRef<jstring>& diagnostic_info);
+      const jni_zero::JavaParamRef<jstring>& diagnostic_info);
   void OnMediaCodecInputBufferAvailable(JNIEnv* env, jint buffer_index);
   void OnMediaCodecOutputBufferAvailable(JNIEnv* env,
                                          jint buffer_index,
@@ -191,7 +191,7 @@ class MediaCodecBridge {
   void Initialize(jobject j_media_codec_bridge);
 
   Handler* const handler_;
-  base::android::ScopedJavaGlobalRef<jobject> j_media_codec_bridge_ = NULL;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_media_codec_bridge_ = NULL;
 
   MediaCodecBridge(const MediaCodecBridge&) = delete;
   void operator=(const MediaCodecBridge&) = delete;

--- a/starboard/android/shared/media_decoder.cc
+++ b/starboard/android/shared/media_decoder.cc
@@ -17,8 +17,6 @@
 #include <sched.h>
 #include <unistd.h>
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/memfd_media_buffer_pool.h"
 #include "starboard/audio_sink.h"
@@ -26,13 +24,13 @@
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
 #include "starboard/thread.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 namespace {
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaLocalRef;
 
 const jint kNoOffset = 0;
 const jlong kNoPts = 0;

--- a/starboard/android/shared/media_drm_bridge.cc
+++ b/starboard/android/shared/media_drm_bridge.cc
@@ -24,6 +24,7 @@
 #include "base/memory/raw_ref.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "cobalt/android/jni_headers/MediaDrmBridge_jni.h"
@@ -31,13 +32,13 @@
 namespace starboard {
 namespace {
 
-using base::android::AttachCurrentThread;
 using base::android::ConvertJavaStringToUTF8;
 using base::android::ConvertUTF8ToJavaString;
 using base::android::JavaByteArrayToString;
-using base::android::JavaParamRef;
-using base::android::ScopedJavaLocalRef;
 using base::android::ToJavaByteArray;
+using jni_zero::AttachCurrentThread;
+using jni_zero::JavaParamRef;
+using jni_zero::ScopedJavaLocalRef;
 
 using DrmOperationResult = MediaDrmBridge::OperationResult;
 
@@ -98,7 +99,7 @@ SbDrmKeyStatus ToSbDrmKeyStatus(jint status_code) {
 
 std::string JavaByteArrayToString(
     JNIEnv* env,
-    const base::android::JavaRef<jbyteArray>& j_byte_array) {
+    const jni_zero::JavaRef<jbyteArray>& j_byte_array) {
   std::string out;
   JavaByteArrayToString(env, j_byte_array, &out);
   return out;

--- a/starboard/android/shared/media_drm_bridge.h
+++ b/starboard/android/shared/media_drm_bridge.h
@@ -22,11 +22,10 @@
 #include <string_view>
 #include <vector>
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
 #include "base/memory/raw_ref.h"
 #include "starboard/common/pass_key.h"
 #include "starboard/drm.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -94,16 +93,15 @@ class MediaDrmBridge {
   const void* GetMetrics(int* size);
   bool CreateMediaCryptoSession();
 
-  void OnSessionMessage(
-      JNIEnv* env,
-      jint ticket,
-      const base::android::JavaParamRef<jbyteArray>& session_id,
-      jint request_type,
-      const base::android::JavaParamRef<jbyteArray>& message);
+  void OnSessionMessage(JNIEnv* env,
+                        jint ticket,
+                        const jni_zero::JavaParamRef<jbyteArray>& session_id,
+                        jint request_type,
+                        const jni_zero::JavaParamRef<jbyteArray>& message);
   void OnKeyStatusChange(
       JNIEnv* env,
-      const base::android::JavaParamRef<jbyteArray>& session_id,
-      const base::android::JavaParamRef<jobjectArray>& key_information);
+      const jni_zero::JavaParamRef<jbyteArray>& session_id,
+      const jni_zero::JavaParamRef<jobjectArray>& key_information);
 
   static bool IsWidevineSupported(JNIEnv* env);
   static bool IsCbcsSupported(JNIEnv* env);
@@ -117,11 +115,11 @@ class MediaDrmBridge {
   // The factory method guarantees that |j_media_drm_bridge_| is non-null.
   // Instances are only returned if initialization succeeds; therefore, this
   // member is guaranteed to be valid for the lifetime of the object.
-  base::android::ScopedJavaGlobalRef<jobject> j_media_drm_bridge_;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_media_drm_bridge_;
 
   // |j_media_crypto_| is non-null after initialization, but may be reset
   // via CreateMediaCryptoSession() if a session creation failure occurs.
-  base::android::ScopedJavaGlobalRef<jobject> j_media_crypto_;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_media_crypto_;
 };
 
 std::ostream& operator<<(std::ostream& os, DrmOperationStatus);

--- a/starboard/android/shared/microphone_impl.cc
+++ b/starboard/android/shared/microphone_impl.cc
@@ -30,11 +30,11 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/starboard/thread_checker.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
+using jni_zero::AttachCurrentThread;
 
 namespace {
 

--- a/starboard/android/shared/platform_info.cc
+++ b/starboard/android/shared/platform_info.cc
@@ -16,18 +16,17 @@
 
 #include <string>
 
-#include "base/android/jni_android.h"
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
 #include "starboard/extension/platform_info.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
 namespace {
 
-// TODO: b/372559388 - Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
+using jni_zero::AttachCurrentThread;
 
 bool GetFirmwareVersionDetails(char* out_value, int value_length) {
   JNIEnv* env = AttachCurrentThread();

--- a/starboard/android/shared/platform_service.cc
+++ b/starboard/android/shared/platform_service.cc
@@ -39,8 +39,10 @@ namespace starboard {
 
 namespace {
 
+using jni_zero::AttachCurrentThread;
+
 bool Has(const char* name) {
-  JNIEnv* env = jni_zero::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
   return starboard::StarboardBridge::GetInstance()->HasCobaltService(env, name);
 }
 
@@ -48,7 +50,7 @@ CobaltExtensionPlatformService Open(void* context,
                                     const char* name,
                                     ReceiveMessageCallback receive_callback) {
   SB_DCHECK(context);
-  JNIEnv* env = jni_zero::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
 
   if (!Has(name)) {
     SB_LOG(ERROR) << "Can't open Service " << name;
@@ -74,7 +76,7 @@ void Close(CobaltExtensionPlatformService service) {
     return;
   }
 
-  JNIEnv* env = jni_zero::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
   Java_CobaltService_onClose(env, service->cobalt_service);
 
   starboard::StarboardBridge::GetInstance()->CloseCobaltService(
@@ -97,7 +99,7 @@ void* Send(CobaltExtensionPlatformService service,
     return nullptr;
   }
 
-  JNIEnv* env = jni_zero::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
   auto j_data = base::android::ToJavaByteArray(
       env, reinterpret_cast<const uint8_t*>(data), length);
   auto j_response = Java_CobaltService_receiveFromClient(

--- a/starboard/android/shared/platform_service.cc
+++ b/starboard/android/shared/platform_service.cc
@@ -17,7 +17,6 @@
 #include <memory>
 #include <vector>
 
-#include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "cobalt/android/jni_headers/CobaltService_jni.h"
 #include "starboard/android/shared/starboard_bridge.h"
@@ -25,12 +24,13 @@
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
 #include "starboard/extension/platform_service.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 typedef struct CobaltExtensionPlatformServicePrivate {
   void* context;
   ReceiveMessageCallback receive_callback;
   std::string name;
-  base::android::ScopedJavaGlobalRef<jobject> cobalt_service;
+  jni_zero::ScopedJavaGlobalRef<jobject> cobalt_service;
 
   ~CobaltExtensionPlatformServicePrivate() = default;
 } CobaltExtensionPlatformServicePrivate;
@@ -40,7 +40,7 @@ namespace starboard {
 namespace {
 
 bool Has(const char* name) {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   return starboard::StarboardBridge::GetInstance()->HasCobaltService(env, name);
 }
 
@@ -48,7 +48,7 @@ CobaltExtensionPlatformService Open(void* context,
                                     const char* name,
                                     ReceiveMessageCallback receive_callback) {
   SB_DCHECK(context);
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
 
   if (!Has(name)) {
     SB_LOG(ERROR) << "Can't open Service " << name;
@@ -74,7 +74,7 @@ void Close(CobaltExtensionPlatformService service) {
     return;
   }
 
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   Java_CobaltService_onClose(env, service->cobalt_service);
 
   starboard::StarboardBridge::GetInstance()->CloseCobaltService(
@@ -97,7 +97,7 @@ void* Send(CobaltExtensionPlatformService service,
     return nullptr;
   }
 
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   auto j_data = base::android::ToJavaByteArray(
       env, reinterpret_cast<const uint8_t*>(data), length);
   auto j_response = Java_CobaltService_receiveFromClient(
@@ -142,7 +142,7 @@ const void* GetPlatformServiceApiAndroid() {
 void JNI_CobaltService_NativeSendToClient(
     JNIEnv* env,
     jlong nativeService,
-    const base::android::JavaParamRef<jbyteArray>& j_data) {
+    const jni_zero::JavaParamRef<jbyteArray>& j_data) {
   auto* service =
       reinterpret_cast<CobaltExtensionPlatformServicePrivate*>(nativeService);
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <jni.h>
+
 #include <atomic>
 #include <memory>
 #include <string>
@@ -44,12 +46,13 @@
 #include "starboard/shared/starboard/player/filter/video_render_algorithm_impl.h"
 #include "starboard/shared/starboard/player/filter/video_renderer_internal_impl.h"
 #include "starboard/shared/starboard/player/filter/video_renderer_sink.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 namespace {
 
-using base::android::AttachCurrentThread;
 using features::FeatureList;
+using jni_zero::AttachCurrentThread;
 
 // On some platforms tunnel mode is only supported in the secure pipeline.  Set
 // the following variable to true to force creating a secure pipeline in tunnel

--- a/starboard/android/shared/player_set_bounds.cc
+++ b/starboard/android/shared/player_set_bounds.cc
@@ -16,12 +16,14 @@
 #include "starboard/player.h"
 // clang-format on
 
+#include <jni.h>
+
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/starboard/player/player_internal.h"
+#include "third_party/jni_zero/jni_zero.h"
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
+using jni_zero::AttachCurrentThread;
 
 void SbPlayerSetBounds(SbPlayer player,
                        int z_index,

--- a/starboard/android/shared/player_set_bounds.cc
+++ b/starboard/android/shared/player_set_bounds.cc
@@ -23,8 +23,6 @@
 #include "starboard/shared/starboard/player/player_internal.h"
 #include "third_party/jni_zero/jni_zero.h"
 
-using jni_zero::AttachCurrentThread;
-
 void SbPlayerSetBounds(SbPlayer player,
                        int z_index,
                        int x,
@@ -36,7 +34,7 @@ void SbPlayerSetBounds(SbPlayer player,
     return;
   }
 
-  JNIEnv* env = AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   starboard::StarboardBridge::GetInstance()->SetVideoSurfaceBounds(
       env, x, y, width, height);
   player->SetBounds(z_index, x, y, width, height);

--- a/starboard/android/shared/runtime_resource_overlay.cc
+++ b/starboard/android/shared/runtime_resource_overlay.cc
@@ -18,12 +18,11 @@
 
 #include "starboard/android/shared/runtime_resource_overlay.h"
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/log.h"
 #include "starboard/common/once.h"
 #include "starboard/common/string.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -31,8 +30,8 @@ SB_ONCE_INITIALIZE_FUNCTION(RuntimeResourceOverlay,
                             RuntimeResourceOverlay::GetInstance)
 
 RuntimeResourceOverlay::RuntimeResourceOverlay() {
-  JNIEnv* env = base::android::AttachCurrentThread();
-  base::android::ScopedJavaLocalRef<jobject> resource_overlay =
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+  jni_zero::ScopedJavaLocalRef<jobject> resource_overlay =
       StarboardBridge::GetInstance()->GetResourceOverlay(env);
 
   // Retrieve all Runtime Resource Overlay variables during initialization, so

--- a/starboard/android/shared/speech_synthesis_cancel.cc
+++ b/starboard/android/shared/speech_synthesis_cancel.cc
@@ -17,13 +17,13 @@
 // clang-format on
 
 #include "starboard/android/shared/starboard_bridge.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "cobalt/android/jni_headers/CobaltTextToSpeechHelper_jni.h"
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaLocalRef;
 
 void SbSpeechSynthesisCancel() {
   JNIEnv* env = AttachCurrentThread();

--- a/starboard/android/shared/speech_synthesis_speak.cc
+++ b/starboard/android/shared/speech_synthesis_speak.cc
@@ -17,13 +17,13 @@
 // clang-format on
 
 #include "starboard/android/shared/starboard_bridge.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "cobalt/android/jni_headers/CobaltTextToSpeechHelper_jni.h"
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaLocalRef;
 
 void SbSpeechSynthesisSpeak(const char* text) {
   if (!text) {

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -400,7 +400,7 @@ int64_t StarboardBridge::GetPlayServicesVersion(JNIEnv* env) const {
       Java_StarboardBridge_getPlayServicesVersion(env, j_starboard_bridge_));
 }
 
-jni_zero::ScopedJavaLocalRef<jobject> StarboardBridge::OpenCobaltService(
+ScopedJavaLocalRef<jobject> StarboardBridge::OpenCobaltService(
     JNIEnv* env,
     jlong native_service,
     const char* service_name) {

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -25,6 +25,7 @@
 #include "starboard/common/log.h"
 #include "starboard/common/time.h"
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 // TODO(b/492704919): enable on AOSP when the layering violation is fixed.
 #if !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
@@ -39,15 +40,14 @@ namespace starboard {
 
 namespace {
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
 using base::android::AppendJavaStringArrayToStringVector;
-using base::android::AttachCurrentThread;
 using base::android::ConvertJavaStringToUTF8;
 using base::android::ConvertUTF8ToJavaString;
-using base::android::GetClass;
-using base::android::JavaParamRef;
-using base::android::ScopedJavaGlobalRef;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::GetClass;
+using jni_zero::JavaParamRef;
+using jni_zero::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaLocalRef;
 
 // Client Hint Header name constants
 constexpr char kAndroidOSExperienceHeader[] =
@@ -400,7 +400,7 @@ int64_t StarboardBridge::GetPlayServicesVersion(JNIEnv* env) const {
       Java_StarboardBridge_getPlayServicesVersion(env, j_starboard_bridge_));
 }
 
-base::android::ScopedJavaLocalRef<jobject> StarboardBridge::OpenCobaltService(
+jni_zero::ScopedJavaLocalRef<jobject> StarboardBridge::OpenCobaltService(
     JNIEnv* env,
     jlong native_service,
     const char* service_name) {
@@ -434,13 +434,13 @@ void StarboardBridge::HideSplashScreen(JNIEnv* env) const {
 }
 
 void StarboardBridge::SetStartupMilestone(jint milestone) const {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
   Java_StarboardBridge_setStartupMilestone(env, j_starboard_bridge_, milestone);
 }
 
 void StarboardBridge::SetStartupDiagnosisInfo(const char* key,
                                               const char* value) const {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
   Java_StarboardBridge_setStartupDiagnosisInfo(
       env, j_starboard_bridge_, ConvertUTF8ToJavaString(env, key),
       ConvertUTF8ToJavaString(env, value));

--- a/starboard/android/shared/starboard_bridge.h
+++ b/starboard/android/shared/starboard_bridge.h
@@ -17,10 +17,9 @@
 
 #include <jni.h>
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
 #include "base/memory/singleton.h"
 #include "starboard/common/size.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -41,8 +40,7 @@ class StarboardBridge {
 
   void AppendArgs(JNIEnv* env, std::vector<std::string>* args_vector);
 
-  base::android::ScopedJavaLocalRef<jintArray> GetSupportedHdrTypes(
-      JNIEnv* env);
+  jni_zero::ScopedJavaLocalRef<jintArray> GetSupportedHdrTypes(JNIEnv* env);
 
   void RaisePlatformError(JNIEnv* env, jint errorType, jlong data);
 
@@ -50,13 +48,13 @@ class StarboardBridge {
 
   void RequestSuspend(JNIEnv* env);
 
-  base::android::ScopedJavaLocalRef<jobject> GetTextToSpeechHelper(JNIEnv* env);
+  jni_zero::ScopedJavaLocalRef<jobject> GetTextToSpeechHelper(JNIEnv* env);
 
-  base::android::ScopedJavaLocalRef<jobject> GetCaptionSettings(JNIEnv* env);
+  jni_zero::ScopedJavaLocalRef<jobject> GetCaptionSettings(JNIEnv* env);
 
-  base::android::ScopedJavaLocalRef<jobject> GetResourceOverlay(JNIEnv* env);
+  jni_zero::ScopedJavaLocalRef<jobject> GetResourceOverlay(JNIEnv* env);
 
-  base::android::ScopedJavaLocalRef<jstring> GetSystemLocaleId(JNIEnv* env);
+  jni_zero::ScopedJavaLocalRef<jstring> GetSystemLocaleId(JNIEnv* env);
 
   std::string GetAdvertisingId(JNIEnv* env);
   bool GetLimitAdTracking(JNIEnv* env);
@@ -65,7 +63,7 @@ class StarboardBridge {
 
   std::string GetTimeZoneId(JNIEnv* env);
 
-  base::android::ScopedJavaLocalRef<jobject> GetDisplayDpi(JNIEnv* env);
+  jni_zero::ScopedJavaLocalRef<jobject> GetDisplayDpi(JNIEnv* env);
 
   Size GetDeviceResolution(JNIEnv* env);
 
@@ -77,13 +75,13 @@ class StarboardBridge {
 
   bool IsMicrophoneDisconnected(JNIEnv* env);
   bool IsMicrophoneMute(JNIEnv* env);
-  base::android::ScopedJavaLocalRef<jobject> GetAudioPermissionRequester(
+  jni_zero::ScopedJavaLocalRef<jobject> GetAudioPermissionRequester(
       JNIEnv* env);
 
   void ResetVideoSurface(JNIEnv* env);
   void SetVideoSurfaceBounds(JNIEnv* env, int x, int y, int width, int height);
 
-  base::android::ScopedJavaLocalRef<jobject> GetAudioOutputManager(JNIEnv* env);
+  jni_zero::ScopedJavaLocalRef<jobject> GetAudioOutputManager(JNIEnv* env);
 
   std::string GetUserAgentAuxField(JNIEnv* env) const;
 
@@ -93,7 +91,7 @@ class StarboardBridge {
 
   int64_t GetPlayServicesVersion(JNIEnv* env) const;
 
-  base::android::ScopedJavaLocalRef<jobject> OpenCobaltService(
+  jni_zero::ScopedJavaLocalRef<jobject> OpenCobaltService(
       JNIEnv* env,
       jlong native_service,
       const char* service_name);
@@ -117,7 +115,7 @@ class StarboardBridge {
   friend struct base::DefaultSingletonTraits<StarboardBridge>;
 
   // Java StarboardBridge instance.
-  base::android::ScopedJavaGlobalRef<jobject> j_starboard_bridge_;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_starboard_bridge_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/starboard_feature_list.cc
+++ b/starboard/android/shared/starboard_feature_list.cc
@@ -20,7 +20,7 @@
 #include "cobalt/android/jni_headers/StarboardFeatureList_jni.h"
 
 using base::android::ConvertJavaStringToUTF8;
-using base::android::JavaParamRef;
+using jni_zero::JavaParamRef;
 
 namespace starboard::features {
 

--- a/starboard/android/shared/system_get_locale_id.cc
+++ b/starboard/android/shared/system_get_locale_id.cc
@@ -18,14 +18,14 @@
 
 #include <string>
 
-#include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
-#include "base/android/scoped_java_ref.h"
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/once.h"
 #include "starboard/common/string.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
+
 namespace {
 
 // A singleton class to hold a locale string
@@ -35,9 +35,9 @@ class LocaleInfo {
   std::string locale_id;
 
   LocaleInfo() {
-    JNIEnv* env = base::android::AttachCurrentThread();
+    JNIEnv* env = jni_zero::AttachCurrentThread();
 
-    base::android::ScopedJavaLocalRef<jstring> result =
+    jni_zero::ScopedJavaLocalRef<jstring> result =
         StarboardBridge::GetInstance()->GetSystemLocaleId(env);
     locale_id = base::android::ConvertJavaStringToUTF8(env, result.obj());
   }

--- a/starboard/android/shared/system_get_path.cc
+++ b/starboard/android/shared/system_get_path.cc
@@ -25,8 +25,9 @@
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
+#include "third_party/jni_zero/jni_zero.h"
 
-using ::base::android::ScopedJavaGlobalRef;
+using ::jni_zero::ScopedJavaGlobalRef;
 using ::starboard::g_app_assets_dir;
 using ::starboard::g_app_cache_dir;
 using ::starboard::g_app_files_dir;

--- a/starboard/android/shared/system_get_path.cc
+++ b/starboard/android/shared/system_get_path.cc
@@ -27,7 +27,6 @@
 #include "starboard/common/string.h"
 #include "third_party/jni_zero/jni_zero.h"
 
-using ::jni_zero::ScopedJavaGlobalRef;
 using ::starboard::g_app_assets_dir;
 using ::starboard::g_app_cache_dir;
 using ::starboard::g_app_files_dir;

--- a/starboard/android/shared/system_get_property.cc
+++ b/starboard/android/shared/system_get_property.cc
@@ -16,19 +16,21 @@
 #include "starboard/system.h"
 // clang-format on
 
+#include <jni.h>
+
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/device_type.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
 #include "sys/system_properties.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 #define STRINGIZE_NO_EXPANSION(x) #x
 #define STRINGIZE(x) STRINGIZE_NO_EXPANSION(x)
 
 namespace {
 
-// TODO: b/372559388 - Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
+using jni_zero::AttachCurrentThread;
 using ::starboard::StarboardBridge;
 
 const char kFriendlyName[] = "Android";

--- a/starboard/android/shared/system_info_api.cc
+++ b/starboard/android/shared/system_info_api.cc
@@ -16,12 +16,13 @@
 
 #include "starboard/android/shared/application_android.h"
 #include "starboard/extension/system_info.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
 namespace {
 
-using base::android::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaGlobalRef;
 
 // Definitions of any functions included as components in the extension
 // are added here.

--- a/starboard/android/shared/system_platform_error.cc
+++ b/starboard/android/shared/system_platform_error.cc
@@ -27,7 +27,6 @@
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace {
-using jni_zero::ScopedJavaGlobalRef;
 using starboard::ApplicationAndroid;
 
 typedef std::function<void(SbSystemPlatformErrorResponse error_response)>

--- a/starboard/android/shared/system_platform_error.cc
+++ b/starboard/android/shared/system_platform_error.cc
@@ -24,9 +24,10 @@
 #include "cobalt/android/jni_headers/PlatformError_jni.h"
 #include "starboard/android/shared/application_android.h"
 #include "starboard/android/shared/starboard_bridge.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace {
-using base::android::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaGlobalRef;
 using starboard::ApplicationAndroid;
 
 typedef std::function<void(SbSystemPlatformErrorResponse error_response)>
@@ -52,7 +53,7 @@ bool SbSystemRaisePlatformError(SbSystemPlatformErrorType type,
       return false;
   }
 
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
 
   auto send_response_callback =
       callback ? new SendResponseCallback(

--- a/starboard/android/shared/system_request_conceal.cc
+++ b/starboard/android/shared/system_request_conceal.cc
@@ -17,8 +17,9 @@
 // clang-format on
 
 #include "starboard/android/shared/starboard_bridge.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 void SbSystemRequestConceal() {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   starboard::StarboardBridge::GetInstance()->RequestSuspend(env);
 }

--- a/starboard/android/shared/text_to_speech_helper.h
+++ b/starboard/android/shared/text_to_speech_helper.h
@@ -15,9 +15,10 @@
 #ifndef STARBOARD_ANDROID_SHARED_TEXT_TO_SPEECH_HELPER_H_
 #define STARBOARD_ANDROID_SHARED_TEXT_TO_SPEECH_HELPER_H_
 
-#include "base/android/jni_android.h"
-#include "base/android/scoped_java_ref.h"
+#include <jni.h>
+
 #include "base/memory/singleton.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -33,7 +34,7 @@ class CobaltTextToSpeechHelper {
  private:
   friend struct base::DefaultSingletonTraits<CobaltTextToSpeechHelper>;
   // Java CobaltTextToSpeechHelper instance.
-  base::android::ScopedJavaGlobalRef<jobject> j_text_to_speech_helper_;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_text_to_speech_helper_;
 
   CobaltTextToSpeechHelper() = default;
   ~CobaltTextToSpeechHelper() = default;

--- a/starboard/android/shared/thread_platform_android.cc
+++ b/starboard/android/shared/thread_platform_android.cc
@@ -16,12 +16,12 @@
 
 #include "starboard/common/thread_platform.h"
 
-#include "base/android/jni_android.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
 void TerminateOnThread() {
-  base::android::DetachFromVM();
+  jni_zero::DetachFromVM();
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/time_zone_get_name.cc
+++ b/starboard/android/shared/time_zone_get_name.cc
@@ -21,13 +21,10 @@
 #include "starboard/android/shared/starboard_bridge.h"
 #include "third_party/jni_zero/jni_zero.h"
 
-using jni_zero::AttachCurrentThread;
-using jni_zero::ScopedJavaLocalRef;
-
 const char* SbTimeZoneGetName() {
   static char s_time_zone_id[64];
   // Note tzset() is called in ApplicationAndroid::Initialize()
-  JNIEnv* env = AttachCurrentThread();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
   std::string time_zone_id =
       starboard::StarboardBridge::GetInstance()->GetTimeZoneId(env);
 

--- a/starboard/android/shared/time_zone_get_name.cc
+++ b/starboard/android/shared/time_zone_get_name.cc
@@ -19,10 +19,10 @@
 #include <time.h>
 
 #include "starboard/android/shared/starboard_bridge.h"
+#include "third_party/jni_zero/jni_zero.h"
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaLocalRef;
 
 const char* SbTimeZoneGetName() {
   static char s_time_zone_id[64];

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -14,6 +14,7 @@
 
 #include "starboard/android/shared/video_decoder.h"
 
+#include <jni.h>
 #include <unistd.h>
 
 #include <algorithm>
@@ -23,7 +24,6 @@
 #include <limits>
 #include <list>
 
-#include "base/android/jni_android.h"
 #include "build/build_config.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
@@ -42,13 +42,14 @@
 #include "starboard/shared/starboard/media/mime_type.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
 #include "starboard/thread.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
 namespace {
 
-using base::android::AttachCurrentThread;
-using base::android::JavaParamRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::JavaParamRef;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
@@ -1061,13 +1062,13 @@ bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
 
 namespace {
 
-void updateTexImage(const base::android::JavaRef<jobject>& surface_texture) {
+void updateTexImage(const jni_zero::JavaRef<jobject>& surface_texture) {
   JNIEnv* env = AttachCurrentThread();
 
   VideoSurfaceTextureBridge::UpdateTexImage(env, surface_texture);
 }
 
-void getTransformMatrix(const base::android::JavaRef<jobject>& surface_texture,
+void getTransformMatrix(const jni_zero::JavaRef<jobject>& surface_texture,
                         float* matrix4x4) {
   JNIEnv* env = AttachCurrentThread();
 

--- a/starboard/android/shared/video_decoder.cc
+++ b/starboard/android/shared/video_decoder.cc
@@ -49,7 +49,7 @@ namespace starboard {
 namespace {
 
 using jni_zero::AttachCurrentThread;
-using jni_zero::JavaParamRef;
+using jni_zero::JavaRef;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
@@ -1062,13 +1062,13 @@ bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
 
 namespace {
 
-void updateTexImage(const jni_zero::JavaRef<jobject>& surface_texture) {
+void updateTexImage(const JavaRef<jobject>& surface_texture) {
   JNIEnv* env = AttachCurrentThread();
 
   VideoSurfaceTextureBridge::UpdateTexImage(env, surface_texture);
 }
 
-void getTransformMatrix(const jni_zero::JavaRef<jobject>& surface_texture,
+void getTransformMatrix(const JavaRef<jobject>& surface_texture,
                         float* matrix4x4) {
   JNIEnv* env = AttachCurrentThread();
 
@@ -1076,7 +1076,8 @@ void getTransformMatrix(const jni_zero::JavaRef<jobject>& surface_texture,
   SB_CHECK(java_array);
 
   VideoSurfaceTextureBridge::GetTransformMatrix(
-      env, surface_texture, JavaParamRef<jfloatArray>(env, java_array));
+      env, surface_texture,
+      jni_zero::JavaParamRef<jfloatArray>(env, java_array));
 
   jfloat* array_values = env->GetFloatArrayElements(java_array, 0);
   memcpy(matrix4x4, array_values, sizeof(float) * 16);

--- a/starboard/android/shared/video_render_algorithm.cc
+++ b/starboard/android/shared/video_render_algorithm.cc
@@ -22,13 +22,15 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/starboard/features.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaLocalRef;
+
 namespace {
-using base::android::AttachCurrentThread;
-using base::android::ScopedJavaGlobalRef;
-using base::android::ScopedJavaLocalRef;
 
 const int64_t kBufferTooLateThreshold = -32'000;  // -32ms
 const int64_t kBufferReadyThreshold = 50'000;     // 50ms
@@ -157,7 +159,7 @@ int VideoRenderAlgorithmAndroid::GetDroppedFrames() {
 
 VideoRenderAlgorithmAndroid::VideoFrameReleaseTimeHelper::
     VideoFrameReleaseTimeHelper() {
-  JNIEnv* env = base::android::AttachCurrentThread();
+  JNIEnv* env = AttachCurrentThread();
 
   j_video_frame_release_time_helper_.Reset(
       Java_VideoFrameReleaseTimeHelper_Constructor(env));

--- a/starboard/android/shared/video_render_algorithm.h
+++ b/starboard/android/shared/video_render_algorithm.h
@@ -17,9 +17,9 @@
 
 #include <list>
 
-#include "base/android/jni_android.h"
 #include "starboard/android/shared/video_decoder.h"
 #include "starboard/shared/starboard/player/filter/video_render_algorithm.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -44,8 +44,7 @@ class VideoRenderAlgorithmAndroid : public VideoRenderAlgorithm {
                             double playback_rate);
 
    private:
-    base::android::ScopedJavaGlobalRef<jobject>
-        j_video_frame_release_time_helper_;
+    jni_zero::ScopedJavaGlobalRef<jobject> j_video_frame_release_time_helper_;
   };
 
   MediaCodecVideoDecoder* video_decoder_ = nullptr;

--- a/starboard/android/shared/video_surface_texture_bridge.cc
+++ b/starboard/android/shared/video_surface_texture_bridge.cc
@@ -20,20 +20,21 @@
 namespace starboard {
 namespace {
 using jni_zero::JavaParamRef;
+using jni_zero::JavaRef;
 using jni_zero::ScopedJavaGlobalRef;
 using jni_zero::ScopedJavaLocalRef;
 }  // namespace
 
 void VideoSurfaceTextureBridge::SetOnFrameAvailableListener(
     JNIEnv* env,
-    const jni_zero::JavaRef<jobject>& surface_texture) const {
+    const JavaRef<jobject>& surface_texture) const {
   Java_VideoSurfaceTexture_setOnFrameAvailableListener(
       env, surface_texture, reinterpret_cast<jlong>(this));
 }
 
 void VideoSurfaceTextureBridge::RemoveOnFrameAvailableListener(
     JNIEnv* env,
-    const jni_zero::JavaRef<jobject>& surface_texture) const {
+    const JavaRef<jobject>& surface_texture) const {
   Java_VideoSurfaceTexture_removeOnFrameAvailableListener(env, surface_texture);
 }
 
@@ -49,7 +50,7 @@ VideoSurfaceTextureBridge::CreateVideoSurfaceTexture(JNIEnv* env,
 // static
 ScopedJavaGlobalRef<jobject> VideoSurfaceTextureBridge::CreateSurface(
     JNIEnv* env,
-    const jni_zero::JavaRef<jobject>& surface_texture) {
+    const JavaRef<jobject>& surface_texture) {
   return ScopedJavaGlobalRef<jobject>(
       Java_VideoSurfaceTexture_createSurface(env, surface_texture));
 }
@@ -57,15 +58,15 @@ ScopedJavaGlobalRef<jobject> VideoSurfaceTextureBridge::CreateSurface(
 // static
 void VideoSurfaceTextureBridge::UpdateTexImage(
     JNIEnv* env,
-    const jni_zero::JavaRef<jobject>& surface_texture) {
+    const JavaRef<jobject>& surface_texture) {
   Java_VideoSurfaceTexture_updateTexImage(env, surface_texture);
 }
 
 // static
 void VideoSurfaceTextureBridge::GetTransformMatrix(
     JNIEnv* env,
-    const jni_zero::JavaRef<jobject>& surface_texture,
-    const jni_zero::JavaParamRef<jfloatArray>& mtx) {
+    const JavaRef<jobject>& surface_texture,
+    const JavaParamRef<jfloatArray>& mtx) {
   Java_VideoSurfaceTexture_getTransformMatrix(env, surface_texture, mtx);
 }
 

--- a/starboard/android/shared/video_surface_texture_bridge.cc
+++ b/starboard/android/shared/video_surface_texture_bridge.cc
@@ -15,24 +15,25 @@
 #include "starboard/android/shared/video_surface_texture_bridge.h"
 
 #include "cobalt/android/jni_headers/VideoSurfaceTexture_jni.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 namespace {
-using base::android::JavaParamRef;
-using base::android::ScopedJavaGlobalRef;
-using base::android::ScopedJavaLocalRef;
+using jni_zero::JavaParamRef;
+using jni_zero::ScopedJavaGlobalRef;
+using jni_zero::ScopedJavaLocalRef;
 }  // namespace
 
 void VideoSurfaceTextureBridge::SetOnFrameAvailableListener(
     JNIEnv* env,
-    const base::android::JavaRef<jobject>& surface_texture) const {
+    const jni_zero::JavaRef<jobject>& surface_texture) const {
   Java_VideoSurfaceTexture_setOnFrameAvailableListener(
       env, surface_texture, reinterpret_cast<jlong>(this));
 }
 
 void VideoSurfaceTextureBridge::RemoveOnFrameAvailableListener(
     JNIEnv* env,
-    const base::android::JavaRef<jobject>& surface_texture) const {
+    const jni_zero::JavaRef<jobject>& surface_texture) const {
   Java_VideoSurfaceTexture_removeOnFrameAvailableListener(env, surface_texture);
 }
 
@@ -48,7 +49,7 @@ VideoSurfaceTextureBridge::CreateVideoSurfaceTexture(JNIEnv* env,
 // static
 ScopedJavaGlobalRef<jobject> VideoSurfaceTextureBridge::CreateSurface(
     JNIEnv* env,
-    const base::android::JavaRef<jobject>& surface_texture) {
+    const jni_zero::JavaRef<jobject>& surface_texture) {
   return ScopedJavaGlobalRef<jobject>(
       Java_VideoSurfaceTexture_createSurface(env, surface_texture));
 }
@@ -56,15 +57,15 @@ ScopedJavaGlobalRef<jobject> VideoSurfaceTextureBridge::CreateSurface(
 // static
 void VideoSurfaceTextureBridge::UpdateTexImage(
     JNIEnv* env,
-    const base::android::JavaRef<jobject>& surface_texture) {
+    const jni_zero::JavaRef<jobject>& surface_texture) {
   Java_VideoSurfaceTexture_updateTexImage(env, surface_texture);
 }
 
 // static
 void VideoSurfaceTextureBridge::GetTransformMatrix(
     JNIEnv* env,
-    const base::android::JavaRef<jobject>& surface_texture,
-    const base::android::JavaParamRef<jfloatArray>& mtx) {
+    const jni_zero::JavaRef<jobject>& surface_texture,
+    const jni_zero::JavaParamRef<jfloatArray>& mtx) {
   Java_VideoSurfaceTexture_getTransformMatrix(env, surface_texture, mtx);
 }
 

--- a/starboard/android/shared/video_surface_texture_bridge.h
+++ b/starboard/android/shared/video_surface_texture_bridge.h
@@ -17,9 +17,9 @@
 
 #include <jni.h>
 
-#include "base/android/jni_android.h"
 #include "base/memory/raw_ref.h"
 #include "starboard/common/log.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
@@ -44,25 +44,24 @@ class VideoSurfaceTextureBridge {
 
   void SetOnFrameAvailableListener(
       JNIEnv* env,
-      const base::android::JavaRef<jobject>& surface_texture) const;
+      const jni_zero::JavaRef<jobject>& surface_texture) const;
   void RemoveOnFrameAvailableListener(
       JNIEnv* env,
-      const base::android::JavaRef<jobject>& surface_texture) const;
+      const jni_zero::JavaRef<jobject>& surface_texture) const;
 
-  static base::android::ScopedJavaGlobalRef<jobject> CreateVideoSurfaceTexture(
+  static jni_zero::ScopedJavaGlobalRef<jobject> CreateVideoSurfaceTexture(
       JNIEnv* env,
       int gl_texture_id);
-  static base::android::ScopedJavaGlobalRef<jobject> CreateSurface(
+  static jni_zero::ScopedJavaGlobalRef<jobject> CreateSurface(
       JNIEnv* env,
-      const base::android::JavaRef<jobject>& surface_texture);
+      const jni_zero::JavaRef<jobject>& surface_texture);
 
-  static void UpdateTexImage(
-      JNIEnv* env,
-      const base::android::JavaRef<jobject>& surface_texture);
+  static void UpdateTexImage(JNIEnv* env,
+                             const jni_zero::JavaRef<jobject>& surface_texture);
   static void GetTransformMatrix(
       JNIEnv* env,
-      const base::android::JavaRef<jobject>& surface_texture,
-      const base::android::JavaParamRef<jfloatArray>& mtx);
+      const jni_zero::JavaRef<jobject>& surface_texture,
+      const jni_zero::JavaParamRef<jfloatArray>& mtx);
 
   void OnFrameAvailable(JNIEnv*) { host_->OnFrameAvailable(); }
 

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -31,9 +31,8 @@
 
 namespace starboard {
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
-using base::android::JavaParamRef;
+using jni_zero::AttachCurrentThread;
+using jni_zero::JavaParamRef;
 
 namespace {
 

--- a/starboard/android/shared/window_get_size.cc
+++ b/starboard/android/shared/window_get_size.cc
@@ -13,14 +13,14 @@
 // limitations under the License.
 
 #include <android/native_window.h>
+#include <jni.h>
 
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/android/shared/window_internal.h"
 #include "starboard/common/log.h"
 #include "starboard/window.h"
 
-// TODO: (cobalt b/372559388) Update namespace to jni_zero.
-using base::android::AttachCurrentThread;
+using jni_zero::AttachCurrentThread;
 
 bool SbWindowGetSize(SbWindow window, SbWindowSize* size) {
   if (!SbWindowIsValid(window)) {


### PR DESCRIPTION
This change migrates JNI helper functions and type usage from the
Chromium-derived base/android JNI wrappers to the jni_zero library.
The jni_zero library provides a more direct and lightweight interface
for JNI interactions specific to Cobalt on Android. This simplifies
the JNI layer and removes dependencies on the older wrappers.

This PR contains no functional changes.

Vibe coded by `jetski-cli`

Bug: 372559388