### PR TITLE
media: Reduce redundant SbPlayerSetBounds calls

### DIFF
--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -486,6 +486,10 @@ void StarboardRenderer::SetStarboardRendererCallbacks(
 
 void StarboardRenderer::OnVideoGeometryChange(const gfx::Rect& output_rect) {
   CHECK(task_runner_->RunsTasksInCurrentSequence());
+  if (output_rect_ == output_rect) {
+    return;
+  }
+
   output_rect_ = output_rect;
 
   ApplyPendingBounds();


### PR DESCRIPTION
Redundant geometry updates can lead to unnecessary processing in the
underlying Starboard implementation. By filtering out geometry changes
where the output rectangle remains identical, we reduce overhead and
ensure that SbPlayerSetBounds is only invoked when an actual layout
change occurs.

Issue: 525034548
Issue: 494377380