### PR TITLE
starboard: Add entry point for NDK-based MediaCodec video decoder

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -1139,26 +1139,26 @@ class MediaCodecBridge {
   @NativeMethods
   interface Natives {
     void onMediaCodecError(
-        long nativeMediaCodecBridge,
+        long nativeJniMediaCodecBridge,
         boolean isRecoverable,
         boolean isTransient,
         String diagnosticInfo);
 
-    void onMediaCodecInputBufferAvailable(long nativeMediaCodecBridge, int bufferIndex);
+    void onMediaCodecInputBufferAvailable(long nativeJniMediaCodecBridge, int bufferIndex);
 
     void onMediaCodecOutputBufferAvailable(
-        long nativeMediaCodecBridge,
+        long nativeJniMediaCodecBridge,
         int bufferIndex,
         int flags,
         int offset,
         long presentationTimeUs,
         int size);
 
-    void onMediaCodecOutputFormatChanged(long nativeMediaCodecBridge);
+    void onMediaCodecOutputFormatChanged(long nativeJniMediaCodecBridge);
 
     void onMediaCodecFrameRendered(
-        long nativeMediaCodecBridge, long presentationTimeUs, long renderAtSystemTimeNs);
+        long nativeJniMediaCodecBridge, long presentationTimeUs, long renderAtSystemTimeNs);
 
-    void onMediaCodecFirstTunnelFrameReady(long nativeMediaCodecBridge);
+    void onMediaCodecFirstTunnelFrameReady(long nativeJniMediaCodecBridge);
   }
 }

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -14,6 +14,10 @@
 
 #include "starboard/android/shared/media_codec_bridge.h"
 
+#include <android/api-level.h>
+
+#include <limits>
+
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
@@ -21,6 +25,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/media.h"
 #include "starboard/common/string.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "third_party/jni_zero/jni_zero.h"
 
@@ -94,6 +99,30 @@ jint SbMediaRangeIdToColorRange(SbMediaRangeId range_id) {
   }
 }
 
+bool CanUseNdkMediaCodec(std::optional<int> tunnel_mode_audio_session_id,
+                         bool require_secured_decoder,
+                         jobject j_media_crypto) {
+  if (!features::FeatureList::IsEnabled(features::kEnableNdkVideo)) {
+    return false;
+  }
+
+  // We do not use NDK AMediaCodec for DRM, since it requires architectural
+  // changes.
+  if (require_secured_decoder || j_media_crypto) {
+    return false;
+  }
+  // NDK AMediaCodec does not support tunnel mode.
+  if (tunnel_mode_audio_session_id) {
+    return false;
+  }
+  // NDK AMediaCodec requires API level >= 28.
+  if (android_get_device_api_level() < 28) {
+    return false;
+  }
+
+  return true;
+}
+
 }  // namespace
 
 std::ostream& operator<<(std::ostream& os, const FrameSize& size) {
@@ -143,8 +172,8 @@ std::unique_ptr<MediaCodecBridge> MediaCodecBridge::CreateAudioMediaCodecBridge(
                         audio_stream_info.audio_specific_config.size()));
   }
 
-  std::unique_ptr<MediaCodecBridge> native_media_codec_bridge(
-      new MediaCodecBridge(handler));
+  auto native_media_codec_bridge =
+      std::make_unique<JniMediaCodecBridge>(handler);
   ScopedJavaLocalRef<jstring> j_mime(env, env->NewStringUTF(mime));
   ScopedJavaLocalRef<jstring> j_decoder_name(
       env, env->NewStringUTF(decoder_name.c_str()));
