### PR TITLE
starboard: Add factories to config classes

### DIFF
--- a/starboard/shared/openh264/openh264_video_decoder.cc
+++ b/starboard/shared/openh264/openh264_video_decoder.cc
@@ -148,10 +148,15 @@ void OpenH264VideoDecoder::DecodeOneBuffer(
   SB_DCHECK(input_buffer);
 
   if (input_buffer->video_sample_info().is_key_frame) {
-    VideoConfig new_config(input_buffer->video_stream_info(),
-                           input_buffer->data(), input_buffer->size());
-    if (!video_config_ || video_config_.value() != new_config) {
-      video_config_ = new_config;
+    auto new_config =
+        VideoConfig::Create(input_buffer->video_stream_info(),
+                            input_buffer->data(), input_buffer->size());
+    if (!new_config) {
+      ReportError("Failed to parse video config.");
+      return;
+    }
+    if (!video_config_ || video_config_.value() != *new_config) {
+      video_config_.emplace(*new_config);
       if (decoder_) {
         FlushFrames();
       }

--- a/starboard/shared/starboard/media/avc_util.cc
+++ b/starboard/shared/starboard/media/avc_util.cc
@@ -24,15 +24,17 @@ namespace starboard {
 
 namespace {
 
-const uint8_t kAnnexBHeader[] = {0, 0, 0, 1};
-const auto kAnnexBHeaderSizeInBytes =
-    AvcParameterSets::kAnnexBHeaderSizeInBytes;
+constexpr uint8_t kAnnexBHeader[] = {0, 0, 0, 1};
+constexpr size_t kAnnexBHeaderSizeInBytes = 4;
+constexpr uint8_t kIdrStartCode = 0x65;
+constexpr uint8_t kSpsStartCode = 0x67;
+constexpr uint8_t kPpsStartCode = 0x68;
+constexpr uint8_t kAudStartCode = 0x09;
 
 bool StartsWithAnnexBHeader(const uint8_t* annex_b_data,
                             size_t annex_b_data_size) {
-  static_assert(
-      sizeof(kAnnexBHeader) == AvcParameterSets::kAnnexBHeaderSizeInBytes,
-      "sizeof(kAnnexBHeader) doesn't match kAnnexBHeaderSizeInBytes");
+  static_assert(sizeof(kAnnexBHeader) == kAnnexBHeaderSizeInBytes,
+                "sizeof(kAnnexBHeader) doesn't match kAnnexBHeaderSizeInBytes");
 
   if (annex_b_data_size < sizeof(kAnnexBHeader)) {
     return false;
@@ -84,19 +86,16 @@ bool ExtractAnnexBNalu(const uint8_t** annex_b_data,
 }  // namespace
 
 // static
-std::optional<AvcParameterSets> AvcParameterSets::Create(Format format,
-                                                         const uint8_t* data,
-                                                         size_t size) {
-  if (format != kAnnexB) {
-    return std::nullopt;
-  }
-
+// static
+std::optional<AvcParameterSets> AvcParameterSets::CreateFromAnnexB(
+    const uint8_t* data,
+    size_t size) {
   if (size > 0 && !StartsWithAnnexBHeader(data, size)) {
     return std::nullopt;
   }
   if (size == 0) {
     return AvcParameterSets(
-        format, /*parameter_sets=*/{}, /*first_sps_index=*/-1,
+        kAnnexB, /*parameter_sets=*/{}, /*first_sps_index=*/-1,
         /*first_pps_index=*/-1, /*combined_size_in_bytes=*/0,
         /*combined_size_with_optionals_in_bytes=*/0);
   }
@@ -132,7 +131,7 @@ std::optional<AvcParameterSets> AvcParameterSets::Create(Format format,
   SB_LOG_IF(ERROR, first_sps_index == -1 || first_pps_index == -1)
       << "AVC parameter set NALUs not found.";
 
-  return AvcParameterSets(format, std::move(parameter_sets), first_sps_index,
+  return AvcParameterSets(kAnnexB, std::move(parameter_sets), first_sps_index,
                           first_pps_index, combined_size_in_bytes,
                           combined_size_with_optionals_in_bytes);
 }

--- a/starboard/shared/starboard/media/avc_util.cc
+++ b/starboard/shared/starboard/media/avc_util.cc
@@ -83,47 +83,70 @@ bool ExtractAnnexBNalu(const uint8_t** annex_b_data,
 
 }  // namespace
 
-AvcParameterSets::AvcParameterSets(Format format,
-                                   const uint8_t* data,
-                                   size_t size)
-    : format_(format) {
-  SB_DCHECK_EQ(format, kAnnexB);
-
-  is_valid_ =
-      format == kAnnexB && (size == 0 || StartsWithAnnexBHeader(data, size));
-
-  if (!is_valid_) {
-    return;
+// static
+std::optional<AvcParameterSets> AvcParameterSets::Create(Format format,
+                                                         const uint8_t* data,
+                                                         size_t size) {
+  if (format != kAnnexB) {
+    return std::nullopt;
   }
 
-  if (size == 0) {
-    return;
+  if (size > 0 && !StartsWithAnnexBHeader(data, size)) {
+    return std::nullopt;
   }
 
-  std::vector<uint8_t> nalu;
-  while (size > kAnnexBHeaderSizeInBytes &&
-         ExtractAnnexBNalu(&data, &size, &nalu)) {
-    if (nalu[kAnnexBHeaderSizeInBytes] == kSpsStartCode) {
-      if (first_sps_index_ == -1) {
-        first_sps_index_ = static_cast<int>(parameter_sets_.size());
+  std::vector<std::vector<uint8_t>> parameter_sets;
+  int first_sps_index = -1;
+  int first_pps_index = -1;
+  size_t combined_size_in_bytes = 0;
+  size_t combined_size_with_optionals_in_bytes = 0;
+
+  if (size > 0) {
+    std::vector<uint8_t> nalu;
+    while (size > kAnnexBHeaderSizeInBytes &&
+           ExtractAnnexBNalu(&data, &size, &nalu)) {
+      if (nalu[kAnnexBHeaderSizeInBytes] == kSpsStartCode) {
+        if (first_sps_index == -1) {
+          first_sps_index = static_cast<int>(parameter_sets.size());
+        }
+        parameter_sets.push_back(nalu);
+        combined_size_in_bytes += nalu.size();
+      } else if (nalu[kAnnexBHeaderSizeInBytes] == kPpsStartCode) {
+        if (first_pps_index == -1) {
+          first_pps_index = static_cast<int>(parameter_sets.size());
+        }
+        parameter_sets.push_back(nalu);
+        combined_size_in_bytes += nalu.size();
+      } else if (nalu[kAnnexBHeaderSizeInBytes] == kIdrStartCode) {
+        break;
+      } else if (nalu[kAnnexBHeaderSizeInBytes] == kAudStartCode) {
+        combined_size_with_optionals_in_bytes += nalu.size();
       }
-      parameter_sets_.push_back(nalu);
-      combined_size_in_bytes_ += nalu.size();
-    } else if (nalu[kAnnexBHeaderSizeInBytes] == kPpsStartCode) {
-      if (first_pps_index_ == -1) {
-        first_pps_index_ = static_cast<int>(parameter_sets_.size());
-      }
-      parameter_sets_.push_back(nalu);
-      combined_size_in_bytes_ += nalu.size();
-    } else if (nalu[kAnnexBHeaderSizeInBytes] == kIdrStartCode) {
-      break;
-    } else if (nalu[kAnnexBHeaderSizeInBytes] == kAudStartCode) {
-      combined_size_with_optionals_in_bytes_ += nalu.size();
     }
   }
-  SB_LOG_IF(ERROR, first_sps_index_ == -1 || first_pps_index_ == -1)
+
+  SB_LOG_IF(ERROR, first_sps_index == -1 || first_pps_index == -1)
       << "AVC parameter set NALUs not found.";
+
+  return AvcParameterSets(format, std::move(parameter_sets), first_sps_index,
+                          first_pps_index, combined_size_in_bytes,
+                          combined_size_with_optionals_in_bytes);
 }
+
+AvcParameterSets::AvcParameterSets(
+    Format format,
+    std::vector<std::vector<uint8_t>> parameter_sets,
+    int first_sps_index,
+    int first_pps_index,
+    size_t combined_size_in_bytes,
+    size_t combined_size_with_optionals_in_bytes)
+    : format_(format),
+      first_sps_index_(first_sps_index),
+      first_pps_index_(first_pps_index),
+      parameter_sets_(std::move(parameter_sets)),
+      combined_size_in_bytes_(combined_size_in_bytes),
+      combined_size_with_optionals_in_bytes_(
+          combined_size_with_optionals_in_bytes) {}
 
 std::vector<uint8_t> AvcParameterSets::GetAllSpses() const {
   std::vector<uint8_t> result;
@@ -153,29 +176,22 @@ AvcParameterSets AvcParameterSets::ConvertTo(Format new_format) const {
   SB_DCHECK_EQ(format_, kAnnexB);
   SB_DCHECK_EQ(new_format, kHeadless);
 
-  AvcParameterSets new_parameter_sets(*this);
-  new_parameter_sets.format_ = new_format;
-  if (!new_parameter_sets.is_valid()) {
-    return new_parameter_sets;
-  }
-  for (auto& parameter_set : new_parameter_sets.parameter_sets_) {
+  std::vector<std::vector<uint8_t>> new_parameter_sets = parameter_sets_;
+  size_t new_combined_size_in_bytes = combined_size_in_bytes_;
+  for (auto& parameter_set : new_parameter_sets) {
     SB_DCHECK_GE(parameter_set.size(), kAnnexBHeaderSizeInBytes);
     parameter_set.erase(parameter_set.begin(),
                         parameter_set.begin() + kAnnexBHeaderSizeInBytes);
-    new_parameter_sets.combined_size_in_bytes_ -= kAnnexBHeaderSizeInBytes;
+    new_combined_size_in_bytes -= kAnnexBHeaderSizeInBytes;
   }
 
-  return new_parameter_sets;
+  return AvcParameterSets(new_format, std::move(new_parameter_sets),
+                          first_sps_index_, first_pps_index_,
+                          new_combined_size_in_bytes,
+                          combined_size_with_optionals_in_bytes_);
 }
 
 bool AvcParameterSets::operator==(const AvcParameterSets& that) const {
-  if (is_valid() != that.is_valid()) {
-    return false;
-  }
-  if (!is_valid()) {
-    return true;
-  }
-
   SB_DCHECK_EQ(format(), that.format());
 
   if (parameter_sets_ == that.parameter_sets_) {

--- a/starboard/shared/starboard/media/avc_util.cc
+++ b/starboard/shared/starboard/media/avc_util.cc
@@ -94,6 +94,12 @@ std::optional<AvcParameterSets> AvcParameterSets::Create(Format format,
   if (size > 0 && !StartsWithAnnexBHeader(data, size)) {
     return std::nullopt;
   }
+  if (size == 0) {
+    return AvcParameterSets(
+        format, /*parameter_sets=*/{}, /*first_sps_index=*/-1,
+        /*first_pps_index=*/-1, /*combined_size_in_bytes=*/0,
+        /*combined_size_with_optionals_in_bytes=*/0);
+  }
 
   std::vector<std::vector<uint8_t>> parameter_sets;
   int first_sps_index = -1;
@@ -101,27 +107,25 @@ std::optional<AvcParameterSets> AvcParameterSets::Create(Format format,
   size_t combined_size_in_bytes = 0;
   size_t combined_size_with_optionals_in_bytes = 0;
 
-  if (size > 0) {
-    std::vector<uint8_t> nalu;
-    while (size > kAnnexBHeaderSizeInBytes &&
-           ExtractAnnexBNalu(&data, &size, &nalu)) {
-      if (nalu[kAnnexBHeaderSizeInBytes] == kSpsStartCode) {
-        if (first_sps_index == -1) {
-          first_sps_index = static_cast<int>(parameter_sets.size());
-        }
-        parameter_sets.push_back(nalu);
-        combined_size_in_bytes += nalu.size();
-      } else if (nalu[kAnnexBHeaderSizeInBytes] == kPpsStartCode) {
-        if (first_pps_index == -1) {
-          first_pps_index = static_cast<int>(parameter_sets.size());
-        }
-        parameter_sets.push_back(nalu);
-        combined_size_in_bytes += nalu.size();
-      } else if (nalu[kAnnexBHeaderSizeInBytes] == kIdrStartCode) {
-        break;
-      } else if (nalu[kAnnexBHeaderSizeInBytes] == kAudStartCode) {
-        combined_size_with_optionals_in_bytes += nalu.size();
+  std::vector<uint8_t> nalu;
+  while (size > kAnnexBHeaderSizeInBytes &&
+         ExtractAnnexBNalu(&data, &size, &nalu)) {
+    if (nalu[kAnnexBHeaderSizeInBytes] == kSpsStartCode) {
+      if (first_sps_index == -1) {
+        first_sps_index = static_cast<int>(parameter_sets.size());
       }
+      parameter_sets.push_back(nalu);
+      combined_size_in_bytes += nalu.size();
+    } else if (nalu[kAnnexBHeaderSizeInBytes] == kPpsStartCode) {
+      if (first_pps_index == -1) {
+        first_pps_index = static_cast<int>(parameter_sets.size());
+      }
+      parameter_sets.push_back(nalu);
+      combined_size_in_bytes += nalu.size();
+    } else if (nalu[kAnnexBHeaderSizeInBytes] == kIdrStartCode) {
+      break;
+    } else if (nalu[kAnnexBHeaderSizeInBytes] == kAudStartCode) {
+      combined_size_with_optionals_in_bytes += nalu.size();
     }
   }
 

--- a/starboard/shared/starboard/media/avc_util.cc
+++ b/starboard/shared/starboard/media/avc_util.cc
@@ -114,14 +114,14 @@ std::optional<AvcParameterSets> AvcParameterSets::Create(Format format,
       if (first_sps_index == -1) {
         first_sps_index = static_cast<int>(parameter_sets.size());
       }
-      parameter_sets.push_back(nalu);
       combined_size_in_bytes += nalu.size();
+      parameter_sets.push_back(std::move(nalu));
     } else if (nalu[kAnnexBHeaderSizeInBytes] == kPpsStartCode) {
       if (first_pps_index == -1) {
         first_pps_index = static_cast<int>(parameter_sets.size());
       }
-      parameter_sets.push_back(nalu);
       combined_size_in_bytes += nalu.size();
+      parameter_sets.push_back(std::move(nalu));
     } else if (nalu[kAnnexBHeaderSizeInBytes] == kIdrStartCode) {
       break;
     } else if (nalu[kAnnexBHeaderSizeInBytes] == kAudStartCode) {

--- a/starboard/shared/starboard/media/avc_util.h
+++ b/starboard/shared/starboard/media/avc_util.h
@@ -43,16 +43,8 @@ class AvcParameterSets {
     kHeadless,
   };
 
-  static const size_t kAnnexBHeaderSizeInBytes = 4;
-  static const uint8_t kIdrStartCode = 0x65;
-  static const uint8_t kSpsStartCode = 0x67;
-  static const uint8_t kPpsStartCode = 0x68;
-  // optional nalu types
-  static const uint8_t kAudStartCode = 0x09;
-
-  static std::optional<AvcParameterSets> Create(Format format,
-                                                const uint8_t* data,
-                                                size_t size);
+  static std::optional<AvcParameterSets> CreateFromAnnexB(const uint8_t* data,
+                                                          size_t size);
 
   Format format() const { return format_; }
   bool has_sps_and_pps() const {

--- a/starboard/shared/starboard/media/avc_util.h
+++ b/starboard/shared/starboard/media/avc_util.h
@@ -50,11 +50,11 @@ class AvcParameterSets {
   // optional nalu types
   static const uint8_t kAudStartCode = 0x09;
 
-  // Only |format == kAnnexB| is supported, which is checked in the ctor.
-  AvcParameterSets(Format format, const uint8_t* data, size_t size);
+  static std::optional<AvcParameterSets> Create(Format format,
+                                                const uint8_t* data,
+                                                size_t size);
 
   Format format() const { return format_; }
-  bool is_valid() const { return is_valid_; }
   bool has_sps_and_pps() const {
     return first_sps_index_ != -1 && first_pps_index_ != -1;
   }
@@ -97,13 +97,19 @@ class AvcParameterSets {
   bool operator!=(const AvcParameterSets& that) const;
 
  private:
-  Format format_ = kAnnexB;
-  bool is_valid_ = false;
-  int first_sps_index_ = -1;
-  int first_pps_index_ = -1;
-  std::vector<std::vector<uint8_t>> parameter_sets_;
-  size_t combined_size_in_bytes_ = 0;
-  size_t combined_size_with_optionals_in_bytes_ = 0;
+  AvcParameterSets(Format format,
+                   std::vector<std::vector<uint8_t>> parameter_sets,
+                   int first_sps_index,
+                   int first_pps_index,
+                   size_t combined_size_in_bytes,
+                   size_t combined_size_with_optionals_in_bytes);
+
+  const Format format_;
+  const int first_sps_index_;
+  const int first_pps_index_;
+  const std::vector<std::vector<uint8_t>> parameter_sets_;
+  const size_t combined_size_in_bytes_;
+  const size_t combined_size_with_optionals_in_bytes_;
 };
 
 // The function will fail only when the input doesn't start with an Annex B

--- a/starboard/shared/starboard/media/avc_util_test.cc
+++ b/starboard/shared/starboard/media/avc_util_test.cc
@@ -22,15 +22,14 @@
 namespace starboard {
 namespace {
 
-const auto kAnnexB = AvcParameterSets::kAnnexB;
-const auto kHeadless = AvcParameterSets::kHeadless;
-const auto kAnnexBHeaderSizeInBytes =
-    AvcParameterSets::kAnnexBHeaderSizeInBytes;
-const uint8_t kSliceStartCode = 0x61;
-const uint8_t kIdrStartCode = AvcParameterSets::kIdrStartCode;
-const uint8_t kSpsStartCode = AvcParameterSets::kSpsStartCode;
-const uint8_t kPpsStartCode = AvcParameterSets::kPpsStartCode;
-const uint8_t kAudStartCode = AvcParameterSets::kAudStartCode;
+constexpr auto kAnnexB = AvcParameterSets::kAnnexB;
+constexpr auto kHeadless = AvcParameterSets::kHeadless;
+constexpr auto kAnnexBHeaderSizeInBytes = 4;
+constexpr uint8_t kSliceStartCode = 0x61;
+constexpr uint8_t kIdrStartCode = 0x65;
+constexpr uint8_t kSpsStartCode = 0x67;
+constexpr uint8_t kPpsStartCode = 0x68;
+constexpr uint8_t kAudStartCode = 0x09;
 
 const std::vector<uint8_t> kRawSlice = {kSliceStartCode, 0, 0, 1, 0, 0, 0};
 const std::vector<uint8_t> kRawIdr = {kIdrStartCode, 1, 2, 3, 4};
@@ -116,8 +115,8 @@ void VerifyAnnexB(const std::vector<uint8_t>& nalus_in_annex_b,
                   const std::vector<uint8_t>& first_sps_in_annex_b,
                   const std::vector<uint8_t>& first_pps_in_annex_b,
                   const std::vector<uint8_t>& parameter_sets_in_annex_b) {
-  auto parameter_sets = AvcParameterSets::Create(
-      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  auto parameter_sets = AvcParameterSets::CreateFromAnnexB(
+      nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
   ASSERT_TRUE(parameter_sets.has_value());
   ASSERT_EQ(parameter_sets->format(), kAnnexB);
@@ -146,8 +145,8 @@ void VerifyAnnexB(const std::vector<uint8_t>& nalus_in_annex_b,
 }
 
 void VerifyAllEmpty(const std::vector<uint8_t>& nalus_in_annex_b) {
-  auto parameter_sets_opt = AvcParameterSets::Create(
-      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  auto parameter_sets_opt = AvcParameterSets::CreateFromAnnexB(
+      nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(parameter_sets_opt.has_value());
   const AvcParameterSets& parameter_sets_annex_b = *parameter_sets_opt;
 
@@ -169,10 +168,10 @@ void VerifyAllEmpty(const std::vector<uint8_t>& nalus_in_annex_b) {
 
 bool HasEqualParameterSets(const std::vector<uint8_t>& nalus_in_annex_b_1,
                            const std::vector<uint8_t>& nalus_in_annex_b_2) {
-  auto parameter_sets_1 = AvcParameterSets::Create(
-      kAnnexB, nalus_in_annex_b_1.data(), nalus_in_annex_b_1.size());
-  auto parameter_sets_2 = AvcParameterSets::Create(
-      kAnnexB, nalus_in_annex_b_2.data(), nalus_in_annex_b_2.size());
+  auto parameter_sets_1 = AvcParameterSets::CreateFromAnnexB(
+      nalus_in_annex_b_1.data(), nalus_in_annex_b_1.size());
+  auto parameter_sets_2 = AvcParameterSets::CreateFromAnnexB(
+      nalus_in_annex_b_2.data(), nalus_in_annex_b_2.size());
   if (!parameter_sets_1 || !parameter_sets_2) {
     return false;
   }
@@ -183,33 +182,33 @@ bool HasEqualParameterSets(const std::vector<uint8_t>& nalus_in_annex_b_1,
   return *parameter_sets_1 == *parameter_sets_2;
 }
 
-TEST(AvcParameterSetsTest, Ctor) {
+TEST(AvcParameterSetsTest, CreateFromAnnexB) {
   auto parameter_sets_1 =
-      AvcParameterSets::Create(kAnnexB, /*data=*/nullptr, /*size=*/0);
+      AvcParameterSets::CreateFromAnnexB(/*data=*/nullptr, /*size=*/0);
   ASSERT_TRUE(parameter_sets_1.has_value());
-  auto parameter_sets_2 = AvcParameterSets::Create(kAnnexB, kSpsInAnnexB.data(),
-                                                   kSpsInAnnexB.size());
+  auto parameter_sets_2 = AvcParameterSets::CreateFromAnnexB(
+      kSpsInAnnexB.data(), kSpsInAnnexB.size());
   ASSERT_TRUE(parameter_sets_2.has_value());
-  auto parameter_sets_3 = AvcParameterSets::Create(kAnnexB, kPpsInAnnexB.data(),
-                                                   kPpsInAnnexB.size());
+  auto parameter_sets_3 = AvcParameterSets::CreateFromAnnexB(
+      kPpsInAnnexB.data(), kPpsInAnnexB.size());
   ASSERT_TRUE(parameter_sets_3.has_value());
-  auto parameter_sets_4 = AvcParameterSets::Create(kAnnexB, kIdrInAnnexB.data(),
-                                                   kIdrInAnnexB.size());
+  auto parameter_sets_4 = AvcParameterSets::CreateFromAnnexB(
+      kIdrInAnnexB.data(), kIdrInAnnexB.size());
   ASSERT_TRUE(parameter_sets_4.has_value());
 
   auto nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
-  auto parameter_sets_5 = AvcParameterSets::Create(
-      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  auto parameter_sets_5 = AvcParameterSets::CreateFromAnnexB(
+      nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(parameter_sets_5.has_value());
 
-  auto parameter_sets_6 = AvcParameterSets::Create(kAnnexB, kAudInAnnexB.data(),
-                                                   kAudInAnnexB.size());
+  auto parameter_sets_6 = AvcParameterSets::CreateFromAnnexB(
+      kAudInAnnexB.data(), kAudInAnnexB.size());
   ASSERT_TRUE(parameter_sets_6.has_value());
   auto nalus_in_annex_b_with_optional =
       kAudInAnnexB + kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
   auto parameter_sets_7 =
-      AvcParameterSets::Create(kAnnexB, nalus_in_annex_b_with_optional.data(),
-                               nalus_in_annex_b_with_optional.size());
+      AvcParameterSets::CreateFromAnnexB(nalus_in_annex_b_with_optional.data(),
+                                         nalus_in_annex_b_with_optional.size());
   ASSERT_TRUE(parameter_sets_7.has_value());
 }
 
@@ -263,8 +262,8 @@ TEST(AvcParameterSetsTest, SpsWithoutPps) {
   for (size_t i = 0; i < 5; ++i) {
     auto nalus_in_annex_b = leading_sps_nalus + kIdrInAnnexB;
 
-    auto parameter_sets = AvcParameterSets::Create(
-        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+    auto parameter_sets = AvcParameterSets::CreateFromAnnexB(
+        nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
     ASSERT_TRUE(parameter_sets.has_value());
     ASSERT_FALSE(parameter_sets->has_sps_and_pps());
@@ -288,8 +287,8 @@ TEST(AvcParameterSetsTest, PpsWithoutSps) {
   for (size_t i = 0; i < 5; ++i) {
     auto nalus_in_annex_b = leading_pps_nalus + kIdrInAnnexB;
 
-    auto parameter_sets = AvcParameterSets::Create(
-        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+    auto parameter_sets = AvcParameterSets::CreateFromAnnexB(
+        nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
     ASSERT_TRUE(parameter_sets.has_value());
     ASSERT_FALSE(parameter_sets->has_sps_and_pps());
@@ -330,9 +329,8 @@ TEST(AvcParameterSetsTest, MultipleSpsAndPpsWithoutPayload) {
         break;
     }
 
-    auto parameter_sets =
-        AvcParameterSets::Create(kAnnexB, parameter_sets_in_annex_b.data(),
-                                 parameter_sets_in_annex_b.size());
+    auto parameter_sets = AvcParameterSets::CreateFromAnnexB(
+        parameter_sets_in_annex_b.data(), parameter_sets_in_annex_b.size());
     ASSERT_TRUE(parameter_sets.has_value());
 
     VerifyAnnexB(parameter_sets_in_annex_b, kSpsInAnnexB, kPpsInAnnexB,
@@ -372,7 +370,7 @@ TEST(AvcParameterSetsTest, SpsAndPpsAfterIdrWithoutSpsAndPps) {
 
 TEST(AvcParameterSetsTest, Nullptr) {
   auto parameter_sets =
-      AvcParameterSets::Create(kAnnexB, /*data=*/nullptr, /*size=*/0);
+      AvcParameterSets::CreateFromAnnexB(/*data=*/nullptr, /*size=*/0);
 
   ASSERT_TRUE(parameter_sets.has_value());
   ASSERT_EQ(parameter_sets->format(), kAnnexB);
@@ -409,8 +407,8 @@ TEST(AvcParameterSetsTest, InvalidNaluHeaderOneLessZero) {
       parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
   nalus_in_annex_b.erase(nalus_in_annex_b.begin());  // One less 0
 
-  auto parameter_sets = AvcParameterSets::Create(
-      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  auto parameter_sets = AvcParameterSets::CreateFromAnnexB(
+      nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_FALSE(parameter_sets.has_value());
 }
 
@@ -420,8 +418,8 @@ TEST(AvcParameterSetsTest, InvalidNaluHeaderOneExtraZero) {
       parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
   nalus_in_annex_b.insert(nalus_in_annex_b.begin(), 0);  // One extra 0
 
-  auto parameter_sets = AvcParameterSets::Create(
-      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  auto parameter_sets = AvcParameterSets::CreateFromAnnexB(
+      nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_FALSE(parameter_sets.has_value());
 }
 
@@ -440,8 +438,8 @@ TEST(AvcParameterSetsTest, MultiNalusWithoutSpsPps) {
 
 TEST(AvcParameterSetsTest, CombinedSize) {
   auto nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
-  auto parameter_sets = AvcParameterSets::Create(
-      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  auto parameter_sets = AvcParameterSets::CreateFromAnnexB(
+      nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(parameter_sets.has_value());
   ASSERT_TRUE(parameter_sets->combined_size_in_bytes() ==
               (kSpsInAnnexB.size() + kPpsInAnnexB.size()));
@@ -450,7 +448,7 @@ TEST(AvcParameterSetsTest, CombinedSize) {
 TEST(AvcParameterSetsTest, CombinedSizeWithOptionalParameter) {
   auto aud_first = kAudInAnnexB + kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
   auto parameter_sets_aud_first =
-      AvcParameterSets::Create(kAnnexB, aud_first.data(), aud_first.size());
+      AvcParameterSets::CreateFromAnnexB(aud_first.data(), aud_first.size());
   ASSERT_TRUE(parameter_sets_aud_first.has_value());
   ASSERT_TRUE(parameter_sets_aud_first->combined_size_in_bytes() ==
               (kSpsInAnnexB.size() + kPpsInAnnexB.size()));
@@ -460,7 +458,7 @@ TEST(AvcParameterSetsTest, CombinedSizeWithOptionalParameter) {
 
   auto aud_last = kPpsInAnnexB + kSpsInAnnexB + kAudInAnnexB + kIdrInAnnexB;
   auto parameter_sets =
-      AvcParameterSets::Create(kAnnexB, aud_last.data(), aud_last.size());
+      AvcParameterSets::CreateFromAnnexB(aud_last.data(), aud_last.size());
   ASSERT_TRUE(parameter_sets.has_value());
   ASSERT_TRUE(parameter_sets->combined_size_in_bytes() ==
               (kPpsInAnnexB.size() + kSpsInAnnexB.size()));

--- a/starboard/shared/starboard/media/avc_util_test.cc
+++ b/starboard/shared/starboard/media/avc_util_test.cc
@@ -382,73 +382,47 @@ TEST(AvcParameterSetsTest, Nullptr) {
   ASSERT_EQ(parameter_sets->combined_size_in_bytes(), 0U);
 }
 
-TEST(AvcParameterSetsTest, NaluHeaderWithoutType) {
-  {
-    auto parameter_sets =
-        AvcParameterSets::Create(kAnnexB, kNaluHeaderOnlyInAnnexB.data(),
-                                 kNaluHeaderOnlyInAnnexB.size());
-
-    ASSERT_TRUE(parameter_sets.has_value());
-    ASSERT_EQ(parameter_sets->format(), kAnnexB);
-    ASSERT_FALSE(parameter_sets->has_sps_and_pps());
-    ASSERT_TRUE(parameter_sets->GetAddresses().empty());
-    ASSERT_TRUE(parameter_sets->GetSizesInBytes().empty());
-    ASSERT_EQ(parameter_sets->combined_size_in_bytes(), 0U);
-  }
-  for (int i = 0; i < 2; ++i) {
-    auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
-    std::vector<uint8_t> nalus_in_annex_b;
-    if (i == 0) {
-      nalus_in_annex_b = parameter_sets_in_annex_b + kNaluHeaderOnlyInAnnexB;
-    } else {
-      nalus_in_annex_b =
-          parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
-    }
-
-    VerifyAnnexB(nalus_in_annex_b, kSpsInAnnexB, kPpsInAnnexB,
-                 parameter_sets_in_annex_b);
-  }
+TEST(AvcParameterSetsTest, NaluHeaderOnlyIsEmpty) {
+  VerifyAllEmpty(kNaluHeaderOnlyInAnnexB);
 }
 
-TEST(AvcParameterSetsTest, InvalidNaluHeader) {
-  {
-    VerifyAllEmpty(kNaluHeaderOnlyInAnnexB);
-  }
-  {
-    auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
-    auto nalus_in_annex_b = parameter_sets_in_annex_b + kNaluHeaderOnlyInAnnexB;
+TEST(AvcParameterSetsTest, TrailingNaluHeaderWithoutTypeIsIgnored) {
+  auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
+  auto nalus_in_annex_b = parameter_sets_in_annex_b + kNaluHeaderOnlyInAnnexB;
 
-    VerifyAnnexB(nalus_in_annex_b, kSpsInAnnexB, kPpsInAnnexB,
-                 parameter_sets_in_annex_b);
-  }
-  {
-    auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
-    auto nalus_in_annex_b =
-        parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
+  VerifyAnnexB(nalus_in_annex_b, kSpsInAnnexB, kPpsInAnnexB,
+               parameter_sets_in_annex_b);
+}
 
-    VerifyAnnexB(nalus_in_annex_b, kSpsInAnnexB, kPpsInAnnexB,
-                 parameter_sets_in_annex_b);
-  }
-  {
-    auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
-    auto nalus_in_annex_b =
-        parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
-    nalus_in_annex_b.erase(nalus_in_annex_b.begin());  // One less 0
+TEST(AvcParameterSetsTest, TrailingNaluHeaderWithoutTypeAfterIdrIsIgnored) {
+  auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
+  auto nalus_in_annex_b =
+      parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
 
-    auto parameter_sets = AvcParameterSets::Create(
-        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
-    ASSERT_FALSE(parameter_sets.has_value());
-  }
-  {
-    auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
-    auto nalus_in_annex_b =
-        parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
-    nalus_in_annex_b.insert(nalus_in_annex_b.begin(), 0);  // One extra 0
+  VerifyAnnexB(nalus_in_annex_b, kSpsInAnnexB, kPpsInAnnexB,
+               parameter_sets_in_annex_b);
+}
 
-    auto parameter_sets = AvcParameterSets::Create(
-        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
-    ASSERT_FALSE(parameter_sets.has_value());
-  }
+TEST(AvcParameterSetsTest, InvalidNaluHeaderOneLessZero) {
+  auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
+  auto nalus_in_annex_b =
+      parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
+  nalus_in_annex_b.erase(nalus_in_annex_b.begin());  // One less 0
+
+  auto parameter_sets = AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_FALSE(parameter_sets.has_value());
+}
+
+TEST(AvcParameterSetsTest, InvalidNaluHeaderOneExtraZero) {
+  auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
+  auto nalus_in_annex_b =
+      parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
+  nalus_in_annex_b.insert(nalus_in_annex_b.begin(), 0);  // One extra 0
+
+  auto parameter_sets = AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_FALSE(parameter_sets.has_value());
 }
 
 TEST(AvcParameterSetsTest, MultiNalusWithoutSpsPps) {
@@ -495,34 +469,33 @@ TEST(AvcParameterSetsTest, CombinedSizeWithOptionalParameter) {
       (kPpsInAnnexB.size() + kSpsInAnnexB.size() + kAudInAnnexB.size()));
 }
 
-TEST(AvcParameterSetsTest, ConvertAnnexBToAvcc) {
-  {
-    std::vector<uint8_t> raw_nalus[] = {kRawSlice, kRawIdr, kRawSps, kRawPps};
-    std::vector<uint8_t> nalus_in_annex_b;
-    std::vector<uint8_t> nalus_in_avcc;
+TEST(AvcParameterSetsTest, ConvertAnnexBToAvccStartingWithSlice) {
+  std::vector<uint8_t> raw_nalus[] = {kRawSlice, kRawIdr, kRawSps, kRawPps};
+  std::vector<uint8_t> nalus_in_annex_b;
+  std::vector<uint8_t> nalus_in_avcc;
 
-    for (int i = 0; i < 20; ++i) {
-      nalus_in_annex_b =
-          nalus_in_annex_b + ToAnnexB(raw_nalus[i % SB_ARRAY_SIZE(raw_nalus)]);
-      nalus_in_avcc =
-          nalus_in_avcc + ToAvcc(raw_nalus[i % SB_ARRAY_SIZE(raw_nalus)]);
+  for (int i = 0; i < 20; ++i) {
+    nalus_in_annex_b =
+        nalus_in_annex_b + ToAnnexB(raw_nalus[i % SB_ARRAY_SIZE(raw_nalus)]);
+    nalus_in_avcc =
+        nalus_in_avcc + ToAvcc(raw_nalus[i % SB_ARRAY_SIZE(raw_nalus)]);
 
-      ASSERT_EQ(ConvertAnnexBToAvccFromVector(nalus_in_annex_b), nalus_in_avcc);
-    }
+    ASSERT_EQ(ConvertAnnexBToAvccFromVector(nalus_in_annex_b), nalus_in_avcc);
   }
-  {
-    std::vector<uint8_t> raw_nalus[] = {kRawSps, kRawPps, kRawSlice, kRawIdr};
-    std::vector<uint8_t> nalus_in_annex_b;
-    std::vector<uint8_t> nalus_in_avcc;
+}
 
-    for (int i = 0; i < 20; ++i) {
-      nalus_in_annex_b =
-          nalus_in_annex_b + ToAnnexB(raw_nalus[i % SB_ARRAY_SIZE(raw_nalus)]);
-      nalus_in_avcc =
-          nalus_in_avcc + ToAvcc(raw_nalus[i % SB_ARRAY_SIZE(raw_nalus)]);
+TEST(AvcParameterSetsTest, ConvertAnnexBToAvccStartingWithSps) {
+  std::vector<uint8_t> raw_nalus[] = {kRawSps, kRawPps, kRawSlice, kRawIdr};
+  std::vector<uint8_t> nalus_in_annex_b;
+  std::vector<uint8_t> nalus_in_avcc;
 
-      ASSERT_EQ(ConvertAnnexBToAvccFromVector(nalus_in_annex_b), nalus_in_avcc);
-    }
+  for (int i = 0; i < 20; ++i) {
+    nalus_in_annex_b =
+        nalus_in_annex_b + ToAnnexB(raw_nalus[i % SB_ARRAY_SIZE(raw_nalus)]);
+    nalus_in_avcc =
+        nalus_in_avcc + ToAvcc(raw_nalus[i % SB_ARRAY_SIZE(raw_nalus)]);
+
+    ASSERT_EQ(ConvertAnnexBToAvccFromVector(nalus_in_annex_b), nalus_in_avcc);
   }
 }
 
@@ -548,27 +521,24 @@ TEST(AvcParameterSetsTest, ConvertAnnexBToAvccEmptyNalus) {
       ToAvcc(kRawNalu) + ToAvcc(kEmpty));
 }
 
-TEST(AvcParameterSetsTest, ConvertAnnexBToAvccInvalidNalus) {
-  {
-    auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
-    auto nalus_in_annex_b =
-        parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
-    nalus_in_annex_b.erase(nalus_in_annex_b.begin());  // One less 0
-    auto nalus_in_avcc = nalus_in_annex_b;
-    ASSERT_FALSE(ConvertAnnexBToAvcc(nalus_in_annex_b.data(),
-                                     nalus_in_annex_b.size(),
-                                     nalus_in_avcc.data()));
-  }
-  {
-    auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
-    auto nalus_in_annex_b =
-        parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
-    nalus_in_annex_b.insert(nalus_in_annex_b.begin(), 0);  // One extra 0
-    auto nalus_in_avcc = nalus_in_annex_b;
-    ASSERT_FALSE(ConvertAnnexBToAvcc(nalus_in_annex_b.data(),
-                                     nalus_in_annex_b.size(),
-                                     nalus_in_avcc.data()));
-  }
+TEST(AvcParameterSetsTest, ConvertAnnexBToAvccFailOneLessZero) {
+  auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
+  auto nalus_in_annex_b =
+      parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
+  nalus_in_annex_b.erase(nalus_in_annex_b.begin());  // One less 0
+  auto nalus_in_avcc = nalus_in_annex_b;
+  ASSERT_FALSE(ConvertAnnexBToAvcc(
+      nalus_in_annex_b.data(), nalus_in_annex_b.size(), nalus_in_avcc.data()));
+}
+
+TEST(AvcParameterSetsTest, ConvertAnnexBToAvccFailOneExtraZero) {
+  auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
+  auto nalus_in_annex_b =
+      parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
+  nalus_in_annex_b.insert(nalus_in_annex_b.begin(), 0);  // One extra 0
+  auto nalus_in_avcc = nalus_in_annex_b;
+  ASSERT_FALSE(ConvertAnnexBToAvcc(
+      nalus_in_annex_b.data(), nalus_in_annex_b.size(), nalus_in_avcc.data()));
 }
 
 }  // namespace

--- a/starboard/shared/starboard/media/avc_util_test.cc
+++ b/starboard/shared/starboard/media/avc_util_test.cc
@@ -82,7 +82,6 @@ std::vector<uint8_t> ConvertAnnexBToAvccFromVector(
 void VerifyConvertTo(const AvcParameterSets& parameter_sets_in_annex_b) {
   auto parameter_sets_headless = parameter_sets_in_annex_b.ConvertTo(kHeadless);
 
-  ASSERT_TRUE(parameter_sets_headless.is_valid());
   ASSERT_EQ(parameter_sets_headless.format(), kHeadless);
   ASSERT_EQ(parameter_sets_headless.has_sps_and_pps(),
             parameter_sets_in_annex_b.has_sps_and_pps());
@@ -117,22 +116,22 @@ void VerifyAnnexB(const std::vector<uint8_t>& nalus_in_annex_b,
                   const std::vector<uint8_t>& first_sps_in_annex_b,
                   const std::vector<uint8_t>& first_pps_in_annex_b,
                   const std::vector<uint8_t>& parameter_sets_in_annex_b) {
-  AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                  nalus_in_annex_b.size());
+  auto parameter_sets = AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
-  ASSERT_TRUE(parameter_sets.is_valid());
-  ASSERT_EQ(parameter_sets.format(), kAnnexB);
-  ASSERT_TRUE(parameter_sets.has_sps_and_pps());
-  ASSERT_EQ(parameter_sets.first_sps(), first_sps_in_annex_b);
-  ASSERT_EQ(parameter_sets.first_pps(), first_pps_in_annex_b);
-  ASSERT_EQ(parameter_sets.combined_size_in_bytes(),
+  ASSERT_TRUE(parameter_sets.has_value());
+  ASSERT_EQ(parameter_sets->format(), kAnnexB);
+  ASSERT_TRUE(parameter_sets->has_sps_and_pps());
+  ASSERT_EQ(parameter_sets->first_sps(), first_sps_in_annex_b);
+  ASSERT_EQ(parameter_sets->first_pps(), first_pps_in_annex_b);
+  ASSERT_EQ(parameter_sets->combined_size_in_bytes(),
             parameter_sets_in_annex_b.size());
 
-  ASSERT_TRUE(parameter_sets == parameter_sets);
-  ASSERT_FALSE(parameter_sets != parameter_sets);
+  ASSERT_TRUE(*parameter_sets == *parameter_sets);
+  ASSERT_FALSE(*parameter_sets != *parameter_sets);
 
-  const auto& addresses = parameter_sets.GetAddresses();
-  const auto& sizes = parameter_sets.GetSizesInBytes();
+  const auto& addresses = parameter_sets->GetAddresses();
+  const auto& sizes = parameter_sets->GetSizesInBytes();
   ASSERT_EQ(addresses.size(), sizes.size());
 
   std::vector<uint8_t> accumulated_parameter_sets;
@@ -143,63 +142,74 @@ void VerifyAnnexB(const std::vector<uint8_t>& nalus_in_annex_b,
   }
   ASSERT_EQ(accumulated_parameter_sets, parameter_sets_in_annex_b);
 
-  VerifyConvertTo(parameter_sets);
+  VerifyConvertTo(*parameter_sets);
 }
 
 void VerifyAllEmpty(const std::vector<uint8_t>& nalus_in_annex_b) {
-  AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                  nalus_in_annex_b.size());
+  auto parameter_sets_opt = AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(parameter_sets_opt.has_value());
+  const AvcParameterSets& parameter_sets_annex_b = *parameter_sets_opt;
 
-  ASSERT_EQ(parameter_sets.format(), kAnnexB);
+  ASSERT_EQ(parameter_sets_annex_b.format(), kAnnexB);
+  ASSERT_FALSE(parameter_sets_annex_b.has_sps_and_pps());
+  ASSERT_TRUE(parameter_sets_annex_b.GetAddresses().empty());
+  ASSERT_TRUE(parameter_sets_annex_b.GetSizesInBytes().empty());
+  ASSERT_EQ(parameter_sets_annex_b.combined_size_in_bytes(), 0U);
 
-  for (int i = 0; i < 2; ++i) {
-    if (i == 1) {
-      parameter_sets = parameter_sets.ConvertTo(kHeadless);
-      ASSERT_EQ(parameter_sets.format(), kHeadless);
-    }
-    ASSERT_TRUE(parameter_sets.is_valid());
-    ASSERT_FALSE(parameter_sets.has_sps_and_pps());
-    ASSERT_TRUE(parameter_sets.GetAddresses().empty());
-    ASSERT_TRUE(parameter_sets.GetSizesInBytes().empty());
-    ASSERT_EQ(parameter_sets.combined_size_in_bytes(), 0U);
-  }
+  auto parameter_sets_headless = parameter_sets_annex_b.ConvertTo(kHeadless);
+  ASSERT_EQ(parameter_sets_headless.format(), kHeadless);
+  ASSERT_FALSE(parameter_sets_headless.has_sps_and_pps());
+  ASSERT_TRUE(parameter_sets_headless.GetAddresses().empty());
+  ASSERT_TRUE(parameter_sets_headless.GetSizesInBytes().empty());
+  ASSERT_EQ(parameter_sets_headless.combined_size_in_bytes(), 0U);
 
-  VerifyConvertTo(parameter_sets);
+  VerifyConvertTo(parameter_sets_annex_b);
 }
 
 bool HasEqualParameterSets(const std::vector<uint8_t>& nalus_in_annex_b_1,
                            const std::vector<uint8_t>& nalus_in_annex_b_2) {
-  AvcParameterSets parameter_sets_1(kAnnexB, nalus_in_annex_b_1.data(),
-                                    nalus_in_annex_b_1.size());
-  AvcParameterSets parameter_sets_2(kAnnexB, nalus_in_annex_b_2.data(),
-                                    nalus_in_annex_b_2.size());
+  auto parameter_sets_1 = AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b_1.data(), nalus_in_annex_b_1.size());
+  auto parameter_sets_2 = AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b_2.data(), nalus_in_annex_b_2.size());
+  if (!parameter_sets_1 || !parameter_sets_2) {
+    return false;
+  }
 
-  SB_CHECK_NE(parameter_sets_1 == parameter_sets_2,
-              parameter_sets_1 != parameter_sets_2);
+  SB_CHECK_NE(*parameter_sets_1 == *parameter_sets_2,
+              *parameter_sets_1 != *parameter_sets_2);
 
-  return parameter_sets_1 == parameter_sets_2;
+  return *parameter_sets_1 == *parameter_sets_2;
 }
 
 TEST(AvcParameterSetsTest, Ctor) {
-  AvcParameterSets parameter_sets_1(kAnnexB, nullptr, 0);
-  AvcParameterSets parameter_sets_2(kAnnexB, kSpsInAnnexB.data(),
-                                    kSpsInAnnexB.size());
-  AvcParameterSets parameter_sets_3(kAnnexB, kPpsInAnnexB.data(),
-                                    kPpsInAnnexB.size());
-  AvcParameterSets parameter_sets_4(kAnnexB, kIdrInAnnexB.data(),
-                                    kIdrInAnnexB.size());
+  auto parameter_sets_1 = AvcParameterSets::Create(kAnnexB, nullptr, 0);
+  ASSERT_TRUE(parameter_sets_1.has_value());
+  auto parameter_sets_2 = AvcParameterSets::Create(kAnnexB, kSpsInAnnexB.data(),
+                                                   kSpsInAnnexB.size());
+  ASSERT_TRUE(parameter_sets_2.has_value());
+  auto parameter_sets_3 = AvcParameterSets::Create(kAnnexB, kPpsInAnnexB.data(),
+                                                   kPpsInAnnexB.size());
+  ASSERT_TRUE(parameter_sets_3.has_value());
+  auto parameter_sets_4 = AvcParameterSets::Create(kAnnexB, kIdrInAnnexB.data(),
+                                                   kIdrInAnnexB.size());
+  ASSERT_TRUE(parameter_sets_4.has_value());
 
   auto nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
-  AvcParameterSets parameter_sets_5(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
+  auto parameter_sets_5 = AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(parameter_sets_5.has_value());
 
-  AvcParameterSets parameter_sets_6(kAnnexB, kAudInAnnexB.data(),
-                                    kAudInAnnexB.size());
+  auto parameter_sets_6 = AvcParameterSets::Create(kAnnexB, kAudInAnnexB.data(),
+                                                   kAudInAnnexB.size());
+  ASSERT_TRUE(parameter_sets_6.has_value());
   auto nalus_in_annex_b_with_optional =
       kAudInAnnexB + kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
-  AvcParameterSets parameter_sets_7(kAnnexB,
-                                    nalus_in_annex_b_with_optional.data(),
-                                    nalus_in_annex_b_with_optional.size());
+  auto parameter_sets_7 =
+      AvcParameterSets::Create(kAnnexB, nalus_in_annex_b_with_optional.data(),
+                               nalus_in_annex_b_with_optional.size());
+  ASSERT_TRUE(parameter_sets_7.has_value());
 }
 
 TEST(AvcParameterSetsTest, SingleSpsAndPps) {
@@ -252,21 +262,21 @@ TEST(AvcParameterSetsTest, SpsWithoutPps) {
   for (size_t i = 0; i < 5; ++i) {
     auto nalus_in_annex_b = leading_sps_nalus + kIdrInAnnexB;
 
-    AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
+    auto parameter_sets = AvcParameterSets::Create(
+        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
-    ASSERT_TRUE(parameter_sets.is_valid());
-    ASSERT_FALSE(parameter_sets.has_sps_and_pps());
-    ASSERT_EQ(kSpsInAnnexB, parameter_sets.first_sps());
-    ASSERT_EQ(parameter_sets.combined_size_in_bytes(),
+    ASSERT_TRUE(parameter_sets.has_value());
+    ASSERT_FALSE(parameter_sets->has_sps_and_pps());
+    ASSERT_EQ(kSpsInAnnexB, parameter_sets->first_sps());
+    ASSERT_EQ(parameter_sets->combined_size_in_bytes(),
               leading_sps_nalus.size());
 
-    ASSERT_EQ(parameter_sets.GetAddresses().size(), i + 1);
-    ASSERT_EQ(parameter_sets.GetSizesInBytes().size(), i + 1);
+    ASSERT_EQ(parameter_sets->GetAddresses().size(), i + 1);
+    ASSERT_EQ(parameter_sets->GetSizesInBytes().size(), i + 1);
     ASSERT_EQ(kSpsInAnnexB,
-              std::vector<uint8_t>(parameter_sets.GetAddresses()[0],
-                                   parameter_sets.GetAddresses()[0] +
-                                       parameter_sets.GetSizesInBytes()[0]));
+              std::vector<uint8_t>(parameter_sets->GetAddresses()[0],
+                                   parameter_sets->GetAddresses()[0] +
+                                       parameter_sets->GetSizesInBytes()[0]));
 
     leading_sps_nalus = leading_sps_nalus + Mutate(kSpsInAnnexB);
   }
@@ -277,21 +287,21 @@ TEST(AvcParameterSetsTest, PpsWithoutSps) {
   for (size_t i = 0; i < 5; ++i) {
     auto nalus_in_annex_b = leading_pps_nalus + kIdrInAnnexB;
 
-    AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
+    auto parameter_sets = AvcParameterSets::Create(
+        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
 
-    ASSERT_TRUE(parameter_sets.is_valid());
-    ASSERT_FALSE(parameter_sets.has_sps_and_pps());
-    ASSERT_EQ(kPpsInAnnexB, parameter_sets.first_pps());
-    ASSERT_EQ(parameter_sets.combined_size_in_bytes(),
+    ASSERT_TRUE(parameter_sets.has_value());
+    ASSERT_FALSE(parameter_sets->has_sps_and_pps());
+    ASSERT_EQ(kPpsInAnnexB, parameter_sets->first_pps());
+    ASSERT_EQ(parameter_sets->combined_size_in_bytes(),
               leading_pps_nalus.size());
 
-    ASSERT_EQ(parameter_sets.GetAddresses().size(), i + 1);
-    ASSERT_EQ(parameter_sets.GetSizesInBytes().size(), i + 1);
+    ASSERT_EQ(parameter_sets->GetAddresses().size(), i + 1);
+    ASSERT_EQ(parameter_sets->GetSizesInBytes().size(), i + 1);
     ASSERT_EQ(kPpsInAnnexB,
-              std::vector<uint8_t>(parameter_sets.GetAddresses()[0],
-                                   parameter_sets.GetAddresses()[0] +
-                                       parameter_sets.GetSizesInBytes()[0]));
+              std::vector<uint8_t>(parameter_sets->GetAddresses()[0],
+                                   parameter_sets->GetAddresses()[0] +
+                                       parameter_sets->GetSizesInBytes()[0]));
 
     leading_pps_nalus = leading_pps_nalus + Mutate(kPpsInAnnexB);
   }
@@ -319,8 +329,10 @@ TEST(AvcParameterSetsTest, MultipleSpsAndPpsWithoutPayload) {
         break;
     }
 
-    AvcParameterSets parameter_sets(kAnnexB, parameter_sets_in_annex_b.data(),
-                                    parameter_sets_in_annex_b.size());
+    auto parameter_sets =
+        AvcParameterSets::Create(kAnnexB, parameter_sets_in_annex_b.data(),
+                                 parameter_sets_in_annex_b.size());
+    ASSERT_TRUE(parameter_sets.has_value());
 
     VerifyAnnexB(parameter_sets_in_annex_b, kSpsInAnnexB, kPpsInAnnexB,
                  parameter_sets_in_annex_b);
@@ -358,27 +370,28 @@ TEST(AvcParameterSetsTest, SpsAndPpsAfterIdrWithoutSpsAndPps) {
 }
 
 TEST(AvcParameterSetsTest, Nullptr) {
-  AvcParameterSets parameter_sets(kAnnexB, nullptr, 0);
+  auto parameter_sets = AvcParameterSets::Create(kAnnexB, nullptr, 0);
 
-  ASSERT_TRUE(parameter_sets.is_valid());
-  ASSERT_EQ(parameter_sets.format(), kAnnexB);
-  ASSERT_FALSE(parameter_sets.has_sps_and_pps());
-  ASSERT_TRUE(parameter_sets.GetAddresses().empty());
-  ASSERT_TRUE(parameter_sets.GetSizesInBytes().empty());
-  ASSERT_EQ(parameter_sets.combined_size_in_bytes(), 0U);
+  ASSERT_TRUE(parameter_sets.has_value());
+  ASSERT_EQ(parameter_sets->format(), kAnnexB);
+  ASSERT_FALSE(parameter_sets->has_sps_and_pps());
+  ASSERT_TRUE(parameter_sets->GetAddresses().empty());
+  ASSERT_TRUE(parameter_sets->GetSizesInBytes().empty());
+  ASSERT_EQ(parameter_sets->combined_size_in_bytes(), 0U);
 }
 
 TEST(AvcParameterSetsTest, NaluHeaderWithoutType) {
   {
-    AvcParameterSets parameter_sets(kAnnexB, kNaluHeaderOnlyInAnnexB.data(),
-                                    kNaluHeaderOnlyInAnnexB.size());
+    auto parameter_sets =
+        AvcParameterSets::Create(kAnnexB, kNaluHeaderOnlyInAnnexB.data(),
+                                 kNaluHeaderOnlyInAnnexB.size());
 
-    ASSERT_TRUE(parameter_sets.is_valid());
-    ASSERT_EQ(parameter_sets.format(), kAnnexB);
-    ASSERT_FALSE(parameter_sets.has_sps_and_pps());
-    ASSERT_TRUE(parameter_sets.GetAddresses().empty());
-    ASSERT_TRUE(parameter_sets.GetSizesInBytes().empty());
-    ASSERT_EQ(parameter_sets.combined_size_in_bytes(), 0U);
+    ASSERT_TRUE(parameter_sets.has_value());
+    ASSERT_EQ(parameter_sets->format(), kAnnexB);
+    ASSERT_FALSE(parameter_sets->has_sps_and_pps());
+    ASSERT_TRUE(parameter_sets->GetAddresses().empty());
+    ASSERT_TRUE(parameter_sets->GetSizesInBytes().empty());
+    ASSERT_EQ(parameter_sets->combined_size_in_bytes(), 0U);
   }
   for (int i = 0; i < 2; ++i) {
     auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
@@ -420,9 +433,9 @@ TEST(AvcParameterSetsTest, InvalidNaluHeader) {
         parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
     nalus_in_annex_b.erase(nalus_in_annex_b.begin());  // One less 0
 
-    AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
-    ASSERT_FALSE(parameter_sets.is_valid());
+    auto parameter_sets = AvcParameterSets::Create(
+        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+    ASSERT_FALSE(parameter_sets.has_value());
   }
   {
     auto parameter_sets_in_annex_b = kSpsInAnnexB + kPpsInAnnexB;
@@ -430,9 +443,9 @@ TEST(AvcParameterSetsTest, InvalidNaluHeader) {
         parameter_sets_in_annex_b + kIdrInAnnexB + kNaluHeaderOnlyInAnnexB;
     nalus_in_annex_b.insert(nalus_in_annex_b.begin(), 0);  // One extra 0
 
-    AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
-    ASSERT_FALSE(parameter_sets.is_valid());
+    auto parameter_sets = AvcParameterSets::Create(
+        kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+    ASSERT_FALSE(parameter_sets.has_value());
   }
 }
 
@@ -451,28 +464,32 @@ TEST(AvcParameterSetsTest, MultiNalusWithoutSpsPps) {
 
 TEST(AvcParameterSetsTest, CombinedSize) {
   auto nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
-  AvcParameterSets parameter_sets(kAnnexB, nalus_in_annex_b.data(),
-                                  nalus_in_annex_b.size());
-  ASSERT_TRUE(parameter_sets.combined_size_in_bytes() ==
+  auto parameter_sets = AvcParameterSets::Create(
+      kAnnexB, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(parameter_sets.has_value());
+  ASSERT_TRUE(parameter_sets->combined_size_in_bytes() ==
               (kSpsInAnnexB.size() + kPpsInAnnexB.size()));
 }
 
 TEST(AvcParameterSetsTest, CombinedSizeWithOptionalParameter) {
   auto aud_first = kAudInAnnexB + kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
-  AvcParameterSets parameter_sets_aud_first(kAnnexB, aud_first.data(),
-                                            aud_first.size());
-  ASSERT_TRUE(parameter_sets_aud_first.combined_size_in_bytes() ==
+  auto parameter_sets_aud_first =
+      AvcParameterSets::Create(kAnnexB, aud_first.data(), aud_first.size());
+  ASSERT_TRUE(parameter_sets_aud_first.has_value());
+  ASSERT_TRUE(parameter_sets_aud_first->combined_size_in_bytes() ==
               (kSpsInAnnexB.size() + kPpsInAnnexB.size()));
   ASSERT_TRUE(
-      parameter_sets_aud_first.combined_size_in_bytes_with_optionals() ==
+      parameter_sets_aud_first->combined_size_in_bytes_with_optionals() ==
       (kAudInAnnexB.size() + kSpsInAnnexB.size() + kPpsInAnnexB.size()));
 
   auto aud_last = kPpsInAnnexB + kSpsInAnnexB + kAudInAnnexB + kIdrInAnnexB;
-  AvcParameterSets parameter_sets(kAnnexB, aud_last.data(), aud_last.size());
-  ASSERT_TRUE(parameter_sets.combined_size_in_bytes() ==
+  auto parameter_sets =
+      AvcParameterSets::Create(kAnnexB, aud_last.data(), aud_last.size());
+  ASSERT_TRUE(parameter_sets.has_value());
+  ASSERT_TRUE(parameter_sets->combined_size_in_bytes() ==
               (kPpsInAnnexB.size() + kSpsInAnnexB.size()));
   ASSERT_TRUE(
-      parameter_sets.combined_size_in_bytes_with_optionals() ==
+      parameter_sets->combined_size_in_bytes_with_optionals() ==
       (kPpsInAnnexB.size() + kSpsInAnnexB.size() + kAudInAnnexB.size()));
 }
 

--- a/starboard/shared/starboard/media/avc_util_test.cc
+++ b/starboard/shared/starboard/media/avc_util_test.cc
@@ -184,7 +184,8 @@ bool HasEqualParameterSets(const std::vector<uint8_t>& nalus_in_annex_b_1,
 }
 
 TEST(AvcParameterSetsTest, Ctor) {
-  auto parameter_sets_1 = AvcParameterSets::Create(kAnnexB, nullptr, 0);
+  auto parameter_sets_1 =
+      AvcParameterSets::Create(kAnnexB, /*data=*/nullptr, /*size=*/0);
   ASSERT_TRUE(parameter_sets_1.has_value());
   auto parameter_sets_2 = AvcParameterSets::Create(kAnnexB, kSpsInAnnexB.data(),
                                                    kSpsInAnnexB.size());
@@ -370,7 +371,8 @@ TEST(AvcParameterSetsTest, SpsAndPpsAfterIdrWithoutSpsAndPps) {
 }
 
 TEST(AvcParameterSetsTest, Nullptr) {
-  auto parameter_sets = AvcParameterSets::Create(kAnnexB, nullptr, 0);
+  auto parameter_sets =
+      AvcParameterSets::Create(kAnnexB, /*data=*/nullptr, /*size=*/0);
 
   ASSERT_TRUE(parameter_sets.has_value());
   ASSERT_EQ(parameter_sets->format(), kAnnexB);

--- a/starboard/shared/starboard/media/codec_util.cc
+++ b/starboard/shared/starboard/media/codec_util.cc
@@ -37,8 +37,7 @@ std::optional<VideoConfig> VideoConfig::Create(SbMediaVideoCodec video_codec,
                        /*avc_parameter_sets=*/std::nullopt);
   } else if (video_codec == kSbMediaVideoCodecH264) {
     auto avc_parameter_sets =
-        AvcParameterSets::Create(/*format=*/AvcParameterSets::kAnnexB,
-                                 /*data=*/data, /*size=*/data_size);
+        AvcParameterSets::CreateFromAnnexB(/*data=*/data, /*size=*/data_size);
     if (avc_parameter_sets) {
       return VideoConfig(video_codec, size, std::move(avc_parameter_sets));
     }

--- a/starboard/shared/starboard/media/codec_util.cc
+++ b/starboard/shared/starboard/media/codec_util.cc
@@ -26,39 +26,43 @@
 
 namespace starboard {
 
-VideoConfig::VideoConfig(SbMediaVideoCodec video_codec,
-                         const Size& size,
-                         const uint8_t* data,
-                         size_t data_size)
-    : size_(size) {
-  if (video_codec == kSbMediaVideoCodecVp9) {
-    video_codec_ = video_codec;
-  } else if (video_codec == kSbMediaVideoCodecAv1) {
-    video_codec_ = video_codec;
+// static
+std::optional<VideoConfig> VideoConfig::Create(SbMediaVideoCodec video_codec,
+                                               const Size& size,
+                                               const uint8_t* data,
+                                               size_t data_size) {
+  if (video_codec == kSbMediaVideoCodecVp9 ||
+      video_codec == kSbMediaVideoCodecAv1) {
+    return VideoConfig(video_codec, size, std::nullopt);
   } else if (video_codec == kSbMediaVideoCodecH264) {
-    avc_parameter_sets_ =
-        AvcParameterSets(AvcParameterSets::kAnnexB, data, data_size);
-    if (avc_parameter_sets_->is_valid()) {
-      video_codec_ = video_codec;
+    auto avc_parameter_sets =
+        AvcParameterSets::Create(AvcParameterSets::kAnnexB, data, data_size);
+    if (avc_parameter_sets) {
+      return VideoConfig(video_codec, size, std::move(avc_parameter_sets));
     }
   } else {
     SB_NOTREACHED();
   }
+  return std::nullopt;
 }
 
-VideoConfig::VideoConfig(const VideoStreamInfo& video_stream_info,
-                         const uint8_t* data,
-                         size_t data_size)
-    : VideoConfig(video_stream_info.codec,
-                  video_stream_info.frame_size,
-                  data,
-                  data_size) {}
+// static
+std::optional<VideoConfig> VideoConfig::Create(
+    const VideoStreamInfo& video_stream_info,
+    const uint8_t* data,
+    size_t data_size) {
+  return Create(video_stream_info.codec, video_stream_info.frame_size, data,
+                data_size);
+}
+
+VideoConfig::VideoConfig(SbMediaVideoCodec video_codec,
+                         const Size& size,
+                         std::optional<AvcParameterSets> avc_parameter_sets)
+    : video_codec_(video_codec),
+      size_(size),
+      avc_parameter_sets_(std::move(avc_parameter_sets)) {}
 
 bool VideoConfig::operator==(const VideoConfig& that) const {
-  if (video_codec_ == kSbMediaVideoCodecNone &&
-      that.video_codec_ == kSbMediaVideoCodecNone) {
-    return true;
-  }
   return video_codec_ == that.video_codec_ &&
          avc_parameter_sets_ == that.avc_parameter_sets_ && size_ == that.size_;
 }
@@ -101,7 +105,7 @@ SbMediaAudioCodec GetAudioCodecFromString(const char* codec,
   if (is_wav && strcmp(codec, "1") == 0) {
     return kSbMediaAudioCodecPcm;
   }
-  if (strcmp(codec, "iamf") == 0 || IamfMimeUtil(codec).is_valid()) {
+  if (strcmp(codec, "iamf") == 0 || IamfMimeUtil::Create(codec).has_value()) {
     return kSbMediaAudioCodecIamf;
   }
   return kSbMediaAudioCodecNone;

--- a/starboard/shared/starboard/media/codec_util.cc
+++ b/starboard/shared/starboard/media/codec_util.cc
@@ -33,10 +33,12 @@ std::optional<VideoConfig> VideoConfig::Create(SbMediaVideoCodec video_codec,
                                                size_t data_size) {
   if (video_codec == kSbMediaVideoCodecVp9 ||
       video_codec == kSbMediaVideoCodecAv1) {
-    return VideoConfig(video_codec, size, std::nullopt);
+    return VideoConfig(video_codec, size,
+                       /*avc_parameter_sets=*/std::nullopt);
   } else if (video_codec == kSbMediaVideoCodecH264) {
     auto avc_parameter_sets =
-        AvcParameterSets::Create(AvcParameterSets::kAnnexB, data, data_size);
+        AvcParameterSets::Create(/*format=*/AvcParameterSets::kAnnexB,
+                                 /*data=*/data, /*size=*/data_size);
     if (avc_parameter_sets) {
       return VideoConfig(video_codec, size, std::move(avc_parameter_sets));
     }

--- a/starboard/shared/starboard/media/codec_util.h
+++ b/starboard/shared/starboard/media/codec_util.h
@@ -33,32 +33,37 @@ namespace starboard {
 class VideoConfig {
  public:
   // |data| must point to the encoded data of a key frame.
-  VideoConfig(SbMediaVideoCodec video_codec,
-              const Size& size,
-              const uint8_t* data,
-              size_t data_size);
+  static std::optional<VideoConfig> Create(SbMediaVideoCodec video_codec,
+                                           const Size& size,
+                                           const uint8_t* data,
+                                           size_t data_size);
 
-  VideoConfig(const VideoStreamInfo& video_stream_info,
-              const uint8_t* data,
-              size_t data_size);
-
-  bool is_valid() const { return video_codec_ != kSbMediaVideoCodecNone; }
+  static std::optional<VideoConfig> Create(
+      const VideoStreamInfo& video_stream_info,
+      const uint8_t* data,
+      size_t data_size);
 
   const AvcParameterSets& avc_parameter_sets() const {
-    SB_DCHECK(is_valid());
     SB_DCHECK_EQ(video_codec_, kSbMediaVideoCodecH264);
     SB_DCHECK(avc_parameter_sets_);
     return avc_parameter_sets_.value();
   }
 
+  SbMediaVideoCodec video_codec() const { return video_codec_; }
+  const Size& size() const { return size_; }
+
   bool operator==(const VideoConfig& that) const;
   bool operator!=(const VideoConfig& that) const;
 
  private:
-  SbMediaVideoCodec video_codec_ = kSbMediaVideoCodecNone;
-  Size size_;
+  VideoConfig(SbMediaVideoCodec video_codec,
+              const Size& size,
+              std::optional<AvcParameterSets> avc_parameter_sets);
+
+  const SbMediaVideoCodec video_codec_;
+  const Size size_;
   // Only valid when |video_codec_| is |kSbMediaVideoCodecH264|.
-  std::optional<AvcParameterSets> avc_parameter_sets_;
+  const std::optional<AvcParameterSets> avc_parameter_sets_;
 };
 
 // Attempts to determine an SbMediaAudioCodec from |codec|, returning

--- a/starboard/shared/starboard/media/codec_util_test.cc
+++ b/starboard/shared/starboard/media/codec_util_test.cc
@@ -55,62 +55,102 @@ TEST(VideoConfigTest, CtorWithVideoStreamInfo) {
   auto config_2 = VideoConfig::Create(
       video_stream_info, nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_2.has_value());
-  ASSERT_EQ(*config_1, *config_2);
+  EXPECT_EQ(*config_1, *config_2);
 }
 
-TEST(VideoConfigTest, IsValid) {
+TEST(VideoConfigTest, IsValidH264PpsOnly) {
+  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                                    kPpsInAnnexB.data(), kPpsInAnnexB.size());
+  ASSERT_TRUE(config.has_value());
+}
+
+TEST(VideoConfigTest, IsValidH264IdrOnly) {
+  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                                    kIdrInAnnexB.data(), kIdrInAnnexB.size());
+  ASSERT_TRUE(config.has_value());
+}
+
+TEST(VideoConfigTest, IsValidH264FullAnnexB) {
+  std::vector<uint8_t> nalus_in_annex_b =
+      kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
+  auto config =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config.has_value());
+}
+
+TEST(VideoConfigTest, IsValidH264InvalidHeader) {
+  std::vector<uint8_t> nalus_in_annex_b =
+      kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
+  // The implementation only fails when the format is avc and the input isn't
+  // empty and doesn't start with a nalu header.
+  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                                    nalus_in_annex_b.data() + 1,
+                                    nalus_in_annex_b.size() - 1);
+  ASSERT_FALSE(config.has_value());
+}
+
+TEST(VideoConfigTest, IsValidVp9) {
+  auto config = VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080},
+                                    /*data=*/nullptr, /*data_size=*/0);
+  ASSERT_TRUE(config.has_value());
+}
+
+TEST(VideoConfigTest, EqualityOperatorsH264) {
   std::vector<uint8_t> nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
 
-  {
-    auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
-                                      kPpsInAnnexB.data(), kPpsInAnnexB.size());
-    ASSERT_TRUE(config.has_value());
-  }
-  {
-    auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
-                                      kIdrInAnnexB.data(), kIdrInAnnexB.size());
-    ASSERT_TRUE(config.has_value());
-  }
-  {
-    auto config =
-        VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
-                            nalus_in_annex_b.data(), nalus_in_annex_b.size());
-    ASSERT_TRUE(config.has_value());
-  }
-  {
-    // The implementation only fails when the format is avc and the input isn't
-    // empty and doesn't start with a nalu header.
-    auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
-                                      nalus_in_annex_b.data() + 1,
-                                      nalus_in_annex_b.size() - 1);
-    ASSERT_FALSE(config.has_value());
-  }
-  {
-    auto config = VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080},
-                                      /*data=*/nullptr, /*data_size=*/0);
-    ASSERT_TRUE(config.has_value());
-  }
+  auto config1 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config1.has_value());
+
+  // Self comparison
+  EXPECT_TRUE(*config1 == *config1);
+  EXPECT_FALSE(*config1 != *config1);
+
+  // Different instances, same values
+  auto config2 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config2.has_value());
+  EXPECT_TRUE(*config1 == *config2);
+  EXPECT_FALSE(*config1 != *config2);
+
+  // Different values (resolution)
+  auto config3 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config3.has_value());
+  EXPECT_FALSE(*config1 == *config3);
+  EXPECT_TRUE(*config1 != *config3);
 }
 
-TEST(VideoConfigTest, SelfComparison) {
-  {
-    std::vector<uint8_t> nalus_in_annex_b =
-        kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
+TEST(VideoConfigTest, EqualityOperatorsVp9) {
+  auto config1 =
+      VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, /*data=*/nullptr,
+                          /*data_size=*/0);
+  ASSERT_TRUE(config1.has_value());
 
-    auto config =
-        VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
-                            nalus_in_annex_b.data(), nalus_in_annex_b.size());
-    ASSERT_TRUE(config.has_value());
-    EXPECT_EQ(*config, *config);
-  }
-  {
-    auto config =
-        VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, /*data=*/nullptr,
-                            /*data_size=*/0);
-    ASSERT_TRUE(config.has_value());
-    EXPECT_EQ(*config, *config);
-  }
+  // Self comparison
+  EXPECT_TRUE(*config1 == *config1);
+  EXPECT_FALSE(*config1 != *config1);
+
+  // Different instances, same values
+  auto config2 =
+      VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, /*data=*/nullptr,
+                          /*data_size=*/0);
+  ASSERT_TRUE(config2.has_value());
+  EXPECT_TRUE(*config1 == *config2);
+  EXPECT_FALSE(*config1 != *config2);
+
+  // Different values (resolution)
+  auto config3 =
+      VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080}, /*data=*/nullptr,
+                          /*data_size=*/0);
+  ASSERT_TRUE(config3.has_value());
+  EXPECT_FALSE(*config1 == *config3);
+  EXPECT_TRUE(*config1 != *config3);
 }
 
 TEST(VideoConfigTest, H264) {

--- a/starboard/shared/starboard/media/codec_util_test.cc
+++ b/starboard/shared/starboard/media/codec_util_test.cc
@@ -23,10 +23,10 @@
 namespace starboard {
 namespace {
 
-const uint8_t kIdrStartCode = 0x65;
-const auto kSpsStartCode = AvcParameterSets::kSpsStartCode;
-const auto kPpsStartCode = AvcParameterSets::kPpsStartCode;
-const auto kAnnexB = AvcParameterSets::kAnnexB;
+constexpr uint8_t kIdrStartCode = 0x65;
+constexpr uint8_t kSpsStartCode = 0x67;
+constexpr uint8_t kPpsStartCode = 0x68;
+constexpr auto kAnnexB = AvcParameterSets::kAnnexB;
 
 const std::vector<uint8_t> kSpsInAnnexB = {0, 0, 0, 1, kSpsStartCode, 10, 11};
 const std::vector<uint8_t> kPpsInAnnexB = {0, 0, 0, 1, kPpsStartCode, 20};
@@ -210,8 +210,8 @@ TEST(VideoConfigTest, H264MultiSpsPps) {
   ASSERT_TRUE(config_dual_sps_pps.has_value());
   EXPECT_NE(*config_single_sps_pps, *config_dual_sps_pps);
   EXPECT_EQ(config_dual_sps_pps->avc_parameter_sets(),
-            *AvcParameterSets::Create(kAnnexB, nalus_in_annex_b.data(),
-                                      nalus_in_annex_b.size()));
+            *AvcParameterSets::CreateFromAnnexB(nalus_in_annex_b.data(),
+                                                nalus_in_annex_b.size()));
 
   // Same resolution, different parameter sets.
   nalus_in_annex_b =

--- a/starboard/shared/starboard/media/codec_util_test.cc
+++ b/starboard/shared/starboard/media/codec_util_test.cc
@@ -87,8 +87,8 @@ TEST(VideoConfigTest, IsValid) {
     ASSERT_FALSE(config.has_value());
   }
   {
-    auto config =
-        VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080}, nullptr, 0);
+    auto config = VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080},
+                                      /*data=*/nullptr, /*data_size=*/0);
     ASSERT_TRUE(config.has_value());
   }
 }
@@ -107,7 +107,8 @@ TEST(VideoConfigTest, SelfComparison) {
   }
   {
     auto config =
-        VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, nullptr, 0);
+        VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, /*data=*/nullptr,
+                            /*data_size=*/0);
     ASSERT_TRUE(config.has_value());
     EXPECT_TRUE(*config == *config);
     EXPECT_FALSE(*config != *config);

--- a/starboard/shared/starboard/media/codec_util_test.cc
+++ b/starboard/shared/starboard/media/codec_util_test.cc
@@ -55,7 +55,7 @@ TEST(VideoConfigTest, CtorWithVideoStreamInfo) {
   auto config_2 = VideoConfig::Create(
       video_stream_info, nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_2.has_value());
-  ASSERT_TRUE(*config_1 == *config_2);
+  ASSERT_EQ(*config_1, *config_2);
 }
 
 TEST(VideoConfigTest, IsValid) {
@@ -102,16 +102,14 @@ TEST(VideoConfigTest, SelfComparison) {
         VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
                             nalus_in_annex_b.data(), nalus_in_annex_b.size());
     ASSERT_TRUE(config.has_value());
-    EXPECT_TRUE(*config == *config);
-    EXPECT_FALSE(*config != *config);
+    EXPECT_EQ(*config, *config);
   }
   {
     auto config =
         VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, /*data=*/nullptr,
                             /*data_size=*/0);
     ASSERT_TRUE(config.has_value());
-    EXPECT_TRUE(*config == *config);
-    EXPECT_FALSE(*config != *config);
+    EXPECT_EQ(*config, *config);
   }
 }
 
@@ -129,9 +127,8 @@ TEST(VideoConfigTest, H264) {
       VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_1.has_value());
-  EXPECT_TRUE(*config != *config_1);
-  EXPECT_TRUE(config->avc_parameter_sets() == config_1->avc_parameter_sets());
-  EXPECT_FALSE(*config == *config_1);
+  EXPECT_NE(*config, *config_1);
+  EXPECT_EQ(config->avc_parameter_sets(), config_1->avc_parameter_sets());
 
   // Same resolution, different parameter sets.
   nalus_in_annex_b =
@@ -140,8 +137,7 @@ TEST(VideoConfigTest, H264) {
       VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_2.has_value());
-  EXPECT_TRUE(*config != *config_2);
-  EXPECT_FALSE(*config == *config_2);
+  EXPECT_NE(*config, *config_2);
 
   // Same resolution, same parameter sets, different idr data.
   nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
@@ -151,8 +147,7 @@ TEST(VideoConfigTest, H264) {
       VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_3.has_value());
-  EXPECT_TRUE(*config == *config_3);
-  EXPECT_FALSE(*config != *config_3);
+  EXPECT_EQ(*config, *config_3);
 }
 
 TEST(VideoConfigTest, H264MultiSpsPps) {
@@ -173,11 +168,10 @@ TEST(VideoConfigTest, H264MultiSpsPps) {
       VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_dual_sps_pps.has_value());
-  EXPECT_TRUE(*config_single_sps_pps != *config_dual_sps_pps);
-  EXPECT_FALSE(*config_single_sps_pps == *config_dual_sps_pps);
-  EXPECT_TRUE(config_dual_sps_pps->avc_parameter_sets() ==
-              *AvcParameterSets::Create(kAnnexB, nalus_in_annex_b.data(),
-                                        nalus_in_annex_b.size()));
+  EXPECT_NE(*config_single_sps_pps, *config_dual_sps_pps);
+  EXPECT_EQ(config_dual_sps_pps->avc_parameter_sets(),
+            *AvcParameterSets::Create(kAnnexB, nalus_in_annex_b.data(),
+                                      nalus_in_annex_b.size()));
 
   // Same resolution, different parameter sets.
   nalus_in_annex_b =
@@ -186,8 +180,7 @@ TEST(VideoConfigTest, H264MultiSpsPps) {
       VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_1.has_value());
-  EXPECT_TRUE(*config_single_sps_pps != *config_1);
-  EXPECT_FALSE(*config_single_sps_pps == *config_1);
+  EXPECT_NE(*config_single_sps_pps, *config_1);
 
   // Same resolution, same parameter sets, different idr data.
   nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
@@ -197,8 +190,7 @@ TEST(VideoConfigTest, H264MultiSpsPps) {
       VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_2.has_value());
-  EXPECT_TRUE(*config_single_sps_pps == *config_2);
-  EXPECT_FALSE(*config_single_sps_pps != *config_2);
+  EXPECT_EQ(*config_single_sps_pps, *config_2);
 }
 
 TEST(VideoConfigTest, Vp9) {
@@ -214,16 +206,14 @@ TEST(VideoConfigTest, Vp9) {
       VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080}, kInvalidData,
                           SB_ARRAY_SIZE(kInvalidData));
   ASSERT_TRUE(config_1.has_value());
-  EXPECT_TRUE(*config != *config_1);
-  EXPECT_FALSE(*config == *config_1);
+  EXPECT_NE(*config, *config_1);
 
   // Same resolution, different data (one less byte).
   auto config_2 =
       VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, kInvalidData,
                           SB_ARRAY_SIZE(kInvalidData) - 1);
   ASSERT_TRUE(config_2.has_value());
-  EXPECT_TRUE(*config == *config_2);
-  EXPECT_FALSE(*config != *config_2);
+  EXPECT_EQ(*config, *config_2);
 }
 
 TEST(VideoConfigTest, H264VsVp9) {
@@ -239,8 +229,7 @@ TEST(VideoConfigTest, H264VsVp9) {
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_vp9.has_value());
 
-  EXPECT_TRUE(*config_h264 != *config_vp9);
-  EXPECT_FALSE(*config_h264 == *config_vp9);
+  EXPECT_NE(*config_h264, *config_vp9);
 }
 
 TEST(CodecUtilTest, ParsesAacCodecs) {

--- a/starboard/shared/starboard/media/codec_util_test.cc
+++ b/starboard/shared/starboard/media/codec_util_test.cc
@@ -48,11 +48,14 @@ TEST(VideoConfigTest, CtorWithVideoStreamInfo) {
   std::vector<uint8_t> nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
 
-  VideoConfig config_1(video_stream_info.codec, video_stream_info.frame_size,
-                       nalus_in_annex_b.data(), nalus_in_annex_b.size());
-  VideoConfig config_2(video_stream_info, nalus_in_annex_b.data(),
-                       nalus_in_annex_b.size());
-  ASSERT_TRUE(config_1 == config_2);
+  auto config_1 =
+      VideoConfig::Create(video_stream_info.codec, video_stream_info.frame_size,
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_1.has_value());
+  auto config_2 = VideoConfig::Create(
+      video_stream_info, nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_2.has_value());
+  ASSERT_TRUE(*config_1 == *config_2);
 }
 
 TEST(VideoConfigTest, IsValid) {
@@ -60,31 +63,33 @@ TEST(VideoConfigTest, IsValid) {
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
 
   {
-    VideoConfig config(kSbMediaVideoCodecH264, {1920, 1080},
-                       kPpsInAnnexB.data(), kPpsInAnnexB.size());
-    ASSERT_TRUE(config.is_valid());
+    auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                                      kPpsInAnnexB.data(), kPpsInAnnexB.size());
+    ASSERT_TRUE(config.has_value());
   }
   {
-    VideoConfig config(kSbMediaVideoCodecH264, {1920, 1080},
-                       kIdrInAnnexB.data(), kIdrInAnnexB.size());
-    ASSERT_TRUE(config.is_valid());
+    auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                                      kIdrInAnnexB.data(), kIdrInAnnexB.size());
+    ASSERT_TRUE(config.has_value());
   }
   {
-    VideoConfig config(kSbMediaVideoCodecH264, {1920, 1080},
-                       nalus_in_annex_b.data(), nalus_in_annex_b.size());
-    ASSERT_TRUE(config.is_valid());
+    auto config =
+        VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                            nalus_in_annex_b.data(), nalus_in_annex_b.size());
+    ASSERT_TRUE(config.has_value());
   }
   {
     // The implementation only fails when the format is avc and the input isn't
     // empty and doesn't start with a nalu header.
-    VideoConfig config(kSbMediaVideoCodecH264, {1920, 1080},
-                       nalus_in_annex_b.data() + 1,
-                       nalus_in_annex_b.size() - 1);
-    ASSERT_FALSE(config.is_valid());
+    auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                                      nalus_in_annex_b.data() + 1,
+                                      nalus_in_annex_b.size() - 1);
+    ASSERT_FALSE(config.has_value());
   }
   {
-    VideoConfig config(kSbMediaVideoCodecVp9, {1920, 1080}, nullptr, 0);
-    ASSERT_TRUE(config.is_valid());
+    auto config =
+        VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080}, nullptr, 0);
+    ASSERT_TRUE(config.has_value());
   }
 }
 
@@ -93,15 +98,19 @@ TEST(VideoConfigTest, SelfComparison) {
     std::vector<uint8_t> nalus_in_annex_b =
         kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
 
-    VideoConfig config(kSbMediaVideoCodecH264, {640, 480},
-                       nalus_in_annex_b.data(), nalus_in_annex_b.size());
-    EXPECT_TRUE(config == config);
-    EXPECT_FALSE(config != config);
+    auto config =
+        VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                            nalus_in_annex_b.data(), nalus_in_annex_b.size());
+    ASSERT_TRUE(config.has_value());
+    EXPECT_TRUE(*config == *config);
+    EXPECT_FALSE(*config != *config);
   }
   {
-    VideoConfig config(kSbMediaVideoCodecVp9, {640, 480}, nullptr, 0);
-    EXPECT_TRUE(config == config);
-    EXPECT_FALSE(config != config);
+    auto config =
+        VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, nullptr, 0);
+    ASSERT_TRUE(config.has_value());
+    EXPECT_TRUE(*config == *config);
+    EXPECT_FALSE(*config != *config);
   }
 }
 
@@ -109,32 +118,40 @@ TEST(VideoConfigTest, H264) {
   std::vector<uint8_t> nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
 
-  VideoConfig config(kSbMediaVideoCodecH264, {640, 480},
-                     nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  auto config =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config.has_value());
 
   // Different resolution, same parameter sets.
-  VideoConfig config_1(kSbMediaVideoCodecH264, {1920, 1080},
-                       nalus_in_annex_b.data(), nalus_in_annex_b.size());
-  EXPECT_TRUE(config != config_1);
-  EXPECT_TRUE(config.avc_parameter_sets() == config_1.avc_parameter_sets());
-  EXPECT_FALSE(config == config_1);
+  auto config_1 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_1.has_value());
+  EXPECT_TRUE(*config != *config_1);
+  EXPECT_TRUE(config->avc_parameter_sets() == config_1->avc_parameter_sets());
+  EXPECT_FALSE(*config == *config_1);
 
   // Same resolution, different parameter sets.
   nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + std::vector<uint8_t>({99}) + kIdrInAnnexB;
-  VideoConfig config_2(kSbMediaVideoCodecH264, {640, 480},
-                       nalus_in_annex_b.data(), nalus_in_annex_b.size());
-  EXPECT_TRUE(config != config_2);
-  EXPECT_FALSE(config == config_2);
+  auto config_2 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_2.has_value());
+  EXPECT_TRUE(*config != *config_2);
+  EXPECT_FALSE(*config == *config_2);
 
   // Same resolution, same parameter sets, different idr data.
   nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
   nalus_in_annex_b.push_back(99);
 
-  VideoConfig config_3(kSbMediaVideoCodecH264, {640, 480},
-                       nalus_in_annex_b.data(), nalus_in_annex_b.size());
-  EXPECT_TRUE(config == config_3);
-  EXPECT_FALSE(config != config_3);
+  auto config_3 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_3.has_value());
+  EXPECT_TRUE(*config == *config_3);
+  EXPECT_FALSE(*config != *config_3);
 }
 
 TEST(VideoConfigTest, H264MultiSpsPps) {
@@ -142,72 +159,87 @@ TEST(VideoConfigTest, H264MultiSpsPps) {
   std::vector<uint8_t> nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
 
-  VideoConfig config_single_sps_pps(kSbMediaVideoCodecH264, {640, 480},
-                                    nalus_in_annex_b.data(),
-                                    nalus_in_annex_b.size());
+  auto config_single_sps_pps =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_single_sps_pps.has_value());
 
   // Same resolution, multiple parameter sets.
   nalus_in_annex_b =
       kSpsInAnnexB + kSpsInAnnexB + kPpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
 
-  VideoConfig config_dual_sps_pps(kSbMediaVideoCodecH264, {640, 480},
-                                  nalus_in_annex_b.data(),
-                                  nalus_in_annex_b.size());
-  EXPECT_TRUE(config_single_sps_pps != config_dual_sps_pps);
-  EXPECT_FALSE(config_single_sps_pps == config_dual_sps_pps);
-  EXPECT_TRUE(config_dual_sps_pps.avc_parameter_sets() ==
-              AvcParameterSets(kAnnexB, nalus_in_annex_b.data(),
-                               nalus_in_annex_b.size()));
+  auto config_dual_sps_pps =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_dual_sps_pps.has_value());
+  EXPECT_TRUE(*config_single_sps_pps != *config_dual_sps_pps);
+  EXPECT_FALSE(*config_single_sps_pps == *config_dual_sps_pps);
+  EXPECT_TRUE(config_dual_sps_pps->avc_parameter_sets() ==
+              *AvcParameterSets::Create(kAnnexB, nalus_in_annex_b.data(),
+                                        nalus_in_annex_b.size()));
 
   // Same resolution, different parameter sets.
   nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + std::vector<uint8_t>({99}) + kIdrInAnnexB;
-  VideoConfig config_1(kSbMediaVideoCodecH264, {640, 480},
-                       nalus_in_annex_b.data(), nalus_in_annex_b.size());
-  EXPECT_TRUE(config_single_sps_pps != config_1);
-  EXPECT_FALSE(config_single_sps_pps == config_1);
+  auto config_1 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_1.has_value());
+  EXPECT_TRUE(*config_single_sps_pps != *config_1);
+  EXPECT_FALSE(*config_single_sps_pps == *config_1);
 
   // Same resolution, same parameter sets, different idr data.
   nalus_in_annex_b = kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
   nalus_in_annex_b.push_back(99);
 
-  VideoConfig config_2(kSbMediaVideoCodecH264, {640, 480},
-                       nalus_in_annex_b.data(), nalus_in_annex_b.size());
-  EXPECT_TRUE(config_single_sps_pps == config_2);
-  EXPECT_FALSE(config_single_sps_pps != config_2);
+  auto config_2 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_2.has_value());
+  EXPECT_TRUE(*config_single_sps_pps == *config_2);
+  EXPECT_FALSE(*config_single_sps_pps != *config_2);
 }
 
 TEST(VideoConfigTest, Vp9) {
   // The class shouldn't look into vp9 bitstreams.
   const uint8_t kInvalidData[] = {1, 7, 25};
 
-  VideoConfig config(kSbMediaVideoCodecVp9, {640, 480}, kInvalidData,
-                     SB_ARRAY_SIZE(kInvalidData));
+  auto config = VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480},
+                                    kInvalidData, SB_ARRAY_SIZE(kInvalidData));
+  ASSERT_TRUE(config.has_value());
 
   // Different resolution, same data.
-  VideoConfig config_1(kSbMediaVideoCodecVp9, {1920, 1080}, kInvalidData,
-                       SB_ARRAY_SIZE(kInvalidData));
-  EXPECT_TRUE(config != config_1);
-  EXPECT_FALSE(config == config_1);
+  auto config_1 =
+      VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080}, kInvalidData,
+                          SB_ARRAY_SIZE(kInvalidData));
+  ASSERT_TRUE(config_1.has_value());
+  EXPECT_TRUE(*config != *config_1);
+  EXPECT_FALSE(*config == *config_1);
 
   // Same resolution, different data (one less byte).
-  VideoConfig config_2(kSbMediaVideoCodecVp9, {640, 480}, kInvalidData,
-                       SB_ARRAY_SIZE(kInvalidData) - 1);
-  EXPECT_TRUE(config == config_2);
-  EXPECT_FALSE(config != config_2);
+  auto config_2 =
+      VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480}, kInvalidData,
+                          SB_ARRAY_SIZE(kInvalidData) - 1);
+  ASSERT_TRUE(config_2.has_value());
+  EXPECT_TRUE(*config == *config_2);
+  EXPECT_FALSE(*config != *config_2);
 }
 
 TEST(VideoConfigTest, H264VsVp9) {
   std::vector<uint8_t> nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
 
-  VideoConfig config_h264(kSbMediaVideoCodecH264, {640, 480},
+  auto config_h264 =
+      VideoConfig::Create(kSbMediaVideoCodecH264, {640, 480},
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
-  VideoConfig config_vp9(kSbMediaVideoCodecVp9, {640, 480},
-                         nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_h264.has_value());
+  auto config_vp9 =
+      VideoConfig::Create(kSbMediaVideoCodecVp9, {640, 480},
+                          nalus_in_annex_b.data(), nalus_in_annex_b.size());
+  ASSERT_TRUE(config_vp9.has_value());
 
-  EXPECT_TRUE(config_h264 != config_vp9);
-  EXPECT_FALSE(config_h264 == config_vp9);
+  EXPECT_TRUE(*config_h264 != *config_vp9);
+  EXPECT_FALSE(*config_h264 == *config_vp9);
 }
 
 TEST(CodecUtilTest, ParsesAacCodecs) {

--- a/starboard/shared/starboard/media/iamf_util.cc
+++ b/starboard/shared/starboard/media/iamf_util.cc
@@ -109,13 +109,14 @@ bool StringToProfile(const std::string& input, uint32_t* profile) {
 }
 }  // namespace
 
-IamfMimeUtil::IamfMimeUtil(const std::string& mime_type) {
+// static
+std::optional<IamfMimeUtil> IamfMimeUtil::Create(const std::string& mime_type) {
   // Reference: Immersive Audio Model and Formats;
   //            v1.0.0
   //            6.3. Codecs Parameter String
   // (https://aomediacodec.github.io/iamf/v1.0.0-errata.html#codecsparameter)
   if (mime_type.find("iamf") != 0) {
-    return;
+    return std::nullopt;
   }
 
   // 4   FOURCC string "iamf".
@@ -127,63 +128,71 @@ IamfMimeUtil::IamfMimeUtil(const std::string& mime_type) {
   // +9  The remaining string is one of "Opus", "mp4a.40.2", "fLaC", or "ipcm".
   constexpr int kMaxIamfCodecIdLength = 22;
   if (mime_type.size() > kMaxIamfCodecIdLength) {
-    return;
+    return std::nullopt;
   }
 
   const std::vector<std::string> vec = SplitString(mime_type, '.');
   // The mime type must be in 4 parts for all substreams other than AAC, which
   // is 6 parts.
   if (vec.size() != 4 && vec.size() != 6) {
-    return;
+    return std::nullopt;
   }
 
   // The primary profile must be between 0 and 255 inclusive.
   uint32_t primary_profile = 0;
   if (!StringToProfile(vec[1], &primary_profile)) {
-    return;
+    return std::nullopt;
   }
 
   // The additional profile must be between 0 and 255 inclusive.
   uint32_t additional_profile = 0;
   if (!StringToProfile(vec[2], &additional_profile)) {
-    return;
+    return std::nullopt;
   }
 
   // The codec string should be one of "Opus", "mp4a", "fLaC", or "ipcm".
   std::string codec = vec[3];
   if ((codec != "Opus") && (codec != "mp4a") && (codec != "fLaC") &&
       (codec != "ipcm")) {
-    return;
+    return std::nullopt;
   }
+
+  IamfSubstreamCodec substream_codec = kIamfSubstreamCodecUnknown;
 
   // Only IAMF codec parameter strings with "mp4a" should be greater than 4
   // elements.
   if (codec == "mp4a") {
     if (vec.size() != 6) {
-      return;
+      return std::nullopt;
     }
 
     // The fields following "mp4a" should be "40" and "2" to signal AAC-LC.
     if (vec[4] != "40" || vec[5] != "2") {
-      return;
+      return std::nullopt;
     }
-    substream_codec_ = kIamfSubstreamCodecMp4a;
+    substream_codec = kIamfSubstreamCodecMp4a;
   } else {
     if (vec.size() > 4) {
-      return;
+      return std::nullopt;
     }
     if (codec == "Opus") {
-      substream_codec_ = kIamfSubstreamCodecOpus;
+      substream_codec = kIamfSubstreamCodecOpus;
     } else if (codec == "fLaC") {
-      substream_codec_ = kIamfSubstreamCodecFlac;
+      substream_codec = kIamfSubstreamCodecFlac;
     } else {
-      substream_codec_ = kIamfSubstreamCodecIpcm;
+      substream_codec = kIamfSubstreamCodecIpcm;
     }
   }
 
-  primary_profile_ = primary_profile;
-  additional_profile_ = additional_profile;
+  return IamfMimeUtil(primary_profile, additional_profile, substream_codec);
 }
+
+IamfMimeUtil::IamfMimeUtil(uint32_t primary_profile,
+                           uint32_t additional_profile,
+                           IamfSubstreamCodec substream_codec)
+    : primary_profile_(primary_profile),
+      additional_profile_(additional_profile),
+      substream_codec_(substream_codec) {}
 
 // static.
 Result<IamfMimeUtil::IamfProfileInfo> IamfMimeUtil::ParseIamfSequenceHeaderObu(

--- a/starboard/shared/starboard/media/iamf_util.h
+++ b/starboard/shared/starboard/media/iamf_util.h
@@ -50,7 +50,7 @@ class IamfMimeUtil {
     uint8_t additional_profile;
   };
 
-  explicit IamfMimeUtil(const std::string& mime_type);
+  static std::optional<IamfMimeUtil> Create(const std::string& mime_type);
 
   // Parses IAMF Config OBUs for the primary and additional profiles,
   // based on IAMF specification v1.0.0-errata.
@@ -58,28 +58,18 @@ class IamfMimeUtil {
   static Result<IamfProfileInfo> ParseIamfSequenceHeaderObu(
       const std::vector<uint8_t>& data);
 
-  bool is_valid() const {
-    return primary_profile_ <= kIamfProfileMax &&
-           additional_profile_ <= kIamfProfileMax &&
-           substream_codec_ != kIamfSubstreamCodecUnknown;
-  }
-  uint32_t primary_profile() const {
-    SB_DCHECK(is_valid());
-    return primary_profile_;
-  }
-  uint32_t additional_profile() const {
-    SB_DCHECK(is_valid());
-    return additional_profile_;
-  }
-  IamfSubstreamCodec substream_codec() const {
-    SB_DCHECK(is_valid());
-    return substream_codec_;
-  }
+  uint32_t primary_profile() const { return primary_profile_; }
+  uint32_t additional_profile() const { return additional_profile_; }
+  IamfSubstreamCodec substream_codec() const { return substream_codec_; }
 
  private:
-  uint32_t primary_profile_ = std::numeric_limits<uint32_t>::max();
-  uint32_t additional_profile_ = std::numeric_limits<uint32_t>::max();
-  IamfSubstreamCodec substream_codec_ = kIamfSubstreamCodecUnknown;
+  IamfMimeUtil(uint32_t primary_profile,
+               uint32_t additional_profile,
+               IamfSubstreamCodec substream_codec);
+
+  const uint32_t primary_profile_;
+  const uint32_t additional_profile_;
+  const IamfSubstreamCodec substream_codec_;
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/media/iamf_util_test.cc
+++ b/starboard/shared/starboard/media/iamf_util_test.cc
@@ -23,231 +23,157 @@ namespace starboard {
 namespace {
 
 TEST(IamfUtilTest, Valid) {
-  std::string codec_param = "iamf.000.000.Opus";
-  IamfMimeUtil util(codec_param);
-  EXPECT_TRUE(util.is_valid());
-
-  codec_param = "iamf.000.000.fLaC";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
-
-  codec_param = "iamf.000.000.ipcm";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
-
-  codec_param = "iamf.000.000.mp4a.40.2";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
+  EXPECT_TRUE(IamfMimeUtil::Create("iamf.000.000.Opus").has_value());
+  EXPECT_TRUE(IamfMimeUtil::Create("iamf.000.000.fLaC").has_value());
+  EXPECT_TRUE(IamfMimeUtil::Create("iamf.000.000.ipcm").has_value());
+  EXPECT_TRUE(IamfMimeUtil::Create("iamf.000.000.mp4a.40.2").has_value());
 }
 
 TEST(IamfUtilTest, Invalid) {
   // Invalid substream codec
-  std::string codec_param = "iamf.000.000.vorbis";
-  IamfMimeUtil util(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.vorbis").has_value());
 
   // Invalid codec capitalization
-  codec_param = "iamf.000.000.opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
-  codec_param = "iamf.000.000.flac";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
-  codec_param = "iamf.000.000.FlAc";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
-  codec_param = "iamf.000.000.MP4a.40.2";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
-  codec_param = "IAMF.000.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.opus").has_value());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.flac").has_value());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.FlAc").has_value());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.MP4a.40.2").has_value());
+  EXPECT_FALSE(IamfMimeUtil::Create("IAMF.000.000.Opus").has_value());
 
   // Invalid additional profile value
-  codec_param = "iamf.000.999.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.999.Opus").has_value());
 
   // Invalid primary profile value
-  codec_param = "iamf.999.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.999.000.Opus").has_value());
 
   // Invalid leading codec param
-  codec_param = "iacb.000.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iacb.000.000.Opus").has_value());
 
   // Invalid length for Opus substream
-  codec_param = "iamf.000.000.Opus.40.2";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.Opus.40.2").has_value());
 
   // Invalid length for AAC-LC substream
-  codec_param = "iamf.000.000.mp4a";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.mp4a").has_value());
 
   // Invalid param for AAC-LC substream
-  codec_param = "iamf.000.000.mp4a.40.3";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.mp4a.40.3").has_value());
 
   // Invalid param for AAC-LC substream
-  codec_param = "iamf.000.000.mp4a.40.20";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.mp4a.40.20").has_value());
 
   // Too many delimiting periods
-  codec_param = "iamf.000.000..Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000..Opus").has_value());
 
   // Leading delimiting period
-  codec_param = ".iamf.000.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create(".iamf.000.000.Opus").has_value());
 
   // Trailing delimiting period
-  codec_param = "iamf.000.000.Opus.";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.Opus.").has_value());
 
   // No delimiting period between codec param string and primary profile
-  codec_param = "iamf000.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf000.000.Opus").has_value());
 
   // Invalid primary profile length
-  codec_param = "iamf.00.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
-  codec_param = "iamf.0000.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.00.000.Opus").has_value());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.0000.000.Opus").has_value());
 
   // Invalid additional profile length
-  codec_param = "iamf.000.00.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
-  codec_param = "iamf.000.0000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.00.Opus").has_value());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.0000.Opus").has_value());
 
   // Letters in primary profile value
-  codec_param = "iamf.0aa.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
-  codec_param = "iamf.xxx.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.0aa.000.Opus").has_value());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.xxx.000.Opus").has_value());
 
   // Letters in additional profile value
-  codec_param = "iamf.000.0aa.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
-  codec_param = "iamf.000.xxx.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.0aa.Opus").has_value());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.xxx.Opus").has_value());
 
   // Letter in primary profile value
-  codec_param = "iamf.0a0.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.0a0.000.Opus").has_value());
 
   // Invalid additional profile with AAC-LC substream
-  codec_param = "iamf.000.00.mp4a.40.2";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.00.mp4a.40.2").has_value());
 
   // Misplaced delimiting period for AAC-LC substream
-  codec_param = "iamf.000.000.mp4a.402.";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.mp4a.402.").has_value());
 
   // Negative primary profile value
-  codec_param = "iamf.-12.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.-12.000.Opus").has_value());
 
-  // Empty param
-  codec_param = "";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("").has_value());
 
   // Leading whitespace
-  codec_param = " iamf.000.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create(" iamf.000.000.Opus").has_value());
 
   // Trailing whitespace
-  codec_param = "iamf.000.000.Opus ";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.Opus ").has_value());
 
   // Whitespace in the middle
-  codec_param = "iamf.00 0.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.00 0.000.Opus").has_value());
 
   // HE-AAC substream param
-  codec_param = "iamf.000.000.mp4a.40.5";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("iamf.000.000.mp4a.40.5").has_value());
 
   // Non IAMF codec param
-  codec_param = "ec-3";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_FALSE(util.is_valid());
+  EXPECT_FALSE(IamfMimeUtil::Create("ec-3").has_value());
 }
 
 TEST(IamfUtilTest, SubstreamCodec) {
-  std::string codec_param = "iamf.000.000.Opus";
-  IamfMimeUtil util(codec_param);
-  EXPECT_TRUE(util.is_valid());
-  EXPECT_EQ(util.substream_codec(), kIamfSubstreamCodecOpus);
+  {
+    auto util = IamfMimeUtil::Create("iamf.000.000.Opus");
+    ASSERT_TRUE(util.has_value());
+    EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecOpus);
+  }
 
-  codec_param = "iamf.000.000.fLaC";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
-  EXPECT_EQ(util.substream_codec(), kIamfSubstreamCodecFlac);
+  {
+    auto util = IamfMimeUtil::Create("iamf.000.000.fLaC");
+    ASSERT_TRUE(util.has_value());
+    EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecFlac);
+  }
 
-  codec_param = "iamf.000.000.ipcm";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
-  EXPECT_EQ(util.substream_codec(), kIamfSubstreamCodecIpcm);
+  {
+    auto util = IamfMimeUtil::Create("iamf.000.000.ipcm");
+    ASSERT_TRUE(util.has_value());
+    EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecIpcm);
+  }
 
-  codec_param = "iamf.000.000.mp4a.40.2";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
-  EXPECT_EQ(util.substream_codec(), kIamfSubstreamCodecMp4a);
+  {
+    auto util = IamfMimeUtil::Create("iamf.000.000.mp4a.40.2");
+    ASSERT_TRUE(util.has_value());
+    EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecMp4a);
+  }
 }
 
 TEST(IamfUtilTest, Profile) {
-  std::string codec_param = "iamf.000.000.Opus";
-  IamfMimeUtil util(codec_param);
-  EXPECT_TRUE(util.is_valid());
-  EXPECT_EQ(util.primary_profile(), kIamfProfileSimple);
-  EXPECT_EQ(util.additional_profile(), kIamfProfileSimple);
+  {
+    auto util = IamfMimeUtil::Create("iamf.000.000.Opus");
+    ASSERT_TRUE(util.has_value());
+    EXPECT_EQ(util->primary_profile(), kIamfProfileSimple);
+    EXPECT_EQ(util->additional_profile(), kIamfProfileSimple);
+  }
 
-  codec_param = "iamf.001.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
-  EXPECT_EQ(util.primary_profile(), kIamfProfileBase);
-  EXPECT_EQ(util.additional_profile(), kIamfProfileSimple);
+  {
+    auto util = IamfMimeUtil::Create("iamf.001.000.Opus");
+    ASSERT_TRUE(util.has_value());
+    EXPECT_EQ(util->primary_profile(), kIamfProfileBase);
+    EXPECT_EQ(util->additional_profile(), kIamfProfileSimple);
+  }
 
-  codec_param = "iamf.000.001.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
-  EXPECT_EQ(util.primary_profile(), kIamfProfileSimple);
-  EXPECT_EQ(util.additional_profile(), kIamfProfileBase);
+  {
+    auto util = IamfMimeUtil::Create("iamf.000.001.Opus");
+    ASSERT_TRUE(util.has_value());
+    EXPECT_EQ(util->primary_profile(), kIamfProfileSimple);
+    EXPECT_EQ(util->additional_profile(), kIamfProfileBase);
+  }
 
-  codec_param = "iamf.002.000.Opus";
-  util = IamfMimeUtil(codec_param);
-  EXPECT_TRUE(util.is_valid());
-  ASSERT_NE(util.primary_profile(), kIamfProfileSimple);
-  ASSERT_NE(util.primary_profile(), kIamfProfileBase);
-  ASSERT_EQ(util.primary_profile(), 2U);
+  {
+    auto util = IamfMimeUtil::Create("iamf.002.000.Opus");
+    ASSERT_TRUE(util.has_value());
+    ASSERT_NE(util->primary_profile(), kIamfProfileSimple);
+    ASSERT_NE(util->primary_profile(), kIamfProfileBase);
+    ASSERT_EQ(util->primary_profile(), 2U);
+  }
 }
 
 TEST(IamfUtilTest, ParsesSequenceHeaderObu) {

--- a/starboard/shared/starboard/media/iamf_util_test.cc
+++ b/starboard/shared/starboard/media/iamf_util_test.cc
@@ -119,61 +119,57 @@ TEST(IamfUtilTest, Invalid) {
   EXPECT_FALSE(IamfMimeUtil::Create("ec-3").has_value());
 }
 
-TEST(IamfUtilTest, SubstreamCodec) {
-  {
-    auto util = IamfMimeUtil::Create("iamf.000.000.Opus");
-    ASSERT_TRUE(util.has_value());
-    EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecOpus);
-  }
-
-  {
-    auto util = IamfMimeUtil::Create("iamf.000.000.fLaC");
-    ASSERT_TRUE(util.has_value());
-    EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecFlac);
-  }
-
-  {
-    auto util = IamfMimeUtil::Create("iamf.000.000.ipcm");
-    ASSERT_TRUE(util.has_value());
-    EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecIpcm);
-  }
-
-  {
-    auto util = IamfMimeUtil::Create("iamf.000.000.mp4a.40.2");
-    ASSERT_TRUE(util.has_value());
-    EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecMp4a);
-  }
+TEST(IamfUtilTest, SubstreamCodecOpus) {
+  auto util = IamfMimeUtil::Create("iamf.000.000.Opus");
+  ASSERT_TRUE(util.has_value());
+  EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecOpus);
 }
 
-TEST(IamfUtilTest, Profile) {
-  {
-    auto util = IamfMimeUtil::Create("iamf.000.000.Opus");
-    ASSERT_TRUE(util.has_value());
-    EXPECT_EQ(util->primary_profile(), kIamfProfileSimple);
-    EXPECT_EQ(util->additional_profile(), kIamfProfileSimple);
-  }
+TEST(IamfUtilTest, SubstreamCodecFlac) {
+  auto util = IamfMimeUtil::Create("iamf.000.000.fLaC");
+  ASSERT_TRUE(util.has_value());
+  EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecFlac);
+}
 
-  {
-    auto util = IamfMimeUtil::Create("iamf.001.000.Opus");
-    ASSERT_TRUE(util.has_value());
-    EXPECT_EQ(util->primary_profile(), kIamfProfileBase);
-    EXPECT_EQ(util->additional_profile(), kIamfProfileSimple);
-  }
+TEST(IamfUtilTest, SubstreamCodecIpcm) {
+  auto util = IamfMimeUtil::Create("iamf.000.000.ipcm");
+  ASSERT_TRUE(util.has_value());
+  EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecIpcm);
+}
 
-  {
-    auto util = IamfMimeUtil::Create("iamf.000.001.Opus");
-    ASSERT_TRUE(util.has_value());
-    EXPECT_EQ(util->primary_profile(), kIamfProfileSimple);
-    EXPECT_EQ(util->additional_profile(), kIamfProfileBase);
-  }
+TEST(IamfUtilTest, SubstreamCodecMp4a) {
+  auto util = IamfMimeUtil::Create("iamf.000.000.mp4a.40.2");
+  ASSERT_TRUE(util.has_value());
+  EXPECT_EQ(util->substream_codec(), kIamfSubstreamCodecMp4a);
+}
 
-  {
-    auto util = IamfMimeUtil::Create("iamf.002.000.Opus");
-    ASSERT_TRUE(util.has_value());
-    ASSERT_NE(util->primary_profile(), kIamfProfileSimple);
-    ASSERT_NE(util->primary_profile(), kIamfProfileBase);
-    ASSERT_EQ(util->primary_profile(), 2U);
-  }
+TEST(IamfUtilTest, ProfileSimpleSimple) {
+  auto util = IamfMimeUtil::Create("iamf.000.000.Opus");
+  ASSERT_TRUE(util.has_value());
+  EXPECT_EQ(util->primary_profile(), kIamfProfileSimple);
+  EXPECT_EQ(util->additional_profile(), kIamfProfileSimple);
+}
+
+TEST(IamfUtilTest, ProfileBaseSimple) {
+  auto util = IamfMimeUtil::Create("iamf.001.000.Opus");
+  ASSERT_TRUE(util.has_value());
+  EXPECT_EQ(util->primary_profile(), kIamfProfileBase);
+  EXPECT_EQ(util->additional_profile(), kIamfProfileSimple);
+}
+
+TEST(IamfUtilTest, ProfileSimpleBase) {
+  auto util = IamfMimeUtil::Create("iamf.000.001.Opus");
+  ASSERT_TRUE(util.has_value());
+  EXPECT_EQ(util->primary_profile(), kIamfProfileSimple);
+  EXPECT_EQ(util->additional_profile(), kIamfProfileBase);
+}
+
+TEST(IamfUtilTest, ProfileOther) {
+  auto util = IamfMimeUtil::Create("iamf.002.000.Opus");
+  ASSERT_TRUE(util.has_value());
+  ASSERT_NE(util->primary_profile(), kIamfProfileSimple);
+  ASSERT_NE(util->primary_profile(), kIamfProfileBase);
+  ASSERT_EQ(util->primary_profile(), 2U);
 }
 
 TEST(IamfUtilTest, ParsesSequenceHeaderObu) {

--- a/starboard/tvos/shared/media/avc_av_video_sample_buffer_builder.mm
+++ b/starboard/tvos/shared/media/avc_av_video_sample_buffer_builder.mm
@@ -58,15 +58,16 @@ void AvcAVVideoSampleBufferBuilder::WriteInputBuffer(
   const uint8_t* source_data = input_buffer->data();
   size_t data_size = input_buffer->size();
   if (sample_info.is_key_frame) {
-    VideoConfig new_config(input_buffer->video_stream_info(),
-                           input_buffer->data(), input_buffer->size());
-    if (!new_config.is_valid()) {
+    auto new_config =
+        VideoConfig::Create(input_buffer->video_stream_info(),
+                            input_buffer->data(), input_buffer->size());
+    if (!new_config) {
       ReportError("Failed to parse video config.");
       return;
     }
-    const auto& parameter_sets = new_config.avc_parameter_sets();
-    if (!video_config_ || video_config_.value() != new_config) {
-      video_config_ = new_config;
+    const auto& parameter_sets = new_config->avc_parameter_sets();
+    if (!video_config_ || video_config_.value() != *new_config) {
+      video_config_.emplace(*new_config);
       if (!RefreshAVCFormatDescription(parameter_sets)) {
         return;
       }


### PR DESCRIPTION
Refactor AvcParameterSets, VideoConfig, and IamfMimeUtil to use
static factory methods that return std::optional. This approach
replaces constructors that could fail to produce a valid object.

https://abseil.io/tips/42

By returning std::optional, callers are forced to explicitly check
for successful object creation, improving error handling and ensuring
that created objects are always in a valid state. Member variables
are also made const to reflect the immutability of these config
objects once successfully created.

Issue: 479994435