### PR TITLE
starboard: Avoid heap allocation during playback

### DIFF
--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -64,7 +64,8 @@ class VideoFrameImpl : public VideoFrame {
   typedef std::function<void()> VideoFrameReleaseCallback;
 
   void* operator new(size_t size) {
-    if (FeatureList::IsEnabled(features::kEnableVideoFrameImplMemoryPool)) {
+    if (FeatureList::IsEnabled(features::kVideoFrameImplMemoryPool) &&
+        size == sizeof(VideoFrameImpl)) {
       return GetPool()->Allocate();
     }
     return ::operator new(size);

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -56,7 +56,7 @@ using jni_zero::JavaRef;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
-LazyInitializer<ObjectPool> g_pool;
+LazyInitializer<ObjectPool, /*NoDestruct=*/true> g_pool;
 ObjectPool* GetPool();
 
 class VideoFrameImpl : public VideoFrame {

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -39,22 +39,45 @@
 #include "starboard/configuration.h"
 #include "starboard/decode_target.h"
 #include "starboard/drm.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/media_tracing.h"
 #include "starboard/shared/starboard/media/mime_type.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
+#include "starboard/shared/starboard/player/lazy_initializer.h"
+#include "starboard/shared/starboard/player/object_pool.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 namespace {
 
+using features::FeatureList;
 using jni_zero::AttachCurrentThread;
 using jni_zero::JavaRef;
 using std::placeholders::_1;
 using std::placeholders::_2;
 
+LazyInitializer<ObjectPool> g_pool;
+ObjectPool* GetPool();
+
 class VideoFrameImpl : public VideoFrame {
  public:
   typedef std::function<void()> VideoFrameReleaseCallback;
+
+  void* operator new(size_t size) {
+    if (FeatureList::IsEnabled(features::kEnableVideoFrameImplMemoryPool)) {
+      return GetPool()->Allocate();
+    }
+    return ::operator new(size);
+  }
+
+  void operator delete(void* ptr) {
+    ObjectPool* pool = g_pool.GetIfInitialized();
+    if (pool) {
+      pool->Free(ptr);
+    } else {
+      ::operator delete(ptr);
+    }
+  }
 
   VideoFrameImpl(const DequeueOutputResult& dequeue_output_result,
                  MediaCodec* media_codec_bridge,
@@ -109,6 +132,15 @@ const int kTunnelModePrerollFrameCount = 1;
 const int kMaxPendingInputsSize = 128;
 
 const int kFpsGuesstimateRequiredInputBufferCount = 3;
+
+// kPoolSize (32) is chosen to accommodate the maximum number of video frames
+// that can be in-flight concurrently in the decoder and renderer pipeline.
+// This is a safe margin to avoid fallback to heap allocation.
+constexpr size_t kPoolSize = 32;
+
+ObjectPool* GetPool() {
+  return g_pool.Get(sizeof(VideoFrameImpl), kPoolSize);
+}
 
 std::array<float, 16> GetTransformMatrix(
     const JavaRef<jobject>& surface_texture) {

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -102,6 +102,11 @@ FEATURE_LIST_START
 
 #if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 // keep-sorted start newline_separated=yes
+// When enabled, Cobalt pools physical memory allocations for decoded audio
+// buffers inside a thread-safe fixed-size pool, preventing progressive heap
+// fragmentation on restricted-memory devices.
+STARBOARD_FEATURE(kDecodedAudioBufferPool, "DecodedAudioBufferPool", false)
+
 // By default, app provisioning is disabled. Set the following variable to true
 // to enable app provisioning.
 STARBOARD_FEATURE(kEnableAppProvisioning, "EnableAppProvisioning", false)
@@ -109,19 +114,6 @@ STARBOARD_FEATURE(kEnableAppProvisioning, "EnableAppProvisioning", false)
 // Set the following variable to true to enable av1 startup optimization.
 STARBOARD_FEATURE(kEnableAv1StartupOptimization,
                   "EnableAv1StartupOptimization",
-                  false)
-
-// When enabled, Cobalt pools physical memory allocations for decoded audio
-// buffers inside a thread-safe fixed-size pool, preventing progressive heap
-// fragmentation on restricted-memory devices.
-STARBOARD_FEATURE(kEnableDecodedAudioBufferPool,
-                  "EnableDecodedAudioBufferPool",
-                  false)
-
-// Enable thread-safe memory pool for VideoFrameImpl to eliminate steady-state
-// heap allocations.
-STARBOARD_FEATURE(kEnableVideoFrameImplMemoryPool,
-                  "EnableVideoFrameImplMemoryPool",
                   false)
 
 // By default, Cobalt destroys and recreates AudioTrack during Seek().
@@ -181,6 +173,10 @@ STARBOARD_FEATURE(kUseStubVideoDecoder, "UseStubVideoDecoder", false)
 STARBOARD_FEATURE(kVideoDecoderDelayUsecOverride,
                   "VideoDecoderDelayUsecOverride",
                   false)
+
+// Enable thread-safe memory pool for VideoFrameImpl to eliminate steady-state
+// heap allocations.
+STARBOARD_FEATURE(kVideoFrameImplMemoryPool, "VideoFrameImplMemoryPool", false)
 // keep-sorted end
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 FEATURE_LIST_END

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -111,6 +111,19 @@ STARBOARD_FEATURE(kEnableAv1StartupOptimization,
                   "EnableAv1StartupOptimization",
                   false)
 
+// When enabled, Cobalt pools physical memory allocations for decoded audio
+// buffers inside a thread-safe fixed-size pool, preventing progressive heap
+// fragmentation on restricted-memory devices.
+STARBOARD_FEATURE(kEnableDecodedAudioBufferPool,
+                  "EnableDecodedAudioBufferPool",
+                  false)
+
+// Enable thread-safe memory pool for VideoFrameImpl to eliminate steady-state
+// heap allocations.
+STARBOARD_FEATURE(kEnableVideoFrameImplMemoryPool,
+                  "EnableVideoFrameImplMemoryPool",
+                  false)
+
 // By default, Cobalt destroys and recreates AudioTrack during Seek().
 // Set the following variable to true to force it to Flush() AudioTrack
 // during Seek().

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -171,6 +171,10 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/starboard/audio_sink/stub_audio_sink_type.h",
     "//starboard/shared/starboard/event_cancel.cc",
     "//starboard/shared/starboard/event_schedule.cc",
+    "//starboard/shared/starboard/feature_list.cc",
+    "//starboard/shared/starboard/feature_list.h",
+    "//starboard/shared/starboard/features.cc",
+    "//starboard/shared/starboard/features.h",
     "//starboard/shared/starboard/file_storage/storage_close_record.cc",
     "//starboard/shared/starboard/file_storage/storage_delete_record.cc",
     "//starboard/shared/starboard/file_storage/storage_get_record_size.cc",
@@ -315,6 +319,7 @@ if (current_toolchain == starboard_toolchain) {
       ":starboard_platform",
       "//starboard:starboard_with_main",
       "//starboard/shared/starboard/player/filter/testing:test_util",
+      "//starboard/testing:scoped_feature_list",
       "//testing/gmock",
       "//testing/gtest",
     ]

--- a/starboard/shared/starboard/player/buffer_internal.cc
+++ b/starboard/shared/starboard/player/buffer_internal.cc
@@ -51,13 +51,10 @@ FixedSizeMemoryPool* GetPool() {
 
 bool UseBufferPool() {
 #if BUILDFLAG(IS_ANDROID)
-  return features::FeatureList::IsEnabled(
-      features::kEnableDecodedAudioBufferPool);
+  return features::FeatureList::IsEnabled(features::kDecodedAudioBufferPool);
 #else
-  if (features::FeatureList::HasOverrideForTesting(
-          "EnableDecodedAudioBufferPool")) {
-    return features::FeatureList::IsEnabledByName(
-        "EnableDecodedAudioBufferPool");
+  if (features::FeatureList::HasOverrideForTesting("DecodedAudioBufferPool")) {
+    return features::FeatureList::IsEnabledByName("DecodedAudioBufferPool");
   }
   return false;
 #endif

--- a/starboard/shared/starboard/player/buffer_internal.cc
+++ b/starboard/shared/starboard/player/buffer_internal.cc
@@ -43,7 +43,7 @@ constexpr size_t kBufferSize = 32 * 1024;
 // consuming only ~1.25MB of RAM total (32KB * 40).
 constexpr size_t kPoolSize = 40;
 
-LazyInitializer<FixedSizeMemoryPool> g_buffer_pool;
+LazyInitializer<FixedSizeMemoryPool, /*NoDestruct=*/true> g_buffer_pool;
 
 FixedSizeMemoryPool* GetPool() {
   return g_buffer_pool.Get(kBufferSize, kPoolSize);

--- a/starboard/shared/starboard/player/buffer_internal.cc
+++ b/starboard/shared/starboard/player/buffer_internal.cc
@@ -1,0 +1,105 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+// Force rebuild.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/buffer_internal.h"
+
+#include <algorithm>
+#include <cstring>
+#include <utility>
+
+#include "build/build_config.h"
+#include "starboard/common/check_op.h"
+#include "starboard/common/log.h"
+#include "starboard/shared/starboard/feature_list.h"
+#include "starboard/shared/starboard/player/fixed_size_memory_pool.h"
+#include "starboard/shared/starboard/player/lazy_initializer.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "starboard/shared/starboard/features.h"
+#endif
+
+namespace starboard {
+namespace {
+// kBufferSize (32KB) is chosen to be large enough to hold the maximum typical
+// float32 PCM audio frame payloads:
+// - Stereo Float32 PCM at 48kHz (20ms packets) requires 7,680 bytes.
+// - 5.1 Surround Float32 PCM at 48kHz (20ms packets) requires 23,040 bytes.
+constexpr size_t kBufferSize = 32 * 1024;
+
+// kPoolSize (40) provides a safe margin. Real-world playback tests show a
+// maximum of ~26 buffers in-flight concurrently (leaving 14+ free), while
+// consuming only ~1.25MB of RAM total (32KB * 40).
+constexpr size_t kPoolSize = 40;
+
+LazyInitializer<FixedSizeMemoryPool> g_buffer_pool;
+
+FixedSizeMemoryPool* GetPool() {
+  return g_buffer_pool.Get(kBufferSize, kPoolSize);
+}
+
+bool UseBufferPool() {
+#if BUILDFLAG(IS_ANDROID)
+  return features::FeatureList::IsEnabled(
+      features::kEnableDecodedAudioBufferPool);
+#else
+  if (features::FeatureList::HasOverrideForTesting(
+          "EnableDecodedAudioBufferPool")) {
+    return features::FeatureList::IsEnabledByName(
+        "EnableDecodedAudioBufferPool");
+  }
+  return false;
+#endif
+}
+}  // namespace
+
+size_t Buffer::GetPoolFreeListSizeForTesting() {
+  return GetPool()->free_list_size();
+}
+
+size_t Buffer::GetPoolCapacityForTesting() {
+  return GetPool()->capacity();
+}
+
+uint8_t* Buffer::AllocateData(size_t size) {
+  if (size == 0) {
+    return nullptr;
+  }
+
+  if (UseBufferPool()) {
+    FixedSizeMemoryPool* pool = GetPool();
+    if (size <= pool->block_size()) {
+      void* ptr = pool->Allocate();
+      if (ptr) {
+        return static_cast<uint8_t*>(ptr);
+      }
+    }
+  }
+  return new uint8_t[size];
+}
+
+void Buffer::FreeData(uint8_t* ptr) {
+  if (!ptr) {
+    return;
+  }
+
+  FixedSizeMemoryPool* pool = g_buffer_pool.GetIfInitialized();
+  if (pool && pool->IsFromPool(ptr)) {
+    pool->Free(ptr);
+    return;
+  }
+  delete[] ptr;
+}
+
+}  // namespace starboard

--- a/starboard/shared/starboard/player/buffer_internal.h
+++ b/starboard/shared/starboard/player/buffer_internal.h
@@ -49,7 +49,12 @@ class Buffer {
   }
 
   Buffer(const Buffer& that)
-      : size_(that.size_), data_(AllocateData(that.size_ + kPaddingSize * 2)) {
+      : size_(that.size_),
+        data_(that.data_ ? AllocateData(that.size_ + kPaddingSize * 2)
+                         : nullptr) {
+    if (!data_) {
+      return;
+    }
     memcpy(data_, that.data_, size_ + kPaddingSize * 2);
   }
   Buffer(Buffer&& that) : size_(that.size_), data_(that.data_) {

--- a/starboard/shared/starboard/player/buffer_internal.h
+++ b/starboard/shared/starboard/player/buffer_internal.h
@@ -26,6 +26,7 @@
 #include "starboard/shared/internal_only.h"
 
 namespace starboard {
+class FixedSizeMemoryPool;
 
 // A buffer containing arbitrary binary data, with life time and size managed.
 // It performs better than std::vector<> as it doesn't fill the buffer with 0s.
@@ -40,7 +41,7 @@ class Buffer {
 
   Buffer() = default;
   explicit Buffer(int size)
-      : size_(size), data_(new uint8_t[size + kPaddingSize * 2]) {
+      : size_(size), data_(AllocateData(size + kPaddingSize * 2)) {
 #if !defined(NDEBUG)
     memset(data_, kPadding, kPaddingSize);
     memset(data_ + kPaddingSize + size_, kPadding, kPaddingSize);
@@ -48,7 +49,7 @@ class Buffer {
   }
 
   Buffer(const Buffer& that)
-      : size_(that.size_), data_(new uint8_t[that.size_ + kPaddingSize * 2]) {
+      : size_(that.size_), data_(AllocateData(that.size_ + kPaddingSize * 2)) {
     memcpy(data_, that.data_, size_ + kPaddingSize * 2);
   }
   Buffer(Buffer&& that) : size_(that.size_), data_(that.data_) {
@@ -65,7 +66,7 @@ class Buffer {
                   0);
     }
 #endif  // !defined(NDEBUG)
-    delete[] data_;
+    FreeData(data_);
   }
 
   Buffer& operator=(Buffer&& that) {
@@ -81,7 +82,13 @@ class Buffer {
     return size_ == 0 ? nullptr : data_ + kPaddingSize;
   }
 
+  static size_t GetPoolFreeListSizeForTesting();
+  static size_t GetPoolCapacityForTesting();
+
  private:
+  static uint8_t* AllocateData(size_t size);
+  static void FreeData(uint8_t* ptr);
+
   int size_ = 0;
   uint8_t* data_ = nullptr;
 

--- a/starboard/shared/starboard/player/buffer_test_internal.cc
+++ b/starboard/shared/starboard/player/buffer_test_internal.cc
@@ -13,8 +13,14 @@
 // limitations under the License.
 
 #include <utility>
+#include <vector>
 
+#include "starboard/shared/starboard/feature_list.h"
 #include "starboard/shared/starboard/player/buffer_internal.h"
+#include "starboard/testing/scoped_feature_list.h"
+#if BUILDFLAG(IS_ANDROID)
+#include "starboard/shared/starboard/features.h"
+#endif
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace starboard {
@@ -86,6 +92,62 @@ TEST(BufferTest, MoveAssignmentOperator) {
   }
 }
 
-}  // namespace
+TEST(BufferTest, PoolAllocation) {
+  starboard::features::ScopedFeatureList scoped_features;
+#if BUILDFLAG(IS_ANDROID)
+  scoped_features.InitAndEnableFeature(features::kEnableDecodedAudioBufferPool);
+#else
+  scoped_features.InitAndEnableFeature("EnableDecodedAudioBufferPool");
+#endif
+  size_t capacity = Buffer::GetPoolCapacityForTesting();
+  size_t initial_free = Buffer::GetPoolFreeListSizeForTesting();
+  EXPECT_EQ(initial_free, capacity);
 
+  {
+    Buffer buffer1(100);
+    EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), initial_free - 1);
+
+    {
+      Buffer buffer2(200);
+      EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), initial_free - 2);
+    }
+    EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), initial_free - 1);
+  }
+  EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), initial_free);
+
+  {
+    Buffer large_buffer(130 * 1024);
+    EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), initial_free);
+  }
+  EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), initial_free);
+
+  std::vector<Buffer> buffers;
+  for (size_t i = 0; i < capacity; ++i) {
+    buffers.emplace_back(100);
+  }
+  EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), 0U);
+
+  {
+    Buffer extra_buffer(100);
+    EXPECT_NE(extra_buffer.data(), nullptr);
+    EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), 0U);
+  }
+
+  buffers.clear();
+  EXPECT_EQ(Buffer::GetPoolFreeListSizeForTesting(), initial_free);
+}
+
+TEST(FeatureListTest, ScopedOverride) {
+  std::string feature_name = "SomeDummyFeatureForTesting";
+  {
+    features::ScopedFeatureList scoped_features;
+    scoped_features.InitAndEnableFeature(feature_name);
+    EXPECT_TRUE(features::FeatureList::IsEnabledByName(feature_name));
+
+    scoped_features.InitAndDisableFeature(feature_name);
+    EXPECT_FALSE(features::FeatureList::IsEnabledByName(feature_name));
+  }
+}
+
+}  // namespace
 }  // namespace starboard

