### PR TITLE
android: Enable Flush AudioTrack during Seek

### DIFF
--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -189,7 +189,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
   SB_DCHECK(frame_buffer_);
   SB_CHECK(bridge_);
 
-  SB_LOG(INFO) << "Creating audio sink starts at " << start_time_;
+  SB_LOG(INFO) << "Creating audio sink starts at " << start_time_.load();
 }
 
 AudioTrackAudioSink::~AudioTrackAudioSink() {
@@ -227,6 +227,11 @@ int AudioTrackAudioSink::GetStartThresholdInFrames() {
   return bridge_->GetStartThresholdInFrames();
 }
 
+bool AudioTrackAudioSink::Flush() {
+  flush_requested_ = true;
+  return true;
+}
+
 // TODO: Break down the function into manageable pieces.
 void AudioTrackAudioSink::AudioThreadFunc() {
   JNIEnv* env = AttachCurrentThread();
@@ -244,6 +249,19 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       features::kReleaseVideoFramesAfterAudioStarts);
 
   while (!quit_) {
+    if (flush_requested_) {
+      bridge_->PauseAndFlush();
+      frames_in_audio_track = 0;
+      accumulated_written_frames = 0;
+      last_playback_head_event_at = -1;
+      // Set to -1 to ignore the first playback head position read after a
+      // flush. This avoids using a stale value from before the reset, which
+      // could lead to incorrect frame consumption calculations.
+      last_playback_head_position = -1;
+      flush_requested_ = false;
+      continue;
+    }
+
     int playback_head_position = 0;
     int64_t frames_consumed_at = 0;
     if (bridge_->GetAndResetHasAudioDeviceChanged(env)) {
@@ -268,10 +286,16 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     if (should_update_media_time) {
       playback_head_position =
           bridge_->GetAudioTimestamp(&frames_consumed_at, env);
-      SB_DCHECK_GE(playback_head_position, last_playback_head_position);
 
-      int frames_consumed =
-          playback_head_position - last_playback_head_position;
+      int frames_consumed = 0;
+      if (last_playback_head_position == -1) {
+        last_playback_head_position = playback_head_position;
+      } else {
+        frames_consumed =
+            std::max(0, static_cast<int>(playback_head_position -
+                                         last_playback_head_position));
+      }
+
       int64_t now = CurrentMonotonicTime();
 
       if (last_playback_head_event_at == -1) {
@@ -367,8 +391,8 @@ void AudioTrackAudioSink::AudioThreadFunc() {
         std::vector<uint8_t> silence_buffer(channels_ *
                                             GetBytesPerSample(sample_type_) *
                                             silence_frames_per_append);
-        int64_t sync_time =
-            start_time_ + GetFramesDurationUs(accumulated_written_frames);
+        int64_t sync_time = start_time_.load() +
+                            GetFramesDurationUs(accumulated_written_frames);
         // Not necessary to handle error of WriteData(), as the audio has
         // reached the end of stream.
         WriteData(env, silence_buffer.data(), silence_frames_per_append,
@@ -380,7 +404,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     }
     SB_DCHECK_GT(expected_written_frames, 0);
     int64_t sync_time =
-        start_time_ + GetFramesDurationUs(accumulated_written_frames);
+        start_time_.load() + GetFramesDurationUs(accumulated_written_frames);
     SB_DCHECK_LE(start_position + expected_written_frames, frames_per_channel_)
         << "start_position: " << start_position
         << ", expected_written_frames: " << expected_written_frames

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -151,6 +151,8 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   void SetVolume(double volume) override;
   int GetUnderrunCount();
   int GetStartThresholdInFrames();
+  bool Flush();
+  void SetStartTime(int64_t start_time) { start_time_.store(start_time); }
 
  private:
   class AudioTrackOutThread;
@@ -171,7 +173,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const raw_ptr<void> frame_buffer_;
   const int frames_per_channel_;
   const AudioTrackAudioSinkType::Callbacks callbacks_;
-  const int64_t start_time_;  // microseconds
+  std::atomic<int64_t> start_time_;  // microseconds
   const int max_frames_per_request_;
   const raw_ptr<void> context_;
 
@@ -181,6 +183,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const std::unique_ptr<AudioTrackBridge> bridge_;
 
   volatile bool quit_ = false;
+  std::atomic_bool flush_requested_{false};
   // Guaranteed to be non-null.
   const std::unique_ptr<Thread> audio_out_thread_;
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -73,7 +73,8 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
   explicit AudioRendererSinkAndroid(
       int tunnel_mode_audio_session_id = -1,
       bool allow_audio_writing_on_pause = false,
-      bool enable_video_renderer_vsp_adjustment = false)
+      bool enable_video_renderer_vsp_adjustment = false,
+      bool allow_flush_during_seek = false)
       : AudioRendererSinkImpl(
             [=](int64_t start_media_time,
                 int channels,
@@ -100,7 +101,8 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
             }),
         tunnel_mode_audio_session_id_(tunnel_mode_audio_session_id),
         enable_video_renderer_vsp_adjustment_(
-            enable_video_renderer_vsp_adjustment) {}
+            enable_video_renderer_vsp_adjustment),
+        allow_flush_during_seek_(allow_flush_during_seek) {}
 
   bool AllowOverflowAudioSamples() const override {
     return tunnel_mode_audio_session_id_ != -1;
@@ -109,6 +111,10 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
   bool AllowDirectPlaybackRateSetting() const override {
     return tunnel_mode_audio_session_id_ != -1 &&
            !enable_video_renderer_vsp_adjustment_;
+  }
+
+  bool HasStarted() const override {
+    return !is_flushed_ && AudioRendererSinkImpl::HasStarted();
   }
 
   void GetAudioRendererParams(const AudioStreamInfo& audio_stream_info,
@@ -155,6 +161,48 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
                                  AudioRendererSink::kAudioSinkFramesAlignment);
   }
 
+  void Start(int64_t media_start_time,
+             int channels,
+             int sampling_frequency_hz,
+             SbMediaAudioSampleType audio_sample_type,
+             SbMediaAudioFrameStorageType audio_frame_storage_type,
+             SbAudioSinkFrameBuffers frame_buffers,
+             int frames_per_channel,
+             RenderCallback* render_callback) override {
+    is_flushed_ = false;
+    // Re-use the existing audio sink if the new audio parameters match the
+    // existing ones. Otherwise, fall back to the default behavior of destroying
+    // and re-creating the sink.
+    if (allow_flush_during_seek_ && audio_sink_ &&
+        audio_sink_->IsType(SbAudioSinkImpl::GetPreferredType()) &&
+        channels == channels_ &&
+        sampling_frequency_hz == sampling_frequency_hz_ &&
+        audio_sample_type == audio_sample_type_ &&
+        audio_frame_storage_type == audio_frame_storage_type_) {
+      SB_LOG(INFO) << "Audio track is already started with the same config, "
+                   << "skipping Start().";
+      auto* track_sink = static_cast<AudioTrackAudioSink*>(audio_sink_);
+      track_sink->SetStartTime(media_start_time);
+      // Explicitly set the playback rate and volume because HasStarted()
+      // returns false while in the flushed state, causing the renderer to
+      // skip updating the sink with these parameters during seek.
+      track_sink->SetPlaybackRate(playback_rate_);
+      track_sink->SetVolume(volume_);
+      render_callback_ = render_callback;
+      return;
+    }
+
+    channels_ = channels;
+    sampling_frequency_hz_ = sampling_frequency_hz;
+    audio_sample_type_ = audio_sample_type;
+    audio_frame_storage_type_ = audio_frame_storage_type;
+
+    AudioRendererSinkImpl::Start(media_start_time, channels,
+                                 sampling_frequency_hz, audio_sample_type,
+                                 audio_frame_storage_type, frame_buffers,
+                                 frames_per_channel, render_callback);
+  }
+
  private:
   bool IsAudioSampleTypeSupported(
       SbMediaAudioSampleType audio_sample_type) const override {
@@ -167,8 +215,33 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
     return SbAudioSinkIsAudioSampleTypeSupported(audio_sample_type);
   }
 
+  void Reset() override {
+    if (allow_flush_during_seek_ && audio_sink_ &&
+        audio_sink_->IsType(SbAudioSinkImpl::GetPreferredType())) {
+      auto* track_sink = static_cast<AudioTrackAudioSink*>(audio_sink_);
+      if (track_sink->Flush()) {
+        SB_LOG(INFO) << "Flushing AudioTrack.";
+        is_flushed_ = true;
+        return;
+      }
+    }
+    SB_LOG(INFO) << "Resetting AudioTrack.";
+    is_flushed_ = false;
+    AudioRendererSink::Reset();
+  }
+
   const int tunnel_mode_audio_session_id_;
   const bool enable_video_renderer_vsp_adjustment_;
+  const bool allow_flush_during_seek_;
+
+  mutable bool is_flushed_ = false;
+
+  int channels_ = -1;
+  int sampling_frequency_hz_ = -1;
+  SbMediaAudioSampleType audio_sample_type_ =
+      kSbMediaAudioSampleTypeInt16Deprecated;
+  SbMediaAudioFrameStorageType audio_frame_storage_type_ =
+      kSbMediaAudioFrameStorageTypeInterleaved;
 };
 
 class PlayerComponentsPassthrough : public PlayerComponents {
@@ -396,6 +469,12 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
                             : "<not provided>")
         << ".";
 
+    bool allow_flush_audio_track_during_seek =
+        FeatureList::IsEnabled(features::kForceFlushAudioTrackDuringReset);
+    SB_LOG_IF(INFO, allow_flush_audio_track_during_seek)
+        << "`kForceFlushAudioTrackDuringReset` is set to true, force flushing"
+        << " audio track during Reset().";
+
     MediaComponents components;
     JobQueue* job_queue = creation_parameters.job_queue();
 
@@ -442,7 +521,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       components.audio.renderer_sink =
           std::make_unique<AudioRendererSinkAndroid>(
               tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
-              enable_video_renderer_vsp_adjustment);
+              enable_video_renderer_vsp_adjustment,
+              allow_flush_audio_track_during_seek);
     }
 
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone) {

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -105,6 +105,13 @@ FEATURE_LIST_START
 // to enable app provisioning.
 STARBOARD_FEATURE(kEnableAppProvisioning, "EnableAppProvisioning", false)
 
+// By default, Cobalt destroys and recreates AudioTrack during Seek().
+// Set the following variable to true to force it to Flush() AudioTrack
+// during Seek().
+STARBOARD_FEATURE(kForceFlushAudioTrackDuringReset,
+                  "ForceFlushAudioTrackDuringReset",
+                  false)
+
 // By default, Cobalt recreates MediaCodec when Reset() during Seek().
 // Set the following variable to true to force it Flush() MediaCodec
 // during Seek().

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -246,29 +246,31 @@ void AudioRendererPcm::Seek(int64_t seek_to_time) {
     last_media_time_ = seek_to_time;
     ended_cb_called_ = false;
     seeking_ = true;
+
+    // The resampler maintains internal state and must be reset during a seek
+    // to avoid audio glitches. If the sink is flushed but not stopped,
+    // the callbacks might still be called by the audio thread, so the following
+    // modifications must be protected by the lock.
+    if (resampler_) {
+      resampler_.reset();
+      time_stretcher_.FlushBuffers();
+    }
+
+    total_frames_sent_to_sink_ = 0;
+    total_frames_consumed_by_sink_ = 0;
+    frames_consumed_by_sink_since_last_get_current_time_ = 0;
+    pending_decoder_outputs_ = 0;
+    audio_frame_tracker_.Reset();
+    frames_consumed_set_at_ = CurrentMonotonicTime();
+    can_accept_more_data_ = true;
+
+    is_eos_reached_on_sink_thread_ = false;
+    is_playing_on_sink_thread_ = false;
+    frames_in_buffer_on_sink_thread_ = 0;
+    offset_in_frames_on_sink_thread_ = 0;
+    frames_consumed_on_sink_thread_ = 0;
+    silence_frames_written_after_eos_on_sink_thread_ = 0;
   }
-
-  // Now the sink is stopped and the callbacks will no longer be called, so the
-  // following modifications are safe without lock.
-  if (resampler_) {
-    resampler_.reset();
-    time_stretcher_.FlushBuffers();
-  }
-
-  total_frames_sent_to_sink_ = 0;
-  total_frames_consumed_by_sink_ = 0;
-  frames_consumed_by_sink_since_last_get_current_time_ = 0;
-  pending_decoder_outputs_ = 0;
-  audio_frame_tracker_.Reset();
-  frames_consumed_set_at_ = CurrentMonotonicTime();
-  can_accept_more_data_ = true;
-
-  is_eos_reached_on_sink_thread_ = false;
-  is_playing_on_sink_thread_ = false;
-  frames_in_buffer_on_sink_thread_ = 0;
-  offset_in_frames_on_sink_thread_ = 0;
-  frames_consumed_on_sink_thread_ = 0;
-  silence_frames_written_after_eos_on_sink_thread_ = 0;
 
   if (first_input_written_) {
     decoder_->Reset();

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -83,21 +83,6 @@ void AudioRendererSinkImpl::GetAudioRendererParams(
   *max_cached_frames = AlignUp(*max_cached_frames, kAudioSinkFramesAlignment);
 }
 
-bool AudioRendererSinkImpl::IsAudioSampleTypeSupported(
-    SbMediaAudioSampleType audio_sample_type) const {
-  return SbAudioSinkIsAudioSampleTypeSupported(audio_sample_type);
-}
-
-bool AudioRendererSinkImpl::IsAudioFrameStorageTypeSupported(
-    SbMediaAudioFrameStorageType audio_frame_storage_type) const {
-  return SbAudioSinkIsAudioFrameStorageTypeSupported(audio_frame_storage_type);
-}
-
-int AudioRendererSinkImpl::GetNearestSupportedSampleFrequency(
-    int sampling_frequency_hz) const {
-  return SbAudioSinkGetNearestSupportedSampleFrequency(sampling_frequency_hz);
-}
-
 bool AudioRendererSinkImpl::HasStarted() const {
   return SbAudioSinkIsValid(audio_sink_);
 }
@@ -139,6 +124,21 @@ void AudioRendererSinkImpl::Start(
   audio_sink_->SetVolume(volume_);
 }
 
+bool AudioRendererSinkImpl::IsAudioSampleTypeSupported(
+    SbMediaAudioSampleType audio_sample_type) const {
+  return SbAudioSinkIsAudioSampleTypeSupported(audio_sample_type);
+}
+
+bool AudioRendererSinkImpl::IsAudioFrameStorageTypeSupported(
+    SbMediaAudioFrameStorageType audio_frame_storage_type) const {
+  return SbAudioSinkIsAudioFrameStorageTypeSupported(audio_frame_storage_type);
+}
+
+int AudioRendererSinkImpl::GetNearestSupportedSampleFrequency(
+    int sampling_frequency_hz) const {
+  return SbAudioSinkGetNearestSupportedSampleFrequency(sampling_frequency_hz);
+}
+
 void AudioRendererSinkImpl::Stop() {
   SB_CHECK(thread_checker_.CalledOnValidThread());
 
@@ -147,13 +147,6 @@ void AudioRendererSinkImpl::Stop() {
     audio_sink_ = kSbAudioSinkInvalid;
     render_callback_ = NULL;
   }
-}
-
-void AudioRendererSinkImpl::Reset() {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
-
-  // TODO: b/330793785 - Flush AudioSink on ATV
-  Stop();
 }
 
 void AudioRendererSinkImpl::SetVolume(double volume) {

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
@@ -50,15 +50,7 @@ class AudioRendererSinkImpl : public AudioRendererSink {
                               int* max_cached_frames,
                               int* min_frames_per_append) const override;
 
- private:
-  // AudioRendererSink methods
-  bool IsAudioSampleTypeSupported(
-      SbMediaAudioSampleType audio_sample_type) const override;
-  bool IsAudioFrameStorageTypeSupported(
-      SbMediaAudioFrameStorageType audio_frame_storage_type) const override;
-  int GetNearestSupportedSampleFrequency(
-      int sampling_frequency_hz) const override;
-
+ protected:
   bool HasStarted() const override;
   void Start(int64_t media_start_time,
              int channels,
@@ -68,8 +60,22 @@ class AudioRendererSinkImpl : public AudioRendererSink {
              SbAudioSinkFrameBuffers frame_buffers,
              int frames_per_channel,
              RenderCallback* render_callback) override;
+
+  SbAudioSinkPrivate* audio_sink_ = kSbAudioSinkInvalid;
+  RenderCallback* render_callback_ = NULL;
+  double playback_rate_ = 1.0;
+  double volume_ = 1.0;
+
+ private:
+  // AudioRendererSink methods
+  bool IsAudioSampleTypeSupported(
+      SbMediaAudioSampleType audio_sample_type) const override;
+  bool IsAudioFrameStorageTypeSupported(
+      SbMediaAudioFrameStorageType audio_frame_storage_type) const override;
+  int GetNearestSupportedSampleFrequency(
+      int sampling_frequency_hz) const override;
+
   void Stop() override;
-  void Reset() override;
 
   void SetVolume(double volume) override;
   void SetPlaybackRate(double playback_rate) override;
@@ -89,11 +95,6 @@ class AudioRendererSinkImpl : public AudioRendererSink {
 
   ThreadChecker thread_checker_;
   const CreateAudioSinkFunc create_audio_sink_func_;
-
-  SbAudioSinkPrivate* audio_sink_ = kSbAudioSinkInvalid;
-  RenderCallback* render_callback_ = NULL;
-  double playback_rate_ = 1.0;
-  double volume_ = 1.0;
 };
 
 }  // namespace starboard


### PR DESCRIPTION
Previously, seeking operations would cause the Android AudioTrack to be
destroyed and recreated. This can lead to audio glitches or delays
during playback.

This change introduces a Starboard extension to allow platforms to
implement an audio sink flush mechanism. For Android, this is
implemented to flush the underlying AudioTrack during a seek operation
rather than stopping and recreating it.

This new behavior is enabled via the
kForceFlushAudioTrackDuringReset feature flag, providing a smoother
and more efficient audio reset during seeks. The internal audio
renderer logic is also updated to correctly handle the sink's state
when it is flushed but not stopped.

Issue: 330793785