### PR TITLE
Fix compiler error due to numeric_limits

### DIFF
--- a/copied_base/base/memory/ref_counted.h
+++ b/copied_base/base/memory/ref_counted.h
@@ -7,6 +7,7 @@
 
 #include <stddef.h>
 
+#include <limits>
 #include <utility>
 
 #include "base/atomic_ref_count.h"


### PR DESCRIPTION
Explicit include <limits> when using numeric_limits.
It fixes build error when compiling with GCC 11 (and newer).

Bug: 510541109