### PR TITLE
Fix UAF during shutdown by waiting for Stop state before teardown

### DIFF
--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -76,7 +76,8 @@ AppEventDelegate::AppEventDelegate(
             SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
   }
 
-  SetApplicationState(ApplicationState::kInitial);
+  application_state_ = ApplicationState::kInitial;
+  SetApplicationStateAnnotation(ApplicationState::kInitial);
   target_state_ = ApplicationState::kInitial;
   if (!runner_) {
     // If a special runner wasn't provided, use the default.
@@ -414,6 +415,9 @@ const char* AppEventDelegate::GetStateString(ApplicationState state) {
 }
 
 void AppEventDelegate::SetApplicationState(ApplicationState state) {
+  if (application_state_ == state) {
+    return;
+  }
   application_state_ = state;
   SetApplicationStateAnnotation(state);
 }

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -130,6 +130,11 @@ PendingAck AppEventDelegate::pending_ack() const {
   return runner_ ? runner_->pending_ack() : PendingAck::kNone;
 }
 
+void AppEventDelegate::SetQuitClosure(base::OnceClosure closure) {
+  base::AutoLock lock(lock_);
+  quit_closure_ = std::move(closure);
+}
+
 bool AppEventDelegate::IsFrozenLocked() const {
   return application_state_ == ApplicationState::kFrozen ||
          application_state_ == ApplicationState::kStopped ||
@@ -317,7 +322,6 @@ void AppEventDelegate::ExecuteEventRunner(ApplicationState next_state,
         runner_->OnFreeze(base::DoNothing());
         break;
       case ApplicationState::kStopped:
-        runner_->OnStop();
         break;
       default:
         NOTREACHED();
@@ -328,6 +332,13 @@ void AppEventDelegate::ExecuteEventRunner(ApplicationState next_state,
 void AppEventDelegate::ExecuteStepOnUIThread(ApplicationState next_state,
                                              bool is_activating) {
   DCHECK_CURRENTLY_ON(content::BrowserThread::UI);
+  {
+    base::AutoLock lock(lock_);
+    if (is_tearing_down_) {
+      LOG(INFO) << "Ignoring ExecuteStepOnUIThread during teardown.";
+      return;
+    }
+  }
   // Note: ExecuteEventRunner does not change state nor rely on state of this
   // object, and always runs as a posted task on the UI thread, and therefore
   // the lock does not need to be held yet here.
@@ -337,19 +348,19 @@ void AppEventDelegate::ExecuteStepOnUIThread(ApplicationState next_state,
   SetApplicationState(next_state);
 
   if (next_state == ApplicationState::kStopped) {
-    SbEventSchedule(&AppEventDelegate::TeardownCallback, this, 0);
+    if (quit_closure_) {
+      std::move(quit_closure_).Run();
+    }
   } else {
     ExecuteNextStep();
   }
 }
 
-// static
-void AppEventDelegate::TeardownCallback(void* data) {
-  AppEventDelegate* delegate = static_cast<AppEventDelegate*>(data);
-  delegate->DoTeardown();
-}
-
 void AppEventDelegate::DoTeardown() {
+  {
+    base::AutoLock lock(lock_);
+    is_tearing_down_ = true;
+  }
   runner_->OnStop();
   base::AutoLock lock(lock_);
   SetApplicationState(ApplicationState::kStopped);

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -345,14 +345,23 @@ void AppEventDelegate::ExecuteStepOnUIThread(ApplicationState next_state,
   // the lock does not need to be held yet here.
   ExecuteEventRunner(next_state, is_activating);
 
-  base::AutoLock lock(lock_);
-  SetApplicationState(next_state);
-
-  if (next_state == ApplicationState::kStopped) {
-    if (quit_closure_) {
-      std::move(quit_closure_).Run();
+  base::OnceClosure quit_closure;
+  bool should_execute_next_step = false;
+  {
+    base::AutoLock lock(lock_);
+    SetApplicationState(next_state);
+    if (next_state == ApplicationState::kStopped) {
+      quit_closure = std::move(quit_closure_);
+    } else {
+      should_execute_next_step = true;
     }
-  } else {
+  }
+
+  if (quit_closure) {
+    std::move(quit_closure).Run();
+  }
+  if (should_execute_next_step) {
+    base::AutoLock lock(lock_);
     ExecuteNextStep();
   }
 }

--- a/cobalt/app/app_event_delegate.cc
+++ b/cobalt/app/app_event_delegate.cc
@@ -369,6 +369,9 @@ void AppEventDelegate::ExecuteStepOnUIThread(ApplicationState next_state,
 void AppEventDelegate::DoTeardown() {
   {
     base::AutoLock lock(lock_);
+    if (is_tearing_down_) {
+      return;
+    }
     is_tearing_down_ = true;
   }
   runner_->OnStop();

--- a/cobalt/app/app_event_delegate.h
+++ b/cobalt/app/app_event_delegate.h
@@ -90,10 +90,10 @@ class AppEventDelegate {
     return is_transitioning_;
   }
   PendingAck pending_ack() const LOCKS_EXCLUDED(lock_);
+  void SetQuitClosure(base::OnceClosure closure) LOCKS_EXCLUDED(lock_);
 
  private:
   static const char* GetStateString(ApplicationState state);
-  static void TeardownCallback(void* data);
 
   void HandleEventLocked(const SbEvent* event) EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
@@ -152,6 +152,7 @@ class AppEventDelegate {
       ApplicationState::kInitial;
   ApplicationState target_state_ GUARDED_BY(lock_) = ApplicationState::kInitial;
   bool is_transitioning_ GUARDED_BY(lock_) = false;
+  bool is_tearing_down_ GUARDED_BY(lock_) = false;
   base::OnceClosure quit_closure_;
 
 #if BUILDFLAG(IS_STARBOARD)

--- a/cobalt/app/app_event_delegate.h
+++ b/cobalt/app/app_event_delegate.h
@@ -153,7 +153,7 @@ class AppEventDelegate {
   ApplicationState target_state_ GUARDED_BY(lock_) = ApplicationState::kInitial;
   bool is_transitioning_ GUARDED_BY(lock_) = false;
   bool is_tearing_down_ GUARDED_BY(lock_) = false;
-  base::OnceClosure quit_closure_;
+  base::OnceClosure quit_closure_ GUARDED_BY(lock_);
 
 #if BUILDFLAG(IS_STARBOARD)
   // Ozone-specific bridge that converts Starboard events to Chromium events.

--- a/cobalt/app/app_event_delegate_unittest.cc
+++ b/cobalt/app/app_event_delegate_unittest.cc
@@ -21,6 +21,7 @@
 
 #include "base/memory/weak_ptr.h"
 #include "base/rand_util.h"
+#include "base/run_loop.h"
 #include "base/task/task_traits.h"
 #include "base/task/thread_pool.h"
 #include "cobalt/app/app_event_runner.h"
@@ -212,8 +213,16 @@ class AppEventDelegateTest : public content::ShellTestBase {
       CreateDelegate();
     }
     SbEvent event = {type, 0, data};
-    delegate_->HandleEvent(&event);
-    base::RunLoop().RunUntilIdle();
+    if (type == kSbEventTypeStop) {
+      base::RunLoop run_loop;
+      delegate_->SetQuitClosure(run_loop.QuitClosure());
+      delegate_->HandleEvent(&event);
+      run_loop.Run();
+      delegate_->DoTeardown();
+    } else {
+      delegate_->HandleEvent(&event);
+      base::RunLoop().RunUntilIdle();
+    }
   }
 
   // Under the fully synchronous mock runner GTest execution flow,

--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -52,11 +52,8 @@
 
 #include <cstdio>
 
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
-#include <init_musl.h>
 #if BUILDFLAG(USE_EVERGREEN)
 #include "cobalt/browser/loader_app_metrics.h"
-#endif
 #endif
 
 namespace cobalt {
@@ -118,9 +115,6 @@ class AppEventRunnerImpl : public AppEventRunner,
 
   void DoStart(const SbEvent* event) override {
     SbEventStartData* data = static_cast<SbEventStartData*>(event->data);
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
-    init_musl();
-#endif
     InitializeSystem();
 #if BUILDFLAG(IS_STARBOARD)
     platform_event_source_ =

--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -16,8 +16,6 @@
 #include "cobalt/app/app_event_delegate.h"
 #include "starboard/event.h"
 
-namespace {}  // namespace
-
 void SbEventHandle(const SbEvent* event) {
   // This object's lifetime extends beyond the function's lifetime, until the
   // function is called with kSbEventTypeStop at some time in the future.

--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "base/run_loop.h"
 #include "cobalt/app/app_event_delegate.h"
 #include "starboard/event.h"
 
@@ -35,6 +36,10 @@ void SbEventHandle(const SbEvent* event) {
   s_lifecycle_delegate->HandleEvent(event);
 
   if (event->type == kSbEventTypeStop) {
+    base::RunLoop run_loop;
+    s_lifecycle_delegate->SetQuitClosure(run_loop.QuitClosure());
+    run_loop.Run();
+    s_lifecycle_delegate->DoTeardown();
     delete s_lifecycle_delegate;
     s_lifecycle_delegate = nullptr;
   }

--- a/starboard/client_porting/wrap_main/wrap_main.h
+++ b/starboard/client_porting/wrap_main/wrap_main.h
@@ -23,11 +23,6 @@
 #include "starboard/event.h"
 #include "starboard/system.h"
 
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD) && \
-    !defined(STARBOARD_IMPLEMENTATION_TEST)
-#include <init_musl.h>
-#endif
-
 namespace starboard {
 namespace client_porting_internal {
 // A main-style function.
@@ -37,10 +32,6 @@ template <MainFunction main_function>
 void SimpleEventHandler(const SbEvent* event) {
   switch (event->type) {
     case kSbEventTypeStart: {
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD) && \
-    !defined(STARBOARD_IMPLEMENTATION_TEST)
-      init_musl();
-#endif
       SbEventStartData* data = static_cast<SbEventStartData*>(event->data);
       SbSystemRequestStop(
           main_function(data->argument_count, data->argument_values));

--- a/third_party/musl/src/starboard/internal/init_musl.c
+++ b/third_party/musl/src/starboard/internal/init_musl.c
@@ -16,7 +16,14 @@
 #include "libc.h"
 #include <sys/auxv.h>
 
-void init_musl() {
+// Initialize musl automatically before program execution begins.
+// We use a constructor attribute with priority 101 (the highest user priority,
+// as 0-100 are reserved for the compiler implementation) to guarantee this runs
+// before any C++ static initializers or other application code.
+// This is critical because it generates the master TLS stack canary. If it
+// runs too late, thread-local storage pointers can become corrupted and
+// functions protected by stack canaries will crash.
+__attribute__((constructor(101))) void init_musl() {
 
   // Set __hwcap bitmask by getauxval.
   __hwcap = getauxval(AT_HWCAP);


### PR DESCRIPTION
The previous fix delayed AppEventDelegate deletion to TeardownCallback (scheduled via SbEventSchedule). However, DoTeardown() was still being called inside TeardownCallback which was executed either concurrently (if multi-threaded Starboard) or recursively during the pump wait, resulting in SequenceManager destruction while DoWorkImpl was still running on the stack, causing a crash.

This revised fix:
1. Removes TeardownCallback entirely.
2. ExecuteStepOnUIThread(kStopped) now directly runs the quit_closure_ (which quits the nested RunLoop in SbEventHandle).
3. SbEventHandle blocks on the RunLoop until kStopped is reached (ensuring all intermediate transitions are safely processed).
4. Once the RunLoop exits (meaning we are safely outside the message loop stack), SbEventHandle synchronously calls DoTeardown() to perform cleanup and then deletes the delegate.
5. This guarantees that SequenceManager is only destroyed after the message loop execution has completely returned, avoiding UAF in DoWorkImpl.

CONV=0467c7c6-ea2e-4d82-83dc-d6ec944028bf

Bug: 490989945