### PR TITLE
aosp: Fix outdated copied_base Java (bundle/isolated-splits, @MainDex)

### DIFF
--- a/copied_base/base/android/java/src/org/chromium/base/BaseFeatureList.java
+++ b/copied_base/base/android/java/src/org/chromium/base/BaseFeatureList.java
@@ -6,13 +6,11 @@ package org.chromium.base;
 
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 /**
  * Java accessor for base/feature_list.h state.
  */
 @JNINamespace("base::android")
-@MainDex
 public final class BaseFeatureList {
     // Do not instantiate this class.
     private BaseFeatureList() {}

--- a/copied_base/base/android/java/src/org/chromium/base/BundleUtils.java
+++ b/copied_base/base/android/java/src/org/chromium/base/BundleUtils.java
@@ -24,7 +24,6 @@ import dalvik.system.PathClassLoader;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.compat.ApiHelperForO;
 import org.chromium.base.metrics.RecordHistogram;
-import org.chromium.build.BuildConfig;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
@@ -38,19 +37,22 @@ import java.util.Map;
  * Important notes about bundle status as interpreted by this class:
  *
  * <ul>
- *   <li>If {@link BuildConfig#BUNDLES_SUPPORTED} is false, then we are definitely not in a bundle,
+ *   <li>If {@link #BUNDLES_SUPPORTED} is false, then we are definitely not in a bundle,
  *   and ProGuard is able to strip out the bundle support library.</li>
- *   <li>If {@link BuildConfig#BUNDLES_SUPPORTED} is true, then we MIGHT be in a bundle.
+ *   <li>If {@link #BUNDLES_SUPPORTED} is true, then we MIGHT be in a bundle.
  *   {@link BundleUtils#sIsBundle} is the source of truth.</li>
  * </ul>
  *
  * We need two fields to store one bit of information here to ensure that ProGuard can optimize out
- * the bundle support library (since {@link BuildConfig#BUNDLES_SUPPORTED} is final) and so that
+ * the bundle support library (since {@link #BUNDLES_SUPPORTED} is final) and so that
  * we can dynamically set whether or not we're in a bundle for targets that use static shared
  * library APKs.
  */
 public class BundleUtils {
     private static final String TAG = "BundleUtils";
+
+    private static final boolean BUNDLES_SUPPORTED = false;
+    private static final boolean ISOLATED_SPLITS_ENABLED = false;
     private static final String LOADED_SPLITS_KEY = "split_compat_loaded_splits";
     private static Boolean sIsBundle;
     private static final Object sSplitLock = new Object();
@@ -91,7 +93,7 @@ public class BundleUtils {
      * @return true if the current build is a bundle.
      */
     public static boolean isBundle() {
-        if (!BuildConfig.BUNDLES_SUPPORTED) {
+        if (!BUNDLES_SUPPORTED) {
             return false;
         }
         assert sIsBundle != null;
@@ -103,7 +105,7 @@ public class BundleUtils {
     }
 
     public static boolean isolatedSplitsEnabled() {
-        return BuildConfig.ISOLATED_SPLITS_ENABLED;
+        return ISOLATED_SPLITS_ENABLED;
     }
 
     @RequiresApi(api = Build.VERSION_CODES.O)

--- a/copied_base/base/android/java/src/org/chromium/base/CommandLine.java
+++ b/copied_base/base/android/java/src/org/chromium/base/CommandLine.java
@@ -10,7 +10,6 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 import java.io.File;
 import java.io.FileReader;
@@ -27,7 +26,6 @@ import java.util.concurrent.atomic.AtomicReference;
  * file at a specific location early during startup. Applications each define their own files, e.g.,
  * ContentShellApplication.COMMAND_LINE_FILE.
 **/
-@MainDex
 public abstract class CommandLine {
     // Public abstract interface, implemented in derived classes.
     // All these methods reflect their native-side counterparts.

--- a/copied_base/base/android/java/src/org/chromium/base/EarlyTraceEvent.java
+++ b/copied_base/base/android/java/src/org/chromium/base/EarlyTraceEvent.java
@@ -13,7 +13,6 @@ import androidx.annotation.VisibleForTesting;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -38,7 +37,6 @@ import javax.annotation.concurrent.GuardedBy;
  * final String| class member. Otherwise NoDynamicStringsInTraceEventCheck error will be thrown.
  */
 @JNINamespace("base::android")
-@MainDex
 public class EarlyTraceEvent {
     /** Single trace event. */
     @VisibleForTesting

--- a/copied_base/base/android/java/src/org/chromium/base/FeatureList.java
+++ b/copied_base/base/android/java/src/org/chromium/base/FeatureList.java
@@ -10,7 +10,6 @@ import androidx.annotation.VisibleForTesting;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
 import org.chromium.base.library_loader.LibraryLoader;
-import org.chromium.build.annotations.MainDex;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -19,7 +18,6 @@ import java.util.Map;
  * Provides shared capabilities for feature flag support.
  */
 @JNINamespace("base::android")
-@MainDex
 public class FeatureList {
     /**
      * Test value overrides for tests without native.

--- a/copied_base/base/android/java/src/org/chromium/base/Features.java
+++ b/copied_base/base/android/java/src/org/chromium/base/Features.java
@@ -6,7 +6,6 @@ package org.chromium.base;
 
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 /**
  * A class that serves as a bridge to native code to check the status of feature switches.
@@ -15,7 +14,6 @@ import org.chromium.build.annotations.MainDex;
  * single C++ Feature.
  */
 @JNINamespace("base::android")
-@MainDex
 public abstract class Features {
     private final String mName;
 

--- a/copied_base/base/android/java/src/org/chromium/base/FieldTrialList.java
+++ b/copied_base/base/android/java/src/org/chromium/base/FieldTrialList.java
@@ -5,12 +5,10 @@
 package org.chromium.base;
 
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 /**
  * Helper to get field trial information.
  */
-@MainDex
 public class FieldTrialList {
 
     private FieldTrialList() {}

--- a/copied_base/base/android/java/src/org/chromium/base/JNIUtils.java
+++ b/copied_base/base/android/java/src/org/chromium/base/JNIUtils.java
@@ -5,14 +5,12 @@
 package org.chromium.base;
 
 import org.chromium.base.annotations.CalledByNative;
-import org.chromium.build.annotations.MainDex;
 
 import java.util.Map;
 
 /**
  * This class provides JNI-related methods to the native library.
  */
-@MainDex
 public class JNIUtils {
     private static final String TAG = "JNIUtils";
     private static ClassLoader sJniClassLoader;

--- a/copied_base/base/android/java/src/org/chromium/base/JavaExceptionReporter.java
+++ b/copied_base/base/android/java/src/org/chromium/base/JavaExceptionReporter.java
@@ -9,7 +9,6 @@ import androidx.annotation.UiThread;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 /**
  * This UncaughtExceptionHandler will create a breakpad minidump when there is an uncaught
@@ -19,7 +18,6 @@ import org.chromium.build.annotations.MainDex;
  * to be reported in the same way as other native crashes.
  */
 @JNINamespace("base::android")
-@MainDex
 public class JavaExceptionReporter implements Thread.UncaughtExceptionHandler {
     private final Thread.UncaughtExceptionHandler mParent;
     private final boolean mCrashAfterReport;

--- a/copied_base/base/android/java/src/org/chromium/base/JavaHandlerThread.java
+++ b/copied_base/base/android/java/src/org/chromium/base/JavaHandlerThread.java
@@ -11,7 +11,6 @@ import android.os.Looper;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 import java.lang.Thread.UncaughtExceptionHandler;
 
@@ -19,7 +18,6 @@ import java.lang.Thread.UncaughtExceptionHandler;
  * Thread in Java with an Android Handler. This class is not thread safe.
  */
 @JNINamespace("base::android")
-@MainDex
 public class JavaHandlerThread {
     private final HandlerThread mThread;
 

--- a/copied_base/base/android/java/src/org/chromium/base/MemoryPressureListener.java
+++ b/copied_base/base/android/java/src/org/chromium/base/MemoryPressureListener.java
@@ -10,7 +10,6 @@ import android.content.ComponentCallbacks2;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.NativeMethods;
 import org.chromium.base.memory.MemoryPressureCallback;
-import org.chromium.build.annotations.MainDex;
 
 /**
  * This class is Java equivalent of base::MemoryPressureListener: it distributes pressure
@@ -25,7 +24,6 @@ import org.chromium.build.annotations.MainDex;
  * NOTE: this class should only be used on UiThread as defined by ThreadUtils (which is
  *       Android main thread for Chrome, but can be some other thread for WebView).
  */
-@MainDex
 public class MemoryPressureListener {
     /**
      * Sending an intent with this action to Chrome will cause it to issue a call to onLowMemory

--- a/copied_base/base/android/java/src/org/chromium/base/PathUtils.java
+++ b/copied_base/base/android/java/src/org/chromium/base/PathUtils.java
@@ -22,7 +22,6 @@ import org.chromium.base.compat.ApiHelperForM;
 import org.chromium.base.compat.ApiHelperForQ;
 import org.chromium.base.compat.ApiHelperForR;
 import org.chromium.base.task.AsyncTask;
-import org.chromium.build.annotations.MainDex;
 
 import java.io.File;
 import java.util.ArrayList;
@@ -35,7 +34,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 /**
  * This class provides the path related methods for the native library.
  */
-@MainDex
 public abstract class PathUtils {
     private static final String TAG = "PathUtils";
     private static final String THUMBNAIL_DIRECTORY_NAME = "textures";

--- a/copied_base/base/android/java/src/org/chromium/base/SysUtils.java
+++ b/copied_base/base/android/java/src/org/chromium/base/SysUtils.java
@@ -18,7 +18,6 @@ import androidx.annotation.VisibleForTesting;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 import java.io.BufferedReader;
 import java.io.FileReader;
@@ -29,7 +28,6 @@ import java.util.regex.Pattern;
  * Exposes system related information about the current device.
  */
 @JNINamespace("base::android")
-@MainDex
 public class SysUtils {
     // A device reporting strictly more total memory in megabytes cannot be considered 'low-end'.
     private static final int ANDROID_LOW_MEMORY_DEVICE_THRESHOLD_MB = 512;

--- a/copied_base/base/android/java/src/org/chromium/base/TimezoneUtils.java
+++ b/copied_base/base/android/java/src/org/chromium/base/TimezoneUtils.java
@@ -8,12 +8,10 @@ import android.os.StrictMode;
 
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.annotations.JNINamespace;
-import org.chromium.build.annotations.MainDex;
 
 import java.util.TimeZone;
 
 @JNINamespace("base::android")
-@MainDex
 class TimezoneUtils {
     /**
      * Guards this class from being instantiated.

--- a/copied_base/base/android/java/src/org/chromium/base/TraceEvent.java
+++ b/copied_base/base/android/java/src/org/chromium/base/TraceEvent.java
@@ -20,7 +20,6 @@ import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
 import org.chromium.base.task.PostTask;
 import org.chromium.base.task.TaskTraits;
-import org.chromium.build.annotations.MainDex;
 
 import java.util.ArrayList;
 
@@ -41,7 +40,6 @@ import java.util.ArrayList;
  * @see EarlyTraceEvent for details.
  */
 @JNINamespace("base::android")
-@MainDex
 public class TraceEvent implements AutoCloseable {
     private static volatile boolean sEnabled; // True when tracing into Chrome's tracing service.
     private static volatile boolean sUiThreadReady;

--- a/copied_base/base/android/java/src/org/chromium/base/library_loader/LibraryLoader.java
+++ b/copied_base/base/android/java/src/org/chromium/base/library_loader/LibraryLoader.java
@@ -31,7 +31,6 @@ import org.chromium.base.metrics.RecordHistogram;
 import org.chromium.base.metrics.UmaRecorderHolder;
 import org.chromium.build.BuildConfig;
 import org.chromium.build.NativeLibraries;
-import org.chromium.build.annotations.MainDex;
 
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -52,7 +51,6 @@ import javax.annotation.concurrent.GuardedBy;
  * See also base/android/library_loader/library_loader_hooks.cc, which contains
  * the native counterpart to this class.
  */
-@MainDex
 @JNINamespace("base::android")
 public class LibraryLoader {
     private static final String TAG = "LibraryLoader";

--- a/copied_base/base/android/java/src/org/chromium/base/library_loader/LibraryPrefetcher.java
+++ b/copied_base/base/android/java/src/org/chromium/base/library_loader/LibraryPrefetcher.java
@@ -13,7 +13,6 @@ import org.chromium.base.annotations.NativeMethods;
 import org.chromium.base.metrics.RecordHistogram;
 import org.chromium.base.task.PostTask;
 import org.chromium.base.task.TaskTraits;
-import org.chromium.build.annotations.MainDex;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
@@ -23,7 +22,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * See also base/android/library_loader/library_prefetcher_hooks.cc, which contains
  * the native counterpart to this class.
  */
-@MainDex
 @JNINamespace("base::android")
 public class LibraryPrefetcher {
 

--- a/copied_base/base/android/java/src/org/chromium/base/memory/MemoryPressureMonitor.java
+++ b/copied_base/base/android/java/src/org/chromium/base/memory/MemoryPressureMonitor.java
@@ -15,7 +15,6 @@ import org.chromium.base.MemoryPressureLevel;
 import org.chromium.base.MemoryPressureListener;
 import org.chromium.base.ThreadUtils;
 import org.chromium.base.supplier.Supplier;
-import org.chromium.build.annotations.MainDex;
 
 /**
  * This class monitors memory pressure and reports it to the native side.
@@ -70,7 +69,6 @@ import org.chromium.build.annotations.MainDex;
  * NOTE: This class should only be used on UiThread as defined by ThreadUtils (which is
  *       Android main thread for Chrome, but can be some other thread for WebView).
  */
-@MainDex
 public class MemoryPressureMonitor {
     private static final int DEFAULT_THROTTLING_INTERVAL_MS = 60 * 1000;
 

--- a/copied_base/base/android/java/src/org/chromium/base/metrics/NativeUmaRecorder.java
+++ b/copied_base/base/android/java/src/org/chromium/base/metrics/NativeUmaRecorder.java
@@ -8,7 +8,6 @@ import org.chromium.base.Callback;
 import org.chromium.base.TimeUtils;
 import org.chromium.base.annotations.JNINamespace;
 import org.chromium.base.annotations.NativeMethods;
-import org.chromium.build.annotations.MainDex;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -23,7 +22,6 @@ import java.util.Map;
  * code.
  */
 @JNINamespace("base::android")
-@MainDex
 /* package */ final class NativeUmaRecorder implements UmaRecorder {
     /**
      * Internally, histograms objects are cached on the Java side by their pointer

--- a/copied_base/base/android/java/src/org/chromium/base/metrics/RecordHistogram.java
+++ b/copied_base/base/android/java/src/org/chromium/base/metrics/RecordHistogram.java
@@ -8,7 +8,6 @@ import android.text.format.DateUtils;
 
 import androidx.annotation.VisibleForTesting;
 
-
 import java.util.List;
 
 /**

--- a/copied_base/base/android/java/src/org/chromium/base/metrics/RecordHistogram.java
+++ b/copied_base/base/android/java/src/org/chromium/base/metrics/RecordHistogram.java
@@ -8,14 +8,12 @@ import android.text.format.DateUtils;
 
 import androidx.annotation.VisibleForTesting;
 
-import org.chromium.build.annotations.MainDex;
 
 import java.util.List;
 
 /**
  * Java API for recording UMA histograms.
  * */
-@MainDex
 public class RecordHistogram {
     /**
      * Records a sample in a boolean UMA histogram of the given name. Boolean histogram has two

--- a/copied_base/base/android/java/src/org/chromium/base/process_launcher/ChildProcessService.java
+++ b/copied_base/base/android/java/src/org/chromium/base/process_launcher/ChildProcessService.java
@@ -34,7 +34,6 @@ import org.chromium.base.compat.ApiHelperForN;
 import org.chromium.base.library_loader.LibraryLoader;
 import org.chromium.base.memory.MemoryPressureMonitor;
 import org.chromium.base.metrics.RecordHistogram;
-import org.chromium.build.annotations.MainDex;
 
 import java.util.List;
 
@@ -63,7 +62,6 @@ import javax.annotation.concurrent.GuardedBy;
  * implementation which cannot directly inherit from this class (e.g. for WebLayer child services).
  */
 @JNINamespace("base::android")
-@MainDex
 public class ChildProcessService {
     private static final String MAIN_THREAD_NAME = "ChildProcessMain";
     private static final String TAG = "ChildProcessService";

--- a/copied_base/base/android/java/src/org/chromium/base/process_launcher/FileDescriptorInfo.java
+++ b/copied_base/base/android/java/src/org/chromium/base/process_launcher/FileDescriptorInfo.java
@@ -8,7 +8,6 @@ import android.os.Parcel;
 import android.os.ParcelFileDescriptor;
 import android.os.Parcelable;
 
-import org.chromium.build.annotations.MainDex;
 import org.chromium.build.annotations.UsedByReflection;
 
 import javax.annotation.concurrent.Immutable;
@@ -18,7 +17,6 @@ import javax.annotation.concurrent.Immutable;
  * be passed to child processes.
  */
 @Immutable
-@MainDex
 @UsedByReflection("child_process_launcher_helper_android.cc")
 public final class FileDescriptorInfo implements Parcelable {
     public final int id;

--- a/copied_base/base/android/javatests/src/org/chromium/base/library_loader/EarlyNativeTest.java
+++ b/copied_base/base/android/javatests/src/org/chromium/base/library_loader/EarlyNativeTest.java
@@ -20,14 +20,12 @@ import org.chromium.base.test.BaseJUnit4ClassRunner;
 import org.chromium.base.test.util.Batch;
 import org.chromium.base.test.util.CallbackHelper;
 import org.chromium.build.BuildConfig;
-import org.chromium.build.annotations.MainDex;
 
 /**
  * Tests for early JNI initialization.
  */
 @RunWith(BaseJUnit4ClassRunner.class)
 @JNINamespace("base")
-@MainDex
 @Batch(Batch.UNIT_TESTS)
 public class EarlyNativeTest {
     private boolean mWasInitialized;

--- a/copied_base/base/test/android/java/src/org/chromium/base/multidex/ChromiumMultiDexInstaller.java
+++ b/copied_base/base/test/android/java/src/org/chromium/base/multidex/ChromiumMultiDexInstaller.java
@@ -11,12 +11,10 @@ import androidx.annotation.VisibleForTesting;
 import androidx.multidex.MultiDex;
 
 import org.chromium.base.Log;
-import org.chromium.build.annotations.MainDex;
 
 /**
  *  Performs multidex installation for non-isolated processes.
  */
-@MainDex
 public class ChromiumMultiDexInstaller {
     private static final String TAG = "base_multidex";
 

--- a/copied_base/base/test/android/javatests/src/org/chromium/base/test/BaseChromiumAndroidJUnitRunner.java
+++ b/copied_base/base/test/android/javatests/src/org/chromium/base/test/BaseChromiumAndroidJUnitRunner.java
@@ -49,7 +49,6 @@ import org.chromium.base.test.util.InMemorySharedPreferences;
 import org.chromium.base.test.util.InMemorySharedPreferencesContext;
 import org.chromium.base.test.util.ScalableTimeout;
 import org.chromium.build.BuildConfig;
-import org.chromium.build.annotations.MainDex;
 
 import java.io.File;
 import java.io.IOException;
@@ -73,7 +72,6 @@ import java.util.concurrent.TimeoutException;
  * Please beware that is this not a class runner. It is declared in test apk AndroidManifest.xml
  * <instrumentation>
  */
-@MainDex
 public class BaseChromiumAndroidJUnitRunner extends AndroidJUnitRunner {
     private static final String LIST_ALL_TESTS_FLAG =
             "org.chromium.base.test.BaseChromiumAndroidJUnitRunner.TestList";

--- a/copied_base/base/test/android/javatests/src/org/chromium/base/test/BaseChromiumRunnerCommon.java
+++ b/copied_base/base/test/android/javatests/src/org/chromium/base/test/BaseChromiumRunnerCommon.java
@@ -14,7 +14,6 @@ import androidx.core.content.ContextCompat;
 
 import org.chromium.base.Log;
 import org.chromium.base.test.util.PackageManagerWrapper;
-import org.chromium.build.annotations.MainDex;
 
 import java.io.File;
 import java.io.IOException;
@@ -26,7 +25,6 @@ import java.util.Comparator;
 /**
  *  Functionality common to the JUnit3 and JUnit4 runners.
  */
-@MainDex
 class BaseChromiumRunnerCommon {
     private static final String TAG = "base_test";
 
@@ -34,7 +32,6 @@ class BaseChromiumRunnerCommon {
      *  A ContextWrapper that allows multidex test APKs to extract secondary dexes into
      *  the APK under test's data directory.
      */
-    @MainDex
     static class MultiDexContextWrapper extends ContextWrapper {
         private final Context mAppContext;
 

--- a/copied_base/base/test/android/javatests/src/org/chromium/base/test/util/UrlUtils.java
+++ b/copied_base/base/test/android/javatests/src/org/chromium/base/test/util/UrlUtils.java
@@ -9,12 +9,10 @@ import org.junit.Assert;
 import org.chromium.base.PathUtils;
 import org.chromium.base.StrictModeContext;
 import org.chromium.base.annotations.CalledByNative;
-import org.chromium.build.annotations.MainDex;
 
 /**
  * Collection of URL utilities.
  */
-@MainDex
 public class UrlUtils {
     private static final String DATA_DIR = "chrome/test/data/";
 


### PR DESCRIPTION
//copied_base/base:base_java still references symbols Chromium has since removed, breaking compilation on the AOSP platform.

Remove BuildConfig.BUNDLES_SUPPORTED and BuildConfig.ISOLATED_SPLITS_ENABLED, which were removed from the generated BuildConfig. They are made into local constants with a false value, since Cobalt builds plain APKs with no isolated splits.

Also remove nonexistent @MainDex annotations.

Bug: 495203133