### PR TITLE
android: Skip service cleanup on activity destroy if another instance is active

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java
@@ -199,6 +199,14 @@ public class StarboardBridge {
   }
 
   protected void onActivityDestroy(Activity activity) {
+    // Note: During rapid restarts or configuration changes, Android allows a new Activity instance's
+    // onCreate()/onStart() to run before the old instance's onDestroy() executes. When that happens,
+    // mActivityHolder will already point to the new activity instance. We must avoid cleaning up
+    // shared platform services or killing the process if another active instance has taken over.
+    if (mActivityHolder.get() != activity && mActivityHolder.get() != null) {
+      Log.i(TAG, "Activity destroyed but another activity is active; skipping service cleanup.");
+      return;
+    }
     closeAllCobaltService();
     if (mApplicationStopped) {
       // We can't restart the starboard app, so kill the process for a clean start next time.


### PR DESCRIPTION
During rapid restarts or configuration changes, a new activity instance's
onCreate() and onStart() can run before the previous instance's onDestroy().
If the old activity's onDestroy() then executes, it previously called
closeAllCobaltService() and potentially terminated the application process, even
though the newly launched activity instance was actively relying on those shared
services.

This change guards StarboardBridge.onActivityDestroy() to verify whether the
dying activity is still the active holder before closing platform services or
killing the application.

Bug: 528367182
TAG=agy
CONV=1af8f0dc-11ee-4286-8e16-d02d06cf0b7b