### PR TITLE
android: Clarify smoke test dependency for browser init log

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -285,7 +285,10 @@ public abstract class CobaltActivity extends Activity {
             new BrowserStartupController.StartupCallback() {
               @Override
               public void onSuccess() {
+                // NOTE: This log message is hard-coded in smoke tests to detect browser startup success.
+                // See ManekiBaseDeviceUtil.CHROBALT_BROWSER_READY_REGEX in the internal test suite.
                 Log.i(TAG, "Browser process init succeeded");
+
                 finishInitialization(savedInstanceState);
                 getStarboardBridge().measureAppStartTimestamp();
               }


### PR DESCRIPTION
Update the comment in CobaltActivity.java to clarify that the "Browser process init succeeded" log message is hard-coded in smoke tests to detect browser startup success.

Issue: 515406853