### PR TITLE
starboard: Abstract common ReuseAllocatorBase class

### DIFF
--- a/starboard/common/BUILD.gn
+++ b/starboard/common/BUILD.gn
@@ -84,6 +84,8 @@ static_library("common") {
     "ref_counted.cc",
     "ref_counted.h",
     "result.h",
+    "reuse_allocator_base.cc",
+    "reuse_allocator_base.h",
     "scoped_timer.cc",
     "scoped_timer.h",
     "semaphore.cc",

--- a/starboard/common/embedded_metadata_reuse_allocator_base.cc
+++ b/starboard/common/embedded_metadata_reuse_allocator_base.cc
@@ -18,8 +18,11 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <map>
+#include <tuple>
 
 #include "starboard/common/check_op.h"
+#include "starboard/common/log.h"
 #include "starboard/common/pointer_arithmetic.h"
 
 namespace starboard {
@@ -215,19 +218,13 @@ void EmbeddedMetadataReuseAllocatorBase::Free(void* memory) {
       total_allocated_in_bytes_ = 0;
       total_allocated_blocks_ = 0;
 
-      for (int i = 0; i < static_cast<int>(fallback_allocations_.size()); ++i) {
-        AddFreeBlock(MemoryBlock(i, fallback_allocations_[i].address,
-                                 fallback_allocations_[i].size));
-      }
+      EnumerateFallbackAllocations(
+          [this](intptr_t index, void* address, size_t size) {
+            AddFreeBlock(MemoryBlock(static_cast<int>(index), address, size));
+          });
 
       if (enable_decommit_on_idle_) {
-        SB_LOG(INFO) << "Batched free triggered idle state, decommitting "
-                     << fallback_allocations_.size()
-                     << " fallback allocations.";
-        for (const auto& fallback_allocation : fallback_allocations_) {
-          fallback_allocator_->Decommit(fallback_allocation.address,
-                                        fallback_allocation.size);
-        }
+        DecommitFallbackAllocations();
       }
     } else {
       for (auto address_to_free : pending_frees_) {
@@ -270,16 +267,15 @@ void EmbeddedMetadataReuseAllocatorBase::PrintAllocations(
     head = head->next;
   }
 
+  size_t capacity = GetCapacity();
   int64_t allocated_percentage =
-      capacity_in_bytes_ == 0
+      capacity == 0
           ? 0
-          : static_cast<int64_t>(total_allocated_in_bytes_) * 100 /
-                capacity_in_bytes_;
+          : static_cast<int64_t>(total_allocated_in_bytes_) * 100 / capacity;
   SB_LOG(INFO) << "Allocated " << total_allocated_in_bytes_ << " bytes ("
                << allocated_percentage << "%) from a pool of capacity "
-               << capacity_in_bytes_ << " bytes.  There are "
-               << capacity_in_bytes_ - total_allocated_in_bytes_
-               << " free bytes.";
+               << capacity << " bytes.  There are "
+               << capacity - total_allocated_in_bytes_ << " free bytes.";
   SB_LOG(INFO) << "Total allocated block: " << total_allocated_blocks_;
 
   int lines = 0;
@@ -342,9 +338,8 @@ bool EmbeddedMetadataReuseAllocatorBase::TryFree(void* memory) {
 
   BlockMetadata* metadata = static_cast<BlockMetadata*>(memory) - 1;
 
-  if (metadata->signature != this || metadata->fallback_index < 0 ||
-      static_cast<size_t>(metadata->fallback_index) >=
-          fallback_allocations_.size()) {
+  if (metadata->signature != this ||
+      !IsValidFallbackIndex(metadata->fallback_index)) {
     return false;
   }
 
@@ -379,12 +374,7 @@ bool EmbeddedMetadataReuseAllocatorBase::TryFree(void* memory) {
   --total_allocated_blocks_;
 
   if (enable_decommit_on_idle_ && total_allocated_in_bytes_ == 0) {
-    SB_LOG(INFO) << "Allocator reached idle state, decommitting "
-                 << fallback_allocations_.size() << " fallback allocations.";
-    for (const auto& fallback_allocation : fallback_allocations_) {
-      fallback_allocator_->Decommit(fallback_allocation.address,
-                                    fallback_allocation.size);
-    }
+    DecommitFallbackAllocations();
   }
 
   return true;
@@ -396,9 +386,8 @@ EmbeddedMetadataReuseAllocatorBase::EmbeddedMetadataReuseAllocatorBase(
     size_t allocation_increment,
     size_t max_capacity,
     bool enable_decommit_on_idle)
-    : fallback_allocator_(fallback_allocator),
+    : ReuseAllocatorBase(fallback_allocator, max_capacity),
       allocation_increment_(allocation_increment),
-      max_capacity_in_bytes_(max_capacity),
       enable_decommit_on_idle_(enable_decommit_on_idle) {
   if (initial_capacity > 0) {
     FreeBlockSet::iterator iter = ExpandToFit(initial_capacity, kMinAlignment);
@@ -418,10 +407,6 @@ EmbeddedMetadataReuseAllocatorBase::~EmbeddedMetadataReuseAllocatorBase() {
   // be the case.
   SB_LOG_IF(ERROR, allocated_block_head_ != nullptr)
       << total_allocated_blocks_ << " blocks still allocated.";
-
-  for (const auto& fallback_allocation : fallback_allocations_) {
-    fallback_allocator_->Free(fallback_allocation.address);
-  }
 }
 
 EmbeddedMetadataReuseAllocatorBase::FreeBlockSet::iterator
@@ -440,32 +425,27 @@ EmbeddedMetadataReuseAllocatorBase::ExpandToFit(size_t size, size_t alignment) {
                  << "%).";
   }
 
-  void* ptr = NULL;
+  void* fallback_address = nullptr;
+  intptr_t fallback_index = -1;
   size_t size_to_try = 0;
   // We try to allocate in unit of |allocation_increment_| to minimize
   // fragmentation.
   if (allocation_increment_ > size) {
     size_to_try = allocation_increment_;
-    if (!max_capacity_in_bytes_ ||
-        capacity_in_bytes_ + size_to_try <= max_capacity_in_bytes_) {
-      ptr = fallback_allocator_->AllocateForAlignment(&size_to_try, alignment);
-    }
+    std::tie(fallback_address, fallback_index) =
+        AllocateFallbackBlock(&size_to_try, alignment);
   }
-  // |ptr| being null indicates the above allocation failed, or in the rare case
-  // |size| is larger than |allocation_increment_|. Try to allocate a block of
-  // |size| instead for both cases.
-  if (ptr == NULL) {
+  // |fallback_address| being null indicates the above allocation failed,
+  // or in the rare case |size| is larger than |allocation_increment_|. Try to
+  // allocate a block of |size| instead for both cases.
+  if (fallback_address == nullptr) {
     size_to_try = size;
-    if (!max_capacity_in_bytes_ ||
-        capacity_in_bytes_ + size_to_try <= max_capacity_in_bytes_) {
-      ptr = fallback_allocator_->AllocateForAlignment(&size_to_try, alignment);
-    }
+    std::tie(fallback_address, fallback_index) =
+        AllocateFallbackBlock(&size_to_try, alignment);
   }
-  if (ptr != NULL) {
-    fallback_allocations_.emplace_back(ptr, size_to_try);
-    capacity_in_bytes_ += size_to_try;
+  if (fallback_address != nullptr) {
     auto free_block_iter = AddFreeBlock(MemoryBlock(
-        static_cast<int>(fallback_allocations_.size() - 1), ptr, size_to_try));
+        static_cast<int>(fallback_index), fallback_address, size_to_try));
 
     if (ExtraLogLevel() >= 1) {
       int capacity = GetCapacity();
@@ -476,7 +456,7 @@ EmbeddedMetadataReuseAllocatorBase::ExpandToFit(size_t size, size_t alignment) {
               : static_cast<int64_t>(capacity - allocated) * 100 / capacity;
 
       SB_LOG(INFO) << "Allocated " << size_to_try
-                   << " bytes from fallback allocator (" << ptr
+                   << " bytes from fallback allocator (" << fallback_address
                    << "), capacity expanded to " << capacity << " with "
                    << capacity - allocated << " bytes free (" << free_percentage
                    << "%)";
@@ -523,21 +503,14 @@ EmbeddedMetadataReuseAllocatorBase::ExpandToFit(size_t size, size_t alignment) {
   //                     |           |
   // |free_address + free_size|  |aligned_address|
   size_t size_to_allocate = aligned_address + size - free_address - free_size;
-  if (max_capacity_in_bytes_ &&
-      capacity_in_bytes_ + size_to_allocate > max_capacity_in_bytes_) {
-    SB_LOG_IF(INFO, ExtraLogLevel() >= 1) << "Failed to expand.";
-    return free_blocks_.end();
-  }
-  SB_DCHECK_GT(size_to_allocate, 0U);
-  ptr = fallback_allocator_->AllocateForAlignment(&size_to_allocate, 1);
-  if (ptr == NULL) {
+  std::tie(fallback_address, fallback_index) =
+      AllocateFallbackBlock(&size_to_allocate, 1);
+  if (fallback_address == nullptr) {
     return free_blocks_.end();
   }
 
-  fallback_allocations_.emplace_back(ptr, size_to_allocate);
-  capacity_in_bytes_ += size_to_allocate;
-  AddFreeBlock(MemoryBlock(static_cast<int>(fallback_allocations_.size() - 1),
-                           ptr, size_to_allocate));
+  AddFreeBlock(MemoryBlock(static_cast<int>(fallback_index), fallback_address,
+                           size_to_allocate));
   FreeBlockSet::iterator iter = free_blocks_.end();
   --iter;
 
@@ -550,7 +523,7 @@ EmbeddedMetadataReuseAllocatorBase::ExpandToFit(size_t size, size_t alignment) {
             : static_cast<int64_t>(capacity - allocated) * 100 / capacity;
 
     SB_LOG(INFO) << "Allocated " << size_to_allocate
-                 << " bytes from fallback allocator (" << ptr
+                 << " bytes from fallback allocator (" << fallback_address
                  << "), capacity expanded to " << capacity << " with "
                  << capacity - allocated << " bytes free (" << free_percentage
                  << "%)";

--- a/starboard/common/embedded_metadata_reuse_allocator_base.h
+++ b/starboard/common/embedded_metadata_reuse_allocator_base.h
@@ -15,28 +15,34 @@
 #ifndef STARBOARD_COMMON_EMBEDDED_METADATA_REUSE_ALLOCATOR_BASE_H_
 #define STARBOARD_COMMON_EMBEDDED_METADATA_REUSE_ALLOCATOR_BASE_H_
 
-#include <algorithm>
 #include <cstddef>
 #include <cstdint>
-#include <map>
 #include <set>
 #include <vector>
 
 #include "starboard/common/allocator.h"
 #include "starboard/common/check_op.h"
-#include "starboard/common/log.h"
-#include "starboard/configuration.h"
+#include "starboard/common/reuse_allocator_base.h"
 
 namespace starboard {
 
 // TODO: b/369245553 - Cobalt: Add unit tests once Starboard unittests are
 //                             enabled.
 
-// The base class of memory-pool based allocators, where the underlying memory
-// pool can be efficiently and safely accessed by the CPU, so the allocation
-// metadata can be kept alongside the allocated memory.  It is passed a fallback
-// allocator that it can request additional memory from as needed.
-class EmbeddedMetadataReuseAllocatorBase : public Allocator {
+// Base class for memory-pool based allocators with embedded metadata.
+//
+// Reason for existence: Accommodates cases where the underlying memory pool can
+// be efficiently and safely accessed by the CPU, allowing allocation
+// bookkeeping metadata to be stored directly in-place alongside the allocated
+// memory buffers.
+//
+// Expected lifetime and ownership: Typically instantiated and owned by media
+// pipeline strategies (such as DecoderBufferAllocator), and held for the entire
+// app lifetime across multiple playback sessions.
+//
+// Threading model: Not thread-safe. Callers must provide external
+// synchronization if methods are called from concurrent threads.
+class EmbeddedMetadataReuseAllocatorBase : public ReuseAllocatorBase {
  public:
   void* Allocate(size_t size) override;
   void* Allocate(size_t size, size_t alignment) override;
@@ -44,33 +50,14 @@ class EmbeddedMetadataReuseAllocatorBase : public Allocator {
   // Marks the memory block as being free and it will then become recyclable
   void Free(void* memory) override;
 
-  size_t GetCapacity() const override { return capacity_in_bytes_; }
   size_t GetAllocated() const override { return total_allocated_in_bytes_; }
-
-  bool CapacityExceeded() const {
-    return max_capacity_in_bytes_ &&
-           (capacity_in_bytes_ > max_capacity_in_bytes_);
-  }
 
   void PrintAllocations(bool align_allocated_size,
                         int max_allocations_to_print) const override;
 
   bool TryFree(void* memory);
 
-  size_t max_capacity() const { return max_capacity_in_bytes_; }
-
  protected:
-  // The metadata of an allocated block stored at the very beginning of the
-  // block when it's allocated.  It natually maintains a double linked list to
-  // allow traverse through all allocated blocks.
-  struct BlockMetadata {
-    const EmbeddedMetadataReuseAllocatorBase* signature;
-    intptr_t fallback_index;
-    intptr_t size;
-    BlockMetadata* previous;
-    BlockMetadata* next;
-  };
-
   class MemoryBlock {
    public:
     MemoryBlock() = default;
@@ -153,12 +140,15 @@ class EmbeddedMetadataReuseAllocatorBase : public Allocator {
                                                bool* allocate_from_front) = 0;
 
  private:
-  // Pointer and size of the block allocated from the fallback allocator.
-  struct FallbackAllocation {
-    void* address;
-    size_t size;
-
-    FallbackAllocation(void* addr, size_t s) : address(addr), size(s) {}
+  // The metadata of an allocated block stored at the very beginning of the
+  // block when it's allocated.  It natually maintains a double linked list to
+  // allow traverse through all allocated blocks.
+  struct BlockMetadata {
+    const EmbeddedMetadataReuseAllocatorBase* signature;
+    intptr_t fallback_index;
+    intptr_t size;
+    BlockMetadata* previous;
+    BlockMetadata* next;
   };
 
   FreeBlockSet::iterator ExpandToFit(size_t size, size_t alignment);
@@ -176,24 +166,10 @@ class EmbeddedMetadataReuseAllocatorBase : public Allocator {
   // of blocks.
   std::vector<void*> pending_frees_;
 
-  // We will allocate from the given allocator whenever we can't find pre-used
-  // memory to allocate.
-  Allocator* const fallback_allocator_;
   const size_t allocation_increment_;
 
-  // If non-zero, this is an upper bound on how large we will let the capacity
-  // expand.
-  const size_t max_capacity_in_bytes_;
-
   // Whether to decommit memory when the pool becomes idle.
-  const bool enable_decommit_on_idle_ = false;
-
-  // A list of allocations made from the fallback allocator.  We keep track of
-  // this so that we can free them all upon our destruction.
-  std::vector<FallbackAllocation> fallback_allocations_;
-
-  // How much we have allocated from the fallback allocator.
-  size_t capacity_in_bytes_ = 0;
+  const bool enable_decommit_on_idle_;
 
   // How many bytes has been allocated from us.
   size_t total_allocated_in_bytes_ = 0;

--- a/starboard/common/external_metadata_reuse_allocator_base.cc
+++ b/starboard/common/external_metadata_reuse_allocator_base.cc
@@ -18,8 +18,10 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <tuple>
 
 #include "starboard/common/check_op.h"
+#include "starboard/common/log.h"
 #include "starboard/common/pointer_arithmetic.h"
 
 namespace starboard {
@@ -208,13 +210,14 @@ void ExternalMetadataReuseAllocatorBase::PrintAllocations(
     entry.total += size;
   }
 
+  size_t capacity = GetCapacity();
   int64_t allocated_percentage =
-      capacity_ == 0 ? 0
-                     : static_cast<int64_t>(total_allocated_) * 100 / capacity_;
+      capacity == 0 ? 0
+                    : static_cast<int64_t>(total_allocated_) * 100 / capacity;
   SB_LOG(INFO) << "Allocated " << total_allocated_ << " bytes ("
                << allocated_percentage << "%) from a pool of capacity "
-               << capacity_ << " bytes.  There are "
-               << capacity_ - total_allocated_ << " free bytes.";
+               << capacity << " bytes.  There are "
+               << capacity - total_allocated_ << " free bytes.";
   SB_LOG(INFO) << "Total allocated block: " << allocated_blocks_.size();
 
   int lines = 0;
@@ -290,12 +293,7 @@ bool ExternalMetadataReuseAllocatorBase::TryFree(void* memory) {
   allocated_blocks_.erase(it);
 
   if (enable_decommit_on_idle_ && total_allocated_ == 0) {
-    SB_LOG(INFO) << "Allocator reached idle state, decommitting "
-                 << fallback_allocations_.size() << " fallback allocations.";
-    for (const auto& fallback_allocation : fallback_allocations_) {
-      fallback_allocator_->Decommit(fallback_allocation.address,
-                                    fallback_allocation.size);
-    }
+    DecommitFallbackAllocations();
   }
 
   return true;
@@ -307,12 +305,9 @@ ExternalMetadataReuseAllocatorBase::ExternalMetadataReuseAllocatorBase(
     size_t allocation_increment,
     size_t max_capacity,
     bool enable_decommit_on_idle)
-    : fallback_allocator_(fallback_allocator),
+    : ReuseAllocatorBase(fallback_allocator, max_capacity),
       allocation_increment_(allocation_increment),
-      max_capacity_(max_capacity),
-      enable_decommit_on_idle_(enable_decommit_on_idle),
-      capacity_(0),
-      total_allocated_(0) {
+      enable_decommit_on_idle_(enable_decommit_on_idle) {
   if (initial_capacity > 0) {
     FreeBlockSet::iterator iter = ExpandToFit(initial_capacity, kMinAlignment);
     SB_DCHECK(iter != free_blocks_.end());
@@ -329,10 +324,6 @@ ExternalMetadataReuseAllocatorBase::~ExternalMetadataReuseAllocatorBase() {
   // be the case.
   SB_LOG_IF(ERROR, allocated_blocks_.size() != 0)
       << allocated_blocks_.size() << " blocks still allocated.";
-
-  for (const auto& fallback_allocation : fallback_allocations_) {
-    fallback_allocator_->Free(fallback_allocation.address);
-  }
 }
 
 ExternalMetadataReuseAllocatorBase::FreeBlockSet::iterator
@@ -351,30 +342,27 @@ ExternalMetadataReuseAllocatorBase::ExpandToFit(size_t size, size_t alignment) {
                  << "%).";
   }
 
-  void* ptr = NULL;
+  void* fallback_address = nullptr;
+  intptr_t fallback_index = -1;
   size_t size_to_try = 0;
   // We try to allocate in unit of |allocation_increment_| to minimize
   // fragmentation.
   if (allocation_increment_ > size) {
     size_to_try = allocation_increment_;
-    if (!max_capacity_ || capacity_ + size_to_try <= max_capacity_) {
-      ptr = fallback_allocator_->AllocateForAlignment(&size_to_try, alignment);
-    }
+    std::tie(fallback_address, fallback_index) =
+        AllocateFallbackBlock(&size_to_try, alignment);
   }
-  // |ptr| being null indicates the above allocation failed, or in the rare case
-  // |size| is larger than |allocation_increment_|. Try to allocate a block of
-  // |size| instead for both cases.
-  if (ptr == NULL) {
+  // |fallback_address| being null indicates the above allocation failed,
+  // or in the rare case |size| is larger than |allocation_increment_|. Try to
+  // allocate a block of |size| instead for both cases.
+  if (fallback_address == nullptr) {
     size_to_try = size;
-    if (!max_capacity_ || capacity_ + size_to_try <= max_capacity_) {
-      ptr = fallback_allocator_->AllocateForAlignment(&size_to_try, alignment);
-    }
+    std::tie(fallback_address, fallback_index) =
+        AllocateFallbackBlock(&size_to_try, alignment);
   }
-  if (ptr != NULL) {
-    fallback_allocations_.push_back({ptr, size_to_try});
-    capacity_ += size_to_try;
+  if (fallback_address != nullptr) {
     auto free_block_iter = AddFreeBlock(MemoryBlock(
-        static_cast<int>(fallback_allocations_.size() - 1), ptr, size_to_try));
+        static_cast<int>(fallback_index), fallback_address, size_to_try));
 
     if (ExtraLogLevel() >= 1) {
       int capacity = GetCapacity();
@@ -385,7 +373,7 @@ ExternalMetadataReuseAllocatorBase::ExpandToFit(size_t size, size_t alignment) {
               : static_cast<int64_t>(capacity - allocated) * 100 / capacity;
 
       SB_LOG(INFO) << "Allocated " << size_to_try
-                   << " bytes from fallback allocator (" << ptr
+                   << " bytes from fallback allocator (" << fallback_address
                    << "), capacity expanded to " << capacity << " with "
                    << capacity - allocated << " bytes free (" << free_percentage
                    << "%)";
@@ -432,20 +420,14 @@ ExternalMetadataReuseAllocatorBase::ExpandToFit(size_t size, size_t alignment) {
   //                     |           |
   // |free_address + free_size|  |aligned_address|
   size_t size_to_allocate = aligned_address + size - free_address - free_size;
-  if (max_capacity_ && capacity_ + size_to_allocate > max_capacity_) {
-    SB_LOG_IF(INFO, ExtraLogLevel() >= 1) << "Failed to expand.";
-    return free_blocks_.end();
-  }
-  SB_DCHECK_GT(size_to_allocate, 0U);
-  ptr = fallback_allocator_->AllocateForAlignment(&size_to_allocate, 1);
-  if (ptr == NULL) {
+  std::tie(fallback_address, fallback_index) =
+      AllocateFallbackBlock(&size_to_allocate, 1);
+  if (fallback_address == nullptr) {
     return free_blocks_.end();
   }
 
-  fallback_allocations_.push_back({ptr, size_to_allocate});
-  capacity_ += size_to_allocate;
-  AddFreeBlock(MemoryBlock(static_cast<int>(fallback_allocations_.size() - 1),
-                           ptr, size_to_allocate));
+  AddFreeBlock(MemoryBlock(static_cast<int>(fallback_index), fallback_address,
+                           size_to_allocate));
   FreeBlockSet::iterator iter = free_blocks_.end();
   --iter;
 
@@ -458,7 +440,7 @@ ExternalMetadataReuseAllocatorBase::ExpandToFit(size_t size, size_t alignment) {
             : static_cast<int64_t>(capacity - allocated) * 100 / capacity;
 
     SB_LOG(INFO) << "Allocated " << size_to_allocate
-                 << " bytes from fallback allocator (" << ptr
+                 << " bytes from fallback allocator (" << fallback_address
                  << "), capacity expanded to " << capacity << " with "
                  << capacity - allocated << " bytes free (" << free_percentage
                  << "%)";

--- a/starboard/common/external_metadata_reuse_allocator_base.h
+++ b/starboard/common/external_metadata_reuse_allocator_base.h
@@ -15,28 +15,33 @@
 #ifndef STARBOARD_COMMON_EXTERNAL_METADATA_REUSE_ALLOCATOR_BASE_H_
 #define STARBOARD_COMMON_EXTERNAL_METADATA_REUSE_ALLOCATOR_BASE_H_
 
-#include <algorithm>
 #include <cstddef>
 #include <map>
 #include <set>
-#include <vector>
 
 #include "starboard/common/allocator.h"
 #include "starboard/common/check_op.h"
-#include "starboard/common/log.h"
-#include "starboard/configuration.h"
+#include "starboard/common/reuse_allocator_base.h"
 
 namespace starboard {
 
 // TODO: b/369245553 - Cobalt: Add unit tests once Starboard unittests are
 //                             enabled.
 
-// The base class of allocators designed to accommodate cases where the memory
-// allocated may not be efficient or safe to access via the CPU.  It solves
-// this problem by maintaining all allocation meta data is outside of the
-// allocated memory.  It is passed a fallback allocator that it can request
-// additional memory from as needed.
-class ExternalMetadataReuseAllocatorBase : public Allocator {
+// Base class for memory-pool based allocators with external metadata tracking.
+//
+// Reason for existence: Accommodates cases where allocated memory may not be
+// efficient or safe to access directly via the CPU (e.g., specialized GPU or
+// media buffers). Solves this by maintaining all allocation bookkeeping
+// metadata in an external data structure outside the allocated buffers.
+//
+// Expected lifetime and ownership: Typically instantiated and owned by media
+// pipeline buffer pools, and held for the entire app lifetime across multiple
+// playback sessions.
+//
+// Threading model: Not thread-safe. Callers must provide external
+// synchronization if methods are called from concurrent threads.
+class ExternalMetadataReuseAllocatorBase : public ReuseAllocatorBase {
  public:
   void* Allocate(size_t size) override;
   void* Allocate(size_t size, size_t alignment) override;
@@ -44,19 +49,12 @@ class ExternalMetadataReuseAllocatorBase : public Allocator {
   // Marks the memory block as being free and it will then become recyclable
   void Free(void* memory) override;
 
-  size_t GetCapacity() const override { return capacity_; }
   size_t GetAllocated() const override { return total_allocated_; }
-
-  bool CapacityExceeded() const {
-    return max_capacity_ && (capacity_ > max_capacity_);
-  }
 
   void PrintAllocations(bool align_allocated_size,
                         int max_allocations_to_print) const override;
 
   bool TryFree(void* memory);
-
-  size_t max_capacity() const { return max_capacity_; }
 
  protected:
   class MemoryBlock {
@@ -140,12 +138,6 @@ class ExternalMetadataReuseAllocatorBase : public Allocator {
                                                bool* allocate_from_front) = 0;
 
  private:
-  // Pointer and size of the block allocated from the fallback allocator.
-  struct FallbackAllocation {
-    void* address;
-    size_t size;
-  };
-
   // Map from pointers we returned to the user, back to memory blocks.
   typedef std::map<void*, MemoryBlock> AllocatedBlockMap;
 
@@ -157,28 +149,13 @@ class ExternalMetadataReuseAllocatorBase : public Allocator {
 
   AllocatedBlockMap allocated_blocks_;
   FreeBlockSet free_blocks_;
-
-  // We will allocate from the given allocator whenever we can't find pre-used
-  // memory to allocate.
-  Allocator* const fallback_allocator_;
   const size_t allocation_increment_;
 
-  // If non-zero, this is an upper bound on how large we will let the capacity
-  // expand.
-  const size_t max_capacity_;
-
   // Whether to decommit memory when the pool becomes idle.
-  const bool enable_decommit_on_idle_ = false;
-
-  // A list of allocations made from the fallback allocator.  We keep track of
-  // this so that we can free them all upon our destruction.
-  std::vector<FallbackAllocation> fallback_allocations_;
-
-  // How much we have allocated from the fallback allocator.
-  size_t capacity_;
+  const bool enable_decommit_on_idle_;
 
   // How much has been allocated from us.
-  size_t total_allocated_;
+  size_t total_allocated_ = 0;
 };
 
 }  // namespace starboard

--- a/starboard/common/reuse_allocator_base.cc
+++ b/starboard/common/reuse_allocator_base.cc
@@ -1,0 +1,66 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/common/reuse_allocator_base.h"
+
+#include <cstddef>
+#include <utility>
+
+#include "starboard/common/check_op.h"
+#include "starboard/common/log.h"
+
+namespace starboard {
+
+ReuseAllocatorBase::ReuseAllocatorBase(Allocator* fallback_allocator,
+                                       size_t max_capacity)
+    : fallback_allocator_(fallback_allocator), max_capacity_(max_capacity) {
+  SB_DCHECK(fallback_allocator_);
+}
+
+ReuseAllocatorBase::~ReuseAllocatorBase() {
+  for (const auto& fallback_allocation : fallback_allocations_) {
+    fallback_allocator_->Free(fallback_allocation.address);
+  }
+}
+
+std::pair<void*, intptr_t> ReuseAllocatorBase::AllocateFallbackBlock(
+    size_t* size_to_try,
+    size_t alignment) {
+  SB_DCHECK(size_to_try);
+  SB_DCHECK_GT(*size_to_try, 0U);
+
+  if (max_capacity_ && capacity_ + *size_to_try > max_capacity_) {
+    return {nullptr, -1};
+  }
+
+  void* ptr = fallback_allocator_->AllocateForAlignment(size_to_try, alignment);
+  if (ptr != nullptr) {
+    intptr_t index = static_cast<intptr_t>(fallback_allocations_.size());
+    fallback_allocations_.emplace_back(ptr, *size_to_try);
+    capacity_ += *size_to_try;
+    return {ptr, index};
+  }
+  return {nullptr, -1};
+}
+
+void ReuseAllocatorBase::DecommitFallbackAllocations() {
+  SB_LOG(INFO) << "Allocator reached idle state, decommitting "
+               << fallback_allocations_.size() << " fallback allocations.";
+  for (const auto& fallback_allocation : fallback_allocations_) {
+    fallback_allocator_->Decommit(fallback_allocation.address,
+                                  fallback_allocation.size);
+  }
+}
+
+}  // namespace starboard

--- a/starboard/common/reuse_allocator_base.h
+++ b/starboard/common/reuse_allocator_base.h
@@ -1,0 +1,108 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_COMMON_REUSE_ALLOCATOR_BASE_H_
+#define STARBOARD_COMMON_REUSE_ALLOCATOR_BASE_H_
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+#include "starboard/common/allocator.h"
+#include "starboard/configuration.h"
+
+namespace starboard {
+
+// Abstract base class for memory reuse allocators.
+//
+// Reason for existence: Manages the lifetime of backing memory blocks
+// sub-allocated from a fallback Allocator and enforces overall memory pool
+// capacity constraints.
+//
+// Expected lifetime and ownership: Owned by concrete reuse allocator subclasses
+// or memory pool strategies. Backing fallback blocks remain owned by this class
+// until its destruction.
+//
+// Threading model: Not thread-safe. External synchronization is required when
+// accessing or allocating memory concurrently across multiple threads.
+class ReuseAllocatorBase : public Allocator {
+ public:
+  // Allocator methods.
+  size_t GetCapacity() const override { return capacity_; }
+
+ protected:
+  ReuseAllocatorBase(Allocator* fallback_allocator, size_t max_capacity);
+  ~ReuseAllocatorBase() override;
+
+  bool CapacityExceeded() const {
+    return max_capacity_ && (capacity_ > max_capacity_);
+  }
+
+  bool IsValidFallbackIndex(intptr_t fallback_index) const {
+    return fallback_index >= 0 &&
+           static_cast<size_t>(fallback_index) < fallback_allocations_.size();
+  }
+
+  // Request a new backing buffer from the fallback allocator with capacity and
+  // alignment constraints, and register it for ownership tracking.
+  // Returns pair of {backing_address, fallback_index} to allow caller unpacking
+  // via structured binding. Returns {nullptr, -1} on failure or if pool
+  // capacity is exceeded.
+  std::pair<void*, intptr_t> AllocateFallbackBlock(size_t* size_to_try,
+                                                   size_t alignment);
+
+  // Triggers decommitting of backing allocations when idle (subclass-driven).
+  void DecommitFallbackAllocations();
+
+  // Enumerates fallback backing allocations. Templated to allow zero-cost
+  // compiler inlining for capturing lambdas and avoid std::function overhead.
+  template <typename Func>
+  void EnumerateFallbackAllocations(Func callback) const {
+    for (size_t i = 0; i < fallback_allocations_.size(); ++i) {
+      callback(static_cast<intptr_t>(i), fallback_allocations_[i].address,
+               fallback_allocations_[i].size);
+    }
+  }
+
+ private:
+  struct FallbackAllocation {
+    void* address;
+    size_t size;
+
+    FallbackAllocation(void* init_address, size_t init_size)
+        : address(init_address), size(init_size) {}
+  };
+
+  // We will allocate from the given allocator whenever we can't find pre-used
+  // memory to allocate.
+  Allocator* const fallback_allocator_;
+
+  // If non-zero, this is an upper bound on how large we will let the total
+  // memory pool capacity expand.
+  const size_t max_capacity_;
+
+  // A list of all backing memory blocks allocated from the fallback allocator.
+  // We keep track of this so we can decommit on idle and free them upon
+  // destruction.
+  std::vector<FallbackAllocation> fallback_allocations_;
+
+  // How many total bytes we currently have allocated from the fallback
+  // allocator.
+  size_t capacity_ = 0;
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_COMMON_REUSE_ALLOCATOR_BASE_H_


### PR DESCRIPTION
Extract the common logic for fallback buffer management into a unified
ReuseAllocatorBase class. This change encapsulates buffer lifecycle
management and capacity limit enforcement, which was previously
duplicated in EmbeddedMetadataReuseAllocatorBase and
ExternalMetadataReuseAllocatorBase.

Bug: 454441375