### PR TITLE
Fix lifecycle shutdown deadlocks, UAF crash, and frame tracking issues

### DIFF
--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include "base/functional/bind.h"
 #include "base/run_loop.h"
 #include "build/buildflag.h"
 #include "cobalt/app/app_event_delegate.h"
@@ -37,6 +38,11 @@ void SbEventHandle(const SbEvent* event) {
     s_lifecycle_delegate->SetQuitClosure(run_loop.QuitClosure());
     s_lifecycle_delegate->HandleEvent(event);
     run_loop.Run();
+
+    // Run pending tasks until idle before teardown.
+    base::RunLoop().RunUntilIdle();
+
+    // Start synchronous teardown.
     s_lifecycle_delegate->DoTeardown();
     delete s_lifecycle_delegate;
     s_lifecycle_delegate = nullptr;

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -44,6 +44,7 @@
 #include "cobalt/browser/features.h"
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/h5vcc_settings_impl.h"
+#include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
 #include "cobalt/browser/mojom/h5vcc_settings.mojom.h"
 #include "cobalt/browser/switches.h"
@@ -415,6 +416,10 @@ void CobaltContentBrowserClient::OnWebContentsCreated(
   }
   VLOG(1) << "NativeSplash: Observing main frame WebContents.";
   web_contents_observer_.reset(new CobaltWebContentsObserver(web_contents));
+  // Initialize the lifecycle tracker for this WebContents to ensure we track
+  // and register its frames (including the main frame) for lifecycle events
+  // from the very start.
+  CobaltLifecycleManager::GetInstance()->InitializeTracker(web_contents);
 #if BUILDFLAG(USE_EVERGREEN)
   // Create the updater module singleton if not already created.
   auto* storage_partition =

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
@@ -14,6 +14,8 @@
 
 #include "cobalt/browser/lifecycle/cobalt_lifecycle_manager.h"
 
+#include <algorithm>
+
 #include "base/no_destructor.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/navigation_handle.h"
@@ -40,6 +42,7 @@ CobaltLifecycleManager::~CobaltLifecycleManager() = default;
 void CobaltLifecycleManager::ResetForTesting() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   receivers_.Clear();
+  receiver_ids_.clear();
   trackers_.clear();
   main_frames_.clear();
   frames_.clear();
@@ -55,7 +58,9 @@ void CobaltLifecycleManager::BindReceiver(
   if (!frame) {
     return;
   }
-  receivers_.Add(this, std::move(receiver), {frame->GetGlobalId()});
+  content::WebContents* web_contents = content::WebContents::FromRenderFrameHost(frame);
+  mojo::ReceiverId id = receivers_.Add(this, std::move(receiver), {frame->GetGlobalId()});
+  receiver_ids_[web_contents].push_back(id);
 }
 
 std::pair<content::RenderFrameHost*, content::WebContents*>
@@ -79,8 +84,17 @@ void CobaltLifecycleManager::InitializeTracker(
 void CobaltLifecycleManager::OnMojoDisconnect() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   auto [frame, web_contents] = GetCurrentContext();
+  mojo::ReceiverId id = receivers_.current_receiver();
   if (web_contents) {
     UnregisterFrame(web_contents, frame);
+    auto it = receiver_ids_.find(web_contents);
+    if (it != receiver_ids_.end()) {
+      auto& ids = it->second;
+      ids.erase(std::remove(ids.begin(), ids.end(), id), ids.end());
+      if (ids.empty()) {
+        receiver_ids_.erase(it);
+      }
+    }
   }
 }
 
@@ -93,9 +107,6 @@ CobaltLifecycleManager::WebContentsTracker::~WebContentsTracker() = default;
 
 void CobaltLifecycleManager::WebContentsTracker::RenderFrameCreated(
     content::RenderFrameHost* render_frame_host) {
-  LOG(INFO) << "WebContentsTracker::RenderFrameCreated: frame="
-            << render_frame_host
-            << ", live=" << render_frame_host->IsRenderFrameLive();
   if (!render_frame_host->IsRenderFrameLive()) {
     return;
   }
@@ -107,8 +118,11 @@ void CobaltLifecycleManager::WebContentsTracker::RenderFrameCreated(
   // renderer-side CobaltLifecycleController. This establishes the two-way
   // communication channel needed for lifecycle ACKs.
   mojo::PendingRemote<cobalt::mojom::CobaltLifecycleObserver> observer;
-  manager_->receivers_.Add(manager_, observer.InitWithNewPipeAndPassReceiver(),
-                           {render_frame_host->GetGlobalId()});
+  // Track the ReceiverId associated with the WebContents for clean teardown.
+  mojo::ReceiverId id = manager_->receivers_.Add(
+      manager_, observer.InitWithNewPipeAndPassReceiver(),
+      {render_frame_host->GetGlobalId()});
+  manager_->receiver_ids_[web_contents()].push_back(id);
   controller->SetObserver(std::move(observer));
 
   controllers_[render_frame_host] = std::move(controller);
@@ -159,8 +173,6 @@ void CobaltLifecycleManager::WebContentsTracker::DidFinishNavigation(
   // re-bind the interface to the new frame host to resume lifecycle tracking.
   content::RenderFrameHost* rfh = navigation_handle->GetRenderFrameHost();
   if (rfh && rfh->IsRenderFrameLive()) {
-    LOG(INFO) << "WebContentsTracker::DidFinishNavigation: Re-binding frame="
-              << rfh;
     Rebind(rfh);
   }
 }
@@ -251,8 +263,11 @@ void CobaltLifecycleManager::WebContentsTracker::Rebind(
 
   // Re-register the browser as an observer after re-binding the interface.
   mojo::PendingRemote<cobalt::mojom::CobaltLifecycleObserver> observer;
-  manager_->receivers_.Add(manager_, observer.InitWithNewPipeAndPassReceiver(),
-                           {frame->GetGlobalId()});
+  // Track the ReceiverId associated with the WebContents for clean teardown.
+  mojo::ReceiverId id = manager_->receivers_.Add(
+      manager_, observer.InitWithNewPipeAndPassReceiver(),
+      {frame->GetGlobalId()});
+  manager_->receiver_ids_[web_contents()].push_back(id);
   controller->SetObserver(std::move(observer));
 
   controllers_[frame] = std::move(controller);
@@ -299,7 +314,6 @@ CobaltLifecycleManager::GetOrCreateTracker(content::WebContents* web_contents) {
 void CobaltLifecycleManager::RegisterFrame(content::WebContents* web_contents,
                                            content::RenderFrameHost* frame) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  LOG(INFO) << "CobaltLifecycleManager::RegisterFrame: frame=" << frame;
   frames_[web_contents].insert(frame);
   GetOrCreateTracker(web_contents);
 
@@ -320,7 +334,6 @@ void CobaltLifecycleManager::RegisterFrame(content::WebContents* web_contents,
 void CobaltLifecycleManager::UnregisterFrame(content::WebContents* web_contents,
                                              content::RenderFrameHost* frame) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  LOG(INFO) << "CobaltLifecycleManager::UnregisterFrame: frame=" << frame;
   frames_[web_contents].erase(frame);
   pending_ack_frames_[web_contents].erase(frame);
 
@@ -559,6 +572,16 @@ void CobaltLifecycleManager::OnAckTimeout(
 void CobaltLifecycleManager::OnWebContentsDestroyed(
     content::WebContents* web_contents) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  // The WebContents is being destroyed. Proactively remove all its Mojo
+  // receivers from `receivers_` BEFORE the WebContents and its RFHs go out of
+  // scope.
+  auto it = receiver_ids_.find(web_contents);
+  if (it != receiver_ids_.end()) {
+    for (auto id : it->second) {
+      receivers_.Remove(id);
+    }
+    receiver_ids_.erase(it);
+  }
   trackers_.erase(web_contents);
   main_frames_.erase(web_contents);
   frames_.erase(web_contents);

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
@@ -16,6 +16,7 @@
 
 #include "base/no_destructor.h"
 #include "content/public/browser/browser_thread.h"
+#include "content/public/browser/navigation_handle.h"
 #include "content/public/browser/render_frame_host.h"
 #include "content/public/browser/web_contents.h"
 #include "content/public/browser/web_contents_observer.h"
@@ -69,6 +70,12 @@ CobaltLifecycleManager::GetCurrentContext() {
   return {frame, content::WebContents::FromRenderFrameHost(frame)};
 }
 
+void CobaltLifecycleManager::InitializeTracker(
+    content::WebContents* web_contents) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  GetOrCreateTracker(web_contents);
+}
+
 void CobaltLifecycleManager::OnMojoDisconnect() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   auto [frame, web_contents] = GetCurrentContext();
@@ -86,6 +93,9 @@ CobaltLifecycleManager::WebContentsTracker::~WebContentsTracker() = default;
 
 void CobaltLifecycleManager::WebContentsTracker::RenderFrameCreated(
     content::RenderFrameHost* render_frame_host) {
+  LOG(INFO) << "WebContentsTracker::RenderFrameCreated: frame="
+            << render_frame_host
+            << ", live=" << render_frame_host->IsRenderFrameLive();
   if (!render_frame_host->IsRenderFrameLive()) {
     return;
   }
@@ -119,6 +129,40 @@ void CobaltLifecycleManager::WebContentsTracker::RenderFrameDeleted(
 
 void CobaltLifecycleManager::WebContentsTracker::WebContentsDestroyed() {
   manager_->OnWebContentsDestroyed(web_contents());
+}
+
+void CobaltLifecycleManager::WebContentsTracker::DidFinishNavigation(
+    content::NavigationHandle* navigation_handle) {
+  // We only care about successful, committed cross-document navigations.
+  // - If the navigation was aborted or failed to commit, the document state
+  //   doesn't change, so we don't need to re-bind.
+  // - Error pages (e.g. net errors) do not load the Cobalt web application
+  //   and therefore do not host the renderer-side lifecycle controller.
+  if (!navigation_handle->HasCommitted() || navigation_handle->IsErrorPage()) {
+    return;
+  }
+
+  // Same-document navigations (e.g. hash changes) reuse the
+  // existing document and JS context. The existing Mojo pipe remains valid.
+  // We MUST skip re-binding here. If we re-bound:
+  // 1. The new remote binding on the renderer would close the old pipe.
+  // 2. The browser would receive a disconnect handler call for the old pipe
+  //    and call UnregisterFrame.
+  // 3. This would race with the new pipe's RegisterFrame call, potentially
+  //    leaving the frame permanently unregistered in the browser.
+  if (navigation_handle->IsSameDocument()) {
+    return;
+  }
+
+  // For cross-document navigations, the new document in the renderer gets a
+  // fresh JS context, invalidating the old Mojo pipe. We must proactively
+  // re-bind the interface to the new frame host to resume lifecycle tracking.
+  content::RenderFrameHost* rfh = navigation_handle->GetRenderFrameHost();
+  if (rfh && rfh->IsRenderFrameLive()) {
+    LOG(INFO) << "WebContentsTracker::DidFinishNavigation: Re-binding frame="
+              << rfh;
+    Rebind(rfh);
+  }
 }
 
 void CobaltLifecycleManager::WebContentsTracker::SetResumed(
@@ -255,6 +299,7 @@ CobaltLifecycleManager::GetOrCreateTracker(content::WebContents* web_contents) {
 void CobaltLifecycleManager::RegisterFrame(content::WebContents* web_contents,
                                            content::RenderFrameHost* frame) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  LOG(INFO) << "CobaltLifecycleManager::RegisterFrame: frame=" << frame;
   frames_[web_contents].insert(frame);
   GetOrCreateTracker(web_contents);
 
@@ -275,6 +320,7 @@ void CobaltLifecycleManager::RegisterFrame(content::WebContents* web_contents,
 void CobaltLifecycleManager::UnregisterFrame(content::WebContents* web_contents,
                                              content::RenderFrameHost* frame) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  LOG(INFO) << "CobaltLifecycleManager::UnregisterFrame: frame=" << frame;
   frames_[web_contents].erase(frame);
   pending_ack_frames_[web_contents].erase(frame);
 

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
@@ -55,11 +55,11 @@ void CobaltLifecycleManager::BindReceiver(
     content::RenderFrameHost* frame,
     mojo::PendingReceiver<cobalt::mojom::CobaltLifecycleObserver> receiver) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-  if (!frame) {
-    return;
-  }
-  content::WebContents* web_contents = content::WebContents::FromRenderFrameHost(frame);
-  mojo::ReceiverId id = receivers_.Add(this, std::move(receiver), {frame->GetGlobalId()});
+  content::WebContents* web_contents =
+      content::WebContents::FromRenderFrameHost(frame);
+  mojo::ReceiverId id =
+      receivers_.Add(this, std::move(receiver), {frame->GetGlobalId()});
+  active_receivers_[frame->GetGlobalId()] = id;
   receiver_ids_[web_contents].push_back(id);
 }
 
@@ -85,8 +85,15 @@ void CobaltLifecycleManager::OnMojoDisconnect() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   auto [frame, web_contents] = GetCurrentContext();
   mojo::ReceiverId id = receivers_.current_receiver();
+  FrameContext context = receivers_.current_context();
   if (web_contents) {
-    UnregisterFrame(web_contents, frame);
+    auto active_it = active_receivers_.find(context.frame_id);
+    if (active_it != active_receivers_.end() && active_it->second == id) {
+      if (frame) {
+        UnregisterFrame(web_contents, frame);
+      }
+      active_receivers_.erase(active_it);
+    }
     auto it = receiver_ids_.find(web_contents);
     if (it != receiver_ids_.end()) {
       auto& ids = it->second;
@@ -122,6 +129,7 @@ void CobaltLifecycleManager::WebContentsTracker::RenderFrameCreated(
   mojo::ReceiverId id = manager_->receivers_.Add(
       manager_, observer.InitWithNewPipeAndPassReceiver(),
       {render_frame_host->GetGlobalId()});
+  manager_->active_receivers_[render_frame_host->GetGlobalId()] = id;
   manager_->receiver_ids_[web_contents()].push_back(id);
   controller->SetObserver(std::move(observer));
 
@@ -267,6 +275,7 @@ void CobaltLifecycleManager::WebContentsTracker::Rebind(
   mojo::ReceiverId id = manager_->receivers_.Add(
       manager_, observer.InitWithNewPipeAndPassReceiver(),
       {frame->GetGlobalId()});
+  manager_->active_receivers_[frame->GetGlobalId()] = id;
   manager_->receiver_ids_[web_contents()].push_back(id);
   controller->SetObserver(std::move(observer));
 
@@ -354,7 +363,7 @@ void CobaltLifecycleManager::OnPageVisibilityChanged(bool visible) {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   auto [frame, web_contents] = GetCurrentContext();
 
-  if (web_contents) {
+  if (web_contents && frame) {
     auto* tracker = GetOrCreateTracker(web_contents);
     tracker->SetVisible(frame, visible);
 
@@ -370,7 +379,7 @@ void CobaltLifecycleManager::OnPageBlurred() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   auto [frame, web_contents] = GetCurrentContext();
 
-  if (web_contents) {
+  if (web_contents && frame) {
     auto* tracker = GetOrCreateTracker(web_contents);
     tracker->SetFocused(frame, false);
 
@@ -385,7 +394,7 @@ void CobaltLifecycleManager::OnPageFocused() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   auto [frame, web_contents] = GetCurrentContext();
 
-  if (web_contents) {
+  if (web_contents && frame) {
     auto* tracker = GetOrCreateTracker(web_contents);
     tracker->SetFocused(frame, true);
   }
@@ -395,7 +404,7 @@ void CobaltLifecycleManager::OnPageResumed() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   auto [frame, web_contents] = GetCurrentContext();
 
-  if (web_contents) {
+  if (web_contents && frame) {
     auto* tracker = GetOrCreateTracker(web_contents);
     tracker->SetResumed(frame);
 
@@ -410,7 +419,7 @@ void CobaltLifecycleManager::OnFrameReady() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   auto [frame, web_contents] = GetCurrentContext();
 
-  if (web_contents) {
+  if (web_contents && frame) {
     RegisterFrame(web_contents, frame);
   }
 }
@@ -575,6 +584,14 @@ void CobaltLifecycleManager::OnWebContentsDestroyed(
   // The WebContents is being destroyed. Proactively remove all its Mojo
   // receivers from `receivers_` BEFORE the WebContents and its RFHs go out of
   // scope.
+  // Proactively clean up the active_receivers_ map for all frames belonging to
+  // this WebContents to avoid memory leaks.
+  auto frames_it = frames_.find(web_contents);
+  if (frames_it != frames_.end()) {
+    for (auto* frame : frames_it->second) {
+      active_receivers_.erase(frame->GetGlobalId());
+    }
+  }
   auto it = receiver_ids_.find(web_contents);
   if (it != receiver_ids_.end()) {
     for (auto id : it->second) {

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
@@ -18,6 +18,7 @@
 #include <map>
 #include <set>
 #include <utility>
+#include <vector>
 
 #include "base/containers/flat_set.h"
 #include "base/containers/small_map.h"
@@ -266,8 +267,19 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
 
   base::ObserverList<CobaltLifecycleManagerObserver>::Unchecked observers_;
 
+  // Mojo receiver set for the CobaltLifecycleObserver interface. Each receiver
+  // corresponds to a renderer-side frame that has registered to send back
+  // lifecycle ACKs. The FrameContext associated with each receiver tracks the
+  // frame's WebContents and RenderFrameHost.
   mojo::ReceiverSet<cobalt::mojom::CobaltLifecycleObserver, FrameContext>
       receivers_;
+
+  // Map tracking the Mojo ReceiverIds associated with each WebContents. Since
+  // mojo::ReceiverSet does not provide a public API to query or iterate over
+  // receivers by their associated context (WebContents*), we must track the
+  // ReceiverIds explicitly. This allows us to cleanly remove only the receivers
+  // associated with a specific WebContents when it is destroyed.
+  std::map<content::WebContents*, std::vector<mojo::ReceiverId>> receiver_ids_;
 
   base::WeakPtrFactory<CobaltLifecycleManager> weak_factory_{this};
 

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
@@ -270,7 +270,7 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
   // Mojo receiver set for the CobaltLifecycleObserver interface. Each receiver
   // corresponds to a renderer-side frame that has registered to send back
   // lifecycle ACKs. The FrameContext associated with each receiver tracks the
-  // frame's WebContents and RenderFrameHost.
+  // frame's WebContents and GlobalRenderFrameHostId.
   mojo::ReceiverSet<cobalt::mojom::CobaltLifecycleObserver, FrameContext>
       receivers_;
 
@@ -280,6 +280,13 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
   // ReceiverIds explicitly. This allows us to cleanly remove only the receivers
   // associated with a specific WebContents when it is destroyed.
   std::map<content::WebContents*, std::vector<mojo::ReceiverId>> receiver_ids_;
+
+  // Map tracking the active Mojo ReceiverId for each RenderFrameHost (by its
+  // GlobalId). This prevents race conditions where an asynchronous disconnect
+  // handler for an old Mojo pipe unregisters a frame that has already been
+  // re-bound to a new pipe.
+  std::map<content::GlobalRenderFrameHostId, mojo::ReceiverId>
+      active_receivers_;
 
   base::WeakPtrFactory<CobaltLifecycleManager> weak_factory_{this};
 

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
@@ -34,6 +34,7 @@
 namespace content {
 class WebContents;
 class RenderFrameHost;
+class NavigationHandle;
 }  // namespace content
 
 namespace cobalt {
@@ -146,6 +147,10 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
       content::RenderFrameHost* frame,
       mojo::PendingReceiver<cobalt::mojom::CobaltLifecycleObserver> receiver);
 
+  // Proactively creates the tracker for the specified WebContents to monitor
+  // frame lifecycle events from startup.
+  void InitializeTracker(content::WebContents* web_contents);
+
   // cobalt::mojom::CobaltLifecycleObserver impl.
   void OnPageVisibilityChanged(bool visible) override;
   void OnPageBlurred() override;
@@ -197,6 +202,8 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
     void RenderFrameDeleted(
         content::RenderFrameHost* render_frame_host) override;
     void WebContentsDestroyed() override;
+    void DidFinishNavigation(
+        content::NavigationHandle* navigation_handle) override;
 
     // Methods to update the tracked state of a specific frame.
     void SetResumed(content::RenderFrameHost* frame);


### PR DESCRIPTION
This PR addresses critical issues during application shutdown and freeze:

1. **Frame Tracking & Re-binding**: Resolves issues where cross-document navigations caused frames to be incorrectly unregistered, preventing clean shutdown. Implemented robust frame re-binding on navigation commit.
2. **Shutdown Deadlock**: Drains pending tasks on the UI thread before starting teardown in `SbEventHandle`.
3. **MiraclePtr/UAF Crash**: Tracks Mojo receiver IDs per `WebContents` and cleans them up in `OnWebContentsDestroyed` to prevent the disconnect handler from accessing dangling pointers.

Bug: 521960047