### PR TITLE
starboard: Rename internal SbThread* priority helper functions

### DIFF
--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -927,7 +927,7 @@ void MediaCodecDecoder::OnMediaCodecInputBufferAvailable(int buffer_index) {
   if (media_type_ == kSbMediaTypeVideo && first_call_on_handler_thread_) {
     // Set the thread priority of the Handler thread to dispatch the async
     // decoder callbacks to high.
-    setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kHigh));
+    setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(ThreadPriority::kHigh));
     first_call_on_handler_thread_ = false;
   }
   std::lock_guard lock(mutex_);

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -927,7 +927,8 @@ void MediaCodecDecoder::OnMediaCodecInputBufferAvailable(int buffer_index) {
   if (media_type_ == kSbMediaTypeVideo && first_call_on_handler_thread_) {
     // Set the thread priority of the Handler thread to dispatch the async
     // decoder callbacks to high.
-    setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(ThreadPriority::kHigh));
+    setpriority(PRIO_PROCESS, 0,
+                ThreadPriorityToNiceValue(ThreadPriority::kHigh));
     first_call_on_handler_thread_ = false;
   }
   std::lock_guard lock(mutex_);

--- a/starboard/common/thread.cc
+++ b/starboard/common/thread.cc
@@ -39,7 +39,7 @@ namespace {
 // Returns a value between 0 and 1 that is used by SetThreadPriority() to scale
 // the desired thread priority between what sched_get_priority_min() and
 // sched_get_priority_max() return.
-float SbThreadPriorityToRelativeSchedPriority(ThreadPriority priority) {
+float ThreadPriorityToRelativeSchedPriority(ThreadPriority priority) {
   switch (priority) {
     case ThreadPriority::kLowest:
       return 0.1f;
@@ -70,7 +70,7 @@ float SbThreadPriorityToRelativeSchedPriority(ThreadPriority priority) {
 bool SetThreadPriority(ThreadPriority priority) {
 #if defined(__APPLE__)
   const float relative_priority =
-      SbThreadPriorityToRelativeSchedPriority(priority);
+      ThreadPriorityToRelativeSchedPriority(priority);
 
   int policy;
   struct sched_param param;
@@ -91,13 +91,13 @@ bool SetThreadPriority(ThreadPriority priority) {
 #else
   // setpriority returns 0 on success and -1 on failure. The default nice value
   // is 0. See https://linux.die.net/man/2/setpriority
-  return (setpriority(PRIO_PROCESS, 0, SbPriorityToNice(priority)) == 0);
+  return (setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(priority)) == 0);
 #endif  // defined(__APPLE__)
 }
 
 }  // namespace
 
-int SbPriorityToNice(ThreadPriority priority) {
+int ThreadPriorityToNiceValue(ThreadPriority priority) {
   // Nice value settings are shared between Android and Linux.
   // They are selected from looking at:
   // https://android.googlesource.com/platform/frameworks/native/+/jb-dev/include/utils/ThreadDefs.h#35

--- a/starboard/common/thread.cc
+++ b/starboard/common/thread.cc
@@ -91,7 +91,8 @@ bool SetThreadPriority(ThreadPriority priority) {
 #else
   // setpriority returns 0 on success and -1 on failure. The default nice value
   // is 0. See https://linux.die.net/man/2/setpriority
-  return (setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(priority)) == 0);
+  return (setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(priority)) ==
+          0);
 #endif  // defined(__APPLE__)
 }
 

--- a/starboard/common/thread.h
+++ b/starboard/common/thread.h
@@ -83,7 +83,7 @@ class Thread {
   void operator=(const Thread&) = delete;
 };
 
-int SbPriorityToNice(ThreadPriority priority);
+int ThreadPriorityToNiceValue(ThreadPriority priority);
 
 }  // namespace starboard
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/audio_sink/gstreamer_audio_sink_type.cc
@@ -279,7 +279,7 @@ GStreamerAudioSink::~GStreamerAudioSink() {
 // static
 void* GStreamerAudioSink::AudioThreadEntryPoint(void* context) {
   SB_DCHECK(context);
-  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kRealTime));
+  setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(ThreadPriority::kRealTime));
 
   GStreamerAudioSink* sink = reinterpret_cast<GStreamerAudioSink*>(context);
   GST_TRACE_OBJECT(sink->pipeline_, "TID: %d", gettid());

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/hang_detector.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/hang_detector.cc
@@ -101,7 +101,7 @@ seconds get_check_interval() {
 struct HangDetector
 {
   static void* ThreadEntryPoint(void* context) {
-    setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kNoPriority));
+    setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(ThreadPriority::kNoPriority));
     SB_DCHECK(context);
     static_cast<HangDetector*>(context)->DoWork();
     return nullptr;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -1773,7 +1773,7 @@ gboolean PlayerImpl::HandleBusMessage(GstBus* bus, GstMessage* message) {
 
 // static
 void* PlayerImpl::ThreadEntryPoint(void* context) {
-  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kRealTime));
+  setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(ThreadPriority::kRealTime));
   SB_DCHECK(context);
   GST_TRACE("%d", gettid());
 

--- a/starboard/nplb/posix_compliance/posix_priority_test.cc
+++ b/starboard/nplb/posix_compliance/posix_priority_test.cc
@@ -166,7 +166,7 @@ TEST_F(PosixSetPriorityTests, SetProcessPriorityToStarboardNiceValues) {
   //  SetProcessPrioritySuccessfully test.
 
   // Low Priority
-  int low_nice = starboard::SbPriorityToNice(starboard::ThreadPriority::kLow);
+  int low_nice = starboard::ThreadPriorityToNiceValue(starboard::ThreadPriority::kLow);
   ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, low_nice))
       << "setpriority failed for Low. Errno: " << errno << " ("
       << strerror(errno) << ")";
