### PR TITLE
starboardbridge: return canonical path for files and cache directories

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
@@ -36,6 +36,7 @@ import dev.cobalt.media.AudioOutputManager;
 import dev.cobalt.util.DisplayUtil;
 import dev.cobalt.util.Holder;
 import dev.cobalt.util.Log;
+import java.io.IOException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Calendar;
@@ -134,8 +135,8 @@ public class BaseStarboardBridge {
         BaseStarboardBridgeJni.get()
             .startNativeStarboard(
                 getAssetsFromContext(),
-                getFilesAbsolutePath(),
-                getCacheAbsolutePath(),
+                getFilesCanonicalPath(),
+                getCacheCanonicalPath(),
                 getNativeLibraryDir());
 
     BaseStarboardBridgeJni.get().handleDeepLink(startDeepLink, /* applicationStarted= */ false);
@@ -356,11 +357,37 @@ public class BaseStarboardBridge {
   }
 
   /**
+   * Returns the canonical path to the directory where application specific files should be written,
+   * resolving symbolic links. nplb tests compare against resolved paths.
+   */
+  protected String getFilesCanonicalPath() {
+    try {
+      return mAppContext.getFilesDir().getCanonicalPath();
+    } catch (IOException e) {
+      Log.w(TAG, "Failed to get canonical path", e);
+      return getFilesAbsolutePath();
+    }
+  }
+
+  /**
    * Returns the absolute path to the application specific cache directory on the filesystem. May be
    * overridden for use cases that need to segregate storage.
    */
   protected String getCacheAbsolutePath() {
     return mAppContext.getCacheDir().getAbsolutePath();
+  }
+
+  /**
+   * Returns the canonical path to the application specific cache directory, resolving symbolic
+   * links. nplb tests compare against resolved paths.
+   */
+  protected String getCacheCanonicalPath() {
+    try {
+      return mAppContext.getCacheDir().getCanonicalPath();
+    } catch (IOException e) {
+      Log.w(TAG, "Failed to get canonical path", e);
+      return getCacheAbsolutePath();
+    }
   }
 
   // TODO: (cobalt b/372559388) remove or migrate JNI?


### PR DESCRIPTION
getAbsolutePath() doesn't resolve symbolic links; nplb's PosixRealpathTest
compares it against resolved paths, causing failures when paths are (or
should be) the same.

Fixes the following issies in tests:
  posix_realpath_test.cc:86 result path mismatch (/data/data/... vs /data/user/0/...)

Bug: 532068409