### PR TITLE
Clean up Cobalt devsite file generation script

### DIFF
--- a/cobalt/doc/build_flavours.md
+++ b/cobalt/doc/build_flavours.md
@@ -4,8 +4,6 @@ This document details naming conventions and common idioms for
 build/preprocessor flags in Cobalt. This only applies to Cobalt on Chromium,
 i.e. versions 26 (included) and later, i.e. project "Chrobalt" and after.
 
-Note: This document is heavily inspired on the internal go/cobalt-naming doc.
-
 The existing Cobalt and Starboard build logic defines a number of variables
 that developers are free to rely upon. Some important patterns follow.
 

--- a/cobalt/site/docs/reference/starboard/modules/18/decode_target.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/decode_target.md
@@ -167,12 +167,12 @@ to all Starboard functions that might create SbDecodeTargets.
 
 #### Members
 
-*   `void * egl_display`
+*   `void* egl_display`
 
     A reference to the EGLDisplay object that hosts the EGLContext that will be
     used to render any produced SbDecodeTargets. Note that it has the type
     `void*` in order to avoid including the EGL header files here.
-*   `void * egl_context`
+*   `void* egl_context`
 
     The EGLContext object that will be used to render any produced
     SbDecodeTargets. Note that it has the type `void*` in order to avoid
@@ -183,7 +183,7 @@ to all Starboard functions that might create SbDecodeTargets.
     into the Starboard implementation, and can be invoked by the Starboard
     implementation to allow running arbitrary code on the renderer's thread with
     the EGLContext above held current.
-*   `void * gles_context_runner_context`
+*   `void* gles_context_runner_context`
 
     Context data that is to be passed in to `gles_context_runner` when it is
     invoked.

--- a/cobalt/site/docs/reference/starboard/modules/18/drm.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/drm.md
@@ -218,7 +218,7 @@ Per-sample metadata for encrypted samples.
 *   `int32_t subsample_count`
 
     The number of subsamples in this sample (must be at least 1).
-*   `constSbDrmSubSampleMapping* subsample_mapping`
+*   `const SbDrmSubSampleMapping* subsample_mapping`
 
     The clear/encrypted mapping of each subsample in this sample. This must be
     an array of `subsample_count` mappings.

--- a/cobalt/site/docs/reference/starboard/modules/18/egl.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/egl.md
@@ -102,7 +102,7 @@ typedef int32_t SbEglInt32
     SbEglSurface read, SbEglContext ctx)`
 *   `SbEglBoolean(*eglQueryContext)(SbEglDisplay dpy, SbEglContext ctx,
     SbEglInt32 attribute, SbEglInt32 *value)`
-*   `const char *(*eglQueryString)(SbEglDisplay dpy, SbEglInt32 name)`
+*   `const char*(*eglQueryString)(SbEglDisplay dpy, SbEglInt32 name)`
 *   `SbEglBoolean(*eglQuerySurface)(SbEglDisplay dpy, SbEglSurface surface,
     SbEglInt32 attribute, SbEglInt32 *value)`
 *   `SbEglBoolean(*eglSwapBuffers)(SbEglDisplay dpy, SbEglSurface surface)`

--- a/cobalt/site/docs/reference/starboard/modules/18/event.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/event.md
@@ -47,38 +47,35 @@ Unfreeze     Freeze
 
 ```
 
