### PR TITLE
build: Reuse evergreen-x64 in more configs

### DIFF
--- a/cobalt/build/configs/evergreen-arm-hardfp-raspi/args.gn
+++ b/cobalt/build/configs/evergreen-arm-hardfp-raspi/args.gn
@@ -1,2 +1,3 @@
-import("//cobalt/build/configs/evergreen-x64/args.gn")
 import("//cobalt/build/configs/raspi-2-modular/args.gn")
+
+use_evergreen = true

--- a/cobalt/build/configs/evergreen-arm-hardfp-raspi/args.gn
+++ b/cobalt/build/configs/evergreen-arm-hardfp-raspi/args.gn
@@ -1,3 +1,2 @@
+import("//cobalt/build/configs/evergreen-x64/args.gn")
 import("//cobalt/build/configs/raspi-2-modular/args.gn")
-
-use_evergreen = true

--- a/cobalt/build/configs/evergreen-arm-hardfp-rdk/args.gn
+++ b/cobalt/build/configs/evergreen-arm-hardfp-rdk/args.gn
@@ -1,10 +1,8 @@
-import("//cobalt/build/configs/linux-x64x11-modular/args.gn")
+import("//cobalt/build/configs/evergreen-x64/args.gn")
 
 use_asan = false
-target_os = "linux"
 target_cpu = "arm"
 starboard_target_platform = "rdk-arm"
-use_evergreen = true
 rdk_build_with_yocto = false
 rdk_starboard_root = "//starboard/contrib/rdk/src"
 rdk_enable_securityagent = false

--- a/cobalt/build/configs/evergreen-arm-softfp/args.gn
+++ b/cobalt/build/configs/evergreen-arm-softfp/args.gn
@@ -1,9 +1,7 @@
-import("//cobalt/build/configs/linux-x64x11-modular/args.gn")
+import("//cobalt/build/configs/evergreen-x64/args.gn")
 
-target_os = "linux"
 target_cpu = "arm"
 starboard_path = "starboard/no_platform"
-use_evergreen = true
 arm_float_abi = "softfp"
 
 # TODO: b/453022760 - Investigate if this should be true and fix build failures

--- a/cobalt/build/configs/evergreen-arm64/args.gn
+++ b/cobalt/build/configs/evergreen-arm64/args.gn
@@ -1,6 +1,4 @@
-import("//cobalt/build/configs/linux-x64x11-modular/args.gn")
+import("//cobalt/build/configs/evergreen-x64/args.gn")
 
-target_os = "linux"
 target_cpu = "arm64"
 starboard_path = "starboard/no_platform"
-use_evergreen = true

--- a/cobalt/build/configs/linux-x64x11-no-starboard/args.gn
+++ b/cobalt/build/configs/linux-x64x11-no-starboard/args.gn
@@ -1,5 +1,4 @@
-target_os = "linux"
-target_cpu = "x64"
+import("//cobalt/build/configs/chromium_linux-x64x11/args.gn")
 
 # This combination of build flags is intended to be used to build content_shell
 # with cobalt's custom web APIs in order to test these web APIs with
@@ -7,9 +6,6 @@ target_cpu = "x64"
 is_cobalt = true
 is_starboard = false
 use_starboard_media = false
-
-# TODO(b/376141256): Decide if this flag is needed here or in .gclient file
-chrome_pgo_phase = 0
 
 # Force the chrome root store for linux/3P platforms.
 chrome_root_store_optional = false

--- a/cobalt/build/configs/raspi-2-modular/args.gn
+++ b/cobalt/build/configs/raspi-2-modular/args.gn
@@ -1,7 +1,6 @@
 import("//cobalt/build/configs/linux-x64x11-modular/args.gn")
 
 use_asan = false
-target_os = "linux"
 target_cpu = "arm"
 starboard_target_platform = "raspi-2"
 


### PR DESCRIPTION
Import cobalt/build/configs/evergreen-x64/args.gn into
several Evergreen-based build configurations. This change
removes redundant variable definitions that are now inherited.

Also perform similar cleanups in other configurations.

This PR is a precursor for adding a new build configuration for aosp-arm.

Bug: 495203133