### PR TITLE
net: Support dynamic Mojo data pipe sizing

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -61,6 +61,14 @@ public class JavaSwitches {
   /** flag to allow scaling clipped images in GpuImageDecodeCache */
   public static final String ENABLE_SCALING_CLIPPED_IMAGES = "EnableScalingClippedImages";
 
+  /** flag to enable dynamic mojo pipe sizing. */
+  public static final String ENABLE_COBALT_DYNAMIC_MOJO_PIPE_SIZING =
+      "EnableCobaltDynamicMojoPipeSizing";
+
+  /** flag to tune cobalt dynamic mojo pipe sizing subresource size in bytes. */
+  public static final String COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE =
+      "CobaltDynamicMojoPipeSubresourceSize";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
 
@@ -103,6 +111,20 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_SCALING_CLIPPED_IMAGES)) {
       extraCommandLineArgs.add("--enable-scaling-clipped-images");
+    }
+
+    StringJoiner mojoPipeParams = new StringJoiner("/");
+    if (javaSwitches.containsKey(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE)) {
+      String size = javaSwitches.get(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE).replaceAll("[^0-9]", "");
+      mojoPipeParams.add("subresource_size/" + size);
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_COBALT_DYNAMIC_MOJO_PIPE_SIZING) || mojoPipeParams.length() > 0) {
+      if (mojoPipeParams.length() > 0) {
+        extraCommandLineArgs.add("--enable-features=CobaltDynamicMojoPipeSizing:" + mojoPipeParams.toString());
+      } else {
+        extraCommandLineArgs.add("--enable-features=CobaltDynamicMojoPipeSizing");
+      }
     }
 
     StringJoiner featureParams = new StringJoiner("/");

--- a/services/network/public/cpp/features.cc
+++ b/services/network/public/cpp/features.cc
@@ -617,4 +617,16 @@ BASE_FEATURE_PARAM(size_t,
                    /*name=*/"max_size",
                    1'000'000);
 
+#if BUILDFLAG(IS_COBALT)
+BASE_FEATURE(kCobaltDynamicMojoPipeSizing,
+             "CobaltDynamicMojoPipeSizing",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+BASE_FEATURE_PARAM(int,
+                   kCobaltDynamicMojoPipeSizingSubresourceSize,
+                   &kCobaltDynamicMojoPipeSizing,
+                   "subresource_size",
+                   128 * 1024);
+#endif  // BUILDFLAG(IS_COBALT)
+
 }  // namespace network::features

--- a/services/network/public/cpp/features.h
+++ b/services/network/public/cpp/features.h
@@ -7,6 +7,7 @@
 
 #include <string>
 
+#include "build/buildflag.h"
 #include "base/component_export.h"
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
@@ -339,6 +340,14 @@ BASE_DECLARE_FEATURE_PARAM(size_t, kSharedDictionaryCacheSize);
 // Maximum size of dictionaries that are allowed to be stored in the cache.
 COMPONENT_EXPORT(NETWORK_CPP_FLAGS_AND_SWITCHES)
 BASE_DECLARE_FEATURE_PARAM(size_t, kSharedDictionaryCacheMaxSizeBytes);
+
+#if BUILDFLAG(IS_COBALT)
+COMPONENT_EXPORT(NETWORK_CPP_FLAGS_AND_SWITCHES)
+BASE_DECLARE_FEATURE(kCobaltDynamicMojoPipeSizing);
+
+COMPONENT_EXPORT(NETWORK_CPP_FLAGS_AND_SWITCHES)
+BASE_DECLARE_FEATURE_PARAM(int, kCobaltDynamicMojoPipeSizingSubresourceSize);
+#endif  // BUILDFLAG(IS_COBALT)
 
 }  // namespace network::features
 

--- a/services/network/url_loader.cc
+++ b/services/network/url_loader.cc
@@ -1177,8 +1177,34 @@ void URLLoader::ContinueOnResponseStarted() {
     options.struct_size = sizeof(MojoCreateDataPipeOptions);
     options.flags = MOJO_CREATE_DATA_PIPE_FLAG_NONE;
     options.element_num_bytes = 1;
+#if BUILDFLAG(IS_COBALT)
+    // Dynamic allocation for Cobalt to save memory on low-end TVs.
+    // Video/audio streams get the large buffer; images and APIs get 128 KB.
+    bool is_media_stream = (request_destination_ == mojom::RequestDestination::kVideo ||
+                            request_destination_ == mojom::RequestDestination::kAudio);
+    // YouTube TV specific: check for /videoplayback URL path
+    if (!is_media_stream) {
+      is_media_stream = (url_request_->url().path() == "/videoplayback");
+    }
+    // General MSE: check for standard video/audio mime-types or YouTube's custom UMP format
+    if (!is_media_stream && response_ && !response_->mime_type.empty()) {
+      const std::string& mime = response_->mime_type;
+      is_media_stream = (base::StartsWith(mime, "video/", base::CompareCase::SENSITIVE) ||
+                         base::StartsWith(mime, "audio/", base::CompareCase::SENSITIVE) ||
+                         mime == "application/vnd.yt-ump");
+    }
+    if (!is_media_stream && base::FeatureList::IsEnabled(features::kCobaltDynamicMojoPipeSizing)) {
+      options.capacity_num_bytes = static_cast<uint32_t>(
+          features::kCobaltDynamicMojoPipeSizingSubresourceSize.Get());
+    } else {
+      options.capacity_num_bytes = GetDataPipeDefaultAllocationSize(
+          DataPipeAllocationSize::kLargerSizeIfPossible);
+    }
+
+#else
     options.capacity_num_bytes = GetDataPipeDefaultAllocationSize(
         DataPipeAllocationSize::kLargerSizeIfPossible);
+#endif  // BUILDFLAG(IS_COBALT)
     MojoResult result =
         mojo::CreateDataPipe(&options, response_body_stream_, consumer_handle_);
     if (result != MOJO_RESULT_OK) {


### PR DESCRIPTION
Introduce a mechanism to dynamically size Mojo data pipe buffers
based on the request type. Cobalt frequently runs on resource-
constrained devices where memory overhead must be minimized.

For non-media requests, such as API calls and image fetches, the
buffer size is reduced to 128 KB when the feature is enabled.
High-bandwidth media streams, identified by destination types,
URL patterns, or MIME types, continue to use the default larger
allocation size to ensure playback performance is maintained.

Issue: 520888239