### PR TITLE
Finalize pruning of services/device peripheral modules

### DIFF
--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -3773,6 +3773,59 @@ source_set("browser") {
   if (is_chromeos) {
     deps += [ "//ash/constants:constants" ]
   }
+
+  if (is_cobalt) {
+    sources -= [
+      "bluetooth/advertisement_client.cc",
+      "bluetooth/advertisement_client.h",
+      "bluetooth/bluetooth_adapter_factory_wrapper.cc",
+      "bluetooth/bluetooth_adapter_factory_wrapper.h",
+      "bluetooth/bluetooth_allowed_devices.cc",
+      "bluetooth/bluetooth_allowed_devices.h",
+      "bluetooth/bluetooth_allowed_devices_map.cc",
+      "bluetooth/bluetooth_allowed_devices_map.h",
+      "bluetooth/bluetooth_blocklist.cc",
+      "bluetooth/bluetooth_blocklist.h",
+      "bluetooth/bluetooth_device_chooser_controller.cc",
+      "bluetooth/bluetooth_device_chooser_controller.h",
+      "bluetooth/bluetooth_device_scanning_prompt_controller.cc",
+      "bluetooth/bluetooth_device_scanning_prompt_controller.h",
+      "bluetooth/bluetooth_metrics.cc",
+      "bluetooth/bluetooth_metrics.h",
+      "bluetooth/bluetooth_util.cc",
+      "bluetooth/bluetooth_util.h",
+      "bluetooth/frame_connected_bluetooth_devices.cc",
+      "bluetooth/frame_connected_bluetooth_devices.h",
+      "bluetooth/web_bluetooth_pairing_manager.h",
+      "bluetooth/web_bluetooth_pairing_manager_delegate.h",
+      "bluetooth/web_bluetooth_pairing_manager_impl.cc",
+      "bluetooth/web_bluetooth_pairing_manager_impl.h",
+      "bluetooth/web_bluetooth_service_impl.cc",
+      "bluetooth/web_bluetooth_service_impl.h",
+
+      "serial/serial_service.cc",
+      "serial/serial_service.h",
+
+      "usb/web_usb_service_impl.cc",
+      "usb/web_usb_service_impl.h",
+    ]
+
+    deps -= [
+      "//device/bluetooth",
+      "//device/bluetooth/public/cpp",
+    ]
+
+    if (!is_android) {
+      sources -= [
+        "hid/hid_service.cc",
+        "hid/hid_service.h",
+        "service_worker/service_worker_hid_delegate_observer.cc",
+        "service_worker/service_worker_hid_delegate_observer.h",
+        "service_worker/service_worker_usb_delegate_observer.cc",
+        "service_worker/service_worker_usb_delegate_observer.h",
+      ]
+    }
+  }
 }
 
 if (is_android) {

--- a/content/browser/browser_interface_binders.cc
+++ b/content/browser/browser_interface_binders.cc
@@ -27,7 +27,9 @@
 #include "content/browser/attribution_reporting/attribution_internals_ui.h"
 #include "content/browser/background_fetch/background_fetch_service_impl.h"
 #include "content/browser/bad_message.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/bluetooth/web_bluetooth_service_impl.h"
+#endif
 #include "content/browser/browser_context_impl.h"
 #include "content/browser/browser_main_loop.h"
 #if !BUILDFLAG(DISABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
@@ -902,8 +904,10 @@ void PopulateFrameBinders(RenderFrameHostImpl* host, mojo::BinderMap* map) {
       &RenderFrameHostImpl::BindFederatedAuthRequestReceiver,
       base::Unretained(host)));
 
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::WebUsbService>(base::BindRepeating(
       &RenderFrameHostImpl::CreateWebUsbService, base::Unretained(host)));
+#endif
 
   map->Add<blink::mojom::WebSocketConnector>(base::BindRepeating(
       &RenderFrameHostImpl::CreateWebSocketConnector, base::Unretained(host)));
@@ -947,8 +951,10 @@ void PopulateFrameBinders(RenderFrameHostImpl* host, mojo::BinderMap* map) {
         &BindWebNNContextProviderForRenderFrame, base::Unretained(host)));
   }
 
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::WebBluetoothService>(base::BindRepeating(
       &WebBluetoothServiceImpl::BindIfAllowed, base::Unretained(host)));
