### PR TITLE
Add Finch config related UMAs

### DIFF
--- a/cobalt/browser/experiments/experiment_config_manager.cc
+++ b/cobalt/browser/experiments/experiment_config_manager.cc
@@ -150,9 +150,26 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
                     kDefaultCrashStreakSafeConfigThreshold,
                 "Threshold to use an empty experiment config should be larger "
                 "than to use the safe one.");
+
+  // Helper lambda to log UMA metrics and return the config type.
+  auto log_and_return = [](ExperimentConfigType type,
+                           bool discarded_expiration) {
+    bool config_loaded = (type == ExperimentConfigType::kRegularConfig ||
+                          type == ExperimentConfigType::kSafeConfig);
+    bool safe_mode_triggered = (type == ExperimentConfigType::kSafeConfig);
+
+    UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.ConfigLoaded", config_loaded);
+    UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.SafeModeTriggered",
+                          safe_mode_triggered);
+    UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.ConfigDiscarded.Expiration",
+                          discarded_expiration);
+
+    return type;
+  };
+
   if (num_crashes >= crash_streak_empty_config_threshold) {
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    return ExperimentConfigType::kEmptyConfig;
+    return log_and_return(ExperimentConfigType::kEmptyConfig, false);
   }
 
   ExperimentConfigType config_type;
@@ -177,7 +194,7 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
   // treat it as an empty config.
   if (HasConfigExpired(experiment_config_) && expiration_enabled) {
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    return ExperimentConfigType::kEmptyConfig;
+    return log_and_return(ExperimentConfigType::kEmptyConfig, true);
   }
 
   // Check if a rollback happened. If so, apply the empty config.
@@ -193,11 +210,11 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
           VersionComparisonResult::kGreaterThan) {
     UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.RollbackDetected", true);
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    return ExperimentConfigType::kEmptyConfig;
+    return log_and_return(ExperimentConfigType::kEmptyConfig, false);
   }
 
   cached_config_type_ = config_type;
