### PR TITLE
media: Refactor bypass bridge for StarboardRenderer

### DIFF
--- a/media/mojo/clients/mojo_renderer.cc
+++ b/media/mojo/clients/mojo_renderer.cc
@@ -4,11 +4,6 @@
 
 #include "media/mojo/clients/mojo_renderer.h"
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-#include <atomic>
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-#include <utility>
-
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/location.h"
@@ -24,36 +19,16 @@
 #include "media/mojo/common/media_type_converters.h"
 #include "media/renderers/video_overlay_factory.h"
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-#include "base/command_line.h"
-#include "base/feature_list.h"
-#include "media/base/media_switches.h"
-#endif
-
 namespace media {
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-namespace {
-std::atomic<uint32_t> g_next_bypass_id{1};
-}  // namespace
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 MojoRenderer::MojoRenderer(
     const scoped_refptr<base::SequencedTaskRunner>& task_runner,
     std::unique_ptr<VideoOverlayFactory> video_overlay_factory,
     VideoRendererSink* video_renderer_sink,
-    mojo::PendingRemote<mojom::Renderer> remote_renderer
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-    ,
-    bool bypass_mojo_for_media
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-)
+    mojo::PendingRemote<mojom::Renderer> remote_renderer)
     : task_runner_(task_runner),
       video_overlay_factory_(std::move(video_overlay_factory)),
       video_renderer_sink_(video_renderer_sink),
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-      bypass_mojo_for_media_(bypass_mojo_for_media),
-#endif
       remote_renderer_pending_remote_(std::move(remote_renderer)),
       media_time_interpolator_(base::DefaultTickClock::GetInstance()) {
   DVLOG(1) << __func__;
@@ -62,13 +37,6 @@ MojoRenderer::MojoRenderer(
 MojoRenderer::~MojoRenderer() {
   DVLOG(1) << __func__;
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (bypass_bridge_) {
-    bypass_bridge_->Invalidate();
-    BypassBridgeRegistry::Unregister(bypass_id_);
-  }
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   CancelPendingCallbacks();
 }
@@ -89,36 +57,6 @@ void MojoRenderer::Initialize(MediaResource* media_resource,
 
   media_resource_ = media_resource;
   init_cb_ = std::move(init_cb);
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if ((base::FeatureList::IsEnabled(kCobaltBypassMojoForMedia)
-       || bypass_mojo_for_media_) &&
-      base::CommandLine::ForCurrentProcess()->HasSwitch("single-process")) {
-
-    // Create the bypass bridge to manage shared state and callbacks.
-    bypass_bridge_ = base::MakeRefCounted<MojoRendererBypassBridge>(
-        task_runner_,
-        base::BindRepeating(&MojoRenderer::OnTimeUpdate,
-          weak_factory_.GetWeakPtr()),
-        base::BindRepeating(&MojoRenderer::OnStatisticsUpdate,
-          weak_factory_.GetWeakPtr()));
-    // Set the actual streams in the bridge.
-    DemuxerStream* audio_stream = media_resource_->GetFirstStream(
-      DemuxerStream::AUDIO);
-    DemuxerStream* video_stream = media_resource_->GetFirstStream(
-      DemuxerStream::VIDEO);
-    bypass_bridge_->SetStreams(audio_stream, video_stream);
-    // Generate a unique ID and register the bridge.
-    bypass_id_ = g_next_bypass_id.fetch_add(1);
-    BypassBridgeRegistry::Register(bypass_id_, bypass_bridge_);
-    BindRemoteRendererIfNeeded();
-    remote_renderer_->InitializeWithBypassBridge(
-        client_receiver_.BindNewEndpointAndPassRemote(),
-        bypass_id_, base::BindOnce(&MojoRenderer::OnInitialized,
-                                   base::Unretained(this), client));
-    return;
-  }
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Create mojom::DemuxerStream for each demuxer stream and bind its lifetime
   // to the pipe.

--- a/media/mojo/clients/mojo_renderer.h
+++ b/media/mojo/clients/mojo_renderer.h
@@ -23,10 +23,6 @@
 #include "mojo/public/cpp/bindings/pending_remote.h"
 #include "mojo/public/cpp/bindings/remote.h"
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
 namespace media {
 
 class MediaResource;
@@ -49,12 +45,7 @@ class MojoRenderer : public Renderer, public mojom::RendererClient {
   MojoRenderer(const scoped_refptr<base::SequencedTaskRunner>& task_runner,
                std::unique_ptr<VideoOverlayFactory> video_overlay_factory,
                VideoRendererSink* video_renderer_sink,
-               mojo::PendingRemote<mojom::Renderer> remote_renderer
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-               ,
-               bool bypass_mojo_for_media = false
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-               );
+               mojo::PendingRemote<mojom::Renderer> remote_renderer);
 
   MojoRenderer(const MojoRenderer&) = delete;
   MojoRenderer& operator=(const MojoRenderer&) = delete;
@@ -74,13 +65,11 @@ class MojoRenderer : public Renderer, public mojom::RendererClient {
   base::TimeDelta GetMediaTime() override;
   RendererType GetRendererType() override;
 
+ private:
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  scoped_refptr<base::SequencedTaskRunner> task_runner() const {
-    return task_runner_;
-  }
+  friend class StarboardRendererClient;
 #endif
 
- private:
   // mojom::RendererClient implementation, dispatched on the |task_runner_|.
   void OnTimeUpdate(base::TimeDelta time,
                     base::TimeDelta max_time,
@@ -137,12 +126,6 @@ class MojoRenderer : public Renderer, public mojom::RendererClient {
   // Client of |this| renderer passed in Initialize.
   raw_ptr<media::RendererClient> client_ = nullptr;
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  bool bypass_mojo_for_media_ = false;
-  scoped_refptr<MojoRendererBypassBridge> bypass_bridge_;
-  uint32_t bypass_id_ = 0;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
   // Mojo demuxer streams.
   // Owned by MojoRenderer instead of remote mojom::Renderer
   // because these demuxer streams need to be destroyed as soon as |this| is
@@ -176,10 +159,6 @@ class MojoRenderer : public Renderer, public mojom::RendererClient {
   media::TimeDeltaInterpolator media_time_interpolator_;
 
   std::optional<PipelineStatistics> pending_stats_;
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  base::WeakPtrFactory<MojoRenderer> weak_factory_{this};
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 }  // namespace media

--- a/media/mojo/clients/mojo_renderer_factory.cc
+++ b/media/mojo/clients/mojo_renderer_factory.cc
@@ -130,8 +130,7 @@ std::unique_ptr<MojoRenderer> MojoRendererFactory::CreateStarboardRenderer(
 
   return std::make_unique<MojoRenderer>(
       media_task_runner, nullptr, video_renderer_sink,
-      std::move(renderer_remote),
-      config.experimental_features.GetBool(kMediaBypassMojoForMedia));
+      std::move(renderer_remote));
 }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/media/mojo/clients/mojo_renderer_wrapper.h
+++ b/media/mojo/clients/mojo_renderer_wrapper.h
@@ -38,6 +38,11 @@ class MojoRendererWrapper : public Renderer {
   void SetVolume(float volume) override;
   base::TimeDelta GetMediaTime() override;
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+ protected:
+  MojoRenderer* mojo_renderer() { return mojo_renderer_.get(); }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
  private:
   std::unique_ptr<MojoRenderer> mojo_renderer_;
 };

--- a/media/mojo/clients/starboard/starboard_renderer_client.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client.cc
@@ -14,15 +14,20 @@
 
 #include "media/mojo/clients/starboard/starboard_renderer_client.h"
 
+#include <atomic>
+
+#include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/time/time.h"
 #include "base/unguessable_token.h"
 #include "media/base/media_log.h"
 #include "media/base/media_resource.h"
+#include "media/base/media_switches.h"
 #include "media/base/video_frame.h"
 #include "media/mojo/clients/mojo_renderer.h"
 #include "media/renderers/video_overlay_factory.h"
 #include "media/video/gpu_video_accelerator_factories.h"
+#include "mojo/public/cpp/bindings/callback_helpers.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
 
 #if BUILDFLAG(IS_ANDROID)
@@ -30,6 +35,10 @@
 #endif  // BUILDFLAG(IS_ANDROID)
 
 namespace media {
+
+namespace {
+std::atomic<uint32_t> g_next_bypass_id{1};
+}  // namespace
 
 StarboardRendererClient::StarboardRendererClient(
     const scoped_refptr<base::SequencedTaskRunner>& media_task_runner,
@@ -45,7 +54,8 @@ StarboardRendererClient::StarboardRendererClient(
     ,
     RequestOverlayInfoCB request_overlay_info_cb
 #endif  // BUILDFLAG(IS_ANDROID)
-    )
+    ,
+    bool bypass_mojo_for_media)
     : MojoRendererWrapper(std::move(mojo_renderer)),
       media_task_runner_(media_task_runner),
       media_log_(std::move(media_log)),
@@ -60,7 +70,8 @@ StarboardRendererClient::StarboardRendererClient(
       ,
       request_overlay_info_cb_(std::move(request_overlay_info_cb))
 #endif  // BUILDFLAG(IS_ANDROID)
-{
+      ,
+      bypass_mojo_for_media_(bypass_mojo_for_media) {
   DCHECK(media_task_runner_);
   DCHECK(video_renderer_sink_);
   DCHECK(video_overlay_factory_);
@@ -70,6 +81,11 @@ StarboardRendererClient::StarboardRendererClient(
 StarboardRendererClient::~StarboardRendererClient() {
   SetPlayingState(false);
   DCHECK(!video_renderer_sink_started_);
+
+  if (bypass_bridge_) {
+    bypass_bridge_->Invalidate();
+    BypassBridgeRegistry::Unregister(bypass_id_);
+  }
 
 #if BUILDFLAG(IS_ANDROID)
   if (request_overlay_info_cb_ && overlay_info_requested_) {
@@ -334,6 +350,72 @@ void StarboardRendererClient::InitializeMojoRenderer(
     PipelineStatusCallback init_cb) {
   DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
   DCHECK(AreMojoPipesConnected());
+
+  if (base::FeatureList::IsEnabled(kCobaltBypassMojoForMedia) ||
+      bypass_mojo_for_media_) {
+    bypass_bridge_ = base::MakeRefCounted<MojoRendererBypassBridge>(
+        media_task_runner_,
+        base::BindRepeating(&StarboardRendererClient::OnTimeUpdateFromBridge,
+                            weak_factory_.GetWeakPtr()),
+        base::BindRepeating(
+            &StarboardRendererClient::OnStatisticsUpdateFromBridge,
+            weak_factory_.GetWeakPtr()));
+    DemuxerStream* audio_stream =
+        media_resource->GetFirstStream(DemuxerStream::AUDIO);
+    DemuxerStream* video_stream =
+        media_resource->GetFirstStream(DemuxerStream::VIDEO);
+    bypass_bridge_->SetStreams(audio_stream, video_stream);
+    bypass_id_ = g_next_bypass_id.fetch_add(1);
+    BypassBridgeRegistry::Register(bypass_id_, bypass_bridge_);
+    renderer_extension_->InitializeWithBypassBridge(
+        bypass_id_,
+        mojo::WrapCallbackWithDefaultInvokeIfNotRun(
+            base::BindOnce(
+                &StarboardRendererClient::OnExtensionBypassInitialized,
+                weak_factory_.GetWeakPtr(), media_resource, client,
+                std::move(init_cb)),
+            false));
+    return;
+  }
+
+  MojoRendererWrapper::Initialize(media_resource, client, std::move(init_cb));
+}
+
+void StarboardRendererClient::OnTimeUpdateFromBridge(
+    base::TimeDelta time,
+    base::TimeDelta max_time,
+    base::TimeTicks capture_time) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  if (mojo_renderer()) {
+    mojo_renderer()->OnTimeUpdate(time, max_time, capture_time);
+  }
+}
+
+void StarboardRendererClient::OnStatisticsUpdateFromBridge(
+    const PipelineStatistics& stats) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  if (mojo_renderer()) {
+    mojo_renderer()->OnStatisticsUpdate(stats);
+  }
+}
+
+void StarboardRendererClient::OnExtensionBypassInitialized(
+    MediaResource* media_resource,
+    RendererClient* client,
+    PipelineStatusCallback init_cb,
+    bool success) {
+  DCHECK(media_task_runner_->RunsTasksInCurrentSequence());
+  if (!success) {
+    if (bypass_bridge_) {
+      bypass_bridge_->Invalidate();
+      BypassBridgeRegistry::Unregister(bypass_id_);
+      bypass_bridge_ = nullptr;
+    }
+    if (init_cb) {
+      std::move(init_cb).Run(PIPELINE_ERROR_INITIALIZATION_FAILED);
+    }
+    return;
+  }
   MojoRendererWrapper::Initialize(media_resource, client, std::move(init_cb));
 }
 

--- a/media/mojo/clients/starboard/starboard_renderer_client.h
+++ b/media/mojo/clients/starboard/starboard_renderer_client.h
@@ -26,6 +26,7 @@
 #include "media/base/starboard/starboard_rendering_mode.h"
 #include "media/base/video_renderer_sink.h"
 #include "media/mojo/clients/mojo_renderer_wrapper.h"
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
 #include "media/mojo/mojom/renderer_extensions.mojom.h"
 #include "media/starboard/starboard_callbacks.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
@@ -68,7 +69,8 @@ class MEDIA_EXPORT StarboardRendererClient
       ,
       RequestOverlayInfoCB request_overlay_info_cb
 #endif  // BUILDFLAG(IS_ANDROID)
-  );
+      ,
+      bool bypass_mojo_for_media = false);
 
   StarboardRendererClient(const StarboardRendererClient&) = delete;
   StarboardRendererClient& operator=(const StarboardRendererClient&) = delete;
@@ -121,6 +123,14 @@ class MEDIA_EXPORT StarboardRendererClient
   void InitializeMojoRenderer(MediaResource* media_resource,
                               RendererClient* client,
                               PipelineStatusCallback init_cb);
+  void OnTimeUpdateFromBridge(base::TimeDelta time,
+                              base::TimeDelta max_time,
+                              base::TimeTicks capture_time);
+  void OnStatisticsUpdateFromBridge(const PipelineStatistics& stats);
+  void OnExtensionBypassInitialized(MediaResource* media_resource,
+                                    RendererClient* client,
+                                    PipelineStatusCallback init_cb,
+                                    bool success);
   void InitAndConstructMojoRenderer(mojom::CommandBufferIdPtr command_buffer_id,
                                     base::OnceClosure complete_cb);
   bool AreMojoPipesConnected() const {
@@ -152,6 +162,9 @@ class MEDIA_EXPORT StarboardRendererClient
 #if BUILDFLAG(IS_ANDROID)
   RequestOverlayInfoCB request_overlay_info_cb_;
 #endif  // BUILDFLAG(IS_ANDROID)
+  bool bypass_mojo_for_media_ = false;
+  scoped_refptr<MojoRendererBypassBridge> bypass_bridge_;
+  uint32_t bypass_id_ = 0;
 
   mojo::Remote<RendererExtension> renderer_extension_;
 

--- a/media/mojo/clients/starboard/starboard_renderer_client_factory.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_factory.cc
@@ -125,7 +125,8 @@ std::unique_ptr<Renderer> StarboardRendererClientFactory::CreateRenderer(
       ,
       std::move(request_overlay_info_cb)
 #endif  // BUILDFLAG(IS_ANDROID)
-  );
+          ,
+      config.experimental_features.GetBool(kMediaBypassMojoForMedia));
 }
 
 }  // namespace media

--- a/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
@@ -53,24 +53,13 @@ struct FakeMojomRendererCallRecord {
 
 class FakeMojomRenderer : public mojom::Renderer {
  public:
-  explicit FakeMojomRenderer(FakeMojomRendererCallRecord* record)
-      : record_(record) {}
+  FakeMojomRenderer() = default;
   ~FakeMojomRenderer() override = default;
 
   void Initialize(
       mojo::PendingAssociatedRemote<mojom::RendererClient>,
       std::optional<std::vector<mojo::PendingRemote<mojom::DemuxerStream>>>,
       InitializeCallback cb) override {
-    std::move(cb).Run(true);
-  }
-  void InitializeWithBypassBridge(
-      mojo::PendingAssociatedRemote<mojom::RendererClient>,
-      uint32_t bypass_bridge_id,
-      InitializeWithBypassBridgeCallback cb) override {
-    if (record_) {
-      record_->initialize_with_bypass_bridge_called = true;
-      record_->last_bypass_bridge_id = bypass_bridge_id;
-    }
     std::move(cb).Run(true);
   }
   MOCK_METHOD1(Flush, void(FlushCallback));
@@ -81,24 +70,35 @@ class FakeMojomRenderer : public mojom::Renderer {
                void(const absl::optional<base::UnguessableToken>&,
                     SetCdmCallback));
   void SetLatencyHint(std::optional<::base::TimeDelta> latency_hint) override {}
-
- private:
-  FakeMojomRendererCallRecord* record_;
 };
 
 class FakeStarboardRendererExtension
     : public mojom::StarboardRendererExtension {
  public:
-  FakeStarboardRendererExtension() = default;
+  explicit FakeStarboardRendererExtension(
+      FakeMojomRendererCallRecord* record = nullptr)
+      : record_(record) {}
   ~FakeStarboardRendererExtension() override = default;
 
   MOCK_METHOD1(GetCurrentVideoFrame, void(GetCurrentVideoFrameCallback cb));
   void OnSbWindowHandleReady(uint64_t sb_window_handle) override {}
+  void InitializeWithBypassBridge(
+      uint32_t bypass_bridge_id,
+      InitializeWithBypassBridgeCallback cb) override {
+    if (record_) {
+      record_->initialize_with_bypass_bridge_called = true;
+      record_->last_bypass_bridge_id = bypass_bridge_id;
+    }
+    std::move(cb).Run(true);
+  }
 #if BUILDFLAG(IS_ANDROID)
   MOCK_METHOD1(OnOverlayInfoChanged, void(const OverlayInfo& overlay_info));
 #endif  // BUILDFLAG(IS_ANDROID)
   void OnGpuChannelTokenReady(
       mojom::CommandBufferIdPtr command_buffer_id) override {}
+
+ private:
+  FakeMojomRendererCallRecord* record_ = nullptr;
 };
 
 class MockVideoRendererSink : public VideoRendererSink {
@@ -153,13 +153,14 @@ class StarboardRendererClientTest : public ::testing::Test {
                                          bool bypass_mojo_for_media = false) {
     mojo::PendingRemote<mojom::Renderer> renderer_remote;
     mojo::MakeSelfOwnedReceiver(
-        std::make_unique<FakeMojomRenderer>(&fake_mojom_renderer_record_),
+        std::make_unique<FakeMojomRenderer>(),
         renderer_remote.InitWithNewPipeAndPassReceiver());
 
     mojo::PendingRemote<mojom::StarboardRendererExtension>
         starboard_renderer_extensions_remote;
     mojo::MakeSelfOwnedReceiver(
-        std::make_unique<FakeStarboardRendererExtension>(),
+        std::make_unique<FakeStarboardRendererExtension>(
+            &fake_mojom_renderer_record_),
         starboard_renderer_extensions_remote.InitWithNewPipeAndPassReceiver());
 
     mojo::PendingRemote<media::mojom::StarboardRendererClientExtension>
@@ -169,8 +170,7 @@ class StarboardRendererClientTest : public ::testing::Test {
     auto mojo_renderer = std::make_unique<MojoRenderer>(
         task_environment_.GetMainThreadTaskRunner(),
         /*video_overlay_factory=*/nullptr,
-        /*video_renderer_sink=*/nullptr, std::move(renderer_remote),
-        bypass_mojo_for_media);
+        /*video_renderer_sink=*/nullptr, std::move(renderer_remote));
     auto overlay_factory = std::make_unique<VideoOverlayFactory>();
     starboard_renderer_client_ = std::make_unique<StarboardRendererClient>(
         task_environment_.GetMainThreadTaskRunner(), media_log_.Clone(),
@@ -185,7 +185,8 @@ class StarboardRendererClientTest : public ::testing::Test {
         ,
         /*request_overlay_info_cb=*/base::DoNothing()
 #endif  // BUILDFLAG(IS_ANDROID)
-    );
+            ,
+        bypass_mojo_for_media);
   }
 
   base::test::SingleThreadTaskEnvironment task_environment_;
@@ -308,6 +309,62 @@ TEST_F(StarboardRendererClientTest, InitializeWithBypassBridge) {
 
   starboard_renderer_client_.reset();
   EXPECT_EQ(BypassBridgeRegistry::Get(bridge_id), nullptr);
+}
+
+TEST_F(StarboardRendererClientTest, InitializeWithBypassBridge_Failure) {
+  base::test::ScopedCommandLine scoped_command_line;
+  scoped_command_line.GetProcessCommandLine()->AppendSwitch("single-process");
+
+  // Create a fake extension that calls cb(false) when
+  // InitializeWithBypassBridge is invoked.
+  class FailingStarboardRendererExtension
+      : public FakeStarboardRendererExtension {
+   public:
+    void InitializeWithBypassBridge(
+        uint32_t bypass_bridge_id,
+        InitializeWithBypassBridgeCallback cb) override {
+      std::move(cb).Run(false);
+    }
+  };
+
+  mojo::PendingRemote<mojom::Renderer> renderer_remote;
+  mojo::MakeSelfOwnedReceiver(std::make_unique<FakeMojomRenderer>(),
+                              renderer_remote.InitWithNewPipeAndPassReceiver());
+
+  mojo::PendingRemote<mojom::StarboardRendererExtension>
+      starboard_renderer_extensions_remote;
+  mojo::MakeSelfOwnedReceiver(
+      std::make_unique<FailingStarboardRendererExtension>(),
+      starboard_renderer_extensions_remote.InitWithNewPipeAndPassReceiver());
+
+  mojo::PendingRemote<media::mojom::StarboardRendererClientExtension>
+      client_extension_remote;
+  auto client_extension_receiver =
+      client_extension_remote.InitWithNewPipeAndPassReceiver();
+  auto mojo_renderer = std::make_unique<MojoRenderer>(
+      task_environment_.GetMainThreadTaskRunner(),
+      /*video_overlay_factory=*/nullptr,
+      /*video_renderer_sink=*/nullptr, std::move(renderer_remote));
+  auto overlay_factory = std::make_unique<VideoOverlayFactory>();
+  auto client = std::make_unique<StarboardRendererClient>(
+      task_environment_.GetMainThreadTaskRunner(), media_log_.Clone(),
+      std::move(mojo_renderer), std::move(overlay_factory),
+      &mock_video_renderer_sink_,
+      std::move(starboard_renderer_extensions_remote),
+      std::move(client_extension_receiver),
+      base::BindRepeating([]() -> uint64_t { return 0; }),
+      mock_gpu_factories_.get(),
+#if BUILDFLAG(IS_ANDROID)
+      /*request_overlay_info_cb=*/base::DoNothing(),
+#endif  // BUILDFLAG(IS_ANDROID)
+      /*bypass_mojo_for_media=*/true);
+
+  EXPECT_CALL(renderer_init_cb_,
+              Run(HasStatusCode(PIPELINE_ERROR_INITIALIZATION_FAILED)));
+  client->Initialize(media_resource_.get(), &renderer_client_,
+                     renderer_init_cb_.Get());
+  client->UpdateStarboardRenderingMode(StarboardRenderingMode::kPunchOut);
+  task_environment_.RunUntilIdle();
 }
 
 }  // namespace

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
@@ -47,6 +47,7 @@ void MojoRendererBypassBridge::Invalidate() {
 
 void MojoRendererBypassBridge::SetStreams(DemuxerStream* audio,
                                           DemuxerStream* video) {
+  DCHECK(client_task_runner_->RunsTasksInCurrentSequence());
   base::AutoLock auto_lock(lock_);
   audio_stream_ = audio;
   video_stream_ = video;
@@ -155,10 +156,14 @@ std::string MojoRendererBypassBridge::GetMimeType(
 
 void MojoRendererBypassBridge::EnableBitstreamConverter(
     DemuxerStream::Type type) {
-  base::AutoLock auto_lock(lock_);
-  if (!active_) {
+  if (!client_task_runner_->RunsTasksInCurrentSequence()) {
+    client_task_runner_->PostTask(
+        FROM_HERE,
+        base::BindOnce(&MojoRendererBypassBridge::EnableBitstreamConverter,
+                       this, type));
     return;
   }
+  base::AutoLock auto_lock(lock_);
   DemuxerStream* stream = GetStreamLocked(type);
   if (!stream) {
     return;
@@ -170,12 +175,16 @@ void MojoRendererBypassBridge::RunTimeUpdateOnClientThread(
     base::TimeDelta time,
     base::TimeDelta max_time,
     base::TimeTicks capture_time) {
-  time_update_cb_.Run(time, max_time, capture_time);
+  if (time_update_cb_) {
+    time_update_cb_.Run(time, max_time, capture_time);
+  }
 }
 
 void MojoRendererBypassBridge::RunStatisticsUpdateOnClientThread(
     const PipelineStatistics& stats) {
-  statistics_update_cb_.Run(stats);
+  if (statistics_update_cb_) {
+    statistics_update_cb_.Run(stats);
+  }
 }
 
 void MojoRendererBypassBridge::OnReadDone(

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
@@ -16,6 +16,7 @@
 #define MEDIA_MOJO_COMMON_STARBOARD_MOJO_RENDERER_BYPASS_BRIDGE_H_
 
 #include <map>
+#include <string>
 
 #include "base/functional/callback.h"
 #include "base/functional/callback_helpers.h"
@@ -24,6 +25,7 @@
 #include "base/synchronization/condition_variable.h"
 #include "base/synchronization/lock.h"
 #include "base/task/sequenced_task_runner.h"
+#include "base/time/time.h"
 #include "media/base/demuxer_stream.h"
 #include "media/base/pipeline_status.h"
 
@@ -52,7 +54,7 @@ namespace media {
 //   destroyed while a Read() is in progress.
 // - Callbacks to the client (PostTimeUpdate(), PostStatisticsUpdate()) are
 //   marshalled to the client's task runner (typically the Media thread) and
-//   executed safely using a WeakPtr to the MojoRenderer.
+//   executed safely using a WeakPtr to the StarboardRendererClient.
 class MojoRendererBypassBridge
     : public base::RefCountedThreadSafe<MojoRendererBypassBridge> {
  public:
@@ -71,12 +73,10 @@ class MojoRendererBypassBridge
 
   void Invalidate();
   void SetStreams(DemuxerStream* audio, DemuxerStream* video);
-
   void PostTimeUpdate(base::TimeDelta time,
                       base::TimeDelta max_time,
                       base::TimeTicks capture_time);
   void PostStatisticsUpdate(const PipelineStatistics& stats);
-
   bool Read(DemuxerStream::Type type,
             uint32_t count,
             DemuxerStream::ReadCB read_cb);

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge_unittest.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge_unittest.cc
@@ -195,5 +195,20 @@ TEST_F(MojoRendererBypassBridgeTest, UnknownStreamType) {
   bridge_->Invalidate();
 }
 
+TEST_F(MojoRendererBypassBridgeTest, PostTimeUpdateAndStatistics) {
+  const base::TimeDelta kTime = base::Seconds(10);
+  const base::TimeDelta kMaxTime = base::Seconds(10);
+  const base::TimeTicks kCaptureTime = base::TimeTicks::Now();
+  EXPECT_CALL(time_update_cb_, Run(kTime, kMaxTime, kCaptureTime));
+  bridge_->PostTimeUpdate(kTime, kMaxTime, kCaptureTime);
+
+  PipelineStatistics stats;
+  stats.audio_bytes_decoded = 1024;
+  EXPECT_CALL(statistics_update_cb_, Run(_));
+  bridge_->PostStatisticsUpdate(stats);
+
+  task_environment_.RunUntilIdle();
+}
+
 }  // namespace
 }  // namespace media

--- a/media/mojo/mojom/renderer.mojom
+++ b/media/mojo/mojom/renderer.mojom
@@ -25,11 +25,6 @@ interface Renderer {
   Initialize(pending_associated_remote<RendererClient> client,
              array<pending_remote<DemuxerStream>>? streams) => (bool success);
 
-  // Supported only in single-process mode with the feature enabled.
-  [EnableIf=use_starboard_media]
-  InitializeWithBypassBridge(pending_associated_remote<RendererClient> client,
-                             uint32 bypass_bridge_id) => (bool success);
-
   // Discards any buffered data, executing callback when completed.
   // NOTE: If an error occurs, RendererClient::OnError() can be called
   // before the callback is executed.

--- a/media/mojo/mojom/renderer_extensions.mojom
+++ b/media/mojo/mojom/renderer_extensions.mojom
@@ -148,6 +148,9 @@ interface StarboardRendererExtension {
   // Pass SbWindow to StarboardRenderer.
   OnSbWindowHandleReady(uint64 sb_window_handle);
 
+  // Initialize media bypass bridge in single-process mode.
+  InitializeWithBypassBridge(uint32 bypass_bridge_id) => (bool success);
+
   [EnableIf=is_android]
   // Notify StarboardRendererWrapper when the current OverlayInfo changes.
   OnOverlayInfoChanged(OverlayInfo overlay_info);

--- a/media/mojo/services/mojo_renderer_service.cc
+++ b/media/mojo/services/mojo_renderer_service.cc
@@ -18,80 +18,13 @@
 #include "media/mojo/services/mojo_cdm_service_context.h"
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/mojo/services/starboard/starboard_renderer_wrapper.h"
+#endif
 
 namespace media {
 
 // Time interval to update media time.
 constexpr auto kTimeUpdateInterval = base::Milliseconds(125);
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-// A proxy DemuxerStream that forwards Read calls to the
-// MojoRendererBypassBridge.
-// This ensures that if the client is destroyed, the read will be safely aborted
-// without accessing the destroyed actual DemuxerStream.
-class ProxyDemuxerStream : public DemuxerStream {
- public:
-  ProxyDemuxerStream(scoped_refptr<MojoRendererBypassBridge> bridge,
-                     DemuxerStream::Type type)
-      : bridge_(bridge), type_(type) {}
-
-  void Read(uint32_t count, ReadCB read_cb) override {
-    bridge_->Read(type_, count, std::move(read_cb));
-  }
-
-  AudioDecoderConfig audio_decoder_config() override {
-    return bridge_->GetAudioConfig();
-  }
-
-  VideoDecoderConfig video_decoder_config() override {
-    return bridge_->GetVideoConfig();
-  }
-
-  Type type() const override { return type_; }
-  
-  StreamLiveness liveness() const override {
-    return bridge_->GetLiveness(type_);
-  }
-
-  bool SupportsConfigChanges() override {
-    return bridge_->SupportsConfigChanges(type_);
-  }
-
-  std::string mime_type() const override {
-    return bridge_->GetMimeType(type_);
-  }
-
-  void EnableBitstreamConverter() override {
-    bridge_->EnableBitstreamConverter(type_);
-  }
-
- private:
-  scoped_refptr<MojoRendererBypassBridge> bridge_;
-  Type type_;
-};
-
-// A MediaResource implementation that holds ProxyDemuxerStreams.
-class ProxyMediaResource : public MediaResource {
- public:
-  ProxyMediaResource(
-    std::unique_ptr<ProxyDemuxerStream> audio,
-    std::unique_ptr<ProxyDemuxerStream> video)
-    : audio_(std::move(audio)), video_(std::move(video)) {}
-
-  std::vector<DemuxerStream*> GetAllStreams() override {
-    std::vector<DemuxerStream*> streams;
-    if (audio_) streams.push_back(audio_.get());
-    if (video_) streams.push_back(video_.get());
-    return streams;
-  }
-
- private:
-  std::unique_ptr<ProxyDemuxerStream> audio_;
-  std::unique_ptr<ProxyDemuxerStream> video_;
-};
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 // static
 mojo::SelfOwnedReceiverRef<mojom::Renderer> MojoRendererService::Create(
@@ -140,50 +73,6 @@ void MojoRendererService::Initialize(
       base::BindOnce(&MojoRendererService::OnAllStreamsReady, weak_this_,
                      std::move(callback)));
 }
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-void MojoRendererService::InitializeWithBypassBridge(
-    mojo::PendingAssociatedRemote<mojom::RendererClient> client,
-    uint32_t bypass_bridge_id,
-    InitializeWithBypassBridgeCallback callback) {
-  DVLOG(1) << __func__;
-  DCHECK_EQ(state_, STATE_UNINITIALIZED);
-
-  client_.Bind(std::move(client));
-  state_ = STATE_INITIALIZING;
-
-  // Retrieve the bypass bridge from the registry.
-  bypass_bridge_ = BypassBridgeRegistry::Get(bypass_bridge_id);
-  if (!bypass_bridge_) {
-    LOG(WARNING) << __func__
-                 << ": Bypass bridge not found for ID " << bypass_bridge_id;
-    std::move(callback).Run(false);
-    return;
-  }
-
-  std::unique_ptr<ProxyDemuxerStream> audio_proxy;
-  std::unique_ptr<ProxyDemuxerStream> video_proxy;
-
-  AudioDecoderConfig audio_config = bypass_bridge_->GetAudioConfig();
-  if (audio_config.IsValidConfig()) {
-    audio_proxy = std::make_unique<ProxyDemuxerStream>(
-        bypass_bridge_, DemuxerStream::AUDIO);
-  }
-  VideoDecoderConfig video_config = bypass_bridge_->GetVideoConfig();
-  if (video_config.IsValidConfig()) {
-    video_proxy = std::make_unique<ProxyDemuxerStream>(
-        bypass_bridge_, DemuxerStream::VIDEO);
-  }
-
-  media_resource_ = std::make_unique<ProxyMediaResource>(
-      std::move(audio_proxy), std::move(video_proxy));
-
-  renderer_->Initialize(
-      media_resource_.get(), this,
-      base::BindOnce(&MojoRendererService::OnRendererInitializeDone, weak_this_,
-                     std::move(callback)));
-}
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 void MojoRendererService::Flush(FlushCallback callback) {
   DVLOG(2) << __func__;
@@ -285,12 +174,6 @@ void MojoRendererService::OnEnded() {
 
 void MojoRendererService::OnStatisticsUpdate(const PipelineStatistics& stats) {
   DVLOG(3) << __func__;
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (bypass_bridge_) {
-    bypass_bridge_->PostStatisticsUpdate(stats);
-    return;
-  }
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   client_->OnStatisticsUpdate(stats);
 }
 
@@ -360,6 +243,19 @@ void MojoRendererService::OnRendererInitializeDone(
 }
 
 void MojoRendererService::UpdateMediaTime(bool force) {
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // When Starboard media bypass is active, media time updates are posted
+  // directly in-process via MojoRendererBypassBridge to StarboardRendererClient.
+  // Bypass all Mojo IPC OnTimeUpdate calls here (which are otherwise triggered
+  // by StartPlayingFrom, SetPlaybackRate, CancelPeriodicMediaTimeUpdates, or
+  // periodic timer ticks) to avoid sending redundant or resetting IPCs over Mojo.
+  if (renderer_ &&
+      renderer_->GetRendererType() == RendererType::kStarboard &&
+      static_cast<StarboardRendererWrapper*>(renderer_.get())->IsBypassing()) {
+    return;
+  }
+#endif
+
   const base::TimeDelta media_time = renderer_->GetMediaTime();
   if (!force && media_time == last_media_time_)
     return;
@@ -369,16 +265,7 @@ void MojoRendererService::UpdateMediaTime(bool force) {
   if (time_update_timer_.IsRunning() && (playback_rate_ > 0))
     max_time += 2 * kTimeUpdateInterval;
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  if (bypass_bridge_) {
-    bypass_bridge_->PostTimeUpdate(media_time, max_time,
-                                   base::TimeTicks::Now());
-  } else {
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   client_->OnTimeUpdate(media_time, max_time, base::TimeTicks::Now());
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  }
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   last_media_time_ = media_time;
 }
 

--- a/media/mojo/services/mojo_renderer_service.h
+++ b/media/mojo/services/mojo_renderer_service.h
@@ -32,9 +32,6 @@
 namespace media {
 
 class CdmContextRef;
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-class MojoRendererBypassBridge;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 class MediaResourceShim;
 class MojoCdmServiceContext;
 class Renderer;
@@ -67,12 +64,6 @@ class MEDIA_MOJO_EXPORT MojoRendererService final : public mojom::Renderer,
       std::optional<std::vector<mojo::PendingRemote<mojom::DemuxerStream>>>
           streams,
       InitializeCallback callback) final;
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  void InitializeWithBypassBridge(
-      mojo::PendingAssociatedRemote<mojom::RendererClient> client,
-      uint32_t bypass_bridge_id,
-      InitializeWithBypassBridgeCallback callback) final;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   void Flush(FlushCallback callback) final;
   void StartPlayingFrom(base::TimeDelta time_delta) final;
   void SetPlaybackRate(double playback_rate) final;
@@ -135,10 +126,6 @@ class MEDIA_MOJO_EXPORT MojoRendererService final : public mojom::Renderer,
 
   base::RepeatingTimer time_update_timer_;
   base::TimeDelta last_media_time_;
-
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  scoped_refptr<MojoRendererBypassBridge> bypass_bridge_;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   mojo::AssociatedRemote<mojom::RendererClient> client_;
 

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -20,12 +20,153 @@
 #include "base/functional/callback_helpers.h"
 #include "base/task/bind_post_task.h"
 #include "base/time/time.h"
+#include "media/base/demuxer_stream.h"
+#include "media/base/media_resource.h"
 #include "media/base/starboard/starboard_rendering_mode.h"
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
 #include "media/mojo/services/mojo_media_log.h"
 #include "ui/gfx/geometry/rect_conversions.h"
 #include "ui/gl/gl_bindings.h"
 
 namespace media {
+
+namespace {
+// Time interval to update media time when bypass is active. This matches
+// `kTimeUpdateInterval` in media/mojo/services/mojo_renderer_service.cc.
+constexpr auto kTimeUpdateInterval = base::Milliseconds(125);
+}  // namespace
+
+// A proxy DemuxerStream that forwards Read calls to the
+// MojoRendererBypassBridge.
+//
+// Lifetime and Ownership: Owned by ProxyMediaResource and exists for the
+// duration of the active media bypass session.
+//
+// Threading Model: This class is thread-affine and must be used on the Mojo
+// service thread where StarboardRenderer and StarboardRendererWrapper run.
+class ProxyDemuxerStream : public DemuxerStream {
+ public:
+  ProxyDemuxerStream(scoped_refptr<MojoRendererBypassBridge> bridge,
+                     DemuxerStream::Type type)
+      : bridge_(bridge), type_(type) {}
+
+  void Read(uint32_t count, ReadCB read_cb) override {
+    bridge_->Read(type_, count, std::move(read_cb));
+  }
+
+  AudioDecoderConfig audio_decoder_config() override {
+    return bridge_->GetAudioConfig();
+  }
+
+  VideoDecoderConfig video_decoder_config() override {
+    return bridge_->GetVideoConfig();
+  }
+
+  Type type() const override { return type_; }
+
+  StreamLiveness liveness() const override {
+    return bridge_->GetLiveness(type_);
+  }
+
+  bool SupportsConfigChanges() override {
+    return bridge_->SupportsConfigChanges(type_);
+  }
+
+  std::string mime_type() const override { return bridge_->GetMimeType(type_); }
+
+  void EnableBitstreamConverter() override {
+    bridge_->EnableBitstreamConverter(type_);
+  }
+
+ private:
+  scoped_refptr<MojoRendererBypassBridge> bridge_;
+  Type type_;
+};
+
+// A MediaResource implementation that holds ProxyDemuxerStreams.
+//
+// Lifetime and Ownership: Owned by StarboardRendererWrapper and exists for the
+// duration of the active media bypass session.
+//
+// Threading Model: This class is thread-affine and must be used on the Mojo
+// service thread where StarboardRenderer and StarboardRendererWrapper run.
+class ProxyMediaResource : public MediaResource {
+ public:
+  ProxyMediaResource(std::unique_ptr<ProxyDemuxerStream> audio,
+                     std::unique_ptr<ProxyDemuxerStream> video)
+      : audio_(std::move(audio)), video_(std::move(video)) {}
+
+  std::vector<DemuxerStream*> GetAllStreams() override {
+    std::vector<DemuxerStream*> streams;
+    if (audio_) {
+      streams.push_back(audio_.get());
+    }
+    if (video_) {
+      streams.push_back(video_.get());
+    }
+    return streams;
+  }
+
+ private:
+  std::unique_ptr<ProxyDemuxerStream> audio_;
+  std::unique_ptr<ProxyDemuxerStream> video_;
+};
+
+// A RendererClient implementation that intercepts statistics updates to post
+// them directly to the bypass bridge.
+//
+// Lifetime and Ownership: Owned by StarboardRendererWrapper and exists for the
+// duration of the active media bypass session.
+//
+// Threading Model: This class is thread-affine and must be used on the Mojo
+// service thread (the same thread where StarboardRendererWrapper is created and
+// used).
+class ProxyRendererClient final : public RendererClient {
+ public:
+  ProxyRendererClient(RendererClient* client,
+                      scoped_refptr<MojoRendererBypassBridge> bridge)
+      : client_(client), bridge_(bridge) {
+    DCHECK(client);
+  }
+  ~ProxyRendererClient() = default;
+
+  void OnError(PipelineStatus status) override { client_->OnError(status); }
+  void OnFallback(PipelineStatus fallback) override {
+    client_->OnFallback(fallback);
+  }
+  void OnEnded() override { client_->OnEnded(); }
+  void OnStatisticsUpdate(const PipelineStatistics& stats) override {
+    if (bridge_) {
+      bridge_->PostStatisticsUpdate(stats);
+    } else {
+      client_->OnStatisticsUpdate(stats);
+    }
+  }
+  void OnBufferingStateChange(BufferingState state,
+                              BufferingStateChangeReason reason) override {
+    client_->OnBufferingStateChange(state, reason);
+  }
+  void OnWaiting(WaitingReason reason) override { client_->OnWaiting(reason); }
+  void OnAudioConfigChange(const AudioDecoderConfig& config) override {
+    client_->OnAudioConfigChange(config);
+  }
+  void OnVideoConfigChange(const VideoDecoderConfig& config) override {
+    client_->OnVideoConfigChange(config);
+  }
+  void OnVideoNaturalSizeChange(const gfx::Size& size) override {
+    client_->OnVideoNaturalSizeChange(size);
+  }
+  void OnVideoOpacityChange(bool opaque) override {
+    client_->OnVideoOpacityChange(opaque);
+  }
+  void OnVideoFrameRateChange(std::optional<int> fps) override {
+    client_->OnVideoFrameRateChange(fps);
+  }
+
+ private:
+  raw_ptr<RendererClient> client_;
+  scoped_refptr<MojoRendererBypassBridge> bridge_;
+};
 
 StarboardRendererWrapper::StarboardRendererWrapper(
     StarboardRendererTraits traits
@@ -130,17 +271,25 @@ void StarboardRendererWrapper::Initialize(MediaResource* media_resource,
 
 void StarboardRendererWrapper::Flush(base::OnceClosure flush_cb) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  StopMediaTimePolling();
   GetRenderer()->Flush(std::move(flush_cb));
 }
 
 void StarboardRendererWrapper::StartPlayingFrom(base::TimeDelta time) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   GetRenderer()->StartPlayingFrom(time);
+  StartMediaTimePollingIfNeeded();
 }
 
 void StarboardRendererWrapper::SetPlaybackRate(double playback_rate) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  playback_rate_ = playback_rate;
   GetRenderer()->SetPlaybackRate(playback_rate);
+  if (playback_rate_ > 0) {
+    StartMediaTimePollingIfNeeded();
+  } else {
+    StopMediaTimePolling();
+  }
 }
 
 void StarboardRendererWrapper::SetVolume(float volume) {
@@ -327,6 +476,45 @@ void StarboardRendererWrapper::OnSbWindowHandleReady(
   GetRenderer()->OnSbWindowHandleReady(sb_window_handle);
 }
 
+void StarboardRendererWrapper::InitializeWithBypassBridge(
+    uint32_t bypass_bridge_id,
+    InitializeWithBypassBridgeCallback callback) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  bypass_bridge_ = BypassBridgeRegistry::Get(bypass_bridge_id);
+  if (!bypass_bridge_) {
+    LOG(WARNING) << __func__ << ": Bypass bridge not found for ID "
+                 << bypass_bridge_id;
+    std::move(callback).Run(false);
+    return;
+  }
+
+  std::unique_ptr<ProxyDemuxerStream> audio_proxy;
+  std::unique_ptr<ProxyDemuxerStream> video_proxy;
+
+  AudioDecoderConfig audio_config = bypass_bridge_->GetAudioConfig();
+  if (audio_config.IsValidConfig()) {
+    audio_proxy = std::make_unique<ProxyDemuxerStream>(bypass_bridge_,
+                                                       DemuxerStream::AUDIO);
+  }
+  VideoDecoderConfig video_config = bypass_bridge_->GetVideoConfig();
+  if (video_config.IsValidConfig()) {
+    video_proxy = std::make_unique<ProxyDemuxerStream>(bypass_bridge_,
+                                                       DemuxerStream::VIDEO);
+  }
+
+  if (!audio_proxy && !video_proxy) {
+    LOG(ERROR) << __func__
+               << ": No valid audio or video config found in bypass bridge.";
+    bypass_bridge_ = nullptr;
+    std::move(callback).Run(false);
+    return;
+  }
+
+  proxy_media_resource_ = std::make_unique<ProxyMediaResource>(
+      std::move(audio_proxy), std::move(video_proxy));
+  std::move(callback).Run(true);
+}
+
 #if BUILDFLAG(IS_ANDROID)
 void StarboardRendererWrapper::OnOverlayInfoChanged(
     const OverlayInfo& overlay_info) {
@@ -375,7 +563,43 @@ void StarboardRendererWrapper::ContinueInitialization(
           &StarboardRendererWrapper::GetSbDecodeTargetGraphicsContextProvider,
           base::Unretained(this)));
 
-  GetRenderer()->Initialize(media_resource, client, std::move(init_cb));
+  if (bypass_bridge_) {
+    proxy_renderer_client_ =
+        std::make_unique<ProxyRendererClient>(client, bypass_bridge_);
+    client = proxy_renderer_client_.get();
+  }
+
+  GetRenderer()->Initialize(
+      proxy_media_resource_ ? proxy_media_resource_.get() : media_resource,
+      client, std::move(init_cb));
+}
+
+void StarboardRendererWrapper::PollMediaTime() {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!bypass_bridge_) {
+    return;
+  }
+  base::TimeDelta media_time = GetRenderer()->GetMediaTime();
+  base::TimeDelta max_time = media_time + 2 * kTimeUpdateInterval;
+  bypass_bridge_->PostTimeUpdate(media_time, max_time, base::TimeTicks::Now());
+}
+
+void StarboardRendererWrapper::StartMediaTimePollingIfNeeded() {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (!bypass_bridge_) {
+    return;
+  }
+  if (playback_rate_ > 0 && !time_update_timer_.IsRunning()) {
+    time_update_timer_.Start(FROM_HERE, kTimeUpdateInterval, this,
+                             &StarboardRendererWrapper::PollMediaTime);
+  }
+}
+
+void StarboardRendererWrapper::StopMediaTimePolling() {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+  if (time_update_timer_.IsRunning()) {
+    time_update_timer_.Stop();
+  }
 }
 
 void StarboardRendererWrapper::OnPaintVideoHoleFrameByStarboard(
@@ -414,6 +638,37 @@ StarboardRendererWrapper::GetSbDecodeTargetGraphicsContextProvider() {
   return &decode_target_graphics_context_provider_;
 }
 
+void StarboardRendererWrapper::GetCurrentDecodeTarget() {
+  decode_target_ = GetRenderer()->GetSbDecodeTarget();
+}
+
+void StarboardRendererWrapper::CreateVideoFrame_OnImageReady(
+    VideoPixelFormat format,
+    const gfx::Size& coded_size,
+    const gfx::Rect& visible_rect,
+    const gfx::Size& natural_size,
+    scoped_refptr<gpu::ClientSharedImage> shared_image) {
+  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+
+  auto release_cb = base::BindOnce(
+      [](scoped_refptr<gpu::ClientSharedImage> shared_image,
+         const gpu::SyncToken& sync_token) {
+        if (sync_token.HasData()) {
+          shared_image->BackingWasExternallyUpdated(sync_token);
+        }
+      },
+      shared_image);
+
+  auto frame = VideoFrame::WrapSharedImage(
+      format, std::move(shared_image), gpu::SyncToken(), std::move(release_cb),
+      coded_size, visible_rect, natural_size, base::TimeDelta());
+  if (!frame) {
+    LOG(ERROR) << __func__ << " failed to create video frame";
+    return;
+  }
+  current_frame_ = std::move(frame);
+}
+
 // static
 // Disable CFI checks for this method because it executes function pointers
 // provided by the Starboard library, which cannot be verified across the
@@ -445,37 +700,6 @@ void StarboardRendererWrapper::GraphicsContextRunner(
     base::ScopedAllowBaseSyncPrimitives allow_wait;
     done_event.Wait();
   }
-}
-
-void StarboardRendererWrapper::GetCurrentDecodeTarget() {
-  decode_target_ = GetRenderer()->GetSbDecodeTarget();
-}
-
-void StarboardRendererWrapper::CreateVideoFrame_OnImageReady(
-    VideoPixelFormat format,
-    const gfx::Size& coded_size,
-    const gfx::Rect& visible_rect,
-    const gfx::Size& natural_size,
-    scoped_refptr<gpu::ClientSharedImage> shared_image) {
-  DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
-
-  auto release_cb = base::BindOnce(
-      [](scoped_refptr<gpu::ClientSharedImage> shared_image,
-         const gpu::SyncToken& sync_token) {
-        if (sync_token.HasData()) {
-          shared_image->BackingWasExternallyUpdated(sync_token);
-        }
-      },
-      shared_image);
-
-  auto frame = VideoFrame::WrapSharedImage(
-      format, std::move(shared_image), gpu::SyncToken(), std::move(release_cb),
-      coded_size, visible_rect, natural_size, base::TimeDelta());
-  if (!frame) {
-    LOG(ERROR) << __func__ << " failed to create video frame";
-    return;
-  }
-  current_frame_ = std::move(frame);
 }
 
 }  // namespace media

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -22,11 +22,13 @@
 #include "base/memory/weak_ptr.h"
 #include "base/threading/sequence_bound.h"
 #include "base/threading/thread_checker.h"
+#include "base/timer/timer.h"
 #include "cobalt/media/service/mojom/video_geometry_setter.mojom.h"
 #include "cobalt/media/service/video_geometry_setter_service.h"
 #include "gpu/ipc/service/command_buffer_stub.h"
 #include "media/base/renderer.h"
 #include "media/gpu/starboard/starboard_gpu_factory_impl.h"
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
 #include "media/mojo/mojom/renderer_extensions.mojom.h"
 #include "media/mojo/services/gpu_mojo_media_client.h"
 #include "media/starboard/starboard_renderer.h"
@@ -48,6 +50,7 @@ class TimeDelta;
 namespace media {
 
 class StarboardGpuFactory;
+class ProxyRendererClient;
 
 // Simple wrapper around a StarboardRenderer.
 // Wraps media::StarboardRenderer to remove its dependence on
@@ -84,12 +87,12 @@ class StarboardRendererWrapper
   void Initialize(MediaResource* media_resource,
                   RendererClient* client,
                   PipelineStatusCallback init_cb) override;
-  void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
-  void SetLatencyHint(absl::optional<base::TimeDelta> latency_hint) override;
   void Flush(base::OnceClosure flush_cb) override;
   void StartPlayingFrom(base::TimeDelta time) override;
   void SetPlaybackRate(double playback_rate) override;
   void SetVolume(float volume) override;
+  void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
+  void SetLatencyHint(absl::optional<base::TimeDelta> latency_hint) override;
   base::TimeDelta GetMediaTime() override;
   RendererType GetRendererType() override;
 
@@ -98,9 +101,14 @@ class StarboardRendererWrapper
       mojom::CommandBufferIdPtr command_buffer_id) override;
   void GetCurrentVideoFrame(GetCurrentVideoFrameCallback callback) override;
   void OnSbWindowHandleReady(uint64_t sb_window_handle) override;
+  void InitializeWithBypassBridge(
+      uint32_t bypass_bridge_id,
+      InitializeWithBypassBridgeCallback callback) override;
 #if BUILDFLAG(IS_ANDROID)
   void OnOverlayInfoChanged(const OverlayInfo& overlay_info) override;
 #endif  // BUILDFLAG(IS_ANDROID)
+
+  bool IsBypassing() const { return !!bypass_bridge_; }
 
   StarboardRenderer* GetRenderer();
   base::SequenceBound<StarboardGpuFactory>* GetGpuFactory();
@@ -119,6 +127,10 @@ class StarboardRendererWrapper
   }
 
  private:
+  void ContinueInitialization(MediaResource* media_resource,
+                              RendererClient* client,
+                              PipelineStatusCallback init_cb);
+  bool IsGpuChannelTokenAvailable() const { return !!command_buffer_id_; }
   void OnPaintVideoHoleFrameByStarboard(const gfx::Size& size);
   void OnUpdateStarboardRenderingModeByStarboard(
       const StarboardRenderingMode mode);
@@ -128,11 +140,6 @@ class StarboardRendererWrapper
 #if BUILDFLAG(IS_ANDROID)
   void OnRequestOverlayInfoByStarboard(bool restart_for_transitions);
 #endif  // BUILDFLAG(IS_ANDROID)
-
-  void ContinueInitialization(MediaResource* media_resource,
-                              RendererClient* client,
-                              PipelineStatusCallback init_cb);
-  bool IsGpuChannelTokenAvailable() const { return !!command_buffer_id_; }
   SbDecodeTargetGraphicsContextProvider*
   GetSbDecodeTargetGraphicsContextProvider();
   void GetCurrentDecodeTarget();
@@ -147,6 +154,9 @@ class StarboardRendererWrapper
       SbDecodeTargetGraphicsContextProvider* graphics_context_provider,
       SbDecodeTargetGlesContextRunnerTarget target_function,
       void* target_function_context);
+  void PollMediaTime();
+  void StartMediaTimePollingIfNeeded();
+  void StopMediaTimePolling();
 
   mojo::Receiver<RendererExtension> renderer_extension_receiver_;
   mojo::Remote<ClientExtension> client_extension_remote_;
@@ -168,6 +178,10 @@ class StarboardRendererWrapper
   std::vector<uint32_t> last_texture_service_ids_;
   SbDecodeTarget decode_target_ = kSbDecodeTargetInvalid;
 
+  scoped_refptr<MojoRendererBypassBridge> bypass_bridge_;
+  std::unique_ptr<MediaResource> proxy_media_resource_;
+  std::unique_ptr<ProxyRendererClient> proxy_renderer_client_;
+
   raw_ptr<StarboardRenderer> test_renderer_;
   raw_ptr<base::SequenceBound<StarboardGpuFactory>> test_gpu_factory_;
 
@@ -176,6 +190,8 @@ class StarboardRendererWrapper
   mojo::Receiver<cobalt::media::mojom::VideoGeometryChangeClient>
       video_geometry_change_client_receiver_{this};
 
+  double playback_rate_ = 0.0;
+  base::RepeatingTimer time_update_timer_;
   THREAD_CHECKER(thread_checker_);
 
   // NOTE: Do not add member variables after weak_factory_

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -30,6 +30,7 @@
 #include "media/base/mock_filters.h"
 #include "media/base/test_helpers.h"
 #include "media/gpu/starboard/starboard_gpu_factory_impl.h"
+#include "media/mojo/common/starboard/mojo_renderer_bypass_bridge.h"
 #include "media/mojo/mojom/renderer_extensions.mojom.h"
 #include "starboard/decode_target.h"
 #include "testing/gmock/include/gmock/gmock.h"
@@ -293,6 +294,50 @@ TEST_F(StarboardRendererWrapperTest, InitializeWithGpuChannelToken) {
   task_environment_.RunUntilIdle();
 }
 
+TEST_F(StarboardRendererWrapperTest, InitializeWithBypassBridge) {
+  auto bypass_bridge = base::MakeRefCounted<MojoRendererBypassBridge>(
+      task_environment_.GetMainThreadTaskRunner(), base::DoNothing(),
+      base::DoNothing());
+  AddStream(DemuxerStream::AUDIO, false);
+  AddStream(DemuxerStream::VIDEO, false);
+  streams_[0]->set_mime_type("audio/mp4");
+  streams_[1]->set_mime_type("video/mp4");
+  bypass_bridge->SetStreams(streams_[0].get(), streams_[1].get());
+  uint32_t bridge_id = 12345;
+  BypassBridgeRegistry::Register(bridge_id, bypass_bridge);
+  base::ScopedClosureRunner unregister_runner(
+      base::BindOnce(&BypassBridgeRegistry::Unregister, bridge_id));
+
+  base::MockOnceCallback<void(bool)> bypass_init_cb;
+  EXPECT_CALL(bypass_init_cb, Run(true));
+  renderer_wrapper_->InitializeWithBypassBridge(bridge_id,
+                                                bypass_init_cb.Get());
+
+  EXPECT_CALL(*mock_renderer_, OnInitialize(_, _, _))
+      .WillOnce(RunOnceCallback<2>(PIPELINE_OK));
+  EXPECT_CALL(renderer_init_cb_, Run(HasStatusCode(PIPELINE_OK)));
+  renderer_wrapper_->Initialize(&media_resource_, &renderer_client_,
+                                renderer_init_cb_.Get());
+
+  task_environment_.RunUntilIdle();
+}
+
+TEST_F(StarboardRendererWrapperTest,
+       InitializeWithBypassBridge_NoValidStreams) {
+  auto bypass_bridge = base::MakeRefCounted<MojoRendererBypassBridge>(
+      task_environment_.GetMainThreadTaskRunner(), base::DoNothing(),
+      base::DoNothing());
+  uint32_t bridge_id = 12345;
+  BypassBridgeRegistry::Register(bridge_id, bypass_bridge);
+  base::ScopedClosureRunner unregister_runner(
+      base::BindOnce(&BypassBridgeRegistry::Unregister, bridge_id));
+
+  base::MockOnceCallback<void(bool)> bypass_init_cb;
+  EXPECT_CALL(bypass_init_cb, Run(false));
+  renderer_wrapper_->InitializeWithBypassBridge(bridge_id,
+                                                bypass_init_cb.Get());
+}
+
 TEST_F(StarboardRendererWrapperTest, Flush) {
   base::MockOnceClosure closure;
   EXPECT_CALL(*mock_renderer_, OnFlush(_)).WillOnce(RunOnceCallback<0>());
@@ -343,6 +388,104 @@ TEST_F(StarboardRendererWrapperTest, GetCurrentVideoFrame) {
       callback;
   EXPECT_CALL(callback, Run(testing::IsNull()));
   renderer_wrapper_->GetCurrentVideoFrame(callback.Get());
+  task_environment_.RunUntilIdle();
+}
+
+TEST_F(StarboardRendererWrapperTest, ProxyDemuxerStreamDelegation) {
+  auto bypass_bridge = base::MakeRefCounted<MojoRendererBypassBridge>(
+      task_environment_.GetMainThreadTaskRunner(), base::DoNothing(),
+      base::DoNothing());
+  AddStream(DemuxerStream::AUDIO, false);
+  AddStream(DemuxerStream::VIDEO, false);
+  streams_[0]->set_mime_type("audio/mp4");
+  streams_[1]->set_mime_type("video/mp4");
+  bypass_bridge->SetStreams(streams_[0].get(), streams_[1].get());
+
+  uint32_t bridge_id = 12345;
+  BypassBridgeRegistry::Register(bridge_id, bypass_bridge);
+  base::ScopedClosureRunner unregister_runner(
+      base::BindOnce(&BypassBridgeRegistry::Unregister, bridge_id));
+
+  base::MockOnceCallback<void(bool)> bypass_init_cb;
+  EXPECT_CALL(bypass_init_cb, Run(true));
+  renderer_wrapper_->InitializeWithBypassBridge(bridge_id,
+                                                bypass_init_cb.Get());
+
+  MediaResource* captured_media_resource = nullptr;
+  EXPECT_CALL(*mock_renderer_, OnInitialize(_, _, _))
+      .WillOnce(
+          Invoke([&captured_media_resource](MediaResource* media_resource,
+                                            RendererClient* client,
+                                            PipelineStatusCallback& init_cb) {
+            captured_media_resource = media_resource;
+            std::move(init_cb).Run(PIPELINE_OK);
+          }));
+  EXPECT_CALL(renderer_init_cb_, Run(HasStatusCode(PIPELINE_OK)));
+  renderer_wrapper_->Initialize(&media_resource_, &renderer_client_,
+                                renderer_init_cb_.Get());
+  task_environment_.RunUntilIdle();
+
+  ASSERT_NE(captured_media_resource, nullptr);
+
+  // Verify delegation of mime_type() and EnableBitstreamConverter() through
+  // proxy streams.
+  EXPECT_CALL(*streams_[0], EnableBitstreamConverter());
+  EXPECT_CALL(*streams_[1], EnableBitstreamConverter());
+
+  auto proxy_streams = captured_media_resource->GetAllStreams();
+  ASSERT_EQ(proxy_streams.size(), 2u);
+  EXPECT_EQ(proxy_streams[0]->mime_type(), "audio/mp4");
+  EXPECT_EQ(proxy_streams[1]->mime_type(), "video/mp4");
+  proxy_streams[0]->EnableBitstreamConverter();
+  proxy_streams[1]->EnableBitstreamConverter();
+}
+
+TEST_F(StarboardRendererWrapperTest, TimerLifecycle) {
+  auto bypass_bridge = base::MakeRefCounted<MojoRendererBypassBridge>(
+      task_environment_.GetMainThreadTaskRunner(), base::DoNothing(),
+      base::DoNothing());
+  AddStream(DemuxerStream::AUDIO, false);
+  AddStream(DemuxerStream::VIDEO, false);
+  streams_[0]->set_mime_type("audio/mp4");
+  streams_[1]->set_mime_type("video/mp4");
+  bypass_bridge->SetStreams(streams_[0].get(), streams_[1].get());
+
+  uint32_t bridge_id = 12345;
+  BypassBridgeRegistry::Register(bridge_id, bypass_bridge);
+  base::ScopedClosureRunner unregister_runner(
+      base::BindOnce(&BypassBridgeRegistry::Unregister, bridge_id));
+
+  base::MockOnceCallback<void(bool)> bypass_init_cb;
+  EXPECT_CALL(bypass_init_cb, Run(true));
+  renderer_wrapper_->InitializeWithBypassBridge(bridge_id,
+                                                bypass_init_cb.Get());
+
+  EXPECT_CALL(*mock_renderer_, OnInitialize(_, _, _))
+      .WillOnce(RunOnceCallback<2>(PIPELINE_OK));
+  EXPECT_CALL(renderer_init_cb_, Run(HasStatusCode(PIPELINE_OK)));
+  renderer_wrapper_->Initialize(&media_resource_, &renderer_client_,
+                                renderer_init_cb_.Get());
+  task_environment_.RunUntilIdle();
+
+  // Start playing (sets playback_rate > 0 when SetPlaybackRate(1.0) is called).
+  EXPECT_CALL(*mock_renderer_, GetMediaTime())
+      .WillRepeatedly(Return(base::Seconds(0)));
+  EXPECT_CALL(*mock_renderer_, SetPlaybackRate(1.0));
+  renderer_wrapper_->SetPlaybackRate(1.0);
+  EXPECT_CALL(*mock_renderer_, StartPlayingFrom(base::Seconds(0)));
+  renderer_wrapper_->StartPlayingFrom(base::Seconds(0));
+
+  // Pause playback (playback_rate == 0).
+  EXPECT_CALL(*mock_renderer_, SetPlaybackRate(0.0));
+  renderer_wrapper_->SetPlaybackRate(0.0);
+
+  // Resume and Flush.
+  EXPECT_CALL(*mock_renderer_, SetPlaybackRate(1.0));
+  renderer_wrapper_->SetPlaybackRate(1.0);
+  base::MockOnceClosure flush_cb;
+  EXPECT_CALL(*mock_renderer_, OnFlush(_)).WillOnce(RunOnceCallback<0>());
+  EXPECT_CALL(flush_cb, Run());
+  renderer_wrapper_->Flush(flush_cb.Get());
   task_environment_.RunUntilIdle();
 }
 


### PR DESCRIPTION
Move the media bypass bridge logic out of the core MojoRenderer and
MojoRendererService classes. This logic is now encapsulated within
StarboardRendererClient and StarboardRendererWrapper.

By moving InitializeWithBypassBridge to the StarboardRendererExtension
mojom interface, this refactor keeps Starboard-specific optimizations
separated from the generic Chromium Mojo media implementation. This
improves code maintainability while preserving support for
single-process media bypass.

This PR also aligns the order of functions in StarboardRendererClient
and StarboardRendererWrapper.

Issue: 513254071