### PR TITLE
media: Reduce redundant SbPlayerSetBounds calls

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -502,6 +502,10 @@ void StarboardRenderer::SetStarboardRendererCallbacks(
 
 void StarboardRenderer::OnVideoGeometryChange(const gfx::Rect& output_rect) {
   CHECK(task_runner_->RunsTasksInCurrentSequence());
+  if (output_rect_ == output_rect) {
+    return;
+  }
+
   output_rect_ = output_rect;
 
 #if BUILDFLAG(IS_ANDROID)


### PR DESCRIPTION
Avoid performing unnecessary operations when the video geometry has
not changed. By caching the current output rectangle and comparing
it against new updates, the renderer can skip redundant calls to the
underlying media player, improving efficiency during playback.

Issue: 525034548
Issue: 494377380