### PR TITLE
android: Prevent partner OS-fallback keys from being dispatched to IME

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -133,6 +133,7 @@ android_library("cobalt_main_java") {
     "apk/app/src/main/java/dev/cobalt/coat/CrashContext.java",
     "apk/app/src/main/java/dev/cobalt/coat/CrashContextUpdateHandler.java",
     "apk/app/src/main/java/dev/cobalt/coat/ErrorDialog.java",
+    "apk/app/src/main/java/dev/cobalt/coat/KeyboardUtils.java",
     "apk/app/src/main/java/dev/cobalt/coat/NetworkStatus.java",
     "apk/app/src/main/java/dev/cobalt/coat/NullCobaltFactory.java",
     "apk/app/src/main/java/dev/cobalt/coat/PlatformError.java",

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -376,12 +376,18 @@ public abstract class CobaltActivity extends Activity {
     if (KeyEvent.isGamepadButton(keyCode)) {
       return super.onKeyDown(keyCode, event);
     }
+    if (KeyboardUtils.isPartnerFallbackKey(keyCode)) {
+      return super.onKeyDown(keyCode, event);
+    }
     return dispatchKeyEventToIme(keyCode, KeyEvent.ACTION_DOWN) || super.onKeyDown(keyCode, event);
   }
 
   @Override
   public boolean onKeyUp(int keyCode, KeyEvent event) {
     if (KeyEvent.isGamepadButton(keyCode)) {
+      return super.onKeyUp(keyCode, event);
+    }
+    if (KeyboardUtils.isPartnerFallbackKey(keyCode)) {
       return super.onKeyUp(keyCode, event);
     }
     if (keyCode == KeyEvent.KEYCODE_BACK) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -371,12 +371,9 @@ public abstract class CobaltActivity extends Activity {
     if (keyCode == KeyEvent.KEYCODE_BACK) {
       mPhysicalBackKeyPressed = true;
     }
-    // If input is a from a gamepad button, it shouldn't be dispatched to IME which incorrectly
-    // consumes the event as a VKEY_UNKNOWN
-    if (KeyEvent.isGamepadButton(keyCode)) {
-      return super.onKeyDown(keyCode, event);
-    }
-    if (KeyboardUtils.isPartnerFallbackKey(keyCode)) {
+    // Gamepad buttons and certain partner-handled keys should bypass IME. The IME incorrectly
+    // consumes the events as VKEY_UNKNOWN and prevent proper handling by the OS.
+    if (KeyEvent.isGamepadButton(keyCode) || KeyboardUtils.isPartnerFallbackKey(keyCode)) {
       return super.onKeyDown(keyCode, event);
     }
     return dispatchKeyEventToIme(keyCode, KeyEvent.ACTION_DOWN) || super.onKeyDown(keyCode, event);
@@ -384,10 +381,7 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   public boolean onKeyUp(int keyCode, KeyEvent event) {
-    if (KeyEvent.isGamepadButton(keyCode)) {
-      return super.onKeyUp(keyCode, event);
-    }
-    if (KeyboardUtils.isPartnerFallbackKey(keyCode)) {
+    if (KeyEvent.isGamepadButton(keyCode) || KeyboardUtils.isPartnerFallbackKey(keyCode)) {
       return super.onKeyUp(keyCode, event);
     }
     if (keyCode == KeyEvent.KEYCODE_BACK) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/KeyboardUtils.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/KeyboardUtils.java
@@ -1,0 +1,51 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.coat;
+
+import android.view.KeyEvent;
+
+/** Utility methods for keyboard event handling. */
+public final class KeyboardUtils {
+  private KeyboardUtils() {}
+
+  /**
+   * Returns true if the key code is a partner-specific fallback key that should not be consumed by
+   * Cobalt, allowing it to fall back to the OS (e.g. to switch TV channels).
+   *
+   * This is similar to the isGamepadButton defined in android.view.KeyEvent but custom for Cobalt-
+   * specific key events that need to be handled before an IME dispatch.
+   *
+   * Note: These keys must be intercepted here in Java before they are dispatched to the IME
+   * pipeline. The Chromium IME dispatch is asynchronous and immediately returns true (consumed) to
+   * the Android OS, which prevents the OS-level fallback mechanism from triggering.
+   *
+   * Consequently, filtering these keys in Cobalt's native keycode conversion (e.g.
+   * keyboard_code_conversion_android_cobalt.cc) is too late to allow fallback, as the key events will
+   * still be consumed although they are mapped to VKEY_UNKNOWN.
+   */
+  public static boolean isPartnerFallbackKey(int keyCode) {
+    switch (keyCode) {
+      case KeyEvent.KEYCODE_11:
+      case KeyEvent.KEYCODE_12:
+      case KeyEvent.KEYCODE_TV_TERRESTRIAL_DIGITAL:
+      case KeyEvent.KEYCODE_TV_SATELLITE_BS:
+      case KeyEvent.KEYCODE_TV_SATELLITE_CS:
+      case KeyEvent.KEYCODE_TV_SATELLITE_SERVICE:
+        return true;
+      default:
+        return false;
+    }
+  }
+}

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/KeyboardUtils.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/KeyboardUtils.java
@@ -16,7 +16,19 @@ package dev.cobalt.coat;
 
 import android.view.KeyEvent;
 
-/** Utility methods for keyboard event handling. */
+/**
+ * Utility methods for keyboard event handling.
+ *
+ * Provides helper methods to identify specific key codes that require custom handling, such as
+ * partner-specific fallback keys that must be intercepted before IME dispatch to allow OS-level
+ * fallback.
+ *
+ * This is a utility class with static methods and cannot be instantiated. It is owned by the
+ * Cobalt Android runtime team and remains active throughout the application's lifetime.
+ *
+ * This class is stateless and thread-safe. All methods are static and can be
+ * safely called from any thread.
+ */
 public final class KeyboardUtils {
   private KeyboardUtils() {}
 


### PR DESCRIPTION
This PR introduces a `KeyboardUtils.java` class that defines key events that should not be dispatched/consumed by the IME pipeline and instead left to the OS to handle. Partners reported that their fallback key events are being consumed by Cobalt and therefore not working as intended. This is handled similarly to Gamepad key events #7101. 


Bug: 513111973