### PR TITLE
Make cobalt:gn_all build nplb_loader

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -63,11 +63,11 @@ group("gn_all") {
     deps += [ ":strip_cobalt_binary" ]
   }
   if (is_cobalt_hermetic_build) {
-    deps += [
-      ":cobalt_loader",
-      "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)",
-      "//starboard/loader_app:loader_app($starboard_toolchain)",
-    ]
+    deps += [ ":cobalt_loader" ]
+
+    if (!cobalt_is_release_build) {
+      deps += [ "//starboard/nplb:nplb_loader" ]
+    }
   }
   if (is_starboard && build_updater_sandbox) {
     deps += [ "//chrome/updater/cobalt:updater_sandbox" ]


### PR DESCRIPTION
When not building a release build, make sure nplb_loader is built as part of the cobalt:gn_all group. This will be relevant for AOSP, where loader_app and elf_loader_sandbox cannot be directly run, and the _loader targets need to be built explicitly.

Bug: 495203133