-  return config_type;
+  return log_and_return(config_type, false);
 }
 
 void ExperimentConfigManager::StoreSafeConfig() {

--- a/cobalt/browser/experiments/experiment_config_manager.cc
+++ b/cobalt/browser/experiments/experiment_config_manager.cc
@@ -17,7 +17,7 @@
 #include <vector>
 
 #include "base/logging.h"
-#include "base/metrics/histogram_macros.h"
+#include "base/metrics/histogram_functions.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
 #include "cobalt/browser/constants/cobalt_experiment_names.h"
@@ -51,8 +51,8 @@ bool HasConfigExpired(PrefService* experiment_prefs) {
   // compatibility and safety on first run, we treat it as valid
   if (!experiment_prefs->HasPrefPath(
           variations::prefs::kVariationsLastFetchTime)) {
-    UMA_HISTOGRAM_ENUMERATION("Cobalt.Finch.ConfigState",
-                              VariationsConfigState::kMissingTimestamp);
+    base::UmaHistogramEnumeration("Cobalt.Finch.ConfigState",
+                                  VariationsConfigState::kMissingTimestamp);
     return false;
   }
 
@@ -60,8 +60,8 @@ bool HasConfigExpired(PrefService* experiment_prefs) {
       experiment_prefs->GetTime(variations::prefs::kVariationsLastFetchTime);
   base::TimeDelta config_age = base::Time::Now() - fetch_time;
 
-  UMA_HISTOGRAM_CUSTOM_COUNTS("Cobalt.Finch.ConfigAgeInDays",
-                              config_age.InDays(), 1, 90, 50);
+  base::UmaHistogramCustomCounts("Cobalt.Finch.ConfigAgeInDays",
+                                 config_age.InDays(), 1, 90, 50);
 
   // Get the expiration threshold from the server config.
   const int expiration_threshold_in_days =
@@ -73,13 +73,13 @@ bool HasConfigExpired(PrefService* experiment_prefs) {
       config_age.InDays() > expiration_threshold_in_days) {
     LOG(WARNING) << "Variations config from " << fetch_time
                  << " has expired. Ignoring.";
-    UMA_HISTOGRAM_ENUMERATION("Cobalt.Finch.ConfigState",
-                              VariationsConfigState::kExpired);
+    base::UmaHistogramEnumeration("Cobalt.Finch.ConfigState",
+                                  VariationsConfigState::kExpired);
     return true;
   }
 
-  UMA_HISTOGRAM_ENUMERATION("Cobalt.Finch.ConfigState",
-                            VariationsConfigState::kValid);
+  base::UmaHistogramEnumeration("Cobalt.Finch.ConfigState",
+                                VariationsConfigState::kValid);
   return false;
 }
 
@@ -102,10 +102,10 @@ ExperimentConfigManager::CompareVersions(const std::string& version1,
   int v1_major, v1_minor, v2_major, v2_minor;
   if (!parse_version(version1, &v1_major, &v1_minor) ||
       !parse_version(version2, &v2_major, &v2_minor)) {
-    UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.VersionComparisonIsValid", false);
+    base::UmaHistogramBoolean("Cobalt.Finch.VersionComparisonIsValid", false);
     return VersionComparisonResult::kInvalidFormat;
   }
-  UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.VersionComparisonIsValid", true);
+  base::UmaHistogramBoolean("Cobalt.Finch.VersionComparisonIsValid", true);
 
   if (v1_major != v2_major) {
     return v1_major > v2_major ? VersionComparisonResult::kGreaterThan
@@ -153,23 +153,15 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
 
   // Helper lambda to log UMA metrics and return the config type.
   auto log_and_return = [](ExperimentConfigType type,
-                           bool discarded_expiration) {
-    bool config_loaded = (type == ExperimentConfigType::kRegularConfig ||
-                          type == ExperimentConfigType::kSafeConfig);
-    bool safe_mode_triggered = (type == ExperimentConfigType::kSafeConfig);
-
-    UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.ConfigLoaded", config_loaded);
-    UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.SafeModeTriggered",
-                          safe_mode_triggered);
-    UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.ConfigDiscarded.Expiration",
-                          discarded_expiration);
-
+                           FinchConfigOutcome outcome) {
+    base::UmaHistogramEnumeration("Cobalt.Finch.ConfigOutcome", outcome);
     return type;
   };
 
   if (num_crashes >= crash_streak_empty_config_threshold) {
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    return log_and_return(ExperimentConfigType::kEmptyConfig, false);
+    return log_and_return(ExperimentConfigType::kEmptyConfig,
+                          FinchConfigOutcome::kEmptyConfigCrashStreak);
   }
 
   ExperimentConfigType config_type;
@@ -194,7 +186,8 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
   // treat it as an empty config.
   if (HasConfigExpired(experiment_config_) && expiration_enabled) {
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    return log_and_return(ExperimentConfigType::kEmptyConfig, true);
+    return log_and_return(ExperimentConfigType::kEmptyConfig,
+                          FinchConfigOutcome::kEmptyConfigExpired);
   }
 
   // Check if a rollback happened. If so, apply the empty config.
@@ -208,13 +201,16 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
   if (!recorded_cobalt_version.empty() &&
       CompareVersions(recorded_cobalt_version, COBALT_VERSION) ==
           VersionComparisonResult::kGreaterThan) {
-    UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.RollbackDetected", true);
     cached_config_type_ = ExperimentConfigType::kEmptyConfig;
-    return log_and_return(ExperimentConfigType::kEmptyConfig, false);
+    return log_and_return(ExperimentConfigType::kEmptyConfig,
+                          FinchConfigOutcome::kEmptyConfigRollback);
   }
 
   cached_config_type_ = config_type;
-  return log_and_return(config_type, false);
+  return log_and_return(config_type,
+                        config_type == ExperimentConfigType::kSafeConfig
+                            ? FinchConfigOutcome::kSafeConfig
+                            : FinchConfigOutcome::kRegularConfig);
 }
 
 void ExperimentConfigManager::StoreSafeConfig() {

--- a/cobalt/browser/experiments/experiment_config_manager.h
+++ b/cobalt/browser/experiments/experiment_config_manager.h
@@ -29,6 +29,17 @@ enum class ExperimentConfigType {
   kEmptyConfig,
 };
 
+// These values are persisted to logs. Entries should not be renumbered and
+// numeric values should never be reused.
+enum class FinchConfigOutcome {
+  kRegularConfig = 0,
+  kSafeConfig = 1,
+  kEmptyConfigCrashStreak = 2,
+  kEmptyConfigExpired = 3,
+  kEmptyConfigRollback = 4,
+  kMaxValue = kEmptyConfigRollback
+};
+
 // This class manages the content of the experiment config stored on disk.
 class ExperimentConfigManager {
  public:

--- a/cobalt/browser/experiments/experiment_config_manager_unittest.cc
+++ b/cobalt/browser/experiments/experiment_config_manager_unittest.cc
@@ -532,8 +532,9 @@ TEST_F(ExperimentConfigManagerTest,
   pref_service_->SetString(kExperimentConfigMinVersion, future_version);
   EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
             ExperimentConfigType::kEmptyConfig);
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.RollbackDetected", true,
-                                       1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Finch.ConfigOutcome",
+      static_cast<int>(FinchConfigOutcome::kEmptyConfigRollback), 1);
 }
 
 TEST_F(ExperimentConfigManagerTest,
@@ -688,7 +689,7 @@ TEST_F(ExperimentConfigManagerTest,
             ExperimentConfigType::kEmptyConfig);
 }
 
-TEST_F(ExperimentConfigManagerTest, HistogramsConfigLoadedAndSafeModeRegular) {
+TEST_F(ExperimentConfigManagerTest, HistogramsConfigOutcomeRegular) {
   base::Value::Dict feature_map;
   feature_map.Set(features::kExperimentConfigExpiration.name, true);
   pref_service_->SetDict(kExperimentConfigFeatures, std::move(feature_map));
@@ -703,11 +704,9 @@ TEST_F(ExperimentConfigManagerTest, HistogramsConfigLoadedAndSafeModeRegular) {
   EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
             ExperimentConfigType::kRegularConfig);
 
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.ConfigLoaded", true, 1);
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.SafeModeTriggered", false,
-                                       1);
   histogram_tester_.ExpectUniqueSample(
-      "Cobalt.Finch.ConfigDiscarded.Expiration", false, 1);
+      "Cobalt.Finch.ConfigOutcome",
+      static_cast<int>(FinchConfigOutcome::kRegularConfig), 1);
 }
 
 TEST_F(ExperimentConfigManagerTest, HistogramsSafeModeTriggered) {
@@ -717,11 +716,9 @@ TEST_F(ExperimentConfigManagerTest, HistogramsSafeModeTriggered) {
   EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
             ExperimentConfigType::kSafeConfig);
 
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.ConfigLoaded", true, 1);
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.SafeModeTriggered", true,
-                                       1);
   histogram_tester_.ExpectUniqueSample(
-      "Cobalt.Finch.ConfigDiscarded.Expiration", false, 1);
+      "Cobalt.Finch.ConfigOutcome",
+      static_cast<int>(FinchConfigOutcome::kSafeConfig), 1);
 }
 
 TEST_F(ExperimentConfigManagerTest, HistogramsConfigDiscardedExpiration) {
@@ -739,11 +736,9 @@ TEST_F(ExperimentConfigManagerTest, HistogramsConfigDiscardedExpiration) {
   EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
             ExperimentConfigType::kEmptyConfig);
 
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.ConfigLoaded", false, 1);
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.SafeModeTriggered", false,
-                                       1);
   histogram_tester_.ExpectUniqueSample(
-      "Cobalt.Finch.ConfigDiscarded.Expiration", true, 1);
+      "Cobalt.Finch.ConfigOutcome",
+      static_cast<int>(FinchConfigOutcome::kEmptyConfigExpired), 1);
 }
 
 TEST_F(ExperimentConfigManagerTest, HistogramsConfigDiscardedDowngrade) {
@@ -754,13 +749,9 @@ TEST_F(ExperimentConfigManagerTest, HistogramsConfigDiscardedDowngrade) {
   EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
             ExperimentConfigType::kEmptyConfig);
 
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.ConfigLoaded", false, 1);
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.SafeModeTriggered", false,
-                                       1);
-  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.RollbackDetected", true,
-                                       1);
   histogram_tester_.ExpectUniqueSample(
-      "Cobalt.Finch.ConfigDiscarded.Expiration", false, 1);
+      "Cobalt.Finch.ConfigOutcome",
+      static_cast<int>(FinchConfigOutcome::kEmptyConfigRollback), 1);
 }
 
 }  // namespace cobalt

