### PR TITLE
tvOS: Make thread priority setting work after SbThreadSetPriority removal

### DIFF
--- a/starboard/common/thread.cc
+++ b/starboard/common/thread.cc
@@ -55,6 +55,7 @@ float SbThreadPriorityToRelativeSchedPriority(SbThreadPriority priority) {
     case kSbThreadPriorityRealTime:
       return 0.99f;
   }
+  SB_NOTREACHED();
 }
 #endif  // defined(__APPLE__)
 

--- a/starboard/common/thread.cc
+++ b/starboard/common/thread.cc
@@ -33,6 +33,69 @@
 
 namespace starboard {
 
+namespace {
+
+#if defined(__APPLE__)
+// Returns a value between 0 and 1 that is used by SetThreadPriority() to scale
+// the desired thread priority between what sched_get_priority_min() and
+// sched_get_priority_max() return.
+float SbThreadPriorityToRelativeSchedPriority(SbThreadPriority priority) {
+  switch (priority) {
+    case kSbThreadPriorityLowest:
+      return 0.1f;
+    case kSbThreadPriorityLow:
+      return 0.3f;
+    case kSbThreadNoPriority:
+    case kSbThreadPriorityNormal:
+      return 0.5f;
+    case kSbThreadPriorityHigh:
+      return 0.7f;
+    case kSbThreadPriorityHighest:
+      return 0.9f;
+    case kSbThreadPriorityRealTime:
+      return 0.99f;
+  }
+}
+#endif  // defined(__APPLE__)
+
+// Wrapper for changing a thread's priority. On Linux kernel-based platforms
+// (including Android), this code relies on setpriority(2), which on Linux
+// deviates from the standard and changes per-thread attributes (rather tha
+// per-process).
+//
+// On tvOS, use pthread_setschedparam() by translating SbThreadPriority into an
+// integer between what sched_get_priority_min() and sched_get_priority_max()
+// return.
+bool SetThreadPriority(SbThreadPriority priority) {
+#if defined(__APPLE__)
+  const float relative_priority =
+      SbThreadPriorityToRelativeSchedPriority(priority);
+
+  int policy;
+  struct sched_param param;
+
+  // Get the current thread scheduling parameters. Only the thread priority
+  // will be changed.
+  SB_CHECK_EQ(pthread_getschedparam(pthread_self(), &policy, &param), 0);
+  const int min_priority = sched_get_priority_min(policy);
+  const int max_priority = sched_get_priority_max(policy);
+
+  // Thread priority set with pthread does not appear to have the same range
+  // as NSThread priorities. A pthread set to sched_get_priority_max() won't
+  // have NSThread.threadPriority == 1.0. Consider switching to NSThread if a
+  // higher priority is required.
+  param.sched_priority = static_cast<int>(
+      min_priority + relative_priority * (max_priority - min_priority));
+  return (pthread_setschedparam(pthread_self(), policy, &param) == 0);
+#else
+  // setpriority returns 0 on success and -1 on failure. The default nice value
+  // is 0. See https://linux.die.net/man/2/setpriority
+  return (setpriority(PRIO_PROCESS, 0, SbPriorityToNice(priority)) == 0);
+#endif  // defined(__APPLE__)
+}
+
+}  // namespace
+
 int SbPriorityToNice(SbThreadPriority priority) {
   // Nice value settings are shared between Android and Linux.
   // They are selected from looking at:
@@ -122,10 +185,7 @@ void* Thread::ThreadEntryPoint(void* context) {
 #endif
   bool priority_set = false;
   if (this_ptr->priority_) {
-    // setpriority returns 0 on success and -1 on failure. The default nice
-    // value is 0. See https://linux.die.net/man/2/setpriority
-    priority_set = (setpriority(PRIO_PROCESS, 0,
-                                SbPriorityToNice(*this_ptr->priority_)) == 0);
+    priority_set = SetThreadPriority(*this_ptr->priority_);
     if (!priority_set) {
       SB_LOG(WARNING) << "Failed to set thread priority (unsupported on this "
                          "platform): requested_priority="


### PR DESCRIPTION
PR #10379 removed `SbThreadSetPriority()` in favor of directly calling `setpriority()` from `starbord::Thread::ThreadEntryPoint()`. However, this behavior is Linux kernel-specific, as documented in its setpriority(2) man page:

> According to POSIX, the nice value is a per-process
> setting. However, under the current Linux/NPTL implementation of
> POSIX threads, the nice value is a per-thread attribute: different
> threads in the same process can have different nice values. Portable
> applications should avoid relying on the Linux behavior, which may
> be made standards conformant in the future.

Consequently, this made changing a thread's priority not work on tvOS. Fix it by implementing a separate code path for tvOS with the same code that was removed in #10379, and moving all the thread priority setting code to a separate function in `thread.cc`.

Fixed: 515540991