### PR TITLE
Refactor: Implement global thread stack size reduction on Android

### DIFF
--- a/base/threading/platform_thread_android.cc
+++ b/base/threading/platform_thread_android.cc
@@ -18,6 +18,7 @@
 #include "base/logging.h"
 #include "base/threading/platform_thread_internal_posix.h"
 #include "base/threading/thread_id_name_manager.h"
+#include "starboard/common/thread_platform.h"
 
 // Must come after all headers that specialize FromJniType() / ToJniType().
 #include "base/tasks_jni/ThreadUtils_jni.h"
@@ -120,6 +121,10 @@ void TerminateOnThread() {
 
 size_t GetDefaultThreadStackSize(const pthread_attr_t& attributes) {
 #if !defined(ADDRESS_SANITIZER)
+  size_t starboard_default = starboard::GetDefaultThreadStackSize();
+  if (starboard_default > 0) {
+    return starboard_default;
+  }
   return 0;
 #else
   // AddressSanitizer bloats the stack approximately 2x. Default stack size of

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -61,6 +61,8 @@ public class JavaSwitches {
   /** flag to allow scaling clipped images in GpuImageDecodeCache */
   public static final String ENABLE_SCALING_CLIPPED_IMAGES = "EnableScalingClippedImages";
 
+  public static final String REDUCE_THREAD_STACK_SIZE = "ReduceThreadStackSize";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
 
@@ -119,6 +121,10 @@ public class JavaSwitches {
     if (featureParams.length() > 0) {
       extraCommandLineArgs.add(
           "--enable-features=SmallerInterestArea:" + featureParams.toString());
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.REDUCE_THREAD_STACK_SIZE)) {
+      extraCommandLineArgs.add("--enable-features=ReduceThreadStackSize");
     }
 
     return extraCommandLineArgs;

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -173,9 +173,7 @@ source_set("starboard_headers_only") {
     "socket.h",
     "storage.h",
     "system.h",
-    "thread.h",
     "time_zone.h",
-    "types.h",
     "window.h",
   ]
 

--- a/starboard/android/shared/thread_platform_android.cc
+++ b/starboard/android/shared/thread_platform_android.cc
@@ -16,12 +16,24 @@
 
 #include "starboard/common/thread_platform.h"
 
+#include "starboard/configuration.h"
+#include "starboard/shared/starboard/features.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 namespace starboard {
 
 void TerminateOnThread() {
   jni_zero::DetachFromVM();
+}
+
+size_t GetDefaultThreadStackSize() {
+#if SB_API_VERSION >= 17
+  if (starboard::features::FeatureList::IsEnabled(
+          starboard::features::kReduceThreadStackSize)) {
+    return 256 * 1024;
+  }
+#endif
+  return 0;
 }
 
 }  // namespace starboard

--- a/starboard/common/thread.cc
+++ b/starboard/common/thread.cc
@@ -130,7 +130,10 @@ struct Thread::Data {
 };
 
 Thread::Thread(std::string_view name, const ThreadOptions& options)
-    : name_(name), priority_(options.priority), d_(std::make_unique<Data>()) {}
+    : name_(name),
+      priority_(options.priority),
+      stack_size_(options.stack_size),
+      d_(std::make_unique<Data>()) {}
 
 Thread::~Thread() {
   // A started thread must be joined before destruction.
@@ -146,6 +149,16 @@ void Thread::Start() {
 
   pthread_attr_t attributes;
   pthread_attr_init(&attributes);
+
+  size_t stack_size =
+      stack_size_ > 0 ? stack_size_ : GetDefaultThreadStackSize();
+  if (stack_size > 0) {
+    int err = pthread_attr_setstacksize(&attributes, stack_size);
+    if (err != 0) {
+      SB_LOG(WARNING) << "Failed to set stack size to " << stack_size
+                      << ", error: " << err << ". Falling back to default.";
+    }
+  }
 
   const int result =
       pthread_create(&d_->thread_, &attributes, ThreadEntryPoint, this);

--- a/starboard/common/thread.h
+++ b/starboard/common/thread.h
@@ -75,6 +75,7 @@ class Thread {
  private:
   const std::string name_;
   const std::optional<ThreadPriority> priority_;
+  const size_t stack_size_;
   struct Data;
   const std::unique_ptr<Data> d_;
 

--- a/starboard/common/thread_options.h
+++ b/starboard/common/thread_options.h
@@ -74,8 +74,13 @@ struct ThreadOptions {
     priority = priority_in;
     return *this;
   }
+  ThreadOptions& SetStackSize(size_t stack_size_in) {
+    stack_size = stack_size_in;
+    return *this;
+  }
 
   std::optional<ThreadPriority> priority;
+  size_t stack_size = 0;
 };
 
 }  // namespace starboard

--- a/starboard/common/thread_platform.h
+++ b/starboard/common/thread_platform.h
@@ -17,10 +17,13 @@
 #ifndef STARBOARD_COMMON_THREAD_PLATFORM_H_
 #define STARBOARD_COMMON_THREAD_PLATFORM_H_
 
+#include <stddef.h>
+
 namespace starboard {
 
 void TerminateOnThread();
+size_t GetDefaultThreadStackSize();
 
-}
+}  // namespace starboard
 
 #endif  // STARBOARD_COMMON_THREAD_PLATFORM_H_

--- a/starboard/common/thread_platform_base.cc
+++ b/starboard/common/thread_platform_base.cc
@@ -20,4 +20,8 @@ namespace starboard {
 
 void TerminateOnThread() {}
 
+size_t GetDefaultThreadStackSize() {
+  return 0;
+}
+
 }  // namespace starboard

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -139,6 +139,9 @@ STARBOARD_FEATURE(kForceResetAudioDecoder, "ForceResetAudioDecoder", false)
 // enabling tunnel mode on all playbacks.
 STARBOARD_FEATURE(kForceTunnelMode, "ForceTunnelMode", false)
 
+// Set the following variable to true to reduce thread stack sizes to 256KB.
+STARBOARD_FEATURE(kReduceThreadStackSize, "ReduceThreadStackSize", false)
+
 // By default, software video codec can be selected when software codec is not
 // required. Set the following variable to true to prevent using low performance
 // software video decoder in MediaCapabilitiesCache when software codec is not

--- a/starboard/shared/starboard/feature_list.cc
+++ b/starboard/shared/starboard/feature_list.cc
@@ -114,7 +114,7 @@ void FeatureList::InitializeFeatureList(const SbFeature* features,
     feature_param_map[param.feature_name][param.param_name] =
         std::make_pair(param.type, value);
   }
-  instance->is_initialized_ = true;
+  instance->is_initialized_.store(true, std::memory_order_release);
 }
 
 void FeatureList::ValidateParam(const std::string& feature_name,
@@ -147,6 +147,10 @@ void FeatureList::ValidateParam(const std::string& feature_name,
 
 // static
 bool FeatureList::IsEnabled(const SbFeature& feature) {
+  FeatureList* instance = GetInstance();
+  if (!instance->is_initialized_.load(std::memory_order_acquire)) {
+    return feature.is_enabled;
+  }
   return IsEnabledByName(feature.name);
 }
 

--- a/starboard/shared/starboard/feature_list.h
+++ b/starboard/shared/starboard/feature_list.h
@@ -15,6 +15,7 @@
 #ifndef STARBOARD_SHARED_STARBOARD_FEATURE_LIST_H_
 #define STARBOARD_SHARED_STARBOARD_FEATURE_LIST_H_
 
+#include <atomic>
 #include <mutex>
 #include <optional>
 #include <string>
@@ -80,7 +81,9 @@ class FeatureList {
   // Helper function to check if the singleton instance of the FeatureList is
   // initialized. Called by other FeatureList class functions. If the
   // FeatureList is accessed before it is initialized, the app will crash.
-  bool IsInitialized() { return is_initialized_; }
+  bool IsInitialized() {
+    return is_initialized_.load(std::memory_order_acquire);
+  }
 
   // Mutex to ensure that in the rare chance that the FeatureList is
   // being accessed while it is initializing, we can let the instance
@@ -104,7 +107,7 @@ class FeatureList {
 
   // When InitializeStarboardFeatures() is completed, this value will be set to
   // true.
-  bool is_initialized_ = false;
+  std::atomic<bool> is_initialized_{false};
 };
 
 // SbFeatureParamExt is a bridge structure used in starboard to support params

--- a/tools/android/forwarder2/BUILD.gn
+++ b/tools/android/forwarder2/BUILD.gn
@@ -45,6 +45,7 @@ if (current_toolchain == android_toolchain) {
     deps = [
       "//base",
       "//tools/android/common",
+      "//starboard:starboard_group",
     ]
   }
 


### PR DESCRIPTION
- Rename REDUCE_MEDIA_THREAD_STACK_SIZE to REDUCE_THREAD_STACK_SIZE in JavaSwitches.java.
- Map REDUCE_THREAD_STACK_SIZE Java switch to --enable-features=ReduceThreadStackSize.
- Add kReduceThreadStackSize feature in starboard/extension/feature_config.h.
- Implement GetDefaultThreadStackSize() in starboard to return 256KB on Android when the feature is enabled.
- Update starboard::Thread and base::PlatformThread on Android to use GetDefaultThreadStackSize() as fallback when no explicit stack size is set.
- This removes the need for setting separate stack sizes in various media threads, as they now fall back to the global default.
- Added safety check in starboard::features::FeatureList to return default state if queried before initialization (e.g. during early thread creation).

TAG=agy
CONV=41bad5ef-65dd-4e97-8833-a7694b888653