### PR TITLE
cobalt/infra: Enable cobalt_memory_instrumentation_unittests 

### DIFF
--- a/cobalt/build/testing/targets/android-arm/test_targets.json
+++ b/cobalt/build/testing/targets/android-arm/test_targets.json
@@ -39,6 +39,10 @@
     "executable": "out/android-arm_devel/net_unittests_apk/net_unittests-debug.apk"
   },
   {
+    "target": "services/resource_coordinator:cobalt_memory_instrumentation_unittests",
+    "executable": "out/android-arm_devel/cobalt_memory_instrumentation_unittests_apk/cobalt_memory_instrumentation_unittests-debug.apk"
+  },
+  {
     "target": "skia:skia_unittests",
     "executable": "out/android-arm_devel/skia_unittests_apk/skia_unittests-debug.apk"
   },

--- a/cobalt/build/testing/targets/android-arm64/test_targets.json
+++ b/cobalt/build/testing/targets/android-arm64/test_targets.json
@@ -39,6 +39,10 @@
     "executable": "out/android-arm64_devel/net_unittests_apk/net_unittests-debug.apk"
   },
   {
+    "target": "services/resource_coordinator:cobalt_memory_instrumentation_unittests",
+    "executable": "out/android-arm64_devel/cobalt_memory_instrumentation_unittests_apk/cobalt_memory_instrumentation_unittests-debug.apk"
+  },
+  {
     "target": "skia:skia_unittests",
     "executable": "out/android-arm64_devel/skia_unittests_apk/skia_unittests-debug.apk"
   },

--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -37,6 +37,10 @@
     "executable": "out/evergreen-arm-hardfp-rdk_devel/media_mojo_unittests_loader.py"
   },
   {
+    "target": "services/resource_coordinator:cobalt_memory_instrumentation_unittests_loader",
+    "executable": "out/evergreen-arm-hardfp-rdk_devel/cobalt_memory_instrumentation_unittests_loader.py"
+  },
+  {
     "target": "skia:skia_unittests_loader",
     "executable": "out/evergreen-arm-hardfp-rdk_devel/skia_unittests_loader.py"
   },

--- a/cobalt/build/testing/targets/evergreen-x64/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-x64/test_targets.json
@@ -85,6 +85,10 @@
     "executable": "out/evergreen-x64_devel/mojo_unittests_loader.py"
   },
   {
+    "target": "services/resource_coordinator:cobalt_memory_instrumentation_unittests_loader",
+    "executable": "out/evergreen-x64_devel/cobalt_memory_instrumentation_unittests_loader.py"
+  },
+  {
     "target": "sql:sql_unittests_loader",
     "executable": "out/evergreen-x64_devel/sql_unittests_loader.py"
   },

--- a/cobalt/build/testing/targets/linux-x64x11-modular/test_targets.json
+++ b/cobalt/build/testing/targets/linux-x64x11-modular/test_targets.json
@@ -74,6 +74,10 @@
     "executable": "out/linux-x64x11-modular_devel/mojo_unittests_loader"
   },
   {
+    "target": "services/resource_coordinator:cobalt_memory_instrumentation_unittests_loader",
+    "executable": "out/linux-x64x11-modular_devel/cobalt_memory_instrumentation_unittests_loader"
+  },
+  {
     "target": "skia:skia_unittests_loader",
     "executable": "out/linux-x64x11-modular_devel/skia_unittests_loader"
   },

--- a/cobalt/build/testing/targets/linux-x64x11/test_targets.json
+++ b/cobalt/build/testing/targets/linux-x64x11/test_targets.json
@@ -80,6 +80,10 @@
     "executable": "out/linux-x64x11_devel/mojo_unittests"
   },
   {
+    "target": "services/resource_coordinator:cobalt_memory_instrumentation_unittests",
+    "executable": "out/linux-x64x11_devel/cobalt_memory_instrumentation_unittests"
+  },
+  {
     "target": "skia:skia_unittests",
     "executable": "out/linux-x64x11_devel/skia_unittests"
   },

