### PR TITLE
Enable H5VCC updater and sideloading APIs for Cobalt 27 QA builds

### DIFF
--- a/cobalt/browser/cobalt_browser_interface_binders.cc
+++ b/cobalt/browser/cobalt_browser_interface_binders.cc
@@ -39,11 +39,10 @@
 
 #if BUILDFLAG(USE_EVERGREEN)
 #include "cobalt/browser/h5vcc_updater/h5vcc_updater_impl.h"
-// TODO(b/458483469): Remove the ALLOW_EVERGREEN_SIDELOADING check after
-// security review.
-#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+
+#if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 #include "cobalt/browser/h5vcc_updater/h5vcc_updater_sideloading_impl.h"
-#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && ALLOW_EVERGREEN_SIDELOADING
+#endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 #include "cobalt/browser/h5vcc_updater/public/mojom/h5vcc_updater.mojom.h"
 #endif  // BUILDFLAG(USE_EVERGREEN)
 
@@ -123,14 +122,11 @@ void PopulateCobaltFrameBinders(
       }));
 #endif
 
-// Always register a binder for H5vccUpdaterSideloading to prevent the browser
-// from killing the Mojo connection if the renderer probes for this interface.
-// If this is not registered, it disconnects the overall BrowserInterfaceBroker
-// for the frame.
-// TODO(b/458483469): Remove the ALLOW_EVERGREEN_SIDELOADING check after
-// security review.
-#if BUILDFLAG(USE_EVERGREEN) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && \
-    ALLOW_EVERGREEN_SIDELOADING
+  // Always register a binder for H5vccUpdaterSideloading to prevent the browser
+  // from killing the Mojo connection if the renderer probes for this interface.
+  // If this is not registered, it disconnects the overall
+  // BrowserInterfaceBroker for the frame.
+#if BUILDFLAG(USE_EVERGREEN) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   binder_map->Add<h5vcc_updater::mojom::H5vccUpdaterSideloading>(
       base::BindRepeating(&h5vcc_updater::H5vccUpdaterSideloadingImpl::Create));
 #else

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_updater/h_5_vcc_updater.cc
@@ -359,10 +359,7 @@ void H5vccUpdater::OnSideloadingConnectionError() {
   // concurrent modification.
   ongoing_sideloading_requests_.swap(h5vcc_updater_promises);
   for (auto& resolver : h5vcc_updater_promises) {
-// TODO(b/458483469): Remove the ALLOW_EVERGREEN_SIDELOADING check after
-// security review.
-#if BUILDFLAG(USE_EVERGREEN) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD) && \
-    ALLOW_EVERGREEN_SIDELOADING
+#if BUILDFLAG(USE_EVERGREEN) && !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
     resolver->Reject("Mojo connection error.");
 #else
     resolver->Reject(


### PR DESCRIPTION
Removed the ALLOW_EVERGREEN_SIDELOADING preprocessor checks from the
H5vccUpdater blink bindings and the Mojo browser interface binders.
This exposes the updater sideloading JavaScript APIs in DevTools for
all non-release builds by default.

Bug: 524678633
