### PR TITLE
Revert "Ignore log settings on device (#4842)"

### DIFF
--- a/base/android/java/src/org/chromium/base/Log.java
+++ b/base/android/java/src/org/chromium/base/Log.java
@@ -75,7 +75,7 @@ public class Log {
      */
     @AlwaysInline
     public static boolean isLoggable(String tag, int level) {
-        return BuildConfig.ENABLE_DEBUG_LOGS;
+        return BuildConfig.ENABLE_DEBUG_LOGS || android.util.Log.isLoggable(tag, level);
     }
 
     /**


### PR DESCRIPTION
This reverts commit ab8342af0c0ae591adaa9d675ab06ad119b2ce63.

Reverting this change enables INFO-level logging by default, matching
the behavior of Chromium and Cobalt 26. This allows the use of system
properties to control logging on the device.

Issue: 514455443