### PR TITLE
media: move Media.EnableAllocateOnDemand to H5vccSettings

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -31,7 +31,6 @@
 #include "media/base/media_log.h"
 #include "media/base/renderer_factory.h"
 #include "media/mojo/clients/starboard/starboard_renderer_client_factory.h"
-#include "media/starboard/decoder_buffer_allocator.h"
 #include "mojo/public/cpp/bindings/generic_pending_receiver.h"
 #include "starboard/media.h"
 #include "starboard/player.h"
@@ -53,8 +52,6 @@ const char kH5vccSettingsKeyMediaAllowAudioWritingOnPause[] =
     "Media.AllowAudioWritingOnPause";
 const char kH5vccSettingsKeyMediaDisableLowPerformanceSoftwareDecoder[] =
     "Media.DisableLowPerformanceSoftwareDecoder";
-const char kH5vccSettingsKeyMediaEnableAllocateOnDemand[] =
-    "Media.EnableAllocateOnDemand";
 const char kH5vccSettingsKeyMediaEnableAv1StartupOptimization[] =
     "Media.EnableAv1StartupOptimization";
 const char kH5vccSettingsKeyMediaEnableCodecOutputChecker[] =
@@ -201,13 +198,6 @@ std::optional<int> ProcessRangedIntH5vccSetting(
 ExperimentalFeatures ProcessH5vccSettings(
     const std::map<std::string, H5vccSettingValue>& settings) {
   ExperimentalFeatures parsed;
-  if (auto* val = GetSettingValue<int64_t>(
-          settings, kH5vccSettingsKeyMediaEnableAllocateOnDemand)) {
-    bool enable_allocate_on_demand = *val != 0;
-    auto* allocator = ::media::DecoderBufferAllocator::Get();
-    CHECK(allocator);
-    allocator->SetAllocateOnDemand(enable_allocate_on_demand);
-  }
   if (auto* val = GetSettingValue<int64_t>(
           settings, kH5vccSettingsKeyMediaAllowAudioWritingOnPause)) {
     parsed.allow_audio_writing_on_pause = *val != 0;

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -169,15 +169,12 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
   }
 
   if (name == "Media.EnableAllocateOnDemand") {
-    return ProcessSettingAs<bool>(
-        script_state, exception_context, name, *value,
-        [](bool enable) -> Result {
+    return ProcessSettingAsEnableOnly(
+        script_state, exception_context, name, *value, [] {
           auto* allocator = ::media::DecoderBufferAllocator::Get();
-          if (!allocator) {
-            return base::unexpected("DecoderBufferAllocator is not available.");
-          }
-          allocator->SetAllocateOnDemand(enable);
-          return base::ok();
+          CHECK(allocator);
+          allocator->SetAllocateOnDemand(true);
+          return true;
         });
   }
   if (name == "Media.AppendFirstSegmentSynchronously") {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -168,6 +168,18 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
                   name + " isn't a supported setting.");
   }
 
+  if (name == "Media.EnableAllocateOnDemand") {
+    return ProcessSettingAs<bool>(
+        script_state, exception_context, name, *value,
+        [](bool enable) -> Result {
+          auto* allocator = ::media::DecoderBufferAllocator::Get();
+          if (!allocator) {
+            return base::unexpected("DecoderBufferAllocator is not available.");
+          }
+          allocator->SetAllocateOnDemand(enable);
+          return base::ok();
+        });
+  }
   if (name == "Media.AppendFirstSegmentSynchronously") {
     return ProcessSettingAs<bool>(script_state, exception_context, name, *value,
                                   [this](bool enable) -> Result {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -168,6 +168,14 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
                   name + " isn't a supported setting.");
   }
 
+  if (name == "Media.AppendFirstSegmentSynchronously") {
+    return ProcessSettingAs<bool>(script_state, exception_context, name, *value,
+                                  [this](bool enable) -> Result {
+                                    append_first_segment_synchronously_ =
+                                        enable;
+                                    return base::ok();
+                                  });
+  }
   if (name == "Media.EnableAllocateOnDemand") {
     return ProcessSettingAsEnableOnly(
         script_state, exception_context, name, *value, [] {
@@ -176,14 +184,6 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
           allocator->SetAllocateOnDemand(true);
           return true;
         });
-  }
-  if (name == "Media.AppendFirstSegmentSynchronously") {
-    return ProcessSettingAs<bool>(script_state, exception_context, name, *value,
-                                  [this](bool enable) -> Result {
-                                    append_first_segment_synchronously_ =
-                                        enable;
-                                    return base::ok();
-                                  });
   }
   if (name == "Media.ExperimentalMaxPendingBytesPerParse") {
     return ProcessSettingAsPositiveInt(


### PR DESCRIPTION
Move Media.EnableAllocateOnDemand handling from CobaltContentRendererClient to H5vccSettings::set to consolidate DecoderBufferAllocator configuration.

Issue: 463439461