### PR TITLE
starboard: Fix resource loading endurance leaks

### DIFF
--- a/third_party/blink/renderer/platform/loader/fetch/data_pipe_bytes_consumer.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/data_pipe_bytes_consumer.cc
@@ -7,6 +7,7 @@
 #include <algorithm>
 
 #include "base/containers/span.h"
+#include "build/build_config.h"
 #include "base/location.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/task/single_thread_task_runner.h"
@@ -50,7 +51,15 @@ DataPipeBytesConsumer::DataPipeBytesConsumer(
   watcher_.Watch(
       data_pipe_.get(),
       MOJO_HANDLE_SIGNAL_READABLE | MOJO_HANDLE_SIGNAL_PEER_CLOSED,
+#if BUILDFLAG(IS_STARBOARD)
+      // Weak self-reference so an abandoned consumer (e.g. a canceled media
+      // fetch dropped without Cancel()) can be garbage collected instead of
+      // being pinned alive forever, leaking its response-body data pipe's fd.
+      WTF::BindRepeating(&DataPipeBytesConsumer::Notify,
+                         WrapWeakPersistent(this)));
+#else
       WTF::BindRepeating(&DataPipeBytesConsumer::Notify, WrapPersistent(this)));
+#endif
 }
 
 DataPipeBytesConsumer::~DataPipeBytesConsumer() {}

--- a/third_party/blink/renderer/platform/loader/fetch/data_pipe_bytes_consumer.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/data_pipe_bytes_consumer.cc
@@ -136,9 +136,18 @@ BytesConsumer::Result DataPipeBytesConsumer::EndRead(size_t read) {
 
   if (has_pending_notification_) {
     has_pending_notification_ = false;
+#if BUILDFLAG(IS_STARBOARD)
+    // Same weak-reference reasoning as the constructor's watcher_.Watch():
+    // a strong Persistent here would re-pin an abandoned consumer for this
+    // task's lifetime. No-ops if the consumer is already collected.
+    task_runner_->PostTask(FROM_HERE,
+                           WTF::BindOnce(&DataPipeBytesConsumer::Notify,
+                                         WrapWeakPersistent(this), MOJO_RESULT_OK));
+#else
     task_runner_->PostTask(FROM_HERE,
                            WTF::BindOnce(&DataPipeBytesConsumer::Notify,
                                          WrapPersistent(this), MOJO_RESULT_OK));
+#endif
   }
   return Result::kOk;
 }

--- a/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_loader.cc
@@ -45,6 +45,7 @@
 #include "base/rand_util.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/unguessable_token.h"
+#include "build/build_config.h"
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "net/base/load_flags.h"
 #include "services/metrics/public/cpp/metrics_utils.h"
