### PR TITLE
build: Refactor test_targets.json to paired schema

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -110,7 +110,7 @@ runs:
           #     --json-output > "${DYN_TEST_TARGETS_JSON_FILE}"
 
 
-          test_targets_json=$(cat ${{ inputs.test_targets_json_file }} | jq -cr '.test_targets')
+          test_targets_json=$(jq -cr '[.[] | select(.target != null) | .target]' ${{ inputs.test_targets_json_file }})
           echo "test_targets_json=${test_targets_json}" >> $GITHUB_OUTPUT
 
           test_targets_count=$(echo ${test_targets_json} | jq -cr 'length')

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -65,7 +65,9 @@ runs:
         failed_suites=""
         cd unit_test/
 
-        for test_binary_path in $(cat out/${{ matrix.platform }}_${{ matrix.config }}/test_targets.json | jq -cr '.executables | join(" ")'); do
+        test_targets_json="out/${{ matrix.platform }}_${{ matrix.config }}/test_targets.json"
+        test_binaries=$(jq -cr '[.[] | select(.executable != null) | .executable] | join(" ")' "${test_targets_json}")
+        for test_binary_path in ${test_binaries}; do
           filename=$(basename "${test_binary_path}")
           test_binary="${filename%%.*}"
 

--- a/.github/actions/test_targets_json/action.yaml
+++ b/.github/actions/test_targets_json/action.yaml
@@ -11,7 +11,7 @@ runs:
     - name: Test target count
       id: parse-json
       run: |
-        test_targets_json="$(cat test_targets.json | jq -cr '.test_targets')"
+        test_targets_json="$(jq -cr '[.[] | select(.target != null) | .target]' test_targets.json)"
         echo "test_targets_json=${test_targets_json}" >> $GITHUB_OUTPUT
         echo "test_targets_count=$(echo "${test_targets_json}" | jq -cr 'length')" >> $GITHUB_OUTPUT
       shell: bash

--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -39,7 +39,7 @@ runs:
         set -eux
         cd cobalt/src/
         mkdir -p "${GITHUB_WORKSPACE}/artifacts/"
-        mapfile -t targets < <(jq -r '.executables | .[]' "${TEST_TARGETS_JSON_FILE}")
+        mapfile -t targets < <(jq -r '.[] | select(.executable != null) | .executable' "${TEST_TARGETS_JSON_FILE}")
         for target in "${targets[@]}"; do
           cp "${target}" "${GITHUB_WORKSPACE}/artifacts/"
         done
@@ -66,7 +66,7 @@ runs:
           FLAGS="--compression zstd --compression-level=9"
         fi
 
-        TARGETS=$(jq -cr '.test_targets | join(",")' "${TEST_TARGETS_JSON_FILE}")
+        TARGETS=$(jq -cr '[.[] | select(.target != null) | .target] | join(",")' "${TEST_TARGETS_JSON_FILE}")
 
         # Archive browser tests if requested.
         if [[ "${ARCHIVE_BROWSERTESTS}" == "true" ]]; then

--- a/cobalt/build/testing/targets/android-arm/test_targets.json
+++ b/cobalt/build/testing/targets/android-arm/test_targets.json
@@ -1,59 +1,109 @@
-{
-  "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "test_targets": [
-    "base:base_perftests",
-    "base:base_unittests",
-    "cobalt/testing/browser_tests:cobalt_browsertests",
-    "cobalt:cobalt_unittests",
-    "media:media_unittests",
-    "media/midi:midi_unittests",
-    "mojo:mojo_perftests",
-    "mojo:mojo_unittests",
-    "net:net_unittests",
-    "skia:skia_unittests",
-    "sql:sql_unittests",
-    "starboard/nplb:nplb",
-    "starboard/android/shared:starboard_platform_tests",
-    "third_party/blink/renderer/controller:blink_unittests",
-    "third_party/blink/renderer/platform:blink_platform_perftests",
-    "third_party/blink/renderer/platform:blink_platform_unittests",
-    "third_party/blink/renderer/platform/heap:blink_heap_perftests",
-    "third_party/blink/renderer/platform/heap:blink_heap_unittests",
-    "third_party/blink/renderer/platform/wtf:wtf_unittests",
-    "third_party/boringssl:boringssl_crypto_tests",
-    "third_party/boringssl:boringssl_ssl_tests",
-    "third_party/perfetto:perfetto_unittests",
-    "third_party/perfetto:trace_processor_minimal_smoke_tests",
-    "third_party/zlib:zlib_unittests",
-    "url:url_perftests",
-    "url:url_unittests"
-  ],
-  "executables": [
-    "out/android-arm_devel/base_perftests_apk/base_perftests-debug.apk",
-    "out/android-arm_devel/base_unittests_apk/base_unittests-debug.apk",
-    "out/android-arm_devel/cobalt_browsertests_apk/cobalt_browsertests-debug.apk",
-    "out/android-arm_devel/cobalt_unittests_apk/cobalt_unittests-debug.apk",
-    "out/android-arm_devel/media_unittests_apk/media_unittests-debug.apk",
-    "out/android-arm_devel/midi_unittests_apk/midi_unittests-debug.apk",
-    "out/android-arm_devel/mojo_perftests_apk/mojo_perftests-debug.apk",
-    "out/android-arm_devel/mojo_unittests_apk/mojo_unittests-debug.apk",
-    "out/android-arm_devel/net_unittests_apk/net_unittests-debug.apk",
-    "out/android-arm_devel/skia_unittests_apk/skia_unittests-debug.apk",
-    "out/android-arm_devel/sql_unittests_apk/sql_unittests-debug.apk",
-    "out/android-arm_devel/nplb_apk/nplb-debug.apk",
-    "out/android-arm_devel/starboard_platform_tests_apk/starboard_platform_tests-debug.apk",
-    "out/android-arm_devel/blink_unittests_apk/blink_unittests-debug.apk",
-    "out/android-arm_devel/blink_platform_perftests_apk/blink_platform_perftests-debug.apk",
-    "out/android-arm_devel/blink_platform_unittests_apk/blink_platform_unittests-debug.apk",
-    "out/android-arm_devel/blink_heap_perftests_apk/blink_heap_perftests-debug.apk",
-    "out/android-arm_devel/blink_heap_unittests_apk/blink_heap_unittests-debug.apk",
-    "out/android-arm_devel/wtf_unittests_apk/wtf_unittests-debug.apk",
-    "out/android-arm_devel/boringssl_crypto_tests_apk/boringssl_crypto_tests-debug.apk",
-    "out/android-arm_devel/boringssl_ssl_tests_apk/boringssl_ssl_tests-debug.apk",
-    "out/android-arm_devel/perfetto_unittests_apk/perfetto_unittests-debug.apk",
-    "out/android-arm_devel/trace_processor_minimal_smoke_tests_apk/trace_processor_minimal_smoke_tests-debug.apk",
-    "out/android-arm_devel/zlib_unittests_apk/zlib_unittests-debug.apk",
-    "out/android-arm_devel/url_perftests_apk/url_perftests-debug.apk",
-    "out/android-arm_devel/url_unittests_apk/url_unittests-debug.apk"
-  ]
-}
+[
+  {
+    "TODO(b/382508397)": "Remove this when list is dynamically generated."
+  },
+  {
+    "target": "base:base_perftests",
+    "executable": "out/android-arm_devel/base_perftests_apk/base_perftests-debug.apk"
+  },
+  {
+    "target": "base:base_unittests",
+    "executable": "out/android-arm_devel/base_unittests_apk/base_unittests-debug.apk"
+  },
+  {
+    "target": "cobalt/testing/browser_tests:cobalt_browsertests",
+    "executable": "out/android-arm_devel/cobalt_browsertests_apk/cobalt_browsertests-debug.apk"
+  },
+  {
+    "target": "cobalt:cobalt_unittests",
+    "executable": "out/android-arm_devel/cobalt_unittests_apk/cobalt_unittests-debug.apk"
+  },
+  {
+    "target": "media:media_unittests",
+    "executable": "out/android-arm_devel/media_unittests_apk/media_unittests-debug.apk"
+  },
+  {
+    "target": "media/midi:midi_unittests",
+    "executable": "out/android-arm_devel/midi_unittests_apk/midi_unittests-debug.apk"
+  },
+  {
+    "target": "mojo:mojo_perftests",
+    "executable": "out/android-arm_devel/mojo_perftests_apk/mojo_perftests-debug.apk"
+  },
+  {
+    "target": "mojo:mojo_unittests",
+    "executable": "out/android-arm_devel/mojo_unittests_apk/mojo_unittests-debug.apk"
+  },
+  {
+    "target": "net:net_unittests",
+    "executable": "out/android-arm_devel/net_unittests_apk/net_unittests-debug.apk"
+  },
+  {
+    "target": "skia:skia_unittests",
+    "executable": "out/android-arm_devel/skia_unittests_apk/skia_unittests-debug.apk"
+  },
+  {
+    "target": "sql:sql_unittests",
+    "executable": "out/android-arm_devel/sql_unittests_apk/sql_unittests-debug.apk"
+  },
+  {
+    "target": "starboard/nplb:nplb",
+    "executable": "out/android-arm_devel/nplb_apk/nplb-debug.apk"
+  },
+  {
+    "target": "starboard/android/shared:starboard_platform_tests",
+    "executable": "out/android-arm_devel/starboard_platform_tests_apk/starboard_platform_tests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/controller:blink_unittests",
+    "executable": "out/android-arm_devel/blink_unittests_apk/blink_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform:blink_platform_perftests",
+    "executable": "out/android-arm_devel/blink_platform_perftests_apk/blink_platform_perftests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform:blink_platform_unittests",
+    "executable": "out/android-arm_devel/blink_platform_unittests_apk/blink_platform_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/heap:blink_heap_perftests",
+    "executable": "out/android-arm_devel/blink_heap_perftests_apk/blink_heap_perftests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/heap:blink_heap_unittests",
+    "executable": "out/android-arm_devel/blink_heap_unittests_apk/blink_heap_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/wtf:wtf_unittests",
+    "executable": "out/android-arm_devel/wtf_unittests_apk/wtf_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_crypto_tests",
+    "executable": "out/android-arm_devel/boringssl_crypto_tests_apk/boringssl_crypto_tests-debug.apk"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_ssl_tests",
+    "executable": "out/android-arm_devel/boringssl_ssl_tests_apk/boringssl_ssl_tests-debug.apk"
+  },
+  {
+    "target": "third_party/perfetto:perfetto_unittests",
+    "executable": "out/android-arm_devel/perfetto_unittests_apk/perfetto_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/perfetto:trace_processor_minimal_smoke_tests",
+    "executable": "out/android-arm_devel/trace_processor_minimal_smoke_tests_apk/trace_processor_minimal_smoke_tests-debug.apk"
+  },
+  {
+    "target": "third_party/zlib:zlib_unittests",
+    "executable": "out/android-arm_devel/zlib_unittests_apk/zlib_unittests-debug.apk"
+  },
+  {
+    "target": "url:url_perftests",
+    "executable": "out/android-arm_devel/url_perftests_apk/url_perftests-debug.apk"
+  },
+  {
+    "target": "url:url_unittests",
+    "executable": "out/android-arm_devel/url_unittests_apk/url_unittests-debug.apk"
+  }
+]

