### PR TITLE
Add new build flag to mitigate rebase conflicts

### DIFF
--- a/content/public/common/BUILD.gn
+++ b/content/public/common/BUILD.gn
@@ -25,6 +25,7 @@ buildflag_header("buildflags") {
     "ENABLE_DEVTOOLS_FRONTEND=$enable_devtools_frontend",
     "ENABLE_SCREEN_CAPTURE=$enable_screen_capture",
     "LOAD_WEBUI_FROM_DISK=$load_webui_from_disk",
+    "CHROMIUM_MILESTONE_LE_138=$chromium_le_138",
   ]
 }
 

--- a/content/public/common/BUILD.gn
+++ b/content/public/common/BUILD.gn
@@ -5,6 +5,7 @@
 import("//build/buildflag_header.gni")
 import("//build/config/features.gni")
 import("//build/config/ui.gni")
+import("//build/util/process_version.gni")
 import("//content/browser/devtools/features.gni")
 import("//content/public/common/features.gni")
 import("//content/public/common/zygote/features.gni")
@@ -25,8 +26,18 @@ buildflag_header("buildflags") {
     "ENABLE_DEVTOOLS_FRONTEND=$enable_devtools_frontend",
     "ENABLE_SCREEN_CAPTURE=$enable_screen_capture",
     "LOAD_WEBUI_FROM_DISK=$load_webui_from_disk",
-    "CHROMIUM_MILESTONE_LE_138=$chromium_le_138",
   ]
+}
+
+# Generates a C++ header file containing the targeted Chromium milestone version
+# and helper macros. This enables Cobalt to conditionally compile custom
+# features, fallbacks, or modifications on older milestones (M138 or lower),
+# while automatically yielding to upstream's official implementations on newer
+# milestones (M139+) to prevent rebase and upgrade merge conflicts.
+process_version("milestone_features") {
+  sources = [ "//chrome/VERSION" ]
+  template_file = "content_milestone_features.h.in"
+  output = "$target_gen_dir/content_milestone_features.h"
 }
 
 # See //content/BUILD.gn for how this works. Note that targets in `//content`
@@ -257,6 +268,7 @@ source_set("common_sources") {
     ":main_function_params",
     ":renderer_type",
     ":switches",
+    ":milestone_features",
     "//content/common",
     "//content/public/common/zygote:buildflags",
     "//ipc",

--- a/content/public/common/content_milestone_features.h.in
+++ b/content/public/common/content_milestone_features.h.in
@@ -1,0 +1,23 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This is automatically generated. Do not edit.
+
+#ifndef CONTENT_PUBLIC_COMMON_CONTENT_MILESTONE_FEATURES_H_
+#define CONTENT_PUBLIC_COMMON_CONTENT_MILESTONE_FEATURES_H_
+
+#define CHROMIUM_MILESTONE @MAJOR @
+#define CHROMIUM_MILESTONE_LE_138 (@MAJOR @ <= 138)
+
+#endif  // CONTENT_PUBLIC_COMMON_CONTENT_MILESTONE_FEATURES_H_

--- a/content/public/common/features.gni
+++ b/content/public/common/features.gni
@@ -3,6 +3,7 @@
 # found in the LICENSE file.
 
 import("//build/config/features.gni")
+import("//chrome/version.gni")
 
 declare_args() {
   # Screen capture is enabled on most platforms. Currently, screen capture
@@ -10,4 +11,11 @@ declare_args() {
   # at some point once the feature is stable. See crbug.com/40418135.
   enable_screen_capture = is_linux || is_chromeos || (is_apple && use_blink) ||
                           is_win || is_desktop_android || is_fuchsia
+
+  # True if the targeted Chromium milestone is 138 or lower.
+  # This allows Cobalt to conditionally compile custom features, fallbacks,
+  # or modifications on older milestones, while automatically yielding to
+  # upstream's official implementations on newer milestones (M139+) to
+  # prevent rebase and upgrade merge conflicts.
+  chromium_le_138 = is_cobalt && chrome_version_major <= "138"
 }

--- a/content/public/common/features.gni
+++ b/content/public/common/features.gni
@@ -3,7 +3,6 @@
 # found in the LICENSE file.
 
 import("//build/config/features.gni")
-import("//chrome/version.gni")
 
 declare_args() {
   # Screen capture is enabled on most platforms. Currently, screen capture
@@ -11,11 +10,4 @@ declare_args() {
   # at some point once the feature is stable. See crbug.com/40418135.
   enable_screen_capture = is_linux || is_chromeos || (is_apple && use_blink) ||
                           is_win || is_desktop_android || is_fuchsia
-
-  # True if the targeted Chromium milestone is 138 or lower.
-  # This allows Cobalt to conditionally compile custom features, fallbacks,
-  # or modifications on older milestones, while automatically yielding to
-  # upstream's official implementations on newer milestones (M139+) to
-  # prevent rebase and upgrade merge conflicts.
-  chromium_le_138 = is_cobalt && chrome_version_major <= "138"
 }


### PR DESCRIPTION
With the build flag, developers could explicitly tag the code that can be removed in future milestones. 

For example, some privacy sandbox APIs will be removed in M150, CHROMIUM_MILESTONE_LE_138
could explicitly tell people who resolve the conflicts that simply remove whatever is included by this flag. 

Usage:
```
  #include "content/public/common/content_milestone_features.h"
  
  #if BUILDFLAG(IS_COBALT) && BUILDFLAG(CHROMIUM_MILESTONE_LE_138)
    // Conditional Cobalt logic specifically for milestone 138 or lower
  #endif
```

Bug: 510041043