### PR TITLE
build: generate JNI / native-library list files via gen_deps

### DIFF
--- a/build/config/android/rules.gni
+++ b/build/config/android/rules.gni
@@ -441,7 +441,7 @@ if (!is_robolectric && enable_java_templates) {
     }
 
     action_with_pydeps(target_name) {
-      forward_variables_from(invoker, TESTONLY_AND_VISIBILITY + [ "deps" ])
+      forward_variables_from(invoker, TESTONLY_AND_VISIBILITY + [ "deps", "gen_deps" ])
       script = "//build/android/gyp/write_native_libraries_java.py"
       outputs = [ _native_libraries_file ]
       args = [
@@ -2684,8 +2684,11 @@ if (!is_robolectric && enable_java_templates) {
         } else if (defined(_use_secondary_abi)) {
           if (_use_secondary_abi) {
             native_libraries_list_file = _secondary_abi_shared_library_list_file
+            gen_deps =
+                [ ":${_template_name}__secondary_abi_shared_library_list" ]
           } else {
             native_libraries_list_file = _shared_library_list_file
+            gen_deps = [ ":${_template_name}__shared_library_list" ]
           }
         }
 

--- a/third_party/jni_zero/jni_zero.gni
+++ b/third_party/jni_zero/jni_zero.gni
@@ -179,6 +179,13 @@ template("generate_jni_registration") {
   }
 
   _invoke_jni_zero(target_name) {
+    gen_deps = [ ":${target_name}__java_sources" ]
+    if (defined(_native_sources_list)) {
+      gen_deps += [ ":${target_name}__native_sources" ]
+    }
+    if (defined(_priority_java_sources_list)) {
+      gen_deps += [ ":${target_name}__priority_java_sources" ]
+    }
     # Cannot depend on jni_sources_list targets since they likely depend on
     # this target via srcjar_deps. Depfiles are used to add the dep instead.
     deps = []


### PR DESCRIPTION
The jni_sources_list and *_shared_library_list targets are generated_file targets whose list-file outputs are written at `gn gen` time via a metadata walk. They are not added to `deps`: a dep on the native-libs list would force building the .so before this action (the depfile captures the real dep instead), and a dep on the jni_sources_list targets would be circular (they depend back via srcjar_deps). In the default toolchain this is fine since those targets are already generated and their outputs written.

In AOSP, Android is a secondary toolchain, so a generated_file there is only written if something pulls it into generation. gen_deps forces that without adding a build-time dep.

The changes to _invoke_jni_zero are also present upstream since https://crrev.com/c/7168943.

Bug: 495203133