### PR TITLE
cobalt/metrics: Add Memory Context API and task helpers

### DIFF
--- a/base/memory/cobalt_memory_attribution_observer.cc
+++ b/base/memory/cobalt_memory_attribution_observer.cc
@@ -14,45 +14,24 @@
 
 #include "base/memory/cobalt_memory_attribution_observer.h"
 
-#ifdef UNSAFE_BUFFERS_BUILD
-// TODO(crbug.com/40284755): Remove this and spanify to fix the errors.
-#pragma allow_unsafe_buffers
+#include "base/compiler_specific.h"
+#if defined(OS_LINUX) || defined(OS_ANDROID)
+#include <sys/prctl.h>
 #endif
 
-#include <string_view>
+
+#if BUILDFLAG(IS_ANDROID)
+#include <android/log.h>
+#endif
+#include "base/logging.h"
 
 #include "base/no_destructor.h"
 #include "base/threading/platform_thread.h"
 
-#include <pthread.h>
 
 namespace base {
 namespace memory {
 
-namespace {
-// Strictly lock-free, allocation-free OS thread name reader
-const char* GetCurrentOSThreadName() {
-  static thread_local char tls_thread_name[32] = {0};
-  if (tls_thread_name[0] == '\0') {
-#if BUILDFLAG(IS_ANDROID)
-    if (__builtin_available(android 26, *)) {
-      if (pthread_getname_np(pthread_self(), tls_thread_name, sizeof(tls_thread_name)) != 0) {
-        tls_thread_name[0] = '\0';
-        return nullptr;
-      }
-    } else {
-      return nullptr;
-    }
-#else
-    if (pthread_getname_np(pthread_self(), tls_thread_name, sizeof(tls_thread_name)) != 0) {
-      tls_thread_name[0] = '\0';
-      return nullptr;
-    }
-#endif
-  }
-  return tls_thread_name;
-}
-}  // namespace
 
 // static
 CobaltMemoryAttributionObserver* CobaltMemoryAttributionObserver::Get() {
@@ -62,7 +41,7 @@ CobaltMemoryAttributionObserver* CobaltMemoryAttributionObserver::Get() {
 
 CobaltMemoryAttributionObserver::CobaltMemoryAttributionObserver() {
   for (size_t i = 0; i < static_cast<size_t>(MemoryContext::kCount); ++i) {
-    counters_[i].value.store(0, std::memory_order_relaxed);
+    UNSAFE_BUFFERS(counters_[i].value.store(0, std::memory_order_relaxed));
   }
   // Ensure ThreadLocalStorage is fully initialized and warmed up before the
   // observer hooks into Dispatcher, preventing reentrancy crashes during the
@@ -72,46 +51,13 @@ CobaltMemoryAttributionObserver::CobaltMemoryAttributionObserver() {
 
 void CobaltMemoryAttributionObserver::OnAllocation(
     const base::allocator::dispatcher::AllocationNotificationData& notification_data) {
-  static thread_local bool g_in_allocation_hook = false;
-  if (g_in_allocation_hook) {
-    return;
-  }
-  g_in_allocation_hook = true;
 
   MemoryContext current_context = GetCurrentMemoryContext();
-  if (current_context == MemoryContext::kUnknown) {
-    const char* thread_name = GetCurrentOSThreadName();
-    if (thread_name) {
-      std::string_view thread_view(thread_name);
-      if (thread_view.find("V8") != std::string_view::npos ||
-          thread_view.find("GC") != std::string_view::npos ||
-          thread_view.find("Compiler") != std::string_view::npos ||
-          thread_view.find("wasm") != std::string_view::npos) {
-        current_context = MemoryContext::kScript;
-      } else if (thread_view.find("Skia") != std::string_view::npos ||
-                 thread_view.find("Compositor") != std::string_view::npos ||
-                 thread_view.find("Raster") != std::string_view::npos) {
-        current_context = MemoryContext::kGraphics;
-      } else if (thread_view.find("Network") != std::string_view::npos ||
-                 thread_view.find("URL") != std::string_view::npos ||
-                 thread_view.find("CrNetwork") != std::string_view::npos) {
-        current_context = MemoryContext::kNetwork;
-      } else if (thread_view.find("Media") != std::string_view::npos ||
-                 thread_view.find("Audio") != std::string_view::npos ||
-                 thread_view.find("Video") != std::string_view::npos ||
-                 thread_view.find("Decoder") != std::string_view::npos ||
-                 thread_view.find("player_worker") != std::string_view::npos) {
-        current_context = MemoryContext::kMedia;
-      }
-    }
-  }
   if (current_context >= MemoryContext::kCount) {
     current_context = MemoryContext::kUnknown;
   }
-  counters_[static_cast<size_t>(current_context)].value.fetch_add(
-      notification_data.size(), std::memory_order_relaxed);
-
-  g_in_allocation_hook = false;
+  UNSAFE_BUFFERS(counters_[static_cast<size_t>(current_context)].value.fetch_add(
+      notification_data.size(), std::memory_order_relaxed));
 }
 
 }  // namespace memory

--- a/base/memory/cobalt_memory_context.h
+++ b/base/memory/cobalt_memory_context.h
@@ -44,16 +44,17 @@ enum class MemoryContext : uint8_t {
 BASE_EXPORT MemoryContext GetCurrentMemoryContext();
 BASE_EXPORT void SetCurrentMemoryContext(MemoryContext context);
 
-// Scoped helper class to temporarily set the current thread's MemoryContext.
-// The previous context is restored when this object goes out of scope.
+// ScopedMemoryContext is a helper class that sets the current thread's
+// memory context for the duration of its lifetime, restoring the previous
+// context upon destruction.
 //
 // Lifetime and Ownership:
-// Typically allocated on the stack as a local variable. It should not outlive
-// the scope in which it is defined.
+// This is a stack-allocated helper designed to be used as a local variable.
+// It should not be dynamically allocated or outlive its enclosing scope.
 //
 // Threading Model:
-// Thread-affine. This class only affects the thread on which it is constructed
-// and destroyed.
+// This class is thread-affine and must only be used on the thread where
+// it was constructed.
 class BASE_EXPORT ScopedMemoryContext {
  public:
   explicit ScopedMemoryContext(MemoryContext context);
@@ -68,7 +69,55 @@ class BASE_EXPORT ScopedMemoryContext {
   MemoryContext prev_context_;
 };
 
-BASE_EXPORT std::string_view ContextToString(MemoryContext context);
+inline std::string_view ContextToString(MemoryContext context) {
+  switch (context) {
+    case MemoryContext::kUnknown:
+      return "Unknown";
+    case MemoryContext::kDOM:
+      return "DOM";
+    case MemoryContext::kLayout:
+      return "Layout";
+    case MemoryContext::kMedia:
+      return "Media";
+    case MemoryContext::kScript:
+      return "Script";
+    case MemoryContext::kNetwork:
+      return "Network";
+    case MemoryContext::kGraphics:
+      return "Graphics";
+    case MemoryContext::kStorage:
+      return "Storage";
+    case MemoryContext::kGraphicsCanvas:
+      return "GraphicsCanvas";
+    case MemoryContext::kGraphicsCompositor:
+      return "GraphicsCompositor";
+    case MemoryContext::kGraphicsGlyphs:
+      return "GraphicsGlyphs";
+    case MemoryContext::kScriptHeap:
+      return "ScriptHeap";
+    case MemoryContext::kScriptJIT:
+      return "ScriptJIT";
+    case MemoryContext::kScriptBindings:
+      return "ScriptBindings";
+    case MemoryContext::kNetworkLoader:
+      return "NetworkLoader";
+    case MemoryContext::kNetworkCache:
+      return "NetworkCache";
+    case MemoryContext::kBlinkDOM:
+      return "BlinkDOM";
+    case MemoryContext::kBlinkStyle:
+      return "BlinkStyle";
+    case MemoryContext::kBlinkParser:
+      return "BlinkParser";
+    case MemoryContext::kPlatformIPC:
+      return "PlatformIPC";
+    case MemoryContext::kPlatformStarboard:
+      return "PlatformStarboard";
+    case MemoryContext::kCount:
+      return "Unknown";
+  }
+  return "Unknown";
+}
 
 }  // namespace memory
 }  // namespace base

--- a/base/pending_task.cc
+++ b/base/pending_task.cc
@@ -6,6 +6,10 @@
 
 #include "base/task/task_features.h"
 
+#if BUILDFLAG(IS_COBALT)
+#include "base/memory/cobalt_memory_context.h"
+#endif
+
 namespace base {
 
 TaskMetadata::TaskMetadata() = default;
@@ -19,7 +23,12 @@ TaskMetadata::TaskMetadata(const Location& posted_from,
       queue_time(queue_time),
       delayed_run_time(delayed_run_time),
       leeway(leeway),
-      delay_policy(delay_policy) {}
+      delay_policy(delay_policy)
+#if BUILDFLAG(IS_COBALT)
+      ,
+      memory_context(::base::memory::GetCurrentMemoryContext())
+#endif
+{}
 
 TaskMetadata::TaskMetadata(TaskMetadata&& other) = default;
 TaskMetadata::TaskMetadata(const TaskMetadata& other) = default;

--- a/base/pending_task.h
+++ b/base/pending_task.h
@@ -12,6 +12,9 @@
 #include "base/location.h"
 #include "base/task/delay_policy.h"
 #include "base/time/time.h"
+#if BUILDFLAG(IS_COBALT)
+#include "base/memory/cobalt_memory_context.h"
+#endif
 
 namespace base {
 
@@ -82,6 +85,10 @@ struct BASE_EXPORT TaskMetadata {
   int sequence_num = 0;
 
   bool task_backtrace_overflow = false;
+#if BUILDFLAG(IS_COBALT)
+  ::base::memory::MemoryContext memory_context =
+      ::base::memory::MemoryContext::kUnknown;
+#endif
 };
 
 // Contains data about a pending task. Stored in TaskQueue and DelayedTaskQueue

--- a/base/task/common/task_annotator.cc
+++ b/base/task/common/task_annotator.cc
@@ -4,6 +4,11 @@
 
 #include "base/task/common/task_annotator.h"
 
+
+#if BUILDFLAG(IS_COBALT)
+#include "base/memory/cobalt_memory_context.h"
+#endif
+
 #include <stdint.h>
 
 #include <algorithm>
@@ -206,6 +211,10 @@ void TaskAnnotator::RunTaskImpl(PendingTask& pending_task) {
     if (g_task_annotator_observer) {
       g_task_annotator_observer->BeforeRunTask(&pending_task);
     }
+#if BUILDFLAG(IS_COBALT)
+    base::memory::ScopedMemoryContext scoped_context(
+        pending_task.memory_context);
+#endif
     std::move(pending_task.task).Run();
   }
 

--- a/base/task/thread_pool/job_task_source.cc
+++ b/base/task/thread_pool/job_task_source.cc
@@ -20,6 +20,9 @@
 #include "base/time/time.h"
 #include "base/time/time_override.h"
 #include "base/trace_event/base_tracing.h"
+#if BUILDFLAG(IS_COBALT)
+#include "base/memory/cobalt_memory_context.h"
+#endif
 
 namespace base::internal {
 
@@ -98,12 +101,21 @@ JobTaskSource::JobTaskSource(const Location& from_here,
             CheckedLock::AssertNoLockHeldOnCurrentThread();
             // Each worker task has its own delegate with associated state.
             JobDelegate job_delegate{self, self->delegate_};
+#if BUILDFLAG(IS_COBALT)
+            base::memory::ScopedMemoryContext scoped_context(
+                self->memory_context_);
+#endif
             self->worker_task_.Run(&job_delegate);
           },
           base::Unretained(this))),
       task_metadata_(from_here),
       ready_time_(TimeTicks::Now()),
-      delegate_(delegate) {
+      delegate_(delegate)
+#if BUILDFLAG(IS_COBALT)
+      ,
+      memory_context_(base::memory::GetCurrentMemoryContext())
+#endif
+{
   DCHECK(delegate_);
   task_metadata_.sequence_num = -1;
 }
@@ -146,6 +158,9 @@ bool JobTaskSource::WillJoin() {
 
 bool JobTaskSource::RunJoinTask() {
   JobDelegate job_delegate{this, nullptr};
+#if BUILDFLAG(IS_COBALT)
+  base::memory::ScopedMemoryContext scoped_context(memory_context_);
+#endif
   worker_task_.Run(&job_delegate);
 
   // It is safe to read |state_| without a lock since this variable is atomic

--- a/base/task/thread_pool/job_task_source.h
+++ b/base/task/thread_pool/job_task_source.h
@@ -23,6 +23,9 @@
 #include "base/task/thread_pool/task.h"
 #include "base/task/thread_pool/task_source.h"
 #include "base/task/thread_pool/task_source_sort_key.h"
+#if BUILDFLAG(IS_COBALT)
+#include "base/memory/cobalt_memory_context.h"
+#endif
 
 namespace base {
 namespace internal {
@@ -228,6 +231,9 @@ class BASE_EXPORT JobTaskSource : public TaskSource {
 
   const TimeTicks ready_time_;
   raw_ptr<PooledTaskRunnerDelegate, LeakedDanglingUntriaged> delegate_;
+#if BUILDFLAG(IS_COBALT)
+  const ::base::memory::MemoryContext memory_context_;
+#endif
 };
 
 }  // namespace internal

--- a/components/memory_system/initializer.cc
+++ b/components/memory_system/initializer.cc
@@ -6,6 +6,8 @@
 
 #include <string_view>
 
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "components/memory_system/memory_system.h"
 #include "components/sampling_profiler/process_type.h"
 
@@ -32,10 +34,18 @@ Initializer& Initializer::SetDispatcherParameters(
         poisson_allocation_sampler_inclusion,
     DispatcherParameters::AllocationTraceRecorderInclusion
         allocation_trace_recorder_inclusion,
-    std::string_view process_type) {
+    std::string_view process_type
+#if BUILDFLAG(IS_COBALT)
+    , CobaltMemoryAttributionInclusion cobalt_memory_attribution_inclusion
+#endif
+    ) {
   dispatcher_parameters_.emplace(poisson_allocation_sampler_inclusion,
                                  allocation_trace_recorder_inclusion,
-                                 process_type);
+                                 process_type
+#if BUILDFLAG(IS_COBALT)
+                                 , cobalt_memory_attribution_inclusion
+#endif
+                                 );
   return *this;
 }
 

--- a/components/memory_system/initializer.h
+++ b/components/memory_system/initializer.h
@@ -8,6 +8,8 @@
 #include <optional>
 #include <string_view>
 
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "components/memory_system/parameters.h"
 #include "components/sampling_profiler/process_type.h"
 #include "components/version_info/channel.h"
@@ -34,7 +36,12 @@ class Initializer {
           poisson_allocation_sampler_inclusion,
       DispatcherParameters::AllocationTraceRecorderInclusion
           allocation_trace_recorder_inclusion,
-      std::string_view process_type);
+      std::string_view process_type
+#if BUILDFLAG(IS_COBALT)
+      , CobaltMemoryAttributionInclusion cobalt_memory_attribution_inclusion =
+            CobaltMemoryAttributionInclusion::kDoNotInclude
+#endif
+  );
 
   void Initialize(MemorySystem& memory_system) const;
 

--- a/components/memory_system/memory_system.cc
+++ b/components/memory_system/memory_system.cc
@@ -14,6 +14,11 @@
 #include "components/memory_system/parameters.h"
 #include "partition_alloc/buildflags.h"
 
+#if BUILDFLAG(IS_COBALT)
+#include "base/memory/cobalt_memory_context.h"
+#include "base/memory/cobalt_memory_attribution_observer.h"
+#endif
+
 #if BUILDFLAG(ENABLE_GWP_ASAN)
 #include "components/gwp_asan/client/gwp_asan.h"  // nogncheck
 #if BUILDFLAG(IS_CHROMEOS)
@@ -348,6 +353,13 @@ void MemorySystem::Impl::InitializeDispatcher(
 #endif
 #if BUILDFLAG(ENABLE_ALLOCATION_STACK_TRACE_RECORDER)
       .AddOptionalObservers(allocation_recording_.recorder.get())
+#endif
+#if BUILDFLAG(IS_COBALT)
+      .AddOptionalObservers(
+          dispatcher_parameters.cobalt_memory_attribution_inclusion ==
+                  CobaltMemoryAttributionInclusion::kInclude
+              ? base::memory::CobaltMemoryAttributionObserver::Get()
+              : nullptr)
 #endif
       .DoInitialize(base::allocator::dispatcher::Dispatcher::GetInstance());
 }

--- a/components/memory_system/parameters.cc
+++ b/components/memory_system/parameters.cc
@@ -6,6 +6,8 @@
 
 #include <string_view>
 
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "components/sampling_profiler/process_type.h"
 
 namespace memory_system {
@@ -22,10 +24,18 @@ ProfilingClientParameters::ProfilingClientParameters(
 DispatcherParameters::DispatcherParameters(
     PoissonAllocationSamplerInclusion poisson_allocation_sampler_inclusion,
     AllocationTraceRecorderInclusion allocation_trace_recorder_inclusion,
-    std::string_view process_type)
+    std::string_view process_type
+#if BUILDFLAG(IS_COBALT)
+    , CobaltMemoryAttributionInclusion cobalt_memory_attribution_inclusion
+#endif
+    )
     : poisson_allocation_sampler_inclusion(
           poisson_allocation_sampler_inclusion),
       allocation_trace_recorder_inclusion(allocation_trace_recorder_inclusion),
-      process_type(process_type) {}
+      process_type(process_type)
+#if BUILDFLAG(IS_COBALT)
+      , cobalt_memory_attribution_inclusion(cobalt_memory_attribution_inclusion)
+#endif
+      {}
 
 }  // namespace memory_system

--- a/components/memory_system/parameters.h
+++ b/components/memory_system/parameters.h
@@ -8,10 +8,19 @@
 #include <string>
 #include <string_view>
 
+#include "build/build_config.h"
+#include "build/buildflag.h"
 #include "components/sampling_profiler/process_type.h"
 #include "components/version_info/channel.h"
 
 namespace memory_system {
+
+#if BUILDFLAG(IS_COBALT)
+enum class CobaltMemoryAttributionInclusion {
+  kInclude,
+  kDoNotInclude,
+};
+#endif
 
 // Configuration objects for all memory subsystem components. The parameters are
 // divided by component. The type of the data corresponds to the type used by
@@ -70,11 +79,22 @@ struct DispatcherParameters {
   explicit DispatcherParameters(
       PoissonAllocationSamplerInclusion poisson_allocation_sampler_inclusion,
       AllocationTraceRecorderInclusion allocation_trace_recorder_inclusion,
-      std::string_view process_type);
+      std::string_view process_type
+#if BUILDFLAG(IS_COBALT)
+      // Cobalt memory attribution can introduce performance overhead, so it is
+      // excluded by default unless explicitly requested.
+      , CobaltMemoryAttributionInclusion cobalt_memory_attribution_inclusion =
+            CobaltMemoryAttributionInclusion::kDoNotInclude
+#endif
+  );
 
   PoissonAllocationSamplerInclusion poisson_allocation_sampler_inclusion;
   AllocationTraceRecorderInclusion allocation_trace_recorder_inclusion;
   std::string process_type;
+#if BUILDFLAG(IS_COBALT)
+  CobaltMemoryAttributionInclusion cobalt_memory_attribution_inclusion =
+      CobaltMemoryAttributionInclusion::kDoNotInclude;
+#endif
 };
 
 }  // namespace memory_system

--- a/copied_base/base/BUILD.gn
+++ b/copied_base/base/BUILD.gn
@@ -451,6 +451,8 @@ component("base") {
     "memory/shared_memory_tracker.cc",
     "memory/shared_memory_tracker.h",
     "memory/singleton.h",
+    "memory/cobalt_memory_context.cc",
+    "memory/cobalt_memory_context.h",
     "memory/stack_allocated.h",
     "memory/unsafe_shared_memory_pool.cc",
     "memory/unsafe_shared_memory_pool.h",

--- a/copied_base/base/memory/cobalt_memory_context.cc
+++ b/copied_base/base/memory/cobalt_memory_context.cc
@@ -65,12 +65,6 @@ ScopedMemoryContext::~ScopedMemoryContext() {
   SetCurrentMemoryContext(prev_context_);
 }
 
-extern "C" {
-void CobaltSetMemoryContext(uint8_t context) {
-  SetCurrentMemoryContext(static_cast<MemoryContext>(context));
-}
-}
-
 std::string_view ContextToString(MemoryContext context) {
   switch (context) {
     case MemoryContext::kUnknown:

--- a/copied_base/base/memory/cobalt_memory_context.h
+++ b/copied_base/base/memory/cobalt_memory_context.h
@@ -1,0 +1,74 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+// http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COPIED_BASE_BASE_MEMORY_COBALT_MEMORY_CONTEXT_H_
+#define COPIED_BASE_BASE_MEMORY_COBALT_MEMORY_CONTEXT_H_
+
+#include <string_view>
+#include "copied_base/base/base_export.h"
+
+namespace base {
+namespace memory {
+
+enum class MemoryContext : uint8_t {
+  kUnknown = 0,
+  kDOM,
+  kLayout,
+  kMedia,
+  kScript,
+  kNetwork,
+  kGraphics,
+  kStorage,
+
+  // Next-Generation Granular Sub-Regions
+  kGraphicsCanvas,
+  kGraphicsCompositor,
+  kGraphicsGlyphs,
+  kScriptHeap,
+  kScriptJIT,
+  kScriptBindings,
+  kNetworkLoader,
+  kNetworkCache,
+  kBlinkDOM,
+  kBlinkStyle,
+  kBlinkParser,
+  kPlatformIPC,
+  kPlatformStarboard,
+  kPlatformDevTools,
+  kBrowserMain,
+
+  kCount
+};
+
+BASE_EXPORT MemoryContext GetCurrentMemoryContext();
+BASE_EXPORT void SetCurrentMemoryContext(MemoryContext context);
+
+class BASE_EXPORT ScopedMemoryContext {
+ public:
+  explicit ScopedMemoryContext(MemoryContext context);
+  ~ScopedMemoryContext();
+
+  ScopedMemoryContext(const ScopedMemoryContext&) = delete;
+  ScopedMemoryContext& operator=(const ScopedMemoryContext&) = delete;
+
+ private:
+  MemoryContext prev_context_;
+};
+
+BASE_EXPORT std::string_view ContextToString(MemoryContext context);
+
+}  // namespace memory
+}  // namespace base
+
+#endif  // COPIED_BASE_BASE_MEMORY_COBALT_MEMORY_CONTEXT_H_


### PR DESCRIPTION
Introduce the Memory Context API and associated task helpers to enable
fine-grained memory attribution. This change allows Cobalt to track
memory allocations by subsystem by propagating a memory context
through the task scheduler and thread pool.

The context is maintained using thread-local storage via pthread keys,
with weak symbols used to ensure consistency across the base and
copied_base components. Integrated these contexts into PendingTask
and TaskAnnotator to automatically restore the context when tasks
are executed.

**Note:** This is based on the design specified in http://shortn/_SRQHp8rmF4.

Bug: 512925852