### PR TITLE
Cherry pick PR #8774: Conditionally bind H5vccUpdater service

### DIFF
--- a/cobalt/browser/cobalt_browser_interface_binders.cc
+++ b/cobalt/browser/cobalt_browser_interface_binders.cc
@@ -113,8 +113,6 @@ void PopulateCobaltFrameBinders(
   binder_map->Add<h5vcc_platform_service::mojom::H5vccPlatformServiceManager>(
       base::BindRepeating(&h5vcc_platform_service::
                               H5vccPlatformServiceManagerImpl::GetOrCreate));
-  binder_map->Add<h5vcc_updater::mojom::H5vccUpdater>(
-      base::BindRepeating(&h5vcc_updater::H5vccUpdaterImpl::Create));
 }
 
 }  // namespace cobalt

--- a/cobalt/browser/cobalt_browser_interface_binders.cc
+++ b/cobalt/browser/cobalt_browser_interface_binders.cc
@@ -31,12 +31,15 @@
 #include "cobalt/browser/h5vcc_storage/public/mojom/h5vcc_storage.mojom.h"
 #include "cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h"
 #include "cobalt/browser/h5vcc_system/public/mojom/h5vcc_system.mojom.h"
-#include "cobalt/browser/h5vcc_updater/h5vcc_updater_impl.h"
-#include "cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom.h"
 #include "cobalt/browser/performance/performance_impl.h"
 #include "cobalt/browser/performance/public/mojom/performance.mojom.h"
 #include "cobalt/media/service/mojom/platform_window_provider.mojom.h"
 #include "cobalt/media/service/platform_window_provider_service.h"
+
+#if BUILDFLAG(USE_EVERGREEN)
+#include "cobalt/browser/h5vcc_updater/h5vcc_updater_impl.h"
+#include "cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom.h"
+#endif
 
 #if BUILDFLAG(IS_ANDROIDTV)
 #include "content/public/browser/render_frame_host.h"
@@ -99,6 +102,10 @@ void PopulateCobaltFrameBinders(
       base::BindRepeating(&h5vcc_settings::H5vccSettingsImpl::Create));
   binder_map->Add<performance::mojom::CobaltPerformance>(base::BindRepeating(
       &performance::PerformanceImpl::Create, app_startup_timestamp));
