### PR TITLE
Cherry-pick: Put IA Descriptors in extradata

### DIFF
--- a/media/formats/mp4/mp4_stream_parser.cc
+++ b/media/formats/mp4/mp4_stream_parser.cc
@@ -585,6 +585,8 @@ bool MP4StreamParser::ParseMoov(BoxReader* reader) {
         codec = AudioCodec::kIAMF;
         profile = entry.iacb.profile == 0 ? AudioCodecProfile::kIAMF_SIMPLE
                                           : AudioCodecProfile::kIAMF_BASE;
+        extra_data = entry.iacb.ia_descriptors;
+
         // The correct values for the channel layout and sample rate can
         // be parsed from the descriptor bitstream prepended to each sample.
         // They are set to the following values here to create a valid


### PR DESCRIPTION
In a related prototype, we found that placing the IA Descriptors in the extra_data field of AudioDecoderConfig allowed us to do containerized IAMF decoding rather than standalone IAMF decoding.

Bug: 374813863
Change-Id: I5bc7ce5f3b7f9a9812dd2f44415195eeb3a8c009
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/7229273
Commit-Queue: Syed AbuTalib <lowkey@google.com>
Reviewed-by: Thomas Guilbert <tguilbert@chromium.org>
Cr-Commit-Position: refs/heads/main@{#1554317}