### PR TITLE
Define STARBOARD only on starboard platforms

### DIFF
--- a/media/starboard/starboard_utils_test.cc
+++ b/media/starboard/starboard_utils_test.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#if !defined(STARBOARD)
+#if !defined(ENABLE_BUILDFLAG_IS_COBALT)
 #error "This file only works with Cobalt/Starboard."
 #endif  // !defined(STARBOARD)
 

--- a/starboard/build/config/BUILD.gn
+++ b/starboard/build/config/BUILD.gn
@@ -20,9 +20,11 @@ import("//starboard/build/config/toolchain_variables.gni")
 config("starboard") {
   if (is_starboardized_toolchain) {
     defines = [
-      "STARBOARD",
       "COBALT",  # TODO: See if this can be replaced by STARBOARD macro.
     ]
+    if (is_starboard) {
+      defines += [ "STARBOARD" ]
+    }
 
     if (!is_gold) {
       defines += [


### PR DESCRIPTION
Also updates a media test that incorrectly depends on a STARBOARD instead of COBALT define.

Fixed: 527881052