### PR TITLE
[EXPERIMENT]  MSE SourceBuffer Memory Limit testing

### DIFF
--- a/media/filters/source_buffer_stream.cc
+++ b/media/filters/source_buffer_stream.cc
@@ -790,8 +790,18 @@ bool SourceBufferStream::GarbageCollectIfNeeded(base::TimeDelta media_time,
   }
 
   // Return if we're under or at the memory limit.
-  if (ranges_size + newDataSize <= effective_memory_limit)
+  if (ranges_size + newDataSize <= effective_memory_limit) {
+    static base::TimeDelta last_log_time;
+    if (media_time - last_log_time > base::Seconds(5) || media_time < last_log_time) {
+      LOG(INFO) << "SourceBufferStream [" << GetStreamTypeName()
+                << "] state: buffered_duration_sec="
+                << (GetBufferedDuration().InSecondsF())
+                << "s, buffered_bytes=" << (ranges_size / 1024) << " KB"
+                << " (Limit=" << (memory_limit_ / 1024 / 1024) << " MB)";
+      last_log_time = media_time;
+    }
     return true;
+  }
 
   size_t bytes_over_hard_memory_limit = 0;
   if (ranges_size + newDataSize > memory_limit_)

--- a/media/starboard/decoder_buffer_memory_info.cc
+++ b/media/starboard/decoder_buffer_memory_info.cc
@@ -14,6 +14,8 @@
 
 #include "media/starboard/decoder_buffer_memory_info.h"
 
+#include "base/debug/stack_trace.h"
+#include "base/logging.h"
 #include "media/base/video_codecs.h"
 #include "media/starboard/starboard_utils.h"
 #include "starboard/media.h"
@@ -28,9 +30,16 @@ int GetAudioDecoderBufferLimitBytes() {
 int GetVideoDecoderBufferLimitBytes(VideoCodec codec,
                                     const gfx::Size& resolution,
                                     int bits_per_pixel) {
-  return SbMediaGetVideoBufferBudget(MediaVideoCodecToSbMediaVideoCodec(codec),
-                                     resolution.width(), resolution.height(),
-                                     bits_per_pixel);
+  int budget = SbMediaGetVideoBufferBudget(
+      MediaVideoCodecToSbMediaVideoCodec(codec), resolution.width(),
+      resolution.height(), bits_per_pixel);
+  LOG(INFO) << "GetVideoDecoderBufferLimitBytes called: codec="
+            << static_cast<int>(codec)
+            << ", resolution=" << resolution.ToString()
+            << ", bits_per_pixel=" << bits_per_pixel
+            << ", returned budget=" << budget << " bytes ("
+            << (budget / 1024 / 1024) << " MB)\n";
+  return budget;
 }
 
 }  // namespace media

--- a/starboard/android/shared/media_get_video_buffer_budget.cc
+++ b/starboard/android/shared/media_get_video_buffer_budget.cc
@@ -13,10 +13,14 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <sstream>
+#include <string>
 
 #include "starboard/android/shared/runtime_resource_overlay.h"
+#include "starboard/common/command_line.h"
 #include "starboard/common/log.h"
 #include "starboard/media.h"
+#include "starboard/shared/starboard/application.h"
 
 namespace {
 
@@ -43,6 +47,23 @@ int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
                                 int resolution_height,
                                 int bits_per_pixel) {
   auto get_overlaid_video_buffer_budget = []() {
+    auto* application = starboard::Application::Get();
+    if (application) {
+      auto* command_line = application->GetCommandLine();
+      if (command_line->HasSwitch("max-video-buffer-budget-mb")) {
+        std::string value =
+            command_line->GetSwitchValue("max-video-buffer-budget-mb");
+        std::stringstream ss(value);
+        int budget_mb = 0;
+        if (ss >> budget_mb && budget_mb > 0) {
+          SB_LOG(INFO)
+              << "CommandLine \"max-video-buffer-budget-mb\" is set to "
+              << budget_mb << " MB.";
+          return budget_mb * 1024 * 1024;
+        }
+      }
+    }
+
     int buffer_budget = starboard::RuntimeResourceOverlay::GetInstance()
                             ->max_video_buffer_budget();
     if (buffer_budget == 0) {


### PR DESCRIPTION
WIP

introduce a command-line switch ( --max-video-buffer-budget-mb ) to allow a runtime override of the Starboard Media Buffer Budget. By capping the W3C MSE SourceBuffer memory limit from 160MB to 40MB on 4K HDR streams, we force early media buffer eviction behind the playhead. This keeps the video buffered timeline to a stable 15–50 second safety window, while reclaiming up to 80MB of process PSS memory.

To test
`adb shell am start -S -n dev.cobalt.coat/dev.cobalt.app.MainActivity \
--esa commandLineArgs "--url=https://www.youtube.com/tv/watch#/watch?v=1La4QzGeaaQ,--max-video-buffer-budget-mb=40"`

Results
https://g3doc.corp.google.com/experimental/users/sideboard/videobuffer/experiment_results.md?cl=head

```
[ JavaScript App ] 
       │  (Appends media segments via MSE)
       ▼
[ blink::SourceBuffer ] 
       │  (Bridges the web-page layer to the browser media engine)
       ▼
[ media::ChunkDemuxer ] 
       │  (Demuxes/splits the data into separate audio and video tracks)
       ▼
[ media::SourceBufferStream ]  <--- HERE
       │  (Buffers, sequences, sorts, and garbage-collects frames)
       ▼
[ Audio / Video Decoders ] 
       │  (Turns compressed data into raw pixels/audio signals)
       ▼
[ Your Screen / Speakers ]
```
