### PR TITLE
media: Add configurable decommit strategy

### DIFF
--- a/content/renderer/media/renderer_web_media_player_delegate.cc
+++ b/content/renderer/media/renderer_web_media_player_delegate.cc
@@ -16,6 +16,10 @@
 #include "content/public/renderer/render_frame.h"
 #include "content/public/renderer/render_thread.h"
 #include "media/base/media_content_type.h"
+#include "media/media_buildflags.h"
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/starboard/decoder_buffer_allocator.h"
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "third_party/blink/public/mojom/frame/user_activation_notification_type.mojom.h"
 #include "third_party/blink/public/platform/web_fullscreen_video_status.h"
 #include "third_party/blink/public/web/web_local_frame.h"
@@ -233,6 +237,15 @@ void RendererWebMediaPlayerDelegate::OnPageVisibilityChanged(
          it.Advance()) {
       it.GetCurrentValue()->OnPageHidden();
     }
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+    if (::media::DecoderBufferAllocator::Get()) {
+      // Decommit all available memory blocks when the application transitions
+      // into a hidden state to free up system memory resources.
+      LOG(INFO) << "Decommitting memory blocks on page hidden.";
+      ::media::DecoderBufferAllocator::Get()->DecommitAllDecommitableBlocks();
+    }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   }
 
   ScheduleUpdateTask();

--- a/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
@@ -21,6 +21,7 @@
 #include "media/starboard/starboard_memory_allocator.h"
 #include "starboard/common/bidirectional_fit_reuse_allocator.h"
 #include "starboard/configuration.h"
+
 namespace media {
 
 template <typename ReuseAllocatorBase>
@@ -28,14 +29,37 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
     : public DecoderBufferAllocator::Strategy {
  public:
   BidirectionalFitDecoderBufferAllocatorStrategy(size_t initial_capacity,
-                                                 size_t allocation_increment,
-                                                 bool enable_decommit_on_idle)
+                                                 size_t allocation_increment)
+      : fallback_allocator_(/*enable_decommit_on_idle=*/false),
+        bidirectional_fit_allocator_(&fallback_allocator_,
+                                     initial_capacity,
+                                     kSmallAllocationThreshold,
+                                     allocation_increment) {}
+
+  // Constructs a strategy with explicit decommit configurations.
+  // |enable_decommit_on_idle|: Whether to perform any decommits when idle.
+  // |retain_blocks|: Number of blocks to keep fully committed when idle.
+  // |conservative_decommit_blocks|: Number of blocks beyond retain blocks to
+  // lazily decommit (e.g. using MADV_FREE if supported). Any blocks beyond
+  // these are aggressively decommitted (e.g. using MADV_DONTNEED).
+  // |aggressive_decommit_on_suspend|: Whether to aggressively decommit all idle
+  // blocks when app is suspended.
+  BidirectionalFitDecoderBufferAllocatorStrategy(
+      size_t initial_capacity,
+      size_t allocation_increment,
+      bool enable_decommit_on_idle,
+      size_t retain_blocks,
+      size_t conservative_decommit_blocks,
+      bool aggressive_decommit_on_suspend = false)
       : fallback_allocator_(enable_decommit_on_idle),
         bidirectional_fit_allocator_(&fallback_allocator_,
                                      initial_capacity,
                                      kSmallAllocationThreshold,
                                      allocation_increment,
-                                     enable_decommit_on_idle) {}
+                                     enable_decommit_on_idle,
+                                     retain_blocks,
+                                     conservative_decommit_blocks,
+                                     aggressive_decommit_on_suspend) {}
 
   void* Allocate(DemuxerStream::Type type,
                  size_t size,
@@ -55,6 +79,10 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
 
   size_t GetAllocated() const override {
     return bidirectional_fit_allocator_.GetAllocated();
+  }
+
+  void DecommitAllDecommitableBlocks() override {
+    bidirectional_fit_allocator_.DecommitAllDecommitableBlocks();
   }
 
  private:

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -110,6 +110,13 @@ void DecoderBufferAllocator::Resume() {
   EnsureStrategyIsCreated();
 }
 
+void DecoderBufferAllocator::DecommitAllDecommitableBlocks() {
+  base::AutoLock scoped_lock(mutex_);
+  if (strategy_) {
+    strategy_->DecommitAllDecommitableBlocks();
+  }
+}
+
 DecoderBuffer::Allocator::Handle DecoderBufferAllocator::Allocate(
     DemuxerStream::Type type,
     size_t size,
@@ -256,29 +263,37 @@ void DecoderBufferAllocator::SetAllocateOnDemand(bool enabled) {
 }
 
 // static
-void DecoderBufferAllocator::EnableDecommitableAllocatorStrategy() {
+void DecoderBufferAllocator::EnableConfigurableDecommitStrategy(
+    int block_size,
+    int retain_blocks,
+    int conservative_decommit_blocks,
+    bool aggressive_decommit_on_suspend) {
   auto* allocator = Get();
   CHECK(allocator);
   allocator->UpdateAllocatorStrategy(base::BindRepeating(
-      [](int initial_capacity, int allocation_unit)
+      [](int block_size, int retain_blocks, int conservative_decommit_blocks,
+         bool aggressive_decommit_on_suspend, int initial_capacity,
+         int allocation_unit)
           -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
-        // The default values of initial_capacity and allocation_unit are often
-        // 4 MB, which in the extreme case aren't enough to hold a key frame.
-        // Increase them to 8 MB to accommodate all known key frames without
-        // special allocations in the underlying allocator.
-        constexpr int kAllocationUnit = 8 * 1024 * 1024;
-
-        LOG(INFO) << "DecoderBufferAllocator is using "
-                     "DefaultReuseAllocatorStrategy with decommit enabled. "
-                  << "initial_capacity (" << initial_capacity
-                  << ") and allocation_unit (" << allocation_unit
-                  << ") are ignored and set to " << kAllocationUnit
-                  << " bytes.";
+        LOG(INFO)
+            << "DecoderBufferAllocator is using "
+               "DefaultReuseAllocatorStrategy with configurable decommit. "
+            << "initial_capacity (" << initial_capacity
+            << ") and allocation_unit (" << allocation_unit
+            << ") are ignored. Using "
+            << "block_size: " << block_size << ", "
+            << "retain_blocks: " << retain_blocks << ", "
+            << "conservative_decommit_blocks: " << conservative_decommit_blocks
+            << ", aggressive_decommit_on_suspend: "
+            << ToString(aggressive_decommit_on_suspend);
 
         return std::make_unique<DefaultReuseAllocatorStrategy>(
-            kAllocationUnit, kAllocationUnit,
-            /*enable_decommit_on_idle=*/true);
-      }));
+            block_size, block_size, /*enable_decommit_on_idle=*/true,
+            retain_blocks, conservative_decommit_blocks,
+            aggressive_decommit_on_suspend);
+      },
+      block_size, retain_blocks, conservative_decommit_blocks,
+      aggressive_decommit_on_suspend));
 }
 
 // static
