### PR TITLE
modular: Initialize TMPDIR in the hermetic environment

### DIFF
--- a/base/files/file_util_posix.cc
+++ b/base/files/file_util_posix.cc
@@ -76,11 +76,6 @@
 #include "base/os_compat_android.h"
 #endif
 
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
-#include "starboard/configuration_constants.h"
-#include "starboard/system.h"
-#endif  // BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
-
 #if !BUILDFLAG(IS_IOS)
 #include <grp.h>
 #endif
@@ -811,19 +806,6 @@ bool ExecutableExistsInPath(Environment* env,
 #if !BUILDFLAG(IS_APPLE)
 // This is implemented in file_util_apple.mm for Mac.
 bool GetTempDir(FilePath* path) {
-#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
-  std::vector<char> temp_path(kSbFileMaxPath, 0);
-  if (!SbSystemGetPath(kSbSystemPathTempDirectory, temp_path.data(),
-                       temp_path.size())) {
-    return false;
-  }
-  *path = FilePath(temp_path.data());
-
-  if (!DirectoryExists(*path)) {
-    return CreateDirectory(*path);
-  }
-  return true;
-#else  // BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
   const char* tmp = getenv("TMPDIR");
   if (tmp) {
     *path = FilePath(tmp);
@@ -836,7 +818,6 @@ bool GetTempDir(FilePath* path) {
   *path = FilePath("/tmp");
   return true;
 #endif
-#endif  // BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
 }
 #endif  // !BUILDFLAG(IS_APPLE)
 

--- a/base/files/file_util_posix.cc
+++ b/base/files/file_util_posix.cc
@@ -76,6 +76,11 @@
 #include "base/os_compat_android.h"
 #endif
 
+#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
+#include "starboard/configuration_constants.h"
+#include "starboard/system.h"
+#endif  // BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
+
 #if !BUILDFLAG(IS_IOS)
 #include <grp.h>
 #endif
@@ -806,6 +811,19 @@ bool ExecutableExistsInPath(Environment* env,
 #if !BUILDFLAG(IS_APPLE)
 // This is implemented in file_util_apple.mm for Mac.
 bool GetTempDir(FilePath* path) {
+#if BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
+  std::vector<char> temp_path(kSbFileMaxPath, 0);
+  if (!SbSystemGetPath(kSbSystemPathTempDirectory, temp_path.data(),
+                       temp_path.size())) {
+    return false;
+  }
+  *path = FilePath(temp_path.data());
+
+  if (!DirectoryExists(*path)) {
+    return CreateDirectory(*path);
+  }
+  return true;
+#else  // BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
   const char* tmp = getenv("TMPDIR");
   if (tmp) {
     *path = FilePath(tmp);
@@ -818,6 +836,7 @@ bool GetTempDir(FilePath* path) {
   *path = FilePath("/tmp");
   return true;
 #endif
+#endif  // BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
 }
 #endif  // !BUILDFLAG(IS_APPLE)
 

--- a/cobalt/common/libc/stdlib/environment.cc
+++ b/cobalt/common/libc/stdlib/environment.cc
@@ -22,6 +22,7 @@
 #include <vector>
 
 #include "cobalt/common/libc/no_destructor.h"
+#include "starboard/configuration_constants.h"
 #include "starboard/system.h"
 #include "starboard/time_zone.h"
 
@@ -103,6 +104,12 @@ char** Environment::InitializeGlobalEnviron() {
 
   // Initialize the LANG variable from the Starboard API.
   setenv("LANG", SbSystemGetLocaleId(), 0);
+
+  // Initialize the TMPDIR variable from the Starboard API.
+  std::vector<char> path(kSbFileMaxPath + 1);
+  if (SbSystemGetPath(kSbSystemPathTempDirectory, path.data(), path.size())) {
+    setenv("TMPDIR", path.data(), /*overwrite=*/0);
+  }
 
   RebuildAndSetGlobalEnviron();
   return ::environ;


### PR DESCRIPTION
Populate TMPDIR in the hermetic libc environment from
SbSystemGetPath(kSbSystemPathTempDirectory). This allows the modular base::GetTempDir()
to work on AOSP.

Fixes: 487548027
Bug: 495203133