### PR TITLE
BACKPORT: compile_xcassets: Support .brandassets files as app icon names

### DIFF
--- a/build/toolchain/apple/compile_xcassets.py
+++ b/build/toolchain/apple/compile_xcassets.py
@@ -34,6 +34,9 @@ NOTICE_SECTION = 'com.apple.actool.compilation-results'
 # App icon asset type.
 APP_ICON_ASSET_TYPE = '.appiconset'
 
+# Brand assets type (tvOS-specific).
+BRAND_ASSETS_TYPE = '.brandassets'
+
 # Map special type of asset catalog to the corresponding command-line
 # parameter that need to be passed to actool.
 ACTOOL_FLAG_FOR_ASSET_TYPE = {
@@ -242,10 +245,11 @@ def CompileAssetCatalog(output, target_os, target_environment, product_type,
 
       asset_name, asset_type = os.path.splitext(file_or_dir_name)
 
-      # If the asset is an app icon, and the caller has specified an app icon
-      # to use, then skip this asset as it will be included in the app icon
-      # set. Otherwise, add the asset to the command-line.
-      if asset_type == APP_ICON_ASSET_TYPE:
+      # If the asset is either an app icon or a brand asset, and the
+      # caller has specified an app icon to use, then skip this asset as
+      # it will be included in the app icon set. Otherwise, add the asset
+      # to the command-line.
+      if asset_type in (APP_ICON_ASSET_TYPE, BRAND_ASSETS_TYPE):
         if app_icon:
           continue
         else:


### PR DESCRIPTION
This is required for the build system to recognize the app icon/top shelf image format used by tvOS and add them to the bundle's assets.

Bug: 507533729

---

Original commit message:

This is a format used on tvOS to specify the app icon and top shelf image:
https://developer.apple.com/library/archive/documentation/Xcode/Reference/xcode_ref-Asset_Catalog_Format/BrandAssetsType.html#//apple_ref/doc/uid/TP40015170-CH37-SW1

Given a directory Foo.brandassets, actool also supports passing 'Foo' to its --app-icon argument, so just extend the existing logic to derive the app icon name that checks for .appicon types.

Change-Id: I1bb706fe8c92b5a2ce003433ff49f6e9b94c6621
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7852538
Cr-Commit-Position: refs/heads/main@{#1632146}