### PR TITLE
copied_base: add RecordHistogram.recordMemoryMediumMBHistogram

### DIFF
--- a/copied_base/base/android/java/src/org/chromium/base/metrics/RecordHistogram.java
+++ b/copied_base/base/android/java/src/org/chromium/base/metrics/RecordHistogram.java
@@ -229,6 +229,19 @@ public class RecordHistogram {
     }
 
     /**
+     * Records a sample in a histogram of sizes in MB. This is the Java equivalent of the
+     * UMA_HISTOGRAM_MEMORY_MEDIUM_MB C++ macro.
+     * <p>
+     * Good for sizes up to about 4000MB.
+     *
+     * @param name name of the histogram
+     * @param sizeInMB Sample to record in MB
+     */
+    public static void recordMemoryMediumMBHistogram(String name, int sizeInMB) {
+        UmaRecorderHolder.get().recordExponentialHistogram(name, sizeInMB, 1, 4000, 100);
+    }
+
+    /**
      * Records a sample in a linear histogram where each bucket in range {@code [0, max)} counts
      * exactly a single value.
      *


### PR DESCRIPTION
Fix a build error on AOSP, where MediaCodecOutputTracker.java depends on this method.

Bug: 495203133