### PR TITLE
media/gpu/ipc: Remove dead DrDc synchronization code

### DIFF
--- a/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.cc
+++ b/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.cc
@@ -25,35 +25,18 @@
 #include "gpu/command_buffer/service/texture_manager.h"
 #include "ui/gl/gl_utils.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include "gpu/command_buffer/service/ref_counted_lock.h"
-#endif
-
 namespace gpu {
 
 class StarboardGLTextureBacking::
     GLTexturePassthroughStarboardImageRepresentation
-    : public GLTexturePassthroughImageRepresentation
-#if BUILDFLAG(IS_ANDROID)
-    ,
-      public RefCountedLockHelperDrDc
-#endif
-{
+    : public GLTexturePassthroughImageRepresentation {
  public:
   GLTexturePassthroughStarboardImageRepresentation(
       SharedImageManager* manager,
       StarboardGLTextureBacking* backing,
       MemoryTypeTracker* tracker,
-      std::vector<scoped_refptr<gpu::gles2::TexturePassthrough>> textures
-#if BUILDFLAG(IS_ANDROID)
-      ,
-      scoped_refptr<RefCountedLock> drdc_lock
-#endif
-      )
+      std::vector<scoped_refptr<gpu::gles2::TexturePassthrough>> textures)
       : GLTexturePassthroughImageRepresentation(manager, backing, tracker),
-#if BUILDFLAG(IS_ANDROID)
-        RefCountedLockHelperDrDc(std::move(drdc_lock)),
-#endif
         passthrough_textures_(std::move(textures)) {
     for (auto& passthrough_texture : passthrough_textures_) {
       CHECK(passthrough_texture);
@@ -68,24 +51,13 @@ class StarboardGLTextureBacking::
     return passthrough_textures_[plane_index];
   }
 
-  bool BeginAccess(GLenum mode) override NO_THREAD_SAFETY_ANALYSIS {
+  bool BeginAccess(GLenum mode) override {
     // This representation should only be called for read.
     DCHECK(mode == GL_SHARED_IMAGE_ACCESS_MODE_READ_CHROMIUM);
-#if BUILDFLAG(IS_ANDROID)
-    if (GetDrDcLockPtr()) {
-      GetDrDcLockPtr()->Acquire();
-    }
-#endif
     return true;
   }
 
-  void EndAccess() override NO_THREAD_SAFETY_ANALYSIS {
-#if BUILDFLAG(IS_ANDROID)
-    if (GetDrDcLockPtr()) {
-      GetDrDcLockPtr()->Release();
-    }
-#endif
-  }
+  void EndAccess() override {}
 
  private:
   std::vector<scoped_refptr<gles2::TexturePassthrough>> passthrough_textures_;
@@ -101,12 +73,7 @@ StarboardGLTextureBacking::StarboardGLTextureBacking(
     SharedImageUsageSet usage,
     std::vector<GLuint> texture_ids,
     std::vector<uint32_t> texture_targets,
-    uint64_t decode_target
-#if BUILDFLAG(IS_ANDROID)
-    ,
-    scoped_refptr<gpu::RefCountedLock> drdc_lock
-#endif
-    )
+    uint64_t decode_target)
     : ClearTrackingSharedImageBacking(mailbox,
                                       format,
                                       size,
@@ -123,9 +90,6 @@ StarboardGLTextureBacking::StarboardGLTextureBacking(
         base::MakeRefCounted<gpu::gles2::TexturePassthrough>(
             texture_ids[i], texture_targets[i]));
   }
-#if BUILDFLAG(IS_ANDROID)
-  drdc_lock_ = std::move(drdc_lock);
-#endif
   SetCleared();
 }
 
@@ -155,12 +119,7 @@ StarboardGLTextureBacking::ProduceGLTexturePassthrough(
     SharedImageManager* manager,
     MemoryTypeTracker* tracker) {
   return std::make_unique<GLTexturePassthroughStarboardImageRepresentation>(
-      manager, this, tracker, passthrough_textures_
-#if BUILDFLAG(IS_ANDROID)
-      ,
-      drdc_lock_
-#endif
-  );
+      manager, this, tracker, passthrough_textures_);
 }
 
 std::unique_ptr<SkiaGaneshImageRepresentation>

--- a/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h
+++ b/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h
@@ -39,9 +39,7 @@ class GPU_GLES2_EXPORT StarboardGLTextureBacking
                             SharedImageUsageSet usage,
                             std::vector<GLuint> texture_ids,
                             std::vector<uint32_t> texture_targets,
-                            uint64_t decode_target
-
-  );
+                            uint64_t decode_target);
 
   ~StarboardGLTextureBacking() override;
 

