### PR TITLE
starboard: Reorder player member functions

### DIFF
--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -92,11 +92,6 @@ int DecodedAudio::frames() const {
   return static_cast<int>(size_in_bytes_ / bytes_per_sample / channels_);
 }
 
-bool DecodedAudio::IsFormat(SbMediaAudioSampleType sample_type,
-                            SbMediaAudioFrameStorageType storage_type) const {
-  return sample_type_ == sample_type && storage_type_ == storage_type;
-}
-
 void DecodedAudio::ShrinkTo(int new_size_in_bytes) {
   SB_DCHECK_LE(new_size_in_bytes, size_in_bytes_);
   size_in_bytes_ = new_size_in_bytes;
@@ -184,6 +179,11 @@ void DecodedAudio::AdjustForDiscardedDurations(
           ? current_frames
           : AudioDurationToFrames(discarded_duration_from_back, sample_rate);
   size_in_bytes_ -= bytes_per_frame * discarded_frames_from_back;
+}
+
+bool DecodedAudio::IsFormat(SbMediaAudioSampleType sample_type,
+                            SbMediaAudioFrameStorageType storage_type) const {
+  return sample_type_ == sample_type && storage_type_ == storage_type;
 }
 
 scoped_refptr<DecodedAudio> DecodedAudio::SwitchFormatTo(

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
@@ -212,20 +212,6 @@ void AdaptiveAudioDecoder::TeardownAudioDecoder() {
   first_input_written_ = false;
 }
 
-void AdaptiveAudioDecoder::ResetInternal() {
-  CancelPendingJobs();
-  while (!decoded_audios_.empty()) {
-    decoded_audios_.pop();
-  }
-  pending_input_buffers_.clear();
-  pending_consumed_cb_ = nullptr;
-  flushing_ = false;
-  stream_ended_ = false;
-  first_output_received_ = false;
-  first_input_written_ = false;
-  output_format_checked_ = false;
-}
-
 void AdaptiveAudioDecoder::OnDecoderOutput() {
   if (!BelongsToCurrentThread()) {
     Schedule(std::bind(&AdaptiveAudioDecoder::OnDecoderOutput, this));
@@ -318,6 +304,20 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
     decoded_audios_.push(decoded_audio);
     Schedule(output_cb_);
   }
+}
+
+void AdaptiveAudioDecoder::ResetInternal() {
+  CancelPendingJobs();
+  while (!decoded_audios_.empty()) {
+    decoded_audios_.pop();
+  }
+  pending_input_buffers_.clear();
+  pending_consumed_cb_ = nullptr;
+  flushing_ = false;
+  stream_ended_ = false;
+  first_output_received_ = false;
+  first_input_written_ = false;
+  output_format_checked_ = false;
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -57,21 +57,6 @@ AudioRendererSinkImpl::~AudioRendererSinkImpl() {
   Stop();
 }
 
-bool AudioRendererSinkImpl::IsAudioSampleTypeSupported(
-    SbMediaAudioSampleType audio_sample_type) const {
-  return SbAudioSinkIsAudioSampleTypeSupported(audio_sample_type);
-}
-
-bool AudioRendererSinkImpl::IsAudioFrameStorageTypeSupported(
-    SbMediaAudioFrameStorageType audio_frame_storage_type) const {
-  return SbAudioSinkIsAudioFrameStorageTypeSupported(audio_frame_storage_type);
-}
-
-int AudioRendererSinkImpl::GetNearestSupportedSampleFrequency(
-    int sampling_frequency_hz) const {
-  return SbAudioSinkGetNearestSupportedSampleFrequency(sampling_frequency_hz);
-}
-
 void AudioRendererSinkImpl::GetAudioRendererParams(
     const AudioStreamInfo& audio_stream_info,
     int* max_cached_frames,
@@ -96,6 +81,21 @@ void AudioRendererSinkImpl::GetAudioRendererParams(
   *max_cached_frames = static_cast<int>(min_frames_required * 1.4) +
                        kDefaultAudioSinkMinFramesPerAppend;
   *max_cached_frames = AlignUp(*max_cached_frames, kAudioSinkFramesAlignment);
+}
+
+bool AudioRendererSinkImpl::IsAudioSampleTypeSupported(
+    SbMediaAudioSampleType audio_sample_type) const {
+  return SbAudioSinkIsAudioSampleTypeSupported(audio_sample_type);
+}
+
+bool AudioRendererSinkImpl::IsAudioFrameStorageTypeSupported(
+    SbMediaAudioFrameStorageType audio_frame_storage_type) const {
+  return SbAudioSinkIsAudioFrameStorageTypeSupported(audio_frame_storage_type);
+}
+
+int AudioRendererSinkImpl::GetNearestSupportedSampleFrequency(
+    int sampling_frequency_hz) const {
+  return SbAudioSinkGetNearestSupportedSampleFrequency(sampling_frequency_hz);
 }
 
 bool AudioRendererSinkImpl::HasStarted() const {

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -257,113 +257,6 @@ bool AudioTimeStretcher::IsQueueFull() const {
   return audio_buffer_.frames() >= capacity_;
 }
 
-// TODO: Make order of functions in .cc the same as order of functions in .h.
-bool AudioTimeStretcher::CanPerformWsola() const {
-  const int search_block_size = num_candidate_blocks_ + (ola_window_size_ - 1);
-  const int frames = audio_buffer_.frames();
-  return target_block_index_ + ola_window_size_ <= frames &&
-         search_block_index_ + search_block_size <= frames;
-}
-
-int AudioTimeStretcher::ConvertMillisecondsToFrames(int ms) const {
-  const double kMillisecondsPerSeconds = 1000;
-  return static_cast<int>(ms * (samples_per_second_ / kMillisecondsPerSeconds));
-}
-
-bool AudioTimeStretcher::RunOneWsolaIteration(double playback_rate) {
-  SB_DCHECK_GT(bytes_per_frame_, 0);
-
-  if (!CanPerformWsola()) {
-    return false;
-  }
-
-  GetOptimalBlock();
-
-  // Overlap-and-add.
-  for (int k = 0; k < channels_; ++k) {
-    const float* const ch_opt_frame =
-        reinterpret_cast<const float*>(optimal_block_->data()) + k;
-    float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) + k +
-                       num_complete_frames_ * channels_;
-    for (int n = 0; n < ola_hop_size_; ++n) {
-      ch_output[n * channels_] =
-          ch_output[n * channels_] * ola_window_[ola_hop_size_ + n] +
-          ch_opt_frame[n * channels_] * ola_window_[n];
-    }
-  }
-  // Copy the second half to the output.
-  const float* const ch_opt_frame =
-      reinterpret_cast<const float*>(optimal_block_->data());
-  float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) +
-                     num_complete_frames_ * channels_;
-  memcpy(&ch_output[ola_hop_size_ * channels_],
-         &ch_opt_frame[ola_hop_size_ * channels_],
-         sizeof(*ch_opt_frame) * ola_hop_size_ * channels_);
-
-  num_complete_frames_ += ola_hop_size_;
-  UpdateOutputTime(playback_rate, ola_hop_size_);
-  RemoveOldInputFrames(playback_rate);
-  return true;
-}
-
-void AudioTimeStretcher::UpdateOutputTime(double playback_rate,
-                                          double time_change) {
-  output_time_ += time_change;
-  // Center of the search region, in frames.
-  const int search_block_center_index =
-      static_cast<int>(output_time_ * playback_rate + 0.5);
-  search_block_index_ = search_block_center_index - search_block_center_offset_;
-}
-
-void AudioTimeStretcher::RemoveOldInputFrames(double playback_rate) {
-  const int earliest_used_index =
-      std::min(target_block_index_, search_block_index_);
-  if (earliest_used_index <= 0) {
-    return;  // Nothing to remove.
-  }
-
-  // Remove frames from input and adjust indices accordingly.
-  audio_buffer_.SeekFrames(earliest_used_index);
-  target_block_index_ -= earliest_used_index;
-
-  // Adjust output index.
-  double output_time_change =
-      static_cast<double>(earliest_used_index) / playback_rate;
-  SB_CHECK_GE(output_time_, output_time_change);
-  UpdateOutputTime(playback_rate, -output_time_change);
-}
-
-int AudioTimeStretcher::WriteCompletedFramesTo(int requested_frames,
-                                               int dest_offset,
-                                               DecodedAudio* dest) {
-  SB_DCHECK_GT(bytes_per_frame_, 0);
-
-  int rendered_frames = std::min(num_complete_frames_, requested_frames);
-
-  if (rendered_frames == 0) {
-    return 0;  // There is nothing to read from |wsola_output_|, return.
-  }
-
-  memcpy(dest->data() + bytes_per_frame_ * dest_offset, wsola_output_->data(),
-         rendered_frames * bytes_per_frame_);
-
-  // Remove the frames which are read.
-  int frames_to_move = wsola_output_->frames() - rendered_frames;
-  memmove(wsola_output_->data(),
-          wsola_output_->data() + rendered_frames * bytes_per_frame_,
-          frames_to_move * bytes_per_frame_);
-  num_complete_frames_ -= rendered_frames;
-  return rendered_frames;
-}
-
-bool AudioTimeStretcher::TargetIsWithinSearchRegion() const {
-  const int search_block_size = num_candidate_blocks_ + (ola_window_size_ - 1);
-
-  return target_block_index_ >= search_block_index_ &&
-         target_block_index_ + ola_window_size_ <=
-             search_block_index_ + search_block_size;
-}
-
 void AudioTimeStretcher::GetOptimalBlock() {
   int optimal_index = 0;
 
@@ -418,6 +311,29 @@ void AudioTimeStretcher::GetOptimalBlock() {
   target_block_index_ = optimal_index + ola_hop_size_;
 }
 
+int AudioTimeStretcher::WriteCompletedFramesTo(int requested_frames,
+                                               int dest_offset,
+                                               DecodedAudio* dest) {
+  SB_DCHECK_GT(bytes_per_frame_, 0);
+
+  int rendered_frames = std::min(num_complete_frames_, requested_frames);
+
+  if (rendered_frames == 0) {
+    return 0;  // There is nothing to read from |wsola_output_|, return.
+  }
+
+  memcpy(dest->data() + bytes_per_frame_ * dest_offset, wsola_output_->data(),
+         rendered_frames * bytes_per_frame_);
+
+  // Remove the frames which are read.
+  int frames_to_move = wsola_output_->frames() - rendered_frames;
+  memmove(wsola_output_->data(),
+          wsola_output_->data() + rendered_frames * bytes_per_frame_,
+          frames_to_move * bytes_per_frame_);
+  num_complete_frames_ -= rendered_frames;
+  return rendered_frames;
+}
+
 void AudioTimeStretcher::PeekAudioWithZeroPrepend(int read_offset_frames,
                                                   DecodedAudio* dest) {
   SB_DCHECK_GT(bytes_per_frame_, 0);
@@ -435,6 +351,89 @@ void AudioTimeStretcher::PeekAudioWithZeroPrepend(int read_offset_frames,
   }
   audio_buffer_.PeekFrames(num_frames_to_read, read_offset_frames, write_offset,
                            dest);
+}
+
+bool AudioTimeStretcher::RunOneWsolaIteration(double playback_rate) {
+  SB_DCHECK_GT(bytes_per_frame_, 0);
+
+  if (!CanPerformWsola()) {
+    return false;
+  }
+
+  GetOptimalBlock();
+
+  // Overlap-and-add.
+  for (int k = 0; k < channels_; ++k) {
+    const float* const ch_opt_frame =
+        reinterpret_cast<const float*>(optimal_block_->data()) + k;
+    float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) + k +
+                       num_complete_frames_ * channels_;
+    for (int n = 0; n < ola_hop_size_; ++n) {
+      ch_output[n * channels_] =
+          ch_output[n * channels_] * ola_window_[ola_hop_size_ + n] +
+          ch_opt_frame[n * channels_] * ola_window_[n];
+    }
+  }
+  // Copy the second half to the output.
+  const float* const ch_opt_frame =
+      reinterpret_cast<const float*>(optimal_block_->data());
+  float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) +
+                     num_complete_frames_ * channels_;
+  memcpy(&ch_output[ola_hop_size_ * channels_],
+         &ch_opt_frame[ola_hop_size_ * channels_],
+         sizeof(*ch_opt_frame) * ola_hop_size_ * channels_);
+
+  num_complete_frames_ += ola_hop_size_;
+  UpdateOutputTime(playback_rate, ola_hop_size_);
+  RemoveOldInputFrames(playback_rate);
+  return true;
+}
+
+void AudioTimeStretcher::RemoveOldInputFrames(double playback_rate) {
+  const int earliest_used_index =
+      std::min(target_block_index_, search_block_index_);
+  if (earliest_used_index <= 0) {
+    return;  // Nothing to remove.
+  }
+
+  // Remove frames from input and adjust indices accordingly.
+  audio_buffer_.SeekFrames(earliest_used_index);
+  target_block_index_ -= earliest_used_index;
+
+  // Adjust output index.
+  double output_time_change =
+      static_cast<double>(earliest_used_index) / playback_rate;
+  SB_CHECK_GE(output_time_, output_time_change);
+  UpdateOutputTime(playback_rate, -output_time_change);
+}
+
+void AudioTimeStretcher::UpdateOutputTime(double playback_rate,
+                                          double time_change) {
+  output_time_ += time_change;
+  // Center of the search region, in frames.
+  const int search_block_center_index =
+      static_cast<int>(output_time_ * playback_rate + 0.5);
+  search_block_index_ = search_block_center_index - search_block_center_offset_;
+}
+
+bool AudioTimeStretcher::TargetIsWithinSearchRegion() const {
+  const int search_block_size = num_candidate_blocks_ + (ola_window_size_ - 1);
+
+  return target_block_index_ >= search_block_index_ &&
+         target_block_index_ + ola_window_size_ <=
+             search_block_index_ + search_block_size;
+}
+
+bool AudioTimeStretcher::CanPerformWsola() const {
+  const int search_block_size = num_candidate_blocks_ + (ola_window_size_ - 1);
+  const int frames = audio_buffer_.frames();
+  return target_block_index_ + ola_window_size_ <= frames &&
+         search_block_index_ + search_block_size <= frames;
+}
+
+int AudioTimeStretcher::ConvertMillisecondsToFrames(int ms) const {
+  const double kMillisecondsPerSeconds = 1000;
+  return static_cast<int>(ms * (samples_per_second_ / kMillisecondsPerSeconds));
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -413,6 +413,75 @@ Result<void> FilterBasedPlayerWorkerHandler::SetBounds(const Bounds& bounds) {
   return Success();
 }
 
+void FilterBasedPlayerWorkerHandler::SetMaxVideoInputSize(
+    int max_video_input_size) {
+  SB_LOG(INFO) << "Set max_video_input_size from " << max_video_input_size_
+               << " to " << max_video_input_size;
+  max_video_input_size_ = max_video_input_size;
+}
+
+void FilterBasedPlayerWorkerHandler::SetExperimentalFeatures(
+    const ExperimentalFeatures& experimental_features) {
+  SB_LOG(INFO) << __func__;
+  experimental_features_ = experimental_features;
+}
+
+void FilterBasedPlayerWorkerHandler::SetVideoSurfaceView(void* surface_view) {
+  SB_LOG(INFO) << "Set surface_view from " << surface_view_ << " to "
+               << surface_view;
+  surface_view_ = surface_view;
+}
+
+void FilterBasedPlayerWorkerHandler::Stop() {
+  SB_CHECK(BelongsToCurrentThread());
+
+  SB_LOG(INFO) << "FilterBasedPlayerWorkerHandler stopped.";
+
+  audio_preroll_track_.End();
+  video_preroll_track_.End();
+
+  RemoveJobByToken(&update_job_token_);
+
+  std::unique_ptr<PlayerComponents> player_components;
+  {
+    // Set |player_components_| to null with the lock, but we actually destroy
+    // it outside of the lock.  This is because the VideoRenderer destructor
+    // may post a task to destroy the SbDecodeTarget to the same thread that
+    // might call GetCurrentDecodeTarget(), which would try to take this lock.
+    std::lock_guard lock(player_components_existence_mutex_);
+    player_components = std::move(player_components_);
+    media_time_provider_ = nullptr;
+    audio_renderer_ = nullptr;
+    video_renderer_ = nullptr;
+  }
+  player_components.reset();
+}
+
+void FilterBasedPlayerWorkerHandler::Update() {
+  SB_CHECK(BelongsToCurrentThread());
+
+  if (!media_time_provider_) {
+    return;
+  }
+
+  if (get_player_state_cb_() == kSbPlayerStatePresenting) {
+    int dropped_frames = 0;
+    if (video_renderer_) {
+      dropped_frames = video_renderer_->GetDroppedFrames();
+    }
+    bool is_playing;
+    bool is_eos_played;
+    bool is_underflow;
+    double playback_rate;
+    auto media_time = media_time_provider_->GetCurrentMediaTime(
+        &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+    update_media_info_cb_(media_time, dropped_frames, !is_underflow);
+  }
+
+  RemoveJobByToken(&update_job_token_);
+  update_job_token_ = Schedule(update_job_, kUpdateIntervalUsec);
+}
+
 void FilterBasedPlayerWorkerHandler::OnError(SbPlayerError error,
                                              const std::string& error_message) {
   if (!BelongsToCurrentThread()) {
@@ -484,56 +553,6 @@ void FilterBasedPlayerWorkerHandler::OnEnded(SbMediaType media_type) {
   }
 }
 
-void FilterBasedPlayerWorkerHandler::Update() {
-  SB_CHECK(BelongsToCurrentThread());
-
-  if (!media_time_provider_) {
-    return;
-  }
-
-  if (get_player_state_cb_() == kSbPlayerStatePresenting) {
-    int dropped_frames = 0;
-    if (video_renderer_) {
-      dropped_frames = video_renderer_->GetDroppedFrames();
-    }
-    bool is_playing;
-    bool is_eos_played;
-    bool is_underflow;
-    double playback_rate;
-    auto media_time = media_time_provider_->GetCurrentMediaTime(
-        &is_playing, &is_eos_played, &is_underflow, &playback_rate);
-    update_media_info_cb_(media_time, dropped_frames, !is_underflow);
-  }
-
-  RemoveJobByToken(&update_job_token_);
-  update_job_token_ = Schedule(update_job_, kUpdateIntervalUsec);
-}
-
-void FilterBasedPlayerWorkerHandler::Stop() {
-  SB_CHECK(BelongsToCurrentThread());
-
-  SB_LOG(INFO) << "FilterBasedPlayerWorkerHandler stopped.";
-
-  audio_preroll_track_.End();
-  video_preroll_track_.End();
-
-  RemoveJobByToken(&update_job_token_);
-
-  std::unique_ptr<PlayerComponents> player_components;
-  {
-    // Set |player_components_| to null with the lock, but we actually destroy
-    // it outside of the lock.  This is because the VideoRenderer destructor
-    // may post a task to destroy the SbDecodeTarget to the same thread that
-    // might call GetCurrentDecodeTarget(), which would try to take this lock.
-    std::lock_guard lock(player_components_existence_mutex_);
-    player_components = std::move(player_components_);
-    media_time_provider_ = nullptr;
-    audio_renderer_ = nullptr;
-    video_renderer_ = nullptr;
-  }
-  player_components.reset();
-}
-
 SbDecodeTarget FilterBasedPlayerWorkerHandler::GetCurrentDecodeTarget() {
   if (output_mode_ != kSbPlayerOutputModeDecodeToTexture) {
     return kSbDecodeTargetInvalid;
@@ -547,25 +566,6 @@ SbDecodeTarget FilterBasedPlayerWorkerHandler::GetCurrentDecodeTarget() {
     }
   }
   return decode_target;
-}
-
-void FilterBasedPlayerWorkerHandler::SetMaxVideoInputSize(
-    int max_video_input_size) {
-  SB_LOG(INFO) << "Set max_video_input_size from " << max_video_input_size_
-               << " to " << max_video_input_size;
-  max_video_input_size_ = max_video_input_size;
-}
-
-void FilterBasedPlayerWorkerHandler::SetExperimentalFeatures(
-    const ExperimentalFeatures& experimental_features) {
-  SB_LOG(INFO) << __func__;
-  experimental_features_ = experimental_features;
-}
-
-void FilterBasedPlayerWorkerHandler::SetVideoSurfaceView(void* surface_view) {
-  SB_LOG(INFO) << "Set surface_view from " << surface_view_ << " to "
-               << surface_view;
-  surface_view_ = surface_view;
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/interleaved_sinc_resampler.cc
+++ b/starboard/shared/starboard/player/filter/interleaved_sinc_resampler.cc
@@ -91,60 +91,6 @@ InterleavedSincResampler::InterleavedSincResampler(double io_sample_rate_ratio,
   InitializeKernel();
 }
 
-void InterleavedSincResampler::InitializeKernel() {
-  // Blackman window parameters.
-  const double kAlpha = 0.16;
-  const double kA0 = 0.5 * (1.0 - kAlpha);
-  const double kA1 = 0.5;
-  const double kA2 = 0.5 * kAlpha;
-
-  // |sinc_scale_factor| is basically the normalized cutoff frequency of the
-  // low-pass filter.
-  double sinc_scale_factor =
-      io_sample_rate_ratio_ > 1.0 ? 1.0 / io_sample_rate_ratio_ : 1.0;
-
-  // The sinc function is an idealized brick-wall filter, but since we're
-  // windowing it the transition from pass to stop does not happen right away.
-  // So we should adjust the low pass filter cutoff slightly downward to avoid
-  // some aliasing at the very high-end.
-  // TODO: this value is empirical and to be more exact should vary depending
-  // on kKernelSize.
-  sinc_scale_factor *= 0.9;
-
-  // Generates a set of windowed sinc() kernels.
-  // We generate a range of sub-sample offsets from 0.0 to 1.0.
-  for (int offset_idx = 0; offset_idx <= kKernelOffsetCount; ++offset_idx) {
-    double subsample_offset =
-        static_cast<double>(offset_idx) / kKernelOffsetCount;
-
-    for (int i = 0; i < kKernelSize; ++i) {
-      // Compute the sinc with offset.
-      double s =
-          sinc_scale_factor * M_PI * (i - kKernelSize / 2 - subsample_offset);
-      double sinc = (!s ? 1.0 : sin(s) / s) * sinc_scale_factor;
-
-      // Compute Blackman window, matching the offset of the sinc().
-      double x = (i - subsample_offset) / kKernelSize;
-      double window =
-          kA0 - kA1 * cos(2.0 * M_PI * x) + kA2 * cos(4.0 * M_PI * x);
-
-      // Window the sinc() function and store at the correct offset.
-      kernel_storage_[i + offset_idx * kKernelSize] = sinc * window;
-    }
-  }
-}
-
-int InterleavedSincResampler::GetNumberOfCachedFrames() const {
-  if (pending_buffers_.empty()) {
-    return 0;
-  }
-
-  SB_DCHECK(frames_queued_ - kBufferSize >
-            frames_resampled_ * io_sample_rate_ratio_);
-  return frames_queued_ - kBufferSize -
-         frames_resampled_ * io_sample_rate_ratio_;
-}
-
 void InterleavedSincResampler::QueueBuffer(const float* data, int frames) {
   SB_DCHECK(CanQueueBuffer());
 
@@ -256,6 +202,60 @@ bool InterleavedSincResampler::HasEnoughData(int frames_to_resample) const {
   // for an extra Read().
   return (frames_resampled_ + frames_to_resample) * io_sample_rate_ratio_ <
          frames_queued_ - kBufferSize;
+}
+
+int InterleavedSincResampler::GetNumberOfCachedFrames() const {
+  if (pending_buffers_.empty()) {
+    return 0;
+  }
+
+  SB_DCHECK(frames_queued_ - kBufferSize >
+            frames_resampled_ * io_sample_rate_ratio_);
+  return frames_queued_ - kBufferSize -
+         frames_resampled_ * io_sample_rate_ratio_;
+}
+
+void InterleavedSincResampler::InitializeKernel() {
+  // Blackman window parameters.
+  const double kAlpha = 0.16;
+  const double kA0 = 0.5 * (1.0 - kAlpha);
+  const double kA1 = 0.5;
+  const double kA2 = 0.5 * kAlpha;
+
+  // |sinc_scale_factor| is basically the normalized cutoff frequency of the
+  // low-pass filter.
+  double sinc_scale_factor =
+      io_sample_rate_ratio_ > 1.0 ? 1.0 / io_sample_rate_ratio_ : 1.0;
+
+  // The sinc function is an idealized brick-wall filter, but since we're
+  // windowing it the transition from pass to stop does not happen right away.
+  // So we should adjust the low pass filter cutoff slightly downward to avoid
+  // some aliasing at the very high-end.
+  // TODO: this value is empirical and to be more exact should vary depending
+  // on kKernelSize.
+  sinc_scale_factor *= 0.9;
+
+  // Generates a set of windowed sinc() kernels.
+  // We generate a range of sub-sample offsets from 0.0 to 1.0.
+  for (int offset_idx = 0; offset_idx <= kKernelOffsetCount; ++offset_idx) {
+    double subsample_offset =
+        static_cast<double>(offset_idx) / kKernelOffsetCount;
+
+    for (int i = 0; i < kKernelSize; ++i) {
+      // Compute the sinc with offset.
+      double s =
+          sinc_scale_factor * M_PI * (i - kKernelSize / 2 - subsample_offset);
+      double sinc = (!s ? 1.0 : sin(s) / s) * sinc_scale_factor;
+
+      // Compute Blackman window, matching the offset of the sinc().
+      double x = (i - subsample_offset) / kKernelSize;
+      double window =
+          kA0 - kA1 * cos(2.0 * M_PI * x) + kA2 * cos(4.0 * M_PI * x);
+
+      // Window the sinc() function and store at the correct offset.
+      kernel_storage_[i + offset_idx * kKernelSize] = sinc * window;
+    }
+  }
 }
 
 void InterleavedSincResampler::Read(float* destination, int frames) {

--- a/starboard/shared/starboard/player/job_thread.cc
+++ b/starboard/shared/starboard/player/job_thread.cc
@@ -61,10 +61,6 @@ std::unique_ptr<JobThread> JobThread::Create(std::string_view thread_name,
       new JobThread(std::move(thread), std::move(job_queue)));
 }
 
-JobThread::JobThread(std::unique_ptr<WorkerThread> thread,
-                     std::unique_ptr<JobQueue> job_queue)
-    : thread_(std::move(thread)), job_queue_(std::move(job_queue)) {}
-
 JobThread::~JobThread() {
   std::lock_guard lock(stop_mutex_);
   SB_CHECK(stopped_)
@@ -91,5 +87,9 @@ void JobThread::Stop() {
   job_queue_->StopSoon();
   thread_->Join();
 }
+
+JobThread::JobThread(std::unique_ptr<WorkerThread> thread,
+                     std::unique_ptr<JobQueue> job_queue)
+    : thread_(std::move(thread)), job_queue_(std::move(job_queue)) {}
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/player_internal.cc
+++ b/starboard/shared/starboard/player/player_internal.cc
@@ -155,20 +155,6 @@ void SbPlayerPrivateImpl::SetVolume(double volume) {
   worker_->SetVolume(volume_);
 }
 
-void SbPlayerPrivateImpl::UpdateMediaInfo(int64_t media_time,
-                                          int dropped_video_frames,
-                                          int ticket,
-                                          bool is_progressing) {
-  std::lock_guard lock(mutex_);
-  if (ticket_ != ticket) {
-    return;
-  }
-  media_time_ = media_time;
-  is_progressing_ = is_progressing;
-  media_time_updated_at_ = CurrentMonotonicTime();
-  dropped_video_frames_ = dropped_video_frames;
-}
-
 SbDecodeTarget SbPlayerPrivateImpl::GetCurrentDecodeTarget() {
   return worker_->GetCurrentDecodeTarget();
 }
@@ -228,6 +214,20 @@ SbPlayerPrivateImpl::~SbPlayerPrivateImpl() {
   --number_of_players_;
   SB_LOG(INFO) << "Destroying SbPlayerPrivateImpl. There are "
                << number_of_players_ << " players.";
+}
+
+void SbPlayerPrivateImpl::UpdateMediaInfo(int64_t media_time,
+                                          int dropped_video_frames,
+                                          int ticket,
+                                          bool is_progressing) {
+  std::lock_guard lock(mutex_);
+  if (ticket_ != ticket) {
+    return;
+  }
+  media_time_ = media_time;
+  is_progressing_ = is_progressing;
+  media_time_updated_at_ = CurrentMonotonicTime();
+  dropped_video_frames_ = dropped_video_frames;
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -43,24 +43,6 @@ DECLARE_INSTANCE_COUNTER(PlayerWorker)
 
 }  // namespace
 
-PlayerWorker::~PlayerWorker() {
-  ON_INSTANCE_RELEASED(PlayerWorker);
-
-  job_thread_->ScheduleAndWait([this] {
-    handler_->Stop();
-    handler_.reset();
-
-    if (!error_occurred_) {
-      UpdatePlayerState(kSbPlayerStateDestroyed);
-    }
-  });
-  job_thread_->Stop();
-
-  // Now the whole pipeline has been torn down and no callback will be called.
-  // The caller can ensure that upon the return of SbPlayerDestroy() all side
-  // effects are gone.
-}
-
 PlayerWorker::PlayerWorker(SbMediaAudioCodec audio_codec,
                            SbMediaVideoCodec video_codec,
                            std::unique_ptr<Handler> handler,
@@ -91,6 +73,24 @@ PlayerWorker::PlayerWorker(SbMediaAudioCodec audio_codec,
   ON_INSTANCE_CREATED(PlayerWorker);
 
   job_thread_->Schedule([this] { DoInit(); });
+}
+
+PlayerWorker::~PlayerWorker() {
+  ON_INSTANCE_RELEASED(PlayerWorker);
+
+  job_thread_->ScheduleAndWait([this] {
+    handler_->Stop();
+    handler_.reset();
+
+    if (!error_occurred_) {
+      UpdatePlayerState(kSbPlayerStateDestroyed);
+    }
+  });
+  job_thread_->Stop();
+
+  // Now the whole pipeline has been torn down and no callback will be called.
+  // The caller can ensure that upon the return of SbPlayerDestroy() all side
+  // effects are gone.
 }
 
 void PlayerWorker::UpdateMediaInfo(int64_t time,


### PR DESCRIPTION
Reorder member function definitions in Starboard player source files
to align with their declarations in corresponding header files. This
improves code consistency and readability across the player modules.

Bug: 276483058