### PR TITLE
ci: Add media team as code owner

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -16,7 +16,7 @@
 /cobalt/app      @youtube/cobalt-embedder-owners
 /cobalt/browser  @youtube/cobalt-embedder-owners
 /cobalt/gpu      @youtube/cobalt-embedder-owners
-/cobalt/renderer @youtube/cobalt-embedder-owners
+/cobalt/renderer @youtube/cobalt-embedder-owners @youtube/cobalt-media
 /cobalt/shell    @youtube/cobalt-embedder-owners
 
 /starboard/  # no default owners


### PR DESCRIPTION
Update the CODEOWNERS configuration to assign the media team as owners
of the Cobalt content renderer client files. This ensures the team is
automatically requested for reviews on changes to these files. This
change also adjusts the alignment of existing media-related entries
for better readability.

Issue: 513687482