### PR TITLE
ci: Set test_attempts to 1

### DIFF
--- a/cobalt/tools/on_device_tests_gateway_client.py
+++ b/cobalt/tools/on_device_tests_gateway_client.py
@@ -360,7 +360,7 @@ def main() -> int:
   trigger_args.add_argument(
       '--test_attempts',
       type=str,
-      default='0',
+      default='1',
       help='The maximum number of times a test can retry.',
   )
   trigger_args.add_argument(


### PR DESCRIPTION
ci: Set test_attempts default to 1 for on-device tests

This makes sure tests don't get retries on the MH side

Bug: 500107472