### PR TITLE
cobalt: Add UMA metrics for Finch configurations

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -529,6 +529,8 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
       use_safe_config ? kSafeConfigFeatureParams
                       : kExperimentConfigFeatureParams);
 
+  bool has_invalid_feature_type = false;
+  int features_applied = 0;
   for (const auto feature_name_and_value : feature_map) {
     if (feature_name_and_value.second.is_bool()) {
       auto override_value =
@@ -537,20 +539,30 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
               : base::FeatureList::OverrideState::OVERRIDE_DISABLE_FEATURE;
       feature_list->RegisterFieldTrialOverride(
           feature_name_and_value.first, override_value, cobalt_field_trial);
+      features_applied++;
     } else {
+      has_invalid_feature_type = true;
       // TODO(b/407734134): Register UMA here for non boolean feature value.
       LOG(ERROR) << "Failed to apply override for feature "
                  << feature_name_and_value.first;
       base::debug::DumpWithoutCrashing();
     }
   }
+  base::UmaHistogramBoolean("Cobalt.Finch.HasInvalidFeatureType",
+                            has_invalid_feature_type);
+  base::UmaHistogramCounts100("Cobalt.Finch.NumFeaturesApplied",
+                              features_applied);
 
+  bool has_invalid_param_type = false;
+  int params_applied = 0;
   base::FieldTrialParams params;
   for (const auto param_name_and_value : param_map) {
     if (param_name_and_value.second.is_string()) {
       params.emplace(param_name_and_value.first,
                      param_name_and_value.second.GetString());
+      params_applied++;
     } else {
+      has_invalid_param_type = true;
       // TODO(b/407734134): Register UMA here for non string param value.
       LOG(ERROR) << "Failed to associate field trial param "
                  << param_name_and_value.first << " with string value "
@@ -558,6 +570,9 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
       base::debug::DumpWithoutCrashing();
     }
   }
+  base::UmaHistogramBoolean("Cobalt.Finch.HasInvalidParamType",
+                            has_invalid_param_type);
+  base::UmaHistogramCounts100("Cobalt.Finch.NumParamsApplied", params_applied);
   base::AssociateFieldTrialParams(kCobaltExperimentName, kCobaltGroupName,
                                   params);
 }

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -529,8 +529,7 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
       use_safe_config ? kSafeConfigFeatureParams
                       : kExperimentConfigFeatureParams);
 
-  bool has_invalid_feature_type = false;
-  int features_applied = 0;
+  size_t features_applied = 0;
   for (const auto feature_name_and_value : feature_map) {
     if (feature_name_and_value.second.is_bool()) {
       auto override_value =
@@ -541,20 +540,18 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
           feature_name_and_value.first, override_value, cobalt_field_trial);
       features_applied++;
     } else {
-      has_invalid_feature_type = true;
-      // TODO(b/407734134): Register UMA here for non boolean feature value.
       LOG(ERROR) << "Failed to apply override for feature "
                  << feature_name_and_value.first;
       base::debug::DumpWithoutCrashing();
     }
   }
+  const bool has_invalid_feature_type = feature_map.size() != features_applied;
   base::UmaHistogramBoolean("Cobalt.Finch.HasInvalidFeatureType",
                             has_invalid_feature_type);
   base::UmaHistogramCounts100("Cobalt.Finch.NumFeaturesApplied",
-                              features_applied);
+                              static_cast<int>(features_applied));
 
-  bool has_invalid_param_type = false;
-  int params_applied = 0;
+  size_t params_applied = 0;
   base::FieldTrialParams params;
   for (const auto param_name_and_value : param_map) {
     if (param_name_and_value.second.is_string()) {
@@ -562,17 +559,17 @@ void CobaltContentBrowserClient::SetUpCobaltFeaturesAndParams(
                      param_name_and_value.second.GetString());
       params_applied++;
     } else {
-      has_invalid_param_type = true;
-      // TODO(b/407734134): Register UMA here for non string param value.
       LOG(ERROR) << "Failed to associate field trial param "
                  << param_name_and_value.first << " with string value "
                  << param_name_and_value.second;
       base::debug::DumpWithoutCrashing();
     }
   }
+  const bool has_invalid_param_type = param_map.size() != params_applied;
   base::UmaHistogramBoolean("Cobalt.Finch.HasInvalidParamType",
                             has_invalid_param_type);
-  base::UmaHistogramCounts100("Cobalt.Finch.NumParamsApplied", params_applied);
+  base::UmaHistogramCounts100("Cobalt.Finch.NumParamsApplied",
+                              static_cast<int>(params_applied));
   base::AssociateFieldTrialParams(kCobaltExperimentName, kCobaltGroupName,
                                   params);
 }