--- a/cobalt/build/testing/targets/android-arm64/test_targets.json
+++ b/cobalt/build/testing/targets/android-arm64/test_targets.json
@@ -1,59 +1,109 @@
-{
-  "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "test_targets": [
-    "base:base_perftests",
-    "base:base_unittests",
-    "cobalt/testing/browser_tests:cobalt_browsertests",
-    "cobalt:cobalt_unittests",
-    "media:media_unittests",
-    "media/midi:midi_unittests",
-    "mojo:mojo_perftests",
-    "mojo:mojo_unittests",
-    "net:net_unittests",
-    "skia:skia_unittests",
-    "sql:sql_unittests",
-    "starboard/nplb:nplb",
-    "starboard/android/shared:starboard_platform_tests",
-    "third_party/blink/renderer/controller:blink_unittests",
-    "third_party/blink/renderer/platform:blink_platform_perftests",
-    "third_party/blink/renderer/platform:blink_platform_unittests",
-    "third_party/blink/renderer/platform/heap:blink_heap_perftests",
-    "third_party/blink/renderer/platform/heap:blink_heap_unittests",
-    "third_party/blink/renderer/platform/wtf:wtf_unittests",
-    "third_party/boringssl:boringssl_crypto_tests",
-    "third_party/boringssl:boringssl_ssl_tests",
-    "third_party/perfetto:perfetto_unittests",
-    "third_party/perfetto:trace_processor_minimal_smoke_tests",
-    "third_party/zlib:zlib_unittests",
-    "url:url_perftests",
-    "url:url_unittests"
-  ],
-  "executables": [
-    "out/android-arm64_devel/base_perftests_apk/base_perftests-debug.apk",
-    "out/android-arm64_devel/base_unittests_apk/base_unittests-debug.apk",
-    "out/android-arm64_devel/cobalt_browsertests_apk/cobalt_browsertests-debug.apk",
-    "out/android-arm64_devel/cobalt_unittests_apk/cobalt_unittests-debug.apk",
-    "out/android-arm64_devel/media_unittests_apk/media_unittests-debug.apk",
-    "out/android-arm64_devel/midi_unittests_apk/midi_unittests-debug.apk",
-    "out/android-arm64_devel/mojo_perftests_apk/mojo_perftests-debug.apk",
-    "out/android-arm64_devel/mojo_unittests_apk/mojo_unittests-debug.apk",
-    "out/android-arm64_devel/net_unittests_apk/net_unittests-debug.apk",
-    "out/android-arm64_devel/skia_unittests_apk/skia_unittests-debug.apk",
-    "out/android-arm64_devel/sql_unittests_apk/sql_unittests-debug.apk",
-    "out/android-arm64_devel/nplb_apk/nplb-debug.apk",
-    "out/android-arm64_devel/starboard_platform_tests_apk/starboard_platform_tests-debug.apk",
-    "out/android-arm64_devel/blink_unittests_apk/blink_unittests-debug.apk",
-    "out/android-arm64_devel/blink_platform_perftests_apk/blink_platform_perftests-debug.apk",
-    "out/android-arm64_devel/blink_platform_unittests_apk/blink_platform_unittests-debug.apk",
-    "out/android-arm64_devel/blink_heap_perftests_apk/blink_heap_perftests-debug.apk",
-    "out/android-arm64_devel/blink_heap_unittests_apk/blink_heap_unittests-debug.apk",
-    "out/android-arm64_devel/wtf_unittests_apk/wtf_unittests-debug.apk",
-    "out/android-arm64_devel/boringssl_crypto_tests_apk/boringssl_crypto_tests-debug.apk",
-    "out/android-arm64_devel/boringssl_ssl_tests_apk/boringssl_ssl_tests-debug.apk",
-    "out/android-arm64_devel/perfetto_unittests_apk/perfetto_unittests-debug.apk",
-    "out/android-arm64_devel/trace_processor_minimal_smoke_tests_apk/trace_processor_minimal_smoke_tests-debug.apk",
-    "out/android-arm64_devel/zlib_unittests_apk/zlib_unittests-debug.apk",
-    "out/android-arm64_devel/url_perftests_apk/url_perftests-debug.apk",
-    "out/android-arm64_devel/url_unittests_apk/url_unittests-debug.apk"
-  ]
-}
+[
+  {
+    "TODO(b/382508397)": "Remove this when list is dynamically generated."
+  },
+  {
+    "target": "base:base_perftests",
+    "executable": "out/android-arm64_devel/base_perftests_apk/base_perftests-debug.apk"
+  },
+  {
+    "target": "base:base_unittests",
+    "executable": "out/android-arm64_devel/base_unittests_apk/base_unittests-debug.apk"
+  },
+  {
+    "target": "cobalt/testing/browser_tests:cobalt_browsertests",
+    "executable": "out/android-arm64_devel/cobalt_browsertests_apk/cobalt_browsertests-debug.apk"
+  },
+  {
+    "target": "cobalt:cobalt_unittests",
+    "executable": "out/android-arm64_devel/cobalt_unittests_apk/cobalt_unittests-debug.apk"
+  },
+  {
+    "target": "media:media_unittests",
+    "executable": "out/android-arm64_devel/media_unittests_apk/media_unittests-debug.apk"
+  },
+  {
+    "target": "media/midi:midi_unittests",
+    "executable": "out/android-arm64_devel/midi_unittests_apk/midi_unittests-debug.apk"
+  },
+  {
+    "target": "mojo:mojo_perftests",
+    "executable": "out/android-arm64_devel/mojo_perftests_apk/mojo_perftests-debug.apk"
+  },
+  {
+    "target": "mojo:mojo_unittests",
+    "executable": "out/android-arm64_devel/mojo_unittests_apk/mojo_unittests-debug.apk"
+  },
+  {
+    "target": "net:net_unittests",
+    "executable": "out/android-arm64_devel/net_unittests_apk/net_unittests-debug.apk"
+  },
+  {
+    "target": "skia:skia_unittests",
+    "executable": "out/android-arm64_devel/skia_unittests_apk/skia_unittests-debug.apk"
+  },
+  {
+    "target": "sql:sql_unittests",
+    "executable": "out/android-arm64_devel/sql_unittests_apk/sql_unittests-debug.apk"
+  },
+  {
+    "target": "starboard/nplb:nplb",
+    "executable": "out/android-arm64_devel/nplb_apk/nplb-debug.apk"
+  },
+  {
+    "target": "starboard/android/shared:starboard_platform_tests",
+    "executable": "out/android-arm64_devel/starboard_platform_tests_apk/starboard_platform_tests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/controller:blink_unittests",
+    "executable": "out/android-arm64_devel/blink_unittests_apk/blink_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform:blink_platform_perftests",
+    "executable": "out/android-arm64_devel/blink_platform_perftests_apk/blink_platform_perftests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform:blink_platform_unittests",
+    "executable": "out/android-arm64_devel/blink_platform_unittests_apk/blink_platform_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/heap:blink_heap_perftests",
+    "executable": "out/android-arm64_devel/blink_heap_perftests_apk/blink_heap_perftests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/heap:blink_heap_unittests",
+    "executable": "out/android-arm64_devel/blink_heap_unittests_apk/blink_heap_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/wtf:wtf_unittests",
+    "executable": "out/android-arm64_devel/wtf_unittests_apk/wtf_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_crypto_tests",
+    "executable": "out/android-arm64_devel/boringssl_crypto_tests_apk/boringssl_crypto_tests-debug.apk"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_ssl_tests",
+    "executable": "out/android-arm64_devel/boringssl_ssl_tests_apk/boringssl_ssl_tests-debug.apk"
+  },
+  {
+    "target": "third_party/perfetto:perfetto_unittests",
+    "executable": "out/android-arm64_devel/perfetto_unittests_apk/perfetto_unittests-debug.apk"
+  },
+  {
+    "target": "third_party/perfetto:trace_processor_minimal_smoke_tests",
+    "executable": "out/android-arm64_devel/trace_processor_minimal_smoke_tests_apk/trace_processor_minimal_smoke_tests-debug.apk"
+  },
+  {
+    "target": "third_party/zlib:zlib_unittests",
+    "executable": "out/android-arm64_devel/zlib_unittests_apk/zlib_unittests-debug.apk"
+  },
+  {
+    "target": "url:url_perftests",
+    "executable": "out/android-arm64_devel/url_perftests_apk/url_perftests-debug.apk"
+  },
+  {
+    "target": "url:url_unittests",
+    "executable": "out/android-arm64_devel/url_unittests_apk/url_unittests-debug.apk"
+  }
+]

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-raspi/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-raspi/test_targets.json
@@ -1,9 +1,9 @@
-{
-  "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "test_targets": [
-    "starboard/nplb:nplb_loader"
-  ],
-  "executables": [
-    "out/evergreen-arm-hardfp-raspi_devel/nplb_loader.py"
-  ]
-}
+[
+  {
+    "TODO(b/382508397)": "Remove this when list is dynamically generated."
+  },
+  {
+    "target": "starboard/nplb:nplb_loader",
+    "executable": "out/evergreen-arm-hardfp-raspi_devel/nplb_loader.py"
+  }
+]

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -1,53 +1,71 @@
-{
-  "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "TODO(todo): EGL init issue, needs new image": [
-    "cc:cc_unittests_loader"
-  ],
-  "TODO(b/486053854): Tests pass but crashes on exit": [
-    "gpu:gl_tests_loader",
-    "gpu:gpu_unittests_loader",
-    "ipc:ipc_tests_loader",
-    "sql:sql_unittests_loader",
-    "third_party/boringssl:boringssl_crypto_tests_loader",
-    "third_party/boringssl:boringssl_ssl_tests_loader",
-    "url:url_unittests_loader",
-    "third_party/zlib:zlib_unittests_loader"
-  ],
-  "TODO(b/486053350): Crashes on missing SbEventHandle": [
-    "compositor:compositor_unittests_loader",
-    "examples:views_examples_unittests_loader",
-    "gl:gl_unittests_loader",
-    "gl:ozone_gl_unittests_loader",
-    "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
-    "third_party/boringssl:boringssl_pki_tests_loader",
-    "third_party/ipcz/src:ipcz_tests_loader",
-    "third_party/opus:opus_tests_loader",
-    "third_party/opus:test_opus_decode_loader",
-    "third_party/opus:test_opus_encode_loader",
-    "third_party/opus:test_opus_padding_loader"
-  ],
-  "test_targets": [
-    "crypto:crypto_unittests_loader",
-    "media/mojo:media_mojo_unittests_loader",
-    "skia:skia_unittests_loader",
-    "starboard/nplb:nplb_loader",
-    "third_party/abseil-cpp:absl_hardening_tests_loader",
-    "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
-    "ui/events:events_unittests_loader",
-    "ui/ozone:ozone_unittests_loader",
-    "third_party/blink/common:blink_common_unittests_loader",
-    "storage:storage_unittests_loader"
-  ],
-  "executables": [
-    "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/media_mojo_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/skia_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/nplb_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/absl_hardening_tests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/wtf_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/events_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/ozone_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py"
-  ]
-}
+[
+  {
+    "TODO(b/382508397)": "Remove this when list is dynamically generated.",
+    "TODO(todo): EGL init issue, needs new image": [
+      "cc:cc_unittests_loader"
+    ],
+    "TODO(b/486053854): Tests pass but crashes on exit": [
+      "gpu:gl_tests_loader",
+      "gpu:gpu_unittests_loader",
+      "ipc:ipc_tests_loader",
+      "sql:sql_unittests_loader",
+      "third_party/boringssl:boringssl_crypto_tests_loader",
+      "third_party/boringssl:boringssl_ssl_tests_loader",
+      "url:url_unittests_loader",
+      "third_party/zlib:zlib_unittests_loader"
+    ],
+    "TODO(b/486053350): Crashes on missing SbEventHandle": [
+      "compositor:compositor_unittests_loader",
+      "examples:views_examples_unittests_loader",
+      "gl:gl_unittests_loader",
+      "gl:ozone_gl_unittests_loader",
+      "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
+      "third_party/boringssl:boringssl_pki_tests_loader",
+      "third_party/ipcz/src:ipcz_tests_loader",
+      "third_party/opus:opus_tests_loader",
+      "third_party/opus:test_opus_decode_loader",
+      "third_party/opus:test_opus_encode_loader",
+      "third_party/opus:test_opus_padding_loader"
+    ]
+  },
+  {
+    "target": "crypto:crypto_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py"
+  },
+  {
+    "target": "media/mojo:media_mojo_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/media_mojo_unittests_loader.py"
+  },
+  {
+    "target": "skia:skia_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/skia_unittests_loader.py"
+  },
+  {
+    "target": "starboard/nplb:nplb_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/nplb_loader.py"
+  },
+  {
+    "target": "third_party/abseil-cpp:absl_hardening_tests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/absl_hardening_tests_loader.py"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/wtf_unittests_loader.py"
+  },
+  {
+    "target": "ui/events:events_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/events_unittests_loader.py"
+  },
+  {
+    "target": "ui/ozone:ozone_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/ozone_unittests_loader.py"
+  },
+  {
+    "target": "third_party/blink/common:blink_common_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py"
+  },
+  {
+    "target": "storage:storage_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py"
+  }
+]

