### PR TITLE
media: Defer read counter decrement in bypass bridge

### DIFF
--- a/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
@@ -18,12 +18,14 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
+#include "base/test/scoped_command_line.h"
 #include "base/test/task_environment.h"
 #include "media/base/fake_demuxer_stream.h"
 #include "media/base/media_switches.h"
 #include "media/base/mock_media_log.h"
 #include "media/base/test_helpers.h"
 #include "media/base/video_renderer_sink.h"
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
 #include "media/mojo/mojom/renderer.mojom.h"
 #include "media/mojo/mojom/renderer_extensions.mojom.h"
 #include "media/renderers/video_overlay_factory.h"
@@ -44,9 +46,15 @@ using ::testing::StrictMock;
 
 namespace {
 
+struct FakeMojomRendererCallRecord {
+  bool initialize_with_bypass_bridge_called = false;
+  uint32_t last_bypass_bridge_id = 0;
+};
+
 class FakeMojomRenderer : public mojom::Renderer {
  public:
-  FakeMojomRenderer() = default;
+  explicit FakeMojomRenderer(FakeMojomRendererCallRecord* record)
+      : record_(record) {}
   ~FakeMojomRenderer() override = default;
 
   void Initialize(
@@ -59,6 +67,10 @@ class FakeMojomRenderer : public mojom::Renderer {
       mojo::PendingAssociatedRemote<mojom::RendererClient>,
       uint32_t bypass_bridge_id,
       InitializeWithBypassBridgeCallback cb) override {
+    if (record_) {
+      record_->initialize_with_bypass_bridge_called = true;
+      record_->last_bypass_bridge_id = bypass_bridge_id;
+    }
     std::move(cb).Run(true);
   }
   MOCK_METHOD1(Flush, void(FlushCallback));
@@ -69,6 +81,9 @@ class FakeMojomRenderer : public mojom::Renderer {
                void(const absl::optional<base::UnguessableToken>&,
                     SetCdmCallback));
   void SetLatencyHint(std::optional<::base::TimeDelta> latency_hint) override {}
+
+ private:
+  FakeMojomRendererCallRecord* record_;
 };
 
 class FakeStarboardRendererExtension
@@ -134,10 +149,11 @@ class StarboardRendererClientTest : public ::testing::Test {
     media_resource_ = std::make_unique<FakeMediaResource>(3, 9, false);
   }
 
-  void InitializeStarboardRendererClient(bool with_gpu_factories = true) {
+  void InitializeStarboardRendererClient(bool with_gpu_factories = true,
+                                         bool bypass_mojo_for_media = false) {
     mojo::PendingRemote<mojom::Renderer> renderer_remote;
     mojo::MakeSelfOwnedReceiver(
-        std::make_unique<FakeMojomRenderer>(),
+        std::make_unique<FakeMojomRenderer>(&fake_mojom_renderer_record_),
         renderer_remote.InitWithNewPipeAndPassReceiver());
 
     mojo::PendingRemote<mojom::StarboardRendererExtension>
@@ -153,7 +169,8 @@ class StarboardRendererClientTest : public ::testing::Test {
     auto mojo_renderer = std::make_unique<MojoRenderer>(
         task_environment_.GetMainThreadTaskRunner(),
         /*video_overlay_factory=*/nullptr,
-        /*video_renderer_sink=*/nullptr, std::move(renderer_remote));
+        /*video_renderer_sink=*/nullptr, std::move(renderer_remote),
+        bypass_mojo_for_media);
     auto overlay_factory = std::make_unique<VideoOverlayFactory>();
     starboard_renderer_client_ = std::make_unique<StarboardRendererClient>(
         task_environment_.GetMainThreadTaskRunner(), media_log_.Clone(),
@@ -180,6 +197,7 @@ class StarboardRendererClientTest : public ::testing::Test {
   base::MockOnceCallback<void(PipelineStatus)> renderer_init_cb_;
   std::unique_ptr<FakeMediaResource> media_resource_;
   std::unique_ptr<StarboardRendererClient> starboard_renderer_client_;
+  FakeMojomRendererCallRecord fake_mojom_renderer_record_;
 };
 
 TEST_F(StarboardRendererClientTest, CreateAndDestroy) {
@@ -263,6 +281,33 @@ TEST_F(StarboardRendererClientTest,
   EXPECT_CALL(mock_video_renderer_sink_, Stop()).Times(0);
   starboard_renderer_client_->OnEnded();
   task_environment_.RunUntilIdle();
+}
+
+TEST_F(StarboardRendererClientTest, InitializeWithBypassBridge) {
+  base::test::ScopedCommandLine scoped_command_line;
+  scoped_command_line.GetProcessCommandLine()->AppendSwitch("single-process");
+
+  InitializeStarboardRendererClient(/*with_gpu_factories=*/true,
+                                    /*bypass_mojo_for_media=*/true);
+
+  EXPECT_CALL(renderer_init_cb_, Run(HasStatusCode(PIPELINE_OK)));
+  starboard_renderer_client_->Initialize(
+      media_resource_.get(), &renderer_client_, renderer_init_cb_.Get());
+  starboard_renderer_client_->UpdateStarboardRenderingMode(
+      StarboardRenderingMode::kPunchOut);
+
+  task_environment_.RunUntilIdle();
+
+  EXPECT_TRUE(fake_mojom_renderer_record_.initialize_with_bypass_bridge_called);
+  uint32_t bridge_id = fake_mojom_renderer_record_.last_bypass_bridge_id;
+  EXPECT_NE(bridge_id, 0u);
+
+  auto bridge = BypassBridgeRegistry::Get(bridge_id);
+  ASSERT_TRUE(bridge);
+  EXPECT_TRUE(bridge->IsActive());
+
+  starboard_renderer_client_.reset();
+  EXPECT_EQ(BypassBridgeRegistry::Get(bridge_id), nullptr);
 }
 
 }  // namespace

--- a/media/mojo/common/BUILD.gn
+++ b/media/mojo/common/BUILD.gn
@@ -54,6 +54,12 @@ source_set("unit_tests") {
     "mojo_decoder_buffer_converter_unittest.cc",
   ]
 
+  if (is_cobalt && use_starboard_media) {
+    sources += [
+      "starboard/mojo_renderer_bypass_bridge_unittest.cc",
+    ]
+  }
+
   deps = [
     "//base",
     "//base/test:test_support",

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
@@ -90,15 +90,15 @@ bool MojoRendererBypassBridge::Read(DemuxerStream::Type type,
     return false;
   }
 
-  stream->Read(count, std::move(read_cb));
+  // Wrap the callback to decrement in_flight_reads_ when it runs.
+  base::ScopedClosureRunner scoped_decrement(
+      base::BindOnce(&MojoRendererBypassBridge::DecrementInFlightReads, this));
 
-  {
-    base::AutoLock auto_lock(lock_);
-    in_flight_reads_--;
-    if (in_flight_reads_ == 0) {
-      cond_var_.Signal();
-    }
-  }
+  auto wrapped_cb =
+      base::BindOnce(&MojoRendererBypassBridge::OnReadDone, this,
+                     std::move(read_cb), std::move(scoped_decrement));
+
+  stream->Read(count, std::move(wrapped_cb));
   return true;
 }
 
@@ -155,6 +155,22 @@ void MojoRendererBypassBridge::RunTimeUpdateOnClientThread(
 void MojoRendererBypassBridge::RunStatisticsUpdateOnClientThread(
     const PipelineStatistics& stats) {
   statistics_update_cb_.Run(stats);
+}
+
+void MojoRendererBypassBridge::OnReadDone(
+    DemuxerStream::ReadCB read_cb,
+    base::ScopedClosureRunner scoped_decrement,
+    DemuxerStream::Status status,
+    DemuxerStream::DecoderBufferVector buffers) {
+  std::move(read_cb).Run(status, std::move(buffers));
+}
+
+void MojoRendererBypassBridge::DecrementInFlightReads() {
+  base::AutoLock auto_lock(lock_);
+  in_flight_reads_--;
+  if (in_flight_reads_ == 0) {
+    cond_var_.Signal();
+  }
 }
 
 // static

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
@@ -18,6 +18,7 @@
 #include <map>
 
 #include "base/functional/callback.h"
+#include "base/functional/callback_helpers.h"
 #include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "base/synchronization/condition_variable.h"
@@ -94,6 +95,11 @@ class MojoRendererBypassBridge
                                    base::TimeDelta max_time,
                                    base::TimeTicks capture_time);
   void RunStatisticsUpdateOnClientThread(const PipelineStatistics& stats);
+  void OnReadDone(DemuxerStream::ReadCB read_cb,
+                  base::ScopedClosureRunner scoped_decrement,
+                  DemuxerStream::Status status,
+                  DemuxerStream::DecoderBufferVector buffers);
+  void DecrementInFlightReads();
 
   const scoped_refptr<base::SequencedTaskRunner> client_task_runner_;
   const TimeUpdateCB time_update_cb_;

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge_unittest.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge_unittest.cc
@@ -1,0 +1,149 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
+
+#include <memory>
+#include <vector>
+
+#include "base/functional/bind.h"
+#include "base/functional/callback_helpers.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/synchronization/waitable_event.h"
+#include "base/task/thread_pool.h"
+#include "base/test/mock_callback.h"
+#include "base/test/task_environment.h"
+#include "base/threading/thread_restrictions.h"
+#include "media/base/demuxer_stream.h"
+#include "media/base/mock_filters.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace media {
+namespace {
+
+using ::testing::_;
+using ::testing::NiceMock;
+
+class MojoRendererBypassBridgeTest : public testing::Test {
+ protected:
+  MojoRendererBypassBridgeTest()
+      : bridge_(base::MakeRefCounted<MojoRendererBypassBridge>(
+            task_environment_.GetMainThreadTaskRunner(),
+            time_update_cb_.Get(),
+            statistics_update_cb_.Get())) {}
+
+  base::test::TaskEnvironment task_environment_;
+  base::MockRepeatingCallback<
+      void(base::TimeDelta, base::TimeDelta, base::TimeTicks)>
+      time_update_cb_;
+  base::MockRepeatingCallback<void(const PipelineStatistics&)>
+      statistics_update_cb_;
+  scoped_refptr<MojoRendererBypassBridge> bridge_;
+};
+
+TEST_F(MojoRendererBypassBridgeTest, RegistryRegisterUnregister) {
+  uint32_t id = 42;
+  BypassBridgeRegistry::Register(id, bridge_);
+  EXPECT_EQ(BypassBridgeRegistry::Get(id), bridge_);
+  BypassBridgeRegistry::Unregister(id);
+  EXPECT_EQ(BypassBridgeRegistry::Get(id), nullptr);
+}
+
+TEST_F(MojoRendererBypassBridgeTest, ReadNormal) {
+  NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
+  bridge_->SetStreams(&audio_stream, nullptr);
+
+  DemuxerStream::ReadCB read_cb;
+  EXPECT_CALL(audio_stream, OnRead(_))
+      .WillOnce(
+          [&read_cb](DemuxerStream::ReadCB& cb) { read_cb = std::move(cb); });
+
+  base::MockCallback<DemuxerStream::ReadCB> client_read_cb;
+  bridge_->Read(DemuxerStream::AUDIO, 1, client_read_cb.Get());
+
+  ASSERT_TRUE(read_cb);
+
+  // Expect client callback to be called.
+  EXPECT_CALL(client_read_cb, Run(DemuxerStream::kOk, _));
+  std::move(read_cb).Run(DemuxerStream::kOk, {});
+
+  task_environment_.RunUntilIdle();
+}
+
+TEST_F(MojoRendererBypassBridgeTest, CallbackDestroyedWithoutRunning) {
+  NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
+  bridge_->SetStreams(&audio_stream, nullptr);
+
+  DemuxerStream::ReadCB read_cb;
+  EXPECT_CALL(audio_stream, OnRead(_))
+      .WillOnce(
+          [&read_cb](DemuxerStream::ReadCB& cb) { read_cb = std::move(cb); });
+
+  base::MockCallback<DemuxerStream::ReadCB> client_read_cb;
+  bridge_->Read(DemuxerStream::AUDIO, 1, client_read_cb.Get());
+
+  ASSERT_TRUE(read_cb);
+
+  // Destroy the callback without running it.
+  read_cb.Reset();
+
+  // Invalidate should not hang because ScopedClosureRunner should have
+  // decremented the counter when read_cb was destroyed.
+  bridge_->Invalidate();
+}
+
+TEST_F(MojoRendererBypassBridgeTest, InvalidateWaitsForRead) {
+  NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
+  bridge_->SetStreams(&audio_stream, nullptr);
+
+  DemuxerStream::ReadCB read_cb;
+  EXPECT_CALL(audio_stream, OnRead(_))
+      .WillOnce(
+          [&read_cb](DemuxerStream::ReadCB& cb) { read_cb = std::move(cb); });
+
+  base::MockCallback<DemuxerStream::ReadCB> client_read_cb;
+  bridge_->Read(DemuxerStream::AUDIO, 1, client_read_cb.Get());
+
+  ASSERT_TRUE(read_cb);
+
+  base::WaitableEvent invalidate_started(
+      base::WaitableEvent::ResetPolicy::MANUAL,
+      base::WaitableEvent::InitialState::NOT_SIGNALED);
+  base::WaitableEvent invalidate_finished(
+      base::WaitableEvent::ResetPolicy::MANUAL,
+      base::WaitableEvent::InitialState::NOT_SIGNALED);
+
+  base::ThreadPool::PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          [](scoped_refptr<MojoRendererBypassBridge> bridge,
+             base::WaitableEvent* started, base::WaitableEvent* finished) {
+            base::ScopedAllowBaseSyncPrimitivesForTesting allow_sync;
+            started->Signal();
+            bridge->Invalidate();
+            finished->Signal();
+          },
+          bridge_, &invalidate_started, &invalidate_finished));
+
+  invalidate_started.Wait();
+  EXPECT_FALSE(invalidate_finished.IsSignaled());
+
+  EXPECT_CALL(client_read_cb, Run(DemuxerStream::kOk, _));
+  std::move(read_cb).Run(DemuxerStream::kOk, {});
+  invalidate_finished.Wait();
+}
+
+}  // namespace
+}  // namespace media


### PR DESCRIPTION
The MojoRendererBypassBridge previously decremented its in-flight read
counter immediately after calling DemuxerStream::Read. This allowed
the bridge to complete its invalidation and teardown sequence before
the asynchronous read operation actually finished.

Premature destruction of the demuxer and decoders while reads were
active led to hardware decoder leaks, MediaCodec driver crashes, and
subsequent failures to create new DRM sessions. This change wraps the
read callback to ensure the counter is only decremented once the
operation is truly complete, guaranteeing a safe teardown.

Issue: 513254071