### PR TITLE
Media: fix pointer arithmetic in Time Stretcher

### DIFF
--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -284,7 +284,7 @@ bool AudioTimeStretcher::RunOneWsolaIteration(double playback_rate) {
     const float* const ch_opt_frame =
         reinterpret_cast<const float*>(optimal_block_->data()) + k;
     float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) + k +
-                       num_complete_frames_ * sizeof(float);
+                       num_complete_frames_ * channels_;
     for (int n = 0; n < ola_hop_size_; ++n) {
       ch_output[n * channels_] =
           ch_output[n * channels_] * ola_window_[ola_hop_size_ + n] +
@@ -295,7 +295,7 @@ bool AudioTimeStretcher::RunOneWsolaIteration(double playback_rate) {
   const float* const ch_opt_frame =
       reinterpret_cast<const float*>(optimal_block_->data());
   float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) +
-                     num_complete_frames_ * sizeof(float);
+                     num_complete_frames_ * channels_;
   memcpy(&ch_output[ola_hop_size_ * channels_],
          &ch_opt_frame[ola_hop_size_ * channels_],
          sizeof(*ch_opt_frame) * ola_hop_size_ * channels_);


### PR DESCRIPTION
### The Issue

In audio_time_stretcher.cc, specifically in the  RunOneWsolaIteration  method, there was a bug in the pointer arithmetic used to calculate where to write the next block of processed audio.

The code was doing this:

```
    float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) + k +
                       num_complete_frames_ * sizeof(float);
```

  Here,  ch_output  is a  float* . In C++, adding an integer  N  to a  float*  advances it by  N  floats (not bytes).

• The code multiplied  num_complete_frames_  by  sizeof(float)  (which is usually 4).
• This effectively assumed that every audio frame had exactly 4 channels.
• For stereo audio (2 channels), this caused the pointer to advance twice as far as it should have, leading to data being written to the wrong location.

### The Fix

We replaced  sizeof(float)  with  channels_  to correctly advance the pointer by the actual number of audio samples per frame:

```
    float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) + k +
                       num_complete_frames_ * channels_;
```

──────
### Why it never failed in production

Despite being a clear bug in the code, it was not causing crashes or audio corruption in production or in standard tests.

The bug only triggers if  num_complete_frames_  is greater than zero when  RunOneWsolaIteration  is called. However, the loop that calls it in  Read()  enforces a strict invariant:

```
      do {
        rendered_frames += WriteCompletedFramesTo(
            requested_frames - rendered_frames, rendered_frames, dest);
      } while (rendered_frames < requested_frames &&
               RunOneWsolaIteration(playback_rate));
```

1. Before calling  RunOneWsolaIteration() , it calls  WriteCompletedFramesTo() .
2.  WriteCompletedFramesTo()  consumes all available completed frames if it needs more to satisfy the request.
3. Therefore, whenever  RunOneWsolaIteration()  is invoked,  num_complete_frames_  has just been drained and is guaranteed to be zero (or extremely small, less than the chunk size requested).

Because  num_complete_frames_  was always  0  at the start of the method,  0 * sizeof(float)  and  0 * channels_  both evaluate to  0 , hiding the bug perfectly! It was effectively "dead code" that would only  activate if someone refactored the  Read()  loop in the future.


Bug: 510823031