### PR TITLE
media: Implement Direct Renderer for single-process

### DIFF
--- a/cobalt/gpu/cobalt_content_gpu_client.cc
+++ b/cobalt/gpu/cobalt_content_gpu_client.cc
@@ -72,4 +72,18 @@ void CobaltContentGpuClient::CreateVideoGeometrySetterService() {
               base::SingleThreadTaskRunner::GetCurrentDefault()));
 }
 
+void CobaltContentGpuClient::SetVideoGeometryChangeSubscriberReceiver(
+    mojo::GenericPendingReceiver receiver) {
+  auto* service = GetVideoGeometrySetterService();
+  if (service && receiver.is_valid()) {
+    service->GetVideoGeometryChangeSubscriber(
+        receiver.As<cobalt::media::mojom::VideoGeometryChangeSubscriber>());
+  }
+}
+
+mojo::GenericPendingReceiver
+CobaltContentGpuClient::TakeVideoGeometryChangeSubscriberReceiver() {
+  return mojo::GenericPendingReceiver();
+}
+
 }  // namespace cobalt

--- a/cobalt/gpu/cobalt_content_gpu_client.h
+++ b/cobalt/gpu/cobalt_content_gpu_client.h
@@ -39,12 +39,17 @@ class CobaltContentGpuClient : public content::ContentGpuClient {
   void PostCompositorThreadCreated(
       base::SingleThreadTaskRunner* task_runner) override;
   media::VideoGeometrySetterService* GetVideoGeometrySetterService() override;
+  void SetVideoGeometryChangeSubscriberReceiver(
+      mojo::GenericPendingReceiver receiver) override;
+  mojo::GenericPendingReceiver TakeVideoGeometryChangeSubscriberReceiver()
+      override;
 
  private:
   void CreateVideoGeometrySetterService();
 
   std::unique_ptr<media::VideoGeometrySetterService, base::OnTaskRunnerDeleter>
       video_geometry_setter_service_;
+  mojo::GenericPendingReceiver pending_subscriber_receiver_;
 };
 
 }  // namespace cobalt

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -85,6 +85,8 @@ const char kH5vccSettingsKeyMediaSkipFlushOnDecoderTeardown[] =
     "Media.SkipFlushOnDecoderTeardown";
 const char kH5vccSettingsKeyMediaSkipVideoFramesOver60Fps[] =
     "Media.SkipVideoFramesOver60Fps";
+const char kH5vccSettingsKeyMediaUseDirectRenderer[] =
+    "Media.UseDirectRenderer";
 const char kH5vccSettingsKeyMediaUseDualThreadsForVideo[] =
     "Media.UseDualThreadsForVideo";
 
