### PR TITLE
Enable v8 memory saving features for 3p

### DIFF
--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -121,6 +121,14 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
        // Disable decommitting pooled pages to prevent virtual memory
        // fragmentation.
        "--no-decommit-pooled-pages "
+       // Enable memory saving mode with little v8 performance tradeoff.
+       "--optimize-for-size "
+       // Set initial old space size to 64MB and max old space size to 512MB.
+       "--initial-old-space-size=64 "
+       "--max-old-space-size=512 "
+       // Disable v8 optimizing compilers (turbofan, maglev, sparkplug).
+       "--disable-optimizing-compilers "
+       "--no-sparkplug "
        // Disable v8 concurrent marking by default.
        "--no-concurrent-marking"},
       // Disable CC image cache items limit.


### PR DESCRIPTION
Three flags are set in Android but were not passed in for 3p, they have showed significant memory improvement from C26 experiments: 

- `optimize-for-size`: enable v8 memory saving mode
- `initial-old-space-size=64` and `max-old-space-size=512`: configure initial old space size and max old space size

Adding two new flags from recent experiment: 
- `disable-optimizing-compilers` and `no-sparkplug`: disable v8 optimizing compilers (i.e. turbofan, maglev, and sparkplug) that are not needed for cobalt. 


Bug: 512163617