### PR TITLE
Fortify the concurrency group setting

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -26,7 +26,7 @@ on:
 
 concurrency:
   # Cancel existing jobs on the same workflow, platform, and branch (or sha if merged).
-  group: ${{ github.workflow }}-${{ inputs.platform }} @ ${{ github.head_ref || github.sha }}-${{ github.ref }}
+  group: ${{ github.workflow }}-${{ inputs.platform }}-${{ github.event_name }} @ ${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: true
 
 env:


### PR DESCRIPTION
Update the GitHub Actions concurrency group to include the event name
and prefer the pull request number over branch references. This
prevents different event types from canceling each other and provides
a more stable identifier for isolating concurrent runs on the same
platform.

Bug: 123