### PR TITLE
cobalt:  Revert Cobalt Java logging migration to Chromium base logger

### DIFF
--- a/base/android/java/src/org/chromium/base/Log.java
+++ b/base/android/java/src/org/chromium/base/Log.java
@@ -75,7 +75,7 @@ public class Log {
      */
     @AlwaysInline
     public static boolean isLoggable(String tag, int level) {
-        return BuildConfig.ENABLE_DEBUG_LOGS || android.util.Log.isLoggable(tag, level);
+        return BuildConfig.ENABLE_DEBUG_LOGS;
     }
 
     /**

--- a/build/config/android/rules.gni
+++ b/build/config/android/rules.gni
@@ -1991,10 +1991,6 @@ if (!is_robolectric && enable_java_templates) {
         if (is_cronet_for_aosp_build) {
           defines += [ "_CRONET_FOR_AOSP_BUILD" ]
         }
-      } else if (is_cobalt) {
-        # We remove "cr_" prefix not to break a rapid smoke test.
-        # TODO: b/515406853 - Remove this once cl/918641330 is deployed to prod test.
-        defines += [ "_LOGTAG_PREFIX=" ]
       } else {
         defines += [ "_LOGTAG_PREFIX=cr_" ]
       }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java
@@ -17,6 +17,7 @@ import android.graphics.Rect;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.Log;
 import android.view.KeyEvent;
 import android.view.View;
 import android.view.accessibility.AccessibilityEvent;
@@ -26,7 +27,6 @@ import androidx.customview.widget.ExploreByTouchHelper;
 import java.lang.ref.WeakReference;
 import java.util.BitSet;
 import java.util.List;
-import org.chromium.base.Log;
 import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.base.ViewAndroidDelegate;
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java
@@ -7,8 +7,8 @@ import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.os.SystemClock;
+import android.util.Log;
 import android.view.KeyEvent;
-import org.chromium.base.Log;
 import org.chromium.content.browser.input.ImeAdapterImpl;
 import org.chromium.content_public.browser.WebContents;
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/javabridge/AmatiDeviceInspector.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/javabridge/AmatiDeviceInspector.java
@@ -17,7 +17,7 @@ package dev.cobalt.coat.javabridge;
 import static dev.cobalt.util.Log.TAG;
 
 import android.content.Context;
-import org.chromium.base.Log;
+import android.util.Log;
 
 /**
  * A simple example to implement CobaltJavaScriptAndroidObject.

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaDrmBridge.java
@@ -32,6 +32,7 @@ import android.os.Build;
 import android.util.Base64;
 import androidx.annotation.RequiresApi;
 import dev.cobalt.coat.CobaltHttpHelper;
+import dev.cobalt.util.Log;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
@@ -39,7 +40,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.UUID;
-import org.chromium.base.Log;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
@@ -124,11 +124,11 @@ public class MediaDrmBridge {
     }
 
     public static OperationResult operationFailed(String errorMessage, Throwable e) {
-      return operationFailed(String.format("%s StackTrace: %s", errorMessage, Log.getStackTraceString(e)));
+      return operationFailed(String.format("%s StackTrace: %s", errorMessage, android.util.Log.getStackTraceString(e)));
     }
 
     public static OperationResult notProvisioned(Throwable e) {
-      return new OperationResult(DrmOperationStatus.NOT_PROVISIONED, String.format("Device is not provisioned. StackTrace: %s", Log.getStackTraceString(e)));
+      return new OperationResult(DrmOperationStatus.NOT_PROVISIONED, String.format("Device is not provisioned. StackTrace: %s", android.util.Log.getStackTraceString(e)));
     }
 
     @CalledByNative("OperationResult")

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
@@ -14,109 +14,114 @@
 
 package dev.cobalt.util;
 
+import java.lang.reflect.Method;
+import java.util.Locale;
+
 /**
- * Logging wrapper that delegates directly to Chromium's base Log class at compile time.
- * This proxy completely eliminates JNI reflection overhead, retains optimal ProGuard
- * dead-code stripping, and restores global usability of Log.d and Log.v.
- * This class is thread-safe and its methods can be safely called from any thread.
+ * Logging wrapper to allow for better control of Proguard log stripping. Many dependent
+ * configurations have rules to strip logs which makes it hard to control from the app.
+ *
+ * <p>The implementation is using reflection.
  */
 public final class Log {
   public static final String TAG = "starboard";
 
+  private static Method sLogV;
+  private static Method sLogD;
+  private static Method sLogI;
+  private static Method sLogW;
+  private static Method sLogE;
+
+  static {
+    initLogging();
+  }
+
   private Log() {}
 
-  // ===============================================================================================
-  // VERBOSE (v) & DEBUG (d) Optimized Overloads
-  // ===============================================================================================
-  //
-  // WHY:
-  // Every call to a varargs method like v(tag, template, Object...) forces the Java compiler to
-  // allocate a `new Object[]` array at the call site *before* entering the method.
-  //
-  // If logging is disabled (e.g., in production), this array is immediately discarded, causing
-  // severe Garbage Collection (GC) pressure if the log is located in a hot path (like the video
-  // frame rendering loop).
-  //
-  // By providing these optimized overloads (taking 0 to 4 parameters) and checking `isLoggable`
-  // *before* delegating to the varargs `org.chromium.base.Log`, we completely avoid any array
-  // allocations when logging is disabled.
-  //
-  // WHY ONLY v AND d:
-  // `v` and `d` are verbose/debug logs that are disabled by default in production but might be
-  // left in performance-critical paths. `i`, `w`, and `e` are enabled by default and should
-  // never be placed in hot paths, making their allocation overhead negligible.
-  // ===============================================================================================
-
-  public static void v(String tag, String message) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.VERBOSE)) return;
-    org.chromium.base.Log.v(tag, message);
+  private static void initLogging() {
+    sLogV = getLogMethod("v");
+    sLogD = getLogMethod("d");
+    sLogI = getLogMethod("i");
+    sLogW = getLogMethod("w");
+    sLogE = getLogMethod("e");
   }
 
