### PR TITLE
Cherry pick PR #9868: cobalt: Register dummy H5vccUpdater binders

### DIFF
--- a/cobalt/browser/cobalt_browser_interface_binders.cc
+++ b/cobalt/browser/cobalt_browser_interface_binders.cc
@@ -31,6 +31,7 @@
 #include "cobalt/browser/h5vcc_storage/public/mojom/h5vcc_storage.mojom.h"
 #include "cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h"
 #include "cobalt/browser/h5vcc_system/public/mojom/h5vcc_system.mojom.h"
+#include "cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom.h"
 #include "cobalt/browser/performance/performance_impl.h"
 #include "cobalt/browser/performance/public/mojom/performance.mojom.h"
 #include "cobalt/media/service/mojom/platform_window_provider.mojom.h"
@@ -110,13 +111,36 @@ void PopulateCobaltFrameBinders(
 #if BUILDFLAG(USE_EVERGREEN)
   binder_map->Add<h5vcc_updater::mojom::H5vccUpdater>(
       base::BindRepeating(&h5vcc_updater::H5vccUpdaterImpl::Create));
+#else
+  // Always register a binder for H5vccUpdater to prevent the browser
+  // from killing the Mojo connection if the renderer probes for this interface.
+  // If this is not registered, it disconnects the overall
+  // BrowserInterfaceBroker for the frame.
+  binder_map->Add<h5vcc_updater::mojom::H5vccUpdater>(base::BindRepeating(
+      [](content::RenderFrameHost*,
+         mojo::PendingReceiver<h5vcc_updater::mojom::H5vccUpdater>) {
+        VLOG(1) << "Ignoring H5vccUpdater request for non-Evergreen build.";
+      }));
+#endif
+
+// Always register a binder for H5vccUpdaterSideloading to prevent the browser
+// from killing the Mojo connection if the renderer probes for this interface.
+// If this is not registered, it disconnects the overall BrowserInterfaceBroker
+// for the frame.
 // TODO(b/458483469): Remove the ALLOW_EVERGREEN_SIDELOADING check after
 // security review.
-#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+#if BUILDFLAG(USE_EVERGREEN) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && \
+    ALLOW_EVERGREEN_SIDELOADING
   binder_map->Add<h5vcc_updater::mojom::H5vccUpdaterSideloading>(
       base::BindRepeating(&h5vcc_updater::H5vccUpdaterSideloadingImpl::Create));
-#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
-#endif  // BUILDFLAG(USE_EVERGREEN)
+#else
+  binder_map->Add<
+      h5vcc_updater::mojom::H5vccUpdaterSideloading>(base::BindRepeating(
+      [](content::RenderFrameHost*,
+         mojo::PendingReceiver<h5vcc_updater::mojom::H5vccUpdaterSideloading>) {
+        VLOG(1) << "Ignoring H5vccUpdaterSideloading request.";
+      }));
+#endif
   binder_map->Add<h5vcc_storage::mojom::H5vccStorage>(
       base::BindRepeating(&h5vcc_storage::H5vccStorageImpl::Create));
   binder_map->Add<media::mojom::PlatformWindowProvider>(


### PR DESCRIPTION
Register dummy binders for H5vccUpdater and H5vccUpdaterSideloading Mojo
interfaces in builds where they are not natively supported (e.g.,
non-Evergreen or Linux-x64).

Previously, JavaScript probing for these interfaces would result in a
ReportBadMessage error if no binder was registered. This error caused
the
BrowserInterfaceBroker (Mojo Master Pipe) to disconnect for the entire
frame. This disconnection prevented subsequent interface requests, such
as MediaDevicesDispatcherHost for getUserMedia(), from reaching the
browser process, leading to microphone recognition failures. Registering
dummy binders ensures these probes fail gracefully without severing the
Mojo connection.

Bug: 479656309
Bug: 515122610