### PR TITLE
Remove SB_DCHECK in SetPlaybackRate

### DIFF
--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -160,9 +160,6 @@ void AudioRendererSinkImpl::SetVolume(double volume) {
 
 void AudioRendererSinkImpl::SetPlaybackRate(double playback_rate) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
-  SB_DCHECK(playback_rate == 0.0 || playback_rate == 1.0)
-      << "Playback rate on audio sink can only be set to 0 or 1, "
-      << "but is now set to " << playback_rate;
 
   playback_rate_ = playback_rate;
   if (HasStarted()) {


### PR DESCRIPTION
The SB_DCHECK in AudioRendererSinkImpl::SetPlaybackRate restricted the
playback rate to values of 0.0 or 1.0. This check should be removed as it is
no longer true for tunnel mode.

Bug: 517316525