### PR TITLE
starboard: Refactor AudioTrack into abstract interface and add unit tests

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -137,6 +137,8 @@ static_library("starboard_platform") {
     "audio_sink_is_audio_sample_type_supported.cc",
     "audio_sink_min_required_frames_tester.cc",
     "audio_sink_min_required_frames_tester.h",
+    "audio_track.cc",
+    "audio_track.h",
     "audio_track_audio_sink_type.cc",
     "audio_track_audio_sink_type.h",
     "audio_track_bridge.cc",
@@ -400,6 +402,8 @@ static_library("test_support") {
   ]
 
   sources = [
+    "fake_audio_track.cc",
+    "fake_audio_track.h",
     "fake_media_codec.cc",
     "fake_media_codec.h",
     "starboard_test_environment.cc",
@@ -412,6 +416,7 @@ test("starboard_platform_tests") {
 
   sources = media_tests_sources + player_tests_sources + [
               "//starboard/common/test_main.cc",
+              "audio_track_audio_sink_type_test.cc",
               "drm_session_id_mapper_test.cc",
               "features_extension_test.cc",
               "media_capabilities_cache_test.cc",

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -543,7 +543,7 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
       //       should revisit this.
       auto sync_time = decoded_audio_writing_in_progress_->timestamp();
       int samples_written = audio_track_bridge_->WriteSample(
-          sample_buffer, samples_to_write, sync_time);
+          MakeSpan(sample_buffer, samples_to_write), sync_time);
       // Error code returned as negative value, like kAudioTrackErrorDeadObject.
       if (samples_written < 0) {
         if (samples_written == AudioTrackBridge::kAudioTrackErrorDeadObject) {

--- a/starboard/android/shared/audio_track.cc
+++ b/starboard/android/shared/audio_track.cc
@@ -1,0 +1,39 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/audio_track.h"
+
+#include <memory>
+#include <optional>
+
+#include "starboard/android/shared/audio_track_bridge.h"
+
+namespace starboard {
+
+// static
+std::unique_ptr<AudioTrack> AudioTrack::Create(
+    SbMediaAudioCodingType coding_type,
+    std::optional<SbMediaAudioSampleType> sample_type,
+    int channels,
+    int sampling_frequency_hz,
+    int preferred_buffer_size_in_bytes,
+    std::optional<int> tunnel_mode_audio_session_id,
+    bool is_web_audio) {
+  return AudioTrackBridge::Create(coding_type, sample_type, channels,
+                                  sampling_frequency_hz,
+                                  preferred_buffer_size_in_bytes,
+                                  tunnel_mode_audio_session_id, is_web_audio);
+}
+
+}  // namespace starboard

--- a/starboard/android/shared/audio_track.h
+++ b/starboard/android/shared/audio_track.h
@@ -1,0 +1,94 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_AUDIO_TRACK_H_
+#define STARBOARD_ANDROID_SHARED_AUDIO_TRACK_H_
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include "starboard/common/span.h"
+#include "starboard/media.h"
+
+namespace starboard {
+
+// These must be in sync with AudioTrack.PLAYSTATE_XXX constants in
+// AudioTrack.java.
+constexpr int PLAYSTATE_STOPPED = 1;
+constexpr int PLAYSTATE_PAUSED = 2;
+constexpr int PLAYSTATE_PLAYING = 3;
+
+// AudioTrack is an abstract interface for Android audio playback functionality,
+// providing a unified API for both JNI-based (AudioTrackBridge) and NDK-based
+// (NdkAudioTrack) implementations.
+//
+// Lifetime and Ownership:
+// Objects of derived classes are typically owned and managed by the audio sink
+// (e.g., via std::unique_ptr).
+//
+// Threading Model:
+// Implementations of this interface are not guaranteed to be thread-safe and
+// are expected to be called on a single audio thread.
+class AudioTrack {
+ public:
+  // The maximum number of frames that can be written to android audio track per
+  // write request.
+  static constexpr int kMaxFramesPerRequest = 65536;
+  // Error code returned as negative value from WriteSample().
+  static constexpr int kAudioTrackErrorDeadObject = -6;
+
+  static std::unique_ptr<AudioTrack> Create(
+      SbMediaAudioCodingType coding_type,
+      std::optional<SbMediaAudioSampleType> sample_type,
+      int channels,
+      int sampling_frequency_hz,
+      int preferred_buffer_size_in_bytes,
+      std::optional<int> tunnel_mode_audio_session_id,
+      bool is_web_audio);
+
+  virtual ~AudioTrack() = default;
+
+  virtual void Play() = 0;
+  virtual void Pause() = 0;
+  virtual void Stop() = 0;
+  virtual void PauseAndFlush() = 0;
+
+  // Returns zero or the positive number of samples written, or a negative error
+  // code.
+  virtual int WriteSample(Span<const float> samples) = 0;
+  // This method is called when tunnel mode is used.
+  // Returns zero or the positive number of samples written, or a negative error
+  // code.
+  virtual int WriteSample(Span<const uint16_t> samples, int64_t sync_time) = 0;
+  // This is used by passthrough, treating buffer as compressed bitstream bytes.
+  // Returns zero or the positive number of bytes written, or a negative error
+  // code.
+  virtual int WriteSample(Span<const uint8_t> buffer, int64_t sync_time) = 0;
+
+  virtual void SetPlaybackRate(double playback_rate) = 0;
+  virtual void SetVolume(double volume) = 0;
+
+  // |updated_at| contains the timestamp when the audio timestamp is updated on
+  // return.  It can be nullptr.
+  virtual int64_t GetAudioTimestamp(int64_t* updated_at) = 0;
+  virtual bool GetAndResetHasAudioDeviceChanged() = 0;
+  virtual int GetUnderrunCount() = 0;
+  virtual int GetStartThresholdInFrames() = 0;
+  virtual int GetPlayState() = 0;
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_ANDROID_SHARED_AUDIO_TRACK_H_

--- a/starboard/android/shared/audio_track.h
+++ b/starboard/android/shared/audio_track.h
@@ -24,12 +24,6 @@
 
 namespace starboard {
 
-// These must be in sync with AudioTrack.PLAYSTATE_XXX constants in
-// AudioTrack.java.
-constexpr int PLAYSTATE_STOPPED = 1;
-constexpr int PLAYSTATE_PAUSED = 2;
-constexpr int PLAYSTATE_PLAYING = 3;
-
 // AudioTrack is an abstract interface for Android audio playback functionality,
 // providing a unified API for both JNI-based (AudioTrackBridge) and NDK-based
 // (NdkAudioTrack) implementations.
@@ -43,10 +37,19 @@ constexpr int PLAYSTATE_PLAYING = 3;
 // are expected to be called on a single audio thread.
 class AudioTrack {
  public:
+  // These must be in sync with AudioTrack.PLAYSTATE_XXX constants in
+  // AudioTrack.java.
+  enum class PlayState {
+    kStopped = 1,
+    kPaused = 2,
+    kPlaying = 3,
+  };
+
   // The maximum number of frames that can be written to android audio track per
   // write request.
-  static constexpr int kMaxFramesPerRequest = 65536;
+  static constexpr int kMaxFramesPerRequest = 65'536;
   // Error code returned as negative value from WriteSample().
+  // The same as Android AudioTrack.ERROR_DEAD_OBJECT.
   static constexpr int kAudioTrackErrorDeadObject = -6;
 
   static std::unique_ptr<AudioTrack> Create(
@@ -86,7 +89,7 @@ class AudioTrack {
   virtual bool GetAndResetHasAudioDeviceChanged() = 0;
   virtual int GetUnderrunCount() = 0;
   virtual int GetStartThresholdInFrames() = 0;
-  virtual int GetPlayState() = 0;
+  virtual PlayState GetPlayState() = 0;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -39,12 +39,6 @@ namespace {
 
 using jni_zero::AttachCurrentThread;
 
-// The maximum number of frames that can be written to android audio track per
-// write request. If we don't set this cap for writing frames to audio track,
-// we will repeatedly allocate a large byte array which cannot be consumed by
-// audio track completely.
-const int kMaxFramesPerRequest = 65536;
-
 // Most Android audio HAL updates audio time for A/V synchronization on audio
 // sync frames. For example, audio HAL may try to render when it gets an entire
 // sync frame and then update audio time. Shorter duration of sync frame
@@ -134,11 +128,11 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
     bool is_web_audio,
     bool allow_audio_writing_on_pause,
     void* context) {
-  std::unique_ptr<AudioTrackBridge> bridge = AudioTrackBridge::Create(
-      kSbMediaAudioCodingTypePcm, sample_type, channels, sampling_frequency_hz,
-      preferred_buffer_size_in_bytes, tunnel_mode_audio_session_id,
-      is_web_audio);
-  if (!bridge) {
+  std::unique_ptr<AudioTrack> audio_track =
+      AudioTrack::Create(kSbMediaAudioCodingTypePcm, sample_type, channels,
+                         sampling_frequency_hz, preferred_buffer_size_in_bytes,
+                         tunnel_mode_audio_session_id, is_web_audio);
+  if (!audio_track) {
     return nullptr;
   }
 
@@ -147,7 +141,37 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
       sample_type, frame_buffers, frames_per_channel,
       preferred_buffer_size_in_bytes, callbacks, start_time,
       tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
-      std::move(bridge), context);
+      std::move(audio_track), context);
+
+  audio_sink->SpawnThread();
+  return audio_sink;
+}
+
+// static
+std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::CreateForTesting(
+    Type* type,
+    int channels,
+    int sampling_frequency_hz,
+    SbMediaAudioSampleType sample_type,
+    SbAudioSinkFrameBuffers frame_buffers,
+    int frames_per_channel,
+    int preferred_buffer_size_in_bytes,
+    AudioTrackAudioSinkType::Callbacks callbacks,
+    int64_t start_time,
+    std::optional<int> tunnel_mode_audio_session_id,
+    bool allow_audio_writing_on_pause,
+    std::unique_ptr<AudioTrack> fake_audio_track,
+    void* context) {
+  if (!fake_audio_track) {
+    return nullptr;
+  }
+
+  auto audio_sink = std::make_unique<AudioTrackAudioSink>(
+      PassKey<AudioTrackAudioSink>(), type, channels, sampling_frequency_hz,
+      sample_type, frame_buffers, frames_per_channel,
+      preferred_buffer_size_in_bytes, callbacks, start_time,
+      tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
+      std::move(fake_audio_track), context);
 
   audio_sink->SpawnThread();
   return audio_sink;
@@ -166,7 +190,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
     int64_t start_time,
     std::optional<int> tunnel_mode_audio_session_id,
     bool allow_audio_writing_on_pause,
-    std::unique_ptr<AudioTrackBridge> bridge,
+    std::unique_ptr<AudioTrack> audio_track,
     void* context)
     : type_(type),
       channels_(channels),
@@ -178,16 +202,16 @@ AudioTrackAudioSink::AudioTrackAudioSink(
       start_time_(start_time),
       max_frames_per_request_(
           !tunnel_mode_audio_session_id
-              ? kMaxFramesPerRequest
+              ? AudioTrack::kMaxFramesPerRequest
               : GetMaxFramesPerRequestForTunnelMode(sampling_frequency_hz_)),
       context_(context),
       allow_audio_writing_on_pause_(allow_audio_writing_on_pause),
-      bridge_(std::move(bridge)),
+      audio_track_(std::move(audio_track)),
       audio_out_thread_(std::make_unique<AudioTrackOutThread>(this)) {
   SB_DCHECK(callbacks_.update_source_status);
   SB_DCHECK(callbacks_.consume_frames);
   SB_DCHECK(frame_buffer_);
-  SB_CHECK(bridge_);
+  SB_CHECK(audio_track_);
 
   SB_LOG(INFO) << "Creating audio sink starts at " << start_time_.load();
 }
@@ -211,20 +235,20 @@ void AudioTrackAudioSink::SetPlaybackRate(double playback_rate) {
   if (playback_rate > 0.0) {
     // AudioTrackBridge.setPlaybackRate() currently is only enabled for tunnel
     // mode. It will be no-op for non tunnel player.
-    bridge_->SetPlaybackRate(playback_rate);
+    audio_track_->SetPlaybackRate(playback_rate);
   }
 }
 
 void AudioTrackAudioSink::SetVolume(double volume) {
-  bridge_->SetVolume(volume);
+  audio_track_->SetVolume(volume);
 }
 
 int AudioTrackAudioSink::GetUnderrunCount() {
-  return bridge_->GetUnderrunCount();
+  return audio_track_->GetUnderrunCount();
 }
 
 int AudioTrackAudioSink::GetStartThresholdInFrames() {
-  return bridge_->GetStartThresholdInFrames();
+  return audio_track_->GetStartThresholdInFrames();
 }
 
 bool AudioTrackAudioSink::Flush() {
@@ -234,7 +258,6 @@ bool AudioTrackAudioSink::Flush() {
 
 // TODO: Break down the function into manageable pieces.
 void AudioTrackAudioSink::AudioThreadFunc() {
-  JNIEnv* env = AttachCurrentThread();
   int frames_in_audio_track = 0;
   int audio_track_play_state = PLAYSTATE_STOPPED;
 
@@ -250,7 +273,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
 
   while (!quit_) {
     if (flush_requested_) {
-      bridge_->PauseAndFlush();
+      audio_track_->PauseAndFlush();
       frames_in_audio_track = 0;
       accumulated_written_frames = 0;
       last_playback_head_event_at = -1;
@@ -264,7 +287,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
 
     int playback_head_position = 0;
     int64_t frames_consumed_at = 0;
-    if (bridge_->GetAndResetHasAudioDeviceChanged(env)) {
+    if (audio_track_->GetAndResetHasAudioDeviceChanged()) {
       SB_LOG(INFO) << "Audio device changed, raising a capability changed "
                       "error to restart playback.";
       ReportError(true, "Audio device capability changed");
@@ -272,20 +295,20 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     }
 
     // The audio data at the returned position by
-    // |bridge_->GetAudioTimestamp()| may either (1) already have been
+    // |audio_track_->GetAudioTimestamp()| may either (1) already have been
     // presented, or (2) may have not yet been presented but is committed to
-    // be presented. It is possible after |bridge_->Pause()|, the audio data
-    // is still committed to be presented as (2), which causes advancing
+    // be presented. It is possible after |audio_track_->Pause()|, the audio
+    // data is still committed to be presented as (2), which causes advancing
     // media time gap when player resumes and dropping video frames, so
-    // player updates playback head positions when |bridge_| doesn't stop.
-    audio_track_play_state = bridge_->GetPlayState();
+    // player updates playback head positions when |audio_track_| doesn't stop.
+    audio_track_play_state = audio_track_->GetPlayState();
 
     bool should_update_media_time =
         (audio_track_play_state == PLAYSTATE_PLAYING ||
          audio_track_play_state == PLAYSTATE_PAUSED);
     if (should_update_media_time) {
       playback_head_position =
-          bridge_->GetAudioTimestamp(&frames_consumed_at, env);
+          audio_track_->GetAudioTimestamp(&frames_consumed_at);
 
       int frames_consumed = 0;
       if (last_playback_head_position == -1) {
@@ -341,11 +364,11 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     bool is_currently_playing = (audio_track_play_state == PLAYSTATE_PLAYING);
     if (is_currently_playing && !is_playing) {
       ScopedTimer timer("Pause");
-      bridge_->Pause();
+      audio_track_->Pause();
     } else if (!is_currently_playing && is_playing) {
       last_playback_head_event_at = -1;
       ScopedTimer timer("Play");
-      bridge_->Play();
+      audio_track_->Play();
       if (release_frames_after_audio_starts) {
         // To promptly re-evaluate and update audio state, we restart the loop
         // after calling AudioTrack.play() on Android, as this operation often
@@ -395,8 +418,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
                             GetFramesDurationUs(accumulated_written_frames);
         // Not necessary to handle error of WriteData(), as the audio has
         // reached the end of stream.
-        WriteData(env, silence_buffer.data(), silence_frames_per_append,
-                  sync_time);
+        WriteData(silence_buffer.data(), silence_frames_per_append, sync_time);
       }
 
       usleep(10'000);
@@ -414,15 +436,14 @@ void AudioTrackAudioSink::AudioThreadFunc() {
         << ", offset_in_frames: " << offset_in_frames;
 
     int written_frames =
-        WriteData(env,
-                  IncrementPointerByBytes(frame_buffer_,
+        WriteData(IncrementPointerByBytes(frame_buffer_,
                                           start_position * channels_ *
                                               GetBytesPerSample(sample_type_)),
                   expected_written_frames, sync_time);
     int64_t now = CurrentMonotonicTime();
 
     if (written_frames < 0) {
-      if (written_frames == AudioTrackBridge::kAudioTrackErrorDeadObject) {
+      if (written_frames == AudioTrack::kAudioTrackErrorDeadObject) {
         // There might be an audio device change, try to recreate the player.
         ReportError(true,
                     "Failed to write data and received dead object error.");
@@ -450,26 +471,26 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     }
   }
 
-  bridge_->PauseAndFlush();
+  audio_track_->PauseAndFlush();
 }
 
 void AudioTrackAudioSink::SpawnThread() {
   audio_out_thread_->Start();
 }
 
-int AudioTrackAudioSink::WriteData(JNIEnv* env,
-                                   const void* buffer,
+int AudioTrackAudioSink::WriteData(const void* buffer,
                                    int expected_written_frames,
                                    int64_t sync_time) {
   int samples_written = 0;
   if (sample_type_ == kSbMediaAudioSampleTypeFloat32) {
-    samples_written =
-        bridge_->WriteSample(static_cast<const float*>(buffer),
-                             expected_written_frames * channels_, env);
+    samples_written = audio_track_->WriteSample(
+        MakeSpan(static_cast<const float*>(buffer),
+                 expected_written_frames * channels_));
   } else if (sample_type_ == kSbMediaAudioSampleTypeInt16Deprecated) {
-    samples_written = bridge_->WriteSample(static_cast<const uint16_t*>(buffer),
-                                           expected_written_frames * channels_,
-                                           sync_time, env);
+    samples_written =
+        audio_track_->WriteSample(MakeSpan(static_cast<const uint16_t*>(buffer),
+                                           expected_written_frames * channels_),
+                                  sync_time);
   } else {
     SB_NOTREACHED();
   }

--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -121,27 +121,25 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::Create(
     SbMediaAudioSampleType sample_type,
     SbAudioSinkFrameBuffers frame_buffers,
     int frames_per_channel,
-    int preferred_buffer_size_in_bytes,
+    int preferred_buffer_size,
     AudioTrackAudioSinkType::Callbacks callbacks,
-    int64_t start_time,
+    int64_t start_media_time,
     std::optional<int> tunnel_mode_audio_session_id,
     bool is_web_audio,
     bool allow_audio_writing_on_pause,
     void* context) {
-  std::unique_ptr<AudioTrack> audio_track =
-      AudioTrack::Create(kSbMediaAudioCodingTypePcm, sample_type, channels,
-                         sampling_frequency_hz, preferred_buffer_size_in_bytes,
-                         tunnel_mode_audio_session_id, is_web_audio);
+  std::unique_ptr<AudioTrack> audio_track = AudioTrack::Create(
+      kSbMediaAudioCodingTypePcm, sample_type, channels, sampling_frequency_hz,
+      preferred_buffer_size, tunnel_mode_audio_session_id, is_web_audio);
   if (!audio_track) {
     return nullptr;
   }
 
   auto audio_sink = std::make_unique<AudioTrackAudioSink>(
       PassKey<AudioTrackAudioSink>(), type, channels, sampling_frequency_hz,
-      sample_type, frame_buffers, frames_per_channel,
-      preferred_buffer_size_in_bytes, callbacks, start_time,
-      tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
-      std::move(audio_track), context);
+      sample_type, frame_buffers, frames_per_channel, preferred_buffer_size,
+      callbacks, start_media_time, tunnel_mode_audio_session_id,
+      allow_audio_writing_on_pause, std::move(audio_track), context);
 
   audio_sink->SpawnThread();
   return audio_sink;
@@ -155,9 +153,9 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::CreateForTesting(
     SbMediaAudioSampleType sample_type,
     SbAudioSinkFrameBuffers frame_buffers,
     int frames_per_channel,
-    int preferred_buffer_size_in_bytes,
+    int preferred_buffer_size,
     AudioTrackAudioSinkType::Callbacks callbacks,
-    int64_t start_time,
+    int64_t start_media_time,
     std::optional<int> tunnel_mode_audio_session_id,
     bool allow_audio_writing_on_pause,
     std::unique_ptr<AudioTrack> fake_audio_track,
@@ -168,10 +166,9 @@ std::unique_ptr<AudioTrackAudioSink> AudioTrackAudioSink::CreateForTesting(
 
   auto audio_sink = std::make_unique<AudioTrackAudioSink>(
       PassKey<AudioTrackAudioSink>(), type, channels, sampling_frequency_hz,
-      sample_type, frame_buffers, frames_per_channel,
-      preferred_buffer_size_in_bytes, callbacks, start_time,
-      tunnel_mode_audio_session_id, allow_audio_writing_on_pause,
-      std::move(fake_audio_track), context);
+      sample_type, frame_buffers, frames_per_channel, preferred_buffer_size,
+      callbacks, start_media_time, tunnel_mode_audio_session_id,
+      allow_audio_writing_on_pause, std::move(fake_audio_track), context);
 
   audio_sink->SpawnThread();
   return audio_sink;
@@ -185,9 +182,9 @@ AudioTrackAudioSink::AudioTrackAudioSink(
     SbMediaAudioSampleType sample_type,
     SbAudioSinkFrameBuffers frame_buffers,
     int frames_per_channel,
-    int preferred_buffer_size_in_bytes,
+    int preferred_buffer_size,
     AudioTrackAudioSinkType::Callbacks callbacks,
-    int64_t start_time,
+    int64_t start_media_time,
     std::optional<int> tunnel_mode_audio_session_id,
     bool allow_audio_writing_on_pause,
     std::unique_ptr<AudioTrack> audio_track,
@@ -199,7 +196,7 @@ AudioTrackAudioSink::AudioTrackAudioSink(
       frame_buffer_(frame_buffers[0]),
       frames_per_channel_(frames_per_channel),
       callbacks_(callbacks),
-      start_time_(start_time),
+      start_time_(start_media_time),
       max_frames_per_request_(
           !tunnel_mode_audio_session_id
               ? AudioTrack::kMaxFramesPerRequest
@@ -259,7 +256,8 @@ bool AudioTrackAudioSink::Flush() {
 // TODO: Break down the function into manageable pieces.
 void AudioTrackAudioSink::AudioThreadFunc() {
   int frames_in_audio_track = 0;
-  int audio_track_play_state = PLAYSTATE_STOPPED;
+  AudioTrack::PlayState audio_track_play_state =
+      AudioTrack::PlayState::kStopped;
 
   SB_LOG(INFO) << "AudioTrackAudioSink thread started.";
 
@@ -304,8 +302,8 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     audio_track_play_state = audio_track_->GetPlayState();
 
     bool should_update_media_time =
-        (audio_track_play_state == PLAYSTATE_PLAYING ||
-         audio_track_play_state == PLAYSTATE_PAUSED);
+        (audio_track_play_state == AudioTrack::PlayState::kPlaying ||
+         audio_track_play_state == AudioTrack::PlayState::kPaused);
     if (should_update_media_time) {
       playback_head_position =
           audio_track_->GetAudioTimestamp(&frames_consumed_at);
@@ -361,7 +359,8 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       }
     }
 
-    bool is_currently_playing = (audio_track_play_state == PLAYSTATE_PLAYING);
+    bool is_currently_playing =
+        (audio_track_play_state == AudioTrack::PlayState::kPlaying);
     if (is_currently_playing && !is_playing) {
       ScopedTimer timer("Pause");
       audio_track_->Pause();

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -26,7 +26,7 @@
 
 #include "base/memory/raw_ptr.h"
 #include "starboard/android/shared/audio_sink_min_required_frames_tester.h"
-#include "starboard/android/shared/audio_track_bridge.h"
+#include "starboard/android/shared/audio_track.h"
 #include "starboard/audio_sink.h"
 #include "starboard/common/log.h"
 #include "starboard/common/pass_key.h"
@@ -36,15 +36,6 @@
 #include "starboard/shared/starboard/audio_sink/audio_sink_internal.h"
 
 namespace starboard {
-
-// These must be in sync with AudioTrack.PLAYSTATE_XXX constants in
-// AudioTrack.java.
-// Indicates AudioTrack state is stopped.
-constexpr jint PLAYSTATE_STOPPED = 1;
-// Indicates AudioTrack state is paused.
-constexpr jint PLAYSTATE_PAUSED = 2;
-// Indicates AudioTrack state is playing.
-constexpr jint PLAYSTATE_PLAYING = 3;
 
 class AudioTrackAudioSinkType : public SbAudioSinkPrivate::Type {
  public:
@@ -128,6 +119,20 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
       bool is_web_audio,
       bool allow_audio_writing_on_pause,
       void* context);
+  static std::unique_ptr<AudioTrackAudioSink> CreateForTesting(
+      Type* type,
+      int channels,
+      int sampling_frequency_hz,
+      SbMediaAudioSampleType sample_type,
+      SbAudioSinkFrameBuffers frame_buffers,
+      int frames_per_channel,
+      int preferred_buffer_size,
+      AudioTrackAudioSinkType::Callbacks callbacks,
+      int64_t start_media_time,
+      std::optional<int> tunnel_mode_audio_session_id,
+      bool allow_audio_writing_on_pause,
+      std::unique_ptr<AudioTrack> fake_audio_track,
+      void* context);
 
   AudioTrackAudioSink(PassKey<AudioTrackAudioSink>,
                       Type* type,
@@ -141,7 +146,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
                       int64_t start_media_time,
                       std::optional<int> tunnel_mode_audio_session_id,
                       bool allow_audio_writing_on_pause,
-                      std::unique_ptr<AudioTrackBridge> bridge,
+                      std::unique_ptr<AudioTrack> audio_track,
                       void* context);
   ~AudioTrackAudioSink() override;
 
@@ -160,7 +165,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   void AudioThreadFunc();
   void SpawnThread();
 
-  int WriteData(JNIEnv* env, const void* buffer, int size, int64_t sync_time);
+  int WriteData(const void* buffer, int size, int64_t sync_time);
 
   void ReportError(bool capability_changed, const std::string& error_message);
 
@@ -180,7 +185,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
   const bool allow_audio_writing_on_pause_;
 
   // Guaranteed to be non-null.
-  const std::unique_ptr<AudioTrackBridge> bridge_;
+  const std::unique_ptr<AudioTrack> audio_track_;
 
   volatile bool quit_ = false;
   std::atomic_bool flush_requested_{false};

--- a/starboard/android/shared/audio_track_audio_sink_type_test.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type_test.cc
@@ -1,0 +1,148 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/audio_track_audio_sink_type.h"
+
+#include <unistd.h>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+#include "starboard/android/shared/fake_audio_track.h"
+#include "starboard/common/ref_counted.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace {
+
+using ::testing::_;
+using ::testing::DoAll;
+using ::testing::InSequence;
+using ::testing::Return;
+using ::testing::SetArgPointee;
+
+class AudioTrackAudioSinkTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    frame_buffer_.resize(1024 * 2 * sizeof(float), 0);
+    frame_buffers_[0] = frame_buffer_.data();
+  }
+
+  static void UpdateSourceStatusCB(int* frames_in_buffer,
+                                   int* offset_in_frames,
+                                   bool* is_playing,
+                                   bool* is_eos_reached,
+                                   void* context) {
+    auto* fixture = static_cast<AudioTrackAudioSinkTest*>(context);
+    *frames_in_buffer = fixture->frames_in_buffer_;
+    *offset_in_frames = fixture->offset_in_frames_;
+    *is_playing = fixture->is_playing_;
+    *is_eos_reached = fixture->is_eos_reached_;
+  }
+
+  static void ConsumeFramesCB(int frames_consumed,
+                              int64_t frames_consumed_at,
+                              void* context) {
+    auto* fixture = static_cast<AudioTrackAudioSinkTest*>(context);
+    fixture->total_frames_consumed_ += frames_consumed;
+  }
+
+  std::vector<uint8_t> frame_buffer_;
+  void* frame_buffers_[1];
+  int frames_in_buffer_ = 512;
+  int offset_in_frames_ = 0;
+  bool is_playing_ = true;
+  bool is_eos_reached_ = false;
+  int total_frames_consumed_ = 0;
+};
+
+TEST_F(AudioTrackAudioSinkTest, CreateAndDestroy) {
+  AudioTrackAudioSinkType type;
+  auto fake_track = std::make_unique<FakeAudioTrack>(
+      2, 48000, kSbMediaAudioSampleTypeFloat32);
+  FakeAudioTrack* track_ptr = fake_track.get();
+
+  AudioTrackAudioSinkType::Callbacks callbacks{
+      UpdateSourceStatusCB,
+      ConsumeFramesCB,
+      /*error=*/nullptr,
+  };
+
+  auto sink = AudioTrackAudioSink::CreateForTesting(
+      &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
+      512, callbacks, 0,
+      /*tunnel_mode_audio_session_id=*/std::nullopt,
+      /*allow_audio_writing_on_pause=*/false, std::move(fake_track), this);
+
+  ASSERT_NE(sink, nullptr);
+  EXPECT_TRUE(sink->IsType(&type));
+
+  // Let the sink thread run and process frames.
+  int elapsed_ms = 0;
+  while (track_ptr->written_frames() == 0 && elapsed_ms < 1000) {
+    usleep(10'000);
+    elapsed_ms += 10;
+  }
+  EXPECT_GT(track_ptr->written_frames(), 0);
+
+  sink.reset();
+}
+
+TEST_F(AudioTrackAudioSinkTest, PauseAndResumePlayback) {
+  AudioTrackAudioSinkType type;
+  auto fake_track = std::make_unique<FakeAudioTrack>(
+      2, 48000, kSbMediaAudioSampleTypeFloat32);
+  FakeAudioTrack* track_ptr = fake_track.get();
+
+  AudioTrackAudioSinkType::Callbacks callbacks{
+      UpdateSourceStatusCB,
+      ConsumeFramesCB,
+      /*error=*/nullptr,
+  };
+
+  auto sink = AudioTrackAudioSink::CreateForTesting(
+      &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
+      512, callbacks, 0,
+      /*tunnel_mode_audio_session_id=*/std::nullopt,
+      /*allow_audio_writing_on_pause=*/false, std::move(fake_track), this);
+
+  ASSERT_NE(sink, nullptr);
+  int elapsed_ms = 0;
+  while (track_ptr->play_state() != PLAYSTATE_PLAYING && elapsed_ms < 1000) {
+    usleep(10'000);
+    elapsed_ms += 10;
+  }
+  EXPECT_EQ(track_ptr->play_state(), PLAYSTATE_PLAYING);
+
+  is_playing_ = false;
+  elapsed_ms = 0;
+  while (track_ptr->play_state() != PLAYSTATE_PAUSED && elapsed_ms < 1000) {
+    usleep(10'000);
+    elapsed_ms += 10;
+  }
+  EXPECT_EQ(track_ptr->play_state(), PLAYSTATE_PAUSED);
+
+  is_playing_ = true;
+  elapsed_ms = 0;
+  while (track_ptr->play_state() != PLAYSTATE_PLAYING && elapsed_ms < 1000) {
+    usleep(10'000);
+    elapsed_ms += 10;
+  }
+  EXPECT_EQ(track_ptr->play_state(), PLAYSTATE_PLAYING);
+}
+
+}  // namespace
+}  // namespace starboard

--- a/starboard/android/shared/audio_track_audio_sink_type_test.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type_test.cc
@@ -16,6 +16,7 @@
 
 #include <unistd.h>
 
+#include <atomic>
 #include <memory>
 #include <optional>
 #include <vector>
@@ -62,11 +63,11 @@ class AudioTrackAudioSinkTest : public ::testing::Test {
 
   std::vector<uint8_t> frame_buffer_;
   void* frame_buffers_[1];
-  int frames_in_buffer_ = 512;
-  int offset_in_frames_ = 0;
-  bool is_playing_ = true;
-  bool is_eos_reached_ = false;
-  int total_frames_consumed_ = 0;
+  std::atomic<int> frames_in_buffer_ = 512;
+  std::atomic<int> offset_in_frames_ = 0;
+  std::atomic<bool> is_playing_ = true;
+  std::atomic<bool> is_eos_reached_ = false;
+  std::atomic<int> total_frames_consumed_ = 0;
 };
 
 TEST_F(AudioTrackAudioSinkTest, CreateAndDestroy) {
@@ -121,27 +122,30 @@ TEST_F(AudioTrackAudioSinkTest, PauseAndResumePlayback) {
 
   ASSERT_NE(sink, nullptr);
   int elapsed_ms = 0;
-  while (track_ptr->play_state() != PLAYSTATE_PLAYING && elapsed_ms < 1000) {
+  while (track_ptr->play_state() != AudioTrack::PlayState::kPlaying &&
+         elapsed_ms < 1000) {
     usleep(10'000);
     elapsed_ms += 10;
   }
-  EXPECT_EQ(track_ptr->play_state(), PLAYSTATE_PLAYING);
+  EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
 
   is_playing_ = false;
   elapsed_ms = 0;
-  while (track_ptr->play_state() != PLAYSTATE_PAUSED && elapsed_ms < 1000) {
+  while (track_ptr->play_state() != AudioTrack::PlayState::kPaused &&
+         elapsed_ms < 1000) {
     usleep(10'000);
     elapsed_ms += 10;
   }
-  EXPECT_EQ(track_ptr->play_state(), PLAYSTATE_PAUSED);
+  EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPaused);
 
   is_playing_ = true;
   elapsed_ms = 0;
-  while (track_ptr->play_state() != PLAYSTATE_PLAYING && elapsed_ms < 1000) {
+  while (track_ptr->play_state() != AudioTrack::PlayState::kPlaying &&
+         elapsed_ms < 1000) {
     usleep(10'000);
     elapsed_ms += 10;
   }
-  EXPECT_EQ(track_ptr->play_state(), PLAYSTATE_PLAYING);
+  EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
 }
 
 }  // namespace

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -137,30 +137,26 @@ AudioTrackBridge::~AudioTrackBridge() {
   }
 }
 
-void AudioTrackBridge::Play(JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+void AudioTrackBridge::Play() {
+  JNIEnv* env = AttachCurrentThread();
   Java_AudioTrackBridge_play(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge playing.";
 }
 
-void AudioTrackBridge::Pause(JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+void AudioTrackBridge::Pause() {
+  JNIEnv* env = AttachCurrentThread();
   Java_AudioTrackBridge_pause(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge paused.";
 }
 
-void AudioTrackBridge::Stop(JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+void AudioTrackBridge::Stop() {
+  JNIEnv* env = AttachCurrentThread();
   Java_AudioTrackBridge_stop(env, j_audio_track_bridge_);
   SB_LOG(INFO) << "AudioTrackBridge stopped.";
 }
 
-void AudioTrackBridge::PauseAndFlush(JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+void AudioTrackBridge::PauseAndFlush() {
+  JNIEnv* env = AttachCurrentThread();
   // For an immediate stop, use pause(), followed by flush() to discard audio
   // data that hasn't been played back yet.
   Java_AudioTrackBridge_pause(env, j_audio_track_bridge_);
@@ -169,11 +165,9 @@ void AudioTrackBridge::PauseAndFlush(JNIEnv* env /*= AttachCurrentThread()*/) {
   Java_AudioTrackBridge_flush(env, j_audio_track_bridge_);
 }
 
-int AudioTrackBridge::WriteSample(const float* samples,
-                                  int num_of_samples,
-                                  JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+int AudioTrackBridge::WriteSample(Span<const float> samples) {
+  JNIEnv* env = AttachCurrentThread();
+  int num_of_samples = static_cast<int>(samples.size());
   SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
@@ -181,18 +175,17 @@ int AudioTrackBridge::WriteSample(const float* samples,
   SB_CHECK(std::holds_alternative<FloatArray>(j_audio_data_));
   const auto& float_array = std::get<FloatArray>(j_audio_data_);
 
-  SetFloatArrayRegion(env, float_array, kNoOffset, num_of_samples, samples);
+  SetFloatArrayRegion(env, float_array, kNoOffset, num_of_samples,
+                      samples.data());
 
   return Java_AudioTrackBridge_write(env, j_audio_track_bridge_, float_array,
                                      num_of_samples);
 }
 
-int AudioTrackBridge::WriteSample(const uint16_t* samples,
-                                  int num_of_samples,
-                                  int64_t sync_time,
-                                  JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+int AudioTrackBridge::WriteSample(Span<const uint16_t> samples,
+                                  int64_t sync_time) {
+  JNIEnv* env = AttachCurrentThread();
+  int num_of_samples = static_cast<int>(samples.size());
   SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
 
   num_of_samples = std::min(num_of_samples, max_samples_per_write_);
@@ -202,7 +195,7 @@ int AudioTrackBridge::WriteSample(const uint16_t* samples,
 
   SetByteArrayRegion(env, byte_array, kNoOffset,
                      num_of_samples * sizeof(uint16_t),
-                     reinterpret_cast<const jbyte*>(samples));
+                     reinterpret_cast<const jbyte*>(samples.data()));
 
   int bytes_written = Java_AudioTrackBridge_writeWithPresentationTime(
       env, j_audio_track_bridge_, byte_array, num_of_samples * sizeof(uint16_t),
@@ -216,24 +209,22 @@ int AudioTrackBridge::WriteSample(const uint16_t* samples,
   return bytes_written / sizeof(uint16_t);
 }
 
-int AudioTrackBridge::WriteSample(const uint8_t* samples,
-                                  int num_of_samples,
-                                  int64_t sync_time,
-                                  JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
+int AudioTrackBridge::WriteSample(Span<const uint8_t> buffer,
+                                  int64_t sync_time) {
+  JNIEnv* env = AttachCurrentThread();
+  int num_of_bytes = static_cast<int>(buffer.size());
+  SB_DCHECK_LE(num_of_bytes, max_samples_per_write_);
 
-  SB_DCHECK_LE(num_of_samples, max_samples_per_write_);
-
-  num_of_samples = std::min(num_of_samples, max_samples_per_write_);
+  num_of_bytes = std::min(num_of_bytes, max_samples_per_write_);
 
   SB_CHECK(std::holds_alternative<ByteArray>(j_audio_data_));
   const auto& byte_array = std::get<ByteArray>(j_audio_data_);
 
-  SetByteArrayRegion(env, byte_array, kNoOffset, num_of_samples,
-                     reinterpret_cast<const jbyte*>(samples));
+  SetByteArrayRegion(env, byte_array, kNoOffset, num_of_bytes,
+                     reinterpret_cast<const jbyte*>(buffer.data()));
 
   int bytes_written = Java_AudioTrackBridge_writeWithPresentationTime(
-      env, j_audio_track_bridge_, byte_array, num_of_samples, sync_time);
+      env, j_audio_track_bridge_, byte_array, num_of_bytes, sync_time);
 
   if (bytes_written < 0) {
     // Error code returned as negative value, like AudioTrack.ERROR_DEAD_OBJECT.
@@ -242,11 +233,8 @@ int AudioTrackBridge::WriteSample(const uint8_t* samples,
   return bytes_written;
 }
 
-void AudioTrackBridge::SetPlaybackRate(
-    double playback_rate,
-    JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+void AudioTrackBridge::SetPlaybackRate(double playback_rate) {
+  JNIEnv* env = AttachCurrentThread();
   // AudioTrack doesn't support playback speed of 0.
   SB_DCHECK_GT(playback_rate, 0.0);
 
@@ -257,10 +245,8 @@ void AudioTrackBridge::SetPlaybackRate(
   }
 }
 
-void AudioTrackBridge::SetVolume(double volume,
-                                 JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+void AudioTrackBridge::SetVolume(double volume) {
+  JNIEnv* env = AttachCurrentThread();
   jint status = Java_AudioTrackBridge_setVolume(env, j_audio_track_bridge_,
                                                 static_cast<float>(volume));
   if (status != 0) {
@@ -268,11 +254,8 @@ void AudioTrackBridge::SetVolume(double volume,
   }
 }
 
-int64_t AudioTrackBridge::GetAudioTimestamp(
-    int64_t* updated_at,
-    JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+int64_t AudioTrackBridge::GetAudioTimestamp(int64_t* updated_at) {
+  JNIEnv* env = AttachCurrentThread();
   ScopedJavaLocalRef<jobject> j_audio_timestamp =
       Java_AudioTrackBridge_getAudioTimestamp(env, j_audio_track_bridge_);
   SB_DCHECK(!j_audio_timestamp.is_null());
@@ -284,32 +267,25 @@ int64_t AudioTrackBridge::GetAudioTimestamp(
   return Java_AudioTimestamp_getFramePosition(env, j_audio_timestamp);
 }
 
-bool AudioTrackBridge::GetAndResetHasAudioDeviceChanged(
-    JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+bool AudioTrackBridge::GetAndResetHasAudioDeviceChanged() {
+  JNIEnv* env = AttachCurrentThread();
   return AudioOutputManager::GetInstance()->GetAndResetHasAudioDeviceChanged(
       env);
 }
 
-int AudioTrackBridge::GetUnderrunCount(
-    JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+int AudioTrackBridge::GetUnderrunCount() {
+  JNIEnv* env = AttachCurrentThread();
   return Java_AudioTrackBridge_getUnderrunCount(env, j_audio_track_bridge_);
 }
 
-int AudioTrackBridge::GetStartThresholdInFrames(
-    JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+int AudioTrackBridge::GetStartThresholdInFrames() {
+  JNIEnv* env = AttachCurrentThread();
   return Java_AudioTrackBridge_getStartThresholdInFrames(env,
                                                          j_audio_track_bridge_);
 }
 
-int AudioTrackBridge::GetPlayState(JNIEnv* env /*= AttachCurrentThread()*/) {
-  SB_DCHECK(env);
-
+int AudioTrackBridge::GetPlayState() {
+  JNIEnv* env = AttachCurrentThread();
   return Java_AudioTrackBridge_getPlayState(env, j_audio_track_bridge_);
 }
 

--- a/starboard/android/shared/audio_track_bridge.cc
+++ b/starboard/android/shared/audio_track_bridge.cc
@@ -284,9 +284,10 @@ int AudioTrackBridge::GetStartThresholdInFrames() {
                                                          j_audio_track_bridge_);
 }
 
-int AudioTrackBridge::GetPlayState() {
+AudioTrack::PlayState AudioTrackBridge::GetPlayState() {
   JNIEnv* env = AttachCurrentThread();
-  return Java_AudioTrackBridge_getPlayState(env, j_audio_track_bridge_);
+  return static_cast<PlayState>(
+      Java_AudioTrackBridge_getPlayState(env, j_audio_track_bridge_));
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -23,6 +23,7 @@
 #include <optional>
 #include <variant>
 
+#include "starboard/android/shared/audio_track.h"
 #include "starboard/common/pass_key.h"
 #include "starboard/media.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -30,7 +31,7 @@
 namespace starboard {
 
 // The C++ encapsulation of the Java class AudioTrackBridge.
-class AudioTrackBridge {
+class AudioTrackBridge : public AudioTrack {
  public:
   using FloatArray = jni_zero::ScopedJavaGlobalRef<jfloatArray>;
   using ByteArray = jni_zero::ScopedJavaGlobalRef<jbyteArray>;
@@ -38,9 +39,10 @@ class AudioTrackBridge {
 
   // The maximum number of frames that can be written to android audio track per
   // write request.  It is used to pre-allocate |j_audio_data_|.
-  static constexpr int kMaxFramesPerRequest = 65536;
+  static constexpr int kMaxFramesPerRequest = AudioTrack::kMaxFramesPerRequest;
   // The same as Android AudioTrack.ERROR_DEAD_OBJECT.
-  static constexpr int kAudioTrackErrorDeadObject = -6;
+  static constexpr int kAudioTrackErrorDeadObject =
+      AudioTrack::kAudioTrackErrorDeadObject;
 
   static std::unique_ptr<AudioTrackBridge> Create(
       SbMediaAudioCodingType coding_type,
@@ -56,43 +58,32 @@ class AudioTrackBridge {
       int max_samples_per_write,
       const jni_zero::ScopedJavaLocalRef<jobject>& j_audio_track_bridge,
       const DataArray& j_audio_data);
-  ~AudioTrackBridge();
+  ~AudioTrackBridge() override;
 
-  void Play(JNIEnv* env = jni_zero::AttachCurrentThread());
-  void Pause(JNIEnv* env = jni_zero::AttachCurrentThread());
-  void Stop(JNIEnv* env = jni_zero::AttachCurrentThread());
-  void PauseAndFlush(JNIEnv* env = jni_zero::AttachCurrentThread());
+  void Play() override;
+  void Pause() override;
+  void Stop() override;
+  void PauseAndFlush() override;
 
   // Returns zero or the positive number of samples written, or a negative error
   // code.
-  int WriteSample(const float* samples,
-                  int num_of_samples,
-                  JNIEnv* env = jni_zero::AttachCurrentThread());
-  int WriteSample(const uint16_t* samples,
-                  int num_of_samples,
-                  int64_t sync_time,
-                  JNIEnv* env = jni_zero::AttachCurrentThread());
+  int WriteSample(Span<const float> samples) override;
+  int WriteSample(Span<const uint16_t> samples, int64_t sync_time) override;
   // This is used by passthrough, it treats samples as if they are in bytes.
   // Returns zero or the positive number of samples written, or a negative error
   // code.
-  int WriteSample(const uint8_t* buffer,
-                  int num_of_samples,
-                  int64_t sync_time,
-                  JNIEnv* env = jni_zero::AttachCurrentThread());
+  int WriteSample(Span<const uint8_t> buffer, int64_t sync_time) override;
 
-  void SetPlaybackRate(double playback_rate,
-                       JNIEnv* env = jni_zero::AttachCurrentThread());
-  void SetVolume(double volume, JNIEnv* env = jni_zero::AttachCurrentThread());
+  void SetPlaybackRate(double playback_rate) override;
+  void SetVolume(double volume) override;
 
   // |updated_at| contains the timestamp when the audio timestamp is updated on
   // return.  It can be nullptr.
-  int64_t GetAudioTimestamp(int64_t* updated_at,
-                            JNIEnv* env = jni_zero::AttachCurrentThread());
-  bool GetAndResetHasAudioDeviceChanged(
-      JNIEnv* env = jni_zero::AttachCurrentThread());
-  int GetUnderrunCount(JNIEnv* env = jni_zero::AttachCurrentThread());
-  int GetStartThresholdInFrames(JNIEnv* env = jni_zero::AttachCurrentThread());
-  int GetPlayState(JNIEnv* env = jni_zero::AttachCurrentThread());
+  int64_t GetAudioTimestamp(int64_t* updated_at) override;
+  bool GetAndResetHasAudioDeviceChanged() override;
+  int GetUnderrunCount() override;
+  int GetStartThresholdInFrames() override;
+  int GetPlayState() override;
 
  private:
   const int max_samples_per_write_;

--- a/starboard/android/shared/audio_track_bridge.h
+++ b/starboard/android/shared/audio_track_bridge.h
@@ -37,13 +37,6 @@ class AudioTrackBridge : public AudioTrack {
   using ByteArray = jni_zero::ScopedJavaGlobalRef<jbyteArray>;
   using DataArray = std::variant<FloatArray, ByteArray>;
 
-  // The maximum number of frames that can be written to android audio track per
-  // write request.  It is used to pre-allocate |j_audio_data_|.
-  static constexpr int kMaxFramesPerRequest = AudioTrack::kMaxFramesPerRequest;
-  // The same as Android AudioTrack.ERROR_DEAD_OBJECT.
-  static constexpr int kAudioTrackErrorDeadObject =
-      AudioTrack::kAudioTrackErrorDeadObject;
-
   static std::unique_ptr<AudioTrackBridge> Create(
       SbMediaAudioCodingType coding_type,
       std::optional<SbMediaAudioSampleType> sample_type,
@@ -83,7 +76,7 @@ class AudioTrackBridge : public AudioTrack {
   bool GetAndResetHasAudioDeviceChanged() override;
   int GetUnderrunCount() override;
   int GetStartThresholdInFrames() override;
-  int GetPlayState() override;
+  PlayState GetPlayState() override;
 
  private:
   const int max_samples_per_write_;

--- a/starboard/android/shared/fake_audio_track.cc
+++ b/starboard/android/shared/fake_audio_track.cc
@@ -32,25 +32,24 @@ FakeAudioTrack::FakeAudioTrack(int channels,
 
 void FakeAudioTrack::Play() {
   std::lock_guard lock(mutex_);
-  play_state_ = PLAYSTATE_PLAYING;
+  play_state_ = PlayState::kPlaying;
 }
 
 void FakeAudioTrack::Pause() {
   std::lock_guard lock(mutex_);
-  play_state_ = PLAYSTATE_PAUSED;
+  play_state_ = PlayState::kPaused;
 }
 
 void FakeAudioTrack::Stop() {
   std::lock_guard lock(mutex_);
-  play_state_ = PLAYSTATE_STOPPED;
+  play_state_ = PlayState::kStopped;
 }
 
 void FakeAudioTrack::PauseAndFlush() {
   std::lock_guard lock(mutex_);
-  play_state_ = PLAYSTATE_PAUSED;
+  play_state_ = PlayState::kPaused;
   written_frames_ = 0;
   consumed_frames_ = 0;
-  written_data_.clear();
 }
 
 int FakeAudioTrack::WriteSample(Span<const float> samples) {
@@ -60,11 +59,6 @@ int FakeAudioTrack::WriteSample(Span<const float> samples) {
   }
   SB_CHECK_EQ(sample_type_, kSbMediaAudioSampleTypeFloat32);
   SB_CHECK_EQ(samples.size() % channels_, 0u);
-
-  size_t bytes_to_append = samples.size() * sizeof(float);
-  const uint8_t* byte_ptr = reinterpret_cast<const uint8_t*>(samples.data());
-  written_data_.insert(written_data_.end(), byte_ptr,
-                       byte_ptr + bytes_to_append);
 
   written_frames_ += samples.size() / channels_;
   return static_cast<int>(samples.size());
@@ -79,11 +73,6 @@ int FakeAudioTrack::WriteSample(Span<const uint16_t> samples,
   SB_CHECK_EQ(sample_type_, kSbMediaAudioSampleTypeInt16Deprecated);
   SB_CHECK_EQ(samples.size() % channels_, 0u);
 
-  size_t bytes_to_append = samples.size() * sizeof(uint16_t);
-  const uint8_t* byte_ptr = reinterpret_cast<const uint8_t*>(samples.data());
-  written_data_.insert(written_data_.end(), byte_ptr,
-                       byte_ptr + bytes_to_append);
-
   written_frames_ += samples.size() / channels_;
   return static_cast<int>(samples.size());
 }
@@ -93,8 +82,6 @@ int FakeAudioTrack::WriteSample(Span<const uint8_t> buffer, int64_t sync_time) {
   if (write_error_code_ != 0) {
     return write_error_code_;
   }
-  written_data_.insert(written_data_.end(), buffer.data(),
-                       buffer.data() + buffer.size());
   written_frames_ += buffer.size() / channels_;
   return static_cast<int>(buffer.size());
 }
@@ -134,7 +121,7 @@ int FakeAudioTrack::GetStartThresholdInFrames() {
   return start_threshold_;
 }
 
-int FakeAudioTrack::GetPlayState() {
+AudioTrack::PlayState FakeAudioTrack::GetPlayState() {
   std::lock_guard lock(mutex_);
   return play_state_;
 }
@@ -159,7 +146,7 @@ double FakeAudioTrack::volume() const {
   return volume_;
 }
 
-int FakeAudioTrack::play_state() const {
+AudioTrack::PlayState FakeAudioTrack::play_state() const {
   std::lock_guard lock(mutex_);
   return play_state_;
 }

--- a/starboard/android/shared/fake_audio_track.cc
+++ b/starboard/android/shared/fake_audio_track.cc
@@ -1,0 +1,187 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/fake_audio_track.h"
+
+#include <algorithm>
+#include <cstring>
+#include <mutex>
+
+#include "starboard/common/check_op.h"
+#include "starboard/common/time.h"
+
+namespace starboard {
+
+FakeAudioTrack::FakeAudioTrack(int channels,
+                               int sampling_frequency_hz,
+                               SbMediaAudioSampleType sample_type)
+    : channels_(channels), sample_type_(sample_type) {
+  SB_CHECK_GT(channels_, 0);
+}
+
+void FakeAudioTrack::Play() {
+  std::lock_guard lock(mutex_);
+  play_state_ = PLAYSTATE_PLAYING;
+}
+
+void FakeAudioTrack::Pause() {
+  std::lock_guard lock(mutex_);
+  play_state_ = PLAYSTATE_PAUSED;
+}
+
+void FakeAudioTrack::Stop() {
+  std::lock_guard lock(mutex_);
+  play_state_ = PLAYSTATE_STOPPED;
+}
+
+void FakeAudioTrack::PauseAndFlush() {
+  std::lock_guard lock(mutex_);
+  play_state_ = PLAYSTATE_PAUSED;
+  written_frames_ = 0;
+  consumed_frames_ = 0;
+  written_data_.clear();
+}
+
+int FakeAudioTrack::WriteSample(Span<const float> samples) {
+  std::lock_guard lock(mutex_);
+  if (write_error_code_ != 0) {
+    return write_error_code_;
+  }
+  SB_CHECK_EQ(sample_type_, kSbMediaAudioSampleTypeFloat32);
+  SB_CHECK_EQ(samples.size() % channels_, 0u);
+
+  size_t bytes_to_append = samples.size() * sizeof(float);
+  const uint8_t* byte_ptr = reinterpret_cast<const uint8_t*>(samples.data());
+  written_data_.insert(written_data_.end(), byte_ptr,
+                       byte_ptr + bytes_to_append);
+
+  written_frames_ += samples.size() / channels_;
+  return static_cast<int>(samples.size());
+}
+
+int FakeAudioTrack::WriteSample(Span<const uint16_t> samples,
+                                int64_t sync_time) {
+  std::lock_guard lock(mutex_);
+  if (write_error_code_ != 0) {
+    return write_error_code_;
+  }
+  SB_CHECK_EQ(sample_type_, kSbMediaAudioSampleTypeInt16Deprecated);
+  SB_CHECK_EQ(samples.size() % channels_, 0u);
+
+  size_t bytes_to_append = samples.size() * sizeof(uint16_t);
+  const uint8_t* byte_ptr = reinterpret_cast<const uint8_t*>(samples.data());
+  written_data_.insert(written_data_.end(), byte_ptr,
+                       byte_ptr + bytes_to_append);
+
+  written_frames_ += samples.size() / channels_;
+  return static_cast<int>(samples.size());
+}
+
+int FakeAudioTrack::WriteSample(Span<const uint8_t> buffer, int64_t sync_time) {
+  std::lock_guard lock(mutex_);
+  if (write_error_code_ != 0) {
+    return write_error_code_;
+  }
+  written_data_.insert(written_data_.end(), buffer.data(),
+                       buffer.data() + buffer.size());
+  written_frames_ += buffer.size() / channels_;
+  return static_cast<int>(buffer.size());
+}
+
+void FakeAudioTrack::SetPlaybackRate(double playback_rate) {
+  std::lock_guard lock(mutex_);
+  playback_rate_ = playback_rate;
+}
+
+void FakeAudioTrack::SetVolume(double volume) {
+  std::lock_guard lock(mutex_);
+  volume_ = volume;
+}
+
+int64_t FakeAudioTrack::GetAudioTimestamp(int64_t* updated_at) {
+  std::lock_guard lock(mutex_);
+  if (updated_at) {
+    *updated_at = CurrentMonotonicTime();
+  }
+  return consumed_frames_;
+}
+
+bool FakeAudioTrack::GetAndResetHasAudioDeviceChanged() {
+  std::lock_guard lock(mutex_);
+  bool changed = device_changed_;
+  device_changed_ = false;
+  return changed;
+}
+
+int FakeAudioTrack::GetUnderrunCount() {
+  std::lock_guard lock(mutex_);
+  return underrun_count_;
+}
+
+int FakeAudioTrack::GetStartThresholdInFrames() {
+  std::lock_guard lock(mutex_);
+  return start_threshold_;
+}
+
+int FakeAudioTrack::GetPlayState() {
+  std::lock_guard lock(mutex_);
+  return play_state_;
+}
+
+int64_t FakeAudioTrack::written_frames() const {
+  std::lock_guard lock(mutex_);
+  return written_frames_;
+}
+
+int64_t FakeAudioTrack::consumed_frames() const {
+  std::lock_guard lock(mutex_);
+  return consumed_frames_;
+}
+
+double FakeAudioTrack::playback_rate() const {
+  std::lock_guard lock(mutex_);
+  return playback_rate_;
+}
+
+double FakeAudioTrack::volume() const {
+  std::lock_guard lock(mutex_);
+  return volume_;
+}
+
+int FakeAudioTrack::play_state() const {
+  std::lock_guard lock(mutex_);
+  return play_state_;
+}
+
+void FakeAudioTrack::set_consumed_frames(int64_t consumed) {
+  std::lock_guard lock(mutex_);
+  consumed_frames_ = consumed;
+}
+
+void FakeAudioTrack::simulate_device_change(bool changed) {
+  std::lock_guard lock(mutex_);
+  device_changed_ = changed;
+}
+
+void FakeAudioTrack::set_underrun_count(int count) {
+  std::lock_guard lock(mutex_);
+  underrun_count_ = count;
+}
+
+void FakeAudioTrack::set_write_error(int error_code) {
+  std::lock_guard lock(mutex_);
+  write_error_code_ = error_code;
+}
+
+}  // namespace starboard

--- a/starboard/android/shared/fake_audio_track.h
+++ b/starboard/android/shared/fake_audio_track.h
@@ -51,14 +51,14 @@ class FakeAudioTrack : public AudioTrack {
   bool GetAndResetHasAudioDeviceChanged() override;
   int GetUnderrunCount() override;
   int GetStartThresholdInFrames() override;
-  int GetPlayState() override;
+  PlayState GetPlayState() override;
 
   // Test control & inspection methods
   int64_t written_frames() const;
   int64_t consumed_frames() const;
   double playback_rate() const;
   double volume() const;
-  int play_state() const;
+  PlayState play_state() const;
   void set_consumed_frames(int64_t consumed);
   void simulate_device_change(bool changed);
   void set_underrun_count(int count);
@@ -69,7 +69,7 @@ class FakeAudioTrack : public AudioTrack {
   const SbMediaAudioSampleType sample_type_;
 
   mutable std::mutex mutex_;
-  int play_state_ = PLAYSTATE_STOPPED;
+  PlayState play_state_ = PlayState::kStopped;
   int64_t written_frames_ = 0;
   int64_t consumed_frames_ = 0;
   double playback_rate_ = 1.0;
@@ -78,7 +78,6 @@ class FakeAudioTrack : public AudioTrack {
   int underrun_count_ = 0;
   int start_threshold_ = 1024;
   int write_error_code_ = 0;
-  std::vector<uint8_t> written_data_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/fake_audio_track.h
+++ b/starboard/android/shared/fake_audio_track.h
@@ -1,0 +1,86 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_FAKE_AUDIO_TRACK_H_
+#define STARBOARD_ANDROID_SHARED_FAKE_AUDIO_TRACK_H_
+
+#include <atomic>
+#include <cstdint>
+#include <mutex>
+#include <vector>
+
+#include "starboard/android/shared/audio_track.h"
+
+namespace starboard {
+
+// FakeAudioTrack is a thread-safe simulation of Android's AudioTrack,
+// used to verify audio sink logic in unit tests.
+//
+// This class is thread-safe.
+class FakeAudioTrack : public AudioTrack {
+ public:
+  explicit FakeAudioTrack(int channels,
+                          int sampling_frequency_hz,
+                          SbMediaAudioSampleType sample_type);
+  ~FakeAudioTrack() override = default;
+
+  void Play() override;
+  void Pause() override;
+  void Stop() override;
+  void PauseAndFlush() override;
+
+  int WriteSample(Span<const float> samples) override;
+  int WriteSample(Span<const uint16_t> samples, int64_t sync_time) override;
+  int WriteSample(Span<const uint8_t> buffer, int64_t sync_time) override;
+
+  void SetPlaybackRate(double playback_rate) override;
+  void SetVolume(double volume) override;
+
+  int64_t GetAudioTimestamp(int64_t* updated_at) override;
+  bool GetAndResetHasAudioDeviceChanged() override;
+  int GetUnderrunCount() override;
+  int GetStartThresholdInFrames() override;
+  int GetPlayState() override;
+
+  // Test control & inspection methods
+  int64_t written_frames() const;
+  int64_t consumed_frames() const;
+  double playback_rate() const;
+  double volume() const;
+  int play_state() const;
+  void set_consumed_frames(int64_t consumed);
+  void simulate_device_change(bool changed);
+  void set_underrun_count(int count);
+  void set_write_error(int error_code);
+
+ private:
+  const int channels_;
+  const SbMediaAudioSampleType sample_type_;
+
+  mutable std::mutex mutex_;
+  int play_state_ = PLAYSTATE_STOPPED;
+  int64_t written_frames_ = 0;
+  int64_t consumed_frames_ = 0;
+  double playback_rate_ = 1.0;
+  double volume_ = 1.0;
+  bool device_changed_ = false;
+  int underrun_count_ = 0;
+  int start_threshold_ = 1024;
+  int write_error_code_ = 0;
+  std::vector<uint8_t> written_data_;
+};
+
+}  // namespace starboard
+
+#endif  // STARBOARD_ANDROID_SHARED_FAKE_AUDIO_TRACK_H_

--- a/starboard/common/span.h
+++ b/starboard/common/span.h
@@ -29,7 +29,8 @@ class Span {
   constexpr Span() = default;
   constexpr Span(T* data, size_t size) : data_(data), size_(size) {}
 
-  template <class U, class = std::enable_if_t<std::is_convertible_v<U*, T*>>>
+  template <class U,
+            class = std::enable_if_t<std::is_convertible_v<U (*)[], T (*)[]>>>
   constexpr Span(const Span<U>& other)
       : data_(other.data()), size_(other.size()) {}
 

--- a/starboard/common/span.h
+++ b/starboard/common/span.h
@@ -16,6 +16,7 @@
 #define STARBOARD_COMMON_SPAN_H_
 
 #include <cstddef>
+#include <type_traits>
 
 // A simple, lightweight alternative to C++20's std::span.
 // Designed to pass a pointer and size together as a single object.
@@ -28,6 +29,10 @@ class Span {
   constexpr Span() = default;
   constexpr Span(T* data, size_t size) : data_(data), size_(size) {}
 
+  template <class U, class = std::enable_if_t<std::is_convertible_v<U*, T*>>>
+  constexpr Span(const Span<U>& other)
+      : data_(other.data()), size_(other.size()) {}
+
   // Member functions are named to match C++20's std::span for future
   // compatibility.
   constexpr T* data() const { return data_; }
@@ -38,6 +43,12 @@ class Span {
   T* data_ = nullptr;
   size_t size_ = 0;
 };
+
+// Helper function analogous to absl::MakeSpan or base::make_span.
+template <class T>
+constexpr Span<T> MakeSpan(T* data, size_t size) {
+  return Span<T>(data, size);
+}
 
 }  // namespace starboard
 

--- a/starboard/common/span.h
+++ b/starboard/common/span.h
@@ -29,6 +29,7 @@ class Span {
   constexpr Span() = default;
   constexpr Span(T* data, size_t size) : data_(data), size_(size) {}
 
+  // Permits safe qualification conversions (e.g. Span<T> to Span<const T>).
   template <class U,
             class = std::enable_if_t<std::is_convertible_v<U (*)[], T (*)[]>>>
   constexpr Span(const Span<U>& other)


### PR DESCRIPTION
Introduce an abstract AudioTrack C++ interface to decouple
AudioTrackAudioSink from its underlying JNI implementation. This
refactoring enables the injection of a FakeAudioTrack for unit
testing and removes JNI dependencies from the audio sink. This
interface also enable simple switch between current java-based audio
track and NDK-based audio track, which will come.

Update audio data passing to utilize starboard::Span for improved
consistency and safety. Add comprehensive unit tests for the
Android audio sink and a fake track implementation to verify
playback state transitions and data handling.

Issue: 512137801
Issue: 428008986