### PR TITLE
android: prevent thread TrustStoreAndroid thread blocking on startup

### DIFF
--- a/net/cert/internal/system_trust_store.cc
+++ b/net/cert/internal/system_trust_store.cc
@@ -365,14 +365,13 @@ std::unique_ptr<SystemTrustStore> CreateSslSystemTrustStoreChromeRoot(
 }
 
 void InitializeTrustStoreAndroid() {
+#if BUILDFLAG(IS_COBALT)
   static bool initialized = false;
   if (initialized) {
-    LOG(INFO) << "Charley: InitializeTrustStoreAndroid already triggered, skipping duplicate background task.";
     return;
   }
   initialized = true;
-  LOG(INFO) << "Charley: InitializeTrustStoreAndroid: Starting CertDB observation and posting background initialization task.";
-
+#endif  // BUILDFLAG(IS_COBALT)
   // Start observing DB change before the Trust Store is initialized so we don't
   // accidentally miss any changes. See https://crrev.com/c/4226436 for context.
   //

--- a/net/cert/internal/system_trust_store.cc
+++ b/net/cert/internal/system_trust_store.cc
@@ -365,6 +365,14 @@ std::unique_ptr<SystemTrustStore> CreateSslSystemTrustStoreChromeRoot(
 }
 
 void InitializeTrustStoreAndroid() {
+  static bool initialized = false;
+  if (initialized) {
+    LOG(INFO) << "Charley: InitializeTrustStoreAndroid already triggered, skipping duplicate background task.";
+    return;
+  }
+  initialized = true;
+  LOG(INFO) << "Charley: InitializeTrustStoreAndroid: Starting CertDB observation and posting background initialization task.";
+
   // Start observing DB change before the Trust Store is initialized so we don't
   // accidentally miss any changes. See https://crrev.com/c/4226436 for context.
   //

--- a/net/cert/internal/trust_store_android.cc
+++ b/net/cert/internal/trust_store_android.cc
@@ -5,6 +5,7 @@
 #include "net/cert/internal/trust_store_android.h"
 
 #include "base/logging.h"
+#include "build/build_config.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
@@ -101,6 +102,33 @@ void TrustStoreAndroid::OnTrustStoreChanged() {
 
 scoped_refptr<TrustStoreAndroid::Impl>
 TrustStoreAndroid::MaybeInitializeAndGetImpl() {
+  #if BUILDFLAG(IS_COBALT)
+  int current_generation = generation_.load();
+  {
+    base::AutoLock lock(init_lock_);
+    if (impl_ && impl_->generation() == current_generation) {
+      return impl_;
+    }
+    if (is_initializing_) {
+      LOG(WARNING) << "Charley: TrustStoreAndroid::MaybeInitializeAndGetImpl: Background initialization actively in progress, returning early to avoid blocking.";
+      return impl_;
+    }
+    is_initializing_ = true;
+  }
+
+  LOG(INFO) << "Charley: TrustStoreAndroid::MaybeInitializeAndGetImpl: Starting background loading of Android user certs (generation=" << current_generation << ").";
+  SCOPED_UMA_HISTOGRAM_LONG_TIMER("Net.CertVerifier.AndroidTrustStoreInit");
+  auto new_impl = base::MakeRefCounted<TrustStoreAndroid::Impl>(current_generation);
+  LOG(INFO) << "Charley: TrustStoreAndroid::MaybeInitializeAndGetImpl: Finished loading Android user certs.";
+
+  {
+    base::AutoLock lock(init_lock_);
+    impl_ = new_impl;
+    is_initializing_ = false;
+    return impl_;
+  }
+#else
+
   base::AutoLock lock(init_lock_);
 
   // It is possible that generation_ might be incremented in between the various
@@ -114,17 +142,36 @@ TrustStoreAndroid::MaybeInitializeAndGetImpl() {
   }
 
   return impl_;
+#endif
 }
+
 
 void TrustStoreAndroid::SyncGetIssuersOf(const bssl::ParsedCertificate* cert,
                                          bssl::ParsedCertificateList* issuers) {
+#if BUILDFLAG(IS_COBALT)
+  if (auto impl = MaybeInitializeAndGetImpl()) {
+    impl->SyncGetIssuersOf(cert, issuers);
+  } else {
+    LOG(INFO) << "Charley: TrustStoreAndroid::SyncGetIssuersOf: Trust store not initialized yet, bypassing query.";
+  }
+#else
   MaybeInitializeAndGetImpl()->SyncGetIssuersOf(cert, issuers);
+#endif
 }
 
 bssl::CertificateTrust TrustStoreAndroid::GetTrust(
     const bssl::ParsedCertificate* cert) {
+#if BUILDFLAG(IS_COBALT)
+  if (auto impl = MaybeInitializeAndGetImpl()) {
+    return impl->GetTrust(cert);
+  }
+  LOG(INFO) << "Charley: TrustStoreAndroid::GetTrust: Trust store not initialized yet, returning unspecified trust.";
+  return bssl::CertificateTrust::ForUnspecified();
+#else
   return MaybeInitializeAndGetImpl()->GetTrust(cert);
+#endif
 }
+
 
 std::vector<net::PlatformTrustStore::CertWithTrust>
 TrustStoreAndroid::GetAllUserAddedCerts() {

--- a/net/cert/internal/trust_store_android.cc
+++ b/net/cert/internal/trust_store_android.cc
@@ -102,7 +102,7 @@ void TrustStoreAndroid::OnTrustStoreChanged() {
 
 scoped_refptr<TrustStoreAndroid::Impl>
 TrustStoreAndroid::MaybeInitializeAndGetImpl() {
-  #if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(IS_COBALT)
   int current_generation = generation_.load();
   {
     base::AutoLock lock(init_lock_);
@@ -110,16 +110,13 @@ TrustStoreAndroid::MaybeInitializeAndGetImpl() {
       return impl_;
     }
     if (is_initializing_) {
-      LOG(WARNING) << "Charley: TrustStoreAndroid::MaybeInitializeAndGetImpl: Background initialization actively in progress, returning early to avoid blocking.";
       return impl_;
     }
     is_initializing_ = true;
   }
 
-  LOG(INFO) << "Charley: TrustStoreAndroid::MaybeInitializeAndGetImpl: Starting background loading of Android user certs (generation=" << current_generation << ").";
   SCOPED_UMA_HISTOGRAM_LONG_TIMER("Net.CertVerifier.AndroidTrustStoreInit");
   auto new_impl = base::MakeRefCounted<TrustStoreAndroid::Impl>(current_generation);
-  LOG(INFO) << "Charley: TrustStoreAndroid::MaybeInitializeAndGetImpl: Finished loading Android user certs.";
 
   {
     base::AutoLock lock(init_lock_);
@@ -142,7 +139,7 @@ TrustStoreAndroid::MaybeInitializeAndGetImpl() {
   }
 
   return impl_;
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
 }
 
 
@@ -151,12 +148,10 @@ void TrustStoreAndroid::SyncGetIssuersOf(const bssl::ParsedCertificate* cert,
 #if BUILDFLAG(IS_COBALT)
   if (auto impl = MaybeInitializeAndGetImpl()) {
     impl->SyncGetIssuersOf(cert, issuers);
-  } else {
-    LOG(INFO) << "Charley: TrustStoreAndroid::SyncGetIssuersOf: Trust store not initialized yet, bypassing query.";
   }
 #else
   MaybeInitializeAndGetImpl()->SyncGetIssuersOf(cert, issuers);
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
 }
 
 bssl::CertificateTrust TrustStoreAndroid::GetTrust(
@@ -165,11 +160,10 @@ bssl::CertificateTrust TrustStoreAndroid::GetTrust(
   if (auto impl = MaybeInitializeAndGetImpl()) {
     return impl->GetTrust(cert);
   }
-  LOG(INFO) << "Charley: TrustStoreAndroid::GetTrust: Trust store not initialized yet, returning unspecified trust.";
   return bssl::CertificateTrust::ForUnspecified();
 #else
   return MaybeInitializeAndGetImpl()->GetTrust(cert);
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
 }
 
 

--- a/net/cert/internal/trust_store_android.h
+++ b/net/cert/internal/trust_store_android.h
@@ -10,6 +10,7 @@
 #include "base/memory/ptr_util.h"
 #include "base/memory/scoped_refptr.h"
 #include "base/synchronization/lock.h"
+#include "build/build_config.h"
 #include "net/base/net_export.h"
 #include "net/cert/cert_database.h"
 #include "net/cert/internal/platform_trust_store.h"
@@ -62,6 +63,9 @@ class NET_EXPORT TrustStoreAndroid : public PlatformTrustStore,
 
   base::Lock init_lock_;
   scoped_refptr<Impl> impl_ GUARDED_BY(init_lock_);
+#if BUILDFLAG(IS_COBALT)
+  bool is_initializing_ GUARDED_BY(init_lock_) = false;
+#endif
   // Generation number that is incremented whenever the backing Android trust
   // store changes.
   std::atomic_int generation_ = 0;

--- a/net/cert/internal/trust_store_android.h
+++ b/net/cert/internal/trust_store_android.h
@@ -65,7 +65,7 @@ class NET_EXPORT TrustStoreAndroid : public PlatformTrustStore,
   scoped_refptr<Impl> impl_ GUARDED_BY(init_lock_);
 #if BUILDFLAG(IS_COBALT)
   bool is_initializing_ GUARDED_BY(init_lock_) = false;
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
   // Generation number that is incremented whenever the backing Android trust
   // store changes.
   std::atomic_int generation_ = 0;


### PR DESCRIPTION
This PR introduces two changes:

One upstream code change (Bug: 489763130) to initialize `TrustStoreAndroid` only once -- on startup,  multiple threads try to initialize the trust store for the same generation. The first thread that acquires the `init_lock_` does the initialization while all subsequent threads are locked. This change ensures initialization is only done once; other threads return early to free up the thread pool.

However, the thread that holds the startup JNI call for the Android Trust Store `net::android::GetUserAddedRoots()` is still holding onto `init_lock` for ~1.5-2 seconds while the navigation to `https://www.youtube.com/tv` begins. The BoringSSL TLS handshake is required to verify certificates; the `NetworkService` thread also then calls `TrustStoreAndroid::SyncGetIssuersOf()` to attempt to acquire `init_lock_` as well. This PR also similarly allows an early return if the background init is actively in progress. 

Bug: 510376425