### PR TITLE
starboard: Replace memory indirection in media capabilities cache

### DIFF
--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -149,10 +149,8 @@ class MediaCapabilitiesProviderImpl : public MediaCapabilitiesProvider {
     return AudioOutputManager::GetInstance()->GetAudioConfiguration(
         env, index, configuration);
   }
-  void GetCodecCapabilities(
-      std::map<std::string, AudioCodecCapabilities>& audio_codec_capabilities,
-      std::map<std::string, VideoCodecCapabilities>& video_codec_capabilities)
-      override {
+  CodecCapabilities GetCodecCapabilities() override {
+    CodecCapabilities capabilities;
     JNIEnv* env = AttachCurrentThread();
     ScopedJavaLocalRef<jobjectArray> j_codec_infos =
         Java_MediaCodecUtil_getAllCodecCapabilityInfos(env);
@@ -176,20 +174,19 @@ class MediaCapabilitiesProviderImpl : public MediaCapabilitiesProvider {
           Java_CodecCapabilityInfo_getAudioCapabilities(env, j_codec_info);
       if (j_audio_capabilities) {
         // Found an audio decoder.
-        audio_codec_capabilities[mime_type].push_back(
-            std::make_unique<AudioCodecCapability>(env, j_codec_info,
-                                                   j_audio_capabilities));
+        capabilities.audio[mime_type].emplace_back(env, j_codec_info,
+                                                   j_audio_capabilities);
         continue;
       }
       ScopedJavaLocalRef<jobject> j_video_capabilities =
           Java_CodecCapabilityInfo_getVideoCapabilities(env, j_codec_info);
       if (j_video_capabilities) {
         // Found a video decoder.
-        video_codec_capabilities[mime_type].push_back(
-            std::make_unique<VideoCodecCapability>(env, j_codec_info,
-                                                   j_video_capabilities));
+        capabilities.video[mime_type].emplace_back(env, j_codec_info,
+                                                   j_video_capabilities);
       }
     }
+    return capabilities;
   }
 };
 }  // namespace
