### PR TITLE
Add build config of devel for tvOS nightly

### DIFF
--- a/cobalt/devinfra/kokoro/build/tvos/arm64/devel.gcl
+++ b/cobalt/devinfra/kokoro/build/tvos/arm64/devel.gcl
@@ -1,0 +1,23 @@
+// -*- protobuffer -*-
+// proto-file: google3/devtools/kokoro/config/proto/build.proto
+// proto-message: BuildConfig
+
+import 'common.gcl' as common
+
+config build = common.build {
+  build_file = 'src/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh'
+  env_vars = super.env_vars + [
+    {
+      key = 'CONFIG'
+      value = 'devel'
+    },
+    {
+      key = 'ENABLE_RBE'
+      value = 'true'
+    },
+    {
+      key = 'GN_TARGET'
+      value = 'cobalt'
+    }
+  ]
+}


### PR DESCRIPTION
The devel config will build test artifacts to run on MH's devices.

Fix the error in the tvOS nightly build:

```
com.google.devtools.kokoro.controller.UserException: An error happened while reading and parsing the build config
...
```

Bug: 519668013