### PR TITLE
media: Resolve video pipeline backpressure leak on Android

### DIFF
--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -235,7 +235,9 @@ Result<void> MediaCodecAudioDecoder::InitializeCodec() {
 
 void MediaCodecAudioDecoder::ProcessOutputBuffer(
     MediaCodec* media_codec_bridge,
-    const DequeueOutputResult& dequeue_output_result) {
+    const DequeueOutputResult& dequeue_output_result,
+    int number_of_pending_inputs) {
+  SB_UNREFERENCED_PARAMETER(number_of_pending_inputs);
   SB_DCHECK(media_codec_bridge);
   SB_DCHECK(output_cb_);
   SB_DCHECK_GE(dequeue_output_result.index, 0);

--- a/starboard/android/shared/media_codec_audio_decoder.h
+++ b/starboard/android/shared/media_codec_audio_decoder.h
@@ -70,7 +70,8 @@ class MediaCodecAudioDecoder : public AudioDecoder,
 
   Result<void> InitializeCodec();
   void ProcessOutputBuffer(MediaCodec* media_codec_bridge,
-                           const DequeueOutputResult& output) override;
+                           const DequeueOutputResult& output,
+                           int number_of_pending_inputs) override;
   void OnEndOfStreamWritten(MediaCodec* media_codec_bridge) override {}
   void RefreshOutputFormat(MediaCodec* media_codec_bridge) override;
   bool Tick(MediaCodec* media_codec_bridge) override { return false; }

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -484,7 +484,8 @@ void MediaCodecDecoder::AudioDecoderThreadFunc() {
         host_->RefreshOutputFormat(media_codec_bridge_.get());
       } else {
         host_->ProcessOutputBuffer(media_codec_bridge_.get(),
-                                   dequeue_output_result);
+                                   dequeue_output_result,
+                                   GetNumberOfPendingInputs());
       }
     }
 
@@ -548,7 +549,8 @@ void MediaCodecDecoder::VideoDecoderThreadFunc() {
       } else {
         SB_DCHECK(!tunnel_mode_enabled_);
         host_->ProcessOutputBuffer(media_codec_bridge_.get(),
-                                   dequeue_output_result);
+                                   dequeue_output_result,
+                                   GetNumberOfPendingInputs());
       }
       dequeue_output_results.erase(dequeue_output_results.begin());
     }
