### PR TITLE
Add java switches for disabling optimizing compilers

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -44,6 +44,9 @@ public class JavaSwitches {
   /** flag to tune delay in seconds before reclaiming prepaint tiles when idle. */
   public static final String RECLAIM_DELAY_IN_SECONDS = "ReclaimDelayInSeconds";
 
+  /** flag to disable v8 optimizing compilers (turbofan, maglev, sparkplug) */
+  public static final String DISABLE_V8_OPTIMIZING_COMPILERS = "DisableV8OptimizingCompilers";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
 
@@ -61,6 +64,10 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_V8_DECOMMIT_POOLED_PAGES)) {
       extraCommandLineArgs.add("--js-flags=--no-decommit-pooled-pages");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.DISABLE_V8_OPTIMIZING_COMPILERS)) {
+      extraCommandLineArgs.add("--js-flags=--disable-optimizing-compilers;--no-sparkplug");
     }
 
     StringJoiner featureParams = new StringJoiner("/");


### PR DESCRIPTION
This PR adds java switches to disable v8 optimizing compilers 
(i.e. maglev, turbofan, and sparkplug) since significant v8 runtime memory 
savings are observed in local runs, see [b/512163617#comment10](https://b.corp.google.com/issues/512163617#comment10)

This will allow us to set up experiment to further evaluate memory
and potential performance impact from disabling those compilers, which 
could also aid investigation of excluding them entirely from cobalt 
build to reduce binary size.

Bug: 512163617