### PR TITLE
perf(starboard): Refactor VideoFrameTracker to use std::vector

### DIFF
--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
-#include <list>
 #include <mutex>
 #include <vector>
 
@@ -31,8 +30,9 @@ const int64_t kMaxAllowedSkew = 5'000;  // 5ms
 
 // TODO: b/409362474 - Add unit test once starboard unittests are enable on
 // Android.
-void RemoveUnexpectedRenderedFrames(const std::list<int64_t>& frames_to_render,
-                                    std::vector<int64_t>* rendered_frames) {
+void RemoveUnexpectedRenderedFrames(
+    const std::vector<int64_t>& frames_to_render,
+    std::vector<int64_t>* rendered_frames) {
   SB_CHECK(rendered_frames);
   if (rendered_frames->empty()) {
     return;
@@ -87,7 +87,7 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
       static_cast<size_t>(max_pending_frames_size_)) {
     // OnFrameRendered() is only available after API level 23.  Cap the size
     // of |frames_to_be_rendered_| in case OnFrameRendered() is not available.
-    frames_to_be_rendered_.pop_front();
+    frames_to_be_rendered_.erase(frames_to_be_rendered_.begin());
   }
 
   // Sort by |timestamp|, because |timestamp| won't be monotonic if there are
@@ -104,7 +104,7 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
     }
   }
 
