### PR TITLE
aosp: Add missing starboard_target_platform

### DIFF
--- a/cobalt/build/configs/aosp-arm/args.gn
+++ b/cobalt/build/configs/aosp-arm/args.gn
@@ -1,6 +1,7 @@
 import("//cobalt/build/configs/evergreen-x64/args.gn")
 
 target_cpu = "arm"
+starboard_target_platform = "aosp-arm"
 arm_float_abi = "softfp"
 
 # TODO: b/453022760 - Investigate if this should be true and fix build failures


### PR DESCRIPTION
Follow up to https://github.com/youtube/cobalt/pull/10313 to add the missing starboard platform.

Bug: 495203133