### PR TITLE
Update autoroller to support merge conflicts.

### DIFF
--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -2,6 +2,7 @@
 """Script to automatically roll LTS branch."""
 import argparse
 from collections import defaultdict
+import enum
 import re
 import subprocess
 import sys
@@ -33,6 +34,19 @@ _SKIP_LIST = {
         'f0ef063d30589b39dc4a1433b0dde659d2fb5eea',
     ],
 }
+
+
+@enum.unique
+class CherryPickStatus(enum.Enum):
+  """Represents the outcome of a cherry-pick attempt."""
+  SUCCESS = 'success'  # Successfully cherry-picked and committed.
+  CONFLICTED = 'conflicted'  # Cherry-picked and committed with conflicts.
+  SKIPPED = 'skipped'  # The commit was already present or no action was needed.
+  FAILED = 'failed'  # The cherry-pick failed due to conflicts or other errors.
+
+
+def run(cmd):
+  subprocess.run(cmd, check=True, stdout=sys.stderr)
 
 
 def get_out(cmd):
@@ -67,17 +81,23 @@ def get_change_id_set(branch, exclude_branch, identifier_type):
     pattern = r'Cherry pick commit ([0-9a-fA-F]{4,40})'
 
   change_ids = set()
+  conflicted_change_ids = set()
   cmd = ['git', 'log', '--reverse', '--format=%s', branch, f'^{exclude_branch}']
   subjects = get_out(cmd).splitlines()
   for subject in subjects:
-    match = re.match(fr'^(Revert\s+[\'"]?)?{pattern}:', subject)
+    match = re.search(fr'^(Revert\s+[\'"]?)?(Conflicted )?{pattern}:', subject)
     if match:
-      revert, change_id = match.groups()
+      revert, conflicted, change_id = match.groups()
       if revert:
-        change_ids.discard(change_id)
+        if conflicted:
+          conflicted_change_ids.discard(change_id)
+        else:
+          change_ids.discard(change_id)
+      elif conflicted:
+        conflicted_change_ids.add(change_id)
       else:
         change_ids.add(change_id)
-  return change_ids
+  return change_ids, conflicted_change_ids
 
 
 def get_unmerged_files():
@@ -88,11 +108,7 @@ def get_unmerged_files():
   - '2': 'ours'
   - '3': 'theirs'
   """
-  res = subprocess.run(['git', 'ls-files', '-u'],
-                       capture_output=True,
-                       text=True,
-                       check=True)
-  lines = res.stdout.splitlines()
+  lines = get_out(['git', 'ls-files', '-u']).splitlines()
   files = defaultdict(set)
   stage_map = {'1': 'ancestor', '2': 'ours', '3': 'theirs'}
   for line in lines:
@@ -136,18 +152,21 @@ def resolve_conflicts(unmerged):
     print(
         f"Resolving 'deleted by us' conflicts: {deleted_by_us}",
         file=sys.stderr)
-    subprocess.run(
-        ['git', 'rm', '--'] + deleted_by_us, check=True, stdout=sys.stderr)
+    run(['git', 'rm', '--'] + deleted_by_us)
     return True
 
   return False
 
 
-def cherry_pick(sha, num, title):
+def cherry_pick(sha, num, title, first_cherry_pick):
   """Attempts to cherry-pick a single commit.
 
   Returns:
