### PR TITLE
v8: Set maglev flag to false to reduce binary size

### DIFF
--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -50,6 +50,9 @@ v8_enable_atomic_object_field_writes = true
 # This will force V8 to embed snapshot blob in binary.
 v8_use_external_startup_data = false
 
+# Disable maglev in binary.
+v8_enable_maglev = false
+
 # Disable hls_demuxer so that enable_mse_mpeg2ts_stream_parser=false
 enable_hls_demuxer = false
 

--- a/cobalt/build/configs/common.gn
+++ b/cobalt/build/configs/common.gn
@@ -50,7 +50,7 @@ v8_enable_atomic_object_field_writes = true
 # This will force V8 to embed snapshot blob in binary.
 v8_use_external_startup_data = false
 
-# Disable maglev in binary.
+# Disable Maglev in binary.
 v8_enable_maglev = false
 
 # Disable hls_demuxer so that enable_mse_mpeg2ts_stream_parser=false


### PR DESCRIPTION
This PR disables V8's Maglev compiler globally for Cobalt builds by setting v8_enable_maglev = false .

Disabling Maglev yields a binary size reduction of 344.0 KB (87607441 bytes to 87263377 bytes).

For context: Maglev is V8’s mid-tier optimizing compiler that sits between Sparkplug (the fast baseline compiler) and Turbofan (the heavy, top-tier optimizing compiler). It is designed to quickly generate optimized machine code for hot JavaScript functions, bridging the gap between rapid application startup and high peak execution performance.

We saw positive results from @tasunnn 's experiment (b/512163617) to disable maglev amongst other flags at runtime; this will allow us to realize binary size reduction as well.

Bug: 504727065