@@ -460,12 +457,13 @@ std::string MediaCapabilitiesCache::FindAudioDecoder(
   std::lock_guard scoped_lock(mutex_);
   UpdateMediaCapabilities_Locked();
 
-  for (auto& audio_capability : audio_codec_capabilities_map_[mime_type]) {
+  for (const auto& audio_capability :
+       audio_codec_capabilities_map_[mime_type]) {
     // Reject if bitrate is not supported.
-    if (!audio_capability->IsBitrateSupported(bitrate)) {
+    if (!audio_capability.IsBitrateSupported(bitrate)) {
       continue;
     }
-    return audio_capability->name();
+    return audio_capability.name();
   }
 
   return "";
@@ -506,61 +504,62 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
   std::lock_guard scoped_lock(mutex_);
   UpdateMediaCapabilities_Locked();
 
-  for (auto& video_capability : video_codec_capabilities_map_[mime_type]) {
+  for (const auto& video_capability :
+       video_codec_capabilities_map_[mime_type]) {
     // Reject if secure decoder is required but codec doesn't support it.
-    if (must_support_secure && !video_capability->is_secure_supported()) {
+    if (must_support_secure && !video_capability.is_secure_supported()) {
       continue;
     }
     // Reject if non secure decoder is required but codec doesn't support it.
-    if (!must_support_secure && video_capability->is_secure_required()) {
+    if (!must_support_secure && video_capability.is_secure_required()) {
       continue;
     }
     // Reject if tunnel mode is required but codec doesn't support it.
     if (must_support_tunnel_mode &&
-        !video_capability->is_tunnel_mode_supported()) {
+        !video_capability.is_tunnel_mode_supported()) {
       continue;
     }
     // Reject if non tunnel mode is required but codec doesn't support it.
     if (!must_support_tunnel_mode &&
-        video_capability->is_tunnel_mode_required()) {
+        video_capability.is_tunnel_mode_required()) {
       continue;
     }
     // Reject if software codec is required but codec is not.
-    if (require_software_codec && !video_capability->is_software_decoder()) {
+    if (require_software_codec && !video_capability.is_software_decoder()) {
       continue;
     }
     // Reject low performance software codec if software codec is not required.
     const bool reject_low_performance_software_decoder =
         FeatureList::IsEnabled(features::kRejectLowPerformanceSoftwareDecoder);
     if ((reject_low_performance_software_decoder || !is_sw_decoder_enabled_) &&
-        !require_software_codec && video_capability->is_software_decoder()) {
+        !require_software_codec && video_capability.is_software_decoder()) {
       const int kMinimumWidth = 1920;
       const int kMinimumHeight = 1080;
-      if (!video_capability->AreResolutionAndRateSupported(kMinimumWidth,
-                                                           kMinimumHeight, 0)) {
+      if (!video_capability.AreResolutionAndRateSupported(kMinimumWidth,
+                                                          kMinimumHeight, 0)) {
         continue;
       }
     }
     // Reject if hdr is required but codec doesn't support it.
-    if (must_support_hdr && !video_capability->is_hdr_capable()) {
+    if (must_support_hdr && !video_capability.is_hdr_capable()) {
       continue;
     }
     // Reject if resolution or frame rate is not supported.
-    if (!video_capability->AreResolutionAndRateSupported(frame_width,
-                                                         frame_height, fps)) {
+    if (!video_capability.AreResolutionAndRateSupported(frame_width,
+                                                        frame_height, fps)) {
       continue;
     }
     // Reject if bitrate is not supported.
-    if (bitrate != 0 && !video_capability->IsBitrateSupported(bitrate)) {
+    if (bitrate != 0 && !video_capability.IsBitrateSupported(bitrate)) {
       continue;
     }
 
     // Append ".secure" for secure decoder if not represents.
     if (must_support_secure &&
-        !EndsWith(video_capability->name(), SECURE_DECODER_SUFFIX)) {
-      return video_capability->name() + SECURE_DECODER_SUFFIX;
+        !EndsWith(video_capability.name(), SECURE_DECODER_SUFFIX)) {
+      return video_capability.name() + SECURE_DECODER_SUFFIX;
     }
-    return video_capability->name();
+    return video_capability.name();
   }
 
   return "";
@@ -594,8 +593,9 @@ void MediaCapabilitiesCache::UpdateMediaCapabilities_Locked() {
   is_cbcs_supported_ = media_capabilities_provider_->GetIsCbcsSchemeSupported();
   supported_transfer_ids_ =
       media_capabilities_provider_->GetSupportedHdrTypes();
-  media_capabilities_provider_->GetCodecCapabilities(
-      audio_codec_capabilities_map_, video_codec_capabilities_map_);
+  auto capabilities = media_capabilities_provider_->GetCodecCapabilities();
+  audio_codec_capabilities_map_ = std::move(capabilities.audio);
+  video_codec_capabilities_map_ = std::move(capabilities.video);
   LoadAudioConfigurations_Locked();
   LoadIsAv18kCappedAt30_Locked();
 }
@@ -622,10 +622,10 @@ void MediaCapabilitiesCache::LoadIsAv18kCappedAt30_Locked() {
            kSbMediaVideoCodecAv1)]) {
     constexpr int kWidth8K = 7680;
     constexpr int kHeight8K = 4320;
-    if (video_capability->AreResolutionAndRateSupported(kWidth8K, kHeight8K,
-                                                        /*fps=*/0) &&
-        !video_capability->AreResolutionAndRateSupported(kWidth8K, kHeight8K,
-                                                         /*fps=*/60)) {
+    if (video_capability.AreResolutionAndRateSupported(kWidth8K, kHeight8K,
+                                                       /*fps=*/0) &&
+        !video_capability.AreResolutionAndRateSupported(kWidth8K, kHeight8K,
+                                                        /*fps=*/60)) {
       is_av1_8k_capped_at_30_ = true;
       break;
     }

--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -457,15 +457,18 @@ std::string MediaCapabilitiesCache::FindAudioDecoder(
   std::lock_guard scoped_lock(mutex_);
   UpdateMediaCapabilities_Locked();
 
-  for (const auto& audio_capability :
-       audio_codec_capabilities_map_[mime_type]) {
+  auto iter = audio_codec_capabilities_map_.find(mime_type);
+  if (iter == audio_codec_capabilities_map_.end()) {
+    return "";
+  }
+
+  for (const auto& audio_capability : iter->second) {
     // Reject if bitrate is not supported.
     if (!audio_capability.IsBitrateSupported(bitrate)) {
       continue;
     }
     return audio_capability.name();
   }
-
   return "";
 }
 
@@ -503,9 +506,12 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
 
   std::lock_guard scoped_lock(mutex_);
   UpdateMediaCapabilities_Locked();
+  auto iter = video_codec_capabilities_map_.find(mime_type);
+  if (iter == video_codec_capabilities_map_.end()) {
+    return "";
+  }
 
-  for (const auto& video_capability :
-       video_codec_capabilities_map_[mime_type]) {
+  for (const auto& video_capability : iter->second) {
     // Reject if secure decoder is required but codec doesn't support it.
     if (must_support_secure && !video_capability.is_secure_supported()) {
       continue;
@@ -617,9 +623,13 @@ void MediaCapabilitiesCache::LoadAudioConfigurations_Locked() {
 
 void MediaCapabilitiesCache::LoadIsAv18kCappedAt30_Locked() {
   is_av1_8k_capped_at_30_ = false;
-  for (const auto& video_capability :
-       video_codec_capabilities_map_[SupportedVideoCodecToMimeType(
-           kSbMediaVideoCodecAv1)]) {
+  auto mime_type = SupportedVideoCodecToMimeType(kSbMediaVideoCodecAv1);
+  auto iter = video_codec_capabilities_map_.find(mime_type);
+  if (iter == video_codec_capabilities_map_.end()) {
+    return;
+  }
+
+  for (const auto& video_capability : iter->second) {
     constexpr int kWidth8K = 7680;
     constexpr int kHeight8K = 4320;
     if (video_capability.AreResolutionAndRateSupported(kWidth8K, kHeight8K,

--- a/starboard/android/shared/media_capabilities_cache.h
+++ b/starboard/android/shared/media_capabilities_cache.h
@@ -48,8 +48,8 @@ class CodecCapability {
   virtual ~CodecCapability() {}
 
   // Move-only.
-  CodecCapability(CodecCapability&&) = default;
-  CodecCapability& operator=(CodecCapability&&) = default;
+  CodecCapability(CodecCapability&&) noexcept = default;
+  CodecCapability& operator=(CodecCapability&&) noexcept = default;
   CodecCapability(const CodecCapability&) = delete;
   CodecCapability& operator=(const CodecCapability&) = delete;
 
@@ -83,8 +83,8 @@ class AudioCodecCapability : public CodecCapability {
   ~AudioCodecCapability() override {}
 
   // Move-only.
-  AudioCodecCapability(AudioCodecCapability&&) = default;
-  AudioCodecCapability& operator=(AudioCodecCapability&&) = default;
+  AudioCodecCapability(AudioCodecCapability&&) noexcept = default;
+  AudioCodecCapability& operator=(AudioCodecCapability&&) noexcept = default;
   AudioCodecCapability(const AudioCodecCapability&) = delete;
   AudioCodecCapability& operator=(const AudioCodecCapability&) = delete;
 
@@ -111,8 +111,8 @@ class VideoCodecCapability : public CodecCapability {
   ~VideoCodecCapability() override {}
 
   // Move-only.
-  VideoCodecCapability(VideoCodecCapability&&) = default;
-  VideoCodecCapability& operator=(VideoCodecCapability&&) = default;
+  VideoCodecCapability(VideoCodecCapability&&) noexcept = default;
+  VideoCodecCapability& operator=(VideoCodecCapability&&) noexcept = default;
   VideoCodecCapability(const VideoCodecCapability&) = delete;
   VideoCodecCapability& operator=(const VideoCodecCapability&) = delete;
 

--- a/starboard/android/shared/media_capabilities_cache.h
+++ b/starboard/android/shared/media_capabilities_cache.h
@@ -47,6 +47,12 @@ class CodecCapability {
                   jni_zero::ScopedJavaLocalRef<jobject>& j_codec_info);
   virtual ~CodecCapability() {}
 
+  // Move-only.
+  CodecCapability(CodecCapability&&) = default;
+  CodecCapability& operator=(CodecCapability&&) = default;
+  CodecCapability(const CodecCapability&) = delete;
+  CodecCapability& operator=(const CodecCapability&) = delete;
+
   const std::string& name() const { return name_; }
   bool is_secure_required() const { return is_secure_required_; }
   bool is_secure_supported() const { return is_secure_supported_; }
@@ -61,14 +67,11 @@ class CodecCapability {
                   bool is_tunnel_sup);
 
  private:
-  CodecCapability(const CodecCapability&) = delete;
-  CodecCapability& operator=(const CodecCapability&) = delete;
-
-  const std::string name_;
-  const bool is_secure_required_;
-  const bool is_secure_supported_;
-  const bool is_tunnel_mode_required_;
-  const bool is_tunnel_mode_supported_;
+  std::string name_;
+  bool is_secure_required_;
+  bool is_secure_supported_;
+  bool is_tunnel_mode_required_;
+  bool is_tunnel_mode_supported_;
 };
 
 class AudioCodecCapability : public CodecCapability {
@@ -78,6 +81,12 @@ class AudioCodecCapability : public CodecCapability {
       jni_zero::ScopedJavaLocalRef<jobject>& j_codec_info,
       jni_zero::ScopedJavaLocalRef<jobject>& j_audio_capabilities);
   ~AudioCodecCapability() override {}
+
+  // Move-only.
+  AudioCodecCapability(AudioCodecCapability&&) = default;
+  AudioCodecCapability& operator=(AudioCodecCapability&&) = default;
+  AudioCodecCapability(const AudioCodecCapability&) = delete;
+  AudioCodecCapability& operator=(const AudioCodecCapability&) = delete;
 
   bool IsBitrateSupported(int bitrate) const;
 
@@ -90,10 +99,7 @@ class AudioCodecCapability : public CodecCapability {
                        Range supported_bitrates);
 
  private:
-  AudioCodecCapability(const AudioCodecCapability&) = delete;
-  AudioCodecCapability& operator=(const AudioCodecCapability&) = delete;
-
-  const Range supported_bitrates_;
+  Range supported_bitrates_;
 };
 
 class VideoCodecCapability : public CodecCapability {
@@ -103,6 +109,12 @@ class VideoCodecCapability : public CodecCapability {
       jni_zero::ScopedJavaLocalRef<jobject>& j_codec_info,
       jni_zero::ScopedJavaLocalRef<jobject>& j_video_capabilities);
   ~VideoCodecCapability() override {}
+
+  // Move-only.
+  VideoCodecCapability(VideoCodecCapability&&) = default;
+  VideoCodecCapability& operator=(VideoCodecCapability&&) = default;
+  VideoCodecCapability(const VideoCodecCapability&) = delete;
+  VideoCodecCapability& operator=(const VideoCodecCapability&) = delete;
 
   bool is_software_decoder() const { return is_software_decoder_; }
   bool is_hdr_capable() const { return is_hdr_capable_; }
@@ -132,16 +144,13 @@ class VideoCodecCapability : public CodecCapability {
                        Range supported_frame_rates);
 
  private:
-  VideoCodecCapability(const VideoCodecCapability&) = delete;
-  VideoCodecCapability& operator=(const VideoCodecCapability&) = delete;
-
-  const bool is_software_decoder_;
-  const bool is_hdr_capable_;
-  const jni_zero::ScopedJavaGlobalRef<jobject> j_video_capabilities_;
-  const Range supported_widths_;
-  const Range supported_heights_;
-  const Range supported_bitrates_;
-  const Range supported_frame_rates_;
+  bool is_software_decoder_;
+  bool is_hdr_capable_;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_video_capabilities_;
+  Range supported_widths_;
+  Range supported_heights_;
+  Range supported_bitrates_;
+  Range supported_frame_rates_;
 };
 
 class MediaCapabilitiesProvider {
@@ -155,14 +164,15 @@ class MediaCapabilitiesProvider {
       int index,
       SbMediaAudioConfiguration* configuration) = 0;
 
-  typedef std::vector<std::unique_ptr<AudioCodecCapability>>
-      AudioCodecCapabilities;
-  typedef std::vector<std::unique_ptr<VideoCodecCapability>>
-      VideoCodecCapabilities;
-  virtual void GetCodecCapabilities(
-      std::map<std::string, AudioCodecCapabilities>& audio_codec_capabilities,
-      std::map<std::string, VideoCodecCapabilities>&
-          video_codec_capabilities) = 0;
+  using AudioCodecCapabilities = std::vector<AudioCodecCapability>;
+  using VideoCodecCapabilities = std::vector<VideoCodecCapability>;
+
+  struct CodecCapabilities {
+    std::map<std::string, AudioCodecCapabilities> audio;
+    std::map<std::string, VideoCodecCapabilities> video;
+  };
+
+  virtual CodecCapabilities GetCodecCapabilities() = 0;
 };
 
 class MediaCapabilitiesCache {
@@ -251,10 +261,8 @@ class MediaCapabilitiesCache {
   std::set<SbMediaTransferId> supported_transfer_ids_;
   std::map<SbMediaAudioCodec, bool> passthrough_supportabilities_;
 
-  typedef std::vector<std::unique_ptr<AudioCodecCapability>>
-      AudioCodecCapabilities;
-  typedef std::vector<std::unique_ptr<VideoCodecCapability>>
-      VideoCodecCapabilities;
+  using AudioCodecCapabilities = std::vector<AudioCodecCapability>;
+  using VideoCodecCapabilities = std::vector<VideoCodecCapability>;
   std::map<std::string, AudioCodecCapabilities> audio_codec_capabilities_map_;
   std::map<std::string, VideoCodecCapabilities> video_codec_capabilities_map_;
   std::vector<SbMediaAudioConfiguration> audio_configurations_;

--- a/starboard/android/shared/media_capabilities_cache_test.cc
+++ b/starboard/android/shared/media_capabilities_cache_test.cc
@@ -260,8 +260,8 @@ TEST_F(MediaCapabilitiesCacheTest, ClearCacheClearsAllValues) {
 
   EXPECT_CALL(*mock_media_capabilities_provider_, GetCodecCapabilities())
       .Times(2)
-      .WillRepeatedly(testing::Return(
-          ByMove(MediaCapabilitiesProvider::CodecCapabilities())));
+      .WillRepeatedly(testing::Invoke(
+          [] { return MediaCapabilitiesProvider::CodecCapabilities(); }));
 
   EXPECT_TRUE(cache_->IsWidevineSupported());
   EXPECT_TRUE(cache_->IsCbcsSchemeSupported());
@@ -294,7 +294,7 @@ TEST_F(MediaCapabilitiesCacheTest, ClearCacheClearsAllValues) {
 
 TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
   EXPECT_CALL(*mock_media_capabilities_provider_, GetCodecCapabilities())
-      .WillOnce(testing::Invoke([]() {
+      .WillOnce(testing::Invoke([] {
         MediaCapabilitiesProvider::CodecCapabilities capabilities;
         capabilities.video["video/x-vnd.on2.vp9"] = CreateVp9DecoderCaps(
             /*is_tunnel_sup=*/true, /*is_secure_sup=*/true,
@@ -355,7 +355,7 @@ TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
 
 TEST_F(MediaCapabilitiesCacheTest, FindVideoDecoder_Overload) {
   EXPECT_CALL(*mock_media_capabilities_provider_, GetCodecCapabilities())
-      .WillOnce(testing::Invoke([]() {
+      .WillOnce(testing::Invoke([] {
         MediaCapabilitiesProvider::CodecCapabilities capabilities;
         capabilities.video["video/x-vnd.on2.vp9"] = CreateVp9DecoderCaps(
             /*is_tunnel_sup=*/true, /*is_secure_sup=*/true,
@@ -373,7 +373,7 @@ TEST_F(MediaCapabilitiesCacheTest, FindVideoDecoder_Overload) {
 
 TEST_F(MediaCapabilitiesCacheTest, RejectLowPerformanceSoftwareDecoder) {
   EXPECT_CALL(*mock_media_capabilities_provider_, GetCodecCapabilities())
-      .WillOnce(testing::Invoke([]() {
+      .WillOnce(testing::Invoke([] {
         MediaCapabilitiesProvider::CodecCapabilities capabilities;
         MediaCapabilitiesProvider::VideoCodecCapabilities caps;
         caps.push_back(MockVideoCodecCapability(

--- a/starboard/android/shared/media_capabilities_cache_test.cc
+++ b/starboard/android/shared/media_capabilities_cache_test.cc
@@ -39,12 +39,12 @@ MediaCapabilitiesProvider::VideoCodecCapabilities CreateVp9DecoderCaps(
     Range bitrate = Range{0, 10'000'000},
     Range fps = Range{0, 30}) {
   MediaCapabilitiesProvider::VideoCodecCapabilities caps;
-  caps.push_back(std::make_unique<MockVideoCodecCapability>(
-      "OMX.google.vp9.decoder",
-      /*is_secure_req=*/false, is_secure_sup,
-      /*is_tunnel_req=*/false, is_tunnel_sup,
-      /*is_software_decoder=*/false, is_hdr_capable, width, height, bitrate,
-      fps));
+  caps.push_back(
+      MockVideoCodecCapability("OMX.google.vp9.decoder",
+                               /*is_secure_req=*/false, is_secure_sup,
+                               /*is_tunnel_req=*/false, is_tunnel_sup,
+                               /*is_software_decoder=*/false, is_hdr_capable,
+                               width, height, bitrate, fps));
   return caps;
 }
 
@@ -258,10 +258,10 @@ TEST_F(MediaCapabilitiesCacheTest, ClearCacheClearsAllValues) {
       .WillOnce(Return(true))
       .WillOnce(Return(false));
 
-  EXPECT_CALL(*mock_media_capabilities_provider_,
-              GetCodecCapabilities(testing::_, testing::_))
+  EXPECT_CALL(*mock_media_capabilities_provider_, GetCodecCapabilities())
       .Times(2)
-      .WillRepeatedly(Return());
+      .WillRepeatedly(testing::Return(
+          ByMove(MediaCapabilitiesProvider::CodecCapabilities())));
 
   EXPECT_TRUE(cache_->IsWidevineSupported());
   EXPECT_TRUE(cache_->IsCbcsSchemeSupported());
@@ -293,13 +293,14 @@ TEST_F(MediaCapabilitiesCacheTest, ClearCacheClearsAllValues) {
 }
 
 TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
-  EXPECT_CALL(*mock_media_capabilities_provider_,
-              GetCodecCapabilities(testing::_, testing::_))
-      .WillOnce(testing::Invoke([](auto&, auto& video_caps) {
-        video_caps["video/x-vnd.on2.vp9"] = CreateVp9DecoderCaps(
+  EXPECT_CALL(*mock_media_capabilities_provider_, GetCodecCapabilities())
+      .WillOnce(testing::Invoke([]() {
+        MediaCapabilitiesProvider::CodecCapabilities capabilities;
+        capabilities.video["video/x-vnd.on2.vp9"] = CreateVp9DecoderCaps(
             /*is_tunnel_sup=*/true, /*is_secure_sup=*/true,
             /*is_hdr_capable=*/false, Range{0, 1920}, Range{0, 1080},
             Range{0, 10'000'000}, Range{0, 30});
+        return capabilities;
       }));
 
   EXPECT_TRUE(cache_->HasVideoDecoderFor("video/x-vnd.on2.vp9",
@@ -353,12 +354,13 @@ TEST_F(MediaCapabilitiesCacheTest, HasVideoDecoderFor_ResolutionLimits) {
 }
 
 TEST_F(MediaCapabilitiesCacheTest, FindVideoDecoder_Overload) {
-  EXPECT_CALL(*mock_media_capabilities_provider_,
-              GetCodecCapabilities(testing::_, testing::_))
-      .WillOnce(testing::Invoke([](auto&, auto& video_caps) {
-        video_caps["video/x-vnd.on2.vp9"] = CreateVp9DecoderCaps(
+  EXPECT_CALL(*mock_media_capabilities_provider_, GetCodecCapabilities())
+      .WillOnce(testing::Invoke([]() {
+        MediaCapabilitiesProvider::CodecCapabilities capabilities;
+        capabilities.video["video/x-vnd.on2.vp9"] = CreateVp9DecoderCaps(
             /*is_tunnel_sup=*/true, /*is_secure_sup=*/true,
             /*is_hdr_capable=*/true);
+        return capabilities;
       }));
 
   EXPECT_EQ(cache_->FindVideoDecoder("video/x-vnd.on2.vp9",
@@ -370,18 +372,19 @@ TEST_F(MediaCapabilitiesCacheTest, FindVideoDecoder_Overload) {
 }
 
 TEST_F(MediaCapabilitiesCacheTest, RejectLowPerformanceSoftwareDecoder) {
-  EXPECT_CALL(*mock_media_capabilities_provider_,
-              GetCodecCapabilities(testing::_, testing::_))
-      .WillOnce(testing::Invoke([](auto&, auto& video_caps) {
+  EXPECT_CALL(*mock_media_capabilities_provider_, GetCodecCapabilities())
+      .WillOnce(testing::Invoke([]() {
+        MediaCapabilitiesProvider::CodecCapabilities capabilities;
         MediaCapabilitiesProvider::VideoCodecCapabilities caps;
-        caps.push_back(std::make_unique<MockVideoCodecCapability>(
+        caps.push_back(MockVideoCodecCapability(
             "OMX.test.soft.vp9.decoder",
             /*is_secure_req=*/false, /*is_secure_sup=*/false,
             /*is_tunnel_req=*/false, /*is_tunnel_sup=*/false,
             /*is_software_decoder=*/true,
             /*is_hdr_capable=*/false, Range{0, 1280}, Range{0, 720},
             Range{0, 5'000'000}, Range{0, 30}));
-        video_caps["video/x-vnd.on2.vp9"] = std::move(caps);
+        capabilities.video["video/x-vnd.on2.vp9"] = std::move(caps);
+        return capabilities;
       }));
 
   // Case 1: Feature is disabled (default). It should find the software decoder.

--- a/starboard/android/shared/mock_media_capabilities_cache.h
+++ b/starboard/android/shared/mock_media_capabilities_cache.h
@@ -64,13 +64,7 @@ class MockMediaCapabilitiesProvider final : public MediaCapabilitiesProvider {
               GetAudioConfiguration,
               (int index, SbMediaAudioConfiguration* configuration),
               (override));
-  MOCK_METHOD(
-      void,
-      GetCodecCapabilities,
-      ((std::map<std::string, AudioCodecCapabilities>)&audio_codec_capabilities,
-       (std::map<std::string,
-                 VideoCodecCapabilities>)&video_codec_capabilities),
-      (override));
+  MOCK_METHOD(CodecCapabilities, GetCodecCapabilities, (), (override));
 };
 
 class MockMediaCapabilitiesCache final : public MediaCapabilitiesCache {


### PR DESCRIPTION
mprove performance of the media capabilities cache by increasing
spatial locality and reducing cache misses during iteration. Storing
codec capability objects directly in vectors rather than using
pointers eliminates unnecessary memory indirection.

Additionally, the MediaCapabilitiesProvider API is modernized to
return a struct by value instead of using output parameters, and
the capability classes are updated to be move-only.

go/fast/92

Issue: 1234