### PR TITLE
Fix: Provide default for max_commits in autoroll_lts workflow

### DIFF
--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -75,11 +75,12 @@ jobs:
           set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
+          MAX_COMMITS=${{ inputs.max_commits || 25 }}
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
             --source-branch "${{ matrix.branch.source }}" \
             --target-branch "${{ matrix.branch.target }}" \
             --start-commit "${{ matrix.branch.start_commit }}" \
-            --max-commits "${{ inputs.max_commits }}" \
+            --max-commits "${MAX_COMMITS}" \
             --identifier-type "${{ matrix.branch.identifier_type }}")
 
           if [[ -n "${PR_LINKS}" ]]; then


### PR DESCRIPTION
**Issue:**

The `autoroll_lts` GitHub Action workflow fails when triggered by its hourly schedule. The error is `autoroll_lts.py: error: argument --max-commits: invalid int value: ''`. This occurs because the `${{ inputs.max_commits }}` expression results in an empty string, as the `workflow_dispatch` inputs (including its default value) are not used during scheduled runs.

**Fix:**

This change introduces a shell-level default for the `max_commits` value within the "Cherry Pick Merged PRs" step. The line `MAX_COMMITS=${{ inputs.max_commits || 25 }}` ensures that if `${{ inputs.max_commits }}` is empty (as in scheduled runs), `MAX_COMMITS` defaults to 25. This variable is then used when calling the `autoroll_lts.py` script.

This ensures the script always receives a valid integer for the `--max-commits` argument, resolving the error and allowing scheduled autorolls to function correctly.

Bug: 521431279