--- a/cobalt/browser/experiments/experiment_config_manager_unittest.cc
+++ b/cobalt/browser/experiments/experiment_config_manager_unittest.cc
@@ -688,4 +688,79 @@ TEST_F(ExperimentConfigManagerTest,
             ExperimentConfigType::kEmptyConfig);
 }
 
+TEST_F(ExperimentConfigManagerTest, HistogramsConfigLoadedAndSafeModeRegular) {
+  base::Value::Dict feature_map;
+  feature_map.Set(features::kExperimentConfigExpiration.name, true);
+  pref_service_->SetDict(kExperimentConfigFeatures, std::move(feature_map));
+
+  base::Value::Dict finch_params;
+  finch_params.Set("experiment_expiration_threshold_days", 30);
+  pref_service_->SetDict(kFinchParameters, std::move(finch_params));
+
+  pref_service_->SetTime(variations::prefs::kVariationsLastFetchTime,
+                         base::Time::Now() - base::Days(10));
+
+  EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
+            ExperimentConfigType::kRegularConfig);
+
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.ConfigLoaded", true, 1);
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.SafeModeTriggered", false,
+                                       1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Finch.ConfigDiscarded.Expiration", false, 1);
+}
+
+TEST_F(ExperimentConfigManagerTest, HistogramsSafeModeTriggered) {
+  metrics_pref_service_->SetInteger(variations::prefs::kVariationsCrashStreak,
+                                    kDefaultCrashStreakSafeConfigThreshold);
+
+  EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
+            ExperimentConfigType::kSafeConfig);
+
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.ConfigLoaded", true, 1);
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.SafeModeTriggered", true,
+                                       1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Finch.ConfigDiscarded.Expiration", false, 1);
+}
+
+TEST_F(ExperimentConfigManagerTest, HistogramsConfigDiscardedExpiration) {
+  base::Value::Dict feature_map;
+  feature_map.Set(features::kExperimentConfigExpiration.name, true);
+  pref_service_->SetDict(kExperimentConfigFeatures, std::move(feature_map));
+
+  base::Value::Dict finch_params;
+  finch_params.Set("experiment_expiration_threshold_days", 30);
+  pref_service_->SetDict(kFinchParameters, std::move(finch_params));
+
+  pref_service_->SetTime(variations::prefs::kVariationsLastFetchTime,
+                         base::Time::Now() - base::Days(31));
+
+  EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
+            ExperimentConfigType::kEmptyConfig);
+
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.ConfigLoaded", false, 1);
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.SafeModeTriggered", false,
+                                       1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Finch.ConfigDiscarded.Expiration", true, 1);
+}
+
+TEST_F(ExperimentConfigManagerTest, HistogramsConfigDiscardedDowngrade) {
+  metrics_pref_service_->SetInteger(variations::prefs::kVariationsCrashStreak,
+                                    0);
+  pref_service_->SetString(kExperimentConfigMinVersion, "99.android.0");
+
+  EXPECT_EQ(experiment_config_manager_->GetExperimentConfigType(),
+            ExperimentConfigType::kEmptyConfig);
+
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.ConfigLoaded", false, 1);
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.SafeModeTriggered", false,
+                                       1);
+  histogram_tester_.ExpectUniqueSample("Cobalt.Finch.RollbackDetected", true,
+                                       1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Finch.ConfigDiscarded.Expiration", false, 1);
+}
+
 }  // namespace cobalt

