### PR TITLE
docs: Update Docker setup for 27 LTS

### DIFF
--- a/cobalt/site/docs/development/setup-docker-legacy.md
+++ b/cobalt/site/docs/development/setup-docker-legacy.md
@@ -1,0 +1,102 @@
+Project: /youtube/cobalt/_project.yaml
+Book: /youtube/cobalt/_book.yaml
+
+# Set up your environment - Docker
+
+We provide <a
+href="https://github.com/youtube/cobalt/tree/main/docker/linux/">Docker image definitions</a> to simplify managing build environments.
+
+The instructions below assume Docker is installed and is able to run basic
+hello-world verification. `docker compose` command is expected to be available as well.
+
+## Set up your workstation
+
+Clone the Cobalt code repository. The following `git` command creates a
+`cobalt` directory that contains the repository:
+
+```
+$ git clone https://github.com/youtube/cobalt.git
+$ cd cobalt
+```
+
+### Usage
+
+The simplest usage is:
+
+```
+docker compose run <platform>
+```
+
+By default, a `debug` build will be built, with `cobalt` as a target.
+You can override this with an environment variable, e.g.
+
+```
+docker compose run -e CONFIG=devel -e TARGET=nplb <platform>
+```
+
+where config is one of the four optimization levels, `debug`, `devel`,
+`qa` and `gold`, and target is the build target passed to ninja
+
+See <a
+href="https://github.com/youtube/cobalt#building-and-running-the-code">Cobalt README</a> for full details.
+
+Builds will be available in your `${COBALT_SRC}/out` directory.
+
+<aside class="note">
+Note that Docker runs processes as root user by default, hence
+output files in `src/out/<platform>` directory have `root` as file owner.
+</aside>
+
+#### Windows Builds
+
+We have a separate docker compose file for windows. Use the -f or --file flags
+to specify a configuration file to use.
+
+```
+docker compose -f docker-compose-windows.yml run win-win32
+```
+
+### Customization
+
+To parametrize base operating system images used for the build, pass
+`BASE_OS` as an argument to `docker compose` as follows:
+
+```
+docker compose build --build-arg BASE_OS="ubuntu:bionic" base
+```
+
+This parameter is defined in `docker/linux/base/Dockerfile` and is passed
+to Docker `FROM ...` statement.
+
+Available parameters for customizing container execution are:
+
+**BASE_OS**: passed to `base` image at build time to select a Debian-based
+   base os image and version. Defaults to Debian 10. `ubuntu:bionic` and
+   `ubuntu:xenial` are other tested examples.
+
+**PLATFORM**: Cobalt build platform, passed to GN
+
+**CONFIG**: Cobalt build config, passed to GN. Defaults to `debug`
+
+**TARGET**: Build target, passed to `ninja`
+
+The `docker-compose.yml` contains the currently defined experimental build
+configurations. Edit or add new `service` entries as needed, to build custom
+configurations.
+
+
+### Pre-built images
+
+Note: Pre-built images from a public container registry are not yet available.
+
+### Troubleshooting
+
+To debug build issues, enter the shell of the corresponding build container
+by launching the bash shell, i.e.
+
+```
+docker compose run linux-x64x11 /bin/bash
+```
+
+and try to build Cobalt with the <a
+href="https://github.com/youtube/cobalt#building-and-running-the-code">usual GN / ninja flow.</a>

--- a/cobalt/site/docs/development/setup-docker-legacy.md
+++ b/cobalt/site/docs/development/setup-docker-legacy.md
@@ -40,7 +40,7 @@ where config is one of the four optimization levels, `debug`, `devel`,
 `qa` and `gold`, and target is the build target passed to ninja
 
 See <a
-href="https://github.com/youtube/cobalt#building-and-running-the-code">Cobalt README</a> for full details.
+href="https://github.com/youtube/cobalt/blob/25.lts.1%2B/README.md#building-and-running-the-code">Cobalt README</a> for full details.
 
 Builds will be available in your `${COBALT_SRC}/out` directory.
 