@@ -260,6 +262,10 @@ ExperimentalFeatures ProcessH5vccSettings(
   if (auto* val = GetSettingValue<int64_t>(
           settings, kH5vccSettingsKeyMediaSkipVideoFramesOver60Fps)) {
     parsed.skip_video_frames_over_60_fps = *val != 0;
+  }
+  if (auto* val = GetSettingValue<int64_t>(
+          settings, kH5vccSettingsKeyMediaUseDirectRenderer)) {
+    parsed.use_direct_renderer = *val != 0;
   }
   if (auto* val = GetSettingValue<int64_t>(
           settings, kH5vccSettingsKeyMediaUseDualThreadsForVideo)) {

--- a/content/gpu/gpu_service_factory.cc
+++ b/content/gpu/gpu_service_factory.cc
@@ -22,6 +22,9 @@
 #include "media/base/media_switches.h"
 #include "media/mojo/services/gpu_mojo_media_client.h"  // nogncheck
 #include "media/mojo/services/media_service_factory.h"  // nogncheck
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/base/starboard/direct_renderer_service_factory.h"
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 #endif  // BUILDFLAG(ENABLE_MOJO_MEDIA_IN_GPU_PROCESS)
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/content/public/gpu/content_gpu_client.h
+++ b/content/public/gpu/content_gpu_client.h
@@ -12,6 +12,9 @@
 #include "content/public/common/content_client.h"
 #include "gpu/command_buffer/service/shared_context_state.h"
 #include "mojo/public/cpp/bindings/binder_map.h"
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "mojo/public/cpp/bindings/generic_pending_receiver.h"
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 namespace cobalt::media {
@@ -70,6 +73,8 @@ class CONTENT_EXPORT ContentGpuClient {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   virtual cobalt::media::VideoGeometrySetterService* GetVideoGeometrySetterService();
+  virtual void SetVideoGeometryChangeSubscriberReceiver(mojo::GenericPendingReceiver receiver) {}
+  virtual mojo::GenericPendingReceiver TakeVideoGeometryChangeSubscriberReceiver() { return mojo::GenericPendingReceiver(); }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 

--- a/content/renderer/media/media_factory.cc
+++ b/content/renderer/media/media_factory.cc
@@ -141,6 +141,8 @@
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "media/base/starboard/renderer_factory_traits.h"
 #include "media/mojo/clients/starboard/starboard_renderer_client_factory.h"
+#include "cobalt/media/service/mojom/video_geometry_setter.mojom.h"  // nogncheck
+#include "content/public/gpu/content_gpu_client.h"  // nogncheck
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace {
@@ -609,6 +611,22 @@ MediaFactory::CreateRendererFactorySelector(
   media::RendererFactoryTraits renderer_factory_traits;
   GetContentClient()->renderer()->GetStarboardRendererFactoryTraits(&renderer_factory_traits);
   renderer_factory_traits.max_video_capabilities = max_video_capabilities;
+  
+  renderer_factory_traits.get_subscriber_cb = base::BindRepeating([]() {
+    mojo::PendingRemote<cobalt::media::mojom::VideoGeometryChangeSubscriber> remote;
+    auto receiver = remote.InitWithNewPipeAndPassReceiver();
+    
+    auto* gpu_client = content::GetContentClient()->gpu();
+    if (gpu_client) {
+      gpu_client->SetVideoGeometryChangeSubscriberReceiver(mojo::GenericPendingReceiver(std::move(receiver)));
+    } else {
+      LOG(ERROR) << "MediaFactory: ContentGpuClient is null!";
+    }
+
+    auto remote_ptr = std::make_unique<mojo::PendingRemote<cobalt::media::mojom::VideoGeometryChangeSubscriber>>(std::move(remote));
+    return static_cast<void*>(remote_ptr.release());
+  });
+
   is_base_renderer_factory_set = true;
   factory_selector->AddBaseFactory(RendererType::kStarboard,
     std::make_unique<media::StarboardRendererClientFactory>(media_log,

--- a/media/base/BUILD.gn
+++ b/media/base/BUILD.gn
@@ -483,6 +483,8 @@ source_set("base") {
   if (is_cobalt && use_starboard_media) {
     sources += [
         "starboard/demuxer_memory_limit_starboard.cc",
+        "starboard/direct_renderer_service_factory.cc",
+        "starboard/direct_renderer_service_factory.h",
         "starboard/renderer_factory_traits.h",
         "starboard/starboard_renderer_config.cc",
         "starboard/starboard_renderer_config.h",

--- a/media/base/ipc/media_param_traits_macros.h
+++ b/media/base/ipc/media_param_traits_macros.h
@@ -212,6 +212,7 @@ IPC_STRUCT_TRAITS_BEGIN(media::StarboardRendererConfig::ExperimentalFeatures)
   IPC_STRUCT_TRAITS_MEMBER(video_decoder_initial_preroll_count)
   IPC_STRUCT_TRAITS_MEMBER(video_renderer_min_input_buffers)
   IPC_STRUCT_TRAITS_MEMBER(video_renderer_min_decoded_frames)
+  IPC_STRUCT_TRAITS_MEMBER(use_direct_renderer)
   IPC_STRUCT_TRAITS_MEMBER(use_dual_threads_for_video)
 IPC_STRUCT_TRAITS_END()
 

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -520,6 +520,10 @@ BASE_FEATURE(kCobaltAudioCaptureFastTrack,
 BASE_FEATURE(kCobaltBypassMojoForMedia,
              "CobaltBypassMojoForMedia",
              base::FEATURE_DISABLED_BY_DEFAULT);
+// Enable DirectRenderer in Cobalt single-process mode.
+BASE_FEATURE(kCobaltUsingDirectRenderer,
+             "CobaltUsingDirectRenderer",
+             base::FEATURE_DISABLED_BY_DEFAULT);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #if BUILDFLAG(IS_CHROMEOS)

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -233,6 +233,8 @@ MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingAndroidOverlay);
 #endif  // BUILDFLAG(IS_ANDROID)
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltAudioCaptureFastTrack);
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltBypassMojoForMedia);
+// Enable DirectRenderer in Cobalt single-process mode.
+MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingDirectRenderer);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 #if BUILDFLAG(IS_CHROMEOS)
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCrOSSystemAEC);

--- a/media/base/starboard/direct_renderer_service_factory.cc
+++ b/media/base/starboard/direct_renderer_service_factory.cc
@@ -1,0 +1,40 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/base/starboard/direct_renderer_service_factory.h"
+
+#include "base/logging.h"
+#include "base/no_destructor.h"
+
+namespace media {
+
+namespace {
+
+CreateDirectRendererServiceCB& GetGlobalCallback() {
+  static base::NoDestructor<CreateDirectRendererServiceCB> g_callback;
+  return *g_callback;
+}
+
+}  // namespace
+
+void SetCreateDirectRendererServiceCallback(CreateDirectRendererServiceCB cb) {
+  LOG(INFO) << "SetCreateDirectRendererServiceCallback called";
+  GetGlobalCallback() = std::move(cb);
+}
+
+CreateDirectRendererServiceCB GetCreateDirectRendererServiceCallback() {
+  return GetGlobalCallback();
+}
+
+}  // namespace media

--- a/media/base/starboard/direct_renderer_service_factory.h
+++ b/media/base/starboard/direct_renderer_service_factory.h
@@ -1,0 +1,54 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_BASE_STARBOARD_DIRECT_RENDERER_SERVICE_FACTORY_H_
+#define MEDIA_BASE_STARBOARD_DIRECT_RENDERER_SERVICE_FACTORY_H_
+
+#include <vector>
+
+#include "base/functional/callback.h"
+#include "base/no_destructor.h"
+#include "base/task/sequenced_task_runner.h"
+#include "media/base/media_export.h"
+namespace cobalt {
+namespace media {
+class VideoGeometrySetterService;
+}
+}  // namespace cobalt
+
+namespace media {
+
+class DirectRendererClient;
+class DirectRendererHost;
+class DemuxerStream;
+struct StarboardRendererConfig;
+class MediaLog;
+
+using CreateDirectRendererServiceCB = base::RepeatingCallback<void(
+    base::WeakPtr<DirectRendererClient> client,
+    const scoped_refptr<base::SequencedTaskRunner>& client_task_runner,
+    const std::vector<DemuxerStream*>& streams,
+    const StarboardRendererConfig& config,
+    std::unique_ptr<MediaLog> media_log,
+    void* subscriber_remote,
+    base::OnceCallback<void(DirectRendererHost*)> callback)>;
+
+MEDIA_EXPORT void SetCreateDirectRendererServiceCallback(
+    CreateDirectRendererServiceCB cb);
+MEDIA_EXPORT CreateDirectRendererServiceCB
+GetCreateDirectRendererServiceCallback();
+
+}  // namespace media
+
+#endif  // MEDIA_BASE_STARBOARD_DIRECT_RENDERER_SERVICE_FACTORY_H_

--- a/media/base/starboard/renderer_factory_traits.h
+++ b/media/base/starboard/renderer_factory_traits.h
@@ -27,6 +27,12 @@
 #include "media/starboard/starboard_callbacks.h"
 #include "ui/gfx/geometry/size.h"
 
+namespace cobalt {
+namespace media {
+class VideoGeometrySetterService;
+}
+}  // namespace cobalt
+
 namespace media {
 
 // Customizations for StarboardRendererClientFactory to
@@ -39,8 +45,11 @@ struct MEDIA_EXPORT RendererFactoryTraits {
   base::TimeDelta audio_write_duration_remote = kNoTimestamp;
   std::string max_video_capabilities;
   StarboardRendererConfig::ExperimentalFeatures experimental_features;
+  using GetVideoGeometryChangeSubscriberCB = base::RepeatingCallback<void*()>;
+
   gfx::Size viewport_size;
   GetSbWindowHandleCallback get_sb_window_handle_callback;
+  GetVideoGeometryChangeSubscriberCB get_subscriber_cb;
 };
 
 }  // namespace media

--- a/media/base/starboard/starboard_renderer_config.cc
+++ b/media/base/starboard/starboard_renderer_config.cc
@@ -66,6 +66,8 @@ std::ostream& operator<<(
             << ToString(features.skip_flush_on_decoder_teardown)
             << ", skip_video_frames_over_60_fps="
             << ToString(features.skip_video_frames_over_60_fps)
+            << ", use_direct_renderer="
+            << ToString(features.use_direct_renderer)
             << ", use_dual_threads_for_video="
             << ToString(features.use_dual_threads_for_video)
             << ", max_samples_per_write="

--- a/media/base/starboard/starboard_renderer_config.h
+++ b/media/base/starboard/starboard_renderer_config.h
@@ -42,6 +42,7 @@ struct MEDIA_EXPORT StarboardRendererConfig {
     bool force_decode_to_texture = false;
     bool skip_flush_on_decoder_teardown = false;
     bool skip_video_frames_over_60_fps = false;
+    bool use_direct_renderer = false;
     std::optional<bool> use_dual_threads_for_video;
     std::optional<int> max_samples_per_write;
     std::optional<int> video_decoder_initial_preroll_count;

--- a/media/mojo/clients/BUILD.gn
+++ b/media/mojo/clients/BUILD.gn
@@ -133,6 +133,8 @@ source_set("clients") {
 
   if (is_cobalt && use_starboard_media) {
     sources += [
+      "starboard/direct_renderer.cc",
+      "starboard/direct_renderer.h",
       "starboard/starboard_renderer_client.cc",
       "starboard/starboard_renderer_client.h",
       "starboard/starboard_renderer_client_factory.cc",

--- a/media/mojo/clients/starboard/direct_renderer.cc
+++ b/media/mojo/clients/starboard/direct_renderer.cc
@@ -1,0 +1,274 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/mojo/clients/starboard/direct_renderer.h"
+
+#include "base/functional/bind.h"
+#include "base/synchronization/waitable_event.h"
+#include "base/task/bind_post_task.h"
+#include "base/time/default_tick_clock.h"
+#include "media/base/starboard/direct_renderer_service_factory.h"
+#include "media/mojo/clients/starboard/starboard_renderer_client.h"
+
+namespace media {
+
+DirectRenderer::DirectRenderer(
+    const scoped_refptr<base::SequencedTaskRunner>& task_runner,
+    const scoped_refptr<base::SequencedTaskRunner>& gpu_task_runner,
+    const StarboardRendererConfig& config,
+    MediaLog* media_log,
+    void* subscriber_remote)
+    : task_runner_(task_runner),
+      gpu_task_runner_(gpu_task_runner),
+      config_(config),
+      media_log_(media_log),
+      subscriber_remote_(subscriber_remote),
+      media_time_interpolator_(base::DefaultTickClock::GetInstance()) {
+  DVLOG(1) << __func__;
+}
+
+DirectRenderer::~DirectRenderer() {
+  DVLOG(1) << __func__;
+  if (service_) {
+    gpu_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce([](DirectRendererHost* service) { delete service; },
+                       base::Unretained(service_)));
+  }
+}
+
+void DirectRenderer::ClearDirectClient() {
+  base::AutoLock lock(lock_);
+  direct_client_ = nullptr;
+}
+
+void DirectRenderer::Initialize(MediaResource* media_resource,
+                                media::RendererClient* client,
+                                PipelineStatusCallback init_cb) {
+  DVLOG(1) << __func__;
+  client_ = client;
+  direct_client_ = static_cast<StarboardRendererClient*>(client)->GetWeakPtr();
+
+  auto create_service_cb = GetCreateDirectRendererServiceCallback();
+  LOG(INFO) << "DirectRenderer::Initialize: create_service_cb is_null="
+            << create_service_cb.is_null();
+  if (create_service_cb.is_null()) {
+    DLOG(ERROR) << "CreateServiceCallback is not set!";
+    std::move(init_cb).Run(PIPELINE_ERROR_INITIALIZATION_FAILED);
+    return;
+  }
+
+  std::vector<DemuxerStream*> streams = media_resource->GetAllStreams();
+
+  gpu_task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          create_service_cb, weak_factory_.GetWeakPtr(), task_runner_, streams,
+          config_, media_log_ ? media_log_->Clone() : nullptr,
+          subscriber_remote_,
+          base::BindPostTaskToCurrentDefault(base::BindOnce(
+              &DirectRenderer::OnServiceCreated, weak_factory_.GetWeakPtr(),
+              base::Unretained(media_resource), std::move(init_cb)))));
+}
+
+void DirectRenderer::OnServiceCreated(MediaResource* media_resource,
+                                      PipelineStatusCallback init_cb,
+                                      DirectRendererHost* service) {
+  LOG(INFO) << "DirectRenderer::OnServiceCreated called";
+  service_ = service;
+  if (!service_) {
+    std::move(init_cb).Run(PIPELINE_ERROR_INITIALIZATION_FAILED);
+    return;
+  }
+
+  gpu_task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(&DirectRendererHost::InitializeService,
+                     base::Unretained(service_),
+                     base::Unretained(media_resource),
+                     base::BindPostTaskToCurrentDefault(std::move(init_cb))));
+}
+
+void DirectRenderer::SetCdm(CdmContext* cdm_context,
+                            CdmAttachedCB cdm_attached_cb) {
+  DVLOG(1) << __func__;
+  std::move(cdm_attached_cb).Run(true);
+}
+
+void DirectRenderer::SetLatencyHint(
+    std::optional<base::TimeDelta> latency_hint) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRenderer::Flush(base::OnceClosure flush_cb) {
+  DVLOG(1) << __func__;
+  if (service_) {
+    gpu_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(
+            &DirectRendererHost::Flush, base::Unretained(service_),
+            base::BindPostTaskToCurrentDefault(std::move(flush_cb))));
+  } else {
+    std::move(flush_cb).Run();
+  }
+}
+
+void DirectRenderer::StartPlayingFrom(base::TimeDelta time) {
+  DVLOG(1) << __func__;
+  {
+    base::AutoLock auto_lock(lock_);
+    media_time_interpolator_.SetBounds(time, time, base::TimeTicks::Now());
+  }
+  if (service_) {
+    gpu_task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&DirectRendererHost::StartPlayingFrom,
+                                  base::Unretained(service_), time));
+  }
+}
+
+void DirectRenderer::SetPlaybackRate(double playback_rate) {
+  DVLOG(1) << __func__;
+  {
+    base::AutoLock auto_lock(lock_);
+    media_time_interpolator_.SetPlaybackRate(playback_rate);
+  }
+  if (service_) {
+    gpu_task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&DirectRendererHost::SetPlaybackRate,
+                                  base::Unretained(service_), playback_rate));
+  }
+}
+
+void DirectRenderer::SetVolume(float volume) {
+  DVLOG(1) << __func__;
+  if (service_) {
+    gpu_task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&DirectRendererHost::SetVolume,
+                                  base::Unretained(service_), volume));
+  }
+}
+
+base::TimeDelta DirectRenderer::GetMediaTime() {
+  base::AutoLock auto_lock(lock_);
+  return media_time_interpolator_.GetInterpolatedTime();
+}
+
+RendererType DirectRenderer::GetRendererType() {
+  return RendererType::kStarboard;
+}
+
+void DirectRenderer::OnTimeUpdate(base::TimeDelta time,
+                                  base::TimeDelta max_time,
+                                  base::TimeTicks capture_time) {
+  base::AutoLock auto_lock(lock_);
+  media_time_interpolator_.SetBounds(time, max_time, capture_time);
+}
+
+void DirectRenderer::OnStatisticsUpdate(const PipelineStatistics& stats) {
+  if (client_) {
+    client_->OnStatisticsUpdate(stats);
+  }
+}
+
+void DirectRenderer::OnBufferingStateChange(BufferingState state,
+                                            BufferingStateChangeReason reason) {
+  if (client_) {
+    client_->OnBufferingStateChange(state, reason);
+  }
+}
+
+void DirectRenderer::OnError(PipelineStatus status) {
+  if (client_) {
+    client_->OnError(status);
+  }
+}
+
+void DirectRenderer::OnFallback(PipelineStatus status) {
+  if (client_) {
+    client_->OnFallback(status);
+  }
+}
+
+void DirectRenderer::OnEnded() {
+  if (client_) {
+    client_->OnEnded();
+  }
+}
+
+void DirectRenderer::OnWaiting(WaitingReason reason) {
+  if (client_) {
+    client_->OnWaiting(reason);
+  }
+}
+
+void DirectRenderer::OnAudioConfigChange(const AudioDecoderConfig& config) {
+  if (client_) {
+    client_->OnAudioConfigChange(config);
+  }
+}
+
+void DirectRenderer::OnVideoConfigChange(const VideoDecoderConfig& config) {
+  if (client_) {
+    client_->OnVideoConfigChange(config);
+  }
+}
+
+void DirectRenderer::OnVideoNaturalSizeChange(const gfx::Size& size) {
+  if (client_) {
+    client_->OnVideoNaturalSizeChange(size);
+  }
+}
+
+void DirectRenderer::OnVideoOpacityChange(bool opaque) {
+  if (client_) {
+    client_->OnVideoOpacityChange(opaque);
+  }
+}
+
+void DirectRenderer::OnVideoFrameRateChange(std::optional<int> fps) {
+  if (client_) {
+    client_->OnVideoFrameRateChange(fps);
+  }
+}
+
+void DirectRenderer::PaintVideoHoleFrame(const gfx::Size& size) {
+  base::AutoLock lock(lock_);
+  if (direct_client_) {
+    direct_client_->PaintVideoHoleFrame(size);
+  }
+}
+
+void DirectRenderer::UpdateStarboardRenderingMode(StarboardRenderingMode mode) {
+  base::AutoLock lock(lock_);
+  if (direct_client_) {
+    direct_client_->UpdateStarboardRenderingMode(mode);
+  }
+}
+
+void DirectRenderer::GetSbWindowHandle() {
+  base::AutoLock lock(lock_);
+  if (direct_client_) {
+    direct_client_->GetSbWindowHandle();
+  }
+}
+
+#if BUILDFLAG(IS_ANDROID)
+void DirectRenderer::RequestOverlayInfo(bool restart_for_transitions) {
+  if (direct_client_) {
+    direct_client_->RequestOverlayInfo(restart_for_transitions);
+  }
+}
+#endif
+
+}  // namespace media

--- a/media/mojo/clients/starboard/direct_renderer.h
+++ b/media/mojo/clients/starboard/direct_renderer.h
@@ -1,0 +1,156 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_MOJO_CLIENTS_STARBOARD_DIRECT_RENDERER_H_
+#define MEDIA_MOJO_CLIENTS_STARBOARD_DIRECT_RENDERER_H_
+
+#include <vector>
+
+#include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/memory/weak_ptr.h"
+#include "base/synchronization/lock.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/time/time.h"
+#include "media/base/demuxer_stream.h"
+#include "media/base/media_log.h"
+#include "media/base/pipeline_status.h"
+#include "media/base/renderer.h"
+#include "media/base/renderer_client.h"
+#include "media/base/starboard/starboard_renderer_config.h"
+#include "media/base/starboard/starboard_rendering_mode.h"
+#include "media/base/time_delta_interpolator.h"
+#include "media/renderers/video_overlay_factory.h"
+
+namespace media {
+
+class DirectRendererService;
+class VideoFrame;
+class MediaResource;
+class StarboardRendererClient;
+
+class DirectRendererHost {
+ public:
+  virtual ~DirectRendererHost() = default;
+
+  virtual void InitializeService(
+      MediaResource* media_resource,
+      base::OnceCallback<void(PipelineStatus)> callback) = 0;
+
+  virtual void OnGpuChannelTokenReady(const base::UnguessableToken& token) = 0;
+  virtual void GetCurrentVideoFrame(
+      base::OnceCallback<void(scoped_refptr<VideoFrame>)> cb) = 0;
+  virtual void OnSbWindowHandleReady(uint64_t sb_window_handle) = 0;
+
+  // Forwarded from Renderer
+  virtual void StartPlayingFrom(base::TimeDelta time) = 0;
+  virtual void SetPlaybackRate(double playback_rate) = 0;
+  virtual void SetVolume(float volume) = 0;
+  virtual void Flush(base::OnceClosure flush_cb) = 0;
+};
+
+// Pure C++ interface for receiving callbacks from DirectRendererService.
+class DirectRendererClient : public media::RendererClient {
+ public:
+  virtual ~DirectRendererClient() = default;
+
+  virtual void OnTimeUpdate(base::TimeDelta time,
+                            base::TimeDelta max_time,
+                            base::TimeTicks capture_time) = 0;
+
+  virtual void PaintVideoHoleFrame(const gfx::Size& size) = 0;
+  virtual void UpdateStarboardRenderingMode(StarboardRenderingMode mode) = 0;
+  virtual void GetSbWindowHandle() = 0;
+#if BUILDFLAG(IS_ANDROID)
+  virtual void RequestOverlayInfo(bool restart_for_transitions) = 0;
+#endif
+};
+
+class DirectRenderer : public Renderer, public DirectRendererClient {
+ public:
+  DirectRenderer(
+      const scoped_refptr<base::SequencedTaskRunner>& task_runner,
+      const scoped_refptr<base::SequencedTaskRunner>& gpu_task_runner,
+      const StarboardRendererConfig& config,
+      MediaLog* media_log,
+      void* subscriber_remote);
+
+  DirectRenderer(const DirectRenderer&) = delete;
+  DirectRenderer& operator=(const DirectRenderer&) = delete;
+
+  ~DirectRenderer() override;
+
+  void ClearDirectClient();
+
+  // Renderer implementation.
+  void Initialize(MediaResource* media_resource,
+                  media::RendererClient* client,
+                  PipelineStatusCallback init_cb) override;
+  void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
+  void SetLatencyHint(std::optional<base::TimeDelta> latency_hint) override;
+  void Flush(base::OnceClosure flush_cb) override;
+  void StartPlayingFrom(base::TimeDelta time) override;
+  void SetPlaybackRate(double playback_rate) override;
+  void SetVolume(float volume) override;
+  base::TimeDelta GetMediaTime() override;
+  RendererType GetRendererType() override;
+
+  // DirectRendererClient implementation.
+  void OnTimeUpdate(base::TimeDelta time,
+                    base::TimeDelta max_time,
+                    base::TimeTicks capture_time) override;
+  void OnStatisticsUpdate(const PipelineStatistics& stats) override;
+  void OnBufferingStateChange(BufferingState state,
+                              BufferingStateChangeReason reason) override;
+  void OnError(PipelineStatus status) override;
+  void OnFallback(PipelineStatus status) override;
+  void OnEnded() override;
+  void OnWaiting(WaitingReason reason) override;
+  void OnAudioConfigChange(const AudioDecoderConfig& config) override;
+  void OnVideoConfigChange(const VideoDecoderConfig& config) override;
+  void OnVideoNaturalSizeChange(const gfx::Size& size) override;
+  void OnVideoOpacityChange(bool opaque) override;
+  void OnVideoFrameRateChange(std::optional<int> fps) override;
+
+  void PaintVideoHoleFrame(const gfx::Size& size) override;
+  void UpdateStarboardRenderingMode(StarboardRenderingMode mode) override;
+  void GetSbWindowHandle() override;
+#if BUILDFLAG(IS_ANDROID)
+  void RequestOverlayInfo(bool restart_for_transitions) override;
+#endif
+
+ private:
+  void OnServiceCreated(MediaResource* media_resource,
+                        PipelineStatusCallback init_cb,
+                        DirectRendererHost* service);
+
+  scoped_refptr<base::SequencedTaskRunner> task_runner_;
+  scoped_refptr<base::SequencedTaskRunner> gpu_task_runner_;
+  StarboardRendererConfig config_;
+  raw_ptr<MediaLog> media_log_ = nullptr;
+  void* subscriber_remote_ = nullptr;
+
+  raw_ptr<media::RendererClient> client_ = nullptr;
+  base::WeakPtr<StarboardRendererClient> direct_client_;
+  raw_ptr<DirectRendererHost> service_ = nullptr;
+
+  base::Lock lock_;
+  std::unique_ptr<VideoOverlayFactory> video_overlay_factory_;
+  media::TimeDeltaInterpolator media_time_interpolator_;
+  base::WeakPtrFactory<DirectRenderer> weak_factory_{this};
+};
+
+}  // namespace media
+
+#endif  // MEDIA_MOJO_CLIENTS_STARBOARD_DIRECT_RENDERER_H_

--- a/media/mojo/clients/starboard/starboard_renderer_client.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client.cc
@@ -21,6 +21,7 @@
 #include "media/base/media_resource.h"
 #include "media/base/video_frame.h"
 #include "media/mojo/clients/mojo_renderer.h"
+#include "media/mojo/clients/starboard/direct_renderer.h"
 #include "media/renderers/video_overlay_factory.h"
 #include "media/video/gpu_video_accelerator_factories.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
@@ -34,7 +35,8 @@ namespace media {
 StarboardRendererClient::StarboardRendererClient(
     const scoped_refptr<base::SequencedTaskRunner>& media_task_runner,
     std::unique_ptr<MediaLog> media_log,
-    std::unique_ptr<MojoRenderer> mojo_renderer,
+    std::unique_ptr<media::Renderer> renderer,
+    bool use_direct_renderer,
     std::unique_ptr<VideoOverlayFactory> video_overlay_factory,
     VideoRendererSink* video_renderer_sink,
     mojo::PendingRemote<RendererExtension> pending_renderer_extension,
@@ -46,7 +48,8 @@ StarboardRendererClient::StarboardRendererClient(
     RequestOverlayInfoCB request_overlay_info_cb
 #endif  // BUILDFLAG(IS_ANDROID)
     )
-    : MojoRendererWrapper(std::move(mojo_renderer)),
+    : renderer_(std::move(renderer)),
+      use_direct_renderer_(use_direct_renderer),
       media_task_runner_(media_task_runner),
       media_log_(std::move(media_log)),
       video_overlay_factory_(std::move(video_overlay_factory)),
@@ -77,6 +80,19 @@ StarboardRendererClient::~StarboardRendererClient() {
     overlay_info_requested_ = false;
   }
 #endif  // BUILDFLAG(IS_ANDROID)
+
+  if (use_direct_renderer_ && renderer_) {
+    static_cast<DirectRenderer*>(renderer_.get())->ClearDirectClient();
+  }
+
+  if (renderer_) {
+    media_task_runner_->DeleteSoon(FROM_HERE, std::move(renderer_));
+  }
+}
+
+base::WeakPtr<StarboardRendererClient> StarboardRendererClient::GetWeakPtr() {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  return weak_factory_.GetWeakPtr();
 }
 
 void StarboardRendererClient::Initialize(MediaResource* media_resource,
@@ -87,6 +103,11 @@ void StarboardRendererClient::Initialize(MediaResource* media_resource,
 
   client_ = client;
   init_cb_ = std::move(init_cb);
+
+  if (use_direct_renderer_) {
+    renderer_->Initialize(media_resource, this, std::move(init_cb_));
+    return;
+  }
 
   DCHECK(!AreMojoPipesConnected());
   InitAndBindMojoRenderer(base::BindOnce(
@@ -104,7 +125,38 @@ void StarboardRendererClient::StartPlayingFrom(base::TimeDelta time) {
     base::AutoLock auto_lock(lock_);
     next_video_frame_.reset();
   }
-  MojoRendererWrapper::StartPlayingFrom(time);
+  renderer_->StartPlayingFrom(time);
+}
+
+void StarboardRendererClient::SetCdm(CdmContext* cdm_context,
+                                     CdmAttachedCB cdm_attached_cb) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  renderer_->SetCdm(cdm_context, std::move(cdm_attached_cb));
+}
+
+void StarboardRendererClient::SetLatencyHint(
+    std::optional<base::TimeDelta> latency_hint) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  renderer_->SetLatencyHint(latency_hint);
+}
+
+void StarboardRendererClient::Flush(base::OnceClosure flush_cb) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  renderer_->Flush(std::move(flush_cb));
+}
+
+void StarboardRendererClient::SetPlaybackRate(double playback_rate) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  renderer_->SetPlaybackRate(playback_rate);
+}
+
+void StarboardRendererClient::SetVolume(float volume) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  renderer_->SetVolume(volume);
+}
+
+base::TimeDelta StarboardRendererClient::GetMediaTime() {
+  return renderer_->GetMediaTime();
 }
 
 RendererType StarboardRendererClient::GetRendererType() {
@@ -334,7 +386,7 @@ void StarboardRendererClient::InitializeMojoRenderer(
     PipelineStatusCallback init_cb) {
   DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
   DCHECK(AreMojoPipesConnected());
-  MojoRendererWrapper::Initialize(media_resource, client, std::move(init_cb));
+  renderer_->Initialize(media_resource, client, std::move(init_cb));
 }
 
 void StarboardRendererClient::InitAndConstructMojoRenderer(

--- a/media/mojo/clients/starboard/starboard_renderer_client.h
+++ b/media/mojo/clients/starboard/starboard_renderer_client.h
@@ -21,6 +21,7 @@
 #include "base/memory/weak_ptr.h"
 #include "base/synchronization/lock.h"
 #include "base/task/sequenced_task_runner.h"
+#include "base/timer/timer.h"
 #include "media/base/pipeline_status.h"
 #include "media/base/renderer_client.h"
 #include "media/base/starboard/starboard_rendering_mode.h"
@@ -46,7 +47,7 @@ class VideoOverlayFactory;
 // (Media thread) talks to the StarboardRenderer living in the
 // Chrome_InProcGpuThread, using `mojo_renderer_` and `renderer_extension_`.
 class MEDIA_EXPORT StarboardRendererClient
-    : public MojoRendererWrapper,
+    : public Renderer,
       public RendererClient,
       public mojom::StarboardRendererClientExtension,
       public VideoRendererSink::RenderCallback {
@@ -57,7 +58,8 @@ class MEDIA_EXPORT StarboardRendererClient
   StarboardRendererClient(
       const scoped_refptr<base::SequencedTaskRunner>& media_task_runner,
       std::unique_ptr<MediaLog> media_log,
-      std::unique_ptr<MojoRenderer> mojo_renderer,
+      std::unique_ptr<media::Renderer> renderer,
+      bool use_direct_renderer,
       std::unique_ptr<VideoOverlayFactory> video_overlay_factory,
       VideoRendererSink* video_renderer_sink,
       mojo::PendingRemote<RendererExtension> pending_renderer_extension,
@@ -75,11 +77,19 @@ class MEDIA_EXPORT StarboardRendererClient
 
   ~StarboardRendererClient() override;
 
-  // MojoRendererWrapper overrides.
+  base::WeakPtr<StarboardRendererClient> GetWeakPtr();
+
+  // Renderer implementation.
   void Initialize(MediaResource* media_resource,
                   RendererClient* client,
                   PipelineStatusCallback init_cb) override;
+  void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
+  void SetLatencyHint(std::optional<base::TimeDelta> latency_hint) override;
+  void Flush(base::OnceClosure flush_cb) override;
   void StartPlayingFrom(base::TimeDelta time) override;
+  void SetPlaybackRate(double playback_rate) override;
+  void SetVolume(float volume) override;
+  base::TimeDelta GetMediaTime() override;
   RendererType GetRendererType() override;
 
   // RendererClient implementation.
@@ -140,6 +150,8 @@ class MEDIA_EXPORT StarboardRendererClient
   void StartVideoRendererSink();
   void StopVideoRendererSink();
 
+  std::unique_ptr<media::Renderer> renderer_;
+  bool use_direct_renderer_ = false;
   scoped_refptr<base::SequencedTaskRunner> media_task_runner_;
   std::unique_ptr<MediaLog> media_log_;
   std::unique_ptr<VideoOverlayFactory> video_overlay_factory_;

--- a/media/mojo/clients/starboard/starboard_renderer_client_factory.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_factory.cc
@@ -15,16 +15,21 @@
 #include "media/mojo/clients/starboard/starboard_renderer_client_factory.h"
 
 #include "base/check.h"
+#include "base/command_line.h"
+#include "base/feature_list.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/time/time.h"
 #include "media/base/media_switches.h"
+#include "media/base/starboard/direct_renderer_service_factory.h"
 #include "media/base/starboard/starboard_renderer_config.h"
 #include "media/mojo/clients/mojo_media_log_service.h"
 #include "media/mojo/clients/mojo_renderer.h"
 #include "media/mojo/clients/mojo_renderer_factory.h"
 #include "media/mojo/clients/mojo_renderer_wrapper.h"
+#include "media/mojo/clients/starboard/direct_renderer.h"
 #include "media/mojo/clients/starboard/starboard_renderer_client.h"
 #include "media/mojo/mojom/renderer_extensions.mojom.h"
+#include "media/mojo/services/starboard/direct_renderer_service.h"  // nogncheck
 #include "media/renderers/video_overlay_factory.h"
 #include "media/video/gpu_video_accelerator_factories.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
@@ -53,7 +58,8 @@ StarboardRendererClientFactory::StarboardRendererClientFactory(
       max_video_capabilities_(traits->max_video_capabilities),
       experimental_features_(traits->experimental_features),
       viewport_size_(traits->viewport_size),
-      get_sb_window_handle_callback_(traits->get_sb_window_handle_callback) {}
+      get_sb_window_handle_callback_(traits->get_sb_window_handle_callback),
+      get_subscriber_cb_(traits->get_subscriber_cb) {}
 
 StarboardRendererClientFactory::~StarboardRendererClientFactory() = default;
 
@@ -103,21 +109,39 @@ std::unique_ptr<Renderer> StarboardRendererClientFactory::CreateRenderer(
   DCHECK(get_gpu_factories_cb_);
   GpuVideoAcceleratorFactories* gpu_factories = get_gpu_factories_cb_.Run();
 
-  // Initialize StarboardRendererWrapper via StarboardRendererConfig.
+  std::unique_ptr<media::Renderer> renderer;
+  bool use_direct_renderer = false;
+
   StarboardRendererConfig config(
       overlay_factory->overlay_plane_id(), audio_write_duration_local_,
       audio_write_duration_remote_, max_video_capabilities_,
       experimental_features_, viewport_size_);
-  std::unique_ptr<media::MojoRenderer> mojo_renderer =
-      mojo_renderer_factory_->CreateStarboardRenderer(
-          std::move(media_log_pending_remote), config,
-          std::move(renderer_extension_receiver),
-          std::move(client_extension_remote), media_task_runner,
-          video_renderer_sink);
+
+  if ((base::FeatureList::IsEnabled(kCobaltUsingDirectRenderer) ||
+       experimental_features_.use_direct_renderer) &&
+      base::CommandLine::ForCurrentProcess()->HasSwitch("single-process")) {
+    DCHECK(gpu_factories);
+
+    SetCreateDirectRendererServiceCallback(
+        base::BindRepeating(&DirectRendererService::Create));
+
+    scoped_refptr<base::SequencedTaskRunner> gpu_task_runner =
+        gpu_factories->GetTaskRunner();
+    void* remote_ptr = get_subscriber_cb_ ? get_subscriber_cb_.Run() : nullptr;
+    renderer = std::make_unique<media::DirectRenderer>(
+        media_task_runner, gpu_task_runner, config, media_log_, remote_ptr);
+    use_direct_renderer = true;
+  } else {
+    renderer = mojo_renderer_factory_->CreateStarboardRenderer(
+        std::move(media_log_pending_remote), config,
+        std::move(renderer_extension_receiver),
+        std::move(client_extension_remote), media_task_runner,
+        video_renderer_sink);
+  }
 
   return std::make_unique<media::StarboardRendererClient>(
-      media_task_runner, media_log_->Clone(), std::move(mojo_renderer),
-      std::move(overlay_factory), video_renderer_sink,
+      media_task_runner, media_log_->Clone(), std::move(renderer),
+      use_direct_renderer, std::move(overlay_factory), video_renderer_sink,
       std::move(renderer_extension_remote),
       std::move(client_extension_receiver), get_sb_window_handle_callback_,
       gpu_factories

--- a/media/mojo/clients/starboard/starboard_renderer_client_factory.h
+++ b/media/mojo/clients/starboard/starboard_renderer_client_factory.h
@@ -76,6 +76,7 @@ class MEDIA_EXPORT StarboardRendererClientFactory final
   const StarboardRendererConfig::ExperimentalFeatures experimental_features_;
   const gfx::Size viewport_size_;
   const GetSbWindowHandleCallback get_sb_window_handle_callback_;
+  RendererFactoryTraits::GetVideoGeometryChangeSubscriberCB get_subscriber_cb_;
 };
 
 }  // namespace media

--- a/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
@@ -159,7 +159,7 @@ class StarboardRendererClientTest : public ::testing::Test {
     auto overlay_factory = std::make_unique<VideoOverlayFactory>();
     starboard_renderer_client_ = std::make_unique<StarboardRendererClient>(
         task_environment_.GetMainThreadTaskRunner(), media_log_.Clone(),
-        std::move(mojo_renderer), std::move(overlay_factory),
+        std::move(mojo_renderer), /*use_direct_renderer=*/false, std::move(overlay_factory),
         &mock_video_renderer_sink_,
         std::move(starboard_renderer_extensions_remote),
         std::move(client_extension_receiver),

--- a/media/mojo/services/BUILD.gn
+++ b/media/mojo/services/BUILD.gn
@@ -117,6 +117,8 @@ component("services") {
 
   if (is_cobalt && use_starboard_media) {
     sources += [
+      "starboard/direct_renderer_service.cc",
+      "starboard/direct_renderer_service.h",
       "starboard/gpu_mojo_media_client_starboard.cc",
       "starboard/starboard_renderer_wrapper.cc",
       "starboard/starboard_renderer_wrapper.h",
@@ -125,6 +127,7 @@ component("services") {
       "//starboard/common",
       "//starboard:starboard_headers_only",
       "//cobalt/media/service",
+      "//media/mojo/clients",
       "//cobalt/media/service/mojom",
     ]
   } else if (is_android) {

--- a/media/mojo/services/interface_factory_impl.cc
+++ b/media/mojo/services/interface_factory_impl.cc
@@ -14,6 +14,10 @@
 #include "media/mojo/mojom/renderer_extensions.mojom.h"
 #include "media/mojo/services/mojo_decryptor_service.h"
 #include "media/mojo/services/mojo_media_client.h"
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/base/starboard/direct_renderer_service_factory.h"
+#include "media/mojo/services/starboard/direct_renderer_service.h"
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #if BUILDFLAG(ENABLE_MOJO_AUDIO_DECODER)
 #include "base/sequence_checker.h"
@@ -140,6 +144,11 @@ InterfaceFactoryImpl::InterfaceFactoryImpl(
   DCHECK(mojo_media_client_);
 
   SetReceiverDisconnectHandler();
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  SetCreateDirectRendererServiceCallback(
+      base::BindRepeating(&DirectRendererService::Create));
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 InterfaceFactoryImpl::~InterfaceFactoryImpl() {
@@ -297,6 +306,10 @@ void InterfaceFactoryImpl::CreateStarboardRenderer(
     mojo::PendingRemote<mojom::StarboardRendererClientExtension>
           client_extension_remote) {
   DVLOG(2) << __func__;
+  
+  SetCreateDirectRendererServiceCallback(
+      base::BindRepeating(&DirectRendererService::Create));
+      
   auto renderer = mojo_media_client_->CreateStarboardRenderer(
       frame_interfaces_.get(),
       base::SingleThreadTaskRunner::GetCurrentDefault(),

--- a/media/mojo/services/starboard/direct_renderer_service.cc
+++ b/media/mojo/services/starboard/direct_renderer_service.cc
@@ -1,0 +1,360 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/mojo/services/starboard/direct_renderer_service.h"
+
+#include "base/logging.h"
+#include "cobalt/media/service/video_geometry_setter_service.h"
+#include "media/base/video_frame.h"
+#include "media/mojo/clients/starboard/direct_renderer.h"
+#include "ui/gfx/geometry/rect_conversions.h"
+
+namespace media {
+
+namespace {
+cobalt::media::VideoGeometrySetterService* g_video_geometry_setter_service =
+    nullptr;
+}
+
+// static
+void DirectRendererService::SetVideoGeometrySetterService(
+    cobalt::media::VideoGeometrySetterService* service) {
+  g_video_geometry_setter_service = service;
+}
+
+// static
+cobalt::media::VideoGeometrySetterService*
+DirectRendererService::GetVideoGeometrySetterService() {
+  return g_video_geometry_setter_service;
+}
+
+// static
+void DirectRendererService::Create(
+    base::WeakPtr<DirectRendererClient> client,
+    const scoped_refptr<base::SequencedTaskRunner>& client_task_runner,
+    const std::vector<DemuxerStream*>& streams,
+    const StarboardRendererConfig& config,
+    std::unique_ptr<MediaLog> media_log,
+    void* subscriber_remote,
+    base::OnceCallback<void(DirectRendererHost*)> callback) {
+  auto task_runner = base::SequencedTaskRunner::GetCurrentDefault();
+
+  DCHECK(media_log);
+
+  auto starboard_renderer = std::make_unique<StarboardRenderer>(
+      task_runner, std::move(media_log), config.overlay_plane_id,
+      config.audio_write_duration_local, config.audio_write_duration_remote,
+      config.max_video_capabilities, config.experimental_features,
+      config.viewport_size
+#if BUILDFLAG(IS_ANDROID)
+      ,
+      base::NullCallback()
+#endif
+  );
+
+  mojo::PendingRemote<::cobalt::media::mojom::VideoGeometryChangeSubscriber>
+      subscriber;
+  if (subscriber_remote) {
+    auto* pending_remote_ptr = static_cast<mojo::PendingRemote<
+        ::cobalt::media::mojom::VideoGeometryChangeSubscriber>*>(
+        subscriber_remote);
+    subscriber = std::move(*pending_remote_ptr);
+    delete pending_remote_ptr;
+  }
+
+  auto service = std::make_unique<DirectRendererService>(
+      std::move(starboard_renderer), client, client_task_runner, task_runner,
+      config.overlay_plane_id, std::move(subscriber));
+
+  std::move(callback).Run(static_cast<DirectRendererHost*>(service.release()));
+}
+
+DirectRendererService::DirectRendererService(
+    std::unique_ptr<StarboardRenderer> renderer,
+    base::WeakPtr<DirectRendererClient> client,
+    const scoped_refptr<base::SequencedTaskRunner>& client_task_runner,
+    const scoped_refptr<base::SequencedTaskRunner>& task_runner,
+    const base::UnguessableToken& overlay_plane_id,
+    mojo::PendingRemote<::cobalt::media::mojom::VideoGeometryChangeSubscriber>
+        subscriber_remote)
+    : renderer_(std::move(renderer)),
+      client_(std::move(client)),
+      client_task_runner_(client_task_runner),
+      task_runner_(task_runner) {
+  DVLOG(1) << __func__;
+
+  if (subscriber_remote.is_valid()) {
+    video_geometry_change_subscriber_remote_.Bind(std::move(subscriber_remote));
+    mojo::PendingRemote<::cobalt::media::mojom::VideoGeometryChangeClient>
+        client_remote;
+    video_geometry_change_receiver_.Bind(
+        client_remote.InitWithNewPipeAndPassReceiver());
+
+    video_geometry_change_subscriber_remote_->SubscribeToVideoGeometryChange(
+        overlay_plane_id, std::move(client_remote), base::BindOnce([]() {
+          LOG(INFO) << "Subscribed to video geometry change via Mojo";
+        }));
+  }
+}
+
+DirectRendererService::~DirectRendererService() {
+  LOG(INFO) << "DirectRendererService destroyed";
+}
+
+void DirectRendererService::Initialize(MediaResource* media_resource,
+                                       RendererClient* client,
+                                       PipelineStatusCallback init_cb) {
+  LOG(INFO) << "DirectRendererService::Initialize called";
+
+  renderer_->SetStarboardRendererCallbacks(
+      base::BindRepeating(
+          &DirectRendererService::OnPaintVideoHoleFrameByStarboard,
+          weak_factory_.GetWeakPtr()),
+      base::BindRepeating(
+          &DirectRendererService::OnUpdateStarboardRenderingModeByStarboard,
+          weak_factory_.GetWeakPtr()),
+#if BUILDFLAG(IS_STARBOARD)
+      base::BindRepeating(&DirectRendererService::OnGetSbWindowHandle,
+                          weak_factory_.GetWeakPtr())
+#else
+      base::NullCallback()
+#endif
+#if BUILDFLAG(IS_ANDROID)
+          ,
+      base::BindRepeating(
+          &DirectRendererService::OnRequestOverlayInfoByStarboard,
+          weak_factory_.GetWeakPtr())
+#endif
+  );
+
+  renderer_->Initialize(media_resource,
+                        static_cast<media::RendererClient*>(this),
+                        std::move(init_cb));
+}
+
+void DirectRendererService::InitializeService(
+    MediaResource* media_resource,
+    base::OnceCallback<void(PipelineStatus)> callback) {
+  LOG(INFO) << "DirectRendererService::InitializeService called";
+  Initialize(media_resource, nullptr, std::move(callback));
+}
+
+void DirectRendererService::SetCdm(CdmContext* cdm_context,
+                                   CdmAttachedCB cdm_attached_cb) {
+  DVLOG(1) << __func__;
+  renderer_->SetCdm(cdm_context, std::move(cdm_attached_cb));
+}
+
+void DirectRendererService::SetLatencyHint(
+    std::optional<base::TimeDelta> latency_hint) {
+  DVLOG(1) << __func__;
+  renderer_->SetLatencyHint(latency_hint);
+}
+
+void DirectRendererService::Flush(base::OnceClosure flush_cb) {
+  LOG(INFO) << "DirectRendererService::Flush called";
+  CancelPeriodicMediaTimeUpdates();
+  renderer_->Flush(std::move(flush_cb));
+}
+
+void DirectRendererService::StartPlayingFrom(base::TimeDelta time) {
+  LOG(INFO) << "DirectRendererService::StartPlayingFrom called with " << time;
+  renderer_->StartPlayingFrom(time);
+  SchedulePeriodicMediaTimeUpdates();
+}
+
+void DirectRendererService::SetPlaybackRate(double playback_rate) {
+  LOG(INFO) << "DirectRendererService::SetPlaybackRate called with "
+            << playback_rate;
+  playback_rate_ = playback_rate;
+  renderer_->SetPlaybackRate(playback_rate);
+}
+
+void DirectRendererService::SetVolume(float volume) {
+  LOG(INFO) << "DirectRendererService::SetVolume called with " << volume;
+  renderer_->SetVolume(volume);
+}
+
+base::TimeDelta DirectRendererService::GetMediaTime() {
+  return renderer_->GetMediaTime();
+}
+
+RendererType DirectRendererService::GetRendererType() {
+  return renderer_->GetRendererType();
+}
+
+void DirectRendererService::OnGpuChannelTokenReady(
+    const base::UnguessableToken& token) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRendererService::GetCurrentVideoFrame(
+    base::OnceCallback<void(scoped_refptr<VideoFrame>)> cb) {
+  DVLOG(1) << __func__;
+  std::move(cb).Run(nullptr);
+}
+
+void DirectRendererService::OnSbWindowHandleReady(uint64_t sb_window_handle) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRendererService::OnPaintVideoHoleFrameByStarboard(
+    const gfx::Size& size) {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&DirectRendererClient::PaintVideoHoleFrame,
+                                  client_, size));
+  }
+}
+
+void DirectRendererService::OnUpdateStarboardRenderingModeByStarboard(
+    const StarboardRenderingMode mode) {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&DirectRendererClient::UpdateStarboardRenderingMode,
+                       client_, mode));
+  }
+}
+
+void DirectRendererService::OnGetSbWindowHandle() {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&DirectRendererClient::GetSbWindowHandle, client_));
+  }
+}
+
+#if BUILDFLAG(IS_ANDROID)
+void DirectRendererService::OnRequestOverlayInfoByStarboard(
+    bool restart_for_transitions) {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&DirectRendererClient::RequestOverlayInfo,
+                                  client_, restart_for_transitions));
+  }
+}
+#endif
+
+// RendererClient implementation.
+void DirectRendererService::OnError(PipelineStatus status) {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&media::RendererClient::OnError, client_, status));
+  }
+}
+
+void DirectRendererService::OnFallback(PipelineStatus status) {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&media::RendererClient::OnFallback, client_, status));
+  }
+}
+
+void DirectRendererService::OnEnded() {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&media::RendererClient::OnEnded, client_));
+  }
+}
+
+void DirectRendererService::OnStatisticsUpdate(
+    const PipelineStatistics& stats) {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE, base::BindOnce(&media::RendererClient::OnStatisticsUpdate,
+                                  client_, stats));
+  }
+}
+
+void DirectRendererService::OnBufferingStateChange(
+    BufferingState state,
+    BufferingStateChangeReason reason) {
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&media::RendererClient::OnBufferingStateChange, client_,
+                       state, reason));
+  }
+}
+
+void DirectRendererService::OnWaiting(WaitingReason reason) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRendererService::OnAudioConfigChange(
+    const AudioDecoderConfig& config) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRendererService::OnVideoConfigChange(
+    const VideoDecoderConfig& config) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRendererService::OnVideoNaturalSizeChange(const gfx::Size& size) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRendererService::OnVideoOpacityChange(bool opaque) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRendererService::OnVideoFrameRateChange(std::optional<int> fps) {
+  DVLOG(1) << __func__;
+}
+
+void DirectRendererService::SchedulePeriodicMediaTimeUpdates() {
+  UpdateMediaTime(/*force=*/true);
+  time_update_timer_.Start(
+      FROM_HERE, base::Milliseconds(250),
+      base::BindRepeating(&DirectRendererService::UpdateMediaTime,
+                          weak_factory_.GetWeakPtr(), /*force=*/false));
+}
+
+void DirectRendererService::CancelPeriodicMediaTimeUpdates() {
+  time_update_timer_.Stop();
+  UpdateMediaTime(/*force=*/false);
+}
+
+void DirectRendererService::UpdateMediaTime(bool force) {
+  const base::TimeDelta media_time = renderer_->GetMediaTime();
+  if (!force && media_time == last_media_time_) {
+    return;
+  }
+
+  base::TimeDelta max_time = media_time;
+  if (time_update_timer_.IsRunning() && (playback_rate_ > 0)) {
+    max_time += base::Milliseconds(500);
+  }
+
+  if (client_ && client_task_runner_) {
+    client_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&DirectRendererClient::OnTimeUpdate, client_, media_time,
+                       max_time, base::TimeTicks::Now()));
+  }
+  last_media_time_ = media_time;
+}
+
+void DirectRendererService::OnVideoGeometryChange(
+    const gfx::RectF& rect_f,
+    gfx::OverlayTransform transform) {
+  gfx::Rect new_bounds = gfx::ToEnclosingRect(rect_f);
+  renderer_->OnVideoGeometryChange(new_bounds);
+}
+
+}  // namespace media

