### PR TITLE
starboard: Simplify MediaCodec input tracking

### DIFF
--- a/starboard/android/shared/media_codec.h
+++ b/starboard/android/shared/media_codec.h
@@ -63,11 +63,6 @@ struct AudioOutputFormatResult {
   jint channel_count;
 };
 
-struct DequeueInputResult {
-  int32_t status;
-  int32_t index;
-};
-
 struct DequeueOutputResult {
   int32_t status;
   int32_t index;

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -18,6 +18,8 @@
 #include <sys/resource.h>
 #include <unistd.h>
 
+#include <iterator>
+
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/memfd_media_buffer_pool.h"
 #include "starboard/audio_sink.h"
@@ -136,7 +138,8 @@ MediaCodecDecoder::CreateForVideo(
     bool use_dual_threads,
     bool skip_video_frames_over_60_fps,
     bool ignore_mediacodec_callbacks_during_flushing,
-    bool enable_ndk_video) {
+    bool enable_ndk_video,
+    bool enable_trivial_optimizations) {
   std::string error_message;
   auto decoder = std::make_unique<MediaCodecDecoder>(
       PassKey<MediaCodecDecoder>(), media_codec_factory, job_queue, host,
@@ -147,6 +150,7 @@ MediaCodecDecoder::CreateForVideo(
       force_big_endian_hdr_metadata, max_video_input_size, flush_delay_usec,
       use_dual_threads, skip_video_frames_over_60_fps,
       ignore_mediacodec_callbacks_during_flushing, enable_ndk_video,
+      enable_trivial_optimizations,
       &error_message);
   if (!decoder->media_codec_bridge_) {
     return Failure(error_message);
@@ -222,6 +226,7 @@ MediaCodecDecoder::MediaCodecDecoder(
     bool skip_video_frames_over_60_fps,
     bool ignore_mediacodec_callbacks_during_flushing,
     bool enable_ndk_video,
+    bool enable_trivial_optimizations,
     std::string* error_message)
     : JobOwner(job_queue),
       media_type_(kSbMediaTypeVideo),
@@ -234,7 +239,8 @@ MediaCodecDecoder::MediaCodecDecoder(
       video_decoder_poll_interval_us_(
           tunnel_mode_enabled_ ? kDefaultVideoDecoderTunnelPollIntervalUs
                                : kDefaultVideoDecoderPollIntervalUs),
-      use_dual_threads_(use_dual_threads && !tunnel_mode_enabled_) {
+      use_dual_threads_(use_dual_threads && !tunnel_mode_enabled_),
+      enable_trivial_optimizations_(enable_trivial_optimizations) {
   SB_DCHECK(frame_rendered_cb_);
   SB_DCHECK(first_tunnel_frame_ready_cb_);
 
@@ -270,7 +276,9 @@ MediaCodecDecoder::MediaCodecDecoder(
                << ToString(tunnel_mode_enabled_)
                << ", video_decoder_poll_interval(msec)="
                << video_decoder_poll_interval_us_ / 1'000
-               << ", use_dual_threads=" << ToString(use_dual_threads_);
+               << ", use_dual_threads=" << ToString(use_dual_threads_)
+               << ", enable_trivial_optimizations="
+               << ToString(enable_trivial_optimizations_);
 }
 
 MediaCodecDecoder::~MediaCodecDecoder() {
@@ -699,8 +707,14 @@ void MediaCodecDecoder::CollectPendingInputData_Locked(
   SB_DCHECK(pending_inputs);
   SB_DCHECK(input_buffer_indices);
 
-  pending_inputs->insert(pending_inputs->end(), pending_inputs_.begin(),
-                         pending_inputs_.end());
+  if (enable_trivial_optimizations_) {
+    pending_inputs->insert(pending_inputs->end(),
+                           std::make_move_iterator(pending_inputs_.begin()),
+                           std::make_move_iterator(pending_inputs_.end()));
+  } else {
+    pending_inputs->insert(pending_inputs->end(), pending_inputs_.begin(),
+                           pending_inputs_.end());
+  }
   pending_inputs_.clear();
 
   input_buffer_indices->insert(input_buffer_indices->end(),
@@ -733,22 +747,31 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
   // decode.  It is not possible to do them as separate steps on Android. From
   // the perspective of user application, decryption and decoding are one
   // atomic step.
-  DequeueInputResult dequeue_input_result;
+  int input_buffer_index = -1;
   PendingInput pending_input;
   bool input_buffer_already_written = false;
   if (pending_input_to_retry_) {
-    dequeue_input_result = pending_input_to_retry_->dequeue_input_result;
-    SB_DCHECK_GE(dequeue_input_result.index, 0);
-    pending_input = pending_input_to_retry_->pending_input;
+    input_buffer_index = pending_input_to_retry_->input_buffer_index;
+    if (enable_trivial_optimizations_) {
+      pending_input = std::move(pending_input_to_retry_->pending_input);
+    } else {
+      pending_input = pending_input_to_retry_->pending_input;
+    }
     pending_input_to_retry_ = std::nullopt;
     input_buffer_already_written = true;
   } else {
-    dequeue_input_result.index = input_buffer_indices->front();
+    input_buffer_index = input_buffer_indices->front();
+    // TODO(b/514758473): Experiment popping the index from the back.
     input_buffer_indices->erase(input_buffer_indices->begin());
-    pending_input = pending_inputs->front();
+    if (enable_trivial_optimizations_) {
+      pending_input = std::move(pending_inputs->front());
+    } else {
+      pending_input = pending_inputs->front();
+    }
     pending_inputs->pop_front();
     --number_of_pending_inputs_;
   }
+  SB_DCHECK_GE(input_buffer_index, 0);
 
   SB_DCHECK(pending_input.type == PendingInput::kWriteCodecConfig ||
             pending_input.type == PendingInput::kWriteInputBuffer ||
@@ -776,14 +799,19 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
   if (!input_buffer_already_written &&
       pending_input.type != PendingInput::kWriteEndOfStream) {
     const auto codec_input_buffer =
-        media_codec_bridge_->GetInputBufferAddress(dequeue_input_result.index);
+        media_codec_bridge_->GetInputBufferAddress(input_buffer_index);
     auto* address = codec_input_buffer.data();
     if (!address) {
       SB_LOG(ERROR) << "Unable to get MediaCodec input buffer address.";
       // There could be dirty callbacks right after flush, thus the
       // MediaCodec.InputBuffer could be unavailable. In that case, we should
       // re-write the input buffer with a different MediaCodec.InputBuffer.
-      pending_inputs->emplace(pending_inputs->begin(), pending_input);
+      if (enable_trivial_optimizations_) {
+        pending_inputs->emplace(pending_inputs->begin(),
+                                std::move(pending_input));
+      } else {
+        pending_inputs->emplace(pending_inputs->begin(), pending_input);
+      }
       number_of_pending_inputs_++;
       return false;
     }
@@ -825,23 +853,23 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
     status = MEDIA_CODEC_NO_KEY;
   } else if (pending_input.type == PendingInput::kWriteCodecConfig) {
     status = media_codec_bridge_->QueueInputBuffer(
-        dequeue_input_result.index, kNoOffset, size, kNoPts,
-        MediaCodec::kBufferFlagCodecConfig, false);
+        input_buffer_index, kNoOffset, size, kNoPts,
+        MediaCodec::kBufferFlagCodecConfig, /*is_decode_only=*/false);
   } else if (pending_input.type == PendingInput::kWriteInputBuffer) {
     jlong pts_us = input_buffer->timestamp();
     if (drm_system_ && input_buffer->drm_info()) {
       status = media_codec_bridge_->QueueSecureInputBuffer(
-          dequeue_input_result.index, kNoOffset, *input_buffer->drm_info(),
-          pts_us, host_->IsBufferDecodeOnly(input_buffer));
+          input_buffer_index, kNoOffset, *input_buffer->drm_info(), pts_us,
+          host_->IsBufferDecodeOnly(input_buffer));
     } else {
       status = media_codec_bridge_->QueueInputBuffer(
-          dequeue_input_result.index, kNoOffset, size, pts_us, kNoBufferFlags,
+          input_buffer_index, kNoOffset, size, pts_us, kNoBufferFlags,
           host_->IsBufferDecodeOnly(input_buffer));
     }
   } else {
     status = media_codec_bridge_->QueueInputBuffer(
-        dequeue_input_result.index, kNoOffset, size, kNoPts,
-        MediaCodec::kBufferFlagEndOfStream, false);
+        input_buffer_index, kNoOffset, size, kNoPts,
+        MediaCodec::kBufferFlagEndOfStream, /*is_decode_only=*/false);
     host_->OnEndOfStreamWritten(media_codec_bridge_.get());
   }
 
@@ -849,7 +877,11 @@ bool MediaCodecDecoder::ProcessOneInputBuffer(
     HandleError("queue(Secure)?InputBuffer", status);
     // TODO: Stop the decoding loop and call error_cb_ on fatal error.
     SB_DCHECK(!pending_input_to_retry_);
-    pending_input_to_retry_ = {dequeue_input_result, pending_input};
+    if (enable_trivial_optimizations_) {
+      pending_input_to_retry_ = {input_buffer_index, std::move(pending_input)};
+    } else {
+      pending_input_to_retry_ = {input_buffer_index, pending_input};
+    }
     return false;
   }
 
@@ -947,6 +979,7 @@ void MediaCodecDecoder::OnMediaCodecError(bool is_recoverable,
 }
 
 void MediaCodecDecoder::OnMediaCodecInputBufferAvailable(int32_t buffer_index) {
+  SB_DCHECK_GE(buffer_index, 0);
   if (media_type_ == kSbMediaTypeVideo && first_call_on_handler_thread_) {
     // Set the thread priority of the Handler thread to dispatch the async
     // decoder callbacks to high.

--- a/starboard/android/shared/media_codec_decoder.h
+++ b/starboard/android/shared/media_codec_decoder.h
@@ -105,7 +105,8 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
       bool use_dual_threads,
       bool skip_video_frames_over_60_fps,
       bool ignore_mediacodec_callbacks_during_flushing,
-      bool enable_ndk_video);
+      bool enable_ndk_video,
+      bool enable_trivial_optimizations);
 
   MediaCodecDecoder(PassKey<MediaCodecDecoder>,
                     MediaCodec::Factory& media_codec_factory,
@@ -141,6 +142,7 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
       bool skip_video_frames_over_60_fps,
       bool ignore_mediacodec_callbacks_during_flushing,
       bool enable_ndk_video,
+      bool enable_trivial_optimizations,
       std::string* error_message);
   ~MediaCodecDecoder();
 
@@ -183,11 +185,11 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
     std::vector<uint8_t> codec_config;
   };
 
-  // Holding a PendingInput and a DequeueInputResult when call to
-  // QueueInputBuffer or QueueSecureInputBuffer fails so it can be retried
+  // Holding an |input_buffer_index| and a PendingInput when a call to
+  // QueueInputBuffer() or QueueSecureInputBuffer() fails so it can be retried
   // later.
   struct PendingInputToRetry {
-    DequeueInputResult dequeue_input_result;
+    int input_buffer_index = -1;
     PendingInput pending_input;
   };
 
@@ -220,8 +222,8 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
   void OnMediaCodecError(bool is_recoverable,
                          bool is_transient,
                          const std::string& error_message) override;
-  void OnMediaCodecInputBufferAvailable(int32_t index) override;
-  void OnMediaCodecOutputBufferAvailable(int32_t index,
+  void OnMediaCodecInputBufferAvailable(int32_t buffer_index) override;
+  void OnMediaCodecOutputBufferAvailable(int32_t buffer_index,
                                          int32_t flags,
                                          int32_t offset,
                                          int64_t presentation_time_us,
@@ -241,6 +243,7 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
   const int64_t flush_delay_usec_;
   const int64_t video_decoder_poll_interval_us_;
   const bool use_dual_threads_ = false;
+  const bool enable_trivial_optimizations_ = false;
 
   ErrorCB error_cb_;
 

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -364,6 +364,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
       ignore_mediacodec_callbacks_during_flushing_(
           pipeline_config.experimental_features.GetBool(
               kMediaIgnoreMediaCodecCallbacksDuringFlushing)),
+      enable_trivial_optimizations_(
+          pipeline_config.experimental_features.GetBool(
+              kMediaEnableTrivialOptimizations)),
       enable_low_latency_(pipeline_config.experimental_features.GetBool(
           kMediaEnableLowLatency)),
       enable_ndk_video_(
@@ -860,7 +863,8 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       enable_low_latency_, force_big_endian_hdr_metadata_,
       max_video_input_size_, flush_delay_usec_, use_dual_threads_,
       skip_video_frames_over_60_fps_,
-      ignore_mediacodec_callbacks_during_flushing_, enable_ndk_video_);
+      ignore_mediacodec_callbacks_during_flushing_, enable_ndk_video_,
+      enable_trivial_optimizations_);
   if (result) {
     media_decoder_ = std::move(result.value());
     if (error_cb_) {

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -221,6 +221,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // Enable the workaround to ignore stale/dirty MediaCodec callback messages
   // queued on the main thread during a flush.
   const bool ignore_mediacodec_callbacks_during_flushing_;
+  const bool enable_trivial_optimizations_;
   const bool enable_low_latency_;
   const bool enable_ndk_video_;
 


### PR DESCRIPTION
Replace the DequeueInputResult wrapper struct with direct integer input
buffer index tracking in Android MediaCodecDecoder. This removes unused
accounting status fields.

In addition, pass down enable_trivial_optimizations to MediaCodecDecoder
to branch several move semantics micro-optimizations (using std::move
and std::make_move_iterator) when handling PendingInput instances.

Bug: 329686979