### PR TITLE
build: Deduplicate Cobalt GN platform configs

### DIFF
--- a/cobalt/build/configs/android-arm/args.gn
+++ b/cobalt/build/configs/android-arm/args.gn
@@ -1,2 +1,3 @@
 import("//cobalt/build/configs/android_common.gn")
-import("//cobalt/build/configs/chromium_android-arm/args.gn")
+
+target_cpu = "arm"

--- a/cobalt/build/configs/android-arm64/args.gn
+++ b/cobalt/build/configs/android-arm64/args.gn
@@ -1,2 +1,3 @@
 import("//cobalt/build/configs/android_common.gn")
-import("//cobalt/build/configs/chromium_android-arm64/args.gn")
+
+target_cpu = "arm64"

--- a/cobalt/build/configs/android-x86/args.gn
+++ b/cobalt/build/configs/android-x86/args.gn
@@ -1,2 +1,3 @@
 import("//cobalt/build/configs/android_common.gn")
-import("//cobalt/build/configs/chromium_android-x86/args.gn")
+
+target_cpu = "x86"

--- a/cobalt/build/configs/android_common.gn
+++ b/cobalt/build/configs/android_common.gn
@@ -1,3 +1,4 @@
+import("//cobalt/build/configs/chromium_android.gn")
 import("//cobalt/build/configs/common.gn")
 
 # This flag comes from build/config/compiler/compiler.gni

--- a/cobalt/build/configs/chromium_android-arm/args.gn
+++ b/cobalt/build/configs/chromium_android-arm/args.gn
@@ -1,6 +1,3 @@
-target_os = "android"
-target_cpu = "arm"
+import("//cobalt/build/configs/chromium_android.gn")
 
-# TODO(b/376141256): Decide if this flag is needed here or in .gclient file
-chrome_pgo_phase = 0
-clang_use_default_sample_profile = false
+target_cpu = "arm"

--- a/cobalt/build/configs/chromium_android-arm64/args.gn
+++ b/cobalt/build/configs/chromium_android-arm64/args.gn
@@ -1,6 +1,3 @@
-target_os = "android"
-target_cpu = "arm64"
+import("//cobalt/build/configs/chromium_android.gn")
 
-# TODO(b/376141256): Decide if this flag is needed here or in .gclient file
-chrome_pgo_phase = 0
-clang_use_default_sample_profile = false
+target_cpu = "arm64"

--- a/cobalt/build/configs/chromium_android-x86/args.gn
+++ b/cobalt/build/configs/chromium_android-x86/args.gn
@@ -1,6 +1,3 @@
-target_os = "android"
-target_cpu = "x86"
+import("//cobalt/build/configs/chromium_android.gn")
 
-# TODO(b/376141256): Decide if this flag is needed here or in .gclient file
-chrome_pgo_phase = 0
-clang_use_default_sample_profile = false
+target_cpu = "x86"

--- a/cobalt/build/configs/chromium_android.gn
+++ b/cobalt/build/configs/chromium_android.gn
@@ -1,0 +1,5 @@
+target_os = "android"
+
+# TODO(b/376141256): Decide if this flag is needed here or in .gclient file
+chrome_pgo_phase = 0
+clang_use_default_sample_profile = false

--- a/cobalt/build/configs/chromium_linux-x64x11/args.gn
+++ b/cobalt/build/configs/chromium_linux-x64x11/args.gn
@@ -1,5 +1,3 @@
-target_os = "linux"
-target_cpu = "x64"
+import("//cobalt/build/configs/chromium_linux.gn")
 
-# TODO(b/376141256): Decide if this flag is needed here or in .gclient file
-chrome_pgo_phase = 0
+target_cpu = "x64"

--- a/cobalt/build/configs/chromium_linux.gn
+++ b/cobalt/build/configs/chromium_linux.gn
@@ -1,0 +1,4 @@
+target_os = "linux"
+
+# TODO(b/376141256): Decide if this flag is needed here or in .gclient file
+chrome_pgo_phase = 0

--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -1,6 +1,6 @@
 is_cobalt = true
 
-# Disable Chrome Remote Desktop
+# Disable Chrome Remote Desktop.
 enable_remoting = false
 
 # Build flag declared originally in build/config/features.gni

--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -1,5 +1,8 @@
 is_cobalt = true
 
+# Disable Chrome Remote Desktop
+enable_remoting = false
+
 # Build flag declared originally in build/config/features.gni
 # This flag is overridden to enable common video codecs playbacks.
 proprietary_codecs = true

--- a/cobalt/build/configs/evergreen_common.gn
+++ b/cobalt/build/configs/evergreen_common.gn
@@ -1,3 +1,3 @@
-import("//cobalt/build/configs/linux-x64x11-modular/args.gn")
+import("//cobalt/build/configs/linux_modular_common.gn")
 
 use_evergreen = true

