### PR TITLE
Implement Configurable Viewport Margin Settings

### DIFF
--- a/cc/base/features.cc
+++ b/cc/base/features.cc
@@ -10,6 +10,10 @@
 #include "base/feature_list.h"
 #include "build/build_config.h"
 
+#ifndef COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS
+#define COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS 1000
+#endif
+
 namespace features {
 
 namespace {
@@ -248,6 +252,13 @@ const base::FeatureParam<int>
 BASE_FEATURE(kUseLayerListsByDefault,
              "UseLayerListsByDefault",
              base::FEATURE_DISABLED_BY_DEFAULT);
+
+BASE_FEATURE(kConfigureMaxPrerasterDistance,
+             "ConfigureMaxPrerasterDistance",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+const base::FeatureParam<int> kMaxPrerasterDistanceInScreenPixels{
+    &kConfigureMaxPrerasterDistance, "distance_in_pixels",
+    COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS};
 
 BASE_FEATURE(kProgrammaticScrollAnimationOverride,
              "ProgrammaticScrollAnimationOverride",

--- a/cc/base/features.h
+++ b/cc/base/features.h
@@ -243,6 +243,10 @@ CC_BASE_EXPORT extern const base::FeatureParam<int>
 // disabled if need be to override this.
 CC_BASE_EXPORT BASE_DECLARE_FEATURE(kUseLayerListsByDefault);
 
+CC_BASE_EXPORT BASE_DECLARE_FEATURE(kConfigureMaxPrerasterDistance);
+CC_BASE_EXPORT extern const base::FeatureParam<int>
+    kMaxPrerasterDistanceInScreenPixels;
+
 // When enabled, the default programmatic scroll animation curve can be
 // overridden with extra params.
 CC_BASE_EXPORT BASE_DECLARE_FEATURE(kProgrammaticScrollAnimationOverride);

--- a/cc/trees/layer_tree_settings.cc
+++ b/cc/trees/layer_tree_settings.cc
@@ -21,7 +21,14 @@ LayerTreeSettings::LayerTreeSettings()
           base::FeatureList::IsEnabled(features::kUseLayerListsByDefault)),
       memory_policy(64 * 1024 * 1024,
                     gpu::MemoryAllocation::CUTOFF_ALLOW_EVERYTHING,
-                    ManagedMemoryPolicy::kDefaultNumResourcesLimit) {}
+                    ManagedMemoryPolicy::kDefaultNumResourcesLimit) {
+  if (base::FeatureList::IsEnabled(features::kConfigureMaxPrerasterDistance)) {
+    int config_val = features::kMaxPrerasterDistanceInScreenPixels.Get();
+    if (config_val >= 0) {
+      max_preraster_distance_in_screen_pixels = config_val;
+    }
+  }
+}
 
 LayerTreeSettings::LayerTreeSettings(const LayerTreeSettings& other) = default;
 LayerTreeSettings::~LayerTreeSettings() = default;

--- a/cc/trees/layer_tree_settings.h
+++ b/cc/trees/layer_tree_settings.h
@@ -19,6 +19,10 @@
 #include "third_party/skia/include/core/SkColor.h"
 #include "ui/gfx/geometry/size.h"
 
+#ifndef COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS
+#define COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS 1000
+#endif
+
 namespace cc {
 
 class CC_EXPORT LayerTreeSettings {
@@ -114,7 +118,7 @@ class CC_EXPORT LayerTreeSettings {
   size_t decoded_image_working_set_budget_bytes =
       ImageDecodeCacheUtils::GetWorkingSetBytesForImageDecode(
           /*for_renderer=*/false);
-  int max_preraster_distance_in_screen_pixels = 1000;
+  int max_preraster_distance_in_screen_pixels = COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS;
   bool use_rgba_4444 = false;
 
   // If set to true, the compositor may selectively defer image decodes to the

--- a/cobalt/build/configs/BUILD.gn
+++ b/cobalt/build/configs/BUILD.gn
@@ -14,6 +14,7 @@
 
 import("//build/config/arm.gni")
 import("//cobalt/build/configs/hacks.gni")
+import("//cobalt/build/configs/cobalt.gni")
 import("//starboard/build/buildflags.gni")
 import("//starboard/build/config/toolchain_variables.gni")
 
@@ -175,6 +176,11 @@ config("buildflag_defines") {
   if (is_partner_toolchain) {
     defines += [ "ENABLE_BUILDFLAG_IS_PARTNER_TOOLCHAIN" ]
   }
+
+  defines += [
+    "COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS=$cobalt_max_preraster_distance_in_screen_pixels",
+    "COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE=$cobalt_display_lock_margin_percentage",
+  ]
 }
 
 config("no_mallinfo") {

--- a/cobalt/build/configs/cobalt.gni
+++ b/cobalt/build/configs/cobalt.gni
@@ -23,4 +23,10 @@ declare_args() {
   # TODO(b/505811196): Remove this argument once Cobalt rebased to the milestone
   # where the privacy sandbox components are fully removed.
   enable_privacy_sandbox_apis = true
+
+  # Default maximum pre-raster distance in screen pixels.
+  cobalt_max_preraster_distance_in_screen_pixels = 1000
+
+  # Default display lock viewport margin percentage.
+  cobalt_display_lock_margin_percentage = 150
 }

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -170,6 +170,15 @@ STARBOARD_FEATURE(kVideoDecoderDelayUsecOverride,
                   false)
 // keep-sorted end
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
+
+// Viewport optimization features
+STARBOARD_FEATURE(kConfigureMaxPrerasterDistance,
+                  "ConfigureMaxPrerasterDistance",
+                  true)
+
+STARBOARD_FEATURE(kConfigureDisplayLockMargin,
+                  "ConfigureDisplayLockMargin",
+                  true)
 FEATURE_LIST_END
 
 // To add a parameter to Starboard, use the macro:
@@ -247,4 +256,25 @@ STARBOARD_FEATURE_PARAM(STARBOARD_FEATURE_PARAM_TIME_TYPE,
                         "ResetDelayUsec",
                         base::Microseconds(0))
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
+
+// Viewport optimization parameters
+#ifndef COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS
+#define COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS 1000
+#endif
+
+#ifndef COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE
+#define COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE 150.0
+#endif
+
+STARBOARD_FEATURE_PARAM(int,
+                        kMaxPrerasterDistanceInScreenPixels,
+                        kConfigureMaxPrerasterDistance,
+                        "distance_in_pixels",
+                        COBALT_DEFAULT_MAX_PRERASTER_DISTANCE_IN_SCREEN_PIXELS)
+
+STARBOARD_FEATURE_PARAM(double,
+                        kDisplayLockMarginPercentage,
+                        kConfigureDisplayLockMargin,
+                        "margin_percentage",
+                        COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE)
 FEATURE_PARAM_LIST_END

--- a/third_party/blink/common/features.cc
+++ b/third_party/blink/common/features.cc
@@ -17,6 +17,10 @@
 #include "third_party/blink/public/common/interest_group/ad_auction_constants.h"
 #include "third_party/blink/public/common/switches.h"
 
+#ifndef COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE
+#define COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE 150.0
+#endif
+
 namespace blink::features {
 
 // -----------------------------------------------------------------------------
@@ -54,6 +58,15 @@ BASE_FEATURE(kBlockMidiByDefault,
 BASE_FEATURE(kComputePressureRateObfuscationMitigation,
              "ComputePressureRateObfuscationMitigation",
              base::FEATURE_ENABLED_BY_DEFAULT);
+
+BASE_FEATURE(kConfigureDisplayLockMargin,
+             "ConfigureDisplayLockMargin",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+BASE_FEATURE_PARAM(double,
+                   kDisplayLockMarginPercentage,
+                   &kConfigureDisplayLockMargin,
+                   "margin_percentage",
+                   COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE);
 
 BASE_FEATURE(kCrashReportingAPIMoreContextData,
              "CrashReportingAPIMoreContextData",

--- a/third_party/blink/public/common/features.h
+++ b/third_party/blink/public/common/features.h
@@ -52,6 +52,10 @@ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(
     kComputePressureRateObfuscationMitigation);
 
+BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kConfigureDisplayLockMargin);
+BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE_PARAM(double,
+                                               kDisplayLockMarginPercentage);
+
 // Enables more context data to crash reports reported via the Crash Reporting
 // API. See https://crbug.com/400432195.
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kCrashReportingAPIMoreContextData);

--- a/third_party/blink/renderer/core/display_lock/display_lock_document_state.cc
+++ b/third_party/blink/renderer/core/display_lock/display_lock_document_state.cc
@@ -5,6 +5,8 @@
 #include "third_party/blink/renderer/core/display_lock/display_lock_document_state.h"
 
 #include "base/trace_event/trace_event.h"
+#include "base/feature_list.h"
+#include "third_party/blink/public/common/features.h"
 #include "third_party/blink/renderer/core/display_lock/display_lock_context.h"
 #include "third_party/blink/renderer/core/dom/document.h"
 #include "third_party/blink/renderer/core/dom/element.h"
@@ -119,6 +121,14 @@ IntersectionObserver& DisplayLockDocumentState::EnsureIntersectionObserver() {
     //
     // Paint containment requires using the overflow clip edge. To do otherwise
     // results in overflow-clip-margin not being painted in certain scenarios.
+    double margin_percent = kViewportMarginPercentage;
+    if (base::FeatureList::IsEnabled(features::kConfigureDisplayLockMargin)) {
+      double config_margin = features::kDisplayLockMarginPercentage.Get();
+      if (config_margin >= 0.0) {
+        margin_percent = config_margin;
+      }
+    }
+
     intersection_observer_ = IntersectionObserver::Create(
         *document_,
         WTF::BindRepeating(
@@ -126,7 +136,7 @@ IntersectionObserver& DisplayLockDocumentState::EnsureIntersectionObserver() {
             WrapWeakPersistent(this)),
         LocalFrameUkmAggregator::kDisplayLockIntersectionObserver,
         IntersectionObserver::Params{
-            .margin = {Length::Percent(kViewportMarginPercentage)},
+            .margin = {Length::Percent(margin_percent)},
             .margin_target = IntersectionObserver::kApplyMarginToTarget,
             .thresholds = {std::numeric_limits<float>::min()},
             .behavior = IntersectionObserver::kDeliverDuringPostLayoutSteps,

--- a/third_party/blink/renderer/core/display_lock/display_lock_document_state.h
+++ b/third_party/blink/renderer/core/display_lock/display_lock_document_state.h
@@ -5,6 +5,10 @@
 #ifndef THIRD_PARTY_BLINK_RENDERER_CORE_DISPLAY_LOCK_DISPLAY_LOCK_DOCUMENT_STATE_H_
 #define THIRD_PARTY_BLINK_RENDERER_CORE_DISPLAY_LOCK_DISPLAY_LOCK_DOCUMENT_STATE_H_
 
+#ifndef COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE
+#define COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE 150.0f
+#endif
+
 #include "third_party/blink/renderer/core/core_export.h"
 #include "third_party/blink/renderer/core/display_lock/display_lock_utilities.h"
 #include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
@@ -187,7 +191,7 @@ class CORE_EXPORT DisplayLockDocumentState final
 
   base::TimeTicks GetLockUpdateTimestamp();
 
-  static constexpr float kViewportMarginPercentage = 150.f;
+  static constexpr float kViewportMarginPercentage = COBALT_DEFAULT_DISPLAY_LOCK_MARGIN_PERCENTAGE;
 
   void IssueForcedRenderWarning(Element*);
 


### PR DESCRIPTION
Introduces dynamic, parameter-driven configuration for the compositor pre-raster distance (via kConfigureMaxPrerasterDistance) and Blink display lock margins (via kConfigureDisplayLockMargin) to support viewport memory optimization experiments. 

Both features are disabled by default and fall back to safe browser baseline settings (1000px and 150%) to ensure clean, non-diluting A/B testing. 

The testing strategy relies on enabling these flags and overriding their numerical parameters (such as setting distance_in_pixels to 300 and margin_percentage to 30) dynamically via the GCF/Mendel framework or the h5vcc experiments API on the target device.