-```
-A Starboard application receives either `Start` (|kSbEventTypeStart|) or
-`Preload` (|kSbEventTypePreload|) as its first event. `Start` transitions the
+A Starboard application receives either `Start` (`kSbEventTypeStart`) or
+`Preload` (`kSbEventTypePreload`) as its first event. `Start` transitions the
 application to the `STARTED` state, while `Preload` transitions it to the
 `CONCEALED` state.
 
-In the `STARTED` state, the application runs in the foreground and can
-perform all standard operations. From the `STARTED` state, the application
-can transition to the `BLURRED` state upon receiving a `Blur` event.
+In the `STARTED` state, the application runs in the foreground and can perform
+all standard operations. From the `STARTED` state, the application can
+transition to the `BLURRED` state upon receiving a `Blur` event.
 
-In the `BLURRED` state, the application remains visible but has lost focus,
-is partially obscured by a modal dialog, or is preparing to shut down. The
-application should reduce activity in this state. From the `BLURRED` state,
-the application can receive a `Focus` event to return to the `STARTED` state,
-or a `Conceal` event to transition to the `CONCEALED` state.
+In the `BLURRED` state, the application remains visible but has lost focus, is
+partially obscured by a modal dialog, or is preparing to shut down. The
+application should reduce activity in this state. From the `BLURRED` state, the
+application can receive a `Focus` event to return to the `STARTED` state, or a
+`Conceal` event to transition to the `CONCEALED` state.
 
-In the `CONCEALED` state, the application behaves like an invisible
-background process. It can still access the network and play audio, though
-the platform might restrict its CPU and memory resources. The platform can
-transition the application from `CONCEALED` to `FROZEN` at any time.
+In the `CONCEALED` state, the application behaves like an invisible background
+process. It can still access the network and play audio, though the platform
+might restrict its CPU and memory resources. The platform can transition the
+application from `CONCEALED` to `FROZEN` at any time.
 
-In the `FROZEN` state, the application is invisible. It must immediately
-release all graphics and video resources, and stop all background activity
-(such as timers and rendering). The application must also flush storage to
-ensure data is preserved if the process is terminated. Although the platform
-can terminate the process in this state, it ideally sends a `Stop` event
-first for a graceful shutdown.
+In the `FROZEN` state, the application is invisible. It must immediately release
+all graphics and video resources, and stop all background activity (such as
+timers and rendering). The application must also flush storage to ensure data is
+preserved if the process is terminated. Although the platform can terminate the
+process in this state, it ideally sends a `Stop` event first for a graceful
+shutdown.
 
-Note that the application always transitions through `BLURRED` and
-`CONCEALED` to `FROZEN` before receiving `Stop` or being terminated.
-
-```
+Note that the application always transitions through `BLURRED` and `CONCEALED`
+to `FROZEN` before receiving `Stop` or being terminated.
 
 ## Enums
 
@@ -244,7 +241,7 @@ This structure represents a Starboard event and its data.
 
 *   `SbEventType type`
 *   `int64_t timestamp`
-*   `void * data`
+*   `void* data`
 
 ### SbEventStartData
 
@@ -252,13 +249,13 @@ Event data for `kSbEventTypeStart` events.
 
 #### Members
 
-*   `char ** argument_values`
+*   `char** argument_values`
 
     The command-line argument values (argv).
 *   `int argument_count`
 
     The command-line argument count (argc).
-*   `const char * link`
+*   `const char* link`
 
     The startup link, if any.
 

