### PR TITLE
evergreen: Fix crashes due to thread blocking restrictions

### DIFF
--- a/base/threading/thread_restrictions.h
+++ b/base/threading/thread_restrictions.h
@@ -214,10 +214,14 @@ namespace chromecast {
 class CrashUtil;
 }
 #if BUILDFLAG(IS_COBALT)
+namespace base {
+class Version;
+}
 namespace cobalt {
 class AppEventRunnerImpl;
 namespace updater {
 class UpdaterModule;
+base::Version ReadEvergreenVersion(base::FilePath installation_dir);
 }
 }
 #endif  // BUILDFLAG(IS_COBALT)
@@ -691,6 +695,10 @@ class BASE_EXPORT ScopedAllowBlocking {
   friend void chrome::SessionEnding();
   friend bool chromeos::system::IsCoreSchedulingAvailable();
   friend int chromeos::system::NumberOfPhysicalCores();
+#if BUILDFLAG(IS_COBALT)
+  friend base::Version cobalt::updater::ReadEvergreenVersion(
+    base::FilePath installation_dir);
+#endif  // BUILDFLAG(IS_COBALT)
   friend base::File content::CreateFileForDrop(
       base::FilePath* file_path);  // http://crbug.com/110709
   friend bool disk_cache::CleanupDirectorySync(const base::FilePath&);

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -189,15 +189,16 @@ UpdaterModule::UpdaterModule(
 
 UpdaterModule::~UpdaterModule() {
   LOG(INFO) << "UpdaterModule::~UpdaterModule";
+
+  // This is necessary to allow blocking for proper cleanup and to prevent
+  // a crash due to blocking restrictions at app exit.
+  base::ScopedAllowBaseSyncPrimitivesOutsideBlockingScope
+      allow_blocking_outside;
   if (is_updater_running_.exchange(false)) {
     // TODO(b/452142372): Investigate UpdaterModule destruction sequence
-    {
-      base::ScopedBlockingCall scoped_blocking_call(
-          FROM_HERE, base::BlockingType::MAY_BLOCK);
-      updater_thread_->task_runner()->PostTask(
-          FROM_HERE,
-          base::BindOnce(&UpdaterModule::Finalize, base::Unretained(this)));
-    }
+    updater_thread_->task_runner()->PostTask(
+        FROM_HERE,
+        base::BindOnce(&UpdaterModule::Finalize, base::Unretained(this)));
   }
 
   // Upon destruction the thread will allow all queued tasks to complete before

--- a/cobalt/updater/util.cc
+++ b/cobalt/updater/util.cc
@@ -26,6 +26,7 @@
 #include "base/path_service.h"
 #include "base/strings/strcat.h"
 #include "base/strings/string_number_conversions.h"
+#include "base/threading/thread_restrictions.h"
 #include "base/values.h"
 #include "build/build_config.h"
 #include "components/update_client/utils.h"
@@ -102,6 +103,10 @@ bool GetProductDirectoryPath(base::FilePath* path) {
 }
 
 base::Version ReadEvergreenVersion(base::FilePath installation_dir) {
+  // This is necessary to allow blocking for reading Evergreen version and
+  // populating it in the user agent string to prevent
+  // a crash due to blocking restrictions.
+  base::ScopedAllowBlocking allow_blocking;
   auto manifest = update_client::ReadManifest(installation_dir);
   if (manifest) {
     auto version = manifest->Find("version");


### PR DESCRIPTION
Allow blocking by cobalt::updater::ReadEvergreenVersion() and the UpdaterModule destructor, the same as 26.eap. Otherwise, there is a crash.

Issue: 479816505
