### PR TITLE
cobalt: Add custom web API to expose friendly name

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -108,6 +108,7 @@ public class StarboardBridge {
   private static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getTimeZone("America/Los_Angeles");
   private final long mTimeNanosecondsPerMicrosecond = 1000;
   private static final String YTS_CERT_SCOPE_SYSTEM_PROPERTY = "ro.vendor.youtube.cert_scope";
+  private static final String DEFAULT_DEVICE_NAME = "Android";
 
   public StarboardBridge(
       Context appContext,
@@ -516,6 +517,16 @@ public class StarboardBridge {
   @CalledByNative
   protected boolean getLimitAdTracking() {
     return mAdvertisingId.isLimitAdTrackingEnabled();
+  }
+
+  @CalledByNative
+  protected String getFriendlyName() {
+    String deviceName = android.provider.Settings.Global.getString(
+        mAppContext.getContentResolver(), android.provider.Settings.Global.DEVICE_NAME);
+    if (deviceName == null || deviceName.isEmpty()) {
+      deviceName = DEFAULT_DEVICE_NAME;
+    }
+    return deviceName;
   }
 
   @CalledByNative

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -521,8 +521,16 @@ public class StarboardBridge {
 
   @CalledByNative
   protected String getFriendlyName() {
-    String deviceName = android.provider.Settings.Global.getString(
-        mAppContext.getContentResolver(), android.provider.Settings.Global.DEVICE_NAME);
+    String deviceName = null;
+    try {
+      deviceName = android.provider.Settings.Global.getString(
+          mAppContext.getContentResolver(), android.provider.Settings.Global.DEVICE_NAME);
+    } catch (SecurityException e) {
+      Log.w(TAG, "SecurityException reading DEVICE_NAME setting", e);
+    }
+    if (deviceName == null || deviceName.isEmpty()) {
+      deviceName = android.os.Build.MODEL;
+    }
     if (deviceName == null || deviceName.isEmpty()) {
       deviceName = DEFAULT_DEVICE_NAME;
     }

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_android.cc
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_android.cc
@@ -90,6 +90,12 @@ void H5vccSystemImpl::RequestTrackingAuthorization(
   std::move(callback).Run(false);
 }
 
+void H5vccSystemImpl::GetFriendlyName(GetFriendlyNameCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  JNIEnv* env = base::android::AttachCurrentThread();
+  std::move(callback).Run(StarboardBridge::GetInstance()->GetFriendlyName(env));
+}
+
 void H5vccSystemImpl::GetUserOnExitStrategy(
     GetUserOnExitStrategyCallback callback) {
   std::move(callback).Run(h5vcc_system::mojom::UserOnExitStrategy::kMinimize);

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_base.h
@@ -51,6 +51,7 @@ class H5vccSystemImpl : public content::DocumentService<mojom::H5vccSystem> {
       GetTrackingAuthorizationStatusSyncCallback) override;
   void RequestTrackingAuthorization(
       RequestTrackingAuthorizationCallback) override;
+  void GetFriendlyName(GetFriendlyNameCallback) override;
   void GetUserOnExitStrategy(GetUserOnExitStrategyCallback) override;
   void Exit() override;
   void HideSplashScreen() override;

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_starboard.cc
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_starboard.cc
@@ -42,7 +42,7 @@ std::string GetAdvertisingIdShared() {
   std::string advertising_id;
   advertising_id =
       starboard::GetSystemPropertyString(kSbSystemPropertyAdvertisingId);
-  DLOG_IF(INFO, advertising_id == "")
+  DLOG_IF(INFO, advertising_id.empty())
       << "Failed to get kSbSystemPropertyAdvertisingId.";
   return advertising_id;
 }
@@ -51,7 +51,7 @@ bool GetLimitAdTrackingShared() {
   bool limit_ad_tracking = false;
   std::string result =
       starboard::GetSystemPropertyString(kSbSystemPropertyLimitAdTracking);
-  if (result == "") {
+  if (result.empty()) {
     DLOG(INFO) << "Failed to get kSbSystemPropertyLimitAdTracking.";
   } else {
     limit_ad_tracking = std::atoi(result.c_str());
@@ -109,7 +109,7 @@ void H5vccSystemImpl::GetFriendlyName(GetFriendlyNameCallback callback) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   std::string friendly_name =
       starboard::GetSystemPropertyString(kSbSystemPropertyFriendlyName);
-  DLOG_IF(INFO, friendly_name == "")
+  DLOG_IF(INFO, friendly_name.empty())
       << "Failed to get kSbSystemPropertyFriendlyName.";
   std::move(callback).Run(friendly_name);
 }

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_starboard.cc
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_starboard.cc
@@ -105,6 +105,15 @@ void H5vccSystemImpl::RequestTrackingAuthorization(
   std::move(callback).Run(false);
 }
 
+void H5vccSystemImpl::GetFriendlyName(GetFriendlyNameCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  std::string friendly_name =
+      starboard::GetSystemPropertyString(kSbSystemPropertyFriendlyName);
+  DLOG_IF(INFO, friendly_name == "")
+      << "Failed to get kSbSystemPropertyFriendlyName.";
+  std::move(callback).Run(friendly_name);
+}
+
 void H5vccSystemImpl::GetUserOnExitStrategy(
     GetUserOnExitStrategyCallback callback) {
   std::move(callback).Run(GetUserOnExitStrategyInternal());

--- a/cobalt/browser/h5vcc_system/h5vcc_system_impl_tvos.mm
+++ b/cobalt/browser/h5vcc_system/h5vcc_system_impl_tvos.mm
@@ -111,6 +111,12 @@ void H5vccSystemImpl::RequestTrackingAuthorization(
       requestTrackingAuthorizationWithCompletionHandler:completion];
 }
 
+void H5vccSystemImpl::GetFriendlyName(GetFriendlyNameCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  std::move(callback).Run(
+      base::SysNSStringToUTF8([UIDevice currentDevice].name));
+}
+
 void H5vccSystemImpl::GetUserOnExitStrategy(
     GetUserOnExitStrategyCallback callback) {
   std::move(callback).Run(h5vcc_system::mojom::UserOnExitStrategy::kMinimize);

--- a/cobalt/browser/h5vcc_system/public/mojom/h5vcc_system.mojom
+++ b/cobalt/browser/h5vcc_system/public/mojom/h5vcc_system.mojom
@@ -36,6 +36,9 @@ interface H5vccSystem {
   GetTrackingAuthorizationStatusSync() => (string tracking_authorization_status);
   RequestTrackingAuthorization() => (bool is_tracking_authorization_supported);
 
+  // Gets the friendly name of the device from the platform.
+  GetFriendlyName() => (string friendly_name);
+
   // Returns the platform-specific user on exit strategy.
   [Sync]
   GetUserOnExitStrategy() => (UserOnExitStrategy userOnExitStrategy);

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -301,6 +301,13 @@ SB_EXPORT_ANDROID bool StarboardBridge::GetLimitAdTracking(JNIEnv* env) {
   return limit_ad_tracking_java == JNI_TRUE;
 }
 
+SB_EXPORT_ANDROID std::string StarboardBridge::GetFriendlyName(JNIEnv* env) {
+  SB_DCHECK(env);
+  ScopedJavaLocalRef<jstring> friendly_name_java =
+      Java_StarboardBridge_getFriendlyName(env, j_starboard_bridge_);
+  return ConvertJavaStringToUTF8(env, friendly_name_java);
+}
+
 SB_EXPORT_ANDROID void StarboardBridge::CloseApp(JNIEnv* env) {
   SB_DCHECK(env);
   return Java_StarboardBridge_closeApp(env, j_starboard_bridge_);

--- a/starboard/android/shared/starboard_bridge.h
+++ b/starboard/android/shared/starboard_bridge.h
@@ -61,6 +61,7 @@ class StarboardBridge {
 
   std::string GetAdvertisingId(JNIEnv* env);
   bool GetLimitAdTracking(JNIEnv* env);
+  std::string GetFriendlyName(JNIEnv* env);
 
   void CloseApp(JNIEnv* env);
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.cc
@@ -82,6 +82,26 @@ absl::optional<bool> H5vccSystem::limitAdTracking() {
   return limit_ad_tracking;
 }
 
+ScriptPromise<IDLString> H5vccSystem::getFriendlyName(
+    ScriptState* script_state,
+    ExceptionState& exception_state) {
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLString>>(
+      script_state, exception_state.GetContext());
+
+  EnsureReceiverIsBound();
+
+  remote_h5vcc_system_->GetFriendlyName(
+      WTF::BindOnce(&H5vccSystem::OnGetFriendlyName, WrapPersistent(this),
+                    WrapPersistent(resolver)));
+
+  return resolver->Promise();
+}
+
+void H5vccSystem::OnGetFriendlyName(ScriptPromiseResolver<IDLString>* resolver,
+                                    const String& result) {
+  resolver->Resolve(result);
+}
+
 ScriptPromise<IDLString> H5vccSystem::getTrackingAuthorizationStatus(
     ScriptState* script_state,
     ExceptionState& exception_state) {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.h
@@ -50,6 +50,7 @@ class MODULES_EXPORT H5vccSystem final
   const String& advertisingId();
   ScriptPromise<IDLBoolean> getLimitAdTracking(ScriptState*, ExceptionState&);
   absl::optional<bool> limitAdTracking();
+  ScriptPromise<IDLString> getFriendlyName(ScriptState*, ExceptionState&);
   ScriptPromise<IDLString> getTrackingAuthorizationStatus(ScriptState*,
                                                           ExceptionState&);
   const String& trackingAuthorizationStatus();
@@ -64,6 +65,7 @@ class MODULES_EXPORT H5vccSystem final
  private:
   void OnGetAdvertisingId(ScriptPromiseResolver<IDLString>*, const String&);
   void OnGetLimitAdTracking(ScriptPromiseResolver<IDLBoolean>*, bool);
+  void OnGetFriendlyName(ScriptPromiseResolver<IDLString>*, const String&);
   void OnGetTrackingAuthorizationStatus(ScriptPromiseResolver<IDLString>*,
                                         const String&);
   void OnRequestTrackingAuthorization(ScriptPromiseResolver<IDLUndefined>*,

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
@@ -39,6 +39,10 @@ interface H5vccSystem : EventTarget {
   readonly attribute boolean? limitAdTracking;
 
   // Gets the device friendly name from the platform.
+  // Note: since there is some performance overhead involved in fetching the
+  // value from the platform via the browser, web clients should be careful not
+  // to call this API excessively. The value is unlikely to be changed during a
+  // Cobalt application lifecycle, anyway.
   [CallWith=ScriptState, RaisesException]
   Promise<DOMString> getFriendlyName();
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
@@ -43,7 +43,7 @@ interface H5vccSystem : EventTarget {
   // value from the platform via the browser, web clients should be careful not
   // to call this API excessively. The value is unlikely to be changed during a
   // Cobalt application lifecycle, anyway.
-  [CallWith=ScriptState, RaisesException]
+  [CallWith=ScriptState, RaisesException, RuntimeEnabled=CobaltFriendlyName]
   Promise<DOMString> getFriendlyName();
 
   [CallWith=ScriptState, RaisesException]

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_system/h_5_vcc_system.idl
@@ -38,6 +38,10 @@ interface H5vccSystem : EventTarget {
   Promise<boolean> getLimitAdTracking();
   readonly attribute boolean? limitAdTracking;
 
+  // Gets the device friendly name from the platform.
+  [CallWith=ScriptState, RaisesException]
+  Promise<DOMString> getFriendlyName();
+
   [CallWith=ScriptState, RaisesException]
   Promise<DOMString> getTrackingAuthorizationStatus();
   readonly attribute DOMString? trackingAuthorizationStatus;

--- a/third_party/blink/renderer/platform/runtime_enabled_features.json5
+++ b/third_party/blink/renderer/platform/runtime_enabled_features.json5
@@ -953,6 +953,11 @@
       status: "stable",
     },
     {
+      // Cobalt comment: guards Cobalt's friendly name web API.
+      name: "CobaltFriendlyName",
+      status: "test",
+    },
+    {
       name: "CoepReflection",
       status: "test",
     },

--- a/third_party/blink/web_tests/TestExpectations
+++ b/third_party/blink/web_tests/TestExpectations
@@ -9429,4 +9429,8 @@ wpt_internal/cobalt/HTMLVideoElementExtension/getAndSetMaxVideoCapabilities.html
 wpt_internal/cobalt/h5vcc-runtime/* [ Failure ]
 
 # Cobalt bug: b/405997906.
-wpt_internal/cobalt/h5vcc-system/* [ Failure ]
+wpt_internal/cobalt/h5vcc-system/h5vcc-system-advertisingId.https.any.html [ Failure Timeout ]
+wpt_internal/cobalt/h5vcc-system/h5vcc-system-exit.https.any.html [ Failure Timeout ]
+wpt_internal/cobalt/h5vcc-system/h5vcc-system-limitAdTracking.https.any.html [ Failure Timeout ]
+wpt_internal/cobalt/h5vcc-system/h5vcc-system-trackingAuthorizationStatus.https.any.html [ Failure Timeout ]
+wpt_internal/cobalt/h5vcc-system/h5vcc-system-userOnExitStrategy.https.any.html [ Failure Timeout ]

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-system/h5vcc-system-getFriendlyName.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-system/h5vcc-system-getFriendlyName.https.any.js
@@ -1,0 +1,13 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_system_tests(async (t, mockH5vccSystem) => {
+    assert_implements(window.h5vcc, "window.h5vcc not supported");
+    assert_implements(window.h5vcc.system, "window.h5vcc.system not supported");
+
+    const expected = 'fake-friendly-name';
+    mockH5vccSystem.stubFriendlyName(expected);
+    let actual = await window.h5vcc.system.getFriendlyName();
+    assert_equals(actual, expected);
+}, 'exercises H5vccSystem.getFriendlyName()');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-system/resources/mock-h5vcc-system.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-system/resources/mock-h5vcc-system.js
@@ -25,6 +25,7 @@ class MockH5vccSystem {
 
   STUB_KEY_ADVERTISING_ID = 'advertisingId';
   STUB_KEY_LIMIT_AD_TRACKING = 'limitAdTracking';
+  STUB_KEY_FRIENDLY_NAME = 'friendlyName';
   STUB_KEY_TRACKING_AUTHORIZATION_STATUS = 'trackingAuthorizationStatus';
   STUB_KEY_USER_ON_EXIT_STRATEGY = 'userOnExitStrategy';
 
@@ -64,6 +65,10 @@ class MockH5vccSystem {
     this.stubResult(this.STUB_KEY_LIMIT_AD_TRACKING, limitAdTracking);
   }
 
+  stubFriendlyName(friendlyName) {
+    this.stubResult(this.STUB_KEY_FRIENDLY_NAME, friendlyName);
+  }
+
   stubTrackingAuthorizationStatus(trackingAuthorizationStatus) {
     this.stubResult(this.STUB_KEY_TRACKING_AUTHORIZATION_STATUS, trackingAuthorizationStatus);
   }
@@ -87,24 +92,28 @@ class MockH5vccSystem {
     return Promise.resolve({ advertisingId: this.stub_result_.get(this.STUB_KEY_ADVERTISING_ID) });
   }
 
-  advertisingId() {
-    return this.stub_result_.get(this.STUB_KEY_ADVERTISING_ID);
+  getAdvertisingIdSync() {
+    return { advertisingId: this.stub_result_.get(this.STUB_KEY_ADVERTISING_ID) };
   }
 
   getLimitAdTracking() {
     return Promise.resolve({ limitAdTracking: this.stub_result_.get(this.STUB_KEY_LIMIT_AD_TRACKING) });
   }
 
-  limitAdTracking() {
-    return this.stub_result_.get(this.STUB_KEY_LIMIT_AD_TRACKING);
+  getLimitAdTrackingSync() {
+    return { limitAdTracking: this.stub_result_.get(this.STUB_KEY_LIMIT_AD_TRACKING) };
+  }
+
+  getFriendlyName() {
+    return Promise.resolve({ friendlyName: this.stub_result_.get(this.STUB_KEY_FRIENDLY_NAME) });
   }
 
   getTrackingAuthorizationStatus() {
     return Promise.resolve({ trackingAuthorizationStatus: this.stub_result_.get(this.STUB_KEY_TRACKING_AUTHORIZATION_STATUS) });
   }
 
-  trackingAuthorizationStatus() {
-    return this.stub_result_.get(this.STUB_KEY_TRACKING_AUTHORIZATION_STATUS);
+  getTrackingAuthorizationStatusSync() {
+    return { trackingAuthorizationStatus: this.stub_result_.get(this.STUB_KEY_TRACKING_AUTHORIZATION_STATUS) };
   }
 
   getUserOnExitStrategy() {
@@ -114,6 +123,14 @@ class MockH5vccSystem {
   exit() {
     incrementExitCallCount();
   }
+
+  // --- Trivial MojoJS Mock Implementations ---
+  // MojoJS requires that an implementation be provided for all methods declared in the Mojom interface.
+  requestTrackingAuthorization() {
+    return Promise.resolve({ isTrackingAuthorizationSupported: false });
+  }
+
+  hideSplashScreen() {}
 }
 
 export const mockH5vccSystem = new MockH5vccSystem();


### PR DESCRIPTION
The changes include an end-to-end implementation of the web API, with browser-side implementations to fetch the TV friendly name from the platform. The value is provided by:
* 3P: the kSbSystemPropertyFriendlyName Staboard property
* ATV: the DEVICE_NAME global system setting, via the Starboard Bridge
* tvOS: the name property from the UIDevice object.

A web test is also added for the new web API, and a couple fixes are made to the MojoJS mock implementation of the H5vccSystem Mojo interface.

#vibe-coded

Issue: 500383665