### PR TITLE
starboard: Convert media info structs to classes

### DIFF
--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -90,7 +90,7 @@ AudioRendererPassthrough::Create(JobQueue* job_queue,
   } else {
     SB_LOG(INFO) << "Creating AudioDecoderPassthrough.";
     decoder = std::make_unique<AudioDecoderPassthrough>(
-        audio_stream_info.samples_per_second);
+        audio_stream_info.samples_per_second());
   }
 
   return std::make_unique<AudioRendererPassthrough>(
@@ -107,8 +107,8 @@ AudioRendererPassthrough::AudioRendererPassthrough(
       audio_stream_info_(audio_stream_info),
       decoder_(std::move(decoder)) {
   SB_CHECK(decoder_);
-  SB_DCHECK(audio_stream_info_.codec == kSbMediaAudioCodecAc3 ||
-            audio_stream_info_.codec == kSbMediaAudioCodecEac3);
+  SB_DCHECK(audio_stream_info_.codec() == kSbMediaAudioCodecAc3 ||
+            audio_stream_info_.codec() == kSbMediaAudioCodecEac3);
 }
 
 AudioRendererPassthrough::~AudioRendererPassthrough() {
@@ -344,13 +344,13 @@ int64_t AudioRendererPassthrough::GetCurrentMediaTime(bool* is_playing,
     SB_DCHECK_GE(now, stopped_at_);
     auto time_elapsed = now - stopped_at_;
     int64_t frames_played =
-        time_elapsed * audio_stream_info_.samples_per_second / 1'000'000LL;
+        time_elapsed * audio_stream_info_.samples_per_second() / 1'000'000LL;
     int64_t total_frames_played =
         frames_played + playback_head_position_when_stopped_;
     total_frames_played = std::min(total_frames_played, total_frames_written_);
     playback_time =
         audio_start_time + total_frames_played * 1'000'000LL /
-                               audio_stream_info_.samples_per_second;
+                               audio_stream_info_.samples_per_second();
     return std::max(playback_time, seek_to_time_);
   }
 
@@ -365,8 +365,9 @@ int64_t AudioRendererPassthrough::GetCurrentMediaTime(bool* is_playing,
 
   // TODO: This may cause time regression, because the unadjusted time will be
   //       returned on pause, after an adjusted time has been returned.
-  playback_time = audio_start_time + playback_head_position * 1'000'000LL /
-                                         audio_stream_info_.samples_per_second;
+  playback_time =
+      audio_start_time + playback_head_position * 1'000'000LL /
+                             audio_stream_info_.samples_per_second();
 
   // When underlying AudioTrack is paused, we use returned playback time
   // directly. Note that we should not use |paused_| or |playback_rate_| here.
@@ -411,12 +412,12 @@ void AudioRendererPassthrough::CreateAudioTrackAndStartProcessing() {
 
   std::unique_ptr<AudioTrackBridge> audio_track_bridge =
       AudioTrackBridge::Create(
-          audio_stream_info_.codec == kSbMediaAudioCodecAc3
+          audio_stream_info_.codec() == kSbMediaAudioCodecAc3
               ? kSbMediaAudioCodingTypeAc3
               : kSbMediaAudioCodingTypeDolbyDigitalPlus,
           /*sample_type=*/std::nullopt,  // Not required in passthrough mode
-          audio_stream_info_.number_of_channels,
-          audio_stream_info_.samples_per_second, kPreferredBufferSizeInBytes,
+          audio_stream_info_.number_of_channels(),
+          audio_stream_info_.samples_per_second(), kPreferredBufferSizeInBytes,
           /*tunnel_mode_audio_session_id=*/std::nullopt,
           /*is_web_audio=*/false);
 
@@ -593,7 +594,7 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
   if (stop_called_ && !end_of_stream_played_.load()) {
     auto time_elapsed = CurrentMonotonicTime() - stopped_at_;
     auto frames_played =
-        time_elapsed * audio_stream_info_.samples_per_second / 1'000'000LL;
+        time_elapsed * audio_stream_info_.samples_per_second() / 1'000'000LL;
     if (frames_played + playback_head_position_when_stopped_ >=
         total_frames_written_on_audio_track_thread_) {
       end_of_stream_played_.store(true);

--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -93,8 +93,8 @@ MediaCodecAudioDecoder::MediaCodecAudioDecoder(
       audio_stream_info_(audio_stream_info),
       sample_type_(GetSupportedSampleType()),
       enable_flush_during_seek_(enable_flush_during_seek),
-      output_sample_rate_(audio_stream_info.samples_per_second),
-      output_channel_count_(audio_stream_info.number_of_channels),
+      output_sample_rate_(audio_stream_info.samples_per_second()),
+      output_channel_count_(audio_stream_info.number_of_channels()),
       drm_system_(static_cast<DrmSystem*>(drm_system)) {
   SB_CHECK(error_message);
   auto result = InitializeCodec();
@@ -181,7 +181,7 @@ scoped_refptr<DecodedAudio> MediaCodecAudioDecoder::Read(
     Schedule(consumed_cb_);
     consumed_cb_ = nullptr;
   }
-  *samples_per_second = audio_stream_info_.samples_per_second;
+  *samples_per_second = audio_stream_info_.samples_per_second();
   return result;
 }
 
@@ -251,7 +251,7 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
     int16_t* data = static_cast<int16_t*>(
         IncrementPointerByBytes(address, dequeue_output_result.offset));
     int size = dequeue_output_result.num_bytes;
-    if (2 * audio_stream_info_.samples_per_second ==
+    if (2 * audio_stream_info_.samples_per_second() ==
         static_cast<uint32_t>(output_sample_rate_)) {
       // The audio is encoded using implicit HE-AAC.  As the audio sink has
       // been created already we try to down-mix the decoded data to half of
@@ -264,13 +264,13 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
     }
 
     scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
-        audio_stream_info_.number_of_channels, sample_type_,
+        audio_stream_info_.number_of_channels(), sample_type_,
         kSbMediaAudioFrameStorageTypeInterleaved,
         dequeue_output_result.presentation_time_microseconds, size);
 
     memcpy(decoded_audio->data(), data, size);
     audio_frame_discarder_.AdjustForDiscardedDurations(
-        audio_stream_info_.samples_per_second, &decoded_audio);
+        audio_stream_info_.samples_per_second(), &decoded_audio);
 
     {
       std::lock_guard lock(decoded_audios_mutex_);

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -117,9 +117,9 @@ std::unique_ptr<MediaCodecBridge> MediaCodecBridge::CreateAudioMediaCodecBridge(
     jobject j_media_crypto) {
   bool is_passthrough = false;
   const char* mime =
-      SupportedAudioCodecToMimeType(audio_stream_info.codec, &is_passthrough);
+      SupportedAudioCodecToMimeType(audio_stream_info.codec(), &is_passthrough);
   if (!mime) {
-    SB_LOG(ERROR) << "Unsupported codec " << audio_stream_info.codec << ".";
+    SB_LOG(ERROR) << "Unsupported codec " << audio_stream_info.codec() << ".";
     return nullptr;
   }
 
@@ -128,7 +128,7 @@ std::unique_ptr<MediaCodecBridge> MediaCodecBridge::CreateAudioMediaCodecBridge(
           mime, /* bitrate = */ 0);
 
   if (decoder_name.empty()) {
-    SB_LOG(ERROR) << "Failed to find decoder for " << audio_stream_info.codec
+    SB_LOG(ERROR) << "Failed to find decoder for " << audio_stream_info.codec()
                   << ".";
     return nullptr;
   }
@@ -136,11 +136,11 @@ std::unique_ptr<MediaCodecBridge> MediaCodecBridge::CreateAudioMediaCodecBridge(
   JNIEnv* env = AttachCurrentThread();
 
   ScopedJavaLocalRef<jbyteArray> configuration_data;
-  if (audio_stream_info.codec == kSbMediaAudioCodecOpus &&
-      !audio_stream_info.audio_specific_config.empty()) {
+  if (audio_stream_info.codec() == kSbMediaAudioCodecOpus &&
+      !audio_stream_info.audio_specific_config().empty()) {
     configuration_data.Reset(
-        ToJavaByteArray(env, audio_stream_info.audio_specific_config.data(),
-                        audio_stream_info.audio_specific_config.size()));
+        ToJavaByteArray(env, audio_stream_info.audio_specific_config().data(),
+                        audio_stream_info.audio_specific_config().size()));
   }
 
   std::unique_ptr<MediaCodecBridge> native_media_codec_bridge(
@@ -154,13 +154,13 @@ std::unique_ptr<MediaCodecBridge> MediaCodecBridge::CreateAudioMediaCodecBridge(
   ScopedJavaLocalRef<jobject> j_media_codec_bridge =
       Java_MediaCodecBridgeBuilder_createAudioDecoder(
           env, reinterpret_cast<jlong>(native_media_codec_bridge.get()), j_mime,
-          j_decoder_name, audio_stream_info.samples_per_second,
-          audio_stream_info.number_of_channels, j_media_crypto_local,
+          j_decoder_name, audio_stream_info.samples_per_second(),
+          audio_stream_info.number_of_channels(), j_media_crypto_local,
           configuration_data);
 
   if (!j_media_codec_bridge) {
     SB_LOG(ERROR) << "Failed to create codec bridge for "
-                  << audio_stream_info.codec << ".";
+                  << audio_stream_info.codec() << ".";
     return nullptr;
   }
 

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -178,9 +178,9 @@ MediaCodecDecoder::MediaCodecDecoder(PassKey<MediaCodecDecoder>,
   // the call to MediaCodecBridge::CreateAudioMediaCodecBridge() above.
   // TODO: Determine if we should send the audio specific configuration here
   // only when |audio_codec| == kSbMediaAudioCodecAac.
-  if (audio_stream_info.codec != kSbMediaAudioCodecOpus &&
-      !audio_stream_info.audio_specific_config.empty()) {
-    pending_inputs_.emplace_back(audio_stream_info.audio_specific_config);
+  if (audio_stream_info.codec() != kSbMediaAudioCodecOpus &&
+      !audio_stream_info.audio_specific_config().empty()) {
+    pending_inputs_.emplace_back(audio_stream_info.audio_specific_config());
     ++number_of_pending_inputs_;
   }
 }

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -268,7 +268,7 @@ MediaCodecVideoDecoder::Create(
   // For AV1, |media_decoder_| is null after creation because its initialization
   // is deferred. For all other codecs, a null |media_decoder_| indicates a
   // failure.
-  if (video_stream_info.codec != kSbMediaVideoCodecAv1 &&
+  if (video_stream_info.codec() != kSbMediaVideoCodecAv1 &&
       !video_decoder->media_decoder_) {
     return Failure(
         "Video decoder was not created, but no error message was provided.");
@@ -297,7 +297,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
     const ExperimentalFeatures& experimental_features,
     std::string* error_message)
     : JobOwner(job_queue),
-      video_codec_(video_stream_info.codec),
+      video_codec_(video_stream_info.codec()),
       drm_system_(static_cast<DrmSystem*>(drm_system)),
       output_mode_(output_mode),
       decode_target_graphics_context_provider_(
@@ -480,7 +480,7 @@ void MediaCodecVideoDecoder::WriteInputBuffers(
     // If color metadata is present and is not an identity mapping, then
     // teardown the codec so it can be reinitalized with the new metadata.
     const auto& color_metadata =
-        input_buffers.front()->video_stream_info().color_metadata;
+        input_buffers.front()->video_stream_info().color_metadata();
     if (!IsIdentity(color_metadata)) {
       SB_DCHECK(!color_metadata_) << "Unexpected residual color metadata.";
       SB_LOG(INFO) << "Reinitializing codec with HDR color metadata.";
@@ -796,12 +796,12 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
   // TODO(b/281431214): Evaluate if we should also parse the fps from
   //                    `max_video_capabilities_` and pass to MediaCodecDecoder
   //                    ctor.
-  std::optional<Size> max_frame_size =
-      ParseMaxResolution(max_video_capabilities_, video_stream_info.frame_size);
+  std::optional<Size> max_frame_size = ParseMaxResolution(
+      max_video_capabilities_, video_stream_info.frame_size());
 
   auto result = MediaCodecDecoder::CreateForVideo(
-      job_queue(), /*host=*/this, video_stream_info.codec,
-      video_stream_info.frame_size, max_frame_size, video_fps_,
+      job_queue(), /*host=*/this, video_stream_info.codec(),
+      video_stream_info.frame_size(), max_frame_size, video_fps_,
       j_output_surface, drm_system_,
       color_metadata_ ? &*color_metadata_ : nullptr, require_software_codec_,
       std::bind(&MediaCodecVideoDecoder::OnFrameRendered, this, _1),

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -143,8 +143,8 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
             : kSbMediaAudioSampleTypeInt16Deprecated;
 
     int min_frames_required = SbAudioSinkGetMinBufferSizeInFrames(
-        audio_stream_info.number_of_channels, sample_type,
-        audio_stream_info.samples_per_second);
+        audio_stream_info.number_of_channels(), sample_type,
+        audio_stream_info.samples_per_second());
 
     if (is_tunnel_mode_enabled_) {
       // AudioTrack.setPlaybackParams() might need extra buffer to support
@@ -154,8 +154,8 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
       min_frames_required = std::max<int>(
           min_frames_required,
           AudioOutputManager::GetInstance()->GetMinBufferSizeInFrames(
-              env, sample_type, audio_stream_info.number_of_channels,
-              audio_stream_info.samples_per_second) *
+              env, sample_type, audio_stream_info.number_of_channels(),
+              audio_stream_info.samples_per_second()) *
               kMaxPlaybackSpeed);
     }
 
@@ -503,11 +503,11 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
           [enable_flush_during_seek, force_platform_opus_decoder, job_queue](
               const AudioStreamInfo& audio_stream_info,
               SbDrmSystem drm_system) -> std::unique_ptr<AudioDecoder> {
-        if (UseLibopusDecoder(audio_stream_info.codec, drm_system,
+        if (UseLibopusDecoder(audio_stream_info.codec(), drm_system,
                               force_platform_opus_decoder)) {
           return OpusAudioDecoder::Create(job_queue, audio_stream_info);
-        } else if (audio_stream_info.codec == kSbMediaAudioCodecAac ||
-                   audio_stream_info.codec == kSbMediaAudioCodecOpus) {
+        } else if (audio_stream_info.codec() == kSbMediaAudioCodecAac ||
+                   audio_stream_info.codec() == kSbMediaAudioCodecOpus) {
           auto audio_decoder_impl = MediaCodecAudioDecoder::Create(
               job_queue, audio_stream_info, drm_system,
               enable_flush_during_seek);
@@ -516,7 +516,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
           }
         } else {
           SB_LOG(ERROR) << "Unsupported audio codec "
-                        << audio_stream_info.codec;
+                        << audio_stream_info.codec();
         }
         return nullptr;
       };
@@ -717,7 +717,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     JNIEnv* env = AttachCurrentThread();
     std::optional<int> tunnel_mode_audio_session_id =
         AudioOutputManager::GetInstance()->GenerateTunnelModeAudioSessionId(
-            env, creation_parameters.audio_stream_info().number_of_channels);
+            env, creation_parameters.audio_stream_info().number_of_channels());
 
     // AudioManager.generateAudioSessionId() return ERROR (-1) to indicate a
     // failure, please see the following url for more details:

--- a/starboard/linux/shared/player_components_factory.cc
+++ b/starboard/linux/shared/player_components_factory.cc
@@ -57,10 +57,10 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       auto decoder_creator =
           [job_queue](const AudioStreamInfo& audio_stream_info,
                       SbDrmSystem drm_system) -> std::unique_ptr<AudioDecoder> {
-        if (audio_stream_info.codec == kSbMediaAudioCodecOpus) {
+        if (audio_stream_info.codec() == kSbMediaAudioCodecOpus) {
           return OpusAudioDecoder::Create(job_queue, audio_stream_info);
-        } else if (audio_stream_info.codec == kSbMediaAudioCodecAac &&
-                   audio_stream_info.number_of_channels <=
+        } else if (audio_stream_info.codec() == kSbMediaAudioCodecAac &&
+                   audio_stream_info.number_of_channels() <=
                        FdkAacAudioDecoder::kMaxChannels &&
                    LibfdkaacHandle::GetHandle()->IsLoaded()) {
           SB_LOG(INFO) << "Playing audio using FdkAacAudioDecoder.";
@@ -72,7 +72,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
             SB_LOG(INFO) << "Playing audio using FfmpegAudioDecoder";
           } else {
             SB_LOG(ERROR) << "Failed to create audio decoder for codec "
-                          << GetMediaAudioCodecName(audio_stream_info.codec);
+                          << GetMediaAudioCodecName(audio_stream_info.codec());
           }
           return ffmpeg_audio_decoder;
         }

--- a/starboard/nplb/player_create_test.cc
+++ b/starboard/nplb/player_create_test.cc
@@ -422,7 +422,7 @@ TEST_F(SbPlayerTest, MultiPlayer) {
                        << " and "
                        << starboard::GetMediaVideoCodecName(kVideoCodecs[l]);
 
-          audio_stream_info.codec = kAudioCodecs[k];
+          audio_stream_info = CreateAudioStreamInfo(kAudioCodecs[k]);
           created_players.push_back(CallSbPlayerCreate(
               fake_graphics_context_provider_.window(), kVideoCodecs[l],
               kAudioCodecs[k], kSbDrmSystemInvalid, &audio_stream_info,

--- a/starboard/nplb/player_creation_param_helpers.cc
+++ b/starboard/nplb/player_creation_param_helpers.cc
@@ -24,96 +24,87 @@ using ::starboard::VideoDmpReader;
 }  // namespace
 
 starboard::AudioStreamInfo CreateAudioStreamInfo(SbMediaAudioCodec codec) {
-  starboard::AudioStreamInfo audio_stream_info = {};
-
-  audio_stream_info.codec = codec;
-  audio_stream_info.mime = "";
+  SbMediaAudioStreamInfo sb_info = {};
+  sb_info.codec = codec;
+  sb_info.mime = "";
 
   switch (codec) {
     case kSbMediaAudioCodecNone:
       break;
     case kSbMediaAudioCodecAac: {
       static const uint8_t kAacAudioSpecificConfig[16] = {18, 16};
-
-      audio_stream_info.number_of_channels = 2;
-      audio_stream_info.samples_per_second = 44100;
-      audio_stream_info.bits_per_sample = 16;
-      audio_stream_info.audio_specific_config.assign(
-          kAacAudioSpecificConfig,
-          kAacAudioSpecificConfig + sizeof(kAacAudioSpecificConfig));
+      sb_info.number_of_channels = 2;
+      sb_info.samples_per_second = 44100;
+      sb_info.bits_per_sample = 16;
+      sb_info.audio_specific_config = kAacAudioSpecificConfig;
+      sb_info.audio_specific_config_size = sizeof(kAacAudioSpecificConfig);
       break;
     }
     case kSbMediaAudioCodecAc3:
     case kSbMediaAudioCodecEac3: {
-      audio_stream_info.number_of_channels = 6;
-      audio_stream_info.samples_per_second = 48000;
-      audio_stream_info.bits_per_sample = 16;
+      sb_info.number_of_channels = 6;
+      sb_info.samples_per_second = 48000;
+      sb_info.bits_per_sample = 16;
       break;
     }
     case kSbMediaAudioCodecOpus: {
       static const uint8_t kOpusAudioSpecificConfig[19] = {
           79, 112, 117, 115, 72, 101, 97, 100, 1, 2, 56, 1, 128, 187};
-
-      audio_stream_info.number_of_channels = 2;
-      audio_stream_info.samples_per_second = 48000;
-      audio_stream_info.bits_per_sample = 32;
-      audio_stream_info.audio_specific_config.assign(
-          kOpusAudioSpecificConfig,
-          kOpusAudioSpecificConfig + sizeof(kOpusAudioSpecificConfig));
+      sb_info.number_of_channels = 2;
+      sb_info.samples_per_second = 48000;
+      sb_info.bits_per_sample = 32;
+      sb_info.audio_specific_config = kOpusAudioSpecificConfig;
+      sb_info.audio_specific_config_size = sizeof(kOpusAudioSpecificConfig);
       break;
     }
     case kSbMediaAudioCodecVorbis: {
-      // Note that unlike the configuration of the other formats, the following
-      // configuration is made up, instead of taking from a real input.
-      audio_stream_info.number_of_channels = 2;
-      audio_stream_info.samples_per_second = 48000;
-      audio_stream_info.bits_per_sample = 16;
+      sb_info.number_of_channels = 2;
+      sb_info.samples_per_second = 48000;
+      sb_info.bits_per_sample = 16;
       break;
     }
     case kSbMediaAudioCodecMp3: {
-      audio_stream_info.number_of_channels = 2;
-      audio_stream_info.samples_per_second = 44100;
-      audio_stream_info.bits_per_sample = 16;
+      sb_info.number_of_channels = 2;
+      sb_info.samples_per_second = 44100;
+      sb_info.bits_per_sample = 16;
       break;
     }
     case kSbMediaAudioCodecFlac: {
-      audio_stream_info.number_of_channels = 2;
-      audio_stream_info.samples_per_second = 44100;
-      audio_stream_info.bits_per_sample = 16;
+      sb_info.number_of_channels = 2;
+      sb_info.samples_per_second = 44100;
+      sb_info.bits_per_sample = 16;
       break;
     }
     case kSbMediaAudioCodecPcm: {
-      audio_stream_info.number_of_channels = 2;
-      audio_stream_info.samples_per_second = 44100;
-      audio_stream_info.bits_per_sample = 32;
+      sb_info.number_of_channels = 2;
+      sb_info.samples_per_second = 44100;
+      sb_info.bits_per_sample = 32;
       break;
     }
     case kSbMediaAudioCodecIamf: {
-      audio_stream_info.number_of_channels = 2;
-      audio_stream_info.samples_per_second = 48000;
-      audio_stream_info.bits_per_sample = 32;
+      sb_info.number_of_channels = 2;
+      sb_info.samples_per_second = 48000;
+      sb_info.bits_per_sample = 32;
       break;
     }
   }
-  return audio_stream_info;
+  return starboard::AudioStreamInfo(sb_info);
 }
 
 starboard::VideoStreamInfo CreateVideoStreamInfo(SbMediaVideoCodec codec) {
-  starboard::VideoStreamInfo video_stream_info;
+  SbMediaVideoStreamInfo sb_info = {};
+  sb_info.codec = codec;
+  sb_info.mime = "";
+  sb_info.max_video_capabilities = "";
+  sb_info.frame_width = 1920;
+  sb_info.frame_height = 1080;
+  sb_info.color_metadata.bits_per_channel = 8;
+  sb_info.color_metadata.primaries = kSbMediaPrimaryIdBt709;
+  sb_info.color_metadata.transfer = kSbMediaTransferIdBt709;
+  sb_info.color_metadata.matrix = kSbMediaMatrixIdBt709;
+  sb_info.color_metadata.range = kSbMediaRangeIdLimited;
 
-  video_stream_info.codec = codec;
-
-  video_stream_info.mime = "";
-  video_stream_info.max_video_capabilities = "";
-  video_stream_info.color_metadata.bits_per_channel = 8;
-  video_stream_info.color_metadata.primaries = kSbMediaPrimaryIdBt709;
-  video_stream_info.color_metadata.transfer = kSbMediaTransferIdBt709;
-  video_stream_info.color_metadata.matrix = kSbMediaMatrixIdBt709;
-  video_stream_info.color_metadata.range = kSbMediaRangeIdLimited;
-
-  video_stream_info.frame_size = {1920, 1080};
-
-  return video_stream_info;
+  return starboard::VideoStreamInfo(sb_info);
 }
 
 PlayerCreationParam CreatePlayerCreationParam(SbMediaAudioCodec audio_codec,
@@ -137,9 +128,10 @@ PlayerCreationParam CreatePlayerCreationParam(
   }
   if (config.video_filename) {
     VideoDmpReader dmp_reader(config.video_filename);
-    creation_param.video_stream_info = dmp_reader.video_stream_info();
-    creation_param.video_stream_info.max_video_capabilities =
-        config.max_video_capabilities;
+    SbMediaVideoStreamInfo sb_info = {};
+    dmp_reader.video_stream_info().ConvertTo(&sb_info);
+    sb_info.max_video_capabilities = config.max_video_capabilities;
+    creation_param.video_stream_info = starboard::VideoStreamInfo(sb_info);
   }
   creation_param.output_mode = config.output_mode;
   return creation_param;

--- a/starboard/nplb/player_test_util.cc
+++ b/starboard/nplb/player_test_util.cc
@@ -235,7 +235,7 @@ SbPlayer CallSbPlayerCreate(
     SbPlayerOutputMode output_mode,
     SbDecodeTargetGraphicsContextProvider* context_provider) {
   if (audio_stream_info) {
-    SB_CHECK_EQ(audio_stream_info->codec, audio_codec);
+    SB_CHECK_EQ(audio_stream_info->codec(), audio_codec);
   } else {
     SB_CHECK_EQ(audio_codec, kSbMediaAudioCodecNone);
   }
@@ -247,8 +247,11 @@ SbPlayer CallSbPlayerCreate(
     creation_param.audio_stream_info = *audio_stream_info;
   }
   creation_param.drm_system = drm_system;
-  creation_param.video_stream_info.max_video_capabilities =
-      max_video_capabilities;
+
+  SbMediaVideoStreamInfo sb_video_info = {};
+  creation_param.video_stream_info.ConvertTo(&sb_video_info);
+  sb_video_info.max_video_capabilities = max_video_capabilities;
+  creation_param.video_stream_info = starboard::VideoStreamInfo(sb_video_info);
 
   SbPlayerCreationParam param = {};
   creation_param.ConvertTo(&param);

--- a/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_audio_decoder_impl.cc
@@ -39,7 +39,7 @@ SbMediaAudioSampleType GetSupportedSampleType() {
 }
 
 AVCodecID GetFfmpegCodecIdByMediaCodec(const AudioStreamInfo& stream_info) {
-  SbMediaAudioCodec audio_codec = stream_info.codec;
+  SbMediaAudioCodec audio_codec = stream_info.codec();
 
   switch (audio_codec) {
     case kSbMediaAudioCodecAac:
@@ -55,20 +55,20 @@ AVCodecID GetFfmpegCodecIdByMediaCodec(const AudioStreamInfo& stream_info) {
     case kSbMediaAudioCodecMp3:
       return AV_CODEC_ID_MP3;
     case kSbMediaAudioCodecPcm:
-      if (stream_info.bits_per_sample == 16) {
+      if (stream_info.bits_per_sample() == 16) {
         return AV_CODEC_ID_PCM_S16LE;
       } else {
         SB_LOG(ERROR) << "PCM is only supported for 16-bit audio ("
-                      << stream_info.bits_per_sample
+                      << stream_info.bits_per_sample()
                       << " bits per sample was requested)";
         return AV_CODEC_ID_NONE;
       }
     case kSbMediaAudioCodecFlac:
-      if (stream_info.bits_per_sample == 16) {
+      if (stream_info.bits_per_sample() == 16) {
         return AV_CODEC_ID_FLAC;
       } else {
         SB_LOG(ERROR) << "FLAC is only supported for 16-bit audio ("
-                      << stream_info.bits_per_sample
+                      << stream_info.bits_per_sample()
                       << " bits per sample was requested)";
         return AV_CODEC_ID_NONE;
       }
@@ -95,7 +95,7 @@ FfmpegAudioDecoderImpl<FFMPEG>::FfmpegAudioDecoderImpl(
   SB_DCHECK(g_registered) << "Decoder Specialization registration failed.";
   SB_DCHECK_NE(GetFfmpegCodecIdByMediaCodec(audio_stream_info_),
                AV_CODEC_ID_NONE)
-      << "Unsupported audio codec " << audio_stream_info_.codec;
+      << "Unsupported audio codec " << audio_stream_info_.codec();
   SB_CHECK(ffmpeg_);
 }
 
@@ -229,7 +229,7 @@ void FfmpegAudioDecoderImpl<FFMPEG>::ProcessDecodedFrame(
 #endif
   int decoded_audio_size = ffmpeg_->av_samples_get_buffer_size(
       NULL, channel_count, av_frame.nb_samples, codec_context_->sample_fmt, 1);
-  audio_stream_info_.samples_per_second = codec_context_->sample_rate;
+  audio_stream_info_.set_samples_per_second(codec_context_->sample_rate);
 
   if (decoded_audio_size <= 0) {
     // TODO: Consider fill it with silence.
@@ -256,9 +256,9 @@ void FfmpegAudioDecoderImpl<FFMPEG>::ProcessDecodedFrame(
         GetSampleType(), kSbMediaAudioFrameStorageTypeInterleaved);
   }
   decoded_audio->AdjustForDiscardedDurations(
-      audio_stream_info_.samples_per_second,
-      input_buffer.audio_sample_info().discarded_duration_from_front,
-      input_buffer.audio_sample_info().discarded_duration_from_back);
+      audio_stream_info_.samples_per_second(),
+      input_buffer.audio_sample_info().discarded_duration_from_front(),
+      input_buffer.audio_sample_info().discarded_duration_from_back());
   decoded_audios_.push(decoded_audio);
   Schedule(output_cb_);
 }
@@ -287,7 +287,7 @@ scoped_refptr<DecodedAudio> FfmpegAudioDecoderImpl<FFMPEG>::Read(
     result = decoded_audios_.front();
     decoded_audios_.pop();
   }
-  *samples_per_second = audio_stream_info_.samples_per_second;
+  *samples_per_second = audio_stream_info_.samples_per_second();
   return result;
 }
 
@@ -355,34 +355,35 @@ bool FfmpegAudioDecoderImpl<FFMPEG>::InitializeCodec() {
       // If we request FLT for 16-bit FLAC, FFmpeg will pick S32 as the closest
       // option. Since the rest of this pipeline doesn't support S32, we should
       // use S16 as the desired format.
-      || audio_stream_info_.codec == kSbMediaAudioCodecFlac) {
+      || audio_stream_info_.codec() == kSbMediaAudioCodecFlac) {
     codec_context_->request_sample_fmt = AV_SAMPLE_FMT_S16;
   } else {
     codec_context_->request_sample_fmt = AV_SAMPLE_FMT_FLT;
   }
 
 #if LIBAVCODEC_VERSION_MAJOR >= 61
-  codec_context_->ch_layout.nb_channels = audio_stream_info_.number_of_channels;
+  codec_context_->ch_layout.nb_channels =
+      audio_stream_info_.number_of_channels();
 #else
-  codec_context_->channels = audio_stream_info_.number_of_channels;
+  codec_context_->channels = audio_stream_info_.number_of_channels();
 #endif
-  codec_context_->sample_rate = audio_stream_info_.samples_per_second;
+  codec_context_->sample_rate = audio_stream_info_.samples_per_second();
   codec_context_->extradata = NULL;
   codec_context_->extradata_size = 0;
 
   if ((codec_context_->codec_id == AV_CODEC_ID_OPUS ||
        codec_context_->codec_id == AV_CODEC_ID_VORBIS) &&
-      !audio_stream_info_.audio_specific_config.empty()) {
+      !audio_stream_info_.audio_specific_config().empty()) {
     // AV_INPUT_BUFFER_PADDING_SIZE is not defined in ancient avcodec.h.  Use a
     // large enough padding here explicitly.
     const int kAvInputBufferPaddingSize = 256;
     codec_context_->extradata_size =
-        audio_stream_info_.audio_specific_config.size();
+        audio_stream_info_.audio_specific_config().size();
     codec_context_->extradata = static_cast<uint8_t*>(ffmpeg_->av_malloc(
         codec_context_->extradata_size + kAvInputBufferPaddingSize));
     SB_DCHECK(codec_context_->extradata);
     memcpy(codec_context_->extradata,
-           audio_stream_info_.audio_specific_config.data(),
+           audio_stream_info_.audio_specific_config().data(),
            codec_context_->extradata_size);
     memset(codec_context_->extradata + codec_context_->extradata_size, 0,
            kAvInputBufferPaddingSize);

--- a/starboard/shared/opus/opus_audio_decoder.cc
+++ b/starboard/shared/opus/opus_audio_decoder.cc
@@ -145,7 +145,7 @@ scoped_refptr<DecodedAudio> OpusAudioDecoder::Read(int* samples_per_second) {
     result = decoded_audios_.front();
     decoded_audios_.pop();
   }
-  *samples_per_second = audio_stream_info_.samples_per_second;
+  *samples_per_second = audio_stream_info_.samples_per_second();
   return result;
 }
 
@@ -178,14 +178,14 @@ void OpusAudioDecoder::Reset() {
 OpusMSDecoder* OpusAudioDecoder::CreateOpusMultistreamDecoder(
     const AudioStreamInfo& audio_stream_info) {
   int error;
-  int channels = audio_stream_info.number_of_channels;
+  int channels = audio_stream_info.number_of_channels();
   if (channels > 8 || channels < 1) {
     SB_LOG(ERROR) << "Can't create decoder with " << channels << " channels";
     return nullptr;
   }
 
   OpusMSDecoder* decoder = opus_multistream_decoder_create(
-      audio_stream_info.samples_per_second, channels,
+      audio_stream_info.samples_per_second(), channels,
       vorbis_mappings[channels - 1].nb_streams,
       vorbis_mappings[channels - 1].nb_coupled_streams,
       vorbis_mappings[channels - 1].mapping, &error);
@@ -239,9 +239,9 @@ bool OpusAudioDecoder::DecodeInternal(
   SB_DCHECK(!stream_ended_ || !pending_audio_buffers_.empty());
 
   scoped_refptr<DecodedAudio> decoded_audio = new DecodedAudio(
-      audio_stream_info_.number_of_channels, GetSampleType(),
+      audio_stream_info_.number_of_channels(), GetSampleType(),
       kSbMediaAudioFrameStorageTypeInterleaved, input_buffer->timestamp(),
-      audio_stream_info_.number_of_channels * frames_per_au_ *
+      audio_stream_info_.number_of_channels() * frames_per_au_ *
           GetBytesPerSample(GetSampleType()));
 
   const char kDecodeFunctionName[] = "opus_multistream_decode_float";
@@ -271,13 +271,13 @@ bool OpusAudioDecoder::DecodeInternal(
   }
 
   frames_per_au_ = decoded_frames;
-  decoded_audio->ShrinkTo(audio_stream_info_.number_of_channels *
+  decoded_audio->ShrinkTo(audio_stream_info_.number_of_channels() *
                           frames_per_au_ * GetBytesPerSample(GetSampleType()));
   const auto& sample_info = input_buffer->audio_sample_info();
   decoded_audio->AdjustForDiscardedDurations(
-      audio_stream_info_.samples_per_second,
-      sample_info.discarded_duration_from_front,
-      sample_info.discarded_duration_from_back);
+      audio_stream_info_.samples_per_second(),
+      sample_info.discarded_duration_from_front(),
+      sample_info.discarded_duration_from_back());
   decoded_audios_.push(decoded_audio);
   output_cb_();
   return true;

--- a/starboard/shared/starboard/media/codec_util.cc
+++ b/starboard/shared/starboard/media/codec_util.cc
@@ -52,7 +52,7 @@ std::optional<VideoConfig> VideoConfig::Create(
     const VideoStreamInfo& video_stream_info,
     const uint8_t* data,
     size_t data_size) {
-  return Create(video_stream_info.codec, video_stream_info.frame_size, data,
+  return Create(video_stream_info.codec(), video_stream_info.frame_size(), data,
                 data_size);
 }
 

--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -27,109 +27,66 @@
 
 namespace starboard {
 
-namespace {
-
-void Assign(const SbMediaAudioStreamInfo& source, AudioStreamInfo* dest) {
-  SB_DCHECK(dest);
-
-  if (source.audio_specific_config_size > 0) {
-    SB_DCHECK(source.audio_specific_config);
-  }
-
-  dest->codec = source.codec;
-
-  if (dest->codec == kSbMediaAudioCodecNone) {
-    dest->mime.clear();
-    dest->audio_specific_config.clear();
-    return;
-  }
-
-  SB_DCHECK(source.mime);
-
-  dest->mime = source.mime;
-  dest->number_of_channels = source.number_of_channels;
-  dest->samples_per_second = source.samples_per_second;
-  dest->bits_per_sample = source.bits_per_sample;
-
-  auto config = static_cast<const uint8_t*>(source.audio_specific_config);
-  dest->audio_specific_config.assign(
-      config, config + source.audio_specific_config_size);
-}
-
-void Assign(const SbMediaVideoStreamInfo& source, VideoStreamInfo* dest) {
-  SB_DCHECK(dest);
-
-  dest->codec = source.codec;
-
-  if (dest->codec == kSbMediaVideoCodecNone) {
-    dest->mime.clear();
-    dest->max_video_capabilities.clear();
-    return;
-  }
-
-  SB_DCHECK(source.mime);
-  SB_DCHECK(source.max_video_capabilities);
-
-  dest->mime = source.mime;
-  dest->max_video_capabilities = source.max_video_capabilities;
-  dest->frame_size = {source.frame_width, source.frame_height};
-  dest->color_metadata = source.color_metadata;
-}
-
-void Assign(const AudioStreamInfo& source, SbMediaAudioStreamInfo* dest) {
-  SB_DCHECK(dest);
-
-  *dest = {};
-
-  dest->codec = source.codec;
-  dest->mime = source.mime.c_str();
-  dest->number_of_channels = source.number_of_channels;
-  dest->samples_per_second = source.samples_per_second;
-  dest->bits_per_sample = source.bits_per_sample;
-  if (!source.audio_specific_config.empty()) {
-    dest->audio_specific_config = source.audio_specific_config.data();
-    dest->audio_specific_config_size =
-        static_cast<uint16_t>(source.audio_specific_config.size());
-  }
-}
-
-void Assign(const VideoStreamInfo& source, SbMediaVideoStreamInfo* dest) {
-  SB_DCHECK(dest);
-
-  *dest = {};
-
-  dest->codec = source.codec;
-  dest->mime = source.mime.c_str();
-  dest->max_video_capabilities = source.max_video_capabilities.c_str();
-  dest->frame_width = source.frame_size.width;
-  dest->frame_height = source.frame_size.height;
-  dest->color_metadata = source.color_metadata;
-}
-
-}  // namespace
-
 AudioStreamInfo& AudioStreamInfo::operator=(
     const SbMediaAudioStreamInfo& that) {
-  Assign(that, this);
+  if (that.audio_specific_config_size > 0) {
+    SB_DCHECK(that.audio_specific_config);
+  }
+
+  codec_ = that.codec;
+
+  if (codec_ == kSbMediaAudioCodecNone) {
+    mime_.clear();
+    audio_specific_config_.clear();
+    return *this;
+  }
+
+  SB_DCHECK(that.mime);
+
+  mime_ = that.mime;
+  number_of_channels_ = that.number_of_channels;
+  samples_per_second_ = that.samples_per_second;
+  bits_per_sample_ = that.bits_per_sample;
+
+  if (that.audio_specific_config_size > 0) {
+    auto config = static_cast<const uint8_t*>(that.audio_specific_config);
+    audio_specific_config_.assign(config,
+                                  config + that.audio_specific_config_size);
+  } else {
+    audio_specific_config_.clear();
+  }
   return *this;
 }
 
 void AudioStreamInfo::ConvertTo(
     SbMediaAudioStreamInfo* audio_stream_info) const {
-  Assign(*this, audio_stream_info);
+  SB_DCHECK(audio_stream_info);
+
+  *audio_stream_info = {};
+
+  audio_stream_info->codec = codec_;
+  audio_stream_info->mime = mime_.c_str();
+  audio_stream_info->number_of_channels = number_of_channels_;
+  audio_stream_info->samples_per_second = samples_per_second_;
+  audio_stream_info->bits_per_sample = bits_per_sample_;
+  if (!audio_specific_config_.empty()) {
+    audio_stream_info->audio_specific_config = audio_specific_config_.data();
+    audio_stream_info->audio_specific_config_size =
+        static_cast<uint16_t>(audio_specific_config_.size());
+  }
 }
 
 bool operator==(const AudioStreamInfo& left, const AudioStreamInfo& right) {
-  if (left.codec == kSbMediaAudioCodecNone &&
-      right.codec == kSbMediaAudioCodecNone) {
+  if (left.codec() == kSbMediaAudioCodecNone &&
+      right.codec() == kSbMediaAudioCodecNone) {
     return true;
   }
 
-  return left.codec == right.codec && left.mime == right.mime &&
-         left.number_of_channels == right.number_of_channels &&
-         left.samples_per_second == right.samples_per_second &&
-         left.bits_per_sample == right.bits_per_sample &&
-         left.audio_specific_config == right.audio_specific_config;
+  return left.codec() == right.codec() && left.mime() == right.mime() &&
+         left.number_of_channels() == right.number_of_channels() &&
+         left.samples_per_second() == right.samples_per_second() &&
+         left.bits_per_sample() == right.bits_per_sample() &&
+         left.audio_specific_config() == right.audio_specific_config();
 }
 
 bool operator!=(const AudioStreamInfo& left, const AudioStreamInfo& right) {
@@ -137,19 +94,19 @@ bool operator!=(const AudioStreamInfo& left, const AudioStreamInfo& right) {
 }
 
 std::ostream& operator<<(std::ostream& os, const AudioStreamInfo& info) {
-  return os << "{codec=" << GetMediaAudioCodecName(info.codec)
-            << ", mime=" << (info.mime.empty() ? "(empty)" : info.mime)
-            << ", channels=" << info.number_of_channels
+  return os << "{codec=" << GetMediaAudioCodecName(info.codec())
+            << ", mime=" << (info.mime().empty() ? "(empty)" : info.mime())
+            << ", channels=" << info.number_of_channels()
             << ", samples_per_second="
-            << FormatWithDigitSeparators(info.samples_per_second)
-            << ", bits_per_sample=" << info.bits_per_sample << "}";
+            << FormatWithDigitSeparators(info.samples_per_second())
+            << ", bits_per_sample=" << info.bits_per_sample() << "}";
 }
 
 AudioSampleInfo& AudioSampleInfo::operator=(
     const SbMediaAudioSampleInfo& that) {
-  stream_info = that.stream_info;
-  discarded_duration_from_front = that.discarded_duration_from_front;
-  discarded_duration_from_back = that.discarded_duration_from_back;
+  stream_info_ = that.stream_info;
+  discarded_duration_from_front_ = that.discarded_duration_from_front;
+  discarded_duration_from_back_ = that.discarded_duration_from_back;
 
   return *this;
 }
@@ -159,34 +116,57 @@ void AudioSampleInfo::ConvertTo(
   SB_DCHECK(audio_sample_info);
 
   *audio_sample_info = {};
-  stream_info.ConvertTo(&audio_sample_info->stream_info);
+  stream_info_.ConvertTo(&audio_sample_info->stream_info);
   audio_sample_info->discarded_duration_from_front =
-      discarded_duration_from_front;
+      discarded_duration_from_front_;
   audio_sample_info->discarded_duration_from_back =
-      discarded_duration_from_back;
+      discarded_duration_from_back_;
 }
 
 VideoStreamInfo& VideoStreamInfo::operator=(
     const SbMediaVideoStreamInfo& that) {
-  Assign(that, this);
+  codec_ = that.codec;
+
+  if (codec_ == kSbMediaVideoCodecNone) {
+    mime_.clear();
+    max_video_capabilities_.clear();
+    return *this;
+  }
+
+  SB_DCHECK(that.mime);
+  SB_DCHECK(that.max_video_capabilities);
+
+  mime_ = that.mime;
+  max_video_capabilities_ = that.max_video_capabilities;
+  frame_size_ = {that.frame_width, that.frame_height};
+  color_metadata_ = that.color_metadata;
   return *this;
 }
 
 void VideoStreamInfo::ConvertTo(
     SbMediaVideoStreamInfo* video_stream_info) const {
-  Assign(*this, video_stream_info);
+  SB_DCHECK(video_stream_info);
+
+  *video_stream_info = {};
+
+  video_stream_info->codec = codec_;
+  video_stream_info->mime = mime_.c_str();
+  video_stream_info->max_video_capabilities = max_video_capabilities_.c_str();
+  video_stream_info->frame_width = frame_size_.width;
+  video_stream_info->frame_height = frame_size_.height;
+  video_stream_info->color_metadata = color_metadata_;
 }
 
 bool operator==(const VideoStreamInfo& left, const VideoStreamInfo& right) {
-  if (left.codec == kSbMediaVideoCodecNone &&
-      right.codec == kSbMediaVideoCodecNone) {
+  if (left.codec() == kSbMediaVideoCodecNone &&
+      right.codec() == kSbMediaVideoCodecNone) {
     return true;
   }
 
-  return left.codec == right.codec && left.mime == right.mime &&
-         left.max_video_capabilities == right.max_video_capabilities &&
-         left.frame_size == right.frame_size &&
-         left.color_metadata == right.color_metadata;
+  return left.codec() == right.codec() && left.mime() == right.mime() &&
+         left.max_video_capabilities() == right.max_video_capabilities() &&
+         left.frame_size() == right.frame_size() &&
+         left.color_metadata() == right.color_metadata();
 }
 
 bool operator!=(const VideoStreamInfo& left, const VideoStreamInfo& right) {
@@ -195,8 +175,8 @@ bool operator!=(const VideoStreamInfo& left, const VideoStreamInfo& right) {
 
 VideoSampleInfo& VideoSampleInfo::operator=(
     const SbMediaVideoSampleInfo& that) {
-  stream_info = that.stream_info;
-  is_key_frame = that.is_key_frame;
+  stream_info_ = that.stream_info;
+  is_key_frame_ = that.is_key_frame;
   return *this;
 }
 
@@ -205,28 +185,28 @@ void VideoSampleInfo::ConvertTo(
   SB_DCHECK(video_sample_info);
 
   *video_sample_info = {};
-  stream_info.ConvertTo(&video_sample_info->stream_info);
-  video_sample_info->is_key_frame = is_key_frame;
+  stream_info_.ConvertTo(&video_sample_info->stream_info);
+  video_sample_info->is_key_frame = is_key_frame_;
 }
 
 std::ostream& operator<<(std::ostream& os, const VideoSampleInfo& sample_info) {
-  const auto& stream_info = sample_info.stream_info;
+  const auto& stream_info = sample_info.stream_info();
 
-  if (stream_info.codec == kSbMediaVideoCodecNone) {
-    return os << "codec: " << GetMediaVideoCodecName(stream_info.codec);
+  if (stream_info.codec() == kSbMediaVideoCodecNone) {
+    return os << "codec: " << GetMediaVideoCodecName(stream_info.codec());
   }
 
-  os << "codec: " << GetMediaVideoCodecName(stream_info.codec) << ", ";
-  os << "mime: " << stream_info.mime
-     << ", max video capabilities: " << stream_info.max_video_capabilities
+  os << "codec: " << GetMediaVideoCodecName(stream_info.codec()) << ", ";
+  os << "mime: " << stream_info.mime()
+     << ", max video capabilities: " << stream_info.max_video_capabilities()
      << ", ";
 
-  if (sample_info.is_key_frame) {
+  if (sample_info.is_key_frame()) {
     os << "key frame, ";
   }
 
-  os << stream_info.frame_size << ' ';
-  os << '(' << stream_info.color_metadata << ')';
+  os << stream_info.frame_size() << ' ';
+  os << '(' << stream_info.color_metadata() << ')';
 
   return os;
 }
@@ -362,10 +342,10 @@ std::string GetMixedRepresentation(const uint8_t* data,
 
 bool IsAudioSampleInfoSubstantiallyDifferent(const AudioStreamInfo& left,
                                              const AudioStreamInfo& right) {
-  return left.codec != right.codec ||
-         left.samples_per_second != right.samples_per_second ||
-         left.number_of_channels != right.number_of_channels ||
-         left.audio_specific_config != right.audio_specific_config;
+  return left.codec() != right.codec() ||
+         left.samples_per_second() != right.samples_per_second() ||
+         left.number_of_channels() != right.number_of_channels() ||
+         left.audio_specific_config() != right.audio_specific_config();
 }
 
 int AudioDurationToFrames(int64_t duration, int samples_per_second) {

--- a/starboard/shared/starboard/media/media_util.h
+++ b/starboard/shared/starboard/media/media_util.h
@@ -30,22 +30,39 @@ namespace starboard {
 // doesn't maintain the same binary layout as `SbMediaAudioStreamInfo`, and is
 // intended to be used across the codebase as a C++ wrapper that owns the memory
 // of all its pointer members.
-struct AudioStreamInfo {
+//
+// Lifetime/Ownership: Objects of this class are value types, typically owned
+// by player or decoder components, and can be copied or moved.
+//
+// Threading Model: This class is not thread-safe and is intended to be used
+// on a single thread or protected by external synchronization.
+class AudioStreamInfo {
+ public:
   AudioStreamInfo() = default;
   explicit AudioStreamInfo(const SbMediaAudioStreamInfo& that) { *this = that; }
   AudioStreamInfo& operator=(const SbMediaAudioStreamInfo& that);
 
   void ConvertTo(SbMediaAudioStreamInfo* audio_stream_info) const;
 
-  // The member variables are the C++ mappings of the members of
-  // `SbMediaAudioStreamInfo` defined in `media.h`.  Please refer to the comment
-  // of `SbMediaAudioStreamInfo` for more details.
-  SbMediaAudioCodec codec = kSbMediaAudioCodecNone;
-  std::string mime;
-  uint16_t number_of_channels = 0;
-  uint32_t samples_per_second = 0;
-  uint16_t bits_per_sample = 0;
-  std::vector<uint8_t> audio_specific_config;
+  SbMediaAudioCodec codec() const { return codec_; }
+  const std::string& mime() const { return mime_; }
+  uint16_t number_of_channels() const { return number_of_channels_; }
+  uint32_t samples_per_second() const { return samples_per_second_; }
+  void set_samples_per_second(uint32_t samples_per_second) {
+    samples_per_second_ = samples_per_second;
+  }
+  uint16_t bits_per_sample() const { return bits_per_sample_; }
+  const std::vector<uint8_t>& audio_specific_config() const {
+    return audio_specific_config_;
+  }
+
+ private:
+  SbMediaAudioCodec codec_ = kSbMediaAudioCodecNone;
+  std::string mime_;
+  uint16_t number_of_channels_ = 0;
+  uint32_t samples_per_second_ = 0;
+  uint16_t bits_per_sample_ = 0;
+  std::vector<uint8_t> audio_specific_config_;
 };
 
 bool operator==(const AudioStreamInfo& left, const AudioStreamInfo& right);
@@ -57,40 +74,66 @@ std::ostream& operator<<(std::ostream& os, const AudioStreamInfo& info);
 // doesn't maintain the same binary layout as `SbMediaAudioSampleInfo`, and is
 // intended to be used across the codebase as a C++ wrapper that owns the memory
 // of all its pointer members.
-struct AudioSampleInfo {
+//
+// Lifetime/Ownership: Objects of this class are value types, typically owned
+// by player or decoder components, and can be copied or moved.
+//
+// Threading Model: This class is not thread-safe and is intended to be used
+// on a single thread or protected by external synchronization.
+class AudioSampleInfo {
+ public:
   AudioSampleInfo() = default;
   explicit AudioSampleInfo(const SbMediaAudioSampleInfo& that) { *this = that; }
   AudioSampleInfo& operator=(const SbMediaAudioSampleInfo& that);
 
   void ConvertTo(SbMediaAudioSampleInfo* audio_sample_info) const;
 
-  // The member variables are the C++ mappings of the members of
-  // `SbMediaAudioSampleInfo` defined in `media.h`.  Please refer to the comment
-  // of `SbMediaAudioSampleInfo` for more details.
-  AudioStreamInfo stream_info;
-  int64_t discarded_duration_from_front = 0;  // in microseconds.
-  int64_t discarded_duration_from_back = 0;   // in microseconds.
+  const AudioStreamInfo& stream_info() const { return stream_info_; }
+  int64_t discarded_duration_from_front() const {
+    return discarded_duration_from_front_;
+  }
+  int64_t discarded_duration_from_back() const {
+    return discarded_duration_from_back_;
+  }
+
+ private:
+  AudioStreamInfo stream_info_;
+  int64_t discarded_duration_from_front_ = 0;  // in microseconds.
+  int64_t discarded_duration_from_back_ = 0;   // in microseconds.
 };
 
 // Encapsulates all information contained in `SbMediaVideoStreamInfo`.  It
 // doesn't maintain the same binary layout as `SbMediaVideoStreamInfo`, and is
 // intended to be used across the codebase as a C++ wrapper that owns the memory
 // of all its pointer members.
-struct VideoStreamInfo {
+//
+// Lifetime/Ownership: Objects of this class are value types, typically owned
+// by player or decoder components, and can be copied or moved.
+//
+// Threading Model: This class is not thread-safe and is intended to be used
+// on a single thread or protected by external synchronization.
+class VideoStreamInfo {
+ public:
   VideoStreamInfo() = default;
   explicit VideoStreamInfo(const SbMediaVideoStreamInfo& that) { *this = that; }
   VideoStreamInfo& operator=(const SbMediaVideoStreamInfo& that);
 
   void ConvertTo(SbMediaVideoStreamInfo* video_stream_info) const;
 
-  // The member variables are the C++ mappings of the members of
-  // `SbMediaVideoStreamInfo` defined in `media.h`.  Please refer to the comment
-  // of `SbMediaVideoStreamInfo` for more details.
-  SbMediaVideoCodec codec = kSbMediaVideoCodecNone;
-  std::string mime;
-  std::string max_video_capabilities;
-  Size frame_size;
-  SbMediaColorMetadata color_metadata = {};
+  SbMediaVideoCodec codec() const { return codec_; }
+  const std::string& mime() const { return mime_; }
+  const std::string& max_video_capabilities() const {
+    return max_video_capabilities_;
+  }
+  Size frame_size() const { return frame_size_; }
+  const SbMediaColorMetadata& color_metadata() const { return color_metadata_; }
+
+ private:
+  SbMediaVideoCodec codec_ = kSbMediaVideoCodecNone;
+  std::string mime_;
+  std::string max_video_capabilities_;
+  Size frame_size_;
+  SbMediaColorMetadata color_metadata_ = {};
 };
 
 bool operator==(const VideoStreamInfo& left, const VideoStreamInfo& right);
@@ -100,18 +143,26 @@ bool operator!=(const VideoStreamInfo& left, const VideoStreamInfo& right);
 // doesn't maintain the same binary layout as `SbMediaVideoSampleInfo`, and is
 // intended to be used across the codebase as a C++ wrapper that owns the memory
 // of all its pointer members.
-struct VideoSampleInfo {
+//
+// Lifetime/Ownership: Objects of this class are value types, typically owned
+// by player or decoder components, and can be copied or moved.
+//
+// Threading Model: This class is not thread-safe and is intended to be used
+// on a single thread or protected by external synchronization.
+class VideoSampleInfo {
+ public:
   VideoSampleInfo() = default;
   explicit VideoSampleInfo(const SbMediaVideoSampleInfo& that) { *this = that; }
   VideoSampleInfo& operator=(const SbMediaVideoSampleInfo& that);
 
   void ConvertTo(SbMediaVideoSampleInfo* video_sample_info) const;
 
-  // The member variables are the C++ mappings of the members of
-  // `SbMediaVideoSampleInfo` defined in `media.h`.  Please refer to the comment
-  // of `SbMediaVideoSampleInfo` for more details.
-  VideoStreamInfo stream_info;
-  bool is_key_frame = false;
+  const VideoStreamInfo& stream_info() const { return stream_info_; }
+  bool is_key_frame() const { return is_key_frame_; }
+
+ private:
+  VideoStreamInfo stream_info_;
+  bool is_key_frame_ = false;
 };
 
 std::ostream& operator<<(std::ostream& os, const VideoSampleInfo& stream_info);

--- a/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
+++ b/starboard/shared/starboard/player/filter/adaptive_audio_decoder_internal.cc
@@ -39,12 +39,12 @@ AdaptiveAudioDecoder::AdaptiveAudioDecoder(
     const AudioDecoderCreator& audio_decoder_creator,
     const OutputFormatAdjustmentCallback& output_adjustment_callback)
     : JobOwner(job_queue),
-      initial_samples_per_second_(audio_stream_info.samples_per_second),
+      initial_samples_per_second_(audio_stream_info.samples_per_second()),
       drm_system_(drm_system),
       audio_decoder_creator_(audio_decoder_creator),
       output_adjustment_callback_(output_adjustment_callback),
-      output_number_of_channels_(audio_stream_info.number_of_channels) {
-  SB_DCHECK_NE(audio_stream_info.codec, kSbMediaAudioCodecNone);
+      output_number_of_channels_(audio_stream_info.number_of_channels()) {
+  SB_DCHECK_NE(audio_stream_info.codec(), kSbMediaAudioCodecNone);
 }
 
 AdaptiveAudioDecoder::AdaptiveAudioDecoder(
@@ -268,7 +268,7 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
     return;
   }
 
-  SB_DCHECK_EQ(input_audio_stream_info_.number_of_channels,
+  SB_DCHECK_EQ(input_audio_stream_info_.number_of_channels(),
                decoded_audio->channels());
   if (!output_format_checked_) {
     SB_DCHECK(!resampler_);
@@ -281,9 +281,9 @@ void AdaptiveAudioDecoder::OnDecoderOutput() {
           decoded_audio->sample_type(), decoded_audio->storage_type(),
           decoded_sample_rate, output_sample_type_, output_storage_type_,
           output_samples_per_second_,
-          input_audio_stream_info_.number_of_channels);
+          input_audio_stream_info_.number_of_channels());
     }
-    if (input_audio_stream_info_.number_of_channels !=
+    if (input_audio_stream_info_.number_of_channels() !=
         output_number_of_channels_) {
       channel_mixer_ = AudioChannelLayoutMixer::Create(
           output_sample_type_, output_storage_type_,

--- a/starboard/shared/starboard/player/filter/audio_frame_discarder.cc
+++ b/starboard/shared/starboard/player/filter/audio_frame_discarder.cc
@@ -27,8 +27,8 @@ void AudioFrameDiscarder::OnInputBuffers(const InputBuffers& input_buffers) {
 
     input_buffer_infos_.push({
         input_buffer->timestamp(),
-        input_buffer->audio_sample_info().discarded_duration_from_front,
-        input_buffer->audio_sample_info().discarded_duration_from_back,
+        input_buffer->audio_sample_info().discarded_duration_from_front(),
+        input_buffer->audio_sample_info().discarded_duration_from_back(),
     });
   }
 

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -79,7 +79,7 @@ AudioRendererPcm::AudioRendererPcm(
       experimental_features_(experimental_features),
       decoder_(std::move(decoder)),
       frames_consumed_set_at_(CurrentMonotonicTime()),
-      channels_(audio_stream_info.number_of_channels),
+      channels_(audio_stream_info.number_of_channels()),
       sink_sample_type_(GetSinkAudioSampleType(audio_renderer_sink.get())),
       bytes_per_frame_(GetBytesPerSample(sink_sample_type_) * channels_),
       frame_buffer_(max_cached_frames_ * bytes_per_frame_),

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -69,11 +69,11 @@ void AudioRendererSinkImpl::GetAudioRendererParams(
   // AudioRenderer prefers to use kSbMediaAudioSampleTypeFloat32 and only uses
   // kSbMediaAudioSampleTypeInt16Deprecated when float32 is not supported.
   int min_frames_required = SbAudioSinkGetMinBufferSizeInFrames(
-      audio_stream_info.number_of_channels,
+      audio_stream_info.number_of_channels(),
       SbAudioSinkIsAudioSampleTypeSupported(kSbMediaAudioSampleTypeFloat32)
           ? kSbMediaAudioSampleTypeFloat32
           : kSbMediaAudioSampleTypeInt16Deprecated,
-      audio_stream_info.samples_per_second);
+      audio_stream_info.samples_per_second());
   // Audio renderer would sleep for a while if it thinks there're enough
   // frames in the sink. The sleeping time is 1/4 of |max_cached_frames|. So, to
   // maintain required min buffer size of audio sink, the |max_cached_frames|

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -109,11 +109,11 @@ Result<void> FilterBasedPlayerWorkerHandler::Init(
       PlayerComponents::Factory::Create();
   SB_DCHECK(factory);
 
-  if (audio_stream_info_.codec != kSbMediaAudioCodecNone) {
+  if (audio_stream_info_.codec() != kSbMediaAudioCodecNone) {
     // TODO: This is not ideal as we should really handle the creation failure
     // of audio sink inside the audio renderer to give the renderer a chance to
     // resample the decoded audio.
-    const int required_audio_channels = audio_stream_info_.number_of_channels;
+    const int required_audio_channels = audio_stream_info_.number_of_channels();
     const int supported_audio_channels = SbAudioSinkGetMaxChannels();
     if (required_audio_channels > supported_audio_channels) {
       SB_LOG(ERROR) << "Audio channels requested " << required_audio_channels
@@ -143,10 +143,10 @@ Result<void> FilterBasedPlayerWorkerHandler::Init(
     audio_renderer_ = player_components_->GetAudioRenderer();
     video_renderer_ = player_components_->GetVideoRenderer();
   }
-  if (audio_stream_info_.codec != kSbMediaAudioCodecNone) {
+  if (audio_stream_info_.codec() != kSbMediaAudioCodecNone) {
     SB_DCHECK(audio_renderer_);
   }
-  if (video_stream_info_.codec != kSbMediaVideoCodecNone) {
+  if (video_stream_info_.codec() != kSbMediaVideoCodecNone) {
     SB_DCHECK(video_renderer_);
   }
   SB_DCHECK(media_time_provider_);

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -81,7 +81,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
       experimental_features_(ExperimentalFeatures{}),
       job_queue_(job_queue),
       drm_system_(drm_system) {
-  SB_DCHECK_NE(audio_stream_info_.codec, kSbMediaAudioCodecNone);
+  SB_DCHECK_NE(audio_stream_info_.codec(), kSbMediaAudioCodecNone);
   SB_CHECK(job_queue_);
 }
 
@@ -106,7 +106,7 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
           decode_target_graphics_context_provider),
       job_queue_(job_queue),
       drm_system_(drm_system) {
-  SB_DCHECK_NE(video_stream_info_.codec, kSbMediaVideoCodecNone);
+  SB_DCHECK_NE(video_stream_info_.codec(), kSbMediaVideoCodecNone);
   SB_DCHECK(SbPlayerIsValid(player_));
   SB_DCHECK_NE(output_mode_, kSbPlayerOutputModeInvalid);
   SB_CHECK(job_queue_);
@@ -135,8 +135,8 @@ PlayerComponents::Factory::CreationParameters::CreationParameters(
           decode_target_graphics_context_provider),
       job_queue_(job_queue),
       drm_system_(drm_system) {
-  SB_DCHECK(audio_stream_info_.codec != kSbMediaAudioCodecNone ||
-            video_stream_info_.codec != kSbMediaVideoCodecNone);
+  SB_DCHECK(audio_stream_info_.codec() != kSbMediaAudioCodecNone ||
+            video_stream_info_.codec() != kSbMediaVideoCodecNone);
   SB_CHECK(job_queue_);
 }
 

--- a/starboard/shared/starboard/player/filter/player_components.h
+++ b/starboard/shared/starboard/player/filter/player_components.h
@@ -83,40 +83,40 @@ class PlayerComponents {
       CreationParameters(const CreationParameters& that) = default;
       void operator=(const CreationParameters& that) = delete;
 
-      void reset_audio_codec() {
-        audio_stream_info_.codec = kSbMediaAudioCodecNone;
-      }
-      void reset_video_codec() {
-        video_stream_info_.codec = kSbMediaVideoCodecNone;
-      }
+      void reset_audio_codec() { audio_stream_info_ = AudioStreamInfo(); }
+      void reset_video_codec() { video_stream_info_ = VideoStreamInfo(); }
 
-      SbMediaAudioCodec audio_codec() const { return audio_stream_info_.codec; }
+      SbMediaAudioCodec audio_codec() const {
+        return audio_stream_info_.codec();
+      }
 
       const AudioStreamInfo& audio_stream_info() const {
-        SB_DCHECK_NE(audio_stream_info_.codec, kSbMediaAudioCodecNone);
+        SB_DCHECK_NE(audio_stream_info_.codec(), kSbMediaAudioCodecNone);
         return audio_stream_info_;
       }
 
-      SbMediaVideoCodec video_codec() const { return video_stream_info_.codec; }
+      SbMediaVideoCodec video_codec() const {
+        return video_stream_info_.codec();
+      }
 
       const std::string& audio_mime() const {
-        SB_DCHECK_NE(audio_stream_info_.codec, kSbMediaAudioCodecNone);
-        return audio_stream_info_.mime;
+        SB_DCHECK_NE(audio_stream_info_.codec(), kSbMediaAudioCodecNone);
+        return audio_stream_info_.mime();
       }
 
       const VideoStreamInfo& video_stream_info() const {
-        SB_DCHECK_NE(video_stream_info_.codec, kSbMediaVideoCodecNone);
+        SB_DCHECK_NE(video_stream_info_.codec(), kSbMediaVideoCodecNone);
         return video_stream_info_;
       }
 
       const std::string& video_mime() const {
-        SB_DCHECK_NE(video_stream_info_.codec, kSbMediaVideoCodecNone);
-        return video_stream_info_.mime;
+        SB_DCHECK_NE(video_stream_info_.codec(), kSbMediaVideoCodecNone);
+        return video_stream_info_.mime();
       }
 
       const std::string& max_video_capabilities() const {
-        SB_DCHECK_NE(video_stream_info_.codec, kSbMediaVideoCodecNone);
-        return video_stream_info_.max_video_capabilities;
+        SB_DCHECK_NE(video_stream_info_.codec(), kSbMediaVideoCodecNone);
+        return video_stream_info_.max_video_capabilities();
       }
 
       SbPlayer player() const { return player_; }
@@ -128,7 +128,7 @@ class PlayerComponents {
       void* surface_view() const { return surface_view_; }
       SbDecodeTargetGraphicsContextProvider*
       decode_target_graphics_context_provider() const {
-        SB_DCHECK_NE(video_stream_info_.codec, kSbMediaVideoCodecNone);
+        SB_DCHECK_NE(video_stream_info_.codec(), kSbMediaVideoCodecNone);
         return decode_target_graphics_context_provider_;
       }
 

--- a/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_audio_decoder.cc
@@ -78,9 +78,9 @@ scoped_refptr<DecodedAudio> CreateDecodedAudio(
 StubAudioDecoder::StubAudioDecoder(JobQueue* job_queue,
                                    const AudioStreamInfo& audio_stream_info)
     : JobOwner(job_queue),
-      codec_(audio_stream_info.codec),
-      number_of_channels_(audio_stream_info.number_of_channels),
-      samples_per_second_(audio_stream_info.samples_per_second),
+      codec_(audio_stream_info.codec()),
+      number_of_channels_(audio_stream_info.number_of_channels()),
+      samples_per_second_(audio_stream_info.samples_per_second()),
       sample_type_(GetSupportedSampleType()) {
   if (codec_ == kSbMediaAudioCodecAac) {
     // Assume the frames per input buffer is always 1024 for aac.
@@ -180,8 +180,8 @@ void StubAudioDecoder::DecodeOneBuffer(
 
     decoded_audio->AdjustForDiscardedDurations(
         samples_per_second_,
-        last_input_buffer_->audio_sample_info().discarded_duration_from_front,
-        last_input_buffer_->audio_sample_info().discarded_duration_from_back);
+        last_input_buffer_->audio_sample_info().discarded_duration_from_front(),
+        last_input_buffer_->audio_sample_info().discarded_duration_from_back());
 
     if (total_input_count_ % kMaxInputBeforeMultipleDecodedAudios != 0) {
       std::lock_guard lock(decoded_audios_mutex_);
@@ -259,13 +259,14 @@ void StubAudioDecoder::DecodeEndOfStream() {
                            number_of_channels_, *frames_per_input_);
 
     auto discarded_duration_from_front =
-        last_input_buffer_->audio_sample_info().discarded_duration_from_front;
+        last_input_buffer_->audio_sample_info().discarded_duration_from_front();
     auto discarded_duration_from_back =
-        last_input_buffer_->audio_sample_info().discarded_duration_from_back;
-    SB_DCHECK(AudioDurationToFrames(
-                  discarded_duration_from_front + discarded_duration_from_back,
-                  last_input_buffer_->audio_stream_info().samples_per_second) <=
-              decoded_audio->frames());
+        last_input_buffer_->audio_sample_info().discarded_duration_from_back();
+    SB_DCHECK(
+        AudioDurationToFrames(
+            discarded_duration_from_front + discarded_duration_from_back,
+            last_input_buffer_->audio_stream_info().samples_per_second()) <=
+        decoded_audio->frames());
 
     decoded_audio->AdjustForDiscardedDurations(samples_per_second_,
                                                discarded_duration_from_front,

--- a/starboard/shared/starboard/player/filter/stub_video_decoder.cc
+++ b/starboard/shared/starboard/player/filter/stub_video_decoder.cc
@@ -84,7 +84,7 @@ SbDecodeTarget StubVideoDecoder::GetCurrentDecodeTarget() {
 void StubVideoDecoder::DecodeBuffers(const InputBuffers& input_buffers) {
   for (const auto& input_buffer : input_buffers) {
     auto& video_sample_info = input_buffer->video_sample_info();
-    if (video_sample_info.is_key_frame) {
+    if (video_sample_info.is_key_frame()) {
       if (video_stream_info_ != input_buffer->video_stream_info()) {
         SB_LOG(INFO) << "New video sample info: " << video_sample_info;
         video_stream_info_ = input_buffer->video_stream_info();
@@ -130,20 +130,20 @@ void StubVideoDecoder::DecodeEndOfStream() {
 
 scoped_refptr<VideoFrame> StubVideoDecoder::CreateOutputFrame(
     int64_t timestamp) const {
-  int bits_per_channel = video_stream_info_.color_metadata.bits_per_channel;
+  int bits_per_channel = video_stream_info_.color_metadata().bits_per_channel;
   if (bits_per_channel == 0) {
     // Assume 8 bits when |bits_per_channel| is unknown (0).
     bits_per_channel = 8;
   }
   int uv_stride = bits_per_channel > 8
-                      ? video_stream_info_.frame_size.width
-                      : video_stream_info_.frame_size.width / 2;
+                      ? video_stream_info_.frame_size().width
+                      : video_stream_info_.frame_size().width / 2;
   int y_stride = uv_stride * 2;
-  std::string data(y_stride * video_stream_info_.frame_size.height, 0);
+  std::string data(y_stride * video_stream_info_.frame_size().height, 0);
 
   return CpuVideoFrame::CreateYV12Frame(
-      bits_per_channel, video_stream_info_.frame_size.width,
-      video_stream_info_.frame_size.height, y_stride, uv_stride, timestamp,
+      bits_per_channel, video_stream_info_.frame_size().width,
+      video_stream_info_.frame_size().height, y_stride, uv_stride, timestamp,
       reinterpret_cast<const uint8_t*>(data.data()),
       reinterpret_cast<const uint8_t*>(data.data()),
       reinterpret_cast<const uint8_t*>(data.data()));

--- a/starboard/shared/starboard/player/input_buffer_internal.cc
+++ b/starboard/shared/starboard/player/input_buffer_internal.cc
@@ -83,17 +83,17 @@ std::ostream& operator<<(std::ostream& os, const InputBuffer& buffer) {
      << " sample @ timestamp: " << buffer.timestamp() << " in " << buffer.size()
      << " bytes ==========\n";
   if (buffer.sample_type() == kSbMediaTypeAudio) {
-    os << "codec: " << buffer.audio_stream_info().codec << ", mime: '"
-       << buffer.audio_stream_info().mime << "'\n";
-    os << buffer.audio_stream_info().samples_per_second << '\n';
+    os << "codec: " << buffer.audio_stream_info().codec() << ", mime: '"
+       << buffer.audio_stream_info().mime() << "'\n";
+    os << buffer.audio_stream_info().samples_per_second() << '\n';
   } else {
     SB_DCHECK_EQ(buffer.sample_type(), kSbMediaTypeVideo);
 
-    os << "codec: " << buffer.video_stream_info().codec << ", mime: '"
-       << buffer.video_stream_info().mime << "'"
+    os << "codec: " << buffer.video_stream_info().codec() << ", mime: '"
+       << buffer.video_stream_info().mime() << "'"
        << ", max_video_capabilities: '"
-       << buffer.video_stream_info().max_video_capabilities << "'\n";
-    os << buffer.video_stream_info().frame_size << '\n';
+       << buffer.video_stream_info().max_video_capabilities() << "'\n";
+    os << buffer.video_stream_info().frame_size() << '\n';
   }
   if (buffer.has_drm_info_) {
     os << "iv: "

--- a/starboard/shared/starboard/player/input_buffer_internal.h
+++ b/starboard/shared/starboard/player/input_buffer_internal.h
@@ -55,10 +55,10 @@ class InputBuffer : public RefCountedThreadSafe<InputBuffer> {
     return video_sample_info_;
   }
   const AudioStreamInfo& audio_stream_info() const {
-    return audio_sample_info().stream_info;
+    return audio_sample_info().stream_info();
   }
   const VideoStreamInfo& video_stream_info() const {
-    return video_sample_info().stream_info;
+    return video_sample_info().stream_info();
   }
 
   const SbDrmSampleInfo* drm_info() const {

--- a/starboard/shared/starboard/player/player_internal.cc
+++ b/starboard/shared/starboard/player/player_internal.cc
@@ -98,7 +98,7 @@ void SbPlayerPrivateImpl::WriteSamples(const SbPlayerSampleInfo* sample_infos,
   const auto& last_input_buffer = input_buffers.back();
   if (last_input_buffer->sample_type() == kSbMediaTypeVideo) {
     total_video_frames_ += number_of_sample_infos;
-    frame_size_ = last_input_buffer->video_stream_info().frame_size;
+    frame_size_ = last_input_buffer->video_stream_info().frame_size();
   }
 
   worker_->WriteSamples(std::move(input_buffers));

--- a/starboard/shared/starboard/player/video_dmp_common.cc
+++ b/starboard/shared/starboard/player/video_dmp_common.cc
@@ -90,20 +90,18 @@ void Read(const ReadCB& read_cb,
           AudioSampleInfo* audio_sample_info) {
   SB_DCHECK(audio_sample_info);
 
-  *audio_sample_info = AudioSampleInfo();
+  SbMediaAudioStreamInfo sb_stream = {};
 
-  AudioStreamInfo* audio_stream_info = &audio_sample_info->stream_info;
+  Read(read_cb, reverse_byte_order, &sb_stream.codec);
 
-  Read(read_cb, reverse_byte_order, &audio_stream_info->codec);
-
-  audio_stream_info->mime = "";
+  sb_stream.mime = "";
 
   // Skip `format_tag` as it's removed from `SbMediaAudioStreamInfo`.
   uint16_t format_tag_to_skip;
   Read(read_cb, reverse_byte_order, &format_tag_to_skip);
 
-  Read(read_cb, reverse_byte_order, &audio_stream_info->number_of_channels);
-  Read(read_cb, reverse_byte_order, &audio_stream_info->samples_per_second);
+  Read(read_cb, reverse_byte_order, &sb_stream.number_of_channels);
+  Read(read_cb, reverse_byte_order, &sb_stream.samples_per_second);
 
   // Skip `average_bytes` and `block_alignment` as they're removed from
   // `SbMediaAudioStreamInfo`.
@@ -112,13 +110,17 @@ void Read(const ReadCB& read_cb,
   uint16_t block_alignment_to_skip;
   Read(read_cb, reverse_byte_order, &block_alignment_to_skip);
 
-  Read(read_cb, reverse_byte_order, &audio_stream_info->bits_per_sample);
+  Read(read_cb, reverse_byte_order, &sb_stream.bits_per_sample);
 
-  uint16_t audio_specific_config_size;
-  Read(read_cb, reverse_byte_order, &audio_specific_config_size);
-  audio_stream_info->audio_specific_config.resize(audio_specific_config_size);
-  Read(read_cb, audio_stream_info->audio_specific_config.data(),
-       audio_specific_config_size);
+  Read(read_cb, reverse_byte_order, &sb_stream.audio_specific_config_size);
+  std::vector<uint8_t> config(sb_stream.audio_specific_config_size);
+  Read(read_cb, config.data(), sb_stream.audio_specific_config_size);
+  sb_stream.audio_specific_config = config.data();
+
+  SbMediaAudioSampleInfo sb_sample = {};
+  sb_sample.stream_info = sb_stream;
+
+  *audio_sample_info = AudioSampleInfo(sb_sample);
 }
 
 void Write(const WriteCB& write_cb,
@@ -130,8 +132,8 @@ void Write(const WriteCB& write_cb,
   // Write a dummy one to be compatible with the existing format.
   Write(write_cb, format_tag);
 
-  Write(write_cb, audio_stream_info.number_of_channels);
-  Write(write_cb, audio_stream_info.samples_per_second);
+  Write(write_cb, audio_stream_info.number_of_channels());
+  Write(write_cb, audio_stream_info.samples_per_second());
 
   uint32_t average_bytes_per_second = 1;
   // Write a dummy one to be compatible with the existing format.
@@ -140,13 +142,13 @@ void Write(const WriteCB& write_cb,
   // Write a dummy one to be compatible with the existing format.
   Write(write_cb, block_alignment);
 
-  Write(write_cb, audio_stream_info.bits_per_sample);
+  Write(write_cb, audio_stream_info.bits_per_sample());
 
   uint16_t audio_specific_config_size =
-      static_cast<uint16_t>(audio_stream_info.audio_specific_config.size());
+      static_cast<uint16_t>(audio_stream_info.audio_specific_config().size());
   Write(write_cb, audio_specific_config_size);
-  Write(write_cb, audio_stream_info.audio_specific_config.data(),
-        audio_stream_info.audio_specific_config.size());
+  Write(write_cb, audio_stream_info.audio_specific_config().data(),
+        audio_stream_info.audio_specific_config().size());
 }
 
 void Read(const ReadCB& read_cb,
@@ -191,16 +193,19 @@ void Read(const ReadCB& read_cb,
           VideoSampleInfo* video_sample_info) {
   SB_DCHECK(video_sample_info);
 
-  *video_sample_info = VideoSampleInfo();
-  VideoStreamInfo* video_stream_info = &video_sample_info->stream_info;
+  SbMediaVideoSampleInfo sb_sample = {};
+  SbMediaVideoStreamInfo* sb_stream = &sb_sample.stream_info;
 
-  Read(read_cb, reverse_byte_order, &video_stream_info->codec);
+  sb_stream->mime = "";
+  sb_stream->max_video_capabilities = "";
 
-  Read(read_cb, reverse_byte_order, &video_sample_info->is_key_frame);
-  Read(read_cb, reverse_byte_order, &video_stream_info->frame_size.width);
-  Read(read_cb, reverse_byte_order, &video_stream_info->frame_size.height);
+  Read(read_cb, reverse_byte_order, &sb_stream->codec);
 
-  auto& color_metadata = video_stream_info->color_metadata;
+  Read(read_cb, reverse_byte_order, &sb_sample.is_key_frame);
+  Read(read_cb, reverse_byte_order, &sb_stream->frame_width);
+  Read(read_cb, reverse_byte_order, &sb_stream->frame_height);
+
+  auto& color_metadata = sb_stream->color_metadata;
 
   Read(read_cb, reverse_byte_order, &color_metadata.bits_per_channel);
   Read(read_cb, reverse_byte_order,
@@ -241,19 +246,21 @@ void Read(const ReadCB& read_cb,
   for (int i = 0; i < 12; ++i) {
     Read(read_cb, reverse_byte_order, &color_metadata.custom_primary_matrix[i]);
   }
+
+  *video_sample_info = VideoSampleInfo(sb_sample);
 }
 
 void Write(const WriteCB& write_cb,
            SbMediaVideoCodec video_codec,
            const VideoSampleInfo& video_sample_info) {
-  const auto& video_stream_info = video_sample_info.stream_info;
+  const auto& video_stream_info = video_sample_info.stream_info();
 
   Write(write_cb, video_codec);
-  Write(write_cb, video_sample_info.is_key_frame);
-  Write(write_cb, video_stream_info.frame_size.width);
-  Write(write_cb, video_stream_info.frame_size.height);
+  Write(write_cb, video_sample_info.is_key_frame());
+  Write(write_cb, video_stream_info.frame_size().width);
+  Write(write_cb, video_stream_info.frame_size().height);
 
-  const auto& color_metadata = video_stream_info.color_metadata;
+  const auto& color_metadata = video_stream_info.color_metadata();
 
   Write(write_cb, color_metadata.bits_per_channel);
   Write(write_cb, color_metadata.chroma_subsampling_horizontal);

--- a/starboard/shared/starboard/player/video_dmp_reader.cc
+++ b/starboard/shared/starboard/player/video_dmp_reader.cc
@@ -173,7 +173,7 @@ std::string VideoDmpReader::audio_mime_type() const {
   }
 
   ss << " channels="
-     << dmp_info_.audio_sample_info.stream_info.number_of_channels;
+     << dmp_info_.audio_sample_info.stream_info().number_of_channels();
   return ss.str();
 }
 
@@ -204,8 +204,8 @@ std::string VideoDmpReader::video_mime_type() {
   }
   if (number_of_video_buffers() > 0) {
     const auto& video_stream_info = this->video_stream_info();
-    ss << "width=" << video_stream_info.frame_size.width
-       << "; height=" << video_stream_info.frame_size.height << ";";
+    ss << "width=" << video_stream_info.frame_size().width
+       << "; height=" << video_stream_info.frame_size().height << ";";
   }
   ss << " framerate=" << dmp_info_.video_fps;
   return ss.str();
@@ -278,7 +278,7 @@ bool VideoDmpReader::ParseOneRecord() {
         Read(read_cb_, reverse_byte_order_.value(),
              &dmp_info_.audio_sample_info);
         SB_DCHECK_EQ(dmp_info_.audio_codec,
-                     dmp_info_.audio_sample_info.stream_info.codec);
+                     dmp_info_.audio_sample_info.stream_info().codec());
       }
       break;
     case kRecordTypeVideoConfig:
@@ -356,7 +356,7 @@ void VideoDmpReader::Parse() {
       if (it->timestamp() > last_frame_timestamp) {
         last_frame_timestamp = it->timestamp();
       }
-      if (it->video_sample_info().is_key_frame) {
+      if (it->video_sample_info().is_key_frame()) {
         break;
       }
     }

--- a/starboard/shared/starboard/player/video_dmp_reader.h
+++ b/starboard/shared/starboard/player/video_dmp_reader.h
@@ -104,12 +104,12 @@ class VideoDmpReader {
 
   SbMediaAudioCodec audio_codec() const { return dmp_info_.audio_codec; }
   const AudioStreamInfo& audio_stream_info() const {
-    return dmp_info_.audio_sample_info.stream_info;
+    return dmp_info_.audio_sample_info.stream_info();
   }
   const VideoStreamInfo& video_stream_info() {
     EnsureSampleLoaded(kSbMediaTypeVideo, 0);
     SB_DCHECK(!video_access_units_.empty());
-    return video_access_units_[0].video_sample_info().stream_info;
+    return video_access_units_[0].video_sample_info().stream_info();
   }
   int64_t audio_bitrate() const { return dmp_info_.audio_bitrate; }
   std::string audio_mime_type() const;

--- a/starboard/shared/starboard/player/video_dmp_writer.cc
+++ b/starboard/shared/starboard/player/video_dmp_writer.cc
@@ -177,11 +177,11 @@ void VideoDmpWriter::DumpAccessUnit(
   Write(write_cb_, sample_buffer, static_cast<size_t>(sample_buffer_size));
 
   if (sample_type == kSbMediaTypeAudio) {
-    Write(write_cb_, input_buffer->audio_stream_info().codec,
+    Write(write_cb_, input_buffer->audio_stream_info().codec(),
           input_buffer->audio_stream_info());
   } else {
     SB_DCHECK_EQ(sample_type, kSbMediaTypeVideo);
-    Write(write_cb_, input_buffer->video_stream_info().codec,
+    Write(write_cb_, input_buffer->video_stream_info().codec(),
           input_buffer->video_sample_info());
   }
 }


### PR DESCRIPTION
Refactor AudioStreamInfo, AudioSampleInfo, VideoStreamInfo, and VideoSampleInfo into strict C++ classes with complete private member encapsulation and public getters.

Key architectural and performance enhancements include:
- Inlining standalone assignment helpers directly into class methods.
- Refactoring all Starboard decoders, filters, dump utilities, and NPLB tests to utilize getter accessors.
- Returning const references for large structures like SbMediaColorMetadata to avoid stack copying overhead.
- Enabling container capacity reuse (std::string, std::vector) during sample info assignments by assigning directly from POD C structures, preventing temporary dynamic allocations.

Bug: 517711136