### PR TITLE
Fix potential crash in TaskUpdate::Cancel() on queued tasks

### DIFF
--- a/components/update_client/task_update.cc
+++ b/components/update_client/task_update.cc
@@ -5,6 +5,8 @@
 
 #include <utility>
 
+#include "build/build_config.h"
+
 #include "base/functional/bind.h"
 #include "base/location.h"
 #include "base/task/sequenced_task_runner.h"
@@ -53,7 +55,15 @@ void TaskUpdate::Run() {
 void TaskUpdate::Cancel() {
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   cancelled_ = true;
+#if BUILDFLAG(IS_STARBOARD)
+  if (cancel_callback_) {
+    cancel_callback_.Run();
+  } else {
+    TaskComplete(Error::UPDATE_CANCELED);
+  }
+#else
   cancel_callback_.Run();
+#endif
 }
 
 std::vector<std::string> TaskUpdate::GetIds() const {


### PR DESCRIPTION
In Cobalt, tasks in the update client's task_queue_ are pending and have
not been executed yet. Because of this, their cancel_callback_ is null.
Calling task->Cancel() on these tasks during UpdateClientImpl::Stop()
leads to a crash when invoking cancel_callback_.Run().

This CL guards the cancel_callback_.Run() call in TaskUpdate::Cancel()
with a null check under the IS_STARBOARD flag. If it's null, we call
TaskComplete(Error::UPDATE_CANCELED) directly to cancel the task
cleanly.

Issue: 479816505
