### PR TITLE
Disable the Network Reporting API and Network Error Logging on Chrobalt

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -86,3 +86,7 @@ include_transport_security_state_preload_list = false
 
 # Disable Vulkan on Cobalt, this reduces binary size (~1.2MB)
 angle_enable_vulkan = false
+
+# Disable the Network Reporting API and Network Error Logging
+# (NEL) on Chrobat, this reduces binary size by ~ 0.1 MB.
+enable_reporting = false


### PR DESCRIPTION
Disable the Network Reporting API and Network Error Logging (NEL) by setting the enable_reporting flag to false in the common build configuration.  Because YouTube utilizes its own custom playback telemetry and QoE (Quality of Experience) client-side reporting APIs to log errors, buffering issues, and connectivity stats back to Google servers. It does not rely on the browser-native W3C Reporting API or NEL.

This PR saves ~0.1 MB on coat gold.
```
Before:
haozheng@haozheng-usa-backup-1:~/cobalt/src$ ls -l ~/cobalt/src/out/android-arm_gold/libchrobalt.so
-rwxr-xr-x 1 haozheng primarygroup 69920316 Jun  9 15:23 /usr/local/google/home/haozheng/cobalt/src/out/android-arm_gold/libchrobalt.so

After:
haozheng@haozheng-usa-backup-1:~/cobalt/src$ ls -l ~/cobalt/src/out/android-arm_gold/libchrobalt.so
-rwxr-xr-x 1 haozheng primarygroup 69822012 Jun  9 16:45 /usr/local/google/home/haozheng/cobalt/src/out/android-arm_gold/libchrobalt.so
```
Bug: 521920064