### PR TITLE
android: Fix memory leak and OOM crash in AudioTrackBridge

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
@@ -424,7 +424,14 @@ public class AudioTrackBridge {
     // The `synchronized` is required as `maxFramePositionSoFar` can also be modified in flush().
     // TODO: Consider refactor the code to remove the dependency on `synchronized`.
     synchronized (mPositionLock) {
-      if (mAudioTrack.getTimestamp(mRawAudioTimestamp)) {
+      boolean success = false;
+      try {
+        success = mAudioTrack.getTimestamp(mRawAudioTimestamp);
+      } catch (Exception | OutOfMemoryError e) {
+        Log.e(TAG, "Failed to getAudioTimestamp", e);
+      }
+
+      if (success) {
         // This conversion is safe, as only the lower bits will be set, since we
         // called |getTimestamp| without a timebase.
         // https://developer.android.com/reference/android/media/AudioTimestamp.html#framePosition

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -66,23 +66,6 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
   }
 
   JNIEnv* env = AttachCurrentThread();
-  ScopedJavaLocalRef<jobject> j_audio_track_bridge =
-      AudioOutputManager::GetInstance()->CreateAudioTrackBridge(
-          env, GetAudioFormatSampleType(coding_type, sample_type),
-          sampling_frequency_hz, channels, preferred_buffer_size_in_bytes,
-          tunnel_mode_audio_session_id, is_web_audio);
-
-  if (j_audio_track_bridge.is_null()) {
-    // One of the cases that this may hit is when output happened to be switched
-    // to a device that doesn't support tunnel mode.
-    // TODO: Find a way to exclude the device from tunnel mode playback, to
-    //       avoid infinite loop in creating the audio sink on a device
-    //       claims to support tunnel mode but fails to create the audio sink.
-    // TODO: Currently this will be reported as a general decode error,
-    //       investigate if this can be reported as a capability changed error.
-    SB_LOG(WARNING) << "Failed to create |j_audio_track_bridge|.";
-    return nullptr;
-  }
 
   int max_samples_per_write = 0;
   ScopedJavaGlobalRef<jobject> j_audio_data;
@@ -106,6 +89,24 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
 
   if (j_audio_data.is_null()) {
     SB_LOG(WARNING) << "Failed to allocate |j_audio_data_|";
+    return nullptr;
+  }
+
+  ScopedJavaLocalRef<jobject> j_audio_track_bridge =
+      AudioOutputManager::GetInstance()->CreateAudioTrackBridge(
+          env, GetAudioFormatSampleType(coding_type, sample_type),
+          sampling_frequency_hz, channels, preferred_buffer_size_in_bytes,
+          tunnel_mode_audio_session_id, is_web_audio);
+
+  if (j_audio_track_bridge.is_null()) {
+    // One of the cases that this may hit is when output happened to be switched
+    // to a device that doesn't support tunnel mode.
+    // TODO: Find a way to exclude the device from tunnel mode playback, to
+    //       avoid infinite loop in creating the audio sink on a device
+    //       claims to support tunnel mode but fails to create the audio sink.
+    // TODO: Currently this will be reported as a general decode error,
+    //       investigate if this can be reported as a capability changed error.
+    SB_LOG(WARNING) << "Failed to create |j_audio_track_bridge|.";
     return nullptr;
   }
 


### PR DESCRIPTION
The change addresses two memory-related issues in the Android AudioTrack
implementation that could lead to application crashes.

First, ensure the Java AudioTrackBridge object is properly destroyed if
the native audio data array allocation fails during creation. Previously,
this path would leak the object and its underlying AudioTrack.

Second, catch Exception and OutOfMemoryError when calling
AudioTrack.getTimestamp() on the audio hot path. This avoids catching the
overly broad Throwable (which can mask critical system failures) while still
protecting against platform-specific RuntimeExceptions and
OutOfMemoryErrors on low-resource devices. This allows the system to
log the error and fall back gracefully to the last known position rather
than crashing.

This is introduced by https://github.com/youtube/cobalt/pull/10291.

#vibe-coded

Issue: 510354897