### PR TITLE
docs: Fix parsing literals and diagrams in docsite gen

### DIFF
--- a/cobalt/site/scripts/cobalt_module_reference.py
+++ b/cobalt/site/scripts/cobalt_module_reference.py
@@ -213,6 +213,17 @@ def _node_to_markdown(out, node):
     assert len(node) == 0
     # Don't replace pipes in verbatim text.
     text = node.text if node.text else ''
+    # Strip doxygen comment prefix '///' and one space if present
+    lines = text.split('\n')
+    cleaned_lines = []
+    for line in lines:
+      if line.startswith('/// '):
+        cleaned_lines.append(line[4:])
+      elif line.startswith('///'):
+        cleaned_lines.append(line[3:])
+      else:
+        cleaned_lines.append(line)
+    text = '\n'.join(cleaned_lines)
     out.code_block(text)
     text = ''
   else:

--- a/cobalt/site/scripts/cobalt_module_reference.py
+++ b/cobalt/site/scripts/cobalt_module_reference.py
@@ -175,9 +175,11 @@ def _node_to_markdown(out, node):
   elif node.tag == 'bold':
     assert len(node) == 0
     out.bold(text)
+    text = ''
   elif node.tag == 'computeroutput':
     assert len(node) == 0
     out.code(text)
+    text = ''
   elif node.tag == 'ulink':
     url = node.get('url')
     assert url

--- a/cobalt/site/scripts/doxygen.py
+++ b/cobalt/site/scripts/doxygen.py
@@ -92,12 +92,65 @@ def _doxygenate_line(line):
   return indent + '/' + stripped
 
 
+def _is_empty_comment(line):
+  """Checks if a line is an empty comment line."""
+  stripped = line.strip()
+  return stripped == '//' or stripped == '///' or not stripped
+
+
 def _doxygenate_lines(lines):
   """Makes a list of comment lines visible to Doxygen."""
   if not lines:
     return []
   indent, _ = _split(lines[0])
-  return [_doxygenate_line(x) for x in lines] + [indent + '///']
+
+  # Split lines into sub-blocks separated by empty comment lines
+  sub_blocks = []
+  current_block = []
+
+  for line in lines:
+    if _is_empty_comment(line):
+      if current_block:
+        sub_blocks.append(('block', current_block))
+        current_block = []
+      sub_blocks.append(('separator', line))
+    else:
+      current_block.append(line)
+  if current_block:
+    sub_blocks.append(('block', current_block))
+
+  output_lines = []
+  for block_type, val in sub_blocks:
+    if block_type == 'separator':
+      output_lines.append(_doxygenate_line(val))
+    else:
+      # Check if the block is a diagram based on the first line's indentation
+      is_diagram = False
+      if val:
+        _, stripped = _split(val[0])
+        if stripped.startswith('///'):
+          content = stripped[3:]
+        elif stripped.startswith('//'):
+          content = stripped[2:]
+        else:
+          content = stripped
+        if content.startswith('    '):
+          is_diagram = True
+
+      doxygenated_block = [_doxygenate_line(l) for l in val]
+      if is_diagram:
+        # Wrap in verbatim, but only if it doesn't already contain verbatim tags
+        block_text = '\n'.join(val)
+        if '@verbatim' not in block_text and '\\verbatim' not in block_text:
+          output_lines.append(indent + '/// \\verbatim')
+          output_lines.extend(doxygenated_block)
+          output_lines.append(indent + '/// \\endverbatim')
+        else:
+          output_lines.extend(doxygenated_block)
+      else:
+        output_lines.extend(doxygenated_block)
+
+  return output_lines + [indent + '///']
 
 
 def _is_comment(line):

--- a/cobalt/site/scripts/markdown_writer.py
+++ b/cobalt/site/scripts/markdown_writer.py
@@ -184,14 +184,17 @@ class MarkdownWriter(object):
     if wrap:
       contents = contents.strip()
       if self.current_line and self.current_line[-1] != ' ':
-        contents = ' ' + contents
+        if self.current_line[-1] not in ['(', '[', '{']:
+          if contents[0] not in ['.', ',', ';', ':', ')', ']', '}', '?', '!']:
+            contents = ' ' + contents
       if not contents:
         return
       current_line_length = len(self.current_line)
       contents = textwrap.fill(
           self.current_line + contents,
           self._get_wrap_width(),
-          break_long_words=False)
+          break_long_words=False,
+          break_on_hyphens=False)
       contents = contents[current_line_length:]
 
     lines = contents.split('\n')


### PR DESCRIPTION
Multiple small issues are fixed in this PR namely:
* Repeated literals when multiple replacements happened inline
* Bad linebreak placements for kebab-case words
* Incorrect diagram and text paragraph differentiation

Bug: 505097004