### PR TITLE
Support passing sequential runtime parameters via --param in deploy_rdk.py

### DIFF
--- a/cobalt/build/android/package.json
+++ b/cobalt/build/android/package.json
@@ -114,7 +114,6 @@
                 "obj/services/device/public/mojom/mojom_java.javac.jar",
                 "obj/services/device/screen_orientation/java.javac.jar",
                 "obj/services/device/time_zone_monitor/java.javac.jar",
-                "obj/services/device/usb/java.javac.jar",
                 "obj/services/device/vibration/android/vibration_manager_java.javac.jar",
                 "obj/services/device/wake_lock/power_save_blocker/java.javac.jar",
                 "obj/services/media_session/public/cpp/android/media_session_java.javac.jar",
@@ -144,7 +143,6 @@
                 "obj/third_party/blink/public/mojom/service_worker/storage_java.javac.jar",
                 "obj/third_party/blink/public/mojom/storage_key/storage_key_java.javac.jar",
                 "obj/third_party/blink/public/mojom/tokens/tokens_java.javac.jar",
-                "obj/third_party/blink/public/mojom/usb/usb_java.javac.jar",
                 "obj/third_party/blink/public/mojom/web_feature_mojo_bindings_java.javac.jar",
                 "obj/third_party/jni_zero/gendeps_java.javac.jar",
                 "obj/third_party/jni_zero/jni_zero_java.javac.jar",
@@ -600,10 +598,6 @@
                     "to_file": "jar/services_device_time_zone_monitor_java.jar"
                 },
                 {
-                    "from_file": "obj/services/device/usb/java.javac.jar",
-                    "to_file": "jar/services_device_usb_java.jar"
-                },
-                {
                     "from_file": "obj/services/device/vibration/android/vibration_manager_java.javac.jar",
                     "to_file": "jar/services_device_vibration_android_vibration_manager_java.jar"
                 },
@@ -718,10 +712,6 @@
                 {
                     "from_file": "obj/third_party/blink/public/mojom/tokens/tokens_java.javac.jar",
                     "to_file": "jar/third_party_blink_public_mojom_tokens_tokens_java.jar"
-                },
-                {
-                    "from_file": "obj/third_party/blink/public/mojom/usb/usb_java.javac.jar",
-                    "to_file": "jar/third_party_blink_public_mojom_usb_usb_java.jar"
                 },
                 {
                     "from_file": "obj/third_party/blink/public/mojom/web_feature_mojo_bindings_java.javac.jar",

--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -3778,6 +3778,59 @@ source_set("browser") {
     sources = _filtered_sources
     deps -= [ "//components/browsing_topics/common:common" ]
   }
+
+  if (is_cobalt) {
+    sources -= [
+      "bluetooth/advertisement_client.cc",
+      "bluetooth/advertisement_client.h",
+      "bluetooth/bluetooth_adapter_factory_wrapper.cc",
+      "bluetooth/bluetooth_adapter_factory_wrapper.h",
+      "bluetooth/bluetooth_allowed_devices.cc",
+      "bluetooth/bluetooth_allowed_devices.h",
+      "bluetooth/bluetooth_allowed_devices_map.cc",
+      "bluetooth/bluetooth_allowed_devices_map.h",
+      "bluetooth/bluetooth_blocklist.cc",
+      "bluetooth/bluetooth_blocklist.h",
+      "bluetooth/bluetooth_device_chooser_controller.cc",
+      "bluetooth/bluetooth_device_chooser_controller.h",
+      "bluetooth/bluetooth_device_scanning_prompt_controller.cc",
+      "bluetooth/bluetooth_device_scanning_prompt_controller.h",
+      "bluetooth/bluetooth_metrics.cc",
+      "bluetooth/bluetooth_metrics.h",
+      "bluetooth/bluetooth_util.cc",
+      "bluetooth/bluetooth_util.h",
+      "bluetooth/frame_connected_bluetooth_devices.cc",
+      "bluetooth/frame_connected_bluetooth_devices.h",
+      "bluetooth/web_bluetooth_pairing_manager.h",
+      "bluetooth/web_bluetooth_pairing_manager_delegate.h",
+      "bluetooth/web_bluetooth_pairing_manager_impl.cc",
+      "bluetooth/web_bluetooth_pairing_manager_impl.h",
+      "bluetooth/web_bluetooth_service_impl.cc",
+      "bluetooth/web_bluetooth_service_impl.h",
+
+      "serial/serial_service.cc",
+      "serial/serial_service.h",
+
+      "usb/web_usb_service_impl.cc",
+      "usb/web_usb_service_impl.h",
+    ]
+
+    deps -= [
+      "//device/bluetooth",
+      "//device/bluetooth/public/cpp",
+    ]
+
+    if (!is_android) {
+      sources -= [
+        "hid/hid_service.cc",
+        "hid/hid_service.h",
+        "service_worker/service_worker_hid_delegate_observer.cc",
+        "service_worker/service_worker_hid_delegate_observer.h",
+        "service_worker/service_worker_usb_delegate_observer.cc",
+        "service_worker/service_worker_usb_delegate_observer.h",
+      ]
+    }
+  }
 }
 
 if (is_android) {

--- a/content/browser/back_forward_cache_features_browsertest.cc
+++ b/content/browser/back_forward_cache_features_browsertest.cc
@@ -9,8 +9,10 @@
 #include "base/time/time.h"
 #include "build/build_config.h"
 #include "content/browser/back_forward_cache_browsertest.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/bluetooth/bluetooth_adapter_factory_wrapper.h"
 #include "content/browser/bluetooth/test/mock_bluetooth_delegate.h"
+#endif
 #include "content/browser/browser_interface_binders.h"
 #include "content/browser/generic_sensor/frame_sensor_provider_proxy.h"
 #include "content/browser/generic_sensor/web_contents_sensor_provider_proxy.h"
@@ -36,7 +38,9 @@
 #include "content/public/test/test_utils.h"
 #include "content/public/test/web_transport_simple_test_server.h"
 #include "content/shell/browser/shell.h"
-#include "device/bluetooth/test/mock_bluetooth_adapter.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "device/bluetooth/test/mock_bluetooth_adapter.h"  // nogncheck
+#endif
 #include "net/test/embedded_test_server/controllable_http_response.h"
 #include "net/test/embedded_test_server/embedded_test_server.h"
 #include "net/test/spawned_test_server/spawned_test_server.h"
@@ -3965,6 +3969,7 @@ IN_PROC_BROWSER_TEST_F(GeolocationBackForwardCacheBrowserTest,
       << "watchPosition API should have reported no errors";
 }
 
+#if !BUILDFLAG(IS_COBALT)
 class BluetoothBrowserTestContentBrowserClient
     : public ContentBrowserTestContentBrowserClient {
  public:
@@ -4165,6 +4170,7 @@ IN_PROC_BROWSER_TEST_F(BackForwardCacheWebBluetoothTest,
   EXPECT_EQ(current_frame_host(), rfh_a.get());
   ExpectRestored(FROM_HERE);
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 enum class SerialContext {
   kDocument,

--- a/content/browser/browser_interface_binders.cc
+++ b/content/browser/browser_interface_binders.cc
@@ -33,7 +33,9 @@
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/background_fetch/background_fetch_service_impl.h"
 #include "content/browser/bad_message.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/bluetooth/web_bluetooth_service_impl.h"
+#endif
 #include "content/browser/browser_context_impl.h"
 #include "content/browser/browser_main_loop.h"
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
@@ -907,8 +909,10 @@ void PopulateFrameBinders(RenderFrameHostImpl* host, mojo::BinderMap* map) {
       &RenderFrameHostImpl::BindFederatedAuthRequestReceiver,
       base::Unretained(host)));
 
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::WebUsbService>(base::BindRepeating(
       &RenderFrameHostImpl::CreateWebUsbService, base::Unretained(host)));
+#endif
 
   map->Add<blink::mojom::WebSocketConnector>(base::BindRepeating(
       &RenderFrameHostImpl::CreateWebSocketConnector, base::Unretained(host)));
@@ -952,8 +956,10 @@ void PopulateFrameBinders(RenderFrameHostImpl* host, mojo::BinderMap* map) {
         &BindWebNNContextProviderForRenderFrame, base::Unretained(host)));
   }
 
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::WebBluetoothService>(base::BindRepeating(
       &WebBluetoothServiceImpl::BindIfAllowed, base::Unretained(host)));
+#endif
 
   map->Add<blink::mojom::PushMessaging>(base::BindRepeating(
       &RenderFrameHostImpl::GetPushMessaging, base::Unretained(host)));
@@ -1099,19 +1105,25 @@ void PopulateFrameBinders(RenderFrameHostImpl* host, mojo::BinderMap* map) {
   }
 
 #if BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   map->Add<device::mojom::NFC>(base::BindRepeating(
       &RenderFrameHostImpl::BindNFCReceiver, base::Unretained(host)));
+#endif  // !BUILDFLAG(IS_COBALT)
 #else
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::HidService>(base::BindRepeating(
       &RenderFrameHostImpl::GetHidService, base::Unretained(host)));
+#endif  // !BUILDFLAG(IS_COBALT)
 
   map->Add<blink::mojom::InstalledAppProvider>(
       base::BindRepeating(&RenderFrameHostImpl::CreateInstalledAppProvider,
                           base::Unretained(host)));
 #endif  // BUILDFLAG(IS_ANDROID)
 
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::SerialService>(base::BindRepeating(
       &RenderFrameHostImpl::BindSerialService, base::Unretained(host)));
