### PR TITLE
starboard: Fix MediaCodec output backpressure

### DIFF
--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -323,6 +323,8 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
           MediaCapabilitiesCache::GetInstance()->IsAv18kCappedAt30()),
       skip_video_frames_over_60_fps_(
           experimental_features.skip_video_frames_over_60_fps),
+      enable_trivial_optimizations_(
+          experimental_features.enable_trivial_optimizations.value_or(false)),
       is_video_frame_tracker_enabled_(
           // OnFrameRenderedListener is available since API 23, but only
           // reliable for standard playback since API 34. Tunnel mode uses it on
@@ -943,11 +945,22 @@ void MediaCodecVideoDecoder::ProcessOutputBuffer(
       }
     }
   }
-  decoder_status_cb_(
-      is_end_of_stream ? kBufferFull : kNeedMoreInput,
-      new VideoFrameImpl(
-          dequeue_output_result, media_codec_bridge,
-          std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
+  if (enable_trivial_optimizations_) {
+    decoder_status_cb_(
+        is_end_of_stream || media_decoder_->GetNumberOfPendingInputs() >=
+                                kMaxPendingInputsSize
+            ? kBufferFull
+            : kNeedMoreInput,
+        new VideoFrameImpl(
+            dequeue_output_result, media_codec_bridge,
+            std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
+  } else {
+    decoder_status_cb_(
+        is_end_of_stream ? kBufferFull : kNeedMoreInput,
+        new VideoFrameImpl(
+            dequeue_output_result, media_codec_bridge,
+            std::bind(&MediaCodecVideoDecoder::OnVideoFrameRelease, this)));
+  }
 }
 
 void MediaCodecVideoDecoder::OnEndOfStreamWritten(

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -195,6 +195,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // effective frame rate no more than 60 fps. This is only used for tunnel
   // mode.
   const bool skip_video_frames_over_60_fps_;
+  const bool enable_trivial_optimizations_;
 
   // On some platforms tunnel mode is only supported in the secure pipeline.  So
   // we create a dummy drm system to force the video playing in secure pipeline


### PR DESCRIPTION
When trivial optimizations are enabled, the decoder now signals a full
buffer status if the number of pending inputs exceeds the maximum
threshold. This ensures that the demuxer pauses read operations
appropriately, preventing runaway memory accumulation within the
bridge layer during media playback.

Bug: 514758473