### PR TITLE
cleanup: De-templatize media wrapper classes

### DIFF
--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -29,8 +29,7 @@ namespace starboard {
 
 namespace {
 
-template <typename StreamInfo>
-void Assign(const StreamInfo& source, AudioStreamInfo* dest) {
+void Assign(const SbMediaAudioStreamInfo& source, AudioStreamInfo* dest) {
   SB_DCHECK(dest);
 
   if (source.audio_specific_config_size > 0) {
@@ -57,8 +56,7 @@ void Assign(const StreamInfo& source, AudioStreamInfo* dest) {
       config, config + source.audio_specific_config_size);
 }
 
-template <typename StreamInfo>
-void Assign(const StreamInfo& source, VideoStreamInfo* dest) {
+void Assign(const SbMediaVideoStreamInfo& source, VideoStreamInfo* dest) {
   SB_DCHECK(dest);
 
   dest->codec = source.codec;
@@ -78,8 +76,7 @@ void Assign(const StreamInfo& source, VideoStreamInfo* dest) {
   dest->color_metadata = source.color_metadata;
 }
 
-template <typename StreamInfo>
-void Assign(const AudioStreamInfo& source, StreamInfo* dest) {
+void Assign(const AudioStreamInfo& source, SbMediaAudioStreamInfo* dest) {
   SB_DCHECK(dest);
 
   *dest = {};
@@ -96,8 +93,7 @@ void Assign(const AudioStreamInfo& source, StreamInfo* dest) {
   }
 }
 
-template <typename StreamInfo>
-void Assign(const VideoStreamInfo& source, StreamInfo* dest) {
+void Assign(const VideoStreamInfo& source, SbMediaVideoStreamInfo* dest) {
   SB_DCHECK(dest);
 
   *dest = {};

--- a/starboard/shared/starboard/media/media_util.h
+++ b/starboard/shared/starboard/media/media_util.h
@@ -32,10 +32,7 @@ namespace starboard {
 // of all its pointer members.
 struct AudioStreamInfo {
   AudioStreamInfo() = default;
-  template <typename StreamInfo>
-  explicit AudioStreamInfo(const StreamInfo& that) {
-    *this = that;
-  }
+  explicit AudioStreamInfo(const SbMediaAudioStreamInfo& that) { *this = that; }
   AudioStreamInfo& operator=(const SbMediaAudioStreamInfo& that);
 
   void ConvertTo(SbMediaAudioStreamInfo* audio_stream_info) const;
@@ -62,10 +59,7 @@ std::ostream& operator<<(std::ostream& os, const AudioStreamInfo& info);
 // of all its pointer members.
 struct AudioSampleInfo {
   AudioSampleInfo() = default;
-  template <typename SampleInfo>
-  explicit AudioSampleInfo(const SampleInfo& that) {
-    *this = that;
-  }
+  explicit AudioSampleInfo(const SbMediaAudioSampleInfo& that) { *this = that; }
   AudioSampleInfo& operator=(const SbMediaAudioSampleInfo& that);
 
   void ConvertTo(SbMediaAudioSampleInfo* audio_sample_info) const;
@@ -84,10 +78,7 @@ struct AudioSampleInfo {
 // of all its pointer members.
 struct VideoStreamInfo {
   VideoStreamInfo() = default;
-  template <typename StreamInfo>
-  explicit VideoStreamInfo(const StreamInfo& that) {
-    *this = that;
-  }
+  explicit VideoStreamInfo(const SbMediaVideoStreamInfo& that) { *this = that; }
   VideoStreamInfo& operator=(const SbMediaVideoStreamInfo& that);
 
   void ConvertTo(SbMediaVideoStreamInfo* video_stream_info) const;
@@ -111,10 +102,7 @@ bool operator!=(const VideoStreamInfo& left, const VideoStreamInfo& right);
 // of all its pointer members.
 struct VideoSampleInfo {
   VideoSampleInfo() = default;
-  template <typename SampleInfo>
-  explicit VideoSampleInfo(const SampleInfo& that) {
-    *this = that;
-  }
+  explicit VideoSampleInfo(const SbMediaVideoSampleInfo& that) { *this = that; }
   VideoSampleInfo& operator=(const SbMediaVideoSampleInfo& that);
 
   void ConvertTo(SbMediaVideoSampleInfo* video_sample_info) const;

--- a/starboard/shared/starboard/player/input_buffer_internal.cc
+++ b/starboard/shared/starboard/player/input_buffer_internal.cc
@@ -26,6 +26,39 @@
 
 namespace starboard {
 
+InputBuffer::InputBuffer(SbPlayerDeallocateSampleFunc deallocate_sample_func,
+                         SbPlayer player,
+                         void* context,
+                         const SbPlayerSampleInfo& sample_info)
+    : deallocate_sample_func_(deallocate_sample_func),
+      player_(player),
+      context_(context),
+      sample_type_(sample_info.type),
+      data_(static_cast<const uint8_t*>(sample_info.buffer)),
+      size_(sample_info.buffer_size),
+      timestamp_(sample_info.timestamp) {
+  SB_DCHECK(deallocate_sample_func);
+
+  if (sample_type_ == kSbMediaTypeAudio) {
+    audio_sample_info_ = sample_info.audio_sample_info;
+  } else {
+    SB_DCHECK_EQ(sample_type_, kSbMediaTypeVideo);
+    video_sample_info_ = sample_info.video_sample_info;
+  }
+  TryToAssignDrmSampleInfo(sample_info.drm_info);
+  if (sample_info.side_data_count > 0) {
+    SB_DCHECK_EQ(sample_info.side_data_count, 1);
+    SB_DCHECK(sample_info.side_data);
+    SB_DCHECK_EQ(sample_info.side_data->type, kMatroskaBlockAdditional);
+    SB_DCHECK(sample_info.side_data->data);
+    // Make a copy anyway as it is possible to release |data_| earlier in
+    // SetDecryptedContent().
+    side_data_.assign(
+        sample_info.side_data->data,
+        sample_info.side_data->data + sample_info.side_data->size);
+  }
+}
+
 InputBuffer::~InputBuffer() {
   DeallocateSampleBuffer(data_);
 }

--- a/starboard/shared/starboard/player/input_buffer_internal.h
+++ b/starboard/shared/starboard/player/input_buffer_internal.h
@@ -32,11 +32,10 @@ namespace starboard {
 // This class encapsulate a media buffer.
 class InputBuffer : public RefCountedThreadSafe<InputBuffer> {
  public:
-  template <typename SampleInfo>
   InputBuffer(SbPlayerDeallocateSampleFunc deallocate_sample_func,
               SbPlayer player,
               void* context,
-              const SampleInfo& sample_info);
+              const SbPlayerSampleInfo& sample_info);
 
   ~InputBuffer();
 
@@ -99,41 +98,6 @@ class InputBuffer : public RefCountedThreadSafe<InputBuffer> {
 };
 
 using InputBuffers = std::vector<scoped_refptr<InputBuffer>>;
-
-template <typename SampleInfo>
-InputBuffer::InputBuffer(SbPlayerDeallocateSampleFunc deallocate_sample_func,
-                         SbPlayer player,
-                         void* context,
-                         const SampleInfo& sample_info)
-    : deallocate_sample_func_(deallocate_sample_func),
-      player_(player),
-      context_(context),
-      sample_type_(sample_info.type),
-      data_(static_cast<const uint8_t*>(sample_info.buffer)),
-      size_(sample_info.buffer_size),
-      timestamp_(sample_info.timestamp) {
-  SB_DCHECK(deallocate_sample_func);
-
-  if (sample_type_ == kSbMediaTypeAudio) {
-    audio_sample_info_ = sample_info.audio_sample_info;
-  } else {
-    SB_DCHECK_EQ(sample_type_, kSbMediaTypeVideo);
-    video_sample_info_ = sample_info.video_sample_info;
-  }
-  TryToAssignDrmSampleInfo(sample_info.drm_info);
-  if (sample_info.side_data_count > 0) {
-    SB_DCHECK_EQ(sample_info.side_data_count, 1);
-    SB_DCHECK(sample_info.side_data);
-    SB_DCHECK_EQ(sample_info.side_data->type, kMatroskaBlockAdditional);
-    SB_DCHECK(sample_info.side_data->data);
-    // Make a copy anyway as it is possible to release |data_| earlier in
-    // SetDecryptedContent().
-    side_data_.assign(
-        sample_info.side_data->data,
-        sample_info.side_data->data + sample_info.side_data->size);
-  }
-}
-
 }  // namespace starboard
 
 #endif  // STARBOARD_SHARED_STARBOARD_PLAYER_INPUT_BUFFER_INTERNAL_H_


### PR DESCRIPTION
De-templatize AudioStreamInfo, AudioSampleInfo, VideoStreamInfo, VideoSampleInfo, and InputBuffer constructors and helper functions to directly use concrete Starboard structures since historical extension structures are no longer supported.

Bug: 276483058