### PR TITLE
Add sparse files during CP conflicts

### DIFF
--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -106,7 +106,7 @@ jobs:
           if [ ${RES} -ne 0 ]; then
             # If the cherry pick failed due to a merge conflict we can
             # add the conflicting file and create the commit anyway.
-            git add .
+            git add --sparse .
             git cherry-pick --continue
           fi
           exit ${RES}


### PR DESCRIPTION
The cherry-pick workflow currently fails when encountering conflicts in
files outside of the sparse checkout cone. This change ensures the
automation can successfully stage all conflicting files and complete
the cherry-pick regardless of which portions of the repository are
present in the environment.

Bug: 525461714