### PR TITLE
cobalt: Make HangWatcher config dynamically updatable

### DIFF
--- a/base/threading/hang_watcher.cc
+++ b/base/threading/hang_watcher.cc
@@ -32,6 +32,8 @@
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_STARBOARD)
+#include <inttypes.h>
+
 #include "starboard/extension/crash_handler.h"
 #include "starboard/system.h"
 #endif
@@ -57,9 +59,18 @@ std::atomic<LoggingLevel> g_threadpool_log_level{LoggingLevel::kNone};
 std::atomic<LoggingLevel> g_io_thread_log_level{LoggingLevel::kNone};
 std::atomic<LoggingLevel> g_main_thread_log_level{LoggingLevel::kNone};
 std::atomic<LoggingLevel> g_compositor_thread_log_level{LoggingLevel::kNone};
+
 #if BUILDFLAG(IS_COBALT)
 std::atomic<LoggingLevel> g_browser_process_renderer_thread_log_level{LoggingLevel::kNone};
-static inline HangWatcher::Delegate* g_hang_watcher_delegate = nullptr;
+
+std::atomic<int64_t> g_hang_watch_time_us{
+    WatchHangsInScope::kDefaultHangWatchTime.InMicroseconds()};
+std::atomic<int64_t> g_hang_watch_monitoring_period_us{
+    base::Seconds(10).InMicroseconds()};
+
+std::atomic<bool> g_hang_reporting_enabled{true};
+
+static std::atomic<HangWatcher::Delegate*> g_hang_watcher_delegate{nullptr};
 #endif
 
 // Indicates whether HangWatcher::Run() should return after the next monitoring.
