### PR TITLE
docs: Add Cobalt 26 EAP release notes

### DIFF
--- a/cobalt/site/docs/releases/26.EAP.md
+++ b/cobalt/site/docs/releases/26.EAP.md
@@ -1,0 +1,1 @@
+Cobalt 26 is an Early Access Release (e.g., `26.eap`). Please use Cobalt 27 LTS and Starboard 18 instead.

--- a/cobalt/site/docs/releases/26.EAP.md
+++ b/cobalt/site/docs/releases/26.EAP.md
@@ -1,1 +1,3 @@
+# Cobalt 26 Early Access Program (EAP)
+
 Cobalt 26 is an Early Access Release (e.g., `26.eap`). Please use Cobalt 27 LTS and Starboard 18 instead.


### PR DESCRIPTION
Add documentation for the Cobalt 26 Early Access Program (EAP)
release. These notes clarify that Cobalt 26 is an EAP version and
advise using Cobalt 27 LTS and Starboard 18 for stable development
and deployment.

Issue: 526669766