--- a/cobalt/site/docs/reference/starboard/modules/18/gles.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/gles.md
@@ -162,7 +162,7 @@ typedef long int SbGlIntPtr
     precisiontype, SbGlInt32 *range, SbGlInt32 *precision)`
 *   `void(*glGetShaderSource)(SbGlUInt32 shader, SbGlSizei bufSize, SbGlSizei
     *length, SbGlChar *source)`
-*   `const SbGlUInt8 *(*glGetString)(SbGlEnum name)`
+*   `const SbGlUInt8*(*glGetString)(SbGlEnum name)`
 *   `void(*glGetTexParameterfv)(SbGlEnum target, SbGlEnum pname, SbGlFloat
     *params)`
 *   `void(*glGetTexParameteriv)(SbGlEnum target, SbGlEnum pname, SbGlInt32
@@ -323,7 +323,7 @@ typedef long int SbGlIntPtr
     SbGlEnum internalformat, SbGlSizei width, SbGlSizei height)`
 *   `void(*glFramebufferTextureLayer)(SbGlEnum target, SbGlEnum attachment,
     SbGlUInt32 texture, SbGlInt32 level, SbGlInt32 layer)`
-*   `void *(*glMapBufferRange)(SbGlEnum target, SbGlIntPtr offset, SbGlSizeiPtr
+*   `void*(*glMapBufferRange)(SbGlEnum target, SbGlIntPtr offset, SbGlSizeiPtr
     length, SbGlBitfield access)`
 *   `void(*glFlushMappedBufferRange)(SbGlEnum target, SbGlIntPtr offset,
     SbGlSizeiPtr length)`
@@ -381,7 +381,7 @@ typedef long int SbGlIntPtr
     SbGlFloat *value)`
 *   `void(*glClearBufferfi)(SbGlEnum buffer, SbGlInt32 drawbuffer, SbGlFloat
     depth, SbGlInt32 stencil)`
-*   `const SbGlUInt8 *(*glGetStringi)(SbGlEnum name, SbGlUInt32 index)`
+*   `const SbGlUInt8*(*glGetStringi)(SbGlEnum name, SbGlUInt32 index)`
 *   `void(*glCopyBufferSubData)(SbGlEnum readTarget, SbGlEnum writeTarget,
     SbGlIntPtr readOffset, SbGlIntPtr writeOffset, SbGlSizeiPtr size)`
 *   `void(*glGetUniformIndices)(SbGlUInt32 program, SbGlSizei uniformCount,

--- a/cobalt/site/docs/reference/starboard/modules/18/input.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/input.md
@@ -149,7 +149,7 @@ Event data for `kSbEventTypeInput` events.
     z-axis. Positive values indicate tilt to the right (x) and towards the user
     (y). Use `(NaN, NaN)` if the device does not report tilt. This value applies
     to mouse and touchscreen input events.
-*   `const char * input_text`
+*   `const char* input_text`
 
     The text to input for events of type `Input`.
 *   `bool is_composing`

--- a/cobalt/site/docs/reference/starboard/modules/18/media.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/media.md
@@ -222,7 +222,7 @@ The set of information required by the decoder or player for each audio stream.
 *   `SbMediaAudioCodec codec`
 
     The audio codec of this sample.
-*   `const char * mime`
+*   `const char* mime`
 
     The mime of the audio stream when `codec` isn't kSbMediaAudioCodecNone. It
     may point to an empty string if the mime is not available, and it can only
@@ -239,7 +239,7 @@ The set of information required by the decoder or player for each audio stream.
 *   `uint16_t audio_specific_config_size`
 
     The size, in bytes, of the audio_specific_config.
-*   `const void * audio_specific_config`
+*   `const void* audio_specific_config`
 
     The AudioSpecificConfig, as specified in ISO/IEC-14496-3, section 1.6.2.1.
 
@@ -397,12 +397,12 @@ The set of information required by the decoder or player for each video stream.
 *   `SbMediaVideoCodec codec`
 
     The video codec of this sample.
-*   `const char * mime`
+*   `const char* mime`
 
     The mime of the video stream when `codec` isn't kSbMediaVideoCodecNone. It
     may point to an empty string if the mime is not available, and it can only
     be set to NULL when `codec` is kSbMediaVideoCodecNone.
-*   `const char * max_video_capabilities`
+*   `const char* max_video_capabilities`
 
     Indicates the max video capabilities required. The web app will not provide
     a video stream exceeding the maximums described by this parameter. Allows

--- a/cobalt/site/docs/reference/starboard/modules/18/player.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/player.md
@@ -250,7 +250,7 @@ Information about the samples to be written into SbPlayerWriteSamples().
 #### Members
 
 *   `SbMediaType type`
-*   `const void * buffer`
+*   `const void* buffer`
 
     Points to the buffer containing the sample data.
 *   `int buffer_size`
@@ -274,8 +274,8 @@ Information about the samples to be written into SbPlayerWriteSamples().
 
     Information about a video sample. This value can only be used when `type` is
     kSbMediaTypeVideo.
-*   `union SbPlayerSampleInfo::@0 @1`
-*   `constSbDrmSampleInfo* drm_info`
+*   `union SbPlayerSampleInfo`
+*   `const SbDrmSampleInfo* drm_info`
 
     The DRM system related info for the media sample. This value is required for
     encrypted samples. Otherwise, it must be `NULL`.
@@ -288,7 +288,7 @@ coming from multiple sources.
 #### Members
 
 *   `SbPlayerSampleSideDataType type`
-*   `const uint8_t * data`
+*   `const uint8_t* data`
 
     `data` will remain valid until SbPlayerDeallocateSampleFunc() is called on
     the `SbPlayerSampleInfo::buffer` the data is associated with.

--- a/cobalt/site/docs/reference/starboard/modules/18/window.md
+++ b/cobalt/site/docs/reference/starboard/modules/18/window.md
@@ -39,7 +39,7 @@ Options that can be requested at window creation time.
 
     Specifies whether the new window is windowed. If `false`, the requested size
     represents the requested resolution.
-*   `const char * name`
+*   `const char* name`
 
     The name of the window to create.
 

--- a/cobalt/site/docs/reference/starboard/modules/decode_target.md
+++ b/cobalt/site/docs/reference/starboard/modules/decode_target.md
@@ -167,12 +167,12 @@ to all Starboard functions that might create SbDecodeTargets.
 
 #### Members
 
-*   `void * egl_display`
+*   `void* egl_display`
 
     A reference to the EGLDisplay object that hosts the EGLContext that will be
     used to render any produced SbDecodeTargets. Note that it has the type
     `void*` in order to avoid including the EGL header files here.
-*   `void * egl_context`
+*   `void* egl_context`
 
     The EGLContext object that will be used to render any produced
     SbDecodeTargets. Note that it has the type `void*` in order to avoid
@@ -183,7 +183,7 @@ to all Starboard functions that might create SbDecodeTargets.
     into the Starboard implementation, and can be invoked by the Starboard
     implementation to allow running arbitrary code on the renderer's thread with
     the EGLContext above held current.
-*   `void * gles_context_runner_context`
+*   `void* gles_context_runner_context`
 
     Context data that is to be passed in to `gles_context_runner` when it is
     invoked.

--- a/cobalt/site/docs/reference/starboard/modules/drm.md
+++ b/cobalt/site/docs/reference/starboard/modules/drm.md
@@ -218,7 +218,7 @@ Per-sample metadata for encrypted samples.
 *   `int32_t subsample_count`
 
     The number of subsamples in this sample (must be at least 1).
-*   `constSbDrmSubSampleMapping* subsample_mapping`
+*   `const SbDrmSubSampleMapping* subsample_mapping`
 
     The clear/encrypted mapping of each subsample in this sample. This must be
     an array of `subsample_count` mappings.

--- a/cobalt/site/docs/reference/starboard/modules/egl.md
+++ b/cobalt/site/docs/reference/starboard/modules/egl.md
@@ -102,7 +102,7 @@ typedef int32_t SbEglInt32
     SbEglSurface read, SbEglContext ctx)`
 *   `SbEglBoolean(*eglQueryContext)(SbEglDisplay dpy, SbEglContext ctx,
     SbEglInt32 attribute, SbEglInt32 *value)`
-*   `const char *(*eglQueryString)(SbEglDisplay dpy, SbEglInt32 name)`
+*   `const char*(*eglQueryString)(SbEglDisplay dpy, SbEglInt32 name)`
 *   `SbEglBoolean(*eglQuerySurface)(SbEglDisplay dpy, SbEglSurface surface,
     SbEglInt32 attribute, SbEglInt32 *value)`
 *   `SbEglBoolean(*eglSwapBuffers)(SbEglDisplay dpy, SbEglSurface surface)`

--- a/cobalt/site/docs/reference/starboard/modules/event.md
+++ b/cobalt/site/docs/reference/starboard/modules/event.md
@@ -47,38 +47,35 @@ Unfreeze     Freeze
 
 ```
 
