### PR TITLE
[C27] Log lifecycle change events with name 

### DIFF
--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -375,6 +375,10 @@ void AppEventDelegate::DoTeardown() {
   runner_->OnStop();
   base::AutoLock lock(lock_);
   SetApplicationState(ApplicationState::kStopped);
+
+  // Delete this object asynchronously after the current event loop execution
+  // finishes.
+  base::SequencedTaskRunner::GetCurrentDefault()->DeleteSoon(FROM_HERE, this);
 }
 
 void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -375,10 +375,6 @@ void AppEventDelegate::DoTeardown() {
   runner_->OnStop();
   base::AutoLock lock(lock_);
   SetApplicationState(ApplicationState::kStopped);
-
-  // Delete this object asynchronously after the current event loop execution
-  // finishes.
-  base::SequencedTaskRunner::GetCurrentDefault()->DeleteSoon(FROM_HERE, this);
 }
 
 void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {
@@ -393,14 +389,17 @@ void AppEventDelegate::TransitionToLifeCycleState(ApplicationState state) {
   CHECK_LE(state, ApplicationState::kStopped);
 
   LOG(INFO) << "AppEventDelegate::TransitionToLifeCycleState called, current="
-            << static_cast<int>(application_state_)
-            << " target=" << static_cast<int>(state);
+            << static_cast<int>(application_state_) << " ("
+            << GetStateString(application_state_)
+            << ") target=" << static_cast<int>(state) << " ("
+            << GetStateString(state) << ")";
 
   target_state_ = state;
 
   if (is_transitioning_) {
     LOG(INFO) << "Transition already in progress. Updated target_state_ to "
-              << static_cast<int>(state);
+              << static_cast<int>(state) << " (" << GetStateString(state)
+              << ")";
     return;
   } else {
     is_transitioning_ = true;

--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -28,10 +28,11 @@ void SbEventHandle(const SbEvent* event) {
     return;
   }
 
-  // The lifecycle delegate is allocated on the heap on the first event call.
-  // Its lifetime extends beyond the scope of this function and is
-  // asynchronously deleted in AppEventDelegate::DoTeardown() on the UI thread
-  // once the stopped transition sequence has fully completed.
+  // This object's lifetime extends beyond the function's lifetime, until the
+  // function is called with kSbEventTypeStop at some time in the future.
+  // When the application is stopped, this object is destroyed and the pointer
+  // is reset to nullptr, to ensure that any spurious events received after the
+  // application is stopped are ignored.
   static cobalt::AppEventDelegate* s_lifecycle_delegate =
       new cobalt::AppEventDelegate();
 

--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -18,19 +18,22 @@
 #include "starboard/event.h"
 
 void SbEventHandle(const SbEvent* event) {
-  // This object's lifetime extends beyond the function's lifetime, until the
-  // function is called with kSbEventTypeStop at some time in the future.
-  // When the application is stopped, this object is destroyed and the pointer
-  // is reset to nullptr, to ensure that any spurious events received after the
-  // application is stopped are ignored.
-  static cobalt::AppEventDelegate* s_lifecycle_delegate =
-      new cobalt::AppEventDelegate();
-
-  if (!s_lifecycle_delegate) {
+  // Tracks whether the application has started the stop sequence. Once set to
+  // true, any spurious events received after kSbEventTypeStop are permanently
+  // ignored.
+  static bool s_stopped = false;
+  if (s_stopped) {
     LOG(WARNING) << "Received spurious SbEventHandle(type = " << event->type
                  << ") call after kSbEventTypeStop, ignoring.";
     return;
   }
+
+  // The lifecycle delegate is allocated on the heap on the first event call.
+  // Its lifetime extends beyond the scope of this function and is
+  // asynchronously deleted in AppEventDelegate::DoTeardown() on the UI thread
+  // once the stopped transition sequence has fully completed.
+  static cobalt::AppEventDelegate* s_lifecycle_delegate =
+      new cobalt::AppEventDelegate();
 
   s_lifecycle_delegate->HandleEvent(event);
 
@@ -41,6 +44,7 @@ void SbEventHandle(const SbEvent* event) {
     s_lifecycle_delegate->DoTeardown();
     delete s_lifecycle_delegate;
     s_lifecycle_delegate = nullptr;
+    s_stopped = true;
   }
 }
 

--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -18,16 +18,6 @@
 #include "starboard/event.h"
 
 void SbEventHandle(const SbEvent* event) {
-  // Tracks whether the application has started the stop sequence. Once set to
-  // true, any spurious events received after kSbEventTypeStop are permanently
-  // ignored.
-  static bool s_stopped = false;
-  if (s_stopped) {
-    LOG(WARNING) << "Received spurious SbEventHandle(type = " << event->type
-                 << ") call after kSbEventTypeStop, ignoring.";
-    return;
-  }
-
   // This object's lifetime extends beyond the function's lifetime, until the
   // function is called with kSbEventTypeStop at some time in the future.
   // When the application is stopped, this object is destroyed and the pointer
@@ -35,6 +25,12 @@ void SbEventHandle(const SbEvent* event) {
   // application is stopped are ignored.
   static cobalt::AppEventDelegate* s_lifecycle_delegate =
       new cobalt::AppEventDelegate();
+
+  if (!s_lifecycle_delegate) {
+    LOG(WARNING) << "Received spurious SbEventHandle(type = " << event->type
+                 << ") call after kSbEventTypeStop, ignoring.";
+    return;
+  }
 
   s_lifecycle_delegate->HandleEvent(event);
 
@@ -45,7 +41,6 @@ void SbEventHandle(const SbEvent* event) {
     s_lifecycle_delegate->DoTeardown();
     delete s_lifecycle_delegate;
     s_lifecycle_delegate = nullptr;
-    s_stopped = true;
   }
 }
 


### PR DESCRIPTION
This is a minor cosmetic logging improvement that logs the state names in addition to the enum values.

Bug: 521960047
