### PR TITLE
Refactor: Introduce generic Span struct

### DIFF
--- a/starboard/android/shared/fake_media_codec.cc
+++ b/starboard/android/shared/fake_media_codec.cc
@@ -39,7 +39,7 @@ FakeMediaCodec::~FakeMediaCodec() {
   }
 }
 
-DataSpan FakeMediaCodec::GetInputBufferAddress(jint index) {
+Span<uint8_t> FakeMediaCodec::GetInputBufferAddress(jint index) {
   std::lock_guard lock(mutex_);
   if (index < 0 || index >= kNumBuffers) {
     return {};
@@ -79,7 +79,7 @@ jint FakeMediaCodec::QueueSecureInputBuffer(
   return -1;  // Not supported in Fake
 }
 
-DataSpan FakeMediaCodec::GetOutputBufferAddress(jint index) {
+Span<uint8_t> FakeMediaCodec::GetOutputBufferAddress(jint index) {
   std::lock_guard lock(mutex_);
   if (index < 0 || index >= kNumBuffers) {
     return {};

--- a/starboard/android/shared/fake_media_codec.h
+++ b/starboard/android/shared/fake_media_codec.h
@@ -17,12 +17,14 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <cstdint>
 #include <deque>
 #include <memory>
 #include <mutex>
 #include <vector>
 
 #include "starboard/android/shared/media_codec.h"
+#include "starboard/common/span.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "third_party/jni_zero/jni_zero.h"
 
@@ -54,7 +56,7 @@ class FakeMediaCodec : public MediaCodec {
   ~FakeMediaCodec() override;
 
   // MediaCodec implementation
-  DataSpan GetInputBufferAddress(jint index) override;
+  Span<uint8_t> GetInputBufferAddress(jint index) override;
   jint QueueInputBuffer(jint index,
                         jint offset,
                         jint size,
@@ -67,7 +69,7 @@ class FakeMediaCodec : public MediaCodec {
                               jlong presentation_time_microseconds,
                               jboolean is_decode_only) override;
 
-  DataSpan GetOutputBufferAddress(jint index) override;
+  Span<uint8_t> GetOutputBufferAddress(jint index) override;
   void ReleaseOutputBuffer(jint index, jboolean render) override;
   void ReleaseOutputBufferAtTimestamp(jint index,
                                       jlong render_timestamp_ns) override;

--- a/starboard/android/shared/media_codec.h
+++ b/starboard/android/shared/media_codec.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_ANDROID_SHARED_MEDIA_CODEC_H_
 #define STARBOARD_ANDROID_SHARED_MEDIA_CODEC_H_
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <ostream>
@@ -22,6 +23,7 @@
 
 #include "starboard/common/result.h"
 #include "starboard/common/size.h"
+#include "starboard/common/span.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -73,11 +75,6 @@ struct DequeueOutputResult {
   int32_t offset;
   int64_t presentation_time_microseconds;
   int32_t num_bytes;
-};
-
-struct DataSpan {
-  void* address = nullptr;
-  size_t capacity = 0;
 };
 
 // MediaCodec is an abstract interface for Android MediaCodec functionality,
@@ -157,7 +154,7 @@ class MediaCodec {
 
   virtual ~MediaCodec() = default;
 
-  virtual DataSpan GetInputBufferAddress(jint index) = 0;
+  virtual Span<uint8_t> GetInputBufferAddress(jint index) = 0;
   virtual jint QueueInputBuffer(jint index,
                                 jint offset,
                                 jint size,
@@ -170,7 +167,7 @@ class MediaCodec {
                                       jlong presentation_time_microseconds,
                                       jboolean is_decode_only) = 0;
 
-  virtual DataSpan GetOutputBufferAddress(jint index) = 0;
+  virtual Span<uint8_t> GetOutputBufferAddress(jint index) = 0;
   virtual void ReleaseOutputBuffer(jint index, jboolean render) = 0;
   virtual void ReleaseOutputBufferAtTimestamp(jint index,
                                               jlong render_timestamp_ns) = 0;

--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -241,7 +241,7 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
   if (dequeue_output_result.num_bytes > 0) {
     void* address =
         media_codec_bridge->GetOutputBufferAddress(dequeue_output_result.index)
-            .address;
+            .data();
 
     if (!address) {
       ReportError(kSbPlayerErrorDecode,

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -263,7 +263,7 @@ void MediaCodecBridge::Initialize(jobject j_media_codec_bridge) {
   j_media_codec_bridge_.Reset(env, j_media_codec_bridge);
 }
 
-DataSpan MediaCodecBridge::GetInputBufferAddress(jint index) {
+Span<uint8_t> MediaCodecBridge::GetInputBufferAddress(jint index) {
   SB_DCHECK_GE(index, 0);
   JNIEnv* env = AttachCurrentThread();
   ScopedJavaLocalRef<jobject> byte_buffer =
@@ -279,7 +279,7 @@ DataSpan MediaCodecBridge::GetInputBufferAddress(jint index) {
   if (!address) {
     return {};
   }
-  return {address, static_cast<size_t>(cap)};
+  return {static_cast<uint8_t*>(address), static_cast<size_t>(cap)};
 }
 
 jint MediaCodecBridge::QueueInputBuffer(jint index,
@@ -340,7 +340,7 @@ jint MediaCodecBridge::QueueSecureInputBuffer(
       blocks_to_skip, presentation_time_microseconds, is_decode_only);
 }
 
-DataSpan MediaCodecBridge::GetOutputBufferAddress(jint index) {
+Span<uint8_t> MediaCodecBridge::GetOutputBufferAddress(jint index) {
   SB_DCHECK_GE(index, 0);
   JNIEnv* env = AttachCurrentThread();
   ScopedJavaLocalRef<jobject> byte_buffer =
@@ -356,7 +356,7 @@ DataSpan MediaCodecBridge::GetOutputBufferAddress(jint index) {
   if (!address) {
     return {};
   }
-  return {address, static_cast<size_t>(cap)};
+  return {static_cast<uint8_t*>(address), static_cast<size_t>(cap)};
 }
 
 void MediaCodecBridge::ReleaseOutputBuffer(jint index, jboolean render) {

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_ANDROID_SHARED_MEDIA_CODEC_BRIDGE_H_
 #define STARBOARD_ANDROID_SHARED_MEDIA_CODEC_BRIDGE_H_
 
+#include <cstdint>
 #include <memory>
 #include <optional>
 #include <string>
@@ -22,6 +23,7 @@
 #include "starboard/android/shared/media_codec.h"
 #include "starboard/common/result.h"
 #include "starboard/common/size.h"
+#include "starboard/common/span.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -66,7 +68,7 @@ class MediaCodecBridge : public MediaCodec {
   void Initialize(jobject j_media_codec_bridge);
 
   // MediaCodec implementation
-  DataSpan GetInputBufferAddress(jint index) override;
+  Span<uint8_t> GetInputBufferAddress(jint index) override;
   jint QueueInputBuffer(jint index,
                         jint offset,
                         jint size,
@@ -79,7 +81,7 @@ class MediaCodecBridge : public MediaCodec {
                               jlong presentation_time_microseconds,
                               jboolean is_decode_only) override;
 
-  DataSpan GetOutputBufferAddress(jint index) override;
+  Span<uint8_t> GetOutputBufferAddress(jint index) override;
   void ReleaseOutputBuffer(jint index, jboolean render) override;
   void ReleaseOutputBufferAtTimestamp(jint index,
                                       jlong render_timestamp_ns) override;

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -760,8 +760,9 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
   // were called and had it stored in |pending_input_to_retry_|.
   if (!input_buffer_already_written &&
       pending_input.type != PendingInput::kWriteEndOfStream) {
-    const auto [address, capacity] =
+    const auto codec_input_buffer =
         media_codec_bridge_->GetInputBufferAddress(dequeue_input_result.index);
+    auto* address = codec_input_buffer.data();
     if (!address) {
       SB_LOG(ERROR) << "Unable to get MediaCodec input buffer address.";
       // There could be dirty callbacks right after flush, thus the
@@ -772,6 +773,7 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
       return false;
     }
 
+    const auto capacity = codec_input_buffer.size();
     if (capacity < static_cast<size_t>(size)) {
       auto error_message = FormatString(
           "Unable to write to MediaCodec buffer, input buffer size (%d) is"

--- a/starboard/common/BUILD.gn
+++ b/starboard/common/BUILD.gn
@@ -98,6 +98,7 @@ static_library("common") {
     "size.h",
     "source_location.cc",
     "source_location.h",
+    "span.h",
     "spin_lock.cc",
     "spin_lock.h",
     "storage.cc",

--- a/starboard/common/span.h
+++ b/starboard/common/span.h
@@ -18,15 +18,25 @@
 #include <cstddef>
 
 // A simple, lightweight alternative to C++20's std::span.
-// Designed to pass a pointer and capacity (size in bytes) together as a single
-// object. Used because Cobalt currently targets C++17 where std::span is not
-// available.
+// Designed to pass a pointer and size together as a single object.
+// Used because Cobalt currently targets C++17 where std::span is not available.
 namespace starboard {
 
 template <class T>
-struct Span {
-  T* address = nullptr;
-  size_t capacity = 0;
+class Span {
+ public:
+  constexpr Span() = default;
+  constexpr Span(T* data, size_t size) : data_(data), size_(size) {}
+
+  // Member functions are named to match C++20's std::span for future
+  // compatibility.
+  constexpr T* data() const { return data_; }
+  constexpr size_t size() const { return size_; }
+  constexpr bool empty() const { return size_ == 0; }
+
+ private:
+  T* data_ = nullptr;
+  size_t size_ = 0;
 };
 
 }  // namespace starboard

--- a/starboard/common/span.h
+++ b/starboard/common/span.h
@@ -1,0 +1,34 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_COMMON_SPAN_H_
+#define STARBOARD_COMMON_SPAN_H_
+
+#include <cstddef>
+
+// A simple, lightweight alternative to C++20's std::span.
+// Designed to pass a pointer and capacity (size in bytes) together as a single
+// object. Used because Cobalt currently targets C++17 where std::span is not
+// available.
+namespace starboard {
+
+template <class T>
+struct Span {
+  T* address = nullptr;
+  size_t capacity = 0;
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_COMMON_SPAN_H_

--- a/starboard/shared/starboard/media/iamf_util.cc
+++ b/starboard/shared/starboard/media/iamf_util.cc
@@ -33,7 +33,7 @@ constexpr uint8_t kIamfSequenceHeaderObu = 31;
 class BufferReader {
  public:
   explicit BufferReader(Span<const uint8_t> buffer)
-      : view_(reinterpret_cast<const char*>(buffer.address), buffer.capacity) {}
+      : view_(reinterpret_cast<const char*>(buffer.data()), buffer.size()) {}
 
   std::optional<uint8_t> ReadByte() {
     if (view_.empty()) {

--- a/starboard/shared/starboard/media/iamf_util.cc
+++ b/starboard/shared/starboard/media/iamf_util.cc
@@ -21,6 +21,7 @@
 #include <string_view>
 #include <vector>
 
+#include "starboard/common/span.h"
 #include "starboard/common/string.h"
 
 namespace starboard {
@@ -31,8 +32,8 @@ constexpr uint8_t kIamfSequenceHeaderObu = 31;
 // A lightweight, forward-only reader for a raw byte buffer.
 class BufferReader {
  public:
-  explicit BufferReader(const uint8_t* data, size_t size)
-      : view_(reinterpret_cast<const char*>(data), size) {}
+  explicit BufferReader(Span<const uint8_t> buffer)
+      : view_(reinterpret_cast<const char*>(buffer.address), buffer.capacity) {}
 
   std::optional<uint8_t> ReadByte() {
     if (view_.empty()) {
@@ -197,7 +198,7 @@ IamfMimeUtil::IamfMimeUtil(uint32_t primary_profile,
 // static.
 Result<IamfMimeUtil::IamfProfileInfo> IamfMimeUtil::ParseIamfSequenceHeaderObu(
     const std::vector<uint8_t>& data) {
-  BufferReader reader(data.data(), data.size());
+  BufferReader reader({data.data(), data.size()});
 
   auto header_byte_opt = reader.ReadByte();
   if (!header_byte_opt) {
@@ -225,7 +226,8 @@ Result<IamfMimeUtil::IamfProfileInfo> IamfMimeUtil::ParseIamfSequenceHeaderObu(
 
   // Create a sub-reader for the OBU payload to ensure we don't read past the
   // specified OBU size.
-  BufferReader obu_reader(reader.CurrentData(), obu_size);
+  BufferReader obu_reader(
+      {reader.CurrentData(), static_cast<size_t>(obu_size)});
 
   // Skip ia_code.
   if (!obu_reader.Skip(sizeof(uint32_t))) {

--- a/starboard/shared/starboard/media/vp9_util.cc
+++ b/starboard/shared/starboard/media/vp9_util.cc
@@ -37,25 +37,26 @@ size_t ReadSize(const uint8_t* data, size_t bytes_of_size) {
 
 }  // namespace
 
-Vp9FrameParser::Vp9FrameParser(const void* vp9_frame, size_t size) {
-  const uint8_t* frame_in_uint8 = static_cast<const uint8_t*>(vp9_frame);
+Vp9FrameParser::Vp9FrameParser(Span<const uint8_t> vp9_frame) {
+  const uint8_t* frame_in_uint8 = vp9_frame.address;
+  size_t size = vp9_frame.capacity;
 
   // To determine whether a chunk of data has a superframe index, check the last
   // byte in the chunk for the marker 3 bits (0b110xxxxx).
   uint8_t last_byte = size == 0 ? 0 : frame_in_uint8[size - 1];
-  if ((last_byte >> 5) == 0b110 && ParseSuperFrame(frame_in_uint8, size)) {
+  if ((last_byte >> 5) == 0b110 && ParseSuperFrame(vp9_frame)) {
     return;
   }
   // Not a superframe, or ParseSuperFrame() fails, treat the whole input as a
   // single subframe.
-  subframes_[0].address = frame_in_uint8;
-  subframes_[0].size = size;
+  subframes_[0] = vp9_frame;
   number_of_subframes_ = 1;
 }
 
-bool Vp9FrameParser::ParseSuperFrame(const uint8_t* frame,
-                                     size_t size_of_superframe) {
-  uint8_t last_byte = frame[size_of_superframe - 1];
+bool Vp9FrameParser::ParseSuperFrame(Span<const uint8_t> frame) {
+  const uint8_t* frame_data = frame.address;
+  size_t size_of_superframe = frame.capacity;
+  uint8_t last_byte = frame_data[size_of_superframe - 1];
   // mask 2 bits (0bxxx11xxx) and add 1 to get the size in bytes for each frame
   // size.
   size_t bytes_of_size = ((last_byte & 0b00011000) >> 3) + 1;
@@ -79,7 +80,7 @@ bool Vp9FrameParser::ParseSuperFrame(const uint8_t* frame,
   // Go to the first byte of the superframe index, and check that it matches the
   // last byte of the superframe index.
   const uint8_t* first_byte =
-      frame + (size_of_superframe - total_bytes_of_superframe_index);
+      frame_data + (size_of_superframe - total_bytes_of_superframe_index);
   if (*first_byte != last_byte) {
     SB_LOG(WARNING) << "Vp9 superframe marker bytes doesn't match.";
     return false;
@@ -89,10 +90,11 @@ bool Vp9FrameParser::ParseSuperFrame(const uint8_t* frame,
   // Skip the first byte, which is a marker.
   const uint8_t* address_of_sizes = first_byte + 1;
   for (size_t i = 0; i < number_of_subframes_; ++i) {
-    subframes_[i].size = ReadSize(address_of_sizes, bytes_of_size);
-    subframes_[i].address = frame + accumulated_size_of_subframes;
+    size_t subframe_size = ReadSize(address_of_sizes, bytes_of_size);
+    subframes_[i].address = frame_data + accumulated_size_of_subframes;
+    subframes_[i].capacity = subframe_size;
     address_of_sizes += bytes_of_size;
-    accumulated_size_of_subframes += subframes_[i].size;
+    accumulated_size_of_subframes += subframe_size;
   }
 
   if (accumulated_size_of_subframes + total_bytes_of_superframe_index >

--- a/starboard/shared/starboard/media/vp9_util.cc
+++ b/starboard/shared/starboard/media/vp9_util.cc
@@ -38,8 +38,8 @@ size_t ReadSize(const uint8_t* data, size_t bytes_of_size) {
 }  // namespace
 
 Vp9FrameParser::Vp9FrameParser(Span<const uint8_t> vp9_frame) {
-  const uint8_t* frame_in_uint8 = vp9_frame.address;
-  size_t size = vp9_frame.capacity;
+  const uint8_t* frame_in_uint8 = vp9_frame.data();
+  size_t size = vp9_frame.size();
 
   // To determine whether a chunk of data has a superframe index, check the last
   // byte in the chunk for the marker 3 bits (0b110xxxxx).
@@ -54,8 +54,8 @@ Vp9FrameParser::Vp9FrameParser(Span<const uint8_t> vp9_frame) {
 }
 
 bool Vp9FrameParser::ParseSuperFrame(Span<const uint8_t> frame) {
-  const uint8_t* frame_data = frame.address;
-  size_t size_of_superframe = frame.capacity;
+  const uint8_t* frame_data = frame.data();
+  size_t size_of_superframe = frame.size();
   uint8_t last_byte = frame_data[size_of_superframe - 1];
   // mask 2 bits (0bxxx11xxx) and add 1 to get the size in bytes for each frame
   // size.
@@ -91,8 +91,7 @@ bool Vp9FrameParser::ParseSuperFrame(Span<const uint8_t> frame) {
   const uint8_t* address_of_sizes = first_byte + 1;
   for (size_t i = 0; i < number_of_subframes_; ++i) {
     size_t subframe_size = ReadSize(address_of_sizes, bytes_of_size);
-    subframes_[i].address = frame_data + accumulated_size_of_subframes;
-    subframes_[i].capacity = subframe_size;
+    subframes_[i] = {frame_data + accumulated_size_of_subframes, subframe_size};
     address_of_sizes += bytes_of_size;
     accumulated_size_of_subframes += subframe_size;
   }

--- a/starboard/shared/starboard/media/vp9_util.h
+++ b/starboard/shared/starboard/media/vp9_util.h
@@ -20,6 +20,7 @@
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "starboard/common/span.h"
 
 namespace starboard {
 
@@ -34,30 +35,27 @@ class Vp9FrameParser {
  public:
   static constexpr size_t kMaxNumberOfSubFrames = 8;
 
-  Vp9FrameParser(const void* vp9_frame, size_t size);
+  explicit Vp9FrameParser(Span<const uint8_t> vp9_frame);
 
   size_t number_of_subframes() const {
     SB_DCHECK_GT(number_of_subframes_, 0U);
     return number_of_subframes_;
   }
-  const uint8_t* address_of_subframe(size_t index) const {
+  Span<const uint8_t> subframe(size_t index) const {
     SB_DCHECK_LT(index, number_of_subframes_);
-    return subframes_[index].address;
+    return subframes_[index];
+  }
+  const uint8_t* address_of_subframe(size_t index) const {
+    return subframe(index).address;
   }
   size_t size_of_subframe(size_t index) const {
-    SB_DCHECK_LT(index, number_of_subframes_);
-    return subframes_[index].size;
+    return subframe(index).capacity;
   }
 
  private:
-  struct Subframe {
-    const uint8_t* address = nullptr;
-    size_t size = 0;
-  };
+  bool ParseSuperFrame(Span<const uint8_t> frame);
 
-  bool ParseSuperFrame(const uint8_t* frame, size_t size);
-
-  Subframe subframes_[kMaxNumberOfSubFrames];
+  Span<const uint8_t> subframes_[kMaxNumberOfSubFrames];
   size_t number_of_subframes_ = 0;
 };
 

--- a/starboard/shared/starboard/media/vp9_util.h
+++ b/starboard/shared/starboard/media/vp9_util.h
@@ -46,11 +46,9 @@ class Vp9FrameParser {
     return subframes_[index];
   }
   const uint8_t* address_of_subframe(size_t index) const {
-    return subframe(index).address;
+    return subframe(index).data();
   }
-  size_t size_of_subframe(size_t index) const {
-    return subframe(index).capacity;
-  }
+  size_t size_of_subframe(size_t index) const { return subframe(index).size(); }
 
  private:
   bool ParseSuperFrame(Span<const uint8_t> frame);

--- a/starboard/shared/starboard/media/vp9_util_test.cc
+++ b/starboard/shared/starboard/media/vp9_util_test.cc
@@ -72,19 +72,19 @@ void AddSubframe(const std::vector<uint8_t>& subframe,
 }
 
 TEST(Vp9FrameParserTests, EmptyFrame) {
-  Vp9FrameParser parser(nullptr, 0);
+  Vp9FrameParser parser({});
 
   ASSERT_EQ(parser.number_of_subframes(), 1U);
-  EXPECT_EQ(parser.size_of_subframe(0), 0U);
+  EXPECT_EQ(parser.subframe(0).capacity, 0U);
 }
 
 TEST(Vp9FrameParserTests, NonSuperFrame) {
   std::vector<uint8_t> kFrameData({1, 2, 3, 0});
-  Vp9FrameParser parser(kFrameData.data(), kFrameData.size());
+  Vp9FrameParser parser({kFrameData.data(), kFrameData.size()});
 
   ASSERT_EQ(parser.number_of_subframes(), 1U);
-  EXPECT_EQ(parser.address_of_subframe(0), kFrameData.data());
-  EXPECT_EQ(parser.size_of_subframe(0), kFrameData.size());
+  EXPECT_EQ(parser.subframe(0).address, kFrameData.data());
+  EXPECT_EQ(parser.subframe(0).capacity, kFrameData.size());
 }
 
 TEST(Vp9FrameParserTests, SuperFrames) {
@@ -112,14 +112,14 @@ TEST(Vp9FrameParserTests, SuperFrames) {
 
       auto superframe = frame_data + superframe_metadata;
 
-      Vp9FrameParser parser(superframe.data(), superframe.size());
+      Vp9FrameParser parser({superframe.data(), superframe.size()});
 
       ASSERT_EQ(parser.number_of_subframes(), number_of_subframes);
       for (size_t subframe_index = 0; subframe_index < number_of_subframes;
            ++subframe_index) {
-        EXPECT_EQ(parser.address_of_subframe(subframe_index),
+        EXPECT_EQ(parser.subframe(subframe_index).address,
                   superframe.data() + subframe_index * kFrameData.size());
-        EXPECT_EQ(parser.size_of_subframe(subframe_index), kFrameData.size());
+        EXPECT_EQ(parser.subframe(subframe_index).capacity, kFrameData.size());
       }
     }
   }
@@ -150,14 +150,14 @@ TEST(Vp9FrameParserTests, SuperFramesWithEmptySubframes) {
 
       auto superframe = frame_data + superframe_metadata;
 
-      Vp9FrameParser parser(superframe.data(), superframe.size());
+      Vp9FrameParser parser({superframe.data(), superframe.size()});
 
       ASSERT_EQ(parser.number_of_subframes(), number_of_subframes);
       for (size_t subframe_index = 0; subframe_index < number_of_subframes;
            ++subframe_index) {
-        EXPECT_EQ(parser.address_of_subframe(subframe_index),
+        EXPECT_EQ(parser.subframe(subframe_index).address,
                   superframe.data() + subframe_index * kEmptyFrameData.size());
-        EXPECT_EQ(parser.size_of_subframe(subframe_index),
+        EXPECT_EQ(parser.subframe(subframe_index).capacity,
                   kEmptyFrameData.size());
       }
     }

--- a/starboard/shared/starboard/media/vp9_util_test.cc
+++ b/starboard/shared/starboard/media/vp9_util_test.cc
@@ -75,7 +75,7 @@ TEST(Vp9FrameParserTests, EmptyFrame) {
   Vp9FrameParser parser({});
 
   ASSERT_EQ(parser.number_of_subframes(), 1U);
-  EXPECT_EQ(parser.subframe(0).capacity, 0U);
+  EXPECT_EQ(parser.subframe(0).size(), 0U);
 }
 
 TEST(Vp9FrameParserTests, NonSuperFrame) {
@@ -83,8 +83,8 @@ TEST(Vp9FrameParserTests, NonSuperFrame) {
   Vp9FrameParser parser({kFrameData.data(), kFrameData.size()});
 
   ASSERT_EQ(parser.number_of_subframes(), 1U);
-  EXPECT_EQ(parser.subframe(0).address, kFrameData.data());
-  EXPECT_EQ(parser.subframe(0).capacity, kFrameData.size());
+  EXPECT_EQ(parser.subframe(0).data(), kFrameData.data());
+  EXPECT_EQ(parser.subframe(0).size(), kFrameData.size());
 }
 
 TEST(Vp9FrameParserTests, SuperFrames) {
@@ -117,9 +117,9 @@ TEST(Vp9FrameParserTests, SuperFrames) {
       ASSERT_EQ(parser.number_of_subframes(), number_of_subframes);
       for (size_t subframe_index = 0; subframe_index < number_of_subframes;
            ++subframe_index) {
-        EXPECT_EQ(parser.subframe(subframe_index).address,
+        EXPECT_EQ(parser.subframe(subframe_index).data(),
                   superframe.data() + subframe_index * kFrameData.size());
-        EXPECT_EQ(parser.subframe(subframe_index).capacity, kFrameData.size());
+        EXPECT_EQ(parser.subframe(subframe_index).size(), kFrameData.size());
       }
     }
   }
@@ -155,9 +155,9 @@ TEST(Vp9FrameParserTests, SuperFramesWithEmptySubframes) {
       ASSERT_EQ(parser.number_of_subframes(), number_of_subframes);
       for (size_t subframe_index = 0; subframe_index < number_of_subframes;
            ++subframe_index) {
-        EXPECT_EQ(parser.subframe(subframe_index).address,
+        EXPECT_EQ(parser.subframe(subframe_index).data(),
                   superframe.data() + subframe_index * kEmptyFrameData.size());
-        EXPECT_EQ(parser.subframe(subframe_index).capacity,
+        EXPECT_EQ(parser.subframe(subframe_index).size(),
                   kEmptyFrameData.size());
       }
     }


### PR DESCRIPTION
Introduce a simple, generic Span template struct in Starboard to serve
as a lightweight alternative to C++20's std::span, which is not yet
available in C++17. This provides a consistent, type-safe way to pass
a pointer and its capacity together as a single object. 

This change replaces the Android-specific DataSpan with Span and
updates Vp9FrameParser and BufferReader to use Span. This improves
type safety and removes unnecessary manual pointer casts across the
media stack.

Issue: 516906963