### PR TITLE
DRAFT android: create and send youtube key event on youtube intent

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -352,6 +352,14 @@ public abstract class CobaltActivity extends Activity {
   }
 
   @Override
+  public boolean dispatchKeyEvent(KeyEvent event) {
+    int keyCode = event.getKeyCode();
+    Log.i(TAG, String.format("Charley: dispatchKeyEvent: keyCode=%d, action=%d, scanCode=%d, metaState=%d",
+        keyCode, event.getAction(), event.getScanCode(), event.getMetaState()));
+    return super.dispatchKeyEvent(event);
+  }
+
+  @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
     // If input is a from a gamepad button, it shouldn't be dispatched to IME which incorrectly
     // consumes the event as a VKEY_UNKNOWN
@@ -428,6 +436,16 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
+    Log.i(TAG, "Charley: onCreate: " + getIntent());
+    if (getIntent() != null) {
+      Log.i(TAG, "Charley: onCreate Action: " + getIntent().getAction());
+      Log.i(TAG, "Charley: onCreate Data: " + getIntent().getDataString());
+      if (getIntent().getExtras() != null) {
+        for (String key : getIntent().getExtras().keySet()) {
+          Log.i(TAG, "Charley onCreate Extra: " + key + " = " + getIntent().getExtras().get(key));
+        }
+      }
+    }
     // Record the application start timestamp.
     mTimeInNanoseconds = System.nanoTime();
 
@@ -467,6 +485,7 @@ public abstract class CobaltActivity extends Activity {
     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
       OnBackInvokedHelper.register(this);
     }
