### PR TITLE
cobalt: Clean up Starboard media settings

### DIFF
--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -143,9 +143,9 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
     const WTF::String& name,
     const V8UnionLongOrString* value,
     ExceptionState& exception_state) {
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
   const ExceptionContext& exception_context = exception_state.GetContext();
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
   if (name == "DecoderBuffer.EnableDecommitableAllocatorStrategy") {
     return ProcessSettingAsEnableOnly(
         script_state, exception_context, name, *value, [] {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -145,27 +145,20 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
     ExceptionState& exception_state) {
   const ExceptionContext& exception_context = exception_state.GetContext();
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
   if (name == "DecoderBuffer.EnableDecommitableAllocatorStrategy") {
     return ProcessSettingAsEnableOnly(
         script_state, exception_context, name, *value, [] {
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
           ::media::DecoderBufferAllocator::
               EnableDecommitableAllocatorStrategy();
           return true;
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
-          return false;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
         });
   }
   if (name == "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy") {
     return ProcessSettingAsEnableOnly(
         script_state, exception_context, name, *value, [] {
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
           ::media::DecoderBufferAllocator::EnableMediaBufferPoolStrategy();
           return true;
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
-          return false;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
         });
   }
   // "DecoderBuffer." settings must be handled before this catch-all block.
@@ -185,26 +178,23 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
   if (name == "Media.ExperimentalMaxPendingBytesPerParse") {
     return ProcessSettingAsPositiveInt(
         script_state, exception_context, name, *value, [](int int_value) {
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
           ::media::SourceBufferState::SetMaxPendingBytesPerParseOverride(
               int_value);
           return true;
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
-          return false;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
         });
   }
   if (name == "Media.IncrementalParseLookAhead") {
     return ProcessSettingAsEnableOnly(
         script_state, exception_context, name, *value, [] {
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
           ::media::StreamParser::SetEnableIncrementalParseLookAhead(true);
           return true;
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
-          return false;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
         });
   }
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Fall back to Mojo if BUILDFLAG(USE_STARBOARD_MEDIA) isn't defined. The
+  // settings will be stored in the browser but won't take effect. This is safe
+  // as USE_STARBOARD_MEDIA is always enabled in production releases.
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   EnsureReceiverIsBound();
 


### PR DESCRIPTION
Group Starboard media-specific settings within H5vccSettings::set
under a single BUILDFLAG(USE_STARBOARD_MEDIA) block. This removes
redundant preprocessor checks inside individual lambdas.

Also add a comment to explain the fallback behavior when
USE_STARBOARD_MEDIA is not defined, ensuring consistency with other
experiments.

Bug: 454441375