### PR TITLE
Refactor autoroller to dynamically update start.

### DIFF
--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -7,10 +7,7 @@ import re
 import subprocess
 import sys
 
-_SKIP_LIST = {
-    '27.lts': [],
-    'staging': [],
-}
+_AUTOROLL_FILE = '.github/AUTOROLL'
 
 
 @enum.unique
@@ -22,6 +19,10 @@ class CherryPickStatus(enum.Enum):
   FAILED = 'failed'  # The cherry-pick failed due to conflicts or other errors.
 
 
+def log(msg):
+  print(msg, file=sys.stderr)
+
+
 def run(cmd):
   subprocess.run(cmd, check=True, stdout=sys.stderr)
 
@@ -31,50 +32,40 @@ def get_out(cmd):
   return res.stdout
 
 
-def get_commits(source, target, start):
-  """Returns a list of commit lines in chronological order.
+def get_start_commit(target):
+  """Returns a start commit hash or None if CONFLICTED."""
+  start = get_out(['git', 'show', f'{target}:{_AUTOROLL_FILE}']).strip()
 
-  Retrieves commits that are present on the source branch but not on the target
-  branch, optionally starting from a specific commit.
+  if start.startswith('CONFLICTED:'):
+    return None
+  return start
+
+
+def get_commits(source, target):
+  """Returns a list of commits in chronological order or None if CONFLICTED.
+
+  Retrieves commits that are on the source branch but not on the target branch.
+  Uses the target branch's AUTOROLL file as the non-inclusive starting commit.
+  Commits are represented as a (sha, title, pr_num) tuple.
   """
+  start = get_start_commit(target)
+  if start is None:
+    return None
+
   cmd = [
-      'git', 'rev-list', '--oneline', '--no-abbrev-commit', '--reverse', source,
-      f'^{target}'
+      'git', 'rev-list', '--oneline', '--no-abbrev-commit', '--reverse',
+      f'{start}^..{source}'
   ]
-  if start:
-    cmd.append(f'{start}^..{source}')
-  return get_out(cmd).splitlines()
+  lines = get_out(cmd).splitlines()
 
-
-def get_change_id_set(branch, exclude_branch, identifier_type):
-  """Returns a set of change IDs that have been merged into the branch.
-
-  Excludes any changes that exist on the exclude_branch. Automatically accounts
-  for reverted cherry-picks.
-  """
-  if identifier_type == 'pr':
-    pattern = r'Cherry pick PR #(\d+)'
-  else:
-    pattern = r'Cherry pick commit ([0-9a-fA-F]{4,40})'
-
-  change_ids = set()
-  conflicted_change_ids = set()
-  cmd = ['git', 'log', '--reverse', '--format=%s', branch, f'^{exclude_branch}']
-  subjects = get_out(cmd).splitlines()
-  for subject in subjects:
-    match = re.search(fr'^(Revert\s+[\'"]?)?(Conflicted )?{pattern}:', subject)
+  commits = []
+  for line in lines:
+    # match.groups() returns (sha, title, pr_num)
+    # If no PR number is found, pr_num will be None
+    match = re.search(r'^(\w+) (.*?)(?: \(#(\d+)\))?$', line)
     if match:
-      revert, conflicted, change_id = match.groups()
-      if revert:
-        if conflicted:
-          conflicted_change_ids.discard(change_id)
-        else:
-          change_ids.discard(change_id)
-      elif conflicted:
-        conflicted_change_ids.add(change_id)
-      else:
-        change_ids.add(change_id)
-  return change_ids, conflicted_change_ids
+      commits.append(match.groups())
+  return commits
 
 
 def get_unmerged_files():
@@ -91,12 +82,12 @@ def get_unmerged_files():
   for line in lines:
     parts = line.split('\t', 1)
     if len(parts) < 2:
-      print(f'Warning: Malformed line (missing tab): {line}', file=sys.stderr)
+      log(f'Warning: Malformed line (missing tab): {line}')
       continue
     metadata, path = parts
     meta_parts = metadata.split()
     if len(meta_parts) < 3:
-      print(f'Warning: Malformed metadata: {metadata}', file=sys.stderr)
+      log(f'Warning: Malformed metadata: {metadata}')
       continue
     _, _, stage = meta_parts[:3]
     stage_name = stage_map.get(stage, stage)
@@ -104,7 +95,7 @@ def get_unmerged_files():
   return files
 
 
-def resolve_conflicts(unmerged):
+def resolve_conflicts(unmerged_files):
   """Attempts to resolve conflicts automatically.
 
   Returns:
