### PR TITLE
Fix fonts.xml generation for Evergreen builds

### DIFF
--- a/cobalt/build/modular_executable.gni
+++ b/cobalt/build/modular_executable.gni
@@ -179,8 +179,7 @@ template("evergreen_final_target") {
     }
 
     copy("copy_${original_target_name}_empty_fonts") {
-      sources =
-          [ "//starboard/content/fonts/$source_font_config_dir/fonts.xml" ]
+      sources = [ "//starboard/content/fonts/config/empty/fonts.xml" ]
       outputs = [
         "$root_out_dir/app/${original_target_name}/content/fonts/fonts.xml",
       ]


### PR DESCRIPTION
The Cobalt-side fonts.xml (under app/) should be empty for Evergreen builds, as the Cobalt core relies on the platform/loader to provide the real fonts. Previously, it was using the platform's font configuration which could result in a non-empty fonts.xml being copied if the platform used standard/limited fonts.

This CL hardcodes the source of the Cobalt-side empty fonts target to use the empty fonts.xml directly.

Bug: 515804261