### PR TITLE
cobalt: Fix EGL destruction crash on Shield

### DIFF
--- a/ui/gl/gl_context_egl.cc
+++ b/ui/gl/gl_context_egl.cc
@@ -411,10 +411,20 @@ void GLContextEGL::Destroy() {
   ReleaseBackpressureFences();
   OnContextWillDestroy();
   if (context_) {
+#if BUILDFLAG(IS_COBALT)
+    EGLDisplay display = gl_display_->GetDisplay();
+    if (display != EGL_NO_DISPLAY) {
+      if (!eglDestroyContext(display, context_)) {
+        LOG(ERROR) << "eglDestroyContext failed with error "
+                   << GetLastEGLErrorString();
+      }
+    }
+#else  // BUILDFLAG(IS_COBALT)
     if (!eglDestroyContext(gl_display_->GetDisplay(), context_)) {
       LOG(ERROR) << "eglDestroyContext failed with error "
                  << GetLastEGLErrorString();
     }
+#endif  // BUILDFLAG(IS_COBALT)
 
     context_ = nullptr;
   }


### PR DESCRIPTION
Ensure the EGL display is valid before calling eglDestroyContext. On
NVIDIA Shield devices, passing an invalid display handle to the EGL
driver during destruction can result in a crash. This change adds a
safety check to verify the display is not EGL_NO_DISPLAY.

Issue: 517926212