### PR TITLE
Starboard/WPE plugin: enable DevTools remote debugging for devel builds

### DIFF
--- a/starboard/contrib/rdk/plugin/CMakeLists.txt
+++ b/starboard/contrib/rdk/plugin/CMakeLists.txt
@@ -34,6 +34,7 @@ set(PLUGIN_COBALT_EXTERNAL_COBALT_LIBRARY "" CACHE STRING "Path of libloader_app
 option(PLUGIN_COBALT_ENABLE_FOCUS_IFACE "Enable support for focus change." OFF)
 option(PLUGIN_COBALT_EVEGREEN_LITE "Enable Evergreen Lite build configuration." OFF)
 option(PLUGIN_COBALT_EVEGREEN_COMPATIBLE "Enable Evergreen compatible configuration." OFF)
+option(PLUGIN_COBALT_ENABLE_DEVTOOLS "Enable DevTools remote debugging port (devel builds)." OFF)
 
 if(PLUGIN_COBALT_ENABLE_FOCUS_IFACE)
     add_definitions(-DPLUGIN_COBALT_ENABLE_FOCUS_IFACE=1)

--- a/starboard/contrib/rdk/plugin/Cobalt.conf.in
+++ b/starboard/contrib/rdk/plugin/Cobalt.conf.in
@@ -43,6 +43,10 @@ sbmainargs = []
 if boolean("@PLUGIN_COBALT_EVEGREEN_LITE@"):
     sbmainargs.append("--evergreen_lite")
 
+if boolean("@PLUGIN_COBALT_ENABLE_DEVTOOLS@"):
+    sbmainargs.append("--remote-debugging-port=9222")
+    sbmainargs.append("--remote-allow-origins=*")
+
 configuration.add("sbmainargs", sbmainargs)
 
 root = JSON()

--- a/starboard/contrib/rdk/plugin/Cobalt.config
+++ b/starboard/contrib/rdk/plugin/Cobalt.config
@@ -98,4 +98,10 @@ if(PLUGIN_COBALT_EVEGREEN_LITE)
     map_append(${configuration} sbmainargs "--evergreen_lite")
 endif()
 
+if(PLUGIN_COBALT_ENABLE_DEVTOOLS)
+    map_append(${configuration} sbmainargs ___array___)
+    map_append(${configuration} sbmainargs "--remote-debugging-port=9222")
+    map_append(${configuration} sbmainargs "--remote-allow-origins=*")
+endif()
+
 map_append(${configuration} root ${rootobject})


### PR DESCRIPTION
Enables Chrome DevTools remote debugging when Cobalt runs as a WPE/Thunder plugin on RDK devices. Previously, `--remote-debugging-port=9222` was only supported by the standalone `loader_app` binary. This change adds the flag to the plugin's `sbmainargs` for `devel` builds via a new `PLUGIN_COBALT_ENABLE_DEVTOOLS` cmake option (off by default), applied in both `Cobalt.conf.in` and `Cobalt.config`.

### How to test

Build and deploy Cobalt in `devel` config (be sure to apply this patch before build) and activate the Cobalt plugin via WPEFramework. Once Cobalt is running, verify from the host that port 9222 is listening with `ssh root@192.168.15.112 "netstat -tlnp | grep 9222"`.

#### ADB

**With a USB ADB cable connected** to the board, run `adb forward tcp:9222 tcp:9222` on the host, to forward the port to the host.

#### SSH

**Without a USB cable connected** to the board, the same result is achieved with `ssh -fNL 9222:127.0.0.1:9222 root@192.168.15.112` on the host.

Both paths expose DevTools at `http://localhost:9222`. In Chrome, go to `chrome://inspect` and add `localhost:9222` as a discovery target.

Bug: 512541004