### PR TITLE
cobalt/metrics: Add core PartitionAlloc metrics to CobaltMemoryMetricsEmitter

### DIFF
--- a/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_emitter.cc
@@ -27,6 +27,7 @@
 #include "base/trace_event/memory_dump_request_args.h"
 #include "build/build_config.h"
 #include "media/base/media_client.h"
+#include "partition_alloc/buildflags.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/browser_metrics.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
 
@@ -237,6 +238,52 @@ const CobaltMemoryMetricsEmitter::Metric kAllocatorDumpNamesForMetrics[] = {
      kAllocatedObjectsSize,
      CobaltMemoryMetricsEmitter::EmitTo::kSizeInUkmAndUma,
      {}},
+
+#if PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+    {"malloc/partitions/allocator/thread_cache",
+     "Malloc.ThreadCache",
+     CobaltMemoryMetricsEmitter::MetricSize::kSmall,
+     "size",
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
+     {}},
+    {"malloc/partitions/allocator",
+     "Malloc.MaxAllocatedSize",
+     CobaltMemoryMetricsEmitter::MetricSize::kLarge,
+     "max_allocated_size",
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
+     {}},
+    {"malloc/partitions/allocator",
+     "Malloc.MaxCommittedSize",
+     CobaltMemoryMetricsEmitter::MetricSize::kLarge,
+     "max_committed_size",
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
+     {}},
+    {"malloc/partitions/allocator",
+     "Malloc.CommittedSize",
+     CobaltMemoryMetricsEmitter::MetricSize::kLarge,
+     "virtual_committed_size",
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
+     {}},
+    {"malloc/partitions/allocator",
+     "Malloc.Wasted",
+     CobaltMemoryMetricsEmitter::MetricSize::kLarge,
+     "wasted",
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
+     {}},
+    {"malloc/partitions/allocator",
+     "Malloc.Fragmentation",
+     CobaltMemoryMetricsEmitter::MetricSize::kPercentage,
+     "fragmentation",
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
+     {}},
+    {"malloc",
+     "Malloc.SyscallsPerMinute",
+     CobaltMemoryMetricsEmitter::MetricSize::kTiny,
+     "syscalls_per_minute",
+     CobaltMemoryMetricsEmitter::EmitTo::kSizeInUmaOnly,
+     {}},
+#endif  // PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+
 #if BUILDFLAG(IS_ANDROID)
     {base::android::MeminfoDumpProvider::kDumpName,
      "AndroidOtherPss",


### PR DESCRIPTION
This commit introduces essential PartitionAlloc memory telemetry by
exposing ThreadCache sizes, max/virtual committed sizes, wasted memory,
syscall frequency, and overall fragmentation metrics. These are
conditionally enabled under `PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)`
and are emitted strictly to UMA to track baseline PA memory health.

Bug: 517340923