### PR TITLE
evergreen: add EG info to ua string and send it to the updater

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -386,7 +386,7 @@ void CobaltContentBrowserClient::OnWebContentsCreated(
     LOG(INFO) << "Creating UpdaterModule singleton.";
     updater::UpdaterModule::CreateInstance(
         storage_partition->GetURLLoaderFactoryForBrowserProcess(),
-        updater::kDefaultUpdateCheckDelay);
+        GetUserAgent(), updater::kDefaultUpdateCheckDelay);
   }
 #endif
 }

--- a/cobalt/browser/user_agent/BUILD.gn
+++ b/cobalt/browser/user_agent/BUILD.gn
@@ -35,4 +35,10 @@ static_library("user_agent") {
       "ANDROID_ABI=$android_app_abi",
     ]
   }
+
+  deps = []
+
+  if (use_evergreen) {
+    deps += [ "//cobalt/updater" ]
+  }
 }

--- a/cobalt/browser/user_agent/user_agent_platform_info.cc
+++ b/cobalt/browser/user_agent/user_agent_platform_info.cc
@@ -34,6 +34,11 @@
 #include "starboard/extension/platform_info.h"
 #include "v8/include/v8-version-string.h"
 
+#if BUILDFLAG(USE_EVERGREEN)
+#include "cobalt/updater/util.h"
+#include "starboard/extension/installation_manager.h"
+#endif
+
 namespace cobalt {
 
 void GetUserAgentInputMap(
@@ -199,15 +204,6 @@ void UserAgentPlatformInfo::InitializePlatformDependentFieldsStarboard() {
       starboard::GetSystemPropertyString(kSbSystemPropertyFirmwareVersion));
   // Rasterizer type is gles for both Linux and Android.
   set_rasterizer_type("gles");
-
-  // TODO(cobalt, b/374213479): Retrieve Evergreen
-  // #if BUILDFLAG(IS_EVERGREEN)
-  //   updater::EvergreenLibraryMetadata evergreen_library_metadata =
-  //       updater::GetCurrentEvergreenLibraryMetadata();
-  //   set_evergreen_version(evergreen_library_metadata.version);
-  //   set_evergreen_file_type(evergreen_library_metadata.file_type);
-  //   set_evergreen_type("Lite");
-  // #endif
 }
 
 #elif BUILDFLAG(IS_IOS_TVOS)
@@ -277,6 +273,20 @@ void UserAgentPlatformInfo::InitializeUserAgentPlatformInfoFields() {
   // We only support JIT for both Linux and Android.
   set_javascript_engine_version(
       base::StringPrintf("v8/%s-jit", V8_VERSION_STRING));
+
+#if BUILDFLAG(USE_EVERGREEN)
+  updater::EvergreenLibraryMetadata evergreen_library_metadata =
+      updater::GetCurrentEvergreenLibraryMetadata();
+  set_evergreen_version(evergreen_library_metadata.version);
+  set_evergreen_file_type(evergreen_library_metadata.file_type);
+  if (!SbSystemGetExtension(kCobaltExtensionInstallationManagerName)) {
+    // If the installation manager is not initialized, the "evergreen_lite"
+    // command line parameter is specified and the system image is loaded.
+    set_evergreen_type("Lite");
+  } else {
+    set_evergreen_type("Full");
+  }
+#endif
 
   if (!avoid_access_to_starboard_for_testing_) {
     set_device_type(

--- a/cobalt/browser/user_agent/user_agent_platform_info.cc
+++ b/cobalt/browser/user_agent/user_agent_platform_info.cc
@@ -35,7 +35,7 @@
 #include "v8/include/v8-version-string.h"
 
 #if BUILDFLAG(USE_EVERGREEN)
-#include "cobalt/updater/util.h"
+#include "cobalt/updater/util.h"  //nogncheck
 #include "starboard/extension/installation_manager.h"
 #endif
 

--- a/cobalt/updater/configurator.cc
+++ b/cobalt/updater/configurator.cc
@@ -73,7 +73,8 @@ namespace cobalt {
 namespace updater {
 
 Configurator::Configurator(
-    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory)
+    scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const std::string& user_agent)
     : pref_service_(CreatePrefService()),
       persisted_data_(update_client::CreatePersistedData(
           base::BindRepeating([](PrefService* p) { return p; },
@@ -88,6 +89,7 @@ Configurator::Configurator(
       patch_factory_(base::MakeRefCounted<PatcherFactory>()),
       crx_cache_(base::MakeRefCounted<update_client::CrxCache>(std::nullopt)),
       is_forced_update_(0),
+      user_agent_string_(user_agent),
       min_free_space_bytes_(48 * 1024 * 1024),  // 48MB
       allow_self_signed_packages_(false),
       require_network_encryption_(true) {

--- a/cobalt/updater/configurator.h
+++ b/cobalt/updater/configurator.h
@@ -65,7 +65,7 @@ namespace updater {
 // mechanisms (locks, atomics) are used to ensure thread safety.
 class Configurator : public update_client::Configurator {
  public:
-  explicit Configurator(
+  Configurator(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
       const std::string& user_agent);
 

--- a/cobalt/updater/configurator.h
+++ b/cobalt/updater/configurator.h
@@ -66,7 +66,8 @@ namespace updater {
 class Configurator : public update_client::Configurator {
  public:
   explicit Configurator(
-      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory);
+      scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      const std::string& user_agent);
 
   // Configurator for update_client::Configurator.
   base::TimeDelta InitialDelay() const override;

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -97,6 +97,7 @@ UpdaterModule* UpdaterModule::updater_module_ = nullptr;
 
 void UpdaterModule::CreateInstance(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const std::string& user_agent,
     base::TimeDelta update_check_delay) {
   if (updater_module_) {
     LOG(WARNING)
@@ -104,8 +105,8 @@ void UpdaterModule::CreateInstance(
            "to get the instance.";
     return;
   }
-  updater_module_ =
-      new UpdaterModule(std::move(url_loader_factory), update_check_delay);
+  updater_module_ = new UpdaterModule(std::move(url_loader_factory), user_agent,
+                                      update_check_delay);
 }
 
 UpdaterModule* UpdaterModule::GetInstance() {
@@ -165,9 +166,11 @@ void Observer::OnEvent(const update_client::CrxUpdateItem& item) {
 
 UpdaterModule::UpdaterModule(
     scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+    const std::string& user_agent,
     base::TimeDelta update_check_delay)
     : url_loader_factory_(std::move(url_loader_factory)),
-      update_check_delay_(update_check_delay) {
+      update_check_delay_(update_check_delay),
+      user_agent_(user_agent) {
   LOG(INFO) << "UpdaterModule::UpdaterModule";
   // TODO(b/453693299): investigate using sequence to replace base::Thread
   updater_thread_.reset(new base::Thread("Updater"));
@@ -240,7 +243,8 @@ void UpdaterModule::Initialize(
   LOG(INFO) << "UpdaterModule::Initialize";
 
   updater_configurator_ = base::MakeRefCounted<Configurator>(
-      network::SharedURLLoaderFactory::Create(std::move(pending_factory)));
+      network::SharedURLLoaderFactory::Create(std::move(pending_factory)),
+      user_agent_);
   update_client_ = update_client::UpdateClientFactory(updater_configurator_);
 
   updater_observer_.reset(new Observer(update_client_, updater_configurator_));

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -127,7 +127,7 @@ class UpdaterModule {
   void MarkSuccessful();
 
  private:
- // Private constructor and destructor to enforce singleton pattern.
+  // Private constructor and destructor to enforce singleton pattern.
   UpdaterModule(scoped_refptr<network::SharedURLLoaderFactory>,
                 const std::string& user_agent,
                 base::TimeDelta update_check_delay);

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -127,10 +127,9 @@ class UpdaterModule {
   void MarkSuccessful();
 
  private:
-  // Private constructor and destructor to enforce singleton pattern.
-  explicit UpdaterModule(scoped_refptr<network::SharedURLLoaderFactory>,
-                         const std::string& user_agent,
-                         base::TimeDelta update_check_delay);
+  UpdaterModule(scoped_refptr<network::SharedURLLoaderFactory>,
+                const std::string& user_agent,
+                base::TimeDelta update_check_delay);
   ~UpdaterModule();
 
   std::unique_ptr<base::Thread> updater_thread_;

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -127,6 +127,7 @@ class UpdaterModule {
   void MarkSuccessful();
 
  private:
+ // Private constructor and destructor to enforce singleton pattern.
   UpdaterModule(scoped_refptr<network::SharedURLLoaderFactory>,
                 const std::string& user_agent,
                 base::TimeDelta update_check_delay);

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -86,6 +86,7 @@ class UpdaterModule {
  public:
   static void CreateInstance(
       scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory,
+      const std::string& user_agent,
       base::TimeDelta update_check_delay);
 
   static UpdaterModule* GetInstance();
@@ -128,6 +129,7 @@ class UpdaterModule {
  private:
   // Private constructor and destructor to enforce singleton pattern.
   explicit UpdaterModule(scoped_refptr<network::SharedURLLoaderFactory>,
+                         const std::string& user_agent,
                          base::TimeDelta update_check_delay);
   ~UpdaterModule();
 
@@ -139,6 +141,7 @@ class UpdaterModule {
   int update_check_count_ = 0;
   std::atomic<bool> is_updater_running_;
   base::TimeDelta update_check_delay_ = kDefaultUpdateCheckDelay;
+  std::string user_agent_;
 
   int GetUpdateCheckCount() { return update_check_count_; }
   void IncrementUpdateCheckCount() { update_check_count_++; }


### PR DESCRIPTION
Porting original PR #8309, PR #9126.

The only difference is we don't need to allow thread blocking anymore as in PR #8309, maybe due to upstream code change.

Issue: 479816505