--- a/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h
+++ b/gpu/command_buffer/service/shared_image/starboard/starboard_gl_texture_image_backing.h
@@ -25,10 +25,6 @@
 #include "gpu/gpu_gles2_export.h"
 #include "starboard/decode_target.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include "gpu/command_buffer/service/ref_counted_lock.h"
-#endif
-
 namespace gpu {
 
 class GPU_GLES2_EXPORT StarboardGLTextureBacking
@@ -44,10 +40,7 @@ class GPU_GLES2_EXPORT StarboardGLTextureBacking
                             std::vector<GLuint> texture_ids,
                             std::vector<uint32_t> texture_targets,
                             uint64_t decode_target
-#if BUILDFLAG(IS_ANDROID)
-                            ,
-                            scoped_refptr<gpu::RefCountedLock> drdc_lock
-#endif
+
   );
 
   ~StarboardGLTextureBacking() override;
@@ -76,10 +69,6 @@ class GPU_GLES2_EXPORT StarboardGLTextureBacking
       passthrough_textures_;
 
   SbDecodeTarget decode_target_ = kSbDecodeTargetInvalid;
-
-#if BUILDFLAG(IS_ANDROID)
-  scoped_refptr<gpu::RefCountedLock> drdc_lock_;
-#endif
 };
 
 }  // namespace gpu

--- a/gpu/ipc/service/gpu_channel_shared_image_interface.cc
+++ b/gpu/ipc/service/gpu_channel_shared_image_interface.cc
@@ -163,10 +163,7 @@ GpuChannelSharedImageInterface::CreateSharedImageForStarboardGLTexture(
     const std::vector<uint32_t>& texture_service_ids,
     const std::vector<uint32_t>& texture_targets,
     uint64_t decode_target
-#if BUILDFLAG(IS_ANDROID)
-    ,
-    scoped_refptr<RefCountedLock> drdc_lock
-#endif
+
 ) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(gpu_sequence_checker_);
 
@@ -181,9 +178,7 @@ GpuChannelSharedImageInterface::CreateSharedImageForStarboardGLTexture(
       kTopLeft_GrSurfaceOrigin, kPremul_SkAlphaType,
       SHARED_IMAGE_USAGE_DISPLAY_READ | SHARED_IMAGE_USAGE_GLES2_READ,
       texture_service_ids, texture_targets, decode_target
-#if BUILDFLAG(IS_ANDROID)
-      , std::move(drdc_lock)
-#endif
+
       );
   
   SharedImageMetadata metadata{backing->format(),

--- a/gpu/ipc/service/gpu_channel_shared_image_interface.cc
+++ b/gpu/ipc/service/gpu_channel_shared_image_interface.cc
@@ -162,9 +162,7 @@ GpuChannelSharedImageInterface::CreateSharedImageForStarboardGLTexture(
     const gfx::ColorSpace& color_space,
     const std::vector<uint32_t>& texture_service_ids,
     const std::vector<uint32_t>& texture_targets,
-    uint64_t decode_target
-
-) {
+    uint64_t decode_target) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(gpu_sequence_checker_);
 
   if (!shared_image_stub_) {
@@ -177,9 +175,7 @@ GpuChannelSharedImageInterface::CreateSharedImageForStarboardGLTexture(
       mailbox, format, size, color_space,
       kTopLeft_GrSurfaceOrigin, kPremul_SkAlphaType,
       SHARED_IMAGE_USAGE_DISPLAY_READ | SHARED_IMAGE_USAGE_GLES2_READ,
-      texture_service_ids, texture_targets, decode_target
-
-      );
+      texture_service_ids, texture_targets, decode_target);
   
   SharedImageMetadata metadata{backing->format(),
                                backing->size(),

--- a/gpu/ipc/service/gpu_channel_shared_image_interface.h
+++ b/gpu/ipc/service/gpu_channel_shared_image_interface.h
@@ -135,12 +135,7 @@ class GPU_IPC_SERVICE_EXPORT GpuChannelSharedImageInterface
       const gfx::ColorSpace& color_space,
       const std::vector<uint32_t>& texture_service_ids,
       const std::vector<uint32_t>& texture_targets,
-      uint64_t decode_target
-#if BUILDFLAG(IS_ANDROID)
-      ,
-      scoped_refptr<RefCountedLock> drdc_lock
-#endif
-  );
+      uint64_t decode_target);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   SequenceId sequence() { return sequence_; }

