### PR TITLE
Deprecate SbThreadPriority

### DIFF
--- a/cobalt/site/docs/reference/starboard/modules/18/thread.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/thread.md
@@ -11,57 +11,6 @@ Defines functionality related to thread creation and cleanup.
 
 Well-defined constant value to mean "no thread ID."
 
-## Enums
-
-### SbThreadPriority
-
-A spectrum of thread priorities. Platforms map them appropriately to their own
-priority system. Note that scheduling is platform-specific, and what these
-priorities mean, if they mean anything at all, is also platform-specific.
-
-In particular, several of these priority values can map to the same priority on
-a given platform. The only guarantee is that each lower priority should be
-treated less-than-or-equal-to a higher priority.
-
-#### Values
-
-*   `kSbThreadPriorityLowest`
-
-    The lowest thread priority available on the current platform.
-*   `kSbThreadPriorityLow`
-
-    A lower-than-normal thread priority, if available on the current platform.
-*   `kSbThreadPriorityNormal`
-
-    Really, what is normal? You should spend time pondering that question more
-    than you consider less-important things, but less than you think about more-
-    important things.
-*   `kSbThreadPriorityHigh`
-
-    A higher-than-normal thread priority, if available on the current platform.
-*   `kSbThreadPriorityHighest`
-
-    The highest thread priority available on the current platform that isn't
-    considered "real-time" or "time-critical," if those terms have any meaning
-    on the current platform.
-*   `kSbThreadPriorityRealTime`
-
-    If the platform provides any kind of real-time or time-critical scheduling,
-    this priority will request that treatment. Real-time scheduling generally
-    means that the thread will have more consistency in scheduling than non-
-    real-time scheduled threads, often by being more deterministic in how
-    threads run in relation to each other. But exactly how being real-time
-    affects the thread scheduling is platform-specific.
-
-    For platforms where that is not offered, or otherwise not meaningful, this
-    will just be the highest priority available in the platform's scheme, which
-    may be the same as kSbThreadPriorityHighest.
-*   `kSbThreadNoPriority`
-
-    Well-defined constant value to mean "no priority." This means to use the
-    default priority assignment method of that platform. This may mean to
-    inherit the priority of the spawning thread, or it may mean a specific
-    default priority, or it may mean something else, depending on the platform.
 
 ## Typedefs
 
@@ -86,14 +35,4 @@ Returns whether the given thread ID is valid.
 
 ```
 static bool SbThreadIsValidId(SbThreadId id)
-```
-
-### SbThreadIsValidPriority
-
-Returns whether the given thread priority is valid.
-
-#### Declaration
-
-```
-static bool SbThreadIsValidPriority(SbThreadPriority priority)
 ```

--- a/cobalt/site/docs/reference/starboard/modules/thread.md
+++ b/cobalt/site/docs/reference/starboard/modules/thread.md
@@ -11,57 +11,6 @@ Defines functionality related to thread creation and cleanup.
 
 Well-defined constant value to mean "no thread ID."
 
-## Enums
-
-### SbThreadPriority
-
-A spectrum of thread priorities. Platforms map them appropriately to their own
-priority system. Note that scheduling is platform-specific, and what these
-priorities mean, if they mean anything at all, is also platform-specific.
-
-In particular, several of these priority values can map to the same priority on
-a given platform. The only guarantee is that each lower priority should be
-treated less-than-or-equal-to a higher priority.
-
-#### Values
-
-*   `kSbThreadPriorityLowest`
-
-    The lowest thread priority available on the current platform.
-*   `kSbThreadPriorityLow`
-
-    A lower-than-normal thread priority, if available on the current platform.
-*   `kSbThreadPriorityNormal`
-
-    Really, what is normal? You should spend time pondering that question more
-    than you consider less-important things, but less than you think about more-
-    important things.
-*   `kSbThreadPriorityHigh`
-
-    A higher-than-normal thread priority, if available on the current platform.
-*   `kSbThreadPriorityHighest`
-
-    The highest thread priority available on the current platform that isn't
-    considered "real-time" or "time-critical," if those terms have any meaning
-    on the current platform.
-*   `kSbThreadPriorityRealTime`
-
-    If the platform provides any kind of real-time or time-critical scheduling,
-    this priority will request that treatment. Real-time scheduling generally
-    means that the thread will have more consistency in scheduling than non-
-    real-time scheduled threads, often by being more deterministic in how
-    threads run in relation to each other. But exactly how being real-time
-    affects the thread scheduling is platform-specific.
-
-    For platforms where that is not offered, or otherwise not meaningful, this
-    will just be the highest priority available in the platform's scheme, which
-    may be the same as kSbThreadPriorityHighest.
-*   `kSbThreadNoPriority`
-
-    Well-defined constant value to mean "no priority." This means to use the
-    default priority assignment method of that platform. This may mean to
-    inherit the priority of the spawning thread, or it may mean a specific
-    default priority, or it may mean something else, depending on the platform.
 
 ## Typedefs
 
