### PR TITLE
Fix map lookup crash in UpdateEngine::Cancel

### DIFF
--- a/components/update_client/update_engine.cc
+++ b/components/update_client/update_engine.cc
@@ -510,7 +510,7 @@ void UpdateEngine::Cancel(const std::string& update_context_session_id,
     LOG(WARNING) << "UpdateEngine::Cancel: context not found or already completed.";
     return;
   }
-  const auto& context = it->second;
+  const scoped_refptr<UpdateContext> context = it->second;
   if (context->update_checker.get()) {
     context->update_checker->Cancel();
   }

--- a/components/update_client/update_engine.cc
+++ b/components/update_client/update_engine.cc
@@ -505,7 +505,12 @@ void UpdateEngine::Cancel(const std::string& update_context_session_id,
     ping_manager_->Cancel();
   }
 
-  const auto& context = update_contexts_.at(update_context_session_id);
+  const auto it = update_contexts_.find(update_context_session_id);
+  if (it == update_contexts_.end()) {
+    LOG(WARNING) << "UpdateEngine::Cancel: context not found or already completed.";
+    return;
+  }
+  const auto& context = it->second;
   if (context->update_checker.get()) {
     context->update_checker->Cancel();
   }


### PR DESCRIPTION
In Cobalt 25, UpdateEngine::Cancel uses update_contexts_.at(session_id)
to look up the update context. If the update context has already completed
and been erased from update_contexts_, this lookup throws a std::out_of_range
exception, causing a crash.

This CL checks if the session_id exists in update_contexts_ before
accessing it. If not found, it logs a warning and returns early.

Issue: 477394770
Change-Id: Ib76cada0eac19d9d2ce7741509e862dcae7c9810
