### PR TITLE
Filter RDK deployment logs by application syslog identifier

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -603,6 +603,8 @@ def main() -> None:
     if args.logs:
         device_id = get_device_id()
         cmd = ["adb", "-s", device_id, "shell", "journalctl"]
+        tag = "YouTube" if args.mode == "plugin" else "Cobalt"
+        cmd += ["-t", tag]
         if args.follow:
             cmd.append("-f")
         try:


### PR DESCRIPTION
Consolidates log streaming logic and introduces explicit filtering for application and system logs in `deploy_rdk.py`.

### Changes
* **Consolidated Log Streaming**: Merged `--logs` and `--system-logs` execution flows to share common device lookup, follow flag (`-f`), and interrupt handling.
* **Application Log Filtering (`--logs`)**: Filters `journalctl` output by relevant application syslog identifiers (`YouTube`, `Cobalt`, and `loader_app`).
* **System Log Support (`--system-logs`)**: Supports fetching unfiltered system journal logs (OS, kernel, and systemd) from the device.

Bug: b/502702565