### PR TITLE
android: Remove  AAudio dependency for Android 7 TV devices

### DIFF
--- a/build/config/android/config.gni
+++ b/build/config/android/config.gni
@@ -81,7 +81,12 @@ if (is_android) {
       default_min_sdk_version = 29
     }
     if (is_cobalt) {
-      default_min_sdk_version = 26
+      # Cobalt maintains backward compatibility with Android 7.0 (API 24), consistent
+      # with Cobalt 25 and 26 releases. Setting this to 24 allows newer system APIs
+      # (like AAudio) to compile as weak symbols, preventing UnsatisfiedLinkError
+      # startup crashes on legacy TV devices where those libraries don't exist.
+      # See b/508072838, b/422247849
+      default_min_sdk_version = 24
     }
 
     # Static analysis can be either "on" or "off" or "build_server". This

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -108,6 +108,10 @@ public final class CommandLineOverrideHelper {
         // For details, see http://b/478022126#comment6.
         paramOverrides.add("UseAAudioInput");
 
+        // Disable AAudio output to prevent UnsatisfiedLinkError crashes on older Android TVs (like Android 7.1).
+        // See b/508072838
+        paramOverrides.add("UseAAudioDriver");
+
         return paramOverrides;
     }
 

--- a/gpu/command_buffer/service/image_reader_gl_owner.cc
+++ b/gpu/command_buffer/service/image_reader_gl_owner.cc
@@ -30,6 +30,13 @@
 #include "ui/gl/scoped_binders.h"
 #include "ui/gl/scoped_make_current.h"
 
+#include "base/android/requires_api.h"
+
+// AImageReader and AHardwareBuffer APIs were introduced in Android 8.0 (API 26).
+// Since Cobalt's default_min_sdk_version is 24, we must declare that this entire
+// file requires API 26 to silence -Wunguarded-availability compile-time warnings.
+#pragma clang attribute push DEFAULT_REQUIRES_ANDROID_API(26)
+
 namespace gpu {
 
 namespace {
@@ -629,5 +636,7 @@ base::ScopedFD ImageReaderGLOwner::ScopedCurrentImageRef::GetReadyFence()
     const {
   return base::ScopedFD(HANDLE_EINTR(dup(ready_fence_.get())));
 }
+
+#pragma clang attribute pop
 
 }  // namespace gpu

--- a/media/audio/BUILD.gn
+++ b/media/audio/BUILD.gn
@@ -281,7 +281,11 @@ source_set("audio") {
         "android/opensles_wrapper.cc",
       ]
     }
-    libs += [ "aaudio" ]
+    # AAudio is removed for Cobalt to prevent UnsatisfiedLinkError on older Android TVs.
+    # See b/508072838
+    if (!is_cobalt) {
+      libs += [ "aaudio" ]
+    }
 
     deps += [ "//media/base/android:media_jni_headers" ]
   }

--- a/media/gpu/BUILD.gn
+++ b/media/gpu/BUILD.gn
@@ -184,9 +184,13 @@ component("gpu") {
       ]
     }
     libs += [
-      "aaudio",
       "mediandk",
     ]
+    # AAudio is removed for Cobalt to prevent UnsatisfiedLinkError on older Android TVs.
+    # See b/508072838
+    if (!is_cobalt) {
+      libs += [ "aaudio" ]
+    }
     deps += [
       # TODO(crbug.com/40552063): This can be removed once CdmManager is removed.
       "//gpu/ipc/common",

--- a/third_party/webrtc/sdk/android/BUILD.gn
+++ b/third_party/webrtc/sdk/android/BUILD.gn
@@ -1285,7 +1285,12 @@ if (current_os == "linux" || is_android) {
         "src/jni/audio_device/aaudio_wrapper.cc",
         "src/jni/audio_device/aaudio_wrapper.h",
       ]
-      libs = [ "aaudio" ]
+      libs = []
+      # AAudio is removed for Cobalt to prevent UnsatisfiedLinkError on older Android TVs.
+      # See b/508072838
+      if (!is_cobalt) {
+        libs += [ "aaudio" ]
+      }
       deps = [
         ":audio_device_module_base",
         ":base_jni",

--- a/ui/android/java/src/org/chromium/ui/base/WindowAndroid.java
+++ b/ui/android/java/src/org/chromium/ui/base/WindowAndroid.java
@@ -284,9 +284,14 @@ public class WindowAndroid
         // TODO(boliu): Observe configuration changes to update the value of isScreenWideColorGamut.
         if (!Build.VERSION.RELEASE.equals("8.0.0")
                 && ContextUtils.activityFromContext(context) != null) {
-            Configuration configuration = context.getResources().getConfiguration();
-            boolean isScreenWideColorGamut = configuration.isScreenWideColorGamut();
-            display.updateIsDisplayServerWideColorGamut(isScreenWideColorGamut);
+            // Configuration.isScreenWideColorGamut() requires API level 26 (Android O).
+            // Guard it to prevent NoSuchMethodError on older devices (e.g. SDK 24/25),
+            // For details, see b/508072838.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                Configuration configuration = context.getResources().getConfiguration();
+                boolean isScreenWideColorGamut = configuration.isScreenWideColorGamut();
+                display.updateIsDisplayServerWideColorGamut(isScreenWideColorGamut);
+            }
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.S_V2) {


### PR DESCRIPTION
App crashes on legacy Android TV devices (e.g., Android 7.1 / API 25)
due to UnsatisfiedLinkError from missing libaaudio.so.
This change removes the AAudio library dependency and disables the
AAudio driver for Cobalt builds. This allows the app to load safely
and fall back to OpenSL ES for microphone and audio playback,
resolving launch blockers on these older devices.

Issue: 508072838
