### PR TITLE
aosp: Use modular_executable for test targets

### DIFF
--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -253,7 +253,10 @@ if (current_toolchain == starboard_toolchain) {
       "//testing/gtest",
     ]
 
-    if (platform_tests_path != "" && !is_android) {
+    # On AOSP, the platform tests are built as a
+    # standalone modular_executable, whose target only exists in the default
+    # toolchain.
+    if (platform_tests_path != "" && !(is_android && is_starboard)) {
       deps += [ platform_tests_path ]
     }
     if (sb_filter_based_player) {

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -253,7 +253,7 @@ if (current_toolchain == starboard_toolchain) {
       "//testing/gtest",
     ]
 
-    if (platform_tests_path != "") {
+    if (platform_tests_path != "" && !is_android) {
       deps += [ platform_tests_path ]
     }
     if (sb_filter_based_player) {
@@ -270,9 +270,6 @@ if (current_toolchain == starboard_toolchain) {
         "//starboard/loader_app:read_evergreen_version_test",
         "//starboard/loader_app:slot_management_test",
       ]
-    }
-    if (is_android) {
-      deps += [ "//starboard/android/shared:starboard_platform_tests" ]
     }
     if (build_with_separate_cobalt_toolchain && use_contrib_cast) {
       deps += [ "//starboard/contrib/cast/cast_starboard_api/samples:cast_starboard_api_test" ]

--- a/testing/test.gni
+++ b/testing/test.gni
@@ -376,7 +376,17 @@ template("test") {
            "allow_cleartext_traffic can be set only for Android tests")
   }
 
-  if (is_android) {
+  # TODO: b/384652502 - Cobalt: Remove use_custom_libc after setting
+  # is_starboard as a toolchain arg.
+  if (is_starboard && use_custom_libc) {
+    mixed_test(target_name) {
+      target_type = "modular_executable"
+      forward_variables_from(invoker,
+                             "*",
+                             TESTONLY_AND_VISIBILITY + [ "use_xvfb" ])
+      testonly = true
+    }
+  } else if (is_android) {
     assert(!defined(invoker.use_xvfb) || !invoker.use_xvfb)
 
     _use_default_launcher =
@@ -1026,16 +1036,6 @@ template("test") {
       if (use_rts) {
         data_deps += [ ":${invoker.target_name}__rts_filters" ]
       }
-    }
-    # TODO: b/384652502 - Cobalt: Remove use_custom_libc after setting
-    # is_starboard as a toolchain arg.
-  } else if (is_starboard && use_custom_libc) {
-    mixed_test(target_name) {
-      target_type = "modular_executable"
-      forward_variables_from(invoker,
-                             "*",
-                             TESTONLY_AND_VISIBILITY + [ "use_xvfb" ])
-      testonly = true
     }
   } else if (!is_nacl) {
     if (is_mac || is_win) {


### PR DESCRIPTION
Reorder platform detection at the test template so that modular builds on AOSP also use modular_executable.

Bug: 495203133