### PR TITLE
Run updater in Cobalt

### DIFF
--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -106,6 +106,10 @@ source_set("browser") {
     ]
   }
 
+  if (use_evergreen) {
+    deps += [ "//cobalt/updater" ]
+  }
+
   if (is_starboard) {
     deps += [ "//ui/ozone/platform/starboard" ]
   }

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -74,6 +74,11 @@
 #include "third_party/blink/public/common/associated_interfaces/associated_interface_registry.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
 
+#if BUILDFLAG(USE_EVERGREEN)
+#include "cobalt/updater/updater_module.h"  //nogncheck
+#include "content/public/browser/storage_partition.h"
+#endif  // BUILDFLAG(USE_EVERGREEN)
+
 #if BUILDFLAG(IS_ANDROID)
 #include "base/android/locale_utils.h"
 #include "cobalt/android/browser_jni_headers/CobaltContentBrowserClient_jni.h"
@@ -376,6 +381,17 @@ void CobaltContentBrowserClient::OnWebContentsCreated(
   }
   VLOG(1) << "NativeSplash: Observing main frame WebContents.";
   web_contents_observer_.reset(new CobaltWebContentsObserver(web_contents));
+#if BUILDFLAG(USE_EVERGREEN)
+  // Create the updater module singleton if not already created.
+  auto* storage_partition =
+      web_contents->GetPrimaryMainFrame()->GetStoragePartition();
+  if (storage_partition) {
+    LOG(INFO) << "Creating UpdaterModule singleton.";
+    updater::UpdaterModule::CreateInstance(
+        storage_partition->GetURLLoaderFactoryForBrowserProcess(),
+        updater::kDefaultUpdateCheckDelay);
+  }
+#endif
 }
 
 void CobaltContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -385,7 +385,7 @@ void CobaltContentBrowserClient::OnWebContentsCreated(
   // Create the updater module singleton if not already created.
   auto* storage_partition =
       web_contents->GetPrimaryMainFrame()->GetStoragePartition();
-  if (storage_partition) {
+  if (storage_partition && !updater::UpdaterModule::GetInstance()) {
     LOG(INFO) << "Creating UpdaterModule singleton.";
     updater::UpdaterModule::CreateInstance(
         storage_partition->GetURLLoaderFactoryForBrowserProcess(),

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -533,6 +533,15 @@ void Shell::PrimaryMainDocumentElementAvailable() {
 #if BUILDFLAG(IS_ANDROIDTV)
   starboard::StarboardBridge::GetInstance()->SetStartupMilestone(27);
 #endif
+#if BUILDFLAG(USE_EVERGREEN)
+  cobalt::updater::UpdaterModule* updater_module =
+      cobalt::updater::UpdaterModule::GetInstance();
+  if (updater_module) {
+    LOG(INFO) << "Mark the current installation as successful after the "
+                 "PrimaryMainDocumentElement is available.";
+    updater_module->MarkSuccessful();
+  }
+#endif
 }
 
 void Shell::DidFinishLoad(RenderFrameHost* render_frame_host,
@@ -862,16 +871,6 @@ WebContents* Shell::OpenURLFromTab(
   if (navigation_handle_callback && navigation_handle) {
     std::move(navigation_handle_callback).Run(*navigation_handle);
   }
-
-#if BUILDFLAG(USE_EVERGREEN)
-  cobalt::updater::UpdaterModule* updater_module =
-      cobalt::updater::UpdaterModule::GetInstance();
-  if (updater_module) {
-    // Mark the current installation as successful.
-    // TODO(b/458770751): investigate moving this to after load is finished
-    updater_module->MarkSuccessful();
-  }
-#endif
 
   return target;
 }

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -70,6 +70,11 @@
 #include "third_party/blink/public/mojom/mediastream/media_stream.mojom.h"
 #include "third_party/blink/public/mojom/window_features/window_features.mojom.h"
 
+#if BUILDFLAG(USE_EVERGREEN)
+#include "cobalt/updater/updater_module.h"
+#include "content/public/browser/storage_partition.h"
+#endif
+
 #if BUILDFLAG(IS_ANDROID)
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "starboard/android/shared/audio_permission_requester.h"
@@ -347,6 +352,18 @@ void Shell::FinishShellInitialization(Shell* shell) {
   GetPlatform()->SetSkipForTesting(shell->skip_for_testing());
 #endif  // BUILDFLAG(IS_ANDROID)
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
+#if BUILDFLAG(USE_EVERGREEN)
+  // Create the updater module singleton.
+  auto* storage_partition =
+      raw_web_contents->GetPrimaryMainFrame()->GetStoragePartition();
+  if (storage_partition) {
+    LOG(INFO) << "Creating UpdaterModule singleton for Shell.";
+    cobalt::updater::UpdaterModule::CreateInstance(
+        storage_partition->GetURLLoaderFactoryForBrowserProcess(),
+        cobalt::updater::kDefaultUpdateCheckDelay);
+  }
+#endif
 }
 
 Shell* Shell::CreateShell(
@@ -845,6 +862,16 @@ WebContents* Shell::OpenURLFromTab(
   if (navigation_handle_callback && navigation_handle) {
     std::move(navigation_handle_callback).Run(*navigation_handle);
   }
+
+#if BUILDFLAG(USE_EVERGREEN)
+  cobalt::updater::UpdaterModule* updater_module =
+      cobalt::updater::UpdaterModule::GetInstance();
+  if (updater_module) {
+    // Mark the current installation as successful.
+    // TODO(b/458770751): investigate moving this to after load is finished
+    updater_module->MarkSuccessful();
+  }
+#endif
 
   return target;
 }

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -71,8 +71,7 @@
 #include "third_party/blink/public/mojom/window_features/window_features.mojom.h"
 
 #if BUILDFLAG(USE_EVERGREEN)
-#include "cobalt/updater/updater_module.h"
-#include "content/public/browser/storage_partition.h"
+#include "cobalt/updater/updater_module.h"  //nogncheck
 #endif
 
 #if BUILDFLAG(IS_ANDROID)
@@ -352,18 +351,6 @@ void Shell::FinishShellInitialization(Shell* shell) {
   GetPlatform()->SetSkipForTesting(shell->skip_for_testing());
 #endif  // BUILDFLAG(IS_ANDROID)
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
-#if BUILDFLAG(USE_EVERGREEN)
-  // Create the updater module singleton.
-  auto* storage_partition =
-      raw_web_contents->GetPrimaryMainFrame()->GetStoragePartition();
-  if (storage_partition) {
-    LOG(INFO) << "Creating UpdaterModule singleton for Shell.";
-    cobalt::updater::UpdaterModule::CreateInstance(
-        storage_partition->GetURLLoaderFactoryForBrowserProcess(),
-        cobalt::updater::kDefaultUpdateCheckDelay);
-  }
-#endif
 }
 
 Shell* Shell::CreateShell(

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -91,6 +91,25 @@ namespace updater {
 // The delay before the first update check.
 const base::TimeDelta kDefaultUpdateCheckDelay = base::Seconds(30);
 
+// static
+base::NoDestructor<UpdaterModule>* UpdaterModule::updater_module_ = nullptr;
+
+void UpdaterModule::CreateInstance(
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    base::TimeDelta update_check_delay) {
+  DCHECK(!updater_module_)
+      << "UpdaterModule is already created. Use UpdaterModule::GetInstance() "
+         "to get the instance.";
+  updater_module_ = new base::NoDestructor<UpdaterModule>(
+      std::move(url_loader_factory), update_check_delay);
+}
+
+UpdaterModule* UpdaterModule::GetInstance() {
+  DCHECK(updater_module_) << "UpdaterModule is not created yet, and cannot be "
+                             "retrieved by UpdaterModule::GetInstance().";
+  return updater_module_->get();
+}
+
 void Observer::OnEvent(const update_client::CrxUpdateItem& item) {
   std::string status;
   crx_update_item_ = item;

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -108,8 +108,11 @@ void UpdaterModule::CreateInstance(
 }
 
 UpdaterModule* UpdaterModule::GetInstance() {
-  DCHECK(updater_module_) << "UpdaterModule is not created yet, and cannot be "
-                             "retrieved by UpdaterModule::GetInstance().";
+  if (!updater_module_) {
+    LOG(WARNING) << "UpdaterModule is not created yet, and cannot be "
+                    "retrieved by UpdaterModule::GetInstance().";
+    return nullptr;
+  }
   return updater_module_;
 }
 

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -97,9 +97,12 @@ base::NoDestructor<UpdaterModule>* UpdaterModule::updater_module_ = nullptr;
 void UpdaterModule::CreateInstance(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
     base::TimeDelta update_check_delay) {
-  DCHECK(!updater_module_)
-      << "UpdaterModule is already created. Use UpdaterModule::GetInstance() "
-         "to get the instance.";
+  if (updater_module_) {
+    LOG(WARNING)
+        << "UpdaterModule is already created. Use UpdaterModule::GetInstance() "
+           "to get the instance.";
+    return;
+  }
   updater_module_ = new base::NoDestructor<UpdaterModule>(
       std::move(url_loader_factory), update_check_delay);
 }

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -92,7 +92,7 @@ namespace updater {
 const base::TimeDelta kDefaultUpdateCheckDelay = base::Seconds(30);
 
 // static
-base::NoDestructor<UpdaterModule>* UpdaterModule::updater_module_ = nullptr;
+UpdaterModule* UpdaterModule::updater_module_ = nullptr;
 
 void UpdaterModule::CreateInstance(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
@@ -103,14 +103,14 @@ void UpdaterModule::CreateInstance(
            "to get the instance.";
     return;
   }
-  updater_module_ = new base::NoDestructor<UpdaterModule>(
-      std::move(url_loader_factory), update_check_delay);
+  updater_module_ =
+      new UpdaterModule(std::move(url_loader_factory), update_check_delay);
 }
 
 UpdaterModule* UpdaterModule::GetInstance() {
   DCHECK(updater_module_) << "UpdaterModule is not created yet, and cannot be "
                              "retrieved by UpdaterModule::GetInstance().";
-  return updater_module_->get();
+  return updater_module_;
 }
 
 void Observer::OnEvent(const update_client::CrxUpdateItem& item) {

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -20,7 +20,6 @@
 #include <string>
 
 #include "base/memory/scoped_refptr.h"
-#include "base/no_destructor.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/threading/thread.h"
 #include "base/threading/thread_checker.h"
@@ -132,7 +131,6 @@ class UpdaterModule {
   ~UpdaterModule();
 
   // TODO: b/454440974 Investigate whether singleton is necessary.
-  friend class base::NoDestructor<UpdaterModule>;
 
   std::unique_ptr<base::Thread> updater_thread_;
   scoped_refptr<update_client::UpdateClient> update_client_;
@@ -153,7 +151,7 @@ class UpdaterModule {
   void Update();
 
   // Holds the single instance of UpdaterModule.
-  static base::NoDestructor<UpdaterModule>* updater_module_;
+  static UpdaterModule* updater_module_;
 };
 
 }  // namespace updater

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -130,8 +130,6 @@ class UpdaterModule {
                          base::TimeDelta update_check_delay);
   ~UpdaterModule();
 
-  // TODO: b/454440974 Investigate whether singleton is necessary.
-
   std::unique_ptr<base::Thread> updater_thread_;
   scoped_refptr<update_client::UpdateClient> update_client_;
   std::unique_ptr<Observer> updater_observer_;

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -148,6 +148,7 @@ class UpdaterModule {
   void MarkSuccessfulImpl();
   void Update();
 
+  // TODO: b/513314330 Investigate alternatives to Singleton
   // Holds the single instance of UpdaterModule.
   static UpdaterModule* updater_module_;
 };

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -20,6 +20,7 @@
 #include <string>
 
 #include "base/memory/scoped_refptr.h"
+#include "base/no_destructor.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/threading/thread.h"
 #include "base/threading/thread_checker.h"
@@ -83,9 +84,14 @@ class Observer : public update_client::UpdateClient::Observer {
 // thread.
 class UpdaterModule {
  public:
-  explicit UpdaterModule(scoped_refptr<network::SharedURLLoaderFactory>,
-                         base::TimeDelta update_check_delay);
-  ~UpdaterModule();
+  static void CreateInstance(
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      base::TimeDelta update_check_delay);
+
+  static UpdaterModule* GetInstance();
+
+  UpdaterModule(const UpdaterModule&) = delete;
+  UpdaterModule& operator=(const UpdaterModule&) = delete;
 
   void Suspend();
   void Resume();
@@ -120,6 +126,14 @@ class UpdaterModule {
   void MarkSuccessful();
 
  private:
+  // Private constructor and destructor to enforce singleton pattern.
+  explicit UpdaterModule(scoped_refptr<network::SharedURLLoaderFactory>,
+                         base::TimeDelta update_check_delay);
+  ~UpdaterModule();
+
+  // TODO: b/454440974 Investigate whether singleton is necessary.
+  friend class base::NoDestructor<UpdaterModule>;
+
   std::unique_ptr<base::Thread> updater_thread_;
   scoped_refptr<update_client::UpdateClient> update_client_;
   std::unique_ptr<Observer> updater_observer_;
@@ -137,6 +151,9 @@ class UpdaterModule {
   void Finalize();
   void MarkSuccessfulImpl();
   void Update();
+
+  // Holds the single instance of UpdaterModule.
+  static base::NoDestructor<UpdaterModule>* updater_module_;
 };
 
 }  // namespace updater

--- a/components/update_client/crx_downloader_factory.cc
+++ b/components/update_client/crx_downloader_factory.cc
@@ -110,7 +110,7 @@ scoped_refptr<CrxDownloader> CrxDownloaderFactoryChromium::MakeCrxDownloader(
 #if BUILDFLAG(IS_STARBOARD)
 scoped_refptr<CrxDownloaderFactory> MakeCrxDownloaderFactory(
     scoped_refptr<NetworkFetcherFactory> network_fetcher_factory,
-    std::optional<base::FilePath> background_downloader_cache_path) {
+    [[maybe_unused]] std::optional<base::FilePath> background_downloader_cache_path) {
   return base::MakeRefCounted<CrxDownloaderFactoryCobalt>(
       std::move(network_fetcher_factory));
 #else

--- a/components/update_client/crx_downloader_factory.cc
+++ b/components/update_client/crx_downloader_factory.cc
@@ -109,7 +109,8 @@ scoped_refptr<CrxDownloader> CrxDownloaderFactoryChromium::MakeCrxDownloader(
 
 #if BUILDFLAG(IS_STARBOARD)
 scoped_refptr<CrxDownloaderFactory> MakeCrxDownloaderFactory(
-    scoped_refptr<NetworkFetcherFactory> network_fetcher_factory) {
+    scoped_refptr<NetworkFetcherFactory> network_fetcher_factory,
+    std::optional<base::FilePath> background_downloader_cache_path) {
   return base::MakeRefCounted<CrxDownloaderFactoryCobalt>(
       std::move(network_fetcher_factory));
 #else

--- a/components/update_client/op_install.cc
+++ b/components/update_client/op_install.cc
@@ -199,11 +199,8 @@ void Install(base::OnceCallback<void(const CrxInstaller::Result&)> callback,
                    result.unpack_path.value(), app_key)) {
       // Write the version of the unpacked update package to the persisted data.
       if (metadata != nullptr) {
-        base::ThreadPool::PostTask(
-            FROM_HERE, base::BindOnce(
-              &PersistedData::SetLastInstalledEgAndSbVersion,
-              base::Unretained(metadata), id, next_version,
-              std::to_string(SB_API_VERSION)));
+        metadata->SetLastInstalledEgAndSbVersion(
+            id, next_version, std::to_string(SB_API_VERSION));
       }
     } else {
       LOG(ERROR) << "CobaltFinishInstallation failed.";

--- a/components/update_client/persisted_data.h
+++ b/components/update_client/persisted_data.h
@@ -61,31 +61,31 @@ class PersistedData {
   // Returns the starboard version of the last successfully installed update
   // for the specified |id|. "" indicates that there is no recorded version value
   // for the |id|.
-  virtual std::string GetLastInstalledSbVersion(const std::string& id) const;
+  virtual std::string GetLastInstalledSbVersion(const std::string& id) const = 0;
 
   // Returns the version of the update that was last successfully installed for
   // the specified |id|. "" indicates that there is no recorded version value
   // for the |id|.
-  virtual std::string GetLastInstalledVersion(const std::string& id) const;
+  virtual std::string GetLastInstalledVersion(const std::string& id) const = 0;
 
   // Returns the updater channel that is set for the specified |id|. ""
   // indicates that there is no recorded updater channel value for the |id|.
-  virtual std::string GetUpdaterChannel(const std::string& id) const;
+  virtual std::string GetUpdaterChannel(const std::string& id) const = 0;
 
   // Returns the updater channel for the previous app startup.
-  virtual std::string GetLatestChannel() const;
+  virtual std::string GetLatestChannel() const = 0;
 
   // Records the Evergreen version and the starboard version of the update that
   // is successfully installed for the specified |id|.
   virtual void SetLastInstalledEgAndSbVersion(const std::string& id,
                                               const std::string& eg_version,
-                                              const std::string& sb_version);
+                                              const std::string& sb_version) = 0;
 
   // Records the updater channel that is set for the specified |id|.
-  virtual void SetUpdaterChannel(const std::string& id, const std::string& channel);
+  virtual void SetUpdaterChannel(const std::string& id, const std::string& channel) = 0;
 
   // Records the latest channel the app is on.
-  virtual void SetLatestChannel(const std::string& channel);
+  virtual void SetLatestChannel(const std::string& channel) = 0;
 #endif
 
   // Returns the PingFreshness (a random token that is written into the profile


### PR DESCRIPTION
- Run updater in the browser. Same as in EAP.
- Fix a `DCHECK` sequence checker crash in `PersistedDataImpl`.
- Refactor `UpdaterModule` to use a singleton pattern to allow global access by the H5vcc updater APIs. Originally from PR #8182.
- Fix a `DCHECK` crash when a singleton already exists.
- Update `MakeCrxDownloaderFactory` signature in Starboard to accept an optional background downloader cache path

Bug: 479816505