### PR TITLE
starboard: Remove base dependency from experimental_features.cc

### DIFF
--- a/starboard/shared/starboard/experimental_features.cc
+++ b/starboard/shared/starboard/experimental_features.cc
@@ -14,11 +14,8 @@
 
 #include "starboard/shared/starboard/experimental_features.h"
 
-#include <memory>
 #include <optional>
 
-#include "base/no_destructor.h"
-#include "base/threading/thread_local.h"
 #include "starboard/common/log.h"
 #include "starboard/extension/experimental_features.h"
 
@@ -26,23 +23,7 @@ namespace starboard {
 
 namespace {
 
-base::ThreadLocalOwnedPointer<ExperimentalFeatures>&
-GetExperimentalFeaturesTLS() {
-  static base::NoDestructor<base::ThreadLocalOwnedPointer<ExperimentalFeatures>>
-      experimental_features_tls;
-  return *experimental_features_tls;
-}
-
-ExperimentalFeatures* GetOrCreateExperimentalFeatures() {
-  auto& tls = GetExperimentalFeaturesTLS();
-  ExperimentalFeatures* ptr = tls.Get();
-  if (ptr) {
-    return ptr;
-  }
-
-  tls.Set(std::make_unique<ExperimentalFeatures>());
-  return tls.Get();
-}
+thread_local std::optional<ExperimentalFeatures> g_experimental_features;
 
 std::optional<int> FromIntPointer(const int* val) {
   if (!val) {
@@ -106,15 +87,14 @@ void SetExperimentalFeaturesForCurrentThread(
   experiment_features.video_renderer_min_input_buffers =
       FromIntPointer(extension_features->video_renderer_min_input_buffers);
 
-  *GetOrCreateExperimentalFeatures() = experiment_features;
+  g_experimental_features = experiment_features;
 }
 
 const ExperimentalFeatures& GetExperimentalFeaturesForCurrentThread() {
-  ExperimentalFeatures* current = GetExperimentalFeaturesTLS().Get();
-  SB_CHECK(current)
+  SB_CHECK(g_experimental_features.has_value())
       << "ExperimentalFeatures are not set. This method was likely "
          "called on the wrong thread or a race condition occurred.";
-  return *current;
+  return *g_experimental_features;
 }
 
 const void* GetExperimentalFeaturesConfigurationApi() {

--- a/starboard/shared/starboard/experimental_features.cc
+++ b/starboard/shared/starboard/experimental_features.cc
@@ -27,6 +27,8 @@ namespace {
 static_assert(
     std::is_trivially_destructible<std::optional<ExperimentalFeatures>>::value,
     "g_experimental_features must be trivially destructible.");
+static_assert(sizeof(ExperimentalFeatures) < 256,
+              "ExperimentalFeatures is too large for thread-local storage.");
 thread_local std::optional<ExperimentalFeatures> g_experimental_features;
 
 std::optional<int> FromIntPointer(const int* val) {

--- a/starboard/shared/starboard/experimental_features.cc
+++ b/starboard/shared/starboard/experimental_features.cc
@@ -15,6 +15,7 @@
 #include "starboard/shared/starboard/experimental_features.h"
 
 #include <optional>
+#include <type_traits>
 
 #include "starboard/common/log.h"
 #include "starboard/extension/experimental_features.h"
@@ -23,6 +24,9 @@ namespace starboard {
 
 namespace {
 
+static_assert(
+    std::is_trivially_destructible<std::optional<ExperimentalFeatures>>::value,
+    "g_experimental_features must be trivially destructible.");
 thread_local std::optional<ExperimentalFeatures> g_experimental_features;
 
 std::optional<int> FromIntPointer(const int* val) {


### PR DESCRIPTION
Starboard components (specifically outside of Android) should not depend on Chromium's //base.

Issue: 509619283