### PR TITLE
starboard/tests: wire storage_unittests target

### DIFF
--- a/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-arm-hardfp-rdk/test_targets.json
@@ -18,7 +18,6 @@
     "examples:views_examples_unittests_loader",
     "gl:gl_unittests_loader",
     "gl:ozone_gl_unittests_loader",
-    "storage:storage_unittests_loader",
     "third_party/blink/renderer/platform/heap:blink_heap_unittests_loader",
     "third_party/boringssl:boringssl_pki_tests_loader",
     "third_party/ipcz/src:ipcz_tests_loader",
@@ -36,7 +35,8 @@
     "third_party/blink/renderer/platform/wtf:wtf_unittests_loader",
     "ui/events:events_unittests_loader",
     "ui/ozone:ozone_unittests_loader",
-    "third_party/blink/common:blink_common_unittests_loader"
+    "third_party/blink/common:blink_common_unittests_loader",
+    "storage:storage_unittests_loader"
   ],
   "executables": [
     "out/evergreen-arm-hardfp-rdk_devel/crypto_unittests_loader.py",
@@ -47,6 +47,7 @@
     "out/evergreen-arm-hardfp-rdk_devel/wtf_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/events_unittests_loader.py",
     "out/evergreen-arm-hardfp-rdk_devel/ozone_unittests_loader.py",
-    "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py"
+    "out/evergreen-arm-hardfp-rdk_devel/blink_common_unittests_loader.py",
+    "out/evergreen-arm-hardfp-rdk_devel/storage_unittests_loader.py"
   ]
 }

--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/storage_unittests_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/storage_unittests_loader_filter.json
@@ -1,0 +1,6 @@
+{
+  "comment": "TODO(b/509862971): Quarantined for initial test landing on evergreen-arm-hardfp-rdk.",
+  "failing_tests": [
+    "*"
+  ]
+}


### PR DESCRIPTION
Wire and quarantine `storage_unittests` target for the `evergreen-arm-hardfp-rdk` platform.

Split per target for easier review.

Includes:
- CI commit that adds target resolution and quarantines all tests for initial landing

Bug: 509862971