### PR TITLE
aosp: treat warnings as errors

### DIFF
--- a/cobalt/build/configs/aosp-arm/args.gn
+++ b/cobalt/build/configs/aosp-arm/args.gn
@@ -3,6 +3,3 @@ import("//cobalt/build/configs/evergreen-x64/args.gn")
 target_cpu = "arm"
 starboard_target_platform = "aosp-arm"
 arm_float_abi = "softfp"
-
-# TODO(b/380339614): Remove this flag after resolving build errors.
-treat_warnings_as_errors = false

--- a/copied_base/base/android/radio_utils.cc
+++ b/copied_base/base/android/radio_utils.cc
@@ -5,6 +5,7 @@
 #include "base/android/radio_utils.h"
 
 #include "base/base_jni/RadioUtils_jni.h"
+#include "base/check.h"
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace base {

--- a/copied_base/base/files/file_posix.cc
+++ b/copied_base/base/files/file_posix.cc
@@ -70,7 +70,14 @@ int CallFutimes(PlatformFile file, const struct timeval times[2]) {
 
   return futimens(file, ts_times);
 #else
+#if __ANDROID_API__ < 26 && defined(__clang__)
+#pragma clang diagnostic push  // Can be removed once Cronet's min-sdk is >= 26.
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+#endif
   return futimes(file, times);
+#if __ANDROID_API__ < 26 && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 #endif
 }
 

--- a/copied_base/base/os_compat_android.cc
+++ b/copied_base/base/os_compat_android.cc
@@ -23,6 +23,9 @@
 #include "base/strings/string_piece.h"
 
 extern "C" {
+// TODO(b/374300500): when posix emulation is re-enabled, move
+// futimes to the emulation layer.
+#if __ANDROID_API__ < 26
 // There is no futimes() avaiable in Bionic, so we provide our own
 // implementation until it is there.
 int futimes(int fd, const struct timeval tv[2]) {
@@ -43,6 +46,7 @@ int futimes(int fd, const struct timeval tv[2]) {
   ts[1].tv_nsec = tv[1].tv_usec * 1000;
   return base::checked_cast<int>(syscall(__NR_utimensat, fd, NULL, ts, 0));
 }
+#endif // __ANDROID_API__ < 26
 
 #if !defined(__LP64__)
 // 32-bit Android has only timegm64() and not timegm().

--- a/copied_base/base/os_compat_android.h
+++ b/copied_base/base/os_compat_android.h
@@ -9,8 +9,10 @@
 #include <sys/types.h>
 #include <utime.h>
 
+#if __ANDROID_API__ < 26
 // Not implemented in Bionic.
 extern "C" int futimes(int fd, const struct timeval tv[2]);
+#endif  // __ANDROID_API__ < 26
 
 // Not exposed or implemented in Bionic.
 extern "C" char* mkdtemp(char* path);

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -49,6 +49,8 @@ using jni_zero::JavaParamRef;
 using jni_zero::ScopedJavaGlobalRef;
 using jni_zero::ScopedJavaLocalRef;
 
+// TODO(b/492704919): enable on AOSP when the layering violation is fixed.
+#if !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
 // Client Hint Header name constants
 constexpr char kAndroidOSExperienceHeader[] =
     "Sec-CH-UA-Co-Android-OS-Experience";
@@ -58,6 +60,7 @@ constexpr char kBuildFingerprintHeader[] =
     "Sec-CH-UA-Co-Android-Build-Fingerprint";
 constexpr char kYoutubeCertScopeHeader[] =
     "Sec-CH-UA-Co-Youtube-Certification-Scope";
+#endif  // !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
 
 // Global pointer to hold the single instance of ApplicationAndroid.
 ApplicationAndroid* g_native_app_instance = nullptr;

--- a/starboard/aosp/arm/platform_configuration/BUILD.gn
+++ b/starboard/aosp/arm/platform_configuration/BUILD.gn
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 config("platform_configuration") {
-  configs = [ "//starboard/android/shared/platform_configuration" ]
+  configs = [ "//starboard/aosp/shared/platform_configuration" ]
 
   if (current_toolchain == starboard_toolchain) {
     configs += [ "//starboard/build/config:starboard" ]

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -22,6 +22,7 @@ config("platform_configuration") {
 config("no_pedantic_warnings") {
   cflags = [
     "-Wno-missing-braces",
-    "-Wno-vla-cxx-extension"
+    "-Wno-vla-cxx-extension",
+    "-Wno-unreachable-code-return",
   ]
 }

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -21,6 +21,7 @@ config("platform_configuration") {
 
 config("no_pedantic_warnings") {
   cflags = [
+    "-Wno-missing-braces",
     "-Wno-vla-cxx-extension"
   ]
 }

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -21,7 +21,9 @@ config("platform_configuration") {
 
 config("no_pedantic_warnings") {
   cflags = [
+    "-Wno-implicit-fallthrough",
     "-Wno-missing-braces",
+    "-Wno-return-type",
     "-Wno-vla-cxx-extension",
     "-Wno-unreachable-code-return",
     "-Wno-unused-function",

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -24,5 +24,6 @@ config("no_pedantic_warnings") {
     "-Wno-missing-braces",
     "-Wno-vla-cxx-extension",
     "-Wno-unreachable-code-return",
+    "-Wno-unused-function",
   ]
 }

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -24,6 +24,7 @@ config("no_pedantic_warnings") {
     "-Wno-implicit-fallthrough",
     "-Wno-missing-braces",
     "-Wno-return-type",
+    "-Wno-sometimes-uninitialized",
     "-Wno-vla-cxx-extension",
     "-Wno-unreachable-code-return",
     "-Wno-unused-function",

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -13,5 +13,14 @@
 # limitations under the License.
 
 config("platform_configuration") {
-  configs = [ "//starboard/android/shared/platform_configuration" ]
+  configs = [
+    "//starboard/android/shared/platform_configuration",
+    ":no_pedantic_warnings",
+  ]
+}
+
+config("no_pedantic_warnings") {
+  cflags = [
+    "-Wno-vla-cxx-extension"
+  ]
 }

--- a/starboard/shared/modular/starboard_layer_posix_directory_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_directory_abi_wrappers.cc
@@ -32,7 +32,17 @@ int __abi_wrap_readdir_r(musl_dir* dirp,
 
   struct dirent entry = {0};  // The type from platform toolchain.
   struct dirent* result = nullptr;
+// from POSIX.1-2008 readdir_r() was fully supported but emitting
+// a future deprecation warning. Marked as obsolecscent in POSIX.1-2024
+// TODO(b/374300500): add back posix emulation
+#if defined(_POSIX_VERSION) && (_POSIX_VERSION < 202406L) && defined(__clang__)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+#endif
   int retval = readdir_r(dirp->dir, &entry, &result);
+#if defined(_POSIX_VERSION) && (_POSIX_VERSION < 202405L) && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
   if (retval != 0) {
     return retval;
   }

--- a/starboard/shared/modular/starboard_layer_posix_getrandom_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_getrandom_abi_wrappers.cc
@@ -32,5 +32,14 @@ ssize_t __abi_wrap_getrandom(void* buf, size_t buflen, unsigned flags) {
     return -1;
   }
 
+#if __ANDROID_API__ < 28 && defined(__clang__)
+// The API doesn exist before API Level 26
+// TODO(b/374300500): add back posix emulation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+#endif
   return getrandom(buf, buflen, platform_flags);
+#if __ANDROID_API__ < 28 && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }

--- a/starboard/shared/modular/starboard_layer_posix_pthread_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_pthread_abi_wrappers.cc
@@ -492,7 +492,16 @@ int __abi_wrap_pthread_setname_np(musl_pthread_t thread, const char* name) {
 int __abi_wrap_pthread_getname_np(musl_pthread_t thread,
                                   char* name,
                                   size_t len) {
+#if __ANDROID_API__ < 26 && defined(__clang__)
+// The API doesn exist before API Level 26
+// TODO(b/374300500): add back posix emulation
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wunguarded-availability"
+#endif
   return pthread_getname_np(reinterpret_cast<pthread_t>(thread), name, len);
+#if __ANDROID_API__ < 26 && defined(__clang__)
+#pragma clang diagnostic pop
+#endif
 }
 
 int __abi_wrap_pthread_getattr_np(musl_pthread_t thread,

--- a/third_party/zlib/BUILD.gn
+++ b/third_party/zlib/BUILD.gn
@@ -301,6 +301,12 @@ config("zlib_warnings") {
       "-Wno-incompatible-pointer-types",
       "-Wunused-variable",
     ]
+    if (is_cobalt && is_partner_toolchain) {
+      # needed because _cpu_check_features is defined under __ARM_NEON
+      # but its only caller isn't defined for ARMv7 when building using
+      # the partner toolchains
+      cflags += [ "-Wno-unused-function" ]
+    }
   }
 }
 


### PR DESCRIPTION
treat_warnings_as_errors was unset to make it easier to progress with other development tasks.

This set of changes make aost treat warnings as errors again and provide the fixes for the build errors that happen because of the warnings.

Bug: 495203133