### PR TITLE
android: Extract BrowserStarboardBridge from StarboardBridge

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -121,6 +121,7 @@ android_library("cobalt_main_java") {
     "apk/app/src/main/java/dev/cobalt/coat/ArtworkDownloaderDefault.java",
     "apk/app/src/main/java/dev/cobalt/coat/ArtworkLoader.java",
     "apk/app/src/main/java/dev/cobalt/coat/AudioPermissionRequester.java",
+    "apk/app/src/main/java/dev/cobalt/coat/BrowserStarboardBridge.java",
     "apk/app/src/main/java/dev/cobalt/coat/CaptionSettings.java",
     "apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java",
     "apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java",

--- a/cobalt/android/apk/app/src/app/java/dev/cobalt/app/CobaltApplication.java
+++ b/cobalt/android/apk/app/src/app/java/dev/cobalt/app/CobaltApplication.java
@@ -16,7 +16,7 @@ package dev.cobalt.app;
 
 import android.app.Application;
 import android.content.Context;
-import dev.cobalt.coat.StarboardBridge;
+import dev.cobalt.coat.BrowserStarboardBridge;
 import org.chromium.base.ApplicationStatus;
 import org.chromium.base.ContextUtils;
 import org.chromium.base.PathUtils;
@@ -24,18 +24,19 @@ import org.chromium.base.library_loader.LibraryLoader;
 import org.chromium.base.library_loader.LibraryProcessType;
 
 /** Android Application hosting the Starboard application. */
-public class CobaltApplication extends Application implements StarboardBridge.HostApplication {
+public class CobaltApplication extends Application
+    implements BrowserStarboardBridge.HostApplication {
   private static final String PRIVATE_DATA_DIRECTORY_SUFFIX = "content_shell";
 
-  StarboardBridge mStarboardBridge;
+  BrowserStarboardBridge mStarboardBridge;
 
   @Override
-  public void setStarboardBridge(StarboardBridge starboardBridge) {
+  public void setStarboardBridge(BrowserStarboardBridge starboardBridge) {
     mStarboardBridge = starboardBridge;
   }
 
   @Override
-  public StarboardBridge getStarboardBridge() {
+  public BrowserStarboardBridge getStarboardBridge() {
     return mStarboardBridge;
   }
 

--- a/cobalt/android/apk/app/src/app/java/dev/cobalt/app/MainActivity.java
+++ b/cobalt/android/apk/app/src/app/java/dev/cobalt/app/MainActivity.java
@@ -18,6 +18,7 @@ import android.app.Activity;
 import android.app.Service;
 import android.os.Bundle;
 import dev.cobalt.coat.ArtworkDownloaderDefault;
+import dev.cobalt.coat.BrowserStarboardBridge;
 import dev.cobalt.coat.CobaltActivity;
 import dev.cobalt.coat.CobaltService;
 import dev.cobalt.coat.StarboardBridge;
@@ -37,7 +38,7 @@ public class MainActivity extends CobaltActivity {
     Holder<Activity> activityHolder = new Holder<>();
     Holder<Service> serviceHolder = new Holder<>();
     StarboardBridge bridge =
-        new StarboardBridge(
+        new BrowserStarboardBridge(
             getApplicationContext(),
             activityHolder,
             serviceHolder,

--- a/cobalt/android/apk/app/src/app/java/dev/cobalt/app/MainActivity.java
+++ b/cobalt/android/apk/app/src/app/java/dev/cobalt/app/MainActivity.java
@@ -21,7 +21,6 @@ import dev.cobalt.coat.ArtworkDownloaderDefault;
 import dev.cobalt.coat.BrowserStarboardBridge;
 import dev.cobalt.coat.CobaltActivity;
 import dev.cobalt.coat.CobaltService;
-import dev.cobalt.coat.StarboardBridge;
 import dev.cobalt.libraries.services.clientloginfo.ClientLogInfoModule;
 import dev.cobalt.util.Holder;
 
@@ -34,10 +33,10 @@ import dev.cobalt.util.Holder;
 public class MainActivity extends CobaltActivity {
 
   @Override
-  protected StarboardBridge createStarboardBridge(String[] args, String startDeepLink) {
+  protected BrowserStarboardBridge createStarboardBridge(String[] args, String startDeepLink) {
     Holder<Activity> activityHolder = new Holder<>();
     Holder<Service> serviceHolder = new Holder<>();
-    StarboardBridge bridge =
+    BrowserStarboardBridge bridge =
         new BrowserStarboardBridge(
             getApplicationContext(),
             activityHolder,

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BrowserStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BrowserStarboardBridge.java
@@ -1,0 +1,83 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.coat;
+
+import android.app.Activity;
+import android.app.Service;
+import android.content.Context;
+import dev.cobalt.shell.StartupGuard;
+import dev.cobalt.util.Holder;
+import org.chromium.content_public.browser.WebContents;
+
+/** Content-dependent StarboardBridge subclass used by AndroidTV. */
+public class BrowserStarboardBridge extends StarboardBridge {
+
+  private CobaltMediaSession mCobaltMediaSession;
+  private VolumeStateReceiver mVolumeStateReceiver;
+  private PlatformError mPlatformError;
+
+  public BrowserStarboardBridge(
+      Context appContext,
+      Holder<Activity> activityHolder,
+      Holder<Service> serviceHolder,
+      ArtworkDownloader artworkDownloader,
+      String[] args,
+      String startDeepLink) {
+    super(appContext, activityHolder, serviceHolder, args, startDeepLink);
+    mCobaltMediaSession = new CobaltMediaSession(appContext, activityHolder, artworkDownloader);
+    mVolumeStateReceiver = new VolumeStateReceiver(appContext);
+  }
+
+  @Override
+  protected void onActivityStop(Activity activity) {
+    super.onActivityStop(activity);
+    mCobaltMediaSession.onActivityStop();
+  }
+
+  @Override
+  void raisePlatformError(int errorType, long data, String url) {
+    StartupGuard.getInstance().setStartupMilestone(37);
+    mPlatformError = new PlatformError(mActivityHolder, errorType, data, url);
+    mPlatformError.raise();
+  }
+
+  @Override
+  public boolean isPlatformErrorShowing() {
+    if (mPlatformError != null) {
+      return mPlatformError.isShowing();
+    }
+    return false;
+  }
+
+  public void setWebContents(WebContents webContents) {
+    mCobaltMediaSession.setWebContents(webContents);
+    mVolumeStateReceiver.setWebContents(webContents);
+  }
+
+  @Override
+  protected void hideSplashScreen() {
+    StartupGuard.getInstance().disarm();
+  }
+
+  @Override
+  protected void setStartupMilestone(int milestone) {
+    StartupGuard.getInstance().setStartupMilestone(milestone);
+  }
+
+  @Override
+  protected void setStartupDiagnosisInfo(String key, String value) {
+    StartupGuard.getInstance().setDiagnosisInfo(key, value);
+  }
+}

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BrowserStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BrowserStarboardBridge.java
@@ -24,6 +24,13 @@ import org.chromium.content_public.browser.WebContents;
 /** Content-dependent StarboardBridge subclass used by AndroidTV. */
 public class BrowserStarboardBridge extends StarboardBridge {
 
+  /** Interface to be implemented by the Android Application hosting the browser app. */
+  public interface HostApplication {
+    void setStarboardBridge(BrowserStarboardBridge starboardBridge);
+
+    BrowserStarboardBridge getStarboardBridge();
+  }
+
   private CobaltMediaSession mCobaltMediaSession;
   private VolumeStateReceiver mVolumeStateReceiver;
   private PlatformError mPlatformError;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -344,7 +344,7 @@ public abstract class CobaltActivity extends Activity {
           public void onWebContentsReady() {
             // Inject JavaBridge objects to the WebContents.
             initializeJavaBridge();
-            getStarboardBridge().setWebContents(getActiveWebContents());
+            ((BrowserStarboardBridge) getStarboardBridge()).setWebContents(getActiveWebContents());
 
             // Load the `url` with the same shell we created above.
             mStartupUrl = ShellManagerJni.get().appendMigrationStatus(mStartupUrl);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -248,8 +248,9 @@ public abstract class CobaltActivity extends Activity {
           || getJavaSwitches().containsKey(JavaSwitches.ENABLE_OPTIMIZED_FONT_LOADING)) {
         FontUtil.copyFontsXml(getApplicationContext());
       }
-      StarboardBridge starboardBridge = createStarboardBridge(getArgs(), mStartDeepLink);
-      ((StarboardBridge.HostApplication) getApplication()).setStarboardBridge(starboardBridge);
+      BrowserStarboardBridge starboardBridge = createStarboardBridge(getArgs(), mStartDeepLink);
+      ((BrowserStarboardBridge.HostApplication) getApplication())
+          .setStarboardBridge(starboardBridge);
     } else {
       // Warm start - Pass the deep link to the running Starboard app.
       if (savedInstanceState == null) {
@@ -344,7 +345,7 @@ public abstract class CobaltActivity extends Activity {
           public void onWebContentsReady() {
             // Inject JavaBridge objects to the WebContents.
             initializeJavaBridge();
-            ((BrowserStarboardBridge) getStarboardBridge()).setWebContents(getActiveWebContents());
+            getStarboardBridge().setWebContents(getActiveWebContents());
 
             // Load the `url` with the same shell we created above.
             mStartupUrl = ShellManagerJni.get().appendMigrationStatus(mStartupUrl);
@@ -558,10 +559,11 @@ public abstract class CobaltActivity extends Activity {
    * Instantiates the StarboardBridge. Apps not supporting sign-in should inject an instance of
    * NoopUserAuthorizer. Apps may subclass StarboardBridge if they need to override anything.
    */
-  protected abstract StarboardBridge createStarboardBridge(String[] args, String startDeepLink);
+  protected abstract BrowserStarboardBridge createStarboardBridge(
+      String[] args, String startDeepLink);
 
-  protected StarboardBridge getStarboardBridge() {
-    return ((StarboardBridge.HostApplication) getApplication()).getStarboardBridge();
+  protected BrowserStarboardBridge getStarboardBridge() {
+    return ((BrowserStarboardBridge.HostApplication) getApplication()).getStarboardBridge();
   }
 
   @Override

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -33,7 +33,6 @@ import android.view.InputDevice;
 import android.view.accessibility.CaptioningManager;
 import androidx.annotation.Nullable;
 import dev.cobalt.media.AudioOutputManager;
-import dev.cobalt.shell.StartupGuard;
 import dev.cobalt.util.DisplayUtil;
 import dev.cobalt.util.Holder;
 import dev.cobalt.util.Log;
@@ -45,7 +44,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.TimeZone;
 import java.util.concurrent.ConcurrentHashMap;
-import org.chromium.content_public.browser.WebContents;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
@@ -67,14 +65,11 @@ public class StarboardBridge {
   private CobaltTextToSpeechHelper mTtsHelper;
   // TODO(cobalt): Re-enable these classes or remove if unnecessary.
   private AudioOutputManager mAudioOutputManager;
-  private CobaltMediaSession mCobaltMediaSession;
   private AudioPermissionRequester mAudioPermissionRequester;
   private ResourceOverlay mResourceOverlay;
   private AdvertisingId mAdvertisingId;
-  private VolumeStateReceiver mVolumeStateReceiver;
-  private PlatformError mPlatformError;
   private final Context mAppContext;
-  private final Holder<Activity> mActivityHolder;
+  protected final Holder<Activity> mActivityHolder;
   private final Holder<Service> mServiceHolder;
   private final String[] mArgs;
   private final long mNativeApp;
@@ -114,7 +109,6 @@ public class StarboardBridge {
       Context appContext,
       Holder<Activity> activityHolder,
       Holder<Service> serviceHolder,
-      ArtworkDownloader artworkDownloader,
       String[] args,
       String startDeepLink) {
 
@@ -131,11 +125,9 @@ public class StarboardBridge {
     mSysConfigChangeReceiver = new CobaltSystemConfigChangeReceiver(appContext, mStopRequester);
     mTtsHelper = new CobaltTextToSpeechHelper(appContext);
     mAudioOutputManager = new AudioOutputManager(appContext);
-    mCobaltMediaSession = new CobaltMediaSession(appContext, activityHolder, artworkDownloader);
     mAudioPermissionRequester = new AudioPermissionRequester(appContext, activityHolder);
     mResourceOverlay = new ResourceOverlay(appContext);
     mAdvertisingId = new AdvertisingId(appContext);
-    mVolumeStateReceiver = new VolumeStateReceiver(appContext);
     mIsAmatiDevice = appContext.getPackageManager().hasSystemFeature(AMATI_EXPERIENCE_FEATURE);
 
     mNativeApp =
@@ -191,7 +183,6 @@ public class StarboardBridge {
   protected void onActivityStop(Activity activity) {
     Log.i(TAG, "onActivityStop ran");
     beforeSuspend();
-    mCobaltMediaSession.onActivityStop();
     if (mActivityHolder.get() == activity) {
       mActivityHolder.set(null);
     }
@@ -303,17 +294,10 @@ public class StarboardBridge {
   }
 
   @CalledByNative
-  void raisePlatformError(@PlatformError.ErrorType int errorType, long data, String url) {
-    StartupGuard.getInstance().setStartupMilestone(37);
-    mPlatformError = new PlatformError(mActivityHolder, errorType, data, url);
-    mPlatformError.raise();
-  }
+  void raisePlatformError(int errorType, long data, String url) {}
 
   @CalledByNative
   public boolean isPlatformErrorShowing() {
-    if (mPlatformError != null) {
-      return mPlatformError.isShowing();
-    }
     return false;
   }
 
@@ -613,10 +597,6 @@ public class StarboardBridge {
     return hdrCapabilities.getSupportedHdrTypes();
   }
 
-  public CobaltMediaSession cobaltMediaSession() {
-    return mCobaltMediaSession;
-  }
-
   public void registerCobaltService(CobaltService.Factory factory) {
     mCobaltServiceFactories.put(factory.getServiceName(), factory);
   }
@@ -765,11 +745,6 @@ public class StarboardBridge {
     }
   }
 
-  public void setWebContents(WebContents webContents) {
-    mCobaltMediaSession.setWebContents(webContents);
-    mVolumeStateReceiver.setWebContents(webContents);
-  }
-
   @CalledByNative
   public void closeApp() {
     Activity activity = mActivityHolder.get();
@@ -800,17 +775,11 @@ public class StarboardBridge {
   }
 
   @CalledByNative
-  protected void hideSplashScreen() {
-    StartupGuard.getInstance().disarm();
-  }
+  protected void hideSplashScreen() {}
 
   @CalledByNative
-  protected void setStartupMilestone(int milestone) {
-    StartupGuard.getInstance().setStartupMilestone(milestone);
-  }
+  protected void setStartupMilestone(int milestone) {}
 
   @CalledByNative
-  protected void setStartupDiagnosisInfo(String key, String value) {
-    StartupGuard.getInstance().setDiagnosisInfo(key, value);
-  }
+  protected void setStartupDiagnosisInfo(String key, String value) {}
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java
@@ -59,7 +59,7 @@ public class CobaltActivityTest {
           }
 
           @Override
-          protected StarboardBridge createStarboardBridge(String[] args, String startDeepLink) {
+          protected BrowserStarboardBridge createStarboardBridge(String[] args, String startDeepLink) {
             return null;
           }
         };
@@ -298,7 +298,7 @@ public class CobaltActivityTest {
       }
 
       @Override
-      protected StarboardBridge createStarboardBridge(String[] args, String startDeepLink) {
+      protected BrowserStarboardBridge createStarboardBridge(String[] args, String startDeepLink) {
         return null;
       }
     };

--- a/cobalt/testing/browser_tests/browsertests_apk/src/org/chromium/content_browsertests_apk/ContentShellBrowserTestActivity.java
+++ b/cobalt/testing/browser_tests/browsertests_apk/src/org/chromium/content_browsertests_apk/ContentShellBrowserTestActivity.java
@@ -20,6 +20,7 @@ import android.view.Window;
 import android.view.WindowManager;
 
 import org.chromium.base.StrictModeContext;
+import dev.cobalt.coat.BrowserStarboardBridge;
 import dev.cobalt.coat.StarboardBridge;
 import dev.cobalt.shell.ShellManager;
 import dev.cobalt.util.Holder;
@@ -85,12 +86,14 @@ public abstract class ContentShellBrowserTestActivity extends NativeBrowserTestA
 
         // Instantiate StarboardBridge. This is crucial for initializing the native Starboard
         // environment that the storage migration relies on.
-        mStarboardBridge = new StarboardBridge(getApplicationContext(),
-                                               new Holder<Activity>(),
-                                               new Holder<Service>(), // Set to null below
-                                               null, // ArtworkDownloader is not needed for tests
-                                               new String[0], // args
-                                               ""); // startDeepLink
+        mStarboardBridge =
+                new BrowserStarboardBridge(
+                        getApplicationContext(),
+                        new Holder<Activity>(),
+                        new Holder<Service>(), // Set to null below
+                        null, // ArtworkDownloader is not needed for tests
+                        new String[0], // args
+                        ""); // startDeepLink
         ((StarboardBridge.HostApplication) getApplication()).setStarboardBridge(mStarboardBridge);
 
         Window wind = this.getWindow();


### PR DESCRIPTION
This is a precursor PR to ease the review of the AOSP work with no functional changes.

Move the content-dependent behavior out of StarboardBridge into a new BrowserStarboardBridge subclass used by AndroidTV.

StarboardBridge keeps the full JNI-facing surface with no-op defaults for the content hooks that BrowserStarboardBridge overrides so it can be shared with the AOSP apk.

Bug: 495203133