### PR TITLE
Cherry-pick: Guard AVIF decoding with enable_dav1d_decoder

### DIFF
--- a/chrome/browser/net/chrome_accept_header_browsertest.cc
+++ b/chrome/browser/net/chrome_accept_header_browsertest.cc
@@ -17,7 +17,7 @@ using ChromeAcceptHeaderTest = InProcessBrowserTest;
 namespace {
 std::string GetOptionalImageCodecs() {
   std::string result;
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   result.append("image/avif,");
 #endif
   return result;

--- a/content/browser/network/accept_header_browsertest.cc
+++ b/content/browser/network/accept_header_browsertest.cc
@@ -73,7 +73,7 @@ class AcceptHeaderTest : public ContentBrowserTest {
 
   std::string GetOptionalImageCodecs() const {
     std::string result;
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
     result.append("image/avif,");
 #endif
     return result;

--- a/third_party/blink/common/loader/network_utils.cc
+++ b/third_party/blink/common/loader/network_utils.cc
@@ -34,7 +34,7 @@ bool AlwaysAccessNetwork(
 }
 
 const char* ImageAcceptHeader() {
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   return "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8";
 #else
   return "image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8";

--- a/third_party/blink/common/mime_util/mime_util.cc
+++ b/third_party/blink/common/mime_util/mime_util.cc
@@ -41,7 +41,7 @@ constexpr auto kSupportedImageTypes = base::MakeFixedFlatSet<std::string_view>({
     "image/x-icon",              // ico
     "image/x-xbitmap",           // xbm
     "image/x-png",
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
     "image/avif",
 #endif
 });

--- a/third_party/blink/common/mime_util/mime_util_unittest.cc
+++ b/third_party/blink/common/mime_util/mime_util_unittest.cc
@@ -20,7 +20,7 @@ TEST(MimeUtilTest, LookupTypes) {
   EXPECT_TRUE(IsSupportedImageMimeType("Image/JPEG"));
   EXPECT_FALSE(IsSupportedImageMimeType("image/jxl"));
   EXPECT_EQ(IsSupportedImageMimeType("image/avif"),
-            BUILDFLAG(ENABLE_AV1_DECODER));
+            BUILDFLAG(ENABLE_DAV1D_DECODER));
   EXPECT_FALSE(IsSupportedImageMimeType("image/lolcat"));
   EXPECT_FALSE(IsSupportedImageMimeType("Image/LolCat"));
   EXPECT_TRUE(IsSupportedNonImageMimeType("text/html"));

--- a/third_party/blink/renderer/core/inspector/inspector_emulation_agent_test.cc
+++ b/third_party/blink/renderer/core/inspector/inspector_emulation_agent_test.cc
@@ -13,7 +13,7 @@ namespace blink {
 class InspectorEmulationAgentTest : public testing::Test {};
 
 TEST_F(InspectorEmulationAgentTest, ModifiesAcceptHeader) {
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   String expected_default =
       "image/avif,image/webp,image/apng,image/svg+xml,image/*,*/*;q=0.8";
   String expected_no_webp =

--- a/third_party/blink/renderer/modules/webcodecs/image_decoder_external_test.cc
+++ b/third_party/blink/renderer/modules/webcodecs/image_decoder_external_test.cc
@@ -90,7 +90,7 @@ class ImageDecoderTest : public testing::Test {
   }
 
   static bool HasAv1Decoder() {
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
     return true;
 #else
     return false;
@@ -682,7 +682,7 @@ TEST_F(ImageDecoderTest, DecoderReadableStreamAvif) {
 
   // Verify decode completes successfully.
   decode_tester.WaitUntilSettled();
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   ASSERT_TRUE(decode_tester.IsFulfilled());
   auto* result = ToImageDecodeResult(&v8_scope, decode_tester.Value());
   EXPECT_TRUE(result->complete());
@@ -756,7 +756,7 @@ TEST_F(ImageDecoderTest, ReadableStreamAvifStillYuvDecoding) {
     auto promise = decoder->decode();
     ScriptPromiseTester tester(v8_scope.GetScriptState(), promise);
     tester.WaitUntilSettled();
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
     ASSERT_TRUE(tester.IsFulfilled());
     auto* result = ToImageDecodeResult(&v8_scope, tester.Value());
     EXPECT_TRUE(result->complete());

--- a/third_party/blink/renderer/platform/BUILD.gn
+++ b/third_party/blink/renderer/platform/BUILD.gn
@@ -2821,17 +2821,19 @@ fuzzer_test("web_icon_sizes_fuzzer") {
   additional_configs = [ "//third_party/blink/renderer:inside_blink" ]
 }
 
-# Fuzzer for blink::CrabbyAVIFImageDecoder
-fuzzer_test("blink_crabbyavif_decoder_fuzzer") {
-  sources = [ "image-decoders/avif/crabbyavif_image_decoder_fuzzer.cc" ]
-  deps = [
-    ":blink_fuzzer_test_support",
-    ":blink_image_decoder_fuzzer_test_support",
-    ":platform",
-  ]
-  seed_corpuses = [ "//third_party/blink/web_tests/images/resources/avif" ]
-  libfuzzer_options = [ "rss_limit_mb=8192" ]
-  additional_configs = [ "//third_party/blink/renderer:inside_blink" ]
+if (enable_dav1d_decoder) {
+  # Fuzzer for blink::CrabbyAVIFImageDecoder
+  fuzzer_test("blink_crabbyavif_decoder_fuzzer") {
+    sources = [ "image-decoders/avif/crabbyavif_image_decoder_fuzzer.cc" ]
+    deps = [
+      ":blink_fuzzer_test_support",
+      ":blink_image_decoder_fuzzer_test_support",
+      ":platform",
+    ]
+    seed_corpuses = [ "//third_party/blink/web_tests/images/resources/avif" ]
+    libfuzzer_options = [ "rss_limit_mb=8192" ]
+    additional_configs = [ "//third_party/blink/renderer:inside_blink" ]
+  }
 }
 
 # Fuzzer for blink::ICOImageDecoder.

--- a/third_party/blink/renderer/platform/graphics/bitmap_image_metrics.cc
+++ b/third_party/blink/renderer/platform/graphics/bitmap_image_metrics.cc
@@ -34,7 +34,7 @@ BitmapImageMetrics::StringToDecodedImageType(const String& type) {
     return BitmapImageMetrics::DecodedImageType::kICO;
   if (type == "bmp")
     return BitmapImageMetrics::DecodedImageType::kBMP;
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   if (type == "avif")
     return BitmapImageMetrics::DecodedImageType::kAVIF;
 #endif
@@ -51,7 +51,7 @@ void BitmapImageMetrics::CountDecodedImageType(const String& type,
   if (use_counter) {
     if (type == "webp") {
       use_counter->CountUse(WebFeature::kWebPImage);
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
     } else if (type == "avif") {
       use_counter->CountUse(WebFeature::kAVIFImage);
 #endif
@@ -87,7 +87,7 @@ void BitmapImageMetrics::CountDecodedImageDensity(const String& type,
   DEFINE_THREAD_SAFE_STATIC_LOCAL(
       CustomCountHistogram, webp_density_histogram,
       ("Blink.DecodedImage.WebPDensity.KiBWeighted2", 1, 1000, 100));
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   DEFINE_THREAD_SAFE_STATIC_LOCAL(
       CustomCountHistogram, avif_density_histogram,
       ("Blink.DecodedImage.AvifDensity.KiBWeighted2", 1, 1000, 100));
@@ -103,7 +103,7 @@ void BitmapImageMetrics::CountDecodedImageDensity(const String& type,
     case BitmapImageMetrics::DecodedImageType::kWebP:
       density_histogram = &webp_density_histogram;
       break;
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
     case BitmapImageMetrics::DecodedImageType::kAVIF:
       density_histogram = &avif_density_histogram;
       break;

--- a/third_party/blink/renderer/platform/graphics/bitmap_image_test.cc
+++ b/third_party/blink/renderer/platform/graphics/bitmap_image_test.cc
@@ -851,11 +851,11 @@ TEST_F(BitmapHistogramTest, DecodedImageType) {
                            BitmapImageMetrics::DecodedImageType::kICO);
   ExpectImageRecordsSample("gracehopper.bmp", "Blink.DecodedImageType",
                            BitmapImageMetrics::DecodedImageType::kBMP);
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   ExpectImageRecordsSample("red-full-ranged-8bpc.avif",
                            "Blink.DecodedImageType",
                            BitmapImageMetrics::DecodedImageType::kAVIF);
-#endif  // BUILDFLAG(ENABLE_AV1_DECODER)
+#endif  // BUILDFLAG(ENABLE_DAV1D_DECODER)
 }
 
 TEST_F(BitmapHistogramTest, DecodedImageDensityKiBWeighted) {
@@ -865,7 +865,7 @@ TEST_F(BitmapHistogramTest, DecodedImageDensityKiBWeighted) {
     LoadImage("rgb-jpeg-red.jpg");           // 64x64
     // 500x500 but animation is not reported.
     LoadBlinkWebTestsImage("webp-animated-large.webp");
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
     LoadImage("red-full-ranged-8bpc.avif");  // 3x3
     // 159x159 but animation is not reported.
     LoadBlinkWebTestsImage("avif/star-animated-8bpc.avif");
@@ -878,7 +878,7 @@ TEST_F(BitmapHistogramTest, DecodedImageDensityKiBWeighted) {
         "Blink.DecodedImage.JpegDensity.KiBWeighted", 0);
     histogram_tester.ExpectTotalCount(
         "Blink.DecodedImage.WebPDensity.KiBWeighted2", 0);
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
     histogram_tester.ExpectTotalCount(
         "Blink.DecodedImage.AvifDensity.KiBWeighted2", 0);
 #endif
@@ -899,11 +899,11 @@ TEST_F(BitmapHistogramTest, DecodedImageDensityKiBWeighted) {
                            "Blink.DecodedImage.WebPDensity.KiBWeighted2", 24,
                            19);
 
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   // 840x1120, 18769 bytes --> 0.16, 18 KiB
   ExpectImageRecordsSample(
       "happy_dog.avif", "Blink.DecodedImage.AvifDensity.KiBWeighted2", 16, 18);
-#endif  // BUILDFLAG(ENABLE_AV1_DECODER)
+#endif  // BUILDFLAG(ENABLE_DAV1D_DECODER)
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/platform/image-decoders/BUILD.gn
+++ b/third_party/blink/renderer/platform/image-decoders/BUILD.gn
@@ -77,7 +77,7 @@ component("image_decoders") {
     "//ui/gfx/geometry:geometry_skia",
   ]
 
-  if (enable_av1_decoder) {
+  if (enable_dav1d_decoder) {
     sources += [
       "avif/crabbyavif_image_decoder.cc",
       "avif/crabbyavif_image_decoder.h",
@@ -129,7 +129,7 @@ source_set("unit_tests") {
     deps += [ "//ui/base:pixel_diff_test_support" ]
   }
 
-  if (enable_av1_decoder) {
+  if (enable_dav1d_decoder) {
     sources += [ "avif/crabbyavif_image_decoder_test.cc" ]
   }
 }

--- a/third_party/blink/renderer/platform/image-decoders/image_decoder.cc
+++ b/third_party/blink/renderer/platform/image-decoders/image_decoder.cc
@@ -51,7 +51,7 @@
 #include "ui/gfx/geometry/size.h"
 #include "ui/gfx/geometry/size_conversions.h"
 
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
 #include "third_party/blink/renderer/platform/image-decoders/avif/crabbyavif_image_decoder.h"
 #endif
 
@@ -78,7 +78,7 @@ cc::ImageType FileExtensionToImageType(String image_extension) {
   if (image_extension == "bmp") {
     return cc::ImageType::kBMP;
   }
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   if (image_extension == "avif") {
     return cc::ImageType::kAVIF;
   }
@@ -196,7 +196,7 @@ String SniffMimeTypeInternal(scoped_refptr<SegmentReader> reader) {
   if (MatchesBMPSignature(contents)) {
     return "image/bmp";
   }
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   if (CrabbyAVIFImageDecoder::MatchesAVIFSignature(fast_reader)) {
     return "image/avif";
   }
@@ -305,7 +305,7 @@ std::unique_ptr<ImageDecoder> ImageDecoder::CreateByMimeType(
   } else if (mime_type == "image/bmp" || mime_type == "image/x-xbitmap") {
     decoder = std::make_unique<BMPImageDecoder>(alpha_option, color_behavior,
                                                 max_decoded_bytes);
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   } else if (mime_type == "image/avif") {
     decoder = std::make_unique<CrabbyAVIFImageDecoder>(
         alpha_option, high_bit_depth_decoding_option, color_behavior, aux_image,
@@ -334,7 +334,7 @@ bool ImageDecoder::HasSufficientDataToSniffMimeType(const SharedBuffer& data) {
     return false;
   }
 
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   {
     // Check for an ISO BMFF File Type Box. Assume that 'largesize' is not used.
     // The first eight bytes would be a big-endian 32-bit unsigned integer
@@ -428,7 +428,7 @@ ImageDecoder::CompressionFormat ImageDecoder::GetCompressionFormat(
     }
   }
 
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
   // Attempt to sniff whether an AVIF image is using a lossy or lossless
   // compression algorithm.
   // TODO(wtc): Implement this. Figure out whether to return kUndefinedFormat or

--- a/third_party/blink/renderer/platform/image-decoders/image_decoder_test.cc
+++ b/third_party/blink/renderer/platform/image-decoders/image_decoder_test.cc
@@ -344,7 +344,7 @@ TEST(ImageDecoderTest, decodedSizeLimitIsIgnored) {
 
 #endif  // BUILDFLAG(IS_FUCHSIA)
 
-#if BUILDFLAG(ENABLE_AV1_DECODER)
+#if BUILDFLAG(ENABLE_DAV1D_DECODER)
 TEST(ImageDecoderTest, hasSufficientDataToSniffMimeTypeAvif) {
   // The first 36 bytes of the Netflix AVIF test image
   // Chimera-AV1-10bit-1280x720-2380kbps-100.avif. Since the major_brand is
@@ -375,6 +375,6 @@ TEST(ImageDecoderTest, hasSufficientDataToSniffMimeTypeAvif) {
   EXPECT_TRUE(ImageDecoder::HasSufficientDataToSniffMimeType(*buffer));
   EXPECT_EQ(ImageDecoder::SniffMimeType(buffer), "image/avif");
 }
-#endif  // BUILDFLAG(ENABLE_AV1_DECODER)
+#endif  // BUILDFLAG(ENABLE_DAV1D_DECODER)
 
 }  // namespace blink


### PR DESCRIPTION
This is a cherry-pick of  https://crrev.com/c/7850382, omitting `//third_party/crabbyavif` when the `enable_dav1d_decoder` flag is set to false. The original commit message follows.

---

The existing guards use enable_av1_decoder which may or may not be dav1d depending on hardware AV1 support. Whereas AVIF decoding is always done via dav1d and thus guarding it with enable_av1_decoder is incorrect.

Bug: 507576499
Change-Id: Ic7b84ae578f38aa9a9ee815761a5002125e20dda
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7850382
Reviewed-by: Nico Weber <thakis@chromium.org>
Reviewed-by: Wan-Teh Chang <wtc@google.com>
Reviewed-by: Rakina Zata Amni <rakina@chromium.org>
Commit-Queue: Vignesh Venkat <vigneshv@google.com>
Cr-Commit-Position: refs/heads/main@{#1631517}