### PR TITLE
starboard: make SbSystemGetLocaleId() honor its non-null contract

### DIFF
--- a/starboard/shared/posix/system_get_locale_id.cc
+++ b/starboard/shared/posix/system_get_locale_id.cc
@@ -41,5 +41,7 @@ const char* SbSystemGetLocaleId() {
     }
   }
 
-  return posix_id;
+  // Contract requires non-null (see system_get_locale_id_test.cc); callers
+  // crash on null (e.g. setenv() in environment.cc).
+  return posix_id ? posix_id : "";
 }

--- a/starboard/shared/stub/system_get_locale_id.cc
+++ b/starboard/shared/stub/system_get_locale_id.cc
@@ -15,5 +15,7 @@
 #include "starboard/system.h"
 
 const char* SbSystemGetLocaleId() {
-  return NULL;
+  // The Starboard contract (see starboard/nplb/system_get_locale_id_test.cc)
+  // requires a non-null return.
+  return "";
 }


### PR DESCRIPTION
The posix and stub implementations could return null, violating the
documented contract and crashing callers that don't guard it (e.g.
GetVoices() trapping under libc++ hardening, setenv() in
environment.cc). Return "" instead.

Issue: 516807166