### PR TITLE
Disable the flag enable_vectorized_html_scanning in Chrobalt

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -95,3 +95,7 @@ enable_rust_png = false
 # ~0.5 MB.
 enable_backup_ref_ptr_support = false
 enable_backup_ref_ptr_feature_flag = false
+
+# Disable vectorized HTML scanning (SIMD speedups for HTML parsing
+# are not needed).
+enable_vectorized_html_scanning = false


### PR DESCRIPTION
Disable the vectorized HTML scanning flag in the common GN
configuration. SIMD speedups for HTML parsing are not currently
required for Cobalt, so this feature is disabled to reduce binary
complexity and resource overhead.

Bug: 524727943