### PR TITLE
cobalt: Prevent hangs in GPU channel establishment

### DIFF
--- a/services/viz/public/cpp/gpu/gpu.cc
+++ b/services/viz/public/cpp/gpu/gpu.cc
@@ -16,6 +16,7 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/threading/thread_checker.h"
 #include "base/trace_event/trace_event.h"
+#include "base/time/time.h"
 #include "build/build_config.h"
 #include "build/chromeos_buildflags.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -341,7 +342,12 @@ scoped_refptr<gpu::GpuChannelHost> Gpu::EstablishGpuChannelSync() {
   base::WaitableEvent event(base::WaitableEvent::ResetPolicy::MANUAL,
                             base::WaitableEvent::InitialState::SIGNALED);
   SendEstablishGpuChannelRequest(&event);
-  event.Wait();
+  if (!event.TimedWait(base::Seconds(1))) {
+    LOG(ERROR) << "Gpu::EstablishGpuChannelSync: Timed out waiting for GPU channel! (1s)";
+    pending_request_->Cancel();
+    pending_request_.reset();
+    return nullptr;
+  }
 
   // Running FinishOnMain() will create |gpu_channel_| and run any callbacks
   // from calls to EstablishGpuChannel() before we return from here.

--- a/services/viz/public/cpp/gpu/gpu.cc
+++ b/services/viz/public/cpp/gpu/gpu.cc
@@ -26,6 +26,21 @@
 
 namespace viz {
 
+class SafeWaitableEvent : public base::RefCountedThreadSafe<SafeWaitableEvent> {
+ public:
+  SafeWaitableEvent()
+      : event_(base::WaitableEvent::ResetPolicy::MANUAL,
+               base::WaitableEvent::InitialState::NOT_SIGNALED) {}
+
+  base::WaitableEvent* event() { return &event_; }
+
+ private:
+  friend class base::RefCountedThreadSafe<SafeWaitableEvent>;
+  ~SafeWaitableEvent() = default;
+
+  base::WaitableEvent event_;
+};
+
 // Encapsulates a mojo::Remote<mojom::Gpu> object that will be used on the IO
 // thread. This is required because we can't install an error handler on a
 // mojo::SharedRemote<mojom::Gpu> to detect if the message pipe was closed. Only
@@ -124,9 +139,9 @@ class Gpu::EstablishRequest
     gpu->EstablishGpuChannel(this);
   }
 
-  // Sets a WaitableEvent so the main thread can block for a synchronous
+  // Sets a SafeWaitableEvent so the main thread can block for a synchronous
   // request. This must be called from main thread.
