### PR TITLE
starboard: Clarify experimental extension usage

### DIFF
--- a/starboard/extension/experimental/README.md
+++ b/starboard/extension/experimental/README.md
@@ -1,7 +1,9 @@
 # starboard/extension/experimental
 
-Please **DO NOT** use the features in this folder.
+**INTERNAL USE ONLY**
 
-Features contained in this folder are strictly experimental. They do not
-constitute a stable interface or ABI, and are subject to change or removal
-at any time, even within the same Cobalt/Starboard version.
+The features in this folder are dedicated to temporary internal experiments
+by Cobalt/Starboard maintainers.
+
+They **DO NOT** constitute a stable interface or ABI, and are subject to change
+or removal at any time, even within the same Cobalt/Starboard version.


### PR DESCRIPTION
Update the README in the experimental extensions directory to clarify
that these features are for internal use by maintainers only. This
prevents third-party developers from relying on these interfaces,
which are unstable and subject to change or removal at any time.

Bug: 520023679