### PR TITLE
cobalt: Disable CC image cache items limit

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -246,6 +246,7 @@ source_set("common") {
 
   deps = [
     "//base",
+    "//cc/base",
     "//cobalt/browser:switches",
     "//cobalt/browser/h5vcc_accessibility:manager",
     "//cobalt/browser/h5vcc_runtime:deep_link_manager",

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -16,6 +16,7 @@
 
 #include "base/base_switches.h"
 #include "build/buildflag.h"
+#include "cc/base/switches.h"
 #include "cobalt/app/cobalt_switch_defaults.h"
 #include "cobalt/browser/switches.h"
 #include "cobalt/shell/common/shell_switches.h"
@@ -119,6 +120,8 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
       // Disable decommitting pooled pages to prevent virtual memory
       // fragmentation.
       {blink::switches::kJavaScriptFlags, "--no-decommit-pooled-pages"},
+      // Disable CC image cache items limit.
+      {::switches::kCCImageCacheLimitItems, "0"},
   };
   return kCobaltSwitchDefaults;
 }


### PR DESCRIPTION
Set kCCImageCacheLimitItems to "0" in Cobalt switch defaults for Starboard. This disables the limit on the number of items in the CC image cache, which can improve performance by reducing cache evictions for some workloads.

Also added the necessary dependency on //cc/base and the header include for cc/base/switches.h.

Bug: 512157288