### PR TITLE
Revert "Revert "android: Add WebContentsObserver for mediaSession""

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltMediaSession.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltMediaSession.java
@@ -32,6 +32,7 @@ import java.util.Set;
 import org.chromium.content_public.browser.MediaSession;
 import org.chromium.content_public.browser.MediaSessionObserver;
 import org.chromium.content_public.browser.WebContents;
+import org.chromium.content_public.browser.WebContentsObserver;
 import org.chromium.media_session.mojom.MediaSessionAction;
 import org.chromium.services.media_session.MediaImage;
 import org.chromium.services.media_session.MediaMetadata;
@@ -54,6 +55,7 @@ public class CobaltMediaSession implements ArtworkLoader.Callback {
   private final ArtworkLoader mArtworkLoader;
   private final Holder<Activity> mActivityHolder;
   private WebContents mWebContents;
+  private WebContentsObserver mWebContentsObserver;
   private MediaSessionCompat mMediaSession;
   private MediaSessionObserver mMediaSessionObserver;
   private boolean mIsControllable;
@@ -102,43 +104,36 @@ public class CobaltMediaSession implements ArtworkLoader.Callback {
 
           @Override
           public void onPlay() {
-            Log.i(TAG, "MediaSession action: PLAY");
             onReceiveAction(MediaSessionAction.PLAY);
           }
 
           @Override
           public void onPause() {
-            Log.i(TAG, "MediaSession action: PAUSE");
             onReceiveAction(MediaSessionAction.PAUSE);
           }
 
           @Override
           public void onSkipToPrevious() {
-            Log.i(TAG, "MediaSession action: SKIP PREVIOUS");
             onReceiveAction(MediaSessionAction.PREVIOUS_TRACK);
           }
 
           @Override
           public void onSkipToNext() {
-            Log.i(TAG, "MediaSession action: SKIP NEXT");
             onReceiveAction(MediaSessionAction.NEXT_TRACK);
           }
 
           @Override
           public void onFastForward() {
-            Log.i(TAG, "MediaSession action: FAST FORWARD");
             onReceiveAction(MediaSessionAction.SEEK_FORWARD);
           }
 
           @Override
           public void onRewind() {
-            Log.i(TAG, "MediaSession action: REWIND");
             onReceiveAction(MediaSessionAction.SEEK_BACKWARD);
           }
 
           @Override
           public void onSeekTo(long pos) {
-            Log.i(TAG, "MediaSession action: SEEK " + pos);
             // To be cautious, explicitly run the code on main loop .
             mMainHandler.post(
                 new Runnable() {
@@ -154,7 +149,6 @@ public class CobaltMediaSession implements ArtworkLoader.Callback {
 
           @Override
           public void onStop() {
-            Log.i(TAG, "MediaSession action: STOP");
             onReceiveAction(MediaSessionAction.STOP);
           }
         };
@@ -164,6 +158,12 @@ public class CobaltMediaSession implements ArtworkLoader.Callback {
     if (mWebContents == webContents) {
       return;
     }
+
+    if (mWebContentsObserver != null) {
+      mWebContentsObserver.observe(null);
+      mWebContentsObserver = null;
+    }
+
     if (webContents == null) {
       cleanupMediaSessionObserver();
       mWebContents = null;
@@ -171,6 +171,18 @@ public class CobaltMediaSession implements ArtworkLoader.Callback {
     }
 
     mWebContents = webContents;
+    mWebContentsObserver =
+        new WebContentsObserver(mWebContents) {
+          @Override
+          public void mediaSessionCreated(MediaSession mediaSession) {
+            setupMediaSessionObserver(mediaSession);
+          }
+
+          @Override
+          public void webContentsDestroyed() {
+            setWebContents(null);
+          }
+        };
     setupMediaSessionObserver(MediaSession.fromWebContents(mWebContents));
   }
 
@@ -210,22 +222,8 @@ public class CobaltMediaSession implements ArtworkLoader.Callback {
     Log.i(TAG, "MediaSession has been deactivated.");
   }
 
-  private void cleanupMediaSessionObserver() {
-    if (mMediaSessionObserver == null) {
-      return;
-    }
-    mMediaSessionObserver.stopObserving();
-    mMediaSessionObserver = null;
-  }
-
-  private void setupMediaSessionObserver(MediaSession mediaSession) {
-    if (mMediaSessionObserver != null && mMediaSessionObserver.getMediaSession() == mediaSession) {
-      return;
-    }
-
-    cleanupMediaSessionObserver();
-    mMediaSessionObserver =
-        new MediaSessionObserver(mediaSession) {
+  private MediaSessionObserver createMediaSessionObserver(MediaSession mediaSession) {
+    return new MediaSessionObserver(mediaSession) {
           @Override
           public void mediaSessionDestroyed() {
             // We always keep a MediaSession, so nothing to destroy here.
@@ -271,6 +269,25 @@ public class CobaltMediaSession implements ArtworkLoader.Callback {
             updatePlaybackState();
           }
         };
+  }
+
+  private void cleanupMediaSessionObserver() {
+    if (mMediaSessionObserver == null) {
+      return;
+    }
+    mMediaSessionObserver.stopObserving();
+    mMediaSessionObserver = null;
+  }
+
+  private void setupMediaSessionObserver(MediaSession mediaSession) {
+    if (mMediaSessionObserver != null && mMediaSessionObserver.getMediaSession() == mediaSession) {
+      return;
+    }
+
+    cleanupMediaSessionObserver();
+    if(mediaSession != null) {
+      mMediaSessionObserver = createMediaSessionObserver(mediaSession);
+    }
   }
 
   private void toggleKeepScreenOn(boolean keepScreenOn) {


### PR DESCRIPTION
Reverts youtube/cobalt#10345.
This re-lands the original change. After landing PR #10380, `Cherry pick PR #10380: Cobalt: Correct MediaImage JNI path for Google3`, we should have resolved the changes causing production runtime crashes due to `ClassNotFoundException: org/chromium/services/media_session/MediaImage`.

Bug: 508673132