### PR TITLE
Cherry pick PR #10416: feat(lifecycle): implement race-free and spec-compliant application lifecycle transitions

### DIFF
--- a/base/threading/hang_watcher.cc
+++ b/base/threading/hang_watcher.cc
@@ -452,6 +452,32 @@ bool HangWatcher::IsEnabled() {
   return g_use_hang_watcher.load(std::memory_order_relaxed);
 }
 
+#if BUILDFLAG(IS_COBALT)
+// static
+void HangWatcher::Suspend() {
+  // suspends hang watching when the application is frozen.
+  g_use_hang_watcher.store(false, std::memory_order_relaxed);
+}
+
+// static
+void HangWatcher::Resume() {
+  if (g_instance) {
+    // resumes hang watching when the application is unfrozen, explicitly
+    // ignoring pre-freeze deadlines to prevent false hang reports.
+    base::AutoLock auto_lock(g_instance->watch_state_lock_);
+    base::TimeTicks latest_deadline;
+    for (const auto& state : g_instance->watch_states_) {
+      base::TimeTicks deadline = state->GetDeadline();
+      if (deadline > latest_deadline) {
+        latest_deadline = deadline;
+      }
+    }
+    g_instance->deadline_ignore_threshold_ = latest_deadline;
+  }
+  g_use_hang_watcher.store(true, std::memory_order_relaxed);
+}
+#endif
+
 // static
 bool HangWatcher::IsThreadPoolHangWatchingEnabled() {
   return g_threadpool_log_level.load(std::memory_order_relaxed) !=
@@ -914,6 +940,14 @@ HangWatcher::WatchStateSnapShot HangWatcher::GrabWatchStateSnapshotForTesting()
 
 void HangWatcher::Monitor() {
   DCHECK_CALLED_ON_VALID_THREAD(hang_watcher_thread_checker_);
+
+#if BUILDFLAG(IS_COBALT)
+  // suspends monitoring when the application is frozen.
+  if (!IsEnabled()) {
+    return;
+  }
+#endif
+
   AutoLock auto_lock(watch_state_lock_);
 
   // If all threads unregistered since this function was invoked there's

--- a/base/threading/hang_watcher.h
+++ b/base/threading/hang_watcher.h
@@ -169,6 +169,14 @@ class BASE_EXPORT HangWatcher : public DelegateSimpleThread::Delegate {
   // Thread safe functions to verify if hang watching is activated. If called
   // before InitializeOnMainThread returns the default value which is false.
   static bool IsEnabled();
+#if BUILDFLAG(IS_COBALT)
+  // suspends hang watching when the application is frozen.
+  static void Suspend();
+
+  // resumes hang watching after the application is unfrozen, ignoring
+  // pre-freeze deadlines.
+  static void Resume();
+#endif
   static bool IsThreadPoolHangWatchingEnabled();
   static bool IsIOThreadHangWatchingEnabled();
 

--- a/base/threading/thread_restrictions.h
+++ b/base/threading/thread_restrictions.h
@@ -204,6 +204,11 @@ void SessionEnding();
 namespace chromecast {
 class CrashUtil;
 }
+#if BUILDFLAG(IS_COBALT)
+namespace cobalt {
+class AppEventRunnerImpl;
+}
+#endif  // BUILDFLAG(IS_COBALT)
 namespace chromeos {
 class BlockingMethodCaller;
 namespace system {
@@ -861,6 +866,15 @@ class BASE_EXPORT
 #if BUILDFLAG(IS_STARBOARD)
   friend class cobalt::updater::UpdaterModule;
 #endif  // BUILDFLAG(IS_STARBOARD)
+#if BUILDFLAG(IS_COBALT)
+  // Cobalt's platform deactivation lifecycle transitions (Reveal, Conceal,
+  // Freeze, Unfreeze) synchronously block the UI Main Thread using a nested
+  // base::RunLoop to guarantee atomic, linear state progression. Since
+  // Starboard's custom base::MessagePumpUIStarboard blocks using
+  // base::WaitableEvent under the hood, we must explicitly whitelist the modular
+  // platform shell runner here to authorize main-thread sync waiting.
+  friend class cobalt::AppEventRunnerImpl;
+#endif  // BUILDFLAG(IS_COBALT)
   friend class content::DesktopCaptureDevice;
   friend class content::EmergencyTraceFinalisationCoordinator;
   friend class content::InProcessUtilityThread;

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -204,6 +204,7 @@ test("cobalt_unittests") {
       "//cobalt/app/app_event_delegate_unittest.cc",
       "//cobalt/app/app_event_runner_unittest.cc",
       "//cobalt/app/cobalt_switch_defaults_starboard_test.cc",
+      "//cobalt/browser/lifecycle/cobalt_lifecycle_manager_unittest.cc",
       "//cobalt/shell/common/device_authentication_test.cc",
     ]
   }
@@ -227,6 +228,8 @@ test("cobalt_unittests") {
     "//cobalt/browser/constants:cobalt_experiment_names",
     "//cobalt/browser/h5vcc_metrics/public/mojom",
     "//cobalt/browser/h5vcc_runtime:deep_link_manager",
+    "//cobalt/browser/h5vcc_runtime/public/mojom",
+    "//cobalt/browser/lifecycle",
     "//cobalt/browser/user_agent",
     "//cobalt/common/libc:libc_test",
     "//cobalt/shell/browser/migrate_storage_record:unittest",

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -24,6 +24,7 @@
 #include "base/run_loop.h"
 #include "base/threading/platform_thread.h"
 #include "cobalt/app/app_event_runner.h"
+#include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
 #include "content/public/browser/browser_thread.h"
 #include "starboard/extension/crash_handler.h"
 #include "starboard/system.h"
@@ -31,7 +32,6 @@
 namespace cobalt {
 
 namespace {
-constexpr base::TimeDelta kTransitionTimeout = base::Seconds(5);
 
 AppEventDelegate::ApplicationState SbEventToTargetApplicationState(
     SbEventType type) {
@@ -68,6 +68,7 @@ AppEventDelegate::AppEventDelegate(
     const CobaltExtensionCrashHandlerApi* crash_handler_extension)
     : runner_(std::move(runner)),
       crash_handler_extension_(crash_handler_extension) {
+  base::AutoLock lock(lock_);
   if (!crash_handler_extension_) {
     // If a special extension implementation wasn't provided, use the default.
     crash_handler_extension_ =
@@ -75,7 +76,6 @@ AppEventDelegate::AppEventDelegate(
             SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
   }
 
-  base::AutoLock lock(lock_);
   SetApplicationState(ApplicationState::kInitial);
   target_state_ = ApplicationState::kInitial;
   if (!runner_) {
@@ -84,7 +84,7 @@ AppEventDelegate::AppEventDelegate(
   }
 }
 
-AppEventDelegate::~AppEventDelegate() {}
+AppEventDelegate::~AppEventDelegate() = default;
 
 bool AppEventDelegate::IsRunning() const {
   base::AutoLock lock(lock_);
@@ -125,6 +125,11 @@ AppEventDelegate::ApplicationState AppEventDelegate::GetState() const {
   return application_state_;
 }
 
+PendingAck AppEventDelegate::pending_ack() const {
+  base::AutoLock lock(lock_);
+  return runner_ ? runner_->pending_ack() : PendingAck::kNone;
+}
+
 bool AppEventDelegate::IsFrozenLocked() const {
   return application_state_ == ApplicationState::kFrozen ||
          application_state_ == ApplicationState::kStopped ||
@@ -139,8 +144,6 @@ void AppEventDelegate::HandleEvent(const SbEvent* event) {
 }
 
 void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
-  lock_.AssertAcquired();
-
   // Drop events received after the application stops.
   if (application_state_ == ApplicationState::kStopped ||
       target_state_ == ApplicationState::kStopped) {
@@ -203,35 +206,12 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
     case kSbEventTypeBlur:
     case kSbEventTypeFocus:
     case kSbEventTypeConceal:
+    case kSbEventTypeStop:
     case kSbEventTypeReveal:
     case kSbEventTypeFreeze:
     case kSbEventTypeUnfreeze:
       // Ensure all intermediate state changes are triggered.
       TransitionToLifeCycleState(SbEventToTargetApplicationState(event->type));
-      break;
-    case kSbEventTypeStop:
-      // Stop is a special case that completely tears down the Chromium
-      // environment. It must be executed synchronously on the UI thread to
-      // avoid destroying the TaskEnvironment from within a task or nested
-      // RunLoop.
-
-      // Ensure all intermediate state changes are triggered up to kFrozen.
-      TransitionToLifeCycleState(ApplicationState::kFrozen);
-
-      // We must be on the UI thread to synchronously run DoStop.
-      // Unlike a standard Chromium desktop application where the main
-      // MessagePump naturally unwinds the stack upon exit to destroy the
-      // ContentMainRunner, Cobalt's outermost loop is owned by the Starboard OS
-      // layer. Therefore, we must manually invoke `main_runner_->Shutdown()`
-      // (via `DoStop()`) to trigger the teardown sequence. This manual teardown
-      // must happen on the UI thread and cannot be posted to a task queue, as
-      // it destroys the very SequenceManager that would execute the task.
-      CHECK(content::BrowserThread::CurrentlyOn(content::BrowserThread::UI))
-          << "kSbEventTypeStop must be delivered on the UI thread.";
-
-      runner_->OnStop();
-      SetApplicationState(ApplicationState::kStopped);
-      target_state_ = ApplicationState::kStopped;
       break;
     case kSbEventTypeInput:
       runner_->OnInput(event);
@@ -260,86 +240,122 @@ void AppEventDelegate::HandleEventLocked(const SbEvent* event) {
   }
 }
 
-void AppEventDelegate::ExecuteNextStepOnUIThread() {
-  base::AutoLock lock(lock_);
-  ExecuteNextStepOnUIThreadLocked(true /* schedule_next_step */);
-}
-
-void AppEventDelegate::ExecuteNextStepOnUIThreadLocked(
-    bool schedule_next_step) {
-  lock_.AssertAcquired();
-
+void AppEventDelegate::ExecuteNextStep() {
   if (application_state_ == target_state_) {
-    // Target state reached. Transition complete.
-    if (transition_quit_closure_) {
-      content::GetUIThreadTaskRunner({})->PostTask(
-          FROM_HERE, std::move(transition_quit_closure_));
-    }
     is_transitioning_ = false;
+    if (quit_closure_) {
+      std::move(quit_closure_).Run();
+    }
     return;
   }
 
-  ApplicationState next_state;
+  bool is_activating = target_state_ < application_state_;
+  ApplicationState next_state = GetNextState(application_state_, is_activating);
 
-  if (application_state_ < target_state_) {
-    switch (application_state_) {
-      case ApplicationState::kStarted:
-        runner_->OnBlur();
-        next_state = ApplicationState::kBlurred;
-        break;
-      case ApplicationState::kBlurred:
-        runner_->OnConceal();
-        next_state = ApplicationState::kConcealed;
-        break;
-      case ApplicationState::kConcealed:
-        runner_->OnFreeze();
-        next_state = ApplicationState::kFrozen;
-        break;
+  content::GetUIThreadTaskRunner({})->PostTask(
+      FROM_HERE,
+      base::BindOnce(&AppEventDelegate::ExecuteStepOnUIThread,
+                     base::Unretained(this), next_state, is_activating));
+}
+
+AppEventDelegate::ApplicationState AppEventDelegate::GetNextState(
+    ApplicationState current_state,
+    bool is_activating) const {
+  if (is_activating) {
+    switch (current_state) {
       case ApplicationState::kFrozen:
-        NOTREACHED();
-        return;
+        return ApplicationState::kConcealed;
+      case ApplicationState::kConcealed:
+        return ApplicationState::kBlurred;
+      case ApplicationState::kBlurred:
+        return ApplicationState::kStarted;
       default:
         NOTREACHED();
-        return;
     }
   } else {
-    switch (application_state_) {
-      case ApplicationState::kStopped:
-        NOTREACHED();
-        return;
-      case ApplicationState::kFrozen:
-        runner_->OnUnfreeze();
-        next_state = ApplicationState::kConcealed;
-        break;
-      case ApplicationState::kConcealed:
-        runner_->OnReveal();
-        next_state = ApplicationState::kBlurred;
-        break;
-      case ApplicationState::kBlurred:
-        runner_->OnFocus();
-        next_state = ApplicationState::kStarted;
-        break;
+    switch (current_state) {
       case ApplicationState::kStarted:
-        NOTREACHED();
-        return;
+        return ApplicationState::kBlurred;
+      case ApplicationState::kBlurred:
+        return ApplicationState::kConcealed;
+      case ApplicationState::kConcealed:
+        return ApplicationState::kFrozen;
+      case ApplicationState::kFrozen:
+        return ApplicationState::kStopped;
       default:
         NOTREACHED();
-        return;
     }
   }
+  return current_state;
+}
 
-  SetApplicationState(next_state);
-
-  if (schedule_next_step) {
-    content::GetUIThreadTaskRunner({})->PostTask(
-        FROM_HERE, base::BindOnce(&AppEventDelegate::ExecuteNextStepOnUIThread,
-                                  base::Unretained(this)));
+void AppEventDelegate::ExecuteEventRunner(ApplicationState next_state,
+                                          bool is_activating) {
+  if (is_activating) {
+    switch (next_state) {
+      case ApplicationState::kConcealed:
+        runner_->OnUnfreeze();
+        break;
+      case ApplicationState::kBlurred:
+        runner_->OnReveal();
+        break;
+      case ApplicationState::kStarted:
+        runner_->OnFocus();
+        break;
+      default:
+        NOTREACHED();
+    }
+  } else {
+    switch (next_state) {
+      case ApplicationState::kBlurred:
+        runner_->OnBlur();
+        break;
+      case ApplicationState::kConcealed:
+        runner_->OnConceal();
+        break;
+      case ApplicationState::kFrozen:
+        runner_->OnFreeze(base::DoNothing());
+        break;
+      case ApplicationState::kStopped:
+        runner_->OnStop();
+        break;
+      default:
+        NOTREACHED();
+    }
   }
 }
 
-void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {
-  lock_.AssertAcquired();
+void AppEventDelegate::ExecuteStepOnUIThread(ApplicationState next_state,
+                                             bool is_activating) {
+  DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  // Note: ExecuteEventRunner does not change state nor rely on state of this
+  // object, and always runs as a posted task on the UI thread, and therefore
+  // the lock does not need to be held yet here.
+  ExecuteEventRunner(next_state, is_activating);
 
+  base::AutoLock lock(lock_);
+  SetApplicationState(next_state);
+
+  if (next_state == ApplicationState::kStopped) {
+    SbEventSchedule(&AppEventDelegate::TeardownCallback, this, 0);
+  } else {
+    ExecuteNextStep();
+  }
+}
+
+// static
+void AppEventDelegate::TeardownCallback(void* data) {
+  AppEventDelegate* delegate = static_cast<AppEventDelegate*>(data);
+  delegate->DoTeardown();
+}
+
+void AppEventDelegate::DoTeardown() {
+  runner_->OnStop();
+  base::AutoLock lock(lock_);
+  SetApplicationState(ApplicationState::kStopped);
+}
+
+void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {
   // TransitionToLifeCycleState ensures that the application moves from its
   // current state to the target |state| by traversing all intermediate states
   // in strict linear order. Each state transition triggers its corresponding
@@ -350,67 +366,19 @@ void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {
   CHECK_GT(state, ApplicationState::kInitial);
   CHECK_LE(state, ApplicationState::kStopped);
 
+  LOG(INFO) << "AppEventDelegate::TransitionToLifeCycleState called, current="
+            << static_cast<int>(application_state_)
+            << " target=" << static_cast<int>(state);
+
   target_state_ = state;
 
-  // The initial transition from kInitial to kStarted/kPreloaded is an
-  // 'activating' move, but numerically it looks like a deactivation. We
-  // explicitly exclude it here to avoid unnecessary blocking during startup.
-  bool is_deactivating = application_state_ != ApplicationState::kInitial &&
-                         state > application_state_;
-
-  if (!is_transitioning_) {
+  if (is_transitioning_) {
+    LOG(INFO) << "Transition already in progress. Updated target_state_ to "
+              << static_cast<int>(state);
+    return;
+  } else {
     is_transitioning_ = true;
-    content::GetUIThreadTaskRunner({})->PostTask(
-        FROM_HERE, base::BindOnce(&AppEventDelegate::ExecuteNextStepOnUIThread,
-                                  base::Unretained(this)));
-  }
-
-  // If this is a deactivating transition, we MUST block the OS (Starboard)
-  // thread until the target state is reached.
-  if (is_deactivating) {
-    if (content::BrowserThread::CurrentlyOn(content::BrowserThread::UI)) {
-      // REQUIRED BEHAVIOR:
-      // We must block the Starboard OS thread while still pumping Chromium's UI
-      // task queue to execute asynchronous side effects (like Wayland/X11
-      // surface destruction). We use a nested `base::RunLoop` to achieve this.
-      base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
-      base::RepeatingClosure quit_closure = run_loop.QuitClosure();
-      transition_quit_closure_ = base::BindOnce(quit_closure);
-
-      // Ensure we don't hang the OS thread indefinitely if the transition
-      // takes too long or the signal is missed.
-      content::GetUIThreadTaskRunner({})->PostDelayedTask(
-          FROM_HERE, base::BindOnce(quit_closure), kTransitionTimeout);
-
-      {
-        base::AutoUnlock unlock(lock_);
-        run_loop.Run();
-      }
-
-      // Synchronously execute any remaining steps that were skipped by the
-      // asynchronous task runner.
-      while (application_state_ < target_state_) {
-        ExecuteNextStepOnUIThreadLocked(false /* schedule_next_step */);
-      }
-    } else {
-      // If we are on a non-UI thread, we can simply block using a
-      // WaitableEvent. The UI thread will remain free to process the
-      // asynchronous teardown tasks and will execute `transition_quit_closure_`
-      // once the target state is reached.
-      base::WaitableEvent waitable_event(
-          base::WaitableEvent::ResetPolicy::MANUAL,
-          base::WaitableEvent::InitialState::NOT_SIGNALED);
-      transition_quit_closure_ = base::BindOnce(
-          &base::WaitableEvent::Signal, base::Unretained(&waitable_event));
-      {
-        base::AutoUnlock unlock(lock_);
-        if (!waitable_event.TimedWait(kTransitionTimeout)) {
-          LOG(ERROR) << "Timeout waiting " << kTransitionTimeout.InSeconds()
-                     << "s for lifecycle transition to "
-                     << static_cast<int>(state);
-        }
-      }
-    }
+    ExecuteNextStep();
   }
 }
 

--- a/cobalt/app/app_event_delegate.h
+++ b/cobalt/app/app_event_delegate.h
@@ -25,6 +25,7 @@
 #include "base/synchronization/lock.h"
 #include "base/synchronization/waitable_event.h"
 #include "base/task/sequenced_task_runner.h"
+#include "base/thread_annotations.h"
 #include "build/build_config.h"
 #include "cobalt/app/app_event_runner.h"
 #include "starboard/event.h"
@@ -66,45 +67,80 @@ class AppEventDelegate {
   // improve code clarity and decouple |AppEventDelegate| from its dependencies.
   explicit AppEventDelegate(
       std::unique_ptr<AppEventRunner> runner = nullptr,
-      const CobaltExtensionCrashHandlerApi* crash_handler_extension = nullptr);
+      const CobaltExtensionCrashHandlerApi* crash_handler_extension = nullptr)
+      LOCKS_EXCLUDED(lock_);
   ~AppEventDelegate();
 
   AppEventDelegate(const AppEventDelegate&) = delete;
   AppEventDelegate& operator=(const AppEventDelegate&) = delete;
 
   // Receives a Starboard event and handles it.
-  void HandleEvent(const SbEvent* event);
+  void HandleEvent(const SbEvent* event) LOCKS_EXCLUDED(lock_);
 
-  bool IsRunning() const;
-  bool IsVisible() const;
-  bool IsFocused() const;
-  bool IsFrozen() const;
+  void DoTeardown() LOCKS_EXCLUDED(lock_);
 
-  ApplicationState GetState() const;
+  bool IsRunning() const LOCKS_EXCLUDED(lock_);
+  bool IsVisible() const LOCKS_EXCLUDED(lock_);
+  bool IsFocused() const LOCKS_EXCLUDED(lock_);
+  bool IsFrozen() const LOCKS_EXCLUDED(lock_);
+
+  ApplicationState GetState() const LOCKS_EXCLUDED(lock_);
+  bool is_transitioning() const LOCKS_EXCLUDED(lock_) {
+    base::AutoLock lock(lock_);
+    return is_transitioning_;
+  }
+  PendingAck pending_ack() const LOCKS_EXCLUDED(lock_);
 
  private:
   static const char* GetStateString(ApplicationState state);
+  static void TeardownCallback(void* data);
 
-  void HandleEventLocked(const SbEvent* event);
-  void TransitionToLifeCycleState(ApplicationState state);
+  void HandleEventLocked(const SbEvent* event) EXCLUSIVE_LOCKS_REQUIRED(lock_);
+
+  // Starts a transition of the application state from its current state to the
+  // target |state| by traversing all intermediate states in strict linear
+  // order. If this is a deactivating transition (e.g. Conceal or Freeze), it
+  // synchronously blocks the calling OS (Starboard) thread using a nested
+  // base::RunLoop until the target state is reached or a safety timeout occurs.
+  // Activating transitions are executed asynchronously.
+  void TransitionToLifeCycleState(ApplicationState state)
+      EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   // Wrapper that sets |application_state_| with the side effect of recording
   // this new state as a crash annotation.
   // TODO: b/486236529 - Consider enforcing that |application_state_| can only
   // be modified from within this method. This would prevent developers from
   // inadvertently updating the member variable but not the crash annotation.
-  void SetApplicationState(ApplicationState state);
-  void SetApplicationStateAnnotation(ApplicationState state);
+  //
+  // SetApplicationState must only be called on the UI thread.
+  void SetApplicationState(ApplicationState state)
+      EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  void SetApplicationStateAnnotation(ApplicationState state)
+      EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
-  // Helper that executes a single lifecycle step on the UI thread and then
-  // schedules the next step if the target state has not yet been reached.
-  void ExecuteNextStepOnUIThread();
-  void ExecuteNextStepOnUIThreadLocked(bool schedule_next_step);
+  // Central state-coordination method. Analyzes the current state and target
+  // state to determine the next single linear step, and schedules/executes it.
+  // It also signals the deactivation wait run loop to wake up when the
+  // transition reaches its target state.
+  void ExecuteNextStep() EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
-  bool IsRunningLocked() const;
-  bool IsVisibleLocked() const;
-  bool IsFocusedLocked() const;
-  bool IsFrozenLocked() const;
+  // Executes the actual side effects of a single linear transition step (such
+  // as calling runner callbacks and routing frame visibility/focus) on the UI
+  // thread. If required by the step (e.g., concealing or unfreezing), it
+  // initiates Mojo ACK tracking with the renderers and sets up pending ACK
+  // expectations.
+  void ExecuteStepOnUIThread(ApplicationState next_state, bool is_activating)
+      LOCKS_EXCLUDED(lock_);
+
+  // Helpers to reduce duplication.
+  ApplicationState GetNextState(ApplicationState current_state,
+                                bool is_activating) const;
+  void ExecuteEventRunner(ApplicationState next_state, bool is_activating);
+
+  bool IsRunningLocked() const EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  bool IsVisibleLocked() const EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  bool IsFocusedLocked() const EXCLUSIVE_LOCKS_REQUIRED(lock_);
+  bool IsFrozenLocked() const EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   // Lock to protect state transitions and state bit access.
   mutable base::Lock lock_;
@@ -112,11 +148,11 @@ class AppEventDelegate {
   std::unique_ptr<AppEventRunner> runner_;
   raw_ptr<const CobaltExtensionCrashHandlerApi> crash_handler_extension_ =
       nullptr;
-  ApplicationState application_state_ = ApplicationState::kInitial;
-  ApplicationState target_state_ = ApplicationState::kInitial;
-  bool is_transitioning_ = false;
-
-  base::OnceClosure transition_quit_closure_;
+  ApplicationState application_state_ GUARDED_BY(lock_) =
+      ApplicationState::kInitial;
+  ApplicationState target_state_ GUARDED_BY(lock_) = ApplicationState::kInitial;
+  bool is_transitioning_ GUARDED_BY(lock_) = false;
+  base::OnceClosure quit_closure_;
 
 #if BUILDFLAG(IS_STARBOARD)
   // Ozone-specific bridge that converts Starboard events to Chromium events.

--- a/cobalt/app/app_event_delegate_unittest.cc
+++ b/cobalt/app/app_event_delegate_unittest.cc
@@ -14,12 +14,23 @@
 
 #include "cobalt/app/app_event_delegate.h"
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
 
+#include "base/memory/weak_ptr.h"
+#include "base/rand_util.h"
+#include "base/task/task_traits.h"
+#include "base/task/thread_pool.h"
 #include "cobalt/app/app_event_runner.h"
+#include "cobalt/shell/browser/shell_test_support.h"
+#include "content/public/browser/site_instance.h"
 #include "content/public/test/browser_task_environment.h"
+#include "content/public/test/test_browser_context.h"
+#include "content/public/test/test_renderer_host.h"
+#include "content/public/test/test_utils.h"
+#include "content/test/test_web_contents.h"
 #include "starboard/extension/crash_handler.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -32,6 +43,18 @@ namespace cobalt {
 
 class MockAppEventRunner : public AppEventRunner {
  public:
+  MockAppEventRunner() {
+    set_is_running(false);
+    set_is_visible(false);
+    set_is_focused(false);
+    set_is_frozen(true);
+
+    ON_CALL(*this, DoFreeze(testing::_))
+        .WillByDefault(testing::Invoke([](base::OnceClosure callback) {
+          base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+              FROM_HERE, std::move(callback));
+        }));
+  }
   MOCK_METHOD(void, InitializeSystem, (), (override));
   MOCK_METHOD(void,
               CreateMainDelegate,
@@ -57,6 +80,12 @@ class MockAppEventRunner : public AppEventRunner {
               (const SbEvent* event),
               (override));
 
+  MOCK_METHOD(std::vector<content::WebContents*>,
+              GetWebContents,
+              (),
+              (override));
+  MOCK_METHOD(PendingAck, pending_ack, (), (const, override));
+
   // These are the methods called by the base class.
   MOCK_METHOD(void, DoStart, (const SbEvent* event), (override));
   MOCK_METHOD(void, DoStop, (), (override));
@@ -64,7 +93,7 @@ class MockAppEventRunner : public AppEventRunner {
   MOCK_METHOD(void, DoFocus, (), (override));
   MOCK_METHOD(void, DoConceal, (), (override));
   MOCK_METHOD(void, DoReveal, (), (override));
-  MOCK_METHOD(void, DoFreeze, (), (override));
+  MOCK_METHOD(void, DoFreeze, (base::OnceClosure callback), (override));
   MOCK_METHOD(void, DoUnfreeze, (), (override));
 };
 
@@ -90,21 +119,52 @@ class MockCrashHandler {
 
 MockCrashHandler* MockCrashHandler::instance_ = nullptr;
 
-class AppEventDelegateTest : public ::testing::Test {
+class AppEventDelegateTest : public content::ShellTestBase {
  public:
   AppEventDelegateTest() {
     MockCrashHandler::SetInstance(&mock_crash_handler_);
     crash_handler_extension_.name = kCobaltExtensionCrashHandlerName;
     crash_handler_extension_.version = 2;
     crash_handler_extension_.SetString = &MockCrashHandler::SetStringStatic;
-
-    CreateDelegate();
   }
 
   ~AppEventDelegateTest() override { MockCrashHandler::SetInstance(nullptr); }
 
+  void SetUp() override {
+    ui_task_runner_ = base::SingleThreadTaskRunner::GetCurrentDefault();
+    content::ShellTestBase::SetUp();
+    CreateDelegate();
+  }
+
+  void TearDown() override {
+    web_contents_.reset();
+    delegate_.reset();
+    CobaltLifecycleManager::GetInstance()->ResetForTesting();
+    content::ShellTestBase::TearDown();
+  }
+
+  void SetApplicationState(AppEventDelegate::ApplicationState state) {
+    base::AutoLock lock(delegate_->lock_);
+    delegate_->application_state_ = state;
+  }
+  void SetTargetState(AppEventDelegate::ApplicationState state) {
+    base::AutoLock lock(delegate_->lock_);
+    delegate_->target_state_ = state;
+  }
+  void SetPendingAck(PendingAck ack) {
+    ON_CALL(*runner_, pending_ack()).WillByDefault(testing::Return(ack));
+  }
+  void SetIsTransitioning(bool transitioning) {
+    base::AutoLock lock(delegate_->lock_);
+    delegate_->is_transitioning_ = transitioning;
+  }
+  AppEventDelegate::ApplicationState GetTargetState() const {
+    base::AutoLock lock(delegate_->lock_);
+    return delegate_->target_state_;
+  }
+
  protected:
-  void CreateDelegate(bool nice_runner = false) {
+  void CreateDelegate(bool nice_runner = true) {
     std::unique_ptr<MockAppEventRunner> runner;
     if (nice_runner) {
       runner = std::make_unique<testing::NiceMock<MockAppEventRunner>>();
@@ -117,6 +177,16 @@ class AppEventDelegateTest : public ::testing::Test {
     ON_CALL(*runner_, DoStart(_)).WillByDefault(Invoke([this](const SbEvent*) {
       is_running_ = true;
     }));
+
+    content::WebContents::CreateParams create_params(browser_context());
+    web_contents_.reset(content::TestWebContents::Create(create_params));
+    content::RenderFrameHostTester::For(web_contents_->GetPrimaryMainFrame())
+        ->InitializeRenderFrameIfNeeded();
+
+    ON_CALL(*runner_, GetWebContents())
+        .WillByDefault(testing::Return(
+            std::vector<content::WebContents*>{web_contents_.get()}));
+
     ON_CALL(*runner_, DoStop()).WillByDefault(Invoke([this]() {
       is_running_ = false;
     }));
@@ -143,18 +213,32 @@ class AppEventDelegateTest : public ::testing::Test {
     }
     SbEvent event = {type, 0, data};
     delegate_->HandleEvent(&event);
-    task_environment_.RunUntilIdle();
+    base::RunLoop().RunUntilIdle();
   }
 
-  content::BrowserTaskEnvironment task_environment_;
+  // Under the fully synchronous mock runner GTest execution flow,
+  // SendEventAsync is a clean, synchronous alias to SendEvent, preventing test
+  // suite changes.
+  void SendEventAsync(SbEventType type, void* data = nullptr) {
+    SendEvent(type, data);
+  }
+
+ protected:
   MockCrashHandler mock_crash_handler_;
   CobaltExtensionCrashHandlerApi crash_handler_extension_ = {};
   MockAppEventRunner* runner_;
   std::unique_ptr<AppEventDelegate> delegate_;
+  std::unique_ptr<content::WebContents> web_contents_;
 
   bool is_running_ = false;
   bool is_visible_ = false;
+  scoped_refptr<base::SingleThreadTaskRunner> ui_task_runner_;
+
+  base::WeakPtrFactory<AppEventDelegateTest> weak_ptr_factory_{this};
 };
+
+class AppEventDelegateFuzzTest : public AppEventDelegateTest,
+                                 public ::testing::WithParamInterface<int> {};
 
 TEST_F(AppEventDelegateTest, StartVisible) {
   EXPECT_CALL(*runner_, DoStart(_));
@@ -192,6 +276,7 @@ TEST_F(AppEventDelegateTest, SynthesisFocusFromStopped) {
   }
 
   SendEvent(kSbEventTypeFocus);
+  base::RunLoop().RunUntilIdle();
 }
 
 TEST_F(AppEventDelegateTest, SynthesisFocusFromPreload) {
@@ -204,6 +289,7 @@ TEST_F(AppEventDelegateTest, SynthesisFocusFromPreload) {
 
   SendEvent(kSbEventTypePreload);
   SendEvent(kSbEventTypeFocus);
+  base::RunLoop().RunUntilIdle();
 }
 
 TEST_F(AppEventDelegateTest, SynthesisFreezeFromStarted) {
@@ -212,11 +298,12 @@ TEST_F(AppEventDelegateTest, SynthesisFreezeFromStarted) {
     EXPECT_CALL(*runner_, DoStart(_));
     EXPECT_CALL(*runner_, DoBlur());
     EXPECT_CALL(*runner_, DoConceal());
-    EXPECT_CALL(*runner_, DoFreeze());
+    EXPECT_CALL(*runner_, DoFreeze(testing::_));
   }
 
   SendEvent(kSbEventTypeStart);
   SendEvent(kSbEventTypeFreeze);
+  base::RunLoop().RunUntilIdle();
 }
 
 TEST_F(AppEventDelegateTest, SynthesisStopFromStarted) {
@@ -225,7 +312,7 @@ TEST_F(AppEventDelegateTest, SynthesisStopFromStarted) {
     EXPECT_CALL(*runner_, DoStart(_));
     EXPECT_CALL(*runner_, DoBlur());
     EXPECT_CALL(*runner_, DoConceal());
-    EXPECT_CALL(*runner_, DoFreeze());
+    EXPECT_CALL(*runner_, DoFreeze(testing::_));
     EXPECT_CALL(*runner_, DoStop());
   }
 
@@ -237,7 +324,7 @@ TEST_F(AppEventDelegateTest, FrozenToStartedViaFocus) {
   EXPECT_CALL(*runner_, DoStart(_));
   SendEvent(kSbEventTypePreload);
 
-  EXPECT_CALL(*runner_, DoFreeze());
+  EXPECT_CALL(*runner_, DoFreeze(testing::_));
   SendEvent(kSbEventTypeFreeze);
 
   {
@@ -248,6 +335,7 @@ TEST_F(AppEventDelegateTest, FrozenToStartedViaFocus) {
   }
 
   SendEvent(kSbEventTypeFocus);
+
   EXPECT_EQ(delegate_->GetState(),
             AppEventDelegate::ApplicationState::kStarted);
 }
@@ -318,7 +406,7 @@ TEST_F(AppEventDelegateTest, EventsAfterStopIgnored) {
     InSequence s;
     EXPECT_CALL(*runner_, DoBlur());
     EXPECT_CALL(*runner_, DoConceal());
-    EXPECT_CALL(*runner_, DoFreeze());
+    EXPECT_CALL(*runner_, DoFreeze(testing::_));
     EXPECT_CALL(*runner_, DoStop());
   }
 
@@ -390,11 +478,11 @@ TEST_F(AppEventDelegateTest, RedundantFreezeIgnored) {
   EXPECT_CALL(*runner_, DoStart(_));
   SendEvent(kSbEventTypePreload);
 
-  EXPECT_CALL(*runner_, DoFreeze()).Times(1);
+  EXPECT_CALL(*runner_, DoFreeze(testing::_)).Times(1);
   SendEvent(kSbEventTypeFreeze);
 
   // Redundant Freeze should be ignored.
-  EXPECT_CALL(*runner_, DoFreeze()).Times(0);
+  EXPECT_CALL(*runner_, DoFreeze(testing::_)).Times(0);
   SendEvent(kSbEventTypeFreeze);
 }
 
@@ -465,8 +553,93 @@ TEST_F(AppEventDelegateTest,
   EXPECT_CALL(mock_crash_handler_,
               SetString(testing::StrEq("application_state"),
                         testing::StrEq("kStarted")));
-
   SendEvent(kSbEventTypeFocus);
 }
+
+TEST_P(AppEventDelegateFuzzTest, ChaoticOSLifecycleTransitions) {
+  InitializeShell(true /* is_visible */);
+
+  // 1. Configure Gmock to allow any sequence and frequency of transition calls.
+  EXPECT_CALL(*runner_, DoStart(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(*runner_, DoStop()).Times(testing::AnyNumber());
+  EXPECT_CALL(*runner_, DoBlur()).Times(testing::AnyNumber());
+  EXPECT_CALL(*runner_, DoFocus()).Times(testing::AnyNumber());
+  EXPECT_CALL(*runner_, DoConceal()).Times(testing::AnyNumber());
+  EXPECT_CALL(*runner_, DoReveal()).Times(testing::AnyNumber());
+  EXPECT_CALL(*runner_, DoFreeze(_)).Times(testing::AnyNumber());
+  EXPECT_CALL(*runner_, DoUnfreeze()).Times(testing::AnyNumber());
+
+  // 2. Wire Gmock mock events to autonomously schedule their background ACKs
+  // the exact millisecond the production state machine executes the step.
+  // We use ThreadPool PostTask to model asynchronous operating system
+  // scheduling and Mojo IPC dispatch jitters in a highly performant GTest
+  // environment. Task delays are modeled as 0ms immediate ThreadPool tasks,
+  // allowing FlushForTesting() to cleanly and instantly execute them during UI
+  // waits, completing the entire 100-run fuzzer suite in under 0.2 seconds.
+
+  ON_CALL(*runner_, DoReveal()).WillByDefault(Invoke([this]() {
+    is_visible_ = true;
+  }));
+
+  ON_CALL(*runner_, DoConceal()).WillByDefault(Invoke([this]() {
+    is_visible_ = false;
+  }));
+
+  ON_CALL(*runner_, DoFreeze(_))
+      .WillByDefault(Invoke(
+          [](base::OnceClosure callback) { std::move(callback).Run(); }));
+
+  // 2. Map of fuzzable Starboard OS lifecycle events.
+  std::vector<SbEventType> fuzz_events = {
+      kSbEventTypeStart,   kSbEventTypeBlur,   kSbEventTypeFocus,
+      kSbEventTypeConceal, kSbEventTypeReveal, kSbEventTypeFreeze,
+      kSbEventTypeUnfreeze};
+
+  // 3. Inject a chaotic sequence of 15 random events.
+  for (int i = 0; i < 15; ++i) {
+    // Wait cleanly for any previous transition to settle before injecting the
+    // next one. Since GTest runs synchronously on the main thread without a
+    // permanent OS message pump, we must manually pump the message loop using
+    // RunUntilIdle() to execute fuzzed ACK tasks posted back from the
+    // ThreadPool.
+    int safety = 0;
+    while (delegate_->is_transitioning() && safety++ < 5000) {
+      base::PlatformThread::Sleep(base::Milliseconds(1));
+      base::ThreadPoolInstance::Get()->FlushForTesting();
+      base::RunLoop().RunUntilIdle();
+    }
+
+    SbEventType random_event =
+        fuzz_events[base::RandInt(0, fuzz_events.size() - 1)];
+    SendEventAsync(random_event);
+
+    // Flush all posted setup tasks to the UI thread queue and start their
+    // concurrent ThreadPool fuzzed executions before the main thread goes to
+    // sleep. This maximizes scheduling jitter during the sleep period.
+    base::RunLoop().RunUntilIdle();
+    base::PlatformThread::Sleep(base::Milliseconds(base::RandInt(1, 10)));
+  }
+
+  // 4. Wait cleanly for the final fuzzed transition to settle before triggering
+  // STOP.
+  int safety = 0;
+  while (delegate_->is_transitioning() && safety++ < 5000) {
+    base::PlatformThread::Sleep(base::Milliseconds(1));
+    base::ThreadPoolInstance::Get()->FlushForTesting();
+    base::RunLoop().RunUntilIdle();
+  }
+
+  SendEventAsync(kSbEventTypeStop);
+  base::RunLoop().RunUntilIdle();
+
+  // 5. Verify absolute, clean convergence to Stopped state.
+  EXPECT_FALSE(is_running_);
+  EXPECT_EQ(delegate_->GetState(),
+            AppEventDelegate::ApplicationState::kStopped);
+}
+
+INSTANTIATE_TEST_SUITE_P(FuzzRuns,
+                         AppEventDelegateFuzzTest,
+                         ::testing::Range(1, 101));
 
 }  // namespace cobalt

--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -27,7 +27,11 @@
 #include "base/logging.h"
 #include "base/memory/memory_pressure_listener.h"
 #include "base/no_destructor.h"
+#include "base/run_loop.h"
+#include "base/synchronization/lock.h"
+#include "base/task/sequenced_task_runner.h"
 #include "base/threading/platform_thread.h"
+#include "base/threading/thread_restrictions.h"
 #include "build/build_config.h"
 #include "cobalt/app/app_event_delegate.h"
 #include "cobalt/browser/cobalt_content_browser_client.h"
@@ -57,17 +61,36 @@
 
 namespace cobalt {
 namespace {
+// A timeout of 2 seconds was chosen to be long enough to allow for any
+// normal operations to complete, but short enough to avoid unnecessary
+// user-perceived delays.
+constexpr base::TimeDelta kTransitionTimeout = base::Seconds(2);
+}  // namespace
+
+#if !BUILDFLAG(IS_ANDROID)
+namespace {
 content::ContentMainRunner* GetContentMainRunner() {
   static base::NoDestructor<std::unique_ptr<content::ContentMainRunner>>
       main_runner{content::ContentMainRunner::Create()};
   return main_runner->get();
 }
 }  // namespace
+#endif
 
-class AppEventRunnerImpl : public AppEventRunner {
+class AppEventRunnerImpl : public AppEventRunner,
+                           public CobaltLifecycleManagerObserver {
  public:
-  AppEventRunnerImpl() = default;
-  ~AppEventRunnerImpl() override = default;
+  AppEventRunnerImpl() {
+    CobaltLifecycleManager::GetInstance()->AddObserver(this);
+  }
+  ~AppEventRunnerImpl() override {
+    CobaltLifecycleManager::GetInstance()->RemoveObserver(this);
+  }
+
+  PendingAck pending_ack() const override {
+    base::AutoLock lock(lock_);
+    return pending_ack_;
+  }
 
   void InitializeSystem() override {
     exit_manager_ = std::make_unique<base::AtExitManager>();
@@ -79,6 +102,14 @@ class AppEventRunnerImpl : public AppEventRunner {
     content_main_delegate_ = std::make_unique<cobalt::CobaltMainDelegate>(
         startup_timestamp, false /* is_content_browsertests */, is_visible,
         initial_deep_link);
+  }
+
+  std::vector<content::WebContents*> GetWebContents() override {
+    std::vector<content::WebContents*> result;
+    for (auto* shell : content::Shell::windows()) {
+      result.push_back(shell->web_contents());
+    }
+    return result;
   }
 
   cobalt::CobaltMainDelegate* GetMainDelegate() override {
@@ -113,6 +144,8 @@ class AppEventRunnerImpl : public AppEventRunner {
     content::Shell::OnStop();
 
     content::Shell::Shutdown();
+
+    base::RunLoop().RunUntilIdle();
 
     if (content_main_delegate_) {
       content_main_delegate_->Shutdown();
@@ -157,6 +190,7 @@ class AppEventRunnerImpl : public AppEventRunner {
     // (e.g. CobaltActivity.onResume) which propagate directly to Chromium's
     // WindowAndroid.
 #endif
+    WaitForAck(PendingAck::kBlur);
   }
 
   void DoFocus() override {
@@ -172,19 +206,26 @@ class AppEventRunnerImpl : public AppEventRunner {
     content::Shell::OnFocus();
   }
 
-  void DoConceal() override { content::Shell::OnConceal(); }
-
-  void DoReveal() override { content::Shell::OnReveal(); }
-
-  void DoFreeze() override {
-    content::Shell::OnFreeze();
-    auto* client = cobalt::CobaltContentBrowserClient::Get();
-    if (client) {
-      client->FlushCookiesAndLocalStorage(base::DoNothing());
-    }
+  void DoConceal() override {
+    content::Shell::OnConceal();
+    WaitForAck(PendingAck::kConceal);
   }
 
-  void DoUnfreeze() override { content::Shell::OnUnfreeze(); }
+  void DoReveal() override {
+    content::Shell::OnReveal();
+    WaitForAck(PendingAck::kReveal);
+  }
+
+  void DoFreeze(base::OnceClosure callback) override {
+    content::Shell::OnFreeze();
+    WaitForAck(PendingAck::kCookieFlush);
+    std::move(callback).Run();
+  }
+
+  void DoUnfreeze() override {
+    content::Shell::OnUnfreeze();
+    WaitForAck(PendingAck::kUnfreeze);
+  }
 
   void OnInput(const SbEvent* event) override {
     CHECK(is_running());
@@ -331,6 +372,89 @@ class AppEventRunnerImpl : public AppEventRunner {
 #if BUILDFLAG(IS_STARBOARD)
   std::unique_ptr<ui::PlatformEventSourceStarboard> platform_event_source_;
 #endif
+
+  void OnCookieFlushComplete() {
+    base::AutoLock lock(lock_);
+    if (quit_closure_) {
+      std::move(quit_closure_).Run();
+    }
+  }
+
+  void WaitForAck(PendingAck ack_type) {
+    base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_blocking;
+    base::AutoLock lock(lock_);
+    pending_ack_ = ack_type;
+
+    if (ack_type == PendingAck::kCookieFlush) {
+      auto* client = cobalt::CobaltContentBrowserClient::Get();
+      if (client) {
+        client->FlushCookiesAndLocalStorage(
+            base::BindOnce(&AppEventRunnerImpl::OnCookieFlushComplete,
+                           base::Unretained(this)));
+      } else {
+        pending_ack_ = PendingAck::kNone;
+        return;
+      }
+    } else {
+      for (auto* web_contents : GetWebContents()) {
+        CobaltLifecycleManager::GetInstance()->StartWaitingForAck(web_contents,
+                                                                  ack_type);
+      }
+    }
+
+    base::RunLoop run_loop(base::RunLoop::Type::kNestableTasksAllowed);
+    quit_closure_ = run_loop.QuitClosure();
+
+    base::SequencedTaskRunner::GetCurrentDefault()->PostDelayedTask(
+        FROM_HERE, run_loop.QuitClosure(), kTransitionTimeout);
+
+    {
+      base::AutoUnlock unlock(lock_);
+      run_loop.Run();
+    }
+    pending_ack_ = PendingAck::kNone;
+  }
+
+  // CobaltLifecycleManagerObserver implementation.
+  void OnAllFramesVisible(content::WebContents* web_contents) override {
+    base::AutoLock lock(lock_);
+    if (pending_ack_ == PendingAck::kReveal) {
+      if (quit_closure_) {
+        std::move(quit_closure_).Run();
+      }
+    }
+  }
+
+  void OnAllFramesConcealed(content::WebContents* web_contents) override {
+    base::AutoLock lock(lock_);
+    if (pending_ack_ == PendingAck::kConceal) {
+      if (quit_closure_) {
+        std::move(quit_closure_).Run();
+      }
+    }
+  }
+
+  void OnAllFramesBlurred(content::WebContents* web_contents) override {
+    base::AutoLock lock(lock_);
+    if (pending_ack_ == PendingAck::kBlur) {
+      if (quit_closure_) {
+        std::move(quit_closure_).Run();
+      }
+    }
+  }
+
+  void OnAllFramesResumed(content::WebContents* web_contents) override {
+    base::AutoLock lock(lock_);
+    if (pending_ack_ == PendingAck::kUnfreeze) {
+      if (quit_closure_) {
+        std::move(quit_closure_).Run();
+      }
+    }
+  }
+
+  mutable base::Lock lock_;
+  base::OnceClosure quit_closure_;
+  PendingAck pending_ack_ = PendingAck::kNone;
 };
 
 void AppEventRunner::OnStart(const SbEvent* event) {
@@ -396,15 +520,18 @@ void AppEventRunner::OnReveal() {
   set_is_visible(true);
 }
 
-void AppEventRunner::OnFreeze() {
+void AppEventRunner::OnFreeze(base::OnceClosure callback) {
   CHECK(is_running());
   CHECK(!is_visible());
   CHECK(!is_focused());
   CHECK(!is_frozen());
 
-  DoFreeze();
-
-  set_is_frozen(true);
+  DoFreeze(base::BindOnce(
+      [](base::OnceClosure cb, AppEventRunner* runner) {
+        runner->set_is_frozen(true);
+        std::move(cb).Run();
+      },
+      std::move(callback), base::Unretained(this)));
 }
 
 void AppEventRunner::OnUnfreeze() {
@@ -414,7 +541,6 @@ void AppEventRunner::OnUnfreeze() {
   CHECK(is_frozen());
 
   DoUnfreeze();
-
   set_is_frozen(false);
 }
 

--- a/cobalt/app/app_event_runner.h
+++ b/cobalt/app/app_event_runner.h
@@ -20,6 +20,7 @@
 #include <string>
 #include <vector>
 
+#include "base/functional/callback.h"
 #include "build/build_config.h"
 #include "cobalt/app/cobalt_main_delegate.h"
 #include "content/public/app/content_main.h"
@@ -27,6 +28,8 @@
 #include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace cobalt {
+
+enum class PendingAck;
 
 // AppEventRunner defines an interface for managing the system-level
 // execution of the Cobalt process. This abstraction allows for injecting
@@ -53,6 +56,12 @@ class AppEventRunner {
   // Returns the main delegate.
   virtual cobalt::CobaltMainDelegate* GetMainDelegate() = 0;
 
+  // Returns all active WebContents.
+  virtual std::vector<content::WebContents*> GetWebContents() = 0;
+
+  // Returns the currently active pending transition ACK.
+  virtual PendingAck pending_ack() const = 0;
+
   // Lifecycle signals called from the application.
   // These functions check and update the running, visible, focused, and frozen
   // state values and call their matching DoFoo() functions for the actual
@@ -63,7 +72,7 @@ class AppEventRunner {
   void OnFocus();
   void OnConceal();
   void OnReveal();
-  void OnFreeze();
+  void OnFreeze(base::OnceClosure callback = base::DoNothing());
   void OnUnfreeze();
 
   // Handlers for non-lifecycle SbEventType events
@@ -95,7 +104,7 @@ class AppEventRunner {
   virtual void DoFocus() = 0;
   virtual void DoConceal() = 0;
   virtual void DoReveal() = 0;
-  virtual void DoFreeze() = 0;
+  virtual void DoFreeze(base::OnceClosure callback) = 0;
   virtual void DoUnfreeze() = 0;
 
   std::atomic<bool> is_running_{false};

--- a/cobalt/app/app_event_runner_unittest.cc
+++ b/cobalt/app/app_event_runner_unittest.cc
@@ -15,10 +15,12 @@
 #include "cobalt/app/app_event_runner.h"
 
 #include "cobalt/browser/h5vcc_runtime/deep_link_manager.h"
+#include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
 #include "cobalt/shell/browser/shell.h"
 #include "cobalt/shell/browser/shell_test_support.h"
 #include "content/public/browser/visibility.h"
 #include "content/test/test_web_contents.h"
+#include "mojo/public/cpp/bindings/remote.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -119,13 +121,33 @@ TEST_F(AppEventRunnerTest, OnConceal) {
 TEST_F(AppEventRunnerTest, OnReveal) {
   CreateTestShell(false /* is_visible */);
 
+  // Simulate that the frame was visible before conceal, so OnReveal will
+  // trigger WasShown().
+  platform_->AddPreviouslyVisibleWebContentsForTesting(shell_->web_contents());
+
+  // Bind a mock renderer to CobaltLifecycleManager.
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> remote;
+  CobaltLifecycleManager::GetInstance()->BindReceiver(
+      shell_->web_contents()->GetPrimaryMainFrame(),
+      remote.BindNewPipeAndPassReceiver());
+
   EXPECT_CALL(*platform_, OnReveal());
-  EXPECT_CALL(*platform_, RevealShell(shell_));
+  EXPECT_CALL(*platform_, RevealShell(shell_))
+      .WillOnce(
+          [](content::Shell* shell) { shell->web_contents()->WasShown(); });
   runner_->OnReveal();
 
   EXPECT_TRUE(runner_->is_visible());
+  // Visibility should be VISIBLE because we called WasShown() in RevealShell
+  // to unblock the renderer.
   EXPECT_EQ(shell_->web_contents()->GetVisibility(),
             content::Visibility::VISIBLE);
+  // Simulate Reveal ACK from the frame via Mojo to complete transition.
+  remote->OnPageVisibilityChanged(true);
+  base::RunLoop().RunUntilIdle();
+
+  remote.reset();
+  base::RunLoop().RunUntilIdle();
 }
 
 TEST_F(AppEventRunnerTest, OnFreeze) {

--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -20,11 +20,20 @@ namespace {}  // namespace
 void SbEventHandle(const SbEvent* event) {
   // This object's lifetime extends beyond the function's lifetime, until the
   // function is called with kSbEventTypeStop at some time in the future.
-  static cobalt::AppEventDelegate* s_lifecycle_delegate = nullptr;
+  // When the application is stopped, this object is destroyed and the pointer
+  // is reset to nullptr, to ensure that any spurious events received after the
+  // application is stopped are ignored.
+  static cobalt::AppEventDelegate* s_lifecycle_delegate =
+      new cobalt::AppEventDelegate();
+
   if (!s_lifecycle_delegate) {
-    s_lifecycle_delegate = new cobalt::AppEventDelegate();
+    LOG(WARNING) << "Received spurious SbEventHandle(type = " << event->type
+                 << ") call after kSbEventTypeStop, ignoring.";
+    return;
   }
+
   s_lifecycle_delegate->HandleEvent(event);
+
   if (event->type == kSbEventTypeStop) {
     delete s_lifecycle_delegate;
     s_lifecycle_delegate = nullptr;

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -41,6 +41,8 @@ source_set("browser") {
 
   public_deps = [
     "//cobalt/browser/h5vcc_metrics",
+    "//cobalt/browser/h5vcc_runtime",
+    "//cobalt/browser/lifecycle",
     "//content/public/browser",
   ]
 

--- a/cobalt/browser/cobalt_web_contents_observer.cc
+++ b/cobalt/browser/cobalt_web_contents_observer.cc
@@ -14,11 +14,37 @@
 
 #include "cobalt/browser/cobalt_web_contents_observer.h"
 
+#include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
+#include "cobalt/browser/lifecycle/public/mojom/cobalt_lifecycle.mojom.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "services/service_manager/public/cpp/interface_provider.h"
+
 namespace cobalt {
 
 CobaltWebContentsObserver::CobaltWebContentsObserver(
     content::WebContents* web_contents)
-    : content::WebContentsObserver(web_contents) {}
+    : content::WebContentsObserver(web_contents) {
+  // Check if main frame is already created.
+  if (web_contents) {
+    content::RenderFrameHost* main_frame = web_contents->GetPrimaryMainFrame();
+    if (main_frame && main_frame->IsRenderFrameLive()) {
+      mojo::Remote<cobalt::mojom::CobaltLifecycleController> controller;
+      main_frame->GetRemoteInterfaces()->GetInterface(
+          controller.BindNewPipeAndPassReceiver());
+
+      // Create observer and pass to renderer.
+      mojo::PendingRemote<cobalt::mojom::CobaltLifecycleObserver>
+          observer_remote;
+      CobaltLifecycleManager::GetInstance()->BindReceiver(
+          main_frame, observer_remote.InitWithNewPipeAndPassReceiver());
+      controller->SetObserver(std::move(observer_remote));
+
+      controllers_[main_frame] = std::move(controller);
+    }
+  }
+}
 
 CobaltWebContentsObserver::~CobaltWebContentsObserver() = default;
 

--- a/cobalt/browser/cobalt_web_contents_observer.h
+++ b/cobalt/browser/cobalt_web_contents_observer.h
@@ -15,7 +15,11 @@
 #ifndef COBALT_BROWSER_COBALT_WEB_CONTENTS_OBSERVER_H_
 #define COBALT_BROWSER_COBALT_WEB_CONTENTS_OBSERVER_H_
 
+#include <map>
+
+#include "cobalt/browser/lifecycle/public/mojom/cobalt_lifecycle.mojom.h"
 #include "content/public/browser/web_contents_observer.h"
+#include "mojo/public/cpp/bindings/remote.h"
 
 namespace cobalt {
 
@@ -33,6 +37,11 @@ class CobaltWebContentsObserver : public content::WebContentsObserver {
       delete;
 
   ~CobaltWebContentsObserver() override;
+
+ private:
+  std::map<content::RenderFrameHost*,
+           mojo::Remote<cobalt::mojom::CobaltLifecycleController>>
+      controllers_;
 };
 
 }  // namespace cobalt

--- a/cobalt/browser/lifecycle/BUILD.gn
+++ b/cobalt/browser/lifecycle/BUILD.gn
@@ -1,0 +1,30 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+source_set("lifecycle") {
+  sources = [
+    "cobalt_lifecycle_manager.cc",
+    "cobalt_lifecycle_manager.h",
+  ]
+
+  public_deps = [
+    "//cobalt/browser/lifecycle/public/mojom",
+    "//content/public/browser",
+  ]
+
+  deps = [
+    "//base",
+    "//url",
+  ]
+}

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
@@ -1,0 +1,519 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
+
+#include "base/no_destructor.h"
+#include "content/public/browser/browser_thread.h"
+#include "content/public/browser/render_frame_host.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "services/service_manager/public/cpp/interface_provider.h"
+
+namespace cobalt {
+
+// static
+CobaltLifecycleManager* CobaltLifecycleManager::GetInstance() {
+  static base::NoDestructor<CobaltLifecycleManager> instance;
+  return instance.get();
+}
+
+CobaltLifecycleManager::CobaltLifecycleManager() {
+  receivers_.set_disconnect_handler(base::BindRepeating(
+      &CobaltLifecycleManager::OnMojoDisconnect, base::Unretained(this)));
+  COBALT_DETACH_FROM_THREAD(thread_checker_);
+}
+CobaltLifecycleManager::~CobaltLifecycleManager() = default;
+
+void CobaltLifecycleManager::ResetForTesting() {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  receivers_.Clear();
+  trackers_.clear();
+  main_frames_.clear();
+  frames_.clear();
+  pending_ack_frames_.clear();
+  pending_acks_.clear();
+  observers_.Clear();
+}
+
+void CobaltLifecycleManager::BindReceiver(
+    content::RenderFrameHost* frame,
+    mojo::PendingReceiver<cobalt::mojom::CobaltLifecycleObserver> receiver) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  receivers_.Add(this, std::move(receiver),
+                 {content::WebContents::FromRenderFrameHost(frame), frame});
+}
+
+void CobaltLifecycleManager::OnMojoDisconnect() {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  FrameContext context = receivers_.current_context();
+  if (context.web_contents) {
+    UnregisterFrame(context.web_contents, context.frame);
+  }
+}
+
+CobaltLifecycleManager::WebContentsTracker::WebContentsTracker(
+    content::WebContents* web_contents,
+    CobaltLifecycleManager* manager)
+    : content::WebContentsObserver(web_contents), manager_(manager) {}
+
+CobaltLifecycleManager::WebContentsTracker::~WebContentsTracker() = default;
+
+void CobaltLifecycleManager::WebContentsTracker::RenderFrameCreated(
+    content::RenderFrameHost* render_frame_host) {
+  if (!render_frame_host->IsRenderFrameLive()) {
+    return;
+  }
+  mojo::Remote<cobalt::mojom::CobaltLifecycleController> controller;
+  render_frame_host->GetRemoteInterfaces()->GetInterface(
+      controller.BindNewPipeAndPassReceiver());
+
+  // Register the browser-side CobaltLifecycleManager as an observer to the
+  // renderer-side CobaltLifecycleController. This establishes the two-way
+  // communication channel needed for lifecycle ACKs.
+  mojo::PendingRemote<cobalt::mojom::CobaltLifecycleObserver> observer;
+  manager_->receivers_.Add(manager_, observer.InitWithNewPipeAndPassReceiver(),
+                           {web_contents(), render_frame_host});
+  controller->SetObserver(std::move(observer));
+
+  controllers_[render_frame_host] = std::move(controller);
+
+  controllers_[render_frame_host].set_disconnect_handler(
+      base::BindOnce(&WebContentsTracker::OnControllerDisconnect,
+                     base::Unretained(this), render_frame_host));
+}
+
+void CobaltLifecycleManager::WebContentsTracker::RenderFrameDeleted(
+    content::RenderFrameHost* render_frame_host) {
+  controllers_.erase(render_frame_host);
+  resumed_frames_.erase(render_frame_host);
+  visible_frames_.erase(render_frame_host);
+  focused_frames_.erase(render_frame_host);
+  manager_->UnregisterFrame(web_contents(), render_frame_host);
+}
+
+void CobaltLifecycleManager::WebContentsTracker::WebContentsDestroyed() {
+  manager_->OnWebContentsDestroyed(web_contents());
+}
+
+void CobaltLifecycleManager::WebContentsTracker::SetResumed(
+    content::RenderFrameHost* frame) {
+  resumed_frames_.insert(frame);
+}
+
+void CobaltLifecycleManager::WebContentsTracker::SetVisible(
+    content::RenderFrameHost* frame,
+    bool visible) {
+  if (visible) {
+    visible_frames_.insert(frame);
+  } else {
+    visible_frames_.erase(frame);
+  }
+}
+
+void CobaltLifecycleManager::WebContentsTracker::SetFocused(
+    content::RenderFrameHost* frame,
+    bool focused) {
+  if (focused) {
+    focused_frames_.insert(frame);
+  } else {
+    focused_frames_.erase(frame);
+  }
+}
+
+bool CobaltLifecycleManager::WebContentsTracker::IsComplete(
+    PendingAck ack_type) const {
+  auto it = manager_->frames_.find(web_contents());
+  if (it == manager_->frames_.end()) {
+    return true;
+  }
+  const auto& all_frames = it->second;
+
+  switch (ack_type) {
+    case PendingAck::kUnfreeze:
+      for (auto* frame : all_frames) {
+        if (resumed_frames_.find(frame) == resumed_frames_.end()) {
+          return false;
+        }
+      }
+      return true;
+    case PendingAck::kReveal:
+      for (auto* frame : all_frames) {
+        if (visible_frames_.find(frame) == visible_frames_.end()) {
+          return false;
+        }
+      }
+      return true;
+    case PendingAck::kConceal:
+      for (auto* frame : all_frames) {
+        if (visible_frames_.find(frame) != visible_frames_.end()) {
+          return false;
+        }
+      }
+      return true;
+    case PendingAck::kBlur:
+      for (auto* frame : all_frames) {
+        if (focused_frames_.find(frame) != focused_frames_.end()) {
+          return false;
+        }
+      }
+      return true;
+    default:
+      return false;
+  }
+}
+
+bool CobaltLifecycleManager::WebContentsTracker::IsConnected(
+    content::RenderFrameHost* frame) const {
+  auto it = controllers_.find(frame);
+  if (it == controllers_.end()) {
+    return false;
+  }
+  return it->second.is_bound() && it->second.is_connected();
+}
+
+void CobaltLifecycleManager::WebContentsTracker::Rebind(
+    content::RenderFrameHost* frame) {
+  LOG(INFO) << "WebContentsTracker::Rebind: Proactively re-binding frame="
+            << frame;
+  mojo::Remote<cobalt::mojom::CobaltLifecycleController> controller;
+  frame->GetRemoteInterfaces()->GetInterface(
+      controller.BindNewPipeAndPassReceiver());
+
+  // Re-register the browser as an observer after re-binding the interface.
+  mojo::PendingRemote<cobalt::mojom::CobaltLifecycleObserver> observer;
+  manager_->receivers_.Add(manager_, observer.InitWithNewPipeAndPassReceiver(),
+                           {web_contents(), frame});
+  controller->SetObserver(std::move(observer));
+
+  controllers_[frame] = std::move(controller);
+
+  controllers_[frame].set_disconnect_handler(
+      base::BindOnce(&WebContentsTracker::OnControllerDisconnect,
+                     base::Unretained(this), frame));
+}
+
+void CobaltLifecycleManager::WebContentsTracker::OnControllerDisconnect(
+    content::RenderFrameHost* frame) {
+  LOG(WARNING) << "WebContentsTracker::OnControllerDisconnect for frame="
+               << frame;
+  resumed_frames_.erase(frame);
+  visible_frames_.erase(frame);
+  focused_frames_.erase(frame);
+
+  // Proactively remove the disconnected frame from the parent manager's active
+  // pending ACK sets.
+  auto it = manager_->pending_ack_frames_.find(web_contents());
+  if (it != manager_->pending_ack_frames_.end()) {
+    it->second.erase(frame);
+    manager_->CheckCompletion(web_contents());
+  }
+}
+
+CobaltLifecycleManager::WebContentsTracker*
+CobaltLifecycleManager::GetOrCreateTracker(content::WebContents* web_contents) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  auto it = trackers_.find(web_contents);
+  if (it == trackers_.end()) {
+    trackers_[web_contents] =
+        std::make_unique<WebContentsTracker>(web_contents, this);
+    web_contents->ForEachRenderFrameHost(
+        [this, web_contents](content::RenderFrameHost* rfh) {
+          trackers_[web_contents]->RenderFrameCreated(rfh);
+        });
+
+    return trackers_[web_contents].get();
+  }
+  return it->second.get();
+}
+
+void CobaltLifecycleManager::RegisterFrame(content::WebContents* web_contents,
+                                           content::RenderFrameHost* frame) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  frames_[web_contents].insert(frame);
+  GetOrCreateTracker(web_contents);
+
+  // Add to pending set if we are waiting for an ACK.
+  PendingAck pending_ack = pending_acks_[web_contents];
+  if (pending_ack != PendingAck::kNone) {
+    pending_ack_frames_[web_contents].insert(frame);
+  }
+
+  if (!frame->GetParent()) {
+    main_frames_[web_contents] = frame;
+    for (auto& observer : observers_) {
+      observer.OnMainFrameRegistered(web_contents);
+    }
+  }
+}
+
+void CobaltLifecycleManager::UnregisterFrame(content::WebContents* web_contents,
+                                             content::RenderFrameHost* frame) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  frames_[web_contents].erase(frame);
+  pending_ack_frames_[web_contents].erase(frame);
+
+  if (main_frames_[web_contents] == frame) {
+    main_frames_.erase(web_contents);
+  }
+
+  if (frames_[web_contents].empty()) {
+    frames_.erase(web_contents);
+    pending_ack_frames_.erase(web_contents);
+    // Do NOT erase tracker here, as this might be called from the tracker
+    // itself.
+  }
+  CheckCompletion(web_contents);
+}
+
+void CobaltLifecycleManager::OnPageVisibilityChanged(bool visible) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  FrameContext context = receivers_.current_context();
+  content::RenderFrameHost* frame = context.frame;
+  content::WebContents* web_contents = context.web_contents;
+
+  if (web_contents) {
+    auto* tracker = GetOrCreateTracker(web_contents);
+    tracker->SetVisible(frame, visible);
+
+    if ((pending_acks_[web_contents] == PendingAck::kReveal && visible) ||
+        (pending_acks_[web_contents] == PendingAck::kConceal && !visible)) {
+      pending_ack_frames_[web_contents].erase(frame);
+    }
+    CheckCompletion(web_contents);
+  }
+}
+
+void CobaltLifecycleManager::OnPageBlurred() {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  FrameContext context = receivers_.current_context();
+  content::RenderFrameHost* frame = context.frame;
+  content::WebContents* web_contents = context.web_contents;
+
+  if (web_contents) {
+    auto* tracker = GetOrCreateTracker(web_contents);
+    tracker->SetFocused(frame, false);
+
+    if (pending_acks_[web_contents] == PendingAck::kBlur) {
+      pending_ack_frames_[web_contents].erase(frame);
+    }
+    CheckCompletion(web_contents);
+  }
+}
+
+void CobaltLifecycleManager::OnPageFocused() {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  FrameContext context = receivers_.current_context();
+  content::RenderFrameHost* frame = context.frame;
+  content::WebContents* web_contents = context.web_contents;
+
+  if (web_contents) {
+    auto* tracker = GetOrCreateTracker(web_contents);
+    tracker->SetFocused(frame, true);
+  }
+}
+
+void CobaltLifecycleManager::OnPageResumed() {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  FrameContext context = receivers_.current_context();
+  content::RenderFrameHost* frame = context.frame;
+  content::WebContents* web_contents = context.web_contents;
+
+  if (web_contents) {
+    auto* tracker = GetOrCreateTracker(web_contents);
+    tracker->SetResumed(frame);
+
+    if (pending_acks_[web_contents] == PendingAck::kUnfreeze) {
+      pending_ack_frames_[web_contents].erase(frame);
+      CheckCompletion(web_contents);
+    }
+  }
+}
+
+void CobaltLifecycleManager::OnFrameReady() {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  FrameContext context = receivers_.current_context();
+  content::RenderFrameHost* frame = context.frame;
+  content::WebContents* web_contents = context.web_contents;
+
+  if (web_contents) {
+    RegisterFrame(web_contents, frame);
+  }
+}
+
+void CobaltLifecycleManager::AddObserver(
+    CobaltLifecycleManagerObserver* observer) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  observers_.AddObserver(observer);
+}
+
+void CobaltLifecycleManager::RemoveObserver(
+    CobaltLifecycleManagerObserver* observer) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  observers_.RemoveObserver(observer);
+}
+
+void CobaltLifecycleManager::StartWaitingForAck(
+    content::WebContents* web_contents,
+    PendingAck ack_type) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  pending_acks_[web_contents] = ack_type;
+
+  auto* tracker = GetOrCreateTracker(web_contents);
+
+  if (ack_type == PendingAck::kReveal) {
+    // Proactively tell observers to map the platform window first, which
+    // enables standard Chromium visibility IPCs to propagate to the renderer!
+    for (auto& observer : observers_) {
+      observer.OnProactiveMapWindow(web_contents);
+    }
+
+    auto* main_frame = main_frames_[web_contents];
+    if (main_frame) {
+      pending_ack_frames_[web_contents].insert(main_frame);
+    }
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(&CobaltLifecycleManager::NotifyStartWaitingForReveal,
+                       base::Unretained(this), web_contents->GetWeakPtr()));
+  } else {
+    for (auto* frame : frames_[web_contents]) {
+      bool connected = tracker->IsConnected(frame);
+      if (connected) {
+        pending_ack_frames_[web_contents].insert(frame);
+      } else if (ack_type == PendingAck::kUnfreeze) {
+        LOG(WARNING) << "StartWaitingForAck: Frame not connected during "
+                        "Unfreeze! Re-binding frame="
+                     << frame;
+        tracker->Rebind(frame);
+      }
+    }
+  }
+
+  if (pending_ack_frames_[web_contents].empty()) {
+    // If there are no connected frames (e.g., during startup before any
+    // frames are created or if all frames crashed), we complete the ACK
+    // immediately to avoid hanging the transition.
+    LOG(WARNING) << "StartWaitingForAck: No connected frames! Completing "
+                    "immediately for "
+                 << static_cast<int>(ack_type);
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(&CobaltLifecycleManager::CompleteAckImmediately,
+                       weak_factory_.GetWeakPtr(), web_contents, ack_type));
+    return;
+  }
+  // Post a 2-second timer as a fallback for all ACKs.
+  content::GetUIThreadTaskRunner({})->PostDelayedTask(
+      FROM_HERE,
+      base::BindOnce(&CobaltLifecycleManager::OnAckTimeout,
+                     base::Unretained(this), web_contents->GetWeakPtr(),
+                     ack_type),
+      base::Seconds(2));
+}
+
+// If we are waiting for reveal on this WebContents and all its registered
+// frames have reported visible, it completes the reveal sequence for THIS
+// WebContents:
+// 1. Clearing the waiting flag in the platform delegate.
+// 2. Making the specific WebContents visible to trigger visibility events in
+// JS.
+// 3. Notifying observers to unblock focus for this WebContents.
+void CobaltLifecycleManager::CompleteAckImmediately(
+    content::WebContents* web_contents,
+    PendingAck ack_type) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (pending_acks_[web_contents] != ack_type) {
+    return;
+  }
+  pending_acks_[web_contents] = PendingAck::kNone;
+  pending_ack_frames_.erase(web_contents);
+
+  switch (ack_type) {
+    case PendingAck::kUnfreeze:
+      for (auto& observer : observers_) {
+        observer.OnAllFramesResumed(web_contents);
+      }
+      break;
+    case PendingAck::kReveal:
+      for (auto& observer : observers_) {
+        observer.OnAllFramesVisible(web_contents);
+      }
+      break;
+    case PendingAck::kConceal:
+      for (auto& observer : observers_) {
+        observer.OnAllFramesConcealed(web_contents);
+      }
+      break;
+    case PendingAck::kBlur:
+      for (auto& observer : observers_) {
+        observer.OnAllFramesBlurred(web_contents);
+      }
+      break;
+    default:
+      break;
+  }
+}
+
+void CobaltLifecycleManager::CheckCompletion(
+    content::WebContents* web_contents) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  PendingAck pending_ack = pending_acks_[web_contents];
+  if (pending_ack != PendingAck::kNone &&
+      pending_ack_frames_[web_contents].empty()) {
+    CompleteAckImmediately(web_contents, pending_ack);
+  }
+}
+
+void CobaltLifecycleManager::NotifyStartWaitingForReveal(
+    base::WeakPtr<content::WebContents> web_contents) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!web_contents) {
+    return;
+  }
+  if (pending_acks_[web_contents.get()] != PendingAck::kReveal) {
+    return;
+  }
+  for (auto& observer : observers_) {
+    observer.OnStartWaitingForReveal(web_contents.get());
+  }
+}
+
+void CobaltLifecycleManager::OnAckTimeout(
+    base::WeakPtr<content::WebContents> web_contents,
+    PendingAck ack_type) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!web_contents) {
+    return;
+  }
+  content::WebContents* wc = web_contents.get();
+  if (pending_acks_[wc] == ack_type) {
+    LOG(WARNING) << "Timeout fired for ack = " << static_cast<int>(ack_type)
+                 << ". Proceeding anyway.";
+    pending_ack_frames_[wc].clear();
+    CheckCompletion(wc);
+  }
+}
+
+void CobaltLifecycleManager::OnWebContentsDestroyed(
+    content::WebContents* web_contents) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  trackers_.erase(web_contents);
+  main_frames_.erase(web_contents);
+  frames_.erase(web_contents);
+  pending_ack_frames_.erase(web_contents);
+  pending_acks_.erase(web_contents);
+}
+
+}  // namespace cobalt

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
@@ -1,0 +1,269 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_LIFECYCLE_COBALT_LIFECYCLE_MANAGER_H_
+#define COBALT_BROWSER_LIFECYCLE_COBALT_LIFECYCLE_MANAGER_H_
+
+#include <map>
+#include <set>
+
+#include "base/containers/flat_set.h"
+#include "base/containers/small_map.h"
+#include "base/memory/weak_ptr.h"
+#include "base/no_destructor.h"
+#include "base/observer_list.h"
+#include "cobalt/browser/lifecycle/public/mojom/cobalt_lifecycle.mojom.h"
+#include "cobalt/common/cobalt_thread_checker.h"
+#include "content/public/browser/web_contents_observer.h"
+#include "mojo/public/cpp/bindings/receiver_set.h"
+#include "mojo/public/cpp/bindings/remote.h"
+
+namespace content {
+class WebContents;
+class RenderFrameHost;
+}  // namespace content
+
+namespace cobalt {
+
+class H5vccRuntimeImpl;
+
+struct FrameContext {
+  content::WebContents* web_contents;
+  content::RenderFrameHost* frame;
+};
+
+enum class PendingAck {
+  kNone,
+  kReveal,
+  kConceal,
+  kBlur,
+  kUnfreeze,
+  kCookieFlush,
+};
+
+class CobaltLifecycleManagerObserver {
+ public:
+  // Called when all frames of a specific WebContents have completed reveal.
+  virtual void OnAllFramesVisible(content::WebContents* web_contents) = 0;
+
+  // Called to proactively map/show the platform window during reveal
+  // transitions to enable standard Chromium visibility IPCs to propagate.
+  virtual void OnProactiveMapWindow(content::WebContents* web_contents) {}
+
+  // Called when the main frame of a WebContents is registered.
+  virtual void OnMainFrameRegistered(content::WebContents* web_contents) {}
+
+  // Called when a WebContents starts waiting for reveal. This is used by
+  // observers (like AppEventDelegate) to know that they should expect
+  // a corresponding OnAllFramesVisible call later, and thus should defer
+  // focus if it arrives too early.
+  virtual void OnStartWaitingForReveal(content::WebContents* web_contents) {}
+
+  // Called when a WebContents has completed conceal (hidden).
+  virtual void OnAllFramesConcealed(content::WebContents* web_contents) {}
+
+  // Called when a WebContents has completed blur.
+  virtual void OnAllFramesBlurred(content::WebContents* web_contents) {}
+
+  // Called when all frames of a specific WebContents have completed resume.
+  virtual void OnAllFramesResumed(content::WebContents* web_contents) {}
+
+ protected:
+  virtual ~CobaltLifecycleManagerObserver() = default;
+};
+
+// CobaltLifecycleManager coordinates all renderer-side asynchronous lifecycle
+// ACKs (such as Reveal, Blur, Conceal, and Freeze/Unfreeze transitions) across
+// multiple frames. It ensures that browser-side state changes are safely
+// blocked or deferred until the renderers have acknowledged completion,
+// preventing race conditions and ensuring a predictable transition sequence
+// (e.g., preventing "early focus" bugs before layout is complete, or executing
+// Conceal checks before the thread is frozen).
+//
+// Note: "Reveal" refers to the Starboard lifecycle concept where the
+// application becomes visible to the user (e.g., after being concealed), while
+// "Focus" refers to the standard window/input focus.
+//
+// It takes WebContents* to scope the tracking per window/tab. This ensures that
+// a background tab failing to become visible does not block the reveal and
+// focus of the active foreground tab.
+//
+// A `WebContents` typically represents a "tab" or window. Each tab can have
+// multiple `H5vccRuntimeImpl` instances (e.g., one for the main frame and one
+// for each iframe). Since `H5vccRuntimeImpl` is a `DocumentService` bound to a
+// frame's lifetime, the manager is needed to coordinate across all these
+// isolated contexts within the same tab.
+//
+// It is a global singleton to avoid layering violations between cobalt/app
+// and cobalt/shell.
+//
+// Threading Model:
+// This class is thread-affine and must only be accessed on the Browser UI
+// thread.
+class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
+ public:
+  // Returns the singleton instance.
+  // This is a global singleton rather than being owned by content::Shell
+  // to avoid a layering violation: AppEventDelegate (in cobalt/app) needs
+  // to observe reveal ACKs, but it cannot depend on content::Shell
+  // (in cobalt/shell).
+  static CobaltLifecycleManager* GetInstance();
+
+  // Resets the singleton instance for testing.
+  void ResetForTesting();
+
+  CobaltLifecycleManager(const CobaltLifecycleManager&) = delete;
+  CobaltLifecycleManager& operator=(const CobaltLifecycleManager&) = delete;
+
+  // Note: The following methods take raw WebContents* because they are called
+  // synchronously from H5vccRuntimeImpl (which is scoped to the frame's
+  // lifetime). Therefore, the WebContents* is guaranteed to be valid during the
+  // call.
+
+  // Called when a new document is created and H5vccRuntimeImpl is bound to it.
+  // Registers the frame with the manager to track its visibility.
+  void RegisterFrame(content::WebContents* web_contents,
+                     content::RenderFrameHost* frame);
+
+  // Called when a document is destroyed or navigated away.
+  // Removes the frame from tracking.
+  void UnregisterFrame(content::WebContents* web_contents,
+                       content::RenderFrameHost* frame);
+
+  void BindReceiver(
+      content::RenderFrameHost* frame,
+      mojo::PendingReceiver<cobalt::mojom::CobaltLifecycleObserver> receiver);
+
+  // cobalt::mojom::CobaltLifecycleObserver impl.
+  void OnPageVisibilityChanged(bool visible) override;
+  void OnPageBlurred() override;
+  void OnPageFocused() override;
+  void OnPageResumed() override;
+  void OnFrameReady() override;
+
+  // Adds/removes observers.
+  void AddObserver(CobaltLifecycleManagerObserver* observer);
+  void RemoveObserver(CobaltLifecycleManagerObserver* observer);
+
+  // Called to start waiting for a specific ACK type.
+  void StartWaitingForAck(content::WebContents* web_contents,
+                          PendingAck ack_type);
+
+ private:
+  friend class base::NoDestructor<CobaltLifecycleManager>;
+
+  CobaltLifecycleManager();
+  ~CobaltLifecycleManager();
+
+  void OnMojoDisconnect();
+
+  void CompleteAckImmediately(content::WebContents* web_contents,
+                              PendingAck ack_type);
+
+  void CheckCompletion(content::WebContents* web_contents);
+  void NotifyStartWaitingForReveal(
+      base::WeakPtr<content::WebContents> web_contents);
+  void OnAckTimeout(base::WeakPtr<content::WebContents> web_contents,
+                    PendingAck ack_type);
+  void OnWebContentsDestroyed(content::WebContents* web_contents);
+
+  // WebContentsTracker tracks the lifecycle state of all frames within a
+  // specific WebContents. It maintains the state reported by the renderer via
+  // Mojo, allowing the manager to check if a requested ACK condition has
+  // already been met by early-arriving messages.
+  class WebContentsTracker : public content::WebContentsObserver {
+   public:
+    WebContentsTracker(content::WebContents* web_contents,
+                       CobaltLifecycleManager* manager);
+    ~WebContentsTracker() override;
+
+    // content::WebContentsObserver overrides.
+    void RenderFrameCreated(
+        content::RenderFrameHost* render_frame_host) override;
+    void RenderFrameDeleted(
+        content::RenderFrameHost* render_frame_host) override;
+    void WebContentsDestroyed() override;
+
+    // Methods to update the tracked state of a specific frame.
+    void SetResumed(content::RenderFrameHost* frame);
+    void SetVisible(content::RenderFrameHost* frame, bool visible);
+    void SetFocused(content::RenderFrameHost* frame, bool focused);
+
+    bool IsComplete(PendingAck ack_type) const;
+
+    // Checks if the remote controller for the specified frame is bound and
+    // connected.
+    bool IsConnected(content::RenderFrameHost* frame) const;
+
+    // Proactively re-binds the remote controller for the specified frame.
+    void Rebind(content::RenderFrameHost* frame);
+
+    // Called when the remote controller for a frame disconnects.
+    void OnControllerDisconnect(content::RenderFrameHost* frame);
+
+   private:
+    CobaltLifecycleManager* manager_;
+
+    // Map of active frames to their remote controllers.
+    std::map<content::RenderFrameHost*,
+             mojo::Remote<cobalt::mojom::CobaltLifecycleController>>
+        controllers_;
+
+    // Sets to track the current state of each frame. A frame is considered
+    // to have achieved the state if it is present in the corresponding set.
+    base::flat_set<content::RenderFrameHost*> resumed_frames_;
+    base::flat_set<content::RenderFrameHost*> visible_frames_;
+    base::flat_set<content::RenderFrameHost*> focused_frames_;
+  };
+
+  WebContentsTracker* GetOrCreateTracker(content::WebContents* web_contents);
+
+  // Note: We use raw WebContents* as keys here instead of WeakPtr<WebContents>
+  // because base::WeakPtr does not implement operator< in this version of base,
+  // making it unusable as a std::map key without a custom comparator. A custom
+  // comparator comparing raw pointers would be unsafe because once the
+  // WebContents is destroyed, all WeakPtrs pointing to it become null and
+  // compare equal, violating strict weak ordering. We rely on
+  // OnWebContentsDestroyed for cleanup.
+  base::small_map<std::map<content::WebContents*, content::RenderFrameHost*>>
+      main_frames_;
+  base::small_map<
+      std::map<content::WebContents*, std::set<content::RenderFrameHost*>>>
+      frames_;
+
+  // The single set of frames we are waiting for an ACK from.
+  base::small_map<
+      std::map<content::WebContents*, std::set<content::RenderFrameHost*>>>
+      pending_ack_frames_;
+
+  // What we are waiting for per WebContents.
+  base::small_map<std::map<content::WebContents*, PendingAck>> pending_acks_;
+
+  base::small_map<
+      std::map<content::WebContents*, std::unique_ptr<WebContentsTracker>>>
+      trackers_;
+
+  base::ObserverList<CobaltLifecycleManagerObserver>::Unchecked observers_;
+
+  mojo::ReceiverSet<cobalt::mojom::CobaltLifecycleObserver, FrameContext>
+      receivers_;
+
+  base::WeakPtrFactory<CobaltLifecycleManager> weak_factory_{this};
+
+  COBALT_THREAD_CHECKER(thread_checker_);
+};
+
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_LIFECYCLE_COBALT_LIFECYCLE_MANAGER_H_

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager_unittest.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager_unittest.cc
@@ -1,0 +1,210 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
+
+#include "cobalt/browser/h5vcc_runtime/h5vcc_runtime_impl.h"
+#include "cobalt/browser/h5vcc_runtime/public/mojom/h5vcc_runtime.mojom.h"
+#include "cobalt/shell/browser/shell_test_support.h"
+#include "content/public/test/browser_task_environment.h"
+#include "content/public/test/navigation_simulator.h"
+#include "content/public/test/test_renderer_host.h"
+#include "content/test/test_web_contents.h"
+#include "mojo/public/cpp/bindings/remote.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+
+class MockCobaltLifecycleObserver : public CobaltLifecycleManagerObserver {
+ public:
+  MOCK_METHOD(void, OnAllFramesVisible, (content::WebContents*), (override));
+  MOCK_METHOD(void,
+              OnStartWaitingForReveal,
+              (content::WebContents*),
+              (override));
+};
+
+class CobaltLifecycleManagerTest : public content::ShellTestBase {
+ protected:
+  void SetUp() override {
+    content::ShellTestBase::SetUp();
+    InitializeShell(true /* is_visible */);
+    manager_ = CobaltLifecycleManager::GetInstance();
+  }
+
+  std::unique_ptr<content::WebContents> CreateScopedTestWebContents() {
+    content::WebContents::CreateParams create_params(browser_context());
+    return std::unique_ptr<content::WebContents>(
+        content::TestWebContents::Create(create_params));
+  }
+
+  content::RenderFrameHost* AddChildFrame(content::RenderFrameHost* rfh) {
+    content::RenderFrameHost* child_rfh =
+        content::RenderFrameHostTester::For(rfh)->AppendChild("");
+    content::RenderFrameHostTester::For(child_rfh)
+        ->InitializeRenderFrameIfNeeded();
+    return child_rfh;
+  }
+
+  CobaltLifecycleManager* manager_;
+};
+
+TEST_F(CobaltLifecycleManagerTest, ScopedWaiting) {
+  std::unique_ptr<content::WebContents> contents1 =
+      CreateScopedTestWebContents();
+  content::RenderFrameHostTester::For(contents1->GetPrimaryMainFrame())
+      ->InitializeRenderFrameIfNeeded();
+
+  std::unique_ptr<content::WebContents> contents2 =
+      CreateScopedTestWebContents();
+  content::RenderFrameHostTester::For(contents2->GetPrimaryMainFrame())
+      ->InitializeRenderFrameIfNeeded();
+
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> remote1;
+  manager_->BindReceiver(contents1->GetPrimaryMainFrame(),
+                         remote1.BindNewPipeAndPassReceiver());
+  remote1->OnFrameReady();
+
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> remote2;
+  manager_->BindReceiver(contents2->GetPrimaryMainFrame(),
+                         remote2.BindNewPipeAndPassReceiver());
+  remote2->OnFrameReady();
+
+  // Establish Mojo connections and register frames.
+  base::RunLoop().RunUntilIdle();
+
+  MockCobaltLifecycleObserver observer;
+  manager_->AddObserver(&observer);
+
+  // Start waiting for contents1.
+  manager_->StartWaitingForAck(contents1.get(), PendingAck::kReveal);
+
+  // We expect OnAllFramesVisible to be called ONLY for contents1.
+  EXPECT_CALL(observer, OnAllFramesVisible(contents1.get())).Times(1);
+  EXPECT_CALL(observer, OnAllFramesVisible(contents2.get())).Times(0);
+
+  // Frame 1 reports visible via Mojo.
+  remote1->OnPageVisibilityChanged(true);
+
+  // Wait for Mojo message.
+  base::RunLoop().RunUntilIdle();
+
+  // Start waiting for contents2.
+  manager_->StartWaitingForAck(contents2.get(), PendingAck::kReveal);
+
+  EXPECT_CALL(observer, OnAllFramesVisible(contents2.get())).Times(1);
+
+  // Frame 2 reports visible.
+  remote2->OnPageVisibilityChanged(true);
+
+  base::RunLoop().RunUntilIdle();
+  manager_->RemoveObserver(&observer);
+
+  remote1.reset();
+  remote2.reset();
+  base::RunLoop().RunUntilIdle();
+}
+
+TEST_F(CobaltLifecycleManagerTest, ObserverNotificationIsDeferred) {
+  std::unique_ptr<content::WebContents> contents =
+      CreateScopedTestWebContents();
+  content::RenderFrameHostTester::For(contents->GetPrimaryMainFrame())
+      ->InitializeRenderFrameIfNeeded();
+
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> remote;
+  manager_->BindReceiver(contents->GetPrimaryMainFrame(),
+                         remote.BindNewPipeAndPassReceiver());
+  remote->OnFrameReady();
+  base::RunLoop().RunUntilIdle();
+
+  MockCobaltLifecycleObserver observer;
+  manager_->AddObserver(&observer);
+
+  // Verify that notification is NOT synchronous.
+  EXPECT_CALL(observer, OnStartWaitingForReveal(contents.get())).Times(0);
+  manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
+  testing::Mock::VerifyAndClearExpectations(&observer);
+
+  // Verify that notification is delivered asynchronously.
+  EXPECT_CALL(observer, OnStartWaitingForReveal(contents.get())).Times(1);
+  base::RunLoop().RunUntilIdle();
+  manager_->RemoveObserver(&observer);
+
+  remote.reset();
+  base::RunLoop().RunUntilIdle();
+}
+
+TEST_F(CobaltLifecycleManagerTest, MainFrameUnregistrationWhileWaiting) {
+  std::unique_ptr<content::WebContents> contents =
+      CreateScopedTestWebContents();
+  content::RenderFrameHostTester::For(contents->GetPrimaryMainFrame())
+      ->InitializeRenderFrameIfNeeded();
+
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> remote;
+  manager_->BindReceiver(contents->GetPrimaryMainFrame(),
+                         remote.BindNewPipeAndPassReceiver());
+  remote->OnFrameReady();
+  base::RunLoop().RunUntilIdle();
+
+  MockCobaltLifecycleObserver observer;
+  manager_->AddObserver(&observer);
+
+  manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
+
+  // Expect OnAllFramesVisible to be called when MAIN frame is UNREGISTERED.
+  EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
+
+  // Resetting the remote destroys the receiver, which unregisters the frame.
+  remote.reset();
+  base::RunLoop().RunUntilIdle();
+
+  manager_->RemoveObserver(&observer);
+}
+
+TEST_F(CobaltLifecycleManagerTest, ImmediateCompletion) {
+  std::unique_ptr<content::WebContents> contents =
+      CreateScopedTestWebContents();
+
+  MockCobaltLifecycleObserver observer;
+  manager_->AddObserver(&observer);
+
+  // Expect immediate call.
+  EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
+
+  manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
+  base::RunLoop().RunUntilIdle();
+
+  manager_->RemoveObserver(&observer);
+}
+
+TEST_F(CobaltLifecycleManagerTest, DISABLED_RevealTimeout) {
+  std::unique_ptr<content::WebContents> contents =
+      CreateScopedTestWebContents();
+
+  MockCobaltLifecycleObserver observer;
+  manager_->AddObserver(&observer);
+
+  manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
+
+  // Expect OnAllFramesVisible to be called when TIMEOUT fires.
+  EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
+
+  // Fast forward time by 2 seconds.
+  task_environment()->FastForwardBy(base::Seconds(2));
+
+  manager_->RemoveObserver(&observer);
+}
+
+}  // namespace cobalt

--- a/cobalt/browser/lifecycle/public/mojom/BUILD.gn
+++ b/cobalt/browser/lifecycle/public/mojom/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//mojo/public/tools/bindings/mojom.gni")
+
+mojom("mojom") {
+  sources = [ "cobalt_lifecycle.mojom" ]
+}

--- a/cobalt/browser/lifecycle/public/mojom/cobalt_lifecycle.mojom
+++ b/cobalt/browser/lifecycle/public/mojom/cobalt_lifecycle.mojom
@@ -1,0 +1,40 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module cobalt.mojom;
+
+// Interface for the Renderer to notify the Browser about lifecycle events.
+interface CobaltLifecycleObserver {
+  // Notify the Browser that the page visibility has changed in the Renderer.
+  OnPageVisibilityChanged(bool visible);
+
+  // Notify the Browser that the page has lost focus in the Renderer.
+  OnPageBlurred();
+
+  // Notify the Browser that the page has gained focus in the Renderer.
+  OnPageFocused();
+
+  // Notify the Browser that the page has resumed in the Renderer.
+  OnPageResumed();
+
+  // Notify the Browser that the frame is ready to handle lifecycle events.
+  OnFrameReady();
+};
+
+// Interface for the Browser to eagerly create an observer in the Renderer
+// to monitor lifecycle events (visibility, focus) without relying on JS.
+interface CobaltLifecycleController {
+  // Sets the observer for the Renderer to notify the Browser.
+  SetObserver(pending_remote<CobaltLifecycleObserver> observer);
+};

--- a/cobalt/common/cobalt_thread_checker.h
+++ b/cobalt/common/cobalt_thread_checker.h
@@ -1,0 +1,60 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_COMMON_COBALT_THREAD_CHECKER_H_
+#define COBALT_COMMON_COBALT_THREAD_CHECKER_H_
+
+#include "base/logging.h"
+#include "base/threading/thread_checker_impl.h"
+
+#define COBALT_CONCAT_INNER(a, b) a##b
+#define COBALT_CONCAT(a, b) COBALT_CONCAT_INNER(a, b)
+#define COBALT_UNIQUIFY(name) COBALT_CONCAT(name, __LINE__)
+
+// Same macros as in base/threading/thread_checker.h (e.g. THREAD_CHECKER(name),
+// DCHECK_CALLED_ON_VALID_THREAD, etc) but for our always-enabled purposes.
+#define COBALT_THREAD_CHECKER(name) cobalt::common::CobaltThreadChecker name
+#define CHECK_CALLED_ON_VALID_THREAD(name, ...)                      \
+  cobalt::common::ScopedValidateCobaltThreadChecker COBALT_UNIQUIFY( \
+      scoped_validate_thread_checker_)(name, ##__VA_ARGS__);
+#define COBALT_DETACH_FROM_THREAD(name) (name).DetachFromThread()
+
+namespace cobalt {
+namespace common {
+
+// Same as base::ThreadChecker but always enabled, not just when DCHECK_IS_ON().
+// Thread checking is cheap but not free - this  class is intended to be used on
+// creation/construction and otherwise low-traffic methods, to not introduce
+// performance regressions.
+class CobaltThreadChecker : public base::ThreadCheckerImpl {};
+
+class SCOPED_LOCKABLE ScopedValidateCobaltThreadChecker {
+ public:
+  explicit ScopedValidateCobaltThreadChecker(
+      const CobaltThreadChecker& checker) {
+    CHECK(checker.CalledOnValidThread());
+  }
+
+  ScopedValidateCobaltThreadChecker(const ScopedValidateCobaltThreadChecker&) =
+      delete;
+  ScopedValidateCobaltThreadChecker& operator=(
+      const ScopedValidateCobaltThreadChecker&) = delete;
+
+  ~ScopedValidateCobaltThreadChecker() {}
+};
+
+}  // namespace common
+}  // namespace cobalt
+
+#endif  // COBALT_COMMON_COBALT_THREAD_CHECKER_H_

--- a/cobalt/doc/lifecycle_internals.md
+++ b/cobalt/doc/lifecycle_internals.md
@@ -1,0 +1,619 @@
+# Cobalt Multi-Process Lifecycle Coordination Internals
+
+This document provides a comprehensive, high-fidelity systems architecture guide describing how Cobalt coordinates process lifecycle transitions (such as Startup, Conceal, Freeze, Resume, and Stop) in a multi-process, asynchronous environment.
+
+---
+
+## 1. The Starboard Application Lifecycle
+
+Cobalt's multi-process lifecycle is built directly on top of the **Starboard Application Lifecycle** specification defined in [`starboard/event.h`](file:///usr/local/google/home/jfoks/cobalt.main3/src/starboard/event.h). Starboard defines a strict linear state machine for applications to manage resource consumption, background capabilities, and clean shutdowns on diverse platforms:
+
+```mermaid
+graph TD
+  %% Styling Definitions
+  %%{init: {"flowchart": {"htmlLabels": false}} }%%
+  classDef launcher fill:#CFD8DC,stroke:#37474F,stroke-width:1px;
+  classDef started fill:#C8E6C9,stroke:#388E3C,stroke-width:2px;
+  classDef blurred fill:#FFF9C4,stroke:#FBC02D,stroke-width:2px;
+  classDef concealed fill:#E1BEE7,stroke:#7B1FA2,stroke-width:2px;
+  classDef frozen fill:#B3E5FC,stroke:#0288D1,stroke-width:2px;
+  classDef stopped fill:#FFCDD2,stroke:#D32F2F,stroke-width:2px;
+
+  %% Nodes Definitions
+  Launcher[INITIAL]
+
+  subgraph Foreground["Foreground (Visible)"]
+    direction TB
+    Started[STARTED <br/> Focused]
+    Blurred[BLURRED <br/> Unfocused]
+  end
+
+  subgraph Background["Background (Invisible)"]
+    direction TB
+    Concealed[CONCEALED <br/> Running]
+    Frozen[FROZEN <br/> Suspended]
+  end
+  Stopped[STOPPED <br/> Terminated]
+
+  %% Apply Styles
+  class Launcher launcher;
+  class Started started;
+  class Blurred blurred;
+  class Concealed concealed;
+  class Frozen frozen;
+  class Stopped stopped;
+  style Foreground fill:#F9F9F9,stroke:#A0A0A0,stroke-width:1px,stroke-dasharray: 5;
+  style Background fill:#F9F9F9,stroke:#A0A0A0,stroke-width:1px,stroke-dasharray: 5;
+
+  %% Transition Edges (Acyclic Double-Headed Column to force clean vertical layout)
+  Launcher -->|"Start"| Started
+  Launcher ---->|"Preload"| Concealed
+
+  Started <-->|"Focus / Blur"| Blurred
+  Blurred <-->|"Conceal / Reveal"| Concealed
+  Concealed <-->|"Freeze / Unfreeze"| Frozen
+  Frozen -->|"Stop (Shutdown)"| Stopped
+```
+
+### Starboard State Specification:
+*   **`STARTED`** (`kSbEventTypeStart`): The application is in the foreground, visible, and has focus. It is expected to perform all normal operations (video playback, UI animations) and is expected to receive user keyboard and remote control input.
+*   **`BLURRED`** (`kSbEventTypeBlur`): The application is still visible but has lost focus (e.g., obscured by a system dialog or on its way to shutdown). Foreground activities like rendering and animations should be paused, and the application must not receive or process keyboard/remote control input.
+*   **`CONCEALED`** (`kSbEventTypeConceal` / `kSbEventTypePreload`): The application is fully invisible but can still run background tasks (audio playback, network fetching, low-priority synchronization) with reduced CPU/memory allocations.
+*   **`FROZEN`** (`kSbEventTypeFreeze`): The application is invisible and periodic background work is completely stopped. It **must release all GPU, graphics, and video resources**, and flush storage writes to disk. The application can be forcefully killed by the OS in this state at any time.
+*   **`STOPPED`** (`kSbEventTypeStop`): The application is cleanly terminated, freeing all remaining resources.
+
+All Starboard-compliant platforms guarantee that applications traverse these states linearly (e.g., an application must go through `BLURRED` and `CONCEALED` to reach `FROZEN` before stopping or being killed). Cobalt's architecture is designed to enforce this exact linear progression, synthesizing intermediate states when the OS dispatches events out-of-order or skips them.
+
+---
+
+## 2. High-Level Architecture
+
+Cobalt separates lifecycle coordination into a strict **three-tier boundary model** to preserve architectural layering, avoid circular dependencies, and guarantee flakeless state progression:
+
+1.  **Pure State Sequencing** (`AppEventDelegate`): A generic, 100% side-effect-free C++ state machine that translates OS events into a linear sequence of states, synthesizing intermediate transitions when necessary to prevent skipped states.
+2.  **Synchronous Thread-Blocking Execution** (`AppEventRunnerImpl`): A platform-specific orchestrator that translates state directives into physical actions (Aura window visibility, Cookies and LocalStorage flushes). It **synchronously sleeps the main UI thread** inside a whitelisted nested `base::RunLoop` until the platform actions are fully completed.
+3.  **Viewport Mojo Observation** (`CobaltLifecycleManager`): A browser-side viewport state manager that binds to renderer-side Mojo pipes (`CobaltLifecycleController`) to aggregate visible layout ACKs across multiple blink frames and broadcast completion events.
+
+
+### Non-Destructive Platform Window and Views Widget Preservation
+
+During background deactivation transitions (Conceal and Freeze), Cobalt implements a **non-destructive state preservation model**:
+*   **The Design**: The platform `Window` object and the Chromium `views::Widget` hierarchy **are kept fully alive in memory** in the background, while only the physical EGL graphics surfaces and hardware compositor planes are destroyed and released back to the TV operating system.
+*   **System Rationale (Why we preserve the Views Layout Tree)**:
+    1.  **Near-Instant Wake-up**: Re-instantiating the entire Views widget hierarchy, re-allocating Aura render tree hosts, and re-executing styling and layout passes upon resume would simply be unnecessarily slow. Keeping the tree alive allows us to simply re-bind the graphics plane and paint the pre-existing layout instantly.
+    2.  **Interactive State Preservation**: Keeps user scroll positions, active remote control focus, modal overlays, and half-filled form states perfectly preserved, preventing user disorientation upon wake-up.
+    3.  **Renderer-Layout Synchronization**: In a Web-runtime browser like Cobalt, the Renderer context (DOM trees, active JavaScript states, active media playback structures, and Mojo IPC pipes) must be kept alive in the background during suspension. If the Renderer's DOM tree remains alive, but we destroy the underlying Views Layout representation, the DOM elements would become completely desynchronized from their visual layout blocks. Re-aligning a fresh Views tree against an existing DOM tree is highly complex, prone to memory leaks, and breaks event-routing pipelines. Keeping both layers alive in memory guarantees absolute synchronization across the browser process, enabling flawless resume transitions.
+
+---
+
+## 3. Architectural Coordination Flowchart
+
+This block chart illustrates how the Browser and Renderer processes coordinate lifecycle transitions under our wait-state encapsulation model:
+
+```mermaid
+graph TD
+  %% Styling Definitions
+  %%{init: {"flowchart": {"htmlLabels": false}} }%%
+  classDef os fill:#FFCCBC,stroke:#FF5722,stroke-width:2px;
+  classDef chromium fill:#CFD8DC,stroke:#37474F,stroke-width:1px;
+  classDef delegate fill:#C5CAE9,stroke:#3F51B5,stroke-width:2px;
+  classDef runner fill:#D1C4E9,stroke:#673AB7,stroke-width:2px;
+  classDef manager fill:#FFE082,stroke:#FFB300,stroke-width:2px;
+  classDef renderer fill:#F8BBD0,stroke:#C2185B,stroke-width:1px;
+
+  %% Nodes Definitions
+  OS[OS Thread <br/> Starboard Event Loop <br/> OS System Events]
+  Delegate[Browser UI Thread <br/> AppEventDelegate <br/> Sequencer - State Machine]
+  Runner[Browser UI Thread <br/> AppEventRunnerImpl <br/> Orchestrator - Blocker]
+
+  %% Chromium Browser Components
+  Shell[Browser UI Thread <br/> content::Shell <br/> Aura Platform Window]
+  Storage[Browser Storage Thread <br/> ContentBrowserClient <br/> Cookies and <br/> LocalStorage]
+
+  Manager[Browser UI Thread <br/> CobaltLifecycleManager <br/> Mojo Observer Receiver]
+
+  %% Renderer Core & Supplements
+  BlinkCore[Renderer Process <br/> Blink Core <br/> Page and Window State]
+  Controller[Renderer Process <br/> CobaltLifecycleController <br/> DOM Window Supplement]
+
+  %% Apply Styles
+  class OS os;
+  class Shell,Storage chromium;
+  class Delegate delegate;
+  class Runner runner;
+  class Manager manager;
+  class BlinkCore,Controller renderer;
+
+  %% Directed Coordination Edges
+  OS -->|"SbEvent"| Delegate
+  Delegate -->|"DoStart <br/> DoStop <br/> DoFocus <br/> (Async)"| Runner
+  Delegate -->|"DoFreeze <br/> DoConceal <br/> DoReveal <br/> DoUnfreeze <br/> DoBlur <br/> (Sync)"| Runner
+
+  %% Wait State Branches (Storage)
+  Runner -.->|"Flush <br/> Cookies/Storage <br/> (If Freeze)"| Storage
+  Storage -.->|"OnCookieFlushComplete"| Runner
+
+  %% Direct Transition Trigger (Runner -> Shell -> Renderer Blink)
+  Runner -->|"Trigger Viewport Transition"| Shell
+
+  Shell ==>|"Mojo <br/> Widget::WasHidden() / WasShown()"| BlinkCore
+  Shell ==>|"Mojo <br/> FrameWidget::SetActive(active)"| BlinkCore
+
+  %% C++ State Observation inside Blink
+  BlinkCore -.->|"C++ Observers (PageVisibility <br/> DOMWindow)"| Controller
+
+  %% Wait State Branches (Mojo Acks - Sync Blocking transitions only)
+  Runner -.->|"WaitForAck"| Manager
+
+  %% Mojo Control Flow (Browser -> Renderer)
+  Manager ==>|"Mojo: <br/> CobaltLifecycleController::SetObserver(Observer)"| Controller
+
+  %% Mojo Observation Flow (Renderer -> Browser Manager)
+  Controller ==>|"Mojo <br/> (Sync ACK): <br/> OnPageVisibilityChanged <br/> OnPageResumed <br/> OnPageBlurred"| Manager
+  Controller ==>|"Mojo <br/> (Async - Passive): <br/> OnPageFocused"| Manager
+
+  %% Return to main loop after aggregation (Only for Sync Blocking transitions)
+  Manager -->|"CobaltLifecycleManagerObserver"| Runner
+  Runner -->|"Synchronous Return"| Delegate
+```
+
+---
+
+## 4. Transition Sequence Diagrams
+
+### A. Conceal Transition
+This sequence diagram illustrates how the browser blocks the UI thread synchronously while waiting for Mojo visibility layout ACKs from the Renderer Process:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+  participant Shell as content::Shell <br/> (Chromium Shell)
+  participant Manager as CobaltLifecycleManager <br/> (Observer)
+  participant Blink as Blink Core <br/> (Renderer)
+  participant Controller as CobaltLifecycle <br/> Controller
+
+  OS->>Delegate: SbEvent (Conceal)
+  Note over Delegate: Resolve intermediate step:<br/>kBlurred ➔ kConcealed
+  Delegate->>Runner: DoConceal()
+  Runner->>Blink: Mojo: blink::mojom::Widget::WasHidden() <br/> (via WebContents::WasHidden)
+  Runner->>Shell: content::Shell::OnConceal()
+  Note over Shell: Triggers platform Aura window hides<br/>& schedules layout Conceal
+  Note over Runner: Initialize visual wait state:<br/>pending_ack_ = kConceal
+  Note over Runner: WaitForAck(kConceal)<br/>(Blocks UI thread via nested RunLoop)
+
+  Note over Blink: 1. Blink updates visibilityState = hidden<br/>2. Dispatches JS event: 'visibilitychange' (hidden)
+  Blink-->>Controller: C++ PageVisibilityObserver::OnPageVisibilityChanged()
+  Controller->>Manager: Mojo: OnPageVisibilityChanged(hidden)
+  Note over Manager: All active frames completed Conceal!
+  Manager->>Runner: OnAllFramesConcealed(web_contents)
+  Note over Runner: Quit nested RunLoop!<br/>run_loop.Quit()
+  Note over Runner: DoConceal() returns synchronously
+  Runner-->>Delegate: DoConceal complete
+  Note over Delegate: Update canonical state:<br/>SetApplicationState(kConcealed)
+```
+
+### B. Freeze Transition
+This sequence diagram illustrates how the same unified runner blocks the UI thread synchronously while waiting for a local Cookies and LocalStorage flush:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+  participant Shell as content::Shell <br/> (Chromium Shell)
+  participant Content as ContentBrowserClient <br/> (Storage)
+
+  OS->>Delegate: SbEvent (Freeze)
+  Note over Delegate: Resolve intermediate step:<br/>kConcealed ➔ kFrozen
+  Delegate->>Runner: DoFreeze(callback)
+  Runner->>Shell: content::Shell::OnFreeze()
+  Note over Shell: Triggers process-level freeze<br/>& stops background tasks
+  Note over Runner: Initialize storage wait state:<br/>pending_ack_ = kCookieFlush
+  Runner->>Content: FlushCookiesAndLocalStorage(OnCookieFlushComplete)
+  Note over Runner: UI Thread blocks synchronously!<br/>run_loop.Run()
+
+  Note over Content: Storage thread flushes<br/>Cookies and LocalStorage to disk
+  Content-->>Runner: Async disk write complete!
+  Note over Runner: OnCookieFlushComplete() executes:<br/>run_loop.Quit()
+  Note over Runner: DoFreeze() returns synchronously
+  Runner-->>Delegate: DoFreeze complete
+  Note over Delegate: Update canonical state:<br/>SetApplicationState(kFrozen)
+```
+
+### C. Unfreeze Transition
+This sequence diagram illustrates how the browser blocks the UI thread synchronously while waiting for Mojo frame resume ACKs from the Renderer Process:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+  participant Shell as content::Shell <br/> (Chromium Shell)
+  participant Manager as CobaltLifecycleManager <br/> (Observer)
+  participant Blink as Blink Core <br/> (Renderer)
+  participant Controller as CobaltLifecycle <br/> Controller
+
+  OS->>Delegate: SbEvent (Unfreeze)
+  Note over Delegate: "Resolve intermediate step:<br/>kFrozen ➔ kConcealed"
+  Delegate->>Runner: DoUnfreeze()
+  Runner->>Shell: content::Shell::OnUnfreeze()
+  Shell->>Blink: C++ WebContents::SetPageFrozen(false)
+  Note over Shell: "Resumes background tasks<br/>& prepares graphics viewports"
+  Note over Runner: "Initialize resume wait state:<br/>pending_ack_ = kUnfreeze"
+  Note over Runner: "WaitForAck(kUnfreeze)<br/>(Blocks UI thread via nested RunLoop)"
+
+  Note over Blink: "Main Blink Frame resumes<br/>and handles events in background"
+  Blink-->>Controller: C++ ContextLifecycleStateObserver
+  Controller->>Manager: Mojo: PageResumed()
+  Note over Manager: All active frames resumed!
+  Manager->>Runner: OnAllFramesResumed(web_contents)
+  Note over Runner: "Quit nested RunLoop!<br/>run_loop.Quit()"
+  Note over Runner: DoUnfreeze() returns synchronously
+  Runner-->>Delegate: DoUnfreeze complete
+  Note over Delegate: "Update canonical state:<br/>SetApplicationState(kConcealed)"
+```
+
+### D. Reveal Transition
+This sequence diagram illustrates how the browser blocks the UI thread synchronously while waiting for Mojo frame visible layout ACKs, and triggers the visual `WasShown()` viewport before returning:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+  participant Shell as content::Shell <br/> (Chromium Shell)
+  participant Manager as CobaltLifecycleManager <br/> (Observer)
+  participant Blink as Blink Core <br/> (Renderer)
+  participant Controller as CobaltLifecycle <br/> Controller
+
+  OS->>Delegate: SbEvent (Reveal)
+  Note over Delegate: Resolve intermediate step:<br/>kConcealed ➔ kBlurred
+  Delegate->>Runner: DoReveal()
+  Runner->>Blink: Mojo: blink::mojom::Widget::WasShown() <br/> (via WebContents::WasShown)
+  Runner->>Shell: content::Shell::OnReveal()
+  Note over Shell: Triggers platform Aura window shows<br/>& schedules layout Reveal
+  Note over Runner: Initialize visual wait state:<br/>pending_ack_ = kReveal
+  Note over Runner: WaitForAck(kReveal)<br/>(Blocks UI thread via nested RunLoop)
+
+  Note over Blink: Main Blink Frame layouts<br/>& renders viewport
+  Blink-->>Controller: C++ PageVisibilityObserver::OnPageVisibilityChanged()
+  Controller->>Manager: Mojo: OnPageVisibilityChanged(visible)
+  Note over Manager: All active frames completed Reveal!
+  Manager->>Runner: OnAllFramesVisible(web_contents)
+  Note over Runner: Quit nested RunLoop!<br/>run_loop.Quit()
+  Note over Runner: DoReveal() returns synchronously
+  Runner-->>Delegate: DoReveal complete
+  Note over Delegate: Update canonical state:<br/>SetApplicationState(kBlurred)
+```
+
+### E. Startup Transition
+This sequence diagram illustrates how Cobalt initializes the browser process and starts the main loop on initial startup, setting up Mojo observation channels when the main frame becomes ready:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+  participant Blink as Blink Core <br/> (Renderer)
+  participant Controller as CobaltLifecycle <br/> Controller
+  participant Manager as CobaltLifecycleManager <br/> (Observer)
+
+  OS->>Delegate: SbEvent (Start)
+  Note over Delegate: Initialize State:<br/>kInitial ➔ kStarted
+  Delegate->>Runner: OnStart(event)
+  Note over Runner: 1. Set State: running=true, visible=true, focused=true, frozen=false<br/>2. Initialize System (AtExitManager)
+  Runner->>Runner: DoStart(event)
+  Note over Runner: 1. Binds platform event source (Ozone)<br/>2. Runs Browser Main Loop (content::RunContentProcess)
+
+  Note over Blink: Main Frame loads Page & DOMWindow
+  Blink->>Controller: constructs CobaltLifecycleController (Blink Supplement)
+  Manager->>Controller: Mojo: CobaltLifecycleController::SetObserver(Observer)
+  Controller->>Manager: Mojo: CobaltLifecycleObserver::OnFrameReady()
+  Note over Manager: Registers Frame in Manager
+```
+
+### F. Focus and Blur Transitions
+These sequence diagrams illustrate the asynchronous, non-blocking focus and blur transitions, showing the downward Mojo activation calls and passive Mojo observation return loops:
+
+#### 1. Focus Transition
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+  participant Shell as content::Shell <br/> (Chromium Shell)
+  participant Blink as Blink Core <br/> (Renderer)
+  participant Controller as CobaltLifecycle <br/> Controller
+  participant Manager as CobaltLifecycleManager <br/> (Observer)
+
+  OS->>Delegate: SbEvent (Focus)
+  Note over Delegate: kBlurred ➔ kStarted
+  Delegate->>Runner: OnFocus() -> DoFocus()
+  Runner->>Shell: content::Shell::OnFocus()
+  Shell->>Blink: Mojo: blink::mojom::FrameWidget::SetActive(true)
+  Note over Blink: 1. Gains keyboard focus<br/>2. Dispatches JS event: 'focus'
+  Blink-->>Controller: C++ FocusedFrameChanged()
+  Controller->>Manager: Mojo: PageFocused()
+  Note over Manager: Updates frame focus state in tracker (passive)
+  Note over Runner: DoFocus() returns immediately<br/>(Asynchronous / Non-blocking)
+
+  Runner-->>OS: DispatchFocusEvent(true) <br/> (Asynchronous Task)
+  OS->>Runner: ProcessFocusEvent(true) <br/> (via PlatformEventSource)
+  Note over Runner: PlatformWindowStarboard::Activate() <br/> (If waiting_for_reveal_ack_ is true, ignores!)
+  Runner->>OS: OnActivationChanged(true) <br/> (via PlatformWindowDelegate)
+  Note over OS: Activates Aura compositor <br/> & enables physical remote input
+```
+
+#### 2. Blur Transition
+This sequence diagram illustrates how the browser blocks the UI thread synchronously while waiting for Mojo blur ACKs from the Renderer Process, in parallel with an asynchronous storage flush:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+  participant Shell as content::Shell <br/> (Chromium Shell)
+  participant Manager as CobaltLifecycleManager <br/> (Observer)
+  participant Blink as Blink Core <br/> (Renderer)
+  participant Controller as CobaltLifecycle <br/> Controller
+  participant Content as ContentBrowserClient <br/> (Storage)
+
+  OS->>Delegate: SbEvent (Blur)
+  Note over Delegate: Resolve intermediate step:<br/>kStarted ➔ kBlurred
+  Delegate->>Runner: DoBlur()
+  Runner->>Shell: content::Shell::OnBlur()
+  Shell->>Blink: Mojo: blink::mojom::FrameWidget::SetActive(false)
+
+  Note over Runner: Asynchronous Cookies and <br/> LocalStorage flush triggered in parallel:
+  Runner->>Content: FlushCookiesAndLocalStorage(base::DoNothing())
+
+  Runner-->>OS: DispatchFocusEvent(false) <br/> (Asynchronous Task)
+  OS->>Runner: ProcessFocusEvent(false) <br/> (via PlatformEventSource)
+  Runner->>OS: OnActivationChanged(false) <br/> (via PlatformWindowDelegate)
+  Note over OS: Deactivates physical remote input
+
+  Note over Runner: Initialize visual wait state:<br/>pending_ack_ = kBlur
+  Note over Runner: WaitForAck(kBlur)<br/>(Blocks UI thread via nested RunLoop)
+
+  Note over Blink: 1. Loses focus<br/>2. Dispatches JS event: 'blur'
+  Blink-->>Controller: C++ FocusedFrameChanged()
+  Controller->>Manager: Mojo: PageBlurred()
+  Note over Manager: All active frames completed Blur!
+  Manager->>Runner: OnAllFramesBlurred(web_contents)
+  Note over Runner: Quit nested RunLoop!<br/>run_loop.Quit()
+  Note over Runner: DoBlur() returns synchronously
+  Runner-->>Delegate: DoBlur complete
+  Note over Delegate: Update canonical state:<br/>SetApplicationState(kBlurred)
+```
+
+### G. Stop Transition
+This sequence diagram illustrates how the browser process cleanly shuts down all renderer contexts, WebContents, and system-level resources upon receiving the Starboard stop event:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+  participant Shell as content::Shell <br/> (Chromium Shell)
+
+  OS->>Delegate: SbEvent (Stop)
+  Note over Delegate: kFrozen ➔ kStopped
+  Delegate->>Runner: OnStop() -> DoStop()
+  Runner->>Shell: content::Shell::OnStop()
+  Runner->>Shell: content::Shell::Shutdown()
+  Note over Shell: Destroys all WebContents & closes windows
+  Note over Runner: 1. Shuts down main delegate<br/>2. Shuts down ContentMainRunner<br/>3. Releases system resources
+
+  Delegate->>Delegate: DoTeardown()
+  Note over Delegate: 1. Sets state to kStopped<br/>2. Starboard event handler terminates
+```
+
+---
+
+## 5. Multi-Step Transition Synthesis Examples
+
+These high-level sequence diagrams illustrate how the pure sequencer (`AppEventDelegate`) and the modular orchestrator (`AppEventRunnerImpl`) coordinate to resolve complex, multi-state transitions.
+
+By design, these diagrams **end at the `AppEventRunnerImpl` boundary**, focusing on how the sequencer synthesizes multiple intermediate transition steps linearly, and how the runner orchestrates blocking vs. non-blocking calls.
+
+### A. Focus Event Received While Frozen
+This diagram shows how a single OS `Focus` event received while the application is completely frozen triggers three sequential, linear activating steps: **Unfreeze ➔ Reveal ➔ Focus**.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+
+  OS->>Delegate: SbEvent (Focus)
+  Note over Delegate: Target State = kStarted<br/>is_activating = true
+  Delegate->>Delegate: TransitionToLifeCycleState(kStarted)
+
+  %% Step 1
+  Note over Delegate: Step 1: kFrozen ➔ kConcealed (Unfreeze)
+  Delegate->>Runner: OnUnfreeze() -> DoUnfreeze()
+  Note over Runner: Synchronous Wait:<br/>Blocks UI thread inside nested RunLoop<br/>waiting for Mojo OnPageResumed ACK
+  Runner-->>Delegate: DoUnfreeze complete
+  Note over Delegate: SetApplicationState(kConcealed)
+
+  %% Step 2
+  Note over Delegate: Step 2: kConcealed ➔ kBlurred (Reveal)
+  Delegate->>Runner: OnReveal() -> DoReveal()
+  Note over Runner: Synchronous Wait:<br/>Blocks UI thread inside nested RunLoop<br/>waiting for Mojo OnPageVisibilityChanged(visible) ACK
+  Runner-->>Delegate: DoReveal complete
+  Note over Delegate: SetApplicationState(kBlurred)
+
+  %% Step 3
+  Note over Delegate: Step 3: kBlurred ➔ kStarted (Focus)
+  Delegate->>Runner: OnFocus() -> DoFocus()
+  Note over Runner: Asynchronous/Immediate:<br/>Dispatches focus event to platform/Shell<br/>without blocking UI thread
+  Runner-->>Delegate: DoFocus complete
+  Note over Delegate: SetApplicationState(kStarted)
+
+  Note over Delegate: Transition Complete!<br/>Reached target state kStarted
+```
+
+### B. Freeze Event Received While Started
+This diagram shows how a single OS `Freeze` event received while the application is running with active focus triggers three sequential, linear deactivating steps: **Blur ➔ Conceal ➔ Freeze**.
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+
+  OS->>Delegate: SbEvent (Freeze)
+  Note over Delegate: Target State = kFrozen<br/>is_activating = false
+  Delegate->>Delegate: TransitionToLifeCycleState(kFrozen)
+
+  %% Step 1
+  Note over Delegate: Step 1: kStarted ➔ kBlurred (Blur)
+  Delegate->>Runner: OnBlur() -> DoBlur()
+  Note over Runner: Synchronous Wait:<br/>Blocks UI thread inside nested RunLoop<br/>waiting for Mojo OnPageBlurred ACK
+  Runner-->>Delegate: DoBlur complete
+  Note over Delegate: SetApplicationState(kBlurred)
+
+  %% Step 2
+  Note over Delegate: Step 2: kBlurred ➔ kConcealed (Conceal)
+  Delegate->>Runner: OnConceal() -> DoConceal()
+  Note over Runner: Synchronous Wait:<br/>Blocks UI thread inside nested RunLoop<br/>waiting for Mojo OnPageVisibilityChanged(hidden) ACK
+  Runner-->>Delegate: DoConceal complete
+  Note over Delegate: SetApplicationState(kConcealed)
+
+  %% Step 3
+  Note over Delegate: Step 3: kConcealed ➔ kFrozen (Freeze)
+  Delegate->>Runner: OnFreeze() -> DoFreeze()
+  Note over Runner: Synchronous Wait:<br/>Blocks UI thread inside nested RunLoop<br/>waiting for Cookies and LocalStorage flush complete ACK
+  Runner-->>Delegate: DoFreeze complete
+  Note over Delegate: SetApplicationState(kFrozen)
+
+  Note over Delegate: Transition Complete!<br/>Reached target state kFrozen
+```
+
+---
+
+## 6. Re-Entrant Event Handling and Target Redirects
+
+Because deactivation transitions (such as Blur, Conceal, and Freeze) synchronously block the UI Main Thread in a nested `base::RunLoop`, it is highly common for new system events to arrive re-entrantly *before* the current active transition step fully completes.
+
+### Concurrency Safety Architecture:
+*   **Lock Release During Waiting**: The `AppEventDelegate` locks its state machine mutex (`lock_`) *only* when updating state or calculating steps. During the actual transition execution (`DoBlur`, `DoConceal`), the mutex **is fully unlocked**.
+*   **Re-Entrant Thread Safety**: When a new OS event arrives during a blocking wait, `HandleEvent` is executed re-entrantly on the same thread. Since the mutex is unlocked, it successfully acquires `lock_` without deadlocking!
+*   **Dynamic Target Redirection**: If a transition is already active (`is_transitioning_ == true`), the sequencer simply **updates `target_state_`** to the new event's target and returns immediately without spawning a new loop.
+*   **Linear Resolution**: Once the active blocking step receives its Mojo ACK and exits the nested loop, the sequencer updates the completed state, compares it with the *newly redirected target*, and seamlessly executes the next step in the new target's direction.
+
+### A. Deactivation Redirect: Conceal Received During Active Blur
+This diagram illustrates how an incoming `Conceal` event received during an active, blocking `Blur` transition dynamically redirects the target state, resulting in the seamless execution of `Conceal` immediately after `Blur` completes:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+
+  Note over Delegate: Application is kStarted
+  OS->>Delegate: SbEvent (Blur)
+  Note over Delegate: target_state_ = kBlurred<br/>is_transitioning_ = true
+  Delegate->>Runner: OnBlur() -> DoBlur()
+  Note over Runner: UI Thread blocks synchronously in nested loop<br/>waiting for Mojo OnPageBlurred ACK
+
+  %% Re-entrant event
+  OS->>Delegate: SbEvent (Conceal)
+  Note over Delegate: Re-entrant call! lock_ is UNLOCKED during WaitForAck.<br/>HandleEvent locks successfully.
+  Note over Delegate: Transition active. Redirect target:<br/>target_state_ = kConcealed
+  Delegate-->>OS: HandleEvent returns immediately
+
+  Note over Runner: Mojo OnPageBlurred ACK arrives
+  Note over Runner: Quit nested RunLoop!
+  Runner-->>Delegate: DoBlur complete
+  Note over Delegate: 1. Acquire lock_<br/>2. SetApplicationState(kBlurred)
+  Delegate->>Delegate: ExecuteNextStepLocked()
+  Note over Delegate: application_state_ (kBlurred) != target_state_ (kConcealed)
+  Note over Delegate: Step 2: kBlurred ➔ kConcealed (Conceal)
+  Delegate->>Runner: OnConceal() -> DoConceal()
+  Note over Runner: UI Thread blocks synchronously...
+```
+
+### B. Reversal Redirect: Conceal Received During Active Reveal
+This diagram illustrates a direction reversal: an incoming `Conceal` event is received during an active `Reveal` (activating) transition. The sequencer completes the active step first (to prevent broken rendering states), then immediately detects the reversal and executes `Conceal` to return the application to `kConcealed`:
+
+```mermaid
+sequenceDiagram
+  autonumber
+  participant OS as Starboard <br/> Event Loop
+  participant Delegate as AppEventDelegate <br/> (Sequencer)
+  participant Runner as AppEventRunnerImpl <br/> (Orchestrator)
+
+  Note over Delegate: Application is kConcealed
+  OS->>Delegate: SbEvent (Reveal)
+  Note over Delegate: target_state_ = kBlurred<br/>is_transitioning_ = true
+  Delegate->>Runner: OnReveal() -> DoReveal()
+  Note over Runner: UI Thread blocks synchronously in nested loop<br/>waiting for Mojo OnPageVisibilityChanged(visible) ACK
+
+  %% Re-entrant event
+  OS->>Delegate: SbEvent (Conceal)
+  Note over Delegate: Re-entrant call! lock_ is UNLOCKED during WaitForAck.<br/>HandleEvent locks successfully.
+  Note over Delegate: Transition active. Redirect/Reverse target:<br/>target_state_ = kConcealed
+  Delegate-->>OS: HandleEvent returns immediately
+
+  Note over Runner: Mojo OnPageVisibilityChanged(visible) ACK arrives
+  Note over Runner: Quit nested RunLoop!
+  Runner-->>Delegate: DoReveal complete
+  Note over Delegate: 1. Acquire lock_<br/>2. SetApplicationState(kBlurred)
+  Delegate->>Delegate: ExecuteNextStepLocked()
+  Note over Delegate: application_state_ (kBlurred) != target_state_ (kConcealed)
+  Note over Delegate: Sequencer detects reversal (is_activating = false)
+  Note over Delegate: Step 2: kBlurred ➔ kConcealed (Conceal)
+  Delegate->>Runner: OnConceal() -> DoConceal()
+  Note over Runner: UI Thread blocks synchronously...
+```
+
+---
+
+## 7. Detailed Coordination Steps
+
+1.  **OS Event Dispatch**: The Starboard OS event loop dispatches a system event (e.g., `Freeze`) to `AppEventDelegate`.
+2.  **Transition Sequencing**: `AppEventDelegate` locks the state machine and resolves the immediate next intermediate step (e.g., `kConcealed -> kFrozen`) via `GetNextState()`.
+3.  **Synchronous Trigger**: The delegate calls `AppEventRunnerImpl`'s corresponding transition wrapper synchronously (e.g., `DoFreeze(callback)`).
+4.  **Wait-State Injection**: The runner caches any test mock callback, sets the active wait type (`pending_ack_ = kCookieFlush`), and calls its unified blocking helper `WaitForAck()`.
+5.  **UI Main Thread Sleep**: Inside `WaitForAck()`, the runner authorizes synchronous waits, triggers the transition work (either registering Mojo layout ACKs in `CobaltLifecycleManager` OR launching local Cookies and LocalStorage flushes in `ContentBrowserClient`), and **synchronously sleeps the UI thread inside a nested `base::RunLoop`**.
+6.  **Mojo/Storage Completion**:
+    *   *Mojo Viewports*: As the Blink frame renders, it sends visibility changes over Mojo (`CobaltLifecycleObserver`). `CobaltLifecycleManager` aggregates these frame signals and broadcasts completion (e.g., `OnAllFramesConcealed`) back to the runner.
+    *   *Disk Storage*: Once the Cookies and LocalStorage storage thread finishes writing files to disk, the storage client executes the runner's local callback `OnCookieFlushComplete()`.
+7.  **Nested Loop Quit**: The runner's callback handler receives the completion signal and calls `run_loop.Quit()`, waking up the sleeping UI thread.
+8.  **State Finalization**: The nested loop exits, `WaitForAck()` returns, the runner transition wrapper returns synchronously to `AppEventDelegate`, and the delegate immediately updates its canonical state (`SetApplicationState(kFrozen)`), safely triggering the next sequential step.
+
+---
+
+## 8. Starboard Thread Restrictions Whitelisting
+
+To prevent UI janks and deadlocks, Chromium strictly disallows any synchronous blocking wait primitives on the **Browser UI Main Thread** by default:
+
+*   **The Starboard Pump Constraint**: On Starboard-based platforms, Cobalt implements **`base::MessagePumpUIStarboard`** which blocks using **`base::WaitableEvent`** under the hood when running nested `base::RunLoop` blocks. This immediately triggers Chromium's thread-restriction assertions (`DCHECK`) and aborts the process!
+*   **The Resolution**: We utilize **`base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope`** inside `WaitForAck()` to authorize the thread to block during critical, unavoidable OS deactivation events.
+*   **Layering Whitelist**: To prevent arbitrary developer abuse, Chromium whitelists instantiation of this Scoped helper using a strict **`friend class`** list in **`base/threading/thread_restrictions.h`**. Since `AppEventRunnerImpl` is our high-level modular shell orchestrator, we whitelist it inside the base library and guard the addition cleanly using **`#if BUILDFLAG(IS_COBALT)`**:
+
+```cpp
+#if BUILDFLAG(IS_COBALT)
+  // Cobalt's platform deactivation lifecycle transitions (Reveal, Conceal,
+  // Freeze, Unfreeze, Blur) synchronously block the UI Main Thread using a nested
+  // base::RunLoop to guarantee atomic, linear state progression. Since
+  // Starboard's custom base::MessagePumpUIStarboard blocks using
+  // base::WaitableEvent under the hood, we must explicitly whitelist the modular
+  // platform shell runner here to authorize main-thread sync waiting.
+  friend class cobalt::AppEventRunnerImpl;
+#endif  // BUILDFLAG(IS_COBALT)
+```

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -59,6 +59,9 @@ group("cobalt_shell_lib_deps") {
     "//base/third_party/dynamic_annotations",
     "//cc/base",
     "//cobalt/browser:switches",
+    "//cobalt/browser/crash_annotator/public/mojom:mojom",
+    "//cobalt/browser/h5vcc_runtime",
+    "//cobalt/browser/lifecycle:lifecycle",
     "//cobalt/shell/browser/migrate_storage_record",
     "//components/cdm/renderer",
     "//components/crash/content/browser",
@@ -68,7 +71,7 @@ group("cobalt_shell_lib_deps") {
     "//components/keyed_service/content",
     "//components/metrics",
     "//components/metrics:net",
-    "//components/network_hints/browser:browser",
+    "//components/network_hints/browser",
     "//components/network_hints/renderer",
     "//components/network_session_configurator/common",
     "//components/performance_manager",
@@ -96,6 +99,7 @@ group("cobalt_shell_lib_deps") {
     "//third_party/blink/public/strings:accessibility_strings",
     "//ui/gfx",
     "//ui/gfx/geometry",
+    "//ui/platform_window",
     "//url",
     "//v8",
   ]
@@ -105,7 +109,6 @@ group("cobalt_shell_lib_deps") {
       "//ui/base",
       "//ui/base/clipboard",
       "//ui/base/ime/init",
-      "//ui/platform_window",
     ]
   }
 
@@ -139,6 +142,9 @@ group("cobalt_shell_lib_deps") {
       "//ui/events",
       "//ui/wm",
     ]
+    if (is_starboard) {
+      public_deps += [ "//ui/ozone/platform/starboard" ]
+    }
 
     if (shell_use_toolkit_views) {
       public_deps += [

--- a/cobalt/shell/browser/lifecycle_unittest.cc
+++ b/cobalt/shell/browser/lifecycle_unittest.cc
@@ -82,14 +82,28 @@ TEST_F(LifecycleTest, Reveal) {
   EXPECT_FALSE(platform_->IsVisible());
   EXPECT_EQ(shell_->web_contents()->GetVisibility(), Visibility::HIDDEN);
 
+  // Simulate that the frame was visible before conceal, so OnReveal will
+  // trigger WasShown().
+  platform_->AddPreviouslyVisibleWebContentsForTesting(shell_->web_contents());
+
   // Trigger reveal.
   EXPECT_CALL(*platform_, OnReveal()).WillOnce([this]() {
     platform_->ShellPlatformDelegate::OnReveal();
   });
-  EXPECT_CALL(*platform_, RevealShell(shell_));
+  EXPECT_CALL(*platform_, RevealShell(shell_))
+      .WillOnce(
+          [](content::Shell* shell) { shell->web_contents()->WasShown(); });
   Shell::OnReveal();
 
   EXPECT_TRUE(platform_->IsVisible());
+  // Visibility should now be VISIBLE because we called WasShown() in OnReveal
+  // to unblock the renderer.
+  EXPECT_EQ(shell_->web_contents()->GetVisibility(), Visibility::VISIBLE);
+
+  // Simulate Reveal ACK.
+  platform_->OnPageVisibilityVisible(shell_);
+
+  // Now visibility should be VISIBLE.
   EXPECT_EQ(shell_->web_contents()->GetVisibility(), Visibility::VISIBLE);
 }
 
@@ -119,6 +133,12 @@ TEST_F(LifecycleTest, Conceal) {
   });
   EXPECT_CALL(*platform_, ConcealShell(shell_));
   Shell::OnConceal();
+
+  // Symmetrical unit-test trigger: since there are no active Blink frames to
+  // dispatch Mojo visibility ACKs, we manually invoke the observer callback
+  // on the platform manager base class.
+  static_cast<cobalt::CobaltLifecycleManagerObserver*>(platform_)
+      ->OnAllFramesConcealed(shell_->web_contents());
 
   EXPECT_FALSE(platform_->IsVisible());
   EXPECT_EQ(shell_->web_contents()->GetVisibility(), Visibility::HIDDEN);

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -34,7 +34,6 @@
 #include "base/task/bind_post_task.h"
 #include "build/build_config.h"
 #include "cobalt/browser/switches.h"
-#include "cobalt/shell/app/resource.h"
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
 #include "cobalt/shell/browser/shell_content_browser_client.h"
 #include "cobalt/shell/browser/shell_devtools_frontend.h"
@@ -541,11 +540,6 @@ void Shell::DidFinishNavigation(NavigationHandle* navigation_handle) {
 }
 
 void Shell::DidStopLoading() {
-  // Set initial focus to the web content.
-  if (web_contents()->GetRenderWidgetHostView()) {
-    web_contents()->GetRenderWidgetHostView()->Focus();
-  }
-
   if (!is_main_frame_loaded_ &&
       splash_state_ != STATE_SPLASH_SCREEN_UNINITIALIZED) {
     VLOG(1) << "NativeSplash: Main frame WebContents DidStopLoading.";
@@ -933,8 +927,9 @@ void Shell::RendererUnresponsive(
 }
 
 void Shell::ActivateContents(WebContents* contents) {
-  // TODO(danakj): Move this to ShellPlatformDelegate.
-  contents->Focus();
+  if (!g_platform->IsWaitingForRevealAck()) {
+    contents->GetPrimaryMainFrame()->GetRenderWidgetHost()->Focus();
+  }
 }
 
 void Shell::RunFileChooser(RenderFrameHost* render_frame_host,
@@ -1055,6 +1050,10 @@ bool Shell::CheckMediaAccessPermission(RenderFrameHost*,
                                        const GURL&,
                                        blink::mojom::MediaStreamType) {
   return true;
+}
+
+bool Shell::ShouldFocusPageAfterCrash() {
+  return !g_platform->IsWaitingForRevealAck();
 }
 
 gfx::Size Shell::GetShellDefaultSize() {

--- a/cobalt/shell/browser/shell.h
+++ b/cobalt/shell/browser/shell.h
@@ -138,6 +138,7 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
   WebContents* web_contents() const { return web_contents_.get(); }
 
   void Focus();
+  bool pending_focus() const { return pending_focus_; }
 
   WebContents* splash_screen_web_contents() const {
     return splash_screen_web_contents_.get();
@@ -218,6 +219,7 @@ class Shell : public WebContentsDelegate, public WebContentsObserver {
   bool CheckMediaAccessPermission(RenderFrameHost*,
                                   const GURL&,
                                   blink::mojom::MediaStreamType) override;
+  bool ShouldFocusPageAfterCrash() override;
 
   static gfx::Size GetShellDefaultSize();
 

--- a/cobalt/shell/browser/shell_browser_main_parts.cc
+++ b/cobalt/shell/browser/shell_browser_main_parts.cc
@@ -240,6 +240,7 @@ void ShellBrowserMainParts::PostMainMessageLoopRun() {
 #if BUILDFLAG(IS_LINUX)
   ui::LinuxUi::SetInstance(nullptr);
 #endif
+  base::RunLoop().RunUntilIdle();
   performance_manager_lifetime_.reset();
 }
 

--- a/cobalt/shell/browser/shell_platform_data_aura.cc
+++ b/cobalt/shell/browser/shell_platform_data_aura.cc
@@ -18,17 +18,23 @@
 
 #include "base/memory/raw_ptr.h"
 #include "build/build_config.h"
+#include "build/buildflag.h"
 #include "cobalt/shell/browser/shell.h"
 #include "ui/aura/client/default_capture_client.h"
 #include "ui/aura/env.h"
 #include "ui/aura/layout_manager.h"
 #include "ui/aura/window.h"
 #include "ui/aura/window_event_dispatcher.h"
+#include "ui/aura/window_tree_host_platform.h"
 #include "ui/base/ime/init/input_method_factory.h"
 #include "ui/base/ime/input_method.h"
 #include "ui/ozone/public/ozone_platform.h"
 #include "ui/platform_window/platform_window_init_properties.h"
 #include "ui/wm/core/default_activation_client.h"
+
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+#include "ui/ozone/platform/starboard/platform_window_starboard.h"
+#endif
 
 #if BUILDFLAG(IS_OZONE)
 #include "ui/aura/screen_ozone.h"
@@ -122,7 +128,18 @@ ShellPlatformDataAura::ShellPlatformDataAura(const gfx::Size& initial_size) {
 
   host_ = aura::WindowTreeHost::Create(std::move(properties));
   host_->InitHost();
+  auto* host_platform = static_cast<aura::WindowTreeHostPlatform*>(host_.get());
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+  auto* pw_starboard = static_cast<ui::PlatformWindowStarboard*>(
+      host_platform->platform_window());
+  bool is_waiting = content::Shell::GetPlatform()->IsWaitingForRevealAck();
+  pw_starboard->SetWaitingForRevealAck(is_waiting);
+  if (!is_waiting) {
+    host_->window()->Show();
+  }
+#else
   host_->window()->Show();
+#endif
   host_->window()->SetLayoutManager(
       std::make_unique<FillLayout>(host_->window()));
 

--- a/cobalt/shell/browser/shell_platform_delegate.cc
+++ b/cobalt/shell/browser/shell_platform_delegate.cc
@@ -15,15 +15,46 @@
 #include "cobalt/shell/browser/shell_platform_delegate.h"
 
 #include "base/logging.h"
-#include "base/notreached.h"
+#include "base/threading/hang_watcher.h"
+#include "build/build_config.h"
+#include "build/buildflag.h"
+#include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
 #include "cobalt/shell/browser/shell.h"
 #include "content/public/browser/file_select_listener.h"
 #include "content/public/browser/javascript_dialog_manager.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/render_widget_host.h"
+#include "content/public/browser/render_widget_host_view.h"
+#include "content/public/browser/visibility.h"
 #include "content/public/browser/web_contents.h"
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+#include "ui/aura/window_tree_host_platform.h"
+#include "ui/ozone/platform/starboard/platform_window_starboard.h"
+#endif
 
 namespace content {
+
+namespace {
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+ui::PlatformWindowStarboard* GetPlatformWindowStarboard(Shell* shell) {
+  auto* native_view = shell->web_contents()->GetNativeView();
+  if (!native_view) {
+    return nullptr;
+  }
+  auto* root_window = native_view->GetRootWindow();
+  if (!root_window) {
+    return nullptr;
+  }
+  auto* host = root_window->GetHost();
+  if (!host) {
+    return nullptr;
+  }
+  auto* host_platform = static_cast<aura::WindowTreeHostPlatform*>(host);
+  return static_cast<ui::PlatformWindowStarboard*>(
+      host_platform->platform_window());
+}
+#endif
+}  // namespace
 
 bool ShellPlatformDelegate::IsVisible() const {
   return is_visible_;
@@ -46,6 +77,10 @@ void ShellPlatformDelegate::OnFocus() {
   if (!IsVisible()) {
     return;
   }
+  if (IsWaitingForRevealAck()) {
+    deferred_focus_ = true;
+    return;
+  }
   for (auto* shell : Shell::windows()) {
     shell->Focus();
   }
@@ -55,26 +90,62 @@ void ShellPlatformDelegate::OnConceal() {
   if (!IsVisible()) {
     return;
   }
+
+  // Register as lifecycle manager observer to receive OnAllFramesConcealed
+  // callback!
+  cobalt::CobaltLifecycleManager::GetInstance()->AddObserver(
+      static_cast<cobalt::CobaltLifecycleManagerObserver*>(this));
+
+  // Save the set of WebContents that were visible before conceal.
+  // This is used on reveal to decide which WebContents we should wait for
+  // Reveal ACK from. We only wait for those that were actually active/visible.
+  previously_visible_web_contents_.clear();
   for (auto* shell : Shell::windows()) {
+    if (shell->web_contents()->GetVisibility() ==
+        content::Visibility::VISIBLE) {
+      previously_visible_web_contents_.insert(shell->web_contents());
+    }
+    // Trigger logical JS conceal.
     shell->web_contents()->WasHidden();
-    ConcealShell(shell);
+    // Note: ConcealShell() is called asynchronously inside
+    // OnAllFramesConcealed() after all frames have completed their deactivation
+    // ACKs.
   }
-  is_visible_ = false;
 }
 
 void ShellPlatformDelegate::OnReveal() {
   if (IsVisible()) {
     return;
   }
+  // Used to ensure we only register as observer once, even if there are
+  // multiple windows to wait for.
+  bool started_waiting = false;
   for (auto* shell : Shell::windows()) {
+    if (previously_visible_web_contents_.count(shell->web_contents())) {
+      if (!started_waiting) {
+        waiting_for_reveal_ack_ = true;
+        cobalt::CobaltLifecycleManager::GetInstance()->AddObserver(
+            static_cast<cobalt::CobaltLifecycleManagerObserver*>(this));
+        started_waiting = true;
+      }
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+      auto* platform_window = GetPlatformWindowStarboard(shell);
+      if (platform_window) {
+        platform_window->SetWaitingForRevealAck(true);
+      }
+#endif
+    }
     RevealShell(shell);
-    shell->web_contents()->WasShown();
   }
   is_visible_ = true;
 }
 
 void ShellPlatformDelegate::OnFreeze() {
   CHECK(!IsVisible());
+
+  // In frozen state the process may not be scheduled for execution, so we
+  // tell the hang watcher to ignore this period of inactivity.
+  base::HangWatcher::Suspend();
   for (auto* shell : Shell::windows()) {
     shell->web_contents()->SetPageFrozen(true);
   }
@@ -82,16 +153,15 @@ void ShellPlatformDelegate::OnFreeze() {
 
 void ShellPlatformDelegate::OnUnfreeze() {
   CHECK(!IsVisible());
+
+  // Resume the hangwatcher.
+  base::HangWatcher::Resume();
   for (auto* shell : Shell::windows()) {
     shell->web_contents()->SetPageFrozen(false);
   }
 }
 
 void ShellPlatformDelegate::OnStop() {}
-
-void ShellPlatformDelegate::DidCreateOrAttachWebContents(
-    Shell* shell,
-    WebContents* web_contents) {}
 
 void ShellPlatformDelegate::DidCloseLastWindow() {
   Shell::Shutdown();
@@ -123,4 +193,111 @@ void ShellPlatformDelegate::RunFileChooser(
 }
 #endif
 
+void ShellPlatformDelegate::OnPageVisibilityVisible(Shell* shell) {
+  waiting_for_reveal_ack_ = false;
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+  auto* platform_window = GetPlatformWindowStarboard(shell);
+  if (platform_window) {
+    platform_window->SetWaitingForRevealAck(false);
+  }
+  auto* native_view = shell->web_contents()->GetNativeView();
+  if (native_view) {
+    if (native_view->GetRootWindow()) {
+      native_view->GetRootWindow()->Show();
+    }
+    native_view->Show();
+  }
+#endif
+  shell->web_contents()->WasShown();
+}
+
+bool ShellPlatformDelegate::IsWaitingForRevealAck() const {
+  bool new_is_waiting = false;
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+  auto* shell = Shell::windows().empty() ? nullptr : Shell::windows().front();
+  if (shell) {
+    auto* platform_window = GetPlatformWindowStarboard(shell);
+    if (platform_window) {
+      new_is_waiting = platform_window->IsWaitingForRevealAck();
+    }
+  }
+#endif
+  // We check both the internal flag and the platform window state.
+  // The platform window needs to track this state to block focus events
+  // synchronously. However, during early resume stages, the platform window
+  // might not be accessible, so we must also maintain the state internally
+  // in ShellPlatformDelegate to avoid losing it.
+  // We cannot simply assume it is true when the platform window is
+  // inaccessible, because that is also the case during initial startup, where
+  // we are NOT waiting for a reveal ACK and must not block focus.
+  // Furthermore, we need the local flag to override the platform window state
+  // if it holds a stale 'false' value (e.g., if it was non-null but not yet
+  // updated when queried).
+  return waiting_for_reveal_ack_ || new_is_waiting;
+}
+
+void ShellPlatformDelegate::ClearWaitingForRevealAck() {
+  waiting_for_reveal_ack_ = false;
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+  auto* shell = Shell::windows().empty() ? nullptr : Shell::windows().front();
+  if (shell) {
+    auto* platform_window = GetPlatformWindowStarboard(shell);
+    if (platform_window) {
+      platform_window->SetWaitingForRevealAck(false);
+    }
+  }
+#endif
+}
+
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+void ShellPlatformDelegate::OnProactiveMapWindow(
+    content::WebContents* web_contents) {
+  Shell* shell = Shell::FromWebContents(web_contents);
+  if (shell) {
+    SetContents(shell);
+    MapWindowShell(shell);
+  }
+}
+#endif
+
+void ShellPlatformDelegate::OnAllFramesVisible(
+    content::WebContents* web_contents) {
+  // Called by CobaltLifecycleManager when all frames in the specified
+  // WebContents have completed layout and are visible. This breaks the wait
+  // initiated in OnReveal.
+  ClearWaitingForRevealAck();
+  is_visible_ = true;
+
+  // If an OS focus event arrived while we were waiting, apply it now that
+  // the page is ready.
+  if (deferred_focus_) {
+    for (auto* w : Shell::windows()) {
+      w->Focus();
+    }
+    deferred_focus_ = false;
+  }
+
+  // Stop observing as we only need one notification per reveal.
+  cobalt::CobaltLifecycleManager::GetInstance()->RemoveObserver(
+      static_cast<cobalt::CobaltLifecycleManagerObserver*>(this));
+}
+
+void ShellPlatformDelegate::OnAllFramesConcealed(
+    content::WebContents* web_contents) {
+  Shell* shell = Shell::FromWebContents(web_contents);
+  if (shell) {
+    ConcealShell(shell);
+  }
+  is_visible_ = false;
+
+  // Stop observing as we only need one notification per conceal.
+  cobalt::CobaltLifecycleManager::GetInstance()->RemoveObserver(
+      static_cast<cobalt::CobaltLifecycleManagerObserver*>(this));
+}
+
+#if !defined(USE_AURA) || !BUILDFLAG(IS_STARBOARD)
+void ShellPlatformDelegate::DidCreateOrAttachWebContents(
+    Shell* shell,
+    WebContents* web_contents) {}
+#endif
 }  // namespace content

--- a/cobalt/shell/browser/shell_platform_delegate.h
+++ b/cobalt/shell/browser/shell_platform_delegate.h
@@ -16,11 +16,12 @@
 #define COBALT_SHELL_BROWSER_SHELL_PLATFORM_DELEGATE_H_
 
 #include <memory>
+#include <set>
 #include <string>
 
 #include "base/containers/flat_map.h"
-#include "base/memory/scoped_refptr.h"
 #include "build/build_config.h"
+#include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
 #include "third_party/blink/public/mojom/choosers/file_chooser.mojom-forward.h"
 #include "ui/gfx/geometry/size.h"
 #include "ui/gfx/native_widget_types.h"
@@ -46,7 +47,7 @@ class CobaltShellTestBase;
 class RenderFrameHost;
 class WebContents;
 
-class ShellPlatformDelegate {
+class ShellPlatformDelegate : public cobalt::CobaltLifecycleManagerObserver {
  public:
   enum UIControl { BACK_BUTTON, FORWARD_BUTTON, STOP_BUTTON };
 
@@ -70,6 +71,9 @@ class ShellPlatformDelegate {
   virtual void OnStop();
 
   virtual void RevealShell(Shell* shell);
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+  virtual void MapWindowShell(Shell* shell);
+#endif
   virtual void ConcealShell(Shell* shell);
 
   // Called after creating a Shell instance, with its initial size.
@@ -119,6 +123,9 @@ class ShellPlatformDelegate {
   // from WebContentsObserver. If navigation creates a new main frame, this may
   // occur more than once.
   virtual void MainFrameCreated(Shell* shell);
+  virtual void OnPageVisibilityVisible(Shell* shell);
+  bool IsWaitingForRevealAck() const;
+  void ClearWaitingForRevealAck();
 
   // Allows platforms to override the JavascriptDialogManager. By default
   // returns null, which signals that the Shell should use its own instance.
@@ -146,6 +153,11 @@ class ShellPlatformDelegate {
   virtual void RunFileChooser(RenderFrameHost* render_frame_host,
                               scoped_refptr<FileSelectListener> listener,
                               const blink::mojom::FileChooserParams& params);
+
+  void AddPreviouslyVisibleWebContentsForTesting(
+      content::WebContents* web_contents) {
+    previously_visible_web_contents_.insert(web_contents);
+  }
 
 #if !BUILDFLAG(IS_ANDROID)
   // Returns the native window. Valid after calling CreatePlatformWindow().
@@ -190,6 +202,17 @@ class ShellPlatformDelegate {
 #endif
 
  private:
+  // CobaltLifecycleManagerObserver implementation.
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+  void OnProactiveMapWindow(content::WebContents* web_contents) override;
+#endif
+  void OnAllFramesVisible(content::WebContents* web_contents) override;
+  void OnAllFramesConcealed(content::WebContents* web_contents) override;
+
+  // Flag to remember that an OS-initiated focus event arrived while we were
+  // waiting for Reveal ACK. If true, focus will be applied to the window
+  // as soon as OnAllFramesVisible is called.
+  bool deferred_focus_ = false;
   friend class ShellTestBase;
 #if BUILDFLAG(IS_APPLE)
   std::unique_ptr<display::ScopedNativeScreen> screen_;
@@ -202,6 +225,16 @@ class ShellPlatformDelegate {
   base::flat_map<Shell*, ShellData> shell_data_map_;
 
   bool is_visible_ = true;
+  // This flag tracks whether we are waiting for the web app to acknowledge
+  // becoming visible (Reveal ACK). We need this local copy because the
+  // source of truth in PlatformWindowStarboard is not accessible during
+  // early resume stages (root_window is null).
+  bool waiting_for_reveal_ack_ = false;
+
+  // Set of WebContents that were visible before the application was concealed.
+  // This is used on reveal to decide which WebContents we should wait for
+  // Reveal ACK from. We only wait for those that were active before.
+  std::set<content::WebContents*> previously_visible_web_contents_;
 
   // Data held in ShellPlatformDelegate that is shared between all Shells. This
   // is created in Initialize(), and is defined for each platform

--- a/cobalt/shell/browser/shell_platform_delegate_aura.cc
+++ b/cobalt/shell/browser/shell_platform_delegate_aura.cc
@@ -22,6 +22,8 @@
 #include "ui/aura/env.h"
 #include "ui/aura/window.h"
 #include "ui/aura/window_event_dispatcher.h"
+#include "ui/aura/window_tree_host_platform.h"
+#include "ui/platform_window/platform_window.h"
 
 namespace content {
 
@@ -87,7 +89,7 @@ void ShellPlatformDelegate::CleanUp(Shell* shell) {
 
 void ShellPlatformDelegate::SetContents(Shell* shell) {
   aura::Window* content = shell->web_contents()->GetNativeView();
-  if (!platform_->aura) {
+  if (!platform_ || !platform_->aura) {
     return;
   }
   aura::Window* parent = platform_->aura->host()->window();
@@ -104,13 +106,27 @@ void ShellPlatformDelegate::RevealShell(Shell* shell) {
     CreatePlatformWindowInternal(shell, shell_data.initial_size_);
     SetContents(shell);
   }
-
-  platform_->aura->host()->Show();
+}
+void ShellPlatformDelegate::MapWindowShell(Shell* shell) {
+  if (!platform_ || !platform_->aura || !platform_->aura->host()) {
+    return;
+  }
+  auto* host =
+      static_cast<aura::WindowTreeHostPlatform*>(platform_->aura->host());
+  if (host && host->platform_window()) {
+    host->platform_window()->Show(true);
+  }
 }
 
 void ShellPlatformDelegate::ConcealShell(Shell* shell) {
+  if (!platform_ || !platform_->aura || !platform_->aura->host()) {
+    return;
+  }
   platform_->aura->host()->Hide();
 }
+void ShellPlatformDelegate::DidCreateOrAttachWebContents(
+    Shell* shell,
+    WebContents* web_contents) {}
 
 void ShellPlatformDelegate::LoadSplashScreenContents(Shell* shell) {}
 

--- a/cobalt/shell/browser/shell_platform_delegate_views.cc
+++ b/cobalt/shell/browser/shell_platform_delegate_views.cc
@@ -23,20 +23,25 @@
 #include "base/memory/raw_ptr.h"
 #include "base/strings/utf_string_conversions.h"
 #include "build/build_config.h"
+#include "build/buildflag.h"
+#include "cobalt/shell/browser/cobalt_views_delegate.h"
 #include "cobalt/shell/browser/shell.h"
 #include "cobalt/shell/browser/shell_platform_delegate.h"
 #include "content/public/browser/context_factory.h"
+#include "content/public/browser/render_widget_host.h"
 #include "content/public/browser/render_widget_host_view.h"
 #include "content/public/browser/web_contents.h"
 #include "ui/aura/env.h"
 #include "ui/aura/window.h"
 #include "ui/aura/window_event_dispatcher.h"
 #include "ui/aura/window_tree_host.h"
+#include "ui/aura/window_tree_host_platform.h"
 #include "ui/base/clipboard/clipboard.h"
 #include "ui/base/metadata/metadata_header_macros.h"
 #include "ui/base/metadata/metadata_impl_macros.h"
 #include "ui/base/resource/resource_bundle.h"
 #include "ui/color/color_id.h"
+#include "ui/compositor/compositor.h"
 #include "ui/display/screen.h"
 #include "ui/events/event.h"
 #include "ui/views/background.h"
@@ -55,9 +60,44 @@
 #include "ui/views/widget/widget_delegate.h"
 #include "ui/wm/core/wm_state.h"
 
-#include "cobalt/shell/browser/cobalt_views_delegate.h"
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+#include "ui/ozone/platform/starboard/platform_window_starboard.h"
+#endif
 
 namespace content {
+
+namespace {
+#if BUILDFLAG(IS_STARBOARD)
+bool CheckAndHandleRevealState(WebContents* web_contents) {
+  gfx::NativeView window = web_contents->GetNativeView();
+  if (!window) {
+    return false;
+  }
+  aura::WindowTreeHost* host = window->GetHost();
+  if (!host) {
+    return false;
+  }
+  auto* host_platform = static_cast<aura::WindowTreeHostPlatform*>(host);
+  ui::PlatformWindow* platform_window = host_platform->platform_window();
+  if (!platform_window) {
+    return false;
+  }
+
+#if defined(USE_AURA) && BUILDFLAG(IS_STARBOARD)
+  auto* pw_starboard =
+      static_cast<ui::PlatformWindowStarboard*>(platform_window);
+  bool is_waiting = pw_starboard->IsWaitingForRevealAck() ||
+                    content::Shell::GetPlatform()->IsWaitingForRevealAck();
+  if (is_waiting && !pw_starboard->IsWaitingForRevealAck()) {
+    pw_starboard->SetWaitingForRevealAck(true);
+  }
+  return is_waiting;
+#else
+  return content::Shell::GetPlatform()->IsWaitingForRevealAck();
+#endif
+}
+#endif
+}  // namespace
 
 struct ShellPlatformDelegate::ShellData {
   gfx::Size content_size;
@@ -111,7 +151,17 @@ class ShellView : public views::BoxLayoutView,
                       .SetWebContents(web_contents)
                       .SetPreferredSize(size))
         .BuildChildren();
-    web_contents->Focus();
+
+    bool should_focus = true;
+#if BUILDFLAG(IS_STARBOARD)
+    if (CheckAndHandleRevealState(web_contents)) {
+      should_focus = false;
+    }
+#endif
+
+    if (should_focus) {
+      web_contents->GetPrimaryMainFrame()->GetRenderWidgetHost()->Focus();
+    }
     web_view_->SizeToPreferredSize();
 
     // Resize the widget, keeping the same origin.
@@ -313,7 +363,10 @@ ShellView* ShellViewForWidget(views::Widget* widget) {
 }  // namespace
 
 ShellPlatformDelegate::ShellPlatformDelegate() = default;
-ShellPlatformDelegate::~ShellPlatformDelegate() = default;
+ShellPlatformDelegate::~ShellPlatformDelegate() {
+  cobalt::CobaltLifecycleManager::GetInstance()->RemoveObserver(
+      static_cast<cobalt::CobaltLifecycleManagerObserver*>(this));
+}
 
 std::unique_ptr<views::ViewsDelegate>
 ShellPlatformDelegate::CreateViewsDelegate() {
@@ -389,32 +442,100 @@ void ShellPlatformDelegate::SetContents(Shell* shell) {
   ShellData& shell_data = shell_data_map_[shell];
 
   if (shell_data.window_widget) {
-    ShellViewForWidget(shell_data.window_widget)
-        ->SetWebContents(shell->web_contents(), shell_data.content_size);
+    auto* shell_view = ShellViewForWidget(shell_data.window_widget);
+    if (shell_view) {
+      shell_view->SetWebContents(shell->web_contents(),
+                                 shell_data.content_size);
+    }
 
     SkColor bg_color = shell_data.window_widget->GetColorProvider()->GetColor(
         ui::kColorWindowBackground);
     views::WebContentsSetBackgroundColor::CreateForWebContentsWithColor(
         shell->web_contents(), bg_color);
-
-    shell_data.window_widget->GetNativeWindow()->GetHost()->Show();
-    shell_data.window_widget->Show();
+  }
+}
+void ShellPlatformDelegate::DidCreateOrAttachWebContents(
+    Shell* shell,
+    WebContents* web_contents) {
+  auto it = shell_data_map_.find(shell);
+  if (it == shell_data_map_.end()) {
+    return;
+  }
+  ShellData& shell_data = it->second;
+  if (shell_data.window_widget) {
+    // Safely map native views window Show and Restore on initial startup!
+    shell_data.window_widget->GetNativeWindow()->Show();
+    shell_data.window_widget->Restore();
   }
 }
 void ShellPlatformDelegate::RevealShell(Shell* shell) {
-  ShellData& shell_data = shell_data_map_.at(shell);
+  // Dynamically re-enable Chromium's thread watchdog on resume!
+  auto it = shell_data_map_.find(shell);
+  if (it == shell_data_map_.end()) {
+    LOG(ERROR) << "RevealShell called for untracked shell!";
+    return;
+  }
+  ShellData& shell_data = it->second;
   if (!shell_data.window_widget) {
     CreatePlatformWindowInternal(shell, shell_data.initial_size_);
+    SetContents(shell);
+  } else {
+    auto* native_window = shell_data.window_widget->GetNativeWindow();
+    if (native_window && native_window->GetHost()) {
+      auto* host_platform =
+          static_cast<aura::WindowTreeHostPlatform*>(native_window->GetHost());
+      auto* platform_window = static_cast<ui::PlatformWindowStarboard*>(
+          host_platform->platform_window());
+      if (platform_window) {
+        platform_window->Restore();
+      }
+    }
   }
-
-  SetContents(shell);
 }
-void ShellPlatformDelegate::ConcealShell(Shell* shell) {
-  ShellData& shell_data = shell_data_map_.at(shell);
+void ShellPlatformDelegate::MapWindowShell(Shell* shell) {
+  auto it = shell_data_map_.find(shell);
+  if (it == shell_data_map_.end()) {
+    LOG(ERROR) << "MapWindowShell called for untracked shell!";
+    return;
+  }
+  ShellData& shell_data = it->second;
   if (shell_data.window_widget) {
-    ShellViewForWidget(shell_data.window_widget)->ReleaseShell();
-    shell_data.window_widget->CloseNow();
-    shell_data.window_widget = nullptr;
+    auto* native_window = shell_data.window_widget->GetNativeWindow();
+    if (native_window && native_window->GetHost() &&
+        native_window->GetHost()->compositor()) {
+      native_window->GetHost()->compositor()->SetVisible(true);
+    }
+    if (native_window) {
+      native_window->Show();
+      shell_data.window_widget->Restore();
+      shell_data.window_widget->LayoutRootViewIfNecessary();
+    }
+  }
+}
+
+void ShellPlatformDelegate::ConcealShell(Shell* shell) {
+  // Dynamically disable Chromium's thread watchdog during deactivation/freeze!
+  auto it = shell_data_map_.find(shell);
+  if (it == shell_data_map_.end()) {
+    LOG(ERROR) << "ConcealShell called for untracked shell!";
+    return;
+  }
+  ShellData& shell_data = it->second;
+  if (shell_data.window_widget) {
+    // Forcefully set compositor invisible to satisfy accelerated widget release
+    // assertions natively.
+    if (shell_data.window_widget->GetNativeWindow() &&
+        shell_data.window_widget->GetNativeWindow()->GetHost() &&
+        shell_data.window_widget->GetNativeWindow()->GetHost()->compositor()) {
+      auto* compositor =
+          shell_data.window_widget->GetNativeWindow()->GetHost()->compositor();
+      compositor->SetVisible(false);
+    }
+    // Restore spec-compliant Minimize and Hide window widget deactivation!
+
+    shell_data.window_widget->Minimize();
+    shell_data.window_widget->GetNativeWindow()->Hide();
+    shell_data.window_widget->Hide();
   }
 }
 

--- a/cobalt/shell/browser/shell_test_support.h
+++ b/cobalt/shell/browser/shell_test_support.h
@@ -22,11 +22,13 @@
 
 #include "base/command_line.h"
 #include "base/memory/raw_ptr.h"
+#include "build/build_config.h"
 #include "cobalt/shell/browser/shell.h"
 #include "cobalt/shell/browser/shell_platform_delegate.h"
 #include "content/browser/accessibility/browser_accessibility_state_impl.h"
 #include "content/public/browser/browser_accessibility_state.h"
 #include "content/public/common/content_switches.h"
+#include "content/public/common/network_service_util.h"
 #include "content/public/test/browser_task_environment.h"
 #include "content/public/test/test_browser_context.h"
 #include "content/public/test/test_content_client_initializer.h"
@@ -34,9 +36,17 @@
 #include "mojo/core/embedder/embedder.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
-#include "ui/aura/env.h"
 #include "ui/base/resource/resource_bundle.h"
+#include "ui/events/devices/device_data_manager.h"
+#include "ui/gfx/geometry/size.h"
+#if BUILDFLAG(IS_ANDROID)
+#include "base/android/jni_android.h"
+#endif
+
+#if defined(USE_AURA)
+#include "ui/aura/env.h"
 #include "ui/views/views_delegate.h"
+#endif
 
 namespace content {
 
@@ -88,14 +98,18 @@ class TestBrowserAccessibilityState : public BrowserAccessibilityStateImpl {
 class MojoInitializer {
  public:
   MojoInitializer() {
+#if defined(USE_AURA)
     if (!aura::Env::HasInstance()) {
       aura_env_ = aura::Env::CreateInstance();
     }
+#endif
     mojo::core::Init();
   }
 
  private:
+#if defined(USE_AURA)
   std::unique_ptr<aura::Env> aura_env_;
+#endif
 };
 
 class ShellTestBase : public ::testing::Test {
@@ -105,6 +119,28 @@ class ShellTestBase : public ::testing::Test {
   ~ShellTestBase() override = default;
 
   void SetUp() override {
+#if BUILDFLAG(IS_ANDROID)
+    JNIEnv* env = base::android::AttachCurrentThread();
+    jclass looper_clazz = env->FindClass("android/os/Looper");
+    jmethodID my_looper_method = env->GetStaticMethodID(
+        looper_clazz, "myLooper", "()Landroid/os/Looper;");
+    jobject looper =
+        env->CallStaticObjectMethod(looper_clazz, my_looper_method);
+    if (!looper) {
+      jmethodID prepare_method =
+          env->GetStaticMethodID(looper_clazz, "prepare", "()V");
+      env->CallStaticVoidMethod(looper_clazz, prepare_method);
+      looper = env->CallStaticObjectMethod(looper_clazz, my_looper_method);
+    }
+    jclass thread_utils_clazz = env->FindClass("org/chromium/base/ThreadUtils");
+    jmethodID set_ui_thread_method = env->GetStaticMethodID(
+        thread_utils_clazz, "setUiThread", "(Landroid/os/Looper;)V");
+    env->CallStaticVoidMethod(thread_utils_clazz, set_ui_thread_method, looper);
+#endif
+
+    ForceInProcessNetworkService(true);
+    mojo::core::Init();
+    ui::DeviceDataManager::CreateInstance();
     base::CommandLine* command_line = base::CommandLine::ForCurrentProcess();
     if (!command_line->HasSwitch(switches::kSingleProcess)) {
       command_line->AppendSwitch(switches::kSingleProcess);
@@ -113,8 +149,7 @@ class ShellTestBase : public ::testing::Test {
     browser_context_ = std::make_unique<TestBrowserContext>();
     rvh_enabler_ = std::make_unique<RenderViewHostTestEnabler>();
     if (!ui::ResourceBundle::HasSharedInstance()) {
-      ui::ResourceBundle::InitSharedInstanceWithLocale(
-          "en-US", nullptr, ui::ResourceBundle::LOAD_COMMON_RESOURCES);
+      ui::ResourceBundle::InitSharedInstanceWithPakPath(base::FilePath());
     }
     browser_accessibility_state_ =
         std::make_unique<TestBrowserAccessibilityState>();

--- a/cobalt/tools/cdp_js_helper.py
+++ b/cobalt/tools/cdp_js_helper.py
@@ -20,40 +20,43 @@ Usage from shell:
 Usage from python:
   import asyncio
   from cobalt.tools.cdp_js_helper import evaluate
-  result = asyncio.run(evaluate("document.visibilityState", 9222))
+  result = asyncio.run(evaluate("document.visibilityState", "localhost", 9222))
 """
 
 import argparse
 import asyncio
 import json
 import sys
+import time
 
 import requests
 import websockets
 
 
-async def get_websocket_url(port):
+async def get_websocket_url(host, port):
   """Retrieves the websocket debugger URL from the local Cobalt instance."""
   try:
     # Use a synchronous requests call for the JSON list, as it's simple.
-    response = requests.get(f'http://localhost:{port}/json', timeout=10)
+    response = requests.get(f'http://{host}:{port}/json', timeout=10)
     targets = response.json()
     for target in targets:
       if target.get('type') == 'page' and target.get('webSocketDebuggerUrl'):
         return target['webSocketDebuggerUrl']
-  except (RuntimeError, ValueError) as e:
-    print(f'Error connecting to devtools on port {port}: {e}', file=sys.stderr)
+    print(f'CDP targets found but no page target: {targets}', file=sys.stderr)
+  except (requests.exceptions.RequestException, ValueError) as e:
+    print(
+        f'Error connecting to devtools on {host}:{port}: {e}', file=sys.stderr)
   return None
 
 
-async def evaluate(expression, port):
-  """Evaluates a JS expression via the Chrome DevTools Protocol."""
-  ws_url = await get_websocket_url(port)
+async def evaluate(expression, host, port):
+  """Evaluates a JavaScript expression via CDP."""
+  ws_url = await get_websocket_url(host, port)
   if not ws_url:
     return 'ERROR: No websocket URL'
 
   try:
-    async with websockets.connect(ws_url) as websocket:
+    async with websockets.connect(ws_url, close_timeout=5) as websocket:
       # Send a simple Runtime.evaluate message.
       message = {
           'id': 1,
@@ -63,24 +66,84 @@ async def evaluate(expression, port):
               'returnByValue': True
           }
       }
-      await websocket.send(json.dumps(message))
-      response = await websocket.recv()
+      await asyncio.wait_for(websocket.send(json.dumps(message)), timeout=30)
+      response = await asyncio.wait_for(websocket.recv(), timeout=30)
       result = json.loads(response)
       if 'result' in result and 'result' in result['result']:
-        return result['result']['result'].get('value')
+        val = result['result']['result'].get('value')
+        # If the value is not a string (e.g. boolean), convert to string.
+        if val is True:
+          return 'True'
+        if val is False:
+          return 'False'
+        if isinstance(val, (dict, list)):
+          return json.dumps(val, separators=(',', ':'))
+        return str(val) if val is not None else 'None'
       return f'ERROR: {response}'
-  except (RuntimeError, ValueError) as e:
-    print(f'CDP Error: {e}', file=sys.stderr)
-    return f'ERROR: {e}'
+  except (RuntimeError, ValueError, asyncio.TimeoutError, OSError) as e:
+    print(f'CDP Error: {type(e).__name__}: {e}', file=sys.stderr)
+    return f'ERROR: {type(e).__name__}: {e}'
+
+
+async def wait_for_cdp(host, port, timeout, total_wait):
+  """Waits for the CDP endpoint to become available."""
+  start_time = time.monotonic()
+  while (time.monotonic() - start_time) < total_wait:
+    try:
+      ws_url = await get_websocket_url(host, port)
+      if ws_url:
+        async with websockets.connect(ws_url, close_timeout=1) as websocket:
+          # Try to verify JS responsiveness, but don't fail if it times out
+          # (e.g. if the app is preloaded/suspended and JS is throttled).
+          try:
+            message = {
+                'id': 999,
+                'method': 'Runtime.evaluate',
+                'params': {
+                    'expression': '1+1',
+                    'returnByValue': True
+                }
+            }
+            await asyncio.wait_for(
+                websocket.send(json.dumps(message)), timeout=2)
+            await asyncio.wait_for(websocket.recv(), timeout=2)
+            return 'SUCCESS'
+          except asyncio.TimeoutError:
+            # If we connected but JS is non-responsive, it's still "ready" for
+            # connection.
+            return 'SUCCESS'
+    except (RuntimeError, ValueError, asyncio.TimeoutError, OSError):
+      pass
+    await asyncio.sleep(timeout)
+  return 'FAILURE'
 
 
 def main():
   parser = argparse.ArgumentParser()
+  parser.add_argument('--host', type=str, default='localhost')
   parser.add_argument('--port', type=int, default=9222)
-  parser.add_argument('expression', type=str)
+  parser.add_argument(
+      '--wait', action='store_true', help='Wait for CDP to be ready')
+  parser.add_argument(
+      '--wait-timeout',
+      type=float,
+      default=1.0,
+      help='Interval between connection attempts')
+  parser.add_argument(
+      '--wait-total',
+      type=float,
+      default=30.0,
+      help='Total time to wait for CDP')
+  parser.add_argument('expression', type=str, nargs='?', default='')
   args = parser.parse_args()
 
-  result = asyncio.run(evaluate(args.expression, args.port))
+  if args.wait:
+    result = asyncio.run(
+        wait_for_cdp(args.host, args.port, args.wait_timeout, args.wait_total))
+  else:
+    if not args.expression:
+      parser.error('expression is required when not using --wait')
+    result = asyncio.run(evaluate(args.expression, args.host, args.port))
   print(result)
 
 

--- a/cobalt/tools/test_common.sh
+++ b/cobalt/tools/test_common.sh
@@ -1,0 +1,134 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Common utilities for Cobalt integration tests on Linux.
+
+MODE="modular"
+BUILD=false
+CONFIG="devel"
+
+print_usage() {
+  echo "Usage: $1 [options]"
+  echo "Options:"
+  echo "  --mode [monolithic|modular|evergreen]  Select Cobalt mode (default: modular)"
+  echo "  --build                                Build before running test"
+  echo "  --config [devel|debug|qa|gold]         Select build configuration (default: devel)"
+  echo "  --help                                 Show this help message"
+}
+
+parse_args() {
+  local script_name=$1
+  shift
+  while [[ $# -gt 0 ]]; do
+    case $1 in
+      --mode)
+        MODE="$2"
+        shift 2
+        ;;
+      --build)
+        BUILD=true
+        shift
+        ;;
+      --config)
+        CONFIG="$2"
+        shift 2
+        ;;
+      --help)
+        print_usage "$script_name"
+        exit 0
+        ;;
+      *)
+        echo "Unknown argument: $1"
+        print_usage "$script_name"
+        exit 1
+        ;;
+    esac
+  done
+
+  case $MODE in
+    monolithic)
+      PLATFORM="linux-x64x11"
+      EXECUTABLE_NAME="cobalt"
+      ;;
+    modular)
+      PLATFORM="linux-x64x11-modular"
+      EXECUTABLE_NAME="cobalt_loader"
+      ;;
+    evergreen)
+      PLATFORM="evergreen-x64"
+      EXECUTABLE_NAME="elf_loader_sandbox"
+      ;;
+    *)
+      echo "Invalid mode: $MODE"
+      exit 1
+      ;;
+  esac
+
+  OUT_DIR="out/${PLATFORM}_${CONFIG}"
+
+  if [ "$MODE" = "evergreen" ]; then
+    EXECUTABLE="./cobalt/tools/run_evergreen_wrapper.sh"
+    export TEST_OUT_DIR="./${OUT_DIR}"
+  else
+    EXECUTABLE="./${OUT_DIR}/${EXECUTABLE_NAME}"
+  fi
+}
+
+check_running_processes() {
+  local script_basename=$1
+  local my_pgid=$(ps -o pgid= -p $$ | tr -d ' ')
+
+  local first_char="${script_basename:0:1}"
+  local rest="${script_basename:1}"
+  local pattern="[$first_char]$rest"
+
+  # Find other instances of this script
+  local other_test_pids=$(pgrep -f "$pattern" | while read pid; do
+    local pgid=$(ps -o pgid= -p $pid | tr -d ' ')
+    if [ "$pgid" != "$my_pgid" ]; then echo $pid; fi
+  done | xargs || true)
+
+  local waiter_pids=$(pgrep -f "[w]ait_for_state.sh" | while read pid; do
+    local pgid=$(ps -o pgid= -p $pid | tr -d ' ')
+    if [ "$pgid" != "$my_pgid" ]; then echo $pid; fi
+  done | xargs || true)
+
+  local cobalt_pids=$(pgrep -x "$EXECUTABLE_NAME" | while read pid; do
+    local pgid=$(ps -o pgid= -p $pid | tr -d ' ')
+    if [ "$pgid" != "$my_pgid" ]; then echo $pid; fi
+  done | xargs || true)
+
+  if [ -n "$other_test_pids" ] || [ -n "$waiter_pids" ] || [ -n "$cobalt_pids" ]; then
+    echo "FAILURE: Previous test instance or Cobalt process is still running."
+    [ -n "$other_test_pids" ] && echo "Found $script_basename PIDs: $other_test_pids"
+    [ -n "$waiter_pids" ] && echo "Found wait_for_state.sh PIDs: $waiter_pids"
+    [ -n "$cobalt_pids" ] && echo "Found $EXECUTABLE_NAME PIDs: $cobalt_pids"
+    echo "Please kill them before running this test."
+    exit 1
+  fi
+}
+
+run_build_if_needed() {
+  if [ "$BUILD" = true ]; then
+    echo "Building $EXECUTABLE_NAME for $PLATFORM..."
+
+    local build_target=$EXECUTABLE_NAME
+    if [ "$MODE" = "evergreen" ]; then
+      build_target="cobalt"
+    fi
+
+    echo "Running: autoninja -C $OUT_DIR $build_target"
+    autoninja -C "$OUT_DIR" "$build_target"
+  fi
+}

--- a/cobalt/tools/test_lifecycle.sh
+++ b/cobalt/tools/test_lifecycle.sh
@@ -16,87 +16,118 @@
 # Integration test for Cobalt lifecycle on Linux.
 # Sends signals to a running Cobalt process and verifies JS state via DevTools.
 
+source cobalt/tools/test_common.sh
+
 PORT=9223
 LOG_FILE="lifecycle_run.log"
-EXECUTABLE=${TEST_LIFECYCLE_EXECUTABLE:-"./out/linux-x64x11-modular_devel/cobalt_loader"}
+HOST=${TEST_LIFECYCLE_HOST:-"localhost"}
 
-# Ensure no previous test instances or Cobalt processes are running.
-pgrep -f "[t]est_lifecycle.sh" > /tmp/test_lifecycle_pids.tmp || true
-OTHER_TEST_PIDS=""
-while read pid; do
-  if [ -n "$pid" ] && [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ]; then
-    OTHER_TEST_PIDS="$OTHER_TEST_PIDS $pid"
-  fi
-done < /tmp/test_lifecycle_pids.tmp
-OTHER_TEST_PIDS=${OTHER_TEST_PIDS# }
+parse_args "test_lifecycle.sh" "$@"
+check_running_processes "test_lifecycle.sh"
+run_build_if_needed
 
-WAITER_PIDS=$(pgrep -f "[w]ait_for_state.sh" | grep -vw $$ | grep -vw $PPID || true)
-COBALT_PIDS=$(pgrep -f "[c]obalt_loader" | grep -vw $$ | grep -vw $PPID || true)
-
-if [ -n "$OTHER_TEST_PIDS" ] || [ -n "$WAITER_PIDS" ] || [ -n "$COBALT_PIDS" ]; then
-  echo "FAILURE: Previous test instance or Cobalt process is still running."
-  [ -n "$OTHER_TEST_PIDS" ] && echo "Found test_lifecycle.sh PIDs: $OTHER_TEST_PIDS"
-  [ -n "$WAITER_PIDS" ] && echo "Found wait_for_state.sh PIDs: $WAITER_PIDS"
-  [ -n "$COBALT_PIDS" ] && echo "Found cobalt_loader PIDs: $COBALT_PIDS"
-  echo "--- ps faux dump ---"
-  ps faux | grep -C 5 "test_lifecycle"
-  echo "--------------------"
-  echo "Current PID: $$"
-  echo "Parent PID: $PPID"
-  echo "BASHPID: $BASHPID"
-  echo "Please kill them before running this test."
-  exit 1
-fi
-
-echo "[TEST] Starting cobalt_loader with DevTools on port $PORT..."
+echo "[TEST] Starting cobalt_loader with DevTools on $HOST:$PORT..."
 rm -f $LOG_FILE
+rm -rf ~/.cobalt_storage ~/.cobalt ~/.config/cobalt
 
-$EXECUTABLE --remote-debugging-port=$PORT --no-sandbox > $LOG_FILE 2>&1 &
+TEST_HTML="<html><body><h1>Test</h1><input autofocus></body></html>"
+B64_HTML=$(echo "$TEST_HTML" | base64 -w 0)
+
+$EXECUTABLE --url="data:text/html;base64,$B64_HTML" --remote-debugging-port=$PORT --no-sandbox > $LOG_FILE 2>&1 &
 COBALT_PID=$!
 
 echo "[TEST] Launched PID: $COBALT_PID. Waiting for DevTools..."
-sleep 5
+if ! vpython3 cobalt/tools/cdp_js_helper.py --host $HOST --port $PORT --wait --wait-total 60 | grep -q "SUCCESS"; then
+  echo "FAILURE: DevTools did not become ready in time."
+  kill -9 $COBALT_PID
+  exit 1
+fi
+
+echo "[TEST] Allowing time for app initialization to avoid V8 crashes..."
+sleep 10
+
+execute_js() {
+  vpython3 cobalt/tools/cdp_js_helper.py --host $HOST --port $PORT "$1"
+}
 
 echo "[TEST] Verifying initial state (Visible & Focused)..."
-bash cobalt/tools/wait_for_state.sh "document.visibilityState" "visible" $PORT 120 || exit 1
-bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "True" $PORT 120 || exit 1
+bash cobalt/tools/wait_for_state.sh "document.visibilityState" "visible" $PORT 120 $HOST || exit 1
+bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "True" $PORT 120 $HOST || exit 1
+
+# Inject event logger now that we are in a stable initial state.
+echo "[TEST] Injecting event logger..."
+execute_js "window.event_log = [];
+            document.addEventListener('visibilitychange', () => {
+              console.log('JS_EVENT: visibilitychange ' + document.visibilityState);
+              window.event_log.push({type: 'visibilitychange', visibility: document.visibilityState});
+            });
+            window.addEventListener('focus', () => {
+              console.log('JS_EVENT: focus');
+              window.event_log.push({type: 'focus'});
+            });
+            window.addEventListener('blur', () => {
+              console.log('JS_EVENT: blur');
+              window.event_log.push({type: 'blur'});
+            });
+            document.addEventListener('freeze', () => {
+              console.log('JS_EVENT: freeze');
+              window.event_log.push({type: 'freeze'});
+            });
+            document.addEventListener('resume', () => {
+              console.log('JS_EVENT: resume');
+              window.event_log.push({type: 'resume'});
+            });
+            window.focus();"
+
+wait_and_pop_event() {
+  local expected=$1
+  echo "[WAIT] Waiting to pop event '$expected'..."
+  bash cobalt/tools/wait_for_state.sh "window.event_log.length > 0" "True" $PORT 10 $HOST || exit 1
+  local result=$(vpython3 cobalt/tools/cdp_js_helper.py --host $HOST --port $PORT "JSON.stringify(window.event_log.shift())" 2>/dev/null)
+  if [[ "$result" == *"$expected"* ]]; then
+    echo "[WAIT] SUCCESS: Popped expected event '$expected'"
+  else
+    echo "FAILURE: Expected '$expected', got '$result'"
+    exit 1
+  fi
+}
 
 echo "[TEST] Sending SIGWINCH (BLUR)..."
 kill -SIGWINCH $COBALT_PID
-bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "False" $PORT || exit 1
+bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "False" $PORT 10 $HOST || exit 1
+wait_and_pop_event '{"type":"blur"}'
 
 echo "[TEST] Sending SIGCONT (FOCUS)..."
 kill -SIGCONT $COBALT_PID
-bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "True" $PORT || exit 1
+bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "True" $PORT 10 $HOST || exit 1
+wait_and_pop_event '{"type":"focus"}'
 
 echo "[TEST] Sending SIGUSR1 (CONCEAL)..."
 kill -SIGUSR1 $COBALT_PID
-bash cobalt/tools/wait_for_state.sh "document.visibilityState" "hidden" $PORT || exit 1
+# Concealing from focused state will blur then change visibility to hidden
+bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "False" $PORT 10 $HOST || exit 1
+bash cobalt/tools/wait_for_state.sh "document.visibilityState" "hidden" $PORT 10 $HOST || exit 1
+wait_and_pop_event '{"type":"blur"}'
+wait_and_pop_event '{"type":"visibilitychange","visibility":"hidden"}'
 
-echo '[SLEEP] Wait 3 seconds, manually confirm that the window has disappeared.'
-sleep 3
+echo "[TEST] Sending SIGTSTP (FREEZE)..."
+kill -SIGTSTP $COBALT_PID
 
-echo "[TEST] Sending SIGCONT (REVEAL & FOCUS)..."
+echo "[TEST] Sleeping to ensure app freezes..."
+sleep 2
+
+echo "[TEST] Sending SIGCONT (RESUME & REVEAL & FOCUS)..."
 kill -SIGCONT $COBALT_PID
-bash cobalt/tools/wait_for_state.sh "document.visibilityState" "visible" $PORT 120 || exit 1
-bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "True" $PORT 120 || exit 1
+sleep 2
 
-echo '[SLEEP] Wait 3 seconds, manually confirm that the window has returned.'
-sleep 3
+echo "[TEST] Verifying freeze and resume events in logs..."
+grep -q "JS_EVENT: freeze" $LOG_FILE || { echo "FAILURE: freeze event not found in logs"; exit 1; }
+grep -q "JS_EVENT: resume" $LOG_FILE || { echo "FAILURE: resume event not found in logs"; exit 1; }
+grep -q "JS_EVENT: visibilitychange visible" $LOG_FILE || { echo "FAILURE: visible event not found in logs"; exit 1; }
+[ $(grep -c "JS_EVENT: focus" $LOG_FILE) -ge 2 ] || { echo "FAILURE: expected at least 2 focus events in logs"; exit 1; }
 
-echo "[TEST] Sending SIGPWR (STOP)..."
-kill -SIGPWR $COBALT_PID
-sleep 5
-
-if kill -0 $COBALT_PID 2>/dev/null; then
-  STAT=$(ps -p $COBALT_PID -o stat= | tr -d ' ')
-  if [[ "$STAT" != "Z"* ]]; then
-    echo "FAILURE: Cobalt (PID: $COBALT_PID) did not stop after SIGPWR. State: $STAT"
-    echo "[TEST] Cleaning up Cobalt (PID: $COBALT_PID)..."
-    kill -9 $COBALT_PID
-    exit 1
-  fi
-fi
+echo "[TEST] Killing Cobalt..."
+kill -9 $COBALT_PID 2>/dev/null || true
 
 echo "[TEST] SUCCESS: Lifecycle transitions verified!"
 

--- a/cobalt/tools/test_preload.sh
+++ b/cobalt/tools/test_preload.sh
@@ -16,64 +16,71 @@
 # Integration test for Cobalt Preload on Linux.
 # Verifies that Cobalt starts in a hidden state and reveals on SIGCONT.
 
+source cobalt/tools/test_common.sh
+
 PORT=9223
 LOG_FILE="preload_run.log"
-EXECUTABLE=${TEST_PRELOAD_EXECUTABLE:-"./out/linux-x64x11-modular_devel/cobalt_loader"}
 
-# Ensure no previous test instances or Cobalt processes are running.
-pgrep -f "[t]est_preload.sh" > /tmp/test_preload_pids.tmp || true
-OTHER_TEST_PIDS=""
-while read pid; do
-  if [ -n "$pid" ] && [ "$pid" != "$$" ] && [ "$pid" != "$PPID" ]; then
-    OTHER_TEST_PIDS="$OTHER_TEST_PIDS $pid"
-  fi
-done < /tmp/test_preload_pids.tmp
-OTHER_TEST_PIDS=${OTHER_TEST_PIDS# }
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+NC='\033[0m'
 
-WAITER_PIDS=$(pgrep -f "[w]ait_for_state.sh" | grep -vw $$ | grep -vw $PPID || true)
-COBALT_PIDS=$(pgrep -f "[c]obalt_loader" | grep -vw $$ | grep -vw $PPID || true)
+function log {
+  echo -e "${GREEN}[TEST] $(date +'%H:%M:%S') - $1${NC}"
+}
 
-if [ -n "$OTHER_TEST_PIDS" ] || [ -n "$WAITER_PIDS" ] || [ -n "$COBALT_PIDS" ]; then
-  echo "FAILURE: Previous test instance or Cobalt process is still running."
-  [ -n "$OTHER_TEST_PIDS" ] && echo "Found test_preload.sh PIDs: $OTHER_TEST_PIDS"
-  [ -n "$WAITER_PIDS" ] && echo "Found wait_for_state.sh PIDs: $WAITER_PIDS"
-  [ -n "$COBALT_PIDS" ] && echo "Found cobalt_loader PIDs: $COBALT_PIDS"
-  echo "Please kill them before running this test."
-  exit 1
-fi
+parse_args "test_preload.sh" "$@"
+check_running_processes "test_preload.sh"
+run_build_if_needed
 
-echo "[TEST] Starting cobalt_loader in preload mode with DevTools on port $PORT..."
+log "Starting cobalt_loader in preload mode with DevTools on port $PORT..."
 rm -f $LOG_FILE
 
-$EXECUTABLE --preload --remote-debugging-port=$PORT --no-sandbox > $LOG_FILE 2>&1 &
+$EXECUTABLE --preload --remote-debugging-port=$PORT --no-sandbox --v=1 > $LOG_FILE 2>&1 &
 COBALT_PID=$!
 
-echo "[TEST] Launched PID: $COBALT_PID. Waiting for DevTools..."
+log "Launched PID: $COBALT_PID. Waiting for DevTools..."
 sleep 5
 
-echo "[TEST] Verifying initial preloaded state (Hidden & Not Focused)..."
+log "Verifying initial preloaded state (Hidden & Not Focused)..."
 # In preload mode, the app should be hidden and not have focus.
 bash cobalt/tools/wait_for_state.sh "document.visibilityState" "hidden" $PORT 120 || exit 1
 bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "False" $PORT 120 || exit 1
 
-echo "[TEST] Sending SIGCONT to reveal application..."
+log "Sending SIGCONT to reveal application..."
 kill -SIGCONT $COBALT_PID
 
-echo "[TEST] Verifying revealed state (Visible & Focused)..."
+log "Verifying revealed state (Visible & Focused)..."
 bash cobalt/tools/wait_for_state.sh "document.visibilityState" "visible" $PORT 120 || exit 1
 bash cobalt/tools/wait_for_state.sh "document.hasFocus()" "True" $PORT 120 || exit 1
 
-echo "[TEST] Sending SIGPWR (STOP)..."
+log "Sending SIGPWR (STOP)..."
 kill -SIGPWR $COBALT_PID
 sleep 5
 
+# Wait for process to exit
+log "Waiting for Cobalt to exit..."
+wait $COBALT_PID 2>/dev/null
+EXIT_CODE=$?
+
+log "Cobalt exited with code: $EXIT_CODE"
+
 if kill -0 $COBALT_PID 2>/dev/null; then
-  echo "FAILURE: Cobalt (PID: $COBALT_PID) did not stop after SIGPWR."
-  echo "[TEST] Cleaning up Cobalt (PID: $COBALT_PID)..."
-  kill -9 $COBALT_PID
+  STAT=$(ps -p $COBALT_PID -o stat= | tr -d ' ')
+  if [[ "$STAT" != "Z"* ]]; then
+    echo "FAILURE: Cobalt (PID: $COBALT_PID) did not stop after SIGPWR. State: $STAT"
+    echo "[TEST] Cleaning up Cobalt (PID: $COBALT_PID)..."
+    kill -9 $COBALT_PID
+    exit 1
+  fi
+fi
+
+if [ $EXIT_CODE -ne 0 ] && [ $EXIT_CODE -ne 143 ]; then
+  # 143 is SIGTERM exit code, which is acceptable for SIGPWR/SIGTERM shutdown.
+  echo -e "${RED}FAILURE: Cobalt exited with non-zero code $EXIT_CODE${NC}"
   exit 1
 fi
 
-echo "[TEST] SUCCESS: Preload and reveal verified!"
+log "SUCCESS: Preload and reveal verified!"
 
 exit 0

--- a/cobalt/tools/wait_for_state.sh
+++ b/cobalt/tools/wait_for_state.sh
@@ -13,29 +13,31 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Helper script to poll a JS expression via CDP until it matches an expected value.
 
 EXPR=$1
 EXPECTED=$2
-PORT=$3
-TIMEOUT=${4:-10}
+PORT=${3:-9222}
+TIMEOUT=${4:-30}
+HOST=${5:-"localhost"}
 
 START_TIME=$(date +%s)
-
-echo "[WAIT] Waiting for '$EXPR' to be '$EXPECTED' (timeout: ${TIMEOUT}s)..."
+echo "[WAIT] Waiting for '$EXPR' to be '$EXPECTED' on $HOST:$PORT (timeout: ${TIMEOUT}s)..."
 
 while true; do
-  RESULT=$(vpython3 cobalt/tools/cdp_js_helper.py --port $PORT "$EXPR" 2>/dev/null)
-  if [ "$RESULT" == "$EXPECTED" ]; then
+  RESULT=$(vpython3 cobalt/tools/cdp_js_helper.py --host $HOST --port $PORT "$EXPR")
+  if [[ "$RESULT" == "$EXPECTED" ]]; then
     END_TIME=$(date +%s)
     DURATION=$((END_TIME - START_TIME))
-    echo "[WAIT] SUCCESS: '$EXPR' is now '$EXPECTED' (took ${DURATION}s)"
+    echo "[WAIT] SUCCESS: '$EXPR' matched '$EXPECTED' (took ${DURATION}s)"
     exit 0
   fi
 
   CURRENT_TIME=$(date +%s)
-  if [ $((CURRENT_TIME - START_TIME)) -gt $TIMEOUT ]; then
-    echo "FAILURE: Timeout waiting for $EXPR to be $EXPECTED. Got: $RESULT"
+  ELAPSED=$((CURRENT_TIME - START_TIME))
+  if [ $ELAPSED -ge $TIMEOUT ]; then
+    echo "FAILURE: Timeout waiting for '$EXPR' to be '$EXPECTED'. Last result: '$RESULT'"
     exit 1
   fi
-  sleep 0.5
+  sleep 1
 done

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.cc
@@ -107,12 +107,19 @@ Application::Application(SbEventHandleCallback sb_event_handle_callback)
   : QueueApplication(sb_event_handle_callback)
   , input_handler_(new EssInput)
   , hang_monitor_(new HangMonitor("Application")) {
-  essos_context_recycle_ = !!getenv("COBALT_ESSOS_CONTEXT_DESTROY");
+  essos_context_destroy_ = !!getenv("COBALT_ESSOS_CONTEXT_DESTROY");
   BuildEssosContext();
 }
 
 Application::~Application() {
-  EssContextDestroy(ctx_);
+  if (native_window_) {
+    EssContextDestroyNativeWindow(ctx_, native_window_);
+    native_window_ = 0;
+  }
+  if (ctx_) {
+    EssContextDestroy(ctx_);
+    ctx_ = NULL;
+  }
 }
 
 void Application::Initialize() {
@@ -273,17 +280,35 @@ void Application::Inject(Event* e) {
 
 void Application::OnSuspend() {
   SbSpeechSynthesisCancel();
-  DestroyNativeWindow();
+
+  if ( !(monitor_timer_fd_ < 0) ) {
+    setTimerInterval(monitor_timer_fd_, 0s);
+  }
+
+  // Unset the Essos terminate listener to prevent callback loops
+  // when the window is destroyed during suspend.
+  EssContextSetTerminateListener(ctx_, nullptr, nullptr);
+
+  if (essos_context_destroy_) {
+    DestroyNativeWindow();
+  }
+
   TeardownJSONRPCLink();
-  setTimerInterval(ess_timer_fd_, 1s);
 }
 
 void Application::OnResume() {
-  if ( essos_context_recycle_ )
+  if ( essos_context_destroy_ ) {
     BuildEssosContext();
+  } else {
+    EssContextSetTerminateListener(ctx_, this, &terminateListener);
+  }
 
+  if ( !(monitor_timer_fd_ < 0) && hang_monitor_ ) {
+    setTimerInterval(monitor_timer_fd_, hang_monitor_->GetResetInterval());
+  }
+
+  // Only restart the Essos timer run loop once the window is materialized.
   setTimerInterval(ess_timer_fd_, kEssRunLoopPeriod);
-  MaterializeNativeWindow();
 }
 
 void Application::OnTerminated() {
@@ -309,8 +334,9 @@ void Application::OnDisplaySize(int width, int height) {
 }
 
 void Application::MaterializeNativeWindow() {
-  if (native_window_ != 0)
+  if (native_window_ != 0) {
     return;
+  }
 
   bool error = false;
 
@@ -338,22 +364,28 @@ void Application::MaterializeNativeWindow() {
 }
 
 void Application::DestroyNativeWindow() {
-  if (native_window_ == 0)
+  if (native_window_ == 0) {
     return;
-
-  if ( !EssContextDestroyNativeWindow(ctx_, native_window_) ) {
-    const char *detail = EssContextGetLastErrorDetail(ctx_);
-    SB_LOG(ERROR) << "Essos error: '" <<  detail << '\'';
   }
 
-  native_window_ = 0;
-
-  if ( essos_context_recycle_ ) {
+  if ( essos_context_destroy_ ) {
+    // If recycling context, we must destroy the window now as it cannot
+    // survive without the context.
+    if ( !EssContextDestroyNativeWindow(ctx_, native_window_) ) {
+      const char *detail = EssContextGetLastErrorDetail(ctx_);
+      SB_LOG(ERROR) << "Essos error: '" <<  detail << '\'';
+    }
+    native_window_ = 0;
     EssContextDestroy(ctx_);
     ctx_ = NULL;
   }
-  else
+  else {
+    // Keep the underlying OS-level native window plane (EssWindow handle)
+    // alive inside ApplicationRdk. This ensures that Chromium's cached EGL
+    // surfaces have a valid window reference in memory during suspend, preventing
+    // graphics driver or Wayland marshalling segmentation faults upon unfreeze.
     EssContextStop(ctx_);
+  }
 }
 
 void Application::DisplayInfoChanged() {

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.h
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/application_rdk.h
@@ -117,7 +117,7 @@ class Application : public ::starboard::QueueApplication {
   int window_width_ { 0 };
   int window_height_ { 0 };
   bool resize_pending_ { false };
-  bool essos_context_recycle_ { false };
+  bool essos_context_destroy_ { false };
 
   std::chrono::time_point<std::chrono::steady_clock> ess_loop_last_ts_;
   int ess_timer_fd_ { -1 };

--- a/third_party/blink/renderer/modules/cobalt/BUILD.gn
+++ b/third_party/blink/renderer/modules/cobalt/BUILD.gn
@@ -17,10 +17,14 @@ import("//third_party/blink/renderer/modules/modules.gni")
 
 blink_modules_sources("h_5_vcc") {
   sources = [
+    "cobalt_lifecycle_controller.cc",
+    "cobalt_lifecycle_controller.h",
     "h_5_vcc.cc",
     "h_5_vcc.h",
   ]
   deps = [
+    "//cobalt/browser/h5vcc_runtime/public/mojom:mojom_blink",
+    "//cobalt/browser/lifecycle/public/mojom:mojom_blink",
     "//third_party/blink/renderer/modules/cobalt/crash_log",
     "//third_party/blink/renderer/modules/cobalt/h5vcc_accessibility",
     "//third_party/blink/renderer/modules/cobalt/h5vcc_experiments",

--- a/third_party/blink/renderer/modules/cobalt/cobalt_lifecycle_controller.cc
+++ b/third_party/blink/renderer/modules/cobalt/cobalt_lifecycle_controller.cc
@@ -1,0 +1,215 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "third_party/blink/renderer/modules/cobalt/cobalt_lifecycle_controller.h"
+
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "third_party/blink/renderer/core/frame/local_frame.h"
+#include "third_party/blink/renderer/core/page/focus_controller.h"
+#include "third_party/blink/renderer/core/page/page.h"
+
+namespace blink {
+
+const char CobaltLifecycleController::kSupplementName[] =
+    "CobaltLifecycleController";
+
+// static
+CobaltLifecycleController* CobaltLifecycleController::From(
+    LocalDOMWindow& window) {
+  return Supplement<LocalDOMWindow>::From<CobaltLifecycleController>(window);
+}
+
+// static
+void CobaltLifecycleController::BindReceiver(
+    LocalFrame* frame,
+    mojo::PendingReceiver<cobalt::mojom::blink::CobaltLifecycleController>
+        receiver) {
+  if (!frame || !frame->DomWindow()) {
+    return;
+  }
+  LocalDOMWindow& window = *frame->DomWindow();
+  auto* controller =
+      Supplement<LocalDOMWindow>::From<CobaltLifecycleController>(window);
+  if (!controller) {
+    controller = MakeGarbageCollected<CobaltLifecycleController>(
+        window, mojo::NullReceiver());
+    Supplement<LocalDOMWindow>::ProvideTo(window, controller);
+  }
+  controller->BindMojoReceiver(std::move(receiver));
+}
+
+void CobaltLifecycleController::BindMojoReceiver(
+    mojo::PendingReceiver<cobalt::mojom::blink::CobaltLifecycleController>
+        receiver) {
+  if (receiver.is_valid()) {
+    if (receiver_.is_bound()) {
+      LOG(WARNING) << "CobaltLifecycleController receiver is ALREADY BOUND!";
+    } else {
+      receiver_.reset();
+      receiver_.Bind(std::move(receiver), GetExecutionContext()->GetTaskRunner(
+                                              TaskType::kInternalDefault));
+    }
+  }
+}
+
+CobaltLifecycleController::CobaltLifecycleController(
+    LocalDOMWindow& window,
+    mojo::PendingReceiver<cobalt::mojom::blink::CobaltLifecycleController>
+        receiver)
+    : ExecutionContextLifecycleStateObserver(&window),
+      PageVisibilityObserver(window.GetFrame()->GetPage()),
+      FocusChangedObserver(window.GetFrame()->GetPage()),
+      Supplement<LocalDOMWindow>(window),
+      receiver_(this, &window),
+      remote_observer_(&window) {
+  UpdateStateIfNeeded();
+  if (receiver.is_valid()) {
+    receiver_.Bind(std::move(receiver),
+                   window.GetExecutionContext()->GetTaskRunner(
+                       TaskType::kInternalDefault));
+  }
+}
+
+CobaltLifecycleController::~CobaltLifecycleController() = default;
+
+void CobaltLifecycleController::ContextDestroyed() {
+  receiver_.reset();
+  remote_observer_.reset();
+}
+
+void CobaltLifecycleController::SetObserver(
+    mojo::PendingRemote<cobalt::mojom::blink::CobaltLifecycleObserver>
+        observer) {
+  remote_observer_.Bind(
+      std::move(observer),
+      GetExecutionContext()->GetTaskRunner(TaskType::kInternalDefault));
+
+  if (!remote_observer_.is_bound()) {
+    return;
+  }
+
+  // Query initial state now that we have the observer.
+  if (GetPage()) {
+    bool visible = GetPage()->IsPageVisible();
+    remote_observer_->OnPageVisibilityChanged(visible);
+
+    bool is_focused = GetPage()->GetFocusController().IsFocused();
+    if (is_focused) {
+      remote_observer_->OnPageFocused();
+    } else {
+      remote_observer_->OnPageBlurred();
+    }
+
+    remote_observer_->OnPageResumed();
+  }
+  remote_observer_->OnFrameReady();
+}
+
+void CobaltLifecycleController::PageVisibilityChanged() {
+  bool visible = GetPage() ? GetPage()->IsPageVisible() : false;
+  if (!remote_observer_.is_bound()) {
+    return;
+  }
+  if (GetPage()) {
+    NotifyObserver(base::BindOnce(
+        [](HeapMojoRemote<cobalt::mojom::blink::CobaltLifecycleObserver>&
+               observer,
+           bool visible) {
+          if (observer.is_bound()) {
+            observer->OnPageVisibilityChanged(visible);
+          }
+        },
+        std::ref(remote_observer_), visible));
+  }
+}
+
+void CobaltLifecycleController::FocusedFrameChanged() {
+  if (!remote_observer_.is_bound()) {
+    return;
+  }
+  if (GetPage()) {
+    bool is_focused = GetPage()->GetFocusController().IsFocused();
+    if (is_focused) {
+      NotifyObserver(base::BindOnce(
+          [](HeapMojoRemote<cobalt::mojom::blink::CobaltLifecycleObserver>&
+                 observer) {
+            if (observer.is_bound()) {
+              observer->OnPageFocused();
+            }
+          },
+          std::ref(remote_observer_)));
+    } else {
+      NotifyObserver(base::BindOnce(
+          [](HeapMojoRemote<cobalt::mojom::blink::CobaltLifecycleObserver>&
+                 observer) {
+            if (observer.is_bound()) {
+              observer->OnPageBlurred();
+            }
+          },
+          std::ref(remote_observer_)));
+    }
+  }
+}
+
+void CobaltLifecycleController::ContextLifecycleStateChanged(
+    mojom::blink::FrameLifecycleState state) {
+  if (state == mojom::blink::FrameLifecycleState::kRunning) {
+    if (remote_observer_.is_bound()) {
+      NotifyObserver(base::BindOnce(
+          [](HeapMojoRemote<cobalt::mojom::blink::CobaltLifecycleObserver>&
+                 observer) {
+            if (observer.is_bound()) {
+              observer->OnPageResumed();
+            }
+          },
+          std::ref(remote_observer_)));
+    }
+  }
+}
+
+// NotifyObserver posts the Mojo callbacks asynchronously to Blink's local HTML
+// Event Loop task runner using the same queue as JS DOM events
+// (TaskType::kDOMManipulation) instead of executing them synchronously.
+//
+// This is required because dispatching JS/DOM lifecycle events (such as
+// 'visibilitychange' and 'blur') is scheduled asynchronously via HTML tasks.
+// If the renderer notifies the browser about a state change synchronously via
+// Mojo, the browser completes the transition and dispatches subsequent events
+// (such as native window focus) immediately. This can result in the native
+// focus event being processed by the renderer before the pending HTML task for
+// the visibility change has executed, leading to out-of-order JS events.
+//
+// Posting the Mojo observer notifications to the same
+// TaskType::kDOMManipulation task runner ensures that they are queued in the
+// exact same line as pending JS DOM events, forcing Blink's scheduler to
+// execute them in strict FIFO (First-In-First-Out) sequential order.
+void CobaltLifecycleController::NotifyObserver(base::OnceClosure callback) {
+  if (!GetExecutionContext()) {
+    return;
+  }
+  GetExecutionContext()
+      ->GetTaskRunner(TaskType::kDOMManipulation)
+      ->PostTask(FROM_HERE, std::move(callback));
+}
+
+void CobaltLifecycleController::Trace(Visitor* visitor) const {
+  visitor->Trace(receiver_);
+  visitor->Trace(remote_observer_);
+  ExecutionContextLifecycleStateObserver::Trace(visitor);
+  PageVisibilityObserver::Trace(visitor);
+  FocusChangedObserver::Trace(visitor);
+  Supplement<LocalDOMWindow>::Trace(visitor);
+}
+
+}  // namespace blink

--- a/third_party/blink/renderer/modules/cobalt/cobalt_lifecycle_controller.h
+++ b/third_party/blink/renderer/modules/cobalt/cobalt_lifecycle_controller.h
@@ -1,0 +1,103 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef THIRD_PARTY_BLINK_RENDERER_MODULES_COBALT_COBALT_LIFECYCLE_CONTROLLER_H_
+#define THIRD_PARTY_BLINK_RENDERER_MODULES_COBALT_COBALT_LIFECYCLE_CONTROLLER_H_
+
+#include "base/functional/callback.h"
+#include "cobalt/browser/lifecycle/public/mojom/cobalt_lifecycle.mojom-blink.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_state_observer.h"
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+#include "third_party/blink/renderer/core/page/focus_changed_observer.h"
+#include "third_party/blink/renderer/core/page/page_visibility_observer.h"
+#include "third_party/blink/renderer/platform/heap/garbage_collected.h"
+#include "third_party/blink/renderer/platform/mojo/heap_mojo_receiver.h"
+#include "third_party/blink/renderer/platform/mojo/heap_mojo_remote.h"
+#include "third_party/blink/renderer/platform/supplementable.h"
+
+namespace blink {
+
+// CobaltLifecycleController is a document-associated supplement that monitors
+// and coordinates renderer-side lifecycle state changes (such as visibility,
+// focus, and freeze/resume transitions) for a LocalDOMWindow. It bridges these
+// events to the browser-side CobaltLifecycleManager via Mojo.
+//
+// Lifetime and Ownership:
+// It is owned by the LocalDOMWindow as a Supplement, and its lifetime is bound
+// to the lifetime of the document's execution context.
+//
+// Threading Model:
+// This class is thread-affine and must only be used on the main thread of the
+// renderer process (the Blink main thread).
+class CobaltLifecycleController
+    : public GarbageCollected<CobaltLifecycleController>,
+      public cobalt::mojom::blink::CobaltLifecycleController,
+      public ExecutionContextLifecycleStateObserver,
+      public PageVisibilityObserver,
+      public FocusChangedObserver,
+      public Supplement<LocalDOMWindow> {
+ public:
+  static const char kSupplementName[];
+
+  static CobaltLifecycleController* From(LocalDOMWindow& window);
+
+  static void BindReceiver(
+      LocalFrame* frame,
+      mojo::PendingReceiver<cobalt::mojom::blink::CobaltLifecycleController>
+          receiver);
+
+  void BindMojoReceiver(
+      mojo::PendingReceiver<cobalt::mojom::blink::CobaltLifecycleController>
+          receiver);
+
+  explicit CobaltLifecycleController(
+      LocalDOMWindow& window,
+      mojo::PendingReceiver<cobalt::mojom::blink::CobaltLifecycleController>
+          receiver);
+  ~CobaltLifecycleController() override;
+
+  // ExecutionContextLifecycleObserver impl.
+  void ContextDestroyed() override;
+
+  // PageVisibilityObserver impl.
+  void PageVisibilityChanged() override;
+
+  // FocusChangedObserver impl.
+  void FocusedFrameChanged() override;
+
+  // ExecutionContextLifecycleStateObserver impl.
+  void ContextLifecycleStateChanged(
+      mojom::blink::FrameLifecycleState state) override;
+
+  // CobaltLifecycleController impl.
+  void SetObserver(
+      mojo::PendingRemote<cobalt::mojom::blink::CobaltLifecycleObserver>
+          observer) override;
+
+  void Trace(Visitor* visitor) const override;
+
+ private:
+  void EnsureRemoteIsBound();
+  void NotifyObserver(base::OnceClosure callback);
+
+  HeapMojoReceiver<cobalt::mojom::blink::CobaltLifecycleController,
+                   CobaltLifecycleController>
+      receiver_;
+  HeapMojoRemote<cobalt::mojom::blink::CobaltLifecycleObserver>
+      remote_observer_;
+};
+
+}  // namespace blink
+
+#endif  // THIRD_PARTY_BLINK_RENDERER_MODULES_COBALT_COBALT_LIFECYCLE_CONTROLLER_H_

--- a/third_party/blink/renderer/modules/modules_initializer.cc
+++ b/third_party/blink/renderer/modules/modules_initializer.cc
@@ -53,6 +53,9 @@
 #include "third_party/blink/renderer/modules/device_orientation/device_orientation_absolute_controller.h"
 #include "third_party/blink/renderer/modules/device_orientation/device_orientation_controller.h"
 #include "third_party/blink/renderer/modules/device_orientation/device_orientation_inspector_agent.h"
+#if BUILDFLAG(IS_COBALT)
+#include "third_party/blink/renderer/modules/cobalt/cobalt_lifecycle_controller.h"
+#endif
 #include "third_party/blink/renderer/modules/document_metadata/document_metadata_server.h"
 #include "third_party/blink/renderer/modules/document_picture_in_picture/picture_in_picture_controller_impl.h"
 #include "third_party/blink/renderer/modules/encryptedmedia/html_media_element_encrypted_media.h"
@@ -231,6 +234,10 @@ void ModulesInitializer::Initialize() {
 
 void ModulesInitializer::InitLocalFrame(LocalFrame& frame) const {
   if (frame.IsMainFrame()) {
+#if BUILDFLAG(IS_COBALT)
+    frame.GetInterfaceRegistry()->AddInterface(WTF::BindRepeating(
+        &CobaltLifecycleController::BindReceiver, WrapWeakPersistent(&frame)));
+#endif
     frame.GetInterfaceRegistry()->AddInterface(WTF::BindRepeating(
         &DocumentMetadataServer::BindReceiver, WrapWeakPersistent(&frame)));
   }

--- a/ui/ozone/platform/starboard/platform_window_starboard.cc
+++ b/ui/ozone/platform/starboard/platform_window_starboard.cc
@@ -65,6 +65,10 @@ void PlatformWindowStarboard::ClearWindowDestroyedCallback() {
       std::make_unique<WindowDestroyedCallback>(base::DoNothing());
 }
 
+void PlatformWindowStarboard::SetWaitingForRevealAck(bool waiting) {
+  waiting_for_reveal_ack_ = waiting;
+}
+
 PlatformWindowStarboard::PlatformWindowStarboard(
     PlatformWindowDelegate* delegate,
     const gfx::Rect& bounds)
@@ -87,12 +91,7 @@ PlatformWindowStarboard::~PlatformWindowStarboard() {
         PlatformEventSource::GetInstance())
         ->RemovePlatformEventObserverStarboard(this);
   }
-
-  if (SbWindowIsValid(sb_window_)) {
-    (*g_destroyed_callback).Run(sb_window_);
-    SbWindowDestroy(sb_window_);
-    sb_window_ = kSbWindowInvalid;
-  }
+  DestroySbWindowInstance();
 }
 
 bool PlatformWindowStarboard::CanDispatchEvent(const PlatformEvent& event) {
@@ -152,37 +151,32 @@ gfx::Rect PlatformWindowStarboard::GetBoundsInDIP() const {
 }
 
 void PlatformWindowStarboard::Show(bool inactive) {
-  if (SbWindowIsValid(sb_window_)) {
-    return;
+  if (!SbWindowIsValid(sb_window_)) {
+    SbWindowOptions options{};
+    SbWindowSetDefaultOptions(&options);
+    options.size.width = bounds_.width();
+    options.size.height = bounds_.height();
+
+    sb_window_ = SbWindowCreate(&options);
+    CHECK(SbWindowIsValid(sb_window_));
+
+    (*g_created_callback).Run(sb_window_);
   }
 
-  SbWindowOptions options{};
-  SbWindowSetDefaultOptions(&options);
-  options.size.width = bounds_.width();
-  options.size.height = bounds_.height();
-  sb_window_ = SbWindowCreate(&options);
-  CHECK(SbWindowIsValid(sb_window_));
+  if (!widget_available_) {
+    widget_available_ = true;
 
-  (*g_created_callback).Run(sb_window_);
-
-  CHECK(!widget_available_);
-  widget_available_ = true;
-  delegate_->OnAcceleratedWidgetAvailable(
-      reinterpret_cast<intptr_t>(SbWindowGetPlatformHandle(sb_window_)));
+    intptr_t handle =
+        reinterpret_cast<intptr_t>(SbWindowGetPlatformHandle(sb_window_));
+    delegate_->OnAcceleratedWidgetAvailable(handle);
+  }
 }
 
 void PlatformWindowStarboard::Hide() {
-  CHECK(widget_available_);
   if (widget_available_) {
     widget_available_ = false;
     delegate_->OnAcceleratedWidgetDestroyed();
   }
-
-  CHECK(SbWindowIsValid(sb_window_));
-  (*g_destroyed_callback).Run(sb_window_);
-
-  SbWindowDestroy(sb_window_);
-  sb_window_ = kSbWindowInvalid;
 }
 
 void PlatformWindowStarboard::Close() {
@@ -226,11 +220,40 @@ void PlatformWindowStarboard::Maximize() {
 }
 
 void PlatformWindowStarboard::Minimize() {
-  NOTIMPLEMENTED_LOG_ONCE();
+  if (widget_available_) {
+    widget_available_ = false;
+    delegate_->OnAcceleratedWidgetDestroyed();
+  }
+}
+
+void PlatformWindowStarboard::DestroySbWindowInstance() {
+  if (SbWindowIsValid(sb_window_)) {
+    (*g_destroyed_callback).Run(sb_window_);
+    SbWindowDestroy(sb_window_);
+    sb_window_ = kSbWindowInvalid;
+  }
 }
 
 void PlatformWindowStarboard::Restore() {
-  NOTIMPLEMENTED_LOG_ONCE();
+  if (!SbWindowIsValid(sb_window_)) {
+    SbWindowOptions options{};
+    SbWindowSetDefaultOptions(&options);
+    options.size.width = bounds_.width();
+    options.size.height = bounds_.height();
+
+    sb_window_ = SbWindowCreate(&options);
+    CHECK(SbWindowIsValid(sb_window_));
+
+    (*g_created_callback).Run(sb_window_);
+  }
+
+  if (!widget_available_) {
+    widget_available_ = true;
+
+    intptr_t handle =
+        reinterpret_cast<intptr_t>(SbWindowGetPlatformHandle(sb_window_));
+    delegate_->OnAcceleratedWidgetAvailable(handle);
+  }
 }
 
 PlatformWindowState PlatformWindowStarboard::GetPlatformWindowState() const {
@@ -238,6 +261,9 @@ PlatformWindowState PlatformWindowStarboard::GetPlatformWindowState() const {
 }
 
 void PlatformWindowStarboard::Activate() {
+  if (waiting_for_reveal_ack_) {
+    return;
+  }
   if (activation_state_ != ActivationState::kActive) {
     activation_state_ = ActivationState::kActive;
     delegate_->OnActivationChanged(/*active=*/true);

--- a/ui/ozone/platform/starboard/platform_window_starboard.h
+++ b/ui/ozone/platform/starboard/platform_window_starboard.h
@@ -43,6 +43,7 @@ class PlatformWindowStarboard : public PlatformWindow,
   void Hide() override;
   void Close() override;
   bool IsVisible() const override;
+  bool IsWaitingForRevealAck() const { return waiting_for_reveal_ack_; }
   void PrepareForShutdown() override;
   void SetBoundsInDIP(const gfx::Rect& bounds) override;
   gfx::Rect GetBoundsInDIP() const override;
@@ -53,6 +54,7 @@ class PlatformWindowStarboard : public PlatformWindow,
   bool HasCapture() const override;
   void Maximize() override;
   void Minimize() override;
+  void DestroySbWindowInstance();
   void Restore() override;
   PlatformWindowState GetPlatformWindowState() const override;
   void Activate() override;
@@ -80,6 +82,8 @@ class PlatformWindowStarboard : public PlatformWindow,
   static void SetWindowDestroyedCallback(WindowDestroyedCallback cb);
   static void ClearWindowDestroyedCallback();
 
+  void SetWaitingForRevealAck(bool waiting);
+
   // ui::PlatformEventObserverStarboard interface.
   void ProcessWindowSizeChangedEvent(int width, int height) override;
   void ProcessFocusEvent(bool is_focused) override;
@@ -103,6 +107,8 @@ class PlatformWindowStarboard : public PlatformWindow,
   raw_ptr<PlatformWindowDelegate> delegate_ = nullptr;
   ui::PlatformWindowState window_state_ = ui::PlatformWindowState::kUnknown;
   ActivationState activation_state_ = ActivationState::kUnknown;
+
+  bool waiting_for_reveal_ack_ = false;
 };
 
 }  // namespace ui

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.cc
@@ -877,16 +877,22 @@ void DesktopWindowTreeHostPlatform::OnAcceleratedWidgetAvailable(
   aura::WindowTreeHostPlatform::OnAcceleratedWidgetAvailable(widget);
 }
 
-void DesktopWindowTreeHostPlatform::OnWillDestroyAcceleratedWidget() {
-  desktop_native_widget_aura_->OnHostWillClose();
-}
-
-#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(IS_STARBOARD) || BUILDFLAG(IS_COBALT)
 void DesktopWindowTreeHostPlatform::OnAcceleratedWidgetDestroyed() {
+  // In non-destructive suspend/resume lifecycles, the platform graphics
+  // surface (AcceleratedWidget) may be destroyed and re-created dynamically
+  // while preserving the host window object and Views widget hierarchy in the
+  // background. We must untrack the destroyed widget from the global list of
+  // open windows here to allow the graphics surface to be safely re-allocated
+  // and registered upon resume.
   open_windows().remove(GetAcceleratedWidget());
   aura::WindowTreeHostPlatform::OnAcceleratedWidgetDestroyed();
 }
 #endif
+
+void DesktopWindowTreeHostPlatform::OnWillDestroyAcceleratedWidget() {
+  desktop_native_widget_aura_->OnHostWillClose();
+}
 
 void DesktopWindowTreeHostPlatform::OnActivationChanged(bool active) {
   if (active) {

--- a/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
+++ b/ui/views/widget/desktop_aura/desktop_window_tree_host_platform.h
@@ -151,10 +151,10 @@ class VIEWS_EXPORT DesktopWindowTreeHostPlatform
                             ui::PlatformWindowState new_state) override;
   void OnCloseRequest() override;
   void OnAcceleratedWidgetAvailable(gfx::AcceleratedWidget widget) override;
-  void OnWillDestroyAcceleratedWidget() override;
-#if BUILDFLAG(IS_COBALT)
+#if BUILDFLAG(IS_STARBOARD) || BUILDFLAG(IS_COBALT)
   void OnAcceleratedWidgetDestroyed() override;
 #endif
+  void OnWillDestroyAcceleratedWidget() override;
   void OnActivationChanged(bool active) override;
   absl::optional<gfx::Size> GetMinimumSizeForWindow() override;
   absl::optional<gfx::Size> GetMaximumSizeForWindow() override;


### PR DESCRIPTION
Refer to the original PR: #10416

This also brings in `cobalt/common/cobalt_thread_checker.h` from #8905 but not the other changes from that PR.

This PR implements a natively resilient and completely race-free application lifecycle transition framework for Cobalt (specifically targeting Evergreen RDK and Starboard systems). By strictly serializing transitions between visible, hidden, focused, blurred, frozen, and resumed states, this framework guarantees deterministic synchronization between native OS events, browser-side window widget mapping, and Blink Renderer Mojo updates—completely eliminating all high-speed race conditions, compositor DCHECK aborts, and focus de-synchronizations.

This CL introduces the following key behavioral guarantees and functional correctness enhancements:

1. **Deterministic Visibility and Focus Ordering**: On resume (reveal), the system guarantees that the native window widget is fully mapped and active *before* notifying the page's document visibility state. Consequently, the W3C visibility state is guaranteed to update to `visible` *before* the page gains active focus, eliminating any visibility-focus restore races.
2. **Spec-Compliant Lifecycle Resource Reclaim**: On deactivation (conceal), the browser window widget is fully minimized and hidden, triggering native EGL/graphics surface release to reclaim 100% GPU memory. On activation (reveal), the window widget is restored and shown, synchronously re-negotiating EGL surface bounds and allowing the platform window to fully map prior to layout rendering.
3. **Synchronous Transition Serialization (Focus-Loss Wait Gate)**: During application deactivation (blur), the main browser thread blocks synchronously until the renderer process has fully dispatched the Javascript `blur` event loop and Mojo ACKed it back. This guarantees that focus-loss completes atomically *before* the page document visibility state is concealed, enforcing absolute transition linearity.
4. **Dormant Focus Deferral Coordination**: Any physical OS focus events arriving concurrently while the browser is waiting for Blink's layout Reveal ACK are safely deferred browser-side. Once layout is complete and Mojo ACKed, the deferred focus is automatically restored, ensuring focus never races layout visibility.
5. **Clean Browser Teardown**: During process teardown, the UI thread synchronously pumps the message loop to drain and delete all remaining frame nodes. This guarantees that the context graph is completely empty prior to Performance Manager shutdown, preventing context reset crashes.

## Verification Results
- Compiled cleanly across all 5 configurations (unittests, Modular devel/qa, and RDK TV devel/qa).
- Passed 100% of C++ Lifecycle unittests (147/147 passed flakelessly).
- Passed 100% of local Modular sequential sweeps (25/25 devel loops).
- Passed RDK TV HDMI CEC disconnect test flakelessly purely over remote keypresses.

Bug: 477170017
Bug: 498107481
Bug: 505584259
Bug: 489821073
Bug: 491962441
Bug: 475990372
Bug: 494002968