@@ -279,8 +308,16 @@ MediaCodecBridge::CreateVideoMediaCodecBridge(
   ScopedJavaLocalRef<jobject> j_create_media_codec_bridge_result(
       Java_CreateMediaCodecBridgeResult_Constructor(env));
 
-  std::unique_ptr<MediaCodecBridge> native_media_codec_bridge(
-      new MediaCodecBridge(handler));
+  if (CanUseNdkMediaCodec(tunnel_mode_audio_session_id, require_secured_decoder,
+                          j_media_crypto)) {
+    // TODO: b/515461431 - Implement the NDK-based MediaCodec video decoder and
+    // instantiate it here.
+    SB_LOG(WARNING) << "NDK Video (AMediaCodec) is not implemented yet. "
+                       "Falling back to Java MediaCodec (JNI).";
+  }
+
+  auto native_media_codec_bridge =
+      std::make_unique<JniMediaCodecBridge>(handler);
   ScopedJavaLocalRef<jobject> j_surface_local(env, env->NewLocalRef(j_surface));
   ScopedJavaLocalRef<jobject> j_media_crypto_local(
       env, env->NewLocalRef(j_media_crypto));
@@ -326,7 +363,9 @@ MediaCodecBridge::CreateVideoMediaCodecBridge(
   return native_media_codec_bridge;
 }
 
-MediaCodecBridge::~MediaCodecBridge() {
+MediaCodecBridge::~MediaCodecBridge() = default;
+
+JniMediaCodecBridge::~JniMediaCodecBridge() {
   if (!j_media_codec_bridge_) {
     return;
   }
@@ -335,26 +374,42 @@ MediaCodecBridge::~MediaCodecBridge() {
   Java_MediaCodecBridge_release(env, j_media_codec_bridge_);
 }
 
-ScopedJavaLocalRef<jobject> MediaCodecBridge::GetInputBuffer(jint index) {
+ScopedJavaLocalRef<jobject> JniMediaCodecBridge::GetInputBuffer(jint index) {
   SB_DCHECK_GE(index, 0);
   JNIEnv* env = AttachCurrentThread();
   return Java_MediaCodecBridge_getInputBuffer(env, j_media_codec_bridge_,
                                               index);
 }
 
-jint MediaCodecBridge::QueueInputBuffer(jint index,
-                                        jint offset,
-                                        jint size,
-                                        jlong presentation_time_microseconds,
-                                        jint flags,
-                                        jboolean is_decode_only) {
+MediaCodecBridge::BufferAddress JniMediaCodecBridge::GetInputBufferAddress(
+    jint index) {
+  JNIEnv* env = AttachCurrentThread();
+  ScopedJavaLocalRef<jobject> buffer = GetInputBuffer(index);
+  if (!buffer) {
+    return {nullptr, 0};
+  }
+  void* address = env->GetDirectBufferAddress(buffer.obj());
+  jlong capacity = env->GetDirectBufferCapacity(buffer.obj());
+  if (address == nullptr || capacity < 0 ||
+      capacity > std::numeric_limits<int>::max()) {
+    return {nullptr, 0};
+  }
+  return {address, static_cast<int>(capacity)};
+}
+
+jint JniMediaCodecBridge::QueueInputBuffer(jint index,
+                                           jint offset,
+                                           jint size,
+                                           jlong presentation_time_microseconds,
+                                           jint flags,
+                                           jboolean is_decode_only) {
   JNIEnv* env = AttachCurrentThread();
   return Java_MediaCodecBridge_queueInputBuffer(
       env, j_media_codec_bridge_, index, offset, size,
       presentation_time_microseconds, flags, is_decode_only);
 }
 
-jint MediaCodecBridge::QueueSecureInputBuffer(
+jint JniMediaCodecBridge::QueueSecureInputBuffer(
     jint index,
     jint offset,
     const SbDrmSampleInfo& drm_sample_info,
@@ -400,20 +455,20 @@ jint MediaCodecBridge::QueueSecureInputBuffer(
       blocks_to_skip, presentation_time_microseconds, is_decode_only);
 }
 
-ScopedJavaLocalRef<jobject> MediaCodecBridge::GetOutputBuffer(jint index) {
+ScopedJavaLocalRef<jobject> JniMediaCodecBridge::GetOutputBuffer(jint index) {
   SB_DCHECK_GE(index, 0);
   JNIEnv* env = AttachCurrentThread();
   return Java_MediaCodecBridge_getOutputBuffer(env, j_media_codec_bridge_,
                                                index);
 }
 
-void MediaCodecBridge::ReleaseOutputBuffer(jint index, jboolean render) {
+void JniMediaCodecBridge::ReleaseOutputBuffer(jint index, jboolean render) {
   JNIEnv* env = AttachCurrentThread();
   Java_MediaCodecBridge_releaseOutputBuffer(env, j_media_codec_bridge_, index,
                                             render);
 }
 
-void MediaCodecBridge::ReleaseOutputBufferAtTimestamp(
+void JniMediaCodecBridge::ReleaseOutputBufferAtTimestamp(
     jint index,
     jlong render_timestamp_ns) {
   JNIEnv* env = AttachCurrentThread();
@@ -421,23 +476,23 @@ void MediaCodecBridge::ReleaseOutputBufferAtTimestamp(
       env, j_media_codec_bridge_, index, render_timestamp_ns);
 }
 
-void MediaCodecBridge::SetPlaybackRate(double playback_rate) {
+void JniMediaCodecBridge::SetPlaybackRate(double playback_rate) {
   JNIEnv* env = AttachCurrentThread();
   Java_MediaCodecBridge_setPlaybackRate(env, j_media_codec_bridge_,
                                         playback_rate);
 }
 
-bool MediaCodecBridge::Restart() {
+bool JniMediaCodecBridge::Restart() {
   JNIEnv* env = AttachCurrentThread();
   return Java_MediaCodecBridge_restart(env, j_media_codec_bridge_) == JNI_TRUE;
 }
 
-jint MediaCodecBridge::Flush() {
+jint JniMediaCodecBridge::Flush() {
   JNIEnv* env = AttachCurrentThread();
   return Java_MediaCodecBridge_flush(env, j_media_codec_bridge_);
 }
 
-std::optional<FrameSize> MediaCodecBridge::GetOutputSize() {
+std::optional<FrameSize> JniMediaCodecBridge::GetOutputSize() {
   JNIEnv* env = AttachCurrentThread();
   ScopedJavaLocalRef<jobject> result(
       Java_MediaCodecBridge_getOutputFormat(env, j_media_codec_bridge_));
@@ -451,7 +506,7 @@ std::optional<FrameSize> MediaCodecBridge::GetOutputSize() {
 }
 
 std::optional<AudioOutputFormatResult>
-MediaCodecBridge::GetAudioOutputFormat() {
+JniMediaCodecBridge::GetAudioOutputFormat() {
   JNIEnv* env = AttachCurrentThread();
   ScopedJavaLocalRef<jobject> result(
       Java_MediaCodecBridge_getOutputFormat(env, j_media_codec_bridge_));
@@ -465,7 +520,7 @@ MediaCodecBridge::GetAudioOutputFormat() {
   };
 }
 
-void MediaCodecBridge::OnMediaCodecError(
+void JniMediaCodecBridge::OnMediaCodecError(
     JNIEnv* env,
     jboolean is_recoverable,
     jboolean is_transient,
@@ -476,12 +531,12 @@ void MediaCodecBridge::OnMediaCodecError(
                               diagnostic_info_in_str);
 }
 
-void MediaCodecBridge::OnMediaCodecInputBufferAvailable(JNIEnv* env,
-                                                        jint buffer_index) {
+void JniMediaCodecBridge::OnMediaCodecInputBufferAvailable(JNIEnv* env,
+                                                           jint buffer_index) {
   handler_->OnMediaCodecInputBufferAvailable(buffer_index);
 }
 
-void MediaCodecBridge::OnMediaCodecOutputBufferAvailable(
+void JniMediaCodecBridge::OnMediaCodecOutputBufferAvailable(
     JNIEnv* env,
     jint buffer_index,
     jint flags,
@@ -492,26 +547,26 @@ void MediaCodecBridge::OnMediaCodecOutputBufferAvailable(
                                               presentation_time_us, size);
 }
 
-void MediaCodecBridge::OnMediaCodecOutputFormatChanged(JNIEnv* env) {
+void JniMediaCodecBridge::OnMediaCodecOutputFormatChanged(JNIEnv* env) {
   handler_->OnMediaCodecOutputFormatChanged();
 }
 
-void MediaCodecBridge::OnMediaCodecFrameRendered(
+void JniMediaCodecBridge::OnMediaCodecFrameRendered(
     JNIEnv* env,
     jlong presentation_time_us,
     jlong render_at_system_time_ns) {
   handler_->OnMediaCodecFrameRendered(presentation_time_us);
 }
 
-void MediaCodecBridge::OnMediaCodecFirstTunnelFrameReady(JNIEnv* env) {
+void JniMediaCodecBridge::OnMediaCodecFirstTunnelFrameReady(JNIEnv* env) {
   handler_->OnMediaCodecFirstTunnelFrameReady();
 }
 
-MediaCodecBridge::MediaCodecBridge(Handler* handler) : handler_(handler) {
+JniMediaCodecBridge::JniMediaCodecBridge(Handler* handler) : handler_(handler) {
   SB_CHECK(handler_);
 }
 
-void MediaCodecBridge::Initialize(jobject j_media_codec_bridge) {
+void JniMediaCodecBridge::Initialize(jobject j_media_codec_bridge) {
   SB_DCHECK(j_media_codec_bridge);
 
   JNIEnv* env = AttachCurrentThread();

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -81,6 +81,12 @@ struct AudioOutputFormatResult {
   jint channel_count;
 };
 
+// MediaCodecBridge is an abstract interface for Android MediaCodec
+// functionality, providing a unified API for both JNI-based
+// (JniMediaCodecBridge) and NDK-based (NdkMediaCodecBridge) implementations. It
+// is typically owned by MediaCodecDecoder.
+//
+// This class is not thread-safe.
 class MediaCodecBridge {
  public:
   // The methods are called on the default Looper.  They won't get called after
@@ -137,34 +143,82 @@ class MediaCodecBridge {
       bool enable_output_checker,
       bool skip_video_frames_over_60_fps);
 
-  ~MediaCodecBridge();
+  virtual ~MediaCodecBridge();
 
   // It is the responsibility of the client to manage the lifetime of the
   // jobject that |GetInputBuffer| returns.
-  jni_zero::ScopedJavaLocalRef<jobject> GetInputBuffer(jint index);
+  virtual jni_zero::ScopedJavaLocalRef<jobject> GetInputBuffer(jint index) = 0;
+
+  struct BufferAddress {
+    void* address = nullptr;
+    int capacity = 0;
+  };
+  virtual BufferAddress GetInputBufferAddress(jint index) = 0;
+
+  virtual jint QueueInputBuffer(jint index,
+                                jint offset,
+                                jint size,
+                                jlong presentation_time_microseconds,
+                                jint flags,
+                                jboolean is_decode_only) = 0;
+  virtual jint QueueSecureInputBuffer(jint index,
+                                      jint offset,
+                                      const SbDrmSampleInfo& drm_sample_info,
+                                      jlong presentation_time_microseconds,
+                                      jboolean is_decode_only) = 0;
+
+  // It is the responsibility of the client to manage the lifetime of the
+  // jobject that |GetOutputBuffer| returns.
+  virtual jni_zero::ScopedJavaLocalRef<jobject> GetOutputBuffer(jint index) = 0;
+  virtual void ReleaseOutputBuffer(jint index, jboolean render) = 0;
+  virtual void ReleaseOutputBufferAtTimestamp(jint index,
+                                              jlong render_timestamp_ns) = 0;
+
+  virtual void SetPlaybackRate(double playback_rate) = 0;
+  virtual bool Restart() = 0;
+  virtual jint Flush() = 0;
+  virtual std::optional<FrameSize> GetOutputSize() = 0;
+  virtual std::optional<AudioOutputFormatResult> GetAudioOutputFormat() = 0;
+};
+
+// JniMediaCodecBridge is an implementation of MediaCodecBridge that interacts
+// with the Android MediaCodec Java API through JNI.
+// It is created by the factory methods in MediaCodecBridge and is owned by
+// the caller (typically a decoder).
+//
+// This class is not thread-safe.
+class JniMediaCodecBridge : public MediaCodecBridge {
+ public:
+  explicit JniMediaCodecBridge(Handler* handler);
+  ~JniMediaCodecBridge() override;
+
+  void Initialize(jobject j_media_codec_bridge);
+
+  // MediaCodecBridge implementation
+  jni_zero::ScopedJavaLocalRef<jobject> GetInputBuffer(jint index) override;
+  BufferAddress GetInputBufferAddress(jint index) override;
   jint QueueInputBuffer(jint index,
                         jint offset,
                         jint size,
                         jlong presentation_time_microseconds,
                         jint flags,
-                        jboolean is_decode_only);
+                        jboolean is_decode_only) override;
   jint QueueSecureInputBuffer(jint index,
                               jint offset,
                               const SbDrmSampleInfo& drm_sample_info,
                               jlong presentation_time_microseconds,
-                              jboolean is_decode_only);
+                              jboolean is_decode_only) override;
 
-  // It is the responsibility of the client to manage the lifetime of the
-  // jobject that |GetOutputBuffer| returns.
-  jni_zero::ScopedJavaLocalRef<jobject> GetOutputBuffer(jint index);
-  void ReleaseOutputBuffer(jint index, jboolean render);
-  void ReleaseOutputBufferAtTimestamp(jint index, jlong render_timestamp_ns);
+  jni_zero::ScopedJavaLocalRef<jobject> GetOutputBuffer(jint index) override;
+  void ReleaseOutputBuffer(jint index, jboolean render) override;
+  void ReleaseOutputBufferAtTimestamp(jint index,
+                                      jlong render_timestamp_ns) override;
 
-  void SetPlaybackRate(double playback_rate);
-  bool Restart();
-  jint Flush();
-  std::optional<FrameSize> GetOutputSize();
-  std::optional<AudioOutputFormatResult> GetAudioOutputFormat();
+  void SetPlaybackRate(double playback_rate) override;
+  bool Restart() override;
+  jint Flush() override;
+  std::optional<FrameSize> GetOutputSize() override;
+  std::optional<AudioOutputFormatResult> GetAudioOutputFormat() override;
 
   void OnMediaCodecError(
       JNIEnv* env,
@@ -185,15 +239,11 @@ class MediaCodecBridge {
   void OnMediaCodecFirstTunnelFrameReady(JNIEnv* env);
 
  private:
-  // |MediaCodecBridge|s must only be created through its factory methods.
-  explicit MediaCodecBridge(Handler* handler);
-  void Initialize(jobject j_media_codec_bridge);
-
   Handler* const handler_;
   jni_zero::ScopedJavaGlobalRef<jobject> j_media_codec_bridge_ = NULL;
 
-  MediaCodecBridge(const MediaCodecBridge&) = delete;
-  void operator=(const MediaCodecBridge&) = delete;
+  JniMediaCodecBridge(const JniMediaCodecBridge&) = delete;
+  void operator=(const JniMediaCodecBridge&) = delete;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -31,9 +31,6 @@
 namespace starboard {
 namespace {
 
-using jni_zero::AttachCurrentThread;
-using jni_zero::ScopedJavaLocalRef;
-
 const jint kNoOffset = 0;
 const jlong kNoPts = 0;
 const jint kNoBufferFlags = 0;
@@ -752,11 +749,10 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
   // were called and had it stored in |pending_input_to_retry_|.
   if (!input_buffer_already_written &&
       pending_input.type != PendingInput::kWriteEndOfStream) {
-    ScopedJavaLocalRef<jobject> byte_buffer(
-        media_codec_bridge_->GetInputBuffer(dequeue_input_result.index));
-    if (byte_buffer.is_null()) {
-      SB_LOG(ERROR) << "Unable to get MediaCodec input buffer, |byte_buffer| is"
-                    << " null.";
+    const auto [address, capacity] =
+        media_codec_bridge_->GetInputBufferAddress(dequeue_input_result.index);
+    if (!address) {
+      SB_LOG(ERROR) << "Unable to get MediaCodec input buffer address.";
       // There could be dirty callbacks right after flush, thus the
       // MediaCodec.InputBuffer could be unavailable. In that case, we should
       // re-write the input buffer with a different MediaCodec.InputBuffer.
@@ -765,13 +761,11 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
       return false;
     }
 
-    JNIEnv* env = AttachCurrentThread();
-    jint capacity = env->GetDirectBufferCapacity(byte_buffer.obj());
     if (capacity < size) {
       auto error_message = FormatString(
           "Unable to write to MediaCodec buffer, input buffer size (%d) is"
-          " greater than |byte_buffer.capacity()| (%d).",
-          size, static_cast<int>(capacity));
+          " greater than buffer capacity (%d).",
+          size, capacity);
       SB_LOG(ERROR) << error_message;
       ReportError(kSbPlayerErrorDecode, error_message);
       return false;
@@ -779,7 +773,6 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
 
     SB_DCHECK_GE(size, 0);
     SB_DCHECK_LE(size, capacity);
-    void* address = env->GetDirectBufferAddress(byte_buffer.obj());
 
     using ::starboard::experimental::IsPointerAnnotated;
     using ::starboard::experimental::UnannotatePointer;

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -111,6 +111,10 @@ STARBOARD_FEATURE(kEnableAv1StartupOptimization,
                   "EnableAv1StartupOptimization",
                   false)
 
+// By default, NDK Video (NDK MediaCodec) backend is disabled. Set the following
+// variable to true to enable NDK Video.
+STARBOARD_FEATURE(kEnableNdkVideo, "EnableNdkVideo", false)
+
 // By default, Cobalt destroys and recreates AudioTrack during Seek().
 // Set the following variable to true to force it to Flush() AudioTrack
 // during Seek().


### PR DESCRIPTION
Future NDK-based MediaCodec video decoders will be added through this entry point. This is gated by a feature flag and capability checks.

Issue: 515461431