### PR TITLE
tvOS: Fix build after #11029 (ATV stack sanitization)

### DIFF
--- a/cobalt/app/cobalt_crash_reporter_client.cc
+++ b/cobalt/app/cobalt_crash_reporter_client.cc
@@ -97,6 +97,7 @@ std::string CobaltCrashReporterClient::GetUploadUrl() {
   return kCrashReportUrl;
 }
 
+#if !BUILDFLAG(IS_IOS_TVOS)
 // Overrides the default behavior to explicitly enable stack sanitization.
 // Setting *sanitize_stacks = true ensures that all stack memory in the
 // minidump is overwritten with the 0x0DEFACED pattern.
@@ -116,3 +117,4 @@ void CobaltCrashReporterClient::GetSanitizationInformation(
     *sanitize_stacks = true;
   }
 }
+#endif  // !BUILDFLAG(IS_IOS_TVOS)

--- a/cobalt/app/cobalt_crash_reporter_client.h
+++ b/cobalt/app/cobalt_crash_reporter_client.h
@@ -38,9 +38,11 @@ class CobaltCrashReporterClient : public crash_reporter::CrashReporterClient {
 
   std::string GetUploadUrl() override;
 
+#if !BUILDFLAG(IS_IOS_TVOS)
   void GetSanitizationInformation(const char* const** allowed_annotations,
                                   void** target_module,
                                   bool* sanitize_stacks) override;
+#endif  // !BUILDFLAG(IS_IOS_TVOS)
 
  private:
   friend class base::NoDestructor<CobaltCrashReporterClient>;


### PR DESCRIPTION
`GetSanitizationInformation()` is not defined on tvOS, see https://github.com/youtube/cobalt/blob/cdcb60f40d572b334458310ba5f7931e1641f0c2/components/crash/core/app/crash_reporter_client.h#L158

Add `BUILDFLAG(IS_IOS_TVOS)` checks to exclude this code from tvOS builds.

Bug: 481729814