### PR TITLE
android: Direct-copy Java buffer to array for GetTransformMatrix

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
@@ -32,6 +32,11 @@ public class VideoSurfaceTexture extends SurfaceTexture {
   @GuardedBy("mLock")
   private long mNativeVideoSurfaceTextureBridge;
 
+  // Cache the matrix to avoid allocating a new float[16] array on every call
+  // to getTransformMatrix(), which is called on the rendering hot path (60fps)
+  // and would cause significant Garbage Collection (GC) churn.
+  private final float[] mTransformMatrix = new float[16];
+
   @CalledByNative
   VideoSurfaceTexture(int texName) {
     super(texName);
@@ -74,8 +79,9 @@ public class VideoSurfaceTexture extends SurfaceTexture {
   }
 
   @CalledByNative
-  public void getTransformMatrix(float[] mtx) {
-    super.getTransformMatrix(mtx);
+  public float[] getTransformMatrix() {
+    super.getTransformMatrix(mTransformMatrix);
+    return mTransformMatrix;
   }
 
   @NativeMethods

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
@@ -32,14 +32,10 @@ public class VideoSurfaceTexture extends SurfaceTexture {
   @GuardedBy("mLock")
   private long mNativeVideoSurfaceTextureBridge;
 
-  // Cache the matrix per thread to avoid allocating a new float[16] array on every call
-  // to getTransformMatrix(), which is called on the rendering hot path (60fps).
-  private final ThreadLocal<float[]> mTransformMatrix = new ThreadLocal<float[]>() {
-    @Override
-    protected float[] initialValue() {
-      return new float[16];
-    }
-  };
+  // Cache the matrix to avoid allocating a new float[16] array on every call
+  // to getTransformMatrix(), which is called on the rendering hot path (60fps)
+  // and would cause significant Garbage Collection (GC) churn.
+  private final float[] mTransformMatrix = new float[16];
 
   @CalledByNative
   VideoSurfaceTexture(int texName) {
@@ -84,9 +80,8 @@ public class VideoSurfaceTexture extends SurfaceTexture {
 
   @CalledByNative
   public float[] getTransformMatrix() {
-    float[] mtx = mTransformMatrix.get();
-    super.getTransformMatrix(mtx);
-    return mtx;
+    super.getTransformMatrix(mTransformMatrix);
+    return mTransformMatrix;
   }
 
   @NativeMethods

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceTexture.java
@@ -32,10 +32,14 @@ public class VideoSurfaceTexture extends SurfaceTexture {
   @GuardedBy("mLock")
   private long mNativeVideoSurfaceTextureBridge;
 
-  // Cache the matrix to avoid allocating a new float[16] array on every call
-  // to getTransformMatrix(), which is called on the rendering hot path (60fps)
-  // and would cause significant Garbage Collection (GC) churn.
-  private final float[] mTransformMatrix = new float[16];
+  // Cache the matrix per thread to avoid allocating a new float[16] array on every call
+  // to getTransformMatrix(), which is called on the rendering hot path (60fps).
+  private final ThreadLocal<float[]> mTransformMatrix = new ThreadLocal<float[]>() {
+    @Override
+    protected float[] initialValue() {
+      return new float[16];
+    }
+  };
 
   @CalledByNative
   VideoSurfaceTexture(int texName) {
@@ -80,8 +84,9 @@ public class VideoSurfaceTexture extends SurfaceTexture {
 
   @CalledByNative
   public float[] getTransformMatrix() {
-    super.getTransformMatrix(mTransformMatrix);
-    return mTransformMatrix;
+    float[] mtx = mTransformMatrix.get();
+    super.getTransformMatrix(mtx);
+    return mtx;
   }
 
   @NativeMethods

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -110,23 +110,6 @@ const int kMaxPendingInputsSize = 128;
 
 const int kFpsGuesstimateRequiredInputBufferCount = 3;
 
-std::array<float, 16> GetTransformMatrix(
-    const JavaRef<jobject>& surface_texture) {
-  JNIEnv* env = AttachCurrentThread();
-
-  jni_zero::ScopedJavaLocalRef<jfloatArray> java_array(env,
-                                                       env->NewFloatArray(16));
-  SB_CHECK(java_array);
-
-  VideoSurfaceTextureBridge::GetTransformMatrix(
-      env, surface_texture,
-      jni_zero::JavaParamRef<jfloatArray>(env, java_array.obj()));
-
-  std::array<float, 16> matrix4x4;
-  env->GetFloatArrayRegion(java_array.obj(), 0, 16, matrix4x4.data());
-  return matrix4x4;
-}
-
 void StubDrmSessionUpdateRequestFunc(SbDrmSystem drm_system,
                                      void* context,
                                      int ticket,
@@ -622,10 +605,14 @@ SbDecodeTarget MediaCodecVideoDecoder::GetCurrentDecodeTarget() {
 void MediaCodecVideoDecoder::UpdateDecodeTargetSizeAndContentRegion_Locked() {
   SB_DCHECK(!frame_sizes_.empty());
 
+  JNIEnv* env = AttachCurrentThread();
+  std::array<float, 16> matrix4x4;
+
   while (!frame_sizes_.empty()) {
     const auto& frame_size = frame_sizes_.front();
     if (frame_size.has_crop_values) {
-      auto matrix4x4 = GetTransformMatrix(decode_target_->surface_texture());
+      VideoSurfaceTextureBridge::GetTransformMatrix(
+          env, decode_target_->surface_texture(), &matrix4x4);
       auto [content_region, coded_size] =
           GetDecodeTargetGeometryFromMatrix(matrix4x4, frame_size.display_size);
 
@@ -685,7 +672,8 @@ void MediaCodecVideoDecoder::UpdateDecodeTargetSizeAndContentRegion_Locked() {
   // the video texture, which is true for most of the playbacks.
   // Leaving the legacy logic in place in case the new logic above doesn't work
   // on some devices, so at least the majority of playbacks still work.
-  auto matrix4x4 = GetTransformMatrix(decode_target_->surface_texture());
+  VideoSurfaceTextureBridge::GetTransformMatrix(
+      env, decode_target_->surface_texture(), &matrix4x4);
   auto [content_region, coded_size] = GetDecodeTargetGeometryFromMatrix(
       matrix4x4, frame_sizes_.back().display_size);
   decode_target_->set_dimension(coded_size);

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -606,13 +606,12 @@ void MediaCodecVideoDecoder::UpdateDecodeTargetSizeAndContentRegion_Locked() {
   SB_DCHECK(!frame_sizes_.empty());
 
   JNIEnv* env = AttachCurrentThread();
-  std::array<float, 16> matrix4x4;
 
   while (!frame_sizes_.empty()) {
     const auto& frame_size = frame_sizes_.front();
     if (frame_size.has_crop_values) {
-      VideoSurfaceTextureBridge::GetTransformMatrix(
-          env, decode_target_->surface_texture(), &matrix4x4);
+      auto matrix4x4 = VideoSurfaceTextureBridge::GetTransformMatrix(
+          env, decode_target_->surface_texture());
       auto [content_region, coded_size] =
           GetDecodeTargetGeometryFromMatrix(matrix4x4, frame_size.display_size);
 
@@ -672,8 +671,8 @@ void MediaCodecVideoDecoder::UpdateDecodeTargetSizeAndContentRegion_Locked() {
   // the video texture, which is true for most of the playbacks.
   // Leaving the legacy logic in place in case the new logic above doesn't work
   // on some devices, so at least the majority of playbacks still work.
-  VideoSurfaceTextureBridge::GetTransformMatrix(
-      env, decode_target_->surface_texture(), &matrix4x4);
+  auto matrix4x4 = VideoSurfaceTextureBridge::GetTransformMatrix(
+      env, decode_target_->surface_texture());
   auto [content_region, coded_size] = GetDecodeTargetGeometryFromMatrix(
       matrix4x4, frame_sizes_.back().display_size);
   decode_target_->set_dimension(coded_size);

--- a/starboard/android/shared/video_surface_texture_bridge.cc
+++ b/starboard/android/shared/video_surface_texture_bridge.cc
@@ -66,8 +66,13 @@ void VideoSurfaceTextureBridge::UpdateTexImage(
 void VideoSurfaceTextureBridge::GetTransformMatrix(
     JNIEnv* env,
     const JavaRef<jobject>& surface_texture,
-    const JavaParamRef<jfloatArray>& mtx) {
-  Java_VideoSurfaceTexture_getTransformMatrix(env, surface_texture, mtx);
+    std::array<float, 16>* out_matrix) {
+  SB_CHECK(out_matrix);
+  ScopedJavaLocalRef<jfloatArray> java_array =
+      Java_VideoSurfaceTexture_getTransformMatrix(env, surface_texture);
+  SB_CHECK(java_array);
+  env->GetFloatArrayRegion(java_array.obj(), /*start=*/0, /*len=*/16,
+                           out_matrix->data());
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/video_surface_texture_bridge.cc
+++ b/starboard/android/shared/video_surface_texture_bridge.cc
@@ -63,16 +63,16 @@ void VideoSurfaceTextureBridge::UpdateTexImage(
 }
 
 // static
-void VideoSurfaceTextureBridge::GetTransformMatrix(
+std::array<float, 16> VideoSurfaceTextureBridge::GetTransformMatrix(
     JNIEnv* env,
-    const JavaRef<jobject>& surface_texture,
-    std::array<float, 16>* out_matrix) {
-  SB_CHECK(out_matrix);
+    const JavaRef<jobject>& surface_texture) {
   ScopedJavaLocalRef<jfloatArray> java_array =
       Java_VideoSurfaceTexture_getTransformMatrix(env, surface_texture);
   SB_CHECK(java_array);
+  std::array<float, 16> out_matrix;
   env->GetFloatArrayRegion(java_array.obj(), /*start=*/0, /*len=*/16,
-                           out_matrix->data());
+                           out_matrix.data());
+  return out_matrix;
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/video_surface_texture_bridge.h
+++ b/starboard/android/shared/video_surface_texture_bridge.h
@@ -60,10 +60,9 @@ class VideoSurfaceTextureBridge {
 
   static void UpdateTexImage(JNIEnv* env,
                              const jni_zero::JavaRef<jobject>& surface_texture);
-  static void GetTransformMatrix(
+  static std::array<float, 16> GetTransformMatrix(
       JNIEnv* env,
-      const jni_zero::JavaRef<jobject>& surface_texture,
-      std::array<float, 16>* out_matrix);
+      const jni_zero::JavaRef<jobject>& surface_texture);
 
   void OnFrameAvailable(JNIEnv*) { host_->OnFrameAvailable(); }
 

--- a/starboard/android/shared/video_surface_texture_bridge.h
+++ b/starboard/android/shared/video_surface_texture_bridge.h
@@ -17,6 +17,8 @@
 
 #include <jni.h>
 
+#include <array>
+
 #include "base/memory/raw_ref.h"
 #include "starboard/common/log.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -61,7 +63,7 @@ class VideoSurfaceTextureBridge {
   static void GetTransformMatrix(
       JNIEnv* env,
       const jni_zero::JavaRef<jobject>& surface_texture,
-      const jni_zero::JavaParamRef<jfloatArray>& mtx);
+      std::array<float, 16>* out_matrix);
 
   void OnFrameAvailable(JNIEnv*) { host_->OnFrameAvailable(); }
 


### PR DESCRIPTION
Refactors VideoSurfaceTexture.getTransformMatrix() to return a cached member float array instead of allocating a new one on every call, avoiding GC churn on the 60fps rendering path.

This change also removes the error-prone `env->NewFloatArray` call from the C++ hot path. See http://b/520007952#comment4.

Issue: 520007952
Issue: 518914404