### PR TITLE
AOSP: add missing includes

### DIFF
--- a/copied_base/base/android/java_exception_reporter.cc
+++ b/copied_base/base/android/java_exception_reporter.cc
@@ -12,6 +12,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/lazy_instance.h"
+#include "base/logging.h"
 
 using base::android::JavaParamRef;
 using base::android::JavaRef;

--- a/starboard/android/shared/application_android.h
+++ b/starboard/android/shared/application_android.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_ANDROID_SHARED_APPLICATION_ANDROID_H_
 #define STARBOARD_ANDROID_SHARED_APPLICATION_ANDROID_H_
 
+#include "base/memory/raw_ptr.h"
 #include "starboard/android/shared/runtime_resource_overlay.h"
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/command_line.h"

--- a/starboard/android/shared/system_get_stack.cc
+++ b/starboard/android/shared/system_get_stack.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <link.h>
 #include <unwind.h>
 
 #include "starboard/common/log.h"


### PR DESCRIPTION
These are minor fixes that add missing includes that caused buid issues while building using the AOSP config (https://github.com/youtube/cobalt/pull/10313)

Bug: 495203133