### PR TITLE
android: Remove unneeded not_empty.txt asset placeholders

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -194,11 +194,7 @@ android_library("cobalt_apk_java") {
 }
 
 android_assets("coat_assets") {
-  sources = [
-    "apk/app/src/app/assets/not_empty.txt",
-    "apk/app/src/app/assets/test/not_empty.txt",
-    "apk/app/src/app/assets/web/cobalt_logo_1024.png",
-  ]
+  sources = [ "apk/app/src/app/assets/web/cobalt_logo_1024.png" ]
   disable_compression = true
 }
 

--- a/cobalt/android/apk/app/src/app/assets/not_empty.txt
+++ b/cobalt/android/apk/app/src/app/assets/not_empty.txt
@@ -1,4 +1,0 @@
-This file is here to ensure that the corresponding directory has at least one
-file in it so that base_unittests PathServiceTest::Get() can see it as
-base::DIR_EXE and base::DIR_MODULE (aka kSbSystemPathContentDirectory). See the
-implementation of OpenAndroidAssetDir() for more details.

--- a/cobalt/android/apk/app/src/app/assets/test/not_empty.txt
+++ b/cobalt/android/apk/app/src/app/assets/test/not_empty.txt
@@ -1,4 +1,0 @@
-This file is here to ensure that the corresponding directory has at least one
-file in it so that base_unittests PathServiceTest::Get() can see it as
-base::DIR_TEST_DATA. See the implementation of OpenAndroidAssetDir() for more
-details.


### PR DESCRIPTION
Remove unneeded not_empty.txt placeholders from
//cobalt/android:coat_assets. Since the target was not using renaming_sources/destinations, both paths were flattened to assets/not_empty.txt. In addition, since the logo file was already present at assets/, none of them are actually needed.

Bug: 492403745