### PR TITLE
cobalt/tools: Add memory breakdown text file

### DIFF
--- a/cobalt/tools/uma/memory_breakdown_histograms.txt
+++ b/cobalt/tools/uma/memory_breakdown_histograms.txt
@@ -1,0 +1,11 @@
+Memory.Browser.LibChrobaltRss
+Memory.Browser.ResidentSet
+Memory.Experimental.Browser2.AndroidRuntime
+Memory.Experimental.Browser2.AshmemJit
+Memory.Experimental.Browser2.CodeOther
+Memory.Experimental.Browser2.Fonts
+Memory.Experimental.Browser2.JavaHeap
+Memory.Experimental.Browser2.Malloc
+Memory.Experimental.Browser2.PartitionAlloc
+Memory.Experimental.Browser2.Stacks
+Memory.Experimental.Browser2.V8


### PR DESCRIPTION
This enables users of `pull_uma_histogram_set_via_cdp.py` to pull the same metics as in the memory metrics dashboard on local runs.

Bug: 524757806