### PR TITLE
Add Cobalt 27 RC Release Notes

### DIFF
--- a/cobalt/site/docs/releases/27.LTS.1.md
+++ b/cobalt/site/docs/releases/27.LTS.1.md
@@ -53,7 +53,7 @@ Cobalt 27 provides a fully modernized, standards-compliant web platform. This sh
 This reduced Starboard APIs from 273 (Starboard 15) to 117 (Starboard 18).
 
 *   [starboard/doc/starboard_posix.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/doc/starboard_posix.md)
-*   See comprehensive list of changes in ([starboard/CHANGELOG.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/CHANGELOG.md))
+*   See the comprehensive list of changes in [starboard/CHANGELOG.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/CHANGELOG.md).
 
 ### Why POSIX API Adoption Matters:
 

--- a/cobalt/site/docs/releases/27.LTS.1.md
+++ b/cobalt/site/docs/releases/27.LTS.1.md
@@ -36,7 +36,7 @@ Migration guide from Cobalt 25 to Cobalt 27 is available here:
 
 ## A Modern Chromium & Blink Engine
 
-Cobalt 27 provides a fully modernized, standards-compliant web platform. This shift brings robust, cutting-edge web technologies directly to Cobalt devices bringing richer user experiences.
+Cobalt 27 provides a fully modernized, standards-compliant web platform. This shift brings robust, cutting-edge web technologies directly to Cobalt devices, enabling richer user experiences.
 
 ### Key Benefits of the Blink Engine Transition:
 

--- a/cobalt/site/docs/releases/27.LTS.1.md
+++ b/cobalt/site/docs/releases/27.LTS.1.md
@@ -50,7 +50,7 @@ Cobalt 27 provides a fully modernized, standards-compliant web platform. This sh
 
 ## Starboard 18
 
-Starboard has undergone a massive simplification. Bespoke, proprietary Starboard APIs (e.g., `SbMemory*`, `SbThread*`, `SbSocket*`, `SbFile*`) have been phased out and replaced with standard POSIX APIs already available on platforms. This reduced Starboard APIs from 273 (Starboard 15) vs 117 (Starboard 18).
+This reduced Starboard APIs from 273 (Starboard 15) to 117 (Starboard 18).
 
 *   [starboard/doc/starboard_posix.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/doc/starboard_posix.md)
 *   See comprehensive list of changes in ([starboard/CHANGELOG.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/CHANGELOG.md))

