### PR TITLE
Add kInMemoryUpdatesMemoryBuffer feature to configure update client memory buffer size

### DIFF
--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -55,5 +55,13 @@ BASE_FEATURE(kCobaltMemoryAttributionManager,
 const base::FeatureParam<int> kCobaltMemoryAttributionReportIntervalParam{
     &kCobaltMemoryAttributionManager, "report-interval", 600};
 
+// Enables custom memory buffer size for in-memory updates.
+BASE_FEATURE(kInMemoryUpdatesMemoryBuffer,
+             "InMemoryUpdatesMemoryBuffer",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+const base::FeatureParam<int> kInMemoryUpdatesMemoryBufferParam{
+    &kInMemoryUpdatesMemoryBuffer, "memory_buffer_bytes", 35 * 1024 * 1024};
+
 }  // namespace features
 }  // namespace cobalt

--- a/cobalt/browser/features.h
+++ b/cobalt/browser/features.h
@@ -56,6 +56,12 @@ extern const base::Feature kCobaltMemoryAttributionManager;
 extern const base::FeatureParam<int>
     kCobaltMemoryAttributionReportIntervalParam;
 
+// Enables custom memory buffer size for in-memory updates.
+extern const base::Feature kInMemoryUpdatesMemoryBuffer;
+
+// Sets the memory buffer size in bytes.
+extern const base::FeatureParam<int> kInMemoryUpdatesMemoryBufferParam;
+
 }  // namespace features
 }  // namespace cobalt
 

--- a/components/update_client/BUILD.gn
+++ b/components/update_client/BUILD.gn
@@ -203,6 +203,7 @@ static_library("update_client") {
   if (is_starboard) {
     deps += [
       "//starboard:starboard_headers_only",
+      "//cobalt/browser:features",
     ]
   }
 

--- a/components/update_client/DEPS
+++ b/components/update_client/DEPS
@@ -13,12 +13,15 @@ include_rules = [
   "+third_party/zlib",
 ]
 
-# Allow the unit tests to depend on the network for testing purposes.
 specific_include_rules = {
+  # Allow the unit tests to depend on the network for testing purposes.
   "(test_configurator|.*_unittest\.(cc|h))" : [
     "+net",
     "+services/network/public/cpp",
     "+services/network/public/mojom",
     "+services/network/test",
-  ]
+  ],
+  "op_download\.cc": [
+    "+cobalt/browser/features.h",
+  ],
 }

--- a/components/update_client/op_download.cc
+++ b/components/update_client/op_download.cc
@@ -35,6 +35,8 @@
 
 #if BUILDFLAG(IS_STARBOARD)
 #include <algorithm>
+#include "base/feature_list.h"
+#include "cobalt/browser/features.h"  // nogncheck
 #include "starboard/system.h"  // nogncheck
 #endif
 
