### PR TITLE
media: Add configurable Video Buffer Pool size for 720p

### DIFF
--- a/media/base/demuxer_memory_limit.h
+++ b/media/base/demuxer_memory_limit.h
@@ -27,6 +27,7 @@ GetDemuxerStreamVideoMemoryLimit(DemuxerType demuxer_type,
 MEDIA_EXPORT size_t GetDemuxerMemoryLimit(DemuxerType demuxer_type);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+MEDIA_EXPORT void Set720pVideoBufferSizeClamp(int size_mb);
 MEDIA_EXPORT size_t GetVideoBufferSizeClamp();
 MEDIA_EXPORT void SetVideoBufferSizeClamp(int size_mb);
 #endif

--- a/media/base/starboard/demuxer_memory_limit_starboard.cc
+++ b/media/base/starboard/demuxer_memory_limit_starboard.cc
@@ -30,8 +30,11 @@
 namespace media {
 namespace {
 
-// |g_video_buffer_size_clamp_bytes| is process-wide, and is currently set by
-// a h5vcc flag.
+// |g_720p_video_buffer_size_clamp_bytes| and
+// |g_video_buffer_size_clamp_bytes| are process-wide, and are currently set by
+// h5vcc flags.
+std::atomic<size_t> g_720p_video_buffer_size_clamp_bytes{
+    std::numeric_limits<size_t>::max()};
 std::atomic<size_t> g_video_buffer_size_clamp_bytes{
     std::numeric_limits<size_t>::max()};
 
@@ -62,6 +65,13 @@ int GetBitsPerPixel(const VideoDecoderConfig& video_config) {
 
 }  // namespace
 
+void Set720pVideoBufferSizeClamp(int size_mb) {
+  CHECK_GE(size_mb, 0);
+  CHECK_LT(size_mb, 4096);
+  g_720p_video_buffer_size_clamp_bytes =
+      static_cast<size_t>(size_mb) * 1024 * 1024;
+}
+
 size_t GetVideoBufferSizeClamp() {
   return g_video_buffer_size_clamp_bytes.load();
 }
@@ -83,6 +93,14 @@ size_t GetDemuxerStreamAudioMemoryLimit(
 size_t GetDemuxerStreamVideoMemoryLimit(
     DemuxerType /*demuxer_type*/,
     const VideoDecoderConfig* video_config) {
+  if (const size_t limit_720p = g_720p_video_buffer_size_clamp_bytes.load();
+      limit_720p != std::numeric_limits<size_t>::max() && video_config) {
+    const gfx::Size resolution = video_config->visible_rect().size();
+    if (resolution.width() <= 1280 && resolution.height() <= 720) {
+      return limit_720p;
+    }
+  }
+
   size_t limit;
   if (!video_config) {
     limit = GetVideoDecoderBufferLimitBytes(

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -214,6 +214,13 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
                                     return base::ok();
                                   });
   }
+  if (name == "Media.720pVideoBufferSizeClampMb") {
+    return ProcessSettingAsPositiveInt(
+        script_state, exception_context, name, *value, [](int int_value) {
+          ::media::Set720pVideoBufferSizeClamp(int_value);
+          return true;
+        });
+  }
   if (name == "Media.ExperimentalMaxPendingBytesPerParse") {
     return ProcessSettingAsPositiveInt(
         script_state, exception_context, name, *value, [](int int_value) {


### PR DESCRIPTION
Introduce the Media.Configurable720pMediaBudgetMb H5vcc setting to
control the video buffer memory limit for resolutions up to 720p.

This change allows for runtime tuning of the demuxer memory limit to
optimize playback performance and memory footprint specifically for
720p video content. The limit applies when the video resolution is
1280x720 or lower.

Bug: 416105795