### PR TITLE
aosp: fix minor warning issues

### DIFF
--- a/copied_base/base/process/current_process.cc
+++ b/copied_base/base/process/current_process.cc
@@ -45,6 +45,8 @@ const char* GetNameForProcessType(CurrentProcessType process_type) {
       return "Service: proxy_resolver.mojom.ProxyResolverFactory";
     case CurrentProcessType::PROCESS_SERVICE_CDM:
       return "Service: media.mojom.CdmService";
+    case CurrentProcessType::PROCESS_SERVICE_MEDIA_FOUNDATION:
+      return "Service: media.mojom.MediaFoundationServiceBroker";
     case CurrentProcessType::PROCESS_SERVICE_VIDEO_CAPTURE:
       return "Service: video_capture.mojom.VideoCaptureService";
     case CurrentProcessType::PROCESS_SERVICE_UNZIPPER:
@@ -137,6 +139,7 @@ ShortProcessType CurrentProcess::GetShortType(TypeKey key) {
     case CurrentProcessType::PROCESS_SERVICE_UTIL_WIN:
     case CurrentProcessType::PROCESS_SERVICE_PROXY_RESOLVER:
     case CurrentProcessType::PROCESS_SERVICE_CDM:
+    case CurrentProcessType::PROCESS_SERVICE_MEDIA_FOUNDATION:
     case CurrentProcessType::PROCESS_SERVICE_VIDEO_CAPTURE:
     case CurrentProcessType::PROCESS_SERVICE_UNZIPPER:
     case CurrentProcessType::PROCESS_SERVICE_MIRRORING:


### PR DESCRIPTION
Fixes minor warning issues that cause build errors due to -Werror in aosp.

aosp is currently setting treat_warnings_as_errors=false, but the fixes are needed in order to re-enable it.

Bug: 495203133