+    handleIntent(getIntent());
   }
 
   /**
@@ -703,8 +722,67 @@ public abstract class CobaltActivity extends Activity {
     return StarboardBridge.isDevelopmentBuild();
   }
 
+  protected void handleIntent(Intent intent) {
+    if (intent == null) return;
+
+    if (isYouTubeButtonIntent(intent)) {
+      Log.i(TAG, "Charley: YouTube button Intent detected. Injecting synthetic key event...");
+      injectSyntheticYouTubeButtonKey();
+    }
+  }
+
+  protected boolean isYouTubeButtonIntent(Intent intent) {
+    if (intent.getBooleanExtra("launched_from_youtube_button", false)) {
+      return true;
+    }
+
+    if (intent.getBooleanExtra("yt_remote_button", false)) {
+      return true;
+    }
+
+    String data = intent.getDataString();
+    if (data != null && data.contains("launch=button")) {
+      return true;
+    }
+
+    if ("com.google.android.youtube.action.LAUNCH_BUTTON".equals(intent.getAction())) {
+      return true;
+    }
+
+    if ("dev.cobalt.coat.action.TEST_YOUTUBE_BUTTON".equals(intent.getAction())) {
+      return true;
+    }
+
+    return false;
+  }
+
+  protected void injectSyntheticYouTubeButtonKey() {
+    final int keyCode = KeyEvent.KEYCODE_BUTTON_1;
+
+    runOnUiThread(new Runnable() {
+      @Override
+      public void run() {
+        Log.i(TAG, "Charley: Directly dispatching synthetic key to IME for BUTTON_1");
+        boolean downResult = dispatchKeyEventToIme(keyCode, KeyEvent.ACTION_DOWN);
+        boolean upResult = dispatchKeyEventToIme(keyCode, KeyEvent.ACTION_UP);
+        Log.i(TAG, "Charley: Synthetic key dispatch results: down=" + downResult + ", up=" + upResult);
+      }
+    });
+  }
+
   @Override
   protected void onNewIntent(Intent intent) {
+    Log.i(TAG, "Charley: onNewIntent: " + intent);
+    if (intent != null) {
+      Log.i(TAG, "Charley: onNewIntent Action: " + intent.getAction());
+      Log.i(TAG, "Charley: onNewIntent Data: " + intent.getDataString());
+      if (intent.getExtras() != null) {
+        for (String key : intent.getExtras().keySet()) {
+          Log.i(TAG, "Charley onNewIntent Extra: " + key + " = " + intent.getExtras().get(key));
+        }
+      }
+    }
+    handleIntent(intent);
     getStarboardBridge().handleDeepLink(getIntentUrlAsString(intent));
   }
 

--- a/cobalt/build/android/package.json
+++ b/cobalt/build/android/package.json
@@ -79,6 +79,13 @@
                 "obj/components/url_formatter/android/url_formatter_java.javac.jar",
                 "obj/components/variations/android/variations_java.javac.jar",
                 "obj/components/variations/variations_java.javac.jar",
+                "obj/components/external_intents/android/java.javac.jar",
+                "obj/components/embedder_support/android/util_java.javac.jar",
+                "obj/components/messages/android/java.javac.jar",
+                "obj/components/navigation_interception/android/navigation_interception_java.javac.jar",
+                "obj/components/webapk/android/libs/client/java.javac.jar",
+                "obj/components/messages/android/jni_headers_java.javac.jar",
+                "obj/components/browser_ui/widget/android/java.javac.jar",
                 "obj/components/crash/android/java.javac.jar",
                 "obj/components/crash/android/jni_headers_java.javac.jar",
                 "obj/components/viz/service/service_java.javac.jar",
@@ -434,6 +441,34 @@
                 {
                     "from_file": "obj/components/embedder_support/android/view_java.javac.jar",
                     "to_file": "jar/components_embedder_support_android_view_java.jar"
+                },
+                {
+                    "from_file": "obj/components/external_intents/android/java.javac.jar",
+                    "to_file": "jar/components_external_intents_android_java.jar"
+                },
+                {
+                    "from_file": "obj/components/embedder_support/android/util_java.javac.jar",
+                    "to_file": "jar/components_embedder_support_android_util_java.jar"
+                },
+                {
+                    "from_file": "obj/components/messages/android/java.javac.jar",
+                    "to_file": "jar/components_messages_android_java.jar"
+                },
+                {
+                    "from_file": "obj/components/messages/android/jni_headers_java.javac.jar",
+                    "to_file": "jar/components_messages_android_jni_headers_java.jar"
+                },
+                {
+                    "from_file": "obj/components/browser_ui/widget/android/java.javac.jar",
+                    "to_file": "jar/components_browser_ui_widget_android_java.jar"
+                },
+                {
+                    "from_file": "obj/components/navigation_interception/android/navigation_interception_java.javac.jar",
+                    "to_file": "jar/components_navigation_interception_android_navigation_interception_java.jar"
+                },
+                {
+                    "from_file": "obj/components/webapk/android/libs/client/java.javac.jar",
+                    "to_file": "jar/components_webapk_android_libs_client_java.jar"
                 },
                 {
                     "from_file": "obj/components/input/android/java.javac.jar",

--- a/components/input/web_input_event_builders_android.cc
+++ b/components/input/web_input_event_builders_android.cc
@@ -7,6 +7,7 @@
 #include <android/input.h>
 
 #include "base/check.h"
+#include "base/logging.h"
 #include "base/time/time.h"
 #include "ui/events/android/key_event_utils.h"
 #include "ui/events/base_event_utils.h"
@@ -99,6 +100,9 @@ WebKeyboardEvent WebKeyboardEventBuilder::Build(
   result.dom_code = static_cast<int>(dom_code);
   result.dom_key = GetDomKeyFromEvent(env, android_key_event, keycode,
                                       modifiers, unicode_character);
+  LOG(INFO) << "Charley WebKeyboardEventBuilder: Build keycode=" << keycode
+            << ", windows_key_code=" << result.windows_key_code
+            << ", dom_key=" << ui::KeycodeConverter::DomKeyToKeyString(result.dom_key);
   result.unmodified_text[0] = unicode_character;
   if (result.windows_key_code == ui::VKEY_RETURN) {
     // This is the same behavior as GTK:

--- a/content/public/android/java/src/org/chromium/content/browser/input/ImeAdapterImpl.java
+++ b/content/public/android/java/src/org/chromium/content/browser/input/ImeAdapterImpl.java
@@ -890,6 +890,7 @@ public class ImeAdapterImpl
                     event.getAction(),
                     event.getKeyCode());
         }
+        Log.i(TAG, "Charley ImeAdapterImpl: dispatchKeyEvent action=" + event.getAction() + ", keycode=" + event.getKeyCode() + ", hasInputConnection=" + (mInputConnection != null));
         if (mInputConnection != null) return mInputConnection.sendKeyEventOnUiThread(event);
         return sendKeyEvent(event);
     }
@@ -1089,6 +1090,7 @@ public class ImeAdapterImpl
     }
 
     boolean sendKeyEvent(KeyEvent event) {
+        Log.i(TAG, "Charley ImeAdapterImpl: sendKeyEvent action=" + event.getAction() + ", keycode=" + event.getKeyCode() + ", isValid=" + isValid());
         if (!isValid()) return false;
 
         int action = event.getAction();

--- a/third_party/blink/renderer/core/events/keyboard_event.cc
+++ b/third_party/blink/renderer/core/events/keyboard_event.cc
@@ -22,6 +22,7 @@
 
 #include "third_party/blink/renderer/core/events/keyboard_event.h"
 
+#include "base/logging.h"
 #include "build/build_config.h"
 #include "third_party/blink/public/common/input/web_input_event.h"
 #include "third_party/blink/public/platform/platform.h"
@@ -138,6 +139,11 @@ KeyboardEvent::KeyboardEvent(const WebKeyboardEvent& key,
   if (key.native_key_code == 0xE5)  // VKEY_PROCESSKEY
     key_code_ = 0xE5;
 #endif
+
+  LOG(INFO) << "Charley Blink KeyboardEvent: Created type=" << type()
+            << ", windows_key_code=" << key.windows_key_code
+            << ", key_code_=" << key_code_
+            << ", key_=" << key_;
 }
 
 KeyboardEvent::KeyboardEvent(const AtomicString& event_type,

--- a/third_party/jni_zero/jni_zero.cc
+++ b/third_party/jni_zero/jni_zero.cc
@@ -5,8 +5,11 @@
 #include "third_party/jni_zero/jni_zero.h"
 
 #include <sys/prctl.h>
+#include <cstring>
+#include <string>
 
 #include "build/build_config.h"
+#include "third_party/jni_zero/cobalt_for_google3_buildflags.h"
 #include "third_party/jni_zero/generate_jni/JniInit_jni.h"
 #include "third_party/jni_zero/jni_methods.h"
 #include "third_party/jni_zero/jni_zero_internal.h"
@@ -32,14 +35,25 @@ void (*g_exception_handler_callback)(JNIEnv*) = nullptr;
 jclass GetClassInternal(JNIEnv* env,
                         const char* class_name,
                         const char* split_name) {
+#if BUILDFLAG(IS_COBALT_ON_GOOGLE3)
+  std::string storage;
+  const char* actual_class_name = class_name;
+  if (strncmp(class_name, "org/chromium/", 13) == 0) {
+    storage = std::string("cobalt/") + class_name;
+    actual_class_name = storage.c_str();
+  }
+#else
+  const char* actual_class_name = class_name;
+#endif
+
   jclass clazz;
   if (g_class_resolver != nullptr) {
-    clazz = g_class_resolver(env, class_name, split_name);
+    clazz = g_class_resolver(env, actual_class_name, split_name);
   } else {
-    clazz = env->FindClass(class_name);
+    clazz = env->FindClass(actual_class_name);
   }
   if (ClearException(env) || !clazz) {
-    JNI_ZERO_FLOG("Failed to find class %s", class_name);
+    JNI_ZERO_FLOG("Failed to find class %s", actual_class_name);
   }
   return clazz;
 }

--- a/ui/events/keycodes/cobalt/keyboard_code_conversion_android_cobalt.cc
+++ b/ui/events/keycodes/cobalt/keyboard_code_conversion_android_cobalt.cc
@@ -48,6 +48,10 @@ KeyboardCode KeyboardCodeFromAndroidKeyCode(int keycode) {
       return VKEY_INFO;
     case AKEYCODE_GUIDE:
       return VKEY_GUIDE;
+    case 188:  // AKEYCODE_BUTTON_1 (YouTube)
+      return VKEY_LAUNCH_THIS_APPLICATION;
+    case 231:  // AKEYCODE_VOICE_ASSIST
+      return VKEY_ASSISTANT;
     case AKEYCODE_MEDIA_AUDIO_TRACK:
       return VKEY_MEDIA_AUDIO_TRACK;
     // End of Cobalt keycode mappings

--- a/ui/events/keycodes/dom_us_layout_data.h
+++ b/ui/events/keycodes/dom_us_layout_data.h
@@ -312,6 +312,9 @@ const struct DomKeyToKeyboardCodeEntry {
     // http://www.w3.org/TR/DOM-Level-3-Events-key/#keys-device
 #if BUILDFLAG(IS_POSIX)
     {DomKey::LAUNCH_ASSISTANT, VKEY_ASSISTANT},
+#if BUILDFLAG(IS_COBALT)
+    {DomKey::LAUNCH_THIS_APPLICATION, VKEY_LAUNCH_THIS_APPLICATION},
+#endif
     {DomKey::BRIGHTNESS_DOWN, VKEY_BRIGHTNESS_DOWN},
     {DomKey::BRIGHTNESS_UP, VKEY_BRIGHTNESS_UP},
     {DomKey::POWER, VKEY_POWER},

--- a/ui/events/keycodes/keyboard_code_conversion_android.cc
+++ b/ui/events/keycodes/keyboard_code_conversion_android.cc
@@ -187,6 +187,8 @@ DomKey GetDomKeyFromAndroidKeycode(int keycode) {
       return DomKey::CLOSE;
     case AKEYCODE_MEDIA_EJECT:
       return DomKey::EJECT;
+    case 188: // AKEYCODE_BUTTON_1
+      return DomKey::LAUNCH_THIS_APPLICATION;
     case AKEYCODE_MEDIA_RECORD:
       return DomKey::MEDIA_RECORD;
     case AKEYCODE_F1:

--- a/ui/events/keycodes/keyboard_codes_posix.h
+++ b/ui/events/keycodes/keyboard_codes_posix.h
@@ -293,6 +293,7 @@ enum KeyboardCode : unsigned short {
 
   // Custom Cobalt Key Events
 #if BUILDFLAG(IS_COBALT)
+  VKEY_LAUNCH_THIS_APPLICATION = 0x3000,
   // Key codes from the DTV Application Software Environment,
   //   http://www.atsc.org/wp-content/uploads/2015/03/a_100_4.pdf
   VKEY_RED = 0x193,


### PR DESCRIPTION
DRAFT WIP

Create and inject a key event `0x3000` when a YouTube intent is received. This unblocks failing YTS tests and provides a signal to the application that a YouTube intent has been received. 

Bug: 463596469