### PR TITLE
[cobalt] Set default force-gpu-mem-available-mb to 64MB

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -74,6 +74,8 @@ public final class CommandLineOverrideHelper {
         paramOverrides.add("--num-raster-threads=2");
         // Hide scrollbars to avoid memory allocation.
         paramOverrides.add("--hide-scrollbars");
+        // Force GPU memory available to 64MB.
+        paramOverrides.add("--force-gpu-mem-available-mb=64");
 
         return paramOverrides;
     }

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -22,6 +22,7 @@
 #include "cobalt/shell/common/shell_switches.h"
 #include "components/network_session_configurator/common/network_switches.h"
 #include "content/public/common/content_switches.h"
+#include "gpu/command_buffer/service/gpu_switches.h"
 #include "gpu/config/gpu_switches.h"
 #include "media/base/media_switches.h"
 #include "sandbox/policy/switches.h"
@@ -133,6 +134,8 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
        "--no-sparkplug "
        // Disable v8 concurrent marking by default.
        "--no-concurrent-marking"},
+      // Limit GPU memory available to 64MB.
+      {::switches::kForceGpuMemAvailableMb, "64"},
       // Disable CC image cache items limit.
       {::switches::kCCImageCacheLimitItems, "0"},
   };

--- a/cobalt/app/cobalt_switch_defaults_starboard_test.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard_test.cc
@@ -22,6 +22,7 @@
 #include "cobalt/shell/common/shell_switches.h"
 #include "cobalt_switch_defaults.h"
 #include "content/public/common/content_switches.h"
+#include "gpu/command_buffer/service/gpu_switches.h"
 #include "gpu/config/gpu_switches.h"
 #include "media/base/media_switches.h"
 #include "sandbox/policy/switches.h"
@@ -95,6 +96,16 @@ TEST(CobaltSwitchDefaultsTest, GfxAngleOverride) {
   EXPECT_EQ(std::string("swiftshader"), use_angle_setting);
   // Note: This swiftshader argument being respected by the defaults is required
   // for running in Forge environments.
+}
+
+TEST(CobaltSwitchDefaultsTest, GpuMemorySwitchDefault) {
+  const auto input_argv = std::to_array<const char*>({"PROGRAM"});
+  const int input_argc = static_cast<int>(input_argv.size());
+  CommandLinePreprocessor cmd_line_pxr(input_argc, input_argv.data());
+
+  std::string gpu_mem =
+      GetSwitchValue(cmd_line_pxr, ::switches::kForceGpuMemAvailableMb);
+  EXPECT_EQ(std::string("64"), gpu_mem);
 }
 
 TEST(CobaltSwitchDefaultsTest, AlwaysEnabledSwitches) {


### PR DESCRIPTION
Set the default value for the force-gpu-mem-available-mb command-line
switch to 64MB for Android and Starboard platforms.

Experiments have shown that this configuration leads to a 0.37%
improvement in YouTube watch time. Limiting the reported available GPU
memory helps optimize resource allocation on these devices.

Bug: 424591313