--- a/cobalt/build/testing/targets/evergreen-x64/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-x64/test_targets.json
@@ -1,79 +1,139 @@
-{
-  "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "disabled": {
-    "base:base_unittests_loader": "b/418842688 - Compilation failure",
-    "net:net_unittests_loader": "b/418842688 - Compilation failure",
-    "third_party/blink/renderer/platform:blink_platform_unittests_loader": "b/418842688 - Compilation failure",
-    "third_party/blink/renderer/controller:blink_unittests_loader": "b/418842688 - Compilation failure",
-    "third_party/perfetto:perfetto_unittests_loader": "b/418842688 - Compilation failure",
-    "third_party/blink/renderer/platform/heap:blink_heap_perftests_loader": "b/418842688 - Execution failure, crashes horribly",
-    "skia:skia_unittests_loader": "b/453909269 - Fails remotely",
-    "third_party/blink/renderer/platform:blink_platform_perftests_loader": "b/453909269 - Fails remotely"
+[
+  {
+    "TODO(b/382508397)": "Remove this when list is dynamically generated.",
+    "disabled": {
+      "base:base_unittests_loader": "b/418842688 - Compilation failure",
+      "net:net_unittests_loader": "b/418842688 - Compilation failure",
+      "third_party/blink/renderer/platform:blink_platform_unittests_loader": "b/418842688 - Compilation failure",
+      "third_party/blink/renderer/controller:blink_unittests_loader": "b/418842688 - Compilation failure",
+      "third_party/perfetto:perfetto_unittests_loader": "b/418842688 - Compilation failure",
+      "third_party/blink/renderer/platform/heap:blink_heap_perftests_loader": "b/418842688 - Execution failure, crashes horribly",
+      "skia:skia_unittests_loader": "b/453909269 - Fails remotely",
+      "third_party/blink/renderer/platform:blink_platform_perftests_loader": "b/453909269 - Fails remotely"
+    }
   },
-  "test_targets": [
-    "base:base_perftests_loader",
-    "cc:cc_perftests_loader",
-    "cc:cc_unittests_loader",
-    "cobalt:cobalt_unittests_loader",
-    "components/viz:viz_perftests_loader",
-    "components/viz:viz_unittests_loader",
-    "crypto:crypto_unittests_loader",
-    "google_apis:google_apis_unittests_loader",
-    "google_apis/gcm:gcm_unit_tests_loader",
-    "gpu:command_buffer_perftests_loader",
-    "gpu:gl_tests_loader",
-    "gpu:gpu_perftests_loader",
-    "gpu:gpu_unittests_loader",
-    "media:media_unittests_loader",
-    "media/capture:capture_unittests_loader",
-    "media/midi:midi_unittests_loader",
-    "mojo:mojo_perftests_loader",
-    "mojo:mojo_unittests_loader",
-    "sql:sql_unittests_loader",
-    "starboard/nplb:nplb_loader",
-    "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
-    "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
-    "third_party/boringssl:boringssl_crypto_tests_loader",
-    "third_party/boringssl:boringssl_ssl_tests_loader",
-    "third_party/perfetto:trace_processor_minimal_smoke_tests_loader",
-    "third_party/zlib:zlib_unittests_loader",
-    "ui/events:events_unittests_loader",
-    "ui/ozone:ozone_unittests_loader",
-    "ui/wm:wm_unittests_loader",
-    "url:url_perftests_loader",
-    "url:url_unittests_loader"
-  ],
-  "executables": [
-    "out/evergreen-x64_devel/base_perftests_loader.py",
-    "out/evergreen-x64_devel/blink_heap_unittests_loader.py",
-    "out/evergreen-x64_devel/boringssl_crypto_tests_loader.py",
-    "out/evergreen-x64_devel/boringssl_ssl_tests_loader.py",
-    "out/evergreen-x64_devel/capture_unittests_loader.py",
-    "out/evergreen-x64_devel/cc_perftests_loader.py",
-    "out/evergreen-x64_devel/cc_unittests_loader.py",
-    "out/evergreen-x64_devel/cobalt_unittests_loader.py",
-    "out/evergreen-x64_devel/command_buffer_perftests_loader.py",
-    "out/evergreen-x64_devel/crypto_unittests_loader.py",
-    "out/evergreen-x64_devel/events_unittests_loader.py",
-    "out/evergreen-x64_devel/gcm_unit_tests_loader.py",
-    "out/evergreen-x64_devel/google_apis_unittests_loader.py",
-    "out/evergreen-x64_devel/gl_tests_loader.py",
-    "out/evergreen-x64_devel/gpu_perftests_loader.py",
-    "out/evergreen-x64_devel/gpu_unittests_loader.py",
-    "out/evergreen-x64_devel/media_unittests_loader.py",
-    "out/evergreen-x64_devel/midi_unittests_loader.py",
-    "out/evergreen-x64_devel/mojo_perftests_loader.py",
-    "out/evergreen-x64_devel/mojo_unittests_loader.py",
-    "out/evergreen-x64_devel/nplb_loader.py",
-    "out/evergreen-x64_devel/ozone_unittests_loader.py",
-    "out/evergreen-x64_devel/sql_unittests_loader.py",
-    "out/evergreen-x64_devel/trace_processor_minimal_smoke_tests_loader.py",
-    "out/evergreen-x64_devel/url_perftests_loader.py",
-    "out/evergreen-x64_devel/url_unittests_loader.py",
-    "out/evergreen-x64_devel/viz_perftests_loader.py",
-    "out/evergreen-x64_devel/viz_unittests_loader.py",
-    "out/evergreen-x64_devel/wm_unittests_loader.py",
-    "out/evergreen-x64_devel/wtf_unittests_loader.py",
-    "out/evergreen-x64_devel/zlib_unittests_loader.py"
-  ]
-}
+  {
+    "target": "base:base_perftests_loader",
+    "executable": "out/evergreen-x64_devel/base_perftests_loader.py"
+  },
+  {
+    "target": "cc:cc_perftests_loader",
+    "executable": "out/evergreen-x64_devel/cc_perftests_loader.py"
+  },
+  {
+    "target": "cc:cc_unittests_loader",
+    "executable": "out/evergreen-x64_devel/cc_unittests_loader.py"
+  },
+  {
+    "target": "cobalt:cobalt_unittests_loader",
+    "executable": "out/evergreen-x64_devel/cobalt_unittests_loader.py"
+  },
+  {
+    "target": "components/viz:viz_perftests_loader",
+    "executable": "out/evergreen-x64_devel/viz_perftests_loader.py"
+  },
+  {
+    "target": "components/viz:viz_unittests_loader",
+    "executable": "out/evergreen-x64_devel/viz_unittests_loader.py"
+  },
+  {
+    "target": "crypto:crypto_unittests_loader",
+    "executable": "out/evergreen-x64_devel/crypto_unittests_loader.py"
+  },
+  {
+    "target": "google_apis:google_apis_unittests_loader",
+    "executable": "out/evergreen-x64_devel/google_apis_unittests_loader.py"
+  },
+  {
+    "target": "google_apis/gcm:gcm_unit_tests_loader",
+    "executable": "out/evergreen-x64_devel/gcm_unit_tests_loader.py"
+  },
+  {
+    "target": "gpu:command_buffer_perftests_loader",
+    "executable": "out/evergreen-x64_devel/command_buffer_perftests_loader.py"
+  },
+  {
+    "target": "gpu:gl_tests_loader",
+    "executable": "out/evergreen-x64_devel/gl_tests_loader.py"
+  },
+  {
+    "target": "gpu:gpu_perftests_loader",
+    "executable": "out/evergreen-x64_devel/gpu_perftests_loader.py"
+  },
+  {
+    "target": "gpu:gpu_unittests_loader",
+    "executable": "out/evergreen-x64_devel/gpu_unittests_loader.py"
+  },
+  {
+    "target": "media:media_unittests_loader",
+    "executable": "out/evergreen-x64_devel/media_unittests_loader.py"
+  },
+  {
+    "target": "media/capture:capture_unittests_loader",
+    "executable": "out/evergreen-x64_devel/capture_unittests_loader.py"
+  },
+  {
+    "target": "media/midi:midi_unittests_loader",
+    "executable": "out/evergreen-x64_devel/midi_unittests_loader.py"
+  },
+  {
+    "target": "mojo:mojo_perftests_loader",
+    "executable": "out/evergreen-x64_devel/mojo_perftests_loader.py"
+  },
+  {
+    "target": "mojo:mojo_unittests_loader",
+    "executable": "out/evergreen-x64_devel/mojo_unittests_loader.py"
+  },
+  {
+    "target": "sql:sql_unittests_loader",
+    "executable": "out/evergreen-x64_devel/sql_unittests_loader.py"
+  },
+  {
+    "target": "starboard/nplb:nplb_loader",
+    "executable": "out/evergreen-x64_devel/nplb_loader.py"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
+    "executable": "out/evergreen-x64_devel/blink_heap_unittests_loader.py"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
+    "executable": "out/evergreen-x64_devel/wtf_unittests_loader.py"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_crypto_tests_loader",
+    "executable": "out/evergreen-x64_devel/boringssl_crypto_tests_loader.py"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_ssl_tests_loader",
+    "executable": "out/evergreen-x64_devel/boringssl_ssl_tests_loader.py"
+  },
+  {
+    "target": "third_party/perfetto:trace_processor_minimal_smoke_tests_loader",
+    "executable": "out/evergreen-x64_devel/trace_processor_minimal_smoke_tests_loader.py"
+  },
+  {
+    "target": "third_party/zlib:zlib_unittests_loader",
+    "executable": "out/evergreen-x64_devel/zlib_unittests_loader.py"
+  },
+  {
+    "target": "ui/events:events_unittests_loader",
+    "executable": "out/evergreen-x64_devel/events_unittests_loader.py"
+  },
+  {
+    "target": "ui/ozone:ozone_unittests_loader",
+    "executable": "out/evergreen-x64_devel/ozone_unittests_loader.py"
+  },
+  {
+    "target": "ui/wm:wm_unittests_loader",
+    "executable": "out/evergreen-x64_devel/wm_unittests_loader.py"
+  },
+  {
+    "target": "url:url_perftests_loader",
+    "executable": "out/evergreen-x64_devel/url_perftests_loader.py"
+  },
+  {
+    "target": "url:url_unittests_loader",
+    "executable": "out/evergreen-x64_devel/url_unittests_loader.py"
+  }
+]

