### PR TITLE
cobalt: Add Picture-in-Picture demo

### DIFF
--- a/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.html
+++ b/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.html
@@ -1,0 +1,80 @@
+<!--
+  Copyright 2026 The Cobalt Authors. All Rights Reserved.
+
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>Cobalt Picture-in-Picture Test</title>
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <style>
+    body {
+      font-family: sans-serif;
+      margin: 20px;
+      background: #f0f0f0;
+      color: #333;
+    }
+    h1 {
+      font-size: 24px;
+    }
+    video {
+      background: #1e2327;
+      border-radius: 8px;
+      width: 640px;
+      height: 360px;
+      box-shadow: 0 4px 8px rgba(0,0,0,0.2);
+    }
+    button {
+      display: block;
+      margin: 20px 0;
+      padding: 15px 30px;
+      font-size: 18px;
+      font-weight: bold;
+      background-color: #008CBA;
+      color: white;
+      border: none;
+      border-radius: 8px;
+      cursor: pointer;
+      box-shadow: 0 2px 4px rgba(0,0,0,0.1);
+    }
+    /* Critical for Android TV remote navigation */
+    button:focus {
+      background-color: #4CAF50;
+      box-shadow: 0 0 10px #4CAF50;
+      outline: 4px solid #4CAF50;
+    }
+    #log {
+      white-space: pre-wrap;
+      font-family: monospace;
+      background: #eee;
+      padding: 10px;
+      border-radius: 4px;
+      margin-top: 20px;
+    }
+  </style>
+</head>
+<body>
+  <h1>Cobalt Picture-in-Picture Test</h1>
+
+  <video id="video" autoplay muted controls playsinline loop></video>
+
+  <button id="togglePipButton" autofocus>Toggle Picture-in-Picture</button>
+
+  <h3>Console Log:</h3>
+  <div id="log"></div>
+
+  <script src="picture-in-picture-demo.js"></script>
+</body>
+</html>

--- a/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.html
+++ b/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.html
@@ -70,7 +70,7 @@
 
   <video id="video" autoplay muted controls playsinline loop></video>
 
-  <button id="togglePipButton" autofocus>Toggle Picture-in-Picture</button>
+  <button id="togglePipButton" autofocus disabled>Toggle Picture-in-Picture</button>
 
   <h3>Console Log:</h3>
   <div id="log"></div>

--- a/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.js
+++ b/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.js
@@ -55,7 +55,7 @@ function loadVideoViaMSE() {
       }, { once: true });
       sourceBuffer.appendBuffer(data);
     } catch (error) {
-      log('Failed to fetch splash video: ' + error);
+      log('Error loading video via MSE: ' + error);
       console.error(error);
     }
   }, { once: true });

