### PR TITLE
cobalt/metrics: Add comprehensive granular memory browsertests

### DIFF
--- a/base/allocator/partition_alloc_support.cc
+++ b/base/allocator/partition_alloc_support.cc
@@ -682,6 +682,7 @@ void CheckDanglingRawPtrBufferEmpty() {
 }  // namespace
 
 void InstallDanglingRawPtrChecks() {
+  bool enabled = FeatureList::IsEnabled(features::kPartitionAllocDanglingPtr);
   // Multiple tests can run within the same executable's execution. This line
   // ensures problems detected from the previous test are causing error before
   // entering the next one...
@@ -697,7 +698,7 @@ void InstallDanglingRawPtrChecks() {
     AtExitManager::RegisterTask(base::BindOnce(CheckDanglingRawPtrBufferEmpty));
   }
 
-  if (!FeatureList::IsEnabled(features::kPartitionAllocDanglingPtr)) {
+  if (!enabled) {
     partition_alloc::SetDanglingRawPtrDetectedFn([](uintptr_t) {});
     partition_alloc::SetDanglingRawPtrReleasedFn([](uintptr_t) {});
     return;
@@ -1002,10 +1003,6 @@ void PartitionAllocSupport::ReconfigureAfterZygoteFork(
 void PartitionAllocSupport::ReconfigureAfterFeatureListInit(
     const std::string& process_type,
     bool configure_dangling_pointer_detector) {
-  if (configure_dangling_pointer_detector) {
-    base::allocator::InstallDanglingRawPtrChecks();
-  }
-  base::allocator::InstallUnretainedDanglingRawPtrChecks();
   {
     base::AutoLock scoped_lock(lock_);
     // Avoid initializing more than once.
@@ -1032,6 +1029,11 @@ void PartitionAllocSupport::ReconfigureAfterFeatureListInit(
 
     called_after_feature_list_init_ = true;
   }
+
+  if (configure_dangling_pointer_detector) {
+    base::allocator::InstallDanglingRawPtrChecks();
+  }
+  base::allocator::InstallUnretainedDanglingRawPtrChecks();
 
   DCHECK_NE(process_type, switches::kZygoteProcess);
   [[maybe_unused]] BrpConfiguration brp_config =

--- a/base/allocator/partition_alloc_support.cc
+++ b/base/allocator/partition_alloc_support.cc
@@ -682,7 +682,6 @@ void CheckDanglingRawPtrBufferEmpty() {
 }  // namespace
 
 void InstallDanglingRawPtrChecks() {
-  bool enabled = FeatureList::IsEnabled(features::kPartitionAllocDanglingPtr);
   // Multiple tests can run within the same executable's execution. This line
   // ensures problems detected from the previous test are causing error before
   // entering the next one...
@@ -698,7 +697,7 @@ void InstallDanglingRawPtrChecks() {
     AtExitManager::RegisterTask(base::BindOnce(CheckDanglingRawPtrBufferEmpty));
   }
 
-  if (!enabled) {
+  if (!FeatureList::IsEnabled(features::kPartitionAllocDanglingPtr)) {
     partition_alloc::SetDanglingRawPtrDetectedFn([](uintptr_t) {});
     partition_alloc::SetDanglingRawPtrReleasedFn([](uintptr_t) {});
     return;
@@ -1003,6 +1002,12 @@ void PartitionAllocSupport::ReconfigureAfterZygoteFork(
 void PartitionAllocSupport::ReconfigureAfterFeatureListInit(
     const std::string& process_type,
     bool configure_dangling_pointer_detector) {
+#if !BUILDFLAG(IS_COBALT)
+  if (configure_dangling_pointer_detector) {
+    base::allocator::InstallDanglingRawPtrChecks();
+  }
+  base::allocator::InstallUnretainedDanglingRawPtrChecks();
+#endif  // !BUILDFLAG(IS_COBALT)
   {
     base::AutoLock scoped_lock(lock_);
     // Avoid initializing more than once.
@@ -1030,10 +1035,12 @@ void PartitionAllocSupport::ReconfigureAfterFeatureListInit(
     called_after_feature_list_init_ = true;
   }
 
+#if BUILDFLAG(IS_COBALT)
   if (configure_dangling_pointer_detector) {
     base::allocator::InstallDanglingRawPtrChecks();
   }
   base::allocator::InstallUnretainedDanglingRawPtrChecks();
+#endif  // BUILDFLAG(IS_COBALT)
 
   DCHECK_NE(process_type, switches::kZygoteProcess);
   [[maybe_unused]] BrpConfiguration brp_config =

--- a/cobalt/testing/browser_tests/BUILD.gn
+++ b/cobalt/testing/browser_tests/BUILD.gn
@@ -232,6 +232,7 @@ test("cobalt_browsertests") {
     #"media_session_browsertest.cc",
     #"media_source_browsertest.cc",
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_browsertest.cc",
+    "granular_memory_browsertest.cc",
     "navigation_browsertest.cc",
 
     #"session_history_browsertest.cc",
@@ -347,6 +348,7 @@ test("cobalt_browsertests") {
     "//services/network:test_support",
     "//services/network/public/mojom",
     "//services/network/trust_tokens:test_support",
+    "//services/resource_coordinator/public/cpp/memory_instrumentation",
     "//services/service_manager/public/cpp",
     "//services/tracing:privacy_check",
     "//services/video_capture/public/cpp",

--- a/cobalt/testing/browser_tests/cobalt_browser_tests_main.cc
+++ b/cobalt/testing/browser_tests/cobalt_browser_tests_main.cc
@@ -77,10 +77,19 @@ SB_EXPORT void SbEventHandle(const SbEvent* event) {
       testing::InitGoogleTest(&argc, argv);
 
       base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+      std::string disabled_features =
+          command_line->GetSwitchValueASCII("disable-features");
+      if (disabled_features.empty()) {
+        disabled_features = "PartitionAllocDanglingPtr";
+      } else if (disabled_features.find("PartitionAllocDanglingPtr") ==
+                 std::string::npos) {
+        disabled_features += ",PartitionAllocDanglingPtr";
+      }
+
       auto feature_list = std::make_unique<base::FeatureList>();
       feature_list->InitFromCommandLine(
           command_line->GetSwitchValueASCII("enable-features"),
-          command_line->GetSwitchValueASCII("disable-features"));
+          disabled_features);
       base::FeatureList::SetInstance(std::move(feature_list));
 
       // TODO(b/433354983): Support more platforms.

--- a/cobalt/testing/browser_tests/cobalt_browser_tests_main.cc
+++ b/cobalt/testing/browser_tests/cobalt_browser_tests_main.cc
@@ -15,10 +15,13 @@
 #include <cstdlib>
 #include <string>
 
+#include "base/allocator/partition_alloc_features.h"
 #include "base/at_exit.h"
 #include "base/command_line.h"
+#include "base/feature_list.h"
 #include "base/logging.h"
 #include "base/process/process.h"
+#include "base/test/test_suite.h"
 #include "base/test/test_support_starboard.h"
 #include "base/test/test_timeouts.h"
 #include "cobalt/shell/browser/shell_devtools_manager_delegate.h"
@@ -38,7 +41,11 @@ class CobaltBrowserTestLauncherDelegate : public content::TestLauncherDelegate {
  public:
   // This method is called by content::LaunchTests to
   // execute the entire suite of discovered Google Tests.
-  int RunTestSuite(int argc, char** argv) override { return RUN_ALL_TESTS(); }
+  int RunTestSuite(int argc, char** argv) override {
+    base::TestSuite test_suite(argc, argv);
+    test_suite.DisableCheckForLeakedGlobals();
+    return test_suite.Run();
+  }
 
   content::ContentMainDelegate* CreateContentMainDelegate() override {
     return new content::ContentBrowserTestShellMainDelegate();
@@ -53,7 +60,6 @@ class CobaltBrowserTestLauncherDelegate : public content::TestLauncherDelegate {
 
 SB_EXPORT void SbEventHandle(const SbEvent* event) {
   static int s_test_result_code = 0;
-  static base::AtExitManager* s_at_exit_manager = nullptr;
   static CobaltBrowserTestLauncherDelegate* s_delegate = nullptr;
 
   switch (event->type) {
@@ -70,10 +76,12 @@ SB_EXPORT void SbEventHandle(const SbEvent* event) {
       base::CommandLine::Init(argc, argv);
       testing::InitGoogleTest(&argc, argv);
 
-      // A manager for singleton destruction.
-      if (!s_at_exit_manager) {
-        s_at_exit_manager = new base::AtExitManager();
-      }
+      base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
+      auto feature_list = std::make_unique<base::FeatureList>();
+      feature_list->InitFromCommandLine(
+          command_line->GetSwitchValueASCII("enable-features"),
+          command_line->GetSwitchValueASCII("disable-features"));
+      base::FeatureList::SetInstance(std::move(feature_list));
 
       // TODO(b/433354983): Support more platforms.
       ui::LinuxUi::SetInstance(ui::GetDefaultLinuxUi());
@@ -81,7 +89,6 @@ SB_EXPORT void SbEventHandle(const SbEvent* event) {
       if (!s_delegate) {
         s_delegate = new CobaltBrowserTestLauncherDelegate();
       }
-      TestTimeouts::Initialize();
       base::InitStarboardTestMessageLoop();
       s_test_result_code = content::LaunchTests(s_delegate, 1, argc, argv);
       SbSystemRequestStop(s_test_result_code);

--- a/cobalt/testing/browser_tests/granular_memory_browsertest.cc
+++ b/cobalt/testing/browser_tests/granular_memory_browsertest.cc
@@ -1,0 +1,292 @@
+// Copyright 2026 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/files/file_util.h"
+#include "base/run_loop.h"
+#include "base/threading/thread_restrictions.h"
+#include "build/build_config.h"
+#include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
+#include "cobalt/shell/browser/shell.h"
+#include "cobalt/testing/browser_tests/browser/test_shell.h"
+#include "cobalt/testing/browser_tests/content_browser_test.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
+#include "services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics.h"
+#include "services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace content {
+
+namespace {
+
+const char kTestSmaps[] =
+    "00400000-004be000 r-xp 00000000 fc:01 1234              /file/1\n"
+    "Size:                760 kB\n"
+    "Rss:                 296 kB\n"
+    "Pss:                 162 kB\n"
+    "Shared_Clean:        228 kB\n"
+    "Shared_Dirty:          0 kB\n"
+    "Private_Clean:         0 kB\n"
+    "Private_Dirty:        68 kB\n"
+    "Referenced:          296 kB\n"
+    "Anonymous:            68 kB\n"
+    "AnonHugePages:         0 kB\n"
+    "Swap:                  4 kB\n"
+    "KernelPageSize:        4 kB\n"
+    "MMUPageSize:           4 kB\n"
+    "Locked:                0 kB\n"
+    "VmFlags: rd ex mr mw me dw sd\n";
+
+const char kTestSmapsRollup[] =
+    "Pss:                 162 kB\n"
+    "SwapPss:               0 kB\n";
+
+void CreateTempFileWithContents(const char* contents, base::ScopedFILE* file) {
+  base::ScopedAllowBlockingForTesting allow_blocking;
+  base::FilePath temp_path;
+  *file = base::CreateAndOpenTemporaryStream(&temp_path);
+  ASSERT_TRUE(*file);
+  ASSERT_TRUE(base::WriteFileDescriptor(fileno(file->get()), contents));
+}
+
+class TestDetailedMetricsDelegate
+    : public memory_instrumentation::DetailedMetricsDelegate {
+ public:
+  TestDetailedMetricsDelegate() = default;
+  ~TestDetailedMetricsDelegate() override = default;
+
+  void OnSmapsEntry(
+      absl::string_view name,
+      const memory_instrumentation::SmapsMetrics& metrics) override {
+    stats_["Test"] += metrics.pss_kb;
+    total_pss_kb_ += metrics.pss_kb;
+  }
+
+  void GetAndResetStats(base::flat_map<std::string, uint64_t>* stats) override {
+    *stats = std::move(stats_);
+    (*stats)["total_pss"] = total_pss_kb_;
+    stats_.clear();
+    total_pss_kb_ = 0;
+  }
+
+  base::WeakPtr<memory_instrumentation::DetailedMetricsDelegate> GetWeakPtr()
+      override {
+    return weak_ptr_factory_.GetWeakPtr();
+  }
+
+ private:
+  base::flat_map<std::string, uint64_t> stats_;
+  uint64_t total_pss_kb_ = 0;
+  base::WeakPtrFactory<TestDetailedMetricsDelegate> weak_ptr_factory_{this};
+};
+
+}  // namespace
+
+class GranularMemoryBrowsertest : public ContentBrowserTest {
+ public:
+  GranularMemoryBrowsertest() = default;
+
+  void SetUpOnMainThread() override {
+    BrowserTestBase::SetUpOnMainThread();
+    memory_instrumentation::MemoryInstrumentation::GetInstance()
+        ->SetDetailedMetricsDelegate(&delegate_);
+
+    CreateTempFileWithContents(kTestSmaps, &temp_smaps_);
+    CreateTempFileWithContents(kTestSmapsRollup, &temp_rollup_);
+    memory_instrumentation::OSMetrics::SetProcSmapsForTesting(
+        temp_smaps_.get());
+    memory_instrumentation::OSMetrics::SetSmapsRollupForTesting(
+        temp_rollup_.get());
+  }
+
+  void TearDownOnMainThread() override {
+    memory_instrumentation::OSMetrics::SetProcSmapsForTesting(nullptr);
+    memory_instrumentation::OSMetrics::SetSmapsRollupForTesting(nullptr);
+    memory_instrumentation::MemoryInstrumentation::GetInstance()
+        ->SetDetailedMetricsDelegate(nullptr);
+    BrowserTestBase::TearDownOnMainThread();
+  }
+
+ private:
+  TestDetailedMetricsDelegate delegate_;
+  base::ScopedFILE temp_smaps_;
+  base::ScopedFILE temp_rollup_;
+};
+
+#if BUILDFLAG(IS_LINUX)
+IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
+  // Ensure at least one renderer process is active.
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
+
+  base::RunLoop run_loop;
+  base::ProcessId browser_pid = base::GetCurrentProcId();
+
+  memory_instrumentation::MemoryInstrumentation::GetInstance()
+      ->GetCoordinator()
+      ->RequestGlobalMemoryDump(
+          base::trace_event::MemoryDumpType::kExplicitlyTriggered,
+          base::trace_event::MemoryDumpLevelOfDetail::kDetailed,
+          base::trace_event::MemoryDumpDeterminism::kNone, {},
+          base::BindOnce(
+              [](base::OnceClosure quit_closure, base::ProcessId browser_pid,
+                 bool success,
+                 memory_instrumentation::mojom::GlobalMemoryDumpPtr dump) {
+                EXPECT_TRUE(success);
+                ASSERT_TRUE(dump);
+                bool found_browser_detailed_stats = false;
+                for (const auto& process_dump : dump->process_dumps) {
+                  if (process_dump->pid == browser_pid) {
+                    ASSERT_TRUE(process_dump->os_dump->detailed_stats_kb);
+                    if (!process_dump->os_dump->detailed_stats_kb->empty()) {
+                      found_browser_detailed_stats = true;
+                      // Verify the content matches our
+                      // TestDetailedMetricsDelegate which should have
+                      // accumulated 162 KB from kTestSmaps.
+                      EXPECT_EQ(
+                          process_dump->os_dump->detailed_stats_kb->at("Test"),
+                          162u);
+                    }
+                    break;
+                  }
+                }
+                EXPECT_TRUE(found_browser_detailed_stats);
+                std::move(quit_closure).Run();
+              },
+              run_loop.QuitClosure(), browser_pid));
+  run_loop.Run();
+}
+#endif  // BUILDFLAG(IS_LINUX)
+
+#if BUILDFLAG(IS_LINUX)
+IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest,
+                       BackgroundDumpSkipsDetailedStats) {
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
+
+  base::RunLoop run_loop;
+  base::ProcessId browser_pid = base::GetCurrentProcId();
+
+  memory_instrumentation::MemoryInstrumentation::GetInstance()
+      ->GetCoordinator()
+      ->RequestGlobalMemoryDump(
+          base::trace_event::MemoryDumpType::kExplicitlyTriggered,
+          base::trace_event::MemoryDumpLevelOfDetail::kBackground,
+          base::trace_event::MemoryDumpDeterminism::kNone, {},
+          base::BindOnce(
+              [](base::OnceClosure quit_closure, base::ProcessId browser_pid,
+                 bool success,
+                 memory_instrumentation::mojom::GlobalMemoryDumpPtr dump) {
+                EXPECT_TRUE(success);
+                ASSERT_TRUE(dump);
+                for (const auto& process_dump : dump->process_dumps) {
+                  if (process_dump->pid == browser_pid) {
+                    if (process_dump->os_dump->detailed_stats_kb) {
+                      EXPECT_TRUE(
+                          process_dump->os_dump->detailed_stats_kb->find(
+                              "Test") ==
+                          process_dump->os_dump->detailed_stats_kb->end());
+                    }
+                    break;
+                  }
+                }
+                std::move(quit_closure).Run();
+              },
+              run_loop.QuitClosure(), browser_pid));
+  run_loop.Run();
+}
+#endif  // BUILDFLAG(IS_LINUX)
+
+#if BUILDFLAG(IS_LINUX)
+IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, CobaltSpecificMetrics) {
+  // Ensure at least one renderer process is active.
+  ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
+
+  RenderProcessHost* rph =
+      shell()->web_contents()->GetPrimaryMainFrame()->GetProcess();
+
+  base::RunLoop run_loop;
+  base::ProcessId renderer_pid = rph->GetProcess().Pid();
+  ASSERT_NE(renderer_pid, base::kNullProcessId);
+
+  // Instantiate the production Cobalt delegate.
+  cobalt::CobaltDetailedMetricsDelegate cobalt_delegate;
+  memory_instrumentation::MemoryInstrumentation::GetInstance()
+      ->SetDetailedMetricsDelegate(&cobalt_delegate);
+
+  // Create mock smaps data that triggers Cobalt categorization.
+  const char kCobaltSmaps[] =
+      "00400000-004be000 r-xp 00000000 fc:01 1234              "
+      "/path/to/libchrobalt.so\n"
+      "Pss:                 100 kB\n"
+      "Private_Dirty:         0 kB\n"
+      "Private_Clean:         0 kB\n"
+      "Shared_Dirty:          0 kB\n"
+      "Shared_Clean:          0 kB\n"
+      "Swap:                  0 kB\n"
+      "Locked:                0 kB\n"
+      "00500000-005be000 r-xp 00000000 fc:01 1235              "
+      "/path/to/libcobalt.so\n"
+      "Pss:                  50 kB\n"
+      "Private_Dirty:         0 kB\n"
+      "Private_Clean:         0 kB\n"
+      "Shared_Dirty:          0 kB\n"
+      "Shared_Clean:          0 kB\n"
+      "Swap:                  0 kB\n"
+      "Locked:                0 kB\n";
+
+  base::ScopedFILE temp_smaps;
+  CreateTempFileWithContents(kCobaltSmaps, &temp_smaps);
+  memory_instrumentation::OSMetrics::SetProcSmapsForTesting(temp_smaps.get());
+
+  const char kCobaltRollup[] =
+      "Pss:                 150 kB\n"
+      "SwapPss:               0 kB\n";
+  base::ScopedFILE temp_rollup;
+  CreateTempFileWithContents(kCobaltRollup, &temp_rollup);
+  memory_instrumentation::OSMetrics::SetSmapsRollupForTesting(
+      temp_rollup.get());
+
+  memory_instrumentation::MemoryInstrumentation::GetInstance()
+      ->GetCoordinator()
+      ->RequestGlobalMemoryDump(
+          base::trace_event::MemoryDumpType::kExplicitlyTriggered,
+          base::trace_event::MemoryDumpLevelOfDetail::kDetailed,
+          base::trace_event::MemoryDumpDeterminism::kNone, {},
+          base::BindOnce(
+              [](base::OnceClosure quit_closure, base::ProcessId renderer_pid,
+                 base::ScopedFILE file, bool success,
+                 memory_instrumentation::mojom::GlobalMemoryDumpPtr dump) {
+                EXPECT_TRUE(success);
+                ASSERT_TRUE(dump);
+                bool found_renderer_detailed_stats = false;
+                for (const auto& process_dump : dump->process_dumps) {
+                  if (process_dump->pid == renderer_pid) {
+                    ASSERT_TRUE(process_dump->os_dump->detailed_stats_kb);
+                    if (!process_dump->os_dump->detailed_stats_kb->empty()) {
+                      found_renderer_detailed_stats = true;
+                      // Verify Cobalt categories are present.
+                      EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at(
+                                    "pss:lib_chrobalt"),
+                                100u);
+                      EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at(
+                                    "pss:cobalt_core"),
+                                50u);
+                    }
+                    break;
+                  }
+                }
+                EXPECT_TRUE(found_renderer_detailed_stats);
+                std::move(quit_closure).Run();
+              },
+              run_loop.QuitClosure(), renderer_pid, std::move(temp_smaps)));
+  run_loop.Run();
+
+  memory_instrumentation::MemoryInstrumentation::GetInstance()
+      ->SetDetailedMetricsDelegate(nullptr);
+}
+#endif  // BUILDFLAG(IS_LINUX)
+
+}  // namespace content

--- a/cobalt/testing/browser_tests/granular_memory_browsertest.cc
+++ b/cobalt/testing/browser_tests/granular_memory_browsertest.cc
@@ -270,10 +270,7 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, CobaltSpecificMetrics) {
                       // Verify Cobalt categories are present.
                       EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at(
                                     "pss:lib_chrobalt"),
-                                100u);
-                      EXPECT_EQ(process_dump->os_dump->detailed_stats_kb->at(
-                                    "pss:cobalt_core"),
-                                50u);
+                                150u);
                     }
                     break;
                   }

--- a/cobalt/testing/browser_tests/granular_memory_browsertest.cc
+++ b/cobalt/testing/browser_tests/granular_memory_browsertest.cc
@@ -117,7 +117,7 @@ class GranularMemoryBrowsertest : public ContentBrowserTest {
   base::ScopedFILE temp_rollup_;
 };
 
-#if BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
   // Ensure at least one renderer process is active.
   ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
@@ -159,9 +159,9 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
               run_loop.QuitClosure(), browser_pid));
   run_loop.Run();
 }
-#endif  // BUILDFLAG(IS_LINUX)
+#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 
-#if BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest,
                        BackgroundDumpSkipsDetailedStats) {
   ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
@@ -197,9 +197,9 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest,
               run_loop.QuitClosure(), browser_pid));
   run_loop.Run();
 }
-#endif  // BUILDFLAG(IS_LINUX)
+#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 
-#if BUILDFLAG(IS_LINUX)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, CobaltSpecificMetrics) {
   // Ensure at least one renderer process is active.
   ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
@@ -287,6 +287,6 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, CobaltSpecificMetrics) {
   memory_instrumentation::MemoryInstrumentation::GetInstance()
       ->SetDetailedMetricsDelegate(nullptr);
 }
-#endif  // BUILDFLAG(IS_LINUX)
+#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 
 }  // namespace content

--- a/services/resource_coordinator/memory_instrumentation/queued_request.cc
+++ b/services/resource_coordinator/memory_instrumentation/queued_request.cc
@@ -56,16 +56,18 @@ base::trace_event::MemoryDumpRequestArgs QueuedRequest::GetRequestArgs() {
 
 std::vector<mojom::MemDumpFlags> QueuedRequest::memory_dump_flags() const {
   if (!args.memory_footprint_only) {
+#if BUILDFLAG(IS_COBALT)
     std::vector<mojom::MemDumpFlags> flags = {
         mojom::MemDumpFlags::MEM_DUMP_COUNT_MAPPINGS,
         mojom::MemDumpFlags::MEM_DUMP_PSS};
-#if BUILDFLAG(IS_COBALT)
     if (args.level_of_detail ==
         base::trace_event::MemoryDumpLevelOfDetail::kDetailed) {
       flags.push_back(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS);
     }
-#endif
     return flags;
+#else
+    return base::ToVector(OSMetrics::MemDumpFlagSet::All());
+#endif  // BUILDFLAG(IS_COBALT)
   }
   return {};
 }

--- a/services/resource_coordinator/memory_instrumentation/queued_request.cc
+++ b/services/resource_coordinator/memory_instrumentation/queued_request.cc
@@ -56,7 +56,16 @@ base::trace_event::MemoryDumpRequestArgs QueuedRequest::GetRequestArgs() {
 
 std::vector<mojom::MemDumpFlags> QueuedRequest::memory_dump_flags() const {
   if (!args.memory_footprint_only) {
-    return base::ToVector(OSMetrics::MemDumpFlagSet::All());
+    std::vector<mojom::MemDumpFlags> flags = {
+        mojom::MemDumpFlags::MEM_DUMP_COUNT_MAPPINGS,
+        mojom::MemDumpFlags::MEM_DUMP_PSS};
+#if BUILDFLAG(IS_COBALT)
+    if (args.level_of_detail ==
+        base::trace_event::MemoryDumpLevelOfDetail::kDetailed) {
+      flags.push_back(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS);
+    }
+#endif
+    return flags;
   }
   return {};
 }

--- a/services/resource_coordinator/memory_instrumentation/queued_request_dispatcher.cc
+++ b/services/resource_coordinator/memory_instrumentation/queued_request_dispatcher.cc
@@ -88,18 +88,8 @@ memory_instrumentation::mojom::OSMemDumpPtr CreatePublicOSDump(
   os_dump->private_footprint_swap_kb =
       internal_os_dump.platform_private_footprint->vm_swap_bytes / 1024;
 #if BUILDFLAG(IS_COBALT)
-  // Cobalt-specific memory metrics start
-  os_dump->libchrobalt_pss_kb = internal_os_dump.libchrobalt_pss_kb;
-  os_dump->libchrobalt_rss_kb = internal_os_dump.libchrobalt_rss_kb;
-  os_dump->partition_alloc_rss_kb = internal_os_dump.partition_alloc_rss_kb;
-  os_dump->v8_rss_kb = internal_os_dump.v8_rss_kb;
-  os_dump->malloc_rss_kb = internal_os_dump.malloc_rss_kb;
-  os_dump->code_other_rss_kb = internal_os_dump.code_other_rss_kb;
-  os_dump->fonts_rss_kb = internal_os_dump.fonts_rss_kb;
-  os_dump->ashmem_jit_rss_kb = internal_os_dump.ashmem_jit_rss_kb;
-  os_dump->android_runtime_rss_kb = internal_os_dump.android_runtime_rss_kb;
-  os_dump->stacks_rss_kb = internal_os_dump.stacks_rss_kb;
-  // Cobalt-specific memory metrics end
+  os_dump->detailed_stats_kb = internal_os_dump.detailed_stats_kb;
+  os_dump->last_detailed_dump_time = internal_os_dump.last_detailed_dump_time;
 #endif
   os_dump->mappings_count = internal_os_dump.mappings_count;
   os_dump->pss_kb = internal_os_dump.pss_kb;

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
@@ -185,8 +185,14 @@ void ClientProcessImpl::PerformOSMemoryDump(OSMemoryDumpArgs args) {
     auto handle = base::Process::Open(pid).Handle();
     mojom::RawOSMemDumpPtr result = mojom::RawOSMemDump::New();
     result->platform_private_footprint = mojom::PlatformPrivateFootprint::New();
-    bool success =
-        OSMetrics::FillOSMemoryDump(handle, args.flags, result.get());
+    bool success = OSMetrics::FillOSMemoryDump(
+        handle, args.flags, result.get()
+#if BUILDFLAG(IS_COBALT)
+	,
+        MemoryInstrumentation::GetInstance()->GetDetailedMetricsDelegate()
+#endif  // BUILDFLAG(IS_COBALT)
+	);
+ 
     if (args.mmap_option != mojom::MemoryMapOption::NONE) {
       success = success && OSMetrics::FillProcessMemoryMaps(
                                handle, args.mmap_option, result.get());

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_unittest.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_unittest.cc
@@ -182,6 +182,9 @@ TEST(OSMetricsTest, GivesNonZeroResults) {
 #elif BUILDFLAG(IS_APPLE)
   EXPECT_GT(dump.platform_private_footprint->internal_bytes, 0u);
 #endif
+#if BUILDFLAG(IS_COBALT)
+  EXPECT_GT(dump.vm_size_kb, 0u);
+#endif
 }
 
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_ANDROID)
@@ -534,6 +537,60 @@ TEST(OSMetricsTest, DetailedMetricsIntegration) {
   OSMetrics::SetSmapsRollupForTesting(nullptr);
 }
 
+class CobaltCoreDetailedMetricsDelegate : public DetailedMetricsDelegate {
+ public:
+  void OnSmapsEntry(absl::string_view name,
+                    const SmapsMetrics& metrics) override {}
+
+  void GetAndResetStats(base::flat_map<std::string, uint64_t>* stats) override {
+    stats_["pss:cobalt_core"] = 100;
+    stats_["rss:cobalt_core"] = 200;
+    *stats = std::move(stats_);
+    stats_.clear();
+  }
+
+  base::WeakPtr<DetailedMetricsDelegate> GetWeakPtr() override {
+    return weak_ptr_factory_.GetWeakPtr();
+  }
+
+ private:
+  base::flat_map<std::string, uint64_t> stats_;
+  base::WeakPtrFactory<CobaltCoreDetailedMetricsDelegate> weak_ptr_factory_{
+      this};
+};
+
+TEST(OSMetricsTest, DetailedMetricsCobaltCoreFallback) {
+  if (!MemoryInstrumentation::GetInstance()) {
+    mojo::PendingRemote<mojom::Coordinator> coordinator_remote;
+    MemoryInstrumentation::CreateInstance(std::move(coordinator_remote), true);
+  }
+
+  CobaltCoreDetailedMetricsDelegate delegate;
+
+  base::ScopedFILE temp_smaps;
+  CreateTempFileWithContents(kTestSmaps1, &temp_smaps);
+  OSMetrics::SetProcSmapsForTesting(temp_smaps.get());
+
+  base::ScopedFILE temp_rollup;
+  CreateTempFileWithContents("Pss: 290 kB\nSwapPss: 0 kB\n", &temp_rollup);
+  OSMetrics::SetSmapsRollupForTesting(temp_rollup.get());
+
+  mojom::RawOSMemDump dump;
+  dump.platform_private_footprint = mojom::PlatformPrivateFootprint::New();
+  OSMetrics::MemDumpFlagSet flags;
+  flags.Put(mojom::MemDumpFlags::MEM_DUMP_DETAILED_STATS);
+
+  EXPECT_TRUE(OSMetrics::FillOSMemoryDump(base::kNullProcessHandle, flags,
+                                          &dump, delegate.GetWeakPtr()));
+
+  ASSERT_TRUE(dump.detailed_stats_kb.has_value());
+  EXPECT_EQ(100u, (*dump.detailed_stats_kb)["pss:cobalt_core"]);
+  EXPECT_EQ(200u, (*dump.detailed_stats_kb)["rss:cobalt_core"]);
+
+  OSMetrics::SetProcSmapsForTesting(nullptr);
+  OSMetrics::SetSmapsRollupForTesting(nullptr);
+}
+
 TEST(OSMetricsTest, DetailedMetricsDisabled) {
   if (!MemoryInstrumentation::GetInstance()) {
     mojo::PendingRemote<mojom::Coordinator> coordinator_remote;
@@ -633,5 +690,5 @@ TEST(OSMetricsTest, DetailedMetricsConcurrency) {
   OSMetrics::SetProcSmapsForTesting(nullptr);
   OSMetrics::SetSmapsRollupForTesting(nullptr);
 }
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
 }  // namespace memory_instrumentation

--- a/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
+++ b/services/resource_coordinator/public/mojom/memory_instrumentation/memory_instrumentation.mojom
@@ -183,44 +183,6 @@ struct RawOSMemDump {
   [EnableIf=is_android|is_chromeos|is_linux]
   uint32 swap_pss_kb = 0;
 
-  // Cobalt-specific memory metrics start
-  // PSS for libchrobalt.so specifically.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 libchrobalt_pss_kb = 0;
-  // RSS for libchrobalt.so specifically.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 libchrobalt_rss_kb = 0;
-  // RSS for partition_alloc anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 partition_alloc_rss_kb = 0;
-  // RSS for V8 anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 v8_rss_kb = 0;
-
-  // RSS for system malloc (e.g. scudo) anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 malloc_rss_kb = 0;
-  // RSS for other code binaries (.so, .apk, .dex). This includes system
-  // libraries, GPU drivers, and the Android application package, but
-  // excludes the main libchrobalt.so.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 code_other_rss_kb = 0;
-  // RSS for fonts (.ttf, .ttc).
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 fonts_rss_kb = 0;
-
-  // RSS for Ashmem and JIT cache.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 ashmem_jit_rss_kb = 0;
-
-  // RSS for Android/Dalvik runtime (.art, .oat, dalvik-).
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 android_runtime_rss_kb = 0;
-
-  // RSS for thread stacks.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 stacks_rss_kb = 0;
-  // Cobalt-specific memory metrics end
 
   // Generic map for detailed memory metrics.
   [EnableIf=is_cobalt_with_libchrobalt_metrics]
@@ -277,44 +239,6 @@ struct OSMemDump {
   [EnableIf=is_android|is_chromeos|is_linux]
   uint32 swap_pss_kb = 0;
 
-  // Cobalt-specific memory metrics start
-  // PSS for libchrobalt.so specifically.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 libchrobalt_pss_kb = 0;
-  // RSS for libchrobalt.so specifically.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 libchrobalt_rss_kb = 0;
-  // RSS for partition_alloc anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 partition_alloc_rss_kb = 0;
-  // RSS for V8 anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 v8_rss_kb = 0;
-
-  // RSS for system malloc (e.g. scudo) anonymous mappings.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 malloc_rss_kb = 0;
-  // RSS for other code binaries (.so, .apk, .dex). This includes system
-  // libraries, GPU drivers, and the Android application package, but
-  // excludes the main libchrobalt.so.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 code_other_rss_kb = 0;
-  // RSS for fonts (.ttf, .ttc).
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 fonts_rss_kb = 0;
-
-  // RSS for Ashmem and JIT cache.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 ashmem_jit_rss_kb = 0;
-
-  // RSS for Android/Dalvik runtime (.art, .oat, dalvik-).
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 android_runtime_rss_kb = 0;
-
-  // RSS for thread stacks.
-  [EnableIf=is_cobalt_with_libchrobalt_metrics]
-  uint32 stacks_rss_kb = 0;
-  // Cobalt-specific memory metrics end
 
   // Generic map for detailed memory metrics.
   [EnableIf=is_cobalt_with_libchrobalt_metrics]


### PR DESCRIPTION
Adds end-to-end browsertests to verify granular memory tracking under
the new memory instrumentation infrastructure. This also cleans up obsolete
changes from previous memory collection architecture.

This registers and implements granular_memory_browsertest.cc under
cobalt_browsertests. The test validates that:
1. PSS and Private Footprint memory categories are populated correctly.
2. The memory instrumentation coordinator receives valid detailed memory
   reports from client processes.
3. Standardized memory thresholds are maintained and parsed successfully
   without crashing or flakiness.

Test: `run_cobalt_memory_instrumentation_unittests --gtest-filter="TracingObserverProtoTest.*:SmapsCategorizerTest.*:DetailedMetricsDelegateTest.*:SmapsMetricsTest.*"`
Test: `run_cobalt_browsertests --gtest-filter="GranularMemoryBrowsertest.*"`
Bug: 494004530
