### PR TITLE
test: Guard memory browsertest with build flags

### DIFF
--- a/cobalt/testing/browser_tests/granular_memory_browsertest.cc
+++ b/cobalt/testing/browser_tests/granular_memory_browsertest.cc
@@ -21,6 +21,8 @@
 
 namespace content {
 
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
+
 namespace {
 
 const char kTestSmaps[] =
@@ -117,7 +119,6 @@ class GranularMemoryBrowsertest : public ContentBrowserTest {
   base::ScopedFILE temp_rollup_;
 };
 
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
   // Ensure at least one renderer process is active.
   ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
@@ -159,9 +160,7 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, DetailedDump) {
               run_loop.QuitClosure(), browser_pid));
   run_loop.Run();
 }
-#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest,
                        BackgroundDumpSkipsDetailedStats) {
   ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));
@@ -197,9 +196,7 @@ IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest,
               run_loop.QuitClosure(), browser_pid));
   run_loop.Run();
 }
-#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 
-#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID)
 IN_PROC_BROWSER_TEST_F(GranularMemoryBrowsertest, CobaltSpecificMetrics) {
   // Ensure at least one renderer process is active.
   ASSERT_TRUE(NavigateToURL(shell()->web_contents(), GURL("about:blank")));


### PR DESCRIPTION
Add platform preprocessor checks around the
GranularMemoryBrowsertest fixture and helper
classes. This fixes compilation failures on
Apple platforms (such as tvOS) where OSMetrics
testing methods are not defined.

Bug: 511356295