+#endif
 
 #if BUILDFLAG(IS_CHROMEOS)
   map->Add<blink::mojom::SmartCardService>(base::BindRepeating(
@@ -1388,8 +1400,10 @@ void PopulateDedicatedWorkerBinders(DedicatedWorkerHost* host,
       base::BindRepeating(&DedicatedWorkerHost::CreateDirectSocketsService,
                           base::Unretained(host)));
 #endif
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::WebUsbService>(base::BindRepeating(
       &DedicatedWorkerHost::CreateWebUsbService, base::Unretained(host)));
+#endif
   map->Add<blink::mojom::WebSocketConnector>(base::BindRepeating(
       &DedicatedWorkerHost::CreateWebSocketConnector, base::Unretained(host)));
   map->Add<blink::mojom::WebTransportConnector>(
@@ -1412,12 +1426,14 @@ void PopulateDedicatedWorkerBinders(DedicatedWorkerHost* host,
                           base::Unretained(host)));
   map->Add<blink::mojom::ReportingServiceProxy>(base::BindRepeating(
       &CreateReportingServiceProxyForDedicatedWorker, base::Unretained(host)));
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::SerialService>(base::BindRepeating(
       &DedicatedWorkerHost::BindSerialService, base::Unretained(host)));
-#if !BUILDFLAG(IS_ANDROID)
+#endif
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::HidService>(base::BindRepeating(
       &DedicatedWorkerHost::BindHidService, base::Unretained(host)));
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::BucketManagerHost>(base::BindRepeating(
       &DedicatedWorkerHost::CreateBucketManagerHost, base::Unretained(host)));
   map->Add<blink::mojom::FileSystemAccessManager>(
@@ -1734,13 +1750,17 @@ void PopulateServiceWorkerBinders(ServiceWorkerHost* host,
                                                          std::move(receiver));
       },
       base::Unretained(host)));
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::HidService>(base::BindRepeating(
       &ServiceWorkerHost::BindHidService, base::Unretained(host)));
 #endif
+#endif
   map->Add<blink::mojom::BucketManagerHost>(base::BindRepeating(
       &ServiceWorkerHost::CreateBucketManagerHost, base::Unretained(host)));
+#if !BUILDFLAG(IS_COBALT)
   map->Add<blink::mojom::WebUsbService>(base::BindRepeating(
       &ServiceWorkerHost::BindUsbService, base::Unretained(host)));
