### PR TITLE
refactor: Remove BindHostReceiverCallback

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -150,10 +150,6 @@ std::string GetMimeFromAudioType(const ::media::AudioType& type) {
   return codecs;
 }
 
-void BindHostReceiverWithValuation(mojo::GenericPendingReceiver receiver) {
-  content::RenderThread::Get()->BindHostReceiver(std::move(receiver));
-}
-
 // TODO: b/460292554 - This code is a tentative solution, and will be replaced
 // once base::Feature is fully supported.
 //
@@ -324,12 +320,6 @@ void CobaltContentRendererClient::EnsureH5vccSettingsRemoteInitialized() {
           base::SequencedTaskRunner::GetCurrentDefault())};
   content::RenderThread::Get()->BindHostReceiver(
       h5vcc_settings_remote_->BindNewPipeAndPassReceiver());
-}
-
-void CobaltContentRendererClient::BindHostReceiver(
-    mojo::GenericPendingReceiver receiver) {
-  CHECK_CALLED_ON_VALID_THREAD(main_thread_checker_);
-  BindHostReceiverWithValuation(std::move(receiver));
 }
 
 CobaltContentRendererClient::CobaltContentRendererClient()
@@ -507,12 +497,6 @@ void CobaltContentRendererClient::GetStarboardRendererFactoryTraits(
     experimental_features = ProcessH5vccSettings(h5vcc_settings);
   }
   renderer_factory_traits->experimental_features = experimental_features;
