### PR TITLE
cobalt/browser: enable default QUIC retransmittable-on-wire keep-alive

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -601,6 +601,26 @@ void CobaltContentBrowserClient::CreateFeatureListAndFieldTrials() {
 
   SetUpCobaltFeaturesAndParams(feature_list.get());
 
+  // Set a default QUIC retransmittable-on-wire keep-alive interval. Cobalt
+  // targets CE devices that are typically deployed behind consumer-grade
+  // NATs whose UDP idle timeout can be as low as 30 seconds. Without an
+  // active keep-alive, a long-lived, mostly-receive QUIC stream (for
+  // example, a server-push long-poll) can lose its NAT binding and stall
+  // silently while the rest of the session still appears healthy. The
+  // 100 ms value backs off exponentially, so this is not a 100 ms ping
+  // forever on healthy connections. Skipped if any external mechanism
+  // (command-line --force-fieldtrials, a variations seed, etc.) has
+  // already configured the "QUIC" trial so that those configurations
+  // continue to win. The trial parameter is consumed by
+  // components/network_session_configurator/browser/
+  // network_session_configurator.cc.
+  if (!base::FieldTrialList::Find("QUIC")) {
+    base::FieldTrialParams quic_trial_params;
+    quic_trial_params["retransmittable_on_wire_timeout_milliseconds"] = "100";
+    base::AssociateFieldTrialParams("QUIC", "Enabled", quic_trial_params);
+    base::FieldTrialList::CreateFieldTrial("QUIC", "Enabled");
+  }
+
   base::FeatureList::SetInstance(std::move(feature_list));
   UMA_HISTOGRAM_BOOLEAN(
       "Cobalt.Features.TestFinchFeature",


### PR DESCRIPTION
  Long-lived, mostly-receive QUIC streams (server-push long-polls, for instance) can silently stall when Cobalt runs behind a consumer-grade NAT.  The client doesn't produce any outgoing traffic on the stream, so after  30-60 seconds of one-way traffic the NAT evicts the UDP mapping. Server  packets get dropped after that, application-level heartbeats may keep arriving for a little while, and the stream eventually fails with a  terminal read error - `ERR_INCOMPLETE_CHUNKED_ENCODING` on the HTTP/1.1 fallback path, or an idle close on HTTP/3. From the client side the QUIC session looks fine right until it dies. The user-visible effect is that  anything driven by server-push freezes while the rest of the session appears to keep working.
`QuicParams::retransmittable_on_wire_timeout` defaults to zero, which  disables the retransmittable-on-wire PING. Idle sessions then rely only on the generic 15-second client PING, which isn't frequent enough for  the kinds of NATs typical Cobalt devices sit behind.
This change registers a default "QUIC" field trial group "Enabled" with  `retransmittable_on_wire_timeout_milliseconds = 100` in `CobaltContentBrowserClient::CreateFeatureListAndFieldTrials()`. The  parameter is read by `components/network_session_configurator/browser/network_session_configurator.cc` in `ConfigureQuicParams()` and applied to `QuicParams` before the `HttpNetworkSession` is built. The timeout backs off exponentially, so it  isn't a 100 ms ping forever on healthy connections.
The registration uses the same field-trial pattern as the existing `SetUpCobaltFeaturesAndParams()`, and is skipped if the "QUIC" trial has already been set up externally (`--force-fieldtrials`, variations seed,  etc.) so anything configured that way still wins.