@@ -321,9 +336,8 @@ void DecoderBufferAllocator::EnsureStrategyIsCreated() {
                     "strategy. Falling back to default.";
   }
 
-  strategy_ = std::make_unique<DefaultReuseAllocatorStrategy>(
-      initial_capacity_, allocation_unit_,
-      /*enable_decommit_on_idle=*/false);
+  strategy_ = std::make_unique<DefaultReuseAllocatorStrategy>(initial_capacity_,
+                                                              allocation_unit_);
   LOG(INFO) << "DecoderBufferAllocator is using "
                "DefaultReuseAllocatorStrategy.";
 

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -49,6 +49,8 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
     virtual size_t GetCapacity() const = 0;
     virtual size_t GetAllocated() const = 0;
+
+    virtual void DecommitAllDecommitableBlocks() = 0;
   };
 
   using StrategyCreateCB =
@@ -65,6 +67,7 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
   void Suspend();
   void Resume();
+  void DecommitAllDecommitableBlocks();
 
   // DecoderBuffer::Allocator methods.
   Handle Allocate(DemuxerStream::Type type,
@@ -86,7 +89,11 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   // Utility functions for h5vcc settings.
   // TODO(b/460292554): To be deprecated with h5vcc settings.
   void SetAllocateOnDemand(bool enabled);
-  static void EnableDecommitableAllocatorStrategy();
+  static void EnableConfigurableDecommitStrategy(
+      int block_size,
+      int retain_blocks,
+      int conservative_decommit_blocks,
+      bool aggressive_decommit_on_suspend);
   static void EnableMediaBufferPoolStrategy();
 
  private:

--- a/media/starboard/decoder_buffer_allocator_strategy_test.cc
+++ b/media/starboard/decoder_buffer_allocator_strategy_test.cc
@@ -42,8 +42,7 @@ void UpdateStrategyWithCreationCounter(DecoderBufferAllocator* allocator,
           -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
         (*creation_count_ptr)++;
         return std::make_unique<EmbeddedMetadataReuseAllocatorStrategy>(
-            initial_capacity, allocation_unit,
-            /*enable_decommit_on_idle=*/false);
+            initial_capacity, allocation_unit);
       },
       base::Unretained(creation_count)));
 }

--- a/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
+++ b/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
@@ -36,8 +36,7 @@ MediaBufferPoolDecoderBufferAllocatorStrategy::
           // avoid expansions in most scenarios.
           SbMediaGetAudioBufferBudget() + kAudioAllocationIncrement,
           kSmallAllocationThreshold,
