### PR TITLE
Fix rdk issue in deployment

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -194,7 +194,12 @@ def launch_on_device(
     remote_cmds = [f"cd {remote_dir}"]
 
     if not is_up_to_date or force_deploy:
-        remote_cmds += ["tar -xzf archive.tar.gz", "rm archive.tar.gz"]
+        # Ensure unprivileged container users have access to extracted artifacts.
+        remote_cmds += [
+            "tar -xzf archive.tar.gz",
+            "rm archive.tar.gz",
+            f"chmod -R 777 {remote_dir}",
+        ]
 
     if test_name:
         remote_cmds += ["rdkDisplay remove || true", "sleep 2", "mkdir -p results"]


### PR DESCRIPTION
Ensure world-read/execute permissions by running chmod -R 777 on the remote directory after extracting archive.tar.gz in deploy_rdk.py.

When artifacts are extracted via adb shell (running as root), directory permissions default to 750 (drwxr-x---) owned by root:root. When the Dobby container runs under an unprivileged user (uid: 2001), it receives EACCES (Permission Denied) when checking /data/out_cobalt/fonts/fonts.xml. Consequently, IsValidContentDirectory returns false and triggers the fallback to /usr/share/content/data. Appending chmod -R 777 ensures unprivileged container users can read and execute extracted artifacts.

Issue: 525123951