### PR TITLE
android: Add an experiment to skip frames over 60fps

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -69,10 +69,31 @@ class MediaCodecBridge {
   private MediaCodec.Callback mCallback;
   private double mPlaybackRate = 1.0;
   private int mFps = 30;
+  private double mOperatingRate = mPlaybackRate * mFps;
+  private boolean mSkipVideoFramesOver60Fps = false;
   private final boolean mIsTunnelingPlayback;
 
   private MediaCodec.OnFrameRenderedListener mFrameRendererListener;
   private MediaCodec.OnFirstTunnelFrameReadyListener mFirstTunnelFrameReadyListener;
+
+  private boolean shouldSkipVideoFrame(long presentationTimeUs, boolean isDecodeOnly) {
+    final double kMaxAcceptedOperatingRate = 60.0;
+    if (isDecodeOnly) {
+      return true;
+    }
+    // |mOperatingRate| won't be 0, but to be cautious we still add a check here.
+    if (!mSkipVideoFramesOver60Fps || mOperatingRate <= kMaxAcceptedOperatingRate || mOperatingRate == 0) {
+      return false;
+    }
+    // Deterministically downsample to 60fps by picking one frame per 1/60s interval.
+    // Some visual jitter may occur briefly when the playback rate changes.
+    double frameIntervalUs = 1_000_000.0 / mOperatingRate;
+    if (Math.floor(presentationTimeUs * kMaxAcceptedOperatingRate / 1_000_000.0)
+        == Math.floor((presentationTimeUs - frameIntervalUs) * kMaxAcceptedOperatingRate / 1_000_000.0)) {
+      return true;
+    }
+    return false;
+  }
 
   public static final class MimeTypes {
     public static final String VIDEO_H264 = "video/avc";
@@ -439,6 +460,7 @@ class MediaCodecBridge {
       int tunnelModeAudioSessionId,
       int maxVideoInputSize,
       boolean enableOutputChecker,
+      boolean skipVideoFramesOver60Fps,
       CreateMediaCodecBridgeResult outCreateMediaCodecBridgeResult) {
     MediaCodec mediaCodec = null;
     outCreateMediaCodecBridgeResult.mMediaCodecBridge = null;
@@ -489,6 +511,7 @@ class MediaCodecBridge {
 
     MediaCodecBridge bridge =
         new MediaCodecBridge(nativeMediaCodecBridge, mediaCodec, tunnelModeAudioSessionId);
+    bridge.mSkipVideoFramesOver60Fps = skipVideoFramesOver60Fps;
     MediaCodecOutputTracker.get().register(bridge);
     MediaFormat mediaFormat =
         createVideoDecoderFormat(mime, widthHint, heightHint, videoCapabilities);
@@ -693,6 +716,11 @@ class MediaCodecBridge {
       return;
     }
     double operatingRate = mPlaybackRate * mFps;
+    if (mOperatingRate == operatingRate) {
+      return;
+    }
+
+    mOperatingRate = operatingRate;
     Bundle b = new Bundle();
     b.putFloat(MediaFormat.KEY_OPERATING_RATE, (float) operatingRate);
     try {
@@ -801,8 +829,8 @@ class MediaCodecBridge {
       int index, int offset, int size, long presentationTimeUs, int flags, boolean isDecodeOnly) {
     try {
       if (isDecodeOnlyFlagEnabled()
-          && isDecodeOnly
-          && (flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) == 0) {
+          && (flags & MediaCodec.BUFFER_FLAG_END_OF_STREAM) == 0
+          && shouldSkipVideoFrame(presentationTimeUs, isDecodeOnly)) {
         flags |= MediaCodec.BUFFER_FLAG_DECODE_ONLY;
       }
       if ((flags & MediaCodec.BUFFER_FLAG_DECODE_ONLY) == 0) {
@@ -849,7 +877,7 @@ class MediaCodecBridge {
       }
 
       int flags = 0;
-      if (isDecodeOnlyFlagEnabled() && isDecodeOnly) {
+      if (isDecodeOnlyFlagEnabled() && shouldSkipVideoFrame(presentationTimeUs, isDecodeOnly)) {
         flags |= MediaCodec.BUFFER_FLAG_DECODE_ONLY;
       } else {
         mOutputChecker.addInputTimestamp(presentationTimeUs);

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -183,7 +183,8 @@ MediaCodecBridge::CreateVideoMediaCodecBridge(
     int tunnel_mode_audio_session_id,
     bool force_big_endian_hdr_metadata,
     int max_video_input_size,
-    bool enable_output_checker) {
+    bool enable_output_checker,
+    bool skip_video_frames_over_60_fps) {
   if (max_frame_size) {
     SB_CHECK_GT(max_frame_size->width, 0);
     SB_CHECK_GT(max_frame_size->height, 0);
@@ -286,7 +287,7 @@ MediaCodecBridge::CreateVideoMediaCodecBridge(
       max_frame_size ? max_frame_size->height : -1, j_surface_local,
       j_media_crypto_local, j_color_info, tunnel_mode_audio_session_id,
       max_video_input_size, enable_output_checker,
-      j_create_media_codec_bridge_result);
+      skip_video_frames_over_60_fps, j_create_media_codec_bridge_result);
 
   ScopedJavaLocalRef<jobject> j_media_codec_bridge(
       Java_CreateMediaCodecBridgeResult_mediaCodecBridge(

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -134,7 +134,8 @@ class MediaCodecBridge {
       int tunnel_mode_audio_session_id,
       bool force_big_endian_hdr_metadata,
       int max_video_input_size,
-      bool enable_output_checker);
+      bool enable_output_checker,
+      bool skip_video_frames_over_60_fps);
 
   ~MediaCodecBridge();
 

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -129,7 +129,8 @@ MediaCodecDecoder::CreateForVideo(
     int max_video_input_size,
     int64_t flush_delay_usec,
     std::optional<bool> use_dual_threads,
-    bool enable_output_checker) {
+    bool enable_output_checker,
+    bool skip_video_frames_over_60_fps) {
   std::string error_message;
   auto decoder = std::make_unique<MediaCodecDecoder>(
       PassKey<MediaCodecDecoder>(), job_queue, host, video_codec,
@@ -137,7 +138,8 @@ MediaCodecDecoder::CreateForVideo(
       color_metadata, require_software_codec, frame_rendered_cb,
       first_tunnel_frame_ready_cb, tunnel_mode_audio_session_id,
       force_big_endian_hdr_metadata, max_video_input_size, flush_delay_usec,
-      use_dual_threads, enable_output_checker, &error_message);
+      use_dual_threads, enable_output_checker, skip_video_frames_over_60_fps,
+      &error_message);
   if (!decoder->media_codec_bridge_) {
     return Failure(error_message);
   }
@@ -201,6 +203,7 @@ MediaCodecDecoder::MediaCodecDecoder(
     int64_t flush_delay_usec,
     std::optional<bool> use_dual_threads,
     bool enable_output_checker,
+    bool skip_video_frames_over_60_fps,
     std::string* error_message)
     : JobOwner(job_queue),
       media_type_(kSbMediaTypeVideo),
@@ -227,7 +230,7 @@ MediaCodecDecoder::MediaCodecDecoder(
       j_output_surface, j_media_crypto, color_metadata, require_secured_decoder,
       require_software_codec, tunnel_mode_audio_session_id,
       force_big_endian_hdr_metadata, max_video_input_size,
-      enable_output_checker);
+      enable_output_checker, skip_video_frames_over_60_fps);
   if (media_codec_bridge) {
     media_codec_bridge_ = std::move(media_codec_bridge.value());
   } else {

--- a/starboard/android/shared/media_codec_decoder.h
+++ b/starboard/android/shared/media_codec_decoder.h
@@ -97,7 +97,8 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
       int max_video_input_size,
       int64_t flush_delay_usec,
       std::optional<bool> use_dual_threads,
-      bool enable_output_checker);
+      bool enable_output_checker,
+      bool skip_video_frames_over_60_fps);
 
   MediaCodecDecoder(PassKey<MediaCodecDecoder>,
                     JobQueue* job_queue,
@@ -127,6 +128,7 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
       int64_t flush_delay_usec,
       std::optional<bool> use_dual_threads,
       bool enable_output_checker,
+      bool skip_video_frames_over_60_fps,
       std::string* error_message);
   ~MediaCodecDecoder();
 

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -554,6 +554,8 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
           video_codec_ == kSbMediaVideoCodecAv1 &&
           MediaCapabilitiesCache::GetInstance()->IsAv18kCappedAt30()),
       enable_output_checker_(experimental_features.enable_codec_output_checker),
+      skip_video_frames_over_60_fps_(
+          experimental_features.skip_video_frames_over_60_fps),
       is_video_frame_tracker_enabled_(IsFrameRenderedCallbackEnabled() ||
                                       tunnel_mode_audio_session_id != -1),
       has_new_texture_available_(false),
@@ -1039,7 +1041,7 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       std::bind(&MediaCodecVideoDecoder::OnFirstTunnelFrameReady, this),
       tunnel_mode_audio_session_id_, force_big_endian_hdr_metadata_,
       max_video_input_size_, flush_delay_usec_, use_dual_threads_,
-      enable_output_checker_);
+      enable_output_checker_, skip_video_frames_over_60_fps_);
   if (result) {
     media_decoder_ = std::move(result.value());
     if (error_cb_) {

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -192,10 +192,13 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // Codec initialization will be delayed until the decoder receives enough
   // inputs to estimate video fps when |needs_fps_to_initialize_codec_| is true.
   const bool needs_fps_to_initialize_codec_;
-
   // Enable MediaCodec OutputChecker to elminate dirty output callbacks after
   // flush.
   const bool enable_output_checker_;
+  // Workaround for b/506257255, which skips some video frames to make the
+  // effective frame rate no more than 60 fps. This is only used for tunnel
+  // mode.
+  const bool skip_video_frames_over_60_fps_;
 
   // On some platforms tunnel mode is only supported in the secure pipeline.  So
   // we create a dummy drm system to force the video playing in secure pipeline

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -36,6 +36,7 @@ struct ExperimentalFeatures {
   bool flush_decoder_during_reset = false;
   bool reset_audio_decoder = false;
   bool skip_flush_on_decoder_teardown = false;
+  bool skip_video_frames_over_60_fps = false;
   std::optional<bool> use_dual_threads_for_video;
   std::optional<int> video_decoder_initial_preroll_count;
   std::optional<int> video_renderer_min_decoded_frames;


### PR DESCRIPTION
A workaround to bypass video stuttering issue on some Android devices when its operating rate is more than 60.

Bug: 454305379