### PR TITLE
tvOS: Fix build after #10134 and #10429

### DIFF
--- a/cobalt/testing/browser_tests/BUILD.gn
+++ b/cobalt/testing/browser_tests/BUILD.gn
@@ -232,7 +232,6 @@ test("cobalt_browsertests") {
     #"media_session_browsertest.cc",
     #"media_source_browsertest.cc",
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_browsertest.cc",
-    "granular_memory_browsertest.cc",
     "navigation_browsertest.cc",
 
     #"session_history_browsertest.cc",
@@ -248,6 +247,11 @@ test("cobalt_browsertests") {
 
   if (is_starboard) {
     sources += [ "cobalt_browser_tests_main.cc" ]
+  }
+
+  if (!is_ios) {
+    # This currently tests Linux-specific information and operations.
+    sources += [ "granular_memory_browsertest.cc" ]
   }
 
   defines = [ "HAS_OUT_OF_PROC_TEST_RUNNER" ]

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_mac.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_mac.cc
@@ -244,8 +244,11 @@ bool OSMetrics::FillOSMemoryDump(
     mojom::RawOSMemDump* dump,
     base::WeakPtr<DetailedMetricsDelegate> delegate) {
   // This is implemented in os_metrics_linux.cc using Linux-specific concepts
-  // and operations. It is unclear if/what should be measured on tvOS.
-  return false;
+  // and operations.
+  //
+  // On tvOS, just fall back to the original, non-Cobalt function that provides
+  // at least some information.
+  return FillOSMemoryDump(handle, flags, dump);
 }
 #endif
 

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_mac.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_mac.cc
@@ -236,6 +236,19 @@ bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
   return FillOSMemoryDump(current_handle, flags, nullptr, dump);
 }
 
+#if BUILDFLAG(IS_COBALT)
+// static
+bool OSMetrics::FillOSMemoryDump(
+    base::ProcessHandle handle,
+    const MemDumpFlagSet& flags,
+    mojom::RawOSMemDump* dump,
+    base::WeakPtr<DetailedMetricsDelegate> delegate) {
+  // This is implemented in os_metrics_linux.cc using Linux-specific concepts
+  // and operations. It is unclear if/what should be measured on tvOS.
+  return false;
+}
+#endif
+
 // static
 bool OSMetrics::FillOSMemoryDump(base::ProcessHandle handle,
                                  const MemDumpFlagSet& flags,


### PR DESCRIPTION
This change includes fixes for two different issues:

1. Failure to link the main `cobalt` target:

```
ld64.lld: error: undefined symbol: memory_instrumentation::OSMetrics::FillOSMemoryDump(int, base::EnumSet<memory_instrumentation::mojom::MemDumpFlags, (memory_instrumentation::mojom::MemDumpFlags)0, (memory_instrumentation::mojom::MemDumpFlags)3> const&, memory_instrumentation::mojom::RawOSMemDump*, base::WeakPtr<memory_instrumentation::DetailedMetricsDelegate>)
>>> referenced by ./../../services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.cc
>>>               obj/services/resource_coordinator/public/cpp/memory_instrumentation/libmemory_instrumentation.a(client_process_impl.o):(symbol memory_instrumentation::ClientProcessImpl::PerformOSMemoryDump(memory_instrumentation::ClientProcessImpl::OSMemoryDumpArgs)+0x174)
```

Add a stub implementation that just falls back to the original, 3-argument function. As explained in the comment, the os_metrics_linux.cc and accompanying classes like DetailedMetricsDelegate depend on Linux-specific concepts and operations that do not translate to tvOS. Calling the existing function provides at least some information to callers.

2. Failure to build the `cobalt_browsertests` target:

```
2026-05-21T08:51:21.2116140Z ../../cobalt/testing/browser_tests/granular_memory_browsertest.cc:100:40: error: no member named 'SetProcSmapsForTesting' in 'memory_instrumentation::OSMetrics'
2026-05-21T08:51:21.2128790Z   100 |     memory_instrumentation::OSMetrics::SetProcSmapsForTesting(
2026-05-21T08:51:21.2130910Z       |                                        ^~~~~~~~~~~~~~~~~~~~~~
2026-05-21T08:51:21.2147470Z ../../cobalt/testing/browser_tests/granular_memory_browsertest.cc:102:40: error: no member named 'SetSmapsRollupForTesting' in 'memory_instrumentation::OSMetrics'
2026-05-21T08:51:21.2150310Z   102 |     memory_instrumentation::OSMetrics::SetSmapsRollupForTesting(
2026-05-21T08:51:21.2152000Z       |                                        ^~~~~~~~~~~~~~~~~~~~~~~~
2026-05-21T08:51:21.2154190Z ../../cobalt/testing/browser_tests/granular_memory_browsertest.cc:107:40: error: no member named 'SetProcSmapsForTesting' in 'memory_instrumentation::OSMetrics'
2026-05-21T08:51:21.2157230Z   107 |     memory_instrumentation::OSMetrics::SetProcSmapsForTesting(nullptr);
2026-05-21T08:51:21.2158740Z       |                                        ^~~~~~~~~~~~~~~~~~~~~~
2026-05-21T08:51:21.2162640Z ../../cobalt/testing/browser_tests/granular_memory_browsertest.cc:108:40: error: no member named 'SetSmapsRollupForTesting' in 'memory_instrumentation::OSMetrics'
2026-05-21T08:51:21.2165580Z   108 |     memory_instrumentation::OSMetrics::SetSmapsRollupForTesting(nullptr);
```

Skip `granular_memory_browsertest.cc` on tvOS builds since it tests Linux-specific behavior and information.

Bug: 494004530