### PR TITLE
cobalt: Remove "cr_" prefix from Cobalt Java log tags

### DIFF
--- a/build/config/android/rules.gni
+++ b/build/config/android/rules.gni
@@ -1991,6 +1991,10 @@ if (!is_robolectric && enable_java_templates) {
         if (is_cronet_for_aosp_build) {
           defines += [ "_CRONET_FOR_AOSP_BUILD" ]
         }
+      } else if (is_cobalt) {
+        # We remove "cr_" prefix not to break a rapid smoke test.
+        # TODO: b/515406853  - Remove this once cl/918641330 is deployed to prod test.
+        defines += [ "_LOGTAG_PREFIX=" ]
       } else {
         defines += [ "_LOGTAG_PREFIX=cr_" ]
       }

--- a/build/config/android/rules.gni
+++ b/build/config/android/rules.gni
@@ -1993,7 +1993,7 @@ if (!is_robolectric && enable_java_templates) {
         }
       } else if (is_cobalt) {
         # We remove "cr_" prefix not to break a rapid smoke test.
-        # TODO: b/515406853  - Remove this once cl/918641330 is deployed to prod test.
+        # TODO: b/515406853 - Remove this once cl/918641330 is deployed to prod test.
         defines += [ "_LOGTAG_PREFIX=" ]
       } else {
         defines += [ "_LOGTAG_PREFIX=cr_" ]


### PR DESCRIPTION
Delegating Cobalt Java logging to Chromium's base logger introduced a "cr_" prefix to all Java log tags on Android. This broke rapid smoke tests which expect raw tags like "starboard".

This change conditionally disables the "cr_" prefix when building Cobalt (is_cobalt = true), while preserving it for other Chromium builds. This is a temporary workaround until cl/918641330 is deployed to prod test.

Issue: 515406853
