### PR TITLE
aosp: Add missing deps to copied_base proto targets

### DIFF
--- a/copied_base/base/tracing/protos/BUILD.gn
+++ b/copied_base/base/tracing/protos/BUILD.gn
@@ -15,6 +15,8 @@ proto_library("chrome_track_event") {
   generate_cc = false
   generate_python = false
   generate_descriptor = "chrome_track_event.descriptor"
+  deps =
+      [ "//third_party/perfetto/protos/perfetto/trace/track_event:source_set" ]
 }
 
 protozero_library("chrome_track_event_zero") {
@@ -23,6 +25,8 @@ protozero_library("chrome_track_event_zero") {
   import_dirs = [ "//third_party/perfetto/" ]
   generator_plugin_options = "wrapper_namespace=pbzero"
   omit_protozero_dep = true
+  proto_deps =
+      [ "//third_party/perfetto/protos/perfetto/trace/track_event:source_set" ]
 }
 
 grit("chrome_track_event_resources") {


### PR DESCRIPTION
Update copied_base's chrome_track_event and chrome_track_event_zero library definitions to add missing dependencies, similarly to the //base targets.

Bug: 495203133