### PR TITLE
fix: Remove problematic ~H5vccPlatformService

### DIFF
--- a/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
@@ -122,6 +122,7 @@ H5vccPlatformService* H5vccPlatformService::open(
 
   return instance;
 }
+
 H5vccPlatformService::H5vccPlatformService(LocalDOMWindow& window,
                                            const WTF::String& service_name,
                                            V8ReceiveCallback* receive_callback)

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
@@ -122,7 +122,6 @@ H5vccPlatformService* H5vccPlatformService::open(
 
   return instance;
 }
-
 H5vccPlatformService::H5vccPlatformService(LocalDOMWindow& window,
                                            const WTF::String& service_name,
                                            V8ReceiveCallback* receive_callback)
@@ -131,11 +130,6 @@ H5vccPlatformService::H5vccPlatformService(LocalDOMWindow& window,
       receive_callback_(receive_callback),
       platform_service_remote_(GetExecutionContext()),
       observer_receiver_(this, GetExecutionContext()) {}
-
-H5vccPlatformService::~H5vccPlatformService() {
-  // Ensures mojo pipes are closed if not done already
-  close();
-}
 
 void H5vccPlatformService::OnManagerConnectionError() {
   DLOG(ERROR) << "H5vccPlatformServiceManager connection error";

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.h
@@ -47,11 +47,9 @@ class MODULES_EXPORT H5vccPlatformService final
   static H5vccPlatformService* open(ScriptState* script_state,
                                     const WTF::String& service_name,
                                     V8ReceiveCallback* receive_callback);
-
   H5vccPlatformService(LocalDOMWindow& window,
                        const WTF::String& service_name,
                        V8ReceiveCallback* receive_callback);
-  ~H5vccPlatformService() override;
 
   // Web-exposed instance methods:
   DOMArrayBuffer* send(DOMArrayBuffer* data, ExceptionState& exception_state);

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.h
@@ -47,6 +47,7 @@ class MODULES_EXPORT H5vccPlatformService final
   static H5vccPlatformService* open(ScriptState* script_state,
                                     const WTF::String& service_name,
                                     V8ReceiveCallback* receive_callback);
+
   H5vccPlatformService(LocalDOMWindow& window,
                        const WTF::String& service_name,
                        V8ReceiveCallback* receive_callback);


### PR DESCRIPTION
This is an attempt to fix a `DCHECK failed: !ref_count_.IsZero()` crash in devel builds.

The destructor calls H5vccPlatformService::close(), which resets HeapMojoRemote and HeapMojoReceiver members. While the crash is not easy to reproduce, the theory is that this causes the crash because 1) Oilpan GC sweeping occurs on a background thread and 2) mojo::Receiver and mojo::Remote are "NOT thread- or sequence- safe and must be used from a single (but otherwise arbitrary) sequence" (see header files).

It should be safe to remove the destructor: H5vccPlatformService participates in Oilpan GC by inheriting from GarbageCollected; Oilpan GC will queue the Mojo wrappers for pre-finalization; pre-finalization will shut down the Mojo connections on the main thread.

Issue: 505835249