### PR TITLE
Disable BackupRefPtr support on Chrobalt

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -84,5 +84,10 @@ rtc_include_dav1d_in_internal_decoder_factory = false
 # a preloaded list of third-party domains.
 include_transport_security_state_preload_list = false
 
-# Disable Vulkan on Cobalt, this reduces binary size (~1.2MB)
+# Disable Vulkan on Cobalt, this reduces binary size by ~1.2 MB.
 angle_enable_vulkan = false
+
+# Disable BackupRefPtr on Chrobalt, this reduces binary size by
+# ~0.5 MB.
+enable_backup_ref_ptr_support = false
+enable_backup_ref_ptr_feature_flag = false


### PR DESCRIPTION
Disable BackupRefPtr support and its associated feature flag to
reduce the binary size.

Binary size reduced by ~0.5 MB on coat gold.
```
Before:
haozheng@haozheng-usa-backup-1:~/cobalt/src$ ls -l ~/cobalt/src/out/android-arm_gold/libchrobalt.so
-rwxr-xr-x 1 haozheng primarygroup 69920316 Jun  9 15:23 /usr/local/google/home/haozheng/cobalt/src/out/android-arm_gold/libchrobalt.so

After:
haozheng@haozheng-usa-backup-1:~/cobalt/src$ ls -l ~/cobalt/src/out/android-arm_gold/libchrobalt.so
-rwxr-xr-x 1 haozheng primarygroup 69416508 Jun  9 15:41 /usr/local/google/home/haozheng/cobalt/src/out/android-arm_gold/libchrobalt.so
```

Bug: 521891002