@@ -86,14 +35,4 @@ Returns whether the given thread ID is valid.
 
 ```
 static bool SbThreadIsValidId(SbThreadId id)
-```
-
-### SbThreadIsValidPriority
-
-Returns whether the given thread priority is valid.
-
-#### Declaration
-
-```
-static bool SbThreadIsValidPriority(SbThreadPriority priority)
 ```

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -144,7 +144,7 @@ void AudioRendererPassthrough::WriteSamples(const InputBuffers& input_buffers) {
 
   if (!audio_track_thread_) {
     audio_track_thread_ = JobThread::Create(
-        "AudioPassthrough", ThreadOptions().SetPriority(kSbThreadPriorityHigh));
+        "AudioPassthrough", ThreadOptions().SetPriority(ThreadPriority::kHigh));
     audio_track_thread_->Schedule(std::bind(
         &AudioRendererPassthrough::CreateAudioTrackAndStartProcessing, this));
   }

--- a/starboard/android/shared/audio_sink_min_required_frames_tester.cc
+++ b/starboard/android/shared/audio_sink_min_required_frames_tester.cc
@@ -48,7 +48,7 @@ class AudioSinkMinRequiredFramesTester::TesterThread : public Thread {
  public:
   explicit TesterThread(AudioSinkMinRequiredFramesTester* tester)
       : Thread("min_frames_test",
-               ThreadOptions().SetPriority(kSbThreadPriorityLowest)),
+               ThreadOptions().SetPriority(ThreadPriority::kLowest)),
         tester_(tester) {}
 
   void Run() override { tester_->TesterThreadFunc(); }

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -112,7 +112,7 @@ class AudioTrackAudioSink::AudioTrackOutThread : public Thread {
  public:
   explicit AudioTrackOutThread(AudioTrackAudioSink* sink)
       : Thread("audio_track_out",
-               ThreadOptions().SetPriority(kSbThreadPriorityRealTime)),
+               ThreadOptions().SetPriority(ThreadPriority::kRealTime)),
         sink_(sink) {}
 
   void Run() override { sink_->AudioThreadFunc(); }

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -81,7 +81,7 @@ class MediaCodecDecoder::DecoderThread : public Thread {
  public:
   DecoderThread(std::string_view name,
                 std::function<void()> runnable,
-                std::optional<SbThreadPriority> priority = std::nullopt)
+                std::optional<ThreadPriority> priority = std::nullopt)
       : Thread(name,
                priority ? ThreadOptions().SetPriority(priority.value())
                         : ThreadOptions()),
@@ -303,14 +303,14 @@ void MediaCodecDecoder::WriteInputBuffers(const InputBuffers& input_buffers) {
           "VidDecIn", [this] { InputThreadFunc(); });
       video_input_thread_->Start();
       video_output_thread_ = std::make_unique<DecoderThread>(
-          "VidDecOut", [this] { OutputThreadFunc(); }, kSbThreadPriorityHigh);
+          "VidDecOut", [this] { OutputThreadFunc(); }, ThreadPriority::kHigh);
       video_output_thread_->Start();
     }
   } else if (!decoder_thread_) {
     decoder_thread_ = std::make_unique<DecoderThread>(
         GetDecoderName(media_type_), [this] { DecoderThreadFunc(); },
-        media_type_ == kSbMediaTypeAudio ? kSbThreadPriorityNormal
-                                         : kSbThreadPriorityHigh);
+        media_type_ == kSbMediaTypeAudio ? ThreadPriority::kNormal
+                                         : ThreadPriority::kHigh);
     decoder_thread_->Start();
   }
 
