### PR TITLE
aosp: fix BuildInfo.java build error (#11230)

### DIFF
--- a/copied_base/base/android/java/src/org/chromium/base/BuildInfo.java
+++ b/copied_base/base/android/java/src/org/chromium/base/BuildInfo.java
@@ -24,6 +24,7 @@ import androidx.core.os.BuildCompat;
 import org.chromium.base.annotations.CalledByNative;
 import org.chromium.base.compat.ApiHelperForP;
 import org.chromium.build.BuildConfig;
+import org.chromium.build.NativeLibraries;
 
 /**
  * BuildInfo is a utility class providing easy access to {@link PackageInfo} information. This is
@@ -137,12 +138,10 @@ public class BuildInfo {
      *     https://chromium.googlesource.com/chromium/src.git/+/master/docs/updater/protocol_3_1.md
      */
     public static String getArch() {
-        String[] abis = Build.SUPPORTED_ABIS;
-        String primaryAbi = (abis != null && abis.length > 0) ? abis[0] : "";
         boolean is64Bit = Process.is64Bit();
-        if (primaryAbi.startsWith("arm")) {
+        if (NativeLibraries.sCpuFamily == NativeLibraries.CPU_FAMILY_ARM) {
             return is64Bit ? "arm64" : "arm";
-        } else if (primaryAbi.startsWith("x86")) {
+        } else if (NativeLibraries.sCpuFamily == NativeLibraries.CPU_FAMILY_X86) {
             return is64Bit ? "x86_64" : "x86";
         }
         return "";


### PR DESCRIPTION
Follow-up of #11230, use NativeLibraries instead of checking the supported ABIs list to actuallly mirror the //base implementation.

Bug: 517566565