### PR TITLE
Deprecate kHasPartialAudioFramesSupport

### DIFF
--- a/starboard/CHANGELOG.md
+++ b/starboard/CHANGELOG.md
@@ -9,6 +9,10 @@ since the version previous to it.
 
 ## Version 18
 
+### Removed kHasPartialAudioFramesSupport
+The `kHasPartialAudioFramesSupport` configuration constant has been removed.
+All Starboard implementations are now expected to support partial audio frames.
+
 ### Cleanup starboard/configuration.h
 Removed deprecated feature macros and derived configurations, including
 `SB_STRINGIFY`, `SB_PREFERRED_RGBA_BYTE_ORDER_*`, `SB_RESTRICT`, `SB_LIKELY`,

--- a/starboard/android/shared/configuration_constants.cc
+++ b/starboard/android/shared/configuration_constants.cc
@@ -59,6 +59,3 @@ const uint32_t kSbMaxSystemPathCacheDirectorySize = 24 << 20;  // 24MiB
 // Whether this platform can map executable memory. This is required for
 // platforms that want to JIT.
 SB_EXPORT extern const bool kSbCanMapExecutableMemory = true;
-
-// Platform can support partial audio frames
-SB_EXPORT extern const bool kHasPartialAudioFramesSupport = true;

--- a/starboard/configuration_constants.h
+++ b/starboard/configuration_constants.h
@@ -70,7 +70,4 @@ SB_EXPORT extern const uint32_t kSbMaxSystemPathCacheDirectorySize;
 // platforms that want to JIT.
 SB_EXPORT extern const bool kSbCanMapExecutableMemory;
 
-// Platform can support partial audio frames
-SB_EXPORT extern const bool kHasPartialAudioFramesSupport;
-
 #endif  // STARBOARD_CONFIGURATION_CONSTANTS_H_

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/configuration_constants.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/configuration_constants.cc
@@ -114,7 +114,4 @@ const uint32_t kSbMaxSystemPathCacheDirectorySize = 24 << 20;  // 24MiB
 
 #if SB_API_VERSION >= 16
 SB_EXPORT extern const bool kSbCanMapExecutableMemory = true;
-
-// Platform can support partial audio frames
-SB_EXPORT extern const bool kHasPartialAudioFramesSupport = true;
 #endif

--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -110,7 +110,6 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(kSbMediaMaxVideoBitrateInBitsPerSecond);
   REGISTER_SYMBOL(kSbMemoryPageSize);
   REGISTER_SYMBOL(kSbCanMapExecutableMemory);
-  REGISTER_SYMBOL(kHasPartialAudioFramesSupport);
   REGISTER_SYMBOL(SbAudioSinkCreate);
   REGISTER_SYMBOL(SbAudioSinkDestroy);
   REGISTER_SYMBOL(SbAudioSinkGetMaxChannels);

--- a/starboard/linux/shared/configuration_constants.cc
+++ b/starboard/linux/shared/configuration_constants.cc
@@ -57,6 +57,3 @@ const uint32_t kSbMaxThreads = 90;
 const uint32_t kSbMaxSystemPathCacheDirectorySize = 24 << 20;  // 24MiB
 
 SB_EXPORT extern const bool kSbCanMapExecutableMemory = true;
-
-// Platform can support partial audio frames
-SB_EXPORT extern const bool kHasPartialAudioFramesSupport = true;

--- a/starboard/nplb/player_test_util.cc
+++ b/starboard/nplb/player_test_util.cc
@@ -330,10 +330,6 @@ bool IsOutputModeSupported(SbPlayerOutputMode output_mode,
   return supported;
 }
 
-bool IsPartialAudioSupported() {
-  return kHasPartialAudioFramesSupport;
-}
-
 bool IsAudioPassthroughUsed(const SbPlayerTestConfig& config) {
   const char* audio_dmp_filename = config.audio_filename;
   SbMediaAudioCodec audio_codec = kSbMediaAudioCodecNone;

--- a/starboard/nplb/player_test_util.h
+++ b/starboard/nplb/player_test_util.h
@@ -115,8 +115,6 @@ bool IsOutputModeSupported(SbPlayerOutputMode output_mode,
                            SbMediaVideoCodec video_codec,
                            const char* key_system = "");
 
-bool IsPartialAudioSupported();
-
 bool IsAudioPassthroughUsed(const SbPlayerTestConfig& config);
 
 }  // namespace nplb

