### PR TITLE
cobalt: Add scrolling to RDK memory benchmarks

### DIFF
--- a/cobalt/tools/performance/memory/README.md
+++ b/cobalt/tools/performance/memory/README.md
@@ -54,7 +54,8 @@ python3 compare_accuracy.py --uma_log uma_histos.txt --smaps_dir cobalt_smaps_lo
 This shell script is designed for RDK-based devices to measure memory usage across critical scenarios and establish a memory baseline. It automates the process of launching `loader_app`, collecting samples, and generating a final report.
 
 **Key Features:**
-- **Critical Scenarios:** Benchmarks Home Page, Blank Page, 1080p, and 4K video playback.
+- **Critical Scenarios:** Benchmarks Home Page (static & scrolling), Blank Page, 1080p and 4K video playback (standard & scrolling).
+- **Interactive Simulation:** Simulates user interactions such as continuous scrolling or playback navigation (via `sendkey` inputs) to measure dynamic memory characteristics.
 - **Multi-Source Metrics:** Collects Resident Set Size (RSS) from both `smaps` (or `smaps_rollup`) and `top`.
 - **GPU Monitoring:** Specifically tracks Mali GPU memory usage via debugfs.
 - **Statistical Analysis:** Calculates Median and Peak RSS for each round and provides averages across multiple rounds for robust benchmarking.

--- a/cobalt/tools/performance/memory/rdk_memory_benchmark.sh
+++ b/cobalt/tools/performance/memory/rdk_memory_benchmark.sh
@@ -17,13 +17,19 @@ echo "Memory Test Started at $(date)" > "$OUTPUT_FILE"
 # Redirect stdout and stderr to both terminal and output file
 exec > >(tee -a "$OUTPUT_FILE") 2>&1
 
-# Define scenarios: name|url|duration|rounds
+# Define scenarios: name|url|duration|rounds|action
 # If rounds is omitted, it defaults to 1.
+# Supported actions:
+#   - scroll: Presses the 'right' key (sendkey right) every second.
+#   - playback_scroll: Plays video for 1 minute, clicks down twice, then presses 'right' every second for 1 minutes.
 SCENARIOS=(
-    "Default Page|https://www.youtube.com/tv|60|3"
+    "Default Page|https://www.youtube.com/tv|60|5"
     "About Blank|about:blank|30|1"
-    "4K Video Playback|https://www.youtube.com/tv#/watch?v=1La4QzGeaaQ|180|3"
-    "1080p Video Playback|https://www.youtube.com/tv#/watch?v=ou0cmY8Fqd0|180|3"
+    "4K Video Playback|https://www.youtube.com/tv#/watch?v=1La4QzGeaaQ|180|5"
+    "1080p Video Playback|https://www.youtube.com/tv#/watch?v=ou0cmY8Fqd0|180|5"
+    "Home Page Scroll|https://www.youtube.com/tv|120|5|scroll"
+    "4K Playback Scroll|https://www.youtube.com/tv#/watch?v=1La4QzGeaaQ|120|5|playback_scroll"
+    "1080p Playback Scroll|https://www.youtube.com/tv#/watch?v=ou0cmY8Fqd0|120|5|playback_scroll"
 )
 
 # Function to calculate median
@@ -167,7 +173,7 @@ scenario_data_ordered=()
 scenario_rounds_ordered=()
 
 for scenario_info in "${SCENARIOS[@]}"; do
-    IFS='|' read -r scenario_name scenario_command scenario_duration scenario_rounds <<< "$scenario_info"
+    IFS='|' read -r scenario_name scenario_command scenario_duration scenario_rounds scenario_action <<< "$scenario_info"
 
     # If rounds is omitted, it defaults to 1.
     if [ -z "$scenario_rounds" ]; then
@@ -248,6 +254,20 @@ for scenario_info in "${SCENARIOS[@]}"; do
 
             printf "[%3d/%3d] smaps: RSS %s MB | status: RSS %s MB | gpu: %s MB\n" \
                 "$i" "$scenario_duration" "$(kb_to_mb $s_rss)" "$(kb_to_mb $t_rss)" "$(kb_to_mb $g_rss)"
+
+            # Inject scroll event if requested
+            if [ "$scenario_action" = "scroll" ]; then
+                echo "Injecting scroll event: sendkey right"
+                sendkey right > /dev/null 2>&1
+            elif [ "$scenario_action" = "playback_scroll" ]; then
+                if [ $i -eq 61 ] || [ $i -eq 62 ]; then
+                    echo "Injecting key event: sendkey down"
+                    sendkey down > /dev/null 2>&1
+                elif [ $i -ge 63 ]; then
+                    echo "Injecting scroll event: sendkey right"
+                    sendkey right > /dev/null 2>&1
+                fi
+            fi
 
             sleep $INTERVAL
         done


### PR DESCRIPTION
Add interactive scrolling and playback navigation scenarios to the RDK
memory benchmark tool. These additions simulate user behavior to
measure dynamic memory usage patterns beyond static page loads,
providing a more comprehensive memory baseline for RDK-based devices.

Bug: 477961848