### PR TITLE
starboard: Enforce alphabetical order of experimental features with keep-sorted

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -24,6 +24,10 @@ exclude: |
     )
 
 repos:
+-   repo: https://github.com/google/keep-sorted
+    rev: v0.8.0
+    hooks:
+    -   id: keep-sorted
 -   repo: https://cobalt.googlesource.com/pre-commit-hooks
     rev: v5.0.0
     hooks:

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -25,7 +25,7 @@ exclude: |
 
 repos:
 -   repo: https://github.com/google/keep-sorted
-    rev: v0.8.0
+    rev: ac58172d1655aa47a6f806e56ff0f269d6dbe637  # v0.8.0
     hooks:
     -   id: keep-sorted
 -   repo: https://cobalt.googlesource.com/pre-commit-hooks

--- a/media/base/starboard/starboard_renderer_config.cc
+++ b/media/base/starboard/starboard_renderer_config.cc
@@ -54,16 +54,16 @@ std::ostream& operator<<(
             << ToString(features.enable_reset_audio_decoder)
             << ", skip_flush_on_decoder_teardown="
             << ToString(features.skip_flush_on_decoder_teardown)
+            << ", use_dual_threads_for_video="
+            << ToString(features.use_dual_threads_for_video)
             << ", max_samples_per_write="
             << ToString(features.max_samples_per_write)
             << ", video_decoder_initial_preroll_count="
             << ToString(features.video_decoder_initial_preroll_count)
-            << ", video_renderer_min_input_buffers="
-            << ToString(features.video_renderer_min_input_buffers)
             << ", video_renderer_min_decoded_frames="
             << ToString(features.video_renderer_min_decoded_frames)
-            << ", use_dual_threads_for_video="
-            << ToString(features.use_dual_threads_for_video) << "}";
+            << ", video_renderer_min_input_buffers="
+            << ToString(features.video_renderer_min_input_buffers) << "}";
 }
 
 }  // namespace media

--- a/media/base/starboard/starboard_renderer_config.h
+++ b/media/base/starboard/starboard_renderer_config.h
@@ -29,17 +29,19 @@ namespace media {
 // Configs for StarboardRenderer.
 struct MEDIA_EXPORT StarboardRendererConfig {
   struct ExperimentalFeatures {
+    // keep-sorted start
     bool disable_low_performance_sw_decoder = false;
     bool enable_av1_startup_optimization = false;
     bool enable_codec_output_checker = false;
     bool enable_flush_during_seek = false;
     bool enable_reset_audio_decoder = false;
     bool skip_flush_on_decoder_teardown = false;
+    std::optional<bool> use_dual_threads_for_video;
     std::optional<int> max_samples_per_write;
     std::optional<int> video_decoder_initial_preroll_count;
-    std::optional<int> video_renderer_min_input_buffers;
     std::optional<int> video_renderer_min_decoded_frames;
-    std::optional<bool> use_dual_threads_for_video;
+    std::optional<int> video_renderer_min_input_buffers;
+    // keep-sorted end
   };
 
   StarboardRendererConfig();

--- a/starboard/extension/experimental_features.h
+++ b/starboard/extension/experimental_features.h
@@ -32,16 +32,18 @@ extern "C" {
 typedef struct StarboardExtensionExperimentalFeatures {
   // If a field is NULL, it means the value is not set.
   // The fields should be in alphabetical order.
+  // keep-sorted start
   bool disable_low_performance_sw_decoder;
   bool enable_av1_startup_optimization;
   bool enable_codec_output_checker;
   bool flush_decoder_during_reset;
   bool reset_audio_decoder;
   bool skip_flush_on_decoder_teardown;
+  const bool* use_dual_threads_for_video;
   const int* video_decoder_initial_preroll_count;
   const int* video_renderer_min_decoded_frames;
   const int* video_renderer_min_input_buffers;
-  const bool* use_dual_threads_for_video;
+  // keep-sorted end
 } StarboardExtensionExperimentalFeatures;
 
 typedef struct StarboardExtensionExperimentalFeaturesConfigurationApi {

--- a/starboard/shared/starboard/experimental_features.cc
+++ b/starboard/shared/starboard/experimental_features.cc
@@ -87,14 +87,14 @@ void SetExperimentalFeaturesForCurrentThread(
       extension_features->reset_audio_decoder;
   experiment_features.skip_flush_on_decoder_teardown =
       extension_features->skip_flush_on_decoder_teardown;
+  experiment_features.use_dual_threads_for_video =
+      FromBoolPointer(extension_features->use_dual_threads_for_video);
   experiment_features.video_decoder_initial_preroll_count =
       FromIntPointer(extension_features->video_decoder_initial_preroll_count);
   experiment_features.video_renderer_min_decoded_frames =
       FromIntPointer(extension_features->video_renderer_min_decoded_frames);
   experiment_features.video_renderer_min_input_buffers =
       FromIntPointer(extension_features->video_renderer_min_input_buffers);
-  experiment_features.use_dual_threads_for_video =
-      FromBoolPointer(extension_features->use_dual_threads_for_video);
 
   *GetOrCreateExperimentalFeatures() = experiment_features;
 }

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -27,6 +27,7 @@ namespace starboard {
 // dedicated function.
 struct ExperimentalFeatures {
   // The fields should be in alphabetical order.
+  // keep-sorted start
   bool allow_audio_writing_on_pause = false;
   bool disable_low_performance_sw_decoder = false;
   bool enable_av1_startup_optimization = false;
@@ -34,10 +35,11 @@ struct ExperimentalFeatures {
   bool flush_decoder_during_reset = false;
   bool reset_audio_decoder = false;
   bool skip_flush_on_decoder_teardown = false;
+  std::optional<bool> use_dual_threads_for_video;
   std::optional<int> video_decoder_initial_preroll_count;
   std::optional<int> video_renderer_min_decoded_frames;
   std::optional<int> video_renderer_min_input_buffers;
-  std::optional<bool> use_dual_threads_for_video;
+  // keep-sorted end
 };
 
 // Sets the experimental features for the current thread.


### PR DESCRIPTION
Integrate google/keep-sorted pre-commit hook to automatically maintain alphabetical order of experimental features structs.

Issue: 510335471