### PR TITLE
android: Support h5vcc overrides via `--enable-h5vcc-settings`

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -304,6 +304,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/client_hint_headers/cobalt_header_value_provider_test.cc",
     "//cobalt/browser/client_hint_headers/cobalt_trusted_header_client_test.cc",
     "//cobalt/browser/client_hint_headers/cobalt_trusted_url_loader_header_client_test.cc",
+    "//cobalt/browser/cobalt_content_browser_client_unittest.cc",
     "//cobalt/browser/cobalt_crash_annotations_unittest.cc",
     "//cobalt/browser/cobalt_secure_navigation_throttle_unittest.cc",
     "//cobalt/browser/cobalt_web_contents_observer_unittest.cc",

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -148,6 +148,7 @@ public final class CommandLineOverrideHelper {
             getDefaultDisableFeatureOverridesList();
         StringJoiner blinkEnableFeatureOverrides =
             getDefaultBlinkEnableFeatureOverridesList();
+        StringJoiner enableH5vccSettings = new StringJoiner(";");
 
         if (params != null) {
             if (!params.mIsOfficialBuild) {
@@ -175,6 +176,8 @@ public final class CommandLineOverrideHelper {
                                 disableFeatureOverrides.add(v);
                             } else if (key.equals("--enable-blink-features")) {
                                 blinkEnableFeatureOverrides.add(v);
+                            } else if (key.equals("--enable-h5vcc-settings")) {
+                                enableH5vccSettings.add(v);
                             } else {
                                 cliOverrides.add(param);
                                 break; // Avoid adding the same param multiple times
@@ -199,5 +202,10 @@ public final class CommandLineOverrideHelper {
         CommandLine.getInstance().appendSwitchesAndArguments(
             new String[]{"--enable-blink-features="
             + blinkEnableFeatureOverrides.toString() });
+        if (enableH5vccSettings.length() > 0) {
+            CommandLine.getInstance().appendSwitchesAndArguments(
+                new String[]{"--enable-h5vcc-settings="
+                + enableH5vccSettings.toString() });
+        }
     }
 }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -101,6 +101,8 @@ public class CommandLineOverrideHelperTest {
         expected =
             CommandLineOverrideHelper.getDefaultBlinkEnableFeatureOverridesList().toString();
         Assert.assertEquals(expected, actual);
+
+        Assert.assertFalse(CommandLine.getInstance().hasSwitch("enable-h5vcc-settings"));
     }
 
     @Test
@@ -123,7 +125,8 @@ public class CommandLineOverrideHelperTest {
         String[] commandLineArgs = {
         "--enable-features=TestFeature1;TestFeature2",
         "--disable-features=TestFeature3",
-        "--js-flags=--test-flag;--another-flag"
+        "--js-flags=--test-flag;--another-flag",
+        "--enable-h5vcc-settings=TestSetting1;TestSetting2"
         };
         CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
             new CommandLineOverrideHelper.CommandLineOverrideHelperParams(
@@ -147,6 +150,10 @@ public class CommandLineOverrideHelperTest {
             CommandLineOverrideHelper.getDefaultJsFlagOverridesList().toString()
                 + ",--test-flag,--another-flag";
         Assert.assertEquals(expectedJs, jsFlags);
+
+        String h5vccSettings = CommandLine.getInstance().getSwitchValue("enable-h5vcc-settings");
+        String expectedH5vcc = "TestSetting1;TestSetting2";
+        Assert.assertEquals(expectedH5vcc, h5vccSettings);
     }
 
     @Test
@@ -198,5 +205,17 @@ public class CommandLineOverrideHelperTest {
             CommandLineOverrideHelper.getDefaultEnableFeatureOverridesList().toString()
                 + ",TestFeature1=value1,TestFeature2=value2";
         Assert.assertEquals(expectedEnable, enableFeatures);
+    }
+
+    @Test
+    public void testFlagOverrides_EnableH5vccSettings() {
+        String[] commandLineArgs = {"--enable-h5vcc-settings=Setting1=val1;Setting2=val2"};
+        CommandLineOverrideHelper.CommandLineOverrideHelperParams params =
+            new CommandLineOverrideHelper.CommandLineOverrideHelperParams(
+                true, commandLineArgs);
+        CommandLineOverrideHelper.getFlagOverrides(params);
+
+        String h5vccSettings = CommandLine.getInstance().getSwitchValue("enable-h5vcc-settings");
+        Assert.assertEquals("Setting1=val1;Setting2=val2", h5vccSettings);
     }
 }

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -29,6 +29,9 @@
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/path_service.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
 #include "base/strings/utf_string_conversions.h"
 #include "base/time/time.h"
 #include "base/timer/elapsed_timer.h"
@@ -130,6 +133,30 @@ void BindPlatformWindowProviderService(
           base::BindRepeating([](uint64_t handle) { return handle; },
                               window_handle)),
       std::move(receiver));
+}
+
+void ParseAndApplyH5vccSettings(std::string_view settings_value,
+                                GlobalFeatures* global_features) {
+  std::vector<std::string> pairs = base::SplitString(
+      settings_value, ";", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  for (const std::string& pair : pairs) {
+    size_t eq_pos = pair.find('=');
+    if (eq_pos == std::string::npos || eq_pos == 0) {
+      LOG(WARNING) << "Skipping value: pair=" << pair;
+      continue;
+    }
+    std::string_view pair_view(pair);
+    std::string_view key =
+        base::TrimWhitespaceASCII(pair_view.substr(0, eq_pos), base::TRIM_ALL);
+    std::string_view val_str =
+        base::TrimWhitespaceASCII(pair_view.substr(eq_pos + 1), base::TRIM_ALL);
+    int64_t int_val = 0;
+    if (base::StringToInt64(val_str, &int_val)) {
+      global_features->SetSettings(key, int_val);
+    } else {
+      global_features->SetSettings(key, std::string(val_str));
+    }
+  }
 }
 
 }  // namespace
@@ -590,8 +617,11 @@ void CobaltContentBrowserClient::CreateFeatureListAndFieldTrials() {
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
 
-  GlobalFeatures::GetInstance()->ApplyCommandLineOverrides(command_line);
-
+  if (command_line.HasSwitch(switches::kEnableH5vccSettings)) {
+    ParseAndApplyH5vccSettings(
+        command_line.GetSwitchValueASCII(switches::kEnableH5vccSettings),
+        global_features);
+  }
   // Overrides for content/common and lower layers' switches.
   std::vector<base::FeatureList::FeatureOverrideInfo> feature_overrides =
       content::GetSwitchDependentFeatureOverrides(command_line);
@@ -620,8 +650,7 @@ void CobaltContentBrowserClient::CreateFeatureListAndFieldTrials() {
             << "], disable_features=["
             << command_line.GetSwitchValueASCII(::switches::kDisableFeatures)
             << "], enable_h5vcc_settings=["
-            << command_line.GetSwitchValueASCII(
-                   cobalt::switches::kEnableH5vccSettings)
+            << command_line.GetSwitchValueASCII(switches::kEnableH5vccSettings)
             << "]";
   LOG(INFO) << "CobaltCommandLine: "
             << CommandLineSwitchesToString(

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -43,6 +43,7 @@
 #include "cobalt/browser/h5vcc_settings_impl.h"
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
 #include "cobalt/browser/mojom/h5vcc_settings.mojom.h"
+#include "cobalt/browser/switches.h"
 #include "cobalt/browser/user_agent/user_agent_platform_info.h"
 #include "cobalt/common/features/starboard_features_initialization.h"
 #include "cobalt/media/service/platform_window_provider_service.h"
@@ -589,6 +590,8 @@ void CobaltContentBrowserClient::CreateFeatureListAndFieldTrials() {
   const base::CommandLine& command_line =
       *base::CommandLine::ForCurrentProcess();
 
+  GlobalFeatures::GetInstance()->ApplyCommandLineOverrides(command_line);
+
   // Overrides for content/common and lower layers' switches.
   std::vector<base::FeatureList::FeatureOverrideInfo> feature_overrides =
       content::GetSwitchDependentFeatureOverrides(command_line);
@@ -616,6 +619,9 @@ void CobaltContentBrowserClient::CreateFeatureListAndFieldTrials() {
             << command_line.GetSwitchValueASCII(::switches::kEnableFeatures)
             << "], disable_features=["
             << command_line.GetSwitchValueASCII(::switches::kDisableFeatures)
+            << "], enable_h5vcc_settings=["
+            << command_line.GetSwitchValueASCII(
+                   cobalt::switches::kEnableH5vccSettings)
             << "]";
   LOG(INFO) << "CobaltCommandLine: "
             << CommandLineSwitchesToString(

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -161,6 +161,11 @@ void ParseAndApplyH5vccSettings(std::string_view settings_value,
 
 }  // namespace
 
+void ParseAndApplyH5vccSettingsForTesting(std::string_view settings_value,
+                                          GlobalFeatures* global_features) {
+  ParseAndApplyH5vccSettings(settings_value, global_features);
+}
+
 #if BUILDFLAG(IS_ANDROID)
 static void JNI_CobaltContentBrowserClient_FlushCookiesAndLocalStorage(
     JNIEnv*) {

--- a/cobalt/browser/cobalt_content_browser_client.h
+++ b/cobalt/browser/cobalt_content_browser_client.h
@@ -16,6 +16,8 @@
 #include "third_party/abseil-cpp/absl/types/optional.h"
 #define COBALT_BROWSER_COBALT_CONTENT_BROWSER_CLIENT_H_
 
+#include <string_view>
+
 #include "cobalt/browser/client_hint_headers/cobalt_trusted_url_loader_header_client.h"
 #include "cobalt/common/cobalt_thread_checker.h"
 #include "cobalt/media/service/mojom/platform_window_provider.mojom.h"
@@ -49,8 +51,12 @@ class BinderMapWithContext;
 
 namespace cobalt {
 
+class GlobalFeatures;
 class CobaltMetricsServicesManagerClient;
 class CobaltWebContentsObserver;
+
+void ParseAndApplyH5vccSettingsForTesting(std::string_view settings_value,
+                                          GlobalFeatures* global_features);
 
 // This class allows Cobalt to inject specific logic in the business of the
 // browser (i.e. of Content), for example for startup or to override the UA.

--- a/cobalt/browser/cobalt_content_browser_client_unittest.cc
+++ b/cobalt/browser/cobalt_content_browser_client_unittest.cc
@@ -14,52 +14,22 @@
 
 #include "cobalt/browser/cobalt_content_browser_client.h"
 
-#include <memory>
-#include <optional>
 #include <string>
 #include <variant>
 
-#include "base/command_line.h"
-#include "base/files/scoped_temp_dir.h"
-#include "base/path_service.h"
-#include "base/test/scoped_path_override.h"
-#include "base/test/task_environment.h"
 #include "cobalt/browser/global_features.h"
-#include "cobalt/browser/switches.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace cobalt {
 namespace {
 
-class CobaltContentBrowserClientTest : public testing::Test {
- protected:
-  void SetUp() override {
-    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
-    cache_override_ = std::make_unique<base::ScopedPathOverride>(
-        base::DIR_CACHE, temp_dir_.GetPath(), true, true);
-    instance_ = GlobalFeatures::GetInstance();
-  }
+TEST(CobaltContentBrowserClientTest, ParseAndApplyH5vccSettingsForTesting) {
+  auto* instance = GlobalFeatures::GetInstance();
+  ASSERT_NE(instance, nullptr);
 
-  base::test::TaskEnvironment task_environment_{
-      base::test::TaskEnvironment::MainThreadType::DEFAULT,
-      base::test::TaskEnvironment::ThreadPoolExecutionMode::QUEUED};
-  base::ScopedTempDir temp_dir_;
-  std::unique_ptr<base::ScopedPathOverride> cache_override_;
-  GlobalFeatures* instance_ = nullptr;
-};
+  ParseAndApplyH5vccSettingsForTesting("Foo=1234;Bar=Baz", instance);
 
-TEST_F(CobaltContentBrowserClientTest,
-       CreateFeatureListAndFieldTrialsAppliesH5vccSettings) {
-  ASSERT_NE(instance_, nullptr);
-
-  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
-      switches::kEnableH5vccSettings, "Foo=1234;Bar=Baz");
-
-  auto backup = base::FeatureList::ClearInstanceForTesting();
-  CobaltContentBrowserClient client(std::nullopt, "");
-  client.CreateFeatureListAndFieldTrials();
-
-  const auto& settings = instance_->GetSettings();
+  const auto& settings = instance->GetSettings();
   auto it1 = settings.find("Foo");
   ASSERT_NE(it1, settings.end());
   EXPECT_EQ(std::get<int64_t>(it1->second), 1234);
@@ -67,9 +37,6 @@ TEST_F(CobaltContentBrowserClientTest,
   auto it2 = settings.find("Bar");
   ASSERT_NE(it2, settings.end());
   EXPECT_EQ(std::get<std::string>(it2->second), "Baz");
-
-  base::FeatureList::ClearInstanceForTesting();
-  base::FeatureList::RestoreInstanceForTesting(std::move(backup));
 }
 
 }  // namespace

--- a/cobalt/browser/cobalt_content_browser_client_unittest.cc
+++ b/cobalt/browser/cobalt_content_browser_client_unittest.cc
@@ -17,13 +17,21 @@
 #include <string>
 #include <variant>
 
+#include "base/test/task_environment.h"
 #include "cobalt/browser/global_features.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace cobalt {
 namespace {
 
-TEST(CobaltContentBrowserClientTest, ParseAndApplyH5vccSettingsForTesting) {
+class CobaltContentBrowserClientTest : public testing::Test {
+ protected:
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::MainThreadType::DEFAULT,
+      base::test::TaskEnvironment::ThreadPoolExecutionMode::QUEUED};
+};
+
+TEST_F(CobaltContentBrowserClientTest, ParseAndApplyH5vccSettingsForTesting) {
   auto* instance = GlobalFeatures::GetInstance();
   ASSERT_NE(instance, nullptr);
 

--- a/cobalt/browser/cobalt_content_browser_client_unittest.cc
+++ b/cobalt/browser/cobalt_content_browser_client_unittest.cc
@@ -1,0 +1,76 @@
+// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/cobalt_content_browser_client.h"
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <variant>
+
+#include "base/command_line.h"
+#include "base/files/scoped_temp_dir.h"
+#include "base/path_service.h"
+#include "base/test/scoped_path_override.h"
+#include "base/test/task_environment.h"
+#include "cobalt/browser/global_features.h"
+#include "cobalt/browser/switches.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace {
+
+class CobaltContentBrowserClientTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    cache_override_ = std::make_unique<base::ScopedPathOverride>(
+        base::DIR_CACHE, temp_dir_.GetPath(), true, true);
+    instance_ = GlobalFeatures::GetInstance();
+  }
+
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::MainThreadType::DEFAULT,
+      base::test::TaskEnvironment::ThreadPoolExecutionMode::QUEUED};
+  base::ScopedTempDir temp_dir_;
+  std::unique_ptr<base::ScopedPathOverride> cache_override_;
+  GlobalFeatures* instance_ = nullptr;
+};
+
+TEST_F(CobaltContentBrowserClientTest,
+       CreateFeatureListAndFieldTrialsAppliesH5vccSettings) {
+  ASSERT_NE(instance_, nullptr);
+
+  base::CommandLine::ForCurrentProcess()->AppendSwitchASCII(
+      switches::kEnableH5vccSettings, "Foo=1234;Bar=Baz");
+
+  auto backup = base::FeatureList::ClearInstanceForTesting();
+  CobaltContentBrowserClient client(std::nullopt, "");
+  client.CreateFeatureListAndFieldTrials();
+
+  const auto& settings = instance_->GetSettings();
+  auto it1 = settings.find("Foo");
+  ASSERT_NE(it1, settings.end());
+  EXPECT_EQ(std::get<int64_t>(it1->second), 1234);
+
+  auto it2 = settings.find("Bar");
+  ASSERT_NE(it2, settings.end());
+  EXPECT_EQ(std::get<std::string>(it2->second), "Baz");
+
+  base::FeatureList::ClearInstanceForTesting();
+  base::FeatureList::RestoreInstanceForTesting(std::move(backup));
+}
+
+}  // namespace
+}  // namespace cobalt

--- a/cobalt/browser/global_features.cc
+++ b/cobalt/browser/global_features.cc
@@ -14,6 +14,7 @@
 
 #include "cobalt/browser/global_features.h"
 
+#include <string_view>
 #include <variant>
 
 #include "base/command_line.h"
@@ -103,10 +104,10 @@ GlobalFeatures::GetSettings() const {
   return settings_;
 }
 
-void GlobalFeatures::SetSettings(const std::string& key,
+void GlobalFeatures::SetSettings(std::string_view key,
                                  const SettingValue& value) {
   base::AutoLock auto_lock(lock_);
-  settings_[key] = value;
+  settings_[std::string(key)] = value;
 
   LOG(INFO) << "SetSettings: key=" << key << ", value=" << [&value] {
     if (const auto* s = std::get_if<std::string>(&value)) {
@@ -116,37 +117,6 @@ void GlobalFeatures::SetSettings(const std::string& key,
     }
     NOTREACHED();
   }();
-}
-
-void GlobalFeatures::ApplyCommandLineOverrides(
-    const base::CommandLine& command_line) {
-  if (!command_line.HasSwitch(switches::kEnableH5vccSettings)) {
-    return;
-  }
-  std::string switch_val =
-      command_line.GetSwitchValueASCII(switches::kEnableH5vccSettings);
-  std::vector<std::string> pairs = base::SplitString(
-      switch_val, ";", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
-  for (const std::string& pair : pairs) {
-    size_t eq_pos = pair.find('=');
-    if (eq_pos == std::string::npos || eq_pos == 0) {
-      LOG(WARNING) << "Skipping value: switch="
-                   << switches::kEnableH5vccSettings << ", pair=" << pair;
-      continue;
-    }
-    std::string key = std::string(
-        base::TrimWhitespaceASCII(pair.substr(0, eq_pos), base::TRIM_ALL));
-    std::string val_str = std::string(
-        base::TrimWhitespaceASCII(pair.substr(eq_pos + 1), base::TRIM_ALL));
-    // SettingValue is std::variant<std::string, int64_t>.
-    // Hence the value is either int64_t or std::string.
-    int64_t int_val = 0;
-    if (base::StringToInt64(val_str, &int_val)) {
-      SetSettings(key, int_val);
-    } else {
-      SetSettings(key, val_str);
-    }
-  }
 }
 
 void GlobalFeatures::CreateExperimentConfig() {

--- a/cobalt/browser/global_features.cc
+++ b/cobalt/browser/global_features.cc
@@ -16,14 +16,19 @@
 
 #include <variant>
 
+#include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/files/file_util.h"
 #include "base/json/string_escape.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/string_split.h"
+#include "base/strings/string_util.h"
 #include "base/time/time.h"
 #include "cobalt/browser/constants/cobalt_experiment_names.h"
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
+#include "cobalt/browser/switches.h"
 #include "components/metrics/metrics_pref_names.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
@@ -111,6 +116,37 @@ void GlobalFeatures::SetSettings(const std::string& key,
     }
     NOTREACHED();
   }();
+}
+
+void GlobalFeatures::ApplyCommandLineOverrides(
+    const base::CommandLine& command_line) {
+  if (!command_line.HasSwitch(switches::kEnableH5vccSettings)) {
+    return;
+  }
+  std::string switch_val =
+      command_line.GetSwitchValueASCII(switches::kEnableH5vccSettings);
+  std::vector<std::string> pairs = base::SplitString(
+      switch_val, ";", base::TRIM_WHITESPACE, base::SPLIT_WANT_NONEMPTY);
+  for (const std::string& pair : pairs) {
+    size_t eq_pos = pair.find('=');
+    if (eq_pos == std::string::npos || eq_pos == 0) {
+      LOG(WARNING) << "Skipping value: switch="
+                   << switches::kEnableH5vccSettings << ", pair=" << pair;
+      continue;
+    }
+    std::string key = std::string(
+        base::TrimWhitespaceASCII(pair.substr(0, eq_pos), base::TRIM_ALL));
+    std::string val_str = std::string(
+        base::TrimWhitespaceASCII(pair.substr(eq_pos + 1), base::TRIM_ALL));
+    // SettingValue is std::variant<std::string, int64_t>.
+    // Hence the value is either int64_t or std::string.
+    int64_t int_val = 0;
+    if (base::StringToInt64(val_str, &int_val)) {
+      SetSettings(key, int_val);
+    } else {
+      SetSettings(key, val_str);
+    }
+  }
 }
 
 void GlobalFeatures::CreateExperimentConfig() {

--- a/cobalt/browser/global_features.cc
+++ b/cobalt/browser/global_features.cc
@@ -17,19 +17,14 @@
 #include <string_view>
 #include <variant>
 
-#include "base/command_line.h"
 #include "base/feature_list.h"
 #include "base/files/file_util.h"
 #include "base/json/string_escape.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
-#include "base/strings/string_number_conversions.h"
-#include "base/strings/string_split.h"
-#include "base/strings/string_util.h"
 #include "base/time/time.h"
 #include "cobalt/browser/constants/cobalt_experiment_names.h"
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
-#include "cobalt/browser/switches.h"
 #include "components/metrics/metrics_pref_names.h"
 #include "components/metrics/metrics_service.h"
 #include "components/metrics_services_manager/metrics_services_manager.h"
@@ -107,7 +102,7 @@ GlobalFeatures::GetSettings() const {
 void GlobalFeatures::SetSettings(std::string_view key,
                                  const SettingValue& value) {
   base::AutoLock auto_lock(lock_);
-  settings_[std::string(key)] = value;
+  settings_[key] = value;
 
   LOG(INFO) << "SetSettings: key=" << key << ", value=" << [&value] {
     if (const auto* s = std::get_if<std::string>(&value)) {

--- a/cobalt/browser/global_features.h
+++ b/cobalt/browser/global_features.h
@@ -16,6 +16,7 @@
 #define COBALT_BROWSER_GLOBAL_FEATURES_H_
 
 #include <optional>
+#include <string_view>
 
 #include "base/feature_list.h"
 #include "base/memory/raw_ptr.h"
@@ -26,10 +27,6 @@
 #include "cobalt/browser/experiments/experiment_config_manager.h"
 #include "components/prefs/pref_registry_simple.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
-
-namespace base {
-class CommandLine;
-}
 
 class PrefService;
 
@@ -84,8 +81,7 @@ class GlobalFeatures {
   using SettingValue = std::variant<std::string, int64_t>;
 
   const absl::flat_hash_map<std::string, SettingValue>& GetSettings() const;
-  void SetSettings(const std::string& key, const SettingValue& value);
-  void ApplyCommandLineOverrides(const base::CommandLine& command_line);
+  void SetSettings(std::string_view key, const SettingValue& value);
 
  private:
   friend class base::NoDestructor<GlobalFeatures>;

--- a/cobalt/browser/global_features.h
+++ b/cobalt/browser/global_features.h
@@ -27,6 +27,10 @@
 #include "components/prefs/pref_registry_simple.h"
 #include "third_party/abseil-cpp/absl/container/flat_hash_map.h"
 
+namespace base {
+class CommandLine;
+}
+
 class PrefService;
 
 namespace metrics {
@@ -81,6 +85,7 @@ class GlobalFeatures {
 
   const absl::flat_hash_map<std::string, SettingValue>& GetSettings() const;
   void SetSettings(const std::string& key, const SettingValue& value);
+  void ApplyCommandLineOverrides(const base::CommandLine& command_line);
 
  private:
   friend class base::NoDestructor<GlobalFeatures>;

--- a/cobalt/browser/switches.h
+++ b/cobalt/browser/switches.h
@@ -35,6 +35,10 @@ constexpr char kEnforceHTTPS[] = "https-enforcement";
 // Specify the initial window size: --window-size=w,h
 constexpr char kWindowSize[] = "window-size";
 
+// Enable H5VCC settings via command line:
+// --enable-h5vcc-settings=Key1=Val1;Key2=Val2
+constexpr char kEnableH5vccSettings[] = "enable-h5vcc-settings";
+
 }  // namespace switches
 }  // namespace cobalt
 


### PR DESCRIPTION
Introduce the --enable-h5vcc-settings command-line switch to enable
dynamic overrides of H5VCC settings during browser startup. This
allows developers to tune internal parameters, such as media
optimizations, on the fly via adb or other command-line interfaces.

To maintain security, these intent-based command-line overrides are
restricted to non-release and non-production builds.

Usage example:
```
adb shell "am start --esa commandLineArgs '--enable-h5vcc-settings=Media.MaxSamplesPerWrite=16\;Media.EnableTrivialOptimizations=1' dev.cobalt.coat/dev.cobalt.app.MainActivity"
```

Issue: 528333559