### PR TITLE
aosp: Avoid the open() superfluous-mode warning

### DIFF
--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -38,8 +38,8 @@ int __wrap_stat(const char* path, struct stat* info) {
     return __real_stat(path, info);  // Using system level stat call
   }
 
-  // Keep a 0 mode so fortification does not rewrite open() to __open_2 and
-  // bypass the POSIX emulation wrappers needed to read the asset.
+  // Don't use the 2-arg open() since _FORTIFY_SOURCE rewrites it to __open_2,
+  // which bypasses -Wl,--wrap=open.
   int file = open(path, O_RDONLY, 0);
   if (file >= 0) {
     int result = fstat(file, info);

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -38,7 +38,9 @@ int __wrap_stat(const char* path, struct stat* info) {
     return __real_stat(path, info);  // Using system level stat call
   }
 
-  int file = open(path, O_RDONLY, S_IRUSR | S_IWUSR);
+  // Keep a 0 mode so fortification does not rewrite open() to __open_2 and
+  // bypass the POSIX emulation wrappers needed to read the asset.
+  int file = open(path, O_RDONLY, 0);
   if (file >= 0) {
     int result = fstat(file, info);
     close(file);

--- a/starboard/elf_loader/file_impl.cc
+++ b/starboard/elf_loader/file_impl.cc
@@ -43,6 +43,8 @@ FileImpl::~FileImpl() {
 bool FileImpl::Open(const char* name) {
   SB_DLOG(INFO) << "Loading: " << name;
   name_ = name;
+  // Keep a 0 mode so fortification does not rewrite open() to __open_2 and
+  // bypass the POSIX emulation wrappers needed to read the asset.
   file_ = open(name, O_RDONLY, 0);
   if (file_ < 0) {
     return false;

--- a/starboard/elf_loader/file_impl.cc
+++ b/starboard/elf_loader/file_impl.cc
@@ -43,8 +43,8 @@ FileImpl::~FileImpl() {
 bool FileImpl::Open(const char* name) {
   SB_DLOG(INFO) << "Loading: " << name;
   name_ = name;
-  // Keep a 0 mode so fortification does not rewrite open() to __open_2 and
-  // bypass the POSIX emulation wrappers needed to read the asset.
+  // Don't use the 2-arg open() since _FORTIFY_SOURCE rewrites it to __open_2,
+  // which bypasses -Wl,--wrap=open.
   file_ = open(name, O_RDONLY, 0);
   if (file_ < 0) {
     return false;

--- a/starboard/elf_loader/file_impl.cc
+++ b/starboard/elf_loader/file_impl.cc
@@ -51,7 +51,7 @@ bool FileImpl::Open(const char* name) {
 }
 
 bool FileImpl::ReadFromOffset(int64_t offset, char* buffer, int size) {
-  if (!file_) {
+  if (file_ < 0) {
     return false;
   }
   int64_t ret = lseek(file_, offset, SEEK_SET);
@@ -71,7 +71,7 @@ bool FileImpl::ReadFromOffset(int64_t offset, char* buffer, int size) {
 }
 
 void FileImpl::Close() {
-  if (file_) {
+  if (file_ >= 0) {
     close(file_);
   }
 }

--- a/starboard/elf_loader/file_impl.cc
+++ b/starboard/elf_loader/file_impl.cc
@@ -43,8 +43,8 @@ FileImpl::~FileImpl() {
 bool FileImpl::Open(const char* name) {
   SB_DLOG(INFO) << "Loading: " << name;
   name_ = name;
-  file_ = open(name, O_RDONLY, S_IRUSR | S_IWUSR);
-  if (!file_) {
+  file_ = open(name, O_RDONLY, 0);
+  if (file_ < 0) {
     return false;
   }
   return true;

--- a/starboard/loader_app/installation_manager.cc
+++ b/starboard/loader_app/installation_manager.cc
@@ -658,7 +658,7 @@ bool InstallationManager::LoadInstallationStore() {
   int file;
 
   SB_LOG(INFO) << "StorePath=" << store_path_;
-  file = open(store_path_.c_str(), O_RDONLY, S_IRUSR | S_IWUSR);
+  file = open(store_path_.c_str(), O_RDONLY);
   if (!starboard::IsValid(file)) {
     SB_LOG(WARNING) << "Failed to open file: " << store_path_;
     return false;

--- a/starboard/loader_app/installation_manager_test.cc
+++ b/starboard/loader_app/installation_manager_test.cc
@@ -73,7 +73,7 @@ class InstallationManagerTest : public ::testing::TestWithParam<int> {
   void ReadStorageState(cobalt::loader::InstallationStore* installation_store) {
     int file;
 
-    file = open(installation_store_path_.c_str(), O_RDONLY, S_IRUSR | S_IWUSR);
+    file = open(installation_store_path_.c_str(), O_RDONLY);
     ASSERT_TRUE(file >= 0);
 
     char buf[IM_MAX_INSTALLATION_STORE_SIZE];

--- a/starboard/loader_app/slot_management_test.cc
+++ b/starboard/loader_app/slot_management_test.cc
@@ -226,7 +226,7 @@ class SlotManagementTest : public testing::TestWithParam<bool> {
     path += kSbFileSepString;
     path += "libcobalt";
     AddFileExtension(path);
-    int sb_file = open(path.c_str(), O_CREAT | O_RDONLY);
+    int sb_file = open(path.c_str(), O_CREAT | O_RDONLY, S_IRUSR | S_IWUSR);
     EXPECT_TRUE(starboard::IsValid(sb_file));
     close(sb_file);
 


### PR DESCRIPTION
Fix compiler warnings about superfluous mode in read-only open() calls by removing the mode parameter.

In the case of file_impl.cc, which accesses Android assets, it must use the 3-arg open() since _FORTIFY_SOURCE rewrites the 2-arg form to __open_2, which bypasses the POSIX emulation wrappers.

Also fix `FileImpl` methods which treated a 0 file descriptor as an error and a -1 as success.

Bug: 495203133