### PR TITLE
media: Remove FLAC from Cobalt builds

### DIFF
--- a/media/audio/BUILD.gn
+++ b/media/audio/BUILD.gn
@@ -41,9 +41,11 @@ source_set("audio") {
     # TODO(dalecurtis): Move android audio pieces into //media/audio.
     "//media/base/android",
   ]
-  if (!is_cobalt) {
-    visibility += [ ":flac_audio_handler_fuzzer" ]
+
+  if (is_cobalt) {
+    visibility -= [ ":flac_audio_handler_fuzzer" ]
   }
+
   sources = [
     "aecdump_recording_manager.cc",
     "aecdump_recording_manager.h",
@@ -388,12 +390,12 @@ source_set("audio") {
     ]
   }
 
-  if (!is_cobalt) {
-    sources += [
+  if (is_cobalt) {
+    sources -= [
       "flac_audio_handler.cc",
       "flac_audio_handler.h",
     ]
-    deps += [ "//third_party/flac" ]
+    deps -= [ "//third_party/flac" ]
   }
 }
 
@@ -533,8 +535,9 @@ source_set("unit_tests") {
       "test_data.h",
       "wav_audio_handler_unittest.cc",
     ]
-    if (!is_cobalt) {
-      sources += [ "flac_audio_handler_unittest.cc" ]
+    
+    if (is_cobalt) {
+      sources -= [ "flac_audio_handler_unittest.cc" ]
     }
   }
 

--- a/media/audio/BUILD.gn
+++ b/media/audio/BUILD.gn
@@ -30,7 +30,6 @@ source_set("audio") {
   # is a roll-up target which is part of the //media component. Most other DEPs
   # should be using //media and not directly DEP this roll-up target.
   visibility = [
-    ":flac_audio_handler_fuzzer",
     ":wav_audio_handler_fuzzer",
     "//media",
     "//media/renderers",
@@ -42,6 +41,9 @@ source_set("audio") {
     # TODO(dalecurtis): Move android audio pieces into //media/audio.
     "//media/base/android",
   ]
+  if (!is_cobalt) {
+    visibility += [ ":flac_audio_handler_fuzzer" ]
+  }
   sources = [
     "aecdump_recording_manager.cc",
     "aecdump_recording_manager.h",
@@ -123,8 +125,6 @@ source_set("audio") {
     "fake_audio_manager.h",
     "fake_audio_output_stream.cc",
     "fake_audio_output_stream.h",
-    "flac_audio_handler.cc",
-    "flac_audio_handler.h",
     "null_audio_sink.cc",
     "null_audio_sink.h",
     "power_observer_helper.cc",
@@ -145,7 +145,6 @@ source_set("audio") {
     "//build:android_buildflags",
     "//build:chromecast_buildflags",
     "//media/base",
-    "//third_party/flac",
     "//third_party/opus:opus",
     "//url",
   ]
@@ -388,6 +387,14 @@ source_set("audio") {
       "//starboard:starboard_headers_only"
     ]
   }
+
+  if (!is_cobalt) {
+    sources += [
+      "flac_audio_handler.cc",
+      "flac_audio_handler.h",
+    ]
+    deps += [ "//third_party/flac" ]
+  }
 }
 
 if (use_cras) {
@@ -523,10 +530,12 @@ source_set("unit_tests") {
 
   if (is_chromeos || is_castos || is_cast_android) {
     sources += [
-      "flac_audio_handler_unittest.cc",
       "test_data.h",
       "wav_audio_handler_unittest.cc",
     ]
+    if (!is_cobalt) {
+      sources += [ "flac_audio_handler_unittest.cc" ]
+    }
   }
 
   if (use_cras) {
@@ -584,11 +593,13 @@ fuzzer_test("wav_audio_handler_fuzzer") {
   ]
 }
 
-fuzzer_test("flac_audio_handler_fuzzer") {
-  sources = [ "flac_audio_handler_fuzzer.cc" ]
-  deps = [
-    ":audio",
-    "//base",
-    "//media:test_support",
-  ]
+if (!is_cobalt) {
+  fuzzer_test("flac_audio_handler_fuzzer") {
+    sources = [ "flac_audio_handler_fuzzer.cc" ]
+    deps = [
+      ":audio",
+      "//base",
+      "//media:test_support",
+    ]
+  }
 }

--- a/media/audio/BUILD.gn
+++ b/media/audio/BUILD.gn
@@ -30,6 +30,7 @@ source_set("audio") {
   # is a roll-up target which is part of the //media component. Most other DEPs
   # should be using //media and not directly DEP this roll-up target.
   visibility = [
+    ":flac_audio_handler_fuzzer",
     ":wav_audio_handler_fuzzer",
     "//media",
     "//media/renderers",
@@ -127,6 +128,8 @@ source_set("audio") {
     "fake_audio_manager.h",
     "fake_audio_output_stream.cc",
     "fake_audio_output_stream.h",
+    "flac_audio_handler.cc",
+    "flac_audio_handler.h",
     "null_audio_sink.cc",
     "null_audio_sink.h",
     "power_observer_helper.cc",
@@ -147,6 +150,7 @@ source_set("audio") {
     "//build:android_buildflags",
     "//build:chromecast_buildflags",
     "//media/base",
+    "//third_party/flac",
     "//third_party/opus:opus",
     "//url",
   ]
@@ -532,6 +536,7 @@ source_set("unit_tests") {
 
   if (is_chromeos || is_castos || is_cast_android) {
     sources += [
+      "flac_audio_handler_unittest.cc",
       "test_data.h",
       "wav_audio_handler_unittest.cc",
     ]


### PR DESCRIPTION
Exclude FLAC audio handling and its associated third-party dependency
from Cobalt builds. This reduction in scope helps minimize the binary
size and build complexity for Cobalt, as FLAC support is not required
for its target platforms.

Bug: 517266324