### PR TITLE
rdk: Fix memory deallocation mismatch in PlayerImpl::SetBounds

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -2612,7 +2612,7 @@ void PlayerImpl::SetBounds(int zindex, int x, int y, int w, int h) {
                                                "rectangle")) {
     gchar* rect = g_strdup_printf("%d,%d,%d,%d", x, y, w, h);
     g_object_set(vid_sink, "rectangle", rect, nullptr);
-    free(rect);
+    g_free(rect);
   } else {
     pending_bounds_ = PendingBounds{x, y, w, h};
   }


### PR DESCRIPTION
Memory allocated by 'g_strdup_printf' must be freed using 'g_free' instead of standard 'free' to avoid potential allocator mismatch and undefined behavior.

Issue: 516875917