-          kAudioAllocationIncrement,
-          /*enable_decommit_on_idle=*/false),
+          kAudioAllocationIncrement),
       video_allocator_(new MediaBufferPoolBidirectionalReuseAllocator(
           media_buffer_pool_,
           video_buffer_initial_capacity,
@@ -102,6 +101,11 @@ size_t MediaBufferPoolDecoderBufferAllocatorStrategy::GetCapacity() const {
 
 size_t MediaBufferPoolDecoderBufferAllocatorStrategy::GetAllocated() const {
   return audio_allocator_.GetAllocated() + video_allocator_->GetAllocated();
+}
+
+void MediaBufferPoolDecoderBufferAllocatorStrategy::
+    DecommitAllDecommitableBlocks() {
+  audio_allocator_.DecommitAllDecommitableBlocks();
 }
 
 }  // namespace media

--- a/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.h
@@ -48,6 +48,8 @@ class MediaBufferPoolDecoderBufferAllocatorStrategy
 
   size_t GetAllocated() const override;
 
+  void DecommitAllDecommitableBlocks() override;
+
  private:
   typedef starboard::experimental::MediaBufferPoolBidirectionalReuseAllocator
       MediaBufferPoolBidirectionalReuseAllocator;

--- a/media/starboard/starboard_memory_allocator.h
+++ b/media/starboard/starboard_memory_allocator.h
@@ -67,7 +67,7 @@ class StarboardMemoryAllocator : public starboard::Allocator {
   }
   void Free(void* memory) override { free(memory); }
 
-  void Decommit(void* memory, size_t size) override {
+  void Decommit(void* memory, size_t size, bool conservative) override {
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
     uintptr_t start = reinterpret_cast<uintptr_t>(memory);
     CHECK(enable_decommit_);
@@ -80,6 +80,11 @@ class StarboardMemoryAllocator : public starboard::Allocator {
     size_t aligned_size = AlignDown(size, page_size_);
 
     if (aligned_size > 0) {
+      // MADV_FREE is not supported on all kernel versions/configurations. If it
+      // fails, fallback to MADV_DONTNEED to ensure memory is still decommitted.
+      if (conservative && madvise(memory, aligned_size, MADV_FREE) == 0) {
+        return;
+      }
       madvise(memory, aligned_size, MADV_DONTNEED);
     }
   }

--- a/starboard/common/allocator.h
+++ b/starboard/common/allocator.h
@@ -77,7 +77,9 @@ class Allocator {
 
   // Hints to the allocator that the physical memory backing this range is no
   // longer needed, but the virtual address space should remain reserved.
-  virtual void Decommit(void* memory, size_t size) {}
+  // When |conservative| is true, the allocator may use a softer decommit
+  // option like MADV_FREE if supported.
+  virtual void Decommit(void* memory, size_t size, bool conservative) {}
 
   // Returns the allocator's total capacity for allocations.  It will always
   // be true that GetSize() <= GetCapacity(), though it is possible for

--- a/starboard/common/bidirectional_fit_reuse_allocator.h
+++ b/starboard/common/bidirectional_fit_reuse_allocator.h
@@ -37,23 +37,40 @@ namespace starboard {
 // Note that when using this class a significant |initial_capacity| should be
 // set as otherwise new allocations will almost always allocate from the front
 // of the fallback allocator.
-template <typename ReuseAllocatorBase>
-class BidirectionalFitReuseAllocator : public ReuseAllocatorBase {
+template <typename UnderlyingReuseAllocator>
+class BidirectionalFitReuseAllocator : public UnderlyingReuseAllocator {
  public:
-  typedef typename ReuseAllocatorBase::FreeBlockSet::iterator FreeBlockIterator;
-  typedef typename ReuseAllocatorBase::FreeBlockSet::reverse_iterator
+  typedef typename UnderlyingReuseAllocator::FreeBlockSet::iterator
+      FreeBlockIterator;
+  typedef typename UnderlyingReuseAllocator::FreeBlockSet::reverse_iterator
       FreeBlockReverseiterator;
 
   BidirectionalFitReuseAllocator(starboard::Allocator* fallback_allocator,
                                  size_t initial_capacity,
                                  size_t small_allocation_threshold,
+                                 size_t allocation_increment)
+      : UnderlyingReuseAllocator(fallback_allocator,
+                                 initial_capacity,
+                                 allocation_increment,
+                                 /*max_capacity=*/0),
+        small_allocation_threshold_(small_allocation_threshold) {}
+
+  BidirectionalFitReuseAllocator(starboard::Allocator* fallback_allocator,
+                                 size_t initial_capacity,
+                                 size_t small_allocation_threshold,
                                  size_t allocation_increment,
-                                 bool enable_decommit_on_idle)
-      : ReuseAllocatorBase(fallback_allocator,
-                           initial_capacity,
-                           allocation_increment,
-                           /*max_capacity=*/0,
-                           enable_decommit_on_idle),
+                                 bool enable_decommit_on_idle,
+                                 size_t retain_blocks,
+                                 size_t conservative_decommit_blocks,
+                                 bool aggressive_decommit_on_suspend = false)
+      : UnderlyingReuseAllocator(fallback_allocator,
+                                 initial_capacity,
+                                 allocation_increment,
+                                 /*max_capacity=*/0,
+                                 enable_decommit_on_idle,
+                                 retain_blocks,
+                                 conservative_decommit_blocks,
+                                 aggressive_decommit_on_suspend),
         small_allocation_threshold_(small_allocation_threshold) {}
 
   FreeBlockIterator FindFreeBlock(size_t size,

--- a/starboard/common/bidirectional_fit_reuse_allocator_test.cc
+++ b/starboard/common/bidirectional_fit_reuse_allocator_test.cc
@@ -94,7 +94,7 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
       FixedNoFreeAllocator::FreeWithSize(memory, size);
     }
 
-    void Decommit(void* memory, size_t size) override {
+    void Decommit(void* memory, size_t size, bool conservative) override {
       auto it = active_allocations_.find(memory);
       EXPECT_NE(it, active_allocations_.end())
           << "Decommitting a pointer not allocated by this fallback allocator.";
@@ -103,12 +103,18 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
             << "Decommit size does not exactly match the allocated size.";
       }
 
-      decommits.push_back({memory, size});
+      decommits.push_back({memory, size, conservative});
       decommit_count++;
     }
 
+    struct DecommitRecord {
+      void* memory;
+      size_t size;
+      bool conservative;
+    };
+
     int decommit_count;
-    std::vector<std::pair<void*, size_t>> decommits;
+    std::vector<DecommitRecord> decommits;
     std::map<void*, size_t> active_allocations_;
   };
 
@@ -123,11 +129,10 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
         new FixedNoFreeAllocator(buffer_.get(), kBufferSize));
     allocator_.reset(new BidirectionalFitReuseAllocator<ReuseAllocatorBase>(
         fallback_allocator.get(), initial_capacity, small_allocation_threshold,
-        allocation_increment, false));
+        allocation_increment));
 
     fallback_allocator_.swap(fallback_allocator);
   }
-
   void ResetAllocatorWithDecommitSupport() {
     void* tmp = nullptr;
     std::ignore = posix_memalign(&tmp, Allocator::kMinAlignment, kBufferSize);
@@ -140,7 +145,29 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
     mock_fallback_allocator_ = fallback_allocator.get();
 
     allocator_.reset(new BidirectionalFitReuseAllocator<ReuseAllocatorBase>(
-        mock_fallback_allocator_, 0, 0, 0, true));
+        mock_fallback_allocator_, 0, 0, 0, true,
+        /*retain_blocks=*/0,
+        /*conservative_decommit_blocks=*/0));
+
+    fallback_allocator_.reset(fallback_allocator.release());
+  }
+
+  void ResetAllocatorWithTieredDecommitSupport(
+      size_t retain_blocks,
+      size_t conservative_decommit_blocks) {
+    void* tmp = nullptr;
+    std::ignore = posix_memalign(&tmp, Allocator::kMinAlignment, kBufferSize);
+    buffer_.reset(static_cast<uint8_t*>(tmp));
+
+    std::unique_ptr<MockDecommitAllocator> fallback_allocator(
+        new MockDecommitAllocator(buffer_.get(), kBufferSize));
+
+    // Store pointer before move/swap
+    mock_fallback_allocator_ = fallback_allocator.get();
+
+    allocator_.reset(new BidirectionalFitReuseAllocator<ReuseAllocatorBase>(
+        mock_fallback_allocator_, 0, 0, 0, true, retain_blocks,
+        conservative_decommit_blocks));
 
     fallback_allocator_.reset(fallback_allocator.release());
   }
