### PR TITLE
docs: Update Cobalt 25 LTS devsite

### DIFF
--- a/cobalt/site/docs/gen/cobalt/doc/cvals.md
+++ b/cobalt/site/docs/gen/cobalt/doc/cvals.md
@@ -466,7 +466,21 @@ query):
 #### PublicCVals
 
 *  **CPU.Total.Usage.IntervalSeconds.[INTERVAL_SECONDS]** - CPU usage in
-   seconds during the last time interval of `INTERVAL_SECONDS`.
+   seconds during the last time interval of `INTERVAL_SECONDS`. The intervals
+   are defined and enabled using `h5vcc.settings`.
+```
+windows.h5vcc.settings.set('cpu_usage_tracker_intervals_enabled', 1);
+windows.h5vcc.settings.set('cpu_usage_tracker_intervals', [
+  {type: 'total', seconds: 1},
+  {type: 'total', seconds: 3},
+  {type: 'total', seconds: 4},
+  {type: 'total', seconds: 120},
+  {type: 'per_thread', seconds: 1},
+  {type: 'per_thread', seconds: 3},
+  {type: 'per_thread', seconds: 5},
+  {type: 'per_thread', seconds: 60}
+]);
+```
 *  **CPU.PerThread.Usage.IntervalSeconds.[INTERVAL_SECONDS]** - CPU usage of all
    running threads. This is expressed as JSON in the following form. `id` is the
    thread ID. `name` is the thread name (not unique). `stime` is the number of
@@ -498,3 +512,14 @@ query):
   ]
 }
 ```
+*  **CPU.Total.Usage.OneTime** - CPU usage in seconds between setting the
+   one-time tracking on and then off.
+```
+window.h5vcc.settings.set('cpu_usage_tracker_one_time_tracking', 1);
+...
+window.h5vcc.settings.set('cpu_usage_tracker_one_time_tracking', 0);
+```
+*  **CPU.PerThread.Usage.OneTime** - CPU usage of all running threads. Same
+   format as interval-base per-thread CPU usage CVals. The `previous` is
+   captured when one-time tracking is enabled. The CVal is updated with
+   `previous` and `current` when one-time tracking is disabled.

--- a/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_overview.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_overview.md
@@ -551,7 +551,7 @@ On Raspberry Pi the Cobalt fonts are configured the following way:
 
 `empty` set of fonts under:
 ```