--- a/cobalt/build/configs/linux-x64x11-modular/args.gn
+++ b/cobalt/build/configs/linux-x64x11-modular/args.gn
@@ -1,22 +1,3 @@
-import("//cobalt/build/configs/linux_common.gn")
+import("//cobalt/build/configs/linux_modular_common.gn")
 
-use_custom_libc = true
-
-# TODO: b/384652502 - Cobalt: Stop overriding enable_pkeys
-# ../../base/allocator/partition_allocator/pkey.cc:35:18: error: use of undeclared identifier 'SYS_pkey_mprotect'
-#   return syscall(SYS_pkey_mprotect, addr, len, prot, pkey);
-enable_pkeys = false
-
-# We don't implement the necessary APIs for mdns.
-enable_mdns = false
-
-# Enables a loadable module, so unsupported for modular builds.
-enable_library_cdms = false
-
-# TODO: b/425694385 - Investigate other ways to ensure emulated tls is
-# is respected with LTO.
-is_cfi = false
-use_thin_lto = false
-
-# We don't currently use sandboxes in Cobalt Evergreen.
-v8_enable_sandbox = false
+target_cpu = "x64"

--- a/cobalt/build/configs/linux-x64x11/args.gn
+++ b/cobalt/build/configs/linux-x64x11/args.gn
@@ -1,1 +1,3 @@
 import("//cobalt/build/configs/linux_common.gn")
+
+target_cpu = "x64"

--- a/cobalt/build/configs/linux_common.gn
+++ b/cobalt/build/configs/linux_common.gn
@@ -1,6 +1,6 @@
 # Common configuration options for linux platforms. Values here should not
 # reference args set elsewhere (e.g. do not use `x = !is_cobalt`).
-import("//cobalt/build/configs/chromium_linux-x64x11/args.gn")
+import("//cobalt/build/configs/chromium_linux.gn")
 import("//cobalt/build/configs/common.gn")
 
 use_ozone = true

--- a/cobalt/build/configs/linux_common.gn
+++ b/cobalt/build/configs/linux_common.gn
@@ -45,9 +45,6 @@ use_xkbcommon = false
 # Disable PipeWire in WebRTC
 rtc_use_pipewire = false
 
-# Disable Chrome Remote Desktop
-enable_remoting = false
-
 # Disable Wayland Ozone Backend
 ozone_platform_wayland = false
 

--- a/cobalt/build/configs/linux_modular_common.gn
+++ b/cobalt/build/configs/linux_modular_common.gn
@@ -1,0 +1,22 @@
+import("//cobalt/build/configs/linux_common.gn")
+
+use_custom_libc = true
+
+# TODO: b/384652502 - Cobalt: Stop overriding enable_pkeys
+# ../../base/allocator/partition_allocator/pkey.cc:35:18: error: use of undeclared identifier 'SYS_pkey_mprotect'
+#   return syscall(SYS_pkey_mprotect, addr, len, prot, pkey);
+enable_pkeys = false
+
+# We don't implement the necessary APIs for mdns.
+enable_mdns = false
+
+# Enables a loadable module, so unsupported for modular builds.
+enable_library_cdms = false
+
+# TODO: b/425694385 - Investigate other ways to ensure emulated tls is
+# is respected with LTO.
+is_cfi = false
+use_thin_lto = false
+
+# We don't currently use sandboxes in Cobalt Evergreen.
+v8_enable_sandbox = false

--- a/cobalt/build/configs/raspi-2-modular/args.gn
+++ b/cobalt/build/configs/raspi-2-modular/args.gn
@@ -1,4 +1,4 @@
-import("//cobalt/build/configs/linux-x64x11-modular/args.gn")
+import("//cobalt/build/configs/linux_modular_common.gn")
 
 use_asan = false
 target_cpu = "arm"

--- a/cobalt/build/configs/tvos_common.gn
+++ b/cobalt/build/configs/tvos_common.gn
@@ -10,9 +10,6 @@ use_blink = true
 # tree.
 ios_build_chrome = false
 
-# Disable Chrome Remote Desktop
-enable_remoting = false
-
 # These flags are disabled in common.gn but are required for the tvOS build to
 # work at the moment (iosurface_image_backing.mm depends on
 # dawn_shared_texture_cache.cc, for example).


### PR DESCRIPTION
Follow-up from https://github.com/youtube/cobalt/pull/10366 to factor shared GN args out of architecture-specific Cobalt config files.

Introduce shared Android, Linux, Linux modular, and Evergreen config files so
architecture-specific args only set target-specific values.

Move `enable_remoting` into common.gn so all Cobalt configs consistently disable
Chrome Remote Desktop, including AndroidTV, which previously differed from the other platforms.

Bug: 495203133