### PR TITLE
Revert "Prune WebXR to reduce android binary size"

### DIFF
--- a/third_party/blink/renderer/bindings/bindings.gni
+++ b/third_party/blink/renderer/bindings/bindings.gni
@@ -276,8 +276,3 @@ cobalt_webnn_exclude_patterns = [
   "*v8_ml.*",
   "*v8_ml_*",
 ]
-
-cobalt_webxr_exclude_patterns = [
-  "*v8_xr.*",
-  "*v8_xr_*",
-]

--- a/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
+++ b/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
@@ -34,9 +34,8 @@ blink_modules_sources("v8") {
   }
 
   if (is_cobalt) {
-    _filtered_cobalt_sources = filter_exclude(
-        sources,
-        cobalt_webnn_exclude_patterns + cobalt_webxr_exclude_patterns)
+    _filtered_cobalt_sources =
+        filter_exclude(sources, cobalt_webnn_exclude_patterns)
     sources = []
     sources = _filtered_cobalt_sources
   }

--- a/third_party/blink/renderer/modules/BUILD.gn
+++ b/third_party/blink/renderer/modules/BUILD.gn
@@ -195,10 +195,7 @@ component("modules") {
         "//third_party/blink/renderer/modules/cobalt/mediasource",
       ]
     }
-    sub_modules -= [
-      "//third_party/blink/renderer/modules/ml",
-      "//third_party/blink/renderer/modules/xr",
-    ]
+    sub_modules -= [ "//third_party/blink/renderer/modules/ml" ]
   }
 
   if (!use_webrtc_peer_connection) {
@@ -797,11 +794,6 @@ source_set("unit_tests") {
   if (is_cobalt) {
     deps += [ "//third_party/blink/renderer/modules/cobalt/h5vcc_experiments:experiments_utils" ]
     deps -= [ "//third_party/blink/renderer/modules/ml:unit_tests" ]
-    sources -= [
-      "xr/xr_rigid_transform_test.cc",
-      "xr/xr_test_utils.cc",
-      "xr/xr_view_test.cc",
-    ]
   }
 
   if (!use_webrtc_peer_connection) {

--- a/third_party/blink/renderer/modules/cobalt_modules_stubs.cc
+++ b/third_party/blink/renderer/modules/cobalt_modules_stubs.cc
@@ -13,9 +13,6 @@
 // limitations under the License.
 
 #include "third_party/blink/renderer/modules/ml/navigator_ml.h"  // nogncheck
-#include "third_party/blink/renderer/modules/xr/xr_system.h"  // nogncheck
-#include "third_party/blink/renderer/modules/xr/xr_frame_provider.h"  // nogncheck
-#include "third_party/blink/renderer/modules/xr/xr_session.h"  // nogncheck
 #include "third_party/blink/renderer/platform/bindings/wrapper_type_info.h"
 
 namespace blink {
@@ -48,56 +45,6 @@ STUB_V8_WRAPPER(V8MLGraph)
 STUB_V8_WRAPPER(V8MLGraphBuilder)
 STUB_V8_WRAPPER(V8MLOperand)
 
-// WebXR V8 Wrappers
-STUB_V8_WRAPPER(V8XRAnchor)
-STUB_V8_WRAPPER(V8XRAnchorSet)
-STUB_V8_WRAPPER(V8XRBoundedReferenceSpace)
-STUB_V8_WRAPPER(V8XRCamera)
-STUB_V8_WRAPPER(V8XRCompositionLayer)
-STUB_V8_WRAPPER(V8XRCPUDepthInformation)
-STUB_V8_WRAPPER(V8XRDepthInformation)
-STUB_V8_WRAPPER(V8XRDOMOverlayState)
-STUB_V8_WRAPPER(V8XRFrame)
-STUB_V8_WRAPPER(V8XRGPUBinding)
-STUB_V8_WRAPPER(V8XRGPUSubImage)
-STUB_V8_WRAPPER(V8XRHand)
-STUB_V8_WRAPPER(V8XRHitTestResult)
-STUB_V8_WRAPPER(V8XRHitTestSource)
-STUB_V8_WRAPPER(V8XRImageTrackingResult)
-STUB_V8_WRAPPER(V8XRInputSource)
-STUB_V8_WRAPPER(V8XRInputSourceArray)
-STUB_V8_WRAPPER(V8XRInputSourceEvent)
-STUB_V8_WRAPPER(V8XRInputSourcesChangeEvent)
-STUB_V8_WRAPPER(V8XRJointPose)
-STUB_V8_WRAPPER(V8XRJointSpace)
-STUB_V8_WRAPPER(V8XRLayer)
-STUB_V8_WRAPPER(V8XRLightEstimate)
-STUB_V8_WRAPPER(V8XRLightProbe)
-STUB_V8_WRAPPER(V8XRPlane)
-STUB_V8_WRAPPER(V8XRPlaneSet)
-STUB_V8_WRAPPER(V8XRPose)
-STUB_V8_WRAPPER(V8XRProjectionLayer)
-STUB_V8_WRAPPER(V8XRRay)
-STUB_V8_WRAPPER(V8XRReferenceSpace)
-STUB_V8_WRAPPER(V8XRReferenceSpaceEvent)
-STUB_V8_WRAPPER(V8XRRenderState)
-STUB_V8_WRAPPER(V8XRRigidTransform)
-STUB_V8_WRAPPER(V8XRSession)
-STUB_V8_WRAPPER(V8XRSessionEvent)
-STUB_V8_WRAPPER(V8XRSpace)
-STUB_V8_WRAPPER(V8XRSubImage)
-STUB_V8_WRAPPER(V8XRSystem)
-STUB_V8_WRAPPER(V8XRTransientInputHitTestResult)
-STUB_V8_WRAPPER(V8XRTransientInputHitTestSource)
-STUB_V8_WRAPPER(V8XRView)
-STUB_V8_WRAPPER(V8XRViewerPose)
-STUB_V8_WRAPPER(V8XRViewport)
-STUB_V8_WRAPPER(V8XRWebGLBinding)
-STUB_V8_WRAPPER(V8XRWebGLDepthInformation)
-STUB_V8_WRAPPER(V8XRWebGLLayer)
-STUB_V8_WRAPPER(V8XRWebGLSubImage)
-STUB_V8_WRAPPER(V8XRWebGLContext)
-
 #undef STUB_V8_WRAPPER
 
 // --- WebNN C++ Stubs ---
@@ -105,37 +52,5 @@ STUB_V8_WRAPPER(V8XRWebGLContext)
 ML* NavigatorML::ml(NavigatorBase& navigator) {
   return nullptr;
 }
-
-// --- WebXR C++ Stubs ---
-
-XRSystem* XRSystem::From(Document& document) {
-  return nullptr;
-}
-
-XRSystem* XRSystem::FromIfExists(Document& document) {
-  return nullptr;
-}
-
-XRSystem* XRSystem::xr(Navigator& navigator) {
-  return nullptr;
-}
-
-void XRSystem::MakeXrCompatibleAsync(device::mojom::blink::VRService::MakeXrCompatibleCallback callback) {
-  std::move(callback).Run(device::mojom::blink::XrCompatibleResult::kNoDeviceAvailable);
-}
-
-void XRSystem::MakeXrCompatibleSync(device::mojom::XrCompatibleResult* xr_compatible_result) {
-  if (xr_compatible_result) {
-    *xr_compatible_result = device::mojom::XrCompatibleResult::kNoDeviceAvailable;
-  }
-}
-
-XRFrameProvider* XRSystem::frameProvider() {
-  return nullptr;
-}
-
-void XRFrameProvider::AddImmersiveSessionObserver(ImmersiveSessionObserver* observer) {}
-
-void XRSession::ScheduleVideoFrameCallbacksExecution(ExecuteVfcCallback callback) {}
 
 }  // namespace blink

--- a/third_party/blink/renderer/modules/video_rvfc/BUILD.gn
+++ b/third_party/blink/renderer/modules/video_rvfc/BUILD.gn
@@ -13,8 +13,4 @@ blink_modules_sources("video_rvfc") {
   ]
 
   deps = [ "//third_party/blink/renderer/modules/xr:xr" ]
-
-  if (is_cobalt) {
-    deps -= [ "//third_party/blink/renderer/modules/xr:xr" ]
-  }
 }

--- a/third_party/blink/renderer/modules/webgl/BUILD.gn
+++ b/third_party/blink/renderer/modules/webgl/BUILD.gn
@@ -198,10 +198,5 @@ blink_modules_sources("webgl") {
     "//third_party/blink/renderer/modules/webcodecs:webcodecs",
     "//third_party/blink/renderer/modules/xr:xr",
   ]
-
-  if (is_cobalt) {
-    deps -= [ "//third_party/blink/renderer/modules/xr:xr" ]
-  }
-
   allow_circular_includes_from = deps
 }


### PR DESCRIPTION
Reverts youtube/cobalt#10649 (pruning WebXR for binary size reduction) due to crashes on 3P builds: https://github.com/youtube/cobalt/pull/10649#issuecomment-4566124338

Bug: 512589073