### PR TITLE
Expose YouTube certification scope via navigator.userAgentData

### DIFF
--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -32,6 +32,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "base/timer/elapsed_timer.h"
+#include "cobalt/browser/client_hint_headers/cobalt_header_value_provider.h"
 #include "cobalt/browser/cobalt_browser_interface_binders.h"
 #include "cobalt/browser/cobalt_browser_main_parts.h"
 #include "cobalt/browser/cobalt_secure_navigation_throttle.h"
@@ -176,6 +177,16 @@ blink::UserAgentMetadata GetCobaltUserAgentMetadata() {
 
   metadata.bitness = embedder_support::GetCpuBitness();
   metadata.wow64 = embedder_support::IsWoW64();
+
+  auto* header_value_provider =
+      cobalt::browser::CobaltHeaderValueProvider::GetInstance();
+  if (header_value_provider) {
+    const auto& headers = header_value_provider->GetHeaderValues();
+    auto it = headers.find("Sec-CH-UA-Co-Youtube-Certification-Scope");
+    if (it != headers.end()) {
+      metadata.youtube_certification_scope = it->second;
+    }
+  }
 
   return metadata;
 }

--- a/cobalt/demos/content/user-agent-client-hints-demo/user-agent-client-hints-demo.html
+++ b/cobalt/demos/content/user-agent-client-hints-demo/user-agent-client-hints-demo.html
@@ -42,7 +42,7 @@
            "jsEngineVersion", "rasterizer", "evergreenVersion",
            "starboardVersion", "originalDesignManufacturer",
            "deviceType", "chipset", "modelYear", "deviceBrand",
-           "connectionType", "aux"])
+           "connectionType", "aux", "youtubeCertificationScope"])
           .then(ua => {
             // Cobalt returns a CobaltUADataValuesInterface object instead of a
             // dictionary as dictionary promises are currently not supported.
@@ -67,6 +67,7 @@
             full_JSON.deviceBrand = ua.deviceBrand;
             full_JSON.connectionType = ua.connectionType;
             full_JSON.aux = ua.aux;
+            full_JSON.youtubeCertificationScope = ua.youtubeCertificationScope;
 
             var full_result = document.createElement("div");
             full_result.innerHTML = JSON.stringify(full_JSON, null, " ");

--- a/third_party/blink/common/user_agent/user_agent_metadata.cc
+++ b/third_party/blink/common/user_agent/user_agent_metadata.cc
@@ -15,7 +15,7 @@
 namespace blink {
 
 namespace {
-constexpr uint32_t kVersion = 3u;
+constexpr uint32_t kVersion = 4u;
 }  // namespace
 
 UserAgentBrandVersion::UserAgentBrandVersion(const std::string& ua_brand,
@@ -98,6 +98,7 @@ std::optional<std::string> UserAgentMetadata::Marshal(
   for (const auto& form_factors : in->form_factors) {
     out.WriteString(form_factors);
   }
+  out.WriteString(in->youtube_certification_scope);
   return std::string(reinterpret_cast<const char*>(out.data()), out.size());
 }
 
@@ -113,7 +114,7 @@ std::optional<UserAgentMetadata> UserAgentMetadata::Demarshal(
 
   uint32_t version;
   UserAgentMetadata out;
-  if (!in.ReadUInt32(&version) || version != kVersion)
+  if (!in.ReadUInt32(&version) || version < 3u || version > kVersion)
     return std::nullopt;
 
   uint32_t brand_version_size;
@@ -168,6 +169,11 @@ std::optional<UserAgentMetadata> UserAgentMetadata::Demarshal(
     }
     out.form_factors.push_back(std::move(form_factors));
   }
+  if (version >= 4u) {
+    if (!in.ReadString(&out.youtube_certification_scope)) {
+      return std::nullopt;
+    }
+  }
   return std::make_optional(std::move(out));
 }
 
@@ -182,7 +188,8 @@ bool operator==(const UserAgentMetadata& a, const UserAgentMetadata& b) {
          a.platform_version == b.platform_version &&
          a.architecture == b.architecture && a.model == b.model &&
          a.mobile == b.mobile && a.bitness == b.bitness && a.wow64 == b.wow64 &&
-         a.form_factors == b.form_factors;
+         a.form_factors == b.form_factors &&
+         a.youtube_certification_scope == b.youtube_certification_scope;
 }
 
 // static

--- a/third_party/blink/common/user_agent/user_agent_metadata_unittest.cc
+++ b/third_party/blink/common/user_agent/user_agent_metadata_unittest.cc
@@ -30,6 +30,7 @@ blink::UserAgentMetadata MakeToEncode() {
   to_encode.bitness = "8";
   to_encode.wow64 = true;
   to_encode.form_factors = {"tubular"};
+  to_encode.youtube_certification_scope = "cert_scope_test";
   return to_encode;
 }
 

--- a/third_party/blink/common/user_agent/user_agent_mojom_traits.cc
+++ b/third_party/blink/common/user_agent/user_agent_mojom_traits.cc
@@ -67,6 +67,10 @@ bool StructTraits<blink::mojom::UserAgentMetadataDataView,
     return false;
   }
 
+  if (!data.ReadYoutubeCertificationScope(&out->youtube_certification_scope)) {
+    return false;
+  }
+
   return true;
 }
 

--- a/third_party/blink/public/common/user_agent/user_agent_metadata.h
+++ b/third_party/blink/public/common/user_agent/user_agent_metadata.h
@@ -78,6 +78,7 @@ struct BLINK_COMMON_EXPORT UserAgentMetadata {
   // compliant with the w3c draft spec:
   // https://wicg.github.io/ua-client-hints/#sec-ch-ua-form-factors.
   std::vector<std::string> form_factors;
+  std::string youtube_certification_scope;
 };
 
 // Used when customizing the sent User-Agent and Sec-CH-UA-* for

--- a/third_party/blink/public/common/user_agent/user_agent_mojom_traits.h
+++ b/third_party/blink/public/common/user_agent/user_agent_mojom_traits.h
@@ -81,6 +81,11 @@ struct BLINK_COMMON_EXPORT StructTraits<blink::mojom::UserAgentMetadataDataView,
     return data.form_factors;
   }
 