@@ -238,7 +249,7 @@ bool ThreadTypeLoggingLevelGreaterOrEqual(HangWatcher::ThreadType thread_type,
 #if BUILDFLAG(IS_COBALT)
 void HangWatcher::SetDelegate(Delegate* delegate) {
   DCHECK(!g_instance) << "SetDelegate must be called before Start()";
-  g_hang_watcher_delegate = delegate;
+  g_hang_watcher_delegate.store(delegate, std::memory_order_relaxed);
 }
 #endif
 
@@ -326,6 +337,19 @@ constexpr const char* kThreadName = "HangWatcher";
 constexpr auto kMonitoringPeriod = base::Seconds(10);
 
 WatchHangsInScope::WatchHangsInScope(TimeDelta timeout) {
+#if BUILDFLAG(IS_COBALT)
+  // Only override the timeout with the global configuration if the caller
+  // did not explicitly hardcode a custom timeout (e.g. for heavy startup
+  // tasks).
+  if (timeout == kDefaultHangWatchTime) {
+    int64_t watch_time_us =
+        g_hang_watch_time_us.load(std::memory_order_relaxed);
+    if (watch_time_us > 0) {
+      timeout = base::Microseconds(watch_time_us);
+    }
+  }
+#endif
+
   internal::HangWatchState* current_hang_watch_state =
       HangWatcher::IsEnabled()
           ? internal::HangWatchState::GetHangWatchStateForCurrentThread()
@@ -421,6 +445,66 @@ WatchHangsInScope::~WatchHangsInScope() {
 
   state->DecrementNestingLevel();
 }
+
+#if BUILDFLAG(IS_COBALT)
+// static
+void HangWatcher::UpdateConfiguration() {
+  auto* delegate = g_hang_watcher_delegate.load(std::memory_order_relaxed);
+  if (!delegate) {
+    return;
+  }
+
+  if (auto configured_timeout = delegate->GetHangWatchTime()) {
+    g_hang_watch_time_us.store(configured_timeout->InMicroseconds(),
+                               std::memory_order_relaxed);
+  } else {
+    g_hang_watch_time_us.store(
+        WatchHangsInScope::kDefaultHangWatchTime.InMicroseconds(),
+        std::memory_order_relaxed);
+  }
+
+  if (auto configured_period = delegate->GetHangWatchMonitoringPeriod()) {
+    g_hang_watch_monitoring_period_us.store(configured_period->InMicroseconds(),
+                                            std::memory_order_relaxed);
+  } else {
+    g_hang_watch_monitoring_period_us.store(kMonitoringPeriod.InMicroseconds(),
+                                            std::memory_order_relaxed);
+  }
+
+  g_hang_reporting_enabled.store(delegate->IsHangReportingEnabled(),
+                                 std::memory_order_relaxed);
+
+  // Update logging levels for thread scopes.
+  if (auto io_enabled = delegate->IsThreadDumpingEnabled(
+          HangWatcher::ThreadType::kIOThread)) {
+    LoggingLevel io_level =
+        *io_enabled ? LoggingLevel::kUmaAndCrash : LoggingLevel::kNone;
+    g_io_thread_log_level.store(io_level, std::memory_order_relaxed);
+  }
+
+  if (auto main_enabled = delegate->IsThreadDumpingEnabled(
+          HangWatcher::ThreadType::kMainThread)) {
+    LoggingLevel main_level =
+        *main_enabled ? LoggingLevel::kUmaAndCrash : LoggingLevel::kNone;
+    g_main_thread_log_level.store(main_level, std::memory_order_relaxed);
+  }
+
+  if (auto pool_enabled = delegate->IsThreadDumpingEnabled(
+          HangWatcher::ThreadType::kThreadPoolThread)) {
+    LoggingLevel pool_level =
+        *pool_enabled ? LoggingLevel::kUmaAndCrash : LoggingLevel::kNone;
+    g_threadpool_log_level.store(pool_level, std::memory_order_relaxed);
+  }
+
+  if (auto renderer_enabled = delegate->IsThreadDumpingEnabled(
+          HangWatcher::ThreadType::kRendererThread)) {
+    LoggingLevel renderer_level =
+        *renderer_enabled ? LoggingLevel::kUmaAndCrash : LoggingLevel::kNone;
+    g_browser_process_renderer_thread_log_level.store(
+        renderer_level, std::memory_order_relaxed);
+  }
+}
+#endif
 
 // static
 void HangWatcher::InitializeOnMainThread(ProcessType process_type,
@@ -804,6 +888,13 @@ void HangWatcher::Run() {
   DCHECK_CALLED_ON_VALID_THREAD(hang_watcher_thread_checker_);
 
   while (g_keep_monitoring.load(std::memory_order_relaxed)) {
+#if BUILDFLAG(IS_COBALT)
+    int64_t period_us =
+        g_hang_watch_monitoring_period_us.load(std::memory_order_relaxed);
+    if (period_us > 0) {
+      monitoring_period_ = base::Microseconds(period_us);
+    }
+#endif
     Wait();
 
     if (!IsWatchListEmpty() &&
@@ -1125,6 +1216,40 @@ void HangWatcher::DoDumpWithoutCrashing(
   SCOPED_CRASH_KEY_BOOL("HangWatcher", "shutting-down",
                         g_shutting_down.load(std::memory_order_relaxed));
 
+#if BUILDFLAG(IS_COBALT)
+  int64_t configured_timeout =
+      g_hang_watch_time_us.load(std::memory_order_relaxed);
+  char timeout_buf[32];
+  snprintf(timeout_buf, sizeof(timeout_buf), "%" PRId64,
+           static_cast<int64_t>(configured_timeout /
+                                base::Time::kMicrosecondsPerSecond));
+  SCOPED_CRASH_KEY_STRING32("HangWatcher", "hang-timeout-sec", timeout_buf);
+
+  int64_t configured_period =
+      g_hang_watch_monitoring_period_us.load(std::memory_order_relaxed);
+  char period_buf[32];
+  snprintf(period_buf, sizeof(period_buf), "%" PRId64,
+           static_cast<int64_t>(configured_period /
+                                base::Time::kMicrosecondsPerSecond));
+  SCOPED_CRASH_KEY_STRING32("HangWatcher", "hang-period-sec", period_buf);
+
+  bool main_enabled = g_main_thread_log_level.load(std::memory_order_relaxed) >=
+                      LoggingLevel::kUmaAndCrash;
+  SCOPED_CRASH_KEY_BOOL("HangWatcher", "hang-dump-main", main_enabled);
+
+  bool io_enabled = g_io_thread_log_level.load(std::memory_order_relaxed) >=
+                    LoggingLevel::kUmaAndCrash;
+  SCOPED_CRASH_KEY_BOOL("HangWatcher", "hang-dump-io", io_enabled);
+
+  bool pool_enabled = g_threadpool_log_level.load(std::memory_order_relaxed) >=
+                      LoggingLevel::kUmaAndCrash;
+  SCOPED_CRASH_KEY_BOOL("HangWatcher", "hang-dump-pool", pool_enabled);
+
+  bool renderer_enabled =
+      g_browser_process_renderer_thread_log_level.load(
+          std::memory_order_relaxed) >= LoggingLevel::kUmaAndCrash;
+  SCOPED_CRASH_KEY_BOOL("HangWatcher", "hang-dump-renderer", renderer_enabled);
+
 #if BUILDFLAG(IS_STARBOARD)
   // Evergreen builds cannot currently use the crash key system directly and we
   // instead use a Starboard extension to pass annotations from the Cobalt layer
@@ -1142,9 +1267,21 @@ void HangWatcher::DoDumpWithoutCrashing(
     crash_handler_extension->SetString(
         "shutting-down",
         g_shutting_down.load(std::memory_order_relaxed) ? "true" : "false");
+
+    crash_handler_extension->SetString("hang-timeout-sec", timeout_buf);
+    crash_handler_extension->SetString("hang-period-sec", period_buf);
+    crash_handler_extension->SetString("hang-dump-main",
+                                       main_enabled ? "true" : "false");
+    crash_handler_extension->SetString("hang-dump-io",
+                                       io_enabled ? "true" : "false");
+    crash_handler_extension->SetString("hang-dump-pool",
+                                       pool_enabled ? "true" : "false");
+    crash_handler_extension->SetString("hang-dump-renderer",
+                                       renderer_enabled ? "true" : "false");
   }
-#endif
-#endif
+#endif  // BUILDFLAG(IS_STARBOARD)
+#endif  // BUILDFLAG(IS_COBALT)
+#endif  // !BUILDFLAG(IS_NACL)
 
   // To avoid capturing more than one hang that blames a subset of the same
   // threads it's necessary to keep track of what is the furthest deadline
@@ -1171,8 +1308,7 @@ void HangWatcher::DoDumpWithoutCrashing(
     on_hang_closure_for_testing_.Run();
   } else {
 #if BUILDFLAG(IS_COBALT)
-    if (g_hang_watcher_delegate &&
-        g_hang_watcher_delegate->IsHangReportingEnabled()) {
+    if (g_hang_reporting_enabled.load(std::memory_order_relaxed)) {
       RecordHang();
     } else {
       LOG(INFO) << "Freeze detection: RecordHang() skipped due to reporting disabled.";
@@ -1202,6 +1338,10 @@ void HangWatcher::SetOnHangClosureForTesting(base::RepeatingClosure closure) {
 void HangWatcher::SetMonitoringPeriodForTesting(base::TimeDelta period) {
   DCHECK_CALLED_ON_VALID_THREAD(constructing_thread_checker_);
   monitoring_period_ = period;
+#if BUILDFLAG(IS_COBALT)
+  g_hang_watch_monitoring_period_us.store(period.InMicroseconds(),
+                                          std::memory_order_relaxed);
+#endif
 }
 
 void HangWatcher::SetAfterWaitCallbackForTesting(

--- a/base/threading/hang_watcher.h
+++ b/base/threading/hang_watcher.h
@@ -33,6 +33,10 @@
 #include "base/time/time.h"
 #include "build/build_config.h"
 
+#if BUILDFLAG(IS_COBALT)
+#include <optional>
+#endif
+
 namespace base {
 class WatchHangsInScope;
 namespace internal {
@@ -106,17 +110,6 @@ class BASE_EXPORT [[maybe_unused, nodiscard]] WatchHangsInScope {
 // within a single process. This instance must outlive all monitored threads.
 class BASE_EXPORT HangWatcher : public DelegateSimpleThread::Delegate {
  public:
-#if BUILDFLAG(IS_COBALT)
-  // Delegate interface to allow embedders to control HangWatcher behavior.
-  class BASE_EXPORT Delegate {
-   public:
-    virtual ~Delegate() = default;
-    // Returns true if hang reporting should be enabled
-    // potentially overriding default settings.
-    virtual bool IsHangReportingEnabled() = 0;
-  };
-#endif
-
   // Describes the type of a process for logging purposes.
   enum class ProcessType {
     kUnknownProcess = 0,
@@ -141,6 +134,30 @@ class BASE_EXPORT HangWatcher : public DelegateSimpleThread::Delegate {
     kMax = kCompositorThread
 #endif
   };
+
+#if BUILDFLAG(IS_COBALT)
+  // Re-polls the delegate to update the cached configuration values (e.g.
+  // timeout, thread scopes).
+  static void UpdateConfiguration();
+
+  // Delegate interface to allow embedders to control HangWatcher behavior.
+  class BASE_EXPORT Delegate {
+   public:
+    virtual ~Delegate() = default;
+    // Returns true if hang reporting should be enabled
+    // potentially overriding default settings.
+    virtual bool IsHangReportingEnabled() = 0;
+    // Returns a custom timeout for hang watching, or std::nullopt to use
+    // default.
+    virtual std::optional<base::TimeDelta> GetHangWatchTime() = 0;
+    // Returns a custom monitoring period, or std::nullopt to use default.
+    virtual std::optional<base::TimeDelta> GetHangWatchMonitoringPeriod() = 0;
+    // Returns whether crash dumps are enabled for a specific thread type.
+    // Returns std::nullopt if the embedder has no specific override.
+    virtual std::optional<bool> IsThreadDumpingEnabled(
+        ThreadType thread_type) = 0;
+  };
+#endif
 
   // Notes on lifetime:
   //   1) The first invocation of the constructor will set the global instance

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -312,6 +312,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/global_features_unittest.cc",
     "//cobalt/browser/h5vcc_metrics/histogram_fetcher_test.cc",
     "//cobalt/browser/h5vcc_runtime/deep_link_manager_unittest.cc",
+    "//cobalt/browser/hang_watcher_delegate_impl_unittest.cc",
     "//cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc",
     "//cobalt/browser/metrics/cobalt_enabled_state_provider_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_log_uploader_test.cc",

--- a/cobalt/browser/global_features.cc
+++ b/cobalt/browser/global_features.cc
@@ -22,6 +22,8 @@
 #include "base/json/string_escape.h"
 #include "base/no_destructor.h"
 #include "base/path_service.h"
+#include "base/strings/string_util.h"
+#include "base/threading/hang_watcher.h"
 #include "base/time/time.h"
 #include "cobalt/browser/constants/cobalt_experiment_names.h"
 #include "cobalt/browser/metrics/cobalt_metrics_services_manager_client.h"
@@ -99,19 +101,42 @@ GlobalFeatures::GetSettings() const {
   return settings_;
 }
 
+std::optional<GlobalFeatures::SettingValue> GlobalFeatures::GetSetting(
+    std::string_view key) const {
+  base::AutoLock auto_lock(lock_);
+  auto it = settings_.find(key);
+  if (it != settings_.end()) {
+    return it->second;
+  }
+  return std::nullopt;
+}
+
 void GlobalFeatures::SetSettings(std::string_view key,
                                  const SettingValue& value) {
-  base::AutoLock auto_lock(lock_);
-  settings_[key] = value;
+  {
+    base::AutoLock auto_lock(lock_);
+    settings_[key] = value;
 
-  LOG(INFO) << "SetSettings: key=" << key << ", value=" << [&value] {
-    if (const auto* s = std::get_if<std::string>(&value)) {
-      return base::GetQuotedJSONString(*s);
-    } else if (const auto* i = std::get_if<int64_t>(&value)) {
-      return std::to_string(*i);
-    }
-    NOTREACHED();
-  }();
+    LOG(INFO) << "SetSettings: key=" << key << ", value=" << [&value] {
+      if (const auto* s = std::get_if<std::string>(&value)) {
+        return base::GetQuotedJSONString(*s);
+      } else if (const auto* i = std::get_if<int64_t>(&value)) {
+        return base::NumberToString(*i);
+      }
+      NOTREACHED();
+    }();
+  }
+
+  base::HangWatcher::UpdateConfiguration();
+}
+
+void GlobalFeatures::ClearSetting(std::string_view key) {
+  {
+    base::AutoLock auto_lock(lock_);
+    settings_.erase(key);
+  }
+
+  base::HangWatcher::UpdateConfiguration();
 }
 
 void GlobalFeatures::CreateExperimentConfig() {

--- a/cobalt/browser/global_features.h
+++ b/cobalt/browser/global_features.h
@@ -81,7 +81,9 @@ class GlobalFeatures {
   using SettingValue = std::variant<std::string, int64_t>;
 
   const absl::flat_hash_map<std::string, SettingValue>& GetSettings() const;
+  std::optional<SettingValue> GetSetting(std::string_view key) const;
   void SetSettings(std::string_view key, const SettingValue& value);
+  void ClearSetting(std::string_view key);
 
  private:
   friend class base::NoDestructor<GlobalFeatures>;

--- a/cobalt/browser/global_features_unittest.cc
+++ b/cobalt/browser/global_features_unittest.cc
@@ -140,4 +140,30 @@ TEST_F(GlobalFeaturesTest,
   EXPECT_TRUE(active_config_data.empty());
 }
 
+TEST_F(GlobalFeaturesTest, SetAndGetSettingInt) {
+  ASSERT_NE(instance_, nullptr);
+  instance_->SetSettings("test_int", int64_t(42));
+  auto opt_val = instance_->GetSetting("test_int");
+  ASSERT_TRUE(opt_val.has_value());
+  const int64_t* val = std::get_if<int64_t>(&opt_val.value());
+  ASSERT_NE(val, nullptr);
+  EXPECT_EQ(*val, 42);
+}
+
+TEST_F(GlobalFeaturesTest, SetAndGetSettingString) {
+  ASSERT_NE(instance_, nullptr);
+  instance_->SetSettings("test_str", std::string("hello"));
+  auto opt_val = instance_->GetSetting("test_str");
+  ASSERT_TRUE(opt_val.has_value());
+  const std::string* val = std::get_if<std::string>(&opt_val.value());
+  ASSERT_NE(val, nullptr);
+  EXPECT_EQ(*val, "hello");
+}
+
+TEST_F(GlobalFeaturesTest, GetSettingNotFound) {
+  ASSERT_NE(instance_, nullptr);
+  auto opt_val = instance_->GetSetting("non_existent_key");
+  EXPECT_FALSE(opt_val.has_value());
+}
+
 }  // namespace cobalt

--- a/cobalt/browser/hang_watcher_delegate_impl.cc
+++ b/cobalt/browser/hang_watcher_delegate_impl.cc
@@ -1,4 +1,4 @@
-// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -14,10 +14,13 @@
 
 #include "cobalt/browser/hang_watcher_delegate_impl.h"
 
-#include <cstdint>
 #include <optional>
+#include <string>
+#include <variant>
 
 #include "base/feature_list.h"
+#include "base/strings/string_number_conversions.h"
+#include "base/strings/string_util.h"
 #include "cobalt/browser/features.h"
 #include "cobalt/browser/global_features.h"
 namespace cobalt {
@@ -29,6 +32,43 @@ void CobaltHangWatcherDelegate::Initialize() {
   base::HangWatcher::SetDelegate(instance.get());
 }
 
+CobaltHangWatcherDelegate::CobaltHangWatcherDelegate()
+    : global_features_(nullptr) {}
+
+CobaltHangWatcherDelegate::CobaltHangWatcherDelegate(
+    GlobalFeatures* global_features)
+    : global_features_(global_features) {}
+
+// We evaluate GlobalFeatures::GetInstance() lazily here rather than in the
+// default constructor. CobaltHangWatcherDelegate is instantiated extremely
+// early during browser startup. Calling GetInstance() at that time would
+// prematurely initialize background threads (Metrics, Experiments) before
+// the Chromium TaskEnvironment and thread pool are ready, causing a FATAL
+// crash.
+GlobalFeatures* CobaltHangWatcherDelegate::GetGlobalFeatures() {
+  return global_features_ ? global_features_ : GlobalFeatures::GetInstance();
+}
+
+std::optional<int64_t> CobaltHangWatcherDelegate::GetIntSetting(
+    std::string_view key) {
+  auto* features = GetGlobalFeatures();
+  if (!features) {
+    return std::nullopt;
+  }
+
+  auto val_opt = features->GetSetting(key);
+  if (!val_opt) {
+    return std::nullopt;
+  }
+
+  const auto* val_int = std::get_if<int64_t>(&val_opt.value());
+  if (!val_int) {
+    return std::nullopt;
+  }
+
+  return *val_int;
+}
+
 bool CobaltHangWatcherDelegate::IsHangReportingEnabled() {
   // First, check 'GlobalFeatures', which is a process-wide settings dictionary
   // typically populated by the embedder via the JS H5VCC API.
@@ -36,21 +76,64 @@ bool CobaltHangWatcherDelegate::IsHangReportingEnabled() {
   // until the proper Finch bridge is fully functional. If the setting isn't
   // explicitly provided, we fallback to the standard Chromium 'FeatureList'
   // which is backed by Finch.
-  if (auto* global_features = GlobalFeatures::GetInstance()) {
-    const auto& settings = global_features->GetSettings();
-    auto it = settings.find("EnableHangReporting");
-    if (it != settings.end()) {
-      if (const auto* val = std::get_if<int64_t>(&it->second)) {
-        bool enabled = (*val != 0);
-        DLOG(INFO) << "CobaltHangWatcherDelegate: EnableHangReporting: "
-                   << enabled;
-        return enabled;
-      }
-    }
+  auto val = GetIntSetting("EnableHangReporting");
+  if (val.has_value()) {
+    bool enabled = *val != 0;
+    DLOG(INFO) << "CobaltHangWatcherDelegate: EnableHangReporting: " << enabled;
+    return enabled;
   }
-  DLOG(INFO) << "CobaltHangWatcherDelegate: EnableHangReporting: using Finch";
 
+  DLOG(INFO) << "CobaltHangWatcherDelegate: EnableHangReporting: using Finch";
   return base::FeatureList::IsEnabled(cobalt::features::kHangReporting);
+}
+
+std::optional<base::TimeDelta> CobaltHangWatcherDelegate::GetHangWatchTime() {
+  auto val = GetIntSetting("HangWatchTimeSeconds");
+  if (!val.has_value() || *val <= 0) {
+    return std::nullopt;
+  }
+  return base::Seconds(*val);
+}
+
+std::optional<base::TimeDelta>
+CobaltHangWatcherDelegate::GetHangWatchMonitoringPeriod() {
+  auto val = GetIntSetting("HangWatchMonitoringPeriodSeconds");
+  if (!val.has_value() || *val <= 0) {
+    return std::nullopt;
+  }
+  return base::Seconds(*val);
+}
+
+std::optional<bool> CobaltHangWatcherDelegate::IsThreadDumpingEnabled(
+    base::HangWatcher::ThreadType thread_type) {
+  std::string_view key;
+  switch (thread_type) {
+    case base::HangWatcher::ThreadType::kMainThread:
+      key = "EnableHangWatchMainThreadDump";
+      break;
+    case base::HangWatcher::ThreadType::kIOThread:
+      key = "EnableHangWatchIOThreadDump";
+      break;
+    case base::HangWatcher::ThreadType::kThreadPoolThread:
+      key = "EnableHangWatchThreadPoolDump";
+      break;
+    case base::HangWatcher::ThreadType::kRendererThread:
+      key = "EnableHangWatchRendererThreadDump";
+      break;
+    default:
+      return std::nullopt;
+  }
+
+  if (key.empty()) {
+    return std::nullopt;
+  }
+
+  auto val = GetIntSetting(key);
+  if (val.has_value()) {
+    return *val != 0;
+  }
+
+  return std::nullopt;
 }
 
 }  // namespace browser

--- a/cobalt/browser/hang_watcher_delegate_impl.h
+++ b/cobalt/browser/hang_watcher_delegate_impl.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -15,19 +15,34 @@
 #ifndef COBALT_BROWSER_HANG_WATCHER_DELEGATE_IMPL_H_
 #define COBALT_BROWSER_HANG_WATCHER_DELEGATE_IMPL_H_
 
+#include <optional>
+#include <string>
+
 #include "base/threading/hang_watcher.h"
 
 namespace cobalt {
+class GlobalFeatures;
 namespace browser {
 
 class CobaltHangWatcherDelegate : public base::HangWatcher::Delegate {
  public:
-  CobaltHangWatcherDelegate() = default;
+  CobaltHangWatcherDelegate();
+  explicit CobaltHangWatcherDelegate(GlobalFeatures* global_features);
   ~CobaltHangWatcherDelegate() override = default;
 
   static void Initialize();
 
   bool IsHangReportingEnabled() override;
+  std::optional<base::TimeDelta> GetHangWatchTime() override;
+  std::optional<base::TimeDelta> GetHangWatchMonitoringPeriod() override;
+  std::optional<bool> IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType thread_type) override;
+
+ private:
+  GlobalFeatures* GetGlobalFeatures();
+  std::optional<int64_t> GetIntSetting(std::string_view key);
+
+  GlobalFeatures* global_features_;
 };
 
 }  // namespace browser

--- a/cobalt/browser/hang_watcher_delegate_impl_unittest.cc
+++ b/cobalt/browser/hang_watcher_delegate_impl_unittest.cc
@@ -1,0 +1,115 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/hang_watcher_delegate_impl.h"
+
+#include <memory>
+#include <string>
+
+#include "base/files/scoped_temp_dir.h"
+#include "base/path_service.h"
+#include "base/test/scoped_path_override.h"
+#include "base/test/task_environment.h"
+#include "base/time/time.h"
+#include "cobalt/browser/global_features.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace browser {
+
+class HangWatcherDelegateImplTest : public testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    cache_override_ = std::make_unique<base::ScopedPathOverride>(
+        base::DIR_CACHE, temp_dir_.GetPath(), true, true);
+    instance_ = GlobalFeatures::GetInstance();
+    delegate_ = std::make_unique<CobaltHangWatcherDelegate>(instance_);
+  }
+
+  void TearDown() override {
+    instance_->ClearSetting("EnableHangReporting");
+    instance_->ClearSetting("HangWatchTimeSeconds");
+    instance_->ClearSetting("HangWatchMonitoringPeriodSeconds");
+    instance_->ClearSetting("EnableHangWatchMainThreadDump");
+    instance_->ClearSetting("EnableHangWatchIOThreadDump");
+    instance_->ClearSetting("EnableHangWatchThreadPoolDump");
+    instance_->ClearSetting("EnableHangWatchRendererThreadDump");
+  }
+
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::MainThreadType::DEFAULT,
+      base::test::TaskEnvironment::ThreadPoolExecutionMode::QUEUED};
+  base::ScopedTempDir temp_dir_;
+  std::unique_ptr<base::ScopedPathOverride> cache_override_;
+  GlobalFeatures* instance_ = nullptr;
+
+  std::unique_ptr<CobaltHangWatcherDelegate> delegate_;
+};
+
+TEST_F(HangWatcherDelegateImplTest, IsHangReportingEnabled_Default) {
+  // Should default to base::FeatureList value (which we can't easily mock here,
+  // but it shouldn't crash).
+  delegate_->IsHangReportingEnabled();
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       IsHangReportingEnabledReturnsValueFromGlobalSettings) {
+  instance_->SetSettings("EnableHangReporting", int64_t(1));
+  EXPECT_TRUE(delegate_->IsHangReportingEnabled());
+
+  instance_->SetSettings("EnableHangReporting", int64_t(0));
+  EXPECT_FALSE(delegate_->IsHangReportingEnabled());
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetHangWatchTimeReturnsValueFromGlobalSettings) {
+  instance_->SetSettings("HangWatchTimeSeconds", int64_t(15));
+
+  auto timeout = delegate_->GetHangWatchTime();
+  ASSERT_TRUE(timeout.has_value());
+  EXPECT_EQ(timeout->InSeconds(), 15);
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       GetHangWatchMonitoringPeriodReturnsValueFromGlobalSettings) {
+  instance_->SetSettings("HangWatchMonitoringPeriodSeconds", int64_t(8));
+  auto period = delegate_->GetHangWatchMonitoringPeriod();
+  ASSERT_TRUE(period.has_value());
+  EXPECT_EQ(period->InSeconds(), 8);
+}
+
+TEST_F(HangWatcherDelegateImplTest,
+       IsThreadDumpingEnabledReturnsValueFromGlobalSettings) {
+  instance_->SetSettings("EnableHangWatchIOThreadDump", int64_t(1));
+  auto io_enabled = delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kIOThread);
+  ASSERT_TRUE(io_enabled.has_value());
+  EXPECT_TRUE(*io_enabled);
+
+  instance_->SetSettings("EnableHangWatchIOThreadDump", int64_t(0));
+  io_enabled = delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kIOThread);
+  ASSERT_TRUE(io_enabled.has_value());
+  EXPECT_FALSE(*io_enabled);
+
+  instance_->SetSettings("EnableHangWatchRendererThreadDump", int64_t(1));
+  auto renderer_enabled = delegate_->IsThreadDumpingEnabled(
+      base::HangWatcher::ThreadType::kRendererThread);
+  ASSERT_TRUE(renderer_enabled.has_value());
+  EXPECT_TRUE(*renderer_enabled);
+}
+
+}  // namespace browser
+}  // namespace cobalt


### PR DESCRIPTION
This introduces dynamic, runtime configuration for base::HangWatcher
in Cobalt, allowing parameters to be tuned via JavaScript
(h5vcc.settings) without requiring a process restart or recompilation:
- The web app updates hangwatcher settings in GlobalFeatures (via web API)
- When a hangwatcher setting is updated in GlobalFeatures, hangwatcher updates its cached values of the settings by asking cobalt's hangwatcher delegate for the settings
- Cobalt's hangwatcher delegate gets its setting values from GlobalSettings
- Hangwatcher uses its cached settings when making decisions about threads it's monitoring

Parameters added:
- HangWatchTimeSeconds: Configures the timeout threshold for hang
  detection.
- HangWatchMonitoringPeriodSeconds: Configures how often the
  background thread wakes up to check for hangs.
- EnableHangWatchMainThreadDump / IOThreadDump / ThreadPoolDump /
  RendererThreadDump: Allows selectively enabling or disabling crash
  dumps for specific thread scopes.

Issue: 517626586