### PR TITLE
android: Fix Android JUnit tests building and running

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltService.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltService.java
@@ -29,7 +29,7 @@ public abstract class CobaltService {
 
   @JNINamespace("starboard")
   @NativeMethods
-  interface Natives {
+  public interface Natives {
     // Can not set it as nativeService, JNI zero has template code to convert it to a Service object
     void nativeSendToClient(long service, byte[] data);
   }
@@ -99,6 +99,19 @@ public abstract class CobaltService {
 
   public abstract void close();
 
+  private static Natives sNatives;
+
+  public static void setNativesForTesting(Natives natives) {
+    sNatives = natives;
+  }
+
+  private static Natives getNatives() {
+    if (sNatives != null) {
+      return sNatives;
+    }
+    return CobaltServiceJni.get();
+  }
+
   /**
    * Send data from the service to the client.
    *
@@ -115,7 +128,7 @@ public abstract class CobaltService {
         return;
       }
 
-      CobaltServiceJni.get().nativeSendToClient(nativeService, data);
+      getNatives().nativeSendToClient(nativeService, data);
     }
   }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java
@@ -59,55 +59,71 @@ public class CobaltActivityTest {
   }
 
   @Test
-  public void testAppendEnableFeaturesIfNecessary_NullMetaData() {
+  public void testAppendArgsFromMetaData_NullMetaData() {
     String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendEnableFeaturesIfNecessary(/*metaData=*/null, args);
+    String[] result = CobaltActivity.appendArgsFromMetaData(/*metaData=*/null, args);
     assertArrayEquals(args, result);
   }
 
   @Test
-  public void testAppendEnableFeaturesIfNecessary_EmptyMetaData() {
+  public void testAppendArgsFromMetaData_EmptyMetaData() {
     Bundle metaData = mock(Bundle.class);
+    when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn(null);
     String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendEnableFeaturesIfNecessary(metaData, args);
+    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
     assertArrayEquals(args, result);
   }
 
   @Test
-  public void testAppendEnableFeaturesIfNecessary_EmptyStringFeature() {
+  public void testAppendArgsFromMetaData_EmptyStringFeature() {
     Bundle metaData = mock(Bundle.class);
+    when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn("");
     String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendEnableFeaturesIfNecessary(metaData, args);
+    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
     assertArrayEquals(args, result);
   }
 
   @Test
-  public void testAppendEnableFeaturesIfNecessary_WithFeature() {
+  public void testAppendArgsFromMetaData_WithFeature() {
     Bundle metaData = mock(Bundle.class);
+    when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn("FeatureA");
     String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendEnableFeaturesIfNecessary(metaData, args);
+    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
     assertArrayEquals(new String[] {"--arg1", "--enable-features=FeatureA"}, result);
   }
 
   @Test
-  public void testAppendEnableFeaturesIfNecessary_WithMultipleFeatures() {
+  public void testAppendArgsFromMetaData_WithMultipleFeatures() {
     Bundle metaData = mock(Bundle.class);
+    when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn("FeatureA;FeatureB");
     String[] args = new String[] {"--arg1"};
-    String[] result = CobaltActivity.appendEnableFeaturesIfNecessary(metaData, args);
+    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
     assertArrayEquals(new String[] {"--arg1", "--enable-features=FeatureA;FeatureB"}, result);
   }
 
   @Test
-  public void testAppendEnableFeaturesIfNecessary_NullArgs() {
+  public void testAppendArgsFromMetaData_NullArgs() {
     Bundle metaData = mock(Bundle.class);
+    when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(true);
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn("FeatureA");
-    String[] result = CobaltActivity.appendEnableFeaturesIfNecessary(metaData, /*commandLineArgs=*/null);
+    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, /*commandLineArgs=*/null);
     assertArrayEquals(new String[] {"--enable-features=FeatureA"}, result);
   }
+
+  @Test
+  public void testAppendArgsFromMetaData_DisableSplashScreen() {
+    Bundle metaData = mock(Bundle.class);
+    when(metaData.getBoolean("cobalt.ENABLE_SPLASH_SCREEN", true)).thenReturn(false);
+    when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn(null);
+    String[] args = new String[] {"--arg1"};
+    String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
+    assertArrayEquals(new String[] {"--arg1", "--disable-splash-screen"}, result);
+  }
+
 
   @Test
   public void testAppendUrlParamsToUrl_NoUrlArg() {

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltServiceTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltServiceTest.java
@@ -35,8 +35,7 @@ import org.robolectric.RobolectricTestRunner;
 @RunWith(RobolectricTestRunner.class)
 public class CobaltServiceTest {
   @Rule public final MockitoRule mocks = MockitoJUnit.rule();
-  @Mock private CobaltActivity mockCobaltActivity;
-  @Captor private ArgumentCaptor<String> jsCodeCaptor;
+  @Mock private CobaltService.Natives mockNatives;
 
   private TestCobaltService testService;
 
@@ -67,71 +66,16 @@ public class CobaltServiceTest {
   @Before
   public void setUp() {
     testService = new TestCobaltService();
-    testService.setCobaltActivity(mockCobaltActivity);
+    CobaltService.setNativesForTesting(mockNatives);
   }
 
   @Test
-  public void sendToClient_formatsJsCodeWithLocaleUS() {
+  public void sendToClient_callsNativeSendToClient() {
     long testNativeService = 98765L;
     byte[] testData = "sample_payload".getBytes();
-    String expectedBase64Data = Base64.encodeToString(testData, Base64.NO_WRAP);
 
-    // Call the method under test.
     testService.callSendToClient(testNativeService, testData);
 
-    // Verify that evaluateJavaScript was called on the mockCobaltActivity.
-    verify(mockCobaltActivity).evaluateJavaScript(jsCodeCaptor.capture());
-
-    // Capture the JavaScript code passed to evaluateJavaScript.
-    String actualJsCode = jsCodeCaptor.getValue();
-
-    String expectedJsCode = String.format(Locale.US, CobaltService.jsCodeTemplate, testNativeService, expectedBase64Data);
-
-    // Assert that the captured JS code matches the expected code formatted with Locale.US.
-    assertEquals(expectedJsCode, actualJsCode);
-  }
-
-  @Test
-  public void sendToClient_usesLocaleUSRegardlessOfDefaultLocale() {
-    // Save the current default locale.
-    Locale originalLocale = Locale.getDefault();
-    try {
-      // Set the default locale to Arabic, which uses different number formatting.
-      Locale.setDefault(new Locale("ar"));
-
-      long testNativeService = 12345L;
-      byte[] testData = "test_data".getBytes();
-      String expectedBase64Data = Base64.encodeToString(testData, Base64.NO_WRAP);
-
-      // Call the method under test.
-      testService.callSendToClient(testNativeService, testData);
-
-      // Verify and capture the argument.
-      verify(mockCobaltActivity).evaluateJavaScript(jsCodeCaptor.capture());
-      String actualJsCode = jsCodeCaptor.getValue();
-
-      String expectedJsCode = String.format(Locale.US, CobaltService.jsCodeTemplate, testNativeService, expectedBase64Data);
-
-      // Assert that the captured JS code matches the expected code formatted with Locale.US.
-      // If Locale.US was NOT used in sendToClient, and the default was Arabic,
-      // the number 12345 would likely be formatted differently (e.g., with Arabic numerals),
-      // causing this assertion to fail.
-      assertEquals(expectedJsCode, actualJsCode);
-    } finally {
-      // Restore the original default locale to avoid affecting other tests.
-      Locale.setDefault(originalLocale);
-    }
-  }
-
-  @Test
-  public void sendToClient_doesNotCallEvaluateJavaScriptIfActivityIsNull() {
-    TestCobaltService serviceWithNullActivity = new TestCobaltService();
-    // We don't call setCobaltActivity, so cobaltActivity remains null.
-
-    // Calling sendToClient should not cause a crash.
-    serviceWithNullActivity.callSendToClient(123L, new byte[] {1, 2, 3});
-
-    // Verify that evaluateJavaScript was never called on the mock.
-    verifyNoInteractions(mockCobaltActivity);
+    verify(mockNatives).nativeSendToClient(testNativeService, testData);
   }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -58,7 +58,7 @@ public class CommandLineOverrideHelperTest {
     public void testDefaultDisableFeatureOverridesList() {
         String overrides =
             CommandLineOverrideHelper.getDefaultDisableFeatureOverridesList().toString();
-        assertThat(overrides.contains("AImageReader")).isTrue();
+        assertThat(overrides.contains("PartitionAllocBackupRefPtr")).isTrue();
         assertThat(overrides.contains("UseAAudioInput")).isTrue();
     }
 

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/MockShellManagerNatives.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/MockShellManagerNatives.java
@@ -22,8 +22,13 @@ public class MockShellManagerNatives implements ShellManager.Natives {
   public void onShellCreated(ShellManager caller, long nativeShell) {}
 
   @Override
-  public void launchShell(String url) {}
+  public void launchShell(String url, String deepLinkUrl) {}
 
   @Override
   public void init(Object shellManagerInstance) {}
+
+  @Override
+  public String appendMigrationStatus(String url) {
+    return url;
+  }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/StartupGuardTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/StartupGuardTest.java
@@ -1,5 +1,7 @@
 package dev.cobalt.util;
 
+import dev.cobalt.shell.StartupGuard;
+
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 


### PR DESCRIPTION
This pull request addresses multiple issues preventing the cobalt_coat_junit_tests from building and passing correctly on Android.

* `CobaltActivityTest.java`: Updated tests to use appendArgsFromMetaData instead of the removed appendEnableFeaturesIfNecessary.
* `CobaltServiceTest.java`: Removed obsolete tests targeting evaluateJavaScript and added a new test to verify JNI calls via a new test hook.
* `StartupGuardTest.java`: Added missing import for StartupGuard.
* `MockShellManagerNatives.java`: Updated to match the current ShellManager.Natives interface (updated launchShell and added appendMigrationStatus).
* `CommandLineOverrideHelperTest.java`: Fixed a failing test by updating the expected default disabled features to include PartitionAllocBackupRefPtr.
* `CobaltService.java`: Made Natives interface public and added setNativesForTesting to facilitate unit testing of JNI calls.

Bug: 431780245