### PR TITLE
android: Add missing menu keyevent

### DIFF
--- a/ui/events/keycodes/cobalt/keyboard_code_conversion_android_cobalt.cc
+++ b/ui/events/keycodes/cobalt/keyboard_code_conversion_android_cobalt.cc
@@ -36,6 +36,8 @@ KeyboardCode KeyboardCodeFromAndroidKeyCode(int keycode) {
     case AKEYCODE_PROG_BLUE:
       return VKEY_BLUE;
 
+    case AKEYCODE_MENU:
+      return VKEY_MENU;
     case AKEYCODE_CHANNEL_UP:
       return VKEY_CHANNEL_UP;
     case AKEYCODE_CHANNEL_DOWN:


### PR DESCRIPTION
Add a mapping for `AKEYCODE_MENU` (android keyevent 82) to `VKEY_MENU`. Chrobalt currently does not respond to this key event; this ensures that the Menu button successfully displays the menu page when a video is playing. 


Bug: 511092068