### PR TITLE
tvos: Rename internal uikit references to tvos

### DIFF
--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -16,7 +16,7 @@ import("//cobalt/build/configs/hacks.gni")
 import("//testing/test.gni")
 
 if (is_ios && target_platform == "tvos" && is_internal_build) {
-  import("//cobalt/internal/starboard/shared/uikit/uikit.gni")
+  import("//cobalt/internal/starboard/shared/tvos/tvos.gni")
 }
 
 declare_args() {
@@ -387,6 +387,6 @@ test("nplb") {
   }
 
   if (is_ios && target_platform == "tvos" && is_internal_build) {
-    sources += internal_uikit_test_sources
+    sources += internal_tvos_test_sources
   }
 }

--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -15,7 +15,7 @@
 import("//starboard/shared/starboard/player/buildfiles.gni")
 
 if (is_internal_build) {
-  import("//cobalt/internal/starboard/shared/uikit/uikit.gni")
+  import("//cobalt/internal/starboard/shared/tvos/tvos.gni")
 }
 
 static_library("test_support") {
@@ -218,7 +218,7 @@ static_library("starboard_platform") {
       "media/oemcrypto_engine_device_properties_uikit.mm",
     ]
 
-    sources += internal_uikit_sources
+    sources += internal_tvos_sources
 
     deps += [
       "//starboard/shared/widevine:oemcrypto",

--- a/starboard/tvos/shared/media/av_video_sample_buffer_builder.mm
+++ b/starboard/tvos/shared/media/av_video_sample_buffer_builder.mm
@@ -21,7 +21,7 @@
 #import "starboard/tvos/shared/media/vp9_sw_av_video_sample_buffer_builder.h"  // nogncheck
 
 #if defined(INTERNAL_BUILD)
-#import "cobalt/internal/starboard/shared/uikit/vp9_hw_av_video_sample_buffer_builder.h"
+#import "cobalt/internal/starboard/shared/tvos/vp9_hw_av_video_sample_buffer_builder.h"
 #endif
 
 namespace starboard {


### PR DESCRIPTION
Update build imports and source references to use the renamed internal
tvos directory instead of the old uikit directory. This aligns the
internal directory naming with the platform convention.

Bug: 501329482