### PR TITLE
aosp: Add POSIX emulation for file operations

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -123,10 +123,6 @@ static_library("starboard_platform") {
     "android_media_session_client.cc",
     "application_android.cc",
     "application_android.h",
-
-    # TODO: b/374300500 - posix_emu things should not be used on Android anymore
-    # "asset_manager.cc",
-    # "asset_manager.h",
     "audio_decoder_passthrough.h",
     "audio_output_manager.cc",
     "audio_output_manager.h",
@@ -222,9 +218,7 @@ static_library("starboard_platform") {
     # TODO: b/374300500 - posix_emu things should not be used on Android anymore
     # "posix_emu/dirent.cc",
     # "posix_emu/errno.cc",
-    # "posix_emu/file.cc",
     # "posix_emu/pthread.cc",
-    # "posix_emu/stat.cc",
 
     "runtime_resource_overlay.cc",
     "runtime_resource_overlay.h",
@@ -333,6 +327,11 @@ static_library("starboard_platform") {
       "//starboard/shared/starboard/crash_handler.h",
       "//starboard/shared/starboard/loader_app_metrics.cc",
       "//starboard/shared/starboard/loader_app_metrics.h",
+      "asset_manager.cc",
+      "asset_manager.h",
+      "posix_emu/access.cc",
+      "posix_emu/file.cc",
+      "posix_emu/stat.cc",
     ]
 
     public_deps += [

--- a/starboard/android/shared/posix_emu/access.cc
+++ b/starboard/android/shared/posix_emu/access.cc
@@ -1,0 +1,48 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+extern "C" {
+
+int __wrap_access(const char* path, int mode) {
+  struct stat info;
+  if (fstatat(AT_FDCWD, path, &info, 0) != 0) {
+    return -1;
+  }
+
+  if (mode == F_OK) {
+    return 0;
+  }
+
+  if ((mode & R_OK) && !(info.st_mode & S_IRUSR)) {
+    errno = EACCES;
+    return -1;
+  }
+  if ((mode & W_OK) && !(info.st_mode & S_IWUSR)) {
+    errno = EACCES;
+    return -1;
+  }
+  if ((mode & X_OK) && !(info.st_mode & S_IXUSR)) {
+    errno = EACCES;
+    return -1;
+  }
+
+  return 0;
+}
+
+}  // extern "C"

--- a/starboard/android/shared/posix_emu/file.cc
+++ b/starboard/android/shared/posix_emu/file.cc
@@ -26,11 +26,21 @@ using starboard::AssetManager;
 using starboard::IsAndroidAssetPath;
 using starboard::OpenAndroidAsset;
 
+namespace {
+
+bool OpenNeedsMode(int oflag) {
+  // O_TMPFILE shares the O_DIRECTORY bit, so it must be masked exactly.
+  return (oflag & O_CREAT) || (oflag & O_TMPFILE) == O_TMPFILE;
+}
+
+}  // namespace
+
 // ///////////////////////////////////////////////////////////////////////////////
 // // Implementations below exposed externally in pure C for emulation.
 // ///////////////////////////////////////////////////////////////////////////////
 
 extern "C" {
+
 int __real_close(int fildes);
 int __real_open(const char* path, int oflag, ...);
 int __real_openat(int dirfd, const char* path, int oflag, ...);
@@ -45,7 +55,7 @@ int __wrap_close(int fildes) {
 
 int __wrap_openat(int dirfd, const char* path, int oflag, ...) {
   if (!IsAndroidAssetPath(path)) {
-    if (oflag & O_CREAT) {
+    if (OpenNeedsMode(oflag)) {
       va_list args;
       va_start(args, oflag);
       mode_t mode = va_arg(args, int);
@@ -58,7 +68,7 @@ int __wrap_openat(int dirfd, const char* path, int oflag, ...) {
 }
 
 int __wrap_open(const char* path, int oflag, ...) {
-  if (oflag & O_CREAT) {
+  if (OpenNeedsMode(oflag)) {
     va_list args;
     va_start(args, oflag);
     mode_t mode = va_arg(args, int);

--- a/starboard/android/shared/posix_emu/file.cc
+++ b/starboard/android/shared/posix_emu/file.cc
@@ -33,6 +33,7 @@ using starboard::OpenAndroidAsset;
 extern "C" {
 int __real_close(int fildes);
 int __real_open(const char* path, int oflag, ...);
+int __real_openat(int dirfd, const char* path, int oflag, ...);
 
 int __wrap_close(int fildes) {
   AssetManager* asset_manager = AssetManager::GetInstance();
@@ -42,19 +43,29 @@ int __wrap_close(int fildes) {
   return __real_close(fildes);
 }
 
-int __wrap_open(const char* path, int oflag, ...) {
+int __wrap_openat(int dirfd, const char* path, int oflag, ...) {
   if (!IsAndroidAssetPath(path)) {
-    va_list args;
-    va_start(args, oflag);
-    int fd;
     if (oflag & O_CREAT) {
+      va_list args;
+      va_start(args, oflag);
       mode_t mode = va_arg(args, int);
-      return __real_open(path, oflag, mode);
-    } else {
-      return __real_open(path, oflag);
+      va_end(args);
+      return __real_openat(dirfd, path, oflag, mode);
     }
+    return __real_openat(dirfd, path, oflag);
   }
   return AssetManager::GetInstance()->Open(path, oflag);
+}
+
+int __wrap_open(const char* path, int oflag, ...) {
+  if (oflag & O_CREAT) {
+    va_list args;
+    va_start(args, oflag);
+    mode_t mode = va_arg(args, int);
+    va_end(args);
+    return __wrap_openat(AT_FDCWD, path, oflag, mode);
+  }
+  return __wrap_openat(AT_FDCWD, path, oflag);
 }
 
 }  // extern "C"

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <android/asset_manager.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <sys/stat.h>
 
@@ -37,6 +38,11 @@ int __wrap_stat(const char* path, struct stat* info) {
 int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags) {
   if (!IsAndroidAssetPath(path)) {
     return __real_fstatat(dirfd, path, info, flags);
+  }
+
+  if (info == NULL) {
+    errno = EFAULT;
+    return -1;
   }
 
   // Asset paths are absolute (/cobalt/assets/...), so `dirfd` is irrelevant.

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -30,6 +30,7 @@ using starboard::OpenAndroidAssetDir;
 extern "C" {
 
 int __real_fstatat(int dirfd, const char* path, struct stat* info, int flags);
+int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags);
 
 int __wrap_stat(const char* path, struct stat* info) {
   return __wrap_fstatat(AT_FDCWD, path, info, 0);

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -15,10 +15,8 @@
 #include <android/asset_manager.h>
 #include <fcntl.h>
 #include <sys/stat.h>
-#include <unistd.h>
 
 #include "starboard/android/shared/file_internal.h"
-#include "starboard/common/log.h"
 
 using starboard::IsAndroidAssetPath;
 using starboard::OpenAndroidAsset;
@@ -29,36 +27,38 @@ using starboard::OpenAndroidAssetDir;
 ///////////////////////////////////////////////////////////////////////////////
 
 extern "C" {
-int __real_stat(const char* path, struct stat* info);
 
-// This needs to be exported to ensure shared_library targets include it.
+int __real_fstatat(int dirfd, const char* path, struct stat* info, int flags);
+
 int __wrap_stat(const char* path, struct stat* info) {
-  // SbFileExists(path) implementation for Android
+  return __wrap_fstatat(AT_FDCWD, path, info, 0);
+}
+
+int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags) {
   if (!IsAndroidAssetPath(path)) {
-    return __real_stat(path, info);  // Using system level stat call
+    return __real_fstatat(dirfd, path, info, flags);
   }
 
-  // Don't use the 2-arg open() since _FORTIFY_SOURCE rewrites it to __open_2,
-  // which bypasses -Wl,--wrap=open.
-  int file = open(path, O_RDONLY, 0);
-  if (file >= 0) {
-    int result = fstat(file, info);
-    close(file);
-    return result;
+  // Asset paths are absolute (/cobalt/assets/...), so `dirfd` is irrelevant.
+  if (AAsset* asset = OpenAndroidAsset(path)) {
+    // Assets are immutable APK content, so report them read-only.
+    info->st_mode = S_IFREG | S_IRUSR;  // Read-only regular file.
+    info->st_ctime = 0;
+    info->st_atime = 0;
+    info->st_mtime = 0;
+    info->st_size = AAsset_getLength(asset);
+    AAsset_close(asset);
+    return 0;
   }
 
-  // Values from SbFileGetPathInfo
-  if (IsAndroidAssetPath(path)) {
-    AAssetDir* asset_dir = OpenAndroidAssetDir(path);
-    if (asset_dir) {
-      info->st_mode = S_IFDIR;
-      info->st_ctime = 0;
-      info->st_atime = 0;
-      info->st_mtime = 0;
-      info->st_size = 0;
-      AAssetDir_close(asset_dir);
-      return 0;
-    }
+  if (AAssetDir* asset_dir = OpenAndroidAssetDir(path)) {
+    info->st_mode = S_IFDIR | S_IRUSR | S_IXUSR;  // Read-only, traversable dir.
+    info->st_ctime = 0;
+    info->st_atime = 0;
+    info->st_mtime = 0;
+    info->st_size = 0;
+    AAssetDir_close(asset_dir);
+    return 0;
   }
 
   return -1;

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -67,6 +67,7 @@ int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags) {
     return 0;
   }
 
+  errno = ENOENT;
   return -1;
 }
 

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -17,6 +17,17 @@ config("platform_configuration") {
     "//starboard/android/shared/platform_configuration",
     ":no_pedantic_warnings",
   ]
+
+  if (current_toolchain == starboard_toolchain) {
+    ldflags = [
+      "-Wl,--wrap=access",
+      "-Wl,--wrap=close",
+      "-Wl,--wrap=fstatat",
+      "-Wl,--wrap=open",
+      "-Wl,--wrap=openat",
+      "-Wl,--wrap=stat",
+    ]
+  }
 }
 
 config("no_pedantic_warnings") {

--- a/starboard/build/config/starboard_target_type.gni
+++ b/starboard/build/config/starboard_target_type.gni
@@ -53,17 +53,6 @@ template("starboard_platform_target") {
     if (is_android) {
       # TODO(b/374300500): - Find a way to avoid wrapping this.
       ldflags = [ "-Wl,--wrap=eglSwapBuffers" ]
-
-      if (is_starboard) {
-        ldflags += [
-          "-Wl,--wrap=access",
-          "-Wl,--wrap=close",
-          "-Wl,--wrap=fstatat",
-          "-Wl,--wrap=open",
-          "-Wl,--wrap=openat",
-          "-Wl,--wrap=stat",
-        ]
-      }
     }
 
     public_deps = [

--- a/starboard/build/config/starboard_target_type.gni
+++ b/starboard/build/config/starboard_target_type.gni
@@ -51,16 +51,19 @@ template("starboard_platform_target") {
       "//starboard/build/config:starboard",
     ]
     if (is_android) {
-      # TODO(b/374300500): - Find a way to avoid wrapping these.
-      ldflags = [
-        # "-Wl,--wrap=close",
-        # "-Wl,--wrap=open",
-        # "-Wl,--wrap=stat",
-        # "-Wl,--wrap=opendir",
-        # "-Wl,--wrap=closedir",
-        # "-Wl,--wrap=readdir_r",
-        "-Wl,--wrap=eglSwapBuffers",
-      ]
+      # TODO(b/374300500): - Find a way to avoid wrapping this.
+      ldflags = [ "-Wl,--wrap=eglSwapBuffers" ]
+
+      if (is_starboard) {
+        ldflags += [
+          "-Wl,--wrap=access",
+          "-Wl,--wrap=close",
+          "-Wl,--wrap=fstatat",
+          "-Wl,--wrap=open",
+          "-Wl,--wrap=openat",
+          "-Wl,--wrap=stat",
+        ]
+      }
     }
 
     public_deps = [

--- a/starboard/shared/modular/starboard_layer_posix_fcntl_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_fcntl_abi_wrappers.cc
@@ -301,13 +301,15 @@ SB_EXPORT int __abi_wrap_fcntl(int fildes, int cmd, ...) {
 
 int __abi_wrap_openat(int fildes, const char* path, int oflag, ...) {
   fildes = (fildes == MUSL_AT_FDCWD) ? AT_FDCWD : fildes;
+  musl_mode_t mode = 0;
   if ((oflag & O_CREAT) || (oflag & O_TMPFILE) == O_TMPFILE) {
     va_list ap;
     va_start(ap, oflag);
-    musl_mode_t mode = va_arg(ap, musl_mode_t);
-    return openat(fildes, path, oflag,
-                  starboard::musl_mode_to_platform_mode(mode));
-  } else {
-    return openat(fildes, path, oflag);
+    mode = va_arg(ap, musl_mode_t);
+    va_end(ap);
   }
+  // Don't use the 3-arg openat() since _FORTIFY_SOURCE rewrites it to
+  // __openat_2, which bypasses -Wl,--wrap=openat.
+  return openat(fildes, path, oflag,
+                starboard::musl_mode_to_platform_mode(mode));
 }


### PR DESCRIPTION
Introduce POSIX emulation wrappers for close, openat, access, and
fstatat on AOSP. These wrappers route file and path access through
the Android AssetManager to resolve paths within the asset tree.

While open and stat have been deprecated at Starboard 17, their wrappers are kept to avoid rewriting existing call sites.

Bug: 374300500
Bug: 495203133