### PR TITLE
starboard/rdk: Resolve loader_app Ninja collision

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -377,9 +377,16 @@ group("loader_app_rdk_plugin") {
 }
 
 if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
-  target("shared_library", "loader_app") {
-    output_dir = root_build_dir
-    deps = [ "//starboard/loader_app:loader_app_sources" ]
-    data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+  if (starboard_level_final_executable_type == "shared_library") {
+    group("loader_app") {
+      deps = [ "//starboard/loader_app:loader_app" ]
+      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+    }
+  } else {
+    target("shared_library", "loader_app") {
+      output_dir = root_build_dir
+      deps = [ "//starboard/loader_app:loader_app_sources" ]
+      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+    }
   }
 }


### PR DESCRIPTION
The RDK build encountered a Ninja error where multiple rules were generating `libloader_app.so` in Evergreen development builds. This collision occurred because both the `loader_app` target and the test-loader path converged on the same output artifact.

This change isolates the `loader_app` output by checking the final executable type. If the type is already a shared library, it uses a group dependency instead of defining a new shared library target, ensuring only one rule owns the artifact.

Bug: 510276245