### PR TITLE
Reland #10539 - 'Implement base MemoryContext TLS mapping and Allocator Observers' 

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -2448,6 +2448,10 @@ component("base") {
 
   if (is_cobalt) {
     sources += [
+      "memory/cobalt_memory_context.cc",
+      "memory/cobalt_memory_context.h",
+      "memory/cobalt_memory_attribution_observer.cc",
+      "memory/cobalt_memory_attribution_observer.h",
       "system/sys_info_starboard.cc",
       "system/sys_info_starboard.h",
     ]

--- a/base/memory/cobalt_memory_attribution_observer.cc
+++ b/base/memory/cobalt_memory_attribution_observer.cc
@@ -1,0 +1,118 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base/memory/cobalt_memory_attribution_observer.h"
+
+#ifdef UNSAFE_BUFFERS_BUILD
+// TODO(crbug.com/40284755): Remove this and spanify to fix the errors.
+#pragma allow_unsafe_buffers
+#endif
+
+#include <string_view>
+
+#include "base/no_destructor.h"
+#include "base/threading/platform_thread.h"
+
+#include <pthread.h>
+
+namespace base {
+namespace memory {
+
+namespace {
+// Strictly lock-free, allocation-free OS thread name reader
+const char* GetCurrentOSThreadName() {
+  static thread_local char tls_thread_name[32] = {0};
+  if (tls_thread_name[0] == '\0') {
+#if BUILDFLAG(IS_ANDROID)
+    if (__builtin_available(android 26, *)) {
+      if (pthread_getname_np(pthread_self(), tls_thread_name, sizeof(tls_thread_name)) != 0) {
+        tls_thread_name[0] = '\0';
+        return nullptr;
+      }
+    } else {
+      return nullptr;
+    }
+#else
+    if (pthread_getname_np(pthread_self(), tls_thread_name, sizeof(tls_thread_name)) != 0) {
+      tls_thread_name[0] = '\0';
+      return nullptr;
+    }
+#endif
+  }
+  return tls_thread_name;
+}
+}  // namespace
+
+// static
+CobaltMemoryAttributionObserver* CobaltMemoryAttributionObserver::Get() {
+  static base::NoDestructor<CobaltMemoryAttributionObserver> observer;
+  return observer.get();
+}
+
+CobaltMemoryAttributionObserver::CobaltMemoryAttributionObserver() {
+  for (size_t i = 0; i < static_cast<size_t>(MemoryContext::kCount); ++i) {
+    counters_[i].value.store(0, std::memory_order_relaxed);
+  }
+  // Ensure ThreadLocalStorage is fully initialized and warmed up before the
+  // observer hooks into Dispatcher, preventing reentrancy crashes during the
+  // first allocation.
+  GetCurrentMemoryContext();
+}
+
+void CobaltMemoryAttributionObserver::OnAllocation(
+    const base::allocator::dispatcher::AllocationNotificationData& notification_data) {
+  static thread_local bool g_in_allocation_hook = false;
+  if (g_in_allocation_hook) {
+    return;
+  }
+  g_in_allocation_hook = true;
+
+  MemoryContext current_context = GetCurrentMemoryContext();
+  if (current_context == MemoryContext::kUnknown) {
+    const char* thread_name = GetCurrentOSThreadName();
+    if (thread_name) {
+      std::string_view thread_view(thread_name);
+      if (thread_view.find("V8") != std::string_view::npos ||
+          thread_view.find("GC") != std::string_view::npos ||
+          thread_view.find("Compiler") != std::string_view::npos ||
+          thread_view.find("wasm") != std::string_view::npos) {
+        current_context = MemoryContext::kScript;
+      } else if (thread_view.find("Skia") != std::string_view::npos ||
+                 thread_view.find("Compositor") != std::string_view::npos ||
+                 thread_view.find("Raster") != std::string_view::npos) {
+        current_context = MemoryContext::kGraphics;
+      } else if (thread_view.find("Network") != std::string_view::npos ||
+                 thread_view.find("URL") != std::string_view::npos ||
+                 thread_view.find("CrNetwork") != std::string_view::npos) {
+        current_context = MemoryContext::kNetwork;
+      } else if (thread_view.find("Media") != std::string_view::npos ||
+                 thread_view.find("Audio") != std::string_view::npos ||
+                 thread_view.find("Video") != std::string_view::npos ||
+                 thread_view.find("Decoder") != std::string_view::npos ||
+                 thread_view.find("player_worker") != std::string_view::npos) {
+        current_context = MemoryContext::kMedia;
+      }
+    }
+  }
+  if (current_context >= MemoryContext::kCount) {
+    current_context = MemoryContext::kUnknown;
+  }
+  counters_[static_cast<size_t>(current_context)].value.fetch_add(
+      notification_data.size(), std::memory_order_relaxed);
+
+  g_in_allocation_hook = false;
+}
+
+}  // namespace memory
+}  // namespace base

--- a/base/memory/cobalt_memory_attribution_observer.h
+++ b/base/memory/cobalt_memory_attribution_observer.h
@@ -1,0 +1,62 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef BASE_MEMORY_COBALT_MEMORY_ATTRIBUTION_OBSERVER_H_
+#define BASE_MEMORY_COBALT_MEMORY_ATTRIBUTION_OBSERVER_H_
+
+#include <atomic>
+#include <cstdint>
+#include "base/allocator/dispatcher/notification_data.h"
+#include "base/allocator/dispatcher/subsystem.h"
+#include "base/base_export.h"
+#include "base/memory/cobalt_memory_context.h"
+#include "base/no_destructor.h"
+
+namespace base {
+namespace memory {
+
+// Observer for PartitionAlloc allocations via base::allocator::dispatcher::Dispatcher.
+// NOTE: This observer strictly tracks cumulative allocation volume (churn) per MemoryContext.
+// It cannot track net memory usage because Dispatcher::OnFree only provides a void* address
+// without allocation size or context, making OnFree a no-op.
+class BASE_EXPORT CobaltMemoryAttributionObserver {
+ public:
+  struct AlignedCounter {
+    // Align to 64 bytes (standard cache line) to eliminate false sharing across CPU cache lines.
+    alignas(64) std::atomic<uint64_t> value{0};
+  };
+
+  static CobaltMemoryAttributionObserver* Get();
+
+  CobaltMemoryAttributionObserver(const CobaltMemoryAttributionObserver&) = delete;
+  CobaltMemoryAttributionObserver& operator=(const CobaltMemoryAttributionObserver&) = delete;
+
+  void OnAllocation(const base::allocator::dispatcher::AllocationNotificationData& notification_data);
+  // No-op. Dispatcher does not provide size or context on free.
+  void OnFree(const base::allocator::dispatcher::FreeNotificationData& notification_data) {}
+
+  AlignedCounter* GetCounters() { return counters_; }
+
+ private:
+  friend class base::NoDestructor<CobaltMemoryAttributionObserver>;
+  CobaltMemoryAttributionObserver();
+  ~CobaltMemoryAttributionObserver() = default;
+
+  AlignedCounter counters_[static_cast<size_t>(MemoryContext::kCount)];
+};
+
+}  // namespace memory
+}  // namespace base
+
+#endif  // BASE_MEMORY_COBALT_MEMORY_ATTRIBUTION_OBSERVER_H_

--- a/base/memory/cobalt_memory_context.cc
+++ b/base/memory/cobalt_memory_context.cc
@@ -1,0 +1,103 @@
+// Copyright 2026 The Chromium Authors and Cobalt Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#include "base/memory/cobalt_memory_context.h"
+
+#include "base/allocator/dispatcher/tls.h"
+#include "base/no_destructor.h"
+#include "base/notreached.h"
+
+namespace base {
+namespace memory {
+
+// Weak symbol to allow the linker to merge this TLS getter across base and copied_base.
+#if defined(__GNUC__)
+__attribute__((weak))
+#endif
+MemoryContext* GetThreadLocalMemoryContext();
+
+#if defined(__GNUC__)
+__attribute__((weak))
+#endif
+MemoryContext* GetThreadLocalMemoryContext() {
+#if USE_LOCAL_TLS_EMULATION()
+  static base::NoDestructor<
+      base::allocator::dispatcher::ThreadLocalStorage<MemoryContext>>
+      thread_local_data("cobalt_memory_context");
+  return thread_local_data->GetThreadLocalData();
+#else
+  static thread_local MemoryContext g_current_memory_context = MemoryContext::kUnknown;
+  return &g_current_memory_context;
+#endif
+}
+
+MemoryContext GetCurrentMemoryContext() {
+  return *GetThreadLocalMemoryContext();
+}
+
+void SetCurrentMemoryContext(MemoryContext context) {
+  *GetThreadLocalMemoryContext() = context;
+}
+
+ScopedMemoryContext::ScopedMemoryContext(MemoryContext context) {
+  MemoryContext* current = GetThreadLocalMemoryContext();
+  prev_context_ = *current;
+  *current = context;
+}
+
+ScopedMemoryContext::~ScopedMemoryContext() {
+  *GetThreadLocalMemoryContext() = prev_context_;
+}
+
+std::string_view ContextToString(MemoryContext context) {
+  switch (context) {
+    case MemoryContext::kUnknown:
+      return "Unknown";
+    case MemoryContext::kDOM:
+      return "DOM";
+    case MemoryContext::kLayout:
+      return "Layout";
+    case MemoryContext::kMedia:
+      return "Media";
+    case MemoryContext::kScript:
+      return "Script";
+    case MemoryContext::kNetwork:
+      return "Network";
+    case MemoryContext::kGraphics:
+      return "Graphics";
+    case MemoryContext::kStorage:
+      return "Storage";
+    case MemoryContext::kGraphicsCanvas:
+      return "GraphicsCanvas";
+    case MemoryContext::kGraphicsCompositor:
+      return "GraphicsCompositor";
+    case MemoryContext::kGraphicsGlyphs:
+      return "GraphicsGlyphs";
+    case MemoryContext::kScriptHeap:
+      return "ScriptHeap";
+    case MemoryContext::kScriptJIT:
+      return "ScriptJIT";
+    case MemoryContext::kScriptBindings:
+      return "ScriptBindings";
+    case MemoryContext::kNetworkLoader:
+      return "NetworkLoader";
+    case MemoryContext::kNetworkCache:
+      return "NetworkCache";
+    case MemoryContext::kBlinkDOM:
+      return "BlinkDOM";
+    case MemoryContext::kBlinkStyle:
+      return "BlinkStyle";
+    case MemoryContext::kBlinkParser:
+      return "BlinkParser";
+    case MemoryContext::kPlatformIPC:
+      return "PlatformIPC";
+    case MemoryContext::kPlatformStarboard:
+      return "PlatformStarboard";
+    case MemoryContext::kCount:
+      return "Unknown";
+  }
+}
+
+}  // namespace memory
+}  // namespace base

--- a/base/memory/cobalt_memory_context.h
+++ b/base/memory/cobalt_memory_context.h
@@ -44,6 +44,16 @@ enum class MemoryContext : uint8_t {
 BASE_EXPORT MemoryContext GetCurrentMemoryContext();
 BASE_EXPORT void SetCurrentMemoryContext(MemoryContext context);
 
+// Scoped helper class to temporarily set the current thread's MemoryContext.
+// The previous context is restored when this object goes out of scope.
+//
+// Lifetime and Ownership:
+// Typically allocated on the stack as a local variable. It should not outlive
+// the scope in which it is defined.
+//
+// Threading Model:
+// Thread-affine. This class only affects the thread on which it is constructed
+// and destroyed.
 class BASE_EXPORT ScopedMemoryContext {
  public:
   explicit ScopedMemoryContext(MemoryContext context);

--- a/base/memory/cobalt_memory_context.h
+++ b/base/memory/cobalt_memory_context.h
@@ -1,0 +1,66 @@
+// Copyright 2026 The Chromium Authors and Cobalt Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+#ifndef BASE_MEMORY_COBALT_MEMORY_CONTEXT_H_
+#define BASE_MEMORY_COBALT_MEMORY_CONTEXT_H_
+
+#include <atomic>
+#include <cstdint>
+#include <string_view>
+#include "base/base_export.h"
+
+namespace base {
+namespace memory {
+
+enum class MemoryContext : uint8_t {
+  kUnknown = 0,
+  kDOM = 1,
+  kLayout = 2,
+  kMedia = 3,
+  kScript = 4,
+  kNetwork = 5,
+  kGraphics = 6,
+  kStorage = 7,
+
+  // Next-Generation Granular Sub-Regions
+  kGraphicsCanvas = 8,
+  kGraphicsCompositor = 9,
+  kGraphicsGlyphs = 10,
+  kScriptHeap = 11,
+  kScriptJIT = 12,
+  kScriptBindings = 13,
+  kNetworkLoader = 14,
+  kNetworkCache = 15,
+  kBlinkDOM = 16,
+  kBlinkStyle = 17,
+  kBlinkParser = 18,
+  kPlatformIPC = 19,
+  kPlatformStarboard = 20,
+
+  kCount
+};
+
+BASE_EXPORT MemoryContext GetCurrentMemoryContext();
+BASE_EXPORT void SetCurrentMemoryContext(MemoryContext context);
+
+class BASE_EXPORT ScopedMemoryContext {
+ public:
+  explicit ScopedMemoryContext(MemoryContext context);
+  ~ScopedMemoryContext();
+
+  ScopedMemoryContext(const ScopedMemoryContext&) = delete;
+  ScopedMemoryContext& operator=(const ScopedMemoryContext&) = delete;
+  ScopedMemoryContext(ScopedMemoryContext&&) = delete;
+  ScopedMemoryContext& operator=(ScopedMemoryContext&&) = delete;
+
+ private:
+  MemoryContext prev_context_;
+};
+
+BASE_EXPORT std::string_view ContextToString(MemoryContext context);
+
+}  // namespace memory
+}  // namespace base
+
+#endif  // BASE_MEMORY_COBALT_MEMORY_CONTEXT_H_


### PR DESCRIPTION
Reapply 'Implement base MemoryContext TLS mapping and Allocator Observers' (#10723) with fixes for Android compile failures.

**Android  pthread_getname_np  Warning Fix:**  The  `__builtin_available(android 26, *)` guard is applied directly inside  `base/memory/cobalt_memory_attribution_observer.cc`.

Bug: 498702469