### PR TITLE
Add more functionality in RDK documentation to the script

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -115,14 +115,17 @@ def run_command(
     return process.stdout if capture_output else ""
 
 
-def configure_build(platform: str, config: str, out_dir: Path) -> None:
+def configure_build(platform: str, config: str, out_dir: Path, no_rbe: bool = False) -> None:
     """Runs GN configuration."""
     print(f"=== Configuring {platform} ({config}) ===")
-    run_command([
+    cmd = [
         "python3", "cobalt/build/gn.py", "-p", platform, "-C", config,
         "--out_directory",
         str(out_dir)
-    ])
+    ]
+    if no_rbe:
+        cmd.append("--no-rbe")
+    run_command(cmd)
 
 
 def build_targets(out_dir: Path, targets: List[str]) -> str:
@@ -344,6 +347,11 @@ def parse_args() -> argparse.Namespace:
         "--revert-c25",
         action="store_true",
         help="Revert the active Cobalt configuration on the device back to Cobalt 25.",
+    )
+    parser.add_argument(
+        "--no-rbe",
+        action="store_true",
+        help="Disable Remote Build Execution (RBE) in GN configuration.",
     )
     return parser.parse_args()
 
@@ -631,7 +639,7 @@ def main() -> None:
             print("Also, make sure to add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain).")
             sys.exit(1)
 