@@ -174,7 +174,7 @@ TEST_F(PosixSetPriorityTests, SetProcessPriorityToStarboardNiceValues) {
 
   // Lowest Priority
   int lowest_nice =
-      starboard::SbPriorityToNice(starboard::ThreadPriority::kLowest);
+      starboard::ThreadPriorityToNiceValue(starboard::ThreadPriority::kLowest);
   ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, lowest_nice))
       << "setpriority failed for Lowest. Errno: " << errno << " ("
       << strerror(errno) << ")";

--- a/starboard/nplb/posix_compliance/posix_priority_test.cc
+++ b/starboard/nplb/posix_compliance/posix_priority_test.cc
@@ -166,7 +166,8 @@ TEST_F(PosixSetPriorityTests, SetProcessPriorityToStarboardNiceValues) {
   //  SetProcessPrioritySuccessfully test.
 
   // Low Priority
-  int low_nice = starboard::ThreadPriorityToNiceValue(starboard::ThreadPriority::kLow);
+  int low_nice =
+      starboard::ThreadPriorityToNiceValue(starboard::ThreadPriority::kLow);
   ASSERT_EQ(0, setpriority(PRIO_PROCESS, 0, low_nice))
       << "setpriority failed for Low. Errno: " << errno << " ("
       << strerror(errno) << ")";

--- a/starboard/raspi/shared/open_max/video_decoder.cc
+++ b/starboard/raspi/shared/open_max/video_decoder.cc
@@ -139,7 +139,8 @@ bool OpenMaxVideoDecoder::TryToDeliverOneFrame() {
 // static
 void* OpenMaxVideoDecoder::ThreadEntryPoint(void* context) {
   pthread_setname_np(pthread_self(), "omx_video_decoder");
-  setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(ThreadPriority::kHigh));
+  setpriority(PRIO_PROCESS, 0,
+              ThreadPriorityToNiceValue(ThreadPriority::kHigh));
   OpenMaxVideoDecoder* decoder =
       reinterpret_cast<OpenMaxVideoDecoder*>(context);
   decoder->RunLoop();

--- a/starboard/raspi/shared/open_max/video_decoder.cc
+++ b/starboard/raspi/shared/open_max/video_decoder.cc
@@ -139,7 +139,7 @@ bool OpenMaxVideoDecoder::TryToDeliverOneFrame() {
 // static
 void* OpenMaxVideoDecoder::ThreadEntryPoint(void* context) {
   pthread_setname_np(pthread_self(), "omx_video_decoder");
-  setpriority(PRIO_PROCESS, 0, SbPriorityToNice(ThreadPriority::kHigh));
+  setpriority(PRIO_PROCESS, 0, ThreadPriorityToNiceValue(ThreadPriority::kHigh));
   OpenMaxVideoDecoder* decoder =
       reinterpret_cast<OpenMaxVideoDecoder*>(context);
   decoder->RunLoop();


### PR DESCRIPTION
Renames the internal helper functions `SbThreadPriorityToRelativeSchedPriority` and `SbPriorityToNice` in `starboard/common/thread` to clarify that they are internal C++ utilities rather than public Starboard C APIs.

### Rationale
Following the deprecation and cleanup of public Starboard C threading APIs, some internal helper functions remained in `starboard/common` that still carried the legacy C-style `Sb` prefix (e.g., `SbPriorityToNice`). This could easily lead to the false impression that these helpers are part of the public Starboard API surface. 

This PR renames them to clarify they are strictly private/internal Starboard C++ utilities and updates all internal callers accordingly.

Issue: 517310205
