### PR TITLE
media: Add platform DRM support for tvOS EME

### DIFF
--- a/cobalt/renderer/BUILD.gn
+++ b/cobalt/renderer/BUILD.gn
@@ -44,6 +44,10 @@ source_set("renderer") {
   if (use_starboard_media) {
     deps += [ "//media/mojo/clients" ]
   }
+
+  if (use_starboard_media && is_ios && is_internal_build) {
+    deps += [ "//cobalt/internal/cobalt/components/cdm/renderer/starboard:platform_drm_key_system_info" ]
+  }
 }
 
 test("cobalt_renderer_unittests") {

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -43,6 +43,10 @@
 #include "third_party/blink/public/web/web_view.h"
 #include "ui/gfx/geometry/size_conversions.h"
 
+#if BUILDFLAG(IS_IOS_TVOS) && defined(COBALT_INTERNAL_BUILD)
+#include "cobalt/internal/cobalt/components/cdm/renderer/starboard/platform_drm_key_system_info.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS) && defined(COBALT_INTERNAL_BUILD)
+
 namespace cobalt {
 
 namespace {
@@ -426,6 +430,20 @@ void AddStarboardCmaKeySystems(::media::KeySystemInfos* key_system_infos) {
       ::media::EmeFeatureSupport::ALWAYS_ENABLED,    // Persistent state.
       ::media::EmeFeatureSupport::ALWAYS_ENABLED));  // Distinctive
                                                      // identifier.
+
+#if BUILDFLAG(IS_IOS_TVOS) && defined(COBALT_INTERNAL_BUILD)
+  const base::flat_set<::media::EncryptionScheme>
+      kPlatformDrmEncryptionSchemes = {::media::EncryptionScheme::kCbcs};
+
+  key_system_infos->push_back(std::make_unique<cdm::PlatformDrmKeySystemInfo>(
+      codecs,                                        // Regular codecs.
+      kPlatformDrmEncryptionSchemes,                 // Encryption schemes.
+      codecs,                                        // Hardware secure codecs.
+      ::media::EmeFeatureSupport::ALWAYS_ENABLED,    // Persistent state.
+      ::media::EmeFeatureSupport::ALWAYS_ENABLED));  // Distinctive
+                                                     // identifier.
+
+#endif  // BUILDFLAG(IS_IOS_TVOS) && defined(COBALT_INTERNAL_BUILD)
 }
 
 std::unique_ptr<::media::KeySystemSupportRegistration>

--- a/components/cdm/renderer/external_clear_key_key_system_info.cc
+++ b/components/cdm/renderer/external_clear_key_key_system_info.cc
@@ -68,6 +68,13 @@ bool ExternalClearKeyKeySystemInfo::IsSupportedInitDataType(
     case media::EmeInitDataType::KEYIDS:
       return true;
 
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+    // Listed for -Wswitch exhaustiveness only. External Clear Key does not
+    // support platform DRM init data types.
+    case media::EmeInitDataType::SINF:
+    case media::EmeInitDataType::SKD:
+    case media::EmeInitDataType::PLATFORM_DRM:
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
     case media::EmeInitDataType::UNKNOWN:
       return false;
   }

--- a/components/cdm/renderer/external_clear_key_key_system_info.cc
+++ b/components/cdm/renderer/external_clear_key_key_system_info.cc
@@ -68,6 +68,11 @@ bool ExternalClearKeyKeySystemInfo::IsSupportedInitDataType(
     case media::EmeInitDataType::KEYIDS:
       return true;
 
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+    // Listed for -Wswitch exhaustiveness only. External Clear Key does not
+    // support platform DRM init data types.
+    case media::EmeInitDataType::PLATFORM_DRM:
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
     case media::EmeInitDataType::UNKNOWN:
       return false;
   }

--- a/media/base/eme_constants.h
+++ b/media/base/eme_constants.h
@@ -9,6 +9,7 @@
 
 #include <optional>
 
+#include "build/build_config.h"
 #include "media/base/media_export.h"
 #include "media/media_buildflags.h"
 
@@ -21,6 +22,12 @@ enum class EmeInitDataType {
   UNKNOWN,
   WEBM,
   CENC,
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Vendor-specific platform DRM init data formats.
+  SINF,          // sinf atom key IDs
+  SKD,           // skd:// key request URI
+  PLATFORM_DRM,  // AVPlayer encrypted event payload
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
   KEYIDS,
   kMaxValue = KEYIDS,
 };

--- a/media/base/eme_constants.h
+++ b/media/base/eme_constants.h
@@ -9,6 +9,7 @@
 
 #include <optional>
 
+#include "build/build_config.h"
 #include "media/base/media_export.h"
 #include "media/media_buildflags.h"
 
@@ -21,6 +22,10 @@ enum class EmeInitDataType {
   UNKNOWN,
   WEBM,
   CENC,
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Vendor-specific platform DRM init data format.
+  PLATFORM_DRM,  // AVPlayer encrypted event payload
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
   KEYIDS,
   kMaxValue = KEYIDS,
 };

--- a/media/starboard/starboard_cdm.cc
+++ b/media/starboard/starboard_cdm.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "base/logging.h"
+#include "build/build_config.h"
 #include "starboard/common/drm.h"
 
 namespace media {
@@ -35,6 +36,14 @@ const char* GetInitDataTypeName(EmeInitDataType type) {
       return "cenc";
     case EmeInitDataType::KEYIDS:
       return "keyids";
+#if BUILDFLAG(IS_IOS_TVOS)
+    case EmeInitDataType::SINF:
+      return "sinf";
+    case EmeInitDataType::SKD:
+      return "skd";
+    case EmeInitDataType::PLATFORM_DRM:
+      return "fairplay";
+#endif  // BUILDFLAG(IS_IOS_TVOS)
     case EmeInitDataType::UNKNOWN:
       return "unknown";
   }

--- a/media/starboard/starboard_cdm.cc
+++ b/media/starboard/starboard_cdm.cc
@@ -21,6 +21,7 @@
 #include <vector>
 
 #include "base/logging.h"
+#include "build/build_config.h"
 #include "starboard/common/drm.h"
 
 namespace media {
@@ -35,6 +36,10 @@ const char* GetInitDataTypeName(EmeInitDataType type) {
       return "cenc";
     case EmeInitDataType::KEYIDS:
       return "keyids";
+#if BUILDFLAG(IS_IOS_TVOS)
+    case EmeInitDataType::PLATFORM_DRM:
+      return "fairplay";
+#endif  // BUILDFLAG(IS_IOS_TVOS)
     case EmeInitDataType::UNKNOWN:
       return "unknown";
   }

--- a/starboard/nplb/BUILD.gn
+++ b/starboard/nplb/BUILD.gn
@@ -403,5 +403,6 @@ test("nplb") {
 
   if (is_ios && target_platform == "tvos" && is_internal_build) {
     sources += internal_tvos_test_sources
+    deps += [ "//cobalt/internal/third_party/platform_drm:headers" ]
   }
 }

--- a/starboard/tvos/shared/BUILD.gn
+++ b/starboard/tvos/shared/BUILD.gn
@@ -232,6 +232,7 @@ static_library("starboard_platform") {
     sources += internal_tvos_sources
 
     deps += [
+      "//cobalt/internal/third_party/platform_drm:headers",
       "//starboard/shared/widevine:oemcrypto",
       "//third_party/internal/ce_cdm/cdm:widevine_cdm_core",
       "//third_party/internal/ce_cdm/cdm:widevine_ce_cdm_static",

--- a/starboard/tvos/shared/media/application_player.mm
+++ b/starboard/tvos/shared/media/application_player.mm
@@ -25,6 +25,14 @@
 #import "starboard/tvos/shared/media/player_manager.h"
 #import "starboard/tvos/shared/starboard_application.h"
 
+#ifdef COBALT_INTERNAL_BUILD
+#include "cobalt/internal/third_party/platform_drm/platform_drm_common.h"
+#else
+namespace starboard {
+constexpr char kPlatformDrmInitDataType[] = "";
+}  // namespace starboard
+#endif  // COBALT_INTERNAL_BUILD
+
 /**
  *  @brief The context used to track the player item through KVO.
  */
@@ -721,7 +729,8 @@ static NSTimeInterval kAccessLogTimerInterval = 1;
             [NSMutableData dataWithBytes:&urlStringDataLength
                                   length:sizeof(urlStringDataLength)];
         [initData appendData:urlStringData];
-        _encryptedMediaFunc(starboardPlayer, _playerContext, "fairplay",
+        _encryptedMediaFunc(starboardPlayer, _playerContext,
+                            starboard::kPlatformDrmInitDataType,
                             static_cast<const unsigned char*>(initData.bytes),
                             initData.length);
       }

--- a/third_party/blink/renderer/modules/encryptedmedia/encrypted_media_utils.cc
+++ b/third_party/blink/renderer/modules/encryptedmedia/encrypted_media_utils.cc
@@ -5,6 +5,7 @@
 #include "third_party/blink/renderer/modules/encryptedmedia/encrypted_media_utils.h"
 
 #include "base/notreached.h"
+#include "build/build_config.h"
 #include "media/base/eme_constants.h"
 #include "media/base/key_systems.h"
 #include "services/metrics/public/cpp/ukm_builders.h"
@@ -32,6 +33,14 @@ media::EmeInitDataType EncryptedMediaUtils::ConvertToInitDataType(
     return media::EmeInitDataType::KEYIDS;
   if (init_data_type == "webm")
     return media::EmeInitDataType::WEBM;
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+  if (init_data_type == "sinf")
+    return media::EmeInitDataType::SINF;
+  if (init_data_type == "skd")
+    return media::EmeInitDataType::SKD;
+  if (init_data_type == "fairplay")
+    return media::EmeInitDataType::PLATFORM_DRM;
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // |initDataType| is not restricted in the idl, so anything is possible.
   return media::EmeInitDataType::UNKNOWN;
@@ -47,6 +56,14 @@ String EncryptedMediaUtils::ConvertFromInitDataType(
       return "keyids";
     case media::EmeInitDataType::WEBM:
       return "webm";
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+    case media::EmeInitDataType::SINF:
+      return "sinf";
+    case media::EmeInitDataType::SKD:
+      return "skd";
+    case media::EmeInitDataType::PLATFORM_DRM:
+      return "fairplay";
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
     case media::EmeInitDataType::UNKNOWN:
       // Chromium should not use Unknown, but we use it in Blink when the
       // actual value has been blocked for non-same-origin or mixed content.

--- a/third_party/blink/renderer/modules/encryptedmedia/encrypted_media_utils.cc
+++ b/third_party/blink/renderer/modules/encryptedmedia/encrypted_media_utils.cc
@@ -5,6 +5,7 @@
 #include "third_party/blink/renderer/modules/encryptedmedia/encrypted_media_utils.h"
 
 #include "base/notreached.h"
+#include "build/build_config.h"
 #include "media/base/eme_constants.h"
 #include "media/base/key_systems.h"
 #include "services/metrics/public/cpp/ukm_builders.h"
@@ -32,6 +33,10 @@ media::EmeInitDataType EncryptedMediaUtils::ConvertToInitDataType(
     return media::EmeInitDataType::KEYIDS;
   if (init_data_type == "webm")
     return media::EmeInitDataType::WEBM;
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+  if (init_data_type == "fairplay")
+    return media::EmeInitDataType::PLATFORM_DRM;
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // |initDataType| is not restricted in the idl, so anything is possible.
   return media::EmeInitDataType::UNKNOWN;
@@ -47,6 +52,10 @@ String EncryptedMediaUtils::ConvertFromInitDataType(
       return "keyids";
     case media::EmeInitDataType::WEBM:
       return "webm";
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+    case media::EmeInitDataType::PLATFORM_DRM:
+      return "fairplay";
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
     case media::EmeInitDataType::UNKNOWN:
       // Chromium should not use Unknown, but we use it in Blink when the
       // actual value has been blocked for non-same-origin or mixed content.

--- a/third_party/blink/renderer/platform/media/web_content_decryption_module_session_impl.cc
+++ b/third_party/blink/renderer/platform/media/web_content_decryption_module_session_impl.cc
@@ -14,6 +14,7 @@
 
 #include "base/check_op.h"
 #include "base/metrics/histogram_functions.h"
+#include "build/build_config.h"
 #include "base/notreached.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/strings/string_util.h"
@@ -111,6 +112,16 @@ bool SanitizeInitData(media::EmeInitDataType init_data_type,
       media::CreateKeyIdsInitData(key_ids, sanitized_init_data);
       return true;
     }
+
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+    // Vendor-specific DRM init data uses formats outside the standard EME init
+    // data types. Forward it to the platform CDM unchanged.
+    case media::EmeInitDataType::SINF:
+    case media::EmeInitDataType::SKD:
+    case media::EmeInitDataType::PLATFORM_DRM:
+      sanitized_init_data->assign(init_data, init_data + init_data_length);
+      return true;
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
 
     case media::EmeInitDataType::UNKNOWN:
       break;

--- a/third_party/blink/renderer/platform/media/web_content_decryption_module_session_impl.cc
+++ b/third_party/blink/renderer/platform/media/web_content_decryption_module_session_impl.cc
@@ -14,6 +14,7 @@
 
 #include "base/check_op.h"
 #include "base/metrics/histogram_functions.h"
+#include "build/build_config.h"
 #include "base/notreached.h"
 #include "base/numerics/safe_conversions.h"
 #include "base/strings/string_util.h"
@@ -111,6 +112,13 @@ bool SanitizeInitData(media::EmeInitDataType init_data_type,
       media::CreateKeyIdsInitData(key_ids, sanitized_init_data);
       return true;
     }
+
+#if BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
+    // Platform DRM init data is passed through as-is to the CDM.
+    case media::EmeInitDataType::PLATFORM_DRM:
+      sanitized_init_data->assign(init_data, init_data + init_data_length);
+      return true;
+#endif  // BUILDFLAG(IS_IOS_TVOS) && BUILDFLAG(USE_STARBOARD_MEDIA)
 
     case media::EmeInitDataType::UNKNOWN:
       break;


### PR DESCRIPTION
Add platform DRM support for tvOS using the Starboard media pipeline.
This introduces support for SINF, SKD, and PLATFORM_DRM initialization
data types.

Platform DRM support is required for playback of encrypted HLS streams
on tvOS devices. This implementation provides the EME plumbing
necessary to handle CBCS encryption schemes and platform-specific key
exchange formats, used by both the HTML5 player and URL Player on tvOS.

Bug: 501343649
Bug: 498421484