-        configure_build(PLATFORM, config, out_dir)
+        configure_build(PLATFORM, config, out_dir, args.no_rbe)
         build_output = build_targets(out_dir, targets)
         is_up_to_date = build_output and any(
             msg in build_output for msg in ["Everything is up-to-date", "no work to do"])

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -41,6 +41,12 @@ Usage Examples:
 
   8. Deploy only the libcobalt library:
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --only-lib
+
+  9. View device system logs (journalctl):
+     python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --logs
+
+  10. Follow device system logs in real-time (journalctl -f):
+      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --logs --follow
 """
 
 import argparse
@@ -353,6 +359,16 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Disable Remote Build Execution (RBE) in GN configuration.",
     )
+    parser.add_argument(
+        "--logs",
+        action="store_true",
+        help="View system/Cobalt logs from the device.",
+    )
+    parser.add_argument(
+        "--follow",
+        action="store_true",
+        help="Follow log output in real-time (runs journalctl -f).",
+    )
     return parser.parse_args()
 
 
@@ -588,6 +604,14 @@ def main() -> None:
     if args.revert_c25:
         device_id = get_device_id()
         revert_to_cobalt_25(device_id)
+        return
+
+    if args.logs:
+        device_id = get_device_id()
+        cmd = ["adb", "-s", device_id, "shell", "journalctl"]
+        if args.follow:
+            cmd.append("-f")
+        run_command(cmd, stream_output=True)
         return
 
     device_id = get_device_id()

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -56,6 +56,7 @@ import os
 from pathlib import Path
 import subprocess
 import sys
+import tempfile
 import time
 from typing import List, Optional, Union
 
@@ -571,7 +572,10 @@ def setup_toolchain() -> None:
 
     url = "https://storage.googleapis.com/cobalt-static-storage-public/20250521_rdk-glibc-x86_64-arm-toolchain-2.0.sh"
     print(f"=== Setting up toolchain in: {rdk_home} ===")
-    run_command(f"wget {url} -O installer.sh && sh installer.sh -d {rdk_home} -y && rm installer.sh")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        installer_path = os.path.join(tmp_dir, "installer.sh")
+        run_command(f"wget {url} -O '{installer_path}'")
+        run_command(f"sh '{installer_path}' -d '{rdk_home}' -y")
 
 
 def main() -> None:
@@ -592,7 +596,10 @@ def main() -> None:
         cmd = ["adb", "-s", device_id, "shell", "journalctl"]
         if args.follow:
             cmd.append("-f")
-        run_command(cmd)
+        try:
+            run_command(cmd)
+        except KeyboardInterrupt:
+            print("\nLog streaming stopped.")
         return
 
     if args.reset:

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -340,6 +340,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Download and install the RDK toolchain to RDK_HOME.",
     )
+    parser.add_argument(
+        "--revert-c25",
+        action="store_true",
+        help="Revert the active Cobalt configuration on the device back to Cobalt 25.",
+    )
     return parser.parse_args()
 
 
@@ -525,6 +530,23 @@ def check_and_switch_cobalt_version(device_id: str) -> None:
         sys.exit(1)
 
 
+def revert_to_cobalt_25(device_id: str) -> None:
+    """Reverts the active Cobalt configuration on the device back to Cobalt 25."""
+    target = run_command(
+        ["adb", "-s", device_id, "shell", "readlink /usr/lib/libloader_app.so"],
+        capture_output=True,
+    ).strip()
+
+    if target != "/data/out_cobalt/libloader_app.so":
+        print("Cobalt 25 is already active on the device.")
+        return
+
+    print("Running 'chCobalt c25' on the device...")
+    run_command(["adb", "-s", device_id, "shell", "chCobalt c25"])
+    run_command(["adb", "-s", device_id, "shell", "reboot -f"])
+    print("Revert to Cobalt 25 completed. The device is rebooting.")
+
+
 def is_toolchain_installed(rdk_home: Optional[str]) -> bool:
     """Checks if the RDK toolchain is installed in the target path."""
     return bool(rdk_home and os.path.exists(os.path.join(rdk_home, "sysroots")))
@@ -553,6 +575,11 @@ def main() -> None:
 
     if args.setup_toolchain:
         setup_toolchain()
+        return
+
+    if args.revert_c25:
+        device_id = get_device_id()
+        revert_to_cobalt_25(device_id)
         return
 
     device_id = get_device_id()

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -36,7 +36,7 @@ Usage Examples:
   6. Force deploy and run even if artifacts are up-to-date:
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run --force-deploy
 
-  7. Reset RDK display (fixes stuck sessions caused by executable mode):
+  7. Reset RDK display and restart WPEFramework (fixes stuck displays/frozen sessions):
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --reset
 
   8. Deploy only the libcobalt library:
@@ -73,10 +73,9 @@ MIN_SYSTEM_SOFTWARE_VERSION = "20260420"
 
 def run_command(
     command: Union[str, List[str]],
-    capture_output: bool = False,
     verbose: bool = True,
     check: bool = True,
-    stream_output: bool = False,
+    sleep_time: int = 0,
 ) -> str:
     """Utility to run shell commands."""
     if verbose:
@@ -84,41 +83,25 @@ def run_command(
         print(f">>> Executing: {cmd_str}")
 
     is_shell = isinstance(command, str)
-
-    if stream_output:
-        process = subprocess.Popen(
-            command,
-            shell=is_shell,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-        )
-        full_output = []
-        if process.stdout:
-            for line in process.stdout:
-                print(line, end="", flush=True)
-                full_output.append(line)
-        process.wait()
-        if check and process.returncode != 0:
-            raise subprocess.CalledProcessError(process.returncode, command,
-                                              "".join(full_output))
-        return "".join(full_output)
-
-    process = subprocess.run(
-        command,
-        shell=is_shell,
-        check=False,
-        stdout=subprocess.PIPE if capture_output else None,
-        stderr=subprocess.PIPE if capture_output else None,
-        text=True,
+    process = subprocess.Popen(
+        command, shell=is_shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
     )
+    stdout_lines = []
+    for line in process.stdout:
+        print(line, end="", flush=True)
+        stdout_lines.append(line)
+    process.wait()
+    stdout = "".join(stdout_lines)
 
     if check and process.returncode != 0:
-        print(f"Error executing command: {process.stderr}")
         sys.exit(process.returncode)
 
-    return process.stdout if capture_output else ""
+    if sleep_time > 0:
+        if verbose:
+            print(f"Waiting {sleep_time} seconds...")
+        time.sleep(sleep_time)
+
+    return stdout
 
 
 def configure_build(platform: str, config: str, out_dir: Path, no_rbe: bool = False) -> None:
@@ -137,8 +120,7 @@ def configure_build(platform: str, config: str, out_dir: Path, no_rbe: bool = Fa
 def build_targets(out_dir: Path, targets: List[str]) -> str:
     """Builds the specified targets using autoninja."""
     print(f"=== Building {' '.join(targets)} ===")
-    return run_command(["autoninja", "-C", str(out_dir)] + targets,
-                       stream_output=True)
+    return run_command(["autoninja", "-C", str(out_dir)] + targets)
 
 
 def deploy_only_lib(device_id: str, out_dir: Path, remote_dir: str) -> None:
@@ -233,7 +215,7 @@ def launch_on_device(
 
         # Get configuration
         get_config_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.configuration@YouTube"}'
-        res_str = run_command(["adb", "-s", device_id, "shell", f"curl -s http://127.0.0.1:9998/jsonrpc -d '{get_config_json}'"], capture_output=True)
+        res_str = run_command(["adb", "-s", device_id, "shell", f"curl -s http://127.0.0.1:9998/jsonrpc -d '{get_config_json}'"])
 
         rpc_deactivate = (
             r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.deactivate\",'
@@ -291,7 +273,7 @@ def launch_on_device(
         ]
 
     full_cmd = " && ".join(remote_cmds)
-    output = run_command(["adb", "-s", device_id, "shell", f"bash -l -c \"{full_cmd}\""], capture_output=True)
+    output = run_command(["adb", "-s", device_id, "shell", f"bash -l -c \"{full_cmd}\""])
     print(output)
     if "ERROR_OPENING_FAILED" in output or "error" in output.lower():
         print("\n[WARNING] Activation failed with error (e.g., ERROR_OPENING_FAILED).")
@@ -336,8 +318,8 @@ def parse_args() -> argparse.Namespace:
         "--reset",
         action="store_true",
         help=(
-            "Run rdkDisplay remove on device. Useful if the display is inactive "
-            "due to a previous executable mode session."),
+            "Run rdkDisplay remove and restart WPEFramework on the device. "
+            "Useful if the display is inactive or WPEFramework is stuck."),
     )
     parser.add_argument(
         "--devtools",
@@ -557,8 +539,7 @@ def check_and_switch_cobalt_version(device_id: str) -> None:
 def revert_to_cobalt_25(device_id: str) -> None:
     """Reverts the active Cobalt configuration on the device back to Cobalt 25."""
     target = run_command(
-        ["adb", "-s", device_id, "shell", "readlink /usr/lib/libloader_app.so"],
-        capture_output=True,
+        ["adb", "-s", device_id, "shell", "readlink /usr/lib/libloader_app.so"]
     ).strip()
 
     if target != "/data/out_cobalt/libloader_app.so":
@@ -611,22 +592,27 @@ def main() -> None:
         cmd = ["adb", "-s", device_id, "shell", "journalctl"]
         if args.follow:
             cmd.append("-f")
-        run_command(cmd, stream_output=True)
+        run_command(cmd)
         return
+
+    if args.reset:
+        device_id = get_device_id()
+        print("=== Resetting display ===")
+        run_command([
+            "adb", "-s", device_id, "shell", "bash -l -c 'rdkDisplay remove || true'"
+        ])
+        print("=== Restarting WPEFramework ===")
+        run_command([
+            "adb", "-s", device_id, "shell", "systemctl restart wpeframework"
+        ], sleep_time=5)
+        if not (args.run or args.tests or args.force_deploy):
+            print("=== Reset finished. ===")
+            return
 
     device_id = get_device_id()
     assert_software_version(device_id, MIN_SYSTEM_SOFTWARE_VERSION)
     if args.mode == "plugin" and not args.tests:
         check_and_switch_cobalt_version(device_id)
-
-    if args.reset:
-        print("=== Resetting display ===")
-        run_command([
-            "adb", "-s", device_id, "shell", "bash -l -c 'rdkDisplay remove || true'"
-        ])
-        if not (args.run or args.tests or args.force_deploy):
-            print("=== Reset finished. ===")
-            return
 
     # Setup Build Paths
     config = args.config or ("devel" if args.tests else "qa")

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -335,6 +335,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Enable Chrome DevTools remote debugging port (port 9222) in plugin mode.",
     )
+    parser.add_argument(
+        "--setup-toolchain",
+        action="store_true",
+        help="Download and install the RDK toolchain to RDK_HOME.",
+    )
     return parser.parse_args()
 
 
@@ -520,9 +525,35 @@ def check_and_switch_cobalt_version(device_id: str) -> None:
         sys.exit(1)
 
 
+def is_toolchain_installed(rdk_home: Optional[str]) -> bool:
+    """Checks if the RDK toolchain is installed in the target path."""
+    return bool(rdk_home and os.path.exists(os.path.join(rdk_home, "sysroots")))
+
+
+def setup_toolchain() -> None:
+    """Downloads and installs the RDK toolchain."""
+    rdk_home = os.environ.get("RDK_HOME")
+    if not rdk_home:
+        print("Error: RDK_HOME environment variable is not set.")
+        print("Please add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain) and restart your shell.")
+        sys.exit(1)
+
+    if is_toolchain_installed(rdk_home):
+        print(f"RDK toolchain is already installed in: {rdk_home}. Skipping setup.")
+        return
+
+    url = "https://storage.googleapis.com/cobalt-static-storage-public/20250521_rdk-glibc-x86_64-arm-toolchain-2.0.sh"
+    print(f"=== Setting up toolchain in: {rdk_home} ===")
+    run_command(f"wget {url} -O installer.sh && sh installer.sh -d {rdk_home} -y && rm installer.sh")
+
+
 def main() -> None:
     """Main execution flow."""
     args = parse_args()
+
+    if args.setup_toolchain:
+        setup_toolchain()
+        return
 
     device_id = get_device_id()
     assert_software_version(device_id, MIN_SYSTEM_SOFTWARE_VERSION)
@@ -566,6 +597,13 @@ def main() -> None:
             remote_dir = EXECUTABLE_REMOTE_DIR
 
     if not args.skip_build:
+        rdk_home = os.environ.get("RDK_HOME")
+        if not is_toolchain_installed(rdk_home):
+            print(f"Error: RDK toolchain is not set up in RDK_HOME ({rdk_home}).")
+            print("Please run this script with --setup-toolchain to download and install the toolchain.")
+            print("Also, make sure to add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain).")
+            sys.exit(1)
+
         configure_build(PLATFORM, config, out_dir)
         build_output = build_targets(out_dir, targets)
         is_up_to_date = build_output and any(

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -47,6 +47,15 @@ Usage Examples:
 
   10. Follow device system logs in real-time (journalctl -f):
       python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --logs --follow
+
+  11. Build, deploy, and run Cobalt plugin with Chrome DevTools remote debugging enabled:
+      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run --devtools
+
+  12. Download and install cross-compilation toolchain:
+      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --setup-toolchain
+
+  13. Revert active Cobalt loader configuration to Cobalt 25:
+      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --revert-c25
 """
 
 import argparse

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk_test.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk_test.py
@@ -201,6 +201,26 @@ class TestDeployRdk(unittest.TestCase):
         self.assertTrue(found_remote_dir, "Did not create remote lib directory")
         self.assertTrue(found_push, "Did not push libcobalt.lz4 to correct folder")
 