--- a/media/gpu/starboard/starboard_gpu_factory.h
+++ b/media/gpu/starboard/starboard_gpu_factory.h
@@ -26,10 +26,6 @@
 #include "ui/gfx/color_space.h"
 #include "ui/gfx/geometry/size.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include "gpu/command_buffer/service/ref_counted_lock.h"
-#endif  // BUILDFLAG(IS_ANDROID)
-
 namespace media {
 // StarboardGpuFactory allows to post tasks on gpu thread.
 // StarboardRenderer uses this class to post graphical tasks.
@@ -63,9 +59,7 @@ class StarboardGpuFactory : public gpu::CommandBufferStub::DestructionObserver {
       const std::vector<uint32_t>& texture_service_ids,
       const std::vector<uint32_t>& texture_targets,
       uint64_t decode_target,
-#if BUILDFLAG(IS_ANDROID)
-      scoped_refptr<gpu::RefCountedLock> drdc_lock,
-#endif  // BUILDFLAG(IS_ANDROID)
+
       base::WaitableEvent* done_event) = 0;
 };
 

--- a/media/gpu/starboard/starboard_gpu_factory.h
+++ b/media/gpu/starboard/starboard_gpu_factory.h
@@ -59,7 +59,6 @@ class StarboardGpuFactory : public gpu::CommandBufferStub::DestructionObserver {
       const std::vector<uint32_t>& texture_service_ids,
       const std::vector<uint32_t>& texture_targets,
       uint64_t decode_target,
-
       base::WaitableEvent* done_event) = 0;
 };
 

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -94,7 +94,6 @@ void StarboardGpuFactoryImpl::CreateImageOnGpu(
     const std::vector<uint32_t>& texture_service_ids,
     const std::vector<uint32_t>& texture_targets,
     uint64_t decode_target,
-
     base::WaitableEvent* done_event) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   if (MakeContextCurrent(stub_)) {

--- a/media/gpu/starboard/starboard_gpu_factory_impl.cc
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.cc
@@ -94,9 +94,7 @@ void StarboardGpuFactoryImpl::CreateImageOnGpu(
     const std::vector<uint32_t>& texture_service_ids,
     const std::vector<uint32_t>& texture_targets,
     uint64_t decode_target,
-#if BUILDFLAG(IS_ANDROID)
-    scoped_refptr<gpu::RefCountedLock> drdc_lock,
-#endif  // BUILDFLAG(IS_ANDROID)
+
     base::WaitableEvent* done_event) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   if (MakeContextCurrent(stub_)) {
@@ -109,12 +107,7 @@ void StarboardGpuFactoryImpl::CreateImageOnGpu(
     shared_image = gpu_channel_shared_image_interface
                        ->CreateSharedImageForStarboardGLTexture(
                            format, coded_size, color_space, texture_service_ids,
-                           texture_targets, decode_target
-#if BUILDFLAG(IS_ANDROID)
-                           ,
-                           std::move(drdc_lock)
-#endif
-                       );
+                           texture_targets, decode_target);
   }
   done_event->Signal();
 }

