### PR TITLE
Revert "westerossink: set stop-keep-frame property to true (#11040)"

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/player/player_internal.cc
@@ -1948,10 +1948,6 @@ void PlayerImpl::SetupElement(GstElement* pipeline,
         GST_INFO_OBJECT(pipeline, "Setting westerossink zoom-mode to 0");
         g_object_set(element, "zoom-mode", 0, nullptr);
       }
-      if (g_object_class_find_property(G_OBJECT_GET_CLASS(element), "stop-keep-frame")) {
-        GST_INFO_OBJECT(pipeline, "Setting westerossink stop-keep-frame to true");
-        g_object_set(element, "stop-keep-frame", true, nullptr);
-      }
       g_signal_connect_swapped(
         G_OBJECT(element), "buffer-underflow-callback",
         G_CALLBACK(OnVideoBufferUnderflow), self);


### PR DESCRIPTION
This reverts commit f3447bc55bcf417afc829732cf5136cf7e28341f. 
Although the commit fixes the black screen during new video transition, a regression was found 
where the last frame becomes visible when the app is closed.

Bug: 515092940
Change-Id: Ice78cab0259abb2ae9aeb13af72b900c250c11ca