@@ -112,30 +103,25 @@ def resolve_conflicts(unmerged):
   """
   deleted_by_us = []
   other_conflicts = []
-  for path, stages in unmerged.items():
+  for path, stages in unmerged_files.items():
     if 'theirs' in stages and 'ours' not in stages:
       deleted_by_us.append(path)
     else:
       other_conflicts.append(path)
 
   if other_conflicts:
-    print(
-        f'Cannot resolve conflicts autonomously. Other conflicts: '
-        f'{other_conflicts}',
-        file=sys.stderr)
+    log(f'Cannot resolve conflicts: {other_conflicts}')
     return False
 
   if deleted_by_us:
-    print(
-        f"Resolving 'deleted by us' conflicts: {deleted_by_us}",
-        file=sys.stderr)
+    log(f'Resolving \'deleted by us\' conflicts: {deleted_by_us}')
     run(['git', 'rm', '--'] + deleted_by_us)
     return True
 
   return False
 
 
-def cherry_pick(sha, num, title, first_cherry_pick):
+def cherry_pick(sha, title, pr_num, first_cherry_pick):
   """Attempts to cherry-pick a single commit.
 
   Returns:
@@ -144,6 +130,7 @@ def cherry_pick(sha, num, title, first_cherry_pick):
       - CONFLICTED: Cherry-picked and committed with conflicts.
       - SKIPPED: The commit was already present or no action was needed.
       - FAILED: The cherry-pick failed due to conflicts or other errors.
