### PR TITLE
android: Always resample audio samples to float

### DIFF
--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -578,13 +578,17 @@ void AudioRendererPcm::OnFirstOutput(
   buffered_frames_to_start_ = std::min(
       destination_sample_rate / 5, max_cached_frames_ - min_frames_per_append_);
 
+  // |time_stretcher_| only supports kSbMediaAudioSampleTypeFloat32 and
+  // kSbMediaAudioFrameStorageTypeInterleaved, so we resample the audio to that
+  // format to avoid unnecessary extra conversion.
   if (decoded_sample_rate != destination_sample_rate ||
-      decoded_sample_type != sink_sample_type_ ||
+      decoded_sample_type != kSbMediaAudioSampleTypeFloat32 ||
       decoded_storage_type != kSbMediaAudioFrameStorageTypeInterleaved) {
     resampler_ = AudioResampler::Create(
         decoded_sample_type, decoded_storage_type, decoded_sample_rate,
-        sink_sample_type_, kSbMediaAudioFrameStorageTypeInterleaved,
-        destination_sample_rate, channels_);
+        kSbMediaAudioSampleTypeFloat32,
+        kSbMediaAudioFrameStorageTypeInterleaved, destination_sample_rate,
+        channels_);
     SB_DCHECK(resampler_);
   } else {
     resampler_.reset(new IdentityAudioResampler);


### PR DESCRIPTION
The AudioTimeStretcher component requires audio data to be in a
float32 interleaved format. This update ensures that the audio
renderer always resamples decoded audio to this format, which
prevents compatibility issues and eliminates the need for
additional conversions later in the pipeline.

Bug: 515433551