### PR TITLE
Remove a gtest hack for custom thread locking

### DIFF
--- a/starboard/nplb/multiple_player_test.cc
+++ b/starboard/nplb/multiple_player_test.cc
@@ -197,8 +197,8 @@ void WriteSamples(const SbPlayerTestConfig& player_config,
     samples.AddVideoEOS();
   }
 
-  ASSERT_NO_FATAL_FAILURE(player_fixture.Write(samples));
-  ASSERT_NO_FATAL_FAILURE(player_fixture.WaitForPlayerEndOfStream());
+  player_fixture.Write(samples);
+  player_fixture.WaitForPlayerEndOfStream();
 }
 
 TEST_F(MultiplePlayerTest, SunnyDay) {

--- a/starboard/nplb/player_test_fixture.cc
+++ b/starboard/nplb/player_test_fixture.cc
@@ -243,9 +243,9 @@ void SbPlayerTestFixture::Seek(const int64_t time) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
   SB_DCHECK(SbPlayerIsValid(player_));
 
-  ASSERT_FALSE(error_occurred_);
-  ASSERT_FALSE(HasReceivedPlayerState(kSbPlayerStateDestroyed));
-  ASSERT_TRUE(HasReceivedPlayerState(kSbPlayerStateInitialized));
+  SB_DCHECK(!error_occurred_);
+  SB_DCHECK(!HasReceivedPlayerState(kSbPlayerStateDestroyed));
+  SB_DCHECK(HasReceivedPlayerState(kSbPlayerStateInitialized));
 
   can_accept_more_audio_data_ = false;
   can_accept_more_video_data_ = false;
@@ -263,7 +263,7 @@ void SbPlayerTestFixture::Write(const GroupedSamples& grouped_samples) {
   SB_DCHECK(!audio_end_of_stream_written_);
   SB_DCHECK(!video_end_of_stream_written_);
 
-  ASSERT_FALSE(error_occurred_);
+  SB_DCHECK(!error_occurred_);
 
   int max_audio_samples_per_write =
       SbPlayerGetMaximumNumberOfSamplesPerWrite(player_, kSbMediaTypeAudio);
@@ -282,7 +282,7 @@ void SbPlayerTestFixture::Write(const GroupedSamples& grouped_samples) {
       auto descriptor = iterator.GetCurrentAudioSamplesToWrite();
       if (descriptor.is_end_of_stream) {
         SB_DCHECK(!audio_end_of_stream_written_);
-        ASSERT_NO_FATAL_FAILURE(WriteEndOfStream(kSbMediaTypeAudio));
+        WriteEndOfStream(kSbMediaTypeAudio);
         iterator.AdvanceAudio(1);
       } else {
         SB_DCHECK_GT(descriptor.samples_count, 0);
@@ -293,11 +293,10 @@ void SbPlayerTestFixture::Write(const GroupedSamples& grouped_samples) {
 
         auto samples_to_write =
             std::min(max_audio_samples_per_write, descriptor.samples_count);
-        ASSERT_NO_FATAL_FAILURE(
-            WriteAudioSamples(descriptor.start_index, samples_to_write,
-                              descriptor.timestamp_offset,
-                              descriptor.discarded_duration_from_front,
-                              descriptor.discarded_duration_from_back));
+        WriteAudioSamples(descriptor.start_index, samples_to_write,
+                          descriptor.timestamp_offset,
+                          descriptor.discarded_duration_from_front,
+                          descriptor.discarded_duration_from_back);
         iterator.AdvanceAudio(samples_to_write);
       }
     }
@@ -305,7 +304,7 @@ void SbPlayerTestFixture::Write(const GroupedSamples& grouped_samples) {
       auto descriptor = iterator.GetCurrentVideoSamplesToWrite();
       if (descriptor.is_end_of_stream) {
         SB_DCHECK(!video_end_of_stream_written_);
-        ASSERT_NO_FATAL_FAILURE(WriteEndOfStream(kSbMediaTypeVideo));
+        WriteEndOfStream(kSbMediaTypeVideo);
         iterator.AdvanceVideo(1);
       } else {
         SB_DCHECK_GT(descriptor.samples_count, 0);
@@ -316,15 +315,14 @@ void SbPlayerTestFixture::Write(const GroupedSamples& grouped_samples) {
 
         auto samples_to_write =
             std::min(max_video_samples_per_write, descriptor.samples_count);
-        ASSERT_NO_FATAL_FAILURE(WriteVideoSamples(descriptor.start_index,
-                                                  samples_to_write,
-                                                  descriptor.timestamp_offset));
+        WriteVideoSamples(descriptor.start_index, samples_to_write,
+                          descriptor.timestamp_offset);
         iterator.AdvanceVideo(samples_to_write);
       }
     }
 
     if (iterator.HasMoreAudio() || iterator.HasMoreVideo()) {
-      ASSERT_NO_FATAL_FAILURE(WaitForDecoderStateNeedsData());
+      WaitForDecoderStateNeedsData();
     } else {
       return;
     }
@@ -337,8 +335,8 @@ void SbPlayerTestFixture::WaitForPlayerPresenting() {
   SB_CHECK(thread_checker_.CalledOnValidThread());
   SB_DCHECK(SbPlayerIsValid(player_));
 
-  ASSERT_FALSE(error_occurred_);
-  ASSERT_NO_FATAL_FAILURE(WaitForPlayerState(kSbPlayerStatePresenting));
+  SB_DCHECK(!error_occurred_);
+  WaitForPlayerState(kSbPlayerStatePresenting);
 }
 
 void SbPlayerTestFixture::WaitForPlayerEndOfStream() {
@@ -347,8 +345,8 @@ void SbPlayerTestFixture::WaitForPlayerEndOfStream() {
   SB_DCHECK(!audio_dmp_reader_ || audio_end_of_stream_written_);
   SB_DCHECK(!video_dmp_reader_ || video_end_of_stream_written_);
 
-  ASSERT_FALSE(error_occurred_);
-  ASSERT_NO_FATAL_FAILURE(WaitForPlayerState(kSbPlayerStateEndOfStream));
+  SB_DCHECK(!error_occurred_);
+  WaitForPlayerState(kSbPlayerStateEndOfStream);
 }
 
 int64_t SbPlayerTestFixture::GetCurrentMediaTime() const {
@@ -468,7 +466,7 @@ void SbPlayerTestFixture::Initialize() {
         key_system_.c_str(), NULL /* context */, DummySessionUpdateRequestFunc,
         DummySessionUpdatedFunc, DummySessionKeyStatusesChangedFunc,
         DummyServerCertificateUpdatedFunc, DummySessionClosedFunc);
-    ASSERT_TRUE(SbDrmSystemIsValid(drm_system_));
+    SB_DCHECK(SbDrmSystemIsValid(drm_system_));
   }
 
   // Initialize player.
@@ -491,9 +489,9 @@ void SbPlayerTestFixture::Initialize() {
       DummyDeallocateSampleFunc, DecoderStatusCallback, PlayerStatusCallback,
       ErrorCallback, this, output_mode_,
       fake_graphics_context_provider_->decoder_target_provider());
-  ASSERT_TRUE(SbPlayerIsValid(player_));
-  ASSERT_NO_FATAL_FAILURE(WaitForPlayerState(kSbPlayerStateInitialized));
-  ASSERT_NO_FATAL_FAILURE(Seek(0));
+  SB_DCHECK(SbPlayerIsValid(player_));
+  WaitForPlayerState(kSbPlayerStateInitialized);
+  Seek(0);
   SbPlayerSetPlaybackRate(player_, 1.0);
   SbPlayerSetVolume(player_, 1.0);
 }
@@ -514,10 +512,10 @@ void SbPlayerTestFixture::TearDown() {
   // We expect player resources are released and all events are sent already
   // after SbPlayerDestroy() finishes.
   while (callback_event_queue_.Size() > 0) {
-    ASSERT_NO_FATAL_FAILURE(WaitAndProcessNextEvent());
+    WaitAndProcessNextEvent();
   }
-  ASSERT_TRUE(HasReceivedPlayerState(kSbPlayerStateDestroyed));
-  ASSERT_FALSE(error_occurred_);
+  SB_DCHECK(HasReceivedPlayerState(kSbPlayerStateDestroyed));
+  SB_DCHECK(!error_occurred_);
 
   player_ = kSbPlayerInvalid;
   drm_system_ = kSbDrmSystemInvalid;
@@ -625,33 +623,33 @@ void SbPlayerTestFixture::WaitAndProcessNextEvent(int64_t timeout) {
     case CallbackEventType::kEmptyEvent:
       break;
     case CallbackEventType::kDecoderStateEvent: {
-      ASSERT_EQ(event.player, player_);
+      SB_DCHECK_EQ(event.player, player_);
       // Callbacks may be in-flight at the time that the player is destroyed by
       // a call to |SbPlayerDestroy|. In this case, the callbacks are ignored.
       // However no new callbacks are expected after receiving the player status
       // |kSbPlayerStateDestroyed|.
-      ASSERT_FALSE(HasReceivedPlayerState(kSbPlayerStateDestroyed));
+      SB_DCHECK(!HasReceivedPlayerState(kSbPlayerStateDestroyed));
       // There's only one valid SbPlayerDecoderState. The received decoder state
       // must be kSbPlayerDecoderStateNeedsData.
-      ASSERT_EQ(event.decoder_state, kSbPlayerDecoderStateNeedsData);
+      SB_DCHECK_EQ(event.decoder_state, kSbPlayerDecoderStateNeedsData);
       if (event.media_type == kSbMediaTypeAudio) {
-        ASSERT_FALSE(can_accept_more_audio_data_);
+        SB_DCHECK(!can_accept_more_audio_data_);
         can_accept_more_audio_data_ = true;
       } else {
-        ASSERT_TRUE(event.media_type == kSbMediaTypeVideo);
-        ASSERT_FALSE(can_accept_more_video_data_);
+        SB_DCHECK(event.media_type == kSbMediaTypeVideo);
+        SB_DCHECK(!can_accept_more_video_data_);
         can_accept_more_video_data_ = true;
       }
       break;
     }
     case CallbackEventType::kPlayerStateEvent: {
-      ASSERT_EQ(event.player, player_);
-      ASSERT_NO_FATAL_FAILURE(AssertPlayerStateIsValid(event.player_state));
+      SB_DCHECK_EQ(event.player, player_);
+      AssertPlayerStateIsValid(event.player_state);
       player_state_set_.insert(event.player_state);
       break;
     }
   }
-  ASSERT_FALSE(error_occurred_);
+  SB_DCHECK(!error_occurred_);
 }
 
 void SbPlayerTestFixture::WaitForDecoderStateNeedsData(const int64_t timeout) {
@@ -662,9 +660,9 @@ void SbPlayerTestFixture::WaitForDecoderStateNeedsData(const int64_t timeout) {
 
   int64_t start = starboard::CurrentMonotonicTime();
   do {
-    ASSERT_FALSE(error_occurred_);
+    SB_DCHECK(!error_occurred_);
     GetDecodeTargetWhenSupported();
-    ASSERT_NO_FATAL_FAILURE(WaitAndProcessNextEvent());
+    WaitAndProcessNextEvent();
     if (old_can_accept_more_audio_data != can_accept_more_audio_data_ ||
         old_can_accept_more_video_data != can_accept_more_video_data_) {
       return;
@@ -681,9 +679,9 @@ void SbPlayerTestFixture::WaitForPlayerState(const SbPlayerState desired_state,
   }
   int64_t start = starboard::CurrentMonotonicTime();
   do {
-    ASSERT_FALSE(error_occurred_);
-    ASSERT_NO_FATAL_FAILURE(GetDecodeTargetWhenSupported());
-    ASSERT_NO_FATAL_FAILURE(WaitAndProcessNextEvent());
+    SB_DCHECK(!error_occurred_);
+    GetDecodeTargetWhenSupported();
+    WaitAndProcessNextEvent();
     if (HasReceivedPlayerState(desired_state)) {
       return;
     }
@@ -697,12 +695,12 @@ void SbPlayerTestFixture::GetDecodeTargetWhenSupported() {
     return;
   }
   fake_graphics_context_provider_->RunOnGlesContextThread([&]() {
-    ASSERT_TRUE(SbPlayerIsValid(player_));
+    SB_DCHECK(SbPlayerIsValid(player_));
     if (output_mode_ != kSbPlayerOutputModeDecodeToTexture) {
-      ASSERT_EQ(SbPlayerGetCurrentFrame(player_), kSbDecodeTargetInvalid);
+      SB_DCHECK_EQ(SbPlayerGetCurrentFrame(player_), kSbDecodeTargetInvalid);
       return;
     }
-    ASSERT_EQ(output_mode_, kSbPlayerOutputModeDecodeToTexture);
+    SB_DCHECK_EQ(output_mode_, kSbPlayerOutputModeDecodeToTexture);
     SbDecodeTarget frame = SbPlayerGetCurrentFrame(player_);
     if (SbDecodeTargetIsValid(frame)) {
       SbDecodeTargetRelease(frame);
@@ -714,37 +712,37 @@ void SbPlayerTestFixture::AssertPlayerStateIsValid(SbPlayerState state) const {
   // Note: it is possible to receive the same state that has been previously
   // received in the case of multiple Seek() calls. Prior to any Seek commands
   // issued in this test, we should reset the |player_state_set_| member.
-  ASSERT_FALSE(HasReceivedPlayerState(state));
+  SB_DCHECK(!HasReceivedPlayerState(state));
 
   switch (state) {
     case kSbPlayerStateInitialized:
       // No other states have been received before getting Initialized.
-      ASSERT_TRUE(player_state_set_.empty());
+      SB_DCHECK(player_state_set_.empty());
       return;
     case kSbPlayerStatePrerolling:
-      ASSERT_TRUE(HasReceivedPlayerState(kSbPlayerStateInitialized));
-      ASSERT_FALSE(HasReceivedPlayerState(kSbPlayerStateDestroyed));
+      SB_DCHECK(HasReceivedPlayerState(kSbPlayerStateInitialized));
+      SB_DCHECK(!HasReceivedPlayerState(kSbPlayerStateDestroyed));
       return;
     case kSbPlayerStatePresenting:
-      ASSERT_TRUE(HasReceivedPlayerState(kSbPlayerStateInitialized));
-      ASSERT_TRUE(HasReceivedPlayerState(kSbPlayerStatePrerolling));
-      ASSERT_FALSE(HasReceivedPlayerState(kSbPlayerStateDestroyed));
+      SB_DCHECK(HasReceivedPlayerState(kSbPlayerStateInitialized));
+      SB_DCHECK(HasReceivedPlayerState(kSbPlayerStatePrerolling));
+      SB_DCHECK(!HasReceivedPlayerState(kSbPlayerStateDestroyed));
       return;
     case kSbPlayerStateEndOfStream:
       if (audio_dmp_reader_) {
-        ASSERT_TRUE(audio_end_of_stream_written_);
+        SB_DCHECK(audio_end_of_stream_written_);
       }
       if (video_dmp_reader_) {
-        ASSERT_TRUE(video_end_of_stream_written_);
+        SB_DCHECK(video_end_of_stream_written_);
       }
-      ASSERT_TRUE(HasReceivedPlayerState(kSbPlayerStateInitialized));
-      ASSERT_TRUE(HasReceivedPlayerState(kSbPlayerStatePrerolling));
-      ASSERT_FALSE(HasReceivedPlayerState(kSbPlayerStateDestroyed));
+      SB_DCHECK(HasReceivedPlayerState(kSbPlayerStateInitialized));
+      SB_DCHECK(HasReceivedPlayerState(kSbPlayerStatePrerolling));
+      SB_DCHECK(!HasReceivedPlayerState(kSbPlayerStateDestroyed));
       return;
     case kSbPlayerStateDestroyed:
       // Nothing stops the user of the player from destroying the player during
       // any of the previous states.
-      ASSERT_TRUE(destroy_player_called_);
+      SB_DCHECK(destroy_player_called_);
       return;
   }
   FAIL() << "Received an invalid SbPlayerState.";

--- a/starboard/nplb/player_test_fixture.h
+++ b/starboard/nplb/player_test_fixture.h
@@ -104,6 +104,8 @@ class SbPlayerTestFixture {
   int ConvertDurationToAudioBufferCount(int64_t duration) const;
   int ConvertDurationToVideoBufferCount(int64_t duration) const;
 
+  bool HasError() const { return error_occurred_.load(); }
+
  private:
   static constexpr int64_t kDefaultWaitForPlayerStateTimeout = 5'000'000LL;
   static constexpr int64_t kDefaultWaitForCallbackEventTimeout = 15'000;

--- a/starboard/nplb/player_write_sample_test.cc
+++ b/starboard/nplb/player_write_sample_test.cc
@@ -327,7 +327,8 @@ class SecondaryPlayerTestThread : public AbstractTestThread {
       const SbPlayerTestConfig& config,
       FakeGraphicsContextProvider* fake_graphics_context_provider)
       : config_(config),
-        fake_graphics_context_provider_(fake_graphics_context_provider) {}
+        fake_graphics_context_provider_(fake_graphics_context_provider),
+        success_(false) {}
 
   void Run() override {
     SbPlayerTestFixture player_fixture(config_,
@@ -350,13 +351,17 @@ class SecondaryPlayerTestThread : public AbstractTestThread {
       samples.AddVideoEOS();
     }
 
-    ASSERT_NO_FATAL_FAILURE(player_fixture.Write(samples));
-    ASSERT_NO_FATAL_FAILURE(player_fixture.WaitForPlayerEndOfStream());
+    player_fixture.Write(samples);
+    player_fixture.WaitForPlayerEndOfStream();
+    success_ = !player_fixture.HasError();
   }
+
+  bool success() const { return success_; }
 
  private:
   const SbPlayerTestConfig config_;
   FakeGraphicsContextProvider* fake_graphics_context_provider_;
+  std::atomic<bool> success_;
 };
 
 TEST_P(SbPlayerWriteSampleTest, SecondaryPlayerTest) {
@@ -385,6 +390,9 @@ TEST_P(SbPlayerWriteSampleTest, SecondaryPlayerTest) {
 
   primary_player_thread.WaitForFinish();
   secondary_player_thread.WaitForFinish();
+
+  ASSERT_TRUE(primary_player_thread.success());
+  ASSERT_TRUE(secondary_player_thread.success());
 }
 
 TEST_P(SbPlayerWriteSampleTest, VideoCodecSwitching) {

--- a/starboard/nplb/posix_compliance/posix_random_test.cc
+++ b/starboard/nplb/posix_compliance/posix_random_test.cc
@@ -32,7 +32,7 @@ TEST(PosixInitStateTest, RandomReturnsValueWithinRange) {
 // Test that the same seed produces a repeatable sequence.
 TEST(PosixInitStateTest, SameSeedProducesRepeatableSequence) {
   std::vector<char> state(256);
-  initstate(123, state.data(), state.size());
+  char* old_state = initstate(123, state.data(), state.size());
   long seq1_val1 = random();
   long seq1_val2 = random();
   long seq1_val3 = random();
@@ -45,6 +45,7 @@ TEST(PosixInitStateTest, SameSeedProducesRepeatableSequence) {
   EXPECT_EQ(seq1_val1, seq2_val1);
   EXPECT_EQ(seq1_val2, seq2_val2);
   EXPECT_EQ(seq1_val3, seq2_val3);
+  setstate(old_state);
 }
 
 // Test that setstate can restore a previous state.
@@ -53,12 +54,11 @@ TEST(PosixInitStateTest, SetStateRestoresState) {
   std::vector<char> state2(256);
 
   // Generate a sequence of numbers and save the state.
-  initstate(123, state1.data(), state1.size());
+  char* old_state = initstate(123, state1.data(), state1.size());
   long val1 = random();
   long val2 = random();
 
   // Switch to a different state and generate a different sequence.
-  char* old_state = setstate(state2.data());
   initstate(456, state2.data(), state2.size());
   long val3 = random();
   long val4 = random();
@@ -67,7 +67,7 @@ TEST(PosixInitStateTest, SetStateRestoresState) {
   EXPECT_NE(val2, val4);
 
   // Restore the original state and verify the sequence continues.
-  setstate(old_state);
+  setstate(state1.data());
   long val5 = random();
   long val6 = random();
 
@@ -80,6 +80,7 @@ TEST(PosixInitStateTest, SetStateRestoresState) {
 
   EXPECT_EQ(val5, expected_val5);
   EXPECT_EQ(val6, expected_val6);
+  setstate(old_state);
 }
 
 }  // namespace

--- a/third_party/googletest/src/googletest/include/gtest/internal/gtest-port.h
+++ b/third_party/googletest/src/googletest/include/gtest/internal/gtest-port.h
@@ -1202,114 +1202,6 @@ void ClearInjectableArgvs();
 
 #endif  // GTEST_HAS_DEATH_TEST
 
-// TODO: b/399507045 - Cobalt: Fix build error, remove hack
-#if BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-// Define synchronization primitives.
-class Mutex {
- public:
-  enum MutexType { kStatic = 0, kDynamic = 1 };
-  // We rely on kStaticMutex being 0 as it is to what the linker initializes
-  // type_ in static mutexes.  critical_section_ will be initialized lazily
-  // in ThreadSafeLazyInit().
-  enum StaticConstructorSelector { kStaticMutex = 0 };
-  // This constructor intentionally does nothing.  It relies on type_ being
-  // statically initialized to 0 (effectively setting it to kStatic) and on
-  // ThreadSafeLazyInit() to lazily initialize the rest of the members.
-  explicit Mutex(StaticConstructorSelector /*dummy*/) {}
-  Mutex() : type_(kDynamic) { pthread_mutex_init(&mutex_, nullptr); }
-  ~Mutex() {
-    if (type_ != kStatic) {
-      pthread_mutex_destroy(&mutex_);
-    }
-  }
-  void Lock() {
-    LazyInit();
-    pthread_mutex_lock(&mutex_);
-  }
-  void Unlock() { pthread_mutex_unlock(&mutex_); }
-  void AssertHeld() const {}
- private:
-  void LazyInit() {
-    if (type_ == kStatic && !initialized_) {
-// TODO: (cobalt b/409757368): Change the code to not have compiler warnings.
-#if BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wexit-time-destructors"
-#endif
-      static starboard::SpinLock s_lock;
-#if BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-#pragma GCC diagnostic pop
-#endif
-      s_lock.Acquire();
-      if (!initialized_) {
-        pthread_mutex_init(&mutex_, nullptr);
-        initialized_ = true;
-      }
-      s_lock.Release();
-    }
-  }
-  pthread_mutex_t mutex_;
-  friend class GTestMutexLock;
-  bool initialized_ = false;
-  // For static mutexes, we rely on type_ member being initialized to zero
-  // by the linker.
-  MutexType type_;
-};
-#define GTEST_DECLARE_STATIC_MUTEX_(mutex) \
-  extern ::testing::internal::Mutex mutex
-#define GTEST_DEFINE_STATIC_MUTEX_(mutex) \
-  ::testing::internal::Mutex mutex(::testing::internal::Mutex::kStaticMutex)
-// We cannot name this class MutexLock because the ctor declaration would
-// conflict with a macro named MutexLock, which is defined on some
-// platforms. That macro is used as a defensive measure to prevent against
-// inadvertent misuses of MutexLock like "MutexLock(&mu)" rather than
-// "MutexLock l(&mu)".  Hence the typedef trick below.
-class GTestMutexLock {
- public:
-  explicit GTestMutexLock(Mutex* mutex) : mutex_(mutex) {
-    mutex_->Lock();
-  }  // NOLINT
-  ~GTestMutexLock() { mutex_->Unlock(); }
- private:
-  Mutex* mutex_;
-};
-typedef GTestMutexLock MutexLock;
-template <typename T>
-class ThreadLocal {
- public:
-  ThreadLocal() {
-    int res = pthread_key_create(&key_, [](void* value) { delete static_cast<T*>(value); });
-    SB_DCHECK(res == 0);
-  }
-  explicit ThreadLocal(const T& value) : ThreadLocal() {
-    default_value_ = value;
-    set(value);
-  }
-  ~ThreadLocal() {
-    pthread_key_delete(key_);
-  }
-  T* pointer() { return GetOrCreateValue(); }
-  const T* pointer() const { return GetOrCreateValue(); }
-  const T& get() const { return *pointer(); }
-  void set(const T& value) { *GetOrCreateValue() = value; }
- private:
-  T* GetOrCreateValue() const {
-    T* ptr = static_cast<T*>(pthread_getspecific(key_));
-    if (ptr) {
-      return ptr;
-    } else {
-      T* new_value = new T(default_value_);
-      int res = pthread_setspecific(key_, new_value);
-      SB_CHECK(res == 0);
-      return new_value;
-    }
-  }
-  T default_value_;
-  pthread_key_t key_;
-};
-
-#else  // BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-
 // Defines synchronization primitives.
 #ifdef GTEST_IS_THREADSAFE
 
@@ -2027,7 +1919,6 @@ class GTEST_API_ ThreadLocal {
 };
 
 #endif  // GTEST_IS_THREADSAFE
-#endif  // BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
 
 // Returns the number of threads running in the process, or 0 to indicate that
 // we cannot detect it.


### PR DESCRIPTION
Now that we have all the thread APIs the hack is no longer needed.
However there was a memory corruption Bug.

1. The Root Cause (The Bug)
The memory corruption was caused by an undocumented data race and thread-safety limitation in the core Google Test (gtest) framework. Google Test maintains a shared, process-wide TestResult object for each active test case to record failures. Under the hood, the internal AddTestPartResult() function appends every pass/fail outcome to a standard std::vector via push_back() without any mutex locking or thread synchronization.

2. The Trigger Mechanism (Multithreaded ASSERT)
The SecondaryPlayerTest suite (and the underlying SbPlayerTestFixture cleanup harness) spawned two concurrent background OS threads (Primary and Secondary players) to validate parallel media playback.

When those concurrent threads executed Google Test assertion macros (ASSERT_NO_FATAL_FAILURE, ASSERT_TRUE, etc.), they invoked AddTestPartResult() simultaneously. The resulting data race on the std::vector::push_back() call triggered a heap reallocation. One thread freed the old memory buffer while the second thread simultaneously wrote its stack address (HasNewFatalFailureHelper) into the freed space. This "write-after-free" bug overwrote adjacent live objects on the heap owned by the Main thread (the Google Test Thread-Local Storage reporter map), resulting in a SIGSEGV segmentation fault during the execution of the very next test case.

3. The hack before 
ThreadLocal() {
int res = pthread_key_create(&key_, [](void* value) {
delete static_cast<T*>(value); // <-- The Hack
});
SB_DCHECK(res == 0);
}
Because that custom hack explicitly invoked delete on the thread-local storage whenever an OS thread exited, it automatically wiped out and cleared the dangling stack pointers left behind by the concurrent background player threads before the Main thread had a chance to read them.

Bug: 399507045