### PR TITLE
cobalt: Disable MemoryCacheStrongReference by default on Starboard

### DIFF
--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -86,7 +86,7 @@ const base::CommandLine::SwitchMap&
 CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
   static const base::CommandLine::SwitchMap kCobaltSwitchDefaults{
       // Disable Vulkan.
-      {::switches::kDisableFeatures, "Vulkan"},
+      {::switches::kDisableFeatures, "Vulkan,MemoryCacheStrongReference"},
       {::switches::kEnableFeatures,
        "LimitImageDecodeCacheSize:mb/24, "
        // When DefaultEnableANGLEValidation is disabled (e.g gold/qa), EGL

--- a/cobalt/app/cobalt_switch_defaults_starboard_test.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard_test.cc
@@ -52,7 +52,9 @@ TEST(CobaltSwitchDefaultsTest, MergeDisabledFeatures) {
 
   std::string disabled_features =
       GetSwitchValue(cmd_line_pxr, ::switches::kDisableFeatures);
-  EXPECT_EQ(std::string("PersistentOriginTrials,Vulkan"), disabled_features);
+  EXPECT_EQ(
+      std::string("PersistentOriginTrials,Vulkan,MemoryCacheStrongReference"),
+      disabled_features);
 }
 
 TEST(CobaltSwitchDefaultsTest, ConsistentWindowSizes) {


### PR DESCRIPTION
Blink's MemoryCacheStrongReference feature keeps resources alive in the memory cache using strong references even after they are no longer used by the DOM.

To save memory on Starboard platforms, this change disables the feature by default by adding it to the default disabled features list. This allows resources to be garbage collected and evicted from the cache as soon as they are no longer referenced by the page.

The unit test is updated to reflect this change.

Note: this feature is removed by Chomium on M145 anyway.

Bug: 529866630