### PR TITLE
starboard: Fix compiler warnings to build starboard_unittests again

### DIFF
--- a/starboard/common/bidirectional_fit_reuse_allocator_test.cc
+++ b/starboard/common/bidirectional_fit_reuse_allocator_test.cc
@@ -388,7 +388,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitExactFallbackBlocks) {
 
   EXPECT_TRUE(block1 != nullptr);
   EXPECT_TRUE(block2 != nullptr);
-  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0);
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0U);
 
   // Free them. The allocator may merge the free blocks internally,
   // but it must still decommit the original exact fallback blocks.
@@ -397,7 +397,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitExactFallbackBlocks) {
   this->allocator_->DecommitAllDecommitableBlocks();
 
   // We should have exactly 2 decommits matching the original blocks.
-  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 2);
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 2U);
 
   // They might be decommitted in any order, so check if both exist.
   // Note: For EmbeddedMetadataReuseAllocatorBase, `block1` and `block2` are
@@ -442,7 +442,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitOnBatchedFree) {
     blocks.push_back(block);
   }
 
-  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0);
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0U);
 
   for (void* block : blocks) {
     this->allocator_->Free(block);
@@ -451,7 +451,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitOnBatchedFree) {
 
   // EmbeddedMetadataReuseAllocatorBase batches frees and processes them all at
   // once when idle.
-  EXPECT_GT(this->mock_fallback_allocator_->decommits.size(), 0);
+  EXPECT_GT(this->mock_fallback_allocator_->decommits.size(), 0U);
 
   size_t total_decommitted_size = 0;
   for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
@@ -487,7 +487,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, TieredDecommit) {
   EXPECT_TRUE(block2 != nullptr);
   EXPECT_TRUE(block3 != nullptr);
   EXPECT_TRUE(block4 != nullptr);
-  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0);
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 0U);
 
   // Free them. The allocator should batch them and process when idle.
   this->allocator_->Free(block1);
@@ -497,7 +497,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, TieredDecommit) {
   this->allocator_->DecommitAllDecommitableBlocks();
 
   // Block 1 (retain) is skipped. Block 2, 3, 4 should be decommitted.
-  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 3);
+  EXPECT_EQ(this->mock_fallback_allocator_->decommits.size(), 3U);
 
   bool found_block2 = false;
   bool found_block3 = false;

