### PR TITLE
android: Fix AudioTrack thread leak on stop

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -237,6 +237,11 @@ class AudioRendererSinkAndroid : public AudioRendererSinkImpl {
     AudioRendererSink::Reset();
   }
 
+  void Stop() override {
+    is_flushed_ = false;
+    AudioRendererSinkImpl::Stop();
+  }
+
   const bool is_tunnel_mode_enabled_;
   const bool enable_video_renderer_vsp_adjustment_;
   const bool allow_flush_during_seek_;

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.h
@@ -60,6 +60,7 @@ class AudioRendererSinkImpl : public AudioRendererSink {
              SbAudioSinkFrameBuffers frame_buffers,
              int frames_per_channel,
              RenderCallback* render_callback) override;
+  void Stop() override;
 
   SbAudioSinkPrivate* audio_sink_ = kSbAudioSinkInvalid;
   RenderCallback* render_callback_ = NULL;
@@ -74,8 +75,6 @@ class AudioRendererSinkImpl : public AudioRendererSink {
       SbMediaAudioFrameStorageType audio_frame_storage_type) const override;
   int GetNearestSupportedSampleFrequency(
       int sampling_frequency_hz) const override;
-
-  void Stop() override;
 
   void SetVolume(double volume) override;
   void SetPlaybackRate(double playback_rate) override;


### PR DESCRIPTION
Reset the is_flushed flag in the AudioRendererSinkAndroid Stop method.
This ensures that the audio sink does not remain in a flushed state
during teardown, which was causing the underlying AudioTrack thread
to leak when the sink was stopped.

Issue: 330793785
Issue: 518886071