### PR TITLE
media: Remove AllocateOnDemand Experiment code

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -31,7 +31,6 @@
 #include "media/base/media_log.h"
 #include "media/base/renderer_factory.h"
 #include "media/mojo/clients/starboard/starboard_renderer_client_factory.h"
-#include "media/starboard/decoder_buffer_allocator.h"
 #include "mojo/public/cpp/bindings/generic_pending_receiver.h"
 #include "starboard/media.h"
 #include "starboard/player.h"
@@ -55,8 +54,6 @@ const char kH5vccSettingsKeyMediaBypassMojoForMedia[] =
     "Media.BypassMojoForMedia";
 const char kH5vccSettingsKeyMediaDisableLowPerformanceSoftwareDecoder[] =
     "Media.DisableLowPerformanceSoftwareDecoder";
-const char kH5vccSettingsKeyMediaEnableAllocateOnDemand[] =
-    "Media.EnableAllocateOnDemand";
 const char kH5vccSettingsKeyMediaEnableAv1StartupOptimization[] =
     "Media.EnableAv1StartupOptimization";
 // TODO: b/474454335 - Remove once seek experiment is done.
@@ -207,13 +204,6 @@ std::optional<int> ProcessRangedIntH5vccSetting(
 ExperimentalFeatures ProcessH5vccSettings(
     const std::map<std::string, H5vccSettingValue>& settings) {
   ExperimentalFeatures parsed;
-  if (auto* val = GetSettingValue<int64_t>(
-          settings, kH5vccSettingsKeyMediaEnableAllocateOnDemand)) {
-    bool enable_allocate_on_demand = *val != 0;
-    auto* allocator = ::media::DecoderBufferAllocator::Get();
-    CHECK(allocator);
-    allocator->SetAllocateOnDemand(enable_allocate_on_demand);
-  }
   if (auto* val = GetSettingValue<int64_t>(
           settings, kH5vccSettingsKeyMediaAllowAudioWritingOnPause)) {
     parsed.allow_audio_writing_on_pause = *val != 0;

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -89,10 +89,10 @@ DecoderBufferAllocator* DecoderBufferAllocator::Get() {
 }
 
 void DecoderBufferAllocator::Suspend() {
-  base::AutoLock scoped_lock(mutex_);
   if (is_memory_pool_allocated_on_demand_) {
     return;
   }
+  base::AutoLock scoped_lock(mutex_);
 
   if (strategy_ && strategy_->GetAllocated() == 0) {
     LOG(INFO) << "Freeing " << strategy_->GetCapacity()
@@ -102,10 +102,10 @@ void DecoderBufferAllocator::Suspend() {
 }
 
 void DecoderBufferAllocator::Resume() {
-  base::AutoLock scoped_lock(mutex_);
   if (is_memory_pool_allocated_on_demand_) {
     return;
   }
+  base::AutoLock scoped_lock(mutex_);
 
   EnsureStrategyIsCreated();
 }
@@ -236,28 +236,6 @@ void DecoderBufferAllocator::UpdateAllocatorStrategy(
     return;
   }
   if (strategy_) {
-    strategy_.reset();
-  }
-}
-
-void DecoderBufferAllocator::SetAllocateOnDemand(bool enabled) {
-  base::AutoLock scoped_lock(mutex_);
-  if (is_memory_pool_allocated_on_demand_ == enabled) {
-    return;
-  }
-
-  LOG(INFO) << "DecoderBufferAllocator::SetAllocateOnDemand: "
-            << ToString(is_memory_pool_allocated_on_demand_) << " -> "
-            << ToString(enabled);
-
-  is_memory_pool_allocated_on_demand_ = enabled;
-  // If we enable |is_memory_pool_allocated_on_demand_|, we should try to
-  // reset the strategy.
-  if (is_memory_pool_allocated_on_demand_ && strategy_ &&
-      strategy_->GetAllocated() == 0) {
-    LOG(INFO) << "Freeing " << strategy_->GetCapacity()
-              << " bytes of decoder buffer pool since allocator now allocates"
-                 " on demand.";
     strategy_.reset();
   }
 }

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -88,7 +88,6 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
 
   // Utility functions for h5vcc settings.
   // TODO(b/460292554): To be deprecated with h5vcc settings.
-  void SetAllocateOnDemand(bool enabled);
   static void EnableConfigurableDecommitStrategy(
       int block_size,
       int retain_blocks,
@@ -103,7 +102,7 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   void TryFlushAllocationLog_Locked() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 
-  bool is_memory_pool_allocated_on_demand_ GUARDED_BY(mutex_);
+  const bool is_memory_pool_allocated_on_demand_;
   const int initial_capacity_;
   const int allocation_unit_;
 


### PR DESCRIPTION
Remove currently unused H5VCC code to enable the AllocateOnDemand strategy. We also update |is_memory_pool_allocated_on_demand_| to be const, as there is now no way to change the value during the DecoderBufferAllocator's lifetime.

Bug: 463439461