--- a/starboard/nplb/player_write_sample_test.cc
+++ b/starboard/nplb/player_write_sample_test.cc
@@ -168,9 +168,6 @@ TEST_P(SbPlayerWriteSampleTest, LimitedAudioInput) {
 }
 
 TEST_P(SbPlayerWriteSampleTest, PartialAudio) {
-  if (!IsPartialAudioSupported()) {
-    GTEST_SKIP() << "The platform doesn't support partial audio.";
-  }
   if (IsAudioPassthroughUsed(GetParam())) {
     GTEST_SKIP() << "The audio passthrough doesn't support partial audio.";
   }
@@ -242,9 +239,6 @@ TEST_P(SbPlayerWriteSampleTest, PartialAudio) {
 }
 
 TEST_P(SbPlayerWriteSampleTest, DiscardAllAudio) {
-  if (!IsPartialAudioSupported()) {
-    GTEST_SKIP() << "The platform doesn't support partial audio.";
-  }
   if (IsAudioPassthroughUsed(GetParam())) {
     GTEST_SKIP() << "The audio passthrough doesn't support partial audio.";
   }

--- a/starboard/raspi/shared/configuration_constants.cc
+++ b/starboard/raspi/shared/configuration_constants.cc
@@ -59,6 +59,3 @@ const uint32_t kSbMaxSystemPathCacheDirectorySize = 24 << 20;  // 24MiB
 // Whether this platform can map executable memory. This is required for
 // platforms that want to JIT.
 SB_EXPORT extern const bool kSbCanMapExecutableMemory = true;
-
-// Platform can support partial audio frames
-SB_EXPORT extern const bool kHasPartialAudioFramesSupport = true;

--- a/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_decoder_test.cc
@@ -189,8 +189,6 @@ class AudioDecoderTest
   void WriteSingleInput(size_t index,
                         int64_t discarded_duration_from_front,
                         int64_t discarded_duration_from_back) {
-    SB_DCHECK(IsPartialAudioSupported());
-
     ASSERT_TRUE(can_accept_more_input_);
     ASSERT_LT(index, dmp_reader_.number_of_audio_buffers());
 
@@ -422,8 +420,6 @@ class AudioDecoderTest
       size_t index,
       int64_t discarded_duration_from_front,
       int64_t discarded_duration_from_back) {
-    SB_DCHECK(IsPartialAudioSupported());
-
     auto input_buffer =
         GetAudioInputBuffer(&dmp_reader_, index, discarded_duration_from_front,
                             discarded_duration_from_back);
@@ -752,10 +748,6 @@ TEST_P(AudioDecoderTest, ContinuedLimitedInput) {
 }
 
 TEST_P(AudioDecoderTest, PartialAudio) {
-  if (!IsPartialAudioSupported()) {
-    return;
-  }
-
   const int max_number_of_input_to_write =
       std::min(7, static_cast<int>(dmp_reader_.number_of_audio_buffers()));
 

--- a/starboard/shared/starboard/player/filter/testing/test_util.cc
+++ b/starboard/shared/starboard/player/filter/testing/test_util.cc
@@ -276,10 +276,6 @@ VideoStreamInfo CreateVideoStreamInfo(SbMediaVideoCodec codec) {
   return video_stream_info;
 }
 
-bool IsPartialAudioSupported() {
-  return true;
-}
-
 scoped_refptr<InputBuffer> GetAudioInputBuffer(VideoDmpReader* dmp_reader,
                                                size_t index) {
   SB_DCHECK(dmp_reader);

--- a/starboard/shared/starboard/player/filter/testing/test_util.h
+++ b/starboard/shared/starboard/player/filter/testing/test_util.h
@@ -65,8 +65,6 @@ bool CreateAudioComponents(
 
 VideoStreamInfo CreateVideoStreamInfo(SbMediaVideoCodec codec);
 
-bool IsPartialAudioSupported();
-
 scoped_refptr<InputBuffer> GetAudioInputBuffer(VideoDmpReader* dmp_reader,
                                                size_t index);
 

--- a/starboard/stub/configuration_constants.cc
+++ b/starboard/stub/configuration_constants.cc
@@ -59,6 +59,3 @@ const uint32_t kSbMaxSystemPathCacheDirectorySize = 24 << 20;  // 24MiB
 // Whether this platform can map executable memory. This is required for
 // platforms that want to JIT.
 SB_EXPORT extern const bool kSbCanMapExecutableMemory = false;
-
-// Platform can support partial audio frames
-SB_EXPORT extern const bool kHasPartialAudioFramesSupport = false;

--- a/starboard/tvos/shared/configuration_constants.cc
+++ b/starboard/tvos/shared/configuration_constants.cc
@@ -59,6 +59,3 @@ const uint32_t kSbMaxSystemPathCacheDirectorySize = 24 << 20;  // 24MiB
 // Whether this platform can map executable memory. This is required for
 // platforms that want to JIT.
 SB_EXPORT extern const bool kSbCanMapExecutableMemory = false;
-
-// Platform can support partial audio frames
-SB_EXPORT extern const bool kHasPartialAudioFramesSupport = true;


### PR DESCRIPTION
Partial audio support is required in 27.lts.

Bug: 502581618