### PR TITLE
media: Pre-allocate vectors in SbPlayerBridge

### DIFF
--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -65,17 +65,11 @@ using starboard::GetPlayerOutputModeName;
 template <typename T>
 class ScopedVectorClearer {
  public:
-  ScopedVectorClearer(bool enable, std::vector<T>& vec)
-      : enable_(enable), vec_(vec) {}
+  explicit ScopedVectorClearer(std::vector<T>& vec) : vec_(vec) {}
 
-  ~ScopedVectorClearer() {
-    if (enable_) {
-      vec_.clear();
-    }
-  }
+  ~ScopedVectorClearer() { vec_.clear(); }
 
  private:
-  const bool enable_;
   std::vector<T>& vec_;
 };
 
@@ -877,14 +871,13 @@ void SbPlayerBridge::WriteBuffersInternal(
               : local_side_data;
 
   ScopedVectorClearer<SbPlayerSampleInfo> clearer_info{
-      enable_trivial_optimizations, gathered_sbplayer_sample_infos};
+      gathered_sbplayer_sample_infos};
   ScopedVectorClearer<SbDrmSampleInfo> clearer_drm{
-      enable_trivial_optimizations, gathered_sbplayer_sample_infos_drm_info};
+      gathered_sbplayer_sample_infos_drm_info};
   ScopedVectorClearer<SbDrmSubSampleMapping> clearer_mapping{
-      enable_trivial_optimizations,
       gathered_sbplayer_sample_infos_subsample_mapping};
   ScopedVectorClearer<SbPlayerSampleSideData> clearer_side_data{
-      enable_trivial_optimizations, gathered_sbplayer_sample_infos_side_data};
+      gathered_sbplayer_sample_infos_side_data};
 
   gathered_sbplayer_sample_infos.reserve(buffers.size());
   gathered_sbplayer_sample_infos_drm_info.reserve(buffers.size());

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -827,11 +827,33 @@ void SbPlayerBridge::WriteBuffersInternal(
     return;
   }
 
-  std::vector<SbPlayerSampleInfo> gathered_sbplayer_sample_infos;
-  std::vector<SbDrmSampleInfo> gathered_sbplayer_sample_infos_drm_info;
-  std::vector<SbDrmSubSampleMapping>
-      gathered_sbplayer_sample_infos_subsample_mapping;
-  std::vector<SbPlayerSampleSideData> gathered_sbplayer_sample_infos_side_data;
+  std::vector<SbPlayerSampleInfo> local_sample_infos;
+  std::vector<SbDrmSampleInfo> local_drm_infos;
+  std::vector<SbDrmSubSampleMapping> local_subsample_mappings;
+  std::vector<SbPlayerSampleSideData> local_side_data;
+
+  const bool enable_trivial_optimizations =
+      experimental_features_.enable_trivial_optimizations.value_or(false);
+
+  std::vector<SbPlayerSampleInfo>& gathered_sbplayer_sample_infos =
+      enable_trivial_optimizations ? gathered_sbplayer_sample_infos_
+                                   : local_sample_infos;
+  std::vector<SbDrmSampleInfo>& gathered_sbplayer_sample_infos_drm_info =
+      enable_trivial_optimizations ? gathered_sbplayer_sample_infos_drm_info_
+                                   : local_drm_infos;
+  std::vector<SbDrmSubSampleMapping>& gathered_sbplayer_sample_infos_subsample_mapping =
+      enable_trivial_optimizations ? gathered_sbplayer_sample_infos_subsample_mapping_
+                                   : local_subsample_mappings;
+  std::vector<SbPlayerSampleSideData>& gathered_sbplayer_sample_infos_side_data =
+      enable_trivial_optimizations ? gathered_sbplayer_sample_infos_side_data_
+                                   : local_side_data;
+
+  if (enable_trivial_optimizations) {
+    gathered_sbplayer_sample_infos.clear();
+    gathered_sbplayer_sample_infos_drm_info.clear();
+    gathered_sbplayer_sample_infos_subsample_mapping.clear();
+    gathered_sbplayer_sample_infos_side_data.clear();
+  }
 
   gathered_sbplayer_sample_infos.reserve(buffers.size());
   gathered_sbplayer_sample_infos_drm_info.reserve(buffers.size());

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -16,6 +16,7 @@
 
 #include <algorithm>
 #include <iomanip>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -68,6 +69,9 @@ class ScopedVectorClearer {
   explicit ScopedVectorClearer(std::vector<T>& vec) : vec_(vec) {}
 
   ~ScopedVectorClearer() { vec_.clear(); }
