### PR TITLE
media: Increase VideoFrameTracker capacity to prevent overflow

### DIFF
--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -106,7 +106,13 @@ const int kNonInitialPrerollFrameCount = 1;
 // rendered, the rest of the playback should play without frame drops. So,
 // tunnel mode prerolling only needs 1 frame.
 const int kTunnelModePrerollFrameCount = 1;
-const int kMaxPendingInputsSize = 128;
+constexpr int kMaxPendingInputsSize = 128;
+// The maximum capacity of the VideoFrameTracker. With batch-writing enabled
+// (max_samples_per_write = 12), we can receive a rapid burst of inputs before
+// rendering begins. A capacity of 512 frames (kMaxPendingInputsSize * 4)
+// provides a safe buffer (approx. 8.5 seconds at 60fps) to ensure early frames
+// are not evicted from the tracker.
+constexpr int kVideoFrameTrackerCapacity = kMaxPendingInputsSize * 4;
 
 const int kFpsGuesstimateRequiredInputBufferCount = 3;
 
@@ -360,7 +366,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
 
   if (is_video_frame_tracker_enabled_) {
     video_frame_tracker_ =
-        std::make_unique<VideoFrameTracker>(kMaxPendingInputsSize * 2);
+        std::make_unique<VideoFrameTracker>(kVideoFrameTrackerCapacity);
   }
 
   if (require_software_codec_) {

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -23,6 +23,7 @@
 #include <vector>
 
 #include "starboard/common/log.h"
+#include "starboard/common/string.h"
 
 namespace starboard {
 namespace {
@@ -87,6 +88,9 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
       static_cast<size_t>(max_pending_frames_size_)) {
     // OnFrameRendered() is only available after API level 23.  Cap the size
     // of |frames_to_be_rendered_| in case OnFrameRendered() is not available.
+    SB_LOG(WARNING)
+        << "Evicting frame from tracker due to queue overflow: PTS(msec)="
+        << FormatWithDigitSeparators(frames_to_be_rendered_.front() / 1'000);
     frames_to_be_rendered_.pop_front();
   }
 


### PR DESCRIPTION
With #10414, video samples are written in batches of 12, which can cause a rapid burst of inputs during startup/preroll before rendering begins. This burst easily exceeded the previous 256-frame capacity of the `VideoFrameTracker` queue, leading to silent eviction of early frames and subsequent "Unexpected rendered frame" warnings.

This PR resolves the problem by increasing capacity

Issue: 515102461