-    bool: True if successfully cherry-picked and committed, False otherwise.
+    CherryPickStatus: Enum indicating the outcome of the operation.
+      - SUCCESS: Successfully cherry-picked and committed.
+      - CONFLICTED: Cherry-picked and committed with conflicts.
+      - SKIPPED: The commit was already present or no action was needed.
+      - FAILED: The cherry-pick failed due to conflicts or other errors.
   """
   log_output = get_out(
       ['git', 'log', '-1', '--format=%ad%x00%an <%ae>%x00%b', sha])
@@ -173,26 +192,32 @@ def cherry_pick(sha, num, title):
   if len(ps) > 1:
     cmd.append('--mainline=1')
 
+  result = CherryPickStatus.SUCCESS
   try:
-    subprocess.run(cmd + [sha], check=True, stdout=sys.stderr)
-  except subprocess.CalledProcessError as error:
+    run(cmd + [sha])
+  except subprocess.CalledProcessError:
     unmerged = get_unmerged_files()
     if not resolve_conflicts(unmerged):
-      subprocess.run(['git', 'reset', '--hard', 'HEAD'], check=True)
-      raise error
+      if not first_cherry_pick:
+        run(['git', 'reset', '--hard', 'HEAD'])
+        return CherryPickStatus.FAILED
+
+      msg = f'Conflicted {msg}'
+      run(['git', 'add'] + list(unmerged))
+      result = CherryPickStatus.CONFLICTED
 
   # Check if there are changes to commit.
   res = subprocess.run(['git', 'diff', '--quiet', '--cached'], check=False)
   if res.returncode == 0:
-    print('Nothing to commit.', file=sys.stderr)
-    return False
+    print('Cherry pick skipped.', file=sys.stderr)
+    return CherryPickStatus.SKIPPED
 
   cmd = [
       'git', 'commit', '--no-verify', f'--author={author}', f'--date={date}',
       '-m', msg
   ]
-  subprocess.run(cmd, check=True, stdout=sys.stderr)
-  return True
+  run(cmd)
+  return result
 
 
 def main():
@@ -205,11 +230,12 @@ def main():
   args = p.parse_args()
 
   # All cherry picked changes in target branch since the branch point.
-  target_change_ids = get_change_id_set(args.target_branch, args.source_branch,
-                                        args.identifier_type)
+  target_change_ids, _ = get_change_id_set(args.target_branch,
+                                           args.source_branch,
+                                           args.identifier_type)
   # All cherry picked changes in autoroll branch since the branch point.
-  autoroll_change_ids = get_change_id_set('HEAD', args.source_branch,
-                                          args.identifier_type)
+  autoroll_change_ids, autoroll_conflicted_change_ids = get_change_id_set(
+      'HEAD', args.source_branch, args.identifier_type)
   commits_added = []
 
   # All commits in source branch and not in target branch (all commits
@@ -220,9 +246,10 @@ def main():
       print(f"Reached commit limit ({args.max_commits}).", file=sys.stderr)
       break
 
-    match = re.match(r'^(\w+) (.*?)(?: \(#(\d+)\))?$', line)
-    sha, title, pr_num = match.groups()
+    match = re.search(r'^(\w+) (.*?)(?: \(#(\d+)\))?$', line)
     if match:
+      sha, title, pr_num = match.groups()
+
       # Skip if in skip list.
       if sha in _SKIP_LIST.get(args.target_branch, []):
         continue
@@ -243,10 +270,20 @@ def main():
         commits_added.append(f'- {prefix}{change_id}')
         continue
 
+      # Break if in autoroll branch as conflicted.
+      if change_id in autoroll_conflicted_change_ids:
+        print(f"Reached conflicted cherry pick ({sha}).", file=sys.stderr)
+        break
+
       # Cherry pick PR.
-      if cherry_pick(sha, pr_num, title):
+      first_cherry_pick = not commits_added
+      result = cherry_pick(sha, pr_num, title, first_cherry_pick)
+      if result in (CherryPickStatus.SUCCESS, CherryPickStatus.CONFLICTED):
         autoroll_change_ids.add(change_id)
         commits_added.append(f'- {prefix}{change_id}')
+      if result in (CherryPickStatus.FAILED, CherryPickStatus.CONFLICTED):
+        print(f"Reached conflicted cherry pick ({sha}).", file=sys.stderr)
+        break
 
   if commits_added:
     print('\n'.join(commits_added))


### PR DESCRIPTION
The autoroller will now create PRs containing cherry-picks up to but not including the conflicting cherry-pick. If the conflicting cherry-pick is the first cherry-pick, the autoroller will create a Conflicted PR containing just that conflicting cherry-pick to then be handled by devs.

Bug: 522987128