@@ -272,7 +273,11 @@ ResourceLoader::ResourceLoader(ResourceFetcher* fetcher,
       progress_receiver_(this, context),
       cancel_timer_(fetcher_->GetTaskRunner(),
                     this,
-                    &ResourceLoader::CancelTimerFired) {
+                    &ResourceLoader::CancelTimerFired),
+      deferred_finish_timeout_timer_(
+          fetcher_->GetTaskRunner(),
+          this,
+          &ResourceLoader::DeferredFinishTimeoutFired) {
   DCHECK(resource_);
   DCHECK(fetcher_);
 
@@ -308,6 +313,7 @@ void ResourceLoader::Trace(Visitor* visitor) const {
   visitor->Trace(response_body_loader_);
   visitor->Trace(data_pipe_completion_notifier_);
   visitor->Trace(cancel_timer_);
+  visitor->Trace(deferred_finish_timeout_timer_);
   visitor->Trace(progress_receiver_);
   ResourceLoadSchedulerClient::Trace(visitor);
 }
@@ -416,10 +422,31 @@ void ResourceLoader::DidFinishLoadingBody() {
 
   const ResourceResponse& response = resource_->GetResponse();
   if (deferred_finish_loading_info_) {
+    deferred_finish_timeout_timer_.Stop();
     DidFinishLoading(deferred_finish_loading_info_->response_end_time,
                      response.EncodedDataLength(), response.EncodedBodyLength(),
                      response.DecodedBodyLength());
   }
+}
+
+void ResourceLoader::DeferredFinishTimeoutFired(TimerBase*) {
+  if (!deferred_finish_loading_info_) {
+    return;
+  }
+  LOG(WARNING) << "ResourceLoader: force-finishing load stuck in deferred "
+                  "completion after timeout, url="
+               << resource_->Url().GetString().Utf8();
+  // Abort the body loader before forcing completion. has_seen_end_of_body_
+  // (set by DidFinishLoadingBody() below) already prevents DidFinishLoading()
+  // from re-deferring in this exact call chain, but leaving the loader
+  // un-aborted here means the underlying body drain is just dropped instead
+  // of explicitly torn down, unlike every other early-exit path in this file
+  // (HandleError(), Cancel(), etc.), which all call Abort() first.
+  if (response_body_loader_) {
+    response_body_loader_->Abort();
+    response_body_loader_ = nullptr;
+  }
+  DidFinishLoadingBody();
 }
 
 void ResourceLoader::DidFailLoadingBody() {
@@ -1169,6 +1196,13 @@ void ResourceLoader::DidFinishLoading(base::TimeTicks response_end_time,
     if (data_pipe_completion_notifier_) {
       data_pipe_completion_notifier_->SignalComplete();
     }
+
+#if BUILDFLAG(IS_STARBOARD)
+    // Some response bodies never get drained (e.g. unconsumed fetch()
+    // beacons), pinning this loader forever. Force-finish after a grace
+    // period; 5s is generous since we're only waiting on bytes already in.
+    deferred_finish_timeout_timer_.StartOneShot(base::Seconds(5), FROM_HERE);
+#endif
     return;
   }
 
@@ -1265,6 +1299,10 @@ void ResourceLoader::HandleError(const ResourceError& error) {
           false /* discard_duplicates */,
           mojom::blink::ConsoleMessageCategory::Cors);
     }
+  }
+
+  if (deferred_finish_loading_info_) {
+    deferred_finish_timeout_timer_.Stop();
   }
 
   Release(ResourceLoadScheduler::ReleaseOption::kReleaseAndSchedule,

--- a/third_party/blink/renderer/platform/loader/fetch/resource_loader.h
+++ b/third_party/blink/renderer/platform/loader/fetch/resource_loader.h
@@ -223,6 +223,7 @@ class PLATFORM_EXPORT ResourceLoader final
   void DidStartLoadingResponseBodyInternal(BytesConsumer& bytes_consumer);
 
   void CancelTimerFired(TimerBase*);
+  void DeferredFinishTimeoutFired(TimerBase*);
 
   void OnProgress(uint64_t delta) override;
   void FinishedCreatingBlob(const scoped_refptr<BlobDataHandle>&);
@@ -294,6 +295,10 @@ class PLATFORM_EXPORT ResourceLoader final
   bool defers_handling_data_url_ = false;
 
   HeapTaskRunnerTimer<ResourceLoader> cancel_timer_;
+
+  // See DeferredFinishTimeoutFired()'s rationale at the call site in
+  // resource_loader.cc.
+  HeapTaskRunnerTimer<ResourceLoader> deferred_finish_timeout_timer_;
 
   FrameScheduler::SchedulingAffectingFeatureHandle
       feature_handle_for_scheduler_;


### PR DESCRIPTION
Resolve memory and file descriptor leaks in the resource loading infrastructure that were identified during endurance testing.

`DataPipeBytesConsumer` was pinning itself as a garbage collector root through its mojo watcher and task runners. This caused abandoned fetches to leak data pipe file descriptors. Moving to weak references allows these objects to be garbage collected when no longer owned.

Additionally, `ResourceLoader` could remain pinned indefinitely if a response body was never consumed by the JavaScript layer. A 5-second timeout now ensures these deferred loads eventually complete, releasing the loader chain and associated resources.

Issue: 516807166