### PR TITLE
cobalt: Disable HSTS Preload List

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -78,3 +78,8 @@ webnn_use_tflite = false
 
 # Disable dav1d in webrtc to reduce binary size (~533KB)
 rtc_include_dav1d_in_internal_decoder_factory = false
+
+# Prune the massive HSTS preloaded list to save 1.3 MB of
+# rodata. Cobalt is a closed app shell and does not need
+# a preloaded list of third-party domains.
+include_transport_security_state_preload_list = false


### PR DESCRIPTION
Disable the HSTS (HTTP Strict Transport Security) preloaded list
to reduce binary size. This change saves approximately 1.3 MB of
read-only data. Cobalt is a closed app shell and does not require
the comprehensive list of third-party domains provided by Chromium.

```
# original
> du -s out/android-arm_qa/libchrobalt.so
70748	out/android-arm_qa/libchrobalt.so
> du -s out/android-arm_qa/apks/Cobalt.apk
89472	out/android-arm_qa/apks/Cobalt.apk
> du -s out/evergreen-arm-hardfp-rdk_qa/libcobalt.so
78992	out/evergreen-arm-hardfp-rdk_qa/libcobalt.so

# include_transport_security_state_preload_list = false
> du -s out/android-arm_qa/libchrobalt.so
69452	out/android-arm_qa/libchrobalt.so
> du -s out/android-arm_qa/apks/Cobalt.apk
88176	out/android-arm_qa/apks/Cobalt.apk
> du -s out/evergreen-arm-hardfp-rdk_qa/libcobalt.so
78992	out/evergreen-arm-hardfp-rdk_qa/libcobalt.so
```

Issue: 520903111