### PR TITLE
media: Use TunnelModeAudioSessionId.NONE instead of -1 in MediaCodecBridge

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
@@ -80,7 +80,7 @@ public class AudioTrackBridge {
       int tunnelModeAudioSessionId,
       boolean isWebAudio) {
 
-    mTunnelModeEnabled = tunnelModeAudioSessionId != -1;
+    mTunnelModeEnabled = tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE;
     int channelConfig;
     switch (channelCount) {
       case 1:

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -324,7 +324,7 @@ class MediaCodecBridge {
     }
     mNativeMediaCodecBridge = nativeMediaCodecBridge;
     mMediaCodec.set(mediaCodec);
-    mIsTunnelingPlayback = tunnelModeAudioSessionId != -1;
+    mIsTunnelingPlayback = tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE;
     mCallback =
         new MediaCodec.Callback() {
           @Override
@@ -529,7 +529,7 @@ class MediaCodecBridge {
       mediaFormat.setByteBuffer(MediaFormat.KEY_HDR_STATIC_INFO, colorInfo.hdrStaticInfo);
     }
 
-    if (tunnelModeAudioSessionId != -1) {
+    if (tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE) {
       mediaFormat.setFeatureEnabled(CodecCapabilities.FEATURE_TunneledPlayback, true);
       mediaFormat.setInteger(MediaFormat.KEY_AUDIO_SESSION_ID, tunnelModeAudioSessionId);
       Log.d(TAG, "Enabled tunnel mode playback on audio session " + tunnelModeAudioSessionId);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
@@ -56,7 +56,7 @@ class MediaCodecBridgeBuilder {
         new MediaCodecBridge(
             nativeMediaCodecBridge,
             mediaCodec,
-            -1);
+            TunnelModeAudioSessionId.NONE);
 
     byte[][] csds = {};
     boolean frameHasAdtsHeader = false;


### PR DESCRIPTION
Update MediaCodecBridge.java to use the generated TunnelModeAudioSessionId.NONE constant instead of the magic number -1. This improves readability and type safety, aligning with the C++ refactoring in #10421 .

Issue: 414009070