+  static const std::string& youtube_certification_scope(
+      const ::blink::UserAgentMetadata& data) {
+    return data.youtube_certification_scope;
+  }
+
   static bool Read(blink::mojom::UserAgentMetadataDataView data,
                    ::blink::UserAgentMetadata* out);
 };

--- a/third_party/blink/public/mojom/user_agent/user_agent_metadata.mojom
+++ b/third_party/blink/public/mojom/user_agent/user_agent_metadata.mojom
@@ -24,6 +24,7 @@ struct UserAgentMetadata {
   string bitness;
   bool wow64;
   array<string> form_factors;
+  string youtube_certification_scope;
 };
 
 // See UserAgentOverride in

--- a/third_party/blink/renderer/core/frame/navigator_ua.cc
+++ b/third_party/blink/renderer/core/frame/navigator_ua.cc
@@ -33,6 +33,8 @@ NavigatorUAData* NavigatorUA::userAgentData() {
     form_factors.push_back(String::FromUTF8(ff));
   }
   ua_data->SetFormFactors(std::move(form_factors));
+  ua_data->SetYoutubeCertificationScope(
+      String::FromUTF8(metadata.youtube_certification_scope));
 
   return ua_data;
 }

--- a/third_party/blink/renderer/core/frame/navigator_ua_data.cc
+++ b/third_party/blink/renderer/core/frame/navigator_ua_data.cc
@@ -140,6 +140,10 @@ void NavigatorUAData::SetFormFactors(Vector<String> form_factors) {
   form_factors_ = std::move(form_factors);
 }
 
+void NavigatorUAData::SetYoutubeCertificationScope(const String& youtube_certification_scope) {
+  youtube_certification_scope_ = youtube_certification_scope;
+}
+
 bool NavigatorUAData::mobile() const {
   if (GetExecutionContext()) {
     return is_mobile_;
@@ -276,6 +280,10 @@ ScriptPromise<UADataValues> NavigatorUAData::getHighEntropyValues(
       } else if (hint == "formFactors") {
         values->setFormFactors(form_factors_);
         MaybeRecordMetric(record_identifiability, hint, form_factors_,
+                          execution_context);
+      } else if (hint == "youtubeCertificationScope") {
+        values->setYoutubeCertificationScope(youtube_certification_scope_);
+        MaybeRecordMetric(record_identifiability, hint, youtube_certification_scope_,
                           execution_context);
       }
     }

--- a/third_party/blink/renderer/core/frame/navigator_ua_data.h
+++ b/third_party/blink/renderer/core/frame/navigator_ua_data.h
@@ -39,6 +39,7 @@ class NavigatorUAData : public ScriptWrappable, ExecutionContextClient {
   void SetBitness(const String& bitness);
   void SetWoW64(bool wow64);
   void SetFormFactors(Vector<String> form_factors);
+  void SetYoutubeCertificationScope(const String& youtube_certification_scope);
 
   // IDL implementation
   const HeapVector<Member<NavigatorUABrandVersion>>& brands() const;
@@ -63,6 +64,7 @@ class NavigatorUAData : public ScriptWrappable, ExecutionContextClient {
   String bitness_;
   bool is_wow64_ = false;
   Vector<String> form_factors_;
+  String youtube_certification_scope_;
 
   void AddBrandVersion(const String& brand, const String& version);
   void AddBrandFullVersion(const String& brand, const String& version);

--- a/third_party/blink/renderer/core/frame/ua_data_values.idl
+++ b/third_party/blink/renderer/core/frame/ua_data_values.idl
@@ -16,4 +16,5 @@ dictionary UADataValues {
   sequence<NavigatorUABrandVersion> fullVersionList;
   boolean wow64;
   sequence<DOMString> formFactors;
+  DOMString youtubeCertificationScope;
 };


### PR DESCRIPTION
This change extends Blink's navigator.userAgentData API to support a custom high-entropy hint "youtubeCertificationScope". This allows the web app to query the certification scope locally without requiring a server roundtrip.

Modified CobaltContentBrowserClient to populate this value from the system property via CobaltHeaderValueProvider.

TAG=agy
CONV=b3e9c2b7-a1cf-4584-aa70-e81f97077a96