### PR TITLE
starboard: Fix SB_DCHECK with Objective-C++ message sends

### DIFF
--- a/starboard/common/check_op.h
+++ b/starboard/common/check_op.h
@@ -246,7 +246,12 @@ DEFINE_SB_CHECK_OP_IMPL(GT, > )
 
 #else
 
-#define SB_DCHECK_OP(name, op, val1, val2) SB_EAT_STREAM_PARAMETERS
+// Mirrors //base/check_op.h: keeps CheckOpValueStr instantiated to avoid
+// unused-function warnings in modular builds.
+#define SB_DCHECK_OP(name, op, val1, val2)                        \
+  SB_EAT_CHECK_STREAM_PARAMS((::starboard::CheckOpValueStr(val1), \
+                              ::starboard::CheckOpValueStr(val2), \
+                              (val1)op(val2)))
 #endif
 
 // clang-format off

--- a/starboard/common/log.h
+++ b/starboard/common/log.h
@@ -114,6 +114,17 @@ class LogMessageVoidify {
   void operator&(std::ostream&);
 };
 
+// Copied from base/check.h.
+// Class used to explicitly ignore an ostream, and optionally a boolean value.
+class VoidifyStream {
+ public:
+  VoidifyStream() = default;
+  explicit VoidifyStream(bool) {}
+
+  // Binary & has lower precedence than << but higher than ?:
+  void operator&(std::ostream&) {}
+};
+
 }  // namespace starboard
 
 #define SB_LOG_MESSAGE_INFO \
@@ -148,6 +159,8 @@ class LogMessageVoidify {
   SB_LAZY_STREAM(SB_LOG_STREAM(severity), SB_LOG_IS_ON(severity) && (condition))
 #define SB_LOG(severity) SB_LOG_IF(severity, true)
 #define SB_EAT_STREAM_PARAMETERS SB_LOG_IF(INFO, false)
+#define SB_EAT_CHECK_STREAM_PARAMS(expr) \
+  true ? (void)0 : ::starboard::VoidifyStream(expr) & SB_LOG_STREAM(INFO)
 #define SB_STACK_IF(severity, condition) \
   SB_LOG_IF(severity, condition) << "\n" << ::starboard::Stack(0)
 #define SB_STACK(severity) SB_STACK_IF(severity, true)
@@ -174,14 +187,7 @@ class LogMessageVoidify {
 
 #if SB_LOGGING_IS_OFFICIAL_BUILD || \
     (defined(NDEBUG) && !defined(DCHECK_ALWAYS_ON))
-class SbDcheckNoOpStream {
- public:
-  template <typename T>
-  const SbDcheckNoOpStream& operator<<(const T&) const {
-    return *this;
-  }
-};
-#define SB_DCHECK(condition) (void)sizeof(bool(condition)), SbDcheckNoOpStream()
+#define SB_DCHECK(condition) SB_EAT_CHECK_STREAM_PARAMS(!(condition))
 #define SB_DCHECK_ENABLED 0
 #else
 #define SB_DCHECK(condition) SB_CHECK(condition)


### PR DESCRIPTION
SB_DCHECK fails to compile in QA builds when the condition contains
Objective-C message send syntax like [obj method:arg]. This happens
because the disabled SB_DCHECK uses `sizeof(bool(condition))`, and
the C++ parser inside sizeof interprets brackets as array subscripts
rather than message sends.

Replace the sizeof pattern with the VoidifyStream ternary approach
already used by //base/check.h.

Also update SB_DCHECK_OP to use the same pattern, keeping
CheckOpValueStr referenced to avoid unused-function warnings.

Bug: 512045535
Bug: 447838008