### PR TITLE
Media: Default enable Android audio capture fast track

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -36,9 +36,6 @@ public class JavaSwitches {
   /** flag to delete stale leveldb LOCK file on startup. */
   public static final String LOCAL_STORAGE_DELETE_LOCK_FILE = "LocalStorageDeleteLockFile";
 
-  /** flag to enable fast track mic capture. */
-  public static final String ENABLE_COBALT_AUDIO_CAPTURE_FAST_TRACK = "EnableCobaltAudioCaptureFastTrack";
-
   /** flag to tune compositor offscreen interest area size in pixels. */
   public static final String INTEREST_AREA_SIZE_IN_PIXELS = "InterestAreaSizeInPixels";
 
@@ -82,10 +79,6 @@ public class JavaSwitches {
 
     if (!javaSwitches.containsKey(JavaSwitches.ENABLE_QUIC)) {
       extraCommandLineArgs.add("--disable-quic");
-    }
-
-    if (javaSwitches.containsKey(JavaSwitches.ENABLE_COBALT_AUDIO_CAPTURE_FAST_TRACK)) {
-      extraCommandLineArgs.add("--enable-features=CobaltAudioCaptureFastTrack");
     }
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_HTTP_CACHE)) {

--- a/content/browser/renderer_host/media/media_stream_manager.cc
+++ b/content/browser/renderer_host/media/media_stream_manager.cc
@@ -110,7 +110,7 @@
 #if BUILDFLAG(IS_ANDROID)
 #include "media/audio/android/starboard_audio_input_stream.h"
 #endif
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 using ::blink::mojom::MediaDeviceType;
 
@@ -2661,7 +2661,7 @@ void MediaStreamManager::SetUpRequest(const std::string& label) {
 #endif
     return;
   }
-#endif
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   const bool is_display_capture =
       request->video_type() == MediaStreamType::DISPLAY_VIDEO_CAPTURE ||
@@ -2792,7 +2792,7 @@ void MediaStreamManager::CompleteFastTrackSetUp(
   HandleAccessRequestResponse(label, params, stream_devices_set,
                               blink::mojom::MediaStreamRequestResult::OK);
 }
-#endif
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 bool MediaStreamManager::SetUpDisplayCaptureRequest(DeviceRequest* request) {
   DCHECK_CURRENTLY_ON(BrowserThread::IO);

--- a/content/browser/renderer_host/media/media_stream_manager.cc
+++ b/content/browser/renderer_host/media/media_stream_manager.cc
@@ -2640,8 +2640,7 @@ void MediaStreamManager::SetUpRequest(const std::string& label) {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   // FAST-TRACK for Cobalt Audio Capture
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack) &&
-      request->audio_type() == MediaStreamType::DEVICE_AUDIO_CAPTURE &&
+  if (request->audio_type() == MediaStreamType::DEVICE_AUDIO_CAPTURE &&
       request->video_type() == MediaStreamType::NO_SERVICE) {
     LOG(INFO) << "SetUpRequest: FAST-TRACKING Cobalt Audio Request";
 

--- a/media/audio/android/README_STARBOARD.md
+++ b/media/audio/android/README_STARBOARD.md
@@ -1,0 +1,71 @@
+# Starboard Low Latency Microphone Path (Android)
+
+This document describes the low-latency microphone capture path implemented for Cobalt on Android, also known as the "Fast-Track" microphone path.
+
+Reference Bug: [b/483713292](https://b.corp.google.com/issues/483713292)
+
+---
+
+## Overview
+
+The standard Chromium audio capture path on Android suffered from severe, unusable latency (taking up to 7 seconds for the microphone to become ready). This rendered voice search effectively broken, as the first few syllables spoken by the user were consistently lost, and the delayed initialization often led to unusable search results.
+
+### Cobalt-Specific Constraints
+The latency was exceptionally severe in Cobalt due to a combination of platform factors:
+*   **Resource-Constrained Devices:** Cobalt runs on low-end Living Room devices (Smart TVs, TV boxes, dongles) with limited CPU and memory.
+*   **Single-Process Architecture:** Cobalt runs in single-process mode. While Chromium's IPC (Mojo) is still used for modularity, it translates to inter-thread communication within the same process.
+*   **Main Thread Contention:** The overhead of thread-switching and message serialization, combined with heavy JavaScript execution on the main thread, created severe CPU contention. This delayed the processing of audio IPC messages, compounding the initialization latency.
+
+To resolve this, Starboard implements a **"Fast-Track"** audio capture path that:
+1.  **Pre-starts** the audio hardware recording asynchronously as soon as the user media request is initiated.
+2.  **Resolves the JavaScript promise immediately**, allowing the UI to transition to the "Listening" state instantly while the hardware is still warming up.
+3.  **Bypasses complex channel/sample-rate negotiations** by hardcoding parameters to **16kHz Mono** (Starboard spec).
+4.  **Bypasses JS-side downsampling** by forcing the WebAudio context to 16kHz Mono end-to-end.
+
+---
+
+## Architectural Details
+
+### 1. Initiation and Fast-Track Setup (`MediaStreamManager`)
+When the web application calls `navigator.mediaDevices.getUserMedia({audio: true, video: false})`, the request is handled by `MediaStreamManager::SetUpRequest` on the Browser IO thread.
+
+*   **Detection:** If the request is audio-only and `USE_STARBOARD_MEDIA` is enabled, it is routed to the fast-track path.
+*   **Permission Check:** On Android, we post a task to request OS-level runtime permission (`StarboardAudioInputStream::RequestRuntimePermission`) on the UI thread.
+*   **Pre-Starting Hardware:** If permission is granted, `MediaStreamManager::CompleteFastTrackSetUp` is called:
+    *   It hardcodes the audio parameters to **16kHz Mono** (PCM Low Latency, 16000Hz, 1024 samples per buffer).
+    *   It generates a unique `session_token` and encodes it into the `device_id` as `fast-track-<session_token>`.
+    *   It calls `AudioManager::PreStartStream(session_token, params)` to warm up the hardware.
+    *   It immediately calls `HandleAccessRequestResponse` with `OK`, resolving the JS `getUserMedia()` promise before the hardware is fully ready.
+
+### 2. Pre-Starting the Stream (`AudioManagerAndroid`)
+In `AudioManagerAndroid::PreStartStream`:
+*   It creates a `PreStartedEntry` in the `pre_started_streams_` map, keyed by the `session_id`.
+*   It instantiates a `StarboardAudioInputStream` and calls `Open()` on it.
+*   `StarboardAudioInputStream::Open()` immediately initializes OpenSL ES and starts the hardware recorder (`SL_RECORDSTATE_RECORDING`).
+*   Once opened, the stream is parked in the `PreStartedEntry` and the `open_event` is signaled.
+
+### 3. Consuming the Pre-started Stream
+When the web application attaches the returned media stream to a WebAudio node or MediaRecorder, the renderer process initiates an IPC connection to create the audio input stream.
+
+*   The IPC request carries the `device_id` containing the `fast-track-<session_id>` prefix.
+*   `AudioManagerAndroid::MakeAudioInputStream` intercepts this request, extracts the `session_id`, and retrieves the parked `PreStartedEntry` from the map.
+*   It waits for the `open_event` to ensure the hardware is open, and then returns the pre-started stream directly, avoiding any additional warmup delay.
+
+---
+
+## Native Implementation (`StarboardAudioInputStream`)
+
+`StarboardAudioInputStream` is a simplified version of Chromium's `OpenSLESInputStream` specifically optimized for Cobalt:
+*   **Fixed Format:** Hardcoded to 16kHz Mono PCM.
+*   **Audio Preset:** Uses `SL_ANDROID_RECORDING_PRESET_VOICE_RECOGNITION` for recording. This preset is **critical** on Google Android TV (ATV) devices (such as Chromecast/Kirkwood) because it triggers the Android system's dynamic audio routing. This routing is required to start the remote service (`go/atv-remote-service`) which captures audio from Bluetooth Low Energy (BLE) remote control microphones.
+*   **Immediate Start:** Starts hardware recording in `Open()` rather than waiting for `Start()`.
+
+---
+
+## Optimizations (Feature Flag: `kCobaltAudioCaptureFastTrack`)
+
+When `media::kCobaltAudioCaptureFastTrack` is enabled, several end-to-end optimizations are activated:
+
+1.  **WebAudio Context Alignment:** `AudioContext::Create` forces the default sample rate to **16kHz** if no rate is specified. This aligns the JS engine with the native 16kHz capture, completely bypassing the heavy `OfflineAudioContext` downsampling that the YouTube application normally performs in JavaScript.
+2.  **Mono End-to-End:** `WebAudioMediaStreamAudioSink` and `MediaStreamAudioSourceHandler` are forced to Mono mode, preventing latency-inducing channel upmixers in Chromium.
+3.  **Increased Buffer Queue:** `AudioInputDevice` increases the shared memory segment count from 10 to **32** (`kStarboardRequestedSharedMemoryCount`). This larger queue prevents audio glitches and dropouts caused by renderer thread jank.

--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -616,8 +616,7 @@ AudioInputStream* AudioManagerAndroid::MakeLinearInputStream(
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   return new StarboardAudioInputStream(this, params);
-#endif
-
+#else
   if (__builtin_available(android AAUDIO_MIN_API, *)) {
     if (UseAAudioInput()) {
       std::optional<AudioDevice> device =
@@ -634,6 +633,7 @@ AudioInputStream* AudioManagerAndroid::MakeLinearInputStream(
 #else
   return nullptr;
 #endif
+#endif
 }
 
 AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
@@ -645,7 +645,7 @@ AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
   DCHECK_EQ(AudioParameters::AUDIO_PCM_LOW_LATENCY, params.format());
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   return new StarboardAudioInputStream(this, params);
-#endif
+#else
   DLOG_IF(ERROR, device_id.empty()) << "Invalid device ID!";
 
   if (!UseAAudioPerStreamDeviceSelection()) {
@@ -678,6 +678,7 @@ AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
   return new OpenSLESInputStream(this, params);
 #else
   return nullptr;
+#endif
 #endif
 }
 

--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -616,7 +616,9 @@ AudioInputStream* AudioManagerAndroid::MakeLinearInputStream(
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   return new StarboardAudioInputStream(this, params);
-#else
+#endif
+
+#if !BUILDFLAG(USE_STARBOARD_MEDIA)
   if (__builtin_available(android AAUDIO_MIN_API, *)) {
     if (UseAAudioInput()) {
       std::optional<AudioDevice> device =
@@ -645,7 +647,9 @@ AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
   DCHECK_EQ(AudioParameters::AUDIO_PCM_LOW_LATENCY, params.format());
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   return new StarboardAudioInputStream(this, params);
-#else
+#endif
+
+#if !BUILDFLAG(USE_STARBOARD_MEDIA)
   DLOG_IF(ERROR, device_id.empty()) << "Invalid device ID!";
 
   if (!UseAAudioPerStreamDeviceSelection()) {

--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -42,12 +42,12 @@
 #include "media/audio/android/starboard_audio_input_stream.h"
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wunused-function"
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "media/base/android/media_jni_headers/AudioManagerAndroid_jni.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #pragma clang diagnostic pop
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 using base::android::AppendJavaStringArrayToStringVector;
 using base::android::AttachCurrentThread;
@@ -71,7 +71,7 @@ const int kMaxOutputStreams = 10;
 [[maybe_unused]] const int kDefaultInputBufferSize = 1024;
 #else
 const int kDefaultInputBufferSize = 1024;
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 const int kDefaultOutputBufferSize = 2048;
 
 void AddDefaultDevice(AudioDeviceNames* device_names) {
@@ -162,7 +162,7 @@ void AudioManagerAndroid::ShutdownOnAudioThread() {
       it.second->stream->Close();
     }
   }
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   AudioManagerBase::ShutdownOnAudioThread();
 
@@ -328,7 +328,7 @@ void AudioManagerAndroid::GetDeviceNames(AudioDeviceNames* device_names,
     DVLOG(1) << "device_name: " << d.device_name;
     DVLOG(1) << "unique_id: " << d.unique_id;
   }
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 std::optional<AudioDevice> AudioManagerAndroid::GetDeviceForAAudioStream(
@@ -404,7 +404,7 @@ AudioParameters AudioManagerAndroid::GetInputStreamParameters(
   params.set_effects(effects);
   DVLOG(1) << params.AsHumanReadableString();
   return params;
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 const std::string_view AudioManagerAndroid::GetName() {
@@ -466,7 +466,7 @@ AudioInputStream* AudioManagerAndroid::MakeAudioInputStream(
   }
 #else
   bool has_input_streams = !HasNoAudioInputStreams();
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   AudioInputStream* stream = AudioManagerBase::MakeAudioInputStream(
       params, device_id, AudioManager::LogCallback());
 
@@ -503,7 +503,7 @@ AudioInputStream* AudioManagerAndroid::MakeAudioInputStream(
     SetCommunicationAudioModeOn(true);
   }
   return stream;
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 void AudioManagerAndroid::ReleaseOutputStream(AudioOutputStream* stream) {
@@ -527,7 +527,7 @@ void AudioManagerAndroid::ReleaseInputStream(AudioInputStream* stream) {
       }
     }
   }
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   AudioManagerBase::ReleaseInputStream(stream);
 
@@ -538,7 +538,7 @@ void AudioManagerAndroid::ReleaseInputStream(AudioInputStream* stream) {
     communication_mode_is_on_ = false;
     SetCommunicationAudioModeOn(false);
   }
-#endif
+#endif // !BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 AudioOutputStream* AudioManagerAndroid::MakeLinearOutputStream(
@@ -616,7 +616,7 @@ AudioInputStream* AudioManagerAndroid::MakeLinearInputStream(
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   return new StarboardAudioInputStream(this, params);
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #if !BUILDFLAG(USE_STARBOARD_MEDIA)
   if (__builtin_available(android AAUDIO_MIN_API, *)) {
@@ -647,7 +647,7 @@ AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
   DCHECK_EQ(AudioParameters::AUDIO_PCM_LOW_LATENCY, params.format());
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   return new StarboardAudioInputStream(this, params);
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #if !BUILDFLAG(USE_STARBOARD_MEDIA)
   DLOG_IF(ERROR, device_id.empty()) << "Invalid device ID!";
@@ -820,7 +820,7 @@ const JavaRef<jobject>& AudioManagerAndroid::GetJavaAudioManager() {
     // notifications.
     Java_AudioManagerAndroid_init(base::android::AttachCurrentThread(),
                                   j_audio_manager_);
-#endif
+#endif // !BUILDFLAG(USE_STARBOARD_MEDIA)
   }
   return j_audio_manager_;
 }
@@ -830,7 +830,7 @@ void AudioManagerAndroid::SetCommunicationAudioModeOn(bool on) {
 #if !BUILDFLAG(USE_STARBOARD_MEDIA)
   Java_AudioManagerAndroid_setCommunicationAudioModeOn(
       base::android::AttachCurrentThread(), GetJavaAudioManager(), on);
-#endif
+#endif // !BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 bool AudioManagerAndroid::SetCommunicationDevice(const std::string& device_id) {
@@ -849,7 +849,7 @@ bool AudioManagerAndroid::SetCommunicationDevice(const std::string& device_id) {
                                                                  : device_id);
   return Java_AudioManagerAndroid_setCommunicationDevice(
       env, GetJavaAudioManager(), j_device_id);
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 bool AudioManagerAndroid::IsBluetoothScoOn() {
@@ -925,7 +925,7 @@ void AudioManagerAndroid::PreStartStream(
 
 AudioManagerAndroid::PreStartedEntry::PreStartedEntry() = default;
 AudioManagerAndroid::PreStartedEntry::~PreStartedEntry() = default;
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 int AudioManagerAndroid::GetNativeOutputSampleRate() {
   return Java_AudioManagerAndroid_getNativeOutputSampleRate(

--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -634,8 +634,8 @@ AudioInputStream* AudioManagerAndroid::MakeLinearInputStream(
   return new OpenSLESInputStream(this, params);
 #else
   return nullptr;
-#endif
-#endif
+#endif  // BUILDFLAG(USE_OPENSLES)
+#endif  // !BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
@@ -682,8 +682,8 @@ AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
   return new OpenSLESInputStream(this, params);
 #else
   return nullptr;
-#endif
-#endif
+#endif  // BUILDFLAG(USE_OPENSLES)
+#endif  // !BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 void AudioManagerAndroid::OnStartAAudioInputStream(AAudioInputStream* stream) {

--- a/media/audio/android/audio_manager_android.cc
+++ b/media/audio/android/audio_manager_android.cc
@@ -433,8 +433,7 @@ AudioInputStream* AudioManagerAndroid::MakeAudioInputStream(
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   // Check if this is a fast-track request by checking for our special prefix.
   static constexpr char kFastTrackPrefix[] = "fast-track-";
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack) &&
-      base::StartsWith(device_id, kFastTrackPrefix)) {
+  if (base::StartsWith(device_id, kFastTrackPrefix)) {
     std::string session_id = device_id.substr(sizeof(kFastTrackPrefix) -1);
     std::unique_ptr<PreStartedEntry> entry;
     {
@@ -616,9 +615,7 @@ AudioInputStream* AudioManagerAndroid::MakeLinearInputStream(
   DCHECK_EQ(AudioParameters::AUDIO_PCM_LINEAR, params.format());
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)) {
-    return new StarboardAudioInputStream(this, params);
-  }
+  return new StarboardAudioInputStream(this, params);
 #endif
 
   if (__builtin_available(android AAUDIO_MIN_API, *)) {
@@ -647,9 +644,7 @@ AudioInputStream* AudioManagerAndroid::MakeLowLatencyInputStream(
   DCHECK(GetTaskRunner()->BelongsToCurrentThread());
   DCHECK_EQ(AudioParameters::AUDIO_PCM_LOW_LATENCY, params.format());
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)) {
-    return new StarboardAudioInputStream(this, params);
-  }
+  return new StarboardAudioInputStream(this, params);
 #endif
   DLOG_IF(ERROR, device_id.empty()) << "Invalid device ID!";
 

--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -43,7 +43,7 @@ namespace {
 const int kRequestedSharedMemoryCount = 10;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 const int kStarboardRequestedSharedMemoryCount = 32;
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 // The number of seconds with missing callbacks before we report a capture
 // error. The value is based on that the Mac audio implementation can defer
@@ -145,7 +145,7 @@ void AudioInputDevice::Initialize(const AudioParameters& params,
   DCHECK(!callback_);
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   LOG(INFO) << "AudioInputDevice::Initialize: params=" << params.AsHumanReadableString();
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   audio_parameters_ = params;
   callback_ = callback;
 }
@@ -163,7 +163,7 @@ void AudioInputDevice::Start() {
   int segment_count = kRequestedSharedMemoryCount;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   segment_count = kStarboardRequestedSharedMemoryCount;
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   ipc_->CreateStream(this, audio_parameters_, agc_is_enabled_, segment_count);
 }
 
@@ -308,7 +308,7 @@ void AudioInputDevice::OnStreamCreated(
   int segment_count = kRequestedSharedMemoryCount;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   segment_count = kStarboardRequestedSharedMemoryCount;
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   audio_callback_ = std::make_unique<AudioInputDevice::AudioThreadCallback>(
       audio_parameters_, std::move(shared_memory_region),
       segment_count, enable_uma_, callback_,

--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -162,9 +162,7 @@ void AudioInputDevice::Start() {
   state_ = CREATING_STREAM;
   int segment_count = kRequestedSharedMemoryCount;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)) {
-    segment_count = kStarboardRequestedSharedMemoryCount;
-  }
+  segment_count = kStarboardRequestedSharedMemoryCount;
 #endif
   ipc_->CreateStream(this, audio_parameters_, agc_is_enabled_, segment_count);
 }
@@ -309,9 +307,7 @@ void AudioInputDevice::OnStreamCreated(
 
   int segment_count = kRequestedSharedMemoryCount;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)) {
-    segment_count = kStarboardRequestedSharedMemoryCount;
-  }
+  segment_count = kStarboardRequestedSharedMemoryCount;
 #endif
   audio_callback_ = std::make_unique<AudioInputDevice::AudioThreadCallback>(
       audio_parameters_, std::move(shared_memory_region),

--- a/media/audio/audio_input_device_unittest.cc
+++ b/media/audio/audio_input_device_unittest.cc
@@ -117,7 +117,7 @@ class AudioInputDeviceTest
     size_t segment_count = kMemorySegmentCount;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
     segment_count = 32u;
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
     const uint32_t memory_size =
         ComputeAudioInputBufferSize(params, segment_count);

--- a/media/audio/audio_input_device_unittest.cc
+++ b/media/audio/audio_input_device_unittest.cc
@@ -116,9 +116,7 @@ class AudioInputDeviceTest
 
     size_t segment_count = kMemorySegmentCount;
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-    if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)) {
-      segment_count = 32u;
-    }
+    segment_count = 32u;
 #endif
 
     const uint32_t memory_size =

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -513,7 +513,6 @@ BASE_FEATURE(kCobaltUsingAndroidOverlay,
              "CobaltUsingAndroidOverlay",
              base::FEATURE_DISABLED_BY_DEFAULT);
 #endif  // BUILDFLAG(IS_ANDROID)
-
 // Bypass Mojo for media pipeline in Cobalt single-process mode.
 BASE_FEATURE(kCobaltBypassMojoForMedia,
              "CobaltBypassMojoForMedia",

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -513,9 +513,7 @@ BASE_FEATURE(kCobaltUsingAndroidOverlay,
              "CobaltUsingAndroidOverlay",
              base::FEATURE_DISABLED_BY_DEFAULT);
 #endif  // BUILDFLAG(IS_ANDROID)
-BASE_FEATURE(kCobaltAudioCaptureFastTrack,
-             "CobaltAudioCaptureFastTrack",
-             base::FEATURE_DISABLED_BY_DEFAULT);
+
 // Bypass Mojo for media pipeline in Cobalt single-process mode.
 BASE_FEATURE(kCobaltBypassMojoForMedia,
              "CobaltBypassMojoForMedia",

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -231,7 +231,6 @@ MEDIA_EXPORT extern const base::FeatureParam<base::TimeDelta> kAudioWriteDuratio
 #if BUILDFLAG(IS_ANDROID)
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingAndroidOverlay);
 #endif  // BUILDFLAG(IS_ANDROID)
-
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltBypassMojoForMedia);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 #if BUILDFLAG(IS_CHROMEOS)

--- a/media/base/media_switches.h
+++ b/media/base/media_switches.h
@@ -231,7 +231,7 @@ MEDIA_EXPORT extern const base::FeatureParam<base::TimeDelta> kAudioWriteDuratio
 #if BUILDFLAG(IS_ANDROID)
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltUsingAndroidOverlay);
 #endif  // BUILDFLAG(IS_ANDROID)
-MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltAudioCaptureFastTrack);
+
 MEDIA_EXPORT BASE_DECLARE_FEATURE(kCobaltBypassMojoForMedia);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 #if BUILDFLAG(IS_CHROMEOS)

--- a/third_party/blink/renderer/modules/mediastream/user_media_processor.cc
+++ b/third_party/blink/renderer/modules/mediastream/user_media_processor.cc
@@ -757,8 +757,7 @@ void UserMediaProcessor::SetupAudioInput() {
 
     SetupVideoInput();
     return;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
+#else
     SendLogMessage(
         base::StringPrintf("SetupAudioInput({request_id=%d}) => "
                            "(Requesting device capabilities)",
@@ -767,6 +766,7 @@ void UserMediaProcessor::SetupAudioInput() {
     GetMediaDevicesDispatcher()->GetAudioInputCapabilities(
         WTF::BindOnce(&UserMediaProcessor::SelectAudioDeviceSettings,
                       WrapWeakPersistent(this), WrapPersistent(request)));
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   } else {
     if (!blink::IsAudioInputMediaType(audio_controls.stream_type)) {
       String failed_constraint_name = String(

--- a/third_party/blink/renderer/modules/mediastream/user_media_processor.cc
+++ b/third_party/blink/renderer/modules/mediastream/user_media_processor.cc
@@ -722,43 +722,41 @@ void UserMediaProcessor::SetupAudioInput() {
 
   if (blink::IsDeviceMediaType(audio_controls.stream_type)) {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-    if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)) {
-      SendLogMessage(
-          base::StringPrintf("Cobalt: SetupAudioInput({request_id=%d}) => "
-                             "(Shortcut handshake, hardcoding capabilities)",
-                             current_request_info_->request_id()));
-      
-      // Force-disable all native processing to get a "Straight Pipe" at 16kHz.
-      // This prevents the WebRtcAudioProcessor from forcing a downsample.
-      blink::AudioProcessingProperties properties;
-      properties.DisableDefaultProperties();
-      properties.echo_cancellation_type = 
-          blink::AudioProcessingProperties::EchoCancellationType::kEchoCancellationDisabled;
+    SendLogMessage(
+        base::StringPrintf("Cobalt: SetupAudioInput({request_id=%d}) => "
+                           "(Shortcut handshake, hardcoding capabilities)",
+                           current_request_info_->request_id()));
+    
+    // Force-disable all native processing to get a "Straight Pipe" at 16kHz.
+    // This prevents the WebRtcAudioProcessor from forcing a downsample.
+    blink::AudioProcessingProperties properties;
+    properties.DisableDefaultProperties();
+    properties.echo_cancellation_type = 
+        blink::AudioProcessingProperties::EchoCancellationType::kEchoCancellationDisabled;
 
-      // Manually construct the settings to bypass the SelectSettingsAudioCapture algorithm
-      // and its default processing dependencies.
-      blink::AudioCaptureSettings settings(
-          "default", /*requested_buffer_size=*/cobalt::media::kSamplesPerBuffer,
-          /*disable_local_echo=*/false,
-          /*enable_automatic_output_device_selection=*/false,
-          blink::AudioCaptureSettings::ProcessingType::kUnprocessed,
-          properties, /*num_channels=*/1);
+    // Manually construct the settings to bypass the SelectSettingsAudioCapture algorithm
+    // and its default processing dependencies.
+    blink::AudioCaptureSettings settings(
+        "default", /*requested_buffer_size=*/cobalt::media::kSamplesPerBuffer,
+        /*disable_local_echo=*/false,
+        /*enable_automatic_output_device_selection=*/false,
+        blink::AudioCaptureSettings::ProcessingType::kUnprocessed,
+        properties, /*num_channels=*/1);
 
-      if (current_request_info_->stream_controls()->audio.stream_type !=
-          MediaStreamType::DISPLAY_AUDIO_CAPTURE) {
-        current_request_info_->stream_controls()->audio.device_ids = {
-            settings.device_id()};
-        current_request_info_->stream_controls()->disable_local_echo =
-            settings.disable_local_echo();
-      }
-      current_request_info_->SetAudioCaptureSettings(
-          settings,
-          !blink::IsDeviceMediaType(
-              current_request_info_->stream_controls()->audio.stream_type));
-
-      SetupVideoInput();
-      return;
+    if (current_request_info_->stream_controls()->audio.stream_type !=
+        MediaStreamType::DISPLAY_AUDIO_CAPTURE) {
+      current_request_info_->stream_controls()->audio.device_ids = {
+          settings.device_id()};
+      current_request_info_->stream_controls()->disable_local_echo =
+          settings.disable_local_echo();
     }
+    current_request_info_->SetAudioCaptureSettings(
+        settings,
+        !blink::IsDeviceMediaType(
+            current_request_info_->stream_controls()->audio.stream_type));
+
+    SetupVideoInput();
+    return;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
     SendLogMessage(

--- a/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
+++ b/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
@@ -38,9 +38,7 @@ WebAudioMediaStreamAudioSink::WebAudioMediaStreamAudioSink(
       platform_buffer_duration_(platform_buffer_duration),
       sink_params_(media::AudioParameters::AUDIO_PCM_LOW_LATENCY,
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-                   base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)
-                       ? media::ChannelLayoutConfig::Mono()
-                       : media::ChannelLayoutConfig::Stereo(),
+                   media::ChannelLayoutConfig::Mono(),
 #else
                    media::ChannelLayoutConfig::Stereo(),
 #endif

--- a/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
+++ b/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
@@ -19,7 +19,7 @@
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "base/feature_list.h"
 #include "media/base/media_switches.h"
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace blink {
 
@@ -41,13 +41,13 @@ WebAudioMediaStreamAudioSink::WebAudioMediaStreamAudioSink(
                    media::ChannelLayoutConfig::Mono(),
 #else
                    media::ChannelLayoutConfig::Stereo(),
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
                    context_sample_rate,
                    kWebAudioRenderBufferSize)
 {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   LOG(INFO) << "WebAudioMediaStreamAudioSink: sink_params=" << sink_params_.AsHumanReadableString();
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   CHECK(sink_params_.IsValid());
   CHECK_GT(platform_buffer_duration_, base::TimeDelta());
 

--- a/third_party/blink/renderer/modules/webaudio/audio_context.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_context.cc
@@ -64,7 +64,7 @@
 #include "base/feature_list.h"
 #include "media/base/media_switches.h"
 #include "cobalt/media/audio/audio_input_constants.h"
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace blink {
 
@@ -224,7 +224,7 @@ AudioContext* AudioContext::Create(ExecutionContext* context,
       WebAudioSinkDescriptor(frame_token);
 #else
       WebAudioSinkDescriptor(g_empty_string, frame_token);
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   // In order to not break echo cancellation of PeerConnection audio, we must
   // not update the echo cancellation reference unless the sink ID is explicitly
   // specified.

--- a/third_party/blink/renderer/modules/webaudio/audio_context.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_context.cc
@@ -211,8 +211,7 @@ AudioContext* AudioContext::Create(ExecutionContext* context,
   // Force 16kHz default for Cobalt if no rate is specified.
   // This aligns the JS engine with the native "Straight Pipe" 16kHz hardware capture,
   // bypassing the heavy OfflineAudioContext downsampling in the YouTube application.
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack) &&
-      !sample_rate.has_value()) {
+  if (!sample_rate.has_value()) {
     sample_rate = cobalt::media::kSampleRate;
     LOG(INFO) << "Cobalt: Force-set sample rate to " << sample_rate.value();
   }
@@ -222,9 +221,7 @@ AudioContext* AudioContext::Create(ExecutionContext* context,
   auto frame_token = window.GetLocalFrameToken();
   WebAudioSinkDescriptor sink_descriptor =
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-      base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)
-          ? WebAudioSinkDescriptor(frame_token)
-          : WebAudioSinkDescriptor(g_empty_string, frame_token);
+      WebAudioSinkDescriptor(frame_token);
 #else
       WebAudioSinkDescriptor(g_empty_string, frame_token);
 #endif

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
@@ -40,21 +40,15 @@ MediaStreamAudioSourceHandler::MediaStreamAudioSourceHandler(
   SendLogMessage(__func__, "");
   
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  unsigned default_channels = kDefaultNumberOfOutputChannels;
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)) {
-    default_channels = 1;
-  }
-  AddOutput(default_channels);
+  AddOutput(1);
 #else
   AddOutput(kDefaultNumberOfOutputChannels);
 #endif
 
   // Force Mono mode end-to-end for Starboard to avoid latency-inducing upmixers.
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack)) {
-    SetInternalChannelCountMode(V8ChannelCountMode::Enum::kExplicit);
-    channel_count_ = 1;
-  }
+  SetInternalChannelCountMode(V8ChannelCountMode::Enum::kExplicit);
+  channel_count_ = 1;
 #endif
 
   Initialize();

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
@@ -15,7 +15,7 @@
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "base/feature_list.h"
 #include "media/base/media_switches.h"
-#endif
+#endif //BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace blink {
 
@@ -23,9 +23,11 @@ namespace {
 
 // Default to stereo. This could change depending on the format of the
 // MediaStream's audio track.
-#if !BUILDFLAG(USE_STARBOARD_MEDIA)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+constexpr unsigned kDefaultNumberOfOutputChannels = 1;
+#else
 constexpr unsigned kDefaultNumberOfOutputChannels = 2;
-#endif
+#endif //BUILDFLAG(USE_STARBOARD_MEDIA)
 
 // Default to mono for Cobalt/Starboard to avoid latency-inducing upmixing.
 // Standard Chromium defaults to stereo.
@@ -41,17 +43,13 @@ MediaStreamAudioSourceHandler::MediaStreamAudioSourceHandler(
       audio_source_provider_(std::move(audio_source_provider)) {
   SendLogMessage(__func__, "");
   
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  AddOutput(1);
-#else
   AddOutput(kDefaultNumberOfOutputChannels);
-#endif
 
   // Force Mono mode end-to-end for Starboard to avoid latency-inducing upmixers.
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   SetInternalChannelCountMode(V8ChannelCountMode::Enum::kExplicit);
   channel_count_ = 1;
-#endif
+#endif //BUILDFLAG(USE_STARBOARD_MEDIA)
 
   Initialize();
 }
@@ -75,7 +73,7 @@ void MediaStreamAudioSourceHandler::SetFormat(uint32_t number_of_channels,
   LOG(INFO) << "MediaStreamAudioSourceHandler::SetFormat: "
             << "channels=" << number_of_channels
             << ", rate=" << source_sample_rate;
-#endif
+#endif //BUILDFLAG(USE_STARBOARD_MEDIA)
   SendLogMessage(
       __func__,
       String::Format("({number_of_channels=%u}, {source_sample_rate=%0.f})",

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
@@ -15,7 +15,7 @@
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "base/feature_list.h"
 #include "media/base/media_switches.h"
-#endif //BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace blink {
 
@@ -27,7 +27,7 @@ namespace {
 constexpr unsigned kDefaultNumberOfOutputChannels = 1;
 #else
 constexpr unsigned kDefaultNumberOfOutputChannels = 2;
-#endif //BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 // Default to mono for Cobalt/Starboard to avoid latency-inducing upmixing.
 // Standard Chromium defaults to stereo.
@@ -49,7 +49,7 @@ MediaStreamAudioSourceHandler::MediaStreamAudioSourceHandler(
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   SetInternalChannelCountMode(V8ChannelCountMode::Enum::kExplicit);
   channel_count_ = 1;
-#endif //BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   Initialize();
 }
@@ -73,7 +73,7 @@ void MediaStreamAudioSourceHandler::SetFormat(uint32_t number_of_channels,
   LOG(INFO) << "MediaStreamAudioSourceHandler::SetFormat: "
             << "channels=" << number_of_channels
             << ", rate=" << source_sample_rate;
-#endif //BUILDFLAG(USE_STARBOARD_MEDIA)
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
   SendLogMessage(
       __func__,
       String::Format("({number_of_channels=%u}, {source_sample_rate=%0.f})",

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
@@ -23,7 +23,9 @@ namespace {
 
 // Default to stereo. This could change depending on the format of the
 // MediaStream's audio track.
+#if !BUILDFLAG(USE_STARBOARD_MEDIA)
 constexpr unsigned kDefaultNumberOfOutputChannels = 2;
+#endif
 
 // Default to mono for Cobalt/Starboard to avoid latency-inducing upmixing.
 // Standard Chromium defaults to stereo.

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
@@ -110,9 +110,7 @@ MediaStreamAudioSourceNode* MediaStreamAudioSourceNode::Create(
 
   // Initializes the node with the stereo output channel.
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  node->SetFormat(
-      base::FeatureList::IsEnabled(media::kCobaltAudioCaptureFastTrack) ? 1 : 2,
-      context.sampleRate());
+  node->SetFormat(1, context.sampleRate());
 #else
   node->SetFormat(2, context.sampleRate());
 #endif

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
@@ -36,7 +36,7 @@
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "base/feature_list.h"
 #include "media/base/media_switches.h"
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 
 namespace blink {
@@ -113,7 +113,7 @@ MediaStreamAudioSourceNode* MediaStreamAudioSourceNode::Create(
   node->SetFormat(1, context.sampleRate());
 #else
   node->SetFormat(2, context.sampleRate());
-#endif
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Lets the context know this source node started.
   context.NotifySourceNodeStartedProcessing(node);


### PR DESCRIPTION
The low-latency fast track for Cobalt audio capture on Android was
previously introduced behind a feature flag. (https://github.com/youtube/cobalt/pull/9978)
Following successful experimentation that showed improvements across 
several metrics, this change removes the flag and enables the fast track
by default.

This update hardcodes the use of StarboardAudioInputStream and
configures a 16kHz mono layout for Starboard-based media capture.
This bypasses heavy processing and upmixing in the WebAudio and
MediaStream layers to minimize latency.


Bug: 483713292