### PR TITLE
starboard: Relax owners for experimental features

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -25,6 +25,7 @@
 /starboard/elf_loader                      @youtube/cobalt-starboard-owners
 /starboard/loader_app                      @youtube/cobalt-starboard-owners
 /starboard/common                          @youtube/cobalt-starboard-owners
+/starboard/common/experimental/            # no owners
 /components/viz/service/display/starboard/ @youtube/cobalt-starboard-owners
 /ui/ozone/platform/starboard/              @youtube/cobalt-starboard-owners
 


### PR DESCRIPTION
Update the CODEOWNERS file to remove mandatory approval requirements
for the experimental starboard common directory. This allows the
community to contribute to experimental features without needing
sign-off from the core starboard owners, reducing friction for
prototyping and development.

Issue: 521171926