### PR TITLE
Restrict delete lock file to Cobalt Android

### DIFF
--- a/components/services/storage/dom_storage/local_storage_impl.cc
+++ b/components/services/storage/dom_storage/local_storage_impl.cc
@@ -651,7 +651,7 @@ void LocalStorageImpl::InitiateConnection(bool in_memory_only) {
     // We were given a subdirectory to write to, so use a disk-backed database.
     in_memory_ = false;
 
-#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_ANDROID)
     if (base::FeatureList::IsEnabled(kLocalStorageDeleteLockFile)) {
       base::FilePath db_path = directory_.AppendASCII(kLocalStorageLeveldbName);
       base::FilePath lock_file_path = db_path.AppendASCII("LOCK");
@@ -659,7 +659,7 @@ void LocalStorageImpl::InitiateConnection(bool in_memory_only) {
           FROM_HERE,
           base::BindOnce(base::IgnoreResult(&base::DeleteFile), lock_file_path));
     }
-#endif  // BUILDFLAG(IS_COBALT)
+#endif
 
     database_ = AsyncDomStorageDatabase::OpenDirectory(
         directory_, kLocalStorageLeveldbName, memory_dump_id_,

--- a/components/services/storage/dom_storage/local_storage_impl_unittest.cc
+++ b/components/services/storage/dom_storage/local_storage_impl_unittest.cc
@@ -949,7 +949,7 @@ TEST_F(LocalStorageImplTest, OnDisk) {
       leveldb_env::LevelDBStatusValue::LEVELDB_STATUS_OK, 2);
 }
 
-#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(IS_COBALT) && BUILDFLAG(IS_ANDROID)
 TEST_F(LocalStorageImplTest, DeleteLockFile) {
   auto key = StdStringToUint8Vector("key");
   auto value = StdStringToUint8Vector("value");


### PR DESCRIPTION
Cobalt on 3p can run 2 instances at the same time, delete the lock file on it can cause bugs.
Bug: 488465561