### PR TITLE
Add java switches for tuning compositor tile configurations

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -65,12 +65,12 @@ public class JavaSwitches {
     StringJoiner featureParams = new StringJoiner("/");
     if (javaSwitches.containsKey(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS)) {
       String size = javaSwitches.get(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS).replaceAll("[^0-9]", "");
-      featureParams.add("size_in_pixels/" + size); 
+      featureParams.add("size_in_pixels/" + size);
     }
 
     if (javaSwitches.containsKey(JavaSwitches.RECLAIM_DELAY_IN_SECONDS)) {
       String delay = javaSwitches.get(JavaSwitches.RECLAIM_DELAY_IN_SECONDS).replaceAll("[^0-9]", "");
-      featureParams.add("reclaim_delay_s/" + delay); 
+      featureParams.add("reclaim_delay_s/" + delay);
     }
 
     if (featureParams.length() > 0) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -37,6 +37,12 @@ public class JavaSwitches {
   /** V8 flag to disable decommitting pooled pages. */
   public static final String DISABLE_V8_DECOMMIT_POOLED_PAGES = "DisableV8DecommitPooledPages";
 
+  /** flag to tune compositor offscreen interest area size in pixels. */
+  public static final String INTEREST_AREA_SIZE_IN_PIXELS = "InterestAreaSizeInPixels";
+
+  /** flag to tune delay in seconds before reclaiming prepaint tiles when idle. */
+  public static final String RECLAIM_DELAY_IN_SECONDS = "ReclaimDelayInSeconds";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
 
@@ -54,6 +60,16 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_V8_DECOMMIT_POOLED_PAGES)) {
       extraCommandLineArgs.add("--js-flags=--no-decommit-pooled-pages");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS)) {
+      String size = javaSwitches.get(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS).replaceAll("[^0-9]", "");
+      extraCommandLineArgs.add("--enable-features=SmallerInterestArea:size_in_pixels/" + size);
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.RECLAIM_DELAY_IN_SECONDS)) {
+      String delay = javaSwitches.get(JavaSwitches.RECLAIM_DELAY_IN_SECONDS).replaceAll("[^0-9]", "");
+      extraCommandLineArgs.add("--enable-features=SmallerInterestArea:reclaim_delay_s/" + delay);
     }
 
     return extraCommandLineArgs;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -17,6 +17,7 @@ package dev.cobalt.util;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.StringJoiner;
 
 /**
  * Defines the constant names for feature switches used in Kimono.

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -62,14 +62,20 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--js-flags=--no-decommit-pooled-pages");
     }
 
+    StringJoiner featureParams = new StringJoiner("/");
     if (javaSwitches.containsKey(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS)) {
       String size = javaSwitches.get(JavaSwitches.INTEREST_AREA_SIZE_IN_PIXELS).replaceAll("[^0-9]", "");
-      extraCommandLineArgs.add("--enable-features=SmallerInterestArea:size_in_pixels/" + size);
+      featureParams.add("size_in_pixels/" + size); 
     }
 
     if (javaSwitches.containsKey(JavaSwitches.RECLAIM_DELAY_IN_SECONDS)) {
       String delay = javaSwitches.get(JavaSwitches.RECLAIM_DELAY_IN_SECONDS).replaceAll("[^0-9]", "");
-      extraCommandLineArgs.add("--enable-features=SmallerInterestArea:reclaim_delay_s/" + delay);
+      featureParams.add("reclaim_delay_s/" + delay); 
+    }
+
+    if (featureParams.length() > 0) {
+      extraCommandLineArgs.add(
+          "--enable-features=SmallerInterestArea:" + featureParams.toString());
     }
 
     return extraCommandLineArgs;


### PR DESCRIPTION
Add `InterestAreaSizeInPixels` and `ReclaimDelayInSeconds` Java switches
to allow runtime experimentation with compositor offscreen interest
area size and tile reclaim delays. These switches map to the
SmallerInterestArea feature flag and will help in investigating
opportunities for memory reduction on Android devices.

Bug: 512154139