### PR TITLE
android: Fix Android ShellManagerTest compilation

### DIFF
--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java
@@ -23,7 +23,7 @@ import android.widget.FrameLayout;
 
 import dev.cobalt.shell.Shell;
 import dev.cobalt.shell.ShellManager;
-import org.chromium.components.embedder_support.view.ContentViewRenderView;
+import dev.cobalt.shell.ContentViewRenderView;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -44,7 +44,7 @@ public class ShellManagerTest {
   private Activity mActivity;
   private ShellManager mShellManager;
   private FrameLayout mRootView;
-  @Mock private dev.cobalt.shell.ContentViewRenderView mMockContentViewRenderView;
+  @Mock private ContentViewRenderView mMockContentViewRenderView;
 
 
   @Before

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java
@@ -44,7 +44,7 @@ public class ShellManagerTest {
   private Activity mActivity;
   private ShellManager mShellManager;
   private FrameLayout mRootView;
-  @Mock private ContentViewRenderView mMockContentViewRenderView;
+  @Mock private dev.cobalt.shell.ContentViewRenderView mMockContentViewRenderView;
 
 
   @Before


### PR DESCRIPTION
Update ShellManagerTest to use the fully qualified class name for
ContentViewRenderView. This resolves a compilation error in Cobalt
Android JUnit tests caused by an ambiguous class reference.

Bug: 431780245