### PR TITLE
Add gemini  rdk skill

### DIFF
--- a/.agent/skills/cobalt-rdk-deploy/SKILL.md
+++ b/.agent/skills/cobalt-rdk-deploy/SKILL.md
@@ -1,0 +1,36 @@
+---
+name: cobalt-rdk-deploy
+description: >-
+  Builds, deploys, runs, resets, and inspects logs for Cobalt on RDK devices using deploy_rdk.py. Use when compiling or launching Cobalt, running GTest suites, resetting active display sessions, or fetching journalctl logs from the target RDK box. Don't use for generic Linux, Android, or Raspberry Pi builds.
+---
+
+# Cobalt RDK Deploy Skill
+
+A skill for building, deploying, running, and debugging Cobalt on RDK devices using the `deploy_rdk.py` CLI script.
+
+## Quick Start
+
+Create an alias for the deployment script:
+
+```bash
+alias deploy_rdk='python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py'
+```
+
+## Execution Protocol
+
+1. **Always query `--help` first** to inspect the available arguments and execution modes of the script:
+   ```bash
+   deploy_rdk --help
+   ```
+
+2. **Formulate and run the command** directly based on the self-documenting options. Do not guess flags or hardcode command paths.
+
+3. **Avoid manual device interaction:** Do NOT run raw shell commands (via `adb shell` or `ssh`) directly on the target device to perform pre-flight checks (such as verifying device properties, OS versions, symlinks, or config status). The `deploy_rdk.py` script automatically manages all version checks, configuration switches, display resets, and reboots internally. Trust the script and execute your formulated command directly.
+
+4. **Identify the connection method:**
+   - **ADB (Default):** The script defaults to ADB for device interaction.
+   - **SSH/SCP:** If you need to target a remote device over SSH, check `--help` for the IP-based configuration flags (e.g., `--device-ip`).
+
+5. **Do NOT use `--no-rbe` by default:** Remote Build Execution (RBE) is enabled by default and must be used for compilation. Only pass the `--no-rbe` flag if RBE build commands fail.
+
+6. **Assume the toolchain is present:** Do NOT pre-emptively check for the cross-compilation toolchain (do not run `echo $RDK_HOME` or list directories to verify sysroots). Assume it is fully configured and present by default. Only troubleshoot the toolchain or run `--setup-toolchain` if the compilation step (`autoninja`) fails with compiler/toolchain errors, or if the user explicitly requests it.


### PR DESCRIPTION
This PR adds the `cobalt-rdk-deploy` agent skill to the repository under `.agent/skills/`.

The skill provides guidelines and execution protocols for Gemini/Jetski to build, deploy, run, and debug Cobalt on RDK devices using the `deploy_rdk.py` script.

### Guidelines included:
1. **Rely on help:** Always run `--help` first to discover available execution modes and flags.
2. **Execute via script:** Formulate and run the `deploy_rdk.py` script directly to interact with the device.
3. **Avoid manual device interaction:** Explicitly forbids running raw shell commands (via `adb shell` or `ssh`) directly on the target device for pre-flight checks (trusting the script to handle them).
4. **Toolchain assumptions:** Assume the compilation toolchain is present by default and do not run `--setup-toolchain` or perform manual pre-emptive checks (like checking `$RDK_HOME`) unless compilation fails.
5. **No-RBE default:** Avoid passing `--no-rbe` by default (only use it if compilation fails).

Bug: 502702565

TAG=agy
CONV=e3d4c794-091a-4ae7-8cd1-810eebeb07ee