### PR TITLE
starboard: Move VideoFrameTracker entry point to prevent queue overflow

### DIFF
--- a/starboard/android/shared/media_codec_audio_decoder.h
+++ b/starboard/android/shared/media_codec_audio_decoder.h
@@ -79,6 +79,7 @@ class MediaCodecAudioDecoder : public AudioDecoder,
       const scoped_refptr<InputBuffer>& input_buffer) override {
     return false;
   }
+  void OnInputBufferQueued(int64_t timestamp_us) override {}
 
   void ReportError(SbPlayerError error, const std::string& error_message);
 

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -832,6 +832,10 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
     return false;
   }
 
+  if (pending_input.type == PendingInput::kWriteInputBuffer) {
+    host_->OnInputBufferQueued(input_buffer->timestamp());
+  }
+
   is_output_restricted_ = false;
   return true;
 }

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -741,6 +741,7 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
     data = pending_input.codec_config.data();
     size = pending_input.codec_config.size();
   } else if (pending_input.type == PendingInput::kWriteInputBuffer) {
+    SB_CHECK(input_buffer);
     data = input_buffer->data();
     size = input_buffer->size();
   } else if (pending_input.type == PendingInput::kWriteEndOfStream) {

--- a/starboard/android/shared/media_codec_decoder.h
+++ b/starboard/android/shared/media_codec_decoder.h
@@ -68,6 +68,8 @@ class MediaCodecDecoder final : private MediaCodecBridge::Handler,
     virtual bool IsBufferDecodeOnly(
         const scoped_refptr<InputBuffer>& input_buffer) = 0;
 
+    virtual void OnInputBufferQueued(int64_t timestamp_us) = 0;
+
    protected:
     ~Host() {}
   };

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -888,13 +888,6 @@ void MediaCodecVideoDecoder::WriteInputBuffersInternal(
     return;
   }
 
