### PR TITLE
starboard: Remove Apple macros in NPLB tests

### DIFF
--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -189,7 +189,10 @@ source_set("starboard_test_main") {
   testonly = true
   sources = [ "//starboard/common/test_main.cc" ]
   public_deps = [ "//testing/gtest" ]
-  deps = [ ":starboard_headers_only" ]
+  deps = [
+    ":starboard_headers_only",
+    "//starboard/testing:test_runner",
+  ]
 
   if (is_ios) {
     deps += [

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -188,11 +188,11 @@ source_set("starboard_headers_only") {
 source_set("starboard_test_main") {
   testonly = true
   sources = [ "//starboard/common/test_main.cc" ]
-  public_deps = [ "//testing/gtest" ]
-  deps = [
-    ":starboard_headers_only",
+  public_deps = [
     "//starboard/testing:test_runner",
+    "//testing/gtest",
   ]
+  deps = [ ":starboard_headers_only" ]
 
   if (is_ios) {
     deps += [

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -195,11 +195,7 @@ source_set("starboard_test_main") {
   deps = [ ":starboard_headers_only" ]
 
   if (is_ios) {
-    deps += [
-      "//base",
-      "//base/test:test_support",
-      "//starboard/tvos/shared:test_support",
-    ]
+    deps += [ "//starboard/tvos/shared:test_support" ]
   }
 
   if (is_android) {

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -391,9 +391,10 @@ static_library("test_support") {
 
   configs += [ "//starboard/build/config:starboard_implementation" ]
 
+  public_deps = [ "//starboard/testing:test_runner" ]
+
   deps = [
     ":starboard_platform",
-    "//starboard/testing:test_runner",
     "//testing/gmock",
     "//testing/gtest",
     "//third_party/jni_zero:jni_zero",

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -393,6 +393,7 @@ static_library("test_support") {
 
   deps = [
     ":starboard_platform",
+    "//starboard/testing:test_runner",
     "//testing/gmock",
     "//testing/gtest",
     "//third_party/jni_zero:jni_zero",
@@ -407,6 +408,7 @@ static_library("test_support") {
     "fake_media_codec.h",
     "starboard_test_environment.cc",
     "starboard_test_environment.h",
+    "test_runner.cc",
   ]
 }
 

--- a/starboard/android/shared/test_runner.cc
+++ b/starboard/android/shared/test_runner.cc
@@ -21,7 +21,7 @@
 
 namespace starboard {
 
-void RunTestBlockingAction(std::function<void()>&& action) {
+void RunTestBlockingAction(std::function<void()> action) {
   action();
 }
 
@@ -30,10 +30,8 @@ void RegisterPlatformTestEnvironments(int argc, char** argv) {
       std::make_unique<starboard::StarboardTestEnvironment>().release());
 }
 
-int RunPlatformTestSuite(int argc,
-                         char** argv,
-                         std::function<int(int, char**)> run_tests_fn) {
-  return run_tests_fn(argc, argv);
+int RunPlatformTestSuite(int argc, char** argv, RunTestsCallback run_tests_cb) {
+  return run_tests_cb(argc, argv);
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/test_runner.cc
+++ b/starboard/android/shared/test_runner.cc
@@ -1,0 +1,39 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/testing/test_runner.h"
+
+#include <memory>
+
+#include "starboard/android/shared/starboard_test_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+
+void RunTestBlockingAction(std::function<void()>&& action) {
+  action();
+}
+
+void RegisterPlatformTestEnvironments(int argc, char** argv) {
+  ::testing::AddGlobalTestEnvironment(
+      std::make_unique<starboard::StarboardTestEnvironment>().release());
+}
+
+int RunPlatformTestSuite(int argc,
+                         char** argv,
+                         std::function<int(int, char**)> run_tests_fn) {
+  return run_tests_fn(argc, argv);
+}
+
+}  // namespace starboard

--- a/starboard/common/test_main.cc
+++ b/starboard/common/test_main.cc
@@ -17,48 +17,19 @@
 #include "starboard/configuration.h"
 #include "starboard/event.h"
 #include "starboard/system.h"
+#include "starboard/testing/test_runner.h"
 #include "testing/gtest/include/gtest/gtest.h"
-
-#if BUILDFLAG(IS_IOS_TVOS)
-#include "base/command_line.h"     // nogncheck
-#include "base/functional/bind.h"  // nogncheck
-#include "base/test/test_support_ios.h"
-#include "starboard/tvos/shared/starboard_test_environment.h"
-#endif  // BUILDFLAG(IS_IOS_TVOS)
-
-#if BUILDFLAG(IS_ANDROID)
-#include "starboard/android/shared/starboard_test_environment.h"
-#endif  // BUILDFLAG(IS_ANDROID)
 
 namespace {
 
 int RunTests(int argc, char** argv) {
-#if BUILDFLAG(IS_ANDROID)
-  ::testing::AddGlobalTestEnvironment(
-      new starboard::StarboardTestEnvironment());
-#elif BUILDFLAG(IS_IOS_TVOS)
-  ::testing::AddGlobalTestEnvironment(
-      new starboard::StarboardTestEnvironment(argc, argv));
-#endif  // BUILDFLAG(IS_ANDROID)
-
+  starboard::RegisterPlatformTestEnvironments(argc, argv);
   return RUN_ALL_TESTS();
 }
 
 int InitAndRunAllTests(int argc, char** argv) {
   ::testing::InitGoogleTest(&argc, argv);
-#if BUILDFLAG(IS_IOS_TVOS)
-  // tvOS tests need to invoke UIApplicationMain() to set up the main loop and
-  // the rest of the expected infrastructure. Invoke InitAndRunAllTests() via
-  // the code in //base/test that takes care of all the initial iOS/tvOS setup.
-  //
-  // This code is based on //base/test/launcher/unit_test_launcher_ios.cc.
-  CHECK(base::CommandLine::InitializedForCurrentProcess() ||
-        base::CommandLine::Init(argc, argv));
-  base::InitIOSRunHook(base::BindOnce(&RunTests, argc, argv));
-  return base::RunTestsFromIOSApp();
-#else   // BUILDFLAG(IS_IOS_TVOS)
-  return RunTests(argc, argv);
-#endif  // BUILDFLAG(IS_IOS_TVOS)
+  return starboard::RunPlatformTestSuite(argc, argv, &RunTests);
 }
 }  // namespace
 

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -358,6 +358,7 @@ test("nplb") {
     "//starboard/shared/starboard/player:player_test_data",
     "//starboard/shared/starboard/player:video_dmp",
     "//starboard/testing:fake_graphics_context_provider",
+    "//starboard/testing:test_runner",
     "//testing/gmock",
     "//testing/gtest",
   ]

--- a/starboard/nplb/player_create_test.cc
+++ b/starboard/nplb/player_create_test.cc
@@ -27,11 +27,7 @@
 #include "starboard/nplb/player_test_util.h"
 #include "starboard/player.h"
 #include "starboard/testing/fake_graphics_context_provider.h"
-#include "testing/gtest/include/gtest/gtest.h"
-
-#if BUILDFLAG(IS_IOS_TVOS)
-#include "starboard/tvos/shared/run_in_background_thread_and_wait.h"
-#endif  // BUILDFLAG(IS_IOS_TVOS)
+#include "starboard/testing/test_runner.h"
 
 namespace nplb {
 namespace {
@@ -120,15 +116,10 @@ class SbPlayerTest : public ::testing::Test {
         break;
       }
 
-#if BUILDFLAG(IS_IOS_TVOS)
-      RunInBackgroundThreadAndWait([&] {
+      starboard::RunTestBlockingAction([&] {
         condition_variable_.wait_for(lock,
                                      std::chrono::microseconds(wait_end - now));
       });
-#else
-      condition_variable_.wait_for(lock,
-                                   std::chrono::microseconds(wait_end - now));
-#endif  // BUILDFLAG(IS_IOS_TVOS)
     }
 
     SB_LOG(INFO) << "WaitForPlayerInitializedOrError() timed out.";

--- a/starboard/nplb/posix_compliance/posix_socket_set_options_test.cc
+++ b/starboard/nplb/posix_compliance/posix_socket_set_options_test.cc
@@ -43,7 +43,7 @@ TEST_P(PosixSocketSetOptionsTest, TryThemAllTCP) {
   EXPECT_EQ(setsockopt(socket_fd, SOL_SOCKET, SO_KEEPALIVE, &true_val,
                        sizeof(true_val)),
             0);
-#if defined(__APPLE__)
+#if defined(TCP_KEEPALIVE)
   // In tvOS, TCP_KEEPIDLE and SOL_TCP are not available.
   // For reference:
   // https://stackoverflow.com/questions/15860127/how-to-configure-tcp-keepalive-under-mac-os-x

--- a/starboard/nplb/posix_compliance/posix_thread_helpers.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.cc
@@ -19,11 +19,9 @@
 #include <cstddef>
 
 #include "build/build_config.h"
+#include "starboard/common/thread_platform.h"
+#include "starboard/testing/test_runner.h"
 #include "testing/gtest/include/gtest/gtest.h"
-
-#if BUILDFLAG(IS_IOS_TVOS)
-#include "starboard/tvos/shared/run_in_background_thread_and_wait.h"
-#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace nplb {
 
@@ -98,11 +96,7 @@ void AbstractTestThread::Start() {
 }
 
 void AbstractTestThread::WaitForFinish() {
-#if BUILDFLAG(IS_IOS_TVOS)
-  RunInBackgroundThreadAndWait([this] { Join(); });
-#else
-  Join();
-#endif  // BUILDFLAG(IS_IOS_TVOS)
+  starboard::RunTestBlockingAction([this] { Join(); });
 }
 
 void AbstractTestThread::Join() {
@@ -113,11 +107,7 @@ void AbstractTestThread::Join() {
 
 // static
 void* AbstractTestThread::ThreadEntryPoint(void* ptr) {
-#if defined(__APPLE__)
-  pthread_setname_np("AbstractTestThread");
-#else
-  pthread_setname_np(pthread_self(), "AbstractTestThread");
-#endif
+  starboard::SetCurrentThreadName("AbstractTestThread");
   AbstractTestThread* this_ptr = static_cast<AbstractTestThread*>(ptr);
   this_ptr->Run();
   return NULL;

--- a/starboard/nplb/posix_compliance/posix_thread_helpers.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_helpers.cc
@@ -18,7 +18,6 @@
 
 #include <cstddef>
 
-#include "build/build_config.h"
 #include "starboard/common/thread_platform.h"
 #include "starboard/testing/test_runner.h"
 #include "testing/gtest/include/gtest/gtest.h"

--- a/starboard/testing/BUILD.gn
+++ b/starboard/testing/BUILD.gn
@@ -53,3 +53,13 @@ source_set("testing_test") {
     "//testing/gtest",
   ]
 }
+
+static_library("test_runner") {
+  testonly = true
+
+  sources = [ "test_runner.h" ]
+
+  if (!is_ios && !is_android) {
+    sources += [ "test_runner.cc" ]
+  }
+}

--- a/starboard/testing/test_runner.cc
+++ b/starboard/testing/test_runner.cc
@@ -1,0 +1,33 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/testing/test_runner.h"
+
+#include <utility>
+
+namespace starboard {
+
+void RunTestBlockingAction(std::function<void()>&& action) {
+  action();
+}
+
+void RegisterPlatformTestEnvironments(int argc, char** argv) {}
+
+int RunPlatformTestSuite(int argc,
+                         char** argv,
+                         std::function<int(int, char**)> run_tests_fn) {
+  return run_tests_fn(argc, argv);
+}
+
+}  // namespace starboard

--- a/starboard/testing/test_runner.cc
+++ b/starboard/testing/test_runner.cc
@@ -18,16 +18,14 @@
 
 namespace starboard {
 
-void RunTestBlockingAction(std::function<void()>&& action) {
+void RunTestBlockingAction(std::function<void()> action) {
   action();
 }
 
 void RegisterPlatformTestEnvironments(int argc, char** argv) {}
 
-int RunPlatformTestSuite(int argc,
-                         char** argv,
-                         std::function<int(int, char**)> run_tests_fn) {
-  return run_tests_fn(argc, argv);
+int RunPlatformTestSuite(int argc, char** argv, RunTestsCallback run_tests_cb) {
+  return run_tests_cb(argc, argv);
 }
 
 }  // namespace starboard

--- a/starboard/testing/test_runner.h
+++ b/starboard/testing/test_runner.h
@@ -1,0 +1,39 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_TESTING_TEST_RUNNER_H_
+#define STARBOARD_TESTING_TEST_RUNNER_H_
+
+#include <functional>
+
+namespace starboard {
+
+// Executes `action`. On platforms requiring main loop pumping (e.g. tvOS),
+// dispatches `action` to a background thread while pumping the main loop.
+void RunTestBlockingAction(std::function<void()>&& action);
+
+// Registers global test environments required by the platform (e.g. Android /
+// tvOS).
+void RegisterPlatformTestEnvironments(int argc, char** argv);
+
+// Runs the platform test suite loop. On platforms requiring a custom app loop
+// launcher (e.g. tvOS UIApplicationMain), executes via the platform runner
+// hook.
+int RunPlatformTestSuite(int argc,
+                         char** argv,
+                         std::function<int(int, char**)> run_tests_fn);
+
+}  // namespace starboard
+
+#endif  // STARBOARD_TESTING_TEST_RUNNER_H_

--- a/starboard/testing/test_runner.h
+++ b/starboard/testing/test_runner.h
@@ -19,9 +19,11 @@
 
 namespace starboard {
 
+using RunTestsCallback = std::function<int(int, char**)>;
+
 // Executes `action`. On platforms requiring main loop pumping (e.g. tvOS),
 // dispatches `action` to a background thread while pumping the main loop.
-void RunTestBlockingAction(std::function<void()>&& action);
+void RunTestBlockingAction(std::function<void()> action);
 
 // Registers global test environments required by the platform (e.g. Android /
 // tvOS).
@@ -30,9 +32,7 @@ void RegisterPlatformTestEnvironments(int argc, char** argv);
 // Runs the platform test suite loop. On platforms requiring a custom app loop
 // launcher (e.g. tvOS UIApplicationMain), executes via the platform runner
 // hook.
-int RunPlatformTestSuite(int argc,
-                         char** argv,
-                         std::function<int(int, char**)> run_tests_fn);
+int RunPlatformTestSuite(int argc, char** argv, RunTestsCallback run_tests_cb);
 
 }  // namespace starboard
 

--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -23,11 +23,15 @@ static_library("test_support") {
 
   public_deps = [ "//testing/gtest" ]
 
-  deps = [ ":starboard_platform" ]
+  deps = [
+    ":starboard_platform",
+    "//starboard/testing:test_runner",
+  ]
 
   sources = [
     "starboard_test_environment.h",
     "starboard_test_environment.mm",
+    "test_runner.cc",
   ]
 }
 

--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -21,12 +21,12 @@ if (is_internal_build) {
 static_library("test_support") {
   testonly = true
 
-  public_deps = [ "//testing/gtest" ]
-
-  deps = [
-    ":starboard_platform",
+  public_deps = [
     "//starboard/testing:test_runner",
+    "//testing/gtest",
   ]
+
+  deps = [ ":starboard_platform" ]
 
   sources = [
     "starboard_test_environment.h",

--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -26,7 +26,11 @@ static_library("test_support") {
     "//testing/gtest",
   ]
 
-  deps = [ ":starboard_platform" ]
+  deps = [
+    ":starboard_platform",
+    "//base",
+    "//base/test:test_support",
+  ]
 
   sources = [
     "starboard_test_environment.h",

--- a/starboard/tvos/shared/test_runner.cc
+++ b/starboard/tvos/shared/test_runner.cc
@@ -26,7 +26,7 @@
 
 namespace starboard {
 
-void RunTestBlockingAction(std::function<void()>&& action) {
+void RunTestBlockingAction(std::function<void()> action) {
   RunInBackgroundThreadAndWait(std::move(action));
 }
 
@@ -36,20 +36,18 @@ void RegisterPlatformTestEnvironments(int argc, char** argv) {
 }
 
 namespace {
-int RunTestsCallback(std::function<int(int, char**)> run_tests_fn,
-                     int argc,
-                     char** argv) {
-  return run_tests_fn(argc, argv);
+int RunTestsCallbackAdapter(RunTestsCallback run_tests_cb,
+                            int argc,
+                            char** argv) {
+  return run_tests_cb(argc, argv);
 }
 }  // namespace
 
-int RunPlatformTestSuite(int argc,
-                         char** argv,
-                         std::function<int(int, char**)> run_tests_fn) {
+int RunPlatformTestSuite(int argc, char** argv, RunTestsCallback run_tests_cb) {
   CHECK(base::CommandLine::InitializedForCurrentProcess() ||
         base::CommandLine::Init(argc, argv));
   base::InitIOSRunHook(
-      base::BindOnce(&RunTestsCallback, run_tests_fn, argc, argv));
+      base::BindOnce(&RunTestsCallbackAdapter, run_tests_cb, argc, argv));
   return base::RunTestsFromIOSApp();
 }
 

--- a/starboard/tvos/shared/test_runner.cc
+++ b/starboard/tvos/shared/test_runner.cc
@@ -1,0 +1,56 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/testing/test_runner.h"
+
+#include <memory>
+#include <utility>
+
+#include "base/command_line.h"
+#include "base/functional/bind.h"
+#include "base/test/test_support_ios.h"
+#include "starboard/tvos/shared/run_in_background_thread_and_wait.h"
+#include "starboard/tvos/shared/starboard_test_environment.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+
+void RunTestBlockingAction(std::function<void()>&& action) {
+  RunInBackgroundThreadAndWait(std::move(action));
+}
+
+void RegisterPlatformTestEnvironments(int argc, char** argv) {
+  ::testing::AddGlobalTestEnvironment(
+      std::make_unique<StarboardTestEnvironment>(argc, argv).release());
+}
+
+namespace {
+int RunTestsCallback(std::function<int(int, char**)> run_tests_fn,
+                     int argc,
+                     char** argv) {
+  return run_tests_fn(argc, argv);
+}
+}  // namespace
+
+int RunPlatformTestSuite(int argc,
+                         char** argv,
+                         std::function<int(int, char**)> run_tests_fn) {
+  CHECK(base::CommandLine::InitializedForCurrentProcess() ||
+        base::CommandLine::Init(argc, argv));
+  base::InitIOSRunHook(
+      base::BindOnce(&RunTestsCallback, run_tests_fn, argc, argv));
+  return base::RunTestsFromIOSApp();
+}
+
+}  // namespace starboard

--- a/starboard/tvos/shared/test_runner.cc
+++ b/starboard/tvos/shared/test_runner.cc
@@ -18,8 +18,9 @@
 #include <utility>
 
 #include "base/command_line.h"
-#include "base/functional/bind.h"
+#include "base/test/bind.h"
 #include "base/test/test_support_ios.h"
+#include "starboard/common/log.h"
 #include "starboard/tvos/shared/run_in_background_thread_and_wait.h"
 #include "starboard/tvos/shared/starboard_test_environment.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -35,19 +36,11 @@ void RegisterPlatformTestEnvironments(int argc, char** argv) {
       std::make_unique<StarboardTestEnvironment>(argc, argv).release());
 }
 
-namespace {
-int RunTestsCallbackAdapter(RunTestsCallback run_tests_cb,
-                            int argc,
-                            char** argv) {
-  return run_tests_cb(argc, argv);
-}
-}  // namespace
-
 int RunPlatformTestSuite(int argc, char** argv, RunTestsCallback run_tests_cb) {
-  CHECK(base::CommandLine::InitializedForCurrentProcess() ||
-        base::CommandLine::Init(argc, argv));
+  SB_CHECK(base::CommandLine::InitializedForCurrentProcess() ||
+           base::CommandLine::Init(argc, argv));
   base::InitIOSRunHook(
-      base::BindOnce(&RunTestsCallbackAdapter, run_tests_cb, argc, argv));
+      base::BindLambdaForTesting([&]() { return run_tests_cb(argc, argv); }));
   return base::RunTestsFromIOSApp();
 }
 

--- a/testing/gtest/BUILD.gn
+++ b/testing/gtest/BUILD.gn
@@ -80,6 +80,7 @@ source_set("gtest_main") {
     deps = [
       ":gtest",
       "//starboard:starboard_group",
+      "//starboard/testing:test_runner",
     ]
   } else {
     deps = [ "//third_party/googletest:gtest_main" ]


### PR DESCRIPTION
Remove platform-specific __APPLE__ preprocessor macros within the
Starboard NPLB POSIX compliance tests. This change improves code
portability by utilizing Starboard abstractions and standard feature
detection instead of hardcoded operating system identification, ensuring
a more consistent test environment across platforms.

Issue: 528033221