### PR TITLE
starboard: Remove sb_is_evergreen_compatible from the codebase

### DIFF
--- a/cobalt/build/configs/starboard.gni
+++ b/cobalt/build/configs/starboard.gni
@@ -20,11 +20,6 @@ declare_args() {
 declare_args() {
   # TODO: b/371241293 - Remove this variable when the hermetic toolchain is setup
   use_custom_libc = false
-
-  # TODO: b/460538637 - Deprecate this variable
-  # Whether this is an Evergreen compatible platform. A compatible platform
-  # can run the elf_loader and launch the Evergreen build.
-  sb_is_evergreen_compatible = is_starboard
 }
 
 if (is_cobalt) {

--- a/cobalt/site/docs/codelabs/starboard_extensions/codelab.md
+++ b/cobalt/site/docs/codelabs/starboard_extensions/codelab.md
@@ -414,7 +414,7 @@ const void* GetPleasantryApi() {
 +#include "starboard/linux/shared/pleasantry.h"
 
  const void* SbSystemGetExtension(const char* name) {
- #if SB_IS(EVERGREEN_COMPATIBLE)
+ #if BUILDFLAG(IS_STARBOARD)
 @@ -74,5 +76,8 @@ const void* SbSystemGetExtension(const char* name) {
      return use_ffmpeg_demuxer ? starboard::shared::ffmpeg::GetFFmpegDemuxerApi()
                                : NULL;

--- a/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_overview.md
+++ b/cobalt/site/docs/gen/starboard/doc/evergreen/cobalt_evergreen_overview.md
@@ -108,10 +108,7 @@ changes are needed by the partner here.
 However, a few small changes are needed in the partner's port, which is used to
 build the partner-built components, to make it compatible with Evergreen.
 
-First, partners should set `sb_is_evergreen_compatible = true` in the platform's
-`platform_configuration/configuration.gni` file. (Please DO NOT set
-`sb_is_evergreen` to `true`, as this should only be set in the Evergreen
-platforms that are maintained by Google and used to build Cobalt core.)
+First, ensure that your platform is built with Starboard enabled (`is_starboard = true`, which is the default for all Starboard platforms). Please DO NOT set `sb_is_evergreen` to `true`, as this should only be set in the Evergreen platforms that are maintained by Google and used to build Cobalt core.
 
 Second, in the platform's `toolchain/BUILD.gn` file partners should copy their
 "starboard" toolchain to add a "native_target" toolchain that is identical
@@ -294,9 +291,7 @@ In order to verify the platform requirements you should run the
 `nplb_evergreen_compat_tests`. These tests ensure that the platform is
 configured appropriately for Evergreen.
 
-To enable the test, set the `sb_is_evergreen_compatible` GN variable to `true`
-in the platform's `configuration.gni`. For more details please take a look at
-the Raspberry Pi 2 GN files.
+These tests are enabled automatically for all Starboard platforms (`is_starboard = true`).
 
 There is a reference implementation available for Raspberry Pi 2 with
 instructions available [here](cobalt_evergreen_reference_port_raspi2.md).

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -62,7 +62,7 @@ if (!is_cobalt) {
     }
 
     if (!sb_is_evergreen) {
-      if (sb_is_evergreen_compatible) {
+      if (is_starboard) {
         deps += [
           "//starboard/elf_loader:elf_loader_test_install($starboard_toolchain)",
           "//starboard/loader_app:installation_manager_test_install($starboard_toolchain)",
@@ -89,7 +89,7 @@ if (!is_cobalt) {
       ":starboard_group",
       "//starboard/tools:build_app_launcher_zip",
     ]
-    if (sb_is_evergreen_compatible) {
+    if (is_starboard) {
       deps += [
         "//starboard/loader_app($starboard_toolchain)",
         "//third_party/crashpad/crashpad/handler:crashpad_handler($native_toolchain)",
@@ -259,7 +259,7 @@ if (current_toolchain == starboard_toolchain) {
     if (sb_filter_based_player) {
       deps += [ "//starboard/shared/starboard/player/filter/testing:player_filter_tests" ]
     }
-    if (sb_is_evergreen_compatible) {
+    if (is_starboard) {
       deps += [
         "//starboard/elf_loader:elf_loader_test",
         "//starboard/extension:extension_test",

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -322,7 +322,7 @@ static_library("starboard_platform") {
     ]
   }
 
-  if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+  if (is_starboard && current_toolchain == starboard_toolchain) {
     sources -= [
       "crash_handler.cc",
       "crash_handler.h",
@@ -365,7 +365,7 @@ static_library("starboard_base_symbolize") {
     "//starboard:starboard_headers_only",
     "//starboard/common:common_headers_only",
   ]
-  if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+  if (is_starboard && current_toolchain == starboard_toolchain) {
     public_deps = [ "//starboard/elf_loader:evergreen_info" ]
   }
 

--- a/starboard/android/shared/install_target.gni
+++ b/starboard/android/shared/install_target.gni
@@ -88,7 +88,7 @@ template("install_target") {
       "-P",
       "cobaltTarget=$installable_target_name",
       "-P",
-      "evergreenCompatible=$sb_is_evergreen_compatible",
+      "evergreenCompatible=$is_starboard",
       "assembleCobalt_$gradle_build_type",
       "-Dorg.gradle.workers.max=$num_gradle_workers",
       "-Dorg.gradle.workers.parallel=$use_parallel_build",

--- a/starboard/build/config/BUILD.gn
+++ b/starboard/build/config/BUILD.gn
@@ -49,10 +49,6 @@ config("starboard") {
       defines += [ "SB_IS_EVERGREEN=1" ]
     }
 
-    if (sb_is_evergreen_compatible) {
-      defines += [ "SB_IS_EVERGREEN_COMPATIBLE=1" ]
-    }
-
     if (sb_evergreen_compatible_use_libunwind) {
       defines += [ "SB_IS_EVERGREEN_COMPATIBLE_LIBUNWIND=1" ]
     }

--- a/starboard/build/config/build_assertions.gni
+++ b/starboard/build/config/build_assertions.gni
@@ -15,9 +15,6 @@
 # Use this file to ensure no conflicting GN build arguments are set for the
 # platform being built.
 
-assert(!(sb_is_evergreen && sb_is_evergreen_compatible),
-       "Cannot be both evergreen and evergreen compatible.")
-
 assert(
-    !sb_evergreen_compatible_use_libunwind || sb_is_evergreen_compatible,
+    !sb_evergreen_compatible_use_libunwind || is_starboard,
     "Can only specify sb_evergreen_compatible_use_libunwind on an evergreen-compatible platform.")

--- a/starboard/common/log.h
+++ b/starboard/common/log.h
@@ -144,8 +144,7 @@ class VoidifyStream {
 #define SB_LAZY_STREAM(stream, condition) \
   !(condition) ? (void)0 : ::starboard::LogMessageVoidify() & (stream)
 
-#if SB_LOGGING_IS_OFFICIAL_BUILD && !SB_IS(MODULAR) && \
-    !SB_IS(EVERGREEN_COMPATIBLE)
+#if SB_LOGGING_IS_OFFICIAL_BUILD && !SB_IS(MODULAR) && !BUILDFLAG(IS_STARBOARD)
 #define SB_LOG_IS_ON(severity)                                               \
   ((::starboard::SB_LOG_##severity >= ::starboard::SB_LOG_FATAL)             \
        ? ((::starboard::SB_LOG_##severity) >= ::starboard::GetMinLogLevel()) \

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -311,7 +311,7 @@ static_library("starboard_platform_sources") {
     ]
   }
 
-  if (!sb_is_modular || sb_is_evergreen_compatible) {
+  if (!sb_is_modular || is_starboard) {
     sources += [
       "main_rdk.cc",
     ]
@@ -376,7 +376,7 @@ group("loader_app_rdk_plugin") {
   data_deps = [":loader_app($starboard_toolchain)"]
 }
 
-if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+if (is_starboard && current_toolchain == starboard_toolchain) {
   if (starboard_level_final_executable_type == "shared_library") {
     group("loader_app") {
       deps = [ "//starboard/loader_app:loader_app" ]

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/platform_configuration/configuration.gni
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/platform_configuration/configuration.gni
@@ -55,6 +55,6 @@ speed_config_path =
 size_config_path =
   "$rdk_starboard_root/third_party/starboard/rdk/shared/platform_configuration:size"
 
-if (sb_is_evergreen_compatible) {
+if (is_starboard) {
   sb_evergreen_compatible_use_libunwind = true
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
@@ -42,7 +42,7 @@
 
 #include "third_party/starboard/rdk/shared/application_rdk.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/common/command_line.h"
 #include "starboard/common/paths.h"
 #include "starboard/crashpad_wrapper/wrapper.h"

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
@@ -44,14 +44,14 @@
 #include "third_party/starboard/rdk/shared/accessibility_extension.h"
 #include "third_party/starboard/rdk/shared/configuration.h"
 #include "third_party/starboard/rdk/shared/platform_service.h"
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_config.h"
 #include "starboard/shared/starboard/crash_handler.h"
 #include "starboard/shared/starboard/loader_app_metrics.h"
 #endif
 
 const void* SbSystemGetExtension(const char* name) {
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
   const elf_loader::EvergreenConfig* evergreen_config =
       elf_loader::EvergreenConfig::GetInstance();
   if (evergreen_config != NULL &&

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_path.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_path.cc
@@ -27,14 +27,14 @@
 #include "starboard/configuration_constants.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_config.h"
 #endif
 #include "starboard/shared/starboard/get_home_directory.h"
 
 namespace {
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 // May override the content path if there is EvergreenConfig published.
 // The override allows for switching to different content paths based
 // on the Evergreen binary executed.
@@ -274,7 +274,7 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
       if (!GetContentDirectory(path, kPathSize)){
         return false;
       }
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
       if (!GetEvergreenContentPathOverride(path, kPathSize)) {
         return false;
       }
@@ -317,7 +317,7 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
 
     case kSbSystemPathFontConfigurationDirectory:
     case kSbSystemPathFontDirectory:
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
       if (!GetContentDirectory(path, kPathSize)) {
         return false;
       }

--- a/starboard/crashpad_wrapper/BUILD.gn
+++ b/starboard/crashpad_wrapper/BUILD.gn
@@ -16,7 +16,7 @@
 # depend on this common target, and not any of the specific "starboard_platform"
 # targets.
 
-if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+if (is_starboard && current_toolchain == starboard_toolchain) {
   static_library("crashpad_wrapper") {
     sources = [
       "wrapper.cc",

--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -124,7 +124,7 @@ bool InitializeCrashpadDatabase(const base::FilePath database_directory_path) {
 }
 
 std::string GetProductName() {
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
   return "Cobalt_Evergreen";
 #else
   return "Cobalt";

--- a/starboard/doc/evergreen/cobalt_evergreen_overview.md
+++ b/starboard/doc/evergreen/cobalt_evergreen_overview.md
@@ -105,10 +105,7 @@ changes are needed by the partner here.
 However, a few small changes are needed in the partner's port, which is used to
 build the partner-built components, to make it compatible with Evergreen.
 
-First, partners should set `sb_is_evergreen_compatible = true` in the platform's
-`platform_configuration/configuration.gni` file. (Please DO NOT set
-`sb_is_evergreen` to `true`, as this should only be set in the Evergreen
-platforms that are maintained by Google and used to build Cobalt core.)
+First, ensure that your platform is built with Starboard enabled (`is_starboard = true`, which is the default for all Starboard platforms). Please DO NOT set `sb_is_evergreen` to `true`, as this should only be set in the Evergreen platforms that are maintained by Google and used to build Cobalt core.
 
 Second, in the platform's `toolchain/BUILD.gn` file partners should copy their
 "starboard" toolchain to add a "native_target" toolchain that is identical
@@ -291,9 +288,7 @@ In order to verify the platform requirements you should run the
 `nplb_evergreen_compat_tests`. These tests ensure that the platform is
 configured appropriately for Evergreen.
 
-To enable the test, set the `sb_is_evergreen_compatible` GN variable to `true`
-in the platform's `configuration.gni`. For more details please take a look at
-the Raspberry Pi 2 GN files.
+These tests are enabled automatically for all Starboard platforms (`is_starboard = true`).
 
 There is a reference implementation available for Raspberry Pi 2 with
 instructions available [here](cobalt_evergreen_reference_port_raspi2.md).

--- a/starboard/elf_loader/BUILD.gn
+++ b/starboard/elf_loader/BUILD.gn
@@ -84,7 +84,7 @@ if (current_toolchain == starboard_toolchain) {
       "//starboard/content/fonts:copy_font_data",
     ]
 
-    if (sb_is_evergreen_compatible && use_crashpad) {
+    if (is_starboard && use_crashpad) {
       deps += [ "//starboard/crashpad_wrapper" ]
     } else {
       deps += [ "//starboard/crashpad_wrapper:wrapper_stub" ]

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -30,7 +30,7 @@ group("starboard_platform") {
     "//third_party/opus",
   ]
 
-  if (sb_is_evergreen_compatible) {
+  if (is_starboard) {
     public_deps += [
       "//starboard/elf_loader:constants",
       "//starboard/elf_loader:evergreen_config",
@@ -52,7 +52,7 @@ static_library("starboard_base_symbolize") {
     "//starboard:starboard_headers_only",
     "//starboard/common:common_headers_only",
   ]
-  if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+  if (is_starboard && current_toolchain == starboard_toolchain) {
     public_deps = [ "//starboard/elf_loader:evergreen_info" ]
   }
 
@@ -220,7 +220,7 @@ static_library("starboard_platform_sources") {
 
   sources -= [ "//starboard/shared/starboard/player/player_set_bounds.cc" ]
 
-  if (sb_is_evergreen_compatible) {
+  if (is_starboard) {
     sources += [
       "//starboard/shared/starboard/loader_app_metrics.cc",
       "//starboard/shared/starboard/loader_app_metrics.h",

--- a/starboard/linux/shared/platform_service.cc
+++ b/starboard/linux/shared/platform_service.cc
@@ -27,9 +27,9 @@
 #include "starboard/linux/shared/pre_app_recommendation_service.h"
 #include "starboard/linux/shared/soft_mic_platform_service.h"
 #include "starboard/shared/starboard/application.h"
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_config.h"
-#endif  // SB_IS(EVERGREEN_COMPATIBLE)
+#endif  // BUILDFLAG(IS_STARBOARD)
 
 namespace starboard {
 

--- a/starboard/linux/shared/system_get_extensions.cc
+++ b/starboard/linux/shared/system_get_extensions.cc
@@ -27,7 +27,7 @@
 #include "starboard/shared/posix/free_space.h"
 #include "starboard/shared/posix/memory_mapped_file.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_config.h"
 #include "starboard/extension/loader_app_metrics.h"
 #include "starboard/shared/starboard/loader_app_metrics.h"
@@ -41,7 +41,7 @@
 #endif
 
 const void* SbSystemGetExtension(const char* name) {
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
   const elf_loader::EvergreenConfig* evergreen_config =
       elf_loader::EvergreenConfig::GetInstance();
   if (evergreen_config != NULL &&
@@ -72,7 +72,7 @@ const void* SbSystemGetExtension(const char* name) {
   if (strcmp(name, kCobaltExtensionFreeSpaceName) == 0) {
     return starboard::GetFreeSpaceApi();
   }
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
   if (strcmp(name, kStarboardExtensionLoaderAppMetricsName) == 0) {
     return starboard::GetLoaderAppMetricsApi();
   }

--- a/starboard/linux/shared/system_get_path.cc
+++ b/starboard/linux/shared/system_get_path.cc
@@ -27,7 +27,7 @@
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
 #include "starboard/configuration_constants.h"
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_config.h"
 #endif
 #include "starboard/shared/starboard/get_home_directory.h"
@@ -109,7 +109,7 @@ bool GetExecutablePath(char* out_path, int path_size) {
   return true;
 }
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 // May override the content path if there is EvergreenConfig published.
 // The override allows for switching to different content paths based
 // on the Evergreen binary executed.
@@ -211,7 +211,7 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
       if (!GetContentDirectory(path.data(), kPathSize)) {
         return false;
       }
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
       if (!GetEvergreenContentPathOverride(path.data(), kPathSize)) {
         return false;
       }
@@ -256,7 +256,7 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
 
     case kSbSystemPathFontConfigurationDirectory:
     case kSbSystemPathFontDirectory:
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
       if (!GetContentDirectory(path.data(), kPathSize)) {
         return false;
       }

--- a/starboard/linux/x64x11/run_starboard_main.cc
+++ b/starboard/linux/x64x11/run_starboard_main.cc
@@ -23,7 +23,7 @@
 #include "starboard/shared/signal/suspend_signals.h"
 #include "starboard/shared/starboard/link_receiver.h"
 #include "starboard/shared/x11/application_x11.h"
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/common/command_line.h"
 #include "starboard/common/paths.h"
 #include "starboard/elf_loader/elf_loader_constants.h"

--- a/starboard/loader_app/BUILD.gn
+++ b/starboard/loader_app/BUILD.gn
@@ -23,7 +23,7 @@ _common_loader_app_sources = [
   "system_get_extension_shim.h",
 ]
 
-if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+if (is_starboard && current_toolchain == starboard_toolchain) {
   group("common_loader_app_dependencies") {
     public_deps = [
       ":installation_manager",
@@ -56,7 +56,7 @@ static_library("record_loader_app_status") {
   deps = [ "//starboard:starboard_group" ]
 }
 
-if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+if (is_starboard && current_toolchain == starboard_toolchain) {
   source_set("loader_app_sources") {
     sources = _common_loader_app_sources
     deps = [
@@ -183,7 +183,7 @@ static_library("installation_manager") {
   ]
 }
 
-if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+if (is_starboard && current_toolchain == starboard_toolchain) {
   source_set("installation_manager_test") {
     testonly = true
     sources = [
@@ -219,7 +219,7 @@ static_library("slot_management") {
     "//starboard/elf_loader:sabi_string",
   ]
 
-  if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain &&
+  if (is_starboard && current_toolchain == starboard_toolchain &&
       use_crashpad) {
     deps += [ "//starboard/crashpad_wrapper" ]
   } else {
@@ -256,7 +256,7 @@ static_library("pending_restart") {
   public_deps = [ "//starboard:starboard_headers_only" ]
 }
 
-if (sb_is_evergreen_compatible && current_toolchain == starboard_toolchain) {
+if (is_starboard && current_toolchain == starboard_toolchain) {
   static_library("memory_tracker_thread") {
     sources = [
       "memory_tracker_thread.cc",

--- a/starboard/loader_app/installation_manager_test.cc
+++ b/starboard/loader_app/installation_manager_test.cc
@@ -28,7 +28,7 @@
 #include "starboard/loader_app/installation_store.pb.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 
 #define NUMBER_INSTALLS_PARAMS ::testing::Values(2, 3, 4, 5, 6)
 
@@ -646,4 +646,4 @@ INSTANTIATE_TEST_CASE_P(NumberOfMaxInstallations,
 
 }  // namespace loader_app
 
-#endif  // SB_IS(EVERGREEN_COMPATIBLE)
+#endif  // BUILDFLAG(IS_STARBOARD)

--- a/starboard/loader_app/pending_restart_test.cc
+++ b/starboard/loader_app/pending_restart_test.cc
@@ -18,7 +18,7 @@
 #include "starboard/loader_app/installation_manager.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 namespace loader_app {
 namespace {
 
@@ -48,4 +48,4 @@ TEST_F(PendingRestartTest, PendingRestart) {
 }  // namespace
 
 }  // namespace loader_app
-#endif  //  SB_IS(EVERGREEN_COMPATIBLE)
+#endif  //  BUILDFLAG(IS_STARBOARD)

--- a/starboard/loader_app/reset_evergreen_update_test.cc
+++ b/starboard/loader_app/reset_evergreen_update_test.cc
@@ -23,7 +23,7 @@
 #include "starboard/configuration_constants.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 
 namespace loader_app {
 namespace {
@@ -92,4 +92,4 @@ TEST(ResetEvergreenUpdateTest, TestSunnyDaySubdir) {
 }  // namespace
 }  // namespace loader_app
 
-#endif  //  SB_IS(EVERGREEN_COMPATIBLE)
+#endif  //  BUILDFLAG(IS_STARBOARD)

--- a/starboard/loader_app/slot_management_test.cc
+++ b/starboard/loader_app/slot_management_test.cc
@@ -35,7 +35,7 @@
 #include "starboard/loader_app/read_evergreen_version.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 
 namespace loader_app {
 namespace {
@@ -496,4 +496,4 @@ INSTANTIATE_TEST_CASE_P(SlotManagementTests,
 
 }  // namespace
 }  // namespace loader_app
-#endif  // #if SB_IS(EVERGREEN_COMPATIBLE)
+#endif  // #if BUILDFLAG(IS_STARBOARD)

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -371,7 +371,7 @@ test("nplb") {
 
   data_deps = [ "//starboard/nplb/testdata/file_tests:nplb_file_tests_data" ]
 
-  if (sb_is_evergreen_compatible) {
+  if (is_starboard) {
     sources += [
       "nplb_evergreen_compat_tests/checks.h",
       "nplb_evergreen_compat_tests/executable_memory_test.cc",

--- a/starboard/nplb/nplb_evergreen_compat_tests/checks.h
+++ b/starboard/nplb/nplb_evergreen_compat_tests/checks.h
@@ -17,7 +17,7 @@
 
 #include "starboard/configuration.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 
 #if SB_API_VERSION < 16
 #if !SB_CAN(MAP_EXECUTABLE_MEMORY)
@@ -25,5 +25,5 @@
 #endif
 #endif
 
-#endif  // SB_IS(EVERGREEN_COMPATIBLE)
+#endif  // BUILDFLAG(IS_STARBOARD)
 #endif  // STARBOARD_NPLB_NPLB_EVERGREEN_COMPAT_TESTS_CHECKS_H_

--- a/starboard/nplb/nplb_evergreen_compat_tests/crashpad_config_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/crashpad_config_test.cc
@@ -23,7 +23,7 @@
 #include "starboard/system.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if !SB_IS(EVERGREEN_COMPATIBLE)
+#if !BUILDFLAG(IS_STARBOARD)
 #error These tests apply only to EVERGREEN_COMPATIBLE platforms.
 #endif
 

--- a/starboard/nplb/nplb_evergreen_compat_tests/executable_memory_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/executable_memory_test.cc
@@ -19,7 +19,7 @@
 #include "starboard/nplb/nplb_evergreen_compat_tests/checks.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if !SB_IS(EVERGREEN_COMPATIBLE)
+#if !BUILDFLAG(IS_STARBOARD)
 #error These tests apply only to EVERGREEN_COMPATIBLE platforms.
 #endif
 

--- a/starboard/nplb/nplb_evergreen_compat_tests/fonts_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/fonts_test.cc
@@ -22,7 +22,7 @@
 #include "starboard/system.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if !SB_IS(EVERGREEN_COMPATIBLE)
+#if !BUILDFLAG(IS_STARBOARD)
 #error These tests apply only to EVERGREEN_COMPATIBLE platforms.
 #endif
 

--- a/starboard/nplb/nplb_evergreen_compat_tests/loader_app_metrics_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/loader_app_metrics_test.cc
@@ -18,7 +18,7 @@
 #include "starboard/system.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if !SB_IS(EVERGREEN_COMPATIBLE)
+#if !BUILDFLAG(IS_STARBOARD)
 #error These tests apply only to EVERGREEN_COMPATIBLE platforms.
 #endif
 

--- a/starboard/nplb/nplb_evergreen_compat_tests/max_file_name_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/max_file_name_test.cc
@@ -16,7 +16,7 @@
 #include "starboard/configuration_constants.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if !SB_IS(EVERGREEN_COMPATIBLE)
+#if !BUILDFLAG(IS_STARBOARD)
 #error These tests apply only to EVERGREEN_COMPATIBLE platforms.
 #endif
 

--- a/starboard/nplb/nplb_evergreen_compat_tests/sabi_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/sabi_test.cc
@@ -21,7 +21,7 @@
 #include "starboard/nplb/nplb_evergreen_compat_tests/checks.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if !SB_IS(EVERGREEN_COMPATIBLE)
+#if !BUILDFLAG(IS_STARBOARD)
 #error These tests apply only to EVERGREEN_COMPATIBLE platforms.
 #endif
 

--- a/starboard/nplb/nplb_evergreen_compat_tests/storage_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/storage_test.cc
@@ -26,7 +26,7 @@
 #include "starboard/system.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#if !SB_IS(EVERGREEN_COMPATIBLE)
+#if !BUILDFLAG(IS_STARBOARD)
 #error These tests apply only to EVERGREEN_COMPATIBLE platforms.
 #endif
 

--- a/starboard/raspi/2/BUILD.gn
+++ b/starboard/raspi/2/BUILD.gn
@@ -26,7 +26,7 @@ static_library("starboard_platform") {
     deps = [ "//third_party/llvm-project/libunwind:unwind_starboard" ]
   }
 
-  if (sb_is_evergreen_compatible) {
+  if (is_starboard) {
     public_deps += [
       "//starboard/elf_loader:constants",
       "//starboard/elf_loader:evergreen_config",

--- a/starboard/raspi/shared/system_get_extensions.cc
+++ b/starboard/raspi/shared/system_get_extensions.cc
@@ -23,7 +23,7 @@
 #include "starboard/raspi/shared/configuration.h"
 #include "starboard/raspi/shared/graphics.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_config.h"
 #include "starboard/extension/loader_app_metrics.h"
 #include "starboard/shared/starboard/loader_app_metrics.h"
@@ -35,7 +35,7 @@
 #endif
 
 const void* SbSystemGetExtension(const char* name) {
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
   const elf_loader::EvergreenConfig* evergreen_config =
       elf_loader::EvergreenConfig::GetInstance();
   if (evergreen_config != NULL &&
@@ -58,7 +58,7 @@ const void* SbSystemGetExtension(const char* name) {
     return starboard::GetCrashHandlerApi();
   }
 #endif
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
   if (strcmp(name, kStarboardExtensionLoaderAppMetricsName) == 0) {
     return starboard::GetLoaderAppMetricsApi();
   }

--- a/starboard/shared/modular/BUILD.gn
+++ b/starboard/shared/modular/BUILD.gn
@@ -14,8 +14,7 @@
 
 # TODO: b/315170518 - Revert to static library after fixing
 # symbol visibility issues for windows based modular platform builds.
-if ((sb_is_modular || is_starboard) &&
-    current_toolchain == starboard_toolchain) {
+if (is_starboard && current_toolchain == starboard_toolchain) {
   source_set("starboard_layer_posix_abi_wrappers") {
     sources = [
       "starboard_layer_posix__Exit_abi_wrappers.cc",

--- a/starboard/shared/modular/BUILD.gn
+++ b/starboard/shared/modular/BUILD.gn
@@ -14,7 +14,7 @@
 
 # TODO: b/315170518 - Revert to static library after fixing
 # symbol visibility issues for windows based modular platform builds.
-if ((sb_is_modular || sb_is_evergreen_compatible) &&
+if ((sb_is_modular || is_starboard) &&
     current_toolchain == starboard_toolchain) {
   source_set("starboard_layer_posix_abi_wrappers") {
     sources = [

--- a/starboard/shared/signal/suspend_signals.cc
+++ b/starboard/shared/signal/suspend_signals.cc
@@ -26,9 +26,9 @@
 #include "starboard/shared/starboard/application.h"
 #include "starboard/system.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#if BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
 #include "starboard/loader_app/pending_restart.h"  // nogncheck
-#endif  // SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#endif  // BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
 
 namespace starboard {
 

--- a/starboard/shared/signal/system_request_freeze.cc
+++ b/starboard/shared/signal/system_request_freeze.cc
@@ -19,9 +19,9 @@
 #include "starboard/shared/signal/signal_internal.h"
 #include "starboard/shared/starboard/application.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#if BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
 #include "starboard/loader_app/pending_restart.h"
-#endif  // SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#endif  // BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
 
 void FreezeDone(void* /*context*/) {
   // Stop all thread execution after fully transitioning into Frozen.
@@ -33,7 +33,7 @@ void FreezeDone(void* /*context*/) {
 }
 
 void SbSystemRequestFreeze() {
-#if SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#if BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
   if (::loader_app::IsPendingRestart()) {
     SbLogRawFormatF("\nPending update restart . Stopping.\n");
     SbLogFlush();
@@ -45,5 +45,5 @@ void SbSystemRequestFreeze() {
 #else
   // Let the platform decide if directly transit into Frozen.
   starboard::Application::Get()->Freeze(NULL, &FreezeDone);
-#endif  // SB_IS(EVERGREEN_COMPATIBLE) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
+#endif  // BUILDFLAG(IS_STARBOARD) && !SB_IS(EVERGREEN_COMPATIBLE_LITE)
 }

--- a/starboard/shared/starboard/log_raw_dump_stack.cc
+++ b/starboard/shared/starboard/log_raw_dump_stack.cc
@@ -14,7 +14,7 @@
 
 #include "starboard/common/log.h"
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_info.h"  // nogncheck
 #endif
 #include "starboard/system.h"
@@ -27,7 +27,7 @@ void SbLogRawDumpStack(int frames_to_skip) {
   void* stack[256];
   int count = SbSystemGetStack(stack, SB_ARRAY_SIZE_INT(stack));
 
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
   EvergreenInfo evergreen_info;
   bool valid_evergreen_info = GetEvergreenInfo(&evergreen_info);
 #endif
@@ -37,7 +37,7 @@ void SbLogRawDumpStack(int frames_to_skip) {
     void* address = stack[i];
     bool result =
         SbSystemSymbolize(stack[i], symbol, SB_ARRAY_SIZE_INT(symbol));
-#if SB_IS(EVERGREEN_COMPATIBLE)
+#if BUILDFLAG(IS_STARBOARD)
     if (!result && valid_evergreen_info &&
         IS_EVERGREEN_ADDRESS(stack[i], evergreen_info)) {
       address = reinterpret_cast<void*>(reinterpret_cast<uint64_t>(stack[i]) -


### PR DESCRIPTION
Historically,  sb_is_evergreen_compatible  was used to identify platforms capable of running the  elf_loader  and launching the Evergreen build. Starting from Cobalt 26+, all Starboard platforms are Evergreen-compatible by default.
  
  As a result, this variable has become redundant and has been replaced by  is_starboard  in build files and  BUILDFLAG(IS_STARBOARD)  in C++ code. This simplifies the configuration surface and aligns with the modern Cobalt architecture.

Issue: 460538637