### PR TITLE
fix: Race condition between focus and visibilityChange events during resume.

### DIFF
--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
@@ -59,7 +59,7 @@ void CobaltLifecycleManager::BindReceiver(
       content::WebContents::FromRenderFrameHost(frame);
   mojo::ReceiverId id =
       receivers_.Add(this, std::move(receiver), {frame->GetGlobalId()});
-  active_receivers_[frame->GetGlobalId()] = id;
+  active_receiver_counts_[frame->GetGlobalId()]++;
   receiver_ids_[web_contents].push_back(id);
 }
 
@@ -83,17 +83,25 @@ void CobaltLifecycleManager::InitializeTracker(
 
 void CobaltLifecycleManager::OnMojoDisconnect() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  FrameContext context = receivers_.current_context();
+
+  auto active_it = active_receiver_counts_.find(context.frame_id);
+  if (active_it != active_receiver_counts_.end()) {
+    active_it->second--;
+    if (active_it->second <= 0) {
+      active_receiver_counts_.erase(active_it);
+      content::RenderFrameHost* frame =
+          content::RenderFrameHost::FromID(context.frame_id);
+      if (frame) {
+        UnregisterFrame(content::WebContents::FromRenderFrameHost(frame),
+                        frame);
+      }
+    }
+  }
+
   auto [frame, web_contents] = GetCurrentContext();
   mojo::ReceiverId id = receivers_.current_receiver();
-  FrameContext context = receivers_.current_context();
   if (web_contents) {
-    auto active_it = active_receivers_.find(context.frame_id);
-    if (active_it != active_receivers_.end() && active_it->second == id) {
-      if (frame) {
-        UnregisterFrame(web_contents, frame);
-      }
-      active_receivers_.erase(active_it);
-    }
     auto it = receiver_ids_.find(web_contents);
     if (it != receiver_ids_.end()) {
       auto& ids = it->second;
@@ -125,12 +133,8 @@ void CobaltLifecycleManager::WebContentsTracker::RenderFrameCreated(
   // renderer-side CobaltLifecycleController. This establishes the two-way
   // communication channel needed for lifecycle ACKs.
   mojo::PendingRemote<cobalt::mojom::CobaltLifecycleObserver> observer;
-  // Track the ReceiverId associated with the WebContents for clean teardown.
-  mojo::ReceiverId id = manager_->receivers_.Add(
-      manager_, observer.InitWithNewPipeAndPassReceiver(),
-      {render_frame_host->GetGlobalId()});
-  manager_->active_receivers_[render_frame_host->GetGlobalId()] = id;
-  manager_->receiver_ids_[web_contents()].push_back(id);
+  manager_->BindReceiver(render_frame_host,
+                         observer.InitWithNewPipeAndPassReceiver());
   controller->SetObserver(std::move(observer));
 
   controllers_[render_frame_host] = std::move(controller);
@@ -272,11 +276,7 @@ void CobaltLifecycleManager::WebContentsTracker::Rebind(
   // Re-register the browser as an observer after re-binding the interface.
   mojo::PendingRemote<cobalt::mojom::CobaltLifecycleObserver> observer;
   // Track the ReceiverId associated with the WebContents for clean teardown.
-  mojo::ReceiverId id = manager_->receivers_.Add(
-      manager_, observer.InitWithNewPipeAndPassReceiver(),
-      {frame->GetGlobalId()});
-  manager_->active_receivers_[frame->GetGlobalId()] = id;
-  manager_->receiver_ids_[web_contents()].push_back(id);
+  manager_->BindReceiver(frame, observer.InitWithNewPipeAndPassReceiver());
   controller->SetObserver(std::move(observer));
 
   controllers_[frame] = std::move(controller);
@@ -326,9 +326,12 @@ void CobaltLifecycleManager::RegisterFrame(content::WebContents* web_contents,
   frames_[web_contents].insert(frame);
   GetOrCreateTracker(web_contents);
 
-  // Add to pending set if we are waiting for an ACK.
+  // If we are currently waiting for an ACK, only dynamically track newly
+  // registered Main Frames (e.g. during active navigations) to resolve the
+  // focus/visibility event race. Subframes (iframes) must be excluded to
+  // prevent Blink scheduler throttling deadlocks.
   PendingAck pending_ack = pending_acks_[web_contents];
-  if (pending_ack != PendingAck::kNone) {
+  if (pending_ack != PendingAck::kNone && !frame->GetParent()) {
     pending_ack_frames_[web_contents].insert(frame);
   }
 
@@ -349,6 +352,9 @@ void CobaltLifecycleManager::UnregisterFrame(content::WebContents* web_contents,
   if (main_frames_[web_contents] == frame) {
     main_frames_.erase(web_contents);
   }
+
+  // Clean up active receiver counts for this frame.
+  active_receiver_counts_.erase(frame->GetGlobalId());
 
   if (frames_[web_contents].empty()) {
     frames_.erase(web_contents);
@@ -460,15 +466,22 @@ void CobaltLifecycleManager::StartWaitingForAck(
         base::BindOnce(&CobaltLifecycleManager::NotifyStartWaitingForReveal,
                        base::Unretained(this), web_contents->GetWeakPtr()));
   } else {
-    for (auto* frame : frames_[web_contents]) {
-      bool connected = tracker->IsConnected(frame);
+    // For downward transitions, only track the active Primary Main Frame.
+    // This excludes subframes (which can be aggressively throttled or paused
+    // by Blink's scheduler) and older, navigated-away main frames that are
+    // still leaking in memory pending deletion.
+    auto* primary_main_frame = web_contents->GetPrimaryMainFrame();
+    if (primary_main_frame) {
+      bool connected = tracker->IsConnected(primary_main_frame);
       if (connected) {
-        pending_ack_frames_[web_contents].insert(frame);
-      } else if (ack_type == PendingAck::kUnfreeze) {
-        LOG(WARNING) << "StartWaitingForAck: Frame not connected during "
-                        "Unfreeze! Re-binding frame="
-                     << frame;
-        tracker->Rebind(frame);
+        pending_ack_frames_[web_contents].insert(primary_main_frame);
+      } else if (ack_type == PendingAck::kUnfreeze &&
+                 primary_main_frame->IsRenderFrameLive()) {
+        LOG(WARNING)
+            << "StartWaitingForAck: Primary Main Frame not connected during "
+               "Unfreeze! Re-binding frame="
+            << primary_main_frame;
+        tracker->Rebind(primary_main_frame);
       }
     }
   }
@@ -584,12 +597,12 @@ void CobaltLifecycleManager::OnWebContentsDestroyed(
   // The WebContents is being destroyed. Proactively remove all its Mojo
   // receivers from `receivers_` BEFORE the WebContents and its RFHs go out of
   // scope.
-  // Proactively clean up the active_receivers_ map for all frames belonging to
-  // this WebContents to avoid memory leaks.
+  // Proactively clean up the active_receiver_counts_ map for all frames
+  // belonging to this WebContents to avoid memory leaks.
   auto frames_it = frames_.find(web_contents);
   if (frames_it != frames_.end()) {
     for (auto* frame : frames_it->second) {
-      active_receivers_.erase(frame->GetGlobalId());
+      active_receiver_counts_.erase(frame->GetGlobalId());
     }
   }
   auto it = receiver_ids_.find(web_contents);

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
@@ -85,8 +85,8 @@ void CobaltLifecycleManager::OnMojoDisconnect() {
   CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   FrameContext context = receivers_.current_context();
 
-  auto active_it = active_receiver_counts_.find(context.frame_id);
-  if (active_it != active_receiver_counts_.end()) {
+  if (auto active_it = active_receiver_counts_.find(context.frame_id);
+      active_it != active_receiver_counts_.end()) {
     active_it->second--;
     if (active_it->second <= 0) {
       active_receiver_counts_.erase(active_it);
@@ -267,8 +267,7 @@ bool CobaltLifecycleManager::WebContentsTracker::IsConnected(
 
 void CobaltLifecycleManager::WebContentsTracker::Rebind(
     content::RenderFrameHost* frame) {
-  LOG(INFO) << "WebContentsTracker::Rebind: Proactively re-binding frame="
-            << frame;
+  LOG(INFO) << __func__ << ": Proactively re-binding frame=" << frame;
   mojo::Remote<cobalt::mojom::CobaltLifecycleController> controller;
   frame->GetRemoteInterfaces()->GetInterface(
       controller.BindNewPipeAndPassReceiver());
@@ -288,8 +287,7 @@ void CobaltLifecycleManager::WebContentsTracker::Rebind(
 
 void CobaltLifecycleManager::WebContentsTracker::OnControllerDisconnect(
     content::RenderFrameHost* frame) {
-  LOG(WARNING) << "WebContentsTracker::OnControllerDisconnect for frame="
-               << frame;
+  LOG(WARNING) << __func__ << " for frame=" << frame;
   resumed_frames_.erase(frame);
   visible_frames_.erase(frame);
   focused_frames_.erase(frame);
@@ -326,20 +324,21 @@ void CobaltLifecycleManager::RegisterFrame(content::WebContents* web_contents,
   frames_[web_contents].insert(frame);
   GetOrCreateTracker(web_contents);
 
-  // If we are currently waiting for an ACK, only dynamically track newly
-  // registered Main Frames (e.g. during active navigations) to resolve the
-  // focus/visibility event race. Subframes (iframes) must be excluded to
-  // prevent Blink scheduler throttling deadlocks.
+  if (frame->GetParent()) {
+    // We only need to track and notify observers about Main Frames. Subframes
+    // (iframes) must be excluded from pending ACKs to prevent Blink scheduler
+    // throttling deadlocks.
+    return;
+  }
+
   PendingAck pending_ack = pending_acks_[web_contents];
-  if (pending_ack != PendingAck::kNone && !frame->GetParent()) {
+  if (pending_ack != PendingAck::kNone) {
     pending_ack_frames_[web_contents].insert(frame);
   }
 
-  if (!frame->GetParent()) {
-    main_frames_[web_contents] = frame;
-    for (auto& observer : observers_) {
-      observer.OnMainFrameRegistered(web_contents);
-    }
+  main_frames_[web_contents] = frame;
+  for (auto& observer : observers_) {
+    observer.OnMainFrameRegistered(web_contents);
   }
 }
 
@@ -353,7 +352,6 @@ void CobaltLifecycleManager::UnregisterFrame(content::WebContents* web_contents,
     main_frames_.erase(web_contents);
   }
 
-  // Clean up active receiver counts for this frame.
   active_receiver_counts_.erase(frame->GetGlobalId());
 
   if (frames_[web_contents].empty()) {
@@ -472,15 +470,14 @@ void CobaltLifecycleManager::StartWaitingForAck(
     // still leaking in memory pending deletion.
     auto* primary_main_frame = web_contents->GetPrimaryMainFrame();
     if (primary_main_frame) {
-      bool connected = tracker->IsConnected(primary_main_frame);
-      if (connected) {
+      if (tracker->IsConnected(primary_main_frame)) {
         pending_ack_frames_[web_contents].insert(primary_main_frame);
       } else if (ack_type == PendingAck::kUnfreeze &&
                  primary_main_frame->IsRenderFrameLive()) {
-        LOG(WARNING)
-            << "StartWaitingForAck: Primary Main Frame not connected during "
-               "Unfreeze! Re-binding frame="
-            << primary_main_frame;
+        LOG(WARNING) << __func__
+                     << ": Primary Main Frame not connected during Unfreeze! "
+                        "Re-binding frame="
+                     << primary_main_frame;
         tracker->Rebind(primary_main_frame);
       }
     }
@@ -490,8 +487,8 @@ void CobaltLifecycleManager::StartWaitingForAck(
     // If there are no connected frames (e.g., during startup before any
     // frames are created or if all frames crashed), we complete the ACK
     // immediately to avoid hanging the transition.
-    LOG(WARNING) << "StartWaitingForAck: No connected frames! Completing "
-                    "immediately for "
+    LOG(WARNING) << __func__
+                 << ": No connected frames! Completing immediately for "
                  << static_cast<int>(ack_type);
     base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
         FROM_HERE,
@@ -584,7 +581,8 @@ void CobaltLifecycleManager::OnAckTimeout(
   }
   content::WebContents* wc = web_contents.get();
   if (pending_acks_[wc] == ack_type) {
-    LOG(WARNING) << "Timeout fired for ack = " << static_cast<int>(ack_type)
+    LOG(WARNING) << __func__
+                 << ": Timeout fired for ack = " << static_cast<int>(ack_type)
                  << ". Proceeding anyway.";
     pending_ack_frames_[wc].clear();
     CheckCompletion(wc);

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
@@ -464,23 +464,7 @@ void CobaltLifecycleManager::StartWaitingForAck(
         base::BindOnce(&CobaltLifecycleManager::NotifyStartWaitingForReveal,
                        base::Unretained(this), web_contents->GetWeakPtr()));
   } else {
-    // For downward transitions, only track the active Primary Main Frame.
-    // This excludes subframes (which can be aggressively throttled or paused
-    // by Blink's scheduler) and older, navigated-away main frames that are
-    // still leaking in memory pending deletion.
-    auto* primary_main_frame = web_contents->GetPrimaryMainFrame();
-    if (primary_main_frame) {
-      if (tracker->IsConnected(primary_main_frame)) {
-        pending_ack_frames_[web_contents].insert(primary_main_frame);
-      } else if (ack_type == PendingAck::kUnfreeze &&
-                 primary_main_frame->IsRenderFrameLive()) {
-        LOG(WARNING) << __func__
-                     << ": Primary Main Frame not connected during Unfreeze! "
-                        "Re-binding frame="
-                     << primary_main_frame;
-        tracker->Rebind(primary_main_frame);
-      }
-    }
+    TrackPrimaryMainFrameForAck(web_contents, tracker, ack_type);
   }
 
   if (pending_ack_frames_[web_contents].empty()) {
@@ -503,6 +487,31 @@ void CobaltLifecycleManager::StartWaitingForAck(
                      base::Unretained(this), web_contents->GetWeakPtr(),
                      ack_type),
       base::Seconds(2));
+}
+
+void CobaltLifecycleManager::TrackPrimaryMainFrameForAck(
+    content::WebContents* web_contents,
+    WebContentsTracker* tracker,
+    PendingAck ack_type) {
+  // For downward transitions, only track the active Primary Main Frame.
+  // This excludes subframes (which can be aggressively throttled or paused
+  // by Blink's scheduler) and older, navigated-away main frames that are
+  // still leaking in memory pending deletion.
+  auto* primary_main_frame = web_contents->GetPrimaryMainFrame();
+  if (!primary_main_frame) {
+    return;
+  }
+
+  if (tracker->IsConnected(primary_main_frame)) {
+    pending_ack_frames_[web_contents].insert(primary_main_frame);
+  } else if (ack_type == PendingAck::kUnfreeze &&
+             primary_main_frame->IsRenderFrameLive()) {
+    LOG(WARNING) << __func__
+                 << ": Primary Main Frame not connected during Unfreeze! "
+                    "Re-binding frame="
+                 << primary_main_frame;
+    tracker->Rebind(primary_main_frame);
+  }
 }
 
 // If we are waiting for reveal on this WebContents and all its registered

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.cc
@@ -89,6 +89,7 @@ void CobaltLifecycleManager::OnMojoDisconnect() {
       active_it != active_receiver_counts_.end()) {
     active_it->second--;
     if (active_it->second <= 0) {
+      DCHECK(active_it->second == 0);
       active_receiver_counts_.erase(active_it);
       content::RenderFrameHost* frame =
           content::RenderFrameHost::FromID(context.frame_id);

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
@@ -281,12 +281,11 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
   // associated with a specific WebContents when it is destroyed.
   std::map<content::WebContents*, std::vector<mojo::ReceiverId>> receiver_ids_;
 
-  // Map tracking the active Mojo ReceiverId for each RenderFrameHost (by its
-  // GlobalId). This prevents race conditions where an asynchronous disconnect
-  // handler for an old Mojo pipe unregisters a frame that has already been
-  // re-bound to a new pipe.
-  std::map<content::GlobalRenderFrameHostId, mojo::ReceiverId>
-      active_receivers_;
+  // Tracks the number of active Mojo lifecycle observer receivers (connections)
+  // associated with each RenderFrameHost (keyed by its global ID). This is used
+  // to dynamically monitor frame connection lifetimes and determine when a
+  // frame is actively participating in the lifecycle transition handshake.
+  std::map<content::GlobalRenderFrameHostId, int> active_receiver_counts_;
 
   base::WeakPtrFactory<CobaltLifecycleManager> weak_factory_{this};
 

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
@@ -21,7 +21,6 @@
 #include <vector>
 
 #include "base/containers/flat_set.h"
-#include "base/containers/small_map.h"
 #include "base/memory/weak_ptr.h"
 #include "base/no_destructor.h"
 #include "base/observer_list.h"
@@ -31,6 +30,8 @@
 #include "content/public/browser/web_contents_observer.h"
 #include "mojo/public/cpp/bindings/receiver_set.h"
 #include "mojo/public/cpp/bindings/remote.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
+#include "third_party/abseil-cpp/absl/container/flat_hash_set.h"
 
 namespace content {
 class WebContents;
@@ -233,9 +234,9 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
 
     // Sets to track the current state of each frame. A frame is considered
     // to have achieved the state if it is present in the corresponding set.
-    base::flat_set<content::RenderFrameHost*> resumed_frames_;
-    base::flat_set<content::RenderFrameHost*> visible_frames_;
-    base::flat_set<content::RenderFrameHost*> focused_frames_;
+    absl::flat_hash_set<content::RenderFrameHost*> resumed_frames_;
+    absl::flat_hash_set<content::RenderFrameHost*> visible_frames_;
+    absl::flat_hash_set<content::RenderFrameHost*> focused_frames_;
   };
 
   WebContentsTracker* GetOrCreateTracker(content::WebContents* web_contents);
@@ -247,22 +248,22 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
   // WebContents is destroyed, all WeakPtrs pointing to it become null and
   // compare equal, violating strict weak ordering. We rely on
   // OnWebContentsDestroyed for cleanup.
-  base::small_map<std::map<content::WebContents*, content::RenderFrameHost*>>
+  absl::flat_hash_map<content::WebContents*, content::RenderFrameHost*>
       main_frames_;
-  base::small_map<
-      std::map<content::WebContents*, std::set<content::RenderFrameHost*>>>
+  absl::flat_hash_map<content::WebContents*,
+                      absl::flat_hash_set<content::RenderFrameHost*>>
       frames_;
 
   // The single set of frames we are waiting for an ACK from.
-  base::small_map<
-      std::map<content::WebContents*, std::set<content::RenderFrameHost*>>>
+  absl::flat_hash_map<content::WebContents*,
+                      absl::flat_hash_set<content::RenderFrameHost*>>
       pending_ack_frames_;
 
   // What we are waiting for per WebContents.
-  base::small_map<std::map<content::WebContents*, PendingAck>> pending_acks_;
+  absl::flat_hash_map<content::WebContents*, PendingAck> pending_acks_;
 
-  base::small_map<
-      std::map<content::WebContents*, std::unique_ptr<WebContentsTracker>>>
+  absl::flat_hash_map<content::WebContents*,
+                      std::unique_ptr<WebContentsTracker>>
       trackers_;
 
   base::ObserverList<CobaltLifecycleManagerObserver>::Unchecked observers_;
@@ -279,13 +280,15 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
   // receivers by their associated context (WebContents*), we must track the
   // ReceiverIds explicitly. This allows us to cleanly remove only the receivers
   // associated with a specific WebContents when it is destroyed.
-  std::map<content::WebContents*, std::vector<mojo::ReceiverId>> receiver_ids_;
+  absl::flat_hash_map<content::WebContents*, std::vector<mojo::ReceiverId>>
+      receiver_ids_;
 
   // Tracks the number of active Mojo lifecycle observer receivers (connections)
   // associated with each RenderFrameHost (keyed by its global ID). This is used
   // to dynamically monitor frame connection lifetimes and determine when a
   // frame is actively participating in the lifecycle transition handshake.
-  std::map<content::GlobalRenderFrameHostId, int> active_receiver_counts_;
+  absl::flat_hash_map<content::GlobalRenderFrameHostId, int>
+      active_receiver_counts_;
 
   base::WeakPtrFactory<CobaltLifecycleManager> weak_factory_{this};
 

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager.h
@@ -15,12 +15,9 @@
 #ifndef COBALT_BROWSER_LIFECYCLE_COBALT_LIFECYCLE_MANAGER_H_
 #define COBALT_BROWSER_LIFECYCLE_COBALT_LIFECYCLE_MANAGER_H_
 
-#include <map>
-#include <set>
 #include <utility>
 #include <vector>
 
-#include "base/containers/flat_set.h"
 #include "base/memory/weak_ptr.h"
 #include "base/no_destructor.h"
 #include "base/observer_list.h"
@@ -228,8 +225,8 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
     CobaltLifecycleManager* manager_;
 
     // Map of active frames to their remote controllers.
-    std::map<content::RenderFrameHost*,
-             mojo::Remote<cobalt::mojom::CobaltLifecycleController>>
+    absl::flat_hash_map<content::RenderFrameHost*,
+                        mojo::Remote<cobalt::mojom::CobaltLifecycleController>>
         controllers_;
 
     // Sets to track the current state of each frame. A frame is considered
@@ -240,6 +237,9 @@ class CobaltLifecycleManager : public cobalt::mojom::CobaltLifecycleObserver {
   };
 
   WebContentsTracker* GetOrCreateTracker(content::WebContents* web_contents);
+  void TrackPrimaryMainFrameForAck(content::WebContents* web_contents,
+                                   WebContentsTracker* tracker,
+                                   PendingAck ack_type);
 
   // Note: We use raw WebContents* as keys here instead of WeakPtr<WebContents>
   // because base::WeakPtr does not implement operator< in this version of base,

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager_unittest.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager_unittest.cc
@@ -207,4 +207,61 @@ TEST_F(CobaltLifecycleManagerTest, DISABLED_RevealTimeout) {
   manager_->RemoveObserver(&observer);
 }
 
+TEST_F(CobaltLifecycleManagerTest,
+       StartWaitingForUnfreezeWithDeadFrameDoesNotCrash) {
+  std::unique_ptr<content::WebContents> contents =
+      CreateScopedTestWebContents();
+  // Do NOT call InitializeRenderFrameIfNeeded(), so IsRenderFrameLive() returns
+  // false. This simulates the state of mock frames in unit tests or extremely
+  // early startup, where Rebind() would crash if called.
+
+  // Start waiting for unfreeze. This shouldn't crash.
+  manager_->StartWaitingForAck(contents.get(), PendingAck::kUnfreeze);
+  base::RunLoop().RunUntilIdle();
+}
+
+TEST_F(CobaltLifecycleManagerTest,
+       ReceiverDisconnectDoesNotUnregisterActiveFrame) {
+  std::unique_ptr<content::WebContents> contents =
+      CreateScopedTestWebContents();
+  content::RenderFrameHostTester::For(contents->GetPrimaryMainFrame())
+      ->InitializeRenderFrameIfNeeded();
+
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> remote1;
+  manager_->BindReceiver(contents->GetPrimaryMainFrame(),
+                         remote1.BindNewPipeAndPassReceiver());
+  remote1->OnFrameReady();
+  base::RunLoop().RunUntilIdle();
+
+  // Simulate a re-bind by creating a second remote for the SAME frame.
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> remote2;
+  manager_->BindReceiver(contents->GetPrimaryMainFrame(),
+                         remote2.BindNewPipeAndPassReceiver());
+  base::RunLoop().RunUntilIdle();
+
+  // Disconnect the FIRST remote (simulating the async disconnect of the old
+  // pipe).
+  remote1.reset();
+  base::RunLoop().RunUntilIdle();
+
+  // The frame should STILL be waiting/registered because remote2 is active!
+  MockCobaltLifecycleObserver observer;
+  manager_->AddObserver(&observer);
+
+  manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
+
+  // If it was unregistered, it would trigger immediate completion (call times
+  // 1). Because it's still registered, it waits (call times 0).
+  EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(0);
+  base::RunLoop().RunUntilIdle();
+  testing::Mock::VerifyAndClearExpectations(&observer);
+
+  // Disconnect the second remote, NOW it should unregister and complete.
+  EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
+  remote2.reset();
+  base::RunLoop().RunUntilIdle();
+
+  manager_->RemoveObserver(&observer);
+}
+
 }  // namespace cobalt

--- a/cobalt/browser/lifecycle/cobalt_lifecycle_manager_unittest.cc
+++ b/cobalt/browser/lifecycle/cobalt_lifecycle_manager_unittest.cc
@@ -61,6 +61,10 @@ class CobaltLifecycleManagerTest : public content::ShellTestBase {
   CobaltLifecycleManager* manager_;
 };
 
+// Verifies that lifecycle transition expectations (StartWaitingForAck) are
+// scoped strictly to the target WebContents, ensuring multiple concurrent
+// WebContents instances do not interfere with each other's visibility
+// callbacks.
 TEST_F(CobaltLifecycleManagerTest, ScopedWaiting) {
   std::unique_ptr<content::WebContents> contents1 =
       CreateScopedTestWebContents();
@@ -91,14 +95,14 @@ TEST_F(CobaltLifecycleManagerTest, ScopedWaiting) {
   // Start waiting for contents1.
   manager_->StartWaitingForAck(contents1.get(), PendingAck::kReveal);
 
-  // We expect OnAllFramesVisible to be called ONLY for contents1.
+  // We expect OnAllFramesVisible to be called only for contents1.
   EXPECT_CALL(observer, OnAllFramesVisible(contents1.get())).Times(1);
   EXPECT_CALL(observer, OnAllFramesVisible(contents2.get())).Times(0);
 
   // Frame 1 reports visible via Mojo.
   remote1->OnPageVisibilityChanged(true);
 
-  // Wait for Mojo message.
+  // Wait for Mojo message dispatch.
   base::RunLoop().RunUntilIdle();
 
   // Start waiting for contents2.
@@ -106,7 +110,7 @@ TEST_F(CobaltLifecycleManagerTest, ScopedWaiting) {
 
   EXPECT_CALL(observer, OnAllFramesVisible(contents2.get())).Times(1);
 
-  // Frame 2 reports visible.
+  // Frame 2 reports visible via Mojo.
   remote2->OnPageVisibilityChanged(true);
 
   base::RunLoop().RunUntilIdle();
@@ -117,6 +121,9 @@ TEST_F(CobaltLifecycleManagerTest, ScopedWaiting) {
   base::RunLoop().RunUntilIdle();
 }
 
+// Verifies that initial transition notifications (OnStartWaitingForReveal) are
+// dispatched asynchronously via posted tasks. This prevents re-entrancy issues
+// when observers modify lifecycle state during direct call stacks.
 TEST_F(CobaltLifecycleManagerTest, ObserverNotificationIsDeferred) {
   std::unique_ptr<content::WebContents> contents =
       CreateScopedTestWebContents();
@@ -132,12 +139,12 @@ TEST_F(CobaltLifecycleManagerTest, ObserverNotificationIsDeferred) {
   MockCobaltLifecycleObserver observer;
   manager_->AddObserver(&observer);
 
-  // Verify that notification is NOT synchronous.
+  // Verify that notification is not delivered synchronously.
   EXPECT_CALL(observer, OnStartWaitingForReveal(contents.get())).Times(0);
   manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
   testing::Mock::VerifyAndClearExpectations(&observer);
 
-  // Verify that notification is delivered asynchronously.
+  // Verify that notification is delivered asynchronously on the run loop.
   EXPECT_CALL(observer, OnStartWaitingForReveal(contents.get())).Times(1);
   base::RunLoop().RunUntilIdle();
   manager_->RemoveObserver(&observer);
@@ -146,6 +153,9 @@ TEST_F(CobaltLifecycleManagerTest, ObserverNotificationIsDeferred) {
   base::RunLoop().RunUntilIdle();
 }
 
+// Verifies that if a main frame unregisters or disconnects while a lifecycle
+// wait is pending, the transition completes automatically so observer state
+// machines do not hang indefinitely waiting for dead frames.
 TEST_F(CobaltLifecycleManagerTest, MainFrameUnregistrationWhileWaiting) {
   std::unique_ptr<content::WebContents> contents =
       CreateScopedTestWebContents();
@@ -163,7 +173,7 @@ TEST_F(CobaltLifecycleManagerTest, MainFrameUnregistrationWhileWaiting) {
 
   manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
 
-  // Expect OnAllFramesVisible to be called when MAIN frame is UNREGISTERED.
+  // Expect OnAllFramesVisible to be called when the main frame is unregistered.
   EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
 
   // Resetting the remote destroys the receiver, which unregisters the frame.
@@ -173,6 +183,8 @@ TEST_F(CobaltLifecycleManagerTest, MainFrameUnregistrationWhileWaiting) {
   manager_->RemoveObserver(&observer);
 }
 
+// Verifies that if a WebContents has no active connected frames when a
+// transition is requested, the manager completes the transition immediately.
 TEST_F(CobaltLifecycleManagerTest, ImmediateCompletion) {
   std::unique_ptr<content::WebContents> contents =
       CreateScopedTestWebContents();
@@ -180,7 +192,7 @@ TEST_F(CobaltLifecycleManagerTest, ImmediateCompletion) {
   MockCobaltLifecycleObserver observer;
   manager_->AddObserver(&observer);
 
-  // Expect immediate call.
+  // Expect immediate completion callback.
   EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
 
   manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
@@ -198,7 +210,7 @@ TEST_F(CobaltLifecycleManagerTest, DISABLED_RevealTimeout) {
 
   manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
 
-  // Expect OnAllFramesVisible to be called when TIMEOUT fires.
+  // Expect OnAllFramesVisible to be called when the timeout duration fires.
   EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
 
   // Fast forward time by 2 seconds.
@@ -207,19 +219,23 @@ TEST_F(CobaltLifecycleManagerTest, DISABLED_RevealTimeout) {
   manager_->RemoveObserver(&observer);
 }
 
+// Verifies that attempting to unfreeze when a frame is not live (e.g. during
+// mock unit tests or very early initialization before renderer creation) does
+// not crash or trigger invalid IPC re-bindings on dead RenderFrameHost objects.
 TEST_F(CobaltLifecycleManagerTest,
        StartWaitingForUnfreezeWithDeadFrameDoesNotCrash) {
   std::unique_ptr<content::WebContents> contents =
       CreateScopedTestWebContents();
-  // Do NOT call InitializeRenderFrameIfNeeded(), so IsRenderFrameLive() returns
-  // false. This simulates the state of mock frames in unit tests or extremely
-  // early startup, where Rebind() would crash if called.
+  // Do not call InitializeRenderFrameIfNeeded(), ensuring IsRenderFrameLive()
+  // returns false.
 
-  // Start waiting for unfreeze. This shouldn't crash.
   manager_->StartWaitingForAck(contents.get(), PendingAck::kUnfreeze);
   base::RunLoop().RunUntilIdle();
 }
 
+// Verifies that when a frame is rebound to a new Mojo pipe during navigation or
+// reload, disconnecting the old pipe asynchronously does not unregister the
+// active frame from the manager while a valid connection still exists.
 TEST_F(CobaltLifecycleManagerTest,
        ReceiverDisconnectDoesNotUnregisterActiveFrame) {
   std::unique_ptr<content::WebContents> contents =
@@ -233,32 +249,105 @@ TEST_F(CobaltLifecycleManagerTest,
   remote1->OnFrameReady();
   base::RunLoop().RunUntilIdle();
 
-  // Simulate a re-bind by creating a second remote for the SAME frame.
+  // Establish a re-bind by creating a second remote for the same frame.
   mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> remote2;
   manager_->BindReceiver(contents->GetPrimaryMainFrame(),
                          remote2.BindNewPipeAndPassReceiver());
   base::RunLoop().RunUntilIdle();
 
-  // Disconnect the FIRST remote (simulating the async disconnect of the old
-  // pipe).
+  // Disconnect the first remote, simulating the asynchronous teardown of the
+  // old pipe.
   remote1.reset();
   base::RunLoop().RunUntilIdle();
 
-  // The frame should STILL be waiting/registered because remote2 is active!
+  // The frame remains registered because remote2 is active.
   MockCobaltLifecycleObserver observer;
   manager_->AddObserver(&observer);
 
   manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
 
-  // If it was unregistered, it would trigger immediate completion (call times
-  // 1). Because it's still registered, it waits (call times 0).
+  // Transition waits because remote2 has not yet reported its visibility ACK.
   EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(0);
   base::RunLoop().RunUntilIdle();
   testing::Mock::VerifyAndClearExpectations(&observer);
 
-  // Disconnect the second remote, NOW it should unregister and complete.
+  // Disconnecting the active remote unregisters the frame and completes the
+  // wait.
   EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
   remote2.reset();
+  base::RunLoop().RunUntilIdle();
+
+  manager_->RemoveObserver(&observer);
+}
+
+// Verifies that when a WebContents contains active subframes (iframes),
+// StartWaitingForAck only tracks and waits for the primary main frame.
+// Subframes are excluded because they may be throttled or paused by the Blink
+// scheduler, which would otherwise prevent transition completion.
+TEST_F(CobaltLifecycleManagerTest, StartWaitingForAckIgnoresSubframes) {
+  std::unique_ptr<content::WebContents> contents =
+      CreateScopedTestWebContents();
+  content::RenderFrameHost* main_rfh = contents->GetPrimaryMainFrame();
+  content::RenderFrameHostTester::For(main_rfh)
+      ->InitializeRenderFrameIfNeeded();
+
+  content::RenderFrameHost* child_rfh = AddChildFrame(main_rfh);
+
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> main_remote;
+  manager_->BindReceiver(main_rfh, main_remote.BindNewPipeAndPassReceiver());
+  main_remote->OnFrameReady();
+
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> child_remote;
+  manager_->BindReceiver(child_rfh, child_remote.BindNewPipeAndPassReceiver());
+  child_remote->OnFrameReady();
+
+  base::RunLoop().RunUntilIdle();
+
+  MockCobaltLifecycleObserver observer;
+  manager_->AddObserver(&observer);
+
+  manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
+
+  // Sending the ACK from the primary main frame alone must satisfy the wait.
+  EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
+  main_remote->OnPageVisibilityChanged(true);
+  base::RunLoop().RunUntilIdle();
+
+  manager_->RemoveObserver(&observer);
+}
+
+// Verifies that if a subframe dynamically registers while a lifecycle
+// transition wait is already active, the subframe is ignored and does not get
+// added to the pending acknowledgment set.
+TEST_F(CobaltLifecycleManagerTest,
+       SubframeRegistrationDuringActiveWaitIsIgnored) {
+  std::unique_ptr<content::WebContents> contents =
+      CreateScopedTestWebContents();
+  content::RenderFrameHost* main_rfh = contents->GetPrimaryMainFrame();
+  content::RenderFrameHostTester::For(main_rfh)
+      ->InitializeRenderFrameIfNeeded();
+
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> main_remote;
+  manager_->BindReceiver(main_rfh, main_remote.BindNewPipeAndPassReceiver());
+  main_remote->OnFrameReady();
+  base::RunLoop().RunUntilIdle();
+
+  MockCobaltLifecycleObserver observer;
+  manager_->AddObserver(&observer);
+
+  manager_->StartWaitingForAck(contents.get(), PendingAck::kReveal);
+
+  // Dynamically attach and register a child subframe mid-transition.
+  content::RenderFrameHost* child_rfh = AddChildFrame(main_rfh);
+  mojo::Remote<cobalt::mojom::CobaltLifecycleObserver> child_remote;
+  manager_->BindReceiver(child_rfh, child_remote.BindNewPipeAndPassReceiver());
+  child_remote->OnFrameReady();
+  base::RunLoop().RunUntilIdle();
+
+  // ACKing the main frame must complete the transition without waiting on
+  // child_remote.
+  EXPECT_CALL(observer, OnAllFramesVisible(contents.get())).Times(1);
+  main_remote->OnPageVisibilityChanged(true);
   base::RunLoop().RunUntilIdle();
 
   manager_->RemoveObserver(&observer);


### PR DESCRIPTION
The visibilityChange event to 'visible' could get raced by the focus event, resulting in focus being signaled before visible. This ensures correct sequencing.

1. Instantiates CobaltLifecycleManager's WebContentsTracker early during DidFinishNavigation to ensure we correctly capture navigating frames, preventing a race condition where focus/visibility JS events were fired out-of-order.

2. Restricts the browser-side lifecycle ACK handshake to only track the active Primary Main Frame (via GetPrimaryMainFrame()) during downward transitions. This excludes throttled subframes (iframes) and leaked navigated-away main frames pending deletion, eliminating a 4-second deadlock safety timeout and reducing transition latencies from 4.0s to ~30ms.

Bug: 491962441
Bug: 475990372
Bug: 448156280
