### PR TITLE
cobalt: Hide scrollbars by default

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -72,6 +72,8 @@ public final class CommandLineOverrideHelper {
         paramOverrides.add("--enable-zero-copy");
         // Set default raster threads to 2 for smoother performance.
         paramOverrides.add("--num-raster-threads=2");
+        // Hide scrollbars to avoid memory allocation.
+        paramOverrides.add("--hide-scrollbars");
 
         return paramOverrides;
     }

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -80,6 +80,7 @@ public class CommandLineOverrideHelperTest {
         Assert.assertTrue(CommandLine.getInstance().hasSwitch("disable-accelerated-video-decode"));
         Assert.assertTrue(CommandLine.getInstance().hasSwitch("disable-accelerated-video-encode"));
         Assert.assertTrue(CommandLine.getInstance().hasSwitch("enable-zero-copy"));
+        Assert.assertTrue(CommandLine.getInstance().hasSwitch("hide-scrollbars"));
 
         String expected = "no-user-gesture-required";
         String actual = CommandLine.getInstance().getSwitchValue("autoplay-policy");

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -76,6 +76,8 @@ CommandLinePreprocessor::GetCobaltToggleSwitches() {
       ::switches::kDisableAcceleratedVideoEncode,
       // Force to use dark mode.
       ::switches::kForceDarkMode,
+      // Hide scrollbars to avoid memory allocation.
+      ::switches::kHideScrollbars,
   };
   return kCobaltToggleSwitches;
 }

--- a/cobalt/app/cobalt_switch_defaults_starboard_test.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard_test.cc
@@ -103,12 +103,14 @@ TEST(CobaltSwitchDefaultsTest, AlwaysEnabledSwitches) {
   CommandLinePreprocessor cmd_line_pxr(input_argc, input_argv.data());
 
   std::vector<const char*> always_on_switches{
-      ::switches::kForceVideoOverlays, ::switches::kSingleProcess,
+      ::switches::kForceVideoOverlays,
+      ::switches::kSingleProcess,
       ::switches::kIgnoreGpuBlocklist,
 #if BUILDFLAG(IS_ANDROID)
       ::switches::kUserLevelMemoryPressureSignalParams,
 #endif  // BUILDFLAG(IS_ANDROID)
-      sandbox::policy::switches::kNoSandbox};
+      sandbox::policy::switches::kNoSandbox,
+      ::switches::kHideScrollbars};
 
   for (const auto& switch_key : always_on_switches) {
     EXPECT_TRUE(HasSwitch(cmd_line_pxr, switch_key));


### PR DESCRIPTION
Blink allocates memory for scrollbars even if they are not displayed. This change enables the --hide-scrollbars flag by default for both Starboard (RDK, etc.) and Android platforms to avoid this memory allocation.

For Starboard, the flag is added to the default toggle switches. For Android, the flag is added to the CommandLineOverrideHelper default overrides. Unit tests are updated to ensure the flag is present by default.

Estimated memory saving: 48kb.

Bug: 529788349
Bug: 435264179