### PR TITLE
android: Add java switch to force angle OpenGL ES

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -70,6 +70,9 @@ public class JavaSwitches {
   public static final String COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE =
       "CobaltDynamicMojoPipeSubresourceSize";
 
+  /** flag to specify ANGLE to use the OpenGL ES backend */
+  public static final String COBALT_USE_ANGLE_GLES = "CobaltUseAngleGles";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
 
@@ -142,6 +145,10 @@ public class JavaSwitches {
     if (featureParams.length() > 0) {
       extraCommandLineArgs.add(
           "--enable-features=SmallerInterestArea:" + featureParams.toString());
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.COBALT_USE_ANGLE_GLES)) {
+      extraCommandLineArgs.add("--use-angle=gles");
     }
 
     return extraCommandLineArgs;


### PR DESCRIPTION
Adding a java switch to enable the experimentation of using the `--use-angle=gles` flag, restricting ANGLE to use the OpenGL ES backend specifically and avoiding the overhead of trying to initialize other unsupported backends and saving startup time.

Bug: 517566565