### PR TITLE
aosp: Remove arm_use_neon=false

### DIFF
--- a/cobalt/build/configs/aosp-arm/args.gn
+++ b/cobalt/build/configs/aosp-arm/args.gn
@@ -4,9 +4,5 @@ target_cpu = "arm"
 starboard_target_platform = "aosp-arm"
 arm_float_abi = "softfp"
 
-# TODO: b/453022760 - Investigate if this should be true and fix build failures
-# if so.
-arm_use_neon = false
-
 # TODO(b/380339614): Remove this flag after resolving build errors.
 treat_warnings_as_errors = false

--- a/cobalt/build/configs/evergreen-arm-softfp/args.gn
+++ b/cobalt/build/configs/evergreen-arm-softfp/args.gn
@@ -3,5 +3,3 @@ import("//cobalt/build/configs/evergreen_common.gn")
 target_cpu = "arm"
 starboard_path = "starboard/no_platform"
 arm_float_abi = "softfp"
-
-arm_use_neon = true


### PR DESCRIPTION
Follow-up from https://github.com/youtube/cobalt/pull/10454, in which neon was enabled for evergreen softfp builds.

For consistency, remove it from evergreen-arm-softfp too, so that the default is always used.

Bug: 453022760