### PR TITLE
android: Update target SDK and handle predictive back

### DIFF
--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -319,7 +319,7 @@ if (is_android) {
   # value of the arguments set above.
   declare_args() {
     # Default value for targetSdkVersion for APK and bundle targets.
-    default_target_sdk_version = "35"
+    default_target_sdk_version = "36"
 
     # Whether java assertions and Preconditions checks are enabled.
     enable_java_asserts = dcheck_always_on || !is_official_build

--- a/cobalt/android/apk/app/build.gradle
+++ b/cobalt/android/apk/app/build.gradle
@@ -17,7 +17,7 @@ apply plugin: 'com.android.application'
 final DEFAULT_COBALT_TARGET = 'cobalt'
 final String[] SUPPORTED_ABIS = [ 'x86', 'armeabi-v7a', 'arm64-v8a' ]
 final MIN_SUPPORTED_SDK_VERSION = 24
-final LATEST_SUPPORTED_SDK_VERSION = 34
+final LATEST_SUPPORTED_SDK_VERSION = 36
 
 // Parse the NDK_VERSION and CMAKE_VERSION defined in sdk_utils.py
 final SDK_UTILS = project.rootProject.file('../../../starboard/android/shared/sdk_utils.py')

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -26,19 +26,19 @@ import android.media.AudioManager;
 import android.net.Uri;
 import android.os.Bundle;
 import android.os.SystemClock;
+import android.os.Build;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.View;
-import android.os.Build;
-import androidx.annotation.RequiresApi;
-import android.window.OnBackInvokedCallback;
-import android.window.OnBackInvokedDispatcher;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewParent;
 import android.view.WindowManager;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 import android.widget.FrameLayout;
 import android.widget.Toast;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
 import androidx.annotation.VisibleForTesting;
 import dev.cobalt.browser.CobaltContentBrowserClient;
 import dev.cobalt.coat.javabridge.CobaltJavaScriptAndroidObject;
@@ -458,7 +458,7 @@ public abstract class CobaltActivity extends Activity {
     StartupGuard.getInstance().setStartupMilestone(9);
 
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
-      OnBackInvokedHelper.register(this, this);
+      OnBackInvokedHelper.register(this);
     }
   }
 
@@ -830,15 +830,15 @@ public abstract class CobaltActivity extends Activity {
 
   @RequiresApi(api = 33)
   private static class OnBackInvokedHelper {
-    static void register(final Activity activity, final CobaltActivity cobaltActivity) {
+    static void register(final CobaltActivity activity) {
       activity.getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
           OnBackInvokedDispatcher.PRIORITY_DEFAULT,
           new OnBackInvokedCallback() {
             @Override
             public void onBackInvoked() {
               // Simulate complete key cycle just like onKeyDown -> IME pipeline expects.
-              cobaltActivity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_DOWN);
-              cobaltActivity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_UP);
+              activity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_DOWN);
+              activity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_UP);
             }
           }
       );

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -29,6 +29,10 @@ import android.os.SystemClock;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.View;
+import android.os.Build;
+import androidx.annotation.RequiresApi;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewParent;
 import android.view.WindowManager;
@@ -452,6 +456,10 @@ public abstract class CobaltActivity extends Activity {
       Log.i(TAG, "Do not create VideoSurfaceView.");
     }
     StartupGuard.getInstance().setStartupMilestone(9);
+
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+      OnBackInvokedHelper.register(this, this);
+    }
   }
 
   /**
@@ -817,6 +825,23 @@ public abstract class CobaltActivity extends Activity {
   private void updateShellActivityVisible(boolean isVisible) {
     if (mShellManager != null) {
       mShellManager.onActivityVisible(isVisible);
+    }
+  }
+
+  @RequiresApi(api = 33)
+  private static class OnBackInvokedHelper {
+    static void register(final Activity activity, final CobaltActivity cobaltActivity) {
+      activity.getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+          OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+          new OnBackInvokedCallback() {
+            @Override
+            public void onBackInvoked() {
+              // Simulate complete key cycle just like onKeyDown -> IME pipeline expects.
+              cobaltActivity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_DOWN);
+              cobaltActivity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_UP);
+            }
+          }
+      );
     }
   }
 }

--- a/cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2
+++ b/cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2
@@ -55,6 +55,7 @@
             android:zygotePreloadName="org.chromium.content_public.app.ZygotePreload"
             {# Always enable debuggable=true for development. This manifest is only used for the development shell (CoAT) and does not affect the production Kimono app. #}
             android:debuggable="true"
+            android:enableOnBackInvokedCallback="true"
             android:label="{% block application_label %}Cobalt Shell{% endblock %}">
         {# Always enable profileable for development. This manifest is only used for the development shell (CoAT) and does not affect the production Kimono app. #}
         <profileable android:shell="true" android:enabled="true" />


### PR DESCRIPTION
Update the default target SDK version to 36 for Android builds.
Introduce support for the Android 13 (API 33) predictive back gesture
by registering an OnBackInvokedCallback. This ensures that when a
user performs the predictive back gesture, it is correctly translated
into a KEYCODE_BACK event, preserving existing back navigation
behavior. The manifest is updated to enable this callback.

Bug: 505562328