-  void SetWaitableEvent(base::WaitableEvent* establish_event) {
+  void SetWaitableEvent(scoped_refptr<SafeWaitableEvent> establish_event) {
     DCHECK(main_task_runner_->BelongsToCurrentThread());
     DCHECK(establish_event);
     base::AutoLock mutex(lock_);
@@ -137,8 +152,7 @@ class Gpu::EstablishRequest
     if (received_)
       return;
 
-    establish_event_ = establish_event;
-    establish_event_->Reset();
+    establish_event_ = std::move(establish_event);
   }
 
   // Cancels the pending request. Any asynchronous calls back into this object
@@ -189,10 +203,7 @@ class Gpu::EstablishRequest
     }
 
     if (establish_event_) {
-      // Gpu::EstablishGpuChannelSync() was called. Unblock the main thread and
-      // let it finish. The main thread owns the event and may destroy it as
-      // soon as the thread is unblocked, so avoid dangling references to it.
-      establish_event_.ExtractAsDangling()->Signal();
+      establish_event_->event()->Signal();
     } else {
       main_task_runner_->PostTask(
           FROM_HERE, base::BindOnce(&EstablishRequest::FinishOnMain, this));
@@ -206,7 +217,7 @@ class Gpu::EstablishRequest
 
   const raw_ptr<Gpu> parent_;
   scoped_refptr<base::SingleThreadTaskRunner> main_task_runner_;
-  raw_ptr<base::WaitableEvent> establish_event_ = nullptr;
+  scoped_refptr<SafeWaitableEvent> establish_event_;
 
   base::Lock lock_;
   bool received_ = false;
@@ -327,7 +338,7 @@ void Gpu::EstablishGpuChannel(gpu::GpuChannelEstablishedCallback callback) {
   }
 
   establish_callbacks_.push_back(std::move(callback));
-  SendEstablishGpuChannelRequest(/*waitable_event=*/nullptr);
+  SendEstablishGpuChannelRequest(nullptr);
 }
 
 scoped_refptr<gpu::GpuChannelHost> Gpu::EstablishGpuChannelSync() {
@@ -339,10 +350,9 @@ scoped_refptr<gpu::GpuChannelHost> Gpu::EstablishGpuChannelSync() {
     return channel;
 
   SCOPED_UMA_HISTOGRAM_TIMER("GPU.EstablishGpuChannelSyncTime");
-  base::WaitableEvent event(base::WaitableEvent::ResetPolicy::MANUAL,
-                            base::WaitableEvent::InitialState::SIGNALED);
-  SendEstablishGpuChannelRequest(&event);
-  if (!event.TimedWait(base::Seconds(1))) {
+  auto safe_event = base::MakeRefCounted<SafeWaitableEvent>();
+  SendEstablishGpuChannelRequest(safe_event);
+  if (!safe_event->event()->TimedWait(base::Seconds(1))) {
     LOG(ERROR) << "Gpu::EstablishGpuChannelSync: Timed out waiting for GPU channel! (1s)";
     pending_request_->Cancel();
     pending_request_.reset();
@@ -375,10 +385,10 @@ scoped_refptr<gpu::GpuChannelHost> Gpu::GetGpuChannel() {
   return gpu_channel_;
 }
 
-void Gpu::SendEstablishGpuChannelRequest(base::WaitableEvent* waitable_event) {
+void Gpu::SendEstablishGpuChannelRequest(scoped_refptr<SafeWaitableEvent> waitable_event) {
   if (pending_request_) {
     if (waitable_event) {
-      pending_request_->SetWaitableEvent(waitable_event);
+      pending_request_->SetWaitableEvent(std::move(waitable_event));
     }
     return;
   }
@@ -386,7 +396,7 @@ void Gpu::SendEstablishGpuChannelRequest(base::WaitableEvent* waitable_event) {
   pending_request_ =
       base::MakeRefCounted<EstablishRequest>(this, main_task_runner_);
   if (waitable_event) {
-    pending_request_->SetWaitableEvent(waitable_event);
+    pending_request_->SetWaitableEvent(std::move(waitable_event));
   }
   io_task_runner_->PostTask(
       FROM_HERE,

--- a/services/viz/public/cpp/gpu/gpu.cc
+++ b/services/viz/public/cpp/gpu/gpu.cc
@@ -30,9 +30,11 @@ class GpuChannelWaitableEvent : public base::RefCountedThreadSafe<GpuChannelWait
  public:
   GpuChannelWaitableEvent()
       : event_(base::WaitableEvent::ResetPolicy::MANUAL,
-               base::WaitableEvent::InitialState::NOT_SIGNALED) {}
+               base::WaitableEvent::InitialState::SIGNALED) {}
 
-  base::WaitableEvent* event() { return &event_; }
+  void Reset() { event_.Reset(); }
+  void Signal() { event_.Signal(); }
+  bool TimedWait(base::TimeDelta max_time) { return event_.TimedWait(max_time); }
 
  private:
   friend class base::RefCountedThreadSafe<GpuChannelWaitableEvent>;
@@ -153,6 +155,7 @@ class Gpu::EstablishRequest
       return;
 
     establish_event_ = establish_event;
+    establish_event_->Reset();
   }
 
   // Cancels the pending request. Any asynchronous calls back into this object
@@ -203,7 +206,7 @@ class Gpu::EstablishRequest
     }
 
     if (establish_event_) {
-      establish_event_->event()->Signal();
+      establish_event_->Signal();
     } else {
       main_task_runner_->PostTask(
           FROM_HERE, base::BindOnce(&EstablishRequest::FinishOnMain, this));
@@ -352,7 +355,7 @@ scoped_refptr<gpu::GpuChannelHost> Gpu::EstablishGpuChannelSync() {
   SCOPED_UMA_HISTOGRAM_TIMER("GPU.EstablishGpuChannelSyncTime");
   auto safe_event = base::MakeRefCounted<GpuChannelWaitableEvent>();
   SendEstablishGpuChannelRequest(safe_event);
-  if (!safe_event->event()->TimedWait(base::Seconds(1))) {
+  if (!safe_event->TimedWait(base::Seconds(1))) {
     LOG(ERROR) << "Gpu::EstablishGpuChannelSync: Timed out waiting for GPU channel! (1s)";
     pending_request_->Cancel();
     pending_request_.reset();

--- a/services/viz/public/cpp/gpu/gpu.cc
+++ b/services/viz/public/cpp/gpu/gpu.cc
@@ -26,17 +26,17 @@
 
 namespace viz {
 
-class SafeWaitableEvent : public base::RefCountedThreadSafe<SafeWaitableEvent> {
+class GpuChannelWaitableEvent : public base::RefCountedThreadSafe<GpuChannelWaitableEvent> {
  public:
-  SafeWaitableEvent()
+  GpuChannelWaitableEvent()
       : event_(base::WaitableEvent::ResetPolicy::MANUAL,
                base::WaitableEvent::InitialState::NOT_SIGNALED) {}
 
   base::WaitableEvent* event() { return &event_; }
 
  private:
-  friend class base::RefCountedThreadSafe<SafeWaitableEvent>;
-  ~SafeWaitableEvent() = default;
+  friend class base::RefCountedThreadSafe<GpuChannelWaitableEvent>;
+  ~GpuChannelWaitableEvent() = default;
 
   base::WaitableEvent event_;
 };
@@ -141,7 +141,7 @@ class Gpu::EstablishRequest
 
   // Sets a SafeWaitableEvent so the main thread can block for a synchronous
   // request. This must be called from main thread.
-  void SetWaitableEvent(scoped_refptr<SafeWaitableEvent> establish_event) {
+  void SetWaitableEvent(const scoped_refptr<GpuChannelWaitableEvent>& establish_event) {
     DCHECK(main_task_runner_->BelongsToCurrentThread());
     DCHECK(establish_event);
     base::AutoLock mutex(lock_);
@@ -152,7 +152,7 @@ class Gpu::EstablishRequest
     if (received_)
       return;
 
-    establish_event_ = std::move(establish_event);
+    establish_event_ = establish_event;
   }
 
   // Cancels the pending request. Any asynchronous calls back into this object
@@ -217,7 +217,7 @@ class Gpu::EstablishRequest
 
   const raw_ptr<Gpu> parent_;
   scoped_refptr<base::SingleThreadTaskRunner> main_task_runner_;
-  scoped_refptr<SafeWaitableEvent> establish_event_;
+  scoped_refptr<GpuChannelWaitableEvent> establish_event_;
 
   base::Lock lock_;
   bool received_ = false;
@@ -350,7 +350,7 @@ scoped_refptr<gpu::GpuChannelHost> Gpu::EstablishGpuChannelSync() {
     return channel;
 
   SCOPED_UMA_HISTOGRAM_TIMER("GPU.EstablishGpuChannelSyncTime");
-  auto safe_event = base::MakeRefCounted<SafeWaitableEvent>();
+  auto safe_event = base::MakeRefCounted<GpuChannelWaitableEvent>();
   SendEstablishGpuChannelRequest(safe_event);
   if (!safe_event->event()->TimedWait(base::Seconds(1))) {
     LOG(ERROR) << "Gpu::EstablishGpuChannelSync: Timed out waiting for GPU channel! (1s)";
@@ -385,10 +385,10 @@ scoped_refptr<gpu::GpuChannelHost> Gpu::GetGpuChannel() {
   return gpu_channel_;
 }
 
-void Gpu::SendEstablishGpuChannelRequest(scoped_refptr<SafeWaitableEvent> waitable_event) {
+void Gpu::SendEstablishGpuChannelRequest(const scoped_refptr<GpuChannelWaitableEvent>& waitable_event) {
   if (pending_request_) {
     if (waitable_event) {
-      pending_request_->SetWaitableEvent(std::move(waitable_event));
+      pending_request_->SetWaitableEvent(waitable_event);
     }
     return;
   }
@@ -396,7 +396,7 @@ void Gpu::SendEstablishGpuChannelRequest(scoped_refptr<SafeWaitableEvent> waitab
   pending_request_ =
       base::MakeRefCounted<EstablishRequest>(this, main_task_runner_);
   if (waitable_event) {
-    pending_request_->SetWaitableEvent(std::move(waitable_event));
+    pending_request_->SetWaitableEvent(waitable_event);
   }
   io_task_runner_->PostTask(
       FROM_HERE,

--- a/services/viz/public/cpp/gpu/gpu.h
+++ b/services/viz/public/cpp/gpu/gpu.h
@@ -24,6 +24,8 @@ class Connector;
 
 namespace viz {
 
+class SafeWaitableEvent;
+
 class Gpu : public gpu::GpuChannelEstablishFactory {
  public:
   // The Gpu has to be initialized in the main thread before establishing
@@ -74,7 +76,7 @@ class Gpu : public gpu::GpuChannelEstablishFactory {
 
   // Sends a request to establish a gpu channel. If a request is currently
   // pending this will do nothing.
-  void SendEstablishGpuChannelRequest(base::WaitableEvent* waitable_event);
+  void SendEstablishGpuChannelRequest(scoped_refptr<SafeWaitableEvent> waitable_event);
 
   // Handles results of request to establish a gpu channel in
   // |pending_request_|.

--- a/services/viz/public/cpp/gpu/gpu.h
+++ b/services/viz/public/cpp/gpu/gpu.h
@@ -24,7 +24,7 @@ class Connector;
 
 namespace viz {
 
-class SafeWaitableEvent;
+class GpuChannelWaitableEvent;
 
 class Gpu : public gpu::GpuChannelEstablishFactory {
  public:
@@ -76,7 +76,7 @@ class Gpu : public gpu::GpuChannelEstablishFactory {
 
   // Sends a request to establish a gpu channel. If a request is currently
   // pending this will do nothing.
-  void SendEstablishGpuChannelRequest(scoped_refptr<SafeWaitableEvent> waitable_event);
+  void SendEstablishGpuChannelRequest(const scoped_refptr<GpuChannelWaitableEvent>& waitable_event);
 
   // Handles results of request to establish a gpu channel in
   // |pending_request_|.


### PR DESCRIPTION
Synchronous GPU channel establishment can result in a permanent hang
of the main thread if the GPU process fails to respond.

A timeout is now enforced for these synchronous requests to prevent
the browser from becoming unresponsive. This ensures that the system
can continue or fail gracefully when the GPU service is stuck.

Bug: 527902163