### PR TITLE
ci: Strip run_ prefix in on_host_tests action

### DIFF
--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -90,6 +90,7 @@ runs:
         for test_executable_path in ${test_executables}; do
           filename=$(basename "${test_executable_path}")
           test_executable="${filename%%.*}"
+          test_executable="${test_executable#run_}"
 
           echo "Running tests for suite: ${test_executable}"
 
@@ -158,6 +159,7 @@ runs:
         for test_executable_path in ${test_executables}; do
           filename=$(basename "${test_executable_path}")
           test_executable="${filename%%.*}"
+          test_executable="${test_executable#run_}"
 
           echo "Running tests for suite: ${test_executable}"
 


### PR DESCRIPTION
When executing JUnit/Robolectric test suites via GN wrapper scripts in bin/ (e.g. out/android-arm64_devel/bin/run_cobalt_coat_junit_tests), basename derives the suite name with a leading run_ prefix.

Strip the run_ prefix when calculating test_executable so that the resulting result XMLs match downstream CI reporting glob patterns.

Issue: 524653685