--- a/cobalt/build/testing/targets/linux-x64x11-modular/test_targets.json
+++ b/cobalt/build/testing/targets/linux-x64x11-modular/test_targets.json
@@ -1,75 +1,124 @@
-{
-  "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "disabled": {
-    "base:base_unittests_loader": "b/418842688 - Compilation failure",
-    "cobalt:cobalt_unittests_loader": "b/453909269 - Devtools missing inputs",
-    "gpu:gpu_benchmark_loader": "b/453909269 - Devtools missing inputs",
-    "gpu:gpu_perftests_loader": "b/418842688 - Compilation failure",
-    "media:media_unittests_loader": "b/418842688 - Compilation failure",
-    "mojo:mojo_perftests_loader": "b/418842688 - Compilation failure",
-    "net:net_unittests_loader": "b/418842688 - Compilation failure",
-    "third_party/blink/renderer/platform/heap:blink_heap_perftests_loader": "b/418842688 - Execution failure, crashes horribly",
-    "third_party/blink/renderer/controller:blink_unittests_loader": "b/453909269 - Devtools missing inputs",
-    "third_party/blink/renderer/platform:blink_platform_unittests_loader": "b/418842688 - Compilation failure",
-    "third_party/perfetto:perfetto_unittests_loader": "b/418842688 - Compilation failure",
-    "ui/wm:wm_unittests_loader": "b/418842688 - Compilation failure",
-    "third_party/blink/renderer/platform:blink_platform_perftests_loader": "b/453909269 - Fails remotely"
+[
+  {
+    "TODO(b/382508397)": "Remove this when list is dynamically generated.",
+    "disabled": {
+      "base:base_unittests_loader": "b/418842688 - Compilation failure",
+      "cobalt:cobalt_unittests_loader": "b/453909269 - Devtools missing inputs",
+      "gpu:gpu_benchmark_loader": "b/453909269 - Devtools missing inputs",
+      "gpu:gpu_perftests_loader": "b/418842688 - Compilation failure",
+      "media:media_unittests_loader": "b/418842688 - Compilation failure",
+      "mojo:mojo_perftests_loader": "b/418842688 - Compilation failure",
+      "net:net_unittests_loader": "b/418842688 - Compilation failure",
+      "third_party/blink/renderer/platform/heap:blink_heap_perftests_loader": "b/418842688 - Execution failure, crashes horribly",
+      "third_party/blink/renderer/controller:blink_unittests_loader": "b/453909269 - Devtools missing inputs",
+      "third_party/blink/renderer/platform:blink_platform_unittests_loader": "b/418842688 - Compilation failure",
+      "third_party/perfetto:perfetto_unittests_loader": "b/418842688 - Compilation failure",
+      "ui/wm:wm_unittests_loader": "b/418842688 - Compilation failure",
+      "third_party/blink/renderer/platform:blink_platform_perftests_loader": "b/453909269 - Fails remotely"
+    }
   },
-  "test_targets": [
-    "base:base_perftests_loader",
-    "cc:cc_perftests_loader",
-    "cc:cc_unittests_loader",
-    "components/viz:viz_perftests_loader",
-    "components/viz:viz_unittests_loader",
-    "crypto:crypto_unittests_loader",
-    "google_apis:google_apis_unittests_loader",
-    "google_apis/gcm:gcm_unit_tests_loader",
-    "gpu:command_buffer_perftests_loader",
-    "gpu:gl_tests_loader",
-    "gpu:gpu_unittests_loader",
-    "media/capture:capture_unittests_loader",
-    "media/midi:midi_unittests_loader",
-    "mojo:mojo_unittests_loader",
-    "skia:skia_unittests_loader",
-    "sql:sql_unittests_loader",
-    "starboard/nplb:nplb_loader",
-    "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
-    "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
-    "third_party/boringssl:boringssl_crypto_tests_loader",
-    "third_party/boringssl:boringssl_ssl_tests_loader",
-    "third_party/perfetto:trace_processor_minimal_smoke_tests_loader",
-    "third_party/zlib:zlib_unittests_loader",
-    "ui/ozone:ozone_unittests_loader",
-    "url:url_perftests_loader",
-    "url:url_unittests_loader"
-  ],
-  "executables": [
-    "out/linux-x64x11-modular_devel/base_perftests_loader",
-    "out/linux-x64x11-modular_devel/blink_heap_perftests_loader",
-    "out/linux-x64x11-modular_devel/blink_heap_unittests_loader",
-    "out/linux-x64x11-modular_devel/boringssl_crypto_tests_loader",
-    "out/linux-x64x11-modular_devel/boringssl_ssl_tests_loader",
-    "out/linux-x64x11-modular_devel/capture_unittests_loader",
-    "out/linux-x64x11-modular_devel/cc_perftests_loader",
-    "out/linux-x64x11-modular_devel/cc_unittests_loader",
-    "out/linux-x64x11-modular_devel/command_buffer_perftests_loader",
-    "out/linux-x64x11-modular_devel/crypto_unittests_loader",
-    "out/linux-x64x11-modular_devel/gcm_unit_tests_loader",
-    "out/linux-x64x11-modular_devel/google_apis_unittests_loader",
-    "out/linux-x64x11-modular_devel/gl_tests_loader",
-    "out/linux-x64x11-modular_devel/gpu_unittests_loader",
-    "out/linux-x64x11-modular_devel/midi_unittests_loader",
-    "out/linux-x64x11-modular_devel/mojo_unittests_loader",
-    "out/linux-x64x11-modular_devel/nplb_loader",
-    "out/linux-x64x11-modular_devel/ozone_unittests_loader",
-    "out/linux-x64x11-modular_devel/skia_unittests_loader",
-    "out/linux-x64x11-modular_devel/sql_unittests_loader",
-    "out/linux-x64x11-modular_devel/trace_processor_minimal_smoke_tests_loader",
-    "out/linux-x64x11-modular_devel/url_perftests_loader",
-    "out/linux-x64x11-modular_devel/url_unittests_loader",
-    "out/linux-x64x11-modular_devel/viz_perftests_loader",
-    "out/linux-x64x11-modular_devel/viz_unittests_loader",
-    "out/linux-x64x11-modular_devel/wtf_unittests_loader",
-    "out/linux-x64x11-modular_devel/zlib_unittests_loader"
-  ]
-}
+  {
+    "target": "base:base_perftests_loader",
+    "executable": "out/linux-x64x11-modular_devel/base_perftests_loader"
+  },
+  {
+    "target": "cc:cc_perftests_loader",
+    "executable": "out/linux-x64x11-modular_devel/cc_perftests_loader"
+  },
+  {
+    "target": "cc:cc_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/cc_unittests_loader"
+  },
+  {
+    "target": "components/viz:viz_perftests_loader",
+    "executable": "out/linux-x64x11-modular_devel/viz_perftests_loader"
+  },
+  {
+    "target": "components/viz:viz_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/viz_unittests_loader"
+  },
+  {
+    "target": "crypto:crypto_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/crypto_unittests_loader"
+  },
+  {
+    "target": "google_apis:google_apis_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/google_apis_unittests_loader"
+  },
+  {
+    "target": "google_apis/gcm:gcm_unit_tests_loader",
+    "executable": "out/linux-x64x11-modular_devel/gcm_unit_tests_loader"
+  },
+  {
+    "target": "gpu:command_buffer_perftests_loader",
+    "executable": "out/linux-x64x11-modular_devel/command_buffer_perftests_loader"
+  },
+  {
+    "target": "gpu:gl_tests_loader",
+    "executable": "out/linux-x64x11-modular_devel/gl_tests_loader"
+  },
+  {
+    "target": "gpu:gpu_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/gpu_unittests_loader"
+  },
+  {
+    "target": "media/capture:capture_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/capture_unittests_loader"
+  },
+  {
+    "target": "media/midi:midi_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/midi_unittests_loader"
+  },
+  {
+    "target": "mojo:mojo_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/mojo_unittests_loader"
+  },
+  {
+    "target": "skia:skia_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/skia_unittests_loader"
+  },
+  {
+    "target": "sql:sql_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/sql_unittests_loader"
+  },
+  {
+    "target": "starboard/nplb:nplb_loader",
+    "executable": "out/linux-x64x11-modular_devel/nplb_loader"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/blink_heap_unittests_loader"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/wtf_unittests_loader"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_crypto_tests_loader",
+    "executable": "out/linux-x64x11-modular_devel/boringssl_crypto_tests_loader"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_ssl_tests_loader",
+    "executable": "out/linux-x64x11-modular_devel/boringssl_ssl_tests_loader"
+  },
+  {
+    "target": "third_party/perfetto:trace_processor_minimal_smoke_tests_loader",
+    "executable": "out/linux-x64x11-modular_devel/trace_processor_minimal_smoke_tests_loader"
+  },
+  {
+    "target": "third_party/zlib:zlib_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/zlib_unittests_loader"
+  },
+  {
+    "target": "ui/ozone:ozone_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/ozone_unittests_loader"
+  },
+  {
+    "target": "url:url_perftests_loader",
+    "executable": "out/linux-x64x11-modular_devel/url_perftests_loader"
+  },
+  {
+    "target": "url:url_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/url_unittests_loader"
+  }
+]

