### PR TITLE
starboard: Fix & optimize WSOLA DotProduct

### DIFF
--- a/starboard/shared/starboard/experimental_features.cc
+++ b/starboard/shared/starboard/experimental_features.cc
@@ -62,7 +62,7 @@ void SetExperimentalFeaturesForCurrentThread(
   experimental_features = ExperimentalFeatures(std::move(map));
 
   if (experimental_features->GetBool(
-          kMediaEnableSimdBasedAudioFormatSwitching)) {
+          kMediaEnableDecodedAudioSimdOptimizations)) {
     DecodedAudio::EnableSimdBasedAudioFormatSwitching();
   }
 }

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -164,15 +164,15 @@ inline constexpr ExperimentalFeatureKey<bool> kMediaEnableAppProvisioning(
 inline constexpr ExperimentalFeatureKey<bool>
     kMediaEnableAv1StartupOptimization("Media.EnableAv1StartupOptimization");
 
+inline constexpr ExperimentalFeatureKey<bool>
+    kMediaEnableDecodedAudioSimdOptimizations(
+        "Media.EnableDecodedAudioSimdOptimizations");
+
 inline constexpr ExperimentalFeatureKey<bool> kMediaEnableFlushDuringSeek(
     "Media.EnableFlushDuringSeek");
 
 inline constexpr ExperimentalFeatureKey<bool> kMediaEnableResetAudioDecoder(
     "Media.EnableResetAudioDecoder");
-
-inline constexpr ExperimentalFeatureKey<bool>
-    kMediaEnableSimdBasedAudioFormatSwitching(
-        "Media.EnableSimdBasedAudioFormatSwitching");
 
 inline constexpr ExperimentalFeatureKey<bool> kMediaEnableTrivialOptimizations(
     "Media.EnableTrivialOptimizations");

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.cc
@@ -79,6 +79,8 @@ AudioRendererPcm::AudioRendererPcm(
       min_frames_per_append_(min_frames_per_append),
       allow_audio_writing_on_pause_(
           experimental_features.GetBool(kMediaAllowAudioWritingOnPause)),
+      enable_decoded_audio_simd_optimizations_(experimental_features.GetBool(
+          kMediaEnableDecodedAudioSimdOptimizations)),
       decoder_(std::move(decoder)),
       frames_consumed_set_at_(CurrentMonotonicTime()),
       channels_(audio_stream_info.number_of_channels),
@@ -578,7 +580,8 @@ void AudioRendererPcm::OnFirstOutput(
       audio_renderer_sink_->GetNearestSupportedSampleFrequency(
           *decoder_sample_rate_);
   time_stretcher_.Initialize(kSbMediaAudioSampleTypeFloat32, channels_,
-                             destination_sample_rate);
+                             destination_sample_rate,
+                             enable_decoded_audio_simd_optimizations_);
 
   buffered_frames_to_start_ = std::min(
       destination_sample_rate / 5, max_cached_frames_ - min_frames_per_append_);

--- a/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_pcm_internal.h
@@ -109,6 +109,7 @@ class AudioRendererPcm : public AudioRenderer,
   const int max_cached_frames_;
   const int min_frames_per_append_;
   const bool allow_audio_writing_on_pause_;
+  const bool enable_decoded_audio_simd_optimizations_;
   // |buffered_frames_to_start_| would be initialized in OnFirstOutput().
   // Before it's initialized, set it to a large number.
   int buffered_frames_to_start_ = 48 * 1024;

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.cc
@@ -21,12 +21,17 @@
 #include <algorithm>
 #include <cmath>
 #include <cstring>
+#include <memory>
 #include <utility>
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "starboard/shared/starboard/player/filter/wsola_internal.h"
+
+#if (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+#include <arm_neon.h>
+#endif  // (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
 
 namespace starboard {
 
@@ -62,22 +67,22 @@ namespace starboard {
 // Max/min supported playback rates for fast/slow audio. Audio outside of these
 // ranges are muted.
 // Audio at these speeds would sound better under a frequency domain algorithm.
-static const double kMinPlaybackRate = 0.5;
-static const double kMaxPlaybackRate = 4.0;
+constexpr double kMinPlaybackRate = 0.5;
+constexpr double kMaxPlaybackRate = 4.0;
 
 // Overlap-and-add window size in milliseconds.
-static const int kOlaWindowSizeMs = 20;
+constexpr int kOlaWindowSizeMs = 20;
 
 // Size of search interval in milliseconds. The search interval is
 // [-delta delta] around |output_index_| * |playback_rate|. So the search
 // interval is 2 * delta.
-static const int kWsolaSearchIntervalMs = 30;
+constexpr int kWsolaSearchIntervalMs = 30;
 
 // The maximum size in seconds for the |audio_buffer_|. Arbitrarily determined.
-static const int kMaxCapacityInSeconds = 3;
+constexpr int kMaxCapacityInSeconds = 3;
 
 // The minimum size in ms for the |audio_buffer_|. Arbitrarily determined.
-static const int kStartingCapacityInMs = 200;
+constexpr int kStartingCapacityInMs = 200;
 
 AudioTimeStretcher::AudioTimeStretcher()
     : sample_type_(kSbMediaAudioSampleTypeFloat32),
@@ -101,11 +106,20 @@ AudioTimeStretcher::~AudioTimeStretcher() {}
 
 void AudioTimeStretcher::Initialize(SbMediaAudioSampleType sample_type,
                                     int channels,
-                                    int samples_per_second) {
+                                    int samples_per_second,
+                                    bool enable_optimized) {
   SB_DCHECK_GT(samples_per_second, 0);
 
   sample_type_ = sample_type;
   channels_ = channels;
+#if SB_IS(ARCH_X86) || SB_IS(ARCH_X64)
+  // Disable optimizations on x86/x64 because the optimized path is currently
+  // only implemented on ARM (using NEON SIMD). Using it on x86/x64 would fall
+  // back to scalar C++ loops, causing a performance regression for Mono audio.
+  enable_optimized_wsola_ = false;
+#else   // SB_IS(ARCH_X86) || SB_IS(ARCH_X64)
+  enable_optimized_wsola_ = enable_optimized;
+#endif  // SB_IS(ARCH_X86) || SB_IS(ARCH_X64)
   bytes_per_frame_ = GetBytesPerSample(sample_type_) * channels_;
   samples_per_second_ = samples_per_second;
   initial_capacity_ = capacity_ =
@@ -142,10 +156,10 @@ void AudioTimeStretcher::Initialize(SbMediaAudioSampleType sample_type,
   search_block_center_offset_ =
       num_candidate_blocks_ / 2 + (ola_window_size_ / 2 - 1);
 
-  ola_window_.reset(new float[ola_window_size_]);
+  ola_window_ = std::make_unique<float[]>(ola_window_size_);
   GetPeriodicHanningWindow(ola_window_size_, ola_window_.get());
 
-  transition_window_.reset(new float[ola_window_size_ * 2]);
+  transition_window_ = std::make_unique<float[]>(ola_window_size_ * 2);
   GetPeriodicHanningWindow(2 * ola_window_size_, transition_window_.get());
 
   wsola_output_ = new DecodedAudio(
@@ -257,6 +271,99 @@ bool AudioTimeStretcher::IsQueueFull() const {
   return audio_buffer_.frames() >= capacity_;
 }
 
+namespace {
+
+#if (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+void BlendTransitionMono_NEON(float* opt,
+                              const float* target,
+                              const float* w1,
+                              const float* w2,
+                              int size) {
+  const int last_index = size - (size % 4);
+  for (int n = 0; n < last_index; n += 4) {
+    float32x4_t opt_reg = vld1q_f32(opt + n);
+    float32x4_t target_reg = vld1q_f32(target + n);
+    float32x4_t w1_reg = vld1q_f32(w1 + n);
+    float32x4_t w2_reg = vld1q_f32(w2 + n);
+    vst1q_f32(opt + n,
+              vmlaq_f32(vmulq_f32(opt_reg, w1_reg), target_reg, w2_reg));
+  }
+  for (int n = last_index; n < size; ++n) {
+    opt[n] = opt[n] * w1[n] + target[n] * w2[n];
+  }
+}
+
+void BlendTransitionStereo_NEON(float* opt,
+                                const float* target,
+                                const float* w1,
+                                const float* w2,
+                                int size) {
+  const int last_index = size - (size % 2);
+  for (int n = 0; n < last_index; n += 2) {
+    float32x4_t opt_reg = vld1q_f32(opt + n * 2);
+    float32x4_t target_reg = vld1q_f32(target + n * 2);
+    float32x2_t w1_2 = vld1_f32(w1 + n);
+    float32x2_t w2_2 = vld1_f32(w2 + n);
+    float32x2x2_t w1_zip = vzip_f32(w1_2, w1_2);
+    float32x2x2_t w2_zip = vzip_f32(w2_2, w2_2);
+    float32x4_t w1_reg = vcombine_f32(w1_zip.val[0], w1_zip.val[1]);
+    float32x4_t w2_reg = vcombine_f32(w2_zip.val[0], w2_zip.val[1]);
+    vst1q_f32(opt + n * 2,
+              vmlaq_f32(vmulq_f32(opt_reg, w1_reg), target_reg, w2_reg));
+  }
+  for (int n = last_index; n < size; ++n) {
+    opt[n * 2] = opt[n * 2] * w1[n] + target[n * 2] * w2[n];
+    opt[n * 2 + 1] = opt[n * 2 + 1] * w1[n] + target[n * 2 + 1] * w2[n];
+  }
+}
+
+void OverlapAndAddMono_NEON(const float* opt,
+                            float* output,
+                            const float* w_out,
+                            const float* w_opt,
+                            int size) {
+  const int last_index = size - (size % 4);
+  for (int n = 0; n < last_index; n += 4) {
+    float32x4_t out_reg = vld1q_f32(output + n);
+    float32x4_t opt_reg = vld1q_f32(opt + n);
+    float32x4_t w_out_reg = vld1q_f32(w_out + n);
+    float32x4_t w_opt_reg = vld1q_f32(w_opt + n);
+    vst1q_f32(output + n,
+              vmlaq_f32(vmulq_f32(out_reg, w_out_reg), opt_reg, w_opt_reg));
+  }
+  for (int n = last_index; n < size; ++n) {
+    output[n] = output[n] * w_out[n] + opt[n] * w_opt[n];
+  }
+}
+
+void OverlapAndAddStereo_NEON(const float* opt,
+                              float* output,
+                              const float* w_out,
+                              const float* w_opt,
+                              int size) {
+  const int last_index = size - (size % 2);
+  for (int n = 0; n < last_index; n += 2) {
+    float32x4_t out_reg = vld1q_f32(output + n * 2);
+    float32x4_t opt_reg = vld1q_f32(opt + n * 2);
+    float32x2_t w_out_2 = vld1_f32(w_out + n);
+    float32x2_t w_opt_2 = vld1_f32(w_opt + n);
+    float32x2x2_t w_out_zip = vzip_f32(w_out_2, w_out_2);
+    float32x2x2_t w_opt_zip = vzip_f32(w_opt_2, w_opt_2);
+    float32x4_t w_out_reg = vcombine_f32(w_out_zip.val[0], w_out_zip.val[1]);
+    float32x4_t w_opt_reg = vcombine_f32(w_opt_zip.val[0], w_opt_zip.val[1]);
+    vst1q_f32(output + n * 2,
+              vmlaq_f32(vmulq_f32(out_reg, w_out_reg), opt_reg, w_opt_reg));
+  }
+  for (int n = last_index; n < size; ++n) {
+    output[n * 2] = output[n * 2] * w_out[n] + opt[n * 2] * w_opt[n];
+    output[n * 2 + 1] =
+        output[n * 2 + 1] * w_out[n] + opt[n * 2 + 1] * w_opt[n];
+  }
+}
+#endif  // (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+
+}  // namespace
+
 void AudioTimeStretcher::GetOptimalBlock() {
   int optimal_index = 0;
 
@@ -280,7 +387,7 @@ void AudioTimeStretcher::GetOptimalBlock() {
     // |search_block_|.
     optimal_index = OptimalIndex(search_block_.get(), target_block_.get(),
                                  kSbMediaAudioFrameStorageTypeInterleaved,
-                                 exclude_interval);
+                                 exclude_interval, enable_optimized_wsola_);
 
     // Translate |index| w.r.t. the beginning of |audio_buffer_| and extract the
     // optimal block.
@@ -295,14 +402,53 @@ void AudioTimeStretcher::GetOptimalBlock() {
     // as that of the optimal-block which makes it like a weighting function
     // where target-block has higher weight close to zero (weight of 1 at index
     // 0) and lower weight close the end.
-    for (int k = 0; k < channels_; ++k) {
-      float* ch_opt = reinterpret_cast<float*>(optimal_block_->data()) + k;
-      const float* const ch_target =
-          reinterpret_cast<float*>(target_block_->data()) + k;
+    if (enable_optimized_wsola_ && channels_ == 1) {
+      bool handled = false;
+#if (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+      BlendTransitionMono_NEON(
+          optimal_block_->data_as_float32(), target_block_->data_as_float32(),
+          transition_window_.get(), transition_window_.get() + ola_window_size_,
+          ola_window_size_);
+      handled = true;
+#endif  // (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+      if (!handled) {
+        float* opt = optimal_block_->data_as_float32();
+        const float* target = target_block_->data_as_float32();
+        const float* w1 = transition_window_.get();
+        const float* w2 = transition_window_.get() + ola_window_size_;
+        for (int n = 0; n < ola_window_size_; ++n) {
+          opt[n] = opt[n] * w1[n] + target[n] * w2[n];
+        }
+      }
+    } else if (enable_optimized_wsola_ && channels_ == 2) {
+      bool handled = false;
+#if (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+      BlendTransitionStereo_NEON(
+          optimal_block_->data_as_float32(), target_block_->data_as_float32(),
+          transition_window_.get(), transition_window_.get() + ola_window_size_,
+          ola_window_size_);
+      handled = true;
+#endif  // (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+      if (!handled) {
+        float* opt = optimal_block_->data_as_float32();
+        const float* target = target_block_->data_as_float32();
+        const float* w1 = transition_window_.get();
+        const float* w2 = transition_window_.get() + ola_window_size_;
+        for (int n = 0; n < ola_window_size_; ++n) {
+          opt[n * 2] = opt[n * 2] * w1[n] + target[n * 2] * w2[n];
+          opt[n * 2 + 1] = opt[n * 2 + 1] * w1[n] + target[n * 2 + 1] * w2[n];
+        }
+      }
+    } else {
       for (int n = 0; n < ola_window_size_; ++n) {
-        ch_opt[n * channels_] =
-            ch_opt[n * channels_] * transition_window_[n] +
-            ch_target[n * channels_] * transition_window_[ola_window_size_ + n];
+        float* ch_opt = optimal_block_->data_as_float32() + n * channels_;
+        const float* const ch_target =
+            target_block_->data_as_float32() + n * channels_;
+        float w1 = transition_window_[n];
+        float w2 = transition_window_[ola_window_size_ + n];
+        for (int k = 0; k < channels_; ++k) {
+          ch_opt[k] = ch_opt[k] * w1 + ch_target[k] * w2;
+        }
       }
     }
   }
@@ -363,22 +509,62 @@ bool AudioTimeStretcher::RunOneWsolaIteration(double playback_rate) {
   GetOptimalBlock();
 
   // Overlap-and-add.
-  for (int k = 0; k < channels_; ++k) {
-    const float* const ch_opt_frame =
-        reinterpret_cast<const float*>(optimal_block_->data()) + k;
-    float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) + k +
-                       num_complete_frames_ * channels_;
+  if (enable_optimized_wsola_ && channels_ == 1) {
+    bool handled = false;
+#if (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+    OverlapAndAddMono_NEON(
+        optimal_block_->data_as_float32(),
+        wsola_output_->data_as_float32() + num_complete_frames_,
+        ola_window_.get() + ola_hop_size_, ola_window_.get(), ola_hop_size_);
+    handled = true;
+#endif  // (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+    if (!handled) {
+      const float* opt = optimal_block_->data_as_float32();
+      float* output = wsola_output_->data_as_float32() + num_complete_frames_;
+      const float* w_out = ola_window_.get() + ola_hop_size_;
+      const float* w_opt = ola_window_.get();
+      for (int n = 0; n < ola_hop_size_; ++n) {
+        output[n] = output[n] * w_out[n] + opt[n] * w_opt[n];
+      }
+    }
+  } else if (enable_optimized_wsola_ && channels_ == 2) {
+    bool handled = false;
+#if (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+    OverlapAndAddStereo_NEON(
+        optimal_block_->data_as_float32(),
+        wsola_output_->data_as_float32() + num_complete_frames_ * 2,
+        ola_window_.get() + ola_hop_size_, ola_window_.get(), ola_hop_size_);
+    handled = true;
+#endif  // (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+    if (!handled) {
+      const float* opt = optimal_block_->data_as_float32();
+      float* output =
+          wsola_output_->data_as_float32() + num_complete_frames_ * 2;
+      const float* w_out = ola_window_.get() + ola_hop_size_;
+      const float* w_opt = ola_window_.get();
+      for (int n = 0; n < ola_hop_size_; ++n) {
+        output[n * 2] = output[n * 2] * w_out[n] + opt[n * 2] * w_opt[n];
+        output[n * 2 + 1] =
+            output[n * 2 + 1] * w_out[n] + opt[n * 2 + 1] * w_opt[n];
+      }
+    }
+  } else {
     for (int n = 0; n < ola_hop_size_; ++n) {
-      ch_output[n * channels_] =
-          ch_output[n * channels_] * ola_window_[ola_hop_size_ + n] +
-          ch_opt_frame[n * channels_] * ola_window_[n];
+      float* ch_output = wsola_output_->data_as_float32() +
+                         (num_complete_frames_ + n) * channels_;
+      const float* const ch_opt_frame =
+          optimal_block_->data_as_float32() + n * channels_;
+      float w_out = ola_window_[ola_hop_size_ + n];
+      float w_opt = ola_window_[n];
+      for (int k = 0; k < channels_; ++k) {
+        ch_output[k] = ch_output[k] * w_out + ch_opt_frame[k] * w_opt;
+      }
     }
   }
   // Copy the second half to the output.
-  const float* const ch_opt_frame =
-      reinterpret_cast<const float*>(optimal_block_->data());
-  float* ch_output = reinterpret_cast<float*>(wsola_output_->data()) +
-                     num_complete_frames_ * channels_;
+  const float* const ch_opt_frame = optimal_block_->data_as_float32();
+  float* ch_output =
+      wsola_output_->data_as_float32() + num_complete_frames_ * channels_;
   memcpy(&ch_output[ola_hop_size_ * channels_],
          &ch_opt_frame[ola_hop_size_ * channels_],
          sizeof(*ch_opt_frame) * ola_hop_size_ * channels_);

--- a/starboard/shared/starboard/player/filter/audio_time_stretcher.h
+++ b/starboard/shared/starboard/player/filter/audio_time_stretcher.h
@@ -50,9 +50,12 @@ class AudioTimeStretcher {
   ~AudioTimeStretcher();
 
   // Initializes this object with information about the audio stream.
+  // |enable_optimized| activates NEON de-interleaving SIMD paths when
+  // available.
   void Initialize(SbMediaAudioSampleType sample_type,
                   int channels,
-                  int samples_per_second);
+                  int samples_per_second,
+                  bool enable_optimized);
 
   // Tries to fill |requested_frames| frames into |dest| with possibly scaled
   // data from our |audio_buffer_|. Data is scaled based on |playback_rate|,
@@ -213,9 +216,10 @@ class AudioTimeStretcher {
   // The initial and maximum capacity calculated by Initialize().
   int initial_capacity_;
   int max_capacity_;
+  bool enable_optimized_wsola_ = false;
 
   AudioTimeStretcher(const AudioTimeStretcher&) = delete;
-  void operator=(const AudioTimeStretcher&) = delete;
+  AudioTimeStretcher& operator=(const AudioTimeStretcher&) = delete;
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/testing/BUILD.gn
+++ b/starboard/shared/starboard/player/filter/testing/BUILD.gn
@@ -31,6 +31,7 @@ if (current_toolchain == starboard_toolchain) {
       "audio_frame_discarder_test.cc",
       "audio_renderer_internal_test.cc",
       "audio_resampler_test.cc",
+      "audio_time_stretcher_test.cc",
       "experimental_features_test.cc",
       "file_cache_reader_test.cc",
       "media_time_provider_impl_test.cc",
@@ -67,6 +68,7 @@ if (current_toolchain == starboard_toolchain) {
       "//starboard/common/benchmark_main.cc",
       "audio_decoder_benchmark.cc",
       "decoded_audio_benchmark.cc",
+      "wsola_benchmark.cc",
     ]
 
     public_deps = [

--- a/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
@@ -372,6 +372,10 @@ vector<vector<const char*>> GetSupportedTests() {
   vector<const char*> supported_files =
       GetSupportedAudioTestFiles(kExcludeHeaac, 6, "audiopassthrough=false");
 
+  if (supported_files.empty()) {
+    return test_params;
+  }
+
   // Generate test cases. For example, we have |supported_files| [A, B, C].
   // Add tests A->A, A->B, A->C, B->A, B->B, B->C, C->A, C->B and C->C.
   for (size_t i = 0; i < supported_files.size(); i++) {
@@ -396,10 +400,10 @@ vector<vector<const char*>> GetSupportedTests() {
   return test_params;
 }
 
-INSTANTIATE_TEST_CASE_P(AdaptiveAudioDecoderTests,
-                        AdaptiveAudioDecoderTest,
-                        Combine(ValuesIn(GetSupportedTests()), Bool()),
-                        GetAdaptiveAudioDecoderTestConfigName);
+INSTANTIATE_TEST_SUITE_P(AdaptiveAudioDecoderTests,
+                         AdaptiveAudioDecoderTest,
+                         Combine(ValuesIn(GetSupportedTests()), Bool()),
+                         GetAdaptiveAudioDecoderTestConfigName);
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/audio_decoder_benchmark.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_decoder_benchmark.cc
@@ -41,7 +41,7 @@ class AudioDecoderHelper {
         number_of_inputs_(std::min(dmp_reader_.number_of_audio_buffers(),
                                    kMaxNumberOfInputs)) {
     const bool kUseStubDecoder = false;
-    SB_CHECK_GT(number_of_inputs_, 0);
+    SB_CHECK_GT(number_of_inputs_, 0u);
     SB_CHECK(CreateAudioComponents(kUseStubDecoder, &job_queue_,
                                    dmp_reader_.audio_stream_info(),
                                    &audio_decoder_, &audio_renderer_sink_));
@@ -53,7 +53,7 @@ class AudioDecoderHelper {
   size_t number_of_inputs() const { return number_of_inputs_; }
 
   void DecodeAll() {
-    SB_CHECK_EQ(current_input_buffer_index_, 0);
+    SB_CHECK_EQ(current_input_buffer_index_, 0u);
     OnConsumed();  // Kick off the first Decode() call
     // Note that we deliberately don't add any time out to the loop, to ensure
     // that the benchmark is accurate.

--- a/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
@@ -146,7 +146,7 @@ TEST_P(AudioFrameDiscarderTest, PartialAudio) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AudioFrameDiscarderTests,
     AudioFrameDiscarderTest,
     ValuesIn(

--- a/starboard/shared/starboard/player/filter/testing/audio_time_stretcher_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_time_stretcher_test.cc
@@ -1,0 +1,152 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/filter/audio_time_stretcher.h"
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+
+#include "starboard/common/ref_counted.h"
+#include "starboard/media.h"
+#include "starboard/shared/starboard/player/decoded_audio_internal.h"
+#include "starboard/shared/starboard/player/filter/testing/test_util.h"
+
+namespace starboard {
+namespace {
+
+constexpr float kFrequency = 440.0f;
+
+using AudioTimeStretcherTest = ::testing::TestWithParam<int>;
+
+TEST_P(AudioTimeStretcherTest, Mono_OldAndNewMatch) {
+  const int sample_rate = GetParam();
+  constexpr int kChannels = 1;
+  constexpr double kPlaybackRate = 1.5;
+  constexpr int kInputFrames = 4800;
+  constexpr int kRequestedFrames = 500;
+
+  // Run Old Path.
+  AudioTimeStretcher stretcher_old;
+  stretcher_old.Initialize(kSbMediaAudioSampleTypeFloat32, kChannels,
+                           sample_rate, /*enable_optimized=*/false);
+  scoped_refptr<DecodedAudio> input_old = CreateTestDecodedAudio(
+      kInputFrames, kChannels, sample_rate, kFrequency, 0.5f);
+  stretcher_old.EnqueueBuffer(input_old);
+  scoped_refptr<DecodedAudio> output_old =
+      stretcher_old.Read(kRequestedFrames, kPlaybackRate);
+
+  // Run New Path.
+  AudioTimeStretcher stretcher_new;
+  stretcher_new.Initialize(kSbMediaAudioSampleTypeFloat32, kChannels,
+                           sample_rate, /*enable_optimized=*/true);
+  scoped_refptr<DecodedAudio> input_new = CreateTestDecodedAudio(
+      kInputFrames, kChannels, sample_rate, kFrequency, 0.5f);
+  stretcher_new.EnqueueBuffer(input_new);
+  scoped_refptr<DecodedAudio> output_new =
+      stretcher_new.Read(kRequestedFrames, kPlaybackRate);
+
+  ASSERT_EQ(output_old->frames(), output_new->frames());
+
+  const float* data_old = output_old->data_as_float32();
+  const float* data_new = output_new->data_as_float32();
+  for (int i = 0; i < output_old->frames() * kChannels; ++i) {
+    EXPECT_NEAR(data_old[i], data_new[i], 1e-5f) << "Mismatch at index " << i;
+  }
+}
+
+TEST_P(AudioTimeStretcherTest, Stereo_OldAndNewMatch) {
+  const int sample_rate = GetParam();
+  constexpr int kChannels = 2;
+  constexpr double kPlaybackRate = 1.5;
+  constexpr int kInputFrames = 4800;
+  constexpr int kRequestedFrames = 500;
+
+  // Run Old Path.
+  AudioTimeStretcher stretcher_old;
+  stretcher_old.Initialize(kSbMediaAudioSampleTypeFloat32, kChannels,
+                           sample_rate, /*enable_optimized=*/false);
+  scoped_refptr<DecodedAudio> input_old = CreateTestStereoDecodedAudio(
+      kInputFrames, sample_rate, 440.0f, 0.5f, 880.0f, 0.5f);
+  stretcher_old.EnqueueBuffer(input_old);
+  scoped_refptr<DecodedAudio> output_old =
+      stretcher_old.Read(kRequestedFrames, kPlaybackRate);
+
+  // Run New Path.
+  AudioTimeStretcher stretcher_new;
+  stretcher_new.Initialize(kSbMediaAudioSampleTypeFloat32, kChannels,
+                           sample_rate, /*enable_optimized=*/true);
+  scoped_refptr<DecodedAudio> input_new = CreateTestStereoDecodedAudio(
+      kInputFrames, sample_rate, 440.0f, 0.5f, 880.0f, 0.5f);
+  stretcher_new.EnqueueBuffer(input_new);
+  scoped_refptr<DecodedAudio> output_new =
+      stretcher_new.Read(kRequestedFrames, kPlaybackRate);
+
+  ASSERT_EQ(output_old->frames(), output_new->frames());
+
+  const float* data_old = output_old->data_as_float32();
+  const float* data_new = output_new->data_as_float32();
+  for (int i = 0; i < output_old->frames() * kChannels; ++i) {
+    EXPECT_NEAR(data_old[i], data_new[i], 1e-5f) << "Mismatch at index " << i;
+  }
+}
+
+TEST_P(AudioTimeStretcherTest, Stereo_NewPath_RunsCorrectly) {
+  const int sample_rate = GetParam();
+  constexpr int kChannels = 2;
+  constexpr double kPlaybackRate = 1.5;
+  constexpr int kInputFrames = 4800;
+  constexpr int kRequestedFrames = 500;
+
+  AudioTimeStretcher stretcher;
+  stretcher.Initialize(kSbMediaAudioSampleTypeFloat32, kChannels, sample_rate,
+                       /*enable_optimized=*/true);
+
+  scoped_refptr<DecodedAudio> input = CreateTestStereoDecodedAudio(
+      kInputFrames, sample_rate, 440.0f, 0.5f, 880.0f, 0.5f);
+  stretcher.EnqueueBuffer(input);
+
+  scoped_refptr<DecodedAudio> output =
+      stretcher.Read(kRequestedFrames, kPlaybackRate);
+
+  EXPECT_EQ(output->frames(), kRequestedFrames);
+}
+
+TEST_P(AudioTimeStretcherTest, OddInputFrames_RunsCorrectly) {
+  const int sample_rate = GetParam();
+  constexpr int kChannels = 2;
+  constexpr double kPlaybackRate = 1.33;
+  constexpr int kInputFrames = 4801;
+  constexpr int kRequestedFrames = 500;
+
+  AudioTimeStretcher stretcher;
+  stretcher.Initialize(kSbMediaAudioSampleTypeFloat32, kChannels, sample_rate,
+                       /*enable_optimized=*/true);
+
+  scoped_refptr<DecodedAudio> input = CreateTestStereoDecodedAudio(
+      kInputFrames, sample_rate, 440.0f, 0.5f, 880.0f, 0.5f);
+  stretcher.EnqueueBuffer(input);
+
+  scoped_refptr<DecodedAudio> output =
+      stretcher.Read(kRequestedFrames, kPlaybackRate);
+
+  EXPECT_EQ(output->frames(), kRequestedFrames);
+}
+
+INSTANTIATE_TEST_SUITE_P(AudioTimeStretcherSampleRates,
+                         AudioTimeStretcherTest,
+                         ::testing::Values(22050, 44100, 48000));
+
+}  // namespace
+}  // namespace starboard

--- a/starboard/shared/starboard/player/filter/testing/test_util.cc
+++ b/starboard/shared/starboard/player/filter/testing/test_util.cc
@@ -12,9 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#if !defined(_USE_MATH_DEFINES)
+#define _USE_MATH_DEFINES
+#endif  // !defined(_USE_MATH_DEFINES)
+
 #include "starboard/shared/starboard/player/filter/testing/test_util.h"
 
 #include <unistd.h>
+
+#include <cmath>
 
 #include "starboard/audio_sink.h"
 #include "starboard/common/check_op.h"
@@ -302,6 +308,75 @@ scoped_refptr<InputBuffer> GetAudioInputBuffer(
   auto input_buffer = new InputBuffer(StubDeallocateSampleFunc, nullptr,
                                       nullptr, player_sample_info);
   return input_buffer;
+}
+
+// A helper function to create a simple DecodedAudio object for testing.
+// It allocates memory and fills it with a simple sine wave.
+scoped_refptr<DecodedAudio> CreateTestDecodedAudio(int frames,
+                                                   int channels,
+                                                   int sample_rate,
+                                                   float frequency,
+                                                   float amplitude) {
+  const int bytes_per_frame = channels * sizeof(float);
+  const int buffer_size = frames * bytes_per_frame;
+
+  auto audio = make_scoped_refptr<DecodedAudio>(
+      channels, kSbMediaAudioSampleTypeFloat32,
+      kSbMediaAudioFrameStorageTypeInterleaved, 0, buffer_size);
+
+  float* data = audio->data_as_float32();
+  for (int i = 0; i < frames; ++i) {
+    for (int c = 0; c < channels; ++c) {
+      data[i * channels + c] =
+          amplitude * std::sin(2.0 * M_PI * frequency * i / sample_rate);
+    }
+  }
+  return audio;
+}
+
+scoped_refptr<DecodedAudio> CreateTestDecodedAudioWithData(
+    const std::vector<float>& data_values,
+    int channels) {
+  int frames = data_values.size() / channels;
+  const int bytes_per_frame = channels * sizeof(float);
+  const int buffer_size = frames * bytes_per_frame;
+
+  auto audio = make_scoped_refptr<DecodedAudio>(
+      channels, kSbMediaAudioSampleTypeFloat32,
+      kSbMediaAudioFrameStorageTypeInterleaved, 0, buffer_size);
+
+  memcpy(audio->data(), data_values.data(), buffer_size);
+  return audio;
+}
+
+// A helper to create a stereo DecodedAudio object with different frequencies
+// and amplitudes on Left and Right channels. This generates a true stereo
+// signal, which is necessary to verify stereo alignment and detect
+// cross-channel contamination bugs, unlike CreateTestDecodedAudio() which
+// generates a dual-mono signal when channels = 2.
+scoped_refptr<DecodedAudio> CreateTestStereoDecodedAudio(
+    int frames,
+    int sample_rate,
+    float left_frequency,
+    float left_amplitude,
+    float right_frequency,
+    float right_amplitude) {
+  const int kChannels = 2;
+  const int bytes_per_frame = kChannels * sizeof(float);
+  const int buffer_size = frames * bytes_per_frame;
+
+  auto audio = make_scoped_refptr<DecodedAudio>(
+      kChannels, kSbMediaAudioSampleTypeFloat32,
+      kSbMediaAudioFrameStorageTypeInterleaved, 0, buffer_size);
+
+  float* data = audio->data_as_float32();
+  for (int i = 0; i < frames; ++i) {
+    data[i * 2] = left_amplitude *
+                  std::sin(2.0 * M_PI * left_frequency * i / sample_rate);
+    data[i * 2 + 1] = right_amplitude *
+                      std::sin(2.0 * M_PI * right_frequency * i / sample_rate);
+  }
+  return audio;
 }
 
 }  // namespace starboard

--- a/starboard/shared/starboard/player/filter/testing/test_util.h
+++ b/starboard/shared/starboard/player/filter/testing/test_util.h
@@ -24,6 +24,7 @@
 #include "starboard/common/ref_counted.h"
 #include "starboard/player.h"
 #include "starboard/shared/starboard/media/media_util.h"
+#include "starboard/shared/starboard/player/decoded_audio_internal.h"
 #include "starboard/shared/starboard/player/filter/audio_decoder_internal.h"
 #include "starboard/shared/starboard/player/filter/audio_renderer_sink.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
@@ -73,6 +74,23 @@ scoped_refptr<InputBuffer> GetAudioInputBuffer(
     size_t index,
     int64_t discarded_duration_from_front,
     int64_t discarded_duration_from_back);
+
+scoped_refptr<DecodedAudio> CreateTestDecodedAudio(int frames,
+                                                   int channels,
+                                                   int sample_rate,
+                                                   float frequency,
+                                                   float amplitude);
+
+scoped_refptr<DecodedAudio> CreateTestDecodedAudioWithData(
+    const std::vector<float>& data_values,
+    int channels);
+
+scoped_refptr<DecodedAudio> CreateTestStereoDecodedAudio(int frames,
+                                                         int sample_rate,
+                                                         float left_frequency,
+                                                         float left_amplitude,
+                                                         float right_frequency,
+                                                         float right_amplitude);
 
 }  // namespace starboard
 

--- a/starboard/shared/starboard/player/filter/testing/wsola_benchmark.cc
+++ b/starboard/shared/starboard/player/filter/testing/wsola_benchmark.cc
@@ -1,0 +1,155 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cmath>
+#include <cstring>
+
+#include "starboard/common/ref_counted.h"
+#include "starboard/media.h"
+#include "starboard/shared/starboard/player/decoded_audio_internal.h"
+#include "starboard/shared/starboard/player/filter/audio_time_stretcher.h"
+#include "starboard/shared/starboard/player/filter/testing/test_util.h"
+#include "starboard/shared/starboard/player/filter/wsola_internal.h"
+#include "third_party/google_benchmark/src/include/benchmark/benchmark.h"
+
+namespace starboard {
+namespace {
+
+void RunOptimalIndexBenchmark(::benchmark::State& state,
+                              int channels,
+                              bool enable_optimized) {
+  constexpr int kSampleRate = 48000;
+  constexpr int kTargetFrames = 960;
+  constexpr int kSearchFrames = 2400;
+
+  scoped_refptr<DecodedAudio> target_block;
+  scoped_refptr<DecodedAudio> search_block;
+
+  if (channels == 2) {
+    target_block = CreateTestStereoDecodedAudio(kTargetFrames, kSampleRate,
+                                                440.0f, 0.5f, 880.0f, 0.5f);
+    search_block = CreateTestStereoDecodedAudio(kSearchFrames, kSampleRate,
+                                                440.0f, 0.5f, 880.0f, 0.5f);
+  } else {
+    target_block = CreateTestDecodedAudio(kTargetFrames, channels, kSampleRate,
+                                          440.0f, 0.5f);
+    search_block = CreateTestDecodedAudio(kSearchFrames, channels, kSampleRate,
+                                          440.0f, 0.5f);
+  }
+
+  float* search_data = search_block->data_as_float32();
+  const float* target_data = target_block->data_as_float32();
+  constexpr int kInjectIndex = 400;
+  memcpy(search_data + kInjectIndex * channels, target_data,
+         kTargetFrames * channels * sizeof(float));
+
+  Interval exclude_interval = {-1, -1};
+
+  for (auto _ : state) {
+    int index = OptimalIndex(search_block.get(), target_block.get(),
+                             kSbMediaAudioFrameStorageTypeInterleaved,
+                             exclude_interval, enable_optimized);
+    ::benchmark::DoNotOptimize(index);
+  }
+}
+
+void RunAudioTimeStretcherBenchmark(::benchmark::State& state,
+                                    int channels,
+                                    bool enable_optimized) {
+  constexpr int kSampleRate = 48000;
+  constexpr double kPlaybackRate = 1.5;
+  constexpr int kInputFrames = 4800;
+  constexpr int kRequestedFrames = 2400;
+
+  scoped_refptr<DecodedAudio> input;
+  if (channels == 2) {
+    input = CreateTestStereoDecodedAudio(kInputFrames, kSampleRate, 440.0f,
+                                         0.5f, 880.0f, 0.5f);
+  } else {
+    input = CreateTestDecodedAudio(kInputFrames, channels, kSampleRate, 440.0f,
+                                   0.5f);
+  }
+
+  AudioTimeStretcher stretcher;
+  stretcher.Initialize(kSbMediaAudioSampleTypeFloat32, channels, kSampleRate,
+                       enable_optimized);
+
+  for (auto _ : state) {
+    state.PauseTiming();
+    stretcher.FlushBuffers();
+    stretcher.EnqueueBuffer(input);
+    state.ResumeTiming();
+
+    scoped_refptr<DecodedAudio> output =
+        stretcher.Read(kRequestedFrames, kPlaybackRate);
+    ::benchmark::DoNotOptimize(output);
+  }
+}
+
+}  // namespace
+}  // namespace starboard
+
+void BM_OptimalIndex_Mono_Old(::benchmark::State& state) {
+  starboard::RunOptimalIndexBenchmark(state, 1, /*enable_optimized=*/false);
+}
+BENCHMARK(BM_OptimalIndex_Mono_Old);
+
+void BM_OptimalIndex_Mono_New(::benchmark::State& state) {
+  starboard::RunOptimalIndexBenchmark(state, 1, /*enable_optimized=*/true);
+}
+BENCHMARK(BM_OptimalIndex_Mono_New);
+
+void BM_OptimalIndex_Stereo_Old(::benchmark::State& state) {
+  starboard::RunOptimalIndexBenchmark(state, 2, /*enable_optimized=*/false);
+}
+BENCHMARK(BM_OptimalIndex_Stereo_Old);
+
+void BM_OptimalIndex_Stereo_New(::benchmark::State& state) {
+  starboard::RunOptimalIndexBenchmark(state, 2, /*enable_optimized=*/true);
+}
+BENCHMARK(BM_OptimalIndex_Stereo_New);
+
+void BM_OptimalIndex_5_1_Old(::benchmark::State& state) {
+  starboard::RunOptimalIndexBenchmark(state, 6, /*enable_optimized=*/false);
+}
+BENCHMARK(BM_OptimalIndex_5_1_Old);
+
+void BM_OptimalIndex_5_1_New(::benchmark::State& state) {
+  starboard::RunOptimalIndexBenchmark(state, 6, /*enable_optimized=*/true);
+}
+BENCHMARK(BM_OptimalIndex_5_1_New);
+
+void BM_AudioTimeStretcher_Mono_Old(::benchmark::State& state) {
+  starboard::RunAudioTimeStretcherBenchmark(state, 1,
+                                            /*enable_optimized=*/false);
+}
+BENCHMARK(BM_AudioTimeStretcher_Mono_Old);
+
+void BM_AudioTimeStretcher_Mono_New(::benchmark::State& state) {
+  starboard::RunAudioTimeStretcherBenchmark(state, 1,
+                                            /*enable_optimized=*/true);
+}
+BENCHMARK(BM_AudioTimeStretcher_Mono_New);
+
+void BM_AudioTimeStretcher_Stereo_Old(::benchmark::State& state) {
+  starboard::RunAudioTimeStretcherBenchmark(state, 2,
+                                            /*enable_optimized=*/false);
+}
+BENCHMARK(BM_AudioTimeStretcher_Stereo_Old);
+
+void BM_AudioTimeStretcher_Stereo_New(::benchmark::State& state) {
+  starboard::RunAudioTimeStretcherBenchmark(state, 2,
+                                            /*enable_optimized=*/true);
+}
+BENCHMARK(BM_AudioTimeStretcher_Stereo_New);

--- a/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
@@ -21,10 +21,13 @@
 #include <gtest/gtest.h>
 
 #include <cmath>
+#include <random>
 #include <vector>
 
+#include "starboard/common/ref_counted.h"
 #include "starboard/media.h"
 #include "starboard/shared/starboard/player/decoded_audio_internal.h"
+#include "starboard/shared/starboard/player/filter/testing/test_util.h"
 
 namespace starboard {
 namespace {
@@ -32,34 +35,223 @@ namespace {
 constexpr int kSampleRate = 48'000;
 constexpr float kFrequency = 440.0f;
 
-// A helper function to create a simple DecodedAudio object for testing.
-// It allocates memory and fills it with a simple sine wave.
-scoped_refptr<DecodedAudio> CreateTestDecodedAudio(int frames,
-                                                   int channels,
-                                                   int sample_rate,
-                                                   float frequency,
-                                                   float amplitude) {
-  const int kBytesPerFrame = channels * sizeof(float);
-  const int kBufferSize = frames * kBytesPerFrame;
+// ============================================================================
+// Reference C implementation for verification
+// ============================================================================
 
-  scoped_refptr<DecodedAudio> audio = new DecodedAudio(
-      channels, kSbMediaAudioSampleTypeFloat32,
-      kSbMediaAudioFrameStorageTypeInterleaved, 0, kBufferSize);
-
-  float* data = audio->data_as_float32();
-  for (int i = 0; i < frames; ++i) {
-    for (int c = 0; c < channels; ++c) {
-      data[i * channels + c] =
-          amplitude * sinf(2.0f * M_PI * frequency * i / sample_rate);
-    }
-  }
-  return audio;
+bool ReferenceInInterval(int n, Interval q) {
+  return n >= q.first && n <= q.second;
 }
 
+float ReferenceMultiChannelSimilarityMeasure(const float* dot_prod_a_b,
+                                             const float* energy_a,
+                                             const float* energy_b,
+                                             int channels) {
+  constexpr float kEpsilon = 1e-12f;
+  float similarity_measure = 0.0f;
+  for (int n = 0; n < channels; ++n) {
+    similarity_measure +=
+        dot_prod_a_b[n] / std::sqrt(energy_a[n] * energy_b[n] + kEpsilon);
+  }
+  return similarity_measure;
+}
+
+void ReferenceMultiChannelDotProduct(const DecodedAudio* a,
+                                     int frame_offset_a,
+                                     const DecodedAudio* b,
+                                     int frame_offset_b,
+                                     int num_frames,
+                                     float* dot_product) {
+  const float* a_frames = reinterpret_cast<const float*>(a->data());
+  const float* b_frames = reinterpret_cast<const float*>(b->data());
+  const int channels = a->channels();
+  memset(dot_product, 0, sizeof(*dot_product) * channels);
+  for (int k = 0; k < channels; ++k) {
+    const float* ch_a = a_frames + frame_offset_a * channels + k;
+    const float* ch_b = b_frames + frame_offset_b * channels + k;
+    for (int n = 0; n < num_frames; ++n) {
+      dot_product[k] += *ch_a * *ch_b;
+      ch_a += channels;
+      ch_b += channels;
+    }
+  }
+}
+
+void ReferenceMultiChannelMovingBlockEnergies(const DecodedAudio* input,
+                                              int frames_per_block,
+                                              float* energy) {
+  int num_blocks = input->frames() - (frames_per_block - 1);
+  int channels = input->channels();
+  const float* input_frames = reinterpret_cast<const float*>(input->data());
+  for (int k = 0; k < channels; ++k) {
+    const float* input_channel = input_frames + k;
+    energy[k] = 0;
+    for (int m = 0; m < frames_per_block; ++m) {
+      energy[k] += input_channel[m * channels] * input_channel[m * channels];
+    }
+    const float* slide_out = input_channel;
+    const float* slide_in = input_channel + frames_per_block * channels;
+    for (int n = 1; n < num_blocks;
+         ++n, slide_in += channels, slide_out += channels) {
+      energy[k + n * channels] = energy[k + (n - 1) * channels] -
+                                 *slide_out * *slide_out +
+                                 *slide_in * *slide_in;
+    }
+  }
+}
+
+void ReferenceQuadraticInterpolation(const float* y_values,
+                                     float* extremum,
+                                     float* extremum_value) {
+  float a = 0.5f * (y_values[2] + y_values[0]) - y_values[1];
+  float b = 0.5f * (y_values[2] - y_values[0]);
+  float c = y_values[1];
+  if (a == 0.f) {
+    *extremum = 0;
+    *extremum_value = y_values[1];
+  } else {
+    *extremum = -b / (2.f * a);
+    *extremum_value = a * (*extremum) * (*extremum) + b * (*extremum) + c;
+  }
+}
+
+int ReferenceDecimatedSearch(int decimation,
+                             Interval exclude_interval,
+                             const DecodedAudio* target_block,
+                             const DecodedAudio* search_segment,
+                             const float* energy_target_block,
+                             const float* energy_candidate_blocks,
+                             bool enable_optimized) {
+  int channels = search_segment->channels();
+  int block_size = target_block->frames();
+  int num_candidate_blocks = search_segment->frames() - (block_size - 1);
+  auto dot_prod = std::make_unique<float[]>(channels);
+  float similarity[3];
+
+  int n = 0;
+  ReferenceMultiChannelDotProduct(target_block, 0, search_segment, n,
+                                  block_size, dot_prod.get());
+  similarity[0] = ReferenceMultiChannelSimilarityMeasure(
+      dot_prod.get(), energy_target_block,
+      &energy_candidate_blocks[n * channels], channels);
+
+  float best_similarity = similarity[0];
+  int optimal_index = 0;
+
+  n += decimation;
+  if (n >= num_candidate_blocks) {
+    return 0;
+  }
+
+  ReferenceMultiChannelDotProduct(target_block, 0, search_segment, n,
+                                  block_size, dot_prod.get());
+  similarity[1] = ReferenceMultiChannelSimilarityMeasure(
+      dot_prod.get(), energy_target_block,
+      &energy_candidate_blocks[n * channels], channels);
+
+  n += decimation;
+  if (n >= num_candidate_blocks) {
+    return similarity[1] > similarity[0] ? decimation : 0;
+  }
+
+  for (; n < num_candidate_blocks; n += decimation) {
+    ReferenceMultiChannelDotProduct(target_block, 0, search_segment, n,
+                                    block_size, dot_prod.get());
+    similarity[2] = ReferenceMultiChannelSimilarityMeasure(
+        dot_prod.get(), energy_target_block,
+        &energy_candidate_blocks[n * channels], channels);
+
+    if ((similarity[1] > similarity[0] && similarity[1] >= similarity[2]) ||
+        (similarity[1] >= similarity[0] && similarity[1] > similarity[2])) {
+      float normalized_candidate_index;
+      float candidate_similarity;
+      ReferenceQuadraticInterpolation(similarity, &normalized_candidate_index,
+                                      &candidate_similarity);
+      int candidate_index = 0;
+      if (enable_optimized) {
+        candidate_index = n - decimation +
+                          static_cast<int>(std::round(
+                              normalized_candidate_index * decimation));
+      } else {
+        candidate_index =
+            n - decimation +
+            static_cast<int>(normalized_candidate_index * decimation + 0.5f);
+      }
+      if (candidate_similarity > best_similarity &&
+          !ReferenceInInterval(candidate_index, exclude_interval)) {
+        optimal_index = candidate_index;
+        best_similarity = candidate_similarity;
+      }
+    } else if (n + decimation >= num_candidate_blocks &&
+               similarity[2] > best_similarity &&
+               !ReferenceInInterval(n, exclude_interval)) {
+      optimal_index = n;
+      best_similarity = similarity[2];
+    }
+    memmove(similarity, &similarity[1], 2 * sizeof(*similarity));
+  }
+  return optimal_index;
+}
+
+int ReferenceFullSearch(int low_limit,
+                        int high_limit,
+                        Interval exclude_interval,
+                        const DecodedAudio* target_block,
+                        const DecodedAudio* search_block,
+                        const float* energy_target_block,
+                        const float* energy_candidate_blocks) {
+  int channels = search_block->channels();
+  int block_size = target_block->frames();
+  auto dot_prod = std::make_unique<float[]>(channels);
+  float best_similarity = std::numeric_limits<float>::min();
+  int optimal_index = 0;
+  for (int n = low_limit; n <= high_limit; ++n) {
+    if (ReferenceInInterval(n, exclude_interval)) {
+      continue;
+    }
+    ReferenceMultiChannelDotProduct(target_block, 0, search_block, n,
+                                    block_size, dot_prod.get());
+    float similarity = ReferenceMultiChannelSimilarityMeasure(
+        dot_prod.get(), energy_target_block,
+        &energy_candidate_blocks[n * channels], channels);
+    if (similarity > best_similarity) {
+      best_similarity = similarity;
+      optimal_index = n;
+    }
+  }
+  return optimal_index;
+}
+
+int ReferenceOptimalIndex(const DecodedAudio* search_block,
+                          const DecodedAudio* target_block,
+                          Interval exclude_interval,
+                          bool enable_optimized) {
+  int channels = search_block->channels();
+  int target_size = target_block->frames();
+  int num_candidate_blocks = search_block->frames() - (target_size - 1);
+  constexpr int kSearchDecimation = 5;
+  auto energy_target_block = std::make_unique<float[]>(channels);
+  auto energy_candidate_blocks =
+      std::make_unique<float[]>(channels * num_candidate_blocks);
+  ReferenceMultiChannelMovingBlockEnergies(search_block, target_size,
+                                           energy_candidate_blocks.get());
+  ReferenceMultiChannelDotProduct(target_block, 0, target_block, 0, target_size,
+                                  energy_target_block.get());
+  int optimal_index = ReferenceDecimatedSearch(
+      kSearchDecimation, exclude_interval, target_block, search_block,
+      energy_target_block.get(), energy_candidate_blocks.get(),
+      enable_optimized);
+  int lim_low = std::max(0, optimal_index - kSearchDecimation);
+  int lim_high =
+      std::min(num_candidate_blocks - 1, optimal_index + kSearchDecimation);
+  return ReferenceFullSearch(lim_low, lim_high, exclude_interval, target_block,
+                             search_block, energy_target_block.get(),
+                             energy_candidate_blocks.get());
+}
 TEST(WsolaInternalTest, OptimalIndex_ExactMatch) {
-  const int kFrames = 100;
-  const int kChannels = 1;
-  const float kAmplitude = 0.5f;
+  constexpr int kFrames = 100;
+  constexpr int kChannels = 1;
+  constexpr float kAmplitude = 0.5f;
 
   scoped_refptr<DecodedAudio> target_block = CreateTestDecodedAudio(
       50, kChannels, kSampleRate, kFrequency, kAmplitude);
@@ -76,15 +268,73 @@ TEST(WsolaInternalTest, OptimalIndex_ExactMatch) {
 
   int optimal_index =
       OptimalIndex(search_block.get(), target_block.get(),
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval,
+                   /*enable_optimized=*/true);
   // Due to floating point precision and quadratic interpolation, it might not
   // be exactly 25, but should be very close. We test for a small range.
   EXPECT_NEAR(optimal_index, 25, 1);
 }
 
+TEST(WsolaInternalTest, OptimalIndex_Stereo_OldPath_Buggy) {
+  constexpr int kChannels = 2;
+  scoped_refptr<DecodedAudio> target_block =
+      CreateTestStereoDecodedAudio(40, kSampleRate, 440.0f, 0.5f, 880.0f, 0.5f);
+
+  std::vector<float> search_data_values(100 * kChannels, 0.0f);
+  scoped_refptr<DecodedAudio> search_block =
+      CreateTestDecodedAudioWithData(search_data_values, kChannels);
+
+  float* search_data = search_block->data_as_float32();
+  const float* target_data = target_block->data_as_float32();
+  memcpy(search_data + 20 * kChannels, target_data,
+         20 * kChannels * sizeof(float));
+  memcpy(search_data + 60 * kChannels, target_data,
+         40 * kChannels * sizeof(float));
+
+  Interval exclude_interval = {-1, -1};
+
+  int optimal_index =
+      OptimalIndex(search_block.get(), target_block.get(),
+                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval,
+                   /*enable_optimized=*/false);
+
+  // On platforms with SIMD, the old buggy path will incorrectly choose 20.
+  // On platforms without SIMD (C fallback), it will correctly choose 60.
+  // We assert that it must be one of these two.
+  EXPECT_TRUE(optimal_index == 20 || optimal_index == 60)
+      << "Old path returned unexpected index: " << optimal_index;
+}
+
+TEST(WsolaInternalTest, OptimalIndex_Stereo_NewPath_Correct) {
+  constexpr int kChannels = 2;
+  scoped_refptr<DecodedAudio> target_block =
+      CreateTestStereoDecodedAudio(40, kSampleRate, 440.0f, 0.5f, 880.0f, 0.5f);
+
+  std::vector<float> search_data_values(100 * kChannels, 0.0f);
+  scoped_refptr<DecodedAudio> search_block =
+      CreateTestDecodedAudioWithData(search_data_values, kChannels);
+
+  float* search_data = search_block->data_as_float32();
+  const float* target_data = target_block->data_as_float32();
+  memcpy(search_data + 20 * kChannels, target_data,
+         20 * kChannels * sizeof(float));
+  memcpy(search_data + 60 * kChannels, target_data,
+         40 * kChannels * sizeof(float));
+
+  Interval exclude_interval = {-1, -1};
+
+  int optimal_index =
+      OptimalIndex(search_block.get(), target_block.get(),
+                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval,
+                   /*enable_optimized=*/true);
+
+  // The new path must always choose 60 (perfect match for all 40 frames).
+  EXPECT_NEAR(optimal_index, 60, 2);
+}
+
 TEST(WsolaInternalTest, OptimalIndex_NoMatch) {
-  const int kFrames = 100;
-  const int kChannels = 1;
+  constexpr int kFrames = 100;
+  constexpr int kChannels = 1;
 
   scoped_refptr<DecodedAudio> target_block =
       CreateTestDecodedAudio(50, kChannels, kSampleRate, 440.0f, 0.5f);
@@ -95,7 +345,8 @@ TEST(WsolaInternalTest, OptimalIndex_NoMatch) {
 
   int optimal_index =
       OptimalIndex(search_block.get(), target_block.get(),
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval,
+                   /*enable_optimized=*/true);
   // With no clear match, the result is less predictable, but it shouldn't crash
   // and should return a valid index within the search range.
   EXPECT_GE(optimal_index, 0);
@@ -103,9 +354,9 @@ TEST(WsolaInternalTest, OptimalIndex_NoMatch) {
 }
 
 TEST(WsolaInternalTest, OptimalIndex_ExcludeInterval) {
-  const int kFrames = 100;
-  const int kChannels = 1;
-  const float kAmplitude = 0.5f;
+  constexpr int kFrames = 100;
+  constexpr int kChannels = 1;
+  constexpr float kAmplitude = 0.5f;
 
   scoped_refptr<DecodedAudio> target_block = CreateTestDecodedAudio(
       20, kChannels, kSampleRate, kFrequency, kAmplitude);
@@ -126,15 +377,16 @@ TEST(WsolaInternalTest, OptimalIndex_ExcludeInterval) {
 
   int optimal_index =
       OptimalIndex(search_block.get(), target_block.get(),
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval,
+                   /*enable_optimized=*/true);
 
   // The match at 10 should be excluded, so it should find the match at 50.
   EXPECT_EQ(optimal_index, 50);
 }
 
 TEST(WsolaInternalTest, OptimalIndex_SmallBlocks) {
-  const int kFrames = 20;
-  const int kChannels = 1;
+  constexpr int kFrames = 20;
+  constexpr int kChannels = 1;
 
   scoped_refptr<DecodedAudio> target_block =
       CreateTestDecodedAudio(5, kChannels, kSampleRate, 440.0f, 0.5f);
@@ -150,7 +402,8 @@ TEST(WsolaInternalTest, OptimalIndex_SmallBlocks) {
 
   int optimal_index =
       OptimalIndex(search_block.get(), target_block.get(),
-                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval);
+                   kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval,
+                   /*enable_optimized=*/true);
   EXPECT_NEAR(optimal_index, 10, 1);
 }
 
@@ -171,7 +424,7 @@ TEST(WsolaInternalTest, GetPeriodicHanningWindow_LengthTwo) {
 }
 
 TEST(WsolaInternalTest, GetPeriodicHanningWindow_AllValuesAreValid) {
-  const int kWindowLength = 64;
+  constexpr int kWindowLength = 64;
   std::vector<float> window(kWindowLength);
 
   GetPeriodicHanningWindow(kWindowLength, window.data());
@@ -179,6 +432,87 @@ TEST(WsolaInternalTest, GetPeriodicHanningWindow_AllValuesAreValid) {
   for (int i = 0; i < kWindowLength; ++i) {
     EXPECT_GE(window[i], 0.0f);
     EXPECT_LE(window[i], 1.0f);
+  }
+}
+
+TEST(WsolaInternalTest, ExtensiveRandomTesting) {
+  // Seed random number generator with a fixed seed for reproducibility
+  std::mt19937 gen(42);
+  std::uniform_real_distribution<float> dis(-1.0f, 1.0f);
+
+  constexpr int kSampleRates[] = {22050, 44100, 48000};
+  constexpr int kChannelCounts[] = {1, 2, 6};  // Mono, Stereo, 5.1
+
+  for (int channels : kChannelCounts) {
+    for (int sample_rate : kSampleRates) {
+      // Create random target block (size 120 frames)
+      int target_frames = 120;
+      std::vector<float> target_data(target_frames * channels);
+      for (float& val : target_data) {
+        val = dis(gen);
+      }
+      scoped_refptr<DecodedAudio> target_block =
+          CreateTestDecodedAudioWithData(target_data, channels);
+
+      // Create random search block (size 300 frames)
+      int search_frames = 300;
+      std::vector<float> search_data(search_frames * channels);
+      for (float& val : search_data) {
+        val = dis(gen);
+      }
+      // Inject target block at a random position
+      std::uniform_int_distribution<int> int_dis(
+          0, search_frames - target_frames - 1);
+      int inject_index = int_dis(gen);
+      memcpy(search_data.data() + inject_index * channels, target_data.data(),
+             target_frames * channels * sizeof(float));
+
+      scoped_refptr<DecodedAudio> search_block =
+          CreateTestDecodedAudioWithData(search_data, channels);
+
+      Interval exclude_interval = {-1, -1};
+
+      // 1. Run Reference C implementation
+      int ref_index = ReferenceOptimalIndex(
+          search_block.get(), target_block.get(), exclude_interval,
+          /*enable_optimized=*/true);
+
+      // 2. Run New Optimized Path
+      int optimized_index = OptimalIndex(
+          search_block.get(), target_block.get(),
+          kSbMediaAudioFrameStorageTypeInterleaved, exclude_interval,
+          /*enable_optimized=*/true);
+
+      // New optimized path MUST match Reference C implementation for all
+      // channels!
+      EXPECT_EQ(optimized_index, ref_index)
+          << "Mismatch in optimized path for channels=" << channels
+          << ", sample_rate=" << sample_rate;
+
+      // 3. Run Old Path
+      int old_index = OptimalIndex(search_block.get(), target_block.get(),
+                                   kSbMediaAudioFrameStorageTypeInterleaved,
+                                   exclude_interval,
+                                   /*enable_optimized=*/false);
+
+      if (channels == 1) {
+        // For Mono, Old Path should ALSO match Reference (with
+        // enable_optimized=false)
+        int ref_index_old = ReferenceOptimalIndex(
+            search_block.get(), target_block.get(), exclude_interval,
+            /*enable_optimized=*/false);
+        EXPECT_EQ(old_index, ref_index_old)
+            << "Mismatch in old path for Mono, sample_rate=" << sample_rate;
+      } else {
+        // For Multi-channel, we just log if they differ (since it's expected to
+        // be buggy on SIMD)
+        if (old_index != ref_index) {
+          SB_LOG(INFO) << "Old path differed from Reference for channels="
+                       << channels << " (Old: " << old_index
+                       << ", Ref: " << ref_index << ")";
+        }
+      }
+    }
   }
 }
 

--- a/starboard/shared/starboard/player/filter/wsola_internal.cc
+++ b/starboard/shared/starboard/player/filter/wsola_internal.cc
@@ -28,7 +28,9 @@
 #include <cstring>
 #include <limits>
 #include <memory>
+#include <vector>
 
+#include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 
 #if SB_IS(ARCH_X86) || SB_IS(ARCH_X64)
@@ -38,12 +40,13 @@
 #define USE_SIMD 1
 #include <arm_neon.h>
 
-#include "starboard/common/check_op.h"
-#endif
+#endif  // SB_IS(ARCH_X86) || SB_IS(ARCH_X64)
 
 namespace starboard {
 
 namespace {
+
+constexpr int kMaxChannels = 8;
 
 bool InInterval(int n, Interval q) {
   return n >= q.first && n <= q.second;
@@ -57,9 +60,159 @@ float MultiChannelSimilarityMeasure(const float* dot_prod_a_b,
   float similarity_measure = 0.0f;
   for (int n = 0; n < channels; ++n) {
     similarity_measure +=
-        dot_prod_a_b[n] / sqrt(energy_a[n] * energy_b[n] + kEpsilon);
+        dot_prod_a_b[n] / std::sqrt(energy_a[n] * energy_b[n] + kEpsilon);
   }
   return similarity_measure;
+}
+
+#if (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+void DotProductMono_NEON(const float* a_src,
+                         const float* b_src,
+                         int num_frames,
+                         float* dot_product) {
+  const int last_index = num_frames - (num_frames % 4);
+  float32x4_t sum = vmovq_n_f32(0);
+  for (int s = 0; s < last_index; s += 4) {
+    sum = vmlaq_f32(sum, vld1q_f32(a_src + s), vld1q_f32(b_src + s));
+  }
+  float32x2_t half = vadd_f32(vget_high_f32(sum), vget_low_f32(sum));
+  float sum_scalar = vget_lane_f32(vpadd_f32(half, half), 0);
+  for (int s = last_index; s < num_frames; ++s) {
+    sum_scalar += a_src[s] * b_src[s];
+  }
+  dot_product[0] = sum_scalar;
+}
+
+void DotProductStereo_NEON(const float* a_src,
+                           const float* b_src,
+                           int num_frames,
+                           float* dot_product) {
+  const int last_index = num_frames - (num_frames % 4);
+  float32x4_t sum_L = vmovq_n_f32(0);
+  float32x4_t sum_R = vmovq_n_f32(0);
+  for (int s = 0; s < last_index; s += 4) {
+    float32x4x2_t a_reg = vld2q_f32(a_src + s * 2);
+    float32x4x2_t b_reg = vld2q_f32(b_src + s * 2);
+    sum_L = vmlaq_f32(sum_L, a_reg.val[0], b_reg.val[0]);
+    sum_R = vmlaq_f32(sum_R, a_reg.val[1], b_reg.val[1]);
+  }
+  float32x2_t half_L = vadd_f32(vget_high_f32(sum_L), vget_low_f32(sum_L));
+  float sum_L_scalar = vget_lane_f32(vpadd_f32(half_L, half_L), 0);
+
+  float32x2_t half_R = vadd_f32(vget_high_f32(sum_R), vget_low_f32(sum_R));
+  float sum_R_scalar = vget_lane_f32(vpadd_f32(half_R, half_R), 0);
+  for (int s = last_index; s < num_frames; ++s) {
+    sum_L_scalar += a_src[s * 2] * b_src[s * 2];
+    sum_R_scalar += a_src[s * 2 + 1] * b_src[s * 2 + 1];
+  }
+  dot_product[0] = sum_L_scalar;
+  dot_product[1] = sum_R_scalar;
+}
+#endif  // (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+
+void MultiChannelDotProductLegacy(const DecodedAudio* a,
+                                  int frame_offset_a,
+                                  const DecodedAudio* b,
+                                  int frame_offset_b,
+                                  int num_frames,
+                                  float* dot_product) {
+  const float* a_frames = a->data_as_float32();
+  const float* b_frames = b->data_as_float32();
+  const int channels = a->channels();
+
+  int rem_num_frames = num_frames;
+  int rem_frame_offset_a = frame_offset_a;
+  int rem_frame_offset_b = frame_offset_b;
+
+#if defined(USE_SIMD)
+  // The legacy SIMD path is only correct for Mono (1 channel).
+  // For multi-channel, it incorrectly processes interleaved data as planar.
+  if (channels == 1) {
+    const int rem = num_frames % 4;
+    const int last_index = num_frames - rem;
+
+    const float* a_src = a_frames + frame_offset_a;
+    const float* b_src = b_frames + frame_offset_b;
+
+#if SB_IS(ARCH_X86) || SB_IS(ARCH_X64)
+    __m128 m_sum = _mm_setzero_ps();
+    for (int s = 0; s < last_index; s += 4) {
+      m_sum = _mm_add_ps(
+          m_sum, _mm_mul_ps(_mm_loadu_ps(a_src + s), _mm_loadu_ps(b_src + s)));
+    }
+    m_sum = _mm_add_ps(_mm_movehl_ps(m_sum, m_sum), m_sum);
+    _mm_store_ss(dot_product,
+                 _mm_add_ss(m_sum, _mm_shuffle_ps(m_sum, m_sum, 1)));
+#elif SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)
+    float32x4_t m_sum = vmovq_n_f32(0);
+    for (int s = 0; s < last_index; s += 4) {
+      m_sum = vmlaq_f32(m_sum, vld1q_f32(a_src + s), vld1q_f32(b_src + s));
+    }
+    float32x2_t m_half = vadd_f32(vget_high_f32(m_sum), vget_low_f32(m_sum));
+    dot_product[0] = vget_lane_f32(vpadd_f32(m_half, m_half), 0);
+#endif  // SB_IS(ARCH_X86) || SB_IS(ARCH_X64)
+
+    if (!rem) {
+      return;
+    }
+    rem_num_frames = rem;
+    rem_frame_offset_a = frame_offset_a + last_index;
+    rem_frame_offset_b = frame_offset_b + last_index;
+  } else {
+    memset(dot_product, 0, sizeof(*dot_product) * channels);
+  }
+#else   // defined(USE_SIMD)
+  memset(dot_product, 0, sizeof(*dot_product) * channels);
+#endif  // defined(USE_SIMD)
+
+  for (int k = 0; k < channels; ++k) {
+    const float* ch_a = a_frames + rem_frame_offset_a * channels + k;
+    const float* ch_b = b_frames + rem_frame_offset_b * channels + k;
+    for (int n = 0; n < rem_num_frames; ++n) {
+      dot_product[k] += *ch_a * *ch_b;
+      ch_a += channels;
+      ch_b += channels;
+    }
+  }
+}
+
+void MultiChannelDotProductOptimized(const DecodedAudio* a,
+                                     int frame_offset_a,
+                                     const DecodedAudio* b,
+                                     int frame_offset_b,
+                                     int num_frames,
+                                     float* dot_product) {
+  if (num_frames == 0) {
+    return;
+  }
+
+  const float* a_frames = a->data_as_float32();
+  const float* b_frames = b->data_as_float32();
+  const int channels = a->channels();
+
+#if (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+  if (channels == 1) {
+    DotProductMono_NEON(a_frames + frame_offset_a, b_frames + frame_offset_b,
+                        num_frames, dot_product);
+    return;
+  }
+  if (channels == 2) {
+    DotProductStereo_NEON(a_frames + frame_offset_a * 2,
+                          b_frames + frame_offset_b * 2, num_frames,
+                          dot_product);
+    return;
+  }
+#endif  // (SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)) && defined(USE_NEON)
+
+  memset(dot_product, 0, sizeof(*dot_product) * channels);
+
+  for (int n = 0; n < num_frames; ++n) {
+    const float* ch_a = a_frames + (frame_offset_a + n) * channels;
+    const float* ch_b = b_frames + (frame_offset_b + n) * channels;
+    for (int k = 0; k < channels; ++k) {
+      dot_product[k] += ch_a[k] * ch_b[k];
+    }
+  }
 }
 
 void MultiChannelDotProduct(const DecodedAudio* a,
@@ -67,69 +220,20 @@ void MultiChannelDotProduct(const DecodedAudio* a,
                             const DecodedAudio* b,
                             int frame_offset_b,
                             int num_frames,
-                            float* dot_product) {
+                            float* dot_product,
+                            bool enable_optimized) {
   SB_DCHECK_EQ(a->channels(), b->channels());
   SB_DCHECK_GE(frame_offset_a, 0);
   SB_DCHECK_GE(frame_offset_b, 0);
   SB_DCHECK_LE(frame_offset_a + num_frames, a->frames());
   SB_DCHECK_LE(frame_offset_b + num_frames, b->frames());
 
-  const float* a_frames = reinterpret_cast<const float*>(a->data());
-  const float* b_frames = reinterpret_cast<const float*>(b->data());
-
-// SIMD optimized variants can provide a massive speedup to this operation.
-#if defined(USE_SIMD)
-  const int rem = num_frames % 4;
-  const int last_index = num_frames - rem;
-  const int channels = a->channels();
-  for (int ch = 0; ch < channels; ++ch) {
-    const float* a_src = a_frames + frame_offset_a * a->channels() + ch;
-    const float* b_src = b_frames + frame_offset_b * b->channels() + ch;
-
-#if SB_IS(ARCH_X86) || SB_IS(ARCH_X64)
-    // First sum all components.
-    __m128 m_sum = _mm_setzero_ps();
-    for (int s = 0; s < last_index; s += 4) {
-      m_sum = _mm_add_ps(
-          m_sum, _mm_mul_ps(_mm_loadu_ps(a_src + s), _mm_loadu_ps(b_src + s)));
-    }
-
-    // Reduce to a single float for this channel. Sadly, SSE1,2 doesn't have a
-    // horizontal sum function, so we have to condense manually.
-    m_sum = _mm_add_ps(_mm_movehl_ps(m_sum, m_sum), m_sum);
-    _mm_store_ss(dot_product + ch,
-                 _mm_add_ss(m_sum, _mm_shuffle_ps(m_sum, m_sum, 1)));
-#elif SB_IS(ARCH_ARM) || SB_IS(ARCH_ARM64)
-    // First sum all components.
-    float32x4_t m_sum = vmovq_n_f32(0);
-    for (int s = 0; s < last_index; s += 4) {
-      m_sum = vmlaq_f32(m_sum, vld1q_f32(a_src + s), vld1q_f32(b_src + s));
-    }
-
-    // Reduce to a single float for this channel.
-    float32x2_t m_half = vadd_f32(vget_high_f32(m_sum), vget_low_f32(m_sum));
-    dot_product[ch] = vget_lane_f32(vpadd_f32(m_half, m_half), 0);
-#endif
-  }
-
-  if (!rem) {
-    return;
-  }
-  num_frames = rem;
-  frame_offset_a += last_index;
-  frame_offset_b += last_index;
-#else   // defined(USE_SIMD)
-  memset(dot_product, 0, sizeof(*dot_product) * a->channels());
-#endif  // defined(USE_SIMD)
-
-  for (int k = 0; k < a->channels(); ++k) {
-    const float* ch_a = a_frames + frame_offset_a * a->channels() + k;
-    const float* ch_b = b_frames + frame_offset_b * b->channels() + k;
-    for (int n = 0; n < num_frames; ++n) {
-      dot_product[k] += *ch_a * *ch_b;
-      ch_a += a->channels();
-      ch_b += b->channels();
-    }
+  if (enable_optimized) {
+    MultiChannelDotProductOptimized(a, frame_offset_a, b, frame_offset_b,
+                                    num_frames, dot_product);
+  } else {
+    MultiChannelDotProductLegacy(a, frame_offset_a, b, frame_offset_b,
+                                 num_frames, dot_product);
   }
 }
 
@@ -139,7 +243,7 @@ void MultiChannelMovingBlockEnergies(const DecodedAudio* input,
   int num_blocks = input->frames() - (frames_per_block - 1);
   int channels = input->channels();
 
-  const float* input_frames = reinterpret_cast<const float*>(input->data());
+  const float* input_frames = input->data_as_float32();
   for (int k = 0; k < channels; ++k) {
     const float* input_channel = input_frames + k;
 
@@ -188,19 +292,30 @@ int DecimatedSearch(int decimation,
                     const DecodedAudio* target_block,
                     const DecodedAudio* search_segment,
                     const float* energy_target_block,
-                    const float* energy_candidate_blocks) {
+                    const float* energy_candidate_blocks,
+                    bool enable_optimized) {
   int channels = search_segment->channels();
   int block_size = target_block->frames();
   int num_candidate_blocks = search_segment->frames() - (block_size - 1);
-  std::unique_ptr<float[]> dot_prod(new float[channels]);
+  std::unique_ptr<float[]> dot_prod_heap;
+  float dot_prod_stack[kMaxChannels];
+  float* dot_prod = nullptr;
+  if (enable_optimized) {
+    SB_DCHECK_LE(channels, kMaxChannels);
+    dot_prod = dot_prod_stack;
+  } else {
+    dot_prod_heap.reset(new float[channels]);
+    dot_prod = dot_prod_heap.get();
+  }
+
   float similarity[3];  // Three elements for cubic interpolation.
 
   int n = 0;
   MultiChannelDotProduct(target_block, 0, search_segment, n, block_size,
-                         dot_prod.get());
+                         dot_prod, enable_optimized);
   similarity[0] = MultiChannelSimilarityMeasure(
-      dot_prod.get(), energy_target_block,
-      &energy_candidate_blocks[n * channels], channels);
+      dot_prod, energy_target_block, &energy_candidate_blocks[n * channels],
+      channels);
 
   // Set the starting point as optimal point.
   float best_similarity = similarity[0];
@@ -212,10 +327,10 @@ int DecimatedSearch(int decimation,
   }
 
   MultiChannelDotProduct(target_block, 0, search_segment, n, block_size,
-                         dot_prod.get());
+                         dot_prod, enable_optimized);
   similarity[1] = MultiChannelSimilarityMeasure(
-      dot_prod.get(), energy_target_block,
-      &energy_candidate_blocks[n * channels], channels);
+      dot_prod, energy_target_block, &energy_candidate_blocks[n * channels],
+      channels);
 
   n += decimation;
   if (n >= num_candidate_blocks) {
@@ -226,11 +341,11 @@ int DecimatedSearch(int decimation,
 
   for (; n < num_candidate_blocks; n += decimation) {
     MultiChannelDotProduct(target_block, 0, search_segment, n, block_size,
-                           dot_prod.get());
+                           dot_prod, enable_optimized);
 
     similarity[2] = MultiChannelSimilarityMeasure(
-        dot_prod.get(), energy_target_block,
-        &energy_candidate_blocks[n * channels], channels);
+        dot_prod, energy_target_block, &energy_candidate_blocks[n * channels],
+        channels);
 
     if ((similarity[1] > similarity[0] && similarity[1] >= similarity[2]) ||
         (similarity[1] >= similarity[0] && similarity[1] > similarity[2])) {
@@ -241,9 +356,16 @@ int DecimatedSearch(int decimation,
       QuadraticInterpolation(similarity, &normalized_candidate_index,
                              &candidate_similarity);
 
-      int candidate_index =
-          n - decimation +
-          static_cast<int>(normalized_candidate_index * decimation + 0.5f);
+      int candidate_index = 0;
+      if (enable_optimized) {
+        candidate_index = n - decimation +
+                          static_cast<int>(std::round(
+                              normalized_candidate_index * decimation));
+      } else {
+        candidate_index =
+            n - decimation +
+            static_cast<int>(normalized_candidate_index * decimation + 0.5f);
+      }
       if (candidate_similarity > best_similarity &&
           !InInterval(candidate_index, exclude_interval)) {
         optimal_index = candidate_index;
@@ -268,10 +390,20 @@ int FullSearch(int low_limit,
                const DecodedAudio* target_block,
                const DecodedAudio* search_block,
                const float* energy_target_block,
-               const float* energy_candidate_blocks) {
+               const float* energy_candidate_blocks,
+               bool enable_optimized) {
   int channels = search_block->channels();
   int block_size = target_block->frames();
-  std::unique_ptr<float[]> dot_prod(new float[channels]);
+  std::unique_ptr<float[]> dot_prod_heap;
+  float dot_prod_stack[kMaxChannels];
+  float* dot_prod = nullptr;
+  if (enable_optimized) {
+    SB_DCHECK_LE(channels, kMaxChannels);
+    dot_prod = dot_prod_stack;
+  } else {
+    dot_prod_heap.reset(new float[channels]);
+    dot_prod = dot_prod_heap.get();
+  }
 
   float best_similarity = std::numeric_limits<float>::min();
   int optimal_index = 0;
@@ -281,11 +413,11 @@ int FullSearch(int low_limit,
       continue;
     }
     MultiChannelDotProduct(target_block, 0, search_block, n, block_size,
-                           dot_prod.get());
+                           dot_prod, enable_optimized);
 
     float similarity = MultiChannelSimilarityMeasure(
-        dot_prod.get(), energy_target_block,
-        &energy_candidate_blocks[n * channels], channels);
+        dot_prod, energy_target_block, &energy_candidate_blocks[n * channels],
+        channels);
 
     if (similarity > best_similarity) {
       best_similarity = similarity;
@@ -301,10 +433,16 @@ int FullSearch(int low_limit,
 int OptimalIndex(const DecodedAudio* search_block,
                  const DecodedAudio* target_block,
                  SbMediaAudioFrameStorageType storage_type,
-                 Interval exclude_interval) {
-  int channels = search_block->channels();
-  SB_DCHECK_EQ(channels, target_block->channels());
+                 Interval exclude_interval,
+                 bool enable_optimized) {
+  SB_DCHECK(search_block);
+  SB_DCHECK(target_block);
+  SB_DCHECK_EQ(search_block->channels(), target_block->channels());
   SB_DCHECK_EQ(storage_type, kSbMediaAudioFrameStorageTypeInterleaved);
+  SB_DCHECK_EQ(search_block->sample_type(), kSbMediaAudioSampleTypeFloat32);
+  SB_DCHECK_EQ(target_block->sample_type(), kSbMediaAudioSampleTypeFloat32);
+
+  int channels = search_block->channels();
 
   int target_size = target_block->frames();
   int num_candidate_blocks = search_block->frames() - (target_size - 1);
@@ -315,9 +453,19 @@ int OptimalIndex(const DecodedAudio* search_block,
   // |search_block| and |target_block|. However, my experiments show the rate of
   // missing the optimal index is significant. This value is chosen
   // heuristically based on experiments.
-  const int kSearchDecimation = 5;
+  constexpr int kSearchDecimation = 5;
 
-  std::unique_ptr<float[]> energy_target_block(new float[channels]);
+  std::unique_ptr<float[]> energy_target_block_heap;
+  float energy_target_block_stack[kMaxChannels];
+  float* energy_target_block = nullptr;
+  if (enable_optimized) {
+    SB_DCHECK_LE(channels, kMaxChannels);
+    energy_target_block = energy_target_block_stack;
+  } else {
+    energy_target_block_heap.reset(new float[channels]);
+    energy_target_block = energy_target_block_heap.get();
+  }
+
   std::unique_ptr<float[]> energy_candidate_blocks(
       new float[channels * num_candidate_blocks]);
 
@@ -327,18 +475,18 @@ int OptimalIndex(const DecodedAudio* search_block,
 
   // Energy of target frame.
   MultiChannelDotProduct(target_block, 0, target_block, 0, target_size,
-                         energy_target_block.get());
+                         energy_target_block, enable_optimized);
 
   int optimal_index = DecimatedSearch(
       kSearchDecimation, exclude_interval, target_block, search_block,
-      energy_target_block.get(), energy_candidate_blocks.get());
+      energy_target_block, energy_candidate_blocks.get(), enable_optimized);
 
   int lim_low = std::max(0, optimal_index - kSearchDecimation);
   int lim_high =
       std::min(num_candidate_blocks - 1, optimal_index + kSearchDecimation);
   return FullSearch(lim_low, lim_high, exclude_interval, target_block,
-                    search_block, energy_target_block.get(),
-                    energy_candidate_blocks.get());
+                    search_block, energy_target_block,
+                    energy_candidate_blocks.get(), enable_optimized);
 }
 
 void GetPeriodicHanningWindow(int window_length, float* window) {

--- a/starboard/shared/starboard/player/filter/wsola_internal.h
+++ b/starboard/shared/starboard/player/filter/wsola_internal.h
@@ -36,10 +36,12 @@ typedef std::pair<int, int> Interval;
 // Find the index of the block, within |search_block|, that is most similar
 // to |target_block|. Obviously, the returned index is w.r.t. |search_block|.
 // |exclude_interval| is an interval that is excluded from the search.
+// |enable_optimized| activates NEON de-interleaving SIMD paths when available.
 int OptimalIndex(const DecodedAudio* search_block,
                  const DecodedAudio* target_block,
                  SbMediaAudioFrameStorageType storage_type,
-                 Interval exclude_interval);
+                 Interval exclude_interval,
+                 bool enable_optimized);
 
 // Return a "periodic" Hann window(https://en.wikipedia.org/wiki/Hann_function).
 // This is the first L samples of an L+1 Hann window. It is perfect


### PR DESCRIPTION
Fix the multi-channel audio bug in WSOLA MultiChannelDotProduct
where interleaved audio data was incorrectly processed as planar.
This caused cross-channel contamination and early termination.

Implement correct C fallback and optimized NEON SIMD paths for Mono
and Stereo audio. Expose the optimization via an H5VCC setting
'Media.EnableDecodedAudioSimdOptimizations' (disabled by default)
which also guards SIMD-based audio format switching. Note that we
changed and reuse the existing setting name for this purpose.

Add parameterized tests to 'player_filter_tests' spanning 22.05 kHz,
44.1 kHz, and 48 kHz to verify SIMD tail remainder handling and odd frame counts.
Add 'wsola_benchmark.cc' to 'player_filter_benchmarks' to measure the performance.

Benchmark results on Kirkwood Pro (connected device):
---------------------------------------------------------------------
Benchmark                           Time             CPU   Iterations
---------------------------------------------------------------------
BM_OptimalIndex_Mono_Old       442072 ns       408564 ns         1712
BM_OptimalIndex_Mono_New       445400 ns       417677 ns         1677
BM_OptimalIndex_Stereo_Old     935802 ns       878252 ns          797
BM_OptimalIndex_Stereo_New     682579 ns       628765 ns         1112
BM_OptimalIndex_5_1_Old       2778891 ns      2584726 ns          270
BM_OptimalIndex_5_1_New      12985698 ns     12080928 ns           58

Stereo delivers a ~28.4% speedup (1.4x). 5.1 is slower because it
correctly falls back to C, fixing the bug.

Bug: 518950923