@@ -367,6 +394,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitExactFallbackBlocks) {
   // but it must still decommit the original exact fallback blocks.
   this->allocator_->Free(block1);
   this->allocator_->Free(block2);
+  this->allocator_->DecommitAllDecommitableBlocks();
 
   // We should have exactly 2 decommits matching the original blocks.
   EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 2);
@@ -379,8 +407,8 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitExactFallbackBlocks) {
   bool found_block1 = false;
   bool found_block2 = false;
   for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
-    uint8_t* fallback_ptr = static_cast<uint8_t*>(decommit.first);
-    size_t fallback_size = decommit.second;
+    uint8_t* fallback_ptr = static_cast<uint8_t*>(decommit.memory);
+    size_t fallback_size = decommit.size;
     uint8_t* ptr1 = static_cast<uint8_t*>(block1);
     uint8_t* ptr2 = static_cast<uint8_t*>(block2);
 
@@ -419,6 +447,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitOnBatchedFree) {
   for (void* block : blocks) {
     this->allocator_->Free(block);
   }
+  this->allocator_->DecommitAllDecommitableBlocks();
 
   // EmbeddedMetadataReuseAllocatorBase batches frees and processes them all at
   // once when idle.
@@ -426,9 +455,77 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitOnBatchedFree) {
 
   size_t total_decommitted_size = 0;
   for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
-    total_decommitted_size += decommit.second;
+    total_decommitted_size += decommit.size;
+    EXPECT_FALSE(decommit.conservative);
   }
   EXPECT_GE(total_decommitted_size, kBlockSize * kNumBlocks);
+}
+
+TYPED_TEST(BidirectionalFitReuseAllocatorTest, TieredDecommit) {
+  const size_t kAlignment = sizeof(void*);
+
+  // In this test, each allocate call will allocate a block of size 64KB (+
+  // metadata for InPlace). Since allocation_increment is 0, each will trigger a
+  // fallback allocation. So we pass blocks directly: 1 block retained, 2 blocks
+  // conservatively decommitted.
+  this->ResetAllocatorWithTieredDecommitSupport(/*retain_blocks=*/1,
+                                                /*conservative_blocks=*/2);
+
+  // Allocate 4 blocks of 64KB each.
+  // Block 1 (0 - 64KB) fits entirely in the retain window.
+  // Block 2 (64KB - 128KB) falls in the conservative window.
+  // Block 3 (128KB - 192KB) falls in the conservative window (starts at 128KB,
+  // bytes_past_retain=64KB < 128KB). Block 4 (192KB - 256KB) falls in the
+  // aggressive window (starts at 192KB, bytes_past_retain=128KB >= 128KB).
+  const size_t kBlockSize = 64 * 1024;
+  void* block1 = this->allocator_->Allocate(kBlockSize, kAlignment);
+  void* block2 = this->allocator_->Allocate(kBlockSize, kAlignment);
+  void* block3 = this->allocator_->Allocate(kBlockSize, kAlignment);
+  void* block4 = this->allocator_->Allocate(kBlockSize, kAlignment);
+
+  EXPECT_TRUE(block1 != nullptr);
+  EXPECT_TRUE(block2 != nullptr);
+  EXPECT_TRUE(block3 != nullptr);
+  EXPECT_TRUE(block4 != nullptr);
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0);
+
+  // Free them. The allocator should batch them and process when idle.
+  this->allocator_->Free(block1);
+  this->allocator_->Free(block2);
+  this->allocator_->Free(block3);
+  this->allocator_->Free(block4);
+  this->allocator_->DecommitAllDecommitableBlocks();
+
+  // Block 1 (retain) is skipped. Block 2, 3, 4 should be decommitted.
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 3);
+
+  bool found_block2 = false;
+  bool found_block3 = false;
+  bool found_block4 = false;
+  for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
+    uint8_t* fallback_ptr = static_cast<uint8_t*>(decommit.memory);
+    size_t fallback_size = decommit.size;
+    uint8_t* ptr2 = static_cast<uint8_t*>(block2);
+    uint8_t* ptr3 = static_cast<uint8_t*>(block3);
+    uint8_t* ptr4 = static_cast<uint8_t*>(block4);
+
+    if (ptr2 >= fallback_ptr && ptr2 < fallback_ptr + fallback_size) {
+      found_block2 = true;
+      EXPECT_TRUE(decommit.conservative);
+    }
+    if (ptr3 >= fallback_ptr && ptr3 < fallback_ptr + fallback_size) {
+      found_block3 = true;
+      EXPECT_TRUE(decommit.conservative);
+    }
+    if (ptr4 >= fallback_ptr && ptr4 < fallback_ptr + fallback_size) {
+      found_block4 = true;
+      EXPECT_FALSE(decommit.conservative);
+    }
+  }
+
+  EXPECT_TRUE(found_block2);
+  EXPECT_TRUE(found_block3);
+  EXPECT_TRUE(found_block4);
 }
 
 }  // namespace starboard

