### PR TITLE
fix: Add missing semicolon in starboard_renderer_unittest

### DIFF
--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -106,7 +106,7 @@ class MockSbPlayerInterface : public SbPlayerInterface {
 
   bool GetUrlPlayerOutputModeSupported(
       SbPlayerOutputMode output_mode) override {
-    return true
+    return true;
   }
 #endif  // SB_HAS(PLAYER_WITH_URL)
 


### PR DESCRIPTION
Add a missing semicolon that caused a build failure in the
starboard_renderer_unittest test file.

Bug: 512045535