### PR TITLE
gpu/media: Fix file descriptor exhaustion during long playback

### DIFF
--- a/cobalt/renderer/BUILD.gn
+++ b/cobalt/renderer/BUILD.gn
@@ -14,6 +14,26 @@
 import("//starboard/build/buildflags.gni")
 import("//testing/test.gni")
 
+# Android keeps the discardable-segment fd open past Map() (ashmem
+# Lock()/Unlock() ioctls), so it uses upstream
+# ClientDiscardableSharedMemoryManager directly and does not build this
+# subclass. See cobalt/renderer/cobalt_discardable_shared_memory_manager.cc.
+if (!is_android) {
+  source_set("discardable_memory") {
+    sources = [
+      "cobalt_discardable_shared_memory_manager.cc",
+      "cobalt_discardable_shared_memory_manager.h",
+    ]
+
+    deps = [
+      "//base",
+      "//components/discardable_memory/client",
+      "//components/discardable_memory/public/mojom",
+      "//mojo/public/cpp/bindings",
+    ]
+  }
+}
+
 source_set("renderer") {
   sources = [
     "cobalt_content_renderer_client.cc",

--- a/cobalt/renderer/cobalt_discardable_shared_memory_manager.cc
+++ b/cobalt/renderer/cobalt_discardable_shared_memory_manager.cc
@@ -1,0 +1,107 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/renderer/cobalt_discardable_shared_memory_manager.h"
+
+#include <stdint.h>
+
+#include <memory>
+#include <utility>
+
+#include "base/memory/discardable_shared_memory.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/task/single_thread_task_runner.h"
+#include "components/discardable_memory/client/client_discardable_shared_memory_manager.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+
+namespace cobalt {
+
+namespace {
+
+// Closes each discardable segment's /dev/shm file descriptor right after it
+// is mapped, mirroring what the in-process and service-for-remote-client
+// allocation paths in ClientDiscardableSharedMemoryManager already do.
+// Otherwise the fd is unused dead weight that accumulates one fd per live
+// discardable segment, bounded only by a byte budget rather than an fd count,
+// until RLIMIT_NOFILE is exhausted during a long-running session (e.g. the
+// YTLR Browse-and-Watch endurance run).
+//
+// This subclass is built only on non-Android Starboard targets. Android needs
+// the fd kept open past Map() (Lock()/Unlock() use ashmem ioctls on it), so it
+// uses upstream ClientDiscardableSharedMemoryManager directly and is excluded
+// at the build level (see content/renderer/discardable_memory_utils.cc,
+// content/renderer/BUILD.gn and cobalt/renderer/BUILD.gn).
+//
+// Lifetime and ownership: ref-counted (via base::RefCountedDeleteOnSequence,
+// inherited from the base class) and created exclusively through
+// CreateCobaltDiscardableSharedMemoryManager(), which is called once by
+// content::CreateDiscardableMemoryAllocator() when the renderer process sets
+// up its discardable memory allocator. The returned scoped_refptr is held by
+// that allocator for as long as the renderer process needs discardable
+// memory, i.e. for the lifetime of the process; there is no other owner and
+// no expectation of being constructed or destroyed more than once.
+//
+// Threading model: inherits the base class's threading model unchanged —
+// safe to call from any thread, with the actual IPC and shared-memory
+// allocation work for AllocateLockedDiscardableSharedMemory() performed on
+// |io_task_runner|. This subclass only adds a synchronous Close() call after
+// the base implementation returns, on the same thread/sequence the base
+// class already runs that allocation on, so no new threading considerations
+// are introduced.
+class CobaltDiscardableSharedMemoryManager
+    : public discardable_memory::ClientDiscardableSharedMemoryManager {
+ public:
+  CobaltDiscardableSharedMemoryManager(
+      mojo::PendingRemote<
+          discardable_memory::mojom::DiscardableSharedMemoryManager> manager,
+      scoped_refptr<base::SingleThreadTaskRunner> io_task_runner)
+      : discardable_memory::ClientDiscardableSharedMemoryManager(
+            std::move(manager),
+            std::move(io_task_runner)) {}
+
+  CobaltDiscardableSharedMemoryManager(
+      const CobaltDiscardableSharedMemoryManager&) = delete;
+  CobaltDiscardableSharedMemoryManager& operator=(
+      const CobaltDiscardableSharedMemoryManager&) = delete;
+
+ protected:
+  ~CobaltDiscardableSharedMemoryManager() override = default;
+
+ private:
+  std::unique_ptr<base::DiscardableSharedMemory>
+  AllocateLockedDiscardableSharedMemory(size_t size, int32_t id) override {
+    std::unique_ptr<base::DiscardableSharedMemory> memory =
+        discardable_memory::ClientDiscardableSharedMemoryManager::
+            AllocateLockedDiscardableSharedMemory(size, id);
+
+    if (memory) {
+      memory->Close();
+    }
+
+    return memory;
+  }
+};
+
+}  // namespace
+
+scoped_refptr<discardable_memory::ClientDiscardableSharedMemoryManager>
+CreateCobaltDiscardableSharedMemoryManager(
+    mojo::PendingRemote<
+        discardable_memory::mojom::DiscardableSharedMemoryManager> manager,
+    scoped_refptr<base::SingleThreadTaskRunner> io_task_runner) {
+  return base::MakeRefCounted<CobaltDiscardableSharedMemoryManager>(
+      std::move(manager), std::move(io_task_runner));
+}
+
+}  // namespace cobalt

--- a/cobalt/renderer/cobalt_discardable_shared_memory_manager.h
+++ b/cobalt/renderer/cobalt_discardable_shared_memory_manager.h
@@ -1,0 +1,36 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_RENDERER_COBALT_DISCARDABLE_SHARED_MEMORY_MANAGER_H_
+#define COBALT_RENDERER_COBALT_DISCARDABLE_SHARED_MEMORY_MANAGER_H_
+
+#include "base/memory/scoped_refptr.h"
+#include "base/task/single_thread_task_runner.h"
+#include "components/discardable_memory/client/client_discardable_shared_memory_manager.h"
+#include "components/discardable_memory/public/mojom/discardable_shared_memory_manager.mojom.h"
+#include "mojo/public/cpp/bindings/pending_remote.h"
+
+namespace cobalt {
+
+// Creates a ClientDiscardableSharedMemoryManager that closes each segment's
+// fd right after Map(), see cobalt_discardable_shared_memory_manager.cc.
+scoped_refptr<discardable_memory::ClientDiscardableSharedMemoryManager>
+CreateCobaltDiscardableSharedMemoryManager(
+    mojo::PendingRemote<
+        discardable_memory::mojom::DiscardableSharedMemoryManager> manager,
+    scoped_refptr<base::SingleThreadTaskRunner> io_task_runner);
+
+}  // namespace cobalt
+
+#endif  // COBALT_RENDERER_COBALT_DISCARDABLE_SHARED_MEMORY_MANAGER_H_

--- a/components/discardable_memory/client/client_discardable_shared_memory_manager.h
+++ b/components/discardable_memory/client/client_discardable_shared_memory_manager.h
@@ -161,9 +161,14 @@ class DISCARDABLE_MEMORY_EXPORT ClientDiscardableSharedMemoryManager
   void ScheduledPurge(base::MemoryReductionTaskContext task_type)
       LOCKS_EXCLUDED(lock_);
 
-  // This is only virtual for testing.
+  // Protected (not private) so that platform-specific subclasses can call
+  // the base implementation from an override. This is also virtual for
+  // testing.
+ protected:
   virtual std::unique_ptr<base::DiscardableSharedMemory>
   AllocateLockedDiscardableSharedMemory(size_t size, int32_t id);
+
+ private:
   void AllocateOnIO(size_t size,
                     int32_t id,
                     base::UnsafeSharedMemoryRegion* region,

--- a/content/renderer/BUILD.gn
+++ b/content/renderer/BUILD.gn
@@ -332,9 +332,13 @@ target(link_target_type, "renderer") {
   allow_circular_includes_from = []
 
   if (is_cobalt) {
-    deps += [
-      "//cobalt/media/audio:audio_decoder",
-    ]
+    deps += [ "//cobalt/media/audio:audio_decoder" ]
+
+    # The Cobalt discardable memory subclass is non-Android only; Android uses
+    # upstream ClientDiscardableSharedMemoryManager directly.
+    if (!is_android) {
+      deps += [ "//cobalt/renderer:discardable_memory" ]
+    }
   }
 
   if (is_android) {

--- a/content/renderer/discardable_memory_utils.cc
+++ b/content/renderer/discardable_memory_utils.cc
@@ -7,8 +7,13 @@
 #include <utility>
 
 #include "base/memory/discardable_memory.h"
+#include "build/build_config.h"
 #include "content/child/child_process.h"
 #include "content/child/child_thread_impl.h"
+
+#if BUILDFLAG(IS_COBALT) && !BUILDFLAG(IS_ANDROID)
+#include "cobalt/renderer/cobalt_discardable_shared_memory_manager.h"
+#endif
 
 namespace content {
 
@@ -20,9 +25,14 @@ CreateDiscardableMemoryAllocator() {
       manager_remote;
   ChildThread::Get()->BindHostReceiver(
       manager_remote.InitWithNewPipeAndPassReceiver());
+#if BUILDFLAG(IS_COBALT) && !BUILDFLAG(IS_ANDROID)
+  return cobalt::CreateCobaltDiscardableSharedMemoryManager(
+      std::move(manager_remote), ChildProcess::current()->io_task_runner());
+#else
   return base::MakeRefCounted<
       discardable_memory::ClientDiscardableSharedMemoryManager>(
       std::move(manager_remote), ChildProcess::current()->io_task_runner());
+#endif
 }
 
 }  // namespace content

--- a/gpu/command_buffer/service/gles2_cmd_decoder_passthrough.h
+++ b/gpu/command_buffer/service/gles2_cmd_decoder_passthrough.h
@@ -576,8 +576,18 @@ class GPU_GLES2_EXPORT GLES2DecoderPassthroughImpl
   };
 
   // Use a limit that is at least ANGLE's IMPLEMENTATION_MAX_ACTIVE_TEXTURES
-  // constant
+  // constant.
+#if BUILDFLAG(IS_STARBOARD)
+  // Starboard/RDK reaches this decoder through ANGLE's GL backend over the
+  // native GLES driver (e.g. Mali), which advertises a GLES 3.2 combined
+  // GL_MAX_COMBINED_TEXTURE_IMAGE_UNITS of 96 -- above the upstream limit of
+  // 64, so context init fails and forces a new media GPU context (and leaked
+  // command buffer) per video. 96 is also ANGLE's own ceiling for this value
+  // (IMPLEMENTATION_MAX_ACTIVE_TEXTURES), so it can never report more.
+  static constexpr size_t kMaxTextureUnits = 96;
+#else
   static constexpr size_t kMaxTextureUnits = 64;
+#endif
   static constexpr size_t kNumTextureTypes =
       static_cast<size_t>(TextureTarget::kCount);
   std::array<std::array<BoundTexture, kMaxTextureUnits>, kNumTextureTypes>


### PR DESCRIPTION
Prevent `/dev/shm` file descriptor exhaustion on Starboard platforms during long-running playback sessions. The issue was primarily caused by the Mali GL driver exceeding the passthrough decoder's texture unit limit, leading to frequent context loss and leaked command buffers.

To address this, increase the maximum texture units for Starboard, ensure the codec factory releases its reference to the context provider when the context is destroyed, and close discardable shared memory file descriptors immediately after mapping. Together, these changes ensure descriptors are reclaimed and prevent `EMFILE` crashes on resource-constrained devices.

Issue: 516807166
