### PR TITLE
evergreen: Suspend and Resume UpdaterModule on Freeze and Unfreeze

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -273,6 +273,10 @@ source_set("common") {
   if (is_starboard) {
     deps += [ "//ui/ozone/platform/starboard:starboard" ]
   }
+
+  if (use_evergreen) {
+    deps += [ "//cobalt/updater:updater" ]
+  }
 }
 
 action("cobalt_build_info") {

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -23,11 +23,16 @@
 #include "base/notreached.h"
 #include "base/run_loop.h"
 #include "base/threading/platform_thread.h"
+#include "build/build_config.h"
 #include "cobalt/app/app_event_runner.h"
 #include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
 #include "content/public/browser/browser_thread.h"
 #include "starboard/extension/crash_handler.h"
 #include "starboard/system.h"
+
+#if BUILDFLAG(USE_EVERGREEN)
+#include "cobalt/updater/updater_module.h"
+#endif
 
 namespace cobalt {
 
@@ -207,8 +212,34 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
     case kSbEventTypeConceal:
     case kSbEventTypeStop:
     case kSbEventTypeReveal:
+      // Ensure all intermediate state changes are triggered.
+      TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
+      break;
     case kSbEventTypeFreeze:
+#if BUILDFLAG(USE_EVERGREEN)
+    {
+      cobalt::updater::UpdaterModule* updater_module =
+          cobalt::updater::UpdaterModule::GetInstance();
+      if (updater_module) {
+        LOG(INFO) << "Suspending UpdaterModule singleton.";
+        updater_module->Suspend();
+      }
+    }
+#endif
+      // Ensure all intermediate state changes are triggered.
+      TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
+      break;
     case kSbEventTypeUnfreeze:
+#if BUILDFLAG(USE_EVERGREEN)
+    {
+      cobalt::updater::UpdaterModule* updater_module =
+          cobalt::updater::UpdaterModule::GetInstance();
+      if (updater_module) {
+        LOG(INFO) << "Resuming UpdaterModule singleton.";
+        updater_module->Resume();
+      }
+    }
+#endif
       // Ensure all intermediate state changes are triggered.
       TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
       break;

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -23,7 +23,6 @@
 #include "base/notreached.h"
 #include "base/run_loop.h"
 #include "base/threading/platform_thread.h"
-#include "build/build_config.h"
 #include "cobalt/app/app_event_runner.h"
 #include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
 #include "content/public/browser/browser_thread.h"

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -30,10 +30,6 @@
 #include "starboard/extension/crash_handler.h"
 #include "starboard/system.h"
 
-#if BUILDFLAG(USE_EVERGREEN)
-#include "cobalt/updater/updater_module.h"
-#endif
-
 namespace cobalt {
 
 namespace {
@@ -212,31 +208,9 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
     case kSbEventTypeConceal:
     case kSbEventTypeStop:
     case kSbEventTypeReveal:
-      // Ensure all intermediate state changes are triggered.
-      TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
-      break;
     case kSbEventTypeFreeze:
-#if BUILDFLAG(USE_EVERGREEN)
-    {
-      cobalt::updater::UpdaterModule* updater_module =
-          cobalt::updater::UpdaterModule::GetInstance();
-      if (updater_module) {
-        updater_module->Suspend();
-      }
-    }
-#endif
-      TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
-      break;
     case kSbEventTypeUnfreeze:
-#if BUILDFLAG(USE_EVERGREEN)
-    {
-      cobalt::updater::UpdaterModule* updater_module =
-          cobalt::updater::UpdaterModule::GetInstance();
-      if (updater_module) {
-        updater_module->Resume();
-      }
-    }
-#endif
+      // Ensure all intermediate state changes are triggered.
       TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
       break;
     case kSbEventTypeInput:

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -221,12 +221,10 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
       cobalt::updater::UpdaterModule* updater_module =
           cobalt::updater::UpdaterModule::GetInstance();
       if (updater_module) {
-        LOG(INFO) << "Suspending UpdaterModule singleton.";
         updater_module->Suspend();
       }
     }
 #endif
-      // Ensure all intermediate state changes are triggered.
       TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
       break;
     case kSbEventTypeUnfreeze:
@@ -235,12 +233,10 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
       cobalt::updater::UpdaterModule* updater_module =
           cobalt::updater::UpdaterModule::GetInstance();
       if (updater_module) {
-        LOG(INFO) << "Resuming UpdaterModule singleton.";
         updater_module->Resume();
       }
     }
 #endif
-      // Ensure all intermediate state changes are triggered.
       TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
       break;
     case kSbEventTypeInput:

--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -34,6 +34,10 @@
 #include "base/threading/thread_restrictions.h"
 #include "build/build_config.h"
 #include "cobalt/app/app_event_delegate.h"
+
+#if BUILDFLAG(USE_EVERGREEN)
+#include "cobalt/updater/updater_module.h"
+#endif
 #include "cobalt/browser/cobalt_content_browser_client.h"
 #include "cobalt/browser/h5vcc_accessibility/h5vcc_accessibility_manager.h"
 #include "cobalt/browser/h5vcc_runtime/deep_link_manager.h"
@@ -221,11 +225,25 @@ class AppEventRunnerImpl : public AppEventRunner,
     content::Shell::OnFreeze();
     WaitForAck(PendingAck::kCookieFlush);
     std::move(callback).Run();
+#if BUILDFLAG(USE_EVERGREEN)
+    cobalt::updater::UpdaterModule* updater_module =
+        cobalt::updater::UpdaterModule::GetInstance();
+    if (updater_module) {
+      updater_module->Suspend();
+    }
+#endif
   }
 
   void DoUnfreeze() override {
     content::Shell::OnUnfreeze();
     WaitForAck(PendingAck::kUnfreeze);
+#if BUILDFLAG(USE_EVERGREEN)
+    cobalt::updater::UpdaterModule* updater_module =
+        cobalt::updater::UpdaterModule::GetInstance();
+    if (updater_module) {
+      updater_module->Resume();
+    }
+#endif
   }
 
   void OnInput(const SbEvent* event) override {

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -27,6 +27,7 @@
 #include "base/stl_util.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/synchronization/waitable_event.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/task_runner.h"
 #include "base/threading/scoped_blocking_call.h"
@@ -206,12 +207,19 @@ UpdaterModule::~UpdaterModule() {
 void UpdaterModule::Suspend() {
   if (is_updater_running_) {
     is_updater_running_ = false;
+    base::WaitableEvent event(base::WaitableEvent::ResetPolicy::MANUAL,
+                              base::WaitableEvent::InitialState::NOT_SIGNALED);
     {
       base::ScopedBlockingCall scoped_blocking_call(
           FROM_HERE, base::BlockingType::MAY_BLOCK);
       updater_thread_->task_runner()->PostTask(
-          FROM_HERE,
-          base::BindOnce(&UpdaterModule::Finalize, base::Unretained(this)));
+          FROM_HERE, base::BindOnce(
+                         [](UpdaterModule* module, base::WaitableEvent* event) {
+                           module->Finalize();
+                           event->Signal();
+                         },
+                         base::Unretained(this), base::Unretained(&event)));
+      event.Wait();
     }
   }
 }

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -185,8 +185,7 @@ UpdaterModule::UpdaterModule(
 
 UpdaterModule::~UpdaterModule() {
   LOG(INFO) << "UpdaterModule::~UpdaterModule";
-  if (is_updater_running_) {
-    is_updater_running_ = false;
+  if (is_updater_running_.exchange(false)) {
     // TODO(b/452142372): Investigate UpdaterModule destruction sequence
     {
       base::ScopedBlockingCall scoped_blocking_call(

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -205,21 +205,22 @@ UpdaterModule::~UpdaterModule() {
 }
 
 void UpdaterModule::Suspend() {
-  if (is_updater_running_) {
-    is_updater_running_ = false;
+  if (is_updater_running_.exchange(false)) {
     base::WaitableEvent event(base::WaitableEvent::ResetPolicy::MANUAL,
                               base::WaitableEvent::InitialState::NOT_SIGNALED);
     {
       base::ScopedBlockingCall scoped_blocking_call(
           FROM_HERE, base::BlockingType::MAY_BLOCK);
-      updater_thread_->task_runner()->PostTask(
-          FROM_HERE, base::BindOnce(
-                         [](UpdaterModule* module, base::WaitableEvent* event) {
-                           module->Finalize();
-                           event->Signal();
-                         },
-                         base::Unretained(this), base::Unretained(&event)));
-      event.Wait();
+      if (updater_thread_->task_runner()->PostTask(
+              FROM_HERE,
+              base::BindOnce(
+                  [](UpdaterModule* module, base::WaitableEvent* event) {
+                    module->Finalize();
+                    event->Signal();
+                  },
+                  base::Unretained(this), base::Unretained(&event)))) {
+        event.Wait();
+      }
     }
   }
 }

--- a/cobalt/updater/updater_module.h
+++ b/cobalt/updater/updater_module.h
@@ -15,6 +15,7 @@
 #ifndef COBALT_UPDATER_UPDATER_MODULE_H_
 #define COBALT_UPDATER_UPDATER_MODULE_H_
 
+#include <atomic>
 #include <map>
 #include <memory>
 #include <string>
@@ -136,7 +137,7 @@ class UpdaterModule {
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;
   scoped_refptr<Configurator> updater_configurator_;
   int update_check_count_ = 0;
-  bool is_updater_running_;
+  std::atomic<bool> is_updater_running_;
   base::TimeDelta update_check_delay_ = kDefaultUpdateCheckDelay;
 
   int GetUpdateCheckCount() { return update_check_count_; }


### PR DESCRIPTION
Coordinate the lifecycle transition of the updater during App Freeze and Unfreeze 

- coordinate Freeze (kSbEventTypeFreeze) and Unfreeze (kSbEventTypeUnfreeze) events inside AppEventDelegate::HandleEventLocked.
- implemented synchronous blocking in UpdaterModule::Suspend using a base::WaitableEvent. This forces the calling thread to wait until the updater thread completely finalizes its operations
- converted is_updater_running_ to std::atomic<bool> to avoid data races.

Issue: 479816505