### PR TITLE
android: Add android:authorities to androidx.startup.InitializationProvider

### DIFF
--- a/cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2
+++ b/cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2
@@ -146,6 +146,7 @@
         <!-- Disables at startup init of Emoji2. See http://crbug.com/1205141 -->
         <provider
             android:name="androidx.startup.InitializationProvider"
+            android:authorities="${applicationId}.androidx-startup"
             android:exported="false"
             tools:node="remove">
         </provider>


### PR DESCRIPTION
PR #11059 stripped androidx.startup.InitializationProvider from the manifest using `tools:node="remove"`. However, according to the Android Manifest Merger specification, elements of type `<provider>` are matched by their authority (`android:authorities`). Without matching `android:authorities="\${applicationId}.androidx-startup"`, the merger may fail to match and remove the provider declared by library dependencies or report validation errors.

Follow-up to PR #11059.

Bug: 495203133

TAG=agy
CONV=77dc1de4-dd7c-479a-9937-22c955c12d6a