### PR TITLE
starboard: Make RDK code to use single-level starboard namespaces

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/accessibility_extension.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/accessibility_extension.cc
@@ -20,65 +20,52 @@
 #include "third_party/starboard/rdk/shared/accessibility_extension.h"
 #include "third_party/starboard/rdk/shared/rdkservices.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-
-namespace accessibility {
 
 bool GetTextToSpeechSettings(SbAccessibilityTextToSpeechSettings* out_setting) {
   if (!out_setting ||
-      !::starboard::MemoryIsZero(
-        out_setting, sizeof(SbAccessibilityTextToSpeechSettings))) {
+      !MemoryIsZero(out_setting, sizeof(SbAccessibilityTextToSpeechSettings))) {
     return false;
   }
   out_setting->has_text_to_speech_setting = true;
-  out_setting->is_text_to_speech_enabled =
-      third_party::starboard::rdk::shared::TextToSpeech::IsEnabled();
+  out_setting->is_text_to_speech_enabled = TextToSpeech::IsEnabled();
   return true;
 }
 
 bool GetDisplaySettings(SbAccessibilityDisplaySettings* out_setting) {
   if (!out_setting ||
-      !::starboard::MemoryIsZero(
-        out_setting, sizeof(SbAccessibilityDisplaySettings))) {
+      !MemoryIsZero(out_setting, sizeof(SbAccessibilityDisplaySettings))) {
     return false;
   }
 
-  return third_party::starboard::rdk::shared::Accessibility::GetDisplaySettings(out_setting);
+  return Accessibility::GetDisplaySettings(out_setting);
 }
 
 bool GetCaptionSettings(SbAccessibilityCaptionSettings* caption_settings) {
   if (!caption_settings ||
-      !::starboard::MemoryIsZero(
-          caption_settings, sizeof(SbAccessibilityCaptionSettings))) {
+      !MemoryIsZero(caption_settings, sizeof(SbAccessibilityCaptionSettings))) {
     return false;
   }
 
-  return third_party::starboard::rdk::shared::Accessibility::GetCaptionSettings(caption_settings);
+  return Accessibility::GetCaptionSettings(caption_settings);
 }
 
 bool SetCaptionsEnabled(bool enabled) {
   return false;
 }
 
-}  // namespace accessibility
 
 const StarboardExtensionAccessibilityApi kAccessibilityAPI = {
   kStarboardExtensionAccessibilityName,
   1,
-  &accessibility::GetTextToSpeechSettings,
-  &accessibility::GetDisplaySettings,
-  &accessibility::GetCaptionSettings,
-  &accessibility::SetCaptionsEnabled
+  &GetTextToSpeechSettings,
+  &GetDisplaySettings,
+  &GetCaptionSettings,
+  &SetCaptionsEnabled
 };
 
 const void* GetAccessibilityApi() {
   return &kAccessibilityAPI;
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/accessibility_extension.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/accessibility_extension.h
@@ -19,14 +19,8 @@
 
 #include "starboard/extension/accessibility.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 const void* GetAccessibilityApi();
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/accessibility_get_caption_settings.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/accessibility_get_caption_settings.cc
@@ -43,6 +43,6 @@ bool SbAccessibilityGetCaptionSettings(
     return false;
   }
 
-  return third_party::starboard::rdk::shared::Accessibility::GetCaptionSettings(caption_settings);
+  return starboard::Accessibility::GetCaptionSettings(caption_settings);
 }
 #endif

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/accessibility_get_display_settings.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/accessibility_get_display_settings.cc
@@ -42,6 +42,6 @@ bool SbAccessibilityGetDisplaySettings(
     return false;
   }
 