@@ -645,7 +647,8 @@ void MediaCodecDecoder::OutputThreadFunc() {
         host_->RefreshOutputFormat(media_codec_bridge_.get());
       } else {
         host_->ProcessOutputBuffer(media_codec_bridge_.get(),
-                                   dequeue_output_result);
+                                   dequeue_output_result,
+                                   GetNumberOfPendingInputs());
       }
       dequeue_output_results.erase(dequeue_output_results.begin());
     } else {

--- a/starboard/android/shared/media_codec_decoder.h
+++ b/starboard/android/shared/media_codec_decoder.h
@@ -55,7 +55,8 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
   class Host {
    public:
     virtual void ProcessOutputBuffer(MediaCodec* media_codec,
-                                     const DequeueOutputResult& output) = 0;
+                                     const DequeueOutputResult& output,
+                                     int number_of_pending_inputs) = 0;
     virtual void OnEndOfStreamWritten(MediaCodec* media_codec) = 0;
     virtual void RefreshOutputFormat(MediaCodec* media_codec) = 0;
     // This function gets called frequently on the decoding thread to give the

--- a/starboard/android/shared/media_codec_decoder_test.cc
+++ b/starboard/android/shared/media_codec_decoder_test.cc
@@ -37,7 +37,9 @@ class MockHost : public MediaCodecDecoder::Host {
  public:
   MOCK_METHOD(void,
               ProcessOutputBuffer,
-              (MediaCodec * media_codec, const DequeueOutputResult& output),
+              (MediaCodec * media_codec,
+               const DequeueOutputResult& output,
+               int number_of_pending_inputs),
               (override));
   MOCK_METHOD(void,
               OnEndOfStreamWritten,
@@ -148,16 +150,16 @@ TEST_F(MediaCodecDecoderTest, BasicDecodingFlow) {
   bool output_processed = false;
   DequeueOutputResult processed_output;
 
-  EXPECT_CALL(host_, ProcessOutputBuffer(_, _))
-      .WillOnce(
-          Invoke([&](MediaCodec* codec, const DequeueOutputResult& output) {
-            std::lock_guard lock(output_mutex);
-            output_processed = true;
-            processed_output = output;
-            // Test code usually releases output buffer
-            codec->ReleaseOutputBuffer(output.index, false);
-            output_cv.notify_all();
-          }));
+  EXPECT_CALL(host_, ProcessOutputBuffer(_, _, _))
+      .WillOnce(Invoke([&](MediaCodec* codec, const DequeueOutputResult& output,
+                           int number_of_pending_inputs) {
+        std::lock_guard lock(output_mutex);
+        output_processed = true;
+        processed_output = output;
+        // Test code usually releases output buffer
+        codec->ReleaseOutputBuffer(output.index, false);
+        output_cv.notify_all();
+      }));
 
   fake_codec->SimulateOutputAvailable(0, 0, 0, 10000, 512);
 

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -966,8 +966,8 @@ void MediaCodecVideoDecoder::WriteInputBuffersInternal(
   }
 
   media_decoder_->WriteInputBuffers(input_buffers);
-  bool need_more_input_signaled = SignalIfNeedMoreInput();
-  if (!need_more_input_signaled && tunnel_mode_audio_session_id_) {
+  bool need_more_input = SignalIfNeedMoreInput();
+  if (!need_more_input && tunnel_mode_audio_session_id_) {
     // In tunnel mode playback when need data is not signaled above, it is
     // possible that the VideoDecoder won't get a chance to send kNeedMoreInput
     // to the renderer again.  Schedule a task to check back.
@@ -1018,11 +1018,11 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
       dequeue_output_result, media_codec_bridge,
       std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this));
 
-  bool need_more_input_signaled = false;
+  bool need_more_input = false;
   if (!is_end_of_stream) {
-    need_more_input_signaled = SignalIfNeedMoreInput(video_frame);
+    need_more_input = SignalIfNeedMoreInput(video_frame);
   }
-  if (!need_more_input_signaled) {
+  if (!need_more_input) {
     decoder_status_cb_(kBufferFull, std::move(video_frame));
   }
 }

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -993,7 +993,8 @@ void MediaCodecVideoDecoder::WriteInputBuffersInternal(
 
 void MediaCodecVideoDecoder::ProcessOutputBuffer(
     MediaCodec* media_codec_bridge,
-    const DequeueOutputResult& dequeue_output_result) {
+    const DequeueOutputResult& dequeue_output_result,
+    int number_of_pending_inputs) {
   SB_DCHECK(decoder_status_cb_);
   SB_DCHECK_GE(dequeue_output_result.index, 0);
 
@@ -1018,14 +1019,13 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
   }
 
   if (fix_need_more_input_backpressure_) {
-    auto video_frame = make_scoped_refptr<VideoFrameImpl>(
-        dequeue_output_result, media_codec_bridge,
-        std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this));
-
-    Schedule([this, is_end_of_stream, video_frame = std::move(video_frame)]() {
-      ProcessOutputBufferWithBackpressure(is_end_of_stream,
-                                          std::move(video_frame));
-    });
+    bool need_more_input =
+        !is_end_of_stream && number_of_pending_inputs < kMaxPendingInputsSize;
+    decoder_status_cb_(
+        need_more_input ? kNeedMoreInput : kBufferFull,
+        make_scoped_refptr<VideoFrameImpl>(
+            dequeue_output_result, media_codec_bridge,
+            std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
     return;
   }
 
@@ -1034,20 +1034,6 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
       new VideoFrameImpl(
           dequeue_output_result, media_codec_bridge,
           std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
-}
-
-void MediaCodecVideoDecoder::ProcessOutputBufferWithBackpressure(
-    bool is_end_of_stream,
-    scoped_refptr<VideoFrame> video_frame) {
-  SB_CHECK(BelongsToCurrentThread());
-  if (!decoder_status_cb_) {
-    return;
-  }
-  bool need_more_input =
-      !is_end_of_stream && media_decoder_ &&
-      media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
-  decoder_status_cb_(need_more_input ? kNeedMoreInput : kBufferFull,
-                     std::move(video_frame));
 }
 
 void MediaCodecVideoDecoder::OnEndOfStreamWritten(

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -381,6 +381,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
           kMediaEnableLowLatency)),
       enable_ndk_video_(
           pipeline_config.experimental_features.GetBool(kMediaNdkVideo)),
+      fix_need_more_input_backpressure_(
+          pipeline_config.experimental_features.GetBool(
+              kMediaFixNeedMoreInputBackpressure)),
       is_video_frame_tracker_enabled_(android_get_device_api_level() >= 34 ||
                                       tunnel_mode_audio_session_id_),
       media_codec_factory_(std::move(media_codec_factory)),
@@ -1014,9 +1017,12 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
     }
   }
 
-  bool need_more_input =
-      !is_end_of_stream && media_decoder_ &&
-      media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
+  bool need_more_input = !is_end_of_stream;
+  if (need_more_input && fix_need_more_input_backpressure_) {
+    need_more_input =
+        media_decoder_ &&
+        media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
+  }
   decoder_status_cb_(
       need_more_input ? kNeedMoreInput : kBufferFull,
       make_scoped_refptr<VideoFrameImpl>(

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -133,17 +133,15 @@ const int kNonInitialPrerollFrameCount = 1;
 // tunnel mode prerolling only needs 1 frame.
 const int kTunnelModePrerollFrameCount = 1;
 // The maximum number of pending inputs allowed in the decoder queue.
-// We set this to 512 frames (approx 8.5 seconds of 60fps video or 17 seconds
-// of 30fps video) to provide a robust buffer safety cushion that survives
-// V8 JavaScript main-thread congestion (which typically lasts 2-5 seconds
-// during app startup or heavy page transitions) without video starvation,
-// while keeping C++ heap memory usage extremely low (~25MB for 4K streams).
-constexpr int kMaxPendingInputsSize = 512;
+// We set this to 128 frames (approx 2.1 seconds of 60fps video or 4.2 seconds
+// of 30fps video) to provide a buffer safety cushion that helps survive
+// V8 JavaScript main-thread congestion without video starvation,
+constexpr int kMaxPendingInputsSize = 128;
 
 // VideoFrameTracker tracks frames in the entire media pipeline (decoder queue,
 // codec, and renderer). We set its capacity to accommodate the maximum input
-// queue size (512) plus a margin of 100 frames for frames in the codec and
-// renderer.
+// queue size (`kMaxPendingInputsSize`) plus a margin of 100 frames for frames
+// in the codec and renderer.
 constexpr int kVideoFrameTrackerCapacity = kMaxPendingInputsSize + 100;
 
 const int kFpsGuesstimateRequiredInputBufferCount = 3;

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -1017,17 +1017,37 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
     }
   }
 
-  bool need_more_input = !is_end_of_stream;
-  if (need_more_input && fix_need_more_input_backpressure_) {
-    need_more_input =
-        media_decoder_ &&
-        media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
+  if (fix_need_more_input_backpressure_) {
+    auto video_frame = make_scoped_refptr<VideoFrameImpl>(
+        dequeue_output_result, media_codec_bridge,
+        std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this));
+
+    Schedule([this, is_end_of_stream, video_frame = std::move(video_frame)]() {
+      ProcessOutputBufferWithBackpressure(is_end_of_stream,
+                                          std::move(video_frame));
+    });
+    return;
   }
+
   decoder_status_cb_(
-      need_more_input ? kNeedMoreInput : kBufferFull,
-      make_scoped_refptr<VideoFrameImpl>(
+      is_end_of_stream ? kBufferFull : kNeedMoreInput,
+      new VideoFrameImpl(
           dequeue_output_result, media_codec_bridge,
           std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
+}
+
+void MediaCodecVideoDecoder::ProcessOutputBufferWithBackpressure(
+    bool is_end_of_stream,
+    scoped_refptr<VideoFrame> video_frame) {
+  SB_CHECK(BelongsToCurrentThread());
+  if (!decoder_status_cb_) {
+    return;
+  }
+  bool need_more_input =
+      !is_end_of_stream && media_decoder_ &&
+      media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
+  decoder_status_cb_(need_more_input ? kNeedMoreInput : kBufferFull,
+                     std::move(video_frame));
 }
 
 void MediaCodecVideoDecoder::OnEndOfStreamWritten(

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -964,8 +964,9 @@ void MediaCodecVideoDecoder::WriteInputBuffersInternal(
   }
 
   media_decoder_->WriteInputBuffers(input_buffers);
-  bool need_more_input = SignalIfNeedMoreInput();
-  if (!need_more_input && tunnel_mode_audio_session_id_) {
+  if (media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize) {
+    decoder_status_cb_(kNeedMoreInput, NULL);
+  } else if (tunnel_mode_audio_session_id_) {
     // In tunnel mode playback when need data is not signaled above, it is
     // possible that the VideoDecoder won't get a chance to send kNeedMoreInput
     // to the renderer again.  Schedule a task to check back.
@@ -1012,17 +1013,15 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
       }
     }
   }
-  auto video_frame = make_scoped_refptr<VideoFrameImpl>(
-      dequeue_output_result, media_codec_bridge,
-      std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this));
 
-  bool need_more_input = false;
-  if (!is_end_of_stream) {
-    need_more_input = SignalIfNeedMoreInput(video_frame);
-  }
-  if (!need_more_input) {
-    decoder_status_cb_(kBufferFull, std::move(video_frame));
-  }
+  bool need_more_input =
+      !is_end_of_stream &&
+      media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
+  decoder_status_cb_(
+      need_more_input ? kNeedMoreInput : kBufferFull,
+      make_scoped_refptr<VideoFrameImpl>(
+          dequeue_output_result, media_codec_bridge,
+          std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
 }
 
 void MediaCodecVideoDecoder::OnEndOfStreamWritten(
@@ -1152,7 +1151,8 @@ void MediaCodecVideoDecoder::OnTunnelModeCheckForNeedMoreInput() {
     return;
   }
 
-  if (SignalIfNeedMoreInput()) {
+  if (media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize) {
+    decoder_status_cb_(kNeedMoreInput, NULL);
     return;
   }
 
@@ -1224,23 +1224,6 @@ void MediaCodecVideoDecoder::ResetInternal(bool skip_flush) {
   //       VideoRenderer::Seek() after calling MediaCodecVideoDecoder::Reset()
   //       to update the seek status of |video_frame_tracker_|.  This is
   //       slightly flaky as it depends on the behavior of the video renderer.
-}
-
-bool MediaCodecVideoDecoder::SignalIfNeedMoreInput(
-    const scoped_refptr<VideoFrame>& frame) {
-  if (!decoder_status_cb_) {
-    return false;
-  }
-  if (!media_decoder_) {
-    return false;
-  }
-
-  bool need_more_input =
-      media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
-  if (need_more_input) {
-    decoder_status_cb_(kNeedMoreInput, frame);
-  }
-  return need_more_input;
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -135,7 +135,7 @@ const int kTunnelModePrerollFrameCount = 1;
 // The maximum number of pending inputs allowed in the decoder queue.
 // We set this to 128 frames (approx 2.1 seconds of 60fps video or 4.2 seconds
 // of 30fps video) to provide a buffer safety cushion that helps survive
-// V8 JavaScript main-thread congestion without video starvation,
+// V8 JavaScript main-thread congestion without video starvation.
 constexpr int kMaxPendingInputsSize = 128;
 
 // VideoFrameTracker tracks frames in the entire media pipeline (decoder queue,
@@ -1015,7 +1015,7 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
   }
 
   bool need_more_input =
-      !is_end_of_stream &&
+      !is_end_of_stream && media_decoder_ &&
       media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
   decoder_status_cb_(
       need_more_input ? kNeedMoreInput : kBufferFull,

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -1229,7 +1229,7 @@ void MediaCodecVideoDecoder::ResetInternal(bool skip_flush) {
 }
 
 bool MediaCodecVideoDecoder::SignalIfNeedMoreInput(
-    scoped_refptr<VideoFrame> frame) {
+    const scoped_refptr<VideoFrame>& frame) {
   if (!decoder_status_cb_) {
     return false;
   }
@@ -1240,7 +1240,7 @@ bool MediaCodecVideoDecoder::SignalIfNeedMoreInput(
   bool need_more_input =
       media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
   if (need_more_input) {
-    decoder_status_cb_(kNeedMoreInput, std::move(frame));
+    decoder_status_cb_(kNeedMoreInput, frame);
   }
   return need_more_input;
 }

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -132,7 +132,19 @@ const int kNonInitialPrerollFrameCount = 1;
 // rendered, the rest of the playback should play without frame drops. So,
 // tunnel mode prerolling only needs 1 frame.
 const int kTunnelModePrerollFrameCount = 1;
-const int kMaxPendingInputsSize = 128;
+// The maximum number of pending inputs allowed in the decoder queue.
+// We set this to 512 frames (approx 8.5 seconds of 60fps video or 17 seconds
+// of 30fps video) to provide a robust buffer safety cushion that survives
+// V8 JavaScript main-thread congestion (which typically lasts 2-5 seconds
+// during app startup or heavy page transitions) without video starvation,
+// while keeping C++ heap memory usage extremely low (~25MB for 4K streams).
+constexpr int kMaxPendingInputsSize = 512;
+
+// VideoFrameTracker tracks frames in the entire media pipeline (decoder queue,
+// codec, and renderer). We set its capacity to accommodate the maximum input
+// queue size (512) plus a margin of 100 frames for frames in the codec and
+// renderer.
+constexpr int kVideoFrameTrackerCapacity = kMaxPendingInputsSize + 100;
 
 const int kFpsGuesstimateRequiredInputBufferCount = 3;
 
@@ -407,7 +419,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
 
   if (is_video_frame_tracker_enabled_) {
     video_frame_tracker_ =
-        std::make_unique<VideoFrameTracker>(kMaxPendingInputsSize * 2);
+        std::make_unique<VideoFrameTracker>(kVideoFrameTrackerCapacity);
   }
 
   if (require_software_codec_) {
@@ -954,9 +966,8 @@ void MediaCodecVideoDecoder::WriteInputBuffersInternal(
   }
 
   media_decoder_->WriteInputBuffers(input_buffers);
-  if (media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize) {
-    decoder_status_cb_(kNeedMoreInput, NULL);
-  } else if (tunnel_mode_audio_session_id_) {
+  bool need_more_input_signaled = SignalIfNeedMoreInput();
+  if (!need_more_input_signaled && tunnel_mode_audio_session_id_) {
     // In tunnel mode playback when need data is not signaled above, it is
     // possible that the VideoDecoder won't get a chance to send kNeedMoreInput
     // to the renderer again.  Schedule a task to check back.
@@ -1003,11 +1014,17 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
       }
     }
   }
-  decoder_status_cb_(
-      is_end_of_stream ? kBufferFull : kNeedMoreInput,
-      new VideoFrameImpl(
-          dequeue_output_result, media_codec_bridge,
-          std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
+  auto video_frame = make_scoped_refptr<VideoFrameImpl>(
+      dequeue_output_result, media_codec_bridge,
+      std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this));
+
+  bool need_more_input_signaled = false;
+  if (!is_end_of_stream) {
+    need_more_input_signaled = SignalIfNeedMoreInput(video_frame);
+  }
+  if (!need_more_input_signaled) {
+    decoder_status_cb_(kBufferFull, std::move(video_frame));
+  }
 }
 
 void MediaCodecVideoDecoder::OnEndOfStreamWritten(
@@ -1137,8 +1154,7 @@ void MediaCodecVideoDecoder::OnTunnelModeCheckForNeedMoreInput() {
     return;
   }
 
-  if (media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize) {
-    decoder_status_cb_(kNeedMoreInput, NULL);
+  if (SignalIfNeedMoreInput()) {
     return;
   }
 
@@ -1210,6 +1226,23 @@ void MediaCodecVideoDecoder::ResetInternal(bool skip_flush) {
   //       VideoRenderer::Seek() after calling MediaCodecVideoDecoder::Reset()
   //       to update the seek status of |video_frame_tracker_|.  This is
   //       slightly flaky as it depends on the behavior of the video renderer.
+}
+
+bool MediaCodecVideoDecoder::SignalIfNeedMoreInput(
+    scoped_refptr<VideoFrame> frame) {
+  if (!decoder_status_cb_) {
+    return false;
+  }
+  if (!media_decoder_) {
+    return false;
+  }
+
+  bool need_more_input =
+      media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize;
+  if (need_more_input) {
+    decoder_status_cb_(kNeedMoreInput, std::move(frame));
+  }
+  return need_more_input;
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -300,7 +300,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
       const PipelineConfig& pipeline_config,
       const PlatformOptions& platform_options);
 
-  bool SignalIfNeedMoreInput(scoped_refptr<VideoFrame> frame = nullptr);
+  bool SignalIfNeedMoreInput(const scoped_refptr<VideoFrame>& frame = nullptr);
 
   const std::unique_ptr<VideoSurfaceTextureBridge> surface_texture_bridge_;
 };

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -300,6 +300,8 @@ class MediaCodecVideoDecoder : public VideoDecoder,
       const PipelineConfig& pipeline_config,
       const PlatformOptions& platform_options);
 
+  bool SignalIfNeedMoreInput(scoped_refptr<VideoFrame> frame = nullptr);
+
   const std::unique_ptr<VideoSurfaceTextureBridge> surface_texture_bridge_;
 };
 

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -224,6 +224,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   const bool enable_trivial_optimizations_;
   const bool enable_low_latency_;
   const bool enable_ndk_video_;
+  const bool fix_need_more_input_backpressure_;
 
   // On some platforms tunnel mode is only supported in the secure pipeline.  So
   // we create a dummy drm system to force the video playing in secure pipeline

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -300,8 +300,6 @@ class MediaCodecVideoDecoder : public VideoDecoder,
       const PipelineConfig& pipeline_config,
       const PlatformOptions& platform_options);
 
-  bool SignalIfNeedMoreInput(const scoped_refptr<VideoFrame>& frame = nullptr);
-
   const std::unique_ptr<VideoSurfaceTextureBridge> surface_texture_bridge_;
 };
 

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -148,7 +148,8 @@ class MediaCodecVideoDecoder : public VideoDecoder,
 
   void WriteInputBuffersInternal(const InputBuffers& input_buffers);
   void ProcessOutputBuffer(MediaCodec* media_codec_bridge,
-                           const DequeueOutputResult& output) override;
+                           const DequeueOutputResult& output,
+                           int number_of_pending_inputs) override;
   void OnEndOfStreamWritten(MediaCodec* media_codec_bridge) override;
   void RefreshOutputFormat(MediaCodec* media_codec_bridge) override;
   bool Tick(MediaCodec* media_codec_bridge) override;
@@ -162,9 +163,6 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   void OnTunnelModeCheckForNeedMoreInput();
 
   void OnVideoFrameRelease();
-  void ProcessOutputBufferWithBackpressure(
-      bool is_end_of_stream,
-      scoped_refptr<VideoFrame> video_frame);
 
   void OnSurfaceDestroyed() override;
   void ReportError(SbPlayerError error, const std::string& error_message);

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -162,6 +162,9 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   void OnTunnelModeCheckForNeedMoreInput();
 
   void OnVideoFrameRelease();
+  void ProcessOutputBufferWithBackpressure(
+      bool is_end_of_stream,
+      scoped_refptr<VideoFrame> video_frame);
 
   void OnSurfaceDestroyed() override;
   void ReportError(SbPlayerError error, const std::string& error_message);

--- a/starboard/android/shared/media_codec_video_decoder_test.cc
+++ b/starboard/android/shared/media_codec_video_decoder_test.cc
@@ -14,6 +14,7 @@
 
 #include "starboard/android/shared/media_codec_video_decoder.h"
 
+#include <chrono>
 #include <condition_variable>
 #include <deque>
 #include <mutex>
@@ -105,6 +106,8 @@ class MediaCodecVideoDecoderTest : public ::testing::Test {
     return fake_factory_ ? fake_factory_->last_created_video_codec() : nullptr;
   }
 
+  std::mutex callback_mutex_;
+  int need_more_input_count_ = 0;
   JobQueue job_queue_;
   FakeMediaCodecFactory* fake_factory_ = nullptr;
   const jni_zero::ScopedJavaGlobalRef<jstring> dummy_surface_{
@@ -186,6 +189,72 @@ TEST_F(MediaCodecVideoDecoderTest, BasicDecodingFlow) {
   EXPECT_FALSE(released_outputs[0].render);
 
   EXPECT_FALSE(error_called);
+}
+
+TEST_F(MediaCodecVideoDecoderTest, BackpressureOnOutputFrame) {
+  CreateDecoder();
+
+  FakeMediaCodec* fake_codec = GetFakeVideoCodec();
+  ASSERT_NE(fake_codec, nullptr);
+
+  std::mutex local_mutex;
+  std::condition_variable local_cv;
+  bool output_received = false;
+  VideoDecoder::Status received_status = VideoDecoder::kNeedMoreInput;
+
+  decoder_->Initialize(
+      [&](VideoDecoder::Status status, const scoped_refptr<VideoFrame>& frame) {
+        std::lock_guard lock(callback_mutex_);
+        if (status == VideoDecoder::kNeedMoreInput) {
+          need_more_input_count_++;
+        }
+        if (frame) {
+          received_status = status;
+          std::lock_guard local_lock(local_mutex);
+          output_received = true;
+          local_cv.notify_all();
+        }
+      },
+      [](SbPlayerError error, const std::string& msg) {});
+
+  const int kMaxPendingInputs = 128;
+
+  // Write `kMaxPendingInputs + 1` buffers to fill the queue and go beyond.
+  // We expect signals for the first `kMaxPendingInputs - 1` writes.
+  for (int i = 0; i < kMaxPendingInputs + 1; ++i) {
+    auto input_buffer = CreateDummyVideoInputBuffer(i * 1000, 1024);
+    decoder_->WriteInputBuffers({input_buffer});
+  }
+
+  {
+    std::lock_guard lock(callback_mutex_);
+    EXPECT_EQ(need_more_input_count_, kMaxPendingInputs - 1);
+  }
+
+  // Simulate one input buffer available.
+  // Decoder should process it, reducing the pending queue size to the threshold
+  // (`kMaxPendingInputs`).
+  fake_codec->SimulateInputBufferAvailable(0);
+  ASSERT_TRUE(fake_codec->WaitForInputQueue(1, 1000));
+
+  // Simulate output buffer ready.
+  // Since the pending queue size is still at the threshold (>=
+  // `kMaxPendingInputs`), the decoder should NOT signal `kNeedMoreInput` but
+  // instead signal `kBufferFull`.
+  fake_codec->SimulateOutputAvailable(/*index=*/0, /*flags=*/0, /*offset=*/0,
+                                      /*pts=*/0, /*size=*/1024);
+
+  // Wait for the output callback.
+  std::unique_lock<std::mutex> local_lock(local_mutex);
+  ASSERT_TRUE(
+      local_cv.wait_for(local_lock, std::chrono::seconds(1),
+                        [&output_received]() { return output_received; }));
+
+  EXPECT_EQ(received_status, VideoDecoder::kBufferFull);
+  {
+    std::lock_guard lock(callback_mutex_);
+    EXPECT_EQ(need_more_input_count_, kMaxPendingInputs - 1);
+  }
 }
 
 }  // namespace

--- a/starboard/android/shared/media_codec_video_decoder_test.cc
+++ b/starboard/android/shared/media_codec_video_decoder_test.cc
@@ -23,6 +23,7 @@
 #include "base/android/jni_string.h"
 #include "starboard/android/shared/fake_media_codec.h"
 #include "starboard/common/ref_counted.h"
+#include "starboard/shared/starboard/experimental_features.h"
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -49,7 +50,7 @@ const VideoStreamInfo kDefaultVideoStreamInfo = [] {
 
 class MediaCodecVideoDecoderTest : public ::testing::Test {
  protected:
-  void CreateDecoder() {
+  void CreateDecoder(ExperimentalFeatures experimental_features = {}) {
     auto factory = std::make_unique<FakeMediaCodecFactory>();
     fake_factory_ = factory.get();  // Save raw pointer before moving!
 
@@ -63,6 +64,7 @@ class MediaCodecVideoDecoderTest : public ::testing::Test {
 
     MediaCodecVideoDecoder::TunnelModeConfig tunnel_config;
     MediaCodecVideoDecoder::PipelineConfig pipeline_config;
+    pipeline_config.experimental_features = std::move(experimental_features);
     MediaCodecVideoDecoder::PlatformOptions platform_options;
 
     auto result = MediaCodecVideoDecoder::CreateForTesting(
@@ -192,7 +194,8 @@ TEST_F(MediaCodecVideoDecoderTest, BasicDecodingFlow) {
 }
 
 TEST_F(MediaCodecVideoDecoderTest, BackpressureOnOutputFrame) {
-  CreateDecoder();
+  CreateDecoder(ExperimentalFeatures(
+      {{std::string(kMediaFixNeedMoreInputBackpressure.key()), 1}}));
 
   FakeMediaCodec* fake_codec = GetFakeVideoCodec();
   ASSERT_NE(fake_codec, nullptr);

--- a/starboard/android/shared/media_codec_video_decoder_test.cc
+++ b/starboard/android/shared/media_codec_video_decoder_test.cc
@@ -217,7 +217,7 @@ TEST_F(MediaCodecVideoDecoderTest, BackpressureOnOutputFrame) {
       },
       [](SbPlayerError error, const std::string& msg) {});
 
-  const int kMaxPendingInputs = 128;
+  constexpr int kMaxPendingInputs = 128;
 
   // Write `kMaxPendingInputs + 1` buffers to fill the queue and go beyond.
   // We expect signals for the first `kMaxPendingInputs - 1` writes.

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -87,6 +87,10 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
       static_cast<size_t>(max_pending_frames_size_)) {
     // OnFrameRendered() is only available after API level 23.  Cap the size
     // of |frames_to_be_rendered_| in case OnFrameRendered() is not available.
+    SB_LOG(WARNING) << "VideoFrameTracker capacity exceeded ("
+                    << max_pending_frames_size_
+                    << " frames). Evicting oldest frame with timestamp: "
+                    << frames_to_be_rendered_.front();
     frames_to_be_rendered_.pop_front();
   }
 

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -184,6 +184,11 @@ inline constexpr ExperimentalFeatureKey<bool>
     kMediaEnableVideoRendererVspAdjustment(
         "Media.EnableVideoRendererVspAdjustment");
 
+// To check the regression of the fix for the bug that pending frame grows
+// 2000+. For details, see http://b/517914191.
+inline constexpr ExperimentalFeatureKey<bool>
+    kMediaFixNeedMoreInputBackpressure("Media.FixNeedMoreInputBackpressure");
+
 inline constexpr ExperimentalFeatureKey<bool> kMediaFlushAudioTrackDuringSeek(
     "Media.FlushAudioTrackDuringSeek");
 


### PR DESCRIPTION
This PR fixes a bug where `MediaCodecVideoDecoder` signaled NEED_MORE_INPUT unconditionally. By introducing the unified `SignalIfNeedMoreInput()` method, this PR ensures all NEED_MORE_INPUT calls are only dispatched after a proper buffer-fullness check.

Issue: 515102461
Issue: 517914191