### PR TITLE
starboard: Reorder shared component member functions

### DIFF
--- a/starboard/shared/libaom/aom_video_decoder.cc
+++ b/starboard/shared/libaom/aom_video_decoder.cc
@@ -116,19 +116,6 @@ void AomVideoDecoder::Reset() {
   frames_ = std::queue<scoped_refptr<CpuVideoFrame>>();
 }
 
-void AomVideoDecoder::UpdateDecodeTarget_Locked(
-    const scoped_refptr<CpuVideoFrame>& frame) {
-  SbDecodeTarget decode_target = DecodeTargetCreate(
-      decode_target_graphics_context_provider_, frame, decode_target_);
-
-  // Lock only after the post to the renderer thread, to prevent deadlock.
-  decode_target_ = decode_target;
-
-  if (!SbDecodeTargetIsValid(decode_target)) {
-    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
-  }
-}
-
 void AomVideoDecoder::ReportError(const std::string& error_message) {
   SB_DCHECK(decoder_thread_->BelongsToCurrentThread());
 
@@ -291,6 +278,19 @@ SbDecodeTarget AomVideoDecoder::GetCurrentDecodeTarget() {
     return DecodeTargetCopy(decode_target_);
   } else {
     return kSbDecodeTargetInvalid;
+  }
+}
+
+void AomVideoDecoder::UpdateDecodeTarget_Locked(
+    const scoped_refptr<CpuVideoFrame>& frame) {
+  SbDecodeTarget decode_target = DecodeTargetCreate(
+      decode_target_graphics_context_provider_, frame, decode_target_);
+
+  // Lock only after the post to the renderer thread, to prevent deadlock.
+  decode_target_ = decode_target;
+
+  if (!SbDecodeTargetIsValid(decode_target)) {
+    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
   }
 }
 

--- a/starboard/shared/libdav1d/dav1d_video_decoder.cc
+++ b/starboard/shared/libdav1d/dav1d_video_decoder.cc
@@ -143,19 +143,6 @@ void Dav1dVideoDecoder::Reset() {
   frames_ = std::queue<scoped_refptr<CpuVideoFrame>>();
 }
 
-void Dav1dVideoDecoder::UpdateDecodeTarget_Locked(
-    const scoped_refptr<CpuVideoFrame>& frame) {
-  SbDecodeTarget decode_target = DecodeTargetCreate(
-      decode_target_graphics_context_provider_, frame, decode_target_);
-
-  // Lock only after the post to the renderer thread, to prevent deadlock.
-  decode_target_ = decode_target;
-
-  if (!SbDecodeTargetIsValid(decode_target)) {
-    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
-  }
-}
-
 void Dav1dVideoDecoder::ReportError(const std::string& error_message) {
   SB_DCHECK(error_cb_);
 
@@ -382,6 +369,19 @@ SbDecodeTarget Dav1dVideoDecoder::GetCurrentDecodeTarget() {
     return DecodeTargetCopy(decode_target_);
   } else {
     return kSbDecodeTargetInvalid;
+  }
+}
+
+void Dav1dVideoDecoder::UpdateDecodeTarget_Locked(
+    const scoped_refptr<CpuVideoFrame>& frame) {
+  SbDecodeTarget decode_target = DecodeTargetCreate(
+      decode_target_graphics_context_provider_, frame, decode_target_);
+
+  // Lock only after the post to the renderer thread, to prevent deadlock.
+  decode_target_ = decode_target;
+
+  if (!SbDecodeTargetIsValid(decode_target)) {
+    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
   }
 }
 

--- a/starboard/shared/libde265/de265_video_decoder.cc
+++ b/starboard/shared/libde265/de265_video_decoder.cc
@@ -114,19 +114,6 @@ void De265VideoDecoder::Reset() {
   frames_ = std::queue<scoped_refptr<CpuVideoFrame>>();
 }
 
