### PR TITLE
YouTube certification requires the device type in UA

### DIFF
--- a/starboard/android/shared/system_get_property.cc
+++ b/starboard/android/shared/system_get_property.cc
@@ -17,6 +17,7 @@
 // clang-format on
 
 #include <jni.h>
+#include <strings.h>
 
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/device_type.h"
@@ -85,6 +86,44 @@ bool CopyAndroidPlatformName(char* out_value, int value_length) {
            version_string_buffer);
 
   return CopyStringAndTestIfSuccess(out_value, value_length, result_string);
+}
+
+const char* MapDeviceType(const char* prop_value) {
+  if (!prop_value || prop_value[0] == '\0') {
+    SB_DLOG(INFO) << "Invalid property value";
+    return starboard::kSystemDeviceTypeUnknown;
+  }
+
+  struct Mapping {
+    const char* prop;
+    const char* type;
+  };
+
+  static const Mapping kMappings[] = {
+      {"BDP", starboard::kSystemDeviceTypeBlueRayDiskPlayer},
+      {"GAME", starboard::kSystemDeviceTypeGameConsole},
+      {"OTT", starboard::kSystemDeviceTypeOverTheTopBox},
+      {"STB", starboard::kSystemDeviceTypeSetTopBox},
+      {"TV", starboard::kSystemDeviceTypeTV},
+      {"ATV", starboard::kSystemDeviceTypeAndroidTV},
+      {"DESKTOP", starboard::kSystemDeviceTypeDesktopPC},
+      {"PROJECTOR", starboard::kSystemDeviceTypeVideoProjector},
+      {"MMD", starboard::kSystemDeviceTypeMultimediaDevices},
+      {"MONITOR", starboard::kSystemDeviceTypeMonitor},
+      {"AUTO", starboard::kSystemDeviceTypeAuto},
+      {"SOUNDBAR", starboard::kSystemDeviceTypeSoundBar},
+      {"HOSPITALITY", starboard::kSystemDeviceTypeHospitality},
+  };
+
+  for (const auto& mapping : kMappings) {
+    if (strcasecmp(prop_value, mapping.prop) == 0) {
+      SB_DLOG(INFO) << "mapped '" << prop_value << "' -> '" << mapping.type
+                    << "'";
+      return mapping.type;
+    }
+  }
+  SB_DLOG(INFO) << "Unknown device type: '" << prop_value << "'";
+  return starboard::kSystemDeviceTypeUnknown;
 }
 
 }  // namespace
@@ -157,9 +196,21 @@ bool SbSystemGetProperty(SbSystemPropertyId property_id,
       return CopyStringAndTestIfSuccess(out_value, value_length,
                                         limit_ad_tracking_enabled ? "1" : "0");
     }
-    case kSbSystemPropertyDeviceType:
-      return CopyStringAndTestIfSuccess(out_value, value_length,
-                                        starboard::kSystemDeviceTypeAndroidTV);
+    case kSbSystemPropertyDeviceType: {
+      char prop_value[PROP_VALUE_MAX] = {0};
+      const char* device_type = starboard::kSystemDeviceTypeTV;
+      if (GetAndroidSystemProperty("ro.vendor.youtube.device_type", prop_value,
+                                   sizeof(prop_value), "")) {
+        const char* mapped_type = MapDeviceType(prop_value);
+        if (mapped_type != starboard::kSystemDeviceTypeUnknown) {
+          device_type = mapped_type;
+        }
+      }
+      SB_DLOG(INFO) << "Device type property: '" << prop_value
+                    << "', mapped device type: '" << device_type << "'";
+
+      return CopyStringAndTestIfSuccess(out_value, value_length, device_type);
+    }
     default:
       SB_DLOG(WARNING) << __FUNCTION__
                        << ": Unrecognized property: " << property_id;


### PR DESCRIPTION
YouTube certification requires the device type in UA
to match the actual product category.

cobalt read the configured device type property ro.vendor.youtube.device_type
and map it to the corresponding Starboard device type value
used in User-Agent generation.

property config refer:starboard/common/device_type.cc

BUG :522026269