### PR TITLE
ci: Bump init timeout

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
     if: |
       github.event.action != 'labeled' ||
       (github.event.pull_request.merged == false && github.event.label.name == 'runtest')
-    timeout-minutes: 10
+    timeout-minutes: 30
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Workaround for random GitHub slowness that causes timeouts during git checkout.

Bug: 1