### PR TITLE
v8: Set maglev flag to false to reduce binary size

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -51,6 +51,7 @@ v8_enable_atomic_object_field_writes = false
 
 # This will force V8 to embed snapshot blob in binary.
 v8_use_external_startup_data = false
+v8_enable_maglev = false
 
 # Disable hls_demuxer so that enable_mse_mpeg2ts_stream_parser=false
 enable_hls_demuxer = false


### PR DESCRIPTION
This PR disables V8's Maglev compiler globally for Cobalt builds by setting  `v8_enable_maglev = false` .                                        
                                                                                                                                                 
Disabling Maglev yields a binary size reduction of  336.0 KB (92,831,100  down to  92,487,036  bytes).  

For context: Maglev is V8’s mid-tier optimizing compiler that sits between Sparkplug (the fast baseline compiler) and Turbofan (the heavy, top-tier optimizing compiler). It is designed to quickly generate optimized machine code for hot JavaScript functions, bridging the gap between rapid application startup and high peak execution performance.    

Through local testing, did not experience a notable difference in frames or performance on ADT-4 for normal playback, 4k, 2x speed, shorts, etc. 
                                                                                                                                                 
Also performed local testing with local UMA histograms, which showed little difference, although this change will likely be guarded with an experiment flag as this is not enough data to determine whether there is a measurable impact. 
                                                                                                                                                 
Performance Validation Results (51 Total Sequences):                                                                                                                                                                                                                          
  1. Frame Smoothness ( `PercentDroppedFrames3.AllSequences` ):                                                                                    
      • Maglev ON (Control):  27.8%  average dropped frames.                                                                                     
      • Maglev OFF (Experiment):  28.4%  average dropped frames.                                                                                 
      • Delta:  +0.6%  absolute increase (a 2.1%  relative regression).                                                              
  2. Visible UI Jank ( `Jank3.AllSequences` ):                                                                                                     
      • Maglev ON (Control):  4.76  jank events per sequence on average.                                                                         
      • Maglev OFF (Experiment):  5.37  jank events per sequence on average.                                                                     
      • Delta:  +0.61  janks per sequence (a 12.8%  relative regression).                                                                 
  3. Frame Scheduling ( `Scheduling.Renderer.DrawInterval` ):                                                                                      
      • Both builds maintain identical and stable draw rhythms locked precisely to vsync intervals, averaging  18.65 ms  (~54FPS).              
      • Delta:  0.0%  change.                                                                                                                    
                                                                                                                                                 
Bug: 504727065