--- a/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.js
+++ b/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.js
@@ -34,6 +34,7 @@ function loadVideoViaMSE() {
   const mediaSource = new MediaSource();
   mediaSource.addEventListener('sourceopen', async () => {
     log('MediaSource open, adding SourceBuffer (vp9)');
+    URL.revokeObjectURL(video.src);
     try {
       // PiP is only supported in decode-to-texture mode.
       const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"; decode-to-texture=true');
@@ -73,7 +74,7 @@ video.addEventListener('pause', () => log('Video paused'));
 video.addEventListener('ended', () => {
   log('Video ended. Looping back to start.');
   video.currentTime = 0;
-  video.play();
+  video.play().catch(e => log('Loop play prevented: ' + e));
 });
 video.addEventListener('enterpictureinpicture', (event) => {
   log('Entered Picture-in-Picture');
@@ -84,6 +85,14 @@ video.addEventListener('leavepictureinpicture', () => {
 });
 
 if ('pictureInPictureEnabled' in document && document.pictureInPictureEnabled) {
+  const enableButton = () => {
+    togglePipButton.disabled = false;
+  };
+  if (video.readyState >= 1) {
+    enableButton();
+  } else {
+    video.addEventListener('loadedmetadata', enableButton, { once: true });
+  }
   togglePipButton.addEventListener('click', async function (event) {
     log('Button clicked');
     togglePipButton.disabled = true;

--- a/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.js
+++ b/cobalt/demos/content/picture-in-picture-demo/picture-in-picture-demo.js
@@ -1,0 +1,111 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+const video = document.getElementById('video');
+const togglePipButton = document.getElementById('togglePipButton');
+const logDiv = document.getElementById('log');
+
+function log(msg) {
+  console.log('JS: ' + msg);
+  logDiv.textContent += msg + '\n';
+}
+
+log('Page loaded');
+log('pictureInPictureEnabled in document: ' + ('pictureInPictureEnabled' in document));
+log('document.pictureInPictureEnabled: ' + document.pictureInPictureEnabled);
+
+function loadVideoViaMSE() {
+  if (typeof MediaSource === 'undefined') {
+    log('MediaSource is not supported in this environment.');
+    return;
+  }
+  log('Starting MSE video load...');
+  const mediaSource = new MediaSource();
+  mediaSource.addEventListener('sourceopen', async () => {
+    log('MediaSource open, adding SourceBuffer (vp9)');
+    try {
+      // PiP is only supported in decode-to-texture mode.
+      const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"; decode-to-texture=true');
+      const fetchUrl = 'https://storage.googleapis.com/ytlr-cert.appspot.com/test-materials/media/big-buck-bunny-vp9-480p-30fps.webm';
+      log('Fetching: ' + fetchUrl);
+      const response = await fetch(fetchUrl);
+      if (!response.ok) {
+        throw new Error('Network response was not ok');
+      }
+      const data = await response.arrayBuffer();
+      log('Fetched ' + data.byteLength + ' bytes, appending to SourceBuffer');
+
+      sourceBuffer.addEventListener('updateend', () => {
+        if (!sourceBuffer.updating && mediaSource.readyState === 'open') {
+          mediaSource.endOfStream();
+          log('MSE Stream ready. Attempting play...');
+          video.play().catch(e => log('Play prevented: ' + e));
+        }
+      }, { once: true });
+      sourceBuffer.appendBuffer(data);
+    } catch (error) {
+      log('Failed to fetch splash video: ' + error);
+      console.error(error);
+    }
+  }, { once: true });
+  video.src = URL.createObjectURL(mediaSource);
+}
+
+// Initialize the MSE video load
+loadVideoViaMSE();
+
+// --- PiP and Video Event Logic from test.html ---
+video.addEventListener('play', () => log('Video started playing'));
+video.addEventListener('pause', () => log('Video paused'));
+
+// MSE videos do not automatically respect the 'loop' attribute.
+video.addEventListener('ended', () => {
+  log('Video ended. Looping back to start.');
+  video.currentTime = 0;
+  video.play();
+});
+video.addEventListener('enterpictureinpicture', (event) => {
+  log('Entered Picture-in-Picture');
+  log('pipWindow: ' + event.pictureInPictureWindow);
+});
+video.addEventListener('leavepictureinpicture', () => {
+  log('Left Picture-in-Picture');
+});
+
+if ('pictureInPictureEnabled' in document && document.pictureInPictureEnabled) {
+  togglePipButton.addEventListener('click', async function (event) {
+    log('Button clicked');
+    togglePipButton.disabled = true;
+    try {
+      if (video !== document.pictureInPictureElement) {
+        log('Requesting Picture-in-Picture...');
+        await video.requestPictureInPicture();
+      } else {
+        log('Exiting Picture-in-Picture...');
+        await document.exitPictureInPicture();
+      }
+    } catch (error) {
+      log('Error: ' + error.message);
+      console.error(error);
+    } finally {
+      togglePipButton.disabled = false;
+      // Refocus button after click
+      togglePipButton.focus();
+    }
+  });
+} else {
+  log('Picture-in-Picture API is not supported in this browser.');
+  togglePipButton.style.backgroundColor = 'grey';
+  togglePipButton.textContent = 'PiP Not Supported';
+}


### PR DESCRIPTION
Add a new standalone demo for testing the Picture-in-Picture (PiP)
API. This provides an isolated environment to verify that the
document.pictureInPictureEnabled property, PiP event listeners,
and video playback via MediaSource Extensions (MSE) function
correctly within Cobalt.

Issue: 445194225