### PR TITLE
android/gpu: Manual cherrypick for raster and skia settings from C26

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -70,6 +70,8 @@ public final class CommandLineOverrideHelper {
         paramOverrides.add("--disable-accelerated-video-encode");
         // Rasterize Tiles directly to GPU memory.
         paramOverrides.add("--enable-zero-copy");
+        // Set default raster threads to 2 for smoother performance.
+        paramOverrides.add("--num-raster-threads=2");
 
         return paramOverrides;
     }

--- a/gpu/config/skia_limits.cc
+++ b/gpu/config/skia_limits.cc
@@ -94,7 +94,8 @@ void DetermineGrCacheLimitsFromAvailableMemory(
 #if !BUILDFLAG(IS_NACL)
   if (base::SysInfo::IsLowEndDevice()) {
 #if BUILDFLAG(IS_COBALT)
-    *max_resource_cache_bytes = 0;
+    constexpr size_t kLowEndCobaltMaxResourceCacheBytes = 2 * 1024 * 1024;
+    *max_resource_cache_bytes = kLowEndCobaltMaxResourceCacheBytes;
 #else
     *max_resource_cache_bytes = GetMaxLowEndGaneshResourceCacheBytes();
 #endif


### PR DESCRIPTION
- Set --num-raster-threads=2 in CommandLineOverrideHelper.
- Increase max_resource_cache_bytes to 2MB for low-end Cobalt devices in skia_limits.cc.

This is a manual cherry-pick from C26.

Bug: 463687039