### PR TITLE
media: Move MediaCodec work off main thread

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -284,6 +284,7 @@ robolectric_binary("cobalt_coat_junit_tests") {
     "apk/app/src/test/java/dev/cobalt/coat/MockShellManagerNatives.java",
     "apk/app/src/test/java/dev/cobalt/coat/PlatformErrorTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/ShellManagerTest.java",
+    "apk/app/src/test/java/dev/cobalt/media/MediaCodecBridgeTest.java",
     "apk/app/src/test/java/dev/cobalt/media/MediaCodecOutputTrackerTest.java",
     "apk/app/src/test/java/dev/cobalt/util/StartupGuardTest.java",
   ]

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -282,11 +282,21 @@ class MediaCodecBridge {
     }
     final MediaCodec[] result = new MediaCodec[1];
     final Exception[] exception = new Exception[1];
+    final boolean[] cancelled = new boolean[1];
     Handler handler = new Handler(handlerThread.getLooper());
     java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
     boolean posted = handler.post(() -> {
       try {
-        result[0] = MediaCodec.createByCodecName(decoderName);
+        MediaCodec codec = MediaCodec.createByCodecName(decoderName);
+        synchronized (latch) {
+          if (cancelled[0]) {
+            if (codec != null) {
+              codec.release();
+            }
+          } else {
+            result[0] = codec;
+          }
+        }
       } catch (Exception e) {
         exception[0] = e;
       } finally {
@@ -300,6 +310,9 @@ class MediaCodecBridge {
     try {
       latch.await();
     } catch (InterruptedException e) {
+      synchronized (latch) {
+        cancelled[0] = true;
+      }
       Thread.currentThread().interrupt();
     }
     if (exception[0] != null) {
@@ -317,8 +330,9 @@ class MediaCodecBridge {
     mMediaCodecThread = new HandlerThread("MediaCodecBridgeThread_" + decoderName);
     mMediaCodecThread.start();
     mMediaCodecHandler = new Handler(mMediaCodecThread.getLooper());
+    MediaCodec mediaCodec = null;
     try {
-      MediaCodec mediaCodec = createMediaCodecOnHandlerThread(decoderName, mMediaCodecThread);
+      mediaCodec = createMediaCodecOnHandlerThread(decoderName, mMediaCodecThread);
       if (mediaCodec == null) {
         throw new IllegalArgumentException("Failed to create MediaCodec for " + decoderName);
       }
@@ -428,6 +442,13 @@ class MediaCodecBridge {
       }
       mFrameRateEstimator = MediaCodecFrameRateEstimator.create(mIsTunnelingPlayback);
     } catch (Throwable t) {
+      if (mediaCodec != null) {
+        try {
+          mediaCodec.release();
+        } catch (Exception e) {
+          Log.e(TAG, "Failed to release MediaCodec during cleanup", e);
+        }
+      }
       mMediaCodecThread.quitSafely();
       throw t;
     }
@@ -531,157 +552,163 @@ class MediaCodecBridge {
       return;
     }
 
-    bridge.mSkipVideoFramesOver60Fps = skipVideoFramesOver60Fps;
-    MediaCodecOutputTracker.get().register(bridge);
-    MediaFormat mediaFormat =
-        createVideoDecoderFormat(mime, widthHint, heightHint, videoCapabilities);
+    try {
+      bridge.mSkipVideoFramesOver60Fps = skipVideoFramesOver60Fps;
+      MediaCodecOutputTracker.get().register(bridge);
+      MediaFormat mediaFormat =
+          createVideoDecoderFormat(mime, widthHint, heightHint, videoCapabilities);
 
-    if (enableLowLatency) {
-      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        Log.i(TAG, "Enabling low-latency playback.");
-        mediaFormat.setInteger(MediaFormat.KEY_LOW_LATENCY, 1);
-      } else {
-        Log.i(
-            TAG,
-            "Low-latency playback requested but not supported on API level "
-                + Build.VERSION.SDK_INT);
-      }
-    }
-
-    boolean shouldConfigureHdr =
-        colorInfo != null && MediaCodecUtil.isHdrCapableVideoDecoder(mime, codecCapabilities);
-    if (shouldConfigureHdr) {
-      Log.d(TAG, "Setting HDR info.");
-      mediaFormat.setInteger(MediaFormat.KEY_COLOR_TRANSFER, colorInfo.colorTransfer);
-      mediaFormat.setInteger(MediaFormat.KEY_COLOR_STANDARD, colorInfo.colorStandard);
-      // If color range is unspecified, don't set it.
-      if (colorInfo.colorRange != 0) {
-        mediaFormat.setInteger(MediaFormat.KEY_COLOR_RANGE, colorInfo.colorRange);
-      }
-      mediaFormat.setByteBuffer(MediaFormat.KEY_HDR_STATIC_INFO, colorInfo.hdrStaticInfo);
-    }
-
-    if (tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE) {
-      mediaFormat.setFeatureEnabled(CodecCapabilities.FEATURE_TunneledPlayback, true);
-      mediaFormat.setInteger(MediaFormat.KEY_AUDIO_SESSION_ID, tunnelModeAudioSessionId);
-      Log.d(TAG, "Enabled tunnel mode playback on audio session " + tunnelModeAudioSessionId);
-
-      // TODO (b/495868363): KEY_PRIORITY might be also needed for non tunnel playback.
-      // Set KEY_PRIORITY to realtime priority.
-      mediaFormat.setInteger(MediaFormat.KEY_PRIORITY, 0 /* realtime priority */);
-    }
-
-    if (maxWidth > 0 && maxHeight > 0) {
-      Log.i(TAG, "Evaluate maxWidth and maxHeight (%d, %d) passed in", maxWidth, maxHeight);
-    } else {
-      maxWidth = videoCapabilities.getSupportedWidths().getUpper();
-      maxHeight = videoCapabilities.getSupportedHeights().getUpper();
-      Log.i(
-          TAG,
-          "maxWidth and maxHeight not passed in, using result of getSupportedWidths()/Heights()"
-              + " (%d, %d)",
-          maxWidth,
-          maxHeight);
-    }
-
-    if (fps > 0) {
-      if (videoCapabilities.areSizeAndRateSupported(maxWidth, maxHeight, fps)) {
-        Log.i(
-            TAG,
-            "Set maxWidth and maxHeight to (%d, %d)@%d per `areSizeAndRateSupported()`",
-            maxWidth,
-            maxHeight,
-            fps);
-      } else {
-        Log.w(
-            TAG,
-            "maxWidth and maxHeight (%d, %d)@%d not supported per `areSizeAndRateSupported()`,"
-                + " continue searching",
-            maxWidth,
-            maxHeight,
-            fps);
-        if (maxHeight >= 4320 && videoCapabilities.areSizeAndRateSupported(7680, 4320, fps)) {
-          maxWidth = 7680;
-          maxHeight = 4320;
-        } else if (maxHeight >= 2160
-            && videoCapabilities.areSizeAndRateSupported(3840, 2160, fps)) {
-          maxWidth = 3840;
-          maxHeight = 2160;
-        } else if (maxHeight >= 1080
-            && videoCapabilities.areSizeAndRateSupported(1920, 1080, fps)) {
-          maxWidth = 1920;
-          maxHeight = 1080;
+      if (enableLowLatency) {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+          Log.i(TAG, "Enabling low-latency playback.");
+          mediaFormat.setInteger(MediaFormat.KEY_LOW_LATENCY, 1);
         } else {
-          Log.e(TAG, "Failed to find a compatible resolution");
-          maxWidth = 1920;
-          maxHeight = 1080;
+          Log.i(
+              TAG,
+              "Low-latency playback requested but not supported on API level "
+                  + Build.VERSION.SDK_INT);
         }
-        Log.i(
-            TAG,
-            "Set maxWidth and maxHeight to (%d, %d)@%d per `areSizeAndRateSupported()`",
-            maxWidth,
-            maxHeight,
-            fps);
       }
-    } else {
-      if (maxHeight >= 480 && videoCapabilities.isSizeSupported(maxWidth, maxHeight)) {
-        // Technically we can do this check for all resolutions, but only check for resolution with
-        // height more than 480p to minimize production impact.  To use a lower resolution is more
-        // to reduce memory footprint, and optimize for lower resolution isn't as helpful anyway.
-        Log.i(
-            TAG,
-            "Set maxWidth and maxHeight to (%d, %d) per `isSizeSupported()`",
-            maxWidth,
-            maxHeight);
-      } else {
-        if (maxHeight >= 2160 && videoCapabilities.isSizeSupported(3840, 2160)) {
-          maxWidth = 3840;
-          maxHeight = 2160;
-        } else if (maxHeight >= 1080 && videoCapabilities.isSizeSupported(1920, 1080)) {
-          maxWidth = 1920;
-          maxHeight = 1080;
-        } else {
-          Log.e(TAG, "Failed to find a compatible resolution");
-          maxWidth = 1920;
-          maxHeight = 1080;
+
+      boolean shouldConfigureHdr =
+          colorInfo != null && MediaCodecUtil.isHdrCapableVideoDecoder(mime, codecCapabilities);
+      if (shouldConfigureHdr) {
+        Log.d(TAG, "Setting HDR info.");
+        mediaFormat.setInteger(MediaFormat.KEY_COLOR_TRANSFER, colorInfo.colorTransfer);
+        mediaFormat.setInteger(MediaFormat.KEY_COLOR_STANDARD, colorInfo.colorStandard);
+        // If color range is unspecified, don't set it.
+        if (colorInfo.colorRange != 0) {
+          mediaFormat.setInteger(MediaFormat.KEY_COLOR_RANGE, colorInfo.colorRange);
         }
+        mediaFormat.setByteBuffer(MediaFormat.KEY_HDR_STATIC_INFO, colorInfo.hdrStaticInfo);
+      }
+
+      if (tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE) {
+        mediaFormat.setFeatureEnabled(CodecCapabilities.FEATURE_TunneledPlayback, true);
+        mediaFormat.setInteger(MediaFormat.KEY_AUDIO_SESSION_ID, tunnelModeAudioSessionId);
+        Log.d(TAG, "Enabled tunnel mode playback on audio session " + tunnelModeAudioSessionId);
+
+        // TODO (b/495868363): KEY_PRIORITY might be also needed for non tunnel playback.
+        // Set KEY_PRIORITY to realtime priority.
+        mediaFormat.setInteger(MediaFormat.KEY_PRIORITY, 0 /* realtime priority */);
+      }
+
+      if (maxWidth > 0 && maxHeight > 0) {
+        Log.i(TAG, "Evaluate maxWidth and maxHeight (%d, %d) passed in", maxWidth, maxHeight);
+      } else {
+        maxWidth = videoCapabilities.getSupportedWidths().getUpper();
+        maxHeight = videoCapabilities.getSupportedHeights().getUpper();
         Log.i(
             TAG,
-            "Set maxWidth and maxHeight to (%d, %d) per `isSizeSupported()`",
+            "maxWidth and maxHeight not passed in, using result of getSupportedWidths()/Heights()"
+                + " (%d, %d)",
             maxWidth,
             maxHeight);
       }
-    }
 
-    if (maxVideoInputSize > 0) {
-      mediaFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxVideoInputSize);
-      try {
-        Log.i(
-            TAG,
-            "Overwrite KEY_MAX_INPUT_SIZE to "
-                + maxVideoInputSize
-                + " (actual: "
-                + mediaFormat.getInteger(android.media.MediaFormat.KEY_MAX_INPUT_SIZE)
-                + ").");
-      } catch (Exception e) {
-        Log.e(TAG, "MediaFormat.getInteger(KEY_MAX_INPUT_SIZE) failed with exception: ", e);
+      if (fps > 0) {
+        if (videoCapabilities.areSizeAndRateSupported(maxWidth, maxHeight, fps)) {
+          Log.i(
+              TAG,
+              "Set maxWidth and maxHeight to (%d, %d)@%d per `areSizeAndRateSupported()`",
+              maxWidth,
+              maxHeight,
+              fps);
+        } else {
+          Log.w(
+              TAG,
+              "maxWidth and maxHeight (%d, %d)@%d not supported per `areSizeAndRateSupported()`,"
+                  + " continue searching",
+              maxWidth,
+              maxHeight,
+              fps);
+          if (maxHeight >= 4320 && videoCapabilities.areSizeAndRateSupported(7680, 4320, fps)) {
+            maxWidth = 7680;
+            maxHeight = 4320;
+          } else if (maxHeight >= 2160
+              && videoCapabilities.areSizeAndRateSupported(3840, 2160, fps)) {
+            maxWidth = 3840;
+            maxHeight = 2160;
+          } else if (maxHeight >= 1080
+              && videoCapabilities.areSizeAndRateSupported(1920, 1080, fps)) {
+            maxWidth = 1920;
+            maxHeight = 1080;
+          } else {
+            Log.e(TAG, "Failed to find a compatible resolution");
+            maxWidth = 1920;
+            maxHeight = 1080;
+          }
+          Log.i(
+              TAG,
+              "Set maxWidth and maxHeight to (%d, %d)@%d per `areSizeAndRateSupported()`",
+              maxWidth,
+              maxHeight,
+              fps);
+        }
+      } else {
+        if (maxHeight >= 480 && videoCapabilities.isSizeSupported(maxWidth, maxHeight)) {
+          // Technically we can do this check for all resolutions, but only check for resolution with
+          // height more than 480p to minimize production impact.  To use a lower resolution is more
+          // to reduce memory footprint, and optimize for lower resolution isn't as helpful anyway.
+          Log.i(
+              TAG,
+              "Set maxWidth and maxHeight to (%d, %d) per `isSizeSupported()`",
+              maxWidth,
+              maxHeight);
+        } else {
+          if (maxHeight >= 2160 && videoCapabilities.isSizeSupported(3840, 2160)) {
+            maxWidth = 3840;
+            maxHeight = 2160;
+          } else if (maxHeight >= 1080 && videoCapabilities.isSizeSupported(1920, 1080)) {
+            maxWidth = 1920;
+            maxHeight = 1080;
+          } else {
+            Log.e(TAG, "Failed to find a compatible resolution");
+            maxWidth = 1920;
+            maxHeight = 1080;
+          }
+          Log.i(
+              TAG,
+              "Set maxWidth and maxHeight to (%d, %d) per `isSizeSupported()`",
+              maxWidth,
+              maxHeight);
+        }
       }
-    }
-    if (!bridge.configureVideo(
-        mediaFormat, surface, crypto, 0, maxWidth, maxHeight, outCreateMediaCodecBridgeResult)) {
-      Log.e(TAG, "Failed to configure video codec.");
-      bridge.release();
-      // outCreateMediaCodecBridgeResult.mErrorMessage is set inside configureVideo() on error.
-      return;
-    }
-    if (!bridge.start(outCreateMediaCodecBridgeResult)) {
-      Log.e(TAG, "Failed to start video codec.");
-      bridge.release();
-      // outCreateMediaCodecBridgeResult.mErrorMessage is set inside start() on error.
-      return;
-    }
 
-    outCreateMediaCodecBridgeResult.mMediaCodecBridge = bridge;
+      if (maxVideoInputSize > 0) {
+        mediaFormat.setInteger(MediaFormat.KEY_MAX_INPUT_SIZE, maxVideoInputSize);
+        try {
+          Log.i(
+              TAG,
+              "Overwrite KEY_MAX_INPUT_SIZE to "
+                  + maxVideoInputSize
+                  + " (actual: "
+                  + mediaFormat.getInteger(android.media.MediaFormat.KEY_MAX_INPUT_SIZE)
+                  + ").");
+        } catch (Exception e) {
+          Log.e(TAG, "MediaFormat.getInteger(KEY_MAX_INPUT_SIZE) failed with exception: ", e);
+        }
+      }
+      if (!bridge.configureVideo(
+          mediaFormat, surface, crypto, 0, maxWidth, maxHeight, outCreateMediaCodecBridgeResult)) {
+        Log.e(TAG, "Failed to configure video codec.");
+        bridge.release();
+        // outCreateMediaCodecBridgeResult.mErrorMessage is set inside configureVideo() on error.
+        return;
+      }
+      if (!bridge.start(outCreateMediaCodecBridgeResult)) {
+        Log.e(TAG, "Failed to start video codec.");
+        bridge.release();
+        // outCreateMediaCodecBridgeResult.mErrorMessage is set inside start() on error.
+        return;
+      }
+
+      outCreateMediaCodecBridgeResult.mMediaCodecBridge = bridge;
+    } catch (Throwable t) {
+      Log.e(TAG, "Unexpected exception during video decoder creation: ", t);
+      outCreateMediaCodecBridgeResult.mErrorMessage = "Unexpected exception during creation: " + t.getMessage();
+      bridge.release();
+    }
   }
 
   public boolean start() {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -281,14 +281,15 @@ class MediaCodecBridge {
       return null;
     }
     final MediaCodec[] result = new MediaCodec[1];
-    final Exception[] exception = new Exception[1];
+    final Throwable[] exception = new Throwable[1];
     final boolean[] cancelled = new boolean[1];
+    final Object lock = new Object();
     Handler handler = new Handler(handlerThread.getLooper());
     java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
     boolean posted = handler.post(() -> {
       try {
         MediaCodec codec = MediaCodec.createByCodecName(decoderName);
-        synchronized (latch) {
+        synchronized (lock) {
           if (cancelled[0]) {
             if (codec != null) {
               codec.release();
@@ -297,8 +298,8 @@ class MediaCodecBridge {
             result[0] = codec;
           }
         }
-      } catch (Exception e) {
-        exception[0] = e;
+      } catch (Throwable t) {
+        exception[0] = t;
       } finally {
         latch.countDown();
       }
@@ -310,8 +311,16 @@ class MediaCodecBridge {
     try {
       latch.await();
     } catch (InterruptedException e) {
-      synchronized (latch) {
+      synchronized (lock) {
         cancelled[0] = true;
+        if (result[0] != null) {
+          try {
+            result[0].release();
+          } catch (Exception ex) {
+            Log.e(TAG, "Failed to release MediaCodec after interruption", ex);
+          }
+          result[0] = null;
+        }
       }
       Thread.currentThread().interrupt();
     }
@@ -410,9 +419,9 @@ class MediaCodecBridge {
           };
 
       if (mEnableIgnoreCallbacksDuringFlushing) {
-        mMediaCodec.get().setCallback(mCallback, mMediaCodecHandler);
+        mediaCodec.setCallback(mCallback, mMediaCodecHandler);
       } else {
-        mMediaCodec.get().setCallback(mCallback);
+        mediaCodec.setCallback(mCallback);
       }
 
       if (mEnableFrameRendererListener) {
@@ -431,14 +440,14 @@ class MediaCodecBridge {
               }
             };
         if (mEnableIgnoreCallbacksDuringFlushing) {
-          mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, mMediaCodecHandler);
+          mediaCodec.setOnFrameRenderedListener(mFrameRendererListener, mMediaCodecHandler);
         } else {
-          mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, null);
+          mediaCodec.setOnFrameRenderedListener(mFrameRendererListener, null);
         }
       }
 
       if (mIsTunnelingPlayback) {
-        setupTunnelingPlayback();
+        setupTunnelingPlayback(mediaCodec);
       }
       mFrameRateEstimator = MediaCodecFrameRateEstimator.create(mIsTunnelingPlayback);
     } catch (Throwable t) {
@@ -1149,7 +1158,7 @@ class MediaCodecBridge {
     }
   }
 
-  private void setupTunnelingPlayback() {
+  private void setupTunnelingPlayback(MediaCodec mediaCodec) {
     // PARAMETER_KEY_TUNNEL_PEEK is added in Android 12.
     if (Build.VERSION.SDK_INT >= 31) {
       // |PARAMETER_KEY_TUNNEL_PEEK| should be default to enabled according to the API
@@ -1158,7 +1167,7 @@ class MediaCodecBridge {
       Bundle bundle = new Bundle();
       bundle.putInt(MediaCodec.PARAMETER_KEY_TUNNEL_PEEK, 1);
       try {
-        mMediaCodec.get().setParameters(bundle);
+        mediaCodec.setParameters(bundle);
       } catch (IllegalStateException e) {
         Log.e(TAG, "Failed to set MediaCodec PARAMETER_KEY_TUNNEL_PEEK: ", e);
       }
@@ -1185,9 +1194,9 @@ class MediaCodecBridge {
             }
           };
       if (mEnableIgnoreCallbacksDuringFlushing) {
-        mMediaCodec.get().setOnFirstTunnelFrameReadyListener(mMediaCodecHandler, mFirstTunnelFrameReadyListener);
+        mediaCodec.setOnFirstTunnelFrameReadyListener(mMediaCodecHandler, mFirstTunnelFrameReadyListener);
       } else {
-        mMediaCodec.get().setOnFirstTunnelFrameReadyListener(null, mFirstTunnelFrameReadyListener);
+        mediaCodec.setOnFirstTunnelFrameReadyListener(null, mFirstTunnelFrameReadyListener);
       }
     } else {
       Log.w(

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -315,7 +315,20 @@ class MediaCodecBridge {
       return null;
     }
     try {
-      latch.await();
+      if (!latch.await(5000, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+        synchronized (lock) {
+          cancelled[0] = true;
+          if (result[0] != null) {
+            try {
+              result[0].release();
+            } catch (Exception ex) {
+              Log.e(TAG, "Failed to release MediaCodec after timeout", ex);
+            }
+            result[0] = null;
+          }
+        }
+        throw new RuntimeException("Timeout waiting for MediaCodec creation on HandlerThread");
+      }
     } catch (InterruptedException e) {
       synchronized (lock) {
         cancelled[0] = true;
@@ -347,7 +360,10 @@ class MediaCodecBridge {
     if (decoderName == null || decoderName.isEmpty()) {
       throw new IllegalArgumentException("Decoder name cannot be null or empty");
     }
-    mMediaCodecThread = new HandlerThread("MediaCodecBridgeThread_" + decoderName);
+    mMediaCodecThread =
+        new HandlerThread(
+            "MediaCodecBridgeThread_" + decoderName,
+            android.os.Process.THREAD_PRIORITY_VIDEO);
     mMediaCodecThread.start();
     Looper looper = mMediaCodecThread.getLooper();
     if (looper == null) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -295,14 +295,16 @@ class MediaCodecBridge {
     boolean posted = handler.post(() -> {
       try {
         MediaCodec codec = MediaCodec.createByCodecName(decoderName);
+        MediaCodec codecToRelease = null;
         synchronized (lock) {
           if (cancelled[0]) {
-            if (codec != null) {
-              codec.release();
-            }
+            codecToRelease = codec;
           } else {
             result[0] = codec;
           }
+        }
+        if (codecToRelease != null) {
+          codecToRelease.release();
         }
       } catch (Throwable t) {
         exception[0] = t;
@@ -316,29 +318,33 @@ class MediaCodecBridge {
     }
     try {
       if (!latch.await(5000, java.util.concurrent.TimeUnit.MILLISECONDS)) {
+        MediaCodec codecToRelease = null;
         synchronized (lock) {
           cancelled[0] = true;
-          if (result[0] != null) {
-            try {
-              result[0].release();
-            } catch (Exception ex) {
-              Log.e(TAG, "Failed to release MediaCodec after timeout", ex);
-            }
-            result[0] = null;
+          codecToRelease = result[0];
+          result[0] = null;
+        }
+        if (codecToRelease != null) {
+          try {
+            codecToRelease.release();
+          } catch (Exception ex) {
+            Log.e(TAG, "Failed to release MediaCodec after timeout", ex);
           }
         }
         throw new RuntimeException("Timeout waiting for MediaCodec creation on HandlerThread");
       }
     } catch (InterruptedException e) {
+      MediaCodec codecToRelease = null;
       synchronized (lock) {
         cancelled[0] = true;
-        if (result[0] != null) {
-          try {
-            result[0].release();
-          } catch (Exception ex) {
-            Log.e(TAG, "Failed to release MediaCodec after interruption", ex);
-          }
-          result[0] = null;
+        codecToRelease = result[0];
+        result[0] = null;
+      }
+      if (codecToRelease != null) {
+        try {
+          codecToRelease.release();
+        } catch (Exception ex) {
+          Log.e(TAG, "Failed to release MediaCodec after interruption", ex);
         }
       }
       Thread.currentThread().interrupt();

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -723,7 +723,8 @@ class MediaCodecBridge {
       outCreateMediaCodecBridgeResult.mMediaCodecBridge = bridge;
     } catch (Throwable t) {
       Log.e(TAG, "Unexpected exception during video decoder creation: ", t);
-      outCreateMediaCodecBridgeResult.mErrorMessage = "Unexpected exception during creation: " + t.getMessage();
+      outCreateMediaCodecBridgeResult.mErrorMessage =
+          "Unexpected exception during creation: " + t.getMessage();
       bridge.release();
     }
   }
@@ -1201,7 +1202,8 @@ class MediaCodecBridge {
               }
             }
           };
-      mediaCodec.setOnFirstTunnelFrameReadyListener(mMediaCodecHandler, mFirstTunnelFrameReadyListener);
+      mediaCodec.setOnFirstTunnelFrameReadyListener(
+          mMediaCodecHandler, mFirstTunnelFrameReadyListener);
     } else {
       Log.w(
           TAG,

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -431,11 +431,7 @@ class MediaCodecBridge {
             }
           };
 
-      if (mEnableIgnoreCallbacksDuringFlushing) {
-        mediaCodec.setCallback(mCallback, mMediaCodecHandler);
-      } else {
-        mediaCodec.setCallback(mCallback);
-      }
+      mediaCodec.setCallback(mCallback, mMediaCodecHandler);
 
       if (mEnableFrameRendererListener) {
         mFrameRendererListener =
@@ -452,11 +448,7 @@ class MediaCodecBridge {
                 }
               }
             };
-        if (mEnableIgnoreCallbacksDuringFlushing) {
-          mediaCodec.setOnFrameRenderedListener(mFrameRendererListener, mMediaCodecHandler);
-        } else {
-          mediaCodec.setOnFrameRenderedListener(mFrameRendererListener, null);
-        }
+        mediaCodec.setOnFrameRenderedListener(mFrameRendererListener, mMediaCodecHandler);
       }
 
       if (mIsTunnelingPlayback) {
@@ -1206,11 +1198,7 @@ class MediaCodecBridge {
               }
             }
           };
-      if (mEnableIgnoreCallbacksDuringFlushing) {
-        mediaCodec.setOnFirstTunnelFrameReadyListener(mMediaCodecHandler, mFirstTunnelFrameReadyListener);
-      } else {
-        mediaCodec.setOnFirstTunnelFrameReadyListener(null, mFirstTunnelFrameReadyListener);
-      }
+      mediaCodec.setOnFirstTunnelFrameReadyListener(mMediaCodecHandler, mFirstTunnelFrameReadyListener);
     } else {
       Log.w(
           TAG,

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -277,7 +277,7 @@ class MediaCodecBridge {
   }
 
   public static MediaCodec createMediaCodecOnHandlerThread(String decoderName, HandlerThread handlerThread) {
-    if (decoderName.equals("")) {
+    if (decoderName == null || decoderName.isEmpty()) {
       return null;
     }
     final MediaCodec[] result = new MediaCodec[1];
@@ -310,11 +310,12 @@ class MediaCodecBridge {
       int tunnelModeAudioSessionId,
       boolean enableFrameRendererListener,
       boolean enableIgnoreCallbacksDuringFlushing) {
-    mMediaCodecThread = new HandlerThread("MediaCodecBridgeThread");
+    mMediaCodecThread = new HandlerThread("MediaCodecBridgeThread_" + decoderName);
     mMediaCodecThread.start();
     mMediaCodecHandler = new Handler(mMediaCodecThread.getLooper());
     MediaCodec mediaCodec = createMediaCodecOnHandlerThread(decoderName, mMediaCodecThread);
     if (mediaCodec == null) {
+      mMediaCodecThread.quitSafely();
       throw new IllegalArgumentException("Failed to create MediaCodec for " + decoderName);
     }
     mNativeMediaCodecBridge = nativeMediaCodecBridge;
@@ -455,6 +456,15 @@ class MediaCodecBridge {
       boolean ignoreCodecCallbacksDuringFlushing,
       boolean enableLowLatency,
       CreateMediaCodecBridgeResult outCreateMediaCodecBridgeResult) {
+    outCreateMediaCodecBridgeResult.mMediaCodecBridge = null;
+
+    if (decoderName == null || decoderName.isEmpty()) {
+      String message = "Invalid decoder name.";
+      Log.e(TAG, message);
+      outCreateMediaCodecBridgeResult.mErrorMessage = message;
+      return;
+    }
+
     MediaCodecBridge bridge;
     try {
       Log.i(TAG, "Creating \"%s\" decoder.", decoderName);
@@ -482,22 +492,26 @@ class MediaCodecBridge {
     MediaCodec mediaCodec = bridge.getMediaCodec();
     if (mediaCodec == null) {
       outCreateMediaCodecBridgeResult.mErrorMessage = "mediaCodec is null";
+      bridge.release();
       return;
     }
 
     MediaCodecInfo codecInfo = mediaCodec.getCodecInfo();
     if (codecInfo == null) {
       outCreateMediaCodecBridgeResult.mErrorMessage = "codecInfo is null";
+      bridge.release();
       return;
     }
     CodecCapabilities codecCapabilities = codecInfo.getCapabilitiesForType(mime);
     if (codecCapabilities == null) {
       outCreateMediaCodecBridgeResult.mErrorMessage = "codecCapabilities is null";
+      bridge.release();
       return;
     }
     VideoCapabilities videoCapabilities = codecCapabilities.getVideoCapabilities();
     if (videoCapabilities == null) {
       outCreateMediaCodecBridgeResult.mErrorMessage = "videoCapabilities is null";
+      bridge.release();
       return;
     }
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -276,7 +276,8 @@ class MediaCodecBridge {
     }
   }
 
-  public static MediaCodec createMediaCodecOnHandlerThread(String decoderName, HandlerThread handlerThread) {
+  public static MediaCodec createMediaCodecOnHandlerThread(
+      String decoderName, HandlerThread handlerThread) {
     if (decoderName == null || decoderName.isEmpty()) {
       return null;
     }
@@ -326,6 +327,7 @@ class MediaCodecBridge {
     }
     if (exception[0] != null) {
       Log.e(TAG, "Failed to create MediaCodec on HandlerThread: %s", decoderName, exception[0]);
+      throw new RuntimeException("Failed to create MediaCodec on HandlerThread", exception[0]);
     }
     return result[0];
   }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -276,7 +276,7 @@ class MediaCodecBridge {
     }
   }
 
-  public static MediaCodec createMediaCodecOnHandlerThread(
+  private static MediaCodec createMediaCodecOnHandlerThread(
       String decoderName, HandlerThread handlerThread) {
     if (decoderName == null || decoderName.isEmpty()) {
       return null;
@@ -344,6 +344,9 @@ class MediaCodecBridge {
       int tunnelModeAudioSessionId,
       boolean enableFrameRendererListener,
       boolean enableIgnoreCallbacksDuringFlushing) {
+    if (decoderName == null || decoderName.isEmpty()) {
+      throw new IllegalArgumentException("Decoder name cannot be null or empty");
+    }
     mMediaCodecThread = new HandlerThread("MediaCodecBridgeThread_" + decoderName);
     mMediaCodecThread.start();
     Looper looper = mMediaCodecThread.getLooper();
@@ -835,7 +838,7 @@ class MediaCodecBridge {
     return MediaCodecStatus.OK;
   }
 
-  public MediaCodec getMediaCodec() {
+  private MediaCodec getMediaCodec() {
     try {
       return mMediaCodec.get();
     } catch (Exception e) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -32,6 +32,7 @@ import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
+import android.os.HandlerThread;
 import android.view.Surface;
 import androidx.annotation.GuardedBy;
 import androidx.annotation.NonNull;
@@ -64,10 +65,12 @@ class MediaCodecBridge {
   private final SynchronizedHolder<MediaCodec, IllegalStateException> mMediaCodec =
       new SynchronizedHolder<>(() -> new IllegalStateException("MediaCodec was destroyed"));
 
-  // mMainHandler is used to ensure that MediaCodec callbacks and state transitions
-  // (like resetting mIsFlushing) happen on the main thread, providing a consistent
-  // execution environment and avoiding potential race conditions with the native layer.
-  private final Handler mMainHandler = new Handler(Looper.getMainLooper());
+  // mMediaCodecThread and mMediaCodecHandler are used to ensure that MediaCodec callbacks
+  // and state transitions (like resetting mIsFlushing) happen on a dedicated single-threaded
+  // HandlerThread, providing a consistent, ordered execution environment without stalling the
+  // main UI thread (CrBrowserMain).
+  private final HandlerThread mMediaCodecThread;
+  private final Handler mMediaCodecHandler;
   private volatile boolean mIsFlushing = false;
   private final boolean mEnableIgnoreCallbacksDuringFlushing;
 
@@ -273,14 +276,46 @@ class MediaCodecBridge {
     }
   }
 
+  public static MediaCodec createMediaCodecOnHandlerThread(String decoderName, HandlerThread handlerThread) {
+    if (decoderName.equals("")) {
+      return null;
+    }
+    final MediaCodec[] result = new MediaCodec[1];
+    final Exception[] exception = new Exception[1];
+    Handler handler = new Handler(handlerThread.getLooper());
+    java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
+    handler.post(() -> {
+      try {
+        result[0] = MediaCodec.createByCodecName(decoderName);
+      } catch (Exception e) {
+        exception[0] = e;
+      } finally {
+        latch.countDown();
+      }
+    });
+    try {
+      latch.await();
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+    }
+    if (exception[0] != null) {
+      Log.e(TAG, "Failed to create MediaCodec on HandlerThread: %s", decoderName, exception[0]);
+    }
+    return result[0];
+  }
+
   public MediaCodecBridge(
       long nativeMediaCodecBridge,
-      MediaCodec mediaCodec,
+      String decoderName,
       int tunnelModeAudioSessionId,
       boolean enableFrameRendererListener,
       boolean enableIgnoreCallbacksDuringFlushing) {
+    mMediaCodecThread = new HandlerThread("MediaCodecBridgeThread");
+    mMediaCodecThread.start();
+    mMediaCodecHandler = new Handler(mMediaCodecThread.getLooper());
+    MediaCodec mediaCodec = createMediaCodecOnHandlerThread(decoderName, mMediaCodecThread);
     if (mediaCodec == null) {
-      throw new IllegalArgumentException();
+      throw new IllegalArgumentException("Failed to create MediaCodec for " + decoderName);
     }
     mNativeMediaCodecBridge = nativeMediaCodecBridge;
     mMediaCodec.set(mediaCodec);
@@ -356,7 +391,7 @@ class MediaCodecBridge {
         };
 
     if (mEnableIgnoreCallbacksDuringFlushing) {
-      mMediaCodec.get().setCallback(mCallback, mMainHandler);
+      mMediaCodec.get().setCallback(mCallback, mMediaCodecHandler);
     } else {
       mMediaCodec.get().setCallback(mCallback);
     }
@@ -377,7 +412,7 @@ class MediaCodecBridge {
             }
           };
       if (mEnableIgnoreCallbacksDuringFlushing) {
-        mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, mMainHandler);
+        mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, mMediaCodecHandler);
       } else {
         mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, null);
       }
@@ -420,24 +455,21 @@ class MediaCodecBridge {
       boolean ignoreCodecCallbacksDuringFlushing,
       boolean enableLowLatency,
       CreateMediaCodecBridgeResult outCreateMediaCodecBridgeResult) {
-    MediaCodec mediaCodec = null;
-    outCreateMediaCodecBridgeResult.mMediaCodecBridge = null;
-
-    if (decoderName.equals("")) {
-      String message = "Invalid decoder name.";
-      Log.e(TAG, message);
-      outCreateMediaCodecBridgeResult.mErrorMessage = message;
-      return;
-    }
-
+    MediaCodecBridge bridge;
     try {
       Log.i(TAG, "Creating \"%s\" decoder.", decoderName);
-      mediaCodec = MediaCodec.createByCodecName(decoderName);
+      bridge =
+          new MediaCodecBridge(
+              nativeMediaCodecBridge,
+              decoderName,
+              tunnelModeAudioSessionId,
+              enableFrameRendererListener,
+              ignoreCodecCallbacksDuringFlushing);
     } catch (Exception e) {
       String message =
           String.format(
               Locale.US,
-              "Failed to create MediaCodec: %s, mustSupportSecure: %s," + " DecoderName: %s",
+              "Failed to create MediaCodecBridge: %s, mustSupportSecure: %s," + " DecoderName: %s",
               mime,
               crypto != null,
               decoderName);
@@ -446,6 +478,8 @@ class MediaCodecBridge {
       outCreateMediaCodecBridgeResult.mErrorMessage = message;
       return;
     }
+
+    MediaCodec mediaCodec = bridge.getMediaCodec();
     if (mediaCodec == null) {
       outCreateMediaCodecBridgeResult.mErrorMessage = "mediaCodec is null";
       return;
@@ -467,13 +501,6 @@ class MediaCodecBridge {
       return;
     }
 
-    MediaCodecBridge bridge =
-        new MediaCodecBridge(
-            nativeMediaCodecBridge,
-            mediaCodec,
-            tunnelModeAudioSessionId,
-            enableFrameRendererListener,
-            ignoreCodecCallbacksDuringFlushing);
     bridge.mSkipVideoFramesOver60Fps = skipVideoFramesOver60Fps;
     MediaCodecOutputTracker.get().register(bridge);
     MediaFormat mediaFormat =
@@ -727,7 +754,7 @@ class MediaCodecBridge {
         mFrameRateEstimator.reset();
       }
       if (mEnableIgnoreCallbacksDuringFlushing) {
-        mMainHandler.post(() -> {
+        mMediaCodecHandler.post(() -> {
           synchronized (mNativeBridgeLock) {
             mIsFlushing = false;
           }
@@ -735,6 +762,14 @@ class MediaCodecBridge {
       }
     }
     return MediaCodecStatus.OK;
+  }
+
+  public MediaCodec getMediaCodec() {
+    try {
+      return mMediaCodec.get();
+    } catch (Exception e) {
+      return null;
+    }
   }
 
   @CalledByNative
@@ -766,6 +801,9 @@ class MediaCodecBridge {
       Log.w(TAG, "Failed to release MediaCodec", e);
     }
     mMediaCodec.set(null);
+    if (mMediaCodecThread != null) {
+      mMediaCodecThread.quitSafely();
+    }
   }
 
   @CalledByNative
@@ -1090,7 +1128,7 @@ class MediaCodecBridge {
             }
           };
       if (mEnableIgnoreCallbacksDuringFlushing) {
-        mMediaCodec.get().setOnFirstTunnelFrameReadyListener(mMainHandler, mFirstTunnelFrameReadyListener);
+        mMediaCodec.get().setOnFirstTunnelFrameReadyListener(mMediaCodecHandler, mFirstTunnelFrameReadyListener);
       } else {
         mMediaCodec.get().setOnFirstTunnelFrameReadyListener(null, mFirstTunnelFrameReadyListener);
       }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -285,7 +285,12 @@ class MediaCodecBridge {
     final Throwable[] exception = new Throwable[1];
     final boolean[] cancelled = new boolean[1];
     final Object lock = new Object();
-    Handler handler = new Handler(handlerThread.getLooper());
+    Looper looper = handlerThread.getLooper();
+    if (looper == null) {
+      Log.e(TAG, "HandlerThread looper is null for decoder: %s", decoderName);
+      return null;
+    }
+    Handler handler = new Handler(looper);
     java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
     boolean posted = handler.post(() -> {
       try {
@@ -324,6 +329,7 @@ class MediaCodecBridge {
         }
       }
       Thread.currentThread().interrupt();
+      throw new RuntimeException("MediaCodec creation was interrupted", e);
     }
     if (exception[0] != null) {
       Log.e(TAG, "Failed to create MediaCodec on HandlerThread: %s", decoderName, exception[0]);
@@ -340,7 +346,12 @@ class MediaCodecBridge {
       boolean enableIgnoreCallbacksDuringFlushing) {
     mMediaCodecThread = new HandlerThread("MediaCodecBridgeThread_" + decoderName);
     mMediaCodecThread.start();
-    mMediaCodecHandler = new Handler(mMediaCodecThread.getLooper());
+    Looper looper = mMediaCodecThread.getLooper();
+    if (looper == null) {
+      mMediaCodecThread.quitSafely();
+      throw new RuntimeException("Failed to obtain Looper for MediaCodecBridgeThread");
+    }
+    mMediaCodecHandler = new Handler(looper);
     MediaCodec mediaCodec = null;
     try {
       mediaCodec = createMediaCodecOnHandlerThread(decoderName, mMediaCodecThread);

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -1243,6 +1243,10 @@ class MediaCodecBridge {
     return false;
   }
 
+  HandlerThread getMediaCodecThreadForTesting() {
+    return mMediaCodecThread;
+  }
+
   @NativeMethods
   interface Natives {
     void onMediaCodecError(

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -284,7 +284,7 @@ class MediaCodecBridge {
     final Exception[] exception = new Exception[1];
     Handler handler = new Handler(handlerThread.getLooper());
     java.util.concurrent.CountDownLatch latch = new java.util.concurrent.CountDownLatch(1);
-    handler.post(() -> {
+    boolean posted = handler.post(() -> {
       try {
         result[0] = MediaCodec.createByCodecName(decoderName);
       } catch (Exception e) {
@@ -293,6 +293,10 @@ class MediaCodecBridge {
         latch.countDown();
       }
     });
+    if (!posted) {
+      Log.e(TAG, "Failed to post MediaCodec creation task to HandlerThread: %s", decoderName);
+      return null;
+    }
     try {
       latch.await();
     } catch (InterruptedException e) {
@@ -313,116 +317,120 @@ class MediaCodecBridge {
     mMediaCodecThread = new HandlerThread("MediaCodecBridgeThread_" + decoderName);
     mMediaCodecThread.start();
     mMediaCodecHandler = new Handler(mMediaCodecThread.getLooper());
-    MediaCodec mediaCodec = createMediaCodecOnHandlerThread(decoderName, mMediaCodecThread);
-    if (mediaCodec == null) {
-      mMediaCodecThread.quitSafely();
-      throw new IllegalArgumentException("Failed to create MediaCodec for " + decoderName);
-    }
-    mNativeMediaCodecBridge = nativeMediaCodecBridge;
-    mMediaCodec.set(mediaCodec);
-    mIsTunnelingPlayback = tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE;
-    mEnableFrameRendererListener = enableFrameRendererListener;
-    mEnableIgnoreCallbacksDuringFlushing = enableIgnoreCallbacksDuringFlushing;
-    mCallback =
-        new MediaCodec.Callback() {
-          @Override
-          public void onError(MediaCodec codec, MediaCodec.CodecException e) {
-            synchronized (mNativeBridgeLock) {
-              if (mNativeMediaCodecBridge == 0) {
-                return;
-              }
-              // Always report codec errors, even when we are flushing, as they indicate
-              // critical hardware/decoder level failures that should not be ignored.
-              MediaCodecBridgeJni.get()
-                  .onMediaCodecError(
-                      mNativeMediaCodecBridge,
-                      e.isRecoverable(),
-                      e.isTransient(),
-                      e.getDiagnosticInfo());
-            }
-          }
-
-          @Override
-          public void onInputBufferAvailable(MediaCodec codec, int index) {
-            synchronized (mNativeBridgeLock) {
-              if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
-                return;
-              }
-              MediaCodecBridgeJni.get()
-                  .onMediaCodecInputBufferAvailable(mNativeMediaCodecBridge, index);
-            }
-          }
-
-          @Override
-          public void onOutputBufferAvailable(
-              MediaCodec codec, int index, MediaCodec.BufferInfo info) {
-            synchronized (mNativeBridgeLock) {
-              if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
-                return;
-              }
-              MediaCodecBridgeJni.get()
-                  .onMediaCodecOutputBufferAvailable(
-                      mNativeMediaCodecBridge,
-                      index,
-                      info.flags,
-                      info.offset,
-                      info.presentationTimeUs,
-                      info.size);
-              mActiveOutputBuffers.incrementAndGet();
-              if (mFrameRateEstimator != null) {
-                mFrameRateEstimator.onNewOutput(info.presentationTimeUs);
-                updateFrameRate();
-              }
-            }
-          }
-
-          @Override
-          public void onOutputFormatChanged(MediaCodec codec, MediaFormat format) {
-            synchronized (mNativeBridgeLock) {
-              if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
-                return;
-              }
-              mActiveFormat = new MediaFormatWrapper(format);
-              MediaCodecBridgeJni.get().onMediaCodecOutputFormatChanged(mNativeMediaCodecBridge);
-              if (mFrameRateEstimator != null) {
-                mFrameRateEstimator.reset();
-              }
-            }
-          }
-        };
-
-    if (mEnableIgnoreCallbacksDuringFlushing) {
-      mMediaCodec.get().setCallback(mCallback, mMediaCodecHandler);
-    } else {
-      mMediaCodec.get().setCallback(mCallback);
-    }
-
-    if (mEnableFrameRendererListener) {
-      mFrameRendererListener =
-          new MediaCodec.OnFrameRenderedListener() {
+    try {
+      MediaCodec mediaCodec = createMediaCodecOnHandlerThread(decoderName, mMediaCodecThread);
+      if (mediaCodec == null) {
+        throw new IllegalArgumentException("Failed to create MediaCodec for " + decoderName);
+      }
+      mNativeMediaCodecBridge = nativeMediaCodecBridge;
+      mMediaCodec.set(mediaCodec);
+      mIsTunnelingPlayback = tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE;
+      mEnableFrameRendererListener = enableFrameRendererListener;
+      mEnableIgnoreCallbacksDuringFlushing = enableIgnoreCallbacksDuringFlushing;
+      mCallback =
+          new MediaCodec.Callback() {
             @Override
-            public void onFrameRendered(MediaCodec codec, long presentationTimeUs, long nanoTime) {
+            public void onError(MediaCodec codec, MediaCodec.CodecException e) {
+              synchronized (mNativeBridgeLock) {
+                if (mNativeMediaCodecBridge == 0) {
+                  return;
+                }
+                // Always report codec errors, even when we are flushing, as they indicate
+                // critical hardware/decoder level failures that should not be ignored.
+                MediaCodecBridgeJni.get()
+                    .onMediaCodecError(
+                        mNativeMediaCodecBridge,
+                        e.isRecoverable(),
+                        e.isTransient(),
+                        e.getDiagnosticInfo());
+              }
+            }
+
+            @Override
+            public void onInputBufferAvailable(MediaCodec codec, int index) {
               synchronized (mNativeBridgeLock) {
                 if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
                   return;
                 }
                 MediaCodecBridgeJni.get()
-                    .onMediaCodecFrameRendered(
-                        mNativeMediaCodecBridge, presentationTimeUs, nanoTime);
+                    .onMediaCodecInputBufferAvailable(mNativeMediaCodecBridge, index);
+              }
+            }
+
+            @Override
+            public void onOutputBufferAvailable(
+                MediaCodec codec, int index, MediaCodec.BufferInfo info) {
+              synchronized (mNativeBridgeLock) {
+                if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
+                  return;
+                }
+                MediaCodecBridgeJni.get()
+                    .onMediaCodecOutputBufferAvailable(
+                        mNativeMediaCodecBridge,
+                        index,
+                        info.flags,
+                        info.offset,
+                        info.presentationTimeUs,
+                        info.size);
+                mActiveOutputBuffers.incrementAndGet();
+                if (mFrameRateEstimator != null) {
+                  mFrameRateEstimator.onNewOutput(info.presentationTimeUs);
+                  updateFrameRate();
+                }
+              }
+            }
+
+            @Override
+            public void onOutputFormatChanged(MediaCodec codec, MediaFormat format) {
+              synchronized (mNativeBridgeLock) {
+                if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
+                  return;
+                }
+                mActiveFormat = new MediaFormatWrapper(format);
+                MediaCodecBridgeJni.get().onMediaCodecOutputFormatChanged(mNativeMediaCodecBridge);
+                if (mFrameRateEstimator != null) {
+                  mFrameRateEstimator.reset();
+                }
               }
             }
           };
-      if (mEnableIgnoreCallbacksDuringFlushing) {
-        mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, mMediaCodecHandler);
-      } else {
-        mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, null);
-      }
-    }
 
-    if (mIsTunnelingPlayback) {
-      setupTunnelingPlayback();
+      if (mEnableIgnoreCallbacksDuringFlushing) {
+        mMediaCodec.get().setCallback(mCallback, mMediaCodecHandler);
+      } else {
+        mMediaCodec.get().setCallback(mCallback);
+      }
+
+      if (mEnableFrameRendererListener) {
+        mFrameRendererListener =
+            new MediaCodec.OnFrameRenderedListener() {
+              @Override
+              public void onFrameRendered(MediaCodec codec, long presentationTimeUs, long nanoTime) {
+                synchronized (mNativeBridgeLock) {
+                  if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
+                    return;
+                  }
+                  MediaCodecBridgeJni.get()
+                      .onMediaCodecFrameRendered(
+                          mNativeMediaCodecBridge, presentationTimeUs, nanoTime);
+                }
+              }
+            };
+        if (mEnableIgnoreCallbacksDuringFlushing) {
+          mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, mMediaCodecHandler);
+        } else {
+          mMediaCodec.get().setOnFrameRenderedListener(mFrameRendererListener, null);
+        }
+      }
+
+      if (mIsTunnelingPlayback) {
+        setupTunnelingPlayback();
+      }
+      mFrameRateEstimator = MediaCodecFrameRateEstimator.create(mIsTunnelingPlayback);
+    } catch (Throwable t) {
+      mMediaCodecThread.quitSafely();
+      throw t;
     }
-    mFrameRateEstimator = MediaCodecFrameRateEstimator.create(mIsTunnelingPlayback);
   }
 
   private boolean isDecodeOnlyFlagEnabled() {
@@ -489,28 +497,36 @@ class MediaCodecBridge {
       return;
     }
 
-    MediaCodec mediaCodec = bridge.getMediaCodec();
-    if (mediaCodec == null) {
-      outCreateMediaCodecBridgeResult.mErrorMessage = "mediaCodec is null";
-      bridge.release();
-      return;
-    }
+    CodecCapabilities codecCapabilities = null;
+    VideoCapabilities videoCapabilities = null;
+    try {
+      MediaCodec mediaCodec = bridge.getMediaCodec();
+      if (mediaCodec == null) {
+        outCreateMediaCodecBridgeResult.mErrorMessage = "mediaCodec is null";
+        bridge.release();
+        return;
+      }
 
-    MediaCodecInfo codecInfo = mediaCodec.getCodecInfo();
-    if (codecInfo == null) {
-      outCreateMediaCodecBridgeResult.mErrorMessage = "codecInfo is null";
-      bridge.release();
-      return;
-    }
-    CodecCapabilities codecCapabilities = codecInfo.getCapabilitiesForType(mime);
-    if (codecCapabilities == null) {
-      outCreateMediaCodecBridgeResult.mErrorMessage = "codecCapabilities is null";
-      bridge.release();
-      return;
-    }
-    VideoCapabilities videoCapabilities = codecCapabilities.getVideoCapabilities();
-    if (videoCapabilities == null) {
-      outCreateMediaCodecBridgeResult.mErrorMessage = "videoCapabilities is null";
+      MediaCodecInfo codecInfo = mediaCodec.getCodecInfo();
+      if (codecInfo == null) {
+        outCreateMediaCodecBridgeResult.mErrorMessage = "codecInfo is null";
+        bridge.release();
+        return;
+      }
+      codecCapabilities = codecInfo.getCapabilitiesForType(mime);
+      if (codecCapabilities == null) {
+        outCreateMediaCodecBridgeResult.mErrorMessage = "codecCapabilities is null";
+        bridge.release();
+        return;
+      }
+      videoCapabilities = codecCapabilities.getVideoCapabilities();
+      if (videoCapabilities == null) {
+        outCreateMediaCodecBridgeResult.mErrorMessage = "videoCapabilities is null";
+        bridge.release();
+        return;
+      }
+    } catch (Exception e) {
+      outCreateMediaCodecBridgeResult.mErrorMessage = "Failed to query codec capabilities: " + e.getMessage();
       bridge.release();
       return;
     }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
@@ -37,7 +37,7 @@ class MediaCodecBridgeBuilder {
       int channelCount,
       MediaCrypto crypto,
       @Nullable byte[] configurationData) {
-    if (decoderName.equals("")) {
+    if (decoderName == null || decoderName.isEmpty()) {
       Log.e(TAG, "Invalid decoder name.");
       return null;
     }
@@ -55,30 +55,36 @@ class MediaCodecBridgeBuilder {
       return null;
     }
 
-    byte[][] csds = {};
-    boolean frameHasAdtsHeader = false;
-    if (mime.contains("opus")) {
-      csds = MediaFormatBuilder.starboardParseOpusConfigurationData(sampleRate, configurationData);
-      if (csds == null) {
+    try {
+      byte[][] csds = {};
+      boolean frameHasAdtsHeader = false;
+      if (mime.contains("opus")) {
+        csds = MediaFormatBuilder.starboardParseOpusConfigurationData(sampleRate, configurationData);
+        if (csds == null) {
+          bridge.release();
+          return null;
+        }
+      } else {
+        // TODO: Determine if we should explicitly check the mime for AAC audio before setting
+        // frameHasAdtsHeader to true, as more codecs may be supported here in the future.
+        frameHasAdtsHeader = true;
+      }
+      MediaFormat mediaFormat =
+          MediaFormatBuilder.createAudioFormat(
+              mime, sampleRate, channelCount, csds, frameHasAdtsHeader);
+
+      if (!bridge.configureAudio(mediaFormat, crypto, 0)) {
+        Log.e(TAG, "Failed to configure audio codec.");
         bridge.release();
         return null;
       }
-    } else {
-      // TODO: Determine if we should explicitly check the mime for AAC audio before setting
-      // frameHasAdtsHeader to true, as more codecs may be supported here in the future.
-      frameHasAdtsHeader = true;
-    }
-    MediaFormat mediaFormat =
-        MediaFormatBuilder.createAudioFormat(
-            mime, sampleRate, channelCount, csds, frameHasAdtsHeader);
-
-    if (!bridge.configureAudio(mediaFormat, crypto, 0)) {
-      Log.e(TAG, "Failed to configure audio codec.");
-      bridge.release();
-      return null;
-    }
-    if (!bridge.start()) {
-      Log.e(TAG, "Failed to start audio codec.");
+      if (!bridge.start()) {
+        Log.e(TAG, "Failed to start audio codec.");
+        bridge.release();
+        return null;
+      }
+    } catch (Throwable t) {
+      Log.e(TAG, "Failed to initialize audio decoder due to exception: ", t);
       bridge.release();
       return null;
     }

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
@@ -59,7 +59,8 @@ class MediaCodecBridgeBuilder {
       byte[][] csds = {};
       boolean frameHasAdtsHeader = false;
       if (mime.contains("opus")) {
-        csds = MediaFormatBuilder.starboardParseOpusConfigurationData(sampleRate, configurationData);
+        csds = MediaFormatBuilder.starboardParseOpusConfigurationData(
+            sampleRate, configurationData);
         if (csds == null) {
           bridge.release();
           return null;

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
@@ -41,24 +41,19 @@ class MediaCodecBridgeBuilder {
       Log.e(TAG, "Invalid decoder name.");
       return null;
     }
-    MediaCodec mediaCodec = null;
+    MediaCodecBridge bridge;
     try {
-      Log.i(TAG, "Creating \"%s\" decoder.", decoderName);
-      mediaCodec = MediaCodec.createByCodecName(decoderName);
+      bridge =
+          new MediaCodecBridge(
+              nativeMediaCodecBridge,
+              decoderName,
+              TunnelModeAudioSessionId.NONE,
+              /*enableFrameRendererListener=*/false,
+              /*enableIgnoreCallbacksDuringFlushing=*/false);
     } catch (Exception e) {
-      Log.e(TAG, "Failed to create MediaCodec: %s, DecoderName: %s", mime, decoderName, e);
+      Log.e(TAG, "Failed to create MediaCodecBridge: %s, DecoderName: %s", mime, decoderName, e);
       return null;
     }
-    if (mediaCodec == null) {
-      return null;
-    }
-    MediaCodecBridge bridge =
-        new MediaCodecBridge(
-            nativeMediaCodecBridge,
-            mediaCodec,
-            TunnelModeAudioSessionId.NONE,
-            /*enableFrameRendererListener=*/false,
-            /*enableIgnoreCallbacksDuringFlushing=*/false);
 
     byte[][] csds = {};
     boolean frameHasAdtsHeader = false;

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/media/MediaCodecBridgeTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/media/MediaCodecBridgeTest.java
@@ -1,0 +1,164 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.media;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import android.os.HandlerThread;
+import android.os.Process;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowMediaCodec;
+import android.media.MediaCodec;
+import java.io.IOException;
+import org.robolectric.annotation.Implementation;
+import org.robolectric.annotation.Implements;
+
+/** Unit Tests for MediaCodecBridge class. */
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE)
+public class MediaCodecBridgeTest {
+
+  @Before
+  public void setUp() {
+    ShadowMediaCodec.clearCodecs();
+    // Register a mock decoder for testing.
+    ShadowMediaCodec.addDecoder(
+        "mock-h264-decoder",
+        new ShadowMediaCodec.CodecConfig(
+            /* inputBufferSize= */ 1024,
+            /* outputBufferSize= */ 1024,
+            (input, output) -> output.put(input)));
+  }
+
+  @Test
+  public void testConstructor_SuccessfulCreationSpawnsThread() {
+    MediaCodecBridge bridge = null;
+    try {
+      bridge =
+          new MediaCodecBridge(
+              12345L,
+              "mock-h264-decoder",
+              TunnelModeAudioSessionId.NONE,
+              /* enableFrameRendererListener= */ false,
+              /* enableIgnoreCallbacksDuringFlushing= */ false);
+
+      HandlerThread thread = bridge.getMediaCodecThreadForTesting();
+      assertNotNull("HandlerThread should be non-null", thread);
+      assertTrue("HandlerThread should be started and alive", thread.isAlive());
+      assertEquals(
+          "Thread priority should be THREAD_PRIORITY_VIDEO",
+          Process.THREAD_PRIORITY_VIDEO,
+          Process.getThreadPriority(thread.getThreadId()));
+    } finally {
+      if (bridge != null) {
+        HandlerThread thread = bridge.getMediaCodecThreadForTesting();
+        bridge.release();
+        if (thread != null) {
+          try {
+            thread.join(1000);
+          } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+          }
+          assertFalse(
+              "Thread should be stopped after release",
+              thread.isAlive());
+        }
+      }
+    }
+  }
+
+  @Test
+  public void testConstructor_InvalidDecoderNameThrowsIllegalArgumentException() {
+    try {
+      new MediaCodecBridge(
+          12345L,
+          null, // Null decoder name
+          TunnelModeAudioSessionId.NONE,
+          /* enableFrameRendererListener= */ false,
+          /* enableIgnoreCallbacksDuringFlushing= */ false);
+      fail("Should have thrown IllegalArgumentException for null decoderName");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Decoder name cannot be null or empty", e.getMessage());
+    }
+
+    try {
+      new MediaCodecBridge(
+          12345L,
+          "", // Empty decoder name
+          TunnelModeAudioSessionId.NONE,
+          /* enableFrameRendererListener= */ false,
+          /* enableIgnoreCallbacksDuringFlushing= */ false);
+      fail("Should have thrown IllegalArgumentException for empty decoderName");
+    } catch (IllegalArgumentException e) {
+      assertEquals("Decoder name cannot be null or empty", e.getMessage());
+    }
+  }
+
+  @Test
+  @Config(shadows = {ShadowFailingMediaCodec.class})
+  public void testConstructor_FailureToCreateCodecCleansUpThread() {
+    try {
+      new MediaCodecBridge(
+          12345L,
+          "unregistered-decoder-name",
+          TunnelModeAudioSessionId.NONE,
+          /* enableFrameRendererListener= */ false,
+          /* enableIgnoreCallbacksDuringFlushing= */ false);
+      fail("Should have thrown RuntimeException due to codec creation failure");
+    } catch (RuntimeException e) {
+      assertTrue(
+          "Exception should contain cause of failure",
+          e.getMessage().contains("Failed to create MediaCodec on HandlerThread"));
+    }
+    // Join the thread if found to wait for its asynchronous shutdown
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      if (t.getName().startsWith("MediaCodecBridgeThread_unregistered-decoder-name")) {
+        try {
+          t.join(1000);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+    // Now verify no alive thread remains
+    boolean foundAliveThread = false;
+    for (Thread t : Thread.getAllStackTraces().keySet()) {
+      if (t.getName().startsWith("MediaCodecBridgeThread_unregistered-decoder-name")) {
+        if (t.isAlive()) {
+          foundAliveThread = true;
+        }
+      }
+    }
+    assertFalse(
+        "Spun up thread should have been stopped during failure cleanup",
+        foundAliveThread);
+  }
+
+  @Implements(MediaCodec.class)
+  public static class ShadowFailingMediaCodec {
+    @Implementation
+    public static MediaCodec createByCodecName(String name) throws IOException {
+      throw new IOException("Simulated codec creation failure for: " + name);
+    }
+  }
+}


### PR DESCRIPTION
Instantiate MediaCodec and route its callbacks to a dedicated
background HandlerThread.

Previously, MediaCodec instances were created on the main UI thread,
causing Android framework events to bind to the CrBrowserMain looper.
This resulted in significant main thread execution time and Java
monitor lock contention during playback.

By moving instantiation and event handling to a dedicated thread,
we eliminate these looper stalls and improve UI responsiveness.

Bug: 530222962