### PR TITLE
Revert "cobalt: Fix EGL destruction crash on Shield"

### DIFF
--- a/ui/gl/gl_context_egl.cc
+++ b/ui/gl/gl_context_egl.cc
@@ -411,20 +411,10 @@ void GLContextEGL::Destroy() {
   ReleaseBackpressureFences();
   OnContextWillDestroy();
   if (context_) {
-#if BUILDFLAG(IS_COBALT)
-    EGLDisplay display = gl_display_->GetDisplay();
-    if (display != EGL_NO_DISPLAY) {
-      if (!eglDestroyContext(display, context_)) {
-        LOG(ERROR) << "eglDestroyContext failed with error "
-                   << GetLastEGLErrorString();
-      }
-    }
-#else  // BUILDFLAG(IS_COBALT)
     if (!eglDestroyContext(gl_display_->GetDisplay(), context_)) {
       LOG(ERROR) << "eglDestroyContext failed with error "
                  << GetLastEGLErrorString();
     }
-#endif  // BUILDFLAG(IS_COBALT)
 
     context_ = nullptr;
   }


### PR DESCRIPTION
Reverts youtube/cobalt#10690 as it doesn't resolve the crash on shield.

Issue: 517926212