### PR TITLE
aosp: Make devil_util_bin depend on //starboard:starboard_group

### DIFF
--- a/tools/android/devil_util/BUILD.gn
+++ b/tools/android/devil_util/BUILD.gn
@@ -51,4 +51,12 @@ executable("devil_util_bin") {
     "//third_party/zstd:compress",
     "//third_party/zstd:decompress",
   ]
+
+  if (is_android && is_starboard) {
+    # TODO(crbug.com/509811765): to avoid a circular dependency, on AOSP //base
+    # doesn't depend on starboard_group, just on starboard_headers_only.
+    # We need to explicitly depend on starboard_group to supply the missing
+    # Starboard symbols that //base uses.
+    deps += [ "//starboard:starboard_group" ]
+  }
 }


### PR DESCRIPTION
devil_util_bin links //base, which on the AOSP device toolchain resolves to //copied_base/base. There, to avoid a circular dependency (the AOSP Starboard layer depends back on //base), //copied_base/base depends only on //starboard:starboard_headers_only instead of starboard_group, which leaves base's Starboard symbols undefined. The final executable must supply them, so depend on starboard_group here.

Bug: 509811765