### PR TITLE
android: Add java switch to disable font src local matching

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -72,6 +72,10 @@ public class JavaSwitches {
   public static final String COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE =
       "CobaltDynamicMojoPipeSubresourceSize";
 
+  /** flag to disable FontSrcLocalMatching lookup table. */
+  public static final String DISABLE_FONT_SRC_LOCAL_MATCHING =
+      "DisableFontSrcLocalMatching";
+
   /** flag to specify ANGLE to use the OpenGL ES backend */
   public static final String COBALT_USE_ANGLE_GLES = "CobaltUseAngleGles";
 
@@ -158,6 +162,10 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.COBALT_USE_ANGLE_GLES)) {
       extraCommandLineArgs.add("--use-angle=gles");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.DISABLE_FONT_SRC_LOCAL_MATCHING)) {
+      extraCommandLineArgs.add("--disable-features=FontSrcLocalMatching");
     }
 
     if (jsFlags.length() > 0 ) {


### PR DESCRIPTION
This PR adds a java switch`DISABLE_FONT_SRC_LOCAL_MATCHING` in `JavaSwitches.java` to map to the native Chromium flag `--disable-features=FontSrcLocalMatching`.

This disables local unique font name table indexing (FontUniqueNameLookup) on startup, mitigating background CPU and I/O contention during initial TLS and EGL handshakes.

Bug: 524080375