### PR TITLE
[android] Add MSAA, disk cache, and HTTP cache switches to JavaSwitches

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -97,6 +97,17 @@ public class JavaSwitches {
 
   /** flag to force use IPv4 for system host resolution. */
   public static final String USE_IPV4_FOR_DNS = "UseIPv4ForDNS";
+  /** GPU rasterization MSAA sample count. Value type: Integer */
+  public static final String GPU_RASTERIZATION_MSAA_SAMPLE_COUNT = "GpuRasterizationMsaaSampleCount";
+
+  /** Disable GPU rasterization MSAA. Value type: Boolean (presence means true) */
+  public static final String DISABLE_GPU_RASTERIZATION_MSAA = "DisableGpuRasterizationMsaa";
+
+  /** Disk cache size. Value type: Integer */
+  public static final String DISK_CACHE_SIZE = "DiskCacheSize";
+
+  /** Disable HTTP cache. Value type: Boolean (presence means true) */
+  public static final String DISABLE_HTTP_CACHE = "DisableHttpCache";
 
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
@@ -222,6 +233,26 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.USE_IPV4_FOR_DNS)) {
       extraCommandLineArgs.add("--enable-features=UseIPv4ForDNS");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.DISABLE_GPU_RASTERIZATION_MSAA)) {
+      extraCommandLineArgs.add("--gpu-rasterization-msaa-sample-count=0");
+    } else if (javaSwitches.containsKey(JavaSwitches.GPU_RASTERIZATION_MSAA_SAMPLE_COUNT)) {
+      extraCommandLineArgs.add(
+          "--gpu-rasterization-msaa-sample-count="
+              + javaSwitches
+                  .get(JavaSwitches.GPU_RASTERIZATION_MSAA_SAMPLE_COUNT)
+                  .replaceAll("[^0-9]", ""));
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.DISK_CACHE_SIZE)) {
+      extraCommandLineArgs.add(
+          "--disk-cache-size="
+              + javaSwitches.get(JavaSwitches.DISK_CACHE_SIZE).replaceAll("[^0-9]", ""));
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.DISABLE_HTTP_CACHE)) {
+      extraCommandLineArgs.add("--disable-http-cache");
     }
 
     return extraCommandLineArgs;

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java
@@ -120,4 +120,39 @@ public class JavaSwitchesTest {
 
     assertThat(args).contains("--avoid-cc-reuse-resource");
   }
+
+  @Test
+  public void getExtraCommandLineArgs_GpuRasterizationMsaa() {
+    Map<String, String> javaSwitches = new HashMap<>();
+    javaSwitches.put(JavaSwitches.GPU_RASTERIZATION_MSAA_SAMPLE_COUNT, "4");
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(javaSwitches);
+
+    assertThat(args).contains("--gpu-rasterization-msaa-sample-count=4");
+  }
+
+  @Test
+  public void getExtraCommandLineArgs_DisableGpuRasterizationMsaa() {
+    Map<String, String> javaSwitches = new HashMap<>();
+    javaSwitches.put(JavaSwitches.DISABLE_GPU_RASTERIZATION_MSAA, "true");
+    // Should take precedence over specific sample count
+    javaSwitches.put(JavaSwitches.GPU_RASTERIZATION_MSAA_SAMPLE_COUNT, "4");
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(javaSwitches);
+
+    assertThat(args).contains("--gpu-rasterization-msaa-sample-count=0");
+    assertThat(args).doesNotContain("--gpu-rasterization-msaa-sample-count=4");
+  }
+
+  @Test
+  public void getExtraCommandLineArgs_DiskCacheAndHttpCache() {
+    Map<String, String> javaSwitches = new HashMap<>();
+    javaSwitches.put(JavaSwitches.DISK_CACHE_SIZE, "10485760");
+    javaSwitches.put(JavaSwitches.DISABLE_HTTP_CACHE, "true");
+
+    List<String> args = JavaSwitches.getExtraCommandLineArgs(javaSwitches);
+
+    assertThat(args).contains("--disk-cache-size=10485760");
+    assertThat(args).contains("--disable-http-cache");
+  }
 }


### PR DESCRIPTION
- Added GPU_RASTERIZATION_MSAA_SAMPLE_COUNT and DISABLE_GPU_RASTERIZATION_MSAA.
- Added DISK_CACHE_SIZE and DISABLE_HTTP_CACHE.
- Updated JavaSwitches.getExtraCommandLineArgs to handle these new switches.
- Added unit tests in JavaSwitchesTest.java.

Bug: 424591313