### PR TITLE
aosp: Fix copied_base's sys_info and process

### DIFF
--- a/copied_base/base/BUILD.gn
+++ b/copied_base/base/BUILD.gn
@@ -1785,6 +1785,10 @@ component("base") {
       "starboard/debugger_starboard.cc",
     ]
 
+    if (is_android) {
+      sources -= [ "process/process_android.cc" ]
+    }
+
     if (is_linux) {
       sources -= [ "process/process_linux.cc" ]
     }

--- a/copied_base/base/process/process_metrics_posix_starboard_stub.cc
+++ b/copied_base/base/process/process_metrics_posix_starboard_stub.cc
@@ -33,9 +33,4 @@ void IncreaseFdLimitTo(unsigned int max_descriptors) {
   NOTIMPLEMENTED();
 }
 
-bool Process::CanBackgroundProcesses() {
-  NOTIMPLEMENTED();
-  return false;
-}
-
 }  // namespace base

--- a/copied_base/base/system/sys_info_android.cc
+++ b/copied_base/base/system/sys_info_android.cc
@@ -137,11 +137,13 @@ std::string HardwareManufacturerName() {
 
 namespace base {
 
+#if !BUILDFLAG(IS_STARBOARD)
 std::string SysInfo::HardwareModelName() {
   char device_model_str[PROP_VALUE_MAX];
   __system_property_get("ro.product.model", device_model_str);
   return std::string(device_model_str);
 }
+#endif  // !BUILDFLAG(IS_STARBOARD)
 
 std::string SysInfo::OperatingSystemName() {
   return "Android";

--- a/copied_base/base/system/sys_info_starboard.cc
+++ b/copied_base/base/system/sys_info_starboard.cc
@@ -29,17 +29,16 @@
 #include "base/containers/contains.h"
 #endif  // BUILDFLAG(IS_STARBOARD)
 
+namespace base {
+
 #if BUILDFLAG(IS_STARBOARD)
 using starboard::GetSystemPropertyString;
 
-namespace base {
 std::string SysInfo::HardwareModelName() {
   return GetSystemPropertyString(kSbSystemPropertyModelName);
 }
-}
 #endif  // BUILDFLAG(IS_STARBOARD)
 
-namespace base {
 namespace starboard {
 
 #if BUILDFLAG(IS_STARBOARD)
@@ -153,7 +152,7 @@ std::string SbSysInfo::Brand() {
   return "Apple";
 }
 
-#endif  // BUILDFLAG(IS_ANDROID)
+#endif  // BUILDFLAG(IS_STARBOARD)
 
 }  // namespace starboard
 }  // namespace base

--- a/copied_base/base/system/sys_info_starboard.cc
+++ b/copied_base/base/system/sys_info_starboard.cc
@@ -16,31 +16,49 @@
 
 #include "build/build_config.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include <sys/system_properties.h>
-#elif BUILDFLAG(IS_STARBOARD)
+#if BUILDFLAG(IS_STARBOARD)
 #include "base/system/sys_info.h"
 #include "starboard/common/system_property.h"
-using starboard::GetSystemPropertyString;
+#elif BUILDFLAG(IS_ANDROID)
+#include <sys/system_properties.h>
 #elif BUILDFLAG(IS_IOS_TVOS)
 #include <map>
 
 #include <sys/utsname.h>
 
 #include "base/containers/contains.h"
-#endif  // BUILDFLAG(IS_ANDROID)
+#endif  // BUILDFLAG(IS_STARBOARD)
 
 #if BUILDFLAG(IS_STARBOARD)
+using starboard::GetSystemPropertyString;
+
 namespace base {
 std::string SysInfo::HardwareModelName() {
   return GetSystemPropertyString(kSbSystemPropertyModelName);
 }
 }
-#endif // BUILDFLAG(IS_STARBOARD)
+#endif  // BUILDFLAG(IS_STARBOARD)
+
 namespace base {
 namespace starboard {
 
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_STARBOARD)
+std::string SbSysInfo::OriginalDesignManufacturer() {
+  return GetSystemPropertyString(kSbSystemPropertySystemIntegratorName);
+}
+
+std::string SbSysInfo::ChipsetModelNumber() {
+  return GetSystemPropertyString(kSbSystemPropertyChipsetModelNumber);
+}
+
+std::string SbSysInfo::ModelYear() {
+  return GetSystemPropertyString(kSbSystemPropertyModelYear);
+}
+
+std::string SbSysInfo::Brand() {
+  return GetSystemPropertyString(kSbSystemPropertyBrandName);
+}
+#elif BUILDFLAG(IS_ANDROID)
 std::string SbSysInfo::OriginalDesignManufacturer() {
   char original_design_manufacturer_str[PROP_VALUE_MAX];
   __system_property_get("ro.product.manufacturer", original_design_manufacturer_str);
@@ -78,23 +96,6 @@ std::string SbSysInfo::Brand() {
   __system_property_get("ro.product.brand", brand_str);
   return std::string(brand_str);
 }
-#elif BUILDFLAG(IS_STARBOARD)
-std::string SbSysInfo::OriginalDesignManufacturer() {
-  return GetSystemPropertyString(kSbSystemPropertySystemIntegratorName);
-}
-
-std::string SbSysInfo::ChipsetModelNumber() {
-  return GetSystemPropertyString(kSbSystemPropertyChipsetModelNumber);
-}
-
-std::string SbSysInfo::ModelYear() {
-  return GetSystemPropertyString(kSbSystemPropertyModelYear);
-}
-
-std::string SbSysInfo::Brand() {
-  return GetSystemPropertyString(kSbSystemPropertyBrandName);
-}
-
 #elif BUILDFLAG(IS_IOS_TVOS)
 std::string SbSysInfo::OriginalDesignManufacturer() {
   // Cobalt 25: https://github.com/youtube/cobalt/blob/62c2380b7eb0da5889a387c4b9be283656a8575d/starboard/shared/uikit/system_get_property.mm#L126

--- a/copied_base/base/system/sys_info_starboard.cc
+++ b/copied_base/base/system/sys_info_starboard.cc
@@ -32,7 +32,7 @@
 namespace base {
 
 #if BUILDFLAG(IS_STARBOARD)
-using starboard::GetSystemPropertyString;
+using ::starboard::GetSystemPropertyString;
 
 std::string SysInfo::HardwareModelName() {
   return GetSystemPropertyString(kSbSystemPropertyModelName);


### PR DESCRIPTION
On AOSP, Android has duplicate definitions of starboard's implementation of sys_info and process. Prefer the starboard implementations.

Note that this code is not really used, since starboard only uses basic types and JNI utilities from //copied_base/base.

Bug: 495203133