### PR TITLE
[Profiling] Create in-process heap profiling symbolizer

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -322,6 +322,15 @@ test("cobalt_unittests") {
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_unittest.cc",
   ]
 
+  # The symbolizer pipeline test requires launching external Python and
+  # llvm-symbolizer processes, which is not supported on Starboard and
+  # modular/Evergreen platforms due to subprocess spawning restrictions.
+  if (!is_starboard && !sb_is_modular) {
+    sources += [
+      "//cobalt/tools/performance/memory/symbolize_in_process_heap_unittest.cc",
+    ]
+  }
+
   if (is_starboard) {
     sources += [
       "//cobalt/app/app_event_delegate_unittest.cc",

--- a/cobalt/tools/performance/memory/symbolize_in_process_heap.py
+++ b/cobalt/tools/performance/memory/symbolize_in_process_heap.py
@@ -1,0 +1,304 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Cobalt DWARF Callstack Symbolizer.
+
+This script parses and symbolizes hexadecimal program counters inside
+in-process heap traces using local unstripped binaries and llvm-symbolizer.
+"""
+
+import argparse
+import json
+import os
+import re
+import subprocess
+import sys
+
+
+def find_repo_root():
+  """Walks upwards to find the Cobalt repository root."""
+  curr = os.path.realpath(os.getcwd())
+  while curr:
+    if os.path.exists(os.path.join(curr, "cobalt")) and os.path.exists(
+        os.path.join(curr, "third_party")):
+      return curr
+    parent = os.path.dirname(curr)
+    if parent == curr:
+      break
+    curr = parent
+  return None
+
+
+def main():
+  parser = argparse.ArgumentParser(
+      description=(
+          "Cobalt DWARF Callstack Symbolizer.\n"
+          "Resolves raw program counters inside in-process heap traces "
+          "using local unstripped binaries."))
+  parser.add_argument(
+      "trace_path",
+      help="Path to the JSON trace file to symbolize (e.g. /tmp/c27_raw.json)")
+  parser.add_argument(
+      "-l",
+      "--lib_path",
+      required=True,
+      help="Path to the unstripped libchrobalt.so.")
+  parser.add_argument(
+      "-s",
+      "--symbolizer_path",
+      help=("Path to llvm-symbolizer. If omitted, will auto-detect "
+            "inside the toolchain, falling back to system PATH."))
+
+  args = parser.parse_args()
+
+  # 1. Validate Trace Path
+  trace_path = os.path.abspath(args.trace_path)
+  if not os.path.exists(trace_path):
+    print(f"Error: Trace file not found at: {trace_path}")
+    sys.exit(1)
+
+  # 2. Discover Repo Root and Validate Library Path
+  repo_root = find_repo_root()
+  lib_path = os.path.abspath(args.lib_path)
+  if not os.path.exists(lib_path):
+    print(f"Error: Specified library not found at: {lib_path}")
+    sys.exit(1)
+
+  # 3. Auto-detect Toolchain llvm-symbolizer
+  symbolizer_path = args.symbolizer_path
+  if not symbolizer_path:
+    toolchain_path = None
+    if repo_root:
+      toolchain_path = os.path.join(
+          repo_root,
+          "third_party/llvm-build/Release+Asserts/bin/llvm-symbolizer")
+
+    if toolchain_path and os.path.exists(toolchain_path):
+      symbolizer_path = toolchain_path
+      rel_sym_path = os.path.relpath(symbolizer_path, repo_root)
+      print(f"💡 Using toolchain prebuilt symbolizer: {rel_sym_path}")
+    else:
+      symbolizer_path = "llvm-symbolizer"
+      print("💡 Toolchain symbolizer not found. "
+            "Falling back to system 'llvm-symbolizer'.")
+  else:
+    if symbolizer_path != "llvm-symbolizer" and not os.path.exists(
+        symbolizer_path):
+      print(f"Warning: Specified symbolizer not found at {symbolizer_path}."
+            f" Falling back to system 'llvm-symbolizer'.")
+      symbolizer_path = "llvm-symbolizer"
+
+  # 4. Present Execution Profile
+  print("============================================================")
+  print("🚀 RUNNING COBALT HEAP SYMBOLIZER")
+  print(f"   📁 Trace File:       {trace_path}")
+  print(f"   ⚙️  Unstripped Lib:   {lib_path}")
+  print(f"   🛠️  LLVM Symbolizer:  {symbolizer_path}")
+  print("============================================================")
+
+  print("Loading trace file...")
+  with open(trace_path, "r", encoding="utf-8", errors="replace") as f:
+    trace_string = f.read()
+
+  # Step 5: Find the base load address of libchrobalt.so
+  print("Extracting libchrobalt.so memory mapping from trace...")
+  regex_pattern = (r"\\\"?mf\\\"?:\s*\\\"?([^\\\"]*libchrobalt.so)\\\"?,"
+                   r"\s*\\\"?pf\\\"?:\s*5,"
+                   r"\s*\\\"?sa\\\"?:\s*\\\"?(?P<sa>[0-9a-fA-F]+)\\\"?,"
+                   r"\s*\\\"?sz\\\"?:\s*\\\"?(?P<sz>[0-9a-fA-F]+)\\\"?")
+  match = re.search(regex_pattern, trace_string)
+
+  if not match:
+    relaxed_pattern = (r"libchrobalt.so[^}\n]*?pf[^}\n]*?5[^}\n]*?sa[^}\n]*?"
+                       r"(?P<sa>[0-9a-fA-F]+)"
+                       r"[^}\n]*?sz[^}\n]*?(?P<sz>[0-9a-fA-F]+)")
+    match = re.search(relaxed_pattern, trace_string)
+
+  if not match:
+    print("Error: Could not find libchrobalt.so executable mapping in trace!")
+    sys.exit(1)
+
+  base_address_hex = match.group("sa")
+  size_hex = match.group("sz")
+
+  base_address = int(base_address_hex, 16)
+  size = int(size_hex, 16)
+
+  print(f"🎉 Found libchrobalt.so base load address: 0x{base_address_hex} "
+        f"(Size: 0x{size_hex} bytes)")
+
+  trace_data = json.loads(trace_string)
+
+  # Step 6: Locate heaps_v2 and extract all PC strings across all snapshots
+  events = [
+      x for x in (trace_data if isinstance(trace_data, list) else trace_data
+                  .get("traceEvents", []))
+      if x.get("name") == "periodic_interval"
+  ]
+
+  entry_map = {}
+  pc_count = 0
+
+  parsed_dumps = []
+  for e in events:
+    args = e.get("args", {})
+    if "dumps" not in args:
+      continue
+    dumps = args["dumps"]
+    was_string = isinstance(dumps, str)
+    temp = json.loads(dumps) if was_string else dumps
+    if isinstance(temp, dict) and "heaps_v2" in temp:
+      parsed_dumps.append((e, temp, was_string))
+      heaps = temp["heaps_v2"]
+      strings_table = heaps.get("maps", {}).get("strings", [])
+      for entry in strings_table:
+        s = entry.get("string", "")
+        if s.startswith("pc:"):
+          pc_hex = s[3:]
+          if pc_hex not in entry_map:
+            entry_map[pc_hex] = []
+          entry_map[pc_hex].append(entry)
+          pc_count += 1
+
+  print(f"Found {len(entry_map)} unique raw program counters "
+        f"({pc_count} total occurrences) across all snapshots.")
+
+  if not entry_map:
+    print("No program counters to resolve!")
+    sys.exit(0)
+
+  # Step 7: Resolve PCs in bulk using llvm-symbolizer
+  print("Resolving C++ symbols...")
+  offsets = []
+  offset_to_entries = {}
+
+  for pc_hex, entries in entry_map.items():
+    pc_val = int(pc_hex, 16)
+    if base_address <= pc_val < base_address + size:
+      offset = pc_val - base_address
+      offset_str = f"0x{offset:x}"
+      if offset_str not in offset_to_entries:
+        offset_to_entries[offset_str] = []
+        offsets.append(offset_str)
+      offset_to_entries[offset_str].extend(entries)
+
+  print(f"Resolving {len(offsets)} offsets belonging to libchrobalt.so...")
+
+  stdout = ""
+  if offsets:
+    cmd = [symbolizer_path, "--demangle", "--no-inlines", f"--obj={lib_path}"]
+    try:
+      with subprocess.Popen(
+          cmd,
+          stdin=subprocess.PIPE,
+          stdout=subprocess.PIPE,
+          stderr=subprocess.PIPE,
+          text=True) as process:
+        stdout, stderr = process.communicate(input="\n".join(offsets))
+      if process.returncode != 0:
+        print(f"Error running llvm-symbolizer: {stderr}")
+        sys.exit(1)
+    except FileNotFoundError:
+      print(f"Error: Symbolizer executable not found at '{symbolizer_path}'. "
+            "Please ensure llvm-symbolizer is installed and in your PATH, "
+            "or specify a valid path using --symbolizer_path.")
+      sys.exit(1)
+
+  lines = stdout.splitlines()
+
+  resolved_count = 0
+  for i in range(len(offsets)):
+    func_idx = 3 * i
+    loc_idx = 3 * i + 1
+    if loc_idx >= len(lines):
+      symbol = f"Unresolved [offset: {offsets[i]}]"
+    else:
+      func = lines[func_idx].strip()
+      loc = lines[loc_idx].strip()
+
+      if func == "??" or not func:
+        symbol = f"Unresolved [offset: {offsets[i]}]"
+      else:
+        if repo_root and loc.startswith(repo_root):
+          loc = os.path.relpath(loc, repo_root)
+        else:
+          common_dirs = [
+              "cobalt/", "starboard/", "third_party/", "base/", "net/",
+              "media/", "ui/", "components/", "content/", "gpu/", "cc/",
+              "mojo/", "services/", "v8/", "skia/", "url/", "ipc/", "crypto/",
+              "copied_base/"
+          ]
+          for d in common_dirs:
+            if d in loc:
+              loc = d + loc.partition(d)[2]
+              break
+
+        symbol = f"{func} ({loc})"
+        resolved_count += 1
+
+    offset_key = offsets[i]
+    for entry in offset_to_entries[offset_key]:
+      entry["string"] = symbol
+
+  print(f"🎉 Successfully resolved {resolved_count} "
+        f"out of {len(offsets)} C++ symbols!")
+
+  # Step 8: Save back to disk in-place
+  print("Saving symbolized trace...")
+  for e, temp, was_string in parsed_dumps:
+    if was_string:
+      e["args"]["dumps"] = json.dumps(temp)
+
+  temp_trace_path = trace_path + ".tmp"
+  try:
+    with open(temp_trace_path, "w", encoding="utf-8") as f:
+      json.dump(trace_data, f)
+    os.replace(temp_trace_path, trace_path)
+  except Exception as e:
+    if os.path.exists(temp_trace_path):
+      os.remove(temp_trace_path)
+    raise e
+
+  # Step 9: Self-Verification Phase
+  print("\nVerifying symbolized trace mapping...")
+  last_heaps = parsed_dumps[-1][1]["heaps_v2"] if parsed_dumps else None
+
+  if last_heaps:
+    strings_table = last_heaps.get("maps", {}).get("strings", [])
+    pcs = [
+        s["string"]
+        for s in strings_table
+        if "string" in s and s["string"].startswith("pc:")
+    ]
+    resolved = [
+        s["string"]
+        for s in strings_table
+        if "string" in s and not s["string"].startswith("pc:")
+    ]
+    print("   📊 Verification Stats (Latest Snapshot):")
+    print(f"      • Total Strings in Maps:    {len(strings_table)}")
+    print(f"      • Fully Symbolized C++:     {len(resolved)}")
+    print(f"      • Unresolved System PCs:    {len(pcs)}")
+    print("   Sample Resolved C++ Symbols:")
+    for s in resolved[:10]:
+      print(f"      - {s}")
+    print()
+
+  print("============================================================")
+  print("🎉 SYMBOLIZATION COMPLETELY SUCCESSFUL!")
+  print(f"   📁 Output Path: {trace_path}")
+  print("============================================================")
+
+
+if __name__ == "__main__":
+  main()

--- a/cobalt/tools/performance/memory/symbolize_in_process_heap_unittest.cc
+++ b/cobalt/tools/performance/memory/symbolize_in_process_heap_unittest.cc
@@ -1,0 +1,151 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "build/build_config.h"
+
+#if (BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)) && !BUILDFLAG(IS_STARBOARD)
+
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/json/json_reader.h"
+#include "base/path_service.h"
+#include "base/process/launch.h"
+#include "base/values.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace {
+
+TEST(SymbolizeInProcessHeapTest, RunSymbolizerPipeline) {
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+
+  // 1. Create a mock Trace JSON File
+  base::FilePath trace_path = temp_dir.GetPath().AppendASCII("trace.json");
+  std::string trace_content = R"({
+    "traceEvents": [
+      {
+        "name": "periodic_interval",
+        "args": {
+          "dumps": "{\"heaps_v2\":{\"maps\":{\"strings\":[{\"string\":\"pc:7f801000\"},{\"string\":\"pc:7f802000\"},{\"string\":\"pc:7F801000\"},{\"string\":\"pc:7f890000\"},{\"string\":\"normal_string\"}]}}}"
+        }
+      }
+    ],
+    "metadata": "mapping: \"mf\":\"libchrobalt.so\",\"pf\":5,\"sa\":\"7f800000\",\"sz\":\"20000\""
+  })";
+  ASSERT_TRUE(base::WriteFile(trace_path, trace_content));
+
+  // 2. Create an empty mock library file
+  base::FilePath lib_path = temp_dir.GetPath().AppendASCII("libchrobalt.so");
+  ASSERT_TRUE(base::WriteFile(lib_path, ""));
+
+  // 3. Create a mock llvm-symbolizer executable python script
+  base::FilePath symbolizer_path =
+      temp_dir.GetPath().AppendASCII("mock_symbolizer.py");
+  std::string symbolizer_content = R"(#!/usr/bin/env python3
+import sys
+for line in sys.stdin:
+  arg = line.strip()
+  if arg == "0x1000":
+    print("my_func_1")
+    print("/home/user/cobalt/cobalt/dom/document.cc:42")
+    print("")
+  elif arg == "0x2000":
+    print("??")
+    print("??:0")
+    print("")
+)";
+  ASSERT_TRUE(base::WriteFile(symbolizer_path, symbolizer_content));
+  ASSERT_TRUE(base::SetPosixFilePermissions(
+      symbolizer_path, base::FILE_PERMISSION_READ_BY_USER |
+                           base::FILE_PERMISSION_WRITE_BY_USER |
+                           base::FILE_PERMISSION_EXECUTE_BY_USER));
+
+  // 4. Resolve the path of symbolize_in_process_heap.py
+  base::FilePath source_root;
+  ASSERT_TRUE(
+      base::PathService::Get(base::DIR_SRC_TEST_DATA_ROOT, &source_root));
+  base::FilePath script_path = source_root.AppendASCII("cobalt")
+                                   .AppendASCII("tools")
+                                   .AppendASCII("performance")
+                                   .AppendASCII("memory")
+                                   .AppendASCII("symbolize_in_process_heap.py");
+
+  // 5. Execute symbolize_in_process_heap.py using Command Line
+  base::CommandLine cmd(base::FilePath(FILE_PATH_LITERAL("python3")));
+  cmd.AppendArgPath(script_path);
+  cmd.AppendArgPath(trace_path);
+  cmd.AppendArg("-l");
+  cmd.AppendArgPath(lib_path);
+  cmd.AppendArg("-s");
+  cmd.AppendArgPath(symbolizer_path);
+
+  std::string output;
+  int exit_code = -1;
+  bool success = base::GetAppOutputWithExitCode(cmd, &output, &exit_code);
+
+  EXPECT_TRUE(success) << "Failed to run python symbolization script.";
+  EXPECT_EQ(0, exit_code) << "Python script failed with output:\n" << output;
+
+  // 6. Read back trace and verify contents
+  std::string result_content;
+  ASSERT_TRUE(base::ReadFileToString(trace_path, &result_content));
+
+  auto parsed = base::JSONReader::ReadAndReturnValueWithError(result_content);
+  ASSERT_TRUE(parsed.has_value()) << parsed.error().message;
+  ASSERT_TRUE(parsed->is_dict());
+
+  const base::Value::Dict& dict = parsed->GetDict();
+  const base::Value::List* events = dict.FindList("traceEvents");
+  ASSERT_TRUE(events != nullptr);
+  ASSERT_EQ(events->size(), 1u);
+
+  const base::Value::Dict& event = (*events)[0].GetDict();
+  const base::Value::Dict* args = event.FindDict("args");
+  ASSERT_TRUE(args != nullptr);
+
+  const std::string* dumps_str = args->FindString("dumps");
+  ASSERT_TRUE(dumps_str != nullptr);
+
+  auto dumps_parsed = base::JSONReader::ReadAndReturnValueWithError(*dumps_str);
+  ASSERT_TRUE(dumps_parsed.has_value()) << dumps_parsed.error().message;
+  ASSERT_TRUE(dumps_parsed->is_dict());
+  const base::Value::Dict& dumps = dumps_parsed->GetDict();
+
+  const base::Value::Dict* heaps_v2 = dumps.FindDict("heaps_v2");
+  ASSERT_TRUE(heaps_v2 != nullptr);
+
+  const base::Value::Dict* maps = heaps_v2->FindDict("maps");
+  ASSERT_TRUE(maps != nullptr);
+
+  const base::Value::List* strings = maps->FindList("strings");
+  ASSERT_TRUE(strings != nullptr);
+  ASSERT_EQ(strings->size(), 5u);
+
+  EXPECT_EQ(*((*strings)[0].GetDict().FindString("string")),
+            "my_func_1 (cobalt/dom/document.cc:42)");
+  EXPECT_EQ(*((*strings)[1].GetDict().FindString("string")),
+            "Unresolved [offset: 0x2000]");
+  EXPECT_EQ(*((*strings)[2].GetDict().FindString("string")),
+            "my_func_1 (cobalt/dom/document.cc:42)");
+  EXPECT_EQ(*((*strings)[3].GetDict().FindString("string")), "pc:7f890000");
+  EXPECT_EQ(*((*strings)[4].GetDict().FindString("string")), "normal_string");
+}
+
+}  // namespace
+}  // namespace cobalt
+
+#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_MAC)


### PR DESCRIPTION
Introduce a DWARF callstack symbolizer to support automated performance
memory tools. This allows profiling and comparing heap footprints by
resolving hexadecimal program counters in traces into human-readable
C++ symbols using local unstripped binaries and llvm-symbolizer.

The change includes a Python script for processing traces and unit
tests to verify the symbolization pipeline.

Test: output of the script will be like https://paste.googleplex.com/5340110672494592, example trace file  is too large to share. Added unittests for the symbolizer too.

Bug: 528397803