### PR TITLE
build: Restore missing binary size reduction flags

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -72,6 +72,11 @@ enable_widevine = true
 
 generate_about_credits = false
 
+# Disable plugins, PDF, and printing support to reduce binary size (from PR #7888).
+enable_plugins = false
+enable_pdf = false
+enable_printing = false
+
 # Disable WebNN and some bits of TensorFlowLite.
 build_tflite_with_xnnpack = false
 webnn_use_tflite = false

--- a/cobalt/build/configs/linux_common.gn
+++ b/cobalt/build/configs/linux_common.gn
@@ -98,8 +98,8 @@ use_dbus = false
 # Embed ICU data in the cobalt binary
 icu_use_data_file = false
 
-# Disable the Pepper API (PPAPI) plugin support
-enable_ppapi = false
+# Disable Linux hardware-accelerated video APIs explicitly (from PR #5515).
+use_vaapi = false
 
 # Enable the compiler size optimizations e.g. -Os.
 optimize_for_size = true


### PR DESCRIPTION
This is the result of reviewing https://github.com/youtube/cobalt/pulls?page=2&q=label%3Alightweight+is%3Aclosed

This change restores those flags to ensure a minimal binary footprint across Cobalt builds:
- enable_plugins = false (from PR #7888)
- enable_pdf = false (from PR #7888)
- enable_printing = false (from PR #7888)
- use_vaapi = false (from PR #5515)