### PR TITLE
test: Fix compiler warnings in Starboard tests

### DIFF
--- a/starboard/common/fixed_no_free_allocator_test.cc
+++ b/starboard/common/fixed_no_free_allocator_test.cc
@@ -63,7 +63,7 @@ TEST_F(FixedNoFreeAllocatorTest, CanDoSimpleAllocations) {
 
 TEST_F(FixedNoFreeAllocatorTest, CanDoMultipleAllocationsProperly) {
   void* buffers[kMaxAllocations];
-  for (int i = 0; i < kMaxAllocations; ++i) {
+  for (size_t i = 0; i < kMaxAllocations; ++i) {
     buffers[i] = allocator_.Allocate(kAllocationSize);
     EXPECT_GE(buffers[i], buffer_.get());
     EXPECT_LE(reinterpret_cast<uintptr_t>(buffers[i]),
@@ -71,7 +71,7 @@ TEST_F(FixedNoFreeAllocatorTest, CanDoMultipleAllocationsProperly) {
                   kAllocationSize);
 
     // Make sure this allocation doesn't overlap with any previous ones.
-    for (int j = 0; j < i; ++j) {
+    for (size_t j = 0; j < i; ++j) {
       EXPECT_NE(buffers[j], buffers[i]);
       if (buffers[j] < buffers[i]) {
         EXPECT_LE(starboard::AsInteger(buffers[j]) + kAllocationSize,
@@ -85,7 +85,7 @@ TEST_F(FixedNoFreeAllocatorTest, CanDoMultipleAllocationsProperly) {
 }
 
 TEST_F(FixedNoFreeAllocatorTest, CanDoMultipleAllocationsAndFreesProperly) {
-  for (int i = 0; i < kMaxAllocations; ++i) {
+  for (size_t i = 0; i < kMaxAllocations; ++i) {
     void* current_allocation = allocator_.Allocate(kAllocationSize);
 
     EXPECT_GE(current_allocation, buffer_.get());
@@ -98,7 +98,7 @@ TEST_F(FixedNoFreeAllocatorTest, CanDoMultipleAllocationsAndFreesProperly) {
 }
 
 TEST_F(FixedNoFreeAllocatorTest, CanHandleOutOfMemory) {
-  for (int i = 0; i < kMaxAllocations; ++i) {
+  for (size_t i = 0; i < kMaxAllocations; ++i) {
     void* current_allocation = allocator_.Allocate(kAllocationSize);
 
     EXPECT_GE(current_allocation, buffer_.get());
@@ -116,14 +116,14 @@ TEST_F(FixedNoFreeAllocatorTest, CanHandleOutOfMemory) {
 }
 
 TEST_F(FixedNoFreeAllocatorTest, CanHandleAlignedMemory) {
-  const int kMinimumAlignedMemoryAllocations =
+  const size_t kMinimumAlignedMemoryAllocations =
       kBufferSize / (kAllocationSize + kAllocationAlignment);
 
-  for (int i = 0; i < kMinimumAlignedMemoryAllocations; ++i) {
+  for (size_t i = 0; i < kMinimumAlignedMemoryAllocations; ++i) {
     void* current_allocation =
         allocator_.Allocate(kAllocationSize, kAllocationAlignment);
-    EXPECT_EQ(0, reinterpret_cast<uintptr_t>(current_allocation) %
-                     kAllocationAlignment);
+    EXPECT_EQ(0u, reinterpret_cast<uintptr_t>(current_allocation) %
+                      kAllocationAlignment);
 
     EXPECT_GE(current_allocation, buffer_.get());
     EXPECT_LE(reinterpret_cast<uintptr_t>(current_allocation),

--- a/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_channel_layout_mixer_test.cc
@@ -121,8 +121,10 @@ class AudioChannelLayoutMixerTest
 
     if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
       float* output_buffer = reinterpret_cast<float*>(output->data());
-      for (size_t i = 0; i < output->frames() * output_num_of_channels; i++) {
-        int src_index = i;
+      for (size_t i = 0;
+           i < static_cast<size_t>(output->frames()) * output_num_of_channels;
+           i++) {
+        size_t src_index = i;
         if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
           src_index = i % output->frames() * output_num_of_channels +
                       i / output->frames();
@@ -138,8 +140,10 @@ class AudioChannelLayoutMixerTest
       }
     } else {
       int16_t* output_buffer = reinterpret_cast<int16_t*>(output->data());
-      for (size_t i = 0; i < output->frames() * output_num_of_channels; i++) {
-        int src_index = i;
+      for (size_t i = 0;
+           i < static_cast<size_t>(output->frames()) * output_num_of_channels;
+           i++) {
+        size_t src_index = i;
         if (storage_type_ == kSbMediaAudioFrameStorageTypePlanar) {
           src_index = i % output->frames() * output_num_of_channels +
                       i / output->frames();
@@ -342,13 +346,14 @@ TEST_P(AudioChannelLayoutMixerTest, MixToFivePointOne) {
                                kExpectedFivePointOneToFivePointOneOutput);
 }
 
-INSTANTIATE_TEST_CASE_P(AudioChannelLayoutMixerTests,
-                        AudioChannelLayoutMixerTest,
-                        Combine(Values(kSbMediaAudioSampleTypeInt16Deprecated,
-                                       kSbMediaAudioSampleTypeFloat32),
-                                Values(kSbMediaAudioFrameStorageTypeInterleaved,
-                                       kSbMediaAudioFrameStorageTypePlanar)),
-                        GetAudioChannelLayoutMixerTestConfigName);
+INSTANTIATE_TEST_SUITE_P(
+    AudioChannelLayoutMixerTests,
+    AudioChannelLayoutMixerTest,
+    Combine(Values(kSbMediaAudioSampleTypeInt16Deprecated,
+                   kSbMediaAudioSampleTypeFloat32),
+            Values(kSbMediaAudioFrameStorageTypeInterleaved,
+                   kSbMediaAudioFrameStorageTypePlanar)),
+    GetAudioChannelLayoutMixerTestConfigName);
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
@@ -107,7 +107,7 @@ class AudioDecoderTest
   }
   void SetUp() override {
     ASSERT_NE(dmp_reader_.audio_stream_info().codec, kSbMediaAudioCodecNone);
-    ASSERT_GT(dmp_reader_.number_of_audio_buffers(), 0);
+    ASSERT_GT(dmp_reader_.number_of_audio_buffers(), 0u);
 
     CreateComponents(dmp_reader_.audio_stream_info(), &audio_decoder_,
                      &audio_renderer_sink_);
@@ -274,12 +274,10 @@ class AudioDecoderTest
   }
 
   // The start_index will be updated to the new position.
-  void WriteTimeLimitedInputs(int* start_index, int64_t time_limit) {
+  void WriteTimeLimitedInputs(size_t* start_index, int64_t time_limit) {
     SB_DCHECK(start_index);
-    SB_DCHECK_GE(*start_index, 0);
     SB_DCHECK_LT(*start_index, dmp_reader_.number_of_audio_buffers());
-    ASSERT_NO_FATAL_FAILURE(
-        WriteSingleInput(static_cast<size_t>(*start_index)));
+    ASSERT_NO_FATAL_FAILURE(WriteSingleInput(*start_index));
     SB_DCHECK(last_input_buffer_);
     int64_t last_timestamp = last_input_buffer_->timestamp();
     int64_t first_timestamp = last_timestamp;
@@ -290,8 +288,7 @@ class AudioDecoderTest
       Event event = kError;
       ASSERT_NO_FATAL_FAILURE(WaitForNextEvent(&event));
       if (event == kConsumed) {
-        ASSERT_NO_FATAL_FAILURE(
-            WriteSingleInput(static_cast<size_t>(*start_index)));
+        ASSERT_NO_FATAL_FAILURE(WriteSingleInput(*start_index));
         SB_DCHECK(last_input_buffer_);
         last_timestamp = last_input_buffer_->timestamp();
         ++(*start_index);
@@ -701,7 +698,7 @@ TEST_P(AudioDecoderTest, LimitedInput) {
   int64_t duration = 500'000;  // 0.5 seconds
 
   ASSERT_TRUE(decoded_audios_.empty());
-  int start_index = 0;
+  size_t start_index = 0;
   ASSERT_NO_FATAL_FAILURE(WriteTimeLimitedInputs(&start_index, duration));
 
   if (start_index >= dmp_reader_.number_of_audio_buffers()) {
@@ -713,16 +710,16 @@ TEST_P(AudioDecoderTest, LimitedInput) {
 }
 
 TEST_P(AudioDecoderTest, ContinuedLimitedInput) {
-  constexpr int kMaxAccessUnitsToDecode = 256;
+  constexpr size_t kMaxAccessUnitsToDecode = 256;
   int64_t duration = 500'000;  // 0.5 seconds
 
   int64_t start = CurrentMonotonicTime();
-  int start_index = 0;
+  size_t start_index = 0;
   Event event;
   while (true) {
     ASSERT_NO_FATAL_FAILURE(WriteTimeLimitedInputs(&start_index, duration));
-    if (start_index >= std::min<int>(dmp_reader_.number_of_audio_buffers(),
-                                     kMaxAccessUnitsToDecode)) {
+    if (start_index >= std::min<size_t>(dmp_reader_.number_of_audio_buffers(),
+                                        kMaxAccessUnitsToDecode)) {
       break;
     }
     SB_DCHECK(last_input_buffer_);
@@ -963,7 +960,7 @@ TEST_P(AudioDecoderTest, ResetInRunningStateWithEndOfStream) {
   ASSERT_NO_FATAL_FAILURE(AssertOutputFormatValid());
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AudioDecoderTests,
     AudioDecoderTest,
     Combine(ValuesIn(GetSupportedAudioTestFiles(kIncludeHeaac,

--- a/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_resampler_test.cc
@@ -139,7 +139,7 @@ TEST_P(AudioResamplerTest, SunnyDay) {
   // they should have same timestamp.
   EXPECT_EQ(inputs_.size(), outputs.size());
   int total_output_frames = 0;
-  for (int i = 0; i < outputs.size(); i++) {
+  for (size_t i = 0; i < outputs.size(); i++) {
     EXPECT_EQ(inputs_[i]->timestamp(), outputs[i]->timestamp());
     total_output_frames += outputs[i]->frames();
     EXPECT_NEAR(
@@ -171,16 +171,16 @@ std::string GetTestConfigName(
   return name;
 }
 
-INSTANTIATE_TEST_CASE_P(AudioResamplerTests,
-                        AudioResamplerTest,
-                        Combine(ValuesIn(kSampleTypesToTest),
-                                ValuesIn(kStorageTypesToTest),
-                                ValuesIn(kSampleRatesToTest),
-                                ValuesIn(kSampleTypesToTest),
-                                ValuesIn(kStorageTypesToTest),
-                                ValuesIn(kSampleRatesToTest),
-                                ValuesIn(kChannelsToTest)),
-                        GetTestConfigName);
+INSTANTIATE_TEST_SUITE_P(AudioResamplerTests,
+                         AudioResamplerTest,
+                         Combine(ValuesIn(kSampleTypesToTest),
+                                 ValuesIn(kStorageTypesToTest),
+                                 ValuesIn(kSampleRatesToTest),
+                                 ValuesIn(kSampleTypesToTest),
+                                 ValuesIn(kStorageTypesToTest),
+                                 ValuesIn(kSampleRatesToTest),
+                                 ValuesIn(kChannelsToTest)),
+                         GetTestConfigName);
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/file_cache_reader_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/file_cache_reader_test.cc
@@ -38,12 +38,12 @@ class FileCacheReaderTest : public ::testing::Test {
 };
 
 TEST_F(FileCacheReaderTest, FileCacheReader) {
+  const int kTestSize = 5 * 1024 * 1024;
   const std::vector<int> sizes_to_read = {0, 1, 2, 3, 4, 0, 5, 8, 13};
 
   std::vector<char> true_contents;
   {
     // Use a 5MB snippet from the true file to compare against.
-    const size_t kTestSize = 5 * 1024 * 1024;
     ScopedFile file(file_cache_reader_.GetAbsolutePathName().c_str(), 0);
     true_contents.resize(kTestSize);
     int bytes_read = file.ReadAll(true_contents.data(), kTestSize);
@@ -55,10 +55,9 @@ TEST_F(FileCacheReaderTest, FileCacheReader) {
 
   int true_offset = 0;
   int size_index = 0;
-  while (true_offset < true_contents.size()) {
+  while (true_offset < kTestSize) {
     auto size_to_read =
-        std::min(sizes_to_read[size_index],
-                 static_cast<int>(true_contents.size()) - true_offset);
+        std::min(sizes_to_read[size_index], kTestSize - true_offset);
     size_index = (size_index + 1) % sizes_to_read.size();
 
     read_contents.resize(size_to_read);
@@ -73,7 +72,7 @@ TEST_F(FileCacheReaderTest, FileCacheReader) {
     ASSERT_EQ(0, result);
     true_offset += bytes_read;
   }
-  EXPECT_EQ(true_offset, true_contents.size());
+  EXPECT_EQ(true_offset, kTestSize);
 }
 
 }  // namespace

--- a/starboard/shared/starboard/player/filter/testing/player_components_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/player_components_test.cc
@@ -173,7 +173,7 @@ class PlayerComponentsTest
     video_index_ = 0;
     // Find the closest key frame prior to |seek_to_time|.
     if (GetAudioRenderer()) {
-      for (int index = 1; index < audio_reader_->number_of_audio_buffers();
+      for (size_t index = 1; index < audio_reader_->number_of_audio_buffers();
            index++) {
         SbPlayerSampleInfo sample_info =
             audio_reader_->GetPlayerSampleInfo(kSbMediaTypeAudio, index);
@@ -184,7 +184,7 @@ class PlayerComponentsTest
       }
     }
     if (GetVideoRenderer()) {
-      for (int index = 1; index < video_reader_->number_of_video_buffers();
+      for (size_t index = 1; index < video_reader_->number_of_video_buffers();
            index++) {
         SbPlayerSampleInfo sample_info =
             video_reader_->GetPlayerSampleInfo(kSbMediaTypeVideo, index);
@@ -485,8 +485,8 @@ class PlayerComponentsTest
   unique_ptr<VideoDmpReader> video_reader_;
   unique_ptr<PlayerComponents> player_components_;
   double playback_rate_ = 1.0;
-  int audio_index_ = 0;
-  int video_index_ = 0;
+  size_t audio_index_ = 0;
+  size_t video_index_ = 0;
   bool has_error_ = false;
   bool audio_prerolled_ = false;
   bool video_prerolled_ = false;
@@ -523,7 +523,6 @@ TEST_P(PlayerComponentsTest, SunnyDay) {
   ASSERT_EQ(GetMediaTime(), 0);
   ASSERT_FALSE(IsPlaying());
 
-  int64_t play_requested_at = CurrentMonotonicTime();
   Play();
   int64_t eos_timestamp =
       std::max<int64_t>(1'000'000LL, GetMaxWrittenBufferTimestamp());
@@ -751,10 +750,10 @@ vector<PlayerComponentsTestParam> GetSupportedCreationParameters() {
   return supported_parameters;
 }
 
-INSTANTIATE_TEST_CASE_P(PlayerComponentsTests,
-                        PlayerComponentsTest,
-                        ValuesIn(GetSupportedCreationParameters()),
-                        GetPlayerComponentsTestConfigName);
+INSTANTIATE_TEST_SUITE_P(PlayerComponentsTests,
+                         PlayerComponentsTest,
+                         ValuesIn(GetSupportedCreationParameters()),
+                         GetPlayerComponentsTestConfigName);
 }  // namespace
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test.cc
@@ -87,11 +87,11 @@ std::string GetVideoDecoderTestConfigName(
 }
 
 TEST_P(VideoDecoderTest, PrerollFrameCount) {
-  EXPECT_GT(fixture_.video_decoder()->GetPrerollFrameCount(), 0);
+  EXPECT_GT(fixture_.video_decoder()->GetPrerollFrameCount(), 0u);
 }
 
 TEST_P(VideoDecoderTest, MaxNumberOfCachedFrames) {
-  EXPECT_GT(fixture_.video_decoder()->GetMaxNumberOfCachedFrames(), 1);
+  EXPECT_GT(fixture_.video_decoder()->GetMaxNumberOfCachedFrames(), 1u);
 }
 
 TEST_P(VideoDecoderTest, PrerollTimeout) {
@@ -149,8 +149,6 @@ TEST_P(VideoDecoderTest, ThreeMoreDecoders) {
               video_components;
 
           for (int i = 0; i < kDecodersToCreate; ++i) {
-            SbMediaAudioSampleInfo dummy_audio_sample_info = {
-                kSbMediaAudioCodecNone};
             PlayerComponents::Factory::CreationParameters creation_parameters(
                 CreateVideoStreamInfo(fixture_.dmp_reader().video_codec()),
                 &players[i], output_mode, max_video_input_size,
@@ -341,7 +339,7 @@ TEST_P(VideoDecoderTest, ResetAfterInput) {
 TEST_P(VideoDecoderTest, MultipleResets) {
   const size_t max_inputs_to_write =
       std::min<size_t>(fixture_.dmp_reader().number_of_video_buffers(), 10);
-  for (int max_inputs = 1; max_inputs < max_inputs_to_write; ++max_inputs) {
+  for (size_t max_inputs = 1; max_inputs < max_inputs_to_write; ++max_inputs) {
     bool error_occurred = false;
     fixture_.WriteMultipleInputs(
         0, max_inputs, [&](const Event& event, bool* continue_process) {
@@ -392,7 +390,7 @@ TEST_P(VideoDecoderTest, MultipleInputs) {
   if (frames_decoded < number_of_expected_decoded_frames) {
     fixture_.WriteEndOfStream();
     ASSERT_NO_FATAL_FAILURE(fixture_.DrainOutputs(
-        &error_occurred, [=](const Event& event, bool* continue_process) {
+        &error_occurred, [this](const Event& event, bool* continue_process) {
           // Keep 1 decoded frame, assuming it's used by renderer.
           while (fixture_.GetDecodedFramesCount() > 1) {
             fixture_.PopDecodedFrame();
@@ -422,7 +420,7 @@ TEST_P(VideoDecoderTest, Preroll) {
         }
         if (CurrentMonotonicTime() - start >= preroll_timeout) {
           // After preroll timeout, we should get at least 1 decoded frame.
-          ASSERT_GT(fixture_.GetDecodedFramesCount(), 0);
+          ASSERT_GT(fixture_.GetDecodedFramesCount(), 0u);
           *continue_process = false;
           return;
         }
@@ -454,7 +452,7 @@ TEST_P(VideoDecoderTest, HoldFramesUntilFull) {
     return;
   }
   ASSERT_NO_FATAL_FAILURE(fixture_.DrainOutputs(
-      &error_occurred, [=](const Event& event, bool* continue_process) {
+      &error_occurred, [this](const Event& event, bool* continue_process) {
         *continue_process =
             fixture_.GetDecodedFramesCount() <
             fixture_.video_decoder()->GetMaxNumberOfCachedFrames();
@@ -463,7 +461,7 @@ TEST_P(VideoDecoderTest, HoldFramesUntilFull) {
 }
 
 TEST_P(VideoDecoderTest, DecodeFullGOP) {
-  int gop_size = 1;
+  size_t gop_size = 1;
   while (gop_size < fixture_.dmp_reader().number_of_video_buffers()) {
     if (fixture_.GetVideoInputBuffer(gop_size)
             ->video_sample_info()
@@ -491,7 +489,7 @@ TEST_P(VideoDecoderTest, DecodeFullGOP) {
   fixture_.WriteEndOfStream();
 
   ASSERT_NO_FATAL_FAILURE(fixture_.DrainOutputs(
-      &error_occurred, [=](const Event& event, bool* continue_process) {
+      &error_occurred, [this](const Event& event, bool* continue_process) {
         // Keep 1 decoded frame, assuming it's used by renderer.
         while (fixture_.GetDecodedFramesCount() > 1) {
           fixture_.PopDecodedFrame();
@@ -501,10 +499,10 @@ TEST_P(VideoDecoderTest, DecodeFullGOP) {
   ASSERT_FALSE(error_occurred);
 }
 
-INSTANTIATE_TEST_CASE_P(VideoDecoderTests,
-                        VideoDecoderTest,
-                        Combine(ValuesIn(GetSupportedVideoTests()), Bool()),
-                        GetVideoDecoderTestConfigName);
+INSTANTIATE_TEST_SUITE_P(VideoDecoderTests,
+                         VideoDecoderTest,
+                         Combine(ValuesIn(GetSupportedVideoTests()), Bool()),
+                         GetVideoDecoderTestConfigName);
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
+++ b/starboard/shared/starboard/player/filter/testing/video_decoder_test_fixture.cc
@@ -72,7 +72,7 @@ VideoDecoderTestFixture::VideoDecoderTestFixture(
 
 void VideoDecoderTestFixture::Initialize() {
   ASSERT_NE(dmp_reader_.video_codec(), kSbMediaVideoCodecNone);
-  ASSERT_GT(dmp_reader_.number_of_video_buffers(), 0);
+  ASSERT_GT(dmp_reader_.number_of_video_buffers(), 0u);
   ASSERT_TRUE(GetVideoInputBuffer(0)->video_sample_info().is_key_frame);
 
   SbPlayerOutputMode output_mode = output_mode_;


### PR DESCRIPTION
Fix various compiler warnings in Starboard unit tests and player filter tests. This includes:
- Fixing sign-compare warnings in loops and assertions by aligning types to size_t or using unsigned literals.
- Removing unused variables.
- Fixing implicit 'this' capture in lambdas to avoid C++20 deprecation.
- Fixing missing braces in subobject initialization.
- Replacing deprecated INSTANTIATE_TEST_CASE_P with INSTANTIATE_TEST_SUITE_P.

Bug: 276483058