### PR TITLE
aosp: fix musl_statvfs layout

### DIFF
--- a/starboard/shared/modular/starboard_layer_posix_statvfs_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_statvfs_abi_wrappers.h
@@ -25,15 +25,21 @@
 extern "C" {
 #endif
 
+// musl's fsblkcnt_t/fsfilcnt_t are 64-bit on every arch but bionic defines them
+// as 32-bit `unsigned long` on 32-bit targets. Use fixed-width 64-bit types so
+// this struct matches musl's layout.
+typedef uint64_t musl_fsblkcnt_t;
+typedef uint64_t musl_fsfilcnt_t;
+
 struct musl_statvfs {
   unsigned long f_bsize;
   unsigned long f_frsize;
-  fsblkcnt_t f_blocks;
-  fsblkcnt_t f_bfree;
-  fsblkcnt_t f_bavail;
-  fsfilcnt_t f_files;
-  fsfilcnt_t f_ffree;
-  fsfilcnt_t f_favail;
+  musl_fsblkcnt_t f_blocks;
+  musl_fsblkcnt_t f_bfree;
+  musl_fsblkcnt_t f_bavail;
+  musl_fsfilcnt_t f_files;
+  musl_fsfilcnt_t f_ffree;
+  musl_fsfilcnt_t f_favail;
   unsigned long f_fsid;
   unsigned : 8 * (2 * sizeof(int) - sizeof(long));
   unsigned long f_flag;


### PR DESCRIPTION
aosp: fix musl_statvfs layout

musl's fsblkcnt_t/fsfilcnt_t are 64-bit on all arch, but bionic defines them
as 32-bit unsigned long on 32-bit targets. On 32-bit arch, the values
can land in wrong offsets in the musl layer.

Fixes the PosixStatvfsTest NPLB tests (SunnyDay, UsageChanges), which read
misaligned fields:
  posix_sys_statvfs_test.cc:46 f_namemax == 0 (expected > 0)

Bug: 532068409