### PR TITLE
cobalt: Use std::optional for cached config type

### DIFF
--- a/cobalt/browser/experiments/experiment_config_manager.cc
+++ b/cobalt/browser/experiments/experiment_config_manager.cc
@@ -127,8 +127,8 @@ ExperimentConfigManager::ExperimentConfigManager(
 }
 
 ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
-  if (has_cached_config_type_) {
-    return cached_config_type_;
+  if (cached_config_type_) {
+    return *cached_config_type_;
   }
 
   DCHECK(metrics_local_state_);
@@ -152,8 +152,7 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
                 "than to use the safe one.");
   if (num_crashes >= crash_streak_empty_config_threshold) {
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    has_cached_config_type_ = true;
-    return cached_config_type_;
+    return ExperimentConfigType::kEmptyConfig;
   }
 
   ExperimentConfigType config_type;
@@ -178,8 +177,7 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
   // treat it as an empty config.
   if (HasConfigExpired(experiment_config_) && expiration_enabled) {
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    has_cached_config_type_ = true;
-    return cached_config_type_;
+    return ExperimentConfigType::kEmptyConfig;
   }
 
   // Check if a rollback happened. If so, apply the empty config.
@@ -195,13 +193,11 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
           VersionComparisonResult::kGreaterThan) {
     UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.RollbackDetected", true);
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    has_cached_config_type_ = true;
-    return cached_config_type_;
+    return ExperimentConfigType::kEmptyConfig;
   }
 
   cached_config_type_ = config_type;
-  has_cached_config_type_ = true;
-  return cached_config_type_;
+  return config_type;
 }
 
 void ExperimentConfigManager::StoreSafeConfig() {

--- a/cobalt/browser/experiments/experiment_config_manager.h
+++ b/cobalt/browser/experiments/experiment_config_manager.h
@@ -15,6 +15,8 @@
 #ifndef COBALT_BROWSER_EXPERIMENTS_EXPERIMENT_CONFIG_MANAGER_H_
 #define COBALT_BROWSER_EXPERIMENTS_EXPERIMENT_CONFIG_MANAGER_H_
 
+#include <optional>
+
 #include "base/gtest_prod_util.h"
 #include "base/memory/raw_ptr.h"
 #include "components/prefs/pref_service.h"
@@ -67,8 +69,7 @@ class ExperimentConfigManager {
   // PrefService for metrics local state.
   const raw_ptr<PrefService> metrics_local_state_;
 
-  bool has_cached_config_type_ = false;
-  ExperimentConfigType cached_config_type_;
+  std::optional<ExperimentConfigType> cached_config_type_;
 
   FRIEND_TEST_ALL_PREFIXES(ExperimentConfigManagerTest,
                            StoreSafeConfigWithRegularConfig);


### PR DESCRIPTION
Refactor ExperimentConfigManager to use std::optional for tracking the
cached experiment configuration type. This replaces the manual boolean
flag used to indicate whether the cached value was set, simplifying
the logic and making the code more idiomatic.

Bug: 481473168