### PR TITLE
cleanup: Replace std::size_t with size_t

### DIFF
--- a/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
@@ -15,6 +15,8 @@
 #ifndef MEDIA_STARBOARD_BIDIRECTIONAL_FIT_DECODER_BUFFER_ALLOCATOR_STRATEGY_H_
 #define MEDIA_STARBOARD_BIDIRECTIONAL_FIT_DECODER_BUFFER_ALLOCATOR_STRATEGY_H_
 
+#include <cstddef>
+
 #include "media/starboard/decoder_buffer_allocator.h"
 #include "media/starboard/starboard_memory_allocator.h"
 #include "starboard/common/bidirectional_fit_reuse_allocator.h"

--- a/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
@@ -25,10 +25,9 @@ template <typename ReuseAllocatorBase>
 class BidirectionalFitDecoderBufferAllocatorStrategy
     : public DecoderBufferAllocator::Strategy {
  public:
-  BidirectionalFitDecoderBufferAllocatorStrategy(
-      std::size_t initial_capacity,
-      std::size_t allocation_increment,
-      bool enable_decommit_on_idle)
+  BidirectionalFitDecoderBufferAllocatorStrategy(size_t initial_capacity,
+                                                 size_t allocation_increment,
+                                                 bool enable_decommit_on_idle)
       : fallback_allocator_(enable_decommit_on_idle),
         birectional_fit_allocator_(&fallback_allocator_,
                                    initial_capacity,

--- a/media/starboard/starboard_memory_allocator.h
+++ b/media/starboard/starboard_memory_allocator.h
@@ -47,16 +47,15 @@ class StarboardMemoryAllocator : public starboard::Allocator {
               << (enable_decommit_ ? "enabled" : "disabled") << ".";
   }
 
-  void* Allocate(std::size_t size) override {
+  void* Allocate(size_t size) override {
     return AllocateForAlignment(&size, 1);
   }
 
-  void* Allocate(std::size_t size, std::size_t alignment) override {
+  void* Allocate(size_t size, size_t alignment) override {
     return AllocateForAlignment(&size, alignment);
   }
 
-  void* AllocateForAlignment(std::size_t* size,
-                             std::size_t alignment) override {
+  void* AllocateForAlignment(size_t* size, size_t alignment) override {
     if (enable_decommit_) {
       alignment = std::max(alignment, page_size_);
       *size = AlignUp(*size, page_size_);
@@ -67,7 +66,7 @@ class StarboardMemoryAllocator : public starboard::Allocator {
   }
   void Free(void* memory) override { free(memory); }
 
-  void Decommit(void* memory, std::size_t size) override {
+  void Decommit(void* memory, size_t size) override {
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
     uintptr_t start = reinterpret_cast<uintptr_t>(memory);
     CHECK(enable_decommit_);
@@ -84,11 +83,11 @@ class StarboardMemoryAllocator : public starboard::Allocator {
     }
   }
 
-  std::size_t GetCapacity() const override {
+  size_t GetCapacity() const override {
     // Returns 0 here to avoid tracking the allocated memory.
     return 0;
   }
-  std::size_t GetAllocated() const override {
+  size_t GetAllocated() const override {
     // Returns 0 here to avoid tracking the allocated memory.
     return 0;
   }

--- a/media/starboard/starboard_memory_allocator.h
+++ b/media/starboard/starboard_memory_allocator.h
@@ -20,6 +20,7 @@
 #include <unistd.h>
 
 #include <algorithm>
+#include <cstddef>
 
 #include "base/check.h"
 #include "base/check_op.h"

--- a/starboard/common/bidirectional_fit_reuse_allocator.h
+++ b/starboard/common/bidirectional_fit_reuse_allocator.h
@@ -45,9 +45,9 @@ class BidirectionalFitReuseAllocator : public ReuseAllocatorBase {
       FreeBlockReverseiterator;
 
   BidirectionalFitReuseAllocator(starboard::Allocator* fallback_allocator,
-                                 std::size_t initial_capacity,
-                                 std::size_t small_allocation_threshold,
-                                 std::size_t allocation_increment,
+                                 size_t initial_capacity,
+                                 size_t small_allocation_threshold,
+                                 size_t allocation_increment,
                                  bool enable_decommit_on_idle)
       : ReuseAllocatorBase(fallback_allocator,
                            initial_capacity,
@@ -56,8 +56,8 @@ class BidirectionalFitReuseAllocator : public ReuseAllocatorBase {
                            enable_decommit_on_idle),
         small_allocation_threshold_(small_allocation_threshold) {}
 
-  FreeBlockIterator FindFreeBlock(std::size_t size,
-                                  std::size_t alignment,
+  FreeBlockIterator FindFreeBlock(size_t size,
+                                  size_t alignment,
                                   FreeBlockIterator begin,
                                   FreeBlockIterator end,
                                   bool* allocate_from_front) override {
@@ -86,7 +86,7 @@ class BidirectionalFitReuseAllocator : public ReuseAllocatorBase {
   }
 
  private:
-  std::size_t small_allocation_threshold_;
+  size_t small_allocation_threshold_;
 };
 
 }  // namespace starboard

--- a/starboard/common/bidirectional_fit_reuse_allocator_test.cc
+++ b/starboard/common/bidirectional_fit_reuse_allocator_test.cc
@@ -46,7 +46,7 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
     MockDecommitAllocator(void* memory_start, size_t memory_size)
         : FixedNoFreeAllocator(memory_start, memory_size), decommit_count(0) {}
 
-    void* Allocate(std::size_t size) override {
+    void* Allocate(size_t size) override {
       void* ptr = FixedNoFreeAllocator::Allocate(size);
       if (ptr) {
         active_allocations_[ptr] = size;
@@ -54,7 +54,7 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
       return ptr;
     }
 
-    void* Allocate(std::size_t size, std::size_t alignment) override {
+    void* Allocate(size_t size, size_t alignment) override {
       void* ptr = FixedNoFreeAllocator::Allocate(size, alignment);
       if (ptr) {
         active_allocations_[ptr] = size;
@@ -62,8 +62,7 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
       return ptr;
     }
 
-    void* AllocateForAlignment(std::size_t* size,
-                               std::size_t alignment) override {
+    void* AllocateForAlignment(size_t* size, size_t alignment) override {
       void* ptr = FixedNoFreeAllocator::AllocateForAlignment(size, alignment);
       if (ptr) {
         active_allocations_[ptr] = *size;
@@ -113,9 +112,9 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
     std::map<void*, size_t> active_allocations_;
   };
 
-  void ResetAllocator(std::size_t initial_capacity = 0,
-                      std::size_t small_allocation_threshold = 0,
-                      std::size_t allocation_increment = 0) {
+  void ResetAllocator(size_t initial_capacity = 0,
+                      size_t small_allocation_threshold = 0,
+                      size_t allocation_increment = 0) {
     void* tmp = nullptr;
     std::ignore = posix_memalign(&tmp, Allocator::kMinAlignment, kBufferSize);
     buffer_.reset(static_cast<uint8_t*>(tmp));
@@ -175,8 +174,8 @@ TYPED_TEST_SUITE(BidirectionalFitReuseAllocatorTest,
                  ClassNameGenerator);
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, SunnyDay) {
-  const std::size_t kAlignment = sizeof(void*);
-  const std::size_t kBlockSizes[] = {4, 97, 256, 65201};
+  const size_t kAlignment = sizeof(void*);
+  const size_t kBlockSizes[] = {4, 97, 256, 65201};
 
   for (size_t j = 0; j < SB_ARRAY_SIZE(kBlockSizes); ++j) {
     void* p = this->allocator_->Allocate(kBlockSizes[j], kAlignment);
@@ -187,7 +186,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, SunnyDay) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeFromFront) {
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kAlignment = sizeof(void*);
 
   for (int loop = 0; loop < 2; ++loop) {
     void* p[3];
@@ -203,7 +202,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeFromFront) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeFromBack) {
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kAlignment = sizeof(void*);
 
   for (int loop = 0; loop < 2; ++loop) {
     void* p[3];
@@ -220,7 +219,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeFromBack) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeFromMiddle) {
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kAlignment = sizeof(void*);
 
   for (int loop = 0; loop < 2; ++loop) {
     void* p[3];
@@ -237,8 +236,8 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeFromMiddle) {
 
 // Check that the reuse allocator actually merges adjacent free blocks.
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeBlockMergingLeft) {
-  const std::size_t kBlockSizes[] = {156, 16475};
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kBlockSizes[] = {156, 16475};
+  const size_t kAlignment = sizeof(void*);
   void* blocks[] = {NULL, NULL};
   blocks[0] = this->allocator_->Allocate(kBlockSizes[0], kAlignment);
   blocks[1] = this->allocator_->Allocate(kBlockSizes[1], kAlignment);
@@ -255,8 +254,8 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeBlockMergingLeft) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeBlockMergingRight) {
-  const std::size_t kBlockSizes[] = {156, 202, 354};
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kBlockSizes[] = {156, 202, 354};
+  const size_t kAlignment = sizeof(void*);
   void* blocks[] = {NULL, NULL, NULL};
   blocks[0] = this->allocator_->Allocate(kBlockSizes[0], kAlignment);
   blocks[1] = this->allocator_->Allocate(kBlockSizes[1], kAlignment);
@@ -275,14 +274,14 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, FreeBlockMergingRight) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, InitialCapacity) {
-  const std::size_t kInitialCapacity = kBufferSize / 2;
+  const size_t kInitialCapacity = kBufferSize / 2;
   this->ResetAllocator(kInitialCapacity);
   EXPECT_GE(this->fallback_allocator_->GetAllocated(), kInitialCapacity);
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, AllocationIncrement) {
-  const std::size_t kAllocationIncrement = kBufferSize / 2;
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kAllocationIncrement = kBufferSize / 2;
+  const size_t kAlignment = sizeof(void*);
   this->ResetAllocator(0, 0, kAllocationIncrement);
   void* p = this->allocator_->Allocate(1, kAlignment);
   EXPECT_TRUE(p != NULL);
@@ -291,7 +290,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, AllocationIncrement) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, FallbackBlockMerge) {
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kAlignment = sizeof(void*);
   void* p = this->allocator_->Allocate(kBufferSize / 2, kAlignment);
   EXPECT_TRUE(p != NULL);
   this->allocator_->Free(p);
@@ -308,8 +307,8 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, FallbackBlockMerge) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, AllocationsWithThreshold) {
-  const std::size_t kSmallAllocationThreshold = 1024;
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kSmallAllocationThreshold = 1024;
+  const size_t kAlignment = sizeof(void*);
 
   this->ResetAllocator(kBufferSize, kSmallAllocationThreshold, 0);
 
@@ -344,7 +343,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, AllocationsWithThreshold) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitExactFallbackBlocks) {
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kAlignment = sizeof(void*);
 
   this->ResetAllocatorWithDecommitSupport();
 
@@ -398,7 +397,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitExactFallbackBlocks) {
 }
 
 TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitOnBatchedFree) {
-  const std::size_t kAlignment = sizeof(void*);
+  const size_t kAlignment = sizeof(void*);
   const size_t kBlockSize = 1024;
   const int kNumBlocks = 4096;
 

--- a/starboard/common/experimental/media_buffer_pool_bidirectional_reuse_allocator.h
+++ b/starboard/common/experimental/media_buffer_pool_bidirectional_reuse_allocator.h
@@ -31,11 +31,10 @@ namespace experimental {
 // bidirectional fit reuse strategy.
 class MediaBufferPoolBidirectionalReuseAllocator : public Allocator {
  public:
-  MediaBufferPoolBidirectionalReuseAllocator(
-      MediaBufferPool* media_buffer_pool,
-      std::size_t initial_capacity,
-      std::size_t small_allocation_threshold,
-      std::size_t allocation_increment)
+  MediaBufferPoolBidirectionalReuseAllocator(MediaBufferPool* media_buffer_pool,
+                                             size_t initial_capacity,
+                                             size_t small_allocation_threshold,
+                                             size_t allocation_increment)
       : fallback_allocator_(media_buffer_pool),
         bidirectional_fit_reuse_allocator_(&fallback_allocator_,
                                            initial_capacity,
@@ -47,11 +46,11 @@ class MediaBufferPoolBidirectionalReuseAllocator : public Allocator {
     SB_DCHECK_EQ(GetAllocated(), 0u);
   }
 
-  void* Allocate(std::size_t size) override {
+  void* Allocate(size_t size) override {
     return AnnotatePointer(bidirectional_fit_reuse_allocator_.Allocate(size));
   }
 
-  void* Allocate(std::size_t size, std::size_t alignment) override {
+  void* Allocate(size_t size, size_t alignment) override {
     return AnnotatePointer(
         bidirectional_fit_reuse_allocator_.Allocate(size, alignment));
   }

--- a/starboard/common/experimental/media_buffer_pool_memory_allocator.h
+++ b/starboard/common/experimental/media_buffer_pool_memory_allocator.h
@@ -16,6 +16,7 @@
 #define STARBOARD_COMMON_EXPERIMENTAL_MEDIA_BUFFER_POOL_MEMORY_ALLOCATOR_H_
 
 #include <algorithm>
+#include <cstddef>
 
 #include "starboard/common/allocator.h"
 #include "starboard/common/experimental/media_buffer_pool.h"

--- a/starboard/common/experimental/media_buffer_pool_memory_allocator.h
+++ b/starboard/common/experimental/media_buffer_pool_memory_allocator.h
@@ -37,9 +37,9 @@ class MediaBufferPoolMemoryAllocator : public starboard::Allocator {
 
   ~MediaBufferPoolMemoryAllocator() { pool_->ShrinkToZero(); }
 
-  void* Allocate(std::size_t size) override { return Allocate(size, 1); }
+  void* Allocate(size_t size) override { return Allocate(size, 1); }
 
-  void* Allocate(std::size_t size, std::size_t alignment) override {
+  void* Allocate(size_t size, size_t alignment) override {
     SB_DCHECK(pool_);
 
     if (size == 0) {
@@ -47,7 +47,7 @@ class MediaBufferPoolMemoryAllocator : public starboard::Allocator {
     }
 
     // Align the current offset.
-    std::size_t padding = 0;
+    size_t padding = 0;
     if (alignment > 1) {
       uintptr_t current_address = offset_;
       uintptr_t aligned_address =
@@ -55,7 +55,7 @@ class MediaBufferPoolMemoryAllocator : public starboard::Allocator {
       padding = aligned_address - current_address;
     }
 
-    std::size_t new_offset = offset_ + padding + size;
+    size_t new_offset = offset_ + padding + size;
     if (!pool_->ExpandTo(new_offset)) {
       SB_LOG(WARNING) << "Failed to expand MediaBufferPool to " << new_offset;
       return nullptr;
@@ -69,8 +69,7 @@ class MediaBufferPoolMemoryAllocator : public starboard::Allocator {
     return ptr;
   }
 
-  void* AllocateForAlignment(std::size_t* size,
-                             std::size_t alignment) override {
+  void* AllocateForAlignment(size_t* size, size_t alignment) override {
     return Allocate(*size, alignment);
   }
 
@@ -78,13 +77,13 @@ class MediaBufferPoolMemoryAllocator : public starboard::Allocator {
     // Free is a no-op.
   }
 
-  std::size_t GetCapacity() const override {
+  size_t GetCapacity() const override {
     // Returns 0 here to avoid tracking the allocated memory twice if used
     // with another allocator that tracks capacity.
     return 0;
   }
 
-  std::size_t GetAllocated() const override { return offset_; }
+  size_t GetAllocated() const override { return offset_; }
 
   void PrintAllocations(bool align_allocated_size,
                         int max_allocations_to_print) const override {}
@@ -92,7 +91,7 @@ class MediaBufferPoolMemoryAllocator : public starboard::Allocator {
  private:
   starboard::experimental::MediaBufferPool* pool_;
   // Not start from 0, so it won't return `nullptr` as a valid pointer.
-  std::size_t offset_ = sizeof(void*);
+  size_t offset_ = sizeof(void*);
 };
 
 }  // namespace experimental


### PR DESCRIPTION
Replace std::size_t with size_t in starboard/common and media/starboard allocator files for style consistency.

This is part of https://github.com/youtube/cobalt/pull/10323, moved into a separate PR so the original one is easier to review.

Bug: 454441375