### PR TITLE
BACKPORT: [Testing] Wrap `bundle_identifier = shared_bundle_id_for_test_apps`

### DIFF
--- a/testing/test.gni
+++ b/testing/test.gni
@@ -946,7 +946,9 @@ template("test") {
         info_plist = "//testing/gtest_ios/unittest-Info.plist"
       }
 
-      bundle_identifier = shared_bundle_id_for_test_apps
+      if (!defined(bundle_identifier)) {
+        bundle_identifier = shared_bundle_id_for_test_apps
+      }
 
       if (!defined(bundle_deps)) {
         bundle_deps = []


### PR DESCRIPTION
Bug: 510495154

Original CL description:

[Testing] Wrap `bundle_identifier = shared_bundle_id_for_test_apps`

- Allows other developer organization or downstream embedder bundle IDs to be used. Otherwise it gets overridden.

Bug: [509988272](https://issues.chromium.org/issues/509988272)
Change-Id: [I780ad817f0ae82b580d1a78d6ce90c7a8bb8d9d5](https://chromium-review.git.corp.google.com/q/I780ad817f0ae82b580d1a78d6ce90c7a8bb8d9d5)
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7817321
Auto-Submit: Faye Johnston <[fayev@google.com](mailto:fayev@google.com)>
Reviewed-by: Rohit Rao <[rohitrao@chromium.org](mailto:rohitrao@chromium.org)>
Reviewed-by: Ben Pastene <[bpastene@chromium.org](mailto:bpastene@chromium.org)>
Commit-Queue: Ben Pastene <[bpastene@chromium.org](mailto:bpastene@chromium.org)>
Cr-Commit-Position: refs/heads/main@{#1626309}