### PR TITLE
feat: Enable hang reporting via Crashpad for 3P

### DIFF
--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -2460,7 +2460,10 @@ component("base") {
       "system/sys_info_starboard.h",
     ]
 
-    deps += [ "//starboard/common:common_headers_only" ]
+    deps += [
+      "//starboard/common:common_headers_only",
+      "//starboard:starboard_headers_only",
+    ]
   }
 
   if (use_blink) {

--- a/base/threading/hang_watcher.cc
+++ b/base/threading/hang_watcher.cc
@@ -31,6 +31,11 @@
 #include "base/trace_event/base_tracing.h"
 #include "build/build_config.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include "starboard/extension/crash_handler.h"
+#include "starboard/system.h"
+#endif
+
 namespace base {
 
 namespace {
@@ -1119,6 +1124,26 @@ void HangWatcher::DoDumpWithoutCrashing(
 
   SCOPED_CRASH_KEY_BOOL("HangWatcher", "shutting-down",
                         g_shutting_down.load(std::memory_order_relaxed));
+
+#if BUILDFLAG(IS_STARBOARD)
+  // Evergreen builds cannot currently use the crash key system directly and we
+  // instead use a Starboard extension to pass annotations from the Cobalt layer
+  // to Crashpad.
+  auto* crash_handler_extension =
+      static_cast<const CobaltExtensionCrashHandlerApi*>(
+          SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
+  if (crash_handler_extension && crash_handler_extension->version >= 2 &&
+      crash_handler_extension->SetString) {
+    crash_handler_extension->SetString("list-of-hung-threads",
+                                       list_of_hung_thread_ids.c_str());
+    crash_handler_extension->SetString(
+        "seconds-since-last-resume",
+        GetTimeSinceLastSystemPowerResumeCrashKeyValue().c_str());
+    crash_handler_extension->SetString(
+        "shutting-down",
+        g_shutting_down.load(std::memory_order_relaxed) ? "true" : "false");
+  }
+#endif
 #endif
 
   // To avoid capturing more than one hang that blames a subset of the same

--- a/cobalt/app/cobalt_main_delegate.cc
+++ b/cobalt/app/cobalt_main_delegate.cc
@@ -36,7 +36,7 @@
 #include "content/public/gpu/content_gpu_client.h"
 #include "content/public/renderer/content_renderer_client.h"
 
-#if BUILDFLAG(IS_ANDROIDTV)
+#if BUILDFLAG(IS_STARBOARD) || BUILDFLAG(IS_ANDROIDTV)
 #include "cobalt/browser/hang_watcher_delegate_impl.h"
 #endif
 #include "cobalt/app/cobalt_crash_reporter_client.h"
@@ -57,6 +57,13 @@
 #include "base/base_switches.h"
 #include "v8/include/v8-wasm-trap-handler-posix.h"
 #endif
+
+#if BUILDFLAG(IS_STARBOARD)
+#include "base/debug/dump_without_crashing.h"
+#include "starboard/extension/crash_handler.h"
+#include "starboard/system.h"
+#endif
+
 namespace cobalt {
 
 CobaltMainDelegate::CobaltMainDelegate(
@@ -130,7 +137,7 @@ std::optional<int> CobaltMainDelegate::PostEarlyInitialization(
     content::InitializeMojoCore();
   }
 
-#if BUILDFLAG(IS_ANDROIDTV)
+#if BUILDFLAG(IS_STARBOARD) || BUILDFLAG(IS_ANDROIDTV)
   // This delegate is for reading the flag value.
   cobalt::browser::CobaltHangWatcherDelegate::Initialize();
 #endif
@@ -255,5 +262,20 @@ void CobaltMainDelegate::InitializeHangWatcher() {
 
   base::HangWatcher::InitializeOnMainThread(hang_watcher_process_type,
                                             emit_crashes);
+
+#if BUILDFLAG(IS_STARBOARD)
+  auto* crash_handler_extension =
+      static_cast<const CobaltExtensionCrashHandlerApi*>(
+          SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
+  if (crash_handler_extension && crash_handler_extension->version >= 4 &&
+      crash_handler_extension->DumpWithoutCrashing) {
+    // For Evergreen builds we do not currently link the Crashpad client
+    // library into the hermetic libcobalt shared library. So, we leverage a
+    // Starboard extension to tunnel the request for Crashpad to dump without
+    // crashing.
+    base::debug::SetDumpWithoutCrashingFunction(
+        crash_handler_extension->DumpWithoutCrashing);
+  }
+#endif
 }
 }  // namespace cobalt

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -159,7 +159,7 @@ source_set("global_features") {
   ]
 }
 
-if (is_androidtv) {
+if (is_starboard || is_androidtv) {
   source_set("hang_watcher_delegate") {
     sources = [
       "hang_watcher_delegate_impl.cc",

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -184,10 +184,11 @@ group("cobalt_shell_lib_deps") {
   }
 
   if (is_androidtv) {
-    public_deps += [
-      "//cobalt/android/oom_intervention",
-      "//cobalt/browser:hang_watcher_delegate",
-    ]
+    public_deps += [ "//cobalt/android/oom_intervention" ]
+  }
+
+  if (is_starboard || is_androidtv) {
+    public_deps += [ "//cobalt/browser:hang_watcher_delegate" ]
   }
 }
 

--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -34,6 +34,7 @@
 #include "starboard/extension/loader_app_metrics.h"
 #include "starboard/system.h"
 #include "third_party/crashpad/crashpad/snapshot/sanitized/sanitization_information.h"
+#include "util/misc/capture_context.h"
 
 using starboard::kSystemPropertyMaxLength;
 
@@ -284,9 +285,15 @@ void InstallCrashpadHandler(const std::string& ca_certificates_path) {
   auto crash_handler_extension =
       static_cast<const CobaltExtensionCrashHandlerApi*>(
           SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
-  if (crash_handler_extension && crash_handler_extension->version >= 3) {
+  if (crash_handler_extension && crash_handler_extension->version >= 3 &&
+      crash_handler_extension->RegisterSetStringCallback) {
     crash_handler_extension->RegisterSetStringCallback(
         &InsertCrashpadAnnotation);
+  }
+  if (crash_handler_extension && crash_handler_extension->version >= 4 &&
+      crash_handler_extension->RegisterDumpWithoutCrashingCallback) {
+    crash_handler_extension->RegisterDumpWithoutCrashingCallback(
+        &DumpWithoutCrashingWrapper);
   }
 
   RecordStatus(CrashpadInstallationStatus::kSucceeded);
@@ -300,6 +307,12 @@ bool AddEvergreenInfoToCrashpad(EvergreenInfo evergreen_info) {
 bool InsertCrashpadAnnotation(const char* key, const char* value) {
   ::crashpad::CrashpadClient* client = GetCrashpadClient();
   return client->InsertAnnotationForHandler(key, value);
+}
+
+void DumpWithoutCrashingWrapper() {
+  ::crashpad::NativeCPUContext context;
+  ::crashpad::CaptureContext(&context);
+  ::crashpad::CrashpadClient::DumpWithoutCrash(&context);
 }
 
 }  // namespace crashpad

--- a/starboard/crashpad_wrapper/wrapper.h
+++ b/starboard/crashpad_wrapper/wrapper.h
@@ -48,6 +48,9 @@ bool AddEvergreenInfoToCrashpad(EvergreenInfo evergreen_info);
 // key. Returns true on success and false on failure.
 bool InsertCrashpadAnnotation(const char* key, const char* value);
 
+// Captures CPU context and triggers a non-crashing dump report.
+void DumpWithoutCrashingWrapper();
+
 }  // namespace crashpad
 
 #endif  // STARBOARD_CRASHPAD_WRAPPER_WRAPPER_H_

--- a/starboard/extension/crash_handler.h
+++ b/starboard/extension/crash_handler.h
@@ -59,6 +59,15 @@ typedef struct CobaltExtensionCrashHandlerApi {
   // injected dependency to implement |SetString|, does not expect this function
   // to be called.
   void (*RegisterSetStringCallback)(SetStringCallback callback);
+
+  // The fields below this point were added in version 4 or later.
+
+  // Triggers a non-crashing dump/hang report.
+  void (*DumpWithoutCrashing)();
+
+  // Registers the provided callback to be called by the extension's
+  // |DumpWithoutCrashing| implementation.
+  void (*RegisterDumpWithoutCrashingCallback)(void (*callback)());
 } CobaltExtensionCrashHandlerApi;
 
 #ifdef __cplusplus

--- a/starboard/nplb/nplb_evergreen_compat_tests/crashpad_config_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/crashpad_config_test.cc
@@ -53,9 +53,17 @@ TEST(CrashpadConfigTest, VerifyUploadCert) {
 #endif  // !defined(ANDROID)
 
 TEST(CrashpadConfigTest, VerifyCrashHandlerExtension) {
-  auto crash_handler_extension =
-      SbSystemGetExtension(kCobaltExtensionCrashHandlerName);
+  auto* crash_handler_extension =
+      static_cast<const CobaltExtensionCrashHandlerApi*>(
+          SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
   ASSERT_TRUE(crash_handler_extension != nullptr);
+  EXPECT_STREQ(crash_handler_extension->name, kCobaltExtensionCrashHandlerName);
+  EXPECT_GE(crash_handler_extension->version, 4u);
+  EXPECT_TRUE(crash_handler_extension->SetString != nullptr);
+  EXPECT_TRUE(crash_handler_extension->RegisterSetStringCallback != nullptr);
+  EXPECT_TRUE(crash_handler_extension->DumpWithoutCrashing != nullptr);
+  EXPECT_TRUE(crash_handler_extension->RegisterDumpWithoutCrashingCallback !=
+              nullptr);
 }
 
 }  // namespace

--- a/starboard/shared/starboard/crash_handler.cc
+++ b/starboard/shared/starboard/crash_handler.cc
@@ -28,6 +28,10 @@ namespace {
 SetStringCallback g_set_string_callback = nullptr;
 pthread_mutex_t g_set_string_callback_mutex = PTHREAD_MUTEX_INITIALIZER;
 
+void (*g_dump_without_crashing_callback)() = nullptr;
+pthread_mutex_t g_dump_without_crashing_callback_mutex =
+    PTHREAD_MUTEX_INITIALIZER;
+
 bool OverrideCrashpadAnnotations(CrashpadAnnotations* crashpad_annotations) {
   return false;  // Deprecated
 }
@@ -50,10 +54,25 @@ void RegisterSetStringCallback(SetStringCallback callback) {
   SB_CHECK_EQ(pthread_mutex_unlock(&g_set_string_callback_mutex), 0);
 }
 
+void DumpWithoutCrashing() {
+  SB_CHECK_EQ(pthread_mutex_lock(&g_dump_without_crashing_callback_mutex), 0);
+  if (g_dump_without_crashing_callback) {
+    g_dump_without_crashing_callback();
+  }
+  SB_CHECK_EQ(pthread_mutex_unlock(&g_dump_without_crashing_callback_mutex), 0);
+}
+
+void RegisterDumpWithoutCrashingCallback(void (*callback)()) {
+  SB_CHECK_EQ(pthread_mutex_lock(&g_dump_without_crashing_callback_mutex), 0);
+  g_dump_without_crashing_callback = callback;
+  SB_CHECK_EQ(pthread_mutex_unlock(&g_dump_without_crashing_callback_mutex), 0);
+}
+
 const CobaltExtensionCrashHandlerApi kCrashHandlerApi = {
-    kCobaltExtensionCrashHandlerName, 3,
-    &OverrideCrashpadAnnotations,     &SetString,
-    &RegisterSetStringCallback,
+    kCobaltExtensionCrashHandlerName,     4,
+    &OverrideCrashpadAnnotations,         &SetString,
+    &RegisterSetStringCallback,           &DumpWithoutCrashing,
+    &RegisterDumpWithoutCrashingCallback,
 };
 
 }  // namespace


### PR DESCRIPTION
Taking over PR #10770 to build out the full 3P Hangwatcher stack. Co-authored by @hlwarriner.

There are a couple key differences vs. the approach used by 1P ATV:
* The CrashHandler Starboard extension is used as a bridge to enable the hermetically built Cobalt layer to request that Crashpad generate a dump without crashing. This is required because the Crashpad client library is not linked into libcobalt. The Starboard extension is extended to provide this additional functionality.
* Because Evergreen builds do not support the crash key system from Chromium, the CrashHandler Starboard extension is used to pass the critical list-of-hung-threads annotation from the Cobalt layer to the Crashpad handler.

Issue: 513671861