### PR TITLE
Add Evergreen test app targets.

### DIFF
--- a/.github/config/evergreen-arm-hardfp-raspi.json
+++ b/.github/config/evergreen-arm-hardfp-raspi.json
@@ -14,7 +14,10 @@
   },
   "targets": [
     "cobalt:gn_all",
-    "loader_app"
+    "loader_app",
+    "crash_sandbox",
+    "noop_sandbox",
+    "one_app_only_sandbox"
   ],
   "includes": [
     {

--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -15,7 +15,10 @@
   "targets": [
     "cobalt:gn_all",
     "loader_app",
-    "loader_app_rdk_plugin"
+    "loader_app_rdk_plugin",
+    "crash_sandbox",
+    "noop_sandbox",
+    "one_app_only_sandbox"
   ],
   "includes": [
     {

--- a/.github/config/evergreen-arm-softfp.json
+++ b/.github/config/evergreen-arm-softfp.json
@@ -5,7 +5,10 @@
   ],
   "targets": [
     "cobalt",
-    "cobalt_loaded_content"
+    "cobalt_loaded_content",
+    "crash_sandbox",
+    "noop_sandbox",
+    "one_app_only_sandbox"
   ],
   "build_configs": [
     "devel",

--- a/.github/config/evergreen-arm64.json
+++ b/.github/config/evergreen-arm64.json
@@ -6,7 +6,10 @@
   "test_package": true,
   "targets": [
     "cobalt",
-    "cobalt_loaded_content"
+    "cobalt_loaded_content",
+    "crash_sandbox",
+    "noop_sandbox",
+    "one_app_only_sandbox"
   ],
   "build_configs": [
     "debug",

--- a/.github/config/evergreen-x64.json
+++ b/.github/config/evergreen-x64.json
@@ -10,7 +10,10 @@
   "targets": [
     "cobalt:gn_all",
     "dump_syms",
-    "minidump_stackwalk"
+    "minidump_stackwalk",
+    "crash_sandbox",
+    "noop_sandbox",
+    "one_app_only_sandbox"
   ],
   "build_configs": [
     "debug",

--- a/cobalt/build/evergreen-arm-hardfp-raspi/package.json
+++ b/cobalt/build/evergreen-arm-hardfp-raspi/package.json
@@ -15,6 +15,9 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
+                "libcrash_sandbox.so",
+                "libnoop_sandbox.so",
+                "libone_app_only_sandbox.so",
                 "loader_app",
                 "native_target/crashpad_handler",
                 {
@@ -46,6 +49,18 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
+                },
+                {
+                    "from_file": "libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "dirs": [

--- a/cobalt/build/evergreen-arm-hardfp-rdk/package.json
+++ b/cobalt/build/evergreen-arm-hardfp-rdk/package.json
@@ -15,6 +15,9 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
+                "libcrash_sandbox.so",
+                "libnoop_sandbox.so",
+                "libone_app_only_sandbox.so",
                 "loader_app",
                 "libloader_app.so",
                 {
@@ -46,6 +49,18 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
+                },
+                {
+                    "from_file": "libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "dirs": [

--- a/cobalt/build/evergreen-arm-softfp/package.json
+++ b/cobalt/build/evergreen-arm-softfp/package.json
@@ -14,6 +14,9 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
+                "libcrash_sandbox.so",
+                "libnoop_sandbox.so",
+                "libone_app_only_sandbox.so",
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"
@@ -39,6 +42,18 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
+                },
+                {
+                    "from_file": "libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "archive_type": "ARCHIVE_TYPE_ZIP"

--- a/cobalt/build/evergreen-arm64/package.json
+++ b/cobalt/build/evergreen-arm64/package.json
@@ -14,6 +14,9 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
+                "libcrash_sandbox.so",
+                "libnoop_sandbox.so",
+                "libone_app_only_sandbox.so",
                 {
                     "from_file": "cobalt_shell.pak",
                     "to_file": "content/cobalt_shell.pak"
@@ -39,6 +42,18 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
+                },
+                {
+                    "from_file": "libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "archive_type": "ARCHIVE_TYPE_ZIP"

--- a/cobalt/build/evergreen-x64/package.json
+++ b/cobalt/build/evergreen-x64/package.json
@@ -15,6 +15,9 @@
                 "gen/licenses_cobalt.spdx",
                 "gen/licenses_cobalt.txt",
                 "libcobalt.so",
+                "libcrash_sandbox.so",
+                "libnoop_sandbox.so",
+                "libone_app_only_sandbox.so",
                 "loader_app",
                 "native_target/crashpad_handler",
                 {
@@ -46,6 +49,18 @@
                 {
                     "from_file": "gen/licenses_cobalt.txt",
                     "to_file": "licenses_cobalt.txt"
+                },
+                {
+                    "from_file": "libcrash_sandbox.so",
+                    "to_file": "lib/test_apps/tcrash/libcobalt.so"
+                },
+                {
+                    "from_file": "libnoop_sandbox.so",
+                    "to_file": "lib/test_apps/tnoop/libcobalt.so"
+                },
+                {
+                    "from_file": "libone_app_only_sandbox.so",
+                    "to_file": "lib/test_apps/t1app/libcobalt.so"
                 }
             ],
             "dirs": [

--- a/cobalt/devinfra/kokoro/build/evergreen/arm-hardfp-raspi/common.gcl
+++ b/cobalt/devinfra/kokoro/build/evergreen/arm-hardfp-raspi/common.gcl
@@ -17,7 +17,7 @@ build = common.build {
     },
     {
       key = 'GN_TARGET'
-      value = 'cobalt:gn_all'
+      value = 'cobalt:gn_all crash_sandbox noop_sandbox one_app_only_sandbox'
     },
     {
       key = 'TARGET_CPU'

--- a/cobalt/devinfra/kokoro/build/evergreen/arm-hardfp-rdk/common.gcl
+++ b/cobalt/devinfra/kokoro/build/evergreen/arm-hardfp-rdk/common.gcl
@@ -17,7 +17,7 @@ build = common.build {
     },
     {
       key = 'GN_TARGET'
-      value = 'cobalt:gn_all loader_app loader_app_rdk_plugin'
+      value = 'cobalt:gn_all loader_app loader_app_rdk_plugin crash_sandbox noop_sandbox one_app_only_sandbox'
     },
     {
       key = 'TARGET_CPU'

--- a/cobalt/devinfra/kokoro/build/evergreen/arm-softfp/common.gcl
+++ b/cobalt/devinfra/kokoro/build/evergreen/arm-softfp/common.gcl
@@ -17,7 +17,7 @@ build = common.build {
     },
     {
       key = 'GN_TARGET'
-      value = 'cobalt copy_cobalt_lib'
+      value = 'cobalt copy_cobalt_lib crash_sandbox noop_sandbox one_app_only_sandbox'
     },
     {
       key = 'TARGET_CPU'

--- a/cobalt/devinfra/kokoro/build/evergreen/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/evergreen/arm64/common.gcl
@@ -13,7 +13,7 @@ build = common.build {
     },
     {
       key = 'GN_TARGET'
-      value = 'cobalt copy_cobalt_lib'
+      value = 'cobalt copy_cobalt_lib crash_sandbox noop_sandbox one_app_only_sandbox'
     },
     {
       key = 'PLATFORM'

--- a/cobalt/devinfra/kokoro/build/evergreen/x64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/evergreen/x64/common.gcl
@@ -17,7 +17,7 @@ build = common.build {
     },
     {
       key = 'GN_TARGET'
-      value = 'cobalt:gn_all'
+      value = 'cobalt:gn_all crash_sandbox noop_sandbox one_app_only_sandbox'
     },
     {
       key = 'TARGET_CPU'


### PR DESCRIPTION
Add crash_sandbox, noop_sandbox, and one_app_only_sandbox Evergreen test app targets. This includes changes to GitHub, Kokoro, and packaging.

Bug: 479599580