### PR TITLE
Refactor on_host_tests to use dynamically passed test executables

### DIFF
--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -70,11 +70,10 @@ runs:
         cd unit_test/
 
         # Parse the JSON array into a space-separated string using jq.
-        # This assumes executable paths will never contain spaces.
         test_executables=$(jq -nr --arg json "${TEST_EXECUTABLES_JSON:-[]}" '$json | fromjson | join(" ")')
 
         if [[ -z "${test_executables}" ]]; then
-          echo "No tests to execute. Exiting cleanly."
+          echo "No tests to execute. Skipping."
           exit 0
         fi
 

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -73,6 +73,11 @@ runs:
         # This assumes executable paths will never contain spaces.
         test_executables=$(jq -nr --arg json "${TEST_EXECUTABLES_JSON:-[]}" '$json | fromjson | join(" ")')
 
+        if [[ -z "${test_executables}" ]]; then
+          echo "No tests to execute. Exiting cleanly."
+          exit 0
+        fi
+
         for test_executable_path in ${test_executables}; do
           filename=$(basename "${test_executable_path}")
           test_executable="${filename%%.*}"

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -69,31 +69,34 @@ runs:
         failed_suites=""
         cd unit_test/
 
-        test_binaries=$(echo "${TEST_EXECUTABLES_JSON}" | jq -cr 'join(" ")')
-        for test_binary_path in ${test_binaries}; do
-          filename=$(basename "${test_binary_path}")
-          test_binary="${filename%%.*}"
+        # Parse the JSON array into a space-separated string using jq.
+        # This assumes executable paths will never contain spaces.
+        test_executables=$(jq -nr --arg json "${TEST_EXECUTABLES_JSON:-[]}" '$json | fromjson | join(" ")')
 
-          echo "Running tests for suite: ${test_binary}"
+        for test_executable_path in ${test_executables}; do
+          filename=$(basename "${test_executable_path}")
+          test_executable="${filename%%.*}"
+
+          echo "Running tests for suite: ${test_executable}"
 
           test_filter="*"
-          test_filter_json_dir="${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}/${test_binary}_filter.json"
+          test_filter_json_dir="${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}/${test_executable}_filter.json"
           if [ -f ${test_filter_json_dir} ]; then
             test_filter=`jq -r '"-" + (.failing_tests | join(":"))' ${test_filter_json_dir}`
           fi
 
           echo "Test filter evaluated to: ${test_filter}"
-          xml_path="${test_output}/${test_binary}_result.xml"
-          log_path="${test_output}/${test_binary}_log.txt"
+          xml_path="${test_output}/${test_executable}_result.xml"
+          log_path="${test_output}/${test_executable}_log.txt"
           # TODO: Investigate test_runner.py
 
           # Check if a wrapper script was generated for the test (e.g. by test_runner_script).
           # If so, use it as the entrypoint to run tests.
-          wrapper_path="$(dirname "${test_binary_path}")/bin/run_${test_binary}"
+          wrapper_path="$(dirname "${test_executable_path}")/bin/run_${test_executable}"
           if [[ -x "${wrapper_path}" ]]; then
             ENTRYPOINT="./${wrapper_path}"
           else
-            ENTRYPOINT="./${test_binary_path}"
+            ENTRYPOINT="./${test_executable_path}"
           fi
 
           if [ "${test_filter}" == "-*" ]; then
@@ -106,7 +109,7 @@ runs:
                 --gtest_total_shards="${GTEST_TOTAL_SHARDS}" \
                 --gtest_output="xml:${xml_path}" \
                 --gtest_filter="${test_filter}" 2>&1 | tee ${log_path} || {
-              failed_suites="${failed_suites} ${test_binary}"
+              failed_suites="${failed_suites} ${test_executable}"
             }
 
             if [[ ! -f ${xml_path} ]]; then

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -72,11 +72,6 @@ runs:
         # Parse the JSON array into a space-separated string using jq.
         test_executables=$(jq -nr --arg json "${TEST_EXECUTABLES_JSON:-[]}" '$json | fromjson | join(" ")')
 
-        if [[ -z "${test_executables}" ]]; then
-          echo "No tests to execute. Skipping."
-          exit 0
-        fi
-
         for test_executable_path in ${test_executables}; do
           filename=$(basename "${test_executable_path}")
           test_executable="${filename%%.*}"

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -13,6 +13,9 @@ inputs:
   num_gtest_shards:
     description: "Total number of shards used to run the steps in this file."
     required: true
+  test_executables_json:
+    description: "JSON array of test executables to run."
+    required: true
 runs:
   using: "composite"
   steps:
@@ -38,6 +41,7 @@ runs:
         XVFB_SERVER_ARGS: "-screen 0 1920x1080x24i +render +extension GLX -noreset"
         GTEST_SHARD_INDEX: ${{ matrix.shard }}
         GTEST_TOTAL_SHARDS: ${{ inputs.num_gtest_shards }}
+        TEST_EXECUTABLES_JSON: ${{ inputs.test_executables_json }}
       run: |
         set -x
         env
@@ -65,9 +69,7 @@ runs:
         failed_suites=""
         cd unit_test/
 
-        # TODO: Refactor this to accept the parsed list of targets as an input instead of parsing here in bash.
-        test_targets_json="out/${{ matrix.platform }}_${{ matrix.config }}/test_targets.json"
-        test_binaries=$(jq -cr '[.[] | select(.executable != null and .runs_on == "host" and .test_type == "gtest") | .executable] | join(" ")' "${test_targets_json}")
+        test_binaries=$(echo "${TEST_EXECUTABLES_JSON}" | jq -cr 'join(" ")')
         for test_binary_path in ${test_binaries}; do
           filename=$(basename "${test_binary_path}")
           test_binary="${filename%%.*}"

