### PR TITLE
starboard/tests: wire blink_common_unittests target

### DIFF
--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/blink_common_unittests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/blink_common_unittests_loader_filter.json
@@ -1,4 +1,5 @@
 {
+  "comment": "TODO(b/509955464): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
   "failing_tests": [
     "*"
   ]


### PR DESCRIPTION
Wire and quarantine `blink_common_unittests` target for the `evergreen-arm-hardfp-rdk` platform.

Split per target for easier review.

Includes:
- CI commit that adds target resolution and quarantines all tests for initial landing

Bug: 509955464