+    def test_revert_c25(self):
+        """Verifies --revert-c25 runs chCobalt c25 and reboot -f."""
+        self.mock_run.return_value = "/data/out_cobalt/libloader_app.so"
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--revert-c25"]):
+            deploy_rdk.main()
+
+        calls = [str(c) for c in self.mock_run.call_args_list]
+        self.assertTrue(any("chCobalt c25" in c for c in calls), "chCobalt c25 not called")
+        self.assertTrue(any("reboot -f" in c for c in calls), "reboot -f not called")
+
+    def test_no_rbe_flag(self):
+        """Verifies --no-rbe flag passes --no-rbe to GN."""
+        self.mock_run.side_effect = ["", "", "linking...", "", "", "", "", ""]
+        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+            with mock.patch("sys.argv", ["deploy_rdk.py", "--no-rbe", "--force-deploy"]):
+                deploy_rdk.main()
+
+        gn_call = next(c for c in self.mock_run.call_args_list if "gn.py" in str(c))
+        self.assertIn("--no-rbe", gn_call[0][0])
+
 
 class TestDeployRdkDeviceDetection(unittest.TestCase):
     """Unit tests for the device auto-detection logic in deploy_rdk script."""
@@ -371,8 +391,9 @@ class TestDeployRdkDeviceDetection(unittest.TestCase):
 
         self.mock_sub_run.side_effect = sub_run_side_effect
 
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-            deploy_rdk.main()
+        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+            with mock.patch("sys.argv", ["deploy_rdk.py", "--force-deploy"]):
+                deploy_rdk.main()
 
         # Check that chCobalt custom_cobalt, reboot, and echo ok were called
         sub_run_calls = [str(call) for call in self.mock_sub_run.call_args_list]
