### PR TITLE
starboard: Video decoder and allocator cleanups

### DIFF
--- a/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
@@ -31,30 +31,30 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
                                                  size_t allocation_increment,
                                                  bool enable_decommit_on_idle)
       : fallback_allocator_(enable_decommit_on_idle),
-        birectional_fit_allocator_(&fallback_allocator_,
-                                   initial_capacity,
-                                   kSmallAllocationThreshold,
-                                   allocation_increment,
-                                   enable_decommit_on_idle) {}
+        bidirectional_fit_allocator_(&fallback_allocator_,
+                                     initial_capacity,
+                                     kSmallAllocationThreshold,
+                                     allocation_increment,
+                                     enable_decommit_on_idle) {}
 
   void* Allocate(DemuxerStream::Type type,
                  size_t size,
                  size_t alignment) override {
-    return birectional_fit_allocator_.Allocate(size, alignment);
+    return bidirectional_fit_allocator_.Allocate(size, alignment);
   }
   void Free(DemuxerStream::Type type, void* p) override {
-    birectional_fit_allocator_.Free(p);
+    bidirectional_fit_allocator_.Free(p);
   }
   void Write(void* p, const void* data, size_t size) override {
     memcpy(p, data, size);
   }
 
   size_t GetCapacity() const override {
-    return birectional_fit_allocator_.GetCapacity();
+    return bidirectional_fit_allocator_.GetCapacity();
   }
 
   size_t GetAllocated() const override {
-    return birectional_fit_allocator_.GetAllocated();
+    return bidirectional_fit_allocator_.GetAllocated();
   }
 
  private:
@@ -64,7 +64,7 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
 
   StarboardMemoryAllocator fallback_allocator_;
   starboard::BidirectionalFitReuseAllocator<ReuseAllocatorBase>
-      birectional_fit_allocator_;
+      bidirectional_fit_allocator_;
 };
 
 }  // namespace media

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -441,9 +441,10 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
           experimental_features.video_decoder_initial_preroll_count.value_or(
               kInitialPrerollFrameCount)),
       number_of_preroll_frames_(initial_number_of_preroll_frames_),
-      bridge_(output_mode_ == kSbPlayerOutputModeDecodeToTexture
-                  ? std::make_unique<VideoSurfaceTextureBridge>(this)
-                  : nullptr) {
+      surface_texture_bridge_(
+          output_mode_ == kSbPlayerOutputModeDecodeToTexture
+              ? std::make_unique<VideoSurfaceTextureBridge>(this)
+              : nullptr) {
   SB_CHECK(error_message);
 
   if (force_secure_pipeline_under_tunnel_mode) {
@@ -801,8 +802,8 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       j_output_surface = decode_target->surface().obj();
 
       JNIEnv* env = AttachCurrentThread();
-      bridge_->SetOnFrameAvailableListener(env,
-                                           decode_target->surface_texture());
+      surface_texture_bridge_->SetOnFrameAvailableListener(
+          env, decode_target->surface_texture());
 
       std::lock_guard lock(decode_target_mutex_);
       decode_target_ = decode_target;
@@ -881,7 +882,7 @@ void MediaCodecVideoDecoder::TeardownCodec() {
       // Remove OnFrameAvailableListener to make sure the callback
       // would not be called.
       JNIEnv* env = AttachCurrentThread();
-      bridge_->RemoveOnFrameAvailableListener(
+      surface_texture_bridge_->RemoveOnFrameAvailableListener(
           env, decode_target_->surface_texture());
 
       decode_target_to_release = decode_target_;
@@ -1049,7 +1050,11 @@ bool MediaCodecVideoDecoder::Tick(MediaCodecBridge* media_codec_bridge) {
 }
 
 void MediaCodecVideoDecoder::OnFlushing() {
-  decoder_status_cb_(kReleaseAllFrames, NULL);
+  SB_CHECK(BelongsToCurrentThread());
+
+  if (decoder_status_cb_) {
+    decoder_status_cb_(kReleaseAllFrames, NULL);
+  }
 }
 
 bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
@@ -1064,13 +1069,13 @@ bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
 
 namespace {
 
-void updateTexImage(const JavaRef<jobject>& surface_texture) {
+void UpdateTexImage(const JavaRef<jobject>& surface_texture) {
   JNIEnv* env = AttachCurrentThread();
 
   VideoSurfaceTextureBridge::UpdateTexImage(env, surface_texture);
 }
 
-void getTransformMatrix(const JavaRef<jobject>& surface_texture,
+void GetTransformMatrix(const JavaRef<jobject>& surface_texture,
                         float* matrix4x4) {
   JNIEnv* env = AttachCurrentThread();
 
@@ -1195,7 +1200,7 @@ SbDecodeTarget MediaCodecVideoDecoder::GetCurrentDecodeTarget() {
   if (decode_target_ != nullptr) {
     bool has_new_texture = has_new_texture_available_.exchange(false);
     if (has_new_texture) {
-      updateTexImage(decode_target_->surface_texture());
+      UpdateTexImage(decode_target_->surface_texture());
       UpdateDecodeTargetSizeAndContentRegion_Locked();
 
       if (!first_texture_received_) {
@@ -1218,7 +1223,7 @@ void MediaCodecVideoDecoder::UpdateDecodeTargetSizeAndContentRegion_Locked() {
     const auto& frame_size = frame_sizes_.front();
     if (frame_size.has_crop_values) {
       float matrix4x4[16];
-      getTransformMatrix(decode_target_->surface_texture(), matrix4x4);
+      GetTransformMatrix(decode_target_->surface_texture(), matrix4x4);
 
       Size coded_size;
       auto content_region = GetDecodeTargetContentRegionFromMatrix(
@@ -1281,7 +1286,7 @@ void MediaCodecVideoDecoder::UpdateDecodeTargetSizeAndContentRegion_Locked() {
   // Leaving the legacy logic in place in case the new logic above doesn't work
   // on some devices, so at least the majority of playbacks still work.
   float matrix4x4[16];
-  getTransformMatrix(decode_target_->surface_texture(), matrix4x4);
+  GetTransformMatrix(decode_target_->surface_texture(), matrix4x4);
 
   Size coded_size;
   auto content_region = GetDecodeTargetContentRegionFromMatrix(

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -264,7 +264,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   const size_t initial_number_of_preroll_frames_;
   size_t number_of_preroll_frames_;
 
-  const std::unique_ptr<VideoSurfaceTextureBridge> bridge_;
+  const std::unique_ptr<VideoSurfaceTextureBridge> surface_texture_bridge_;
 };
 
 }  // namespace starboard


### PR DESCRIPTION
- Rename private member `bridge_` to `surface_texture_bridge_` in
  MediaCodecVideoDecoder to improve readability and avoid ambiguity
  with MediaCodecBridge.
- Add thread check `SB_CHECK(BelongsToCurrentThread())` to
  OnFlushing() to guarantee it is called on the expected Player
  thread.
- Add null check for `decoder_status_cb_` in OnFlushing() to prevent
  potential crashes during early teardown.
- Rename private member `birectional_fit_allocator_` to
  `bidirectional_fit_allocator_` in
  BidirectionalFitDecoderBufferAllocatorStrategy to correct a typo.
- Rename helper functions `updateTexImage` and `getTransformMatrix` to
  PascalCase (`UpdateTexImage`, `GetTransformMatrix`) in
  media_codec_video_decoder.cc to match Starboard style guidelines.

Bug: 511356295