-
-  // TODO(b/405424096) - Cobalt: Move VideoGeometrySetterService to Gpu thread.
-  renderer_factory_traits->bind_host_receiver_callback =
-      base::BindPostTaskToCurrentDefault(
-          base::BindRepeating(&CobaltContentRendererClient::BindHostReceiver,
-                              weak_factory_.GetWeakPtr()));
 }
 
 void CobaltContentRendererClient::PostSandboxInitialized() {

--- a/cobalt/renderer/cobalt_content_renderer_client.h
+++ b/cobalt/renderer/cobalt_content_renderer_client.h
@@ -69,8 +69,6 @@ class CobaltContentRendererClient : public content::ContentRendererClient {
 
   uint64_t GetSbWindowHandle() const { return sb_window_handle_; }
 
-  void BindHostReceiver(mojo::GenericPendingReceiver receiver);
-
  private:
   void EnsureH5vccSettingsRemoteInitialized();
   void OnGetSbWindow(uint64_t handle);

--- a/media/base/starboard/renderer_factory_traits.h
+++ b/media/base/starboard/renderer_factory_traits.h
@@ -24,7 +24,7 @@
 #include "media/base/media_export.h"
 #include "media/base/starboard/starboard_renderer_config.h"
 #include "media/base/timestamp_constants.h"
-#include "media/starboard/bind_host_receiver_callback.h"
+#include "media/starboard/starboard_callbacks.h"
 #include "ui/gfx/geometry/size.h"
 
 namespace media {
@@ -41,7 +41,6 @@ struct MEDIA_EXPORT RendererFactoryTraits {
   StarboardRendererConfig::ExperimentalFeatures experimental_features;
   gfx::Size viewport_size;
   GetSbWindowHandleCallback get_sb_window_handle_callback;
-  BindHostReceiverCallback bind_host_receiver_callback = base::NullCallback();
 };
 
 }  // namespace media

--- a/media/mojo/clients/starboard/starboard_renderer_client.h
+++ b/media/mojo/clients/starboard/starboard_renderer_client.h
@@ -27,7 +27,7 @@
 #include "media/base/video_renderer_sink.h"
 #include "media/mojo/clients/mojo_renderer_wrapper.h"
 #include "media/mojo/mojom/renderer_extensions.mojom.h"
-#include "media/starboard/bind_host_receiver_callback.h"
+#include "media/starboard/starboard_callbacks.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/receiver.h"

--- a/media/mojo/clients/starboard/starboard_renderer_client_factory.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_factory.cc
@@ -53,8 +53,7 @@ StarboardRendererClientFactory::StarboardRendererClientFactory(
       max_video_capabilities_(traits->max_video_capabilities),
       experimental_features_(traits->experimental_features),
       viewport_size_(traits->viewport_size),
-      get_sb_window_handle_callback_(traits->get_sb_window_handle_callback),
-      bind_host_receiver_callback_(traits->bind_host_receiver_callback) {}
+      get_sb_window_handle_callback_(traits->get_sb_window_handle_callback) {}
 
 StarboardRendererClientFactory::~StarboardRendererClientFactory() = default;
 

--- a/media/mojo/clients/starboard/starboard_renderer_client_factory.h
+++ b/media/mojo/clients/starboard/starboard_renderer_client_factory.h
@@ -22,7 +22,7 @@
 #include "media/base/renderer_factory.h"
 #include "media/base/starboard/renderer_factory_traits.h"
 #include "media/base/starboard/starboard_renderer_config.h"
-#include "media/starboard/bind_host_receiver_callback.h"
+#include "media/starboard/starboard_callbacks.h"
 
 namespace base {
 class TimeDelta;
@@ -76,7 +76,6 @@ class MEDIA_EXPORT StarboardRendererClientFactory final
   const StarboardRendererConfig::ExperimentalFeatures experimental_features_;
   const gfx::Size viewport_size_;
   const GetSbWindowHandleCallback get_sb_window_handle_callback_;
-  const BindHostReceiverCallback bind_host_receiver_callback_;
 };
 
 }  // namespace media

--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -35,7 +35,6 @@ source_set("starboard") {
   if (use_starboard_media) {
     sources += [
       "bidirectional_fit_decoder_buffer_allocator_strategy.h",
-      "bind_host_receiver_callback.h",
       "decoder_buffer_allocator.cc",
       "decoder_buffer_allocator.h",
       "decoder_buffer_memory_info.cc",
@@ -46,6 +45,7 @@ source_set("starboard") {
       "sbplayer_bridge.h",
       "sbplayer_interface.cc",
       "sbplayer_interface.h",
+      "starboard_callbacks.h",
       "starboard_cdm.cc",
       "starboard_cdm.h",
       "starboard_cdm_factory.cc",

--- a/media/starboard/starboard_callbacks.h
+++ b/media/starboard/starboard_callbacks.h
@@ -12,22 +12,18 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef MEDIA_STARBOARD_BIND_HOST_RECEIVER_CALLBACK_H_
-#define MEDIA_STARBOARD_BIND_HOST_RECEIVER_CALLBACK_H_
+#ifndef MEDIA_STARBOARD_STARBOARD_CALLBACKS_H_
+#define MEDIA_STARBOARD_STARBOARD_CALLBACKS_H_
+
+#include <cstdint>
 
 #include "base/functional/callback.h"
-#include "mojo/public/cpp/bindings/generic_pending_receiver.h"
 
 namespace media {
 
 // Handy callback type to get sb window handle from CobaltContentRendererClient.
 using GetSbWindowHandleCallback = base::RepeatingCallback<uint64_t()>;
 
-// Handy callback type to bind host receiver to
-// VideoGeometryChangeSubscriber on browser thread.
-using BindHostReceiverCallback =
-    base::RepeatingCallback<void(mojo::GenericPendingReceiver)>;
-
 }  // namespace media
 
-#endif  // MEDIA_STARBOARD_BIND_HOST_RECEIVER_CALLBACK_H_
+#endif  // MEDIA_STARBOARD_STARBOARD_CALLBACKS_H_


### PR DESCRIPTION
Remove the out-of-date BindHostReceiverCallback type and its usages,
This callback was wrongly cherry-picked and is no longer needed
(https://github.com/youtube/cobalt/pull/9489).
The related header file is renamed to starboard_callbacks.h to reflect
that it now only contains GetSbWindowHandleCallback.

Issue: 510848941