### PR TITLE
Remove .rlib special case from API leak detector

### DIFF
--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -459,8 +459,7 @@ def FindLeakLocations(leaked_symbols, config_path, only_grep, use_ripgrep):
     # we just assume those are matches.
     leaking_files[_UNKNOWN_LIBRARIES][symbol] = set()
     for obj_file in obj_files_to_check:
-      if os.path.splitext(obj_file)[1] == '.rlib' or symbol in ProcessNmOutput(
-          RunCommand(['nm', '-u', '-C', obj_file])):
+      if symbol in ProcessNmOutput(RunCommand(['nm', '-u', '-C', obj_file])):
         leaking_files[_UNKNOWN_LIBRARIES][symbol].add(
             '//' + os.path.relpath(obj_file, paths.REPOSITORY_ROOT))
     if len(leaking_files[_UNKNOWN_LIBRARIES][symbol]) == 0:

--- a/starboard/tools/api_leak_detector/evergreen/dev_manifest
+++ b/starboard/tools/api_leak_detector/evergreen/dev_manifest
@@ -4,7 +4,6 @@
 
 TLS init function for v8::internal::trap_handler::g_thread_in_wasm_code
 __cxa_thread_atexit_impl
-dl_iterate_phdr
 dlopen
 dlsym
 if_indextoname


### PR DESCRIPTION
This has the effect of "fixing" the leak of `dl_iterate_phdr`, which was only showing up in the metadata section of Rust's libc.

Bug: 500421877