### PR TITLE
starboard: Add keep-sorted tags to feature_config.h and sort  flags

### DIFF
--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -101,9 +101,15 @@ FEATURE_LIST_START
 // #endif // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 
 #if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
+// keep-sorted start newline_separated=yes
 // By default, app provisioning is disabled. Set the following variable to true
 // to enable app provisioning.
 STARBOARD_FEATURE(kEnableAppProvisioning, "EnableAppProvisioning", false)
+
+// Set the following variable to true to enable av1 startup optimization.
+STARBOARD_FEATURE(kEnableAv1StartupOptimization,
+                  "EnableAv1StartupOptimization",
+                  false)
 
 // By default, Cobalt destroys and recreates AudioTrack during Seek().
 // Set the following variable to true to force it to Flush() AudioTrack
@@ -133,6 +139,14 @@ STARBOARD_FEATURE(kForceResetAudioDecoder, "ForceResetAudioDecoder", false)
 // enabling tunnel mode on all playbacks.
 STARBOARD_FEATURE(kForceTunnelMode, "ForceTunnelMode", false)
 
+// By default, software video codec can be selected when software codec is not
+// required. Set the following variable to true to prevent using low performance
+// software video decoder in MediaCapabilitiesCache when software codec is not
+// explicitly required.
+STARBOARD_FEATURE(kRejectLowPerformanceSoftwareDecoder,
+                  "RejectLowPerformanceSoftwareDecoder",
+                  false)
+
 // Cobalt VideoRenderAlgorithm used to release video frames immediately after
 // playback starts. Set the following variable to true to make it release video
 // frames until the underlying audio sink actually starts.
@@ -140,9 +154,10 @@ STARBOARD_FEATURE(kReleaseVideoFramesAfterAudioStarts,
                   "ReleaseVideoFramesAfterAudioStarts",
                   false)
 
-// By default, set the following to true to use stub decoder as audio/video
-// decoder.
+// By default, stub audio decoder is disabled.
 STARBOARD_FEATURE(kUseStubAudioDecoder, "UseStubAudioDecoder", false)
+
+// By default, stub video decoder is disabled.
 STARBOARD_FEATURE(kUseStubVideoDecoder, "UseStubVideoDecoder", false)
 
 // By default, Cobalt restarts MediaCodec after stops/flushes during
@@ -153,19 +168,7 @@ STARBOARD_FEATURE(kUseStubVideoDecoder, "UseStubVideoDecoder", false)
 STARBOARD_FEATURE(kVideoDecoderDelayUsecOverride,
                   "VideoDecoderDelayUsecOverride",
                   false)
-
-// By default, software video codec can be selected when software codec is not
-// required. Set the following variable to true to prevent using low performance
-// software video decoder in MediaCapabilitiesCache when software codec is not
-// explicitly required.
-STARBOARD_FEATURE(kRejectLowPerformanceSoftwareDecoder,
-                  "RejectLowPerformanceSoftwareDecoder",
-                  false)
-
-// Set the following variable to true to enable av1 startup optimization.
-STARBOARD_FEATURE(kEnableAv1StartupOptimization,
-                  "EnableAv1StartupOptimization",
-                  false)
+// keep-sorted end
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 FEATURE_LIST_END
 


### PR DESCRIPTION
Added // keep-sorted tags to Android features block in feature_config.h and sorted the flags alphabetically.

Issue: 414009070