+
+  ScopedVectorClearer(const ScopedVectorClearer&) = delete;
+  ScopedVectorClearer& operator=(const ScopedVectorClearer&) = delete;
 
  private:
   std::vector<T>& vec_;
@@ -834,6 +838,7 @@ void SbPlayerBridge::WriteBuffersInternal(
     const std::vector<scoped_refptr<DecoderBuffer>>& buffers,
     const SbMediaAudioStreamInfo* audio_stream_info,
     const SbMediaVideoStreamInfo* video_stream_info) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
 #if SB_HAS(PLAYER_WITH_URL)
   DCHECK(!is_url_based_);
 #endif  // SB_HAS(PLAYER_WITH_URL)
@@ -845,30 +850,37 @@ void SbPlayerBridge::WriteBuffersInternal(
     return;
   }
 
-  std::vector<SbPlayerSampleInfo> local_sample_infos;
-  std::vector<SbDrmSampleInfo> local_drm_infos;
-  std::vector<SbDrmSubSampleMapping> local_subsample_mappings;
-  std::vector<SbPlayerSampleSideData> local_side_data;
-
   const bool enable_trivial_optimizations =
       experimental_features_.enable_trivial_optimizations.value_or(false);
 
+  std::optional<std::vector<SbPlayerSampleInfo>> local_sample_infos;
+  std::optional<std::vector<SbDrmSampleInfo>> local_drm_infos;
+  std::optional<std::vector<SbDrmSubSampleMapping>> local_subsample_mappings;
+  std::optional<std::vector<SbPlayerSampleSideData>> local_side_data;
+
+  if (!enable_trivial_optimizations) {
+    local_sample_infos.emplace();
+    local_drm_infos.emplace();
+    local_subsample_mappings.emplace();
+    local_side_data.emplace();
+  }
+
   std::vector<SbPlayerSampleInfo>& gathered_sbplayer_sample_infos =
       enable_trivial_optimizations ? gathered_sbplayer_sample_infos_
-                                   : local_sample_infos;
+                                   : *local_sample_infos;
   std::vector<SbDrmSampleInfo>& gathered_sbplayer_sample_infos_drm_info =
       enable_trivial_optimizations ? gathered_sbplayer_sample_infos_drm_info_
-                                   : local_drm_infos;
+                                   : *local_drm_infos;
   std::vector<SbDrmSubSampleMapping>&
       gathered_sbplayer_sample_infos_subsample_mapping =
           enable_trivial_optimizations
               ? gathered_sbplayer_sample_infos_subsample_mapping_
-              : local_subsample_mappings;
+              : *local_subsample_mappings;
   std::vector<SbPlayerSampleSideData>&
       gathered_sbplayer_sample_infos_side_data =
           enable_trivial_optimizations
               ? gathered_sbplayer_sample_infos_side_data_
