### PR TITLE
starboard: Make ffmpeg dynamic loading compatible with FFMPEG 6.2 (621)

### DIFF
--- a/starboard/shared/ffmpeg/ffmpeg_dispatch.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dispatch.cc
@@ -37,7 +37,9 @@ int FFMPEGDispatch::OpenCodec(AVCodecContext* codec_context,
 
 void FFMPEGDispatch::CloseCodec(AVCodecContext* codec_context) {
   pthread_mutex_lock(&g_codec_mutex);
-  avcodec_close(codec_context);
+  if (avcodec_close) {
+    avcodec_close(codec_context);
+  }
   pthread_mutex_unlock(&g_codec_mutex);
 }
 

--- a/starboard/shared/ffmpeg/ffmpeg_dispatch.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dispatch.cc
@@ -39,6 +39,9 @@ void FFMPEGDispatch::CloseCodec(AVCodecContext* codec_context) {
   pthread_mutex_lock(&g_codec_mutex);
   if (avcodec_close) {
     avcodec_close(codec_context);
+  } else {
+    SB_LOG(INFO) << "avcodec_close is unavailable (likely due to modern FFMPEG "
+                    "version). Cleanup is handled by avcodec_free_context.";
   }
   pthread_mutex_unlock(&g_codec_mutex);
 }

--- a/starboard/shared/ffmpeg/ffmpeg_dispatch.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dispatch.cc
@@ -40,6 +40,12 @@ void FFMPEGDispatch::CloseCodec(AVCodecContext* codec_context) {
   if (avcodec_close) {
     avcodec_close(codec_context);
   } else {
+    // avcodec_close is deprecated/removed in modern FFmpeg.
+    // Complete cleanup (including closing the codec) is handled by
+    // avcodec_free_context(), which is called via FFMPEGDispatch::FreeContext()
+    // inside TeardownCodec(). TeardownCodec() is invoked during the destruction
+    // of the decoders (e.g., FfmpegAudioDecoderImpl and FfmpegVideoDecoderImpl
+    // destructors).
     SB_LOG(INFO) << "avcodec_close is unavailable (likely due to modern FFMPEG "
                     "version). Cleanup is handled by avcodec_free_context.";
   }

--- a/starboard/shared/ffmpeg/ffmpeg_dynamic_load_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dynamic_load_audio_decoder_impl.cc
@@ -53,6 +53,12 @@ std::unique_ptr<FfmpegAudioDecoder> FfmpegAudioDecoder::Create(
       return FfmpegAudioDecoderImpl<601>::Create(job_queue, audio_stream_info);
     case 611:
       return FfmpegAudioDecoderImpl<611>::Create(job_queue, audio_stream_info);
+    case 621:
+      // We reuse the 611 implementation because FFMPEG 6.2 (621) is
+      // API-compatible with 6.1 (611).
+      // TODO: b/508705038 - Use a dedicated 621 specialization once
+      // third_party/ffmpeg is updated.
+      return FfmpegAudioDecoderImpl<611>::Create(job_queue, audio_stream_info);
     default:
       SB_LOG(WARNING) << "Unsupported FFMPEG specialization "
                       << ffmpeg->specialization_version();

--- a/starboard/shared/ffmpeg/ffmpeg_dynamic_load_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_dynamic_load_video_decoder_impl.cc
@@ -62,6 +62,13 @@ std::unique_ptr<FfmpegVideoDecoder> FfmpegVideoDecoder::Create(
     case 611:
       return FfmpegVideoDecoderImpl<611>::Create(
           video_codec, output_mode, decode_target_graphics_context_provider);
+    case 621:
+      // We reuse the 611 implementation because FFMPEG 6.2 (621) is
+      // API-compatible with 6.1 (611).
+      // TODO: b/508705038 - Use a dedicated 621 specialization once
+      // third_party/ffmpeg is updated.
+      return FfmpegVideoDecoderImpl<611>::Create(
+          video_codec, output_mode, decode_target_graphics_context_provider);
     default:
       SB_LOG(WARNING) << "Unsupported FFMPEG version "
                       << ffmpeg->specialization_version();


### PR DESCRIPTION
The FFMPEG dynamic loading mechanism is updated to gracefully handle
FFMPEG 6.2 (version 621). This is achieved by conditionally calling
avcodec_close, as it may be undefined in modern FFMPEG versions.

Additionally, specialization version 621 is temporarily mapped to the
existing 611 decoder implementations for both audio and video. This
allows FFMPEG 6.2 to be dynamically loaded, leveraging its API
compatibility with version 6.1, until a dedicated 6.2 specialization
is implemented.

Issue: 508705038