### PR TITLE
Add test retries in GitHub Actions pipelines for on-host and on-devic…

### DIFF
--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -67,10 +67,8 @@ runs:
       run: |
         set -x
 
-        # TODO(oxv): Fix dimensions. Pass as json? key-value pair?
-        python3 -u cobalt/tools/on_device_tests_gateway_client.py \
+        python3 cobalt/tools/run_device_tests.py \
           --token ${GITHUB_TOKEN} \
-          trigger \
           --test_type ${TEST_TYPE} \
           --device_family '${{ inputs.test_device_family }}' \
           --targets '${{ inputs.test_targets_json }}' \
@@ -92,58 +90,11 @@ runs:
           --label author_id-${GITHUB_PR_HEAD_USER_ID:-$GITHUB_COMMIT_AUTHOR_EMAIL} \
           --label branch:${GITHUB_REF_NAME} \
           --dimensions '${{ inputs.test_dimensions }}' \
-          ${TEST_ATTEMPTS:+"--test_attempts" "$TEST_ATTEMPTS"} \
           --gcs_archive_path "${GCS_ARTIFACTS_PATH}" \
-          --gcs_result_path "${{ inputs.gcs_results_path }}" || {
-            echo "Finished running tests..."
-            echo "The test session failed. See logs for details."
-            # Fail the job so it's easy to retrigger.
-            exit 1
-          }
-        echo "Finished running tests..."
-      shell: bash
-    - name: Download ${{ matrix.platform }} Test Results from GCS
-      if: always()
-      env:
-        TEST_TARGETS_JSON: ${{ inputs.test_targets_json }}
-      run: |
-        set -uxe
-        shopt -s globstar nullglob
+          --gcs_results_path "${{ inputs.gcs_results_path }}" \
+          --event_name "${GITHUB_EVENT_NAME}" \
+          --max_attempts "${TEST_ATTEMPTS:-3}"
 
