### PR TITLE
evergreen: Add slot selection status to loader app metrics

### DIFF
--- a/cobalt/browser/loader_app_metrics.cc
+++ b/cobalt/browser/loader_app_metrics.cc
@@ -59,6 +59,12 @@ void RecordLoaderAppMetrics() {
     return;
   }
 
+  if (loader_app_metrics->version >= 3) {
+    base::UmaHistogramEnumeration("Cobalt.LoaderApp.SlotSelectionStatus",
+                                  loader_app_metrics->GetSlotSelectionStatus());
+    LOG(INFO) << "Recorded sample for Cobalt.LoaderApp.SlotSelectionStatus";
+  }
+
   if (!loader_app_metrics->GetElfLibraryStoredCompressed()) {
     LOG(INFO) << "LoaderAppMetrics: ELF was not stored compressed. Skipping "
                  "decompression metric.";

--- a/cobalt/browser/loader_app_metrics.cc
+++ b/cobalt/browser/loader_app_metrics.cc
@@ -62,7 +62,6 @@ void RecordLoaderAppMetrics() {
   if (loader_app_metrics->version >= 3) {
     base::UmaHistogramEnumeration("Cobalt.LoaderApp.SlotSelectionStatus",
                                   loader_app_metrics->GetSlotSelectionStatus());
-    LOG(INFO) << "Recorded sample for Cobalt.LoaderApp.SlotSelectionStatus";
   }
 
   if (!loader_app_metrics->GetElfLibraryStoredCompressed()) {

--- a/tools/metrics/histograms/metadata/cobalt/enums.xml
+++ b/tools/metrics/histograms/metadata/cobalt/enums.xml
@@ -44,27 +44,12 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="1" label="Is hung"/>
 </enum>
 
-<enum name="SplashScreenFetchedState">
-  <int value="0" label="Success: Content from builtin"/>
-  <int value="1" label="Success: Content from cache"/>
-  <int value="2"
-      label="Error: content from cache is empty, fallback to builtin."/>
-  <int value="3"
-      label="Error: Content from cache is too large, fallback to builtin."/>
-  <int value="4" label="Error: Failed to read cache, fallback to builtin."/>
-  <int value="5" label="Error: Builtin resource not found."/>
-</enum>
-
-<enum name="VariationsConfigState">
-  <int value="0" label="Config is valid"/>
-  <int value="1" label="Config is expired"/>
-  <int value="2" label="Config is missing timestamp"/>
-</enum>
-
-<enum name="StorageInjectionResult">
-  <int value="0" label="Success"/>
-  <int value="1" label="Error"/>
-  <int value="2" label="Timeout"/>
+<enum name="LocalStorageDatabaseResetReason">
+  <int value="0" label="Failure to open the database"/>
+  <int value="1" label="Schema version mismatch"/>
+  <int value="2" label="Database corruption or read errors"/>
+  <int value="3" label="Excessive commit errors"/>
+  <int value="4" label="Unknown"/>
 </enum>
 
 <enum name="MigrationOutcome">
@@ -81,6 +66,40 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="2" label="Write Failed"/>
 </enum>
 
+<enum name="SlotSelectionStatus">
+  <summary>Possible status of slot selection by the Loader App</summary>
+  <int value="0" label="UNKNOWN"/>
+  <int value="1" label="CURRENT_SLOT"/>
+  <int value="2" label="ROLL_FORWARD"/>
+  <int value="3" label="ROLL_BACK_OUT_OF_RETRIES"/>
+  <int value="4" label="ROLL_BACK_NO_LIB_FILE"/>
+  <int value="5" label="ROLL_BACK_BAD_APP_KEY_FILE"/>
+  <int value="6" label="ROLL_BACK_SLOT_DRAINING"/>
+  <int value="7" label="ROLL_BACK_FAILED_TO_ADOPT"/>
+  <int value="8" label="ROLL_BACK_FAILED_TO_LOAD_COBALT"/>
+  <int value="9" label="ROLL_BACK_FAILED_TO_CHECK_SABI"/>
+  <int value="10" label="ROLL_BACK_FAILED_TO_LOOK_UP_SYMBOLS"/>
+  <int value="11" label="EVERGREEN_LITE"/>
+  <int value="12" label="LOAD_SYS_IMG_FAILED_TO_INIT_INSTALLATION_MANAGER"/>
+</enum>
+
+<enum name="SplashScreenFetchedState">
+  <int value="0" label="Success: Content from builtin"/>
+  <int value="1" label="Success: Content from cache"/>
+  <int value="2"
+      label="Error: content from cache is empty, fallback to builtin."/>
+  <int value="3"
+      label="Error: Content from cache is too large, fallback to builtin."/>
+  <int value="4" label="Error: Failed to read cache, fallback to builtin."/>
+  <int value="5" label="Error: Builtin resource not found."/>
+</enum>
+
+<enum name="StorageInjectionResult">
+  <int value="0" label="Success"/>
+  <int value="1" label="Error"/>
+  <int value="2" label="Timeout"/>
+</enum>
+
 <enum name="StorageReadResult">
   <int value="0" label="Success"/>
   <int value="1" label="Partition key not default"/>
@@ -92,12 +111,10 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="7" label="Parse error"/>
 </enum>
 
-<enum name="LocalStorageDatabaseResetReason">
-  <int value="0" label="Failure to open the database"/>
-  <int value="1" label="Schema version mismatch"/>
-  <int value="2" label="Database corruption or read errors"/>
-  <int value="3" label="Excessive commit errors"/>
-  <int value="4" label="Unknown"/>
+<enum name="VariationsConfigState">
+  <int value="0" label="Config is valid"/>
+  <int value="1" label="Config is expired"/>
+  <int value="2" label="Config is missing timestamp"/>
 </enum>
 
 </enums>

--- a/tools/metrics/histograms/metadata/cobalt/enums.xml
+++ b/tools/metrics/histograms/metadata/cobalt/enums.xml
@@ -67,20 +67,20 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
 </enum>
 
 <enum name="SlotSelectionStatus">
-  <summary>Possible status of slot selection by the Loader App</summary>
-  <int value="0" label="UNKNOWN"/>
-  <int value="1" label="CURRENT_SLOT"/>
-  <int value="2" label="ROLL_FORWARD"/>
-  <int value="3" label="ROLL_BACK_OUT_OF_RETRIES"/>
-  <int value="4" label="ROLL_BACK_NO_LIB_FILE"/>
-  <int value="5" label="ROLL_BACK_BAD_APP_KEY_FILE"/>
-  <int value="6" label="ROLL_BACK_SLOT_DRAINING"/>
-  <int value="7" label="ROLL_BACK_FAILED_TO_ADOPT"/>
-  <int value="8" label="ROLL_BACK_FAILED_TO_LOAD_COBALT"/>
-  <int value="9" label="ROLL_BACK_FAILED_TO_CHECK_SABI"/>
-  <int value="10" label="ROLL_BACK_FAILED_TO_LOOK_UP_SYMBOLS"/>
-  <int value="11" label="EVERGREEN_LITE"/>
-  <int value="12" label="LOAD_SYS_IMG_FAILED_TO_INIT_INSTALLATION_MANAGER"/>
+  <summary>Possible status of slot selection by the Loader App.</summary>
+  <int value="0" label="Unknown"/>
+  <int value="1" label="Current slot"/>
+  <int value="2" label="Roll forward"/>
+  <int value="3" label="Roll back: Out of retries"/>
+  <int value="4" label="Roll back: No library file"/>
+  <int value="5" label="Roll back: Bad app key file"/>
+  <int value="6" label="Roll back: Slot draining"/>
+  <int value="7" label="Roll back: Failed to adopt"/>
+  <int value="8" label="Roll back: Failed to load Cobalt"/>
+  <int value="9" label="Roll back: Failed to check SABI"/>
+  <int value="10" label="Roll back: Failed to look up symbols"/>
+  <int value="11" label="Evergreen Lite"/>
+  <int value="12" label="Load system image: Failed to initialize installation manager"/>
 </enum>
 
 <enum name="SplashScreenFetchedState">

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -103,6 +103,15 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.LoaderApp.SlotSelectionStatus"
+    enum="SlotSelectionStatus" expires_after="never">
+<!-- expires-never: Needed for Evergreen updates health metrics. -->
+
+  <owner>yuying@google.com</owner>
+  <owner>cobalt-team@google.com</owner>
+  <summary>Status of slot selection by the Loader App.</summary>
+</histogram>
+
 <histogram name="Cobalt.LocalStorage.DatabaseCommitError" enum="LevelDBStatus"
     expires_after="never">
   <owner>colinliang@google.com</owner>


### PR DESCRIPTION
Apply Cobalt browser and XML telemetry changes from PR #3340. The Starboard-side C++ changes from PR #3340 are already present in the current codebase, so only the Cobalt browser-side reporting logic and metadata are added. Alphabetized enums.xml for the lint check.

Issue: 479816505