### PR TITLE
tvos: Implement UrlPlayer for native HLS playback

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -20,6 +20,7 @@
 
 #include "base/task/bind_post_task.h"
 #include "base/time/time.h"
+#include "build/build_config.h"
 #include "cobalt/media/service/mojom/platform_window_provider.mojom.h"
 #include "cobalt/renderer/cobalt_render_frame_observer.h"
 #include "cobalt/shell/common/url_constants.h"
@@ -45,6 +46,10 @@
 #include "third_party/blink/public/web/web_security_policy.h"
 #include "third_party/blink/public/web/web_view.h"
 #include "ui/gfx/geometry/size_conversions.h"
+
+#if BUILDFLAG(IS_IOS_TVOS)
+#include "media/starboard/url_player_demuxer.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace cobalt {
 
@@ -366,6 +371,20 @@ void CobaltContentRendererClient::PostSandboxInitialized() {
     unregister_thread_closure = base::HangWatcher::RegisterThread(
         base::HangWatcher::ThreadType::kRendererThread);
   }
+}
+
+std::unique_ptr<::media::Demuxer>
+CobaltContentRendererClient::OverrideDemuxerForUrl(
+    content::RenderFrame* render_frame,
+    const GURL& url,
+    scoped_refptr<base::SequencedTaskRunner> task_runner) {
+#if BUILDFLAG(IS_IOS_TVOS)
+  if (::media::IsHlsUrl(url)) {
+    return std::make_unique<::media::UrlPlayerDemuxer>(std::move(task_runner),
+                                                       url);
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+  return nullptr;
 }
 
 }  // namespace cobalt

--- a/cobalt/renderer/cobalt_content_renderer_client.h
+++ b/cobalt/renderer/cobalt_content_renderer_client.h
@@ -16,6 +16,7 @@
 #define COBALT_RENDERER_COBALT_CONTENT_RENDERER_CLIENT_H_
 
 #include <atomic>
+#include <memory>
 
 #include "base/functional/callback.h"
 #include "base/memory/weak_ptr.h"
@@ -27,6 +28,7 @@
 #include "cobalt/media/audio/cobalt_audio_device_factory.h"
 #include "cobalt/media/service/mojom/platform_window_provider.mojom.h"
 #include "content/public/renderer/content_renderer_client.h"
+#include "media/base/demuxer.h"
 #include "media/base/key_systems_support_registration.h"
 #include "media/base/starboard/renderer_factory_traits.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -74,6 +76,10 @@ class CobaltContentRendererClient : public content::ContentRendererClient {
   void GetStarboardRendererFactoryTraits(
       ::media::RendererFactoryTraits* traits) override;
   void PostSandboxInitialized() override;
+  std::unique_ptr<::media::Demuxer> OverrideDemuxerForUrl(
+      content::RenderFrame* render_frame,
+      const GURL& url,
+      scoped_refptr<base::SequencedTaskRunner> task_runner) override;
 
   uint64_t GetSbWindowHandle() const { return sb_window_handle_; }
 

--- a/media/base/demuxer.h
+++ b/media/base/demuxer.h
@@ -12,6 +12,7 @@
 #include <vector>
 
 #include "base/time/time.h"
+#include "build/build_config.h"
 #include "media/base/container_names.h"
 #include "media/base/data_source.h"
 #include "media/base/demuxer_stream.h"