--- a/starboard/common/memory_test.cc
+++ b/starboard/common/memory_test.cc
@@ -29,7 +29,7 @@ TEST(MemoryIsAlignedTest, CheckAlignmentVariousSizes) {
 }
 
 TEST(MemoryAlignToPageSizeTest, AlignsVariousSizes) {
-  EXPECT_EQ(0, MemoryAlignToPageSize(0));
+  EXPECT_EQ(0U, MemoryAlignToPageSize(0));
   EXPECT_EQ(kSbMemoryPageSize, MemoryAlignToPageSize(1));
   EXPECT_EQ(kSbMemoryPageSize, MemoryAlignToPageSize(kSbMemoryPageSize - 1));
   EXPECT_EQ(kSbMemoryPageSize, MemoryAlignToPageSize(kSbMemoryPageSize));

--- a/starboard/common/queue_test.cc
+++ b/starboard/common/queue_test.cc
@@ -150,19 +150,19 @@ class ProducerConcurrentThread : public Thread {
 
 TEST_F(QueueIntTest, PollEmptyQueueReturnsDefault) {
   EXPECT_EQ(0, queue_.Poll());  // Default for int is 0
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueuePointerTest, PollEmptyQueueReturnsNullptr) {
   EXPECT_EQ(nullptr, queue_.Poll());  // Default for pointer is nullptr
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueIntTest, PutAndPoll) {
   queue_.Put(10);
-  EXPECT_EQ(1, queue_.Size());
+  EXPECT_EQ(1U, queue_.Size());
   EXPECT_EQ(10, queue_.Poll());
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
   EXPECT_EQ(0, queue_.Poll());  // Should be empty now
 }
 
@@ -175,11 +175,11 @@ TEST_F(QueuePointerTest, PutAndPollPointers) {
   queue_.Put(obj1);
   queue_.Put(obj2);
 
-  EXPECT_EQ(2, queue_.Size());
+  EXPECT_EQ(2U, queue_.Size());
   EXPECT_EQ(obj1, queue_.Poll());
-  EXPECT_EQ(1, queue_.Size());
+  EXPECT_EQ(1U, queue_.Size());
   EXPECT_EQ(obj2, queue_.Poll());
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueUniquePointerTest, PutAndPollUniquePointers) {
@@ -192,13 +192,13 @@ TEST_F(QueueUniquePointerTest, PutAndPollUniquePointers) {
   queue_.Put(std::move(obj1));
   queue_.Put(std::move(obj2));
 
-  EXPECT_EQ(2, queue_.Size());
+  EXPECT_EQ(2U, queue_.Size());
   UniqueTestObject retrieved_obj1 = queue_.Poll();
   EXPECT_EQ(raw_obj1, retrieved_obj1.get());
-  EXPECT_EQ(1, queue_.Size());
+  EXPECT_EQ(1U, queue_.Size());
   UniqueTestObject retrieved_obj2 = queue_.Poll();
   EXPECT_EQ(raw_obj2, retrieved_obj2.get());
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueIntTest, GetBlocksUntilItemIsAvailable) {
@@ -210,13 +210,13 @@ TEST_F(QueueIntTest, GetBlocksUntilItemIsAvailable) {
   putter_thread.Join();
 
   EXPECT_EQ(42, received_value);
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueIntTest, GetTimedReturnsDefaultOnTimeout) {
   int received_value = queue_.GetTimed(kMillisInUs * 50);
   EXPECT_EQ(0, received_value);
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueIntTest, GetTimedRetrievesItemWithinTimeout) {
@@ -228,7 +228,7 @@ TEST_F(QueueIntTest, GetTimedRetrievesItemWithinTimeout) {
   putter_thread.Join();
 
   EXPECT_EQ(99, received_value);
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueIntTest, WakeWakesUpGetCall) {
@@ -240,7 +240,7 @@ TEST_F(QueueIntTest, WakeWakesUpGetCall) {
   waker_thread.Join();
 
   EXPECT_EQ(0, received_value);  // Default value for int
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueIntTest, WakeWakesUpGetTimedCall) {
@@ -252,29 +252,29 @@ TEST_F(QueueIntTest, WakeWakesUpGetTimedCall) {
   waker_thread.Join();
 
   EXPECT_EQ(0, received_value);  // Default value for int
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueIntTest, MultiplePutsAndGets) {
   for (int i = 0; i < 100; ++i) {
     queue_.Put(i);
   }
-  EXPECT_EQ(100, queue_.Size());
+  EXPECT_EQ(100U, queue_.Size());
 
   for (int i = 0; i < 100; ++i) {
     EXPECT_EQ(i, queue_.Get());
   }
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 TEST_F(QueueIntTest, ClearEmptiesQueue) {
   queue_.Put(1);
   queue_.Put(2);
   queue_.Put(3);
-  EXPECT_EQ(3, queue_.Size());
+  EXPECT_EQ(3U, queue_.Size());
 
   queue_.Clear();
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
   EXPECT_EQ(0, queue_.Poll());
 }
 
@@ -294,10 +294,10 @@ TEST_F(QueuePointerTest, RemoveSpecificItem) {
   queue_.Put(obj3);
   queue_.Put(obj4);
 
-  EXPECT_EQ(4, queue_.Size());
+  EXPECT_EQ(4U, queue_.Size());
   queue_.Remove(obj2);  // Should remove the first instance of obj2
 
-  EXPECT_EQ(3, queue_.Size());
+  EXPECT_EQ(3U, queue_.Size());
   EXPECT_EQ(obj1, queue_.Poll());
   EXPECT_EQ(obj3, queue_.Poll());
   EXPECT_EQ(obj4, queue_.Poll());
@@ -313,11 +313,11 @@ TEST_F(QueuePointerTest, RemoveNonExistentItem) {
   queue_.Put(obj1);
   queue_.Put(obj2);
 
-  EXPECT_EQ(2, queue_.Size());
+  EXPECT_EQ(2U, queue_.Size());
   auto non_existent_obj_owner = std::make_unique<TestObject>(99);
   queue_.Remove(non_existent_obj_owner.get());  // Should do nothing
 
-  EXPECT_EQ(2, queue_.Size());
+  EXPECT_EQ(2U, queue_.Size());
   EXPECT_EQ(obj1, queue_.Poll());
   EXPECT_EQ(obj2, queue_.Poll());
 }
@@ -372,7 +372,7 @@ TEST_F(QueueIntTest, ConcurrentPutAndGet) {
 
   EXPECT_EQ(kTotalItems, produced_count.load());
   EXPECT_EQ(kTotalItems, consumed_count.load());
-  EXPECT_EQ(0, queue_.Size());
+  EXPECT_EQ(0U, queue_.Size());
 }
 
 }  // namespace

--- a/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
@@ -176,7 +176,7 @@ class AdaptiveAudioDecoderTest
       return;
     }
     ASSERT_LE(static_cast<size_t>(
-                  abs(expected_output_frames - num_of_output_frames_)),
+                  std::abs(expected_output_frames - num_of_output_frames_)),
               dmp_readers_.size());
   }
 

--- a/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
@@ -77,10 +77,10 @@ class AdaptiveAudioDecoderTest
   }
 
   void SetUp() override {
-    ASSERT_GT(dmp_readers_.size(), 0);
+    ASSERT_GT(dmp_readers_.size(), 0U);
     for (auto& dmp_reader : dmp_readers_) {
       ASSERT_NE(dmp_reader->audio_codec(), kSbMediaAudioCodecNone);
-      ASSERT_GT(dmp_reader->number_of_audio_buffers(), 0);
+      ASSERT_GT(dmp_reader->number_of_audio_buffers(), 0U);
     }
 
     std::unique_ptr<AudioRendererSink> audio_renderer_sink;
@@ -175,7 +175,8 @@ class AdaptiveAudioDecoderTest
       // StubAudioDecoder, because it is not actually doing any decoding work.
       return;
     }
-    ASSERT_LE(abs(expected_output_frames - num_of_output_frames_),
+    ASSERT_LE(static_cast<size_t>(
+                  abs(expected_output_frames - num_of_output_frames_)),
               dmp_readers_.size());
   }
 
@@ -373,8 +374,8 @@ vector<vector<const char*>> GetSupportedTests() {
 
   // Generate test cases. For example, we have |supported_files| [A, B, C].
   // Add tests A->A, A->B, A->C, B->A, B->B, B->C, C->A, C->B and C->C.
-  for (int i = 0; i < supported_files.size(); i++) {
-    for (int j = 0; j < supported_files.size(); j++) {
+  for (size_t i = 0; i < supported_files.size(); i++) {
+    for (size_t j = 0; j < supported_files.size(); j++) {
       test_params.push_back({supported_files[i], supported_files[j]});
     }
   }

--- a/starboard/shared/starboard/player/filter/testing/player_components_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/player_components_test.cc
@@ -727,7 +727,7 @@ vector<PlayerComponentsTestParam> GetSupportedCreationParameters() {
           CreateParam(audio_files[j], video_params[i], max_video_input_size));
     }
   }
-  SB_DCHECK_LT(supported_parameters.size(), 50)
+  SB_DCHECK_LT(supported_parameters.size(), 50U)
       << "Running the tests may take too long and result in a timeout.";
 
   for (size_t i = 0; i < audio_files.size(); i++) {

--- a/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/wsola_internal_test.cc
@@ -56,22 +56,6 @@ scoped_refptr<DecodedAudio> CreateTestDecodedAudio(int frames,
   return audio;
 }
 
-// A helper to create a DecodedAudio object with specific data.
-scoped_refptr<DecodedAudio> CreateTestDecodedAudioWithData(
-    const std::vector<float>& data_values,
-    int channels) {
-  int frames = data_values.size() / channels;
-  const int kBytesPerFrame = channels * sizeof(float);
-  const int kBufferSize = frames * kBytesPerFrame;
-
-  scoped_refptr<DecodedAudio> audio = new DecodedAudio(
-      channels, kSbMediaAudioSampleTypeFloat32,
-      kSbMediaAudioFrameStorageTypeInterleaved, 0, kBufferSize);
-
-  memcpy(audio->data(), data_values.data(), kBufferSize);
-  return audio;
-}
-
 TEST(WsolaInternalTest, OptimalIndex_ExactMatch) {
   const int kFrames = 100;
   const int kChannels = 1;


### PR DESCRIPTION
After #9840 turned compiler warnings into errors, the starboard_unittests build started failing on tvOS because the port, unlike e.g. Linux, does not disable warnings like -Wsign-compare and -Wunused-function.

Fix the files built by the tvOS port; covering all files used on e.g. Linux requires a bigger effort.

Fixed: 530516198