### PR TITLE
Toggle on in-memory update

### DIFF
--- a/cobalt/updater/network_fetcher.cc
+++ b/cobalt/updater/network_fetcher.cc
@@ -153,8 +153,45 @@ void NetworkFetcher::DownloadToString(
     ProgressCallback progress_callback,
     DownloadToStringCompleteCallback download_to_string_complete_callback) {
   LOG(INFO) << "NetworkFetcher::DownloadToString, url = " << url;
-  // TODO(b/444006168): implement this to support in-memory updates
-  NOTIMPLEMENTED();
+  CHECK(dst != nullptr);
+  dst_str_ = dst;
+
+  CHECK(!simple_url_loader_);
+  auto resource_request = std::make_unique<network::ResourceRequest>();
+  resource_request->url = url;
+  resource_request->method = "GET";
+  resource_request->load_flags = net::LOAD_DISABLE_CACHE;
+  simple_url_loader_ = network::SimpleURLLoader::Create(
+      std::move(resource_request), traffic_annotation);
+  simple_url_loader_->SetRetryOptions(
+      kMaxRetriesOnNetworkChange,
+      network::SimpleURLLoader::RetryMode::RETRY_ON_NETWORK_CHANGE);
+  simple_url_loader_->SetOnResponseStartedCallback(base::BindOnce(
+      &NetworkFetcher::OnResponseStartedCallback, base::Unretained(this),
+      std::move(response_started_callback)));
+  simple_url_loader_->SetOnDownloadProgressCallback(base::BindRepeating(
+      &NetworkFetcher::OnProgressCallback, base::Unretained(this),
+      std::move(progress_callback)));
+  simple_url_loader_->DownloadToString(
+      url_loader_factory_.get(),
+      base::BindOnce(&NetworkFetcher::OnDownloadToStringComplete,
+                     base::Unretained(this),
+                     std::move(download_to_string_complete_callback)),
+      network::SimpleURLLoader::kMaxBoundedStringDownloadSize);
+}
+
+void NetworkFetcher::OnDownloadToStringComplete(
+    DownloadToStringCompleteCallback download_to_string_complete_callback,
+    std::unique_ptr<std::string> response_body) {
+  if (!response_body) {
+    LOG(ERROR) << "DownloadToString failed to get response from a string";
+    dst_str_->clear();
+  } else {
+    *dst_str_ = std::move(*response_body);
+  }
+  std::move(download_to_string_complete_callback)
+      .Run(dst_str_, simple_url_loader_->NetError(),
+           simple_url_loader_->GetContentSize());
 }
 
 #else
