### PR TITLE
Disable preloaded HSTS list for Cobalt

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -3,6 +3,9 @@ is_cobalt = true
 # Disable Chrome Remote Desktop.
 enable_remoting = false
 
+# We know we can trust clients to use https.
+include_transport_security_state_preload_list = false
+
 # Build flag declared originally in build/config/features.gni
 # This flag is overridden to enable common video codecs playbacks.
 proprietary_codecs = true

--- a/cobalt/build/configs/linux_common.gn
+++ b/cobalt/build/configs/linux_common.gn
@@ -54,9 +54,6 @@ enable_print_preview = false
 use_cups = false
 use_kerberos = false
 
-# We know we can trust clients to use https.
-include_transport_security_state_preload_list = false
-
 # Disable the chrome root store for linux/3P platforms.
 chrome_root_store_optional = false
 chrome_root_store_only = false


### PR DESCRIPTION
This list is redundant for Cobalt as it only connects to a strict set of Google and YouTube endpoints. Disabling it saves binary size.