+#if BUILDFLAG(USE_EVERGREEN)
+  binder_map->Add<h5vcc_updater::mojom::H5vccUpdater>(
+      base::BindRepeating(&h5vcc_updater::H5vccUpdaterImpl::Create));
+#endif
   binder_map->Add<h5vcc_storage::mojom::H5vccStorage>(
       base::BindRepeating(&h5vcc_storage::H5vccStorageImpl::Create));
   binder_map->Add<media::mojom::PlatformWindowProvider>(

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/BUILD.gn
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/BUILD.gn
@@ -19,7 +19,5 @@ blink_modules_sources("h5vcc_updater") {
     "h_5_vcc_updater.cc",
     "h_5_vcc_updater.h",
   ]
-  if (use_evergreen) {
-    deps = [ "//cobalt/browser/h5vcc_updater/public/mojom:mojom_blink" ]
-  }
+  deps = [ "//cobalt/browser/h5vcc_updater/public/mojom:mojom_blink" ]
 }

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
@@ -22,13 +22,8 @@
 namespace blink {
 
 H5vccUpdater::H5vccUpdater(LocalDOMWindow& window)
-    : ExecutionContextLifecycleObserver(window.GetExecutionContext())
-#if BUILDFLAG(USE_EVERGREEN)
-      ,
-      remote_h5vcc_updater_(window.GetExecutionContext())
-#endif
-{
-}
+    : ExecutionContextLifecycleObserver(window.GetExecutionContext()),
+      remote_h5vcc_updater_(window.GetExecutionContext()) {}
 
 void H5vccUpdater::ContextDestroyed() {}
 
@@ -38,15 +33,13 @@ ScriptPromise<IDLString> H5vccUpdater::getUpdaterChannel(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLString>>(
       script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->GetUpdaterChannel(
       WTF::BindOnce(&H5vccUpdater::OnGetUpdaterChannel, WrapPersistent(this),
                     WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -57,15 +50,13 @@ ScriptPromise<IDLUndefined> H5vccUpdater::setUpdaterChannel(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
       script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->SetUpdaterChannel(
       channel, WTF::BindOnce(&H5vccUpdater::OnSetUpdaterChannel,
                              WrapPersistent(this), WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -75,15 +66,13 @@ ScriptPromise<IDLString> H5vccUpdater::getUpdateStatus(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLString>>(
       script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->GetUpdateStatus(
       WTF::BindOnce(&H5vccUpdater::OnGetUpdateStatus, WrapPersistent(this),
                     WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -93,15 +82,13 @@ ScriptPromise<IDLUndefined> H5vccUpdater::resetInstallations(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
       script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->ResetInstallations(
       WTF::BindOnce(&H5vccUpdater::OnResetInstallations, WrapPersistent(this),
                     WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -112,15 +99,13 @@ ScriptPromise<IDLUnsignedShort> H5vccUpdater::getInstallationIndex(
       MakeGarbageCollected<ScriptPromiseResolver<IDLUnsignedShort>>(
           script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->GetInstallationIndex(
       WTF::BindOnce(&H5vccUpdater::OnGetInstallationIndex, WrapPersistent(this),
                     WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -130,15 +115,13 @@ ScriptPromise<IDLBoolean> H5vccUpdater::getAllowSelfSignedPackages(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLBoolean>>(
       script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->GetAllowSelfSignedPackages(
       WTF::BindOnce(&H5vccUpdater::OnGetAllowSelfSignedPackages,
                     WrapPersistent(this), WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -152,6 +135,7 @@ ScriptPromise<IDLUndefined> H5vccUpdater::setAllowSelfSignedPackages(
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->SetAllowSelfSignedPackages(
       allow_self_signed_packages,
       WTF::BindOnce(&H5vccUpdater::OnSetAllowSelfSignedPackages,
@@ -168,15 +152,13 @@ ScriptPromise<IDLString> H5vccUpdater::getUpdateServerUrl(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLString>>(
       script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->GetUpdateServerUrl(
       WTF::BindOnce(&H5vccUpdater::OnGetUpdateServerUrl, WrapPersistent(this),
                     WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -190,6 +172,7 @@ ScriptPromise<IDLUndefined> H5vccUpdater::setUpdateServerUrl(
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->SetUpdateServerUrl(
       update_server_url,
       WTF::BindOnce(&H5vccUpdater::OnSetUpdateServerUrl, WrapPersistent(this),
@@ -206,15 +189,13 @@ ScriptPromise<IDLBoolean> H5vccUpdater::getRequireNetworkEncryption(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLBoolean>>(
       script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->GetRequireNetworkEncryption(
       WTF::BindOnce(&H5vccUpdater::OnGetRequireNetworkEncryption,
                     WrapPersistent(this), WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -228,6 +209,7 @@ ScriptPromise<IDLUndefined> H5vccUpdater::setRequireNetworkEncryption(
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->SetRequireNetworkEncryption(
       require_network_encryption,
       WTF::BindOnce(&H5vccUpdater::OnSetRequireNetworkEncryption,
@@ -245,85 +227,94 @@ ScriptPromise<IDLString> H5vccUpdater::getLibrarySha256(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLString>>(
       script_state, exception_state.GetContext());
 
-#if BUILDFLAG(USE_EVERGREEN)
   EnsureReceiverIsBound();
 
+  ongoing_requests_.insert(resolver);
   remote_h5vcc_updater_->GetLibrarySha256(
       index, WTF::BindOnce(&H5vccUpdater::OnGetLibrarySha256,
                            WrapPersistent(this), WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
 void H5vccUpdater::OnGetUpdaterChannel(
     ScriptPromiseResolver<IDLString>* resolver,
     const String& result) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve(result);
 }
 
 void H5vccUpdater::OnSetUpdaterChannel(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve();
 }
 
 void H5vccUpdater::OnGetUpdateStatus(ScriptPromiseResolver<IDLString>* resolver,
                                      const String& result) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve(result);
 }
 
 void H5vccUpdater::OnResetInstallations(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve();
 }
 
 void H5vccUpdater::OnGetInstallationIndex(
     ScriptPromiseResolver<IDLUnsignedShort>* resolver,
     uint16_t result) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve(result);
 }
 
 void H5vccUpdater::OnGetLibrarySha256(
     ScriptPromiseResolver<IDLString>* resolver,
     const String& result) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve(result);
 }
 
 void H5vccUpdater::OnGetAllowSelfSignedPackages(
     ScriptPromiseResolver<IDLBoolean>* resolver,
     bool result) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve(result);
 }
 
 void H5vccUpdater::OnSetAllowSelfSignedPackages(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve();
 }
 
 void H5vccUpdater::OnGetUpdateServerUrl(
     ScriptPromiseResolver<IDLString>* resolver,
     const String& result) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve(result);
 }
 
 void H5vccUpdater::OnSetUpdateServerUrl(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve();
 }
 
 void H5vccUpdater::OnGetRequireNetworkEncryption(
     ScriptPromiseResolver<IDLBoolean>* resolver,
     bool result) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve(result);
 }
 
 void H5vccUpdater::OnSetRequireNetworkEncryption(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
+  ongoing_requests_.erase(resolver);
   resolver->Resolve();
 }
 
-#if BUILDFLAG(USE_EVERGREEN)
 void H5vccUpdater::EnsureReceiverIsBound() {
   DCHECK(GetExecutionContext());
 
@@ -335,16 +326,31 @@ void H5vccUpdater::EnsureReceiverIsBound() {
       GetExecutionContext()->GetTaskRunner(TaskType::kMiscPlatformAPI);
   GetExecutionContext()->GetBrowserInterfaceBroker().GetInterface(
       remote_h5vcc_updater_.BindNewPipeAndPassReceiver(task_runner));
+  remote_h5vcc_updater_.set_disconnect_handler(WTF::BindOnce(
+      &H5vccUpdater::OnConnectionError, WrapWeakPersistent(this)));
 }
 
+void H5vccUpdater::OnConnectionError() {
+  remote_h5vcc_updater_.reset();
+  HeapHashSet<Member<ScriptPromiseResolverBase>> h5vcc_updater_promises;
+  // Script may execute during a call to Reject(). Swap these sets to prevent
+  // concurrent modification.
+  ongoing_requests_.swap(h5vcc_updater_promises);
+  for (auto& resolver : h5vcc_updater_promises) {
+#if BUILDFLAG(USE_EVERGREEN)
+    resolver->Reject("Mojo connection error.");
+#else
+    resolver->Reject("API not supported for this platform.");
 #endif
+  }
+  ongoing_requests_.clear();
+}
 
 void H5vccUpdater::Trace(Visitor* visitor) const {
   ScriptWrappable::Trace(visitor);
   ExecutionContextLifecycleObserver::Trace(visitor);
-#if BUILDFLAG(USE_EVERGREEN)
+  visitor->Trace(ongoing_requests_);
   visitor->Trace(remote_h5vcc_updater_);
-#endif
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.h
@@ -24,6 +24,7 @@
 #include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
 #include "third_party/blink/renderer/modules/modules_export.h"
 #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
+#include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_receiver.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_remote.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_wrapper_mode.h"

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.h
@@ -16,10 +16,7 @@
 #define THIRD_PARTY_BLINK_RENDERER_MODULES_COBALT_H5VCC_UPDATER_H_5_VCC_UPDATER_H_
 
 #include "build/build_config.h"
-
-#if BUILDFLAG(USE_EVERGREEN)
 #include "cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom-blink.h"  // nogncheck
-#endif
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #include "third_party/blink/renderer/bindings/core/v8/idl_types.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
@@ -92,11 +89,11 @@ class MODULES_EXPORT H5vccUpdater final
   void OnSetUpdateServerUrl(ScriptPromiseResolver<IDLUndefined>*);
   void OnGetRequireNetworkEncryption(ScriptPromiseResolver<IDLBoolean>*, bool);
   void OnSetRequireNetworkEncryption(ScriptPromiseResolver<IDLUndefined>*);
-#if BUILDFLAG(USE_EVERGREEN)
+  void OnConnectionError();
   void EnsureReceiverIsBound();
+  HeapHashSet<Member<ScriptPromiseResolverBase>> ongoing_requests_;
   HeapMojoRemote<h5vcc_updater::mojom::blink::H5vccUpdater>
       remote_h5vcc_updater_;
-#endif
 };
 
 }  // namespace blink

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.idl
@@ -13,6 +13,8 @@
 // limitations under the License.
 
 // Custom API for getting and setting Evergreen update settings.
+// A disconnect handler in the renderer will reject all pending promises with a
+// "API not supported for this platform." if called from a non-Evergreen build.
 
 interface H5vccUpdater {
   [CallWith=ScriptState, RaisesException]


### PR DESCRIPTION
Cobalt: Conditionally bind H5vccUpdater service

Relocate the conditional binding of the H5vccUpdater Mojo interface
from the Blink renderer module to the Cobalt browser process.
This change ensures the Mojo service is only provided when the
USE_EVERGREEN build flag is enabled, centralizing control over
the API's availability. The client-side module now always attempts
to bind and gracefully handles Mojo connection errors by rejecting
pending promises if the service is unavailable.

Bug: 515122610