### PR TITLE
Fix workflow secrets error in composite action

### DIFF
--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -1,6 +1,11 @@
 name: On Device Test
 description: Runs on-device tests.
 
+inputs:
+  DD_API_KEY:
+    description: 'DataDog API Key'
+    required: true
+
 runs:
   using: "composite"
   steps:
@@ -173,7 +178,7 @@ runs:
     - name: Upload to DataDog
       if: always() && env.TEST_TYPE == 'unit_test' && github.event == 'push'
       env:
-        DATADOG_API_KEY: ${{ secrets.DD_API_KEY }}
+        DATADOG_API_KEY: ${{ inputs.DD_API_KEY }}
         DATADOG_SITE: us5.datadoghq.com
         DD_ENV: ci
         DD_SERVICE: ${{ github.event.repository.name }}

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -4,7 +4,7 @@ description: Runs on-device tests.
 inputs:
   DD_API_KEY:
     description: 'DataDog API Key'
-    required: true
+    required: false
 
 runs:
   using: "composite"
@@ -164,7 +164,7 @@ runs:
         name: unit-test-results
         path: ${{ env.UNIT_TEST_RESULT_PATH }}/
     - name: Get Datadog CLI
-      if: always() && env.TEST_TYPE == 'unit_test' && github.event == 'push'
+      if: always() && env.TEST_TYPE == 'unit_test' && github.event == 'push' && inputs.DD_API_KEY != ''
       shell: bash
       env:
         DD_VERSION: 'v2.18.0'
@@ -176,7 +176,7 @@ runs:
         echo ${DD_SHA256SUM} | sha256sum --check
         chmod +x datadog-ci
     - name: Upload to DataDog
-      if: always() && env.TEST_TYPE == 'unit_test' && github.event == 'push'
+      if: always() && env.TEST_TYPE == 'unit_test' && github.event == 'push' && inputs.DD_API_KEY != ''
       env:
         DATADOG_API_KEY: ${{ inputs.DD_API_KEY }}
         DATADOG_SITE: us5.datadoghq.com

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -306,6 +306,8 @@ jobs:
           persist-credentials: false
       - name: Run Tests (${{ matrix.shard }})
         uses: ./.github/actions/on_device_tests
+        with:
+          DD_API_KEY: ${{ secrets.DD_API_KEY }}
 
   # Runs on-host integration and unit tests.
   on-host-test:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,9 +29,11 @@ x-build-volumes: &build-volumes
     - ${CCACHE_DIR:-container-ccache}:/root/ccache
 
 x-build-common-definitions: &build-common-definitions
-  <<:
-    - *common-definitions
-    - *build-volumes
+  <<: *common-definitions
+  volumes:
+    - ${COBALT_SRC:-.}:/code/
+    - android-debug-keystore:/root/.android/
+    - ${CCACHE_DIR:-container-ccache}:/root/ccache
   depends_on:
     - build-base
 
@@ -175,9 +177,11 @@ services:
       SB_API_VERSION: ${SB_API_VERSION}
 
   linux-x64x11-bionic:
-    <<:
-      - *common-definitions
-      - *build-volumes
+    <<: *common-definitions
+    volumes:
+      - ${COBALT_SRC:-.}:/code/
+      - android-debug-keystore:/root/.android/
+      - ${CCACHE_DIR:-container-ccache}:/root/ccache
     build:
       context: ./docker/linux
       dockerfile: linux-x64x11/Dockerfile
@@ -189,9 +193,11 @@ services:
     scale: 0
 
   linux-x64x11-gcc:
-    <<:
-      - *common-definitions
-      - *build-volumes
+    <<: *common-definitions
+    volumes:
+      - ${COBALT_SRC:-.}:/code/
+      - android-debug-keystore:/root/.android/
+      - ${CCACHE_DIR:-container-ccache}:/root/ccache
     build:
       context: ./docker/linux
       dockerfile: gcc-6-3/Dockerfile
@@ -205,9 +211,11 @@ services:
       - linux-x64x11-bionic
 
   build-linux-gcc:
-    <<:
-      - *common-definitions
-      - *build-volumes
+    <<: *common-definitions
+    volumes:
+      - ${COBALT_SRC:-.}:/code/
+      - android-debug-keystore:/root/.android/
+      - ${CCACHE_DIR:-container-ccache}:/root/ccache
     build:
       context: ./docker/linux
       dockerfile: gcc-6-3/Dockerfile
@@ -216,9 +224,11 @@ services:
       - linux-x64x11-bionic
 
   linux-x64x11-clang-3-9:
-    <<:
-      - *common-definitions
-      - *build-volumes
+    <<: *common-definitions
+    volumes:
+      - ${COBALT_SRC:-.}:/code/
+      - android-debug-keystore:/root/.android/
+      - ${CCACHE_DIR:-container-ccache}:/root/ccache
     build:
       context: ./docker/linux/
       dockerfile: clang-3-9/Dockerfile
@@ -232,9 +242,11 @@ services:
       - linux-x64x11-bionic
 
   build-linux-clang-3-9:
-    <<:
-      - *common-definitions
-      - *build-volumes
+    <<: *common-definitions
+    volumes:
+      - ${COBALT_SRC:-.}:/code/
+      - android-debug-keystore:/root/.android/
+      - ${CCACHE_DIR:-container-ccache}:/root/ccache
     build:
       context: ./docker/linux/
       dockerfile: clang-3-9/Dockerfile


### PR DESCRIPTION
This PR fixes the 'Unrecognized named-value: secrets' error in the composite action by passing the secret as an input. Minimal change for release branch.

BUG=508469475
TAG=agy
CONV=b353fb67-a1fd-4829-890c-12c9bc6ae550