### PR TITLE
Add initial .github/AUTOROLL file.

### DIFF
--- a/.github/AUTOROLL
+++ b/.github/AUTOROLL
@@ -1,0 +1,1 @@
+7025ca2b8cdecc96ecbefb4353ebb6b49ce50425


### PR DESCRIPTION
Used for tracking autoroll start commit.

Bug: 522987128