### PR TITLE
android: Fix silent Java logging regression in Log wrapper

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
@@ -39,41 +39,24 @@ public final class Log {
   private Log() {}
 
   private static void initLogging() {
+    sLogV = getLogMethod("v");
+    sLogD = getLogMethod("d");
+    sLogI = getLogMethod("i");
+    sLogW = getLogMethod("w");
+    sLogE = getLogMethod("e");
+  }
+
+  private static Method getLogMethod(String methodName) {
     try {
-      sLogV =
-          org.chromium.base.Log.class.getDeclaredMethod(
-              "v", String.class, String.class, Throwable.class);
+      return org.chromium.base.Log.class.getDeclaredMethod(
+          methodName, String.class, String.class, Throwable.class);
     } catch (Throwable e) {
-      // ignore
+      // We catch Throwable to handle NoClassDefFoundError if the R8 compiler
+      // completely strips the org.chromium.base.Log class, preventing a startup crash.
+      // This failure is safely ignorable as logging is a non-critical helper feature
+      // and the application should still boot normally even if logging is disabled.
     }
-    try {
-      sLogD =
-          org.chromium.base.Log.class.getDeclaredMethod(
-              "d", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {
-      // ignore
-    }
-    try {
-      sLogI =
-          org.chromium.base.Log.class.getDeclaredMethod(
-              "i", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {
-      // ignore
-    }
-    try {
-      sLogW =
-          org.chromium.base.Log.class.getDeclaredMethod(
-              "w", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {
-      // ignore
-    }
-    try {
-      sLogE =
-          org.chromium.base.Log.class.getDeclaredMethod(
-              "e", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {
-      // ignore
-    }
+    return null;
   }
 
   private static Throwable getThrowableToLog(Object[] args) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
@@ -43,27 +43,37 @@ public final class Log {
       sLogV =
           org.chromium.base.Log.class.getDeclaredMethod(
               "v", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {}
+    } catch (Throwable e) {
+      // ignore
+    }
     try {
       sLogD =
           org.chromium.base.Log.class.getDeclaredMethod(
               "d", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {}
+    } catch (Throwable e) {
+      // ignore
+    }
     try {
       sLogI =
           org.chromium.base.Log.class.getDeclaredMethod(
               "i", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {}
+    } catch (Throwable e) {
+      // ignore
+    }
     try {
       sLogW =
           org.chromium.base.Log.class.getDeclaredMethod(
               "w", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {}
+    } catch (Throwable e) {
+      // ignore
+    }
     try {
       sLogE =
           org.chromium.base.Log.class.getDeclaredMethod(
               "e", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {}
+    } catch (Throwable e) {
+      // ignore
+    }
   }
 
   private static Throwable getThrowableToLog(Object[] args) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
@@ -43,21 +43,27 @@ public final class Log {
       sLogV =
           org.chromium.base.Log.class.getDeclaredMethod(
               "v", String.class, String.class, Throwable.class);
+    } catch (Throwable e) {}
+    try {
       sLogD =
           org.chromium.base.Log.class.getDeclaredMethod(
               "d", String.class, String.class, Throwable.class);
+    } catch (Throwable e) {}
+    try {
       sLogI =
           org.chromium.base.Log.class.getDeclaredMethod(
               "i", String.class, String.class, Throwable.class);
+    } catch (Throwable e) {}
+    try {
       sLogW =
           org.chromium.base.Log.class.getDeclaredMethod(
               "w", String.class, String.class, Throwable.class);
+    } catch (Throwable e) {}
+    try {
       sLogE =
           org.chromium.base.Log.class.getDeclaredMethod(
               "e", String.class, String.class, Throwable.class);
-    } catch (Throwable e) {
-      // ignore
-    }
+    } catch (Throwable e) {}
   }
 
   private static Throwable getThrowableToLog(Object[] args) {


### PR DESCRIPTION
Isolate dynamic reflection method lookups in the Log utility into
individual try-catch blocks.

The logging wrapper reflects against org.chromium.base.Log, which
does not contain certain overloads for verbose or debug logging.
Previously, these lookups were grouped in a single try-catch block,
causing a failure in any lookup to abort the initialization of
subsequent methods. This resulted in silent logging for warnings and
errors. Using individual blocks ensures that available logging
methods are correctly initialized.

Issue: 514455443