### PR TITLE
android: Enable dual thread video decoding by default

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -89,8 +89,6 @@ const char kH5vccSettingsKeyMediaSkipFlushOnDecoderTeardown[] =
     "Media.SkipFlushOnDecoderTeardown";
 const char kH5vccSettingsKeyMediaSkipVideoFramesOver60Fps[] =
     "Media.SkipVideoFramesOver60Fps";
-const char kH5vccSettingsKeyMediaUseDualThreadsForVideo[] =
-    "Media.UseDualThreadsForVideo";
 
 using ExperimentalFeatures =
     ::media::StarboardRendererConfig::ExperimentalFeatures;
@@ -275,10 +273,6 @@ ExperimentalFeatures ProcessH5vccSettings(
   if (auto* val = GetSettingValue<int64_t>(
           settings, kH5vccSettingsKeyMediaSkipVideoFramesOver60Fps)) {
     parsed.skip_video_frames_over_60_fps = *val != 0;
-  }
-  if (auto* val = GetSettingValue<int64_t>(
-          settings, kH5vccSettingsKeyMediaUseDualThreadsForVideo)) {
-    parsed.use_dual_threads_for_video = *val != 0;
   }
 
   parsed.video_decoder_initial_preroll_count = ProcessRangedIntH5vccSetting(

--- a/media/base/ipc/media_param_traits_macros.h
+++ b/media/base/ipc/media_param_traits_macros.h
@@ -216,7 +216,6 @@ IPC_STRUCT_TRAITS_BEGIN(media::StarboardRendererConfig::ExperimentalFeatures)
   IPC_STRUCT_TRAITS_MEMBER(video_decoder_initial_preroll_count)
   IPC_STRUCT_TRAITS_MEMBER(video_renderer_min_input_buffers)
   IPC_STRUCT_TRAITS_MEMBER(video_renderer_min_decoded_frames)
-  IPC_STRUCT_TRAITS_MEMBER(use_dual_threads_for_video)
 IPC_STRUCT_TRAITS_END()
 
 IPC_STRUCT_TRAITS_BEGIN(media::StarboardRendererConfig)

--- a/media/base/starboard/starboard_renderer_config.cc
+++ b/media/base/starboard/starboard_renderer_config.cc
@@ -73,8 +73,6 @@ std::ostream& operator<<(
             << ToString(features.enable_trivial_optimizations)
             << ", enable_simd_based_audio_format_switching="
             << ToString(features.enable_simd_based_audio_format_switching)
-            << ", use_dual_threads_for_video="
-            << ToString(features.use_dual_threads_for_video)
             << ", max_samples_per_write="
             << ToString(features.max_samples_per_write)
             << ", video_decoder_initial_preroll_count="

--- a/media/base/starboard/starboard_renderer_config.h
+++ b/media/base/starboard/starboard_renderer_config.h
@@ -46,7 +46,6 @@ struct MEDIA_EXPORT StarboardRendererConfig {
     bool skip_video_frames_over_60_fps = false;
     std::optional<bool> enable_simd_based_audio_format_switching;
     std::optional<bool> enable_trivial_optimizations;
-    std::optional<bool> use_dual_threads_for_video;
     std::optional<int> max_samples_per_write;
     std::optional<int> video_decoder_initial_preroll_count;
     std::optional<int> video_renderer_min_decoded_frames;

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -829,8 +829,6 @@ void SbPlayerBridge::CreatePlayer() {
         ToBoolPointer(experimental_features_.enable_trivial_optimizations);
     extension_features.enable_simd_based_audio_format_switching = ToBoolPointer(
         experimental_features_.enable_simd_based_audio_format_switching);
-    extension_features.use_dual_threads_for_video =
-        ToBoolPointer(experimental_features_.use_dual_threads_for_video);
     extension_features.video_decoder_initial_preroll_count = ToIntPointer(
         experimental_features_.video_decoder_initial_preroll_count);
     extension_features.video_renderer_min_decoded_frames =

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -133,7 +133,7 @@ MediaCodecDecoder::CreateForVideo(
     bool force_big_endian_hdr_metadata,
     int max_video_input_size,
     int64_t flush_delay_usec,
-    std::optional<bool> use_dual_threads,
+    bool use_dual_threads,
     bool skip_video_frames_over_60_fps,
     bool ignore_mediacodec_callbacks_during_flushing) {
   std::string error_message;
@@ -211,7 +211,7 @@ MediaCodecDecoder::MediaCodecDecoder(
     bool force_big_endian_hdr_metadata,
     int max_video_input_size,
     int64_t flush_delay_usec,
-    std::optional<bool> use_dual_threads,
+    bool use_dual_threads,
     bool skip_video_frames_over_60_fps,
     bool ignore_mediacodec_callbacks_during_flushing,
     std::string* error_message)
@@ -226,8 +226,7 @@ MediaCodecDecoder::MediaCodecDecoder(
       video_decoder_poll_interval_us_(
           tunnel_mode_enabled_ ? kDefaultVideoDecoderTunnelPollIntervalUs
                                : kDefaultVideoDecoderPollIntervalUs),
-      use_dual_threads_(use_dual_threads.value_or(false) &&
-                        !tunnel_mode_enabled_) {
+      use_dual_threads_(use_dual_threads && !tunnel_mode_enabled_) {
   SB_DCHECK(frame_rendered_cb_);
   SB_DCHECK(first_tunnel_frame_ready_cb_);
 

--- a/starboard/android/shared/media_codec_decoder.h
+++ b/starboard/android/shared/media_codec_decoder.h
@@ -102,7 +102,7 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
       bool force_big_endian_hdr_metadata,
       int max_video_input_size,
       int64_t flush_delay_usec,
-      std::optional<bool> use_dual_threads,
+      bool use_dual_threads,
       bool skip_video_frames_over_60_fps,
       bool ignore_mediacodec_callbacks_during_flushing);
 
@@ -136,7 +136,7 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
       bool force_big_endian_hdr_metadata,
       int max_video_input_size,
       int64_t flush_delay_usec,
-      std::optional<bool> use_dual_threads,
+      bool use_dual_threads,
       bool skip_video_frames_over_60_fps,
       bool ignore_mediacodec_callbacks_during_flushing,
       std::string* error_message);

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -290,8 +290,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
           platform_options.force_big_endian_hdr_metadata),
       tunnel_mode_audio_session_id_(tunnel_mode_config.audio_session_id),
       max_video_input_size_(pipeline_config.max_input_size),
-      use_dual_threads_(
-          pipeline_config.experimental_features.use_dual_threads_for_video),
+      use_dual_threads_(pipeline_config.use_dual_threads),
       surface_view_(stream_config.surface_view),
       enable_flush_during_seek_(pipeline_config.enable_flush_during_seek),
       reset_delay_usec_(android_get_device_api_level() < 34

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -74,6 +74,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   struct PipelineConfig {
     int max_input_size = 0;
     bool enable_flush_during_seek = false;
+    bool use_dual_threads = true;
     ExperimentalFeatures experimental_features;
   };
 
@@ -189,7 +190,10 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // Set the maximum size in bytes of an input buffer for video.
   const int max_video_input_size_;
 
-  const std::optional<bool> use_dual_threads_;
+  // Enable the use of dual-threading for video decoders. This separates the
+  // single threaded decoder thread into separate input and output processing
+  // threads when enabled.
+  const bool use_dual_threads_;
 
   // SurfaceView from AndroidOverlay passed from StarboardRenderer to SbPlayer.
   void* surface_view_;

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -614,10 +614,10 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         << "`kResetDelayUsec` is set to > 0, force a delay of "
         << reset_delay_usec << "us during Reset().";
 
-    if (experimental_features.use_dual_threads_for_video.value_or(false) &&
-        creation_parameters.audio_codec() != kSbMediaAudioCodecNone) {
-      // `use_dual_threads_for_video` should be disabled if the libopus audio
-      // decoder isn't used, as we want to limit the initial experiment to
+    bool use_dual_threads = true;
+    if (creation_parameters.audio_codec() != kSbMediaAudioCodecNone) {
+      // `use_dual_threads` should be disabled if the libopus audio
+      // decoder isn't used, as we want to limit the initial behavior to
       // playbacks with software based audio where their threading behavior is
       // more straightforward.
       // TODO(b/329686979): Make this work better with AdaptiveAudioDecoder,
@@ -625,7 +625,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       if (!UseLibopusDecoder(creation_parameters.audio_codec(),
                              creation_parameters.drm_system(),
                              force_platform_opus_decoder_)) {
-        experimental_features.use_dual_threads_for_video = false;
+        use_dual_threads = false;
       }
     }
 
@@ -637,7 +637,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
          creation_parameters.surface_view(),
          creation_parameters.max_video_capabilities()},
         {tunnel_mode_audio_session_id, force_secure_pipeline_under_tunnel_mode},
-        {max_video_input_size, enable_flush_during_seek, experimental_features},
+        {max_video_input_size, enable_flush_during_seek, use_dual_threads,
+         experimental_features},
         {force_big_endian_hdr_metadata, reset_delay_usec, flush_delay_usec});
   }
 

--- a/starboard/extension/experimental/experimental_features.h
+++ b/starboard/extension/experimental/experimental_features.h
@@ -47,7 +47,6 @@ typedef struct StarboardExtensionExperimentalFeatures {
   bool skip_video_frames_over_60_fps;
   const bool* enable_simd_based_audio_format_switching;
   const bool* enable_trivial_optimizations;
-  const bool* use_dual_threads_for_video;
   const int* video_decoder_initial_preroll_count;
   const int* video_renderer_min_decoded_frames;
   const int* video_renderer_min_input_buffers;

--- a/starboard/shared/starboard/experimental_features.cc
+++ b/starboard/shared/starboard/experimental_features.cc
@@ -92,8 +92,6 @@ void SetExperimentalFeaturesForCurrentThread(
           extension_features->enable_simd_based_audio_format_switching);
   experiment_features.enable_trivial_optimizations =
       FromBoolPointer(extension_features->enable_trivial_optimizations);
-  experiment_features.use_dual_threads_for_video =
-      FromBoolPointer(extension_features->use_dual_threads_for_video);
   experiment_features.video_decoder_initial_preroll_count =
       FromIntPointer(extension_features->video_decoder_initial_preroll_count);
   experiment_features.video_renderer_min_decoded_frames =

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -42,7 +42,6 @@ struct ExperimentalFeatures {
   bool skip_video_frames_over_60_fps = false;
   std::optional<bool> enable_simd_based_audio_format_switching;
   std::optional<bool> enable_trivial_optimizations;
-  std::optional<bool> use_dual_threads_for_video;
   std::optional<int> video_decoder_initial_preroll_count;
   std::optional<int> video_renderer_min_decoded_frames;
   std::optional<int> video_renderer_min_input_buffers;


### PR DESCRIPTION
Remove the experimental H5VCC setting and associated configuration
flags for dual-thread video decoding. This feature is now enabled
by default for video playback.

The implementation updates the MediaCodec-based video decoder on
Android to use dual threads as the standard configuration, with
conditional logic to ensure stability when specific audio decoders
are used. We keep both single-threaded and dual-threaded code
present as well, as there are cases where we cannot use dual
thread video decoding.

Bug: 329686979