--- a/cobalt/build/testing/targets/linux-x64x11-no-starboard/test_targets.json
+++ b/cobalt/build/testing/targets/linux-x64x11-no-starboard/test_targets.json
@@ -1,7 +1,5 @@
-{
-  "test_targets": [
-    ":blink_web_tests"
-  ],
-  "executables": [
-  ]
-}
+[
+  {
+    "target": ":blink_web_tests"
+  }
+]

--- a/cobalt/build/testing/targets/linux-x64x11/test_targets.json
+++ b/cobalt/build/testing/targets/linux-x64x11/test_targets.json
@@ -1,84 +1,150 @@
-{
-  "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "disabled": {
-    "cobalt:cobalt_unittests": "b/453909269 - Devtools missing inputs",
-    "gpu:gpu_benchmark": "b/453909269 - Devtools missing inputs",
-    "third_party/blink/renderer/controller:blink_unittests": "b/453909269 - Devtools missing inputs",
-    "third_party/blink/renderer/platform:blink_platform_nocompile_tests": "b/453909269 - Packaging issue",
-    "third_party/blink/renderer/platform/heap:blink_heap_perftests": "b/453909269 - crashes on startup",
-    "net:net_unittests": "b/453909269 - Fails remotely",
-    "media:media_unittests": "b/453909269 - Fails remotely"
+[
+  {
+    "TODO(b/382508397)": "Remove this when list is dynamically generated.",
+    "disabled": {
+      "cobalt:cobalt_unittests": "b/453909269 - Devtools missing inputs",
+      "gpu:gpu_benchmark": "b/453909269 - Devtools missing inputs",
+      "third_party/blink/renderer/controller:blink_unittests": "b/453909269 - Devtools missing inputs",
+      "third_party/blink/renderer/platform:blink_platform_nocompile_tests": "b/453909269 - Packaging issue",
+      "third_party/blink/renderer/platform/heap:blink_heap_perftests": "b/453909269 - crashes on startup",
+      "net:net_unittests": "b/453909269 - Fails remotely",
+      "media:media_unittests": "b/453909269 - Fails remotely"
+    }
   },
-  "test_targets": [
-    "base:base_perftests",
-    "base:base_unittests",
-    "cc:cc_perftests",
-    "cc:cc_unittests",
-    "components/viz:viz_perftests",
-    "components/viz:viz_unittests",
-    "crypto:crypto_unittests",
-    "google_apis:google_apis_unittests",
-    "google_apis/gcm:gcm_unit_tests",
-    "gpu:command_buffer_perftests",
-    "gpu:gl_tests",
-    "gpu:gpu_perftests",
-    "gpu:gpu_unittests",
-    "media/capture:capture_unittests",
-    "media/midi:midi_unittests",
-    "mojo:mojo_perftests",
-    "mojo:mojo_unittests",
-    "skia:skia_unittests",
-    "sql:sql_unittests",
-    "starboard:starboard_unittests_wrapper",
-    "starboard/nplb:nplb",
-    "third_party/blink/renderer/platform:blink_platform_perftests",
-    "third_party/blink/renderer/platform:blink_platform_unittests",
-    "third_party/blink/renderer/platform/heap:blink_heap_unittests",
-    "third_party/blink/renderer/platform/wtf:wtf_unittests",
-    "third_party/boringssl:boringssl_crypto_tests",
-    "third_party/boringssl:boringssl_ssl_tests",
-    "third_party/perfetto:perfetto_unittests",
-    "third_party/perfetto:trace_processor_minimal_smoke_tests",
-    "third_party/zlib:zlib_unittests",
-    "ui/ozone:ozone_unittests",
-    "ui/wm:wm_unittests",
-    "url:url_perftests",
-    "url:url_unittests"
-  ],
-  "executables": [
-    "out/linux-x64x11_devel/base_perftests",
-    "out/linux-x64x11_devel/base_unittests",
-    "out/linux-x64x11_devel/blink_heap_unittests",
-    "out/linux-x64x11_devel/blink_platform_perftests",
-    "out/linux-x64x11_devel/blink_platform_unittests",
-    "out/linux-x64x11_devel/boringssl_crypto_tests",
-    "out/linux-x64x11_devel/boringssl_ssl_tests",
-    "out/linux-x64x11_devel/capture_unittests",
-    "out/linux-x64x11_devel/cc_perftests",
-    "out/linux-x64x11_devel/cc_unittests",
-    "out/linux-x64x11_devel/command_buffer_perftests",
-    "out/linux-x64x11_devel/crypto_unittests",
-    "out/linux-x64x11_devel/gcm_unit_tests",
-    "out/linux-x64x11_devel/google_apis_unittests",
-    "out/linux-x64x11_devel/gl_tests",
-    "out/linux-x64x11_devel/gpu_perftests",
-    "out/linux-x64x11_devel/gpu_unittests",
-    "out/linux-x64x11_devel/midi_unittests",
-    "out/linux-x64x11_devel/mojo_perftests",
-    "out/linux-x64x11_devel/mojo_unittests",
-    "out/linux-x64x11_devel/nplb",
-    "out/linux-x64x11_devel/ozone_unittests",
-    "out/linux-x64x11_devel/perfetto_unittests",
-    "out/linux-x64x11_devel/skia_unittests",
-    "out/linux-x64x11_devel/sql_unittests",
-    "out/linux-x64x11_devel/starboard_unittests_wrapper",
-    "out/linux-x64x11_devel/trace_processor_minimal_smoke_tests",
-    "out/linux-x64x11_devel/url_perftests",
-    "out/linux-x64x11_devel/url_unittests",
-    "out/linux-x64x11_devel/viz_perftests",
-    "out/linux-x64x11_devel/viz_unittests",
-    "out/linux-x64x11_devel/wm_unittests",
-    "out/linux-x64x11_devel/wtf_unittests",
-    "out/linux-x64x11_devel/zlib_unittests"
-  ]
-}
+  {
+    "target": "base:base_perftests",
+    "executable": "out/linux-x64x11_devel/base_perftests"
+  },
+  {
+    "target": "base:base_unittests",
+    "executable": "out/linux-x64x11_devel/base_unittests"
+  },
+  {
+    "target": "cc:cc_perftests",
+    "executable": "out/linux-x64x11_devel/cc_perftests"
+  },
+  {
+    "target": "cc:cc_unittests",
+    "executable": "out/linux-x64x11_devel/cc_unittests"
+  },
+  {
+    "target": "components/viz:viz_perftests",
+    "executable": "out/linux-x64x11_devel/viz_perftests"
+  },
+  {
+    "target": "components/viz:viz_unittests",
+    "executable": "out/linux-x64x11_devel/viz_unittests"
+  },
+  {
+    "target": "crypto:crypto_unittests",
+    "executable": "out/linux-x64x11_devel/crypto_unittests"
+  },
+  {
+    "target": "google_apis:google_apis_unittests",
+    "executable": "out/linux-x64x11_devel/google_apis_unittests"
+  },
+  {
+    "target": "google_apis/gcm:gcm_unit_tests",
+    "executable": "out/linux-x64x11_devel/gcm_unit_tests"
+  },
+  {
+    "target": "gpu:command_buffer_perftests",
+    "executable": "out/linux-x64x11_devel/command_buffer_perftests"
+  },
+  {
+    "target": "gpu:gl_tests",
+    "executable": "out/linux-x64x11_devel/gl_tests"
+  },
+  {
+    "target": "gpu:gpu_perftests",
+    "executable": "out/linux-x64x11_devel/gpu_perftests"
+  },
+  {
+    "target": "gpu:gpu_unittests",
+    "executable": "out/linux-x64x11_devel/gpu_unittests"
+  },
+  {
+    "target": "media/capture:capture_unittests",
+    "executable": "out/linux-x64x11_devel/capture_unittests"
+  },
+  {
+    "target": "media/midi:midi_unittests",
+    "executable": "out/linux-x64x11_devel/midi_unittests"
+  },
+  {
+    "target": "mojo:mojo_perftests",
+    "executable": "out/linux-x64x11_devel/mojo_perftests"
+  },
+  {
+    "target": "mojo:mojo_unittests",
+    "executable": "out/linux-x64x11_devel/mojo_unittests"
+  },
+  {
+    "target": "skia:skia_unittests",
+    "executable": "out/linux-x64x11_devel/skia_unittests"
+  },
+  {
+    "target": "sql:sql_unittests",
+    "executable": "out/linux-x64x11_devel/sql_unittests"
+  },
+  {
+    "target": "starboard:starboard_unittests_wrapper",
+    "executable": "out/linux-x64x11_devel/starboard_unittests_wrapper"
+  },
+  {
+    "target": "starboard/nplb:nplb",
+    "executable": "out/linux-x64x11_devel/nplb"
+  },
+  {
+    "target": "third_party/blink/renderer/platform:blink_platform_perftests",
+    "executable": "out/linux-x64x11_devel/blink_platform_perftests"
+  },
+  {
+    "target": "third_party/blink/renderer/platform:blink_platform_unittests",
+    "executable": "out/linux-x64x11_devel/blink_platform_unittests"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/heap:blink_heap_unittests",
+    "executable": "out/linux-x64x11_devel/blink_heap_unittests"
+  },
+  {
+    "target": "third_party/blink/renderer/platform/wtf:wtf_unittests",
+    "executable": "out/linux-x64x11_devel/wtf_unittests"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_crypto_tests",
+    "executable": "out/linux-x64x11_devel/boringssl_crypto_tests"
+  },
+  {
+    "target": "third_party/boringssl:boringssl_ssl_tests",
+    "executable": "out/linux-x64x11_devel/boringssl_ssl_tests"
+  },
+  {
+    "target": "third_party/perfetto:perfetto_unittests",
+    "executable": "out/linux-x64x11_devel/perfetto_unittests"
+  },
+  {
+    "target": "third_party/perfetto:trace_processor_minimal_smoke_tests",
+    "executable": "out/linux-x64x11_devel/trace_processor_minimal_smoke_tests"
+  },
+  {
+    "target": "third_party/zlib:zlib_unittests",
+    "executable": "out/linux-x64x11_devel/zlib_unittests"
+  },
+  {
+    "target": "ui/ozone:ozone_unittests",
+    "executable": "out/linux-x64x11_devel/ozone_unittests"
+  },
+  {
+    "target": "ui/wm:wm_unittests",
+    "executable": "out/linux-x64x11_devel/wm_unittests"
+  },
+  {
+    "target": "url:url_perftests",
+    "executable": "out/linux-x64x11_devel/url_perftests"
+  },
+  {
+    "target": "url:url_unittests",
+    "executable": "out/linux-x64x11_devel/url_unittests"
+  }
+]

