### PR TITLE
tvos: Support events from GCControllerDirectionPad

### DIFF
--- a/components/input/web_input_event_builders_ios.h
+++ b/components/input/web_input_event_builders_ios.h
@@ -37,6 +37,11 @@ class COMPONENT_EXPORT(INPUT) WebTouchEventBuilder {
       UIEvent* event,
       UIView* view,
       const std::optional<gfx::Vector2dF>& view_offset);
+#if BUILDFLAG(IS_COBALT)
+  static blink::WebTouchEvent BuildFromGamepadData(
+      blink::WebInputEvent::Type type,
+      CGPoint point);
+#endif
 };
 
 }  // namespace input

--- a/components/input/web_input_event_builders_ios.mm
+++ b/components/input/web_input_event_builders_ios.mm
@@ -362,4 +362,53 @@ blink::WebTouchEvent WebTouchEventBuilder::Build(
   return result;
 }
 
+#if BUILDFLAG(IS_COBALT)
+blink::WebTouchEvent WebTouchEventBuilder::BuildFromGamepadData(
+    blink::WebInputEvent::Type type,
+    CGPoint point) {
+  blink::WebTouchEvent result(type, 0, ui::EventTimeForNow());
+  blink::WebTouchPoint::State state =
+      blink::WebTouchPoint::State::kStateUndefined;
+  switch (type) {
+    case blink::WebInputEvent::Type::kTouchStart:
+      state = blink::WebTouchPoint::State::kStatePressed;
+      break;
+    case blink::WebInputEvent::Type::kTouchEnd:
+      state = blink::WebTouchPoint::State::kStateReleased;
+      break;
+    case blink::WebInputEvent::Type::kTouchMove:
+      state = blink::WebTouchPoint::State::kStateMoved;
+      break;
+    case blink::WebInputEvent::Type::kTouchCancel:
+      state = blink::WebTouchPoint::State::kStateCancelled;
+      break;
+    default:
+      NOTREACHED() << "Invalid types for touch events." << type;
+  }
+  result.dispatch_type =
+      result.GetType() == blink::WebInputEvent::Type::kTouchCancel
+          ? blink::WebInputEvent::DispatchType::kEventNonBlocking
+          : blink::WebInputEvent::DispatchType::kBlocking;
+  result.hovering = type == blink::WebInputEvent::Type::kTouchEnd;
+  result.unique_touch_event_id = ui::GetNextTouchEventId();
+  result.touches_length = 1;
+
+  blink::WebTouchPoint touch;
+  // tvOS supports only one touch at the same time.
+  SetWebPointerPropertiesFromMotionEventData(touch, /*pointer_id=*/1,
+                                             /*pressure=*/NAN);
+  touch.state = state;
+  gfx::PointF position(point);
+  // The gamepad data read from the Siri Remote is normalized from -1 to 1 and
+  // this is what Kabuki uses. Note that this behavior is not spec-compliant,
+  // as the reported values are not relative to the viewport or the screen.
+  // TODO(532457474): Use a more standardized approach.
+  touch.SetPositionInScreen(position);
+  touch.SetPositionInWidget(position);
+  result.touches[0] = touch;
+
+  return result;
+}
+#endif
+
 }  // namespace input

--- a/content/browser/renderer_host/render_widget_host_view_tvos_uiview.mm
+++ b/content/browser/renderer_host/render_widget_host_view_tvos_uiview.mm
@@ -16,6 +16,12 @@
 #include "ui/events/keycodes/dom/dom_key.h"
 #include "ui/events/keycodes/keyboard_codes.h"
 
+#if BUILDFLAG(IS_COBALT)
+#import <GameController/GameController.h>
+
+#include "components/input/web_input_event_builders_ios.h"
+#endif
+
 static void* kObservingContext = &kObservingContext;
 
 namespace {
@@ -87,6 +93,15 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
 
 }  // namespace
 
+#if BUILDFLAG(IS_COBALT)
+@interface RenderWidgetUIView () {
+  NSMutableSet<GCController*>* _gameControllers;
+  CGPoint _lastSiriRemoteGamepadLocation;
+  BOOL _isBeingTouched;
+}
+@end
+#endif
+
 @implementation RenderWidgetUIView
 
 #pragma mark - Public
@@ -102,7 +117,25 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
     // tvOS supports multiple types of input events from the Remote, including
     // the clickpad (touch surface), the clickpad ring (directional control),
     // and various physical buttons.
