### PR TITLE
Remove the libraries from the ignore list

### DIFF
--- a/starboard/tools/api_leak_detector/libraries_to_ignore
+++ b/starboard/tools/api_leak_detector/libraries_to_ignore
@@ -1,11 +1,1 @@
 # Allowlisted Libraries
-
-libANGLE.a
-libangle_common.a
-libffmpeg_dynamic_load.a
-libgtest.a
-libpreprocessor.a
-libstarboard_base_symbolize.a
-libstarboard_platform.a
-libangle_gpu_info_util.a
-libtranslator.a


### PR DESCRIPTION
This list was used in C25 to filter starboard related libraries. This is no longer needed as we use different toolchains and the output is separated.

Bug: 437417239