### PR TITLE
Cobalt: Correct MediaImage JNI path for Google3

### DIFF
--- a/services/media_session/public/cpp/BUILD.gn
+++ b/services/media_session/public/cpp/BUILD.gn
@@ -33,6 +33,11 @@ component("base_cpp") {
       "media_position_android.cc",
     ]
     deps += [ "android:media_session_jni_headers" ]
+    if (is_cobalt) {
+      deps += [ 
+        "//third_party/jni_zero:cobalt_for_google3_buildflags",
+      ]
+    }
   }
 
   defines = [ "IS_MEDIA_SESSION_BASE_CPP_IMPL" ]

--- a/services/media_session/public/cpp/media_image_android.cc
+++ b/services/media_session/public/cpp/media_image_android.cc
@@ -24,12 +24,14 @@ namespace media_session {
 ScopedJavaLocalRef<jobjectArray> MediaImage::ToJavaArray(
     JNIEnv* env,
     const std::vector<MediaImage>& images) {
-  ScopedJavaLocalRef<jclass> string_clazz = base::android::GetClass(
-      env, "org/chromium/services/media_session/MediaImage");
-#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_COBALT_ON_GOOGLE3)
-    string_clazz = base::android::GetClass(
-      env, "cobalt/org/chromium/services/media_session/MediaImage");
+    std::string class_name = "org/chromium/services/media_session/MediaImage";
+#if BUILDFLAG(IS_COBALT) 
+#if BUILDFLAG(IS_COBALT_ON_GOOGLE3)
+    class_name = "cobalt/org/chromium/services/media_session/MediaImage";
 #endif
+#endif
+  ScopedJavaLocalRef<jclass> string_clazz = base::android::GetClass(
+      env, class_name.c_str());
   jobjectArray joa =
       env->NewObjectArray(images.size(), string_clazz.obj(), NULL);
   base::android::CheckException(env);

--- a/services/media_session/public/cpp/media_image_android.cc
+++ b/services/media_session/public/cpp/media_image_android.cc
@@ -9,6 +9,9 @@
 #include "base/android/jni_android.h"
 #include "base/android/jni_string.h"
 #include "url/android/gurl_android.h"
+#if BUILDFLAG(IS_COBALT)
+#include "third_party/jni_zero/cobalt_for_google3_buildflags.h" // nogncheck
+#endif
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "services/media_session/public/cpp/android/media_session_jni_headers/MediaImage_jni.h"
@@ -23,6 +26,10 @@ ScopedJavaLocalRef<jobjectArray> MediaImage::ToJavaArray(
     const std::vector<MediaImage>& images) {
   ScopedJavaLocalRef<jclass> string_clazz = base::android::GetClass(
       env, "org/chromium/services/media_session/MediaImage");
+#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_COBALT_ON_GOOGLE3)
+    string_clazz = base::android::GetClass(
+      env, "cobalt/org/chromium/services/media_session/MediaImage");
+#endif
   jobjectArray joa =
       env->NewObjectArray(images.size(), string_clazz.obj(), NULL);
   base::android::CheckException(env);


### PR DESCRIPTION
Add conditional logic to resolve the MediaImage JNI class path.
When built for Cobalt within the Google3 environment, the Java
package for MediaImage is prefixed with "cobalt/". This ensures
the correct class is found, preventing failures in media session
APIs on Android for these specific builds. Also add the required
build flag dependency.

Bug: 508673132