### PR TITLE
Fix javascript cache handling

### DIFF
--- a/cobalt/script/v8c/v8c_global_environment.cc
+++ b/cobalt/script/v8c/v8c_global_environment.cc
@@ -529,15 +529,21 @@ v8::MaybeLocal<v8::Script> V8cGlobalEnvironment::Compile(
     v8::Local<v8::Script> script;
     if (v8::ScriptCompiler::Compile(context, &script_source,
                                     v8::ScriptCompiler::kConsumeCodeCache)
-            .ToLocal(&script) &&
-        !cached_code->rejected) {
+            .ToLocal(&script)) {
+      if (cached_code->rejected) {
+        cobalt::cache::Cache::GetInstance()->Delete(
+            network::disk_cache::ResourceType::kCompiledScript, javascript_cache_key);
+        LOG(WARNING)
+            << "CompileWithCaching: Failed to reuse the cached script rejected="
+            << cached_code->rejected << ", key=" << javascript_cache_key;
+      }
       return script;
     }
   }
   cobalt::cache::Cache::GetInstance()->Delete(
       network::disk_cache::ResourceType::kCompiledScript, javascript_cache_key);
   LOG(WARNING)
-      << "CompileWithCaching: Failed to reuse the cached script rejected="
+      << "CompileWithCaching: Failed to compile script completely. rejected="
       << cached_code->rejected << ", key=" << javascript_cache_key;
   return {};
 }


### PR DESCRIPTION
cobalt: Retain compiled JS despite rejected cache

The V8 JavaScript compiler incorrectly discarded a successfully compiled
script if its associated cache entry was marked as 'rejected'. This led
to unnecessary recompilation of valid JavaScript code.

This change ensures that if the script compilation process
succeeds, the compiled script is always returned. If the original
cache entry was marked as rejected, it is now explicitly deleted
from the cache to prevent future issues with that specific entry.
This improves performance by reusing valid compiled scripts.

Issue: 506177754