### PR TITLE
build: Rename INTERNAL_BUILD to COBALT_INTERNAL_BUILD

### DIFF
--- a/starboard/build/config/BUILD.gn
+++ b/starboard/build/config/BUILD.gn
@@ -34,7 +34,7 @@ config("starboard") {
     }
 
     if (is_internal_build) {
-      defines += [ "INTERNAL_BUILD" ]
+      defines += [ "COBALT_INTERNAL_BUILD" ]
     }
 
     if (sb_enable_lib) {

--- a/starboard/tvos/shared/media/av_video_sample_buffer_builder.mm
+++ b/starboard/tvos/shared/media/av_video_sample_buffer_builder.mm
@@ -20,7 +20,7 @@
 #import "starboard/tvos/shared/media/playback_capabilities.h"
 #import "starboard/tvos/shared/media/vp9_sw_av_video_sample_buffer_builder.h"  // nogncheck
 
-#if defined(INTERNAL_BUILD)
+#if defined(COBALT_INTERNAL_BUILD)
 #import "cobalt/internal/starboard/shared/tvos/vp9_hw_av_video_sample_buffer_builder.h"
 #endif
 
@@ -32,11 +32,11 @@ AVVideoSampleBufferBuilder* AVVideoSampleBufferBuilder::CreateBuilder(
   if (video_stream_info.codec == kSbMediaVideoCodecH264) {
     return new AvcAVVideoSampleBufferBuilder();
   } else if (video_stream_info.codec == kSbMediaVideoCodecVp9) {
-#if defined(INTERNAL_BUILD)
+#if defined(COBALT_INTERNAL_BUILD)
     if (PlaybackCapabilities::IsHwVp9Supported()) {
       return new Vp9HwAVVideoSampleBufferBuilder(video_stream_info);
     }
-#endif  // defined(INTERNAL_BUILD)
+#endif  // defined(COBALT_INTERNAL_BUILD)
     return new Vp9SwAVVideoSampleBufferBuilder(video_stream_info);
   }
   SB_NOTREACHED();

--- a/starboard/tvos/shared/media_is_video_supported.mm
+++ b/starboard/tvos/shared/media_is_video_supported.mm
@@ -67,7 +67,7 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
       return !is_hdr && frame_height <= 1080 && frame_width <= 1920;
     }
     if (video_codec == kSbMediaVideoCodecVp9) {
-#if defined(INTERNAL_BUILD)
+#if defined(COBALT_INTERNAL_BUILD)
       if (is_hdr) {
         if (transfer_id == kSbMediaTransferIdSmpteSt2084 ||
             transfer_id == kSbMediaTransferIdAribStdB67) {
@@ -130,7 +130,7 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
 #else
       SB_LOG(INFO) << "Non-internal build, accepting all VP9";
       return true;
-#endif  // defined(INTERNAL_BUILD)
+#endif  // defined(COBALT_INTERNAL_BUILD)
     }
   }  // @autoreleasepool
 

--- a/starboard/tvos/shared/system_get_property.mm
+++ b/starboard/tvos/shared/system_get_property.mm
@@ -23,7 +23,7 @@
 #include "starboard/common/string.h"
 #include "starboard/system.h"
 
-#if defined(INTERNAL_BUILD)
+#if defined(COBALT_INTERNAL_BUILD)
 #include "starboard/keyboxes/tvos/system_properties.h"
 #endif
 


### PR DESCRIPTION
Rename the INTERNAL_BUILD preprocessor macro to COBALT_INTERNAL_BUILD
across the build config and tvOS platform sources. The prefixed name
avoids collisions with generic `INTERNAL_BUILD` defines from third-party
dependencies. [1]

[1] https://chromium.googlesource.com/external/github.com/google/cld_3.git/+/refs/heads/master/src/base.h#95

Bug: 492080113