### PR TITLE
cobalt: Prune CED Encoding Detector

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -3063,6 +3063,9 @@ component("i18n") {
     "//third_party/ced",
     "//third_party/icu",
   ]
+  if (is_cobalt) {
+    public_deps -= [ "//third_party/ced" ]
+  }
   deps = [
     ":i18n_transliterator",
     "//build:chromecast_buildflags",

--- a/base/i18n/encoding_detection.cc
+++ b/base/i18n/encoding_detection.cc
@@ -5,7 +5,10 @@
 #include "base/i18n/encoding_detection.h"
 
 #include "build/build_config.h"
-#include "third_party/ced/src/compact_enc_det/compact_enc_det.h"
+#include "build/buildflag.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "third_party/ced/src/compact_enc_det/compact_enc_det.h"  // nogncheck
+#endif  // !BUILDFLAG(IS_COBALT)
 
 // third_party/ced/src/util/encodings/encodings.h, which is included
 // by the include above, undefs UNICODE because that is a macro used
@@ -20,6 +23,7 @@
 namespace base {
 
 bool DetectEncoding(const std::string& text, std::string* encoding) {
+#if !BUILDFLAG(IS_COBALT)
   int consumed_bytes;
   bool is_reliable;
   Encoding enc = CompactEncDet::DetectEncoding(
@@ -35,5 +39,10 @@ bool DetectEncoding(const std::string& text, std::string* encoding) {
 
   *encoding = MimeEncodingName(enc);
   return true;
+#else
+  // Cobalt always uses UTF-8 and does not need dynamic encoding detection.
+  *encoding = "UTF-8";
+  return true;
+#endif  // !BUILDFLAG(IS_COBALT)
 }
 }  // namespace base

--- a/components/services/unzip/public/cpp/unzip.cc
+++ b/components/services/unzip/public/cpp/unzip.cc
@@ -24,6 +24,7 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
 #include "base/time/time.h"
+#include "build/buildflag.h"
 #include "components/services/storage/public/cpp/filesystem/filesystem_impl.h"
 #include "components/services/unzip/public/mojom/unzipper.mojom.h"
 #include "mojo/public/cpp/bindings/receiver.h"
@@ -147,6 +148,7 @@ class UnzipOperation : public base::RefCountedThreadSafe<UnzipOperation>,
   UnzipCallback callback_;
 };
 
+#if !BUILDFLAG(IS_COBALT)
 class DetectEncodingParams : public base::RefCounted<DetectEncodingParams> {
  public:
   DetectEncodingParams(mojo::PendingRemote<mojom::Unzipper> unzipper,
@@ -179,6 +181,7 @@ class DetectEncodingParams : public base::RefCounted<DetectEncodingParams> {
   DetectEncodingCallback callback_;
   const base::TimeTicks start_time_ = base::TimeTicks::Now();
 };
+#endif  // !BUILDFLAG(IS_COBALT)
 
 class GetExtractedInfoParams : public base::RefCounted<GetExtractedInfoParams> {
  public:
@@ -276,6 +279,7 @@ class DecodeOperation : public base::RefCountedThreadSafe<DecodeOperation> {
   base::OnceCallback<void(bool)> callback_;
 };
 
+#if !BUILDFLAG(IS_COBALT)
 void DoDetectEncoding(mojo::PendingRemote<mojom::Unzipper> unzipper,
                       const base::FilePath& zip_path,
                       DetectEncodingCallback result_callback) {
@@ -300,6 +304,7 @@ void DoDetectEncoding(mojo::PendingRemote<mojom::Unzipper> unzipper,
       std::move(zip_file),
       base::BindOnce(&DetectEncodingParams::InvokeCallback, params));
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void DoGetExtractedInfo(mojo::PendingRemote<mojom::Unzipper> unzipper,
                         const base::FilePath& zip_path,
@@ -357,6 +362,7 @@ base::OnceClosure Unzip(mojo::PendingRemote<mojom::Unzipper> unzipper,
       runner, base::BindOnce(&UnzipOperation::Cancel, unzip_operation));
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void DetectEncoding(mojo::PendingRemote<mojom::Unzipper> unzipper,
                     const base::FilePath& zip_path,
                     DetectEncodingCallback result_callback) {
@@ -368,6 +374,7 @@ void DetectEncoding(mojo::PendingRemote<mojom::Unzipper> unzipper,
                                            base::BindPostTaskToCurrentDefault(
                                                std::move(result_callback))));
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void GetExtractedInfo(mojo::PendingRemote<mojom::Unzipper> unzipper,
                       const base::FilePath& zip_path,

--- a/components/services/unzip/public/cpp/unzip.h
+++ b/components/services/unzip/public/cpp/unzip.h
@@ -8,9 +8,12 @@
 #include <cstdint>
 
 #include "base/functional/callback_forward.h"
+#include "build/buildflag.h"
 #include "components/services/unzip/public/mojom/unzipper.mojom.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
-#include "third_party/ced/src/util/encodings/encodings.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "third_party/ced/src/util/encodings/encodings.h"  // nogncheck
+#endif  // !BUILDFLAG(IS_COBALT)
 
 namespace base {
 class FilePath;
@@ -40,10 +43,12 @@ base::OnceClosure Unzip(mojo::PendingRemote<mojom::Unzipper> unzipper,
 
 // Must be called on a sequenced task runner. `result_callback` will run on the
 // same sequence.
+#if !BUILDFLAG(IS_COBALT)
 using DetectEncodingCallback = base::OnceCallback<void(Encoding)>;
 void DetectEncoding(mojo::PendingRemote<mojom::Unzipper> unzipper,
                     const base::FilePath& zip_file,
                     DetectEncodingCallback result_callback);
+#endif  // !BUILDFLAG(IS_COBALT)
 
 // Must be called on a sequenced task runner. `result_callback` will run on the
 // same sequence.

--- a/third_party/blink/renderer/platform/BUILD.gn
+++ b/third_party/blink/renderer/platform/BUILD.gn
@@ -1865,6 +1865,7 @@ component("platform") {
   }
 
   if (is_cobalt) {
+    deps -= [ "//third_party/ced" ]
     if (use_dawn) {
       deps -= [ "//third_party/dawn/src/dawn/wire" ]
     } else {
@@ -2532,6 +2533,10 @@ source_set("blink_platform_unittests_sources") {
   defines = [ "INSIDE_BLINK" ]
   if (use_minikin_hyphenation) {
     defines += [ "USE_MINIKIN_HYPHENATION" ]
+  }
+
+  if (is_cobalt) {
+    sources -= [ "text/text_encoding_detector_test.cc" ]
   }
 }
 

--- a/third_party/blink/renderer/platform/loader/fetch/url_loader/navigation_body_loader.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/url_loader/navigation_body_loader.cc
@@ -19,6 +19,7 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/trace_event/trace_event.h"
+#include "build/buildflag.h"
 #include "mojo/public/cpp/base/big_buffer.h"
 #include "services/network/public/cpp/loading_params.h"
 #include "services/network/public/cpp/record_ontransfersizeupdate_utils.h"
@@ -42,7 +43,9 @@
 #include "third_party/blink/renderer/platform/wtf/text/string_builder.h"
 #include "third_party/blink/renderer/platform/wtf/vector.h"
 #include "third_party/blink/renderer/platform/wtf/wtf.h"
-#include "third_party/ced/src/compact_enc_det/compact_enc_det.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "third_party/ced/src/compact_enc_det/compact_enc_det.h"  // nogncheck
+#endif  // !BUILDFLAG(IS_COBALT)
 
 namespace blink {
 namespace {
@@ -458,11 +461,13 @@ void NavigationBodyLoader::StartLoadingBodyInBackground(
   if (!response_body_)
     return;
 
+#if !BUILDFLAG(IS_COBALT)
   // Initializing the map used when detecting encodings is not thread safe.
   // Initialize on the main thread here to avoid races.
   // TODO(crbug.com/1384221): Consider making the map thread safe in
   // third_party/ced/src/util/encodings/encodings.cc.
   EncodingNameAliasToEncoding("");
+#endif  // !BUILDFLAG(IS_COBALT)
 
   off_thread_body_reader_.reset(new OffThreadBodyReader(
       std::move(response_body_), std::move(decoder), weak_factory_.GetWeakPtr(),

--- a/third_party/blink/renderer/platform/text/text_encoding_detector.cc
+++ b/third_party/blink/renderer/platform/text/text_encoding_detector.cc
@@ -31,9 +31,12 @@
 #include "third_party/blink/renderer/platform/text/text_encoding_detector.h"
 
 #include "build/build_config.h"
+#include "build/buildflag.h"
 #include "third_party/blink/renderer/platform/weborigin/kurl.h"
 #include "third_party/blink/renderer/platform/wtf/text/text_encoding.h"
-#include "third_party/ced/src/compact_enc_det/compact_enc_det.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "third_party/ced/src/compact_enc_det/compact_enc_det.h"  // nogncheck
+#endif  // !BUILDFLAG(IS_COBALT)
 
 // third_party/ced/src/util/encodings/encodings.h, which is included
 // by the include above, undefs UNICODE because that is a macro used
@@ -52,6 +55,7 @@ bool DetectTextEncoding(base::span<const uint8_t> bytes,
                         const KURL& hint_url,
                         const char* hint_user_language,
                         WTF::TextEncoding* detected_encoding) {
+#if !BUILDFLAG(IS_COBALT)
   *detected_encoding = WTF::TextEncoding();
   // In general, do not use language hint. This helps get more
   // deterministic encoding detection results across devices. Note that local
@@ -83,6 +87,10 @@ bool DetectTextEncoding(base::span<const uint8_t> bytes,
   // determined from system locale or TLD.
   return !(encoding == UNKNOWN_ENCODING ||
            (hint_url.Protocol() != "file" && encoding == UTF8));
+#else
+  *detected_encoding = WTF::TextEncoding();
+  return false;
+#endif  // !BUILDFLAG(IS_COBALT)
 }
 
 }  // namespace blink


### PR DESCRIPTION
Disable the Compact Encoding Detector (CED) library for Cobalt builds
to reduce binary size. Cobalt primarily uses UTF-8 and does not
require dynamic encoding detection for web content or zip files.

This change removes the third_party/ced dependency and stubs out
detection logic in base, Blink, and unzip components. This reduces
the size of libcobalt.so and the Cobalt APK on Android and
Evergreen platforms.

```
# original
> du -s out/android-arm_gold/libchrobalt.so
69436   out/android-arm_gold/libchrobalt.so
> du -s out/android-arm_gold/apks/Cobalt.apk
88160   out/android-arm_gold/apks/Cobalt.apk
> du -s out/evergreen-arm-hardfp-rdk_gold/libcobalt.so
76512   out/evergreen-arm-hardfp-rdk_gold/libcobalt.so

# remove CED
> du -s out/android-arm_gold/libchrobalt.so
69232   out/android-arm_gold/libchrobalt.so
> du -s out/android-arm_gold/apks/Cobalt.apk
87952   out/android-arm_gold/apks/Cobalt.apk
> du -s out/evergreen-arm-hardfp-rdk_gold/libcobalt.so
76508   out/evergreen-arm-hardfp-rdk_gold/libcobalt.so
```

Issue: 520915383