### PR TITLE
starboard/rdk: fix navigator.language to reflect device presentation language

### DIFF
--- a/cobalt/shell/browser/shell_content_browser_client.cc
+++ b/cobalt/shell/browser/shell_content_browser_client.cc
@@ -94,6 +94,7 @@
 #include "services/network/public/mojom/network_context.mojom.h"
 #include "services/network/public/mojom/network_service.mojom.h"
 #include "services/network/public/mojom/permissions_policy/permissions_policy_feature.mojom-shared.h"
+#include "starboard/system.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/user_agent/user_agent_metadata.h"
 #include "third_party/blink/public/common/web_preferences/web_preferences.h"
@@ -224,6 +225,13 @@ SharedState& GetSharedState() {
 }
 
 std::string GetShellLanguage() {
+  // Defer to the Starboard layer, which is the single source of truth for
+  // the platform's presentation language and already returns a normalised
+  // BCP-47 tag.
+  const char* locale = SbSystemGetLocaleId();
+  if (locale && *locale) {
+    return locale;
+  }
   return "en-us,en";
 }
 

--- a/starboard/contrib/rdk/plugin/CobaltImplementation.cpp
+++ b/starboard/contrib/rdk/plugin/CobaltImplementation.cpp
@@ -291,6 +291,9 @@ private:
       }
 
       if (config.Language.IsSet() == true) {
+        // Explicit config override always wins; SbSystemGetLocaleId() reads
+        // UserSettings directly when LANG is unset, so no fallback is
+        // needed here.
         string lang = config.Language.Value();
         Core::SystemInfo::SetEnvironment(_T("LANG"), lang);
       }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -138,7 +138,7 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/posix/system_clear_last_error.cc",
     "//starboard/shared/posix/system_get_error_string.cc",
     "//starboard/shared/posix/system_get_last_error.cc",
-    "//starboard/shared/posix/system_get_locale_id.cc",
+    "system/system_get_locale_id_bcp47.cc",
     "//starboard/shared/posix/system_get_number_of_processors.cc",
     "//starboard/shared/pthread/thread_types_public.h",
     "//starboard/shared/signal/crash_signals.cc",

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.cc
@@ -1626,6 +1626,17 @@ public:
     needs_refresh_ = true;
     subscriptions_.clear();
   }
+
+  bool GetPresentationLanguage(std::string& out) {
+    Core::JSON::String result;
+    uint32_t rc = link_.Get(kDefaultTimeoutMs, "getPresentationLanguage", result);
+    if (Core::ERROR_NONE != rc) {
+      SB_LOG(ERROR) << "UserSettings.getPresentationLanguage failed, rc=" << rc;
+      return false;
+    }
+    out = result.Value();
+    return !out.empty();
+  }
 };
 
 SB_ONCE_INITIALIZE_FUNCTION(UserSettingsImpl, GetUserSettings);
