### PR TITLE
aosp: wrap pread and pwrite

### DIFF
--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -253,8 +253,6 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(pause);
   REGISTER_SYMBOL(pipe);
   REGISTER_SYMBOL(posix_memalign);
-  REGISTER_SYMBOL(pread);
-  REGISTER_SYMBOL(pwrite);
   REGISTER_SYMBOL(raise);
   REGISTER_SYMBOL(rand);
   REGISTER_SYMBOL(rand_r);
@@ -336,6 +334,8 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_WRAPPER(pipe2);
   REGISTER_WRAPPER(poll);
   REGISTER_WRAPPER(prctl);
+  REGISTER_WRAPPER(pread);
+  REGISTER_WRAPPER(pwrite);
   REGISTER_WRAPPER(pthread_attr_init);
   REGISTER_WRAPPER(pthread_attr_destroy);
   REGISTER_WRAPPER(pthread_attr_getdetachstate);

--- a/starboard/shared/modular/cobalt_layer_posix_unistd_abi_wrappers.cc
+++ b/starboard/shared/modular/cobalt_layer_posix_unistd_abi_wrappers.cc
@@ -75,4 +75,17 @@ int __abi_wrap_unlinkat(int fildes, const char* path, int flag);
 int unlinkat(int fildes, const char* path, int flag) {
   return __abi_wrap_unlinkat(fildes, path, flag);
 }
+
+ssize_t __abi_wrap_pread(int fd, void* buf, size_t size, off_t ofs);
+
+ssize_t pread(int fd, void* buf, size_t size, off_t ofs) {
+  return __abi_wrap_pread(fd, buf, size, ofs);
+}
+
+ssize_t __abi_wrap_pwrite(int fd, const void* buf, size_t size, off_t ofs);
+
+ssize_t pwrite(int fd, const void* buf, size_t size, off_t ofs) {
+  return __abi_wrap_pwrite(fd, buf, size, ofs);
+}
+
 }  // extern "C"

--- a/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.cc
@@ -723,3 +723,14 @@ int __abi_wrap_unlinkat(int fildes, const char* path, int musl_flag) {
   }
   return unlinkat(fildes, path, flag);
 }
+
+ssize_t __abi_wrap_pread(int fd, void* buf, size_t size, musl_off_t ofs) {
+  return pread(fd, buf, size, static_cast<off_t>(ofs));
+}
+
+ssize_t __abi_wrap_pwrite(int fd,
+                          const void* buf,
+                          size_t size,
+                          musl_off_t ofs) {
+  return pwrite(fd, buf, size, static_cast<off_t>(ofs));
+}

--- a/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_unistd_abi_wrappers.h
@@ -239,6 +239,16 @@ SB_EXPORT int __abi_wrap_fchown(int fd, musl_uid_t owner, musl_gid_t group);
 
 SB_EXPORT int __abi_wrap_unlinkat(int fildes, const char* path, int musl_flag);
 
+SB_EXPORT ssize_t __abi_wrap_pread(int fd,
+                                   void* buf,
+                                   size_t size,
+                                   musl_off_t ofs);
+
+SB_EXPORT ssize_t __abi_wrap_pwrite(int fd,
+                                    const void* buf,
+                                    size_t size,
+                                    musl_off_t ofs);
+
 #ifdef __cplusplus
 }  // extern "C"
 #endif


### PR DESCRIPTION
In starboard/elf_loader/exported_symbols.cc pread are exported as

  REGISTER_SYMBOL(pread);
  REGISTER_SYMBOL(pwrite);

but libcobalt is statically linked with musl, which contains those
functions with different signatures:

ssize_t pread(int fd, void *buf, size_t size, off_t ofs);
ssize_t pwrite(int fd, void *buf, size_t size, off_t ofs);

So in modular builds, this change creates and registers ABI wrappers
for those calls, handling the different signatures.

Fixes the following issues in tests:
  posix_file_read_test.cc:286 pread failed: Invalid argument (bytes_read = 4294967295)

Bug: 532068409