### PR TITLE
cobalt: Prune CLD3 Language Detection

### DIFF
--- a/ui/accessibility/BUILD.gn
+++ b/ui/accessibility/BUILD.gn
@@ -225,6 +225,10 @@ component("accessibility_internal") {
     "//third_party/cld_3/src/src:cld_3",
   ]
 
+  if (is_cobalt) {
+    deps -= [ "//third_party/cld_3/src/src:cld_3" ]
+  }
+
   public_deps = [
     ":ax_base",
     "//skia",

--- a/ui/accessibility/ax_language_detection.cc
+++ b/ui/accessibility/ax_language_detection.cc
@@ -32,14 +32,18 @@ const int kMaxDetectedLanguagesPerPage = 3;
 // starting point.
 const int kMaxDetectedLanguagesPerSpan = 3;
 
+#if !BUILDFLAG(IS_COBALT)
 const int kShortTextIdentifierMinByteLength = 1;
 // TODO(crbug.com/41463459): Determine appropriate value for
 // |kShortTextIdentifierMaxByteLength|.
 const int kShortTextIdentifierMaxByteLength = 1000;
+#endif  // !BUILDFLAG(IS_COBALT)
 }  // namespace
 
+#if !BUILDFLAG(IS_COBALT)
 using Result = chrome_lang_id::NNetLanguageIdentifier::Result;
 using SpanInfo = chrome_lang_id::NNetLanguageIdentifier::SpanInfo;
+#endif  // !BUILDFLAG(IS_COBALT)
 
 AXLanguageInfo::AXLanguageInfo() = default;
 AXLanguageInfo::~AXLanguageInfo() = default;
@@ -206,9 +210,13 @@ void AXLanguageInfoStats::ClearMetrics() {
 }
 
 AXLanguageDetectionManager::AXLanguageDetectionManager(AXTree* tree)
+#if !BUILDFLAG(IS_COBALT)
     : short_text_language_identifier_(kShortTextIdentifierMinByteLength,
                                       kShortTextIdentifierMaxByteLength),
       tree_(tree) {}
+#else
+    : tree_(tree) {}
+#endif  // !BUILDFLAG(IS_COBALT)
 
 AXLanguageDetectionManager::~AXLanguageDetectionManager() = default;
 
@@ -279,6 +287,7 @@ void AXLanguageDetectionManager::DetectLanguagesForSubtree(
 // Will not descend into children.
 // Will not check feature flag.
 void AXLanguageDetectionManager::DetectLanguagesForNode(AXNode* node) {
+#if !BUILDFLAG(IS_COBALT)
   // Count this detection attempt.
   lang_info_stats_.RecordDetectionAttempt();
 
@@ -325,6 +334,9 @@ void AXLanguageDetectionManager::DetectLanguagesForNode(AXNode* node) {
     // Update statistics to take these results into account.
     lang_info_stats_.Add(lang_info->detected_languages);
   }
+#else
+  (void)node;
+#endif  // !BUILDFLAG(IS_COBALT)
 }
 
 // Label languages for each node. This relies on DetectLanguages having already
@@ -414,6 +426,7 @@ std::vector<AXLanguageSpan>
 AXLanguageDetectionManager::GetLanguageAnnotationForStringAttribute(
     const AXNode& node,
     ax::mojom::StringAttribute attr) {
+#if !BUILDFLAG(IS_COBALT)
   std::vector<AXLanguageSpan> language_annotation;
   if (!node.HasStringAttribute(attr))
     return language_annotation;
@@ -461,6 +474,11 @@ AXLanguageDetectionManager::GetLanguageAnnotationForStringAttribute(
     }
   }
   return language_annotation;
+#else
+  (void)node;
+  (void)attr;
+  return std::vector<AXLanguageSpan>();
+#endif  // !BUILDFLAG(IS_COBALT)
 }
 
 AXLanguageDetectionObserver::AXLanguageDetectionObserver(AXTree* tree) {

--- a/ui/accessibility/ax_language_detection.h
+++ b/ui/accessibility/ax_language_detection.h
@@ -14,7 +14,9 @@
 
 #include "base/memory/raw_ptr.h"
 #include "base/scoped_observation.h"
-#include "third_party/cld_3/src/src/nnet_language_identifier.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "third_party/cld_3/src/src/nnet_language_identifier.h"  // nogncheck
+#endif  // !BUILDFLAG(IS_COBALT)
 #include "ui/accessibility/ax_enums.mojom-forward.h"
 #include "ui/accessibility/ax_export.h"
 #include "ui/accessibility/ax_tree_observer.h"
@@ -294,12 +296,14 @@ class AX_EXPORT AXLanguageDetectionManager {
   // This language identifier is constructed with a default minimum byte length
   // of chrome_lang_id::NNetLanguageIdentifier::kMinNumBytesToConsider and is
   // used for detecting page-level languages.
+#if !BUILDFLAG(IS_COBALT)
   chrome_lang_id::NNetLanguageIdentifier language_identifier_;
 
   // This language identifier is constructed with a minimum byte length of
   // kShortTextIdentifierMinByteLength so it can be used for detecting languages
   // of shorter text (e.g. one character).
   chrome_lang_id::NNetLanguageIdentifier short_text_language_identifier_;
+#endif  // !BUILDFLAG(IS_COBALT)
 
   // The observer to support dynamic content language detection.
   std::unique_ptr<AXLanguageDetectionObserver> language_detection_observer_;


### PR DESCRIPTION
CLD3 (Compact Language Detector v3) is used for language detection
within the accessibility layer. This feature is not required for
Cobalt and contributes significantly to the binary size.

Disabling CLD3 and its dependencies reduces the libchrobalt.so and
libcobalt.so binary sizes by approximately 500 KB across Android and
Evergreen platforms.

```
# original
> du -s out/android-arm_gold/libchrobalt.so
69436   out/android-arm_gold/libchrobalt.so
> du -s out/android-arm_gold/apks/Cobalt.apk
88160   out/android-arm_gold/apks/Cobalt.apk
> du -s out/evergreen-arm-hardfp-rdk_gold/libcobalt.so
76512   out/evergreen-arm-hardfp-rdk_gold/libcobalt.so

# remove CLD3 Language Detection
> du -s out/android-arm_gold/libchrobalt.so
68956   out/android-arm_gold/libchrobalt.so
> du -s out/android-arm_gold/apks/Cobalt.apk
87680   out/android-arm_gold/apks/Cobalt.apk
> du -s out/evergreen-arm-hardfp-rdk_gold/libcobalt.so
76032   out/evergreen-arm-hardfp-rdk_gold/libcobalt.so
```

Issue: 520901839