### PR TITLE
Enable stack sanitization for Android TV

### DIFF
--- a/cobalt/app/cobalt_crash_reporter_client.cc
+++ b/cobalt/app/cobalt_crash_reporter_client.cc
@@ -96,3 +96,23 @@ bool CobaltCrashReporterClient::IsRunningUnattended() {
 std::string CobaltCrashReporterClient::GetUploadUrl() {
   return kCrashReportUrl;
 }
+
+// Overrides the default behavior to explicitly enable stack sanitization.
+// Setting *sanitize_stacks = true ensures that all stack memory in the
+// minidump is overwritten with the 0x0DEFACED pattern.
+// This aligns the native Android crashpad path with the
+// behavior established in the Starboard crashpad wrapper for 3P platforms.
+void CobaltCrashReporterClient::GetSanitizationInformation(
+    const char* const** allowed_annotations,
+    void** target_module,
+    bool* sanitize_stacks) {
+  if (allowed_annotations) {
+    *allowed_annotations = nullptr;
+  }
+  if (target_module) {
+    *target_module = nullptr;
+  }
+  if (sanitize_stacks) {
+    *sanitize_stacks = true;
+  }
+}

--- a/cobalt/app/cobalt_crash_reporter_client.h
+++ b/cobalt/app/cobalt_crash_reporter_client.h
@@ -38,6 +38,10 @@ class CobaltCrashReporterClient : public crash_reporter::CrashReporterClient {
 
   std::string GetUploadUrl() override;
 
+  void GetSanitizationInformation(const char* const** allowed_annotations,
+                                  void** target_module,
+                                  bool* sanitize_stacks) override;
+
  private:
   friend class base::NoDestructor<CobaltCrashReporterClient>;
 

--- a/components/crash/core/app/crashpad_android.cc
+++ b/components/crash/core/app/crashpad_android.cc
@@ -567,6 +567,13 @@ class HandlerStarter {
       return database_path;
     }
 
+#if BUILDFLAG(IS_COBALT)
+    // Disable periodic tasks. In the Android "at-crash" execution model, this
+    // flag prevents an unnecessary file system scan for pending reports, reducing
+    // thread contention during the critical crash dumping window.
+    // TODO: Implement actual database pruning for Android TV.
+    arguments.push_back("--no-periodic-tasks");
+#endif
     if (crashpad::SetSanitizationInfo(GetCrashReporterClient(),
                                       &browser_sanitization_info_)) {
       arguments.push_back(base::StringPrintf("--sanitization-information=%p",


### PR DESCRIPTION
android: Enable stack sanitization for Android

Enable stack sanitization for Cobalt on Android to ensure minidumps
replace stack memory content with the 0x0DEFACED pattern. This aligns
Android TV crash reporting with the behavior already established in the
Starboard crashpad wrapper for third-party platforms.

Furthermore, disable periodic tasks during Crashpad initialization on
Android to prevent the creation of unnecessary background threads
during crash handling.

Issue: 481729814