### PR TITLE
Make --no-decommit-pooled-pages a default JS flag

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -85,6 +85,9 @@ public final class CommandLineOverrideHelper {
         paramOverrides.add("--initial-old-space-size=64");
         paramOverrides.add("--max-old-space-size=512");
 
+        // Disable decommitting pooled pages to prevent virtual memory fragmentation.
+        paramOverrides.add("--no-decommit-pooled-pages");
+
         return paramOverrides;
     }
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -39,9 +39,6 @@ public class JavaSwitches {
   /** flag to enable fast track mic capture. */
   public static final String ENABLE_COBALT_AUDIO_CAPTURE_FAST_TRACK = "EnableCobaltAudioCaptureFastTrack";
 
-  /** V8 flag to disable decommitting pooled pages. */
-  public static final String DISABLE_V8_DECOMMIT_POOLED_PAGES = "DisableV8DecommitPooledPages";
-
   /** flag to tune compositor offscreen interest area size in pixels. */
   public static final String INTEREST_AREA_SIZE_IN_PIXELS = "InterestAreaSizeInPixels";
 
@@ -72,10 +69,6 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_HTTP_CACHE)) {
       extraCommandLineArgs.add("--disable-http-cache");
-    }
-
-    if (javaSwitches.containsKey(JavaSwitches.DISABLE_V8_DECOMMIT_POOLED_PAGES)) {
-      extraCommandLineArgs.add("--js-flags=--no-decommit-pooled-pages");
     }
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_V8_OPTIMIZING_COMPILERS)) {

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -116,6 +116,9 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
       // Enable autoplay video/audio, as Cobalt may launch directly into media
       // playback before user interaction.
       {::switches::kAutoplayPolicy, "no-user-gesture-required"},
+      // Disable decommitting pooled pages to prevent virtual memory
+      // fragmentation.
+      {blink::switches::kJavaScriptFlags, "--no-decommit-pooled-pages"},
   };
   return kCobaltSwitchDefaults;
 }


### PR DESCRIPTION
Relocated the --no-decommit-pooled-pages flag to be a default setting in both Android (CommandLineOverrideHelper.java) and native Starboard platforms (cobalt_switch_defaults_starboard.cc).
Removed the now-obsolete DISABLE_V8_DECOMMIT_POOLED_PAGES Java switch. This change helps prevent virtual memory fragmentation.

Bug: 509933791