### PR TITLE
starboard: Noop change to verify actions

### DIFF
--- a/starboard/configuration.h
+++ b/starboard/configuration.h
@@ -30,7 +30,7 @@
 #include "build/build_config.h"
 
 #if !BUILDFLAG(IS_COBALT)
-#error "IS_COBALT should be defined while building this file"
+#error "IS_COBALT should be defined while building this file."
 #endif
 
 // --- Common Defines --------------------------------------------------------


### PR DESCRIPTION
Add a period to the end of the error message when IS_COBALT is not defined in starboard/configuration.h.

Bug: 276483058