### PR TITLE
Revert 'attribution: Gate API under enable_privacy_sandbox_apis'

### DIFF
--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -2519,13 +2519,8 @@ source_set("browser") {
     "worker_host/worker_script_loader_factory.h",
   ]
 
-  # If in the future privacy sandbox components are removed from the code base, ignore this if block.
   if (!enable_privacy_sandbox_apis) {
-    _filtered_sources = filter_exclude(sources,
-                                       [
-                                         "browsing_topics/*",
-                                         "attribution_reporting/*",
-                                       ])
+    _filtered_sources = filter_exclude(sources, [ "browsing_topics/*" ])
     sources = []
     sources = _filtered_sources
     deps -= [ "//components/browsing_topics/common:common" ]
@@ -3252,7 +3247,7 @@ source_set("browser") {
     }
   }
 
-  if (((is_linux && !is_cobalt_hermetic_build) || is_chromeos) && use_aura) {
+  if ((is_linux && !is_cobalt_hermetic_build || is_chromeos) && use_aura) {
     deps += [ "//third_party/fontconfig" ]
   }
 

--- a/content/browser/browser_interface_binders.cc
+++ b/content/browser/browser_interface_binders.cc
@@ -4,12 +4,6 @@
 
 #include "content/browser/browser_interface_binders.h"
 
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "third_party/blink/public/public_buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include "base/check_op.h"
 #include "base/command_line.h"
 #include "base/feature_list.h"
@@ -22,15 +16,15 @@
 #include "build/branding_buildflags.h"
 #include "build/build_config.h"
 #include "cc/base/switches.h"
+#include "content/public/common/content_milestone_features.h"
+#include "content/public/common/buildflags.h"
 #if !BUILDFLAG(IS_COBALT)
 #include "components/language_detection/content/common/language_detection.mojom.h"  // nogncheck
 #endif  // !BUILDFLAG(IS_COBALT)
 #include "components/optimization_guide/public/mojom/model_broker.mojom.h"
 #include "components/viz/host/gpu_client.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_internals.mojom.h"
 #include "content/browser/attribution_reporting/attribution_internals_ui.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/background_fetch/background_fetch_service_impl.h"
 #include "content/browser/bad_message.h"
 #include "content/browser/bluetooth/web_bluetooth_service_impl.h"
@@ -208,6 +202,7 @@
 #include "third_party/blink/public/mojom/webtransport/web_transport_connector.mojom.h"
 #include "third_party/blink/public/mojom/worker/dedicated_worker_host_factory.mojom.h"
 #include "third_party/blink/public/mojom/worker/shared_worker_connector.mojom.h"
+#include "third_party/blink/public/public_buildflags.h"
 #include "url/origin.h"
 
 #if BUILDFLAG(IS_ANDROID)
@@ -1257,10 +1252,8 @@ void PopulateBinderMapWithContext(
   RegisterWebUIControllerInterfaceBinder<
       private_aggregation_internals::mojom::Factory,
       PrivateAggregationInternalsUI>(map);
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   RegisterWebUIControllerInterfaceBinder<attribution_internals::mojom::Factory,
                                          AttributionInternalsUI>(map);
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   RegisterWebUIControllerInterfaceBinder<storage::mojom::IdbInternalsHandler,
                                          indexed_db::IndexedDBInternalsUI>(map);
   RegisterWebUIControllerInterfaceBinder<::mojom::ProcessInternalsHandler,

--- a/content/browser/loader/keep_alive_attribution_request_helper.cc
+++ b/content/browser/loader/keep_alive_attribution_request_helper.cc
@@ -4,12 +4,6 @@
 
 #include "content/browser/loader/keep_alive_attribution_request_helper.h"
 
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "content/public/common/buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include <stdint.h>
 
 #include <memory>
@@ -30,11 +24,9 @@
 #include "components/attribution_reporting/features.h"
 #include "components/attribution_reporting/registration_eligibility.mojom-forward.h"
 #include "components/attribution_reporting/suitable_origin.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_background_registrations_id.h"
 #include "content/browser/attribution_reporting/attribution_data_host_manager.h"
 #include "content/browser/attribution_reporting/attribution_suitable_context.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/renderer_host/document_associated_data.h"
 #include "content/browser/renderer_host/render_frame_host_impl.h"
 #include "content/public/browser/global_routing_id.h"
@@ -48,7 +40,6 @@
 
 namespace content {
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 namespace {
 
 using ::attribution_reporting::AttributionSrcRequestStatus;
@@ -272,37 +263,5 @@ void KeepAliveAttributionRequestHelper::RecordAttributionSrcRequestStatus(
 KeepAliveAttributionRequestHelper::~KeepAliveAttributionRequestHelper() {
   OnComplete();
 }
-#else
-// static
-std::unique_ptr<KeepAliveAttributionRequestHelper>
-KeepAliveAttributionRequestHelper::CreateIfNeeded(
-    network::mojom::AttributionReportingEligibility,
-    const GURL&,
-    const std::optional<base::UnguessableToken>&,
-    const std::optional<std::string>&,
-    const std::optional<AttributionSuitableContext>&,
-    WeakDocumentPtr) {
-  return nullptr;
-}
-
-KeepAliveAttributionRequestHelper::KeepAliveAttributionRequestHelper(
-    BackgroundRegistrationsId,
-    AttributionDataHostManager*,
-    const GURL&,
-    bool,
-    WeakDocumentPtr) {}
-
-KeepAliveAttributionRequestHelper::~KeepAliveAttributionRequestHelper() =
-    default;
-
-void KeepAliveAttributionRequestHelper::OnReceiveRedirect(
-    scoped_refptr<net::HttpResponseHeaders>,
-    const GURL&) {}
-
-void KeepAliveAttributionRequestHelper::OnReceiveResponse(
-    scoped_refptr<net::HttpResponseHeaders>) {}
-
-void KeepAliveAttributionRequestHelper::OnError() {}
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
 }  // namespace content

--- a/content/browser/loader/keep_alive_attribution_request_helper.h
+++ b/content/browser/loader/keep_alive_attribution_request_helper.h
@@ -11,24 +11,10 @@
 #include <optional>
 #include <string>
 
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "content/public/common/buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include "base/memory/scoped_refptr.h"
 #include "base/memory/weak_ptr.h"
-#include "base/unguessable_token.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_background_registrations_id.h"
 #include "content/browser/attribution_reporting/attribution_suitable_context.h"
-#else
-namespace content {
-class AttributionSuitableContext;
-using BackgroundRegistrationsId = int64_t;
-}  // namespace content
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/common/content_export.h"
 #include "content/public/browser/weak_document_ptr.h"
 #include "services/network/public/mojom/attribution.mojom-forward.h"

--- a/content/browser/loader/keep_alive_url_loader_service.cc
+++ b/content/browser/loader/keep_alive_url_loader_service.cc
@@ -4,12 +4,6 @@
 
 #include "content/browser/loader/keep_alive_url_loader_service.h"
 
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "content/public/common/buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include <map>
 
 #include "base/feature_list.h"
@@ -17,9 +11,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "base/trace_event/typed_macros.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_suitable_context.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/loader/keep_alive_attribution_request_helper.h"
 #include "content/browser/loader/keep_alive_url_loader.h"
 #include "content/browser/renderer_host/document_associated_data.h"
@@ -71,9 +63,7 @@ KeepAliveURLLoaderService::FactoryContext::FactoryContext(
       weak_document_ptr(other->weak_document_ptr),
       ukm_source_id(other->ukm_source_id),
       policy_container_host(other->policy_container_host),
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
       attribution_context(other->attribution_context),
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
       network_isolation_key(other->network_isolation_key) {}
 
 KeepAliveURLLoaderService::FactoryContext::~FactoryContext() = default;
@@ -94,11 +84,9 @@ void KeepAliveURLLoaderService::FactoryContext::OnDidCommitNavigation(
   ukm_source_id = navigation_handle->GetNextPageUkmSourceId();
   policy_container_host = rfh->policy_container_host();
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   // `attribution_context` is needed for all kinds of keepalive requests, as
   // trigger registrations are allowed for all subresource requests.
   attribution_context = AttributionSuitableContext::Create(navigation_handle);
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   CHECK(policy_container_host);
 
@@ -116,9 +104,7 @@ void KeepAliveURLLoaderService::FactoryContext::
       weak_document_ptr.AsRenderFrameHostIfValid());
   CHECK(rfh);
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   attribution_context = AttributionSuitableContext::Create(rfh);
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 void KeepAliveURLLoaderService::FactoryContext::
@@ -275,17 +261,12 @@ class KeepAliveURLLoaderService::KeepAliveURLLoaderFactoriesBase {
         base::BindRepeating(&KeepAliveURLLoaderFactoriesBase::CreateThrottles,
                             base::Unretained(this)),
         base::PassKey<KeepAliveURLLoaderService>(),
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
         KeepAliveAttributionRequestHelper::CreateIfNeeded(
             resource_request.attribution_reporting_eligibility,
             resource_request.url,
             resource_request.attribution_reporting_src_token,
             resource_request.devtools_request_id, context->attribution_context,
-            context->weak_document_ptr)
-#else
-        nullptr
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
-    );
+            context->weak_document_ptr));
     // Adds a new loader receiver to the set held by `this`, binding the pending
     // `receiver` from a renderer to `raw_loader` with `loader` as its context.
     // The set will keep `loader` alive.

--- a/content/browser/loader/keep_alive_url_loader_service.h
+++ b/content/browser/loader/keep_alive_url_loader_service.h
@@ -8,17 +8,9 @@
 #include <memory>
 #include <optional>
 
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "content/public/common/buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include "base/containers/lru_cache.h"
 #include "base/memory/scoped_refptr.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_suitable_context.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/loader/keep_alive_url_loader.h"
 #include "content/common/content_export.h"
 #include "content/public/browser/weak_document_ptr.h"
@@ -148,9 +140,7 @@ class CONTENT_EXPORT KeepAliveURLLoaderService {
     // context and information from that context is needed. Upon
     // NavigationRequest::DidCommitNavigation(), if the context is suitable,
     // the `attribution_context` is created.
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
     std::optional<AttributionSuitableContext> attribution_context;
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
     // On NavigationRequest::DidCommitNavigation(), this field is set to the
     // network isolation key of the committed RenderFrameHostImpl.

--- a/content/browser/renderer_host/render_frame_host_impl_interface_binders.cc
+++ b/content/browser/renderer_host/render_frame_host_impl_interface_binders.cc
@@ -6,13 +6,6 @@
 #include <vector>
 
 #include "base/debug/dump_without_crashing.h"
-
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "content/public/common/buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/memory/raw_ptr.h"
@@ -20,9 +13,7 @@
 #include "base/metrics/metrics_hashes.h"
 #include "base/task/single_thread_task_runner.h"
 #include "content/browser/accessibility/render_accessibility_host.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_host.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/blob_storage/chrome_blob_storage_context.h"
 #include "content/browser/file_system/file_system_manager_impl.h"
 #include "content/browser/geolocation/geolocation_service_impl.h"
@@ -339,7 +330,6 @@ void RenderFrameHostImpl::SetUpMojoConnection() {
           },
           base::Unretained(this)));
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   associated_registry_->AddInterface<blink::mojom::AttributionHost>(
       base::BindRepeating(
           [](RenderFrameHostImpl* impl,
@@ -348,7 +338,6 @@ void RenderFrameHostImpl::SetUpMojoConnection() {
             AttributionHost::BindReceiver(std::move(receiver), impl);
           },
           base::Unretained(this)));
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   associated_registry_->AddInterface<device::mojom::ScreenOrientation>(
       base::BindRepeating(

--- a/content/browser/storage_partition_impl.cc
+++ b/content/browser/storage_partition_impl.cc
@@ -4,12 +4,6 @@
 
 #include "content/browser/storage_partition_impl.h"
 
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "content/public/common/buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include <stdint.h>
 
 #include <functional>
@@ -137,6 +131,8 @@
 #include "content/public/browser/storage_partition_config.h"
 #include "content/public/browser/storage_usage_info.h"
 #include "content/public/common/content_client.h"
+#include "content/public/common/content_milestone_features.h"
+#include "content/public/common/buildflags.h"
 #include "content/public/common/content_constants.h"
 #include "content/public/common/content_features.h"
 #include "content/public/common/content_switches.h"
@@ -1477,7 +1473,6 @@ void StoragePartitionImpl::Initialize(
 
   bucket_manager_ = std::make_unique<BucketManager>(this);
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   if (base::FeatureList::IsEnabled(
           attribution_reporting::features::kConversionMeasurement)) {
     // The Conversion Measurement API is not available in Incognito mode, but
@@ -1486,7 +1481,6 @@ void StoragePartitionImpl::Initialize(
     attribution_manager_ = std::make_unique<AttributionManagerImpl>(
         this, path, special_storage_policy_);
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   if (base::FeatureList::IsEnabled(network::features::kInterestGroupStorage)) {
     // Auction worklets on non-Android use dedicated processes; on Android due
@@ -1844,20 +1838,12 @@ StoragePartitionImpl::GetFileSystemAccessManager() {
 
 AttributionManager* StoragePartitionImpl::GetAttributionManager() {
   DCHECK(initialized_);
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   return attribution_manager_.get();
-#else
-  return nullptr;
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 AttributionDataModel* StoragePartitionImpl::GetAttributionDataModel() {
   DCHECK(initialized_);
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   return attribution_manager_.get();
-#else
-  return nullptr;
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 FontAccessManager* StoragePartitionImpl::GetFontAccessManager() {
@@ -2781,7 +2767,7 @@ void StoragePartitionImpl::ClearDataImpl(
       std::move(cookie_deletion_filter), GetPath(), dom_storage_context_.get(),
       quota_manager_.get(), special_storage_policy_.get(),
       filesystem_context_.get(), GetCookieManagerForBrowserProcess(),
-      interest_group_manager_.get(), GetAttributionManager(),
+      interest_group_manager_.get(), attribution_manager_.get(),
       aggregation_service_.get(), private_aggregation_manager_.get(),
       shared_storage_manager_.get(),
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
@@ -3139,7 +3125,6 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
     }
   }
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   // It is not expected to only delete internal attribution reporting data.
   DCHECK(!(remove_mask_ & REMOVE_DATA_MASK_ATTRIBUTION_REPORTING_INTERNAL) ||
          remove_mask_ & REMOVE_DATA_MASK_ATTRIBUTION_REPORTING_SITE_CREATED);
@@ -3164,7 +3149,6 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
               CreateTaskCompletionClosure(TracingDataType::kConversions)));
     }
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   if (aggregation_service &&
       (remove_mask_ & REMOVE_DATA_MASK_AGGREGATION_SERVICE)) {

--- a/content/browser/storage_partition_impl.h
+++ b/content/browser/storage_partition_impl.h
@@ -12,12 +12,6 @@
 #include <set>
 #include <string>
 
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "content/public/common/buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include "base/containers/flat_map.h"
 #include "base/dcheck_is_on.h"
 #include "base/files/file_path.h"
@@ -39,6 +33,8 @@
 #include "content/browser/service_worker/service_worker_context_wrapper.h"
 #include "content/browser/worker_host/dedicated_worker_service_impl.h"
 #include "content/common/content_export.h"
+#include "content/public/common/content_milestone_features.h"
+#include "content/public/common/buildflags.h"
 #include "content/public/browser/storage_partition.h"
 #include "content/public/browser/storage_partition_config.h"
 #include "media/media_buildflags.h"
@@ -809,9 +805,7 @@ class CONTENT_EXPORT StoragePartitionImpl
   std::unique_ptr<leveldb_proto::ProtoDatabaseProvider>
       proto_database_provider_;
   scoped_refptr<ContentIndexContextImpl> content_index_context_;
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   std::unique_ptr<AttributionManager> attribution_manager_;
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   std::unique_ptr<FontAccessManager> font_access_manager_;
   std::unique_ptr<InterestGroupManagerImpl> interest_group_manager_;
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138

--- a/content/browser/web_contents/web_contents_impl.cc
+++ b/content/browser/web_contents/web_contents_impl.cc
@@ -4,12 +4,6 @@
 
 #include "content/browser/web_contents/web_contents_impl.h"
 
-// clang-format off
-// Remove these two includes after CHROMIUM_MILESTONE_LE_138
-#include "content/public/common/buildflags.h"
-#include "content/public/common/content_milestone_features.h"
-// clang-format on
-
 #include <stddef.h>
 
 #include <algorithm>
@@ -68,11 +62,9 @@
 #include "components/viz/common/features.h"
 #include "components/viz/host/host_frame_sink_manager.h"
 #include "content/browser/accessibility/browser_accessibility_state_impl.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_host.h"
 #include "content/browser/attribution_reporting/attribution_manager.h"
 #include "content/browser/attribution_reporting/attribution_os_level_manager.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/bad_message.h"
 #include "content/browser/browser_context_impl.h"
 #include "content/browser/browser_main_loop.h"
@@ -4115,14 +4107,12 @@ void WebContentsImpl::Init(const WebContents::CreateParams& params,
   DateTimeChooser::CreateDateTimeChooser(this);
 #endif
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   // AttributionHost must be created after `view_->CreateView()` is called as it
   // may invoke `WebContentsAndroid::AddObserver()`.
   if (base::FeatureList::IsEnabled(
           attribution_reporting::features::kConversionMeasurement)) {
     AttributionHost::CreateForWebContents(this);
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   RedirectChainDetector::CreateForWebContents(this);
   BtmWebContentsObserver::MaybeCreateForWebContents(this);
@@ -12158,7 +12148,6 @@ void WebContentsImpl::SetOverscrollNavigationEnabled(bool enabled) {
 }
 
 network::mojom::AttributionSupport WebContentsImpl::GetAttributionSupport() {
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   ContentBrowserClient::AttributionReportingOsRegistrars reportTypes =
       AttributionOsLevelManager::GetAttributionReportingOsRegistrars(this);
 
@@ -12167,9 +12156,6 @@ network::mojom::AttributionSupport WebContentsImpl::GetAttributionSupport() {
           AttributionReportingOsRegistrar::kDisabled &&
       reportTypes.trigger_registrar ==
           AttributionReportingOsRegistrar::kDisabled);
-#else
-  return network::mojom::AttributionSupport::kNone;
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 void WebContentsImpl::UpdateAttributionSupportRenderer() {

--- a/content/public/android/BUILD.gn
+++ b/content/public/android/BUILD.gn
@@ -4,7 +4,6 @@
 
 import("//build/config/android/config.gni")
 import("//build/config/android/rules.gni")
-import("//content/public/common/features.gni")
 import("//device/vr/buildflags/buildflags.gni")
 import("//third_party/jni_zero/jni_zero.gni")
 import("//tools/grit/grit_rule.gni")
@@ -232,7 +231,7 @@ android_library("content_full_java") {
   if(is_cobalt) {
     deps -= [ "//services/shape_detection:shape_detection_java" ]
   }
-
+  
   srcjar_deps = [
     ":content_jni_headers",
     ":is_ready_to_pay_service_aidl",
@@ -440,13 +439,6 @@ android_library("content_full_java") {
     "java/src/org/chromium/content_public/browser/selection/SelectionDropdownMenuDelegate.java",
   ]
 
-  # If in the future privacy sandbox components are removed from the code base, ignore this if block.
-  if (!enable_privacy_sandbox_apis) {
-    sources -= [
-      "java/src/org/chromium/content/browser/AttributionOsLevelManager.java",
-    ]
-  }
-
   public_deps = [ "//ui/base/mojom:ui_base_types_java" ]
 }
 
@@ -552,13 +544,6 @@ generate_jni("content_jni_headers") {
     "java/src/org/chromium/content_public/browser/NavigationHandle.java",
     "java/src/org/chromium/content_public/browser/Page.java",
   ]
-
-  # If in the future privacy sandbox components are removed from the code base, ignore this if block.
-  if (!enable_privacy_sandbox_apis) {
-    sources -= [
-      "java/src/org/chromium/content/browser/AttributionOsLevelManager.java",
-    ]
-  }
 }
 
 group("browser_jni") {


### PR DESCRIPTION
This reverts the following accidental commits:
- 5e27d0370b06 (Fix1)
- 849e7534a0fd (remove unnecessary changes)
- 04197f4caa9b (Remove attribution_reporting)

This restores the main branch to the clean state (0bc643df0d28).

Bug: 505811196