### PR TITLE
tvOS: Implement performance.getAppStartupTimestamp

### DIFF
--- a/cobalt/app/tvos/main.mm
+++ b/cobalt/app/tvos/main.mm
@@ -35,6 +35,7 @@
 #include "content/public/browser/render_widget_host.h"
 #include "net/base/apple/url_conversions.h"
 #include "starboard/common/command_line.h"
+#include "starboard/common/time.h"
 #include "starboard/tvos/shared/application_darwin.h"
 
 static int g_argc = 0;
@@ -187,7 +188,13 @@ static const char** g_argv = nullptr;
   std::ranges::transform(processed_argv, std::back_inserter(char_argv),
                          [](const std::string& arg) { return arg.c_str(); });
 
-  _mainDelegate = std::make_unique<cobalt::CobaltMainDelegate>();
+  // This is similar to base::TimeTicks::Now() and a call to ToInternalValue()
+  // and follows what Starboard platforms measure in
+  // starboard::Application::RunLoop().
+  const int64_t startup_time_in_us = starboard::CurrentMonotonicTime();
+
+  _mainDelegate =
+      std::make_unique<cobalt::CobaltMainDelegate>(startup_time_in_us);
   _mainRunner = content::ContentMainRunner::Create();
   content::ContentMainParams params(_mainDelegate.get());
   params.argc = char_argv.size();

--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -91,10 +91,6 @@ void PerformanceImpl::GetAppStartupTimeStamp(
         StarboardBridge::GetInstance()->GetAppStartTimestamp(env);
   }
 #endif
-#if BUILDFLAG(IS_IOS_TVOS)
-  // TODO - b/487001977: Implement this method.
-  NOTIMPLEMENTED();
-#endif
   std::move(callback).Run(app_startup_timestamp_.value_or(0));
 }
 

--- a/cobalt/browser/performance/performance_impl.h
+++ b/cobalt/browser/performance/performance_impl.h
@@ -26,7 +26,7 @@ class RenderFrameHost;
 
 namespace performance {
 
-// Implements the H5vccSystem Mojo interface and extends
+// Implements the CobaltPerformance Mojo interface and extends
 // DocumentService so that an object's lifetime is scoped to the corresponding
 // document / RenderFrameHost (see DocumentService for details).
 class PerformanceImpl

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
@@ -14,8 +14,6 @@
 
 #include "third_party/blink/renderer/core/cobalt/performance/performance_extensions.h"
 
-#include "base/notreached.h"
-#include "build/build_config.h"
 #include "cobalt/browser/performance/public/mojom/performance.mojom.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "third_party/blink/public/platform/browser_interface_broker_proxy.h"
@@ -89,11 +87,6 @@ ScriptPromise<IDLDouble> PerformanceExtensions::getAppStartupTimeStamp(
       script_state, exception_state.GetContext());
   ScriptPromise<IDLDouble> promise = resolver->Promise();
 
-#if BUILDFLAG(IS_IOS_TVOS)
-  // TODO - b/487001977: Implement startup time measurement for tvOS.
-  resolver->Reject(MakeGarbageCollected<DOMException>(
-      DOMExceptionCode::kNotSupportedError, "Not implemented on iOS/tvOS."));
-#else
   int64_t startup_timestamp = 0;
   BindRemotePerformance(script_state)
       ->GetAppStartupTimeStamp(&startup_timestamp);
@@ -103,7 +96,6 @@ ScriptPromise<IDLDouble> PerformanceExtensions::getAppStartupTimeStamp(
       base::TimeTicks::FromInternalValue(startup_timestamp),
       true /* allow_negative_value */,
       context->CrossOriginIsolatedCapability()));
-#endif
 
   return promise;
 }


### PR DESCRIPTION
Do something similar to what Starboard platforms and just record the timestamp right before `cobalt::CobaltMainDelegate` is created.

Fixed: 487001977