### PR TITLE
cobalt: Remove stale leveldb lock files on startup

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -32,6 +32,9 @@ public class JavaSwitches {
   /** flag to force use IPv4 for system host resolution. */
   public static final String USE_IPV4_FOR_DNS = "UseIPv4ForDNS";
 
+  /** flag to delete stale leveldb LOCK file on startup. */
+  public static final String LOCAL_STORAGE_DELETE_LOCK_FILE = "LocalStorageDeleteLockFile";
+
   /** flag to enable fast track mic capture. */
   public static final String ENABLE_COBALT_AUDIO_CAPTURE_FAST_TRACK = "EnableCobaltAudioCaptureFastTrack";
 
@@ -49,6 +52,10 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.USE_IPV4_FOR_DNS)) {
       extraCommandLineArgs.add("--enable-features=UseIPv4ForDNS");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.LOCAL_STORAGE_DELETE_LOCK_FILE)) {
+      extraCommandLineArgs.add("--enable-features=LocalStorageDeleteLockFile");
     }
 
     if (!javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {

--- a/components/services/storage/dom_storage/features.cc
+++ b/components/services/storage/dom_storage/features.cc
@@ -10,8 +10,10 @@ BASE_FEATURE(kCoalesceStorageAreaCommits,
              "CoalesceStorageAreaCommits",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+#if BUILDFLAG(IS_COBALT)  
 BASE_FEATURE(kLocalStorageDeleteLockFile,
              "LocalStorageDeleteLockFile",
-             base::FEATURE_ENABLED_BY_DEFAULT);
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#endif
 
 }  // namespace storage

--- a/components/services/storage/dom_storage/features.cc
+++ b/components/services/storage/dom_storage/features.cc
@@ -10,4 +10,8 @@ BASE_FEATURE(kCoalesceStorageAreaCommits,
              "CoalesceStorageAreaCommits",
              base::FEATURE_ENABLED_BY_DEFAULT);
 
+BASE_FEATURE(kLocalStorageDeleteLockFile,
+             "LocalStorageDeleteLockFile",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+
 }  // namespace storage

--- a/components/services/storage/dom_storage/features.h
+++ b/components/services/storage/dom_storage/features.h
@@ -11,10 +11,10 @@
 namespace storage {
 
 BASE_DECLARE_FEATURE(kCoalesceStorageAreaCommits);
+
 #if BUILDFLAG(IS_COBALT)
 BASE_DECLARE_FEATURE(kLocalStorageDeleteLockFile);
 #endif
-
 
 }  // namespace storage
 

--- a/components/services/storage/dom_storage/features.h
+++ b/components/services/storage/dom_storage/features.h
@@ -6,11 +6,15 @@
 #define COMPONENTS_SERVICES_STORAGE_DOM_STORAGE_FEATURES_H_
 
 #include "base/features.h"
+#include "build/build_config.h"
 
 namespace storage {
 
 BASE_DECLARE_FEATURE(kCoalesceStorageAreaCommits);
+#if BUILDFLAG(IS_COBALT)
 BASE_DECLARE_FEATURE(kLocalStorageDeleteLockFile);
+#endif
+
 
 }  // namespace storage
 

--- a/components/services/storage/dom_storage/features.h
+++ b/components/services/storage/dom_storage/features.h
@@ -10,6 +10,7 @@
 namespace storage {
 
 BASE_DECLARE_FEATURE(kCoalesceStorageAreaCommits);
+BASE_DECLARE_FEATURE(kLocalStorageDeleteLockFile);
 
 }  // namespace storage
 

--- a/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/components/services/storage/dom_storage/local_storage_impl.cc
@@ -685,6 +685,7 @@ void LocalStorageImpl::OnDatabaseOpened(leveldb::Status status) {
                                   leveldb_env::LEVELDB_STATUS_MAX);
 #endif
     DeleteAndRecreateDatabase();
+    return;
   }
 
   // Verify DB schema version.
@@ -736,6 +737,7 @@ void LocalStorageImpl::OnGotDatabaseVersion(leveldb::Status status,
                                   leveldb_env::LEVELDB_STATUS_MAX);
 #endif
     DeleteAndRecreateDatabase();
+    return;
   }
 
   OnConnectionFinished();