+#endif
 
   map->Add<blink::mojom::PushMessaging>(base::BindRepeating(
       &RenderFrameHostImpl::GetPushMessaging, base::Unretained(host)));
@@ -1094,19 +1100,25 @@ void PopulateFrameBinders(RenderFrameHostImpl* host, mojo::BinderMap* map) {
   }
 
 #if BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   map->Add<device::mojom::NFC>(base::BindRepeating(
       &RenderFrameHostImpl::BindNFCReceiver, base::Unretained(host)));
+#endif
 #else
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::HidService>(base::BindRepeating(
       &RenderFrameHostImpl::GetHidService, base::Unretained(host)));
+#endif
 
   map->Add<blink::mojom::InstalledAppProvider>(
       base::BindRepeating(&RenderFrameHostImpl::CreateInstalledAppProvider,
                           base::Unretained(host)));
 #endif  // BUILDFLAG(IS_ANDROID)
 
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::SerialService>(base::BindRepeating(
       &RenderFrameHostImpl::BindSerialService, base::Unretained(host)));
+#endif
 
 #if BUILDFLAG(IS_CHROMEOS)
   map->Add<blink::mojom::SmartCardService>(base::BindRepeating(
@@ -1381,8 +1393,10 @@ void PopulateDedicatedWorkerBinders(DedicatedWorkerHost* host,
       base::BindRepeating(&DedicatedWorkerHost::CreateDirectSocketsService,
                           base::Unretained(host)));
 #endif
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::WebUsbService>(base::BindRepeating(
       &DedicatedWorkerHost::CreateWebUsbService, base::Unretained(host)));
+#endif
   map->Add<blink::mojom::WebSocketConnector>(base::BindRepeating(
       &DedicatedWorkerHost::CreateWebSocketConnector, base::Unretained(host)));
   map->Add<blink::mojom::WebTransportConnector>(
@@ -1405,11 +1419,15 @@ void PopulateDedicatedWorkerBinders(DedicatedWorkerHost* host,
                           base::Unretained(host)));
   map->Add<blink::mojom::ReportingServiceProxy>(base::BindRepeating(
       &CreateReportingServiceProxyForDedicatedWorker, base::Unretained(host)));
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::SerialService>(base::BindRepeating(
       &DedicatedWorkerHost::BindSerialService, base::Unretained(host)));
+#endif
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::HidService>(base::BindRepeating(
       &DedicatedWorkerHost::BindHidService, base::Unretained(host)));
+#endif
 #endif  // !BUILDFLAG(IS_ANDROID)
   map->Add<blink::mojom::BucketManagerHost>(base::BindRepeating(
       &DedicatedWorkerHost::CreateBucketManagerHost, base::Unretained(host)));
@@ -1727,13 +1745,17 @@ void PopulateServiceWorkerBinders(ServiceWorkerHost* host,
                                                          std::move(receiver));
       },
       base::Unretained(host)));
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::HidService>(base::BindRepeating(
       &ServiceWorkerHost::BindHidService, base::Unretained(host)));
 #endif
+#endif
   map->Add<blink::mojom::BucketManagerHost>(base::BindRepeating(
       &ServiceWorkerHost::CreateBucketManagerHost, base::Unretained(host)));
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::WebUsbService>(base::BindRepeating(
       &ServiceWorkerHost::BindUsbService, base::Unretained(host)));
