### PR TITLE
media: Area based buffer budget experiment

### DIFF
--- a/starboard/android/shared/media_get_video_buffer_budget.cc
+++ b/starboard/android/shared/media_get_video_buffer_budget.cc
@@ -17,6 +17,7 @@
 #include "starboard/android/shared/runtime_resource_overlay.h"
 #include "starboard/common/log.h"
 #include "starboard/media.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/resolutions.h"
 
 namespace {
@@ -36,6 +37,19 @@ namespace {
 // TODO: b/416039556 - Allow starboard::feature to override this value, once
 // b/416039556 is completed.
 constexpr int kMaxVideoBufferBudget = 200 * 1024 * 1024;
+
+// Specifies the maximum amount of memory used by video buffers of media
+// source before triggering a garbage collection when the video resolution
+// is up to 1080p (1920x1080) or invalid.
+constexpr int kVideoBufferBudget1080p = 30 * 1024 * 1024;
+// Specifies the maximum amount of memory used by video buffers of media
+// source before triggering a garbage collection when the video resolution
+// is up to 4k (3840x2160) and bit per pixel is up to 8.
+constexpr int kVideoBufferBudget4KSdr = 100 * 1024 * 1024;
+// Specifies the maximum amount of memory used by video buffers of media
+// source before triggering a garbage collection when video resolution is
+// up to 4k (3840x2160) and bit per pixel is greater than 8.
+constexpr int kVideoBufferBudget4KHdr = 160 * 1024 * 1024;
 
 }  // namespace
 
@@ -59,30 +73,37 @@ int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
 
   int video_buffer_budget = 0;
   starboard::Size resolution(resolution_width, resolution_height);
-  if (resolution.FitsWithin(starboard::Resolution::k1080p) ||
-      resolution_width == kSbMediaVideoResolutionDimensionInvalid ||
-      resolution_height == kSbMediaVideoResolutionDimensionInvalid) {
-    // Specifies the maximum amount of memory used by video buffers of media
-    // source before triggering a garbage collection when the video resolution
-    // is up to 1080p (1920x1080) or invalid.
-    video_buffer_budget = 30 * 1024 * 1024;
-  } else if (resolution.FitsWithin(starboard::Resolution::k4k)) {
-    if (bits_per_pixel <= 8) {
-      // Specifies the maximum amount of memory used by video buffers of media
-      // source before triggering a garbage collection when the video resolution
-      // is up to 4k (3840x2160) and bit per pixel is up to 8.
-      video_buffer_budget = 100 * 1024 * 1024;
+
+  if (starboard::features::FeatureList::IsEnabled(
+          starboard::features::kAreaBasedVideoBufferBudget)) {
+    if (resolution.IsEmpty() ||
+        resolution.GetArea() <= starboard::Resolution::k1080p.GetArea()) {
+      video_buffer_budget = kVideoBufferBudget1080p;
+    } else if (resolution.GetArea() <= starboard::Resolution::k4k.GetArea()) {
+      if (bits_per_pixel <= 8) {
+        video_buffer_budget = kVideoBufferBudget4KSdr;
+      }
+      video_buffer_budget = kVideoBufferBudget4KHdr;
     } else {
-      // Specifies the maximum amount of memory used by video buffers of media
-      // source before triggering a garbage collection when video resolution is
-      // up to 4k (3840x2160) and bit per pixel is greater than 8.
-      video_buffer_budget = 160 * 1024 * 1024;
+      video_buffer_budget = kMaxVideoBufferBudget;
     }
   } else {
-    // Specifies the maximum amount of memory used by video buffers of media
-    // source before triggering a garbage collection when the video resolution
-    // is above 4K (e.g., 8K).
-    video_buffer_budget = kMaxVideoBufferBudget;
+    if (resolution.FitsWithin(starboard::Resolution::k1080p) ||
+        resolution_width == kSbMediaVideoResolutionDimensionInvalid ||
+        resolution_height == kSbMediaVideoResolutionDimensionInvalid) {
+      video_buffer_budget = kVideoBufferBudget1080p;
+    } else if (resolution.FitsWithin(starboard::Resolution::k4k)) {
+      if (bits_per_pixel <= 8) {
+        video_buffer_budget = kVideoBufferBudget4KSdr;
+      } else {
+        video_buffer_budget = kVideoBufferBudget4KHdr;
+      }
+    } else {
+      // Specifies the maximum amount of memory used by video buffers of media
+      // source before triggering a garbage collection when the video resolution
+      // is above 4K (e.g., 8K).
+      video_buffer_budget = kMaxVideoBufferBudget;
+    }
   }
 
   return std::min(video_buffer_budget, overlaid_video_buffer_budget);

--- a/starboard/android/shared/media_get_video_buffer_budget.cc
+++ b/starboard/android/shared/media_get_video_buffer_budget.cc
@@ -82,8 +82,9 @@ int SbMediaGetVideoBufferBudget(SbMediaVideoCodec codec,
     } else if (resolution.GetArea() <= starboard::Resolution::k4k.GetArea()) {
       if (bits_per_pixel <= 8) {
         video_buffer_budget = kVideoBufferBudget4KSdr;
+      } else {
+        video_buffer_budget = kVideoBufferBudget4KHdr;
       }
-      video_buffer_budget = kVideoBufferBudget4KHdr;
     } else {
       video_buffer_budget = kMaxVideoBufferBudget;
     }

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -102,6 +102,11 @@ FEATURE_LIST_START
 
 #if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 // keep-sorted start newline_separated=yes
+// Set to true to enable area-based video buffer budget calculation.
+STARBOARD_FEATURE(kAreaBasedVideoBufferBudget,
+                  "AreaBasedVideoBufferBudget",
+                  false)
+
 // By default, app provisioning is disabled. Set the following variable to true
 // to enable app provisioning.
 STARBOARD_FEATURE(kEnableAppProvisioning, "EnableAppProvisioning", false)


### PR DESCRIPTION
Use Area based buffer budget for Android experiment.

Currently the MediaSource buffer budget is vertical resolution based, e.g. on Android TV 30 MB is used for 1080p, 100 MB is used for 4K SDR, and 160 MB is used for 4K HDR.

When a Shorts is played at 1080x1920, while having the same pixel count to a 1080p video, it will allocate MediaSource buffer as a 4K video based on the vertical resolution.

This PR implements the change on Android, gated behind a feature flag 'AreaBasedVideoBufferBudget'
to enable an experiment rollout.

Testing locally with and without the flag to enable this, , watching a 50 second Shorts, shows:
 
  ### Summary of Memory Usage Results
    
  #### 1. Total PSS (Peak & Steady State)
  
  • With  --enable-features=AreaBasedVideoBufferBudget :
      • Peak Total PSS: ~422.5 MB (at ~17s)
      • Steady State PSS: ~380 MB (from ~28s to ~42s)
      • Ending PSS: ~399 MB
  • Without  --enable-features=AreaBasedVideoBufferBudget :
      • Peak Total PSS: ~425.5 MB (at ~14s)
      • Steady State PSS: ~388 MB (from ~25s to ~41s)
      • Ending PSS: ~406 MB
  
  
  │ Key Takeaway: Enabling  AreaBasedVideoBufferBudget  showed a modest reduction in total PSS memory usage (~8 MB lower in steady state and ~7 MB lower overall ending memory).
  ──────
  #### 2. Graphics & Native Heap Memory Breakdown
  
  • Graphics Memory:
      • With Flag: ~154.5 MB steady state, peaking at ~168.9 MB
      • Without Flag: ~162.6 MB steady state, peaking at ~177.8 MB
      • (The flag lowered graphics memory allocation by ~8–9 MB)
  • Native Heap Memory:
      • With Flag: ~11.5 MB initial, dropped to ~9.1 MB near end
      • Without Flag: ~11.5 MB initial, dropped to ~9.1 MB near end
      • (Native heap usage was nearly identical across both runs)
  
  ──────


Bug: 520049429