### PR TITLE
android: Manual cherrypick for V8 settings

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -79,6 +79,9 @@ public final class CommandLineOverrideHelper {
 
         // Trades a little V8 performance for significant memory savings.
         paramOverrides.add("--optimize-for-size");
+        // Set initial old space size to 64MB and max old space size to 512MB.
+        paramOverrides.add("--initial-old-space-size=64");
+        paramOverrides.add("--max-old-space-size=512");
 
         return paramOverrides;
     }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -43,6 +43,8 @@ public class CommandLineOverrideHelperTest {
     public void testDefaultJsFlagOverridesList() {
         String overrides = CommandLineOverrideHelper.getDefaultJsFlagOverridesList().toString();
         assertThat(overrides.contains("--optimize-for-size")).isTrue();
+        assertThat(overrides.contains("--initial-old-space-size=64")).isTrue();
+        assertThat(overrides.contains("--max-old-space-size=512")).isTrue();
     }
 
     @Test


### PR DESCRIPTION
Add --initial-old-space-size=64 and --max-old-space-size=512 to the default JS flags in CommandLineOverrideHelper to optimize V8 heap usage on Android. Update unit tests to verify the new defaults.

Bug: 477955599