+#endif
   if (base::FeatureList::IsEnabled(
           webnn::mojom::features::kWebMachineLearningNeuralNetwork)) {
     map->Add<webnn::mojom::WebNNContextProvider>(base::BindRepeating(

--- a/content/browser/renderer_host/render_frame_host_impl.cc
+++ b/content/browser/renderer_host/render_frame_host_impl.cc
@@ -13732,6 +13732,7 @@ void RenderFrameHostImpl::CreateSecurePaymentConfirmationService(
   }
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void RenderFrameHostImpl::CreateWebUsbService(
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
   if (!base::FeatureList::IsEnabled(features::kWebUsb)) {
@@ -13752,6 +13753,7 @@ void RenderFrameHostImpl::CreateWebUsbService(
                 BackForwardCacheDisable::DisabledReasonId::kWebUSB));
   WebUsbServiceImpl::Create(*this, std::move(receiver));
 }
+#endif
 
 void RenderFrameHostImpl::ResetPermissionsPolicy(
     const network::ParsedPermissionsPolicy& header_policy) {
@@ -14105,12 +14107,15 @@ void RenderFrameHostImpl::CreateDedicatedWorkerHostFactory(
 }
 
 #if BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
 void RenderFrameHostImpl::BindNFCReceiver(
     mojo::PendingReceiver<device::mojom::NFC> receiver) {
   delegate_->GetNFC(this, std::move(receiver));
 }
 #endif
+#endif
 
+#if !BUILDFLAG(IS_COBALT)
 void RenderFrameHostImpl::BindSerialService(
     mojo::PendingReceiver<blink::mojom::SerialService> receiver) {
   if (!IsFeatureEnabled(network::mojom::PermissionsPolicyFeature::kSerial)) {
@@ -14138,12 +14143,15 @@ void RenderFrameHostImpl::BindSerialService(
 
   SerialService::GetOrCreateForCurrentDocument(this)->Bind(std::move(receiver));
 }
+#endif
 
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
 void RenderFrameHostImpl::GetHidService(
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
   HidService::Create(this, std::move(receiver));
 }
+#endif
 #endif
 
 #if BUILDFLAG(IS_CHROMEOS)

--- a/content/browser/renderer_host/render_frame_host_impl.h
+++ b/content/browser/renderer_host/render_frame_host_impl.h
@@ -2086,11 +2086,15 @@ class CONTENT_EXPORT RenderFrameHostImpl
       mojo::PendingReceiver<blink::mojom::FileSystemAccessManager> receiver);
 
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   void GetHidService(mojo::PendingReceiver<blink::mojom::HidService> receiver);
 #endif
+#endif
 
+#if !BUILDFLAG(IS_COBALT)
   void BindSerialService(
       mojo::PendingReceiver<blink::mojom::SerialService> receiver);
+#endif
 
 #if BUILDFLAG(IS_CHROMEOS)
   void GetSmartCardService(
@@ -2158,7 +2162,9 @@ class CONTENT_EXPORT RenderFrameHostImpl
       const blink::StorageKey& storage_key);
 
 #if BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   void BindNFCReceiver(mojo::PendingReceiver<device::mojom::NFC> receiver);
+#endif
 #endif
 
   // Binds a `CacheStorage` object for the default bucket.
@@ -2208,9 +2214,11 @@ class CONTENT_EXPORT RenderFrameHostImpl
   void BindTrustTokenQueryAnswerer(
       mojo::PendingReceiver<network::mojom::TrustTokenQueryAnswerer> receiver);
 
+#if !BUILDFLAG(IS_COBALT)
   // Creates connections to WebUSB interfaces bound to this frame.
   void CreateWebUsbService(
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver);
+#endif
 
   void CreateWebSocketConnector(
       mojo::PendingReceiver<blink::mojom::WebSocketConnector> receiver);

--- a/content/browser/service_worker/embedded_worker_instance.cc
+++ b/content/browser/service_worker/embedded_worker_instance.cc
@@ -800,6 +800,7 @@ void EmbeddedWorkerInstance::BindCacheStorage(
 }
 
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
 void EmbeddedWorkerInstance::BindHidService(
     const url::Origin& origin,
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
@@ -813,8 +814,10 @@ void EmbeddedWorkerInstance::BindHidService(
                        std::move(receiver));
   }
 }
+#endif
 #endif  // !BUILDFLAG(IS_ANDROID)
 
+#if !BUILDFLAG(IS_COBALT)
 void EmbeddedWorkerInstance::BindUsbService(
     const url::Origin& origin,
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
@@ -828,6 +831,7 @@ void EmbeddedWorkerInstance::BindUsbService(
                               std::move(receiver));
   }
 }
+#endif
 
 base::WeakPtr<EmbeddedWorkerInstance> EmbeddedWorkerInstance::AsWeakPtr() {
   return weak_factory_.GetWeakPtr();

--- a/content/browser/service_worker/embedded_worker_instance.h
+++ b/content/browser/service_worker/embedded_worker_instance.h
@@ -246,13 +246,17 @@ class CONTENT_EXPORT EmbeddedWorkerInstance
       const storage::BucketLocator& bucket_locator);
 
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   void BindHidService(const url::Origin& origin,
                       mojo::PendingReceiver<blink::mojom::HidService> receiver);
+#endif
 #endif  // !BUILDFLAG(IS_ANDROID)
 
+#if !BUILDFLAG(IS_COBALT)
   void BindUsbService(
       const url::Origin& origin,
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver);
+#endif
 
   base::WeakPtr<EmbeddedWorkerInstance> AsWeakPtr();
 

--- a/content/browser/service_worker/service_worker_context_core.cc
+++ b/content/browser/service_worker/service_worker_context_core.cc
@@ -1524,7 +1524,7 @@ ScopedServiceWorkerClient::CommitResponseAndRelease(
   return std::make_tuple(std::move(container_info), std::move(controller));
 }
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 ServiceWorkerHidDelegateObserver*
 ServiceWorkerContextCore::hid_delegate_observer() {
   if (!hid_delegate_observer_) {
@@ -1552,5 +1552,5 @@ void ServiceWorkerContextCore::SetServiceWorkerUsbDelegateObserverForTesting(
     std::unique_ptr<ServiceWorkerUsbDelegateObserver> usb_delegate_observer) {
   usb_delegate_observer_ = std::move(usb_delegate_observer);
 }
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 }  // namespace content

--- a/content/browser/service_worker/service_worker_context_core.h
+++ b/content/browser/service_worker/service_worker_context_core.h
@@ -50,10 +50,10 @@ class ServiceWorkerQuotaClient;
 class ServiceWorkerRegistration;
 struct ServiceWorkerContextSynchronousObserverList;
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 class ServiceWorkerHidDelegateObserver;
 class ServiceWorkerUsbDelegateObserver;
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
 // A smart pointer of `ServiceWorkerClient`.
 //
@@ -555,7 +555,7 @@ class CONTENT_EXPORT ServiceWorkerContextCore
     test_version_observers_.RemoveObserver(observer);
   }
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   ServiceWorkerHidDelegateObserver* hid_delegate_observer();
 
   void SetServiceWorkerHidDelegateObserverForTesting(
@@ -568,7 +568,7 @@ class CONTENT_EXPORT ServiceWorkerContextCore
 
   void SetServiceWorkerUsbDelegateObserverForTesting(
       std::unique_ptr<ServiceWorkerUsbDelegateObserver> usb_delegate_observer);
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
  private:
   friend class ServiceWorkerContextCoreTest;
@@ -701,10 +701,10 @@ class CONTENT_EXPORT ServiceWorkerContextCore
 
   bool is_processing_warming_up_ = false;
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   std::unique_ptr<ServiceWorkerHidDelegateObserver> hid_delegate_observer_;
   std::unique_ptr<ServiceWorkerUsbDelegateObserver> usb_delegate_observer_;
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
   base::ObserverList<TestVersionObserver> test_version_observers_;
 

--- a/content/browser/service_worker/service_worker_host.cc
+++ b/content/browser/service_worker/service_worker_host.cc
@@ -121,6 +121,7 @@ void ServiceWorkerHost::GetSandboxedFileSystemForBucket(
 }
 
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
 void ServiceWorkerHost::BindHidService(
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -128,7 +129,9 @@ void ServiceWorkerHost::BindHidService(
                                               std::move(receiver));
 }
 #endif
+#endif
 
+#if !BUILDFLAG(IS_COBALT)
 void ServiceWorkerHost::BindUsbService(
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -145,6 +148,7 @@ void ServiceWorkerHost::BindUsbService(
   version_->embedded_worker()->BindUsbService(
       container_host_->top_frame_origin(), std::move(receiver));
 }
+#endif
 
 net::NetworkIsolationKey ServiceWorkerHost::GetNetworkIsolationKey() const {
   return version_->key().ToPartialNetIsolationInfo().network_isolation_key();

--- a/content/browser/service_worker/service_worker_host.h
+++ b/content/browser/service_worker/service_worker_host.h
@@ -96,11 +96,15 @@ class CONTENT_EXPORT ServiceWorkerHost : public BucketContext,
       mojo::PendingReceiver<blink::mojom::CacheStorage> receiver);
 
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   void BindHidService(mojo::PendingReceiver<blink::mojom::HidService> receiver);
+#endif
 #endif  // !BUILDFLAG(IS_ANDROID)
 
+#if !BUILDFLAG(IS_COBALT)
   void BindUsbService(
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver);
+#endif
 
   ServiceWorkerContainerHostForServiceWorker* container_host() {
     return container_host_.get();

--- a/content/browser/service_worker/service_worker_version.cc
+++ b/content/browser/service_worker/service_worker_version.cc
@@ -34,6 +34,7 @@
 #include "components/services/storage/public/mojom/service_worker_database.mojom-forward.h"
 #include "content/browser/bad_message.h"
 #include "content/browser/child_process_security_policy_impl.h"
+#include "content/browser/storage_partition_impl.h"
 #include "content/browser/renderer_host/back_forward_cache_can_store_document_result.h"
 #include "content/browser/renderer_host/private_network_access_util.h"
 #include "content/browser/service_worker/payment_handler_support.h"
@@ -42,11 +43,15 @@
 #include "content/browser/service_worker/service_worker_container_host.h"
 #include "content/browser/service_worker/service_worker_context_core.h"
 #include "content/browser/service_worker/service_worker_context_wrapper.h"
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 #include "content/browser/service_worker/service_worker_hid_delegate_observer.h"
+#endif
 #include "content/browser/service_worker/service_worker_host.h"
 #include "content/browser/service_worker/service_worker_installed_scripts_sender.h"
 #include "content/browser/service_worker/service_worker_security_utils.h"
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 #include "content/browser/service_worker/service_worker_usb_delegate_observer.h"
+#endif
 #include "content/common/content_navigation_policy.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/content_browser_client.h"
@@ -453,7 +458,7 @@ void ServiceWorkerVersion::SetStatus(Status status) {
   if (status == INSTALLED) {
     embedded_worker_->OnWorkerVersionInstalled();
   } else if (status == ACTIVATED) {
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
     // Notify the hid delegate observer if the active service worker has any hid
     // event handlers.
     context_->hid_delegate_observer()->UpdateHasEventHandlers(
@@ -463,7 +468,7 @@ void ServiceWorkerVersion::SetStatus(Status status) {
     // event handlers.
     context_->usb_delegate_observer()->UpdateHasEventHandlers(
         registration_id_, has_usb_event_handlers_);
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   } else if (status == REDUNDANT) {
     embedded_worker_->OnWorkerVersionDoomed();
 

--- a/content/browser/storage_partition_impl.cc
+++ b/content/browser/storage_partition_impl.cc
@@ -56,7 +56,9 @@
 #include "content/browser/background_fetch/background_fetch_context.h"
 #include "content/browser/blob_storage/blob_registry_wrapper.h"
 #include "content/browser/blob_storage/chrome_blob_storage_context.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/bluetooth/bluetooth_allowed_devices_map.h"
+#endif
 #include "content/browser/broadcast_channel/broadcast_channel_service.h"
 #include "content/browser/browsing_data/clear_site_data_handler.h"
 #include "content/browser/browsing_data/storage_partition_code_cache_data_remover.h"
@@ -1422,8 +1424,10 @@ void StoragePartitionImpl::Initialize(
 
   broadcast_channel_service_ = std::make_unique<BroadcastChannelService>();
 
+#if !BUILDFLAG(IS_COBALT)
   bluetooth_allowed_devices_map_ =
       std::make_unique<BluetoothAllowedDevicesMap>();
+#endif
 
   // Must be initialized before the
   // `shared_url_loader_factory_for_browser_process_`. Cookie deprecation
@@ -1780,11 +1784,13 @@ BroadcastChannelService* StoragePartitionImpl::GetBroadcastChannelService() {
   return broadcast_channel_service_.get();
 }
 
+#if !BUILDFLAG(IS_COBALT)
 BluetoothAllowedDevicesMap*
 StoragePartitionImpl::GetBluetoothAllowedDevicesMap() {
   DCHECK(initialized_);
   return bluetooth_allowed_devices_map_.get();
 }
+#endif
 
 BlobRegistryWrapper* StoragePartitionImpl::GetBlobRegistry() {
   DCHECK(initialized_);
@@ -3346,10 +3352,12 @@ void StoragePartitionImpl::ResetURLLoaderFactories() {
       ->Reset();
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void StoragePartitionImpl::ClearBluetoothAllowedDevicesMapForTesting() {
   DCHECK(initialized_);
   bluetooth_allowed_devices_map_->Clear();
 }
+#endif
 
 void StoragePartitionImpl::AddObserver(DataRemovalObserver* observer) {
   data_removal_observers_.AddObserver(observer);

--- a/content/browser/storage_partition_impl.h
+++ b/content/browser/storage_partition_impl.h
@@ -88,7 +88,9 @@ class AggregationService;
 class AttributionManager;
 class BackgroundFetchContext;
 class BlobRegistryWrapper;
+#if !BUILDFLAG(IS_COBALT)
 class BluetoothAllowedDevicesMap;
+#endif
 class BroadcastChannelService;
 class BrowsingDataFilterBuilder;
 class KeepAliveURLLoaderService;
@@ -265,7 +267,9 @@ class CONTENT_EXPORT StoragePartitionImpl
       base::OnceClosure callback) override;
   void Flush() override;
   void ResetURLLoaderFactories() override;
+#if !BUILDFLAG(IS_COBALT)
   void ClearBluetoothAllowedDevicesMapForTesting() override;
+#endif
   void AddObserver(DataRemovalObserver* observer) override;
   void RemoveObserver(DataRemovalObserver* observer) override;
   void FlushNetworkInterfaceForTesting() override;
@@ -286,7 +290,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   BackgroundFetchContext* GetBackgroundFetchContext();
   PaymentAppContextImpl* GetPaymentAppContext();
   BroadcastChannelService* GetBroadcastChannelService();
+#if !BUILDFLAG(IS_COBALT)
   BluetoothAllowedDevicesMap* GetBluetoothAllowedDevicesMap();
+#endif
   BlobRegistryWrapper* GetBlobRegistry();
   storage::BlobUrlRegistry* GetBlobUrlRegistry();
   SubresourceProxyingURLLoaderService* GetSubresourceProxyingURLLoaderService();
@@ -790,7 +796,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   scoped_refptr<BackgroundSyncContextImpl> background_sync_context_;
   scoped_refptr<PaymentAppContextImpl> payment_app_context_;
   std::unique_ptr<BroadcastChannelService> broadcast_channel_service_;
+#if !BUILDFLAG(IS_COBALT)
   std::unique_ptr<BluetoothAllowedDevicesMap> bluetooth_allowed_devices_map_;
+#endif
   scoped_refptr<BlobRegistryWrapper> blob_registry_;
   std::unique_ptr<storage::BlobUrlRegistry> blob_url_registry_;
   std::unique_ptr<SubresourceProxyingURLLoaderService>

--- a/content/browser/worker_host/dedicated_worker_host.cc
+++ b/content/browser/worker_host/dedicated_worker_host.cc
@@ -708,6 +708,7 @@ void DedicatedWorkerHost::CreateDirectSocketsService(
 }
 #endif
 
+#if !BUILDFLAG(IS_COBALT)
 void DedicatedWorkerHost::CreateWebUsbService(
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -721,6 +722,7 @@ void DedicatedWorkerHost::CreateWebUsbService(
 
   ancestor_render_frame_host->CreateWebUsbService(std::move(receiver));
 }
+#endif
 
 void DedicatedWorkerHost::CreateWebSocketConnector(
     mojo::PendingReceiver<blink::mojom::WebSocketConnector> receiver) {
@@ -863,6 +865,7 @@ void DedicatedWorkerHost::CreateCodeCacheHost(
                                  GetStorageKey(), std::move(receiver));
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void DedicatedWorkerHost::BindSerialService(
     mojo::PendingReceiver<blink::mojom::SerialService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -876,8 +879,10 @@ void DedicatedWorkerHost::BindSerialService(
 
   ancestor_render_frame_host->BindSerialService(std::move(receiver));
 }
+#endif
 
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
 void DedicatedWorkerHost::BindHidService(
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -891,6 +896,7 @@ void DedicatedWorkerHost::BindHidService(
 
   ancestor_render_frame_host->GetHidService(std::move(receiver));
 }
+#endif
 #endif
 
 void DedicatedWorkerHost::CreateBucketManagerHost(

--- a/content/browser/worker_host/dedicated_worker_host.h
+++ b/content/browser/worker_host/dedicated_worker_host.h
@@ -143,8 +143,10 @@ class CONTENT_EXPORT DedicatedWorkerHost final
   void CreateDirectSocketsService(
       mojo::PendingReceiver<blink::mojom::DirectSocketsService> receiver);
 #endif
+#if !BUILDFLAG(IS_COBALT)
   void CreateWebUsbService(
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver);
+#endif
   void CreateWebSocketConnector(
       mojo::PendingReceiver<blink::mojom::WebSocketConnector> receiver);
   void CreateWebTransportConnector(
@@ -173,10 +175,14 @@ class CONTENT_EXPORT DedicatedWorkerHost final
       mojo::PendingReceiver<blink::mojom::WebPressureManager> receiver);
 #endif  // BUILDFLAG(ENABLE_COMPUTE_PRESSURE)
 
+#if !BUILDFLAG(IS_COBALT)
   void BindSerialService(
       mojo::PendingReceiver<blink::mojom::SerialService> receiver);
+#endif
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   void BindHidService(mojo::PendingReceiver<blink::mojom::HidService> receiver);
+#endif
 #endif
 
   void StartScriptLoad(

--- a/content/public/browser/storage_partition.h
+++ b/content/public/browser/storage_partition.h
@@ -362,8 +362,10 @@ class CONTENT_EXPORT StoragePartition {
 
   virtual void RemoveObserver(DataRemovalObserver* observer) = 0;
 
+#if !BUILDFLAG(IS_COBALT)
   // Clear the bluetooth allowed devices map. For test use only.
   virtual void ClearBluetoothAllowedDevicesMapForTesting() = 0;
+#endif
 
   // Call |FlushForTesting()| on Network Service related interfaces. For test
   // use only.

--- a/content/public/test/test_storage_partition.cc
+++ b/content/public/test/test_storage_partition.cc
@@ -263,7 +263,9 @@ int TestStoragePartition::GetDataRemovalObserverCount() {
   return data_removal_observer_count_;
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void TestStoragePartition::ClearBluetoothAllowedDevicesMapForTesting() {}
+#endif
 
 void TestStoragePartition::FlushNetworkInterfaceForTesting() {}
 

--- a/content/public/test/test_storage_partition.h
+++ b/content/public/test/test_storage_partition.h
@@ -251,7 +251,9 @@ class TestStoragePartition : public StoragePartition {
   void RemoveObserver(DataRemovalObserver* observer) override;
   int GetDataRemovalObserverCount();
 
+#if !BUILDFLAG(IS_COBALT)
   void ClearBluetoothAllowedDevicesMapForTesting() override;
+#endif
   void FlushNetworkInterfaceForTesting() override;
   void FlushCertVerifierInterfaceForTesting() override;
   void WaitForDeletionTasksForTesting() override;

--- a/device/bluetooth/emulation/buildflags.gni
+++ b/device/bluetooth/emulation/buildflags.gni
@@ -1,4 +1,4 @@
 # Bluetooth Device Emulation is currently not enabled on
 # binary size constrained platforms.
 
-enable_bluetooth_emulation = is_win || is_mac || is_linux || is_chromeos
+enable_bluetooth_emulation = !is_cobalt && (is_win || is_mac || is_linux || is_chromeos)

--- a/services/device/BUILD.gn
+++ b/services/device/BUILD.gn
@@ -17,7 +17,7 @@ if (is_ios) {
 }
 
 is_serial_enabled_platform =
-    is_win || ((is_linux || is_chromeos) && use_udev) || is_mac || is_android
+    !is_cobalt && (is_win || ((is_linux || is_chromeos) && use_udev) || is_mac || is_android)
 
 source_set("lib") {
   # This should be visible only to embedders of the Device Service, and the
@@ -88,7 +88,12 @@ source_set("lib") {
 
   if (is_serial_enabled_platform) {
     deps += [ "//services/device/serial" ]
-    defines = [ "IS_SERIAL_ENABLED_PLATFORM" ]
+  }
+
+  if (is_cobalt) {
+    deps -= [
+      "//services/device/usb/mojo",
+    ]
   }
 }
 
@@ -490,6 +495,11 @@ if (is_android) {
       "//services/service_manager/public/mojom:mojom_java",
       "//third_party/jni_zero:jni_zero_java",
     ]
+    if (is_cobalt) {
+      deps -= [
+        "//services/device/usb:java",
+      ]
+    }
   }
 }
 

--- a/services/device/device_service.cc
+++ b/services/device/device_service.cc
@@ -22,7 +22,9 @@
 #include "services/device/geolocation/public_ip_address_location_notifier.h"
 #include "services/device/power_monitor/power_monitor_message_broadcaster.h"
 #include "services/device/public/mojom/battery_monitor.mojom.h"
+#if defined(IS_SERIAL_ENABLED_PLATFORM)
 #include "services/device/serial/serial_port_manager_impl.h"
+#endif
 #include "services/device/time_zone_monitor/time_zone_monitor.h"
 #include "services/device/vibration/vibration_manager_impl.h"
 #include "services/device/wake_lock/wake_lock_provider.h"
@@ -335,6 +337,7 @@ void DeviceService::BindWakeLockProvider(
 
 void DeviceService::BindUsbDeviceManager(
     mojo::PendingReceiver<mojom::UsbDeviceManager> receiver) {
+#if !BUILDFLAG(IS_COBALT)
   const auto& binder_override = internal::GetUsbDeviceManagerBinderOverride();
   if (binder_override) {
     binder_override.Run(std::move(receiver));
@@ -348,10 +351,14 @@ void DeviceService::BindUsbDeviceManager(
     usb_device_manager_ = std::make_unique<usb::DeviceManagerImpl>();
 
   usb_device_manager_->AddReceiver(std::move(receiver));
+#else
+  NOTREACHED() << "WebUSB is not supported on Cobalt.";
+#endif
 }
 
 void DeviceService::BindUsbDeviceManagerTest(
     mojo::PendingReceiver<mojom::UsbDeviceManagerTest> receiver) {
+#if !BUILDFLAG(IS_COBALT)
   // TODO(crbug.com/40141825): usb::DeviceManagerImpl depends on the
   // permission_broker service on Chromium OS. We will need to redirect
   // connections for LaCrOS here.
@@ -364,6 +371,9 @@ void DeviceService::BindUsbDeviceManagerTest(
   }
 
   usb_device_manager_test_->BindReceiver(std::move(receiver));
+#else
+  NOTREACHED() << "WebUSB is not supported on Cobalt.";
+#endif
 }
 
 #if BUILDFLAG(IS_ANDROID)

--- a/services/device/device_service.h
+++ b/services/device/device_service.h
@@ -35,8 +35,10 @@
 #include "services/device/public/mojom/usb_manager_test.mojom.h"
 #include "services/device/public/mojom/vibration_manager.mojom.h"
 #include "services/device/public/mojom/wake_lock_provider.mojom.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "services/device/usb/mojo/device_manager_impl.h"
 #include "services/device/usb/mojo/device_manager_test.h"
+#endif
 #include "services/device/wake_lock/wake_lock_context.h"
 #include "services/device/wake_lock/wake_lock_provider.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
@@ -245,8 +247,10 @@ class DeviceService : public mojom::DeviceService {
       public_ip_address_geolocation_provider_;
   std::unique_ptr<SensorProviderImpl> sensor_provider_;
   std::unique_ptr<TimeZoneMonitor> time_zone_monitor_;
+#if !BUILDFLAG(IS_COBALT)
   std::unique_ptr<usb::DeviceManagerImpl> usb_device_manager_;
   std::unique_ptr<usb::DeviceManagerTest> usb_device_manager_test_;
+#endif
   scoped_refptr<base::SingleThreadTaskRunner> file_task_runner_;
   scoped_refptr<base::SingleThreadTaskRunner> io_task_runner_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;


### PR DESCRIPTION
This change completes the pruning of unused peripheral hardware modules (WebUSB, Web Bluetooth, WebHID, Web Serial, and Web NFC) in content/browser and services/device. Gated StoragePartition maps and browser binders under !BUILDFLAG(IS_COBALT).

This additional pruning achieves the following binary size savings on Android:
- libchrobalt.so: -237,568 bytes (-232.0 KB)
- Cobalt.apk: -261,708 bytes (-255.5 KB)