### PR TITLE
Disable memfd_create

### DIFF
--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -142,7 +142,6 @@ _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
     'madvise',
     'malloc',
     'malloc_usable_size',
-    'memfd_create',
     'mincore',
     'mkdir',
     'mkdtemp',

--- a/v8/src/wasm/wasm-objects.cc
+++ b/v8/src/wasm/wasm-objects.cc
@@ -1302,7 +1302,7 @@ DirectHandle<JSArrayBuffer> WasmMemoryObject::ToResizableBuffer(
 
 MaybeDirectHandle<WasmMemoryMapDescriptor>
 WasmMemoryMapDescriptor::NewFromAnonymous(Isolate* isolate, size_t length) {
-#if V8_TARGET_OS_LINUX
+#if V8_TARGET_OS_LINUX && !BUILDFLAG(IS_STARBOARD)
   CHECK(v8_flags.experimental_wasm_memory_control);
   DirectHandle<JSFunction> descriptor_ctor(
       isolate->native_context()->wasm_memory_map_descriptor_constructor(),

--- a/v8/src/wasm/wasm-objects.cc
+++ b/v8/src/wasm/wasm-objects.cc
@@ -1302,6 +1302,7 @@ DirectHandle<JSArrayBuffer> WasmMemoryObject::ToResizableBuffer(
 
 MaybeDirectHandle<WasmMemoryMapDescriptor>
 WasmMemoryMapDescriptor::NewFromAnonymous(Isolate* isolate, size_t length) {
+// This method is used by experimental_wasm_memory_control and is not enabled by default.
 #if V8_TARGET_OS_LINUX && !BUILDFLAG(IS_STARBOARD)
   CHECK(v8_flags.experimental_wasm_memory_control);
   DirectHandle<JSFunction> descriptor_ctor(


### PR DESCRIPTION
This is a followup to PR #10157 to remove additional usage of memfd_create that was missed in the original pass.

Bug: 500418451