### PR TITLE
ci: Fortify workflow concurrency group logic

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ on:
 
 concurrency:
   # Cancel existing jobs on the same workflow, platform, and branch (or sha if merged).
-  group: ${{ github.workflow }}-${{ inputs.platform }} @ ${{ github.head_ref || github.sha }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.platform }}-${{ github.event_name }} @ ${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Update the concurrency group definition to include the event name and
prioritize the pull request number over the git reference. This
prevents concurrency collisions between different event types and
ensures stale runs are canceled more reliably for specific pull
requests and branches.

Bug: 515425390