### PR TITLE
Prune WebNN to reduce android binary size

### DIFF
--- a/third_party/blink/renderer/bindings/bindings.gni
+++ b/third_party/blink/renderer/bindings/bindings.gni
@@ -271,3 +271,8 @@ cobalt_bindings_exclude_patterns = [
   "*explicit_congestion_notification*",
   "*v8_union_mediastreamtrack_string*",
 ]
+
+cobalt_webnn_exclude_patterns = [
+  "*v8_ml.*",
+  "*v8_ml_*",
+]

--- a/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
+++ b/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
@@ -33,6 +33,13 @@ blink_modules_sources("v8") {
     sources = _filtered_sources
   }
 
+  if (is_cobalt) {
+    _filtered_cobalt_sources =
+        filter_exclude(sources, cobalt_webnn_exclude_patterns)
+    sources = []
+    sources = _filtered_cobalt_sources
+  }
+
   deps = [
     ":generated",
     "//third_party/blink/renderer/platform",

--- a/third_party/blink/renderer/modules/BUILD.gn
+++ b/third_party/blink/renderer/modules/BUILD.gn
@@ -42,6 +42,10 @@ component("modules") {
 
   sources += blink_modules_sources_bindings
 
+  if (is_cobalt) {
+    sources += [ "cobalt_modules_stubs.cc" ]
+  }
+
   configs += [
     ":modules_implementation",
 
@@ -191,6 +195,7 @@ component("modules") {
         "//third_party/blink/renderer/modules/cobalt/mediasource",
       ]
     }
+    sub_modules -= [ "//third_party/blink/renderer/modules/ml" ]
   }
 
   if (!use_webrtc_peer_connection) {
@@ -788,6 +793,7 @@ source_set("unit_tests") {
 
   if (is_cobalt) {
     deps += [ "//third_party/blink/renderer/modules/cobalt/h5vcc_experiments:experiments_utils" ]
+    deps -= [ "//third_party/blink/renderer/modules/ml:unit_tests" ]
   }
 
   if (!use_webrtc_peer_connection) {

--- a/third_party/blink/renderer/modules/cobalt_modules_stubs.cc
+++ b/third_party/blink/renderer/modules/cobalt_modules_stubs.cc
@@ -1,0 +1,54 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "third_party/blink/renderer/modules/ml/navigator_ml.h"  // nogncheck
+#include "third_party/blink/renderer/platform/bindings/wrapper_type_info.h"
+
+namespace blink {
+
+static const WrapperTypeInfo g_dummy_wrapper_type_info = {
+    gin::kEmbedderBlink,
+    nullptr,
+    nullptr,
+    "Dummy",
+    nullptr,
+    v8::CppHeapPointerTag::kDefaultTag,
+    v8::CppHeapPointerTag::kDefaultTag,
+    WrapperTypeInfo::kWrapperTypeObjectPrototype,
+    WrapperTypeInfo::kObjectClassId,
+    WrapperTypeInfo::kIdlInterface,
+    false,
+};
+
+// --- V8 WrapperTypeInfo Stubs ---
+
+#define STUB_V8_WRAPPER(ClassName) \
+  class ClassName { public: static const WrapperTypeInfo wrapper_type_info_; }; \
+  const WrapperTypeInfo ClassName::wrapper_type_info_ = g_dummy_wrapper_type_info;
+
+// WebNN V8 Wrappers
+STUB_V8_WRAPPER(V8ML)
+STUB_V8_WRAPPER(V8MLContext)
+STUB_V8_WRAPPER(V8MLTensor)
+STUB_V8_WRAPPER(V8MLGraph)
+STUB_V8_WRAPPER(V8MLGraphBuilder)
+STUB_V8_WRAPPER(V8MLOperand)
+
+// --- WebNN C++ Stubs ---
+
+ML* NavigatorML::ml(NavigatorBase& navigator) {
+  return nullptr;
+}
+
+}  // namespace blink

--- a/third_party/blink/renderer/modules/cobalt_modules_stubs.cc
+++ b/third_party/blink/renderer/modules/cobalt_modules_stubs.cc
@@ -45,6 +45,8 @@ STUB_V8_WRAPPER(V8MLGraph)
 STUB_V8_WRAPPER(V8MLGraphBuilder)
 STUB_V8_WRAPPER(V8MLOperand)
 
+#undef STUB_V8_WRAPPER
+
 // --- WebNN C++ Stubs ---
 
 ML* NavigatorML::ml(NavigatorBase& navigator) {


### PR DESCRIPTION
This PR decouples Cobalt's dependency on WebNN, which is important in pruning dawn/WebGPU. This is Step 1 of 3 to safely remove the heavy Dawn/WebGPU dependencies and achieve a significant binary size reduction on Android (~800 KB total). Pruning just WebNN shows a binary size decrease of ~278.5 KB (93,372,357 to 93,093,829 bytes).
                                                                                                               
  #### Key Changes:                                                                                            
                                                                                                               
  1. Build Graph Pruning (GN Subtraction):                                                                     
      • Subtracted  //third_party/blink/renderer/modules/ml  from sub_modules  in  modules/BUILD.gn .         
      • Subtracted  //third_party/blink/renderer/modules/ml:unit_tests  from the  unit_tests  target in modules/BUILD.gn  to completely sever the module and prevent GN header-check errors.                     
  2. Bindings Filtering:                                                                                       
      • Added  cobalt_webnn_exclude_patterns  to  bindings.gni  to target  *v8_ml.*  and  *v8_ml_* .           
      • Surgically filtered out generated WebNN V8 bindings in  bindings/modules/v8/BUILD.gn  to prevent their 
      compilation into libv8.a .                                                                              
  3. Lightweight C++ Stubbing:                                                                                 
      • Created  cobalt_modules_stubs.cc  to provide minimal, dummy V8 wrapper definitions and a stubbed       
      implementation for  NavigatorML::ml()  (which now instantly returns  nullptr ).                          
      • This satisfies the linker for shared headers (like  Navigator ) without requiring intrusive, conflict- 
      prone edits to shared Chromium files.
  
Bug: 512589073
Bug: 506153165