### PR TITLE
    media: Draw punch hole when native player is in presenting state

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -742,8 +742,7 @@ void StarboardRenderer::UpdateDecoderConfig(DemuxerStream* stream) {
     }
 #endif  // 0
     color_space_ = decoder_config.color_space_info().ToGfxColorSpace();
-    paint_video_hole_frame_cb_.Run(
-        stream->video_decoder_config().visible_rect().size());
+    video_rect_ = stream->video_decoder_config().visible_rect();
   }
 }
 
@@ -824,8 +823,11 @@ void StarboardRenderer::OnDemuxerStreamRead(
       // TODO(b/375275033): Refine calling to OnVideoNaturalSizeChange().
       client_->OnVideoNaturalSizeChange(
           stream->video_decoder_config().visible_rect().size());
-      paint_video_hole_frame_cb_.Run(
-          stream->video_decoder_config().visible_rect().size());
+
+      video_rect_ = stream->video_decoder_config().visible_rect();
+      if (state_ == STATE_PLAYING) {
+        paint_video_hole_frame_cb_.Run(video_rect_.size());
+      }
     }
     UpdateDecoderConfig(stream);
     stream->Read(
@@ -976,6 +978,7 @@ void StarboardRenderer::OnPlayerStatus(SbPlayerState state) {
     case kSbPlayerStatePrerolling:
       break;
     case kSbPlayerStatePresenting:
+      paint_video_hole_frame_cb_.Run(video_rect_.size());
       buffering_state_ = BUFFERING_HAVE_ENOUGH;
       task_runner_->PostTask(
           FROM_HERE,

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -230,6 +230,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   OverlayInfo overlay_info_;
 
   std::optional<gfx::Rect> output_rect_;
+  gfx::Rect video_rect_;
 
   // Temporary callback used for Initialize().
   PipelineStatusCallback init_cb_;


### PR DESCRIPTION
media: Draw punch hole when player is presenting

Postpone punch hole drawing until the native player has finished
prerolling and is ready to move to the presenting state.

Previously, the punch hole was drawn as soon as the decoded frame size
was available, even if playback had not yet started. This caused
visible flickering and "behind the scenes" black content to appear
during video transitions.

Bug: 474168518
