### PR TITLE
android: Fix crash in ReleaseInputStream

### DIFF
--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -918,8 +918,9 @@ void AudioManagerAndroid::PreStartStream(
   }
 
   // Release the stream outside the lock to avoid deadlock, as
-  // ReleaseInputStream also acquires pre_started_streams_lock_.
-  ReleaseInputStream(stream);
+  // Close() eventually calls ReleaseInputStream which acquires
+  // pre_started_streams_lock_.
+  stream->Close();
 }
 
 AudioManagerAndroid::PreStartedEntry::PreStartedEntry() = default;


### PR DESCRIPTION
Update AudioManagerAndroid to call stream->Close() instead of
ReleaseInputStream() directly. This prevents a potential deadlock or
crash, as Close() handles the necessary internal cleanup and locking
logic required to safely release the input stream.

This is introduced by https://github.com/youtube/cobalt/pull/9978.

Issue: 517599157