-  public static void v(String tag, String messageTemplate, Object p1) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.VERBOSE)) return;
-    org.chromium.base.Log.v(tag, messageTemplate, p1);
+  private static Method getLogMethod(String methodName) {
+    try {
+      return org.chromium.base.Log.class.getDeclaredMethod(
+          methodName, String.class, String.class, Throwable.class);
+    } catch (Throwable e) {
+      // We catch Throwable to handle NoClassDefFoundError if the R8 compiler
+      // completely strips the org.chromium.base.Log class, preventing a startup crash.
+      // This failure is safely ignorable as logging is a non-critical helper feature
+      // and the application should still boot normally even if logging is disabled.
+    }
+    return null;
   }
 
-  public static void v(String tag, String messageTemplate, Object p1, Object p2) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.VERBOSE)) return;
-    org.chromium.base.Log.v(tag, messageTemplate, p1, p2);
+  private static Throwable getThrowableToLog(Object[] args) {
+    if (args == null || args.length == 0) {
+      return null;
+    }
+    Object lastArg = args[args.length - 1];
+    if (!(lastArg instanceof Throwable)) {
+      return null;
+    }
+    return (Throwable) lastArg;
   }
 
-  public static void v(String tag, String messageTemplate, Object p1, Object p2, Object p3) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.VERBOSE)) return;
-    org.chromium.base.Log.v(tag, messageTemplate, p1, p2, p3);
+  /** Returns a formatted log message, using the supplied format and arguments. */
+  private static String formatLog(String messageTemplate, Throwable tr, Object... params) {
+    if ((params != null) && ((tr == null && params.length > 0) || params.length > 1)) {
+      messageTemplate = String.format(Locale.US, messageTemplate, params);
+    }
+    return messageTemplate;
   }
 
-  public static void v(String tag, String messageTemplate, Object p1, Object p2, Object p3, Object p4) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.VERBOSE)) return;
-    org.chromium.base.Log.v(tag, messageTemplate, p1, p2, p3, p4);
+  private static int logWithMethod(
+      Method logMethod, String tag, String messageTemplate, Object... args) {
+    try {
+      if (logMethod != null) {
+        Throwable tr = getThrowableToLog(args);
+        String msg = formatLog(messageTemplate, tr, args);
+        return (int) logMethod.invoke(null, tag, msg, tr);
+      }
+    } catch (Throwable e) {
+      // ignore
+    }
+    return 0;
   }
 
