### PR TITLE
Cherry pick PR #8615: Mojo implementation for updater APIs

### DIFF
--- a/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.cc
+++ b/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.cc
@@ -16,6 +16,7 @@
 
 #include "base/functional/callback.h"
 #include "build/build_config.h"
+#include "cobalt/updater/util.h"
 
 #if BUILDFLAG(USE_EVERGREEN)
 #include "cobalt/updater/updater_module.h"
@@ -49,51 +50,137 @@ void H5vccUpdaterImpl::Create(
 
 void H5vccUpdaterImpl::GetUpdaterChannel(GetUpdaterChannelCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if BUILDFLAG(USE_EVERGREEN)
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (!updater_module) {
+    std::move(callback).Run("");
+    return;
+  }
+  std::move(callback).Run(updater_module->GetUpdaterChannel());
+#else
+  std::move(callback).Run("");
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::SetUpdaterChannel(const std::string& channel,
                                          SetUpdaterChannelCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if BUILDFLAG(USE_EVERGREEN)
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (updater_module) {
+    // Force an update if SetUpdaterChannel() is called, even if
+    // the |channel| doesn't change, as long as it's not
+    // "prod"/"experiment"/"control"/"rollback" channel
+    if (updater_module->GetUpdaterChannel().compare(channel) != 0) {
+      updater_module->SetUpdaterChannel(channel);
+    } else if (channel == "prod" || channel == "experiment" ||
+               channel == "control" || channel == "rollback") {
+      std::move(callback).Run();
+      return;
+    }
+    updater_module->CompareAndSwapForcedUpdate(0, 1);
+    updater_module->RunUpdateCheck();
+  }
+  std::move(callback).Run();
+#else
+  std::move(callback).Run();
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::GetUpdateStatus(GetUpdateStatusCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if BUILDFLAG(USE_EVERGREEN)
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (!updater_module) {
+    std::move(callback).Run("");
+    return;
+  }
+  std::move(callback).Run(updater_module->GetUpdaterStatus());
+#else
+  std::move(callback).Run("");
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::ResetInstallations(ResetInstallationsCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if BUILDFLAG(USE_EVERGREEN)
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (updater_module) {
+    updater_module->ResetInstallations();
+  }
+  std::move(callback).Run();
+#else
+  std::move(callback).Run();
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::GetInstallationIndex(
     GetInstallationIndexCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  const uint16_t kInvalidInstallationIndex = 1000;
+#if BUILDFLAG(USE_EVERGREEN)
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (!updater_module) {
+    std::move(callback).Run(kInvalidInstallationIndex);
+    return;
+  }
+  int index = updater_module->GetInstallationIndex();
+  std::move(callback).Run(index == -1 ? kInvalidInstallationIndex
+                                      : base::checked_cast<uint16_t>(index));
+#else
+  std::move(callback).Run(kInvalidInstallationIndex);
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::GetAllowSelfSignedPackages(
     GetAllowSelfSignedPackagesCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if BUILDFLAG(USE_EVERGREEN)
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (!updater_module) {
+    std::move(callback).Run(false);
+    return;
+  }
+  std::move(callback).Run(updater_module->GetAllowSelfSignedPackages());
+#else
+  std::move(callback).Run(false);
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::SetAllowSelfSignedPackages(
     bool allow_self_signed_packages,
     SetAllowSelfSignedPackagesCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (updater_module) {
+    updater_module->SetAllowSelfSignedPackages(allow_self_signed_packages);
+  }
+  std::move(callback).Run();
+#else
+  std::move(callback).Run();
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::GetUpdateServerUrl(GetUpdateServerUrlCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
 #if BUILDFLAG(USE_EVERGREEN)
-  std::string url =
-      cobalt::updater::UpdaterModule::GetInstance()->GetUpdateServerUrl();
-  std::move(callback).Run(url);
+  auto updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (updater_module) {
+    std::string url = updater_module->GetUpdateServerUrl();
+    std::move(callback).Run(url);
+  } else {
+    std::move(callback).Run("");
+  }
 #else
+  std::move(callback).Run("");
   NOTIMPLEMENTED();
 #endif
 }
@@ -101,26 +188,59 @@ void H5vccUpdaterImpl::GetUpdateServerUrl(GetUpdateServerUrlCallback callback) {
 void H5vccUpdaterImpl::SetUpdateServerUrl(const std::string& update_server_url,
                                           SetUpdateServerUrlCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (updater_module) {
+    updater_module->SetUpdateServerUrl(update_server_url);
+  }
+  std::move(callback).Run();
+#else
+  std::move(callback).Run();
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::GetRequireNetworkEncryption(
     GetRequireNetworkEncryptionCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if BUILDFLAG(USE_EVERGREEN)
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (!updater_module) {
+    std::move(callback).Run(false);
+    return;
+  }
+  std::move(callback).Run(updater_module->GetRequireNetworkEncryption());
+#else
+  std::move(callback).Run(false);
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::SetRequireNetworkEncryption(
     bool require_network_encryption,
     SetRequireNetworkEncryptionCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
+  if (updater_module) {
+    updater_module->SetRequireNetworkEncryption(require_network_encryption);
+  }
+  std::move(callback).Run();
+#else
+  std::move(callback).Run();
   NOTIMPLEMENTED();
+#endif
 }
 
 void H5vccUpdaterImpl::GetLibrarySha256(unsigned short index,
                                         GetLibrarySha256Callback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+#if BUILDFLAG(USE_EVERGREEN)
+  std::move(callback).Run(cobalt::updater::GetLibrarySha256(index));
+#else
+  std::move(callback).Run("");
   NOTIMPLEMENTED();
+#endif
 }
 
 }  // namespace h5vcc_updater


### PR DESCRIPTION
evergreen: Implement updater H5vcc APIs

This change implements the H5vcc updater APIs in H5vccUpdaterImpl.
Previously, these APIs were stubbed out with NOTIMPLEMENTED() calls.
Now, for Evergreen builds, these methods delegate to the UpdaterModule,
providing concrete functionality for managing updater channels,
installation status, and other related update features. This enables
the browser to expose full updater capabilities via the H5vcc API.

Bug: 454440974
Bug: 515122610