### PR TITLE
android: Centralize frame rendered listener decision  

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -72,6 +72,7 @@ class MediaCodecBridge {
   private double mOperatingRate = mPlaybackRate * mFps;
   private boolean mSkipVideoFramesOver60Fps = false;
   private final boolean mIsTunnelingPlayback;
+  private final boolean mEnableFrameRendererListener;
 
   private MediaCodec.OnFrameRenderedListener mFrameRendererListener;
   private MediaCodec.OnFirstTunnelFrameReadyListener mFirstTunnelFrameReadyListener;
@@ -318,13 +319,17 @@ class MediaCodecBridge {
   }
 
   public MediaCodecBridge(
-      long nativeMediaCodecBridge, MediaCodec mediaCodec, int tunnelModeAudioSessionId) {
+      long nativeMediaCodecBridge,
+      MediaCodec mediaCodec,
+      int tunnelModeAudioSessionId,
+      boolean enableFrameRendererListener) {
     if (mediaCodec == null) {
       throw new IllegalArgumentException();
     }
     mNativeMediaCodecBridge = nativeMediaCodecBridge;
     mMediaCodec.set(mediaCodec);
     mIsTunnelingPlayback = tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE;
+    mEnableFrameRendererListener = enableFrameRendererListener;
     mCallback =
         new MediaCodec.Callback() {
           @Override
@@ -402,7 +407,7 @@ class MediaCodecBridge {
         };
     mMediaCodec.get().setCallback(mCallback);
 
-    if (isFrameRenderedCallbackEnabled() || mIsTunnelingPlayback) {
+    if (mEnableFrameRendererListener) {
       mFrameRendererListener =
           new MediaCodec.OnFrameRenderedListener() {
             @Override
@@ -424,13 +429,6 @@ class MediaCodecBridge {
       setupTunnelingPlayback();
     }
     mFrameRateEstimator = MediaCodecFrameRateEstimator.create(mIsTunnelingPlayback);
-  }
-
-  @CalledByNative
-  public static boolean isFrameRenderedCallbackEnabled() {
-    // Starting with Android 14, onFrameRendered should be called accurately for each rendered
-    // frame.
-    return Build.VERSION.SDK_INT >= 34;
   }
 
   private boolean isDecodeOnlyFlagEnabled() {
@@ -460,6 +458,7 @@ class MediaCodecBridge {
       int tunnelModeAudioSessionId,
       int maxVideoInputSize,
       boolean enableOutputChecker,
+      boolean enableFrameRendererListener,
       boolean skipVideoFramesOver60Fps,
       CreateMediaCodecBridgeResult outCreateMediaCodecBridgeResult) {
     MediaCodec mediaCodec = null;
@@ -510,7 +509,11 @@ class MediaCodecBridge {
     }
 
     MediaCodecBridge bridge =
-        new MediaCodecBridge(nativeMediaCodecBridge, mediaCodec, tunnelModeAudioSessionId);
+        new MediaCodecBridge(
+            nativeMediaCodecBridge,
+            mediaCodec,
+            tunnelModeAudioSessionId,
+            enableFrameRendererListener);
     bridge.mSkipVideoFramesOver60Fps = skipVideoFramesOver60Fps;
     MediaCodecOutputTracker.get().register(bridge);
     MediaFormat mediaFormat =

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
@@ -56,7 +56,8 @@ class MediaCodecBridgeBuilder {
         new MediaCodecBridge(
             nativeMediaCodecBridge,
             mediaCodec,
-            TunnelModeAudioSessionId.NONE);
+            TunnelModeAudioSessionId.NONE,
+            /*enableFrameRendererListener=*/false);
 
     byte[][] csds = {};
     boolean frameHasAdtsHeader = false;

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -181,6 +181,7 @@ MediaCodecBridge::CreateVideoMediaCodecBridge(
     jobject j_surface,
     jobject j_media_crypto,
     const SbMediaColorMetadata* color_metadata,
+    bool use_frame_rendered_callback,
     bool require_secured_decoder,
     bool require_software_codec,
     std::optional<int> tunnel_mode_audio_session_id,
@@ -291,7 +292,7 @@ MediaCodecBridge::CreateVideoMediaCodecBridge(
       max_frame_size ? max_frame_size->height : -1, j_surface_local,
       j_media_crypto_local, j_color_info,
       tunnel_mode_audio_session_id.value_or(TUNNEL_MODE_AUDIO_SESSION_ID_NONE),
-      max_video_input_size, enable_output_checker,
+      max_video_input_size, enable_output_checker, use_frame_rendered_callback,
       skip_video_frames_over_60_fps, j_create_media_codec_bridge_result);
 
   ScopedJavaLocalRef<jobject> j_media_codec_bridge(
@@ -503,12 +504,6 @@ void MediaCodecBridge::OnMediaCodecFrameRendered(
 
 void MediaCodecBridge::OnMediaCodecFirstTunnelFrameReady(JNIEnv* env) {
   handler_->OnMediaCodecFirstTunnelFrameReady();
-}
-
-// static
-jboolean MediaCodecBridge::IsFrameRenderedCallbackEnabled() {
-  JNIEnv* env = AttachCurrentThread();
-  return Java_MediaCodecBridge_isFrameRenderedCallbackEnabled(env);
 }
 
 MediaCodecBridge::MediaCodecBridge(Handler* handler) : handler_(handler) {

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -181,7 +181,7 @@ MediaCodecBridge::CreateVideoMediaCodecBridge(
     jobject j_surface,
     jobject j_media_crypto,
     const SbMediaColorMetadata* color_metadata,
-    bool use_frame_rendered_callback,
+    bool enable_frame_renderer_listener,
     bool require_secured_decoder,
     bool require_software_codec,
     std::optional<int> tunnel_mode_audio_session_id,
@@ -292,8 +292,9 @@ MediaCodecBridge::CreateVideoMediaCodecBridge(
       max_frame_size ? max_frame_size->height : -1, j_surface_local,
       j_media_crypto_local, j_color_info,
       tunnel_mode_audio_session_id.value_or(TUNNEL_MODE_AUDIO_SESSION_ID_NONE),
-      max_video_input_size, enable_output_checker, use_frame_rendered_callback,
-      skip_video_frames_over_60_fps, j_create_media_codec_bridge_result);
+      max_video_input_size, enable_output_checker,
+      enable_frame_renderer_listener, skip_video_frames_over_60_fps,
+      j_create_media_codec_bridge_result);
 
   ScopedJavaLocalRef<jobject> j_media_codec_bridge(
       Java_CreateMediaCodecBridgeResult_mediaCodecBridge(

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -128,7 +128,7 @@ class MediaCodecBridge {
       jobject j_surface,
       jobject j_media_crypto,
       const SbMediaColorMetadata* color_metadata,
-      bool use_frame_rendered_callback,
+      bool enable_frame_renderer_listener,
       bool require_secured_decoder,
       bool require_software_codec,
       std::optional<int> tunnel_mode_audio_session_id,

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -128,6 +128,7 @@ class MediaCodecBridge {
       jobject j_surface,
       jobject j_media_crypto,
       const SbMediaColorMetadata* color_metadata,
+      bool use_frame_rendered_callback,
       bool require_secured_decoder,
       bool require_software_codec,
       std::optional<int> tunnel_mode_audio_session_id,
@@ -182,8 +183,6 @@ class MediaCodecBridge {
                                  jlong presentation_time_us,
                                  jlong render_at_system_time_ns);
   void OnMediaCodecFirstTunnelFrameReady(JNIEnv* env);
-
-  static jboolean IsFrameRenderedCallbackEnabled();
 
  private:
   // |MediaCodecBridge|s must only be created through its factory methods.

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -127,22 +127,22 @@ MediaCodecDecoder::CreateForVideo(
     const FrameRenderedCB& frame_rendered_cb,
     const FirstTunnelFrameReadyCB& first_tunnel_frame_ready_cb,
     std::optional<int> tunnel_mode_audio_session_id,
+    bool enable_frame_renderer_listener,
     bool force_big_endian_hdr_metadata,
     int max_video_input_size,
     int64_t flush_delay_usec,
     std::optional<bool> use_dual_threads,
     bool enable_output_checker,
-    bool skip_video_frames_over_60_fps,
-    bool use_frame_rendered_callback) {
+    bool skip_video_frames_over_60_fps) {
   std::string error_message;
   auto decoder = std::make_unique<MediaCodecDecoder>(
       PassKey<MediaCodecDecoder>(), job_queue, host, video_codec,
       frame_size_hint, max_frame_size, fps, j_output_surface, drm_system,
       color_metadata, require_software_codec, frame_rendered_cb,
       first_tunnel_frame_ready_cb, tunnel_mode_audio_session_id,
-      force_big_endian_hdr_metadata, max_video_input_size, flush_delay_usec,
-      use_dual_threads, enable_output_checker, skip_video_frames_over_60_fps,
-      use_frame_rendered_callback, &error_message);
+      enable_frame_renderer_listener, force_big_endian_hdr_metadata,
+      max_video_input_size, flush_delay_usec, use_dual_threads,
+      enable_output_checker, skip_video_frames_over_60_fps, &error_message);
   if (!decoder->media_codec_bridge_) {
     return Failure(error_message);
   }
@@ -201,13 +201,13 @@ MediaCodecDecoder::MediaCodecDecoder(
     const FrameRenderedCB& frame_rendered_cb,
     const FirstTunnelFrameReadyCB& first_tunnel_frame_ready_cb,
     std::optional<int> tunnel_mode_audio_session_id,
+    bool enable_frame_renderer_listener,
     bool force_big_endian_hdr_metadata,
     int max_video_input_size,
     int64_t flush_delay_usec,
     std::optional<bool> use_dual_threads,
     bool enable_output_checker,
     bool skip_video_frames_over_60_fps,
-    bool use_frame_rendered_callback,
     std::string* error_message)
     : JobOwner(job_queue),
       media_type_(kSbMediaTypeVideo),
@@ -232,7 +232,7 @@ MediaCodecDecoder::MediaCodecDecoder(
   auto media_codec_bridge = MediaCodecBridge::CreateVideoMediaCodecBridge(
       video_codec, frame_size_hint, fps, max_frame_size, /*handler=*/this,
       j_output_surface, j_media_crypto, color_metadata,
-      use_frame_rendered_callback, require_secured_decoder,
+      enable_frame_renderer_listener, require_secured_decoder,
       require_software_codec, tunnel_mode_audio_session_id,
       force_big_endian_hdr_metadata, max_video_input_size,
       enable_output_checker, skip_video_frames_over_60_fps);

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -132,7 +132,8 @@ MediaCodecDecoder::CreateForVideo(
     int64_t flush_delay_usec,
     std::optional<bool> use_dual_threads,
     bool enable_output_checker,
-    bool skip_video_frames_over_60_fps) {
+    bool skip_video_frames_over_60_fps,
+    bool use_frame_rendered_callback) {
   std::string error_message;
   auto decoder = std::make_unique<MediaCodecDecoder>(
       PassKey<MediaCodecDecoder>(), job_queue, host, video_codec,
@@ -141,7 +142,7 @@ MediaCodecDecoder::CreateForVideo(
       first_tunnel_frame_ready_cb, tunnel_mode_audio_session_id,
       force_big_endian_hdr_metadata, max_video_input_size, flush_delay_usec,
       use_dual_threads, enable_output_checker, skip_video_frames_over_60_fps,
-      &error_message);
+      use_frame_rendered_callback, &error_message);
   if (!decoder->media_codec_bridge_) {
     return Failure(error_message);
   }
@@ -206,6 +207,7 @@ MediaCodecDecoder::MediaCodecDecoder(
     std::optional<bool> use_dual_threads,
     bool enable_output_checker,
     bool skip_video_frames_over_60_fps,
+    bool use_frame_rendered_callback,
     std::string* error_message)
     : JobOwner(job_queue),
       media_type_(kSbMediaTypeVideo),
@@ -229,7 +231,8 @@ MediaCodecDecoder::MediaCodecDecoder(
   SB_DCHECK(!drm_system_ || j_media_crypto);
   auto media_codec_bridge = MediaCodecBridge::CreateVideoMediaCodecBridge(
       video_codec, frame_size_hint, fps, max_frame_size, /*handler=*/this,
-      j_output_surface, j_media_crypto, color_metadata, require_secured_decoder,
+      j_output_surface, j_media_crypto, color_metadata,
+      use_frame_rendered_callback, require_secured_decoder,
       require_software_codec, tunnel_mode_audio_session_id,
       force_big_endian_hdr_metadata, max_video_input_size,
       enable_output_checker, skip_video_frames_over_60_fps);

--- a/starboard/android/shared/media_codec_decoder.h
+++ b/starboard/android/shared/media_codec_decoder.h
@@ -98,7 +98,8 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
       int64_t flush_delay_usec,
       std::optional<bool> use_dual_threads,
       bool enable_output_checker,
-      bool skip_video_frames_over_60_fps);
+      bool skip_video_frames_over_60_fps,
+      bool use_frame_rendered_callback);
 
   MediaCodecDecoder(PassKey<MediaCodecDecoder>,
                     JobQueue* job_queue,
@@ -129,6 +130,7 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
       std::optional<bool> use_dual_threads,
       bool enable_output_checker,
       bool skip_video_frames_over_60_fps,
+      bool use_frame_rendered_callback,
       std::string* error_message);
   ~MediaCodecDecoder();
 

--- a/starboard/android/shared/media_codec_decoder.h
+++ b/starboard/android/shared/media_codec_decoder.h
@@ -93,13 +93,13 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
       const FrameRenderedCB& frame_rendered_cb,
       const FirstTunnelFrameReadyCB& first_tunnel_frame_ready_cb,
       std::optional<int> tunnel_mode_audio_session_id,
+      bool enable_frame_renderer_listener,
       bool force_big_endian_hdr_metadata,
       int max_video_input_size,
       int64_t flush_delay_usec,
       std::optional<bool> use_dual_threads,
       bool enable_output_checker,
-      bool skip_video_frames_over_60_fps,
-      bool use_frame_rendered_callback);
+      bool skip_video_frames_over_60_fps);
 
   MediaCodecDecoder(PassKey<MediaCodecDecoder>,
                     JobQueue* job_queue,
@@ -124,13 +124,13 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
       const FrameRenderedCB& frame_rendered_cb,
       const FirstTunnelFrameReadyCB& first_tunnel_frame_ready_cb,
       std::optional<int> tunnel_mode_audio_session_id,
+      bool enable_frame_renderer_listener,
       bool force_big_endian_hdr_metadata,
       int max_video_input_size,
       int64_t flush_delay_usec,
       std::optional<bool> use_dual_threads,
       bool enable_output_checker,
       bool skip_video_frames_over_60_fps,
-      bool use_frame_rendered_callback,
       std::string* error_message);
   ~MediaCodecDecoder();
 

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -807,10 +807,10 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       color_metadata_ ? &*color_metadata_ : nullptr, require_software_codec_,
       std::bind(&MediaCodecVideoDecoder::OnFrameRendered, this, _1),
       std::bind(&MediaCodecVideoDecoder::OnFirstTunnelFrameReady, this),
-      tunnel_mode_audio_session_id_, force_big_endian_hdr_metadata_,
-      max_video_input_size_, flush_delay_usec_, use_dual_threads_,
-      enable_output_checker_, skip_video_frames_over_60_fps_,
-      is_video_frame_tracker_enabled_);
+      tunnel_mode_audio_session_id_, is_video_frame_tracker_enabled_,
+      force_big_endian_hdr_metadata_, max_video_input_size_, flush_delay_usec_,
+      use_dual_threads_, enable_output_checker_,
+      skip_video_frames_over_60_fps_);
   if (result) {
     media_decoder_ = std::move(result.value());
     if (error_cb_) {

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -324,8 +324,11 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
       enable_output_checker_(experimental_features.enable_codec_output_checker),
       skip_video_frames_over_60_fps_(
           experimental_features.skip_video_frames_over_60_fps),
-      is_video_frame_tracker_enabled_(IsFrameRenderedCallbackEnabled() ||
-                                      tunnel_mode_audio_session_id),
+      is_video_frame_tracker_enabled_(
+          // OnFrameRenderedListener is available since API 23, but only
+          // reliable for standard playback since API 34. Tunnel mode uses it on
+          // all SDKs.
+          android_get_device_api_level() >= 34 || tunnel_mode_audio_session_id),
       has_new_texture_available_(false),
       initial_number_of_preroll_frames_(
           experimental_features.video_decoder_initial_preroll_count.value_or(
@@ -804,7 +807,8 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       std::bind(&MediaCodecVideoDecoder::OnFirstTunnelFrameReady, this),
       tunnel_mode_audio_session_id_, force_big_endian_hdr_metadata_,
       max_video_input_size_, flush_delay_usec_, use_dual_threads_,
-      enable_output_checker_, skip_video_frames_over_60_fps_);
+      enable_output_checker_, skip_video_frames_over_60_fps_,
+      is_video_frame_tracker_enabled_);
   if (result) {
     media_decoder_ = std::move(result.value());
     if (error_cb_) {
@@ -1044,10 +1048,6 @@ void MediaCodecVideoDecoder::TryToSignalPrerollForTunnelMode() {
     decoder_status_cb_(kNeedMoreInput,
                        new VideoFrame(video_frame_tracker_->seek_to_time()));
   }
-}
-
-bool MediaCodecVideoDecoder::IsFrameRenderedCallbackEnabled() {
-  return MediaCodecBridge::IsFrameRenderedCallbackEnabled() == JNI_TRUE;
 }
 
 void MediaCodecVideoDecoder::OnFrameRendered(int64_t frame_timestamp) {

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -383,8 +383,10 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
                << ", preroll count=" << number_of_preroll_frames_
                << ", max pending input size=" << kMaxPendingInputsSize
                << ", max video capabilities=\"" << max_video_capabilities_
-               << "\", and tunnel mode audio session id="
-               << ToString(tunnel_mode_audio_session_id_);
+               << "\", tunnel mode audio session id="
+               << ToString(tunnel_mode_audio_session_id_)
+               << ", is_video_frame_tracker_enabled="
+               << ToString(is_video_frame_tracker_enabled_);
 }
 
 MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -139,7 +139,6 @@ class MediaCodecVideoDecoder : public VideoDecoder,
       const scoped_refptr<InputBuffer>& input_buffer) override;
 
   void TryToSignalPrerollForTunnelMode();
-  bool IsFrameRenderedCallbackEnabled();
   void OnFrameRendered(int64_t frame_timestamp);
   void OnFirstTunnelFrameReady();
   void OnTunnelModeCheckForNeedMoreInput();


### PR DESCRIPTION
Shift the decision-making logic for enabling the MediaCodec frame
rendered callback from the Java layer to the C++ native layer.

Previously, the Java layer independently decided to enable the listener
based on the SDK version or tunnel mode status. This change centralizes
the logic in MediaCodecVideoDecoder. The decision is then passed to
the Java MediaCodecBridge via JNI, ensuring the native and Java layers
stay synchronized regarding frame tracking.

Issue: 414009070