### PR TITLE
android: Refine pending inputs handling in VideoRendererImpl

### DIFF
--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -491,6 +491,7 @@ void VideoRendererImpl::WritePendingInputs() {
   if (pending_end_of_stream_ && pending_input_buffers_.empty()) {
     // All pending buffers have been sent to the decoder; now it's safe to
     // send the end-of-stream signal.
+    pending_end_of_stream_ = false;
     WriteEndOfStream();
   }
 }


### PR DESCRIPTION
Reset the pending end-of-stream flag before calling WriteEndOfStream
while writing pending inputs. This ensures the internal state is
synchronized before the end-of-stream signal is processed by the
player, preventing potential inconsistencies in state tracking.

Bug: 513852955