--- a/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
+++ b/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
@@ -18,7 +18,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/metrics/field_trial_params.h"
-#include "base/metrics/histogram_macros.h"
+#include "base/metrics/histogram_functions.h"
 #include "base/time/time.h"
 #include "build/build_config.h"
 #include "cobalt/browser/constants/cobalt_experiment_names.h"
@@ -104,12 +104,11 @@ void H5vccExperimentsImpl::SetExperimentState(
     base::TimeDelta time_since_last_write =
         base::Time::Now() - previous_fetch_time;
     if (time_since_last_write.is_positive()) {
-      UMA_HISTOGRAM_CUSTOM_COUNTS("Cobalt.Finch.TimeBetweenWritesInHours",
-                                  time_since_last_write.InHours(), 1, 24 * 30,
-                                  50);
+      base::UmaHistogramCustomTimes("Cobalt.Finch.TimeBetweenWrites",
+                                    time_since_last_write, base::Hours(1),
+                                    base::Days(30), 50);
     }
   }
-  UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.WriteToStorage", true);
 
   experiment_config_ptr->SetInt64(variations::prefs::kVariationsLastFetchTime,
                                   base::Time::Now().ToInternalValue());

--- a/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
+++ b/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
@@ -18,6 +18,7 @@
 #include "base/functional/bind.h"
 #include "base/functional/callback.h"
 #include "base/metrics/field_trial_params.h"