@@ -1769,6 +1780,10 @@ bool DeviceInfo::GetAudioConfiguration(int index, SbMediaAudioConfiguration* out
 
 bool DeviceInfo::GetBrandName(std::string& out) {
   return GetDeviceInfo()->GetBrandName(out);
+}
+
+bool UserSettings::GetPresentationLanguage(std::string& out) {
+  return GetUserSettings()->GetPresentationLanguage(out);
 }
 
 void TeardownJSONRPCLink() {

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.h
@@ -115,6 +115,11 @@ public:
   static bool GetBrandName(std::string& out);
 };
 
+class UserSettings {
+public:
+  static bool GetPresentationLanguage(std::string &out);
+};
+
 void TeardownJSONRPCLink();
 
 }  // namespace starboard

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_locale_id_bcp47.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_locale_id_bcp47.cc
@@ -1,0 +1,99 @@
+//
+// Copyright 2020 Comcast Cable Communications Management, LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+// SPDX-License-Identifier: Apache-2.0
+
+#include "starboard/system.h"
+
+#include <locale.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include <string>
+
+#include "starboard/common/log.h"
+#include "third_party/starboard/rdk/shared/rdkservices.h"
+
+namespace {
+
+bool IsValidLocaleIdBcp47(const char* id) {
+  if (!id || *id == '\0') {
+    return false;
+  }
+  return strcmp(id, "C") != 0 && strcmp(id, "POSIX") != 0;
+}
+
+// Normalise a POSIX locale string to a BCP-47 language tag in place.
+// e.g. "fr_FR.UTF-8" → "fr-FR", "en_US@euro" → "en-US".
+void NormalizePosixLocaleToBcp47(std::string& locale) {
+  size_t at = locale.find('@');
+  if (at != std::string::npos) {
+    locale.resize(at);
+  }
+  size_t dot = locale.find('.');
+  if (dot != std::string::npos) {
+    locale.resize(dot);
+  }
+  for (char& c : locale) {
+    if (c == '_') {
+      c = '-';
+    }
+  }
+}
+
+}  // namespace
+
+// Cache the BCP-47 locale string so SbSystemGetLocaleId() returns a stable
+// pointer. An empty string is returned when nothing is found to honor the
+// non-null contract (callers like setenv() in environment.cc crash on null).
+// Thread-safe initialization (and avoidance of fixed-size buffer truncation)
+// is guaranteed by C++11 magic statics.
+const char* SbSystemGetLocaleId() {
+  static const std::string cached_locale = []() -> std::string {
+    // 0. Primary source: the device's durable presentation language setting,
+    //    fetched from UserSettings over Thunder JSON-RPC. Read here (rather
+    //    than by the plugin wrapper) so SbSystemGetLocaleId() stays the
+    //    single, self-contained owner of locale resolution on RDK.
+    std::string presentation_language;
+    if (starboard::UserSettings::GetPresentationLanguage(
+            presentation_language) &&
+        IsValidLocaleIdBcp47(presentation_language.c_str())) {
+      NormalizePosixLocaleToBcp47(presentation_language);
+      return presentation_language;
+    }
+
+    // 1. Check setlocale, then $LC_ALL / $LC_MESSAGES / $LANG, in priority
+    //    order. setlocale() reflects any explicit setlocale(LC_ALL, "") call
+    //    made earlier during startup, which may differ from the raw env vars.
+    const char* candidates[] = {
+      setlocale(LC_MESSAGES, NULL),
+      getenv("LC_ALL"),
+      getenv("LC_MESSAGES"),
+      getenv("LANG"),
+    };
+    for (const char* id : candidates) {
+      if (IsValidLocaleIdBcp47(id)) {
+        std::string locale(id);
+        NormalizePosixLocaleToBcp47(locale);
+        return locale;
+      }
+    }
+
+    SB_LOG(WARNING) << "SbSystemGetLocaleId: no valid locale found";
+    return "";
+  }();
+
+  return cached_locale.c_str();
+}


### PR DESCRIPTION
Currently, `navigator.language` is hardcoded to `en-us,en` in `GetShellLanguage()` because the WPEFramework process starts with `LANG=C` — systemd does not source `/etc/locale.conf` for service units, so localectl changes had no effect on the running process.

Fix:
- Added an RDK override of `SbSystemGetLocaleId()` that owns locale resolution end-to-end: it first queries `UserSettings.getPresentationLanguage` via Thunder JSON-RPC (the durable, always-fresh source), then falls back to `setlocale(LC_MESSAGES)`/`$LC_ALL`/`$LC_MESSAGES`/`$LANG`, normalising POSIX locales to BCP-47. Returns `""` (never `NULL`) when nothing is found, honoring the Starboard API's non-null contract.
- Added `UserSettings::GetPresentationLanguage()` to `rdkservices.h/cc` using the existing `ServiceLink` pattern.
- `GetShellLanguage()` in `shell_content_browser_client.cc` now simply defers to `SbSystemGetLocaleId()`, falling back to `"en-us,en"` only if Starboard reports nothing — removing duplicated normalisation logic from platform-agnostic Cobalt code.
- `CobaltImplementation::Configure()` no longer fetches the language itself; it only sets `$LANG` when the plugin configuration provides an explicit override, since `SbSystemGetLocaleId()` now reads UserSettings directly.
- Updated `BUILD.gn` to use the new RDK `system_get_locale_id_bcp47.cc` instead of the posix implementation.

Bug: 503631204
