### PR TITLE
docs: Add Cobalt 24.LTS.60 release notes

### DIFF
--- a/cobalt/site/docs/releases/24.LTS.60.md
+++ b/cobalt/site/docs/releases/24.LTS.60.md
@@ -1,0 +1,42 @@
+Project: /youtube/cobalt/_project.yaml
+Book: /youtube/cobalt/_book.yaml
+
+## Cobalt 24.LTS.60 Stable Release
+
+The Cobalt team has pushed critical patches to the Cobalt 24.lts.stable branch
+with tag [24.lts.60](https://github.com/youtube/cobalt/tree/24.lts.60)
+(24.lts.60.1032993) \
+
+The Evergreen binaries are available on GitHub
+([4.60.2](https://github.com/youtube/cobalt/releases/tag/24.lts.60))
+
+## Cobalt Changes
+
+### Critical Bug Fix
+
+*   **Evergreen Full:** Resolved an issue in previous versions of Cobalt which
+    caused the app to crash when an edge-case network error is encountered while
+    updating the Cobalt version using EG Full.
+    ([#4914](https://github.com/youtube/cobalt/pull/4914))
+
+### New Features / Support
+
+*   Added support for `nextHopProtocol` in the `PerformanceResourceTiming` API
+    to enable capturing metrics.
+    ([#4027](https://github.com/youtube/cobalt/pull/4027))
+
+### Updates
+
+*   Fixed a bug causing dropped frames during 4K video playback after resuming
+    from rest mode by adding socket watcher closure if there are no pending
+    operations. ([#4121](https://github.com/youtube/cobalt/pull/4121))
+
+Considering the critical Evergreen Full fix
+([#4914](https://github.com/youtube/cobalt/pull/4914)) included in this release,
+YouTube **strongly recommends** Partners to move to the latest 24.lts.60 (or
+newer) version as soon as possible.
+
+## Contact Points
+
+Please contact our [support channels](https://cobalt.dev/communication.html) if
+you have any problems, questions, or feedback.


### PR DESCRIPTION
Add the missing release notes for the Cobalt 24.LTS.60 stable release.
This documentation provides details on critical bug fixes, including
an Evergreen Full network error crash, and updates to the
PerformanceResourceTiming API and 4K video playback stability.


Bug: 505097004