### PR TITLE
starboard: Fix empty key system handling in cache

### DIFF
--- a/starboard/shared/starboard/media/key_system_supportability_cache.cc
+++ b/starboard/shared/starboard/media/key_system_supportability_cache.cc
@@ -129,6 +129,7 @@ void KeySystemSupportabilityCache::CacheKeySystemSupportability(
 
   if (strlen(key_system) == 0) {
     SB_LOG(WARNING) << "Rejected empty key system as it's always supported.";
+    return;
   }
 
   GetContainer<SbMediaAudioCodec>()->CacheKeySystemSupportability(


### PR DESCRIPTION
Avoid caching empty key systems in KeySystemSupportabilityCache for audio codecs. If the key system is empty, it is always supported and should not be cached. Previously, it logged a warning but did not return, leading to caching.

Bug: 511356295