-  // Fallback for 5+ arguments (always allocates array at call site)
-  public static void v(String tag, String messageTemplate, Object... args) {
-    org.chromium.base.Log.v(tag, messageTemplate, args);
+  public static int v(String tag, String messageTemplate, Object... args) {
+    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.VERBOSE)) {
+      return logWithMethod(sLogV, tag, messageTemplate, args);
+    }
+    return 0;
   }
 
-  public static void d(String tag, String message) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.DEBUG)) return;
-    org.chromium.base.Log.d(tag, message);
+  public static int d(String tag, String messageTemplate, Object... args) {
+    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.DEBUG)) {
+      return logWithMethod(sLogD, tag, messageTemplate, args);
+    }
+    return 0;
   }
 
-  public static void d(String tag, String messageTemplate, Object p1) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.DEBUG)) return;
-    org.chromium.base.Log.d(tag, messageTemplate, p1);
+  public static int i(String tag, String messageTemplate, Object... args) {
+    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.INFO)) {
+      return logWithMethod(sLogI, tag, messageTemplate, args);
+    }
+    return 0;
   }
 
-  public static void d(String tag, String messageTemplate, Object p1, Object p2) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.DEBUG)) return;
-    org.chromium.base.Log.d(tag, messageTemplate, p1, p2);
+  public static int w(String tag, String messageTemplate, Object... args) {
+    return logWithMethod(sLogW, tag, messageTemplate, args);
   }
 
-  public static void d(String tag, String messageTemplate, Object p1, Object p2, Object p3) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.DEBUG)) return;
-    org.chromium.base.Log.d(tag, messageTemplate, p1, p2, p3);
+  public static int w(String tag, Throwable tr) {
+    return logWithMethod(sLogW, tag, "", tr);
   }
 
-  public static void d(String tag, String messageTemplate, Object p1, Object p2, Object p3, Object p4) {
-    if (!org.chromium.base.Log.isLoggable(tag, org.chromium.base.Log.DEBUG)) return;
-    org.chromium.base.Log.d(tag, messageTemplate, p1, p2, p3, p4);
+  public static int e(String tag, String messageTemplate, Object... args) {
+    return logWithMethod(sLogE, tag, messageTemplate, args);
   }
-
-  // Fallback for 5+ arguments (always allocates array at call site)
-  public static void d(String tag, String messageTemplate, Object... args) {
-    org.chromium.base.Log.d(tag, messageTemplate, args);
-  }
-
-  public static void i(String tag, String messageTemplate, Object... args) {
-    org.chromium.base.Log.i(tag, messageTemplate, args);
-  }
-
-  public static void w(String tag, String messageTemplate, Object... args) {
-    org.chromium.base.Log.w(tag, messageTemplate, args);
-  }
-
-  public static void e(String tag, String messageTemplate, Object... args) {
-    org.chromium.base.Log.e(tag, messageTemplate, args);
-  }
-
 }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
