### PR TITLE
starboard: move InitializeStarboardFeatureListWithDefaults out of testonly

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -80,6 +80,8 @@ static_library("starboard_platform") {
     "//starboard/shared/starboard/drm/drm_update_session.cc",
     "//starboard/shared/starboard/experimental_features.cc",
     "//starboard/shared/starboard/experimental_features.h",
+    "//starboard/shared/starboard/feature_defaults.cc",
+    "//starboard/shared/starboard/feature_defaults.h",
     "//starboard/shared/starboard/file_storage/storage_close_record.cc",
     "//starboard/shared/starboard/file_storage/storage_delete_record.cc",
     "//starboard/shared/starboard/file_storage/storage_get_record_size.cc",
@@ -399,8 +401,6 @@ static_library("test_support") {
   ]
 
   sources = [
-    "//starboard/shared/starboard/features_test_util.cc",
-    "//starboard/shared/starboard/features_test_util.h",
     "fake_audio_track.cc",
     "fake_audio_track.h",
     "fake_media_codec.cc",

--- a/starboard/android/shared/starboard_test_environment.cc
+++ b/starboard/android/shared/starboard_test_environment.cc
@@ -14,7 +14,7 @@
 
 #include "starboard/android/shared/starboard_test_environment.h"
 
-#include "starboard/shared/starboard/features_test_util.h"
+#include "starboard/shared/starboard/feature_defaults.h"
 
 namespace starboard {
 

--- a/starboard/elf_loader/elf_loader_sandbox.cc
+++ b/starboard/elf_loader/elf_loader_sandbox.cc
@@ -28,6 +28,7 @@
 #include "starboard/elf_loader/evergreen_info.h"
 #include "starboard/elf_loader/sabi_string.h"
 #include "starboard/event.h"
+#include "starboard/shared/starboard/feature_defaults.h"
 
 elf_loader::ElfLoader g_elf_loader;
 
@@ -135,5 +136,6 @@ void SbEventHandle(const SbEvent* event) {
 }
 
 int main(int argc, char** argv) {
+  starboard::features::InitializeStarboardFeatureListWithDefaults();
   return SbRunStarboardMain(argc, argv, SbEventHandle);
 }

--- a/starboard/shared/starboard/feature_defaults.cc
+++ b/starboard/shared/starboard/feature_defaults.cc
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "starboard/shared/starboard/features_test_util.h"
+#include "starboard/shared/starboard/feature_defaults.h"
 
 #include <stdint.h>
 

--- a/starboard/shared/starboard/feature_defaults.h
+++ b/starboard/shared/starboard/feature_defaults.h
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef STARBOARD_SHARED_STARBOARD_FEATURES_TEST_UTIL_H_
-#define STARBOARD_SHARED_STARBOARD_FEATURES_TEST_UTIL_H_
+#ifndef STARBOARD_SHARED_STARBOARD_FEATURE_DEFAULTS_H_
+#define STARBOARD_SHARED_STARBOARD_FEATURE_DEFAULTS_H_
 
 namespace starboard::features {
 
@@ -21,4 +21,4 @@ void InitializeStarboardFeatureListWithDefaults();
 
 }  // namespace starboard::features
 
-#endif  // STARBOARD_SHARED_STARBOARD_FEATURES_TEST_UTIL_H_
+#endif  // STARBOARD_SHARED_STARBOARD_FEATURE_DEFAULTS_H_


### PR DESCRIPTION
Rename features_test_util.{cc,h} to feature_defaults.{cc,h} and build them in the non-testonly starboard_platform target.