### PR TITLE
Add new JNI zero best practices

### DIFF
--- a/third_party/jni_zero/skills/jni-zero/references/jobject_subclass_examples.md
+++ b/third_party/jni_zero/skills/jni-zero/references/jobject_subclass_examples.md
@@ -76,3 +76,71 @@ return ScopedJavaLocalRef<jobject>();
 ```cpp
 return nullptr;
 ```
+
+## 5. Replacing Unsafe Manual JNI Get method call with Safe Helpers
+
+**Before:**
+
+```cpp
+const void* MediaDrmBridge::GetMetrics(int* size) {
+  JNIEnv* env = AttachCurrentThread();
+  ScopedJavaLocalRef<jbyteArray> j_metrics = Java_MediaDrmBridge_getMetrics(env, j_media_drm_bridge_);
+  
+  // Unsafe: Manual pointer retrieval
+  jbyte* metrics_elements = env->GetByteArrayElements(j_metrics.obj(), nullptr);
+  jsize metrics_size = base::android::SafeGetArrayLength(env, j_metrics);
+  SB_DCHECK(metrics_elements);
+
+  metrics_.assign(metrics_elements, metrics_elements + metrics_size);
+
+  // Unsafe: Must remember to release, otherwise it leaks!
+  env->ReleaseByteArrayElements(j_metrics.obj(), metrics_elements, JNI_ABORT);
+  
+  *size = static_cast<int>(metrics_.size());
+  return metrics_.data();
+}
+```
+
+**After:**
+
+```cpp
+const void* MediaDrmBridge::GetMetrics(int* size) {
+  JNIEnv* env = AttachCurrentThread();
+  ScopedJavaLocalRef<jbyteArray> j_metrics = Java_MediaDrmBridge_getMetrics(env, j_media_drm_bridge_);
+  
+  // Safe: Automatically handles lifetime, copying, and release
+  base::android::JavaByteArrayToByteVector(env, j_metrics, &metrics_);
+  
+  *size = static_cast<int>(metrics_.size());
+  return metrics_.data();
+}
+```
+
+## 6. Replacing Unsafe Manual JNI Creation (New*) with Safe Helpers
+
+**Before:**
+
+```cpp
+ScopedJavaLocalRef<jbyteArray> ToScopedJavaByteArray(JNIEnv* env, std::string_view data) {
+  // Unsafe: Raw NewByteArray call returns a raw local ref that can leak
+  jbyteArray j_array = env->NewByteArray(data.size());
+  if (!j_array) {
+    return nullptr;
+  }
+  
+  // Unsafe: Raw SetByteArrayRegion call
+  env->SetByteArrayRegion(j_array, 0, data.size(), reinterpret_cast<const jbyte*>(data.data()));
+  
+  // Must remember to wrap it before returning, but any early return above would have leaked j_array!
+  return ScopedJavaLocalRef<jbyteArray>(env, j_array);
+}
+```
+
+**After:**
+
+```cpp
+ScopedJavaLocalRef<jbyteArray> ToScopedJavaByteArray(JNIEnv* env, std::string_view data) {
+  // Safe: ToJavaByteArray handles NewByteArray, SetByteArrayRegion, and ScopedJavaLocalRef wrapping in one shot
+  return base::android::ToJavaByteArray(env, data);
+}
+```


### PR DESCRIPTION
android: Document safe JNI zero helper patterns

Update the JNI zero reference documentation to include best practices
for using safe helper functions. Manual JNI calls for array retrieval
and creation are prone to memory leaks and require careful manual
lifecycle management.

The new examples demonstrate how to replace unsafe manual pointer
retrieval and raw array creation with ToJavaByteArray and
JavaByteArrayToByteVector helpers, which automatically handle
lifetime and scoping.

Bug: 521956189