@@ -41,19 +41,19 @@ public final class Log {
   private static void initLogging() {
     try {
       sLogV =
-          org.chromium.base.Log.class.getDeclaredMethod(
+          android.util.Log.class.getDeclaredMethod(
               "v", String.class, String.class, Throwable.class);
       sLogD =
-          org.chromium.base.Log.class.getDeclaredMethod(
+          android.util.Log.class.getDeclaredMethod(
               "d", String.class, String.class, Throwable.class);
       sLogI =
-          org.chromium.base.Log.class.getDeclaredMethod(
+          android.util.Log.class.getDeclaredMethod(
               "i", String.class, String.class, Throwable.class);
       sLogW =
-          org.chromium.base.Log.class.getDeclaredMethod(
+          android.util.Log.class.getDeclaredMethod(
               "w", String.class, String.class, Throwable.class);
       sLogE =
-          org.chromium.base.Log.class.getDeclaredMethod(
+          android.util.Log.class.getDeclaredMethod(
               "e", String.class, String.class, Throwable.class);
     } catch (Throwable e) {
       // ignore
@@ -94,21 +94,21 @@ public final class Log {
   }
 
   public static int v(String tag, String messageTemplate, Object... args) {
-    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.VERBOSE)) {
+    if (android.util.Log.isLoggable(TAG, android.util.Log.VERBOSE)) {
       return logWithMethod(sLogV, tag, messageTemplate, args);
     }
     return 0;
   }
 
   public static int d(String tag, String messageTemplate, Object... args) {
-    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.DEBUG)) {
+    if (android.util.Log.isLoggable(TAG, android.util.Log.DEBUG)) {
       return logWithMethod(sLogD, tag, messageTemplate, args);
     }
     return 0;
   }
 
   public static int i(String tag, String messageTemplate, Object... args) {
-    if (org.chromium.base.Log.isLoggable(TAG, org.chromium.base.Log.INFO)) {
+    if (android.util.Log.isLoggable(TAG, android.util.Log.INFO)) {
       return logWithMethod(sLogI, tag, messageTemplate, args);
     }
     return 0;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/Log.java
@@ -39,24 +39,25 @@ public final class Log {
   private Log() {}
 
   private static void initLogging() {
-    sLogV = getLogMethod("v");
-    sLogD = getLogMethod("d");
-    sLogI = getLogMethod("i");
-    sLogW = getLogMethod("w");
-    sLogE = getLogMethod("e");
-  }
-
-  private static Method getLogMethod(String methodName) {
     try {
-      return org.chromium.base.Log.class.getDeclaredMethod(
-          methodName, String.class, String.class, Throwable.class);
+      sLogV =
+          org.chromium.base.Log.class.getDeclaredMethod(
+              "v", String.class, String.class, Throwable.class);
+      sLogD =
+          org.chromium.base.Log.class.getDeclaredMethod(
+              "d", String.class, String.class, Throwable.class);
+      sLogI =
+          org.chromium.base.Log.class.getDeclaredMethod(
+              "i", String.class, String.class, Throwable.class);
+      sLogW =
+          org.chromium.base.Log.class.getDeclaredMethod(
+              "w", String.class, String.class, Throwable.class);
+      sLogE =
+          org.chromium.base.Log.class.getDeclaredMethod(
+              "e", String.class, String.class, Throwable.class);
     } catch (Throwable e) {
-      // We catch Throwable to handle NoClassDefFoundError if the R8 compiler
-      // completely strips the org.chromium.base.Log class, preventing a startup crash.
-      // This failure is safely ignorable as logging is a non-critical helper feature
-      // and the application should still boot normally even if logging is disabled.
+      // ignore
     }
-    return null;
   }
 
   private static Throwable getThrowableToLog(Object[] args) {


### PR DESCRIPTION
Reverts the migration of Cobalt's Android Java logging to `org.chromium.base.Log`. The migration caused rapid smoke teststo fail because:
- All Android Java logs were prefixed with "cr_", breaking tests that  expected raw tags like "starboard".
- Attempting to remove the prefix led to all INFO-level Java logs being silenced in release builds.

This rollbacks the codebase to using android.util.Log via the reflection
wrapper in `dev.cobalt.util.Log`, restoring the previous working state.

 This squashes the reversion of:
 - "Clean up use of android.util.Log in //cobalt." (2a71426ef85561abffd67b5ed22f63ee759f71e8)
 - "android: Fix silent Java logging regression in Log wrapper" (4a7488a418b02cd54073431a2a4f3debd49b8442)
 - "android: Refactor Log wrapper to compile-time delegate from run-time reflection" (a10e93d965802e31a020623019d043f62598ed40)
 - "cobalt: Remove "cr_" prefix from Cobalt Java log tags" (41f5dad3e801debb9cc8d9ef808c4a3ba5decce7)
 - "Ignore log settings on device" (08d52ca3fd55de0a5639cdecead1d6e632e12c74)

Issue: 515406853