### PR TITLE
tvos: Remove obsolete MimeType validity check

### DIFF
--- a/starboard/tvos/shared/media_is_video_supported.mm
+++ b/starboard/tvos/shared/media_is_video_supported.mm
@@ -86,9 +86,6 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
 
       bool experimental_allowed = false;
       if (mime_type) {
-        if (!mime_type->is_valid()) {
-          return false;
-        }
         // This block checks if the "experimental" attribute is explicitly set
         // to "allowed". If the attribute is not present or has an invalid
         // value, `ValidateStringParameter` will cause an early return of


### PR DESCRIPTION
MimeType was refactored in #10303 to use a factory method returning
std::optional but the tvOS video support check was not updated, causing
a build error. The validity check is now redundant and can be removed.

Bug: 479994435
Bug: 487326366