### PR TITLE
Fix: Provide default for max_commits in autoroll_lts workflow

### DIFF
--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -71,16 +71,17 @@ jobs:
 
       - name: Cherry Pick Merged PRs
         id: autoroll
+        env:
+          MAX_COMMITS: ${{ inputs.max_commits || 25 }}
         run: |
           set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
-          MAX_COMMITS=${{ inputs.max_commits || 25 }}
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
             --source-branch "${{ matrix.branch.source }}" \
             --target-branch "${{ matrix.branch.target }}" \
             --start-commit "${{ matrix.branch.start_commit }}" \
-            --max-commits "${MAX_COMMITS}" \
+            --max-commits "${{ env.MAX_COMMITS }}" \
             --identifier-type "${{ matrix.branch.identifier_type }}")
 
           if [[ -n "${PR_LINKS}" ]]; then

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -75,11 +75,12 @@ jobs:
           set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
+          MAX_COMMITS=${{ inputs.max_commits || 25 }}
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
             --source-branch "${{ matrix.branch.source }}" \
             --target-branch "${{ matrix.branch.target }}" \
             --start-commit "${{ matrix.branch.start_commit }}" \
-            --max-commits "${{ inputs.max_commits }}" \
+            --max-commits "${MAX_COMMITS}" \
             --identifier-type "${{ matrix.branch.identifier_type }}")
 
           if [[ -n "${PR_LINKS}" ]]; then


### PR DESCRIPTION
ci: Provide default max_commits for autoroll_lts

The autoroll_lts workflow fails during scheduled runs because the
max_commits input is empty, leading to an invalid integer error in the
autoroll_lts.py script. Scheduled runs do not use the default values
defined in workflow_dispatch inputs.

This change introduces a default value of 25 using the GitHub Actions
env context, ensuring the script always receives a valid integer for
the max-commits argument.

Bug: 521431279