### PR TITLE
Prune WebGPU, WebXR, and WebNN to reduce Android binary size

### DIFF
--- a/gpu/command_buffer/service/BUILD.gn
+++ b/gpu/command_buffer/service/BUILD.gn
@@ -399,7 +399,6 @@ target(link_target_type, "gles2_sources") {
     "//third_party/angle:angle_image_util",
     "//third_party/angle:angle_version_info",
     "//third_party/dawn/include/dawn:cpp_headers",
-    "//third_party/dawn/src/dawn:proc",
     "//third_party/libyuv",
     "//third_party/protobuf:protobuf_lite",
     "//third_party/re2",
@@ -412,6 +411,10 @@ target(link_target_type, "gles2_sources") {
     "//ui/gl:buildflags",
     "//ui/gl/init",
   ]
+
+  if (!is_cobalt) {
+    deps += [ "//third_party/dawn/src/dawn:proc" ]
+  }
 
   deps += [ "//third_party/angle:translator" ]
 

--- a/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
+++ b/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
@@ -24,6 +24,22 @@ blink_modules_sources("v8") {
       generated_sync_iterator_sources_in_modules +
       generated_typedef_sources_in_modules + generated_union_sources_in_modules
 
+  if (is_cobalt) {
+    _excludes = [
+      "*v8_canvas_2d_gpu_*",
+      "*v8_gpu.*",
+      "*v8_gpu_*",
+      "*v8_ml.*",
+      "*v8_ml_*",
+      "*v8_xr.*",
+      "*v8_xr_*",
+      "*v8_union_*gpu*",
+    ]
+    _filtered = filter_exclude(sources, _excludes)
+    sources = []
+    sources = _filtered
+  }
+
   deps = [
     ":generated",
     "//third_party/blink/renderer/platform",

--- a/third_party/blink/renderer/modules/BUILD.gn
+++ b/third_party/blink/renderer/modules/BUILD.gn
@@ -42,6 +42,10 @@ component("modules") {
 
   sources += blink_modules_sources_bindings
 
+  if (is_cobalt) {
+    sources += [ "cobalt_modules_stubs.cc" ]
+  }
+
   configs += [
     ":modules_implementation",
 
@@ -172,6 +176,11 @@ component("modules") {
   ]
 
   if (is_cobalt) {
+    sub_modules -= [
+      "//third_party/blink/renderer/modules/ml",
+      "//third_party/blink/renderer/modules/webgpu",
+      "//third_party/blink/renderer/modules/xr",
+    ]
     sub_modules += [
       "//third_party/blink/renderer/modules/cobalt:h_5_vcc",
       "//third_party/blink/renderer/modules/cobalt/crash_log",

--- a/third_party/blink/renderer/modules/canvas/BUILD.gn
+++ b/third_party/blink/renderer/modules/canvas/BUILD.gn
@@ -63,8 +63,10 @@ blink_modules_sources("canvas") {
 
   deps = [
     "//third_party/blink/renderer/modules/webcodecs",
-    "//third_party/blink/renderer/modules/webgpu",
   ]
+  if (!is_cobalt) {
+    deps += [ "//third_party/blink/renderer/modules/webgpu" ]
+  }
   allow_circular_includes_from =
       [ "//third_party/blink/renderer/modules/webcodecs" ]
 }

--- a/third_party/blink/renderer/modules/cobalt_modules_stubs.cc
+++ b/third_party/blink/renderer/modules/cobalt_modules_stubs.cc
@@ -1,0 +1,290 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "third_party/blink/renderer/modules/webgpu/gpu_texture.h"
+#include "third_party/blink/renderer/modules/webgpu/gpu_device.h"
+#include "third_party/blink/renderer/modules/webgpu/dawn_object.h"
+#include "third_party/blink/renderer/modules/webgpu/dawn_enum_conversions.h"
+#include "third_party/blink/renderer/modules/webgpu/gpu.h"
+#include "third_party/blink/renderer/modules/webgpu/wgsl_language_features.h"
+#include "third_party/blink/renderer/modules/webgpu/gpu_supported_features.h"
+#include "third_party/blink/renderer/modules/xr/xr_system.h"
+#include "third_party/blink/renderer/modules/xr/xr_frame_provider.h"
+#include "third_party/blink/renderer/modules/xr/xr_session.h"
+#include "third_party/blink/renderer/modules/ml/navigator_ml.h"
+#include "third_party/blink/renderer/platform/bindings/wrapper_type_info.h"
+#include "third_party/blink/renderer/platform/graphics/gpu/webgpu_mailbox_texture.h"
+#include "third_party/blink/renderer/bindings/modules/v8/v8_canvas_2d_gpu_transfer_option.h"
+#include "third_party/blink/renderer/bindings/modules/v8/v8_gpu_texture_format.h"
+
+namespace blink {
+
+static const WrapperTypeInfo g_dummy_wrapper_type_info = {
+    gin::kEmbedderBlink,
+    nullptr,
+    nullptr,
+    "Dummy",
+    nullptr,
+    v8::CppHeapPointerTag::kDefaultTag,
+    v8::CppHeapPointerTag::kDefaultTag,
+    WrapperTypeInfo::kWrapperTypeObjectPrototype,
+    WrapperTypeInfo::kObjectClassId,
+    WrapperTypeInfo::kIdlInterface,
+    false,
+};
+
+// --- V8 WrapperTypeInfo Stubs ---
+
+#define STUB_V8_WRAPPER(ClassName) \
+  class ClassName { public: static const WrapperTypeInfo wrapper_type_info_; }; \
+  const WrapperTypeInfo ClassName::wrapper_type_info_ = g_dummy_wrapper_type_info;
+
+// WebNN V8 Wrappers
+STUB_V8_WRAPPER(V8ML)
+STUB_V8_WRAPPER(V8MLContext)
+STUB_V8_WRAPPER(V8MLTensor)
+STUB_V8_WRAPPER(V8MLGraph)
+STUB_V8_WRAPPER(V8MLGraphBuilder)
+STUB_V8_WRAPPER(V8MLOperand)
+
+// WebGPU V8 Wrappers
+STUB_V8_WRAPPER(V8GPU)
+STUB_V8_WRAPPER(V8GPUAdapter)
+STUB_V8_WRAPPER(V8GPUAdapterInfo)
+STUB_V8_WRAPPER(V8GPUBindGroup)
+STUB_V8_WRAPPER(V8GPUBindGroupLayout)
+STUB_V8_WRAPPER(V8GPUBuffer)
+STUB_V8_WRAPPER(V8GPUBufferUsage)
+STUB_V8_WRAPPER(V8GPUCanvasContext)
+STUB_V8_WRAPPER(V8GPUColorWrite)
+STUB_V8_WRAPPER(V8GPUCommandBuffer)
+STUB_V8_WRAPPER(V8GPUCommandEncoder)
+STUB_V8_WRAPPER(V8GPUCompilationInfo)
+STUB_V8_WRAPPER(V8GPUCompilationMessage)
+STUB_V8_WRAPPER(V8GPUComputePassEncoder)
+STUB_V8_WRAPPER(V8GPUComputePipeline)
+STUB_V8_WRAPPER(V8GPUDevice)
+STUB_V8_WRAPPER(V8GPUDeviceLostInfo)
+STUB_V8_WRAPPER(V8GPUError)
+STUB_V8_WRAPPER(V8GPUExternalTexture)
+STUB_V8_WRAPPER(V8GPUHeapProperty)
+STUB_V8_WRAPPER(V8GPUInternalError)
+STUB_V8_WRAPPER(V8GPUMapMode)
+STUB_V8_WRAPPER(V8GPUMemoryHeapInfo)
+STUB_V8_WRAPPER(V8GPUOutOfMemoryError)
+STUB_V8_WRAPPER(V8GPUPipelineError)
+STUB_V8_WRAPPER(V8GPUPipelineLayout)
+STUB_V8_WRAPPER(V8GPUQuerySet)
+STUB_V8_WRAPPER(V8GPUQueue)
+STUB_V8_WRAPPER(V8GPURenderBundle)
+STUB_V8_WRAPPER(V8GPURenderBundleEncoder)
+STUB_V8_WRAPPER(V8GPURenderPassEncoder)
+STUB_V8_WRAPPER(V8GPURenderPipeline)
+STUB_V8_WRAPPER(V8GPUSampler)
+STUB_V8_WRAPPER(V8GPUShaderModule)
+STUB_V8_WRAPPER(V8GPUShaderStage)
+STUB_V8_WRAPPER(V8GPUSubgroupMatrixConfig)
+STUB_V8_WRAPPER(V8GPUSupportedFeatures)
+STUB_V8_WRAPPER(V8GPUSupportedLimits)
+STUB_V8_WRAPPER(V8GPUTexture)
+STUB_V8_WRAPPER(V8GPUTextureUsage)
+STUB_V8_WRAPPER(V8GPUTextureView)
+STUB_V8_WRAPPER(V8GPUUncapturedErrorEvent)
+STUB_V8_WRAPPER(V8GPUValidationError)
+
+// WebXR V8 Wrappers
+STUB_V8_WRAPPER(V8XRAnchor)
+STUB_V8_WRAPPER(V8XRAnchorSet)
+STUB_V8_WRAPPER(V8XRBoundedReferenceSpace)
+STUB_V8_WRAPPER(V8XRCamera)
+STUB_V8_WRAPPER(V8XRCompositionLayer)
+STUB_V8_WRAPPER(V8XRCPUDepthInformation)
+STUB_V8_WRAPPER(V8XRDepthInformation)
+STUB_V8_WRAPPER(V8XRDOMOverlayState)
+STUB_V8_WRAPPER(V8XRFrame)
+STUB_V8_WRAPPER(V8XRGPUBinding)
+STUB_V8_WRAPPER(V8XRGPUSubImage)
+STUB_V8_WRAPPER(V8XRHand)
+STUB_V8_WRAPPER(V8XRHitTestResult)
+STUB_V8_WRAPPER(V8XRHitTestSource)
+STUB_V8_WRAPPER(V8XRImageTrackingResult)
+STUB_V8_WRAPPER(V8XRInputSource)
+STUB_V8_WRAPPER(V8XRInputSourceArray)
+STUB_V8_WRAPPER(V8XRInputSourceEvent)
+STUB_V8_WRAPPER(V8XRInputSourcesChangeEvent)
+STUB_V8_WRAPPER(V8XRJointPose)
+STUB_V8_WRAPPER(V8XRJointSpace)
+STUB_V8_WRAPPER(V8XRLayer)
+STUB_V8_WRAPPER(V8XRLightEstimate)
+STUB_V8_WRAPPER(V8XRLightProbe)
+STUB_V8_WRAPPER(V8XRPlane)
+STUB_V8_WRAPPER(V8XRPlaneSet)
+STUB_V8_WRAPPER(V8XRPose)
+STUB_V8_WRAPPER(V8XRProjectionLayer)
+STUB_V8_WRAPPER(V8XRRay)
+STUB_V8_WRAPPER(V8XRReferenceSpace)
+STUB_V8_WRAPPER(V8XRReferenceSpaceEvent)
+STUB_V8_WRAPPER(V8XRRenderState)
+STUB_V8_WRAPPER(V8XRRigidTransform)
+STUB_V8_WRAPPER(V8XRSession)
+STUB_V8_WRAPPER(V8XRSessionEvent)
+STUB_V8_WRAPPER(V8XRSpace)
+STUB_V8_WRAPPER(V8XRSubImage)
+STUB_V8_WRAPPER(V8XRSystem)
+STUB_V8_WRAPPER(V8XRTransientInputHitTestResult)
+STUB_V8_WRAPPER(V8XRTransientInputHitTestSource)
+STUB_V8_WRAPPER(V8XRView)
+STUB_V8_WRAPPER(V8XRViewerPose)
+STUB_V8_WRAPPER(V8XRViewport)
+STUB_V8_WRAPPER(V8XRWebGLBinding)
+STUB_V8_WRAPPER(V8XRWebGLDepthInformation)
+STUB_V8_WRAPPER(V8XRWebGLLayer)
+STUB_V8_WRAPPER(V8XRWebGLSubImage)
+STUB_V8_WRAPPER(V8XRWebGLContext)
+
+// --- WebGPU C++ Stubs ---
+
+const WrapperTypeInfo& GPUTexture::wrapper_type_info_ = g_dummy_wrapper_type_info;
+
+DawnObjectBase::DawnObjectBase(
+    scoped_refptr<DawnControlClientHolder> dawn_control_client,
+    const String& label)
+    : dawn_control_client_(std::move(dawn_control_client)), label_(label) {}
+
+const scoped_refptr<DawnControlClientHolder>&
+DawnObjectBase::GetDawnControlClient() const {
+  return dawn_control_client_;
+}
+
+void DawnObjectBase::setLabel(const String& value) {}
+void DawnObjectBase::EnsureFlush(scheduler::EventLoop& event_loop) {}
+void DawnObjectBase::FlushNow() {}
+
+DawnObjectImpl::DawnObjectImpl(GPUDevice* device, const String& label)
+    : DawnObjectBase(nullptr, label), device_(device) {}
+
+DawnObjectImpl::~DawnObjectImpl() = default;
+
+const wgpu::Device& DawnObjectImpl::GetDeviceHandle() const {
+  return device_->GetHandle();
+}
+
+void DawnObjectImpl::Trace(Visitor* visitor) const {
+  visitor->Trace(device_);
+  ScriptWrappable::Trace(visitor);
+}
+
+void GPUDevice::Trace(Visitor* visitor) const {
+  ScriptWrappable::Trace(visitor);
+}
+
+GPUTexture::GPUTexture(GPUDevice* device,
+                       wgpu::TextureFormat format,
+                       wgpu::TextureUsage usage,
+                       scoped_refptr<WebGPUMailboxTexture> mailbox_texture,
+                       const String& label)
+    : DawnObject<wgpu::Texture>(device, mailbox_texture->GetTexture(), label),
+      dimension_(wgpu::TextureDimension::e2D),
+      format_(format),
+      usage_(usage),
+      mailbox_texture_(std::move(mailbox_texture)) {}
+
+GPUTexture::~GPUTexture() {}
+
+void GPUTexture::destroy() {}
+
+scoped_refptr<WebGPUMailboxTexture> GPUTexture::GetMailboxTexture() {
+  return mailbox_texture_;
+}
+
+void GPUTexture::DissociateMailbox() {}
+
+const char* const V8GPUTextureFormat::string_table_[] = { "r8unorm" };
+
+V8GPUTextureFormat FromDawnEnum(wgpu::TextureFormat dawn_enum) {
+  return V8GPUTextureFormat(V8GPUTextureFormat::Enum::kR8Unorm);
+}
+
+GPU* GPU::gpu(NavigatorBase& navigator) {
+  return nullptr;
+}
+
+bool WGSLLanguageFeatures::hasForBinding(ScriptState* script_state, const String&, ExceptionState&) const {
+  return false;
+}
+
+bool GPUSupportedFeatures::hasForBinding(ScriptState* script_state, const String&, ExceptionState&) const {
+  return false;
+}
+
+// --- WebNN C++ Stubs ---
+
+ML* NavigatorML::ml(NavigatorBase& navigator) {
+  return nullptr;
+}
+
+// --- WebXR C++ Stubs ---
+
+XRSystem* XRSystem::From(Document& document) {
+  return nullptr;
+}
+
+XRSystem* XRSystem::FromIfExists(Document& document) {
+  return nullptr;
+}
+
+XRSystem* XRSystem::xr(Navigator& navigator) {
+  return nullptr;
+}
+
+void XRSystem::MakeXrCompatibleAsync(device::mojom::blink::VRService::MakeXrCompatibleCallback callback) {
+  std::move(callback).Run(device::mojom::blink::XrCompatibleResult::kNoDeviceAvailable);
+}
+
+XRFrameProvider* XRSystem::frameProvider() {
+  return nullptr;
+}
+
+void XRFrameProvider::AddImmersiveSessionObserver(ImmersiveSessionObserver* observer) {}
+
+void XRSession::ScheduleVideoFrameCallbacksExecution(ExecuteVfcCallback callback) {}
+
+// --- Canvas 2D GPU Transfer Stubs ---
+
+Canvas2dGPUTransferOption::Canvas2dGPUTransferOption(v8::Isolate* isolate) {}
+
+void Canvas2dGPUTransferOption::Trace(Visitor* visitor) const {
+  visitor->Trace(member_device_);
+  bindings::InputDictionaryBase::Trace(visitor);
+}
+
+Canvas2dGPUTransferOption* Canvas2dGPUTransferOption::Create(v8::Isolate* isolate, v8::Local<v8::Value> v8_value, ExceptionState& exception_state) {
+  return MakeGarbageCollected<Canvas2dGPUTransferOption>(isolate);
+}
+
+String Canvas2dGPUTransferOption::getLabelOr(const String& fallback_value) const {
+  if (!hasLabel()) {
+    return fallback_value;
+  }
+  return label();
+}
+
+String Canvas2dGPUTransferOption::getLabelOr(String&& fallback_value) const {
+  if (!hasLabel()) {
+    return fallback_value;
+  }
+  return label();
+}
+
+}  // namespace blink

--- a/third_party/blink/renderer/modules/modules_initializer.cc
+++ b/third_party/blink/renderer/modules/modules_initializer.cc
@@ -96,7 +96,9 @@
 #include "third_party/blink/renderer/modules/webaudio/inspector_web_audio_agent.h"
 #include "third_party/blink/renderer/modules/webgl/webgl_context_factory.h"
 #include "third_party/blink/renderer/modules/webgl/webgl_rendering_context.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "third_party/blink/renderer/modules/webgpu/gpu_canvas_context.h"
+#endif
 #include "third_party/blink/renderer/modules/worklet/animation_and_paint_worklet_thread.h"
 #include "third_party/blink/renderer/platform/heap/garbage_collected.h"
 #include "third_party/blink/renderer/platform/heap/persistent.h"
@@ -212,8 +214,10 @@ void ModulesInitializer::Initialize() {
       WebGLContextFactory::MakeWebGL2());
   HTMLCanvasElement::RegisterRenderingContextFactory(
       std::make_unique<ImageBitmapRenderingContext::Factory>());
+#if !BUILDFLAG(IS_COBALT)
   HTMLCanvasElement::RegisterRenderingContextFactory(
       std::make_unique<GPUCanvasContext::Factory>());
+#endif
 
   // OffscreenCanvas context types must be registered with the OffscreenCanvas.
   OffscreenCanvas::RegisterRenderingContextFactory(
@@ -224,8 +228,10 @@ void ModulesInitializer::Initialize() {
       WebGLContextFactory::MakeWebGL2());
   OffscreenCanvas::RegisterRenderingContextFactory(
       std::make_unique<ImageBitmapRenderingContext::Factory>());
+#if !BUILDFLAG(IS_COBALT)
   OffscreenCanvas::RegisterRenderingContextFactory(
       std::make_unique<GPUCanvasContext::Factory>());
+#endif
 
   V8PerIsolateData::SetTaskAttributionTrackerFactory(
       &scheduler::TaskAttributionTrackerImpl::Create);

--- a/third_party/blink/renderer/modules/video_rvfc/BUILD.gn
+++ b/third_party/blink/renderer/modules/video_rvfc/BUILD.gn
@@ -12,5 +12,8 @@ blink_modules_sources("video_rvfc") {
     "video_frame_request_callback_collection.h",
   ]
 
-  deps = [ "//third_party/blink/renderer/modules/xr:xr" ]
+  deps = []
+  if (!is_cobalt) {
+    deps += [ "//third_party/blink/renderer/modules/xr:xr" ]
+  }
 }

--- a/third_party/blink/renderer/modules/webgl/BUILD.gn
+++ b/third_party/blink/renderer/modules/webgl/BUILD.gn
@@ -196,7 +196,9 @@ blink_modules_sources("webgl") {
   deps = [
     "//device/vr/buildflags:buildflags",
     "//third_party/blink/renderer/modules/webcodecs:webcodecs",
-    "//third_party/blink/renderer/modules/xr:xr",
   ]
+  if (!is_cobalt) {
+    deps += [ "//third_party/blink/renderer/modules/xr:xr" ]
+  }
   allow_circular_includes_from = deps
 }

--- a/third_party/blink/renderer/modules/webgpu/BUILD.gn
+++ b/third_party/blink/renderer/modules/webgpu/BUILD.gn
@@ -115,7 +115,7 @@ blink_modules_sources("webgpu") {
 
   if (use_dawn) {
     deps += [ "//third_party/dawn/src/dawn/wire" ]
-  } else {
+  } else if (!is_cobalt) {
     # If Dawn is not used, use the proc table. This gives the WebGPU implementation
     # something to link to, though WebGPU won't be supported.
     deps += [ "//third_party/dawn/src/dawn:proc" ]

--- a/third_party/blink/renderer/platform/BUILD.gn
+++ b/third_party/blink/renderer/platform/BUILD.gn
@@ -1858,10 +1858,12 @@ component("platform") {
 
   if (use_dawn) {
     deps += [ "//third_party/dawn/src/dawn/wire" ]
-  } else {
+  } else if (!is_cobalt) {
     # If Dawn is not used, use the proc table. This gives the WebGPU implementation
     # something to link to, though WebGPU won't be supported.
     deps += [ "//third_party/dawn/src/dawn:proc" ]
+  } else {
+    sources += [ "graphics/gpu/cobalt_webgpu_stubs.cc" ]
   }
 
   if (is_android) {

--- a/third_party/blink/renderer/platform/graphics/gpu/cobalt_webgpu_stubs.cc
+++ b/third_party/blink/renderer/platform/graphics/gpu/cobalt_webgpu_stubs.cc
@@ -1,0 +1,1071 @@
+
+#include "dawn/dawn_proc.h"
+
+// The sanitizer is disabled for calls to procs.* since those functions may be
+// dynamically loaded.
+#ifndef DAWN_NO_SANITIZE
+#define DAWN_NO_SANITIZE(x)
+#endif
+
+// A fake wgpuCreateInstance that prints a warning so folks know that they are using dawn_procs and
+// should either use a different target to link against, or call dawnProcSetProcs.
+WGPUInstance CreateInstanceThatWarns(const WGPUInstanceDescriptor* desc) {
+    return nullptr;
+}
+
+constexpr DawnProcTable MakeNullProcTable() {
+    DawnProcTable procs = {};
+    procs.createInstance = CreateInstanceThatWarns;
+    return procs;
+}
+
+static DawnProcTable kNullProcs = MakeNullProcTable();
+static DawnProcTable procs = MakeNullProcTable();
+
+void dawnProcSetProcs(const DawnProcTable* procs_) {
+    if (procs_) {
+        procs = *procs_;
+    } else {
+        procs = kNullProcs;
+    }
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuAdapterInfoFreeMembers(WGPUAdapterInfo value) {
+    procs.adapterInfoFreeMembers(value);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuAdapterPropertiesMemoryHeapsFreeMembers(WGPUAdapterPropertiesMemoryHeaps value) {
+    procs.adapterPropertiesMemoryHeapsFreeMembers(value);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuAdapterPropertiesSubgroupMatrixConfigsFreeMembers(WGPUAdapterPropertiesSubgroupMatrixConfigs value) {
+    procs.adapterPropertiesSubgroupMatrixConfigsFreeMembers(value);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUInstance wgpuCreateInstance(WGPUInstanceDescriptor const * descriptor) {
+return     procs.createInstance(descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDawnDrmFormatCapabilitiesFreeMembers(WGPUDawnDrmFormatCapabilities value) {
+    procs.dawnDrmFormatCapabilitiesFreeMembers(value);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuGetInstanceCapabilities(WGPUInstanceCapabilities * capabilities) {
+return     procs.getInstanceCapabilities(capabilities);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUProc wgpuGetProcAddress(WGPUStringView procName) {
+return     procs.getProcAddress(procName);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedBufferMemoryEndAccessStateFreeMembers(WGPUSharedBufferMemoryEndAccessState value) {
+    procs.sharedBufferMemoryEndAccessStateFreeMembers(value);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedTextureMemoryEndAccessStateFreeMembers(WGPUSharedTextureMemoryEndAccessState value) {
+    procs.sharedTextureMemoryEndAccessStateFreeMembers(value);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSupportedFeaturesFreeMembers(WGPUSupportedFeatures value) {
+    procs.supportedFeaturesFreeMembers(value);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSupportedWGSLLanguageFeaturesFreeMembers(WGPUSupportedWGSLLanguageFeatures value) {
+    procs.supportedWGSLLanguageFeaturesFreeMembers(value);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSurfaceCapabilitiesFreeMembers(WGPUSurfaceCapabilities value) {
+    procs.surfaceCapabilitiesFreeMembers(value);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUDevice wgpuAdapterCreateDevice(WGPUAdapter adapter, WGPUDeviceDescriptor const * descriptor) {
+return     procs.adapterCreateDevice(adapter, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuAdapterGetFeatures(WGPUAdapter adapter, WGPUSupportedFeatures * features) {
+    procs.adapterGetFeatures(adapter, features);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuAdapterGetFormatCapabilities(WGPUAdapter adapter, WGPUTextureFormat format, WGPUDawnFormatCapabilities * capabilities) {
+return     procs.adapterGetFormatCapabilities(adapter, format, capabilities);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuAdapterGetInfo(WGPUAdapter adapter, WGPUAdapterInfo * info) {
+return     procs.adapterGetInfo(adapter, info);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUInstance wgpuAdapterGetInstance(WGPUAdapter adapter) {
+return     procs.adapterGetInstance(adapter);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuAdapterGetLimits(WGPUAdapter adapter, WGPULimits * limits) {
+return     procs.adapterGetLimits(adapter, limits);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBool wgpuAdapterHasFeature(WGPUAdapter adapter, WGPUFeatureName feature) {
+return     procs.adapterHasFeature(adapter, feature);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuAdapterRequestDevice(WGPUAdapter adapter, WGPUDeviceDescriptor const * options, WGPURequestDeviceCallbackInfo callbackInfo) {
+return     procs.adapterRequestDevice(adapter, options, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuAdapterAddRef(WGPUAdapter adapter) {
+    procs.adapterAddRef(adapter);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuAdapterRelease(WGPUAdapter adapter) {
+    procs.adapterRelease(adapter);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBindGroupSetLabel(WGPUBindGroup bindGroup, WGPUStringView label) {
+    procs.bindGroupSetLabel(bindGroup, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBindGroupAddRef(WGPUBindGroup bindGroup) {
+    procs.bindGroupAddRef(bindGroup);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBindGroupRelease(WGPUBindGroup bindGroup) {
+    procs.bindGroupRelease(bindGroup);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBindGroupLayoutSetLabel(WGPUBindGroupLayout bindGroupLayout, WGPUStringView label) {
+    procs.bindGroupLayoutSetLabel(bindGroupLayout, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBindGroupLayoutAddRef(WGPUBindGroupLayout bindGroupLayout) {
+    procs.bindGroupLayoutAddRef(bindGroupLayout);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBindGroupLayoutRelease(WGPUBindGroupLayout bindGroupLayout) {
+    procs.bindGroupLayoutRelease(bindGroupLayout);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBufferDestroy(WGPUBuffer buffer) {
+    procs.bufferDestroy(buffer);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void const * wgpuBufferGetConstMappedRange(WGPUBuffer buffer, size_t offset, size_t size) {
+return     procs.bufferGetConstMappedRange(buffer, offset, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void * wgpuBufferGetMappedRange(WGPUBuffer buffer, size_t offset, size_t size) {
+return     procs.bufferGetMappedRange(buffer, offset, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBufferMapState wgpuBufferGetMapState(WGPUBuffer buffer) {
+return     procs.bufferGetMapState(buffer);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+uint64_t wgpuBufferGetSize(WGPUBuffer buffer) {
+return     procs.bufferGetSize(buffer);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBufferUsage wgpuBufferGetUsage(WGPUBuffer buffer) {
+return     procs.bufferGetUsage(buffer);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuBufferMapAsync(WGPUBuffer buffer, WGPUMapMode mode, size_t offset, size_t size, WGPUBufferMapCallbackInfo callbackInfo) {
+return     procs.bufferMapAsync(buffer, mode, offset, size, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuBufferReadMappedRange(WGPUBuffer buffer, size_t offset, void * data, size_t size) {
+return     procs.bufferReadMappedRange(buffer, offset, data, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBufferSetLabel(WGPUBuffer buffer, WGPUStringView label) {
+    procs.bufferSetLabel(buffer, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBufferUnmap(WGPUBuffer buffer) {
+    procs.bufferUnmap(buffer);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuBufferWriteMappedRange(WGPUBuffer buffer, size_t offset, void const * data, size_t size) {
+return     procs.bufferWriteMappedRange(buffer, offset, data, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBufferAddRef(WGPUBuffer buffer) {
+    procs.bufferAddRef(buffer);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuBufferRelease(WGPUBuffer buffer) {
+    procs.bufferRelease(buffer);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandBufferSetLabel(WGPUCommandBuffer commandBuffer, WGPUStringView label) {
+    procs.commandBufferSetLabel(commandBuffer, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandBufferAddRef(WGPUCommandBuffer commandBuffer) {
+    procs.commandBufferAddRef(commandBuffer);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandBufferRelease(WGPUCommandBuffer commandBuffer) {
+    procs.commandBufferRelease(commandBuffer);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUComputePassEncoder wgpuCommandEncoderBeginComputePass(WGPUCommandEncoder commandEncoder, WGPUComputePassDescriptor const * descriptor) {
+return     procs.commandEncoderBeginComputePass(commandEncoder, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPURenderPassEncoder wgpuCommandEncoderBeginRenderPass(WGPUCommandEncoder commandEncoder, WGPURenderPassDescriptor const * descriptor) {
+return     procs.commandEncoderBeginRenderPass(commandEncoder, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderClearBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t offset, uint64_t size) {
+    procs.commandEncoderClearBuffer(commandEncoder, buffer, offset, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderCopyBufferToBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer source, uint64_t sourceOffset, WGPUBuffer destination, uint64_t destinationOffset, uint64_t size) {
+    procs.commandEncoderCopyBufferToBuffer(commandEncoder, source, sourceOffset, destination, destinationOffset, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderCopyBufferToTexture(WGPUCommandEncoder commandEncoder, WGPUTexelCopyBufferInfo const * source, WGPUTexelCopyTextureInfo const * destination, WGPUExtent3D const * copySize) {
+    procs.commandEncoderCopyBufferToTexture(commandEncoder, source, destination, copySize);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderCopyTextureToBuffer(WGPUCommandEncoder commandEncoder, WGPUTexelCopyTextureInfo const * source, WGPUTexelCopyBufferInfo const * destination, WGPUExtent3D const * copySize) {
+    procs.commandEncoderCopyTextureToBuffer(commandEncoder, source, destination, copySize);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderCopyTextureToTexture(WGPUCommandEncoder commandEncoder, WGPUTexelCopyTextureInfo const * source, WGPUTexelCopyTextureInfo const * destination, WGPUExtent3D const * copySize) {
+    procs.commandEncoderCopyTextureToTexture(commandEncoder, source, destination, copySize);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUCommandBuffer wgpuCommandEncoderFinish(WGPUCommandEncoder commandEncoder, WGPUCommandBufferDescriptor const * descriptor) {
+return     procs.commandEncoderFinish(commandEncoder, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderInjectValidationError(WGPUCommandEncoder commandEncoder, WGPUStringView message) {
+    procs.commandEncoderInjectValidationError(commandEncoder, message);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderInsertDebugMarker(WGPUCommandEncoder commandEncoder, WGPUStringView markerLabel) {
+    procs.commandEncoderInsertDebugMarker(commandEncoder, markerLabel);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderPopDebugGroup(WGPUCommandEncoder commandEncoder) {
+    procs.commandEncoderPopDebugGroup(commandEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderPushDebugGroup(WGPUCommandEncoder commandEncoder, WGPUStringView groupLabel) {
+    procs.commandEncoderPushDebugGroup(commandEncoder, groupLabel);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderResolveQuerySet(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t firstQuery, uint32_t queryCount, WGPUBuffer destination, uint64_t destinationOffset) {
+    procs.commandEncoderResolveQuerySet(commandEncoder, querySet, firstQuery, queryCount, destination, destinationOffset);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderSetLabel(WGPUCommandEncoder commandEncoder, WGPUStringView label) {
+    procs.commandEncoderSetLabel(commandEncoder, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderWriteBuffer(WGPUCommandEncoder commandEncoder, WGPUBuffer buffer, uint64_t bufferOffset, uint8_t const * data, uint64_t size) {
+    procs.commandEncoderWriteBuffer(commandEncoder, buffer, bufferOffset, data, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderWriteTimestamp(WGPUCommandEncoder commandEncoder, WGPUQuerySet querySet, uint32_t queryIndex) {
+    procs.commandEncoderWriteTimestamp(commandEncoder, querySet, queryIndex);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderAddRef(WGPUCommandEncoder commandEncoder) {
+    procs.commandEncoderAddRef(commandEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuCommandEncoderRelease(WGPUCommandEncoder commandEncoder) {
+    procs.commandEncoderRelease(commandEncoder);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderDispatchWorkgroups(WGPUComputePassEncoder computePassEncoder, uint32_t workgroupCountX, uint32_t workgroupCountY, uint32_t workgroupCountZ) {
+    procs.computePassEncoderDispatchWorkgroups(computePassEncoder, workgroupCountX, workgroupCountY, workgroupCountZ);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderDispatchWorkgroupsIndirect(WGPUComputePassEncoder computePassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) {
+    procs.computePassEncoderDispatchWorkgroupsIndirect(computePassEncoder, indirectBuffer, indirectOffset);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderEnd(WGPUComputePassEncoder computePassEncoder) {
+    procs.computePassEncoderEnd(computePassEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderInsertDebugMarker(WGPUComputePassEncoder computePassEncoder, WGPUStringView markerLabel) {
+    procs.computePassEncoderInsertDebugMarker(computePassEncoder, markerLabel);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderPopDebugGroup(WGPUComputePassEncoder computePassEncoder) {
+    procs.computePassEncoderPopDebugGroup(computePassEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderPushDebugGroup(WGPUComputePassEncoder computePassEncoder, WGPUStringView groupLabel) {
+    procs.computePassEncoderPushDebugGroup(computePassEncoder, groupLabel);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderSetBindGroup(WGPUComputePassEncoder computePassEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) {
+    procs.computePassEncoderSetBindGroup(computePassEncoder, groupIndex, group, dynamicOffsetCount, dynamicOffsets);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderSetImmediateData(WGPUComputePassEncoder computePassEncoder, uint32_t offset, void const * data, size_t size) {
+    procs.computePassEncoderSetImmediateData(computePassEncoder, offset, data, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderSetLabel(WGPUComputePassEncoder computePassEncoder, WGPUStringView label) {
+    procs.computePassEncoderSetLabel(computePassEncoder, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderSetPipeline(WGPUComputePassEncoder computePassEncoder, WGPUComputePipeline pipeline) {
+    procs.computePassEncoderSetPipeline(computePassEncoder, pipeline);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderWriteTimestamp(WGPUComputePassEncoder computePassEncoder, WGPUQuerySet querySet, uint32_t queryIndex) {
+    procs.computePassEncoderWriteTimestamp(computePassEncoder, querySet, queryIndex);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderAddRef(WGPUComputePassEncoder computePassEncoder) {
+    procs.computePassEncoderAddRef(computePassEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePassEncoderRelease(WGPUComputePassEncoder computePassEncoder) {
+    procs.computePassEncoderRelease(computePassEncoder);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBindGroupLayout wgpuComputePipelineGetBindGroupLayout(WGPUComputePipeline computePipeline, uint32_t groupIndex) {
+return     procs.computePipelineGetBindGroupLayout(computePipeline, groupIndex);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePipelineSetLabel(WGPUComputePipeline computePipeline, WGPUStringView label) {
+    procs.computePipelineSetLabel(computePipeline, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePipelineAddRef(WGPUComputePipeline computePipeline) {
+    procs.computePipelineAddRef(computePipeline);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuComputePipelineRelease(WGPUComputePipeline computePipeline) {
+    procs.computePipelineRelease(computePipeline);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBindGroup wgpuDeviceCreateBindGroup(WGPUDevice device, WGPUBindGroupDescriptor const * descriptor) {
+return     procs.deviceCreateBindGroup(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBindGroupLayout wgpuDeviceCreateBindGroupLayout(WGPUDevice device, WGPUBindGroupLayoutDescriptor const * descriptor) {
+return     procs.deviceCreateBindGroupLayout(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBuffer wgpuDeviceCreateBuffer(WGPUDevice device, WGPUBufferDescriptor const * descriptor) {
+return     procs.deviceCreateBuffer(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUCommandEncoder wgpuDeviceCreateCommandEncoder(WGPUDevice device, WGPUCommandEncoderDescriptor const * descriptor) {
+return     procs.deviceCreateCommandEncoder(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUComputePipeline wgpuDeviceCreateComputePipeline(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor) {
+return     procs.deviceCreateComputePipeline(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuDeviceCreateComputePipelineAsync(WGPUDevice device, WGPUComputePipelineDescriptor const * descriptor, WGPUCreateComputePipelineAsyncCallbackInfo callbackInfo) {
+return     procs.deviceCreateComputePipelineAsync(device, descriptor, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBuffer wgpuDeviceCreateErrorBuffer(WGPUDevice device, WGPUBufferDescriptor const * descriptor) {
+return     procs.deviceCreateErrorBuffer(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUExternalTexture wgpuDeviceCreateErrorExternalTexture(WGPUDevice device) {
+return     procs.deviceCreateErrorExternalTexture(device);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUShaderModule wgpuDeviceCreateErrorShaderModule(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor, WGPUStringView errorMessage) {
+return     procs.deviceCreateErrorShaderModule(device, descriptor, errorMessage);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUTexture wgpuDeviceCreateErrorTexture(WGPUDevice device, WGPUTextureDescriptor const * descriptor) {
+return     procs.deviceCreateErrorTexture(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUExternalTexture wgpuDeviceCreateExternalTexture(WGPUDevice device, WGPUExternalTextureDescriptor const * externalTextureDescriptor) {
+return     procs.deviceCreateExternalTexture(device, externalTextureDescriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUPipelineLayout wgpuDeviceCreatePipelineLayout(WGPUDevice device, WGPUPipelineLayoutDescriptor const * descriptor) {
+return     procs.deviceCreatePipelineLayout(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUQuerySet wgpuDeviceCreateQuerySet(WGPUDevice device, WGPUQuerySetDescriptor const * descriptor) {
+return     procs.deviceCreateQuerySet(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPURenderBundleEncoder wgpuDeviceCreateRenderBundleEncoder(WGPUDevice device, WGPURenderBundleEncoderDescriptor const * descriptor) {
+return     procs.deviceCreateRenderBundleEncoder(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPURenderPipeline wgpuDeviceCreateRenderPipeline(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor) {
+return     procs.deviceCreateRenderPipeline(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuDeviceCreateRenderPipelineAsync(WGPUDevice device, WGPURenderPipelineDescriptor const * descriptor, WGPUCreateRenderPipelineAsyncCallbackInfo callbackInfo) {
+return     procs.deviceCreateRenderPipelineAsync(device, descriptor, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUSampler wgpuDeviceCreateSampler(WGPUDevice device, WGPUSamplerDescriptor const * descriptor) {
+return     procs.deviceCreateSampler(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUShaderModule wgpuDeviceCreateShaderModule(WGPUDevice device, WGPUShaderModuleDescriptor const * descriptor) {
+return     procs.deviceCreateShaderModule(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUTexture wgpuDeviceCreateTexture(WGPUDevice device, WGPUTextureDescriptor const * descriptor) {
+return     procs.deviceCreateTexture(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceDestroy(WGPUDevice device) {
+    procs.deviceDestroy(device);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceForceLoss(WGPUDevice device, WGPUDeviceLostReason type, WGPUStringView message) {
+    procs.deviceForceLoss(device, type, message);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUAdapter wgpuDeviceGetAdapter(WGPUDevice device) {
+return     procs.deviceGetAdapter(device);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuDeviceGetAdapterInfo(WGPUDevice device, WGPUAdapterInfo * adapterInfo) {
+return     procs.deviceGetAdapterInfo(device, adapterInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuDeviceGetAHardwareBufferProperties(WGPUDevice device, void * handle, WGPUAHardwareBufferProperties * properties) {
+return     procs.deviceGetAHardwareBufferProperties(device, handle, properties);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceGetFeatures(WGPUDevice device, WGPUSupportedFeatures * features) {
+    procs.deviceGetFeatures(device, features);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuDeviceGetLimits(WGPUDevice device, WGPULimits * limits) {
+return     procs.deviceGetLimits(device, limits);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuDeviceGetLostFuture(WGPUDevice device) {
+return     procs.deviceGetLostFuture(device);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUQueue wgpuDeviceGetQueue(WGPUDevice device) {
+return     procs.deviceGetQueue(device);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBool wgpuDeviceHasFeature(WGPUDevice device, WGPUFeatureName feature) {
+return     procs.deviceHasFeature(device, feature);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUSharedBufferMemory wgpuDeviceImportSharedBufferMemory(WGPUDevice device, WGPUSharedBufferMemoryDescriptor const * descriptor) {
+return     procs.deviceImportSharedBufferMemory(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUSharedFence wgpuDeviceImportSharedFence(WGPUDevice device, WGPUSharedFenceDescriptor const * descriptor) {
+return     procs.deviceImportSharedFence(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUSharedTextureMemory wgpuDeviceImportSharedTextureMemory(WGPUDevice device, WGPUSharedTextureMemoryDescriptor const * descriptor) {
+return     procs.deviceImportSharedTextureMemory(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceInjectError(WGPUDevice device, WGPUErrorType type, WGPUStringView message) {
+    procs.deviceInjectError(device, type, message);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuDevicePopErrorScope(WGPUDevice device, WGPUPopErrorScopeCallbackInfo callbackInfo) {
+return     procs.devicePopErrorScope(device, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDevicePushErrorScope(WGPUDevice device, WGPUErrorFilter filter) {
+    procs.devicePushErrorScope(device, filter);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceSetLabel(WGPUDevice device, WGPUStringView label) {
+    procs.deviceSetLabel(device, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceSetLoggingCallback(WGPUDevice device, WGPULoggingCallbackInfo callbackInfo) {
+    procs.deviceSetLoggingCallback(device, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceTick(WGPUDevice device) {
+    procs.deviceTick(device);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceValidateTextureDescriptor(WGPUDevice device, WGPUTextureDescriptor const * descriptor) {
+    procs.deviceValidateTextureDescriptor(device, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceAddRef(WGPUDevice device) {
+    procs.deviceAddRef(device);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuDeviceRelease(WGPUDevice device) {
+    procs.deviceRelease(device);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuExternalTextureDestroy(WGPUExternalTexture externalTexture) {
+    procs.externalTextureDestroy(externalTexture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuExternalTextureExpire(WGPUExternalTexture externalTexture) {
+    procs.externalTextureExpire(externalTexture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuExternalTextureRefresh(WGPUExternalTexture externalTexture) {
+    procs.externalTextureRefresh(externalTexture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuExternalTextureSetLabel(WGPUExternalTexture externalTexture, WGPUStringView label) {
+    procs.externalTextureSetLabel(externalTexture, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuExternalTextureAddRef(WGPUExternalTexture externalTexture) {
+    procs.externalTextureAddRef(externalTexture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuExternalTextureRelease(WGPUExternalTexture externalTexture) {
+    procs.externalTextureRelease(externalTexture);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUSurface wgpuInstanceCreateSurface(WGPUInstance instance, WGPUSurfaceDescriptor const * descriptor) {
+return     procs.instanceCreateSurface(instance, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuInstanceGetWGSLLanguageFeatures(WGPUInstance instance, WGPUSupportedWGSLLanguageFeatures * features) {
+return     procs.instanceGetWGSLLanguageFeatures(instance, features);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBool wgpuInstanceHasWGSLLanguageFeature(WGPUInstance instance, WGPUWGSLLanguageFeatureName feature) {
+return     procs.instanceHasWGSLLanguageFeature(instance, feature);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuInstanceProcessEvents(WGPUInstance instance) {
+    procs.instanceProcessEvents(instance);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuInstanceRequestAdapter(WGPUInstance instance, WGPURequestAdapterOptions const * options, WGPURequestAdapterCallbackInfo callbackInfo) {
+return     procs.instanceRequestAdapter(instance, options, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUWaitStatus wgpuInstanceWaitAny(WGPUInstance instance, size_t futureCount, WGPUFutureWaitInfo * futures, uint64_t timeoutNS) {
+return     procs.instanceWaitAny(instance, futureCount, futures, timeoutNS);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuInstanceAddRef(WGPUInstance instance) {
+    procs.instanceAddRef(instance);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuInstanceRelease(WGPUInstance instance) {
+    procs.instanceRelease(instance);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuPipelineLayoutSetLabel(WGPUPipelineLayout pipelineLayout, WGPUStringView label) {
+    procs.pipelineLayoutSetLabel(pipelineLayout, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuPipelineLayoutAddRef(WGPUPipelineLayout pipelineLayout) {
+    procs.pipelineLayoutAddRef(pipelineLayout);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuPipelineLayoutRelease(WGPUPipelineLayout pipelineLayout) {
+    procs.pipelineLayoutRelease(pipelineLayout);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQuerySetDestroy(WGPUQuerySet querySet) {
+    procs.querySetDestroy(querySet);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+uint32_t wgpuQuerySetGetCount(WGPUQuerySet querySet) {
+return     procs.querySetGetCount(querySet);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUQueryType wgpuQuerySetGetType(WGPUQuerySet querySet) {
+return     procs.querySetGetType(querySet);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQuerySetSetLabel(WGPUQuerySet querySet, WGPUStringView label) {
+    procs.querySetSetLabel(querySet, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQuerySetAddRef(WGPUQuerySet querySet) {
+    procs.querySetAddRef(querySet);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQuerySetRelease(WGPUQuerySet querySet) {
+    procs.querySetRelease(querySet);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQueueCopyExternalTextureForBrowser(WGPUQueue queue, WGPUImageCopyExternalTexture const * source, WGPUTexelCopyTextureInfo const * destination, WGPUExtent3D const * copySize, WGPUCopyTextureForBrowserOptions const * options) {
+    procs.queueCopyExternalTextureForBrowser(queue, source, destination, copySize, options);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQueueCopyTextureForBrowser(WGPUQueue queue, WGPUTexelCopyTextureInfo const * source, WGPUTexelCopyTextureInfo const * destination, WGPUExtent3D const * copySize, WGPUCopyTextureForBrowserOptions const * options) {
+    procs.queueCopyTextureForBrowser(queue, source, destination, copySize, options);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuQueueOnSubmittedWorkDone(WGPUQueue queue, WGPUQueueWorkDoneCallbackInfo callbackInfo) {
+return     procs.queueOnSubmittedWorkDone(queue, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQueueSetLabel(WGPUQueue queue, WGPUStringView label) {
+    procs.queueSetLabel(queue, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQueueSubmit(WGPUQueue queue, size_t commandCount, WGPUCommandBuffer const * commands) {
+    procs.queueSubmit(queue, commandCount, commands);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQueueWriteBuffer(WGPUQueue queue, WGPUBuffer buffer, uint64_t bufferOffset, void const * data, size_t size) {
+    procs.queueWriteBuffer(queue, buffer, bufferOffset, data, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQueueWriteTexture(WGPUQueue queue, WGPUTexelCopyTextureInfo const * destination, void const * data, size_t dataSize, WGPUTexelCopyBufferLayout const * dataLayout, WGPUExtent3D const * writeSize) {
+    procs.queueWriteTexture(queue, destination, data, dataSize, dataLayout, writeSize);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQueueAddRef(WGPUQueue queue) {
+    procs.queueAddRef(queue);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuQueueRelease(WGPUQueue queue) {
+    procs.queueRelease(queue);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleSetLabel(WGPURenderBundle renderBundle, WGPUStringView label) {
+    procs.renderBundleSetLabel(renderBundle, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleAddRef(WGPURenderBundle renderBundle) {
+    procs.renderBundleAddRef(renderBundle);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleRelease(WGPURenderBundle renderBundle) {
+    procs.renderBundleRelease(renderBundle);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderDraw(WGPURenderBundleEncoder renderBundleEncoder, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance) {
+    procs.renderBundleEncoderDraw(renderBundleEncoder, vertexCount, instanceCount, firstVertex, firstInstance);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderDrawIndexed(WGPURenderBundleEncoder renderBundleEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance) {
+    procs.renderBundleEncoderDrawIndexed(renderBundleEncoder, indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderDrawIndexedIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) {
+    procs.renderBundleEncoderDrawIndexedIndirect(renderBundleEncoder, indirectBuffer, indirectOffset);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderDrawIndirect(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) {
+    procs.renderBundleEncoderDrawIndirect(renderBundleEncoder, indirectBuffer, indirectOffset);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPURenderBundle wgpuRenderBundleEncoderFinish(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderBundleDescriptor const * descriptor) {
+return     procs.renderBundleEncoderFinish(renderBundleEncoder, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderInsertDebugMarker(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView markerLabel) {
+    procs.renderBundleEncoderInsertDebugMarker(renderBundleEncoder, markerLabel);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderPopDebugGroup(WGPURenderBundleEncoder renderBundleEncoder) {
+    procs.renderBundleEncoderPopDebugGroup(renderBundleEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderPushDebugGroup(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView groupLabel) {
+    procs.renderBundleEncoderPushDebugGroup(renderBundleEncoder, groupLabel);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderSetBindGroup(WGPURenderBundleEncoder renderBundleEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) {
+    procs.renderBundleEncoderSetBindGroup(renderBundleEncoder, groupIndex, group, dynamicOffsetCount, dynamicOffsets);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderSetImmediateData(WGPURenderBundleEncoder renderBundleEncoder, uint32_t offset, void const * data, size_t size) {
+    procs.renderBundleEncoderSetImmediateData(renderBundleEncoder, offset, data, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderSetIndexBuffer(WGPURenderBundleEncoder renderBundleEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) {
+    procs.renderBundleEncoderSetIndexBuffer(renderBundleEncoder, buffer, format, offset, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderSetLabel(WGPURenderBundleEncoder renderBundleEncoder, WGPUStringView label) {
+    procs.renderBundleEncoderSetLabel(renderBundleEncoder, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderSetPipeline(WGPURenderBundleEncoder renderBundleEncoder, WGPURenderPipeline pipeline) {
+    procs.renderBundleEncoderSetPipeline(renderBundleEncoder, pipeline);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderSetVertexBuffer(WGPURenderBundleEncoder renderBundleEncoder, uint32_t slot, WGPUBuffer buffer, uint64_t offset, uint64_t size) {
+    procs.renderBundleEncoderSetVertexBuffer(renderBundleEncoder, slot, buffer, offset, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderAddRef(WGPURenderBundleEncoder renderBundleEncoder) {
+    procs.renderBundleEncoderAddRef(renderBundleEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderBundleEncoderRelease(WGPURenderBundleEncoder renderBundleEncoder) {
+    procs.renderBundleEncoderRelease(renderBundleEncoder);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderBeginOcclusionQuery(WGPURenderPassEncoder renderPassEncoder, uint32_t queryIndex) {
+    procs.renderPassEncoderBeginOcclusionQuery(renderPassEncoder, queryIndex);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderDraw(WGPURenderPassEncoder renderPassEncoder, uint32_t vertexCount, uint32_t instanceCount, uint32_t firstVertex, uint32_t firstInstance) {
+    procs.renderPassEncoderDraw(renderPassEncoder, vertexCount, instanceCount, firstVertex, firstInstance);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderDrawIndexed(WGPURenderPassEncoder renderPassEncoder, uint32_t indexCount, uint32_t instanceCount, uint32_t firstIndex, int32_t baseVertex, uint32_t firstInstance) {
+    procs.renderPassEncoderDrawIndexed(renderPassEncoder, indexCount, instanceCount, firstIndex, baseVertex, firstInstance);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderDrawIndexedIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) {
+    procs.renderPassEncoderDrawIndexedIndirect(renderPassEncoder, indirectBuffer, indirectOffset);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderDrawIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset) {
+    procs.renderPassEncoderDrawIndirect(renderPassEncoder, indirectBuffer, indirectOffset);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderEnd(WGPURenderPassEncoder renderPassEncoder) {
+    procs.renderPassEncoderEnd(renderPassEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderEndOcclusionQuery(WGPURenderPassEncoder renderPassEncoder) {
+    procs.renderPassEncoderEndOcclusionQuery(renderPassEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderExecuteBundles(WGPURenderPassEncoder renderPassEncoder, size_t bundleCount, WGPURenderBundle const * bundles) {
+    procs.renderPassEncoderExecuteBundles(renderPassEncoder, bundleCount, bundles);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderInsertDebugMarker(WGPURenderPassEncoder renderPassEncoder, WGPUStringView markerLabel) {
+    procs.renderPassEncoderInsertDebugMarker(renderPassEncoder, markerLabel);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderMultiDrawIndexedIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset, uint32_t maxDrawCount, WGPUBuffer drawCountBuffer, uint64_t drawCountBufferOffset) {
+    procs.renderPassEncoderMultiDrawIndexedIndirect(renderPassEncoder, indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountBufferOffset);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderMultiDrawIndirect(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer indirectBuffer, uint64_t indirectOffset, uint32_t maxDrawCount, WGPUBuffer drawCountBuffer, uint64_t drawCountBufferOffset) {
+    procs.renderPassEncoderMultiDrawIndirect(renderPassEncoder, indirectBuffer, indirectOffset, maxDrawCount, drawCountBuffer, drawCountBufferOffset);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderPixelLocalStorageBarrier(WGPURenderPassEncoder renderPassEncoder) {
+    procs.renderPassEncoderPixelLocalStorageBarrier(renderPassEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderPopDebugGroup(WGPURenderPassEncoder renderPassEncoder) {
+    procs.renderPassEncoderPopDebugGroup(renderPassEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderPushDebugGroup(WGPURenderPassEncoder renderPassEncoder, WGPUStringView groupLabel) {
+    procs.renderPassEncoderPushDebugGroup(renderPassEncoder, groupLabel);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetBindGroup(WGPURenderPassEncoder renderPassEncoder, uint32_t groupIndex, WGPUBindGroup group, size_t dynamicOffsetCount, uint32_t const * dynamicOffsets) {
+    procs.renderPassEncoderSetBindGroup(renderPassEncoder, groupIndex, group, dynamicOffsetCount, dynamicOffsets);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetBlendConstant(WGPURenderPassEncoder renderPassEncoder, WGPUColor const * color) {
+    procs.renderPassEncoderSetBlendConstant(renderPassEncoder, color);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetImmediateData(WGPURenderPassEncoder renderPassEncoder, uint32_t offset, void const * data, size_t size) {
+    procs.renderPassEncoderSetImmediateData(renderPassEncoder, offset, data, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetIndexBuffer(WGPURenderPassEncoder renderPassEncoder, WGPUBuffer buffer, WGPUIndexFormat format, uint64_t offset, uint64_t size) {
+    procs.renderPassEncoderSetIndexBuffer(renderPassEncoder, buffer, format, offset, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetLabel(WGPURenderPassEncoder renderPassEncoder, WGPUStringView label) {
+    procs.renderPassEncoderSetLabel(renderPassEncoder, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetPipeline(WGPURenderPassEncoder renderPassEncoder, WGPURenderPipeline pipeline) {
+    procs.renderPassEncoderSetPipeline(renderPassEncoder, pipeline);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetScissorRect(WGPURenderPassEncoder renderPassEncoder, uint32_t x, uint32_t y, uint32_t width, uint32_t height) {
+    procs.renderPassEncoderSetScissorRect(renderPassEncoder, x, y, width, height);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetStencilReference(WGPURenderPassEncoder renderPassEncoder, uint32_t reference) {
+    procs.renderPassEncoderSetStencilReference(renderPassEncoder, reference);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetVertexBuffer(WGPURenderPassEncoder renderPassEncoder, uint32_t slot, WGPUBuffer buffer, uint64_t offset, uint64_t size) {
+    procs.renderPassEncoderSetVertexBuffer(renderPassEncoder, slot, buffer, offset, size);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderSetViewport(WGPURenderPassEncoder renderPassEncoder, float x, float y, float width, float height, float minDepth, float maxDepth) {
+    procs.renderPassEncoderSetViewport(renderPassEncoder, x, y, width, height, minDepth, maxDepth);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderWriteTimestamp(WGPURenderPassEncoder renderPassEncoder, WGPUQuerySet querySet, uint32_t queryIndex) {
+    procs.renderPassEncoderWriteTimestamp(renderPassEncoder, querySet, queryIndex);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderAddRef(WGPURenderPassEncoder renderPassEncoder) {
+    procs.renderPassEncoderAddRef(renderPassEncoder);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPassEncoderRelease(WGPURenderPassEncoder renderPassEncoder) {
+    procs.renderPassEncoderRelease(renderPassEncoder);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBindGroupLayout wgpuRenderPipelineGetBindGroupLayout(WGPURenderPipeline renderPipeline, uint32_t groupIndex) {
+return     procs.renderPipelineGetBindGroupLayout(renderPipeline, groupIndex);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPipelineSetLabel(WGPURenderPipeline renderPipeline, WGPUStringView label) {
+    procs.renderPipelineSetLabel(renderPipeline, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPipelineAddRef(WGPURenderPipeline renderPipeline) {
+    procs.renderPipelineAddRef(renderPipeline);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuRenderPipelineRelease(WGPURenderPipeline renderPipeline) {
+    procs.renderPipelineRelease(renderPipeline);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSamplerSetLabel(WGPUSampler sampler, WGPUStringView label) {
+    procs.samplerSetLabel(sampler, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSamplerAddRef(WGPUSampler sampler) {
+    procs.samplerAddRef(sampler);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSamplerRelease(WGPUSampler sampler) {
+    procs.samplerRelease(sampler);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUFuture wgpuShaderModuleGetCompilationInfo(WGPUShaderModule shaderModule, WGPUCompilationInfoCallbackInfo callbackInfo) {
+return     procs.shaderModuleGetCompilationInfo(shaderModule, callbackInfo);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuShaderModuleSetLabel(WGPUShaderModule shaderModule, WGPUStringView label) {
+    procs.shaderModuleSetLabel(shaderModule, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuShaderModuleAddRef(WGPUShaderModule shaderModule) {
+    procs.shaderModuleAddRef(shaderModule);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuShaderModuleRelease(WGPUShaderModule shaderModule) {
+    procs.shaderModuleRelease(shaderModule);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuSharedBufferMemoryBeginAccess(WGPUSharedBufferMemory sharedBufferMemory, WGPUBuffer buffer, WGPUSharedBufferMemoryBeginAccessDescriptor const * descriptor) {
+return     procs.sharedBufferMemoryBeginAccess(sharedBufferMemory, buffer, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBuffer wgpuSharedBufferMemoryCreateBuffer(WGPUSharedBufferMemory sharedBufferMemory, WGPUBufferDescriptor const * descriptor) {
+return     procs.sharedBufferMemoryCreateBuffer(sharedBufferMemory, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuSharedBufferMemoryEndAccess(WGPUSharedBufferMemory sharedBufferMemory, WGPUBuffer buffer, WGPUSharedBufferMemoryEndAccessState * descriptor) {
+return     procs.sharedBufferMemoryEndAccess(sharedBufferMemory, buffer, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuSharedBufferMemoryGetProperties(WGPUSharedBufferMemory sharedBufferMemory, WGPUSharedBufferMemoryProperties * properties) {
+return     procs.sharedBufferMemoryGetProperties(sharedBufferMemory, properties);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBool wgpuSharedBufferMemoryIsDeviceLost(WGPUSharedBufferMemory sharedBufferMemory) {
+return     procs.sharedBufferMemoryIsDeviceLost(sharedBufferMemory);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedBufferMemorySetLabel(WGPUSharedBufferMemory sharedBufferMemory, WGPUStringView label) {
+    procs.sharedBufferMemorySetLabel(sharedBufferMemory, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedBufferMemoryAddRef(WGPUSharedBufferMemory sharedBufferMemory) {
+    procs.sharedBufferMemoryAddRef(sharedBufferMemory);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedBufferMemoryRelease(WGPUSharedBufferMemory sharedBufferMemory) {
+    procs.sharedBufferMemoryRelease(sharedBufferMemory);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedFenceExportInfo(WGPUSharedFence sharedFence, WGPUSharedFenceExportInfo * info) {
+    procs.sharedFenceExportInfo(sharedFence, info);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedFenceAddRef(WGPUSharedFence sharedFence) {
+    procs.sharedFenceAddRef(sharedFence);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedFenceRelease(WGPUSharedFence sharedFence) {
+    procs.sharedFenceRelease(sharedFence);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuSharedTextureMemoryBeginAccess(WGPUSharedTextureMemory sharedTextureMemory, WGPUTexture texture, WGPUSharedTextureMemoryBeginAccessDescriptor const * descriptor) {
+return     procs.sharedTextureMemoryBeginAccess(sharedTextureMemory, texture, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUTexture wgpuSharedTextureMemoryCreateTexture(WGPUSharedTextureMemory sharedTextureMemory, WGPUTextureDescriptor const * descriptor) {
+return     procs.sharedTextureMemoryCreateTexture(sharedTextureMemory, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuSharedTextureMemoryEndAccess(WGPUSharedTextureMemory sharedTextureMemory, WGPUTexture texture, WGPUSharedTextureMemoryEndAccessState * descriptor) {
+return     procs.sharedTextureMemoryEndAccess(sharedTextureMemory, texture, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuSharedTextureMemoryGetProperties(WGPUSharedTextureMemory sharedTextureMemory, WGPUSharedTextureMemoryProperties * properties) {
+return     procs.sharedTextureMemoryGetProperties(sharedTextureMemory, properties);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUBool wgpuSharedTextureMemoryIsDeviceLost(WGPUSharedTextureMemory sharedTextureMemory) {
+return     procs.sharedTextureMemoryIsDeviceLost(sharedTextureMemory);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedTextureMemorySetLabel(WGPUSharedTextureMemory sharedTextureMemory, WGPUStringView label) {
+    procs.sharedTextureMemorySetLabel(sharedTextureMemory, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedTextureMemoryAddRef(WGPUSharedTextureMemory sharedTextureMemory) {
+    procs.sharedTextureMemoryAddRef(sharedTextureMemory);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSharedTextureMemoryRelease(WGPUSharedTextureMemory sharedTextureMemory) {
+    procs.sharedTextureMemoryRelease(sharedTextureMemory);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSurfaceConfigure(WGPUSurface surface, WGPUSurfaceConfiguration const * config) {
+    procs.surfaceConfigure(surface, config);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUStatus wgpuSurfaceGetCapabilities(WGPUSurface surface, WGPUAdapter adapter, WGPUSurfaceCapabilities * capabilities) {
+return     procs.surfaceGetCapabilities(surface, adapter, capabilities);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSurfaceGetCurrentTexture(WGPUSurface surface, WGPUSurfaceTexture * surfaceTexture) {
+    procs.surfaceGetCurrentTexture(surface, surfaceTexture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSurfacePresent(WGPUSurface surface) {
+    procs.surfacePresent(surface);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSurfaceSetLabel(WGPUSurface surface, WGPUStringView label) {
+    procs.surfaceSetLabel(surface, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSurfaceUnconfigure(WGPUSurface surface) {
+    procs.surfaceUnconfigure(surface);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSurfaceAddRef(WGPUSurface surface) {
+    procs.surfaceAddRef(surface);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuSurfaceRelease(WGPUSurface surface) {
+    procs.surfaceRelease(surface);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUTextureView wgpuTextureCreateErrorView(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor) {
+return     procs.textureCreateErrorView(texture, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUTextureView wgpuTextureCreateView(WGPUTexture texture, WGPUTextureViewDescriptor const * descriptor) {
+return     procs.textureCreateView(texture, descriptor);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuTextureDestroy(WGPUTexture texture) {
+    procs.textureDestroy(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+uint32_t wgpuTextureGetDepthOrArrayLayers(WGPUTexture texture) {
+return     procs.textureGetDepthOrArrayLayers(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUTextureDimension wgpuTextureGetDimension(WGPUTexture texture) {
+return     procs.textureGetDimension(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUTextureFormat wgpuTextureGetFormat(WGPUTexture texture) {
+return     procs.textureGetFormat(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+uint32_t wgpuTextureGetHeight(WGPUTexture texture) {
+return     procs.textureGetHeight(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+uint32_t wgpuTextureGetMipLevelCount(WGPUTexture texture) {
+return     procs.textureGetMipLevelCount(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+uint32_t wgpuTextureGetSampleCount(WGPUTexture texture) {
+return     procs.textureGetSampleCount(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+WGPUTextureUsage wgpuTextureGetUsage(WGPUTexture texture) {
+return     procs.textureGetUsage(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+uint32_t wgpuTextureGetWidth(WGPUTexture texture) {
+return     procs.textureGetWidth(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuTextureSetLabel(WGPUTexture texture, WGPUStringView label) {
+    procs.textureSetLabel(texture, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuTextureAddRef(WGPUTexture texture) {
+    procs.textureAddRef(texture);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuTextureRelease(WGPUTexture texture) {
+    procs.textureRelease(texture);
+}
+
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuTextureViewSetLabel(WGPUTextureView textureView, WGPUStringView label) {
+    procs.textureViewSetLabel(textureView, label);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuTextureViewAddRef(WGPUTextureView textureView) {
+    procs.textureViewAddRef(textureView);
+}
+DAWN_NO_SANITIZE("cfi-icall")
+void wgpuTextureViewRelease(WGPUTextureView textureView) {
+    procs.textureViewRelease(textureView);
+}
+


### PR DESCRIPTION
This commit completely decouples WebGPU, WebXR, and WebNN from the Cobalt Android build graph to achieve a binary size reduction under 96MB (saving ~803KB), while maintaining full WebGL and 2D Canvas functionality.

Detailed changes:
1. Build Graph Pruning:
   - third_party/blink/renderer/modules/BUILD.gn: Removed ml, webgpu, and xr from sub_modules for Cobalt builds.
   - third_party/blink/renderer/bindings/modules/v8/BUILD.gn: Filtered out generated V8 binding sources for WebGPU, WebXR, WebNN, and Canvas2dGPUTransferOption.
   - third_party/blink/renderer/modules/canvas/BUILD.gn: Gated webgpu module dependency behind !is_cobalt.
   - third_party/blink/renderer/modules/video_rvfc/BUILD.gn: Gated xr module dependency behind !is_cobalt.
   - third_party/blink/renderer/modules/webgl/BUILD.gn: Gated xr module dependency behind !is_cobalt to ensure WebGL remains fully functional without WebXR.
   - gpu/command_buffer/service/BUILD.gn, third_party/blink/renderer/modules/webgpu/BUILD.gn, third_party/blink/renderer/platform/BUILD.gn: Gated fallback dawn:proc dependencies behind !is_cobalt.

2. Runtime & Initialization Gating:
   - third_party/blink/renderer/modules/modules_initializer.cc: Gated GPUCanvasContext factory registrations behind !BUILDFLAG(IS_COBALT).

3. Lightweight Stubbing:
   - third_party/blink/renderer/platform/graphics/gpu/cobalt_webgpu_stubs.cc: Added minimal stubs for WebGPUMailboxTexture, DawnControlClientHolder, and WebGPUCppConfiguration to satisfy platform-level graphics linking.
   - third_party/blink/renderer/modules/cobalt_modules_stubs.cc: Added lightweight C++ stubs and V8 wrapper_type_info_ definitions for all pruned WebGPU, WebXR, and WebNN interfaces referenced by global worker and window scopes, resolving all vtable and duplicate symbol linker errors.

Final APK size verification: reduced from 96,704,413 bytes to 95,901,597 bytes.