### PR TITLE
Disable `sigaltstack` and `sched_getcpu`

### DIFF
--- a/third_party/abseil-cpp/absl/base/config.h
+++ b/third_party/abseil-cpp/absl/base/config.h
@@ -398,7 +398,7 @@ static_assert(ABSL_INTERNAL_INLINE_NAMESPACE_STR[0] != 'h' ||
 // Checks whether sched_getcpu is available.
 #ifdef ABSL_HAVE_SCHED_GETCPU
 #error ABSL_HAVE_SCHED_GETCPU cannot be directly set
-#elif defined(__linux__)
+#elif defined(__linux__) && !defined(STARBOARD)
 #define ABSL_HAVE_SCHED_GETCPU 1
 #endif
 

--- a/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
+++ b/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
@@ -61,7 +61,8 @@
 // Apple macOS has sigaltstack, but using it makes backtrace() unusable.
 #if !(defined(TARGET_OS_OSX) && TARGET_OS_OSX) &&     \
     !(defined(TARGET_OS_WATCH) && TARGET_OS_WATCH) && \
-    !(defined(TARGET_OS_TV) && TARGET_OS_TV) && !defined(__QNX__)
+    !(defined(TARGET_OS_TV) && TARGET_OS_TV) && !defined(__QNX__) && \
+    !defined(STARBOARD)
 #define ABSL_HAVE_SIGALTSTACK
 #endif
 #endif

--- a/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
+++ b/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
@@ -350,7 +350,7 @@ using GetTidType = decltype(absl::base_internal::GetTID());
 ABSL_CONST_INIT static std::atomic<GetTidType> failed_tid(0);
 
 static int GetCpuNumber() {
-#if defined(ABSL_HAVE_SCHED_GETCPU) && !defined(STARBOARD)
+#ifdef ABSL_HAVE_SCHED_GETCPU
   return sched_getcpu();
 #elif defined(ABSL_HAVE_PTHREAD_CPU_NUMBER_NP)
   size_t cpu_num;

--- a/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
+++ b/third_party/abseil-cpp/absl/debugging/failure_signal_handler.cc
@@ -350,7 +350,7 @@ using GetTidType = decltype(absl::base_internal::GetTID());
 ABSL_CONST_INIT static std::atomic<GetTidType> failed_tid(0);
 
 static int GetCpuNumber() {
-#ifdef ABSL_HAVE_SCHED_GETCPU
+#if defined(ABSL_HAVE_SCHED_GETCPU) && !defined(STARBOARD)
   return sched_getcpu();
 #elif defined(ABSL_HAVE_PTHREAD_CPU_NUMBER_NP)
   size_t cpu_num;


### PR DESCRIPTION
This fixes an NPLB-only symbol leak by disabling optional absl features that use `sigaltstack` and `sched_getcpu`.

Bug: 477257357