### PR TITLE
infra: Update CODEOWNERS for h5vcc_settings and CODEOWNERS file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,7 @@
 /third_party/blink/renderer/platform/media/ @youtube/cobalt-media
 
 /.github/ # no owners
+/.github/CODEOWNERS @youtube/cobalt-3p-repository-owners
 /cobalt/  # no default owners
 /cobalt/android  @youtube/cobalt-androidtv
 /cobalt/app      @youtube/cobalt-embedder-owners
@@ -36,6 +37,8 @@
 /cobalt/build/gn.py @youtube/cobalt-build
 
 /third_party/blink/ @youtube/cobalt-web-api
+# media team runs experiments through h5vcc settings.
+/third_party/blink/renderer/modules/cobalt/h5vcc_settings/ @youtube/cobalt-web-api @youtube/cobalt-media
 
 *.nplb_filter.json @youtube/nplb-filters
 /starboard/contrib/rdk @youtube/starboard-rdk-owners


### PR DESCRIPTION
This PR sets explicit ownership of .github/CODEOWNERS to @youtube/cobalt-3p-repository-owners. Previously, CODEOWNERS file iself has no ownernship

Additionally, this PR adds the cobalt-media team as co-owners of the h5vcc_settings Blink
module. The media team runs experiments through these settings, so
this change allows them to manage the ownership and review process
for this directory.


Issue: 529445724