### PR TITLE
starboard: Make JobQueue support move-only job

### DIFF
--- a/starboard/android/shared/video_window_test.cc
+++ b/starboard/android/shared/video_window_test.cc
@@ -129,15 +129,11 @@ TEST_F(VideoDecoderSurfaceTest, TeardownDuringSurfaceDestroyReleasesSurface) {
   // Thread B: Simulate decoder teardown on the decoder thread.
   // We add a small delay to ensure the JNI thread can acquire the lock first,
   // which is necessary to trigger the deadlock on the unpatched code.
-  std::shared_ptr<MediaCodecVideoDecoder> shared_decoder = std::move(decoder);
-  job_thread->Schedule([shared_decoder]() mutable {
+  job_thread->Schedule([decoder = std::move(decoder)] {
     SB_LOG(INFO) << "Decoder thread: Waiting before destroying...";
     usleep(100'000);
     SB_LOG(INFO) << "Decoder thread: Destroying decoder...";
-    shared_decoder.reset();
-    SB_LOG(INFO) << "Decoder thread: Decoder destroyed.";
   });
-  shared_decoder.reset();
 
   jni_sim_thread.Join();
   auto duration = CurrentMonotonicTime() - start_time;

--- a/starboard/shared/starboard/player/job_queue.cc
+++ b/starboard/shared/starboard/player/job_queue.cc
@@ -35,20 +35,11 @@ JobQueue::~JobQueue() {
   StopSoon();
 }
 
-JobQueue::JobToken JobQueue::Schedule(const Job& job,
-                                      int64_t delay_usec /*= 0*/) {
-  return Schedule(job, NULL, delay_usec);
+JobQueue::JobToken JobQueue::Schedule(Job job, int64_t delay_usec /*= 0*/) {
+  return Schedule(std::move(job), /*owner=*/nullptr, delay_usec);
 }
 
-JobQueue::JobToken JobQueue::Schedule(Job&& job, int64_t delay_usec /*= 0*/) {
-  return Schedule(std::move(job), NULL, delay_usec);
-}
-
-void JobQueue::ScheduleAndWait(const Job& job) {
-  ScheduleAndWait(Job(job));
-}
-
-void JobQueue::ScheduleAndWait(Job&& job) {
+void JobQueue::ScheduleAndWait(Job job) {
   // TODO: Allow calling from the JobQueue thread.
   SB_CHECK(!BelongsToCurrentThread());
 
@@ -122,13 +113,7 @@ bool JobQueue::BelongsToCurrentThread() const {
   return thread_checker_.CalledOnValidThread();
 }
 
-JobQueue::JobToken JobQueue::Schedule(const Job& job,
-                                      JobOwner* owner,
-                                      int64_t delay_usec) {
-  return Schedule(Job(job), owner, delay_usec);
-}
-
-JobQueue::JobToken JobQueue::Schedule(Job&& job,
+JobQueue::JobToken JobQueue::Schedule(Job job,
                                       JobOwner* owner,
                                       int64_t delay_usec) {
   SB_DCHECK(job);

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -18,8 +18,10 @@
 #include <condition_variable>
 #include <functional>
 #include <map>
+#include <memory>
 #include <mutex>
 #include <optional>
+#include <type_traits>
 #include <utility>
 
 #include "starboard/common/check_op.h"
@@ -44,7 +46,65 @@ namespace starboard {
 // A thread can only have one job queue.
 class JobQueue {
  public:
-  using Job = std::function<void()>;
+  class Job {
+   public:
+    Job() = default;
+    Job(std::nullptr_t) {}
+
+    template <
+        typename F,
+        typename = std::enable_if_t<!std::is_same_v<std::decay_t<F>, Job> &&
+                                    std::is_invocable_v<std::decay_t<F>&>>>
+    Job(F&& f)
+        : impl_(
+              std::make_unique<ImplType<std::decay_t<F>>>(std::forward<F>(f))) {
+    }
+
+    Job(const Job&) = delete;
+    Job& operator=(const Job&) = delete;
+    Job(Job&&) = default;
+    Job& operator=(Job&&) = default;
+
+    Job& operator=(std::nullptr_t) {
+      impl_.reset();
+      return *this;
+    }
+
+    void operator()() {
+      SB_CHECK(impl_);
+      impl_->Run();
+    }
+
+    explicit operator bool() const { return impl_ != nullptr; }
+    friend bool operator==(const Job& job, std::nullptr_t) {
+      return job.impl_ == nullptr;
+    }
+    friend bool operator==(std::nullptr_t, const Job& job) {
+      return job.impl_ == nullptr;
+    }
+    friend bool operator!=(const Job& job, std::nullptr_t) {
+      return job.impl_ != nullptr;
+    }
+    friend bool operator!=(std::nullptr_t, const Job& job) {
+      return job.impl_ != nullptr;
+    }
+
+   private:
+    struct ImplBase {
+      virtual ~ImplBase() = default;
+      virtual void Run() = 0;
+    };
+
+    template <typename F>
+    struct ImplType : public ImplBase {
+      template <typename U>
+      explicit ImplType(U&& f) : f_(std::forward<U>(f)) {}
+      void Run() override { f_(); }
+      F f_;
+    };
+
+    std::unique_ptr<ImplBase> impl_;
+  };
 
   class JobToken {
    public:
@@ -81,10 +141,7 @@ class JobQueue {
       return job_queue_->BelongsToCurrentThread();
     }
 
-    JobToken Schedule(const Job& job, int64_t delay_usec = 0) {
-      return job_queue_->Schedule(job, this, delay_usec);
-    }
-    JobToken Schedule(Job&& job, int64_t delay_usec = 0) {
+    JobToken Schedule(Job job, int64_t delay_usec = 0) {
       return job_queue_->Schedule(std::move(job), this, delay_usec);
     }
 
@@ -124,10 +181,8 @@ class JobQueue {
   JobQueue();
   ~JobQueue();
 
-  JobToken Schedule(const Job& job, int64_t delay_usec = 0);
-  JobToken Schedule(Job&& job, int64_t delay_usec = 0);
-  void ScheduleAndWait(const Job& job);
-  void ScheduleAndWait(Job&& job);
+  JobToken Schedule(Job job, int64_t delay_usec = 0);
+  void ScheduleAndWait(Job job);
   void RemoveJobByToken(JobToken* job_token);
 
   // The processing of jobs may not be stopped when this function returns, but
@@ -158,8 +213,7 @@ class JobQueue {
   };
   typedef std::multimap<int64_t, JobRecord> TimeToJobRecordMap;
 
-  JobToken Schedule(const Job& job, JobOwner* owner, int64_t delay_usec);
-  JobToken Schedule(Job&& job, JobOwner* owner, int64_t delay_usec);
+  JobToken Schedule(Job job, JobOwner* owner, int64_t delay_usec);
   void RemoveJobsByOwner(JobOwner* owner);
   // Return true if a job is run, otherwise return false.  When there is no job
   // ready to run currently and |wait_for_next_job| is true, the function will

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -168,25 +168,28 @@ class JobQueue {
     };
 
     void Reset() {
-      if (destroy_) {
-        destroy_(storage_);
-        invoke_ = nullptr;
-        destroy_ = nullptr;
-        move_ = nullptr;
+      if (!destroy_) {
+        return;
       }
+
+      destroy_(storage_);
+      invoke_ = nullptr;
+      destroy_ = nullptr;
+      move_ = nullptr;
     }
 
     void MoveFrom(Job&& other) {
       invoke_ = other.invoke_;
       destroy_ = other.destroy_;
       move_ = other.move_;
-
-      if (other.move_) {
-        other.move_(other.storage_, storage_);
-        other.invoke_ = nullptr;
-        other.destroy_ = nullptr;
-        other.move_ = nullptr;
+      if (!other.move_) {
+        return;
       }
+
+      other.move_(other.storage_, storage_);
+      other.invoke_ = nullptr;
+      other.destroy_ = nullptr;
+      other.move_ = nullptr;
     }
 
     template <typename T>
@@ -198,6 +201,7 @@ class JobQueue {
     }
 
     Buffer storage_;
+    // Function pointers for type-erased operations:
     void (*invoke_)(Buffer&) = nullptr;
     void (*destroy_)(Buffer&) = nullptr;
     void (*move_)(Buffer&, Buffer&) = nullptr;

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -16,10 +16,12 @@
 #define STARBOARD_SHARED_STARBOARD_PLAYER_JOB_QUEUE_H_
 
 #include <condition_variable>
+#include <cstddef>
 #include <functional>
 #include <map>
 #include <memory>
 #include <mutex>
+#include <new>
 #include <optional>
 #include <type_traits>
 #include <utility>
@@ -46,6 +48,16 @@ namespace starboard {
 // A thread can only have one job queue.
 class JobQueue {
  public:
+  // A move-only type-erased wrapper for callables with signature void().
+  // This is similar to C++23 std::move_only_function. It allows capturing
+  // move-only objects like std::unique_ptr.
+  //
+  // Lifetime: A Job object owns the wrapped callable. When the Job is
+  // destroyed, the wrapped callable is also destroyed.
+  //
+  // Threading: A Job can be constructed and moved on any thread, but it
+  // should only be invoked once. Typically, Jobs are scheduled and executed
+  // on the JobQueue's thread.
   class Job {
    public:
     Job() = default;
@@ -55,41 +67,93 @@ class JobQueue {
         typename F,
         typename = std::enable_if_t<!std::is_same_v<std::decay_t<F>, Job> &&
                                     std::is_invocable_v<std::decay_t<F>&>>>
-    Job(F&& f)
-        : impl_(
-              std::make_unique<ImplType<std::decay_t<F>>>(std::forward<F>(f))) {
+    Job(F&& f) {
+      if (IsNull(f)) {
+        return;
+      }
+
+      using DecayedF = std::decay_t<F>;
+      if constexpr (sizeof(DecayedF) <= kInlineStorageSize &&
+                    alignof(DecayedF) <= kInlineStorageAlignment &&
+                    std::is_nothrow_move_constructible_v<DecayedF>) {
+        new (storage_.buffer) DecayedF(std::forward<F>(f));
+        invoke_ = [](Buffer& buf) {
+          (*reinterpret_cast<DecayedF*>(buf.buffer))();
+        };
+        destroy_ = [](Buffer& buf) {
+          reinterpret_cast<DecayedF*>(buf.buffer)->~DecayedF();
+        };
+        move_ = [](Buffer& src, Buffer& dest) {
+          new (dest.buffer)
+              DecayedF(std::move(*reinterpret_cast<DecayedF*>(src.buffer)));
+          reinterpret_cast<DecayedF*>(src.buffer)->~DecayedF();
+        };
+      } else {
+        using Impl = ImplType<DecayedF>;
+        storage_.ptr = new Impl(std::forward<F>(f));
+        invoke_ = [](Buffer& buf) { static_cast<Impl*>(buf.ptr)->Run(); };
+        destroy_ = [](Buffer& buf) { delete static_cast<Impl*>(buf.ptr); };
+        move_ = [](Buffer& src, Buffer& dest) {
+          dest.ptr = src.ptr;
+          src.ptr = nullptr;
+        };
+      }
     }
 
     Job(const Job&) = delete;
     Job& operator=(const Job&) = delete;
-    Job(Job&&) = default;
-    Job& operator=(Job&&) = default;
+
+    Job(Job&& other) noexcept { MoveFrom(std::move(other)); }
+
+    Job& operator=(Job&& other) noexcept {
+      if (this != &other) {
+        Reset();
+        MoveFrom(std::move(other));
+      }
+      return *this;
+    }
+
+    ~Job() { Reset(); }
 
     Job& operator=(std::nullptr_t) {
-      impl_.reset();
+      Reset();
       return *this;
     }
 
     void operator()() {
-      SB_CHECK(impl_);
-      impl_->Run();
+      SB_CHECK(invoke_);
+      invoke_(storage_);
     }
 
-    explicit operator bool() const { return impl_ != nullptr; }
+    explicit operator bool() const { return invoke_ != nullptr; }
+
     friend bool operator==(const Job& job, std::nullptr_t) {
-      return job.impl_ == nullptr;
+      return job.invoke_ == nullptr;
     }
     friend bool operator==(std::nullptr_t, const Job& job) {
-      return job.impl_ == nullptr;
+      return job.invoke_ == nullptr;
     }
     friend bool operator!=(const Job& job, std::nullptr_t) {
-      return job.impl_ != nullptr;
+      return job.invoke_ != nullptr;
     }
     friend bool operator!=(std::nullptr_t, const Job& job) {
-      return job.impl_ != nullptr;
+      return job.invoke_ != nullptr;
     }
 
    private:
+    // 24 bytes is large enough to fit most common callables, such as:
+    // - Standard function pointers (8 bytes)
+    // - Member function pointers (up to 16 bytes)
+    // - Small lambdas capturing up to 3 pointers (e.g., 'this' and a couple of
+    //   arguments)
+    static constexpr size_t kInlineStorageSize = 24;
+    static constexpr size_t kInlineStorageAlignment = alignof(std::max_align_t);
+
+    union Buffer {
+      alignas(kInlineStorageAlignment) char buffer[kInlineStorageSize];
+      void* ptr;
+    };
+
     struct ImplBase {
       virtual ~ImplBase() = default;
       virtual void Run() = 0;
@@ -103,7 +167,40 @@ class JobQueue {
       F f_;
     };
 
-    std::unique_ptr<ImplBase> impl_;
+    void Reset() {
+      if (destroy_) {
+        destroy_(storage_);
+        invoke_ = nullptr;
+        destroy_ = nullptr;
+        move_ = nullptr;
+      }
+    }
+
+    void MoveFrom(Job&& other) {
+      invoke_ = other.invoke_;
+      destroy_ = other.destroy_;
+      move_ = other.move_;
+
+      if (other.move_) {
+        other.move_(other.storage_, storage_);
+        other.invoke_ = nullptr;
+        other.destroy_ = nullptr;
+        other.move_ = nullptr;
+      }
+    }
+
+    template <typename T>
+    static constexpr bool IsNull(const T& t) {
+      if constexpr (std::is_pointer_v<T> || std::is_member_pointer_v<T>) {
+        return t == nullptr;
+      }
+      return false;
+    }
+
+    Buffer storage_;
+    void (*invoke_)(Buffer&) = nullptr;
+    void (*destroy_)(Buffer&) = nullptr;
+    void (*move_)(Buffer&, Buffer&) = nullptr;
   };
 
   class JobToken {

--- a/starboard/shared/starboard/player/job_queue.h
+++ b/starboard/shared/starboard/player/job_queue.h
@@ -91,7 +91,7 @@ class JobQueue {
       } else {
         using Impl = ImplType<DecayedF>;
         storage_.ptr = new Impl(std::forward<F>(f));
-        invoke_ = [](Buffer& buf) { static_cast<Impl*>(buf.ptr)->Run(); };
+        invoke_ = [](Buffer& buf) { static_cast<Impl*>(buf.ptr)->f_(); };
         destroy_ = [](Buffer& buf) { delete static_cast<Impl*>(buf.ptr); };
         move_ = [](Buffer& src, Buffer& dest) {
           dest.ptr = src.ptr;
@@ -154,16 +154,10 @@ class JobQueue {
       void* ptr;
     };
 
-    struct ImplBase {
-      virtual ~ImplBase() = default;
-      virtual void Run() = 0;
-    };
-
     template <typename F>
-    struct ImplType : public ImplBase {
+    struct ImplType {
       template <typename U>
       explicit ImplType(U&& f) : f_(std::forward<U>(f)) {}
-      void Run() override { f_(); }
       F f_;
     };
 

--- a/starboard/shared/starboard/player/job_queue_test.cc
+++ b/starboard/shared/starboard/player/job_queue_test.cc
@@ -176,6 +176,12 @@ TEST_F(JobQueueTest, MoveOnlyLambdaIsAccepted) {
   EXPECT_TRUE(executed);
 }
 
+TEST_F(JobQueueTest, NullFunctionPointerIsInvalidJob) {
+  void (*null_func)() = nullptr;
+  JobQueue::Job job(null_func);
+  EXPECT_FALSE(job);
+}
+
 TEST_F(JobQueueTest, QueueBelongsToCorrectThread) {
   EXPECT_TRUE(job_queue_.BelongsToCurrentThread());
 }

--- a/starboard/shared/starboard/player/job_queue_test.cc
+++ b/starboard/shared/starboard/player/job_queue_test.cc
@@ -17,6 +17,7 @@
 #include <unistd.h>
 
 #include <atomic>
+#include <memory>
 #include <vector>
 
 #include "testing/gmock/include/gmock/gmock.h"
@@ -160,6 +161,19 @@ TEST_F(JobQueueTest, JobsAreMovedAndNotCopied) {
 
   EXPECT_FALSE(copied);
   EXPECT_TRUE(moved);
+}
+
+TEST_F(JobQueueTest, MoveOnlyLambdaIsAccepted) {
+  std::atomic_bool executed = false;
+  auto move_only_obj = std::make_unique<int>(42);
+
+  job_queue_.Schedule([ptr = std::move(move_only_obj), &executed]() {
+    EXPECT_EQ(*ptr, 42);
+    executed = true;
+  });
+  job_queue_.RunUntilIdle();
+
+  EXPECT_TRUE(executed);
 }
 
 TEST_F(JobQueueTest, QueueBelongsToCorrectThread) {

--- a/starboard/shared/starboard/player/job_thread.h
+++ b/starboard/shared/starboard/player/job_thread.h
@@ -52,23 +52,14 @@ class JobThread {
     return job_queue_->BelongsToCurrentThread();
   }
 
-  JobQueue::JobToken Schedule(const JobQueue::Job& job,
-                              int64_t delay_usec = 0) {
-    return job_queue_->Schedule(job, delay_usec);
-  }
-
-  JobQueue::JobToken Schedule(JobQueue::Job&& job, int64_t delay_usec = 0) {
+  JobQueue::JobToken Schedule(JobQueue::Job job, int64_t delay_usec = 0) {
     return job_queue_->Schedule(std::move(job), delay_usec);
-  }
-
-  void ScheduleAndWait(const JobQueue::Job& job) {
-    job_queue_->ScheduleAndWait(job);
   }
 
   // TODO: Calling ScheduleAndWait with a call to JobQueue::StopSoon will cause
   // heap-use-after-free errors in ScheduleAndWait due to JobQueue dtor
   // occasionally running before ScheduleAndWait has finished.
-  void ScheduleAndWait(JobQueue::Job&& job) {
+  void ScheduleAndWait(JobQueue::Job job) {
     job_queue_->ScheduleAndWait(std::move(job));
   }
 

--- a/starboard/shared/starboard/player/job_thread_test.cc
+++ b/starboard/shared/starboard/player/job_thread_test.cc
@@ -18,6 +18,7 @@
 
 #include <atomic>
 #include <condition_variable>
+#include <memory>
 #include <mutex>
 #include <vector>
 
@@ -72,6 +73,20 @@ TEST(JobThreadTest, ScheduleAndWaitWaits) {
   // Verify that the job ran and that it took at least as long as it slept.
   EXPECT_TRUE(job_1);
   EXPECT_GE(CurrentMonotonicTime() - start, 1 * kPrecisionUsec);
+  job_thread->Stop();
+}
+
+TEST(JobThreadTest, AcceptsMoveOnlyLambda) {
+  std::atomic_bool executed = false;
+  auto move_only_obj = std::make_unique<int>(100);
+  auto job_thread = JobThread::Create("JobThreadTests");
+
+  job_thread->ScheduleAndWait([ptr = std::move(move_only_obj), &executed]() {
+    EXPECT_EQ(*ptr, 100);
+    executed = true;
+  });
+
+  EXPECT_TRUE(executed);
   job_thread->Stop();
 }
 


### PR DESCRIPTION
starboard: Support move-only jobs in JobQueue

Replace std::function with a custom move-only type-erasure wrapper to
allow tasks to capture move-only objects like unique_ptr.

This change enables more flexible task scheduling by removing the
requirement that all captured objects be copyable. The Schedule and
ScheduleAndWait methods are updated to accept jobs by value to leverage
move semantics throughout the player job management system.

Issue: 527555517