+    unmerged_files: List of files with conflicts.
   """
   log_output = get_out(
       ['git', 'log', '-1', '--format=%ad%x00%an <%ae>%x00%b', sha])
@@ -153,9 +140,9 @@ def cherry_pick(sha, num, title, first_cherry_pick):
   body = parts[2] if len(parts) > 2 else ''
 
   body_section = f'{body}\n\n' if body else ''
-  if num is not None:
-    msg = (f'Cherry pick PR #{num}: {title}\n\n'
-           f'Refer to original PR: #{num}\n\n'
+  if pr_num is not None:
+    msg = (f'Cherry pick PR #{pr_num}: {title}\n\n'
+           f'Refer to original PR: #{pr_num}\n\n'
            f'{body_section}'
            f'(cherry picked from commit {sha})')
   else:
@@ -170,99 +157,96 @@ def cherry_pick(sha, num, title, first_cherry_pick):
     cmd.append('--mainline=1')
 
   result = CherryPickStatus.SUCCESS
+  unmerged_files = None
   try:
     run(cmd + [sha])
   except subprocess.CalledProcessError:
-    unmerged = get_unmerged_files()
-    if not resolve_conflicts(unmerged):
+    unmerged_files = get_unmerged_files()
+    if resolve_conflicts(unmerged_files):
+      unmerged_files = None
+    else:
+      unmerged_files = list(unmerged_files)
+
       if not first_cherry_pick:
         run(['git', 'reset', '--hard', 'HEAD'])
-        return CherryPickStatus.FAILED
+        return CherryPickStatus.FAILED, unmerged_files
 
-      msg = f'Conflicted {msg}'
-      run(['git', 'add', '--sparse'] + list(unmerged))
+      run(['git', 'add', '--sparse'] + unmerged_files)
+      msg = f'CONFLICTED {msg}'
       result = CherryPickStatus.CONFLICTED
 
-  # Check if there are changes to commit.
-  res = subprocess.run(['git', 'diff', '--quiet', '--cached'], check=False)
+  # Check if there are changes to commit
+  cmd = ['git', 'diff', '--quiet', '--cached']
+  res = subprocess.run(cmd, check=False)
   if res.returncode == 0:
-    print('Cherry pick skipped.', file=sys.stderr)
-    return CherryPickStatus.SKIPPED
+    log('Cherry pick skipped.')
+    return CherryPickStatus.SKIPPED, unmerged_files
+
+  # Update autoroll file
+  with open(_AUTOROLL_FILE, 'w', encoding='utf-8') as f:
+    if result == CherryPickStatus.CONFLICTED:
+      f.write(f'CONFLICTED:{sha}\n')
+    else:
+      f.write(f'{sha}\n')
+  run(['git', 'add', '--sparse', _AUTOROLL_FILE])
 
   cmd = [
       'git', 'commit', '--no-verify', f'--author={author}', f'--date={date}',
       '-m', msg
   ]
   run(cmd)
-  return result
+  return result, unmerged_files
 
 
 def main():
   p = argparse.ArgumentParser()
   p.add_argument('--source-branch', required=True)
   p.add_argument('--target-branch', required=True)
-  p.add_argument('--start-commit')
-  p.add_argument('--max-commits', type=int, default=1000)
+  p.add_argument('--max-commits', type=int, required=True)
   p.add_argument('--identifier-type', required=True)
   args = p.parse_args()
 
-  # All cherry picked changes in target branch since the branch point.
-  target_change_ids, _ = get_change_id_set(args.target_branch,
-                                           args.source_branch,
-                                           args.identifier_type)
-  # All cherry picked changes in autoroll branch since the branch point.
-  autoroll_change_ids, autoroll_conflicted_change_ids = get_change_id_set(
-      'HEAD', args.source_branch, args.identifier_type)
+  # Commits in source but not in target
+  commits_to_target = get_commits(args.source_branch, args.target_branch)
+  # Commits in source but not in autoroll
+  commits_to_autoroll = get_commits(args.source_branch, 'HEAD')
+
+  if commits_to_autoroll is None:
+    log('Autoroll branch has unresolved CONFLICTED cherry pick.')
+    return
+
+  # SHAs in source but not in autoroll
+  shas_to_autoroll = {sha for sha, _, _ in commits_to_autoroll}
+
   commits_added = []
 
-  # All commits in source branch and not in target branch (all commits
-  # since the branch point).
-  for line in get_commits(args.source_branch, args.target_branch,
-                          args.start_commit):
+  for sha, title, pr_num in commits_to_target:
     if len(commits_added) >= args.max_commits:
-      print(f"Reached commit limit ({args.max_commits}).", file=sys.stderr)
+      log(f'Reached commit limit ({args.max_commits}).')
       break
 
-    match = re.search(r'^(\w+) (.*?)(?: \(#(\d+)\))?$', line)
-    if match:
-      sha, title, pr_num = match.groups()
+    identifier = f'- #{pr_num}' if args.identifier_type == 'pr' else f'- {sha}'
 
-      # Skip if in skip list.
-      if sha in _SKIP_LIST.get(args.target_branch, []):
-        continue
+    # Skip if already in autoroll
+    if sha not in shas_to_autoroll:
+      commits_added.append(identifier)
+      continue
 
-      if args.identifier_type == 'pr':
-        change_id = pr_num
-        prefix = '#'
-      else:
-        change_id = sha
-        prefix = ''
+    # Cherry pick PR
+    first_cherry_pick = not commits_added
+    result, unmerged_files = cherry_pick(sha, title, pr_num, first_cherry_pick)
 
-      # Skip if in target branch.
-      if change_id in target_change_ids:
-        continue
-
-      # Skip if in autoroll branch.
-      if change_id in autoroll_change_ids:
-        commits_added.append(f'- {prefix}{change_id}')
-        continue
-
-      # Break if in autoroll branch as conflicted.
-      if change_id in autoroll_conflicted_change_ids:
-        print(f"Reached conflicted cherry pick ({sha}).", file=sys.stderr)
-        break
-
-      # Cherry pick PR.
-      first_cherry_pick = not commits_added
-      result = cherry_pick(sha, pr_num, title, first_cherry_pick)
+    if result in (CherryPickStatus.SUCCESS, CherryPickStatus.CONFLICTED):
+      commits_added.append(identifier)
       if result == CherryPickStatus.CONFLICTED:
-        commits_added.append('CONFLICTED:')
-      if result in (CherryPickStatus.SUCCESS, CherryPickStatus.CONFLICTED):
-        autoroll_change_ids.add(change_id)
-        commits_added.append(f'- {prefix}{change_id}')
-      if result in (CherryPickStatus.FAILED, CherryPickStatus.CONFLICTED):
-        print(f"Reached conflicted cherry pick ({sha}).", file=sys.stderr)
-        break
+        commits_added.append('CONFLICTED files:')
+        commits_added.append('```')
+        commits_added.extend(unmerged_files)
+        commits_added.append('```')
+
+    if result in (CherryPickStatus.FAILED, CherryPickStatus.CONFLICTED):
+      log(f'Reached CONFLICTED cherry pick ({sha}).')
+      break
 
   if commits_added:
     print('\n'.join(commits_added))

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -32,29 +32,24 @@ def get_out(cmd):
   return res.stdout
 
 
-def get_start_commit(target):
-  """Returns a start commit hash or None if CONFLICTED."""
-  start = get_out(['git', 'show', f'{target}:{_AUTOROLL_FILE}']).strip()
+def get_start_sha(branch):
+  """Returns an autoroll start SHA or None if CONFLICTED."""
+  start = get_out(['git', 'show', f'{branch}:{_AUTOROLL_FILE}']).strip()
 
   if start.startswith('CONFLICTED:'):
     return None
   return start
 
 
-def get_commits(source, target):
-  """Returns a list of commits in chronological order or None if CONFLICTED.
+def get_commits(branch, start):
+  """Returns a list of commits in chronological order.
 
-  Retrieves commits that are on the source branch but not on the target branch.
-  Uses the target branch's AUTOROLL file as the non-inclusive starting commit.
-  Commits are represented as a (sha, title, pr_num) tuple.
+  Starting from the non-inclusive start, the commits are represented as a
+  (sha, title, pr_num) tuple.
   """