--- a/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
+++ b/services/resource_coordinator/public/cpp/memory_instrumentation/os_metrics_linux.cc
@@ -1102,6 +1102,16 @@ OSMetrics::MappedAndResidentPagesDumpState OSMetrics::GetMappedAndResidentPages(
       return OSMetrics::MappedAndResidentPagesDumpState::kAccessPagemapDenied;
     }
   }
+#if BUILDFLAG(IS_COBALT)
+  // Disable stdio buffering for the pagemap file.
+  // In musl libc, buffered reads (like fread) are optimized using readv, which
+  // splits the read such that the first segment has size N-1. For special files
+  // like /proc/self/pagemap, the Linux kernel strictly enforces that all reads
+  // must be in multiples of 8 bytes. An unaligned read size (like N-1) will
+  // fail with EINVAL. Making the stream unbuffered forces musl to perform
+  // direct, aligned reads, avoiding this issue.
+  setvbuf(pagemap_file.get(), NULL, _IONBF, 0);
+#endif  // BUILDFLAG(IS_COBALT)
 
   const size_t kPageSize = base::GetPageSize();
   const size_t start_page = start_address / kPageSize;
@@ -1112,17 +1122,35 @@ OSMetrics::MappedAndResidentPagesDumpState OSMetrics::GetMappedAndResidentPages(
   // The pagemap has one 64 bit entry per page or 8 bytes.
   auto offset = static_cast<long>(start_page * 8);
   if (fseek(pagemap_file.get(), offset, SEEK_SET) != 0) {
+#if BUILDFLAG(IS_COBALT)
+    PLOG(ERROR) << "Error in fseek " << kPagemap << " to offset " << offset;
+#else
     DLOG(ERROR) << "Error in fseek " << kPagemap;
+#endif  // BUILDFLAG(IS_COBALT)
     return OSMetrics::MappedAndResidentPagesDumpState::kFailure;
   }
 
   // |entries| will be 2kB/MB (if |kPageSize| = 4096),
   // that would only be ~80kB on Android, and up to 200kB on Linux (for 100MB)
   std::vector<uint64_t> entries(total_pages);
+#if BUILDFLAG(IS_COBALT)
+  size_t read_bytes = fread(&entries[0], sizeof(uint64_t), total_pages, pagemap_file.get());
+  if (read_bytes != total_pages) {
+    PLOG(ERROR) << "Error in fread " << kPagemap << ", read " << read_bytes << " of " << total_pages << " entries";
+    if (ferror(pagemap_file.get())) {
+      LOG(ERROR) << "pagemap_file has error indicator set";
+    }
+    if (feof(pagemap_file.get())) {
+      LOG(ERROR) << "pagemap_file has EOF indicator set";
+    }
+    return OSMetrics::MappedAndResidentPagesDumpState::kFailure;
+  }
+#else
   if (fread(&entries[0], sizeof(uint64_t), total_pages, pagemap_file.get()) !=
       total_pages) {
     return OSMetrics::MappedAndResidentPagesDumpState::kFailure;
   }
+#endif  // BUILDFLAG(IS_COBALT)
 
   accessed_pages_bitmap->resize(1 + (total_pages - 1) / 8);
   for (size_t page = 0; page < total_pages; page++) {

--- a/third_party/musl/src/internal/libc.c
+++ b/third_party/musl/src/internal/libc.c
@@ -1,6 +1,14 @@
 #include "libc.h"
 
+#if defined(STARBOARD)
+struct __libc __libc = {
+	.threaded = 1,
+	.need_locks = 1,
+	.can_do_threads = 1,
+};
+#else
 struct __libc __libc;
+#endif
 
 size_t __hwcap;
 char *__progname=0, *__progname_full=0;


### PR DESCRIPTION
Enable `cobalt_memory_instrumentation_unittests` on Linux, Android, and Evergreen.

This unittest suite was introduced as part of the smaps parsing refactoring for Cobalt. See PR #10135  for its introduction.

Bug: 498702469