### PR TITLE
android: Use safe JNI helpers for DRM/Capabilities

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -435,12 +435,14 @@ test("starboard_platform_tests") {
     ":media_codec_video_decoder_helpers",
     ":starboard_platform",
     ":test_support",
+    "//base",
     "//starboard:starboard_group",
     "//starboard/shared/starboard/drm:drm_test_helpers",
     "//starboard/shared/starboard/player/filter/testing:test_util",
     "//starboard/testing:scoped_feature_list",
     "//testing/gmock",
     "//testing/gtest",
+    "//third_party/jni_zero",
   ]
 }
 

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -228,6 +228,8 @@ static_library("starboard_platform") {
 
     "runtime_resource_overlay.cc",
     "runtime_resource_overlay.h",
+    "safe_jni.cc",
+    "safe_jni.h",
     "sanitizer_options.cc",
 
     # TODO: (cobalt b/392178584) clean up speech synthesis code.
@@ -423,6 +425,7 @@ test("starboard_platform_tests") {
               "mock_media_capabilities_cache.h",
               "model_year_test.cc",
               "player_get_preferred_output_mode_test.cc",
+              "safe_jni_test.cc",
               "video_frame_tracker_test.cc",
             ]
 

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -25,6 +25,7 @@
 #include "starboard/android/shared/audio_output_manager.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/media_drm_bridge.h"
+#include "starboard/android/shared/safe_jni.h"
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
@@ -155,14 +156,13 @@ class MediaCapabilitiesProviderImpl : public MediaCapabilitiesProvider {
     JNIEnv* env = AttachCurrentThread();
     ScopedJavaLocalRef<jobjectArray> j_codec_infos =
         Java_MediaCodecUtil_getAllCodecCapabilityInfos(env);
-    size_t length = base::android::SafeGetArrayLength(env, j_codec_infos);
+    std::vector<ScopedJavaLocalRef<jobject>> codec_infos =
+        JavaObjectArrayToVector(env, j_codec_infos);
 
     // Note: Codec infos are sorted by the framework such that the best
     // decoders come first.
     // This order is maintained in the cache.
-    for (size_t i = 0; i < length; i++) {
-      ScopedJavaLocalRef<jobject> j_codec_info(
-          env, env->GetObjectArrayElement(j_codec_infos.obj(), i));
+    for (auto& j_codec_info : codec_infos) {
       SB_CHECK(j_codec_info);
 
       ScopedJavaLocalRef<jstring> j_mime_type =

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -104,11 +104,11 @@ class MediaCapabilitiesProviderImpl : public MediaCapabilitiesProvider {
       return std::set<SbMediaTransferId>();
     }
 
-    jsize length = env->GetArrayLength(j_supported_hdr_types.obj());
-    jint* numbers =
-        env->GetIntArrayElements(j_supported_hdr_types.obj(), nullptr);
-    for (int i = 0; i < length; i++) {
-      switch (numbers[i]) {
+    std::vector<int> hdr_types;
+    base::android::JavaIntArrayToIntVector(env, j_supported_hdr_types,
+                                           &hdr_types);
+    for (int hdr_type : hdr_types) {
+      switch (hdr_type) {
         case HDR_TYPE_DOLBY_VISION:
           continue;
         case HDR_TYPE_HDR10:
@@ -121,7 +121,6 @@ class MediaCapabilitiesProviderImpl : public MediaCapabilitiesProvider {
           continue;
       }
     }
-    env->ReleaseIntArrayElements(j_supported_hdr_types.obj(), numbers, 0);
 
     return supported_transfer_ids;
   }
@@ -156,12 +155,12 @@ class MediaCapabilitiesProviderImpl : public MediaCapabilitiesProvider {
     JNIEnv* env = AttachCurrentThread();
     ScopedJavaLocalRef<jobjectArray> j_codec_infos =
         Java_MediaCodecUtil_getAllCodecCapabilityInfos(env);
-    jsize length = env->GetArrayLength(j_codec_infos.obj());
+    size_t length = base::android::SafeGetArrayLength(env, j_codec_infos);
 
     // Note: Codec infos are sorted by the framework such that the best
     // decoders come first.
     // This order is maintained in the cache.
-    for (int i = 0; i < length; i++) {
+    for (size_t i = 0; i < length; i++) {
       ScopedJavaLocalRef<jobject> j_codec_info(
           env, env->GetObjectArrayElement(j_codec_infos.obj(), i));
       SB_CHECK(j_codec_info);

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -18,6 +18,7 @@
 #include "base/android/jni_string.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
+#include "starboard/android/shared/safe_jni.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/media.h"
 #include "starboard/common/string.h"
@@ -266,20 +267,8 @@ void MediaCodecBridge::Initialize(jobject j_media_codec_bridge) {
 Span<uint8_t> MediaCodecBridge::GetInputBufferAddress(jint index) {
   SB_DCHECK_GE(index, 0);
   JNIEnv* env = AttachCurrentThread();
-  ScopedJavaLocalRef<jobject> byte_buffer =
-      Java_MediaCodecBridge_getInputBuffer(env, j_media_codec_bridge_, index);
-  if (byte_buffer.is_null()) {
-    return {};
-  }
-  jlong cap = env->GetDirectBufferCapacity(byte_buffer.obj());
-  if (cap < 0) {
-    return {};
-  }
-  void* address = env->GetDirectBufferAddress(byte_buffer.obj());
-  if (!address) {
-    return {};
-  }
-  return {static_cast<uint8_t*>(address), static_cast<size_t>(cap)};
+  return JavaByteBufferToSpan(env, Java_MediaCodecBridge_getInputBuffer(
+                                       env, j_media_codec_bridge_, index));
 }
 
 jint MediaCodecBridge::QueueInputBuffer(jint index,
@@ -343,20 +332,8 @@ jint MediaCodecBridge::QueueSecureInputBuffer(
 Span<uint8_t> MediaCodecBridge::GetOutputBufferAddress(jint index) {
   SB_DCHECK_GE(index, 0);
   JNIEnv* env = AttachCurrentThread();
-  ScopedJavaLocalRef<jobject> byte_buffer =
-      Java_MediaCodecBridge_getOutputBuffer(env, j_media_codec_bridge_, index);
-  if (byte_buffer.is_null()) {
-    return {};
-  }
-  jlong cap = env->GetDirectBufferCapacity(byte_buffer.obj());
-  if (cap < 0) {
-    return {};
-  }
-  void* address = env->GetDirectBufferAddress(byte_buffer.obj());
-  if (!address) {
-    return {};
-  }
-  return {static_cast<uint8_t*>(address), static_cast<size_t>(cap)};
+  return JavaByteBufferToSpan(env, Java_MediaCodecBridge_getOutputBuffer(
+                                       env, j_media_codec_bridge_, index));
 }
 
 void MediaCodecBridge::ReleaseOutputBuffer(jint index, jboolean render) {

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -15,10 +15,10 @@
 #include "starboard/android/shared/media_codec_bridge.h"
 
 #include "base/android/jni_array.h"
+#include "base/android/jni_bytebuffer.h"
 #include "base/android/jni_string.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
-#include "starboard/android/shared/safe_jni.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/media.h"
 #include "starboard/common/string.h"
@@ -34,11 +34,17 @@ namespace {
 
 using base::android::ConvertJavaStringToUTF8;
 using base::android::ConvertUTF8ToJavaString;
+using base::android::JavaByteBufferToMutableSpan;
 using base::android::ToJavaByteArray;
 using base::android::ToJavaIntArray;
 using jni_zero::AttachCurrentThread;
 using jni_zero::JavaParamRef;
 using jni_zero::ScopedJavaLocalRef;
+
+template <typename SpanType>
+starboard::Span<uint8_t> ToSpan(const SpanType& base_span) {
+  return starboard::Span<uint8_t>(base_span.data(), base_span.size());
+}
 
 // See
 // https://developer.android.com/reference/android/media/MediaFormat.html#COLOR_RANGE_FULL.
@@ -267,8 +273,10 @@ void MediaCodecBridge::Initialize(jobject j_media_codec_bridge) {
 Span<uint8_t> MediaCodecBridge::GetInputBufferAddress(jint index) {
   SB_DCHECK_GE(index, 0);
   JNIEnv* env = AttachCurrentThread();
-  return JavaByteBufferToSpan(env, Java_MediaCodecBridge_getInputBuffer(
-                                       env, j_media_codec_bridge_, index));
+  return ToSpan(JavaByteBufferToMutableSpan(
+      env,
+      Java_MediaCodecBridge_getInputBuffer(env, j_media_codec_bridge_, index)
+          .obj()));
 }
 
 jint MediaCodecBridge::QueueInputBuffer(jint index,
@@ -332,8 +340,10 @@ jint MediaCodecBridge::QueueSecureInputBuffer(
 Span<uint8_t> MediaCodecBridge::GetOutputBufferAddress(jint index) {
   SB_DCHECK_GE(index, 0);
   JNIEnv* env = AttachCurrentThread();
-  return JavaByteBufferToSpan(env, Java_MediaCodecBridge_getOutputBuffer(
-                                       env, j_media_codec_bridge_, index));
+  return ToSpan(JavaByteBufferToMutableSpan(
+      env,
+      Java_MediaCodecBridge_getOutputBuffer(env, j_media_codec_bridge_, index)
+          .obj()));
 }
 
 void MediaCodecBridge::ReleaseOutputBuffer(jint index, jboolean render) {

--- a/starboard/android/shared/media_drm_bridge.cc
+++ b/starboard/android/shared/media_drm_bridge.cc
@@ -235,13 +235,7 @@ const void* MediaDrmBridge::GetMetrics(int* size) {
     return nullptr;
   }
 
-  jbyte* metrics_elements = env->GetByteArrayElements(j_metrics.obj(), nullptr);
-  jsize metrics_size = base::android::SafeGetArrayLength(env, j_metrics);
-  SB_DCHECK(metrics_elements);
-
-  metrics_.assign(metrics_elements, metrics_elements + metrics_size);
-
-  env->ReleaseByteArrayElements(j_metrics.obj(), metrics_elements, JNI_ABORT);
+  base::android::JavaByteArrayToByteVector(env, j_metrics, &metrics_);
   *size = static_cast<int>(metrics_.size());
 
   return metrics_.data();
@@ -277,12 +271,13 @@ void MediaDrmBridge::OnKeyStatusChange(
   std::string session_id_bytes = JavaByteArrayToString(env, session_id);
 
   // nullptr array indicates key status isn't supported (i.e. Android API < 23)
-  jsize length =
-      (key_information == nullptr) ? 0 : env->GetArrayLength(key_information);
+  size_t length = key_information.is_null()
+                      ? 0
+                      : base::android::SafeGetArrayLength(env, key_information);
   std::vector<SbDrmKeyId> drm_key_ids(length);
   std::vector<SbDrmKeyStatus> drm_key_statuses(length);
 
-  for (jsize i = 0; i < length; ++i) {
+  for (size_t i = 0; i < length; ++i) {
     ScopedJavaLocalRef<jobject> j_key_status(
         env, env->GetObjectArrayElement(key_information.obj(), i));
     ScopedJavaLocalRef<jbyteArray> j_key_id =

--- a/starboard/android/shared/media_drm_bridge.cc
+++ b/starboard/android/shared/media_drm_bridge.cc
@@ -22,6 +22,7 @@
 #include "base/android/jni_array.h"
 #include "base/android/jni_string.h"
 #include "base/memory/raw_ref.h"
+#include "starboard/android/shared/safe_jni.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -270,23 +271,23 @@ void MediaDrmBridge::OnKeyStatusChange(
     const JavaParamRef<jobjectArray>& key_information) {
   std::string session_id_bytes = JavaByteArrayToString(env, session_id);
 
-  // nullptr array indicates key status isn't supported (i.e. Android API < 23)
-  size_t length = key_information.is_null()
-                      ? 0
-                      : base::android::SafeGetArrayLength(env, key_information);
+  std::vector<ScopedJavaLocalRef<jobject>> key_statuses =
+      JavaObjectArrayToVector(env, key_information);
+
+  size_t length = key_statuses.size();
   std::vector<SbDrmKeyId> drm_key_ids(length);
   std::vector<SbDrmKeyStatus> drm_key_statuses(length);
 
   for (size_t i = 0; i < length; ++i) {
-    ScopedJavaLocalRef<jobject> j_key_status(
-        env, env->GetObjectArrayElement(key_information.obj(), i));
+    const auto& j_key_status = key_statuses[i];
     ScopedJavaLocalRef<jbyteArray> j_key_id =
         Java_KeyStatus_getKeyId(env, j_key_status);
-    std::string key_id = JavaByteArrayToString(env, j_key_id);
+    std::vector<uint8_t> key_id_bytes;
+    base::android::JavaByteArrayToByteVector(env, j_key_id, &key_id_bytes);
 
-    SB_DCHECK_LE(key_id.size(), sizeof(drm_key_ids[i].identifier));
-    memcpy(drm_key_ids[i].identifier, key_id.data(), key_id.size());
-    drm_key_ids[i].identifier_size = key_id.size();
+    SB_DCHECK_LE(key_id_bytes.size(), sizeof(drm_key_ids[i].identifier));
+    memcpy(drm_key_ids[i].identifier, key_id_bytes.data(), key_id_bytes.size());
+    drm_key_ids[i].identifier_size = key_id_bytes.size();
 
     drm_key_statuses[i] =
         ToSbDrmKeyStatus(Java_KeyStatus_getStatusCode(env, j_key_status));

--- a/starboard/android/shared/platform_service.cc
+++ b/starboard/android/shared/platform_service.cc
@@ -119,8 +119,9 @@ void* Send(CobaltExtensionPlatformService service,
     return nullptr;
   }
 
-  env->GetByteArrayRegion(j_out_data.obj(), 0, data_length,
-                          reinterpret_cast<jbyte*>(output));
+  base::android::JavaByteArrayToByteSpan(
+      env, j_out_data,
+      {static_cast<uint8_t*>(output), static_cast<size_t>(data_length)});
 
   *invalid_state = Java_ResponseToClient_getInvalidState(env, j_response);
   *output_length = data_length;

--- a/starboard/android/shared/safe_jni.cc
+++ b/starboard/android/shared/safe_jni.cc
@@ -14,26 +14,10 @@
 
 #include "starboard/android/shared/safe_jni.h"
 
-#include <atomic>
-
 #include "base/android/jni_array.h"
-#include "base/android/jni_bytebuffer.h"
 #include "starboard/common/check_op.h"
-#include "starboard/common/log.h"
-#include "third_party/jni_zero/jni_zero_internal.h"
 
 namespace starboard {
-namespace {
-
-// Following the JNI Generator convention for class accessor naming:
-// [package]_[subpackage]_[ClassName]_clazz
-jclass java_nio_ByteBuffer_clazz(JNIEnv* env) {
-  static std::atomic<jclass> cached_class;
-  return jni_zero::internal::LazyGetClass(env, "java/nio/ByteBuffer",
-                                          &cached_class);
-}
-
-}  // namespace
 
 using jni_zero::ScopedJavaLocalRef;
 
@@ -51,25 +35,6 @@ std::vector<ScopedJavaLocalRef<jobject>> JavaObjectArrayToVector(
         env, env->GetObjectArrayElement(array.obj(), static_cast<jsize>(i)));
   }
   return out;
-}
-
-Span<uint8_t> JavaByteBufferToSpan(
-    JNIEnv* env,
-    const jni_zero::JavaRef<jobject>& byte_buffer) {
-  SB_CHECK(env);
-  if (!byte_buffer) {
-    return {};
-  }
-  if (!env->IsInstanceOf(byte_buffer.obj(), java_nio_ByteBuffer_clazz(env))) {
-    SB_LOG(WARNING) << "Object is not an instance of java/nio/ByteBuffer";
-    return {};
-  }
-  auto span =
-      base::android::MaybeJavaByteBufferToMutableSpan(env, byte_buffer.obj());
-  if (!span.has_value()) {
-    return {};
-  }
-  return {span->data(), span->size()};
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/safe_jni.cc
+++ b/starboard/android/shared/safe_jni.cc
@@ -15,6 +15,7 @@
 #include "starboard/android/shared/safe_jni.h"
 
 #include "base/android/jni_array.h"
+#include "base/android/jni_bytebuffer.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 
@@ -26,7 +27,7 @@ std::vector<ScopedJavaLocalRef<jobject>> JavaObjectArrayToVector(
     JNIEnv* env,
     const jni_zero::JavaRef<jobjectArray>& array) {
   SB_CHECK(env);
-  if (array.is_null()) {
+  if (!array) {
     return {};
   }
   size_t length = base::android::SafeGetArrayLength(env, array);
@@ -42,20 +43,15 @@ Span<uint8_t> JavaByteBufferToSpan(
     JNIEnv* env,
     const jni_zero::JavaRef<jobject>& byte_buffer) {
   SB_CHECK(env);
-  if (byte_buffer.is_null()) {
+  if (!byte_buffer) {
     return {};
   }
-  jlong capacity = env->GetDirectBufferCapacity(byte_buffer.obj());
-  if (capacity < 0) {
-    SB_LOG(WARNING) << "ByteBuffer is not direct or capacity is invalid.";
+  auto span =
+      base::android::MaybeJavaByteBufferToMutableSpan(env, byte_buffer.obj());
+  if (!span.has_value()) {
     return {};
   }
-  void* address = env->GetDirectBufferAddress(byte_buffer.obj());
-  if (!address) {
-    SB_LOG(WARNING) << "Failed to get direct buffer address.";
-    return {};
-  }
-  return {static_cast<uint8_t*>(address), static_cast<size_t>(capacity)};
+  return {span->data(), span->size()};
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/safe_jni.cc
+++ b/starboard/android/shared/safe_jni.cc
@@ -1,0 +1,41 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/safe_jni.h"
+
+#include "base/android/jni_array.h"
+#include "starboard/common/check_op.h"
+#include "starboard/common/log.h"
+
+namespace starboard {
+
+using jni_zero::ScopedJavaLocalRef;
+
+std::vector<ScopedJavaLocalRef<jobject>> JavaObjectArrayToVector(
+    JNIEnv* env,
+    const jni_zero::JavaRef<jobjectArray>& array) {
+  SB_CHECK(env);
+  if (array.is_null()) {
+    return {};
+  }
+  size_t length = base::android::SafeGetArrayLength(env, array);
+  std::vector<ScopedJavaLocalRef<jobject>> out(length);
+  for (size_t i = 0; i < length; ++i) {
+    out[i] = ScopedJavaLocalRef<jobject>(
+        env, env->GetObjectArrayElement(array.obj(), static_cast<jsize>(i)));
+  }
+  return out;
+}
+
+}  // namespace starboard

--- a/starboard/android/shared/safe_jni.cc
+++ b/starboard/android/shared/safe_jni.cc
@@ -14,12 +14,24 @@
 
 #include "starboard/android/shared/safe_jni.h"
 
+#include <atomic>
+
 #include "base/android/jni_array.h"
 #include "base/android/jni_bytebuffer.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "third_party/jni_zero/jni_zero_internal.h"
 
 namespace starboard {
+namespace {
+
+jclass GetByteBufferClass(JNIEnv* env) {
+  static std::atomic<jclass> cached_class;
+  return jni_zero::internal::LazyGetClass(env, "java/nio/ByteBuffer",
+                                          &cached_class);
+}
+
+}  // namespace
 
 using jni_zero::ScopedJavaLocalRef;
 
@@ -44,6 +56,10 @@ Span<uint8_t> JavaByteBufferToSpan(
     const jni_zero::JavaRef<jobject>& byte_buffer) {
   SB_CHECK(env);
   if (!byte_buffer) {
+    return {};
+  }
+  if (!env->IsInstanceOf(byte_buffer.obj(), GetByteBufferClass(env))) {
+    SB_LOG(WARNING) << "Object is not an instance of java/nio/ByteBuffer";
     return {};
   }
   auto span =

--- a/starboard/android/shared/safe_jni.cc
+++ b/starboard/android/shared/safe_jni.cc
@@ -38,4 +38,24 @@ std::vector<ScopedJavaLocalRef<jobject>> JavaObjectArrayToVector(
   return out;
 }
 
+Span<uint8_t> JavaByteBufferToSpan(
+    JNIEnv* env,
+    const jni_zero::JavaRef<jobject>& byte_buffer) {
+  SB_CHECK(env);
+  if (byte_buffer.is_null()) {
+    return {};
+  }
+  jlong capacity = env->GetDirectBufferCapacity(byte_buffer.obj());
+  if (capacity < 0) {
+    SB_LOG(WARNING) << "ByteBuffer is not direct or capacity is invalid.";
+    return {};
+  }
+  void* address = env->GetDirectBufferAddress(byte_buffer.obj());
+  if (!address) {
+    SB_LOG(WARNING) << "Failed to get direct buffer address.";
+    return {};
+  }
+  return {static_cast<uint8_t*>(address), static_cast<size_t>(capacity)};
+}
+
 }  // namespace starboard

--- a/starboard/android/shared/safe_jni.cc
+++ b/starboard/android/shared/safe_jni.cc
@@ -25,7 +25,9 @@
 namespace starboard {
 namespace {
 
-jclass GetByteBufferClass(JNIEnv* env) {
+// Following the JNI Generator convention for class accessor naming:
+// [package]_[subpackage]_[ClassName]_clazz
+jclass java_nio_ByteBuffer_clazz(JNIEnv* env) {
   static std::atomic<jclass> cached_class;
   return jni_zero::internal::LazyGetClass(env, "java/nio/ByteBuffer",
                                           &cached_class);
@@ -58,7 +60,7 @@ Span<uint8_t> JavaByteBufferToSpan(
   if (!byte_buffer) {
     return {};
   }
-  if (!env->IsInstanceOf(byte_buffer.obj(), GetByteBufferClass(env))) {
+  if (!env->IsInstanceOf(byte_buffer.obj(), java_nio_ByteBuffer_clazz(env))) {
     SB_LOG(WARNING) << "Object is not an instance of java/nio/ByteBuffer";
     return {};
   }

--- a/starboard/android/shared/safe_jni.h
+++ b/starboard/android/shared/safe_jni.h
@@ -1,0 +1,56 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_SAFE_JNI_H_
+#define STARBOARD_ANDROID_SHARED_SAFE_JNI_H_
+
+#include <jni.h>
+
+#include <vector>
+
+#include "base/android/scoped_java_ref.h"
+#include "third_party/jni_zero/jni_zero.h"
+
+// ============================================================================
+// JNI Safety Gatekeeper Philosophy
+// ============================================================================
+// This library serves as a safe boundary between Starboard C++ and raw Java
+// JNI.
+//
+// 1. Minimize Unsafe JNI: We want to minimize the use of raw, legacy JNI Env
+//    calls (like GetObjectArrayElement, GetMethodID) in our main media and
+//    platform logic. Raw JNI is highly error-prone, prone to local reference
+//    leaks, and difficult to review.
+// 2. Strict Isolation: If we absolutely must write raw JNI (because a safe
+//    helper does not exist in base::android or jni_zero), we isolate it here.
+// 3. Rigorous Audit: Every function in this library must undergo rigorous
+//    code review to ensure it is 100% leak-free, uses RAII (ScopedJavaLocalRef)
+//    correctly, and handles type/narrowing conversions safely.
+// 4. Mandated Reuse: All engineers should ALWAYS use the safe, high-level C++
+//    APIs exposed in this file instead of writing raw JNI in their own files.
+// ============================================================================
+
+namespace starboard {
+
+// Converts a Java object array (jobjectArray) to a C++ std::vector of
+// jni_zero::ScopedJavaLocalRef<jobject>.
+// This helper encapsulates the JNI array indexing and type-casting,
+// allowing business logic to use clean range-based for loops.
+std::vector<jni_zero::ScopedJavaLocalRef<jobject>> JavaObjectArrayToVector(
+    JNIEnv* env,
+    const jni_zero::JavaRef<jobjectArray>& array);
+
+}  // namespace starboard
+
+#endif  // STARBOARD_ANDROID_SHARED_SAFE_JNI_H_

--- a/starboard/android/shared/safe_jni.h
+++ b/starboard/android/shared/safe_jni.h
@@ -20,6 +20,7 @@
 #include <vector>
 
 #include "base/android/scoped_java_ref.h"
+#include "starboard/common/span.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 // ============================================================================
@@ -50,6 +51,12 @@ namespace starboard {
 std::vector<jni_zero::ScopedJavaLocalRef<jobject>> JavaObjectArrayToVector(
     JNIEnv* env,
     const jni_zero::JavaRef<jobjectArray>& array);
+
+// Converts a Java direct ByteBuffer to a C++ Span<uint8_t>.
+// Returns an empty Span if the buffer is not direct or if JNI calls fail.
+Span<uint8_t> JavaByteBufferToSpan(
+    JNIEnv* env,
+    const jni_zero::JavaRef<jobject>& byte_buffer);
 
 }  // namespace starboard
 

--- a/starboard/android/shared/safe_jni.h
+++ b/starboard/android/shared/safe_jni.h
@@ -52,12 +52,6 @@ std::vector<jni_zero::ScopedJavaLocalRef<jobject>> JavaObjectArrayToVector(
     JNIEnv* env,
     const jni_zero::JavaRef<jobjectArray>& array);
 
-// Converts a Java direct ByteBuffer to a C++ Span<uint8_t>.
-// Returns an empty Span if the buffer is not direct or if JNI calls fail.
-Span<uint8_t> JavaByteBufferToSpan(
-    JNIEnv* env,
-    const jni_zero::JavaRef<jobject>& byte_buffer);
-
 }  // namespace starboard
 
 #endif  // STARBOARD_ANDROID_SHARED_SAFE_JNI_H_

--- a/starboard/android/shared/safe_jni_test.cc
+++ b/starboard/android/shared/safe_jni_test.cc
@@ -78,49 +78,5 @@ TEST(SafeJniTest, JavaObjectArrayToVector_EmptyArray) {
   EXPECT_TRUE(result.empty());
 }
 
-TEST(SafeJniTest, JavaByteBufferToSpan_ValidBuffer) {
-  JNIEnv* env = AttachCurrentThread();
-  ASSERT_NE(env, nullptr);
-
-  uint8_t c_buffer[16] = {0};
-  ScopedJavaLocalRef<jobject> j_buffer(
-      env, env->NewDirectByteBuffer(c_buffer, sizeof(c_buffer)));
-  ASSERT_FALSE(j_buffer.is_null());
-
-  Span<uint8_t> result = JavaByteBufferToSpan(env, j_buffer);
-
-  EXPECT_EQ(result.data(), c_buffer);
-  EXPECT_EQ(result.size(), sizeof(c_buffer));
-  EXPECT_FALSE(result.empty());
-}
-
-TEST(SafeJniTest, JavaByteBufferToSpan_NullBuffer) {
-  JNIEnv* env = AttachCurrentThread();
-  ASSERT_NE(env, nullptr);
-
-  ScopedJavaLocalRef<jobject> j_buffer;  // Null
-  Span<uint8_t> result = JavaByteBufferToSpan(env, j_buffer);
-
-  EXPECT_EQ(result.data(), nullptr);
-  EXPECT_EQ(result.size(), 0U);
-  EXPECT_TRUE(result.empty());
-}
-
-TEST(SafeJniTest, JavaByteBufferToSpan_NonDirectBuffer) {
-  JNIEnv* env = AttachCurrentThread();
-  ASSERT_NE(env, nullptr);
-
-  // Create a regular Java byte array, which is NOT a direct ByteBuffer
-  ScopedJavaLocalRef<jbyteArray> j_array(env, env->NewByteArray(10));
-  ASSERT_FALSE(j_array.is_null());
-
-  // Pass the byte array (cast to jobject) to the helper
-  Span<uint8_t> result = JavaByteBufferToSpan(env, j_array);
-
-  EXPECT_EQ(result.data(), nullptr);
-  EXPECT_EQ(result.size(), 0U);
-  EXPECT_TRUE(result.empty());
-}
-
 }  // namespace
 }  // namespace starboard

--- a/starboard/android/shared/safe_jni_test.cc
+++ b/starboard/android/shared/safe_jni_test.cc
@@ -1,0 +1,82 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/safe_jni.h"
+
+#include <string>
+#include <vector>
+
+#include "base/android/jni_array.h"
+#include "base/android/jni_string.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/jni_zero/jni_zero.h"
+
+namespace starboard {
+namespace {
+
+using base::android::ConvertJavaStringToUTF8;
+using base::android::ToJavaArrayOfStrings;
+using jni_zero::AttachCurrentThread;
+using jni_zero::ScopedJavaLocalRef;
+
+TEST(SafeJniTest, JavaObjectArrayToVector_ValidArray) {
+  JNIEnv* env = AttachCurrentThread();
+  ASSERT_NE(env, nullptr);
+
+  std::vector<std::string> input_strings = {"apple", "banana", "cherry"};
+  ScopedJavaLocalRef<jobjectArray> j_array =
+      ToJavaArrayOfStrings(env, input_strings);
+  ASSERT_FALSE(j_array.is_null());
+
+  std::vector<ScopedJavaLocalRef<jobject>> result =
+      JavaObjectArrayToVector(env, j_array);
+
+  EXPECT_EQ(result.size(), input_strings.size());
+
+  for (size_t i = 0; i < input_strings.size(); ++i) {
+    ASSERT_FALSE(result[i].is_null());
+    std::string result_str =
+        ConvertJavaStringToUTF8(env, static_cast<jstring>(result[i].obj()));
+    EXPECT_EQ(result_str, input_strings[i]);
+  }
+}
+
+TEST(SafeJniTest, JavaObjectArrayToVector_NullArray) {
+  JNIEnv* env = AttachCurrentThread();
+  ASSERT_NE(env, nullptr);
+
+  ScopedJavaLocalRef<jobjectArray> j_array;  // Null ref
+  std::vector<ScopedJavaLocalRef<jobject>> result =
+      JavaObjectArrayToVector(env, j_array);
+
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(SafeJniTest, JavaObjectArrayToVector_EmptyArray) {
+  JNIEnv* env = AttachCurrentThread();
+  ASSERT_NE(env, nullptr);
+
+  std::vector<std::string> input_strings = {};
+  ScopedJavaLocalRef<jobjectArray> j_array =
+      ToJavaArrayOfStrings(env, input_strings);
+  ASSERT_FALSE(j_array.is_null());
+
+  std::vector<ScopedJavaLocalRef<jobject>> result =
+      JavaObjectArrayToVector(env, j_array);
+
+  EXPECT_TRUE(result.empty());
+}
+
+}  // namespace
+}  // namespace starboard

--- a/starboard/android/shared/safe_jni_test.cc
+++ b/starboard/android/shared/safe_jni_test.cc
@@ -78,5 +78,49 @@ TEST(SafeJniTest, JavaObjectArrayToVector_EmptyArray) {
   EXPECT_TRUE(result.empty());
 }
 
+TEST(SafeJniTest, JavaByteBufferToSpan_ValidBuffer) {
+  JNIEnv* env = AttachCurrentThread();
+  ASSERT_NE(env, nullptr);
+
+  uint8_t c_buffer[16] = {0};
+  ScopedJavaLocalRef<jobject> j_buffer(
+      env, env->NewDirectByteBuffer(c_buffer, sizeof(c_buffer)));
+  ASSERT_FALSE(j_buffer.is_null());
+
+  Span<uint8_t> result = JavaByteBufferToSpan(env, j_buffer);
+
+  EXPECT_EQ(result.data(), c_buffer);
+  EXPECT_EQ(result.size(), sizeof(c_buffer));
+  EXPECT_FALSE(result.empty());
+}
+
+TEST(SafeJniTest, JavaByteBufferToSpan_NullBuffer) {
+  JNIEnv* env = AttachCurrentThread();
+  ASSERT_NE(env, nullptr);
+
+  ScopedJavaLocalRef<jobject> j_buffer;  // Null
+  Span<uint8_t> result = JavaByteBufferToSpan(env, j_buffer);
+
+  EXPECT_EQ(result.data(), nullptr);
+  EXPECT_EQ(result.size(), 0U);
+  EXPECT_TRUE(result.empty());
+}
+
+TEST(SafeJniTest, JavaByteBufferToSpan_NonDirectBuffer) {
+  JNIEnv* env = AttachCurrentThread();
+  ASSERT_NE(env, nullptr);
+
+  // Create a regular Java byte array, which is NOT a direct ByteBuffer
+  ScopedJavaLocalRef<jbyteArray> j_array(env, env->NewByteArray(10));
+  ASSERT_FALSE(j_array.is_null());
+
+  // Pass the byte array (cast to jobject) to the helper
+  Span<uint8_t> result = JavaByteBufferToSpan(env, j_array);
+
+  EXPECT_EQ(result.data(), nullptr);
+  EXPECT_EQ(result.size(), 0U);
+  EXPECT_TRUE(result.empty());
+}
+
 }  // namespace
 }  // namespace starboard


### PR DESCRIPTION
Refactor JNI code in MediaDrmBridge and MediaCapabilitiesProviderImpl
to use safer Chromium base::android helpers instead of manual JNI
array access.

This change replaces manual element retrieval and releases with helper
functions to reduce the risk of memory leaks. It also adopts
SafeGetArrayLength and size_t indices to prevent potential crashes
and signed/unsigned comparison warnings.

Issue: 520007952