-  start = get_start_commit(target)
-  if start is None:
-    return None
-
   cmd = [
       'git', 'rev-list', '--oneline', '--no-abbrev-commit', '--reverse',
-      f'{start}^..{source}'
+      f'{start}^..{branch}'
   ]
   lines = get_out(cmd).splitlines()
 
@@ -206,15 +201,16 @@ def main():
   p.add_argument('--identifier-type', required=True)
   args = p.parse_args()
 
-  # Commits in source but not in target
-  commits_to_target = get_commits(args.source_branch, args.target_branch)
-  # Commits in source but not in autoroll
-  commits_to_autoroll = get_commits(args.source_branch, 'HEAD')
-
-  if commits_to_autoroll is None:
-    log('Autoroll branch has unresolved CONFLICTED cherry pick.')
+  target_start = get_start_sha(args.target_branch)
+  autoroll_start = get_start_sha('HEAD')
+  if autoroll_start is None:
+    log('Autoroll branch has an unresolved CONFLICTED cherry pick.')
     return
 
+  # Commits in source but not in target
+  commits_to_target = get_commits(args.source_branch, target_start)
+  # Commits in source but not in autoroll
+  commits_to_autoroll = get_commits(args.source_branch, autoroll_start)
   # SHAs in source but not in autoroll
   shas_to_autoroll = {sha for sha, _, _ in commits_to_autoroll}
 

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -198,7 +198,6 @@ def main():
   p.add_argument('--source-branch', required=True)
   p.add_argument('--target-branch', required=True)
   p.add_argument('--max-commits', type=int, required=True)
-  p.add_argument('--identifier-type', required=True)
   args = p.parse_args()
 
   target_start = get_start_sha(args.target_branch)
@@ -221,7 +220,7 @@ def main():
       log(f'Reached commit limit ({args.max_commits}).')
       break
 
-    identifier = f'- #{pr_num}' if args.identifier_type == 'pr' else f'- {sha}'
+    identifier = f'- #{pr_num}' if pr_num else f'- {sha}'
 
     # Skip if already in autoroll
     if sha not in shas_to_autoroll:

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         branch: [
-          {source: main, target: 27.lts, identifier_type: pr},
-          {source: main, target: staging, identifier_type: pr},
+          {source: main, target: 27.lts},
+          {source: main, target: staging},
         ]
     steps:
       - name: Checkout code
@@ -80,8 +80,7 @@ jobs:
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
             --source-branch "${{ matrix.branch.source }}" \
             --target-branch "${{ matrix.branch.target }}" \
-            --max-commits "${{ env.MAX_COMMITS }}" \
-            --identifier-type "${{ matrix.branch.identifier_type }}")
+            --max-commits "${{ env.MAX_COMMITS }}")
 
           if [[ -n "${PR_LINKS}" ]]; then
             echo "cherry_picked=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -23,8 +23,8 @@ jobs:
       fail-fast: false
       matrix:
         branch: [
-          {source: main, target: 27.lts, start_commit: 7da7391967914a586724a107102c06d0f81280b5, identifier_type: pr},
-          {source: main, target: staging, start_commit: 7da7391967914a586724a107102c06d0f81280b5, identifier_type: pr},
+          {source: main, target: 27.lts, identifier_type: pr},
+          {source: main, target: staging, identifier_type: pr},
         ]
     steps:
       - name: Checkout code
@@ -80,7 +80,6 @@ jobs:
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
             --source-branch "${{ matrix.branch.source }}" \
             --target-branch "${{ matrix.branch.target }}" \
-            --start-commit "${{ matrix.branch.start_commit }}" \
             --max-commits "${{ env.MAX_COMMITS }}" \
             --identifier-type "${{ matrix.branch.identifier_type }}")
 
@@ -117,11 +116,11 @@ jobs:
             echo "${PR_LINKS}"
           } > "${PR_BODY_FILE}"
 
-          if [[ "${PR_LINKS}" == CONFLICTED:* ]]; then
+          if [[ -f .github/AUTOROLL ]] && grep -q "^CONFLICTED:" .github/AUTOROLL; then
             PR_TITLE="CONFLICTED: ${PR_TITLE}"
             {
               echo ""
-              echo "⚠️ This PR has conflicts that must be resolved manually. Use the following commands to check out the branch locally and resolve the conflicts in a separate commit:"
+              echo "⚠️ This PR has conflicts that must be resolved manually (don't forget the .github/AUTOROLL file). Use the following commands to check out the branch locally and resolve the conflicts in a separate commit:"
               echo '```bash'
               echo "gh pr checkout \${PR_NUMBER} -R ${{ github.repository }}"
               echo "git commit -a"


### PR DESCRIPTION
Rather than a hard coded start commit combined with potentially brittle commit title parsing to determine which commits to autoroll, utilize a dyanmically updated start commit stored in .github/AUTOROLL.

Bug: 522987128