### PR TITLE
Cherry pick PR #8525: Skeleton implementation for remaining updater APIs

### DIFF
--- a/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.cc
+++ b/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.cc
@@ -47,13 +47,80 @@ void H5vccUpdaterImpl::Create(
   new H5vccUpdaterImpl(*render_frame_host, std::move(receiver));
 }
 
+void H5vccUpdaterImpl::GetUpdaterChannel(GetUpdaterChannelCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::SetUpdaterChannel(const std::string& channel,
+                                         SetUpdaterChannelCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::GetUpdateStatus(GetUpdateStatusCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::ResetInstallations(ResetInstallationsCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::GetInstallationIndex(
+    GetInstallationIndexCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::GetAllowSelfSignedPackages(
+    GetAllowSelfSignedPackagesCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::SetAllowSelfSignedPackages(
+    bool allow_self_signed_packages,
+    SetAllowSelfSignedPackagesCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
 void H5vccUpdaterImpl::GetUpdateServerUrl(GetUpdateServerUrlCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 #if BUILDFLAG(USE_EVERGREEN)
   std::string url =
       cobalt::updater::UpdaterModule::GetInstance()->GetUpdateServerUrl();
   std::move(callback).Run(url);
+#else
+  NOTIMPLEMENTED();
 #endif
+}
+
+void H5vccUpdaterImpl::SetUpdateServerUrl(const std::string& update_server_url,
+                                          SetUpdateServerUrlCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::GetRequireNetworkEncryption(
+    GetRequireNetworkEncryptionCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::SetRequireNetworkEncryption(
+    bool require_network_encryption,
+    SetRequireNetworkEncryptionCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
+}
+
+void H5vccUpdaterImpl::GetLibrarySha256(unsigned short index,
+                                        GetLibrarySha256Callback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  NOTIMPLEMENTED();
 }
 
 }  // namespace h5vcc_updater

--- a/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.h
+++ b/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.h
@@ -41,7 +41,27 @@ class H5vccUpdaterImpl : public content::DocumentService<mojom::H5vccUpdater> {
   H5vccUpdaterImpl(const H5vccUpdaterImpl&) = delete;
   H5vccUpdaterImpl& operator=(const H5vccUpdaterImpl&) = delete;
 
-  void GetUpdateServerUrl(GetUpdateServerUrlCallback) override;
+  void GetUpdaterChannel(GetUpdaterChannelCallback callback) override;
+  void SetUpdaterChannel(const std::string& channel,
+                         SetUpdaterChannelCallback callback) override;
+  void GetUpdateStatus(GetUpdateStatusCallback callback) override;
+  void ResetInstallations(ResetInstallationsCallback callback) override;
+  void GetInstallationIndex(GetInstallationIndexCallback callback) override;
+  void GetAllowSelfSignedPackages(
+      GetAllowSelfSignedPackagesCallback callback) override;
+  void SetAllowSelfSignedPackages(
+      bool allow_self_signed_packages,
+      SetAllowSelfSignedPackagesCallback callback) override;
+  void GetUpdateServerUrl(GetUpdateServerUrlCallback callback) override;
+  void SetUpdateServerUrl(const std::string& update_server_url,
+                          SetUpdateServerUrlCallback callback) override;
+  void GetRequireNetworkEncryption(
+      GetRequireNetworkEncryptionCallback callback) override;
+  void SetRequireNetworkEncryption(
+      bool require_network_encryption,
+      SetRequireNetworkEncryptionCallback callback) override;
+  void GetLibrarySha256(unsigned short index,
+                        GetLibrarySha256Callback callback) override;
 
  private:
   H5vccUpdaterImpl(content::RenderFrameHost& render_frame_host,

--- a/cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom
+++ b/cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom
@@ -14,9 +14,17 @@
 
 module h5vcc_updater.mojom;
 
-// The browser process must provide an implementation of this interface so that
-// the renderer process can implement the H5vccUpdater Blink API.
 interface H5vccUpdater {
-  // Get the update server url for the device.
+  GetUpdaterChannel() => (string channel);
+  SetUpdaterChannel(string channel) => ();
+  GetUpdateStatus() => (string status);
+  ResetInstallations() => ();
+  GetInstallationIndex() => (uint16 index);
+  GetAllowSelfSignedPackages() => (bool allow_self_signed_packages);
+  SetAllowSelfSignedPackages(bool allow_self_signed_packages) => ();
   GetUpdateServerUrl() => (string update_server_url);
+  SetUpdateServerUrl(string update_server_url) => ();
+  GetRequireNetworkEncryption() => (bool require_network_encryption);
+  SetRequireNetworkEncryption(bool require_network_encryption) => ();
+  GetLibrarySha256(uint16 index) => (string sha256);
 };

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
@@ -307,18 +307,19 @@ void H5vccUpdater::OnGetUpdateServerUrl(
   resolver->Resolve(result);
 }
 
-void H5vccUpdater::OnSetUpdateServerUrl(ScriptPromiseResolver* resolver) {
+void H5vccUpdater::OnSetUpdateServerUrl(
+    ScriptPromiseResolver<IDLUndefined>* resolver) {
   resolver->Resolve();
 }
 
 void H5vccUpdater::OnGetRequireNetworkEncryption(
-    ScriptPromiseResolver* resolver,
+    ScriptPromiseResolver<IDLBoolean>* resolver,
     bool result) {
   resolver->Resolve(result);
 }
 
 void H5vccUpdater::OnSetRequireNetworkEncryption(
-    ScriptPromiseResolver* resolver) {
+    ScriptPromiseResolver<IDLUndefined>* resolver) {
   resolver->Resolve();
 }
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
@@ -32,6 +32,136 @@ H5vccUpdater::H5vccUpdater(LocalDOMWindow& window)
 
 void H5vccUpdater::ContextDestroyed() {}
 
+ScriptPromise<IDLString> H5vccUpdater::getUpdaterChannel(
+    ScriptState* script_state,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLString>>(
+      script_state, exception_state.GetContext());
+
+#if BUILDFLAG(USE_EVERGREEN)
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->GetUpdaterChannel(
+      WTF::BindOnce(&H5vccUpdater::OnGetUpdaterChannel, WrapPersistent(this),
+                    WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLUndefined> H5vccUpdater::setUpdaterChannel(
+    ScriptState* script_state,
+    const String& channel,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
+      script_state, exception_state.GetContext());
+
+#if BUILDFLAG(USE_EVERGREEN)
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->SetUpdaterChannel(
+      channel, WTF::BindOnce(&H5vccUpdater::OnSetUpdaterChannel,
+                             WrapPersistent(this), WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLString> H5vccUpdater::getUpdateStatus(
+    ScriptState* script_state,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLString>>(
+      script_state, exception_state.GetContext());
+
+#if BUILDFLAG(USE_EVERGREEN)
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->GetUpdateStatus(
+      WTF::BindOnce(&H5vccUpdater::OnGetUpdateStatus, WrapPersistent(this),
+                    WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLUndefined> H5vccUpdater::resetInstallations(
+    ScriptState* script_state,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
+      script_state, exception_state.GetContext());
+
+#if BUILDFLAG(USE_EVERGREEN)
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->ResetInstallations(
+      WTF::BindOnce(&H5vccUpdater::OnResetInstallations, WrapPersistent(this),
+                    WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLUnsignedShort> H5vccUpdater::getInstallationIndex(
+    ScriptState* script_state,
+    ExceptionState& exception_state) {
+  auto* resolver =
+      MakeGarbageCollected<ScriptPromiseResolver<IDLUnsignedShort>>(
+          script_state, exception_state.GetContext());
+
+#if BUILDFLAG(USE_EVERGREEN)
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->GetInstallationIndex(
+      WTF::BindOnce(&H5vccUpdater::OnGetInstallationIndex, WrapPersistent(this),
+                    WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLBoolean> H5vccUpdater::getAllowSelfSignedPackages(
+    ScriptState* script_state,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLBoolean>>(
+      script_state, exception_state.GetContext());
+
+#if BUILDFLAG(USE_EVERGREEN)
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->GetAllowSelfSignedPackages(
+      WTF::BindOnce(&H5vccUpdater::OnGetAllowSelfSignedPackages,
+                    WrapPersistent(this), WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLUndefined> H5vccUpdater::setAllowSelfSignedPackages(
+    ScriptState* script_state,
+    bool allow_self_signed_packages,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
+      script_state, exception_state.GetContext());
+
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->SetAllowSelfSignedPackages(
+      allow_self_signed_packages,
+      WTF::BindOnce(&H5vccUpdater::OnSetAllowSelfSignedPackages,
+                    WrapPersistent(this), WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
 ScriptPromise<IDLString> H5vccUpdater::getUpdateServerUrl(
     ScriptState* script_state,
     ExceptionState& exception_state) {
@@ -50,10 +180,146 @@ ScriptPromise<IDLString> H5vccUpdater::getUpdateServerUrl(
   return resolver->Promise();
 }
 
+ScriptPromise<IDLUndefined> H5vccUpdater::setUpdateServerUrl(
+    ScriptState* script_state,
+    const String& update_server_url,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
+      script_state, exception_state.GetContext());
+
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->SetUpdateServerUrl(
+      update_server_url,
+      WTF::BindOnce(&H5vccUpdater::OnSetUpdateServerUrl, WrapPersistent(this),
+                    WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLBoolean> H5vccUpdater::getRequireNetworkEncryption(
+    ScriptState* script_state,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLBoolean>>(
+      script_state, exception_state.GetContext());
+
+#if BUILDFLAG(USE_EVERGREEN)
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->GetRequireNetworkEncryption(
+      WTF::BindOnce(&H5vccUpdater::OnGetRequireNetworkEncryption,
+                    WrapPersistent(this), WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLUndefined> H5vccUpdater::setRequireNetworkEncryption(
+    ScriptState* script_state,
+    bool require_network_encryption,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
+      script_state, exception_state.GetContext());
+
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->SetRequireNetworkEncryption(
+      require_network_encryption,
+      WTF::BindOnce(&H5vccUpdater::OnSetRequireNetworkEncryption,
+                    WrapPersistent(this), WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLString> H5vccUpdater::getLibrarySha256(
+    ScriptState* script_state,
+    uint16_t index,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLString>>(
+      script_state, exception_state.GetContext());
+
+#if BUILDFLAG(USE_EVERGREEN)
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_updater_->GetLibrarySha256(
+      index, WTF::BindOnce(&H5vccUpdater::OnGetLibrarySha256,
+                           WrapPersistent(this), WrapPersistent(resolver)));
+#else
+  resolver->Reject();
+#endif
+  return resolver->Promise();
+}
+
+void H5vccUpdater::OnGetUpdaterChannel(
+    ScriptPromiseResolver<IDLString>* resolver,
+    const String& result) {
+  resolver->Resolve(result);
+}
+
+void H5vccUpdater::OnSetUpdaterChannel(
+    ScriptPromiseResolver<IDLUndefined>* resolver) {
+  resolver->Resolve();
+}
+
+void H5vccUpdater::OnGetUpdateStatus(ScriptPromiseResolver<IDLString>* resolver,
+                                     const String& result) {
+  resolver->Resolve(result);
+}
+
+void H5vccUpdater::OnResetInstallations(
+    ScriptPromiseResolver<IDLUndefined>* resolver) {
+  resolver->Resolve();
+}
+
+void H5vccUpdater::OnGetInstallationIndex(
+    ScriptPromiseResolver<IDLUnsignedShort>* resolver,
+    uint16_t result) {
+  resolver->Resolve(result);
+}
+
+void H5vccUpdater::OnGetLibrarySha256(
+    ScriptPromiseResolver<IDLString>* resolver,
+    const String& result) {
+  resolver->Resolve(result);
+}
+
+void H5vccUpdater::OnGetAllowSelfSignedPackages(
+    ScriptPromiseResolver<IDLBoolean>* resolver,
+    bool result) {
+  resolver->Resolve(result);
+}
+
+void H5vccUpdater::OnSetAllowSelfSignedPackages(
+    ScriptPromiseResolver<IDLUndefined>* resolver) {
+  resolver->Resolve();
+}
+
 void H5vccUpdater::OnGetUpdateServerUrl(
     ScriptPromiseResolver<IDLString>* resolver,
     const String& result) {
   resolver->Resolve(result);
+}
+
+void H5vccUpdater::OnSetUpdateServerUrl(ScriptPromiseResolver* resolver) {
+  resolver->Resolve();
+}
+
+void H5vccUpdater::OnGetRequireNetworkEncryption(
+    ScriptPromiseResolver* resolver,
+    bool result) {
+  resolver->Resolve(result);
+}
+
+void H5vccUpdater::OnSetRequireNetworkEncryption(
+    ScriptPromiseResolver* resolver) {
+  resolver->Resolve();
 }
 
 #if BUILDFLAG(USE_EVERGREEN)

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.h
@@ -50,12 +50,48 @@ class MODULES_EXPORT H5vccUpdater final
   void ContextDestroyed() override;
 
   // Web-exposed interface:
+  ScriptPromise<IDLString> getUpdaterChannel(ScriptState*, ExceptionState&);
+  ScriptPromise<IDLUndefined> setUpdaterChannel(ScriptState*,
+                                                const String&,
+                                                ExceptionState&);
+  ScriptPromise<IDLString> getUpdateStatus(ScriptState*, ExceptionState&);
+  ScriptPromise<IDLUndefined> resetInstallations(ScriptState*, ExceptionState&);
+  ScriptPromise<IDLUnsignedShort> getInstallationIndex(ScriptState*,
+                                                       ExceptionState&);
+  ScriptPromise<IDLString> getLibrarySha256(ScriptState*,
+                                            uint16_t,
+                                            ExceptionState&);
+  ScriptPromise<IDLBoolean> getAllowSelfSignedPackages(ScriptState*,
+                                                       ExceptionState&);
+  ScriptPromise<IDLUndefined> setAllowSelfSignedPackages(ScriptState*,
+                                                         bool,
+                                                         ExceptionState&);
   ScriptPromise<IDLString> getUpdateServerUrl(ScriptState*, ExceptionState&);
+  ScriptPromise<IDLUndefined> setUpdateServerUrl(ScriptState*,
+                                                 const String&,
+                                                 ExceptionState&);
+  ScriptPromise<IDLBoolean> getRequireNetworkEncryption(ScriptState*,
+                                                        ExceptionState&);
+  ScriptPromise<IDLUndefined> setRequireNetworkEncryption(ScriptState*,
+                                                          bool,
+                                                          ExceptionState&);
 
   void Trace(Visitor*) const override;
 
  private:
+  void OnGetUpdaterChannel(ScriptPromiseResolver<IDLString>*, const String&);
+  void OnSetUpdaterChannel(ScriptPromiseResolver<IDLUndefined>*);
+  void OnGetUpdateStatus(ScriptPromiseResolver<IDLString>*, const String&);
+  void OnResetInstallations(ScriptPromiseResolver<IDLUndefined>*);
+  void OnGetInstallationIndex(ScriptPromiseResolver<IDLUnsignedShort>*,
+                              uint16_t);
+  void OnGetLibrarySha256(ScriptPromiseResolver<IDLString>*, const String&);
+  void OnGetAllowSelfSignedPackages(ScriptPromiseResolver<IDLBoolean>*, bool);
+  void OnSetAllowSelfSignedPackages(ScriptPromiseResolver<IDLUndefined>*);
   void OnGetUpdateServerUrl(ScriptPromiseResolver<IDLString>*, const String&);
+  void OnSetUpdateServerUrl(ScriptPromiseResolver<IDLUndefined>*);
+  void OnGetRequireNetworkEncryption(ScriptPromiseResolver<IDLBoolean>*, bool);
+  void OnSetRequireNetworkEncryption(ScriptPromiseResolver<IDLUndefined>*);
 #if BUILDFLAG(USE_EVERGREEN)
   void EnsureReceiverIsBound();
   HeapMojoRemote<h5vcc_updater::mojom::blink::H5vccUpdater>

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.idl
@@ -15,8 +15,45 @@
 // Custom API for getting and setting Evergreen update settings.
 
 interface H5vccUpdater {
+  [CallWith=ScriptState, RaisesException]
+  Promise<DOMString> getUpdaterChannel();
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<undefined> setUpdaterChannel(DOMString channel);
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<DOMString> getUpdateStatus();
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<undefined> resetInstallations();
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<unsigned short> getInstallationIndex();
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<DOMString> getLibrarySha256(unsigned short index);
+
+  // Toggles the ability to load self-signed packages in the updater. This
+  // should only be used for testing and should not be available in production.
+  [CallWith=ScriptState, RaisesException]
+  Promise<boolean> getAllowSelfSignedPackages();
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<undefined> setAllowSelfSignedPackages(boolean allow_self_signed_packages);
+
   // Gets the URL the updater will use for updates. This should only be used for
   // testing and should not be available in production.
   [CallWith=ScriptState, RaisesException]
   Promise<DOMString> getUpdateServerUrl();
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<undefined> setUpdateServerUrl(DOMString update_server_url);
+
+  // Sets if network encryption is required for the update server. This should
+  // only be used for testing and should not be available in production.
+  [CallWith=ScriptState, RaisesException]
+  Promise<boolean> getRequireNetworkEncryption();
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<undefined> setRequireNetworkEncryption(boolean require_network_encryption);
 };


### PR DESCRIPTION
cobalt: Implement skeleton for H5vccUpdater APIs

This change introduces the IDL, Mojo interface, Blink API, and
browser-side skeleton implementations for several updater-related
APIs. Browser side changes to follow.

Bug: 454440974

idl file in 25.lts.1+ for reference:

https://source.corp.google.com/h/github/youtube/cobalt/+/25.lts.1+:cobalt/h5vcc/h5vcc_updater.idl
list of apis to be implemented in 26.eap:
go/h5vcc-interface-changes

Bug: 515122610