### PR TITLE
cleanup: Replace bug links with short descriptions

### DIFF
--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -495,7 +495,8 @@ std::string MediaCapabilitiesCache::FindVideoDecoder(
       continue;
     }
     // Reject low performance software codec if software codec is not required.
-    // See b/456473829 for more details.
+    // This can help ensure that a hardware decoder is chosen when a device
+    // reports support for a low performing software decoder.
     if (!require_software_codec && video_capability->is_software_decoder()) {
       const int kMinimumWidth = 1920;
       const int kMinimumHeight = 1080;

--- a/starboard/android/shared/media_capabilities_cache_test.cc
+++ b/starboard/android/shared/media_capabilities_cache_test.cc
@@ -386,7 +386,7 @@ TEST_F(MediaCapabilitiesCacheTest, RejectLowPerformanceSoftwareDecoder) {
 
   // Case 1: Software codec is NOT required.
   // The software decoder should be rejected because it is low performance (does
-  // not support 1080p). See b/456473829 for better context.
+  // not support 1080p).
   EXPECT_EQ(cache_->FindVideoDecoder("video/x-vnd.on2.vp9",
                                      /*must_support_secure=*/false,
                                      /*must_support_hdr=*/false,


### PR DESCRIPTION
Remove internal bug tracker references in the Android media
capabilities cache and its associated tests. Replace these links with
descriptive comments explaining why low-performance software decoders
are rejected, providing better context directly within the codebase.

Bug: 508269486