### PR TITLE
test: explicitly set test_attempts to 1 (#10348)

### DIFF
--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -211,8 +211,13 @@ def _unit_test_params(args: argparse.Namespace, target_name: str,
   if args.gcs_result_path:
     params.append(f'gcs_result_path={args.gcs_result_path}')
   if args.test_attempts:
-    # Must delete existing results when retries are enabled.
-    params.append('gcs_delete_before_upload=true')
+    try:
+      if int(args.test_attempts) > 1:
+        # Must delete existing results when retries are enabled.
+        params.append('gcs_delete_before_upload=true')
+    except ValueError:
+      logging.warning('Invalid test_attempts value: %s', args.test_attempts)
+
   return params
 
 
@@ -343,6 +348,7 @@ def main() -> int:
   trigger_args.add_argument(
       '--test_attempts',
       type=str,
+      default='1',
       help='The maximum number of times a test can retry.',
   )
   trigger_args.add_argument(


### PR DESCRIPTION
    Explicitly set the default value for the --test_attempts argument
    to '1' in the on_device_tests_gateway_client.py script. This
    ensures that tests run via this client will execute only once by
    default, preventing unintended retries potentially configured by
    external systems.
    
    Additionally, the logic for enabling gcs_delete_before_upload is
    made more robust by parsing the test_attempts value as an integer
    and only setting the flag if more than one attempt is specified.
    
Bug: 507140857