### PR TITLE
media: Batch-free DecoderBuffers on teardown

### DIFF
--- a/media/base/decoder_buffer.h
+++ b/media/base/decoder_buffer.h
@@ -105,6 +105,22 @@ class MEDIA_EXPORT DecoderBuffer
     virtual int GetBufferPadding() const = 0;
     virtual base::TimeDelta GetBufferGarbageCollectionDurationThreshold()
         const = 0;
+    virtual bool IsBatchFreeEnabled() const { return false; }
+    virtual void StartBatching() {}
+    virtual void StopBatching() {}
+
+    // RAII helper to safely manage the batching lifecycle.
+    class MEDIA_EXPORT BatchScope {
+     public:
+      BatchScope() {
+        DCHECK(Allocator::Get()->IsBatchFreeEnabled());
+        Allocator::Get()->StartBatching();
+      }
+      ~BatchScope() { Allocator::Get()->StopBatching(); }
+
+      BatchScope(const BatchScope&) = delete;
+      BatchScope& operator=(const BatchScope&) = delete;
+    };
 
    protected:
     ~Allocator() {}

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -1525,6 +1525,32 @@ void ChunkDemuxer::ChangeState_Locked(State new_state) {
 
 ChunkDemuxer::~ChunkDemuxer() {
   DCHECK_NE(state_, INITIALIZED);
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+    auto* allocator = DecoderBuffer::Allocator::Get();
+    if (allocator->IsBatchFreeEnabled()) {
+      DecoderBuffer::Allocator::BatchScope batch_scope;
+    // Design choices for manual clearing in BatchScope:
+    // 1. Cleared in exact reverse declaration order to minimize logic changes
+    //    when the feature is disabled (where the compiler destroys members in
+    //    reverse declaration order anyway).
+    // 2. Explicitly includes member variables that don't strictly need clearing
+    //    (because they don't hold DecoderBuffers) but appear between the ones
+    //    we DO need to clear in reverse declaration order. This ensures that
+    //    destruction of everything in this range happens within the BatchScope.
+
+    id_to_mime_map_.clear();
+    // supports_change_type_ does not need clearing
+    track_id_to_demux_stream_map_.clear();
+    removed_streams_.clear();
+    id_to_streams_map_.clear();
+    source_state_map_.clear();
+    // liveness_, timeline_offset_, user_specified_duration_, duration_ do not
+    // need clearing
+    pending_source_init_ids_.clear();
+    video_streams_.clear();
+    audio_streams_.clear();
+  }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 void ChunkDemuxer::ReportError_Locked(PipelineStatus error) {

--- a/media/filters/demuxer_manager.cc
+++ b/media/filters/demuxer_manager.cc
@@ -127,6 +127,13 @@ DemuxerManager::~DemuxerManager() {
   // thread, and needs to be deleted there.
   if (GetDemuxerType() == DemuxerType::kManifestDemuxer) {
     media_task_runner_->DeleteSoon(FROM_HERE, std::move(demuxer_));
+  } else if (GetDemuxerType() == DemuxerType::kChunkDemuxer) {
+    base::TimeTicks start = base::TimeTicks::Now();
+    demuxer_.reset();
+    base::TimeDelta elapsed = base::TimeTicks::Now() - start;
+    LOG(INFO) << "ChunkDemuxer total destruction took "
+              << elapsed.InMilliseconds() << " ms ("
+              << elapsed.InMicroseconds() << " us)";
   }
 }
 

--- a/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
@@ -45,6 +45,10 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
   void Free(DemuxerStream::Type type, void* p) override {
     bidirectional_fit_allocator_.Free(p);
   }
+  void BatchFree(const std::vector<void*>& audio_pointers,
+                 const std::vector<void*>& video_pointers) override {
+    bidirectional_fit_allocator_.BatchFree(audio_pointers, video_pointers);
+  }
   void Write(void* p, const void* data, size_t size) override {
     memcpy(p, data, size);
   }

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -35,6 +35,11 @@
 
 namespace media {
 
+thread_local std::vector<void*>* DecoderBufferAllocator::pending_audio_frees_ =
+    nullptr;
+thread_local std::vector<void*>* DecoderBufferAllocator::pending_video_frees_ =
+    nullptr;
+
 namespace {
 
 // The current default AllocatorStrategy is InPlaceReuseAllocatorBase.
@@ -143,6 +148,17 @@ void DecoderBufferAllocator::Free(DemuxerStream::Type type,
     return;
   }
 
+  if (pending_audio_frees_) {
+    DCHECK(is_batch_free_enabled_);
+    if (type == DemuxerStream::AUDIO) {
+      pending_audio_frees_->push_back(p);
+    } else {
+      DCHECK_EQ(type, DemuxerStream::VIDEO);
+      pending_video_frees_->push_back(p);
+    }
+    return;
+  }
+
   base::AutoLock scoped_lock(mutex_);
 
   DCHECK(strategy_);
@@ -201,6 +217,64 @@ base::TimeDelta
 DecoderBufferAllocator::GetBufferGarbageCollectionDurationThreshold() const {
   return base::Microseconds(
       SbMediaGetBufferGarbageCollectionDurationThreshold());
+}
+
+bool DecoderBufferAllocator::IsBatchFreeEnabled() const {
+  return is_batch_free_enabled_;
+}
+
+void DecoderBufferAllocator::StartBatching() {
+  DCHECK(is_batch_free_enabled_);
+  DCHECK(!pending_audio_frees_);
+  DCHECK(!pending_video_frees_);
+  pending_audio_frees_ = new std::vector<void*>();
+  pending_audio_frees_->reserve(16 * 1024);
+  pending_video_frees_ = new std::vector<void*>();
+  pending_video_frees_->reserve(16 * 1024);
+}
+
+void DecoderBufferAllocator::StopBatching() {
+  DCHECK(pending_audio_frees_);
+  DCHECK(pending_video_frees_);
+
+  bool has_pending_frees =
+      !pending_audio_frees_->empty() || !pending_video_frees_->empty();
+
+  if (has_pending_frees) {
+    base::AutoLock scoped_lock(mutex_);
+    DCHECK(strategy_);
+
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+    if (starboard::Allocator::ExtraLogLevel() >= 2) {
+      for (const auto& p : *pending_audio_frees_) {
+        ++pending_allocation_operations_count_;
+        pending_allocation_operations_ << " f " << p;
+        TryFlushAllocationLog_Locked();
+      }
+      for (const auto& p : *pending_video_frees_) {
+        ++pending_allocation_operations_count_;
+        pending_allocation_operations_ << " f " << p;
+        TryFlushAllocationLog_Locked();
+      }
+    }
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+
+    strategy_->BatchFree(*pending_audio_frees_, *pending_video_frees_);
+
+    bool should_reset_strategy =
+        is_strategy_switch_pending_ || is_memory_pool_allocated_on_demand_;
+
+    if (should_reset_strategy && strategy_->GetAllocated() == 0) {
+      LOG(INFO) << "Freeing " << strategy_->GetCapacity()
+                << " bytes of decoder buffer pool.";
+      strategy_.reset();
+    }
+  }
+
+  delete pending_audio_frees_;
+  pending_audio_frees_ = nullptr;
+  delete pending_video_frees_;
+  pending_video_frees_ = nullptr;
 }
 
 size_t DecoderBufferAllocator::GetAllocatedMemory() const {
@@ -360,5 +434,11 @@ void DecoderBufferAllocator::TryFlushAllocationLog_Locked() {
   }
 }
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
+
+// static
+void DecoderBufferAllocator::EnableBatchFree() {
+  Get()->is_batch_free_enabled_ = true;
+  LOG(INFO) << "DecoderBufferAllocator batch free is enabled";
+}
 
 }  // namespace media

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -17,7 +17,9 @@
 
 #include <memory>
 #include <sstream>
+#include <vector>
 
+#include "base/check.h"
 #include "base/compiler_specific.h"
 #include "base/functional/callback.h"
 #include "base/synchronization/lock.h"
@@ -45,6 +47,8 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
                            size_t size,
                            size_t alignment) = 0;
     virtual void Free(DemuxerStream::Type type, void* p) = 0;
+    virtual void BatchFree(const std::vector<void*>& audio_pointers,
+                           const std::vector<void*>& video_pointers) = 0;
     virtual void Write(void* p, const void* data, size_t size) = 0;
 
     virtual size_t GetCapacity() const = 0;
@@ -60,6 +64,9 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
                          int initial_capacity,
                          int allocation_unit);
   ~DecoderBufferAllocator() override;
+
+  DecoderBufferAllocator(const DecoderBufferAllocator&) = delete;
+  DecoderBufferAllocator& operator=(const DecoderBufferAllocator&) = delete;
 
   static DecoderBufferAllocator* Get();
 
@@ -77,6 +84,10 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   int GetBufferPadding() const override;
   base::TimeDelta GetBufferGarbageCollectionDurationThreshold() const override;
 
+  bool IsBatchFreeEnabled() const override;
+  void StartBatching() override;
+  void StopBatching() override;
+
   // DecoderBufferMemoryInfo methods.
   size_t GetAllocatedMemory() const override LOCKS_EXCLUDED(mutex_);
   size_t GetCurrentMemoryCapacity() const override LOCKS_EXCLUDED(mutex_);
@@ -89,6 +100,8 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   void SetAllocateOnDemand(bool enabled);
   static void EnableDecommitableAllocatorStrategy();
   static void EnableMediaBufferPoolStrategy();
+
+  static void EnableBatchFree();
 
  private:
   void EnsureStrategyIsCreated() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
@@ -105,6 +118,11 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   std::unique_ptr<Strategy> strategy_ GUARDED_BY(mutex_);
   bool is_strategy_switch_pending_ GUARDED_BY(mutex_) = false;
   StrategyCreateCB experimental_strategy_create_cb_ GUARDED_BY(mutex_);
+
+  bool is_batch_free_enabled_ = false;
+
+  static thread_local std::vector<void*>* pending_audio_frees_;
+  static thread_local std::vector<void*>* pending_video_frees_;
 
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   // The following variables are used for comprehensive logging of allocation

--- a/media/starboard/decoder_buffer_allocator_test.cc
+++ b/media/starboard/decoder_buffer_allocator_test.cc
@@ -255,6 +255,36 @@ TEST_P(DecoderBufferAllocatorTest, CapacityByType) {
   }
 }
 
+TEST(DecoderBufferAllocatorSimpleTest, BatchFree) {
+  DecoderBufferAllocator* allocator = DecoderBufferAllocator::Get();
+  DecoderBufferAllocator::EnableBatchFree();
+
+  size_t allocated_initially = allocator->GetAllocatedMemory();
+
+  std::vector<Handle> handles;
+  size_t allocation_size = 1024;
+  for (int i = 0; i < 10; ++i) {
+    handles.push_back(
+        allocator->Allocate(DemuxerStream::AUDIO, allocation_size, 8));
+  }
+
+  size_t allocated_before_free = allocator->GetAllocatedMemory();
+  EXPECT_GT(allocated_before_free, allocated_initially);
+
+  {
+    DecoderBufferAllocator::BatchScope batch_scope;
+    for (int i = 0; i < 10; ++i) {
+      allocator->Free(DemuxerStream::AUDIO, handles[i], allocation_size);
+    }
+
+    // Memory should still be allocated because frees are deferred.
+    EXPECT_EQ(allocator->GetAllocatedMemory(), allocated_before_free);
+  }
+
+  // After BatchScope exits, memory should be freed.
+  EXPECT_EQ(allocator->GetAllocatedMemory(), allocated_initially);
+}
+
 INSTANTIATE_TEST_SUITE_P(DecoderBufferAllocatorTests,
                          DecoderBufferAllocatorTest,
                          Values("starboard/allocations_1La4QzGeaaQ.txt",

--- a/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
+++ b/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
@@ -83,6 +83,13 @@ void MediaBufferPoolDecoderBufferAllocatorStrategy::Free(
   }
 }
 
+void MediaBufferPoolDecoderBufferAllocatorStrategy::BatchFree(
+    const std::vector<void*>& audio_pointers,
+    const std::vector<void*>& video_pointers) {
+  CHECK(false) << "MediaBufferPoolDecoderBufferAllocatorStrategy doesn't "
+                  "support BatchFree.";
+}
+
 void MediaBufferPoolDecoderBufferAllocatorStrategy::Write(void* p,
                                                           const void* data,
                                                           size_t size) {

--- a/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.h
@@ -41,6 +41,8 @@ class MediaBufferPoolDecoderBufferAllocatorStrategy
                  size_t alignment) override;
 
   void Free(DemuxerStream::Type type, void* p) override;
+  void BatchFree(const std::vector<void*>& audio_pointers,
+                 const std::vector<void*>& video_pointers) override;
 
   void Write(void* p, const void* data, size_t size) override;
 

--- a/starboard/common/in_place_reuse_allocator_base.cc
+++ b/starboard/common/in_place_reuse_allocator_base.cc
@@ -199,39 +199,72 @@ void InPlaceReuseAllocatorBase::Free(void* memory) {
   }
 
   pending_frees_.push_back(memory);
+  CheckAndProcessPendingFrees();
+}
 
+void InPlaceReuseAllocatorBase::BatchFree(const std::vector<void*>& memories1,
+                                          const std::vector<void*>& memories2) {
+  size_t total_to_free = memories1.size() + memories2.size();
+  if (total_to_free == 0) {
+    return;
+  }
+
+  // Optimization: If we are freeing all blocks, we can skip inserting them
+  // and directly clear the allocator state.
+  if (pending_frees_.size() + total_to_free == total_allocated_blocks_) {
+    if (total_allocated_blocks_ > 32) {
+      ResetAllocatorPool();
+      return;
+    }
+  }
+
+  // Fallback: Insert and process as usual.
+  if (!memories1.empty()) {
+    pending_frees_.insert(pending_frees_.end(), memories1.begin(),
+                          memories1.end());
+  }
+  if (!memories2.empty()) {
+    pending_frees_.insert(pending_frees_.end(), memories2.begin(),
+                          memories2.end());
+  }
+  CheckAndProcessPendingFrees();
+}
+
+void InPlaceReuseAllocatorBase::CheckAndProcessPendingFrees() {
   if (pending_frees_.size() == total_allocated_blocks_) {
     if (total_allocated_blocks_ > 32) {
-      SB_LOG_IF(INFO, total_allocated_blocks_ > 2048)
-          << "Batched free triggered for " << total_allocated_blocks_
-          << " blocks.";
-      allocated_block_head_ = nullptr;
-      free_blocks_.clear();
-      pending_frees_.clear();
-
-      total_allocated_in_bytes_ = 0;
-      total_allocated_blocks_ = 0;
-
-      for (int i = 0; i < static_cast<int>(fallback_allocations_.size()); ++i) {
-        AddFreeBlock(MemoryBlock(i, fallback_allocations_[i].address,
-                                 fallback_allocations_[i].size));
-      }
-
-      if (enable_decommit_on_idle_) {
-        SB_LOG(INFO) << "Batched free triggered idle state, decommitting "
-                     << fallback_allocations_.size()
-                     << " fallback allocations.";
-        for (const auto& fallback_allocation : fallback_allocations_) {
-          fallback_allocator_->Decommit(fallback_allocation.address,
-                                        fallback_allocation.size);
-        }
-      }
+      ResetAllocatorPool();
     } else {
       for (auto address_to_free : pending_frees_) {
         bool freed = TryFree(address_to_free);
         SB_DCHECK(freed);
       }
       pending_frees_.clear();
+    }
+  }
+}
+
+void InPlaceReuseAllocatorBase::ResetAllocatorPool() {
+  SB_LOG_IF(INFO, total_allocated_blocks_ > 2048)
+      << "Batched free triggered for " << total_allocated_blocks_ << " blocks.";
+  allocated_block_head_ = nullptr;
+  free_blocks_.clear();
+  pending_frees_.clear();
+
+  total_allocated_in_bytes_ = 0;
+  total_allocated_blocks_ = 0;
+
+  for (int i = 0; i < static_cast<int>(fallback_allocations_.size()); ++i) {
+    AddFreeBlock(MemoryBlock(i, fallback_allocations_[i].address,
+                             fallback_allocations_[i].size));
+  }
+
+  if (enable_decommit_on_idle_) {
+    SB_LOG(INFO) << "Batched free triggered idle state, decommitting "
+                 << fallback_allocations_.size() << " fallback allocations.";
+    for (const auto& fallback_allocation : fallback_allocations_) {
+      fallback_allocator_->Decommit(fallback_allocation.address,
+                                    fallback_allocation.size);
     }
   }
 }

--- a/starboard/common/in_place_reuse_allocator_base.h
+++ b/starboard/common/in_place_reuse_allocator_base.h
@@ -43,6 +43,8 @@ class InPlaceReuseAllocatorBase : public Allocator {
 
   // Marks the memory block as being free and it will then become recyclable
   void Free(void* memory) override;
+  void BatchFree(const std::vector<void*>& memories1,
+                 const std::vector<void*>& memories2);
 
   size_t GetCapacity() const override { return capacity_in_bytes_; }
   size_t GetAllocated() const override { return total_allocated_in_bytes_; }
@@ -166,6 +168,8 @@ class InPlaceReuseAllocatorBase : public Allocator {
   void AddAllocatedBlock(const MemoryBlock& block);
   FreeBlockSet::iterator AddFreeBlock(MemoryBlock block_to_add);
   void RemoveFreeBlock(FreeBlockSet::iterator it);
+  void CheckAndProcessPendingFrees();
+  void ResetAllocatorPool();
 
   BlockMetadata* allocated_block_head_ = nullptr;
   FreeBlockSet free_blocks_;

--- a/starboard/common/reuse_allocator_base.cc
+++ b/starboard/common/reuse_allocator_base.cc
@@ -177,6 +177,18 @@ void ReuseAllocatorBase::Free(void* memory) {
   SB_DCHECK(result);
 }
 
+void ReuseAllocatorBase::BatchFree(const std::vector<void*>& memories1,
+                                   const std::vector<void*>& memories2) {
+  for (auto memory : memories1) {
+    bool result = TryFree(memory);
+    SB_DCHECK(result);
+  }
+  for (auto memory : memories2) {
+    bool result = TryFree(memory);
+    SB_DCHECK(result);
+  }
+}
+
 void ReuseAllocatorBase::PrintAllocations(bool align_allocated_size,
                                           int max_allocations_to_print) const {
   struct HistogramEntry {

--- a/starboard/common/reuse_allocator_base.h
+++ b/starboard/common/reuse_allocator_base.h
@@ -43,6 +43,8 @@ class ReuseAllocatorBase : public Allocator {
 
   // Marks the memory block as being free and it will then become recyclable
   void Free(void* memory) override;
+  void BatchFree(const std::vector<void*>& memories1,
+                 const std::vector<void*>& memories2);
 
   size_t GetCapacity() const override { return capacity_; }
   size_t GetAllocated() const override { return total_allocated_; }

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -162,6 +162,13 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
           return true;
         });
   }
+  if (name == "DecoderBuffer.EnableBatchFree") {
+    return ProcessSettingAsEnableOnly(
+        script_state, exception_context, name, *value, [] {
+          ::media::DecoderBufferAllocator::EnableBatchFree();
+          return true;
+        });
+  }
   // "DecoderBuffer." settings must be handled before this catch-all block.
   if (name.StartsWith("DecoderBuffer.")) {
     return Reject(script_state, exception_context,


### PR DESCRIPTION
Introduce a thread-local batch-free mechanism in DecoderBufferAllocator to defer and batch frees during ChunkDemuxer destruction. This avoids thousands of sequential allocator lock acquisitions, reducing teardown overhead significantly.

Expose a new H5vcc setting 'DecoderBuffer.EnableBatchFree' to control this optimization at runtime.

Bug: 399430536

TAG=agy

CONV=4d1e05de-9caf-4a50-ae67-aca8e59a4089