### PR TITLE
starboard: Remove unused variable kAnnexB in codec_util_test.cc

### DIFF
--- a/starboard/shared/starboard/media/codec_util_test.cc
+++ b/starboard/shared/starboard/media/codec_util_test.cc
@@ -26,7 +26,6 @@ namespace {
 constexpr uint8_t kIdrStartCode = 0x65;
 constexpr uint8_t kSpsStartCode = 0x67;
 constexpr uint8_t kPpsStartCode = 0x68;
-constexpr auto kAnnexB = AvcParameterSets::kAnnexB;
 
 const std::vector<uint8_t> kSpsInAnnexB = {0, 0, 0, 1, kSpsStartCode, 10, 11};
 const std::vector<uint8_t> kPpsInAnnexB = {0, 0, 0, 1, kPpsStartCode, 20};


### PR DESCRIPTION
Removes the unused variable `kAnnexB` to fix the compiler warning: `warning: unused variable 'kAnnexB' [-Wunused-const-variable]`

Issue: 517622571