--- a/media/mojo/services/starboard/direct_renderer_service.h
+++ b/media/mojo/services/starboard/direct_renderer_service.h
@@ -1,0 +1,152 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_MOJO_SERVICES_STARBOARD_DIRECT_RENDERER_SERVICE_H_
+#define MEDIA_MOJO_SERVICES_STARBOARD_DIRECT_RENDERER_SERVICE_H_
+
+#include <memory>
+#include <vector>
+
+#include "base/memory/scoped_refptr.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/timer/timer.h"
+#include "cobalt/media/service/mojom/video_geometry_setter.mojom.h"
+#include "media/base/renderer.h"
+#include "media/base/renderer_client.h"
+#include "mojo/public/cpp/bindings/receiver.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace cobalt {
+namespace media {
+class VideoGeometrySetterService;
+}
+}  // namespace cobalt
+#include "media/base/starboard/starboard_renderer_config.h"
+#include "media/mojo/clients/starboard/direct_renderer.h"
+#include "media/starboard/starboard_renderer.h"
+
+namespace media {
+
+class DirectRendererClient;
+class VideoFrame;
+
+class DirectRendererService
+    : public ::media::Renderer,
+      public ::media::DirectRendererHost,
+      public ::media::RendererClient,
+      public ::cobalt::media::mojom::VideoGeometryChangeClient {
+ public:
+  static void Create(
+      base::WeakPtr<DirectRendererClient> client,
+      const scoped_refptr<base::SequencedTaskRunner>& client_task_runner,
+      const std::vector<DemuxerStream*>& streams,
+      const StarboardRendererConfig& config,
+      std::unique_ptr<MediaLog> media_log,
+      void* subscriber_remote,
+      base::OnceCallback<void(DirectRendererHost*)> callback);
+
+  static void SetVideoGeometrySetterService(
+      ::cobalt::media::VideoGeometrySetterService* service);
+  static ::cobalt::media::VideoGeometrySetterService*
+  GetVideoGeometrySetterService();
+
+  DirectRendererService(
+      std::unique_ptr<StarboardRenderer> renderer,
+      base::WeakPtr<DirectRendererClient> client,
+      const scoped_refptr<base::SequencedTaskRunner>& client_task_runner,
+      const scoped_refptr<base::SequencedTaskRunner>& task_runner,
+      const base::UnguessableToken& overlay_plane_id,
+      mojo::PendingRemote<::cobalt::media::mojom::VideoGeometryChangeSubscriber>
+          subscriber_remote);
+
+  DirectRendererService(const DirectRendererService&) = delete;
+  DirectRendererService& operator=(const DirectRendererService&) = delete;
+
+  void SetCallbacks();
+
+  ~DirectRendererService() override;
+
+  // Renderer implementation.
+  void Initialize(MediaResource* media_resource,
+                  RendererClient* client,
+                  PipelineStatusCallback init_cb) override;
+  void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
+  void SetLatencyHint(std::optional<base::TimeDelta> latency_hint) override;
+  void Flush(base::OnceClosure flush_cb) override;
+  void StartPlayingFrom(base::TimeDelta time) override;
+  void SetPlaybackRate(double playback_rate) override;
+  void SetVolume(float volume) override;
+  base::TimeDelta GetMediaTime() override;
+  RendererType GetRendererType() override;
+
+  // DirectRendererHost implementation.
+  void InitializeService(
+      MediaResource* media_resource,
+      base::OnceCallback<void(PipelineStatus)> callback) override;
+  void OnGpuChannelTokenReady(const base::UnguessableToken& token) override;
+  void GetCurrentVideoFrame(
+      base::OnceCallback<void(scoped_refptr<VideoFrame>)> cb) override;
+  void OnSbWindowHandleReady(uint64_t sb_window_handle) override;
+
+  // cobalt::media::mojom::VideoGeometryChangeClient implementation.
+  void OnVideoGeometryChange(const gfx::RectF& rect_f,
+                             gfx::OverlayTransform transform) override;
+
+  // RendererClient implementation (to receive from StarboardRenderer).
+  void OnError(PipelineStatus status) override;
+  void OnFallback(PipelineStatus status) override;
+  void OnEnded() override;
+  void OnStatisticsUpdate(const PipelineStatistics& stats) override;
+  void OnBufferingStateChange(BufferingState state,
+                              BufferingStateChangeReason reason) override;
+  void OnWaiting(WaitingReason reason) override;
+  void OnAudioConfigChange(const AudioDecoderConfig& config) override;
+  void OnVideoConfigChange(const VideoDecoderConfig& config) override;
+  void OnVideoNaturalSizeChange(const gfx::Size& size) override;
+  void OnVideoOpacityChange(bool opaque) override;
+  void OnVideoFrameRateChange(std::optional<int> fps) override;
+
+ private:
+  void OnPaintVideoHoleFrameByStarboard(const gfx::Size& size);
+  void OnUpdateStarboardRenderingModeByStarboard(
+      const StarboardRenderingMode mode);
+  void OnGetSbWindowHandle();
+#if BUILDFLAG(IS_ANDROID)
+  void OnRequestOverlayInfoByStarboard(bool restart_for_transitions);
+#endif
+
+  void SchedulePeriodicMediaTimeUpdates();
+  void CancelPeriodicMediaTimeUpdates();
+  void UpdateMediaTime(bool force);
+
+  std::unique_ptr<StarboardRenderer> renderer_;
+  base::WeakPtr<DirectRendererClient> client_;
+  scoped_refptr<base::SequencedTaskRunner> client_task_runner_;
+  scoped_refptr<base::SequencedTaskRunner> task_runner_;
+
+  base::RepeatingTimer time_update_timer_;
+  base::TimeDelta last_media_time_;
+  double playback_rate_ = 0;
+
+  mojo::Receiver<::cobalt::media::mojom::VideoGeometryChangeClient>
+      video_geometry_change_receiver_{this};
+  mojo::Remote<::cobalt::media::mojom::VideoGeometryChangeSubscriber>
+      video_geometry_change_subscriber_remote_;
+
+  base::WeakPtrFactory<DirectRendererService> weak_factory_{this};
+};
+
+}  // namespace media
+
+#endif  // MEDIA_MOJO_SERVICES_STARBOARD_DIRECT_RENDERER_SERVICE_H_

--- a/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
+++ b/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
@@ -20,6 +20,7 @@
 #include "media/base/media_log.h"
 #include "media/base/video_decoder.h"
 #include "media/mojo/services/gpu_mojo_media_client.h"
+#include "media/mojo/services/starboard/direct_renderer_service.h"
 #include "media/mojo/services/starboard/starboard_renderer_wrapper.h"
 #include "media/starboard/starboard_cdm_factory.h"
 


### PR DESCRIPTION
Introduce a Direct Renderer path to optimize media playback in
single-process mode. This allows the Starboard renderer client to
communicate directly with the renderer service via a C++ interface,
bypassing Mojo IPC overhead.

The feature is controlled by the CobaltUsingDirectRenderer feature
flag and the Media.UseDirectRenderer H5vcc setting, and requires the
single-process command-line switch.

Issue: 513254071