### PR TITLE
starboard: Use starboard::Size instead of width/height int pair

### DIFF
--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -271,7 +271,7 @@ bool VideoCodecCapability::IsBitrateSupported(int bitrate) const {
   return supported_bitrates_.Contains(bitrate);
 }
 
-bool VideoCodecCapability::AreResolutionAndRateSupported(const Size& size,
+bool VideoCodecCapability::AreResolutionAndRateSupported(Size size,
                                                          int fps) const {
   if (!(j_video_capabilities_.is_null())) {
     JNIEnv* env = AttachCurrentThread();
@@ -391,7 +391,7 @@ bool MediaCapabilitiesCache::HasVideoDecoderFor(const std::string& mime_type,
                                                 bool must_support_secure,
                                                 bool must_support_hdr,
                                                 bool must_support_tunnel_mode,
-                                                const Size& frame_size,
+                                                Size frame_size,
                                                 int bitrate,
                                                 int fps) {
   return !FindVideoDecoder(mime_type, must_support_secure, must_support_hdr,
@@ -451,7 +451,7 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
     bool must_support_hdr,
     bool require_software_codec,
     bool must_support_tunnel_mode,
-    const Size& frame_size,
+    Size frame_size,
     int bitrate,
     int fps) {
   if (!is_enabled_) {

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -32,6 +32,7 @@
 #include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/key_system_supportability_cache.h"
 #include "starboard/shared/starboard/media/mime_supportability_cache.h"
+#include "starboard/shared/starboard/media/resolutions.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
@@ -270,24 +271,23 @@ bool VideoCodecCapability::IsBitrateSupported(int bitrate) const {
   return supported_bitrates_.Contains(bitrate);
 }
 
-bool VideoCodecCapability::AreResolutionAndRateSupported(int frame_width,
-                                                         int frame_height,
+bool VideoCodecCapability::AreResolutionAndRateSupported(const Size& size,
                                                          int fps) const {
   if (!(j_video_capabilities_.is_null())) {
     JNIEnv* env = AttachCurrentThread();
-    if (frame_width != 0 && frame_height != 0 && fps != 0) {
+    if (!size.IsEmpty() && fps != 0) {
       return Java_MediaCodecUtil_areSizeAndRateSupported(
-          env, j_video_capabilities_, frame_width, frame_height,
+          env, j_video_capabilities_, size.width, size.height,
           static_cast<jdouble>(fps));
-    } else if (frame_width != 0 && frame_height != 0) {
+    } else if (!size.IsEmpty()) {
       return Java_MediaCodecUtil_isSizeSupported(env, j_video_capabilities_,
-                                                 frame_width, frame_height);
+                                                 size.width, size.height);
     }
   }
-  if (frame_width != 0 && !supported_widths_.Contains(frame_width)) {
+  if (size.width != 0 && !supported_widths_.Contains(size.width)) {
     return false;
   }
-  if (frame_height != 0 && !supported_heights_.Contains(frame_height)) {
+  if (size.height != 0 && !supported_heights_.Contains(size.height)) {
     return false;
   }
   if (fps != 0 && !supported_frame_rates_.Contains(fps)) {
@@ -391,14 +391,12 @@ bool MediaCapabilitiesCache::HasVideoDecoderFor(const std::string& mime_type,
                                                 bool must_support_secure,
                                                 bool must_support_hdr,
                                                 bool must_support_tunnel_mode,
-                                                int frame_width,
-                                                int frame_height,
+                                                const Size& frame_size,
                                                 int bitrate,
                                                 int fps) {
   return !FindVideoDecoder(mime_type, must_support_secure, must_support_hdr,
                            /*require_software_codec=*/false,
-                           must_support_tunnel_mode, frame_width, frame_height,
-                           bitrate, fps)
+                           must_support_tunnel_mode, frame_size, bitrate, fps)
               .empty();
 }
 
@@ -407,8 +405,8 @@ bool MediaCapabilitiesCache::HasVideoDecoderFor(const std::string& mime_type,
                                                 bool must_support_hdr,
                                                 bool must_support_tunnel_mode) {
   return HasVideoDecoderFor(mime_type, must_support_secure, must_support_hdr,
-                            must_support_tunnel_mode, /*frame_width=*/0,
-                            /*frame_height=*/0, /*bitrate=*/0, /*fps=*/0);
+                            must_support_tunnel_mode, Size::Zero(),
+                            /*bitrate=*/0, /*fps=*/0);
 }
 
 std::string MediaCapabilitiesCache::FindAudioDecoder(
@@ -444,8 +442,7 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
     bool must_support_tunnel_mode) {
   return FindVideoDecoder(mime_type, must_support_secure, must_support_hdr,
                           require_software_codec, must_support_tunnel_mode,
-                          /*frame_width=*/0, /*frame_height=*/0, /*bitrate=*/0,
-                          /*fps=*/0);
+                          Size::Zero(), /*bitrate=*/0, /*fps=*/0);
 }
 
 std::string MediaCapabilitiesCache::FindVideoDecoder(
@@ -454,8 +451,7 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
     bool must_support_hdr,
     bool require_software_codec,
     bool must_support_tunnel_mode,
-    int frame_width,
-    int frame_height,
+    const Size& frame_size,
     int bitrate,
     int fps) {
   if (!is_enabled_) {
@@ -464,7 +460,8 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
     auto j_decoder_name = Java_MediaCodecUtil_findVideoDecoder(
         env, j_mime, must_support_secure, must_support_hdr,
         /*mustSupportSoftwareCodec=*/false, must_support_tunnel_mode,
-        /*decoderCacheTtlMs=*/-1, frame_width, frame_height, bitrate, fps);
+        /*decoderCacheTtlMs=*/-1, frame_size.width, frame_size.height, bitrate,
+        fps);
     return ConvertJavaStringToUTF8(env, j_decoder_name);
   }
 
@@ -497,10 +494,8 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
     // Reject low performance software codec if software codec is not required.
     // See b/456473829 for more details.
     if (!require_software_codec && video_capability->is_software_decoder()) {
-      const int kMinimumWidth = 1920;
-      const int kMinimumHeight = 1080;
-      if (!video_capability->AreResolutionAndRateSupported(kMinimumWidth,
-                                                           kMinimumHeight, 0)) {
+      if (!video_capability->AreResolutionAndRateSupported(Resolution::k1080p,
+                                                           /*fps=*/0)) {
         continue;
       }
     }
@@ -509,8 +504,7 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
       continue;
     }
     // Reject if resolution or frame rate is not supported.
-    if (!video_capability->AreResolutionAndRateSupported(frame_width,
-                                                         frame_height, fps)) {
+    if (!video_capability->AreResolutionAndRateSupported(frame_size, fps)) {
       continue;
     }
     // Reject if bitrate is not supported.
@@ -583,11 +577,9 @@ void MediaCapabilitiesCache::LoadIsAv18kCappedAt30_Locked() {
   for (const auto& video_capability :
        video_codec_capabilities_map_[SupportedVideoCodecToMimeType(
            kSbMediaVideoCodecAv1)]) {
-    constexpr int kWidth8K = 7680;
-    constexpr int kHeight8K = 4320;
-    if (video_capability->AreResolutionAndRateSupported(kWidth8K, kHeight8K,
+    if (video_capability->AreResolutionAndRateSupported(Resolution::k8k,
                                                         /*fps=*/0) &&
-        !video_capability->AreResolutionAndRateSupported(kWidth8K, kHeight8K,
+        !video_capability->AreResolutionAndRateSupported(Resolution::k8k,
                                                          /*fps=*/60)) {
       is_av1_8k_capped_at_30_ = true;
       break;

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -405,7 +405,7 @@ bool MediaCapabilitiesCache::HasVideoDecoderFor(const std::string& mime_type,
                                                 bool must_support_hdr,
                                                 bool must_support_tunnel_mode) {
   return HasVideoDecoderFor(mime_type, must_support_secure, must_support_hdr,
-                            must_support_tunnel_mode, Size::Zero(),
+                            must_support_tunnel_mode, Size(),
                             /*bitrate=*/0, /*fps=*/0);
 }
 
@@ -442,7 +442,7 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
     bool must_support_tunnel_mode) {
   return FindVideoDecoder(mime_type, must_support_secure, must_support_hdr,
                           require_software_codec, must_support_tunnel_mode,
-                          Size::Zero(), /*bitrate=*/0, /*fps=*/0);
+                          Size(), /*bitrate=*/0, /*fps=*/0);
 }
 
 std::string MediaCapabilitiesCache::FindVideoDecoder(

--- a/starboard/android/shared/media_capabilities_cache.h
+++ b/starboard/android/shared/media_capabilities_cache.h
@@ -129,7 +129,7 @@ class VideoCodecCapability : public CodecCapability {
   // VideoCapabilities.areSizeAndRateSupported() or
   // VideoCapabilities.isSizeSupported() will be used to check the
   // supportability.
-  bool AreResolutionAndRateSupported(const Size& size, int fps) const;
+  bool AreResolutionAndRateSupported(Size size, int fps) const;
 
  protected:
   VideoCodecCapability(std::string name,
@@ -207,7 +207,7 @@ class MediaCapabilitiesCache {
                           bool must_support_secure,
                           bool must_support_hdr,
                           bool must_support_tunnel_mode,
-                          const Size& frame_size,
+                          Size frame_size,
                           int bitrate,
                           int fps);
   bool HasVideoDecoderFor(const std::string& mime_type,
@@ -243,7 +243,7 @@ class MediaCapabilitiesCache {
                                bool must_support_hdr,
                                bool require_software_codec,
                                bool must_support_tunnel_mode,
-                               const Size& frame_size,
+                               Size frame_size,
                                int bitrate,
                                int fps);
 

--- a/starboard/android/shared/media_capabilities_cache.h
+++ b/starboard/android/shared/media_capabilities_cache.h
@@ -25,6 +25,7 @@
 #include <string>
 #include <vector>
 
+#include "starboard/common/size.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -128,9 +129,7 @@ class VideoCodecCapability : public CodecCapability {
   // VideoCapabilities.areSizeAndRateSupported() or
   // VideoCapabilities.isSizeSupported() will be used to check the
   // supportability.
-  bool AreResolutionAndRateSupported(int frame_width,
-                                     int frame_height,
-                                     int fps) const;
+  bool AreResolutionAndRateSupported(const Size& size, int fps) const;
 
  protected:
   VideoCodecCapability(std::string name,
@@ -208,8 +207,7 @@ class MediaCapabilitiesCache {
                           bool must_support_secure,
                           bool must_support_hdr,
                           bool must_support_tunnel_mode,
-                          int frame_width,
-                          int frame_height,
+                          const Size& frame_size,
                           int bitrate,
                           int fps);
   bool HasVideoDecoderFor(const std::string& mime_type,
@@ -245,8 +243,7 @@ class MediaCapabilitiesCache {
                                bool must_support_hdr,
                                bool require_software_codec,
                                bool must_support_tunnel_mode,
-                               int frame_width,
-                               int frame_height,
+                               const Size& frame_size,
                                int bitrate,
                                int fps);
 

--- a/starboard/android/shared/media_capabilities_cache_test.cc
+++ b/starboard/android/shared/media_capabilities_cache_test.cc
@@ -18,8 +18,10 @@
 #include <vector>
 
 #include "starboard/android/shared/mock_media_capabilities_cache.h"
+#include "starboard/common/size.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/features.h"
+#include "starboard/shared/starboard/media/resolutions.h"
 #include "starboard/testing/scoped_feature_list.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -306,8 +308,7 @@ TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
                                          /*must_support_secure=*/false,
                                          /*must_support_hdr=*/false,
                                          /*must_support_tunnel_mode=*/false,
-                                         /*frame_width=*/1920,
-                                         /*frame_height=*/1080,
+                                         Resolution::k1080p,
                                          /*bitrate=*/5'000'000,
                                          /*fps=*/30));
 
@@ -316,8 +317,7 @@ TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
                                           /*must_support_secure=*/false,
                                           /*must_support_hdr=*/false,
                                           /*must_support_tunnel_mode=*/false,
-                                          /*frame_width=*/3840,
-                                          /*frame_height=*/1080,
+                                          Size(3840, 1080),
                                           /*bitrate=*/5'000'000,
                                           /*fps=*/30));
 
@@ -326,8 +326,7 @@ TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
                                           /*must_support_secure=*/false,
                                           /*must_support_hdr=*/false,
                                           /*must_support_tunnel_mode=*/false,
-                                          /*frame_width=*/1920,
-                                          /*frame_height=*/2160,
+                                          Size(1920, 2160),
                                           /*bitrate=*/5'000'000,
                                           /*fps=*/30));
 
@@ -336,8 +335,7 @@ TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
                                           /*must_support_secure=*/false,
                                           /*must_support_hdr=*/false,
                                           /*must_support_tunnel_mode=*/false,
-                                          /*frame_width=*/1920,
-                                          /*frame_height=*/1080,
+                                          Resolution::k1080p,
                                           /*bitrate=*/20'000'000,
                                           /*fps=*/30));
 
@@ -346,8 +344,7 @@ TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
                                           /*must_support_secure=*/false,
                                           /*must_support_hdr=*/false,
                                           /*must_support_tunnel_mode=*/false,
-                                          /*frame_width=*/1920,
-                                          /*frame_height=*/1080,
+                                          Resolution::k1080p,
                                           /*bitrate=*/5'000'000,
                                           /*fps=*/60));
 }

--- a/starboard/android/shared/media_codec_video_decoder_helpers.cc
+++ b/starboard/android/shared/media_codec_video_decoder_helpers.cc
@@ -21,6 +21,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/starboard/media/mime_type.h"
+#include "starboard/shared/starboard/media/resolutions.h"
 
 namespace starboard {
 
@@ -51,8 +52,9 @@ bool IsSoftwareDecoderRequired(const std::string& max_video_capabilities) {
     return false;
   }
 
-  bool is_low_resolution = mime_type->GetParamIntValue("width", 1920) <= 432 &&
-                           mime_type->GetParamIntValue("height", 1080) <= 240;
+  bool is_low_resolution =
+      mime_type->GetParamIntValue("width", Resolution::k1080p.width) <= 432 &&
+      mime_type->GetParamIntValue("height", Resolution::k1080p.height) <= 240;
   bool is_low_fps = mime_type->GetParamIntValue("framerate", 30) <= 15;
 
   if (!is_low_resolution || !is_low_fps) {
@@ -102,7 +104,7 @@ std::optional<Size> ParseMaxResolution(
     return max_size;
   }
 
-  if (frame_size.width <= 0 || frame_size.height <= 0) {
+  if (frame_size.IsEmpty()) {
     SB_LOG(WARNING)
         << "Failed to parse max resolutions due to invalid frame resolutions ("
         << frame_size << ").";

--- a/starboard/android/shared/media_codec_video_decoder_helpers_test.cc
+++ b/starboard/android/shared/media_codec_video_decoder_helpers_test.cc
@@ -17,6 +17,7 @@
 #include <array>
 #include <optional>
 
+#include "starboard/shared/starboard/media/resolutions.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -43,7 +44,7 @@ TEST(MediaCodecVideoDecoderHelpersTest, IsSoftwareDecoderRequired) {
 }
 
 TEST(MediaCodecVideoDecoderHelpersTest, ParseMaxResolution) {
-  Size frame_size = {1920, 1080};
+  Size frame_size = Resolution::k1080p;
 
   // Both dimensions provided
   auto res = ParseMaxResolution("width=1280; height=720", frame_size);
@@ -94,7 +95,7 @@ TEST(MediaCodecVideoDecoderHelpersTest, GetDecodeTargetGeometryFromMatrix) {
   std::array<float, 16> identity = {1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,
                                     0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
                                     0.0f, 0.0f, 0.0f, 1.0f};
-  Size display_size = {1920, 1080};
+  Size display_size = Resolution::k1080p;
 
   auto geom = GetDecodeTargetGeometryFromMatrix(identity, display_size);
   EXPECT_EQ(geom.coded_size.width, 1920);
@@ -116,7 +117,7 @@ TEST(MediaCodecVideoDecoderHelpersTest,
   std::array<float, 16> flipped = {-1.0f, 0.0f, 0.0f, 0.0f, 0.0f, 1.0f,
                                    0.0f,  0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
                                    1.0f,  0.0f, 0.0f, 1.0f};
-  Size display_size = {1920, 1080};
+  Size display_size = Resolution::k1080p;
 
   auto geom = GetDecodeTargetGeometryFromMatrix(flipped, display_size);
   EXPECT_EQ(geom.coded_size.width, 1920);
@@ -138,7 +139,7 @@ TEST(MediaCodecVideoDecoderHelpersTest,
   std::array<float, 16> scaled = {0.5f, 0.0f, 0.0f, 0.0f, 0.0f, 0.5f,
                                   0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
                                   0.0f, 0.0f, 0.0f, 1.0f};
-  Size display_size = {1920, 1080};
+  Size display_size = Resolution::k1080p;
 
   auto geom = GetDecodeTargetGeometryFromMatrix(scaled, display_size);
   // 2x scaling means coded_size resolves to 3840x2160.
@@ -159,7 +160,7 @@ TEST(MediaCodecVideoDecoderHelpersTest,
   std::array<float, 16> translated = {0.8f, 0.0f, 0.0f, 0.0f, 0.0f, 0.8f,
                                       0.0f, 0.0f, 0.0f, 0.0f, 1.0f, 0.0f,
                                       0.1f, 0.1f, 0.0f, 1.0f};
-  Size display_size = {1920, 1080};
+  Size display_size = Resolution::k1080p;
 
   auto geom = GetDecodeTargetGeometryFromMatrix(translated, display_size);
   EXPECT_EQ(geom.coded_size.width, 2398);

--- a/starboard/android/shared/media_get_video_buffer_budget.cc
+++ b/starboard/android/shared/media_get_video_buffer_budget.cc
@@ -17,6 +17,7 @@
 #include "starboard/android/shared/runtime_resource_overlay.h"
 #include "starboard/common/log.h"
 #include "starboard/media.h"
+#include "starboard/shared/starboard/media/resolutions.h"
 
 namespace {
 
@@ -57,14 +58,15 @@ int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
       get_overlaid_video_buffer_budget();
 
   int video_buffer_budget = 0;
-  if ((resolution_width <= 1920 && resolution_height <= 1080) ||
+  starboard::Size resolution(resolution_width, resolution_height);
+  if (resolution.FitsWithin(starboard::Resolution::k1080p) ||
       resolution_width == kSbMediaVideoResolutionDimensionInvalid ||
       resolution_height == kSbMediaVideoResolutionDimensionInvalid) {
     // Specifies the maximum amount of memory used by video buffers of media
     // source before triggering a garbage collection when the video resolution
     // is up to 1080p (1920x1080) or invalid.
     video_buffer_budget = 30 * 1024 * 1024;
-  } else if (resolution_width <= 3840 && resolution_height <= 2160) {
+  } else if (resolution.FitsWithin(starboard::Resolution::k4k)) {
     if (bits_per_pixel <= 8) {
       // Specifies the maximum amount of memory used by video buffers of media
       // source before triggering a garbage collection when the video resolution

--- a/starboard/android/shared/media_is_video_supported.cc
+++ b/starboard/android/shared/media_is_video_supported.cc
@@ -19,6 +19,7 @@
 #include "starboard/android/shared/max_media_codec_output_buffers_lookup_table.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
+#include "starboard/common/size.h"
 #include "starboard/configuration.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/media/media_util.h"
@@ -107,7 +108,7 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
 
   return MediaCapabilitiesCache::GetInstance()->HasVideoDecoderFor(
       mime, require_secure_playback, must_support_hdr, must_support_tunnel_mode,
-      frame_width, frame_height, bitrate, fps);
+      Size(frame_width, frame_height), bitrate, fps);
 }
 
 }  // namespace starboard

--- a/starboard/common/size.h
+++ b/starboard/common/size.h
@@ -21,8 +21,6 @@
 namespace starboard {
 
 struct Size {
-  static constexpr Size Zero() { return Size(); }
-
   constexpr Size() : width(0), height(0) {}
   constexpr Size(int width, int height) : width(width), height(height) {}
 

--- a/starboard/common/size.h
+++ b/starboard/common/size.h
@@ -29,7 +29,7 @@ struct Size {
   constexpr bool IsEmpty() const { return width <= 0 || height <= 0; }
   constexpr int GetArea() const { return width * height; }
 
-  constexpr bool FitsWithin(const Size& other) const {
+  constexpr bool FitsWithin(Size other) const {
     return this->width <= other.width && this->height <= other.height;
   }
 

--- a/starboard/common/size.h
+++ b/starboard/common/size.h
@@ -21,8 +21,17 @@
 namespace starboard {
 
 struct Size {
+  static constexpr Size Zero() { return Size(); }
+
   constexpr Size() : width(0), height(0) {}
   constexpr Size(int width, int height) : width(width), height(height) {}
+
+  constexpr bool IsEmpty() const { return width <= 0 || height <= 0; }
+  constexpr int GetArea() const { return width * height; }
+
+  constexpr bool FitsWithin(const Size& other) const {
+    return this->width <= other.width && this->height <= other.height;
+  }
 
   constexpr bool operator==(const Size& other) const {
     return width == other.width && height == other.height;

--- a/starboard/common/size.h
+++ b/starboard/common/size.h
@@ -30,7 +30,7 @@ struct Size {
   constexpr int GetArea() const { return width * height; }
 
   constexpr bool FitsWithin(Size other) const {
-    return this->width <= other.width && this->height <= other.height;
+    return width <= other.width && height <= other.height;
   }
 
   constexpr bool operator==(const Size& other) const {

--- a/starboard/common/size_test.cc
+++ b/starboard/common/size_test.cc
@@ -87,13 +87,5 @@ TEST(SizeTest, FitsWithin) {
   EXPECT_FALSE(size.FitsWithin(Size(10, 9)));
   EXPECT_FALSE(size.FitsWithin(Size(5, 5)));
 }
-
-TEST(SizeTest, Zero) {
-  EXPECT_EQ(0, Size::Zero().width);
-  EXPECT_EQ(0, Size::Zero().height);
-  EXPECT_TRUE(Size::Zero().IsEmpty());
-  EXPECT_EQ(0, Size::Zero().GetArea());
-}
-
 }  // namespace
 }  // namespace starboard

--- a/starboard/common/size_test.cc
+++ b/starboard/common/size_test.cc
@@ -66,5 +66,34 @@ TEST(SizeTest, StreamInsertion) {
   EXPECT_EQ("1280x720", ss.str());
 }
 
+TEST(SizeTest, IsEmpty) {
+  EXPECT_TRUE(Size(0, 0).IsEmpty());
+  EXPECT_TRUE(Size(-1, 10).IsEmpty());
+  EXPECT_TRUE(Size(10, -1).IsEmpty());
+  EXPECT_FALSE(Size(1, 1).IsEmpty());
+}
+
+TEST(SizeTest, GetArea) {
+  EXPECT_EQ(0, Size(0, 0).GetArea());
+  EXPECT_EQ(12, Size(3, 4).GetArea());
+}
+
+TEST(SizeTest, FitsWithin) {
+  Size size(10, 10);
+  EXPECT_TRUE(size.FitsWithin(Size(10, 10)));
+  EXPECT_TRUE(size.FitsWithin(Size(15, 15)));
+
+  EXPECT_FALSE(size.FitsWithin(Size(9, 10)));
+  EXPECT_FALSE(size.FitsWithin(Size(10, 9)));
+  EXPECT_FALSE(size.FitsWithin(Size(5, 5)));
+}
+
+TEST(SizeTest, Zero) {
+  EXPECT_EQ(0, Size::Zero().width);
+  EXPECT_EQ(0, Size::Zero().height);
+  EXPECT_TRUE(Size::Zero().IsEmpty());
+  EXPECT_EQ(0, Size::Zero().GetArea());
+}
+
 }  // namespace
 }  // namespace starboard

--- a/starboard/linux/shared/decode_target_internal.cc
+++ b/starboard/linux/shared/decode_target_internal.cc
@@ -84,11 +84,13 @@ void CreateTargetFromVideoFrameWithContextRunner(void* context) {
         params->decode_target_out->data->info.planes[plane_index].texture));
     GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT,
                           video_frame_plane.pitch_in_bytes));
-    if (target_info.planes[plane_index].width == video_frame_plane.width &&
-        target_info.planes[plane_index].height == video_frame_plane.height) {
+    if (target_info.planes[plane_index].width == video_frame_plane.size.width &&
+        target_info.planes[plane_index].height ==
+            video_frame_plane.size.height) {
       // No need to reallocate texture object, only update pixels.
-      GL_CALL(glTexSubImage2D(GL_TEXTURE_2D, 0, 0, 0, video_frame_plane.width,
-                              video_frame_plane.height, GL_RED_EXT,
+      GL_CALL(glTexSubImage2D(GL_TEXTURE_2D, /*level=*/0, /*xoffset=*/0,
+                              /*yoffset=*/0, video_frame_plane.size.width,
+                              video_frame_plane.size.height, GL_RED_EXT,
                               GL_UNSIGNED_BYTE, video_frame_plane.data));
 
     } else {
@@ -100,10 +102,10 @@ void CreateTargetFromVideoFrameWithContextRunner(void* context) {
       GL_CALL(
           glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE));
 
-      GL_CALL(glTexImage2D(GL_TEXTURE_2D, 0, GL_RED_EXT,
-                           video_frame_plane.width, video_frame_plane.height, 0,
-                           GL_RED_EXT, GL_UNSIGNED_BYTE,
-                           video_frame_plane.data));
+      GL_CALL(glTexImage2D(
+          GL_TEXTURE_2D, /*level=*/0, GL_RED_EXT, video_frame_plane.size.width,
+          video_frame_plane.size.height, /*border=*/0, GL_RED_EXT,
+          GL_UNSIGNED_BYTE, video_frame_plane.data));
     }
 
     GL_CALL(glPixelStorei(GL_UNPACK_ROW_LENGTH_EXT, 0));
@@ -111,15 +113,15 @@ void CreateTargetFromVideoFrameWithContextRunner(void* context) {
 
     // Set sizes and regions.
     target_info.planes[plane_index].content_region.right =
-        static_cast<float>(video_frame_plane.width);
+        static_cast<float>(video_frame_plane.size.width);
     target_info.planes[plane_index].content_region.bottom =
-        static_cast<float>(video_frame_plane.height);
-    target_info.planes[plane_index].width = video_frame_plane.width;
-    target_info.planes[plane_index].height = video_frame_plane.height;
+        static_cast<float>(video_frame_plane.size.height);
+    target_info.planes[plane_index].width = video_frame_plane.size.width;
+    target_info.planes[plane_index].height = video_frame_plane.size.height;
   }
 
-  target_info.width = params->frame->width();
-  target_info.height = params->frame->height();
+  target_info.width = params->frame->size().width;
+  target_info.height = params->frame->size().height;
 }
 
 void CreateTargetFromImageWithContextRunner(void* context) {

--- a/starboard/shared/starboard/media/BUILD.gn
+++ b/starboard/shared/starboard/media/BUILD.gn
@@ -42,6 +42,7 @@ static_library("media_util") {
     "//starboard/shared/starboard/media/mime_util.h",
     "//starboard/shared/starboard/media/parsed_mime_info.cc",
     "//starboard/shared/starboard/media/parsed_mime_info.h",
+    "//starboard/shared/starboard/media/resolutions.h",
     "//starboard/shared/starboard/media/vp9_util.cc",
     "//starboard/shared/starboard/media/vp9_util.h",
   ]

--- a/starboard/shared/starboard/media/codec_util_test.cc
+++ b/starboard/shared/starboard/media/codec_util_test.cc
@@ -18,6 +18,7 @@
 
 #include "starboard/media.h"
 #include "starboard/shared/starboard/media/avc_util.h"
+#include "starboard/shared/starboard/media/resolutions.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -42,7 +43,7 @@ std::vector<uint8_t> operator+(const std::vector<uint8_t>& left,
 TEST(VideoConfigTest, CtorWithVideoStreamInfo) {
   VideoStreamInfo video_stream_info;
   video_stream_info.codec = kSbMediaVideoCodecH264;
-  video_stream_info.frame_size = {1920, 1080};
+  video_stream_info.frame_size = Resolution::k1080p;
 
   std::vector<uint8_t> nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
@@ -58,13 +59,13 @@ TEST(VideoConfigTest, CtorWithVideoStreamInfo) {
 }
 
 TEST(VideoConfigTest, IsValidH264PpsOnly) {
-  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, Resolution::k1080p,
                                     kPpsInAnnexB.data(), kPpsInAnnexB.size());
   ASSERT_TRUE(config.has_value());
 }
 
 TEST(VideoConfigTest, IsValidH264IdrOnly) {
-  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, Resolution::k1080p,
                                     kIdrInAnnexB.data(), kIdrInAnnexB.size());
   ASSERT_TRUE(config.has_value());
 }
@@ -73,7 +74,7 @@ TEST(VideoConfigTest, IsValidH264FullAnnexB) {
   std::vector<uint8_t> nalus_in_annex_b =
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
   auto config =
-      VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+      VideoConfig::Create(kSbMediaVideoCodecH264, Resolution::k1080p,
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config.has_value());
 }
@@ -83,14 +84,14 @@ TEST(VideoConfigTest, IsValidH264InvalidHeader) {
       kSpsInAnnexB + kPpsInAnnexB + kIdrInAnnexB;
   // The implementation only fails when the format is avc and the input isn't
   // empty and doesn't start with a nalu header.
-  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+  auto config = VideoConfig::Create(kSbMediaVideoCodecH264, Resolution::k1080p,
                                     nalus_in_annex_b.data() + 1,
                                     nalus_in_annex_b.size() - 1);
   ASSERT_FALSE(config.has_value());
 }
 
 TEST(VideoConfigTest, IsValidVp9) {
-  auto config = VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080},
+  auto config = VideoConfig::Create(kSbMediaVideoCodecVp9, Resolution::k1080p,
                                     /*data=*/nullptr, /*data_size=*/0);
   ASSERT_TRUE(config.has_value());
 }
@@ -118,7 +119,7 @@ TEST(VideoConfigTest, EqualityOperatorsH264) {
 
   // Different values (resolution)
   auto config3 =
-      VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+      VideoConfig::Create(kSbMediaVideoCodecH264, Resolution::k1080p,
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config3.has_value());
   EXPECT_FALSE(*config1 == *config3);
@@ -144,9 +145,9 @@ TEST(VideoConfigTest, EqualityOperatorsVp9) {
   EXPECT_FALSE(*config1 != *config2);
 
   // Different values (resolution)
-  auto config3 =
-      VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080}, /*data=*/nullptr,
-                          /*data_size=*/0);
+  auto config3 = VideoConfig::Create(kSbMediaVideoCodecVp9, Resolution::k1080p,
+                                     /*data=*/nullptr,
+                                     /*data_size=*/0);
   ASSERT_TRUE(config3.has_value());
   EXPECT_FALSE(*config1 == *config3);
   EXPECT_TRUE(*config1 != *config3);
@@ -163,7 +164,7 @@ TEST(VideoConfigTest, H264) {
 
   // Different resolution, same parameter sets.
   auto config_1 =
-      VideoConfig::Create(kSbMediaVideoCodecH264, {1920, 1080},
+      VideoConfig::Create(kSbMediaVideoCodecH264, Resolution::k1080p,
                           nalus_in_annex_b.data(), nalus_in_annex_b.size());
   ASSERT_TRUE(config_1.has_value());
   EXPECT_NE(*config, *config_1);
@@ -242,8 +243,8 @@ TEST(VideoConfigTest, Vp9) {
 
   // Different resolution, same data.
   auto config_1 =
-      VideoConfig::Create(kSbMediaVideoCodecVp9, {1920, 1080}, kInvalidData,
-                          SB_ARRAY_SIZE(kInvalidData));
+      VideoConfig::Create(kSbMediaVideoCodecVp9, Resolution::k1080p,
+                          kInvalidData, SB_ARRAY_SIZE(kInvalidData));
   ASSERT_TRUE(config_1.has_value());
   EXPECT_NE(*config, *config_1);
 

--- a/starboard/shared/starboard/media/media_get_video_buffer_budget.cc
+++ b/starboard/shared/starboard/media/media_get_video_buffer_budget.cc
@@ -13,12 +13,16 @@
 // limitations under the License.
 
 #include "starboard/media.h"
+#include "starboard/shared/starboard/media/resolutions.h"
+
+using ::starboard::Resolution;
 
 int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
                                 int resolution_width,
                                 int resolution_height,
                                 int bits_per_pixel) {
-  if ((resolution_width <= 1920 && resolution_height <= 1080) ||
+  starboard::Size resolution(resolution_width, resolution_height);
+  if (resolution.FitsWithin(Resolution::k1080p) ||
       resolution_width == kSbMediaVideoResolutionDimensionInvalid ||
       resolution_height == kSbMediaVideoResolutionDimensionInvalid) {
     // Specifies the maximum amount of memory used by video buffers of media
@@ -27,7 +31,7 @@ int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
     return 30 * 1024 * 1024;
   }
 
-  if (resolution_width <= 3840 && resolution_height <= 2160) {
+  if (resolution.FitsWithin(Resolution::k4k)) {
     if (bits_per_pixel <= 8) {
       // Specifies the maximum amount of memory used by video buffers of media
       // source before triggering a garbage collection when the video resolution

--- a/starboard/shared/starboard/media/media_util_test.cc
+++ b/starboard/shared/starboard/media/media_util_test.cc
@@ -18,6 +18,7 @@
 
 #include "starboard/common/log.h"
 #include "starboard/media.h"
+#include "starboard/shared/starboard/media/resolutions.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 extern bool operator==(const SbMediaColorMetadata&,
@@ -237,6 +238,17 @@ TEST(AudioStreamInfoTest, StreamOperator_Empty) {
             "{codec=opus, mime=(empty), channels=2, "
             "samples_per_second=48'000, bits_per_sample=16}");
 }
-}  // namespace
 
+TEST(MediaUtilTest, Resolutions) {
+  EXPECT_EQ(Resolution::k240p, Size(426, 240));
+  EXPECT_EQ(Resolution::k360p, Size(640, 360));
+  EXPECT_EQ(Resolution::k480p, Size(854, 480));
+  EXPECT_EQ(Resolution::k720p, Size(1280, 720));
+  EXPECT_EQ(Resolution::k1080p, Size(1920, 1080));
+  EXPECT_EQ(Resolution::k1440p, Size(2560, 1440));
+  EXPECT_EQ(Resolution::k4k, Size(3840, 2160));
+  EXPECT_EQ(Resolution::k8k, Size(7680, 4320));
+}
+
+}  // namespace
 }  // namespace starboard

--- a/starboard/shared/starboard/media/resolutions.h
+++ b/starboard/shared/starboard/media/resolutions.h
@@ -1,0 +1,36 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_STARBOARD_MEDIA_RESOLUTIONS_H_
+#define STARBOARD_SHARED_STARBOARD_MEDIA_RESOLUTIONS_H_
+
+#include "starboard/common/size.h"
+
+namespace starboard {
+
+// Well-known video resolutions.
+struct Resolution {
+  static constexpr Size k240p{426, 240};
+  static constexpr Size k360p{640, 360};
+  static constexpr Size k480p{854, 480};
+  static constexpr Size k720p{1280, 720};    // HD
+  static constexpr Size k1080p{1920, 1080};  // Full HD (FHD)
+  static constexpr Size k1440p{2560, 1440};  // Quad HD (QHD)
+  static constexpr Size k4k{3840, 2160};     // 4K Ultra HD (UHD)
+  static constexpr Size k8k{7680, 4320};     // 8K Ultra HD
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_SHARED_STARBOARD_MEDIA_RESOLUTIONS_H_

--- a/starboard/shared/starboard/player/filter/cpu_video_frame.cc
+++ b/starboard/shared/starboard/player/filter/cpu_video_frame.cc
@@ -125,19 +125,18 @@ scoped_refptr<CpuVideoFrame> CpuVideoFrame::ConvertTo(
   scoped_refptr<CpuVideoFrame> target_frame(new CpuVideoFrame(timestamp()));
 
   target_frame->format_ = target_format;
-  target_frame->width_ = width();
-  target_frame->height_ = height();
-  target_frame->pixel_buffer_.reset(new uint8_t[width() * height() * 4]);
+  target_frame->size_ = size();
+  target_frame->pixel_buffer_.reset(new uint8_t[size().GetArea() * 4]);
   target_frame->planes_.push_back(
-      Plane(width(), height(), width() * 4, target_frame->pixel_buffer_.get()));
+      Plane(size(), size().width * 4, target_frame->pixel_buffer_.get()));
 
   const uint8_t* y_data = GetPlane(0).data;
   const uint8_t* u_data = GetPlane(1).data;
   const uint8_t* v_data = GetPlane(2).data;
   uint8_t* bgra_data = target_frame->pixel_buffer_.get();
 
-  int height = this->height();
-  int width = this->width();
+  int height = this->size().height;
+  int width = this->size().width;
 
   for (int row = 0; row < height; ++row) {
     const uint8_t* y = &y_data[row * GetPlane(0).pitch_in_bytes];
@@ -178,8 +177,7 @@ scoped_refptr<CpuVideoFrame> CpuVideoFrame::ConvertTo(
 // static
 scoped_refptr<CpuVideoFrame> CpuVideoFrame::CreateYV12Frame(
     int bit_depth,
-    int width,
-    int height,
+    const Size& size,
     int source_y_pitch_in_bytes,
     int source_uv_pitch_in_bytes,
     int64_t timestamp,
@@ -189,15 +187,14 @@ scoped_refptr<CpuVideoFrame> CpuVideoFrame::CreateYV12Frame(
   SB_DCHECK(bit_depth == 8 || bit_depth == 10 || bit_depth == 12);
 
   if (bit_depth > 8) {
-    SB_DCHECK_GE(source_y_pitch_in_bytes, width * 2);
+    SB_DCHECK_GE(source_y_pitch_in_bytes, size.width * 2);
   } else {
-    SB_DCHECK_GE(source_y_pitch_in_bytes, width);
+    SB_DCHECK_GE(source_y_pitch_in_bytes, size.width);
   }
 
   scoped_refptr<CpuVideoFrame> frame(new CpuVideoFrame(timestamp));
   frame->format_ = kYV12;
-  frame->width_ = width;
-  frame->height_ = height;
+  frame->size_ = size;
 
   auto destination_y_pitch_in_bytes = source_y_pitch_in_bytes;
   auto destination_uv_pitch_in_bytes = source_uv_pitch_in_bytes;
@@ -210,10 +207,10 @@ scoped_refptr<CpuVideoFrame> CpuVideoFrame::CreateYV12Frame(
   // U/V planes generally have half resolution of the Y plane.  However, in the
   // extreme case that any dimension of Y plane is odd, we want to have an
   // extra pixel on U/V planes.
-  int uv_height = height / 2 + height % 2;
-  int uv_width = width / 2 + width % 2;
+  int uv_height = size.height / 2 + size.height % 2;
+  int uv_width = size.width / 2 + size.width % 2;
 
-  int y_plane_size_in_bytes = height * destination_y_pitch_in_bytes;
+  int y_plane_size_in_bytes = size.height * destination_y_pitch_in_bytes;
   int uv_plane_size_in_bytes = uv_height * destination_uv_pitch_in_bytes;
   frame->pixel_buffer_.reset(
       new uint8_t[y_plane_size_in_bytes + uv_plane_size_in_bytes * 2]);
@@ -226,13 +223,13 @@ scoped_refptr<CpuVideoFrame> CpuVideoFrame::CreateYV12Frame(
                 uv_plane_size_in_bytes,
             v, uv_plane_size_in_bytes);
 
-  frame->planes_.push_back(Plane(width, height, destination_y_pitch_in_bytes,
-                                 frame->pixel_buffer_.get()));
   frame->planes_.push_back(
-      Plane(uv_width, uv_height, destination_uv_pitch_in_bytes,
+      Plane(size, destination_y_pitch_in_bytes, frame->pixel_buffer_.get()));
+  frame->planes_.push_back(
+      Plane(Size(uv_width, uv_height), destination_uv_pitch_in_bytes,
             frame->pixel_buffer_.get() + y_plane_size_in_bytes));
   frame->planes_.push_back(
-      Plane(uv_width, uv_height, destination_uv_pitch_in_bytes,
+      Plane(Size(uv_width, uv_height), destination_uv_pitch_in_bytes,
             frame->pixel_buffer_.get() + y_plane_size_in_bytes +
                 uv_plane_size_in_bytes));
   return frame;

--- a/starboard/shared/starboard/player/filter/cpu_video_frame.cc
+++ b/starboard/shared/starboard/player/filter/cpu_video_frame.cc
@@ -177,7 +177,7 @@ scoped_refptr<CpuVideoFrame> CpuVideoFrame::ConvertTo(
 // static
 scoped_refptr<CpuVideoFrame> CpuVideoFrame::CreateYV12Frame(
     int bit_depth,
-    const Size& size,
+    Size size,
     int source_y_pitch_in_bytes,
     int source_uv_pitch_in_bytes,
     int64_t timestamp,

--- a/starboard/shared/starboard/player/filter/cpu_video_frame.h
+++ b/starboard/shared/starboard/player/filter/cpu_video_frame.h
@@ -41,7 +41,7 @@ class CpuVideoFrame : public VideoFrame {
   };
 
   struct Plane {
-    Plane(const Size& size, int pitch_in_bytes, const uint8_t* data)
+    Plane(Size size, int pitch_in_bytes, const uint8_t* data)
         : size(size),
           width(size.width),
           height(size.height),
@@ -68,7 +68,7 @@ class CpuVideoFrame : public VideoFrame {
 
   static scoped_refptr<CpuVideoFrame> CreateYV12Frame(
       int bit_depth,
-      const Size& size,
+      Size size,
       int source_y_pitch_in_bytes,
       int source_uv_pitch_in_bytes,
       int64_t timestamp,  // microseconds

--- a/starboard/shared/starboard/player/filter/cpu_video_frame.h
+++ b/starboard/shared/starboard/player/filter/cpu_video_frame.h
@@ -19,6 +19,7 @@
 #include <vector>
 
 #include "starboard/common/ref_counted.h"
+#include "starboard/common/size.h"
 #include "starboard/configuration.h"
 #include "starboard/media.h"
 #include "starboard/shared/internal_only.h"
@@ -40,11 +41,13 @@ class CpuVideoFrame : public VideoFrame {
   };
 
   struct Plane {
-    Plane(int width, int height, int pitch_in_bytes, const uint8_t* data)
-        : width(width),
-          height(height),
+    Plane(const Size& size, int pitch_in_bytes, const uint8_t* data)
+        : size(size),
+          width(size.width),
+          height(size.height),
           pitch_in_bytes(pitch_in_bytes),
           data(data) {}
+    Size size;
     int width;
     int height;
     int pitch_in_bytes;
@@ -54,14 +57,26 @@ class CpuVideoFrame : public VideoFrame {
   explicit CpuVideoFrame(int64_t timestamp) : VideoFrame(timestamp) {}
 
   Format format() const { return format_; }
-  int width() const { return width_; }
-  int height() const { return height_; }
+  int width() const { return size_.width; }
+  int height() const { return size_.height; }
+  const Size& size() const { return size_; }
 
   int GetPlaneCount() const;
   const Plane& GetPlane(int index) const;
 
   scoped_refptr<CpuVideoFrame> ConvertTo(Format target_format) const;
 
+  static scoped_refptr<CpuVideoFrame> CreateYV12Frame(
+      int bit_depth,
+      const Size& size,
+      int source_y_pitch_in_bytes,
+      int source_uv_pitch_in_bytes,
+      int64_t timestamp,  // microseconds
+      const uint8_t* y,
+      const uint8_t* u,
+      const uint8_t* v);
+
+  // Deprecated: Use the Size-based overload.
   static scoped_refptr<CpuVideoFrame> CreateYV12Frame(
       int bit_depth,
       int width,
@@ -71,12 +86,15 @@ class CpuVideoFrame : public VideoFrame {
       int64_t timestamp,  // microseconds
       const uint8_t* y,
       const uint8_t* u,
-      const uint8_t* v);
+      const uint8_t* v) {
+    return CreateYV12Frame(bit_depth, Size(width, height),
+                           source_y_pitch_in_bytes, source_uv_pitch_in_bytes,
+                           timestamp, y, u, v);
+  }
 
  private:
   Format format_;
-  int width_;
-  int height_;
+  Size size_;
 
   // The following two variables are valid when the frame contains pixel data.
   std::vector<Plane> planes_;

--- a/starboard/shared/starboard/player/filter/cpu_video_frame.h
+++ b/starboard/shared/starboard/player/filter/cpu_video_frame.h
@@ -42,14 +42,8 @@ class CpuVideoFrame : public VideoFrame {
 
   struct Plane {
     Plane(Size size, int pitch_in_bytes, const uint8_t* data)
-        : size(size),
-          width(size.width),
-          height(size.height),
-          pitch_in_bytes(pitch_in_bytes),
-          data(data) {}
+        : size(size), pitch_in_bytes(pitch_in_bytes), data(data) {}
     Size size;
-    int width;
-    int height;
     int pitch_in_bytes;
     const uint8_t* data;
   };
@@ -57,8 +51,6 @@ class CpuVideoFrame : public VideoFrame {
   explicit CpuVideoFrame(int64_t timestamp) : VideoFrame(timestamp) {}
 
   Format format() const { return format_; }
-  int width() const { return size_.width; }
-  int height() const { return size_.height; }
   const Size& size() const { return size_; }
 
   int GetPlaneCount() const;

--- a/starboard/shared/starboard/player/filter/stub_video_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_video_decoder.cc
@@ -142,9 +142,8 @@ scoped_refptr<VideoFrame> StubVideoDecoder::CreateOutputFrame(
   std::string data(y_stride * video_stream_info_.frame_size.height, 0);
 
   return CpuVideoFrame::CreateYV12Frame(
-      bits_per_channel, video_stream_info_.frame_size.width,
-      video_stream_info_.frame_size.height, y_stride, uv_stride, timestamp,
-      reinterpret_cast<const uint8_t*>(data.data()),
+      bits_per_channel, video_stream_info_.frame_size, y_stride, uv_stride,
+      timestamp, reinterpret_cast<const uint8_t*>(data.data()),
       reinterpret_cast<const uint8_t*>(data.data()),
       reinterpret_cast<const uint8_t*>(data.data()));
 }

--- a/starboard/shared/starboard/player/filter/testing/test_util.cc
+++ b/starboard/shared/starboard/player/filter/testing/test_util.cc
@@ -21,6 +21,7 @@
 #include "starboard/common/log.h"
 #include "starboard/shared/starboard/media/media_support_internal.h"
 #include "starboard/shared/starboard/media/mime_type.h"
+#include "starboard/shared/starboard/media/resolutions.h"
 #include "starboard/shared/starboard/player/filter/player_components.h"
 #include "starboard/shared/starboard/player/filter/stub_player_components_factory.h"
 #include "starboard/shared/starboard/player/video_dmp_reader.h"
@@ -271,7 +272,7 @@ VideoStreamInfo CreateVideoStreamInfo(SbMediaVideoCodec codec) {
   video_stream_info.color_metadata.matrix = kSbMediaMatrixIdBt709;
   video_stream_info.color_metadata.range = kSbMediaRangeIdLimited;
 
-  video_stream_info.frame_size = {1920, 1080};
+  video_stream_info.frame_size = Resolution::k1080p;
 
   return video_stream_info;
 }

--- a/starboard/shared/x11/window_internal.cc
+++ b/starboard/shared/x11/window_internal.cc
@@ -48,8 +48,7 @@ SbWindowPrivate::SbWindowPrivate(Display* display,
       composition_pixmap(None),
       composition_picture(None),
       video_pixmap(None),
-      video_pixmap_width(0),
-      video_pixmap_height(0),
+      video_pixmap_size(),
       video_pixmap_gc(None),
       video_picture(None),
       gl_window(None),
@@ -177,9 +176,8 @@ void SbWindowPrivate::CompositeVideoFrame(
     const starboard::scoped_refptr<starboard::CpuVideoFrame>& frame) {
   if (frame != nullptr &&
       frame->format() == starboard::CpuVideoFrame::kBGRA32 &&
-      frame->GetPlaneCount() > 0 && frame->width() > 0 && frame->height() > 0) {
-    if (frame->width() != video_pixmap_width ||
-        frame->height() != video_pixmap_height) {
+      frame->GetPlaneCount() > 0 && !frame->size().IsEmpty()) {
+    if (frame->size() != video_pixmap_size) {
       if (video_pixmap != None) {
         XRenderFreePicture(display, video_picture);
         video_picture = None;
@@ -191,10 +189,9 @@ void SbWindowPrivate::CompositeVideoFrame(
     }
 
     if (video_pixmap == None) {
-      video_pixmap_width = frame->width();
-      video_pixmap_height = frame->height();
-      video_pixmap = XCreatePixmap(display, window, video_pixmap_width,
-                                   video_pixmap_height, 32);
+      video_pixmap_size = frame->size();
+      video_pixmap = XCreatePixmap(display, window, video_pixmap_size.width,
+                                   video_pixmap_size.height, /*depth=*/32);
       SB_DCHECK_NE(video_pixmap, None);
 
       video_pixmap_gc = XCreateGC(display, video_pixmap, 0, NULL);
@@ -207,8 +204,8 @@ void SbWindowPrivate::CompositeVideoFrame(
     SB_CHECK_NE(video_picture, None);
 
     XImage image = {0};
-    image.width = frame->width();
-    image.height = frame->height();
+    image.width = frame->size().width;
+    image.height = frame->size().height;
     image.format = ZPixmap;
     image.data = const_cast<char*>(
         reinterpret_cast<const char*>(frame->GetPlane(0).data));
@@ -225,10 +222,10 @@ void SbWindowPrivate::CompositeVideoFrame(
 
     // Initially assume we don't have to center or scale.
     if (rect.size.width != width || rect.size.height != height ||
-        frame->width() != width || frame->height() != height) {
+        frame->size().width != width || frame->size().height != height) {
       // This transform maps the destination pixel back to the source pixel.
-      double sx = static_cast<double>(frame->width()) / rect.size.width;
-      double sy = static_cast<double>(frame->height()) / rect.size.height;
+      double sx = static_cast<double>(frame->size().width) / rect.size.width;
+      double sy = static_cast<double>(frame->size().height) / rect.size.height;
       XTransform transform = {
           {{XDoubleToFixed(sx), XDoubleToFixed(0), XDoubleToFixed(0)},
            {XDoubleToFixed(0), XDoubleToFixed(sy), XDoubleToFixed(0)},

--- a/starboard/shared/x11/window_internal.h
+++ b/starboard/shared/x11/window_internal.h
@@ -19,6 +19,7 @@
 #include <X11/extensions/Xrender.h>
 
 #include "starboard/common/rect.h"
+#include "starboard/common/size.h"
 #include "starboard/configuration.h"
 #include "starboard/shared/internal_only.h"
 #include "starboard/shared/starboard/player/filter/cpu_video_frame.h"
@@ -57,11 +58,8 @@ struct SbWindowPrivate {
   // |composition_pixmap|. This is done so that we can stretch it with XRender.
   Pixmap video_pixmap;
 
-  // The width of the |video_pixmap|.
-  int video_pixmap_width;
-
-  // The height of the allocated |video_pixmap|.
-  int video_pixmap_height;
+  // The size of the allocated |video_pixmap|.
+  starboard::Size video_pixmap_size;
 
   // A cached GC for the |video_pixmap| to upload the frame.
   GC video_pixmap_gc;


### PR DESCRIPTION
This change replaces individual width and height integer pairs with the
`starboard::Size` structure throughout the Starboard layer. Using a
unified structure provides a more consistent interface and reduces
parameter clutter across internal player, renderer, and application
frame interfaces.

Additionally, this update introduces common helper methods to the Size
class and defines a set of standard video resolutions to simplify
handling of common display and video formats across platform
implementations including Android, X11, Raspi, TVOS, and RDK.

Issue: 516906963