### PR TITLE
starboard: make elf_loader_sandbox testonly

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -173,8 +173,6 @@ if (is_ios && target_platform == "tvos") {
     cobalt_target_type = "executable"
   }
   target(cobalt_target_type, "cobalt") {
-    testonly = true
-
     sources = [ "app/cobalt.cc" ]
 
     configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
@@ -193,6 +191,7 @@ if (is_ios && target_platform == "tvos") {
       deps += [ "//ui/ozone/platform/starboard:starboard" ]
     } else {
       # Web test support only built for the linux-x64x11-no-starboard target.
+      testonly = true
       deps += [
         "//content/web_test:web_test_browser",
         "//content/web_test:web_test_common",

--- a/cobalt/build/modular_executable.gni
+++ b/cobalt/build/modular_executable.gni
@@ -99,7 +99,8 @@ template("evergreen_final_target") {
     if (original_target_name == "cobalt") {
       data_deps += [ "//starboard/loader_app($starboard_toolchain)" ]
     } else {
-      data_deps += [ "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)" ]
+      data_deps +=
+          [ "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)" ]
     }
   }
 

--- a/cobalt/build/modular_executable.gni
+++ b/cobalt/build/modular_executable.gni
@@ -92,11 +92,15 @@ template("evergreen_final_target") {
     data_deps = [
       ":${original_target_name}_loaded_content",
       ":${original_target_name}_runfile_gen",
-      "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)",
-      "//starboard/loader_app($starboard_toolchain)",
     ]
     deps = [ "//starboard/loader_app($starboard_toolchain)" ]
     write_runtime_deps = "$root_build_dir/${target_name}.runtime_deps"
+
+    if (original_target_name == "cobalt") {
+      data_deps += [ "//starboard/loader_app($starboard_toolchain)" ]
+    } else {
+      data_deps += [ "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)" ]
+    }
   }
 
   group("${original_target_name}_loaded_content") {

--- a/cobalt/build/modular_executable.gni
+++ b/cobalt/build/modular_executable.gni
@@ -88,20 +88,15 @@ template("evergreen_final_target") {
   }
 
   group("${original_target_name}_loader") {
-    forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
+    testonly = true
     data_deps = [
       ":${original_target_name}_loaded_content",
       ":${original_target_name}_runfile_gen",
+      "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)",
+      "//starboard/loader_app($starboard_toolchain)",
     ]
     deps = [ "//starboard/loader_app($starboard_toolchain)" ]
     write_runtime_deps = "$root_build_dir/${target_name}.runtime_deps"
-
-    if (original_target_name == "cobalt") {
-      data_deps += [ "//starboard/loader_app($starboard_toolchain)" ]
-    } else {
-      data_deps +=
-          [ "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)" ]
-    }
   }
 
   group("${original_target_name}_loaded_content") {

--- a/starboard/elf_loader/BUILD.gn
+++ b/starboard/elf_loader/BUILD.gn
@@ -88,6 +88,10 @@ if (current_toolchain == starboard_toolchain) {
       "//starboard/content/fonts:copy_font_data",
     ]
 
+    if (is_android) {
+      deps += [ "//starboard/android/shared:test_support" ]
+    }
+
     if (is_starboard && use_crashpad) {
       deps += [ "//starboard/crashpad_wrapper" ]
     } else {

--- a/starboard/elf_loader/BUILD.gn
+++ b/starboard/elf_loader/BUILD.gn
@@ -72,6 +72,7 @@ static_library("elf_loader") {
 # TODO: b/309493306 - Stop building evergreen targets for all non-evergreen platforms.
 if (current_toolchain == starboard_toolchain) {
   target(starboard_level_final_executable_type, "elf_loader_sandbox") {
+    testonly = true
     output_dir = root_build_dir
 
     sources = [ "elf_loader_sandbox.cc" ]

--- a/starboard/elf_loader/elf_loader_sandbox.cc
+++ b/starboard/elf_loader/elf_loader_sandbox.cc
@@ -29,6 +29,10 @@
 #include "starboard/elf_loader/sabi_string.h"
 #include "starboard/event.h"
 
+#if defined(IS_ANDROID)
+#include "starboard/shared/starboard/features_test_util.h"
+#endif
+
 elf_loader::ElfLoader g_elf_loader;
 
 void (*g_sb_event_func)(const SbEvent*) = NULL;
@@ -135,5 +139,10 @@ void SbEventHandle(const SbEvent* event) {
 }
 
 int main(int argc, char** argv) {
+#if defined(IS_ANDROID)
+  // The evergreen inner library's static initializers query Starboard
+  // features, so seed the FeatureList with defaults before it is loaded.
+  starboard::features::InitializeStarboardFeatureListWithDefaults();
+#endif
   return SbRunStarboardMain(argc, argv, SbEventHandle);
 }

--- a/starboard/elf_loader/elf_loader_sandbox.cc
+++ b/starboard/elf_loader/elf_loader_sandbox.cc
@@ -29,7 +29,7 @@
 #include "starboard/elf_loader/sabi_string.h"
 #include "starboard/event.h"
 
-#if defined(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID)
 #include "starboard/shared/starboard/features_test_util.h"
 #endif
 
@@ -139,10 +139,10 @@ void SbEventHandle(const SbEvent* event) {
 }
 
 int main(int argc, char** argv) {
-#if defined(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID)
   // The evergreen inner library's static initializers query Starboard
   // features, so seed the FeatureList with defaults before it is loaded.
   starboard::features::InitializeStarboardFeatureListWithDefaults();
-#endif
+#endif  // BUILDFLAG(IS_ANDROID)
   return SbRunStarboardMain(argc, argv, SbEventHandle);
 }


### PR DESCRIPTION
Make //starboard:elf_loader_sandbox and <name>_loader targets testonly. This allows to depend on //starboard/android/shared:test_support, so that on AOSP, the elf loader can correctly initialize starboard's FeatureList. See https://github.com/youtube/cobalt/pull/11025 for the motivation.

Additionally, scope //cobalt's testonly to !is_starboard, where there are test dependencies.

Bug: 495203133