--- a/cobalt/site/docs/releases/27.LTS.1.md
+++ b/cobalt/site/docs/releases/27.LTS.1.md
@@ -1,0 +1,89 @@
+Project: /youtube/cobalt/_project.yaml
+Book: /youtube/cobalt/_book.yaml
+
+# Cobalt 27 RC (Release Candidate)
+
+The Cobalt team has published **Cobalt 27 RC (Release Candidate)** including **Starboard API version 18** to the [27.lts](https://github.com/youtube/cobalt/tree/27.lts) branch with tag [27.lts.1](https://github.com/youtube/cobalt/tree/27.lts.1) (`27.lts.1.1040201`).
+
+* [cobalt/CHANGELOG.md](https://github.com/youtube/cobalt/blob/27.lts/cobalt/CHANGELOG.md)
+* [starboard/CHANGELOG.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/CHANGELOG.md)
+
+Corresponding Evergreen binaries are available on [GitHub at the 27.lts.1 Release tag](https://github.com/youtube/cobalt/releases/tag/27.lts.1)
+
+*   **NOTE:** We are expecting to release on a periodic cadence (barring any blockers) leading up to LTS Stable for faster development.
+
+Cobalt 27 represents the most significant architectural evolution in Cobalt's history. By transitioning the core engine from a custom web runtime to a fully-fledged Chromium fork based on M138, **Cobalt 27 brings modern, next-generation features, performance, and developer experience to Cobalt-powered devices**.
+
+This release also marks a major milestone in platform portability. **Starboard 18 consolidates the transition to standard POSIX APIs, replacing over a hundred proprietary Starboard functions with industry-standard calls.** This dramatically simplifies porting, shortening the timeline for bringing Cobalt to new devices from months to just weeks, saving significant engineering, testing, and operational resources.
+
+### Available Reference Ports:
+
+*   **Desktop Linux**
+*   **RDK** (`starboard/contrib/rdk`)
+*   **Android (AOSP)**
+    *   Coming with 27.lts.2 RC release
+    *   Preview available on tip of [27.lts](https://github.com/youtube/cobalt/tree/27.lts) branch
+
+Migration guide from Cobalt 25 to Cobalt 27 is available here:
+
+*   [starboard/doc/eap/25_to_27.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/doc/eap/25_to_27.md)
+
+**IMPORTANT NOTE:** As this version is a RC (Release Candidate), the code is subject to change. Only the Starboard API is frozen. **This is ready for integration and we STRONGLY RECOMMEND you start integration of this Cobalt 27 LTS RC on your respective platforms early and report issues ASAP** so there is ample time to investigate and resolve any detected issues before Cobalt 27 LTS Stable Release later this year.
+
+*   For the latest changes, the code at tip in [27.lts](https://github.com/youtube/cobalt/tree/27.lts) is always available, but is under development and may be unstable.
+
+---
+
+## A Modern Chromium & Blink Engine
+
+Cobalt 27 provides a fully modernized, standards-compliant web platform. This shift brings robust, cutting-edge web technologies directly to Cobalt devices bringing richer user experiences.
+
+### Key Benefits of the Blink Engine Transition:
+
+*   **Rich WebGL Capabilities:** Full support for standard WebGL opens up advanced 2D and 3D graphics capabilities able to render complex visual effects, highly interactive UI layouts, and immersive animations with hardware-accelerated graphics performance.
+*   **Standards Compliance:** Developers can target modern Web APIs with confidence. The transition enables modern CSS layouts, advanced JS features, and full compliance with standard Web APIs, making it easier and faster for Cobalt developers to deploy new features.
+*   **V8 Performance Boost:** By running the latest V8 JavaScript engine, complex JavaScript animations and app state transitions execute faster and more efficiently.
+*   **Ozone and Graphics Integration:** Window and graphics subsystems now leverage the Chromium Ozone framework. GPU rasterization and compositing are fully handled by Blink's pipeline via standard OpenGL ES 2.0 calls.
+*   **Fully Featured DevTools (Available on non-gold builds):** You can now debug Cobalt applications using the standard Chrome DevTools interface out-of-the-box. Simply launch a build, navigate to `chrome://inspect` on a desktop Chrome browser on the same network, and inspect the running app with access to the DOM tree, performance profilers, console, and network analyzers. This replaces the limited, custom debugging tools of the past.
+
+---
+
+## Starboard 18
+
+Starboard has undergone a massive simplification. Bespoke, proprietary Starboard APIs (e.g., `SbMemory*`, `SbThread*`, `SbSocket*`, `SbFile*`) have been phased out and replaced with standard POSIX APIs already available on platforms. This reduced Starboard APIs from 273 (Starboard 15) vs 117 (Starboard 18).
+
+*   [starboard/doc/starboard_posix.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/doc/starboard_posix.md)
+*   See comprehensive list of changes in ([starboard/CHANGELOG.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/CHANGELOG.md))
+
+### Why POSIX API Adoption Matters:
+
+By adopting POSIX, Cobalt integration efforts can be cut from months of development to just weeks. Porting is no longer about implementing custom wrapper functions for threading, file I/O, and sockets. Instead, developers can link their system's standard libraries (e.g., pthread, libc, openssl) directly, dramatically reducing integration time.
+
+### New Starboard APIs and Extensions ([starboard/CHANGELOG.md](https://github.com/youtube/cobalt/blob/27.lts/starboard/CHANGELOG.md)):
+
+While many Starboard APIs were removed, several new interfaces and updates were introduced to support modern media capabilities, features, and modularity:
+
+#### Starboard Changes
+
+*   **Dynamic Media Codec Switching:**
+    *   **SbMediaCanChangeType()**
+        *   Added to `media.h`. This API allows the browser to query whether the platform's media pipeline supports dynamic transitions (e.g., SourceBuffer type changes) without destroying and recreating the player instance.
+    *   **SbPlayerWriteSamples()**
+        *   Capabilities Update: Now supports writing samples with different mime-types and codecs on the fly if `SbMediaCanChangeType()` returns true.
+*   **System and Storage Updates:**
+    *   **kSbSystemPathFilesDirectory**
+        *   System Property: Introduced to define the permanent write-path for DOM localStorage and persistent cookies.
+    *   **Evergreen now uses 2-slots (instead of 3)** optimizing flash storage usage.
+*   **AV2 Video Codec Support:** Added AV2 definition to `SbMediaVideoCodec` to prepare the media stack for next-generation AV2 streams.
+
+#### New & Updated Starboard Extensions
+
+These extensions are either brand new, updated, or have had their legacy core API C headers fully removed, making the extension implementation mandatory for baseline functionality:
+
+*   **[Coming in 27.lts.2]** **Crash Handling (New Required Version 4)** - **CobaltExtensionCrashHandlerApi**
+    *   Preview available on tip of [27.lts](https://github.com/youtube/cobalt/tree/27.lts)
+    *   The platform should continue to simply wire up the provided, shared implementation of the extension at `starboard/shared/starboard/crash_handler.h` / `starboard/shared/starboard/crash_handler.cc`.
+
+### Contact Points
+
+Please contact our [support channels](https://cobalt.dev/communication.html) if you have any problems, questions, or feedback.


### PR DESCRIPTION
Adds the release notes for the Cobalt 27 Release Candidate (27.lts.1).
This release marks a major evolution in Cobalt's architecture, moving
to a Chromium-based engine (M138) and simplifying the Starboard API
by adopting POSIX standards in Starboard 18.

The documentation highlights benefits like full Blink engine support,
modern DevTools, and reduced integration time for platform ports.

Issue: 526669766