### PR TITLE
Posix: Add wrappers for `_Exit`

### DIFF
--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -57,6 +57,7 @@
 #include "starboard/log.h"
 #include "starboard/microphone.h"
 #include "starboard/player.h"
+#include "starboard/shared/modular/starboard_layer_posix__Exit_abi_wrappers.h"
 #include "starboard/shared/modular/starboard_layer_posix_auxv_abi_wrappers.h"
 #include "starboard/shared/modular/starboard_layer_posix_directory_abi_wrappers.h"
 #include "starboard/shared/modular/starboard_layer_posix_errno_abi_wrappers.h"
@@ -289,6 +290,7 @@ ExportedSymbols::ExportedSymbols() {
   // in //starboard/shared/modular.
   // TODO: b/316603042 - Detect via NPLB and only add the wrapper if needed.
 
+  REGISTER_WRAPPER(_Exit);
   REGISTER_WRAPPER(accept);
   REGISTER_WRAPPER(access);
   REGISTER_WRAPPER(bind);

--- a/starboard/shared/modular/BUILD.gn
+++ b/starboard/shared/modular/BUILD.gn
@@ -18,6 +18,8 @@ if ((sb_is_modular || sb_is_evergreen_compatible) &&
     current_toolchain == starboard_toolchain) {
   source_set("starboard_layer_posix_abi_wrappers") {
     sources = [
+      "starboard_layer_posix__Exit_abi_wrappers.cc",
+      "starboard_layer_posix__Exit_abi_wrappers.h",
       "starboard_layer_posix_auxv_abi_wrappers.cc",
       "starboard_layer_posix_auxv_abi_wrappers.h",
       "starboard_layer_posix_directory_abi_wrappers.cc",
@@ -83,6 +85,7 @@ if (is_cobalt_hermetic_build && !sb_is_evergreen &&
     current_toolchain == cobalt_toolchain) {
   source_set("cobalt_layer_posix_abi_wrappers") {
     sources = [
+      "cobalt_layer_posix__Exit_abi_wrappers.cc",
       "cobalt_layer_posix_auxv_abi_wrappers.cc",
       "cobalt_layer_posix_directory_abi_wrappers.cc",
       "cobalt_layer_posix_errno_abi_wrappers.cc",

--- a/starboard/shared/modular/cobalt_layer_posix__Exit_abi_wrappers.cc
+++ b/starboard/shared/modular/cobalt_layer_posix__Exit_abi_wrappers.cc
@@ -12,8 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include <stdlib.h>
-
 #include "starboard/configuration.h"
 
 extern "C" {

--- a/starboard/shared/modular/cobalt_layer_posix__Exit_abi_wrappers.cc
+++ b/starboard/shared/modular/cobalt_layer_posix__Exit_abi_wrappers.cc
@@ -1,0 +1,24 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdlib.h>
+
+#include "starboard/configuration.h"
+
+extern "C" {
+SB_NORETURN void __abi_wrap__Exit(int status);
+SB_NORETURN void _Exit(int status) {
+  __abi_wrap__Exit(status);
+}
+}

--- a/starboard/shared/modular/starboard_layer_posix__Exit_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix__Exit_abi_wrappers.cc
@@ -1,0 +1,41 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/modular/starboard_layer_posix__Exit_abi_wrappers.h"
+
+#include <stdlib.h>
+
+#include "starboard/configuration.h"
+#include "starboard/export.h"
+
+namespace {
+int musl_status_to_platform_status(int status) {
+  if (status == MUSL_EXIT_SUCCESS) {
+    return EXIT_SUCCESS;
+  }
+  if (status == MUSL_EXIT_FAILURE) {
+    return EXIT_FAILURE;
+  }
+  // Handle unlikely cases where the platform's EXIT_SUCCESS is something
+  // like 2, but we know that the incoming value represents a failure.
+  if (status == EXIT_SUCCESS) {
+    return EXIT_FAILURE;
+  }
+  return status;
+}
+}  // namespace
+
+SB_EXPORT SB_NORETURN void __abi_wrap__Exit(int status) {
+  _Exit(musl_status_to_platform_status(status));
+}

--- a/starboard/shared/modular/starboard_layer_posix__Exit_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix__Exit_abi_wrappers.h
@@ -1,0 +1,36 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_MODULAR_STARBOARD_LAYER_POSIX__EXIT_ABI_WRAPPERS_H_
+#define STARBOARD_SHARED_MODULAR_STARBOARD_LAYER_POSIX__EXIT_ABI_WRAPPERS_H_
+
+#include <stdlib.h>
+
+#include "starboard/configuration.h"
+#include "starboard/export.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define MUSL_EXIT_SUCCESS 0
+#define MUSL_EXIT_FAILURE 1
+
+SB_EXPORT SB_NORETURN void __abi_wrap__Exit(int status);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif  // STARBOARD_SHARED_MODULAR_STARBOARD_LAYER_POSIX__EXIT_ABI_WRAPPERS_H_

--- a/starboard/shared/modular/starboard_layer_posix__Exit_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix__Exit_abi_wrappers.h
@@ -15,8 +15,6 @@
 #ifndef STARBOARD_SHARED_MODULAR_STARBOARD_LAYER_POSIX__EXIT_ABI_WRAPPERS_H_
 #define STARBOARD_SHARED_MODULAR_STARBOARD_LAYER_POSIX__EXIT_ABI_WRAPPERS_H_
 
-#include <stdlib.h>
-
 #include "starboard/configuration.h"
 #include "starboard/export.h"
 

--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -85,8 +85,8 @@ _UNKNOWN_SOURCE_FILES = 'unknown_source_file(s)'
 
 # Allowed POSIX symbols in Starboard 16
 _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
-    '__errno_location',
     '_Exit',
+    '__errno_location',
     'accept',
     'access',
     'alarm',

--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -86,6 +86,7 @@ _UNKNOWN_SOURCE_FILES = 'unknown_source_file(s)'
 # Allowed POSIX symbols in Starboard 16
 _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
     '__errno_location',
+    '_Exit',
     'accept',
     'access',
     'alarm',


### PR DESCRIPTION
`_Exit`, not to be confused with the existing `exit`, is leaking from NPLB because it is a used by gmock. This adds the `_Exit` symbol by implementing a simple wrapper that ensures the exit status retains its meaning across platforms.

Bug: 477257357