### PR TITLE
build: guard crash_annotator_jni with !use_evergreen

### DIFF
--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -211,7 +211,7 @@ source_set("cobalt_crash_annotations") {
     "//base",
     "//third_party/crashpad/crashpad/client",
   ]
-  if (is_android) {
+  if (is_android && !use_evergreen) {
     sources += [ "crash_annotator/crash_annotator_jni.cc" ]
     deps += [ "//cobalt/android:jni_headers" ]
   }


### PR DESCRIPTION
CrashAnnotatorImplFirstParty is generated (//cobalt/android/BUILD.gn) only when !use_evergreen, use the same logic when adding the source in //cobalt/browser, otherwise the build fails because cobalt/android/jni_headers/CrashAnnotatorImplFirstParty_jni.h isn't being generated.

Bug: 495203133