### PR TITLE
[DRAFT] Merge Blink partitions to reduce memory fragmentation in Cobalt

### DIFF
--- a/third_party/blink/renderer/platform/wtf/allocator/partitions.cc
+++ b/third_party/blink/renderer/platform/wtf/allocator/partitions.cc
@@ -59,12 +59,6 @@ namespace WTF {
 const char* const Partitions::kAllocatedObjectPoolName =
     "partition_alloc/allocated_objects";
 
-#if BUILDFLAG(IS_COBALT)
-BASE_FEATURE(kCobaltMergeBlinkPartitions,
-             "CobaltMergeBlinkPartitions",
-             base::FEATURE_ENABLED_BY_DEFAULT);
-#endif
-
 #if !BUILDFLAG(IS_COBALT)
 BASE_FEATURE(kBlinkUseLargeEmptySlotSpanRingForBufferRoot,
              "BlinkUseLargeEmptySlotSpanRingForBufferRoot",
@@ -151,23 +145,12 @@ bool Partitions::InitializeOnce() {
   }
 
 #if BUILDFLAG(IS_COBALT)
-  const bool merge_partitions = base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions);
-  if (merge_partitions) {
-#if PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
-    fast_malloc_root_ = allocator_shim::internal::PartitionAllocMalloc::Allocator();
-#else
-    options.thread_cache = PartitionOptions::kEnabled;
-    static base::NoDestructor<partition_alloc::PartitionAllocator>
-        fast_malloc_allocator(options);
-    fast_malloc_root_ = fast_malloc_allocator->root();
-#endif // PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
-    buffer_root_ = fast_malloc_root_;
-  } else {
-    static base::NoDestructor<partition_alloc::PartitionAllocator>
-        buffer_allocator(options);
-    buffer_root_ = buffer_allocator->root();
-  }
-#else
+  // Cobalt explicitly merges array_buffer_root_ and buffer_root_ to reduce memory footprint.
+  // To avoid ARM alignment crashes and thread cache pollution, we disable BRP and thread cache.
+  options.backup_ref_ptr = PartitionOptions::kDisabled;
+  options.thread_cache = PartitionOptions::kDisabled;
+#endif
+
   static base::NoDestructor<partition_alloc::PartitionAllocator>
       buffer_allocator(options);
   buffer_root_ = buffer_allocator->root();
@@ -175,7 +158,6 @@ bool Partitions::InitializeOnce() {
           kBlinkUseLargeEmptySlotSpanRingForBufferRoot)) {
     buffer_root_->EnableLargeEmptySlotSpanRing();
   }
