### PR TITLE
ci: Fix git rm output leak in autoroll script

### DIFF
--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -113,7 +113,7 @@ def resolve_conflicts(unmerged):
         f"Resolving 'deleted by us' conflicts: {deleted_by_us}",
         file=sys.stderr)
     for path in deleted_by_us:
-      subprocess.run(['git', 'rm', path], check=True)
+      subprocess.run(['git', 'rm', path], check=True, stdout=sys.stderr)
     return True
 
   return False


### PR DESCRIPTION
Redirect the stdout of git rm to stderr in the autoroll script conflict
resolution logic. This prevents git rm output from being captured and
included in the pull request description generated by the automated
workflow.

Bug: 512199092