### PR TITLE
Remove Vulkan dependency from Chrobalt

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -83,3 +83,6 @@ rtc_include_dav1d_in_internal_decoder_factory = false
 # rodata. Cobalt is a closed app shell and does not need
 # a preloaded list of third-party domains.
 include_transport_security_state_preload_list = false
+
+# Disable Vulkan on Cobalt, this reduces binary size (~1.2MB)
+angle_enable_vulkan = false


### PR DESCRIPTION
Vulkan should not be supported by Chrobalt.

This PR saves ~1.2MB on coat gold build:
```
Before:
haozheng@haozheng-usa-backup-1:~/cobalt/src$ ls -l ~/cobalt/src/out/android-arm_gold/libchrobalt.so
-rwxr-xr-x 1 haozheng primarygroup 71099964 Jun  8 19:18 /usr/local/google/home/haozheng/cobalt/src/out/android-arm_gold/libchrobalt.so

After:
haozheng@haozheng-usa-backup-1:~/cobalt/src$ ls -l ~/cobalt/src/out/android-arm_gold/libchrobalt.so
-rwxr-xr-x 1 haozheng primarygroup 69916220 Jun  8 19:36 /usr/local/google/home/haozheng/cobalt/src/out/android-arm_gold/libchrobalt.so
```


Bug: 521513706