### PR TITLE
Fix DCHECK crash on exit/freeze in UpdaterModule::Suspend().

### DIFF
--- a/base/threading/thread_restrictions.h
+++ b/base/threading/thread_restrictions.h
@@ -216,6 +216,9 @@ class CrashUtil;
 #if BUILDFLAG(IS_COBALT)
 namespace cobalt {
 class AppEventRunnerImpl;
+namespace updater {
+class UpdaterModule;
+}
 }
 #endif  // BUILDFLAG(IS_COBALT)
 namespace chromeos {
@@ -869,6 +872,7 @@ class BASE_EXPORT
   // base::WaitableEvent under the hood, we must explicitly whitelist the modular
   // platform shell runner here to authorize main-thread sync waiting.
   friend class cobalt::AppEventRunnerImpl;
+  friend class cobalt::updater::UpdaterModule;
 #endif  // BUILDFLAG(IS_COBALT)
   friend class content::DesktopCaptureDevice;
   friend class content::EmergencyTraceFinalisationCoordinator;

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -32,6 +32,7 @@
 #include "base/task/task_runner.h"
 #include "base/threading/scoped_blocking_call.h"
 #include "base/threading/thread.h"
+#include "base/threading/thread_restrictions.h"
 #include "base/time/time.h"
 #include "base/version.h"
 #include "cobalt/updater/util.h"
@@ -208,21 +209,18 @@ UpdaterModule::~UpdaterModule() {
 
 void UpdaterModule::Suspend() {
   if (is_updater_running_.exchange(false)) {
+    base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope allow_sync;
     base::WaitableEvent event(base::WaitableEvent::ResetPolicy::MANUAL,
                               base::WaitableEvent::InitialState::NOT_SIGNALED);
-    {
-      base::ScopedBlockingCall scoped_blocking_call(
-          FROM_HERE, base::BlockingType::MAY_BLOCK);
-      if (updater_thread_->task_runner()->PostTask(
-              FROM_HERE,
-              base::BindOnce(
-                  [](UpdaterModule* module, base::WaitableEvent* event) {
-                    module->Finalize();
-                    event->Signal();
-                  },
-                  base::Unretained(this), base::Unretained(&event)))) {
-        event.Wait();
-      }
+    if (updater_thread_->task_runner()->PostTask(
+            FROM_HERE,
+            base::BindOnce(
+                [](UpdaterModule* module, base::WaitableEvent* event) {
+                  module->Finalize();
+                  event->Signal();
+                },
+                base::Unretained(this), base::Unretained(&event)))) {
+      event.Wait();
     }
   }
 }


### PR DESCRIPTION
During application freeze (DoFreeze), UpdaterModule::Suspend() is called on the UI thread. It synchronously blocks the UI thread waiting for Finalize() to run on the updater thread. Since blocking is disallowed by default on the UI thread, this triggers a DCHECK in ScopedBlockingCall.

This CL resolves the crash by:
1. Removing the redundant ScopedBlockingCall from UpdaterModule::Suspend().
2. Using base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope in Suspend() to allow waiting on the WaitableEvent on the UI thread without relaxing general blocking restrictions.
3. Befriending UpdaterModule in ScopedAllowBaseSyncPrimitivesOutsideBlockingScope in base/threading/thread_restrictions.h.

Bug: 525008015
Bug: 524804554