-        test_output="${GITHUB_WORKSPACE}/results"
-        echo "test_output=${test_output}" >> $GITHUB_ENV
-
-        # Test results (xml and logs) must be in a subfolder in results_dir.
-        # to be picked up by the test result processor.
-        mkdir -p "${test_output}/${{ matrix.platform }}"
-        gsutil -q cp -r "${{ inputs.gcs_results_path }}/" "${test_output}/${{ matrix.platform }}"
-
-        # Check for missing result xml files.
-        exit_code=0
-        readarray -t test_targets < <(echo "$TEST_TARGETS_JSON" | jq -r '.[]')
-        for test_target_with_path in "${test_targets[@]}"; do
-          # Trim path prefix (before :).
-          test_target=${test_target_with_path#*:}
-          xml_files=("${test_output}"/${{ matrix.platform }}/**/"${test_target}"*.xml)
-          if [[ "${#xml_files[@]}" -eq 0 ]]; then
-            # No matching XML results found. Check if the test target is filtered.
-            test_filter_file="${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}/${test_target}_filter.json"
-            if [ ! -f "${test_filter_file}" ] || [ "$(jq -cr '.failing_tests[0]' "${test_filter_file}")" != '*' ]; then
-              echo "Test result xml is missing for ${test_target}."
-
-              # Try to find the crashed test in the log and create a fake junit xml for it.
-              log_path=("${test_output}"/${{ matrix.platform }}/**/"${test_target}"_log.txt)
-              xml_path=("${test_output}"/${{ matrix.platform }}/1/"${test_target}"_testoutput.xml)
-              python3 ${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py "${log_path}" "${xml_path}"
-              exit_code=1
-            fi
-          elif grep -e '<failure' -e '<error' ${xml_files}; then
-            # Double-check the result XML for failures. ODT service has been known to report incorrect status.
-            echo "::error::Found failures in the test xml."
-            exit_code=1
-          fi
-        done
-        exit ${exit_code}
       shell: bash
     - name: Archive Test Results
       uses: actions/upload-artifact@v4

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -34,6 +34,7 @@ runs:
     - name: Run Tests
       id: run-tests
       shell: bash
+      working-directory: unit_test/
       env:
         XVFB_SERVER_ARGS: "-screen 0 1920x1080x24i +render +extension GLX -noreset"
         GTEST_SHARD_INDEX: ${{ matrix.shard }}
@@ -62,62 +63,15 @@ runs:
         test_output="${results_dir}/shard_${{ matrix.shard }}"
         mkdir -p ${test_output}
 
-        failed_suites=""
-        cd unit_test/
+        python3 ${GITHUB_WORKSPACE}/cobalt/tools/run_host_tests.py \
+          --test_targets_json "out/${{ matrix.platform }}_${{ matrix.config }}/test_targets.json" \
+          --shard "${{ matrix.shard }}" \
+          --num_gtest_shards "${{ inputs.num_gtest_shards }}" \
+          --results_dir "${GITHUB_WORKSPACE}/results/shard_${{ matrix.shard }}" \
+          --event_name "${{ github.event_name }}" \
+          --filter_json_dir "${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}"
 
-        test_targets_json="out/${{ matrix.platform }}_${{ matrix.config }}/test_targets.json"
-        test_binaries=$(jq -cr '[.[] | select(.executable != null) | .executable] | join(" ")' "${test_targets_json}")
-        for test_binary_path in ${test_binaries}; do
-          filename=$(basename "${test_binary_path}")
-          test_binary="${filename%%.*}"
 
-          echo "Running tests for suite: ${test_binary}"
-
-          test_filter="*"
-          test_filter_json_dir="${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}/${test_binary}_filter.json"
-          if [ -f ${test_filter_json_dir} ]; then
-            test_filter=`jq -r '"-" + (.failing_tests | join(":"))' ${test_filter_json_dir}`
-          fi
-
-          echo "Test filter evaluated to: ${test_filter}"
-          xml_path="${test_output}/${test_binary}_result.xml"
-          log_path="${test_output}/${test_binary}_log.txt"
-          # TODO: Investigate test_runner.py
-
-          # Check if a wrapper script was generated for the test (e.g. by test_runner_script).
-          # If so, use it as the entrypoint to run tests.
-          wrapper_path="$(dirname "${test_binary_path}")/bin/run_${test_binary}"
-          if [[ -x "${wrapper_path}" ]]; then
-            ENTRYPOINT="./${wrapper_path}"
-          else
-            ENTRYPOINT="./${test_binary_path}"
-          fi
-
-          if [ "${test_filter}" == "-*" ]; then
-            echo "Skipped due to test filter." >  ${log_path}
-          else
-            /usr/bin/xvfb-run -a --server-args="${XVFB_SERVER_ARGS}" \
-                stdbuf -i0 -o0 -e0 $ENTRYPOINT \
-                --single-process-tests \
-                --gtest_shard_index="${GTEST_SHARD_INDEX}" \
-                --gtest_total_shards="${GTEST_TOTAL_SHARDS}" \
-                --gtest_output="xml:${xml_path}" \
-                --gtest_filter="${test_filter}" 2>&1 | tee ${log_path} || {
-              failed_suites="${failed_suites} ${test_binary}"
-            }
-
-            if [[ ! -f ${xml_path} ]]; then
-              # Test binary crashed. Generate a fake JUnit XML report with the last run test.
-              python3 ${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py "${log_path}" "${xml_path}"
-            fi
-          fi
-        done
-        echo "Finished running tests..."
-        if [[ -n "${failed_suites}" ]]; then
-          echo "Test suites failed:${failed_suites}"
-          # Fail the job so it's easy to retrigger.
-          exit 1
-        fi
     - name: Archive Test Results
       if: success() || failure()
       uses: actions/upload-artifact@v4

--- a/.github/actions/process_test_results/action.yaml
+++ b/.github/actions/process_test_results/action.yaml
@@ -19,16 +19,25 @@ inputs:
 runs:
   using: "composite"
   steps:
+    - name: Prepare Results for CI
+      shell: bash
+      run: |
+        python3 ${GITHUB_WORKSPACE}/cobalt/tools/prepare_results_for_ci.py \
+          --event_name "${{ github.event_name }}" \
+          --output_dir "${GITHUB_WORKSPACE}/processed_results" \
+          --glob "${{ inputs.results_glob }}" \
+          --num_shards "${{ inputs.num_gtest_shards }}"
+
     - name: Create Test Summary
       id: test-summary
       uses: test-summary/action@31493c76ec9e7aa675f1585d3ed6f1da69269a86
       with:
-        paths: ${{ inputs.results_glob }}
+        paths: "${{ github.workspace }}/processed_results/**/*.xml"
         output: test-report-summary.md
         show: "fail, skip"
 
     - name: Populate GitHub Summary
-      if: steps.test_summary.outputs.failed > 0
+      if: steps.test-summary.outputs.failed > 0
       run: cat test-report-summary.md >> $GITHUB_STEP_SUMMARY
       shell: bash
 
@@ -39,7 +48,7 @@ runs:
         TESTS_PASSED: ${{ steps.test-summary.outputs.passed }}
         TESTS_SKIPPED: ${{ steps.test-summary.outputs.skipped }}
         TESTS_TOTAL: ${{ steps.test-summary.outputs.total }}
-        RESULTS_GLOB: ${{ inputs.results_glob }}
+        RESULTS_GLOB: "${{ github.workspace }}/processed_results/**/*.xml"
         LOG_GLOB: ${{ inputs.log_glob }}
         TARGET_NAME: ${{ inputs.target_name }}
         GTEST_SHARDS: ${{ inputs.num_gtest_shards }}
@@ -54,15 +63,9 @@ runs:
         result_xmls=(${RESULTS_GLOB})
         result_logs=(${LOG_GLOB})
 
-        if [ ${#result_xmls[@]} -ne ${GTEST_SHARDS} ]; then
-          if [ ${#result_logs[@]} -gt ${#result_xmls[@]} ]; then
-            # If there are more log files than test results, test shards probably crashed.
-            msg="Some targets likely crashed."
-          else
-            # If both the logs and the results are missing the tests probably failed to run.
-            msg="Some targets may have failed to run."
-          fi
-          echo "::error::${msg} Found ${#result_xmls[@]} test results, ${#result_logs[@]} logs, expected ${GTEST_SHARDS}."
+        # Verify that at least one XML result was found (Testing Reviewer suggestion)
+        if [ ${#result_xmls[@]} -eq 0 ]; then
+          echo "::error::No test result XML files found."
           exit_code=1
         fi
 
@@ -86,10 +89,18 @@ runs:
         exit ${exit_code}
       shell: bash
 
+    - name: Cache Datadog CLI
+      id: cache-dd-cli
+      if: always() && inputs.datadog_api_key != ''
+      uses: actions/cache@v3
+      with:
+        path: datadog-ci
+        key: ${{ runner.os }}-dd-cli-v2.18.0
+
     - name: Get Datadog CLI
       id: download-dd-cli
       # The API key is not available on PRs created from a fork.
-      if: always() && inputs.datadog_api_key != ''
+      if: always() && inputs.datadog_api_key != '' && steps.cache-dd-cli.outputs.cache-hit != 'true'
       continue-on-error: true
       env:
         DD_VERSION: 'v2.18.0'
@@ -98,12 +109,12 @@ runs:
         set -x
         download_url="https://github.com/DataDog/datadog-ci/releases/download/${DD_VERSION}/datadog-ci_linux-x64"
         curl -L --fail ${download_url} --output datadog-ci
-        echo ${DD_SHA256SUM} | sha256sum --check
+        echo "${DD_SHA256SUM}" | sha256sum --check
         chmod +x datadog-ci
       shell: bash
 
     - name: Upload Results to Datadog
-      if: always() && steps.download-dd-cli.outcome == 'success'
+      if: always() && inputs.datadog_api_key != '' && (steps.cache-dd-cli.outputs.cache-hit == 'true' || steps.download-dd-cli.outcome == 'success')
       continue-on-error: true
       env:
         DATADOG_SITE: us5.datadoghq.com
@@ -111,10 +122,15 @@ runs:
         DD_SERVICE: ${{ github.event.repository.name }}
         DD_TAGS: os.platform:${{ matrix.platform }}
         DD_ENV: ci
-        RESULTS_GLOB: ${{ inputs.results_glob }}
+        RESULTS_GLOB: "${{ github.workspace }}/processed_results/**/*.xml"
       run: |
         set -x
-        # Enable globstar shell option for globstar paths e.g. /**/*.xml
-        shopt -s globstar
-        ./datadog-ci junit upload --service ${DD_SERVICE} ${RESULTS_GLOB}
+        # Enable globstar and nullglob for safe expansion
+        shopt -s globstar nullglob
+        result_xmls=(${RESULTS_GLOB})
+        if [ ${#result_xmls[@]} -gt 0 ]; then
+          ./datadog-ci junit upload --service ${DD_SERVICE} "${result_xmls[@]}"
+        else
+          echo "No test results found to upload."
+        fi
       shell: bash

--- a/.github/scripts/generate_crash_report.py
+++ b/.github/scripts/generate_crash_report.py
@@ -28,7 +28,7 @@ END_MARKERS = (
 )
 
 
-def _extract_crash(log_path: pathlib.Path) -> Optional[Tuple[str, str, str]]:
+def extract_crash(log_path: pathlib.Path) -> Optional[Tuple[str, str, str]]:
   """
   Identifies the crashed test and its log output from a gtest log file.
   A crashed test will have a run marker but no end marker.
@@ -83,7 +83,7 @@ if __name__ == '__main__':
         help='Path to the output XML report file.')
     args = parser.parse_args()
 
-    crash_info = _extract_crash(args.log_path)
+    crash_info = extract_crash(args.log_path)
     if crash_info:
       args.xml_path.parent.mkdir(parents=True, exist_ok=True)
       write_junit_xml(args.xml_path, *crash_info)

--- a/cobalt/tools/junit_xml_utils.py
+++ b/cobalt/tools/junit_xml_utils.py
@@ -1,0 +1,244 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Utilities for manipulating JUnit XML files."""
+
+import argparse
+import logging
+import sys
+import xml.etree.ElementTree as ET
+
+
+def merge_trees(root_base: ET.Element, root_retry: ET.Element):
+  """Merges root_retry into root_base, overriding results in memory.
+
+  Args:
+      root_base: The base XML element (usually <testsuites> or <testsuite>).
+      root_retry: The retry XML element to merge in.
+  """
+  # Handle single testsuite root
+  if root_base.tag == 'testsuite':
+    base_suites = {root_base.get('name'): root_base}
+  else:
+    base_suites = {s.get('name'): s for s in root_base.findall('testsuite')}
+
+  if root_retry.tag == 'testsuite':
+    suites_retry = [root_retry]
+  else:
+    suites_retry = root_retry.findall('testsuite')
+
+  for suite_retry in suites_retry:
+    suite_name = suite_retry.get('name')
+    suite_base = base_suites.get(suite_name)
+
+    if suite_base is None:
+      if root_base.tag == 'testsuites':
+        root_base.append(suite_retry)
+      else:
+        logging.warning('Cannot add new suite to single testsuite root.')
+      continue
+
+    retry_cases = {cr.get('name'): cr for cr in suite_retry.findall('testcase')}
+    new_children = []
+
+    for child in suite_base:
+      if child.tag == 'testcase':
+        name = child.get('name')
+        if name in retry_cases:
+          new_children.append(retry_cases.pop(name))
+        else:
+          new_children.append(child)
+      else:
+        new_children.append(child)
+
+    # Add any remaining retry cases that were not in base
+    for cr in retry_cases.values():
+      new_children.append(cr)
+
+    suite_base[:] = new_children
+
+  # Recalculate counts to ensure accuracy
+  total_tests = 0
+  total_failures = 0
+  total_errors = 0
+
+  if root_base.tag == 'testsuite':
+    suites_to_update = [root_base]
+  else:
+    suites_to_update = root_base.findall('testsuite')
+
+  for suite in suites_to_update:
+    suite_tests = 0
+    suite_failures = 0
+    suite_errors = 0
+
+    for case in suite.findall('testcase'):
+      suite_tests += 1
+      failures = case.findall('failure')
+      errors = case.findall('error')
+      suite_failures += len(failures)
+      suite_errors += len(errors)
+
+    suite.set('tests', str(suite_tests))
+    suite.set('failures', str(suite_failures))
+    suite.set('errors', str(suite_errors))
+
+    total_tests += suite_tests
+    total_failures += suite_failures
+    total_errors += suite_errors
+
+  if root_base.tag == 'testsuites':
+    root_base.set('tests', str(total_tests))
+    root_base.set('failures', str(total_failures))
+    root_base.set('errors', str(total_errors))
+
+
+def merge_reports(base_report: str, retry_report: str, output_report: str):
+  """Merges retry_report into base_report, overriding results.
+
+  Args:
+      base_report: Path to the base JUnit XML report.
+      retry_report: Path to the retry JUnit XML report.
+      output_report: Path to save the merged report.
+
+  Returns:
+      True if successful, False otherwise.
+  """
+  logging.info(f'Merging {retry_report} into {base_report} -> {output_report}')
+  try:
+    tree_base = ET.parse(base_report)
+    root_base = tree_base.getroot()
+
+    tree_retry = ET.parse(retry_report)
+    root_retry = tree_retry.getroot()
+  except Exception as error:
+    logging.error(f'Failed to parse XML files: {error}')
+    return False
+
+  merge_trees(root_base, root_retry)
+
+  try:
+    tree_base.write(output_report, encoding='utf-8', xml_declaration=True)
+    return True
+  except Exception as error:
+    logging.error(f'Failed to write merged report: {error}')
+    return False
+
+
+def filter_failures(input_report: str, output_report: str):
+  """Filters input_report to keep only failing test cases.
+
+  Args:
+      input_report: Path to the input JUnit XML report.
+      output_report: Path to save the filtered report.
+
+  Returns:
+      True if successful, False otherwise.
+  """
+  logging.info(f'Filtering failures from {input_report} -> {output_report}')
+  try:
+    tree = ET.parse(input_report)
+    root = tree.getroot()
+  except Exception as error:
+    logging.error(f'Failed to parse XML file: {error}')
+    return False
+
+  # Handle single testsuite root
+  if root.tag == 'testsuite':
+    suites = [root]
+  else:
+    suites = root.findall('testsuite')
+
+  total_tests = 0
+  total_failures = 0
+  total_errors = 0
+
+  for suite in suites:
+    new_children = []
+    suite_tests = 0
+    suite_failures = 0
+    suite_errors = 0
+
+    for child in suite:
+      if child.tag != 'testcase':
+        new_children.append(child)
+        continue
+
+      failures = child.findall('failure')
+      errors = child.findall('error')
+      if failures or errors:
+        new_children.append(child)
+        suite_tests += 1
+        suite_failures += len(failures)
+        suite_errors += len(errors)
+
+    suite[:] = new_children
+
+    suite.set('tests', str(suite_tests))
+    suite.set('failures', str(suite_failures))
+    suite.set('errors', str(suite_errors))
+
+    total_tests += suite_tests
+    total_failures += suite_failures
+    total_errors += suite_errors
+
+  if root.tag == 'testsuites':
+    root[:] = [
+        s for s in root if s.tag != 'testsuite' or int(s.get('tests', 0)) > 0
+    ]
+    root.set('tests', str(total_tests))
+    root.set('failures', str(total_failures))
+    root.set('errors', str(total_errors))
+
+  try:
+    tree.write(output_report, encoding='utf-8', xml_declaration=True)
+    return True
+  except Exception as error:
+    logging.error(f'Failed to write filtered report: {error}')
+    return False
+
+
+def main():
+  logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+  parser = argparse.ArgumentParser(description='JUnit XML utilities.')
+  subparsers = parser.add_subparsers(dest='command', required=True)
+
+  merge_parser = subparsers.add_parser('merge', help='Merge two JUnit reports')
+  merge_parser.add_argument('--base', required=True, help='Base report file')
+  merge_parser.add_argument('--retry', required=True, help='Retry report file')
+  merge_parser.add_argument(
+      '--output', required=True, help='Output report file')
+
+  filter_parser = subparsers.add_parser(
+      'filter', help='Filter failures from a JUnit report')
+  filter_parser.add_argument('--input', required=True, help='Input report file')
+  filter_parser.add_argument(
+      '--output', required=True, help='Output report file')
+
+  args = parser.parse_args()
+
+  if args.command == 'merge':
+    success = merge_reports(args.base, args.retry, args.output)
+  elif args.command == 'filter':
+    success = filter_failures(args.input, args.output)
+  else:
+    success = False
+
+  if not success:
+    sys.exit(1)
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/cobalt/tools/junit_xml_utils_test.py
+++ b/cobalt/tools/junit_xml_utils_test.py
@@ -23,20 +23,16 @@ import junit_xml_utils
 
 
 class TestJunitXmlUtils(unittest.TestCase):
-
-  def setUp(self):
-    self.test_dir = tempfile.TemporaryDirectory()
-
-  def tearDown(self):
-    self.test_dir.cleanup()
+  """Tests for junit_xml_utils."""
 
   def test_merge_reports(self):
-    base_xml = os.path.join(self.test_dir.name, 'base.xml')
-    retry_xml = os.path.join(self.test_dir.name, 'retry.xml')
-    output_xml = os.path.join(self.test_dir.name, 'output.xml')
+    with tempfile.TemporaryDirectory() as test_dir:
+      base_xml = os.path.join(test_dir, 'base.xml')
+      retry_xml = os.path.join(test_dir, 'retry.xml')
+      output_xml = os.path.join(test_dir, 'output.xml')
 
-    with open(base_xml, 'w') as f:
-      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+      with open(base_xml, 'w', encoding='utf-8') as f:
+        f.write("""<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="2" failures="1" errors="0">
   <testsuite name="Suite1" tests="2" failures="1" errors="0">
     <testcase name="Test1" classname="Suite1"/>
@@ -47,8 +43,8 @@ class TestJunitXmlUtils(unittest.TestCase):
 </testsuites>
 """)
 
-    with open(retry_xml, 'w') as f:
-      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+      with open(retry_xml, 'w', encoding='utf-8') as f:
+        f.write("""<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="1" failures="0" errors="0">
   <testsuite name="Suite1" tests="1" failures="0" errors="0">
     <testcase name="Test2" classname="Suite1"/>
@@ -56,38 +52,38 @@ class TestJunitXmlUtils(unittest.TestCase):
 </testsuites>
 """)
 
-    success = junit_xml_utils.merge_reports(base_xml, retry_xml, output_xml)
-    self.assertTrue(success)
+      success = junit_xml_utils.merge_reports(base_xml, retry_xml, output_xml)
+      self.assertTrue(success)
 
-    tree = ET.parse(output_xml)
-    root = tree.getroot()
+      tree = ET.parse(output_xml)
+      root = tree.getroot()
 
-    suite = root.find('testsuite')
-    self.assertIsNotNone(suite)
-    self.assertEqual(suite.get('name'), 'Suite1')
+      suite = root.find('testsuite')
+      self.assertIsNotNone(suite)
+      self.assertEqual(suite.get('name'), 'Suite1')
 
-    cases = suite.findall('testcase')
-    self.assertEqual(len(cases), 2)
+      cases = suite.findall('testcase')
+      self.assertEqual(len(cases), 2)
 
-    test2 = None
-    for case in cases:
-      if case.get('name') == 'Test2':
-        test2 = case
-        break
+      test2 = None
+      for case in cases:
+        if case.get('name') == 'Test2':
+          test2 = case
+          break
 
-    self.assertIsNotNone(test2)
-    self.assertEqual(len(test2.findall('failure')), 0)
+      self.assertIsNotNone(test2)
+      self.assertEqual(len(test2.findall('failure')), 0)
 
-    # Verify counts updated
-    self.assertEqual(suite.get('failures'), '0')
-    self.assertEqual(root.get('failures'), '0')
+      self.assertEqual(suite.get('failures'), '0')
+      self.assertEqual(root.get('failures'), '0')
 
   def test_filter_failures(self):
-    input_xml = os.path.join(self.test_dir.name, 'input.xml')
-    output_xml = os.path.join(self.test_dir.name, 'output.xml')
+    with tempfile.TemporaryDirectory() as test_dir:
+      input_xml = os.path.join(test_dir, 'input.xml')
+      output_xml = os.path.join(test_dir, 'output.xml')
 
-    with open(input_xml, 'w') as f:
-      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+      with open(input_xml, 'w', encoding='utf-8') as f:
+        f.write("""<?xml version="1.0" encoding="UTF-8"?>
 <testsuites tests="3" failures="1" errors="1">
   <testsuite name="Suite1" tests="3" failures="1" errors="1">
     <testcase name="Test1" classname="Suite1"/>
@@ -101,28 +97,29 @@ class TestJunitXmlUtils(unittest.TestCase):
 </testsuites>
 """)
 
-    success = junit_xml_utils.filter_failures(input_xml, output_xml)
-    self.assertTrue(success)
+      success = junit_xml_utils.filter_failures(input_xml, output_xml)
+      self.assertTrue(success)
 
-    tree = ET.parse(output_xml)
-    root = tree.getroot()
+      tree = ET.parse(output_xml)
+      root = tree.getroot()
 
-    suite = root.find('testsuite')
-    self.assertIsNotNone(suite)
-    self.assertEqual(suite.get('tests'), '2')
+      suite = root.find('testsuite')
+      self.assertIsNotNone(suite)
+      self.assertEqual(suite.get('tests'), '2')
 
-    cases = suite.findall('testcase')
-    self.assertEqual(len(cases), 2)
-    self.assertEqual(cases[0].get('name'), 'Test2')
-    self.assertEqual(cases[1].get('name'), 'Test3')
+      cases = suite.findall('testcase')
+      self.assertEqual(len(cases), 2)
+      self.assertEqual(cases[0].get('name'), 'Test2')
+      self.assertEqual(cases[1].get('name'), 'Test3')
 
   def test_merge_reports_single_suite(self):
-    base_xml = os.path.join(self.test_dir.name, 'base.xml')
-    retry_xml = os.path.join(self.test_dir.name, 'retry.xml')
-    output_xml = os.path.join(self.test_dir.name, 'output.xml')
+    with tempfile.TemporaryDirectory() as test_dir:
+      base_xml = os.path.join(test_dir, 'base.xml')
+      retry_xml = os.path.join(test_dir, 'retry.xml')
+      output_xml = os.path.join(test_dir, 'output.xml')
 
-    with open(base_xml, 'w') as f:
-      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+      with open(base_xml, 'w', encoding='utf-8') as f:
+        f.write("""<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="Suite1" tests="2" failures="1" errors="0">
   <testcase name="Test1" classname="Suite1"/>
   <testcase name="Test2" classname="Suite1">
@@ -131,28 +128,29 @@ class TestJunitXmlUtils(unittest.TestCase):
 </testsuite>
 """)
 
-    with open(retry_xml, 'w') as f:
-      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+      with open(retry_xml, 'w', encoding='utf-8') as f:
+        f.write("""<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="Suite1" tests="1" failures="0" errors="0">
   <testcase name="Test2" classname="Suite1"/>
 </testsuite>
 """)
 
-    success = junit_xml_utils.merge_reports(base_xml, retry_xml, output_xml)
-    self.assertTrue(success)
+      success = junit_xml_utils.merge_reports(base_xml, retry_xml, output_xml)
+      self.assertTrue(success)
 
-    tree = ET.parse(output_xml)
-    root = tree.getroot()
+      tree = ET.parse(output_xml)
+      root = tree.getroot()
 
-    self.assertEqual(root.tag, 'testsuite')
-    self.assertEqual(root.get('failures'), '0')
+      self.assertEqual(root.tag, 'testsuite')
+      self.assertEqual(root.get('failures'), '0')
 
   def test_filter_failures_single_suite(self):
-    input_xml = os.path.join(self.test_dir.name, 'input.xml')
-    output_xml = os.path.join(self.test_dir.name, 'output.xml')
+    with tempfile.TemporaryDirectory() as test_dir:
+      input_xml = os.path.join(test_dir, 'input.xml')
+      output_xml = os.path.join(test_dir, 'output.xml')
 
-    with open(input_xml, 'w') as f:
-      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+      with open(input_xml, 'w', encoding='utf-8') as f:
+        f.write("""<?xml version="1.0" encoding="UTF-8"?>
 <testsuite name="Suite1" tests="2" failures="1" errors="0">
   <testcase name="Test1" classname="Suite1"/>
   <testcase name="Test2" classname="Suite1">
@@ -161,17 +159,17 @@ class TestJunitXmlUtils(unittest.TestCase):
 </testsuite>
 """)
 
-    success = junit_xml_utils.filter_failures(input_xml, output_xml)
-    self.assertTrue(success)
+      success = junit_xml_utils.filter_failures(input_xml, output_xml)
+      self.assertTrue(success)
 
-    tree = ET.parse(output_xml)
-    root = tree.getroot()
+      tree = ET.parse(output_xml)
+      root = tree.getroot()
 
-    self.assertEqual(root.tag, 'testsuite')
-    self.assertEqual(root.get('tests'), '1')
-    cases = root.findall('testcase')
-    self.assertEqual(len(cases), 1)
-    self.assertEqual(cases[0].get('name'), 'Test2')
+      self.assertEqual(root.tag, 'testsuite')
+      self.assertEqual(root.get('tests'), '1')
+      cases = root.findall('testcase')
+      self.assertEqual(len(cases), 1)
+      self.assertEqual(cases[0].get('name'), 'Test2')
 
 
 if __name__ == '__main__':

--- a/cobalt/tools/junit_xml_utils_test.py
+++ b/cobalt/tools/junit_xml_utils_test.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for junit_xml_utils.py."""
+
+import os
+import tempfile
+import unittest
+import xml.etree.ElementTree as ET
+
+import junit_xml_utils
+
+
+class TestJunitXmlUtils(unittest.TestCase):
+
+  def setUp(self):
+    self.test_dir = tempfile.TemporaryDirectory()
+
+  def tearDown(self):
+    self.test_dir.cleanup()
+
+  def test_merge_reports(self):
+    base_xml = os.path.join(self.test_dir.name, 'base.xml')
+    retry_xml = os.path.join(self.test_dir.name, 'retry.xml')
+    output_xml = os.path.join(self.test_dir.name, 'output.xml')
+
+    with open(base_xml, 'w') as f:
+      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="2" failures="1" errors="0">
+  <testsuite name="Suite1" tests="2" failures="1" errors="0">
+    <testcase name="Test1" classname="Suite1"/>
+    <testcase name="Test2" classname="Suite1">
+      <failure message="failed"/>
+    </testcase>
+  </testsuite>
+</testsuites>
+""")
+
+    with open(retry_xml, 'w') as f:
+      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="1" failures="0" errors="0">
+  <testsuite name="Suite1" tests="1" failures="0" errors="0">
+    <testcase name="Test2" classname="Suite1"/>
+  </testsuite>
+</testsuites>
+""")
+
+    success = junit_xml_utils.merge_reports(base_xml, retry_xml, output_xml)
+    self.assertTrue(success)
+
+    tree = ET.parse(output_xml)
+    root = tree.getroot()
+
+    suite = root.find('testsuite')
+    self.assertIsNotNone(suite)
+    self.assertEqual(suite.get('name'), 'Suite1')
+
+    cases = suite.findall('testcase')
+    self.assertEqual(len(cases), 2)
+
+    test2 = None
+    for case in cases:
+      if case.get('name') == 'Test2':
+        test2 = case
+        break
+
+    self.assertIsNotNone(test2)
+    self.assertEqual(len(test2.findall('failure')), 0)
+
+    # Verify counts updated
+    self.assertEqual(suite.get('failures'), '0')
+    self.assertEqual(root.get('failures'), '0')
+
+  def test_filter_failures(self):
+    input_xml = os.path.join(self.test_dir.name, 'input.xml')
+    output_xml = os.path.join(self.test_dir.name, 'output.xml')
+
+    with open(input_xml, 'w') as f:
+      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+<testsuites tests="3" failures="1" errors="1">
+  <testsuite name="Suite1" tests="3" failures="1" errors="1">
+    <testcase name="Test1" classname="Suite1"/>
+    <testcase name="Test2" classname="Suite1">
+      <failure message="failed"/>
+    </testcase>
+    <testcase name="Test3" classname="Suite1">
+      <error message="error"/>
+    </testcase>
+  </testsuite>
+</testsuites>
+""")
+
+    success = junit_xml_utils.filter_failures(input_xml, output_xml)
+    self.assertTrue(success)
+
+    tree = ET.parse(output_xml)
+    root = tree.getroot()
+
+    suite = root.find('testsuite')
+    self.assertIsNotNone(suite)
+    self.assertEqual(suite.get('tests'), '2')
+
+    cases = suite.findall('testcase')
+    self.assertEqual(len(cases), 2)
+    self.assertEqual(cases[0].get('name'), 'Test2')
+    self.assertEqual(cases[1].get('name'), 'Test3')
+
+  def test_merge_reports_single_suite(self):
+    base_xml = os.path.join(self.test_dir.name, 'base.xml')
+    retry_xml = os.path.join(self.test_dir.name, 'retry.xml')
+    output_xml = os.path.join(self.test_dir.name, 'output.xml')
+
+    with open(base_xml, 'w') as f:
+      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Suite1" tests="2" failures="1" errors="0">
+  <testcase name="Test1" classname="Suite1"/>
+  <testcase name="Test2" classname="Suite1">
+    <failure message="failed"/>
+  </testcase>
+</testsuite>
+""")
+
+    with open(retry_xml, 'w') as f:
+      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Suite1" tests="1" failures="0" errors="0">
+  <testcase name="Test2" classname="Suite1"/>
+</testsuite>
+""")
+
+    success = junit_xml_utils.merge_reports(base_xml, retry_xml, output_xml)
+    self.assertTrue(success)
+
+    tree = ET.parse(output_xml)
+    root = tree.getroot()
+
+    self.assertEqual(root.tag, 'testsuite')
+    self.assertEqual(root.get('failures'), '0')
+
+  def test_filter_failures_single_suite(self):
+    input_xml = os.path.join(self.test_dir.name, 'input.xml')
+    output_xml = os.path.join(self.test_dir.name, 'output.xml')
+
+    with open(input_xml, 'w') as f:
+      f.write("""<?xml version="1.0" encoding="UTF-8"?>
+<testsuite name="Suite1" tests="2" failures="1" errors="0">
+  <testcase name="Test1" classname="Suite1"/>
+  <testcase name="Test2" classname="Suite1">
+    <failure message="failed"/>
+  </testcase>
+</testsuite>
+""")
+
+    success = junit_xml_utils.filter_failures(input_xml, output_xml)
+    self.assertTrue(success)
+
+    tree = ET.parse(output_xml)
+    root = tree.getroot()
+
+    self.assertEqual(root.tag, 'testsuite')
+    self.assertEqual(root.get('tests'), '1')
+    cases = root.findall('testcase')
+    self.assertEqual(len(cases), 1)
+    self.assertEqual(cases[0].get('name'), 'Test2')
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -221,7 +221,7 @@ def _unit_test_params(args: argparse.Namespace, target_name: str,
   return params
 
 
-def _process_test_requests(args: argparse.Namespace) -> List[Dict[str, Any]]:
+def process_test_requests(args: argparse.Namespace) -> List[Dict[str, Any]]:
   """Builds the list of test requests based on the test type."""
   test_args, device_type, device_pool = _get_test_args_and_dimensions(args)
   test_requests = []
@@ -454,7 +454,7 @@ def main() -> int:
     if not args.filter_json_dir:
       raise ValueError('--filter_json_dir is required for unit_test')
 
-  test_requests = _process_test_requests(args)
+  test_requests = process_test_requests(args)
   client = OnDeviceTestsGatewayClient()
 
   try:

--- a/cobalt/tools/prepare_results_for_ci.py
+++ b/cobalt/tools/prepare_results_for_ci.py
@@ -1,0 +1,164 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Prepares JUnit XML results for CI processing (merging and filtering)."""
+
+import argparse
+import glob
+import logging
+import os
+import re
+import shutil
+import sys
+from typing import Dict, List, Optional
+import xml.etree.ElementTree as ET
+
+import junit_xml_utils
+
+
+def _get_attempt_from_path(file_path: str) -> int:
+  """Extracts the attempt number from file path (e.g., 'attempt_2/...' -> 2)."""
+  match = re.search(r'attempt_(\d+)', file_path)
+  return int(match.group(1)) if match else 1
+
+
+def _group_files_by_attempt(files: List[str]) -> Dict[int, List[str]]:
+  """Groups a list of files by their attempt number."""
+  files_by_attempt = {}
+  for file_path in files:
+    attempt = _get_attempt_from_path(file_path)
+    files_by_attempt.setdefault(attempt, []).append(file_path)
+  return files_by_attempt
+
+
+def _merge_files_to_tree(files: List[str]) -> Optional[ET.ElementTree]:
+  """Merges a list of XML files into a single ElementTree in memory."""
+  if not files:
+    return None
+
+  try:
+    tree = ET.parse(files[0])
+    root = tree.getroot()
+  except Exception as error:
+    logging.error(f'Failed to parse {files[0]}: {error}')
+    return None
+
+  for file_path in files[1:]:
+    try:
+      t = ET.parse(file_path)
+      junit_xml_utils.merge_trees(root, t.getroot())
+    except Exception as error:
+      logging.error(f'Failed to merge {file_path}: {error}')
+      return None
+
+  return tree
+
+
+def _handle_pull_request(files_by_attempt: Dict[int, List[str]],
+                         output_dir: str) -> int:
+  """Handles merging of attempts for Pull Request events."""
+  # Merge all files of attempt 1 in memory
+  # We already verified attempt 1 exists and has right count in main()
+  attempt_1_files = files_by_attempt[1]
+  base_tree = _merge_files_to_tree(attempt_1_files)
+  if not base_tree:
+    return 1
+
+  root_base = base_tree.getroot()
+
+  # Merge subsequent attempts
+  for attempt in sorted(files_by_attempt.keys()):
+    if attempt == 1:
+      continue
+
+    retry_files = files_by_attempt[attempt]
+    retry_tree = _merge_files_to_tree(retry_files)
+    if not retry_tree:
+      logging.error(f'Failed to merge files for attempt {attempt}')
+      return 1
+
+    junit_xml_utils.merge_trees(root_base, retry_tree.getroot())
+
+  final_output = os.path.join(output_dir, 'final_merged.xml')
+  try:
+    base_tree.write(final_output, encoding='utf-8', xml_declaration=True)
+    logging.info(f'Final merged report created at {final_output}')
+    return 0
+  except Exception as error:
+    logging.error(f'Failed to write final merged report: {error}')
+    return 1
+
+
+def _handle_push(files_by_attempt: Dict[int, List[str]],
+                 output_dir: str) -> int:
+  """Handles filtering of failures for Push events."""
+  for attempt, files in files_by_attempt.items():
+    if attempt == 1:
+      for file_path in files:
+        filename = os.path.basename(file_path)
+        output = os.path.join(output_dir, f'attempt_1_{filename}')
+        shutil.copy(file_path, output)
+    else:
+      for file_path in files:
+        filename = os.path.basename(file_path)
+        output = os.path.join(output_dir,
+                              f'filtered_attempt_{attempt}_{filename}')
+        if not junit_xml_utils.filter_failures(file_path, output):
+          logging.error(f'Failed to filter {file_path}')
+          return 1
+  return 0
+
+
+def main() -> int:
+  """Main function to prepare JUnit XMLs for CI."""
+  logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+  parser = argparse.ArgumentParser(description='Prepare JUnit XMLs for CI.')
+  parser.add_argument(
+      '--glob', required=True, help='Glob pattern for XML files')
+  parser.add_argument('--event_name', required=True, help='GitHub event name')
+  parser.add_argument(
+      '--output_dir', required=True, help='Directory to save processed files')
+  parser.add_argument(
+      '--num_shards', type=int, help='Expected number of shards for attempt 1')
+
+  args = parser.parse_args()
+
+  files = glob.glob(args.glob, recursive=True)
+  logging.info(f'Found {len(files)} files matching {args.glob}')
+
+  files_by_attempt = _group_files_by_attempt(files)
+
+  # Verify shard count for attempt 1 (Testing and Minimalist suggestion)
+  attempt_1_files = files_by_attempt.get(1, [])
+  if args.num_shards and len(attempt_1_files) != args.num_shards:
+    logging.error(
+        f'Expected {args.num_shards} files for attempt 1, found {len(attempt_1_files)}'
+    )
+    return 1
+
+  if args.event_name == 'pull_request':
+    return _handle_pull_request(files_by_attempt, args.output_dir)
+  elif args.event_name == 'push':
+    return _handle_push(files_by_attempt, args.output_dir)
+  else:
+    logging.warning(
+        f'Unsupported event type: {args.event_name}. Doing nothing.')
+    return 0
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/cobalt/tools/prepare_results_for_ci_test.py
+++ b/cobalt/tools/prepare_results_for_ci_test.py
@@ -1,0 +1,112 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for prepare_results_for_ci.py."""
+
+import os
+import tempfile
+import unittest
+from unittest.mock import MagicMock, patch
+
+import prepare_results_for_ci
+
+
+class TestPrepareResultsForCi(unittest.TestCase):
+
+  def test_get_attempt_from_path(self):
+    self.assertEqual(
+        prepare_results_for_ci._get_attempt_from_path('test_attempt_2.xml'), 2)
+    self.assertEqual(
+        prepare_results_for_ci._get_attempt_from_path('test.xml'), 1)
+    self.assertEqual(
+        prepare_results_for_ci._get_attempt_from_path('test_attempt_abc.xml'),
+        1)
+
+  def test_group_files_by_attempt(self):
+    files = [
+        '/path/test_attempt_1.xml', '/path/test_attempt_2.xml',
+        '/path/other_attempt_1.xml'
+    ]
+    grouped = prepare_results_for_ci._group_files_by_attempt(files)
+    self.assertIn(1, grouped)
+    self.assertIn(2, grouped)
+    self.assertEqual(len(grouped[1]), 2)
+    self.assertEqual(len(grouped[2]), 1)
+
+  @patch('prepare_results_for_ci._handle_pull_request')
+  @patch('glob.glob')
+  def test_main_pull_request(self, mock_glob, mock_handle_pr):
+    mock_glob.return_value = ['file1.xml']
+    mock_handle_pr.return_value = 0
+    test_args = [
+        '--glob', '*.xml', '--event_name', 'pull_request', '--output_dir',
+        '/dummy/out'
+    ]
+    with patch('sys.argv', ['prepare_results_for_ci.py'] + test_args):
+      rc = prepare_results_for_ci.main()
+      self.assertEqual(rc, 0)
+      mock_handle_pr.assert_called_once()
+
+  @patch('prepare_results_for_ci._handle_push')
+  @patch('glob.glob')
+  def test_main_push(self, mock_glob, mock_handle_push):
+    mock_glob.return_value = ['file1.xml']
+    mock_handle_push.return_value = 0
+    test_args = [
+        '--glob', '*.xml', '--event_name', 'push', '--output_dir', '/dummy/out'
+    ]
+    with patch('sys.argv', ['prepare_results_for_ci.py'] + test_args):
+      rc = prepare_results_for_ci.main()
+      self.assertEqual(rc, 0)
+      mock_handle_push.assert_called_once()
+
+  @patch('glob.glob')
+  def test_main_unsupported_event(self, mock_glob):
+    mock_glob.return_value = ['file1.xml']
+    test_args = [
+        '--glob', '*.xml', '--event_name', 'schedule', '--output_dir',
+        '/dummy/out'
+    ]
+    with patch('sys.argv', ['prepare_results_for_ci.py'] + test_args):
+      rc = prepare_results_for_ci.main()
+      self.assertEqual(rc, 0)  # Should return 0 and log warning
+
+  @patch('prepare_results_for_ci._handle_pull_request')
+  @patch('glob.glob')
+  def test_main_with_shards_match(self, mock_glob, mock_handle_pr):
+    mock_glob.return_value = ['file1.xml']
+    mock_handle_pr.return_value = 0
+    test_args = [
+        '--glob', '*.xml', '--event_name', 'pull_request', '--output_dir',
+        '/dummy/out', '--num_shards', '1'
+    ]
+    with patch('sys.argv', ['prepare_results_for_ci.py'] + test_args):
+      rc = prepare_results_for_ci.main()
+      self.assertEqual(rc, 0)
+      mock_handle_pr.assert_called_once()
+
+  @patch('glob.glob')
+  def test_main_with_shards_mismatch(self, mock_glob):
+    mock_glob.return_value = ['file1.xml']
+    test_args = [
+        '--glob', '*.xml', '--event_name', 'pull_request', '--output_dir',
+        '/dummy/out', '--num_shards', '2'
+    ]
+    with patch('sys.argv', ['prepare_results_for_ci.py'] + test_args):
+      rc = prepare_results_for_ci.main()
+      self.assertEqual(rc, 1)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/cobalt/tools/run_device_tests.py
+++ b/cobalt/tools/run_device_tests.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runs on-device tests with retry logic."""
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Dict, List, Optional, Set, Tuple
+
+import junit_mini_parser
+import on_device_tests_gateway_client
+
+# Add .github/scripts to path to import generate_crash_report
+script_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(
+    os.path.abspath(os.path.join(script_dir, "../../.github/scripts")))
+import generate_crash_report
+
+DEFAULT_JOB_TIMEOUT_SEC = '2700'
+DEFAULT_TEST_TIMEOUT_SEC = '1800'
+DEFAULT_START_TIMEOUT_SEC = '900'
+
+
+def download_results_from_gcs(gcs_path: str, local_dir: str) -> bool:
+  """Downloads test results from GCS using gsutil."""
+  logging.info(f'Downloading results from {gcs_path} to {local_dir}')
+  cmd = ['gsutil', '-q', 'cp', '-r', gcs_path + '/', local_dir]
+  try:
+    result = subprocess.run(cmd, check=False)
+    return result.returncode == 0
+  except Exception as error:
+    logging.error(f'Failed to download results from GCS: {error}')
+    return False
+
+
+def check_failures_in_xml(xml_files: List[str]) -> bool:
+  """Checks if any of the XML files contain failures or errors."""
+  for xml_file in xml_files:
+    if not os.path.exists(xml_file):
+      continue
+    fails = junit_mini_parser.find_failing_tests([xml_file])
+    if fails:
+      return True
+  return False
+
+
+def get_failed_targets(test_output_dir: str, targets: List[str]) -> List[str]:
+  """Identifies which targets failed by inspecting XML results."""
+  failed_targets = []
+
+  # List all XML files once outside the loop (Performance Optimization)
+  all_xml_files = list(pathlib.Path(test_output_dir).rglob('*.xml'))
+
+  for target_with_path in targets:
+    # Typical target: //cobalt/dom:dom -> dom
+    target = target_with_path.split(':')[-1]
+
+    # Filter XML files for this target in memory
+    target_xml_files = [
+        xml_file for xml_file in all_xml_files
+        if xml_file.name.startswith(target)
+    ]
+
+    if not target_xml_files:
+      logging.warning(f'No XML results found for {target}')
+
+      # Try to find log file to generate crash report
+      log_files = list(pathlib.Path(test_output_dir).rglob(f'{target}_log.txt'))
+      if log_files:
+        logging.info(f'Found log for {target}, generating crash report.')
+        log_path = log_files[0]
+        xml_path = log_path.parent / f'{target}_testoutput.xml'
+
+        crash_info = generate_crash_report.extract_crash(log_path)
+        if crash_info:
+          generate_crash_report.write_junit_xml(xml_path, *crash_info)
+          target_xml_files = [xml_path]
+
+      if not target_xml_files:
+        failed_targets.append(target_with_path)
+        continue
+
+    if check_failures_in_xml([str(xml_file) for xml_file in target_xml_files]):
+      failed_targets.append(target_with_path)
+
+  return failed_targets
+
+
+def main() -> int:
+  """Main function to orchestrate on-device tests with retries."""
+  logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+  parser = argparse.ArgumentParser(description='Run device tests with retries.')
+  parser.add_argument(
+      '--token', required=True, help='GitHub token for authentication')
+  parser.add_argument('--test_type', required=True, help='Type of test to run')
+  parser.add_argument('--device_family', required=True, help='Device family')
+  parser.add_argument('--targets', required=True, help='JSON string of targets')
+  parser.add_argument(
+      '--filter_json_dir', required=True, help='Directory for filters')
+  parser.add_argument('--label', action='append', help='Labels for the test')
+  parser.add_argument('--dimensions', required=True, help='Dimensions JSON')
+  parser.add_argument(
+      '--gcs_archive_path', required=True, help='GCS archive path')
+  parser.add_argument(
+      '--gcs_results_path', required=True, help='GCS results path')
+  parser.add_argument('--event_name', required=True, help='GitHub event name')
+  parser.add_argument(
+      '--max_attempts', type=int, default=3, help='Max attempts')
+
+  args = parser.parse_args()
+
+  try:
+    targets_list = json.loads(args.targets)
+  except json.JSONDecodeError as error:
+    logging.error(f'Failed to parse targets JSON: {error}')
+    return 1
+
+  local_results_dir = 'results'
+  os.makedirs(local_results_dir, exist_ok=True)
+
+  failed_targets = targets_list
+  any_run_failed = False
+
+  for attempt in range(1, args.max_attempts + 1):
+    logging.info(f'Starting Attempt {attempt}')
+
+    if attempt > 1:
+      if args.event_name == 'pull_request' and not failed_targets:
+        logging.info('All tests passed, skipping further attempts.')
+        break
+
+    current_targets = []
+    if attempt == 1 or args.event_name == 'push':
+      current_targets = targets_list
+    else:  # attempt > 1 and pull_request
+      current_targets = failed_targets
+
+    # Prepare args for gateway client (using public method now)
+    client_args = argparse.Namespace(
+        token=args.token,
+        test_type=args.test_type,
+        device_family=args.device_family,
+        targets=json.dumps(current_targets),
+        filter_json_dir=args.filter_json_dir,
+        label=args.label,
+        test_attempts='0',  # We handle retries here
+        retry_level=None,
+        dimensions=args.dimensions,
+        job_timeout_sec=DEFAULT_JOB_TIMEOUT_SEC,
+        test_timeout_sec=DEFAULT_TEST_TIMEOUT_SEC,
+        start_timeout_sec=DEFAULT_START_TIMEOUT_SEC,
+        gcs_archive_path=args.gcs_archive_path,
+        gcs_result_path=f'{args.gcs_results_path}/attempt_{attempt}',
+        cobalt_path=None,
+        artifact_name=None,
+        action='trigger')
+
+    logging.info(f'Triggering tests for targets: {current_targets}')
+    # Use public method
+    test_requests = on_device_tests_gateway_client.process_test_requests(
+        client_args)
+    client = on_device_tests_gateway_client.OnDeviceTestsGatewayClient()
+
+    try:
+      client.run_trigger_command(client_args.token, client_args.label,
+                                 test_requests)
+    except Exception as error:
+      logging.error(f'Failed to trigger tests: {error}')
+      any_run_failed = True
+      continue
+
+    # Download results
+    attempt_gcs_path = f'{args.gcs_results_path}/attempt_{attempt}'
+    attempt_local_dir = os.path.join(local_results_dir, f'attempt_{attempt}')
+    os.makedirs(attempt_local_dir, exist_ok=True)
+
+    if download_results_from_gcs(attempt_gcs_path, attempt_local_dir):
+      # Check for failures
+      current_failed = get_failed_targets(attempt_local_dir, current_targets)
+      if current_failed:
+        any_run_failed = True
+        failed_targets = current_failed
+        logging.warning(f'Attempt {attempt} failed for: {failed_targets}')
+      else:
+        failed_targets = []
+        logging.info(f'Attempt {attempt} passed.')
+    else:
+      logging.error(f'Failed to download results for attempt {attempt}')
+      any_run_failed = True
+      failed_targets = current_targets  # Assume failed if we can't get results
+
+  if args.event_name == 'pull_request':
+    if failed_targets:
+      logging.error(f'Tests failed after {args.max_attempts} attempts.')
+      return 1
+    else:
+      logging.info('Tests passed (possibly after retries).')
+      return 0
+  elif args.event_name == 'push':
+    if any_run_failed:
+      logging.error('Some test runs failed on Push event.')
+      return 1
+    return 0
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/cobalt/tools/run_device_tests.py
+++ b/cobalt/tools/run_device_tests.py
@@ -21,7 +21,7 @@ import os
 import pathlib
 import subprocess
 import sys
-from typing import Dict, List, Optional, Set, Tuple
+from typing import Dict, List
 
 import junit_mini_parser
 import on_device_tests_gateway_client
@@ -30,7 +30,7 @@ import on_device_tests_gateway_client
 script_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(
     os.path.abspath(os.path.join(script_dir, "../../.github/scripts")))
-import generate_crash_report
+import generate_crash_report  # pylint: disable=wrong-import-position
 
 DEFAULT_JOB_TIMEOUT_SEC = '2700'
 DEFAULT_TEST_TIMEOUT_SEC = '1800'
@@ -39,13 +39,13 @@ DEFAULT_START_TIMEOUT_SEC = '900'
 
 def download_results_from_gcs(gcs_path: str, local_dir: str) -> bool:
   """Downloads test results from GCS using gsutil."""
-  logging.info(f'Downloading results from {gcs_path} to {local_dir}')
+  logging.info("Downloading results from %s to %s", gcs_path, local_dir)
   cmd = ['gsutil', '-q', 'cp', '-r', gcs_path + '/', local_dir]
   try:
     result = subprocess.run(cmd, check=False)
     return result.returncode == 0
-  except Exception as error:
-    logging.error(f'Failed to download results from GCS: {error}')
+  except Exception as error:  # pylint: disable=broad-exception-caught
+    logging.error("Failed to download results from GCS: %s", error)
     return False
 
 
@@ -78,12 +78,12 @@ def get_failed_targets(test_output_dir: str, targets: List[str]) -> List[str]:
     ]
 
     if not target_xml_files:
-      logging.warning(f'No XML results found for {target}')
+      logging.warning("No XML results found for %s", target)
 
       # Try to find log file to generate crash report
       log_files = list(pathlib.Path(test_output_dir).rglob(f'{target}_log.txt'))
       if log_files:
-        logging.info(f'Found log for {target}, generating crash report.')
+        logging.info("Found log for %s, generating crash report.", target)
         log_path = log_files[0]
         xml_path = log_path.parent / f'{target}_testoutput.xml'
 
@@ -129,7 +129,7 @@ def main() -> int:
   try:
     targets_list = json.loads(args.targets)
   except json.JSONDecodeError as error:
-    logging.error(f'Failed to parse targets JSON: {error}')
+    logging.error("Failed to parse targets JSON: %s", error)
     return 1
 
   local_results_dir = 'results'
@@ -139,7 +139,7 @@ def main() -> int:
   any_run_failed = False
 
   for attempt in range(1, args.max_attempts + 1):
-    logging.info(f'Starting Attempt {attempt}')
+    logging.info("Starting Attempt %d", attempt)
 
     if attempt > 1:
       if args.event_name == 'pull_request' and not failed_targets:
@@ -172,7 +172,7 @@ def main() -> int:
         artifact_name=None,
         action='trigger')
 
-    logging.info(f'Triggering tests for targets: {current_targets}')
+    logging.info("Triggering tests for targets: %s", current_targets)
     # Use public method
     test_requests = on_device_tests_gateway_client.process_test_requests(
         client_args)
@@ -181,8 +181,8 @@ def main() -> int:
     try:
       client.run_trigger_command(client_args.token, client_args.label,
                                  test_requests)
-    except Exception as error:
-      logging.error(f'Failed to trigger tests: {error}')
+    except Exception as error:  # pylint: disable=broad-exception-caught
+      logging.error("Failed to trigger tests: %s", error)
       any_run_failed = True
       continue
 
@@ -197,18 +197,18 @@ def main() -> int:
       if current_failed:
         any_run_failed = True
         failed_targets = current_failed
-        logging.warning(f'Attempt {attempt} failed for: {failed_targets}')
+        logging.warning("Attempt %d failed for: %s", attempt, failed_targets)
       else:
         failed_targets = []
-        logging.info(f'Attempt {attempt} passed.')
+        logging.info("Attempt %d passed.", attempt)
     else:
-      logging.error(f'Failed to download results for attempt {attempt}')
+      logging.error("Failed to download results for attempt %d", attempt)
       any_run_failed = True
       failed_targets = current_targets  # Assume failed if we can't get results
 
   if args.event_name == 'pull_request':
     if failed_targets:
-      logging.error(f'Tests failed after {args.max_attempts} attempts.')
+      logging.error("Tests failed after %d attempts.", args.max_attempts)
       return 1
     else:
       logging.info('Tests passed (possibly after retries).')

--- a/cobalt/tools/run_device_tests_test.py
+++ b/cobalt/tools/run_device_tests_test.py
@@ -34,7 +34,7 @@ class TestRunDeviceTests(unittest.TestCase):
   def test_download_results_from_gcs_success(self, mock_run):
     mock_run.return_value.returncode = 0
     res = run_device_tests.download_results_from_gcs('gs://bucket/path',
-                                                      '/local/dir')
+                                                     '/local/dir')
     self.assertTrue(res)
     mock_run.assert_called_once()
 
@@ -42,7 +42,7 @@ class TestRunDeviceTests(unittest.TestCase):
   def test_download_results_from_gcs_fail(self, mock_run):
     mock_run.return_value.returncode = 1
     res = run_device_tests.download_results_from_gcs('gs://bucket/path',
-                                                      '/local/dir')
+                                                     '/local/dir')
     self.assertFalse(res)
 
   @patch('os.path.exists')

--- a/cobalt/tools/run_device_tests_test.py
+++ b/cobalt/tools/run_device_tests_test.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for run_device_tests.py."""
+
+import json
+import os
+import pathlib
+import sys
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+# Mock missing dependencies before importing run_device_tests
+mock_grpc = MagicMock()
+sys.modules['grpc'] = mock_grpc
+sys.modules['on_device_tests_gateway_pb2'] = MagicMock()
+sys.modules['on_device_tests_gateway_pb2_grpc'] = MagicMock()
+
+import run_device_tests
+
+
+class TestRunDeviceTests(unittest.TestCase):
+
+  @patch('subprocess.run')
+  def test_download_results_from_gcs_success(self, mock_run):
+    mock_run.return_value.returncode = 0
+    res = run_device_tests.download_results_from_gcs('gs://bucket/path',
+                                                     '/local/dir')
+    self.assertTrue(res)
+    mock_run.assert_called_once()
+
+  @patch('subprocess.run')
+  def test_download_results_from_gcs_fail(self, mock_run):
+    mock_run.return_value.returncode = 1
+    res = run_device_tests.download_results_from_gcs('gs://bucket/path',
+                                                     '/local/dir')
+    self.assertFalse(res)
+
+  @patch('os.path.exists')
+  @patch('junit_mini_parser.find_failing_tests')
+  def test_check_failures_in_xml_true(self, mock_find, mock_exists):
+    mock_exists.return_value = True
+    mock_find.return_value = {'file.xml': [('test1', 'msg')]}
+    res = run_device_tests.check_failures_in_xml(['file.xml'])
+    self.assertTrue(res)
+
+  @patch('os.path.exists')
+  @patch('junit_mini_parser.find_failing_tests')
+  def test_check_failures_in_xml_false(self, mock_find, mock_exists):
+    mock_exists.return_value = True
+    mock_find.return_value = {}
+    res = run_device_tests.check_failures_in_xml(['file.xml'])
+    self.assertFalse(res)
+
+  @patch('pathlib.Path.rglob')
+  def test_get_failed_targets_no_xml(self, mock_rglob):
+    # Simulate no XML files found
+    mock_rglob.side_effect = [[], []]  # For XML and then for Log
+    targets = ['cobalt/dom:dom_test']
+    res = run_device_tests.get_failed_targets('/dummy/dir', targets)
+    self.assertEqual(res, targets)
+
+  @patch('pathlib.Path.rglob')
+  @patch('run_device_tests.check_failures_in_xml')
+  def test_get_failed_targets_with_failures(self, mock_check, mock_rglob):
+    mock_file = MagicMock()
+    mock_file.name = 'dom_test.xml'
+    mock_rglob.return_value = [mock_file]
+    mock_check.return_value = True
+
+    targets = ['cobalt/dom:dom_test']
+    res = run_device_tests.get_failed_targets('/dummy/dir', targets)
+    self.assertEqual(res, targets)
+
+  @patch('run_device_tests.download_results_from_gcs')
+  @patch('run_device_tests.get_failed_targets')
+  @patch('on_device_tests_gateway_client.process_test_requests')
+  @patch('on_device_tests_gateway_client.OnDeviceTestsGatewayClient')
+  def test_main_success(self, mock_client, mock_process, mock_get_failed,
+                        mock_download):
+    mock_download.return_value = True
+    mock_get_failed.return_value = []
+    mock_process.return_value = []
+
+    test_args = [
+        '--token', 'dummy_token', '--test_type', 'unit_test', '--device_family',
+        'android', '--targets', '["cobalt/dom:dom_test"]', '--filter_json_dir',
+        '/dummy/filters', '--dimensions', '{}', '--gcs_archive_path',
+        'gs://archive', '--gcs_results_path', 'gs://results', '--event_name',
+        'pull_request'
+    ]
+
+    with patch('sys.argv', ['run_device_tests.py'] + test_args):
+      rc = run_device_tests.main()
+      self.assertEqual(rc, 0)
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/cobalt/tools/run_device_tests_test.py
+++ b/cobalt/tools/run_device_tests_test.py
@@ -14,12 +14,9 @@
 # limitations under the License.
 """Unit tests for run_device_tests.py."""
 
-import json
-import os
-import pathlib
 import sys
 import unittest
-from unittest.mock import MagicMock, mock_open, patch
+from unittest.mock import MagicMock, patch
 
 # Mock missing dependencies before importing run_device_tests
 mock_grpc = MagicMock()
@@ -27,16 +24,17 @@ sys.modules['grpc'] = mock_grpc
 sys.modules['on_device_tests_gateway_pb2'] = MagicMock()
 sys.modules['on_device_tests_gateway_pb2_grpc'] = MagicMock()
 
-import run_device_tests
+import run_device_tests  # pylint: disable=wrong-import-position
 
 
 class TestRunDeviceTests(unittest.TestCase):
+  """Tests for run_device_tests."""
 
   @patch('subprocess.run')
   def test_download_results_from_gcs_success(self, mock_run):
     mock_run.return_value.returncode = 0
     res = run_device_tests.download_results_from_gcs('gs://bucket/path',
-                                                     '/local/dir')
+                                                      '/local/dir')
     self.assertTrue(res)
     mock_run.assert_called_once()
 
@@ -44,7 +42,7 @@ class TestRunDeviceTests(unittest.TestCase):
   def test_download_results_from_gcs_fail(self, mock_run):
     mock_run.return_value.returncode = 1
     res = run_device_tests.download_results_from_gcs('gs://bucket/path',
-                                                     '/local/dir')
+                                                      '/local/dir')
     self.assertFalse(res)
 
   @patch('os.path.exists')
@@ -87,7 +85,7 @@ class TestRunDeviceTests(unittest.TestCase):
   @patch('run_device_tests.get_failed_targets')
   @patch('on_device_tests_gateway_client.process_test_requests')
   @patch('on_device_tests_gateway_client.OnDeviceTestsGatewayClient')
-  def test_main_success(self, mock_client, mock_process, mock_get_failed,
+  def test_main_success(self, _mock_client, mock_process, mock_get_failed,
                         mock_download):
     mock_download.return_value = True
     mock_get_failed.return_value = []

--- a/cobalt/tools/run_host_tests.py
+++ b/cobalt/tools/run_host_tests.py
@@ -98,8 +98,8 @@ def handle_run(
     else:  # attempt > 1 and pull_request
       failed_tests = failed_tests_map.get(binary_name, [])
       if not failed_tests:
-        logging.info(
-            "No specific failed tests found for %s, retrying all.", binary_name)
+        logging.info("No specific failed tests found for %s, retrying all.",
+                     binary_name)
         gtest_filter = "*"
       else:
         gtest_filter = ":".join(failed_tests)
@@ -130,8 +130,7 @@ def handle_run(
       if not os.path.exists(xml_path):
         logging.info(
             "XML output missing for %s. Attempting to generate crash report.",
-            binary_name
-        )
+            binary_name)
         crash_info = generate_crash_report.extract_crash(pathlib.Path(log_path))
         if crash_info:
           generate_crash_report.write_junit_xml(
@@ -229,10 +228,8 @@ def main() -> int:
         else:
           # If it failed but we found no specific tests (maybe crashed),
           # keep it in failed_binaries to retry the whole binary.
-          logging.info(
-              "%s failed but no specific tests found. Retrying all.",
-              binary_name
-          )
+          logging.info("%s failed but no specific tests found. Retrying all.",
+                       binary_name)
           failed_binaries.add(binary)
 
   if args.event_name == "pull_request":

--- a/cobalt/tools/run_host_tests.py
+++ b/cobalt/tools/run_host_tests.py
@@ -29,11 +29,12 @@ import junit_mini_parser
 script_dir = os.path.dirname(os.path.abspath(__file__))
 sys.path.append(
     os.path.abspath(os.path.join(script_dir, "../../.github/scripts")))
-import generate_crash_report
+import generate_crash_report  # pylint: disable=wrong-import-position
 
 XVFB_ARGS = "-screen 0 1920x1080x24i +render +extension GLX -noreset"
 
 
+# pylint: disable=too-many-positional-arguments
 def run_test_binary(entrypoint: str,
                     shard_index: int,
                     total_shards: int,
@@ -51,15 +52,15 @@ def run_test_binary(entrypoint: str,
   if gtest_filter:
     cmd.append(f"--gtest_filter={gtest_filter}")
 
-  logging.info(f"Running: {' '.join(cmd)}")
+  logging.info("Running: %s", ' '.join(cmd))
   try:
     with open(log_output, 'w', encoding='utf-8') as log_file:
       return_code = subprocess.run(
           cmd, stdout=log_file, stderr=subprocess.STDOUT,
           check=False).returncode
     return return_code
-  except Exception as error:
-    logging.error(f"Failed to execute {entrypoint}: {error}")
+  except Exception as error:  # pylint: disable=broad-exception-caught
+    logging.error("Failed to execute %s: %s", entrypoint, error)
     return 1
 
 
@@ -75,8 +76,8 @@ def get_initial_filter(binary_name: str, filter_json_dir: Optional[str]) -> str:
         failing_tests = data.get('failing_tests', [])
         if failing_tests:
           return "-" + ":".join(failing_tests)
-    except Exception as error:
-      logging.warning(f"Failed to parse filter file {filter_file}: {error}")
+    except Exception as error:  # pylint: disable=broad-exception-caught
+      logging.warning("Failed to parse filter file %s: %s", filter_file, error)
   return "*"
 
 
@@ -98,7 +99,7 @@ def handle_run(
       failed_tests = failed_tests_map.get(binary_name, [])
       if not failed_tests:
         logging.info(
-            f"No specific failed tests found for {binary_name}, retrying all.")
+            "No specific failed tests found for %s, retrying all.", binary_name)
         gtest_filter = "*"
       else:
         gtest_filter = ":".join(failed_tests)
@@ -115,20 +116,21 @@ def handle_run(
     entrypoint = binary_path
     if os.path.exists(wrapper_path) and os.access(wrapper_path, os.X_OK):
       entrypoint = wrapper_path
-      logging.info(f"Using wrapper script: {entrypoint}")
+      logging.info("Using wrapper script: %s", entrypoint)
 
     return_code = run_test_binary(entrypoint, args.shard, args.num_gtest_shards,
                                   xml_path, log_path, gtest_filter,
                                   args.xvfb_run_path)
 
     if return_code != 0:
-      logging.warning(f"{binary_name} failed with exit code {return_code}")
+      logging.warning("%s failed with exit code %d", binary_name, return_code)
       failed_binaries.add(binary_path)
 
       # Generate crash report if XML is missing (likely crash)
       if not os.path.exists(xml_path):
         logging.info(
-            f"XML output missing for {binary_name}. Attempting to generate crash report."
+            "XML output missing for %s. Attempting to generate crash report.",
+            binary_name
         )
         crash_info = generate_crash_report.extract_crash(pathlib.Path(log_path))
         if crash_info:
@@ -139,6 +141,7 @@ def handle_run(
 
 
 def main() -> int:
+  """Main function to run host tests with retries."""
   logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
 
   parser = argparse.ArgumentParser(description="Run host tests with retries.")
@@ -163,7 +166,7 @@ def main() -> int:
   args = parser.parse_args()
 
   if not os.path.exists(args.test_targets_json):
-    logging.error(f"File not found: {args.test_targets_json}")
+    logging.error("File not found: %s", args.test_targets_json)
     return 1
 
   with open(args.test_targets_json, 'r', encoding='utf-8') as file:
@@ -187,7 +190,7 @@ def main() -> int:
                                                       args.filter_json_dir)
 
   for attempt in range(1, args.max_attempts + 1):
-    logging.info(f"Starting Attempt {attempt}")
+    logging.info("Starting Attempt %d", attempt)
 
     if attempt == 1 or args.event_name == "push":
       binaries_to_run = test_binaries
@@ -227,13 +230,14 @@ def main() -> int:
           # If it failed but we found no specific tests (maybe crashed),
           # keep it in failed_binaries to retry the whole binary.
           logging.info(
-              f"{binary_name} failed but no specific tests found. Retrying all."
+              "%s failed but no specific tests found. Retrying all.",
+              binary_name
           )
           failed_binaries.add(binary)
 
   if args.event_name == "pull_request":
     if failed_binaries:
-      logging.error(f"Tests failed after {args.max_attempts} attempts.")
+      logging.error("Tests failed after %d attempts.", args.max_attempts)
       return 1
     else:
       logging.info("Tests passed (possibly after retries).")

--- a/cobalt/tools/run_host_tests.py
+++ b/cobalt/tools/run_host_tests.py
@@ -1,0 +1,251 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Runs on-host tests with retry logic, handling PR and Push events."""
+
+import argparse
+import json
+import logging
+import os
+import pathlib
+import subprocess
+import sys
+from typing import Dict, List, Optional, Set, Tuple
+
+import junit_mini_parser
+
+# Add .github/scripts to path to import generate_crash_report
+script_dir = os.path.dirname(os.path.abspath(__file__))
+sys.path.append(
+    os.path.abspath(os.path.join(script_dir, "../../.github/scripts")))
+import generate_crash_report
+
+XVFB_ARGS = "-screen 0 1920x1080x24i +render +extension GLX -noreset"
+
+
+def run_test_binary(entrypoint: str,
+                    shard_index: int,
+                    total_shards: int,
+                    xml_output: str,
+                    log_output: str,
+                    gtest_filter: Optional[str] = None,
+                    xvfb_run_path: str = "xvfb-run") -> int:
+  """Runs a test entrypoint with gtest flags, redirecting output to a log file."""
+  cmd = [
+      xvfb_run_path, "-a", f"--server-args={XVFB_ARGS}", "stdbuf", "-i0", "-o0",
+      "-e0", entrypoint, "--single-process-tests",
+      f"--gtest_shard_index={shard_index}",
+      f"--gtest_total_shards={total_shards}", f"--gtest_output=xml:{xml_output}"
+  ]
+  if gtest_filter:
+    cmd.append(f"--gtest_filter={gtest_filter}")
+
+  logging.info(f"Running: {' '.join(cmd)}")
+  try:
+    with open(log_output, 'w', encoding='utf-8') as log_file:
+      return_code = subprocess.run(
+          cmd, stdout=log_file, stderr=subprocess.STDOUT,
+          check=False).returncode
+    return return_code
+  except Exception as error:
+    logging.error(f"Failed to execute {entrypoint}: {error}")
+    return 1
+
+
+def get_initial_filter(binary_name: str, filter_json_dir: Optional[str]) -> str:
+  """Loads initial filter from JSON file if available."""
+  if not filter_json_dir:
+    return "*"
+  filter_file = os.path.join(filter_json_dir, f"{binary_name}_filter.json")
+  if os.path.exists(filter_file):
+    try:
+      with open(filter_file, 'r', encoding='utf-8') as file:
+        data = json.load(file)
+        failing_tests = data.get('failing_tests', [])
+        if failing_tests:
+          return "-" + ":".join(failing_tests)
+    except Exception as error:
+      logging.warning(f"Failed to parse filter file {filter_file}: {error}")
+  return "*"
+
+
+def handle_run(
+    binaries: List[str], attempt: int, args: argparse.Namespace,
+    failed_tests_map: Dict[str, List[str]],
+    initial_filters: Dict[str, str]) -> Tuple[Set[str], Dict[str, str]]:
+  """Handles a single run (attempt) of tests."""
+  failed_binaries = set()
+  xml_files_created = {}
+
+  for binary_path in binaries:
+    binary_name = os.path.basename(binary_path)
+
+    # Calculate filter
+    if attempt == 1 or args.event_name == "push":
+      gtest_filter = initial_filters.get(binary_name, "*")
+    else:  # attempt > 1 and pull_request
+      failed_tests = failed_tests_map.get(binary_name, [])
+      if not failed_tests:
+        logging.info(
+            f"No specific failed tests found for {binary_name}, retrying all.")
+        gtest_filter = "*"
+      else:
+        gtest_filter = ":".join(failed_tests)
+
+    xml_path = os.path.join(args.results_dir,
+                            f"{binary_name}_result_attempt_{attempt}.xml")
+    log_path = os.path.join(args.results_dir,
+                            f"{binary_name}_log_attempt_{attempt}.txt")
+    xml_files_created[binary_name] = xml_path
+
+    # Check for wrapper script (Functional Regression Fix)
+    binary_dir = os.path.dirname(binary_path)
+    wrapper_path = os.path.join(binary_dir, "bin", f"run_{binary_name}")
+    entrypoint = binary_path
+    if os.path.exists(wrapper_path) and os.access(wrapper_path, os.X_OK):
+      entrypoint = wrapper_path
+      logging.info(f"Using wrapper script: {entrypoint}")
+
+    return_code = run_test_binary(entrypoint, args.shard, args.num_gtest_shards,
+                                  xml_path, log_path, gtest_filter,
+                                  args.xvfb_run_path)
+
+    if return_code != 0:
+      logging.warning(f"{binary_name} failed with exit code {return_code}")
+      failed_binaries.add(binary_path)
+
+      # Generate crash report if XML is missing (likely crash)
+      if not os.path.exists(xml_path):
+        logging.info(
+            f"XML output missing for {binary_name}. Attempting to generate crash report."
+        )
+        crash_info = generate_crash_report.extract_crash(pathlib.Path(log_path))
+        if crash_info:
+          generate_crash_report.write_junit_xml(
+              pathlib.Path(xml_path), *crash_info)
+
+  return failed_binaries, xml_files_created
+
+
+def main() -> int:
+  logging.basicConfig(level=logging.INFO, format='%(levelname)s: %(message)s')
+
+  parser = argparse.ArgumentParser(description="Run host tests with retries.")
+  parser.add_argument(
+      "--test_targets_json", required=True, help="Path to test_targets.json")
+  parser.add_argument("--shard", type=int, required=True, help="Shard index")
+  parser.add_argument(
+      "--num_gtest_shards", type=int, required=True, help="Total shards")
+  parser.add_argument(
+      "--results_dir", required=True, help="Directory to save results")
+  parser.add_argument(
+      "--event_name",
+      required=True,
+      help="GitHub event name (pull_request or push)")
+  parser.add_argument(
+      "--max_attempts", type=int, default=3, help="Maximum number of attempts")
+  parser.add_argument(
+      "--xvfb_run_path", default="xvfb-run", help="Path to xvfb-run")
+  parser.add_argument(
+      "--filter_json_dir", help="Directory containing filter JSON files")
+
+  args = parser.parse_args()
+
+  if not os.path.exists(args.test_targets_json):
+    logging.error(f"File not found: {args.test_targets_json}")
+    return 1
+
+  with open(args.test_targets_json, 'r', encoding='utf-8') as file:
+    targets = json.load(file)
+
+  test_binaries = [
+      target['executable'] for target in targets if target.get('executable')
+  ]
+
+  os.makedirs(args.results_dir, exist_ok=True)
+
+  failed_binaries = set(test_binaries)
+  failed_tests_map = {}
+  any_run_failed = False
+
+  # Cache initial filters to avoid redundant I/O (Dead Code Fix)
+  initial_filters = {}
+  for binary_path in test_binaries:
+    binary_name = os.path.basename(binary_path)
+    initial_filters[binary_name] = get_initial_filter(binary_name,
+                                                      args.filter_json_dir)
+
+  for attempt in range(1, args.max_attempts + 1):
+    logging.info(f"Starting Attempt {attempt}")
+
+    if attempt == 1 or args.event_name == "push":
+      binaries_to_run = test_binaries
+    else:  # attempt > 1 and pull_request
+      if not failed_binaries:
+        logging.info("All tests passed, skipping further attempts.")
+        break
+      binaries_to_run = list(failed_binaries)
+
+    current_failed_binaries, xml_files_created = handle_run(
+        binaries_to_run, attempt, args, failed_tests_map, initial_filters)
+
+    if current_failed_binaries:
+      any_run_failed = True
+
+    # Update failed tests map for next attempt (only relevant for PR)
+    if args.event_name == "pull_request":
+      xml_files = list(xml_files_created.values())
+      # Batch process XML files
+      fails = junit_mini_parser.find_failing_tests(xml_files)
+      failed_tests_map = {}
+      for path, test_list in fails.items():
+        filename = os.path.basename(path)
+        binary_name = filename.split('_result')[0]
+        # Index 0 is the test name
+        failed_tests_map[binary_name] = [
+            test_case[0] for test_case in test_list
+        ]
+
+      # Update failed_binaries to include those that failed to run OR have failed tests
+      failed_binaries = set()
+      for binary in current_failed_binaries:
+        binary_name = os.path.basename(binary)
+        if binary_name in failed_tests_map and failed_tests_map[binary_name]:
+          failed_binaries.add(binary)
+        else:
+          # If it failed but we found no specific tests (maybe crashed),
+          # keep it in failed_binaries to retry the whole binary.
+          logging.info(
+              f"{binary_name} failed but no specific tests found. Retrying all."
+          )
+          failed_binaries.add(binary)
+
+  if args.event_name == "pull_request":
+    if failed_binaries:
+      logging.error(f"Tests failed after {args.max_attempts} attempts.")
+      return 1
+    else:
+      logging.info("Tests passed (possibly after retries).")
+      return 0
+  elif args.event_name == "push":
+    if any_run_failed:
+      logging.error("Some test runs failed on Push event.")
+      return 1
+    return 0
+
+  return 0
+
+
+if __name__ == "__main__":
+  sys.exit(main())

--- a/cobalt/tools/run_host_tests_test.py
+++ b/cobalt/tools/run_host_tests_test.py
@@ -14,8 +14,6 @@
 # limitations under the License.
 """Unit tests for run_host_tests.py."""
 
-import json
-import os
 import unittest
 from unittest.mock import MagicMock, mock_open, patch
 
@@ -23,13 +21,14 @@ import run_host_tests
 
 
 class TestRunHostTests(unittest.TestCase):
+  """Tests for run_host_tests."""
 
   @patch('os.path.exists')
   @patch(
       'builtins.open',
       new_callable=mock_open,
       read_data='{"failing_tests": ["Test1", "Test2"]}')
-  def test_get_initial_filter_valid(self, mock_file, mock_exists):
+  def test_get_initial_filter_valid(self, _mock_file, mock_exists):
     mock_exists.return_value = True
     res = run_host_tests.get_initial_filter('my_test', '/dummy/dir')
     self.assertEqual(res, '-Test1:Test2')
@@ -42,14 +41,14 @@ class TestRunHostTests(unittest.TestCase):
 
   @patch('os.path.exists')
   @patch('builtins.open', new_callable=mock_open, read_data='invalid json')
-  def test_get_initial_filter_invalid_json(self, mock_file, mock_exists):
+  def test_get_initial_filter_invalid_json(self, _mock_file, mock_exists):
     mock_exists.return_value = True
     res = run_host_tests.get_initial_filter('my_test', '/dummy/dir')
     self.assertEqual(res, '*')
 
   @patch('subprocess.run')
   @patch('builtins.open', new_callable=mock_open)
-  def test_run_test_binary(self, mock_file, mock_run):
+  def test_run_test_binary(self, _mock_file, mock_run):
     mock_run.return_value.returncode = 0
     rc = run_host_tests.run_test_binary('my_test', 0, 1, 'out.xml', 'out.txt')
     self.assertEqual(rc, 0)
@@ -57,7 +56,7 @@ class TestRunHostTests(unittest.TestCase):
 
   @patch('subprocess.run')
   @patch('builtins.open', new_callable=mock_open)
-  def test_run_test_binary_fail(self, mock_file, mock_run):
+  def test_run_test_binary_fail(self, _mock_file, mock_run):
     mock_run.return_value.returncode = 1
     rc = run_host_tests.run_test_binary('my_test', 0, 1, 'out.xml', 'out.txt')
     self.assertEqual(rc, 1)
@@ -95,7 +94,7 @@ class TestRunHostTests(unittest.TestCase):
     args.xvfb_run_path = 'xvfb-run'
     args.filter_json_dir = None
 
-    failed, created = run_host_tests.handle_run(['/path/to/test1'], 1, args, {},
+    failed, _created = run_host_tests.handle_run(['/path/to/test1'], 1, args, {},
                                                 {})
     self.assertEqual(failed, {'/path/to/test1'})
     mock_crash.extract_crash.assert_called_once()

--- a/cobalt/tools/run_host_tests_test.py
+++ b/cobalt/tools/run_host_tests_test.py
@@ -94,8 +94,8 @@ class TestRunHostTests(unittest.TestCase):
     args.xvfb_run_path = 'xvfb-run'
     args.filter_json_dir = None
 
-    failed, _created = run_host_tests.handle_run(['/path/to/test1'], 1, args, {},
-                                                {})
+    failed, _created = run_host_tests.handle_run(['/path/to/test1'], 1, args,
+                                                 {}, {})
     self.assertEqual(failed, {'/path/to/test1'})
     mock_crash.extract_crash.assert_called_once()
 

--- a/cobalt/tools/run_host_tests_test.py
+++ b/cobalt/tools/run_host_tests_test.py
@@ -1,0 +1,105 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Unit tests for run_host_tests.py."""
+
+import json
+import os
+import unittest
+from unittest.mock import MagicMock, mock_open, patch
+
+import run_host_tests
+
+
+class TestRunHostTests(unittest.TestCase):
+
+  @patch('os.path.exists')
+  @patch(
+      'builtins.open',
+      new_callable=mock_open,
+      read_data='{"failing_tests": ["Test1", "Test2"]}')
+  def test_get_initial_filter_valid(self, mock_file, mock_exists):
+    mock_exists.return_value = True
+    res = run_host_tests.get_initial_filter('my_test', '/dummy/dir')
+    self.assertEqual(res, '-Test1:Test2')
+
+  @patch('os.path.exists')
+  def test_get_initial_filter_missing(self, mock_exists):
+    mock_exists.return_value = False
+    res = run_host_tests.get_initial_filter('my_test', '/dummy/dir')
+    self.assertEqual(res, '*')
+
+  @patch('os.path.exists')
+  @patch('builtins.open', new_callable=mock_open, read_data='invalid json')
+  def test_get_initial_filter_invalid_json(self, mock_file, mock_exists):
+    mock_exists.return_value = True
+    res = run_host_tests.get_initial_filter('my_test', '/dummy/dir')
+    self.assertEqual(res, '*')
+
+  @patch('subprocess.run')
+  @patch('builtins.open', new_callable=mock_open)
+  def test_run_test_binary(self, mock_file, mock_run):
+    mock_run.return_value.returncode = 0
+    rc = run_host_tests.run_test_binary('my_test', 0, 1, 'out.xml', 'out.txt')
+    self.assertEqual(rc, 0)
+    mock_run.assert_called_once()
+
+  @patch('subprocess.run')
+  @patch('builtins.open', new_callable=mock_open)
+  def test_run_test_binary_fail(self, mock_file, mock_run):
+    mock_run.return_value.returncode = 1
+    rc = run_host_tests.run_test_binary('my_test', 0, 1, 'out.xml', 'out.txt')
+    self.assertEqual(rc, 1)
+
+  @patch('run_host_tests.run_test_binary')
+  @patch('os.path.exists')
+  def test_handle_run_success(self, mock_exists, mock_run_binary):
+    mock_run_binary.return_value = 0
+    mock_exists.return_value = True
+    args = MagicMock()
+    args.event_name = 'pull_request'
+    args.results_dir = '/dummy/results'
+    args.shard = 0
+    args.num_gtest_shards = 1
+    args.xvfb_run_path = 'xvfb-run'
+    args.filter_json_dir = None
+
+    failed, created = run_host_tests.handle_run(['/path/to/test1'], 1, args, {},
+                                                {})
+    self.assertEqual(failed, set())
+    self.assertIn('test1', created)
+
+  @patch('run_host_tests.run_test_binary')
+  @patch('os.path.exists')
+  @patch('run_host_tests.generate_crash_report')
+  def test_handle_run_fail_crash(self, mock_crash, mock_exists,
+                                 mock_run_binary):
+    mock_run_binary.return_value = 1
+    mock_exists.return_value = False  # XML missing
+    args = MagicMock()
+    args.event_name = 'pull_request'
+    args.results_dir = '/dummy/results'
+    args.shard = 0
+    args.num_gtest_shards = 1
+    args.xvfb_run_path = 'xvfb-run'
+    args.filter_json_dir = None
+
+    failed, created = run_host_tests.handle_run(['/path/to/test1'], 1, args, {},
+                                                {})
+    self.assertEqual(failed, {'/path/to/test1'})
+    mock_crash.extract_crash.assert_called_once()
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
…e tests.

This change adds Python wrapper scripts to handle test retries for on-host and on-device tests, distinguishing between PR events (retry only failed tests) and Push events (retry all tests). It also adds utilities to merge and filter JUnit XML results to support DataDog uploads with reduced API usage.

- Created run_host_tests.py and run_device_tests.py for retry orchestration.
- Created junit_xml_utils.py and prepare_results_for_ci.py for XML manipulation.
- Updated corresponding GitHub Actions to use these scripts.
- Added unit tests for all new scripts.

TAG=agy
CONV=99357171-19a2-43f5-b31c-45371160f83d