@@ -100,7 +100,5 @@ by launching the bash shell, i.e.
 docker compose run linux-x64x11 /bin/bash
 ```
 
-and try to build Cobalt with the usual GN/Ninja flow described in
-[setup-linux.md].
-<a
-href="https://github.com/youtube/cobalt#building-and-running-the-code">usual GN / ninja flow.</a>
+and try to build Cobalt with the <a
+href="https://github.com/youtube/cobalt/blob/25.lts.1%2B/README.md#building-and-running-the-code">usual GN / ninja flow.</a>

--- a/cobalt/site/docs/development/setup-docker-legacy.md
+++ b/cobalt/site/docs/development/setup-docker-legacy.md
@@ -1,9 +1,12 @@
 Project: /youtube/cobalt/_project.yaml
 Book: /youtube/cobalt/_book.yaml
 
-NOTE: These are the instructions for Docker builds with Cobalt 25 LTS and older.
-
 # Setup Docker for Building Cobalt
+
+> [!NOTE]
+> * These are the instructions for Docker builds with Cobalt 25 LTS and older.
+>
+> * For instructions for 26 LTS and older see [setup-docker.md].
 
 We provide <a
 href="https://github.com/youtube/cobalt/tree/25.lts.1%2B/docker/linux">Docker image definitions</a> to simplify managing build environments.

--- a/cobalt/site/docs/development/setup-docker-legacy.md
+++ b/cobalt/site/docs/development/setup-docker-legacy.md
@@ -6,7 +6,7 @@ Book: /youtube/cobalt/_book.yaml
 > [!NOTE]
 > * These are the instructions for Docker builds with Cobalt 25 LTS and older.
 >
-> * For instructions for 26 LTS and older see [setup-docker.md].
+> * For instructions for 26 LTS and older see (latest docker setup instructions)[setup-docker.md].
 
 We provide <a
 href="https://github.com/youtube/cobalt/tree/25.lts.1%2B/docker/linux">Docker image definitions</a> to simplify managing build environments.

--- a/cobalt/site/docs/development/setup-docker-legacy.md
+++ b/cobalt/site/docs/development/setup-docker-legacy.md
@@ -6,7 +6,7 @@ Book: /youtube/cobalt/_book.yaml
 > [!NOTE]
 > * These are the instructions for Docker builds with Cobalt 25 LTS and older.
 >
-> * For instructions for 26 LTS and older see (latest docker setup instructions)[setup-docker.md].
+> * For instructions for 26 LTS and older see [latest docker setup instructions](setup-docker.md).
 
 We provide <a
 href="https://github.com/youtube/cobalt/tree/25.lts.1%2B/docker/linux">Docker image definitions</a> to simplify managing build environments.

--- a/cobalt/site/docs/development/setup-docker-legacy.md
+++ b/cobalt/site/docs/development/setup-docker-legacy.md
@@ -1,10 +1,12 @@
 Project: /youtube/cobalt/_project.yaml
 Book: /youtube/cobalt/_book.yaml
 
-# Set up your environment - Docker
+NOTE: These are the instructions for Docker builds with Cobalt 25 LTS and older.
+
+# Setup Docker for Building Cobalt
 
 We provide <a
-href="https://github.com/youtube/cobalt/tree/main/docker/linux/">Docker image definitions</a> to simplify managing build environments.
+href="https://github.com/youtube/cobalt/tree/25.lts.1%2B/docker/linux">Docker image definitions</a> to simplify managing build environments.
 
 The instructions below assume Docker is installed and is able to run basic
 hello-world verification. `docker compose` command is expected to be available as well.
@@ -98,5 +100,7 @@ by launching the bash shell, i.e.
 docker compose run linux-x64x11 /bin/bash
 ```
 
-and try to build Cobalt with the <a
+and try to build Cobalt with the usual GN/Ninja flow described in
+[setup-linux.md].
+<a
 href="https://github.com/youtube/cobalt#building-and-running-the-code">usual GN / ninja flow.</a>

--- a/cobalt/site/docs/development/setup-docker.md
+++ b/cobalt/site/docs/development/setup-docker.md
@@ -1,7 +1,7 @@
 Project: /youtube/cobalt/_project.yaml
 Book: /youtube/cobalt/_book.yaml
 
-# Set up your environment - Docker
+# Setup Docker for Building Cobalt
 
 We provide Docker image definitions to simplify managing Cobalt build environments on Linux.
 
@@ -27,30 +27,29 @@ docker build -t linux cobalt/docker/linux
 
 ## 2. Launching the Linux Container
 