--- a/cobalt/build/testing/targets/raspi-2-modular/test_targets.json
+++ b/cobalt/build/testing/targets/raspi-2-modular/test_targets.json
@@ -1,9 +1,9 @@
-{
-  "TODO(b/382508397)": "Remove this when list is dynamically generated.",
-  "test_targets": [
-    "starboard/nplb:nplb_loader"
-  ],
-  "executables": [
-    "out/raspi-2-modular_devel/nplb_loader"
-  ]
-}
+[
+  {
+    "TODO(b/382508397)": "Remove this when list is dynamically generated."
+  },
+  {
+    "target": "starboard/nplb:nplb_loader",
+    "executable": "out/raspi-2-modular_devel/nplb_loader"
+  }
+]

--- a/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json
+++ b/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json
@@ -1,12 +1,16 @@
-{
-  "test_targets": [
-    "base:base_perftests",
-    "base:base_unittests",
-    "cobalt/testing/browser_tests:cobalt_browsertests"
-  ],
-  "TODO(b/507872542)": "Revisit this and determine how we configure tvOS tests.",
-  "executables": [
-    "out/arm64-simulator_devel/bin/base_perftests",
-    "out/arm64-simulator_devel/bin/base_unittests"
-  ]
-}
+[
+  {
+    "TODO(b/507872542)": "Revisit this and determine how we configure tvOS tests."
+  },
+  {
+    "target": "base:base_perftests",
+    "executable": "out/arm64-simulator_devel/bin/base_perftests"
+  },
+  {
+    "target": "base:base_unittests",
+    "executable": "out/arm64-simulator_devel/bin/base_unittests"
+  },
+  {
+    "target": "cobalt/testing/browser_tests:cobalt_browsertests"
+  }
+]

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -80,7 +80,9 @@ EOF
   # Extract test targets from JSON.
   local test_targets_json="${WORKSPACE_COBALT}/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json"
   if [[ -f "${test_targets_json}" ]]; then
