### PR TITLE
cobalt tests: Only reference detailed_stats_kb when not on tvOS

### DIFF
--- a/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
+++ b/cobalt/browser/metrics/cobalt_metrics_service_client_test.cc
@@ -82,6 +82,7 @@ class TestProcessMemoryMetricsEmitter : public CobaltMemoryMetricsEmitter {
     browser_dump->os_dump->private_footprint_kb = 10240;  // 10 MB
     browser_dump->os_dump->resident_set_kb = 20480;       // 20 MB
     browser_dump->os_dump->shared_footprint_kb = 5120;    // 5 MB
+#if !BUILDFLAG(IS_IOS_TVOS)
     browser_dump->os_dump->detailed_stats_kb = {
         {"rss:partition_alloc", 16384},
         {"rss:malloc", 10240},
@@ -89,6 +90,7 @@ class TestProcessMemoryMetricsEmitter : public CobaltMemoryMetricsEmitter {
         {"rss:lib_chrobalt", 10240},
         {"pss:lib_chrobalt", 8192},
     };
+#endif  // !BUILDFLAG(IS_IOS_TVOS)
 
     // Add a blink_gc dump
     auto blink_gc_dump = memory_instrumentation::mojom::AllocatorMemDump::New();
@@ -198,9 +200,11 @@ class TestProcessMemoryMetricsEmitter : public CobaltMemoryMetricsEmitter {
         memory_instrumentation::mojom::ProcessType::RENDERER;
     renderer_dump->os_dump = memory_instrumentation::mojom::OSMemDump::New();
     renderer_dump->os_dump->private_footprint_kb = 20480;  // 20 MB
+#if !BUILDFLAG(IS_IOS_TVOS)
     renderer_dump->os_dump->detailed_stats_kb = {
         {"rss:partition_alloc", 2048},
     };
+#endif  // !BUILDFLAG(IS_IOS_TVOS)
 
     auto renderer_blink_gc_dump =
         memory_instrumentation::mojom::AllocatorMemDump::New();


### PR DESCRIPTION
Follow-up to #10583.

This fixes the cobalt_unittests build on tvOS after #10248. This field is only enabled in Mojo on Linux and Android.

Bug: 494004530