--- a/media/gpu/starboard/starboard_gpu_factory_impl.h
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.h
@@ -47,9 +47,7 @@ class StarboardGpuFactoryImpl : public StarboardGpuFactory {
                         const std::vector<uint32_t>& texture_service_ids,
                         const std::vector<uint32_t>& texture_targets,
                         uint64_t decode_target,
-#if BUILDFLAG(IS_ANDROID)
-                        scoped_refptr<gpu::RefCountedLock> drdc_lock,
-#endif  // BUILDFLAG(IS_ANDROID)
+
                         base::WaitableEvent* done_event) override;
 
  private:

--- a/media/gpu/starboard/starboard_gpu_factory_impl.h
+++ b/media/gpu/starboard/starboard_gpu_factory_impl.h
@@ -47,7 +47,6 @@ class StarboardGpuFactoryImpl : public StarboardGpuFactory {
                         const std::vector<uint32_t>& texture_service_ids,
                         const std::vector<uint32_t>& texture_targets,
                         uint64_t decode_target,
-
                         base::WaitableEvent* done_event) override;
 
  private:

--- a/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
+++ b/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
@@ -23,10 +23,6 @@
 #include "media/mojo/services/starboard/starboard_renderer_wrapper.h"
 #include "media/starboard/starboard_cdm_factory.h"
 
