### PR TITLE
starboard: Add factory methods to AlsaAudioSink and NPLB AudioSinkTestEnvironment

### DIFF
--- a/starboard/nplb/audio_sink_helpers.cc
+++ b/starboard/nplb/audio_sink_helpers.cc
@@ -96,14 +96,28 @@ void AudioSinkTestFrameBuffers::Init() {
   }
 }
 
+std::unique_ptr<AudioSinkTestEnvironment> AudioSinkTestEnvironment::Create(
+    const AudioSinkTestFrameBuffers& frame_buffers) {
+  bool success = false;
+  auto environment = std::make_unique<AudioSinkTestEnvironment>(
+      starboard::PassKey<AudioSinkTestEnvironment>(), frame_buffers, &success);
+  if (!success) {
+    return nullptr;
+  }
+  return environment;
+}
+
 AudioSinkTestEnvironment::AudioSinkTestEnvironment(
-    const AudioSinkTestFrameBuffers& frame_buffers)
+    starboard::PassKey<AudioSinkTestEnvironment>,
+    const AudioSinkTestFrameBuffers& frame_buffers,
+    bool* out_success)
     : frame_buffers_(frame_buffers) {
   sink_ = SbAudioSinkCreate(
       frame_buffers_.channels(), sample_rate(), frame_buffers_.sample_type(),
       frame_buffers_.storage_type(), frame_buffers_.frame_buffers(),
       frame_buffers_.frames_per_channel(), UpdateSourceStatusFunc,
       ConsumeFramesFunc, this);
+  *out_success = SbAudioSinkIsValid(sink_);
 }
 
 AudioSinkTestEnvironment::~AudioSinkTestEnvironment() {

--- a/starboard/nplb/audio_sink_helpers.cc
+++ b/starboard/nplb/audio_sink_helpers.cc
@@ -98,10 +98,9 @@ void AudioSinkTestFrameBuffers::Init() {
 
 std::unique_ptr<AudioSinkTestEnvironment> AudioSinkTestEnvironment::Create(
     const AudioSinkTestFrameBuffers& frame_buffers) {
-  bool success = false;
   auto environment = std::make_unique<AudioSinkTestEnvironment>(
-      starboard::PassKey<AudioSinkTestEnvironment>(), frame_buffers, &success);
-  if (!success) {
+      starboard::PassKey<AudioSinkTestEnvironment>(), frame_buffers);
+  if (!SbAudioSinkIsValid(environment->sink_)) {
     return nullptr;
   }
   return environment;
@@ -109,15 +108,13 @@ std::unique_ptr<AudioSinkTestEnvironment> AudioSinkTestEnvironment::Create(
 
 AudioSinkTestEnvironment::AudioSinkTestEnvironment(
     starboard::PassKey<AudioSinkTestEnvironment>,
-    const AudioSinkTestFrameBuffers& frame_buffers,
-    bool* out_success)
+    const AudioSinkTestFrameBuffers& frame_buffers)
     : frame_buffers_(frame_buffers) {
   sink_ = SbAudioSinkCreate(
       frame_buffers_.channels(), sample_rate(), frame_buffers_.sample_type(),
       frame_buffers_.storage_type(), frame_buffers_.frame_buffers(),
       frame_buffers_.frames_per_channel(), UpdateSourceStatusFunc,
       ConsumeFramesFunc, this);
-  *out_success = SbAudioSinkIsValid(sink_);
 }
 
 AudioSinkTestEnvironment::~AudioSinkTestEnvironment() {

--- a/starboard/nplb/audio_sink_helpers.h
+++ b/starboard/nplb/audio_sink_helpers.h
@@ -72,8 +72,7 @@ class AudioSinkTestEnvironment {
       const AudioSinkTestFrameBuffers& frame_buffers);
 
   AudioSinkTestEnvironment(starboard::PassKey<AudioSinkTestEnvironment>,
-                           const AudioSinkTestFrameBuffers& frame_buffers,
-                           bool* out_success);
+                           const AudioSinkTestFrameBuffers& frame_buffers);
   ~AudioSinkTestEnvironment();
 
   static int sample_rate() {

--- a/starboard/nplb/audio_sink_helpers.h
+++ b/starboard/nplb/audio_sink_helpers.h
@@ -16,10 +16,12 @@
 #define STARBOARD_NPLB_AUDIO_SINK_HELPERS_H_
 
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <vector>
 
 #include "starboard/audio_sink.h"
+#include "starboard/common/pass_key.h"
 #include "starboard/media.h"
 
 namespace nplb {
@@ -66,11 +68,13 @@ class AudioSinkTestEnvironment {
  public:
   static const int kSampleRateCD = 44100;
 
-  explicit AudioSinkTestEnvironment(
+  static std::unique_ptr<AudioSinkTestEnvironment> Create(
       const AudioSinkTestFrameBuffers& frame_buffers);
-  ~AudioSinkTestEnvironment();
 
-  bool is_valid() const { return SbAudioSinkIsValid(sink_); }
+  AudioSinkTestEnvironment(starboard::PassKey<AudioSinkTestEnvironment>,
+                           const AudioSinkTestFrameBuffers& frame_buffers,
+                           bool* out_success);
+  ~AudioSinkTestEnvironment();
 
   static int sample_rate() {
     return SbAudioSinkGetNearestSupportedSampleFrequency(kSampleRateCD);

--- a/starboard/nplb/audio_sink_test.cc
+++ b/starboard/nplb/audio_sink_test.cc
@@ -26,103 +26,103 @@ namespace nplb {
 
 TEST(SbAudioSinkTest, UpdateStatusCalled) {
   AudioSinkTestFrameBuffers frame_buffers(SbAudioSinkGetMaxChannels());
-  AudioSinkTestEnvironment environment(frame_buffers);
-  ASSERT_TRUE(environment.is_valid());
+  auto environment = AudioSinkTestEnvironment::Create(frame_buffers);
+  ASSERT_TRUE(environment);
 
-  EXPECT_TRUE(environment.WaitUntilUpdateStatusCalled());
-  EXPECT_TRUE(environment.WaitUntilUpdateStatusCalled());
+  EXPECT_TRUE(environment->WaitUntilUpdateStatusCalled());
+  EXPECT_TRUE(environment->WaitUntilUpdateStatusCalled());
 }
 
 TEST(SbAudioSinkTest, SomeFramesConsumed) {
   AudioSinkTestFrameBuffers frame_buffers(SbAudioSinkGetMaxChannels());
-  AudioSinkTestEnvironment environment(frame_buffers);
-  ASSERT_TRUE(environment.is_valid());
+  auto environment = AudioSinkTestEnvironment::Create(frame_buffers);
+  ASSERT_TRUE(environment);
 
   // Audio sink need to be fully filled once to ensure it can start working.
   int frames_to_append = frame_buffers.frames_per_channel();
-  environment.AppendFrame(frames_to_append);
+  environment->AppendFrame(frames_to_append);
 
-  EXPECT_TRUE(environment.WaitUntilSomeFramesAreConsumed());
+  EXPECT_TRUE(environment->WaitUntilSomeFramesAreConsumed());
 }
 
 TEST(SbAudioSinkTest, AllFramesConsumed) {
   AudioSinkTestFrameBuffers frame_buffers(SbAudioSinkGetMaxChannels());
-  AudioSinkTestEnvironment environment(frame_buffers);
-  ASSERT_TRUE(environment.is_valid());
+  auto environment = AudioSinkTestEnvironment::Create(frame_buffers);
+  ASSERT_TRUE(environment);
 
   int frames_to_append = frame_buffers.frames_per_channel();
-  environment.AppendFrame(frames_to_append / 2);
+  environment->AppendFrame(frames_to_append / 2);
 
-  EXPECT_TRUE(environment.WaitUntilAllFramesAreConsumed());
+  EXPECT_TRUE(environment->WaitUntilAllFramesAreConsumed());
 }
 
 TEST(SbAudioSinkTest, MultipleAppendAndConsume) {
   AudioSinkTestFrameBuffers frame_buffers(SbAudioSinkGetMaxChannels());
-  AudioSinkTestEnvironment environment(frame_buffers);
-  ASSERT_TRUE(environment.is_valid());
+  auto environment = AudioSinkTestEnvironment::Create(frame_buffers);
+  ASSERT_TRUE(environment);
 
   // Audio sink need to be fully filled once to ensure it can start working.
   int frames_to_append = frame_buffers.frames_per_channel();
-  environment.AppendFrame(frames_to_append);
+  environment->AppendFrame(frames_to_append);
 
-  EXPECT_TRUE(environment.WaitUntilSomeFramesAreConsumed());
-  ASSERT_GT(environment.GetFrameBufferFreeSpaceInFrames(), 0);
-  environment.AppendFrame(environment.GetFrameBufferFreeSpaceInFrames());
-  EXPECT_TRUE(environment.WaitUntilAllFramesAreConsumed());
+  EXPECT_TRUE(environment->WaitUntilSomeFramesAreConsumed());
+  ASSERT_GT(environment->GetFrameBufferFreeSpaceInFrames(), 0);
+  environment->AppendFrame(environment->GetFrameBufferFreeSpaceInFrames());
+  EXPECT_TRUE(environment->WaitUntilAllFramesAreConsumed());
 }
 
 TEST(SbAudioSinkTest, Pause) {
   AudioSinkTestFrameBuffers frame_buffers(SbAudioSinkGetMaxChannels());
-  AudioSinkTestEnvironment environment(frame_buffers);
-  ASSERT_TRUE(environment.is_valid());
+  auto environment = AudioSinkTestEnvironment::Create(frame_buffers);
+  ASSERT_TRUE(environment);
 
-  environment.SetIsPlaying(false);
+  environment->SetIsPlaying(false);
 
   // Audio sink need to be fully filled once to ensure it can start working.
   int frames_to_append = frame_buffers.frames_per_channel();
-  environment.AppendFrame(frames_to_append);
+  environment->AppendFrame(frames_to_append);
 
-  int free_space = environment.GetFrameBufferFreeSpaceInFrames();
-  EXPECT_TRUE(environment.WaitUntilUpdateStatusCalled());
-  EXPECT_TRUE(environment.WaitUntilUpdateStatusCalled());
-  EXPECT_EQ(free_space, environment.GetFrameBufferFreeSpaceInFrames());
-  environment.SetIsPlaying(true);
-  EXPECT_TRUE(environment.WaitUntilSomeFramesAreConsumed());
+  int free_space = environment->GetFrameBufferFreeSpaceInFrames();
+  EXPECT_TRUE(environment->WaitUntilUpdateStatusCalled());
+  EXPECT_TRUE(environment->WaitUntilUpdateStatusCalled());
+  EXPECT_EQ(free_space, environment->GetFrameBufferFreeSpaceInFrames());
+  environment->SetIsPlaying(true);
+  EXPECT_TRUE(environment->WaitUntilSomeFramesAreConsumed());
 }
 
 TEST(SbAudioSinkTest, Underflow) {
   AudioSinkTestFrameBuffers frame_buffers(SbAudioSinkGetMaxChannels());
-  AudioSinkTestEnvironment environment(frame_buffers);
-  ASSERT_TRUE(environment.is_valid());
+  auto environment = AudioSinkTestEnvironment::Create(frame_buffers);
+  ASSERT_TRUE(environment);
 
   // Audio sink need to be fully filled once to ensure it can start working.
   int frames_to_append = frame_buffers.frames_per_channel();
-  environment.AppendFrame(frames_to_append);
+  environment->AppendFrame(frames_to_append);
 
-  EXPECT_TRUE(environment.WaitUntilSomeFramesAreConsumed());
+  EXPECT_TRUE(environment->WaitUntilSomeFramesAreConsumed());
   usleep(250'000);
-  ASSERT_GT(environment.GetFrameBufferFreeSpaceInFrames(), 0);
-  environment.AppendFrame(environment.GetFrameBufferFreeSpaceInFrames());
-  EXPECT_TRUE(environment.WaitUntilAllFramesAreConsumed());
+  ASSERT_GT(environment->GetFrameBufferFreeSpaceInFrames(), 0);
+  environment->AppendFrame(environment->GetFrameBufferFreeSpaceInFrames());
+  EXPECT_TRUE(environment->WaitUntilAllFramesAreConsumed());
 }
 
 TEST(SbAudioSinkTest, ContinuousAppend) {
   AudioSinkTestFrameBuffers frame_buffers(SbAudioSinkGetMaxChannels());
 
-  AudioSinkTestEnvironment environment(frame_buffers);
-  ASSERT_TRUE(environment.is_valid());
+  auto environment = AudioSinkTestEnvironment::Create(frame_buffers);
+  ASSERT_TRUE(environment);
 
-  int sample_rate = environment.sample_rate();
+  int sample_rate = environment->sample_rate();
   // We are trying to send 1/4s worth of audio samples.
   int frames_to_append = sample_rate / 4;
 
   while (frames_to_append > 0) {
-    int free_space = environment.GetFrameBufferFreeSpaceInFrames();
-    environment.AppendFrame(std::min(free_space, frames_to_append));
+    int free_space = environment->GetFrameBufferFreeSpaceInFrames();
+    environment->AppendFrame(std::min(free_space, frames_to_append));
     frames_to_append -= std::min(free_space, frames_to_append);
-    ASSERT_TRUE(environment.WaitUntilSomeFramesAreConsumed());
+    ASSERT_TRUE(environment->WaitUntilSomeFramesAreConsumed());
   }
-  EXPECT_TRUE(environment.WaitUntilAllFramesAreConsumed());
+  EXPECT_TRUE(environment->WaitUntilAllFramesAreConsumed());
 }
 
 }  // namespace nplb

--- a/starboard/shared/alsa/alsa_audio_sink_type.cc
+++ b/starboard/shared/alsa/alsa_audio_sink_type.cc
@@ -241,6 +241,8 @@ AlsaAudioSink::~AlsaAudioSink() {
   audio_out_thread_->Stop();
 
   delete[] static_cast<uint8_t*>(silence_frames_);
+
+  AlsaCloseDevice(playback_handle_);
 }
 
 void AlsaAudioSink::ProcessAudio() {
@@ -252,8 +254,6 @@ void AlsaAudioSink::ProcessAudio() {
       break;
     }
   }
-
-  AlsaCloseDevice(playback_handle_);
 }
 
 bool AlsaAudioSink::IdleLoop() {

--- a/starboard/shared/alsa/alsa_audio_sink_type.cc
+++ b/starboard/shared/alsa/alsa_audio_sink_type.cc
@@ -439,6 +439,9 @@ SbAudioSink AlsaAudioSinkType::Create(
       this, channels, sampling_frequency_hz, audio_sample_type, frame_buffers,
       frames_per_channel, update_source_status_func, consume_frames_func,
       context);
+  if (!audio_sink) {
+    return kSbAudioSinkInvalid;
+  }
   return audio_sink.release();
 }
 

--- a/starboard/shared/alsa/alsa_audio_sink_type.cc
+++ b/starboard/shared/alsa/alsa_audio_sink_type.cc
@@ -92,14 +92,14 @@ class AlsaAudioSink : public SbAudioSinkImpl {
   AlsaAudioSink(PassKey<AlsaAudioSink>,
                 Type* type,
                 int channels,
-                int sampling_frequency_hz,
                 SbMediaAudioSampleType sample_type,
                 SbAudioSinkFrameBuffers frame_buffers,
                 int frames_per_channel,
                 SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
                 ConsumeFramesFunc consume_frames_func,
                 void* context,
-                void* playback_handle);
+                void* playback_handle,
+                int64_t time_to_wait_us);
   ~AlsaAudioSink() override;
 
   bool IsType(Type* type) override { return type_ == type; }
@@ -133,28 +133,28 @@ class AlsaAudioSink : public SbAudioSinkImpl {
                    int frames_in_buffer,
                    int offset_in_frames);
 
-  Type* type_;
-  SbAudioSinkUpdateSourceStatusFunc update_source_status_func_;
-  ConsumeFramesFunc consume_frames_func_;
-  void* context_;
+  Type* const type_;
+  const SbAudioSinkUpdateSourceStatusFunc update_source_status_func_;
+  const ConsumeFramesFunc consume_frames_func_;
+  void* const context_;
 
   double playback_rate_;
   double volume_;
   std::vector<uint8_t> resample_buffer_;
 
-  int channels_;
-  SbMediaAudioSampleType sample_type_;
+  const int channels_;
+  const SbMediaAudioSampleType sample_type_;
 
   const std::unique_ptr<JobThread> audio_out_thread_;
   std::mutex mutex_;
 
-  int64_t time_to_wait_;
+  const int64_t time_to_wait_us_;
 
   bool destroying_;
 
-  void* frame_buffer_;
-  int frames_per_channel_;
-  void* silence_frames_;
+  void* const frame_buffer_;
+  const int frames_per_channel_;
+  void* const silence_frames_;
 
   void* const playback_handle_;
 };
@@ -179,24 +179,27 @@ std::unique_ptr<AlsaAudioSink> AlsaAudioSink::Create(
     return nullptr;
   }
 
+  int64_t time_to_wait_us =
+      kFramesPerRequest * 1'000'000LL / sampling_frequency_hz / 2;
+
   return std::make_unique<AlsaAudioSink>(
-      PassKey<AlsaAudioSink>(), type, channels, sampling_frequency_hz,
-      sample_type, frame_buffers, frames_per_channel, update_source_status_func,
-      consume_frames_func, context, playback_handle);
+      PassKey<AlsaAudioSink>(), type, channels, sample_type, frame_buffers,
+      frames_per_channel, update_source_status_func, consume_frames_func,
+      context, playback_handle, time_to_wait_us);
 }
 
 AlsaAudioSink::AlsaAudioSink(
     PassKey<AlsaAudioSink>,
     Type* type,
     int channels,
-    int sampling_frequency_hz,
     SbMediaAudioSampleType sample_type,
     SbAudioSinkFrameBuffers frame_buffers,
     int frames_per_channel,
     SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
     ConsumeFramesFunc consume_frames_func,
     void* context,
-    void* playback_handle)
+    void* playback_handle,
+    int64_t time_to_wait_us)
     : type_(type),
       update_source_status_func_(update_source_status_func),
       consume_frames_func_(consume_frames_func),
@@ -210,8 +213,7 @@ AlsaAudioSink::AlsaAudioSink(
       audio_out_thread_(JobThread::Create(
           "alsa_audio_out",
           ThreadOptions().SetPriority(kSbThreadPriorityRealTime))),
-      time_to_wait_(kFramesPerRequest * 1'000'000LL / sampling_frequency_hz /
-                    2),
+      time_to_wait_us_(time_to_wait_us),
       destroying_(false),
       frame_buffer_(frame_buffers[0]),
       frames_per_channel_(frames_per_channel),
@@ -284,7 +286,7 @@ bool AlsaAudioSink::IdleLoop() {
       AlsaWriteFrames(playback_handle_, silence_frames_, kFramesPerRequest);
       AlsaDrain(playback_handle_);
     }
-    usleep(time_to_wait_);
+    usleep(time_to_wait_us_);
   }
 
   return false;
@@ -322,7 +324,7 @@ bool AlsaAudioSink::PlaybackLoop() {
       WriteFrames(playback_rate, std::min(kFramesPerRequest, frames_in_buffer),
                   frames_in_buffer, offset_in_frames);
     } else {
-      usleep(time_to_wait_);
+      usleep(time_to_wait_us_);
     }
   }
 

--- a/starboard/shared/alsa/alsa_audio_sink_type.cc
+++ b/starboard/shared/alsa/alsa_audio_sink_type.cc
@@ -18,7 +18,6 @@
 #include <unistd.h>
 
 #include <algorithm>
-#include <condition_variable>
 #include <memory>
 #include <mutex>
 #include <vector>
@@ -26,6 +25,7 @@
 #include "starboard/audio_sink.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "starboard/common/pass_key.h"
 #include "starboard/common/thread_options.h"
 #include "starboard/common/time.h"
 #include "starboard/configuration.h"
@@ -78,7 +78,19 @@ void* IncrementPointerByBytes(void* pointer, size_t offset) {
 //    silence to ALSA.
 class AlsaAudioSink : public SbAudioSinkImpl {
  public:
-  AlsaAudioSink(Type* type,
+  static std::unique_ptr<AlsaAudioSink> Create(
+      Type* type,
+      int channels,
+      int sampling_frequency_hz,
+      SbMediaAudioSampleType sample_type,
+      SbAudioSinkFrameBuffers frame_buffers,
+      int frames_per_channel,
+      SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
+      ConsumeFramesFunc consume_frames_func,
+      void* context);
+
+  AlsaAudioSink(PassKey<AlsaAudioSink>,
+                Type* type,
                 int channels,
                 int sampling_frequency_hz,
                 SbMediaAudioSampleType sample_type,
@@ -86,7 +98,8 @@ class AlsaAudioSink : public SbAudioSinkImpl {
                 int frames_per_channel,
                 SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
                 ConsumeFramesFunc consume_frames_func,
-                void* context);
+                void* context,
+                void* playback_handle);
   ~AlsaAudioSink() override;
 
   bool IsType(Type* type) override { return type_ == type; }
@@ -100,8 +113,6 @@ class AlsaAudioSink : public SbAudioSinkImpl {
     std::lock_guard lock(mutex_);
     volume_ = volume;
   }
-
-  bool is_valid() { return playback_handle_ != NULL; }
 
  private:
   AlsaAudioSink(const AlsaAudioSink&) = delete;
@@ -132,13 +143,10 @@ class AlsaAudioSink : public SbAudioSinkImpl {
   std::vector<uint8_t> resample_buffer_;
 
   int channels_;
-  int sampling_frequency_hz_;
   SbMediaAudioSampleType sample_type_;
 
   const std::unique_ptr<JobThread> audio_out_thread_;
   std::mutex mutex_;
-  std::condition_variable creation_signal_;
-  bool audio_thread_created_ = false;  // Guarded by |mutex_|.
 
   int64_t time_to_wait_;
 
@@ -148,10 +156,10 @@ class AlsaAudioSink : public SbAudioSinkImpl {
   int frames_per_channel_;
   void* silence_frames_;
 
-  void* playback_handle_;
+  void* const playback_handle_;
 };
 
-AlsaAudioSink::AlsaAudioSink(
+std::unique_ptr<AlsaAudioSink> AlsaAudioSink::Create(
     Type* type,
     int channels,
     int sampling_frequency_hz,
@@ -160,7 +168,35 @@ AlsaAudioSink::AlsaAudioSink(
     int frames_per_channel,
     SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
     ConsumeFramesFunc consume_frames_func,
-    void* context)
+    void* context) {
+  snd_pcm_format_t alsa_sample_type =
+      sample_type == kSbMediaAudioSampleTypeFloat32 ? SND_PCM_FORMAT_FLOAT_LE
+                                                    : SND_PCM_FORMAT_S16;
+  void* playback_handle =
+      AlsaOpenPlaybackDevice(channels, sampling_frequency_hz, kFramesPerRequest,
+                             kALSABufferSizeInFrames, alsa_sample_type);
+  if (!playback_handle) {
+    return nullptr;
+  }
+
+  return std::make_unique<AlsaAudioSink>(
+      PassKey<AlsaAudioSink>(), type, channels, sampling_frequency_hz,
+      sample_type, frame_buffers, frames_per_channel, update_source_status_func,
+      consume_frames_func, context, playback_handle);
+}
+
+AlsaAudioSink::AlsaAudioSink(
+    PassKey<AlsaAudioSink>,
+    Type* type,
+    int channels,
+    int sampling_frequency_hz,
+    SbMediaAudioSampleType sample_type,
+    SbAudioSinkFrameBuffers frame_buffers,
+    int frames_per_channel,
+    SbAudioSinkUpdateSourceStatusFunc update_source_status_func,
+    ConsumeFramesFunc consume_frames_func,
+    void* context,
+    void* playback_handle)
     : type_(type),
       update_source_status_func_(update_source_status_func),
       consume_frames_func_(consume_frames_func),
@@ -170,7 +206,6 @@ AlsaAudioSink::AlsaAudioSink(
       resample_buffer_(channels * kFramesPerRequest *
                        GetSampleSize(sample_type)),
       channels_(channels),
-      sampling_frequency_hz_(sampling_frequency_hz),
       sample_type_(sample_type),
       audio_out_thread_(JobThread::Create(
           "alsa_audio_out",
@@ -182,19 +217,18 @@ AlsaAudioSink::AlsaAudioSink(
       frames_per_channel_(frames_per_channel),
       silence_frames_(new uint8_t[channels * kFramesPerRequest *
                                   GetSampleSize(sample_type)]),
-      playback_handle_(NULL) {
+      playback_handle_(playback_handle) {
   SB_DCHECK(update_source_status_func_);
   SB_DCHECK(consume_frames_func_);
   SB_DCHECK(frame_buffer_);
   SB_DCHECK(SbAudioSinkIsAudioSampleTypeSupported(sample_type_));
   SB_CHECK(audio_out_thread_);
+  SB_CHECK(playback_handle_);
 
   memset(silence_frames_, 0,
          channels * kFramesPerRequest * GetSampleSize(sample_type));
 
-  std::unique_lock lock(mutex_);
   audio_out_thread_->Schedule([this] { ProcessAudio(); });
-  creation_signal_.wait(lock, [this] { return audio_thread_created_; });
 }
 
 AlsaAudioSink::~AlsaAudioSink() {
@@ -208,23 +242,6 @@ AlsaAudioSink::~AlsaAudioSink() {
 }
 
 void AlsaAudioSink::ProcessAudio() {
-  snd_pcm_format_t alsa_sample_type =
-      sample_type_ == kSbMediaAudioSampleTypeFloat32 ? SND_PCM_FORMAT_FLOAT_LE
-                                                     : SND_PCM_FORMAT_S16;
-
-  playback_handle_ = AlsaOpenPlaybackDevice(
-      channels_, sampling_frequency_hz_, kFramesPerRequest,
-      kALSABufferSizeInFrames, alsa_sample_type);
-  {
-    std::lock_guard lock(mutex_);
-    audio_thread_created_ = true;
-  }
-  creation_signal_.notify_one();
-
-  if (!playback_handle_) {
-    return;
-  }
-
   for (;;) {
     if (!IdleLoop()) {
       break;
@@ -235,8 +252,6 @@ void AlsaAudioSink::ProcessAudio() {
   }
 
   AlsaCloseDevice(playback_handle_);
-  std::lock_guard lock(mutex_);
-  playback_handle_ = NULL;
 }
 
 bool AlsaAudioSink::IdleLoop() {
@@ -418,16 +433,11 @@ SbAudioSink AlsaAudioSinkType::Create(
     SbAudioSinkPrivate::ConsumeFramesFunc consume_frames_func,
     SbAudioSinkPrivate::ErrorFunc error_func,
     void* context) {
-  AlsaAudioSink* audio_sink = new AlsaAudioSink(
+  std::unique_ptr<AlsaAudioSink> audio_sink = AlsaAudioSink::Create(
       this, channels, sampling_frequency_hz, audio_sample_type, frame_buffers,
       frames_per_channel, update_source_status_func, consume_frames_func,
       context);
-  if (!audio_sink->is_valid()) {
-    delete audio_sink;
-    return kSbAudioSinkInvalid;
-  }
-
-  return audio_sink;
+  return audio_sink.release();
 }
 
 AlsaAudioSinkType* alsa_audio_sink_type_;


### PR DESCRIPTION
Introduce static Create factory methods for AlsaAudioSink and NPLB AudioSinkTestEnvironment, encapsulating construction logic and avoiding semi-initialized states.

https://abseil.io/tips/42

TESTED=test linux build and verified ALSA audio is working

Issue: 479994435