--- a/cobalt/browser/experiments/experiment_config_manager.cc
+++ b/cobalt/browser/experiments/experiment_config_manager.cc
@@ -146,6 +146,8 @@ ExperimentConfigType ExperimentConfigManager::GetExperimentConfigType() {
 
   int num_crashes = metrics_local_state_->GetInteger(
       variations::prefs::kVariationsCrashStreak);
+  base::UmaHistogramExactLinear("Cobalt.Finch.CrashStreakAtStartup",
+                                num_crashes, 20);
   static_assert(kDefaultCrashStreakEmptyConfigThreshold >
                     kDefaultCrashStreakSafeConfigThreshold,
                 "Threshold to use an empty experiment config should be larger "

--- a/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
+++ b/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
@@ -67,6 +67,8 @@ H5vccExperimentsImpl::H5vccExperimentsImpl(
 void H5vccExperimentsImpl::SetExperimentState(
     base::Value::Dict experiment_config,
     SetExperimentStateCallback callback) {
+  base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.BrowserCalled",
+                            true);
   auto* global_features = cobalt::GlobalFeatures::GetInstance();
   auto* experiment_config_ptr = global_features->experiment_config();
   // A valid experiment config is supplied by h5vcc and we store the current

--- a/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
+++ b/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
@@ -67,8 +67,6 @@ H5vccExperimentsImpl::H5vccExperimentsImpl(
 void H5vccExperimentsImpl::SetExperimentState(
     base::Value::Dict experiment_config,
     SetExperimentStateCallback callback) {
-  base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.BrowserCalled",
-                            true);
   auto* global_features = cobalt::GlobalFeatures::GetInstance();
   auto* experiment_config_ptr = global_features->experiment_config();
   // A valid experiment config is supplied by h5vcc and we store the current

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_experiments/h_5_vcc_experiments.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_experiments/h_5_vcc_experiments.cc
@@ -50,7 +50,6 @@ ScriptPromise<IDLUndefined> H5vccExperiments::setExperimentState(
   if (!experiment_config_dict.has_value()) {
     base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.ParseError",
                               true);
-    base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.Result", false);
     resolver->RejectWithDOMException(
         DOMExceptionCode::kInvalidStateError,
         "Unable to parse experiment configuration.");
@@ -200,7 +199,6 @@ void H5vccExperiments::OnGetLatestExperimentConfigHashData(
 
 void H5vccExperiments::OnSetExperimentState(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
-  base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.Result", true);
   ongoing_requests_.erase(resolver);
   resolver->Resolve();
 }
@@ -250,9 +248,6 @@ void H5vccExperiments::OnConnectionError() {
   // concurrent modification.
   ongoing_requests_.swap(h5vcc_experiments_promises);
   for (auto& resolver : h5vcc_experiments_promises) {
-    base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.ConnectionError",
-                              true);
-    base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.Result", false);
     resolver->Reject("Mojo connection error.");
   }
   ongoing_requests_.clear();

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_experiments/h_5_vcc_experiments.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_experiments/h_5_vcc_experiments.cc
@@ -15,6 +15,7 @@
 #include "third_party/blink/renderer/modules/cobalt/h5vcc_experiments/h_5_vcc_experiments.h"
 
 #include "base/metrics/field_trial_params.h"
+#include "base/metrics/histogram_functions.h"
 #include "base/values.h"
 #include "cobalt/browser/constants/cobalt_experiment_names.h"
 #include "cobalt/browser/h5vcc_experiments/public/mojom/h5vcc_experiments.mojom-blink.h"
@@ -47,6 +48,9 @@ ScriptPromise<IDLUndefined> H5vccExperiments::setExperimentState(
       ParseConfigToDictionary(experiment_configuration);
 
   if (!experiment_config_dict.has_value()) {
+    base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.ParseError",
+                              true);
+    base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.Result", false);
     resolver->RejectWithDOMException(
         DOMExceptionCode::kInvalidStateError,
         "Unable to parse experiment configuration.");
@@ -196,6 +200,7 @@ void H5vccExperiments::OnGetLatestExperimentConfigHashData(
 
 void H5vccExperiments::OnSetExperimentState(
     ScriptPromiseResolver<IDLUndefined>* resolver) {
+  base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.Result", true);
   ongoing_requests_.erase(resolver);
   resolver->Resolve();
 }
@@ -245,6 +250,9 @@ void H5vccExperiments::OnConnectionError() {
   // concurrent modification.
   ongoing_requests_.swap(h5vcc_experiments_promises);
   for (auto& resolver : h5vcc_experiments_promises) {
+    base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.ConnectionError",
+                              true);
+    base::UmaHistogramBoolean("Cobalt.Finch.SetExperimentState.Result", false);
     resolver->Reject("Mojo connection error.");
   }
   ongoing_requests_.clear();

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -53,6 +53,24 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.Features.TestFinchFeature" enum="Boolean"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records whether the test Finch feature is enabled. Used for validating feature
+    deployment.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Features.TestFinchFeatureParam" units="hash"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the hash of the parameter value for the test Finch feature. Used
+    for validating parameter propagation.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.Finch.ConfigAgeInDays" units="days"
     expires_after="never">
   <owner>yijiazhang@google.com</owner>
@@ -81,6 +99,55 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.Finch.CrashStreakAtStartup" units="crashes"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the variations crash streak number at startup. This helps track
+    system stability and safe config activation.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Finch.HasInvalidFeatureType" enum="Boolean"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records whether any features in the variations configuration had an invalid (non-boolean) type.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Finch.HasInvalidParamType" enum="Boolean"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records whether any parameters in the variations configuration had an invalid (non-string) type.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Finch.NumFeaturesApplied" units="features"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the number of experiment features successfully registered and applied at startup.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Finch.NumParamsApplied" units="parameters"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the number of experiment parameters successfully registered and applied at startup.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Finch.SetExperimentState.ParseError" enum="Boolean"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records when SetExperimentState fails because the variations config dictionary could not be parsed.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.Finch.TimeBetweenWrites" units="ms"
     expires_after="never">
   <owner>yijiazhang@google.com</owner>
@@ -99,7 +166,6 @@ Always run the pretty print utility on this file after editing:
     received.
   </summary>
 </histogram>
-
 
 <histogram name="Cobalt.LoaderApp.ElfDecompressionDuration" units="ms"
     expires_after="never">


### PR DESCRIPTION
Add several UMA histograms to track the status and success rate of
Finch experiment configurations. These metrics monitor feature and
parameter application counts, detect invalid data types, and track
startup crash streaks.

Additionally, telemetry is added to the H5VCC experiments interface to
record parse errors, connection errors, and overall success rates
when setting experiment states. This data is essential for
identifying and diagnosing configuration issues in production where
log-based debugging is limited.

Bug: 515520976