### PR TITLE
drm:  Connect DRM app provioning to h5vcc settings

### DIFF
--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -20,6 +20,7 @@
 #include <utility>
 
 #include "starboard/android/shared/drm_session_id_mapper.h"
+#include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/media_drm_bridge.h"
 #include "starboard/common/instance_counter.h"
@@ -75,7 +76,7 @@ DrmSystem::DrmSystem(PassKey<DrmSystem>,
     : Thread("DrmSystemThread"),
       key_system_(key_system),
       enable_app_provisioning_(
-          features::FeatureList::IsEnabled(features::kEnableAppProvisioning)),
+          MediaCapabilitiesCache::GetInstance()->IsAppProvisioningEnabled()),
       context_(context),
       callbacks_(callbacks),
       hdcp_lost_(false),

--- a/starboard/android/shared/media_capabilities_cache.h
+++ b/starboard/android/shared/media_capabilities_cache.h
@@ -226,6 +226,10 @@ class MediaCapabilitiesCache {
   bool IsEnabled() const { return is_enabled_; }
   void SetCacheEnabled(bool enabled) { is_enabled_ = enabled; }
   void SetAv1OptEnabled(bool enabled) { is_av1_opt_enabled_ = enabled; }
+  void SetAppProvisioningEnabled(bool enabled) {
+    is_app_provisioning_enabled_ = enabled;
+  }
+  bool IsAppProvisioningEnabled() const { return is_app_provisioning_enabled_; }
   void ClearCache() { capabilities_is_dirty_ = true; }
 
  protected:
@@ -273,6 +277,7 @@ class MediaCapabilitiesCache {
 
   std::atomic_bool is_enabled_{true};
   std::atomic_bool is_av1_opt_enabled_{false};
+  std::atomic_bool is_app_provisioning_enabled_{false};
   std::atomic_bool capabilities_is_dirty_{true};
 };
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -298,6 +298,10 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     MediaCodecVideoDecoder::SetVideoFramePoolEnabled(
         experimental_features.GetBool(kMediaVideoFrameImplPool));
 
+    if (experimental_features.GetBool(kMediaEnableAppProvisioning)) {
+      MediaCapabilitiesCache::GetInstance()->SetAppProvisioningEnabled(true);
+      SB_LOG(INFO) << "`enable_app_provisioning` is set to true.";
+    }
     if (experimental_features.GetBool(kMediaEnableAv1StartupOptimization)) {
       MediaCapabilitiesCache::GetInstance()->SetAv1OptEnabled(true);
       SB_LOG(INFO) << "`enable_av1_startup_optimization` is set to true.";

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -107,10 +107,6 @@ STARBOARD_FEATURE(kAreaBasedVideoBufferBudget,
                   "AreaBasedVideoBufferBudget",
                   false)
 
-// By default, app provisioning is disabled. Set the following variable to true
-// to enable app provisioning.
-STARBOARD_FEATURE(kEnableAppProvisioning, "EnableAppProvisioning", false)
-
 // Set the following variable to true to enable av1 startup optimization.
 STARBOARD_FEATURE(kEnableAv1StartupOptimization,
                   "EnableAv1StartupOptimization",

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -156,6 +156,9 @@ inline constexpr ExperimentalFeatureKey<bool> kMediaAllowAudioWritingOnPause(
 inline constexpr ExperimentalFeatureKey<bool> kMediaDecodedAudioBufferPool(
     "Media.DecodedAudioBufferPool");
 
+inline constexpr ExperimentalFeatureKey<bool> kMediaEnableAppProvisioning(
+    "Media.EnableAppProvisioning");
+
 inline constexpr ExperimentalFeatureKey<bool>
     kMediaEnableAv1StartupOptimization("Media.EnableAv1StartupOptimization");
 


### PR DESCRIPTION
Introduce the `Media.EnableAppProvisioning` h5vcc experimental feature flag to
control DRM app provisioning on Android. This allows the feature to be enabled via
h5vcc settings so that we can do launch experiment for b/79941850

Issue: 79941850
Issue: 532552802