### PR TITLE
net: Support dynamic Mojo media data pipe sizing

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -75,6 +75,10 @@ public class JavaSwitches {
   public static final String COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE =
       "CobaltDynamicMojoPipeSubresourceSize";
 
+  /** flag to tune cobalt dynamic mojo pipe sizing media size in bytes. */
+  public static final String COBALT_DYNAMIC_MOJO_PIPE_MEDIA_SIZE =
+      "CobaltDynamicMojoPipeMediaSize";
+
   /** flag to disable FontSrcLocalMatching lookup table. */
   public static final String DISABLE_FONT_SRC_LOCAL_MATCHING =
       "DisableFontSrcLocalMatching";
@@ -134,9 +138,20 @@ public class JavaSwitches {
     }
 
     StringJoiner mojoPipeParams = new StringJoiner("/");
-    if (javaSwitches.containsKey(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE)) {
-      String size = javaSwitches.get(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE).replaceAll("[^0-9]", "");
-      mojoPipeParams.add("subresource_size/" + size);
+    String subresourceSize = javaSwitches.get(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_SUBRESOURCE_SIZE);
+    if (subresourceSize != null) {
+      String size = subresourceSize.replaceAll("[^0-9]", "");
+      if (!size.isEmpty()) {
+        mojoPipeParams.add("subresource_size/" + size);
+      }
+    }
+
+    String mediaSize = javaSwitches.get(JavaSwitches.COBALT_DYNAMIC_MOJO_PIPE_MEDIA_SIZE);
+    if (mediaSize != null) {
+      String size = mediaSize.replaceAll("[^0-9]", "");
+      if (!size.isEmpty()) {
+        mojoPipeParams.add("media_size/" + size);
+      }
     }
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_COBALT_DYNAMIC_MOJO_PIPE_SIZING) || mojoPipeParams.length() > 0) {

--- a/services/network/public/cpp/features.cc
+++ b/services/network/public/cpp/features.cc
@@ -626,7 +626,13 @@ BASE_FEATURE_PARAM(int,
                    kCobaltDynamicMojoPipeSizingSubresourceSize,
                    &kCobaltDynamicMojoPipeSizing,
                    "subresource_size",
-                   128 * 1024);
+                   512 * 1024);
+
+BASE_FEATURE_PARAM(int,
+                   kCobaltDynamicMojoPipeSizingMediaSize,
+                   &kCobaltDynamicMojoPipeSizing,
+                   "media_size",
+                   512 * 1024);
 #endif  // BUILDFLAG(IS_COBALT)
 
 }  // namespace network::features

--- a/services/network/public/cpp/features.h
+++ b/services/network/public/cpp/features.h
@@ -347,6 +347,9 @@ BASE_DECLARE_FEATURE(kCobaltDynamicMojoPipeSizing);
 
 COMPONENT_EXPORT(NETWORK_CPP_FLAGS_AND_SWITCHES)
 BASE_DECLARE_FEATURE_PARAM(int, kCobaltDynamicMojoPipeSizingSubresourceSize);
+
+COMPONENT_EXPORT(NETWORK_CPP_FLAGS_AND_SWITCHES)
+BASE_DECLARE_FEATURE_PARAM(int, kCobaltDynamicMojoPipeSizingMediaSize);
 #endif  // BUILDFLAG(IS_COBALT)
 
 }  // namespace network::features

--- a/services/network/url_loader.cc
+++ b/services/network/url_loader.cc
@@ -1193,9 +1193,16 @@ void URLLoader::ContinueOnResponseStarted() {
                          base::StartsWith(mime, "audio/", base::CompareCase::SENSITIVE) ||
                          mime == "application/vnd.yt-ump");
     }
-    if (!is_media_stream && base::FeatureList::IsEnabled(features::kCobaltDynamicMojoPipeSizing)) {
-      options.capacity_num_bytes = static_cast<uint32_t>(
-          features::kCobaltDynamicMojoPipeSizingSubresourceSize.Get());
+    if (base::FeatureList::IsEnabled(features::kCobaltDynamicMojoPipeSizing)) {
+      int configured_size = is_media_stream
+                                ? features::kCobaltDynamicMojoPipeSizingMediaSize.Get()
+                                : features::kCobaltDynamicMojoPipeSizingSubresourceSize.Get();
+      if (configured_size > 0) {
+        options.capacity_num_bytes = static_cast<uint32_t>(configured_size);
+      } else {
+        options.capacity_num_bytes = GetDataPipeDefaultAllocationSize(
+            DataPipeAllocationSize::kLargerSizeIfPossible);
+      }
     } else {
       options.capacity_num_bytes = GetDataPipeDefaultAllocationSize(
           DataPipeAllocationSize::kLargerSizeIfPossible);


### PR DESCRIPTION
Introduce a specific capacity configuration for Mojo data pipes used
by media streams. This allows Cobalt to independently tune the
buffer sizes for media versus other subresources, optimizing
memory usage and throughput based on the content type.

Additionally, the default subresource pipe size is increased to
512 KB to improve general loading performance, and Android system
switches are updated to support the new media size parameter.

This PR is a follow-up by https://github.com/youtube/cobalt/pull/10791.

Issue: 520888239