### PR TITLE
[Cobalt] Add dynamic GPU image decode cache optimization switches

### DIFF
--- a/cc/base/switches.cc
+++ b/cc/base/switches.cc
@@ -5,6 +5,7 @@
 #include "cc/base/switches.h"
 
 #include "base/command_line.h"
+#include "build/build_config.h"
 
 namespace switches {
 
@@ -111,5 +112,11 @@ const char kCCLayerTreeTestLongTimeout[] = "cc-layer-tree-test-long-timeout";
 // Controls the duration of the scroll animation curve.
 const char kCCScrollAnimationDurationForTesting[] =
     "cc-scroll-animation-duration-in-seconds";
+
+#if BUILDFLAG(IS_COBALT)
+const char kCCImageCacheLimitItems[] = "cc-image-cache-limit-items";
+const char kDecodedImageWorkingSetBudgetBytes[] =
+    "decoded-image-working-set-budget-bytes";
+#endif
 
 }  // namespace switches

--- a/cc/base/switches.h
+++ b/cc/base/switches.h
@@ -8,6 +8,7 @@
 #define CC_BASE_SWITCHES_H_
 
 #include "base/check.h"
+#include "build/build_config.h"
 #include "cc/base/base_export.h"
 
 // Since cc is used from the render process, anything that goes here also needs
@@ -65,6 +66,11 @@ CC_BASE_EXPORT extern const char kEnableClippedImageScaling[];
 CC_BASE_EXPORT extern const char kCCLayerTreeTestNoTimeout[];
 CC_BASE_EXPORT extern const char kCCLayerTreeTestLongTimeout[];
 CC_BASE_EXPORT extern const char kCCScrollAnimationDurationForTesting[];
+
+#if BUILDFLAG(IS_COBALT)
+CC_BASE_EXPORT extern const char kCCImageCacheLimitItems[];
+CC_BASE_EXPORT extern const char kDecodedImageWorkingSetBudgetBytes[];
+#endif
 
 }  // namespace switches
 

--- a/cc/tiles/gpu_image_decode_cache.cc
+++ b/cc/tiles/gpu_image_decode_cache.cc
@@ -26,6 +26,9 @@
 #include "base/notreached.h"
 #include "base/numerics/safe_math.h"
 #include "base/strings/stringprintf.h"
+#if BUILDFLAG(IS_COBALT)
+#include "base/strings/string_number_conversions.h"
+#endif
 #include "base/synchronization/lock.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/tick_clock.h"