--- a/.github/actions/test_targets_json/action.yaml
+++ b/.github/actions/test_targets_json/action.yaml
@@ -35,8 +35,8 @@ runs:
               )
             | .target
           ]' test_targets.json)"
-        echo "test_targets_json=${test_targets_json}" >> $GITHUB_OUTPUT
-        echo "test_targets_count=$(echo "${test_targets_json}" | jq -cr 'length')" >> $GITHUB_OUTPUT
+        printf "test_targets_json=%s\n" "${test_targets_json}" >> "$GITHUB_OUTPUT"
+        printf "test_targets_count=%s\n" "$(echo "${test_targets_json}" | jq -cr 'length')" >> "$GITHUB_OUTPUT"
 
         test_executables_json="$(jq -cr \
           --arg test_type "${TEST_TYPE}" \
@@ -50,7 +50,7 @@ runs:
               )
             | .executable
           ]' test_targets.json)"
-        echo "test_executables_json=${test_executables_json}" >> $GITHUB_OUTPUT
+        printf "test_executables_json=%s\n" "${test_executables_json}" >> "$GITHUB_OUTPUT"
       shell: bash
 outputs:
   test_targets_count:

--- a/.github/actions/test_targets_json/action.yaml
+++ b/.github/actions/test_targets_json/action.yaml
@@ -23,33 +23,22 @@ runs:
         TEST_TYPE: ${{ inputs.test_type }}
         RUNS_ON: ${{ inputs.runs_on }}
       run: |
-        test_targets_json="$(jq -cr \
+        filtered_json="$(jq -cr \
           --arg test_type "${TEST_TYPE}" \
           --arg runs_on "${RUNS_ON}" \
           '[
             .[]
             | select(
-                .target != null and
                 ($test_type == "" or .test_type == $test_type) and
                 ($runs_on == "" or .runs_on == $runs_on)
               )
-            | .target
           ]' test_targets.json)"
-        printf "test_targets_json=%s\n" "${test_targets_json}" >> "$GITHUB_OUTPUT"
-        printf "test_targets_count=%s\n" "$(echo "${test_targets_json}" | jq -cr 'length')" >> "$GITHUB_OUTPUT"
 
-        test_executables_json="$(jq -cr \
-          --arg test_type "${TEST_TYPE}" \
-          --arg runs_on "${RUNS_ON}" \
-          '[
-            .[]
-            | select(
-                .executable != null and
-                ($test_type == "" or .test_type == $test_type) and
-                ($runs_on == "" or .runs_on == $runs_on)
-              )
-            | .executable
-          ]' test_targets.json)"
+        test_targets_json="$(jq -ncr --argjson data "${filtered_json}" '[$data[] | select(.target != null) | .target]')"
+        printf "test_targets_json=%s\n" "${test_targets_json}" >> "$GITHUB_OUTPUT"
+        printf "test_targets_count=%s\n" "$(jq -ncr --argjson data "${test_targets_json}" '$data | length')" >> "$GITHUB_OUTPUT"
+
+        test_executables_json="$(jq -ncr --argjson data "${filtered_json}" '[$data[] | select(.executable != null) | .executable]')"
         printf "test_executables_json=%s\n" "${test_executables_json}" >> "$GITHUB_OUTPUT"
       shell: bash
 outputs:

--- a/.github/actions/test_targets_json/action.yaml
+++ b/.github/actions/test_targets_json/action.yaml
@@ -37,6 +37,20 @@ runs:
           ]' test_targets.json)"
         echo "test_targets_json=${test_targets_json}" >> $GITHUB_OUTPUT
         echo "test_targets_count=$(echo "${test_targets_json}" | jq -cr 'length')" >> $GITHUB_OUTPUT
+
+        test_executables_json="$(jq -cr \
+          --arg test_type "${TEST_TYPE}" \
+          --arg runs_on "${RUNS_ON}" \
+          '[
+            .[]
+            | select(
+                .executable != null and
+                ($test_type == "" or .test_type == $test_type) and
+                ($runs_on == "" or .runs_on == $runs_on)
+              )
+            | .executable
+          ]' test_targets.json)"
+        echo "test_executables_json=${test_executables_json}" >> $GITHUB_OUTPUT
       shell: bash
 outputs:
   test_targets_count:
@@ -45,3 +59,6 @@ outputs:
   test_targets_json:
     description: The matched test targets in a JSON array.
     value: '${{ steps.parse-json.outputs.test_targets_json }}'
+  test_executables_json:
+    description: The matched test executables in a JSON array.
+    value: '${{ steps.parse-json.outputs.test_executables_json }}'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -760,6 +760,7 @@ jobs:
           test_artifacts_key: ${{ env.TEST_ARTIFACTS_KEY }}
           test_results_key: ${{ env.TEST_RESULTS_KEY }}
           num_gtest_shards: ${{ needs.initialize.outputs.num_gtest_shards }}
+          test_executables_json: ${{ steps.parse-host-targets.outputs.test_executables_json }}
     outputs:
       test_targets_json: ${{ steps.parse-host-targets.outputs.test_targets_json }}
 


### PR DESCRIPTION
- Extend `test_targets_json` action to output `test_executables_json`.
- Modify `on_host_tests` to accept `test_executables_json` instead of hardcoded parsing.
- Update `main.yaml` to pipe the output correctly.

Bug: 431780245