@@ -176,7 +213,6 @@ base::OnceClosure NetworkFetcher::DownloadToFile(
   simple_url_loader_->SetRetryOptions(
       kMaxRetriesOnNetworkChange,
       network::SimpleURLLoader::RetryMode::RETRY_ON_NETWORK_CHANGE);
-  simple_url_loader_->SetAllowPartialResults(true);
   simple_url_loader_->SetOnResponseStartedCallback(base::BindOnce(
       &NetworkFetcher::OnResponseStartedCallback, base::Unretained(this),
       std::move(response_started_callback)));

--- a/cobalt/updater/network_fetcher.h
+++ b/cobalt/updater/network_fetcher.h
@@ -117,7 +117,17 @@ class NetworkFetcher : public update_client::NetworkFetcher {
   void OnProgressCallback(ProgressCallback response_started_callback,
                           uint64_t current);
 
+#if defined(IN_MEMORY_UPDATES)
+  void OnDownloadToStringComplete(
+      DownloadToStringCompleteCallback download_to_string_complete_callback,
+      std::unique_ptr<std::string> response_body);
+#endif
+
   static constexpr int kMaxRetriesOnNetworkChange = 3;
+
+#if defined(IN_MEMORY_UPDATES)
+  base::raw_ptr<std::string> dst_str_;  // not owned, can't be null
+#endif
 
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   std::unique_ptr<network::SimpleURLLoader> simple_url_loader_;

--- a/components/crx_file/crx_verifier.cc
+++ b/components/crx_file/crx_verifier.cc
@@ -328,7 +328,8 @@ VerifierResult VerifyCrx3FromString(
 
   // Create a little-endian representation of [signed-header-size].
   const auto header_size_octets =
-      base::I32ToLittleEndian(signed_header_data_str.size());
+      base::I32ToLittleEndian(base::checked_cast<int32_t>(
+          signed_header_data_str.size()));
 
   // Create a set of all required key hashes.
   std::set<KeyHash> required_key_set;

--- a/components/crx_file/crx_verifier.cc
+++ b/components/crx_file/crx_verifier.cc
@@ -216,6 +216,9 @@ VerifierResult VerifyCrx3(
   // Create a set of all required key hashes.
   std::set<KeyHash> required_key_set;
   for (const auto& key_hash : required_key_hashes) {
+    if (key_hash.size() != sizeof(KeyHash)) {
+      return VerifierResult::ERROR_EXPECTED_HASH_INVALID;
+    }
     KeyHash hash_copy;
     base::span<uint8_t>(hash_copy).copy_from(key_hash);
     required_key_set.insert(hash_copy);
@@ -330,6 +333,9 @@ VerifierResult VerifyCrx3FromString(
   // Create a set of all required key hashes.
   std::set<KeyHash> required_key_set;
   for (const auto& key_hash : required_key_hashes) {
+    if (key_hash.size() != sizeof(KeyHash)) {
+      return VerifierResult::ERROR_EXPECTED_HASH_INVALID;
+    }
     KeyHash hash_copy;
     base::span<uint8_t>(hash_copy).copy_from(key_hash);
     required_key_set.insert(hash_copy);

--- a/components/crx_file/crx_verifier.cc
+++ b/components/crx_file/crx_verifier.cc
@@ -67,10 +67,10 @@ std::optional<size_t> ReadAndHashBuffer(base::span<uint8_t> buffer,
 int ReadAndHashBufferFromString(uint8_t* buffer,
                                 int length,
                                 std::string::const_iterator* it,
-                                crypto::SecureHash* hash) {
+                                crypto::hash::Hasher& hash) {
   static_assert(sizeof(char) == sizeof(uint8_t), "Unsupported char size.");
   memcpy(buffer, &(**it), length);
-  hash->Update(buffer, length);
+  hash.Update(base::span(buffer, base::checked_cast<size_t>(length)));
 
   // TODO(b/158043520): consider wrapping the CRX string in a type that keeps
   // track of how much of the string has already been copied so that the string
@@ -96,7 +96,7 @@ uint32_t ReadAndHashLittleEndianUInt32(base::File* file,
 // Returns the read uint32.
 uint32_t ReadAndHashLittleEndianUInt32FromString(
     std::string::const_iterator* it,
-    crypto::SecureHash* hash) {
+    crypto::hash::Hasher& hash) {
   uint8_t buffer[4] = {};
   ReadAndHashBufferFromString(buffer, sizeof(buffer), it, hash);
   return buffer[3] << 24 | buffer[2] << 16 | buffer[1] << 8 | buffer[0];
@@ -130,7 +130,7 @@ bool ReadHashAndVerifyArchive(base::File* file,
 // Reads to the end of the string, updating the hash and all verifiers.
 bool ReadHashAndVerifyArchiveFromString(const std::string& crx_str,
                                         std::string::const_iterator* it,
-                                        crypto::SecureHash* hash,
+                                        crypto::hash::Hasher& hash,
                                         const VerifierCollection& verifiers) {
   int remaining_bytes = crx_str.end() - *it;
 
@@ -143,7 +143,7 @@ bool ReadHashAndVerifyArchiveFromString(const std::string& crx_str,
     remaining_bytes -= len;
 
     for (auto& verifier : verifiers) {
-      verifier->VerifyUpdate(base::make_span(buffer, len));
+      verifier->VerifyUpdate(base::span(buffer, len));
     }
   }
 
@@ -286,7 +286,7 @@ VerifierResult VerifyCrx3(
 VerifierResult VerifyCrx3FromString(
     const std::string& crx_str,
     std::string::const_iterator* it,
-    crypto::SecureHash* hash,
+    crypto::hash::Hasher& hash,
     const std::vector<std::vector<uint8_t>>& required_key_hashes,
     std::string* public_key,
     std::string* crx_id,
@@ -320,20 +320,20 @@ VerifierResult VerifyCrx3FromString(
   if (!signed_header_data.ParseFromString(signed_header_data_str))
     return VerifierResult::ERROR_HEADER_INVALID;
   const std::string& crx_id_encoded = signed_header_data.crx_id();
-  const std::string declared_crx_id = id_util::GenerateIdFromHex(
-      base::HexEncode(crx_id_encoded.data(), crx_id_encoded.size()));
+  const std::string declared_crx_id =
+      id_util::GenerateIdFromHex(base::HexEncode(crx_id_encoded));
 
   // Create a little-endian representation of [signed-header-size].
-  const int signed_header_size = signed_header_data_str.size();
-  const uint8_t header_size_octets[] = {
-      static_cast<uint8_t>(signed_header_size),
-      static_cast<uint8_t>(signed_header_size >> 8),
-      static_cast<uint8_t>(signed_header_size >> 16),
-      static_cast<uint8_t>(signed_header_size >> 24)};
+  const auto header_size_octets =
+      base::I32ToLittleEndian(signed_header_data_str.size());
 
   // Create a set of all required key hashes.
-  std::set<std::vector<uint8_t>> required_key_set(required_key_hashes.begin(),
-                                                  required_key_hashes.end());
+  std::set<KeyHash> required_key_set;
+  for (const auto& key_hash : required_key_hashes) {
+    KeyHash hash_copy;
+    base::span<uint8_t>(hash_copy).copy_from(key_hash);
+    required_key_set.insert(hash_copy);
+  }
 
   using ProofFetcher = const RepeatedProof& (CrxFileHeader::*)() const;
   ProofFetcher rsa = &CrxFileHeader::sha256_with_rsa;
@@ -349,13 +349,6 @@ VerifierResult VerifyCrx3FromString(
           std::make_pair(rsa, crypto::SignatureVerifier::RSA_PKCS1_SHA256),
           std::make_pair(ecdsa, crypto::SignatureVerifier::ECDSA_SHA256)};
 
-  std::vector<uint8_t> publisher_key(std::begin(kPublisherKeyHash),
-                                     std::end(kPublisherKeyHash));
-  absl::optional<std::vector<uint8_t>> publisher_test_key;
-  if (accept_publisher_test_key) {
-    publisher_test_key.emplace(std::begin(kPublisherTestKeyHash),
-                               std::end(kPublisherTestKeyHash));
-  }
   bool found_publisher_key = false;
 
   // Initialize all verifiers and update them with
@@ -368,23 +361,18 @@ VerifierResult VerifyCrx3FromString(
       const std::string& sig = proof.signature();
       if (id_util::GenerateId(key) == declared_crx_id)
         public_key_bytes = key;
-      std::vector<uint8_t> key_hash(crypto::kSHA256Length);
-      crypto::SHA256HashString(key, key_hash.data(), key_hash.size());
+      auto key_hash = crypto::hash::Sha256(key);
       required_key_set.erase(key_hash);
-      DCHECK_EQ(accept_publisher_test_key, publisher_test_key.has_value());
       found_publisher_key =
-          found_publisher_key || key_hash == publisher_key ||
-          (accept_publisher_test_key && key_hash == *publisher_test_key);
+          found_publisher_key || key_hash == kPublisherKeyHash ||
+          (accept_publisher_test_key && key_hash == kPublisherTestKeyHash);
       auto v = std::make_unique<crypto::SignatureVerifier>();
-      static_assert(sizeof(unsigned char) == sizeof(uint8_t),
-                    "Unsupported char size.");
-      if (!v->VerifyInit(proof_type.second,
-                         base::as_bytes(base::make_span(sig)),
-                         base::as_bytes(base::make_span(key))))
+      if (!v->VerifyInit(proof_type.second, base::as_byte_span(sig),
+                         base::as_byte_span(key)))
         return VerifierResult::ERROR_SIGNATURE_INITIALIZATION_FAILED;
-      v->VerifyUpdate(base::as_bytes(base::make_span(kSignatureContext)));
+      v->VerifyUpdate(base::as_byte_span(kSignatureContext));
       v->VerifyUpdate(header_size_octets);
-      v->VerifyUpdate(base::as_bytes(base::make_span(signed_header_data_str)));
+      v->VerifyUpdate(base::as_byte_span(signed_header_data_str));
       verifiers.push_back(std::move(v));
     }
   }
@@ -398,7 +386,7 @@ VerifierResult VerifyCrx3FromString(
   if (!ReadHashAndVerifyArchiveFromString(crx_str, it, hash, verifiers))
     return VerifierResult::ERROR_SIGNATURE_VERIFICATION_FAILED;
 
-  base::Base64Encode(public_key_bytes, public_key);
+  *public_key = base::Base64Encode(public_key_bytes);
   *crx_id = declared_crx_id;
   return VerifierResult::OK_FULL;
 }
@@ -489,34 +477,35 @@ VerifierResult Verify(
   std::string public_key_local;
   std::string crx_id_local;
 
-  std::unique_ptr<crypto::SecureHash> file_hash =
-      crypto::SecureHash::Create(crypto::SecureHash::SHA256);
+  crypto::hash::Hasher file_hash(crypto::hash::HashKind::kSha256);
 
   // Magic number.
   bool diff = false;
-  if (!strncmp(crx_str.c_str(), kCrxDiffFileHeaderMagic,
-               kCrxFileHeaderMagicSize)) {
-    diff = true;
-  } else if (strncmp(crx_str.c_str(), kCrxFileHeaderMagic,
-                     kCrxFileHeaderMagicSize)) {
+  if (crx_str.size() < std::size(kCrxFileHeaderMagic)) {
     return VerifierResult::ERROR_HEADER_INVALID;
   }
-  file_hash->Update(crx_str.c_str(), kCrxFileHeaderMagicSize);
+  auto buffer = base::span(crx_str).first(std::size(kCrxFileHeaderMagic));
+  if (std::ranges::equal(buffer, kCrxDiffFileHeaderMagic)) {
+    diff = true;
+  } else if (!std::ranges::equal(buffer, kCrxFileHeaderMagic)) {
+    return VerifierResult::ERROR_HEADER_INVALID;
+  }
+  file_hash.Update(base::as_byte_span(buffer));
 
   std::string::const_iterator it = crx_str.begin();
   // Advance the iterator past the magic string embedded in the header.
-  std::advance(it, kCrxFileHeaderMagicSize);
+  std::advance(it, std::size(kCrxFileHeaderMagic));
 
   // Version number.
   const uint32_t version =
-      ReadAndHashLittleEndianUInt32FromString(&it, file_hash.get());
+      ReadAndHashLittleEndianUInt32FromString(&it, file_hash);
   VerifierResult result;
   if (version == 3) {
     bool require_publisher_key =
         format == VerifierFormat::CRX3_WITH_PUBLISHER_PROOF ||
         format == VerifierFormat::CRX3_WITH_TEST_PUBLISHER_PROOF;
     result = VerifyCrx3FromString(
-        crx_str, &it, file_hash.get(), required_key_hashes, &public_key_local,
+        crx_str, &it, file_hash, required_key_hashes, &public_key_local,
         &crx_id_local, compressed_verified_contents, require_publisher_key,
         format == VerifierFormat::CRX3_WITH_TEST_PUBLISHER_PROOF);
   } else {
@@ -526,13 +515,12 @@ VerifierResult Verify(
     return result;
 
   // Finalize file hash.
-  uint8_t final_hash[crypto::kSHA256Length] = {};
-  file_hash->Finish(final_hash, sizeof(final_hash));
+  std::array<uint8_t, crypto::hash::kSha256Size> final_hash;
+  file_hash.Finish(final_hash);
   if (!required_file_hash.empty()) {
-    if (required_file_hash.size() != crypto::kSHA256Length)
+    if (required_file_hash.size() != crypto::hash::kSha256Size)
       return VerifierResult::ERROR_EXPECTED_HASH_INVALID;
-    if (!crypto::SecureMemEqual(final_hash, required_file_hash.data(),
-                                crypto::kSHA256Length)) {
+    if (!crypto::SecureMemEqual(final_hash, required_file_hash)) {
       return VerifierResult::ERROR_FILE_HASH_FAILED;
     }
   }

--- a/components/update_client/crx_downloader.cc
+++ b/components/update_client/crx_downloader.cc
@@ -236,7 +236,8 @@ void CrxDownloader::HandleDownloadError(
   CHECK_NE(0, download_metrics.error);
 
 #if BUILDFLAG(IS_STARBOARD)
-  LOG(INFO) << "CrxDownloader::HandleDownloadError";
+  LOG(INFO) << "CrxDownloader::HandleDownloadError, result.error="
+            << result.error;
 #endif
 
   download_metrics_.push_back(download_metrics);

--- a/components/update_client/crx_downloader.h
+++ b/components/update_client/crx_downloader.h
@@ -190,7 +190,6 @@ class CrxDownloader : public base::RefCountedThreadSafe<CrxDownloader> {
   std::vector<DownloadMetrics> download_metrics_;
 
 #if defined(IN_MEMORY_UPDATES)
-  // TODO(b/449250040): Replace naked pointers
   base::raw_ptr<std::string> dst_str_;  // not owned, can't be null
 #endif
 };

--- a/components/update_client/network.h
+++ b/components/update_client/network.h
@@ -34,8 +34,13 @@ class NetworkFetcher {
                               const std::string& header_x_cup_server_proof,
                               const std::string& header_cookie,
                               int64_t xheader_retry_after_sec)>;
+#if defined(IN_MEMORY_UPDATES)
+  using DownloadToStringCompleteCallback = base::OnceCallback<
+      void(std::string* dst, int net_error, int64_t content_size)>;
+#else
   using DownloadToFileCompleteCallback =
       base::OnceCallback<void(int net_error, int64_t content_size)>;
+#endif
 
   // `content_length` is -1 if the value is not known.
   using ResponseStartedCallback =
@@ -77,6 +82,16 @@ class NetworkFetcher {
       ProgressCallback progress_callback,
       PostRequestCompleteCallback post_request_complete_callback) = 0;
 
+#if defined(IN_MEMORY_UPDATES)
+  // Does not take ownership of |dst|, which must refer to a valid string that
+  // outlives this object.
+  virtual void DownloadToString(
+      const GURL& url,
+      std::string* dst,
+      ResponseStartedCallback response_started_callback,
+      ProgressCallback progress_callback,
+      DownloadToStringCompleteCallback download_to_string_complete_callback) = 0;
+#else
   // Returns a cancellation closure.
   virtual base::OnceClosure DownloadToFile(
       const GURL& url,
@@ -84,6 +99,7 @@ class NetworkFetcher {
       ResponseStartedCallback response_started_callback,
       ProgressCallback progress_callback,
       DownloadToFileCompleteCallback download_to_file_complete_callback) = 0;
+#endif
 
 #if BUILDFLAG(IS_STARBOARD)
   virtual void Cancel() = 0;

--- a/components/update_client/op_download.cc
+++ b/components/update_client/op_download.cc
@@ -128,7 +128,9 @@ void DownloadComplete(
   }
 
   if (download_result.error) {
+#if !defined(IN_MEMORY_UPDATES)
     CHECK(download_result.response.empty());
+#endif
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE, base::BindOnce(std::move(callback),
                                   base::unexpected<CategorizedError>(

--- a/components/update_client/op_download.h
+++ b/components/update_client/op_download.h
@@ -47,7 +47,7 @@ base::OnceClosure DownloadOperation(
     base::RepeatingCallback<void(base::Value::Dict)> event_adder,
     base::RepeatingCallback<void(ComponentState)> state_tracker,
 #if defined(IN_MEMORY_UPDATES)
-    const std::string* crx_str,
+    std::string* crx_str,
 #endif
     CrxDownloader::ProgressCallback progress_callback,
 #if BUILDFLAG(IS_STARBOARD)

--- a/components/update_client/op_puffin.cc
+++ b/components/update_client/op_puffin.cc
@@ -68,6 +68,7 @@ void PatchDone(
       FROM_HERE, base::BindOnce(std::move(callback), result));
 }
 
+#if !defined(IN_MEMORY_UPDATES)
 // Runs in the blocking pool. Deletes any files that are no longer needed.
 void VerifyAndCleanUp(
 #if BUILDFLAG(IS_STARBOARD)
@@ -174,6 +175,7 @@ void CacheLookupDone(
                          base::BindPostTaskToCurrentDefault(base::BindOnce(
                              &PatchDone, std::move(callback), event_adder))));
 }
+#endif  // !defined(IN_MEMORY_UPDATES)
 
 }  // namespace
 
@@ -191,6 +193,14 @@ base::OnceClosure PuffOperation(
     base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)>
 #endif
         callback) {
+#if defined(IN_MEMORY_UPDATES)
+  LOG(ERROR) << "Puffin delta patching Operation not supported with Cobalt IN_MEMORY_UPDATES";
+  PatchDone(std::move(callback), event_adder,
+            base::unexpected<CategorizedError>(
+                {.category = ErrorCategory::kUnpack,
+                 .code = static_cast<int>(UnpackerError::kDeltaOperationFailure)}));
+  return base::DoNothing();
+#else
 #if BUILDFLAG(IS_STARBOARD)
   const base::FilePath& patch_file = patch_operation_result.response;
 #endif
@@ -203,6 +213,7 @@ base::OnceClosure PuffOperation(
                      patch_file.DirName(), output_hash, std::move(callback)));
 #endif
   return base::DoNothing();
+#endif  // defined(IN_MEMORY_UPDATES)
 }
 
 }  // namespace update_client

--- a/components/update_client/op_xz.cc
+++ b/components/update_client/op_xz.cc
@@ -20,6 +20,10 @@
 #include "components/update_client/update_client_errors.h"
 #include "components/zucchini/zucchini.h"
 
+#if defined(IN_MEMORY_UPDATES)
+#include "base/logging.h"
+#endif
+
 namespace update_client {
 
 namespace {
@@ -49,7 +53,9 @@ void Done(base::OnceCallback<
           [&]() -> base::expected<OperationResult, CategorizedError> {
             if (success) {
               OperationResult out_result = in_file_result;
+#if !defined(IN_MEMORY_UPDATES)
               out_result.response = out_file;
+#endif
               return out_result;
             }
 #else
@@ -57,7 +63,7 @@ void Done(base::OnceCallback<
             if (success) {
               return out_file;
             }
-#endif
+#endif  // BUILDFLAG(IS_STARBOARD)
             return base::unexpected<CategorizedError>(
                 {.category = ErrorCategory::kUnpack,
                  .code = static_cast<int>(UnpackerError::kXzFailed)});
@@ -73,13 +79,21 @@ base::OnceClosure XzOperation(
     const OperationResult& in_file_result,
     base::OnceCallback<void(base::expected<OperationResult, CategorizedError>)>
         callback) {
+#if defined(IN_MEMORY_UPDATES)
+  LOG(ERROR) << "Xz decoding Operation not supported with Cobalt IN_MEMORY_UPDATES";
+  Done(in_file_result, std::move(callback), event_adder, base::FilePath(), false);
+  return base::DoNothing();
+#else
   const base::FilePath& in_file = in_file_result.response;
+  base::FilePath dest_file = in_file.DirName().AppendUTF8("decoded_xz");
+#endif  // defined(IN_MEMORY_UPDATES)
 #else
     const base::FilePath& in_file,
     base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)>
         callback) {
-#endif
   base::FilePath dest_file = in_file.DirName().AppendUTF8("decoded_xz");
+#endif  // BUILDFLAG(IS_STARBOARD)
+#if !defined(IN_MEMORY_UPDATES)
   Unzipper* unzipper_raw = unzipper.get();
   return unzipper_raw->DecodeXz(
       in_file, dest_file,
@@ -97,6 +111,7 @@ base::OnceClosure XzOperation(
           .Then(base::BindPostTaskToCurrentDefault(base::BindOnce(
               &Done, std::move(callback), event_adder, dest_file))));
 #endif
+#endif  // !defined(IN_MEMORY_UPDATES)
 }
 
 }  // namespace update_client

--- a/components/update_client/op_zucchini.cc
+++ b/components/update_client/op_zucchini.cc
@@ -67,6 +67,7 @@ void PatchDone(
       FROM_HERE, base::BindOnce(std::move(callback), result));
 }
 
+#if !defined(IN_MEMORY_UPDATES)
 // Runs in the blocking pool. Deletes any files that are no longer needed.
 void VerifyAndCleanUp(
 #if BUILDFLAG(IS_STARBOARD)
@@ -172,6 +173,7 @@ void CacheLookupDone(
                          temp_dir, output_hash, std::move(callback)));
 #endif
 }
+#endif  // !defined(IN_MEMORY_UPDATES)
 
 }  // namespace
 
@@ -189,6 +191,14 @@ base::OnceClosure ZucchiniOperation(
     base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)>
 #endif
         callback) {
+#if defined(IN_MEMORY_UPDATES)
+  LOG(ERROR) << "Zucchini delta patching Operation not supported with Cobalt IN_MEMORY_UPDATES";
+  PatchDone(std::move(callback), event_adder,
+            base::unexpected<CategorizedError>(
+                {.category = ErrorCategory::kUnpack,
+                 .code = static_cast<int>(UnpackerError::kDeltaOperationFailure)}));
+  return base::DoNothing();
+#else
 #if BUILDFLAG(IS_STARBOARD)
   const base::FilePath& patch_file = patch_operation_result.response;
 #endif
@@ -203,6 +213,7 @@ base::OnceClosure ZucchiniOperation(
                      base::BindPostTaskToCurrentDefault(base::BindOnce(
                          &PatchDone, std::move(callback), event_adder))));
   return base::DoNothing();
+#endif  // defined(IN_MEMORY_UPDATES)
 }
 
 }  // namespace update_client

--- a/components/update_client/pipeline.cc
+++ b/components/update_client/pipeline.cc
@@ -245,7 +245,9 @@ Operation SkipIfCached(
                 // Skip the operation, and return the path to the next step.
 #if BUILDFLAG(IS_STARBOARD)
                 OperationResult cached_result = path_in;
+#if !defined(IN_MEMORY_UPDATES)
                 cached_result.response = cached_path.value();
+#endif
                 std::move(callback).Run(cached_result);
 #else
                 std::move(callback).Run(cached_path.value());

--- a/components/update_client/unpacker.cc
+++ b/components/update_client/unpacker.cc
@@ -50,7 +50,9 @@ Unpacker::Unpacker(const OperationResult& crx_operation_result,
                    std::unique_ptr<Unzipper> unzipper,
                    base::OnceCallback<void(const Result& result)> callback)
     : result_(crx_operation_result),
+#if !defined(IN_MEMORY_UPDATES)
       path_(crx_operation_result.response),
+#endif
       unzipper_(std::move(unzipper)),
       callback_(std::move(callback)) {}
 

--- a/components/update_client/unpacker.h
+++ b/components/update_client/unpacker.h
@@ -137,7 +137,9 @@ class Unpacker : public base::RefCountedThreadSafe<Unpacker> {
 #if BUILDFLAG(IS_STARBOARD)
   OperationResult result_;
 #endif
+#if !defined(IN_MEMORY_UPDATES)
   base::FilePath path_;
+#endif
   std::unique_ptr<Unzipper> unzipper_;
   base::OnceCallback<void(const Result& result)> callback_;
   base::FilePath unpack_path_;

--- a/components/update_client/unzipper.h
+++ b/components/update_client/unzipper.h
@@ -27,6 +27,12 @@ class Unzipper {
                      const base::FilePath& destination,
                      UnzipCompleteCallback callback) = 0;
 
+#if defined(IN_MEMORY_UPDATES)
+  virtual void Unzip(const std::string& zip_str,
+                     const base::FilePath& destination,
+                     UnzipCompleteCallback callback) = 0;
+#endif
+
   // Decode an `xz_file` into a `destination` file, then call `callback` with
   // true if and only if the operation is successful. Returns a cancellation
   // callback. The cancellation callback can be run on any sequence.

--- a/components/update_client/url_fetcher_downloader.cc
+++ b/components/update_client/url_fetcher_downloader.cc
@@ -327,7 +327,12 @@ void UrlFetcherDownloader::Cancel() {
   }
 }
 
+#if defined(IN_MEMORY_UPDATES)
+void UrlFetcherDownloader::OnNetworkFetcherComplete(std::string* dst,
+                                                    int net_error,
+#else
 void UrlFetcherDownloader::OnNetworkFetcherComplete(int net_error,
+#endif
                                                     int64_t content_size) {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
 

--- a/components/update_client/url_fetcher_downloader.h
+++ b/components/update_client/url_fetcher_downloader.h
@@ -88,7 +88,15 @@ class UrlFetcherDownloader : public CrxDownloader {
 #endif  // defined(IN_MEMORY_UPDATES)
 #endif  // BUILDFLAG(IS_STARBOARD)
 
+#if defined(IN_MEMORY_UPDATES)
+  // Does not take ownership of |dst|, which must refer to a valid string that
+  // outlives this object.
+  void OnNetworkFetcherComplete(std::string* dst,
+                                int net_error,
+                                int64_t content_size);
+#else
   void OnNetworkFetcherComplete(int net_error, int64_t content_size);
+#endif
   void OnResponseStarted(int response_code, int64_t content_length);
   void OnDownloadProgress(int64_t content_length);
   void Cancel();

--- a/services/network/public/cpp/simple_url_loader.h
+++ b/services/network/public/cpp/simple_url_loader.h
@@ -93,6 +93,9 @@ class COMPONENT_EXPORT(NETWORK_CPP) SimpleURLLoader {
 
   // The maximum size DownloadToString will accept.
 #if BUILDFLAG(IS_STARBOARD)
+  // TODO(b/465213840): Check with upstream authors regarding the 20MB limit
+  // and establish a robust process for managing hardcoded download limits
+  // across release versions.
   // The existing packages are as big as 64MB, so setting the limit to 80MB for now.
   static constexpr size_t kMaxBoundedStringDownloadSize = 80 * 1024 * 1024;
 #else

--- a/services/network/public/cpp/simple_url_loader.h
+++ b/services/network/public/cpp/simple_url_loader.h
@@ -92,8 +92,12 @@ class COMPONENT_EXPORT(NETWORK_CPP) SimpleURLLoader {
   };
 
   // The maximum size DownloadToString will accept.
-  static constexpr size_t kMaxBoundedStringDownloadSize = 5 * 1024 * 1024;
-
+#if BUILDFLAG(IS_STARBOARD)
+  // The existing packages are as big as 64MB, so setting the limit to 80MB for now.
+  static constexpr size_t kMaxBoundedStringDownloadSize = 80 * 1024 * 1024;
+#else
+  static constexpr size_t kMaxBoundedStringDownloadSize = 20 * 1024 * 1024;
+#endif
   // Maximum upload body size to send as a block to the URLLoaderFactory. This
   // data may appear in memory twice for a while, in the retry case, and there
   // may briefly be 3 to 5 copies as it's copied over the Mojo pipe:  This

--- a/starboard/evergreen/shared/platform_configuration/BUILD.gn
+++ b/starboard/evergreen/shared/platform_configuration/BUILD.gn
@@ -50,7 +50,7 @@ config("platform_configuration") {
     # this macro.
     # TODO(b/444006168): Uncomment this once in-memory updates is fully
     # supported.
-    # "IN_MEMORY_UPDATES",
+    "IN_MEMORY_UPDATES",
   ]
 
   if (use_asan) {

--- a/third_party/zlib/google/zip.cc
+++ b/third_party/zlib/google/zip.cc
@@ -301,6 +301,17 @@ bool Zip(const ZipParams& params) {
   return zip_writer->Close();
 }
 
+#if defined(IN_MEMORY_UPDATES)
+bool Unzip(const std::string& zip_str,
+           const base::FilePath& dest_dir,
+           UnzipOptions options) {
+  return Unzip(zip_str,
+               base::BindRepeating(&CreateFilePathWriterDelegate, dest_dir),
+               base::BindRepeating(&CreateDirectory, dest_dir),
+               std::move(options));
+}
+#endif
+
 bool Unzip(const base::FilePath& src_file,
            const base::FilePath& dest_dir,
            UnzipOptions options,
@@ -312,8 +323,13 @@ bool Unzip(const base::FilePath& src_file,
     return false;
   }
 
+#if BUILDFLAG(IS_STARBOARD)
+// |dest_dir| contains a newly created drain file to prevent race conditions,
+// so it is expected to be non-empty.
+#else
   DLOG_IF(WARNING, !base::IsDirectoryEmpty(dest_dir))
       << "ZIP extraction directory is not empty: " << dest_dir;
+#endif
 
   base::RepeatingCallback<bool(const base::FilePath&, const base::FilePath&)>
       symlink_creator;
@@ -328,6 +344,61 @@ bool Unzip(const base::FilePath& src_file,
                    base::BindRepeating(&CreateDirectory, dest_dir),
                    std::move(options), symlink_creator);
 }
+
+#if defined(IN_MEMORY_UPDATES)
+bool Unzip(const std::string& zip_str,
+           WriterFactory writer_factory,
+           DirectoryCreator directory_creator,
+           UnzipOptions options) {
+  ZipReader reader;
+  reader.SetEncoding(std::move(options.encoding));
+  reader.SetPassword(std::move(options.password));
+
+  if (!reader.OpenFromString(zip_str)) {
+    LOG(ERROR) << "Failed to open zip_str";
+    return false;
+  }
+
+  while (const ZipReader::Entry* const entry = reader.Next()) {
+    if (entry->is_unsafe) {
+      LOG(ERROR) << "Found unsafe entry " << Redact(entry->path) << " in ZIP";
+      if (!options.continue_on_error)
+        return false;
+      continue;
+    }
+
+    if (options.filter && !options.filter.Run(entry->path)) {
+      VLOG(1) << "Skipped ZIP entry " << Redact(entry->path);
+      continue;
+    }
+
+    if (entry->is_directory) {
+      // It's a directory.
+      if (!directory_creator.Run(entry->path)) {
+        LOG(ERROR) << "Cannot create directory " << Redact(entry->path);
+        if (!options.continue_on_error)
+          return false;
+      }
+
+      continue;
+    }
+
+    // It's a file.
+    std::unique_ptr<WriterDelegate> writer = writer_factory.Run(entry->path);
+    if (!writer ||
+        (options.progress ? !reader.ExtractCurrentEntryWithListener(
+                                writer.get(), options.progress)
+                          : !reader.ExtractCurrentEntry(writer.get()))) {
+      LOG(ERROR) << "Cannot extract file " << Redact(entry->path)
+                 << " from ZIP";
+      if (!options.continue_on_error)
+        return false;
+    }
+  }
+
+  return reader.ok();
+}
+#endif //  defined(IN_MEMORY_UPDATES)
 
 bool Unzip(const base::PlatformFile& src_file,
            WriterFactory writer_factory,

--- a/third_party/zlib/google/zip.h
+++ b/third_party/zlib/google/zip.h
@@ -212,6 +212,24 @@ typedef base::RepeatingCallback<std::unique_ptr<WriterDelegate>(
 
 typedef base::RepeatingCallback<bool(const base::FilePath&)> DirectoryCreator;
 
+#if defined(IN_MEMORY_UPDATES)
+// Unzips the contents of |zip_str|, using the writers provided by
+// |writer_factory|.
+bool Unzip(const std::string& zip_str,
+           WriterFactory writer_factory,
+           DirectoryCreator directory_creator,
+           UnzipOptions options = {});
+
+// Unzips the contents of |zip_str| into |dest_dir|.
+// This function does not overwrite any existing file.
+// A filename collision will result in an error.
+// |dest_dir| is purged by CobaltSlotManagement::ConfirmSlot(),
+// except for the newly created drain file.
+bool Unzip(const std::string& zip_str,
+           const base::FilePath& dest_dir,
+           UnzipOptions options = {});
+#endif
+
 // Unzips the contents of |zip_file|, using the writers provided by
 // |writer_factory|.
 bool Unzip(const base::PlatformFile& zip_file,


### PR DESCRIPTION
Port the core in-memory update pipeline from PR #8161 to main, allowing
update packages to be downloaded directly into memory, verified, and unpacked.
Key changes in this PR over the original implementation:

1. Updated CRX verification logic in `crx_verifier.cc` to utilize Chromium's
   modern `crypto::hash::Hasher` and `base::span` APIs.
2. Implemented strict bounds checking on key hash copies (`span::copy_from`)
   and applied `base::checked_cast` on header sizes to guarantee robust,
   crash-proof error handling against malformed CRX3 inputs.
3. Handled compatibility issues with newer pipeline operations on main
   (including zucchini, puffin, and xz) for in-memory updates, cleanly gating unsupported
   operations.
4. Configured in-memory download string limit to 80MB in `simple_url_loader.h`
   and added tracking TODO (b/465213840) to coordinate long-term quota
   management with upstream network authors.

Issue: 479816505