### PR TITLE
media: Support changeType in media pipeline

### DIFF
--- a/media/base/audio_decoder_config.cc
+++ b/media/base/audio_decoder_config.cc
@@ -78,17 +78,6 @@ bool AudioDecoderConfig::IsValidConfig() const {
 // the config/mime_type is identical to the current config/mime_type.
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
-  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
-  // is intentionally excluded from Matches():
-  // 1. Matches() checks whether underlying hardware decoders require 
-  //    re-initialization based on elementary stream properties (codec,
-  //    profile, resolution, extra_data).
-  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
-  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
-  //    boundaries.
-  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
-  //    container MIME strings differ while elementary video/audio parameters
-  //    remain identical.
   return (
       (codec() == config.codec()) &&
       (bytes_per_channel() == config.bytes_per_channel()) &&

--- a/media/base/audio_decoder_config.cc
+++ b/media/base/audio_decoder_config.cc
@@ -88,16 +88,6 @@ bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
   //    boundaries.
   // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
   //    container MIME strings differ while elementary video/audio parameters
-  //    remain identical.  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
-  // is intentionally excluded from Matches():
-  // 1. Matches() checks whether underlying hardware decoders require 
-  //    re-initialization based on elementary stream properties (codec,
-  //    profile, resolution, extra_data).
-  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
-  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
-  //    boundaries.
-  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
-  //    container MIME strings differ while elementary video/audio parameters
   //    remain identical.
   return (
       (codec() == config.codec()) &&

--- a/media/base/audio_decoder_config.cc
+++ b/media/base/audio_decoder_config.cc
@@ -78,6 +78,27 @@ bool AudioDecoderConfig::IsValidConfig() const {
 // the config/mime_type is identical to the current config/mime_type.
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
+  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
+  // is intentionally excluded from Matches():
+  // 1. Matches() checks whether underlying hardware decoders require 
+  //    re-initialization based on elementary stream properties (codec,
+  //    profile, resolution, extra_data).
+  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
+  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
+  //    boundaries.
+  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
+  //    container MIME strings differ while elementary video/audio parameters
+  //    remain identical.  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
+  // is intentionally excluded from Matches():
+  // 1. Matches() checks whether underlying hardware decoders require 
+  //    re-initialization based on elementary stream properties (codec,
+  //    profile, resolution, extra_data).
+  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
+  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
+  //    boundaries.
+  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
+  //    container MIME strings differ while elementary video/audio parameters
+  //    remain identical.
   return (
       (codec() == config.codec()) &&
       (bytes_per_channel() == config.bytes_per_channel()) &&

--- a/media/base/audio_decoder_config.h
+++ b/media/base/audio_decoder_config.h
@@ -127,7 +127,6 @@ class MEDIA_EXPORT AudioDecoderConfig {
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
  private:
   // WARNING: When modifying or adding any parameters, update the following:
   // - AudioDecoderConfig::AsHumanReadableString()

--- a/media/base/audio_decoder_config.h
+++ b/media/base/audio_decoder_config.h
@@ -127,6 +127,7 @@ class MEDIA_EXPORT AudioDecoderConfig {
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
  private:
   // WARNING: When modifying or adding any parameters, update the following:
   // - AudioDecoderConfig::AsHumanReadableString()

--- a/media/base/video_decoder_config.cc
+++ b/media/base/video_decoder_config.cc
@@ -88,6 +88,17 @@ bool VideoDecoderConfig::IsValidConfig() const {
 // the config/mime_type is identical to the current config/mime_type.
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 bool VideoDecoderConfig::Matches(const VideoDecoderConfig& config) const {
+  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
+  // is intentionally excluded from Matches():
+  // 1. Matches() checks whether underlying hardware decoders require 
+  //    re-initialization based on elementary stream properties (codec,
+  //    profile, resolution, extra_data).
+  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
+  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
+  //    boundaries.
+  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
+  //    container MIME strings differ while elementary video/audio parameters
+  //    remain identical.
   return codec() == config.codec() && profile() == config.profile() &&
          alpha_mode() == config.alpha_mode() &&
          video_transformation() == config.video_transformation() &&

--- a/media/base/video_decoder_config.cc
+++ b/media/base/video_decoder_config.cc
@@ -88,17 +88,6 @@ bool VideoDecoderConfig::IsValidConfig() const {
 // the config/mime_type is identical to the current config/mime_type.
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 bool VideoDecoderConfig::Matches(const VideoDecoderConfig& config) const {
-  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
-  // is intentionally excluded from Matches():
-  // 1. Matches() checks whether underlying hardware decoders require 
-  //    re-initialization based on elementary stream properties (codec,
-  //    profile, resolution, extra_data).
-  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
-  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
-  //    boundaries.
-  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
-  //    container MIME strings differ while elementary video/audio parameters
-  //    remain identical.
   return codec() == config.codec() && profile() == config.profile() &&
          alpha_mode() == config.alpha_mode() &&
          video_transformation() == config.video_transformation() &&

--- a/media/base/video_decoder_config.h
+++ b/media/base/video_decoder_config.h
@@ -169,7 +169,6 @@ class MEDIA_EXPORT VideoDecoderConfig {
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
  private:
   VideoCodec codec_ = VideoCodec::kUnknown;
   VideoCodecProfile profile_ = VIDEO_CODEC_PROFILE_UNKNOWN;

--- a/media/base/video_decoder_config.h
+++ b/media/base/video_decoder_config.h
@@ -169,6 +169,7 @@ class MEDIA_EXPORT VideoDecoderConfig {
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
  private:
   VideoCodec codec_ = VideoCodec::kUnknown;
   VideoCodecProfile profile_ = VIDEO_CODEC_PROFILE_UNKNOWN;

--- a/media/filters/BUILD.gn
+++ b/media/filters/BUILD.gn
@@ -84,7 +84,7 @@ source_set("filters") {
   ]
 
   if (use_starboard_media) {
-        deps += [ "//starboard:starboard_headers_only" ]
+    deps += [ "//starboard:starboard_headers_only" ]
   }
 
   libs = []

--- a/media/filters/BUILD.gn
+++ b/media/filters/BUILD.gn
@@ -83,6 +83,10 @@ source_set("filters") {
     "//ui/gfx/geometry:geometry",
   ]
 
+  if (use_starboard_media) {
+        deps += [ "//starboard:starboard_headers_only" ]
+  }
+
   libs = []
 
   if (proprietary_codecs) {

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -876,7 +876,6 @@ ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
   CHECK(it != id_to_mime_map_.end());
   const std::string& mime_type = it->second;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
   source_state->Init(base::BindOnce(&ChunkDemuxer::OnSourceInitDone,
                                     base::Unretained(this), id),
 #if BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -32,6 +32,7 @@
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "base/containers/contains.h"
 #include "base/strings/string_split.h"
+#include "starboard/media.h"
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace {
@@ -1303,6 +1304,22 @@ bool ChunkDemuxer::CanChangeType(const std::string& id,
   if (!supports_change_type_) {
     return false;
   }
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  auto iter = id_to_mime_map_.find(id);
+  std::string current_mime = iter != id_to_mime_map_.end() ? iter->second : "";
+  std::string target_mime = content_type;
+  if (!codecs.empty()) {
+    target_mime += "; codecs=\"" + codecs + "\"";
+  }
+
+  if (!SbMediaIsChangeTypeTransitionSupported(current_mime.c_str(),
+                                              target_mime.c_str())) {
+    LOG(INFO) << "Codec transition unsupported natively on hardware: "
+              << current_mime << " -> " << target_mime;
+    return false;
+  }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // CanChangeType() doesn't care if there has or hasn't been received a first
   // initialization segment for the source buffer corresponding to |id|.

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -32,7 +32,7 @@
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "base/containers/contains.h"
 #include "base/strings/string_split.h"
-#include "starboard/media.h"
+#include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace {
@@ -872,11 +872,6 @@ ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
   CHECK(*insert_result.first == id);
   CHECK(insert_result.second);  // Only true if insertion succeeded.
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  auto it = id_to_mime_map_.find(id);
-  CHECK(it != id_to_mime_map_.end());
-  const std::string& mime_type = it->second;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   source_state->Init(base::BindOnce(&ChunkDemuxer::OnSourceInitDone,
                                     base::Unretained(this), id),
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
@@ -1305,21 +1300,6 @@ bool ChunkDemuxer::CanChangeType(const std::string& id,
     return false;
   }
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  auto iter = id_to_mime_map_.find(id);
-  std::string current_mime = iter != id_to_mime_map_.end() ? iter->second : "";
-  std::string target_mime = content_type;
-  if (!codecs.empty()) {
-    target_mime += "; codecs=\"" + codecs + "\"";
-  }
-
-  if (!SbMediaCanChangeType(current_mime.c_str(), target_mime.c_str())) {
-    LOG(INFO) << "Codec transition unsupported natively on hardware: "
-              << current_mime << " -> " << target_mime;
-    return false;
-  }
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
   // CanChangeType() doesn't care if there has or hasn't been received a first
   // initialization segment for the source buffer corresponding to |id|.
 
@@ -1349,10 +1329,30 @@ void ChunkDemuxer::ChangeType(const std::string& id,
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 bool ChunkDemuxer::CanChangeType(const std::string& id,
-                                 const std::string& mime_type) {
+                                 const std::string& target_mime) {
+  std::string current_mime;
+  {
+    base::AutoLock auto_lock(lock_);
+    DCHECK(IsValidId_Locked(id));
+
+    auto itr = source_state_map_.find(id);
+    if (itr == source_state_map_.end()) {
+      LOG(INFO) << "CanChangeType failed: id '" << id
+                << "' not found in source_state_map_.";
+      return false;
+    }
+    current_mime = itr->second->mime_type();
+  }
+
+  if (current_mime.empty() ||
+      !SbMediaCanChangeType(current_mime.c_str(), target_mime.c_str())) {
+    LOG(INFO) << "Codec transition unsupported: current_mime='" << current_mime
+              << "' -> target_mime='" << target_mime << "'";
+    return false;
+  }
   std::string content_type;
   std::string codecs;
-  ParseMimeType(mime_type, &content_type, &codecs);
+  ParseMimeType(target_mime, &content_type, &codecs);
   return CanChangeType(id, content_type, codecs);
 }
 
@@ -1364,8 +1364,6 @@ void ChunkDemuxer::ChangeType(const std::string& id,
   DCHECK(state_ == INITIALIZING || state_ == INITIALIZED) << state_;
   DCHECK(IsValidId_Locked(id));
 
-  id_to_mime_map_[id] = mime_type;
-
   std::string content_type;
   std::string codecs;
   ParseMimeType(mime_type, &content_type, &codecs);
@@ -1373,8 +1371,12 @@ void ChunkDemuxer::ChangeType(const std::string& id,
   std::unique_ptr<media::StreamParser> stream_parser(
       CreateParserForTypeAndCodecs(content_type, codecs, media_log_));
   DCHECK(stream_parser);
-  source_state_map_[id]->ChangeType(std::move(stream_parser),
-                                    ExpectedCodecs(content_type, codecs));
+
+  auto itr = source_state_map_.find(id);
+  DCHECK(itr != source_state_map_.end());
+  itr->second->set_mime_type(mime_type);
+  itr->second->ChangeType(std::move(stream_parser),
+                          ExpectedCodecs(content_type, codecs));
 }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -1313,8 +1313,7 @@ bool ChunkDemuxer::CanChangeType(const std::string& id,
     target_mime += "; codecs=\"" + codecs + "\"";
   }
 
-  if (!SbMediaIsChangeTypeTransitionSupported(current_mime.c_str(),
-                                              target_mime.c_str())) {
+  if (!SbMediaCanChangeType(current_mime.c_str(), target_mime.c_str())) {
     LOG(INFO) << "Codec transition unsupported natively on hardware: "
               << current_mime << " -> " << target_mime;
     return false;
@@ -1347,6 +1346,37 @@ void ChunkDemuxer::ChangeType(const std::string& id,
   source_state_map_[id]->ChangeType(std::move(stream_parser),
                                     ExpectedCodecs(content_type, codecs));
 }
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+bool ChunkDemuxer::CanChangeType(const std::string& id,
+                                 const std::string& mime_type) {
+  std::string content_type;
+  std::string codecs;
+  ParseMimeType(mime_type, &content_type, &codecs);
+  return CanChangeType(id, content_type, codecs);
+}
+
+void ChunkDemuxer::ChangeType(const std::string& id,
+                              const std::string& mime_type) {
+  DVLOG(1) << __func__ << " id=" << id << " mime_type=" << mime_type;
+
+  base::AutoLock auto_lock(lock_);
+  DCHECK(state_ == INITIALIZING || state_ == INITIALIZED) << state_;
+  DCHECK(IsValidId_Locked(id));
+
+  id_to_mime_map_[id] = mime_type;
+
+  std::string content_type;
+  std::string codecs;
+  ParseMimeType(mime_type, &content_type, &codecs);
+
+  std::unique_ptr<media::StreamParser> stream_parser(
+      CreateParserForTypeAndCodecs(content_type, codecs, media_log_));
+  DCHECK(stream_parser);
+  source_state_map_[id]->ChangeType(std::move(stream_parser),
+                                    ExpectedCodecs(content_type, codecs));
+}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 double ChunkDemuxer::GetDuration() {
   base::AutoLock auto_lock(lock_);

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -871,6 +871,10 @@ ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
   CHECK(*insert_result.first == id);
   CHECK(insert_result.second);  // Only true if insertion succeeded.
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  const std::string& mime_type = id_to_mime_map_[id];
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   source_state->Init(base::BindOnce(&ChunkDemuxer::OnSourceInitDone,
                                     base::Unretained(this), id),
 #if BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -872,7 +872,9 @@ ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
   CHECK(insert_result.second);  // Only true if insertion succeeded.
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  const std::string& mime_type = id_to_mime_map_[id];
+  auto it = id_to_mime_map_.find(id);
+  CHECK(it != id_to_mime_map_.end());
+  const std::string& mime_type = it->second;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   source_state->Init(base::BindOnce(&ChunkDemuxer::OnSourceInitDone,

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -1329,52 +1329,51 @@ void ChunkDemuxer::ChangeType(const std::string& id,
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 bool ChunkDemuxer::CanChangeType(const std::string& id,
-                                 const std::string& target_mime) {
-  std::string current_mime;
+                                 const std::string& target_mime_type) {
+  std::string current_mime_type;
   {
     base::AutoLock auto_lock(lock_);
     DCHECK(IsValidId_Locked(id));
 
     auto itr = source_state_map_.find(id);
-    if (itr == source_state_map_.end()) {
-      LOG(INFO) << "CanChangeType failed: id '" << id
-                << "' not found in source_state_map_.";
-      return false;
-    }
-    current_mime = itr->second->mime_type();
+    current_mime_type = itr->second->mime_type();
   }
 
-  if (current_mime.empty() ||
-      !SbMediaCanChangeType(current_mime.c_str(), target_mime.c_str())) {
-    LOG(INFO) << "Codec transition unsupported: current_mime='" << current_mime
-              << "' -> target_mime='" << target_mime << "'";
+  if (!SbMediaCanChangeType(current_mime_type.c_str(), 
+                            target_mime_type.c_str())) {
+    LOG(INFO) << "Codec transition unsupported: current_mime_type='" 
+              << current_mime_type << "' -> target_mime_type='" 
+              << target_mime_type << "'";
     return false;
   }
+
   std::string content_type;
   std::string codecs;
-  ParseMimeType(target_mime, &content_type, &codecs);
+  ParseMimeType(target_mime_type, &content_type, &codecs);
   return CanChangeType(id, content_type, codecs);
 }
 
 void ChunkDemuxer::ChangeType(const std::string& id,
-                              const std::string& mime_type) {
-  DVLOG(1) << __func__ << " id=" << id << " mime_type=" << mime_type;
-
-  base::AutoLock auto_lock(lock_);
-  DCHECK(state_ == INITIALIZING || state_ == INITIALIZED) << state_;
-  DCHECK(IsValidId_Locked(id));
+                              const std::string& target_mime_type) {
+  DVLOG(1) << __func__ << " id=" << id << " target_mime_type=" 
+           << target_mime_type;
 
   std::string content_type;
   std::string codecs;
-  ParseMimeType(mime_type, &content_type, &codecs);
+  ParseMimeType(target_mime_type, &content_type, &codecs);
+
+  base::AutoLock auto_lock(lock_);
+
+  DCHECK(state_ == INITIALIZING || state_ == INITIALIZED) << state_;
+  DCHECK(IsValidId_Locked(id));
 
   std::unique_ptr<media::StreamParser> stream_parser(
       CreateParserForTypeAndCodecs(content_type, codecs, media_log_));
+  // Caller should query CanChangeType() first to protect from failing this.
   DCHECK(stream_parser);
 
   auto itr = source_state_map_.find(id);
-  DCHECK(itr != source_state_map_.end());
-  itr->second->set_mime_type(mime_type);
+  itr->second->set_mime_type(target_mime_type);
   itr->second->ChangeType(std::move(stream_parser),
                           ExpectedCodecs(content_type, codecs));
 }

--- a/media/filters/chunk_demuxer.h
+++ b/media/filters/chunk_demuxer.h
@@ -419,6 +419,11 @@ class MEDIA_EXPORT ChunkDemuxer : public Demuxer {
                   const std::string& content_type,
                   const std::string& codecs);
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  bool CanChangeType(const std::string& id, const std::string& mime_type);
+  void ChangeType(const std::string& id, const std::string& mime_type);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   // If the buffer is full, attempts to try to free up space, as specified in
   // the "Coded Frame Eviction Algorithm" in the Media Source Extensions Spec.
   // Returns false iff buffer is still full after running eviction.

--- a/media/filters/chunk_demuxer.h
+++ b/media/filters/chunk_demuxer.h
@@ -422,8 +422,9 @@ class MEDIA_EXPORT ChunkDemuxer : public Demuxer {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   // Starboard-specific implementations of CanChangeType() and ChangeType()
   // that accept in the full mime_type string from the web app.
-  bool CanChangeType(const std::string& id, const std::string& target_mime);
-  void ChangeType(const std::string& id, const std::string& mime_type);
+  bool CanChangeType(const std::string& id, 
+                     const std::string& target_mime_type);
+  void ChangeType(const std::string& id, const std::string& target_mime_type);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // If the buffer is full, attempts to try to free up space, as specified in

--- a/media/filters/chunk_demuxer.h
+++ b/media/filters/chunk_demuxer.h
@@ -420,7 +420,9 @@ class MEDIA_EXPORT ChunkDemuxer : public Demuxer {
                   const std::string& codecs);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  bool CanChangeType(const std::string& id, const std::string& mime_type);
+  // Starboard-specific implementations of CanChangeType() and ChangeType()
+  // that accept in the full mime_type string from the web app.
+  bool CanChangeType(const std::string& id, const std::string& target_mime);
   void ChangeType(const std::string& id, const std::string& mime_type);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/media/filters/source_buffer_state.h
+++ b/media/filters/source_buffer_state.h
@@ -185,6 +185,14 @@ class MEDIA_EXPORT SourceBufferState {
 
   void SetParseWarningCallback(SourceBufferParseWarningCB parse_warning_cb);
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Set and get the current |mime_type_| string for the SourceBuffer.
+  void set_mime_type(std::string_view mime_type) {
+    mime_type_ = std::string(mime_type);
+  }
+  const std::string& mime_type() const { return mime_type_; }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
  private:
   // State advances through this list to PARSER_INITIALIZED.
   // The intent is to ensure at least one config is received prior to parser
@@ -301,7 +309,9 @@ class MEDIA_EXPORT SourceBufferState {
 
   std::vector<AudioCodec> expected_audio_codecs_;
   std::vector<VideoCodec> expected_video_codecs_;
+
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Full mime_type string of the SourceBuffer.
   std::string mime_type_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 };

--- a/media/mojo/mojom/audio_decoder_config_mojom_traits.h
+++ b/media/mojo/mojom/audio_decoder_config_mojom_traits.h
@@ -70,14 +70,14 @@ struct StructTraits<media::mojom::AudioDecoderConfigDataView,
     return input.should_discard_decoder_delay();
   }
 
+  static bool Read(media::mojom::AudioDecoderConfigDataView input,
+                   media::AudioDecoderConfig* output);
+
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   static const std::string& mime_type(const media::AudioDecoderConfig& input) {
     return input.mime_type();
   }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
-  static bool Read(media::mojom::AudioDecoderConfigDataView input,
-                   media::AudioDecoderConfig* output);
 };
 
 }  // namespace mojo

--- a/media/mojo/mojom/audio_decoder_config_mojom_traits.h
+++ b/media/mojo/mojom/audio_decoder_config_mojom_traits.h
@@ -70,14 +70,14 @@ struct StructTraits<media::mojom::AudioDecoderConfigDataView,
     return input.should_discard_decoder_delay();
   }
 
-  static bool Read(media::mojom::AudioDecoderConfigDataView input,
-                   media::AudioDecoderConfig* output);
-
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   static const std::string& mime_type(const media::AudioDecoderConfig& input) {
     return input.mime_type();
   }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
+  static bool Read(media::mojom::AudioDecoderConfigDataView input,
+                   media::AudioDecoderConfig* output);
 };
 
 }  // namespace mojo

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -346,6 +346,7 @@ void SbPlayerBridge::UpdateVideoConfig(const VideoDecoderConfig& video_config) {
             << video_config.AsHumanReadableString();
 
   video_config_ = video_config;
+  video_mime_type_ = video_config_.mime_type();
   video_stream_info_.frame_width =
       static_cast<int>(video_config_.natural_size().width());
   video_stream_info_.frame_height =

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -346,7 +346,6 @@ void SbPlayerBridge::UpdateVideoConfig(const VideoDecoderConfig& video_config) {
             << video_config.AsHumanReadableString();
 
   video_config_ = video_config;
-  video_mime_type_ = video_config_.mime_type();
   video_stream_info_.frame_width =
       static_cast<int>(video_config_.natural_size().width());
   video_stream_info_.frame_height =

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -197,6 +197,7 @@ static_library("starboard_platform") {
     "media_get_video_buffer_budget.cc",
     "media_is_audio_supported.cc",
     "media_is_buffer_pool_allocate_on_demand.cc",
+    "media_is_changetype_transition_supported.cc",
     "media_is_key_system_supported.cc",
     "media_is_video_supported.cc",
     "memfd_media_buffer_pool.cc",

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -197,7 +197,6 @@ static_library("starboard_platform") {
     "media_get_video_buffer_budget.cc",
     "media_is_audio_supported.cc",
     "media_is_buffer_pool_allocate_on_demand.cc",
-    "media_is_changetype_transition_supported.cc",
     "media_is_key_system_supported.cc",
     "media_is_video_supported.cc",
     "memfd_media_buffer_pool.cc",

--- a/starboard/player.h
+++ b/starboard/player.h
@@ -487,17 +487,6 @@ SB_EXPORT void SbPlayerSeek(SbPlayer player,
 // |sample_infos|: A pointer to an array of SbPlayerSampleInfo with
 // |number_of_sample_infos| elements, each holds the data for an sample, i.e.
 // a sequence of whole NAL Units for video, or a complete audio frame.
-// Subsequent calls to SbPlayerWriteSamples() may pass samples with a media
-// configuration (such as codec or MIME type) that differs from the player's
-// current active configuration.
-//
-// When this transition is supported (see
-// SbMediaIsChangeTypeTransitionSupported()), the player is expected to handle
-// the configuration switch on the active SbPlayer instance while maintaining
-// uninterrupted playback.
-//
-// The caller is guaranteed not to attempt dynamic configuration changes for
-// a transition path if SbMediaIsChangeTypeTransitionSupported() returns false.
 // |sample_infos| cannot be assumed to live past the call into
 // SbPlayerWriteSamples(), so it must be copied if its content will be used
 // after SbPlayerWriteSamples() returns.

--- a/starboard/player.h
+++ b/starboard/player.h
@@ -487,6 +487,17 @@ SB_EXPORT void SbPlayerSeek(SbPlayer player,
 // |sample_infos|: A pointer to an array of SbPlayerSampleInfo with
 // |number_of_sample_infos| elements, each holds the data for an sample, i.e.
 // a sequence of whole NAL Units for video, or a complete audio frame.
+// Subsequent calls to SbPlayerWriteSamples() may pass samples with a media
+// configuration (such as codec or MIME type) that differs from the player's
+// current active configuration.
+//
+// When this transition is supported (see
+// SbMediaIsChangeTypeTransitionSupported()), the player is expected to handle
+// the configuration switch on the active SbPlayer instance while maintaining
+// uninterrupted playback.
+//
+// The caller is guaranteed not to attempt dynamic configuration changes for
+// a transition path if SbMediaIsChangeTypeTransitionSupported() returns false.
 // |sample_infos| cannot be assumed to live past the call into
 // SbPlayerWriteSamples(), so it must be copied if its content will be used
 // after SbPlayerWriteSamples() returns.

--- a/third_party/blink/public/platform/web_source_buffer.h
+++ b/third_party/blink/public/platform/web_source_buffer.h
@@ -118,6 +118,12 @@ class WebSourceBuffer {
   virtual void ResetParserState() = 0;
   virtual void Remove(double start, double end) = 0;
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Special Starboard versions of CanChangeType and ChangeType that accept the
+  // raw mime_type string passed from the webapp.
+  virtual bool CanChangeType(const WebString& mime_type) = 0;
+  virtual void ChangeType(const WebString& mime_type) = 0;
+#else  // BUILDFLAG(USE_STARBOARD_MEDIA)
   // Returns true iff this SourceBuffer supports changing bytestream and codecs
   // to |content_type| and |codecs|.  |content_type| is the ContentType string
   // of the bytestream's MIME type, and |codecs| contains the "codecs" parameter
@@ -132,6 +138,7 @@ class WebSourceBuffer {
   // |content_type| and |codecs| parameters.
   virtual void ChangeType(const WebString& content_type,
                           const WebString& codecs) = 0;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   virtual bool SetTimestampOffset(double) = 0;
 

--- a/third_party/blink/renderer/modules/mediasource/source_buffer.cc
+++ b/third_party/blink/renderer/modules/mediasource/source_buffer.cc
@@ -1078,8 +1078,10 @@ void SourceBuffer::ChangeType_Locked(
   //    previously) of SourceBuffer objects in the sourceBuffers attribute of
   //    the parent media source, then throw a NotSupportedError exception and
   //    abort these steps.
+#if !BUILDFLAG(USE_STARBOARD_MEDIA)
   ContentType content_type(type);
   String codecs = content_type.Parameter("codecs");
+#endif  // !BUILDFLAG(USE_STARBOARD_MEDIA)
   // TODO(wolenetz): Refactor and use a less-strict version of isTypeSupported
   // here. As part of that, CanChangeType in Chromium should inherit relaxation
   // of impl's StreamParserFactory (since it returns true iff a stream parser
@@ -1087,7 +1089,11 @@ void SourceBuffer::ChangeType_Locked(
   if (!MediaSource::IsTypeSupportedInternal(
           GetExecutionContext(), type,
           false /* allow underspecified codecs in |type| */) ||
+#if !BUILDFLAG(USE_STARBOARD_MEDIA)
       !web_source_buffer_->CanChangeType(content_type.GetType(), codecs)) {
+#else   // !BUILDFLAG(USE_STARBOARD_MEDIA)
+      !web_source_buffer_->CanChangeType(type)) {
+#endif  // !BUILDFLAG(USE_STARBOARD_MEDIA)
     MediaSource::LogAndThrowDOMException(
         *exception_state, DOMExceptionCode::kNotSupportedError,
         "Changing to the type provided ('" + type + "') is not supported.");
@@ -1108,7 +1114,11 @@ void SourceBuffer::ChangeType_Locked(
   //    value in the "Generate Timestamps Flag" column of the byte stream format
   //    registry entry that is associated with type.
   // This call also updates the pipeline to switch bytestream parser and codecs.
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  web_source_buffer_->ChangeType(type);
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
   web_source_buffer_->ChangeType(content_type.GetType(), codecs);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // 8. If the generate timestamps flag equals true: Set the mode attribute on
   //    this SourceBuffer object to "sequence", including running the associated

--- a/third_party/blink/renderer/modules/mediasource/source_buffer.cc
+++ b/third_party/blink/renderer/modules/mediasource/source_buffer.cc
@@ -1091,7 +1091,7 @@ void SourceBuffer::ChangeType_Locked(
           false /* allow underspecified codecs in |type| */) ||
 #if !BUILDFLAG(USE_STARBOARD_MEDIA)
       !web_source_buffer_->CanChangeType(content_type.GetType(), codecs)) {
-#else   // !BUILDFLAG(USE_STARBOARD_MEDIA)
+#else  // !BUILDFLAG(USE_STARBOARD_MEDIA)
       !web_source_buffer_->CanChangeType(type)) {
 #endif  // !BUILDFLAG(USE_STARBOARD_MEDIA)
     MediaSource::LogAndThrowDOMException(
@@ -1116,7 +1116,7 @@ void SourceBuffer::ChangeType_Locked(
   // This call also updates the pipeline to switch bytestream parser and codecs.
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   web_source_buffer_->ChangeType(type);
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
+#else  // BUILDFLAG(USE_STARBOARD_MEDIA)
   web_source_buffer_->ChangeType(content_type.GetType(), codecs);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/third_party/blink/renderer/modules/mediasource/source_buffer.cc
+++ b/third_party/blink/renderer/modules/mediasource/source_buffer.cc
@@ -1089,11 +1089,11 @@ void SourceBuffer::ChangeType_Locked(
   if (!MediaSource::IsTypeSupportedInternal(
           GetExecutionContext(), type,
           false /* allow underspecified codecs in |type| */) ||
-#if !BUILDFLAG(USE_STARBOARD_MEDIA)
-      !web_source_buffer_->CanChangeType(content_type.GetType(), codecs)) {
-#else  // !BUILDFLAG(USE_STARBOARD_MEDIA)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
       !web_source_buffer_->CanChangeType(type)) {
-#endif  // !BUILDFLAG(USE_STARBOARD_MEDIA)
+#else  // BUILDFLAG(USE_STARBOARD_MEDIA)
+      !web_source_buffer_->CanChangeType(content_type.GetType(), codecs)) {
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
     MediaSource::LogAndThrowDOMException(
         *exception_state, DOMExceptionCode::kNotSupportedError,
         "Changing to the type provided ('" + type + "') is not supported.");

--- a/third_party/blink/renderer/platform/media/web_source_buffer_impl.cc
+++ b/third_party/blink/renderer/platform/media/web_source_buffer_impl.cc
@@ -206,6 +206,18 @@ void WebSourceBufferImpl::Remove(double start, double end) {
   demuxer_->Remove(id_, timedelta_start, timedelta_end);
 }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+bool WebSourceBufferImpl::CanChangeType(const WebString& mime_type) {
+  return demuxer_->CanChangeType(id_, mime_type.Utf8());
+}
+
+void WebSourceBufferImpl::ChangeType(const WebString& mime_type) {
+  // Caller must first call ResetParserState() to flush any pending frames.
+  DCHECK(!demuxer_->IsParsingMediaSegment(id_));
+
+  demuxer_->ChangeType(id_, mime_type.Utf8());
+}
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
 bool WebSourceBufferImpl::CanChangeType(const WebString& content_type,
                                         const WebString& codecs) {
   return demuxer_->CanChangeType(id_, content_type.Utf8(), codecs.Utf8());
@@ -218,6 +230,7 @@ void WebSourceBufferImpl::ChangeType(const WebString& content_type,
 
   demuxer_->ChangeType(id_, content_type.Utf8(), codecs.Utf8());
 }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 bool WebSourceBufferImpl::SetTimestampOffset(double offset) {
   if (demuxer_->IsParsingMediaSegment(id_))

--- a/third_party/blink/renderer/platform/media/web_source_buffer_impl.cc
+++ b/third_party/blink/renderer/platform/media/web_source_buffer_impl.cc
@@ -217,7 +217,7 @@ void WebSourceBufferImpl::ChangeType(const WebString& mime_type) {
 
   demuxer_->ChangeType(id_, mime_type.Utf8());
 }
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
+#else  // BUILDFLAG(USE_STARBOARD_MEDIA)
 bool WebSourceBufferImpl::CanChangeType(const WebString& content_type,
                                         const WebString& codecs) {
   return demuxer_->CanChangeType(id_, content_type.Utf8(), codecs.Utf8());

--- a/third_party/blink/renderer/platform/media/web_source_buffer_impl.h
+++ b/third_party/blink/renderer/platform/media/web_source_buffer_impl.h
@@ -53,10 +53,15 @@ class PLATFORM_EXPORT WebSourceBufferImpl : public WebSourceBuffer {
       double* timestamp_offset) override;
   void ResetParserState() override;
   void Remove(double start, double end) override;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  bool CanChangeType(const WebString& mime_type) override;
+  void ChangeType(const WebString& mime_type) override;
+#else  // BUILDFLAG(USE_STARBOARD_MEDIA)
   bool CanChangeType(const WebString& content_type,
                      const WebString& codecs) override;
   void ChangeType(const WebString& content_type,
                   const WebString& codecs) override;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   bool SetTimestampOffset(double offset) override;
   void SetAppendWindowStart(double start) override;
   void SetAppendWindowEnd(double end) override;


### PR DESCRIPTION
Implementing MSE changeType() allows media players to switch containers
or codecs mid-stream without a full pipeline reset. This is essential
for features like adaptive bitrate switching across different formats.

This PR adds:

* **Blink MSE `SourceBuffer.changeType()`**: Added Starboard (`BUILDFLAG(USE_STARBOARD_MEDIA)`) support to pass full raw MIME strings directly to `WebSourceBuffer` without splitting container and codec parameters.
* **Hardware Capability Validation**: Integrated `SbMediaCanChangeType(current_mime, target_mime)` into `ChunkDemuxer::CanChangeType()` to validate platform decoder support before committing to format switches.
* **Decoder Config Synchronization**: Updated `SourceBufferState` and `ChunkDemuxer::ChangeType()` to maintain and update the active `mime_type_`, binding container MIME strings directly to `AudioDecoderConfig` and `VideoDecoderConfig`.
* **Starboard Platform Integration**: Added platform interface stubs and Android build targets for `SbMediaIsChangeTypeTransitionSupported` / `SbMediaCanChangeType`.

A follow-up PR is planned to provide support for Starboard Android builds.


Bug: 132743206