### PR TITLE
Fix compilation error in thread_platform.cc by including check_op.h

### DIFF
--- a/starboard/tvos/shared/thread_platform.cc
+++ b/starboard/tvos/shared/thread_platform.cc
@@ -19,6 +19,7 @@
 #include <pthread.h>
 #include <sched.h>
 
+#include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 
 namespace starboard {


### PR DESCRIPTION
Include starboard/common/check_op.h to define SB_CHECK_EQ, which is used in SetCurrentThreadPriority.

Bug: 528930301