### PR TITLE
Freeze with a 1.5s delay after visibilityChange

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -35,6 +35,8 @@ import android.view.View;
 import android.view.ViewGroup.LayoutParams;
 import android.view.ViewParent;
 import android.view.WindowManager;
+import android.view.Display;
+import android.hardware.display.DisplayManager;
 import android.window.OnBackInvokedCallback;
 import android.window.OnBackInvokedDispatcher;
 import android.widget.FrameLayout;
@@ -116,7 +118,8 @@ public abstract class CobaltActivity extends Activity {
   private IntentRequestTracker mIntentRequestTracker;
   // Tracks the status of the FLAG_KEEP_SCREEN_ON window flag.
   private Boolean mIsKeepScreenOnEnabled = false;
-
+  private Runnable mFreezeRunnable;
+  private final Handler mHandler = new Handler(Looper.getMainLooper());
   private boolean mIsCobaltUsingAndroidOverlay;
 
   private boolean mEnableSplashScreen;
@@ -131,6 +134,15 @@ public abstract class CobaltActivity extends Activity {
   // to Escape), this flag is used by OnBackInvokedCallback to detect physical key presses and
   // bypass simulated key dispatching.
   private boolean mPhysicalBackKeyPressed = false;
+  private final DisplayUtil.Listener mDisplayListener = new DisplayUtil.Listener() {
+    @Override
+    public void onDisplayChanged(int displayId) {
+      if (displayId == Display.DEFAULT_DISPLAY) {
+        checkDisplayState();
+      }
+    }
+  };
+  private boolean mWasDisplayOn = true;
 
   private Bundle getActivityMetaData() {
     ComponentName componentName = getIntent().getComponent();
@@ -550,6 +562,10 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   protected void onStart() {
+    DisplayUtil.cacheDefaultDisplay(this);
+    DisplayUtil.addDisplayListener(this);
+    mWasDisplayOn = isDisplayOn();
+    registerDisplayListener();
     StartupGuard.getInstance().setStartupMilestone(10);
     if (isDevelopmentBuild()) {
       getStarboardBridge().getAudioOutputManager().dumpAllOutputDevices();
@@ -562,21 +578,24 @@ public abstract class CobaltActivity extends Activity {
       createNewSurfaceView();
     }
 
-    DisplayUtil.cacheDefaultDisplay(this);
-    DisplayUtil.addDisplayListener(this);
     AudioOutputManager.addAudioDeviceListener(this);
 
     getStarboardBridge().onActivityStart(this);
     super.onStart();
 
+    if (mFreezeRunnable != null) {
+      mHandler.removeCallbacks(mFreezeRunnable);
+      mFreezeRunnable = null;
+    }
     WebContents webContents = getActiveWebContents();
-    // If ENABLE_FREEZE is not specified, disable corresponding resume event by default.
-    if (webContents != null && getJavaSwitches().containsKey(JavaSwitches.ENABLE_FREEZE)) {
+    if (webContents != null &&
+        (getJavaSwitches().containsKey(JavaSwitches.DELAY_FREEZE_ON_BACKGROUND) ||
+         getJavaSwitches().containsKey(JavaSwitches.ENABLE_FREEZE))) {
       // document.onresume event
       webContents.onResume();
     }
     // visibility:visible event
-    updateShellActivityVisible(true);
+    updateShellActivityVisible(mWasDisplayOn);
     MemoryPressureMonitor.INSTANCE.enablePolling(false);
 
     StartupGuard.getInstance().setStartupMilestone(11);
@@ -591,16 +610,33 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   protected void onStop() {
+    unregisterDisplayListener();
     getStarboardBridge().onActivityStop(this);
     super.onStop();
 
     // visibility:hidden event
     updateShellActivityVisible(false);
     WebContents webContents = getActiveWebContents();
-    // If ENABLE_FREEZE is not specified, disable freeze event by default.
-    if (webContents != null && getJavaSwitches().containsKey(JavaSwitches.ENABLE_FREEZE)) {
-      // document.onfreeze event
-      webContents.onFreeze();
+    if (webContents != null) {
+      if (getJavaSwitches().containsKey(JavaSwitches.DELAY_FREEZE_ON_BACKGROUND)) {
+        if (mFreezeRunnable != null) {
+          mHandler.removeCallbacks(mFreezeRunnable);
+        }
+        mFreezeRunnable = new Runnable() {
+          @Override
+          public void run() {
+            WebContents currentWebContents = getActiveWebContents();
+            if (currentWebContents != null) {
+              currentWebContents.onFreeze();
+            }
+            mFreezeRunnable = null;
+          }
+        };
+        mHandler.postDelayed(mFreezeRunnable, 1500);
+      } else if (getJavaSwitches().containsKey(JavaSwitches.ENABLE_FREEZE)) {
+        // If ENABLE_FREEZE is specified, fire freeze event immediately
+        webContents.onFreeze();
+      }
     }
 
     if (VideoSurfaceView.getCurrentSurface() != null) {
@@ -628,6 +664,11 @@ public abstract class CobaltActivity extends Activity {
 
   @Override
   protected void onDestroy() {
+    unregisterDisplayListener();
+    if (mFreezeRunnable != null) {
+      mHandler.removeCallbacks(mFreezeRunnable);
+      mFreezeRunnable = null;
+    }
     if (mShellManager != null) {
       mShellManager.destroy();
     }
@@ -871,6 +912,39 @@ public abstract class CobaltActivity extends Activity {
     if (mShellManager != null) {
       mShellManager.onActivityVisible(isVisible);
     }
+  }
+
+  private boolean isDisplayOn() {
+    Display defaultDisplay = DisplayUtil.getDefaultDisplay();
+    if (defaultDisplay == null) {
+      DisplayUtil.cacheDefaultDisplay(this);
+      defaultDisplay = DisplayUtil.getDefaultDisplay();
+    }
+    if (defaultDisplay == null) {
+      // Fail-safe: assume display is ON if we cannot query it
+      return true;
+    }
+    int state = defaultDisplay.getState();
+    // If the state is unknown, we fail-safe to true (display ON) to prevent
+    // rendering freezes or black screens on devices that do not report display state correctly.
+    return state == Display.STATE_ON || state == Display.STATE_UNKNOWN;
+  }
+
+  private void checkDisplayState() {
+    boolean isDisplayOn = isDisplayOn();
+    if (isDisplayOn != mWasDisplayOn) {
+      mWasDisplayOn = isDisplayOn;
+      Log.i(TAG, "Display state changed: isDisplayOn = " + isDisplayOn);
+      updateShellActivityVisible(isDisplayOn);
+    }
+  }
+
+  private void registerDisplayListener() {
+    DisplayUtil.registerListener(mDisplayListener);
+  }
+
+  private void unregisterDisplayListener() {
+    DisplayUtil.unregisterListener(mDisplayListener);
   }
 
   @RequiresApi(api = 33)

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/DisplayUtil.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/DisplayUtil.java
@@ -27,6 +27,7 @@ import androidx.annotation.RequiresApi;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
+import java.util.concurrent.CopyOnWriteArrayList;
 
 /** Utility functions for querying display attributes. */
 public class DisplayUtil {
@@ -180,21 +181,44 @@ public class DisplayUtil {
     return sCachedDisplayMetrics;
   }
 
+  public interface Listener {
+    void onDisplayChanged(int displayId);
+  }
+
+  private static final CopyOnWriteArrayList<Listener> sListeners = new CopyOnWriteArrayList<>();
+
+  public static void registerListener(Listener listener) {
+    sListeners.add(listener);
+  }
+
+  public static void unregisterListener(Listener listener) {
+    sListeners.remove(listener);
+  }
+
   private static DisplayListener sDisplayerListener =
       new DisplayListener() {
+        private void notifyListeners(int displayId) {
+          for (Listener listener : sListeners) {
+            listener.onDisplayChanged(displayId);
+          }
+        }
+
         @Override
         public void onDisplayAdded(int displayId) {
           DisplayUtilJni.get().onDisplayChanged();
+          notifyListeners(displayId);
         }
 
         @Override
         public void onDisplayChanged(int displayId) {
           DisplayUtilJni.get().onDisplayChanged();
+          notifyListeners(displayId);
         }
 
         @Override
         public void onDisplayRemoved(int displayId) {
           DisplayUtilJni.get().onDisplayChanged();
+          notifyListeners(displayId);
         }
       };
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -31,6 +31,9 @@ public class JavaSwitches {
   /** flag to re-enable freeze and resume events */
   public static final String ENABLE_FREEZE = "EnableFreeze";
 
+  /** flag to enable a 1.5s delay before firing the freeze event on background. */
+  public static final String DELAY_FREEZE_ON_BACKGROUND = "DelayFreezeOnBackground";
+
   /** flag to force use IPv4 for system host resolution. */
   public static final String USE_IPV4_FOR_DNS = "UseIPv4ForDNS";
 


### PR DESCRIPTION
## Description
This PR brings back the `freeze` event to the web client with a critical 1.5-second cushioning delay after the `visibilitychange` event is dispatched. 

Additionally, it resolves visibility tracking inaccuracies on Android TV by introducing a hardware-level `DisplayListener`. On many Android TV devices, turning off the TV screen or switching HDMI inputs does not immediately trigger standard Activity lifecycle events like `onPause()` or `onStop()`. To ensure the web app is correctly notified when it becomes invisible, we now monitor the hardware display state directly.

By combination of these two changes:
1. `visibilitychange` (hidden) is fired immediately when the app goes to the background (`onStop`) OR when the physical display turns off.
2. If triggered by `onStop`, the `freeze` event is queued with a 1.5s delay. If the app is resumed before the timer expires, the pending freeze is canceled.
3. This allows the web client to cleanly save state and process backgrounding tasks before JS execution is suspended.

## Changes
- Modified `dev.cobalt.coat.CobaltActivity`:
  - Added a `Handler` and a `Runnable` (`mFreezeRunnable`) to manage the delayed freeze.
  - Implemented `DisplayManager.DisplayListener` to track hardware display state changes (ON/OFF/UNKNOWN) and update shell visibility immediately.
  - Updated `onStart()` to register the display listener and cancel any pending freeze.
  - Updated `onStop()` to unregister the display listener, fire `visibilitychange` (hidden), and queue the `freeze` event with a 1.5s delay.
  - Overrode `onDestroy()` to ensure the pending `mFreezeRunnable` is canceled to prevent memory leaks.

## Testing
Tested manually on a connected Android TV device by sideloading a local HTML file and validating the web events via ADB intents:
- **Foreground -> Background** (`KEYCODE_HOME`):
  - `visibilitychange` (hidden) dispatched immediately.
  - `freeze` (hidden) dispatched exactly 1.5 seconds later.
- **Background -> Foreground** (App launched via intent):
  - Pending `freeze` (if any) is correctly canceled.
  - `resume` dispatched, followed by `visibilitychange` (visible).
- **Screen Off / HDMI Disconnect** (Simulated display changes):
  - `visibilitychange` (hidden) is fired immediately via the new `DisplayListener` even if the Activity remains in the foreground.

Bug: 517926212
TAG=agy
CONV=142f4a55-aaa4-4b03-a6ca-b0833ef012e0