### PR TITLE
posix: Fix statvfs padding in musl

### DIFF
--- a/starboard/nplb/posix_compliance/posix_sys_statvfs_test.cc
+++ b/starboard/nplb/posix_compliance/posix_sys_statvfs_test.cc
@@ -33,15 +33,17 @@ TEST(PosixStatvfsTest, SunnyDay) {
       SbSystemGetPath(kSbSystemPathCacheDirectory, cache_path, kSbFileMaxPath));
 
   struct statvfs buf;
+  memset(&buf, 0, sizeof(buf));
   errno = 0;
   int result = statvfs(cache_path, &buf);
 
   ASSERT_EQ(result, 0) << "statvfs failed with error: " << strerror(errno);
 
-  EXPECT_GT(buf.f_bsize, static_cast<SbSystemCapabilityId>(0));
-  EXPECT_GT(buf.f_frsize, static_cast<SbSystemCapabilityId>(0));
+  EXPECT_GT(buf.f_bsize, 0UL);
+  EXPECT_GT(buf.f_frsize, 0UL);
   EXPECT_GT(buf.f_blocks, static_cast<fsblkcnt_t>(0));
   EXPECT_GT(buf.f_files, static_cast<fsfilcnt_t>(0));
+  EXPECT_GT(buf.f_namemax, 0UL);
 }
 
 TEST(PosixStatvfsTest, RainyDayInvalidPath) {

--- a/starboard/shared/modular/starboard_layer_posix_statvfs_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_statvfs_abi_wrappers.h
@@ -35,6 +35,7 @@ struct musl_statvfs {
   fsfilcnt_t f_ffree;
   fsfilcnt_t f_favail;
   unsigned long f_fsid;
+  unsigned : 8 * (2 * sizeof(int) - sizeof(long));
   unsigned long f_flag;
   unsigned long f_namemax;
   int __f_spare[6];


### PR DESCRIPTION
Correct the musl_statvfs structure definition to include necessary
padding after the f_fsid field. This ensures ABI compatibility with
musl libc, which is required for the modular Starboard layer to
correctly interpret statvfs data.

Update the PosixStatvfsTest to zero-initialize the buffer and verify
the f_namemax field to ensure better test coverage and reliability.

Issue: 525267707