### PR TITLE
aosp: Fix deprecated declaration warnings

### DIFF
--- a/starboard/common/file.cc
+++ b/starboard/common/file.cc
@@ -183,18 +183,14 @@ bool SbFileDeleteRecursive(const char* path, bool preserve_root) {
 
   std::vector<char> entry(kSbFileMaxName);
 
-  struct dirent dirent_buffer;
   struct dirent* dirent;
   while (true) {
     if (entry.size() < static_cast<size_t>(kSbFileMaxName) || !dir ||
         !entry.data()) {
       break;
     }
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
-    int result = readdir_r(dir, &dirent_buffer, &dirent);
-#pragma GCC diagnostic pop
-    if (result || !dirent) {
+    dirent = readdir(dir);
+    if (!dirent) {
       break;
     }
     starboard::strlcpy(entry.data(), dirent->d_name, kSbFileMaxName);

--- a/starboard/loader_app/app_key_files.cc
+++ b/starboard/loader_app/app_key_files.cc
@@ -103,10 +103,8 @@ bool AnyGoodAppKeyFile(const std::string& dir) {
       break;
     }
 
-    struct dirent dirent_buffer;
-    struct dirent* dirent;
-    int result = readdir_r(directory, &dirent_buffer, &dirent);
-    if (result || !dirent) {
+    struct dirent* dirent = readdir(directory);
+    if (!dirent) {
       break;
     }
 

--- a/starboard/loader_app/drain_file.cc
+++ b/starboard/loader_app/drain_file.cc
@@ -93,10 +93,8 @@ std::vector<std::string> FindAllWithPrefix(const std::string& dir,
     if (filename.size() < kSbFileMaxName || !directory || !filename.data()) {
       break;
     }
-    struct dirent dirent_buffer;
-    struct dirent* dirent;
-    int result = readdir_r(directory, &dirent_buffer, &dirent);
-    if (result || !dirent) {
+    struct dirent* dirent = readdir(directory);
+    if (!dirent) {
       break;
     }
     starboard::strlcpy(filename.data(), dirent->d_name, filename.size());

--- a/starboard/loader_app/installation_manager.cc
+++ b/starboard/loader_app/installation_manager.cc
@@ -586,13 +586,13 @@ int InstallationManager::RequestRollForwardToInstallation(
 bool InstallationManager::SaveInstallationStore() {
   ValidatePriorities();
 
-  if (IM_MAX_INSTALLATION_STORE_SIZE < installation_store_.ByteSize()) {
+  if (IM_MAX_INSTALLATION_STORE_SIZE < installation_store_.ByteSizeLong()) {
     SB_LOG(ERROR) << "SaveInstallationStore: Data too large"
-                  << installation_store_.ByteSize();
+                  << installation_store_.ByteSizeLong();
     return false;
   }
 
-  const size_t buf_size = installation_store_.ByteSize();
+  const size_t buf_size = installation_store_.ByteSizeLong();
   std::vector<char> buf(buf_size, 0);
 
   int result = installation_store_.roll_forward_to_installation();
@@ -601,10 +601,10 @@ bool InstallationManager::SaveInstallationStore() {
 #endif
 
   installation_store_.SerializeToArray(buf.data(),
-                                       installation_store_.ByteSize());
+                                       installation_store_.ByteSizeLong());
 
   if (!starboard::FileAtomicReplace(store_path_.c_str(), buf.data(),
-                                    installation_store_.ByteSize())) {
+                                    installation_store_.ByteSizeLong())) {
     SB_LOG(ERROR)
         << "SaveInstallationStore: Failed to store installation store: "
         << store_path_;


### PR DESCRIPTION
Fix the last deprecation warnings that prevent to build loader_app on AOSP. Replace readdir_r with readdir and MessageLite::ByteSize with ByteSizeLong.

Bug: 495203133