### PR TITLE
copied_base: Delegate JNI to jni_zero

### DIFF
--- a/copied_base/base/BUILD.gn
+++ b/copied_base/base/BUILD.gn
@@ -1340,6 +1340,14 @@ component("base") {
       sources += [ "android/reached_code_profiler_stub.cc" ]
     }
 
+    # TODO(https://crbug.com/495203133): the native_target partner toolchain
+    # compiles debug/stack_trace_android.cc but links neither an unwinder nor
+    # Starboard's unwind_starboard, leaving the _Unwind_* symbols it references
+    # undefined.
+    if (!is_starboard) {
+      sources += [ "debug/cobalt_unwind_stubs.cc" ]
+    }
+
     # This is actually a linker script, but it can be added to the link in the
     # same way as a library.
     libs += [ "android/library_loader/anchor_functions.lds" ]
@@ -1393,7 +1401,9 @@ component("base") {
 
     deps += [
       ":base_jni",
+      ":jni_android_jni",
       ":process_launcher_jni",
+      "//build:robolectric_buildflags",
     ]
   }  # is_android || is_robolectric
 
@@ -4268,7 +4278,10 @@ if (is_android || is_robolectric) {
   }
 
   generate_jar_jni("android_runtime_jni_headers") {
-    classes = [ "java/lang/Runtime.class" ]
+    classes = [
+      "java/lang/Runtime.class",
+      "java/lang/Throwable.class",
+    ]
   }
 
   generate_jar_jni("android_runtime_unchecked_jni_headers") {
@@ -4280,6 +4293,10 @@ if (is_android || is_robolectric) {
     sources = [
       "android/java/src/org/chromium/base/process_launcher/ChildProcessService.java",
     ]
+  }
+
+  generate_jni("jni_android_jni") {
+    sources = [ "android/java/src/org/chromium/base/JniAndroid.java" ]
   }
 }  # is_android || is_robolectric
 