-  if (is_video_frame_tracker_enabled_) {
-    SB_DCHECK(video_frame_tracker_);
-    for (const auto& input_buffer : input_buffers) {
-      video_frame_tracker_->OnInputBuffer(input_buffer->timestamp());
-    }
-  }
-
   media_decoder_->WriteInputBuffers(input_buffers);
   if (media_decoder_->GetNumberOfPendingInputs() < kMaxPendingInputsSize) {
     decoder_status_cb_(kNeedMoreInput, NULL);
@@ -1033,6 +1026,13 @@ bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
 
   SB_CHECK(video_frame_tracker_);
   return input_buffer->timestamp() < video_frame_tracker_->seek_to_time();
+}
+
+void MediaCodecVideoDecoder::OnInputBufferQueued(int64_t timestamp_us) {
+  if (is_video_frame_tracker_enabled_) {
+    SB_DCHECK(video_frame_tracker_);
+    video_frame_tracker_->OnInputBuffer(timestamp_us);
+  }
 }
 
 void MediaCodecVideoDecoder::TryToSignalPrerollForTunnelMode() {

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -107,6 +107,13 @@ const int kNonInitialPrerollFrameCount = 1;
 // tunnel mode prerolling only needs 1 frame.
 const int kTunnelModePrerollFrameCount = 1;
 const int kMaxPendingInputsSize = 128;
+// The maximum number of pending frames in VideoFrameTracker.
+// Since the tracker now only tracks frames once they are actually queued to the
+// hardware decoder (OnInputBufferQueued), the number of active frames in flight
+// is limited by the hardware capacity (InCodec + BufferedOutput + Surface
+// queue, which is typically < 40 in practice). 128 provides a safe 3x margin.
+// For details, see http://b/515102461#comment6
+constexpr int kMaxTrackerPendingFrames = 128;
 
 const int kFpsGuesstimateRequiredInputBufferCount = 3;
 
@@ -360,7 +367,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
 
   if (is_video_frame_tracker_enabled_) {
     video_frame_tracker_ =
-        std::make_unique<VideoFrameTracker>(kMaxPendingInputsSize * 2);
+        std::make_unique<VideoFrameTracker>(kMaxTrackerPendingFrames);
   }
 
   if (require_software_codec_) {

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -1037,7 +1037,7 @@ bool MediaCodecVideoDecoder::IsBufferDecodeOnly(
 
 void MediaCodecVideoDecoder::OnInputBufferQueued(int64_t timestamp_us) {
   if (is_video_frame_tracker_enabled_) {
-    SB_DCHECK(video_frame_tracker_);
+    SB_CHECK(video_frame_tracker_);
     video_frame_tracker_->OnInputBuffer(timestamp_us);
   }
 }

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -137,6 +137,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   void OnFlushing() override;
   bool IsBufferDecodeOnly(
       const scoped_refptr<InputBuffer>& input_buffer) override;
+  void OnInputBufferQueued(int64_t timestamp_us) override;
 
   void TryToSignalPrerollForTunnelMode();
   void OnFrameRendered(int64_t frame_timestamp);

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -34,6 +34,14 @@ const int64_t kMaxAllowedSkew = 5'000;  // 5ms
 // a different data structure should be considered.
 constexpr int kMaxTrackerSizeThreshold = 512;
 
+// Pre-allocates capacity to prevent heap allocations during initial std::vector
+// growth. This threshold is large enough to typically avoid any subsequent
+// reallocations during playback, while still allowing std::vector to safely
+// grow dynamically under the hood if exceeded. The typical peak number of
+// rendered frames in a 200ms update window is 12 (at 60fps). 24 provides a safe
+// 2x margin to completely avoid allocations on the time-sensitive JNI thread.
+constexpr int kInitialRenderedFramesCapacity = 24;
+
 void RemoveUnexpectedRenderedFrames(
     const std::vector<int64_t>& frames_to_render,
     std::vector<int64_t>* rendered_frames) {
@@ -78,13 +86,13 @@ void RemoveUnexpectedRenderedFrames(
 VideoFrameTracker::VideoFrameTracker(int max_tracked_frames)
     : max_tracked_frames_(max_tracked_frames) {
   frames_to_be_rendered_.reserve(max_tracked_frames_);
-  rendered_frames_on_decoder_thread_.reserve(max_tracked_frames_);
-  rendered_frames_on_tracker_thread_.reserve(max_tracked_frames_);
   SB_LOG_IF(WARNING, max_tracked_frames_ > kMaxTrackerSizeThreshold)
       << "VideoFrameTracker created with large size (" << max_tracked_frames_
       << "). Large sizes can degrade std::vector performance due to shifting "
          "elements. "
       << "Consider reducing the size or switching to other data type.";
+  rendered_frames_on_decoder_thread_.reserve(kInitialRenderedFramesCapacity);
+  rendered_frames_on_tracker_thread_.reserve(kInitialRenderedFramesCapacity);
 }
 
 int64_t VideoFrameTracker::seek_to_time() const {

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -77,7 +77,9 @@ void RemoveUnexpectedRenderedFrames(
 
 VideoFrameTracker::VideoFrameTracker(int max_tracked_frames)
     : max_tracked_frames_(max_tracked_frames) {
-  frames_to_be_rendered_.reserve(max_tracked_frames_ + 1);
+  frames_to_be_rendered_.reserve(max_tracked_frames_);
+  rendered_frames_on_decoder_thread_.reserve(max_tracked_frames_);
+  rendered_frames_on_tracker_thread_.reserve(max_tracked_frames_);
   SB_LOG_IF(WARNING, max_tracked_frames_ > kMaxTrackerSizeThreshold)
       << "VideoFrameTracker created with large size (" << max_tracked_frames_
       << "). Large sizes can degrade std::vector performance due to shifting "
@@ -97,7 +99,7 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
     return;
   }
 
-  if (frames_to_be_rendered_.size() >
+  if (frames_to_be_rendered_.size() >=
       static_cast<size_t>(max_tracked_frames_)) {
     SB_LOG(WARNING)
         << "Evicting frame from VideoFrameTracker due to queue overflow: "

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -31,8 +31,9 @@ const int64_t kMaxAllowedSkew = 5'000;  // 5ms
 
 // TODO: b/409362474 - Add unit test once starboard unittests are enable on
 // Android.
-void RemoveUnexpectedRenderedFrames(const std::list<int64_t>& frames_to_render,
-                                    std::vector<int64_t>* rendered_frames) {
+void RemoveUnexpectedRenderedFrames(
+    const std::vector<int64_t>& frames_to_render,
+    std::vector<int64_t>* rendered_frames) {
   SB_CHECK(rendered_frames);
   if (rendered_frames->empty()) {
     return;
@@ -76,7 +77,7 @@ int64_t VideoFrameTracker::seek_to_time() const {
 }
 
 void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
-  std::lock_guard lock(mutex_);
+  std::lock_guard lock(state_mutex_);
 
   if (frames_to_be_rendered_.empty()) {
     frames_to_be_rendered_.push_back(timestamp);
@@ -92,7 +93,7 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
         << ", max_size=" << max_pending_frames_size_;
     // OnFrameRendered() is only available after API level 23.  Cap the size
     // of |frames_to_be_rendered_| in case OnFrameRendered() is not available.
-    frames_to_be_rendered_.pop_front();
+    frames_to_be_rendered_.erase(frames_to_be_rendered_.begin());
   }
 
   // Sort by |timestamp|, because |timestamp| won't be monotonic if there are
@@ -109,7 +110,7 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
     }
   }
 
-  frames_to_be_rendered_.emplace_front(timestamp);
+  frames_to_be_rendered_.emplace(frames_to_be_rendered_.begin(), timestamp);
 }
 
 void VideoFrameTracker::OnFrameRendered(int64_t frame_timestamp) {
@@ -118,7 +119,7 @@ void VideoFrameTracker::OnFrameRendered(int64_t frame_timestamp) {
 }
 
 void VideoFrameTracker::Seek(int64_t seek_to_time) {
-  std::lock_guard lock(mutex_);
+  std::lock_guard lock(state_mutex_);
 
   // Ensure that all dropped frames before seeking are captured.
   UpdateDroppedFrames_Locked();
@@ -128,14 +129,12 @@ void VideoFrameTracker::Seek(int64_t seek_to_time) {
 }
 
 int VideoFrameTracker::UpdateAndGetDroppedFrames() {
-  std::lock_guard lock(mutex_);
+  std::lock_guard lock(state_mutex_);
   UpdateDroppedFrames_Locked();
   return dropped_frames_;
 }
 
 void VideoFrameTracker::UpdateDroppedFrames_Locked() {
-  // Assumes mutex_ is locked by the caller.
-
   {
     std::lock_guard lock_rendered(rendered_frames_mutex_);
     rendered_frames_on_tracker_thread_.swap(rendered_frames_on_decoder_thread_);
@@ -147,7 +146,7 @@ void VideoFrameTracker::UpdateDroppedFrames_Locked() {
     // seek to time, when the platform decides to render a frame earlier
     // than the seek to time during preroll. This shouldn't be an issue
     // after we align seek time to the next video key frame.
-    frames_to_be_rendered_.pop_front();
+    frames_to_be_rendered_.erase(frames_to_be_rendered_.begin());
   }
 
   RemoveUnexpectedRenderedFrames(frames_to_be_rendered_,

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -76,7 +76,7 @@ int64_t VideoFrameTracker::seek_to_time() const {
 }
 
 void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+  std::lock_guard lock(mutex_);
 
   if (frames_to_be_rendered_.empty()) {
     frames_to_be_rendered_.push_back(timestamp);
@@ -85,6 +85,11 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
 
   if (frames_to_be_rendered_.size() >
       static_cast<size_t>(max_pending_frames_size_)) {
+    SB_LOG(WARNING)
+        << "Evicting frame from VideoFrameTracker due to queue overflow: "
+        << "evicted_timestamp=" << frames_to_be_rendered_.front()
+        << ", new_timestamp=" << timestamp
+        << ", max_size=" << max_pending_frames_size_;
     // OnFrameRendered() is only available after API level 23.  Cap the size
     // of |frames_to_be_rendered_| in case OnFrameRendered() is not available.
     frames_to_be_rendered_.pop_front();
@@ -113,31 +118,31 @@ void VideoFrameTracker::OnFrameRendered(int64_t frame_timestamp) {
 }
 
 void VideoFrameTracker::Seek(int64_t seek_to_time) {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+  std::lock_guard lock(mutex_);
 
   // Ensure that all dropped frames before seeking are captured.
-  UpdateDroppedFrames();
+  UpdateDroppedFrames_Locked();
 
   frames_to_be_rendered_.clear();
   seek_to_time_ = seek_to_time;
 }
 
 int VideoFrameTracker::UpdateAndGetDroppedFrames() {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
-  UpdateDroppedFrames();
+  std::lock_guard lock(mutex_);
+  UpdateDroppedFrames_Locked();
   return dropped_frames_;
 }
 
-void VideoFrameTracker::UpdateDroppedFrames() {
-  SB_CHECK(thread_checker_.CalledOnValidThread());
+void VideoFrameTracker::UpdateDroppedFrames_Locked() {
+  // Assumes mutex_ is locked by the caller.
 
   {
-    std::lock_guard lock(rendered_frames_mutex_);
+    std::lock_guard lock_rendered(rendered_frames_mutex_);
     rendered_frames_on_tracker_thread_.swap(rendered_frames_on_decoder_thread_);
   }
 
   while (!frames_to_be_rendered_.empty() &&
-         frames_to_be_rendered_.front() < seek_to_time_) {
+         frames_to_be_rendered_.front() < seek_to_time_.load()) {
     // It is possible that the initial frame rendered time is before the
     // seek to time, when the platform decides to render a frame earlier
     // than the seek to time during preroll. This shouldn't be an issue

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -18,7 +18,6 @@
 #include <cmath>
 #include <cstdint>
 #include <cstdlib>
-#include <list>
 #include <mutex>
 #include <vector>
 
@@ -29,8 +28,12 @@ namespace {
 
 const int64_t kMaxAllowedSkew = 5'000;  // 5ms
 
-// TODO: b/409362474 - Add unit test once starboard unittests are enable on
-// Android.
+// Benchmark tests show VideoFrameTracker with std::vector outperforms
+// the std::list version for sizes up to 512, while also eliminating
+// per-frame heap allocations. If the capacity exceeds this threshold,
+// a different data structure should be considered.
+constexpr int kMaxTrackerSizeThreshold = 512;
+
 void RemoveUnexpectedRenderedFrames(
     const std::vector<int64_t>& frames_to_render,
     std::vector<int64_t>* rendered_frames) {
@@ -72,6 +75,16 @@ void RemoveUnexpectedRenderedFrames(
 }
 }  // namespace
 
+VideoFrameTracker::VideoFrameTracker(int max_tracked_frames)
+    : max_tracked_frames_(max_tracked_frames) {
+  frames_to_be_rendered_.reserve(max_tracked_frames_ + 1);
+  SB_LOG_IF(WARNING, max_tracked_frames_ > kMaxTrackerSizeThreshold)
+      << "VideoFrameTracker created with large size (" << max_tracked_frames_
+      << "). Large sizes can degrade std::vector performance due to shifting "
+         "elements. "
+      << "Consider reducing the size or switching to other data type.";
+}
+
 int64_t VideoFrameTracker::seek_to_time() const {
   return seek_to_time_;
 }
@@ -85,12 +98,12 @@ void VideoFrameTracker::OnInputBuffer(int64_t timestamp) {
   }
 
   if (frames_to_be_rendered_.size() >
-      static_cast<size_t>(max_pending_frames_size_)) {
+      static_cast<size_t>(max_tracked_frames_)) {
     SB_LOG(WARNING)
         << "Evicting frame from VideoFrameTracker due to queue overflow: "
         << "evicted_timestamp=" << frames_to_be_rendered_.front()
         << ", new_timestamp=" << timestamp
-        << ", max_size=" << max_pending_frames_size_;
+        << ", max_size=" << max_tracked_frames_;
     // OnFrameRendered() is only available after API level 23.  Cap the size
     // of |frames_to_be_rendered_| in case OnFrameRendered() is not available.
     frames_to_be_rendered_.erase(frames_to_be_rendered_.begin());
@@ -136,18 +149,18 @@ int VideoFrameTracker::UpdateAndGetDroppedFrames() {
 
 void VideoFrameTracker::UpdateDroppedFrames_Locked() {
   {
-    std::lock_guard lock_rendered(rendered_frames_mutex_);
+    std::lock_guard lock(rendered_frames_mutex_);
     rendered_frames_on_tracker_thread_.swap(rendered_frames_on_decoder_thread_);
   }
 
-  while (!frames_to_be_rendered_.empty() &&
-         frames_to_be_rendered_.front() < seek_to_time_.load()) {
-    // It is possible that the initial frame rendered time is before the
-    // seek to time, when the platform decides to render a frame earlier
-    // than the seek to time during preroll. This shouldn't be an issue
-    // after we align seek time to the next video key frame.
-    frames_to_be_rendered_.erase(frames_to_be_rendered_.begin());
-  }
+  // It is possible that the initial frame rendered time is before the
+  // seek to time, when the platform decides to render a frame earlier
+  // than the seek to time during preroll. This shouldn't be an issue
+  // after we align seek time to the next video key frame.
+  auto iter =
+      std::lower_bound(frames_to_be_rendered_.begin(),
+                       frames_to_be_rendered_.end(), seek_to_time_.load());
+  frames_to_be_rendered_.erase(frames_to_be_rendered_.begin(), iter);
 
   RemoveUnexpectedRenderedFrames(frames_to_be_rendered_,
                                  &rendered_frames_on_tracker_thread_);

--- a/starboard/android/shared/video_frame_tracker.h
+++ b/starboard/android/shared/video_frame_tracker.h
@@ -16,7 +16,6 @@
 #define STARBOARD_ANDROID_SHARED_VIDEO_FRAME_TRACKER_H_
 
 #include <atomic>
-#include <list>
 #include <mutex>
 #include <vector>
 
@@ -25,7 +24,9 @@ namespace starboard {
 class VideoFrameTracker {
  public:
   explicit VideoFrameTracker(int max_pending_frames_size)
-      : max_pending_frames_size_(max_pending_frames_size) {}
+      : max_pending_frames_size_(max_pending_frames_size) {
+    frames_to_be_rendered_.reserve(max_pending_frames_size_);
+  }
 
   int64_t seek_to_time() const;
 
@@ -38,18 +39,24 @@ class VideoFrameTracker {
   int UpdateAndGetDroppedFrames();
 
  private:
-  void UpdateDroppedFrames_Locked();
+  void UpdateDroppedFrames_Locked();  // Requires |state_mutex_|.
 
-  std::list<int64_t> frames_to_be_rendered_;
+  std::mutex state_mutex_;
+  std::vector<int64_t> frames_to_be_rendered_;  // Guarded by |state_mutex_|.
 
   const int max_pending_frames_size_;
-  int dropped_frames_ = 0;
+  int dropped_frames_ = 0;                // Guarded by |state_mutex_|.
   std::atomic<int64_t> seek_to_time_{0};  // microseconds
 
-  std::mutex mutex_;
+  std::vector<int64_t>
+      rendered_frames_on_tracker_thread_;  // Guarded by |state_mutex_|
+                                           // (microseconds).
+
   std::mutex rendered_frames_mutex_;
-  std::vector<int64_t> rendered_frames_on_tracker_thread_;  // microseconds
-  std::vector<int64_t> rendered_frames_on_decoder_thread_;  // microseconds
+  std::vector<int64_t>
+      rendered_frames_on_decoder_thread_;  // Guarded by
+                                           // |rendered_frames_mutex_|
+                                           // (microseconds).
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/video_frame_tracker.h
+++ b/starboard/android/shared/video_frame_tracker.h
@@ -23,10 +23,7 @@ namespace starboard {
 
 class VideoFrameTracker {
  public:
-  explicit VideoFrameTracker(int max_pending_frames_size)
-      : max_pending_frames_size_(max_pending_frames_size) {
-    frames_to_be_rendered_.reserve(max_pending_frames_size_);
-  }
+  explicit VideoFrameTracker(int max_tracked_frames);
 
   int64_t seek_to_time() const;
 
@@ -42,9 +39,10 @@ class VideoFrameTracker {
   void UpdateDroppedFrames_Locked();  // Requires |state_mutex_|.
 
   std::mutex state_mutex_;
+  // NOTE: std::vector is used to avoid heap allocations during playback.
   std::vector<int64_t> frames_to_be_rendered_;  // Guarded by |state_mutex_|.
 
-  const int max_pending_frames_size_;
+  const int max_tracked_frames_;
   int dropped_frames_ = 0;                // Guarded by |state_mutex_|.
   std::atomic<int64_t> seek_to_time_{0};  // microseconds
 

--- a/starboard/android/shared/video_frame_tracker.h
+++ b/starboard/android/shared/video_frame_tracker.h
@@ -15,11 +15,10 @@
 #ifndef STARBOARD_ANDROID_SHARED_VIDEO_FRAME_TRACKER_H_
 #define STARBOARD_ANDROID_SHARED_VIDEO_FRAME_TRACKER_H_
 
+#include <atomic>
 #include <list>
 #include <mutex>
 #include <vector>
-
-#include "starboard/shared/starboard/thread_checker.h"
 
 namespace starboard {
 
@@ -39,16 +38,15 @@ class VideoFrameTracker {
   int UpdateAndGetDroppedFrames();
 
  private:
-  void UpdateDroppedFrames();
-
-  ThreadChecker thread_checker_;
+  void UpdateDroppedFrames_Locked();
 
   std::list<int64_t> frames_to_be_rendered_;
 
   const int max_pending_frames_size_;
   int dropped_frames_ = 0;
-  int64_t seek_to_time_ = 0;  // microseconds
+  std::atomic<int64_t> seek_to_time_{0};  // microseconds
 
+  std::mutex mutex_;
   std::mutex rendered_frames_mutex_;
   std::vector<int64_t> rendered_frames_on_tracker_thread_;  // microseconds
   std::vector<int64_t> rendered_frames_on_decoder_thread_;  // microseconds

--- a/starboard/android/shared/video_frame_tracker_test.cc
+++ b/starboard/android/shared/video_frame_tracker_test.cc
@@ -158,5 +158,28 @@ TEST(VideoFrameTrackerTest, UnorderedInputFramesAreHandled) {
   EXPECT_EQ(video_frame_tracker.UpdateAndGetDroppedFrames(), 0);
 }
 
+TEST(VideoFrameTrackerTest, DoesNotEvictEarlyAtCapacity) {
+  const int kCapacity = 5;
+  VideoFrameTracker video_frame_tracker(kCapacity);
+
+  // Feed kCapacity + 1 frames.
+  // Since we check size > kCapacity before evicting, none of these should be
+  // evicted yet. frames_to_be_rendered_ should contain [10000, 20000, 30000,
+  // 40000, 50000, 60000].
+  for (int i = 1; i <= kCapacity + 1; ++i) {
+    video_frame_tracker.OnInputBuffer(i * 10000);
+  }
+
+  // Simulate that the very first frame (10000) was dropped, and all others
+  // rendered. If 10000 was evicted early (bug), it won't be counted as dropped.
+  // If 10000 was preserved (correct), it will be counted as dropped.
+  for (int i = 2; i <= kCapacity + 1; ++i) {
+    video_frame_tracker.OnFrameRendered(i * 10000);
+  }
+
+  // Should detect exactly 1 dropped frame (the first one).
+  EXPECT_EQ(video_frame_tracker.UpdateAndGetDroppedFrames(), 1);
+}
+
 }  // namespace
 }  // namespace starboard

--- a/starboard/android/shared/video_frame_tracker_test.cc
+++ b/starboard/android/shared/video_frame_tracker_test.cc
@@ -158,22 +158,19 @@ TEST(VideoFrameTrackerTest, UnorderedInputFramesAreHandled) {
   EXPECT_EQ(video_frame_tracker.UpdateAndGetDroppedFrames(), 0);
 }
 
-TEST(VideoFrameTrackerTest, DoesNotEvictEarlyAtCapacity) {
+TEST(VideoFrameTrackerTest, DetectsDroppedFrameAtCapacity) {
   const int kCapacity = 5;
   VideoFrameTracker video_frame_tracker(kCapacity);
 
-  // Feed kCapacity + 1 frames.
-  // Since we check size > kCapacity before evicting, none of these should be
-  // evicted yet. frames_to_be_rendered_ should contain [10000, 20000, 30000,
-  // 40000, 50000, 60000].
-  for (int i = 1; i <= kCapacity + 1; ++i) {
+  // Feed exactly kCapacity frames (up to the limit).
+  // frames_to_be_rendered_ should contain [10000, 20000, 30000, 40000, 50000].
+  for (int i = 1; i <= kCapacity; ++i) {
     video_frame_tracker.OnInputBuffer(i * 10000);
   }
 
   // Simulate that the very first frame (10000) was dropped, and all others
-  // rendered. If 10000 was evicted early (bug), it won't be counted as dropped.
-  // If 10000 was preserved (correct), it will be counted as dropped.
-  for (int i = 2; i <= kCapacity + 1; ++i) {
+  // rendered.
+  for (int i = 2; i <= kCapacity; ++i) {
     video_frame_tracker.OnFrameRendered(i * 10000);
   }
 


### PR DESCRIPTION
Fix a bug where the VideoFrameTracker queue could easily grow over the
limit, triggering overflow evict warnings and causing inaccurate drop
frame reports.

Previously, the tracker registered frames in `WriteInputBuffersInternal` 
as soon as they were submitted to the decoder interface. This caused the 
tracker queue to buffer all frames in the decoder's large backlog 
(`pending_inputs_`), easily exceeding limits and growing up to ~2,400 
frames during startup or seek catch-ups.

Resolve this by moving the tracking entry point to `OnInputBufferQueued`, 
registering frames only when they are successfully queued to the hardware 
`MediaCodec`. This keeps the tracker queue highly stable and strictly 
bounded by the active in-flight hardware/display pipeline capacity 
(InCodec + BufferedOutput + Surface queue), which peaks at ~39 frames in 
practice.

With a guaranteed stable and small queue size:
1. Reduced the tracker capacity limit to a safe 128 (down from 256).
2. Migrated the queue from `std::list` to `std::vector` with pre-allocated 
   memory (reserve), which has the additional benefit of completely 
   eliminating transient heap node allocations (implementing 
   Recommendation 2 of kjyoun.gemini/memory-pressure/allocations.md).

Also reformatted thread-safety documentation to trailing comments 
(mimicking Chromium annotations) and renamed `mutex_` to `state_mutex_` 
for clarity.

Side-by-side Google Benchmark results verify that the enabled 
vector migration yields massive performance gains, especially on Android:

Android (ARM 32-bit, Emulator):
- BM_NormalPlayback:  4790 ns -> 2589 ns (~45.9% faster, 1.85x speedup)
- BM_BFramesPlayback: 1585 ns -> 911 ns  (~42.5% faster, 1.74x speedup)
- BM_Seek:            2103 ns -> 766 ns  (~63.6% faster, 2.75x speedup)

Linux (x86_64 Workstation):
- BM_NormalPlayback:  392 ns  -> 318 ns  (~18.9% faster, 1.23x speedup)
- BM_BFramesPlayback: 128 ns  -> 109 ns  (~14.8% faster, 1.17x speedup)
- BM_Seek:            139 ns  -> 108 ns  (~22.3% faster, 1.28x speedup)

Issue: 517947010

