### PR TITLE
Fix SIGSEGV in DialHttpServer::OnReceivedResponse after Stop()

### DIFF
--- a/cobalt/network/dial/dial_http_server.cc
+++ b/cobalt/network/dial/dial_http_server.cc
@@ -251,6 +251,11 @@ void DialHttpServer::OnReceivedResponse(
 
   DCHECK_EQ(task_runner_, base::SequencedTaskRunner::GetCurrentDefault());
   TRACE_EVENT0("net::dial", __FUNCTION__);
+
+  if (!http_server_) {
+    return;
+  }
+
   if (response) {
     http_server_->SendResponse(conn_id, *(response.get()),
                                kNetworkTrafficAnnotation);


### PR DESCRIPTION
OnReceivedResponse crosses a thread boundary via PostTask. If Stop() is called on the network thread between the PostTask and the task execution, http_server_ will be null when the task runs, causing a null pointer dereference inside HttpServer::FindConnection (nullptr + 0x28).

Add a null guard for http_server_ after the thread hop so stale callbacks posted after Stop() are silently discarded.

GOOGAMCONS-310