-void De265VideoDecoder::UpdateDecodeTarget_Locked(
-    const scoped_refptr<CpuVideoFrame>& frame) {
-  SbDecodeTarget decode_target = DecodeTargetCreate(
-      decode_target_graphics_context_provider_, frame, decode_target_);
-
-  // Lock only after the post to the renderer thread, to prevent deadlock.
-  decode_target_ = decode_target;
-
-  if (!SbDecodeTargetIsValid(decode_target)) {
-    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
-  }
-}
-
 void De265VideoDecoder::ReportError(const std::string& error_message) {
   SB_DCHECK(decoder_thread_->BelongsToCurrentThread());
 
@@ -302,6 +289,19 @@ SbDecodeTarget De265VideoDecoder::GetCurrentDecodeTarget() {
     return DecodeTargetCopy(decode_target_);
   } else {
     return kSbDecodeTargetInvalid;
+  }
+}
+
+void De265VideoDecoder::UpdateDecodeTarget_Locked(
+    const scoped_refptr<CpuVideoFrame>& frame) {
+  SbDecodeTarget decode_target = DecodeTargetCreate(
+      decode_target_graphics_context_provider_, frame, decode_target_);
+
+  // Lock only after the post to the renderer thread, to prevent deadlock.
+  decode_target_ = decode_target;
+
+  if (!SbDecodeTargetIsValid(decode_target)) {
+    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
   }
 }
 

--- a/starboard/shared/libvpx/vpx_video_decoder.cc
+++ b/starboard/shared/libvpx/vpx_video_decoder.cc
@@ -114,19 +114,6 @@ void VpxVideoDecoder::Reset() {
   frames_ = std::queue<scoped_refptr<CpuVideoFrame>>();
 }
 
-void VpxVideoDecoder::UpdateDecodeTarget_Locked(
-    const scoped_refptr<CpuVideoFrame>& frame) {
-  SbDecodeTarget decode_target = DecodeTargetCreate(
-      decode_target_graphics_context_provider_, frame, decode_target_);
-
-  // Lock only after the post to the renderer thread, to prevent deadlock.
-  decode_target_ = decode_target;
-
-  if (!SbDecodeTargetIsValid(decode_target)) {
-    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
-  }
-}
-
 void VpxVideoDecoder::ReportError(const std::string& error_message) {
   SB_DCHECK(decoder_thread_->BelongsToCurrentThread());
 
@@ -289,6 +276,19 @@ SbDecodeTarget VpxVideoDecoder::GetCurrentDecodeTarget() {
     return DecodeTargetCopy(decode_target_);
   } else {
     return kSbDecodeTargetInvalid;
+  }
+}
+
+void VpxVideoDecoder::UpdateDecodeTarget_Locked(
+    const scoped_refptr<CpuVideoFrame>& frame) {
+  SbDecodeTarget decode_target = DecodeTargetCreate(
+      decode_target_graphics_context_provider_, frame, decode_target_);
+
+  // Lock only after the post to the renderer thread, to prevent deadlock.
+  decode_target_ = decode_target;
+
+  if (!SbDecodeTargetIsValid(decode_target)) {
+    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
   }
 }
 

--- a/starboard/shared/openh264/openh264_video_decoder.cc
+++ b/starboard/shared/openh264/openh264_video_decoder.cc
@@ -54,6 +54,44 @@ void OpenH264VideoDecoder::Initialize(const DecoderStatusCB& decoder_status_cb,
   error_cb_ = error_cb;
 }
 