@@ -47,11 +49,6 @@ namespace {
 constexpr int64_t kBackgroundDownloadSizeThreshold = 10'000'000; /*10 MB*/
 #elif !BUILDFLAG(IS_STARBOARD)
 constexpr int64_t kBackgroundDownloadSizeThreshold = 0;
-#endif
-
-#if defined(IN_MEMORY_UPDATES)
-// Memory buffer required for downloading the update in memory.
-constexpr int64_t kMemoryBufferBytes = 20 * 1024 * 1024;
 #endif
 
 #if !BUILDFLAG(IS_STARBOARD)
@@ -203,9 +200,17 @@ void HandleAvailableSpace(
   int64_t used_memory = SbSystemGetUsedCPUMemory();
   int64_t available_memory = std::max(int64_t{0}, total_memory - used_memory);
 
-  if (total_memory > 0 && available_memory < size + kMemoryBufferBytes) {
+  // Get() returns the C++ default (35MB) if the feature is disabled,
+  // or the Finch-provided value if the feature is enabled. This buffer
+  // acts as a safety margin in case memory usage fluctuates elsewhere
+  // on the system while the download is in progress.
+  int64_t memory_buffer_bytes = cobalt::features::kInMemoryUpdatesMemoryBufferParam.Get();
+
+  if (total_memory > 0 && available_memory < size + memory_buffer_bytes) {
     VLOG(1)
-        << "Insufficient memory for the update plus 20MB buffer. Available memory: "
+        << "Insufficient memory for the update plus "
+        << (memory_buffer_bytes / (1024 * 1024))
+        << "MB buffer. Available memory: "
         << available_memory << ", download size: " << size;
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE,

--- a/components/update_client/op_download.cc
+++ b/components/update_client/op_download.cc
@@ -33,6 +33,11 @@
 #include "components/update_client/update_engine.h"
 #include "url/gurl.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include <algorithm>
+#include "starboard/system.h"  // nogncheck
+#endif
+
 namespace update_client {
 
 namespace {
@@ -42,6 +47,11 @@ namespace {
 constexpr int64_t kBackgroundDownloadSizeThreshold = 10'000'000; /*10 MB*/
 #elif !BUILDFLAG(IS_STARBOARD)
 constexpr int64_t kBackgroundDownloadSizeThreshold = 0;
+#endif
+
+#if defined(IN_MEMORY_UPDATES)
+// Memory buffer required for downloading the update in memory.
+constexpr int64_t kMemoryBufferBytes = 20 * 1024 * 1024;
 #endif
 
 #if !BUILDFLAG(IS_STARBOARD)
@@ -187,6 +197,26 @@ void HandleAvailableSpace(
                  .code = static_cast<int>(CrxDownloaderError::DISK_FULL)})));
     return;
   }
+
+#if BUILDFLAG(IS_STARBOARD) && defined(IN_MEMORY_UPDATES)
+  int64_t total_memory = SbSystemGetTotalCPUMemory();
+  int64_t used_memory = SbSystemGetUsedCPUMemory();
+  int64_t available_memory = std::max(int64_t{0}, total_memory - used_memory);
+
+  if (total_memory > 0 && available_memory < size + kMemoryBufferBytes) {
+    VLOG(1)
+        << "Insufficient memory for the update plus 20MB buffer. Available memory: "
+        << available_memory << ", download size: " << size;
+    base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
+        FROM_HERE,
+        base::BindOnce(
+            std::move(callback),
+            base::unexpected<CategorizedError>(
+                {.category = ErrorCategory::kDownload,
+                 .code = static_cast<int>(CrxDownloaderError::OUT_OF_MEMORY)})));
+    return;
+  }
+#endif
   scoped_refptr<CrxDownloader> crx_downloader =
 #if BUILDFLAG(IS_STARBOARD)
       config->GetCrxDownloaderFactory()->MakeCrxDownloader(config);

--- a/components/update_client/update_client_errors.h
+++ b/components/update_client/update_client_errors.h
@@ -49,6 +49,9 @@ enum class CrxDownloaderError {
   DISK_FULL = 13,
   CANCELLED = 14,
   NO_DOWNLOAD_DIR = 15,
+#if BUILDFLAG(IS_STARBOARD)
+  OUT_OF_MEMORY = 16,
+#endif
 
   // The Windows BITS queue contains to many update client jobs. The value is
   // chosen so that it can be reported as a custom COM error on this platform.

--- a/components/update_client/update_client_errors.h
+++ b/components/update_client/update_client_errors.h
@@ -41,6 +41,7 @@ enum class ErrorCategory {
 enum class CrxDownloaderError {
   NONE = 0,
 #if BUILDFLAG(IS_STARBOARD)
+  OUT_OF_MEMORY = 8,
   SLOT_UNAVAILABLE = 9,
 #endif
   NO_URL = 10,
@@ -49,9 +50,6 @@ enum class CrxDownloaderError {
   DISK_FULL = 13,
   CANCELLED = 14,
   NO_DOWNLOAD_DIR = 15,
-#if BUILDFLAG(IS_STARBOARD)
-  OUT_OF_MEMORY = 16,
-#endif
 
   // The Windows BITS queue contains to many update client jobs. The value is
   // chosen so that it can be reported as a custom COM error on this platform.


### PR DESCRIPTION
Define the kInMemoryUpdatesMemoryBuffer feature and parameter and use it to check available memory before downloading an update.

Issue: 479816505