-#if BUILDFLAG(IS_ANDROID)
-#include "gpu/command_buffer/service/ref_counted_lock.h"
-#endif  // BUILDFLAG(IS_ANDROID)
-
 namespace media {
 
 class GpuMojoMediaClientStarboard final : public GpuMojoMediaClient {
@@ -69,16 +65,8 @@ class GpuMojoMediaClientStarboard final : public GpuMojoMediaClient {
       StarboardRendererTraits traits) final {
 #if BUILDFLAG(IS_ANDROID)
     traits.android_overlay_factory_cb = android_overlay_factory_cb_;
-    scoped_refptr<gpu::RefCountedLock> ref_counted_lock;
-
-    if (features::NeedThreadSafeAndroidMedia()) {
-      ref_counted_lock = base::MakeRefCounted<gpu::RefCountedLock>();
-    }
-    return std::make_unique<StarboardRendererWrapper>(std::move(traits),
-                                                      ref_counted_lock);
-#else   // BUILDFLAG(IS_ANDROID)
-    return std::make_unique<StarboardRendererWrapper>(std::move(traits));
 #endif  // BUILDFLAG(IS_ANDROID)
+    return std::make_unique<StarboardRendererWrapper>(std::move(traits));
   }
 
   std::unique_ptr<CdmFactory> CreatePlatformCdmFactory(

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -28,16 +28,8 @@
 namespace media {
 
 StarboardRendererWrapper::StarboardRendererWrapper(
-    StarboardRendererTraits traits
-#if BUILDFLAG(IS_ANDROID)
-    ,
-    scoped_refptr<gpu::RefCountedLock> drdc_lock)
-    : gpu::RefCountedLockHelperDrDc(std::move(drdc_lock)),
-#else   // BUILDFLAG(IS_ANDROID)
-    )
-    :
-#endif  // BUILDFLAG(IS_ANDROID)
-      renderer_extension_receiver_(
+    StarboardRendererTraits traits)
+    : renderer_extension_receiver_(
           this,
           std::move(traits.renderer_extension_receiver)),
       client_extension_remote_(std::move(traits.client_extension_remote),
@@ -298,11 +290,7 @@ void StarboardRendererWrapper::GetCurrentVideoFrame(
           .WithArgs(coded_size, GetRenderer()->color_space(), viz_format,
                     std::ref(shared_image), std::ref(texture_service_ids),
                     std::ref(texture_targets),
-                    reinterpret_cast<uint64_t>(decode_target_),
-#if BUILDFLAG(IS_ANDROID)
-                    GetDrDcLock(),
-#endif  // BUILDFLAG(IS_ANDROID)
-                    &done_event);
+                    reinterpret_cast<uint64_t>(decode_target_), &done_event);
       // Blocking is okay here to create image from textures on gpu thread.
       base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_wait;
       done_event.Wait();

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -37,7 +37,6 @@
 #include "starboard/decode_target.h"
 
 #if BUILDFLAG(IS_ANDROID)
-#include "gpu/command_buffer/service/ref_counted_lock.h"
 #include "media/base/android_overlay_mojo_factory.h"
 #endif  // BUILDFLAG(IS_ANDROID)
 
@@ -59,21 +58,13 @@ class StarboardGpuFactory;
 class StarboardRendererWrapper
     : public Renderer,
       public mojom::StarboardRendererExtension,
-#if BUILDFLAG(IS_ANDROID)
-      public gpu::RefCountedLockHelperDrDc,
-#endif  // BUILDFLAG(IS_ANDROID)
       public cobalt::media::mojom::VideoGeometryChangeClient {
  public:
   using RendererExtension = mojom::StarboardRendererExtension;
   using ClientExtension = mojom::StarboardRendererClientExtension;
   using GetStarboardCommandBufferStubCB = StarboardGpuFactory::GetStubCB;
 
-#if BUILDFLAG(IS_ANDROID)
-  StarboardRendererWrapper(StarboardRendererTraits traits,
-                           scoped_refptr<gpu::RefCountedLock> drdc_lock);
-#else   // BUILDFLAG(IS_ANDROID)
   explicit StarboardRendererWrapper(StarboardRendererTraits traits);
-#endif  // BUILDFLAG(IS_ANDROID)
 
   StarboardRendererWrapper(const StarboardRendererWrapper&) = delete;
   StarboardRendererWrapper& operator=(const StarboardRendererWrapper&) = delete;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -159,9 +159,6 @@ class MockStarboardGpuFactory : public StarboardGpuFactory {
                         const std::vector<uint32_t>& texture_service_ids,
                         const std::vector<uint32_t>& texture_targets,
                         uint64_t decode_target,
-#if BUILDFLAG(IS_ANDROID)
-                        scoped_refptr<gpu::RefCountedLock> drdc_lock,
-#endif  // BUILDFLAG(IS_ANDROID)
                         base::WaitableEvent* done_event) override {
     done_event->Signal();
   }
@@ -210,12 +207,7 @@ class StarboardRendererWrapperTest : public testing::Test {
         gfx::Size(), std::move(renderer_extension_receiver),
         std::move(client_extension_remote), base::NullCallback());
     renderer_wrapper_ =
-        std::make_unique<StarboardRendererWrapper>(std::move(traits)
-#if BUILDFLAG(IS_ANDROID)
-                                                       ,
-                                                   /*ref_counted_lock=*/nullptr
-#endif  // BUILDFLAG(IS_ANDROID)
-        );
+        std::make_unique<StarboardRendererWrapper>(std::move(traits));
     renderer_wrapper_->SetRendererForTesting(mock_renderer_.get());
     renderer_wrapper_->SetGpuFactoryForTesting(&gpu_factory_);
 


### PR DESCRIPTION
This change removes vestigial DrDc (Dual Raster/Display Composer) lock synchronization code from Cobalt's decode-to-texture GPU pipeline.

This is a pure dead-code cleanup. We are not changing the behavior or
disabling DrDc with this change, as DrDc was already inactive across
all Cobalt configurations:
1. DrDc is explicitly disabled in Cobalt (we recently hardcoded EnableAndroidImageReader() to return false when IS_COBALT is defined).
2. DrDc is not actually supported or used in Cobalt's Starboard-based media pipeline.
3. While 26.android carried similar DrDc-lock-related code, it was also effectively a No-OP there because AImageReader was disabled via startup feature overrides.

Removing this vestigial code simplifies the shared image backings and Mojo wrapper layers, reducing complexity and potential for future merge conflicts.

Issue: 150410605