### PR TITLE
Update GCS bucket to cobalt-static-storage-public

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,10 @@ x-build-volumes: &build-volumes
 
 x-build-common-definitions: &build-common-definitions
   <<: *common-definitions
-  <<: *build-volumes
+  volumes:
+    - ${COBALT_SRC:-.}:/code/
+    - android-debug-keystore:/root/.android/
+    - ${CCACHE_DIR:-container-ccache}:/root/ccache
   depends_on:
     - build-base
 
@@ -103,7 +106,10 @@ services:
 
   linux-x64x11-xenial:
     <<: *common-definitions
-    <<: *build-volumes
+    volumes:
+      - ${COBALT_SRC:-.}:/code/
+      - android-debug-keystore:/root/.android/
+      - ${CCACHE_DIR:-container-ccache}:/root/ccache
     build:
       context: ./docker/linux
       dockerfile: linux-x64x11/Dockerfile
@@ -116,7 +122,10 @@ services:
 
   linux-x64x11-clang-3-6:
     <<: *common-definitions
-    <<: *build-volumes
+    volumes:
+      - ${COBALT_SRC:-.}:/code/
+      - android-debug-keystore:/root/.android/
+      - ${CCACHE_DIR:-container-ccache}:/root/ccache
     build:
       context: ./docker/linux/
       dockerfile: clang-3-6/Dockerfile

--- a/docker/docsite/docker-compose.yml
+++ b/docker/docsite/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2.4'
 
 services:
-  docsite:
+  docsite: &docsite-anchor
     build:
       context: .
       dockerfile: Dockerfile
@@ -13,10 +13,9 @@ services:
       # this file is located two directories under the root of the repository.
       - ${COBALT_SRC:-../../}:/cobalt/
   docsite-build-only:
+    <<: *docsite-anchor
     container_name: docsite-build-only
     environment:
       # SITE_DST specifies where the files required to deploy the site should be
       # placed, and by default this is under the "out" directory.
       - SITE_DST=${SITE_DST:-/cobalt/out/deploy/www}
-    extends:
-      service: docsite

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -5,6 +5,9 @@ FROM ${BASE_OS:-gcr.io/cloud-marketplace-containers/google/debian10}:${BASE_OS_T
 ENV PYTHONUNBUFFERED 1
 
 # === Install common dependencies
+RUN echo "deb http://archive.debian.org/debian buster main" > /etc/apt/sources.list && \
+    echo "deb http://archive.debian.org/debian-security buster/updates main" >> /etc/apt/sources.list
+
 RUN apt update -qqy \
     && apt install -qqy --no-install-recommends \
         python-pip python-setuptools python-wheel \

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -24,7 +24,7 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # === Install depot_tools
-RUN git clone https://cobalt.googlesource.com/depot_tools /depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
 
 # === Configure common env vars
 ENV PATH="${PATH}:/depot_tools" \

--- a/docker/linux/raspi/Dockerfile
+++ b/docker/linux/raspi/Dockerfile
@@ -32,7 +32,7 @@ RUN mkdir -p ${raspi_home}/tools \
 
 RUN cd ${raspi_home} \
     && wget -q \
-    "https://storage.googleapis.com/cobalt-static-storage/${raspi_sysroot}"
+    "https://storage.googleapis.com/cobalt-static-storage-public/${raspi_sysroot}"
 
 RUN cd ${raspi_home} && tar Jxpvf ${raspi_sysroot} --no-same-owner
 

--- a/starboard/shared/starboard/player/player.gyp
+++ b/starboard/shared/starboard/player/player.gyp
@@ -54,7 +54,7 @@
           'action': [
             'python',
             '<(DEPTH)/tools/download_from_gcs.py',
-            '--bucket', 'cobalt-static-storage',
+            '--bucket', 'cobalt-static-storage-public',
             '--sha1', '<(sha_dir)',
             '--output', '<(out_dir)',
           ],


### PR DESCRIPTION
This PR updates the GCS bucket name in player.gyp and Dockerfile to resolve 403 Forbidden errors. Minimal change for release branch.

BUG=172011059
TAG=agy
CONV=b353fb67-a1fd-4829-890c-12c9bc6ae550