### PR TITLE
Cherry pick PR #8803: Conditionally add binding in mojo for sideloading APIs

### DIFF
--- a/cobalt/browser/cobalt_browser_interface_binders.cc
+++ b/cobalt/browser/cobalt_browser_interface_binders.cc
@@ -38,8 +38,13 @@
 
 #if BUILDFLAG(USE_EVERGREEN)
 #include "cobalt/browser/h5vcc_updater/h5vcc_updater_impl.h"
+// TODO(b/458483469): Remove the ALLOW_EVERGREEN_SIDELOADING check after
+// security review.
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+#include "cobalt/browser/h5vcc_updater/h5vcc_updater_sideloading_impl.h"
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
 #include "cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom.h"
-#endif
+#endif  // BUILDFLAG(USE_EVERGREEN)
 
 #if BUILDFLAG(IS_ANDROIDTV)
 #include "content/public/browser/render_frame_host.h"
@@ -105,7 +110,13 @@ void PopulateCobaltFrameBinders(
 #if BUILDFLAG(USE_EVERGREEN)
   binder_map->Add<h5vcc_updater::mojom::H5vccUpdater>(
       base::BindRepeating(&h5vcc_updater::H5vccUpdaterImpl::Create));
-#endif
+// TODO(b/458483469): Remove the ALLOW_EVERGREEN_SIDELOADING check after
+// security review.
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+  binder_map->Add<h5vcc_updater::mojom::H5vccUpdaterSideloading>(
+      base::BindRepeating(&h5vcc_updater::H5vccUpdaterSideloadingImpl::Create));
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+#endif  // BUILDFLAG(USE_EVERGREEN)
   binder_map->Add<h5vcc_storage::mojom::H5vccStorage>(
       base::BindRepeating(&h5vcc_storage::H5vccStorageImpl::Create));
   binder_map->Add<media::mojom::PlatformWindowProvider>(

--- a/cobalt/browser/h5vcc_updater/BUILD.gn
+++ b/cobalt/browser/h5vcc_updater/BUILD.gn
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# TODO(b/458483469): Conditionally add sideloading files to sources if
+# 'cobalt_is_release_build' and sideloading are enabled.
 source_set("h5vcc_updater") {
-  sources = [
-    "h5vcc_updater_impl.cc",
-    "h5vcc_updater_impl.h",
-  ]
+  if (use_evergreen) {
+    sources = [
+      "h5vcc_updater_impl.cc",
+      "h5vcc_updater_impl.h",
+      "h5vcc_updater_sideloading_impl.cc",
+      "h5vcc_updater_sideloading_impl.h",
+    ]
+  }
 
   deps = [
     "//base",

--- a/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.cc
+++ b/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.cc
@@ -28,6 +28,7 @@
 #include "starboard/system.h"
 #endif
 
+// Note: these APIs are only bound to mojo if evergreen is enabled.
 namespace h5vcc_updater {
 
 H5vccUpdaterImpl::H5vccUpdaterImpl(
@@ -50,23 +51,17 @@ void H5vccUpdaterImpl::Create(
 
 void H5vccUpdaterImpl::GetUpdaterChannel(GetUpdaterChannelCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
   auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (!updater_module) {
-    std::move(callback).Run("");
+  if (updater_module) {
+    std::move(callback).Run(updater_module->GetUpdaterChannel());
     return;
   }
-  std::move(callback).Run(updater_module->GetUpdaterChannel());
-#else
   std::move(callback).Run("");
-  NOTIMPLEMENTED();
-#endif
 }
 
 void H5vccUpdaterImpl::SetUpdaterChannel(const std::string& channel,
                                          SetUpdaterChannelCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
   auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
   if (updater_module) {
     // Force an update if SetUpdaterChannel() is called, even if
@@ -83,164 +78,45 @@ void H5vccUpdaterImpl::SetUpdaterChannel(const std::string& channel,
     updater_module->RunUpdateCheck();
   }
   std::move(callback).Run();
-#else
-  std::move(callback).Run();
-  NOTIMPLEMENTED();
-#endif
 }
 
 void H5vccUpdaterImpl::GetUpdateStatus(GetUpdateStatusCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
   auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (!updater_module) {
-    std::move(callback).Run("");
+  if (updater_module) {
+    std::move(callback).Run(updater_module->GetUpdaterStatus());
     return;
   }
-  std::move(callback).Run(updater_module->GetUpdaterStatus());
-#else
   std::move(callback).Run("");
-  NOTIMPLEMENTED();
-#endif
 }
 
 void H5vccUpdaterImpl::ResetInstallations(ResetInstallationsCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
   auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
   if (updater_module) {
     updater_module->ResetInstallations();
   }
   std::move(callback).Run();
-#else
-  std::move(callback).Run();
-  NOTIMPLEMENTED();
-#endif
 }
 
 void H5vccUpdaterImpl::GetInstallationIndex(
     GetInstallationIndexCallback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   const uint16_t kInvalidInstallationIndex = 1000;
-#if BUILDFLAG(USE_EVERGREEN)
   auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (!updater_module) {
-    std::move(callback).Run(kInvalidInstallationIndex);
+  if (updater_module) {
+    int index = updater_module->GetInstallationIndex();
+    std::move(callback).Run(index == -1 ? kInvalidInstallationIndex
+                                        : base::checked_cast<uint16_t>(index));
     return;
   }
-  int index = updater_module->GetInstallationIndex();
-  std::move(callback).Run(index == -1 ? kInvalidInstallationIndex
-                                      : base::checked_cast<uint16_t>(index));
-#else
   std::move(callback).Run(kInvalidInstallationIndex);
-  NOTIMPLEMENTED();
-#endif
-}
-
-void H5vccUpdaterImpl::GetAllowSelfSignedPackages(
-    GetAllowSelfSignedPackagesCallback callback) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
-  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (!updater_module) {
-    std::move(callback).Run(false);
-    return;
-  }
-  std::move(callback).Run(updater_module->GetAllowSelfSignedPackages());
-#else
-  std::move(callback).Run(false);
-  NOTIMPLEMENTED();
-#endif
-}
-
-void H5vccUpdaterImpl::SetAllowSelfSignedPackages(
-    bool allow_self_signed_packages,
-    SetAllowSelfSignedPackagesCallback callback) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
-  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (updater_module) {
-    updater_module->SetAllowSelfSignedPackages(allow_self_signed_packages);
-  }
-  std::move(callback).Run();
-#else
-  std::move(callback).Run();
-  NOTIMPLEMENTED();
-#endif
-}
-
-void H5vccUpdaterImpl::GetUpdateServerUrl(GetUpdateServerUrlCallback callback) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
-  auto updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (updater_module) {
-    std::string url = updater_module->GetUpdateServerUrl();
-    std::move(callback).Run(url);
-  } else {
-    std::move(callback).Run("");
-  }
-#else
-  std::move(callback).Run("");
-  NOTIMPLEMENTED();
-#endif
-}
-
-void H5vccUpdaterImpl::SetUpdateServerUrl(const std::string& update_server_url,
-                                          SetUpdateServerUrlCallback callback) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
-  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (updater_module) {
-    updater_module->SetUpdateServerUrl(update_server_url);
-  }
-  std::move(callback).Run();
-#else
-  std::move(callback).Run();
-  NOTIMPLEMENTED();
-#endif
-}
-
-void H5vccUpdaterImpl::GetRequireNetworkEncryption(
-    GetRequireNetworkEncryptionCallback callback) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
-  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (!updater_module) {
-    std::move(callback).Run(false);
-    return;
-  }
-  std::move(callback).Run(updater_module->GetRequireNetworkEncryption());
-#else
-  std::move(callback).Run(false);
-  NOTIMPLEMENTED();
-#endif
-}
-
-void H5vccUpdaterImpl::SetRequireNetworkEncryption(
-    bool require_network_encryption,
-    SetRequireNetworkEncryptionCallback callback) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
-  auto* updater_module = cobalt::updater::UpdaterModule::GetInstance();
-  if (updater_module) {
-    updater_module->SetRequireNetworkEncryption(require_network_encryption);
-  }
-  std::move(callback).Run();
-#else
-  std::move(callback).Run();
-  NOTIMPLEMENTED();
-#endif
 }
 
 void H5vccUpdaterImpl::GetLibrarySha256(unsigned short index,
                                         GetLibrarySha256Callback callback) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-#if BUILDFLAG(USE_EVERGREEN)
   std::move(callback).Run(cobalt::updater::GetLibrarySha256(index));
-#else
-  std::move(callback).Run("");
-  NOTIMPLEMENTED();
-#endif
 }
 
 }  // namespace h5vcc_updater

--- a/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.h
+++ b/cobalt/browser/h5vcc_updater/h5vcc_updater_impl.h
@@ -47,19 +47,6 @@ class H5vccUpdaterImpl : public content::DocumentService<mojom::H5vccUpdater> {
   void GetUpdateStatus(GetUpdateStatusCallback callback) override;
   void ResetInstallations(ResetInstallationsCallback callback) override;
   void GetInstallationIndex(GetInstallationIndexCallback callback) override;
-  void GetAllowSelfSignedPackages(
-      GetAllowSelfSignedPackagesCallback callback) override;
-  void SetAllowSelfSignedPackages(
-      bool allow_self_signed_packages,
-      SetAllowSelfSignedPackagesCallback callback) override;
-  void GetUpdateServerUrl(GetUpdateServerUrlCallback callback) override;
-  void SetUpdateServerUrl(const std::string& update_server_url,
-                          SetUpdateServerUrlCallback callback) override;
-  void GetRequireNetworkEncryption(
-      GetRequireNetworkEncryptionCallback callback) override;
-  void SetRequireNetworkEncryption(
-      bool require_network_encryption,
-      SetRequireNetworkEncryptionCallback callback) override;
   void GetLibrarySha256(unsigned short index,
                         GetLibrarySha256Callback callback) override;
 
@@ -70,7 +57,6 @@ class H5vccUpdaterImpl : public content::DocumentService<mojom::H5vccUpdater> {
 
   THREAD_CHECKER(thread_checker_);
 };
-
 }  // namespace h5vcc_updater
 
 #endif  // COBALT_BROWSER_H5VCC_UPDATER_H5VCC_UPDATER_IMPL_H_

--- a/cobalt/browser/h5vcc_updater/h5vcc_updater_sideloading_impl.h
+++ b/cobalt/browser/h5vcc_updater/h5vcc_updater_sideloading_impl.h
@@ -1,0 +1,67 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_H5VCC_UPDATER_H5VCC_UPDATER_SIDELOADING_IMPL_H_
+#define COBALT_BROWSER_H5VCC_UPDATER_H5VCC_UPDATER_SIDELOADING_IMPL_H_
+
+#include <string>
+
+#include "base/threading/thread_checker.h"
+#include "cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom.h"
+#include "content/public/browser/document_service.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+
+namespace content {
+class RenderFrameHost;
+}  // namespace content
+
+namespace h5vcc_updater {
+
+class H5vccUpdaterSideloadingImpl
+    : public content::DocumentService<mojom::H5vccUpdaterSideloading> {
+ public:
+  static void Create(
+      content::RenderFrameHost* render_frame_host,
+      mojo::PendingReceiver<mojom::H5vccUpdaterSideloading> receiver);
+
+  H5vccUpdaterSideloadingImpl(const H5vccUpdaterSideloadingImpl&) = delete;
+  H5vccUpdaterSideloadingImpl& operator=(const H5vccUpdaterSideloadingImpl&) =
+      delete;
+
+  void SetAllowSelfSignedPackages(
+      bool allow_self_signed_packages,
+      SetAllowSelfSignedPackagesCallback callback) override;
+  void GetAllowSelfSignedPackages(
+      GetAllowSelfSignedPackagesCallback callback) override;
+  void SetUpdateServerUrl(const std::string& update_server_url,
+                          SetUpdateServerUrlCallback callback) override;
+  void GetUpdateServerUrl(GetUpdateServerUrlCallback callback) override;
+  void SetRequireNetworkEncryption(
+      bool require_network_encryption,
+      SetRequireNetworkEncryptionCallback callback) override;
+  void GetRequireNetworkEncryption(
+      GetRequireNetworkEncryptionCallback callback) override;
+
+ private:
+  H5vccUpdaterSideloadingImpl(
+      content::RenderFrameHost& render_frame_host,
+      mojo::PendingReceiver<mojom::H5vccUpdaterSideloading> receiver);
+  ~H5vccUpdaterSideloadingImpl();
+
+  THREAD_CHECKER(thread_checker_);
+};
+
+}  // namespace h5vcc_updater
+
+#endif  // COBALT_BROWSER_H5VCC_UPDATER_H5VCC_UPDATER_SIDELOADING_IMPL_H_

--- a/cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom
+++ b/cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom
@@ -20,11 +20,14 @@ interface H5vccUpdater {
   GetUpdateStatus() => (string status);
   ResetInstallations() => ();
   GetInstallationIndex() => (uint16 index);
-  GetAllowSelfSignedPackages() => (bool allow_self_signed_packages);
-  SetAllowSelfSignedPackages(bool allow_self_signed_packages) => ();
-  GetUpdateServerUrl() => (string update_server_url);
-  SetUpdateServerUrl(string update_server_url) => ();
-  GetRequireNetworkEncryption() => (bool require_network_encryption);
-  SetRequireNetworkEncryption(bool require_network_encryption) => ();
   GetLibrarySha256(uint16 index) => (string sha256);
+};
+
+interface H5vccUpdaterSideloading {
+  SetAllowSelfSignedPackages(bool allow_self_signed_packages) => ();
+  GetAllowSelfSignedPackages() => (bool allow_self_signed_packages);
+  SetUpdateServerUrl(string update_server_url) => ();
+  GetUpdateServerUrl() => (string update_server_url);
+  SetRequireNetworkEncryption(bool require_network_encryption) => ();
+  GetRequireNetworkEncryption() => (bool require_network_encryption);
 };

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
@@ -23,7 +23,8 @@ namespace blink {
 
 H5vccUpdater::H5vccUpdater(LocalDOMWindow& window)
     : ExecutionContextLifecycleObserver(window.GetExecutionContext()),
-      remote_h5vcc_updater_(window.GetExecutionContext()) {}
+      remote_h5vcc_updater_(window.GetExecutionContext()),
+      remote_h5vcc_updater_sideloading_(window.GetExecutionContext()) {}
 
 void H5vccUpdater::ContextDestroyed() {}
 
@@ -117,8 +118,8 @@ ScriptPromise<IDLBoolean> H5vccUpdater::getAllowSelfSignedPackages(
 
   EnsureReceiverIsBound();
 
-  ongoing_requests_.insert(resolver);
-  remote_h5vcc_updater_->GetAllowSelfSignedPackages(
+  ongoing_sideloading_requests_.insert(resolver);
+  remote_h5vcc_updater_sideloading_->GetAllowSelfSignedPackages(
       WTF::BindOnce(&H5vccUpdater::OnGetAllowSelfSignedPackages,
                     WrapPersistent(this), WrapPersistent(resolver)));
 
@@ -132,17 +133,13 @@ ScriptPromise<IDLUndefined> H5vccUpdater::setAllowSelfSignedPackages(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
       script_state, exception_state.GetContext());
 
-#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
-  EnsureReceiverIsBound();
+  EnsureSideloadingReceiverIsBound();
 
-  ongoing_requests_.insert(resolver);
-  remote_h5vcc_updater_->SetAllowSelfSignedPackages(
+  ongoing_sideloading_requests_.insert(resolver);
+  remote_h5vcc_updater_sideloading_->SetAllowSelfSignedPackages(
       allow_self_signed_packages,
       WTF::BindOnce(&H5vccUpdater::OnSetAllowSelfSignedPackages,
                     WrapPersistent(this), WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
   return resolver->Promise();
 }
 
@@ -154,8 +151,8 @@ ScriptPromise<IDLString> H5vccUpdater::getUpdateServerUrl(
 
   EnsureReceiverIsBound();
 
-  ongoing_requests_.insert(resolver);
-  remote_h5vcc_updater_->GetUpdateServerUrl(
+  ongoing_sideloading_requests_.insert(resolver);
+  remote_h5vcc_updater_sideloading_->GetUpdateServerUrl(
       WTF::BindOnce(&H5vccUpdater::OnGetUpdateServerUrl, WrapPersistent(this),
                     WrapPersistent(resolver)));
 
@@ -169,17 +166,13 @@ ScriptPromise<IDLUndefined> H5vccUpdater::setUpdateServerUrl(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
       script_state, exception_state.GetContext());
 
-#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
-  EnsureReceiverIsBound();
+  EnsureSideloadingReceiverIsBound();
 
-  ongoing_requests_.insert(resolver);
-  remote_h5vcc_updater_->SetUpdateServerUrl(
+  ongoing_sideloading_requests_.insert(resolver);
+  remote_h5vcc_updater_sideloading_->SetUpdateServerUrl(
       update_server_url,
       WTF::BindOnce(&H5vccUpdater::OnSetUpdateServerUrl, WrapPersistent(this),
                     WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
   return resolver->Promise();
 }
 
@@ -191,8 +184,8 @@ ScriptPromise<IDLBoolean> H5vccUpdater::getRequireNetworkEncryption(
 
   EnsureReceiverIsBound();
 
-  ongoing_requests_.insert(resolver);
-  remote_h5vcc_updater_->GetRequireNetworkEncryption(
+  ongoing_sideloading_requests_.insert(resolver);
+  remote_h5vcc_updater_sideloading_->GetRequireNetworkEncryption(
       WTF::BindOnce(&H5vccUpdater::OnGetRequireNetworkEncryption,
                     WrapPersistent(this), WrapPersistent(resolver)));
 
@@ -206,17 +199,14 @@ ScriptPromise<IDLUndefined> H5vccUpdater::setRequireNetworkEncryption(
   auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
       script_state, exception_state.GetContext());
 
-#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
-  EnsureReceiverIsBound();
+  EnsureSideloadingReceiverIsBound();
 
-  ongoing_requests_.insert(resolver);
-  remote_h5vcc_updater_->SetRequireNetworkEncryption(
+  ongoing_sideloading_requests_.insert(resolver);
+  remote_h5vcc_updater_sideloading_->SetRequireNetworkEncryption(
       require_network_encryption,
       WTF::BindOnce(&H5vccUpdater::OnSetRequireNetworkEncryption,
                     WrapPersistent(this), WrapPersistent(resolver)));
-#else
-  resolver->Reject();
-#endif
+
   return resolver->Promise();
 }
 
@@ -285,7 +275,7 @@ void H5vccUpdater::OnGetAllowSelfSignedPackages(
 
 void H5vccUpdater::OnSetAllowSelfSignedPackages(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
-  ongoing_requests_.erase(resolver);
+  ongoing_sideloading_requests_.erase(resolver);
   resolver->Resolve();
 }
 
@@ -298,7 +288,7 @@ void H5vccUpdater::OnGetUpdateServerUrl(
 
 void H5vccUpdater::OnSetUpdateServerUrl(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
-  ongoing_requests_.erase(resolver);
+  ongoing_sideloading_requests_.erase(resolver);
   resolver->Resolve();
 }
 
@@ -311,7 +301,7 @@ void H5vccUpdater::OnGetRequireNetworkEncryption(
 
 void H5vccUpdater::OnSetRequireNetworkEncryption(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
-  ongoing_requests_.erase(resolver);
+  ongoing_sideloading_requests_.erase(resolver);
   resolver->Resolve();
 }
 
@@ -346,11 +336,50 @@ void H5vccUpdater::OnConnectionError() {
   ongoing_requests_.clear();
 }
 
+void H5vccUpdater::EnsureSideloadingReceiverIsBound() {
+  DCHECK(GetExecutionContext());
+
+  if (remote_h5vcc_updater_sideloading_.is_bound()) {
+    return;
+  }
+
+  auto task_runner =
+      GetExecutionContext()->GetTaskRunner(TaskType::kMiscPlatformAPI);
+  GetExecutionContext()->GetBrowserInterfaceBroker().GetInterface(
+      remote_h5vcc_updater_sideloading_.BindNewPipeAndPassReceiver(
+          task_runner));
+  remote_h5vcc_updater_sideloading_.set_disconnect_handler(WTF::BindOnce(
+      &H5vccUpdater::OnSideloadingConnectionError, WrapWeakPersistent(this)));
+}
+
+void H5vccUpdater::OnSideloadingConnectionError() {
+  remote_h5vcc_updater_sideloading_.reset();
+  HeapHashSet<Member<ScriptPromiseResolverBase>> h5vcc_updater_promises;
+  // Script may execute during a call to Reject(). Swap these sets to prevent
+  // concurrent modification.
+  ongoing_sideloading_requests_.swap(h5vcc_updater_promises);
+  for (auto& resolver : h5vcc_updater_promises) {
+// TODO(b/458483469): Remove the ALLOW_EVERGREEN_SIDELOADING check after
+// security review.
+#if BUILDFLAG(USE_EVERGREEN) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && \
+    ALLOW_EVERGREEN_SIDELOADING
+    resolver->Reject("Mojo connection error.");
+#else
+    resolver->Reject(
+        "API not supported for this build configuration. Enabled for "
+        "sideloading only.");
+#endif
+  }
+  ongoing_sideloading_requests_.clear();
+}
+
 void H5vccUpdater::Trace(Visitor* visitor) const {
   ScriptWrappable::Trace(visitor);
   ExecutionContextLifecycleObserver::Trace(visitor);
   visitor->Trace(ongoing_requests_);
+  visitor->Trace(ongoing_sideloading_requests_);
   visitor->Trace(remote_h5vcc_updater_);
+  visitor->Trace(remote_h5vcc_updater_sideloading_);
 }
 
 }  // namespace blink

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.h
@@ -91,10 +91,15 @@ class MODULES_EXPORT H5vccUpdater final
   void OnGetRequireNetworkEncryption(ScriptPromiseResolver<IDLBoolean>*, bool);
   void OnSetRequireNetworkEncryption(ScriptPromiseResolver<IDLUndefined>*);
   void OnConnectionError();
+  void OnSideloadingConnectionError();
   void EnsureReceiverIsBound();
+  void EnsureSideloadingReceiverIsBound();
   HeapHashSet<Member<ScriptPromiseResolverBase>> ongoing_requests_;
+  HeapHashSet<Member<ScriptPromiseResolverBase>> ongoing_sideloading_requests_;
   HeapMojoRemote<h5vcc_updater::mojom::blink::H5vccUpdater>
       remote_h5vcc_updater_;
+  HeapMojoRemote<h5vcc_updater::mojom::blink::H5vccUpdaterSideloading>
+      remote_h5vcc_updater_sideloading_;
 };
 
 }  // namespace blink


### PR DESCRIPTION
Evergreen: Isolate updater sideloading configuration

Move updater configuration setters to a dedicated sideloading Mojo
interface. This separates sensitive update settings, such as allowing
self-signed packages, update server URL, and network encryption
requirements, into an interface only bound in non-release Evergreen
builds with sideloading enabled. This prevents unauthorized modification
of update settings in production environments.

Bug: 454440974
Bug: 515122610