### PR TITLE
Add `getpriority` to allowed symbols list

### DIFF
--- a/starboard/tools/api_leak_detector/api_leak_detector.py
+++ b/starboard/tools/api_leak_detector/api_leak_detector.py
@@ -127,6 +127,7 @@ _ALLOWED_SB_GE_16_POSIX_SYMBOLS = [
     'getifaddrs',
     'getpeername',
     'getpid',
+    'getpriority',
     'getrandom',
     'getrlimit',
     'getsockname',


### PR DESCRIPTION
`getpriority` already has a registered wrapper, but the API leak detector is picking it up in NPLB because it isn't in the allowlist yet.

Bug: 477257357