### PR TITLE
Filter rdk logs by app tag

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -368,7 +368,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--system-logs",
-        action="store_true",
+        action="store_false",
         help="View global OS/kernel/systemd logs from the device (runs raw journalctl).",
     )
     return parser.parse_args()

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -608,6 +608,8 @@ def main() -> None:
     if args.logs:
         device_id = get_device_id()
         cmd = ["adb", "-s", device_id, "shell", "journalctl"]
+        tag = "YouTube" if args.mode == "plugin" else "Cobalt"
+        cmd += ["-t", tag]
         if args.follow:
             cmd.append("-f")
         try:

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -42,19 +42,22 @@ Usage Examples:
   8. Deploy only the libcobalt library:
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --only-lib
 
-  9. View device system logs (journalctl):
+  9. View filtered application logs (YouTube/Cobalt):
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --logs
 
-  10. Follow device system logs in real-time (journalctl -f):
+  10. Follow application logs in real-time (journalctl -f):
       python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --logs --follow
 
-  11. Build, deploy, and run Cobalt plugin with Chrome DevTools remote debugging enabled:
+  11. View raw global OS/system logs (journalctl):
+      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --system-logs
+
+  12. Build, deploy, and run Cobalt plugin with Chrome DevTools remote debugging enabled:
       python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run --devtools
 
-  12. Download and install cross-compilation toolchain:
+  13. Download and install cross-compilation toolchain:
       python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --setup-toolchain
 
-  13. Revert active Cobalt loader configuration to Cobalt 25:
+  14. Revert active Cobalt loader configuration to Cobalt 25:
       python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --revert-c25
 """
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -371,7 +371,7 @@ def parse_args() -> argparse.Namespace:
     )
     parser.add_argument(
         "--system-logs",
-        action="store_false",
+        action="store_true",
         help="View global OS/kernel/systemd logs from the device (runs raw journalctl).",
     )
     return parser.parse_args()

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -366,6 +366,11 @@ def parse_args() -> argparse.Namespace:
         action="store_true",
         help="Follow log output in real-time (runs journalctl -f).",
     )
+    parser.add_argument(
+        "--system-logs",
+        action="store_true",
+        help="View global OS/kernel/systemd logs from the device (runs raw journalctl).",
+    )
     return parser.parse_args()
 
 
@@ -605,11 +610,18 @@ def main() -> None:
         revert_to_cobalt_25(device_id)
         return
 
-    if args.logs:
+    if args.logs or args.system_logs:
         device_id = get_device_id()
         cmd = ["adb", "-s", device_id, "shell", "journalctl"]
-        tag = "YouTube" if args.mode == "plugin" else "Cobalt"
-        cmd += ["-t", tag]
+        if args.logs:
+            cmd.extend([
+                "-t",
+                "YouTube",
+                "-t",
+                "Cobalt",
+                "-t",
+                "loader_app",
+            ])
         if args.follow:
             cmd.append("-f")
         try:


### PR DESCRIPTION
Consolidates log streaming logic and introduces explicit filtering for application and system logs in `deploy_rdk.py`.

### Changes
* **Consolidated Log Streaming**: Merged `--logs` and `--system-logs` execution flows to share common device lookup, follow flag (`-f`), and interrupt handling.
* **Application Log Filtering (`--logs`)**: Filters `journalctl` output by relevant application syslog identifiers (`YouTube`, `Cobalt`, and `loader_app`).
* **System Log Support (`--system-logs`)**: Supports fetching unfiltered system journal logs (OS, kernel, and systemd) from the device.

Bug: 502702565