### PR TITLE
aosp: Bump NDK API level

### DIFF
--- a/starboard/aosp/arm/toolchain/BUILD.gn
+++ b/starboard/aosp/arm/toolchain/BUILD.gn
@@ -54,6 +54,9 @@ android_clang_toolchain("starboard") {
     is_starboard = true
     use_cxx17 = true
     build_base_with_cpp17 = true
+
+    # 'aligned_alloc' is only available on Android 28 or newer.
+    android_ndk_api_level = 28
   }
 }
 


### PR DESCRIPTION
aligned_alloc is only supported on Android 28 or newer. Bump the NDK API level on AOSP's starboard toolchain.

Bug: 495203133