### PR TITLE
Add UMA for Android memory pressure

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -60,6 +60,7 @@ import org.chromium.base.CommandLine;
 import org.chromium.base.library_loader.LibraryLoader;
 import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.base.memory.MemoryPressureMonitor;
+import org.chromium.base.memory.MemoryPressureUma;
 import org.chromium.base.version_info.VersionInfo;
 import org.chromium.content.browser.input.ImeAdapterImpl;
 import org.chromium.content_public.browser.BrowserStartupController;
@@ -441,6 +442,7 @@ public abstract class CobaltActivity extends Activity {
 
     createContent(savedInstanceState);
     MemoryPressureMonitor.INSTANCE.registerComponentCallbacks();
+    MemoryPressureUma.initializeForBrowser();
     NetworkChangeNotifier.init();
     NetworkChangeNotifier.setAutoDetectConnectivityState(true);
 

--- a/tools/metrics/histograms/metadata/cobalt/enums.xml
+++ b/tools/metrics/histograms/metadata/cobalt/enums.xml
@@ -27,6 +27,18 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
 
 <enums>
 
+<enum name="Android.MemoryPressureNotification">
+  <int value="0" label="Unknown onTrimMemory() level"/>
+  <int value="1" label="TRIM_MEMORY_COMPLETE"/>
+  <int value="2" label="TRIM_MEMORY_MODERATE"/>
+  <int value="3" label="TRIM_MEMORY_BACKGROUND"/>
+  <int value="4" label="TRIM_MEMORY_UI_HIDDEN"/>
+  <int value="5" label="TRIM_MEMORY_RUNNING_CRITICAL"/>
+  <int value="6" label="TRIM_MEMORY_RUNNING_LOW"/>
+  <int value="7" label="TRIM_MEMORY_RUNNING_MODERATE"/>
+  <int value="8" label="onLowMemory()"/>
+</enum>
+
 <enum name="BooleanHung">
   <int value="0" label="Is not hung"/>
   <int value="1" label="Is hung"/>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -31,6 +31,20 @@ Always run the pretty print utility on this file after editing:
 
 <histograms>
 
+<histogram name="Android.MemoryPressureNotification{AndroidProcessType}"
+    enum="Android.MemoryPressureNotification" expires_after="never">
+  <owner>sideboard@google.com</owner>
+  <summary>
+    Memory pressure notifications sent by Android through ComponentCallbacks2.
+    This metric is copied from android/histograms where it expired in 2021.
+  </summary>
+  <token key="AndroidProcessType">
+    <variant name=".Browser" summary="Browser process"/>
+    <variant name=".ChildService"
+        summary="Child service process (renderer, GPU, etc.)"/>
+  </token>
+</histogram>
+
 <histogram name="Cobalt.Finch.ConfigAgeInDays" units="days"
     expires_after="never">
   <owner>yijiazhang@google.com</owner>


### PR DESCRIPTION
This change introduces UMA metrics to track how often the Cobalt
application receives memory pressure notifications from Android.
A new histogram, Android.MemoryPressureNotification, is added to record
the frequency of various onTrimMemory() levels and onLowMemory() calls.
This data helps identify memory pressure patterns and aids in
understanding and improving Cobalt's memory management on Android.

Bug: 411466538