--- a/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/components/services/storage/dom_storage/local_storage_impl.cc
@@ -653,7 +653,9 @@ void LocalStorageImpl::InitiateConnection(bool in_memory_only) {
     if (base::FeatureList::IsEnabled(kLocalStorageDeleteLockFile)) {
       base::FilePath db_path = directory_.AppendASCII(kLocalStorageLeveldbName);
       base::FilePath lock_file_path = db_path.AppendASCII("LOCK");
-      base::DeleteFile(lock_file_path);
+      database_task_runner_->PostTask(
+          FROM_HERE,
+          base::BindOnce(base::IgnoreResult(&base::DeleteFile), lock_file_path));
     }
     database_ = AsyncDomStorageDatabase::OpenDirectory(
         directory_, kLocalStorageLeveldbName, memory_dump_id_,

--- a/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/components/services/storage/dom_storage/local_storage_impl.cc
@@ -684,12 +684,7 @@ void LocalStorageImpl::OnDatabaseOpened(leveldb::Status status) {
                                   leveldb_env::GetLevelDBStatusUMAValue(status),
                                   leveldb_env::LEVELDB_STATUS_MAX);
 #endif
-    if (status.IsCorruption()) {
-      DeleteAndRecreateDatabase();
-    } else {
-      FallbackToInMemory();
-    }
-    return;
+    DeleteAndRecreateDatabase();
   }
 
   // Verify DB schema version.
@@ -740,12 +735,7 @@ void LocalStorageImpl::OnGotDatabaseVersion(leveldb::Status status,
                                   leveldb_env::GetLevelDBStatusUMAValue(status),
                                   leveldb_env::LEVELDB_STATUS_MAX);
 #endif
-    if (status.IsCorruption()) {
-      DeleteAndRecreateDatabase();
-    } else {
-      FallbackToInMemory();
-    }
-    return;
+    DeleteAndRecreateDatabase();
   }
 
   OnConnectionFinished();
@@ -818,27 +808,6 @@ void LocalStorageImpl::DeleteAndRecreateDatabase() {
     // fail, but try anyway.
     InitiateConnection(recreate_in_memory);
   }
-}
-
-void LocalStorageImpl::FallbackToInMemory() {
-  if (connection_state_ == CONNECTION_SHUTDOWN)
-    return;
-
-  PurgeAllStorageAreas();
-
-  // Reset state to be in process of connecting.
-  connection_state_ = CONNECTION_IN_PROGRESS;
-  commit_error_count_ = 0;
-  database_.reset();
-
-  if (tried_to_recreate_during_open_) {
-    // Give up completely, run without any database.
-    OnConnectionFinished();
-    return;
-  }
-
-  tried_to_recreate_during_open_ = true;
-  InitiateConnection(true);
 }
 
 void LocalStorageImpl::OnDBDestroyed(bool recreate_in_memory,
@@ -1026,11 +995,7 @@ void LocalStorageImpl::OnCommitResult(leveldb::Status status) {
                                   leveldb_env::GetLevelDBStatusUMAValue(status),
                                   leveldb_env::LEVELDB_STATUS_MAX);
 #endif
-    if (status.IsCorruption()) {
-      DeleteAndRecreateDatabase();
-    } else {
-      FallbackToInMemory();
-    }
+    DeleteAndRecreateDatabase();
   }
 }
 

--- a/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/components/services/storage/dom_storage/local_storage_impl.cc
@@ -678,7 +678,11 @@ void LocalStorageImpl::OnDatabaseOpened(leveldb::Status status) {
                                   leveldb_env::GetLevelDBStatusUMAValue(status),
                                   leveldb_env::LEVELDB_STATUS_MAX);
 #endif
