### PR TITLE
Disable the flag use_bundled_fontconfig in Chrobalt

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -95,3 +95,6 @@ enable_rust_png = false
 # ~0.5 MB.
 enable_backup_ref_ptr_support = false
 enable_backup_ref_ptr_feature_flag = false
+
+# Disable bundled fontconfig (use system/Starboard direct loading).
+use_bundled_fontconfig = false


### PR DESCRIPTION
Disable the use_bundled_fontconfig flag in the common build
configurations. Bundling fontconfig is unnecessary as Cobalt can
rely on Starboard or the system for font loading. This change
reduces the final binary size.

Bug: 524721099