-  return third_party::starboard::rdk::shared::Accessibility::GetDisplaySettings(out_setting);
+  return starboard::Accessibility::GetDisplaySettings(out_setting);
 }
 #endif

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.cc
@@ -133,7 +133,7 @@ void ApplicationRdk::Initialize() {
 #endif
 
   SbAudioSinkImpl::Initialize();
-  Initialize();
+  ::starboard::Initialize();
   MimeSupportabilityCache::GetInstance()->SetCacheEnabled(true);
   KeySystemSupportabilityCache::GetInstance()->SetCacheEnabled(true);
 
@@ -143,7 +143,7 @@ void ApplicationRdk::Initialize() {
 
 void ApplicationRdk::Teardown() {
   SbAudioSinkImpl::TearDown();
-  Teardown();
+  ::starboard::Teardown();
   TeardownJSONRPCLink();
 
   close(ess_timer_fd_);

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.cc
@@ -59,23 +59,23 @@ void Teardown();
 
 void ForceStop();
 
-EssTerminateListener Application::terminateListener = {
+EssTerminateListener ApplicationRdk::terminateListener = {
   //terminated
-  [](void* data) { reinterpret_cast<Application*>(data)->OnTerminated(); }
+  [](void* data) { reinterpret_cast<ApplicationRdk*>(data)->OnTerminated(); }
 };
 
-EssKeyListener Application::keyListener = {
+EssKeyListener ApplicationRdk::keyListener = {
   // keyPressed
-  [](void* data, unsigned int key) { reinterpret_cast<Application*>(data)->OnKeyPressed(key); },
+  [](void* data, unsigned int key) { reinterpret_cast<ApplicationRdk*>(data)->OnKeyPressed(key); },
   // keyReleased
-  [](void* data, unsigned int key) { reinterpret_cast<Application*>(data)->OnKeyReleased(key); },
+  [](void* data, unsigned int key) { reinterpret_cast<ApplicationRdk*>(data)->OnKeyReleased(key); },
   // keyRepeat
-  [](void* data, unsigned int key) { reinterpret_cast<Application*>(data)->OnKeyPressed(key); }
+  [](void* data, unsigned int key) { reinterpret_cast<ApplicationRdk*>(data)->OnKeyPressed(key); }
 };
 
-EssSettingsListener Application::settingsListener = {
+EssSettingsListener ApplicationRdk::settingsListener = {
   // displaySize
-  [](void *data, int width, int height ) { reinterpret_cast<Application*>(data)->OnDisplaySize(width, height); },
+  [](void *data, int width, int height ) { reinterpret_cast<ApplicationRdk*>(data)->OnDisplaySize(width, height); },
   // displaySafeArea
   nullptr
 };
@@ -94,19 +94,19 @@ static void setTimerInterval(int fd, microseconds time) {
   }
 }
 
-Application::Application(SbEventHandleCallback sb_event_handle_callback)
+ApplicationRdk::ApplicationRdk(SbEventHandleCallback sb_event_handle_callback)
   : QueueApplication(sb_event_handle_callback)
   , input_handler_(new EssInput)
-  , hang_monitor_(new HangMonitor("Application")) {
+  , hang_monitor_(new HangMonitor("ApplicationRdk")) {
   essos_context_recycle_ = !!getenv("COBALT_ESSOS_CONTEXT_DESTROY");
   BuildEssosContext();
 }
 
-Application::~Application() {
+ApplicationRdk::~ApplicationRdk() {
   EssContextDestroy(ctx_);
 }
 
-void Application::Initialize() {
+void ApplicationRdk::Initialize() {
   wakeup_fd_ = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
   if ( wakeup_fd_ == -1 ) {
     SB_LOG(ERROR) << "Failed to create eventfd, error: " << errno << " (" << strerror(errno) << ')';
@@ -141,7 +141,7 @@ void Application::Initialize() {
   NetworkInfo::Initialize();
 }
 
-void Application::Teardown() {
+void ApplicationRdk::Teardown() {
   SbAudioSinkImpl::TearDown();
   Teardown();
   TeardownJSONRPCLink();
@@ -153,12 +153,11 @@ void Application::Teardown() {
   ess_timer_fd_ = wakeup_fd_ = monitor_timer_fd_ = -1;
 }
 
-bool Application::MayHaveSystemEvents() {
+bool ApplicationRdk::MayHaveSystemEvents() {
   return true;
 }
 
-Application::Event*
-Application::PollNextSystemEvent() {
+ApplicationRdk::Event* ApplicationRdk::PollNextSystemEvent() {
   auto now = steady_clock::now();
   if ((now - ess_loop_last_ts_) > kEssRunLoopPeriod) {
     ess_loop_last_ts_ = now;
@@ -167,8 +166,7 @@ Application::PollNextSystemEvent() {
   return NULL;
 }
 
-Application::Event*
-Application::WaitForSystemEventWithTimeout(int64_t time) {
+ApplicationRdk::Event* ApplicationRdk::WaitForSystemEventWithTimeout(int64_t time) {
   struct timespec timeout;
   struct pollfd fds[3];
   int fds_sz = 0;
@@ -218,12 +216,12 @@ Application::WaitForSystemEventWithTimeout(int64_t time) {
   return NULL;
 }
 
-void Application::WakeSystemEventWait() {
+void ApplicationRdk::WakeSystemEventWait() {
   uint64_t u = 1;
   write(wakeup_fd_, &u, sizeof(uint64_t));
 }
 
-SbWindow Application::CreateSbWindow(const SbWindowOptions* options) {
+SbWindow ApplicationRdk::CreateSbWindow(const SbWindowOptions* options) {
   SB_DCHECK(window_ == nullptr);
   if (window_ != nullptr)
     return kSbWindowInvalid;
@@ -232,7 +230,7 @@ SbWindow Application::CreateSbWindow(const SbWindowOptions* options) {
   return window_;
 }
 
-bool Application::DestroySbWindow(SbWindow window) {
+bool ApplicationRdk::DestroySbWindow(SbWindow window) {
   if (!SbWindowIsValid(window))
     return false;
   window_ = nullptr;
@@ -241,18 +239,18 @@ bool Application::DestroySbWindow(SbWindow window) {
   return true;
 }
 
-void Application::InjectInputEvent(SbInputData* data) {
+void ApplicationRdk::InjectInputEvent(SbInputData* data) {
   if (native_window_ == 0) {
-    Application::DeleteDestructor<SbInputData>(data);
+    ApplicationRdk::DeleteDestructor<SbInputData>(data);
     return;
   }
 
   data->window = window_;
   Inject(new Event(kSbEventTypeInput, data,
-                   &Application::DeleteDestructor<SbInputData>));
+                   &ApplicationRdk::DeleteDestructor<SbInputData>));
 }
 
-void Application::Inject(Event* e) {
+void ApplicationRdk::Inject(Event* e) {
   if (e && e->event && e->event->type == kSbEventTypeFreeze) {
     ForceStop();
   }
@@ -260,14 +258,14 @@ void Application::Inject(Event* e) {
   QueueApplication::Inject(e);
 }
 
-void Application::OnSuspend() {
+void ApplicationRdk::OnSuspend() {
   SbSpeechSynthesisCancel();
   DestroyNativeWindow();
   TeardownJSONRPCLink();
   setTimerInterval(ess_timer_fd_, 1s);
 }
 
-void Application::OnResume() {
+void ApplicationRdk::OnResume() {
   if ( essos_context_recycle_ )
     BuildEssosContext();
 
@@ -275,19 +273,19 @@ void Application::OnResume() {
   MaterializeNativeWindow();
 }
 
-void Application::OnTerminated() {
+void ApplicationRdk::OnTerminated() {
   Stop(0);
 }
 
-void Application::OnKeyPressed(unsigned int key) {
+void ApplicationRdk::OnKeyPressed(unsigned int key) {
   input_handler_->OnKeyPressed(key);
 }
 
-void Application::OnKeyReleased(unsigned int key) {
+void ApplicationRdk::OnKeyReleased(unsigned int key) {
   input_handler_->OnKeyReleased(key);
 }
 
-void Application::OnDisplaySize(int width, int height) {
+void ApplicationRdk::OnDisplaySize(int width, int height) {
   if (window_width_ == width && window_height_ == height) {
     resize_pending_ = false;
     return;
@@ -297,7 +295,7 @@ void Application::OnDisplaySize(int width, int height) {
   resize_pending_ = true;
 }
 
-void Application::MaterializeNativeWindow() {
+void ApplicationRdk::MaterializeNativeWindow() {
   if (native_window_ != 0)
     return;
 
@@ -326,7 +324,7 @@ void Application::MaterializeNativeWindow() {
   }
 }
 
-void Application::DestroyNativeWindow() {
+void ApplicationRdk::DestroyNativeWindow() {
   if (native_window_ == 0)
     return;
 
@@ -345,7 +343,7 @@ void Application::DestroyNativeWindow() {
     EssContextStop(ctx_);
 }
 
-void Application::DisplayInfoChanged() {
+void ApplicationRdk::DisplayInfoChanged() {
   if (state() != kStateStarted)
     return;
 
@@ -354,10 +352,10 @@ void Application::DisplayInfoChanged() {
   auto *data = new SbEventWindowSizeChangedData();
   data->size = window_size;
   data->window = window_;
-  WindowSizeChanged(data, &Application::DeleteDestructor<SbEventWindowSizeChangedData>);
+  WindowSizeChanged(data, &ApplicationRdk::DeleteDestructor<SbEventWindowSizeChangedData>);
 }
 
-void Application::BuildEssosContext() {
+void ApplicationRdk::BuildEssosContext() {
   bool error = false;
   ctx_ = EssContextCreate();
 
@@ -381,29 +379,29 @@ void Application::BuildEssosContext() {
   }
 }
 
-void Application::FatalError() {
+void ApplicationRdk::FatalError() {
   SB_LOG(ERROR) << "Exiting due to fatal error.";
   ess_loop_last_ts_ = time_point<steady_clock>::max(); // Stop Essos run loop
   SbEventSchedule([](void* data) {
-    Application::Get()->Stop(0);
+    ApplicationRdk::Get()->Stop(0);
   }, nullptr, 0);
 }
 
-void Application::ReleaseMemory() {
+void ApplicationRdk::ReleaseMemory() {
   Inject(new Event(kSbEventTypeLowMemory, NULL, [](void*) {
     malloc_trim(0);
   }));
 }
 
-void Application::ScheduleMemoryUsageCheck(int64_t delay) {
+void ApplicationRdk::ScheduleMemoryUsageCheck(int64_t delay) {
   SbEventSchedule([](void* data) {
-    int64_t back_off_timeout = Application::Get()->CheckMemoryUsage();
+    int64_t back_off_timeout = ApplicationRdk::Get()->CheckMemoryUsage();
     if (back_off_timeout && back_off_timeout != std::numeric_limits<int64_t>::max())
-      Application::Get()->ScheduleMemoryUsageCheck(back_off_timeout);
+      ApplicationRdk::Get()->ScheduleMemoryUsageCheck(back_off_timeout);
   }, nullptr, delay);
 }
 
-int64_t Application::CheckMemoryUsage() {
+int64_t ApplicationRdk::CheckMemoryUsage() {
   static const int64_t kCPUMemoryPressureLimit = ([]() -> int64_t {
     const char* env = std::getenv("COBALT_CPU_MEM_PRESSURE_IN_MB");
     // For C25, default memory pressure threshold was 400 MB, but has been
@@ -433,11 +431,11 @@ int64_t Application::CheckMemoryUsage() {
   return kSbTimeSecond;
 }
 
-void Application::InjectAccessibilityTextToSpeechSettingsChanged(bool enabled) {
+void ApplicationRdk::InjectAccessibilityTextToSpeechSettingsChanged(bool enabled) {
   bool* enabled_data = new bool(enabled);
   Inject(new Event(kSbEventTypeAccessibilityTextToSpeechSettingsChanged,
                    enabled_data,
-                   &Application::DeleteDestructor<bool>));
+                   &ApplicationRdk::DeleteDestructor<bool>));
 }
 
 }  // namespace starboard

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.cc
@@ -52,19 +52,12 @@
 using namespace std::chrono;
 using namespace std::chrono_literals;
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
-namespace libcobalt_api {
 void Initialize();
 void Teardown();
-}
 
-namespace player {
 void ForceStop();
-}  // namespace player
 
 EssTerminateListener Application::terminateListener = {
   //terminated
@@ -100,8 +93,6 @@ static void setTimerInterval(int fd, microseconds time) {
     SB_LOG(ERROR) << "Failed to set timer interval, error: " << errno << " ("<< strerror(errno) << ')';
   }
 }
-
-using ::starboard::SbAudioSinkImpl;
 
 Application::Application(SbEventHandleCallback sb_event_handle_callback)
   : QueueApplication(sb_event_handle_callback)
@@ -142,9 +133,7 @@ void Application::Initialize() {
 #endif
 
   SbAudioSinkImpl::Initialize();
-  libcobalt_api::Initialize();
-  using ::starboard::KeySystemSupportabilityCache;
-  using ::starboard::MimeSupportabilityCache;
+  Initialize();
   MimeSupportabilityCache::GetInstance()->SetCacheEnabled(true);
   KeySystemSupportabilityCache::GetInstance()->SetCacheEnabled(true);
 
@@ -154,7 +143,7 @@ void Application::Initialize() {
 
 void Application::Teardown() {
   SbAudioSinkImpl::TearDown();
-  libcobalt_api::Teardown();
+  Teardown();
   TeardownJSONRPCLink();
 
   close(ess_timer_fd_);
@@ -168,7 +157,7 @@ bool Application::MayHaveSystemEvents() {
   return true;
 }
 
-::starboard::Application::Event*
+Application::Event*
 Application::PollNextSystemEvent() {
   auto now = steady_clock::now();
   if ((now - ess_loop_last_ts_) > kEssRunLoopPeriod) {
@@ -178,7 +167,7 @@ Application::PollNextSystemEvent() {
   return NULL;
 }
 
-::starboard::Application::Event*
+Application::Event*
 Application::WaitForSystemEventWithTimeout(int64_t time) {
   struct timespec timeout;
   struct pollfd fds[3];
@@ -265,7 +254,7 @@ void Application::InjectInputEvent(SbInputData* data) {
 
 void Application::Inject(Event* e) {
   if (e && e->event && e->event->type == kSbEventTypeFreeze) {
-    player::ForceStop();
+    ForceStop();
   }
 
   QueueApplication::Inject(e);
@@ -451,7 +440,4 @@ void Application::InjectAccessibilityTextToSpeechSettingsChanged(bool enabled) {
                    &Application::DeleteDestructor<bool>));
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.h
@@ -46,19 +46,15 @@
 #include <essos-app.h>
 #include <chrono>
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
-class Application : public ::starboard::QueueApplication {
+class Application : public QueueApplication {
  public:
   explicit Application(SbEventHandleCallback sb_event_handle_callback);
   ~Application() override;
 
-  static third_party::starboard::rdk::shared::Application* Get() {
-    return static_cast<third_party::starboard::rdk::shared::Application*>(
-        ::starboard::Application::Get());
+  static Application* Get() {
+    return static_cast<Application*>(Application::Get());
   }
 
   SbWindow CreateSbWindow(const SbWindowOptions* options);
@@ -127,9 +123,6 @@ class Application : public ::starboard::QueueApplication {
   std::unique_ptr<HangMonitor> hang_monitor_ { nullptr };
 };
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_APPLICATION_RDK_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.h
@@ -48,13 +48,13 @@
 
 namespace starboard {
 
-class Application : public QueueApplication {
+class ApplicationRdk : public QueueApplication {
  public:
-  explicit Application(SbEventHandleCallback sb_event_handle_callback);
-  ~Application() override;
+  explicit ApplicationRdk(SbEventHandleCallback sb_event_handle_callback);
+  ~ApplicationRdk() override;
 
-  static Application* Get() {
-    return static_cast<Application*>(Application::Get());
+  static ApplicationRdk* Get() {
+    return static_cast<ApplicationRdk*>(Application::Get());
   }
 
   SbWindow CreateSbWindow(const SbWindowOptions* options);

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.cc
@@ -57,11 +57,7 @@
 
 #include "third_party/starboard/rdk/shared/hang_detector.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace audio_sink {
 namespace {
 
 GST_DEBUG_CATEGORY(cobalt_gst_audio_sink_debug);
@@ -74,8 +70,6 @@ constexpr int kFramesPerRequest = 1024;
 // `kernel-source/common_drivers/drivers/media/avsync/msync.c
 // #define MAX_SESSION_NUM 4
 constexpr int MAX_ALLOWED_SESSION = 4;
-
-using ::starboard::GetBytesPerSample;
 
 class GStreamerAudioSink : public SbAudioSinkPrivate {
  public:
@@ -284,7 +278,7 @@ GStreamerAudioSink::~GStreamerAudioSink() {
 // static
 void* GStreamerAudioSink::AudioThreadEntryPoint(void* context) {
   SB_DCHECK(context);
-  setpriority(PRIO_PROCESS, 0, ::starboard::SbPriorityToNice(kSbThreadPriorityRealTime));
+  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(kSbThreadPriorityRealTime));
 
   GStreamerAudioSink* sink = reinterpret_cast<GStreamerAudioSink*>(context);
   GST_TRACE_OBJECT(sink->pipeline_, "TID: %d", SbThreadGetId());
@@ -519,15 +513,6 @@ SbAudioSink GStreamerAudioSinkType::Create(
   return sink;
 }
 
-}  // namespace audio_sink
-}  // namespace shared
-}  // namespace rdk
-}  // namespace starboard
-}  // namespace third_party
-
-using third_party::starboard::rdk::shared::audio_sink::GStreamerAudioSinkType;
-using ::starboard::SbAudioSinkImpl;
-
 // static
 void SbAudioSinkImpl::PlatformInitialize() {
   auto* sink_type = GStreamerAudioSinkType::CreateInstance();
@@ -542,3 +527,5 @@ void SbAudioSinkImpl::PlatformTearDown() {
   GStreamerAudioSinkType::DestroyInstance(
       static_cast<GStreamerAudioSinkType*>(sink_type));
 }
+
+}  // namespace starboard

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.h
@@ -36,11 +36,7 @@
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 #include "third_party/starboard/rdk/shared/log_override.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace audio_sink {
 
 class GStreamerAudioSinkType : public SbAudioSinkPrivate::Type {
  public:
@@ -78,10 +74,6 @@ class GStreamerAudioSinkType : public SbAudioSinkPrivate::Type {
   ~GStreamerAudioSinkType() = default;
 };
 
-}  // namespace audio_sink
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_AUDIO_SINK_GSTREAMER_AUDIO_SINK_TYPE_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type_lifecycle.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type_lifecycle.cc
@@ -30,11 +30,7 @@
 
 #include "third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace audio_sink {
 
 // static
 GStreamerAudioSinkType* GStreamerAudioSinkType::CreateInstance() {
@@ -46,8 +42,4 @@ void GStreamerAudioSinkType::DestroyInstance(GStreamerAudioSinkType* instance) {
   delete instance;
 }
 
-}  // namespace audio_sink
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/configuration.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/configuration.cc
@@ -35,10 +35,7 @@
 
 #include "third_party/starboard/rdk/shared/libcobalt.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 namespace {
 
@@ -54,29 +51,29 @@ const CobaltExtensionConfigurationApi kConfigurationApi = {
     kCobaltExtensionConfigurationName,
     2,
     &CobaltUserOnExitStrategy,
-    &::starboard::CobaltRenderDirtyRegionOnlyDefault,
-    &::starboard::CobaltEglSwapIntervalDefault,
-    &::starboard::CobaltFallbackSplashScreenUrlDefault,
+    &CobaltRenderDirtyRegionOnlyDefault,
+    &CobaltEglSwapIntervalDefault,
+    &CobaltFallbackSplashScreenUrlDefault,
     &CobaltEnableQuic,
-    &::starboard::CobaltSkiaCacheSizeInBytesDefault,
-    &::starboard::CobaltOffscreenTargetCacheSizeInBytesDefault,
-    &::starboard::CobaltEncodedImageCacheSizeInBytesDefault,
-    &::starboard::CobaltImageCacheSizeInBytesDefault,
-    &::starboard::CobaltLocalTypefaceCacheSizeInBytesDefault,
-    &::starboard::CobaltRemoteTypefaceCacheSizeInBytesDefault,
-    &::starboard::CobaltMeshCacheSizeInBytesDefault,
-    &::starboard::CobaltSoftwareSurfaceCacheSizeInBytesDefault,
-    &::starboard::CobaltImageCacheCapacityMultiplierWhenPlayingVideoDefault,
-    &::starboard::CobaltSkiaGlyphAtlasWidthDefault,
-    &::starboard::CobaltSkiaGlyphAtlasHeightDefault,
-    &::starboard::CobaltJsGarbageCollectionThresholdInBytesDefault,
-    &::starboard::CobaltReduceCpuMemoryByDefault,
-    &::starboard::CobaltReduceGpuMemoryByDefault,
-    &::starboard::CobaltGcZealDefault,
-    &::starboard::CobaltRasterizerTypeDefault,
-    &::starboard::CobaltEnableJitDefault,
-    &::starboard::CobaltFallbackSplashScreenTopicsDefault,
-    &::starboard::CobaltCanStoreCompiledJavascriptDefault,
+    &CobaltSkiaCacheSizeInBytesDefault,
+    &CobaltOffscreenTargetCacheSizeInBytesDefault,
+    &CobaltEncodedImageCacheSizeInBytesDefault,
+    &CobaltImageCacheSizeInBytesDefault,
+    &CobaltLocalTypefaceCacheSizeInBytesDefault,
+    &CobaltRemoteTypefaceCacheSizeInBytesDefault,
+    &CobaltMeshCacheSizeInBytesDefault,
+    &CobaltSoftwareSurfaceCacheSizeInBytesDefault,
+    &CobaltImageCacheCapacityMultiplierWhenPlayingVideoDefault,
+    &CobaltSkiaGlyphAtlasWidthDefault,
+    &CobaltSkiaGlyphAtlasHeightDefault,
+    &CobaltJsGarbageCollectionThresholdInBytesDefault,
+    &CobaltReduceCpuMemoryByDefault,
+    &CobaltReduceGpuMemoryByDefault,
+    &CobaltGcZealDefault,
+    &CobaltRasterizerTypeDefault,
+    &CobaltEnableJitDefault,
+    &CobaltFallbackSplashScreenTopicsDefault,
+    &CobaltCanStoreCompiledJavascriptDefault,
 };
 
 }  // namespace
@@ -85,7 +82,4 @@ const void* GetConfigurationApi() {
   return &kConfigurationApi;
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/configuration.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/configuration.h
@@ -31,16 +31,10 @@
 #ifndef THIRD_PARTY_STARBOARD_RDK_SHARED_CONFIGURATION_H_
 #define THIRD_PARTY_STARBOARD_RDK_SHARED_CONFIGURATION_H_
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 const void* GetConfigurationApi();
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_CONFIGURATION_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_create_system.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_create_system.cc
@@ -40,7 +40,7 @@ SbDrmSystem SbDrmCreateSystem(
     return kSbDrmSystemInvalid;
   }
 #if defined(HAS_OCDM)
-  using third_party::starboard::rdk::shared::drm::DrmSystemOcdm;
+  using starboard::DrmSystemOcdm;
   std::string empty;
   if (!DrmSystemOcdm::IsKeySystemSupported(key_system, empty.c_str())) {
     SB_DLOG(WARNING) << "Invalid key system " << key_system;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_destroy_system.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_destroy_system.cc
@@ -40,7 +40,7 @@
 void SbDrmDestroySystem(SbDrmSystem drm_system) {
   if (SbDrmSystemIsValid(drm_system)) {
 #if defined(HAS_OCDM)
-    using third_party::starboard::rdk::shared::drm::DrmSystemOcdm;
+    using starboard::DrmSystemOcdm;
     auto *ocdm = reinterpret_cast<DrmSystemOcdm*>( drm_system );
     ocdm->Invalidate();
     ocdm->Release();

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.cc
@@ -30,11 +30,7 @@
 
 #include "third_party/starboard/rdk/shared/log_override.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace drm {
 namespace {
 
 static pthread_mutex_t g_session_dtor_mutex_ = PTHREAD_MUTEX_INITIALIZER;
@@ -69,8 +65,6 @@ static OcdmGetMetricSystemDataFn g_ocdmGetMetricSystemData { nullptr };
 static OcdmGetMetricsFn g_ocdmGetMetrics { nullptr };
 
 }  // namespace
-
-namespace session {
 
 SbDrmKeyStatus KeyStatus2DrmKeyStatus(KeyStatus status) {
   switch (status) {
@@ -150,7 +144,7 @@ class Session {
     kUpdate,
   };
 
-  ::starboard::ThreadChecker thread_checker_;
+  ThreadChecker thread_checker_;
   Operation operation_{Operation::kNone};
   int ticket_{0};
   DrmSystemOcdm* drm_system_;
@@ -513,10 +507,6 @@ void Session::OnError(struct OpenCDMSession* /*ocdm_session*/,
   }
 }
 
-}  // namespace session
-
-using session::Session;
-
 DrmSystemOcdm::DrmSystemOcdm(
     const char* key_system,
     void* context,
@@ -643,7 +633,7 @@ void DrmSystemOcdm::UpdateServerCertificate(int ticket,
 }
 
 SbDrmSystemPrivate::DecryptStatus DrmSystemOcdm::Decrypt(
-    ::starboard::InputBuffer* buffer) {
+    InputBuffer* buffer) {
   SB_NOTREACHED();
   return kFailure;
 }
@@ -766,7 +756,7 @@ int DrmSystemOcdm::Decrypt(const std::string& id,
                             _GstBuffer* iv,
                             _GstBuffer* key,
                             _GstCaps* caps) {
-  session::Session* session = GetSessionById(id);
+  Session* session = GetSessionById(id);
   if (!session)
     return ERROR_INVALID_SESSION;
   return session->Decrypt(buffer, sub_sample, sub_sample_count, iv, key, caps);
@@ -827,10 +817,6 @@ const void* DrmSystemOcdm::GetMetrics(int* size) {
   return metrics_.data();
 }
 
-}  // namespace drm
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // defined(HAS_OCDM)

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.cc
@@ -632,8 +632,7 @@ void DrmSystemOcdm::UpdateServerCertificate(int ticket,
       "Error");
 }
 
-SbDrmSystemPrivate::DecryptStatus DrmSystemOcdm::Decrypt(
-    InputBuffer* buffer) {
+SbDrmSystemPrivate::DecryptStatus DrmSystemOcdm::Decrypt(InputBuffer* buffer) {
   SB_NOTREACHED();
   return kFailure;
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/drm_system_ocdm.h
@@ -32,17 +32,11 @@ struct _GstCaps;
 struct _GstBuffer;
 struct OpenCDMSystem;
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace drm {
 
-namespace session {
 class Session;
-}
 
-class DrmSystemOcdm : public SbDrmSystemPrivate, public ::starboard::RefCountedThreadSafe<DrmSystemOcdm> {
+class DrmSystemOcdm : public SbDrmSystemPrivate, public RefCountedThreadSafe<DrmSystemOcdm> {
  public:
   class Observer {
    public:
@@ -82,7 +76,7 @@ class DrmSystemOcdm : public SbDrmSystemPrivate, public ::starboard::RefCountedT
                      int key_size,
                      const void* session_id,
                      int session_id_size) override;
-  DecryptStatus Decrypt(::starboard::InputBuffer* buffer) override;
+  DecryptStatus Decrypt(InputBuffer* buffer) override;
   bool IsServerCertificateUpdatable() override { return false; }
   void UpdateServerCertificate(int ticket,
                                const void* certificate,
@@ -110,14 +104,14 @@ class DrmSystemOcdm : public SbDrmSystemPrivate, public ::starboard::RefCountedT
   void Invalidate();
 
  private:
-  session::Session* GetSessionById(const std::string& id);
+  Session* GetSessionById(const std::string& id);
   void AnnounceKeys();
 
   std::set<std::string> GetReadyKeysUnlocked() const;
 
   std::string key_system_;
   void* context_;
-  std::vector<std::unique_ptr<session::Session>> sessions_;
+  std::vector<std::unique_ptr<Session>> sessions_;
 
   const SbDrmSessionUpdateRequestFunc session_update_request_callback_;
   const SbDrmSessionUpdatedFunc session_updated_callback_;
@@ -135,10 +129,6 @@ class DrmSystemOcdm : public SbDrmSystemPrivate, public ::starboard::RefCountedT
   std::vector<uint8_t> metrics_;
 };
 
-}  // namespace drm
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_DRM_DRM_SYSTEM_OCDM_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/gst_decryptor_ocdm.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/gst_decryptor_ocdm.cc
@@ -28,12 +28,7 @@
 
 #include <opencdm/open_cdm.h>
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace drm {
-
 namespace {
 
 G_BEGIN_DECLS
@@ -573,28 +568,15 @@ GstElement *CreateDecryptorElement(const gchar* name) {
   return GST_ELEMENT ( g_object_new (COBALT_OCDM_DECRYPTOR_TYPE, name) );
 }
 
-}  // namespace drm
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #else  //defined(HAS_OCDM)
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace drm {
-
 GstElement *CreateDecryptorElement(const gchar* name) {
   return nullptr;
 }
 
-}  // namespace drm
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  //defined(HAS_OCDM)

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/gst_decryptor_ocdm.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/drm/gst_decryptor_ocdm.h
@@ -19,18 +19,9 @@
 
 #include <gst/gst.h>
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace drm {
-
 GstElement *CreateDecryptorElement(const gchar* name);
 
-}  // namespace drm
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_DRM_GST_DECRYPTOR_OCDM_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/ess_input.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/ess_input.cc
@@ -424,7 +424,7 @@ void EssInput::CreateKey(unsigned int key, SbInputEventType type, unsigned int m
   data->key_location = KeyCodeToSbKeyLocation(key);
   data->key_modifiers = modifiers;
 
-  Application::Get()->InjectInputEvent(data);
+  ApplicationRdk::Get()->InjectInputEvent(data);
 
   DeleteRepeatKey();
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/ess_input.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/ess_input.cc
@@ -44,10 +44,7 @@
 #include <linux/input.h>
 #include <cstring>
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 namespace {
 
@@ -513,7 +510,4 @@ void EssInput::OnKeyReleased(unsigned int key) {
   OnKeyboardKey(key, kSbInputEventTypeUnpress);
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/ess_input.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/ess_input.h
@@ -36,10 +36,7 @@
 #include "starboard/event.h"
 #include "starboard/input.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 class EssInput {
 public:
@@ -63,9 +60,6 @@ private:
   int64_t key_repeat_interval_ { 0 };
 };
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_ESS_INPUT_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/get_home_directory.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/get_home_directory.cc
@@ -45,7 +45,7 @@ bool GetHomeDirectory(char* out_path, int path_size) {
 
   const char* home_directory = getenv("HOME");
   if (home_directory) {
-    ::starboard::strlcpy<char>(out_path, home_directory, path_size);
+    strlcpy<char>(out_path, home_directory, path_size);
     return true;
   }
 
@@ -63,7 +63,7 @@ bool GetHomeDirectory(char* out_path, int path_size) {
     return false;
   }
 
-  ::starboard::strlcpy<char>(out_path, passwd.pw_dir, path_size);
+  strlcpy<char>(out_path, passwd.pw_dir, path_size);
   delete[] buffer;
   return true;
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/graphics.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/graphics.cc
@@ -18,8 +18,6 @@
 #include "starboard/extension/graphics.h"
 
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 namespace {
 
@@ -49,6 +47,4 @@ const void* GetGraphicsApi() {
   return &kGraphicsApi;
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/graphics.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/graphics.h
@@ -19,13 +19,9 @@
 #define STARBOARD_RDK_SHARED_GRAPHICS_H_
 
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 const void* GetGraphicsApi();
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
 
 #endif // STARBOARD_RDK_SHARED_GRAPHICS_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/hang_detector.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/hang_detector.cc
@@ -39,10 +39,7 @@
 using namespace std::chrono_literals;
 using namespace std::chrono;
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 namespace {
 
@@ -104,7 +101,7 @@ seconds get_check_interval() {
 struct HangDetector
 {
   static void* ThreadEntryPoint(void* context) {
-    setpriority(PRIO_PROCESS, 0, ::starboard::SbPriorityToNice(kSbThreadNoPriority));
+    setpriority(PRIO_PROCESS, 0, SbPriorityToNice(kSbThreadNoPriority));
     SB_DCHECK(context);
     static_cast<HangDetector*>(context)->DoWork();
     return nullptr;
@@ -244,7 +241,4 @@ void HangMonitor::Reset() {
   tid_ = get_tid();
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/hang_detector.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/hang_detector.h
@@ -21,10 +21,7 @@
 #include <sys/types.h>
 #include <chrono>
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 class HangMonitor {
 public:
@@ -49,10 +46,7 @@ private:
   pid_t tid_ { 0 };
 };
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_HANG_DETECTOR_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/libcobalt.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/libcobalt.cc
@@ -26,7 +26,7 @@
 #include "third_party/starboard/rdk/shared/rdkservices.h"
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
-using namespace third_party::starboard::rdk::shared;
+using namespace starboard;
 
 namespace
 {
@@ -176,11 +176,11 @@ private:
   void RequestAndWait(void (Application::*action)(void*, Application::EventHandledCallback)) {
     std::unique_lock lock(mutex_);
     if (WaitForApp(lock) == kRunning) {
-      starboard::Semaphore sem;
+      Semaphore sem;
       (Application::Get()->*action)(
         &sem,
         [](void* ctx) {
-          reinterpret_cast<starboard::Semaphore*>(ctx)->Put();
+          reinterpret_cast<Semaphore*>(ctx)->Put();
         });
       lock.unlock();
       sem.Take();
@@ -204,12 +204,7 @@ SB_ONCE_INITIALIZE_FUNCTION(APIContext, GetContext);
 
 }  // namespace
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace libcobalt_api {
-
 void Initialize()
 {
   GetContext()->OnInitialize();
@@ -220,11 +215,7 @@ void Teardown()
   GetContext()->OnTeardown();
 }
 
-}  // namespace libcobalt_api
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 extern "C" {
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/libcobalt.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/libcobalt.cc
@@ -26,10 +26,13 @@
 #include "third_party/starboard/rdk/shared/rdkservices.h"
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
-using namespace starboard;
-
 namespace
 {
+using ::starboard::Accessibility;
+using ::starboard::AdvertisingId;
+using ::starboard::ApplicationRdk;
+using ::starboard::Semaphore;
+using ::starboard::SystemProperties;
 
 struct APIContext
 {
@@ -40,7 +43,7 @@ struct APIContext
   void OnInitialize()
   {
     std::lock_guard lock(mutex_);
-    SB_CHECK(nullptr != Application::Get());
+    SB_CHECK(ApplicationRdk::Get());
     state_ = kRunning;
     condition_.notify_all();
   }
@@ -55,20 +58,20 @@ struct APIContext
   {
     std::unique_lock lock(mutex_);
     if (WaitForApp(lock) == kRunning) {
-      Application::Get()->Link(link);
+      ApplicationRdk::Get()->Link(link);
     }
   }
 
   void RequestFreeze() {
-    RequestAndWait(&Application::Freeze);
+    RequestAndWait(&ApplicationRdk::Freeze);
   }
 
   void RequestFocus() {
-    RequestAndWait(&Application::Focus);
+    RequestAndWait(&ApplicationRdk::Focus);
   }
 
   void RequestBlur() {
-    RequestAndWait(&Application::Blur);
+    RequestAndWait(&ApplicationRdk::Blur);
   }
 
   void RequestQuit()
@@ -77,7 +80,7 @@ struct APIContext
     stop_request_cb_ = nullptr;
     stop_request_cb_data_ = nullptr;
     if (state_ == kRunning)
-        Application::Get()->Stop(0);
+        ApplicationRdk::Get()->Stop(/*error_level=*/0);
   }
 
   void SetStopRequestHandler(SbRdkCallbackFunc cb, void* user_data)
@@ -132,7 +135,8 @@ struct APIContext
     if (should_invoke_default) {
       std::lock_guard lock(mutex_);
       if (state_ == kRunning) {
-        Application::Get()->Conceal(NULL, NULL);
+        ApplicationRdk::Get()->Conceal(
+            /*context=*/nullptr, /*callback=*/nullptr);
       }
     }
   }
@@ -173,11 +177,13 @@ private:
     return state_;
   }
 
-  void RequestAndWait(void (Application::*action)(void*, Application::EventHandledCallback)) {
+  void RequestAndWait(
+      void (ApplicationRdk::*action)(
+          void*, ApplicationRdk::EventHandledCallback)) {
     std::unique_lock lock(mutex_);
     if (WaitForApp(lock) == kRunning) {
       Semaphore sem;
-      (Application::Get()->*action)(
+      (ApplicationRdk::Get()->*action)(
         &sem,
         [](void* ctx) {
           reinterpret_cast<Semaphore*>(ctx)->Put();

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/linux_key_mapping.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/linux_key_mapping.cc
@@ -40,10 +40,7 @@ ENUM_CONVERSION_END(SbKeyModifiers);
 
 }
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 namespace {
 
@@ -265,7 +262,4 @@ void LinuxKeyMapping::MapKeyCodeAndModifiers(uint32_t& key_code, uint32_t& modif
   GetLinuxKeyMapping()->MapKeyCodeAndModifiers(key_code, modifiers);
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/linux_key_mapping.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/linux_key_mapping.h
@@ -23,19 +23,13 @@
 
 #include <string>
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 class LinuxKeyMapping {
 public:
   static void MapKeyCodeAndModifiers(uint32_t& key_code, uint32_t& modifiers);
 };
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_LINUXKEYMAPPING_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/gst_media_utils.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/gst_media_utils.cc
@@ -28,11 +28,7 @@
 #include "third_party/starboard/rdk/shared/media/gst_media_utils.h"
 #include "third_party/starboard/rdk/shared/log_override.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace media {
 namespace {
 
 GST_DEBUG_CATEGORY(cobalt_gst_media_utils);
@@ -448,8 +444,4 @@ GstCaps* CodecToGstCaps(SbMediaAudioCodec codec, const SbMediaAudioStreamInfo* i
 
 }
 
-}  // namespace media
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/gst_media_utils.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/gst_media_utils.h
@@ -24,21 +24,13 @@
 
 typedef struct _GstCaps GstCaps;
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace media {
 
 bool GstRegistryHasElementForMediaType(SbMediaVideoCodec codec);
 bool GstRegistryHasElementForMediaType(SbMediaAudioCodec codec);
 GstCaps* CodecToGstCaps(SbMediaAudioCodec codec, const SbMediaAudioStreamInfo* info = nullptr);
 GstCaps* CodecToGstCaps(SbMediaVideoCodec codec);
 
-}  // namespace media
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_MEDIA_GST_MEDIA_UTILS_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_get_audio_configuration.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_get_audio_configuration.cc
@@ -36,5 +36,5 @@
 bool SbMediaGetAudioConfiguration(
     int output_index,
     SbMediaAudioConfiguration* out_configuration) {
-  return third_party::starboard::rdk::shared::DeviceInfo::GetAudioConfiguration(output_index, out_configuration);
+  return starboard::DeviceInfo::GetAudioConfiguration(output_index, out_configuration);
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_is_audio_supported.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_is_audio_supported.cc
@@ -41,8 +41,7 @@ bool MediaIsAudioSupported(SbMediaAudioCodec audio_codec,
                              const MimeType* content_type,
                              int64_t bitrate) {
     return bitrate < kSbMediaMaxAudioBitrateInBitsPerSecond &&
-         third_party::starboard::rdk::shared::media::
-             GstRegistryHasElementForMediaType(audio_codec);
+           GstRegistryHasElementForMediaType(audio_codec);
 }
 
 }  // namespace starboard

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_is_key_system_supported.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_is_key_system_supported.cc
@@ -98,7 +98,6 @@ bool MediaIsKeySystemSupported(SbMediaVideoCodec video_codec,
                                   SbMediaAudioCodec audio_codec,
                                   const char* key_system) {
 #if defined(HAS_OCDM)
-  using third_party::starboard::rdk::shared::drm::DrmSystemOcdm;
   return DrmSystemOcdm::IsKeySystemSupported(
       key_system, CodecToMimeType(video_codec).c_str()) &&
       DrmSystemOcdm::IsKeySystemSupported(

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_is_video_supported.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/media/media_is_video_supported.cc
@@ -39,8 +39,6 @@
 #include "third_party/starboard/rdk/shared/rdkservices.h"
 #include "third_party/starboard/rdk/shared/log_override.h"
 
-using third_party::starboard::rdk::shared::DisplayInfo;
-
 namespace starboard {
 
 bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
@@ -87,8 +85,7 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
   }
 
   return bitrate <= kSbMediaMaxVideoBitrateInBitsPerSecond && fps <= 60 &&
-         third_party::starboard::rdk::shared::media::
-             GstRegistryHasElementForMediaType(video_codec);
+         GstRegistryHasElementForMediaType(video_codec);
 }
 
 }  // namespace starboard

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/platform_service.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/platform_service.cc
@@ -53,10 +53,7 @@ typedef struct CobaltExtensionPlatformServicePrivate {
                      bool* invalid_state) = 0;
 } CobaltExtensionPlatformServicePrivate;
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 namespace {
 
@@ -138,7 +135,4 @@ const void* GetPlatformServiceApi() {
   return &kPlatformServiceApi;
 }
 
-}  // namespace thirdpary
 }  // namespace starboard
-}  // namespace rdk
-}  // namespace shared

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/platform_service.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/platform_service.h
@@ -31,16 +31,10 @@
 #ifndef THIRD_PARTY_STARBOARD_RDK_SHARED_PLATFORM_SERVICE_H_
 #define THIRD_PARTY_STARBOARD_RDK_SHARED_PLATFORM_SERVICE_H_
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 const void* GetPlatformServiceApi();
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_PLATFORM_SERVICE_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/elements/gst_audio_clipping.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/elements/gst_audio_clipping.cc
@@ -20,13 +20,7 @@
 #include <gst/base/gstbasetransform.h>
 #include <gst/audio/audio.h>
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace player {
-namespace elements {
-
 namespace {
 
 G_BEGIN_DECLS
@@ -137,9 +131,4 @@ GstElement *CreateAudioClippingElement(const gchar* name) {
   return GST_ELEMENT ( g_object_new (COBALT_AUDIO_CLIPPING_TYPE, name) );
 }
 
-}  // namespace elements
-}  // namespace player
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/elements/gst_audio_clipping.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/elements/gst_audio_clipping.h
@@ -18,18 +18,7 @@
 
 #include <gst/gst.h>
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace player {
-namespace elements {
-
 GstElement *CreateAudioClippingElement(const gchar* name);
 
-}  // namespace elements
-}  // namespace player
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_create.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_create.cc
@@ -65,15 +65,13 @@ SbPlayerCreate(SbWindow window,
   }
 
   if (audio_codec != kSbMediaAudioCodecNone &&
-      !third_party::starboard::rdk::shared::media::
-      GstRegistryHasElementForMediaType(audio_codec)) {
+      !starboard::GstRegistryHasElementForMediaType(audio_codec)) {
     SB_LOG(ERROR) << "Unsupported audio codec " << audio_codec;
     return kSbPlayerInvalid;
   }
 
   if (video_codec != kSbMediaVideoCodecNone &&
-      !third_party::starboard::rdk::shared::media::
-      GstRegistryHasElementForMediaType(video_codec)) {
+      !starboard::GstRegistryHasElementForMediaType(video_codec)) {
     SB_LOG(ERROR) << "Unsupported video codec " << video_codec;
     return kSbPlayerInvalid;
   }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -1513,7 +1513,6 @@ PlayerImpl::PlayerImpl(SbPlayer player,
 
   if (drm_system_) {
 #if defined(HAS_OCDM)
-    using DrmSystemOcdm;
     reinterpret_cast<DrmSystemOcdm*>( drm_system_ )->AddRef();
 #endif
     GstContext* context = gst_context_new("cobalt-drm-system", FALSE);
@@ -1579,7 +1578,6 @@ PlayerImpl::~PlayerImpl() {
   g_object_unref(pipeline_);
   if (drm_system_) {
 #if defined(HAS_OCDM)
-    using DrmSystemOcdm;
     reinterpret_cast<DrmSystemOcdm*>( drm_system_ )->Release();
 #endif
   }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -57,12 +57,7 @@
 #endif
 #include "third_party/starboard/rdk/shared/player/elements/gst_audio_clipping.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace player {
-
 static constexpr int kMaxNumberOfSamplesPerWrite = 1;
 static const char kCustomInstantRateChangeEventName[] = "custom-instant-rate-change";
 static const char kDidReceiveFirstSegmentMsgName[] = "did-receive-first-segment";
@@ -72,9 +67,6 @@ static const char kDidReachBufferingTargetMsgName[] = "did-reach-buffering-targe
 int Player::MaxNumberOfSamplesPerWrite() {
   return kMaxNumberOfSamplesPerWrite;
 }
-
-using third_party::starboard::rdk::shared::drm::CreateDecryptorElement;
-using third_party::starboard::rdk::shared::media::CodecToGstCaps;
 
 // **************************** GST/GLIB Helpers **************************** //
 
@@ -1515,13 +1507,13 @@ PlayerImpl::PlayerImpl(SbPlayer player,
   }
 
   if (audio_codec_ == kSbMediaAudioCodecPcm) {
-    GstElement* filter = elements::CreateAudioClippingElement(nullptr);
+    GstElement* filter = CreateAudioClippingElement(nullptr);
     g_object_set(pipeline_, "audio-filter", filter, nullptr);
   }
 
   if (drm_system_) {
 #if defined(HAS_OCDM)
-    using third_party::starboard::rdk::shared::drm::DrmSystemOcdm;
+    using DrmSystemOcdm;
     reinterpret_cast<DrmSystemOcdm*>( drm_system_ )->AddRef();
 #endif
     GstContext* context = gst_context_new("cobalt-drm-system", FALSE);
@@ -1587,7 +1579,7 @@ PlayerImpl::~PlayerImpl() {
   g_object_unref(pipeline_);
   if (drm_system_) {
 #if defined(HAS_OCDM)
-    using third_party::starboard::rdk::shared::drm::DrmSystemOcdm;
+    using DrmSystemOcdm;
     reinterpret_cast<DrmSystemOcdm*>( drm_system_ )->Release();
 #endif
   }
@@ -1791,7 +1783,7 @@ gboolean PlayerImpl::HandleBusMessage(GstBus* bus, GstMessage* message) {
 
 // static
 void* PlayerImpl::ThreadEntryPoint(void* context) {
-  setpriority(PRIO_PROCESS, 0, ::starboard::SbPriorityToNice(kSbThreadPriorityRealTime));
+  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(kSbThreadPriorityRealTime));
   SB_DCHECK(context);
   GST_TRACE("%d", SbThreadGetId());
 
@@ -3158,22 +3150,16 @@ void PlayerImpl::AudioConfigurationChanged() {
 }  // namespace
 
 void ForceStop() {
-  using third_party::starboard::rdk::shared::player::GetPlayerRegistry;
   GetPlayerRegistry()->ForceStop();
 }
 
 void AudioConfigurationChanged() {
-  using third_party::starboard::rdk::shared::player::GetPlayerRegistry;
   GetPlayerRegistry()->AudioConfigurationChanged();
 }
 
-}  // namespace player
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
-using third_party::starboard::rdk::shared::player::PlayerImpl;
+using ::starboard::PlayerImpl;
 
 SbPlayerPrivate::SbPlayerPrivate(
     SbWindow window,
@@ -3189,7 +3175,7 @@ SbPlayerPrivate::SbPlayerPrivate(
     void* context,
     SbPlayerOutputMode output_mode,
     SbDecodeTargetGraphicsContextProvider* provider) {
-  if ( third_party::starboard::rdk::shared::player::GetPlayerRegistry()->CanCreate(max_video_capabilities) ) {
+  if (starboard::GetPlayerRegistry()->CanCreate(max_video_capabilities)) {
     player_.reset(
       new PlayerImpl(this,
                      window,

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.h
@@ -21,12 +21,7 @@
 
 #include "starboard/player.h"
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
-namespace player {
-
 struct SB_EXPORT Player {
   virtual ~Player() {}
   static int MaxNumberOfSamplesPerWrite();
@@ -44,11 +39,7 @@ struct SB_EXPORT Player {
 void ForceStop();
 void AudioConfigurationChanged();
 
-}  // namespace player
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 struct SbPlayerPrivate {
   SbPlayerPrivate(SbWindow window,
@@ -67,11 +58,11 @@ struct SbPlayerPrivate {
   ~SbPlayerPrivate() {}
 
   int MaxNumberOfSamplesPerWrite() const {
-    using third_party::starboard::rdk::shared::player::Player;
+    using Player;
     return Player::MaxNumberOfSamplesPerWrite();
   }
 
-  std::unique_ptr<third_party::starboard::rdk::shared::player::Player> player_;
+  std::unique_ptr<Player> player_;
 };
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_PLAYER_PLAYER_INTERNAL_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.h
@@ -58,11 +58,10 @@ struct SbPlayerPrivate {
   ~SbPlayerPrivate() {}
 
   int MaxNumberOfSamplesPerWrite() const {
-    using Player;
-    return Player::MaxNumberOfSamplesPerWrite();
+    return starboard::Player::MaxNumberOfSamplesPerWrite();
   }
 
-  std::unique_ptr<Player> player_;
+  std::unique_ptr<starboard::Player> player_;
 };
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_PLAYER_PLAYER_INTERNAL_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.cc
@@ -409,9 +409,9 @@ public:
       notify_on_change &= (is_voice_guidance_enabled_ != enabled);
       is_voice_guidance_enabled_ = enabled;
     }
-    if (notify_on_change && Application::Get()) {
+    if (notify_on_change && ApplicationRdk::Get()) {
       SB_LOG(INFO) << "Accessibility voice guidance setting changed, enabled = " << enabled;
-      Application::Get()->InjectAccessibilityTextToSpeechSettingsChanged(enabled);
+      ApplicationRdk::Get()->InjectAccessibilityTextToSpeechSettingsChanged(enabled);
     }
   }
 
@@ -1005,7 +1005,7 @@ void DisplayInfoImpl::OnUpdated(const Core::JSON::String&) {
     SbEventSchedule([](void* data) {
       // Clear mime cache until display info is updated
       MimeSupportabilityCache::GetInstance()->ClearCachedMimeSupportabilities();
-      Application::Get()->DisplayInfoChanged();
+      ApplicationRdk::Get()->DisplayInfoChanged();
     }, nullptr, 0);
   }
 }
@@ -1122,9 +1122,9 @@ private:
       if (is_connected_.load() != has_connected_interface) {
         is_connected_.store(has_connected_interface);
         if (has_connected_interface)
-          Application::Get()->InjectOsNetworkConnectedEvent();
+          ApplicationRdk::Get()->InjectOsNetworkConnectedEvent();
         else
-          Application::Get()->InjectOsNetworkDisconnectedEvent();
+          ApplicationRdk::Get()->InjectOsNetworkDisconnectedEvent();
       }
     }
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.cc
@@ -58,10 +58,7 @@ MODULE_NAME_DECLARATION(BUILD_REFERENCE);
 
 using namespace  WPEFramework;
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 namespace {
 
@@ -814,7 +811,7 @@ struct AuthServiceImpl {
     }
 
     // Try to read directly from file
-    ::starboard::ScopedFile file(kAuthServiceExperienceFile, O_RDONLY);
+    ScopedFile file(kAuthServiceExperienceFile, O_RDONLY);
     if ( file.IsValid() ) {
       const int kBufferSize = 128;
       char buffer[kBufferSize];
@@ -989,7 +986,6 @@ void DisplayInfoImpl::Refresh() {
 
   if (needs_refresh) {
     SbEventSchedule([](void* data) {
-      using ::starboard::MimeSupportabilityCache;
       MimeSupportabilityCache::GetInstance()->ClearCachedMimeSupportabilities();
       GetDisplayInfo()->ForceNeedsRefresh();
     }, nullptr, kSbTimeSecond);
@@ -1007,7 +1003,6 @@ void DisplayInfoImpl::OnUpdated(const Core::JSON::String&) {
   if (needs_refresh_.load() == false) {
     needs_refresh_.store(true);
     SbEventSchedule([](void* data) {
-      using ::starboard::MimeSupportabilityCache;
       // Clear mime cache until display info is updated
       MimeSupportabilityCache::GetInstance()->ClearCachedMimeSupportabilities();
       Application::Get()->DisplayInfoChanged();
@@ -1351,7 +1346,7 @@ void DeviceInfoImpl::OnBluetoothStatusChanged(const StatusChangedData& data) {
   // Interrupt player only if new wireless device got connected
   if (data.Connected.Value() && !hasBluetoothConnector()) {
     SbEventSchedule([](void*) {
-      player::AudioConfigurationChanged();
+      AudioConfigurationChanged();
     }, nullptr, 0);
   }
 }
@@ -1438,7 +1433,7 @@ void DeviceInfoImpl::Refresh() {
 
   SB_LOG(INFO) << "Updated audio configuration:";
   for (const auto& config : audio_configs) {
-    SB_LOG(INFO) << " connector: " << (uint32_t) config.connector << " (" << ::starboard::GetMediaAudioConnectorName(config.connector) << ")";
+    SB_LOG(INFO) << " connector: " << (uint32_t) config.connector << " (" << GetMediaAudioConnectorName(config.connector) << ")";
   }
 
   std::lock_guard lock(mutex_);
@@ -1784,7 +1779,4 @@ void TeardownJSONRPCLink() {
   GetUserSettings()->Teardown();
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/rdkservices.h
@@ -26,10 +26,7 @@ struct SbAccessibilityCaptionSettings;
 struct SbAccessibilityDisplaySettings;
 struct SbMediaAudioConfiguration;
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 struct ResolutionInfo {
   ResolutionInfo() {}
@@ -120,9 +117,6 @@ public:
 
 void TeardownJSONRPCLink();
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 #endif  // THIRD_PARTY_STARBOARD_RDK_SHARED_RDKSERVICES_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
@@ -49,10 +49,7 @@
 #include "starboard/elf_loader/elf_loader_constants.h"
 #endif
 
-namespace third_party {
 namespace starboard {
-namespace rdk {
-namespace shared {
 
 static struct sigaction old_actions[2];
 
@@ -74,10 +71,7 @@ static void UninstallStopSignalHandlers() {
   ::sigaction(SIGTERM, &old_actions[1], nullptr);
 }
 
-}  // namespace shared
-}  // namespace rdk
 }  // namespace starboard
-}  // namespace third_party
 
 int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
   tzset();
@@ -87,20 +81,20 @@ int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
   stack_size.rlim_cur = 2 * 1024 * 1024;
   setrlimit(RLIMIT_STACK, &stack_size);
 
-  starboard::InstallSuspendSignalHandlers();
-  third_party::starboard::rdk::shared::InstallStopSignalHandlers();
+  InstallSuspendSignalHandlers();
+  InstallStopSignalHandlers();
 
   GError* error = NULL;
   gst_init_check(NULL, NULL, &error);
   g_free(error);
 
-  third_party::starboard::rdk::shared::Application application(callback);
+  Application application(callback);
   int result = application.Run(argc, argv);
 
   gst_deinit();
 
-  third_party::starboard::rdk::shared::UninstallStopSignalHandlers();
-  starboard::UninstallSuspendSignalHandlers();
+  UninstallStopSignalHandlers();
+  UninstallSuspendSignalHandlers();
 
   return result;
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
@@ -81,20 +81,20 @@ int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
   stack_size.rlim_cur = 2 * 1024 * 1024;
   setrlimit(RLIMIT_STACK, &stack_size);
 
-  InstallSuspendSignalHandlers();
-  InstallStopSignalHandlers();
+  starboard::InstallSuspendSignalHandlers();
+  starboard::InstallStopSignalHandlers();
 
   GError* error = NULL;
   gst_init_check(NULL, NULL, &error);
   g_free(error);
 
-  Application application(callback);
+  starboard::ApplicationRdk application(callback);
   int result = application.Run(argc, argv);
 
   gst_deinit();
 
-  UninstallStopSignalHandlers();
-  UninstallSuspendSignalHandlers();
+  starboard::UninstallStopSignalHandlers();
+  starboard::UninstallSuspendSignalHandlers();
 
   return result;
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/speech/accessibility_get_text_to_speech_settings.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/speech/accessibility_get_text_to_speech_settings.cc
@@ -44,7 +44,7 @@ bool SbAccessibilityGetTextToSpeechSettings(
   }
   out_setting->has_text_to_speech_setting = true;
   out_setting->is_text_to_speech_enabled =
-      third_party::starboard::rdk::shared::TextToSpeech::IsEnabled();
+      starboard::TextToSpeech::IsEnabled();
   return true;
 }
 #endif

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/speech/accessibility_get_text_to_speech_settings.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/speech/accessibility_get_text_to_speech_settings.cc
@@ -43,8 +43,7 @@ bool SbAccessibilityGetTextToSpeechSettings(
     return false;
   }
   out_setting->has_text_to_speech_setting = true;
-  out_setting->is_text_to_speech_enabled =
-      starboard::TextToSpeech::IsEnabled();
+  out_setting->is_text_to_speech_enabled = starboard::TextToSpeech::IsEnabled();
   return true;
 }
 #endif

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/speech/speech_synthesis_cancel.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/speech/speech_synthesis_cancel.cc
@@ -32,5 +32,5 @@
 #include "third_party/starboard/rdk/shared/rdkservices.h"
 
 void SbSpeechSynthesisCancel() {
-  third_party::starboard::rdk::shared::TextToSpeech::Cancel();
+  starboard::TextToSpeech::Cancel();
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/speech/speech_synthesis_speak.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/speech/speech_synthesis_speak.cc
@@ -34,5 +34,5 @@
 void SbSpeechSynthesisSpeak(const char* text) {
   if (!text)
     return;
-  third_party::starboard::rdk::shared::TextToSpeech::Speak(text);
+  starboard::TextToSpeech::Speak(text);
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_egl.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_egl.cc
@@ -141,7 +141,7 @@ SbEglSurface SbEglCreateWindowSurface(SbEglDisplay dpy,
 
 SbEglDisplay SbEglGetDisplay(SbEglNativeDisplayType display_id) {
   NativeDisplayType display_type;
-  EssCtx *ctx = third_party::starboard::rdk::shared::Application::Get()->GetEssCtx();
+  EssCtx *ctx = starboard::Application::Get()->GetEssCtx();
 
   if (EssContextGetEGLDisplayType(ctx, &display_type) == false) {
     SB_LOG(ERROR) << "EssContextGetEGLDisplayType failed! Going to try display_id=" << display_id << '.';

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_egl.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_egl.cc
@@ -141,7 +141,7 @@ SbEglSurface SbEglCreateWindowSurface(SbEglDisplay dpy,
 
 SbEglDisplay SbEglGetDisplay(SbEglNativeDisplayType display_id) {
   NativeDisplayType display_type;
-  EssCtx *ctx = starboard::Application::Get()->GetEssCtx();
+  EssCtx *ctx = starboard::ApplicationRdk::Get()->GetEssCtx();
 
   if (EssContextGetEGLDisplayType(ctx, &display_type) == false) {
     SB_LOG(ERROR) << "EssContextGetEGLDisplayType failed! Going to try display_id=" << display_id << '.';

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
@@ -69,16 +69,16 @@ const void* SbSystemGetExtension(const char* name) {
   }
 #endif
   if (strcmp(name, kCobaltExtensionConfigurationName) == 0) {
-    return third_party::starboard::rdk::shared::GetConfigurationApi();
+    return starboard::GetConfigurationApi();
   }
   else if (strcmp(name, kCobaltExtensionGraphicsName) == 0) {
-    return starboard::rdk::shared::GetGraphicsApi();
+    return starboard::GetGraphicsApi();
   }
   else if (strcmp(name, kCobaltExtensionPlatformServiceName) == 0) {
-    return third_party::starboard::rdk::shared::GetPlatformServiceApi();
+    return starboard::GetPlatformServiceApi();
   }
   if (strcmp(name, kStarboardExtensionAccessibilityName) == 0) {
-    return third_party::starboard::rdk::shared::GetAccessibilityApi();
+    return starboard::GetAccessibilityApi();
   }
   return NULL;
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_property.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_property.cc
@@ -43,7 +43,7 @@
 #include "third_party/starboard/rdk/shared/rdkservices.h"
 #include "third_party/starboard/rdk/shared/log_override.h"
 
-using namespace third_party::starboard::rdk::shared;
+using namespace starboard;
 
 namespace {
 
@@ -212,7 +212,7 @@ bool GetCertificationScope(char* out_value, int value_length) {
   if ( cert_scope_file_name == nullptr )
     cert_scope_file_name = "/opt/drm/0681000006810001.bin";
 
-  ::starboard::ScopedFile file(cert_scope_file_name, O_RDONLY);
+  starboard::ScopedFile file(cert_scope_file_name, O_RDONLY);
   if ( !file.IsValid() ) {
     SB_LOG(INFO) << "Cannot open cert scope file '" << cert_scope_file_name << "'";
     return false;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_property.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_property.cc
@@ -43,9 +43,12 @@
 #include "third_party/starboard/rdk/shared/rdkservices.h"
 #include "third_party/starboard/rdk/shared/log_override.h"
 
-using namespace starboard;
-
 namespace {
+using ::starboard::AdvertisingId;
+using ::starboard::AuthService;
+using ::starboard::DeviceIdentification;
+using ::starboard::DeviceInfo;
+using ::starboard::SystemProperties;
 
 const char kPlatformName[] = "Linux";
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_network_is_disconnected.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_network_is_disconnected.cc
@@ -33,7 +33,7 @@
 #include "starboard/event.h"
 #include "third_party/starboard/rdk/shared/rdkservices.h"
 
-using third_party::starboard::rdk::shared::NetworkInfo;
+using starboard::NetworkInfo;
 
 bool SbSystemNetworkIsDisconnected() {
   return NetworkInfo::IsDisconnected();

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_sign_with_certification_secret_key.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_sign_with_certification_secret_key.cc
@@ -72,7 +72,7 @@ bool SbSystemSignWithCertificationSecretKey(const uint8_t* message,
   using CryptographyVault = cryptographyvault;
 #endif
 
-  third_party::starboard::rdk::shared::HangMonitor hang_monitor(__func__);
+  starboard::HangMonitor hang_monitor(__func__);
 
   std::string key_name;
   const char *env = std::getenv("COBALT_CERT_KEY_NAME");

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_create.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_create.cc
@@ -34,6 +34,6 @@
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
 SbWindow SbWindowCreate(const SbWindowOptions* options) {
-  return third_party::starboard::rdk::shared::Application::Get()->CreateSbWindow(
+  return starboard::Application::Get()->CreateSbWindow(
       options);
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_create.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_create.cc
@@ -34,6 +34,6 @@
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
 SbWindow SbWindowCreate(const SbWindowOptions* options) {
-  return starboard::Application::Get()->CreateSbWindow(
+  return starboard::ApplicationRdk::Get()->CreateSbWindow(
       options);
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_destroy.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_destroy.cc
@@ -34,6 +34,6 @@
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
 bool SbWindowDestroy(SbWindow window) {
-  return third_party::starboard::rdk::shared::Application::Get()->DestroySbWindow(
+  return starboard::Application::Get()->DestroySbWindow(
       window);
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_destroy.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_destroy.cc
@@ -34,6 +34,6 @@
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
 bool SbWindowDestroy(SbWindow window) {
-  return starboard::Application::Get()->DestroySbWindow(
+  return starboard::ApplicationRdk::Get()->DestroySbWindow(
       window);
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_internal.cc
@@ -33,7 +33,9 @@
 #include "third_party/starboard/rdk/shared/window/window_internal.h"
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
-using namespace starboard;
+
+using ::starboard::ApplicationRdk;
+using ::starboard::DisplayInfo;
 
 SbWindowPrivate::SbWindowPrivate(const SbWindowOptions* /* options */) { }
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_internal.cc
@@ -33,7 +33,7 @@
 #include "third_party/starboard/rdk/shared/window/window_internal.h"
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
-using namespace third_party::starboard::rdk::shared;
+using namespace starboard;
 
 SbWindowPrivate::SbWindowPrivate(const SbWindowOptions* /* options */) { }
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/window/window_internal.cc
@@ -40,20 +40,20 @@ SbWindowPrivate::SbWindowPrivate(const SbWindowOptions* /* options */) { }
 SbWindowPrivate::~SbWindowPrivate() = default;
 
 void* SbWindowPrivate::Native() const {
-  return reinterpret_cast<void*>(Application::Get()->GetNativeWindow());
+  return reinterpret_cast<void*>(ApplicationRdk::Get()->GetNativeWindow());
 }
 
 int SbWindowPrivate::Width() const {
-  return Application::Get()->GetWindowWidth();
+  return ApplicationRdk::Get()->GetWindowWidth();
 }
 
 int SbWindowPrivate::Height() const {
-  return Application::Get()->GetWindowHeight();
+  return ApplicationRdk::Get()->GetWindowHeight();
 }
 
 float SbWindowPrivate::VideoPixelRatio() const {
   auto resolution_info = DisplayInfo::GetResolution();
-  int window_height = Application::Get()->GetWindowHeight();
+  int window_height = ApplicationRdk::Get()->GetWindowHeight();
   float ratio = resolution_info.Height / static_cast<float>(window_height);
   float max_ratio = ( window_height < 1080 )
     ? 1.5f : ( resolution_info.Height <= 2160 ? 2.f : 4.f );


### PR DESCRIPTION
Flatten the deeply nested namespace `third_party::starboard::rdk::shared` to a single-level `namespace starboard` in `starboard/contrib/rdk/`.

Also removed nested sub-namespaces (`accessibility`, `player`, `elements`, `drm`, `libcobalt_api`) to achieve a fully flattened structure under `namespace starboard`.

Cleaned up redundant prefixes like `starboard::` and sub-namespace prefixes where they are no longer needed.

go/cobalt-flatten-starboard-namespace

Issue: 441955897
