### PR TITLE
[test] Disable MH retries

### DIFF
--- a/.github/config/raspi-2-modular.json
+++ b/.github/config/raspi-2-modular.json
@@ -6,7 +6,6 @@
   "test_on_device": true,
   "test_device_family": "raspi",
   "test_root_target": "//cobalt:gn_all",
-  "test_attempts": "3",
   "test_dimensions": {
     "device_type": "raspi",
     "device_pool": "maneki"

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -360,7 +360,7 @@ def main() -> int:
   trigger_args.add_argument(
       '--test_attempts',
       type=str,
-      default='1',
+      default='0',
       help='The maximum number of times a test can retry.',
   )
   trigger_args.add_argument(


### PR DESCRIPTION
ci: Disable test retries for raspi-2-modular and set test_attempt default to 0

Remove the test_attempts configuration from the raspi-2 modular GitHub
config. This disables automatic retries for test failures in the CI
environment, providing better visibility into flakiness and ensuring
that failures are surfaced immediately.

Bug: 507140857