--- a/copied_base/base/BUILD.gn
+++ b/copied_base/base/BUILD.gn
@@ -4371,6 +4371,7 @@ if (is_android) {
       "//third_party/androidx:androidx_annotation_annotation_java",
       "//third_party/androidx:androidx_collection_collection_java",
       "//third_party/androidx:androidx_core_core_java",
+      "//third_party/jni_zero:jni_zero_java",
     ]
 
     sources = [

--- a/copied_base/base/android/base_jni_onload.cc
+++ b/copied_base/base/android/base_jni_onload.cc
@@ -14,8 +14,6 @@ namespace android {
 
 bool OnJNIOnLoadInit() {
   InitAtExitManager();
-  JNIEnv* env = base::android::AttachCurrentThread();
-  base::android::InitGlobalClassLoader(env);
   return true;
 }
 

--- a/copied_base/base/android/java/src/org/chromium/base/JniAndroid.java
+++ b/copied_base/base/android/java/src/org/chromium/base/JniAndroid.java
@@ -1,0 +1,143 @@
+// Copyright 2023 The Chromium Authors
+// Use of this source code is governed by a BSD-style license that can be
+// found in the LICENSE file.
+
+package org.chromium.base;
+
+import org.jni_zero.CalledByNative;
+import org.jni_zero.JniType;
+
+import org.chromium.build.annotations.NullMarked;
+import org.chromium.build.annotations.Nullable;
+
+/** Provides Java-side code to back `jni_android` native logic. */
+@NullMarked
+public final class JniAndroid {
+    private JniAndroid() {}
+
+    private static final String TAG = "JniAndroid";
+    static boolean sSimulateOomInSanitizedStacktraceForTesting;
+
+    /**
+     * Returns a sanitized stacktrace (per {@link PiiElider#sanitizeStacktrace(String)}) for the
+     * given throwable. Returns null if an OutOfMemoryError occurs.
+     *
+     * <p>Since this is running inside an uncaught exception handler, this method will make every
+     * effort not to throw; instead, any failures will be surfaced through the returned string.
+     */
+    @CalledByNative
+    private static @Nullable @JniType("std::string") String
+            sanitizedStacktraceForUnhandledException(Throwable throwable) {
+        if (sSimulateOomInSanitizedStacktraceForTesting) {
+            return null;
+        }
+        try {
+            return PiiElider.sanitizeStacktrace(Log.getStackTraceString(throwable));
+        } catch (OutOfMemoryError oomError) {
+            return null;
+        } catch (Throwable stacktraceThrowable) {
+            try {
+                return "Error while getting stack trace: "
+                        + Log.getStackTraceString(stacktraceThrowable);
+            } catch (OutOfMemoryError oomError) {
+                return null;
+            }
+        }
+    }
+
+    /**
+     * Indicates that native code was faced with an uncaught Java exception.
+     *
+     * <p>{@code #getCause} returns the original uncaught exception.
+     */
+    public static class UncaughtExceptionException extends RuntimeException {
+        public UncaughtExceptionException(String nativeStackTrace, Throwable uncaughtException) {
+            super(
+                    getTopFrameString(uncaughtException) + System.lineSeparator()
+                            + "Uncaught Java exception:" + System.lineSeparator()
+                            + Log.getStackTraceString(uncaughtException) + System.lineSeparator()
+                            + "Native stack trace:" + System.lineSeparator() + nativeStackTrace,
+                    uncaughtException);
+            setStackTrace(uncaughtException.getStackTrace());
+        }
+
+        private static String getTopFrameString(Throwable uncaughtException) {
+            StackTraceElement[] frames = uncaughtException.getStackTrace();
+            if (frames != null && frames.length > 0) {
+                StackTraceElement top = frames[0];
+                String fileName = top.getFileName();
+                return (fileName != null ? fileName : "UnknownSource") + ":" + top.getLineNumber();
+            }
+            return "UnknownSource";
+        }
+    }
+
+    /**
+     * Called by the Chromium native JNI framework when faced with an uncaught Java exception while
+     * executing a Java method from native code.
+     *
+     * <p>This method is expected to terminate the process (but is not guaranteed to).
+     *
+     * <p>The goal of this method is to provide an opportunity to terminate the process from the
+     * Java side so that the crash looks like any other uncaught Java exception, and is handled
+     * accordingly by system crash handlers. This ensures the Java stack trace will be collected, as
+     * opposed to the native stack trace - the former is typically more useful as the true root
+     * cause of the crash is Java code, not native code. See https://crbug.com/1426888 for more
+     * discussion.
+     *
+     * <p>This method will make every effort not to throw to avoid re-entering the Chromium JNI
+     * native exception handler. Errors will be sent to the system log instead.
+     *
+     * @param throwable The uncaught Java exception that was thrown by a Java method called via JNI.
+     * @param nativeStackTrace The stack trace of the native code that called the Java method that
+     *     threw.
+     * @return null, unless the uncaught exception handler threw an exception other than
+     *     OutOfMemoryError exception, in which case that exception is returned.
+     */
+    @CalledByNative
+    private static @Nullable Throwable handleException(
+            Throwable throwable, @JniType("std::string") String nativeStackTrace) {
+        try {
+            // Try to make sure the exception details at least make their way to the log even if the
+            // rest of this method goes horribly wrong.
+            Log.e(TAG, "Handling uncaught Java exception", throwable);
+
+            // Wrap the original exception so that we can annotate it with native stack information,
+            // with the goal of including as much information in the Java crash report as possible.
+            // (The native caller might itself have been called from Java. We don't need to care
+            // about that because the stack trace in `throwable` includes the *entire* Java stack of
+            // the current thread, even if there are native calls in the middle.)
+            var wrappedThrowable = new UncaughtExceptionException(nativeStackTrace, throwable);
+
+            // The Chromium JNI framework does not support resuming execution after a Java method
+            // called through JNI throws an exception - we have to terminate the process at some
+            // point, otherwise undefined behavior may result. The goal here is to provide as much
+            // useful information to the crash handler as we can.
+            //
+            // To that end, we try to call the global uncaught exception handler. Hopefully that
+            // will eventually reach the default Android uncaught exception handler (possibly going
+            // through JavaExceptionReporter first, if we set one up), which will terminate the
+            // process. If for any reason that doesn't happen (e.g. the app set up a different
+            // handler), then we just give up and return the new exception (if any) - the native
+            // code we're returning to will terminate the process for us. (Note that, even then,
+            // there is still a case where we might not terminate the process: if the uncaught
+            // exception handler deliberately terminates the current thread but not the entire
+            // process. This is very contrived though, and protecting against this would be
+            // complicated, so we don't even try.)
+            Thread.getDefaultUncaughtExceptionHandler()
+                    .uncaughtException(Thread.currentThread(), wrappedThrowable);
+            Log.e(TAG, "Global uncaught exception handler did not terminate the process.");
+            return null;
+        } catch (OutOfMemoryError e) {
+            // Don't call Log.e() so as to not risk throwing again.
+            return null;
+        } catch (Throwable e) {
+            // Log the new crash rather than the original crash, since if there is a bug in our
+            // crash handling logic, we need to know about it. If there is a crash in a webview
+            // app's crash handling logic, then we can rely on other apps to upload the underlying
+            // exception.
+            Log.e(TAG, "Exception in uncaught exception handler.", e);
+            return e;
+        }
+    }
+}

--- a/copied_base/base/android/jni_android.cc
+++ b/copied_base/base/android/jni_android.cc
@@ -4,136 +4,95 @@
 
 #include "base/android/jni_android.h"
 
-#include <cstring>
 #include <stddef.h>
-
-#if BUILDFLAG(IS_COBALT)
-#include <string>
-#include <iostream>
-#include <regex>
-#endif
+#include <sys/prctl.h>
 
 #include "base/android/java_exception_reporter.h"
 #include "base/android/jni_string.h"
 #include "base/android/jni_utils.h"
-#include "base/base_jni/PiiElider_jni.h"
+#include "base/android_runtime_jni_headers/Throwable_jni.h"
 #include "base/debug/debugging_buildflags.h"
+#include "base/feature_list.h"
 #include "base/logging.h"
-#include "base/base_switches.h"
-#include "base/command_line.h"
+#include "base/strings/string_util.h"
 #include "build/build_config.h"
-#include "third_party/abseil-cpp/absl/base/attributes.h"
+#include "build/robolectric_buildflags.h"
 #include "third_party/jni_zero/jni_zero.h"
+
+// Must come after all headers that specialize FromJniType() / ToJniType().
+#include "base/jni_android_jni/JniAndroid_jni.h"
 
 namespace base {
 namespace android {
 namespace {
 
-jobject g_class_loader = nullptr;
-jmethodID g_class_loader_load_class_method_id = 0;
+// If disabled, we LOG(FATAL) immediately in native code when faced with an
+// uncaught Java exception (historical behavior). If enabled, we give the Java
+// uncaught exception handler a chance to handle the exception first, so that
+// the crash is (hopefully) seen as a Java crash, not a native crash.
+// TODO(crbug.com/40261529): remove this switch once we are confident the
+// new behavior is fine.
+BASE_FEATURE(kHandleExceptionsInJava,
+             "HandleJniExceptionsInJava",
+             base::FEATURE_ENABLED_BY_DEFAULT);
 
-#if BUILDFLAG(CAN_UNWIND_WITH_FRAME_POINTERS)
-ABSL_CONST_INIT thread_local void* stack_frame_pointer = nullptr;
-#endif
+jclass g_out_of_memory_error_class = nullptr;
 
-bool g_fatal_exception_occurred = false;
-
-/* Cobalt specific hack to move Java classes to a custom namespace.
-   For every class org.chromium.foo moves them to cobalt.org.chromium.foo
-   This works around link-time conflicts when building the final
-   package against other Chromium release artifacts. */
-#if BUILDFLAG(IS_COBALT)
-const char* COBALT_ORG_CHROMIUM = "cobalt/org/chromium";
-const char* ORG_CHROMIUM = "org/chromium";
-
-std::string getRepackagedName(const char* signature) {
-  std::string holder(signature);
-  size_t pos = 0;
-  while ((pos = holder.find(ORG_CHROMIUM, pos)) != std::string::npos) {
-    holder.replace(pos, strlen(ORG_CHROMIUM), COBALT_ORG_CHROMIUM);
-    pos += strlen(COBALT_ORG_CHROMIUM);
-  }
-  return holder;
-}
-
-// Java exception stack trace example:
-//
-// java.lang.RuntimeException: Hello
-//     at dev.cobalt.media.VideoFrameReleaseTimeHelper.MethodC(VideoFrameReleaseTimeHelper.java:111)
-//     at dev.cobalt.media.VideoFrameReleaseTimeHelper.MethodB(VideoFrameReleaseTimeHelper.java:115)
-//     at dev.cobalt.media.VideoFrameReleaseTimeHelper.MethodA(VideoFrameReleaseTimeHelper.java:119)
-//     at dev.cobalt.media.VideoFrameReleaseTimeHelper.adjustReleaseTime(VideoFrameReleaseTimeHelper.java:135)
-std::string GetFirstLine(const std::string& stack_trace) {
-  return stack_trace.substr(0, stack_trace.find('\n'));
-}
-
-std::string FindTopJavaMethodsAndFiles(const std::string& stack_trace, const size_t max_matches) {
-    std::regex pattern("\\.([^.(]+)\\(([^)]+\\.java:\\d+)\\)");
-
-    std::vector<std::string> all_matches;
-    std::sregex_iterator it(stack_trace.begin(), stack_trace.end(), pattern);
-    std::sregex_iterator end;
-
-    while (it != end && all_matches.size() < max_matches) {
-        std::smatch match = *it;
-
-        // match[0] contains the method, file, and line (e.g., ".onCreate(CobaltActivity.java:219)")
-        all_matches.push_back(match[0].str());
-
-        ++it; // Move to the next match
-    }
-
-    std::ostringstream oss;
-    for (size_t i = 0; i < all_matches.size(); ++i) {
-        oss << all_matches[i];
-        if (i < all_matches.size() - 1) {
-            oss << "&";
-        }
-    }
-
-    return oss.str();
-}
-#endif  // BUILDFLAG(IS_COBALT)
-
-ScopedJavaLocalRef<jclass> GetClassInternal(JNIEnv* env,
-                                            const char* class_name,
-                                            jobject class_loader) {
-  jclass clazz;
-  if (class_loader != nullptr) {
-    // ClassLoader.loadClass expects a classname with components separated by
-    // dots instead of the slashes that JNIEnv::FindClass expects. The JNI
-    // generator generates names with slashes, so we have to replace them here.
-    // TODO(torne): move to an approach where we always use ClassLoader except
-    // for the special case of base::android::GetClassLoader(), and change the
-    // JNI generator to generate dot-separated names. http://crbug.com/461773
-    size_t bufsize = strlen(class_name) + 1;
-    char dotted_name[bufsize];
-    memmove(dotted_name, class_name, bufsize);
-    for (size_t i = 0; i < bufsize; ++i) {
-      if (dotted_name[i] == '/') {
-        dotted_name[i] = '.';
-      }
-    }
-
-    clazz = static_cast<jclass>(
-        env->CallObjectMethod(class_loader, g_class_loader_load_class_method_id,
-                              ConvertUTF8ToJavaString(env, dotted_name).obj()));
-  } else {
-    clazz = env->FindClass(class_name);
-  }
-  if (ClearException(env) || !clazz) {
-    LOG(FATAL) << "Failed to find class " << class_name;
-  }
-  return ScopedJavaLocalRef<jclass>(env, clazz);
-}
-
+#if !BUILDFLAG(IS_ROBOLECTRIC)
+jmethodID g_class_loader_load_class_method_id = nullptr;
+// ClassLoader.loadClass() accepts either slashes or dots on Android, but JVM
+// requires dots. We could translate, but there is no need to go through
+// ClassLoaders in Robolectric anyways.
+// https://cs.android.com/search?q=symbol:DexFile_defineClassNative
 jclass GetClassFromSplit(JNIEnv* env,
                          const char* class_name,
                          const char* split_name) {
-  return GetClass(env, class_name, split_name).Release();
+  DCHECK(IsStringASCII(class_name));
+  ScopedJavaLocalRef<jstring> j_class_name(env, env->NewStringUTF(class_name));
+  return static_cast<jclass>(env->CallObjectMethod(
+      GetSplitClassLoader(env, split_name), g_class_loader_load_class_method_id,
+      j_class_name.obj()));
 }
 
+// Must be called before using GetClassFromSplit - we need to set the global,
+// and we need to call GetClassLoader at least once to allow the default
+// resolver (env->FindClass()) to get our main ClassLoader class instance, which
+// we then cache use for all future calls to GetSplitClassLoader.
+void PrepareClassLoaders(JNIEnv* env) {
+  if (g_class_loader_load_class_method_id == nullptr) {
+    GetClassLoader(env);
+    ScopedJavaLocalRef<jclass> class_loader_clazz = ScopedJavaLocalRef<jclass>(
+        env, env->FindClass("java/lang/ClassLoader"));
+    CHECK(!ClearException(env));
+    g_class_loader_load_class_method_id =
+        env->GetMethodID(class_loader_clazz.obj(), "loadClass",
+                         "(Ljava/lang/String;)Ljava/lang/Class;");
+    CHECK(!ClearException(env));
+  }
+}
+#endif  // !BUILDFLAG(IS_ROBOLECTRIC)
+
 }  // namespace
+
+LogFatalCallback g_log_fatal_callback_for_testing = nullptr;
+const char kUnableToGetStackTraceMessage[] =
+    "Unable to retrieve Java caller stack trace as the exception handler is "
+    "being re-entered";
+const char kReetrantOutOfMemoryMessage[] =
+    "While handling an uncaught Java exception, an OutOfMemoryError "
+    "occurred.";
+const char kReetrantExceptionMessage[] =
+    "While handling an uncaught Java exception, another exception "
+    "occurred.";
+const char kUncaughtExceptionMessage[] =
+    "Uncaught Java exception in native code. Please include the Java exception "
+    "stack from the Android log in your crash report.";
+const char kUncaughtExceptionHandlerFailedMessage[] =
+    "Uncaught Java exception in native code and the Java uncaught exception "
+    "handler did not terminate the process. Please include the Java exception "
+    "stack from the Android log in your crash report.";
+const char kOomInGetJavaExceptionInfoMessage[] =
+    "Unable to obtain Java stack trace due to OutOfMemoryError";
 
 void InitVM(JavaVM* vm) {
   jni_zero::InitVM(vm);
@@ -143,209 +102,169 @@ void InitVM(JavaVM* vm) {
   // Warm-up needed for GetClassFromSplit, must be called before we set the
   // resolver, since GetClassFromSplit won't work until after
   // PrepareClassLoaders has happened.
-  InitGlobalClassLoader(env);
+  PrepareClassLoaders(env);
   jni_zero::SetClassResolver(GetClassFromSplit);
 #endif
-}
-
-void InitGlobalClassLoader(JNIEnv* env) {
-  DCHECK(g_class_loader == nullptr);
-
-  ScopedJavaLocalRef<jclass> class_loader_clazz =
-      GetClass(env, "java/lang/ClassLoader");
-  CHECK(!ClearException(env));
-  g_class_loader_load_class_method_id =
-      env->GetMethodID(class_loader_clazz.obj(),
-                       "loadClass",
-                       "(Ljava/lang/String;)Ljava/lang/Class;");
-  CHECK(!ClearException(env));
-
-  // GetClassLoader() caches the reference, so we do not need to wrap it in a
-  // smart pointer as well.
-  g_class_loader = GetClassLoader(env);
-}
-
-ScopedJavaLocalRef<jclass> GetClass(JNIEnv* env,
-                                    const char* class_name,
-                                    const char* split_name) {
-  return GetClassInternal(env, class_name,
-                          GetSplitClassLoader(env, split_name));
-}
-
-ScopedJavaLocalRef<jclass> GetClass(JNIEnv* env, const char* class_name) {
-  return GetClassInternal(env, class_name, g_class_loader);
-}
-
-// This is duplicated with LazyGetClass below because these are performance
-// sensitive.
-jclass LazyGetClass(JNIEnv* env,
-                    const char* class_name,
-                    const char* split_name,
-                    std::atomic<jclass>* atomic_class_id) {
-  const jclass value = atomic_class_id->load(std::memory_order_acquire);
-  if (value)
-    return value;
-  ScopedJavaGlobalRef<jclass> clazz;
-  clazz.Reset(GetClass(env, class_name, split_name));
-  jclass cas_result = nullptr;
-  if (atomic_class_id->compare_exchange_strong(cas_result, clazz.obj(),
-                                               std::memory_order_acq_rel)) {
-    // We intentionally leak the global ref since we now storing it as a raw
-    // pointer in |atomic_class_id|.
-    return clazz.Release();
-  } else {
-    return cas_result;
-  }
-}
-
-// This is duplicated with LazyGetClass above because these are performance
-// sensitive.
-jclass LazyGetClass(JNIEnv* env,
-                    const char* class_name,
-                    std::atomic<jclass>* atomic_class_id) {
-  const jclass value = atomic_class_id->load(std::memory_order_acquire);
-  if (value)
-    return value;
-  ScopedJavaGlobalRef<jclass> clazz;
-  clazz.Reset(GetClass(env, class_name));
-  jclass cas_result = nullptr;
-  if (atomic_class_id->compare_exchange_strong(cas_result, clazz.obj(),
-                                               std::memory_order_acq_rel)) {
-    // We intentionally leak the global ref since we now storing it as a raw
-    // pointer in |atomic_class_id|.
-    return clazz.Release();
-  } else {
-    return cas_result;
-  }
-}
-
-template<MethodID::Type type>
-jmethodID MethodID::Get(JNIEnv* env,
-                        jclass clazz,
-                        const char* method_name,
-                        const char* jni_signature) {
-  auto get_method_ptr = type == MethodID::TYPE_STATIC ?
-      &JNIEnv::GetStaticMethodID :
-      &JNIEnv::GetMethodID;
-  jmethodID id = (env->*get_method_ptr)(clazz, method_name, jni_signature);
-  if (base::android::ClearException(env) || !id) {
-    LOG(FATAL) << "Failed to find " <<
-        (type == TYPE_STATIC ? "static " : "") <<
-        "method " << method_name << " " << jni_signature;
-  }
-  return id;
-}
-
-// If |atomic_method_id| set, it'll return immediately. Otherwise, it'll call
-// into ::Get() above. If there's a race, it's ok since the values are the same
-// (and the duplicated effort will happen only once).
-template <MethodID::Type type>
-jmethodID MethodID::LazyGet(JNIEnv* env,
-                            jclass clazz,
-                            const char* method_name,
-                            const char* jni_signature,
-                            std::atomic<jmethodID>* atomic_method_id) {
-  const jmethodID value = atomic_method_id->load(std::memory_order_acquire);
-  if (value)
-    return value;
-  jmethodID id = MethodID::Get<type>(env, clazz, method_name, jni_signature);
-  atomic_method_id->store(id, std::memory_order_release);
-  return id;
-}
-
-// Various template instantiations.
-template jmethodID MethodID::Get<MethodID::TYPE_STATIC>(
-    JNIEnv* env, jclass clazz, const char* method_name,
-    const char* jni_signature);
-
-template jmethodID MethodID::Get<MethodID::TYPE_INSTANCE>(
-    JNIEnv* env, jclass clazz, const char* method_name,
-    const char* jni_signature);
-
-template jmethodID MethodID::LazyGet<MethodID::TYPE_STATIC>(
-    JNIEnv* env, jclass clazz, const char* method_name,
-    const char* jni_signature, std::atomic<jmethodID>* atomic_method_id);
-
-template jmethodID MethodID::LazyGet<MethodID::TYPE_INSTANCE>(
-    JNIEnv* env, jclass clazz, const char* method_name,
-    const char* jni_signature, std::atomic<jmethodID>* atomic_method_id);
-
-bool HasException(JNIEnv* env) {
-  return env->ExceptionCheck() != JNI_FALSE;
-}
-
-bool ClearException(JNIEnv* env) {
-  if (!HasException(env))
-    return false;
-  env->ExceptionDescribe();
-  env->ExceptionClear();
-  return true;
+  g_out_of_memory_error_class = static_cast<jclass>(
+      env->NewGlobalRef(env->FindClass("java/lang/OutOfMemoryError")));
+  DCHECK(g_out_of_memory_error_class);
 }
 
 void CheckException(JNIEnv* env) {
-  if (!HasException(env))
+  if (!jni_zero::HasException(env)) {
     return;
-
-#if BUILDFLAG(IS_COBALT)
-  std::string exception_token;
-#endif
-  jthrowable java_throwable = env->ExceptionOccurred();
-  if (java_throwable) {
-    // Clear the pending exception, since a local reference is now held.
-    env->ExceptionDescribe();
-    env->ExceptionClear();
-
-    if (g_fatal_exception_occurred) {
-      // Another exception (probably OOM) occurred during GetJavaExceptionInfo.
-      base::android::SetJavaException(
-          "Java OOM'ed in exception handling, check logcat");
-#if BUILDFLAG(IS_COBALT)
-      exception_token = "Java OOM'ed";
-#endif
-    } else {
-      g_fatal_exception_occurred = true;
-#if BUILDFLAG(IS_COBALT)
-      std::string exception_info = GetJavaExceptionInfo(env, java_throwable);
-      base::android::SetJavaException(exception_info.c_str());
-      exception_token =
-          GetFirstLine(exception_info) + " at " +
-          FindTopJavaMethodsAndFiles(exception_info, /*max_matches=*/4);
-#else
-      // RVO should avoid any extra copies of the exception string.
-      base::android::SetJavaException(
-          GetJavaExceptionInfo(env, java_throwable).c_str());
-#endif
-    }
   }
 
-  // Now, feel good about it and die.
-#if BUILDFLAG(IS_COBALT)
-  LOG(FATAL) << "JNI exception: " << exception_token;
-#else
-  LOG(FATAL) << "Please include Java exception stack in crash report";
-#endif
+  static thread_local bool g_reentering = false;
+  if (g_reentering) {
+    // We were handling an uncaught Java exception already, but one of the Java
+    // methods we called below threw another exception. (This is unlikely to
+    // happen, as we are careful to never throw from these methods, but we
+    // can't rule it out entirely. E.g. an OutOfMemoryError when constructing
+    // the jstring for the return value of
+    // sanitizedStacktraceForUnhandledException().
+    env->ExceptionDescribe();
+    jthrowable raw_throwable = env->ExceptionOccurred();
+    env->ExceptionClear();
+    jclass clazz = env->GetObjectClass(raw_throwable);
+    bool is_oom_error = env->IsSameObject(clazz, g_out_of_memory_error_class);
+    env->Throw(raw_throwable);  // Ensure we don't re-enter Java.
+
+    if (is_oom_error) {
+      base::android::SetJavaException(kReetrantOutOfMemoryMessage);
+      // Use different LOG(FATAL) statements to ensure unique stack traces.
+      if (g_log_fatal_callback_for_testing) {
+        g_log_fatal_callback_for_testing(kReetrantOutOfMemoryMessage);
+      } else {
+        LOG(FATAL) << kReetrantOutOfMemoryMessage;
+      }
+    } else {
+      base::android::SetJavaException(kReetrantExceptionMessage);
+      if (g_log_fatal_callback_for_testing) {
+        g_log_fatal_callback_for_testing(kReetrantExceptionMessage);
+      } else {
+        LOG(FATAL) << kReetrantExceptionMessage;
+      }
+    }
+    // Needed for tests, which do not terminate from LOG(FATAL).
+    return;
+  }
+  g_reentering = true;
+
+  // Log a message to ensure there is something in the log even if the rest of
+  // this function goes horribly wrong, and also to provide a convenient marker
+  // in the log for where Java exception crash information starts.
+  LOG(ERROR) << "Crashing due to uncaught Java exception";
+
+  const bool handle_exception_in_java =
+      base::FeatureList::IsEnabled(kHandleExceptionsInJava);
+
+  if (!handle_exception_in_java) {
+    env->ExceptionDescribe();
+  }
+
+  // We cannot use `ScopedJavaLocalRef` directly because that ends up calling
+  // env->GetObjectRefType() when DCHECK is on, and that call is not allowed
+  // with a pending exception according to the JNI spec.
+  jthrowable raw_throwable = env->ExceptionOccurred();
+  // Now that we saved the reference to the throwable, clear the exception.
+  //
+  // We need to do this as early as possible to remove the risk that code below
+  // might accidentally call back into Java, which is not allowed when `env`
+  // has an exception set, per the JNI spec. (For example, LOG(FATAL) doesn't
+  // work with a JNI exception set, because it calls
+  // GetJavaStackTraceIfPresent()).
+  env->ExceptionClear();
+  // The reference returned by `ExceptionOccurred()` is a local reference.
+  // `ExceptionClear()` merely removes the exception information from `env`;
+  // it doesn't delete the reference, which is why this call is valid.
+  auto throwable = ScopedJavaLocalRef<jthrowable>::Adopt(env, raw_throwable);
+
+  if (!handle_exception_in_java) {
+    base::android::SetJavaException(
+        GetJavaExceptionInfo(env, throwable).c_str());
+    if (g_log_fatal_callback_for_testing) {
+      g_log_fatal_callback_for_testing(kUncaughtExceptionMessage);
+    } else {
+      LOG(FATAL) << kUncaughtExceptionMessage;
+    }
+    // Needed for tests, which do not terminate from LOG(FATAL).
+    g_reentering = false;
+    return;
+  }
+
+  // We don't need to call SetJavaException() in this branch because we
+  // expect handleException() to eventually call JavaExceptionReporter through
+  // the global uncaught exception handler.
+
+  const std::string native_stack_trace = base::debug::StackTrace().ToString();
+  LOG(ERROR) << "Native stack trace:" << std::endl << native_stack_trace;
+
+  ScopedJavaLocalRef<jthrowable> secondary_exception =
+      Java_JniAndroid_handleException(env, throwable, native_stack_trace);
+
+  // Ideally handleException() should have terminated the process and we should
+  // not get here. This can happen in the case of OutOfMemoryError or if the
+  // app that embedded WebView installed an exception handler that does not
+  // terminate, or itself threw an exception. We cannot be confident that
+  // JavaExceptionReporter ran, so set the java exception explicitly.
+  base::android::SetJavaException(
+      GetJavaExceptionInfo(
+          env, secondary_exception ? secondary_exception : throwable)
+          .c_str());
+  if (g_log_fatal_callback_for_testing) {
+    g_log_fatal_callback_for_testing(kUncaughtExceptionHandlerFailedMessage);
+  } else {
+    LOG(FATAL) << kUncaughtExceptionHandlerFailedMessage;
+  }
+  // Needed for tests, which do not terminate from LOG(FATAL).
+  g_reentering = false;
 }
 
-std::string GetJavaExceptionInfo(JNIEnv* env, jthrowable java_throwable) {
-  ScopedJavaLocalRef<jstring> sanitized_exception_string =
-      Java_PiiElider_getSanitizedStacktrace(
-          env, ScopedJavaLocalRef<jthrowable>(env, java_throwable));
-
-  return ConvertJavaStringToUTF8(sanitized_exception_string);
+std::string GetJavaExceptionInfo(JNIEnv* env,
+                                 const JavaRef<jthrowable>& throwable) {
+  std::string sanitized_exception_string =
+      Java_JniAndroid_sanitizedStacktraceForUnhandledException(env, throwable);
+  // Returns null when PiiElider results in an OutOfMemoryError.
+  return !sanitized_exception_string.empty()
+             ? sanitized_exception_string
+             : kOomInGetJavaExceptionInfoMessage;
 }
 
-#if BUILDFLAG(CAN_UNWIND_WITH_FRAME_POINTERS)
+std::string GetJavaStackTraceIfPresent() {
+  JNIEnv* env = nullptr;
+  JavaVM* jvm = jni_zero::GetVM();
+  if (jvm) {
+    jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_2);
+  }
+  if (!env) {
+    // JNI has not been initialized on this thread.
+    return {};
+  }
 
-JNIStackFrameSaver::JNIStackFrameSaver(void* current_fp)
-    : resetter_(&stack_frame_pointer, current_fp) {}
+  if (HasException(env)) {
+    // This can happen if CheckException() is being re-entered, decided to
+    // LOG(FATAL) immediately, and LOG(FATAL) itself is calling us. In that case
+    // it is imperative that we don't try to call Java again.
+    return kUnableToGetStackTraceMessage;
+  }
 
-JNIStackFrameSaver::~JNIStackFrameSaver() = default;
-
-void* JNIStackFrameSaver::SavedFrame() {
-  return stack_frame_pointer;
+  ScopedJavaLocalRef<jthrowable> throwable =
+      JNI_Throwable::Java_Throwable_Constructor(env);
+  std::string ret = GetJavaExceptionInfo(env, throwable);
+  // Strip the exception message and leave only the "at" lines. Example:
+  // java.lang.Throwable:
+  // {tab}at Clazz.method(Clazz.java:111)
+  // {tab}at ...
+  size_t newline_idx = ret.find('\n');
+  if (newline_idx == std::string::npos) {
+    // There are no java frames.
+    return {};
+  }
+  return ret.substr(newline_idx + 1);
 }
-
-#endif  // BUILDFLAG(CAN_UNWIND_WITH_FRAME_POINTERS)
 
 }  // namespace android
 }  // namespace base
+
+DEFINE_JNI_FOR_JniAndroid()

--- a/copied_base/base/android/jni_android.cc
+++ b/copied_base/base/android/jni_android.cc
@@ -6,7 +6,6 @@
 
 #include <cstring>
 #include <stddef.h>
-#include <sys/prctl.h>
 
 #if BUILDFLAG(IS_COBALT)
 #include <string>
@@ -24,12 +23,12 @@
 #include "base/command_line.h"
 #include "build/build_config.h"
 #include "third_party/abseil-cpp/absl/base/attributes.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 namespace base {
 namespace android {
 namespace {
 
-JavaVM* g_jvm = nullptr;
 jobject g_class_loader = nullptr;
 jmethodID g_class_loader_load_class_method_id = 0;
 
@@ -128,71 +127,25 @@ ScopedJavaLocalRef<jclass> GetClassInternal(JNIEnv* env,
   return ScopedJavaLocalRef<jclass>(env, clazz);
 }
 
+jclass GetClassFromSplit(JNIEnv* env,
+                         const char* class_name,
+                         const char* split_name) {
+  return GetClass(env, class_name, split_name).Release();
+}
+
 }  // namespace
 
-JNIEnv* AttachCurrentThread() {
-  DCHECK(g_jvm);
-  JNIEnv* env = nullptr;
-  jint ret = g_jvm->GetEnv(reinterpret_cast<void**>(&env), JNI_VERSION_1_2);
-  if (ret == JNI_EDETACHED || !env) {
-    JavaVMAttachArgs args;
-    args.version = JNI_VERSION_1_2;
-    args.group = nullptr;
-
-    // 16 is the maximum size for thread names on Android.
-    char thread_name[16];
-    int err = prctl(PR_GET_NAME, thread_name);
-    if (err < 0) {
-      DPLOG(ERROR) << "prctl(PR_GET_NAME)";
-      args.name = nullptr;
-    } else {
-      args.name = thread_name;
-    }
-
-#if BUILDFLAG(IS_ANDROID)
-    ret = g_jvm->AttachCurrentThread(&env, &args);
-#else
-    ret = g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), &args);
-#endif
-    CHECK_EQ(JNI_OK, ret);
-  }
-  return env;
-}
-
-JNIEnv* AttachCurrentThreadWithName(const std::string& thread_name) {
-  DCHECK(g_jvm);
-  JavaVMAttachArgs args;
-  args.version = JNI_VERSION_1_2;
-  args.name = const_cast<char*>(thread_name.c_str());
-  args.group = nullptr;
-  JNIEnv* env = nullptr;
-#if BUILDFLAG(IS_ANDROID)
-  jint ret = g_jvm->AttachCurrentThread(&env, &args);
-#else
-  jint ret = g_jvm->AttachCurrentThread(reinterpret_cast<void**>(&env), &args);
-#endif
-  CHECK_EQ(JNI_OK, ret);
-  return env;
-}
-
-void DetachFromVM() {
-  // Ignore the return value, if the thread is not attached, DetachCurrentThread
-  // will fail. But it is ok as the native thread may never be attached.
-  if (g_jvm)
-    g_jvm->DetachCurrentThread();
-}
-
 void InitVM(JavaVM* vm) {
-  DCHECK(!g_jvm || g_jvm == vm);
-  g_jvm = vm;
-}
-
-bool IsVMInitialized() {
-  return g_jvm != nullptr;
-}
-
-JavaVM* GetVM() {
-  return g_jvm;
+  jni_zero::InitVM(vm);
+  jni_zero::SetExceptionHandler(CheckException);
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+#if !BUILDFLAG(IS_ROBOLECTRIC)
+  // Warm-up needed for GetClassFromSplit, must be called before we set the
+  // resolver, since GetClassFromSplit won't work until after
+  // PrepareClassLoaders has happened.
+  InitGlobalClassLoader(env);
+  jni_zero::SetClassResolver(GetClassFromSplit);
+#endif
 }
 
 void InitGlobalClassLoader(JNIEnv* env) {

--- a/copied_base/base/android/jni_android.h
+++ b/copied_base/base/android/jni_android.h
@@ -17,6 +17,7 @@
 #include "base/compiler_specific.h"
 #include "base/debug/debugging_buildflags.h"
 #include "base/debug/stack_trace.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 #if BUILDFLAG(CAN_UNWIND_WITH_FRAME_POINTERS)
 
@@ -62,26 +63,36 @@ struct RegistrationMethod {
 };
 
 // Attaches the current thread to the VM (if necessary) and return the JNIEnv*.
-BASE_EXPORT JNIEnv* AttachCurrentThread();
+inline JNIEnv* AttachCurrentThread() {
+  return jni_zero::AttachCurrentThread();
+}
 
 // Same to AttachCurrentThread except that thread name will be set to
 // |thread_name| if it is the first call. Otherwise, thread_name won't be
 // changed. AttachCurrentThread() doesn't regard underlying platform thread
 // name, but just resets it to "Thread-???". This function should be called
 // right after new thread is created if it is important to keep thread name.
-BASE_EXPORT JNIEnv* AttachCurrentThreadWithName(const std::string& thread_name);
+inline JNIEnv* AttachCurrentThreadWithName(const std::string& thread_name) {
+  return jni_zero::AttachCurrentThreadWithName(thread_name);
+}
 
 // Detaches the current thread from VM if it is attached.
-BASE_EXPORT void DetachFromVM();
+inline void DetachFromVM() {
+  jni_zero::DetachFromVM();
+}
 
 // Initializes the global JVM.
 BASE_EXPORT void InitVM(JavaVM* vm);
 
 // Returns true if the global JVM has been initialized.
-BASE_EXPORT bool IsVMInitialized();
+inline bool IsJavaAvailable() {
+  return jni_zero::IsVMInitialized();
+}
 
 // Returns the global JVM, or nullptr if it has not been initialized.
-BASE_EXPORT JavaVM* GetVM();
+inline JavaVM* GetVM() {
+  return jni_zero::GetVM();
+}
 
 // Initializes the global ClassLoader used by the GetClass and LazyGetClass
 // methods. This is needed because JNI will use the base ClassLoader when there

--- a/copied_base/base/android/jni_android.h
+++ b/copied_base/base/android/jni_android.h
@@ -19,48 +19,27 @@
 #include "base/debug/stack_trace.h"
 #include "third_party/jni_zero/jni_zero.h"
 
-#if BUILDFLAG(CAN_UNWIND_WITH_FRAME_POINTERS)
-
-// When profiling is enabled (enable_profiling=true) this macro is added to
-// all generated JNI stubs so that it becomes the last thing that runs before
-// control goes into Java.
-//
-// This macro saves stack frame pointer of the current function. Saved value
-// used later by JNI_LINK_SAVED_FRAME_POINTER.
-#define JNI_SAVE_FRAME_POINTER \
-  base::android::JNIStackFrameSaver jni_frame_saver(__builtin_frame_address(0))
-
-// When profiling is enabled (enable_profiling=true) this macro is added to
-// all generated JNI callbacks so that it becomes the first thing that runs
-// after control returns from Java.
-//
-// This macro links stack frame of the current function to the stack frame
-// saved by JNI_SAVE_FRAME_POINTER, allowing frame-based unwinding
-// (used by the heap profiler) to produce complete traces.
-#define JNI_LINK_SAVED_FRAME_POINTER                    \
-  base::debug::ScopedStackFrameLinker jni_frame_linker( \
-      __builtin_frame_address(0),                       \
-      base::android::JNIStackFrameSaver::SavedFrame())
-
-#else
-
-// Frame-based stack unwinding is not supported, do nothing.
-#define JNI_SAVE_FRAME_POINTER
-#define JNI_LINK_SAVED_FRAME_POINTER
-
-#endif  // BUILDFLAG(CAN_UNWIND_WITH_FRAME_POINTERS)
-
 namespace base {
 namespace android {
 
 // Used to mark symbols to be exported in a shared library's symbol table.
-#define JNI_EXPORT __attribute__ ((visibility("default")))
+#define JNI_EXPORT __attribute__((visibility("default")))
 
 // Contains the registration method information for initializing JNI bindings.
 struct RegistrationMethod {
   const char* name;
   bool (*func)(JNIEnv* env);
 };
+
+using LogFatalCallback = void (*)(const char* message);
+
+BASE_EXPORT extern LogFatalCallback g_log_fatal_callback_for_testing;
+BASE_EXPORT extern const char kUnableToGetStackTraceMessage[];
+BASE_EXPORT extern const char kReetrantOutOfMemoryMessage[];
+BASE_EXPORT extern const char kReetrantExceptionMessage[];
+BASE_EXPORT extern const char kUncaughtExceptionMessage[];
+BASE_EXPORT extern const char kUncaughtExceptionHandlerFailedMessage[];
+BASE_EXPORT extern const char kOomInGetJavaExceptionInfoMessage[];
 
 // Attaches the current thread to the VM (if necessary) and return the JNIEnv*.
 inline JNIEnv* AttachCurrentThread() {
@@ -84,7 +63,9 @@ inline void DetachFromVM() {
 // Initializes the global JVM.
 BASE_EXPORT void InitVM(JavaVM* vm);
 
-// Returns true if the global JVM has been initialized.
+// Returns true if the global JVM has been initialized. This happens
+// immediately on native library load, so this is still correct even very
+// early in startup.
 inline bool IsJavaAvailable() {
   return jni_zero::IsVMInitialized();
 }
@@ -94,100 +75,46 @@ inline JavaVM* GetVM() {
   return jni_zero::GetVM();
 }
 
-// Initializes the global ClassLoader used by the GetClass and LazyGetClass
-// methods. This is needed because JNI will use the base ClassLoader when there
-// is no Java code on the stack. The base ClassLoader doesn't know about any of
-// the application classes and will fail to lookup anything other than system
-// classes.
-void InitGlobalClassLoader(JNIEnv* env);
+// Do not allow any future native->java calls.
+// This is necessary in gtest DEATH_TESTS to prevent
+// GetJavaStackTraceIfPresent() from accessing a defunct JVM (due to fork()).
+// https://crbug.com/1484834
+inline void DisableJvmForTesting() {
+  return jni_zero::DisableJvmForTesting();
+}
 
 // Finds the class named |class_name| and returns it.
 // Use this method instead of invoking directly the JNI FindClass method (to
 // prevent leaking local references).
 // This method triggers a fatal assertion if the class could not be found.
 // Use HasClass if you need to check whether the class exists.
-BASE_EXPORT ScopedJavaLocalRef<jclass> GetClass(JNIEnv* env,
-                                                const char* class_name,
-                                                const char* split_name);
-BASE_EXPORT ScopedJavaLocalRef<jclass> GetClass(JNIEnv* env,
-                                                const char* class_name);
-
-// The method will initialize |atomic_class_id| to contain a global ref to the
-// class. And will return that ref on subsequent calls.  It's the caller's
-// responsibility to release the ref when it is no longer needed.
-// The caller is responsible to zero-initialize |atomic_method_id|.
-// It's fine to simultaneously call this on multiple threads referencing the
-// same |atomic_method_id|.
-BASE_EXPORT jclass LazyGetClass(JNIEnv* env,
-                                const char* class_name,
-                                const char* split_name,
-                                std::atomic<jclass>* atomic_class_id);
-BASE_EXPORT jclass LazyGetClass(
-    JNIEnv* env,
-    const char* class_name,
-    std::atomic<jclass>* atomic_class_id);
-
-// This class is a wrapper for JNIEnv Get(Static)MethodID.
-class BASE_EXPORT MethodID {
- public:
-  enum Type {
-    TYPE_STATIC,
-    TYPE_INSTANCE,
-  };
-
-  // Returns the method ID for the method with the specified name and signature.
-  // This method triggers a fatal assertion if the method could not be found.
-  template<Type type>
-  static jmethodID Get(JNIEnv* env,
-                       jclass clazz,
-                       const char* method_name,
-                       const char* jni_signature);
-
-  // The caller is responsible to zero-initialize |atomic_method_id|.
-  // It's fine to simultaneously call this on multiple threads referencing the
-  // same |atomic_method_id|.
-  template<Type type>
-  static jmethodID LazyGet(JNIEnv* env,
-                           jclass clazz,
-                           const char* method_name,
-                           const char* jni_signature,
-                           std::atomic<jmethodID>* atomic_method_id);
-};
+inline ScopedJavaLocalRef<jclass> GetClass(JNIEnv* env,
+                                           const char* class_name) {
+  return jni_zero::GetClass(env, class_name);
+}
 
 // Returns true if an exception is pending in the provided JNIEnv*.
-BASE_EXPORT bool HasException(JNIEnv* env);
+inline bool HasException(JNIEnv* env) {
+  return jni_zero::HasException(env);
+}
 
 // If an exception is pending in the provided JNIEnv*, this function clears it
 // and returns true.
-BASE_EXPORT bool ClearException(JNIEnv* env);
+inline bool ClearException(JNIEnv* env) {
+  return jni_zero::ClearException(env);
+}
 
 // This function will call CHECK() macro if there's any pending exception.
 BASE_EXPORT void CheckException(JNIEnv* env);
 
 // This returns a string representation of the java stack trace.
-BASE_EXPORT std::string GetJavaExceptionInfo(JNIEnv* env,
-                                             jthrowable java_throwable);
+BASE_EXPORT std::string GetJavaExceptionInfo(
+    JNIEnv* env,
+    const JavaRef<jthrowable>& throwable);
+// This returns a string representation of the java stack trace.
+BASE_EXPORT std::string GetJavaStackTraceIfPresent();
 
-#if BUILDFLAG(CAN_UNWIND_WITH_FRAME_POINTERS)
-
-// Saves caller's PC and stack frame in a thread-local variable.
-// Implemented only when profiling is enabled (enable_profiling=true).
-class BASE_EXPORT JNIStackFrameSaver {
- public:
-  JNIStackFrameSaver(void* current_fp);
-
-  JNIStackFrameSaver(const JNIStackFrameSaver&) = delete;
-  JNIStackFrameSaver& operator=(const JNIStackFrameSaver&) = delete;
-
-  ~JNIStackFrameSaver();
-  static void* SavedFrame();
-
- private:
-  const AutoReset<void*> resetter_;
-};
-
-#endif  // BUILDFLAG(CAN_UNWIND_WITH_FRAME_POINTERS)
-
+using MethodID = jni_zero::MethodID;
 }  // namespace android
 }  // namespace base
 

--- a/copied_base/base/debug/cobalt_unwind_stubs.cc
+++ b/copied_base/base/debug/cobalt_unwind_stubs.cc
@@ -1,0 +1,34 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <stdint.h>
+#include <unwind.h>
+
+extern "C" {
+
+_Unwind_Reason_Code _Unwind_Backtrace(_Unwind_Trace_Fn /*trace*/,
+                                      void* /*trace_argument*/) {
+  return _URC_END_OF_STACK;
+}
+
+_Unwind_VRS_Result _Unwind_VRS_Get(
+    struct _Unwind_Context* /*context*/,
+    _Unwind_VRS_RegClass /*regclass*/,
+    uint32_t /*regno*/,
+    _Unwind_VRS_DataRepresentation /*representation*/,
+    void* /*valuep*/) {
+  return _UVRSR_FAILED;
+}
+
+}  // extern "C"

--- a/copied_base/base/system/sys_info_android.cc
+++ b/copied_base/base/system/sys_info_android.cc
@@ -207,7 +207,7 @@ bool SysInfo::IsLowEndDeviceImpl() {
   // implementations which could give different results.
   // Also the Java code cannot depend on the native code
   // since it might not be loaded yet.
-  if (!base::android::IsVMInitialized())
+  if (!base::android::IsJavaAvailable())
     return false;
   return g_lazy_low_end_device.Get().value();
 }


### PR DESCRIPTION
Mirror upstream //base by routing copied_base's JNI VM management through jni_zero instead of keeping a separate JavaVM pointer.

Bug: 495203133