### PR TITLE
build: Remove obsolete native target guards

### DIFF
--- a/starboard/elf_loader/evergreen_info.h
+++ b/starboard/elf_loader/evergreen_info.h
@@ -26,7 +26,6 @@
 #define EVERGREEN_FILE_PATH_MAX_SIZE 4096
 #define EVERGREEN_BUILD_ID_MAX_SIZE 128
 
-#ifndef NATIVE_TARGET_BUILD
 #define IS_EVERGREEN_ADDRESS(address, evergreen_info)                    \
   (evergreen_info.base_address != 0 &&                                   \
    reinterpret_cast<uint64_t>(address) >= evergreen_info.base_address && \
@@ -36,7 +35,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-#endif  // !NATIVE_TARGET_BUILD
 
 // Evergreen shared library memory mapping information used for
 // stack unwinding and symbolizing.
@@ -64,7 +62,6 @@ typedef struct EvergreenInfo {
   size_t build_id_length;
 } EvergreenInfo;
 
-#ifndef NATIVE_TARGET_BUILD
 // Set the Evergreen information. Should be called only from the
 // elf_loader module. Passing NULL clears the currently stored
 // information.
@@ -80,6 +77,5 @@ bool GetEvergreenInfo(EvergreenInfo* evergreen_info);
 #ifdef __cplusplus
 }  // extern "C"
 #endif
-#endif  // !NATIVE_TARGET_BUILD
 
 #endif  // STARBOARD_ELF_LOADER_EVERGREEN_INFO_H_


### PR DESCRIPTION
Delete a non-existent native target guard that was removed in https://github.com/youtube/cobalt/pull/7405.

Bug: 492403745