### PR TITLE
test: Update flaky test filters

### DIFF
--- a/cobalt/testing/filters/android-arm/perfetto_unittests_filter.json
+++ b/cobalt/testing/filters/android-arm/perfetto_unittests_filter.json
@@ -3,6 +3,7 @@
     "MessageTest.DestructInvalidMessageHandle",
     "NullTraceWriterDeathTest.NewTracePacketTakeStreamWriterNoFinish",
     "ScopedDirTest.CloseOutOfScope",
-    "UtilsTest.EintrWrapper"
+    "UtilsTest.EintrWrapper",
+    "FuchsiaTraceParserTest.FxtWithProtos"
   ]
 }

--- a/cobalt/testing/filters/linux-x64x11/cobalt_browsertests_filter.json
+++ b/cobalt/testing/filters/linux-x64x11/cobalt_browsertests_filter.json
@@ -1,6 +1,7 @@
 {
   "comment": "Temporarily disable tests in NavigationBrowserTest. See b/433354983.",
   "failing_tests": [
+    "All/CobaltMemoryThresholdBrowserTest.BlankPageMemoryFootprint/0",
     "*CobaltMetricsBrowserTest*",
     "*DeferSpeculativeRFHCreationRenderProcessTest*",
     "*NavigationBrowserTestDeprecateUnloadOptOut*",


### PR DESCRIPTION
Update the test filters for android-arm and linux-x64x11 based on
reports from the flaky test dashboard. Disabling these unstable tests
ensures more reliable CI results for Perfetto and Cobalt browser tests.

Bug: 520506351