### PR TITLE
android: Reorder member functions in Starboard Android

### DIFF
--- a/starboard/android/shared/asset_manager.cc
+++ b/starboard/android/shared/asset_manager.cc
@@ -74,30 +74,6 @@ std::string FallbackPath(const std::string& path) {
 // static
 SB_ONCE_INITIALIZE_FUNCTION(AssetManager, AssetManager::GetInstance)
 
-AssetManager::AssetManager() {
-  const int kPathSize = PATH_MAX / 2;
-  char path[kPathSize] = {0};
-  SB_CHECK(SbSystemGetPath(kSbSystemPathTempDirectory, path, kPathSize))
-      << "Unable to get system temp path for AssetManager.";
-  SB_CHECK_LT(starboard::strlcat(path, "/asset_tmp", kPathSize), kPathSize)
-      << "Unable to construct temp path for AssetManager.";
-  tmp_root_ = path;
-  ClearTempDir();
-}
-
-uint64_t AssetManager::AcquireInternalFd() {
-  std::lock_guard scoped_lock(mutex_);
-  do {
-    ++internal_fd_;
-  } while (in_use_internal_fd_set_.count(internal_fd_) == 1);
-  in_use_internal_fd_set_.insert(internal_fd_);
-  return internal_fd_;
-}
-
-std::string AssetManager::TempFilepath(uint64_t internal_fd) const {
-  return tmp_root_ + "/" + std::to_string(internal_fd);
-}
-
 int AssetManager::Open(const char* path, int oflag) {
   if (!path) {
     return -1;
@@ -145,11 +121,6 @@ int AssetManager::Open(const char* path, int oflag) {
   return fd;
 }
 
-bool AssetManager::IsAssetFd(int fd) const {
-  std::lock_guard scoped_lock(mutex_);
-  return fd_to_internal_fd_map_.count(fd) == 1;
-}
-
 int AssetManager::Close(int fd) {
   mutex_.Acquire();
   if (auto search = fd_to_internal_fd_map_.find(fd);
@@ -167,6 +138,35 @@ int AssetManager::Close(int fd) {
   }
   mutex_.Release();
   return -1;
+}
+
+bool AssetManager::IsAssetFd(int fd) const {
+  std::lock_guard scoped_lock(mutex_);
+  return fd_to_internal_fd_map_.count(fd) == 1;
+}
+
+AssetManager::AssetManager() {
+  const int kPathSize = PATH_MAX / 2;
+  char path[kPathSize] = {0};
+  SB_CHECK(SbSystemGetPath(kSbSystemPathTempDirectory, path, kPathSize))
+      << "Unable to get system temp path for AssetManager.";
+  SB_CHECK_LT(starboard::strlcat(path, "/asset_tmp", kPathSize), kPathSize)
+      << "Unable to construct temp path for AssetManager.";
+  tmp_root_ = path;
+  ClearTempDir();
+}
+
+uint64_t AssetManager::AcquireInternalFd() {
+  std::lock_guard scoped_lock(mutex_);
+  do {
+    ++internal_fd_;
+  } while (in_use_internal_fd_set_.count(internal_fd_) == 1);
+  in_use_internal_fd_set_.insert(internal_fd_);
+  return internal_fd_;
+}
+
+std::string AssetManager::TempFilepath(uint64_t internal_fd) const {
+  return tmp_root_ + "/" + std::to_string(internal_fd);
 }
 
 void AssetManager::ClearTempDir() {

--- a/starboard/android/shared/audio_output_manager.cc
+++ b/starboard/android/shared/audio_output_manager.cc
@@ -139,13 +139,6 @@ SbMediaAudioConnector GetConnectorFromAndroidOutputType(
 }
 }  // namespace
 
-AudioOutputManager::AudioOutputManager() {
-  JNIEnv* env = jni_zero::AttachCurrentThread();
-  SB_DCHECK(env);
-  j_audio_output_manager_ =
-      StarboardBridge::GetInstance()->GetAudioOutputManager(env);
-}
-
 SB_EXPORT_ANDROID AudioOutputManager* AudioOutputManager::GetInstance() {
   return base::Singleton<AudioOutputManager>::get();
 }
@@ -253,6 +246,13 @@ bool AudioOutputManager::GetAudioConfiguration(
   }
 
   return true;
+}
+
+AudioOutputManager::AudioOutputManager() {
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+  SB_DCHECK(env);
+  j_audio_output_manager_ =
+      StarboardBridge::GetInstance()->GetAudioOutputManager(env);
 }
 
 void JNI_AudioOutputManager_OnAudioDeviceChanged(JNIEnv* env) {

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -192,10 +192,6 @@ AudioTrackAudioSink::AudioTrackAudioSink(
   SB_LOG(INFO) << "Creating audio sink starts at " << start_time_;
 }
 
-void AudioTrackAudioSink::SpawnThread() {
-  audio_out_thread_->Start();
-}
-
 AudioTrackAudioSink::~AudioTrackAudioSink() {
   quit_ = true;
 
@@ -217,6 +213,18 @@ void AudioTrackAudioSink::SetPlaybackRate(double playback_rate) {
     // mode. It will be no-op for non tunnel player.
     bridge_->SetPlaybackRate(playback_rate);
   }
+}
+
+void AudioTrackAudioSink::SetVolume(double volume) {
+  bridge_->SetVolume(volume);
+}
+
+int AudioTrackAudioSink::GetUnderrunCount() {
+  return bridge_->GetUnderrunCount();
+}
+
+int AudioTrackAudioSink::GetStartThresholdInFrames() {
+  return bridge_->GetStartThresholdInFrames();
 }
 
 // TODO: Break down the function into manageable pieces.
@@ -421,6 +429,10 @@ void AudioTrackAudioSink::AudioThreadFunc() {
   bridge_->PauseAndFlush();
 }
 
+void AudioTrackAudioSink::SpawnThread() {
+  audio_out_thread_->Start();
+}
+
 int AudioTrackAudioSink::WriteData(JNIEnv* env,
                                    const void* buffer,
                                    int expected_written_frames,
@@ -455,18 +467,6 @@ void AudioTrackAudioSink::ReportError(bool capability_changed,
 
 int64_t AudioTrackAudioSink::GetFramesDurationUs(int frames) const {
   return frames * 1'000'000LL / sampling_frequency_hz_;
-}
-
-void AudioTrackAudioSink::SetVolume(double volume) {
-  bridge_->SetVolume(volume);
-}
-
-int AudioTrackAudioSink::GetUnderrunCount() {
-  return bridge_->GetUnderrunCount();
-}
-
-int AudioTrackAudioSink::GetStartThresholdInFrames() {
-  return bridge_->GetStartThresholdInFrames();
 }
 
 // static

--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -104,25 +104,6 @@ DrmSystem::DrmSystem(PassKey<DrmSystem>,
   }
 }
 
-void DrmSystem::Run() {
-  SB_CHECK(!enable_app_provisioning_);
-
-  if (media_drm_bridge_->CreateMediaCryptoSession()) {
-    created_media_crypto_session_.store(true);
-  } else {
-    SB_LOG(INFO) << "Could not create media crypto session";
-    return;
-  }
-
-  std::lock_guard scoped_lock(mutex_);
-  if (!deferred_session_update_requests_.empty()) {
-    for (const auto& update_request : deferred_session_update_requests_) {
-      update_request->Generate(media_drm_bridge_.get());
-    }
-    deferred_session_update_requests_.clear();
-  }
-}
-
 DrmSystem::~DrmSystem() {
   ON_INSTANCE_RELEASED(AndroidDrmSystem);
   if (!enable_app_provisioning_) {
@@ -184,44 +165,6 @@ void DrmSystem::GenerateSessionUpdateRequest(int ticket,
   // |onSessionMessage|.
 }
 
-void DrmSystem::GenerateSessionUpdateRequestWithAppProvisioning(
-    std::unique_ptr<SessionUpdateRequest> request) {
-  SB_CHECK(enable_app_provisioning_);
-
-  {
-    std::lock_guard scoped_lock(mutex_);
-    if (!deferred_session_update_requests_.empty()) {
-      SB_LOG(INFO)
-          << "A provisioning request is in progress. Defer this request.";
-      deferred_session_update_requests_.push_back(std::move(request));
-      return;
-    }
-  }
-
-  SB_LOG(INFO) << __func__;
-  // |update_request_callback_| will be called asynchronously by Java calling
-  // into |OnSessionUpdate| or |OnProvisioningRequest|.
-  MediaDrmBridge::OperationResult result =
-      request->GenerateWithAppProvisioning(media_drm_bridge_.get());
-  switch (result.status) {
-    case DRM_OPERATION_STATUS_SUCCESS:
-      created_media_crypto_session_ = true;
-      return;
-    case DRM_OPERATION_STATUS_NOT_PROVISIONED:
-      SB_LOG(INFO) << "Device is not provisioned. Generating provision request";
-      {
-        std::lock_guard scoped_lock(mutex_);
-        deferred_session_update_requests_.push_back(std::move(request));
-      }
-      OnProvisioningRequest(media_drm_bridge_->GenerateProvisionRequest());
-      return;
-    case DRM_OPERATION_STATUS_OPERATION_FAILED:
-    default:
-      SB_LOG(ERROR) << "GenerateWithAppProvisioning failed: " << result;
-      return;
-  }
-}
-
 void DrmSystem::UpdateSession(int ticket,
                               const void* key,
                               int key_size,
@@ -243,61 +186,6 @@ void DrmSystem::UpdateSession(int ticket,
       this, context_, ticket,
       result.ok() ? kSbDrmStatusSuccess : kSbDrmStatusUnknownError,
       result.error_message.c_str(), session_id, session_id_size);
-}
-
-void DrmSystem::UpdateSessionWithAppProvisioning(int ticket,
-                                                 std::string_view key,
-                                                 std::string_view session_id) {
-  SB_CHECK(enable_app_provisioning_);
-
-  const auto media_drm_session_id =
-      [this, &session_id]() -> std::optional<std::string> {
-    std::lock_guard lock(mutex_);
-    if (!deferred_session_update_requests_.empty()) {
-      return std::nullopt;
-    }
-    return std::string(session_id_mapper_->GetMediaDrmSessionId(session_id));
-  }();
-
-  bool provisioning_ok = false;
-  const MediaDrmBridge::OperationResult result = [this, ticket, key,
-                                                  media_drm_session_id,
-                                                  &provisioning_ok]() {
-    if (!media_drm_session_id) {
-      SB_LOG(INFO) << " >  Handles the given key as provision response.";
-      auto result = media_drm_bridge_->ProvideProvisionResponse(key);
-      if (result.ok()) {
-        provisioning_ok = true;
-      }
-      return result;
-    }
-
-    return media_drm_bridge_->UpdateSession(ticket, key, *media_drm_session_id);
-  }();
-
-  SB_LOG_IF(ERROR, !result.ok()) << "UpdateSession failed: " << result;
-
-  callbacks_.session_updated(
-      this, context_, ticket,
-      result.ok() ? kSbDrmStatusSuccess : kSbDrmStatusUnknownError,
-      result.error_message.c_str(), session_id.data(), session_id.size());
-
-  if (provisioning_ok) {
-    HandlePendingRequests();
-  }
-}
-
-void DrmSystem::HandlePendingRequests() {
-  SB_LOG(INFO) << __func__;
-  std::vector<std::unique_ptr<SessionUpdateRequest>> pending_requests;
-  {
-    std::lock_guard scoped_lock(mutex_);
-    pending_requests.swap(deferred_session_update_requests_);
-  }
-
-  for (auto& request : pending_requests) {
-    GenerateSessionUpdateRequestWithAppProvisioning(std::move(request));
-  }
 }
 
 void DrmSystem::CloseSession(const void* session_id_data, int session_id_size) {
@@ -432,6 +320,10 @@ void DrmSystem::OnInsufficientOutputProtection() {
   CallKeyStatusesChangedCallbackWithKeyStatusRestricted_Locked();
 }
 
+bool DrmSystem::IsReady() {
+  return created_media_crypto_session_.load();
+}
+
 void DrmSystem::CallKeyStatusesChangedCallbackWithKeyStatusRestricted_Locked() {
   for (auto& iter : cached_drm_key_ids_) {
     const std::string& session_id = iter.first;
@@ -446,8 +338,116 @@ void DrmSystem::CallKeyStatusesChangedCallbackWithKeyStatusRestricted_Locked() {
   }
 }
 
-bool DrmSystem::IsReady() {
-  return created_media_crypto_session_.load();
+void DrmSystem::HandlePendingRequests() {
+  SB_LOG(INFO) << __func__;
+  std::vector<std::unique_ptr<SessionUpdateRequest>> pending_requests;
+  {
+    std::lock_guard scoped_lock(mutex_);
+    pending_requests.swap(deferred_session_update_requests_);
+  }
+
+  for (auto& request : pending_requests) {
+    GenerateSessionUpdateRequestWithAppProvisioning(std::move(request));
+  }
+}
+
+void DrmSystem::GenerateSessionUpdateRequestWithAppProvisioning(
+    std::unique_ptr<SessionUpdateRequest> request) {
+  SB_CHECK(enable_app_provisioning_);
+
+  {
+    std::lock_guard scoped_lock(mutex_);
+    if (!deferred_session_update_requests_.empty()) {
+      SB_LOG(INFO)
+          << "A provisioning request is in progress. Defer this request.";
+      deferred_session_update_requests_.push_back(std::move(request));
+      return;
+    }
+  }
+
+  SB_LOG(INFO) << __func__;
+  // |update_request_callback_| will be called asynchronously by Java calling
+  // into |OnSessionUpdate| or |OnProvisioningRequest|.
+  MediaDrmBridge::OperationResult result =
+      request->GenerateWithAppProvisioning(media_drm_bridge_.get());
+  switch (result.status) {
+    case DRM_OPERATION_STATUS_SUCCESS:
+      created_media_crypto_session_ = true;
+      return;
+    case DRM_OPERATION_STATUS_NOT_PROVISIONED:
+      SB_LOG(INFO) << "Device is not provisioned. Generating provision request";
+      {
+        std::lock_guard scoped_lock(mutex_);
+        deferred_session_update_requests_.push_back(std::move(request));
+      }
+      OnProvisioningRequest(media_drm_bridge_->GenerateProvisionRequest());
+      return;
+    case DRM_OPERATION_STATUS_OPERATION_FAILED:
+    default:
+      SB_LOG(ERROR) << "GenerateWithAppProvisioning failed: " << result;
+      return;
+  }
+}
+
+void DrmSystem::UpdateSessionWithAppProvisioning(int ticket,
+                                                 std::string_view key,
+                                                 std::string_view session_id) {
+  SB_CHECK(enable_app_provisioning_);
+
+  const auto media_drm_session_id =
+      [this, &session_id]() -> std::optional<std::string> {
+    std::lock_guard lock(mutex_);
+    if (!deferred_session_update_requests_.empty()) {
+      return std::nullopt;
+    }
+    return std::string(session_id_mapper_->GetMediaDrmSessionId(session_id));
+  }();
+
+  bool provisioning_ok = false;
+  const MediaDrmBridge::OperationResult result = [this, ticket, key,
+                                                  media_drm_session_id,
+                                                  &provisioning_ok]() {
+    if (!media_drm_session_id) {
+      SB_LOG(INFO) << " >  Handles the given key as provision response.";
+      auto result = media_drm_bridge_->ProvideProvisionResponse(key);
+      if (result.ok()) {
+        provisioning_ok = true;
+      }
+      return result;
+    }
+
+    return media_drm_bridge_->UpdateSession(ticket, key, *media_drm_session_id);
+  }();
+
+  SB_LOG_IF(ERROR, !result.ok()) << "UpdateSession failed: " << result;
+
+  callbacks_.session_updated(
+      this, context_, ticket,
+      result.ok() ? kSbDrmStatusSuccess : kSbDrmStatusUnknownError,
+      result.error_message.c_str(), session_id.data(), session_id.size());
+
+  if (provisioning_ok) {
+    HandlePendingRequests();
+  }
+}
+
+void DrmSystem::Run() {
+  SB_CHECK(!enable_app_provisioning_);
+
+  if (media_drm_bridge_->CreateMediaCryptoSession()) {
+    created_media_crypto_session_.store(true);
+  } else {
+    SB_LOG(INFO) << "Could not create media crypto session";
+    return;
+  }
+
+  std::lock_guard scoped_lock(mutex_);
+  if (!deferred_session_update_requests_.empty()) {
+    for (const auto& update_request : deferred_session_update_requests_) {
+      update_request->Generate(media_drm_bridge_.get());
+    }
+    deferred_session_update_requests_.clear();
+  }
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -336,18 +336,6 @@ bool VideoCodecCapability::AreResolutionAndRateSupported(int frame_width,
 SB_ONCE_INITIALIZE_FUNCTION(MediaCapabilitiesCache,
                             MediaCapabilitiesCache::GetInstance)
 
-MediaCapabilitiesCache::MediaCapabilitiesCache()
-    : MediaCapabilitiesCache(
-          std::make_unique<MediaCapabilitiesProviderImpl>()) {}
-
-MediaCapabilitiesCache::MediaCapabilitiesCache(
-    std::unique_ptr<MediaCapabilitiesProvider> media_capabilities_provider)
-    : media_capabilities_provider_(std::move(media_capabilities_provider)) {
-  // Enable mime and key system caches.
-  MimeSupportabilityCache::GetInstance()->SetCacheEnabled(true);
-  KeySystemSupportabilityCache::GetInstance()->SetCacheEnabled(true);
-}
-
 bool MediaCapabilitiesCache::IsWidevineSupported() {
   if (!is_enabled_) {
     return media_capabilities_provider_->GetIsWidevineSupported();
@@ -555,6 +543,18 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
   }
 
   return "";
+}
+
+MediaCapabilitiesCache::MediaCapabilitiesCache()
+    : MediaCapabilitiesCache(
+          std::make_unique<MediaCapabilitiesProviderImpl>()) {}
+
+MediaCapabilitiesCache::MediaCapabilitiesCache(
+    std::unique_ptr<MediaCapabilitiesProvider> media_capabilities_provider)
+    : media_capabilities_provider_(std::move(media_capabilities_provider)) {
+  // Enable mime and key system caches.
+  MimeSupportabilityCache::GetInstance()->SetCacheEnabled(true);
+  KeySystemSupportabilityCache::GetInstance()->SetCacheEnabled(true);
 }
 
 void MediaCapabilitiesCache::UpdateMediaCapabilities_Locked() {

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -496,6 +496,12 @@ void MediaCodecBridge::OnMediaCodecFirstTunnelFrameReady(JNIEnv* env) {
   handler_->OnMediaCodecFirstTunnelFrameReady();
 }
 
+// static
+jboolean MediaCodecBridge::IsFrameRenderedCallbackEnabled() {
+  JNIEnv* env = AttachCurrentThread();
+  return Java_MediaCodecBridge_isFrameRenderedCallbackEnabled(env);
+}
+
 MediaCodecBridge::MediaCodecBridge(Handler* handler) : handler_(handler) {
   SB_CHECK(handler_);
 }
@@ -505,12 +511,6 @@ void MediaCodecBridge::Initialize(jobject j_media_codec_bridge) {
 
   JNIEnv* env = AttachCurrentThread();
   j_media_codec_bridge_.Reset(env, j_media_codec_bridge);
-}
-
-// static
-jboolean MediaCodecBridge::IsFrameRenderedCallbackEnabled() {
-  JNIEnv* env = AttachCurrentThread();
-  return Java_MediaCodecBridge_isFrameRenderedCallbackEnabled(env);
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -344,6 +344,61 @@ void MediaCodecDecoder::SetPlaybackRate(double playback_rate) {
   media_codec_bridge_->SetPlaybackRate(playback_rate);
 }
 
+bool MediaCodecDecoder::Flush() {
+  SB_CHECK(thread_checker_.CalledOnValidThread());
+
+  // Try to flush if we can, otherwise return |false| to recreate the codec
+  // completely. Flush() is called by `player_worker` thread,
+  // but MediaCodecDecoder is on `audio_decoder` and `video_decoder`
+  // threads, let `player_worker` destroy `audio_decoder` and
+  // `video_decoder` threads to clean up all pending tasks,
+  // and Flush()/Start() |media_codec_bridge_|.
+
+  // 1. Terminate `audio_decoder` or `video_decoder` thread.
+  TerminateDecoderThread();
+
+  // 2. Flush()/Start() |media_codec_bridge_| and clean up pending tasks.
+  // 2.1. Flush() |media_codec_bridge_|.
+  host_->OnFlushing();
+  jint status = media_codec_bridge_->Flush();
+  if (status != MEDIA_CODEC_OK) {
+    SB_LOG(ERROR) << "Failed to flush media codec.";
+    return false;
+  }
+
+  // 2.2. Clean up pending_inputs and input_buffer/output_buffer indices.
+  number_of_pending_inputs_.store(0);
+  pending_inputs_.clear();
+  input_buffer_indices_.clear();
+  dequeue_output_results_.clear();
+  pending_input_to_retry_ = std::nullopt;
+
+  // 2.3. Add OutputFormatChanged to get current output format after Flush().
+  DequeueOutputResult dequeue_output_result = {};
+  dequeue_output_result.index = -1;
+  dequeue_output_results_.push_back(dequeue_output_result);
+
+  // 2.4. Wait for |flush_delay_usec_| on pre Android 13 devices.
+  if (flush_delay_usec_ > 0) {
+    usleep(flush_delay_usec_);
+  }
+
+  // 2.5. Restart() |media_codec_bridge_|. As the codec is configured in
+  // asynchronous mode, call Start() after Flush() has returned to
+  // resume codec operations. After Restart(), input_buffer_index should
+  // start with 0.
+  if (!media_codec_bridge_->Restart()) {
+    SB_LOG(ERROR) << "Failed to start media codec.";
+    return false;
+  }
+
+  // 3. Recreate `audio_decoder` and `video_decoder` threads in
+  // WriteInputBuffers().
+  stream_ended_.store(false);
+  destroying_.store(false);
+  return true;
+}
+
 // TODO(b/329686979): Abstract common code of thread creation functions.
 void MediaCodecDecoder::DecoderThreadFunc() {
   // Initialize() should be called before creating the thread, where `error_cb_`
@@ -932,61 +987,6 @@ void MediaCodecDecoder::OnMediaCodecFirstTunnelFrameReady() {
   SB_DCHECK(tunnel_mode_enabled_);
 
   first_tunnel_frame_ready_cb_();
-}
-
-bool MediaCodecDecoder::Flush() {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
-
-  // Try to flush if we can, otherwise return |false| to recreate the codec
-  // completely. Flush() is called by `player_worker` thread,
-  // but MediaCodecDecoder is on `audio_decoder` and `video_decoder`
-  // threads, let `player_worker` destroy `audio_decoder` and
-  // `video_decoder` threads to clean up all pending tasks,
-  // and Flush()/Start() |media_codec_bridge_|.
-
-  // 1. Terminate `audio_decoder` or `video_decoder` thread.
-  TerminateDecoderThread();
-
-  // 2. Flush()/Start() |media_codec_bridge_| and clean up pending tasks.
-  // 2.1. Flush() |media_codec_bridge_|.
-  host_->OnFlushing();
-  jint status = media_codec_bridge_->Flush();
-  if (status != MEDIA_CODEC_OK) {
-    SB_LOG(ERROR) << "Failed to flush media codec.";
-    return false;
-  }
-
-  // 2.2. Clean up pending_inputs and input_buffer/output_buffer indices.
-  number_of_pending_inputs_.store(0);
-  pending_inputs_.clear();
-  input_buffer_indices_.clear();
-  dequeue_output_results_.clear();
-  pending_input_to_retry_ = std::nullopt;
-
-  // 2.3. Add OutputFormatChanged to get current output format after Flush().
-  DequeueOutputResult dequeue_output_result = {};
-  dequeue_output_result.index = -1;
-  dequeue_output_results_.push_back(dequeue_output_result);
-
-  // 2.4. Wait for |flush_delay_usec_| on pre Android 13 devices.
-  if (flush_delay_usec_ > 0) {
-    usleep(flush_delay_usec_);
-  }
-
-  // 2.5. Restart() |media_codec_bridge_|. As the codec is configured in
-  // asynchronous mode, call Start() after Flush() has returned to
-  // resume codec operations. After Restart(), input_buffer_index should
-  // start with 0.
-  if (!media_codec_bridge_->Restart()) {
-    SB_LOG(ERROR) << "Failed to start media codec.";
-    return false;
-  }
-
-  // 3. Recreate `audio_decoder` and `video_decoder` threads in
-  // WriteInputBuffers().
-  stream_ended_.store(false);
-  destroying_.store(false);
-  return true;
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -45,7 +45,6 @@
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
-
 namespace {
 
 using jni_zero::AttachCurrentThread;
@@ -241,6 +240,126 @@ bool IsIdentity(const SbMediaColorMetadata& color_metadata) {
          Equal(color_metadata.mastering_metadata, kEmptyMasteringMetadata);
 }
 
+void UpdateTexImage(const JavaRef<jobject>& surface_texture) {
+  JNIEnv* env = AttachCurrentThread();
+
+  VideoSurfaceTextureBridge::UpdateTexImage(env, surface_texture);
+}
+
+void GetTransformMatrix(const JavaRef<jobject>& surface_texture,
+                        float* matrix4x4) {
+  JNIEnv* env = AttachCurrentThread();
+
+  jni_zero::ScopedJavaLocalRef<jfloatArray> java_array(env,
+                                                       env->NewFloatArray(16));
+  SB_CHECK(java_array);
+
+  VideoSurfaceTextureBridge::GetTransformMatrix(
+      env, surface_texture,
+      jni_zero::JavaParamRef<jfloatArray>(env, java_array.obj()));
+
+  env->GetFloatArrayRegion(java_array.obj(), 0, 16, matrix4x4);
+}
+
+// Converts a 4x4 matrix representing the texture coordinate transform into
+// an equivalent rectangle representing the region within the texture where
+// the pixel data is valid.  Note that the width and height of this region may
+// be negative to indicate that that axis should be flipped.
+// This function also infers the coded size of the texture from the matrix
+// and the display size.
+SbDecodeTargetInfoContentRegion GetDecodeTargetContentRegionFromMatrix(
+    const float* matrix4x4,
+    const Size& display_size,
+    Size* out_coded_size) {
+  // Ensure that this matrix contains no rotations or shears.  In other words,
+  // make sure that we can convert it to a decode target content region without
+  // losing any information.
+  const float kEpsilon = 1e-6f;
+  SB_DCHECK_LT(std::abs(matrix4x4[1]), kEpsilon);
+  SB_DCHECK_LT(std::abs(matrix4x4[2]), kEpsilon);
+  SB_DCHECK_LT(std::abs(matrix4x4[3]), kEpsilon);
+
+  SB_DCHECK_LT(std::abs(matrix4x4[4]), kEpsilon);
+  SB_DCHECK_LT(std::abs(matrix4x4[6]), kEpsilon);
+  SB_DCHECK_LT(std::abs(matrix4x4[7]), kEpsilon);
+
+  SB_DCHECK_LT(std::abs(matrix4x4[8]), kEpsilon);
+  SB_DCHECK_LT(std::abs(matrix4x4[9]), kEpsilon);
+  SB_DCHECK_LT(std::abs(matrix4x4[10] - 1.0f), kEpsilon);
+  SB_DCHECK_LT(std::abs(matrix4x4[11]), kEpsilon);
+
+  SB_DCHECK_LT(std::abs(matrix4x4[14]), kEpsilon);
+  SB_DCHECK_LT(std::abs(matrix4x4[15] - 1.0f), kEpsilon);
+
+  float raw_sx = matrix4x4[0];
+  float raw_sy = matrix4x4[5];
+
+  float tx = raw_sx > 0 ? matrix4x4[12] : (raw_sx + matrix4x4[12]);
+  float ty = raw_sy > 0 ? matrix4x4[13] : (raw_sy + matrix4x4[13]);
+
+  float sx = std::abs(raw_sx);
+  float sy = std::abs(raw_sy);
+
+  Size coded_size = display_size;
+  int visible_x = 0;
+  int visible_y = 0;
+
+  if (sx > kEpsilon && sy > kEpsilon) {
+    const float possible_shrinks_amounts[] = {1.0f, 0.5f, 0.0f};
+    for (const float& shrink_amount : possible_shrinks_amounts) {
+      if (sx < 1.0f) {
+        coded_size.width =
+            std::round((display_size.width - 2.0f * shrink_amount) / sx);
+        visible_x = std::round(tx * coded_size.width - shrink_amount);
+      }
+      if (sy < 1.0f) {
+        coded_size.height =
+            std::round((display_size.height - 2.0f * shrink_amount) / sy);
+        visible_y = std::round(ty * coded_size.height - shrink_amount);
+      }
+
+      if (visible_x >= 0 && visible_y >= 0) {
+        break;
+      }
+    }
+  }
+
+  if (out_coded_size) {
+    *out_coded_size = coded_size;
+  }
+
+  SbDecodeTargetInfoContentRegion content_region;
+
+  // Create a base content region using the derived visible_x/y and
+  // display_size. The matrix produced by SurfaceTexture already maps to a
+  // top-down coordinate system (relative to the upper-left corner of the
+  // image), so visible_x/y are the top-left pixel offsets.
+  float left = visible_x;
+  float right = visible_x + display_size.width;
+  float top = visible_y;
+  float bottom = visible_y + display_size.height;
+
+  // The Android matrix usually includes a vertical flip because GL's origin
+  // is bottom-left. In our derived top-down pixel space:
+  // - If raw_sx < 0, the image is horizontally flipped.
+  // - If raw_sy > 0, the image is vertically flipped (standard for
+  // SurfaceTexture). We swap the coordinates to signal these flips to the
+  // Starboard renderer.
+  if (raw_sx < 0) {
+    std::swap(left, right);
+  }
+  if (raw_sy > 0) {
+    std::swap(top, bottom);
+  }
+
+  content_region.left = left;
+  content_region.right = right;
+  content_region.top = top;
+  content_region.bottom = bottom;
+
+  return content_region;
+}
+
 void StubDrmSessionUpdateRequestFunc(SbDrmSystem drm_system,
                                      void* context,
                                      int ticket,
@@ -272,6 +391,7 @@ void StubDrmSessionKeyStatusesChangedFunc(SbDrmSystem drm_system,
 const DrmSystem::Callbacks kStubDrmSystemCallbacks = {
     StubDrmSessionUpdateRequestFunc, StubDrmSessionUpdatedFunc,
     StubDrmSessionKeyStatusesChangedFunc};
+
 }  // namespace
 
 // TODO: Merge this with VideoFrameTracker, maybe?
@@ -686,48 +806,6 @@ void MediaCodecVideoDecoder::WriteEndOfStream() {
   media_decoder_->WriteEndOfStream();
 }
 
-void MediaCodecVideoDecoder::ResetInternal(bool skip_flush) {
-  SB_CHECK(BelongsToCurrentThread());
-
-  // If fail to flush |media_decoder_| or |media_decoder_| is null, then
-  // re-create |media_decoder_|. If |needs_fps_to_initialize_codec_| is true,
-  // set video_fps_ to 0 will call InitializeCodec(),
-  // which we do not need if flush the codec.
-  if (!enable_flush_during_seek_ || skip_flush || !media_decoder_ ||
-      !media_decoder_->Flush()) {
-    TeardownCodec();
-    if (reset_delay_usec_ > 0) {
-      usleep(reset_delay_usec_);
-    }
-
-    // Note that |input_buffer_written_| may not be strictly accurate after
-    // Flush() since it counts all buffers written since codec initialization.
-    // This is acceptable because it is used to estimate pre-roll frames, and
-    // retaining its accumulated value correctly signals that we are past the
-    // initial pre-roll phase after a Flush().
-    input_buffer_written_ = 0;
-    video_fps_ = 0;
-  }
-  CancelPendingJobs();
-
-  // TODO(b/291959069): After flush |media_decoder_|, the output buffers
-  // may have invalid frames. Reset |output_format_| to null here to skip max
-  // output buffers check.
-  decoded_output_frames_ = 0;
-  output_format_ = std::nullopt;
-
-  tunnel_mode_prerolling_.store(true);
-  tunnel_mode_first_frame_rendered_.store(false);
-  tunnel_mode_prerolled_frames_.store(0);
-  end_of_stream_written_ = false;
-  pending_input_buffers_.clear();
-
-  // TODO: We rely on VideoRenderAlgorithmTunneled::Seek() to be called inside
-  //       VideoRenderer::Seek() after calling MediaCodecVideoDecoder::Reset()
-  //       to update the seek status of |video_frame_tracker_|.  This is
-  //       slightly flaky as it depends on the behavior of the video renderer.
-}
-
 void MediaCodecVideoDecoder::Reset() {
   ResetInternal(/*skip_flush=*/false);
 }
@@ -735,461 +813,6 @@ void MediaCodecVideoDecoder::Reset() {
 void MediaCodecVideoDecoder::ResetForTeardown() {
   ResetInternal(skip_flush_on_decoder_teardown_);
 }
-
-Result<void> MediaCodecVideoDecoder::InitializeCodec(
-    const VideoStreamInfo& video_stream_info) {
-  SB_CHECK(BelongsToCurrentThread());
-
-  if (needs_fps_to_initialize_codec_) {
-    SB_DCHECK_GT(pending_input_buffers_.size(), 0u);
-
-    // Guesstimate the video fps.
-    if (pending_input_buffers_.size() == 1) {
-      video_fps_ = 30;
-    } else {
-      int64_t first_timestamp = pending_input_buffers_[0]->timestamp();
-      int64_t second_timestamp = pending_input_buffers_[1]->timestamp();
-      if (pending_input_buffers_.size() > 2) {
-        second_timestamp =
-            std::min(second_timestamp, pending_input_buffers_[2]->timestamp());
-      }
-      int64_t frame_duration = second_timestamp - first_timestamp;
-      if (frame_duration > 0) {
-        // To avoid problems caused by deviation of fps calculation, we use the
-        // nearest multiple of 5 to check codec capability. So, the fps like 61,
-        // 62 will be capped to 60, and 24 will be increased to 25.
-        const double kFpsMinDifference = 5;
-        video_fps_ =
-            std::round(1'000'000LL / (second_timestamp - first_timestamp) /
-                       kFpsMinDifference) *
-            kFpsMinDifference;
-      } else {
-        video_fps_ = 30;
-      }
-    }
-    SB_DCHECK_GT(video_fps_, 0);
-  }
-
-  // Setup the output surface object.  If we are in punch-out mode, target
-  // the passed in Android video surface.  If we are in decode-to-texture
-  // mode, create a surface from a new texture target and use that as the
-  // output surface.
-  jobject j_output_surface = NULL;
-  switch (output_mode_) {
-    case kSbPlayerOutputModePunchOut: {
-      if (surface_view_) {
-        j_output_surface = static_cast<jobject>(surface_view_);
-      } else {
-        j_output_surface = AcquireVideoSurface();
-      }
-      if (j_output_surface) {
-        owns_video_surface_ = true;
-      }
-    } break;
-    case kSbPlayerOutputModeDecodeToTexture: {
-      // A width and height of (0, 0) is provided here because Android doesn't
-      // actually allocate any memory into the texture at this time.  That is
-      // done behind the scenes, the acquired texture is not actually backed
-      // by texture data until updateTexImage() is called on it.
-      if (!decode_target_graphics_context_provider_) {
-        return Failure("Invalid decode target graphics context provider.");
-      }
-      DecodeTarget* decode_target =
-          new DecodeTarget(decode_target_graphics_context_provider_);
-      if (!SbDecodeTargetIsValid(decode_target)) {
-        return Failure("Could not acquire a decode target from provider.");
-      }
-      j_output_surface = decode_target->surface().obj();
-
-      JNIEnv* env = AttachCurrentThread();
-      surface_texture_bridge_->SetOnFrameAvailableListener(
-          env, decode_target->surface_texture());
-
-      std::lock_guard lock(decode_target_mutex_);
-      decode_target_ = decode_target;
-      // We manually call AddRef() here because `decode_target_` is stored as a
-      // raw pointer. This ensures Starboard claims its initial ownership of the
-      // target, preventing it from stealing Chromium's reference and deleting
-      // the texture prematurely during TeardownCodec().
-      decode_target_->AddRef();
-    } break;
-    case kSbPlayerOutputModeInvalid: {
-      SB_NOTREACHED();
-    } break;
-  }
-  if (!j_output_surface) {
-    return Failure("Video surface does not exist.");
-  }
-
-  if (needs_fps_to_initialize_codec_) {
-    SB_DCHECK_GT(video_fps_, 0);
-  } else {
-    SB_DCHECK_EQ(video_fps_, 0);
-  }
-
-  // TODO(b/281431214): Evaluate if we should also parse the fps from
-  //                    `max_video_capabilities_` and pass to MediaCodecDecoder
-  //                    ctor.
-  std::optional<Size> max_frame_size =
-      ParseMaxResolution(max_video_capabilities_, video_stream_info.frame_size);
-
-  auto result = MediaCodecDecoder::CreateForVideo(
-      job_queue(), /*host=*/this, video_stream_info.codec,
-      video_stream_info.frame_size, max_frame_size, video_fps_,
-      j_output_surface, drm_system_,
-      color_metadata_ ? &*color_metadata_ : nullptr, require_software_codec_,
-      std::bind(&MediaCodecVideoDecoder::OnFrameRendered, this, _1),
-      std::bind(&MediaCodecVideoDecoder::OnFirstTunnelFrameReady, this),
-      tunnel_mode_audio_session_id_, force_big_endian_hdr_metadata_,
-      max_video_input_size_, flush_delay_usec_, use_dual_threads_,
-      enable_output_checker_);
-  if (result) {
-    media_decoder_ = std::move(result.value());
-    if (error_cb_) {
-      media_decoder_->Initialize(
-          std::bind(&MediaCodecVideoDecoder::ReportError, this, _1, _2));
-    }
-    media_decoder_->SetPlaybackRate(playback_rate_);
-
-    if (needs_fps_to_initialize_codec_) {
-      SB_DCHECK(!pending_input_buffers_.empty());
-    } else {
-      SB_DCHECK(pending_input_buffers_.empty());
-    }
-    if (!pending_input_buffers_.empty()) {
-      WriteInputBuffersInternal(pending_input_buffers_);
-      pending_input_buffers_.clear();
-    }
-    return Success();
-  }
-  media_decoder_.reset();
-  return Failure("Media Decoder is not valid: " + result.error());
-}
-
-void MediaCodecVideoDecoder::TeardownCodec() {
-  SB_CHECK(BelongsToCurrentThread());
-  if (owns_video_surface_) {
-    ReleaseVideoSurface();
-    owns_video_surface_ = false;
-  }
-  media_decoder_.reset();
-  color_metadata_ = std::nullopt;
-
-  SbDecodeTarget decode_target_to_release = kSbDecodeTargetInvalid;
-  {
-    std::lock_guard lock(decode_target_mutex_);
-    if (decode_target_ != nullptr) {
-      // Remove OnFrameAvailableListener to make sure the callback
-      // would not be called.
-      JNIEnv* env = AttachCurrentThread();
-      surface_texture_bridge_->RemoveOnFrameAvailableListener(
-          env, decode_target_->surface_texture());
-
-      decode_target_to_release = decode_target_;
-      decode_target_ = nullptr;
-      first_texture_received_ = false;
-      has_new_texture_available_.store(false);
-    } else {
-      // If |decode_target_| is not created, |first_texture_received_| and
-      // |has_new_texture_available_| should always be false.
-      SB_DCHECK(!first_texture_received_);
-      SB_DCHECK(!has_new_texture_available_.load());
-    }
-  }
-  // Release SbDecodeTarget on renderer thread. As |decode_target_mutex_| may
-  // be required in renderer thread, SbDecodeTargetReleaseInGlesContext() must
-  // be called when |decode_target_mutex_| is not locked, or we may get
-  // deadlock.
-  if (SbDecodeTargetIsValid(decode_target_to_release)) {
-    SbDecodeTargetReleaseInGlesContext(decode_target_graphics_context_provider_,
-                                       decode_target_to_release);
-  }
-}
-
-void MediaCodecVideoDecoder::OnEndOfStreamWritten(
-    MediaCodecBridge* media_codec_bridge) {
-  if (tunnel_mode_audio_session_id_ == -1) {
-    return;
-  }
-
-  SB_DCHECK(decoder_status_cb_);
-
-  // TODO: Refactor the VideoDecoder and the VideoRendererImpl to improve the
-  //       handling of preroll and EOS for pure punchout decoders.
-  decoder_status_cb_(kBufferFull, VideoFrame::CreateEOSFrame());
-  sink_->Render();
-}
-
-void MediaCodecVideoDecoder::WriteInputBuffersInternal(
-    const InputBuffers& input_buffers) {
-  SB_DCHECK(!input_buffers.empty());
-
-  // There's a race condition when suspending the app. If surface view is
-  // destroyed before video decoder stopped, |media_decoder_| could be null
-  // here. And error_cb_() could be handled asynchronously. It's possible
-  // that WriteInputBuffer() is called again when the first WriteInputBuffer()
-  // fails, in such case |media_decoder_| will be null.
-  if (!media_decoder_) {
-    SB_LOG(INFO) << "Trying to write input buffer when media_decoder_ is null.";
-    return;
-  }
-
-  if (is_video_frame_tracker_enabled_) {
-    SB_DCHECK(video_frame_tracker_);
-    for (const auto& input_buffer : input_buffers) {
-      video_frame_tracker_->OnInputBuffer(input_buffer->timestamp());
-    }
-  }
-
-  media_decoder_->WriteInputBuffers(input_buffers);
-  if (media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize) {
-    decoder_status_cb_(kNeedMoreInput, NULL);
-  } else if (tunnel_mode_audio_session_id_ != -1) {
-    // In tunnel mode playback when need data is not signaled above, it is
-    // possible that the VideoDecoder won't get a chance to send kNeedMoreInput
-    // to the renderer again.  Schedule a task to check back.
-    Schedule(
-        std::bind(&MediaCodecVideoDecoder::OnTunnelModeCheckForNeedMoreInput,
-                  this),
-        kNeedMoreInputCheckIntervalInTunnelMode);
-  }
-
-  if (tunnel_mode_audio_session_id_ != -1 && tunnel_mode_prerolling_.load()) {
-    for (const auto& input_buffer : input_buffers) {
-      if (input_buffer->timestamp() >= video_frame_tracker_->seek_to_time()) {
-        tunnel_mode_prerolled_frames_++;
-      }
-    }
-    if (tunnel_mode_prerolled_frames_ >= kTunnelModePrerollFrameCount) {
-      TryToSignalPrerollForTunnelMode();
-    }
-  }
-}
-
-void MediaCodecVideoDecoder::ProcessOutputBuffer(
-    MediaCodecBridge* media_codec_bridge,
-    const DequeueOutputResult& dequeue_output_result) {
-  SB_DCHECK(decoder_status_cb_);
-  SB_DCHECK_GE(dequeue_output_result.index, 0);
-
-  bool is_end_of_stream =
-      dequeue_output_result.flags & BUFFER_FLAG_END_OF_STREAM;
-  if (!is_end_of_stream) {
-    ++decoded_output_frames_;
-    if (output_format_) {
-      ++buffered_output_frames_;
-      // We have to wait until we feed enough inputs to the decoder and receive
-      // enough outputs before update |max_buffered_output_frames_|. Otherwise,
-      // |max_buffered_output_frames_| may be updated to a very small number
-      // when we receive the first few outputs.
-      if (decoded_output_frames_ > kInitialPrerollFrameCount &&
-          buffered_output_frames_ > max_buffered_output_frames_) {
-        max_buffered_output_frames_ = buffered_output_frames_;
-        MaxMediaCodecOutputBuffersLookupTable::GetInstance()
-            ->UpdateMaxOutputBuffers(output_format_.value(),
-                                     max_buffered_output_frames_);
-      }
-    }
-  }
-  decoder_status_cb_(
-      is_end_of_stream ? kBufferFull : kNeedMoreInput,
-      new VideoFrameImpl(
-          dequeue_output_result, media_codec_bridge,
-          std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
-}
-
-void MediaCodecVideoDecoder::RefreshOutputFormat(
-    MediaCodecBridge* media_codec_bridge) {
-  SB_DCHECK(media_codec_bridge);
-  SB_DLOG(INFO) << "Output format changed, trying to dequeue again.";
-
-  std::lock_guard lock(decode_target_mutex_);
-  std::optional<FrameSize> output_size = media_codec_bridge->GetOutputSize();
-  if (!output_size) {
-    SB_LOG(WARNING)
-        << "GetOutputSize() returned null. Defaulting to an empty FrameSize.";
-    // We default to an empty FrameSize instead of propagating a failure to
-    // ensure system robustness. The calling code historically does not expect
-    // this call to fail and is not equipped to handle a null optional.
-    output_size = FrameSize();
-  }
-
-  // Record the latest dimensions of the decoded input.
-  frame_sizes_.push_back(*output_size);
-
-  if (tunnel_mode_audio_session_id_ != -1) {
-    return;
-  }
-  if (first_output_format_changed_) {
-    // After resolution changes, the output buffers may have frames of different
-    // resolutions. In that case, it's hard to determine the max supported
-    // output buffers. So, we reset |output_format_| to null here to skip max
-    // output buffers check.
-    output_format_ = std::nullopt;
-    return;
-  }
-  output_format_ =
-      VideoOutputFormat(video_codec_, frame_sizes_.back().display_size,
-                        color_metadata_.has_value());
-  first_output_format_changed_ = true;
-  auto max_output_buffers =
-      MaxMediaCodecOutputBuffersLookupTable::GetInstance()
-          ->GetMaxOutputVideoBuffers(output_format_.value());
-  if (max_output_buffers > 0 &&
-      max_output_buffers <
-          static_cast<int>(initial_number_of_preroll_frames_)) {
-    number_of_preroll_frames_ = max_output_buffers;
-  }
-}
-
-bool MediaCodecVideoDecoder::Tick(MediaCodecBridge* media_codec_bridge) {
-  // Tunnel mode renders frames in MediaCodec automatically and shouldn't reach
-  // here.
-  SB_DCHECK_EQ(tunnel_mode_audio_session_id_, -1);
-  return sink_->Render();
-}
-
-void MediaCodecVideoDecoder::OnFlushing() {
-  SB_CHECK(BelongsToCurrentThread());
-
-  if (decoder_status_cb_) {
-    decoder_status_cb_(kReleaseAllFrames, NULL);
-  }
-}
-
-bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
-    const scoped_refptr<InputBuffer>& input_buffer) {
-  if (!is_video_frame_tracker_enabled_) {
-    return false;
-  }
-
-  SB_CHECK(video_frame_tracker_);
-  return input_buffer->timestamp() < video_frame_tracker_->seek_to_time();
-}
-
-namespace {
-
-void UpdateTexImage(const JavaRef<jobject>& surface_texture) {
-  JNIEnv* env = AttachCurrentThread();
-
-  VideoSurfaceTextureBridge::UpdateTexImage(env, surface_texture);
-}
-
-void GetTransformMatrix(const JavaRef<jobject>& surface_texture,
-                        float* matrix4x4) {
-  JNIEnv* env = AttachCurrentThread();
-
-  jni_zero::ScopedJavaLocalRef<jfloatArray> java_array(env,
-                                                       env->NewFloatArray(16));
-  SB_CHECK(java_array);
-
-  VideoSurfaceTextureBridge::GetTransformMatrix(
-      env, surface_texture,
-      jni_zero::JavaParamRef<jfloatArray>(env, java_array.obj()));
-
-  env->GetFloatArrayRegion(java_array.obj(), 0, 16, matrix4x4);
-}
-
-// Converts a 4x4 matrix representing the texture coordinate transform into
-// an equivalent rectangle representing the region within the texture where
-// the pixel data is valid.  Note that the width and height of this region may
-// be negative to indicate that that axis should be flipped.
-// This function also infers the coded size of the texture from the matrix
-// and the display size.
-SbDecodeTargetInfoContentRegion GetDecodeTargetContentRegionFromMatrix(
-    const float* matrix4x4,
-    const Size& display_size,
-    Size* out_coded_size) {
-  // Ensure that this matrix contains no rotations or shears.  In other words,
-  // make sure that we can convert it to a decode target content region without
-  // losing any information.
-  const float kEpsilon = 1e-6f;
-  SB_DCHECK_LT(std::abs(matrix4x4[1]), kEpsilon);
-  SB_DCHECK_LT(std::abs(matrix4x4[2]), kEpsilon);
-  SB_DCHECK_LT(std::abs(matrix4x4[3]), kEpsilon);
-
-  SB_DCHECK_LT(std::abs(matrix4x4[4]), kEpsilon);
-  SB_DCHECK_LT(std::abs(matrix4x4[6]), kEpsilon);
-  SB_DCHECK_LT(std::abs(matrix4x4[7]), kEpsilon);
-
-  SB_DCHECK_LT(std::abs(matrix4x4[8]), kEpsilon);
-  SB_DCHECK_LT(std::abs(matrix4x4[9]), kEpsilon);
-  SB_DCHECK_LT(std::abs(matrix4x4[10] - 1.0f), kEpsilon);
-  SB_DCHECK_LT(std::abs(matrix4x4[11]), kEpsilon);
-
-  SB_DCHECK_LT(std::abs(matrix4x4[14]), kEpsilon);
-  SB_DCHECK_LT(std::abs(matrix4x4[15] - 1.0f), kEpsilon);
-
-  float raw_sx = matrix4x4[0];
-  float raw_sy = matrix4x4[5];
-
-  float tx = raw_sx > 0 ? matrix4x4[12] : (raw_sx + matrix4x4[12]);
-  float ty = raw_sy > 0 ? matrix4x4[13] : (raw_sy + matrix4x4[13]);
-
-  float sx = std::abs(raw_sx);
-  float sy = std::abs(raw_sy);
-
-  Size coded_size = display_size;
-  int visible_x = 0;
-  int visible_y = 0;
-
-  if (sx > kEpsilon && sy > kEpsilon) {
-    const float possible_shrinks_amounts[] = {1.0f, 0.5f, 0.0f};
-    for (const float& shrink_amount : possible_shrinks_amounts) {
-      if (sx < 1.0f) {
-        coded_size.width =
-            std::round((display_size.width - 2.0f * shrink_amount) / sx);
-        visible_x = std::round(tx * coded_size.width - shrink_amount);
-      }
-      if (sy < 1.0f) {
-        coded_size.height =
-            std::round((display_size.height - 2.0f * shrink_amount) / sy);
-        visible_y = std::round(ty * coded_size.height - shrink_amount);
-      }
-
-      if (visible_x >= 0 && visible_y >= 0) {
-        break;
-      }
-    }
-  }
-
-  if (out_coded_size) {
-    *out_coded_size = coded_size;
-  }
-
-  SbDecodeTargetInfoContentRegion content_region;
-
-  // Create a base content region using the derived visible_x/y and
-  // display_size. The matrix produced by SurfaceTexture already maps to a
-  // top-down coordinate system (relative to the upper-left corner of the
-  // image), so visible_x/y are the top-left pixel offsets.
-  float left = visible_x;
-  float right = visible_x + display_size.width;
-  float top = visible_y;
-  float bottom = visible_y + display_size.height;
-
-  // The Android matrix usually includes a vertical flip because GL's origin
-  // is bottom-left. In our derived top-down pixel space:
-  // - If raw_sx < 0, the image is horizontally flipped.
-  // - If raw_sy > 0, the image is vertically flipped (standard for
-  // SurfaceTexture). We swap the coordinates to signal these flips to the
-  // Starboard renderer.
-  if (raw_sx < 0) {
-    std::swap(left, right);
-  }
-  if (raw_sy > 0) {
-    std::swap(top, bottom);
-  }
-
-  content_region.left = left;
-  content_region.right = right;
-  content_region.top = top;
-  content_region.bottom = bottom;
-
-  return content_region;
-}
-
-}  // namespace
 
 // When in decode-to-texture mode, this returns the current decoded video frame.
 SbDecodeTarget MediaCodecVideoDecoder::GetCurrentDecodeTarget() {
@@ -1310,6 +933,337 @@ void MediaCodecVideoDecoder::OnFrameAvailable() {
   has_new_texture_available_.store(true);
 }
 
+Result<void> MediaCodecVideoDecoder::InitializeCodec(
+    const VideoStreamInfo& video_stream_info) {
+  SB_CHECK(BelongsToCurrentThread());
+
+  if (needs_fps_to_initialize_codec_) {
+    SB_DCHECK_GT(pending_input_buffers_.size(), 0u);
+
+    // Guesstimate the video fps.
+    if (pending_input_buffers_.size() == 1) {
+      video_fps_ = 30;
+    } else {
+      int64_t first_timestamp = pending_input_buffers_[0]->timestamp();
+      int64_t second_timestamp = pending_input_buffers_[1]->timestamp();
+      if (pending_input_buffers_.size() > 2) {
+        second_timestamp =
+            std::min(second_timestamp, pending_input_buffers_[2]->timestamp());
+      }
+      int64_t frame_duration = second_timestamp - first_timestamp;
+      if (frame_duration > 0) {
+        // To avoid problems caused by deviation of fps calculation, we use the
+        // nearest multiple of 5 to check codec capability. So, the fps like 61,
+        // 62 will be capped to 60, and 24 will be increased to 25.
+        const double kFpsMinDifference = 5;
+        video_fps_ =
+            std::round(1'000'000LL / (second_timestamp - first_timestamp) /
+                       kFpsMinDifference) *
+            kFpsMinDifference;
+      } else {
+        video_fps_ = 30;
+      }
+    }
+    SB_DCHECK_GT(video_fps_, 0);
+  }
+
+  // Setup the output surface object.  If we are in punch-out mode, target
+  // the passed in Android video surface.  If we are in decode-to-texture
+  // mode, create a surface from a new texture target and use that as the
+  // output surface.
+  jobject j_output_surface = NULL;
+  switch (output_mode_) {
+    case kSbPlayerOutputModePunchOut: {
+      if (surface_view_) {
+        j_output_surface = static_cast<jobject>(surface_view_);
+      } else {
+        j_output_surface = AcquireVideoSurface();
+      }
+      if (j_output_surface) {
+        owns_video_surface_ = true;
+      }
+    } break;
+    case kSbPlayerOutputModeDecodeToTexture: {
+      // A width and height of (0, 0) is provided here because Android doesn't
+      // actually allocate any memory into the texture at this time.  That is
+      // done behind the scenes, the acquired texture is not actually backed
+      // by texture data until UpdateTexImage() is called on it.
+      if (!decode_target_graphics_context_provider_) {
+        return Failure("Invalid decode target graphics context provider.");
+      }
+      DecodeTarget* decode_target =
+          new DecodeTarget(decode_target_graphics_context_provider_);
+      if (!SbDecodeTargetIsValid(decode_target)) {
+        return Failure("Could not acquire a decode target from provider.");
+      }
+      j_output_surface = decode_target->surface().obj();
+
+      JNIEnv* env = AttachCurrentThread();
+      surface_texture_bridge_->SetOnFrameAvailableListener(
+          env, decode_target->surface_texture());
+
+      std::lock_guard lock(decode_target_mutex_);
+      decode_target_ = decode_target;
+      // We manually call AddRef() here because `decode_target_` is stored as a
+      // raw pointer. This ensures Starboard claims its initial ownership of the
+      // target, preventing it from stealing Chromium's reference and deleting
+      // the texture prematurely during TeardownCodec().
+      decode_target_->AddRef();
+    } break;
+    case kSbPlayerOutputModeInvalid: {
+      SB_NOTREACHED();
+    } break;
+  }
+  if (!j_output_surface) {
+    return Failure("Video surface does not exist.");
+  }
+
+  if (needs_fps_to_initialize_codec_) {
+    SB_DCHECK_GT(video_fps_, 0);
+  } else {
+    SB_DCHECK_EQ(video_fps_, 0);
+  }
+
+  // TODO(b/281431214): Evaluate if we should also parse the fps from
+  //                    `max_video_capabilities_` and pass to MediaCodecDecoder
+  //                    ctor.
+  std::optional<Size> max_frame_size =
+      ParseMaxResolution(max_video_capabilities_, video_stream_info.frame_size);
+
+  auto result = MediaCodecDecoder::CreateForVideo(
+      job_queue(), /*host=*/this, video_stream_info.codec,
+      video_stream_info.frame_size, max_frame_size, video_fps_,
+      j_output_surface, drm_system_,
+      color_metadata_ ? &*color_metadata_ : nullptr, require_software_codec_,
+      std::bind(&MediaCodecVideoDecoder::OnFrameRendered, this, _1),
+      std::bind(&MediaCodecVideoDecoder::OnFirstTunnelFrameReady, this),
+      tunnel_mode_audio_session_id_, force_big_endian_hdr_metadata_,
+      max_video_input_size_, flush_delay_usec_, use_dual_threads_,
+      enable_output_checker_);
+  if (result) {
+    media_decoder_ = std::move(result.value());
+    if (error_cb_) {
+      media_decoder_->Initialize(
+          std::bind(&MediaCodecVideoDecoder::ReportError, this, _1, _2));
+    }
+    media_decoder_->SetPlaybackRate(playback_rate_);
+
+    if (needs_fps_to_initialize_codec_) {
+      SB_DCHECK(!pending_input_buffers_.empty());
+    } else {
+      SB_DCHECK(pending_input_buffers_.empty());
+    }
+    if (!pending_input_buffers_.empty()) {
+      WriteInputBuffersInternal(pending_input_buffers_);
+      pending_input_buffers_.clear();
+    }
+    return Success();
+  }
+  media_decoder_.reset();
+  return Failure("Media Decoder is not valid: " + result.error());
+}
+
+void MediaCodecVideoDecoder::TeardownCodec() {
+  SB_CHECK(BelongsToCurrentThread());
+  if (owns_video_surface_) {
+    ReleaseVideoSurface();
+    owns_video_surface_ = false;
+  }
+  media_decoder_.reset();
+  color_metadata_ = std::nullopt;
+
+  SbDecodeTarget decode_target_to_release = kSbDecodeTargetInvalid;
+  {
+    std::lock_guard lock(decode_target_mutex_);
+    if (decode_target_ != nullptr) {
+      // Remove OnFrameAvailableListener to make sure the callback
+      // would not be called.
+      JNIEnv* env = AttachCurrentThread();
+      surface_texture_bridge_->RemoveOnFrameAvailableListener(
+          env, decode_target_->surface_texture());
+
+      decode_target_to_release = decode_target_;
+      decode_target_ = nullptr;
+      first_texture_received_ = false;
+      has_new_texture_available_.store(false);
+    } else {
+      // If |decode_target_| is not created, |first_texture_received_| and
+      // |has_new_texture_available_| should always be false.
+      SB_DCHECK(!first_texture_received_);
+      SB_DCHECK(!has_new_texture_available_.load());
+    }
+  }
+  // Release SbDecodeTarget on renderer thread. As |decode_target_mutex_| may
+  // be required in renderer thread, SbDecodeTargetReleaseInGlesContext() must
+  // be called when |decode_target_mutex_| is not locked, or we may get
+  // deadlock.
+  if (SbDecodeTargetIsValid(decode_target_to_release)) {
+    SbDecodeTargetReleaseInGlesContext(decode_target_graphics_context_provider_,
+                                       decode_target_to_release);
+  }
+}
+
+void MediaCodecVideoDecoder::WriteInputBuffersInternal(
+    const InputBuffers& input_buffers) {
+  SB_DCHECK(!input_buffers.empty());
+
+  // There's a race condition when suspending the app. If surface view is
+  // destroyed before video decoder stopped, |media_decoder_| could be null
+  // here. And error_cb_() could be handled asynchronously. It's possible
+  // that WriteInputBuffer() is called again when the first WriteInputBuffer()
+  // fails, in such case |media_decoder_| will be null.
+  if (!media_decoder_) {
+    SB_LOG(INFO) << "Trying to write input buffer when media_decoder_ is null.";
+    return;
+  }
+
+  if (is_video_frame_tracker_enabled_) {
+    SB_DCHECK(video_frame_tracker_);
+    for (const auto& input_buffer : input_buffers) {
+      video_frame_tracker_->OnInputBuffer(input_buffer->timestamp());
+    }
+  }
+
+  media_decoder_->WriteInputBuffers(input_buffers);
+  if (media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize) {
+    decoder_status_cb_(kNeedMoreInput, NULL);
+  } else if (tunnel_mode_audio_session_id_ != -1) {
+    // In tunnel mode playback when need data is not signaled above, it is
+    // possible that the VideoDecoder won't get a chance to send kNeedMoreInput
+    // to the renderer again.  Schedule a task to check back.
+    Schedule(
+        std::bind(&MediaCodecVideoDecoder::OnTunnelModeCheckForNeedMoreInput,
+                  this),
+        kNeedMoreInputCheckIntervalInTunnelMode);
+  }
+
+  if (tunnel_mode_audio_session_id_ != -1 && tunnel_mode_prerolling_.load()) {
+    for (const auto& input_buffer : input_buffers) {
+      if (input_buffer->timestamp() >= video_frame_tracker_->seek_to_time()) {
+        tunnel_mode_prerolled_frames_++;
+      }
+    }
+    if (tunnel_mode_prerolled_frames_ >= kTunnelModePrerollFrameCount) {
+      TryToSignalPrerollForTunnelMode();
+    }
+  }
+}
+
+void MediaCodecVideoDecoder::ProcessOutputBuffer(
+    MediaCodecBridge* media_codec_bridge,
+    const DequeueOutputResult& dequeue_output_result) {
+  SB_DCHECK(decoder_status_cb_);
+  SB_DCHECK_GE(dequeue_output_result.index, 0);
+
+  bool is_end_of_stream =
+      dequeue_output_result.flags & BUFFER_FLAG_END_OF_STREAM;
+  if (!is_end_of_stream) {
+    ++decoded_output_frames_;
+    if (output_format_) {
+      ++buffered_output_frames_;
+      // We have to wait until we feed enough inputs to the decoder and receive
+      // enough outputs before update |max_buffered_output_frames_|. Otherwise,
+      // |max_buffered_output_frames_| may be updated to a very small number
+      // when we receive the first few outputs.
+      if (decoded_output_frames_ > kInitialPrerollFrameCount &&
+          buffered_output_frames_ > max_buffered_output_frames_) {
+        max_buffered_output_frames_ = buffered_output_frames_;
+        MaxMediaCodecOutputBuffersLookupTable::GetInstance()
+            ->UpdateMaxOutputBuffers(output_format_.value(),
+                                     max_buffered_output_frames_);
+      }
+    }
+  }
+  decoder_status_cb_(
+      is_end_of_stream ? kBufferFull : kNeedMoreInput,
+      new VideoFrameImpl(
+          dequeue_output_result, media_codec_bridge,
+          std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
+}
+
+void MediaCodecVideoDecoder::OnEndOfStreamWritten(
+    MediaCodecBridge* media_codec_bridge) {
+  if (tunnel_mode_audio_session_id_ == -1) {
+    return;
+  }
+
+  SB_DCHECK(decoder_status_cb_);
+
+  // TODO: Refactor the VideoDecoder and the VideoRendererImpl to improve the
+  //       handling of preroll and EOS for pure punchout decoders.
+  decoder_status_cb_(kBufferFull, VideoFrame::CreateEOSFrame());
+  sink_->Render();
+}
+
+void MediaCodecVideoDecoder::RefreshOutputFormat(
+    MediaCodecBridge* media_codec_bridge) {
+  SB_DCHECK(media_codec_bridge);
+  SB_DLOG(INFO) << "Output format changed, trying to dequeue again.";
+
+  std::lock_guard lock(decode_target_mutex_);
+  std::optional<FrameSize> output_size = media_codec_bridge->GetOutputSize();
+  if (!output_size) {
+    SB_LOG(WARNING)
+        << "GetOutputSize() returned null. Defaulting to an empty FrameSize.";
+    // We default to an empty FrameSize instead of propagating a failure to
+    // ensure system robustness. The calling code historically does not expect
+    // this call to fail and is not equipped to handle a null optional.
+    output_size = FrameSize();
+  }
+
+  // Record the latest dimensions of the decoded input.
+  frame_sizes_.push_back(*output_size);
+
+  if (tunnel_mode_audio_session_id_ != -1) {
+    return;
+  }
+  if (first_output_format_changed_) {
+    // After resolution changes, the output buffers may have frames of different
+    // resolutions. In that case, it's hard to determine the max supported
+    // output buffers. So, we reset |output_format_| to null here to skip max
+    // output buffers check.
+    output_format_ = std::nullopt;
+    return;
+  }
+  output_format_ =
+      VideoOutputFormat(video_codec_, frame_sizes_.back().display_size,
+                        color_metadata_.has_value());
+  first_output_format_changed_ = true;
+  auto max_output_buffers =
+      MaxMediaCodecOutputBuffersLookupTable::GetInstance()
+          ->GetMaxOutputVideoBuffers(output_format_.value());
+  if (max_output_buffers > 0 &&
+      max_output_buffers <
+          static_cast<int>(initial_number_of_preroll_frames_)) {
+    number_of_preroll_frames_ = max_output_buffers;
+  }
+}
+
+bool MediaCodecVideoDecoder::Tick(MediaCodecBridge* media_codec_bridge) {
+  // Tunnel mode renders frames in MediaCodec automatically and shouldn't reach
+  // here.
+  SB_DCHECK_EQ(tunnel_mode_audio_session_id_, -1);
+  return sink_->Render();
+}
+
+void MediaCodecVideoDecoder::OnFlushing() {
+  SB_CHECK(BelongsToCurrentThread());
+
+  if (decoder_status_cb_) {
+    decoder_status_cb_(kReleaseAllFrames, NULL);
+  }
+}
+
+bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
+    const scoped_refptr<InputBuffer>& input_buffer) {
+  if (!is_video_frame_tracker_enabled_) {
+    return false;
+  }
+
+  SB_CHECK(video_frame_tracker_);
+  return input_buffer->timestamp() < video_frame_tracker_->seek_to_time();
+}
+
 void MediaCodecVideoDecoder::TryToSignalPrerollForTunnelMode() {
   if (!tunnel_mode_first_frame_rendered_ ||
       tunnel_mode_prerolled_frames_ < kTunnelModePrerollFrameCount) {
@@ -1405,6 +1359,48 @@ void MediaCodecVideoDecoder::ReportError(SbPlayerError error,
   }
 
   error_cb_(kSbPlayerErrorDecode, error_message);
+}
+
+void MediaCodecVideoDecoder::ResetInternal(bool skip_flush) {
+  SB_CHECK(BelongsToCurrentThread());
+
+  // If fail to flush |media_decoder_| or |media_decoder_| is null, then
+  // re-create |media_decoder_|. If |needs_fps_to_initialize_codec_| is true,
+  // set video_fps_ to 0 will call InitializeCodec(),
+  // which we do not need if flush the codec.
+  if (!enable_flush_during_seek_ || skip_flush || !media_decoder_ ||
+      !media_decoder_->Flush()) {
+    TeardownCodec();
+    if (reset_delay_usec_ > 0) {
+      usleep(reset_delay_usec_);
+    }
+
+    // Note that |input_buffer_written_| may not be strictly accurate after
+    // Flush() since it counts all buffers written since codec initialization.
+    // This is acceptable because it is used to estimate pre-roll frames, and
+    // retaining its accumulated value correctly signals that we are past the
+    // initial pre-roll phase after a Flush().
+    input_buffer_written_ = 0;
+    video_fps_ = 0;
+  }
+  CancelPendingJobs();
+
+  // TODO(b/291959069): After flush |media_decoder_|, the output buffers
+  // may have invalid frames. Reset |output_format_| to null here to skip max
+  // output buffers check.
+  decoded_output_frames_ = 0;
+  output_format_ = std::nullopt;
+
+  tunnel_mode_prerolling_.store(true);
+  tunnel_mode_first_frame_rendered_.store(false);
+  tunnel_mode_prerolled_frames_.store(0);
+  end_of_stream_written_ = false;
+  pending_input_buffers_.clear();
+
+  // TODO: We rely on VideoRenderAlgorithmTunneled::Seek() to be called inside
+  //       VideoRenderer::Seek() after calling MediaCodecVideoDecoder::Reset()
+  //       to update the seek status of |video_frame_tracker_|.  This is
+  //       slightly flaky as it depends on the behavior of the video renderer.
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/media_drm_bridge.cc
+++ b/starboard/android/shared/media_drm_bridge.cc
@@ -153,35 +153,6 @@ MediaDrmBridge::MediaDrmBridge(PassKey<MediaDrmBridge>,
                                base::raw_ref<MediaDrmBridge::Host> host)
     : host_(host) {}
 
-bool MediaDrmBridge::Initialize(std::string_view key_system,
-                                bool enable_app_provisioning) {
-  JNIEnv* env = AttachCurrentThread();
-
-  ScopedJavaLocalRef<jstring> j_key_system(
-      ConvertUTF8ToJavaString(env, key_system));
-  ScopedJavaLocalRef<jobject> j_media_drm_bridge(
-      Java_MediaDrmBridge_create(env, j_key_system, enable_app_provisioning,
-                                 reinterpret_cast<jlong>(this)));
-
-  if (j_media_drm_bridge.is_null()) {
-    SB_LOG(ERROR) << "Failed to create MediaDrmBridge.";
-    return false;
-  }
-
-  ScopedJavaLocalRef<jobject> j_media_crypto(
-      Java_MediaDrmBridge_getMediaCrypto(env, j_media_drm_bridge));
-
-  if (j_media_crypto.is_null()) {
-    SB_LOG(ERROR) << "Failed to create MediaCrypto.";
-    return false;
-  }
-
-  j_media_drm_bridge_.Reset(env, j_media_drm_bridge.obj());
-  j_media_crypto_.Reset(env, j_media_crypto.obj());
-
-  return true;
-}
-
 MediaDrmBridge::~MediaDrmBridge() {
   if (!j_media_drm_bridge_.is_null()) {
     Java_MediaDrmBridge_destroy(AttachCurrentThread(), j_media_drm_bridge_);
@@ -337,6 +308,35 @@ bool MediaDrmBridge::IsWidevineSupported(JNIEnv* env) {
 // static
 bool MediaDrmBridge::IsCbcsSupported(JNIEnv* env) {
   return Java_MediaDrmBridge_isCbcsSchemeSupported(env) == JNI_TRUE;
+}
+
+bool MediaDrmBridge::Initialize(std::string_view key_system,
+                                bool enable_app_provisioning) {
+  JNIEnv* env = AttachCurrentThread();
+
+  ScopedJavaLocalRef<jstring> j_key_system(
+      ConvertUTF8ToJavaString(env, key_system));
+  ScopedJavaLocalRef<jobject> j_media_drm_bridge(
+      Java_MediaDrmBridge_create(env, j_key_system, enable_app_provisioning,
+                                 reinterpret_cast<jlong>(this)));
+
+  if (j_media_drm_bridge.is_null()) {
+    SB_LOG(ERROR) << "Failed to create MediaDrmBridge.";
+    return false;
+  }
+
+  ScopedJavaLocalRef<jobject> j_media_crypto(
+      Java_MediaDrmBridge_getMediaCrypto(env, j_media_drm_bridge));
+
+  if (j_media_crypto.is_null()) {
+    SB_LOG(ERROR) << "Failed to create MediaCrypto.";
+    return false;
+  }
+
+  j_media_drm_bridge_.Reset(env, j_media_drm_bridge.obj());
+  j_media_crypto_.Reset(env, j_media_crypto.obj());
+
+  return true;
 }
 
 std::ostream& operator<<(std::ostream& os, DrmOperationStatus status) {

--- a/starboard/android/shared/memfd_media_buffer_pool.cc
+++ b/starboard/android/shared/memfd_media_buffer_pool.cc
@@ -108,22 +108,6 @@ MemFdMediaBufferPool* MemFdMediaBufferPool::Get() {
   return &instance;
 }
 
-MemFdMediaBufferPool::MemFdMediaBufferPool() {
-  fd_ = CreateReliableCacheFd("cobalt_media_buffer_pool", 0);
-
-  if (fd_ >= 0) {
-    SB_LOG(INFO) << "Created memfd for MediaBufferPool.";
-  } else {
-    SB_LOG(WARNING) << "Failed to create memfd in constructor.";
-  }
-}
-
-MemFdMediaBufferPool::~MemFdMediaBufferPool() {
-  if (fd_ >= 0) {
-    close(fd_);
-  }
-}
-
 void MemFdMediaBufferPool::ShrinkToZero() {
   // fd_ is guaranteed to be >= 0 if Get() returned this instance.
   SB_DCHECK_GE(fd_, 0);
@@ -235,6 +219,22 @@ void MemFdMediaBufferPool::Read(intptr_t position, void* buffer, size_t size) {
 #if BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   SB_CHECK_EQ(total_read, size);
 #endif  // BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+}
+
+MemFdMediaBufferPool::MemFdMediaBufferPool() {
+  fd_ = CreateReliableCacheFd("cobalt_media_buffer_pool", 0);
+
+  if (fd_ >= 0) {
+    SB_LOG(INFO) << "Created memfd for MediaBufferPool.";
+  } else {
+    SB_LOG(WARNING) << "Failed to create memfd in constructor.";
+  }
+}
+
+MemFdMediaBufferPool::~MemFdMediaBufferPool() {
+  if (fd_ >= 0) {
+    close(fd_);
+  }
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -339,12 +339,6 @@ void StarboardBridge::SetCrashContext(JNIEnv* env,
                                        ConvertUTF8ToJavaString(env, value));
 }
 
-ScopedJavaLocalRef<jobject> StarboardBridge::GetAudioOutputManager(
-    JNIEnv* env) {
-  SB_DCHECK(env);
-  return Java_StarboardBridge_getAudioOutputManager(env, j_starboard_bridge_);
-}
-
 bool StarboardBridge::IsMicrophoneDisconnected(JNIEnv* env) {
   SB_DCHECK(env);
   return Java_StarboardBridge_isMicrophoneDisconnected(env,
@@ -376,6 +370,12 @@ void StarboardBridge::SetVideoSurfaceBounds(JNIEnv* env,
   SB_DCHECK(env);
   return Java_StarboardBridge_setVideoSurfaceBounds(env, j_starboard_bridge_, x,
                                                     y, width, height);
+}
+
+ScopedJavaLocalRef<jobject> StarboardBridge::GetAudioOutputManager(
+    JNIEnv* env) {
+  SB_DCHECK(env);
+  return Java_StarboardBridge_getAudioOutputManager(env, j_starboard_bridge_);
 }
 
 std::string StarboardBridge::GetUserAgentAuxField(JNIEnv* env) const {


### PR DESCRIPTION
Reorder member function definitions in source files under
starboard/android/ to match the order of their declarations in
header files. This improves consistency and readability.

Bug: 276483058