### PR TITLE
evergreen: Clean up deprecated ALLOW_EVERGREEN_SIDELOADING checks

### DIFF
--- a/chrome/updater/configurator.cc
+++ b/chrome/updater/configurator.cc
@@ -109,12 +109,11 @@ int Configurator::UpdateDelay() const {
 }
 
 std::vector<GURL> Configurator::UpdateUrl() const {
-// TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're fully launched.
-#if !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#if !defined(COBALT_BUILD_TYPE_GOLD)
   if (allow_self_signed_packages_ && !update_server_url_.empty()) {
     return std::vector<GURL>{GURL(update_server_url_)};
   }
-#endif // !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#endif // !defined(COBALT_BUILD_TYPE_GOLD)
   if (base::CommandLine::ForCurrentProcess()->HasSwitch(
           browser::switches::kUseQAUpdateServer)) {
     return std::vector<GURL>{GURL(kUpdaterJSONDefaultUrlQA)};

--- a/chrome/updater/updater_module.cc
+++ b/chrome/updater/updater_module.cc
@@ -275,15 +275,13 @@ void UpdaterModule::Update() {
     return;
   }
 
-  // TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're
-  // fully launched.
-#if !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#if !defined(COBALT_BUILD_TYPE_GOLD)
   bool skip_verify_public_key_hash = GetAllowSelfSignedPackages();
   bool require_network_encryption = GetRequireNetworkEncryption();
 #else
   bool skip_verify_public_key_hash = false;
   bool require_network_encryption = true;
-#endif // defined(COBALT_BUILD_TYPE_GOLD)
+#endif // !defined(COBALT_BUILD_TYPE_GOLD)
 
   update_client_->Update(
       app_ids,
@@ -300,14 +298,12 @@ void UpdaterModule::Update() {
             component.pk_hash.assign(std::begin(kCobaltPublicKeyHash),
                                      std::end(kCobaltPublicKeyHash));
             component.requires_network_encryption = true;
-            // TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check
-            // once we're fully launched.
-#if !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#if !defined(COBALT_BUILD_TYPE_GOLD)
             if (skip_verify_public_key_hash) {
               component.pk_hash.clear();
             }
             component.requires_network_encryption = require_network_encryption;
-#endif // !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#endif // !defined(COBALT_BUILD_TYPE_GOLD)
             component.crx_format_requirement = crx_file::VerifierFormat::CRX3;
             return {component};
           },

--- a/cobalt/h5vcc/h5vcc_updater.cc
+++ b/cobalt/h5vcc/h5vcc_updater.cc
@@ -106,13 +106,11 @@ bool H5vccUpdater::GetAllowSelfSignedPackages() {
 }
 
 void H5vccUpdater::SetAllowSelfSignedPackages(bool allow_self_signed_packages) {
-  // TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're
-  // fully launched.
-#if !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#if !defined(COBALT_BUILD_TYPE_GOLD)
   if (updater_module_) {
     updater_module_->SetAllowSelfSignedPackages(allow_self_signed_packages);
   }
-#endif  // !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#endif  // !defined(COBALT_BUILD_TYPE_GOLD)
 }
 
 std::string H5vccUpdater::GetUpdateServerUrl() const {
@@ -124,13 +122,11 @@ std::string H5vccUpdater::GetUpdateServerUrl() const {
 }
 
 void H5vccUpdater::SetUpdateServerUrl(const std::string& update_server_url) {
-  // TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're
-  // fully launched.
-#if !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#if !defined(COBALT_BUILD_TYPE_GOLD)
   if (updater_module_) {
     updater_module_->SetUpdateServerUrl(update_server_url);
   }
-#endif  // !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#endif  // !defined(COBALT_BUILD_TYPE_GOLD)
 }
 
 bool H5vccUpdater::GetRequireNetworkEncryption() const {
@@ -143,13 +139,11 @@ bool H5vccUpdater::GetRequireNetworkEncryption() const {
 
 void H5vccUpdater::SetRequireNetworkEncryption(
     bool require_network_encryption) {
-  // TODO(b/325626249): Remove the ALLOW_EVERGREEN_SIDELOADING check once we're
-  // fully launched.
-#if !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#if !defined(COBALT_BUILD_TYPE_GOLD)
   if (updater_module_) {
     updater_module_->SetRequireNetworkEncryption(require_network_encryption);
   }
-#endif  // !defined(COBALT_BUILD_TYPE_GOLD) && ALLOW_EVERGREEN_SIDELOADING
+#endif  // !defined(COBALT_BUILD_TYPE_GOLD)
 }
 #endif  // SB_IS(EVERGREEN)
 }  // namespace h5vcc

--- a/starboard/configuration.h
+++ b/starboard/configuration.h
@@ -123,6 +123,10 @@ struct CompileAssert {};
 // targets and all configurations.
 #include STARBOARD_CONFIGURATION_INCLUDE
 
+#ifndef ALLOW_EVERGREEN_SIDELOADING
+#define ALLOW_EVERGREEN_SIDELOADING 1
+#endif
+
 // --- Overridable Helper Macros ---------------------------------------------
 
 // The following macros can be overridden in STARBOARD_CONFIGURATION_INCLUDE
@@ -412,16 +416,5 @@ struct CompileAssert {};
 #else
 #define SB_FUNCTION __FUNCTION__
 #endif
-
-// --- Deprecated Feature Macros -----------------------------------------------
-
-// Deprecated feature macros are no longer referenced by application code, and
-// will be removed in a later Starboard API version. Any Starboard
-// implementation that supports any of these macros should be modified to no
-// longer rely on them, and operate with the assumption that their values are
-// always 1.
-
-// This will be removed in subsequent API releases and should be ignored.
-#define ALLOW_EVERGREEN_SIDELOADING 0
 
 #endif  // STARBOARD_CONFIGURATION_H_


### PR DESCRIPTION
evergreen: Remove deprecated sideloading macro

Remove the ALLOW_EVERGREEN_SIDELOADING macro and its associated
preprocessor checks across the codebase. This macro is being deprecated
in Starboard and is no longer necessary, as logic for self-signed
packages and update server overrides is now primarily gated by the
Cobalt build type. Internal references and TODOs are also removed to
clean up public-facing configuration files.

Bug: 325626249