-    DeleteAndRecreateDatabase();
+    if (status.IsCorruption()) {
+      DeleteAndRecreateDatabase();
+    } else {
+      FallbackToInMemory();
+    }
     return;
   }
 
@@ -730,7 +734,11 @@ void LocalStorageImpl::OnGotDatabaseVersion(leveldb::Status status,
                                   leveldb_env::GetLevelDBStatusUMAValue(status),
                                   leveldb_env::LEVELDB_STATUS_MAX);
 #endif
-    DeleteAndRecreateDatabase();
+    if (status.IsCorruption()) {
+      DeleteAndRecreateDatabase();
+    } else {
+      FallbackToInMemory();
+    }
     return;
   }
 
@@ -804,6 +812,27 @@ void LocalStorageImpl::DeleteAndRecreateDatabase() {
     // fail, but try anyway.
     InitiateConnection(recreate_in_memory);
   }
+}
+
+void LocalStorageImpl::FallbackToInMemory() {
+  if (connection_state_ == CONNECTION_SHUTDOWN)
+    return;
+
+  PurgeAllStorageAreas();
+
+  // Reset state to be in process of connecting.
+  connection_state_ = CONNECTION_IN_PROGRESS;
+  commit_error_count_ = 0;
+  database_.reset();
+
+  if (tried_to_recreate_during_open_) {
+    // Give up completely, run without any database.
+    OnConnectionFinished();
+    return;
+  }
+
+  tried_to_recreate_during_open_ = true;
+  InitiateConnection(true);
 }
 
 void LocalStorageImpl::OnDBDestroyed(bool recreate_in_memory,
@@ -991,7 +1020,11 @@ void LocalStorageImpl::OnCommitResult(leveldb::Status status) {
                                   leveldb_env::GetLevelDBStatusUMAValue(status),
                                   leveldb_env::LEVELDB_STATUS_MAX);
 #endif
-    DeleteAndRecreateDatabase();
+    if (status.IsCorruption()) {
+      DeleteAndRecreateDatabase();
+    } else {
+      FallbackToInMemory();
+    }
   }
 }
 

