### PR TITLE
media: Implement zero-allocation audio bypass

### DIFF
--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -188,7 +188,9 @@ bool AudioRendererPcm::IsEndOfStreamPlayed() const {
 bool AudioRendererPcm::CanAcceptMoreData() const {
   SB_CHECK(BelongsToCurrentThread());
   return eos_state_ == kEOSNotReceived && can_accept_more_data_ &&
-         (!decoder_sample_rate_ || !time_stretcher_.IsQueueFull());
+         (!decoder_sample_rate_ ||
+          (bypass_ ? bypass_->queue.frames() < max_cached_frames_
+                   : !time_stretcher_.IsQueueFull()));
 }
 
 void AudioRendererPcm::Play() {
@@ -213,6 +215,25 @@ void AudioRendererPcm::SetPlaybackRate(double playback_rate) {
 
   if (playback_rate_ == 0.f && playback_rate > 0.f) {
     consume_frames_called_ = false;
+  }
+
+  if (bypass_ && playback_rate != 1.0) {
+    SB_LOG(INFO) << "AudioRendererPcm: Exiting bypass mode, moving "
+                 << bypass_->queue.frames() << " frames to time stretcher.";
+    int frames_to_move = bypass_->queue.frames();
+    if (frames_to_move > 0) {
+      auto moved_audio = make_scoped_refptr<DecodedAudio>(
+          channels_, kSbMediaAudioSampleTypeFloat32,
+          kSbMediaAudioFrameStorageTypeInterleaved, /*timestamp=*/0,
+          frames_to_move * bypass_->bytes_per_frame);
+      int frames_read = bypass_->queue.ReadFrames(
+          frames_to_move, /*dest_frame_offset=*/0, moved_audio.get());
+      SB_CHECK_EQ(frames_read, frames_to_move);
+      time_stretcher_.EnqueueBuffer(moved_audio);
+    }
+    // Exit bypass mode permanently. We do not support re-entering
+    // bypass mode after this.
+    bypass_.reset();
   }
 
   playback_rate_ = playback_rate;
@@ -254,6 +275,7 @@ void AudioRendererPcm::Seek(int64_t seek_to_time) {
     if (resampler_) {
       resampler_.reset();
       time_stretcher_.FlushBuffers();
+      bypass_.reset();
     }
 
     total_frames_sent_to_sink_ = 0;
@@ -595,6 +617,11 @@ void AudioRendererPcm::OnFirstOutput(
     SB_DCHECK(resampler_);
   } else {
     resampler_.reset(new IdentityAudioResampler);
+    if (playback_rate_ == 1.0) {
+      bypass_.emplace(sizeof(float) * channels_);
+      SB_LOG(INFO)
+          << "AudioRendererPcm: Bypassing resampler and time stretcher";
+    }
   }
 
   // TODO: Support planar only audio sink.
@@ -689,18 +716,23 @@ void AudioRendererPcm::ProcessAudioData() {
           Schedule(prerolled_cb_);
         }
       }
-
-      resampled_audio = resampler_->WriteEndOfStream();
+      if (!bypass_) {
+        resampled_audio = resampler_->WriteEndOfStream();
+      }
     } else {
       // Discard any audio data before the seeking target.
       if (seeking_ && decoded_audio->timestamp() < seeking_to_time_) {
         continue;
       }
 
-      resampled_audio = resampler_->Resample(decoded_audio);
+      if (bypass_) {
+        bypass_->queue.Append(decoded_audio);
+      } else {
+        resampled_audio = resampler_->Resample(decoded_audio);
+      }
     }
 
-    if (resampled_audio && resampled_audio->size_in_bytes() > 0) {
+    if (!bypass_ && resampled_audio && resampled_audio->size_in_bytes() > 0) {
       // |time_stretcher_| only support kSbMediaAudioSampleTypeFloat32 and
       // kSbMediaAudioFrameStorageTypeInterleaved.
       if (!resampled_audio->IsFormat(
@@ -744,7 +776,10 @@ bool AudioRendererPcm::AppendAudioToFrameBuffer(bool* is_frame_buffer_full) {
 
   *is_frame_buffer_full = false;
 
-  if (time_stretcher_.IsQueueFull()) {
+  bool preroll_completed =
+      bypass_ ? bypass_->queue.frames() >= max_cached_frames_ / 2
+              : time_stretcher_.IsQueueFull();
+  if (preroll_completed) {
     std::lock_guard lock(mutex_);
     if (seeking_) {
       seeking_ = false;
@@ -769,6 +804,11 @@ bool AudioRendererPcm::AppendAudioToFrameBuffer(bool* is_frame_buffer_full) {
   double adjusted_playback_rate = playback_rate_;
   if (audio_renderer_sink_->AllowDirectPlaybackRateSetting()) {
     adjusted_playback_rate = 1.0;
+  }
+
+  if (bypass_) {
+    return AppendBypassAudioToFrameBuffer(frames_in_buffer, offset_to_append,
+                                          adjusted_playback_rate);
   }
 
   scoped_refptr<DecodedAudio> decoded_audio = time_stretcher_.Read(
@@ -810,6 +850,54 @@ bool AudioRendererPcm::AppendAudioToFrameBuffer(bool* is_frame_buffer_full) {
 
   total_frames_sent_to_sink_ += frames_appended;
 
+  return frames_appended > 0;
+}
+
+bool AudioRendererPcm::AppendBypassAudioToFrameBuffer(
+    int frames_in_buffer,
+    int offset_to_append,
+    double adjusted_playback_rate) {
+  SB_CHECK(bypass_);
+
+  int frames_to_read = max_cached_frames_ - frames_in_buffer;
+  frames_to_read = std::min(frames_to_read, bypass_->queue.frames());
+  if (frames_to_read == 0 && eos_state_ != kEOSDecoded) {
+    return false;
+  }
+
+  int frames_appended = 0;
+  if (frames_to_read > 0) {
+    int frames_to_append = frames_to_read;
+    if (frames_to_append > max_cached_frames_ - offset_to_append) {
+      int first_chunk = max_cached_frames_ - offset_to_append;
+      int read = bypass_->queue.ReadFramesDirect(
+          first_chunk, &frame_buffer_[offset_to_append * bytes_per_frame_],
+          bytes_per_frame_);
+      SB_CHECK_EQ(read, first_chunk);
+
+      frames_to_append -= first_chunk;
+      frames_appended += first_chunk;
+      offset_to_append = 0;
+    }
+
+    if (frames_to_append > 0) {
+      int read = bypass_->queue.ReadFramesDirect(
+          frames_to_append, &frame_buffer_[offset_to_append * bytes_per_frame_],
+          bytes_per_frame_);
+      SB_CHECK_EQ(read, frames_to_append);
+      frames_appended += frames_to_append;
+    }
+  }
+
+  if (frames_appended > 0 || eos_state_ == kEOSDecoded) {
+    std::lock_guard lock(mutex_);
+    if (frames_appended == 0 && eos_state_ == kEOSDecoded) {
+      eos_state_ = kEOSSentToSink;
+    }
+    audio_frame_tracker_.AddFrames(frames_appended, adjusted_playback_rate);
+  }
+
+  total_frames_sent_to_sink_ += frames_appended;
   return frames_appended > 0;
 }
 

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -98,7 +98,16 @@ class AudioRendererPcm : public AudioRenderer,
   int64_t GetAudioWriteHead() override;
   int64_t AdjustTimestampToAudioClock(int64_t timestamp) override;
 
+  bool IsBypassingForTesting() const { return bypass_.has_value(); }
+
  private:
+  struct BypassContext {
+    explicit BypassContext(int bytes_per_frame)
+        : bytes_per_frame(bytes_per_frame) {}
+    DecodedAudioQueue queue;
+    const int bytes_per_frame;
+  };
+
   enum EOSState {
     kEOSNotReceived,
     kEOSWrittenToDecoder,
@@ -158,6 +167,9 @@ class AudioRendererPcm : public AudioRenderer,
   void ProcessAudioData();
   void FillResamplerAndTimeStretcher();
   bool AppendAudioToFrameBuffer(bool* is_frame_buffer_full);
+  bool AppendBypassAudioToFrameBuffer(int frames_in_buffer,
+                                      int offset_to_append,
+                                      double adjusted_playback_rate);
 
   EOSState eos_state_ = kEOSNotReceived;
   const int channels_;
@@ -167,6 +179,16 @@ class AudioRendererPcm : public AudioRenderer,
   std::unique_ptr<AudioResampler> resampler_;
   std::optional<int> decoder_sample_rate_;
   AudioTimeStretcher time_stretcher_;
+
+  // When it has a value, indicates that the renderer is in "bypass mode",
+  // skipping the resampler and time stretcher. This is only enabled
+  // at the start of playback if the input format natively matches the
+  // sink format and the playback rate is 1.0.
+  // Once we exit bypass mode (e.g. due to a playback rate change),
+  // the context is destroyed (reset to std::nullopt) and we never re-enter
+  // bypass mode for the remainder of the playback session to avoid
+  // the complexity of draining the time stretcher back into the queue.
+  std::optional<BypassContext> bypass_;
 
   std::vector<uint8_t> frame_buffer_;
   uint8_t* frame_buffers_[1];

--- a/starboard/shared/starboard/player/filter/decoded_audio_queue.cc
+++ b/starboard/shared/starboard/player/filter/decoded_audio_queue.cc
@@ -167,4 +167,53 @@ int DecodedAudioQueue::InternalRead(int frames,
   return taken;
 }
 
+int DecodedAudioQueue::ReadFramesDirect(int frames,
+                                        uint8_t* dest_buffer,
+                                        int bytes_per_frame) {
+  int taken = 0;
+  BufferQueue::iterator current_buffer = current_buffer_;
+  int current_buffer_offset = current_buffer_offset_;
+
+  while (taken < frames) {
+    if (current_buffer == buffers_.end()) {
+      break;
+    }
+
+    scoped_refptr<DecodedAudio> buffer = *current_buffer;
+    int remaining_frames_in_buffer = buffer->frames() - current_buffer_offset;
+
+    int copied = std::min(frames - taken, remaining_frames_in_buffer);
+
+    if (dest_buffer) {
+      const uint8_t* source =
+          buffer->data() + current_buffer_offset * bytes_per_frame;
+      uint8_t* destination = dest_buffer + taken * bytes_per_frame;
+      memcpy(destination, source, copied * bytes_per_frame);
+    }
+
+    taken += copied;
+    current_buffer_offset += copied;
+
+    if (current_buffer_offset == buffer->frames()) {
+      BufferQueue::iterator next = current_buffer + 1;
+      if (next == buffers_.end()) {
+        break;
+      }
+      current_buffer = next;
+      current_buffer_offset = 0;
+    }
+  }
+
+  // Pruning logic is now unconditional and runs at the end of the read
+  frames_ -= taken;
+  SB_DCHECK_GE(frames_, 0);
+  SB_DCHECK(current_buffer_ != buffers_.end() || frames_ == 0);
+
+  buffers_.erase(buffers_.begin(), current_buffer);
+  current_buffer_ = buffers_.begin();
+  current_buffer_offset_ = current_buffer_offset;
+
+  return taken;
+}
+
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/decoded_audio_queue.h
+++ b/starboard/shared/starboard/player/filter/decoded_audio_queue.h
@@ -51,6 +51,13 @@ class DecodedAudioQueue {
   // into the destination DecodedAudio.
   int ReadFrames(int frames, int dest_frame_offset, DecodedAudio* dest);
 
+  // Reads a maximum of |frames| from the current position and copies them
+  // directly into the raw |dest_buffer|. The data is assumed to be in the
+  // queue's native sample type and Interleaved storage type.
+  // Returns the number of frames read. The current position will advance by the
+  // amount of frames read.
+  int ReadFramesDirect(int frames, uint8_t* dest_buffer, int bytes_per_frame);
+
   // Copies up to |frames| frames from current position to |dest|. Returns
   // number of frames copied. Doesn't advance current position. Starts at
   // |source_frame_offset| from current position. |dest_frame_offset| specifies

--- a/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_renderer_internal_test.cc
@@ -319,6 +319,7 @@ TEST_F(AudioRendererTest, SunnyDay) {
   Seek(0);
 
   int frames_written = FillRendererWithDecodedAudioAndWriteEOS(0);
+  EXPECT_TRUE(audio_renderer_->IsBypassingForTesting());
 
   bool is_playing = true;
   bool is_eos_played = true;
@@ -408,6 +409,7 @@ TEST_F(AudioRendererTest, SunnyDayWithDoublePlaybackRateAndInt16Samples) {
   Seek(0);
 
   int frames_written = FillRendererWithDecodedAudioAndWriteEOS(0);
+  EXPECT_FALSE(audio_renderer_->IsBypassingForTesting());
   bool is_playing = false;
   bool is_eos_played = true;
   bool is_underflow = true;
@@ -890,6 +892,85 @@ TEST_F(AudioRendererTest, Seek) {
 }
 
 // TODO: Add more Seek tests.
+
+TEST_F(AudioRendererTest, TransitionFromBypassToNonBypass) {
+  if (HasAsyncAudioFramesReporting()) {
+    SB_LOG(INFO) << "Platform has async audio frames reporting. Test skipped.";
+    return;
+  }
+
+  {
+    ::testing::InSequence seq;
+    EXPECT_CALL(
+        *audio_renderer_sink_,
+        Start(0, kDefaultNumberOfChannels, kDefaultSamplesPerSecond,
+              kDefaultAudioSampleType, kDefaultAudioFrameStorageType, _, _, _));
+  }
+
+  Seek(0);
+
+  const int kFramesPerBuffer = 1024;
+  int frames_written = 0;
+
+  // Write some samples at 1.0 rate.
+  for (int i = 0; i < 5; ++i) {
+    int64_t timestamp = frames_written * 1'000'000LL / kDefaultSamplesPerSecond;
+    WriteSample(CreateInputBuffer(timestamp));
+    CallConsumedCB();
+    SendDecoderOutput(CreateDecodedAudio(timestamp, kFramesPerBuffer));
+    frames_written += kFramesPerBuffer;
+  }
+
+  // We should be in bypass mode.
+  EXPECT_TRUE(audio_renderer_->IsBypassingForTesting());
+
+  // Now change playback rate to 2.0. This should trigger transition.
+  EXPECT_CALL(*audio_renderer_sink_, SetPlaybackRate(1.0))
+      .Times(::testing::AnyNumber());
+  audio_renderer_->SetPlaybackRate(2.0);
+  job_queue_.RunUntilIdle();
+
+  // We should no longer be in bypass mode.
+  EXPECT_FALSE(audio_renderer_->IsBypassingForTesting());
+
+  // Fill the rest and write EOS.
+  while (!prerolled_) {
+    int64_t timestamp = frames_written * 1'000'000LL / kDefaultSamplesPerSecond;
+    WriteSample(CreateInputBuffer(timestamp));
+    CallConsumedCB();
+    SendDecoderOutput(CreateDecodedAudio(timestamp, kFramesPerBuffer));
+    frames_written += kFramesPerBuffer;
+  }
+
+  WriteEndOfStream();
+
+  // Play and consume.
+  audio_renderer_->Play();
+  SendDecoderOutput(new DecodedAudio);
+
+  bool is_playing = false;
+  bool is_eos_played = false;
+  bool is_underflow = false;
+  double playback_rate = -1.0;
+
+  int64_t media_time = audio_renderer_->GetCurrentMediaTime(
+      &is_playing, &is_eos_played, &is_underflow, &playback_rate);
+
+  int frames_in_buffer;
+  int offset_in_frames;
+  bool is_eos_reached;
+  renderer_callback_->GetSourceStatus(&frames_in_buffer, &offset_in_frames,
+                                      &is_playing, &is_eos_reached);
+  EXPECT_GT(frames_in_buffer, 0);
+  EXPECT_TRUE(is_playing);
+  EXPECT_TRUE(is_eos_reached);
+
+  // Consume all.
+  renderer_callback_->ConsumeFrames(frames_in_buffer, CurrentMonotonicTime());
+  job_queue_.RunUntilIdle();
+
+  EXPECT_TRUE(audio_renderer_->IsEndOfStreamPlayed());
+}
 
 }  // namespace
 


### PR DESCRIPTION
   Optimize Audio Pipeline: Zero-Allocation, Single-Copy Bypass
    
    Implement a high-performance "Bypass Mode" in AudioRendererPcm that completely
    bypasses the AudioResampler and AudioTimeStretcher during 1.0x playback when
    the decoded format natively matches the sink format (Float32 Interleaved).
    
    To achieve maximum rendering performance with zero heap allocations in the
    steady-state loop, this change introduces:
    1. `DecodedAudioQueue::ReadFramesDirect`: A new, purely additive API that
       copies audio frames directly from the queue's internal deque into a raw
       memory destination buffer.
    2. `AudioRendererPcm::AppendBypassAudioToFrameBuffer`: A dedicated private
       helper that handles the circular-buffer wrap-around (up to two direct
       reads) and writes directly into the sink's frame buffer using the new
       queue API. This completely eliminates intermediate `DecodedAudio` heap
       allocations and reduces memory copies by 50% in the steady state.
    3. Clean dispatch in `AppendAudioToFrameBuffer` which delegates to the new
       helper if bypass is active, keeping the main rendering loop extremely
       clean and leaving the complex `AudioTimeStretcher` class 100% untouched.
    
    To support this cleanly:
    - Introduced a `BypassContext` struct wrapped in a `std::optional` to
      encapsulate all bypass-specific state (the queue and bytes per frame).
      This serves as the single source of truth for the bypass state, ensuring a
      clean lifecycle and no redundant member variables.
    - Implemented one-way transition logic in `SetPlaybackRate` to seamlessly
      exit bypass mode and move all buffered frames to the TimeStretcher if the
      playback rate changes mid-stream.
    - Maintained a 50% preroll buffer cap for the bypass path, allowing video
      playback to start twice as fast as the legacy path during startup/seeking.
    
    Added a comprehensive unit test `TransitionFromBypassToNonBypass` to verify
    the transition logic, and updated existing tests to assert the bypass state.

    Issue: 518914404
