### PR TITLE
android: Populate gl_implementation_parts in-process path

### DIFF
--- a/gpu/ipc/service/gpu_init.cc
+++ b/gpu/ipc/service/gpu_init.cc
@@ -953,6 +953,8 @@ void GpuInit::InitializeInProcess(base::CommandLine* command_line,
     LOG(FATAL) << "gpu::InitializeGLThreadSafe() failed.";
   }
 
+  gpu_info_.gl_implementation_parts = gl::GetGLImplementationParts();
+
   if (command_line->HasSwitch(switches::kWebViewDrawFunctorUsesVulkan)) {
     bool result = InitializeVulkan();
     // There is no fallback for webview.


### PR DESCRIPTION
`GpuInit::InitializeInProcess` did not populate `gl_implementation_part` in GPUInfo for the Android path. This caused diagnostics (such as chrome://gpu) to report `gl=none,angle=none` even though hardware GL and ANGLE were successfully initialized and active.                                                                                          
                                                                                                                                                 
This PR fixes the issue by copying the active GL implementation parts to `gpu_info_` right after successful GL initialization, matching the behavior of the non-Android / out-of-process initialization paths.  

Bug: 517566565