-    local json_targets=$(python3 -c "import json, re; print(' '.join(t.split(':')[-1] for t in json.loads(re.sub(r'//.*', '', open('${test_targets_json}').read())).get('test_targets', [])))")
+    # Extract test targets from the JSON file (list of dicts schema)
+    # and format them as a space-separated list of target names (after the colon).
+    local json_targets=$(python3 -c "import json, re; data=json.loads(re.sub(r'//.*', '', open('${test_targets_json}').read())); targets=[e['target'] for e in data if isinstance(e, dict) and 'target' in e]; print(' '.join(t.split(':')[-1] for t in targets))")
     GN_TARGET="${GN_TARGET:-} ${json_targets}"
   fi
 

--- a/cobalt/tools/code_coverage/run_coverage.py
+++ b/cobalt/tools/code_coverage/run_coverage.py
@@ -65,8 +65,11 @@ def discover_targets(test_targets_dir, platform):
   if os.path.exists(target_file):
     with open(target_file, 'r', encoding='utf-8') as f:
       data = json.load(f)
-      if 'test_targets' in data:
-        discovered_targets.extend(data['test_targets'])
+      # The schema is a list of dicts, which pairs each target with its
+      # executable (if defined).
+      for entry in data:
+        if isinstance(entry, dict) and 'target' in entry:
+          discovered_targets.append(entry['target'])
   return discovered_targets
 
 

