### PR TITLE
media: Disable WetRtc processing for Cobalt

### DIFF
--- a/media/BUILD.gn
+++ b/media/BUILD.gn
@@ -209,7 +209,10 @@ test("media_unittests") {
     "//media/test:pipeline_integration_tests",
     "//media/test:run_all_unittests",
     "//media/video:unit_tests",
-    "//media/webrtc:unit_tests",
+    # Cobalt disabled WebRtc processing in 
+    # https://github.com/youtube/cobalt/pull/10471
+    # due to additional latency for the microphone path.
+    # "//media/webrtc:unit_tests",
   ]
 
   if (is_cobalt && use_starboard_media) {

--- a/media/BUILD.gn
+++ b/media/BUILD.gn
@@ -214,6 +214,9 @@ test("media_unittests") {
 
   if (is_cobalt && use_starboard_media) {
     deps += ["//media/starboard:unit_tests"]
+  }
+
+  if (is_cobalt) {
     # Cobalt disabled WebRtc processing in 
     # https://github.com/youtube/cobalt/pull/10471
     # due to additional latency for the microphone path.

--- a/media/BUILD.gn
+++ b/media/BUILD.gn
@@ -209,14 +209,15 @@ test("media_unittests") {
     "//media/test:pipeline_integration_tests",
     "//media/test:run_all_unittests",
     "//media/video:unit_tests",
-    # Cobalt disabled WebRtc processing in 
-    # https://github.com/youtube/cobalt/pull/10471
-    # due to additional latency for the microphone path.
-    # "//media/webrtc:unit_tests",
+    "//media/webrtc:unit_tests",
   ]
 
   if (is_cobalt && use_starboard_media) {
     deps += ["//media/starboard:unit_tests"]
+    # Cobalt disabled WebRtc processing in 
+    # https://github.com/youtube/cobalt/pull/10471
+    # due to additional latency for the microphone path.
+    deps -= ["//media/webrtc:unit_tests"]
   }
 
   data = [

--- a/media/base/audio_processing.h
+++ b/media/base/audio_processing.h
@@ -36,6 +36,7 @@ struct MEDIA_EXPORT AudioProcessingSettings {
 #if BUILDFLAG(IS_COBALT)
   // Cobalt does not support WebRtcAudioProcessing, since it increases audio
   // latency on low-end TV devices
+  // https://b.corp.google.com/issues/483713292#comment61
   return false;
 #endif
     // TODO(crbug.com/40205004): Legacy iOS-specific behavior;

--- a/media/base/audio_processing.h
+++ b/media/base/audio_processing.h
@@ -33,6 +33,11 @@ struct MEDIA_EXPORT AudioProcessingSettings {
   }
 
   bool NeedWebrtcAudioProcessing() const {
+#if BUILDFLAG(IS_COBALT)
+  // Cobalt does not support WebRtcAudioProcessing, since it increases audio
+  // latency on low-end TV devices
+  return false;
+#endif
     // TODO(crbug.com/40205004): Legacy iOS-specific behavior;
     // reconsider.
 #if !BUILDFLAG(IS_IOS)

--- a/media/webrtc/audio_processor.cc
+++ b/media/webrtc/audio_processor.cc
@@ -618,10 +618,11 @@ AudioParameters AudioProcessor::GetDefaultOutputFormat(
       need_webrtc_audio_processing
           ?
 #if BUILDFLAG(IS_CASTOS) || BUILDFLAG(IS_CAST_ANDROID)
-          std::min(media::WebRtcAudioProcessingSampleRateHz(),
+          std::min(media::webrtcaudioprocessingsampleratehz(),
                    input_format.sample_rate())
 #elif BUILDFLAG(IS_COBALT)
-          input_format.sample_rate()
+          std::min(media::webrtcaudioprocessingsampleratehz(),
+                   input_format.sample_rate())
 #else
           media::WebRtcAudioProcessingSampleRateHz()
 #endif

--- a/media/webrtc/audio_processor.cc
+++ b/media/webrtc/audio_processor.cc
@@ -620,6 +620,8 @@ AudioParameters AudioProcessor::GetDefaultOutputFormat(
 #if BUILDFLAG(IS_CASTOS) || BUILDFLAG(IS_CAST_ANDROID)
           std::min(media::WebRtcAudioProcessingSampleRateHz(),
                    input_format.sample_rate())
+#elif BUILDFLAG(IS_COBALT)
+          input_format.sample_rate()
 #else
           media::WebRtcAudioProcessingSampleRateHz()
 #endif

--- a/media/webrtc/audio_processor.cc
+++ b/media/webrtc/audio_processor.cc
@@ -620,9 +620,6 @@ AudioParameters AudioProcessor::GetDefaultOutputFormat(
 #if BUILDFLAG(IS_CASTOS) || BUILDFLAG(IS_CAST_ANDROID)
           std::min(media::WebRtcAudioProcessingSampleRateHz(),
                    input_format.sample_rate())
-#elif BUILDFLAG(IS_COBALT)
-          std::min(media::WebRtcAudioProcessingSampleRateHz(),
-                   input_format.sample_rate())
 #else
           media::WebRtcAudioProcessingSampleRateHz()
 #endif

--- a/media/webrtc/audio_processor.cc
+++ b/media/webrtc/audio_processor.cc
@@ -618,10 +618,10 @@ AudioParameters AudioProcessor::GetDefaultOutputFormat(
       need_webrtc_audio_processing
           ?
 #if BUILDFLAG(IS_CASTOS) || BUILDFLAG(IS_CAST_ANDROID)
-          std::min(media::webrtcaudioprocessingsampleratehz(),
+          std::min(media::WebRtcAudioProcessingSampleRateHz(),
                    input_format.sample_rate())
 #elif BUILDFLAG(IS_COBALT)
-          std::min(media::webrtcaudioprocessingsampleratehz(),
+          std::min(media::WebRtcAudioProcessingSampleRateHz(),
                    input_format.sample_rate())
 #else
           media::WebRtcAudioProcessingSampleRateHz()


### PR DESCRIPTION
Cobalt does not require WebRtc processing as it adds additional latency for the microphone path.
Normally this is used for echo cancellation and automatic gain control when handling two way calls, which we don't need or support.

Bug: 483713292
