### PR TITLE
BACKPORT: [tvOS] Handle select button presses using UIPressTypeSelect

### DIFF
--- a/content/browser/renderer_host/render_widget_host_view_tvos_uiview.h
+++ b/content/browser/renderer_host/render_widget_host_view_tvos_uiview.h
@@ -22,6 +22,9 @@
   // but doing so on a UITextField instance does, so we use this text field to
   // show/hide the system keyboard and plumb its value to |_view| and Blink.
   UITextField* _textFieldForAllTextInput;
+  // Set on pressesBegan for kSelect when an input field is focused, cleared and
+  // used on pressesEnded to show the keyboard.
+  BOOL _selectWillShowKeyboard;
 }
 
 - (instancetype)initWithWidget:

--- a/content/browser/renderer_host/render_widget_host_view_tvos_uiview.mm
+++ b/content/browser/renderer_host/render_widget_host_view_tvos_uiview.mm
@@ -26,6 +26,7 @@ typedef NS_ENUM(NSInteger, RemoteButton) {
   kLeft,
   kRight,
   kMediaPlayPause,
+  kSelect,
   kMenu,
   kNone
 };
@@ -72,6 +73,9 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
     case UIPressTypePlayPause:
       button = kMediaPlayPause;
       break;
+    case UIPressTypeSelect:
+      button = kSelect;
+      break;
     case UIPressTypeMenu:
       button = kMenu;
       break;
@@ -98,11 +102,6 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
     // tvOS supports multiple types of input events from the Remote, including
     // the clickpad (touch surface), the clickpad ring (directional control),
     // and various physical buttons.
-    // Add a tap gesture recognizer to handle center-clickpad press events.
-    UITapGestureRecognizer* tapGesture =
-        [[UITapGestureRecognizer alloc] initWithTarget:self
-                                                action:@selector(tapGesture:)];
-    [self addGestureRecognizer:tapGesture];
 
     // Create and add swipe gesture recognizers for all directions originating
     // from the clickpad buttons.
@@ -194,44 +193,6 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
   [self addGestureRecognizer:swipeGesture];
 }
 
-- (void)tapGesture:(UIGestureRecognizer*)gestureRecognizer {
-  if ([gestureRecognizer state] != UIGestureRecognizerStateEnded) {
-    return;
-  }
-
-  const ui::mojom::TextInputState* state = [self editState];
-  if (state && state->mode != ui::TextInputMode::TEXT_INPUT_MODE_NONE &&
-      state->type != ui::TextInputType::TEXT_INPUT_TYPE_NONE) {
-    [self showKeyboard:*state];
-    return;
-  }
-
-  blink::WebKeyboardEvent event(blink::WebInputEvent::Type::kKeyDown,
-                                blink::WebInputEvent::kNoModifiers,
-                                ui::EventTimeForNow());
-  event.native_key_code = UIKeyboardHIDUsageKeyboardReturnOrEnter;
-  event.dom_code = static_cast<int>(ui::DomCode::ENTER);
-  event.dom_key = ui::DomKey::ENTER;
-  event.windows_key_code = ui::VKEY_RETURN;
-
-  // Copied from components/input/web_input_event_builders_mac.mm's
-  // WebKeyboardEventBuilder::Build().
-  // This is necessary due to way some HTML elements process keyboard activation
-  // (e.g. blink::HTMLElement::HandleKeyboardActivation()).
-  event.text[0] = '\r';
-  event.unmodified_text[0] = '\r';
-
-  _view->SendKeyEvent(
-      input::NativeWebKeyboardEvent(event, _view->GetNativeView()));
-
-  // We also need to send a keyup event so that e.g. checkboxes are properly
-  // activated/deactivated with the keyboard.
-  event.SetType(blink::WebInputEvent::Type::kKeyUp);
-  event.SetTimeStamp(ui::EventTimeForNow());
-  _view->SendKeyEvent(
-      input::NativeWebKeyboardEvent(event, _view->GetNativeView()));
-}
-
 - (void)swipeGesture:(UISwipeGestureRecognizer*)gestureRecognizer {
   if ([gestureRecognizer state] != UIGestureRecognizerStateEnded) {
     return;
@@ -281,6 +242,29 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
   }
 }
 
+// Handles keyboard-show logic for UIPressTypeSelect. Returns YES if the key
+// event should be suppressed (keyboard was shown or will be shown).
+- (BOOL)handleSelectPressWithType:(blink::WebInputEvent::Type)type {
+  const ui::mojom::TextInputState* state = [self editState];
+  if (type == blink::WebInputEvent::Type::kKeyDown) {
+    if (state && state->mode != ui::TextInputMode::TEXT_INPUT_MODE_NONE &&
+        state->type != ui::TextInputType::TEXT_INPUT_TYPE_NONE) {
+      _selectWillShowKeyboard = YES;
+      return YES;
+    }
+    _selectWillShowKeyboard = NO;
+  } else if (type == blink::WebInputEvent::Type::kKeyUp) {
+    if (_selectWillShowKeyboard) {
+      _selectWillShowKeyboard = NO;
+      if (state) {
+        [self showKeyboard:*state];
+      }
+      return YES;
+    }
+  }
+  return NO;
+}
+
 // Returns YES if events are handled. Otherwise, NO to allow the event
 // to propagate to `super`.
 - (BOOL)handlePresses:(NSSet<UIPress*>*)presses
@@ -293,6 +277,9 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
       // Since UIPress has key information from the physical keyboard,
       // NativeWebKeyboardEvent is built with it in `sendKeyboardEvent`.
       needToHandleInFramework |= ![self sendKeyboardEvent:press eventType:type];
+      continue;
+    }
+    if (button == kSelect && [self handleSelectPressWithType:type]) {
       continue;
     }
     needToHandleInFramework |= ![self sendKeyEventWithRemoteButton:button
@@ -374,6 +361,18 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
       event.dom_code = static_cast<int>(ui::DomCode::MEDIA_PLAY_PAUSE);
       event.dom_key = ui::DomKey::MEDIA_PLAY_PAUSE;
       event.windows_key_code = ui::VKEY_MEDIA_PLAY_PAUSE;
+      break;
+    case kSelect:
+      event.native_key_code = UIKeyboardHIDUsageKeyboardReturnOrEnter;
+      event.dom_code = static_cast<int>(ui::DomCode::ENTER);
+      event.dom_key = ui::DomKey::ENTER;
+      event.windows_key_code = ui::VKEY_RETURN;
+      // Copied from components/input/web_input_event_builders_mac.mm's
+      // WebKeyboardEventBuilder::Build().
+      // This is necessary due to way some HTML elements process keyboard
+      // activation (e.g. blink::HTMLElement::HandleKeyboardActivation()).
+      event.text[0] = '\r';
+      event.unmodified_text[0] = '\r';
       break;
     case kMenu:
       // Refer to https://support.apple.com/en-us/102337.


### PR DESCRIPTION
This is a backport for fixing center click long press.

Bug: 507159562

---
Original CL message:

Adds support for UIPressTypeSelect by mapping it to a new kSelect remote button type.

Removes the tap gesture recognizer previously used for center-clickpad press handling, allowing select button events to be handled directly through the press event pipeline instead of gesture recognition. This enables web pages to detect and handle long press interactions for the select button.

Change-Id: Ie3974e8c7b1340eb024b17cc15cdb5605b7db008
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7810179
Reviewed-by: Dave Tapuska <dtapuska@chromium.org>
Commit-Queue: Julie Jeongeun Kim <jkim@igalia.com>
Cr-Commit-Position: refs/heads/main@{#1626721}