-To run build commands in the container environment as your host user (matching your host user's UID and GID to prevent files created in the mounts from being owned by root), launch it using:
+To run build commands in the container environment first launch the container using:
 
 ```bash
 docker run --rm \
   --user $(id -u):$(id -g) \
   -e HOME=/tmp \
-  -v /path/to/parent/directory:/chromium \
-  -w /chromium/src \
-  -e PYTHONPATH="/chromium/src" \
+  -v /path/to/workspace:/cobalt \
+  -w /cobalt/src \
+  -e PYTHONPATH="/cobalt/src" \
   -it linux /bin/bash
 ```
 
-> [!NOTE]
-> * Replace `/path/to/parent/directory` with the absolute path of the parent directory on your host machine (e.g. the directory containing `.gclient`, `tools/`, and `src/`). Mounting the parent directory ensures all relative path checks for gclient and depot_tools succeed.
-> * Setting `-e HOME=/tmp` redirects the home directory inside the container to a writeable directory, avoiding permission errors when build tools (like `autoninja`) try to write to telemetry or cache configurations under the default home directory (`/` when running as a non-root user).
+IMPORTANT: the `/path/to/workspace` should contain both the repo checkout at in `src/` and the `depot_tools` checkout.
+
 
 ## 3. Building Cobalt inside the Container
 
-Once inside the interactive container shell (at `/chromium/src`), run the following commands sequentially to configure and build the Cobalt target:
+Once inside the interactive container shell (at `/cobalt/src`), run the following commands sequentially to configure and build the Cobalt target:
 
 1. **Set the environment PATH variable**:
    Set the path to locate `depot_tools` and `ninja` correctly:
    ```bash
-   export PATH="/chromium/tools/depot_tools:/chromium/src/third_party/ninja:/chromium/src:$PATH"
+   export PATH="/cobalt/tools/depot_tools:/cobalt/src/third_party/ninja:/cobalt/src:$PATH"
    ```
 
 2. **(Optional) Clean stale build locks**:

--- a/cobalt/site/docs/development/setup-docker.md
+++ b/cobalt/site/docs/development/setup-docker.md
@@ -39,7 +39,8 @@ docker run --rm \
   -it linux /bin/bash
 ```
 
-IMPORTANT: the `/path/to/workspace` should contain both the repo checkout at in `src/` and the `depot_tools` checkout.
+> [!IMPORTANT]
+> * The `/path/to/workspace` should contain both the repo checkout at in `src/` and the `depot_tools` checkout.
 
 
 ## 3. Building Cobalt inside the Container

--- a/cobalt/site/docs/development/setup-docker.md
+++ b/cobalt/site/docs/development/setup-docker.md
@@ -3,100 +3,70 @@ Book: /youtube/cobalt/_book.yaml
 
 # Set up your environment - Docker
 
-We provide <a
-href="https://github.com/youtube/cobalt/tree/main/docker/linux/">Docker image definitions</a> to simplify managing build environments.
+We provide Docker image definitions to simplify managing Cobalt build environments on Linux.
 
-The instructions below assume Docker is installed and is able to run basic
-hello-world verification. `docker compose` command is expected to be available as well.
+## Prerequisites
 
-## Set up your workstation
+These instructions assume:
+- You have already set up your Cobalt repository workspace on the host machine.
+- Docker is installed and running on your host Linux machine. If you need to install Docker, refer to the [official Docker installation guide for Linux](https://docs.docker.com/engine/install/).
 
-Clone the Cobalt code repository. The following `git` command creates a
-`cobalt` directory that contains the repository:
+## 1. Building the Linux Docker Image
 
-```
-$ git clone https://github.com/youtube/cobalt.git
-$ cd cobalt
-```
+To build the `linux` builder Docker image, run one of the following commands from your workspace root (the directory containing `docker-compose.yaml`):
 
-### Usage
-
-The simplest usage is:
-
-```
-docker compose run <platform>
+Using `docker compose`:
+```bash
+docker compose build linux
 ```
 
-By default, a `debug` build will be built, with `cobalt` as a target.
-You can override this with an environment variable, e.g.
-
-```
-docker compose run -e CONFIG=devel -e TARGET=nplb <platform>
+Or using Docker directly:
+```bash
+docker build -t linux cobalt/docker/linux
 ```
 
-where config is one of the four optimization levels, `debug`, `devel`,
-`qa` and `gold`, and target is the build target passed to ninja
+## 2. Launching the Linux Container
 
-See <a
-href="https://github.com/youtube/cobalt#building-and-running-the-code">Cobalt README</a> for full details.
+To run build commands in the container environment as your host user (matching your host user's UID and GID to prevent files created in the mounts from being owned by root), launch it using:
 
-Builds will be available in your `${COBALT_SRC}/out` directory.
-
-<aside class="note">
-Note that Docker runs processes as root user by default, hence
-output files in `src/out/<platform>` directory have `root` as file owner.
-</aside>
-
-#### Windows Builds
-
-We have a separate docker compose file for windows. Use the -f or --file flags
-to specify a configuration file to use.
-
-```
-docker compose -f docker-compose-windows.yml run win-win32
+```bash
+docker run --rm \
+  --user $(id -u):$(id -g) \
+  -e HOME=/tmp \
+  -v /path/to/parent/directory:/chromium \
+  -w /chromium/src \
+  -e PYTHONPATH="/chromium/src" \
+  -it linux /bin/bash
 ```
 
-### Customization
+> [!NOTE]
+> * Replace `/path/to/parent/directory` with the absolute path of the parent directory on your host machine (e.g. the directory containing `.gclient`, `tools/`, and `src/`). Mounting the parent directory ensures all relative path checks for gclient and depot_tools succeed.
+> * Setting `-e HOME=/tmp` redirects the home directory inside the container to a writeable directory, avoiding permission errors when build tools (like `autoninja`) try to write to telemetry or cache configurations under the default home directory (`/` when running as a non-root user).
 
-To parametrize base operating system images used for the build, pass
-`BASE_OS` as an argument to `docker compose` as follows:
+## 3. Building Cobalt inside the Container
 
-```
-docker compose build --build-arg BASE_OS="ubuntu:bionic" base
-```
+Once inside the interactive container shell (at `/chromium/src`), run the following commands sequentially to configure and build the Cobalt target:
 
-This parameter is defined in `docker/linux/base/Dockerfile` and is passed
-to Docker `FROM ...` statement.
+1. **Set the environment PATH variable**:
+   Set the path to locate `depot_tools` and `ninja` correctly:
+   ```bash
+   export PATH="/chromium/tools/depot_tools:/chromium/src/third_party/ninja:/chromium/src:$PATH"
+   ```
 
-Available parameters for customizing container execution are:
+2. **(Optional) Clean stale build locks**:
+   If a previous compilation attempt was interrupted, a stale lock file might block siso. You can clean it by running:
+   ```bash
+   rm -f out/linux-x64x11_devel/.siso_lock
+   ```
 
-**BASE_OS**: passed to `base` image at build time to select a Debian-based
-   base os image and version. Defaults to Debian 10. `ubuntu:bionic` and
-   `ubuntu:xenial` are other tested examples.
+3. **Generate the build configuration files** for the `linux-x64x11` platform, using the `devel` config, and disabling Remote Build Execution (RBE):
+   ```bash
+   python3 cobalt/build/gn.py -p linux-x64x11 -C devel --no-rbe
+   ```
 
-**PLATFORM**: Cobalt build platform, passed to GN
+4. **Compile the Cobalt target** using `autoninja`:
+   ```bash
+   autoninja -C out/linux-x64x11_devel cobalt
+   ```
 
-**CONFIG**: Cobalt build config, passed to GN. Defaults to `debug`
-
-**TARGET**: Build target, passed to `ninja`
-
-The `docker-compose.yml` contains the currently defined experimental build
-configurations. Edit or add new `service` entries as needed, to build custom
-configurations.
-
-
-### Pre-built images
-
-Note: Pre-built images from a public container registry are not yet available.
-
-### Troubleshooting
-
-To debug build issues, enter the shell of the corresponding build container
-by launching the bash shell, i.e.
-
-```
-docker compose run linux-x64x11 /bin/bash
-```
-
-and try to build Cobalt with the <a
-href="https://github.com/youtube/cobalt#building-and-running-the-code">usual GN / ninja flow.</a>
+Completed builds will be generated in the `out/linux-x64x11_devel` directory in your workspace.


### PR DESCRIPTION
Update the main Docker documentation to reflect the new build workflow
introduced for Cobalt 27 LTS. This includes updated instructions for
building images, launching containers with proper user permissions, and
using the Chromium-based GN and autoninja build flow.

Preserve the previous Docker instructions in a new legacy setup file to
maintain documentation for older branches.

Bug: 508341541