-  frames_to_be_rendered_.emplace_front(timestamp);
+  frames_to_be_rendered_.insert(frames_to_be_rendered_.begin(), timestamp);
 }
 
 void VideoFrameTracker::OnFrameRendered(int64_t frame_timestamp) {
@@ -136,14 +136,9 @@ void VideoFrameTracker::UpdateDroppedFrames() {
     rendered_frames_on_tracker_thread_.swap(rendered_frames_on_decoder_thread_);
   }
 
-  while (!frames_to_be_rendered_.empty() &&
-         frames_to_be_rendered_.front() < seek_to_time_) {
-    // It is possible that the initial frame rendered time is before the
-    // seek to time, when the platform decides to render a frame earlier
-    // than the seek to time during preroll. This shouldn't be an issue
-    // after we align seek time to the next video key frame.
-    frames_to_be_rendered_.pop_front();
-  }
+  auto it = std::lower_bound(frames_to_be_rendered_.begin(),
+                             frames_to_be_rendered_.end(), seek_to_time_);
+  frames_to_be_rendered_.erase(frames_to_be_rendered_.begin(), it);
 
   RemoveUnexpectedRenderedFrames(frames_to_be_rendered_,
                                  &rendered_frames_on_tracker_thread_);

--- a/starboard/android/shared/video_frame_tracker.h
+++ b/starboard/android/shared/video_frame_tracker.h
@@ -15,7 +15,6 @@
 #ifndef STARBOARD_ANDROID_SHARED_VIDEO_FRAME_TRACKER_H_
 #define STARBOARD_ANDROID_SHARED_VIDEO_FRAME_TRACKER_H_
 
-#include <list>
 #include <mutex>
 #include <vector>
 
@@ -26,7 +25,9 @@ namespace starboard {
 class VideoFrameTracker {
  public:
   explicit VideoFrameTracker(int max_pending_frames_size)
-      : max_pending_frames_size_(max_pending_frames_size) {}
+      : max_pending_frames_size_(max_pending_frames_size) {
+    frames_to_be_rendered_.reserve(max_pending_frames_size + 1);
+  }
 
   int64_t seek_to_time() const;
 
@@ -43,7 +44,7 @@ class VideoFrameTracker {
 
   ThreadChecker thread_checker_;
 
-  std::list<int64_t> frames_to_be_rendered_;
+  std::vector<int64_t> frames_to_be_rendered_;
 
   const int max_pending_frames_size_;
   int dropped_frames_ = 0;

--- a/starboard/benchmark/BUILD.gn
+++ b/starboard/benchmark/BUILD.gn
@@ -24,10 +24,12 @@ target(_benchmark_type, "benchmark") {
   testonly = true
 
   sources = [
+    "//starboard/android/shared/video_frame_tracker.cc",
     "//starboard/common/benchmark_main.cc",
     "memory_benchmark.cc",
     "thread_benchmark.cc",
     "thread_id_benchmark.cc",
+    "video_frame_tracker_benchmark.cc",
   ]
 
   public_deps = [

--- a/starboard/benchmark/video_frame_tracker_benchmark.cc
+++ b/starboard/benchmark/video_frame_tracker_benchmark.cc
@@ -1,0 +1,242 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstdlib>
+#include <deque>
+#include <list>
+#include <type_traits>
+#include <vector>
+
+#include "starboard/android/shared/video_frame_tracker.h"
+#include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
+
+namespace starboard {
+namespace {
+
+template <typename Container>
+class MockVideoFrameTracker {
+ public:
+  explicit MockVideoFrameTracker(int max_pending_frames_size)
+      : max_pending_frames_size_(max_pending_frames_size) {}
+
+  void OnInputBuffer(int64_t timestamp) {
+    if (frames_to_be_rendered_.empty()) {
+      PushBack(frames_to_be_rendered_, timestamp);
+      return;
+    }
+
+    if (frames_to_be_rendered_.size() >
+        static_cast<size_t>(max_pending_frames_size_)) {
+      PopFront(frames_to_be_rendered_);
+    }
+
+    // Sort by |timestamp|, because |timestamp| won't be monotonic if there are
+    // B frames.
+    for (auto it = frames_to_be_rendered_.end();
+         it != frames_to_be_rendered_.begin();) {
+      it--;
+      if (*it < timestamp) {
+        frames_to_be_rendered_.emplace(++it, timestamp);
+        return;
+      } else if (*it == timestamp) {
+        return;
+      }
+    }
+
+    EmplaceFront(frames_to_be_rendered_, timestamp);
+  }
+
+  void OnFrameRendered(int64_t frame_timestamp) {
+    rendered_frames_on_decoder_thread_.push_back(frame_timestamp);
+  }
+
+  void Seek(int64_t seek_to_time) {
+    UpdateDroppedFrames();
+    frames_to_be_rendered_.clear();
+    seek_to_time_ = seek_to_time;
+  }
+
+  int UpdateAndGetDroppedFrames() {
+    UpdateDroppedFrames();
+    return dropped_frames_;
+  }
+
+ private:
+  void PushBack(Container& c, int64_t val) { c.push_back(val); }
+
+  void PopFront(Container& c) {
+    if constexpr (std::is_same_v<Container, std::vector<int64_t>>) {
+      c.erase(c.begin());
+    } else {
+      c.pop_front();
+    }
+  }
+
+  void EmplaceFront(Container& c, int64_t val) {
+    if constexpr (std::is_same_v<Container, std::vector<int64_t>>) {
+      c.insert(c.begin(), val);
+    } else {
+      c.emplace_front(val);
+    }
+  }
+
+  void RemoveUnexpectedRenderedFrames(const Container& frames_to_render,
+                                      std::vector<int64_t>* rendered_frames) {
+    if (rendered_frames->empty()) {
+      return;
+    }
+    if (frames_to_render.empty()) {
+      rendered_frames->clear();
+      return;
+    }
+
+    const int64_t min_valid_rendered_frame =
+        std::max<int64_t>(0, frames_to_render.front() - kMaxAllowedSkew);
+    const int64_t max_valid_rendered_frame =
+        frames_to_render.back() + kMaxAllowedSkew;
+    auto is_not_expected = [min_valid_rendered_frame,
+                            max_valid_rendered_frame](int64_t timestamp) {
+      return timestamp < min_valid_rendered_frame ||
+             max_valid_rendered_frame < timestamp;
+    };
+
+    auto to_remove = std::remove_if(rendered_frames->begin(),
+                                    rendered_frames->end(), is_not_expected);
+    rendered_frames->erase(to_remove, rendered_frames->end());
+  }
+
+  void UpdateDroppedFrames() {
+    rendered_frames_on_tracker_thread_.swap(rendered_frames_on_decoder_thread_);
+
+    while (!frames_to_be_rendered_.empty() &&
+           frames_to_be_rendered_.front() < seek_to_time_) {
+      PopFront(frames_to_be_rendered_);
+    }
+
+    RemoveUnexpectedRenderedFrames(frames_to_be_rendered_,
+                                   &rendered_frames_on_tracker_thread_);
+
+    for (auto rendered_timestamp : rendered_frames_on_tracker_thread_) {
+      auto to_render_timestamp = frames_to_be_rendered_.begin();
+      while (to_render_timestamp != frames_to_be_rendered_.end() &&
+             !(*to_render_timestamp - rendered_timestamp > kMaxAllowedSkew)) {
+        if (std::abs(*to_render_timestamp - rendered_timestamp) <=
+            kMaxAllowedSkew) {
+          to_render_timestamp =
+              frames_to_be_rendered_.erase(to_render_timestamp);
+        } else if (rendered_timestamp - *to_render_timestamp >
+                   kMaxAllowedSkew) {
+          ++dropped_frames_;
+          to_render_timestamp =
+              frames_to_be_rendered_.erase(to_render_timestamp);
+        } else {
+          ++to_render_timestamp;
+        }
+      }
+    }
+
+    rendered_frames_on_tracker_thread_.clear();
+  }
+
+  Container frames_to_be_rendered_;
+  const int max_pending_frames_size_;
+  int dropped_frames_ = 0;
+  int64_t seek_to_time_ = 0;
+
+  std::vector<int64_t> rendered_frames_on_tracker_thread_;
+  std::vector<int64_t> rendered_frames_on_decoder_thread_;
+
+  static constexpr int64_t kMaxAllowedSkew = 5000;
+};
+
+template <typename Container>
+void BM_VideoFrameTracker(::benchmark::State& state) {
+  const int kMaxPendingFrames = 256;
+  const int kFrameIntervalUs = 16666;  // 60fps
+  const int kNumFrames = 1000;
+  const int kRenderPeriod = 10;
+  const int64_t kStartPts =
+      1000000;  // Start from 1s to avoid negative PTS with skew
+
+  for (auto _ : state) {
+    MockVideoFrameTracker<Container> tracker(kMaxPendingFrames);
+
+    int64_t next_render_timestamp = 0;
+
+    for (int i = 0; i < kNumFrames; ++i) {
+      // Strictly monotonic PTS (IPPP)
+      int64_t pts = kStartPts + i * kFrameIntervalUs;
+
+      tracker.OnInputBuffer(pts);
+
+      // Periodically render frames
+      if (i > 0 && i % kRenderPeriod == 0) {
+        // Render frames up to current i
+        for (int j = next_render_timestamp; j <= i; ++j) {
+          // Simulate some skew (e.g. +/- 2ms)
+          int64_t skew = (j % 3 - 1) * 1000;
+          tracker.OnFrameRendered(kStartPts + j * kFrameIntervalUs + skew);
+        }
+        next_render_timestamp = i + 1;
+        tracker.UpdateAndGetDroppedFrames();
+      }
+    }
+  }
+  state.SetItemsProcessed(kNumFrames * state.iterations());
+}
+
+void BM_VideoFrameTrackerBaseline(::benchmark::State& state) {
+  const int kMaxPendingFrames = 256;
+  const int kFrameIntervalUs = 16666;  // 60fps
+  const int kNumFrames = 1000;
+  const int kRenderPeriod = 10;
+  const int64_t kStartPts = 1000000;
+
+  for (auto _ : state) {
+    VideoFrameTracker tracker(kMaxPendingFrames);
+
+    int64_t next_render_timestamp = 0;
+
+    for (int i = 0; i < kNumFrames; ++i) {
+      // Strictly monotonic PTS (IPPP)
+      int64_t pts = kStartPts + i * kFrameIntervalUs;
+
+      tracker.OnInputBuffer(pts);
+
+      // Periodically render frames
+      if (i > 0 && i % kRenderPeriod == 0) {
+        // Render frames up to current i
+        for (int j = next_render_timestamp; j <= i; ++j) {
+          // Simulate some skew (e.g. +/- 2ms)
+          int64_t skew = (j % 3 - 1) * 1000;
+          tracker.OnFrameRendered(kStartPts + j * kFrameIntervalUs + skew);
+        }
+        next_render_timestamp = i + 1;
+        tracker.UpdateAndGetDroppedFrames();
+      }
+    }
+  }
+  state.SetItemsProcessed(kNumFrames * state.iterations());
+}
+
+BENCHMARK_TEMPLATE(BM_VideoFrameTracker, std::list<int64_t>);
+BENCHMARK_TEMPLATE(BM_VideoFrameTracker, std::deque<int64_t>);
+BENCHMARK_TEMPLATE(BM_VideoFrameTracker, std::vector<int64_t>);
+BENCHMARK(BM_VideoFrameTrackerBaseline);
+
+}  // namespace
+}  // namespace starboard


### PR DESCRIPTION
Refactored VideoFrameTracker to use std::vector<int64_t> instead of std::list<int64_t> for tracking pending frames to be rendered.

For the typical maximum size of this queue (N <= 256), std::vector significantly outperforms std::list due to excellent cache locality and the elimination of per-element heap allocation churn, which also prevents heap fragmentation on long-running embedded devices.

Additionally, optimized UpdateDroppedFrames to use std::lower_bound and a single erase range operation instead of popping elements individually in a loop.

Benchmark Results (Monotonic PTS, No Drops/Logs):

Benchmark Case                                 | Time per Iteration   | CPU Time             | Throughput          | Perf. vs Real Baseline
------------------------------------------------|----------------------|----------------------|---------------------|------------------------
MockVideoFrameTracker<std::vector>            | 12,466 ns            | 12,459 ns            | 80.3 M/s            | ~61.7% Faster
MockVideoFrameTracker<std::list>              | 19,649 ns            | 19,641 ns            | 50.9 M/s            | ~39.6% Faster
MockVideoFrameTracker<std::deque>             | 32,419 ns            | 32,418 ns            | 30.8 M/s            | ~0.4% Faster
VideoFrameTrackerBaseline  (Real  std::list ) | 32,560 ns            | 32,550 ns            | 30.7 M/s            | Baseline

After refactoring, the real VideoFrameTrackerBaseline time dropped from 32,560 ns to 26,405 ns (~19% performance improvement for the production class) in this simulated workload.

Also added the micro-benchmark under starboard/benchmark.

TAG=agy
CONV=96ce3aad-2f27-4ebf-a9eb-9adde5c777ca