--- a/starboard/shared/starboard/player/buffer_test_internal.cc
+++ b/starboard/shared/starboard/player/buffer_test_internal.cc
@@ -58,6 +58,13 @@ TEST(BufferTest, CopyCtor) {
   }
 }
 
+TEST(BufferTest, CopyEmptyBuffer) {
+  Buffer original;
+  Buffer copy(original);
+  EXPECT_EQ(copy.size(), 0);
+  EXPECT_EQ(copy.data(), nullptr);
+}
+
 TEST(BufferTest, MoveCtor) {
   Buffer original(128);
   memset(original.data(), 'x', 128);
@@ -95,9 +102,9 @@ TEST(BufferTest, MoveAssignmentOperator) {
 TEST(BufferTest, PoolAllocation) {
   starboard::features::ScopedFeatureList scoped_features;
 #if BUILDFLAG(IS_ANDROID)
-  scoped_features.InitAndEnableFeature(features::kEnableDecodedAudioBufferPool);
+  scoped_features.InitAndEnableFeature(features::kDecodedAudioBufferPool);
 #else
-  scoped_features.InitAndEnableFeature("EnableDecodedAudioBufferPool");
+  scoped_features.InitAndEnableFeature("DecodedAudioBufferPool");
 #endif
   size_t capacity = Buffer::GetPoolCapacityForTesting();
   size_t initial_free = Buffer::GetPoolFreeListSizeForTesting();

--- a/starboard/shared/starboard/player/buildfiles.gni
+++ b/starboard/shared/starboard/player/buildfiles.gni
@@ -13,15 +13,21 @@
 # limitations under the License.
 
 common_player_sources = [
+  "//starboard/shared/starboard/player/buffer_internal.cc",
   "//starboard/shared/starboard/player/buffer_internal.h",
   "//starboard/shared/starboard/player/decoded_audio_internal.cc",
   "//starboard/shared/starboard/player/decoded_audio_internal.h",
+  "//starboard/shared/starboard/player/fixed_size_memory_pool.cc",
+  "//starboard/shared/starboard/player/fixed_size_memory_pool.h",
   "//starboard/shared/starboard/player/input_buffer_internal.cc",
   "//starboard/shared/starboard/player/input_buffer_internal.h",
   "//starboard/shared/starboard/player/job_queue.cc",
   "//starboard/shared/starboard/player/job_queue.h",
   "//starboard/shared/starboard/player/job_thread.cc",
   "//starboard/shared/starboard/player/job_thread.h",
+  "//starboard/shared/starboard/player/lazy_initializer.h",
+  "//starboard/shared/starboard/player/object_pool.cc",
+  "//starboard/shared/starboard/player/object_pool.h",
   "//starboard/shared/starboard/player/player_create.cc",
   "//starboard/shared/starboard/player/player_destroy.cc",
   "//starboard/shared/starboard/player/player_get_audio_configuration.cc",

--- a/starboard/shared/starboard/player/fixed_size_memory_pool.cc
+++ b/starboard/shared/starboard/player/fixed_size_memory_pool.cc
@@ -14,24 +14,32 @@
 
 #include "starboard/shared/starboard/player/fixed_size_memory_pool.h"
 
+#include <cstddef>
 #include <cstdint>
+#include <limits>
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "starboard/common/pointer_arithmetic.h"
 
 namespace starboard {
 
 FixedSizeMemoryPool::FixedSizeMemoryPool(size_t block_size, size_t capacity)
     : block_size_([&] {
         SB_CHECK_GT(block_size, 0U);
-        return block_size;
+        return AlignUp(block_size, alignof(std::max_align_t));
       }()),
       capacity_([&] {
         SB_CHECK_GT(capacity, 0U);
         return capacity;
       }()),
-      pool_storage_(::operator new(block_size* capacity)) {
-  SB_CHECK(pool_storage_);
+      pool_storage_([&] {
+        SB_CHECK_LE(block_size_,
+                    std::numeric_limits<size_t>::max() / capacity_);
+        void* storage = ::operator new(block_size_ * capacity_);
+        SB_CHECK(storage);
+        return storage;
+      }()) {
   free_list_.reserve(capacity_);
 
   uint8_t* base = static_cast<uint8_t*>(pool_storage_);

--- a/starboard/shared/starboard/player/fixed_size_memory_pool.cc
+++ b/starboard/shared/starboard/player/fixed_size_memory_pool.cc
@@ -1,0 +1,87 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/fixed_size_memory_pool.h"
+
+#include <cstdint>
+
+#include "starboard/common/check_op.h"
+#include "starboard/common/log.h"
+
+namespace starboard {
+
+FixedSizeMemoryPool::FixedSizeMemoryPool(size_t block_size, size_t capacity)
+    : block_size_([&] {
+        SB_CHECK_GT(block_size, 0U);
+        return block_size;
+      }()),
+      capacity_([&] {
+        SB_CHECK_GT(capacity, 0U);
+        return capacity;
+      }()),
+      pool_storage_(::operator new(block_size* capacity)) {
+  SB_CHECK(pool_storage_);
+  free_list_.reserve(capacity_);
+
+  uint8_t* base = static_cast<uint8_t*>(pool_storage_);
+  for (size_t i = 0; i < capacity_; ++i) {
+    free_list_.push_back(base + i * block_size_);
+  }
+}
+
+FixedSizeMemoryPool::~FixedSizeMemoryPool() {
+  SB_DCHECK_EQ(free_list_.size(), capacity_)
+      << "Not all blocks were returned to the pool.";
+  ::operator delete(pool_storage_);
+}
+
+void* FixedSizeMemoryPool::Allocate() {
+  std::lock_guard lock(mutex_);
+  if (free_list_.empty()) {
+    return nullptr;
+  }
+
+  void* ptr = free_list_.back();
+  free_list_.pop_back();
+  return ptr;
+}
+
+void FixedSizeMemoryPool::Free(void* ptr) {
+  if (!ptr) {
+    return;
+  }
+
+  SB_CHECK(IsFromPool(ptr));
+  std::lock_guard lock(mutex_);
+  SB_CHECK_LT(free_list_.size(), capacity_);
+  free_list_.push_back(ptr);
+}
+
+bool FixedSizeMemoryPool::IsFromPool(void* ptr) const {
+  if (!pool_storage_) {
+    return false;
+  }
+  uintptr_t ptr_val = reinterpret_cast<uintptr_t>(ptr);
+  uintptr_t start_val = reinterpret_cast<uintptr_t>(pool_storage_);
+  uintptr_t end_val = start_val + block_size_ * capacity_;
+  return ptr_val >= start_val && ptr_val < end_val &&
+         (ptr_val - start_val) % block_size_ == 0;
+}
+
+size_t FixedSizeMemoryPool::free_list_size() const {
+  std::lock_guard lock(mutex_);
+  return free_list_.size();
+}
+
+}  // namespace starboard

--- a/starboard/shared/starboard/player/fixed_size_memory_pool.h
+++ b/starboard/shared/starboard/player/fixed_size_memory_pool.h
@@ -1,0 +1,68 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_STARBOARD_PLAYER_FIXED_SIZE_MEMORY_POOL_H_
+#define STARBOARD_SHARED_STARBOARD_PLAYER_FIXED_SIZE_MEMORY_POOL_H_
+
+#include <cstddef>
+#include <mutex>
+#include <vector>
+
+namespace starboard {
+
+// A thread-safe, fixed-size memory pool that allocates memory blocks of a
+// constant size from a single pre-allocated contiguous block.
+// This pool is designed to eliminate memory fragmentation.
+// It does NOT handle fallback to heap internally; Allocate() returns nullptr
+// if the pool is exhausted.
+class FixedSizeMemoryPool {
+ public:
+  // Constructor.
+  // |block_size| is the size of each block in bytes.
+  // |capacity| is the number of blocks to pre-allocate. Must be > 0.
+  FixedSizeMemoryPool(size_t block_size, size_t capacity);
+  ~FixedSizeMemoryPool();
+
+  // Disallow copy and assign.
+  FixedSizeMemoryPool(const FixedSizeMemoryPool&) = delete;
+  FixedSizeMemoryPool& operator=(const FixedSizeMemoryPool&) = delete;
+
+  // Allocates a block of memory of block_size.
+  // Returns a pointer to the allocated block, or nullptr if the pool is
+  // exhausted.
+  void* Allocate();
+
+  // Returns a block of memory back to the pool.
+  // |ptr| must have been allocated from this pool and not yet freed.
+  void Free(void* ptr);
+
+  // Helper to check if a pointer belongs to this pool.
+  bool IsFromPool(void* ptr) const;
+
+  size_t block_size() const { return block_size_; }
+  size_t capacity() const { return capacity_; }
+  size_t free_list_size() const;
+
+ private:
+  const size_t block_size_;
+  const size_t capacity_;
+  void* const pool_storage_;
+
+  mutable std::mutex mutex_;
+  std::vector<void*> free_list_;  // Guarded by |mutex_|.
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_SHARED_STARBOARD_PLAYER_FIXED_SIZE_MEMORY_POOL_H_

--- a/starboard/shared/starboard/player/fixed_size_memory_pool_test.cc
+++ b/starboard/shared/starboard/player/fixed_size_memory_pool_test.cc
@@ -1,0 +1,146 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/fixed_size_memory_pool.h"
+
+#include <thread>
+#include <vector>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace {
+
+TEST(FixedSizeMemoryPoolTest, BasicAllocationAndFree) {
+  const size_t kBlockSize = 32;
+  const size_t kCapacity = 4;
+  FixedSizeMemoryPool pool(kBlockSize, kCapacity);
+
+  EXPECT_EQ(pool.block_size(), kBlockSize);
+  EXPECT_EQ(pool.capacity(), kCapacity);
+  EXPECT_EQ(pool.free_list_size(), kCapacity);
+
+  std::vector<void*> allocated_blocks;
+
+  // 1. Allocate all blocks.
+  for (size_t i = 0; i < kCapacity; ++i) {
+    void* ptr = pool.Allocate();
+    ASSERT_NE(ptr, nullptr);
+    EXPECT_TRUE(pool.IsFromPool(ptr));
+    allocated_blocks.push_back(ptr);
+  }
+  EXPECT_EQ(pool.free_list_size(), 0);
+
+  // 2. Try to allocate one more. Should return nullptr (no fallback).
+  void* extra_ptr = pool.Allocate();
+  EXPECT_EQ(extra_ptr, nullptr);
+
+  // 3. Free all blocks.
+  for (void* ptr : allocated_blocks) {
+    pool.Free(ptr);
+  }
+  EXPECT_EQ(pool.free_list_size(), kCapacity);
+
+  // 4. Allocate again.
+  void* ptr = pool.Allocate();
+  EXPECT_NE(ptr, nullptr);
+  EXPECT_TRUE(pool.IsFromPool(ptr));
+  pool.Free(ptr);
+}
+
+TEST(FixedSizeMemoryPoolTest, IsFromPool) {
+  const size_t kBlockSize = 16;
+  const size_t kCapacity = 2;
+  FixedSizeMemoryPool pool(kBlockSize, kCapacity);
+
+  void* ptr1 = pool.Allocate();
+  void* ptr2 = pool.Allocate();
+
+  ASSERT_NE(ptr1, nullptr);
+  ASSERT_NE(ptr2, nullptr);
+
+  EXPECT_TRUE(pool.IsFromPool(ptr1));
+  EXPECT_TRUE(pool.IsFromPool(ptr2));
+
+  // Null pointer.
+  EXPECT_FALSE(pool.IsFromPool(nullptr));
+
+  // Heap pointer.
+  int* heap_ptr = new int;
+  EXPECT_FALSE(pool.IsFromPool(heap_ptr));
+  delete heap_ptr;
+
+  // Misaligned pointer (inside the pool but not at block start).
+  uint8_t* misaligned_ptr = static_cast<uint8_t*>(ptr1) + 1;
+  EXPECT_FALSE(pool.IsFromPool(misaligned_ptr));
+
+  // Pointer past the end of the pool.
+  uint8_t* past_end_ptr = static_cast<uint8_t*>(ptr1) + kBlockSize * kCapacity;
+  EXPECT_FALSE(pool.IsFromPool(past_end_ptr));
+
+  pool.Free(ptr1);
+  pool.Free(ptr2);
+}
+
+TEST(FixedSizeMemoryPoolTest, ThreadSafety) {
+  const size_t kBlockSize = 64;
+  const size_t kCapacity = 10;
+  FixedSizeMemoryPool pool(kBlockSize, kCapacity);
+
+  const int kNumThreads = 4;
+  const int kIterations = 100;
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kNumThreads; ++t) {
+    threads.emplace_back([&pool]() {
+      for (int i = 0; i < kIterations; ++i) {
+        std::vector<void*> allocated;
+        // Allocate up to 2 blocks per thread.
+        for (size_t j = 0; j < 2; ++j) {
+          void* ptr = pool.Allocate();
+          if (ptr) {
+            EXPECT_TRUE(pool.IsFromPool(ptr));
+            allocated.push_back(ptr);
+          }
+        }
+        std::this_thread::yield();
+        for (void* ptr : allocated) {
+          pool.Free(ptr);
+        }
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  EXPECT_EQ(pool.free_list_size(), kCapacity);
+}
+
+using FixedSizeMemoryPoolDeathTest = ::testing::Test;
+
+TEST_F(FixedSizeMemoryPoolDeathTest, DeathTest_InvalidConstructorArgs) {
+  EXPECT_DEATH_IF_SUPPORTED(FixedSizeMemoryPool(0, 10), "");
+  EXPECT_DEATH_IF_SUPPORTED(FixedSizeMemoryPool(10, 0), "");
+}
+
+TEST_F(FixedSizeMemoryPoolDeathTest, DeathTest_FreeInvalidPointer) {
+  FixedSizeMemoryPool pool(16, 2);
+  int x;
+  EXPECT_DEATH_IF_SUPPORTED(pool.Free(&x), "");
+}
+
+}  // namespace
+}  // namespace starboard

--- a/starboard/shared/starboard/player/lazy_initializer.h
+++ b/starboard/shared/starboard/player/lazy_initializer.h
@@ -1,0 +1,73 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_STARBOARD_PLAYER_LAZY_INITIALIZER_H_
+#define STARBOARD_SHARED_STARBOARD_PLAYER_LAZY_INITIALIZER_H_
+
+#include <atomic>
+#include <mutex>
+#include <utility>
+
+namespace starboard {
+
+// LazyInitializer handles thread-safe, lazy initialization of an object of type
+// T. It uses double-checked locking with std::atomic and std::call_once to
+// ensure that the object is initialized at most once, even when accessed from
+// multiple threads concurrently.
+//
+// This is useful for delaying the allocation of heavy resources (like memory
+// pools) until they are actually needed, while still allowing safe, lock-free
+// checks of whether the resource has been initialized.
+template <typename T>
+class LazyInitializer {
+ public:
+  LazyInitializer() = default;
+  ~LazyInitializer() {
+    T* val = value_.load(std::memory_order_acquire);
+    delete val;
+  }
+
+  // Disallows copy and assign.
+  LazyInitializer(const LazyInitializer&) = delete;
+  LazyInitializer& operator=(const LazyInitializer&) = delete;
+
+  // Returns the pointer to the initialized object. If the object has not been
+  // initialized yet, it initializes it using the provided arguments.
+  // This method is thread-safe.
+  template <typename... Args>
+  T* Get(Args&&... args) {
+    T* val = value_.load(std::memory_order_acquire);
+    if (!val) {
+      std::call_once(once_flag_, [&]() {
+        value_.store(new T(std::forward<Args>(args)...),
+                     std::memory_order_release);
+      });
+      val = value_.load(std::memory_order_acquire);
+    }
+    return val;
+  }
+
+  // Returns the pointer to the object if it has already been initialized, or
+  // nullptr otherwise. This check is thread-safe and lock-free, and does NOT
+  // trigger initialization.
+  T* GetIfInitialized() const { return value_.load(std::memory_order_acquire); }
+
+ private:
+  std::atomic<T*> value_{nullptr};
+  std::once_flag once_flag_;
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_SHARED_STARBOARD_PLAYER_LAZY_INITIALIZER_H_

--- a/starboard/shared/starboard/player/lazy_initializer.h
+++ b/starboard/shared/starboard/player/lazy_initializer.h
@@ -29,11 +29,18 @@ namespace starboard {
 // This is useful for delaying the allocation of heavy resources (like memory
 // pools) until they are actually needed, while still allowing safe, lock-free
 // checks of whether the resource has been initialized.
-template <typename T>
+//
+// If |NoDestruct| is true, the initialized object will not be deleted at
+// destruction. This is useful for global singletons to avoid shutdown
+// use-after-free crashes.
+template <typename T, bool NoDestruct = false>
 class LazyInitializer {
  public:
   LazyInitializer() = default;
   ~LazyInitializer() {
+    if (NoDestruct) {
+      return;
+    }
     T* val = value_.load(std::memory_order_acquire);
     delete val;
   }

--- a/starboard/shared/starboard/player/lazy_initializer_test.cc
+++ b/starboard/shared/starboard/player/lazy_initializer_test.cc
@@ -1,0 +1,111 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/lazy_initializer.h"
+
+#include <atomic>
+#include <thread>
+#include <vector>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace {
+
+// Helper class to track constructor calls.
+class TestObject {
+ public:
+  static std::atomic<int> constructor_calls;
+
+  TestObject() { constructor_calls.fetch_add(1); }
+
+  explicit TestObject(int value) : value_(value) {
+    constructor_calls.fetch_add(1);
+  }
+
+  int value() const { return value_; }
+
+ private:
+  int value_ = 0;
+};
+
+std::atomic<int> TestObject::constructor_calls{0};
+
+class LazyInitializerTest : public ::testing::Test {
+ protected:
+  void SetUp() override { TestObject::constructor_calls.store(0); }
+};
+
+TEST_F(LazyInitializerTest, BasicInitialization) {
+  LazyInitializer<TestObject> initializer;
+
+  EXPECT_EQ(initializer.GetIfInitialized(), nullptr);
+  EXPECT_EQ(TestObject::constructor_calls.load(), 0);
+
+  TestObject* obj1 = initializer.Get();
+  ASSERT_NE(obj1, nullptr);
+  EXPECT_EQ(TestObject::constructor_calls.load(), 1);
+  EXPECT_EQ(initializer.GetIfInitialized(), obj1);
+
+  TestObject* obj2 = initializer.Get();
+  EXPECT_EQ(obj2, obj1);
+  EXPECT_EQ(TestObject::constructor_calls.load(), 1);
+}
+
+TEST_F(LazyInitializerTest, ArgumentsPassing) {
+  LazyInitializer<TestObject> initializer;
+  const int kExpectedValue = 42;
+
+  TestObject* obj = initializer.Get(kExpectedValue);
+  ASSERT_NE(obj, nullptr);
+  EXPECT_EQ(obj->value(), kExpectedValue);
+  EXPECT_EQ(TestObject::constructor_calls.load(), 1);
+}
+
+TEST_F(LazyInitializerTest, ConcurrentInitialization) {
+  LazyInitializer<TestObject> initializer;
+  const int kNumThreads = 10;
+  std::vector<std::thread> threads;
+  std::vector<TestObject*> results(kNumThreads, nullptr);
+  std::atomic<bool> start_signal{false};
+
+  for (int i = 0; i < kNumThreads; ++i) {
+    threads.emplace_back([&initializer, &results, &start_signal, i]() {
+      while (!start_signal.load()) {
+        std::this_thread::yield();
+      }
+      results[i] = initializer.Get();
+    });
+  }
+
+  // Release threads to call Get() simultaneously.
+  start_signal.store(true);
+
+  for (auto& t : threads) {
+    t.join();
+  }
+
+  // Verify that only one object was created.
+  EXPECT_EQ(TestObject::constructor_calls.load(), 1);
+
+  // Verify that all threads got the same pointer.
+  TestObject* first_result = results[0];
+  ASSERT_NE(first_result, nullptr);
+  for (int i = 1; i < kNumThreads; ++i) {
+    EXPECT_EQ(results[i], first_result);
+  }
+}
+
+}  // namespace
+}  // namespace starboard

--- a/starboard/shared/starboard/player/object_pool.cc
+++ b/starboard/shared/starboard/player/object_pool.cc
@@ -1,0 +1,60 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/object_pool.h"
+
+#include <new>
+
+namespace starboard {
+
+ObjectPool::ObjectPool(size_t element_size, size_t capacity)
+    : pool_(element_size, capacity) {}
+
+void* ObjectPool::Allocate() {
+  void* ptr = pool_.Allocate();
+  if (ptr) {
+    return ptr;
+  }
+  return ::operator new(pool_.block_size());
+}
+
+void ObjectPool::Free(void* ptr) {
+  if (!ptr) {
+    return;
+  }
+
+  if (pool_.IsFromPool(ptr)) {
+    pool_.Free(ptr);
+  } else {
+    ::operator delete(ptr);
+  }
+}
+
+bool ObjectPool::IsFromPreallocatedPool(void* ptr) const {
+  return pool_.IsFromPool(ptr);
+}
+
+size_t ObjectPool::element_size() const {
+  return pool_.block_size();
+}
+
+size_t ObjectPool::capacity() const {
+  return pool_.capacity();
+}
+
+size_t ObjectPool::free_list_size() const {
+  return pool_.free_list_size();
+}
+
+}  // namespace starboard

--- a/starboard/shared/starboard/player/object_pool.h
+++ b/starboard/shared/starboard/player/object_pool.h
@@ -1,0 +1,61 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_STARBOARD_PLAYER_OBJECT_POOL_H_
+#define STARBOARD_SHARED_STARBOARD_PLAYER_OBJECT_POOL_H_
+
+#include "starboard/shared/starboard/player/fixed_size_memory_pool.h"
+
+namespace starboard {
+
+// A thread-safe object pool for recycling memory allocations of a fixed size.
+// It wraps FixedSizeMemoryPool and adds fallback to heap allocation when
+// the pre-allocated pool is exhausted.
+class ObjectPool {
+ public:
+  // Constructor.
+  // |element_size| is the size of each object in bytes.
+  // |capacity| is the number of objects to pre-allocate. Must be > 0.
+  ObjectPool(size_t element_size, size_t capacity);
+
+  ~ObjectPool() = default;
+
+  // Disallow copy and assign.
+  ObjectPool(const ObjectPool&) = delete;
+  ObjectPool& operator=(const ObjectPool&) = delete;
+
+  // Allocates a block of memory of element_size.
+  // Returns a recycled block from the pool if available, or allocates a new one
+  // from heap.
+  void* Allocate();
+
+  // Returns a block of memory back to the pool for future reuse
+  // if it belongs to the pool. Otherwise, deletes it.
+  void Free(void* ptr);
+
+  // Helper to check if a pointer belongs to the pre-allocated pool.
+  bool IsFromPreallocatedPool(void* ptr) const;
+
+  // Getters for testing
+  size_t element_size() const;
+  size_t capacity() const;
+  size_t free_list_size() const;
+
+ private:
+  FixedSizeMemoryPool pool_;
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_SHARED_STARBOARD_PLAYER_OBJECT_POOL_H_

--- a/starboard/shared/starboard/player/object_pool_test.cc
+++ b/starboard/shared/starboard/player/object_pool_test.cc
@@ -1,0 +1,127 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/object_pool.h"
+
+#include <thread>
+#include <vector>
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace {
+
+struct TestObject {
+  int x;
+  double y;
+  char buffer[64];
+};
+
+TEST(ObjectPoolTest, BasicAllocationAndRecycle) {
+  // Create a pool with capacity 2.
+  ObjectPool pool(sizeof(TestObject), 2);
+  EXPECT_EQ(pool.capacity(), 2);
+  EXPECT_EQ(pool.free_list_size(), 2);
+
+  // 1. Allocate first object. Should be from pool.
+  void* ptr1 = pool.Allocate();
+  ASSERT_NE(ptr1, nullptr);
+  EXPECT_TRUE(pool.IsFromPreallocatedPool(ptr1));
+  EXPECT_EQ(pool.free_list_size(), 1);
+
+  // 2. Allocate second object. Should be from pool.
+  void* ptr2 = pool.Allocate();
+  ASSERT_NE(ptr2, nullptr);
+  EXPECT_TRUE(pool.IsFromPreallocatedPool(ptr2));
+  EXPECT_EQ(pool.free_list_size(), 0);
+
+  // 3. Allocate third object. Should fallback to heap (not from pool).
+  void* ptr3 = pool.Allocate();
+  ASSERT_NE(ptr3, nullptr);
+  EXPECT_FALSE(pool.IsFromPreallocatedPool(ptr3));
+  EXPECT_EQ(pool.free_list_size(), 0);
+
+  // 4. Free ptr1 (pool). Should return to pool.
+  pool.Free(ptr1);
+  EXPECT_EQ(pool.free_list_size(), 1);
+
+  // 5. Free ptr3 (heap). Should be deleted, not returned to pool.
+  pool.Free(ptr3);
+  EXPECT_EQ(pool.free_list_size(), 1);
+
+  // 6. Allocate again. Should recycle ptr1.
+  void* ptr4 = pool.Allocate();
+  EXPECT_EQ(ptr1, ptr4);
+  EXPECT_EQ(pool.free_list_size(), 0);
+
+  // Clean up remaining.
+  pool.Free(ptr2);
+  pool.Free(ptr4);
+  EXPECT_EQ(pool.free_list_size(), 2);
+}
+
+TEST(ObjectPoolTest, ThreadSafety) {
+  const int kCapacity = 20;
+  ObjectPool pool(sizeof(TestObject), kCapacity);
+  const int kNumThreads = 8;
+  const int kAllocationsPerThread = 100;
+
+  std::vector<std::thread> threads;
+  for (int t = 0; t < kNumThreads; ++t) {
+    threads.emplace_back([&pool]() {
+      std::vector<void*> allocated;
+      for (int i = 0; i < kAllocationsPerThread; ++i) {
+        void* ptr = pool.Allocate();
+        ASSERT_NE(ptr, nullptr);
+        TestObject* obj = new (ptr) TestObject();
+        obj->x = i;
+        allocated.push_back(ptr);
+      }
+
+      // Free half of them
+      for (size_t i = 0; i < allocated.size() / 2; ++i) {
+        TestObject* obj = static_cast<TestObject*>(allocated[i]);
+        obj->~TestObject();
+        pool.Free(allocated[i]);
+      }
+
+      // Allocate again
+      for (size_t i = 0; i < allocated.size() / 2; ++i) {
+        void* ptr = pool.Allocate();
+        ASSERT_NE(ptr, nullptr);
+        TestObject* obj = new (ptr) TestObject();
+        obj->x = 999;
+        allocated[i] = ptr;
+      }
+
+      // Clean up all
+      for (void* ptr : allocated) {
+        TestObject* obj = static_cast<TestObject*>(ptr);
+        obj->~TestObject();
+        pool.Free(ptr);
+      }
+    });
+  }
+
+  for (auto& thread : threads) {
+    thread.join();
+  }
+
+  // All pool buffers should be returned to the pool.
+  // Fallback allocations should have been deleted.
+  EXPECT_EQ(pool.free_list_size(), kCapacity);
+}
+
+}  // namespace
+}  // namespace starboard

--- a/starboard/shared/starboard/player/player_tests.gni
+++ b/starboard/shared/starboard/player/player_tests.gni
@@ -15,6 +15,9 @@
 player_tests_sources = [
   "//starboard/shared/starboard/player/buffer_test_internal.cc",
   "//starboard/shared/starboard/player/decoded_audio_test_internal.cc",
+  "//starboard/shared/starboard/player/fixed_size_memory_pool_test.cc",
   "//starboard/shared/starboard/player/job_queue_test.cc",
   "//starboard/shared/starboard/player/job_thread_test.cc",
+  "//starboard/shared/starboard/player/lazy_initializer_test.cc",
+  "//starboard/shared/starboard/player/object_pool_test.cc",
 ]


### PR DESCRIPTION
Introduce FixedSizeMemoryPool and ObjectPool to manage allocations for
video frames and decoded audio buffers. By using these pools, Cobalt
minimizes steady-state heap allocations during media playback, which
prevents progressive heap fragmentation on memory-restricted devices.

This change includes an Android-specific implementation for
VideoFrameImpl and a shared implementation for decoded audio buffers,
both controlled by new Starboard feature flags.

Issue: 518914404