### PR TITLE
Revert `GetHeapSize` to only `used_heap_size` (CP #7865)

### DIFF
--- a/third_party/blink/renderer/core/timing/memory_info.cc
+++ b/third_party/blink/renderer/core/timing/memory_info.cc
@@ -34,6 +34,7 @@
 
 #include "base/time/default_tick_clock.h"
 #include "base/time/time.h"
+#include "build/build_config.h"
 #include "third_party/blink/renderer/core/frame/settings.h"
 #include "third_party/blink/renderer/platform/runtime_enabled_features.h"
 #include "third_party/blink/renderer/platform/wtf/math_extras.h"
@@ -47,10 +48,19 @@ static constexpr base::TimeDelta kFiftyMs = base::Milliseconds(50);
 static void GetHeapSize(HeapInfo& info) {
   v8::HeapStatistics heap_statistics;
   v8::Isolate::GetCurrent()->GetHeapStatistics(&heap_statistics);
+#if BUILDFLAG(IS_COBALT)
+  // TODO - b/457773763: Chromium upstream calculates `used_js_heap_size` and
+  // `total_js_heap_size` to include `external_memory`. This is not backwards
+  // compatible with previous versions of Cobalt. For now, remove
+  // `external_memory`. Introduce a separate API to include it.
+  info.used_js_heap_size = heap_statistics.used_heap_size();
+  info.total_js_heap_size = heap_statistics.total_physical_size();
+#else
   info.used_js_heap_size =
       heap_statistics.used_heap_size() + heap_statistics.external_memory();
   info.total_js_heap_size =
       heap_statistics.total_physical_size() + heap_statistics.external_memory();
+#endif
   info.js_heap_size_limit = heap_statistics.heap_size_limit();
 }
 


### PR DESCRIPTION
Upstream Chromium calculates `used_js_heap_size` by including `external_memory`. This is not backwards compatible with previous versions of Cobalt where it was only `used_heap_size`. Revert this for now and check canary metrics. Follow up with introducing a new API that takes into account `external_memory`: b/457773763

Bug: 456183913