-```
-A Starboard application receives either `Start` (|kSbEventTypeStart|) or
-`Preload` (|kSbEventTypePreload|) as its first event. `Start` transitions the
+A Starboard application receives either `Start` (`kSbEventTypeStart`) or
+`Preload` (`kSbEventTypePreload`) as its first event. `Start` transitions the
 application to the `STARTED` state, while `Preload` transitions it to the
 `CONCEALED` state.
 
-In the `STARTED` state, the application runs in the foreground and can
-perform all standard operations. From the `STARTED` state, the application
-can transition to the `BLURRED` state upon receiving a `Blur` event.
+In the `STARTED` state, the application runs in the foreground and can perform
+all standard operations. From the `STARTED` state, the application can
+transition to the `BLURRED` state upon receiving a `Blur` event.
 
-In the `BLURRED` state, the application remains visible but has lost focus,
-is partially obscured by a modal dialog, or is preparing to shut down. The
-application should reduce activity in this state. From the `BLURRED` state,
-the application can receive a `Focus` event to return to the `STARTED` state,
-or a `Conceal` event to transition to the `CONCEALED` state.
+In the `BLURRED` state, the application remains visible but has lost focus, is
+partially obscured by a modal dialog, or is preparing to shut down. The
+application should reduce activity in this state. From the `BLURRED` state, the
+application can receive a `Focus` event to return to the `STARTED` state, or a
+`Conceal` event to transition to the `CONCEALED` state.
 
-In the `CONCEALED` state, the application behaves like an invisible
-background process. It can still access the network and play audio, though
-the platform might restrict its CPU and memory resources. The platform can
-transition the application from `CONCEALED` to `FROZEN` at any time.
+In the `CONCEALED` state, the application behaves like an invisible background
+process. It can still access the network and play audio, though the platform
+might restrict its CPU and memory resources. The platform can transition the
+application from `CONCEALED` to `FROZEN` at any time.
 
-In the `FROZEN` state, the application is invisible. It must immediately
-release all graphics and video resources, and stop all background activity
-(such as timers and rendering). The application must also flush storage to
-ensure data is preserved if the process is terminated. Although the platform
-can terminate the process in this state, it ideally sends a `Stop` event
-first for a graceful shutdown.
+In the `FROZEN` state, the application is invisible. It must immediately release
+all graphics and video resources, and stop all background activity (such as
+timers and rendering). The application must also flush storage to ensure data is
+preserved if the process is terminated. Although the platform can terminate the
+process in this state, it ideally sends a `Stop` event first for a graceful
+shutdown.
 
-Note that the application always transitions through `BLURRED` and
-`CONCEALED` to `FROZEN` before receiving `Stop` or being terminated.
-
-```
+Note that the application always transitions through `BLURRED` and `CONCEALED`
+to `FROZEN` before receiving `Stop` or being terminated.
 
 ## Enums
 
