### PR TITLE
aosp: Use android_toolchain in missing places (#10178)

### DIFF
--- a/build/config/android/BUILD.gn
+++ b/build/config/android/BUILD.gn
@@ -6,8 +6,9 @@ import("//build/config/android/rules.gni")
 import("//build/config/c++/c++.gni")
 import("//build/config/compiler/compiler.gni")
 import("//build/config/sanitizers/sanitizers.gni")
+import("//starboard/build/config/android_toolchain.gni")
 
-if (current_toolchain == default_toolchain) {
+if (current_toolchain == android_toolchain) {
   import("//build/toolchain/concurrent_links.gni")
 }
 
@@ -137,7 +138,7 @@ config("default_orderfile_instrumentation") {
   }
 }
 
-if (current_toolchain == default_toolchain) {
+if (current_toolchain == android_toolchain) {
   # nocompile tests share output directory to avoid them all needing to rebuild
   # things. But this also means they can't run in parallel.
   pool("nocompile_pool") {

--- a/build/config/android/internal_rules.gni
+++ b/build/config/android/internal_rules.gni
@@ -14,7 +14,8 @@ import("//build/config/sanitizers/sanitizers.gni")
 import("//build/toolchain/kythe.gni")
 import("//build/util/generate_wrapper.gni")
 import("//build_overrides/build.gni")
-if (current_toolchain == default_toolchain) {
+import("//starboard/build/config/android_toolchain.gni")
+if (current_toolchain == android_toolchain) {
   import("//build/toolchain/concurrent_links.gni")
 }
 assert(is_android)
@@ -128,7 +129,7 @@ template("write_build_config") {
   _inputs = [ _params_file ]
   _deps = []
 
-  if (current_toolchain == default_toolchain) {
+  if (current_toolchain == android_toolchain) {
     _type = invoker.type
 
     # Ensure targets match naming patterns so that __assetres, __header, __host,
@@ -154,7 +155,7 @@ template("write_build_config") {
     _target_label = invoker.public_target_label
   }
 
-  if (current_toolchain != default_toolchain) {
+  if (current_toolchain != android_toolchain) {
     not_needed(invoker, "*")
     _params = {
       # This has to be a build-time error rather than a GN assert because many
@@ -172,7 +173,7 @@ template("write_build_config") {
         "Tried to build an Android target in a non-default toolchain.",
         "target: $_target_label",
         "current_toolchain: $current_toolchain",
-        "default_toolchain: $default_toolchain",
+        "android_toolchain: $android_toolchain",
       ]
     }
   } else {
@@ -940,9 +941,9 @@ if (enable_java_templates) {
 
       # https://crbug.com/1098752 Fix for bot OOM (https://crbug.com/1098333).
       if (defined(java_cmd_pool_size)) {
-        pool = "//build/config/android:java_cmd_pool($default_toolchain)"
+        pool = "//build/config/android:java_cmd_pool($android_toolchain)"
       } else {
-        pool = "//build/toolchain:link_pool($default_toolchain)"
+        pool = "//build/toolchain:link_pool($android_toolchain)"
       }
 
       # Lint requires generated sources and generated resources from the build.
@@ -1373,9 +1374,9 @@ if (enable_java_templates) {
 
       # http://crbug.com/725224. Fix for bots running out of memory.
       if (defined(java_cmd_pool_size)) {
-        pool = "//build/config/android:java_cmd_pool($default_toolchain)"
+        pool = "//build/config/android:java_cmd_pool($android_toolchain)"
       } else {
-        pool = "//build/toolchain:link_pool($default_toolchain)"
+        pool = "//build/toolchain:link_pool($android_toolchain)"
       }
     }
 
@@ -1563,9 +1564,9 @@ if (enable_java_templates) {
         if (!_is_library) {
           # http://crbug.com/725224. Fix for bots running out of memory.
           if (defined(java_cmd_pool_size)) {
-            pool = "//build/config/android:java_cmd_pool($default_toolchain)"
+            pool = "//build/config/android:java_cmd_pool($android_toolchain)"
           } else {
-            pool = "//build/toolchain:link_pool($default_toolchain)"
+            pool = "//build/toolchain:link_pool($android_toolchain)"
           }
         }
 
@@ -2295,7 +2296,7 @@ if (enable_java_templates) {
     if (defined(invoker.emit_ids_out_path)) {
       _outputs += [ invoker.emit_ids_out_path ]
       _rebased_emit_ids_path =
-          rebase_path(invoker.emit_ids_out_path, root_out_dir)
+          rebase_path(invoker.emit_ids_out_path, root_build_dir)
       _args += [ "--emit-ids-out=$_rebased_emit_ids_path" ]
     }
 

--- a/build/toolchain/concurrent_links.gni
+++ b/build/toolchain/concurrent_links.gni
@@ -5,7 +5,9 @@
 # This file should only be imported from files that define toolchains.
 # There's no way to enforce this exactly, but all toolchains are processed
 # in the context of the default_toolchain, so we can at least check for that.
-assert(current_toolchain == default_toolchain)
+import("//starboard/build/config/android_toolchain.gni")
+assert(current_toolchain == default_toolchain ||
+       current_toolchain == android_toolchain)
 
 import("//build/config/android/config.gni")
 import("//build/config/apple/symbols.gni")


### PR DESCRIPTION
Replace `default_toolchain` with `android_toolchain` in several more places. This is a follow-up of
https://github.com/youtube/cobalt/pull/9923 and
https://github.com/youtube/cobalt/pull/10178, where these changes were missing.

Bug: 495203133