### PR TITLE
build: Update EOL Debian Buster repositories

### DIFF
--- a/docker/precommit_hooks/Dockerfile
+++ b/docker/precommit_hooks/Dockerfile
@@ -14,7 +14,10 @@
 
 FROM gcr.io/cloud-marketplace-containers/google/debian10:latest
 
-RUN apt update -qqy \
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until \
+    && apt update -qqy \
     && apt install -qqy --no-install-recommends \
         git python2 python3 python3-pip \
         python3-setuptools python3-wheel \


### PR DESCRIPTION
Debian Buster has reached End of Life (EOL), causing standard
repositories at deb.debian.org and security.debian.org to be moved to
archive.debian.org. This update modifies the pre-commit hooks
Dockerfile to point to the archive mirrors and disables the repository
validity check to allow continued use of the legacy environment.

Bug: 508470183
TAG=agy
CONV=78f70614-a187-4521-a0eb-67af17e2c1e3