### PR TITLE
Cherry pick PR #8637: Web tests for h5vcc updater

### DIFF
--- a/third_party/blink/web_tests/TestExpectations
+++ b/third_party/blink/web_tests/TestExpectations
@@ -9437,4 +9437,4 @@ wpt_internal/cobalt/h5vcc-runtime/* [ Failure ]
 wpt_internal/cobalt/h5vcc-system/* [ Failure ]
 
 # Cobalt bug: b/479816505.
-wpt_internal/cobalt/h5vcc-updater/* [ Failure ]
+wpt_internal/cobalt/h5vcc-updater/* [ Crash Failure ]

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getAllowSelfSignedPackages.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getAllowSelfSignedPackages.https.any.js
@@ -1,0 +1,14 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  mockH5vccUpdater.setMockAllowSelfSignedPackages(true);
+  const result = await window.h5vcc.updater.getAllowSelfSignedPackages();
+  assert_true(result);
+}, 'exercises H5vccUpdater.getAllowSelfSignedPackages()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this platform.', window.h5vcc.updater.getAllowSelfSignedPackages());
+}, 'getAllowSelfSignedPackages() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getInstallationIndex.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getInstallationIndex.https.any.js
@@ -1,0 +1,15 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  const test_index = 42;
+  mockH5vccUpdater.setMockInstallationIndex(test_index);
+  const result = await window.h5vcc.updater.getInstallationIndex();
+  assert_equals(result, test_index);
+}, 'exercises H5vccUpdater.getInstallationIndex()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this platform.', window.h5vcc.updater.getInstallationIndex());
+}, 'getInstallationIndex() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getLibrarySha256.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getLibrarySha256.https.any.js
@@ -1,0 +1,16 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  const test_index = 1;
+  const test_sha256 = "test_sha256";
+  mockH5vccUpdater.setMockLibrarySha256(test_index, test_sha256);
+  const result = await window.h5vcc.updater.getLibrarySha256(test_index);
+  assert_equals(result, test_sha256);
+}, 'exercises H5vccUpdater.getLibrarySha256()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this platform.', window.h5vcc.updater.getLibrarySha256(0));
+}, 'getLibrarySha256() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getRequireNetworkEncryption.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getRequireNetworkEncryption.https.any.js
@@ -1,0 +1,14 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  mockH5vccUpdater.setMockRequireNetworkEncryption(true);
+  const result = await window.h5vcc.updater.getRequireNetworkEncryption();
+  assert_true(result);
+}, 'exercises H5vccUpdater.getRequireNetworkEncryption()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this platform.', window.h5vcc.updater.getRequireNetworkEncryption());
+}, 'getRequireNetworkEncryption() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getUpdateServerUrl.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getUpdateServerUrl.https.any.js
@@ -3,11 +3,13 @@
 // META: script=resources/automation.js
 
 h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
-  assert_implements(window.h5vcc, "window.h5vcc not supported");
-  assert_implements(window.h5vcc.updater, "window.h5vcc.updater not supported");
+  const test_url = "https://example.com/update";
+  mockH5vccUpdater.setMockUpdateServerUrl(test_url);
+  const result = await window.h5vcc.updater.getUpdateServerUrl();
+  assert_equals(result, test_url);
+}, 'exercises H5vccUpdater.getUpdateServerUrl()');
 
-  const expected = 'test_url';
-  mockH5vccUpdater.stubGetUpdateServerUrl(expected);
-  let actual = await window.h5vcc.updater.getUpdateServerUrl();
-  assert_equals(actual, expected);
-}, 'H5vccUpdater.getUpdateServerUrl() returns the URL set in the mock.');
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this platform.', window.h5vcc.updater.getUpdateServerUrl());
+}, 'getUpdateServerUrl() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getUpdateStatus.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getUpdateStatus.https.any.js
@@ -1,0 +1,15 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  const test_status = "test_status";
+  mockH5vccUpdater.setMockUpdateStatus(test_status);
+  const result = await window.h5vcc.updater.getUpdateStatus();
+  assert_equals(result, test_status);
+}, 'exercises H5vccUpdater.getUpdateStatus()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this platform.', window.h5vcc.updater.getUpdateStatus());
+}, 'getUpdateStatus() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getUpdaterChannel.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-getUpdaterChannel.https.any.js
@@ -1,0 +1,15 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  const test_channel = "test_channel";
+  mockH5vccUpdater.setUpdaterChannel(test_channel);
+  const result = await window.h5vcc.updater.getUpdaterChannel();
+  assert_equals(result, test_channel);
+}, 'exercises H5vccUpdater.getUpdaterChannel()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this platform.', window.h5vcc.updater.getUpdaterChannel());
+}, 'getUpdaterChannel() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-setAllowSelfSignedPackages.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-setAllowSelfSignedPackages.https.any.js
@@ -1,0 +1,15 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  await window.h5vcc.updater.setAllowSelfSignedPackages(true);
+  const result = await window.h5vcc.updater.getAllowSelfSignedPackages();
+  assert_true(result);
+}, 'exercises H5vccUpdater.setAllowSelfSignedPackages()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this build configuration. Enabled for sideloading only.',
+    window.h5vcc.updater.setAllowSelfSignedPackages(true));
+}, 'setAllowSelfSignedPackages() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-setRequireNetworkEncryption.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-setRequireNetworkEncryption.https.any.js
@@ -1,0 +1,15 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  await window.h5vcc.updater.setRequireNetworkEncryption(true);
+  const result = await window.h5vcc.updater.getRequireNetworkEncryption();
+  assert_true(result);
+}, 'exercises H5vccUpdater.setRequireNetworkEncryption()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this build configuration. Enabled for sideloading only.',
+    window.h5vcc.updater.setRequireNetworkEncryption(true));
+}, 'setRequireNetworkEncryption() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-setUpdateServerUrl.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-setUpdateServerUrl.https.any.js
@@ -1,0 +1,16 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  const test_url = "https://new.example.com/update";
+  await window.h5vcc.updater.setUpdateServerUrl(test_url);
+  const result = await window.h5vcc.updater.getUpdateServerUrl();
+  assert_equals(result, test_url);
+}, 'exercises H5vccUpdater.setUpdateServerUrl()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this build configuration. Enabled for sideloading only.',
+    window.h5vcc.updater.setUpdateServerUrl("https://example.com"));
+}, 'setUpdateServerUrl() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-setUpdaterChannel.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/h5vcc-updater-setUpdaterChannel.https.any.js
@@ -1,0 +1,15 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_updater_tests(async (t, mockH5vccUpdater) => {
+  const test_channel = "new_test_channel";
+  await window.h5vcc.updater.setUpdaterChannel(test_channel);
+  const result = await window.h5vcc.updater.getUpdaterChannel();
+  assert_equals(result, test_channel);
+}, 'exercises H5vccUpdater.setUpdaterChannel()');
+
+h5vcc_updater_mojo_disconnection_tests(async (t) => {
+  return promise_rejects_exactly(
+    t, 'API not supported for this platform.', window.h5vcc.updater.setUpdaterChannel("channel"));
+}, 'setUpdaterChannel() rejects when unimplemented due to pipe closure');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/resources/automation.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/resources/automation.js
@@ -1,18 +1,19 @@
 'use strict';
 
-
 let mockH5vccUpdater = undefined;
 
 function h5vcc_updater_tests(func, name, properties) {
-  promise_test(async t => {
+  promise_test(async (test) => {
+    // Wait for any previous connection error to propagate.
+    await new Promise(resolve => test.step_timeout(resolve, 200));
+
+    assert_implements(window.h5vcc.updater,
+                      'missing window.h5vcc.updater');
     if (mockH5vccUpdater === undefined) {
-      if (isChromiumBased) {
-        const mocks = await import('./mock-h5vcc-updater.js');
-        mockH5vccUpdater = mocks.mockH5vccUpdater;
-      }
+      const mocks = await import('./mock-h5vcc-updater.js');
+      mockH5vccUpdater = mocks.mockH5vccUpdater;
     }
-    assert_implements(
-        mockH5vccUpdater, 'missing mockH5vccUpdater after initialization');
+    assert_implements(mockH5vccUpdater, 'missing mockH5vccUpdater');
 
     mockH5vccUpdater.start();
     try {
@@ -20,6 +21,29 @@ function h5vcc_updater_tests(func, name, properties) {
     } finally {
       mockH5vccUpdater.stop();
       mockH5vccUpdater.reset();
+    }
+  }, name, properties);
+}
+
+function h5vcc_updater_mojo_disconnection_tests(func, name, properties) {
+  promise_test(async (test) => {
+    const { H5vccUpdater, H5vccUpdaterSideloading } = await import(
+      '/gen/cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom.m.js');
+    let interceptor =
+      new MojoInterfaceInterceptor(H5vccUpdater.$interfaceName);
+    interceptor.oninterfacerequest = e => e.handle.close();
+    interceptor.start();
+
+    let sideloading_interceptor =
+      new MojoInterfaceInterceptor(H5vccUpdaterSideloading.$interfaceName);
+    sideloading_interceptor.oninterfacerequest = e => e.handle.close();
+    sideloading_interceptor.start();
+
+    try {
+      await func(test, interceptor);
+    } finally {
+      interceptor.stop();
+      sideloading_interceptor.stop();
     }
   }, name, properties);
 }

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/resources/mock-h5vcc-updater.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-updater/resources/mock-h5vcc-updater.js
@@ -1,47 +1,148 @@
 import {
-  H5vccUpdater, H5vccUpdaterReceiver
+  H5vccUpdater, H5vccUpdaterReceiver,
+  H5vccUpdaterSideloading, H5vccUpdaterSideloadingReceiver
 } from '/gen/cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom.m.js';
 
-
-// Implementation of h5vcc_updater.mojom.H5vccUpdater.
+// Implementation of h5vcc_updater.mojom.H5vccUpdater and H5vccUpdaterSideloading
 class MockH5vccUpdater {
   constructor() {
     this.interceptor_ =
       new MojoInterfaceInterceptor(H5vccUpdater.$interfaceName);
     this.interceptor_.oninterfacerequest = e => this.bind(e.handle);
+
+    this.sideloading_interceptor_ =
+      new MojoInterfaceInterceptor(H5vccUpdaterSideloading.$interfaceName);
+    this.sideloading_interceptor_.oninterfacerequest = e => this.bindSideloading(e.handle);
+
     this.receiver_ = new H5vccUpdaterReceiver(this);
+    this.sideloading_receiver_ = new H5vccUpdaterSideloadingReceiver(this);
 
-    this.stub_result_ = new Map();
+    this.reset();
   }
-
-  STUB_KEY_UPDATE_SERVER_URL = 'testUpdateServerUrl';
 
   start() {
     this.interceptor_.start();
+    this.sideloading_interceptor_.start();
   }
 
   stop() {
     this.interceptor_.stop();
+    this.sideloading_interceptor_.stop();
+  }
+
+  reset() {
+    this.called_reset_installations_ = false;
+    this.updater_channel_ = "";
+    this.update_status_ = "";
+    this.installation_index_ = 0;
+    this.library_sha256_ = new Map();
+    this.allow_self_signed_packages_ = false;
+    this.update_server_url_ = "";
+    this.require_network_encryption_ = false;
+    if (this.receiver_) {
+        this.receiver_.$.close();
+    }
+    if (this.sideloading_receiver_) {
+        this.sideloading_receiver_.$.close();
+    }
   }
 
   bind(handle) {
     this.receiver_.$.bindHandle(handle);
   }
 
-  reset() {
-    this.stub_result_ = new Map();
+  bindSideloading(handle) {
+    this.sideloading_receiver_.$.bindHandle(handle);
   }
 
-  stubResult(key, value) {
-    this.stub_result_.set(key, value);
+  hasCalledResetInstallations() {
+    return this.called_reset_installations_;
   }
 
-  stubGetUpdateServerUrl(updateServerUrl) {
-    this.stubResult(this.STUB_KEY_UPDATE_SERVER_URL, updateServerUrl);
+  async resetInstallations() {
+    this.called_reset_installations_ = true;
   }
 
-  exit() {
-    incrementExitCallCount();
+  // --- H5vccUpdater Interface Methods ---
+
+  async setUpdaterChannel(channel) {
+    this.updater_channel_ = channel;
+  }
+
+  async getUpdaterChannel() {
+    return { channel: this.updater_channel_ };
+  }
+
+  setMockUpdateStatus(status) {
+    this.update_status_ = status;
+  }
+
+  async getUpdateStatus() {
+    return { status: this.update_status_ };
+  }
+
+  setMockInstallationIndex(index) {
+    this.installation_index_ = index;
+  }
+
+  async getInstallationIndex() {
+    return { index: this.installation_index_ };
+  }
+
+  setMockAllowSelfSignedPackages(allow) {
+    this.allow_self_signed_packages_ = allow;
+  }
+
+  async getAllowSelfSignedPackages() {
+    return {
+        allowSelfSignedPackages: this.allow_self_signed_packages_,
+        allow_self_signed_packages: this.allow_self_signed_packages_
+    };
+  }
+
+  setMockUpdateServerUrl(url) {
+    this.update_server_url_ = url;
+  }
+
+  async getUpdateServerUrl() {
+    return {
+        updateServerUrl: this.update_server_url_,
+        update_server_url: this.update_server_url_
+    };
+  }
+
+  setMockRequireNetworkEncryption(require) {
+    this.require_network_encryption_ = require;
+  }
+
+  async getRequireNetworkEncryption() {
+    return {
+        requireNetworkEncryption: this.require_network_encryption_,
+        require_network_encryption: this.require_network_encryption_
+    };
+  }
+
+  setMockLibrarySha256(index, sha256) {
+    this.library_sha256_.set(index, sha256);
+  }
+
+  async getLibrarySha256(index) {
+    const sha256 = this.library_sha256_.get(index) || "";
+    return { sha256: sha256 };
+  }
+
+  // --- H5vccUpdaterSideloading Interface Methods ---
+
+  async setAllowSelfSignedPackages(allow) {
+    this.allow_self_signed_packages_ = allow;
+  }
+
+  async setUpdateServerUrl(url) {
+    this.update_server_url_ = url;
+  }
+
+  async setRequireNetworkEncryption(require) {
+    this.require_network_encryption_ = require;
   }
 }
 


### PR DESCRIPTION
Comprehensive web platform tests are added for all H5vccUpdater
methods, including specific tests that verify promise rejection upon
Mojo connection errors.

Bug: 454440974
Bug: 515122610