### PR TITLE
Manual Cherry pick PR ##10414: media: Update kDefaultMaxSamplePerWrite

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -49,7 +49,9 @@ using ::starboard::GetPlayerStateName;
 // buffer, this extra write during preroll can be eliminated.
 const int kPrerollGuardAudioBuffer = 1;
 
-constexpr int kDefaultMaxSamplePerWrite = 1;
+// The value of 12 was chosen after experimentation was done. For more
+// details, see b/497891900.
+constexpr int kDefaultMaxSamplePerWrite = 12;
 
 bool HasRemoteAudioOutputs(
     const std::vector<SbMediaAudioConfiguration>& configurations) {


### PR DESCRIPTION
This is a manually cherry-pick of the original PR, #10414.

This PR updates kDefaultMaxSamplePerWrite from 1 to 12. After running an experiment between 1, 4, 8, 12, and 60, we saw that kDefaultMaxSamplePerWrite at 12 showed the best improvements.

Bug: 497891900