-#endif // BUILDFLAG(IS_COBALT)
 
   if (base::FeatureList::IsEnabled(
           base::features::kPartitionAllocDisableBRPInBufferPartition)) {
@@ -189,23 +171,12 @@ bool Partitions::InitializeOnce() {
   // Note that we could keep the two heaps separate, but each PartitionAlloc's
   // root has a cost, both in used memory and in virtual address space. Don't
   // pay it when we don't have to.
-#if BUILDFLAG(IS_COBALT)
-  if (!merge_partitions) {
-#if !PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
-    options.thread_cache = PartitionOptions::kEnabled;
-    static base::NoDestructor<partition_alloc::PartitionAllocator>
-        fast_malloc_allocator(options);
-    fast_malloc_root_ = fast_malloc_allocator->root();
-#endif
-  }
-#else
 #if !PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
   options.thread_cache = PartitionOptions::kEnabled;
   static base::NoDestructor<partition_alloc::PartitionAllocator>
       fast_malloc_allocator(options);
   fast_malloc_root_ = fast_malloc_allocator->root();
 #endif
-#endif // BUILDFLAG(IS_COBALT)
 
   initialized_ = true;
   return initialized_;
@@ -219,10 +190,9 @@ void Partitions::InitializeArrayBufferPartition() {
   // BackupRefPtr disallowed because it will prevent allocations from being 16B
   // aligned as required by ArrayBufferContents.
 #if BUILDFLAG(IS_COBALT)
-  if (base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
-    array_buffer_root_ = fast_malloc_root_;
-    return;
-  }
+  // Merge array_buffer_root_ with buffer_root_
+  array_buffer_root_ = buffer_root_;
+  return;
 #endif
   static base::NoDestructor<partition_alloc::PartitionAllocator>
       array_buffer_allocator([]() {
@@ -266,19 +236,13 @@ void Partitions::DumpMemoryStats(
     fast_malloc_partition->DumpStats("fast_malloc", is_light_dump,
                                      partition_stats_dumper);
   }
-#if BUILDFLAG(IS_COBALT)
-  if (!base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
-    if (ArrayBufferPartitionInitialized()) {
-      ArrayBufferPartition()->DumpStats("array_buffer", is_light_dump,
-                                        partition_stats_dumper);
-    }
-    BufferPartition()->DumpStats("buffer", is_light_dump, partition_stats_dumper);
-  }
-#else
   if (ArrayBufferPartitionInitialized()) {
     ArrayBufferPartition()->DumpStats("array_buffer", is_light_dump,
                                       partition_stats_dumper);
   }
+#if BUILDFLAG(IS_COBALT)
+  // buffer_root_ is the same as array_buffer_root_, don't dump twice
+#else
   BufferPartition()->DumpStats("buffer", is_light_dump, partition_stats_dumper);
 #endif
 }
@@ -317,20 +281,13 @@ size_t Partitions::TotalSizeOfCommittedPages() {
     total_size +=
         TS_UNCHECKED_READ(fast_malloc_partition->total_size_of_committed_pages);
   }
-#if BUILDFLAG(IS_COBALT)
-  if (!base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
-    if (ArrayBufferPartitionInitialized()) {
-      total_size += TS_UNCHECKED_READ(
-          ArrayBufferPartition()->total_size_of_committed_pages);
-    }
-    total_size +=
-        TS_UNCHECKED_READ(BufferPartition()->total_size_of_committed_pages);
-  }
-#else
   if (ArrayBufferPartitionInitialized()) {
     total_size += TS_UNCHECKED_READ(
         ArrayBufferPartition()->total_size_of_committed_pages);
   }
+#if BUILDFLAG(IS_COBALT)
+  // buffer_root_ is the same as array_buffer_root_, don't double count
+#else
   total_size +=
       TS_UNCHECKED_READ(BufferPartition()->total_size_of_committed_pages);
 #endif
@@ -517,25 +474,13 @@ void Partitions::AdjustPartitionsForForeground() {
   DCHECK(initialized_);
   if (base::FeatureList::IsEnabled(
           base::features::kPartitionAllocAdjustSizeWhenInForeground)) {
-#if BUILDFLAG(IS_COBALT)
-    if (base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
-      if (fast_malloc_root_) {
-        fast_malloc_root_->AdjustForForeground();
-      }
-    } else {
-      array_buffer_root_->AdjustForForeground();
-      buffer_root_->AdjustForForeground();
-      if (fast_malloc_root_) {
-        fast_malloc_root_->AdjustForForeground();
-      }
-    }
-#else
     array_buffer_root_->AdjustForForeground();
+#if !BUILDFLAG(IS_COBALT)
     buffer_root_->AdjustForForeground();
+#endif
     if (fast_malloc_root_) {
       fast_malloc_root_->AdjustForForeground();
     }
-#endif
   }
 }
 
@@ -544,25 +489,13 @@ void Partitions::AdjustPartitionsForBackground() {
   DCHECK(initialized_);
   if (base::FeatureList::IsEnabled(
           base::features::kPartitionAllocAdjustSizeWhenInForeground)) {
-#if BUILDFLAG(IS_COBALT)
-    if (base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
-      if (fast_malloc_root_) {
-        fast_malloc_root_->AdjustForBackground();
-      }
-    } else {
-      array_buffer_root_->AdjustForBackground();
-      buffer_root_->AdjustForBackground();
-      if (fast_malloc_root_) {
-        fast_malloc_root_->AdjustForBackground();
-      }
-    }
-#else
     array_buffer_root_->AdjustForBackground();
+#if !BUILDFLAG(IS_COBALT)
     buffer_root_->AdjustForBackground();
+#endif
     if (fast_malloc_root_) {
       fast_malloc_root_->AdjustForBackground();
     }
-#endif
   }
 }
 

--- a/third_party/blink/renderer/platform/wtf/allocator/partitions.cc
+++ b/third_party/blink/renderer/platform/wtf/allocator/partitions.cc
@@ -48,17 +48,31 @@
 #include "partition_alloc/partition_root.h"
 #include "third_party/blink/renderer/platform/wtf/wtf.h"
 
+#if BUILDFLAG(IS_COBALT)
+#if PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+#include "base/allocator/partition_allocator/src/partition_alloc/shim/allocator_shim_default_dispatch_to_partition_alloc.h"
+#endif
+#endif
+
 namespace WTF {
 
 const char* const Partitions::kAllocatedObjectPoolName =
     "partition_alloc/allocated_objects";
 
+#if BUILDFLAG(IS_COBALT)
+BASE_FEATURE(kCobaltMergeBlinkPartitions,
+             "CobaltMergeBlinkPartitions",
+             base::FEATURE_ENABLED_BY_DEFAULT);
+#endif
+
+#if !BUILDFLAG(IS_COBALT)
 BASE_FEATURE(kBlinkUseLargeEmptySlotSpanRingForBufferRoot,
              "BlinkUseLargeEmptySlotSpanRingForBufferRoot",
 #if BUILDFLAG(IS_MAC) || BUILDFLAG(IS_WIN)
              base::FEATURE_ENABLED_BY_DEFAULT);
 #else
              base::FEATURE_DISABLED_BY_DEFAULT);
+#endif
 #endif
 
 bool Partitions::initialized_ = false;
@@ -136,6 +150,24 @@ bool Partitions::InitializeOnce() {
     options.backup_ref_ptr = PartitionOptions::kDisabled;
   }
 
+#if BUILDFLAG(IS_COBALT)
+  const bool merge_partitions = base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions);
+  if (merge_partitions) {
+#if PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+    fast_malloc_root_ = allocator_shim::internal::PartitionAllocMalloc::Allocator();
+#else
+    options.thread_cache = PartitionOptions::kEnabled;
+    static base::NoDestructor<partition_alloc::PartitionAllocator>
+        fast_malloc_allocator(options);
+    fast_malloc_root_ = fast_malloc_allocator->root();
+#endif // PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+    buffer_root_ = fast_malloc_root_;
+  } else {
+    static base::NoDestructor<partition_alloc::PartitionAllocator>
+        buffer_allocator(options);
+    buffer_root_ = buffer_allocator->root();
+  }
+#else
   static base::NoDestructor<partition_alloc::PartitionAllocator>
       buffer_allocator(options);
   buffer_root_ = buffer_allocator->root();
@@ -143,6 +175,7 @@ bool Partitions::InitializeOnce() {
           kBlinkUseLargeEmptySlotSpanRingForBufferRoot)) {
     buffer_root_->EnableLargeEmptySlotSpanRing();
   }
+#endif // BUILDFLAG(IS_COBALT)
 
   if (base::FeatureList::IsEnabled(
           base::features::kPartitionAllocDisableBRPInBufferPartition)) {
@@ -156,12 +189,23 @@ bool Partitions::InitializeOnce() {
   // Note that we could keep the two heaps separate, but each PartitionAlloc's
   // root has a cost, both in used memory and in virtual address space. Don't
   // pay it when we don't have to.
+#if BUILDFLAG(IS_COBALT)
+  if (!merge_partitions) {
+#if !PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
+    options.thread_cache = PartitionOptions::kEnabled;
+    static base::NoDestructor<partition_alloc::PartitionAllocator>
+        fast_malloc_allocator(options);
+    fast_malloc_root_ = fast_malloc_allocator->root();
+#endif
+  }
+#else
 #if !PA_BUILDFLAG(USE_PARTITION_ALLOC_AS_MALLOC)
   options.thread_cache = PartitionOptions::kEnabled;
   static base::NoDestructor<partition_alloc::PartitionAllocator>
       fast_malloc_allocator(options);
   fast_malloc_root_ = fast_malloc_allocator->root();
 #endif
+#endif // BUILDFLAG(IS_COBALT)
 
   initialized_ = true;
   return initialized_;
@@ -174,6 +218,12 @@ void Partitions::InitializeArrayBufferPartition() {
 
   // BackupRefPtr disallowed because it will prevent allocations from being 16B
   // aligned as required by ArrayBufferContents.
+#if BUILDFLAG(IS_COBALT)
+  if (base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
+    array_buffer_root_ = fast_malloc_root_;
+    return;
+  }
+#endif
   static base::NoDestructor<partition_alloc::PartitionAllocator>
       array_buffer_allocator([]() {
         partition_alloc::PartitionOptions opts;
@@ -216,11 +266,21 @@ void Partitions::DumpMemoryStats(
     fast_malloc_partition->DumpStats("fast_malloc", is_light_dump,
                                      partition_stats_dumper);
   }
+#if BUILDFLAG(IS_COBALT)
+  if (!base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
+    if (ArrayBufferPartitionInitialized()) {
+      ArrayBufferPartition()->DumpStats("array_buffer", is_light_dump,
+                                        partition_stats_dumper);
+    }
+    BufferPartition()->DumpStats("buffer", is_light_dump, partition_stats_dumper);
+  }
+#else
   if (ArrayBufferPartitionInitialized()) {
     ArrayBufferPartition()->DumpStats("array_buffer", is_light_dump,
                                       partition_stats_dumper);
   }
   BufferPartition()->DumpStats("buffer", is_light_dump, partition_stats_dumper);
+#endif
 }
 
 namespace {
@@ -257,12 +317,23 @@ size_t Partitions::TotalSizeOfCommittedPages() {
     total_size +=
         TS_UNCHECKED_READ(fast_malloc_partition->total_size_of_committed_pages);
   }
+#if BUILDFLAG(IS_COBALT)
+  if (!base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
+    if (ArrayBufferPartitionInitialized()) {
+      total_size += TS_UNCHECKED_READ(
+          ArrayBufferPartition()->total_size_of_committed_pages);
+    }
+    total_size +=
+        TS_UNCHECKED_READ(BufferPartition()->total_size_of_committed_pages);
+  }
+#else
   if (ArrayBufferPartitionInitialized()) {
     total_size += TS_UNCHECKED_READ(
         ArrayBufferPartition()->total_size_of_committed_pages);
   }
   total_size +=
       TS_UNCHECKED_READ(BufferPartition()->total_size_of_committed_pages);
+#endif
   return total_size;
 }
 
@@ -446,11 +517,25 @@ void Partitions::AdjustPartitionsForForeground() {
   DCHECK(initialized_);
   if (base::FeatureList::IsEnabled(
           base::features::kPartitionAllocAdjustSizeWhenInForeground)) {
+#if BUILDFLAG(IS_COBALT)
+    if (base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
+      if (fast_malloc_root_) {
+        fast_malloc_root_->AdjustForForeground();
+      }
+    } else {
+      array_buffer_root_->AdjustForForeground();
+      buffer_root_->AdjustForForeground();
+      if (fast_malloc_root_) {
+        fast_malloc_root_->AdjustForForeground();
+      }
+    }
+#else
     array_buffer_root_->AdjustForForeground();
     buffer_root_->AdjustForForeground();
     if (fast_malloc_root_) {
       fast_malloc_root_->AdjustForForeground();
     }
+#endif
   }
 }
 
@@ -459,11 +544,25 @@ void Partitions::AdjustPartitionsForBackground() {
   DCHECK(initialized_);
   if (base::FeatureList::IsEnabled(
           base::features::kPartitionAllocAdjustSizeWhenInForeground)) {
+#if BUILDFLAG(IS_COBALT)
+    if (base::FeatureList::IsEnabled(kCobaltMergeBlinkPartitions)) {
+      if (fast_malloc_root_) {
+        fast_malloc_root_->AdjustForBackground();
+      }
+    } else {
+      array_buffer_root_->AdjustForBackground();
+      buffer_root_->AdjustForBackground();
+      if (fast_malloc_root_) {
+        fast_malloc_root_->AdjustForBackground();
+      }
+    }
+#else
     array_buffer_root_->AdjustForBackground();
     buffer_root_->AdjustForBackground();
     if (fast_malloc_root_) {
       fast_malloc_root_->AdjustForBackground();
     }
+#endif
   }
 }
 

--- a/third_party/blink/renderer/platform/wtf/allocator/partitions.cc
+++ b/third_party/blink/renderer/platform/wtf/allocator/partitions.cc
@@ -154,10 +154,12 @@ bool Partitions::InitializeOnce() {
   static base::NoDestructor<partition_alloc::PartitionAllocator>
       buffer_allocator(options);
   buffer_root_ = buffer_allocator->root();
+#if !BUILDFLAG(IS_COBALT)
   if (base::FeatureList::IsEnabled(
           kBlinkUseLargeEmptySlotSpanRingForBufferRoot)) {
     buffer_root_->EnableLargeEmptySlotSpanRing();
   }
+#endif
 
   if (base::FeatureList::IsEnabled(
           base::features::kPartitionAllocDisableBRPInBufferPartition)) {
@@ -193,7 +195,7 @@ void Partitions::InitializeArrayBufferPartition() {
   // Merge array_buffer_root_ with buffer_root_
   array_buffer_root_ = buffer_root_;
   return;
-#endif
+#else
   static base::NoDestructor<partition_alloc::PartitionAllocator>
       array_buffer_allocator([]() {
         partition_alloc::PartitionOptions opts;
@@ -211,8 +213,8 @@ void Partitions::InitializeArrayBufferPartition() {
             .enabled = partition_alloc::PartitionOptions::kDisabled};
         return opts;
       }());
-
-  array_buffer_root_ = array_buffer_allocator->root();
+array_buffer_root_ = array_buffer_allocator->root();
+#endif
 }
 
 // static


### PR DESCRIPTION
Routes array_buffer_root_ and buffer_root_ to fast_malloc_root_ to save memory.

Bug: 525464502