### PR TITLE
android: treat warnings as errors

### DIFF
--- a/cobalt/build/configs/android_common.gn
+++ b/cobalt/build/configs/android_common.gn
@@ -1,10 +1,6 @@
 import("//cobalt/build/configs/chromium_android.gn")
 import("//cobalt/build/configs/common.gn")
 
-# This flag comes from build/config/compiler/compiler.gni
-# TODO(b/380339614): Remove this flag after resolving build errors.
-treat_warnings_as_errors = false
-
 # hashed jni names make build artifact opaque for Kimono build.
 use_hashed_jni_names = false
 use_errorprone_java_compiler = false

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -44,10 +44,12 @@ static_assert(std::is_trivially_destructible<std::atomic<bool>>::value,
 std::atomic<bool> g_enable_simd_based_audio_format_switching{
     kIsSimdBasedAudioFormatSwitchingDefaultEnabled};
 
+#if defined(USE_NEON_FOR_AUDIO)
 bool GetSimdBasedAudioFormatSwitchingSetting() {
   return g_enable_simd_based_audio_format_switching.load(
       std::memory_order_acquire);
 }
+#endif  // defined(USE_NEON_FOR_AUDIO)
 
 void ConvertSample(const int16_t* source, float* destination) {
   *destination = static_cast<float>(*source) / 32768.f;

--- a/third_party/blink/renderer/bindings/modules/v8/serialization/v8_script_value_serializer_for_modules_test.cc
+++ b/third_party/blink/renderer/bindings/modules/v8/serialization/v8_script_value_serializer_for_modules_test.cc
@@ -124,6 +124,7 @@ testing::AssertionResult HadDOMExceptionInModulesTest(const StringView& name,
   return testing::AssertionSuccess();
 }
 
+#if BUILDFLAG(USE_WEBRTC_PEER_CONNECTION)
 static const char kEcdsaPrivateKey[] =
     "-----BEGIN PRIVATE KEY-----\n"
     "MIGHAgEAMBMGByqGSM49AgEGCCqGSM49AwEHBG0wawIBAQQghHwQ1xYtCoEhFk7r\n"
@@ -201,7 +202,6 @@ static const uint8_t kEcdsaCertificateEncoded[] = {
     0x54, 0x49, 0x46, 0x49, 0x43, 0x41, 0x54, 0x45, 0x2d, 0x2d, 0x2d, 0x2d,
     0x2d, 0x0a};
 
-#if BUILDFLAG(USE_WEBRTC_PEER_CONNECTION)
 TEST(V8ScriptValueSerializerForModulesTest, RoundTripRTCCertificate) {
   test::TaskEnvironment task_environment;
   // If WebRTC is not supported in this build, this test is meaningless.

--- a/third_party/blink/renderer/modules/webaudio/audio_context_test.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_context_test.cc
@@ -57,7 +57,10 @@ constexpr char kFakeAudioOutput2[] = "fake_audio_output_2";
 constexpr char kInvalidAudioOutput[] = "INVALID_AUDIO_OUTPUT";
 constexpr char kSecurityOrigin[] = "https://example.com";
 constexpr char kTestData[] = "simple_div.html";
+
+#if BUILDFLAG(USE_WEBRTC_PEER_CONNECTION)
 constexpr char kDefaultDeviceId[] = "";
+#endif
 
 bool web_audio_device_paused_;
 


### PR DESCRIPTION
All warnings have been fixed, enable `treat_warnings_as_errors`.

Bug: 380339614