### PR TITLE
starboard: Add ScopedFeatureList for testing

### DIFF
--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -249,6 +249,8 @@ if (current_toolchain == starboard_toolchain) {
       ":starboard_test_main",
       "//starboard:starboard_headers_only",
       "//starboard/common:common_test",
+      "//starboard/shared/starboard:starboard_test",
+      "//starboard/testing:testing_test",
       "//testing/gtest",
     ]
 

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -80,8 +80,6 @@ static_library("starboard_platform") {
     "//starboard/shared/starboard/drm/drm_update_session.cc",
     "//starboard/shared/starboard/experimental_features.cc",
     "//starboard/shared/starboard/experimental_features.h",
-    "//starboard/shared/starboard/feature_list.cc",
-    "//starboard/shared/starboard/feature_list.h",
     "//starboard/shared/starboard/features.cc",
     "//starboard/shared/starboard/features.h",
     "//starboard/shared/starboard/file_storage/storage_close_record.cc",
@@ -302,6 +300,7 @@ static_library("starboard_platform") {
     "//cobalt/browser/h5vcc_runtime:deep_link_manager",
     "//starboard/common",
     "//starboard/extension:feature_config_header",
+    "//starboard/shared/starboard:feature_list",
     "//starboard/shared/starboard/media:media_util",
     "//starboard/shared/starboard/player/filter:filter_based_player_sources",
   ]
@@ -428,10 +427,6 @@ test("starboard_platform_tests") {
 
   # Add starboard_feature_test to Android's starboard_platform_tests,
   # since Android is the only platform that includes starboard_feature.
-  sources += [
-    "//starboard/shared/starboard/starboard_feature_test.cc",
-    "//starboard/testing/scoped_feature_list_test.cc",
-  ]
 
   configs += [ "//starboard/build/config:starboard_implementation" ]
 

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -428,7 +428,10 @@ test("starboard_platform_tests") {
 
   # Add starboard_feature_test to Android's starboard_platform_tests,
   # since Android is the only platform that includes starboard_feature.
-  sources += [ "//starboard/shared/starboard/starboard_feature_test.cc" ]
+  sources += [
+    "//starboard/shared/starboard/starboard_feature_test.cc",
+    "//starboard/testing/scoped_feature_list_test.cc",
+  ]
 
   configs += [ "//starboard/build/config:starboard_implementation" ]
 
@@ -439,6 +442,7 @@ test("starboard_platform_tests") {
     "//starboard:starboard_group",
     "//starboard/shared/starboard/drm:drm_test_helpers",
     "//starboard/shared/starboard/player/filter/testing:test_util",
+    "//starboard/testing:scoped_feature_list",
     "//testing/gmock",
     "//testing/gtest",
   ]

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -413,6 +413,7 @@ test("starboard_platform_tests") {
   sources = media_tests_sources + player_tests_sources + [
               "//starboard/common/test_main.cc",
               "drm_session_id_mapper_test.cc",
+              "features_extension_test.cc",
               "media_capabilities_cache_test.cc",
               "media_codec_decoder_test.cc",
               "media_codec_video_decoder_helpers_test.cc",
@@ -424,9 +425,6 @@ test("starboard_platform_tests") {
               "player_get_preferred_output_mode_test.cc",
               "video_frame_tracker_test.cc",
             ]
-
-  # Add starboard_feature_test to Android's starboard_platform_tests,
-  # since Android is the only platform that includes starboard_feature.
 
   configs += [ "//starboard/build/config:starboard_implementation" ]
 

--- a/starboard/android/shared/features_extension_test.cc
+++ b/starboard/android/shared/features_extension_test.cc
@@ -1,0 +1,50 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/extension/features.h"
+#include "starboard/shared/starboard/feature_list.h"
+#include "starboard/system.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace {
+
+TEST(FeaturesExtensionTest, InitializeFeatures) {
+  const StarboardExtensionFeaturesApi* extension_api =
+      static_cast<const StarboardExtensionFeaturesApi*>(
+          SbSystemGetExtension(kStarboardExtensionFeaturesName));
+  ASSERT_NE(extension_api, nullptr);
+  EXPECT_STREQ(extension_api->name, kStarboardExtensionFeaturesName);
+  EXPECT_EQ(extension_api->version, 1u);
+  ASSERT_NE(extension_api->InitializeStarboardFeatures, nullptr);
+
+  SbFeature test_feature = {"AndroidExtensionTestFeature", true};
+
+  SbFeatureParam test_param;
+  test_param.feature_name = "AndroidExtensionTestFeature";
+  test_param.param_name = "TestParam";
+  test_param.type = SbFeatureParamTypeBool;
+  test_param.value.bool_value = true;
+
+  extension_api->InitializeStarboardFeatures(&test_feature, 1, &test_param, 1);
+
+  EXPECT_TRUE(features::FeatureList::IsEnabled(test_feature));
+
+  const features::SbFeatureParamExt<bool> test_param_ext(test_feature,
+                                                         "TestParam");
+  EXPECT_TRUE(test_param_ext.Get());
+}
+
+}  // namespace
+}  // namespace starboard

--- a/starboard/android/shared/media_capabilities_cache_test.cc
+++ b/starboard/android/shared/media_capabilities_cache_test.cc
@@ -19,6 +19,8 @@
 
 #include "starboard/android/shared/mock_media_capabilities_cache.h"
 #include "starboard/media.h"
+#include "starboard/shared/starboard/features.h"
+#include "starboard/testing/scoped_feature_list.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -365,6 +367,51 @@ TEST_F(MediaCapabilitiesCacheTest, FindVideoDecoder_Overload) {
                                      /*require_software_codec=*/false,
                                      /*must_support_tunnel_mode=*/true),
             "OMX.google.vp9.decoder");
+}
+
+TEST_F(MediaCapabilitiesCacheTest, RejectLowPerformanceSoftwareDecoder) {
+  EXPECT_CALL(*mock_media_capabilities_provider_,
+              GetCodecCapabilities(testing::_, testing::_))
+      .WillOnce(testing::Invoke([](auto&, auto& video_caps) {
+        MediaCapabilitiesProvider::VideoCodecCapabilities caps;
+        caps.push_back(std::make_unique<MockVideoCodecCapability>(
+            "OMX.test.soft.vp9.decoder",
+            /*is_secure_req=*/false, /*is_secure_sup=*/false,
+            /*is_tunnel_req=*/false, /*is_tunnel_sup=*/false,
+            /*is_software_decoder=*/true,
+            /*is_hdr_capable=*/false, Range{0, 1280}, Range{0, 720},
+            Range{0, 5'000'000}, Range{0, 30}));
+        video_caps["video/x-vnd.on2.vp9"] = std::move(caps);
+      }));
+
+  // Case 1: Feature is disabled (default). It should find the software decoder.
+  {
+    features::ScopedFeatureList scoped_features;
+    scoped_features.InitAndDisableFeature(
+        features::kRejectLowPerformanceSoftwareDecoder);
+
+    EXPECT_EQ(cache_->FindVideoDecoder("video/x-vnd.on2.vp9",
+                                       /*must_support_secure=*/false,
+                                       /*must_support_hdr=*/false,
+                                       /*require_software_codec=*/false,
+                                       /*must_support_tunnel_mode=*/false),
+              "OMX.test.soft.vp9.decoder");
+  }
+
+  // Case 2: Feature is enabled. It should reject the software decoder because
+  // it is low performance.
+  {
+    features::ScopedFeatureList scoped_features;
+    scoped_features.InitAndEnableFeature(
+        features::kRejectLowPerformanceSoftwareDecoder);
+
+    EXPECT_EQ(cache_->FindVideoDecoder("video/x-vnd.on2.vp9",
+                                       /*must_support_secure=*/false,
+                                       /*must_support_hdr=*/false,
+                                       /*require_software_codec=*/false,
+                                       /*must_support_tunnel_mode=*/false),
+              "");
+  }
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/BUILD.gn
+++ b/starboard/shared/starboard/BUILD.gn
@@ -12,44 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-static_library("fake_graphics_context_provider") {
-  testonly = true
-
+static_library("feature_list") {
   sources = [
-    "fake_graphics_context_provider.cc",
-    "fake_graphics_context_provider.h",
+    "feature_list.cc",
+    "feature_list.h",
   ]
 
-  deps = [
-    "//starboard:starboard_headers_only",
-    "//starboard/common",
-    "//starboard/egl_and_gles:buildflags",
-  ]
+  deps = [ "//starboard/common" ]
 }
 
-static_library("scoped_feature_list") {
+source_set("starboard_test") {
   testonly = true
 
-  sources = [
-    "scoped_feature_list.cc",
-    "scoped_feature_list.h",
-  ]
+  sources = [ "feature_list_test.cc" ]
 
   deps = [
+    ":feature_list",
     "//starboard/common",
-    "//starboard/shared/starboard:feature_list",
-  ]
-}
-
-source_set("testing_test") {
-  testonly = true
-
-  sources = [ "scoped_feature_list_test.cc" ]
-
-  deps = [
-    ":scoped_feature_list",
-    "//starboard/common",
-    "//starboard/shared/starboard:feature_list",
     "//testing/gtest",
   ]
 }

--- a/starboard/shared/starboard/feature_list.cc
+++ b/starboard/shared/starboard/feature_list.cc
@@ -263,4 +263,22 @@ bool FeatureList::HasOverrideForTesting(const std::string& feature_name) {
          instance->overridden_features_.end();
 }
 
+// static
+std::optional<bool> FeatureList::GetOverrideForTesting(
+    const SbFeature& feature) {
+  return GetOverrideForTesting(feature.name);
+}
+
+// static
+std::optional<bool> FeatureList::GetOverrideForTesting(
+    const std::string& feature_name) {
+  FeatureList* instance = GetInstance();
+  std::lock_guard lock(instance->mutex_);
+  auto it = instance->overridden_features_.find(feature_name);
+  if (it != instance->overridden_features_.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
 }  // namespace starboard::features

--- a/starboard/shared/starboard/feature_list.cc
+++ b/starboard/shared/starboard/feature_list.cc
@@ -155,6 +155,11 @@ bool FeatureList::IsEnabledByName(const std::string& feature_name) {
   FeatureList* instance = GetInstance();
   std::lock_guard lock(instance->mutex_);
 
+  auto override_it = instance->overridden_features_.find(feature_name);
+  if (override_it != instance->overridden_features_.end()) {
+    return override_it->second;
+  }
+
   // IsEnabled can only be called after the FeatureList has been initialized.
   SB_CHECK(instance->IsInitialized())
       << "Starboard features and parameters are not initialized.";
@@ -217,4 +222,45 @@ int64_t FeatureList::GetParam(const SbFeatureParamExt<int64_t>& param) {
   return std::get<int64_t>(
       instance->params_[param.feature_name][param.param_name].second);
 }
+
+// static
+void FeatureList::SetFeatureForTesting(const std::string& feature_name,
+                                       bool enabled) {
+  FeatureList* instance = GetInstance();
+  std::lock_guard lock(instance->mutex_);
+  instance->overridden_features_[feature_name] = enabled;
+}
+
+// static
+void FeatureList::SetFeatureForTesting(const SbFeature& feature, bool enabled) {
+  SetFeatureForTesting(feature.name, enabled);
+}
+
+// static
+void FeatureList::ClearFeatureForTesting(const std::string& feature_name) {
+  FeatureList* instance = GetInstance();
+  std::lock_guard lock(instance->mutex_);
+  instance->overridden_features_.erase(feature_name);
+}
+
+// static
+void FeatureList::ClearFeatureForTesting(const SbFeature& feature) {
+  ClearFeatureForTesting(feature.name);
+}
+
+// static
+void FeatureList::ClearAllFeaturesForTesting() {
+  FeatureList* instance = GetInstance();
+  std::lock_guard lock(instance->mutex_);
+  instance->overridden_features_.clear();
+}
+
+// static
+bool FeatureList::HasOverrideForTesting(const std::string& feature_name) {
+  FeatureList* instance = GetInstance();
+  std::lock_guard lock(instance->mutex_);
+  return instance->overridden_features_.find(feature_name) !=
+         instance->overridden_features_.end();
+}
+
 }  // namespace starboard::features

--- a/starboard/shared/starboard/feature_list.h
+++ b/starboard/shared/starboard/feature_list.h
@@ -54,6 +54,21 @@ class FeatureList {
   // Template function to retrieve a parameter based on the value type of the
   // parameter.SbParams must be initialized before use. There's an SB_CHECK() to
   // ensure that the given SbFeature must exist in the FeatureList.
+  // Set a feature override for testing.
+  static void SetFeatureForTesting(const SbFeature& feature, bool enabled);
+  static void SetFeatureForTesting(const std::string& feature_name,
+                                   bool enabled);
+
+  // Clear a feature override for testing.
+  static void ClearFeatureForTesting(const SbFeature& feature);
+  static void ClearFeatureForTesting(const std::string& feature_name);
+
+  // Clear all feature overrides for testing.
+  static void ClearAllFeaturesForTesting();
+
+  // Check if a feature has an override.
+  static bool HasOverrideForTesting(const std::string& feature_name);
+
   template <typename T>
   static T GetParam(const SbFeatureParamExt<T>& param);
 
@@ -91,6 +106,10 @@ class FeatureList {
   // are the string representations of the features, and the values are the
   // associated boolean value of the feature.
   std::unordered_map<std::string, bool> features_;  // Guarded by |mutex_|.
+
+  // Overridden features for testing.
+  std::unordered_map<std::string, bool>
+      overridden_features_;  // Guarded by |mutex_|.
 
   // Starboard feature parameters will be stored in a 2D std::unordered_map,
   // where the outer map's keys will be the string of the feature associated

--- a/starboard/shared/starboard/feature_list.h
+++ b/starboard/shared/starboard/feature_list.h
@@ -69,6 +69,13 @@ class FeatureList {
   // Check if a feature has an override.
   static bool HasOverrideForTesting(const std::string& feature_name);
 
+  // Get the current override value for a feature if it exists.
+  // Returns the overridden value if the feature was overridden, otherwise
+  // std::nullopt.
+  static std::optional<bool> GetOverrideForTesting(const SbFeature& feature);
+  static std::optional<bool> GetOverrideForTesting(
+      const std::string& feature_name);
+
   template <typename T>
   static T GetParam(const SbFeatureParamExt<T>& param);
 

--- a/starboard/shared/starboard/feature_list_test.cc
+++ b/starboard/shared/starboard/feature_list_test.cc
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "starboard/shared/starboard/feature_list.h"
+
 #include <iterator>
 
-#include "starboard/shared/starboard/feature_list.h"
-#include "starboard/shared/starboard/features.h"
 #include "starboard/system.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -95,35 +95,20 @@ const SbFeatureParam kParams[] = {
 
 }  // namespace
 
-const StarboardExtensionFeaturesApi* kExtension_api = nullptr;
-
-class StarboardFeatureTest : public ::testing::Test {
+class StarboardFeatureListTest : public ::testing::Test {
  protected:
   static void SetUpTestSuite() {
-    kExtension_api = static_cast<const StarboardExtensionFeaturesApi*>(
-        SbSystemGetExtension(kStarboardExtensionFeaturesName));
-    if (!kExtension_api) {
-      return;
-    }
-
-    kExtension_api->InitializeStarboardFeatures(kFeatures, std::size(kFeatures),
-                                                kParams, std::size(kParams));
-  }
-
-  void SetUp() override {
-    if (!kExtension_api) {
-      GTEST_SKIP() << "Failed to get Starboard Features API; skipping all "
-                      "tests in this suite.";
-    }
+    FeatureList::InitializeFeatureList(kFeatures, std::size(kFeatures), kParams,
+                                       std::size(kParams));
   }
 };
 
-TEST_F(StarboardFeatureTest, CanAccessFeatures) {
+TEST_F(StarboardFeatureListTest, CanAccessFeatures) {
   EXPECT_TRUE(FeatureList::IsEnabled(kStarboardFeatureTestEnabled));
   EXPECT_FALSE(FeatureList::IsEnabled(kStarboardFeatureTestDisabled));
 }
 
-TEST_F(StarboardFeatureTest, CanAccessParams) {
+TEST_F(StarboardFeatureListTest, CanAccessParams) {
   for (const auto& param : kParams) {
     switch (param.type) {
       case SbFeatureParamTypeBool: {

--- a/starboard/testing/BUILD.gn
+++ b/starboard/testing/BUILD.gn
@@ -26,3 +26,12 @@ static_library("fake_graphics_context_provider") {
     "//starboard/egl_and_gles:buildflags",
   ]
 }
+
+static_library("scoped_feature_list") {
+  testonly = true
+
+  sources = [
+    "scoped_feature_list.cc",
+    "scoped_feature_list.h",
+  ]
+}

--- a/starboard/testing/BUILD.gn
+++ b/starboard/testing/BUILD.gn
@@ -34,4 +34,6 @@ static_library("scoped_feature_list") {
     "scoped_feature_list.cc",
     "scoped_feature_list.h",
   ]
+
+  deps = [ "//starboard:starboard_group" ]
 }

--- a/starboard/testing/scoped_feature_list.cc
+++ b/starboard/testing/scoped_feature_list.cc
@@ -1,0 +1,48 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/testing/scoped_feature_list.h"
+
+namespace starboard::features {
+
+ScopedFeatureList::~ScopedFeatureList() {
+  Reset();
+}
+
+void ScopedFeatureList::InitAndEnableFeature(const SbFeature& feature) {
+  InitAndEnableFeature(feature.name);
+}
+
+void ScopedFeatureList::InitAndEnableFeature(const std::string& feature_name) {
+  FeatureList::SetFeatureForTesting(feature_name, true);
+  overridden_features_.push_back(feature_name);
+}
+
+void ScopedFeatureList::InitAndDisableFeature(const SbFeature& feature) {
+  InitAndDisableFeature(feature.name);
+}
+
+void ScopedFeatureList::InitAndDisableFeature(const std::string& feature_name) {
+  FeatureList::SetFeatureForTesting(feature_name, false);
+  overridden_features_.push_back(feature_name);
+}
+
+void ScopedFeatureList::Reset() {
+  for (const auto& feature_name : overridden_features_) {
+    FeatureList::ClearFeatureForTesting(feature_name);
+  }
+  overridden_features_.clear();
+}
+
+}  // namespace starboard::features

--- a/starboard/testing/scoped_feature_list.cc
+++ b/starboard/testing/scoped_feature_list.cc
@@ -45,17 +45,15 @@ void ScopedFeatureList::SaveOverride(const std::string& feature_name) {
     }
   }
 
-  OriginalOverride original;
-  original.feature_name = feature_name;
-  original.value = FeatureList::GetOverrideForTesting(feature_name);
-  overridden_features_.push_back(original);
+  overridden_features_.push_back(
+      {feature_name, FeatureList::GetOverrideForTesting(feature_name)});
 }
 
 void ScopedFeatureList::Reset() {
   for (auto it = overridden_features_.rbegin();
        it != overridden_features_.rend(); ++it) {
     if (it->value.has_value()) {
-      FeatureList::SetFeatureForTesting(it->feature_name, it->value.value());
+      FeatureList::SetFeatureForTesting(it->feature_name, *it->value);
     } else {
       FeatureList::ClearFeatureForTesting(it->feature_name);
     }

--- a/starboard/testing/scoped_feature_list.cc
+++ b/starboard/testing/scoped_feature_list.cc
@@ -25,8 +25,8 @@ void ScopedFeatureList::InitAndEnableFeature(const SbFeature& feature) {
 }
 
 void ScopedFeatureList::InitAndEnableFeature(const std::string& feature_name) {
+  SaveOverride(feature_name);
   FeatureList::SetFeatureForTesting(feature_name, true);
-  overridden_features_.push_back(feature_name);
 }
 
 void ScopedFeatureList::InitAndDisableFeature(const SbFeature& feature) {
@@ -34,13 +34,31 @@ void ScopedFeatureList::InitAndDisableFeature(const SbFeature& feature) {
 }
 
 void ScopedFeatureList::InitAndDisableFeature(const std::string& feature_name) {
+  SaveOverride(feature_name);
   FeatureList::SetFeatureForTesting(feature_name, false);
-  overridden_features_.push_back(feature_name);
+}
+
+void ScopedFeatureList::SaveOverride(const std::string& feature_name) {
+  for (const auto& override : overridden_features_) {
+    if (override.feature_name == feature_name) {
+      return;
+    }
+  }
+
+  OriginalOverride original;
+  original.feature_name = feature_name;
+  original.value = FeatureList::GetOverrideForTesting(feature_name);
+  overridden_features_.push_back(original);
 }
 
 void ScopedFeatureList::Reset() {
-  for (const auto& feature_name : overridden_features_) {
-    FeatureList::ClearFeatureForTesting(feature_name);
+  for (auto it = overridden_features_.rbegin();
+       it != overridden_features_.rend(); ++it) {
+    if (it->value.has_value()) {
+      FeatureList::SetFeatureForTesting(it->feature_name, it->value.value());
+    } else {
+      FeatureList::ClearFeatureForTesting(it->feature_name);
+    }
   }
   overridden_features_.clear();
 }

--- a/starboard/testing/scoped_feature_list.cc
+++ b/starboard/testing/scoped_feature_list.cc
@@ -14,6 +14,8 @@
 
 #include "starboard/testing/scoped_feature_list.h"
 
+#include "starboard/shared/starboard/feature_list.h"
+
 namespace starboard::features {
 
 ScopedFeatureList::~ScopedFeatureList() {

--- a/starboard/testing/scoped_feature_list.h
+++ b/starboard/testing/scoped_feature_list.h
@@ -26,6 +26,12 @@ namespace starboard::features {
 // Helper class to override features in tests.
 // This follows the pattern of base::test::ScopedFeatureList in Chromium.
 //
+// Expected lifetime and ownership:
+// This class is designed to be stack-allocated (RAII). Its lifetime should
+// be scoped to the block or test where the overrides are needed. Upon
+// destruction, it automatically restores the original feature states.
+//
+// Threading model:
 // This class is NOT thread-safe. It modifies global state in FeatureList,
 // so it should only be used in single-threaded test contexts or when access
 // to FeatureList is otherwise synchronized. Multiple ScopedFeatureList

--- a/starboard/testing/scoped_feature_list.h
+++ b/starboard/testing/scoped_feature_list.h
@@ -19,7 +19,7 @@
 #include <string>
 #include <vector>
 
-#include "starboard/shared/starboard/feature_list.h"
+#include "starboard/extension/features.h"
 
 namespace starboard::features {
 

--- a/starboard/testing/scoped_feature_list.h
+++ b/starboard/testing/scoped_feature_list.h
@@ -1,0 +1,58 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_TESTING_SCOPED_FEATURE_LIST_H_
+#define STARBOARD_TESTING_SCOPED_FEATURE_LIST_H_
+
+#include <string>
+#include <vector>
+
+#include "starboard/shared/starboard/feature_list.h"
+
+namespace starboard::features {
+
+// Helper class to override features in tests.
+// This follows the pattern of base::test::ScopedFeatureList in Chromium.
+//
+// This class is NOT thread-safe. It modifies global state in FeatureList,
+// so it should only be used in single-threaded test contexts or when access
+// to FeatureList is otherwise synchronized. Multiple ScopedFeatureList
+// instances should not be active concurrently if they modify the same features.
+class ScopedFeatureList {
+ public:
+  ScopedFeatureList() = default;
+  ~ScopedFeatureList();
+
+  // Disallow copy and assign.
+  ScopedFeatureList(const ScopedFeatureList&) = delete;
+  ScopedFeatureList& operator=(const ScopedFeatureList&) = delete;
+
+  // Overrides the given feature to be enabled.
+  void InitAndEnableFeature(const SbFeature& feature);
+  void InitAndEnableFeature(const std::string& feature_name);
+
+  // Overrides the given feature to be disabled.
+  void InitAndDisableFeature(const SbFeature& feature);
+  void InitAndDisableFeature(const std::string& feature_name);
+
+  // Resets all overrides made by this instance.
+  void Reset();
+
+ private:
+  std::vector<std::string> overridden_features_;
+};
+
+}  // namespace starboard::features
+
+#endif  // STARBOARD_TESTING_SCOPED_FEATURE_LIST_H_

--- a/starboard/testing/scoped_feature_list.h
+++ b/starboard/testing/scoped_feature_list.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_TESTING_SCOPED_FEATURE_LIST_H_
 #define STARBOARD_TESTING_SCOPED_FEATURE_LIST_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -50,7 +51,13 @@ class ScopedFeatureList {
   void Reset();
 
  private:
-  std::vector<std::string> overridden_features_;
+  struct OriginalOverride {
+    std::string feature_name;
+    std::optional<bool> value;
+  };
+  std::vector<OriginalOverride> overridden_features_;
+
+  void SaveOverride(const std::string& feature_name);
 };
 
 }  // namespace starboard::features

--- a/starboard/testing/scoped_feature_list_test.cc
+++ b/starboard/testing/scoped_feature_list_test.cc
@@ -1,0 +1,114 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/testing/scoped_feature_list.h"
+
+#include "starboard/shared/starboard/feature_list.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard::features {
+namespace {
+
+const SbFeature kTestFeatureEnabledByDefault = {"TestFeatureEnabledByDefault",
+                                                true};
+const SbFeature kTestFeatureDisabledByDefault = {"TestFeatureDisabledByDefault",
+                                                 false};
+
+class ScopedFeatureListTest : public ::testing::Test {
+ protected:
+  static void SetUpTestSuite() {
+    SbFeature features[] = {
+        kTestFeatureEnabledByDefault,
+        kTestFeatureDisabledByDefault,
+    };
+    FeatureList::InitializeFeatureList(features, 2, nullptr, 0);
+  }
+
+  void SetUp() override {
+    // Ensure no leftovers from other tests.
+    FeatureList::ClearAllFeaturesForTesting();
+  }
+
+  void TearDown() override { FeatureList::ClearAllFeaturesForTesting(); }
+};
+
+TEST_F(ScopedFeatureListTest, EnableFeature) {
+  EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+
+  {
+    ScopedFeatureList scoped_list;
+    scoped_list.InitAndEnableFeature(kTestFeatureDisabledByDefault);
+    EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+  }
+
+  EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+}
+
+TEST_F(ScopedFeatureListTest, DisableFeature) {
+  EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+
+  {
+    ScopedFeatureList scoped_list;
+    scoped_list.InitAndDisableFeature(kTestFeatureEnabledByDefault);
+    EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+  }
+
+  EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+}
+
+TEST_F(ScopedFeatureListTest, MultipleFeatures) {
+  EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+  EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+
+  {
+    ScopedFeatureList scoped_list;
+    scoped_list.InitAndDisableFeature(kTestFeatureEnabledByDefault);
+    scoped_list.InitAndEnableFeature(kTestFeatureDisabledByDefault);
+
+    EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+    EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+  }
+
+  EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+  EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+}
+
+TEST_F(ScopedFeatureListTest, NestedDifferentFeatures) {
+  EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+  EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+
+  {
+    ScopedFeatureList outer;
+    outer.InitAndDisableFeature(kTestFeatureEnabledByDefault);
+    EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+
+    {
+      ScopedFeatureList inner;
+      inner.InitAndEnableFeature(kTestFeatureDisabledByDefault);
+
+      EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+      EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+    }
+
+    // Inner destructed, kTestFeatureDisabledByDefault should be restored.
+    EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+    EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+  }
+
+  EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+  EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+}
+
+}  // namespace
+}  // namespace starboard::features

--- a/starboard/testing/scoped_feature_list_test.cc
+++ b/starboard/testing/scoped_feature_list_test.cc
@@ -110,5 +110,49 @@ TEST_F(ScopedFeatureListTest, NestedDifferentFeatures) {
   EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
 }
 
+TEST_F(ScopedFeatureListTest, NestedSameFeature) {
+  EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+
+  {
+    ScopedFeatureList outer;
+    outer.InitAndEnableFeature(kTestFeatureDisabledByDefault);
+    EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+
+    {
+      ScopedFeatureList inner;
+      inner.InitAndDisableFeature(kTestFeatureDisabledByDefault);
+      EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+    }
+
+    // Inner destructed, outer's override should be restored (enabled).
+    EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+  }
+
+  // Outer destructed, should be back to default (disabled).
+  EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureDisabledByDefault));
+}
+
+TEST_F(ScopedFeatureListTest, NestedSameFeatureStartEnabled) {
+  EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+
+  {
+    ScopedFeatureList outer;
+    outer.InitAndDisableFeature(kTestFeatureEnabledByDefault);
+    EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+
+    {
+      ScopedFeatureList inner;
+      inner.InitAndEnableFeature(kTestFeatureEnabledByDefault);
+      EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+    }
+
+    // Inner destructed, outer's override should be restored (disabled).
+    EXPECT_FALSE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+  }
+
+  // Outer destructed, should be back to default (enabled).
+  EXPECT_TRUE(FeatureList::IsEnabled(kTestFeatureEnabledByDefault));
+}
+
 }  // namespace
 }  // namespace starboard::features


### PR DESCRIPTION
Introduce a ScopedFeatureList utility class to allow tests to toggle
Starboard features. This helper provides a mechanism to override
feature states within a specific scope, ensuring that global
configuration is restored once the test finishes.

The FeatureList class is updated with methods to set and clear
testing overrides, and the Android media capabilities tests are
updated to use this new functionality for verifying codec rejection
logic.

Issue: 512137801