### PR TITLE
 starboard/rdk: fix stack trace symbolization on 32-bit systems

### DIFF
--- a/base/third_party/symbolize/symbolize.cc
+++ b/base/third_party/symbolize/symbolize.cc
@@ -52,6 +52,9 @@
 #include GLOG_BUILD_CONFIG_INCLUDE
 #endif  // GLOG_BUILD_CONFIG_INCLUDE
 
+// Allow pread() to use higher offsets on 32-bit systems.
+#define _FILE_OFFSET_BITS 64
+
 #include "symbolize.h"
 
 #include "utilities.h"

--- a/base/third_party/symbolize/symbolize.cc
+++ b/base/third_party/symbolize/symbolize.cc
@@ -52,9 +52,6 @@
 #include GLOG_BUILD_CONFIG_INCLUDE
 #endif  // GLOG_BUILD_CONFIG_INCLUDE
 
-// Allow pread() to use higher offsets on 32-bit systems.
-#define _FILE_OFFSET_BITS 64
-
 #include "symbolize.h"
 
 #include "utilities.h"
@@ -71,6 +68,13 @@
 #include "demangle.h"
 
 #include "build/build_config.h"
+
+#if BUILDFLAG(IS_STARBOARD)
+// Allow pread() to use higher offsets on 32-bit systems.
+#define _FILE_OFFSET_BITS 64
+#endif  // BUILDFLAG(IS_STARBOARD)
+
+
 // TODO: b/398296821 - Cobalt: to support google::Symbolize() when called from
 // the Evergreen library (as opposed to from below Starboard) we would need to
 // also make these customizations when building with the Cobalt toolchain,

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -195,7 +195,7 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/starboard/window_set_default_options.cc",
     "//starboard/shared/stub/decode_target_get_info.cc",
     "//starboard/shared/stub/decode_target_release.cc",
-    "//starboard/shared/stub/log_raw_dump_stack.cc",
+    "//starboard/shared/starboard/log_raw_dump_stack.cc",
     "//starboard/shared/stub/media_can_change_type.cc",
     "//starboard/shared/stub/microphone_close.cc",
     "//starboard/shared/stub/microphone_create.cc",
@@ -206,7 +206,7 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/stub/microphone_read.cc",
     "//starboard/shared/stub/system_hide_splash_screen.cc",
     "//starboard/shared/stub/system_raise_platform_error.cc",
-    "//starboard/shared/stub/system_symbolize.cc",
+    "//starboard/shared/linux/system_symbolize.cc",
 
     # RDK implementation
     "accessibility_data.cc",

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
@@ -81,6 +81,7 @@ int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
   stack_size.rlim_cur = 2 * 1024 * 1024;
   setrlimit(RLIMIT_STACK, &stack_size);
 
+  starboard::InstallCrashSignalHandlers();
   starboard::InstallSuspendSignalHandlers();
   starboard::InstallStopSignalHandlers();
 
@@ -95,6 +96,7 @@ int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
 
   starboard::UninstallStopSignalHandlers();
   starboard::UninstallSuspendSignalHandlers();
+  starboard::UninstallCrashSignalHandlers();
 
   return result;
 }

--- a/starboard/elf_loader/evergreen_info.h
+++ b/starboard/elf_loader/evergreen_info.h
@@ -26,10 +26,10 @@
 #define EVERGREEN_FILE_PATH_MAX_SIZE 4096
 #define EVERGREEN_BUILD_ID_MAX_SIZE 128
 
-#define IS_EVERGREEN_ADDRESS(address, evergreen_info)                    \
-  (evergreen_info.base_address != 0 &&                                   \
-   reinterpret_cast<uint64_t>(address) >= evergreen_info.base_address && \
-   (reinterpret_cast<uint64_t>(address) - evergreen_info.base_address) < \
+#define IS_EVERGREEN_ADDRESS(address, evergreen_info)                     \
+  (evergreen_info.base_address != 0 &&                                    \
+   reinterpret_cast<uintptr_t>(address) >= evergreen_info.base_address && \
+   (reinterpret_cast<uintptr_t>(address) - evergreen_info.base_address) < \
        evergreen_info.load_size)
 
 #ifdef __cplusplus

--- a/third_party/llvm-project/libunwind/BUILD.gn
+++ b/third_party/llvm-project/libunwind/BUILD.gn
@@ -135,10 +135,19 @@ config("unwind_starboard_config") {
   ]
 }
 
