### PR TITLE
nplb: Move WaitForFinish() to AbstractTestThread

### DIFF
--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -84,6 +84,9 @@ test("nplb") {
     "player_test_util.cc",
     "player_test_util.h",
     "player_write_sample_test.cc",
+    # These helper files are used by the player tests.
+    "posix_compliance/posix_thread_helpers.cc",
+    "posix_compliance/posix_thread_helpers.h",
   ]
 
   # All platforms use the Starboard Media functionality.
@@ -242,8 +245,6 @@ test("nplb") {
       "posix_compliance/posix_thread_detach_test.cc",
       "posix_compliance/posix_thread_get_current_test.cc",
       "posix_compliance/posix_thread_get_name_test.cc",
-      "posix_compliance/posix_thread_helpers.cc",
-      "posix_compliance/posix_thread_helpers.h",
       "posix_compliance/posix_thread_is_equal_test.cc",
       "posix_compliance/posix_thread_join_test.cc",
       "posix_compliance/posix_thread_kill_test.cc",

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -84,6 +84,7 @@ test("nplb") {
     "player_test_util.cc",
     "player_test_util.h",
     "player_write_sample_test.cc",
+
     # These helper files are used by the player tests.
     "posix_compliance/posix_thread_helpers.cc",
     "posix_compliance/posix_thread_helpers.h",

--- a/starboard/nplb/multiple_player_test.cc
+++ b/starboard/nplb/multiple_player_test.cc
@@ -15,7 +15,6 @@
 #include <list>
 #include <string>
 
-#include "build/build_config.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/string.h"
 #include "starboard/nplb/maximum_player_configuration_explorer.h"
@@ -24,10 +23,6 @@
 #include "starboard/nplb/posix_compliance/posix_thread_helpers.h"
 #include "starboard/testing/fake_graphics_context_provider.h"
 #include "testing/gtest/include/gtest/gtest.h"
-
-#if BUILDFLAG(IS_IOS_TVOS)
-#include "starboard/tvos/shared/run_in_background_thread_and_wait.h"
-#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace nplb {
 namespace {
@@ -47,18 +42,6 @@ class PlayerThread : public AbstractTestThread {
       : functor_(functor) {}
 
   void Run() override { functor_(); }
-
-  // A wrapper for Join() that, on tvOS, invokes it on a background GCD queue.
-  // This must be done to avoid a deadlock when the main thread is blocked on
-  // Join() and the worker thread is blocked attempting to invoke code in the
-  // main thread (in AVSBVideoRenderer).
-  void WaitForFinish() {
-#if BUILDFLAG(IS_IOS_TVOS)
-    RunInBackgroundThreadAndWait([this] { Join(); });
-#else
-    Join();
-#endif  // BUILDFLAG(IS_IOS_TVOS)
-  }
 
  private:
   std::function<void()> functor_;

--- a/starboard/nplb/player_write_sample_test.cc
+++ b/starboard/nplb/player_write_sample_test.cc
@@ -389,8 +389,8 @@ TEST_P(SbPlayerWriteSampleTest, SecondaryPlayerTest) {
   primary_player_thread.Start();
   secondary_player_thread.Start();
 
-  primary_player_thread.Join();
-  secondary_player_thread.Join();
+  primary_player_thread.WaitForFinish();
+  secondary_player_thread.WaitForFinish();
 }
 
 INSTANTIATE_TEST_SUITE_P(SbPlayerWriteSampleTests,

--- a/starboard/nplb/posix_compliance/posix_thread_helpers.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.cc
@@ -18,8 +18,13 @@
 
 #include <cstddef>
 
+#include "build/build_config.h"
 #include "starboard/thread.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(IS_IOS_TVOS)
+#include "starboard/tvos/shared/run_in_background_thread_and_wait.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace nplb {
 
@@ -84,6 +89,39 @@ void WaiterContext::WaitForReturnSignal() {
   }
   --unreturned_waiters;
   EXPECT_EQ(pthread_mutex_unlock(&mutex), 0);
+}
+
+void AbstractTestThread::Start() {
+  pthread_create(&thread_, nullptr, ThreadEntryPoint, this);
+  if (0 == thread_) {
+    ADD_FAILURE_AT(__FILE__, __LINE__) << "Invalid thread.";
+  }
+}
+
+void AbstractTestThread::WaitForFinish() {
+#if BUILDFLAG(IS_IOS_TVOS)
+  RunInBackgroundThreadAndWait([this] { Join(); });
+#else
+  Join();
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+}
+
+void AbstractTestThread::Join() {
+  if (pthread_join(thread_, nullptr) != 0) {
+    ADD_FAILURE_AT(__FILE__, __LINE__) << "Could not join thread.";
+  }
+}
+
+// static
+void* AbstractTestThread::ThreadEntryPoint(void* ptr) {
+#if defined(__APPLE__)
+  pthread_setname_np("AbstractTestThread");
+#else
+  pthread_setname_np(pthread_self(), "AbstractTestThread");
+#endif
+  AbstractTestThread* this_ptr = static_cast<AbstractTestThread*>(ptr);
+  this_ptr->Run();
+  return NULL;
 }
 
 }  // namespace nplb

--- a/starboard/nplb/posix_compliance/posix_thread_helpers.h
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.h
@@ -20,14 +20,9 @@
 #include <cstddef>
 #include <cstdint>
 
-#include "build/build_config.h"
 #include "starboard/configuration.h"
 #include "starboard/thread.h"
 #include "testing/gtest/include/gtest/gtest.h"
-
-#if BUILDFLAG(IS_IOS_TVOS)
-#include "starboard/tvos/shared/run_in_background_thread_and_wait.h"
-#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace nplb {
 
@@ -169,43 +164,18 @@ class AbstractTestThread {
   virtual void Run() = 0;
 
   // Calls pthread_create() with default parameters.
-  void Start() {
-    pthread_create(&thread_, NULL, ThreadEntryPoint, this);
-    if (0 == thread_) {
-      ADD_FAILURE_AT(__FILE__, __LINE__) << "Invalid thread.";
-    }
-    return;
-  }
+  void Start();
 
   // A wrapper for Join() that, on tvOS, invokes it on a background GCD queue.
   // This must be done to avoid a deadlock when the main thread is blocked on
   // Join() and the worker thread is blocked attempting to invoke code in the
   // main thread (in AVSBVideoRenderer).
-  void WaitForFinish() {
-#if BUILDFLAG(IS_IOS_TVOS)
-    RunInBackgroundThreadAndWait([this] { Join(); });
-#else
-    Join();
-#endif  // BUILDFLAG(IS_IOS_TVOS)
-  }
+  void WaitForFinish();
 
  private:
-  void Join() {
-    if (pthread_join(thread_, NULL) != 0) {
-      ADD_FAILURE_AT(__FILE__, __LINE__) << "Could not join thread.";
-    }
-  }
+  void Join();
 
-  static void* ThreadEntryPoint(void* ptr) {
-#if defined(__APPLE__)
-    pthread_setname_np("AbstractTestThread");
-#else
-    pthread_setname_np(pthread_self(), "AbstractTestThread");
-#endif
-    AbstractTestThread* this_ptr = static_cast<AbstractTestThread*>(ptr);
-    this_ptr->Run();
-    return NULL;
-  }
+  static void* ThreadEntryPoint(void* ptr);
 
   pthread_t thread_;
 

--- a/starboard/nplb/posix_compliance/posix_thread_helpers.h
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.h
@@ -189,8 +189,6 @@ class AbstractTestThread {
 #endif  // BUILDFLAG(IS_IOS_TVOS)
   }
 
-  pthread_t GetThread() { return thread_; }
-
  private:
   void Join() {
     if (pthread_join(thread_, NULL) != 0) {

--- a/starboard/nplb/posix_compliance/posix_thread_helpers.h
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.h
@@ -20,9 +20,14 @@
 #include <cstddef>
 #include <cstdint>
 
+#include "build/build_config.h"
 #include "starboard/configuration.h"
 #include "starboard/thread.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(IS_IOS_TVOS)
+#include "starboard/tvos/shared/run_in_background_thread_and_wait.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace nplb {
 
@@ -172,15 +177,27 @@ class AbstractTestThread {
     return;
   }
 
+  // A wrapper for Join() that, on tvOS, invokes it on a background GCD queue.
+  // This must be done to avoid a deadlock when the main thread is blocked on
+  // Join() and the worker thread is blocked attempting to invoke code in the
+  // main thread (in AVSBVideoRenderer).
+  void WaitForFinish() {
+#if BUILDFLAG(IS_IOS_TVOS)
+    RunInBackgroundThreadAndWait([this] { Join(); });
+#else
+    Join();
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+  }
+
+  pthread_t GetThread() { return thread_; }
+
+ private:
   void Join() {
     if (pthread_join(thread_, NULL) != 0) {
       ADD_FAILURE_AT(__FILE__, __LINE__) << "Could not join thread.";
     }
   }
 
-  pthread_t GetThread() { return thread_; }
-
- private:
   static void* ThreadEntryPoint(void* ptr) {
 #if defined(__APPLE__)
     pthread_setname_np("AbstractTestThread");

--- a/starboard/nplb/semaphore_test.cc
+++ b/starboard/nplb/semaphore_test.cc
@@ -64,7 +64,7 @@ TEST(Semaphore, ThreadTakes) {
   ThreadTakesSemaphore thread(&semaphore);
   thread.Start();
   semaphore.Put();
-  thread.Join();
+  thread.WaitForFinish();
 }
 
 class ThreadTakesWaitSemaphore : public AbstractTestThread {
@@ -106,7 +106,7 @@ TEST(Semaphore, FLAKY_ThreadTakesWait_PutBeforeTimeExpires) {
   usleep(wait_time);
   thread.semaphore_.Put();
 
-  thread.Join();
+  thread.WaitForFinish();
 
   EXPECT_TRUE(thread.result_signaled_);
   EXPECT_LT(thread.result_wait_time_, timeout_time);
@@ -142,7 +142,7 @@ TEST(Semaphore, ThreadTakesWait_TimeExpires) {
     usleep(wait_time * 5);
     thread.semaphore_.Put();
 
-    thread.Join();
+    thread.WaitForFinish();
     EXPECT_FALSE(thread.result_signaled_);
 
     if (IsDoubleNear(1.0 * wait_time, 1.0 * thread.result_wait_time_,
@@ -166,7 +166,7 @@ TEST(Semaphore, ThreadPuts) {
   Semaphore semaphore;
   ThreadPutsSemaphore thread(&semaphore);
   thread.Start();
-  thread.Join();
+  thread.WaitForFinish();
   semaphore.Put();
 }
 }  // namespace


### PR DESCRIPTION
Move the function added in #8732 to work around some hangs and freezes on tvOS out of `multiple_player_test.cc` and into the base class, and make Join() a private method so that callers must call the right function.

This fixes a hang in SbPlayerWriteSampleTest.SecondaryPlayerTest with the same cause described in #8732.

While here, remove `AbstractTestThread::GetThread()`. It is not used anywhere, and the handle it returns could be used by callers to invoke `pthread_join()` directly.

Bug: 465634083