### PR TITLE
media: Fix use-after-free in Mojo bypass

### DIFF
--- a/media/mojo/clients/mojo_renderer.cc
+++ b/media/mojo/clients/mojo_renderer.cc
@@ -4,13 +4,10 @@
 
 #include "media/mojo/clients/mojo_renderer.h"
 
-#include <utility>
-
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-#include "base/command_line.h"
-#include "base/feature_list.h"
-#include "media/base/media_switches.h"
-#endif
+#include <atomic>
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+#include <utility>
 
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
@@ -27,7 +24,19 @@
 #include "media/mojo/common/media_type_converters.h"
 #include "media/renderers/video_overlay_factory.h"
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "base/command_line.h"
+#include "base/feature_list.h"
+#include "media/base/media_switches.h"
+#endif
+
 namespace media {
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+namespace {
+std::atomic<uint32_t> g_next_bypass_id{1};
+}  // namespace
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 MojoRenderer::MojoRenderer(
     const scoped_refptr<base::SequencedTaskRunner>& task_runner,
@@ -54,6 +63,13 @@ MojoRenderer::~MojoRenderer() {
   DVLOG(1) << __func__;
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  if (bypass_bridge_) {
+    bypass_bridge_->Invalidate();
+    BypassBridgeRegistry::Unregister(bypass_id_);
+  }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   CancelPendingCallbacks();
 }
 
@@ -75,26 +91,31 @@ void MojoRenderer::Initialize(MediaResource* media_resource,
   init_cb_ = std::move(init_cb);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if ((base::FeatureList::IsEnabled(kCobaltBypassMojoForMedia) || bypass_mojo_for_media_) &&
+  if ((base::FeatureList::IsEnabled(kCobaltBypassMojoForMedia)
+       || bypass_mojo_for_media_) &&
       base::CommandLine::ForCurrentProcess()->HasSwitch("single-process")) {
-    std::vector<DemuxerStream*> streams = media_resource_->GetAllStreams();
-    std::vector<uint64_t> stream_pointers;
-    for (media::DemuxerStream* stream : streams) {
-      stream_pointers.push_back(reinterpret_cast<uint64_t>(stream));
-    }
-    
+
+    // Create the bypass bridge to manage shared state and callbacks.
+    bypass_bridge_ = base::MakeRefCounted<MojoRendererBypassBridge>(
+        task_runner_,
+        base::BindRepeating(&MojoRenderer::OnTimeUpdate,
+          weak_factory_.GetWeakPtr()),
+        base::BindRepeating(&MojoRenderer::OnStatisticsUpdate,
+          weak_factory_.GetWeakPtr()));
+    // Set the actual streams in the bridge.
+    DemuxerStream* audio_stream = media_resource_->GetFirstStream(
+      DemuxerStream::AUDIO);
+    DemuxerStream* video_stream = media_resource_->GetFirstStream(
+      DemuxerStream::VIDEO);
+    bypass_bridge_->SetStreams(audio_stream, video_stream);
+    // Generate a unique ID and register the bridge.
+    bypass_id_ = g_next_bypass_id.fetch_add(1);
+    BypassBridgeRegistry::Register(bypass_id_, bypass_bridge_);
     BindRemoteRendererIfNeeded();
-    
-    // Pass 'this' as a raw pointer (cast to uint64_t) to bypass Mojo for
-    // high-frequency callbacks like OnStatisticsUpdate and OnTimeUpdate.
-    // This is safe in single-process mode because MojoRenderer outlives
-    // MojoRendererService (guaranteed by Mojo SelfOwnedReceiver).
-    remote_renderer_->InitializeWithStreamPointers(client_receiver_.BindNewEndpointAndPassRemote(),
-                                                   std::move(stream_pointers),
-                                                   reinterpret_cast<uint64_t>(static_cast<mojom::RendererClient*>(this)),
-                                                   reinterpret_cast<uint64_t>(task_runner_.get()),
-                                                   base::BindOnce(&MojoRenderer::OnInitialized,
-                                                                  base::Unretained(this), client));
+    remote_renderer_->InitializeWithBypassBridge(
+        client_receiver_.BindNewEndpointAndPassRemote(),
+        bypass_id_, base::BindOnce(&MojoRenderer::OnInitialized,
+                                   base::Unretained(this), client));
     return;
   }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/mojo/clients/mojo_renderer.h
+++ b/media/mojo/clients/mojo_renderer.h
@@ -23,6 +23,10 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/remote.h"
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 namespace media {
 
 class MediaResource;
@@ -135,7 +139,9 @@ class MojoRenderer : public Renderer, public mojom::RendererClient {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   bool bypass_mojo_for_media_ = false;
-#endif
+  scoped_refptr<MojoRendererBypassBridge> bypass_bridge_;
+  uint32_t bypass_id_ = 0;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Mojo demuxer streams.
   // Owned by MojoRenderer instead of remote mojom::Renderer
@@ -170,6 +176,10 @@ class MojoRenderer : public Renderer, public mojom::RendererClient {
   media::TimeDeltaInterpolator media_time_interpolator_;
 
   std::optional<PipelineStatistics> pending_stats_;
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  base::WeakPtrFactory<MojoRenderer> weak_factory_{this};
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 }  // namespace media

--- a/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
@@ -55,12 +55,10 @@ class FakeMojomRenderer : public mojom::Renderer {
       InitializeCallback cb) override {
     std::move(cb).Run(true);
   }
-  void InitializeWithStreamPointers(
+  void InitializeWithBypassBridge(
       mojo::PendingAssociatedRemote<mojom::RendererClient>,
-      const std::optional<std::vector<uint64_t>>& stream_pointers,
-      uint64_t client_pointer,
-      uint64_t task_runner_pointer,
-      InitializeWithStreamPointersCallback cb) override {
+      uint32_t bypass_bridge_id,
+      InitializeWithBypassBridgeCallback cb) override {
     std::move(cb).Run(true);
   }
   MOCK_METHOD1(Flush, void(FlushCallback));

--- a/media/mojo/common/BUILD.gn
+++ b/media/mojo/common/BUILD.gn
@@ -2,6 +2,11 @@
 # Use of this source code is governed by a BSD-style license that can be
 # found in the LICENSE file.
 
+import("//media/media_options.gni")
+if (is_cobalt) {
+  import("//starboard/build/buildflags.gni")
+}
+
 source_set("common") {
   sources = [
     "audio_data_s16_converter.cc",
@@ -19,6 +24,13 @@ source_set("common") {
     "validation_utils.cc",
     "validation_utils.h",
   ]
+
+  if (is_cobalt && use_starboard_media) {
+    sources += [
+      "starboard/mojo_renderer_bypass_bridge.cc",
+      "starboard/mojo_renderer_bypass_bridge.h",
+    ]
+  }
 
   deps = [
     "//base",

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
@@ -1,0 +1,196 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
+
+#include "base/functional/bind.h"
+#include "base/no_destructor.h"
+#include "media/base/audio_decoder_config.h"
+#include "media/base/decoder_buffer.h"
+#include "media/base/video_decoder_config.h"
+
+namespace media {
+
+MojoRendererBypassBridge::MojoRendererBypassBridge(
+    scoped_refptr<base::SequencedTaskRunner> client_task_runner,
+    TimeUpdateCB time_update_cb,
+    StatisticsUpdateCB statistics_update_cb)
+    : client_task_runner_(std::move(client_task_runner)),
+      time_update_cb_(std::move(time_update_cb)),
+      statistics_update_cb_(std::move(statistics_update_cb)),
+      cond_var_(&lock_) {}
+
+MojoRendererBypassBridge::~MojoRendererBypassBridge() {
+  Invalidate();
+}
+
+void MojoRendererBypassBridge::Invalidate() {
+  base::AutoLock auto_lock(lock_);
+  active_ = false;
+  audio_stream_ = nullptr;
+  video_stream_ = nullptr;
+  while (in_flight_reads_ > 0) {
+    cond_var_.Wait();
+  }
+}
+
+void MojoRendererBypassBridge::SetStreams(DemuxerStream* audio,
+                                          DemuxerStream* video) {
+  base::AutoLock auto_lock(lock_);
+  audio_stream_ = audio;
+  video_stream_ = video;
+}
+
+void MojoRendererBypassBridge::PostTimeUpdate(base::TimeDelta time,
+                                              base::TimeDelta max_time,
+                                              base::TimeTicks capture_time) {
+  client_task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(&MojoRendererBypassBridge::RunTimeUpdateOnClientThread,
+                     this, time, max_time, capture_time));
+}
+
+void MojoRendererBypassBridge::PostStatisticsUpdate(
+    const PipelineStatistics& stats) {
+  client_task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          &MojoRendererBypassBridge::RunStatisticsUpdateOnClientThread, this,
+          stats));
+}
+
+bool MojoRendererBypassBridge::Read(DemuxerStream::Type type,
+                                    uint32_t count,
+                                    DemuxerStream::ReadCB read_cb) {
+  DemuxerStream* stream = nullptr;
+  {
+    base::AutoLock auto_lock(lock_);
+    if (!active_) {
+      std::move(read_cb).Run(DemuxerStream::kAborted, {});
+      return false;
+    }
+    stream = (type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_);
+    if (stream) {
+      in_flight_reads_++;
+    }
+  }
+  if (!stream) {
+    std::move(read_cb).Run(DemuxerStream::kAborted, {});
+    return false;
+  }
+
+  stream->Read(count, std::move(read_cb));
+
+  {
+    base::AutoLock auto_lock(lock_);
+    in_flight_reads_--;
+    if (in_flight_reads_ == 0) {
+      cond_var_.Signal();
+    }
+  }
+  return true;
+}
+
+bool MojoRendererBypassBridge::IsActive() const {
+  base::AutoLock auto_lock(lock_);
+  return active_;
+}
+
+AudioDecoderConfig MojoRendererBypassBridge::GetAudioConfig() const {
+  base::AutoLock auto_lock(lock_);
+  if (!active_ || !audio_stream_) {
+    return AudioDecoderConfig();
+  }
+  return audio_stream_->audio_decoder_config();
+}
+
+VideoDecoderConfig MojoRendererBypassBridge::GetVideoConfig() const {
+  base::AutoLock auto_lock(lock_);
+  if (!active_ || !video_stream_) {
+    return VideoDecoderConfig();
+  }
+  return video_stream_->video_decoder_config();
+}
+
+bool MojoRendererBypassBridge::SupportsConfigChanges(
+    DemuxerStream::Type type) const {
+  base::AutoLock auto_lock(lock_);
+  if (!active_) {
+    return false;
+  }
+  DemuxerStream* stream =
+      (type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_);
+  return stream ? stream->SupportsConfigChanges() : false;
+}
+
+StreamLiveness MojoRendererBypassBridge::GetLiveness(
+    DemuxerStream::Type type) const {
+  base::AutoLock auto_lock(lock_);
+  if (!active_) {
+    return StreamLiveness::kUnknown;
+  }
+  DemuxerStream* stream =
+      (type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_);
+  return stream ? stream->liveness() : StreamLiveness::kUnknown;
+}
+
+void MojoRendererBypassBridge::RunTimeUpdateOnClientThread(
+    base::TimeDelta time,
+    base::TimeDelta max_time,
+    base::TimeTicks capture_time) {
+  time_update_cb_.Run(time, max_time, capture_time);
+}
+
+void MojoRendererBypassBridge::RunStatisticsUpdateOnClientThread(
+    const PipelineStatistics& stats) {
+  statistics_update_cb_.Run(stats);
+}
+
+// static
+void BypassBridgeRegistry::Register(
+    uint32_t id,
+    scoped_refptr<MojoRendererBypassBridge> bridge) {
+  base::AutoLock auto_lock(GetLock());
+  GetMap()[id] = bridge;
+}
+
+// static
+void BypassBridgeRegistry::Unregister(uint32_t id) {
+  base::AutoLock auto_lock(GetLock());
+  GetMap().erase(id);
+}
+
+// static
+scoped_refptr<MojoRendererBypassBridge> BypassBridgeRegistry::Get(uint32_t id) {
+  base::AutoLock auto_lock(GetLock());
+  auto it = GetMap().find(id);
+  return it != GetMap().end() ? it->second : nullptr;
+}
+
+// static
+base::Lock& BypassBridgeRegistry::GetLock() {
+  static base::NoDestructor<base::Lock> lock;
+  return *lock;
+}
+
+// static
+std::map<uint32_t, scoped_refptr<MojoRendererBypassBridge>>&
+BypassBridgeRegistry::GetMap() {
+  static base::NoDestructor<
+      std::map<uint32_t, scoped_refptr<MojoRendererBypassBridge>>>
+      id_to_bridge_map;
+  return *id_to_bridge_map;
+}
+
+}  // namespace media

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
@@ -1,0 +1,141 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_MOJO_COMMON_STARBOARD_MOJO_RENDERER_BYPASS_BRIDGE_H_
+#define MEDIA_MOJO_COMMON_STARBOARD_MOJO_RENDERER_BYPASS_BRIDGE_H_
+
+#include <map>
+
+#include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/ref_counted.h"
+#include "base/synchronization/condition_variable.h"
+#include "base/synchronization/lock.h"
+#include "base/task/sequenced_task_runner.h"
+#include "media/base/demuxer_stream.h"
+#include "media/base/pipeline_status.h"
+
+namespace media {
+
+// MojoRendererBypassBridge facilitates high-performance media playback in
+// single-process mode by bypassing Mojo IPC for media data transfers and
+// high-frequency callbacks (e.g., time and statistics updates).
+//
+// Lifetime and Ownership:
+// - It is a thread-safe ref-counted object.
+// - It is co-owned by MojoRenderer (on the client side) and MojoRendererService
+//   (on the service side) via scoped_refptr.
+// - The client registers the bridge in the BypassBridgeRegistry during
+//   initialization and unregisters it on destruction.
+// - On destruction, the client calls Invalidate() to signal the service that
+//   the client is dead. The bridge remains alive until both client and service
+//   release their references.
+//
+// Threading Model:
+// - Thread-safe. All public methods accessing the shared state (audio/video
+//   streams, configurations, active status) are guarded by `lock_`.
+// - Media data reads (Read()) are initiated outside the lock to prevent
+//   deadlocks if the demuxer calls the read callback synchronously. An internal
+//   in-flight counter and condition variable ensure that the streams are not
+//   destroyed while a Read() is in progress.
+// - Callbacks to the client (PostTimeUpdate(), PostStatisticsUpdate()) are
+//   marshalled to the client's task runner (typically the Media thread) and
+//   executed safely using a WeakPtr to the MojoRenderer.
+class MojoRendererBypassBridge
+    : public base::RefCountedThreadSafe<MojoRendererBypassBridge> {
+ public:
+  using TimeUpdateCB = base::RepeatingCallback<
+      void(base::TimeDelta, base::TimeDelta, base::TimeTicks)>;
+  using StatisticsUpdateCB =
+      base::RepeatingCallback<void(const PipelineStatistics&)>;
+
+  MojoRendererBypassBridge(
+      scoped_refptr<base::SequencedTaskRunner> client_task_runner,
+      TimeUpdateCB time_update_cb,
+      StatisticsUpdateCB statistics_update_cb);
+
+  MojoRendererBypassBridge(const MojoRendererBypassBridge&) = delete;
+  MojoRendererBypassBridge& operator=(const MojoRendererBypassBridge&) = delete;
+
+  void Invalidate();
+  void SetStreams(DemuxerStream* audio, DemuxerStream* video);
+
+  void PostTimeUpdate(base::TimeDelta time,
+                      base::TimeDelta max_time,
+                      base::TimeTicks capture_time);
+  void PostStatisticsUpdate(const PipelineStatistics& stats);
+
+  bool Read(DemuxerStream::Type type,
+            uint32_t count,
+            DemuxerStream::ReadCB read_cb);
+  bool IsActive() const;
+
+  AudioDecoderConfig GetAudioConfig() const;
+  VideoDecoderConfig GetVideoConfig() const;
+  bool SupportsConfigChanges(DemuxerStream::Type type) const;
+  StreamLiveness GetLiveness(DemuxerStream::Type type) const;
+
+ private:
+  friend class base::RefCountedThreadSafe<MojoRendererBypassBridge>;
+  ~MojoRendererBypassBridge();
+
+  void RunTimeUpdateOnClientThread(base::TimeDelta time,
+                                   base::TimeDelta max_time,
+                                   base::TimeTicks capture_time);
+  void RunStatisticsUpdateOnClientThread(const PipelineStatistics& stats);
+
+  const scoped_refptr<base::SequencedTaskRunner> client_task_runner_;
+  const TimeUpdateCB time_update_cb_;
+  const StatisticsUpdateCB statistics_update_cb_;
+
+  mutable base::Lock lock_;
+  base::ConditionVariable cond_var_;
+  int in_flight_reads_ GUARDED_BY(lock_) = 0;
+  bool active_ GUARDED_BY(lock_) = true;
+  raw_ptr<DemuxerStream> audio_stream_ GUARDED_BY(lock_) = nullptr;
+  raw_ptr<DemuxerStream> video_stream_ GUARDED_BY(lock_) = nullptr;
+};
+
+// BypassBridgeRegistry is a global, thread-safe registry used to share
+// MojoRendererBypassBridge instances between the client (MojoRenderer) and
+// the service (MojoRendererService) in single-process mode.
+//
+// Since Mojo IPC is bypassed, we cannot pass ref-counted pointers directly
+// through Mojo interfaces without risking memory leaks if the Mojo connection
+// is prematurely severed. Instead:
+// 1. The client generates a unique ID, associates it with the bridge, and
+//    registers it here.
+// 2. The client passes only the ID (uint32_t) over Mojo to the service.
+//    (If the Mojo connection fails before the service receives the ID, the
+//    client destructor will safely unregister and release the bridge).
+// 3. The service retrieves the bridge from this registry using the ID.
+// 4. The client unregisters the ID upon its destruction.
+//
+// Threading Model:
+// - Thread-safe. All static methods (Register, Unregister, Get) are guarded
+//   by an internal static lock.
+class BypassBridgeRegistry {
+ public:
+  static void Register(uint32_t id,
+                       scoped_refptr<MojoRendererBypassBridge> bridge);
+  static void Unregister(uint32_t id);
+  static scoped_refptr<MojoRendererBypassBridge> Get(uint32_t id);
+
+ private:
+  static base::Lock& GetLock();
+  static std::map<uint32_t, scoped_refptr<MojoRendererBypassBridge>>& GetMap();
+};
+
+}  // namespace media
+#endif  // MEDIA_MOJO_COMMON_STARBOARD_MOJO_RENDERER_BYPASS_BRIDGE_H_

--- a/media/mojo/mojom/renderer.mojom
+++ b/media/mojo/mojom/renderer.mojom
@@ -27,10 +27,8 @@ interface Renderer {
 
   // Supported only in single-process mode with the feature enabled.
   [EnableIf=use_starboard_media]
-  InitializeWithStreamPointers(pending_associated_remote<RendererClient> client,
-                               array<uint64>? stream_pointers,
-                               uint64 client_pointer,
-                               uint64 task_runner_pointer) => (bool success);
+  InitializeWithBypassBridge(pending_associated_remote<RendererClient> client,
+                             uint32 bypass_bridge_id) => (bool success);
 
   // Discards any buffered data, executing callback when completed.
   // NOTE: If an error occurs, RendererClient::OnError() can be called

--- a/media/mojo/services/mojo_renderer_service.cc
+++ b/media/mojo/services/mojo_renderer_service.cc
@@ -17,37 +17,75 @@
 #include "media/mojo/services/media_resource_shim.h"
 #include "media/mojo/services/mojo_cdm_service_context.h"
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 namespace media {
 
 // Time interval to update media time.
 constexpr auto kTimeUpdateInterval = base::Milliseconds(125);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-// A simple implementation of MediaResource that holds raw pointers to local
-// DemuxerStreams. Used in single-process mode to bypass Mojo Data Pipes for
-// passing media data.
-//
-// Lifetime: Owned by MojoRendererService. It does not own the DemuxerStreams,
-// and the caller must ensure that the DemuxerStreams outlive this object.
-// This is safe in single-process mode as the cleanup order is ensured by
-// WebMediaPlayerImpl, which destroys MojoRenderer (and thus this service)
-// before destroying the DemuxerStreams.
-//
-// Threading: This class is not thread-safe and should be used on the same
-// sequence as MojoRendererService.
-class DirectMediaResource : public MediaResource {
+// A proxy DemuxerStream that forwards Read calls to the
+// MojoRendererBypassBridge.
+// This ensures that if the client is destroyed, the read will be safely aborted
+// without accessing the destroyed actual DemuxerStream.
+class ProxyDemuxerStream : public DemuxerStream {
  public:
-  explicit DirectMediaResource(std::vector<DemuxerStream*> streams)
-      : streams_(std::move(streams)) {}
-      
-  std::vector<DemuxerStream*> GetAllStreams() override {
-    return streams_;
+  ProxyDemuxerStream(scoped_refptr<MojoRendererBypassBridge> bridge,
+                     DemuxerStream::Type type)
+      : bridge_(bridge), type_(type) {}
+
+  void Read(uint32_t count, ReadCB read_cb) override {
+    bridge_->Read(type_, count, std::move(read_cb));
   }
+
+  AudioDecoderConfig audio_decoder_config() override {
+    return bridge_->GetAudioConfig();
+  }
+
+  VideoDecoderConfig video_decoder_config() override {
+    return bridge_->GetVideoConfig();
+  }
+
+  Type type() const override { return type_; }
   
+  StreamLiveness liveness() const override {
+    return bridge_->GetLiveness(type_);
+  }
+
+  bool SupportsConfigChanges() override {
+    return bridge_->SupportsConfigChanges(type_);
+  }
+
+  void EnableBitstreamConverter() override {}
+
  private:
-  std::vector<DemuxerStream*> streams_;
+  scoped_refptr<MojoRendererBypassBridge> bridge_;
+  Type type_;
 };
-#endif
+
+// A MediaResource implementation that holds ProxyDemuxerStreams.
+class ProxyMediaResource : public MediaResource {
+ public:
+  ProxyMediaResource(
+    std::unique_ptr<ProxyDemuxerStream> audio,
+    std::unique_ptr<ProxyDemuxerStream> video)
+    : audio_(std::move(audio)), video_(std::move(video)) {}
+
+  std::vector<DemuxerStream*> GetAllStreams() override {
+    std::vector<DemuxerStream*> streams;
+    if (audio_) streams.push_back(audio_.get());
+    if (video_) streams.push_back(video_.get());
+    return streams;
+  }
+
+ private:
+  std::unique_ptr<ProxyDemuxerStream> audio_;
+  std::unique_ptr<ProxyDemuxerStream> video_;
+};
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 // static
 mojo::SelfOwnedReceiverRef<mojom::Renderer> MojoRendererService::Create(
@@ -98,37 +136,48 @@ void MojoRendererService::Initialize(
 }
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-void MojoRendererService::InitializeWithStreamPointers(
+void MojoRendererService::InitializeWithBypassBridge(
     mojo::PendingAssociatedRemote<mojom::RendererClient> client,
-    const std::optional<std::vector<uint64_t>>& stream_pointers,
-    uint64_t client_pointer,
-    uint64_t task_runner_pointer,
-    InitializeWithStreamPointersCallback callback) {
+    uint32_t bypass_bridge_id,
+    InitializeWithBypassBridgeCallback callback) {
   DVLOG(1) << __func__;
   DCHECK_EQ(state_, STATE_UNINITIALIZED);
 
   client_.Bind(std::move(client));
   state_ = STATE_INITIALIZING;
 
-  DCHECK(stream_pointers.has_value());
-  std::vector<DemuxerStream*> streams;
-  for (uint64_t ptr : *stream_pointers) {
-    streams.push_back(reinterpret_cast<DemuxerStream*>(ptr));
+  // Retrieve the bypass bridge from the registry.
+  bypass_bridge_ = BypassBridgeRegistry::Get(bypass_bridge_id);
+  if (!bypass_bridge_) {
+    LOG(WARNING) << __func__
+                 << ": Bypass bridge not found for ID " << bypass_bridge_id;
+    std::move(callback).Run(false);
+    return;
   }
 
-  media_resource_ = std::make_unique<DirectMediaResource>(std::move(streams));
+  std::unique_ptr<ProxyDemuxerStream> audio_proxy;
+  std::unique_ptr<ProxyDemuxerStream> video_proxy;
 
-  client_pointer_ = client_pointer;
-  if (task_runner_pointer) {
-    client_task_runner_ = reinterpret_cast<base::SequencedTaskRunner*>(task_runner_pointer);
+  AudioDecoderConfig audio_config = bypass_bridge_->GetAudioConfig();
+  if (audio_config.IsValidConfig()) {
+    audio_proxy = std::make_unique<ProxyDemuxerStream>(
+        bypass_bridge_, DemuxerStream::AUDIO);
   }
+  VideoDecoderConfig video_config = bypass_bridge_->GetVideoConfig();
+  if (video_config.IsValidConfig()) {
+    video_proxy = std::make_unique<ProxyDemuxerStream>(
+        bypass_bridge_, DemuxerStream::VIDEO);
+  }
+
+  media_resource_ = std::make_unique<ProxyMediaResource>(
+      std::move(audio_proxy), std::move(video_proxy));
 
   renderer_->Initialize(
       media_resource_.get(), this,
       base::BindOnce(&MojoRendererService::OnRendererInitializeDone, weak_this_,
                      std::move(callback)));
 }
-#endif
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 void MojoRendererService::Flush(FlushCallback callback) {
   DVLOG(2) << __func__;
@@ -231,15 +280,11 @@ void MojoRendererService::OnEnded() {
 void MojoRendererService::OnStatisticsUpdate(const PipelineStatistics& stats) {
   DVLOG(3) << __func__;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (client_pointer_ && client_task_runner_) {
-    client_task_runner_->PostTask(
-        FROM_HERE,
-        base::BindOnce(&mojom::RendererClient::OnStatisticsUpdate,
-                       base::Unretained(reinterpret_cast<mojom::RendererClient*>(client_pointer_)),
-                       stats));
+  if (bypass_bridge_) {
+    bypass_bridge_->PostStatisticsUpdate(stats);
     return;
   }
-#endif
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   client_->OnStatisticsUpdate(stats);
 }
 
@@ -319,18 +364,15 @@ void MojoRendererService::UpdateMediaTime(bool force) {
     max_time += 2 * kTimeUpdateInterval;
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (client_pointer_ && client_task_runner_) {
-    client_task_runner_->PostTask(
-        FROM_HERE,
-        base::BindOnce(&mojom::RendererClient::OnTimeUpdate,
-                       base::Unretained(reinterpret_cast<mojom::RendererClient*>(client_pointer_)),
-                       media_time, max_time, base::TimeTicks::Now()));
+  if (bypass_bridge_) {
+    bypass_bridge_->PostTimeUpdate(media_time, max_time,
+                                   base::TimeTicks::Now());
   } else {
-#endif
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   client_->OnTimeUpdate(media_time, max_time, base::TimeTicks::Now());
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   }
-#endif
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   last_media_time_ = media_time;
 }
 

--- a/media/mojo/services/mojo_renderer_service.h
+++ b/media/mojo/services/mojo_renderer_service.h
@@ -32,6 +32,9 @@
 namespace media {
 
 class CdmContextRef;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+class MojoRendererBypassBridge;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 class MediaResourceShim;
 class MojoCdmServiceContext;
 class Renderer;
@@ -65,13 +68,11 @@ class MEDIA_MOJO_EXPORT MojoRendererService final : public mojom::Renderer,
           streams,
       InitializeCallback callback) final;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  void InitializeWithStreamPointers(
+  void InitializeWithBypassBridge(
       mojo::PendingAssociatedRemote<mojom::RendererClient> client,
-      const std::optional<std::vector<uint64_t>>& stream_pointers,
-      uint64_t client_pointer,
-      uint64_t task_runner_pointer,
-      InitializeWithStreamPointersCallback callback) final;
-#endif
+      uint32_t bypass_bridge_id,
+      InitializeWithBypassBridgeCallback callback) final;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   void Flush(FlushCallback callback) final;
   void StartPlayingFrom(base::TimeDelta time_delta) final;
   void SetPlaybackRate(double playback_rate) final;
@@ -136,9 +137,8 @@ class MEDIA_MOJO_EXPORT MojoRendererService final : public mojom::Renderer,
   base::TimeDelta last_media_time_;
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  uint64_t client_pointer_ = 0;
-  scoped_refptr<base::SequencedTaskRunner> client_task_runner_;
-#endif
+  scoped_refptr<MojoRendererBypassBridge> bypass_bridge_;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   mojo::AssociatedRemote<mojom::RendererClient> client_;
 


### PR DESCRIPTION
In single-process mode, Cobalt uses a Mojo bypass to improve performance
for high-frequency media updates. Previously, this relied on passing raw
pointers between the client and service, which caused use-after-free
crashes during destruction.

This change introduces a thread-safe, ref-counted bridge and a registry
to manage shared state. The bridge handles synchronization and ensures
that callbacks and stream reads are safely aborted if the underlying
renderer is invalidated.

Issue: 521843763
Issue: 521835243
Issue: 513254071