--- a/starboard/common/embedded_metadata_reuse_allocator_base.cc
+++ b/starboard/common/embedded_metadata_reuse_allocator_base.cc
@@ -195,6 +195,7 @@ void* EmbeddedMetadataReuseAllocatorBase::Allocate(size_t size,
       static_cast<uint8_t*>(allocated_block.address()) + sizeof(BlockMetadata);
 
   AddAllocatedBlock(allocated_block);
+  TryToDecommitOneBlock();
 
   return user_address;
 }
@@ -218,13 +219,13 @@ void EmbeddedMetadataReuseAllocatorBase::Free(void* memory) {
       total_allocated_in_bytes_ = 0;
       total_allocated_blocks_ = 0;
 
-      EnumerateFallbackAllocations(
-          [this](intptr_t index, void* address, size_t size) {
-            AddFreeBlock(MemoryBlock(static_cast<int>(index), address, size));
-          });
-
       if (enable_decommit_on_idle_) {
-        DecommitFallbackAllocations();
+        ReclaimFallbackBlocks();
+      } else {
+        EnumerateFallbackAllocations(
+            [this](intptr_t index, void* address, size_t size) {
+              AddFreeBlock(MemoryBlock(static_cast<int>(index), address, size));
+            });
       }
     } else {
       for (auto address_to_free : pending_frees_) {
@@ -374,7 +375,8 @@ bool EmbeddedMetadataReuseAllocatorBase::TryFree(void* memory) {
   --total_allocated_blocks_;
 
   if (enable_decommit_on_idle_ && total_allocated_in_bytes_ == 0) {
-    DecommitFallbackAllocations();
+    free_blocks_.clear();
+    ReclaimFallbackBlocks();
   }
 
   return true;
@@ -384,9 +386,31 @@ EmbeddedMetadataReuseAllocatorBase::EmbeddedMetadataReuseAllocatorBase(
     Allocator* fallback_allocator,
     size_t initial_capacity,
     size_t allocation_increment,
+    size_t max_capacity)
+    : EmbeddedMetadataReuseAllocatorBase(
+          fallback_allocator,
+          initial_capacity,
+          allocation_increment,
+          max_capacity,
+          /*enable_decommit_on_idle=*/false,
+          /*retain_blocks=*/0,
+          /*conservative_decommit_blocks=*/0,
+          /*aggressive_decommit_on_suspend=*/false) {}
+
+EmbeddedMetadataReuseAllocatorBase::EmbeddedMetadataReuseAllocatorBase(
+    Allocator* fallback_allocator,
+    size_t initial_capacity,
+    size_t allocation_increment,
     size_t max_capacity,
-    bool enable_decommit_on_idle)
-    : ReuseAllocatorBase(fallback_allocator, max_capacity),
+    bool enable_decommit_on_idle,
+    size_t retain_blocks,
+    size_t conservative_decommit_blocks,
+    bool aggressive_decommit_on_suspend)
+    : ReuseAllocatorBase(fallback_allocator,
+                         max_capacity,
+                         retain_blocks,
+                         conservative_decommit_blocks,
+                         aggressive_decommit_on_suspend),
       allocation_increment_(allocation_increment),
       enable_decommit_on_idle_(enable_decommit_on_idle) {
   if (initial_capacity > 0) {

--- a/starboard/common/embedded_metadata_reuse_allocator_base.h
+++ b/starboard/common/embedded_metadata_reuse_allocator_base.h
@@ -123,8 +123,16 @@ class EmbeddedMetadataReuseAllocatorBase : public ReuseAllocatorBase {
   EmbeddedMetadataReuseAllocatorBase(Allocator* fallback_allocator,
                                      size_t initial_capacity,
                                      size_t allocation_increment,
-                                     size_t max_capacity,
-                                     bool enable_decommit_on_idle);
+                                     size_t max_capacity);
+  EmbeddedMetadataReuseAllocatorBase(
+      Allocator* fallback_allocator,
+      size_t initial_capacity,
+      size_t allocation_increment,
+      size_t max_capacity,
+      bool enable_decommit_on_idle,
+      size_t retain_blocks,
+      size_t conservative_decommit_blocks,
+      bool aggressive_decommit_on_suspend = false);
   ~EmbeddedMetadataReuseAllocatorBase() override;
 
   // The inherited class should implement this function to inform the base

--- a/starboard/common/experimental/media_buffer_pool_bidirectional_reuse_allocator.h
+++ b/starboard/common/experimental/media_buffer_pool_bidirectional_reuse_allocator.h
@@ -39,8 +39,7 @@ class MediaBufferPoolBidirectionalReuseAllocator : public Allocator {
         bidirectional_fit_reuse_allocator_(&fallback_allocator_,
                                            initial_capacity,
                                            small_allocation_threshold,
-                                           allocation_increment,
-                                           /*enable_decommit_on_idle=*/false) {}
+                                           allocation_increment) {}
 
   ~MediaBufferPoolBidirectionalReuseAllocator() {
     SB_DCHECK_EQ(GetAllocated(), 0u);

--- a/starboard/common/external_metadata_reuse_allocator_base.cc
+++ b/starboard/common/external_metadata_reuse_allocator_base.cc
@@ -174,6 +174,7 @@ void* ExternalMetadataReuseAllocatorBase::Allocate(size_t size,
   }
   void* user_address = AlignUp(allocated_block.address(), alignment);
   AddAllocatedBlock(user_address, allocated_block);
+  TryToDecommitOneBlock();
 
   return user_address;
 }
@@ -293,7 +294,8 @@ bool ExternalMetadataReuseAllocatorBase::TryFree(void* memory) {
   allocated_blocks_.erase(it);
 
   if (enable_decommit_on_idle_ && total_allocated_ == 0) {
-    DecommitFallbackAllocations();
+    free_blocks_.clear();
+    ReclaimFallbackBlocks();
   }
 
   return true;
@@ -303,9 +305,31 @@ ExternalMetadataReuseAllocatorBase::ExternalMetadataReuseAllocatorBase(
     Allocator* fallback_allocator,
     size_t initial_capacity,
     size_t allocation_increment,
+    size_t max_capacity)
+    : ExternalMetadataReuseAllocatorBase(
+          fallback_allocator,
+          initial_capacity,
+          allocation_increment,
+          max_capacity,
+          /*enable_decommit_on_idle=*/false,
+          /*retain_blocks=*/0,
+          /*conservative_decommit_blocks=*/0,
+          /*aggressive_decommit_on_suspend=*/false) {}
+
+ExternalMetadataReuseAllocatorBase::ExternalMetadataReuseAllocatorBase(
+    Allocator* fallback_allocator,
+    size_t initial_capacity,
+    size_t allocation_increment,
     size_t max_capacity,
-    bool enable_decommit_on_idle)
-    : ReuseAllocatorBase(fallback_allocator, max_capacity),
+    bool enable_decommit_on_idle,
+    size_t retain_blocks,
+    size_t conservative_decommit_blocks,
+    bool aggressive_decommit_on_suspend)
+    : ReuseAllocatorBase(fallback_allocator,
+                         max_capacity,
+                         retain_blocks,
+                         conservative_decommit_blocks,
+                         aggressive_decommit_on_suspend),
       allocation_increment_(allocation_increment),
       enable_decommit_on_idle_(enable_decommit_on_idle) {
   if (initial_capacity > 0) {

--- a/starboard/common/external_metadata_reuse_allocator_base.h
+++ b/starboard/common/external_metadata_reuse_allocator_base.h
@@ -121,8 +121,16 @@ class ExternalMetadataReuseAllocatorBase : public ReuseAllocatorBase {
   ExternalMetadataReuseAllocatorBase(Allocator* fallback_allocator,
                                      size_t initial_capacity,
                                      size_t allocation_increment,
-                                     size_t max_capacity,
-                                     bool enable_decommit_on_idle);
+                                     size_t max_capacity);
+  ExternalMetadataReuseAllocatorBase(
+      Allocator* fallback_allocator,
+      size_t initial_capacity,
+      size_t allocation_increment,
+      size_t max_capacity,
+      bool enable_decommit_on_idle,
+      size_t retain_blocks,
+      size_t conservative_decommit_blocks,
+      bool aggressive_decommit_on_suspend = false);
   ~ExternalMetadataReuseAllocatorBase() override;
 
   // The inherited class should implement this function to inform the base

--- a/starboard/common/reuse_allocator_base.cc
+++ b/starboard/common/reuse_allocator_base.cc
@@ -19,12 +19,20 @@
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "starboard/common/memory.h"
 
 namespace starboard {
 
 ReuseAllocatorBase::ReuseAllocatorBase(Allocator* fallback_allocator,
-                                       size_t max_capacity)
-    : fallback_allocator_(fallback_allocator), max_capacity_(max_capacity) {
+                                       size_t max_capacity,
+                                       size_t retain_blocks,
+                                       size_t conservative_decommit_blocks,
+                                       bool aggressive_decommit_on_suspend)
+    : fallback_allocator_(fallback_allocator),
+      max_capacity_(max_capacity),
+      retain_blocks_(retain_blocks),
+      conservative_decommit_blocks_(conservative_decommit_blocks),
+      aggressive_decommit_on_suspend_(aggressive_decommit_on_suspend) {
   SB_DCHECK(fallback_allocator_);
 }
 
@@ -34,11 +42,58 @@ ReuseAllocatorBase::~ReuseAllocatorBase() {
   }
 }
 
+void ReuseAllocatorBase::DecommitAllDecommitableBlocks() {
+  if (aggressive_decommit_on_suspend_) {
+    // Aggressively decommit all idle blocks (including retained and
+    // lazily-freed blocks) with MADV_DONTNEED (conservative=false). This
+    // instantly drops the process RSS to prevent the OS Out-Of-Memory killer
+    // from terminating the app in background/suspended states.
+    for (auto& fallback_block : fallback_allocations_) {
+      if (fallback_block.state != kActiveInUse &&
+          fallback_block.state != kIdleDecommitted) {
+        fallback_allocator_->Decommit(fallback_block.address,
+                                      fallback_block.size,
+                                      /*conservative=*/false);
+        fallback_block.state = kIdleDecommitted;
+      }
+    }
+    has_pending_decommits_ = false;
+  } else {
+    if (!has_pending_decommits_) {
+      return;
+    }
+    for (auto it = fallback_allocations_.rbegin();
+         it != fallback_allocations_.rend(); ++it) {
+      if (it->state == kIdlePendingDecommit) {
+        fallback_allocator_->Decommit(it->address, it->size,
+                                      /*conservative=*/false);
+        it->state = kIdleDecommitted;
+      } else if (it->state == kIdlePendingFree) {
+        fallback_allocator_->Decommit(it->address, it->size,
+                                      /*conservative=*/true);
+        it->state = kIdleFreed;
+      }
+    }
+    has_pending_decommits_ = false;
+  }
+}
+
 std::pair<void*, intptr_t> ReuseAllocatorBase::AllocateFallbackBlock(
     size_t* size_to_try,
     size_t alignment) {
   SB_DCHECK(size_to_try);
   SB_DCHECK_GT(*size_to_try, 0U);
+
+  for (size_t i = 0; i < fallback_allocations_.size(); ++i) {
+    auto& fallback_block = fallback_allocations_[i];
+    if (fallback_block.state != kActiveInUse &&
+        fallback_block.size >= *size_to_try &&
+        MemoryIsAligned(fallback_block.address, alignment)) {
+      fallback_block.state = kActiveInUse;
+      *size_to_try = fallback_block.size;
+      return {fallback_block.address, static_cast<intptr_t>(i)};
+    }
+  }
 
   if (max_capacity_ && capacity_ + *size_to_try > max_capacity_) {
     return {nullptr, -1};
@@ -54,12 +109,46 @@ std::pair<void*, intptr_t> ReuseAllocatorBase::AllocateFallbackBlock(
   return {nullptr, -1};
 }
 
-void ReuseAllocatorBase::DecommitFallbackAllocations() {
-  SB_LOG(INFO) << "Allocator reached idle state, decommitting "
+void ReuseAllocatorBase::ReclaimFallbackBlocks() {
+  SB_LOG(INFO) << "Allocator reached idle state, reclaiming "
                << fallback_allocations_.size() << " fallback allocations.";
-  for (const auto& fallback_allocation : fallback_allocations_) {
-    fallback_allocator_->Decommit(fallback_allocation.address,
-                                  fallback_allocation.size);
+  allocation_counter_ = 0;
+  for (size_t i = 0; i < fallback_allocations_.size(); ++i) {
+    auto& fallback_block = fallback_allocations_[i];
+    if (i < retain_blocks_) {
+      fallback_block.state = kIdleRetained;
+    } else if (i < retain_blocks_ + conservative_decommit_blocks_) {
+      fallback_block.state = kIdlePendingFree;
+      has_pending_decommits_ = true;
+    } else {
+      fallback_block.state = kIdlePendingDecommit;
+      has_pending_decommits_ = true;
+    }
+  }
+}
+
+void ReuseAllocatorBase::TryToDecommitOneBlock() {
+  if (!has_pending_decommits_) {
+    return;
+  }
+  ++allocation_counter_;
+  if (allocation_counter_ % 100 == 0) {
+    for (auto it = fallback_allocations_.rbegin();
+         it != fallback_allocations_.rend(); ++it) {
+      if (it->state == kIdlePendingDecommit) {
+        fallback_allocator_->Decommit(it->address, it->size,
+                                      /*conservative=*/false);
+        it->state = kIdleDecommitted;
+        return;
+      }
+      if (it->state == kIdlePendingFree) {
+        fallback_allocator_->Decommit(it->address, it->size,
+                                      /*conservative=*/true);
+        it->state = kIdleFreed;
+        return;
+      }
+    }
+    has_pending_decommits_ = false;
   }
 }
 

--- a/starboard/common/reuse_allocator_base.h
+++ b/starboard/common/reuse_allocator_base.h
@@ -42,8 +42,16 @@ class ReuseAllocatorBase : public Allocator {
   // Allocator methods.
   size_t GetCapacity() const override { return capacity_; }
 
+  // Immediately decommit all remaining decommitable blocks (e.g. on app
+  // suspend).
+  void DecommitAllDecommitableBlocks();
+
  protected:
-  ReuseAllocatorBase(Allocator* fallback_allocator, size_t max_capacity);
+  ReuseAllocatorBase(Allocator* fallback_allocator,
+                     size_t max_capacity,
+                     size_t retain_blocks,
+                     size_t conservative_decommit_blocks,
+                     bool aggressive_decommit_on_suspend = false);
   ~ReuseAllocatorBase() override;
 
   bool CapacityExceeded() const {
@@ -63,8 +71,11 @@ class ReuseAllocatorBase : public Allocator {
   std::pair<void*, intptr_t> AllocateFallbackBlock(size_t* size_to_try,
                                                    size_t alignment);
 
-  // Triggers decommitting of backing allocations when idle (subclass-driven).
-  void DecommitFallbackAllocations();
+  // Reclaims all backing allocations to the base idle pool (subclass-driven).
+  void ReclaimFallbackBlocks();
+
+  // Step counter to amortize decommits across sequential active allocations.
+  void TryToDecommitOneBlock();
 
   // Enumerates fallback backing allocations. Templated to allow zero-cost
   // compiler inlining for capturing lambdas and avoid std::function overhead.
@@ -77,9 +88,25 @@ class ReuseAllocatorBase : public Allocator {
   }
 
  private:
+  enum BlockState {
+    // Actively allocated and managed by subclass.
+    kActiveInUse,
+    // Reclaimed to base pool, retained fully committed in memory.
+    kIdleRetained,
+    // Reclaimed to base pool, pending MADV_FREE decommit.
+    kIdlePendingFree,
+    // Reclaimed to base pool, pending MADV_DONTNEED decommit.
+    kIdlePendingDecommit,
+    // Reclaimed to base pool, successfully decommitted via MADV_FREE.
+    kIdleFreed,
+    // Reclaimed to base pool, successfully decommitted via MADV_DONTNEED.
+    kIdleDecommitted,
+  };
+
   struct FallbackAllocation {
     void* address;
     size_t size;
+    BlockState state = kActiveInUse;
 
     FallbackAllocation(void* init_address, size_t init_size)
         : address(init_address), size(init_size) {}
@@ -93,6 +120,15 @@ class ReuseAllocatorBase : public Allocator {
   // memory pool capacity expand.
   const size_t max_capacity_;
 
+  // How many blocks to retain (not decommit) when the pool becomes idle.
+  const size_t retain_blocks_ = 0;
+
+  // How many blocks to decommit with MADV_FREE after retaining.
+  const size_t conservative_decommit_blocks_ = 0;
+
+  // Whether to aggressively decommit all idle blocks on app suspend.
+  const bool aggressive_decommit_on_suspend_ = false;
+
   // A list of all backing memory blocks allocated from the fallback allocator.
   // We keep track of this so we can decommit on idle and free them upon
   // destruction.
@@ -101,6 +137,12 @@ class ReuseAllocatorBase : public Allocator {
   // How many total bytes we currently have allocated from the fallback
   // allocator.
   size_t capacity_ = 0;
+
+  // Counter to amortize decommits over multiple allocations.
+  size_t allocation_counter_ = 0;
+
+  // Set to true when idle reclamation stages blocks for decommit.
+  bool has_pending_decommits_ = false;
 };
 
 }  // namespace starboard

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -147,11 +147,49 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   const ExceptionContext& exception_context = exception_state.GetContext();
 
-  if (name == "DecoderBuffer.EnableDecommitableAllocatorStrategy") {
-    return ProcessSettingAsEnableOnly(
-        script_state, exception_context, name, *value, [] {
-          ::media::DecoderBufferAllocator::
-              EnableDecommitableAllocatorStrategy();
+  if (name == "DecoderBuffer.EnableConfigurableDecommitStrategy") {
+    // The value is a 32-bit integer encoding four parts:
+    // aggressive_decommit_on_suspend (flag), block_size (in MB), retain_blocks
+    // (count), and conservative_decommit_blocks (count). For example,
+    // 0x01040402 sets aggressive_decommit_on_suspend to true, 4 MB block size,
+    // 4 retain blocks, and 2 conservative decommit blocks respectively.
+    // Passing multiple parameters encoded within a single integer is not
+    // ideal, but it simplifies experiment setup in the current framework.
+    //
+    // - aggressive_decommit_on_suspend: When non-zero, enables aggressive
+    //                                   MADV_DONTNEED decommit on all idle
+    //                                   blocks when app suspends/hides.
+    // - block_size: Specifies both the initial pool capacity and the fallback
+    //               allocation increment.
+    // - retain_blocks: The first `retain_blocks` blocks of the pool are kept
+    //                  fully committed.
+    // - conservative_decommit_blocks: The next `conservative_decommit_blocks`
+    //                                 blocks are conservatively decommitted
+    //                                 (e.g. using MADV_FREE).
+    // Any remaining memory beyond these two windows is aggressively decommitted
+    // (e.g. MADV_DONTNEED).
+    // For example, if 128 MB is allocated for the memory pool, and
+    // retain_blocks is set to 4 with conservative_decommit_blocks set to 2
+    // (with 4 MB block size):
+    //   - The first 16 MB (4 blocks) will be retained during an idle flush.
+    //   - The next 8 MB (2 blocks) will be conservatively decommitted (the OS
+    //     may reclaim it if under memory pressure, but it is not freed
+    //     immediately).
+    //   - The remaining 104 MB (26 blocks) will be aggressively decommitted
+    //   (returned
+    //     to the OS immediately, with virtual memory address range retained).
+    //
+    // Note: The values passed in are assumed to be valid positive integers. A
+    // value of 0 will not enable this feature as it is not a positive integer.
+    return ProcessSettingAsPositiveInt(
+        script_state, exception_context, name, *value, [](int value) {
+          bool aggressive_decommit_on_suspend = ((value >> 24) & 0xFF) != 0;
+          int block_size_mb = (value >> 16) & 0xFF;
+          int retain_blocks = (value >> 8) & 0xFF;
+          int conservative_decommit_blocks = value & 0xFF;
+          ::media::DecoderBufferAllocator::EnableConfigurableDecommitStrategy(
+              block_size_mb * 1024 * 1024, retain_blocks,
+              conservative_decommit_blocks, aggressive_decommit_on_suspend);
           return true;
         });
   }


### PR DESCRIPTION
The DecoderBuffer allocator now utilizes a configurable decommit
strategy. This strategy allows for a tiered approach to memory
management when the buffer pool is idle. It defines distinct regions
for memory to be retained, conservatively decommitted (e.g., using
MADV_FREE), or aggressively decommitted (e.g., using MADV_DONTNEED).

This refactoring replaces the old fixed decommitable allocator strategy,
enabling more granular control and flexibility for memory management
experiments. The new strategy is configured via the
h5vcc setting DecoderBuffer.EnableConfigurableDecommitStrategy,
which encodes unit size, retain size, and conservative decommit size
into a single integer.

Bug: 454441375