### PR TITLE
android: Avoid double-triggering back navigation

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -569,6 +569,7 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   protected void onPause() {
+    mPhysicalBackKeyPressed = false;
     CobaltContentBrowserClient.dispatchBlur();
     super.onPause();
   }
@@ -859,18 +860,29 @@ public abstract class CobaltActivity extends Activity {
 
   @RequiresApi(api = 33)
   private static class OnBackInvokedHelper {
+    private static final Handler sHandler = new Handler(Looper.getMainLooper());
+
     static Object register(final CobaltActivity activity) {
       OnBackInvokedCallback callback = new OnBackInvokedCallback() {
         @Override
         public void onBackInvoked() {
           if (activity.mPhysicalBackKeyPressed) {
-            return;
+            return; // Bypassed: physical key events are already driving this navigation
           }
-          // Simulate complete key cycle just like onKeyDown -> IME pipeline expects.
+
+          // 1. Dispatch keydown to initiate navigation immediately.
           activity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_DOWN);
-          new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+
+          // 2. Simulate physical key release with a 100ms delay.
+          // This mimics natural user latency and prevents the web page's focus manager
+          // from receiving 'keyup' prematurely during asynchronous page transitions
+          // (which would otherwise disrupt cursor/spatial navigation focus restoration).
+          sHandler.postDelayed(new Runnable() {
             @Override
             public void run() {
+              if (activity.isDestroyed() || activity.isFinishing()) {
+                return; // Avoid memory leaks or dispatching keyup to a destroyed activity
+              }
               activity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_UP);
             }
           }, 100);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -27,6 +27,8 @@ import android.net.Uri;
 import android.os.Bundle;
 import android.os.SystemClock;
 import android.os.Build;
+import android.os.Handler;
+import android.os.Looper;
 import android.text.TextUtils;
 import android.view.KeyEvent;
 import android.view.View;
@@ -125,6 +127,14 @@ public abstract class CobaltActivity extends Activity {
   private String mStartDeepLink;
 
   private Object mBackInvokedCallback;
+
+  // Tracks if a physical/hardware back button press is currently in progress.
+  // On Android 13+ (API >= 33) with predictive back gesture enabled, the OS dispatches physical
+  // back button presses as both key events (onKeyDown/onKeyUp) and OnBackInvokedCallback.
+  // To prevent double-triggering back navigation in the web application (which maps back keys
+  // to Escape), this flag is used by OnBackInvokedCallback to detect physical key presses and
+  // bypass simulated key dispatching.
+  private boolean mPhysicalBackKeyPressed = false;
 
   private Bundle getActivityMetaData() {
     ComponentName componentName = getIntent().getComponent();
@@ -355,6 +365,9 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   public boolean onKeyDown(int keyCode, KeyEvent event) {
+    if (keyCode == KeyEvent.KEYCODE_BACK) {
+      mPhysicalBackKeyPressed = true;
+    }
     // If input is a from a gamepad button, it shouldn't be dispatched to IME which incorrectly
     // consumes the event as a VKEY_UNKNOWN
     if (KeyEvent.isGamepadButton(keyCode)) {
@@ -367,6 +380,9 @@ public abstract class CobaltActivity extends Activity {
   public boolean onKeyUp(int keyCode, KeyEvent event) {
     if (KeyEvent.isGamepadButton(keyCode)) {
       return super.onKeyUp(keyCode, event);
+    }
+    if (keyCode == KeyEvent.KEYCODE_BACK) {
+      mPhysicalBackKeyPressed = false;
     }
     return dispatchKeyEventToIme(keyCode, KeyEvent.ACTION_UP) || super.onKeyUp(keyCode, event);
   }
@@ -847,9 +863,17 @@ public abstract class CobaltActivity extends Activity {
       OnBackInvokedCallback callback = new OnBackInvokedCallback() {
         @Override
         public void onBackInvoked() {
+          if (activity.mPhysicalBackKeyPressed) {
+            return;
+          }
           // Simulate complete key cycle just like onKeyDown -> IME pipeline expects.
           activity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_DOWN);
-          activity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_UP);
+          new Handler(Looper.getMainLooper()).postDelayed(new Runnable() {
+            @Override
+            public void run() {
+              activity.dispatchKeyEventToIme(KeyEvent.KEYCODE_BACK, KeyEvent.ACTION_UP);
+            }
+          }, 100);
         }
       };
       activity.getOnBackInvokedDispatcher().registerOnBackInvokedCallback(


### PR DESCRIPTION
Prevent the back button from firing twice on Android 13+ devices.
When predictive back gestures are enabled, the system dispatches
both physical back button key events and the OnBackInvokedCallback.

This change tracks the state of hardware back key presses to ensure
that the callback does not simulate a second set of key events
when a physical button is already being handled.

Bug: 505562328