+config("unwind_hide_symbols_config") {
+  cflags = [ "-fvisibility=hidden" ]
+
+  defines = [
+    "_LIBUNWIND_HIDE_SYMBOLS",
+  ]
+}
+
 static_library("unwind_starboard") {
   sources = common_sources
 
   configs += [ ":unwind_starboard_config" ]
+  configs += [ ":unwind_hide_symbols_config" ]
   all_dependent_configs = [ ":common_unwind_dependents_config" ]
 
   public_deps = [


### PR DESCRIPTION
## Description ##

Cherry-picks 3 commits from #10267 (`feature/rdk7-26.eap`) into `main`, and add additional fixes. This PR fixes symbolized stack traces on 32-bit RDK targets (arm-hardfp), where crashhandlers previously printed `<unknown> [0x...]` for every frame.

Four root causes addressed:

1. **libgcc_s symbol conflict** — `libgcc_s.so` overrides Cobalt's bundled   libunwind symbols, crashing the unwinder before any frames are collected.   Fix: `-fvisibility=hidden` on the `unwind_starboard` build config.

2. **IS_EVERGREEN_ADDRESS overflow** — casting 32-bit pointers to `uint64_t`   sign-extends addresses ≥ `0x80000000`, so no Evergreen frame is recognized.   Fix: cast to `uintptr_t` in `evergreen_info.h`.

3. **pread() offset limit** — without `_FILE_OFFSET_BITS=64`, pread fails for   libraries mapped above `0x7fffffff`, blocking ELF header reads in symbolize.cc.   Fix: add `#define _FILE_OFFSET_BITS 64`.

4. **No-op stubs in RDK BUILD.gn** — `log_raw_dump_stack` and `system_symbolize`   were wired to empty stubs, so nothing was ever logged even if unwinding worked.   Fix: replace with the real Linux/Starboard implementations.

Verified on an arm-hardfp RDK device: frames now show function names instead of
`<unknown>`.

## Validating the bugfix

To create a controlled crash to verify, after the fixes in `pr/fix-stack-tracing`, add an intentional SIGSEGV at the top of `SbRunStarboardMain` in:
 
```
starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
```

Add the `InstallCrashSignalHandlers()` call and the null dereference right before the rest of the function body:

```cpp
#include "starboard/shared/signal/crash_signals.h"  // already included

int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
tzset();
// ...

  starboard::InstallCrashSignalHandlers();   // <-- add this
  starboard::InstallSuspendSignalHandlers();
  starboard::InstallStopSignalHandlers();

  // Intentional crash to verify stack trace symbolization — remove after check
  volatile int* null_ptr = nullptr;
  *null_ptr = 0;

// ... rest of function
```

Build and deploy normally, then run `loader_app`. The crash handler fires on SIGSEGV and prints the stack trace to stderr. 

### Expected output (with fixes applied)

The named frames, e.g.:

```
[loader_app/26797:0602/214516.536348(UTC):FATAL:loader_app.cc(167)] Check failed: false. Failed to load library at '/data/out_cobalt/app/cobalt/lib/libcobalt.lz4'.
        (anonymous namespace)::LoadLibraryAndInitialize() [0x440087]
        SbEventHandle [0x440a89]
        starboard::Application::HandleEventAndUpdateState() [0x463c1f]
        starboard::Application::DispatchAndDelete() [0x463fc5]
        starboard::Application::DispatchStart() [0x46420b]
        starboard::Application::RunLoop() [0x4643db]
        starboard::Application::Run() [0x4646ef]
        SbRunStarboardMain [0x462093]
        __libc_start_main [0xf56e6a0f]
```

Bug: 507107324
Bug: 511316178