-              : local_side_data;
+              : *local_side_data;
 
   ScopedVectorClearer<SbPlayerSampleInfo> clearer_info{
       gathered_sbplayer_sample_infos};

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -841,19 +841,35 @@ void SbPlayerBridge::WriteBuffersInternal(
   std::vector<SbDrmSampleInfo>& gathered_sbplayer_sample_infos_drm_info =
       enable_trivial_optimizations ? gathered_sbplayer_sample_infos_drm_info_
                                    : local_drm_infos;
-  std::vector<SbDrmSubSampleMapping>& gathered_sbplayer_sample_infos_subsample_mapping =
-      enable_trivial_optimizations ? gathered_sbplayer_sample_infos_subsample_mapping_
-                                   : local_subsample_mappings;
-  std::vector<SbPlayerSampleSideData>& gathered_sbplayer_sample_infos_side_data =
-      enable_trivial_optimizations ? gathered_sbplayer_sample_infos_side_data_
-                                   : local_side_data;
+  std::vector<SbDrmSubSampleMapping>&
+      gathered_sbplayer_sample_infos_subsample_mapping =
+          enable_trivial_optimizations
+              ? gathered_sbplayer_sample_infos_subsample_mapping_
+              : local_subsample_mappings;
+  std::vector<SbPlayerSampleSideData>&
+      gathered_sbplayer_sample_infos_side_data =
+          enable_trivial_optimizations
+              ? gathered_sbplayer_sample_infos_side_data_
+              : local_side_data;
 
-  if (enable_trivial_optimizations) {
-    gathered_sbplayer_sample_infos.clear();
-    gathered_sbplayer_sample_infos_drm_info.clear();
-    gathered_sbplayer_sample_infos_subsample_mapping.clear();
-    gathered_sbplayer_sample_infos_side_data.clear();
-  }
+  struct ScopedClearer {
+    ~ScopedClearer() {
+      if (enable) {
+        infos.clear();
+        drms.clear();
+        mappings.clear();
+        sides.clear();
+      }
+    }
+    bool enable;
+    std::vector<SbPlayerSampleInfo>& infos;
+    std::vector<SbDrmSampleInfo>& drms;
+    std::vector<SbDrmSubSampleMapping>& mappings;
+    std::vector<SbPlayerSampleSideData>& sides;
+  } clearer{enable_trivial_optimizations, gathered_sbplayer_sample_infos,
+            gathered_sbplayer_sample_infos_drm_info,
+            gathered_sbplayer_sample_infos_subsample_mapping,
+            gathered_sbplayer_sample_infos_side_data};
 
   gathered_sbplayer_sample_infos.reserve(buffers.size());
   gathered_sbplayer_sample_infos_drm_info.reserve(buffers.size());

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -16,7 +16,6 @@
 
 #include <algorithm>
 #include <iomanip>
-#include <optional>
 #include <string>
 #include <vector>
 
@@ -853,34 +852,27 @@ void SbPlayerBridge::WriteBuffersInternal(
   const bool enable_trivial_optimizations =
       experimental_features_.enable_trivial_optimizations.value_or(false);
 
-  std::optional<std::vector<SbPlayerSampleInfo>> local_sample_infos;
-  std::optional<std::vector<SbDrmSampleInfo>> local_drm_infos;
-  std::optional<std::vector<SbDrmSubSampleMapping>> local_subsample_mappings;
-  std::optional<std::vector<SbPlayerSampleSideData>> local_side_data;
-
-  if (!enable_trivial_optimizations) {
-    local_sample_infos.emplace();
-    local_drm_infos.emplace();
-    local_subsample_mappings.emplace();
-    local_side_data.emplace();
-  }
+  std::vector<SbPlayerSampleInfo> local_sample_infos;
+  std::vector<SbDrmSampleInfo> local_drm_infos;
+  std::vector<SbDrmSubSampleMapping> local_subsample_mappings;
+  std::vector<SbPlayerSampleSideData> local_side_data;
 
   std::vector<SbPlayerSampleInfo>& gathered_sbplayer_sample_infos =
       enable_trivial_optimizations ? gathered_sbplayer_sample_infos_
-                                   : *local_sample_infos;
+                                   : local_sample_infos;
   std::vector<SbDrmSampleInfo>& gathered_sbplayer_sample_infos_drm_info =
       enable_trivial_optimizations ? gathered_sbplayer_sample_infos_drm_info_
-                                   : *local_drm_infos;
+                                   : local_drm_infos;
   std::vector<SbDrmSubSampleMapping>&
       gathered_sbplayer_sample_infos_subsample_mapping =
           enable_trivial_optimizations
               ? gathered_sbplayer_sample_infos_subsample_mapping_
-              : *local_subsample_mappings;
+              : local_subsample_mappings;
   std::vector<SbPlayerSampleSideData>&
       gathered_sbplayer_sample_infos_side_data =
           enable_trivial_optimizations
               ? gathered_sbplayer_sample_infos_side_data_
-              : *local_side_data;
+              : local_side_data;
 
   ScopedVectorClearer<SbPlayerSampleInfo> clearer_info{
       gathered_sbplayer_sample_infos};

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -55,6 +55,17 @@ using base::TimeDelta;
 using starboard::FormatString;
 using starboard::GetPlayerOutputModeName;
 
+template <typename T>
+struct ScopedVectorClearer {
+  ~ScopedVectorClearer() {
+    if (enable) {
+      vec.clear();
+    }
+  }
+  bool enable;
+  std::vector<T>& vec;
+};
+
 #if BUILDFLAG(COBALT_MEDIA_ENABLE_STARTUP_LATENCY_TRACKING)
 class StatisticsWrapper {
  public:
@@ -852,24 +863,15 @@ void SbPlayerBridge::WriteBuffersInternal(
               ? gathered_sbplayer_sample_infos_side_data_
               : local_side_data;
 
-  struct ScopedClearer {
-    ~ScopedClearer() {
-      if (enable) {
-        infos.clear();
-        drms.clear();
-        mappings.clear();
-        sides.clear();
-      }
-    }
-    bool enable;
-    std::vector<SbPlayerSampleInfo>& infos;
-    std::vector<SbDrmSampleInfo>& drms;
-    std::vector<SbDrmSubSampleMapping>& mappings;
-    std::vector<SbPlayerSampleSideData>& sides;
-  } clearer{enable_trivial_optimizations, gathered_sbplayer_sample_infos,
-            gathered_sbplayer_sample_infos_drm_info,
-            gathered_sbplayer_sample_infos_subsample_mapping,
-            gathered_sbplayer_sample_infos_side_data};
+  ScopedVectorClearer<SbPlayerSampleInfo> clearer_info{
+      enable_trivial_optimizations, gathered_sbplayer_sample_infos};
+  ScopedVectorClearer<SbDrmSampleInfo> clearer_drm{
+      enable_trivial_optimizations, gathered_sbplayer_sample_infos_drm_info};
+  ScopedVectorClearer<SbDrmSubSampleMapping> clearer_mapping{
+      enable_trivial_optimizations,
+      gathered_sbplayer_sample_infos_subsample_mapping};
+  ScopedVectorClearer<SbPlayerSampleSideData> clearer_side_data{
+      enable_trivial_optimizations, gathered_sbplayer_sample_infos_side_data};
 
   gathered_sbplayer_sample_infos.reserve(buffers.size());
   gathered_sbplayer_sample_infos_drm_info.reserve(buffers.size());

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -55,15 +55,28 @@ using base::TimeDelta;
 using starboard::FormatString;
 using starboard::GetPlayerOutputModeName;
 
+// Reason for existence: Guarantees automatic clearing of an underlying vector
+// upon exiting a scoped execution block, preventing stale or dangling pointers.
+//
+// Expected lifetime and ownership: Instantiated locally on the stack within a
+// function body. Destruction occurs automatically at scope exit.
+//
+// Threading model: Strictly single-threaded execution on the invoking thread.
 template <typename T>
-struct ScopedVectorClearer {
+class ScopedVectorClearer {
+ public:
+  ScopedVectorClearer(bool enable, std::vector<T>& vec)
+      : enable_(enable), vec_(vec) {}
+
   ~ScopedVectorClearer() {
-    if (enable) {
-      vec.clear();
+    if (enable_) {
+      vec_.clear();
     }
   }
-  bool enable;
-  std::vector<T>& vec;
+
+ private:
+  const bool enable_;
+  std::vector<T>& vec_;
 };
 
 #if BUILDFLAG(COBALT_MEDIA_ENABLE_STARTUP_LATENCY_TRACKING)

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -366,6 +366,14 @@ class SbPlayerBridge {
   std::string pipeline_identifier_;
 #endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_CVAL)
 
+  // Pre-allocated vectors for WriteBuffersInternal to avoid allocations when
+  // enable_trivial_optimizations is enabled.
+  std::vector<SbPlayerSampleInfo> gathered_sbplayer_sample_infos_;
+  std::vector<SbDrmSampleInfo> gathered_sbplayer_sample_infos_drm_info_;
+  std::vector<SbDrmSubSampleMapping>
+      gathered_sbplayer_sample_infos_subsample_mapping_;
+  std::vector<SbPlayerSampleSideData> gathered_sbplayer_sample_infos_side_data_;
+
   // NOTE: Do not add member variables after weak_factory_
   // It should be the first one destroyed among all members.
   // See base/memory/weak_ptr.h.


### PR DESCRIPTION
Pre-allocate scratchpad vectors for WriteBuffersInternal as persistent
member variables of SbPlayerBridge to eliminate dynamic heap allocation
and fragmentation per media sample. This behavior is guarded behind
the Media.EnableTrivialOptimizations configuration setting.

Bug: 514758473
Bug: 516313342