+void OpenH264VideoDecoder::WriteInputBuffers(
+    const InputBuffers& input_buffers) {
+  SB_CHECK(BelongsToCurrentThread());
+  SB_DCHECK_EQ(input_buffers.size(), 1);
+  SB_DCHECK(input_buffers[0]);
+  SB_DCHECK(decoder_status_cb_);
+
+  if (stream_ended_) {
+    ReportError("WriteInputBuffer() was called after WriteEndOfStream().");
+    return;
+  }
+  if (!decoder_thread_) {
+    decoder_thread_ = JobThread::Create("openh264_video_decoder");
+    SB_DCHECK(decoder_thread_);
+  }
+  const auto& input_buffer = input_buffers[0];
+  decoder_thread_->Schedule(
+      std::bind(&OpenH264VideoDecoder::DecodeOneBuffer, this, input_buffer));
+}
+
+void OpenH264VideoDecoder::WriteEndOfStream() {
+  SB_CHECK(BelongsToCurrentThread());
+  SB_DCHECK(decoder_status_cb_);
+
+  // We have to flush the decoder to decode the rest frames and to ensure that
+  // Decode() is not called when the stream is ended.
+  stream_ended_ = true;
+
+  if (!decoder_thread_) {
+    // In case there is no WriteInputBuffer() call before WriteEndOfStream(),
+    // don't create the decoder thread and send the EOS frame directly.
+    decoder_status_cb_(kBufferFull, VideoFrame::CreateEOSFrame());
+    return;
+  }
+  decoder_thread_->Schedule(
+      std::bind(&OpenH264VideoDecoder::DecodeEndOfStream, this));
+}
+
 void OpenH264VideoDecoder::Reset() {
   SB_CHECK(BelongsToCurrentThread());
 
@@ -74,6 +112,41 @@ void OpenH264VideoDecoder::Reset() {
 
   std::lock_guard lock(decode_target_mutex_);
   frames_ = std::queue<scoped_refptr<CpuVideoFrame>>();
+}
+
+// When in decode-to-texture mode, this returns the current decoded video frame.
+SbDecodeTarget OpenH264VideoDecoder::GetCurrentDecodeTarget() {
+  SB_DCHECK_EQ(output_mode_, kSbPlayerOutputModeDecodeToTexture);
+
+  // We must take a lock here since this function can be called from a
+  // separate thread.
+  std::lock_guard lock(decode_target_mutex_);
+  while (frames_.size() > 1 && frames_.front()->HasOneRef()) {
+    frames_.pop();
+  }
+  if (!frames_.empty()) {
+    UpdateDecodeTarget_Locked(frames_.front());
+  }
+  if (SbDecodeTargetIsValid(decode_target_)) {
+    // Make a disposable copy, since the state is internally reused by this
+    // class (to avoid recreating GL objects).
+    return DecodeTargetCopy(decode_target_);
+  } else {
+    return kSbDecodeTargetInvalid;
+  }
+}
+
+void OpenH264VideoDecoder::UpdateDecodeTarget_Locked(
+    const scoped_refptr<CpuVideoFrame>& frame) {
+  SbDecodeTarget decode_target = DecodeTargetCreate(
+      decode_target_graphics_context_provider_, frame, decode_target_);
+
+  // Lock only after the post to the renderer thread, to prevent deadlock.
+  decode_target_ = decode_target;
+
+  if (!SbDecodeTargetIsValid(decode_target)) {
+    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
+  }
 }
 
 void OpenH264VideoDecoder::InitializeCodec() {
@@ -122,26 +195,6 @@ void OpenH264VideoDecoder::TeardownCodec() {
   }
 }
 
-void OpenH264VideoDecoder::WriteInputBuffers(
-    const InputBuffers& input_buffers) {
-  SB_CHECK(BelongsToCurrentThread());
-  SB_DCHECK_EQ(input_buffers.size(), 1);
-  SB_DCHECK(input_buffers[0]);
-  SB_DCHECK(decoder_status_cb_);
-
-  if (stream_ended_) {
-    ReportError("WriteInputBuffer() was called after WriteEndOfStream().");
-    return;
-  }
-  if (!decoder_thread_) {
-    decoder_thread_ = JobThread::Create("openh264_video_decoder");
-    SB_DCHECK(decoder_thread_);
-  }
-  const auto& input_buffer = input_buffers[0];
-  decoder_thread_->Schedule(
-      std::bind(&OpenH264VideoDecoder::DecodeOneBuffer, this, input_buffer));
-}
-
 void OpenH264VideoDecoder::DecodeOneBuffer(
     const scoped_refptr<InputBuffer>& input_buffer) {
   SB_DCHECK(decoder_thread_->BelongsToCurrentThread());
@@ -179,36 +232,11 @@ void OpenH264VideoDecoder::DecodeOneBuffer(
   }
 }
 
-void OpenH264VideoDecoder::FlushFrames() {
+void OpenH264VideoDecoder::DecodeEndOfStream() {
   SB_DCHECK(decoder_thread_->BelongsToCurrentThread());
-  SB_DCHECK(decoder_);
-
-  int num_of_frames_in_buffer = 0;
-  unsigned char* decoded_frame[3];
-  SBufferInfo buffer_info;
-  decoder_->GetOption(DECODER_OPTION_NUM_OF_FRAMES_REMAINING_IN_BUFFER,
-                      &num_of_frames_in_buffer);
-  for (int i = 0; i < num_of_frames_in_buffer; ++i) {
-    decoder_->FlushFrame(decoded_frame, &buffer_info);
-    if (buffer_info.iBufferStatus == 1) {
-      ProcessDecodedImage(decoded_frame, buffer_info, true);
-    } else {
-      SB_LOG(WARNING) << "Cannot get decoded frame by calling FlushFrame()!";
-    }
-  }
-  if (frames_being_decoded_ != 0) {
-    SB_LOG(WARNING) << "Inconsistency in the number of input/output frames";
-  }
-
-  while (!time_sequential_queue_.empty()) {
-    auto output_frame = time_sequential_queue_.top();
-    if (output_mode_ == kSbPlayerOutputModeDecodeToTexture) {
-      std::lock_guard lock(decode_target_mutex_);
-      frames_.push(output_frame);
-    }
-    Schedule(std::bind(decoder_status_cb_, kBufferFull, output_frame));
-    time_sequential_queue_.pop();
-  }
+  FlushFrames();
+  Schedule(
+      std::bind(decoder_status_cb_, kBufferFull, VideoFrame::CreateEOSFrame()));
 }
 
 void OpenH264VideoDecoder::ProcessDecodedImage(unsigned char* decoded_frame[],
@@ -256,63 +284,35 @@ void OpenH264VideoDecoder::ProcessDecodedImage(unsigned char* decoded_frame[],
   }
 }
 
-void OpenH264VideoDecoder::WriteEndOfStream() {
-  SB_CHECK(BelongsToCurrentThread());
-  SB_DCHECK(decoder_status_cb_);
-
-  // We have to flush the decoder to decode the rest frames and to ensure that
-  // Decode() is not called when the stream is ended.
-  stream_ended_ = true;
-
-  if (!decoder_thread_) {
-    // In case there is no WriteInputBuffer() call before WriteEndOfStream(),
-    // don't create the decoder thread and send the EOS frame directly.
-    decoder_status_cb_(kBufferFull, VideoFrame::CreateEOSFrame());
-    return;
-  }
-  decoder_thread_->Schedule(
-      std::bind(&OpenH264VideoDecoder::DecodeEndOfStream, this));
-}
-
-void OpenH264VideoDecoder::DecodeEndOfStream() {
+void OpenH264VideoDecoder::FlushFrames() {
   SB_DCHECK(decoder_thread_->BelongsToCurrentThread());
-  FlushFrames();
-  Schedule(
-      std::bind(decoder_status_cb_, kBufferFull, VideoFrame::CreateEOSFrame()));
-}
+  SB_DCHECK(decoder_);
 
-void OpenH264VideoDecoder::UpdateDecodeTarget_Locked(
-    const scoped_refptr<CpuVideoFrame>& frame) {
-  SbDecodeTarget decode_target = DecodeTargetCreate(
-      decode_target_graphics_context_provider_, frame, decode_target_);
-
-  // Lock only after the post to the renderer thread, to prevent deadlock.
-  decode_target_ = decode_target;
-
-  if (!SbDecodeTargetIsValid(decode_target)) {
-    SB_LOG(ERROR) << "Could not acquire a decode target from provider.";
+  int num_of_frames_in_buffer = 0;
+  unsigned char* decoded_frame[3];
+  SBufferInfo buffer_info;
+  decoder_->GetOption(DECODER_OPTION_NUM_OF_FRAMES_REMAINING_IN_BUFFER,
+                      &num_of_frames_in_buffer);
+  for (int i = 0; i < num_of_frames_in_buffer; ++i) {
+    decoder_->FlushFrame(decoded_frame, &buffer_info);
+    if (buffer_info.iBufferStatus == 1) {
+      ProcessDecodedImage(decoded_frame, buffer_info, true);
+    } else {
+      SB_LOG(WARNING) << "Cannot get decoded frame by calling FlushFrame()!";
+    }
   }
-}
-
-// When in decode-to-texture mode, this returns the current decoded video frame.
-SbDecodeTarget OpenH264VideoDecoder::GetCurrentDecodeTarget() {
-  SB_DCHECK_EQ(output_mode_, kSbPlayerOutputModeDecodeToTexture);
-
-  // We must take a lock here since this function can be called from a
-  // separate thread.
-  std::lock_guard lock(decode_target_mutex_);
-  while (frames_.size() > 1 && frames_.front()->HasOneRef()) {
-    frames_.pop();
+  if (frames_being_decoded_ != 0) {
+    SB_LOG(WARNING) << "Inconsistency in the number of input/output frames";
   }
-  if (!frames_.empty()) {
-    UpdateDecodeTarget_Locked(frames_.front());
-  }
-  if (SbDecodeTargetIsValid(decode_target_)) {
-    // Make a disposable copy, since the state is internally reused by this
-    // class (to avoid recreating GL objects).
-    return DecodeTargetCopy(decode_target_);
-  } else {
-    return kSbDecodeTargetInvalid;
+
+  while (!time_sequential_queue_.empty()) {
+    auto output_frame = time_sequential_queue_.top();
+    if (output_mode_ == kSbPlayerOutputModeDecodeToTexture) {
+      std::lock_guard lock(decode_target_mutex_);
+      frames_.push(output_frame);
+    }
+    Schedule(std::bind(decoder_status_cb_, kBufferFull, output_frame));
+    time_sequential_queue_.pop();
   }
 }
 

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -118,6 +118,94 @@ void OpusAudioDecoder::Decode(const InputBuffers& input_buffers,
   }
 }
 
+void OpusAudioDecoder::WriteEndOfStream() {
+  SB_CHECK(BelongsToCurrentThread());
+  SB_DCHECK(output_cb_);
+
+  // Opus has no dependent frames so we needn't flush the decoder.  Set the
+  // flag to ensure that Decode() is not called when the stream is ended.
+  stream_ended_ = true;
+  if (!pending_audio_buffers_.empty()) {
+    return;
+  }
+
+  // Put EOS into the queue.
+  decoded_audios_.push(new DecodedAudio);
+
+  Schedule(output_cb_);
+}
+
+scoped_refptr<DecodedAudio> OpusAudioDecoder::Read(int* samples_per_second) {
+  SB_CHECK(BelongsToCurrentThread());
+  SB_DCHECK(output_cb_);
+  SB_DCHECK(!decoded_audios_.empty());
+
+  scoped_refptr<DecodedAudio> result;
+  if (!decoded_audios_.empty()) {
+    result = decoded_audios_.front();
+    decoded_audios_.pop();
+  }
+  *samples_per_second = audio_stream_info_.samples_per_second;
+  return result;
+}
+
+void OpusAudioDecoder::Reset() {
+  SB_CHECK(BelongsToCurrentThread());
+
+  if (decoder_) {
+    int error = opus_multistream_decoder_ctl(decoder_, OPUS_RESET_STATE);
+    if (error != OPUS_OK) {
+      SB_LOG(ERROR) << "Failed to reset OpusAudioDecoder with error: "
+                    << opus_strerror(error);
+
+      // If fail to reset opus decoder, re-create it.
+      TeardownCodec();
+      decoder_ = CreateOpusMultistreamDecoder(audio_stream_info_);
+    }
+  }
+
+  frames_per_au_ = kMaxOpusFramesPerAU;
+  stream_ended_ = false;
+  while (!decoded_audios_.empty()) {
+    decoded_audios_.pop();
+  }
+  pending_audio_buffers_.clear();
+  consumed_cb_ = nullptr;
+
+  CancelPendingJobs();
+}
+
+OpusMSDecoder* OpusAudioDecoder::CreateOpusMultistreamDecoder(
+    const AudioStreamInfo& audio_stream_info) {
+  int error;
+  int channels = audio_stream_info.number_of_channels;
+  if (channels > 8 || channels < 1) {
+    SB_LOG(ERROR) << "Can't create decoder with " << channels << " channels";
+    return nullptr;
+  }
+
+  OpusMSDecoder* decoder = opus_multistream_decoder_create(
+      audio_stream_info.samples_per_second, channels,
+      vorbis_mappings[channels - 1].nb_streams,
+      vorbis_mappings[channels - 1].nb_coupled_streams,
+      vorbis_mappings[channels - 1].mapping, &error);
+  if (error != OPUS_OK) {
+    SB_LOG(ERROR) << "Failed to create decoder with error: "
+                  << opus_strerror(error);
+    return nullptr;
+  }
+  SB_CHECK(decoder);
+
+  return decoder;
+}
+
+void OpusAudioDecoder::TeardownCodec() {
+  if (decoder_) {
+    opus_multistream_decoder_destroy(decoder_);
+    decoder_ = nullptr;
+  }
+}
+
 void OpusAudioDecoder::DecodePendingBuffers() {
   SB_CHECK(BelongsToCurrentThread());
   SB_DCHECK(!pending_audio_buffers_.empty());
@@ -193,94 +281,6 @@ bool OpusAudioDecoder::DecodeInternal(
   decoded_audios_.push(decoded_audio);
   output_cb_();
   return true;
-}
-
-void OpusAudioDecoder::WriteEndOfStream() {
-  SB_CHECK(BelongsToCurrentThread());
-  SB_DCHECK(output_cb_);
-
-  // Opus has no dependent frames so we needn't flush the decoder.  Set the
-  // flag to ensure that Decode() is not called when the stream is ended.
-  stream_ended_ = true;
-  if (!pending_audio_buffers_.empty()) {
-    return;
-  }
-
-  // Put EOS into the queue.
-  decoded_audios_.push(new DecodedAudio);
-
-  Schedule(output_cb_);
-}
-
-OpusMSDecoder* OpusAudioDecoder::CreateOpusMultistreamDecoder(
-    const AudioStreamInfo& audio_stream_info) {
-  int error;
-  int channels = audio_stream_info.number_of_channels;
-  if (channels > 8 || channels < 1) {
-    SB_LOG(ERROR) << "Can't create decoder with " << channels << " channels";
-    return nullptr;
-  }
-
-  OpusMSDecoder* decoder = opus_multistream_decoder_create(
-      audio_stream_info.samples_per_second, channels,
-      vorbis_mappings[channels - 1].nb_streams,
-      vorbis_mappings[channels - 1].nb_coupled_streams,
-      vorbis_mappings[channels - 1].mapping, &error);
-  if (error != OPUS_OK) {
-    SB_LOG(ERROR) << "Failed to create decoder with error: "
-                  << opus_strerror(error);
-    return nullptr;
-  }
-  SB_CHECK(decoder);
-
-  return decoder;
-}
-
-void OpusAudioDecoder::TeardownCodec() {
-  if (decoder_) {
-    opus_multistream_decoder_destroy(decoder_);
-    decoder_ = nullptr;
-  }
-}
-
-scoped_refptr<DecodedAudio> OpusAudioDecoder::Read(int* samples_per_second) {
-  SB_CHECK(BelongsToCurrentThread());
-  SB_DCHECK(output_cb_);
-  SB_DCHECK(!decoded_audios_.empty());
-
-  scoped_refptr<DecodedAudio> result;
-  if (!decoded_audios_.empty()) {
-    result = decoded_audios_.front();
-    decoded_audios_.pop();
-  }
-  *samples_per_second = audio_stream_info_.samples_per_second;
-  return result;
-}
-
-void OpusAudioDecoder::Reset() {
-  SB_CHECK(BelongsToCurrentThread());
-
-  if (decoder_) {
-    int error = opus_multistream_decoder_ctl(decoder_, OPUS_RESET_STATE);
-    if (error != OPUS_OK) {
-      SB_LOG(ERROR) << "Failed to reset OpusAudioDecoder with error: "
-                    << opus_strerror(error);
-
-      // If fail to reset opus decoder, re-create it.
-      TeardownCodec();
-      decoder_ = CreateOpusMultistreamDecoder(audio_stream_info_);
-    }
-  }
-
-  frames_per_au_ = kMaxOpusFramesPerAU;
-  stream_ended_ = false;
-  while (!decoded_audios_.empty()) {
-    decoded_audios_.pop();
-  }
-  pending_audio_buffers_.clear();
-  consumed_cb_ = nullptr;
-
-  CancelPendingJobs();
 }
 
 SbMediaAudioSampleType OpusAudioDecoder::GetSampleType() const {

--- a/starboard/shared/starboard/media/mime_type.cc
+++ b/starboard/shared/starboard/media/mime_type.cc
@@ -184,15 +184,6 @@ std::optional<MimeType> MimeType::Create(const std::string& content_type) {
                   std::move(params));
 }
 
-MimeType::MimeType(std::string type,
-                   std::string subtype,
-                   std::vector<std::string> codecs,
-                   Params params)
-    : type_(std::move(type)),
-      subtype_(std::move(subtype)),
-      codecs_(std::move(codecs)),
-      params_(std::move(params)) {}
-
 int MimeType::GetParamCount() const {
   return static_cast<int>(params_.size());
 }
@@ -344,6 +335,15 @@ bool MimeType::ValidateBoolParameter(const char* name) const {
   ParamType type = GetParamType(index);
   return type == kParamTypeBoolean;
 }
+
+MimeType::MimeType(std::string type,
+                   std::string subtype,
+                   std::vector<std::string> codecs,
+                   Params params)
+    : type_(std::move(type)),
+      subtype_(std::move(subtype)),
+      codecs_(std::move(codecs)),
+      params_(std::move(params)) {}
 
 std::ostream& operator<<(std::ostream& os, const MimeType& mime_type) {
   os << "{ type: " << mime_type.type();

--- a/starboard/shared/starboard/media/parsed_mime_info.cc
+++ b/starboard/shared/starboard/media/parsed_mime_info.cc
@@ -99,15 +99,6 @@ std::optional<ParsedMimeInfo> ParsedMimeInfo::Create(
                         video_info);
 }
 
-ParsedMimeInfo::ParsedMimeInfo(MimeType mime_type,
-                               bool disable_cache,
-                               AudioCodecInfo audio_info,
-                               VideoCodecInfo video_info)
-    : mime_type_(std::move(mime_type)),
-      disable_cache_(disable_cache),
-      audio_info_(audio_info),
-      video_info_(video_info) {}
-
 ParsedMimeInfo ParsedMimeInfo::WithBitrate(int bitrate) const {
   AudioCodecInfo audio_info = audio_info_;
   VideoCodecInfo video_info = video_info_;
@@ -117,6 +108,15 @@ ParsedMimeInfo ParsedMimeInfo::WithBitrate(int bitrate) const {
 
   return ParsedMimeInfo(mime_type_, disable_cache_, audio_info, video_info);
 }
+
+ParsedMimeInfo::ParsedMimeInfo(MimeType mime_type,
+                               bool disable_cache,
+                               AudioCodecInfo audio_info,
+                               VideoCodecInfo video_info)
+    : mime_type_(std::move(mime_type)),
+      disable_cache_(disable_cache),
+      audio_info_(audio_info),
+      video_info_(video_info) {}
 
 namespace {
 

--- a/starboard/shared/widevine/drm_system_widevine.cc
+++ b/starboard/shared/widevine/drm_system_widevine.cc
@@ -375,20 +375,6 @@ void DrmSystemWidevine::CloseSession(const void* sb_drm_session_id,
                            sb_drm_session_id_size);
 }
 
-void DrmSystemWidevine::UpdateServerCertificate(int ticket,
-                                                const void* certificate,
-                                                int certificate_size) {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
-  const std::string str_certificate(static_cast<const char*>(certificate),
-                                    certificate_size);
-  wv3cdm::Status status = cdm_->setServiceCertificate(str_certificate);
-
-  is_server_certificate_set_ = (status == wv3cdm::kSuccess);
-
-  server_certificate_updated_callback_(this, context_, ticket,
-                                       CdmStatusToSbDrmStatus(status), "");
-}
-
 void IncrementIv(uint8_t* iv, size_t block_count) {
   if (0 == block_count) {
     return;
@@ -546,6 +532,20 @@ SbDrmSystemPrivate::DecryptStatus DrmSystemWidevine::Decrypt(
 
   buffer->SetDecryptedContent(std::move(output_data));
   return kSuccess;
+}
+
+void DrmSystemWidevine::UpdateServerCertificate(int ticket,
+                                                const void* certificate,
+                                                int certificate_size) {
+  SB_CHECK(thread_checker_.CalledOnValidThread());
+  const std::string str_certificate(static_cast<const char*>(certificate),
+                                    certificate_size);
+  wv3cdm::Status status = cdm_->setServiceCertificate(str_certificate);
+
+  is_server_certificate_set_ = (status == wv3cdm::kSuccess);
+
+  server_certificate_updated_callback_(this, context_, ticket,
+                                       CdmStatusToSbDrmStatus(status), "");
 }
 
 void DrmSystemWidevine::GenerateSessionUpdateRequestInternal(


### PR DESCRIPTION
Reorder member function definitions in source files under
starboard/shared/. This includes video/audio decoders, MIME utilities,
and Widevine DRM components. The reordering ensures that definitions
match the order of their declarations in corresponding header files.
This improves code readability and maintainability by establishing a
consistent layout.

Bug: 276483058