### PR TITLE
Deprecate kSbHasThreadPrioritySupport

### DIFF
--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -52,6 +52,7 @@ This prepares Cobalt for future AV2 playback support.
 ### Removed unused configuration constants
 The following configuration constants were removed as they are no longer used by Cobalt core:
 * `kSbFileMaxOpen`
+* `kSbHasThreadPrioritySupport`
 * `kSbMaxThreadLocalKeys`
 * `kSbMaxThreadNameLength`
 * `kSbNetworkReceiveBufferSize`

--- a/starboard/android/shared/configuration_constants.cc
+++ b/starboard/android/shared/configuration_constants.cc
@@ -32,9 +32,6 @@ const char kSbFileSepChar = '/';
 // The string form of SB_FILE_SEP_CHAR.
 const char* kSbFileSepString = "/";
 
-// Whether the current platform supports thread priorities.
-const bool kSbHasThreadPrioritySupport = true;
-
 // The maximum audio bitrate the platform can decode.  The following value
 // equals to 5M bytes per seconds which is more than enough for compressed
 // audio.

--- a/starboard/configuration_constants.h
+++ b/starboard/configuration_constants.h
@@ -42,9 +42,6 @@ SB_EXPORT extern const char kSbFileSepChar;
 // The string form of SB_FILE_SEP_CHAR.
 SB_EXPORT extern const char* kSbFileSepString;
 
-// Whether the current platform supports thread priorities.
-SB_EXPORT extern const bool kSbHasThreadPrioritySupport;
-
 // The maximum audio bitrate the platform can decode.  The following value
 // equals to 5M bytes per seconds which is more than enough for compressed
 // audio.

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/configuration_constants.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/configuration_constants.cc
@@ -59,10 +59,6 @@ const bool kSbHasAc3Audio = true;
 // non-zero on platforms with webm/vp9 support.
 const bool kSbHasMediaWebmVp9Support = true;
 
-// On default Linux desktop, you must be a superuser in order to set real time
-// scheduling on threads.
-const bool kSbHasThreadPrioritySupport = false;
-
 // Determines the alignment that allocations should have on this platform.
 const size_t kSbMallocAlignment = 16;
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm64/configuration_constants.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm64/configuration_constants.cc
@@ -59,10 +59,6 @@ const bool kSbHasAc3Audio = true;
 // non-zero on platforms with webm/vp9 support.
 const bool kSbHasMediaWebmVp9Support = true;
 
-// On default Linux desktop, you must be a superuser in order to set real time
-// scheduling on threads.
-const bool kSbHasThreadPrioritySupport = false;
-
 // Determines the alignment that allocations should have on this platform.
 const size_t kSbMallocAlignment = 16;
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/rpi/configuration_constants.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/rpi/configuration_constants.cc
@@ -60,10 +60,6 @@ const bool kSbHasAc3Audio = true;
 // non-zero on platforms with webm/vp9 support.
 const bool kSbHasMediaWebmVp9Support = false;
 
-// On default Linux desktop, you must be a superuser in order to set real time
-// scheduling on threads.
-const bool kSbHasThreadPrioritySupport = false;
-
 // Determines the alignment that allocations should have on this platform.
 const size_t kSbMallocAlignment = 16;
 

--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -104,7 +104,6 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(kSbFileMaxPath);
   REGISTER_SYMBOL(kSbFileSepChar);
   REGISTER_SYMBOL(kSbFileSepString);
-  REGISTER_SYMBOL(kSbHasThreadPrioritySupport);
   REGISTER_SYMBOL(kSbMaxSystemPathCacheDirectorySize);
   REGISTER_SYMBOL(kSbMaxThreads);
   REGISTER_SYMBOL(kSbMediaMaxAudioBitrateInBitsPerSecond);

--- a/starboard/linux/shared/configuration_constants.cc
+++ b/starboard/linux/shared/configuration_constants.cc
@@ -32,10 +32,6 @@ const char kSbFileSepChar = '/';
 // The string form of SB_FILE_SEP_CHAR.
 const char* kSbFileSepString = "/";
 
-// On default Linux desktop, you must be a superuser in order to set real time
-// scheduling on threads.
-const bool kSbHasThreadPrioritySupport = false;
-
 // The maximum audio bitrate the platform can decode.  The following value
 // equals to 5M bytes per seconds which is more than enough for compressed
 // audio.