+#if BUILDFLAG(IS_COBALT)
+    _gameControllers = [[NSMutableSet alloc] init];
+    NSNotificationCenter* notifications = [NSNotificationCenter defaultCenter];
+    [notifications addObserver:self
+                      selector:@selector(controllerConnected:)
+                          name:GCControllerDidConnectNotification
+                        object:nil];
+    [notifications addObserver:self
+                      selector:@selector(controllerDisconnected:)
+                          name:GCControllerDidDisconnectNotification
+                        object:nil];
+    // Only register swipe/pan gestures when no game controller is present;
+    // the controller provides its own input events.
+    if (![self addExistingControllers]) {
+      [self addSwipeAndPanGestureRecognizers];
+    }
+#else
     [self addSwipeAndPanGestureRecognizers];
+#endif
   }
   return self;
 }
@@ -148,6 +181,14 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
 }
 
 - (void)removeView {
+#if BUILDFLAG(IS_COBALT)
+  // Release our strong references to controllers and stop observing
+  // connect/disconnect notifications. The valueChangedHandler blocks capture
+  // weakSelf, so they naturally become no-ops when this view deallocates.
+  [_gameControllers removeAllObjects];
+  [[NSNotificationCenter defaultCenter] removeObserver:self];
+#endif
+
   UIScrollView* view = (UIScrollView*)[self superview];
   [view removeObserver:self
             forKeyPath:NSStringFromSelector(@selector(contentInset))];
@@ -184,6 +225,21 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
     }
   }
 }
+
+#if BUILDFLAG(IS_COBALT)
+- (void)removeSwipeAndPanGestureRecognizers {
+  NSMutableArray<UIGestureRecognizer*>* toRemove = [NSMutableArray array];
+  for (UIGestureRecognizer* recognizer in self.gestureRecognizers) {
+    if ([recognizer isKindOfClass:[UISwipeGestureRecognizer class]] ||
+        [recognizer isKindOfClass:[UIPanGestureRecognizer class]]) {
+      [toRemove addObject:recognizer];
+    }
+  }
+  for (UIGestureRecognizer* recognizer in toRemove) {
+    [self removeGestureRecognizer:recognizer];
+  }
+}
+#endif
 
 // Helper method to add swipe gestures for `direction`.
 - (void)addSwipeGestureRecognizerWithDirection:
@@ -297,6 +353,13 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
 
 - (void)pressesBegan:(NSSet<UIPress*>*)presses
            withEvent:(UIPressesEvent*)event {
+#if BUILDFLAG(IS_COBALT)
+  // A button press does not implicitly cancel an in-progress gamepad touch
+  // sequence, so cancel it explicitly here before dispatching the key event.
+  if (_isBeingTouched) {
+    [self touchCancelled];
+  }
+#endif
   BOOL handled = [self handlePresses:presses
                             withType:blink::WebInputEvent::Type::kKeyDown];
   if (!handled) {
@@ -497,6 +560,21 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
       (result || _view->CanBecomeFirstResponderForTesting())) {
     _view->OnFirstResponderChanged();
   }
+#if BUILDFLAG(IS_COBALT)
+  if (result) {
+    // Re-register gamepad handlers in case another UIView had overwritten them.
+    // Clear first so startListeningToInputForController: doesn't skip already-
+    // known controllers.
+    [_gameControllers removeAllObjects];
+    BOOL hasControllers = [self addExistingControllers];
+    // Sync gesture state: gestures are mutually exclusive with controller
+    // input.
+    [self removeSwipeAndPanGestureRecognizers];
+    if (!hasControllers) {
+      [self addSwipeAndPanGestureRecognizers];
+    }
+  }
+#endif
   return result;
 }
 
@@ -525,6 +603,122 @@ RemoteButton remoteButtonFromPressType(UIPressType type) {
 
   [self hideAndDeleteKeyboard];
 }
