### PR TITLE
cobalt: Handle URL fragments for splash screen

### DIFF
--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -97,44 +97,59 @@ namespace content {
 namespace {
 
 constexpr char kMusicTopic[] = "music";
-constexpr int kMaxDeepLinkRecursionDepth = 10;
 
 // Helper function to check if a URL is a valid deep link for a specific topic.
 // It requires both a "launch" parameter and a matching "topic" parameter.
-bool IsDeepLinkTopic(const GURL& link_url,
-                     std::string_view target_topic,
-                     int depth = 0) {
-  if (depth > kMaxDeepLinkRecursionDepth) {
-    return false;
-  }
-  if (!link_url.is_valid() || !link_url.has_query()) {
+bool IsDeepLinkTopic(const GURL& link_url, std::string_view target_topic) {
+  if (!link_url.is_valid()) {
     return false;
   }
 
-  std::string query = link_url.query();
-  // Decode URL encoded characters in the entire query string first so that
-  // QueryIterator can correctly split on ampersands, even if they were encoded.
-  std::string unescaped_query = base::UnescapeURLComponent(
-      query, base::UnescapeRule::REPLACE_PLUS_WITH_SPACE |
-                 base::UnescapeRule::URL_SPECIAL_CHARS_EXCEPT_PATH_SEPARATORS);
-  GURL unescaped_url;
-  GURL::Replacements replacements;
-  replacements.SetQueryStr(unescaped_query);
-  unescaped_url = link_url.ReplaceComponents(replacements);
+  // Helper lambda to check a query string
+  auto check_query_string = [&](std::string_view query_str) {
+    std::string unescaped_query = base::UnescapeURLComponent(
+        query_str,
+        base::UnescapeRule::REPLACE_PLUS_WITH_SPACE |
+            base::UnescapeRule::URL_SPECIAL_CHARS_EXCEPT_PATH_SEPARATORS);
 
-  bool has_launch = false;
-  bool has_target_topic = false;
+    // Use GURL::Replacements to safely set the query string without worrying
+    // about special characters like '#' truncating the query.
+    GURL dummy_url("http://dummy/");
+    GURL::Replacements replacements;
+    replacements.SetQueryStr(unescaped_query);
+    dummy_url = dummy_url.ReplaceComponents(replacements);
 
-  for (net::QueryIterator it(unescaped_url); !it.IsAtEnd(); it.Advance()) {
-    if (!has_launch && it.GetKey() == "launch") {
-      has_launch = true;
-    } else if (!has_target_topic && it.GetKey() == "topic" &&
-               it.GetUnescapedValue() == target_topic) {
-      has_target_topic = true;
+    bool has_launch = false;
+    bool has_target_topic = false;
+
+    for (net::QueryIterator it(dummy_url); !it.IsAtEnd(); it.Advance()) {
+      if (!has_launch && it.GetKey() == "launch") {
+        has_launch = true;
+      } else if (!has_target_topic && it.GetKey() == "topic" &&
+                 it.GetUnescapedValue() == target_topic) {
+        has_target_topic = true;
+      }
+
+      if (has_launch && has_target_topic) {
+        return true;
+      }
     }
+    return false;
+  };
 
-    if (has_launch && has_target_topic) {
-      return true;
+  // 1. Check the standard query part
+  if (link_url.has_query() && check_query_string(link_url.query())) {
+    return true;
+  }
+
+  // 2. Check the fragment part if it looks like a query (starts with '?')
+  if (link_url.has_ref()) {
+    std::string ref = link_url.ref();
+    if (!ref.empty() && ref[0] == '?') {
+      // Skip the leading '?'
+      if (check_query_string(std::string_view(ref).substr(1))) {
+        return true;
+      }
     }
   }
 


### PR DESCRIPTION
Update the deep link topic identification logic to check both the
standard query string and the URL fragment. Some deep links provide
parameters within a fragment that starts with a question mark.

This ensures that Cobalt correctly identifies the intended topic, such
as music, even when the query parameters are passed in the fragment.
This is necessary for the browser to initialize with the correct
state and splash screen.

Issue: 489756553