### PR TITLE
android: Add java switch to enable custom fonts.xml

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -133,6 +133,7 @@ android_library("cobalt_main_java") {
     "apk/app/src/main/java/dev/cobalt/coat/CrashContext.java",
     "apk/app/src/main/java/dev/cobalt/coat/CrashContextUpdateHandler.java",
     "apk/app/src/main/java/dev/cobalt/coat/ErrorDialog.java",
+    "apk/app/src/main/java/dev/cobalt/coat/FontUtil.java",
     "apk/app/src/main/java/dev/cobalt/coat/KeyboardUtils.java",
     "apk/app/src/main/java/dev/cobalt/coat/NetworkStatus.java",
     "apk/app/src/main/java/dev/cobalt/coat/NullCobaltFactory.java",
@@ -197,7 +198,13 @@ android_library("cobalt_apk_java") {
 
 android_assets("coat_assets") {
   sources = [ "apk/app/src/app/assets/web/cobalt_logo_1024.png" ]
+  renaming_sources = [ "$root_out_dir/content/data/fonts/fonts.xml" ]
+  renaming_destinations = [ "fonts/fonts.xml" ]
   disable_compression = true
+  deps = [
+    "//starboard/content/fonts:copy_font_data",
+    "//starboard/content/fonts:fonts_xml",
+  ]
 }
 
 # TODO(b/450024477): just a shared library once jni migration is complete

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -244,6 +244,10 @@ public abstract class CobaltActivity extends Activity {
     if (getStarboardBridge() == null) {
       // Cold start - Instantiate the singleton StarboardBridge.
       RecordHistogram.recordBooleanHistogram("Cobalt.Android.ColdStart", true);
+      if (CommandLine.getInstance().hasSwitch("enable-optimized-font-loading")
+          || getJavaSwitches().containsKey(JavaSwitches.ENABLE_OPTIMIZED_FONT_LOADING)) {
+        FontUtil.copyFontsXml(getApplicationContext());
+      }
       StarboardBridge starboardBridge = createStarboardBridge(getArgs(), mStartDeepLink);
       ((StarboardBridge.HostApplication) getApplication()).setStarboardBridge(starboardBridge);
     } else {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/FontUtil.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/FontUtil.java
@@ -45,18 +45,23 @@ public class FontUtil {
 
   public static void copyFontsXml(Context context) {
     File storageDir = new File(PathUtils.getDataDirectory(), "storage");
-    if (!storageDir.exists()) {
-      storageDir.mkdirs();
+    if (!storageDir.exists() && !storageDir.mkdirs()) {
+      Log.e(TAG, "Failed to create directory: " + storageDir.getAbsolutePath());
+      return;
     }
     String asset = "fonts/fonts.xml";
     String fileName = "cobalt_android_fonts.xml";
     File targetFile = new File(storageDir, fileName);
-    try (InputStream is = context.getAssets().open(asset);
-         FileOutputStream fos = new FileOutputStream(targetFile)) {
-      byte[] buf = new byte[8192];
-      int len;
-      while ((len = is.read(buf)) != -1) {
-        fos.write(buf, 0, len);
+    try (InputStream is = context.getAssets().open(asset)) {
+      if (targetFile.exists() && targetFile.length() == is.available()) {
+        return;
+      }
+      try (FileOutputStream fos = new FileOutputStream(targetFile)) {
+        byte[] buf = new byte[8192];
+        int len;
+        while ((len = is.read(buf)) != -1) {
+          fos.write(buf, 0, len);
+        }
       }
     } catch (IOException e) {
       Log.e(TAG, "Failed copying asset: " + asset, e);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/FontUtil.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/FontUtil.java
@@ -1,0 +1,65 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.coat;
+
+import android.content.Context;
+import android.util.Log;
+import org.chromium.base.PathUtils;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Arrays;
+
+/**
+ * Utility class responsible for extracting Cobalt's font configuration table asset from the APK.
+ *
+ * Reason for existence: Native C++ Skia (`SkFontMgr_Android_CustomFonts`) requires a raw
+ * filesystem file path (`storage/cobalt_android_fonts.xml`) to read custom font definitions and
+ * multilingual glyph fallbacks. This helper copies `fonts/fonts.xml` from the APK assets bundle
+ * into the application's private data storage directory on cold start.
+ *
+ * Expected lifetime/ownership: Stateless static utility class. It owns no long-lived
+ * references, holds no internal instance state, and does not instantiate any objects beyond temporary
+ * I/O streams during the copy operation.
+ *
+ * Threading model: Synchronous utility method designed to be invoked from the main UI thread
+ * or startup background threads during early initialization milestones (`CobaltActivity` cold start).
+ * Performs blocking filesystem I/O to guarantee the XML file is persisted on disk before the native
+ * Starboard/Chromium engine boots.
+ */
+public class FontUtil {
+  private static final String TAG = "FontUtil";
+
+  public static void copyFontsXml(Context context) {
+    File storageDir = new File(PathUtils.getDataDirectory(), "storage");
+    if (!storageDir.exists()) {
+      storageDir.mkdirs();
+    }
+    String asset = "fonts/fonts.xml";
+    String fileName = "cobalt_android_fonts.xml";
+    File targetFile = new File(storageDir, fileName);
+    try (InputStream is = context.getAssets().open(asset);
+         FileOutputStream fos = new FileOutputStream(targetFile)) {
+      byte[] buf = new byte[8192];
+      int len;
+      while ((len = is.read(buf)) != -1) {
+        fos.write(buf, 0, len);
+      }
+    } catch (IOException e) {
+      Log.e(TAG, "Failed copying asset: " + asset, e);
+    }
+  }
+}

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -27,6 +27,7 @@ public class JavaSwitches {
   public static final String DISABLE_STARTUP_GUARD = "DisableStartupGuard";
   public static final String STARTUP_GUARD_INTERVAL_IN_SECONDS = "StartupGuardIntervalInSeconds";
   public static final String DISABLE_HTTP_CACHE = "DisableHttpCache";
+  public static final String ENABLE_OPTIMIZED_FONT_LOADING = "EnableOptimizedFontLoading";
 
   /** flag to re-enable freeze and resume events */
   public static final String ENABLE_FREEZE = "EnableFreeze";
@@ -169,6 +170,10 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_FONT_SRC_LOCAL_MATCHING)) {
       extraCommandLineArgs.add("--disable-features=FontSrcLocalMatching");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_OPTIMIZED_FONT_LOADING)) {
+      extraCommandLineArgs.add("--enable-optimized-font-loading");
     }
 
     if (jsFlags.length() > 0 ) {

--- a/cobalt/shell/android/BUILD.gn
+++ b/cobalt/shell/android/BUILD.gn
@@ -142,10 +142,14 @@ android_aidl("content_javatests_aidl") {
 
 android_assets("cobalt_shell_assets") {
   sources = [ "$root_out_dir/cobalt_shell.pak" ]
+  renaming_sources = [ "$root_out_dir/content/data/fonts/fonts.xml" ]
+  renaming_destinations = [ "fonts/fonts.xml" ]
   disable_compression = true
   deps = [
     "//cobalt/shell:pak",
     "//gin:v8_snapshot_assets",
+    "//starboard/content/fonts:copy_font_data",
+    "//starboard/content/fonts:fonts_xml",
     "//third_party/icu:icu_assets",
   ]
 }

--- a/content/browser/font_unique_name_lookup/font_unique_name_lookup_android.cc
+++ b/content/browser/font_unique_name_lookup/font_unique_name_lookup_android.cc
@@ -9,6 +9,7 @@
 
 #include "base/android/build_info.h"
 #include "base/check.h"
+#include "base/command_line.h"
 #include "base/containers/span_rust.h"
 #include "base/files/file.h"
 #include "base/files/file_enumerator.h"
@@ -251,6 +252,14 @@ std::vector<base::FilePath> FontUniqueNameLookup::GetFontFilePaths() const {
   if (font_file_paths_for_testing_.size())
     return font_file_paths_for_testing_;
   std::vector<base::FilePath> font_files;
+#if BUILDFLAG(IS_ANDROID)
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch("enable-optimized-font-loading")) {
+    // When Cobalt optimized font loading is enabled, custom fonts are configured
+    // hermetically in Skia. Scanning 200+ Android OS ROM font files is unnecessary
+    // and adds ~950 ms of cold-start indexing overhead.
+    return font_files;
+  }
+#endif
   for (const char* font_dir_path : kAndroidFontPaths) {
     base::FileEnumerator files_enumerator(
         base::MakeAbsoluteFilePath(base::FilePath(font_dir_path)), true,

--- a/skia/ext/font_utils.cc
+++ b/skia/ext/font_utils.cc
@@ -13,6 +13,10 @@
 #include "third_party/skia/include/core/SkTypeface.h"
 
 #if BUILDFLAG(IS_ANDROID)
+#include "base/base_paths_android.h"
+#include "base/command_line.h"
+#include "base/files/file_path.h"
+#include "base/path_service.h"
 #include "third_party/skia/include/ports/SkFontMgr_android.h"
 #include "third_party/skia/include/ports/SkFontScanner_Fontations.h"
 #endif
@@ -67,6 +71,25 @@ static sk_sp<SkFontMgr> fontmgr_factory() {
   return SkFontMgr_New_Cobalt();
 #else
 #if BUILDFLAG(IS_ANDROID)
+  // When Cobalt optimized font loading is enabled, configure Skia to use hermetic custom
+  // XML font fallbacks (`cobalt_android_fonts.xml`) extracted into the app data directory.
+  if (base::CommandLine::ForCurrentProcess()->HasSwitch("enable-optimized-font-loading")) {
+    base::FilePath app_data_dir;
+    if (base::PathService::Get(base::DIR_ANDROID_APP_DATA, &app_data_dir)) {
+      std::string xml_path = app_data_dir.Append("storage").Append("cobalt_android_fonts.xml").value();
+      SkFontMgr_Android_CustomFonts custom_fonts;
+      custom_fonts.fSystemFontUse = SkFontMgr_Android_CustomFonts::kOnlyCustom;
+      custom_fonts.fBasePath = "/system/fonts/";
+      custom_fonts.fFontsXml = xml_path.c_str();
+      custom_fonts.fFallbackFontsXml = nullptr;
+      custom_fonts.fIsolated = true;
+      if (base::FeatureList::IsEnabled(skia::kFontationsAndroidSystemFonts)) {
+        return SkFontMgr_New_Android(&custom_fonts, SkFontScanner_Make_Fontations());
+      } else {
+        return SkFontMgr_New_Android(&custom_fonts);
+      }
+    }
+  }
   if (base::FeatureList::IsEnabled(skia::kFontationsAndroidSystemFonts)) {
     return SkFontMgr_New_Android(nullptr, SkFontScanner_Make_Fontations());
   } else {

--- a/starboard/content/fonts/BUILD.gn
+++ b/starboard/content/fonts/BUILD.gn
@@ -58,7 +58,7 @@ if (current_toolchain == default_toolchain) {
     }
 
     group("copy_font_data") {
-      data_deps = [
+      public_deps = [
         ":copy_fonts",
         ":fonts_xml",
       ]

--- a/starboard/content/fonts/BUILD.gn
+++ b/starboard/content/fonts/BUILD.gn
@@ -58,7 +58,7 @@ if (current_toolchain == default_toolchain) {
     }
 
     group("copy_font_data") {
-      public_deps = [
+      data_deps = [
         ":copy_fonts",
         ":fonts_xml",
       ]

--- a/starboard/content/fonts/config/android/fonts.xml
+++ b/starboard/content/fonts/config/android/fonts.xml
@@ -100,7 +100,7 @@
  | there is no bold font available and a bold weight (>500) is specified.
  |==============================================================================
  -->
-<familyset version="1">
+<familyset version="21">
     <!-- first family is default -->
     <family name="sans-serif">
         <font weight="100" style="normal" font_name="Roboto Thin" postscript_name="Roboto-Thin">Roboto-Thin.ttf</font>
@@ -130,6 +130,12 @@
     </family>
     <!-- Note that aliases must come after the fonts they reference. -->
     <alias name="roboto" to="sans-serif" />
+    <alias name="sans" to="sans-serif" />
+    <alias name="Sans" to="sans-serif" />
+    <alias name="arial" to="sans-serif" />
+    <alias name="Arial" to="sans-serif" />
+    <alias name="helvetica" to="sans-serif" />
+    <alias name="Helvetica" to="sans-serif" />
     <!-- This is the default font when Roboto is unavailable. -->
     <family pages="0">
         <font weight="400" style="normal">Roboto-Regular-Subsetted.ttf</font>


### PR DESCRIPTION
Introduce the `--enable-optimized-font-loading` switch to enable a hermetic font configuration on Android.

When active, the application copies a custom `fonts.xml` from assets to internal storage so native Skia can access it via a raw filesystem path. This isolated configuration avoids scanning system fonts, reducing cold-start latency by nearly a second, as the YouTube application relies primarily on 2 fonts (YTSans and Roboto) whereas the default `fonts.xml` has a large number of unnecessary fonts. This change also updates the bundled font configuration with common font aliases.

Bug: 517249177