@@ -927,7 +927,7 @@ void MediaCodecDecoder::OnMediaCodecInputBufferAvailable(int buffer_index) {
   if (media_type_ == kSbMediaTypeVideo && first_call_on_handler_thread_) {
     // Set the thread priority of the Handler thread to dispatch the async
     // decoder callbacks to high.
-    setpriority(PRIO_PROCESS, 0, SbPriorityToNice(kSbThreadPriorityHigh));
+    setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kHigh));
     first_call_on_handler_thread_ = false;
   }
   std::lock_guard lock(mutex_);

--- a/starboard/common/thread.cc
+++ b/starboard/common/thread.cc
@@ -39,20 +39,20 @@ namespace {
 // Returns a value between 0 and 1 that is used by SetThreadPriority() to scale
 // the desired thread priority between what sched_get_priority_min() and
 // sched_get_priority_max() return.
-float SbThreadPriorityToRelativeSchedPriority(SbThreadPriority priority) {
+float SbThreadPriorityToRelativeSchedPriority(ThreadPriority priority) {
   switch (priority) {
-    case kSbThreadPriorityLowest:
+    case ThreadPriority::kLowest:
       return 0.1f;
-    case kSbThreadPriorityLow:
+    case ThreadPriority::kLow:
       return 0.3f;
-    case kSbThreadNoPriority:
-    case kSbThreadPriorityNormal:
+    case ThreadPriority::kNoPriority:
+    case ThreadPriority::kNormal:
       return 0.5f;
-    case kSbThreadPriorityHigh:
+    case ThreadPriority::kHigh:
       return 0.7f;
-    case kSbThreadPriorityHighest:
+    case ThreadPriority::kHighest:
       return 0.9f;
-    case kSbThreadPriorityRealTime:
+    case ThreadPriority::kRealTime:
       return 0.99f;
   }
   SB_NOTREACHED();
@@ -61,13 +61,13 @@ float SbThreadPriorityToRelativeSchedPriority(SbThreadPriority priority) {
 
 // Wrapper for changing a thread's priority. On Linux kernel-based platforms
 // (including Android), this code relies on setpriority(2), which on Linux
-// deviates from the standard and changes per-thread attributes (rather tha
+// deviates from the standard and changes per-thread attributes (rather than
 // per-process).
 //
-// On tvOS, use pthread_setschedparam() by translating SbThreadPriority into an
+// On tvOS, use pthread_setschedparam() by translating ThreadPriority into an
 // integer between what sched_get_priority_min() and sched_get_priority_max()
 // return.
-bool SetThreadPriority(SbThreadPriority priority) {
+bool SetThreadPriority(ThreadPriority priority) {
 #if defined(__APPLE__)
   const float relative_priority =
       SbThreadPriorityToRelativeSchedPriority(priority);
@@ -97,23 +97,23 @@ bool SetThreadPriority(SbThreadPriority priority) {
 
 }  // namespace
 
-int SbPriorityToNice(SbThreadPriority priority) {
+int SbPriorityToNice(ThreadPriority priority) {
   // Nice value settings are shared between Android and Linux.
   // They are selected from looking at:
   // https://android.googlesource.com/platform/frameworks/native/+/jb-dev/include/utils/ThreadDefs.h#35
   switch (priority) {
-    case kSbThreadPriorityLowest:
+    case ThreadPriority::kLowest:
       return 19;
-    case kSbThreadPriorityLow:
+    case ThreadPriority::kLow:
       return 10;
-    case kSbThreadNoPriority:
-    case kSbThreadPriorityNormal:
+    case ThreadPriority::kNoPriority:
+    case ThreadPriority::kNormal:
       return 0;
-    case kSbThreadPriorityHigh:
+    case ThreadPriority::kHigh:
       return -8;
-    case kSbThreadPriorityHighest:
+    case ThreadPriority::kHighest:
       return -16;
-    case kSbThreadPriorityRealTime:
+    case ThreadPriority::kRealTime:
       return -19;
     default:
       SB_NOTREACHED();

--- a/starboard/common/thread.h
+++ b/starboard/common/thread.h
@@ -75,7 +75,7 @@ class Thread {
 
  private:
   const std::string name_;
-  const std::optional<SbThreadPriority> priority_;
+  const std::optional<ThreadPriority> priority_;
   struct Data;
   const std::unique_ptr<Data> d_;
 
@@ -83,7 +83,7 @@ class Thread {
   void operator=(const Thread&) = delete;
 };
 
-int SbPriorityToNice(SbThreadPriority priority);
+int SbPriorityToNice(ThreadPriority priority);
 
 }  // namespace starboard
 

--- a/starboard/common/thread_options.h
+++ b/starboard/common/thread_options.h
@@ -68,11 +68,6 @@ enum class ThreadPriority {
   kNoPriority = INT_MIN,
 };
 
-// Returns whether the given thread priority is valid.
-static inline bool ThreadIsValidPriority(ThreadPriority priority) {
-  return priority != ThreadPriority::kNoPriority;
-}
-
 struct ThreadOptions {
   ThreadOptions() = default;
   ThreadOptions& SetPriority(ThreadPriority priority_in) {

--- a/starboard/common/thread_options.h
+++ b/starboard/common/thread_options.h
@@ -15,20 +15,72 @@
 #ifndef STARBOARD_COMMON_THREAD_OPTIONS_H_
 #define STARBOARD_COMMON_THREAD_OPTIONS_H_
 
-#include <optional>
+#include <limits.h>
 
-#include "starboard/thread.h"
+#include <optional>
 
 namespace starboard {
 
+// A spectrum of thread priorities. Platforms map them appropriately to their
+// own priority system. Note that scheduling is platform-specific, and what
+// these priorities mean, if they mean anything at all, is also
+// platform-specific.
+//
+// In particular, several of these priority values can map to the same priority
+// on a given platform. The only guarantee is that each lower priority should be
+// treated less-than-or-equal-to a higher priority.
+enum class ThreadPriority {
+  // The lowest thread priority available on the current platform.
+  kLowest,
+
+  // A lower-than-normal thread priority, if available on the current platform.
+  kLow,
+
+  // Really, what is normal? You should spend time pondering that question more
+  // than you consider less-important things, but less than you think about
+  // more-important things.
+  kNormal,
+
+  // A higher-than-normal thread priority, if available on the current platform.
+  kHigh,
+
+  // The highest thread priority available on the current platform that isn't
+  // considered "real-time" or "time-critical," if those terms have any meaning
+  // on the current platform.
+  kHighest,
+
+  // If the platform provides any kind of real-time or time-critical scheduling,
+  // this priority will request that treatment. Real-time scheduling generally
+  // means that the thread will have more consistency in scheduling than
+  // non-real-time scheduled threads, often by being more deterministic in how
+  // threads run in relation to each other. But exactly how being real-time
+  // affects the thread scheduling is platform-specific.
+  //
+  // For platforms where that is not offered, or otherwise not meaningful, this
+  // will just be the highest priority available in the platform's scheme, which
+  // may be the same as kHighest.
+  kRealTime,
+
+  // Well-defined constant value to mean "no priority."  This means to use the
+  // default priority assignment method of that platform. This may mean to
+  // inherit the priority of the spawning thread, or it may mean a specific
+  // default priority, or it may mean something else, depending on the platform.
+  kNoPriority = INT_MIN,
+};
+
+// Returns whether the given thread priority is valid.
+static inline bool ThreadIsValidPriority(ThreadPriority priority) {
+  return priority != ThreadPriority::kNoPriority;
+}
+
 struct ThreadOptions {
   ThreadOptions() = default;
-  ThreadOptions& SetPriority(SbThreadPriority priority_in) {
+  ThreadOptions& SetPriority(ThreadPriority priority_in) {
     priority = priority_in;
     return *this;
   }
 
-  std::optional<SbThreadPriority> priority;
+  std::optional<ThreadPriority> priority;
 };
 
 }  // namespace starboard

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.cc
@@ -279,7 +279,7 @@ GStreamerAudioSink::~GStreamerAudioSink() {
 // static
 void* GStreamerAudioSink::AudioThreadEntryPoint(void* context) {
   SB_DCHECK(context);
-  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(kSbThreadPriorityRealTime));
+  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kRealTime));
 
   GStreamerAudioSink* sink = reinterpret_cast<GStreamerAudioSink*>(context);
   GST_TRACE_OBJECT(sink->pipeline_, "TID: %d", gettid());

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/hang_detector.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/hang_detector.cc
@@ -101,7 +101,7 @@ seconds get_check_interval() {
 struct HangDetector
 {
   static void* ThreadEntryPoint(void* context) {
-    setpriority(PRIO_PROCESS, 0, SbPriorityToNice(kSbThreadNoPriority));
+    setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kNoPriority));
     SB_DCHECK(context);
     static_cast<HangDetector*>(context)->DoWork();
     return nullptr;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -1773,7 +1773,7 @@ gboolean PlayerImpl::HandleBusMessage(GstBus* bus, GstMessage* message) {
 
 // static
 void* PlayerImpl::ThreadEntryPoint(void* context) {
-  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(kSbThreadPriorityRealTime));
+  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kRealTime));
   SB_DCHECK(context);
   GST_TRACE("%d", gettid());
 

--- a/starboard/nplb/posix_compliance/posix_priority_test.cc
+++ b/starboard/nplb/posix_compliance/posix_priority_test.cc
@@ -166,14 +166,15 @@ TEST_F(PosixSetPriorityTests, SetProcessPriorityToStarboardNiceValues) {
   //  SetProcessPrioritySuccessfully test.
 
   // Low Priority
-  int low_nice = starboard::SbPriorityToNice(kSbThreadPriorityLow);
+  int low_nice = starboard::SbPriorityToNice(starboard::ThreadPriority::kLow);
   ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, low_nice))
       << "setpriority failed for Low. Errno: " << errno << " ("
       << strerror(errno) << ")";
   EXPECT_EQ(low_nice, getpriority(PRIO_PROCESS, 0));
 
   // Lowest Priority
-  int lowest_nice = starboard::SbPriorityToNice(kSbThreadPriorityLowest);
+  int lowest_nice =
+      starboard::SbPriorityToNice(starboard::ThreadPriority::kLowest);
   ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, lowest_nice))
       << "setpriority failed for Lowest. Errno: " << errno << " ("
       << strerror(errno) << ")";

--- a/starboard/raspi/shared/open_max/video_decoder.cc
+++ b/starboard/raspi/shared/open_max/video_decoder.cc
@@ -139,7 +139,7 @@ bool OpenMaxVideoDecoder::TryToDeliverOneFrame() {
 // static
 void* OpenMaxVideoDecoder::ThreadEntryPoint(void* context) {
   pthread_setname_np(pthread_self(), "omx_video_decoder");
-  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(kSbThreadPriorityHigh));
+  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kHigh));
   OpenMaxVideoDecoder* decoder =
       reinterpret_cast<OpenMaxVideoDecoder*>(context);
   decoder->RunLoop();

--- a/starboard/shared/alsa/alsa_audio_sink_type.cc
+++ b/starboard/shared/alsa/alsa_audio_sink_type.cc
@@ -212,7 +212,7 @@ AlsaAudioSink::AlsaAudioSink(
       sample_type_(sample_type),
       audio_out_thread_(JobThread::Create(
           "alsa_audio_out",
-          ThreadOptions().SetPriority(kSbThreadPriorityRealTime))),
+          ThreadOptions().SetPriority(ThreadPriority::kRealTime))),
       time_to_wait_us_(time_to_wait_us),
       destroying_(false),
       frame_buffer_(frame_buffers[0]),

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.h
@@ -85,7 +85,7 @@ class FfmpegVideoDecoderImpl<FFMPEG> : public FfmpegVideoDecoder {
    public:
     explicit DecoderThread(FfmpegVideoDecoderImpl<FFMPEG>* decoder)
         : Thread("ff_video_dec",
-                 ThreadOptions().SetPriority(kSbThreadPriorityHigh)),
+                 ThreadOptions().SetPriority(ThreadPriority::kHigh)),
           decoder_(decoder) {
       SB_CHECK(decoder_);
     }

--- a/starboard/shared/linux/system_network_status.cc
+++ b/starboard/shared/linux/system_network_status.cc
@@ -104,9 +104,9 @@ bool GetOnlineStatus(bool* is_online_ptr, int netlink_fd) {
 class NotifierThread : public starboard::Thread {
  public:
   explicit NotifierThread(NetworkNotifier* notifier)
-      : starboard::Thread(
-            "NetworkNotifier",
-            starboard::ThreadOptions().SetPriority(kSbThreadPriorityLow)),
+      : starboard::Thread("NetworkNotifier",
+                          starboard::ThreadOptions().SetPriority(
+                              starboard::ThreadPriority::kLow)),
         notifier_(notifier) {}
 
   void Run() override { NetworkNotifier::NotifierThreadEntry(notifier_); }

--- a/starboard/shared/pulse/pulse_audio_sink_type.cc
+++ b/starboard/shared/pulse/pulse_audio_sink_type.cc
@@ -476,7 +476,7 @@ bool PulseAudioSinkType::Initialize() {
   }
 
   audio_thread_ = JobThread::Create(
-      "pulse_audio", ThreadOptions().SetPriority(kSbThreadPriorityRealTime));
+      "pulse_audio", ThreadOptions().SetPriority(ThreadPriority::kRealTime));
   audio_thread_->Schedule([this] { ProcessAudio(); });
 
   return true;

--- a/starboard/shared/starboard/audio_sink/stub_audio_sink_type.cc
+++ b/starboard/shared/starboard/audio_sink/stub_audio_sink_type.cc
@@ -73,7 +73,7 @@ StubAudioSink::StubAudioSink(
       context_(context),
       audio_out_thread_(JobThread::Create(
           "stub_audio_out",
-          ThreadOptions().SetPriority(kSbThreadPriorityRealTime))) {
+          ThreadOptions().SetPriority(ThreadPriority::kRealTime))) {
   SB_CHECK(audio_out_thread_);
 
   audio_out_thread_->Schedule([this] { AudioThreadFunc(); });

--- a/starboard/shared/starboard/player/job_thread.h
+++ b/starboard/shared/starboard/player/job_thread.h
@@ -45,7 +45,7 @@ class JobThread {
   static std::unique_ptr<JobThread> Create(
       std::string_view thread_name,
       const ThreadOptions& options =
-          ThreadOptions().SetPriority(kSbThreadPriorityNormal));
+          ThreadOptions().SetPriority(ThreadPriority::kNormal));
   ~JobThread();
 
   bool BelongsToCurrentThread() const {

--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -54,7 +54,7 @@ PlayerWorker::PlayerWorker(SbMediaAudioCodec audio_codec,
                            void* context)
     : job_thread_(JobThread::Create(
           "player_worker",
-          ThreadOptions().SetPriority(kSbThreadPriorityHigh))),
+          ThreadOptions().SetPriority(ThreadPriority::kHigh))),
       audio_codec_(audio_codec),
       video_codec_(video_codec),
       handler_(std::move(handler)),

--- a/starboard/thread.h
+++ b/starboard/thread.h
@@ -32,53 +32,6 @@
 extern "C" {
 #endif
 
-// A spectrum of thread priorities. Platforms map them appropriately to their
-// own priority system. Note that scheduling is platform-specific, and what
-// these priorities mean, if they mean anything at all, is also
-// platform-specific.
-//
-// In particular, several of these priority values can map to the same priority
-// on a given platform. The only guarantee is that each lower priority should be
-// treated less-than-or-equal-to a higher priority.
-typedef enum SbThreadPriority {
-  // The lowest thread priority available on the current platform.
-  kSbThreadPriorityLowest,
-
-  // A lower-than-normal thread priority, if available on the current platform.
-  kSbThreadPriorityLow,
-
-  // Really, what is normal? You should spend time pondering that question more
-  // than you consider less-important things, but less than you think about
-  // more-important things.
-  kSbThreadPriorityNormal,
-
-  // A higher-than-normal thread priority, if available on the current platform.
-  kSbThreadPriorityHigh,
-
-  // The highest thread priority available on the current platform that isn't
-  // considered "real-time" or "time-critical," if those terms have any meaning
-  // on the current platform.
-  kSbThreadPriorityHighest,
-
-  // If the platform provides any kind of real-time or time-critical scheduling,
-  // this priority will request that treatment. Real-time scheduling generally
-  // means that the thread will have more consistency in scheduling than
-  // non-real-time scheduled threads, often by being more deterministic in how
-  // threads run in relation to each other. But exactly how being real-time
-  // affects the thread scheduling is platform-specific.
-  //
-  // For platforms where that is not offered, or otherwise not meaningful, this
-  // will just be the highest priority available in the platform's scheme, which
-  // may be the same as kSbThreadPriorityHighest.
-  kSbThreadPriorityRealTime,
-
-  // Well-defined constant value to mean "no priority."  This means to use the
-  // default priority assignment method of that platform. This may mean to
-  // inherit the priority of the spawning thread, or it may mean a specific
-  // default priority, or it may mean something else, depending on the platform.
-  kSbThreadNoPriority = INT_MIN,
-} SbThreadPriority;
-
 // An ID type that is unique per thread.
 typedef int32_t SbThreadId;
 
@@ -88,11 +41,6 @@ typedef int32_t SbThreadId;
 // Returns whether the given thread ID is valid.
 static inline bool SbThreadIsValidId(SbThreadId id) {
   return id != kSbThreadInvalidId;
-}
-
-// Returns whether the given thread priority is valid.
-static inline bool SbThreadIsValidPriority(SbThreadPriority priority) {
-  return priority != kSbThreadNoPriority;
 }
 
 #ifdef __cplusplus

--- a/starboard/tvos/shared/media/audio_queue_audio_sink_type.mm
+++ b/starboard/tvos/shared/media/audio_queue_audio_sink_type.mm
@@ -392,7 +392,7 @@ void TvosAudioSink::TryWriteFrames(int frames_in_buffer, int offset_in_frames) {
 TvosAudioSinkType::TvosAudioSinkType()
     : audio_thread_(JobThread::Create(
           "tvos_audio_out",
-          ThreadOptions().SetPriority(kSbThreadPriorityRealTime))) {
+          ThreadOptions().SetPriority(ThreadPriority::kRealTime))) {
   SB_CHECK(audio_thread_);
 
   audio_thread_->Schedule([this] { ProcessAudio(); });


### PR DESCRIPTION
This PR deprecates `SbThreadPriority` from the Starboard API, transitioning the codebase to use a type-safe C++ enum class `ThreadPriority` under the `starboard` namespace. 

### Key Refactors:

1. **Starboard API Deprecation**
   - Removed `SbThreadPriority` and `SbThreadIsValidPriority` from the core Starboard header `starboard/thread.h`.
   - Introduced the C++ `ThreadPriority` enum class in `starboard/common/thread_options.h` to align with modern C++ styles and improve type safety.

2. **Internal Usage Migration**
   - Replaced legacy `kSbThreadPriority*` values with `ThreadPriority::k*` equivalents.
   - Fixed RDK `hang_detector.cc` and downstream usages to correctly resolve `ThreadPriority::kNoPriority`.

3. **Documentation & Test Cleanup**
   - Removed the unused `ThreadIsValidPriority` helper function from `thread_options.h`.
   - Cleaned up documentation by deleting deprecated `SbThreadPriority` and `SbThreadIsValidPriority` definitions from `thread.md` and `18/thread.md`.
   - Updated `posix_priority_test.cc` compliance tests to use the modern `ThreadPriority` class.

Bug: 517239886
