### PR TITLE
Media: Fix deadlock during Surface destruction

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
@@ -18,6 +18,7 @@ import android.graphics.SurfaceTexture;
 import android.view.Surface;
 import androidx.annotation.GuardedBy;
 import org.jni_zero.CalledByNative;
+import org.jni_zero.CalledByNativeForTesting;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.JniType;
 import org.jni_zero.NativeMethods;
@@ -72,6 +73,11 @@ public class VideoSurfaceTexture extends SurfaceTexture {
   @CalledByNative
   static Surface createSurface(VideoSurfaceTexture surfaceTexture) {
     return new Surface(surfaceTexture);
+  }
+
+  @CalledByNativeForTesting
+  static Surface createSurfaceForTesting() {
+    return new Surface(new SurfaceTexture(1));
   }
 
   @CalledByNative

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -424,6 +424,7 @@ test("starboard_platform_tests") {
               "model_year_test.cc",
               "player_get_preferred_output_mode_test.cc",
               "video_frame_tracker_test.cc",
+              "video_window_test.cc",
             ]
 
   configs += [ "//starboard/build/config:starboard_implementation" ]

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -440,6 +440,7 @@ test("starboard_platform_tests") {
     "//starboard/testing:scoped_feature_list",
     "//testing/gmock",
     "//testing/gtest",
+    "//third_party/jni_zero:jni_zero",
   ]
 }
 

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -434,6 +434,7 @@ test("starboard_platform_tests") {
     ":starboard_platform",
     ":test_support",
     "//base",
+    "//cobalt/android:cobalt_main_java",
     "//starboard:starboard_group",
     "//starboard/shared/starboard/drm:drm_test_helpers",
     "//starboard/shared/starboard/player/filter/testing:test_util",

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -834,13 +834,13 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
 
 void MediaCodecVideoDecoder::TeardownCodec() {
   SB_CHECK(BelongsToCurrentThread());
-  if (surface_destroy_notifier_) {
-    surface_destroy_notifier_->Disconnect();
-    surface_destroy_notifier_ = nullptr;
-  }
   if (owns_video_surface_) {
     ReleaseVideoSurface();
     owns_video_surface_ = false;
+  }
+  if (surface_destroy_notifier_) {
+    surface_destroy_notifier_->Disconnect();
+    surface_destroy_notifier_ = nullptr;
   }
   media_decoder_.reset();
   color_metadata_ = std::nullopt;

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -743,8 +743,9 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       if (surface_view_) {
         j_output_surface = surface_view_.AsLocalRef(env);
       } else {
-        surface_destroy_notifier_ =
-            AcquireVideoSurface(job_queue(), &j_output_surface);
+        AcquiredSurface acquired_surface = AcquireVideoSurface(job_queue());
+        surface_destroy_notifier_ = acquired_surface.destroy_notifier;
+        j_output_surface = acquired_surface.surface;
       }
       if (j_output_surface) {
         owns_video_surface_ = true;

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -743,7 +743,8 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       if (surface_view_) {
         j_output_surface = surface_view_.AsLocalRef(env);
       } else {
-        j_output_surface = AcquireVideoSurface();
+        surface_destroy_notifier_ =
+            AcquireVideoSurface(job_queue(), &j_output_surface);
       }
       if (j_output_surface) {
         owns_video_surface_ = true;
@@ -833,6 +834,10 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
 
 void MediaCodecVideoDecoder::TeardownCodec() {
   SB_CHECK(BelongsToCurrentThread());
+  if (surface_destroy_notifier_) {
+    surface_destroy_notifier_->Disconnect();
+    surface_destroy_notifier_ = nullptr;
+  }
   if (owns_video_surface_) {
     ReleaseVideoSurface();
     owns_video_surface_ = false;
@@ -1094,24 +1099,8 @@ void MediaCodecVideoDecoder::OnVideoFrameRelease() {
 }
 
 void MediaCodecVideoDecoder::OnSurfaceDestroyed() {
-  if (!BelongsToCurrentThread()) {
-    // Wait until codec is stopped.
-    std::unique_lock lock(surface_destroy_mutex_);
-    surface_destroyed_ = false;
-    Schedule(std::bind(&MediaCodecVideoDecoder::OnSurfaceDestroyed, this));
-    surface_condition_variable_.wait_for(lock,
-                                         std::chrono::microseconds(1'000'000),
-                                         [this] { return surface_destroyed_; });
-    return;
-  }
   // When this function is called, the decoder no longer owns the surface.
-  owns_video_surface_ = false;
   TeardownCodec();
-  {
-    std::lock_guard lock(surface_destroy_mutex_);
-    surface_destroyed_ = true;
-  }
-  surface_condition_variable_.notify_one();
 }
 
 void MediaCodecVideoDecoder::ReportError(SbPlayerError error,

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -273,9 +273,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // invocation of ReleaseVideoSurface(), though ReleaseVideoSurface() would
   // do nothing if not own the surface.
   bool owns_video_surface_ = false;
-  std::mutex surface_destroy_mutex_;
-  std::condition_variable surface_condition_variable_;
-  bool surface_destroyed_ = false;  // Guarded by |surface_destroy_mutex_|.
+  scoped_refptr<SurfaceDestroyNotifier> surface_destroy_notifier_;
 
   std::vector<scoped_refptr<InputBuffer>> pending_input_buffers_;
   int video_fps_ = 0;

--- a/starboard/android/shared/video_surface_texture_bridge.cc
+++ b/starboard/android/shared/video_surface_texture_bridge.cc
@@ -59,6 +59,13 @@ ScopedJavaGlobalRef<jobject> VideoSurfaceTextureBridge::CreateSurface(
 }
 
 // static
+ScopedJavaGlobalRef<jobject> VideoSurfaceTextureBridge::CreateSurfaceForTesting(
+    JNIEnv* env) {
+  return ScopedJavaGlobalRef<jobject>(
+      Java_VideoSurfaceTexture_createSurfaceForTesting(env));
+}
+
+// static
 void VideoSurfaceTextureBridge::UpdateTexImage(
     JNIEnv* env,
     const JavaRef<jobject>& surface_texture) {

--- a/starboard/android/shared/video_surface_texture_bridge.h
+++ b/starboard/android/shared/video_surface_texture_bridge.h
@@ -57,6 +57,8 @@ class VideoSurfaceTextureBridge {
   static jni_zero::ScopedJavaGlobalRef<jobject> CreateSurface(
       JNIEnv* env,
       const jni_zero::JavaRef<jobject>& surface_texture);
+  static jni_zero::ScopedJavaGlobalRef<jobject> CreateSurfaceForTesting(
+      JNIEnv* env);
 
   static void UpdateTexImage(JNIEnv* env,
                              const jni_zero::JavaRef<jobject>& surface_texture);

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -28,8 +28,10 @@
 #include "starboard/common/log.h"
 #include "starboard/common/no_destructor.h"
 #include "starboard/common/once.h"
+#include "starboard/common/ref_counted.h"
 #include "starboard/configuration.h"
 #include "starboard/shared/gles/gl_call.h"
+#include "starboard/shared/starboard/player/job_queue.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
@@ -48,9 +50,11 @@ jni_zero::ScopedJavaGlobalRef<jobject>& GetGlobalVideoSurface() {
 }
 
 // Global pointer to the single video window.
-ANativeWindow* g_native_video_window = NULL;
-// Global video surface pointer holder.
-VideoSurfaceHolder* g_video_surface_holder = NULL;
+ANativeWindow* g_native_video_window = nullptr;
+
+// Global ref-counted video surface destroy notifier
+scoped_refptr<SurfaceDestroyNotifier> g_surface_destroy_notifier = nullptr;
+
 // Global boolean to indicate if we need to reset SurfaceView after playing
 // vertical video.
 // TODO: b/521503666 - Revisit to see if we need this variable or not.
@@ -144,19 +148,26 @@ void ClearNativeWindow(void* raw_context) {
 void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
     JNIEnv* env,
     const JavaParamRef<jobject>& surface) {
-  std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_video_surface_holder) {
-    g_video_surface_holder->OnSurfaceDestroyed();
-    g_video_surface_holder = NULL;
+  scoped_refptr<SurfaceDestroyNotifier> notifier_to_notify;
+  {
+    std::lock_guard lock(*GetViewSurfaceMutex());
+    if (g_surface_destroy_notifier) {
+      notifier_to_notify = g_surface_destroy_notifier;
+      g_surface_destroy_notifier = nullptr;
+    }
+    GetGlobalVideoSurface().Reset();
+    if (g_native_video_window) {
+      ANativeWindow_release(g_native_video_window);
+      g_native_video_window = NULL;
+    }
+    if (surface) {
+      GetGlobalVideoSurface().Reset(env, surface);
+      g_native_video_window = ANativeWindow_fromSurface(env, surface.obj());
+    }
   }
-  GetGlobalVideoSurface().Reset();
-  if (g_native_video_window) {
-    ANativeWindow_release(g_native_video_window);
-    g_native_video_window = NULL;
-  }
-  if (surface) {
-    GetGlobalVideoSurface().Reset(env, surface);
-    g_native_video_window = ANativeWindow_fromSurface(env, surface.obj());
+
+  if (notifier_to_notify) {
+    notifier_to_notify->Notify();
   }
 }
 
@@ -164,33 +175,56 @@ void JNI_VideoSurfaceView_SetNeedResetSurface(JNIEnv* env) {
   g_reset_surface_on_clear_window = true;
 }
 
+void SurfaceDestroyNotifier::RunTask() {
+  VideoSurfaceHolder* holder_to_notify = nullptr;
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (!disconnected_) {
+      holder_to_notify = holder_;
+    }
+  }
+
+  if (holder_to_notify) {
+    holder_to_notify->OnSurfaceDestroyed();
+  }
+
+  {
+    std::unique_lock<std::mutex> lock(mutex_);
+    done_ = true;
+    cv_.notify_one();
+  }
+}
+
 // static
 bool VideoSurfaceHolder::IsVideoSurfaceAvailable() {
   // We only consider video surface is available when there is a video
   // surface and it is not held by any decoder, i.e.
-  // g_video_surface_holder is NULL.
+  // g_surface_destroy_notifier is NULL.
   std::lock_guard lock(*GetViewSurfaceMutex());
-  return !g_video_surface_holder && GetGlobalVideoSurface();
+  return !g_surface_destroy_notifier && GetGlobalVideoSurface();
 }
 
-jni_zero::ScopedJavaLocalRef<jobject>
-VideoSurfaceHolder::AcquireVideoSurface() {
+scoped_refptr<SurfaceDestroyNotifier> VideoSurfaceHolder::AcquireVideoSurface(
+    JobQueue* job_queue,
+    jni_zero::ScopedJavaLocalRef<jobject>* out_surface) {
   std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_video_surface_holder != NULL) {
-    return {};
+  if (g_surface_destroy_notifier != nullptr) {
+    return nullptr;
   }
   if (!GetGlobalVideoSurface()) {
-    return {};
+    return nullptr;
   }
-  g_video_surface_holder = this;
+  g_surface_destroy_notifier = new SurfaceDestroyNotifier(this, job_queue);
   JNIEnv* env = jni_zero::AttachCurrentThread();
-  return jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface());
+  *out_surface = jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface());
+  return g_surface_destroy_notifier;
 }
 
 void VideoSurfaceHolder::ReleaseVideoSurface() {
   std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_video_surface_holder == this) {
-    g_video_surface_holder = NULL;
+  if (g_surface_destroy_notifier && g_surface_destroy_notifier->Holds(this)) {
+    g_surface_destroy_notifier->Disconnect();
+    g_surface_destroy_notifier = nullptr;
   }
 }
 

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -162,7 +162,7 @@ void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
     GetGlobalVideoSurface().Reset();
     if (g_native_video_window) {
       ANativeWindow_release(g_native_video_window);
-      g_native_video_window = NULL;
+      g_native_video_window = nullptr;
     }
     if (surface) {
       GetGlobalVideoSurface().Reset(env, surface);
@@ -179,7 +179,32 @@ void JNI_VideoSurfaceView_SetNeedResetSurface(JNIEnv* env) {
   g_reset_surface_on_clear_window = true;
 }
 
-void SurfaceDestroyNotifier::RunTask() {
+void SurfaceDestroyNotifier::Disconnect() {
+  {
+    std::lock_guard lock(mutex_);
+    disconnected_ = true;
+    job_queue_ = nullptr;
+    holder_ = nullptr;
+    done_ = true;  // Mark as done_ so Notify() can exit immediately
+  }
+  done_cv_.notify_one();
+}
+
+void SurfaceDestroyNotifier::Notify() {
+  std::unique_lock lock(mutex_);
+  if (disconnected_ || !holder_ || !job_queue_) {
+    return;
+  }
+
+  done_ = false;
+  scoped_refptr<SurfaceDestroyNotifier> self(this);
+  job_queue_->Schedule([self]() { self->NotifyDestroyed(); });
+
+  // Wait for the task to complete with a 1-second timeout.
+  done_cv_.wait_for(lock, std::chrono::seconds(1), [this] { return done_; });
+}
+
+void SurfaceDestroyNotifier::NotifyDestroyed() {
   VideoSurfaceHolder* holder_to_notify = nullptr;
   {
     std::lock_guard lock(mutex_);
@@ -196,14 +221,14 @@ void SurfaceDestroyNotifier::RunTask() {
     std::lock_guard lock(mutex_);
     done_ = true;
   }
-  cv_.notify_one();
+  done_cv_.notify_one();
 }
 
 // static
 bool VideoSurfaceHolder::IsVideoSurfaceAvailable() {
   // We only consider video surface is available when there is a video
   // surface and it is not held by any decoder, i.e.
-  // g_surface_destroy_notifier is NULL.
+  // g_surface_destroy_notifier is nullptr.
   std::lock_guard lock(*GetViewSurfaceMutex());
   return !GetGlobalSurfaceDestroyNotifier() && GetGlobalVideoSurface();
 }
@@ -212,33 +237,35 @@ VideoSurfaceHolder::AcquiredSurface VideoSurfaceHolder::AcquireVideoSurface(
     JobQueue* job_queue) {
   std::lock_guard lock(*GetViewSurfaceMutex());
   if (GetGlobalSurfaceDestroyNotifier() != nullptr) {
+    // Other VideoSurfaceHolder has already acquired destroyer
     return {};
   }
   if (!GetGlobalVideoSurface()) {
+    // Video Surface not created yet
     return {};
   }
   GetGlobalSurfaceDestroyNotifier() =
-      new SurfaceDestroyNotifier(this, job_queue);
+      make_scoped_refptr<SurfaceDestroyNotifier>(this, job_queue);
   JNIEnv* env = jni_zero::AttachCurrentThread();
-  AcquiredSurface result;
-  result.destroy_notifier = GetGlobalSurfaceDestroyNotifier();
-  result.surface =
-      jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface());
-  return result;
+
+  return {GetGlobalSurfaceDestroyNotifier(),
+          jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface())};
 }
 
 void VideoSurfaceHolder::ReleaseVideoSurface() {
   std::lock_guard lock(*GetViewSurfaceMutex());
-  if (GetGlobalSurfaceDestroyNotifier() &&
-      GetGlobalSurfaceDestroyNotifier()->Holds(this)) {
-    GetGlobalSurfaceDestroyNotifier()->Disconnect();
-    GetGlobalSurfaceDestroyNotifier() = nullptr;
+
+  auto& notifier = GetGlobalSurfaceDestroyNotifier();
+  if (!notifier || !notifier->Holds(this)) {
+    return;
   }
+  notifier->Disconnect();
+  notifier = nullptr;
 }
 
 bool VideoSurfaceHolder::GetVideoWindowSize(int* width, int* height) {
   std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_native_video_window == NULL) {
+  if (g_native_video_window == nullptr) {
     return false;
   } else {
     *width = ANativeWindow_getWidth(g_native_video_window);

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -182,7 +182,7 @@ void JNI_VideoSurfaceView_SetNeedResetSurface(JNIEnv* env) {
 void SurfaceDestroyNotifier::RunTask() {
   VideoSurfaceHolder* holder_to_notify = nullptr;
   {
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::lock_guard lock(mutex_);
     if (!disconnected_) {
       holder_to_notify = holder_;
     }
@@ -193,10 +193,10 @@ void SurfaceDestroyNotifier::RunTask() {
   }
 
   {
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::lock_guard lock(mutex_);
     done_ = true;
-    cv_.notify_one();
   }
+  cv_.notify_one();
 }
 
 // static
@@ -208,26 +208,23 @@ bool VideoSurfaceHolder::IsVideoSurfaceAvailable() {
   return !GetGlobalSurfaceDestroyNotifier() && GetGlobalVideoSurface();
 }
 
-scoped_refptr<SurfaceDestroyNotifier> VideoSurfaceHolder::AcquireVideoSurface(
-    JobQueue* job_queue,
-    jni_zero::ScopedJavaLocalRef<jobject>* out_surface) {
-  if (out_surface) {
-    *out_surface = {};
-  }
+VideoSurfaceHolder::AcquiredSurface VideoSurfaceHolder::AcquireVideoSurface(
+    JobQueue* job_queue) {
   std::lock_guard lock(*GetViewSurfaceMutex());
   if (GetGlobalSurfaceDestroyNotifier() != nullptr) {
-    return nullptr;
+    return {};
   }
   if (!GetGlobalVideoSurface()) {
-    return nullptr;
+    return {};
   }
   GetGlobalSurfaceDestroyNotifier() =
       new SurfaceDestroyNotifier(this, job_queue);
-  if (out_surface) {
-    JNIEnv* env = jni_zero::AttachCurrentThread();
-    *out_surface = jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface());
-  }
-  return GetGlobalSurfaceDestroyNotifier();
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+  AcquiredSurface result;
+  result.destroy_notifier = GetGlobalSurfaceDestroyNotifier();
+  result.surface =
+      jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface());
+  return result;
 }
 
 void VideoSurfaceHolder::ReleaseVideoSurface() {

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -256,7 +256,7 @@ void VideoSurfaceHolder::ReleaseVideoSurface() {
   std::lock_guard lock(*GetViewSurfaceMutex());
 
   auto& notifier = GetGlobalSurfaceDestroyNotifier();
-  if (!notifier || !notifier->Holds(this)) {
+  if (!notifier || !notifier->IsCurrentHolder(this)) {
     return;
   }
   notifier->Disconnect();
@@ -302,6 +302,11 @@ void VideoSurfaceHolder::CleanUpVideoWindow(
 
   StarboardBridge::GetInstance()->ResetVideoSurface(env);
   SB_LOG(INFO) << "Video surface has been reset (default behavior).";
+}
+
+void SetVideoSurfaceForTesting(JNIEnv* env, jobject surface) {
+  JNI_VideoSurfaceView_OnVideoSurfaceChanged(
+      env, jni_zero::JavaParamRef<jobject>(env, surface));
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -52,8 +52,12 @@ jni_zero::ScopedJavaGlobalRef<jobject>& GetGlobalVideoSurface() {
 // Global pointer to the single video window.
 ANativeWindow* g_native_video_window = nullptr;
 
-// Global ref-counted video surface destroy notifier
-scoped_refptr<SurfaceDestroyNotifier> g_surface_destroy_notifier = nullptr;
+// Global ref-counted video surface destroy notifier wrapped in NoDestructor
+// to avoid exit-time destructor issues.
+scoped_refptr<SurfaceDestroyNotifier>& GetGlobalSurfaceDestroyNotifier() {
+  static NoDestructor<scoped_refptr<SurfaceDestroyNotifier>> notifier;
+  return *notifier;
+}
 
 // Global boolean to indicate if we need to reset SurfaceView after playing
 // vertical video.
@@ -151,9 +155,9 @@ void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
   scoped_refptr<SurfaceDestroyNotifier> notifier_to_notify;
   {
     std::lock_guard lock(*GetViewSurfaceMutex());
-    if (g_surface_destroy_notifier) {
-      notifier_to_notify = g_surface_destroy_notifier;
-      g_surface_destroy_notifier = nullptr;
+    if (GetGlobalSurfaceDestroyNotifier()) {
+      notifier_to_notify = GetGlobalSurfaceDestroyNotifier();
+      GetGlobalSurfaceDestroyNotifier() = nullptr;
     }
     GetGlobalVideoSurface().Reset();
     if (g_native_video_window) {
@@ -201,30 +205,37 @@ bool VideoSurfaceHolder::IsVideoSurfaceAvailable() {
   // surface and it is not held by any decoder, i.e.
   // g_surface_destroy_notifier is NULL.
   std::lock_guard lock(*GetViewSurfaceMutex());
-  return !g_surface_destroy_notifier && GetGlobalVideoSurface();
+  return !GetGlobalSurfaceDestroyNotifier() && GetGlobalVideoSurface();
 }
 
 scoped_refptr<SurfaceDestroyNotifier> VideoSurfaceHolder::AcquireVideoSurface(
     JobQueue* job_queue,
     jni_zero::ScopedJavaLocalRef<jobject>* out_surface) {
+  if (out_surface) {
+    *out_surface = {};
+  }
   std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_surface_destroy_notifier != nullptr) {
+  if (GetGlobalSurfaceDestroyNotifier() != nullptr) {
     return nullptr;
   }
   if (!GetGlobalVideoSurface()) {
     return nullptr;
   }
-  g_surface_destroy_notifier = new SurfaceDestroyNotifier(this, job_queue);
-  JNIEnv* env = jni_zero::AttachCurrentThread();
-  *out_surface = jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface());
-  return g_surface_destroy_notifier;
+  GetGlobalSurfaceDestroyNotifier() =
+      new SurfaceDestroyNotifier(this, job_queue);
+  if (out_surface) {
+    JNIEnv* env = jni_zero::AttachCurrentThread();
+    *out_surface = jni_zero::ScopedJavaLocalRef<jobject>(env, GetGlobalVideoSurface());
+  }
+  return GetGlobalSurfaceDestroyNotifier();
 }
 
 void VideoSurfaceHolder::ReleaseVideoSurface() {
   std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_surface_destroy_notifier && g_surface_destroy_notifier->Holds(this)) {
-    g_surface_destroy_notifier->Disconnect();
-    g_surface_destroy_notifier = nullptr;
+  if (GetGlobalSurfaceDestroyNotifier() &&
+      GetGlobalSurfaceDestroyNotifier()->Holds(this)) {
+    GetGlobalSurfaceDestroyNotifier()->Disconnect();
+    GetGlobalSurfaceDestroyNotifier() = nullptr;
   }
 }
 

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -44,8 +44,10 @@ class VideoSurfaceHolder {
  protected:
   ~VideoSurfaceHolder() {}
 
-  // Returns the surface to which video should be rendered. The surface
-  // cannot be acquired before last holder release the surface.
+  // Acquires the video surface and returns a SurfaceDestroyNotifier to monitor
+  // its lifetime. The actual surface is returned via the `out_surface` output
+  // parameter. The surface cannot be acquired before the previous holder
+  // releases it.
   scoped_refptr<SurfaceDestroyNotifier> AcquireVideoSurface(
       JobQueue* job_queue,
       jni_zero::ScopedJavaLocalRef<jobject>* out_surface);

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -49,8 +49,11 @@ class VideoSurfaceHolder {
  protected:
   ~VideoSurfaceHolder() {}
 
-  // Returns the surface to which video should be rendered. The surface
-  // cannot be acquired before last holder release the surface.
+  // Returns the surface to which video should be rendered, along with a
+  // SurfaceDestroyNotifier to safely handle surface destruction.
+  // The surface cannot be acquired if it's already held by another player.
+  // |job_queue| is used by SurfaceDestroyNotifier to schedule the teardown
+  // task on the player worker thread when the surface is destroyed.
   AcquiredSurface AcquireVideoSurface(JobQueue* job_queue);
 
   // Release the surface to make the surface available for other holder.

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -98,7 +98,7 @@ class SurfaceDestroyNotifier
   void Disconnect();
   void Notify();
 
-  bool Holds(VideoSurfaceHolder* holder) const {
+  bool IsCurrentHolder(VideoSurfaceHolder* holder) const {
     std::lock_guard lock(mutex_);
     return holder_ == holder;
   }
@@ -116,6 +116,9 @@ class SurfaceDestroyNotifier
   VideoSurfaceHolder* holder_;  // Guarded by |mutex_|
   JobQueue* job_queue_;         // Guarded by |mutex_|
 };
+
+// Set the global video surface. Exposed for unit testing.
+void SetVideoSurfaceForTesting(JNIEnv* env, jobject surface);
 
 }  // namespace starboard
 

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -86,39 +86,17 @@ class VideoSurfaceHolder {
 // The task scheduled on the JobQueue also retains a reference to ensure
 // the object stays alive until execution completes.
 //
-// Threading Model: `Notify()` is called from the JNI thread. `RunTask()`
-// executes on the player worker thread. Internal state is protected by its
-// own mutex.
+// Threading Model: `Notify()` is called from the JNI thread.
+// `NotifyDestroyed()` executes on the player worker thread. Internal state is
+// protected by its own mutex.
 class SurfaceDestroyNotifier
     : public RefCountedThreadSafe<SurfaceDestroyNotifier> {
  public:
   SurfaceDestroyNotifier(VideoSurfaceHolder* holder, JobQueue* job_queue)
       : holder_(holder), job_queue_(job_queue) {}
 
-  void Disconnect() {
-    {
-      std::lock_guard lock(mutex_);
-      disconnected_ = true;
-      job_queue_ = nullptr;
-      holder_ = nullptr;
-      done_ = true;  // Mark as done_ so Notify() can exit immediately
-    }
-    cv_.notify_one();
-  }
-
-  void Notify() {
-    std::unique_lock lock(mutex_);
-    if (disconnected_ || !holder_ || !job_queue_) {
-      return;
-    }
-
-    done_ = false;
-    scoped_refptr<SurfaceDestroyNotifier> self(this);
-    job_queue_->Schedule([self]() { self->RunTask(); });
-
-    // Wait for the task to complete with a 1-second timeout.
-    cv_.wait_for(lock, std::chrono::seconds(1), [this] { return done_; });
-  }
+  void Disconnect();
+  void Notify();
 
   bool Holds(VideoSurfaceHolder* holder) const {
     std::lock_guard lock(mutex_);
@@ -129,15 +107,14 @@ class SurfaceDestroyNotifier
   ~SurfaceDestroyNotifier() = default;
   friend class RefCountedThreadSafe<SurfaceDestroyNotifier>;
 
- private:
-  void RunTask();
+  void NotifyDestroyed();
 
   mutable std::mutex mutex_;
-  std::condition_variable cv_;
-  bool done_ = false;
-  bool disconnected_ = false;
-  VideoSurfaceHolder* holder_;
-  JobQueue* job_queue_;
+  std::condition_variable done_cv_;
+  bool done_ = false;           // Guarded by |mutex_|
+  bool disconnected_ = false;   // Guarded by |mutex_|
+  VideoSurfaceHolder* holder_;  // Guarded by |mutex_|
+  JobQueue* job_queue_;         // Guarded by |mutex_|
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -32,6 +32,11 @@ class SurfaceDestroyNotifier;
 
 class VideoSurfaceHolder {
  public:
+  struct AcquiredSurface {
+    scoped_refptr<SurfaceDestroyNotifier> destroy_notifier;
+    jni_zero::ScopedJavaLocalRef<jobject> surface;
+  };
+
   // Return true only if the video surface is available.
   static bool IsVideoSurfaceAvailable();
 
@@ -44,13 +49,9 @@ class VideoSurfaceHolder {
  protected:
   ~VideoSurfaceHolder() {}
 
-  // Acquires the video surface and returns a SurfaceDestroyNotifier to monitor
-  // its lifetime. The actual surface is returned via the `out_surface` output
-  // parameter. The surface cannot be acquired before the previous holder
-  // releases it.
-  scoped_refptr<SurfaceDestroyNotifier> AcquireVideoSurface(
-      JobQueue* job_queue,
-      jni_zero::ScopedJavaLocalRef<jobject>* out_surface);
+  // Returns the surface to which video should be rendered. The surface
+  // cannot be acquired before last holder release the surface.
+  AcquiredSurface AcquireVideoSurface(JobQueue* job_queue);
 
   // Release the surface to make the surface available for other holder.
   void ReleaseVideoSurface();
@@ -92,16 +93,18 @@ class SurfaceDestroyNotifier
       : holder_(holder), job_queue_(job_queue) {}
 
   void Disconnect() {
-    std::lock_guard<std::mutex> lock(mutex_);
-    disconnected_ = true;
-    job_queue_ = nullptr;
-    holder_ = nullptr;
-    done_ = true;  // Mark as done_ so Notify() can exit immediately
+    {
+      std::lock_guard lock(mutex_);
+      disconnected_ = true;
+      job_queue_ = nullptr;
+      holder_ = nullptr;
+      done_ = true;  // Mark as done_ so Notify() can exit immediately
+    }
     cv_.notify_one();
   }
 
   void Notify() {
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::unique_lock lock(mutex_);
     if (disconnected_ || !holder_ || !job_queue_) {
       return;
     }
@@ -115,11 +118,11 @@ class SurfaceDestroyNotifier
   }
 
   bool Holds(VideoSurfaceHolder* holder) const {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::lock_guard lock(mutex_);
     return holder_ == holder;
   }
 
- protected:
+ private:
   ~SurfaceDestroyNotifier() = default;
   friend class RefCountedThreadSafe<SurfaceDestroyNotifier>;
 

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -18,10 +18,17 @@
 #include <android/native_window.h>
 #include <jni.h>
 
+#include <condition_variable>
+#include <mutex>
+
+#include "starboard/common/ref_counted.h"
 #include "starboard/decode_target.h"
+#include "starboard/shared/starboard/player/job_queue.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
+
+class SurfaceDestroyNotifier;
 
 class VideoSurfaceHolder {
  public:
@@ -37,9 +44,11 @@ class VideoSurfaceHolder {
  protected:
   ~VideoSurfaceHolder() {}
 
-  // Returns the surface which video should be rendered. Surface cannot be
-  // acquired before last holder release the surface.
-  jni_zero::ScopedJavaLocalRef<jobject> AcquireVideoSurface();
+  // Returns the surface to which video should be rendered. The surface
+  // cannot be acquired before last holder release the surface.
+  scoped_refptr<SurfaceDestroyNotifier> AcquireVideoSurface(
+      JobQueue* job_queue,
+      jni_zero::ScopedJavaLocalRef<jobject>* out_surface);
 
   // Release the surface to make the surface available for other holder.
   void ReleaseVideoSurface();
@@ -55,6 +64,72 @@ class VideoSurfaceHolder {
   void CleanUpVideoWindow(
       bool force_clear,
       SbDecodeTargetGraphicsContextProvider* gpu_provider = nullptr);
+};
+
+// SurfaceDestroyNotifier is used to safely handle the destruction of the video
+// surface from JNI without causing deadlocks.
+//
+// Purpose: Decouples the JNI thread (which notifies about surface destruction)
+// from the player worker thread (which performs the teardown). It schedules
+// the teardown task on the player worker thread and waits for it with a timeout
+// to avoid hanging the JNI thread.
+//
+// Lifetime/Ownership: This class is RefCountedThreadSafe. It is created by
+// VideoSurfaceHolder when acquiring the surface, and references are held by
+// the global `g_surface_destroy_notifier` and the `MediaCodecVideoDecoder`.
+// The task scheduled on the JobQueue also retains a reference to ensure
+// the object stays alive until execution completes.
+//
+// Threading Model: `Notify()` is called from the JNI thread. `RunTask()`
+// executes on the player worker thread. Internal state is protected by its
+// own mutex.
+class SurfaceDestroyNotifier
+    : public RefCountedThreadSafe<SurfaceDestroyNotifier> {
+ public:
+  SurfaceDestroyNotifier(VideoSurfaceHolder* holder, JobQueue* job_queue)
+      : holder_(holder), job_queue_(job_queue) {}
+
+  void Disconnect() {
+    std::lock_guard<std::mutex> lock(mutex_);
+    disconnected_ = true;
+    job_queue_ = nullptr;
+    holder_ = nullptr;
+    done_ = true;  // Mark as done_ so Notify() can exit immediately
+    cv_.notify_one();
+  }
+
+  void Notify() {
+    std::unique_lock<std::mutex> lock(mutex_);
+    if (disconnected_ || !holder_ || !job_queue_) {
+      return;
+    }
+
+    done_ = false;
+    scoped_refptr<SurfaceDestroyNotifier> self(this);
+    job_queue_->Schedule([self]() { self->RunTask(); });
+
+    // Wait for the task to complete with a 1-second timeout.
+    cv_.wait_for(lock, std::chrono::seconds(1), [this] { return done_; });
+  }
+
+  bool Holds(VideoSurfaceHolder* holder) const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    return holder_ == holder;
+  }
+
+ protected:
+  ~SurfaceDestroyNotifier() = default;
+  friend class RefCountedThreadSafe<SurfaceDestroyNotifier>;
+
+ private:
+  void RunTask();
+
+  mutable std::mutex mutex_;
+  std::condition_variable cv_;
+  bool done_ = false;
+  bool disconnected_ = false;
+  VideoSurfaceHolder* holder_;
+  JobQueue* job_queue_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window_test.cc
+++ b/starboard/android/shared/video_window_test.cc
@@ -23,6 +23,7 @@
 
 #include "starboard/android/shared/fake_media_codec.h"
 #include "starboard/android/shared/media_codec_video_decoder.h"
+#include "starboard/android/shared/video_surface_texture_bridge.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/starboard/player/job_thread.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -37,37 +38,8 @@ class VideoDecoderSurfaceTest : public ::testing::Test {
     env_ = jni_zero::AttachCurrentThread();
     ASSERT_NE(env_, nullptr);
 
-    // Create a real Java Surface to pass to ANativeWindow_fromSurface.
-    // We use standard Android framework classes (SurfaceTexture, Surface)
-    // rather than Cobalt wrappers because Cobalt Java classes are not packaged
-    // inside the standalone starboard_platform_tests_apk.
-    //
-    // All local references are wrapped in ScopedJavaLocalRef to prevent leaks.
-    jni_zero::ScopedJavaLocalRef<jclass> surface_texture_class(
-        env_, env_->FindClass("android/graphics/SurfaceTexture"));
-    ASSERT_FALSE(surface_texture_class.is_null());
-
-    jmethodID surface_texture_ctor =
-        env_->GetMethodID(surface_texture_class.obj(), "<init>", "(I)V");
-    ASSERT_NE(surface_texture_ctor, nullptr);
-
-    jni_zero::ScopedJavaLocalRef<jobject> surface_texture(
-        env_,
-        env_->NewObject(surface_texture_class.obj(), surface_texture_ctor, 1));
-    ASSERT_FALSE(surface_texture.is_null());
-
-    jni_zero::ScopedJavaLocalRef<jclass> surface_class(
-        env_, env_->FindClass("android/view/Surface"));
-    ASSERT_FALSE(surface_class.is_null());
-
-    jmethodID surface_ctor = env_->GetMethodID(
-        surface_class.obj(), "<init>", "(Landroid/graphics/SurfaceTexture;)V");
-    ASSERT_NE(surface_ctor, nullptr);
-
-    real_surface_ = jni_zero::ScopedJavaLocalRef<jobject>(
-        env_, env_->NewObject(surface_class.obj(), surface_ctor,
-                              surface_texture.obj()));
-    ASSERT_FALSE(real_surface_.is_null());
+    real_surface_ = VideoSurfaceTextureBridge::CreateSurfaceForTesting(env_);
+    ASSERT_TRUE(real_surface_);
   }
 
   void TearDown() override {

--- a/starboard/android/shared/video_window_test.cc
+++ b/starboard/android/shared/video_window_test.cc
@@ -14,17 +14,16 @@
 
 #include "starboard/android/shared/video_window.h"
 
-#include <jni.h>
 #include <unistd.h>
 
 #include <chrono>
 #include <memory>
-#include <thread>
 
 #include "starboard/android/shared/fake_media_codec.h"
 #include "starboard/android/shared/media_codec_video_decoder.h"
 #include "starboard/android/shared/video_surface_texture_bridge.h"
 #include "starboard/common/log.h"
+#include "starboard/common/thread.h"
 #include "starboard/shared/starboard/player/job_thread.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -109,25 +108,39 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   std::atomic<bool> jni_thread_done{false};
 
   // Thread A: Simulate JNI thread receiving surface destroyed event.
+  struct JniSimThread : public starboard::Thread {
+    explicit JniSimThread(std::atomic<bool>& done)
+        : Thread("JniSimThread"), done_(done) {}
+    void Run() override {
+      // JNIEnv is thread-local. Background threads must obtain their own local
+      // JNIEnv pointer by attaching to the JVM.
+      JNIEnv* env = jni_zero::AttachCurrentThread();
+      SB_LOG(INFO) << "JNI thread: Calling OnVideoSurfaceChanged(nullptr)...";
+      starboard::SetVideoSurfaceForTesting(env, nullptr);
+      SB_LOG(INFO) << "JNI thread: OnVideoSurfaceChanged returned.";
+      done_ = true;
+    }
+    std::atomic<bool>& done_;
+  };
+
   auto start_time = std::chrono::steady_clock::now();
-  std::thread jni_sim_thread([&]() {
-    SB_LOG(INFO) << "JNI thread: Calling OnVideoSurfaceChanged(nullptr)...";
-    starboard::SetVideoSurfaceForTesting(env_, nullptr);
-    SB_LOG(INFO) << "JNI thread: OnVideoSurfaceChanged returned.";
-    jni_thread_done = true;
-  });
+  JniSimThread jni_sim_thread(jni_thread_done);
+  jni_sim_thread.Start();
 
   // Thread B: Simulate decoder teardown on the decoder thread.
   // We add a small delay to ensure the JNI thread can acquire the lock first,
   // which is necessary to trigger the deadlock on the unpatched code.
-  MediaCodecVideoDecoder* raw_decoder = decoder.release();
-  job_thread->Schedule([raw_decoder]() {
+  std::shared_ptr<MediaCodecVideoDecoder> shared_decoder = std::move(decoder);
+  job_thread->Schedule([shared_decoder]() mutable {
     SB_LOG(INFO) << "Decoder thread: Waiting before destroying...";
     usleep(100'000);
     SB_LOG(INFO) << "Decoder thread: Destroying decoder...";
+    shared_decoder.reset();
+    SB_LOG(INFO) << "Decoder thread: Decoder destroyed.";
   });
+  shared_decoder.reset();
 
-  jni_sim_thread.join();
+  jni_sim_thread.Join();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start_time);
   EXPECT_LT(duration.count(), 800);  // Expect less than 800ms (should be ~100ms

--- a/starboard/android/shared/video_window_test.cc
+++ b/starboard/android/shared/video_window_test.cc
@@ -35,7 +35,6 @@ class VideoDecoderSurfaceTest : public ::testing::Test {
  protected:
   void SetUp() override {
     env_ = jni_zero::AttachCurrentThread();
-    ASSERT_NE(env_, nullptr);
 
     real_surface_ = VideoSurfaceTextureBridge::CreateSurfaceForTesting(env_);
     ASSERT_TRUE(real_surface_);
@@ -123,7 +122,7 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
     std::atomic<bool>& done_;
   };
 
-  auto start_time = std::chrono::steady_clock::now();
+  auto start_time = CurrentMonotonicTime();
   JniSimThread jni_sim_thread(jni_thread_done);
   jni_sim_thread.Start();
 
@@ -141,10 +140,9 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   shared_decoder.reset();
 
   jni_sim_thread.Join();
-  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
-      std::chrono::steady_clock::now() - start_time);
-  EXPECT_LT(duration.count(), 800);  // Expect less than 800ms (should be ~100ms
-                                     // with fix, 1000ms with deadlock)
+  auto duration = CurrentMonotonicTime() - start_time;
+  EXPECT_LT(duration, 800'000);  // Expect less than 800ms (should be ~100ms
+                                 // with fix, 1000ms with deadlock)
 
   SB_LOG(INFO) << "Stopping job thread...";
   job_thread->Stop();

--- a/starboard/android/shared/video_window_test.cc
+++ b/starboard/android/shared/video_window_test.cc
@@ -15,6 +15,7 @@
 #include "starboard/android/shared/video_window.h"
 
 #include <jni.h>
+#include <unistd.h>
 
 #include <chrono>
 #include <memory>
@@ -28,14 +29,6 @@
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
-extern "C" void Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(
-    JNIEnv* env,
-    jobject surface);
-}
-
-namespace starboard {
-namespace android {
-namespace shared {
 namespace {
 
 class VideoDecoderSurfaceTest : public ::testing::Test {
@@ -45,43 +38,41 @@ class VideoDecoderSurfaceTest : public ::testing::Test {
     ASSERT_NE(env_, nullptr);
 
     // Create a real Java Surface to pass to ANativeWindow_fromSurface.
-    // 1. Find SurfaceTexture class
-    jclass surface_texture_class =
-        env_->FindClass("android/graphics/SurfaceTexture");
-    ASSERT_NE(surface_texture_class, nullptr);
+    // We use standard Android framework classes (SurfaceTexture, Surface)
+    // rather than Cobalt wrappers because Cobalt Java classes are not packaged
+    // inside the standalone starboard_platform_tests_apk.
+    //
+    // All local references are wrapped in ScopedJavaLocalRef to prevent leaks.
+    jni_zero::ScopedJavaLocalRef<jclass> surface_texture_class(
+        env_, env_->FindClass("android/graphics/SurfaceTexture"));
+    ASSERT_FALSE(surface_texture_class.is_null());
 
-    // 2. Get constructor SurfaceTexture(int texName)
     jmethodID surface_texture_ctor =
-        env_->GetMethodID(surface_texture_class, "<init>", "(I)V");
+        env_->GetMethodID(surface_texture_class.obj(), "<init>", "(I)V");
     ASSERT_NE(surface_texture_ctor, nullptr);
 
-    // 3. Create SurfaceTexture instance with dummy texture ID 1
-    jobject surface_texture =
-        env_->NewObject(surface_texture_class, surface_texture_ctor, 1);
-    ASSERT_NE(surface_texture, nullptr);
+    jni_zero::ScopedJavaLocalRef<jobject> surface_texture(
+        env_,
+        env_->NewObject(surface_texture_class.obj(), surface_texture_ctor, 1));
+    ASSERT_FALSE(surface_texture.is_null());
 
-    // 4. Find Surface class
-    jclass surface_class = env_->FindClass("android/view/Surface");
-    ASSERT_NE(surface_class, nullptr);
+    jni_zero::ScopedJavaLocalRef<jclass> surface_class(
+        env_, env_->FindClass("android/view/Surface"));
+    ASSERT_FALSE(surface_class.is_null());
 
-    // 5. Get constructor Surface(SurfaceTexture surfaceTexture)
     jmethodID surface_ctor = env_->GetMethodID(
-        surface_class, "<init>", "(Landroid/graphics/SurfaceTexture;)V");
+        surface_class.obj(), "<init>", "(Landroid/graphics/SurfaceTexture;)V");
     ASSERT_NE(surface_ctor, nullptr);
 
-    // 6. Create Surface instance
-    jobject surface =
-        env_->NewObject(surface_class, surface_ctor, surface_texture);
-    ASSERT_NE(surface, nullptr);
-
-    real_surface_ = jni_zero::ScopedJavaLocalRef<jobject>(env_, surface);
+    real_surface_ = jni_zero::ScopedJavaLocalRef<jobject>(
+        env_, env_->NewObject(surface_class.obj(), surface_ctor,
+                              surface_texture.obj()));
     ASSERT_FALSE(real_surface_.is_null());
   }
 
   void TearDown() override {
     // Clean up global surface state
-    Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(env_,
-                                                                  nullptr);
+    starboard::SetVideoSurfaceForTesting(env_, nullptr);
   }
 
   JNIEnv* env_ = nullptr;
@@ -90,8 +81,7 @@ class VideoDecoderSurfaceTest : public ::testing::Test {
 
 TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   // 1. Set the global video surface so the decoder can acquire it.
-  Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(
-      env_, real_surface_.obj());
+  starboard::SetVideoSurfaceForTesting(env_, real_surface_.obj());
 
   // 2. Create JobThread for the decoder.
   std::unique_ptr<JobThread> job_thread = JobThread::Create("decoder_thread");
@@ -124,11 +114,11 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   bool init_done = false;
   bool init_success = false;
 
-  job_thread->job_queue()->Schedule([&]() {
+  job_thread->Schedule([&]() {
     auto result = MediaCodecVideoDecoder::CreateForTesting(
         std::move(factory), job_thread->job_queue(), stream_config,
         tunnel_config, pipeline_config, platform_options);
-    std::lock_guard<std::mutex> lock(init_mutex);
+    std::lock_guard lock(init_mutex);
     if (result) {
       decoder = std::move(result.value());
       init_success = true;
@@ -138,7 +128,7 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   });
 
   {
-    std::unique_lock<std::mutex> lock(init_mutex);
+    std::unique_lock lock(init_mutex);
     init_cv.wait(lock, [&] { return init_done; });
   }
   ASSERT_TRUE(init_success);
@@ -150,8 +140,7 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   auto start_time = std::chrono::steady_clock::now();
   std::thread jni_sim_thread([&]() {
     SB_LOG(INFO) << "JNI thread: Calling OnVideoSurfaceChanged(nullptr)...";
-    Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(env_,
-                                                                  nullptr);
+    starboard::SetVideoSurfaceForTesting(env_, nullptr);
     SB_LOG(INFO) << "JNI thread: OnVideoSurfaceChanged returned.";
     jni_thread_done = true;
   });
@@ -160,9 +149,9 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   // We add a small delay to ensure the JNI thread can acquire the lock first,
   // which is necessary to trigger the deadlock on the unpatched code.
   MediaCodecVideoDecoder* raw_decoder = decoder.release();
-  job_thread->job_queue()->Schedule([raw_decoder]() {
+  job_thread->Schedule([raw_decoder]() {
     SB_LOG(INFO) << "Decoder thread: Waiting before destroying...";
-    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    usleep(100'000);
     SB_LOG(INFO) << "Decoder thread: Destroying decoder...";
     delete raw_decoder;
     SB_LOG(INFO) << "Decoder thread: Decoder destroyed.";
@@ -183,6 +172,4 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
 }
 
 }  // namespace
-}  // namespace shared
-}  // namespace android
 }  // namespace starboard

--- a/starboard/android/shared/video_window_test.cc
+++ b/starboard/android/shared/video_window_test.cc
@@ -153,8 +153,6 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
     SB_LOG(INFO) << "Decoder thread: Waiting before destroying...";
     usleep(100'000);
     SB_LOG(INFO) << "Decoder thread: Destroying decoder...";
-    delete raw_decoder;
-    SB_LOG(INFO) << "Decoder thread: Decoder destroyed.";
   });
 
   jni_sim_thread.join();

--- a/starboard/android/shared/video_window_test.cc
+++ b/starboard/android/shared/video_window_test.cc
@@ -38,7 +38,7 @@ namespace android {
 namespace shared {
 namespace {
 
-class OriginalDeadlockTest : public ::testing::Test {
+class VideoDecoderSurfaceTest : public ::testing::Test {
  protected:
   void SetUp() override {
     env_ = jni_zero::AttachCurrentThread();
@@ -88,7 +88,7 @@ class OriginalDeadlockTest : public ::testing::Test {
   jni_zero::ScopedJavaLocalRef<jobject> real_surface_;
 };
 
-TEST_F(OriginalDeadlockTest, VerifyNoDeadlockDuringTeardownAndSurfaceDestroy) {
+TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   // 1. Set the global video surface so the decoder can acquire it.
   Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(
       env_, real_surface_.obj());
@@ -171,7 +171,7 @@ TEST_F(OriginalDeadlockTest, VerifyNoDeadlockDuringTeardownAndSurfaceDestroy) {
   jni_sim_thread.join();
   auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
       std::chrono::steady_clock::now() - start_time);
-  EXPECT_LT(duration.count(), 500);  // Expect less than 500ms (should be ~100ms
+  EXPECT_LT(duration.count(), 800);  // Expect less than 800ms (should be ~100ms
                                      // with fix, 1000ms with deadlock)
 
   SB_LOG(INFO) << "Stopping job thread...";

--- a/starboard/android/shared/video_window_test.cc
+++ b/starboard/android/shared/video_window_test.cc
@@ -1,0 +1,188 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/video_window.h"
+
+#include <jni.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+#include "starboard/android/shared/fake_media_codec.h"
+#include "starboard/android/shared/media_codec_video_decoder.h"
+#include "starboard/common/log.h"
+#include "starboard/shared/starboard/player/job_thread.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/jni_zero/jni_zero.h"
+
+namespace starboard {
+extern "C" void Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(
+    JNIEnv* env,
+    jobject surface);
+}
+
+namespace starboard {
+namespace android {
+namespace shared {
+namespace {
+
+class OriginalDeadlockTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    env_ = jni_zero::AttachCurrentThread();
+    ASSERT_NE(env_, nullptr);
+
+    // Create a real Java Surface to pass to ANativeWindow_fromSurface.
+    // 1. Find SurfaceTexture class
+    jclass surface_texture_class =
+        env_->FindClass("android/graphics/SurfaceTexture");
+    ASSERT_NE(surface_texture_class, nullptr);
+
+    // 2. Get constructor SurfaceTexture(int texName)
+    jmethodID surface_texture_ctor =
+        env_->GetMethodID(surface_texture_class, "<init>", "(I)V");
+    ASSERT_NE(surface_texture_ctor, nullptr);
+
+    // 3. Create SurfaceTexture instance with dummy texture ID 1
+    jobject surface_texture =
+        env_->NewObject(surface_texture_class, surface_texture_ctor, 1);
+    ASSERT_NE(surface_texture, nullptr);
+
+    // 4. Find Surface class
+    jclass surface_class = env_->FindClass("android/view/Surface");
+    ASSERT_NE(surface_class, nullptr);
+
+    // 5. Get constructor Surface(SurfaceTexture surfaceTexture)
+    jmethodID surface_ctor = env_->GetMethodID(
+        surface_class, "<init>", "(Landroid/graphics/SurfaceTexture;)V");
+    ASSERT_NE(surface_ctor, nullptr);
+
+    // 6. Create Surface instance
+    jobject surface =
+        env_->NewObject(surface_class, surface_ctor, surface_texture);
+    ASSERT_NE(surface, nullptr);
+
+    real_surface_ = jni_zero::ScopedJavaLocalRef<jobject>(env_, surface);
+    ASSERT_FALSE(real_surface_.is_null());
+  }
+
+  void TearDown() override {
+    // Clean up global surface state
+    Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(env_,
+                                                                  nullptr);
+  }
+
+  JNIEnv* env_ = nullptr;
+  jni_zero::ScopedJavaLocalRef<jobject> real_surface_;
+};
+
+TEST_F(OriginalDeadlockTest, VerifyNoDeadlockDuringTeardownAndSurfaceDestroy) {
+  // 1. Set the global video surface so the decoder can acquire it.
+  Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(
+      env_, real_surface_.obj());
+
+  // 2. Create JobThread for the decoder.
+  std::unique_ptr<JobThread> job_thread = JobThread::Create("decoder_thread");
+  ASSERT_NE(job_thread, nullptr);
+
+  // 3. Create Decoder Config (punch-out mode, null surface_view to force
+  // acquisition).
+  MediaCodecVideoDecoder::StreamConfig stream_config{
+      []() {
+        VideoStreamInfo info;
+        info.codec = kSbMediaVideoCodecH264;
+        info.frame_size = {1920, 1080};
+        return info;
+      }(),
+      /*drm_system=*/kSbDrmSystemInvalid,
+      kSbPlayerOutputModePunchOut,
+      /*decode_target_graphics_context_provider=*/nullptr,
+      /*surface_view=*/nullptr,
+      /*max_video_capabilities=*/""};
+
+  MediaCodecVideoDecoder::TunnelModeConfig tunnel_config;
+  MediaCodecVideoDecoder::PipelineConfig pipeline_config;
+  MediaCodecVideoDecoder::PlatformOptions platform_options;
+
+  auto factory = std::make_unique<FakeMediaCodecFactory>();
+
+  std::unique_ptr<MediaCodecVideoDecoder> decoder;
+  std::mutex init_mutex;
+  std::condition_variable init_cv;
+  bool init_done = false;
+  bool init_success = false;
+
+  job_thread->job_queue()->Schedule([&]() {
+    auto result = MediaCodecVideoDecoder::CreateForTesting(
+        std::move(factory), job_thread->job_queue(), stream_config,
+        tunnel_config, pipeline_config, platform_options);
+    std::lock_guard<std::mutex> lock(init_mutex);
+    if (result) {
+      decoder = std::move(result.value());
+      init_success = true;
+    }
+    init_done = true;
+    init_cv.notify_all();
+  });
+
+  {
+    std::unique_lock<std::mutex> lock(init_mutex);
+    init_cv.wait(lock, [&] { return init_done; });
+  }
+  ASSERT_TRUE(init_success);
+  ASSERT_NE(decoder, nullptr);
+
+  std::atomic<bool> jni_thread_done{false};
+
+  // Thread A: Simulate JNI thread receiving surface destroyed event.
+  auto start_time = std::chrono::steady_clock::now();
+  std::thread jni_sim_thread([&]() {
+    SB_LOG(INFO) << "JNI thread: Calling OnVideoSurfaceChanged(nullptr)...";
+    Muxed_dev_cobalt_media_VideoSurfaceView_onVideoSurfaceChanged(env_,
+                                                                  nullptr);
+    SB_LOG(INFO) << "JNI thread: OnVideoSurfaceChanged returned.";
+    jni_thread_done = true;
+  });
+
+  // Thread B: Simulate decoder teardown on the decoder thread.
+  // We add a small delay to ensure the JNI thread can acquire the lock first,
+  // which is necessary to trigger the deadlock on the unpatched code.
+  MediaCodecVideoDecoder* raw_decoder = decoder.release();
+  job_thread->job_queue()->Schedule([raw_decoder]() {
+    SB_LOG(INFO) << "Decoder thread: Waiting before destroying...";
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    SB_LOG(INFO) << "Decoder thread: Destroying decoder...";
+    delete raw_decoder;
+    SB_LOG(INFO) << "Decoder thread: Decoder destroyed.";
+  });
+
+  jni_sim_thread.join();
+  auto duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+      std::chrono::steady_clock::now() - start_time);
+  EXPECT_LT(duration.count(), 500);  // Expect less than 500ms (should be ~100ms
+                                     // with fix, 1000ms with deadlock)
+
+  SB_LOG(INFO) << "Stopping job thread...";
+  job_thread->Stop();
+  job_thread.reset();
+  SB_LOG(INFO) << "Job thread stopped.";
+
+  EXPECT_TRUE(jni_thread_done);
+}
+
+}  // namespace
+}  // namespace shared
+}  // namespace android
+}  // namespace starboard


### PR DESCRIPTION
### Summary
This PR addresses a potential deadlock and a Use-After-Free (UAF) risk during Android surface destruction in `MediaCodecVideoDecoder`. It introduces a ref-counted helper object to safely bridge the JNI thread and the decoder thread for synchronous surface destruction notification.

### Problem
*   **Potential Deadlock:** In the original code, `JNI_VideoSurfaceView_OnVideoSurfaceChanged` (JNI thread) held `GetViewSurfaceMutex()` and blocked waiting for the decoder thread. If the decoder thread simultaneously tried to acquire `GetViewSurfaceMutex()` (e.g., during teardown via `ReleaseVideoSurface`), a deadlock occurred.
*   **Use-After-Free Risk:** Simply releasing the lock before calling `OnSurfaceDestroyed()` to fix the deadlock would introduce a UAF risk, as the raw pointer to the holder could be deleted by the player thread before the JNI thread finished using it.

### Solution
Introduce `SurfaceDestroyNotifier`, a thread-safe, ref-counted helper class.

*   The JNI thread can safely acquire a reference to this notifier, release the global lock, and then trigger the notification.
*   The notification itself schedules a task on the decoder thread and waits for completion, satisfying Android's requirement to stop using the surface before returning.
*   If the decoder is destroyed concurrently, it disconnects itself from the notifier, preventing the JNI thread from accessing freed memory.

### Changes

#### `starboard/android/shared/video_window.h`
*   Included `<condition_variable>`, `<mutex>`, and `"starboard/common/ref_counted.h"`.
*   Declared `SurfaceDestroyNotifier` class.
*   Updated `AcquireVideoSurface()` signature to return `scoped_refptr<SurfaceDestroyNotifier>` and accept `JobQueue*` and output `jobject*` parameters.
*   Updated comments to match the new signature.

#### `starboard/android/shared/video_window.cc`
*   Implemented `SurfaceDestroyNotifier::RunTask()` and lifetime methods.
*   Replaced the global raw pointer `g_video_surface_holder` with a global `scoped_refptr<SurfaceDestroyNotifier>` wrapped in a `NoDestructor` helper function to comply with Chromium style guidelines.
*   Updated `JNI_VideoSurfaceView_OnVideoSurfaceChanged` to trigger notification outside `GetViewSurfaceMutex()`.
*   Updated `AcquireVideoSurface` and `ReleaseVideoSurface` to manage the notifier lifecycle.

#### `starboard/android/shared/media_codec_video_decoder.h`
*   Added `surface_destroy_notifier_` member.
*   Removed obsolete `surface_destroy_mutex_`, `surface_condition_variable_`, and `surface_destroyed_` members.

#### `starboard/android/shared/media_codec_video_decoder.cc`
*   Updated `InitializeCodec` to pass `job_queue()` and store the returned notifier.
*   Updated `TeardownCodec` to disconnect the notifier.
*   Simplified `OnSurfaceDestroyed` to just call `TeardownCodec` without internal wait/notify logic.

#### `starboard/android/shared/BUILD.gn`
*   Added `video_window_test.cc` to `starboard_platform_tests` sources.
*   Added direct dependency on `//third_party/jni_zero:jni_zero` to `starboard_platform_tests` to resolve GN header check.

#### `starboard/android/shared/video_window_test.cc` (New File)
*   Added regression test `OriginalDeadlockTest.VerifyNoDeadlockDuringTeardownAndSurfaceDestroy`.
*   Uses an artificial delay to reliably trigger and assert the deadlock on unpatched code, verifying the fix.

Bug: 511329384