### PR TITLE
media: Erase id_to_mime_map_ entry on RemoveId

### DIFF
--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -928,6 +928,9 @@ void ChunkDemuxer::RemoveId(const std::string& id) {
     CHECK(stream_found);
   }
   id_to_streams_map_.erase(id);
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  id_to_mime_map_.erase(id);
+#endif
 }
 
 Ranges<base::TimeDelta> ChunkDemuxer::GetBufferedRanges(


### PR DESCRIPTION
Ensure the MIME type mapping for a source buffer ID is cleared when the
ID is removed from the demuxer. This prevents the demuxer from holding
onto stale state in the Starboard media implementation, maintaining
consistency across internal maps when source buffers are detached.

Bug: 519741453