### PR TITLE
starboard: Cache features and enforce literals

### DIFF
--- a/media/base/starboard/experimental_features.h
+++ b/media/base/starboard/experimental_features.h
@@ -48,7 +48,9 @@ class MEDIA_EXPORT ExperimentalFeatureKey {
  public:
   using ValueType = T;
 
-  constexpr explicit ExperimentalFeatureKey(std::string_view key) : key_(key) {}
+  template <size_t N>
+  constexpr explicit ExperimentalFeatureKey(const char (&key)[N])
+      : key_(key, N - 1) {}
 
   constexpr std::string_view key() const { return key_; }
 

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -47,7 +47,9 @@ template <typename T>
 class ExperimentalFeatureKey {
  public:
   using ValueType = T;
-  constexpr explicit ExperimentalFeatureKey(std::string_view key) : key_(key) {}
+  template <size_t N>
+  constexpr explicit ExperimentalFeatureKey(const char (&key)[N])
+      : key_(key, N - 1) {}
   constexpr std::string_view key() const { return key_; }
 
  private:

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.cc
@@ -77,7 +77,8 @@ AudioRendererPcm::AudioRendererPcm(
     : JobOwner(job_queue),
       max_cached_frames_(max_cached_frames),
       min_frames_per_append_(min_frames_per_append),
-      experimental_features_(experimental_features),
+      allow_audio_writing_on_pause_(
+          experimental_features.GetBool(kMediaAllowAudioWritingOnPause)),
       decoder_(std::move(decoder)),
       frames_consumed_set_at_(CurrentMonotonicTime()),
       channels_(audio_stream_info.number_of_channels),
@@ -439,8 +440,7 @@ void AudioRendererPcm::GetSourceStatus(int* frames_in_buffer,
   *is_eos_reached = is_eos_reached_on_sink_thread_;
   *is_playing = is_playing_on_sink_thread_;
 
-  if (*is_playing ||
-      experimental_features_.GetBool(kMediaAllowAudioWritingOnPause)) {
+  if (*is_playing || allow_audio_writing_on_pause_) {
     *frames_in_buffer =
         frames_in_buffer_on_sink_thread_ - frames_consumed_on_sink_thread_;
     *offset_in_frames =

--- a/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
+++ b/starboard/shared/starboard/player/filter/audio_renderer_internal_pcm.h
@@ -108,7 +108,7 @@ class AudioRendererPcm : public AudioRenderer,
 
   const int max_cached_frames_;
   const int min_frames_per_append_;
-  const ExperimentalFeatures experimental_features_;
+  const bool allow_audio_writing_on_pause_;
   // |buffered_frames_to_start_| would be initialized in OnFirstOutput().
   // Before it's initialized, set it to a large number.
   int buffered_frames_to_start_ = 48 * 1024;

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.cc
@@ -50,7 +50,14 @@ VideoRendererImpl::VideoRendererImpl(
       algorithm_(std::move(algorithm)),
       sink_(sink),
       decoder_(std::move(decoder)),
-      experimental_features_(experimental_features) {
+      min_input_buffers_(
+          experimental_features.Get(kMediaVideoRendererMinInputBuffers)),
+      min_decoded_frames_(
+          experimental_features.Get(kMediaVideoRendererMinDecodedFrames)),
+      enable_video_renderer_vsp_adjustment_(experimental_features.GetBool(
+          kMediaEnableVideoRendererVspAdjustment)),
+      enable_trivial_optimizations_(
+          experimental_features.GetBool(kMediaEnableTrivialOptimizations)) {
   SB_CHECK(decoder_);
   SB_CHECK(algorithm_);
   SB_DCHECK_GT(decoder_->GetMaxNumberOfCachedFrames(), 1U);
@@ -67,14 +74,10 @@ VideoRendererImpl::VideoRendererImpl(
            kCheckBufferingStateInterval);
   time_of_last_lag_warning_ = CurrentMonotonicTime() - kMinLagWarningInterval;
 #endif  // SB_PLAYER_FILTER_ENABLE_STATE_CHECK
-  auto min_input_buffers =
-      experimental_features_.Get(kMediaVideoRendererMinInputBuffers);
-  auto min_decoded_frames =
-      experimental_features_.Get(kMediaVideoRendererMinDecodedFrames);
-  if (min_input_buffers && min_decoded_frames) {
+  if (min_input_buffers_ && min_decoded_frames_) {
     SB_LOG(INFO) << "VideoRendererImpl is created: preroll_params="
-                 << "{min_input_buffers=" << *min_input_buffers
-                 << ", min_decoded_frames=" << *min_decoded_frames << "}";
+                 << "{min_input_buffers=" << *min_input_buffers_
+                 << ", min_decoded_frames=" << *min_decoded_frames_ << "}";
   } else {
     SB_LOG(INFO) << "VideoRendererImpl is created: using default preroll logic";
   }
@@ -153,7 +156,7 @@ void VideoRendererImpl::WriteSamples(const InputBuffers& input_buffers) {
     decoder_->WriteInputBuffers(buffers);
   };
 
-  if (!experimental_features_.GetBool(kMediaEnableVideoRendererVspAdjustment) ||
+  if (!enable_video_renderer_vsp_adjustment_ ||
       (!is_vsp_adjustment_enabled_ && seeking_)) {
     write_to_decoder(input_buffers);
     return;
@@ -271,8 +274,8 @@ void VideoRendererImpl::SetPlaybackRate(double playback_rate) {
   SB_DCHECK(BelongsToCurrentThread());
   SB_DCHECK_GE(playback_rate, 0);
 
-  if (experimental_features_.GetBool(kMediaEnableVideoRendererVspAdjustment) &&
-      playback_rate != 0.0 && playback_rate != 1.0) {
+  if (enable_video_renderer_vsp_adjustment_ && playback_rate != 0.0 &&
+      playback_rate != 1.0) {
     // Start vsp adjustment of video input presentation timepstamps in video
     // renderer after we see a none 0.0x or 1.0x playback rate.
     is_vsp_adjustment_enabled_ = true;
@@ -381,13 +384,9 @@ void VideoRendererImpl::OnDecoderStatus(
     }
 
     bool preroll_completed = false;
-    auto min_input_buffers =
-        experimental_features_.Get(kMediaVideoRendererMinInputBuffers);
-    auto min_decoded_frames =
-        experimental_features_.Get(kMediaVideoRendererMinDecodedFrames);
-    if (min_input_buffers && min_decoded_frames) {
-      preroll_completed = input_buffers_sent_.load() >= *min_input_buffers &&
-                          number_of_frames_.load() >= *min_decoded_frames;
+    if (min_input_buffers_ && min_decoded_frames_) {
+      preroll_completed = input_buffers_sent_.load() >= *min_input_buffers_ &&
+                          number_of_frames_.load() >= *min_decoded_frames_;
     } else {
       preroll_completed =
           number_of_frames_.load() >=
@@ -395,7 +394,7 @@ void VideoRendererImpl::OnDecoderStatus(
     }
 
     bool should_call_preroll_cb;
-    if (experimental_features_.GetBool(kMediaEnableTrivialOptimizations)) {
+    if (enable_trivial_optimizations_) {
       // Avoid unconditional cache thrashing.
       should_call_preroll_cb =
           preroll_completed && seeking_.load() && seeking_.exchange(false);
@@ -441,7 +440,7 @@ void VideoRendererImpl::Render(VideoRendererSink::DrawFrameCB draw_frame_cb) {
   {
     std::lock_guard scoped_lock_decoder_frames(decoder_frames_mutex_);
     sink_frames_mutex_.lock();
-    if (experimental_features_.GetBool(kMediaEnableTrivialOptimizations)) {
+    if (enable_trivial_optimizations_) {
       auto it = decoder_frames_.begin();
       while (it != decoder_frames_.end()) {
         auto next = std::next(it);

--- a/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
+++ b/starboard/shared/starboard/player/filter/video_renderer_internal_impl.h
@@ -90,7 +90,10 @@ class VideoRendererImpl : public VideoRenderer, private JobQueue::JobOwner {
   const std::unique_ptr<VideoRenderAlgorithm> algorithm_;
   scoped_refptr<VideoRendererSink> sink_;
   std::unique_ptr<VideoDecoder> decoder_;
-  const ExperimentalFeatures experimental_features_;
+  const std::optional<int> min_input_buffers_;
+  const std::optional<int> min_decoded_frames_;
+  const bool enable_video_renderer_vsp_adjustment_;
+  const bool enable_trivial_optimizations_;
 
   PrerolledCB prerolled_cb_;
   EndedCB ended_cb_;


### PR DESCRIPTION
This PR is to address post-merge code review comments made on https://github.com/youtube/cobalt/pull/11114.

Cache experimental feature values in audio and video renderers to
minimize overhead on performance-critical hot paths. This ensures
more efficient lookups during media rendering.

Enforce the use of string literals for experimental feature keys to
ensure they are defined as compile-time constants. This improves
robustness and prevents the use of dynamic strings for feature keys.

Issue: 480134029