### PR TITLE
Deprecate raspi on device tests

### DIFF
--- a/.github/config/evergreen-arm-hardfp-raspi.json
+++ b/.github/config/evergreen-arm-hardfp-raspi.json
@@ -4,7 +4,7 @@
     "evergreen-arm-hardfp-raspi"
   ],
   "test_package": true,
-  "test_on_device": true,
+  "test_on_device": false,
   "test_device_family": "raspi",
   "test_e2e": true,
   "test_root_target": "//cobalt:gn_all",

--- a/.github/config/raspi-2-modular.json
+++ b/.github/config/raspi-2-modular.json
@@ -3,7 +3,7 @@
   "platforms": [
     "raspi-2-modular"
   ],
-  "test_on_device": true,
+  "test_on_device": false,
   "test_device_family": "raspi",
   "test_root_target": "//cobalt:gn_all",
   "test_dimensions": {


### PR DESCRIPTION
ci: Disable on-device tests for Raspberry Pi

Disable on-device test execution for Raspberry Pi platforms in the
GitHub CI configuration. This change affects both the raspi-2-modular
and evergreen-arm-hardfp-raspi configurations as these tests are being
deprecated.

Issue: 517295375