@@ -244,7 +241,7 @@ This structure represents a Starboard event and its data.
 
 *   `SbEventType type`
 *   `int64_t timestamp`
-*   `void * data`
+*   `void* data`
 
 ### SbEventStartData
 
@@ -252,13 +249,13 @@ Event data for `kSbEventTypeStart` events.
 
 #### Members
 
-*   `char ** argument_values`
+*   `char** argument_values`
 
     The command-line argument values (argv).
 *   `int argument_count`
 
     The command-line argument count (argc).
-*   `const char * link`
+*   `const char* link`
 
     The startup link, if any.
 

--- a/cobalt/site/docs/reference/starboard/modules/gles.md
+++ b/cobalt/site/docs/reference/starboard/modules/gles.md
@@ -162,7 +162,7 @@ typedef long int SbGlIntPtr
     precisiontype, SbGlInt32 *range, SbGlInt32 *precision)`
 *   `void(*glGetShaderSource)(SbGlUInt32 shader, SbGlSizei bufSize, SbGlSizei
     *length, SbGlChar *source)`
-*   `const SbGlUInt8 *(*glGetString)(SbGlEnum name)`
+*   `const SbGlUInt8*(*glGetString)(SbGlEnum name)`
 *   `void(*glGetTexParameterfv)(SbGlEnum target, SbGlEnum pname, SbGlFloat
     *params)`
 *   `void(*glGetTexParameteriv)(SbGlEnum target, SbGlEnum pname, SbGlInt32
@@ -323,7 +323,7 @@ typedef long int SbGlIntPtr
     SbGlEnum internalformat, SbGlSizei width, SbGlSizei height)`
 *   `void(*glFramebufferTextureLayer)(SbGlEnum target, SbGlEnum attachment,
     SbGlUInt32 texture, SbGlInt32 level, SbGlInt32 layer)`
-*   `void *(*glMapBufferRange)(SbGlEnum target, SbGlIntPtr offset, SbGlSizeiPtr
+*   `void*(*glMapBufferRange)(SbGlEnum target, SbGlIntPtr offset, SbGlSizeiPtr
     length, SbGlBitfield access)`
 *   `void(*glFlushMappedBufferRange)(SbGlEnum target, SbGlIntPtr offset,
     SbGlSizeiPtr length)`
@@ -381,7 +381,7 @@ typedef long int SbGlIntPtr
     SbGlFloat *value)`
 *   `void(*glClearBufferfi)(SbGlEnum buffer, SbGlInt32 drawbuffer, SbGlFloat
     depth, SbGlInt32 stencil)`
-*   `const SbGlUInt8 *(*glGetStringi)(SbGlEnum name, SbGlUInt32 index)`
+*   `const SbGlUInt8*(*glGetStringi)(SbGlEnum name, SbGlUInt32 index)`
 *   `void(*glCopyBufferSubData)(SbGlEnum readTarget, SbGlEnum writeTarget,
     SbGlIntPtr readOffset, SbGlIntPtr writeOffset, SbGlSizeiPtr size)`
 *   `void(*glGetUniformIndices)(SbGlUInt32 program, SbGlSizei uniformCount,

--- a/cobalt/site/docs/reference/starboard/modules/input.md
+++ b/cobalt/site/docs/reference/starboard/modules/input.md
@@ -149,7 +149,7 @@ Event data for `kSbEventTypeInput` events.
     z-axis. Positive values indicate tilt to the right (x) and towards the user
     (y). Use `(NaN, NaN)` if the device does not report tilt. This value applies
     to mouse and touchscreen input events.
-*   `const char * input_text`
+*   `const char* input_text`
 
     The text to input for events of type `Input`.
 *   `bool is_composing`

--- a/cobalt/site/docs/reference/starboard/modules/media.md
+++ b/cobalt/site/docs/reference/starboard/modules/media.md
@@ -222,7 +222,7 @@ The set of information required by the decoder or player for each audio stream.
 *   `SbMediaAudioCodec codec`
 
     The audio codec of this sample.
-*   `const char * mime`
+*   `const char* mime`
 
     The mime of the audio stream when `codec` isn't kSbMediaAudioCodecNone. It
     may point to an empty string if the mime is not available, and it can only
@@ -239,7 +239,7 @@ The set of information required by the decoder or player for each audio stream.
 *   `uint16_t audio_specific_config_size`
 
     The size, in bytes, of the audio_specific_config.
-*   `const void * audio_specific_config`
+*   `const void* audio_specific_config`
 
     The AudioSpecificConfig, as specified in ISO/IEC-14496-3, section 1.6.2.1.
 
@@ -397,12 +397,12 @@ The set of information required by the decoder or player for each video stream.
 *   `SbMediaVideoCodec codec`
 
     The video codec of this sample.
-*   `const char * mime`
+*   `const char* mime`
 
     The mime of the video stream when `codec` isn't kSbMediaVideoCodecNone. It
     may point to an empty string if the mime is not available, and it can only
     be set to NULL when `codec` is kSbMediaVideoCodecNone.
-*   `const char * max_video_capabilities`
+*   `const char* max_video_capabilities`
 
     Indicates the max video capabilities required. The web app will not provide
     a video stream exceeding the maximums described by this parameter. Allows

--- a/cobalt/site/docs/reference/starboard/modules/player.md
+++ b/cobalt/site/docs/reference/starboard/modules/player.md
@@ -250,7 +250,7 @@ Information about the samples to be written into SbPlayerWriteSamples().
 #### Members
 
 *   `SbMediaType type`
-*   `const void * buffer`
+*   `const void* buffer`
 
     Points to the buffer containing the sample data.
 *   `int buffer_size`
@@ -274,8 +274,8 @@ Information about the samples to be written into SbPlayerWriteSamples().
 
     Information about a video sample. This value can only be used when `type` is
     kSbMediaTypeVideo.
-*   `union SbPlayerSampleInfo::@0 @1`
-*   `constSbDrmSampleInfo* drm_info`
+*   `union SbPlayerSampleInfo`
+*   `const SbDrmSampleInfo* drm_info`
 
     The DRM system related info for the media sample. This value is required for
     encrypted samples. Otherwise, it must be `NULL`.
@@ -288,7 +288,7 @@ coming from multiple sources.
 #### Members
 
 *   `SbPlayerSampleSideDataType type`
-*   `const uint8_t * data`
+*   `const uint8_t* data`
 
     `data` will remain valid until SbPlayerDeallocateSampleFunc() is called on
     the `SbPlayerSampleInfo::buffer` the data is associated with.

--- a/cobalt/site/docs/reference/starboard/modules/window.md
+++ b/cobalt/site/docs/reference/starboard/modules/window.md
@@ -39,7 +39,7 @@ Options that can be requested at window creation time.
 
     Specifies whether the new window is windowed. If `false`, the requested size
     represents the requested resolution.
-*   `const char * name`
+*   `const char* name`
 
     The name of the window to create.
 

--- a/cobalt/site/scripts/cobalt_module_reference.py
+++ b/cobalt/site/scripts/cobalt_module_reference.py
@@ -83,7 +83,8 @@ def _find_innertext(element, query=''):
       return ''
   else:
     node = element
-  return _strip(''.join(x.strip() for x in node.itertext()))
+  text = ''.join(x for x in node.itertext())
+  return _strip(re.sub(r'\s+', ' ', text))
 
 
 def _find_memberdefs(compounddef_element, kind):
@@ -141,6 +142,10 @@ def _find_member_definition(memberdef_element):
   type_name = _find_innertext(type_element)
   args_name = _strip(memberdef_element.findtext('./argsstring'))
   member_name = _strip(memberdef_element.findtext('./name'))
+  # Doxygen sometimes adds spaces before asterisks, normalize them.
+  type_name = re.sub(r'\s+\*', '*', type_name)
+  type_name = re.sub(r'\s+&', '&', type_name)
+
   # Doxygen does not handle structs of non-typedef'd function pointers
   # gracefully. The 'type' and 'argsstring' elements are used to temporarily
   # store the information needed to be able to rebuild the full signature, e.g.:
@@ -155,7 +160,9 @@ def _find_member_definition(memberdef_element):
   # 'argsstring' we return the full member signature instead.
   if type_name.endswith('(*') and args_name.startswith(')('):
     return type_name + member_name + args_name
-  return type_name + ' ' + member_name
+  if member_name:
+    return type_name + ' ' + member_name
+  return type_name
 
 
 def _node_to_markdown(out, node):
@@ -450,7 +457,10 @@ def generate(source_dir, output_dir):
     site_path = environment.get_site_dir(source_dir)
   doc_dir_path = os.path.join(site_path, 'docs', 'reference', 'starboard',
                               'modules')
-  environment.make_clean_dirs(doc_dir_path)
+  environment.make_dirs(doc_dir_path)
+  for item in os.listdir(doc_dir_path):
+    if item.endswith('.md'):
+      os.remove(os.path.join(doc_dir_path, item))
   starboard_directory_path = environment.get_starboard_dir(source_dir)
   starboard_files = _get_files(starboard_directory_path, _HEADER_RE)
   with environment.mkdtemp(suffix='.' + _SCRIPT_NAME) as temp_directory_path:
@@ -463,13 +473,13 @@ def generate(source_dir, output_dir):
     for sb_version in _OSS_STARBOARD_VERSIONS:
       version_path = os.path.join(doxygen_directory_path, str(sb_version))
       version_doc_dir_path = os.path.join(doc_dir_path, str(sb_version))
+      environment.make_clean_dirs(version_doc_dir_path)
       doxygen.doxygen(sb_version, doxygenated_files, [], version_path)
       doxygen_xml_path = os.path.join(version_path, 'xml')
       for header_xml_path in _get_files(doxygen_xml_path, _HEADER_XML_RE):
         header_xml = ET.parse(header_xml_path)
         for compounddef_element in header_xml.findall(
             ".//compounddef[@kind='file'][compoundname]"):
-          environment.make_dirs(version_doc_dir_path)
           header_filename = _find_filename(compounddef_element)
           doc_filename = (
               os.path.splitext(os.path.basename(header_filename))[0] + '.md')


### PR DESCRIPTION
This change fixes issues where C++ types were not being formatted correctly in code blocks. Additionally, the site generator script should stop deleting the module reference directories for old Starboard versions. Another cleanup removes the internal go link from another markdown file.

Bug: 505097004