### PR TITLE
Manually cherry pick #10288: Android: Update Platform Error to append retry param and add tests (#…

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -266,6 +266,7 @@ robolectric_binary("cobalt_coat_junit_tests") {
     "apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/MockShellManagerNatives.java",
+    "apk/app/src/test/java/dev/cobalt/coat/PlatformErrorTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java",
     "apk/app/src/test/java/dev/cobalt/shell/StartupGuardTest.java",
     "apk/app/src/test/java/dev/cobalt/util/JavaSwitchesTest.java",

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/PlatformError.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/PlatformError.java
@@ -27,11 +27,15 @@ import android.os.Looper;
 import android.provider.Settings;
 import android.view.KeyEvent;
 import androidx.annotation.IntDef;
+import androidx.annotation.NonNull;
+import androidx.annotation.VisibleForTesting;
+import dev.cobalt.shell.StartupGuard;
 import dev.cobalt.util.Holder;
 import dev.cobalt.util.Log;
 import dev.cobalt.shell.StartupGuard;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.chromium.content_public.browser.WebContents;
 
 /** Shows an ErrorDialog to inform the user of a Starboard platform error. */
@@ -59,20 +63,26 @@ public class PlatformError
   private static final int DISMISS_BUTTON = 3;
 
   private static final String RETRY_PARAM_KEY = "netdialog_retry";
-  private static final String RETRY_PARAM_VALUE = "1";
+  private static final AtomicInteger sRetryCount = new AtomicInteger(0);
 
   private final Holder<Activity> mActivityHolder;
   private final @ErrorType int mErrorType;
   private final long mData;
   private final Handler mUiThreadHandler;
+  @NonNull
+  private final String mUrl;
 
   private Dialog mDialog;
   private int mResponse;
 
-  public PlatformError(Holder<Activity> activityHolder, @ErrorType int errorType, long data) {
+  /**
+   * @param url The URL that caused the navigation error.
+   */
+  public PlatformError(Holder<Activity> activityHolder, @ErrorType int errorType, long data, String url) {
     mActivityHolder = activityHolder;
     mErrorType = errorType;
     mData = data;
+    mUrl = url == null ? "" : url;
     mUiThreadHandler = new Handler(Looper.getMainLooper());
     mResponse = CANCELLED;
   }
@@ -171,15 +181,22 @@ public class PlatformError
             if (webContents == null) {
               Log.e(TAG, "WebContents is null and not available to reload the URL.");
             } else {
-              String currentUrl = webContents.getVisibleUrl() != null ? webContents.getVisibleUrl().getSpec() : "";
-
-              // Reloading the web contents as a fallback if the URL is empty to attempt a fresh navigation.
-              // Otherwise, add a param to the URL to indicate a bootstrap request with a retry from the network dialog
+              String currentUrl = mUrl;
               if (currentUrl.isEmpty()) {
-                Log.i(TAG, "Visible URL is empty; cannot append retry parameter. Reloading the WebContents");
-                webContents.getNavigationController().reload(/*param=*/true);
+                // This is not expected to happen, if it does, it's a bug. Handle it regardless.
+                Log.i(TAG, "No URL provided, using visible URL");
+                currentUrl = webContents.getVisibleUrl() != null ? webContents.getVisibleUrl().getSpec() : "";
+              }
+
+              int retryCount = sRetryCount.incrementAndGet();
+
+              // Add a param to the URL to indicate a bootstrap request with a retry from the network dialog
+              if (currentUrl.isEmpty()) {
+                // This shouldn't happen, but log it incase it does.
+                Log.i(TAG, "Visible URL and fallback URL are empty, reloading without adding retry param");
+                webContents.getNavigationController().reload(/*checkForRepost=*/true);
               } else {
-                cobaltActivity.getActiveShell().loadUrl(addRetryUrlParam(currentUrl));
+                cobaltActivity.getActiveShell().loadUrl(addRetryUrlParam(currentUrl, retryCount));
               }
             }
           }
@@ -206,18 +223,55 @@ public class PlatformError
 
   private native void nativeSendResponse(@PlatformError.Response int response, long data);
 
-  //TODO(b/496219065): Add unit tests for retry URL param logic
-  /** Adds a retry param to the URL if not already present to differentiate
+  /**
+   *  Adds a retry param to the URL if not already present to differentiate
    *  bootstrap requests that originate from a network dialog retry.
+   *  Note: Uri.Builder handles appending query parameters before the fragment (hash) correctly.
    */
-  private String addRetryUrlParam(String url) {
+  String addRetryUrlParam(String url, int count) {
     Uri parsedUri = Uri.parse(url);
-    if (parsedUri.getQueryParameter(RETRY_PARAM_KEY) == null) {
-      Uri.Builder uriBuilder = parsedUri.buildUpon();
-      uriBuilder.appendQueryParameter(RETRY_PARAM_KEY, RETRY_PARAM_VALUE);
-      return uriBuilder.build().toString();
+    Uri.Builder uriBuilder = parsedUri.buildUpon();
+
+    uriBuilder.query(null);
+    boolean retryParamAdded = false;
+
+    for (String key : parsedUri.getQueryParameterNames()) {
+      if (RETRY_PARAM_KEY.equals(key)) {
+        // Add the updated retry parameter only once
+        if (!retryParamAdded) {
+          uriBuilder.appendQueryParameter(key, String.valueOf(count));
+          retryParamAdded = true;
+        }
+      } else {
+        // Preserve all other existing parameters and their values
+        for (String value : parsedUri.getQueryParameters(key)) {
+          uriBuilder.appendQueryParameter(key, value);
+        }
+      }
     }
-    return url;
+
+    // If the parameter wasn't in the original URL, add it now
+    if (!retryParamAdded) {
+      uriBuilder.appendQueryParameter(RETRY_PARAM_KEY, String.valueOf(count));
+    }
+
+    String result = uriBuilder.build().toString();
+    Log.i(TAG, "Reloading URL with retry param: " + result);
+    return result;
   }
 
+  @VisibleForTesting
+  static void resetRetryCount() {
+    sRetryCount.set(0);
+  }
+
+  @VisibleForTesting
+  void setDialog(Dialog dialog) {
+    this.mDialog = dialog;
+  }
+
+  @VisibleForTesting
+  int getResponse() {
+    return mResponse;
+  }
 }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -311,9 +311,9 @@ public class StarboardBridge {
   }
 
   @CalledByNative
-  void raisePlatformError(@PlatformError.ErrorType int errorType, long data) {
+  void raisePlatformError(@PlatformError.ErrorType int errorType, long data, String url) {
     StartupGuard.getInstance().setStartupMilestone(37);
-    mPlatformError = new PlatformError(activityHolder, errorType, data);
+    mPlatformError = new PlatformError(activityHolder, errorType, data, url);
     mPlatformError.raise();
   }
 

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/PlatformErrorTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/PlatformErrorTest.java
@@ -1,0 +1,180 @@
+package dev.cobalt.coat;
+
+import static org.junit.Assert.assertEquals;
+
+import android.net.Uri;
+import android.app.Activity;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import android.app.Dialog;
+import dev.cobalt.util.Holder;
+import dev.cobalt.shell.Shell;
+import org.chromium.content_public.browser.WebContents;
+import org.chromium.content_public.browser.NavigationController;
+
+/** Tests for PlatformError. */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class PlatformErrorTest {
+
+    private static final String TEST_URL = "https://www.youtube.com/tv";
+    private static final int TEST_DATA = 0;
+    private static final int RETRY_BUTTON_ID = 1;
+    private static final int DISMISS_BUTTON_ID = 3;
+
+    private PlatformError platformError;
+
+    @Before
+    public void setUp() throws Exception {
+        CobaltActivity mockActivity = mock(CobaltActivity.class);
+        Holder<Activity> holder = new Holder<>();
+        holder.set(mockActivity);
+        platformError = new PlatformError(holder, PlatformError.CONNECTION_ERROR, TEST_DATA, "");
+
+        PlatformError.resetRetryCount();
+    }
+
+    @Test
+    public void addRetryUrlParam_appendsParam_whenNotPresent() {
+        String url = TEST_URL;
+        String result = platformError.addRetryUrlParam(url, 1);
+        assertEquals(TEST_URL + "?netdialog_retry=1", result);
+    }
+
+    @Test
+    public void addRetryUrlParam_updatesParam_whenPresent() {
+        String url = TEST_URL + "?netdialog_retry=1";
+        String result = platformError.addRetryUrlParam(url, 2);
+        assertEquals(TEST_URL + "?netdialog_retry=2", result);
+    }
+
+    @Test
+    public void addRetryUrlParam_preservesOtherParams() {
+        String url = "https://www.youtube.com/tv?foo=bar";
+        String result = platformError.addRetryUrlParam(url, 1);
+        assertEquals("https://www.youtube.com/tv?foo=bar&netdialog_retry=1", result);
+    }
+
+    @Test
+    public void addRetryUrlParam_preservesFragment() {
+        String url = "https://www.youtube.com/tv#/browse";
+        String result = platformError.addRetryUrlParam(url, 1);
+        assertEquals("https://www.youtube.com/tv?netdialog_retry=1#/browse", result);
+    }
+
+    @Test
+    public void addRetryUrlParam_preservesParamsAndFragment() {
+        String url = "https://www.youtube.com/tv?foo=bar#/browse";
+        String result = platformError.addRetryUrlParam(url, 1);
+        assertEquals("https://www.youtube.com/tv?foo=bar&netdialog_retry=1#/browse", result);
+    }
+
+    @Test
+    public void addRetryUrlParam_handlesEmptyUrl() {
+        String url = "";
+        String result = platformError.addRetryUrlParam(url, 1);
+        assertEquals("?netdialog_retry=1", result);
+    }
+
+    @Test
+    public void setResponse_updatesResponse() {
+        platformError.setResponse(PlatformError.POSITIVE);
+        try {
+            int response = platformError.getResponse();
+            assertEquals(PlatformError.POSITIVE, response);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+  @Test
+  public void onClick_dismissesDialog_whenDismissButtonClicked() throws Exception {
+    Dialog mockDialog = mock(Dialog.class);
+    platformError.setDialog(mockDialog);
+
+    platformError.onClick(null, DISMISS_BUTTON_ID);
+
+    int response = platformError.getResponse();
+    assertEquals(PlatformError.NEGATIVE, response);
+    verify(mockDialog).dismiss();
+  }
+
+  @Test
+  public void onClick_reloadsUrl_whenRetryButtonClickedAndUrlNotEmpty() throws Exception {
+    CobaltActivity mockActivity = mock(CobaltActivity.class);
+    WebContents mockWebContents = mock(WebContents.class);
+    Shell mockShell = mock(Shell.class);
+    Dialog mockDialog = mock(Dialog.class);
+
+    Holder<Activity> holder = new Holder<>();
+    holder.set(mockActivity);
+
+    PlatformError testPlatformError = new PlatformError(holder, PlatformError.CONNECTION_ERROR, 0, "https://www.youtube.com/tv");
+    testPlatformError.setDialog(mockDialog);
+
+    org.mockito.Mockito.when(mockActivity.getActiveWebContents()).thenReturn(mockWebContents);
+    org.mockito.Mockito.when(mockActivity.getActiveShell()).thenReturn(mockShell);
+
+    testPlatformError.onClick(null, RETRY_BUTTON_ID);
+
+    verify(mockShell).loadUrl("https://www.youtube.com/tv?netdialog_retry=1");
+    verify(mockDialog).dismiss();
+  }
+
+  @Test
+  public void onClick_retryUrlParamIncrements_whenCalledMultipleTimes() throws Exception {
+    CobaltActivity mockActivity = mock(CobaltActivity.class);
+    WebContents mockWebContents = mock(WebContents.class);
+    Shell mockShell = mock(Shell.class);
+    Dialog mockDialog = mock(Dialog.class);
+
+    Holder<Activity> holder = new Holder<>();
+    holder.set(mockActivity);
+
+    PlatformError testPlatformError = new PlatformError(holder, PlatformError.CONNECTION_ERROR, 0,
+        "https://www.youtube.com/tv");
+    testPlatformError.setDialog(mockDialog);
+
+    org.mockito.Mockito.when(mockActivity.getActiveWebContents()).thenReturn(mockWebContents);
+    org.mockito.Mockito.when(mockActivity.getActiveShell()).thenReturn(mockShell);
+
+    // First retry
+    testPlatformError.onClick(null, RETRY_BUTTON_ID);
+    verify(mockShell).loadUrl("https://www.youtube.com/tv?netdialog_retry=1");
+
+    // Second retry
+    testPlatformError.onClick(null, RETRY_BUTTON_ID);
+    verify(mockShell).loadUrl("https://www.youtube.com/tv?netdialog_retry=2");
+  }
+
+  @Test
+  public void onClick_reloadsWebContents_whenRetryButtonClickedAndUrlIsEmpty() throws Exception {
+    CobaltActivity mockActivity = mock(CobaltActivity.class);
+    WebContents mockWebContents = mock(WebContents.class);
+    NavigationController mockNavController = mock(NavigationController.class);
+    Dialog mockDialog = mock(Dialog.class);
+
+    Holder<Activity> holder = new Holder<>();
+    holder.set(mockActivity);
+
+    PlatformError testPlatformError = new PlatformError(holder, PlatformError.CONNECTION_ERROR, 0, "");
+    testPlatformError.setDialog(mockDialog);
+
+    org.mockito.Mockito.when(mockActivity.getActiveWebContents()).thenReturn(mockWebContents);
+    org.mockito.Mockito.when(mockWebContents.getNavigationController()).thenReturn(mockNavController);
+    org.chromium.url.GURL mockGurl = mock(org.chromium.url.GURL.class);
+    org.mockito.Mockito.when(mockGurl.getSpec()).thenReturn("");
+    org.mockito.Mockito.when(mockWebContents.getVisibleUrl()).thenReturn(mockGurl);
+
+    testPlatformError.onClick(null, RETRY_BUTTON_ID);
+
+    verify(mockNavController).reload(true);
+    verify(mockDialog).dismiss();
+  }
+
+}

--- a/cobalt/browser/cobalt_web_contents_observer.cc
+++ b/cobalt/browser/cobalt_web_contents_observer.cc
@@ -62,8 +62,8 @@ void CobaltWebContentsObserver::DidStartNavigation(
   timeout_timer_->Stop();
   timeout_timer_->Start(
       FROM_HERE, base::Seconds(kNavigationTimeoutSeconds),
-      base::BindOnce(&CobaltWebContentsObserver::RaisePlatformError,
-                     weak_factory_.GetWeakPtr()));
+      base::BindOnce(&CobaltWebContentsObserver::OnNavigationTimeout,
+                     weak_factory_.GetWeakPtr(), handle->GetURL().spec()));
 }
 
 // Opting for WebContentsObserver::DidFinishNavigation() over
@@ -83,14 +83,19 @@ void CobaltWebContentsObserver::DidFinishNavigation(
     UMA_HISTOGRAM_BOOLEAN("Cobalt.WebContentsObserver.FailedNavigation", true);
     LOG(INFO) << "DidFinishNavigation: Raising platform error with code: "
               << net::ErrorToString(net_error_code);
-    RaisePlatformError();
+    RaisePlatformError(navigation_handle->GetURL().spec());
   } else if (net_error_code == net::OK) {
     UMA_HISTOGRAM_BOOLEAN("Cobalt.WebContentsObserver.FailedNavigation", false);
     platform_error_raised_count_ = 0;
   }
 }
 
-void CobaltWebContentsObserver::RaisePlatformError() {
+void CobaltWebContentsObserver::OnNavigationTimeout(const std::string& url) {
+  UMA_HISTOGRAM_BOOLEAN("Cobalt.Network.NavigationTimeout", true);
+  RaisePlatformError(url);
+}
+
+void CobaltWebContentsObserver::RaisePlatformError(const std::string& url) {
   JNIEnv* env = base::android::AttachCurrentThread();
   auto* starboard_bridge =
       starboard::android::shared::StarboardBridge::GetInstance();
@@ -102,7 +107,13 @@ void CobaltWebContentsObserver::RaisePlatformError() {
   platform_error_raised_count_++;
   UMA_HISTOGRAM_COUNTS_100("Cobalt.Network.CumulativePlatformErrorRaised",
                            platform_error_raised_count_);
-  starboard_bridge->RaisePlatformError(env, kJniErrorTypeConnectionError, 0);
+  starboard_bridge->RaisePlatformError(env, kJniErrorTypeConnectionError, 0,
+                                       url);
+}
+
+void CobaltWebContentsObserver::SetStartupDiagnosisInfo(const char* key,
+                                                        const char* value) {
+  // No-op on this branch
 }
 #endif  // BUILDFLAG(IS_ANDROIDTV)
 

--- a/cobalt/browser/cobalt_web_contents_observer.h
+++ b/cobalt/browser/cobalt_web_contents_observer.h
@@ -44,12 +44,14 @@ class CobaltWebContentsObserver : public content::WebContentsObserver {
       content::NavigationHandle* navigation_handle) override;
   void DidFinishNavigation(
       content::NavigationHandle* navigation_handle) override;
-  virtual void RaisePlatformError();
+  virtual void RaisePlatformError(const std::string& url);
+  virtual void SetStartupDiagnosisInfo(const char* key, const char* value);
 
  protected:
   void SetTimerForTestInternal(std::unique_ptr<base::OneShotTimer> timer);
 
  private:
+  void OnNavigationTimeout(const std::string& url);
   std::unique_ptr<base::OneShotTimer> timeout_timer_;
   base::WeakPtrFactory<CobaltWebContentsObserver> weak_factory_{this};
   int platform_error_raised_count_ = 0;

--- a/cobalt/browser/cobalt_web_contents_observer_unittest.cc
+++ b/cobalt/browser/cobalt_web_contents_observer_unittest.cc
@@ -22,6 +22,7 @@
 #include "net/base/net_errors.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 
 using ::testing::_;
 using ::testing::Return;
@@ -29,19 +30,22 @@ using ::testing::Return;
 namespace cobalt {
 
 #if BUILDFLAG(IS_ANDROIDTV)
+namespace {
+const char kTestUrl[] = "https://www.youtube.com/tv";
+}  // namespace
 class TestCobaltWebContentsObserver : public CobaltWebContentsObserver {
  public:
   explicit TestCobaltWebContentsObserver(content::WebContents* web_contents)
       : CobaltWebContentsObserver(web_contents) {}
 
-  MOCK_METHOD(void, RaisePlatformErrorProxy, (), ());
+  MOCK_METHOD(void, RaisePlatformErrorProxy, (const std::string& url), ());
 
-  void RaisePlatformError() override {
+  void RaisePlatformError(const std::string& url) override {
     if (error_is_showing_) {
       return;
     }
     error_is_showing_ = true;
-    RaisePlatformErrorProxy();
+    RaisePlatformErrorProxy(url);
   }
 
   void SetTimerForTestInternal(std::unique_ptr<base::OneShotTimer> timer) {
@@ -60,6 +64,9 @@ class CobaltWebContentsObserverTest : public testing::Test {
     auto mock_timer = std::make_unique<base::MockOneShotTimer>();
     mock_timer_ = mock_timer.get();
     observer_->SetTimerForTestInternal(std::move(mock_timer));
+
+    navigation_handle_.set_is_in_primary_main_frame(true);
+    navigation_handle_.set_url(GURL(kTestUrl));
   }
 
   TestCobaltWebContentsObserver* observer() { return observer_.get(); }
@@ -76,7 +83,7 @@ class CobaltWebContentsObserverTest : public testing::Test {
 };
 
 TEST_F(CobaltWebContentsObserverTest, NoErrorOnSuccessfulNavigation) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(0);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(_)).Times(0);
   navigation_handle().set_is_in_primary_main_frame(true);
   navigation_handle().set_net_error_code(net::OK);
 
@@ -88,7 +95,7 @@ TEST_F(CobaltWebContentsObserverTest, NoErrorOnSuccessfulNavigation) {
 }
 
 TEST_F(CobaltWebContentsObserverTest, NoErrorOnAbortedNavigation) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(0);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(_)).Times(0);
   navigation_handle().set_is_in_primary_main_frame(true);
   navigation_handle().set_net_error_code(net::ERR_ABORTED);
 
@@ -100,8 +107,7 @@ TEST_F(CobaltWebContentsObserverTest, NoErrorOnAbortedNavigation) {
 }
 
 TEST_F(CobaltWebContentsObserverTest, RaisesErrorOnFailedNavigation) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(1);
-  navigation_handle().set_is_in_primary_main_frame(true);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(kTestUrl)).Times(1);
   navigation_handle().set_net_error_code(net::ERR_CONNECTION_TIMED_OUT);
 
   observer()->DidStartNavigation(&navigation_handle());
@@ -112,8 +118,7 @@ TEST_F(CobaltWebContentsObserverTest, RaisesErrorOnFailedNavigation) {
 }
 
 TEST_F(CobaltWebContentsObserverTest, RaisesErrorOnTimeout) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(1);
-  navigation_handle().set_is_in_primary_main_frame(true);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(kTestUrl)).Times(1);
 
   observer()->DidStartNavigation(&navigation_handle());
   EXPECT_TRUE(mock_timer()->IsRunning());
@@ -123,7 +128,7 @@ TEST_F(CobaltWebContentsObserverTest, RaisesErrorOnTimeout) {
 }
 
 TEST_F(CobaltWebContentsObserverTest, DoesNotRaiseErrorForSubFrame) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(0);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(_)).Times(0);
   navigation_handle().set_is_in_primary_main_frame(false);
   navigation_handle().set_net_error_code(net::ERR_CONNECTION_TIMED_OUT);
 
@@ -135,7 +140,7 @@ TEST_F(CobaltWebContentsObserverTest, DoesNotRaiseErrorForSubFrame) {
 }
 
 TEST_F(CobaltWebContentsObserverTest, MultipleNavigationsResetsTimer) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(0);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(_)).Times(0);
   navigation_handle().set_is_in_primary_main_frame(true);
   navigation_handle().set_net_error_code(net::OK);
 
@@ -150,9 +155,7 @@ TEST_F(CobaltWebContentsObserverTest, MultipleNavigationsResetsTimer) {
 }
 
 TEST_F(CobaltWebContentsObserverTest, DoesNotRaiseAnotherErrorIfOneIsShowing) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(1);
-
-  navigation_handle().set_is_in_primary_main_frame(true);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(kTestUrl)).Times(1);
   navigation_handle().set_net_error_code(net::ERR_CONNECTION_RESET);
   observer()->DidFinishNavigation(&navigation_handle());
 
@@ -161,9 +164,7 @@ TEST_F(CobaltWebContentsObserverTest, DoesNotRaiseAnotherErrorIfOneIsShowing) {
 }
 
 TEST_F(CobaltWebContentsObserverTest, TimeoutThenFailureOnlyRaisesOnce) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(1);
-
-  navigation_handle().set_is_in_primary_main_frame(true);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(kTestUrl)).Times(1);
   observer()->DidStartNavigation(&navigation_handle());
   EXPECT_TRUE(mock_timer()->IsRunning());
 
@@ -176,9 +177,7 @@ TEST_F(CobaltWebContentsObserverTest, TimeoutThenFailureOnlyRaisesOnce) {
 }
 
 TEST_F(CobaltWebContentsObserverTest, SuccessAfterTimeout) {
-  EXPECT_CALL(*observer(), RaisePlatformErrorProxy()).Times(1);
-
-  navigation_handle().set_is_in_primary_main_frame(true);
+  EXPECT_CALL(*observer(), RaisePlatformErrorProxy(kTestUrl)).Times(1);
   observer()->DidStartNavigation(&navigation_handle());
   EXPECT_TRUE(mock_timer()->IsRunning());
 

--- a/cobalt/precommit/google_java_format_wrapper.py
+++ b/cobalt/precommit/google_java_format_wrapper.py
@@ -19,13 +19,26 @@ import platform
 import subprocess
 import sys
 
+import os
+
 if __name__ == '__main__':
   if platform.system() != 'Linux':
     sys.exit(0)
 
   google_java_format_args = sys.argv[1:]
+
+  # Verify that the actual google-java-format binary is checked out locally,
+  # rather than executing depot_tools' placeholder wrapper which exits with 2.
+  primary_solution_path = os.path.abspath(
+      os.path.join(os.path.dirname(__file__), '..', '..'))
+  bin_path = os.path.join(primary_solution_path, 'third_party',
+                          'google-java-format', 'google-java-format')
+  if not os.path.exists(bin_path):
+    print('google-java-format binary not found, skipping.')
+    sys.exit(0)
+
   try:
-    sys.exit(subprocess.call(['google-java-format'] + google_java_format_args))
+    sys.exit(subprocess.call([bin_path] + google_java_format_args))
   except FileNotFoundError:
     print('google-java-format not found, skipping.')
     sys.exit(0)

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -40,6 +40,7 @@ namespace {
 using base::android::AppendJavaStringArrayToStringVector;
 using base::android::AttachCurrentThread;
 using base::android::ConvertJavaStringToUTF8;
+using base::android::ConvertUTF8ToJavaString;
 using base::android::GetClass;
 
 // Client Hint Header name constants
@@ -207,7 +208,6 @@ int64_t StarboardBridge::GetAppStartTimestamp(JNIEnv* env) {
   return Java_StarboardBridge_getAppStartTimestamp(env, j_starboard_bridge_);
 }
 
-
 void StarboardBridge::ApplicationStarted(JNIEnv* env) {
   SB_DCHECK(env);
   Java_StarboardBridge_applicationStarted(env, j_starboard_bridge_);
@@ -234,10 +234,12 @@ ScopedJavaLocalRef<jintArray> StarboardBridge::GetSupportedHdrTypes(
 
 void StarboardBridge::RaisePlatformError(JNIEnv* env,
                                          jint errorType,
-                                         jlong data) {
+                                         jlong data,
+                                         const std::string& url) {
   SB_DCHECK(env);
   Java_StarboardBridge_raisePlatformError(env, j_starboard_bridge_, errorType,
-                                          data);
+                                          data,
+                                          ConvertUTF8ToJavaString(env, url));
 }
 
 bool StarboardBridge::IsPlatformErrorShowing(JNIEnv* env) {

--- a/starboard/android/shared/starboard_bridge.h
+++ b/starboard/android/shared/starboard_bridge.h
@@ -39,7 +39,6 @@ class StarboardBridge {
 
   int64_t GetAppStartTimestamp(JNIEnv* env);
 
-
   void ApplicationStarted(JNIEnv* env);
 
   void ApplicationStopping(JNIEnv* env);
@@ -48,7 +47,10 @@ class StarboardBridge {
 
   ScopedJavaLocalRef<jintArray> GetSupportedHdrTypes(JNIEnv* env);
 
-  void RaisePlatformError(JNIEnv* env, jint errorType, jlong data);
+  void RaisePlatformError(JNIEnv* env,
+                          jint errorType,
+                          jlong data,
+                          const std::string& url);
 
   bool IsPlatformErrorShowing(JNIEnv* env);
 

--- a/starboard/android/shared/system_platform_error.cc
+++ b/starboard/android/shared/system_platform_error.cc
@@ -63,7 +63,7 @@ bool SbSystemRaisePlatformError(SbSystemPlatformErrorType type,
 
   starboard::android::shared::StarboardBridge::GetInstance()
       ->RaisePlatformError(env, jni_error_type,
-                           reinterpret_cast<jlong>(send_response_callback));
+                           reinterpret_cast<jlong>(send_response_callback), "");
   return true;
 }
 


### PR DESCRIPTION
…10288)

android tv: Track network dialog retry attempts

The RaisePlatformError mechanism was updated to propagate the navigation URL, allowing PlatformError to use it for retries, increasing the url param coverage.

The 'netdialog_retry' URL parameter for Android TV's Network Dialog was previously hardcoded to '1'. This change introduces a monotonically increasing counter to track
retry attempts throughout the app instance's lifecycle. The addRetryUrlParam logic now correctly appends or updates this dynamic parameter, handling existing query parameters and URL fragments.

New Robolectric tests for PlatformError dialog.

Bug: 496219065