### PR TITLE
android/jni-zero: Move AudioTrackBridge array allocation to Java

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioOutputManager.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioOutputManager.java
@@ -54,6 +54,7 @@ public class AudioOutputManager {
       int sampleType,
       int sampleRate,
       int channelCount,
+      int maxSamplesPerWrite,
       int preferredBufferSizeInBytes,
       int tunnelModeAudioSessionId,
       boolean isWebAudio) {
@@ -62,6 +63,7 @@ public class AudioOutputManager {
             sampleType,
             sampleRate,
             channelCount,
+            maxSamplesPerWrite,
             preferredBufferSizeInBytes,
             tunnelModeAudioSessionId,
             isWebAudio);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
@@ -292,8 +292,19 @@ public class AudioTrackBridge {
   }
 
   @CalledByNative
-  public Object getPreAllocatedAudioData() {
-    return mPreAllocatedAudioData;
+  public float[] getPreAllocatedFloatArray() {
+    if (mPreAllocatedAudioData instanceof float[]) {
+      return (float[]) mPreAllocatedAudioData;
+    }
+    return null;
+  }
+
+  @CalledByNative
+  public byte[] getPreAllocatedByteArray() {
+    if (mPreAllocatedAudioData instanceof byte[]) {
+      return (byte[]) mPreAllocatedAudioData;
+    }
+    return null;
   }
 
   // TODO (b/262608024): Have this method return a boolean and return false on failure.

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/AudioTrackBridge.java
@@ -59,6 +59,11 @@ public class AudioTrackBridge {
   private ByteBuffer mAvSyncHeader;
   private int mAvSyncPacketBytesRemaining;
 
+  // Pre-allocated byte[] or float[] shared with C++ via getPreAllocatedAudioData() to avoid
+  // allocation on every WriteSample(). C++ writes directly to this array,
+  // which is then passed back to Java write*() methods.
+  private Object mPreAllocatedAudioData;
+
   private static int getBytesPerSample(int audioFormat) {
     switch (audioFormat) {
       case AudioFormat.ENCODING_PCM_16BIT:
@@ -71,11 +76,27 @@ public class AudioTrackBridge {
     }
   }
 
+  private static Object createAudioDataArray(int sampleType, int maxSamplesPerWrite) {
+    switch (sampleType) {
+      case AudioFormat.ENCODING_PCM_FLOAT:
+        return new float[maxSamplesPerWrite];
+      case AudioFormat.ENCODING_PCM_16BIT:
+        return new byte[maxSamplesPerWrite * getBytesPerSample(sampleType)];
+      case AudioFormat.ENCODING_AC3:
+      case AudioFormat.ENCODING_E_AC3:
+        return new byte[maxSamplesPerWrite];
+      default:
+        Log.e(TAG, "Unsupported sample type: " + sampleType);
+        return null;
+    }
+  }
+
   // TODO: Pass error details to caller.
   public AudioTrackBridge(
       int sampleType,
       int sampleRate,
       int channelCount,
+      int maxSamplesPerWrite,
       int preferredBufferSizeInBytes,
       int tunnelModeAudioSessionId,
       boolean isWebAudio) {
@@ -204,6 +225,8 @@ public class AudioTrackBridge {
           Log.i(TAG, String.format(Locale.US, "Unknown AudioFormat %d.", sampleType));
           break;
       }
+
+      mPreAllocatedAudioData = createAudioDataArray(sampleType, maxSamplesPerWrite);
     }
     Log.i(
         TAG,
@@ -227,7 +250,6 @@ public class AudioTrackBridge {
     mAvSyncHeader = null;
     mAvSyncPacketBytesRemaining = 0;
   }
-
 
   @CalledByNative
   public boolean setPlaybackRate(float playbackRate) {
@@ -267,6 +289,11 @@ public class AudioTrackBridge {
       return AudioTrack.PLAYSTATE_STOPPED;
     }
     return mAudioTrack.getPlayState();
+  }
+
+  @CalledByNative
+  public Object getPreAllocatedAudioData() {
+    return mPreAllocatedAudioData;
   }
 
   // TODO (b/262608024): Have this method return a boolean and return false on failure.

--- a/starboard/android/shared/audio_output_manager.cc
+++ b/starboard/android/shared/audio_output_manager.cc
@@ -148,13 +148,14 @@ ScopedJavaLocalRef<jobject> AudioOutputManager::CreateAudioTrackBridge(
     int sample_type,
     int sample_rate,
     int channel_count,
+    int max_samples_per_write,
     int preferred_buffer_size_in_bytes,
     std::optional<int> tunnel_mode_audio_session_id,
     jboolean is_web_audio) {
   SB_DCHECK(env);
   return Java_AudioOutputManager_createAudioTrackBridge(
       env, j_audio_output_manager_, sample_type, sample_rate, channel_count,
-      preferred_buffer_size_in_bytes,
+      max_samples_per_write, preferred_buffer_size_in_bytes,
       tunnel_mode_audio_session_id.value_or(TUNNEL_MODE_AUDIO_SESSION_ID_NONE),
       is_web_audio);
 }

--- a/starboard/android/shared/audio_output_manager.h
+++ b/starboard/android/shared/audio_output_manager.h
@@ -35,6 +35,7 @@ class AudioOutputManager {
       int sample_type,
       int sample_rate,
       int channel_count,
+      int max_samples_per_write,
       int preferred_buffer_size_in_bytes,
       std::optional<int> tunnel_mode_audio_session_id,
       jboolean is_web_audio);

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -39,6 +39,22 @@ using jni_zero::ScopedJavaLocalRef;
 
 const jint kNoOffset = 0;
 
+void SetFloatArrayRegion(JNIEnv* env,
+                         const jni_zero::JavaRef<jfloatArray>& array,
+                         jsize start,
+                         jsize len,
+                         const jfloat* buf) {
+  env->SetFloatArrayRegion(array.obj(), start, len, buf);
+}
+
+void SetByteArrayRegion(JNIEnv* env,
+                        const jni_zero::JavaRef<jbyteArray>& array,
+                        jsize start,
+                        jsize len,
+                        const jbyte* buf) {
+  env->SetByteArrayRegion(array.obj(), start, len, buf);
+}
+
 }  // namespace
 
 std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
@@ -94,21 +110,20 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
     return nullptr;
   }
 
-  ScopedJavaLocalRef<jobject> j_audio_data =
-      Java_AudioTrackBridge_getPreAllocatedAudioData(env, j_audio_track_bridge);
-  if (j_audio_data.is_null()) {
-    SB_LOG(WARNING) << "Failed to retrieve |j_audio_data_|";
-    return nullptr;
-  }
-
   const auto j_audio_data_var = [&]() -> DataArray {
     if (coding_type == kSbMediaAudioCodingTypePcm &&
         sample_type == kSbMediaAudioSampleTypeFloat32) {
-      SB_CHECK(env->IsInstanceOf(j_audio_data.obj(), env->FindClass("[F")));
-      return FloatArray(env, static_cast<jfloatArray>(j_audio_data.obj()));
+      ScopedJavaLocalRef<jfloatArray> j_float_array =
+          Java_AudioTrackBridge_getPreAllocatedFloatArray(env,
+                                                          j_audio_track_bridge);
+      SB_CHECK(j_float_array);
+      return FloatArray(env, j_float_array);
     }
-    SB_CHECK(env->IsInstanceOf(j_audio_data.obj(), env->FindClass("[B")));
-    return ByteArray(env, static_cast<jbyteArray>(j_audio_data.obj()));
+    ScopedJavaLocalRef<jbyteArray> j_byte_array =
+        Java_AudioTrackBridge_getPreAllocatedByteArray(env,
+                                                       j_audio_track_bridge);
+    SB_CHECK(j_byte_array);
+    return ByteArray(env, j_byte_array);
   }();
 
   return std::make_unique<AudioTrackBridge>(
@@ -181,8 +196,7 @@ int AudioTrackBridge::WriteSample(const float* samples,
   SB_CHECK(std::holds_alternative<FloatArray>(j_audio_data_));
   const auto& float_array = std::get<FloatArray>(j_audio_data_);
 
-  env->SetFloatArrayRegion(float_array.obj(), kNoOffset, num_of_samples,
-                           samples);
+  SetFloatArrayRegion(env, float_array, kNoOffset, num_of_samples, samples);
 
   return Java_AudioTrackBridge_write(env, j_audio_track_bridge_, float_array,
                                      num_of_samples);
@@ -201,9 +215,9 @@ int AudioTrackBridge::WriteSample(const uint16_t* samples,
   SB_CHECK(std::holds_alternative<ByteArray>(j_audio_data_));
   const auto& byte_array = std::get<ByteArray>(j_audio_data_);
 
-  env->SetByteArrayRegion(byte_array.obj(), kNoOffset,
-                          num_of_samples * sizeof(uint16_t),
-                          reinterpret_cast<const jbyte*>(samples));
+  SetByteArrayRegion(env, byte_array, kNoOffset,
+                     num_of_samples * sizeof(uint16_t),
+                     reinterpret_cast<const jbyte*>(samples));
 
   int bytes_written = Java_AudioTrackBridge_writeWithPresentationTime(
       env, j_audio_track_bridge_, byte_array, num_of_samples * sizeof(uint16_t),
@@ -230,8 +244,8 @@ int AudioTrackBridge::WriteSample(const uint8_t* samples,
   SB_CHECK(std::holds_alternative<ByteArray>(j_audio_data_));
   const auto& byte_array = std::get<ByteArray>(j_audio_data_);
 
-  env->SetByteArrayRegion(byte_array.obj(), kNoOffset, num_of_samples,
-                          reinterpret_cast<const jbyte*>(samples));
+  SetByteArrayRegion(env, byte_array, kNoOffset, num_of_samples,
+                     reinterpret_cast<const jbyte*>(samples));
 
   int bytes_written = Java_AudioTrackBridge_writeWithPresentationTime(
       env, j_audio_track_bridge_, byte_array, num_of_samples, sync_time);

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -15,6 +15,7 @@
 #include "starboard/android/shared/audio_track_bridge.h"
 
 #include <algorithm>
+#include <variant>
 
 #include "starboard/android/shared/audio_output_manager.h"
 #include "starboard/android/shared/media_common.h"
@@ -26,7 +27,6 @@
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "cobalt/android/jni_headers/AudioTrackBridge_jni.h"
-#include "starboard/common/check_op.h"
 
 namespace starboard {
 
@@ -36,19 +36,6 @@ using jni_zero::AttachCurrentThread;
 using jni_zero::JavaParamRef;
 using jni_zero::ScopedJavaGlobalRef;
 using jni_zero::ScopedJavaLocalRef;
-
-// Safely casts a JavaRef (like ScopedJavaGlobalRef) to a ScopedJavaLocalRef of
-// a different JNI type (e.g. jobject to jfloatArray).
-//
-// Copied from Chromium/WebRTC. See
-// https://github.com/youtube/cobalt/blob/f0ef063d30589b39dc4a1433b0dde659d2fb5eea/third_party/webrtc/sdk/android/native_api/jni/scoped_java_ref.h#L30-L37
-template <typename T, typename U>
-inline ScopedJavaLocalRef<T> static_java_ref_cast(
-    JNIEnv* env,
-    const jni_zero::JavaRef<U>& ref) {
-  ScopedJavaLocalRef<U> owned_ref(env, ref);
-  return ScopedJavaLocalRef<T>(env, static_cast<T>(owned_ref.Release()));
-}
 
 const jint kNoOffset = 0;
 
@@ -109,22 +96,31 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
 
   ScopedJavaLocalRef<jobject> j_audio_data =
       Java_AudioTrackBridge_getPreAllocatedAudioData(env, j_audio_track_bridge);
-
   if (j_audio_data.is_null()) {
     SB_LOG(WARNING) << "Failed to retrieve |j_audio_data_|";
     return nullptr;
   }
 
+  const auto j_audio_data_var = [&]() -> DataArray {
+    if (coding_type == kSbMediaAudioCodingTypePcm &&
+        sample_type == kSbMediaAudioSampleTypeFloat32) {
+      SB_CHECK(env->IsInstanceOf(j_audio_data.obj(), env->FindClass("[F")));
+      return FloatArray(env, static_cast<jfloatArray>(j_audio_data.obj()));
+    }
+    SB_CHECK(env->IsInstanceOf(j_audio_data.obj(), env->FindClass("[B")));
+    return ByteArray(env, static_cast<jbyteArray>(j_audio_data.obj()));
+  }();
+
   return std::make_unique<AudioTrackBridge>(
       PassKey<AudioTrackBridge>(), max_samples_per_write, j_audio_track_bridge,
-      ScopedJavaGlobalRef<jobject>(env, j_audio_data));
+      j_audio_data_var);
 }
 
 AudioTrackBridge::AudioTrackBridge(
     PassKey<AudioTrackBridge>,
     int max_samples_per_write,
     const ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
-    const ScopedJavaGlobalRef<jobject>& j_audio_data)
+    const DataArray& j_audio_data)
     : max_samples_per_write_(max_samples_per_write),
       j_audio_track_bridge_(j_audio_track_bridge),
       j_audio_data_(j_audio_data) {}
@@ -182,17 +178,14 @@ int AudioTrackBridge::WriteSample(const float* samples,
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
 
-  SB_DCHECK(env->IsInstanceOf(j_audio_data_.obj(), env->FindClass("[F")));
-  ScopedJavaLocalRef<jfloatArray> audio_data_local_ref =
-      static_java_ref_cast<jfloatArray>(env, j_audio_data_);
+  SB_CHECK(std::holds_alternative<FloatArray>(j_audio_data_));
+  const auto& float_array = std::get<FloatArray>(j_audio_data_);
 
-  env->SetFloatArrayRegion(audio_data_local_ref.obj(), kNoOffset,
-                           num_of_samples, samples);
+  env->SetFloatArrayRegion(float_array.obj(), kNoOffset, num_of_samples,
+                           samples);
 
-  return Java_AudioTrackBridge_write(env, j_audio_track_bridge_,
-                                     // JavaParamRef<jfloatArray>'s raw pointer
-                                     // constructor expects a local reference.
-                                     audio_data_local_ref, num_of_samples);
+  return Java_AudioTrackBridge_write(env, j_audio_track_bridge_, float_array,
+                                     num_of_samples);
 }
 
 int AudioTrackBridge::WriteSample(const uint16_t* samples,
@@ -205,19 +198,16 @@ int AudioTrackBridge::WriteSample(const uint16_t* samples,
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
 
-  SB_DCHECK(env->IsInstanceOf(j_audio_data_.obj(), env->FindClass("[B")));
-  ScopedJavaLocalRef<jbyteArray> audio_data_local_ref =
-      static_java_ref_cast<jbyteArray>(env, j_audio_data_);
+  SB_CHECK(std::holds_alternative<ByteArray>(j_audio_data_));
+  const auto& byte_array = std::get<ByteArray>(j_audio_data_);
 
-  env->SetByteArrayRegion(audio_data_local_ref.obj(), kNoOffset,
+  env->SetByteArrayRegion(byte_array.obj(), kNoOffset,
                           num_of_samples * sizeof(uint16_t),
                           reinterpret_cast<const jbyte*>(samples));
 
   int bytes_written = Java_AudioTrackBridge_writeWithPresentationTime(
-      env, j_audio_track_bridge_,
-      // JavaParamRef<jbyteArray>'s raw pointer constructor expects a local
-      // reference.
-      audio_data_local_ref, num_of_samples * sizeof(uint16_t), sync_time);
+      env, j_audio_track_bridge_, byte_array, num_of_samples * sizeof(uint16_t),
+      sync_time);
   if (bytes_written < 0) {
     // Error code returned as negative value, like AudioTrack.ERROR_DEAD_OBJECT.
     return bytes_written;
@@ -237,18 +227,14 @@ int AudioTrackBridge::WriteSample(const uint8_t* samples,
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
 
-  SB_DCHECK(env->IsInstanceOf(j_audio_data_.obj(), env->FindClass("[B")));
-  ScopedJavaLocalRef<jbyteArray> audio_data_local_ref =
-      static_java_ref_cast<jbyteArray>(env, j_audio_data_);
+  SB_CHECK(std::holds_alternative<ByteArray>(j_audio_data_));
+  const auto& byte_array = std::get<ByteArray>(j_audio_data_);
 
-  env->SetByteArrayRegion(audio_data_local_ref.obj(), kNoOffset, num_of_samples,
+  env->SetByteArrayRegion(byte_array.obj(), kNoOffset, num_of_samples,
                           reinterpret_cast<const jbyte*>(samples));
 
   int bytes_written = Java_AudioTrackBridge_writeWithPresentationTime(
-      env, j_audio_track_bridge_,
-      // JavaParamRef<jbyteArray>'s raw pointer constructor expects a local
-      // reference.
-      audio_data_local_ref, num_of_samples, sync_time);
+      env, j_audio_track_bridge_, byte_array, num_of_samples, sync_time);
 
   if (bytes_written < 0) {
     // Error code returned as negative value, like AudioTrack.ERROR_DEAD_OBJECT.

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -37,6 +37,19 @@ using jni_zero::JavaParamRef;
 using jni_zero::ScopedJavaGlobalRef;
 using jni_zero::ScopedJavaLocalRef;
 
+// Safely casts a JavaRef (like ScopedJavaGlobalRef) to a ScopedJavaLocalRef of
+// a different JNI type (e.g. jobject to jfloatArray).
+//
+// Copied from Chromium/WebRTC. See
+// https://github.com/youtube/cobalt/blob/f0ef063d30589b39dc4a1433b0dde659d2fb5eea/third_party/webrtc/sdk/android/native_api/jni/scoped_java_ref.h#L30-L37
+template <typename T, typename U>
+inline ScopedJavaLocalRef<T> static_java_ref_cast(
+    JNIEnv* env,
+    const jni_zero::JavaRef<U>& ref) {
+  ScopedJavaLocalRef<U> owned_ref(env, ref);
+  return ScopedJavaLocalRef<T>(env, static_cast<T>(owned_ref.Release()));
+}
+
 const jint kNoOffset = 0;
 
 }  // namespace
@@ -65,39 +78,22 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
     // explicit.
   }
 
+  int max_samples_per_write = [&] {
+    if (coding_type != kSbMediaAudioCodingTypePcm) {
+      SB_DCHECK(!sample_type);
+      return kMaxFramesPerRequest;
+    }
+    return channels * kMaxFramesPerRequest;
+  }();
+
   JNIEnv* env = AttachCurrentThread();
-
-  int max_samples_per_write = 0;
-  ScopedJavaGlobalRef<jobject> j_audio_data;
-  if (coding_type != kSbMediaAudioCodingTypePcm) {
-    SB_DCHECK(!sample_type);
-    max_samples_per_write = kMaxFramesPerRequest;
-    j_audio_data = ScopedJavaLocalRef<jbyteArray>(
-        env, env->NewByteArray(max_samples_per_write));
-  } else if (sample_type == kSbMediaAudioSampleTypeFloat32) {
-    max_samples_per_write = channels * kMaxFramesPerRequest;
-    j_audio_data = ScopedJavaLocalRef<jfloatArray>(
-        env, env->NewFloatArray(channels * kMaxFramesPerRequest));
-  } else if (sample_type == kSbMediaAudioSampleTypeInt16Deprecated) {
-    max_samples_per_write = channels * kMaxFramesPerRequest;
-    int size_in_bytes = channels * GetBytesPerSample(sample_type.value()) *
-                        kMaxFramesPerRequest;
-    j_audio_data =
-        ScopedJavaLocalRef<jbyteArray>(env, env->NewByteArray(size_in_bytes));
-  } else {
-    SB_NOTREACHED();
-  }
-
-  if (j_audio_data.is_null()) {
-    SB_LOG(WARNING) << "Failed to allocate |j_audio_data_|";
-    return nullptr;
-  }
 
   ScopedJavaLocalRef<jobject> j_audio_track_bridge =
       AudioOutputManager::GetInstance()->CreateAudioTrackBridge(
           env, GetAudioFormatSampleType(coding_type, sample_type),
-          sampling_frequency_hz, channels, preferred_buffer_size_in_bytes,
-          tunnel_mode_audio_session_id, is_web_audio);
+          sampling_frequency_hz, channels, max_samples_per_write,
+          preferred_buffer_size_in_bytes, tunnel_mode_audio_session_id,
+          is_web_audio);
 
   if (j_audio_track_bridge.is_null()) {
     // One of the cases that this may hit is when output happened to be switched
@@ -111,9 +107,17 @@ std::unique_ptr<AudioTrackBridge> AudioTrackBridge::Create(
     return nullptr;
   }
 
-  return std::make_unique<AudioTrackBridge>(PassKey<AudioTrackBridge>(),
-                                            max_samples_per_write,
-                                            j_audio_track_bridge, j_audio_data);
+  ScopedJavaLocalRef<jobject> j_audio_data =
+      Java_AudioTrackBridge_getPreAllocatedAudioData(env, j_audio_track_bridge);
+
+  if (j_audio_data.is_null()) {
+    SB_LOG(WARNING) << "Failed to retrieve |j_audio_data_|";
+    return nullptr;
+  }
+
+  return std::make_unique<AudioTrackBridge>(
+      PassKey<AudioTrackBridge>(), max_samples_per_write, j_audio_track_bridge,
+      ScopedJavaGlobalRef<jobject>(env, j_audio_data));
 }
 
 AudioTrackBridge::AudioTrackBridge(
@@ -130,9 +134,8 @@ AudioTrackBridge::~AudioTrackBridge() {
     // Both the global and local references refer to the exact same Java object
     // in the JVM.
     JNIEnv* env = AttachCurrentThread();
-    jobject audio_track_bridge_ref =
-        env->NewLocalRef(j_audio_track_bridge_.obj());
-    ScopedJavaLocalRef<jobject> audio_track_bridge(env, audio_track_bridge_ref);
+    ScopedJavaLocalRef<jobject> audio_track_bridge =
+        j_audio_track_bridge_.AsLocalRef(env);
     AudioOutputManager::GetInstance()->DestroyAudioTrackBridge(
         env, audio_track_bridge);
   }
@@ -180,11 +183,11 @@ int AudioTrackBridge::WriteSample(const float* samples,
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
 
   SB_DCHECK(env->IsInstanceOf(j_audio_data_.obj(), env->FindClass("[F")));
-  env->SetFloatArrayRegion(static_cast<jfloatArray>(j_audio_data_.obj()),
-                           kNoOffset, num_of_samples, samples);
+  ScopedJavaLocalRef<jfloatArray> audio_data_local_ref =
+      static_java_ref_cast<jfloatArray>(env, j_audio_data_);
 
-  ScopedJavaLocalRef<jfloatArray> audio_data_local_ref(
-      env, static_cast<jfloatArray>(env->NewLocalRef(j_audio_data_.obj())));
+  env->SetFloatArrayRegion(audio_data_local_ref.obj(), kNoOffset,
+                           num_of_samples, samples);
 
   return Java_AudioTrackBridge_write(env, j_audio_track_bridge_,
                                      // JavaParamRef<jfloatArray>'s raw pointer
@@ -203,12 +206,12 @@ int AudioTrackBridge::WriteSample(const uint16_t* samples,
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
 
   SB_DCHECK(env->IsInstanceOf(j_audio_data_.obj(), env->FindClass("[B")));
-  env->SetByteArrayRegion(static_cast<jbyteArray>(j_audio_data_.obj()),
-                          kNoOffset, num_of_samples * sizeof(uint16_t),
-                          reinterpret_cast<const jbyte*>(samples));
+  ScopedJavaLocalRef<jbyteArray> audio_data_local_ref =
+      static_java_ref_cast<jbyteArray>(env, j_audio_data_);
 
-  ScopedJavaLocalRef<jbyteArray> audio_data_local_ref(
-      env, static_cast<jbyteArray>(env->NewLocalRef(j_audio_data_.obj())));
+  env->SetByteArrayRegion(audio_data_local_ref.obj(), kNoOffset,
+                          num_of_samples * sizeof(uint16_t),
+                          reinterpret_cast<const jbyte*>(samples));
 
   int bytes_written = Java_AudioTrackBridge_writeWithPresentationTime(
       env, j_audio_track_bridge_,
@@ -235,12 +238,11 @@ int AudioTrackBridge::WriteSample(const uint8_t* samples,
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
 
   SB_DCHECK(env->IsInstanceOf(j_audio_data_.obj(), env->FindClass("[B")));
-  env->SetByteArrayRegion(static_cast<jbyteArray>(j_audio_data_.obj()),
-                          kNoOffset, num_of_samples,
-                          reinterpret_cast<const jbyte*>(samples));
+  ScopedJavaLocalRef<jbyteArray> audio_data_local_ref =
+      static_java_ref_cast<jbyteArray>(env, j_audio_data_);
 
-  ScopedJavaLocalRef<jbyteArray> audio_data_local_ref(
-      env, static_cast<jbyteArray>(env->NewLocalRef(j_audio_data_.obj())));
+  env->SetByteArrayRegion(audio_data_local_ref.obj(), kNoOffset, num_of_samples,
+                          reinterpret_cast<const jbyte*>(samples));
 
   int bytes_written = Java_AudioTrackBridge_writeWithPresentationTime(
       env, j_audio_track_bridge_,

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <variant>
 
 #include "starboard/common/pass_key.h"
 #include "starboard/media.h"
@@ -31,6 +32,10 @@ namespace starboard {
 // The C++ encapsulation of the Java class AudioTrackBridge.
 class AudioTrackBridge {
  public:
+  using FloatArray = jni_zero::ScopedJavaGlobalRef<jfloatArray>;
+  using ByteArray = jni_zero::ScopedJavaGlobalRef<jbyteArray>;
+  using DataArray = std::variant<FloatArray, ByteArray>;
+
   // The maximum number of frames that can be written to android audio track per
   // write request.  It is used to pre-allocate |j_audio_data_|.
   static constexpr int kMaxFramesPerRequest = 65536;
@@ -50,7 +55,7 @@ class AudioTrackBridge {
       PassKey<AudioTrackBridge>,
       int max_samples_per_write,
       const jni_zero::ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
-      const jni_zero::ScopedJavaGlobalRef<jobject>& j_audio_data);
+      const DataArray& j_audio_data);
   ~AudioTrackBridge();
 
   void Play(JNIEnv* env = jni_zero::AttachCurrentThread());
@@ -96,7 +101,7 @@ class AudioTrackBridge {
   // The audio data has to be copied into a Java Array before writing into the
   // audio track. Allocating a large array and saves as a member variable
   // avoids an array being allocated repeatedly.
-  const jni_zero::ScopedJavaGlobalRef<jobject> j_audio_data_;
+  const DataArray j_audio_data_;
 };
 
 }  // namespace starboard


### PR DESCRIPTION
Move the allocation of audio data buffers from C++ JNI calls to the
Java AudioTrackBridge constructor.

This change follows JNI best practices by avoiding direct calls to
memory allocation methods in the JNI environment, which reduces the
risk of memory leaks from un-wrapped local references. The Java side
now manages the buffer lifecycle, and the C++ layer retrieves the
reference during initialization.


Issue: 520007952