### PR TITLE
starboard: Avoid redundant free block scanning

### DIFF
--- a/starboard/common/bidirectional_fit_reuse_allocator.h
+++ b/starboard/common/bidirectional_fit_reuse_allocator.h
@@ -71,14 +71,14 @@ class BidirectionalFitReuseAllocator : public ReuseAllocatorBase {
           return it;
         }
       }
-    }
-
-    // Start looking through the free list from the back.
-    FreeBlockReverseiterator rbegin(end);
-    FreeBlockReverseiterator rend(begin);
-    for (FreeBlockReverseiterator it = rbegin; it != rend; ++it) {
-      if (it->CanFulfill(size, alignment)) {
-        return --it.base();
+    } else {
+      // Start looking through the free list from the back.
+      FreeBlockReverseiterator rbegin(end);
+      FreeBlockReverseiterator rend(begin);
+      for (FreeBlockReverseiterator it = rbegin; it != rend; ++it) {
+        if (it->CanFulfill(size, alignment)) {
+          return --it.base();
+        }
       }
     }
 


### PR DESCRIPTION
starboard: Avoid redundant free block scanning

Wrap the reverse search logic in an else block within the
BidirectionalFitReuseAllocator. This change ensures that the
allocator does not redundantly scan the free block list in reverse
when a forward scan has already been performed, improving performance
by avoiding unnecessary iterations.

Bug: 511356295