### PR TITLE
android: Wait for surface during player creation

### DIFF
--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -16,6 +16,7 @@
 #include "starboard/player.h"
 // clang-format on
 
+#include <chrono>
 #include <string>
 #include <utility>
 
@@ -32,6 +33,12 @@
 #include "starboard/shared/starboard/player/filter/filter_based_player_worker_handler.h"
 #include "starboard/shared/starboard/player/player_internal.h"
 #include "starboard/shared/starboard/player/player_worker.h"
+
+namespace {
+
+constexpr auto kVideoSurfaceWaitTimeout = std::chrono::seconds(5);
+
+}  // namespace
 
 SbPlayer SbPlayerCreate(SbWindow /*window*/,
                         const SbPlayerCreationParam* creation_param,
@@ -195,9 +202,16 @@ SbPlayer SbPlayerCreate(SbWindow /*window*/,
     // Check the availability of the video window. As we only support one main
     // player, and sub players are in decode to texture mode on Android, a
     // single video window should be enough.
-    if (!starboard::VideoSurfaceHolder::IsVideoSurfaceAvailable() &&
-        !starboard::GetSurfaceViewForCurrentThread()) {
-      SB_LOG(ERROR) << "Video surface is not available now.";
+
+    // Block safely on a condition variable until the UI thread registers the
+    // surface (up to kVideoSurfaceWaitTimeout) to resolve the startup race
+    // condition where player creation runs ahead of surface registration. We
+    // check the fast thread-local surface first to avoid blocking in
+    // AndroidOverlay mode.
+    if (!starboard::GetSurfaceViewForCurrentThread() &&
+        !starboard::VideoSurfaceHolder::WaitForVideoSurface(
+            kVideoSurfaceWaitTimeout)) {
+      SB_LOG(ERROR) << "Video surface is not available now after waiting.";
       player_error_func(kSbPlayerInvalid, context, kSbPlayerErrorDecode,
                         "Video surface is not available now");
       return kSbPlayerInvalid;

--- a/starboard/android/shared/player_create.cc
+++ b/starboard/android/shared/player_create.cc
@@ -36,7 +36,7 @@
 
 namespace {
 
-constexpr auto kVideoSurfaceWaitTimeout = std::chrono::seconds(5);
+constexpr auto kVideoSurfaceWaitTimeout = std::chrono::seconds(30);
 
 }  // namespace
 

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -20,6 +20,8 @@
 #include <android/native_window_jni.h>
 #include <jni.h>
 
+#include <chrono>
+#include <condition_variable>
 #include <mutex>
 
 #include "cobalt/android/jni_headers/VideoSurfaceView_jni.h"
@@ -38,6 +40,8 @@ namespace {
 
 // Global video surface pointer mutex.
 SB_ONCE_INITIALIZE_FUNCTION(std::mutex, GetViewSurfaceMutex)
+// Global condition variable to notify waiters when surface becomes available.
+SB_ONCE_INITIALIZE_FUNCTION(std::condition_variable, GetViewSurfaceCondVar)
 // Global pointer to the single video surface.
 jobject g_j_video_surface = NULL;
 // Global pointer to the single video window.
@@ -53,22 +57,27 @@ bool g_reset_surface_on_clear_window = false;
 void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
     JNIEnv* env,
     const JavaParamRef<jobject>& surface) {
-  std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_video_surface_holder) {
-    g_video_surface_holder->OnSurfaceDestroyed();
-    g_video_surface_holder = NULL;
-  }
-  if (g_j_video_surface) {
-    env->DeleteGlobalRef(g_j_video_surface);
-    g_j_video_surface = NULL;
-  }
-  if (g_native_video_window) {
-    ANativeWindow_release(g_native_video_window);
-    g_native_video_window = NULL;
+  {
+    std::lock_guard lock(*GetViewSurfaceMutex());
+    if (g_video_surface_holder) {
+      g_video_surface_holder->OnSurfaceDestroyed();
+      g_video_surface_holder = NULL;
+    }
+    if (g_j_video_surface) {
+      env->DeleteGlobalRef(g_j_video_surface);
+      g_j_video_surface = NULL;
+    }
+    if (g_native_video_window) {
+      ANativeWindow_release(g_native_video_window);
+      g_native_video_window = NULL;
+    }
+    if (surface) {
+      g_j_video_surface = env->NewGlobalRef(surface.obj());
+      g_native_video_window = ANativeWindow_fromSurface(env, surface.obj());
+    }
   }
   if (surface) {
-    g_j_video_surface = env->NewGlobalRef(surface.obj());
-    g_native_video_window = ANativeWindow_fromSurface(env, surface.obj());
+    GetViewSurfaceCondVar()->notify_all();
   }
 }
 
@@ -77,12 +86,14 @@ void JNI_VideoSurfaceView_SetNeedResetSurface(JNIEnv* env) {
 }
 
 // static
-bool VideoSurfaceHolder::IsVideoSurfaceAvailable() {
-  // We only consider video surface is available when there is a video
-  // surface and it is not held by any decoder, i.e.
-  // g_video_surface_holder is NULL.
-  std::lock_guard lock(*GetViewSurfaceMutex());
-  return !g_video_surface_holder && g_j_video_surface;
+bool VideoSurfaceHolder::WaitForVideoSurface(
+    std::chrono::milliseconds timeout) {
+  std::unique_lock lock(*GetViewSurfaceMutex());
+  if (g_j_video_surface) {
+    return true;
+  }
+  return GetViewSurfaceCondVar()->wait_for(
+      lock, timeout, [] { return g_j_video_surface != nullptr; });
 }
 
 jobject VideoSurfaceHolder::AcquireVideoSurface() {

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -43,11 +43,11 @@ SB_ONCE_INITIALIZE_FUNCTION(std::mutex, GetViewSurfaceMutex)
 // Global condition variable to notify waiters when surface becomes available.
 SB_ONCE_INITIALIZE_FUNCTION(std::condition_variable, GetViewSurfaceCondVar)
 // Global pointer to the single video surface.
-jobject g_j_video_surface = NULL;
+jobject g_j_video_surface = nullptr;
 // Global pointer to the single video window.
-ANativeWindow* g_native_video_window = NULL;
+ANativeWindow* g_native_video_window = nullptr;
 // Global video surface pointer holder.
-VideoSurfaceHolder* g_video_surface_holder = NULL;
+VideoSurfaceHolder* g_video_surface_holder = nullptr;
 // Global boolean to indicate if we need to reset SurfaceView after playing
 // vertical video.
 bool g_reset_surface_on_clear_window = false;
@@ -61,15 +61,15 @@ void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
     std::lock_guard lock(*GetViewSurfaceMutex());
     if (g_video_surface_holder) {
       g_video_surface_holder->OnSurfaceDestroyed();
-      g_video_surface_holder = NULL;
+      g_video_surface_holder = nullptr;
     }
     if (g_j_video_surface) {
       env->DeleteGlobalRef(g_j_video_surface);
-      g_j_video_surface = NULL;
+      g_j_video_surface = nullptr;
     }
     if (g_native_video_window) {
       ANativeWindow_release(g_native_video_window);
-      g_native_video_window = NULL;
+      g_native_video_window = nullptr;
     }
     if (surface) {
       g_j_video_surface = env->NewGlobalRef(surface.obj());
@@ -96,11 +96,11 @@ bool VideoSurfaceHolder::WaitForVideoSurface(
 
 jobject VideoSurfaceHolder::AcquireVideoSurface() {
   std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_video_surface_holder != NULL) {
-    return NULL;
+  if (g_video_surface_holder != nullptr) {
+    return nullptr;
   }
   if (!g_j_video_surface) {
-    return NULL;
+    return nullptr;
   }
   g_video_surface_holder = this;
   return g_j_video_surface;
@@ -118,7 +118,7 @@ void VideoSurfaceHolder::ReleaseVideoSurface() {
 
 bool VideoSurfaceHolder::GetVideoWindowSize(int* width, int* height) {
   std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_native_video_window == NULL) {
+  if (g_native_video_window == nullptr) {
     return false;
   } else {
     *width = ANativeWindow_getWidth(g_native_video_window);

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -89,11 +89,9 @@ void JNI_VideoSurfaceView_SetNeedResetSurface(JNIEnv* env) {
 bool VideoSurfaceHolder::WaitForVideoSurface(
     std::chrono::milliseconds timeout) {
   std::unique_lock lock(*GetViewSurfaceMutex());
-  if (g_j_video_surface) {
-    return true;
-  }
-  return GetViewSurfaceCondVar()->wait_for(
-      lock, timeout, [] { return g_j_video_surface != nullptr; });
+  return GetViewSurfaceCondVar()->wait_for(lock, timeout, [] {
+    return g_j_video_surface != nullptr && g_video_surface_holder == nullptr;
+  });
 }
 
 jobject VideoSurfaceHolder::AcquireVideoSurface() {
@@ -109,10 +107,13 @@ jobject VideoSurfaceHolder::AcquireVideoSurface() {
 }
 
 void VideoSurfaceHolder::ReleaseVideoSurface() {
-  std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_video_surface_holder == this) {
-    g_video_surface_holder = NULL;
+  {
+    std::lock_guard lock(*GetViewSurfaceMutex());
+    if (g_video_surface_holder == this) {
+      g_video_surface_holder = nullptr;
+    }
   }
+  GetViewSurfaceCondVar()->notify_all();
 }
 
 bool VideoSurfaceHolder::GetVideoWindowSize(int* width, int* height) {

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -18,12 +18,15 @@
 #include <android/native_window.h>
 #include <jni.h>
 
+#include <chrono>
+
 namespace starboard {
 
 class VideoSurfaceHolder {
  public:
-  // Return true only if the video surface is available.
-  static bool IsVideoSurfaceAvailable();
+  // Suspends the thread until the surface is available, or timeout occurs.
+  // Returns true if surface became available, false on timeout.
+  static bool WaitForVideoSurface(std::chrono::milliseconds timeout);
 
   // OnSurfaceDestroyed() will be invoked when surface is destroyed. When this
   // function is called, the decoder no longer owns the surface. Calling


### PR DESCRIPTION
On Android, deep-link launches can trigger Activity recreation which
destroys the initial SurfaceView. If the media thread initializes the
player before the UI thread registers a new surface, playback can fail
or result in a black screen.

This change ensures the media thread waits for the video surface to be
registered before proceeding with player creation. This resolves the
race condition between the asynchronous media thread and the UI thread
during startup.


Issue: 514355186