@@ -2356,7 +2359,24 @@ bool GpuImageDecodeCache::ExceedsCacheLimits() const {
   if (aggressively_freeing_resources_) {
     items_limit = kSuspendedMaxItemsInCacheForGpu;
   } else {
+#if BUILDFLAG(IS_COBALT)
+    static const int normal_max_items = []() {
+      int limit = kNormalMaxItemsInCacheForGpu;
+      auto* command_line = base::CommandLine::ForCurrentProcess();
+      if (command_line->HasSwitch(switches::kCCImageCacheLimitItems)) {
+        std::string value = command_line->GetSwitchValueASCII(
+            switches::kCCImageCacheLimitItems);
+        int parsed_value;
+        if (base::StringToInt(value, &parsed_value) && parsed_value >= 0) {
+          limit = parsed_value;
+        }
+      }
+      return limit;
+    }();
+    items_limit = normal_max_items;
+#else
     items_limit = kNormalMaxItemsInCacheForGpu;
+#endif
   }
 
   return persistent_cache_.size() > items_limit;

--- a/cc/tiles/gpu_image_decode_cache.h
+++ b/cc/tiles/gpu_image_decode_cache.h
@@ -26,6 +26,7 @@
 #include "base/time/time.h"
 #include "base/timer/timer.h"
 #include "base/trace_event/memory_dump_provider.h"
+#include "build/build_config.h"
 #include "cc/cc_export.h"
 #include "cc/paint/image_transfer_cache_entry.h"
 #include "cc/tiles/image_decode_cache.h"

--- a/cc/tiles/image_decode_cache_utils.cc
+++ b/cc/tiles/image_decode_cache_utils.cc
@@ -7,6 +7,14 @@
 
 #include "cc/tiles/image_decode_cache_utils.h"
 
+#include "build/build_config.h"
+
+#if BUILDFLAG(IS_COBALT)
+#include "base/command_line.h"
+#include "base/strings/string_number_conversions.h"
+#include "cc/base/switches.h"
+#endif
+
 #include "base/check.h"
 #include "cc/paint/paint_flags.h"
 #include "third_party/skia/include/core/SkBitmap.h"
@@ -35,6 +43,22 @@ bool ImageDecodeCacheUtils::ShouldEvictCaches(
 // static
 size_t ImageDecodeCacheUtils::GetWorkingSetBytesForImageDecode(
     bool for_renderer) {
+#if BUILDFLAG(IS_COBALT)
+  static const size_t cobalt_decoded_image_working_set_budget_bytes = []() {
+    size_t budget = 128 * 1024 * 1024;
+    auto* command_line = base::CommandLine::ForCurrentProcess();
+    if (command_line->HasSwitch(switches::kDecodedImageWorkingSetBudgetBytes)) {
+      std::string value = command_line->GetSwitchValueASCII(
+          switches::kDecodedImageWorkingSetBudgetBytes);
+      int64_t parsed_value;
+      if (base::StringToInt64(value, &parsed_value) && parsed_value >= 0) {
+        budget = parsed_value;
+      }
+    }
+    return budget;
+  }();
+  return cobalt_decoded_image_working_set_budget_bytes;
+#else
   size_t decoded_image_working_set_budget_bytes = 128 * 1024 * 1024;
 #if !BUILDFLAG(IS_ANDROID)
   if (for_renderer) {
@@ -51,6 +75,7 @@ size_t ImageDecodeCacheUtils::GetWorkingSetBytesForImageDecode(
   }
 #endif  // !BUILDFLAG(IS_ANDROID)
   return decoded_image_working_set_budget_bytes;
+#endif
 }
 
 }  // namespace cc

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -52,6 +52,15 @@ public class JavaSwitches {
   /** flag to disable v8 optimizing compilers (turbofan, maglev, sparkplug) */
   public static final String DISABLE_V8_OPTIMIZING_COMPILERS = "DisableV8OptimizingCompilers";
 
+  /** flag to limit GPU image cache items */
+  public static final String GPU_IMAGE_CACHE_LIMIT_ITEMS = "GpuImageCacheLimitItems";
+
+  /** flag to limit GPU image cache working set budget bytes */
+  public static final String DECODED_IMAGE_WORKING_SET_BUDGET_BYTES = "DecodedImageWorkingSetBudgetBytes";
+
+  /** flag to allow scaling clipped images in GpuImageDecodeCache */
+  public static final String ENABLE_SCALING_CLIPPED_IMAGES = "EnableScalingClippedImages";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
 
@@ -81,6 +90,19 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_GPU_MEMORY_BUFFER_COMPOSITOR_RESOURCES)) {
       extraCommandLineArgs.add("--disable-gpu-memory-buffer-compositor-resources");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.GPU_IMAGE_CACHE_LIMIT_ITEMS)) {
+      String limit = javaSwitches.get(JavaSwitches.GPU_IMAGE_CACHE_LIMIT_ITEMS).replaceAll("[^0-9]", "");
+      extraCommandLineArgs.add("--cc-image-cache-limit-items=" + limit);
+    }
+    if (javaSwitches.containsKey(JavaSwitches.DECODED_IMAGE_WORKING_SET_BUDGET_BYTES)) {
+      String budget = javaSwitches.get(JavaSwitches.DECODED_IMAGE_WORKING_SET_BUDGET_BYTES).replaceAll("[^0-9]", "");
+      extraCommandLineArgs.add("--decoded-image-working-set-budget-bytes=" + budget);
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_SCALING_CLIPPED_IMAGES)) {
+      extraCommandLineArgs.add("--enable-scaling-clipped-images");
     }
 
     StringJoiner featureParams = new StringJoiner("/");


### PR DESCRIPTION
Introduce dynamic, runtime-configurable switches to optimize Cobalt's GPU image decode cache and working set memory footprint:
1. cc-image-cache-limit-items: Dynamically limits historical off-screen image cache retention (supports Zero-Cache policy).
2. decoded-image-working-set-budget-bytes: Customizes active image decode working set budget dynamically.
3. enable-scaling-clipped-images: Exposes pre-existing scale down capabilities on clipped images to the Java experiment switches layer.

All C++ changes are strictly gated under BUILDFLAG(IS_COBALT).

Bug: 512157288