@@ -38,6 +39,9 @@ enum class DemuxerType {
   kFrameInjectingDemuxer = 5,
   kStreamProviderDemuxer = 6,
   kManifestDemuxer = 7,
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+  kUrlPlayerDemuxer = 8,  // URL player placeholder demuxer.
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 class MEDIA_EXPORT DemuxerHost {

--- a/media/base/media_resource.cc
+++ b/media/base/media_resource.cc
@@ -25,4 +25,10 @@ DemuxerStream* MediaResource::GetFirstStream(DemuxerStream::Type type) {
   return nullptr;
 }
 
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+GURL MediaResource::GetMediaUrl() const {
+  return GURL();
+}
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+
 }  // namespace media

--- a/media/base/media_resource.h
+++ b/media/base/media_resource.h
@@ -9,8 +9,12 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/time/time.h"
+#include "build/build_config.h"
 #include "media/base/demuxer_stream.h"
 #include "media/base/media_export.h"
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "url/gurl.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace media {
 
@@ -41,6 +45,11 @@ class MEDIA_EXPORT MediaResource {
   // A helper function that return the first stream of the given `type` if one
   // exists or a null pointer if there is no streams of that type.
   DemuxerStream* GetFirstStream(DemuxerStream::Type type);
+
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Returns the media URL for URL player.
+  virtual GURL GetMediaUrl() const;
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 }  // namespace media

--- a/media/mojo/clients/starboard/starboard_renderer_client.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client.cc
@@ -20,6 +20,7 @@
 #include "base/functional/bind.h"
 #include "base/time/time.h"
 #include "base/unguessable_token.h"
+#include "build/build_config.h"
 #include "media/base/media_log.h"
 #include "media/base/media_resource.h"
 #include "media/base/media_switches.h"
@@ -29,6 +30,10 @@
 #include "media/video/gpu_video_accelerator_factories.h"
 #include "mojo/public/cpp/bindings/callback_helpers.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
+
+#if BUILDFLAG(IS_IOS_TVOS)
+#include "url/gurl.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 #if BUILDFLAG(IS_ANDROID)
 #include "base/task/bind_post_task.h"
@@ -351,8 +356,18 @@ void StarboardRendererClient::InitializeMojoRenderer(
   DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
   DCHECK(AreMojoPipesConnected());
 
-  if (base::FeatureList::IsEnabled(kCobaltBypassMojoForMedia) ||
-      bypass_mojo_for_media_) {
+  // URL player is incompatible with the bypass bridge because the bypass
+  // bridge proxies demuxer streams, while the URL player delegates playback
+  // entirely to the native platform player.
+  bool is_url_player = false;
+#if BUILDFLAG(IS_IOS_TVOS)
+  GURL url = media_resource->GetMediaUrl();
+  is_url_player = url.is_valid();
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+
+  if (!is_url_player &&
+      (base::FeatureList::IsEnabled(kCobaltBypassMojoForMedia) ||
+       bypass_mojo_for_media_)) {
     bypass_bridge_ = base::MakeRefCounted<MojoRendererBypassBridge>(
         media_task_runner_,
         base::BindRepeating(&StarboardRendererClient::OnTimeUpdateFromBridge,
@@ -377,6 +392,12 @@ void StarboardRendererClient::InitializeMojoRenderer(
             false));
     return;
   }
+
+#if BUILDFLAG(IS_IOS_TVOS)
+  if (is_url_player) {
+    renderer_extension_->SetSourceUrl(url.spec());
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   MojoRendererWrapper::Initialize(media_resource, client, std::move(init_cb));
 }

--- a/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
@@ -20,6 +20,7 @@
 #include "base/test/mock_callback.h"
 #include "base/test/scoped_command_line.h"
 #include "base/test/task_environment.h"
+#include "build/build_config.h"
 #include "media/base/fake_demuxer_stream.h"
 #include "media/base/media_switches.h"
 #include "media/base/mock_media_log.h"
@@ -96,7 +97,9 @@ class FakeStarboardRendererExtension
 #endif  // BUILDFLAG(IS_ANDROID)
   void OnGpuChannelTokenReady(
       mojom::CommandBufferIdPtr command_buffer_id) override {}
-
+#if BUILDFLAG(IS_IOS_TVOS)
+  void SetSourceUrl(const std::string& source_url) override {}
+#endif  // BUILDFLAG(IS_IOS_TVOS)
  private:
   FakeMojomRendererCallRecord* record_ = nullptr;
 };

--- a/media/mojo/mojom/media_types.mojom
+++ b/media/mojo/mojom/media_types.mojom
@@ -662,6 +662,8 @@ enum DemuxerType {
   kFrameInjectingDemuxer = 5,
   kStreamProviderDemuxer = 6,
   kManifestDemuxer = 7,
+  [EnableIf=use_starboard_media&is_ios]
+  kUrlPlayerDemuxer = 8,  // URL player placeholder demuxer.
 };
 
 // See media::CreateCdmStatus

--- a/media/mojo/mojom/media_types_enum_mojom_traits.h
+++ b/media/mojo/mojom/media_types_enum_mojom_traits.h
@@ -391,7 +391,7 @@ struct EnumTraits<media::mojom::RendererType, ::media::RendererType> {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
       case ::media::RendererType::kStarboard:
         return media::mojom::RendererType::kStarboard;
-#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
     }
 
     NOTREACHED();
@@ -436,7 +436,7 @@ struct EnumTraits<media::mojom::RendererType, ::media::RendererType> {
       case media::mojom::RendererType::kStarboard:
         *output = ::media::RendererType::kStarboard;
         return true;
-#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
     }
 
     NOTREACHED();
@@ -461,6 +461,10 @@ struct EnumTraits<media::mojom::DemuxerType, ::media::DemuxerType> {
         return media::mojom::DemuxerType::kStreamProviderDemuxer;
       case ::media::DemuxerType::kManifestDemuxer:
         return media::mojom::DemuxerType::kManifestDemuxer;
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+      case ::media::DemuxerType::kUrlPlayerDemuxer:
+        return media::mojom::DemuxerType::kUrlPlayerDemuxer;
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
     }
 
     NOTREACHED();
@@ -492,6 +496,11 @@ struct EnumTraits<media::mojom::DemuxerType, ::media::DemuxerType> {
       case media::mojom::DemuxerType::kManifestDemuxer:
         *output = ::media::DemuxerType::kManifestDemuxer;
         return true;
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+      case media::mojom::DemuxerType::kUrlPlayerDemuxer:
+        *output = ::media::DemuxerType::kUrlPlayerDemuxer;
+        return true;
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
     }
 
     NOTREACHED();

--- a/media/mojo/mojom/renderer_extensions.mojom
+++ b/media/mojo/mojom/renderer_extensions.mojom
@@ -151,6 +151,10 @@ interface StarboardRendererExtension {
   // Initialize media bypass bridge in single-process mode.
   InitializeWithBypassBridge(uint32 bypass_bridge_id) => (bool success);
 
+  [EnableIf=is_ios]
+  // Pass source URL for URL player.
+  SetSourceUrl(string source_url);
+
   [EnableIf=is_android]
   // Notify StarboardRendererWrapper when the current OverlayInfo changes.
   OnOverlayInfoChanged(OverlayInfo overlay_info);

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -20,6 +20,7 @@
 #include "base/functional/callback_helpers.h"
 #include "base/task/bind_post_task.h"
 #include "base/time/time.h"
+#include "build/build_config.h"
 #include "media/base/demuxer_stream.h"
 #include "media/base/media_resource.h"
 #include "media/base/starboard/starboard_rendering_mode.h"
@@ -514,6 +515,13 @@ void StarboardRendererWrapper::InitializeWithBypassBridge(
       std::move(audio_proxy), std::move(video_proxy));
   std::move(callback).Run(true);
 }
+
+#if BUILDFLAG(IS_IOS_TVOS)
+void StarboardRendererWrapper::SetSourceUrl(const std::string& source_url) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  GetRenderer()->SetSourceUrl(source_url);
+}
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 #if BUILDFLAG(IS_ANDROID)
 void StarboardRendererWrapper::OnOverlayInfoChanged(

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -104,6 +104,9 @@ class StarboardRendererWrapper
   void InitializeWithBypassBridge(
       uint32_t bypass_bridge_id,
       InitializeWithBypassBridgeCallback callback) override;
+#if BUILDFLAG(IS_IOS_TVOS)
+  void SetSourceUrl(const std::string& source_url) override;
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 #if BUILDFLAG(IS_ANDROID)
   void OnOverlayInfoChanged(const OverlayInfo& overlay_info) override;
 #endif  // BUILDFLAG(IS_ANDROID)

--- a/media/starboard/BUILD.gn
+++ b/media/starboard/BUILD.gn
@@ -60,6 +60,12 @@ source_set("starboard") {
     ]
 
     deps += [ ":buildflags" ]
+    if (is_ios && target_platform == "tvos") {
+      sources += [
+        "url_player_demuxer.cc",
+        "url_player_demuxer.h",
+      ]
+    }
   }
 
   deps += [

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -29,6 +29,7 @@
 #include "media/base/video_codecs.h"
 #include "media/starboard/buildflags.h"
 #include "media/starboard/decoder_buffer_allocator.h"
+#include "starboard/common/log.h"
 #include "starboard/common/media.h"
 #include "starboard/common/player.h"
 #include "starboard/common/string.h"
@@ -212,6 +213,18 @@ void StarboardRenderer::Initialize(MediaResource* media_resource,
 
   client_ = client;
   init_cb_ = std::move(init_cb);
+
+#if BUILDFLAG(IS_IOS_TVOS)
+  if (IsUrlPlayer()) {
+    state_ = STATE_INITIALIZING;
+    if (get_sb_window_handle_cb_) {
+      get_sb_window_handle_cb_.Run();
+      return;
+    }
+    CreatePlayerBridge();
+    return;
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   audio_stream_ = media_resource->GetFirstStream(DemuxerStream::AUDIO);
   video_stream_ = media_resource->GetFirstStream(DemuxerStream::VIDEO);
@@ -530,6 +543,48 @@ void StarboardRenderer::OnSbWindowHandleReady(const uint64_t sb_window_handle) {
   CreatePlayerBridge();
 }
 
+#if BUILDFLAG(IS_IOS_TVOS)
+bool StarboardRenderer::IsUrlPlayer() const {
+  return !source_url_.empty();
+}
+
+void StarboardRenderer::OnUrlPlayerPresenting() {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  if (!player_bridge_) {
+    return;
+  }
+  int width = 0, height = 0;
+  player_bridge_->GetVideoResolution(&width, &height);
+  if (width > 0 && height > 0) {
+    gfx::Size size(width, height);
+    client_->OnVideoNaturalSizeChange(size);
+    // TODO(b/541996730): Handle resolution changes during adaptive HLS
+    // playback. Currently this is only called once at presenting state.
+    paint_video_hole_frame_cb_.Run(size);
+  } else {
+    LOG(WARNING) << "Platform player reported invalid dimensions (" << width
+                 << "x" << height
+                 << ") at presenting; skipping video hole update.";
+  }
+
+  // Re-apply playback rate; the platform player ignores rate changes
+  // before it is ready to play.
+  player_bridge_->SetPlaybackRate(playback_rate_);
+}
+
+void StarboardRenderer::SetSourceUrl(const std::string& source_url) {
+  DCHECK(task_runner_->RunsTasksInCurrentSequence());
+  source_url_ = source_url;
+}
+
+void StarboardRenderer::OnEncryptedMediaInitDataEncountered(
+    const char* init_data_type,
+    const unsigned char* init_data,
+    unsigned int init_data_length) {
+  // TODO: Forward encrypted media init data to the EME/DRM layer.
+}
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+
 #if BUILDFLAG(IS_ANDROID)
 void StarboardRenderer::OnOverlayInfoChanged(const OverlayInfo& overlay_info) {
   bool overlay_changed = !overlay_info_.RefersToSameOverlayAs(overlay_info);
@@ -578,11 +633,34 @@ SbPlayerInterface* StarboardRenderer::GetSbPlayerInterface() {
   return &sbplayer_interface_;
 }
 
+void StarboardRenderer::UpdateAudioWriteDuration() {
+#if BUILDFLAG(IS_IOS_TVOS)
+  // URL player handles audio natively; no write duration to configure.
+  if (IsUrlPlayer()) {
+    return;
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+  // TODO(b/267678497): When `player_bridge_->GetAudioConfigurations()`
+  // returns no audio configurations, update the write durations again
+  // before the SbPlayer reaches `kSbPlayerStatePresenting`.
+  audio_write_duration_for_preroll_ = audio_write_duration_ =
+      HasRemoteAudioOutputs(player_bridge_->GetAudioConfigurations())
+          ? audio_write_duration_remote_
+          : audio_write_duration_local_;
+  LOG(INFO) << "audio write duration at " << audio_write_duration_
+            << ", max_video_capabilities_ at " << max_video_capabilities_;
+}
+
 void StarboardRenderer::CreatePlayerBridge() {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
   DCHECK(init_cb_);
   DCHECK_EQ(state_, STATE_INITIALIZING);
+#if BUILDFLAG(IS_IOS_TVOS)
+  DCHECK(audio_stream_ || video_stream_ ||
+         (IsUrlPlayer() && !audio_stream_ && !video_stream_));
+#else
   DCHECK(audio_stream_ || video_stream_);
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   TRACE_EVENT0("media", "StarboardRenderer::CreatePlayerBridge");
 
@@ -622,27 +700,43 @@ void StarboardRenderer::CreatePlayerBridge() {
   // number of active players.
   player_bridge_.reset();
 
-  LOG(INFO) << "Creating SbPlayerBridge.";
-
-  player_bridge_.reset(new SbPlayerBridge(
-      GetSbPlayerInterface(), task_runner_,
-      get_decode_target_graphics_context_provider_func_, audio_config,
-      audio_mime_type, video_config, video_mime_type,
-      // TODO(b/326497953): Support suspend/resume.
-      // TODO(b/326508279): Support background mode.
-      sb_window_, drm_system_, this,
-      // TODO(b/326497953): Support suspend/resume.
-      false,
-      // TODO(b/326825450): Revisit 360 videos.
-      kSbPlayerOutputModeInvalid, max_video_capabilities_,
-      // TODO(b/326654546): Revisit HTMLVideoElement.setMaxVideoInputSize.
-      /*max_video_input_size=*/-1, experimental_features_
+#if BUILDFLAG(IS_IOS_TVOS)
+  if (IsUrlPlayer()) {
+    player_bridge_.reset(new SbPlayerBridge(
+        GetSbPlayerInterface(), task_runner_, source_url_, sb_window_, this,
+        /*allow_resume_after_suspend=*/false, kSbPlayerOutputModePunchOut,
+        base::BindRepeating(
+            &StarboardRenderer::OnEncryptedMediaInitDataEncountered,
+            base::Unretained(this))
+#if BUILDFLAG(COBALT_MEDIA_ENABLE_CVAL)
+            ,
+        /*pipeline_identifier=*/""
+#endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_CVAL)
+        ));
+  } else {
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+    player_bridge_.reset(new SbPlayerBridge(
+        GetSbPlayerInterface(), task_runner_,
+        get_decode_target_graphics_context_provider_func_, audio_config,
+        audio_mime_type, video_config, video_mime_type,
+        // TODO(b/326497953): Support suspend/resume.
+        // TODO(b/326508279): Support background mode.
+        sb_window_, drm_system_, this,
+        // TODO(b/326497953): Support suspend/resume.
+        false,
+        // TODO(b/326825450): Revisit 360 videos.
+        kSbPlayerOutputModeInvalid, max_video_capabilities_,
+        // TODO(b/326654546): Revisit HTMLVideoElement.setMaxVideoInputSize.
+        /*max_video_input_size=*/-1, experimental_features_
 #if BUILDFLAG(IS_ANDROID)
-      ,
-      // TODO: b/475294958 - Revisit platform-specific codes above starboard.
-      surface_view_
+        ,
+        // TODO: b/475294958 - Revisit platform-specific codes above starboard.
+        surface_view_
 #endif  // BUILDFLAG(IS_ANDROID)
-      ));
+        ));
+#if BUILDFLAG(IS_IOS_TVOS)
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   if (!player_bridge_->IsValid()) {
     error_message = player_bridge_->GetPlayerCreationErrorMessage();
@@ -661,17 +755,7 @@ void StarboardRenderer::CreatePlayerBridge() {
     return;
   }
 
-  // TODO(b/267678497): When `player_bridge_->GetAudioConfigurations()`
-  // returns no audio configurations, update the write durations again
-  // before the SbPlayer reaches `kSbPlayerStatePresenting`.
-  audio_write_duration_for_preroll_ = audio_write_duration_ =
-      HasRemoteAudioOutputs(player_bridge_->GetAudioConfigurations())
-          ? audio_write_duration_remote_
-          : audio_write_duration_local_;
-  LOG(INFO) << "SbPlayerBridge created, with audio write duration at "
-            << audio_write_duration_for_preroll_
-            << " and with max_video_capabilities_ at "
-            << max_video_capabilities_;
+  UpdateAudioWriteDuration();
 
   ApplyPendingBounds();
 
@@ -849,6 +933,12 @@ void StarboardRenderer::OnStatisticsUpdate(const PipelineStatistics& stats) {
 void StarboardRenderer::OnNeedData(DemuxerStream::Type type,
                                    int max_number_of_buffers_to_write) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
+#if BUILDFLAG(IS_IOS_TVOS)
+  // URL player handles all buffering natively; OnNeedData should never
+  // be called because SbUrlPlayerCreate does not take a decoder-status
+  // callback. This is defensive guard.
+  DCHECK(!IsUrlPlayer());
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   // In case if the callback is fired when creation of the `player_bridge_`
   // fails.
@@ -984,11 +1074,12 @@ void StarboardRenderer::OnPlayerStatus(SbPlayerState state) {
           FROM_HERE,
           base::BindOnce(&StarboardRenderer::OnBufferingStateChange,
                          weak_factory_.GetWeakPtr(), buffering_state_));
-      audio_write_duration_for_preroll_ = audio_write_duration_ =
-          HasRemoteAudioOutputs(player_bridge_->GetAudioConfigurations())
-              ? audio_write_duration_remote_
-              : audio_write_duration_local_;
-      LOG(INFO) << "Audio write duration is " << audio_write_duration_;
+      UpdateAudioWriteDuration();
+#if BUILDFLAG(IS_IOS_TVOS)
+      if (IsUrlPlayer()) {
+        OnUrlPlayerPresenting();
+      }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
       break;
     case kSbPlayerStateEndOfStream:
       client_->OnEnded();

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -22,6 +22,7 @@
 #include "base/memory/scoped_refptr.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/time/time.h"
+#include "build/build_config.h"
 #include "media/base/cdm_context.h"
 #include "media/base/decoder_buffer.h"
 #include "media/base/demuxer_stream.h"
@@ -122,6 +123,12 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
 
   void OnVideoGeometryChange(const gfx::Rect& output_rect);
   void OnSbWindowHandleReady(const uint64_t sb_window_handle);
+#if BUILDFLAG(IS_IOS_TVOS)
+  void SetSourceUrl(const std::string& source_url);
+  void OnEncryptedMediaInitDataEncountered(const char* init_data_type,
+                                           const unsigned char* init_data,
+                                           unsigned int init_data_length);
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 #if BUILDFLAG(IS_ANDROID)
   void OnOverlayInfoChanged(const OverlayInfo& overlay_info);
 #endif  // BUILDFLAG(IS_ANDROID)
@@ -150,6 +157,15 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
     STATE_ERROR
   };
 
+#if BUILDFLAG(IS_IOS_TVOS)
+  // Returns true when the renderer is operating in URL player mode.
+  bool IsUrlPlayer() const;
+  // Handles presenting state for URL player: propagates video resolution
+  // for hole-punch rendering and re-applies playback rate.
+  void OnUrlPlayerPresenting();
+#endif  // BUILDFLAG(IS_IOS_TVOS)
+
+  void UpdateAudioWriteDuration();
   void CreatePlayerBridge();
   void ApplyPendingBounds();
   void UpdateDecoderConfig(DemuxerStream* stream);
@@ -200,6 +216,9 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   const TimeDelta audio_write_duration_local_;
   const TimeDelta audio_write_duration_remote_;
   const std::string max_video_capabilities_;
+#if BUILDFLAG(IS_IOS_TVOS)
+  std::string source_url_;
+#endif  // BUILDFLAG(IS_IOS_TVOS)
   const StarboardRendererConfig::ExperimentalFeatures experimental_features_;
   // TODO: b/375674101 - Connect this to h5vcc setting.
   const int max_samples_per_write_;

--- a/media/starboard/url_player_demuxer.cc
+++ b/media/starboard/url_player_demuxer.cc
@@ -1,0 +1,156 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/starboard/url_player_demuxer.h"
+
+#include <utility>
+#include <vector>
+
+#include "base/functional/bind.h"
+#include "base/logging.h"
+#include "base/task/sequenced_task_runner.h"
+#include "media/base/audio_decoder_config.h"
+#include "media/base/channel_layout.h"
+#include "media/base/decoder_buffer.h"
+#include "media/base/media_track.h"
+#include "media/base/sample_format.h"
+#include "media/base/video_decoder_config.h"
+
+namespace media {
+
+bool IsHlsUrl(const GURL& url) {
+  auto path = url.path_piece();
+  return path.ends_with(".m3u8") ||
+         path.find("hls_variant") != std::string_view::npos;
+}
+
+UrlPlayerDemuxerStream::UrlPlayerDemuxerStream(Type type) : type_(type) {}
+
+UrlPlayerDemuxerStream::~UrlPlayerDemuxerStream() = default;
+
+void UrlPlayerDemuxerStream::Read(uint32_t count, ReadCB read_cb) {
+  NOTREACHED();
+}
+
+// Returns a placeholder audio config to satisfy Mojo IPC stream
+// initialization. The URL player handles audio decoding natively;
+// this config is not used for actual decoding.
+AudioDecoderConfig UrlPlayerDemuxerStream::audio_decoder_config() {
+  return AudioDecoderConfig(AudioCodec::kAAC, kSampleFormatS16,
+                            CHANNEL_LAYOUT_STEREO,
+                            /*samples_per_second=*/44100, /*extra_data=*/{},
+                            EncryptionScheme::kUnencrypted);
+}
+
+// Returns a placeholder video config to satisfy Mojo IPC stream
+// initialization. The URL player handles video decoding natively;
+// this config is not used for actual decoding.
+VideoDecoderConfig UrlPlayerDemuxerStream::video_decoder_config() {
+  static const gfx::Size kPlaceholderSize(1, 1);
+  return VideoDecoderConfig(
+      VideoCodec::kH264, VideoCodecProfile::H264PROFILE_BASELINE,
+      VideoDecoderConfig::AlphaMode::kIsOpaque, VideoColorSpace(),
+      kNoTransformation, kPlaceholderSize, gfx::Rect(kPlaceholderSize),
+      kPlaceholderSize, /*extra_data=*/{}, EncryptionScheme::kUnencrypted);
+}
+
+DemuxerStream::Type UrlPlayerDemuxerStream::type() const {
+  return type_;
+}
+
+bool UrlPlayerDemuxerStream::SupportsConfigChanges() {
+  return false;
+}
+
+UrlPlayerDemuxer::UrlPlayerDemuxer(
+    scoped_refptr<base::SequencedTaskRunner> media_task_runner,
+    GURL url)
+    : media_task_runner_(std::move(media_task_runner)), url_(std::move(url)) {
+  DCHECK(media_task_runner_);
+}
+
+UrlPlayerDemuxer::~UrlPlayerDemuxer() = default;
+
+std::vector<DemuxerStream*> UrlPlayerDemuxer::GetAllStreams() {
+  return {&audio_stream_, &video_stream_};
+}
+
+GURL UrlPlayerDemuxer::GetMediaUrl() const {
+  return url_;
+}
+
+std::string UrlPlayerDemuxer::GetDisplayName() const {
+  return "UrlPlayerDemuxer";
+}
+
+DemuxerType UrlPlayerDemuxer::GetDemuxerType() const {
+  return DemuxerType::kUrlPlayerDemuxer;
+}
+
+void UrlPlayerDemuxer::Initialize(DemuxerHost* host,
+                                  PipelineStatusCallback status_cb) {
+  DVLOG(1) << __func__;
+  host_ = host;
+  media_task_runner_->PostTask(
+      FROM_HERE, base::BindOnce(std::move(status_cb), PIPELINE_OK));
+}
+
+void UrlPlayerDemuxer::AbortPendingReads() {}
+void UrlPlayerDemuxer::StartWaitingForSeek(base::TimeDelta seek_time) {}
+void UrlPlayerDemuxer::CancelPendingSeek(base::TimeDelta seek_time) {}
+
+void UrlPlayerDemuxer::Seek(base::TimeDelta time,
+                            PipelineStatusCallback status_cb) {
+  DVLOG(1) << __func__ << "(" << time << ")";
+  media_task_runner_->PostTask(
+      FROM_HERE, base::BindOnce(std::move(status_cb), PIPELINE_OK));
+}
+
+// While the demuxer itself is not seekable, the underlying URL player is.
+bool UrlPlayerDemuxer::IsSeekable() const {
+  return true;
+}
+
+void UrlPlayerDemuxer::Stop() {}
+
+base::TimeDelta UrlPlayerDemuxer::GetStartTime() const {
+  return base::TimeDelta();
+}
+
+base::Time UrlPlayerDemuxer::GetTimelineOffset() const {
+  return base::Time();
+}
+
+int64_t UrlPlayerDemuxer::GetMemoryUsage() const {
+  return 0;
+}
+
+std::optional<container_names::MediaContainerName>
+UrlPlayerDemuxer::GetContainerForMetrics() const {
+  return std::nullopt;
+}
+
+void UrlPlayerDemuxer::OnTracksChanged(
+    DemuxerStream::Type track_type,
+    const std::vector<MediaTrack::Id>& track_ids,
+    base::TimeDelta curr_time,
+    TrackChangeCB change_completed_cb) {
+  std::vector<DemuxerStream*> streams;
+  std::move(change_completed_cb).Run(streams);
+  DLOG(WARNING) << "Track changes are not supported by UrlPlayerDemuxer.";
+}
+
+void UrlPlayerDemuxer::SetPlaybackRate(double rate) {}
+
+}  // namespace media

--- a/media/starboard/url_player_demuxer.h
+++ b/media/starboard/url_player_demuxer.h
@@ -1,0 +1,99 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_STARBOARD_URL_PLAYER_DEMUXER_H_
+#define MEDIA_STARBOARD_URL_PLAYER_DEMUXER_H_
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+#include "base/memory/raw_ptr.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/task/sequenced_task_runner.h"
+#include "media/base/demuxer.h"
+#include "media/base/demuxer_stream.h"
+#include "media/base/media_export.h"
+#include "url/gurl.h"
+
+namespace media {
+
+// Returns true if the URL looks like an HLS stream that the URL player
+// should handle.
+MEDIA_EXPORT bool IsHlsUrl(const GURL& url);
+
+// Placeholder stream to satisfy the stream-based pipeline initialization.
+// Owned by UrlPlayerDemuxer. Created and accessed on the media thread.
+class MEDIA_EXPORT UrlPlayerDemuxerStream : public DemuxerStream {
+ public:
+  explicit UrlPlayerDemuxerStream(Type type);
+  ~UrlPlayerDemuxerStream() override;
+
+  // DemuxerStream implementation.
+  void Read(uint32_t count, ReadCB read_cb) override;
+  AudioDecoderConfig audio_decoder_config() override;
+  VideoDecoderConfig video_decoder_config() override;
+  Type type() const override;
+  bool SupportsConfigChanges() override;
+
+ private:
+  const Type type_;
+};
+
+// Demuxer placeholder for URL player. Carries the media URL and exposes
+// placeholder streams required by the stream-based pipeline initialization.
+// Owned by PipelineImpl. Created and accessed on the media thread.
+class MEDIA_EXPORT UrlPlayerDemuxer : public Demuxer {
+ public:
+  UrlPlayerDemuxer(scoped_refptr<base::SequencedTaskRunner> media_task_runner,
+                   GURL url);
+  ~UrlPlayerDemuxer() override;
+
+  // MediaResource implementation.
+  std::vector<DemuxerStream*> GetAllStreams() override;
+  GURL GetMediaUrl() const override;
+
+  // Demuxer implementation.
+  std::string GetDisplayName() const override;
+  DemuxerType GetDemuxerType() const override;
+  void Initialize(DemuxerHost* host, PipelineStatusCallback status_cb) override;
+  void AbortPendingReads() override;
+  void StartWaitingForSeek(base::TimeDelta seek_time) override;
+  void CancelPendingSeek(base::TimeDelta seek_time) override;
+  void Seek(base::TimeDelta time, PipelineStatusCallback status_cb) override;
+  bool IsSeekable() const override;
+  void Stop() override;
+  base::TimeDelta GetStartTime() const override;
+  base::Time GetTimelineOffset() const override;
+  int64_t GetMemoryUsage() const override;
+  std::optional<container_names::MediaContainerName> GetContainerForMetrics()
+      const override;
+  void OnTracksChanged(DemuxerStream::Type track_type,
+                       const std::vector<MediaTrack::Id>& track_ids,
+                       base::TimeDelta curr_time,
+                       TrackChangeCB change_completed_cb) override;
+  void SetPlaybackRate(double rate) override;
+
+ private:
+  scoped_refptr<base::SequencedTaskRunner> media_task_runner_;
+  raw_ptr<DemuxerHost> host_ = nullptr;
+  const GURL url_;
+  UrlPlayerDemuxerStream audio_stream_{DemuxerStream::AUDIO};
+  UrlPlayerDemuxerStream video_stream_{DemuxerStream::VIDEO};
+};
+
+}  // namespace media
+
+#endif  // MEDIA_STARBOARD_URL_PLAYER_DEMUXER_H_

--- a/tools/metrics/histograms/enums.xml
+++ b/tools/metrics/histograms/enums.xml
@@ -19911,6 +19911,7 @@ from previous Chrome versions.
   <int value="5" label="kFrameInjectingDemuxer"/>
   <int value="6" label="kStreamProviderDemuxer"/>
   <int value="7" label="kManifestDemuxer"/>
+  <int value="8" label="kUrlPlayerDemuxer"/>
 </enum>
 
 <enum name="MediaEncryptionType">


### PR DESCRIPTION
Introduce native HLS support for tvOS by integrating the platform's
AVPlayer into the media pipeline. This allows Cobalt to leverage
native hardware acceleration and platform-specific HLS features
while maintaining the standard Chromium control interface.

A UrlPlayerDemuxer is injected via the demuxer_override mechanism
and exposes placeholder streams to satisfy Chromium's stream-based
initialization. Actual playback is delegated to the platform player.

The HLS URL is carried from the demuxer through
MediaResource::GetMediaUrl() in the renderer process, then bridged
to the GPU process via the StarboardRendererExtension Mojo interface.

Bug: 512045535