@@ -437,6 +458,33 @@ class TestDeployRdkDeviceDetection(unittest.TestCase):
                 deploy_rdk.main()
 
         self.mock_exit.assert_called_once_with(1)
+
+
+    @mock.patch("tempfile.TemporaryDirectory")
+    def test_setup_toolchain_uses_temporary_directory(self, mock_temp_dir):
+        mock_temp_dir.return_value.__enter__.return_value = "/tmp/mock_dir"
+        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+            with mock.patch("os.path.exists", return_value=False):
+                with mock.patch("sys.argv", ["deploy_rdk.py", "--setup-toolchain"]):
+                    deploy_rdk.main()
+        mock_temp_dir.assert_called_once()
+
+    def test_logs_streaming_handles_keyboard_interrupt(self):
+        self.mock_run.side_effect = KeyboardInterrupt
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+            return mock.MagicMock(returncode=0, stdout="")
+        self.mock_sub_run.side_effect = sub_run_side_effect
+
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--logs"]):
+            try:
+                deploy_rdk.main()
+            except KeyboardInterrupt:
+                self.fail("KeyboardInterrupt was not caught by deploy_rdk --logs")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Overview
This PR bridges the remaining gaps between the manual onboarding/advanced development documentation for Cobalt 26+ on RDK and the `deploy_rdk.py` automation script. It introduces robust toolchain setup verification, version reversion, real-time log streaming, non-RBE build configuration, and full middleware reset capabilities.

