### PR TITLE
starboard: Add certification scope to client hints

### DIFF
--- a/cobalt/browser/client_hint_headers/BUILD.gn
+++ b/cobalt/browser/client_hint_headers/BUILD.gn
@@ -1,3 +1,17 @@
+# Copyright 2025 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 source_set("client_hint_headers") {
   sources = [
     "cobalt_header_value_provider.cc",
@@ -9,9 +23,10 @@ source_set("client_hint_headers") {
   ]
 
   deps = [
+    "//base",
     "//mojo/public/cpp/bindings",
-    "//net:net",
-    "//services/network/public/mojom",
+    "//net",
+    "//starboard/common",
   ]
 
   public_deps = [ "//services/network/public/mojom" ]

--- a/cobalt/browser/client_hint_headers/cobalt_header_value_provider.cc
+++ b/cobalt/browser/client_hint_headers/cobalt_header_value_provider.cc
@@ -30,7 +30,7 @@ CobaltHeaderValueProvider* CobaltHeaderValueProvider::GetInstance() {
 }
 
 CobaltHeaderValueProvider::CobaltHeaderValueProvider() {
-  LoadSystemPropertiesForTesting();
+  LoadSystemProperties();
 }
 
 CobaltHeaderValueProvider::HeaderMap
@@ -54,7 +54,7 @@ void CobaltHeaderValueProvider::ClearHeaderValuesForTesting() {
   header_values_.clear();
 }
 
-void CobaltHeaderValueProvider::LoadSystemPropertiesForTesting() {
+void CobaltHeaderValueProvider::LoadSystemProperties() {
 #if BUILDFLAG(IS_STARBOARD)
   // Retrieve the platform certification scope upon singleton initialization.
   // If present on the underlying platform/device, store it so it is

--- a/cobalt/browser/client_hint_headers/cobalt_header_value_provider.cc
+++ b/cobalt/browser/client_hint_headers/cobalt_header_value_provider.cc
@@ -14,9 +14,11 @@
 
 #include "cobalt/browser/client_hint_headers/cobalt_header_value_provider.h"
 
-#include <iostream>
-
+#include "base/logging.h"
 #include "base/no_destructor.h"
+#include "base/synchronization/lock.h"
+#include "build/build_config.h"
+#include "starboard/common/system_property.h"
 
 namespace cobalt {
 namespace browser {
@@ -27,14 +29,42 @@ CobaltHeaderValueProvider* CobaltHeaderValueProvider::GetInstance() {
   return instance.get();
 }
 
-const HeaderMap& CobaltHeaderValueProvider::GetHeaderValues() const {
+CobaltHeaderValueProvider::CobaltHeaderValueProvider() {
+  LoadSystemPropertiesForTesting();
+}
+
+CobaltHeaderValueProvider::HeaderMap
+CobaltHeaderValueProvider::GetHeaderValues() const {
+  // Thread-safely acquire lock and return a copy of current header values.
+  base::AutoLock auto_lock(lock_);
   return header_values_;
 }
 
 void CobaltHeaderValueProvider::SetHeaderValue(
     const std::string& header_name,
     const std::string& header_value) {
-  header_values_[header_name] = header_value;
+  // Thread-safely acquire lock and insert or update the specified header key.
+  base::AutoLock auto_lock(lock_);
+  header_values_.insert_or_assign(header_name, header_value);
+}
+
+void CobaltHeaderValueProvider::ClearHeaderValuesForTesting() {
+  // Thread-safely acquire lock and clear stored headers for test isolation.
+  base::AutoLock auto_lock(lock_);
+  header_values_.clear();
+}
+
+void CobaltHeaderValueProvider::LoadSystemPropertiesForTesting() {
+#if BUILDFLAG(IS_STARBOARD)
+  // Retrieve the platform certification scope upon singleton initialization.
+  // If present on the underlying platform/device, store it so it is
+  // automatically attached as a trusted client hint header.
+  std::string cert_scope =
+      starboard::GetSystemPropertyString(kSbSystemPropertyCertificationScope);
+  if (!cert_scope.empty()) {
+    SetHeaderValue(kCobaltCertScopeHeaderName, cert_scope);
+  }
+#endif
 }
 
 }  // namespace browser

--- a/cobalt/browser/client_hint_headers/cobalt_header_value_provider.h
+++ b/cobalt/browser/client_hint_headers/cobalt_header_value_provider.h
@@ -60,7 +60,7 @@ class CobaltHeaderValueProvider {
   void ClearHeaderValuesForTesting();
 
   // Re-initializes system property client hint headers for testing.
-  void LoadSystemPropertiesForTesting();
+  void LoadSystemProperties();
 
  private:
   friend class base::NoDestructor<CobaltHeaderValueProvider>;

--- a/cobalt/browser/client_hint_headers/cobalt_header_value_provider.h
+++ b/cobalt/browser/client_hint_headers/cobalt_header_value_provider.h
@@ -19,33 +19,62 @@
 #include <string>
 
 #include "base/no_destructor.h"
+#include "base/synchronization/lock.h"
+#include "base/thread_annotations.h"
 
 namespace cobalt {
 namespace browser {
 
-using HeaderMap = std::map<std::string, std::string>;
+// Client hint header name constants.
+constexpr char kCobaltCertScopeHeaderName[] =
+    "Sec-CH-UA-Co-Youtube-Certification-Scope";
+constexpr char kAndroidOSExperienceHeaderName[] =
+    "Sec-CH-UA-Co-Android-OS-Experience";
+constexpr char kPlayServicesVersionHeaderName[] =
+    "Sec-CH-UA-Co-Android-Play-Services-Version";
+constexpr char kBuildFingerprintHeaderName[] =
+    "Sec-CH-UA-Co-Android-Build-Fingerprint";
 
+// Thread-safe provider for Cobalt-specific trusted client hint HTTP headers.
+// Holds global header key-value pairs attached to outgoing network requests.
 class CobaltHeaderValueProvider {
  public:
-  // Get the singleton instance.
-  static CobaltHeaderValueProvider* GetInstance();
+  using HeaderMap = std::map<std::string, std::string>;
 
-  CobaltHeaderValueProvider() = default;
+  // Returns the process-wide singleton instance of CobaltHeaderValueProvider.
+  static CobaltHeaderValueProvider* GetInstance();
 
   CobaltHeaderValueProvider(const CobaltHeaderValueProvider&) = delete;
   CobaltHeaderValueProvider& operator=(const CobaltHeaderValueProvider&) =
       delete;
 
-  ~CobaltHeaderValueProvider() = default;
-
+  // Thread-safely sets or updates a client hint header key-value pair.
   void SetHeaderValue(const std::string& header_name,
                       const std::string& header_value);
-  const HeaderMap& GetHeaderValues() const;
+
+  // Thread-safely returns a copy of all current client hint header key-value
+  // pairs.
+  HeaderMap GetHeaderValues() const;
+
+  // Clears all stored header values for test isolation.
+  void ClearHeaderValuesForTesting();
+
+  // Re-initializes system property client hint headers for testing.
+  void LoadSystemPropertiesForTesting();
 
  private:
   friend class base::NoDestructor<CobaltHeaderValueProvider>;
 
-  HeaderMap header_values_;
+  // Private constructor and destructor to enforce singleton usage via
+  // GetInstance() and base::NoDestructor.
+  CobaltHeaderValueProvider();
+  ~CobaltHeaderValueProvider() = default;
+
+  // Guard for concurrent access to header_values_.
+  mutable base::Lock lock_;
+
+  // Map of header name to header value.
+  HeaderMap header_values_ GUARDED_BY(lock_);
 };
 
 }  // namespace browser

--- a/cobalt/browser/client_hint_headers/cobalt_header_value_provider_test.cc
+++ b/cobalt/browser/client_hint_headers/cobalt_header_value_provider_test.cc
@@ -14,29 +14,57 @@
 
 #include "cobalt/browser/client_hint_headers/cobalt_header_value_provider.h"
 
+#include "build/build_config.h"
 #include "testing/gtest/include/gtest/gtest.h"
+
+#if BUILDFLAG(IS_STARBOARD)
+#include "starboard/common/system_property.h"
+#endif
 
 namespace cobalt {
 namespace browser {
 
-TEST(CobaltHeaderValueProviderTest, GetInstanceReturnsSameInstance) {
+class CobaltHeaderValueProviderTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // Clear any leftover test state before each test run to ensure isolation.
+    CobaltHeaderValueProvider::GetInstance()->ClearHeaderValuesForTesting();
+  }
+
+  void TearDown() override {
+    // Clean up test state after each test case.
+    CobaltHeaderValueProvider::GetInstance()->ClearHeaderValuesForTesting();
+  }
+};
+
+// Verifies that GetInstance() returns a non-null, valid process-wide singleton.
+TEST_F(CobaltHeaderValueProviderTest, GetInstanceReturnsSameInstance) {
+  // Step 1: Obtain two instance pointers from GetInstance().
   CobaltHeaderValueProvider* instance1 =
       CobaltHeaderValueProvider::GetInstance();
   CobaltHeaderValueProvider* instance2 =
       CobaltHeaderValueProvider::GetInstance();
+
+  // Step 2: Assert both pointers are non-null and point to identical memory
+  // address.
   ASSERT_NE(nullptr, instance1);
   ASSERT_EQ(instance1, instance2);
 }
 
-TEST(CobaltHeaderValueProviderTest, SetAndGetHeaderValues) {
+// Verifies setting and retrieving custom client hint header key-value pairs.
+TEST_F(CobaltHeaderValueProviderTest, SetAndGetHeaderValues) {
+  // Step 1: Obtain singleton instance.
   CobaltHeaderValueProvider* provider =
       CobaltHeaderValueProvider::GetInstance();
   ASSERT_NE(nullptr, provider);
 
+  // Step 2: Insert two distinct header key-value pairs.
   provider->SetHeaderValue("Cobalt-Client-Hint-Header-A", "Test-Value-A");
   provider->SetHeaderValue("Cobalt-Client-Hint-Header-B", "Test-Value-B");
 
-  const HeaderMap& headers = provider->GetHeaderValues();
+  // Step 3: Retrieve current header map and verify both key-value pairs exist
+  // and match.
+  const auto headers = provider->GetHeaderValues();
 
   auto it_a = headers.find("Cobalt-Client-Hint-Header-A");
   ASSERT_NE(headers.end(), it_a);
@@ -47,22 +75,59 @@ TEST(CobaltHeaderValueProviderTest, SetAndGetHeaderValues) {
   EXPECT_EQ("Test-Value-B", it_b->second);
 }
 
-TEST(CobaltHeaderValueProviderTest, UpdateHeaderValue) {
+// Verifies that updating an existing header key overwrites the previous value
+// cleanly.
+TEST_F(CobaltHeaderValueProviderTest, UpdateHeaderValue) {
+  // Step 1: Obtain singleton instance.
   CobaltHeaderValueProvider* provider =
       CobaltHeaderValueProvider::GetInstance();
   ASSERT_NE(nullptr, provider);
 
-  provider->SetHeaderValue("Cobalt-Client-Hint-Header", "Value1");
-  ASSERT_EQ("Value1",
-            provider->GetHeaderValues().at("Cobalt-Client-Hint-Header"));
+  // Step 2: Set initial header value and safely verify via find() without
+  // std::map::at().
+  provider->SetHeaderValue("Cobalt-Client-Hint-Header-Update", "Value1");
+  const auto headers1 = provider->GetHeaderValues();
+  auto it1 = headers1.find("Cobalt-Client-Hint-Header-Update");
+  ASSERT_NE(headers1.end(), it1);
+  EXPECT_EQ("Value1", it1->second);
 
-  // Update the value
-  provider->SetHeaderValue("Cobalt-Client-Hint-Header", "Value2");
-  const HeaderMap& headers = provider->GetHeaderValues();
-  auto it = headers.find("Cobalt-Client-Hint-Header");
-  ASSERT_NE(headers.end(), it);
-  EXPECT_EQ("Value2", it->second);
+  // Step 3: Overwrite header value and verify updated value.
+  provider->SetHeaderValue("Cobalt-Client-Hint-Header-Update", "Value2");
+  const auto headers2 = provider->GetHeaderValues();
+  auto it2 = headers2.find("Cobalt-Client-Hint-Header-Update");
+  ASSERT_NE(headers2.end(), it2);
+  EXPECT_EQ("Value2", it2->second);
 }
+
+#if BUILDFLAG(IS_STARBOARD)
+// Verifies that kCobaltCertScopeHeaderName is properly populated from the
+// platform system property kSbSystemPropertyCertificationScope on Starboard
+// (b/530151533).
+TEST_F(CobaltHeaderValueProviderTest, CertScopeHeaderMatchesPlatformProperty) {
+  // Step 1: Obtain singleton instance and re-initialize from system properties.
+  CobaltHeaderValueProvider* provider =
+      CobaltHeaderValueProvider::GetInstance();
+  ASSERT_NE(nullptr, provider);
+  provider->LoadSystemPropertiesForTesting();
+
+  // Step 2: Query system property directly on the test platform.
+  std::string cert_scope =
+      starboard::GetSystemPropertyString(kSbSystemPropertyCertificationScope);
+
+  // Step 3: Retrieve header map and assert:
+  // - If cert_scope is empty, header must NOT be present.
+  // - If cert_scope is non-empty, header must be present and match.
+  const auto headers = provider->GetHeaderValues();
+  auto it = headers.find(kCobaltCertScopeHeaderName);
+
+  if (cert_scope.empty()) {
+    EXPECT_EQ(headers.end(), it);
+  } else {
+    ASSERT_NE(headers.end(), it);
+    EXPECT_EQ(cert_scope, it->second);
+  }
+}
+#endif  // BUILDFLAG(IS_STARBOARD)
 
 }  // namespace browser
 }  // namespace cobalt

--- a/cobalt/browser/client_hint_headers/cobalt_header_value_provider_test.cc
+++ b/cobalt/browser/client_hint_headers/cobalt_header_value_provider_test.cc
@@ -108,7 +108,6 @@ TEST_F(CobaltHeaderValueProviderTest, CertScopeHeaderMatchesPlatformProperty) {
   CobaltHeaderValueProvider* provider =
       CobaltHeaderValueProvider::GetInstance();
   ASSERT_NE(nullptr, provider);
-  provider->LoadSystemPropertiesForTesting();
 
   // Step 2: Query system property directly on the test platform.
   std::string cert_scope =

--- a/starboard/android/shared/starboard_bridge.cc
+++ b/starboard/android/shared/starboard_bridge.cc
@@ -49,19 +49,6 @@ using jni_zero::JavaParamRef;
 using jni_zero::ScopedJavaGlobalRef;
 using jni_zero::ScopedJavaLocalRef;
 
-// TODO(b/492704919): enable on AOSP when the layering violation is fixed.
-#if !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
-// Client Hint Header name constants
-constexpr char kAndroidOSExperienceHeader[] =
-    "Sec-CH-UA-Co-Android-OS-Experience";
-constexpr char kPlayServicesVersionHeader[] =
-    "Sec-CH-UA-Co-Android-Play-Services-Version";
-constexpr char kBuildFingerprintHeader[] =
-    "Sec-CH-UA-Co-Android-Build-Fingerprint";
-constexpr char kYoutubeCertScopeHeader[] =
-    "Sec-CH-UA-Co-Youtube-Certification-Scope";
-#endif  // !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
-
 // Global pointer to hold the single instance of ApplicationAndroid.
 ApplicationAndroid* g_native_app_instance = nullptr;
 static pthread_mutex_t g_native_app_init_mutex PTHREAD_MUTEX_INITIALIZER;
@@ -151,7 +138,8 @@ void JNI_StarboardBridge_SetAndroidOSExperience(JNIEnv* env,
   std::string value = isAmatiDevice ? "Amati" : "Watson";
   auto header_value_provider =
       cobalt::browser::CobaltHeaderValueProvider::GetInstance();
-  header_value_provider->SetHeaderValue(kAndroidOSExperienceHeader, value);
+  header_value_provider->SetHeaderValue(
+      cobalt::browser::kAndroidOSExperienceHeaderName, value);
 #endif  // !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
 }
 
@@ -161,8 +149,9 @@ void JNI_StarboardBridge_SetAndroidPlayServicesVersion(JNIEnv* env,
 #if !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
   auto header_value_provider =
       cobalt::browser::CobaltHeaderValueProvider::GetInstance();
-  header_value_provider->SetHeaderValue(kPlayServicesVersionHeader,
-                                        base::NumberToString(version));
+  header_value_provider->SetHeaderValue(
+      cobalt::browser::kPlayServicesVersionHeaderName,
+      base::NumberToString(version));
 #endif  // !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
 }
 
@@ -174,7 +163,8 @@ void JNI_StarboardBridge_SetAndroidBuildFingerprint(
   auto header_value_provider =
       cobalt::browser::CobaltHeaderValueProvider::GetInstance();
   header_value_provider->SetHeaderValue(
-      kBuildFingerprintHeader, ConvertJavaStringToUTF8(env, fingerprint));
+      cobalt::browser::kBuildFingerprintHeaderName,
+      ConvertJavaStringToUTF8(env, fingerprint));
 #endif  // !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
 }
 
@@ -186,7 +176,8 @@ void JNI_StarboardBridge_SetYoutubeCertificationScope(
   auto header_value_provider =
       cobalt::browser::CobaltHeaderValueProvider::GetInstance();
   header_value_provider->SetHeaderValue(
-      kYoutubeCertScopeHeader, ConvertJavaStringToUTF8(env, certScope));
+      cobalt::browser::kCobaltCertScopeHeaderName,
+      ConvertJavaStringToUTF8(env, certScope));
 #endif  // !BUILDFLAG(IS_PARTNER_TOOLCHAIN)
 }
 

--- a/starboard/android/shared/system_get_property.cc
+++ b/starboard/android/shared/system_get_property.cc
@@ -160,6 +160,9 @@ bool SbSystemGetProperty(SbSystemPropertyId property_id,
     case kSbSystemPropertyDeviceType:
       return CopyStringAndTestIfSuccess(out_value, value_length,
                                         starboard::kSystemDeviceTypeAndroidTV);
+    case kSbSystemPropertyCertificationScope:
+      return GetAndroidSystemProperty("ro.vendor.youtube.cert_scope", out_value,
+                                      value_length, "");
     default:
       SB_DLOG(WARNING) << __FUNCTION__
                        << ": Unrecognized property: " << property_id;

--- a/starboard/linux/x64x11/system_get_property_impl.cc
+++ b/starboard/linux/x64x11/system_get_property_impl.cc
@@ -67,6 +67,11 @@ bool GetSystemPropertyLinux(SbSystemPropertyId property_id,
           out_value, value_length,
           env_value.empty() ? kBrandName : env_value.c_str());
     case kSbSystemPropertyCertificationScope:
+      env_value = GetEnvironment("COBALT_TESTING_CERTIFICATION_SCOPE");
+      if (!env_value.empty()) {
+        return CopyStringAndTestIfSuccess(out_value, value_length,
+                                          env_value.c_str());
+      }
       if (kCertificationScope[0] == '\0') {
         return false;
       }

--- a/starboard/linux/x64x11/system_get_property_impl.cc
+++ b/starboard/linux/x64x11/system_get_property_impl.cc
@@ -67,11 +67,6 @@ bool GetSystemPropertyLinux(SbSystemPropertyId property_id,
           out_value, value_length,
           env_value.empty() ? kBrandName : env_value.c_str());
     case kSbSystemPropertyCertificationScope:
-      env_value = GetEnvironment("COBALT_TESTING_CERTIFICATION_SCOPE");
-      if (!env_value.empty()) {
-        return CopyStringAndTestIfSuccess(out_value, value_length,
-                                          env_value.c_str());
-      }
       if (kCertificationScope[0] == '\0') {
         return false;
       }


### PR DESCRIPTION
Include the certification scope system property in the client hint
headers. This allows the backend to identify the specific
certification scope of the device. The header value is retrieved from
the Starboard system property kSbSystemPropertyCertificationScope.

Fixed: 530151533