+
+#if BUILDFLAG(IS_COBALT)
+#pragma mark - Controller Connect/Disconnect Notifications
+
+- (void)controllerConnected:(NSNotification*)notification {
+  GCController* controller = (GCController*)notification.object;
+  [self startListeningToInputForController:controller];
+  if (_gameControllers.count == 1) {
+    // First controller connected — remove gestures so the controller drives
+    // input.
+    [self removeSwipeAndPanGestureRecognizers];
+  }
+}
+
+- (void)controllerDisconnected:(NSNotification*)notification {
+  GCController* controller = (GCController*)notification.object;
+  [self stopListeningToInputForController:controller];
+  if (_gameControllers.count == 0) {
+    // Last controller gone — restore gesture-based input.
+    [self addSwipeAndPanGestureRecognizers];
+  }
+}
+
+#pragma mark - Controller Connect/Disconnect
+
+// Adds controllers that are already connected to the system.
+// Returns YES if at least one controller was registered.
+- (BOOL)addExistingControllers {
+  NSArray<GCController*>* controllers = [GCController controllers];
+  for (GCController* controller in controllers) {
+    [self startListeningToInputForController:controller];
+  }
+  return _gameControllers.count > 0;
+}
+
+// Starts listening to inputs from the given controller.
+// `controller` is the controller to start listening for input events.
+- (void)startListeningToInputForController:(GCController*)controller {
+  // For now, GCMicroGamepad from the siri remote is only handled.
+  if (!controller.microGamepad) {
+    return;
+  }
+
+  if ([_gameControllers containsObject:controller]) {
+    return;
+  }
+
+  [_gameControllers addObject:controller];
+  [self addDpadHandler:controller];
+}
+
+// Stops listening to inputs from the given controller.
+- (void)stopListeningToInputForController:(GCController*)controller {
+  [_gameControllers removeObject:controller];
+  // Reset touch state so a reconnected controller starts fresh.
+  _isBeingTouched = NO;
+}
+
+- (void)addDpadHandler:(GCController*)controller {
+  if (controller.extendedGamepad) {
+    // Only handle Siri remotes here.
+    return;
+  }
+
+  GCMicroGamepad* siriRemoteGamepad = controller.microGamepad;
+  siriRemoteGamepad.reportsAbsoluteDpadValues = YES;
+  // Ensure the handler runs on the main queue so that base::WeakPtr (_view) is
+  // accessed on the same sequence it was created on.
+  controller.handlerQueue = dispatch_get_main_queue();
+  __weak RenderWidgetUIView* weakSelf = self;
+  siriRemoteGamepad.valueChangedHandler =
+      ^(GCMicroGamepad* gamepad, GCControllerElement* element) {
+        RenderWidgetUIView* strongSelf = weakSelf;
+        if (!strongSelf || !strongSelf.isFocused || element != gamepad.dpad) {
+          return;
+        }
+        GCControllerDirectionPad* dpad = gamepad.dpad;
+        // This follows the way of how Kabuki currently works.
+        // TODO(532457474): Use a more standardized approach.
+        CGPoint newLocation = CGPointMake(dpad.xAxis.value, -dpad.yAxis.value);
+        BOOL isBeingTouched = dpad.up.pressed || dpad.down.pressed ||
+                              dpad.left.pressed || dpad.right.pressed;
+        if (!strongSelf->_isBeingTouched && isBeingTouched) {
+          // If the dpad has gone from not being touched, to being touched,
+          // report a touch down.
+          [strongSelf touchAtPosition:newLocation
+                            eventType:blink::WebInputEvent::Type::kTouchStart];
+        } else if (isBeingTouched) {
+          [strongSelf touchAtPosition:newLocation
+                            eventType:blink::WebInputEvent::Type::kTouchMove];
+        } else {
+          // No longer being touched, report a touch up.
+          [strongSelf touchAtPosition:strongSelf->_lastSiriRemoteGamepadLocation
+                            eventType:blink::WebInputEvent::Type::kTouchEnd];
+        }
+        strongSelf->_lastSiriRemoteGamepadLocation = newLocation;
+        strongSelf->_isBeingTouched = isBeingTouched;
+      };
+}
+
+- (void)touchAtPosition:(CGPoint)position
+              eventType:(blink::WebInputEvent::Type)type {
+  if (!_view) {
+    return;
+  }
+  _view->OnTouchEvent(
+      input::WebTouchEventBuilder::BuildFromGamepadData(type, position));
+}
+
+- (void)touchCancelled {
+  [self touchAtPosition:_lastSiriRemoteGamepadLocation
+              eventType:blink::WebInputEvent::Type::kTouchCancel];
+  _isBeingTouched = NO;
+  _lastSiriRemoteGamepadLocation = CGPointMake(0, 0);
+}
+#endif
 
 #pragma mark - UIGestureRecognizerDelegate
 


### PR DESCRIPTION
Add support for mapping GCControllerDirectionPad input from tvOS game
controllers, such as the Siri Remote, into web touch events. This
allows D-pad X and Y axis values to be passed to the Blink rendering
engine.

The logic handles controller connection notifications and maps d-pad
state changes to touch start, move, and end events. This
functionality is ported from Cobalt 25.

Bug: 521473039