### PR TITLE
perfetto: skip VMADDR_FLAG_TO_HOST under STARBOARD

### DIFF
--- a/third_party/perfetto/src/base/unix_socket.cc
+++ b/third_party/perfetto/src/base/unix_socket.cc
@@ -236,7 +236,7 @@ SockaddrAny MakeSockAddr(SockFamily family, const std::string& socket_name) {
       addr.svm_family = AF_VSOCK;
       addr.svm_cid = *base::StringToUInt32(parts[0]);
       addr.svm_port = *base::StringToUInt32(parts[1]);
-#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID)
+#if PERFETTO_BUILDFLAG(PERFETTO_OS_ANDROID) && !defined(STARBOARD)
       if (IsVirtualized()) {
         // VM-to-VM VSOCK communication requires messages to be
         // routed through the host.


### PR DESCRIPTION
perfetto: skip VMADDR_FLAG_TO_HOST under STARBOARD
    
Under STARBOARD, Perfetto’s stripped fallback in vm_sockets.h is used
instead of <linux/vm_sockets.h>, and it does not define
VMADDR_FLAG_TO_HOST. Guard the only consumer (the Android VM-to-host
routing branch in unix_socket.cc) with STARBOARD to avoid a build
failure.


Bug: 495203133