### PR TITLE
starboard: Add factory to OpusAudioDecoder

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -430,8 +430,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         if (UseLibopusDecoder(audio_stream_info.codec, drm_system,
                               force_platform_opus_decoder)) {
           auto audio_decoder_impl =
-              std::make_unique<OpusAudioDecoder>(job_queue, audio_stream_info);
-          if (audio_decoder_impl->is_valid()) {
+              OpusAudioDecoder::Create(job_queue, audio_stream_info);
+          if (audio_decoder_impl) {
             return audio_decoder_impl;
           }
         } else if (audio_stream_info.codec == kSbMediaAudioCodecAac ||

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -429,11 +429,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
               SbDrmSystem drm_system) -> std::unique_ptr<AudioDecoder> {
         if (UseLibopusDecoder(audio_stream_info.codec, drm_system,
                               force_platform_opus_decoder)) {
-          auto audio_decoder_impl =
-              OpusAudioDecoder::Create(job_queue, audio_stream_info);
-          if (audio_decoder_impl) {
-            return audio_decoder_impl;
-          }
+          return OpusAudioDecoder::Create(job_queue, audio_stream_info);
         } else if (audio_stream_info.codec == kSbMediaAudioCodecAac ||
                    audio_stream_info.codec == kSbMediaAudioCodecOpus) {
           auto audio_decoder_impl = MediaCodecAudioDecoder::Create(

--- a/starboard/linux/shared/player_components_factory.cc
+++ b/starboard/linux/shared/player_components_factory.cc
@@ -59,8 +59,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
                       SbDrmSystem drm_system) -> std::unique_ptr<AudioDecoder> {
         if (audio_stream_info.codec == kSbMediaAudioCodecOpus) {
           auto opus_audio_decoder =
-              std::make_unique<OpusAudioDecoder>(job_queue, audio_stream_info);
-          if (opus_audio_decoder->is_valid()) {
+              OpusAudioDecoder::Create(job_queue, audio_stream_info);
+          if (opus_audio_decoder) {
             return opus_audio_decoder;
           } else {
             SB_LOG(ERROR) << "Failed to create audio decoder for codec "

--- a/starboard/linux/shared/player_components_factory.cc
+++ b/starboard/linux/shared/player_components_factory.cc
@@ -58,14 +58,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
           [job_queue](const AudioStreamInfo& audio_stream_info,
                       SbDrmSystem drm_system) -> std::unique_ptr<AudioDecoder> {
         if (audio_stream_info.codec == kSbMediaAudioCodecOpus) {
-          auto opus_audio_decoder =
-              OpusAudioDecoder::Create(job_queue, audio_stream_info);
-          if (opus_audio_decoder) {
-            return opus_audio_decoder;
-          } else {
-            SB_LOG(ERROR) << "Failed to create audio decoder for codec "
-                          << GetMediaAudioCodecName(audio_stream_info.codec);
-          }
+          return OpusAudioDecoder::Create(job_queue, audio_stream_info);
         } else if (audio_stream_info.codec == kSbMediaAudioCodecAac &&
                    audio_stream_info.number_of_channels <=
                        FdkAacAudioDecoder::kMaxChannels &&
@@ -77,13 +70,13 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
               FfmpegAudioDecoder::Create(job_queue, audio_stream_info);
           if (ffmpeg_audio_decoder) {
             SB_LOG(INFO) << "Playing audio using FfmpegAudioDecoder";
-            return ffmpeg_audio_decoder;
           } else {
             SB_LOG(ERROR) << "Failed to create audio decoder for codec "
                           << GetMediaAudioCodecName(audio_stream_info.codec);
           }
+          return ffmpeg_audio_decoder;
         }
-        return nullptr;
+        SB_NOTREACHED();
       };
 
       components.audio.decoder = std::make_unique<AdaptiveAudioDecoder>(

--- a/starboard/raspi/shared/player_components_factory.cc
+++ b/starboard/raspi/shared/player_components_factory.cc
@@ -42,8 +42,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
                       SbDrmSystem drm_system) -> std::unique_ptr<AudioDecoder> {
         if (audio_stream_info.codec == kSbMediaAudioCodecOpus) {
           auto opus_audio_decoder =
-              std::make_unique<OpusAudioDecoder>(job_queue, audio_stream_info);
-          if (opus_audio_decoder && opus_audio_decoder->is_valid()) {
+              OpusAudioDecoder::Create(job_queue, audio_stream_info);
+          if (opus_audio_decoder) {
             return opus_audio_decoder;
           }
         } else {

--- a/starboard/raspi/shared/player_components_factory.cc
+++ b/starboard/raspi/shared/player_components_factory.cc
@@ -41,19 +41,10 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
           [job_queue](const AudioStreamInfo& audio_stream_info,
                       SbDrmSystem drm_system) -> std::unique_ptr<AudioDecoder> {
         if (audio_stream_info.codec == kSbMediaAudioCodecOpus) {
-          auto opus_audio_decoder =
-              OpusAudioDecoder::Create(job_queue, audio_stream_info);
-          if (opus_audio_decoder) {
-            return opus_audio_decoder;
-          }
+          return OpusAudioDecoder::Create(job_queue, audio_stream_info);
         } else {
-          auto ffmpeg_audio_decoder =
-              FfmpegAudioDecoder::Create(job_queue, audio_stream_info);
-          if (ffmpeg_audio_decoder) {
-            return ffmpeg_audio_decoder;
-          }
+          return FfmpegAudioDecoder::Create(job_queue, audio_stream_info);
         }
-        return nullptr;
       };
 
       components.audio.decoder = std::make_unique<AdaptiveAudioDecoder>(

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -44,7 +44,7 @@ static const VorbisLayout vorbis_mappings[8] = {
 };
 
 constexpr int kMinimumBuffersToDecode = 2;
-constexpr int kMaxOpusFramesPerAU = 9600;
+constexpr int kMaxOpusFramesPerAU = 9'600;
 
 }  // namespace
 
@@ -52,7 +52,7 @@ std::unique_ptr<OpusAudioDecoder> OpusAudioDecoder::Create(
     JobQueue* job_queue,
     const AudioStreamInfo& audio_stream_info) {
   OpusMSDecoder* decoder = CreateOpusMultistreamDecoder(audio_stream_info);
-  if (decoder == nullptr) {
+  if (!decoder) {
     return nullptr;
   }
 

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -231,7 +231,7 @@ OpusMSDecoder* OpusAudioDecoder::CreateOpusMultistreamDecoder(
                   << opus_strerror(error);
     return nullptr;
   }
-  SB_DCHECK(decoder);
+  SB_CHECK(decoder);
 
   return decoder;
 }

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -43,16 +43,34 @@ static const VorbisLayout vorbis_mappings[8] = {
     {5, 3, {0, 6, 1, 2, 3, 4, 5, 7}}, /* 8: 7.1 surround */
 };
 
+constexpr int kMinimumBuffersToDecode = 2;
+constexpr int kMaxOpusFramesPerAU = 9600;
+
 }  // namespace
 
-OpusAudioDecoder::OpusAudioDecoder(JobQueue* job_queue,
-                                   const AudioStreamInfo& audio_stream_info)
-    : JobOwner(job_queue), audio_stream_info_(audio_stream_info) {
-  InitializeCodec();
+std::unique_ptr<OpusAudioDecoder> OpusAudioDecoder::Create(
+    JobQueue* job_queue,
+    const AudioStreamInfo& audio_stream_info) {
+  OpusMSDecoder* decoder = CreateOpusMultistreamDecoder(audio_stream_info);
+  if (decoder == nullptr) {
+    return nullptr;
+  }
+
+  return std::make_unique<OpusAudioDecoder>(
+      PassKey<OpusAudioDecoder>(), job_queue, audio_stream_info, decoder);
 }
 
+OpusAudioDecoder::OpusAudioDecoder(PassKey<OpusAudioDecoder>,
+                                   JobQueue* job_queue,
+                                   const AudioStreamInfo& audio_stream_info,
+                                   OpusMSDecoder* decoder)
+    : JobOwner(job_queue),
+      decoder_(decoder),
+      audio_stream_info_(audio_stream_info),
+      frames_per_au_(kMaxOpusFramesPerAU) {}
+
 OpusAudioDecoder::~OpusAudioDecoder() {
-  if (is_valid()) {
+  if (decoder_ != nullptr) {
     opus_multistream_decoder_ctl(decoder_, OPUS_RESET_STATE);
   }
   TeardownCodec();
@@ -194,32 +212,34 @@ void OpusAudioDecoder::WriteEndOfStream() {
   Schedule(output_cb_);
 }
 
-void OpusAudioDecoder::InitializeCodec() {
+OpusMSDecoder* OpusAudioDecoder::CreateOpusMultistreamDecoder(
+    const AudioStreamInfo& audio_stream_info) {
   int error;
-  int channels = audio_stream_info_.number_of_channels;
+  int channels = audio_stream_info.number_of_channels;
   if (channels > 8 || channels < 1) {
     SB_LOG(ERROR) << "Can't create decoder with " << channels << " channels";
-    return;
+    return nullptr;
   }
 
-  decoder_ = opus_multistream_decoder_create(
-      audio_stream_info_.samples_per_second, channels,
+  OpusMSDecoder* decoder = opus_multistream_decoder_create(
+      audio_stream_info.samples_per_second, channels,
       vorbis_mappings[channels - 1].nb_streams,
       vorbis_mappings[channels - 1].nb_coupled_streams,
       vorbis_mappings[channels - 1].mapping, &error);
   if (error != OPUS_OK) {
     SB_LOG(ERROR) << "Failed to create decoder with error: "
                   << opus_strerror(error);
-    decoder_ = NULL;
-    return;
+    return nullptr;
   }
-  SB_DCHECK(decoder_);
+  SB_DCHECK(decoder);
+
+  return decoder;
 }
 
 void OpusAudioDecoder::TeardownCodec() {
-  if (is_valid()) {
+  if (decoder_ != nullptr) {
     opus_multistream_decoder_destroy(decoder_);
-    decoder_ = NULL;
+    decoder_ = nullptr;
   }
 }
 
@@ -240,7 +260,7 @@ scoped_refptr<DecodedAudio> OpusAudioDecoder::Read(int* samples_per_second) {
 void OpusAudioDecoder::Reset() {
   SB_CHECK(BelongsToCurrentThread());
 
-  if (is_valid()) {
+  if (decoder_ != nullptr) {
     int error = opus_multistream_decoder_ctl(decoder_, OPUS_RESET_STATE);
     if (error != OPUS_OK) {
       SB_LOG(ERROR) << "Failed to reset OpusAudioDecoder with error: "
@@ -248,7 +268,7 @@ void OpusAudioDecoder::Reset() {
 
       // If fail to reset opus decoder, re-create it.
       TeardownCodec();
-      InitializeCodec();
+      decoder_ = CreateOpusMultistreamDecoder(audio_stream_info_);
     }
   }
 
@@ -261,10 +281,6 @@ void OpusAudioDecoder::Reset() {
   consumed_cb_ = nullptr;
 
   CancelPendingJobs();
-}
-
-bool OpusAudioDecoder::is_valid() const {
-  return decoder_ != NULL;
 }
 
 SbMediaAudioSampleType OpusAudioDecoder::GetSampleType() const {

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -70,7 +70,7 @@ OpusAudioDecoder::OpusAudioDecoder(PassKey<OpusAudioDecoder>,
       frames_per_au_(kMaxOpusFramesPerAU) {}
 
 OpusAudioDecoder::~OpusAudioDecoder() {
-  if (decoder_ != nullptr) {
+  if (decoder_) {
     opus_multistream_decoder_ctl(decoder_, OPUS_RESET_STATE);
   }
   TeardownCodec();
@@ -237,7 +237,7 @@ OpusMSDecoder* OpusAudioDecoder::CreateOpusMultistreamDecoder(
 }
 
 void OpusAudioDecoder::TeardownCodec() {
-  if (decoder_ != nullptr) {
+  if (decoder_) {
     opus_multistream_decoder_destroy(decoder_);
     decoder_ = nullptr;
   }
@@ -260,7 +260,7 @@ scoped_refptr<DecodedAudio> OpusAudioDecoder::Read(int* samples_per_second) {
 void OpusAudioDecoder::Reset() {
   SB_CHECK(BelongsToCurrentThread());
 
-  if (decoder_ != nullptr) {
+  if (decoder_) {
     int error = opus_multistream_decoder_ctl(decoder_, OPUS_RESET_STATE);
     if (error != OPUS_OK) {
       SB_LOG(ERROR) << "Failed to reset OpusAudioDecoder with error: "

--- a/starboard/shared/opus/opus_audio_decoder.h
+++ b/starboard/shared/opus/opus_audio_decoder.h
@@ -16,9 +16,11 @@
 #define STARBOARD_SHARED_OPUS_OPUS_AUDIO_DECODER_H_
 
 #include <deque>
+#include <memory>
 #include <queue>
 #include <vector>
 
+#include "starboard/common/pass_key.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
@@ -32,11 +34,15 @@ namespace starboard {
 
 class OpusAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
  public:
-  OpusAudioDecoder(JobQueue* job_queue,
-                   const AudioStreamInfo& audio_stream_info);
-  ~OpusAudioDecoder() override;
+  static std::unique_ptr<OpusAudioDecoder> Create(
+      JobQueue* job_queue,
+      const AudioStreamInfo& audio_stream_info);
 
-  bool is_valid() const;
+  OpusAudioDecoder(PassKey<OpusAudioDecoder>,
+                   JobQueue* job_queue,
+                   const AudioStreamInfo& audio_stream_info,
+                   OpusMSDecoder* decoder);
+  ~OpusAudioDecoder() override;
 
   // AudioDecoder functions
   void Initialize(const OutputCB& output_cb, const ErrorCB& error_cb) override;
@@ -47,24 +53,22 @@ class OpusAudioDecoder : public AudioDecoder, private JobQueue::JobOwner {
   void Reset() override;
 
  private:
-  static constexpr int kMinimumBuffersToDecode = 2;
+  static OpusMSDecoder* CreateOpusMultistreamDecoder(
+      const AudioStreamInfo& audio_stream_info);
 
-  void InitializeCodec();
   void TeardownCodec();
   void DecodePendingBuffers();
   bool DecodeInternal(const scoped_refptr<InputBuffer>& input_buffer);
-  static const int kMaxOpusFramesPerAU = 9600;
-
   SbMediaAudioSampleType GetSampleType() const;
 
   OutputCB output_cb_;
   ErrorCB error_cb_;
 
-  OpusMSDecoder* decoder_ = NULL;
+  OpusMSDecoder* decoder_ = nullptr;
   bool stream_ended_ = false;
   std::queue<scoped_refptr<DecodedAudio>> decoded_audios_;
-  AudioStreamInfo audio_stream_info_;
-  int frames_per_au_ = kMaxOpusFramesPerAU;
+  const AudioStreamInfo audio_stream_info_;
+  int frames_per_au_;
 
   std::deque<scoped_refptr<InputBuffer>> pending_audio_buffers_;
   ConsumedCB consumed_cb_;

--- a/starboard/tvos/shared/media/player_components_factory.mm
+++ b/starboard/tvos/shared/media/player_components_factory.mm
@@ -170,8 +170,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
           return std::make_unique<TvosAudioDecoder>(job_queue,
                                                     audio_stream_info);
         } else if (audio_stream_info.codec == kSbMediaAudioCodecOpus) {
-          return std::make_unique<OpusAudioDecoder>(job_queue,
-                                                    audio_stream_info);
+          return OpusAudioDecoder::Create(job_queue, audio_stream_info);
         } else {
           SB_NOTREACHED();
         }


### PR DESCRIPTION
Introduce a static Create factory method for OpusAudioDecoder.

https://abseil.io/tips/42

This change encapsulates the construction logic, allowing for clearer
handling of potential failures during Opus decoder initialization.
Instead of a constructor that might result in an invalid object state
requiring a subsequent is_valid() check, the factory method returns
a unique_ptr that is null on failure. This simplifies client code
and ensures that a valid OpusAudioDecoder instance is always returned
upon successful creation. A PassKey is used to prevent direct
instantiation of the class, enforcing the use of the factory method.

Issue: 479994435