--- a/starboard/nplb/posix_compliance/posix_priority_test.cc
+++ b/starboard/nplb/posix_compliance/posix_priority_test.cc
@@ -161,28 +161,23 @@ TEST_F(PosixSetPriorityTests, ErrorOnPermissionDenied) {
 }
 
 TEST_F(PosixSetPriorityTests, SetProcessPriorityToStarboardNiceValues) {
-  if (kSbHasThreadPrioritySupport) {
-    // Normal Priority
-    int normal_nice = starboard::SbPriorityToNice(kSbThreadPriorityNormal);
-    ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, normal_nice))
-        << "setpriority failed for Normal. Errno: " << errno << " ("
-        << strerror(errno) << ")";
-    EXPECT_EQ(normal_nice, getpriority(PRIO_PROCESS, 0));
+  // Test only low priorities as the process can't go back to higher priorities.
+  // NOTE: The priority is already lowered from the normal level by the
+  //  SetProcessPrioritySuccessfully test.
 
-    // Low Priority
-    int low_nice = starboard::SbPriorityToNice(kSbThreadPriorityLow);
-    ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, low_nice))
-        << "setpriority failed for Low. Errno: " << errno << " ("
-        << strerror(errno) << ")";
-    EXPECT_EQ(low_nice, getpriority(PRIO_PROCESS, 0));
+  // Low Priority
+  int low_nice = starboard::SbPriorityToNice(kSbThreadPriorityLow);
+  ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, low_nice))
+      << "setpriority failed for Low. Errno: " << errno << " ("
+      << strerror(errno) << ")";
+  EXPECT_EQ(low_nice, getpriority(PRIO_PROCESS, 0));
 
-    // Lowest Priority
-    int lowest_nice = starboard::SbPriorityToNice(kSbThreadPriorityLowest);
-    ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, lowest_nice))
-        << "setpriority failed for Lowest. Errno: " << errno << " ("
-        << strerror(errno) << ")";
-    EXPECT_EQ(lowest_nice, getpriority(PRIO_PROCESS, 0));
-  }
+  // Lowest Priority
+  int lowest_nice = starboard::SbPriorityToNice(kSbThreadPriorityLowest);
+  ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, lowest_nice))
+      << "setpriority failed for Lowest. Errno: " << errno << " ("
+      << strerror(errno) << ")";
+  EXPECT_EQ(lowest_nice, getpriority(PRIO_PROCESS, 0));
 }
 
 }  // namespace

--- a/starboard/raspi/shared/configuration_constants.cc
+++ b/starboard/raspi/shared/configuration_constants.cc
@@ -32,12 +32,6 @@ const char kSbFileSepChar = '/';
 // The string form of SB_FILE_SEP_CHAR.
 const char* kSbFileSepString = "/";
 
-// On the current version of Raspbian, real time thread scheduling seems to be
-// broken in that higher priority threads do not always have priority over lower
-// priority threads.  It looks like the thread created last will always have the
-// highest priority.
-const bool kSbHasThreadPrioritySupport = true;
-
 // The maximum audio bitrate the platform can decode.  The following value
 // equals to 5M bytes per seconds which is more than enough for compressed
 // audio.

--- a/starboard/stub/configuration_constants.cc
+++ b/starboard/stub/configuration_constants.cc
@@ -32,9 +32,6 @@ const char kSbFileSepChar = '/';
 // The string form of SB_FILE_SEP_CHAR.
 const char* kSbFileSepString = "/";
 
-// Whether the current platform supports thread priorities.
-const bool kSbHasThreadPrioritySupport = false;
-
 // The maximum audio bitrate the platform can decode.  The following value
 // equals to 5M bytes per seconds which is more than enough for compressed
 // audio.

--- a/starboard/tvos/shared/configuration_constants.cc
+++ b/starboard/tvos/shared/configuration_constants.cc
@@ -32,9 +32,6 @@ const char kSbFileSepChar = '/';
 // The string form of SB_FILE_SEP_CHAR.
 const char* kSbFileSepString = "/";
 
-// Whether the current platform supports thread priorities.
-const bool kSbHasThreadPrioritySupport = true;
-
 // The maximum audio bitrate the platform can decode.  The following value
 // equals to 5M bytes per seconds which is more than enough for compressed
 // audio.


### PR DESCRIPTION
starboard: Remove kSbHasThreadPrioritySupport

The kSbHasThreadPrioritySupport configuration constant is no longer
used by Cobalt core and has been removed from the Starboard API.
This constant was previously used to indicate whether a platform
supported thread priorities.

Starboard implementations should no longer define this value, and
related symbols have been removed from the exported symbol list.
Tests in NPLB that were previously conditional on this constant
have been updated to execute directly.

Bug: 502581618