--- a/cobalt/tools/code_coverage/test_run_coverage.py
+++ b/cobalt/tools/code_coverage/test_run_coverage.py
@@ -296,11 +296,11 @@ class RunCoverageTest(unittest.TestCase):
         'android-arm64/test_targets.json' in path)
 
     # Mock the content of test_targets.json for android-arm
-    mock_arm_json_content = (
-        '{"test_targets": ["android_arm_target1", "android_arm_target2"]}')
+    mock_arm_json_content = ('[{"target": "android_arm_target1"}, '
+                             '{"target": "android_arm_target2"}]')
     # Mock the content of test_targets.json for android-arm64
-    mock_arm64_json_content = (
-        '{"test_targets": ["android_arm64_target1", "android_arm64_target2"]}')
+    mock_arm64_json_content = ('[{"target": "android_arm64_target1"}, '
+                               '{"target": "android_arm64_target2"}]')
 
     def open_side_effect(file_path, *args, **kwargs):
       del args, kwargs  # unused


### PR DESCRIPTION
Refactor test_targets.json files across all platforms to use a paired
schema where GN targets and their corresponding executables are defined
together in list entries. This change simplifies the association
between build targets and their output binaries.

Update GitHub Actions, code coverage utilities, and CI scripts to
support the new array-based format. Metadata keys such as TODO and
disabled are preserved within the schema.

Bug: 431780245