### Key Changes & Features

1. **Toolchain Setup & Validation (`--setup-toolchain`)**
   * Automatically downloads and unpacks the RDK cross-compilation toolchain into `RDK_HOME`.
   * Skips re-installation if `sysroots` is already detected.
   * Enforces pre-build validation to verify `RDK_HOME` is set and configured before running GN.

2. **Revert to Cobalt 25 (`--revert-c25`)**
   * Inspects the active loader symlink on the device.
   * If running custom Cobalt, executes `chCobalt c25` and reboots the device back to the resident Cobalt 25 image.

3. **Distributed Build Bypass (`--no-rbe`)**
   * Dynamically passes `--no-rbe` to `cobalt/build/gn.py` for local or non-distributed build environments.

4. **Real-Time Log Streaming (`--logs` & `--follow`)**
   * Queries system journal logs directly from the device via `journalctl`.
   * Integrates live log following (`journalctl -f`) via `--follow`.

5. **Enhanced Display & Framework Reset (`--reset`)**
   * Clears inactive or stuck display sessions (`rdkDisplay remove`).
   * Restarts the WPEFramework service (`systemctl restart wpeframework`) and includes a 5-second stabilization wait before releasing focus.

6. **Unified Subprocess Streaming (`run_command`)**
   * Refactored `run_command` to consistently stream real-time execution output (e.g., during long `autoninja` builds), removing redundant capture/stream flags and simplifying caller code.

Issue: 502702565