### PR TITLE
fix NameError in android_monitor.py when pandas is not installed

### DIFF
--- a/cobalt/tools/performance/android_monitor.py
+++ b/cobalt/tools/performance/android_monitor.py
@@ -110,7 +110,7 @@ def _write_monitoring_data_csv(output_dir: str, filename_base: str,
 
 
 def _plot_monitoring_data_from_df(
-    df_input: pd.DataFrame,
+    df_input: 'pd.DataFrame',
     output_filename_base_with_dir: str,
     output_filepath_override: Optional[str] = None,
 ) -> bool:


### PR DESCRIPTION
Update the type hint for the pandas DataFrame to use a string literal.
This prevents the script from failing with a NameError during module
loading in environments where the pandas library is not installed.

Bug: 526652922