### PR TITLE
android: Enable QUIC Java switch

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -41,13 +41,8 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--enable-features=UseIPv4ForDNS");
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
-      String value = javaSwitches.get(JavaSwitches.ENABLE_QUIC);
-      if ("false".equalsIgnoreCase(value)) {
-        extraCommandLineArgs.add("--disable-quic");
-      } else {
-        extraCommandLineArgs.add("--enable-quic");
-      }
+    if (!javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
+      extraCommandLineArgs.add("--disable-quic");
     }
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_COBALT_AUDIO_CAPTURE_FAST_TRACK)) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -41,6 +41,10 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--enable-features=UseIPv4ForDNS");
     }
 
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
+      extraCommandLineArgs.add("--enable-quic");
+    }
+
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_COBALT_AUDIO_CAPTURE_FAST_TRACK)) {
       extraCommandLineArgs.add("--enable-features=CobaltAudioCaptureFastTrack");
     }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -42,7 +42,12 @@ public class JavaSwitches {
     }
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
-      extraCommandLineArgs.add("--enable-quic");
+      String value = javaSwitches.get(JavaSwitches.ENABLE_QUIC);
+      if ("false".equalsIgnoreCase(value)) {
+        extraCommandLineArgs.add("--disable-quic");
+      } else {
+        extraCommandLineArgs.add("--enable-quic");
+      }
     }
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_COBALT_AUDIO_CAPTURE_FAST_TRACK)) {


### PR DESCRIPTION
This bug enables the EnableQUIC Java switch and allowing --enable-quic or --disable-quic to be appended to the command line arguments. This provides a control mechanism to activate/disable QUIC for network requests.

Bug: 467778593