+#include "base/metrics/histogram_macros.h"
 #include "base/time/time.h"
 #include "build/build_config.h"
 #include "cobalt/browser/constants/cobalt_experiment_names.h"
@@ -94,6 +95,21 @@ void H5vccExperimentsImpl::SetExperimentState(
       ->GetMetricsStateManager()
       ->clean_exit_beacon()
       ->WriteBeaconValue(true);
+
+  int64_t previous_fetch_time_internal = experiment_config_ptr->GetInt64(
+      variations::prefs::kVariationsLastFetchTime);
+  if (previous_fetch_time_internal > 0) {
+    base::Time previous_fetch_time =
+        base::Time::FromInternalValue(previous_fetch_time_internal);
+    base::TimeDelta time_since_last_write =
+        base::Time::Now() - previous_fetch_time;
+    if (time_since_last_write.is_positive()) {
+      UMA_HISTOGRAM_CUSTOM_COUNTS("Cobalt.Finch.TimeBetweenWritesInHours",
+                                  time_since_last_write.InHours(), 1, 24 * 30,
+                                  50);
+    }
+  }
+  UMA_HISTOGRAM_BOOLEAN("Cobalt.Finch.WriteToStorage", true);
 
   experiment_config_ptr->SetInt64(variations::prefs::kVariationsLastFetchTime,
                                   base::Time::Now().ToInternalValue());

--- a/tools/metrics/histograms/metadata/cobalt/enums.xml
+++ b/tools/metrics/histograms/metadata/cobalt/enums.xml
@@ -117,6 +117,14 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="2" label="Config is missing timestamp"/>
 </enum>
 
+<enum name="FinchConfigOutcome">
+  <int value="0" label="Regular config loaded"/>
+  <int value="1" label="Safe config loaded"/>
+  <int value="2" label="Empty config loaded due to crash streak"/>
+  <int value="3" label="Empty config loaded due to expiration"/>
+  <int value="4" label="Empty config loaded due to rollback"/>
+</enum>
+
 </enums>
 
 </histogram-configuration>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -63,6 +63,15 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.Finch.ConfigOutcome" enum="FinchConfigOutcome"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the outcome of variations experiment configuration loading during
+    startup.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.Finch.ConfigState" enum="VariationsConfigState"
     expires_after="never">
   <owner>yijiazhang@google.com</owner>
@@ -72,13 +81,12 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
-<histogram name="Cobalt.Finch.RollbackDetected" enum="Boolean"
+<histogram name="Cobalt.Finch.TimeBetweenWrites" units="ms"
     expires_after="never">
   <owner>yijiazhang@google.com</owner>
   <summary>
-    Records when a rollback is detected and prevented. This happens when the
-    cobalt version recorded for a previous Finch config is greater than the
-    current version of the Cobalt binary.
+    Records the duration since the last time the variations experiment configuration
+    was written to persistent storage.
   </summary>
 </histogram>
 
@@ -91,6 +99,7 @@ Always run the pretty print utility on this file after editing:
     received.
   </summary>
 </histogram>
+
 
 <histogram name="Cobalt.LoaderApp.ElfDecompressionDuration" units="ms"
     expires_after="never">


### PR DESCRIPTION
Add several UMA histograms to track the status and lifecycle of Finch
experiment configurations. These metrics help monitor if configurations
are successfully loaded, when safe mode is activated, and the reasons
for discarding configurations, such as expiration or version rollbacks.

Furthermore, these changes include metrics to track when configurations
are written to storage and the time intervals between these writes to
improve observability of the experiment system performance.

Bug: 515520976