### PR TITLE
media: Support area-based video buffer budget - h5vcc version

### DIFF
--- a/media/starboard/decoder_buffer_memory_info.cc
+++ b/media/starboard/decoder_buffer_memory_info.cc
@@ -14,12 +14,73 @@
 
 #include "media/starboard/decoder_buffer_memory_info.h"
 
+#include <algorithm>
+#include <atomic>
+
+#include "base/logging.h"
 #include "media/base/video_codecs.h"
 #include "media/starboard/starboard_utils.h"
 #include "starboard/media.h"
+#include "starboard/shared/starboard/media/resolutions.h"
 #include "ui/gfx/geometry/size.h"
 
+#if BUILDFLAG(IS_ANDROID)
+#include "starboard/android/shared/runtime_resource_overlay.h"
+#endif  // BUILDFLAG(IS_ANDROID)
+
 namespace media {
+
+namespace {
+std::atomic<bool> g_enable_area_based_video_buffer_budget{false};
+constexpr int kMaxVideoBufferBudget = 200 * 1024 * 1024;
+
+#if BUILDFLAG(IS_ANDROID)
+// this is duplicated from
+// starboard/android/shared/media_get_video_buffer_budget.cc in order to allow
+// h5vcc experimentation.
+int ExperimentalAreaBasedVideoBufferBudget(int resolution_width,
+                                           int resolution_height,
+                                           int bits_per_pixel) {
+  auto get_overlaid_video_buffer_budget = []() {
+    auto* overlay = starboard::RuntimeResourceOverlay::GetInstance();
+    if (!overlay) {
+      return kMaxVideoBufferBudget;
+    }
+
+    int buffer_budget = overlay->max_video_buffer_budget();
+    if (buffer_budget <= 0 || buffer_budget > 2047) {
+      return kMaxVideoBufferBudget;
+    }
+    LOG(INFO) << "RRO \"max_video_buffer_budget\" is set to " << buffer_budget
+              << " MB.";
+    return buffer_budget * 1024 * 1024;
+  };
+
+  static const int overlaid_video_buffer_budget =
+      get_overlaid_video_buffer_budget();
+
+  int video_buffer_budget = 0;
+  starboard::Size resolution(resolution_width, resolution_height);
+  if (resolution.IsEmpty() ||
+      resolution.GetArea() <= starboard::Resolution::k1080p.GetArea()) {
+    video_buffer_budget = 30 * 1024 * 1024;
+  } else if (resolution.GetArea() <= starboard::Resolution::k4k.GetArea()) {
+    if (bits_per_pixel <= 8) {
+      video_buffer_budget = 100 * 1024 * 1024;
+    } else {
+      video_buffer_budget = 160 * 1024 * 1024;
+    }
+  } else {
+    video_buffer_budget = kMaxVideoBufferBudget;
+  }
+  return std::min(video_buffer_budget, overlaid_video_buffer_budget);
+}
+#endif  // BUILDFLAG(IS_ANDROID)
+}  // namespace
+
+void EnableAreaBasedVideoBufferBudget() {
+  g_enable_area_based_video_buffer_budget.store(true);
+}
 
 int GetAudioDecoderBufferLimitBytes() {
   return SbMediaGetAudioBufferBudget();
@@ -28,6 +89,12 @@ int GetAudioDecoderBufferLimitBytes() {
 int GetVideoDecoderBufferLimitBytes(VideoCodec codec,
                                     const gfx::Size& resolution,
                                     int bits_per_pixel) {
+#if BUILDFLAG(IS_ANDROID)
+  if (g_enable_area_based_video_buffer_budget.load()) {
+    return ExperimentalAreaBasedVideoBufferBudget(
+        resolution.width(), resolution.height(), bits_per_pixel);
+  }
+#endif  // BUILDFLAG(IS_ANDROID)
   return SbMediaGetVideoBufferBudget(MediaVideoCodecToSbMediaVideoCodec(codec),
                                      resolution.width(), resolution.height(),
                                      bits_per_pixel);

--- a/media/starboard/decoder_buffer_memory_info.cc
+++ b/media/starboard/decoder_buffer_memory_info.cc
@@ -61,9 +61,11 @@ int ExperimentalAreaBasedVideoBufferBudget(const gfx::Size& resolution,
   constexpr int64_t k4kArea = 3840 * 2160;
 
   int video_buffer_budget = 0;
-  if (resolution.IsEmpty() || resolution.GetArea() <= k1080pArea) {
+  const int64_t area =
+      static_cast<int64_t>(resolution.width()) * resolution.height();
+  if (resolution.IsEmpty() || area <= k1080pArea) {
     video_buffer_budget = 30 * 1024 * 1024;
-  } else if (resolution.GetArea() <= k4kArea) {
+  } else if (area <= k4kArea) {
     if (bits_per_pixel <= 8) {
       video_buffer_budget = 100 * 1024 * 1024;
     } else {

--- a/media/starboard/decoder_buffer_memory_info.cc
+++ b/media/starboard/decoder_buffer_memory_info.cc
@@ -21,7 +21,6 @@
 #include "media/base/video_codecs.h"
 #include "media/starboard/starboard_utils.h"
 #include "starboard/media.h"
-#include "starboard/shared/starboard/media/resolutions.h"
 #include "ui/gfx/geometry/size.h"
 
 #if BUILDFLAG(IS_ANDROID)
@@ -32,14 +31,13 @@ namespace media {
 
 namespace {
 std::atomic<bool> g_enable_area_based_video_buffer_budget{false};
-constexpr int kMaxVideoBufferBudget = 200 * 1024 * 1024;
 
 #if BUILDFLAG(IS_ANDROID)
+constexpr int kMaxVideoBufferBudget = 200 * 1024 * 1024;
 // this is duplicated from
 // starboard/android/shared/media_get_video_buffer_budget.cc in order to allow
 // h5vcc experimentation.
-int ExperimentalAreaBasedVideoBufferBudget(int resolution_width,
-                                           int resolution_height,
+int ExperimentalAreaBasedVideoBufferBudget(const gfx::Size& resolution,
                                            int bits_per_pixel) {
   auto get_overlaid_video_buffer_budget = []() {
     auto* overlay = starboard::RuntimeResourceOverlay::GetInstance();
@@ -59,12 +57,13 @@ int ExperimentalAreaBasedVideoBufferBudget(int resolution_width,
   static const int overlaid_video_buffer_budget =
       get_overlaid_video_buffer_budget();
 
+  constexpr int64_t k1080pArea = 1920 * 1080;
+  constexpr int64_t k4kArea = 3840 * 2160;
+
   int video_buffer_budget = 0;
-  starboard::Size resolution(resolution_width, resolution_height);
-  if (resolution.IsEmpty() ||
-      resolution.GetArea() <= starboard::Resolution::k1080p.GetArea()) {
+  if (resolution.IsEmpty() || resolution.GetArea() <= k1080pArea) {
     video_buffer_budget = 30 * 1024 * 1024;
-  } else if (resolution.GetArea() <= starboard::Resolution::k4k.GetArea()) {
+  } else if (resolution.GetArea() <= k4kArea) {
     if (bits_per_pixel <= 8) {
       video_buffer_budget = 100 * 1024 * 1024;
     } else {
@@ -91,8 +90,7 @@ int GetVideoDecoderBufferLimitBytes(VideoCodec codec,
                                     int bits_per_pixel) {
 #if BUILDFLAG(IS_ANDROID)
   if (g_enable_area_based_video_buffer_budget.load()) {
-    return ExperimentalAreaBasedVideoBufferBudget(
-        resolution.width(), resolution.height(), bits_per_pixel);
+    return ExperimentalAreaBasedVideoBufferBudget(resolution, bits_per_pixel);
   }
 #endif  // BUILDFLAG(IS_ANDROID)
   return SbMediaGetVideoBufferBudget(MediaVideoCodecToSbMediaVideoCodec(codec),

--- a/media/starboard/decoder_buffer_memory_info.h
+++ b/media/starboard/decoder_buffer_memory_info.h
@@ -23,6 +23,8 @@
 
 namespace media {
 
+MEDIA_EXPORT void EnableAreaBasedVideoBufferBudget();
+
 class DecoderBufferMemoryInfo {
  public:
   virtual ~DecoderBufferMemoryInfo() {}

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -20,6 +20,7 @@
 #include "media/base/demuxer_memory_limit.h"
 #include "media/base/stream_parser.h"
 #include "media/filters/source_buffer_state.h"
+#include "media/starboard/decoder_buffer_memory_info.h"
 #include "third_party/blink/public/platform/browser_interface_broker_proxy.h"
 #include "third_party/blink/renderer/bindings/core/v8/idl_types.h"
 #include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
@@ -225,6 +226,13 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
     return ProcessSettingAsPositiveInt(
         script_state, exception_context, name, *value, [](int int_value) {
           ::media::Set720pVideoBufferSizeClamp(int_value);
+          return true;
+        });
+  }
+  if (name == "Media.EnableAreaBasedVideoBufferBudget") {
+    return ProcessSettingAsEnableOnly(
+        script_state, exception_context, name, *value, [] {
+          ::media::EnableAreaBasedVideoBufferBudget();
           return true;
         });
   }


### PR DESCRIPTION
Use Area based buffer budget for Android experiment.

This is an alternative version of https://github.com/youtube/cobalt/pull/11170 to compare using h5vcc for experimentation rather than a java flag.

Currently the MediaSource buffer budget is vertical resolution based, e.g. on Android TV 30 MB is used for 1080p, 100 MB is used for 4K SDR, and 160 MB is used for 4K HDR.

When a Shorts is played at 1080x1920, while having the same pixel count to a 1080p video, it will allocate MediaSource buffer as a 4K video based on the vertical resolution.

This PR implements the change on Android, gated by an h5vcc switch.

Bug: 520049429