### PR TITLE
westerossink: set stop-keep-frame property to true

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -1948,6 +1948,10 @@ void PlayerImpl::SetupElement(GstElement* pipeline,
         GST_INFO_OBJECT(pipeline, "Setting westerossink zoom-mode to 0");
         g_object_set(element, "zoom-mode", 0, nullptr);
       }
+      if (g_object_class_find_property(G_OBJECT_GET_CLASS(element), "stop-keep-frame")) {
+        GST_INFO_OBJECT(pipeline, "Setting westerossink stop-keep-frame to true");
+        g_object_set(element, "stop-keep-frame", true, nullptr);
+      }
       g_signal_connect_swapped(
         G_OBJECT(element), "buffer-underflow-callback",
         G_CALLBACK(OnVideoBufferUnderflow), self);


### PR DESCRIPTION
    
Setting westerossink `stop-keep-frame` property to true stops
flashing black screen (display blank for a few seconds) on the display
during video transition.
This allows drivers to hold the last frame on the video plane from
previous video and thus the display are not blanked
(since something is there to display)
    
Property details:
stop-keep-frame     : true - keep last frame; false: display black
                                     flags: readable, writable
                                     Boolean. Default: false
 
Bug: 515092940
