### PR TITLE
starboard: Enable starboard::features across platforms and make features extenson optional

### DIFF
--- a/cobalt/app/cobalt_switch_defaults.cc
+++ b/cobalt/app/cobalt_switch_defaults.cc
@@ -74,11 +74,39 @@ CommandLinePreprocessor::CommandLinePreprocessor(int argc,
   // * Duplicate switches with arguments.
   // * Inconsistent settings across related switches.
 
-  // Merge all disabled and enabled feature lists together with their defaults.
-  MergeFeatures(&cmd_line_, ::switches::kDisableFeatures,
-                cobalt_param_switch_defaults);
-  MergeFeatures(&cmd_line_, ::switches::kEnableFeatures,
-                cobalt_param_switch_defaults);
+  // Merge all disabled feature lists together.
+  if (cmd_line_.HasSwitch(::switches::kDisableFeatures)) {
+    std::string disabled_features(
+        cmd_line_.GetSwitchValueASCII(::switches::kDisableFeatures));
+    auto old_value =
+        cobalt_param_switch_defaults.find(::switches::kDisableFeatures);
+    if (old_value != cobalt_param_switch_defaults.end() &&
+        !old_value->second.empty()) {
+      if (!disabled_features.empty()) {
+        disabled_features += ",";
+      }
+      disabled_features += old_value->second;
+      cmd_line_.AppendSwitchNative(::switches::kDisableFeatures,
+                                   disabled_features);
+    }
+  }
+
+  // Merge all enabled feature lists together.
+  if (cmd_line_.HasSwitch(::switches::kEnableFeatures)) {
+    std::string enabled_features(
+        cmd_line_.GetSwitchValueASCII(::switches::kEnableFeatures));
+    auto old_value =
+        cobalt_param_switch_defaults.find(::switches::kEnableFeatures);
+    if (old_value != cobalt_param_switch_defaults.end() &&
+        !old_value->second.empty()) {
+      if (!enabled_features.empty()) {
+        enabled_features += ",";
+      }
+      enabled_features += old_value->second;
+      cmd_line_.AppendSwitchASCII(::switches::kEnableFeatures,
+                                  enabled_features);
+    }
+  }
 
   // Override kContentShellHostWindowSize if the user sets kWindowSize.
   if (cmd_line_.HasSwitch(switches::kWindowSize)) {

--- a/cobalt/app/cobalt_switch_defaults.cc
+++ b/cobalt/app/cobalt_switch_defaults.cc
@@ -74,19 +74,11 @@ CommandLinePreprocessor::CommandLinePreprocessor(int argc,
   // * Duplicate switches with arguments.
   // * Inconsistent settings across related switches.
 
-  // Merge all disabled feature lists together.
-  if (cmd_line_.HasSwitch(::switches::kDisableFeatures)) {
-    std::string disabled_features(
-        cmd_line_.GetSwitchValueASCII(::switches::kDisableFeatures));
-    auto old_value =
-        cobalt_param_switch_defaults.find(::switches::kDisableFeatures);
-    if (old_value != cobalt_param_switch_defaults.end()) {
-      disabled_features += std::string(",");
-      disabled_features += std::string(old_value->second);
-      cmd_line_.AppendSwitchNative(::switches::kDisableFeatures,
-                                   disabled_features);
-    }
-  }
+  // Merge all disabled and enabled feature lists together with their defaults.
+  MergeFeatures(&cmd_line_, ::switches::kDisableFeatures,
+                cobalt_param_switch_defaults);
+  MergeFeatures(&cmd_line_, ::switches::kEnableFeatures,
+                cobalt_param_switch_defaults);
 
   // Override kContentShellHostWindowSize if the user sets kWindowSize.
   if (cmd_line_.HasSwitch(switches::kWindowSize)) {

--- a/cobalt/app/cobalt_switch_defaults.cc
+++ b/cobalt/app/cobalt_switch_defaults.cc
@@ -80,31 +80,11 @@ CommandLinePreprocessor::CommandLinePreprocessor(int argc,
         cmd_line_.GetSwitchValueASCII(::switches::kDisableFeatures));
     auto old_value =
         cobalt_param_switch_defaults.find(::switches::kDisableFeatures);
-    if (old_value != cobalt_param_switch_defaults.end() &&
-        !old_value->second.empty()) {
-      if (!disabled_features.empty()) {
-        disabled_features += ",";
-      }
-      disabled_features += old_value->second;
+    if (old_value != cobalt_param_switch_defaults.end()) {
+      disabled_features += std::string(",");
+      disabled_features += std::string(old_value->second);
       cmd_line_.AppendSwitchNative(::switches::kDisableFeatures,
                                    disabled_features);
-    }
-  }
-
-  // Merge all enabled feature lists together.
-  if (cmd_line_.HasSwitch(::switches::kEnableFeatures)) {
-    std::string enabled_features(
-        cmd_line_.GetSwitchValueASCII(::switches::kEnableFeatures));
-    auto old_value =
-        cobalt_param_switch_defaults.find(::switches::kEnableFeatures);
-    if (old_value != cobalt_param_switch_defaults.end() &&
-        !old_value->second.empty()) {
-      if (!enabled_features.empty()) {
-        enabled_features += ",";
-      }
-      enabled_features += old_value->second;
-      cmd_line_.AppendSwitchASCII(::switches::kEnableFeatures,
-                                  enabled_features);
     }
   }
 

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -300,7 +300,6 @@ static_library("starboard_platform") {
   deps = [
     ":media_codec_video_decoder_helpers",
     "//base",
-    "//starboard/shared/starboard:features",
     "//third_party/opus",
   ]
 
@@ -410,7 +409,6 @@ static_library("test_support") {
 
   deps = [
     ":starboard_platform",
-    "//starboard/shared/starboard:features",
     "//testing/gmock",
     "//testing/gtest",
     "//third_party/jni_zero:jni_zero",
@@ -456,7 +454,6 @@ test("starboard_platform_tests") {
     ":test_support",
     "//base",
     "//starboard:starboard_group",
-    "//starboard/shared/starboard:features",
     "//starboard/shared/starboard:starboard_test",
     "//starboard/shared/starboard/drm:drm_test_helpers",
     "//starboard/shared/starboard/player/filter/testing:test_util",

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -155,8 +155,6 @@ static_library("starboard_platform") {
     "drm_system.cc",
     "drm_system.h",
     "egl_swap_buffers.cc",
-    "features_extension.cc",
-    "features_extension.h",
     "file_internal.cc",
     "file_internal.h",
     "get_home_directory.cc",
@@ -295,7 +293,6 @@ static_library("starboard_platform") {
     "//cobalt/browser/h5vcc_runtime:deep_link_manager",
     "//starboard/common",
     "//starboard/extension:feature_config_header",
-    "//starboard/shared/starboard:feature_list",
     "//starboard/shared/starboard/media:media_util",
     "//starboard/shared/starboard/player/filter:filter_based_player_sources",
   ]
@@ -303,6 +300,7 @@ static_library("starboard_platform") {
   deps = [
     ":media_codec_video_decoder_helpers",
     "//base",
+    "//starboard/shared/starboard:features",
     "//third_party/opus",
   ]
 
@@ -412,6 +410,7 @@ static_library("test_support") {
 
   deps = [
     ":starboard_platform",
+    "//starboard/shared/starboard:features",
     "//testing/gmock",
     "//testing/gtest",
     "//third_party/jni_zero:jni_zero",
@@ -437,7 +436,6 @@ test("starboard_platform_tests") {
               "//starboard/common/test_main.cc",
               "audio_track_audio_sink_type_test.cc",
               "drm_session_id_mapper_test.cc",
-              "features_extension_test.cc",
               "media_capabilities_cache_test.cc",
               "media_codec_decoder_test.cc",
               "media_codec_video_decoder_helpers_test.cc",
@@ -458,6 +456,8 @@ test("starboard_platform_tests") {
     ":test_support",
     "//base",
     "//starboard:starboard_group",
+    "//starboard/shared/starboard:features",
+    "//starboard/shared/starboard:starboard_test",
     "//starboard/shared/starboard/drm:drm_test_helpers",
     "//starboard/shared/starboard/player/filter/testing:test_util",
     "//starboard/testing:scoped_feature_list",

--- a/starboard/android/shared/system_get_extensions.cc
+++ b/starboard/android/shared/system_get_extensions.cc
@@ -20,7 +20,6 @@
 #include "starboard/android/shared/android_media_session_client.h"
 #include "starboard/android/shared/configuration.h"
 #include "starboard/android/shared/crash_handler.h"
-#include "starboard/android/shared/features_extension.h"
 #include "starboard/android/shared/graphics.h"
 #include "starboard/android/shared/media_buffer_pool_extension.h"
 #include "starboard/android/shared/platform_info.h"
@@ -41,6 +40,7 @@
 #include "starboard/extension/player_set_video_surface_view.h"
 #include "starboard/extension/system_info.h"
 #include "starboard/shared/starboard/experimental_features.h"
+#include "starboard/shared/starboard/features_extension.h"
 
 const void* SbSystemGetExtension(const char* name) {
   if (strcmp(name, kCobaltExtensionPlatformServiceName) == 0) {

--- a/starboard/build/config/starboard_target_type.gni
+++ b/starboard/build/config/starboard_target_type.gni
@@ -58,7 +58,7 @@ template("starboard_platform_target") {
     public_deps = [
       "//starboard/common",
       "//starboard/egl_and_gles",
-      "//starboard/shared/starboard:feature_list",
+      "//starboard/shared/starboard:features",
     ]
     if (!sb_is_evergreen) {
       public_deps += [ "//$starboard_path:starboard_platform" ]

--- a/starboard/extension/BUILD.gn
+++ b/starboard/extension/BUILD.gn
@@ -19,7 +19,7 @@ source_set("feature_config_header") {
     "//cobalt/android:java_features_srcjar",
     "//cobalt/common/features:features",
     "//starboard/android/shared:starboard_platform",
-    "//starboard/shared/starboard:feature_list",
+    "//starboard/shared/starboard:features",
   ]
   sources = [ "feature_config.h" ]
 

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -100,7 +100,25 @@ FEATURE_LIST_START
 //   STARBOARD_FEATURE(kCobaltVideoDebug, "CobaltVideoDebug", false)
 // #endif // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 
-#if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
+// Common features starts
+// keep-sorted start newline_separated=yes
+STARBOARD_FEATURE(kDumpVideoData, "DumpVideoData", false)
+
+STARBOARD_FEATURE(kDumpVideoInputHash, "DumpVideoInputHash", false)
+
+STARBOARD_FEATURE(kLimitDrmSessionUpdates, "LimitDrmSessionUpdates", false)
+
+// By default, stub audio decoder is disabled.
+STARBOARD_FEATURE(kUseStubAudioDecoder, "UseStubAudioDecoder", false)
+
+STARBOARD_FEATURE(kUseStubAudioSink, "UseStubAudioSink", false)
+
+// By default, stub video decoder is disabled.
+STARBOARD_FEATURE(kUseStubVideoDecoder, "UseStubVideoDecoder", false)
+// keep-sorted end
+// Common features end
+
+#if BUILDFLAG(IS_ANDROID)
 // keep-sorted start newline_separated=yes
 // Set to true to enable area-based video buffer budget calculation.
 STARBOARD_FEATURE(kAreaBasedVideoBufferBudget,
@@ -146,12 +164,6 @@ STARBOARD_FEATURE(kForceTunnelMode, "ForceTunnelMode", false)
 STARBOARD_FEATURE(kReleaseVideoFramesAfterAudioStarts,
                   "ReleaseVideoFramesAfterAudioStarts",
                   false)
-
-// By default, stub audio decoder is disabled.
-STARBOARD_FEATURE(kUseStubAudioDecoder, "UseStubAudioDecoder", false)
-
-// By default, stub video decoder is disabled.
-STARBOARD_FEATURE(kUseStubVideoDecoder, "UseStubVideoDecoder", false)
 
 // By default, Cobalt restarts MediaCodec after stops/flushes during
 // Reset()/Flush(). Set the following variable to true with parameters
@@ -236,6 +248,12 @@ FEATURE_PARAM_LIST_START
 //                           "standard")
 // #endif // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 
+STARBOARD_FEATURE_PARAM(int,
+                        kMaxDrmSessionUpdates,
+                        kLimitDrmSessionUpdates,
+                        "MaximumDrmSessionUpdates",
+                        0)
+
 #if BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
 // By default, Cobalt restarts MediaCodec after stops/flushes during
 // Reset()/Flush(). Set the following variable to > 0 to force it to
@@ -251,4 +269,5 @@ STARBOARD_FEATURE_PARAM(STARBOARD_FEATURE_PARAM_TIME_TYPE,
                         "ResetDelayUsec",
                         base::Microseconds(0))
 #endif  // BUILDFLAG(IS_ANDROID) && (SB_API_VERSION >= 17)
+
 FEATURE_PARAM_LIST_END

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -253,7 +253,7 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/starboard/media:media_util",
     "//starboard/shared/starboard/player/filter:filter_based_player_sources",
   ]
-  deps = [ "//starboard/shared/starboard:features" ]
+  deps = []
   if (is_internal_build) {
     sources += [
       "//internal/starboard/linux/shared/internal/oemcrypto_engine_device_properties_linux.cc",

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -253,7 +253,7 @@ static_library("starboard_platform_sources") {
     "//starboard/shared/starboard/media:media_util",
     "//starboard/shared/starboard/player/filter:filter_based_player_sources",
   ]
-  deps = []
+  deps = [ "//starboard/shared/starboard:features" ]
   if (is_internal_build) {
     sources += [
       "//internal/starboard/linux/shared/internal/oemcrypto_engine_device_properties_linux.cc",

--- a/starboard/linux/shared/system_get_extensions.cc
+++ b/starboard/linux/shared/system_get_extensions.cc
@@ -19,6 +19,7 @@
 #include "build/build_config.h"
 #include "starboard/common/string.h"
 #include "starboard/extension/configuration.h"
+#include "starboard/extension/features.h"
 #include "starboard/extension/free_space.h"
 #include "starboard/extension/ifa.h"
 #include "starboard/extension/memory_mapped_file.h"
@@ -26,6 +27,7 @@
 #include "starboard/linux/shared/ifa.h"
 #include "starboard/shared/posix/free_space.h"
 #include "starboard/shared/posix/memory_mapped_file.h"
+#include "starboard/shared/starboard/features_extension.h"
 
 #if BUILDFLAG(IS_STARBOARD)
 #include "starboard/elf_loader/evergreen_config.h"
@@ -71,6 +73,9 @@ const void* SbSystemGetExtension(const char* name) {
   }
   if (strcmp(name, kCobaltExtensionFreeSpaceName) == 0) {
     return starboard::GetFreeSpaceApi();
+  }
+  if (strcmp(name, kStarboardExtensionFeaturesName) == 0) {
+    return starboard::GetFeaturesApi();
   }
 #if BUILDFLAG(IS_STARBOARD)
   if (strcmp(name, kStarboardExtensionLoaderAppMetricsName) == 0) {

--- a/starboard/shared/starboard/BUILD.gn
+++ b/starboard/shared/starboard/BUILD.gn
@@ -12,27 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-static_library("feature_list") {
+static_library("features") {
   sources = [
     "feature_list.cc",
     "feature_list.h",
     "features.cc",
     "features.h",
+    "features_extension.cc",
+    "features_extension.h",
   ]
 
+  public_deps = [ "//starboard/extension:feature_config_header" ]
+
   deps = [
+    "//starboard:starboard_headers_only",
     "//starboard/common",
-    "//starboard/extension:feature_config_header",
   ]
 }
 
 source_set("starboard_test") {
   testonly = true
 
-  sources = [ "feature_list_test.cc" ]
+  sources = [
+    "feature_list_test.cc",
+    "features_extension_test.cc",
+  ]
 
   deps = [
-    ":feature_list",
+    ":features",
     "//starboard/common",
     "//testing/gtest",
   ]

--- a/starboard/shared/starboard/application.cc
+++ b/starboard/shared/starboard/application.cc
@@ -15,7 +15,9 @@
 #include "starboard/shared/starboard/application.h"
 
 #include <atomic>
+#include <memory>
 #include <string>
+#include <vector>
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/command_line.h"
@@ -23,7 +25,6 @@
 #include "starboard/common/string.h"
 #include "starboard/configuration.h"
 #include "starboard/event.h"
-
 namespace starboard {
 
 namespace {
@@ -35,6 +36,36 @@ const char kMinLogLevel[] = "min_log_level";
 // debug (0), info, warning, error, fatal. Note that Starboard has no debug;
 // levels start at kSbLogPriorityInfo which is a 1.
 const char kV[] = "v";
+
+struct DeprecatedSwitchMapping {
+  const char* old_flag;
+  const char* replacement_instruction;
+};
+
+const DeprecatedSwitchMapping kDeprecatedSwitchMappings[] = {
+    {"dump_video_data", "--enable-features=DumpVideoData"},
+    {"dump_video_input_hash", "--enable-features=DumpVideoInputHash"},
+    {"maximum_drm_session_updates",
+     "--enable-features=LimitDrmSessionUpdates:MaximumDrmSessionUpdates/"
+     "<value>"},
+    {"use_stub_audio_decoder", "--enable-features=UseStubAudioDecoder"},
+    {"use_stub_audio_sink", "--enable-features=UseStubAudioSink"},
+    {"use_stub_video_decoder", "--enable-features=UseStubVideoDecoder"},
+};
+
+void CheckDeprecatedSwitches(const CommandLine* command_line) {
+  if (!command_line) {
+    return;
+  }
+
+  for (const auto& mapping : kDeprecatedSwitchMappings) {
+    if (command_line->HasSwitch(mapping.old_flag)) {
+      SB_LOG(FATAL) << "Command-line switch '--" << mapping.old_flag
+                    << "' is deprecated. Please use '"
+                    << mapping.replacement_instruction << "' instead.";
+    }
+  }
+}
 
 void DeleteStartData(void* data) {
   SbEventStartData* start_data = static_cast<SbEventStartData*>(data);
@@ -80,6 +111,7 @@ Application* Application::Get() {
 
 int Application::Run(CommandLine command_line, const char* link_data) {
   Initialize();
+  CheckDeprecatedSwitches(&command_line);
   command_line_.reset(new CommandLine(command_line));
   if (link_data) {
     SetStartLink(link_data);
@@ -90,6 +122,7 @@ int Application::Run(CommandLine command_line, const char* link_data) {
 
 int Application::Run(CommandLine command_line) {
   Initialize();
+  CheckDeprecatedSwitches(&command_line);
   command_line_.reset(new CommandLine(command_line));
 
   if (command_line_->HasSwitch(kLinkSwitch)) {
@@ -194,6 +227,17 @@ void Application::HandleFrame(SbPlayer player,
                               int z_index,
                               const Rect& rect) {
   AcceptFrame(player, frame, z_index, rect);
+}
+
+void Application::SetCommandLine(int argc, const char** argv) {
+  auto command_line = std::make_unique<CommandLine>(argc, argv);
+  CheckDeprecatedSwitches(command_line.get());
+  command_line_ = std::move(command_line);
+}
+
+void Application::SetCommandLine(std::unique_ptr<CommandLine> command_line) {
+  CheckDeprecatedSwitches(command_line.get());
+  command_line_ = std::move(command_line);
 }
 
 void Application::SetStartLink(const char* start_link) {

--- a/starboard/shared/starboard/application.h
+++ b/starboard/shared/starboard/application.h
@@ -346,13 +346,8 @@ class SB_EXPORT_ANDROID Application {
 
   // Sets the command-line parameters for the application. Used to support
   // system message pump-based implementations, which don't call |Run()|.
-  void SetCommandLine(int argc, const char** argv) {
-    command_line_.reset(new CommandLine(argc, argv));
-  }
-
-  void SetCommandLine(std::unique_ptr<CommandLine> command_line) {
-    command_line_ = std::move(command_line);
-  }
+  void SetCommandLine(int argc, const char** argv);
+  void SetCommandLine(std::unique_ptr<CommandLine> command_line);
 
   // Sets the launch deep link string, if any, which is passed in the start
   // event that initializes and starts Cobalt.

--- a/starboard/shared/starboard/audio_sink/audio_sink_internal.cc
+++ b/starboard/shared/starboard/audio_sink/audio_sink_internal.cc
@@ -16,10 +16,9 @@
 
 #include <functional>
 
-#include "starboard/common/command_line.h"
-#include "starboard/common/log.h"
-#include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/audio_sink/stub_audio_sink_type.h"
+#include "starboard/shared/starboard/feature_list.h"
+#include "starboard/shared/starboard/features.h"
 
 namespace starboard {
 namespace {
@@ -31,10 +30,6 @@ using std::placeholders::_3;
 bool is_fallback_to_stub_enabled;
 SbAudioSinkImpl::Type* primary_audio_sink_type;
 SbAudioSinkImpl::Type* fallback_audio_sink_type;
-
-// Command line switch that controls whether we default to the stub audio sink,
-// even when the primary audio sink may be available.
-const char kUseStubAudioSink[] = "use_stub_audio_sink";
 
 void WrapConsumeFramesFunc(SbAudioSinkConsumeFramesFunc sb_consume_frames_func,
                            int frames_consumed,
@@ -83,8 +78,7 @@ SbAudioSinkImpl::Type* SbAudioSinkImpl::GetFallbackType() {
 // static
 SbAudioSinkImpl::Type* SbAudioSinkImpl::GetPreferredType() {
   SbAudioSinkImpl::Type* audio_sink_type = NULL;
-  auto command_line = Application::Get()->GetCommandLine();
-  if (!command_line->HasSwitch(kUseStubAudioSink)) {
+  if (!features::FeatureList::IsEnabled(features::kUseStubAudioSink)) {
     audio_sink_type = SbAudioSinkImpl::GetPrimaryType();
   }
   if (!audio_sink_type) {

--- a/starboard/shared/starboard/feature_list.cc
+++ b/starboard/shared/starboard/feature_list.cc
@@ -161,10 +161,14 @@ bool FeatureList::IsEnabled(const SbFeature& feature) {
 
   const auto& feature_map = instance->features_;
   auto feature_it = feature_map.find(feature.name);
-  SB_CHECK(feature_it != feature_map.end())
-      << "Feature " << feature.name
-      << " is not initialized in the Starboard level. Is the feature "
-         "initialized in starboard/extension/feature_config.h?";
+  if (feature_it == feature_map.end()) {
+    SB_LOG(WARNING)
+        << "Feature " << feature.name
+        << " is not initialized in the Starboard level. "
+           "The features extension is available, but does not have "
+           "a value for this feature. This could be due to a version mismatch.";
+    return feature.is_enabled;
+  }
   return feature_it->second;
 }
 

--- a/starboard/shared/starboard/feature_list.cc
+++ b/starboard/shared/starboard/feature_list.cc
@@ -147,7 +147,25 @@ void FeatureList::ValidateParam(const std::string& feature_name,
 
 // static
 bool FeatureList::IsEnabled(const SbFeature& feature) {
-  return IsEnabledByName(feature.name);
+  FeatureList* instance = GetInstance();
+  std::lock_guard lock(instance->mutex_);
+
+  auto override_it = instance->overridden_features_.find(feature.name);
+  if (override_it != instance->overridden_features_.end()) {
+    return override_it->second;
+  }
+
+  if (!instance->IsInitialized()) {
+    return feature.is_enabled;
+  }
+
+  const auto& feature_map = instance->features_;
+  auto feature_it = feature_map.find(feature.name);
+  SB_CHECK(feature_it != feature_map.end())
+      << "Feature " << feature.name
+      << " is not initialized in the Starboard level. Is the feature "
+         "initialized in starboard/extension/feature_config.h?";
+  return feature_it->second;
 }
 
 // static
@@ -160,9 +178,9 @@ bool FeatureList::IsEnabledByName(const std::string& feature_name) {
     return override_it->second;
   }
 
-  // IsEnabled can only be called after the FeatureList has been initialized.
-  SB_CHECK(instance->IsInitialized())
-      << "Starboard features and parameters are not initialized.";
+  if (!instance->IsInitialized()) {
+    return false;
+  }
 
   const auto& feature_map = instance->features_;
   auto feature_it = feature_map.find(feature_name);
@@ -177,6 +195,9 @@ template <>
 bool FeatureList::GetParam(const SbFeatureParamExt<bool>& param) {
   FeatureList* instance = GetInstance();
   std::lock_guard lock(instance->mutex_);
+  if (!instance->IsInitialized()) {
+    return param.value.bool_value;
+  }
   instance->ValidateParam(param.feature_name, param.param_name,
                           SbFeatureParamTypeBool);
   return std::get<bool>(
@@ -187,6 +208,9 @@ template <>
 int FeatureList::GetParam(const SbFeatureParamExt<int>& param) {
   FeatureList* instance = GetInstance();
   std::lock_guard lock(instance->mutex_);
+  if (!instance->IsInitialized()) {
+    return param.value.int_value;
+  }
   instance->ValidateParam(param.feature_name, param.param_name,
                           SbFeatureParamTypeInt);
   return std::get<int>(
@@ -197,6 +221,9 @@ template <>
 double FeatureList::GetParam(const SbFeatureParamExt<double>& param) {
   FeatureList* instance = GetInstance();
   std::lock_guard lock(instance->mutex_);
+  if (!instance->IsInitialized()) {
+    return param.value.double_value;
+  }
   instance->ValidateParam(param.feature_name, param.param_name,
                           SbFeatureParamTypeDouble);
   return std::get<double>(
@@ -207,6 +234,9 @@ template <>
 std::string FeatureList::GetParam(const SbFeatureParamExt<std::string>& param) {
   FeatureList* instance = GetInstance();
   std::lock_guard lock(instance->mutex_);
+  if (!instance->IsInitialized()) {
+    return param.value.string_value ? param.value.string_value : "";
+  }
   instance->ValidateParam(param.feature_name, param.param_name,
                           SbFeatureParamTypeString);
   return std::get<std::string>(
@@ -217,6 +247,9 @@ template <>
 int64_t FeatureList::GetParam(const SbFeatureParamExt<int64_t>& param) {
   FeatureList* instance = GetInstance();
   std::lock_guard lock(instance->mutex_);
+  if (!instance->IsInitialized()) {
+    return param.value.time_value;
+  }
   instance->ValidateParam(param.feature_name, param.param_name,
                           SbFeatureParamTypeTime);
   return std::get<int64_t>(

--- a/starboard/shared/starboard/features_extension.cc
+++ b/starboard/shared/starboard/features_extension.cc
@@ -12,14 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "starboard/android/shared/features_extension.h"
+#include "starboard/shared/starboard/features_extension.h"
 
 #include "starboard/extension/features.h"
 #include "starboard/shared/starboard/feature_list.h"
 
 namespace starboard {
 // Variable that designates what extension version is used.
-const uint32_t FEATURES_API_EXTENSION_VERSION = 1u;
+constexpr uint32_t kFeaturesApiExtensionVersion = 1u;
 
 // Extension function to receive the features and parameters passed
 // down from Cobalt. This function will then pass these values to
@@ -35,7 +35,7 @@ void InitializeStarboardFeatures(const SbFeature* features,
 
 constexpr StarboardExtensionFeaturesApi kFeaturesApi = {
     kStarboardExtensionFeaturesName,
-    FEATURES_API_EXTENSION_VERSION,
+    kFeaturesApiExtensionVersion,
     &InitializeStarboardFeatures,
 };
 

--- a/starboard/shared/starboard/features_extension.h
+++ b/starboard/shared/starboard/features_extension.h
@@ -1,4 +1,4 @@
-// Copyright 2025 The Cobalt Authors. All Rights Reserved.
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef STARBOARD_ANDROID_SHARED_FEATURES_EXTENSION_H_
-#define STARBOARD_ANDROID_SHARED_FEATURES_EXTENSION_H_
+#ifndef STARBOARD_SHARED_STARBOARD_FEATURES_EXTENSION_H_
+#define STARBOARD_SHARED_STARBOARD_FEATURES_EXTENSION_H_
 
 namespace starboard {
 
@@ -23,4 +23,4 @@ const void* GetFeaturesApi();
 
 }  // namespace starboard
 
-#endif  // STARBOARD_ANDROID_SHARED_FEATURES_EXTENSION_H_
+#endif  // STARBOARD_SHARED_STARBOARD_FEATURES_EXTENSION_H_

--- a/starboard/shared/starboard/features_extension_test.cc
+++ b/starboard/shared/starboard/features_extension_test.cc
@@ -29,10 +29,10 @@ TEST(FeaturesExtensionTest, InitializeFeatures) {
   EXPECT_EQ(extension_api->version, 1u);
   ASSERT_NE(extension_api->InitializeStarboardFeatures, nullptr);
 
-  SbFeature test_feature = {"AndroidExtensionTestFeature", true};
+  SbFeature test_feature = {"ExtensionTestFeature", true};
 
   SbFeatureParam test_param;
-  test_param.feature_name = "AndroidExtensionTestFeature";
+  test_param.feature_name = "ExtensionTestFeature";
   test_param.param_name = "TestParam";
   test_param.type = SbFeatureParamTypeBool;
   test_param.value.bool_value = true;

--- a/starboard/shared/starboard/player/filter/BUILD.gn
+++ b/starboard/shared/starboard/player/filter/BUILD.gn
@@ -79,6 +79,7 @@ static_library("filter_based_player_sources") {
   configs += [ "//starboard/build/config:starboard_implementation" ]
   deps = [
     "//starboard:starboard_headers_only",
+    "//starboard/shared/starboard:features",
     "//starboard/shared/starboard/media:media_util",
   ]
 }

--- a/starboard/shared/starboard/player/filter/BUILD.gn
+++ b/starboard/shared/starboard/player/filter/BUILD.gn
@@ -77,9 +77,9 @@ static_library("filter_based_player_sources") {
     "//starboard/shared/starboard/player/filter/wsola_internal.h",
   ]
   configs += [ "//starboard/build/config:starboard_implementation" ]
+  public_deps = [ "//starboard/shared/starboard:features" ]
   deps = [
     "//starboard:starboard_headers_only",
-    "//starboard/shared/starboard:features",
     "//starboard/shared/starboard/media:media_util",
   ]
 }

--- a/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
+++ b/starboard/shared/starboard/player/filter/filter_based_player_worker_handler.cc
@@ -26,8 +26,9 @@
 #include "starboard/common/murmurhash2.h"
 #include "starboard/common/player.h"
 #include "starboard/common/string.h"
-#include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/drm/drm_system_internal.h"
+#include "starboard/shared/starboard/feature_list.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/media_tracing.h"
 #include "starboard/shared/starboard/player/filter/audio_decoder_internal.h"
 #include "starboard/shared/starboard/player/filter/video_decoder_internal.h"
@@ -49,7 +50,7 @@ void DumpInputHash(const InputBuffer* input_buffer) {}
 
 void DumpInputHash(const InputBuffer* input_buffer) {
   static const bool s_dump_input_hash =
-      Application::Get()->GetCommandLine()->HasSwitch("dump_video_input_hash");
+      features::FeatureList::IsEnabled(features::kDumpVideoInputHash);
 
   if (!s_dump_input_hash) {
     return;

--- a/starboard/shared/starboard/player/filter/player_components.cc
+++ b/starboard/shared/starboard/player/filter/player_components.cc
@@ -19,6 +19,7 @@
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/command_line.h"
+#include "starboard/common/string.h"
 #include "starboard/common/time.h"
 #include "starboard/shared/starboard/application.h"
 #include "starboard/shared/starboard/features.h"
@@ -147,18 +148,10 @@ PlayerComponents::Factory::CreateComponents(
             creation_parameters.video_codec() != kSbMediaVideoCodecNone);
   SB_CHECK(creation_parameters.job_queue());
 
-  bool use_stub_audio_decoder = false;
-  bool use_stub_video_decoder = false;
-#if BUILDFLAG(IS_ANDROID)
-  use_stub_audio_decoder =
+  bool use_stub_audio_decoder =
       features::FeatureList::IsEnabled(features::kUseStubAudioDecoder);
-  use_stub_video_decoder =
+  bool use_stub_video_decoder =
       features::FeatureList::IsEnabled(features::kUseStubVideoDecoder);
-#else
-  auto command_line = Application::Get()->GetCommandLine();
-  use_stub_audio_decoder = command_line->HasSwitch("use_stub_audio_decoder");
-  use_stub_video_decoder = command_line->HasSwitch("use_stub_video_decoder");
-#endif  // BUILDFLAG(IS_ANDROID)
 
   MediaComponents components;
   if (use_stub_audio_decoder && use_stub_video_decoder) {

--- a/starboard/shared/starboard/player/video_dmp_writer.cc
+++ b/starboard/shared/starboard/player/video_dmp_writer.cc
@@ -27,7 +27,8 @@
 #include "starboard/common/log.h"
 #include "starboard/common/once.h"
 #include "starboard/common/string.h"
-#include "starboard/shared/starboard/application.h"
+#include "starboard/shared/starboard/feature_list.h"
+#include "starboard/shared/starboard/features.h"
 
 namespace starboard {
 
@@ -39,8 +40,8 @@ using std::placeholders::_2;
 class PlayerToWriterMap {
  public:
   PlayerToWriterMap()
-      : dump_video_data_(Application::Get()->GetCommandLine()->HasSwitch(
-            "dump_video_data")) {}
+      : dump_video_data_(
+            features::FeatureList::IsEnabled(features::kDumpVideoData)) {}
   bool dump_video_data() const { return dump_video_data_; }
   void Register(SbPlayer player) {
     std::lock_guard scoped_lock(mutex_);

--- a/starboard/shared/widevine/drm_system_widevine.cc
+++ b/starboard/shared/widevine/drm_system_widevine.cc
@@ -30,7 +30,8 @@
 #include "starboard/common/string.h"
 #include "starboard/common/time.h"
 #include "starboard/configuration_constants.h"
-#include "starboard/shared/starboard/application.h"
+#include "starboard/shared/starboard/feature_list.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/mime_type.h"
 #include "starboard/shared/widevine/widevine_storage.h"
 #include "starboard/shared/widevine/widevine_timer.h"
@@ -227,12 +228,12 @@ DrmSystemWidevine::DrmSystemWidevine(
   ON_INSTANCE_CREATED(DrmSystemWidevine);
 
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
-  auto command_line = Application::Get()->GetCommandLine();
-  auto value = command_line->GetSwitchValue("maximum_drm_session_updates");
-  if (!value.empty()) {
-    maximum_number_of_session_updates_ = atoi(value.c_str());
-    SB_LOG(INFO) << "Limit drm session updates to "
-                 << maximum_number_of_session_updates_;
+  if (features::FeatureList::IsEnabled(features::kLimitDrmSessionUpdates)) {
+    if (int value = features::kMaxDrmSessionUpdates.Get(); value > 0) {
+      maximum_number_of_session_updates_ = value;
+      SB_LOG(INFO) << "Limit drm session updates to "
+                   << maximum_number_of_session_updates_;
+    }
   }
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
 

--- a/starboard/testing/BUILD.gn
+++ b/starboard/testing/BUILD.gn
@@ -37,7 +37,7 @@ static_library("scoped_feature_list") {
 
   deps = [
     "//starboard/common",
-    "//starboard/shared/starboard:feature_list",
+    "//starboard/shared/starboard:features",
   ]
 }
 
@@ -49,7 +49,7 @@ source_set("testing_test") {
   deps = [
     ":scoped_feature_list",
     "//starboard/common",
-    "//starboard/shared/starboard:feature_list",
+    "//starboard/shared/starboard:features",
     "//testing/gtest",
   ]
 }


### PR DESCRIPTION
Move starboard::features and its extension implementation to a shared
location to enable cross-platform usage. This allows all platforms to
utilize the centralized feature management system.

Make the runtime features extension optional so that platforms without
extension support can gracefully fall back to default values when
uninitialized.

Deprecate legacy command-line switches in favor of the standardized
--enable-features syntax. The application now logs a fatal error if
deprecated flags are used, providing instructions on the replacement.

http://go/cobalt-enable-sb-feature-across-platforms

Issue: 441147438