### PR TITLE
Update Omaha config mapping

### DIFF
--- a/cobalt/updater/configurator.cc
+++ b/cobalt/updater/configurator.cc
@@ -14,7 +14,7 @@
 
 #include "cobalt/updater/configurator.h"
 
-#include <regex>
+#include <cctype>
 #include <set>
 #include <utility>
 
@@ -281,18 +281,32 @@ update_client::UpdaterStateProvider Configurator::GetUpdaterStateProvider()
 std::string Configurator::GetAppGuidHelper(const std::string& updater_channel,
                                            const std::string& version,
                                            const int sb_version) {
-  if (updater_channel == "ltsnightly" || updater_channel == "ltsnightlyqa") {
-    return kOmahaCobaltLTSNightlyAppID;
+  if (updater_channel == "27nightly" || updater_channel == "27nightlyqa") {
+    return kOmahaCobalt27NightlyAppID;
   }
   if (version.find(".lts.") == std::string::npos &&
       version.find(".master.") != std::string::npos) {
     return kOmahaCobaltTrunkAppID;
   }
   std::string channel(updater_channel);
-  // This regex matches to all static channels for C25 and newer in the format
+  // This matches to all static channels for C27 and newer in the format
   // of XXltsY.
-  if (std::regex_match(updater_channel,
-                       std::regex("(2[5-9]|[3-9][0-9])lts\\d+"))) {
+  bool is_static = false;
+  if (updater_channel.size() >= 6 && std::isdigit(updater_channel[0]) &&
+      std::isdigit(updater_channel[1]) &&
+      updater_channel.compare(2, 3, "lts") == 0) {
+    int major = (updater_channel[0] - '0') * 10 + (updater_channel[1] - '0');
+    if (major >= 27) {
+      is_static = true;
+      for (size_t i = 5; i < updater_channel.size(); ++i) {
+        if (!std::isdigit(updater_channel[i])) {
+          is_static = false;
+          break;
+        }
+      }
+    }
+  }
+  if (is_static) {
     channel = "static";
   }
   auto it = kChannelAndSbVersionToOmahaIdMap.find(channel +
@@ -301,21 +315,18 @@ std::string Configurator::GetAppGuidHelper(const std::string& updater_channel,
     return it->second;
   }
   LOG(INFO) << "Configurator::GetAppGuidHelper updater channel and starboard "
-            << "combination is undefined with the new Omaha configs.";
+            << "combination is undefined with the new Omaha configs. Using "
+               "prod config";
 
-  // All undefined channel requests go to prod configs except for static
-  // channel requests for C24 and older.
-  // TODO(b/449024263): Replace regex matchers with substring_set_matcher or re2
-  if (!std::regex_match(updater_channel, std::regex("2[0-4]lts\\d+")) &&
-      sb_version >= 14 && sb_version <= 16) {
-    it = kChannelAndSbVersionToOmahaIdMap.find("prod" +
-                                               std::to_string(sb_version));
-    if (it != kChannelAndSbVersionToOmahaIdMap.end()) {
-      return it->second;
-    }
+  // All undefined channel requests go to prod configs
+  it = kChannelAndSbVersionToOmahaIdMap.find("prod" +
+                                             std::to_string(sb_version));
+  if (it != kChannelAndSbVersionToOmahaIdMap.end()) {
+    return it->second;
   }
-  LOG(INFO) << __func__ << " starboard version is invalid.";
-  return kOmahaCobaltAppID;
+  LOG(INFO) << __func__
+            << "Starboard version is invalid. Using dev-branch config.";
+  return kOmahaCobaltTrunkAppID;
 }
 
 std::string Configurator::GetAppGuid() const {

--- a/cobalt/updater/util.cc
+++ b/cobalt/updater/util.cc
@@ -50,55 +50,27 @@ const char kUncompressedLibraryPath[] = "lib/libcobalt.so";
 
 const std::unordered_map<std::string, std::string>
     kChannelAndSbVersionToOmahaIdMap = {
-        {"control14", "{5F96FC23-F232-40B6-B283-FAD8DB21E1A7}"},
-        {"control15", "{409F15C9-4E10-4224-9DD1-BEE7E5A2A55B}"},
-        {"control16", "{30061C09-D926-4B82-8D42-600C06B6134C}"},
-        {"experiment14", "{9BCC272B-3F78-43FD-9B34-A3810AE1B85D}"},
-        {"experiment15", "{C412A665-9BAD-4981-93C0-264233720222}"},
-        {"experiment16", "{32B5CF5A-96A4-4F64-AD0E-7C62705222FF}"},
-        {"prod14", "{B3F9BCA2-8AD1-448F-9829-BB9F432815DE}"},
-        {"prod15", "{14ED1D09-DAD2-4FB2-A89B-3ADC82137BCD}"},
-        {"prod16", "{10F11416-0D9C-4CB1-A82A-0168594E8256}"},
-        {"qa14", "{94C5D27F-5981-46E8-BD4F-4645DBB5AFD3}"},
-        {"qa15", "{14ED1D09-DAD2-4FB2-A89B-3ADC82137BCD}"},
-        {"qa16", "{B725A22D-553A-49DC-BD61-F042B07C6B22}"},
-        {"rollback14", "{A83768A9-9556-48C2-8D5E-D7C845C16C19}"},
-        {"rollback15", "{1526831E-B130-43C1-B31A-AEE6E90063ED}"},
-        {"rollback16", "{2A1FCBE4-E4F9-4DC3-9E1A-700FBC1D551B}"},
-        {"static14", "{8001FE2C-F523-4AEC-A753-887B5CC35EBB}"},
-        {"static15", "{F58B7C5F-8DC5-4E32-8CF1-455F1302D609}"},
-        {"static16", "{A68BE0E4-7EE3-451A-9395-A789518FF7C5}"},
-        {"t1app14", "{7C8BCB72-705D-41A6-8189-D8312E795302}"},
-        {"t1app15", "{12A94004-F661-42A7-9DFC-325A4DA72D29}"},
-        {"t1app16", "{B677F645-A8DB-4014-BD95-C6C06715C7CE}"},
-        {"tcrash14", "{328C380E-75B4-4D7A-BF98-9B443ABA8FFF}"},
-        {"tcrash15", "{1A924F1C-A46D-4104-8CCE-E8DB3C6E0ED1}"},
-        {"tcrash16", "{0F876BD6-7C15-4B09-8C95-9FBBA2F93E94}"},
-        {"test14", "{DB2CC00C-4FA9-4DB8-A947-647CEDAEBF29}"},
-        {"test15", "{24A8A3BF-5944-4D5C-A5C4-BE00DF0FB9E1}"},
-        {"test16", "{5EADD81E-A98E-4F8B-BFAA-875509A51991}"},
-        {"tfailv14", "{F06C3516-8706-4579-9493-881F84606E98}"},
-        {"tfailv15", "{36CFD9A7-1A73-4E8A-AC05-E3013CC4F75C}"},
-        {"tfailv16", "{8F9EC6E9-B89D-4C75-9E7E-A5B9B0254844}"},
-        {"tmsabi14", "{87EDA0A7-ED13-4A72-9CD9-EBD4BED081AB}"},
-        {"tmsabi15", "{60296D57-2572-4B16-89EC-C9DA5A558E8A}"},
-        {"tmsabi16", "{1B915523-8ADD-4C66-9E8F-D73FB48A4296}"},
-        {"tnoop14", "{C407CF3F-21A4-47AA-9667-63E7EEA750CB}"},
-        {"tnoop15", "{FC568D82-E608-4F15-95F0-A539AB3F6E9D}"},
-        {"tnoop16", "{5F4E8AD9-067B-443A-8B63-A7CC4C95B264}"},
-        {"tseries114", "{0A8A3F51-3FAB-4427-848E-28590DB75AA1}"},
-        {"tseries115", "{92B7AC78-1B3B-4CE6-BA39-E1F50C4F5F72}"},
-        {"tseries116", "{6E7C6582-3DC4-4B48-97F2-FA43614B2B4D}"},
-        {"tseries214", "{7CB65840-5FA4-4706-BC9E-86A89A56B4E0}"},
-        {"tseries215", "{7CCA7DB3-C27D-4CEB-B6A5-50A4D6DE40DA}"},
-        {"tseries216", "{012BF4F5-8463-490F-B6C8-E9B64D972152}"},
+        {"control18", "{18C5B2A4-D8E2-4F31-9A4C-7E2B1D4F8A31}"},
+        {"dogfood18", "{29D6C3B5-E9F3-4042-AB5D-8F3C2E5A9B42}"},
+        {"experiment18", "{4BF8E5D7-0B15-4264-CD7F-A15E407CBD64}"},
+        {"prod18", "{5C09F6E8-1C26-4375-DE80-B26F518DCE75}"},
+        {"qa18", "{6D1A07F9-2D37-4486-EF91-C370629EDF86}"},
+        {"rollback18", "{7E2B180A-3E48-4597-F0A2-D48173AFE097}"},
+        {"static18", "{8F3C291B-4F59-46A8-01B3-E59284B0F1A8}"},
+        {"t1app18", "{904D3A2C-506A-47B9-12C4-F6A395C102B9}"},
+        {"tcrash18", "{A15E4B3D-617B-48CA-23D5-07B4A6D213CA}"},
+        {"test18", "{B26F5C4E-728C-49DB-34E6-18C5B7E324DB}"},
+        {"tfailv18", "{C3706D5F-839D-4AEC-45F7-29D6C8F435EC}"},
+        {"tmsabi18", "{D4817E60-94AE-4BFD-5608-3AE7D90546FD}"},
+        {"tnoop18", "{E5928F71-A5BF-4C0E-6719-4BF8EA16570E}"},
+        {"tseries118", "{F6A39082-B6C0-4D1F-782A-5C09FB27681F}"},
+        {"tseries218", "{07B4A193-C7D1-4E20-893B-6D1A0C387920}"},
 };
 
 const char kDefaultManifestVersion[] = "1.0.0";
 
-const char kOmahaCobaltAppID[] = "{6D4E53F3-CC64-4CB8-B6BD-AB0B8F300E1C}";
-const char kOmahaCobaltLTSNightlyAppID[] =
-    "{26CD2F67-091F-4680-A9A9-2229635B65A5}";
+const char kOmahaCobalt27NightlyAppID[] =
+    "{7B255C60-876C-41E1-A5E7-C0F9EBE78772}";
 const char kOmahaCobaltTrunkAppID[] = "{A9557415-DDCD-4948-8113-C643EFCF710C}";
 
 bool CreateProductDirectory(base::FilePath* path) {

--- a/cobalt/updater/util.h
+++ b/cobalt/updater/util.h
@@ -38,11 +38,7 @@ extern const std::unordered_map<std::string, std::string>
 // errors, or any other error unrelated to parsing the manifest.
 extern const char kDefaultManifestVersion[];
 
-// Legacy prod config containing all prod, tests and static channels with all
-// SB versions of C25 and prior.
-extern const char kOmahaCobaltAppID[];
-
-extern const char kOmahaCobaltLTSNightlyAppID[];
+extern const char kOmahaCobalt27NightlyAppID[];
 
 extern const char kOmahaCobaltTrunkAppID[];
 


### PR DESCRIPTION
Updates the updater Omaha config mappings with the new sb18 configs

The change also updates nightly channel identification to Cobalt 27,
adjusts static channel regex filters for newer versions, and
simplifies fallback logic for undefined channels to use prod or trunk
configurations.

Issue: 479816505