-<kSbSystemPathContentDirectory>/app/cobalt/content/fonts
+<kSbSystemPathContentDirectory>/app/starboard/content/fonts
 ```
 
 `standard` or `limited` set of fonts under:

--- a/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_reference_port_raspi2.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_reference_port_raspi2.md
@@ -17,11 +17,11 @@ $ git clone https://cobalt.googlesource.com/cobalt
 ## Build the loader app (new entry point)
 $ cd cobalt/src
 $ cobalt/build/gn.py -p raspi-2 -c qa
-$ ninja -C out/raspi-2_qa loader_app crashpad_handler
+$ ninja -C out/raspi-2_qa starboard/loader_app native_target/crashpad_handler
 
 ## Create package directory for Cobalt Evergreen
 $ export COEG_PATH=coeg
-$ cp out/raspi-2_qa/loader_app $COEG_PATH
+$ cp out/raspi-2_qa/starboard/loader_app $COEG_PATH
 
 ## Create directory structure for the initial installation
 [2-slot configuration]

--- a/cobalt/site/docs/gen/starboard/doc/evergreen/symbolizing_minidumps.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/symbolizing_minidumps.md
@@ -11,7 +11,33 @@ debugging, as these minidumps have the information for the dynamic
 `libcobalt.so` module correctly mapped, which a out-of-the-box dumper could not
 manage.
 
-## Obtaining the Tools to Symbolize Minidumps
+## Symbolizing with the Provided Docker Container (Recommended)
+
+We provide a docker container at `docker/crashpad_symbolize/Dockerfile` with a
+corresponding docker-compose service, `crashpad-symbolize`, with which you can
+symbolize your minidumps.
+
+Build and run the container with:
+
+```
+MINIDUMP_PATH=/path/to/minidump_file.dmp docker-compose up --build crashpad-symbolize
+```
+
+Where `MINIDUMP_PATH` is the path to your minidump file. The service will also
+pick up environment values for `GITHUB_TAG`, `ARCHITECTURE`, `SB_API_VERSION`,
+and `CONFIG`, so ensure these are correct.
+
+* `GITHUB_TAG`: A Cobalt version with an associated release, i.e. 25.lts.10
+* `ARCHITECTURE`: One of `x64`, `x86`, `arm64`, `arm-hardfp`, or `arm-softfp`
+* `SB_API_VERSION`: The Starboard version, i.e. `16`
+* `CONFIG`: One of `release` or `qa`
+
+## Symbolizing Locally
+
+If you wish, you can download all the necessary tools to locally symbolize
+minidumps. This is more work than doing it with the docker container.
+
+### Obtaining the Tools to Symbolize Minidumps
 
 Tools for symbolizing these dumps are available through
 [Breakpad](https://chromium.googlesource.com/breakpad/breakpad/). Breakpad is
@@ -19,8 +45,7 @@ an open source crash reporting library that we use to obtain symbol files
 (`.sym`) from unstripped binaries, and to process the symbol files with the
 minidumps to produce human-readable stacktraces.
 
-
-### Building Breakpad
+#### Building Breakpad
 
 [Breakpad](https://chromium.googlesource.com/breakpad/breakpad/) provides
 instructions for building these tools yourself. The
@@ -54,7 +79,7 @@ building on Linux it will also build the `dump_syms` tool
 depot_tools from your `$PATH` environment variable, as it can conflict with
 Cobalt's depot_tools.
 
-## Symbolizing Minidumps
+### Symbolizing Minidumps
 
 Now that you have all the tools you need, we can symbolize the dumps. To be
 able to symbolize Cobalt using Evergreen, you need to be get the unstripped
@@ -100,7 +125,7 @@ $ /path/to/minidump_stackwalk /path/to/your/minidump.dmp symbols/
 `minidump_stackwalk` produces verbose output on stderr, and the stacktrace on
 stdout, so you may want to redirect stderr.
 
-### Addendum: Adding Other Symbols
+#### Addendum: Adding Other Symbols
 
 We can use the process above to add symbols for any library or executable you
 use, not just `libcobalt.so`. To do this, all you have to do is run the

--- a/cobalt/site/docs/gen/starboard/doc/networking_performance.md
+++ b/cobalt/site/docs/gen/starboard/doc/networking_performance.md
@@ -1,0 +1,88 @@
+Project: /youtube/cobalt/_project.yaml
+Book: /youtube/cobalt/_book.yaml
+
+# Networking performance
+
+## Overview
+
+Cobalt 25 implements IETF HTTP/3 which uses the QUIC transport protocol which is implemented using the UDP protocol and application level stream multiplexing, flow control, congestion avoidance, connection establishment, field compression, etc.
+
+For HTTP/3, Cobalt benefits from more specific tuning and customizations to improve its performance.
+
+## Starboard Extension
+
+It is strongly encouraged for platforms to include the
+`CobaltExtensionSocketReceiveMultiMsgApi` extension.
+
+Starting in Cobalt 25.lts.20, a significant networking performance
+improvement can be achieved on platforms that implement the
+extension.
+
+The extension allows a platform to provide an API to read multiple
+UDP packets in a single call.  When on a Linux kernel, the `recvmmsg`
+system call can be used and results in a significantly reduced amount
+of CPU usage and corresponding increase in networking throughput.
+This not only makes the application more responsive, but also
+improves the video quality that the devices can play.
+
+## Implementation details
+
+A functioning implementation for Linux kernel based devices is
+included in the 25.lts.20 source and can be added to a platform with
+the changes below.  The changes are present in the source for the
+Android and Linux targets.
+
+To add the extension to a platform, (1) add the four source files
+with the extension's implementation to the platform and (2) expand
+`SbSystemGetExtension` to return the extension:
+
+1.  In the platform's `BUILD.gn`:
+    Add the extension's implementation to the
+    `static_library("starboard_platform")` section.
+
+    ```
+    patch -p1 <<EOF
+    --- a/starboard/linux/shared/BUILD.gn
+    +++ b/starboard/linux/shared/BUILD.gn
+    @@ -205,2 +205,6 @@ static_library("starboard_platform_sources") {
+         "//starboard/shared/posix/socket_receive_from.cc",
+    +    "//starboard/shared/posix/socket_receive_multi_msg_internal.cc",
+    +    "//starboard/shared/posix/socket_receive_multi_msg_internal.h",
+    +    "//starboard/shared/posix/socket_receive_multi_msg.cc",
+    +    "//starboard/shared/posix/socket_receive_multi_msg.h",
+         "//starboard/shared/posix/socket_resolve.cc",
+    EOF
+    ```
+
+2.  In the platform's `system_get_extensions.cc`:
+    Add two includes and a three line if statement.
+
+    ```
+    patch -p1 <<EOF
+    --- a/starboard/linux/shared/system_get_extensions.cc
+    +++ b/starboard/linux/shared/system_get_extensions.cc
+    @@ -31,2 +31,3 @@
+     #include "starboard/extension/platform_service.h"
+    +#include "starboard/extension/socket_receive_multi_msg.h"
+     #include "starboard/extension/time_zone.h"
+    @@ -40,2 +41,3 @@
+     #include "starboard/shared/posix/memory_mapped_file.h"
+    +#include "starboard/shared/posix/socket_receive_multi_msg.h"
+     #include "starboard/shared/starboard/application.h"
+    @@ -71,3 +73,6 @@ const void* SbSystemGetExtension(const char* name) {
+       if (strcmp(name, kCobaltExtensionFreeSpaceName) == 0) {
+         return starboard::shared::posix::GetFreeSpaceApi();
+       }
+    +  if (strcmp(name, kCobaltExtensionSocketReceiveMultiMsgName) == 0) {
+    +    return starboard::shared::posix::GetSocketReceiveMultiMsgApi();
+    +  }
+    EOF
+    ```
+
+## Links
+
++   The extension was added in PR [#4321](https://github.com/youtube/cobalt/pull/4321).
++   Linux man page for [recvmmsg](https://man7.org/linux/man-pages/man2/recvmmsg.2.html).
++   HTTP/3 explainer <https://en.wikipedia.org/wiki/HTTP/3>
++   [RFC9114] Bishop, M., Ed., "HTTP/3", RFC 9114, DOI 10.17487/RFC9114, June 2022, <https://www.rfc-editor.org/info/rfc9114>.
++   [RFC9000] Iyengar, J., Ed., and M. Thomson, Ed., "QUIC: A UDP-Based Multiplexed and Secure Transport", RFC 9000, DOI 10.17487/RFC9000, May 2021, <https://www.rfc-editor.org/info/rfc9000>.

--- a/cobalt/site/docs/reference/starboard/configuration-public.md
+++ b/cobalt/site/docs/reference/starboard/configuration-public.md
@@ -21,3 +21,5 @@ Book: /youtube/cobalt/_book.yaml
 | **`SB_IS_WCHAR_T_UTF32`**<br><br>Type detection for wchar_t.<br><br>The default value in the Stub implementation is `1` |
 | **`SB_IS_WCHAR_T_UTF16`**<br><br>The default value in the Stub implementation is `1` |
 | **`SB_IS_WCHAR_T_UNSIGNED`**<br><br>Chrome only defines this for ARMEL. Chrome has an exclusion for iOS here, we should too when we support iOS.<br><br>The default value in the Stub implementation is `1` |
+
+

--- a/cobalt/site/docs/reference/starboard/modules/14/accessibility.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/accessibility.md
@@ -251,3 +251,4 @@ off (false).
 ```
 bool SbAccessibilitySetCaptionsEnabled(bool enabled)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/atomic.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/atomic.md
@@ -108,3 +108,4 @@ Overloaded functions for Atomic8.
 ```
 static SbAtomic8 SbAtomicRelease_CompareAndSwap8(volatile SbAtomic8 *ptr, SbAtomic8 old_value, SbAtomic8 new_value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/audio_sink.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/audio_sink.md
@@ -212,3 +212,4 @@ Indicates whether the given audio sink handle is valid.
 ```
 bool SbAudioSinkIsValid(SbAudioSink audio_sink)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/byte_swap.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/byte_swap.md
@@ -73,3 +73,4 @@ value for which the byte order will be swapped.
 ```
 uint64_t SbByteSwapU64(uint64_t value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/condition_variable.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/condition_variable.md
@@ -138,3 +138,4 @@ kSbConditionVariableTimedOut result.
 ```
 SbConditionVariableResult SbConditionVariableWaitTimed(SbConditionVariable *condition, SbMutex *mutex, int64_t timeout_duration)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/configuration.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/configuration.md
@@ -15,6 +15,11 @@ Starboard.
 
 ## Macros
 
+### ALLOW_EVERGREEN_SIDELOADING
+
+TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're fully
+launched.
+
 ### SB_ALIGNAS(byte_alignment)
 
 Specifies the alignment for a class, struct, union, enum, class/struct field, or

--- a/cobalt/site/docs/reference/starboard/modules/14/cpu_features.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/cpu_features.md
@@ -259,3 +259,4 @@ fields in `features` are invalid.
 ```
 bool SbCPUFeaturesGet(SbCPUFeatures *features)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/decode_target.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/decode_target.md
@@ -354,3 +354,4 @@ Starboard implementations, if it is necessary.
 ```
 static void SbDecodeTargetRunInGlesContext(SbDecodeTargetGraphicsContextProvider *provider, SbDecodeTargetGlesContextRunnerTarget target, void *target_context)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/directory.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/directory.md
@@ -121,3 +121,4 @@ that the directory could not be opened.
 ```
 SbDirectory SbDirectoryOpen(const char *path, SbFileError *out_error)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/drm.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/drm.md
@@ -410,7 +410,7 @@ Indicates whether `drm_system` is a valid SbDrmSystem.
 #### Declaration
 
 ```
-static bool SbDrmSystemIsValid(SbDrmSystem drm)
+bool SbDrmSystemIsValid(SbDrmSystem drm)
 ```
 
 ### SbDrmTicketIsValid
@@ -420,7 +420,7 @@ Indicates whether `ticket` is a valid ticket.
 #### Declaration
 
 ```
-static bool SbDrmTicketIsValid(int ticket)
+bool SbDrmTicketIsValid(int ticket)
 ```
 
 ### SbDrmUpdateServerCertificate
@@ -475,3 +475,4 @@ must not be NULL.
 ```
 void SbDrmUpdateSession(SbDrmSystem drm_system, int ticket, const void *key, int key_size, const void *session_id, int session_id_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/egl.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/egl.md
@@ -144,3 +144,4 @@ typedef int32_t SbEglInt32
     config, void *native_pixmap, const SbEglAttrib *attrib_list)`
 *   `SbEglBoolean(*eglWaitSync)(SbEglDisplay dpy, SbEglSync sync, SbEglInt32
     flags)`
+

--- a/cobalt/site/docs/reference/starboard/modules/14/event.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/event.md
@@ -401,3 +401,4 @@ of microseconds to wait before calling the `callback` function. Set `delay` to
 ```
 SbEventId SbEventSchedule(SbEventCallback callback, void *context, int64_t delay)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/file.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/file.md
@@ -430,3 +430,4 @@ The return value identifies the number of bytes written, or `-1` on error.
 ```
 static int SbFileWriteAll(SbFile file, const char *data, int size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/gles.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/gles.md
@@ -459,3 +459,4 @@ typedef long int SbGlIntPtr
     internalformat, SbGlSizei width, SbGlSizei height, SbGlSizei depth)`
 *   `void(*glGetInternalformativ)(SbGlEnum target, SbGlEnum internalformat,
     SbGlEnum pname, SbGlSizei bufSize, SbGlInt32 *params)`
+

--- a/cobalt/site/docs/reference/starboard/modules/14/image.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/image.md
@@ -76,3 +76,4 @@ indefinitely.
 ```
 bool SbImageIsDecodeSupported(const char *mime_type, SbDecodeTargetFormat format)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/input.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/input.md
@@ -168,3 +168,4 @@ A 2-dimensional vector used to represent points and motion vectors.
 
 *   `float x`
 *   `float y`
+

--- a/cobalt/site/docs/reference/starboard/modules/14/key.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/key.md
@@ -290,3 +290,4 @@ Bit-mask of key modifiers.
 *   `kSbKeyModifiersPointerButtonMiddle`
 *   `kSbKeyModifiersPointerButtonBack`
 *   `kSbKeyModifiersPointerButtonForward`
+

--- a/cobalt/site/docs/reference/starboard/modules/14/log.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/log.md
@@ -134,3 +134,4 @@ Inline wrapper of SbLogFormat to convert from ellipsis to va_args.
 ```
 void static void static void SbLogRawFormatF(const char *format,...) SB_PRINTF_FORMAT(1
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/media.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/media.md
@@ -734,3 +734,4 @@ may assume `duration` >= 0.5 seconds.
 ```
 void SbMediaSetAudioWriteDuration(int64_t duration)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/memory.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/memory.md
@@ -343,3 +343,4 @@ SbMemoryMap(). For example, if one call to `SbMemoryMap(0x1000)` returns
 ```
 bool SbMemoryUnmap(void *virtual_address, int64_t size_bytes)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/memory_reporter.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/memory_reporter.md
@@ -104,3 +104,4 @@ SbMemoryReporter* mem_reporter = new ...; SbMemorySetReporter(&mem_reporter);
 ```
 bool SbMemorySetReporter(struct SbMemoryReporter *tracker)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/microphone.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/microphone.md
@@ -260,3 +260,4 @@ has already been read from the device is discarded.
 ```
 int SbMicrophoneRead(SbMicrophone microphone, void *out_audio_data, int audio_data_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/mutex.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/mutex.md
@@ -125,3 +125,4 @@ held by the current thread.
 ```
 bool SbMutexRelease(SbMutex *mutex)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/once.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/once.md
@@ -55,3 +55,4 @@ Thread-safely runs `init_routine` only once.
 ```
 bool SbOnce(SbOnceControl *once_control, SbOnceInitRoutine init_routine)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/player.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/player.md
@@ -663,3 +663,4 @@ SbPlayerGetMaximumNumberOfSamplesPerWrite().
 ```
 void SbPlayerWriteSample2(SbPlayer player, SbMediaType sample_type, const SbPlayerSampleInfo *sample_infos, int number_of_sample_infos)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/socket.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/socket.md
@@ -631,3 +631,4 @@ option.
 ```
 bool SbSocketSetTcpWindowScaling(SbSocket socket, bool value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/socket_waiter.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/socket_waiter.md
@@ -239,3 +239,4 @@ next 7 times they are called.
 ```
 void SbSocketWaiterWakeUp(SbSocketWaiter waiter)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/speech_synthesis.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/speech_synthesis.md
@@ -49,3 +49,4 @@ when the previous utterances are complete.
 ```
 void SbSpeechSynthesisSpeak(const char *text)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/storage.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/storage.md
@@ -156,3 +156,4 @@ after a short time, even if there is an unexpected process termination before
 ```
 bool SbStorageWriteRecord(SbStorageRecord record, const char *data, int64_t data_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/string.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/string.md
@@ -157,3 +157,4 @@ Values matching `pattern` that were extracted from `buffer`.
 ```
 static int SbStringScanF(const char *buffer, const char *pattern,...)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/system.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/system.md
@@ -713,3 +713,4 @@ signal-safe on platforms that support signals.
 ```
 bool SbSystemSymbolize(const void *address, char *out_buffer, int buffer_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/thread.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/thread.md
@@ -531,3 +531,4 @@ Yields the currently executing thread, so another thread has a chance to run.
 ```
 void SbThreadYield()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/time.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/time.md
@@ -150,3 +150,4 @@ times.
 ```
 static int64_t SbTimeToPosix(SbTime time)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/time_zone.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/time_zone.md
@@ -45,3 +45,4 @@ and LOCATION is a specific location within the area. Typical names are
 ```
 const char* SbTimeZoneGetName()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/ui_navigation.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/ui_navigation.md
@@ -262,7 +262,7 @@ right and top-to-bottom.
 ///     | Negative position. | Positive position. | Positive position. |
 ///     +--------------------+--------------------+--------------------+
 ///                          ^
-///                  Content Offset X = 0.
+///                  Content Offset X = 0. 
 ```
 
 ```
@@ -282,7 +282,7 @@ This represents a 2x3 transform matrix in row-major order.
 
 ```
 ///   | a b tx |
-///   | c d ty |
+///   | c d ty | 
 ```
 
 #### Members
@@ -321,3 +321,4 @@ Returns whether the given navigation item handle is valid.
 ```
 static bool SbUiNavItemIsValid(SbUiNavItem item)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/user.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/user.md
@@ -131,3 +131,4 @@ Returns whether the given user handle is valid.
 ```
 static bool SbUserIsValid(SbUser user)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/14/window.md
+++ b/cobalt/site/docs/reference/starboard/modules/14/window.md
@@ -328,3 +328,4 @@ hidden.
 ```
 void SbWindowUpdateOnScreenKeyboardSuggestions(SbWindow window, const char *suggestions[], int num_suggestions, int ticket)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/accessibility.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/accessibility.md
@@ -251,3 +251,4 @@ off (false).
 ```
 bool SbAccessibilitySetCaptionsEnabled(bool enabled)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/atomic.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/atomic.md
@@ -108,3 +108,4 @@ Overloaded functions for Atomic8.
 ```
 static SbAtomic8 SbAtomicRelease_CompareAndSwap8(volatile SbAtomic8 *ptr, SbAtomic8 old_value, SbAtomic8 new_value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/audio_sink.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/audio_sink.md
@@ -212,3 +212,4 @@ Indicates whether the given audio sink handle is valid.
 ```
 bool SbAudioSinkIsValid(SbAudioSink audio_sink)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/byte_swap.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/byte_swap.md
@@ -73,3 +73,4 @@ value for which the byte order will be swapped.
 ```
 uint64_t SbByteSwapU64(uint64_t value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/condition_variable.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/condition_variable.md
@@ -138,3 +138,4 @@ kSbConditionVariableTimedOut result.
 ```
 SbConditionVariableResult SbConditionVariableWaitTimed(SbConditionVariable *condition, SbMutex *mutex, int64_t timeout_duration)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/configuration.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/configuration.md
@@ -15,6 +15,11 @@ Starboard.
 
 ## Macros
 
+### ALLOW_EVERGREEN_SIDELOADING
+
+TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're fully
+launched.
+
 ### SB_ALIGNAS(byte_alignment)
 
 Specifies the alignment for a class, struct, union, enum, class/struct field, or

--- a/cobalt/site/docs/reference/starboard/modules/15/cpu_features.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/cpu_features.md
@@ -259,3 +259,4 @@ fields in `features` are invalid.
 ```
 bool SbCPUFeaturesGet(SbCPUFeatures *features)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/decode_target.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/decode_target.md
@@ -354,3 +354,4 @@ Starboard implementations, if it is necessary.
 ```
 static void SbDecodeTargetRunInGlesContext(SbDecodeTargetGraphicsContextProvider *provider, SbDecodeTargetGlesContextRunnerTarget target, void *target_context)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/directory.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/directory.md
@@ -121,3 +121,4 @@ that the directory could not be opened.
 ```
 SbDirectory SbDirectoryOpen(const char *path, SbFileError *out_error)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/drm.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/drm.md
@@ -410,7 +410,7 @@ Indicates whether `drm_system` is a valid SbDrmSystem.
 #### Declaration
 
 ```
-static bool SbDrmSystemIsValid(SbDrmSystem drm)
+bool SbDrmSystemIsValid(SbDrmSystem drm)
 ```
 
 ### SbDrmTicketIsValid
@@ -420,7 +420,7 @@ Indicates whether `ticket` is a valid ticket.
 #### Declaration
 
 ```
-static bool SbDrmTicketIsValid(int ticket)
+bool SbDrmTicketIsValid(int ticket)
 ```
 
 ### SbDrmUpdateServerCertificate
@@ -475,3 +475,4 @@ must not be NULL.
 ```
 void SbDrmUpdateSession(SbDrmSystem drm_system, int ticket, const void *key, int key_size, const void *session_id, int session_id_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/egl.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/egl.md
@@ -144,3 +144,4 @@ typedef int32_t SbEglInt32
     config, void *native_pixmap, const SbEglAttrib *attrib_list)`
 *   `SbEglBoolean(*eglWaitSync)(SbEglDisplay dpy, SbEglSync sync, SbEglInt32
     flags)`
+

--- a/cobalt/site/docs/reference/starboard/modules/15/event.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/event.md
@@ -412,3 +412,4 @@ event loop with the application event handler.
 ```
 int SbRunStarboardMain(int argc, char **argv, SbEventHandleCallback callback)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/file.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/file.md
@@ -430,3 +430,4 @@ The return value identifies the number of bytes written, or `-1` on error.
 ```
 static int SbFileWriteAll(SbFile file, const char *data, int size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/gles.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/gles.md
@@ -459,3 +459,4 @@ typedef long int SbGlIntPtr
     internalformat, SbGlSizei width, SbGlSizei height, SbGlSizei depth)`
 *   `void(*glGetInternalformativ)(SbGlEnum target, SbGlEnum internalformat,
     SbGlEnum pname, SbGlSizei bufSize, SbGlInt32 *params)`
+

--- a/cobalt/site/docs/reference/starboard/modules/15/image.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/image.md
@@ -76,3 +76,4 @@ indefinitely.
 ```
 bool SbImageIsDecodeSupported(const char *mime_type, SbDecodeTargetFormat format)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/input.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/input.md
@@ -168,3 +168,4 @@ A 2-dimensional vector used to represent points and motion vectors.
 
 *   `float x`
 *   `float y`
+

--- a/cobalt/site/docs/reference/starboard/modules/15/key.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/key.md
@@ -291,3 +291,4 @@ Bit-mask of key modifiers.
 *   `kSbKeyModifiersPointerButtonMiddle`
 *   `kSbKeyModifiersPointerButtonBack`
 *   `kSbKeyModifiersPointerButtonForward`
+

--- a/cobalt/site/docs/reference/starboard/modules/15/log.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/log.md
@@ -134,3 +134,4 @@ Inline wrapper of SbLogFormat to convert from ellipsis to va_args.
 ```
 void static void static void SbLogRawFormatF(const char *format,...) SB_PRINTF_FORMAT(1
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/media.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/media.md
@@ -730,3 +730,4 @@ removed, only to emit warnings at build and test time.
 ```
 bool SbMediaIsBufferUsingMemoryPool()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/memory.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/memory.md
@@ -330,3 +330,4 @@ SbMemoryMap(). For example, if one call to `SbMemoryMap(0x1000)` returns
 ```
 bool SbMemoryUnmap(void *virtual_address, int64_t size_bytes)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/microphone.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/microphone.md
@@ -260,3 +260,4 @@ has already been read from the device is discarded.
 ```
 int SbMicrophoneRead(SbMicrophone microphone, void *out_audio_data, int audio_data_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/mutex.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/mutex.md
@@ -125,3 +125,4 @@ held by the current thread.
 ```
 bool SbMutexRelease(SbMutex *mutex)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/once.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/once.md
@@ -55,3 +55,4 @@ Thread-safely runs `init_routine` only once.
 ```
 bool SbOnce(SbOnceControl *once_control, SbOnceInitRoutine init_routine)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/player.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/player.md
@@ -735,3 +735,4 @@ SbPlayerGetMaximumNumberOfSamplesPerWrite().
 ```
 void SbPlayerWriteSamples(SbPlayer player, SbMediaType sample_type, const SbPlayerSampleInfo *sample_infos, int number_of_sample_infos)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/socket.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/socket.md
@@ -631,3 +631,4 @@ option.
 ```
 bool SbSocketSetTcpWindowScaling(SbSocket socket, bool value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/socket_waiter.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/socket_waiter.md
@@ -239,3 +239,4 @@ next 7 times they are called.
 ```
 void SbSocketWaiterWakeUp(SbSocketWaiter waiter)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/speech_synthesis.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/speech_synthesis.md
@@ -49,3 +49,4 @@ when the previous utterances are complete.
 ```
 void SbSpeechSynthesisSpeak(const char *text)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/storage.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/storage.md
@@ -156,3 +156,4 @@ after a short time, even if there is an unexpected process termination before
 ```
 bool SbStorageWriteRecord(SbStorageRecord record, const char *data, int64_t data_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/string.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/string.md
@@ -157,3 +157,4 @@ Values matching `pattern` that were extracted from `buffer`.
 ```
 static int SbStringScanF(const char *buffer, const char *pattern,...)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/system.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/system.md
@@ -670,3 +670,4 @@ signal-safe on platforms that support signals.
 ```
 bool SbSystemSymbolize(const void *address, char *out_buffer, int buffer_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/thread.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/thread.md
@@ -531,3 +531,4 @@ Yields the currently executing thread, so another thread has a chance to run.
 ```
 void SbThreadYield()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/time.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/time.md
@@ -150,3 +150,4 @@ times.
 ```
 static int64_t SbTimeToPosix(SbTime time)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/time_zone.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/time_zone.md
@@ -45,3 +45,4 @@ and LOCATION is a specific location within the area. Typical names are
 ```
 const char* SbTimeZoneGetName()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/ui_navigation.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/ui_navigation.md
@@ -262,7 +262,7 @@ right and top-to-bottom.
 ///     | Negative position. | Positive position. | Positive position. |
 ///     +--------------------+--------------------+--------------------+
 ///                          ^
-///                  Content Offset X = 0.
+///                  Content Offset X = 0. 
 ```
 
 ```
@@ -282,7 +282,7 @@ This represents a 2x3 transform matrix in row-major order.
 
 ```
 ///   | a b tx |
-///   | c d ty |
+///   | c d ty | 
 ```
 
 #### Members
@@ -321,3 +321,4 @@ Returns whether the given navigation item handle is valid.
 ```
 static bool SbUiNavItemIsValid(SbUiNavItem item)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/user.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/user.md
@@ -131,3 +131,4 @@ Returns whether the given user handle is valid.
 ```
 static bool SbUserIsValid(SbUser user)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/15/window.md
+++ b/cobalt/site/docs/reference/starboard/modules/15/window.md
@@ -328,3 +328,4 @@ hidden.
 ```
 void SbWindowUpdateOnScreenKeyboardSuggestions(SbWindow window, const char *suggestions[], int num_suggestions, int ticket)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/atomic.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/atomic.md
@@ -108,3 +108,4 @@ Overloaded functions for Atomic8.
 ```
 static SbAtomic8 SbAtomicRelease_CompareAndSwap8(volatile SbAtomic8 *ptr, SbAtomic8 old_value, SbAtomic8 new_value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/audio_sink.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/audio_sink.md
@@ -212,3 +212,4 @@ Indicates whether the given audio sink handle is valid.
 ```
 bool SbAudioSinkIsValid(SbAudioSink audio_sink)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/configuration.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/configuration.md
@@ -15,6 +15,11 @@ Starboard.
 
 ## Macros
 
+### ALLOW_EVERGREEN_SIDELOADING
+
+TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're fully
+launched.
+
 ### SB_ALIGNAS(byte_alignment)
 
 Specifies the alignment for a class, struct, union, enum, class/struct field, or

--- a/cobalt/site/docs/reference/starboard/modules/16/cpu_features.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/cpu_features.md
@@ -259,3 +259,4 @@ fields in `features` are invalid.
 ```
 bool SbCPUFeaturesGet(SbCPUFeatures *features)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/decode_target.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/decode_target.md
@@ -354,3 +354,4 @@ Starboard implementations, if it is necessary.
 ```
 static void SbDecodeTargetRunInGlesContext(SbDecodeTargetGraphicsContextProvider *provider, SbDecodeTargetGlesContextRunnerTarget target, void *target_context)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/directory.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/directory.md
@@ -95,3 +95,4 @@ that the directory could not be opened.
 ```
 SbDirectory SbDirectoryOpen(const char *path, SbFileError *out_error)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/drm.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/drm.md
@@ -410,7 +410,7 @@ Indicates whether `drm_system` is a valid SbDrmSystem.
 #### Declaration
 
 ```
-static bool SbDrmSystemIsValid(SbDrmSystem drm)
+bool SbDrmSystemIsValid(SbDrmSystem drm)
 ```
 
 ### SbDrmTicketIsValid
@@ -420,7 +420,7 @@ Indicates whether `ticket` is a valid ticket.
 #### Declaration
 
 ```
-static bool SbDrmTicketIsValid(int ticket)
+bool SbDrmTicketIsValid(int ticket)
 ```
 
 ### SbDrmUpdateServerCertificate
@@ -475,3 +475,4 @@ must not be NULL.
 ```
 void SbDrmUpdateSession(SbDrmSystem drm_system, int ticket, const void *key, int key_size, const void *session_id, int session_id_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/egl.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/egl.md
@@ -144,3 +144,4 @@ typedef int32_t SbEglInt32
     config, void *native_pixmap, const SbEglAttrib *attrib_list)`
 *   `SbEglBoolean(*eglWaitSync)(SbEglDisplay dpy, SbEglSync sync, SbEglInt32
     flags)`
+

--- a/cobalt/site/docs/reference/starboard/modules/16/event.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/event.md
@@ -405,3 +405,4 @@ event loop with the application event handler.
 ```
 int SbRunStarboardMain(int argc, char **argv, SbEventHandleCallback callback)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/file.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/file.md
@@ -418,3 +418,4 @@ The return value identifies the number of bytes written, or `-1` on error.
 ```
 static int SbFileWriteAll(SbFile file, const char *data, int size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/gles.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/gles.md
@@ -459,3 +459,4 @@ typedef long int SbGlIntPtr
     internalformat, SbGlSizei width, SbGlSizei height, SbGlSizei depth)`
 *   `void(*glGetInternalformativ)(SbGlEnum target, SbGlEnum internalformat,
     SbGlEnum pname, SbGlSizei bufSize, SbGlInt32 *params)`
+

--- a/cobalt/site/docs/reference/starboard/modules/16/input.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/input.md
@@ -168,3 +168,4 @@ A 2-dimensional vector used to represent points and motion vectors.
 
 *   `float x`
 *   `float y`
+

--- a/cobalt/site/docs/reference/starboard/modules/16/key.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/key.md
@@ -291,3 +291,4 @@ Bit-mask of key modifiers.
 *   `kSbKeyModifiersPointerButtonMiddle`
 *   `kSbKeyModifiersPointerButtonBack`
 *   `kSbKeyModifiersPointerButtonForward`
+

--- a/cobalt/site/docs/reference/starboard/modules/16/log.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/log.md
@@ -124,3 +124,4 @@ Inline wrapper of SbLogFormat to convert from ellipsis to va_args.
 ```
 void static void static void SbLogRawFormatF(const char *format,...) SB_PRINTF_FORMAT(1
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/media.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/media.md
@@ -710,3 +710,4 @@ removed, only to emit warnings at build and test time.
 ```
 bool SbMediaIsBufferUsingMemoryPool()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/memory.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/memory.md
@@ -43,3 +43,4 @@ the mapped memory can be used.
 *   `kSbMemoryMapProtectWrite`
 *   `kSbMemoryMapProtectExec`
 *   `kSbMemoryMapProtectReadWrite`
+

--- a/cobalt/site/docs/reference/starboard/modules/16/microphone.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/microphone.md
@@ -260,3 +260,4 @@ has already been read from the device is discarded.
 ```
 int SbMicrophoneRead(SbMicrophone microphone, void *out_audio_data, int audio_data_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/player.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/player.md
@@ -735,3 +735,4 @@ SbPlayerGetMaximumNumberOfSamplesPerWrite().
 ```
 void SbPlayerWriteSamples(SbPlayer player, SbMediaType sample_type, const SbPlayerSampleInfo *sample_infos, int number_of_sample_infos)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/socket.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/socket.md
@@ -631,3 +631,4 @@ option.
 ```
 bool SbSocketSetTcpWindowScaling(SbSocket socket, bool value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/socket_waiter.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/socket_waiter.md
@@ -249,3 +249,4 @@ next 7 times they are called.
 ```
 void SbSocketWaiterWakeUp(SbSocketWaiter waiter)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/speech_synthesis.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/speech_synthesis.md
@@ -49,3 +49,4 @@ when the previous utterances are complete.
 ```
 void SbSpeechSynthesisSpeak(const char *text)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/storage.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/storage.md
@@ -153,3 +153,4 @@ after a short time, even if there is an unexpected process termination before
 ```
 bool SbStorageWriteRecord(SbStorageRecord record, const char *data, int64_t data_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/system.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/system.md
@@ -670,3 +670,4 @@ signal-safe on platforms that support signals.
 ```
 bool SbSystemSymbolize(const void *address, char *out_buffer, int buffer_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/thread.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/thread.md
@@ -247,3 +247,4 @@ Set the thread priority of the current thread.
 ```
 bool SbThreadSetPriority(SbThreadPriority priority)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/time_zone.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/time_zone.md
@@ -45,3 +45,4 @@ and LOCATION is a specific location within the area. Typical names are
 ```
 const char* SbTimeZoneGetName()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/16/window.md
+++ b/cobalt/site/docs/reference/starboard/modules/16/window.md
@@ -181,3 +181,4 @@ Sets the default options for system windows.
 ```
 void SbWindowSetDefaultOptions(SbWindowOptions *options)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/atomic.md
+++ b/cobalt/site/docs/reference/starboard/modules/atomic.md
@@ -108,3 +108,4 @@ Overloaded functions for Atomic8.
 ```
 static SbAtomic8 SbAtomicRelease_CompareAndSwap8(volatile SbAtomic8 *ptr, SbAtomic8 old_value, SbAtomic8 new_value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/audio_sink.md
+++ b/cobalt/site/docs/reference/starboard/modules/audio_sink.md
@@ -212,3 +212,4 @@ Indicates whether the given audio sink handle is valid.
 ```
 bool SbAudioSinkIsValid(SbAudioSink audio_sink)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/configuration.md
+++ b/cobalt/site/docs/reference/starboard/modules/configuration.md
@@ -15,6 +15,11 @@ Starboard.
 
 ## Macros
 
+### ALLOW_EVERGREEN_SIDELOADING
+
+TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're fully
+launched.
+
 ### SB_ALIGNAS(byte_alignment)
 
 Specifies the alignment for a class, struct, union, enum, class/struct field, or

--- a/cobalt/site/docs/reference/starboard/modules/cpu_features.md
+++ b/cobalt/site/docs/reference/starboard/modules/cpu_features.md
@@ -259,3 +259,4 @@ fields in `features` are invalid.
 ```
 bool SbCPUFeaturesGet(SbCPUFeatures *features)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/decode_target.md
+++ b/cobalt/site/docs/reference/starboard/modules/decode_target.md
@@ -354,3 +354,4 @@ Starboard implementations, if it is necessary.
 ```
 static void SbDecodeTargetRunInGlesContext(SbDecodeTargetGraphicsContextProvider *provider, SbDecodeTargetGlesContextRunnerTarget target, void *target_context)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/directory.md
+++ b/cobalt/site/docs/reference/starboard/modules/directory.md
@@ -95,3 +95,4 @@ that the directory could not be opened.
 ```
 SbDirectory SbDirectoryOpen(const char *path, SbFileError *out_error)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/drm.md
+++ b/cobalt/site/docs/reference/starboard/modules/drm.md
@@ -410,7 +410,7 @@ Indicates whether `drm_system` is a valid SbDrmSystem.
 #### Declaration
 
 ```
-static bool SbDrmSystemIsValid(SbDrmSystem drm)
+bool SbDrmSystemIsValid(SbDrmSystem drm)
 ```
 
 ### SbDrmTicketIsValid
@@ -420,7 +420,7 @@ Indicates whether `ticket` is a valid ticket.
 #### Declaration
 
 ```
-static bool SbDrmTicketIsValid(int ticket)
+bool SbDrmTicketIsValid(int ticket)
 ```
 
 ### SbDrmUpdateServerCertificate
@@ -475,3 +475,4 @@ must not be NULL.
 ```
 void SbDrmUpdateSession(SbDrmSystem drm_system, int ticket, const void *key, int key_size, const void *session_id, int session_id_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/egl.md
+++ b/cobalt/site/docs/reference/starboard/modules/egl.md
@@ -144,3 +144,4 @@ typedef int32_t SbEglInt32
     config, void *native_pixmap, const SbEglAttrib *attrib_list)`
 *   `SbEglBoolean(*eglWaitSync)(SbEglDisplay dpy, SbEglSync sync, SbEglInt32
     flags)`
+

--- a/cobalt/site/docs/reference/starboard/modules/event.md
+++ b/cobalt/site/docs/reference/starboard/modules/event.md
@@ -405,3 +405,4 @@ event loop with the application event handler.
 ```
 int SbRunStarboardMain(int argc, char **argv, SbEventHandleCallback callback)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/file.md
+++ b/cobalt/site/docs/reference/starboard/modules/file.md
@@ -418,3 +418,4 @@ The return value identifies the number of bytes written, or `-1` on error.
 ```
 static int SbFileWriteAll(SbFile file, const char *data, int size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/gles.md
+++ b/cobalt/site/docs/reference/starboard/modules/gles.md
@@ -459,3 +459,4 @@ typedef long int SbGlIntPtr
     internalformat, SbGlSizei width, SbGlSizei height, SbGlSizei depth)`
 *   `void(*glGetInternalformativ)(SbGlEnum target, SbGlEnum internalformat,
     SbGlEnum pname, SbGlSizei bufSize, SbGlInt32 *params)`
+

--- a/cobalt/site/docs/reference/starboard/modules/input.md
+++ b/cobalt/site/docs/reference/starboard/modules/input.md
@@ -168,3 +168,4 @@ A 2-dimensional vector used to represent points and motion vectors.
 
 *   `float x`
 *   `float y`
+

--- a/cobalt/site/docs/reference/starboard/modules/key.md
+++ b/cobalt/site/docs/reference/starboard/modules/key.md
@@ -291,3 +291,4 @@ Bit-mask of key modifiers.
 *   `kSbKeyModifiersPointerButtonMiddle`
 *   `kSbKeyModifiersPointerButtonBack`
 *   `kSbKeyModifiersPointerButtonForward`
+

--- a/cobalt/site/docs/reference/starboard/modules/log.md
+++ b/cobalt/site/docs/reference/starboard/modules/log.md
@@ -124,3 +124,4 @@ Inline wrapper of SbLogFormat to convert from ellipsis to va_args.
 ```
 void static void static void SbLogRawFormatF(const char *format,...) SB_PRINTF_FORMAT(1
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/media.md
+++ b/cobalt/site/docs/reference/starboard/modules/media.md
@@ -710,3 +710,4 @@ removed, only to emit warnings at build and test time.
 ```
 bool SbMediaIsBufferUsingMemoryPool()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/memory.md
+++ b/cobalt/site/docs/reference/starboard/modules/memory.md
@@ -43,3 +43,4 @@ the mapped memory can be used.
 *   `kSbMemoryMapProtectWrite`
 *   `kSbMemoryMapProtectExec`
 *   `kSbMemoryMapProtectReadWrite`
+

--- a/cobalt/site/docs/reference/starboard/modules/microphone.md
+++ b/cobalt/site/docs/reference/starboard/modules/microphone.md
@@ -260,3 +260,4 @@ has already been read from the device is discarded.
 ```
 int SbMicrophoneRead(SbMicrophone microphone, void *out_audio_data, int audio_data_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/player.md
+++ b/cobalt/site/docs/reference/starboard/modules/player.md
@@ -735,3 +735,4 @@ SbPlayerGetMaximumNumberOfSamplesPerWrite().
 ```
 void SbPlayerWriteSamples(SbPlayer player, SbMediaType sample_type, const SbPlayerSampleInfo *sample_infos, int number_of_sample_infos)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/socket.md
+++ b/cobalt/site/docs/reference/starboard/modules/socket.md
@@ -631,3 +631,4 @@ option.
 ```
 bool SbSocketSetTcpWindowScaling(SbSocket socket, bool value)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/socket_waiter.md
+++ b/cobalt/site/docs/reference/starboard/modules/socket_waiter.md
@@ -249,3 +249,4 @@ next 7 times they are called.
 ```
 void SbSocketWaiterWakeUp(SbSocketWaiter waiter)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/speech_synthesis.md
+++ b/cobalt/site/docs/reference/starboard/modules/speech_synthesis.md
@@ -49,3 +49,4 @@ when the previous utterances are complete.
 ```
 void SbSpeechSynthesisSpeak(const char *text)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/storage.md
+++ b/cobalt/site/docs/reference/starboard/modules/storage.md
@@ -153,3 +153,4 @@ after a short time, even if there is an unexpected process termination before
 ```
 bool SbStorageWriteRecord(SbStorageRecord record, const char *data, int64_t data_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/system.md
+++ b/cobalt/site/docs/reference/starboard/modules/system.md
@@ -670,3 +670,4 @@ signal-safe on platforms that support signals.
 ```
 bool SbSystemSymbolize(const void *address, char *out_buffer, int buffer_size)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/thread.md
+++ b/cobalt/site/docs/reference/starboard/modules/thread.md
@@ -247,3 +247,4 @@ Set the thread priority of the current thread.
 ```
 bool SbThreadSetPriority(SbThreadPriority priority)
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/time_zone.md
+++ b/cobalt/site/docs/reference/starboard/modules/time_zone.md
@@ -45,3 +45,4 @@ and LOCATION is a specific location within the area. Typical names are
 ```
 const char* SbTimeZoneGetName()
 ```
+

--- a/cobalt/site/docs/reference/starboard/modules/window.md
+++ b/cobalt/site/docs/reference/starboard/modules/window.md
@@ -181,3 +181,4 @@ Sets the default options for system windows.
 ```
 void SbWindowSetDefaultOptions(SbWindowOptions *options)
 ```
+


### PR DESCRIPTION
Update the documentation for the Cobalt 25 LTS release. This includes
new details on networking performance optimizations using the multi-msg
socket extension, instructions for symbolizing minidumps via Docker,
and updated CVal definitions for CPU tracking. It also fixes paths
and commands for Raspberry Pi reference ports.

Bug: 505097004