+#endif
   if (base::FeatureList::IsEnabled(
           webnn::mojom::features::kWebMachineLearningNeuralNetwork)) {
     map->Add<webnn::mojom::WebNNContextProvider>(base::BindRepeating(

--- a/content/browser/renderer_host/render_frame_host_impl.cc
+++ b/content/browser/renderer_host/render_frame_host_impl.cc
@@ -67,7 +67,9 @@
 #include "content/browser/accessibility/render_accessibility_host.h"
 #include "content/browser/bad_message.h"
 #include "content/browser/blob_storage/file_backed_blob_factory_frame_impl.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/bluetooth/web_bluetooth_service_impl.h"
+#endif
 #include "content/browser/broadcast_channel/broadcast_channel_provider.h"
 #include "content/browser/broadcast_channel/broadcast_channel_service.h"
 #include "content/browser/browser_main_loop.h"
@@ -152,7 +154,9 @@
 #include "content/browser/renderer_host/view_transition_opt_in_state.h"
 #include "content/browser/scoped_active_url.h"
 #include "content/browser/security/coop/cross_origin_opener_policy_reporter.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/serial/serial_service.h"
+#endif
 #include "content/browser/service_worker/service_worker_client.h"
 #include "content/browser/site_info.h"
 #include "content/browser/sms/webotp_service.h"
@@ -160,7 +164,9 @@
 #include "content/browser/storage_access/storage_access_handle.h"
 #include "content/browser/storage_partition_impl.h"
 #include "content/browser/url_loader_factory_params_helper.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/usb/web_usb_service_impl.h"
+#endif
 #include "content/browser/web_exposed_isolation_info.h"
 #include "content/browser/web_package/prefetched_signed_exchange_cache.h"
 #include "content/browser/webauth/authenticator_impl.h"
@@ -322,7 +328,9 @@
 #include "content/public/browser/android/java_interfaces.h"
 #include "content/public/browser/authenticator_request_client_delegate.h"
 #else
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/hid/hid_service.h"
+#endif
 #include "content/browser/host_zoom_map_impl.h"
 #endif
 
@@ -13732,6 +13740,7 @@ void RenderFrameHostImpl::CreateSecurePaymentConfirmationService(
   }
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void RenderFrameHostImpl::CreateWebUsbService(
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
   if (!base::FeatureList::IsEnabled(features::kWebUsb)) {
@@ -13752,6 +13761,7 @@ void RenderFrameHostImpl::CreateWebUsbService(
                 BackForwardCacheDisable::DisabledReasonId::kWebUSB));
   WebUsbServiceImpl::Create(*this, std::move(receiver));
 }
+#endif
 
 void RenderFrameHostImpl::ResetPermissionsPolicy(
     const network::ParsedPermissionsPolicy& header_policy) {
@@ -14104,13 +14114,14 @@ void RenderFrameHostImpl::CreateDedicatedWorkerHostFactory(
       std::move(receiver));
 }
 
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 void RenderFrameHostImpl::BindNFCReceiver(
     mojo::PendingReceiver<device::mojom::NFC> receiver) {
   delegate_->GetNFC(this, std::move(receiver));
 }
 #endif
 
+#if !BUILDFLAG(IS_COBALT)
 void RenderFrameHostImpl::BindSerialService(
     mojo::PendingReceiver<blink::mojom::SerialService> receiver) {
   if (!IsFeatureEnabled(network::mojom::PermissionsPolicyFeature::kSerial)) {
@@ -14138,8 +14149,9 @@ void RenderFrameHostImpl::BindSerialService(
 
   SerialService::GetOrCreateForCurrentDocument(this)->Bind(std::move(receiver));
 }
+#endif
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 void RenderFrameHostImpl::GetHidService(
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
   HidService::Create(this, std::move(receiver));

--- a/content/browser/renderer_host/render_frame_host_impl.h
+++ b/content/browser/renderer_host/render_frame_host_impl.h
@@ -202,7 +202,7 @@
 #include "base/containers/id_map.h"
 #include "content/browser/webauth/webauth_request_security_checker.h"
 #include "services/device/public/mojom/nfc.mojom.h"
-#else
+#elif !BUILDFLAG(IS_COBALT)
 #include "third_party/blink/public/mojom/hid/hid.mojom-forward.h"
 #endif
 
@@ -226,7 +226,9 @@ class CacheStorage;
 class DeviceAPIService;
 class GeolocationService;
 class ManagedConfigurationService;
+#if !BUILDFLAG(IS_COBALT)
 class WebUsbService;
+#endif
 }  // namespace mojom
 }  // namespace blink
 
@@ -2085,12 +2087,14 @@ class CONTENT_EXPORT RenderFrameHostImpl
   void GetFileSystemAccessManager(
       mojo::PendingReceiver<blink::mojom::FileSystemAccessManager> receiver);
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   void GetHidService(mojo::PendingReceiver<blink::mojom::HidService> receiver);
 #endif
 
+#if !BUILDFLAG(IS_COBALT)
   void BindSerialService(
       mojo::PendingReceiver<blink::mojom::SerialService> receiver);
+#endif
 
 #if BUILDFLAG(IS_CHROMEOS)
   void GetSmartCardService(
@@ -2157,7 +2161,7 @@ class CONTENT_EXPORT RenderFrameHostImpl
       const net::NetworkIsolationKey& nik,
       const blink::StorageKey& storage_key);
 
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   void BindNFCReceiver(mojo::PendingReceiver<device::mojom::NFC> receiver);
 #endif
 
@@ -2208,9 +2212,11 @@ class CONTENT_EXPORT RenderFrameHostImpl
   void BindTrustTokenQueryAnswerer(
       mojo::PendingReceiver<network::mojom::TrustTokenQueryAnswerer> receiver);
 
+#if !BUILDFLAG(IS_COBALT)
   // Creates connections to WebUSB interfaces bound to this frame.
   void CreateWebUsbService(
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver);
+#endif
 
   void CreateWebSocketConnector(
       mojo::PendingReceiver<blink::mojom::WebSocketConnector> receiver);

--- a/content/browser/service_worker/embedded_worker_instance.cc
+++ b/content/browser/service_worker/embedded_worker_instance.cc
@@ -799,7 +799,7 @@ void EmbeddedWorkerInstance::BindCacheStorage(
   BindCacheStorageInternal();
 }
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 void EmbeddedWorkerInstance::BindHidService(
     const url::Origin& origin,
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
@@ -813,8 +813,9 @@ void EmbeddedWorkerInstance::BindHidService(
                        std::move(receiver));
   }
 }
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
+#if !BUILDFLAG(IS_COBALT)
 void EmbeddedWorkerInstance::BindUsbService(
     const url::Origin& origin,
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
@@ -828,6 +829,7 @@ void EmbeddedWorkerInstance::BindUsbService(
                               std::move(receiver));
   }
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 base::WeakPtr<EmbeddedWorkerInstance> EmbeddedWorkerInstance::AsWeakPtr() {
   return weak_factory_.GetWeakPtr();

--- a/content/browser/service_worker/embedded_worker_instance.h
+++ b/content/browser/service_worker/embedded_worker_instance.h
@@ -246,13 +246,17 @@ class CONTENT_EXPORT EmbeddedWorkerInstance
       const storage::BucketLocator& bucket_locator);
 
 #if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_COBALT)
   void BindHidService(const url::Origin& origin,
                       mojo::PendingReceiver<blink::mojom::HidService> receiver);
+#endif
 #endif  // !BUILDFLAG(IS_ANDROID)
 
+#if !BUILDFLAG(IS_COBALT)
   void BindUsbService(
       const url::Origin& origin,
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver);
+#endif
 
   base::WeakPtr<EmbeddedWorkerInstance> AsWeakPtr();
 

--- a/content/browser/service_worker/service_worker_context_core.cc
+++ b/content/browser/service_worker/service_worker_context_core.cc
@@ -30,7 +30,9 @@
 #include "content/browser/service_worker/service_worker_container_host.h"
 #include "content/browser/service_worker/service_worker_context_core_observer.h"
 #include "content/browser/service_worker/service_worker_context_wrapper.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/service_worker/service_worker_hid_delegate_observer.h"
+#endif
 #include "content/browser/service_worker/service_worker_host.h"
 #include "content/browser/service_worker/service_worker_info.h"
 #include "content/browser/service_worker/service_worker_job_coordinator.h"
@@ -39,7 +41,9 @@
 #include "content/browser/service_worker/service_worker_register_job.h"
 #include "content/browser/service_worker/service_worker_registration.h"
 #include "content/browser/service_worker/service_worker_security_utils.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/service_worker/service_worker_usb_delegate_observer.h"
+#endif
 #include "content/browser/service_worker/service_worker_version.h"
 #include "content/browser/storage_partition_impl.h"
 #include "content/common/content_navigation_policy.h"
@@ -1524,7 +1528,7 @@ ScopedServiceWorkerClient::CommitResponseAndRelease(
   return std::make_tuple(std::move(container_info), std::move(controller));
 }
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 ServiceWorkerHidDelegateObserver*
 ServiceWorkerContextCore::hid_delegate_observer() {
   if (!hid_delegate_observer_) {
@@ -1552,5 +1556,5 @@ void ServiceWorkerContextCore::SetServiceWorkerUsbDelegateObserverForTesting(
     std::unique_ptr<ServiceWorkerUsbDelegateObserver> usb_delegate_observer) {
   usb_delegate_observer_ = std::move(usb_delegate_observer);
 }
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 }  // namespace content

--- a/content/browser/service_worker/service_worker_context_core.h
+++ b/content/browser/service_worker/service_worker_context_core.h
@@ -50,10 +50,10 @@ class ServiceWorkerQuotaClient;
 class ServiceWorkerRegistration;
 struct ServiceWorkerContextSynchronousObserverList;
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 class ServiceWorkerHidDelegateObserver;
 class ServiceWorkerUsbDelegateObserver;
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
 // A smart pointer of `ServiceWorkerClient`.
 //
@@ -555,7 +555,7 @@ class CONTENT_EXPORT ServiceWorkerContextCore
     test_version_observers_.RemoveObserver(observer);
   }
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   ServiceWorkerHidDelegateObserver* hid_delegate_observer();
 
   void SetServiceWorkerHidDelegateObserverForTesting(
@@ -568,7 +568,7 @@ class CONTENT_EXPORT ServiceWorkerContextCore
 
   void SetServiceWorkerUsbDelegateObserverForTesting(
       std::unique_ptr<ServiceWorkerUsbDelegateObserver> usb_delegate_observer);
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
  private:
   friend class ServiceWorkerContextCoreTest;
@@ -701,10 +701,10 @@ class CONTENT_EXPORT ServiceWorkerContextCore
 
   bool is_processing_warming_up_ = false;
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   std::unique_ptr<ServiceWorkerHidDelegateObserver> hid_delegate_observer_;
   std::unique_ptr<ServiceWorkerUsbDelegateObserver> usb_delegate_observer_;
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
   base::ObserverList<TestVersionObserver> test_version_observers_;
 

--- a/content/browser/service_worker/service_worker_host.cc
+++ b/content/browser/service_worker/service_worker_host.cc
@@ -120,7 +120,7 @@ void ServiceWorkerHost::GetSandboxedFileSystemForBucket(
   }
 }
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 void ServiceWorkerHost::BindHidService(
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -129,6 +129,7 @@ void ServiceWorkerHost::BindHidService(
 }
 #endif
 
+#if !BUILDFLAG(IS_COBALT)
 void ServiceWorkerHost::BindUsbService(
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -145,6 +146,7 @@ void ServiceWorkerHost::BindUsbService(
   version_->embedded_worker()->BindUsbService(
       container_host_->top_frame_origin(), std::move(receiver));
 }
+#endif
 
 net::NetworkIsolationKey ServiceWorkerHost::GetNetworkIsolationKey() const {
   return version_->key().ToPartialNetIsolationInfo().network_isolation_key();

--- a/content/browser/service_worker/service_worker_host.h
+++ b/content/browser/service_worker/service_worker_host.h
@@ -95,12 +95,14 @@ class CONTENT_EXPORT ServiceWorkerHost : public BucketContext,
   void BindCacheStorage(
       mojo::PendingReceiver<blink::mojom::CacheStorage> receiver);
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   void BindHidService(mojo::PendingReceiver<blink::mojom::HidService> receiver);
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif
 
+#if !BUILDFLAG(IS_COBALT)
   void BindUsbService(
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver);
+#endif
 
   ServiceWorkerContainerHostForServiceWorker* container_host() {
     return container_host_.get();

--- a/content/browser/service_worker/service_worker_version.cc
+++ b/content/browser/service_worker/service_worker_version.cc
@@ -34,6 +34,7 @@
 #include "components/services/storage/public/mojom/service_worker_database.mojom-forward.h"
 #include "content/browser/bad_message.h"
 #include "content/browser/child_process_security_policy_impl.h"
+#include "content/browser/storage_partition_impl.h"
 #include "content/browser/renderer_host/back_forward_cache_can_store_document_result.h"
 #include "content/browser/renderer_host/private_network_access_util.h"
 #include "content/browser/service_worker/payment_handler_support.h"
@@ -42,11 +43,15 @@
 #include "content/browser/service_worker/service_worker_container_host.h"
 #include "content/browser/service_worker/service_worker_context_core.h"
 #include "content/browser/service_worker/service_worker_context_wrapper.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/service_worker/service_worker_hid_delegate_observer.h"
+#endif
 #include "content/browser/service_worker/service_worker_host.h"
 #include "content/browser/service_worker/service_worker_installed_scripts_sender.h"
 #include "content/browser/service_worker/service_worker_security_utils.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/service_worker/service_worker_usb_delegate_observer.h"
+#endif
 #include "content/common/content_navigation_policy.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/content_browser_client.h"
@@ -453,7 +458,7 @@ void ServiceWorkerVersion::SetStatus(Status status) {
   if (status == INSTALLED) {
     embedded_worker_->OnWorkerVersionInstalled();
   } else if (status == ACTIVATED) {
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
     // Notify the hid delegate observer if the active service worker has any hid
     // event handlers.
     context_->hid_delegate_observer()->UpdateHasEventHandlers(
@@ -463,7 +468,7 @@ void ServiceWorkerVersion::SetStatus(Status status) {
     // event handlers.
     context_->usb_delegate_observer()->UpdateHasEventHandlers(
         registration_id_, has_usb_event_handlers_);
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   } else if (status == REDUNDANT) {
     embedded_worker_->OnWorkerVersionDoomed();
 

--- a/content/browser/storage_partition_impl.cc
+++ b/content/browser/storage_partition_impl.cc
@@ -62,7 +62,9 @@
 #include "content/browser/background_fetch/background_fetch_context.h"
 #include "content/browser/blob_storage/blob_registry_wrapper.h"
 #include "content/browser/blob_storage/chrome_blob_storage_context.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/browser/bluetooth/bluetooth_allowed_devices_map.h"
+#endif
 #include "content/browser/broadcast_channel/broadcast_channel_service.h"
 #include "content/browser/browsing_data/clear_site_data_handler.h"
 #include "content/browser/browsing_data/storage_partition_code_cache_data_remover.h"
@@ -1426,8 +1428,10 @@ void StoragePartitionImpl::Initialize(
 
   broadcast_channel_service_ = std::make_unique<BroadcastChannelService>();
 
+#if !BUILDFLAG(IS_COBALT)
   bluetooth_allowed_devices_map_ =
       std::make_unique<BluetoothAllowedDevicesMap>();
+#endif
 
   // Must be initialized before the
   // `shared_url_loader_factory_for_browser_process_`. Cookie deprecation
@@ -1786,11 +1790,13 @@ BroadcastChannelService* StoragePartitionImpl::GetBroadcastChannelService() {
   return broadcast_channel_service_.get();
 }
 
+#if !BUILDFLAG(IS_COBALT)
 BluetoothAllowedDevicesMap*
 StoragePartitionImpl::GetBluetoothAllowedDevicesMap() {
   DCHECK(initialized_);
   return bluetooth_allowed_devices_map_.get();
 }
+#endif
 
 BlobRegistryWrapper* StoragePartitionImpl::GetBlobRegistry() {
   DCHECK(initialized_);
@@ -3367,10 +3373,12 @@ void StoragePartitionImpl::ResetURLLoaderFactories() {
       ->Reset();
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void StoragePartitionImpl::ClearBluetoothAllowedDevicesMapForTesting() {
   DCHECK(initialized_);
   bluetooth_allowed_devices_map_->Clear();
 }
+#endif
 
 void StoragePartitionImpl::AddObserver(DataRemovalObserver* observer) {
   data_removal_observers_.AddObserver(observer);

--- a/content/browser/storage_partition_impl.h
+++ b/content/browser/storage_partition_impl.h
@@ -92,7 +92,9 @@ class AggregationService;
 class AttributionManager;
 class BackgroundFetchContext;
 class BlobRegistryWrapper;
+#if !BUILDFLAG(IS_COBALT)
 class BluetoothAllowedDevicesMap;
+#endif
 class BroadcastChannelService;
 class BrowsingDataFilterBuilder;
 class KeepAliveURLLoaderService;
@@ -271,7 +273,9 @@ class CONTENT_EXPORT StoragePartitionImpl
       base::OnceClosure callback) override;
   void Flush() override;
   void ResetURLLoaderFactories() override;
+#if !BUILDFLAG(IS_COBALT)
   void ClearBluetoothAllowedDevicesMapForTesting() override;
+#endif
   void AddObserver(DataRemovalObserver* observer) override;
   void RemoveObserver(DataRemovalObserver* observer) override;
   void FlushNetworkInterfaceForTesting() override;
@@ -292,7 +296,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   BackgroundFetchContext* GetBackgroundFetchContext();
   PaymentAppContextImpl* GetPaymentAppContext();
   BroadcastChannelService* GetBroadcastChannelService();
+#if !BUILDFLAG(IS_COBALT)
   BluetoothAllowedDevicesMap* GetBluetoothAllowedDevicesMap();
+#endif
   BlobRegistryWrapper* GetBlobRegistry();
   storage::BlobUrlRegistry* GetBlobUrlRegistry();
   SubresourceProxyingURLLoaderService* GetSubresourceProxyingURLLoaderService();
@@ -796,7 +802,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   scoped_refptr<BackgroundSyncContextImpl> background_sync_context_;
   scoped_refptr<PaymentAppContextImpl> payment_app_context_;
   std::unique_ptr<BroadcastChannelService> broadcast_channel_service_;
+#if !BUILDFLAG(IS_COBALT)
   std::unique_ptr<BluetoothAllowedDevicesMap> bluetooth_allowed_devices_map_;
+#endif
   scoped_refptr<BlobRegistryWrapper> blob_registry_;
   std::unique_ptr<storage::BlobUrlRegistry> blob_url_registry_;
   std::unique_ptr<SubresourceProxyingURLLoaderService>

--- a/content/browser/webauth/webauth_browsertest.cc
+++ b/content/browser/webauth/webauth_browsertest.cc
@@ -65,8 +65,10 @@
 #include "content/test/content_browser_test_utils_internal.h"
 #include "content/test/did_commit_navigation_interceptor.h"
 #include "content/test/fake_network_url_loader_factory.h"
-#include "device/bluetooth/bluetooth_adapter_factory.h"
-#include "device/bluetooth/test/mock_bluetooth_adapter.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "device/bluetooth/bluetooth_adapter_factory.h"  // nogncheck
+#include "device/bluetooth/test/mock_bluetooth_adapter.h"  // nogncheck
+#endif
 #include "device/fido/fake_fido_discovery.h"
 #include "device/fido/features.h"
 #include "device/fido/fido_parsing_utils.h"
@@ -1571,6 +1573,7 @@ IN_PROC_BROWSER_TEST_F(WebAuthJavascriptClientBrowserTest,
   }
 }
 
+#if !BUILDFLAG(IS_COBALT)
 // Regression test for crbug.com/399383355.
 IN_PROC_BROWSER_TEST_F(WebAuthJavascriptClientBrowserTest,
                        GetClientCapabilitiesCrossOriginIframe) {
@@ -1603,6 +1606,7 @@ IN_PROC_BROWSER_TEST_F(WebAuthJavascriptClientBrowserTest,
   ASSERT_TRUE(iframe);
   EXPECT_TRUE(EvalJs(iframe, kScript).ExtractBool());
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 // Tests that a credentials.create() call triggered by the main frame will
 // successfully complete even if a subframe navigation takes place while the

--- a/content/browser/webid/digital_credentials/cross_device_request_dispatcher_unittest.cc
+++ b/content/browser/webid/digital_credentials/cross_device_request_dispatcher_unittest.cc
@@ -11,8 +11,10 @@
 #include "content/browser/webid/digital_credentials/cross_device_request_dispatcher.h"
 #include "content/public/browser/cross_device_request_info.h"
 #include "content/public/browser/digital_credentials_cross_device.h"
-#include "device/bluetooth/bluetooth_adapter_factory.h"
-#include "device/bluetooth/test/mock_bluetooth_adapter.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "device/bluetooth/bluetooth_adapter_factory.h"  // nogncheck
+#include "device/bluetooth/test/mock_bluetooth_adapter.h"  // nogncheck
+#endif
 #include "device/fido/cable/fido_cable_discovery.h"
 #include "device/fido/cable/v2_authenticator.h"
 #include "device/fido/cable/v2_constants.h"
@@ -51,9 +53,11 @@ class DigitalCredentialsCrossDeviceRequestDispatcherTest
                  POINT_CONVERSION_UNCOMPRESSED, peer_identity_x962_,
                  sizeof(peer_identity_x962_), /*ctx=*/nullptr));
 
+#if !BUILDFLAG(IS_COBALT)
     mock_adapter_ =
         base::MakeRefCounted<NiceMock<device::MockBluetoothAdapter>>();
     device::BluetoothAdapterFactory::SetAdapterForTesting(mock_adapter_);
+#endif
   }
 
  protected:
@@ -129,7 +133,9 @@ class DigitalCredentialsCrossDeviceRequestDispatcherTest
       0};
   const std::array<uint8_t, device::cablev2::kQRSeedSize> zero_seed_ = {0};
 
+#if !BUILDFLAG(IS_COBALT)
   scoped_refptr<NiceMock<device::MockBluetoothAdapter>> mock_adapter_;
+#endif
 
   base::test::TaskEnvironment task_environment;
 };

--- a/content/browser/worker_host/dedicated_worker_host.cc
+++ b/content/browser/worker_host/dedicated_worker_host.cc
@@ -708,6 +708,7 @@ void DedicatedWorkerHost::CreateDirectSocketsService(
 }
 #endif
 
+#if !BUILDFLAG(IS_COBALT)
 void DedicatedWorkerHost::CreateWebUsbService(
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -721,6 +722,7 @@ void DedicatedWorkerHost::CreateWebUsbService(
 
   ancestor_render_frame_host->CreateWebUsbService(std::move(receiver));
 }
+#endif
 
 void DedicatedWorkerHost::CreateWebSocketConnector(
     mojo::PendingReceiver<blink::mojom::WebSocketConnector> receiver) {
@@ -863,6 +865,7 @@ void DedicatedWorkerHost::CreateCodeCacheHost(
                                  GetStorageKey(), std::move(receiver));
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void DedicatedWorkerHost::BindSerialService(
     mojo::PendingReceiver<blink::mojom::SerialService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);
@@ -876,8 +879,9 @@ void DedicatedWorkerHost::BindSerialService(
 
   ancestor_render_frame_host->BindSerialService(std::move(receiver));
 }
+#endif
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 void DedicatedWorkerHost::BindHidService(
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
   DCHECK_CURRENTLY_ON(BrowserThread::UI);

--- a/content/browser/worker_host/dedicated_worker_host.h
+++ b/content/browser/worker_host/dedicated_worker_host.h
@@ -143,8 +143,10 @@ class CONTENT_EXPORT DedicatedWorkerHost final
   void CreateDirectSocketsService(
       mojo::PendingReceiver<blink::mojom::DirectSocketsService> receiver);
 #endif
+#if !BUILDFLAG(IS_COBALT)
   void CreateWebUsbService(
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver);
+#endif
   void CreateWebSocketConnector(
       mojo::PendingReceiver<blink::mojom::WebSocketConnector> receiver);
   void CreateWebTransportConnector(
@@ -173,9 +175,11 @@ class CONTENT_EXPORT DedicatedWorkerHost final
       mojo::PendingReceiver<blink::mojom::WebPressureManager> receiver);
 #endif  // BUILDFLAG(ENABLE_COMPUTE_PRESSURE)
 
+#if !BUILDFLAG(IS_COBALT)
   void BindSerialService(
       mojo::PendingReceiver<blink::mojom::SerialService> receiver);
-#if !BUILDFLAG(IS_ANDROID)
+#endif
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   void BindHidService(mojo::PendingReceiver<blink::mojom::HidService> receiver);
 #endif
 

--- a/content/public/browser/storage_partition.h
+++ b/content/public/browser/storage_partition.h
@@ -362,8 +362,10 @@ class CONTENT_EXPORT StoragePartition {
 
   virtual void RemoveObserver(DataRemovalObserver* observer) = 0;
 
+#if !BUILDFLAG(IS_COBALT)
   // Clear the bluetooth allowed devices map. For test use only.
   virtual void ClearBluetoothAllowedDevicesMapForTesting() = 0;
+#endif
 
   // Call |FlushForTesting()| on Network Service related interfaces. For test
   // use only.

--- a/content/public/test/test_renderer_host.h
+++ b/content/public/test/test_renderer_host.h
@@ -159,15 +159,17 @@ class RenderFrameHostTester {
   // Creates and appends a fenced frame.
   virtual RenderFrameHost* AppendFencedFrame() = 0;
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   // Creates the HidService and binds `receiver`.
   virtual void CreateHidServiceForTesting(
       mojo::PendingReceiver<blink::mojom::HidService> receiever) = 0;
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
+#if !BUILDFLAG(IS_COBALT)
   // Creates the WebUsbService and binds `receiver`.
   virtual void CreateWebUsbServiceForTesting(
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) = 0;
+#endif  // !BUILDFLAG(IS_COBALT)
 
   // Detaches the LocalFrame mojo connection to the renderer. This is useful
   // when tests override the creation logic for the LocalFrame and need the

--- a/content/public/test/test_storage_partition.cc
+++ b/content/public/test/test_storage_partition.cc
@@ -263,7 +263,9 @@ int TestStoragePartition::GetDataRemovalObserverCount() {
   return data_removal_observer_count_;
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void TestStoragePartition::ClearBluetoothAllowedDevicesMapForTesting() {}
+#endif
 
 void TestStoragePartition::FlushNetworkInterfaceForTesting() {}
 

--- a/content/public/test/test_storage_partition.h
+++ b/content/public/test/test_storage_partition.h
@@ -251,7 +251,9 @@ class TestStoragePartition : public StoragePartition {
   void RemoveObserver(DataRemovalObserver* observer) override;
   int GetDataRemovalObserverCount();
 
+#if !BUILDFLAG(IS_COBALT)
   void ClearBluetoothAllowedDevicesMapForTesting() override;
+#endif
   void FlushNetworkInterfaceForTesting() override;
   void FlushCertVerifierInterfaceForTesting() override;
   void WaitForDeletionTasksForTesting() override;

--- a/content/test/BUILD.gn
+++ b/content/test/BUILD.gn
@@ -869,6 +869,17 @@ static_library("test_support") {
   if (is_fuchsia) {
     public_deps += [ "//third_party/fuchsia-sdk/sdk/fidl/fuchsia.mediacodec:fuchsia.mediacodec_hlcpp" ]
   }
+
+  if (is_cobalt) {
+    sources -= [
+      "../browser/bluetooth/test/mock_bluetooth_delegate.cc",
+      "../browser/bluetooth/test/mock_bluetooth_delegate.h",
+      "../public/test/bluetooth_test_utils.cc",
+      "../public/test/bluetooth_test_utils.h",
+      "../public/test/embedded_worker_instance_test_harness.cc",
+      "../public/test/embedded_worker_instance_test_harness.h",
+    ]
+  }
 }
 
 # Fuchsia performance tests on smart displays use web_engine and a browser
@@ -1808,6 +1819,10 @@ test("content_browsertests") {
     sources += [ "../browser/network/sandboxed_socket_broker_browsertest.cc" ]
   }
 
+  if (is_cobalt) {
+    sources -= [ "../browser/bluetooth/web_bluetooth_service_impl_browsertest.cc" ]
+  }
+
   if (enable_reporting) {
     sources += [ "../browser/security/coop/cross_origin_opener_policy_reporting_browsertest.cc" ]
   }
@@ -1980,6 +1995,10 @@ test("content_browsertests") {
 
   if (!(is_chromeos && target_cpu == "arm64" && current_cpu == "arm")) {
     deps += [ "//components/variations" ]
+  }
+
+  if (is_cobalt) {
+    deps -= [ "//device/bluetooth:mocks" ]
   }
 
   data_deps = [
@@ -3020,6 +3039,19 @@ test("content_unittests") {
     "FirstPartySetFuzzer.ParsesSetsCorrectly",
   ]
 
+  if (is_cobalt) {
+    sources -= [
+      "../browser/bluetooth/bluetooth_allowed_devices_unittest.cc",
+      "../browser/bluetooth/bluetooth_blocklist_unittest.cc",
+      "../browser/bluetooth/bluetooth_device_chooser_controller_unittest.cc",
+      "../browser/bluetooth/bluetooth_util_unittest.cc",
+      "../browser/bluetooth/frame_connected_bluetooth_devices_unittest.cc",
+      "../browser/bluetooth/web_bluetooth_pairing_manager_impl_unittest.cc",
+      "../browser/bluetooth/web_bluetooth_service_impl_unittest.cc",
+      "../browser/service_worker/embedded_worker_instance_unittest.cc",
+    ]
+  }
+
   if (is_mac) {
     sources += [
       "../browser/child_process_task_port_provider_mac_unittest.cc",
@@ -3086,6 +3118,11 @@ test("content_unittests") {
       "../browser/webid/digital_credentials/cross_device_request_dispatcher_unittest.cc",
       "../browser/webid/digital_credentials/cross_device_transaction_impl_unittest.cc",
     ]
+    if (is_cobalt) {
+      sources -= [
+        "../browser/webid/digital_credentials/cross_device_transaction_impl_unittest.cc",
+      ]
+    }
   }
 
   if (!is_android && !is_ios) {
@@ -3314,6 +3351,13 @@ test("content_unittests") {
 
   if (enable_nocompile_tests) {
     deps += [ ":content_nocompile_tests" ]
+  }
+
+  if (is_cobalt) {
+    deps -= [
+      "//device/bluetooth",
+      "//device/bluetooth:mocks",
+    ]
   }
 
   data_deps = [
@@ -3551,7 +3595,7 @@ test("content_unittests") {
 
   # HID support is not available without udev.
   is_linux_without_udev = (is_linux || is_chromeos) && !use_udev
-  if (!is_linux_without_udev && !is_android) {
+  if (!is_linux_without_udev && !is_android && !is_cobalt) {
     sources += [
       "../browser/hid/hid_service_unittest.cc",
       "../browser/service_worker/service_worker_hid_delegate_observer_unittest.cc",

--- a/content/test/test_render_frame_host.cc
+++ b/content/test/test_render_frame_host.cc
@@ -601,17 +601,19 @@ void TestRenderFrameHost::SimulateCommitProcessed(
       same_document);
 }
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 void TestRenderFrameHost::CreateHidServiceForTesting(
     mojo::PendingReceiver<blink::mojom::HidService> receiver) {
   RenderFrameHostImpl::GetHidService(std::move(receiver));
 }
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
+#if !BUILDFLAG(IS_COBALT)
 void TestRenderFrameHost::CreateWebUsbServiceForTesting(
     mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) {
   RenderFrameHostImpl::CreateWebUsbService(std::move(receiver));
 }
+#endif
 
 void TestRenderFrameHost::ResetLocalFrame() {
   local_frame_.reset();

--- a/content/test/test_render_frame_host.h
+++ b/content/test/test_render_frame_host.h
@@ -113,14 +113,16 @@ class TestRenderFrameHost : public RenderFrameHostImpl,
   int GetHeavyAdIssueCount(HeavyAdIssueType type) override;
   void SimulateManifestURLUpdate(const GURL& manifest_url) override;
   TestRenderFrameHost* AppendFencedFrame() override;
+#if !BUILDFLAG(IS_COBALT)
   void CreateWebUsbServiceForTesting(
       mojo::PendingReceiver<blink::mojom::WebUsbService> receiver) override;
+#endif
   void ResetLocalFrame() override;
 
-#if !BUILDFLAG(IS_ANDROID)
+#if !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   void CreateHidServiceForTesting(
       mojo::PendingReceiver<blink::mojom::HidService> receiver) override;
-#endif  // !BUILDFLAG(IS_ANDROID)
+#endif  // !BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
 
   void SendNavigate(int nav_entry_id,
                     bool did_create_new_entry,

--- a/content/web_test/BUILD.gn
+++ b/content/web_test/BUILD.gn
@@ -39,6 +39,10 @@ mojom("web_test_common_mojom") {
   ]
 
   if (is_cobalt) {
+    sources -= [
+      "common/fake_bluetooth_chooser.mojom",
+      "common/web_test_bluetooth_fake_adapter_setter.mojom",
+    ]
     # These deps automatically generate the JavaScript bindings.
     public_deps += [
       "//cobalt/browser/crash_annotator/public/mojom",
@@ -196,6 +200,25 @@ static_library("web_test_browser") {
   if (is_linux || is_chromeos) {
     sources += [ "browser/web_test_browser_main_platform_support_linux.cc" ]
   }
+  
+  if (is_cobalt) {
+    sources -= [
+      "browser/fake_bluetooth_chooser.cc",
+      "browser/fake_bluetooth_chooser.h",
+      "browser/fake_bluetooth_chooser_factory.cc",
+      "browser/fake_bluetooth_chooser_factory.h",
+      "browser/fake_bluetooth_delegate.cc",
+      "browser/fake_bluetooth_delegate.h",
+      "browser/web_test_bluetooth_adapter_provider.cc",
+      "browser/web_test_bluetooth_adapter_provider.h",
+      "browser/web_test_bluetooth_chooser_factory.cc",
+      "browser/web_test_bluetooth_chooser_factory.h",
+      "browser/web_test_bluetooth_fake_adapter_setter_impl.cc",
+      "browser/web_test_bluetooth_fake_adapter_setter_impl.h",
+      "browser/web_test_first_device_bluetooth_chooser.cc",
+      "browser/web_test_first_device_bluetooth_chooser.h",
+    ]
+  }
 
   deps = [
     ":web_test_common",
@@ -272,6 +295,11 @@ static_library("web_test_browser") {
     deps += [
       "//cobalt/browser/h5vcc_runtime/public/mojom",
       "//cobalt/testing/h5vcc_runtime:stub_h5vcc_runtime",
+    ]
+    deps -= [
+      "//device/bluetooth:fake_bluetooth",
+      "//device/bluetooth:mocks",
+      "//device/bluetooth/public/mojom:fake_bluetooth_interfaces",
     ]
   }
 }

--- a/content/web_test/browser/web_test_content_browser_client.cc
+++ b/content/web_test/browser/web_test_content_browser_client.cc
@@ -43,13 +43,17 @@
 #include "content/test/data/mojo_web_test_helper.test-mojom.h"
 #include "content/test/mock_badge_service.h"
 #include "content/test/mock_clipboard_host.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/web_test/browser/fake_bluetooth_chooser.h"
 #include "content/web_test/browser/fake_bluetooth_chooser_factory.h"
 #include "content/web_test/browser/fake_bluetooth_delegate.h"
+#endif
 #include "content/web_test/browser/mojo_echo.h"
 #include "content/web_test/browser/mojo_optional_numerics_unittest.h"
 #include "content/web_test/browser/mojo_web_test_helper.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/web_test/browser/web_test_bluetooth_fake_adapter_setter_impl.h"
+#endif
 #include "content/web_test/browser/web_test_browser_context.h"
 #include "content/web_test/browser/web_test_browser_main_parts.h"
 #include "content/web_test/browser/web_test_control_host.h"
@@ -62,11 +66,15 @@
 #include "content/web_test/browser/web_test_sensor_provider_manager.h"
 #include "content/web_test/browser/web_test_storage_access_manager.h"
 #include "content/web_test/browser/web_test_tts_platform.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/web_test/common/web_test_bluetooth_fake_adapter_setter.mojom.h"
+#endif
 #include "content/web_test/common/web_test_string_util.h"
 #include "content/web_test/common/web_test_switches.h"
-#include "device/bluetooth/emulation/fake_bluetooth.h"
-#include "device/bluetooth/public/mojom/emulation/fake_bluetooth.mojom.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "device/bluetooth/emulation/fake_bluetooth.h"  // nogncheck
+#include "device/bluetooth/public/mojom/emulation/fake_bluetooth.mojom.h"  // nogncheck
+#endif
 #include "gpu/config/gpu_switches.h"
 #include "mojo/public/cpp/bindings/associated_receiver_set.h"
 #include "mojo/public/cpp/bindings/binder_map.h"
@@ -329,12 +337,14 @@ void WebTestContentBrowserClient::ResetMockClipboardHosts() {
     mock_clipboard_host_->Reset();
 }
 
+#if !BUILDFLAG(IS_COBALT)
 std::unique_ptr<FakeBluetoothChooser>
 WebTestContentBrowserClient::GetNextFakeBluetoothChooser() {
   if (!fake_bluetooth_chooser_factory_)
     return nullptr;
   return fake_bluetooth_chooser_factory_->GetNextFakeBluetoothChooser();
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void WebTestContentBrowserClient::BrowserChildProcessHostCreated(
     BrowserChildProcessHost* host) {
@@ -359,6 +369,7 @@ void WebTestContentBrowserClient::ExposeInterfacesToRenderer(
   registry->AddInterface(
       base::BindRepeating(&optional_numerics_unittest::ResponseParams::Bind),
       ui_task_runner);
+#if !BUILDFLAG(IS_COBALT)
   registry->AddInterface(
       base::BindRepeating(&WebTestBluetoothFakeAdapterSetterImpl::Create),
       ui_task_runner);
@@ -373,6 +384,7 @@ void WebTestContentBrowserClient::ExposeInterfacesToRenderer(
           &WebTestContentBrowserClient::CreateFakeBluetoothChooserFactory,
           base::Unretained(this)),
       ui_task_runner);
+#endif  // !BUILDFLAG(IS_COBALT)
   registry->AddInterface(base::BindRepeating(&MojoWebTestHelper::Create));
 
   registry->AddInterface(
@@ -600,6 +612,7 @@ bool WebTestContentBrowserClient::CanAcceptUntrustedExchangesIfNeeded() {
   return true;
 }
 
+#if !BUILDFLAG(IS_COBALT)
 BluetoothDelegate* WebTestContentBrowserClient::GetBluetoothDelegate() {
   if (!fake_bluetooth_delegate_)
     fake_bluetooth_delegate_ = std::make_unique<FakeBluetoothDelegate>();
@@ -609,6 +622,7 @@ BluetoothDelegate* WebTestContentBrowserClient::GetBluetoothDelegate() {
 void WebTestContentBrowserClient::ResetFakeBluetoothDelegate() {
   fake_bluetooth_delegate_.reset();
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 content::TtsPlatform* WebTestContentBrowserClient::GetTtsPlatform() {
   return WebTestTtsPlatform::GetInstance();
@@ -752,11 +766,13 @@ void WebTestContentBrowserClient::ConfigureNetworkContextParamsForShell(
   }
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void WebTestContentBrowserClient::CreateFakeBluetoothChooserFactory(
     mojo::PendingReceiver<mojom::FakeBluetoothChooserFactory> receiver) {
   fake_bluetooth_chooser_factory_ =
       FakeBluetoothChooserFactory::Create(std::move(receiver));
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void WebTestContentBrowserClient::BindWebTestControlHost(
     int render_process_id,

--- a/content/web_test/browser/web_test_content_browser_client.h
+++ b/content/web_test/browser/web_test_content_browser_client.h
@@ -11,7 +11,9 @@
 
 #include "build/build_config.h"
 #include "content/shell/browser/shell_content_browser_client.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/web_test/common/fake_bluetooth_chooser.mojom-forward.h"
+#endif
 #include "content/web_test/common/web_test.mojom-forward.h"
 #include "mojo/public/cpp/bindings/binder_map.h"
 #include "mojo/public/cpp/bindings/pending_associated_receiver.h"
@@ -40,9 +42,11 @@ struct WebPreferences;
 }  // namespace blink
 
 namespace content {
+#if !BUILDFLAG(IS_COBALT)
 class FakeBluetoothChooser;
 class FakeBluetoothChooserFactory;
 class FakeBluetoothDelegate;
+#endif
 class MockBadgeService;
 class MockClipboardHost;
 class NavigationThrottleRegistry;
@@ -65,9 +69,11 @@ class WebTestContentBrowserClient : public ShellContentBrowserClient {
   void SetPopupBlockingEnabled(bool block_popups_);
   void ResetMockClipboardHosts();
 
+#if !BUILDFLAG(IS_COBALT)
   // Retrieves the last created FakeBluetoothChooser instance.
   std::unique_ptr<FakeBluetoothChooser> GetNextFakeBluetoothChooser();
   void ResetFakeBluetoothDelegate();
+#endif
 
   void ResetWebSensorProviderAutomation();
 
@@ -109,7 +115,9 @@ class WebTestContentBrowserClient : public ShellContentBrowserClient {
       RenderFrameHost* render_frame_host,
       mojo::BinderMapWithContext<content::RenderFrameHost*>* map) override;
   bool CanAcceptUntrustedExchangesIfNeeded() override;
+#if !BUILDFLAG(IS_COBALT)
   BluetoothDelegate* GetBluetoothDelegate() override;
+#endif
   content::TtsPlatform* GetTtsPlatform() override;
   std::unique_ptr<LoginDelegate> CreateLoginDelegate(
       const net::AuthChallengeInfo& auth_info,
@@ -153,9 +161,11 @@ class WebTestContentBrowserClient : public ShellContentBrowserClient {
       cert_verifier::mojom::CertVerifierCreationParams*
           cert_verifier_creation_params) override;
 
+#if !BUILDFLAG(IS_COBALT)
   // Creates and stores a FakeBluetoothChooserFactory instance.
   void CreateFakeBluetoothChooserFactory(
       mojo::PendingReceiver<mojom::FakeBluetoothChooserFactory> receiver);
+#endif
   void BindClipboardHost(
       RenderFrameHost* render_frame_host,
       mojo::PendingReceiver<blink::mojom::ClipboardHost> receiver);
@@ -215,9 +225,11 @@ class WebTestContentBrowserClient : public ShellContentBrowserClient {
 
   bool block_popups_ = true;
 
+#if !BUILDFLAG(IS_COBALT)
   // Stores the FakeBluetoothChooserFactory that produces FakeBluetoothChoosers.
   std::unique_ptr<FakeBluetoothChooserFactory> fake_bluetooth_chooser_factory_;
   std::unique_ptr<FakeBluetoothDelegate> fake_bluetooth_delegate_;
+#endif
   std::unique_ptr<MockClipboardHost> mock_clipboard_host_;
   std::unique_ptr<MockBadgeService> mock_badge_service_;
   mojo::UniqueReceiverSet<blink::test::mojom::DevicePostureProviderAutomation>

--- a/content/web_test/browser/web_test_control_host.cc
+++ b/content/web_test/browser/web_test_control_host.cc
@@ -83,13 +83,19 @@
 #include "content/test/mock_platform_notification_service.h"
 #include "content/test/storage_partition_test_helpers.h"
 #include "content/web_test/browser/devtools_protocol_test_bindings.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/web_test/browser/fake_bluetooth_chooser.h"
+#endif
 #include "content/web_test/browser/test_info_extractor.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/web_test/browser/web_test_bluetooth_chooser_factory.h"
+#endif
 #include "content/web_test/browser/web_test_browser_context.h"
 #include "content/web_test/browser/web_test_content_browser_client.h"
 #include "content/web_test/browser/web_test_devtools_bindings.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/web_test/browser/web_test_first_device_bluetooth_chooser.h"
+#endif
 #include "content/web_test/browser/web_test_permission_manager.h"
 #include "content/web_test/browser/web_test_pressure_manager.h"
 #include "content/web_test/common/web_test_constants.h"
@@ -730,7 +736,9 @@ void WebTestControlHost::ResetBrowserAfterWebTest() {
   should_override_prefs_ = false;
   WebTestContentBrowserClient::Get()->SetPopupBlockingEnabled(true);
   WebTestContentBrowserClient::Get()->ResetMockClipboardHosts();
+#if !BUILDFLAG(IS_COBALT)
   WebTestContentBrowserClient::Get()->ResetFakeBluetoothDelegate();
+#endif
   WebTestContentBrowserClient::Get()->ResetWebSensorProviderAutomation();
   WebTestContentBrowserClient::Get()
       ->GetWebTestBrowserContext()
@@ -751,8 +759,9 @@ void WebTestControlHost::ResetBrowserAfterWebTest() {
 
   BlockThirdPartyCookies(
       net::cookie_util::IsForceThirdPartyCookieBlockingEnabled());
+#if !BUILDFLAG(IS_COBALT)
   SetBluetoothManualChooser(false);
-
+#endif
   ShellBrowserContext* browser_context =
       ShellContentBrowserClient::Get()->browser_context();
   static_cast<InMemoryFederatedPermissionContext*>(
@@ -1050,6 +1059,7 @@ bool WebTestControlHost::IsMainWindow(WebContents* web_contents) const {
   return main_window_ && web_contents == main_window_->web_contents();
 }
 
+#if !BUILDFLAG(IS_COBALT)
 std::unique_ptr<BluetoothChooser> WebTestControlHost::RunBluetoothChooser(
     RenderFrameHost* frame,
     const BluetoothChooser::EventHandler& event_handler) {
@@ -1071,6 +1081,7 @@ std::unique_ptr<BluetoothChooser> WebTestControlHost::RunBluetoothChooser(
 
   return std::make_unique<WebTestFirstDeviceBluetoothChooser>(event_handler);
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void WebTestControlHost::RequestPointerLock(WebContents* web_contents) {
   if (next_pointer_lock_action_ == NextPointerLockAction::kTestWillRespond)
@@ -1339,7 +1350,9 @@ void WebTestControlHost::OnTestFinished() {
       browser_context->GetDefaultStoragePartition();
   storage_partition->GetServiceWorkerContext()->ClearAllServiceWorkersForTest(
       barrier_closure);
+#if !BUILDFLAG(IS_COBALT)
   storage_partition->ClearBluetoothAllowedDevicesMapForTesting();
+#endif
 
   // TODO(nhiroki): Add a comment about the reason why we terminate all shared
   // workers here.
@@ -2072,6 +2085,7 @@ void WebTestControlHost::CloseAllWindows() {
   base::RunLoop().RunUntilIdle();
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void WebTestControlHost::SetBluetoothManualChooser(bool enable) {
   if (enable) {
     bluetooth_chooser_factory_ =
@@ -2117,6 +2131,7 @@ void WebTestControlHost::SendBluetoothManualChooserEvent(
   }
   bluetooth_chooser_factory_->SendEvent(event, argument);
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void WebTestControlHost::BlockThirdPartyCookies(bool block) {
   ShellBrowserContext* browser_context =

--- a/content/web_test/browser/web_test_control_host.h
+++ b/content/web_test/browser/web_test_control_host.h
@@ -24,7 +24,9 @@
 #include "base/synchronization/lock.h"
 #include "base/values.h"
 #include "build/build_config.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/public/browser/bluetooth_chooser.h"
+#endif
 #include "content/public/browser/global_routing_id.h"
 #include "content/public/browser/gpu_data_manager_observer.h"
 #include "content/public/browser/render_process_host.h"
@@ -46,7 +48,9 @@ namespace content {
 class DevToolsProtocolTestBindings;
 class RenderFrameHost;
 class Shell;
+#if !BUILDFLAG(IS_COBALT)
 class WebTestBluetoothChooserFactory;
+#endif
 class WebTestDevToolsBindings;
 struct TestInfo;
 
@@ -136,9 +140,11 @@ class WebTestControlHost : public WebContentsObserver,
   void OverrideWebPreferences(blink::web_pref::WebPreferences* prefs);
   void OpenURL(const GURL& url);
   bool IsMainWindow(WebContents* web_contents) const;
+#if !BUILDFLAG(IS_COBALT)
   std::unique_ptr<BluetoothChooser> RunBluetoothChooser(
       RenderFrameHost* frame,
       const BluetoothChooser::EventHandler& event_handler);
+#endif
   void RequestPointerLock(WebContents* web_contents);
 
   WebTestResultPrinter* printer() { return printer_.get(); }
@@ -223,11 +229,13 @@ class WebTestControlHost : public WebContentsObserver,
                             bool hidden) override;
   void CheckForLeakedWindows() override;
   void GoToOffset(int offset) override;
+#if !BUILDFLAG(IS_COBALT)
   void SendBluetoothManualChooserEvent(const std::string& event,
                                        const std::string& argument) override;
   void SetBluetoothManualChooser(bool enable) override;
   void GetBluetoothManualChooserEvents(
       GetBluetoothManualChooserEventsCallback reply) override;
+#endif
   void SetPopupBlockingEnabled(bool block_popups) override;
   void LoadURLForFrame(const GURL& url, const std::string& frame_name) override;
   void SimulateScreenOrientationChanged() override;
@@ -387,7 +395,9 @@ class WebTestControlHost : public WebContentsObserver,
   bool crash_when_leak_found_ = false;
   std::unique_ptr<LeakDetector> leak_detector_;
 
+#if !BUILDFLAG(IS_COBALT)
   std::unique_ptr<WebTestBluetoothChooserFactory> bluetooth_chooser_factory_;
+#endif
 
   // Observe windows opened by tests.
   base::flat_map<WebContents*, std::unique_ptr<WebTestWindowObserver>>

--- a/content/web_test/common/web_test.mojom
+++ b/content/web_test/common/web_test.mojom
@@ -223,14 +223,17 @@ interface WebTestControlHost {
   //  * "cancel" - simulates the user canceling the chooser.
   //  * "select" - simulates the user selecting a device whose device ID is in
   //               |argument|.
+  [EnableIfNot=is_cobalt]
   SendBluetoothManualChooserEvent(string event, string argument);
 
   // If |enable| is true makes the Bluetooth chooser record its input and wait
   // for instructions from the test program on how to proceed. Otherwise
   // fall backs to the browser's default chooser.
+  [EnableIfNot=is_cobalt]
   SetBluetoothManualChooser(bool enable);
 
   // Returns the events recorded since the last call to this function.
+  [EnableIfNot=is_cobalt]
   GetBluetoothManualChooserEvents() => (array<string> events);
 
   // Manages the popup blocking setting to used for web tests.

--- a/content/web_test/renderer/test_runner.cc
+++ b/content/web_test/renderer/test_runner.cc
@@ -299,7 +299,9 @@ class TestRunnerBindings : public gin::Wrappable<TestRunnerBindings> {
   void FocusDevtoolsSecondaryWindow();
   void ForceNextDrawingBufferCreationToFail();
   void ForceNextWebGLContextCreationToFail();
+  #if !BUILDFLAG(IS_COBALT)
   void GetBluetoothManualChooserEvents(v8::Local<v8::Function> callback);
+  #endif
   void GetManifestThen(v8::Local<v8::Function> callback);
   std::string GetWritableDirectory();
   void InsertStyleSheet(const std::string& source_code);
@@ -320,17 +322,21 @@ class TestRunnerBindings : public gin::Wrappable<TestRunnerBindings> {
   void RemoveSpellCheckResolvedCallback();
   void RemoveWebPageOverlay();
   void ResolveBeforeInstallPromptPromise(const std::string& platform);
+  #if !BUILDFLAG(IS_COBALT)
   void SendBluetoothManualChooserEvent(const std::string& event,
                                        const std::string& argument);
+  #endif
   void SetAcceptLanguages(const std::string& accept_languages);
   void SetAllowFileAccessFromFileURLs(bool allow);
   void SetAllowRunningOfInsecureContent(bool allowed);
   void SetBlockThirdPartyCookies(bool block);
   void SetAudioData(const gin::ArrayBufferView& view);
   void SetBackingScaleFactor(double value, v8::Local<v8::Function> callback);
+  #if !BUILDFLAG(IS_COBALT)
   void SetBluetoothFakeAdapter(const std::string& adapter_name,
                                v8::Local<v8::Function> callback);
   void SetBluetoothManualChooser(bool enable);
+  #endif
   void SetBrowserHandlesFocus(bool enable);
   void SetCaretBrowsingEnabled();
   void SetColorProfile(const std::string& name,
@@ -652,12 +658,14 @@ gin::ObjectTemplateBuilder TestRunnerBindings::GetObjectTemplateBuilder(
       .SetMethod("forceNextWebGLContextCreationToFail",
                  &TestRunnerBindings::ForceNextWebGLContextCreationToFail)
 
+#if !BUILDFLAG(IS_COBALT)
       // The Bluetooth functions are specified at
       // https://webbluetoothcg.github.io/web-bluetooth/tests/.
       //
       // Returns the events recorded since the last call to this function.
       .SetMethod("getBluetoothManualChooserEvents",
                  &TestRunnerBindings::GetBluetoothManualChooserEvents)
+#endif
       .SetMethod("getManifestThen", &TestRunnerBindings::GetManifestThen)
       // Returns the absolute path to a directory this test can write data in.
       // This returns the path to a fresh empty directory every time this method
@@ -706,6 +714,7 @@ gin::ObjectTemplateBuilder TestRunnerBindings::GetObjectTemplateBuilder(
       // The Bluetooth functions are specified at
       // https://webbluetoothcg.github.io/web-bluetooth/tests/.
 
+#if !BUILDFLAG(IS_COBALT)
       // Calls the BluetoothChooser::EventHandler with the arguments here. Valid
       // event strings are:
       //  * "cancel" - simulates the user canceling the chooser.
@@ -713,6 +722,7 @@ gin::ObjectTemplateBuilder TestRunnerBindings::GetObjectTemplateBuilder(
       //               in the 2nd parameter.
       .SetMethod("sendBluetoothManualChooserEvent",
                  &TestRunnerBindings::SendBluetoothManualChooserEvent)
+#endif
       .SetMethod("setAcceptLanguages", &TestRunnerBindings::SetAcceptLanguages)
       .SetMethod("setAllowFileAccessFromFileURLs",
                  &TestRunnerBindings::SetAllowFileAccessFromFileURLs)
@@ -727,6 +737,7 @@ gin::ObjectTemplateBuilder TestRunnerBindings::GetObjectTemplateBuilder(
       .SetMethod("setAudioData", &TestRunnerBindings::SetAudioData)
       .SetMethod("setBackingScaleFactor",
                  &TestRunnerBindings::SetBackingScaleFactor)
+#if !BUILDFLAG(IS_COBALT)
       // Set the bluetooth adapter while running a web test.
       .SetMethod("setBluetoothFakeAdapter",
                  &TestRunnerBindings::SetBluetoothFakeAdapter)
@@ -735,6 +746,7 @@ gin::ObjectTemplateBuilder TestRunnerBindings::GetObjectTemplateBuilder(
       // Otherwise falls back to the browser's default chooser.
       .SetMethod("setBluetoothManualChooser",
                  &TestRunnerBindings::SetBluetoothManualChooser)
+#endif
       .SetMethod("setBrowserHandlesFocus",
                  &TestRunnerBindings::SetBrowserHandlesFocus)
       .SetMethod("setCallCloseOnWebViews", &TestRunnerBindings::NotImplemented)
@@ -1917,7 +1929,7 @@ void TestRunnerBindings::SetColorProfile(const std::string& name,
 
   WrapV8Closure(std::move(v8_callback)).Run();
 }
-
+#if !BUILDFLAG(IS_COBALT)
 void TestRunnerBindings::SetBluetoothFakeAdapter(
     const std::string& adapter_name,
     v8::Local<v8::Function> v8_callback) {
@@ -1970,6 +1982,7 @@ void TestRunnerBindings::GetBluetoothManualChooserEvents(
                      weak_ptr_factory_.GetWeakPtr(), GetWebFrame(),
                      WrapV8Callback(std::move(callback))));
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void TestRunnerBindings::SetBrowserHandlesFocus(bool enable) {
   if (!frame_) {
@@ -1978,6 +1991,7 @@ void TestRunnerBindings::SetBrowserHandlesFocus(bool enable) {
   blink::SetBrowserCanHandleFocusForWebTest(enable);
 }
 
+#if !BUILDFLAG(IS_COBALT)
 void TestRunnerBindings::SendBluetoothManualChooserEvent(
     const std::string& event,
     const std::string& argument) {
@@ -1987,6 +2001,7 @@ void TestRunnerBindings::SendBluetoothManualChooserEvent(
   frame_->GetWebTestControlHostRemote()->SendBluetoothManualChooserEvent(
       event, argument);
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void TestRunnerBindings::SetPOSIXLocale(const std::string& locale) {
   if (!frame_) {
@@ -3836,6 +3851,7 @@ void TestRunner::FinishTest(WebFrameTestProxy& source) {
       browser_should_dump_pixels);
 }
 
+#if !BUILDFLAG(IS_COBALT)
 mojom::WebTestBluetoothFakeAdapterSetter&
 TestRunner::GetBluetoothFakeAdapterSetter() {
   if (!bluetooth_fake_adapter_setter_) {
@@ -3851,6 +3867,7 @@ TestRunner::GetBluetoothFakeAdapterSetter() {
 void TestRunner::HandleBluetoothFakeAdapterSetterDisconnected() {
   bluetooth_fake_adapter_setter_.reset();
 }
+#endif  // !BUILDFLAG(IS_COBALT)
 
 void TestRunner::DisableAutomaticDragDrop(WebFrameTestProxy& source) {
   web_test_runtime_flags_.set_auto_drag_drop_enabled(false);

--- a/content/web_test/renderer/test_runner.h
+++ b/content/web_test/renderer/test_runner.h
@@ -21,7 +21,9 @@
 #include "base/memory/weak_ptr.h"
 #include "base/values.h"
 #include "content/web_test/common/web_test.mojom.h"
+#if !BUILDFLAG(IS_COBALT)
 #include "content/web_test/common/web_test_bluetooth_fake_adapter_setter.mojom.h"
+#endif
 #include "content/web_test/common/web_test_constants.h"
 #include "content/web_test/common/web_test_runtime_flags.h"
 #include "content/web_test/renderer/fake_screen_orientation_impl.h"
@@ -528,10 +530,12 @@ class TestRunner {
   ///////////////////////////////////////////////////////////////////////////
   // Internal helpers
 
+#if !BUILDFLAG(IS_COBALT)
   mojom::WebTestBluetoothFakeAdapterSetter& GetBluetoothFakeAdapterSetter();
   void HandleBluetoothFakeAdapterSetterDisconnected();
   mojo::Remote<mojom::WebTestBluetoothFakeAdapterSetter>
       bluetooth_fake_adapter_setter_;
+#endif
 
   bool test_is_running_ = false;
 

--- a/device/bluetooth/emulation/buildflags.gni
+++ b/device/bluetooth/emulation/buildflags.gni
@@ -1,4 +1,4 @@
 # Bluetooth Device Emulation is currently not enabled on
 # binary size constrained platforms.
 
-enable_bluetooth_emulation = is_win || is_mac || is_linux || is_chromeos
+enable_bluetooth_emulation = !is_cobalt && (is_win || is_mac || is_linux || is_chromeos)

--- a/mojo/public/tools/bindings/mojom.gni
+++ b/mojo/public/tools/bindings/mojom.gni
@@ -754,6 +754,9 @@ template("mojom") {
     if (is_posix) {
       enabled_features += [ "is_posix" ]
     }
+    if (is_cobalt) {
+      enabled_features += [ "is_cobalt" ]
+    }
     if (is_android) {
       enabled_features += [ "is_android" ]
     } else if (is_chromeos) {

--- a/services/device/BUILD.gn
+++ b/services/device/BUILD.gn
@@ -17,7 +17,7 @@ if (is_ios) {
 }
 
 is_serial_enabled_platform =
-    is_win || ((is_linux || is_chromeos) && use_udev) || is_mac || is_android
+    !is_cobalt && (is_win || ((is_linux || is_chromeos) && use_udev) || is_mac || is_android)
 
 source_set("lib") {
   # This should be visible only to embedders of the Device Service, and the
@@ -89,6 +89,12 @@ source_set("lib") {
   if (is_serial_enabled_platform) {
     deps += [ "//services/device/serial" ]
     defines = [ "IS_SERIAL_ENABLED_PLATFORM" ]
+  }
+
+  if (is_cobalt) {
+    deps -= [
+      "//services/device/usb/mojo",
+    ]
   }
 }
 
@@ -279,29 +285,31 @@ source_set("tests") {
       deps += [ "//services/device/battery" ]
     }
 
-    if ((!is_linux && !is_chromeos) || use_udev) {
-      sources += [
-        "hid/hid_connection_impl_unittest.cc",
-        "public/cpp/hid/hid_device_filter_unittest.cc",
-        "public/cpp/hid/hid_report_descriptor_unittest.cc",
-      ]
-      if (is_linux || is_chromeos) {
+    if (!is_cobalt) {
+      if ((!is_linux && !is_chromeos) || use_udev) {
         sources += [
-          "hid/hid_service_linux_unittest.cc",
-          "hid/input_service_linux_unittest.cc",
+          "hid/hid_connection_impl_unittest.cc",
+          "public/cpp/hid/hid_device_filter_unittest.cc",
+          "public/cpp/hid/hid_report_descriptor_unittest.cc",
         ]
-      }
-      if (!is_fuchsia && !is_ios) {
-        # Fuchsia and iOS do not currently implement HidService.
-        sources += [ "hid/hid_service_unittest.cc" ]
-      }
-      if (!is_ios) {
-        sources += [ "hid/hid_connection_unittest.cc" ]
-        deps += [
-          ":usb_test_gadget",
-          "//net:test_support",
-          "//services/device/usb",
-        ]
+        if (is_linux || is_chromeos) {
+          sources += [
+            "hid/hid_service_linux_unittest.cc",
+            "hid/input_service_linux_unittest.cc",
+          ]
+        }
+        if (!is_fuchsia && !is_ios) {
+          # Fuchsia and iOS do not currently implement HidService.
+          sources += [ "hid/hid_service_unittest.cc" ]
+        }
+        if (!is_ios) {
+          sources += [ "hid/hid_connection_unittest.cc" ]
+          deps += [
+            ":usb_test_gadget",
+            "//net:test_support",
+            "//services/device/usb",
+          ]
+        }
       }
     }
   }
@@ -490,6 +498,11 @@ if (is_android) {
       "//services/service_manager/public/mojom:mojom_java",
       "//third_party/jni_zero:jni_zero_java",
     ]
+    if (is_cobalt) {
+      deps -= [
+        "//services/device/usb:java",
+      ]
+    }
   }
 }
 

--- a/services/device/device_service.cc
+++ b/services/device/device_service.cc
@@ -22,7 +22,9 @@
 #include "services/device/geolocation/public_ip_address_location_notifier.h"
 #include "services/device/power_monitor/power_monitor_message_broadcaster.h"
 #include "services/device/public/mojom/battery_monitor.mojom.h"
+#if defined(IS_SERIAL_ENABLED_PLATFORM)
 #include "services/device/serial/serial_port_manager_impl.h"
+#endif
 #include "services/device/time_zone_monitor/time_zone_monitor.h"
 #include "services/device/vibration/vibration_manager_impl.h"
 #include "services/device/wake_lock/wake_lock_provider.h"
@@ -335,6 +337,7 @@ void DeviceService::BindWakeLockProvider(
 
 void DeviceService::BindUsbDeviceManager(
     mojo::PendingReceiver<mojom::UsbDeviceManager> receiver) {
+#if !BUILDFLAG(IS_COBALT)
   const auto& binder_override = internal::GetUsbDeviceManagerBinderOverride();
   if (binder_override) {
     binder_override.Run(std::move(receiver));
@@ -348,10 +351,14 @@ void DeviceService::BindUsbDeviceManager(
     usb_device_manager_ = std::make_unique<usb::DeviceManagerImpl>();
 
   usb_device_manager_->AddReceiver(std::move(receiver));
+#else
+  NOTREACHED() << "WebUSB is not supported on Cobalt.";
+#endif
 }
 
 void DeviceService::BindUsbDeviceManagerTest(
     mojo::PendingReceiver<mojom::UsbDeviceManagerTest> receiver) {
+#if !BUILDFLAG(IS_COBALT)
   // TODO(crbug.com/40141825): usb::DeviceManagerImpl depends on the
   // permission_broker service on Chromium OS. We will need to redirect
   // connections for LaCrOS here.
@@ -364,6 +371,9 @@ void DeviceService::BindUsbDeviceManagerTest(
   }
 
   usb_device_manager_test_->BindReceiver(std::move(receiver));
+#else
+  NOTREACHED() << "WebUSB is not supported on Cobalt.";
+#endif
 }
 
 #if BUILDFLAG(IS_ANDROID)

--- a/services/device/device_service.h
+++ b/services/device/device_service.h
@@ -35,8 +35,10 @@
 #include "services/device/public/mojom/usb_manager_test.mojom.h"
 #include "services/device/public/mojom/vibration_manager.mojom.h"
 #include "services/device/public/mojom/wake_lock_provider.mojom.h"
-#include "services/device/usb/mojo/device_manager_impl.h"
-#include "services/device/usb/mojo/device_manager_test.h"
+#if !BUILDFLAG(IS_COBALT)
+#include "services/device/usb/mojo/device_manager_impl.h"  // nogncheck
+#include "services/device/usb/mojo/device_manager_test.h"  // nogncheck
+#endif
 #include "services/device/wake_lock/wake_lock_context.h"
 #include "services/device/wake_lock/wake_lock_provider.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
@@ -245,8 +247,10 @@ class DeviceService : public mojom::DeviceService {
       public_ip_address_geolocation_provider_;
   std::unique_ptr<SensorProviderImpl> sensor_provider_;
   std::unique_ptr<TimeZoneMonitor> time_zone_monitor_;
+#if !BUILDFLAG(IS_COBALT)
   std::unique_ptr<usb::DeviceManagerImpl> usb_device_manager_;
   std::unique_ptr<usb::DeviceManagerTest> usb_device_manager_test_;
+#endif
   scoped_refptr<base::SingleThreadTaskRunner> file_task_runner_;
   scoped_refptr<base::SingleThreadTaskRunner> io_task_runner_;
   scoped_refptr<network::SharedURLLoaderFactory> url_loader_factory_;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -56,6 +56,9 @@ Usage Examples:
 
   13. Revert active Cobalt loader configuration to Cobalt 25:
       python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --revert-c25
+
+  14. Launch Cobalt plugin with custom runtime parameters (e.g. YouTube TV URL):
+      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run --param --url=https://tv.youtube.com
 """
 
 import argparse
@@ -188,6 +191,7 @@ def launch_on_device(
     test_name: Optional[str],
     mode: str,
     devtools: bool = False,
+    param: Optional[List[str]] = None,
 ) -> None:
     """Executes remote commands to launch Cobalt or tests."""
     print("=== Launching on device ===")
@@ -246,7 +250,10 @@ def launch_on_device(
                 
                 if devtools:
                     sb_args.append("--remote-debugging-port=9222")
-                
+
+                if param:
+                    sb_args.extend(param)
+
                 config["sbmainargs"] = sb_args
 
                 # Set configuration
@@ -365,6 +372,12 @@ def parse_args() -> argparse.Namespace:
         "--follow",
         action="store_true",
         help="Follow log output in real-time (runs journalctl -f).",
+    )
+    parser.add_argument(
+        "--param",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help="Additional runtime parameter(s) to pass to StarboardMain (must be specified last).",
     )
     return parser.parse_args()
 
@@ -697,6 +710,7 @@ def main() -> None:
             args.tests,
             args.mode,
             args.devtools,
+            args.param,
         )
 
     print("=== Finished ===")


### PR DESCRIPTION
Supports passing additional runtime parameters sequentially via `--param` in `deploy_rdk.py`.

### Changes
* **Sequential Runtime Parameters (`--param`)**: Captures arbitrary Starboard/Cobalt runtime arguments using `argparse.REMAINDER` (e.g., `--param --url=https://tv.youtube.com --disable_quic`).
* **Configuration Extension**: Automatically forwards specified runtime parameters to the plugin's `sbmainargs` JSON-RPC configuration array upon launch.

Bug: b/502702565