--- a/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/components/services/storage/dom_storage/local_storage_impl.cc
@@ -19,6 +19,7 @@
 #include "base/feature_list.h"
 #include "base/files/file_enumerator.h"
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
@@ -649,6 +650,11 @@ void LocalStorageImpl::InitiateConnection(bool in_memory_only) {
   if (!directory_.empty() && directory_.IsAbsolute() && !in_memory_only) {
     // We were given a subdirectory to write to, so use a disk-backed database.
     in_memory_ = false;
+    if (base::FeatureList::IsEnabled(kLocalStorageDeleteLockFile)) {
+      base::FilePath db_path = directory_.AppendASCII(kLocalStorageLeveldbName);
+      base::FilePath lock_file_path = db_path.AppendASCII("LOCK");
+      base::DeleteFile(lock_file_path);
+    }
     database_ = AsyncDomStorageDatabase::OpenDirectory(
         directory_, kLocalStorageLeveldbName, memory_dump_id_,
         database_task_runner_,

--- a/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/components/services/storage/dom_storage/local_storage_impl.cc
@@ -650,6 +650,8 @@ void LocalStorageImpl::InitiateConnection(bool in_memory_only) {
   if (!directory_.empty() && directory_.IsAbsolute() && !in_memory_only) {
     // We were given a subdirectory to write to, so use a disk-backed database.
     in_memory_ = false;
+
+#if BUILDFLAG(IS_COBALT)
     if (base::FeatureList::IsEnabled(kLocalStorageDeleteLockFile)) {
       base::FilePath db_path = directory_.AppendASCII(kLocalStorageLeveldbName);
       base::FilePath lock_file_path = db_path.AppendASCII("LOCK");
@@ -657,6 +659,8 @@ void LocalStorageImpl::InitiateConnection(bool in_memory_only) {
           FROM_HERE,
           base::BindOnce(base::IgnoreResult(&base::DeleteFile), lock_file_path));
     }
+#endif  // BUILDFLAG(IS_COBALT)
+
     database_ = AsyncDomStorageDatabase::OpenDirectory(
         directory_, kLocalStorageLeveldbName, memory_dump_id_,
         database_task_runner_,

--- a/components/services/storage/dom_storage/local_storage_impl.h
+++ b/components/services/storage/dom_storage/local_storage_impl.h
@@ -127,7 +127,6 @@ class LocalStorageImpl : public base::trace_event::MemoryDumpProvider,
                             DomStorageDatabase::Value value);
   void OnConnectionFinished();
   void DeleteAndRecreateDatabase();
-  void FallbackToInMemory();
   void OnDBDestroyed(bool recreate_in_memory, leveldb::Status status);
 
   StorageAreaHolder* GetOrCreateStorageArea(

--- a/components/services/storage/dom_storage/local_storage_impl.h
+++ b/components/services/storage/dom_storage/local_storage_impl.h
@@ -127,6 +127,7 @@ class LocalStorageImpl : public base::trace_event::MemoryDumpProvider,
                             DomStorageDatabase::Value value);
   void OnConnectionFinished();
   void DeleteAndRecreateDatabase();
+  void FallbackToInMemory();
   void OnDBDestroyed(bool recreate_in_memory, leveldb::Status status);
 
   StorageAreaHolder* GetOrCreateStorageArea(

--- a/components/services/storage/dom_storage/local_storage_impl_unittest.cc
+++ b/components/services/storage/dom_storage/local_storage_impl_unittest.cc
@@ -980,7 +980,6 @@ TEST_F(LocalStorageImplTest, DeleteLockFile) {
 }
 #endif
 
-
 TEST_F(LocalStorageImplTest, InvalidVersionOnDisk) {
   auto key = StdStringToUint8Vector("key");
   auto value = StdStringToUint8Vector("value");

--- a/components/services/storage/dom_storage/local_storage_impl_unittest.cc
+++ b/components/services/storage/dom_storage/local_storage_impl_unittest.cc
@@ -949,6 +949,38 @@ TEST_F(LocalStorageImplTest, OnDisk) {
       leveldb_env::LevelDBStatusValue::LEVELDB_STATUS_OK, 2);
 }
 
+#if BUILDFLAG(IS_COBALT)
+TEST_F(LocalStorageImplTest, DeleteLockFile) {
+  auto key = StdStringToUint8Vector("key");
+  auto value = StdStringToUint8Vector("value");
+
+  DoTestPut(key, value);
+  std::vector<uint8_t> result;
+  EXPECT_TRUE(DoTestGet(key, &result));
+
+  ShutDownStorage();
+
+  base::FilePath db_path = storage_path()
+                               .Append(kLocalStoragePath)
+                               .AppendASCII(kLocalStorageLeveldbName);
+  base::FilePath lock_file_path = db_path.AppendASCII("LOCK");
+
+  // Create a dummy LOCK file to simulate an orphaned lock file.
+  ASSERT_TRUE(base::WriteFile(lock_file_path, ""));
+  ASSERT_TRUE(base::PathExists(lock_file_path));
+
+  // Re-opening the storage with kLocalStorageDeleteLockFile enabled (default).
+  InitializeStorage(storage_path());
+  EXPECT_TRUE(DoTestGet(key, &result));
+  EXPECT_EQ(value, result);
+
+  // Verify the lock file has been deleted.
+  RunUntilIdle();
+  EXPECT_FALSE(base::PathExists(lock_file_path));
+}
+#endif
+
+
 TEST_F(LocalStorageImplTest, InvalidVersionOnDisk) {
   auto key = StdStringToUint8Vector("key");
   auto value = StdStringToUint8Vector("value");


### PR DESCRIPTION
Adds a mechanism to clear stale lock files on startup to
prevent permanent storage failures caused by improper shutdowns.

See [b/488465561#comment19](https://b.corp.google.com/issues/488465561#comment19) and [b/488465561#comment20](https://b.corp.google.com/issues/488465561#comment20)

Bug: 488465561