### PR TITLE
aosp: Break starboard -> base dep cycle

### DIFF
--- a/copied_base/base/BUILD.gn
+++ b/copied_base/base/BUILD.gn
@@ -1765,6 +1765,14 @@ component("base") {
       "//starboard:starboard_group",
       "//starboard/common",
     ]
+
+    # TODO(crbug.com/495203133): Android is the only platform whose starboard
+    # library depends on //base. On AOSP, `is_starboard` is true, so this leads
+    # to a circular dependency.
+    if (is_android) {
+      deps -= [ "//starboard:starboard_group" ]
+      deps += [ "//starboard:starboard_headers_only" ]
+    }
   }
 
   if (is_cobalt_hermetic_build) {


### PR DESCRIPTION
On AOSP, the Starboard library is built from //starboard/android/shared, which depends on //base. //base in turn depends on //starboard via the is_starboard branch in copied_base/base/BUILD.gn, closing a dependency cycle that GN refuses during 'gn gen'.

Temporarily restrict the Starboard dependency to :starboard_headers_only for AOSP.

Bug: 495203133