### PR TITLE
media: Disable WetRtc processing for Cobalt (#10471)

### DIFF
--- a/media/BUILD.gn
+++ b/media/BUILD.gn
@@ -207,6 +207,13 @@ test("media_unittests") {
     deps += ["//media/starboard:unit_tests"]
   }
 
+  if (is_cobalt) {
+    # Cobalt disabled WebRtc processing in 
+    # https://github.com/youtube/cobalt/pull/10471
+    # due to additional latency for the microphone path.
+    deps -= ["//media/webrtc:unit_tests"]
+  }
+
   data = [
     "test/data/",
     "formats/mp4/h264_annex_b_fuzz_corpus/",

--- a/media/base/audio_processing.h
+++ b/media/base/audio_processing.h
@@ -53,6 +53,12 @@ struct MEDIA_EXPORT AudioProcessingSettings {
   }
 
   bool NeedWebrtcAudioProcessing() const {
+#if BUILDFLAG(IS_COBALT)
+  // Cobalt does not support WebRtcAudioProcessing, since it increases audio
+  // latency on low-end TV devices
+  // https://b.corp.google.com/issues/483713292#comment61
+  return false;
+#endif
     // TODO(https://crbug.com/1269364): Legacy iOS-specific behavior;
     // reconsider.
 #if BUILDFLAG(IS_IOS)


### PR DESCRIPTION
cherry-pick from https://github.com/youtube/cobalt/pull/10471

Cobalt does not require WebRtc processing as it adds additional latency for the microphone path.
Normally this is used for echo cancellation and automatic gain control when handling two way calls, which we don't need or support.

Bug: 483713292