### PR TITLE
Disable the flag build_with_tflite_lib on Chrobalt

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -75,6 +75,7 @@ generate_about_credits = false
 # Disable WebNN and some bits of TensorFlowLite.
 build_tflite_with_xnnpack = false
 webnn_use_tflite = false
+build_with_tflite_lib = false
 
 # Disable dav1d in webrtc to reduce binary size (~533KB)
 rtc_include_dav1d_in_internal_decoder_factory = false


### PR DESCRIPTION
Turning off this flag only saves 12 KB binary size, but has greater estimated Runtime PSS/RSS savings: ~500 KB to 1.5 MB

Bug: 524713476