### PR TITLE
Add e2e proof of concept for CMC Storage MVP on 3P

### DIFF
--- a/base/threading/hang_watcher.cc
+++ b/base/threading/hang_watcher.cc
@@ -32,6 +32,7 @@
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_STARBOARD)
+#include "base/uuid.h"
 #include "starboard/extension/crash_handler.h"
 #include "starboard/system.h"
 #endif
@@ -825,8 +826,35 @@ HangWatcher* HangWatcher::GetInstance() {
 void HangWatcher::RecordHang() {
 #if BUILDFLAG(IS_COBALT)
   LOG(INFO) << "Freeze detection: start reporting";
-#endif
+#endif  // BUILDFLAG(IS_COBALT)
+
+#if BUILDFLAG(IS_STARBOARD)
+  // Key Separation + Scoped Transactional Annotation Model:
+  // To prevent any possible race condition between non-fatal hangs and fatal crashes,
+  // we do NOT touch the process-wide 'cmc_crash_uuid' (which is immutable from boot).
+  // Instead, we populate a distinct 'cmc_hang_uuid' key during non-fatal dump capture.
+  // This approach is completely sound and race-condition free because:
+  // 1) On Linux/POSIX, Crashpad captures annotations as frozen '--annotation=key=value' argv strings at fork() time.
+  // 2) The parent Cobalt process blocks synchronously on waitpid() until crashpad_handler completes writing the dump.
+  // Immediately after DumpWithoutCrashing() returns, we reset 'cmc_hang_uuid' to empty ("") to keep memory clean.
+  auto* crash_ext = static_cast<const CobaltExtensionCrashHandlerApi*>(
+      SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
+  if (crash_ext && crash_ext->version >= 2) {
+    std::string hang_uuid = base::Uuid::GenerateRandomV4().AsLowercaseString();
+    if (g_hang_watcher_delegate) {
+      g_hang_watcher_delegate->OnHangStarted(hang_uuid);
+    }
+    crash_ext->SetString("cmc_hang_uuid", hang_uuid.c_str());
+
+    base::debug::DumpWithoutCrashing();
+
+    crash_ext->SetString("cmc_hang_uuid", "");
+  } else {
+    base::debug::DumpWithoutCrashing();
+  }
+#else  // !BUILDFLAG(IS_STARBOARD)
   base::debug::DumpWithoutCrashing();
+#endif  // BUILDFLAG(IS_STARBOARD)
   NO_CODE_FOLDING();
 }
 

--- a/base/threading/hang_watcher.h
+++ b/base/threading/hang_watcher.h
@@ -9,6 +9,7 @@
 #include <cstdint>
 #include <memory>
 #include <type_traits>
+#include <string>
 #include <vector>
 
 #include "base/auto_reset.h"
@@ -114,6 +115,9 @@ class BASE_EXPORT HangWatcher : public DelegateSimpleThread::Delegate {
     // Returns true if hang reporting should be enabled
     // potentially overriding default settings.
     virtual bool IsHangReportingEnabled() = 0;
+    // Invoked when a hang is first detected on a monitored thread,
+    // prior to triggering a non-fatal hang report.
+    virtual void OnHangStarted(const std::string& hang_uuid) {}
   };
 #endif
 

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -32,6 +32,10 @@ source_set("browser") {
     "cobalt_secure_navigation_throttle.h",
     "cobalt_web_contents_observer.cc",
     "cobalt_web_contents_observer.h",
+    "core_metric_components_manager.cc",
+    "core_metric_components_manager.h",
+    "h5vcc_core_metric_components/h5vcc_core_metric_components_impl.cc",
+    "h5vcc_core_metric_components/h5vcc_core_metric_components_impl.h",
     "h5vcc_settings_impl.cc",
     "h5vcc_settings_impl.h",
   ]
@@ -40,6 +44,13 @@ source_set("browser") {
     sources += [
       "android/mojo/cobalt_interface_registrar_android.cc",
       "android/mojo/cobalt_interface_registrar_android.h",
+    ]
+  }
+
+  if (is_starboard || is_androidtv) {
+    sources += [
+      "hang_watcher_delegate_impl.cc",
+      "hang_watcher_delegate_impl.h",
     ]
   }
 
@@ -61,6 +72,7 @@ source_set("browser") {
     "//cobalt/browser/crash_annotator/public/mojom",
     "//cobalt/browser/h5vcc_accessibility",
     "//cobalt/browser/h5vcc_accessibility/public/mojom",
+    "//cobalt/browser/h5vcc_core_metric_components/public/mojom",
     "//cobalt/browser/h5vcc_experiments",
     "//cobalt/browser/h5vcc_experiments/public/mojom",
     "//cobalt/browser/h5vcc_metrics/public/mojom",
@@ -175,18 +187,6 @@ source_set("global_features") {
   ]
 }
 
-if (is_starboard || is_androidtv) {
-  source_set("hang_watcher_delegate") {
-    sources = [
-      "hang_watcher_delegate_impl.cc",
-      "hang_watcher_delegate_impl.h",
-    ]
-    deps = [
-      ":global_features",
-      "//base",
-    ]
-  }
-}
 
 source_set("metrics") {
   sources = [

--- a/cobalt/browser/cobalt_browser_interface_binders.cc
+++ b/cobalt/browser/cobalt_browser_interface_binders.cc
@@ -19,6 +19,8 @@
 #include "cobalt/browser/crash_annotator/public/mojom/crash_annotator.mojom.h"
 #include "cobalt/browser/h5vcc_accessibility/h5vcc_accessibility_impl.h"
 #include "cobalt/browser/h5vcc_accessibility/public/mojom/h5vcc_accessibility.mojom.h"
+#include "cobalt/browser/h5vcc_core_metric_components/h5vcc_core_metric_components_impl.h"
+#include "cobalt/browser/h5vcc_core_metric_components/public/mojom/h5vcc_core_metric_components.mojom.h"
 #include "cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.h"
 #include "cobalt/browser/h5vcc_experiments/public/mojom/h5vcc_experiments.mojom.h"
 #include "cobalt/browser/h5vcc_metrics/h5vcc_metrics_impl.h"
@@ -104,6 +106,9 @@ void PopulateCobaltFrameBinders(
   binder_map->Add<h5vcc_accessibility::mojom::H5vccAccessibilityBrowser>(
       base::BindRepeating(
           &h5vcc_accessibility::H5vccAccessibilityImpl::Create));
+  binder_map->Add<h5vcc_core_metric_components::mojom::H5vccCoreMetricComponents>(
+      base::BindRepeating(
+          &h5vcc_core_metric_components::H5vccCoreMetricComponentsImpl::Create));
   binder_map->Add<h5vcc_experiments::mojom::H5vccExperiments>(
       base::BindRepeating(&h5vcc_experiments::H5vccExperimentsImpl::Create));
   binder_map->Add<h5vcc_metrics::mojom::H5vccMetrics>(

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -22,6 +22,9 @@
 #include "base/path_service.h"
 #include "base/run_loop.h"
 #include "base/sequence_checker.h"
+#include "base/uuid.h"
+#include "starboard/extension/crash_handler.h"
+#include "starboard/system.h"
 #include "base/task/bind_post_task.h"
 #include "base/trace_event/memory_dump_manager.h"
 #include "build/build_config.h"
@@ -29,6 +32,7 @@
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
+#include "cobalt/browser/core_metric_components_manager.h"
 #include "cobalt/browser/switches.h"
 #include "cobalt/memory/cobalt_memory_attribution_manager.h"
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
@@ -240,6 +244,20 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
   }
 
   StartStorageMigration();
+
+  std::string session_join_uuid = base::Uuid::GenerateRandomV4().AsLowercaseString();
+  auto* crash_ext = static_cast<const CobaltExtensionCrashHandlerApi*>(
+      SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
+  if (crash_ext && crash_ext->version >= 2) {
+    // Key Separation: We set 'cmc_crash_uuid' once on boot. This key is immutable in memory
+    // for the entire process lifetime, ensuring fatal crash dumps can never be corrupted by hang triggers.
+    crash_ext->SetString("cmc_crash_uuid", session_join_uuid.c_str());
+    LOG(INFO) << "CobaltBrowserMainParts: Armed session crash annotations. cmc_crash_uuid = "
+              << session_join_uuid;
+  }
+
+  browser::CoreMetricComponentsManager::GetInstance()
+      ->ReconcileReportsOnStartup();
 
   return result;
 }

--- a/cobalt/browser/core_metric_components_manager.cc
+++ b/cobalt/browser/core_metric_components_manager.cc
@@ -1,0 +1,390 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/core_metric_components_manager.h"
+
+#include <memory>
+#include <optional>
+
+#include "base/files/file_util.h"
+#include "base/files/important_file_writer.h"
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
+#include "base/logging.h"
+#include "base/no_destructor.h"
+#include "base/task/thread_pool.h"
+#include "base/values.h"
+#include "starboard/configuration_constants.h"
+#include "starboard/extension/core_metric_components.h"
+#include "starboard/system.h"
+
+namespace cobalt {
+namespace browser {
+
+// static
+CoreMetricComponentsManager* CoreMetricComponentsManager::GetInstance() {
+  static base::NoDestructor<CoreMetricComponentsManager> instance;
+  return instance.get();
+}
+
+CoreMetricComponentsManager::CoreMetricComponentsManager()
+    : task_runner_(base::ThreadPool::CreateSequencedTaskRunner(
+          {base::MayBlock(), base::TaskPriority::BEST_EFFORT,
+           base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN})) {}
+CoreMetricComponentsManager::~CoreMetricComponentsManager() = default;
+
+base::FilePath CoreMetricComponentsManager::GetAckFilePath() {
+  std::vector<char> cache_dir(static_cast<size_t>(kSbFileMaxPath));
+  if (!SbSystemGetPath(kSbSystemPathCacheDirectory, cache_dir.data(),
+                       kSbFileMaxPath)) {
+    return base::FilePath();
+  }
+  return base::FilePath(cache_dir.data()).Append("cmc_acked_uuids.json");
+}
+
+std::set<std::string> CoreMetricComponentsManager::LoadAckedUuids() {
+  std::set<std::string> acked;
+  base::FilePath path = GetAckFilePath();
+  if (path.empty() || !base::PathExists(path)) {
+    return acked;
+  }
+
+  std::string json;
+  if (!base::ReadFileToString(path, &json)) {
+    return acked;
+  }
+
+  std::optional<base::Value> root = base::JSONReader::Read(json);
+  if (!root || !root->is_list()) {
+    return acked;
+  }
+
+  for (const auto& item : root->GetList()) {
+    if (item.is_string()) {
+      acked.insert(item.GetString());
+    }
+  }
+  return acked;
+}
+
+void CoreMetricComponentsManager::SaveAckedUuids(
+    const std::set<std::string>& uuids) {
+  base::FilePath path = GetAckFilePath();
+  if (path.empty()) {
+    return;
+  }
+
+  base::Value::List list;
+  for (const auto& u : uuids) {
+    list.Append(u);
+  }
+
+  std::optional<std::string> json = base::WriteJson(list);
+  if (json) {
+    base::ImportantFileWriter::WriteFileAtomically(path, *json);
+  }
+}
+
+base::FilePath CoreMetricComponentsManager::GetHangStatusFilePath() {
+  std::vector<char> cache_dir(static_cast<size_t>(kSbFileMaxPath));
+  if (!SbSystemGetPath(kSbSystemPathCacheDirectory, cache_dir.data(),
+                       kSbFileMaxPath)) {
+    return base::FilePath();
+  }
+  return base::FilePath(cache_dir.data()).Append("cmc_hang_status.json");
+}
+
+std::map<std::string, std::string>
+CoreMetricComponentsManager::LoadHangStatuses() {
+  std::map<std::string, std::string> statuses;
+  base::FilePath path = GetHangStatusFilePath();
+  if (path.empty() || !base::PathExists(path)) {
+    return statuses;
+  }
+
+  std::string json;
+  if (!base::ReadFileToString(path, &json)) {
+    return statuses;
+  }
+
+  std::optional<base::Value> root = base::JSONReader::Read(json);
+  if (!root || !root->is_dict()) {
+    return statuses;
+  }
+
+  for (const auto item : root->GetDict()) {
+    if (item.second.is_string()) {
+      statuses[item.first] = item.second.GetString();
+    }
+  }
+  return statuses;
+}
+
+void CoreMetricComponentsManager::SaveHangStatuses(
+    const std::map<std::string, std::string>& statuses) {
+  base::FilePath path = GetHangStatusFilePath();
+  if (path.empty()) {
+    return;
+  }
+
+  base::Value::Dict dict;
+  for (const auto& kv : statuses) {
+    dict.Set(kv.first, kv.second);
+  }
+
+  std::optional<std::string> json = base::WriteJson(dict);
+  if (json) {
+    base::ImportantFileWriter::WriteFileAtomically(path, *json);
+  }
+}
+
+void CoreMetricComponentsManager::RecordHangStarted(
+    const std::string& cmc_join_uuid) {
+  if (cmc_join_uuid.empty()) return;
+  task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(&CoreMetricComponentsManager::RecordHangStartedInternal,
+                     base::Unretained(this), cmc_join_uuid));
+}
+
+void CoreMetricComponentsManager::RecordHangStartedInternal(
+    const std::string& cmc_join_uuid) {
+  auto statuses = LoadHangStatuses();
+  statuses[cmc_join_uuid] = "unrecovered";
+  SaveHangStatuses(statuses);
+  LOG(INFO) << "=== CoreMetricComponentsManager: Recorded Hang Started "
+            << cmc_join_uuid << " (unrecovered) ===";
+}
+
+void CoreMetricComponentsManager::RecordHangRecovered(
+    const std::string& cmc_join_uuid) {
+  if (cmc_join_uuid.empty()) return;
+  task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(&CoreMetricComponentsManager::RecordHangRecoveredInternal,
+                     base::Unretained(this), cmc_join_uuid));
+}
+
+void CoreMetricComponentsManager::RecordHangRecoveredInternal(
+    const std::string& cmc_join_uuid) {
+  auto statuses = LoadHangStatuses();
+  statuses[cmc_join_uuid] = "recovered";
+  SaveHangStatuses(statuses);
+  LOG(INFO) << "=== CoreMetricComponentsManager: Recorded Hang Recovered "
+            << cmc_join_uuid << " (recovered) ===";
+}
+
+
+void CoreMetricComponentsManager::ReconcileReportsOnStartup() {
+  task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          &CoreMetricComponentsManager::ReconcileReportsOnStartupInternal,
+          base::Unretained(this)));
+}
+
+void CoreMetricComponentsManager::ReconcileReportsOnStartupInternal() {
+  PruneStorage();
+  LOG(INFO) << "=== CoreMetricComponentsManager: Startup Reconciliation Complete ===";
+}
+
+void CoreMetricComponentsManager::GetPendingReportsForClient(
+    base::OnceCallback<void(std::vector<StabilityReport>)> callback) {
+  task_runner_->PostTaskAndReplyWithResult(
+      FROM_HERE,
+      base::BindOnce(
+          &CoreMetricComponentsManager::GetPendingReportsForClientInternal,
+          base::Unretained(this)),
+      std::move(callback));
+}
+
+std::vector<StabilityReport>
+CoreMetricComponentsManager::GetPendingReportsForClientInternal() {
+  std::vector<StabilityReport> pending_for_client;
+
+  auto* extension = static_cast<const CobaltExtensionCoreMetricComponentsApi*>(
+      SbSystemGetExtension(kCobaltExtensionCoreMetricComponentsName));
+  if (!extension || extension->version < 1 ||
+      !extension->GetCompletedReports) {
+    return pending_for_client;
+  }
+
+  // 1. Fetch completed reports from Starboard (Crashpad DB).
+  std::vector<char> buffer(65536);
+  if (!extension->GetCompletedReports(buffer.data(), buffer.size())) {
+    LOG(ERROR) << "GetPendingReports: GetCompletedReports returned false";
+    return pending_for_client;
+  }
+
+  LOG(INFO) << "GetPendingReportsForClient: Raw Starboard JSON buffer = "
+            << buffer.data();
+
+  std::optional<base::Value> reports_root =
+      base::JSONReader::Read(buffer.data());
+  if (!reports_root || !reports_root->is_list()) {
+    return pending_for_client;
+  }
+
+  // 2. Load existing ACKed UUIDs and Hang Statuses.
+  std::set<std::string> acked_uuids = LoadAckedUuids();
+  std::map<std::string, std::string> hang_statuses = LoadHangStatuses();
+
+  for (const auto& report : reports_root->GetList()) {
+    if (!report.is_dict()) continue;
+    const auto& dict = report.GetDict();
+    const std::string* join_uuid = dict.FindString("cmc_join_uuid");
+    // TODO: Consider supporting early startup crashes that lack a custom
+    // Cobalt-generated UUID. For now, we ignore them.
+    if (!join_uuid || join_uuid->empty()) {
+      continue;
+    }
+
+    std::string tracking_id = *join_uuid;
+
+    // Filter out already ACKed items.
+    if (acked_uuids.find(tracking_id) != acked_uuids.end()) {
+      LOG(INFO) << "[Skipping] Report " << tracking_id << " (Already ACKed)";
+      continue;
+    }
+
+    std::optional<double> creation_time = dict.FindDouble("creation_time");
+    const std::string* report_type_str = dict.FindString("cmc_report_type");
+
+    StabilityReport stability_report;
+    stability_report.cmc_join_uuid = tracking_id;
+    stability_report.creation_time =
+        creation_time ? static_cast<int64_t>(*creation_time) : 0;
+
+    if (report_type_str && *report_type_str == "hang") {
+      auto hang_it = hang_statuses.find(tracking_id);
+      if (hang_it != hang_statuses.end() && hang_it->second == "recovered") {
+        stability_report.report_type = StabilityReportType::kHangRecovered;
+      } else {
+        stability_report.report_type = StabilityReportType::kHangUnrecovered;
+      }
+    } else {
+      stability_report.report_type = StabilityReportType::kCrash;
+    }
+
+    pending_for_client.push_back(stability_report);
+    LOG(INFO) << "[Delivering to Client] UUID: "
+              << stability_report.cmc_join_uuid
+              << ", Type: " << static_cast<int>(stability_report.report_type);
+  }
+
+  return pending_for_client;
+}
+
+void CoreMetricComponentsManager::PruneStorage() {
+  auto* extension = static_cast<const CobaltExtensionCoreMetricComponentsApi*>(
+      SbSystemGetExtension(kCobaltExtensionCoreMetricComponentsName));
+  if (!extension || extension->version < 1 ||
+      !extension->GetCompletedReports) {
+    return;
+  }
+
+  // 1. Fetch completed reports from Starboard (Crashpad DB).
+  std::vector<char> buffer(65536);
+  if (!extension->GetCompletedReports(buffer.data(), buffer.size())) {
+    LOG(ERROR) << "PruneStorage: GetCompletedReports returned false";
+    return;
+  }
+
+  std::optional<base::Value> reports_root =
+      base::JSONReader::Read(buffer.data());
+  if (!reports_root || !reports_root->is_list()) {
+    return;
+  }
+
+  // 2. Load existing ACKed UUIDs and Hang Statuses.
+  std::set<std::string> acked_uuids = LoadAckedUuids();
+  std::map<std::string, std::string> hang_statuses = LoadHangStatuses();
+  std::set<std::string> active_uuids;
+  bool acked_needs_write = false;
+  bool hangs_needs_write = false;
+
+  LOG(INFO)
+      << "=== CoreMetricComponentsManager: Pruning Local Caches ===";
+
+  for (const auto& report : reports_root->GetList()) {
+    if (!report.is_dict()) continue;
+    const auto& dict = report.GetDict();
+    const std::string* join_uuid = dict.FindString("cmc_join_uuid");
+    // TODO: Consider supporting early startup crashes that lack a custom
+    // Cobalt-generated UUID. For now, we ignore them.
+    if (!join_uuid || join_uuid->empty()) {
+      continue;
+    }
+
+    std::string tracking_id = *join_uuid;
+    active_uuids.insert(tracking_id);
+  }
+
+  // 3. Prune stale ACKed UUIDs no longer in DB.
+  std::set<std::string> acked_uuids_to_keep;
+  for (const auto& u : acked_uuids) {
+    if (active_uuids.find(u) != active_uuids.end()) {
+      acked_uuids_to_keep.insert(u);
+    } else {
+      acked_needs_write = true;
+      LOG(INFO) << "[Pruning Stale ACK] Tracking ID " << u
+                << " no longer in DB.";
+    }
+  }
+
+  // 4. Prune stale Hang Statuses no longer in DB.
+  std::map<std::string, std::string> hang_statuses_to_keep;
+  for (const auto& kv : hang_statuses) {
+    if (active_uuids.find(kv.first) != active_uuids.end()) {
+      hang_statuses_to_keep[kv.first] = kv.second;
+    } else {
+      hangs_needs_write = true;
+      LOG(INFO) << "[Pruning Stale Hang Status] Tracking ID " << kv.first
+                << " no longer in DB.";
+    }
+  }
+
+  if (acked_needs_write) {
+    SaveAckedUuids(acked_uuids_to_keep);
+  }
+  if (hangs_needs_write) {
+    SaveHangStatuses(hang_statuses_to_keep);
+  }
+}
+
+void CoreMetricComponentsManager::AcknowledgeReports(
+    const std::vector<std::string>& acked_uuids,
+    base::OnceClosure callback) {
+  task_runner_->PostTaskAndReply(
+      FROM_HERE,
+      base::BindOnce(&CoreMetricComponentsManager::AcknowledgeReportsInternal,
+                     base::Unretained(this), acked_uuids),
+      std::move(callback));
+}
+
+void CoreMetricComponentsManager::AcknowledgeReportsInternal(
+    const std::vector<std::string>& acked_uuids) {
+  if (acked_uuids.empty()) return;
+
+  std::set<std::string> existing = LoadAckedUuids();
+  for (const auto& u : acked_uuids) {
+    existing.insert(u);
+  }
+  SaveAckedUuids(existing);
+  LOG(INFO) << "=== CoreMetricComponentsManager: Recorded "
+            << acked_uuids.size() << " Report ACKs ===";
+}
+
+}  // namespace browser
+}  // namespace cobalt

--- a/cobalt/browser/core_metric_components_manager.h
+++ b/cobalt/browser/core_metric_components_manager.h
@@ -1,0 +1,103 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_CORE_METRIC_COMPONENTS_MANAGER_H_
+#define COBALT_BROWSER_CORE_METRIC_COMPONENTS_MANAGER_H_
+
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/functional/callback.h"
+#include "base/memory/scoped_refptr.h"
+#include "base/task/sequenced_task_runner.h"
+
+namespace cobalt {
+namespace browser {
+
+enum class StabilityReportType {
+  kCrash,
+  kHangUnrecovered,
+  kHangRecovered,
+};
+
+struct StabilityReport {
+  std::string cmc_join_uuid;
+  int64_t creation_time = 0;
+  StabilityReportType report_type = StabilityReportType::kCrash;
+};
+
+// Manages deduplication and delivery of stability reports (Core Metric
+// Components) from the Starboard storage layer to the web client (Kabuki).
+class CoreMetricComponentsManager {
+ public:
+  static CoreMetricComponentsManager* GetInstance();
+
+  CoreMetricComponentsManager();
+  ~CoreMetricComponentsManager();
+
+  // Reconciles local storage on application startup by pruning stale ACK and
+  // hang status entries that are no longer present in the Crashpad database.
+  // Runs asynchronously on a background sequence.
+  void ReconcileReportsOnStartup();
+
+  // Queries local storage via Starboard, filters out previously ACKed reports,
+  // and logs the records that would be returned to the web application.
+  // Returns the list of active, un-ACKed reports via callback.
+  void GetPendingReportsForClient(
+      base::OnceCallback<void(std::vector<StabilityReport>)> callback);
+
+  // Acknowledges successful ingestion by the web application, appending the
+  // UUIDs to cmc_acked_uuids.json on disk. Calls |callback| on completion.
+  void AcknowledgeReports(const std::vector<std::string>& acked_uuids,
+                          base::OnceClosure callback);
+
+  // Records that a hang has started, pre-committing "unrecovered" status to
+  // cmc_hang_status.json before a minidump is generated.
+  void RecordHangStarted(const std::string& cmc_join_uuid);
+
+  // Records that a stalled thread resumed execution, updating its status to
+  // "recovered" in cmc_hang_status.json.
+  void RecordHangRecovered(const std::string& cmc_join_uuid);
+
+ private:
+  void ReconcileReportsOnStartupInternal();
+  std::vector<StabilityReport> GetPendingReportsForClientInternal();
+  void PruneStorage();
+  void AcknowledgeReportsInternal(const std::vector<std::string>& acked_uuids);
+  void RecordHangStartedInternal(const std::string& cmc_join_uuid);
+  void RecordHangRecoveredInternal(const std::string& cmc_join_uuid);
+
+  // Helper methods for accessing local JSON caches.
+  // Note: All Load/Save operations MUST run exclusively on the |task_runner_|
+  // sequence to guarantee safe read-modify-write cycles without raw locks.
+  base::FilePath GetAckFilePath();
+  std::set<std::string> LoadAckedUuids();
+  // Overwrites the ACKed UUIDs JSON cache file atomically on disk.
+  void SaveAckedUuids(const std::set<std::string>& uuids);
+
+  base::FilePath GetHangStatusFilePath();
+  std::map<std::string, std::string> LoadHangStatuses();
+  // Overwrites the hang status JSON cache file atomically on disk.
+  void SaveHangStatuses(const std::map<std::string, std::string>& statuses);
+
+  scoped_refptr<base::SequencedTaskRunner> task_runner_;
+};
+
+}  // namespace browser
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_CORE_METRIC_COMPONENTS_MANAGER_H_

--- a/cobalt/browser/h5vcc_core_metric_components/h5vcc_core_metric_components_impl.cc
+++ b/cobalt/browser/h5vcc_core_metric_components/h5vcc_core_metric_components_impl.cc
@@ -1,0 +1,101 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/h5vcc_core_metric_components/h5vcc_core_metric_components_impl.h"
+
+#include <utility>
+
+#include "base/check.h"
+#include "base/json/json_reader.h"
+#include "base/values.h"
+#include "cobalt/browser/core_metric_components_manager.h"
+#include "content/public/browser/render_frame_host.h"
+
+namespace h5vcc_core_metric_components {
+
+// static
+void H5vccCoreMetricComponentsImpl::Create(
+    content::RenderFrameHost* render_frame_host,
+    mojo::PendingReceiver<mojom::H5vccCoreMetricComponents> receiver) {
+  CHECK(render_frame_host);
+  new H5vccCoreMetricComponentsImpl(*render_frame_host, std::move(receiver));
+}
+
+H5vccCoreMetricComponentsImpl::H5vccCoreMetricComponentsImpl(
+    content::RenderFrameHost& render_frame_host,
+    mojo::PendingReceiver<mojom::H5vccCoreMetricComponents> receiver)
+    : content::DocumentService<mojom::H5vccCoreMetricComponents>(
+          render_frame_host,
+          std::move(receiver)) {}
+
+void H5vccCoreMetricComponentsImpl::GetPendingReports(
+    GetPendingReportsCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+
+  cobalt::browser::CoreMetricComponentsManager::GetInstance()
+      ->GetPendingReportsForClient(base::BindOnce(
+          &H5vccCoreMetricComponentsImpl::OnPendingReportsReceived,
+          weak_factory_.GetWeakPtr(), std::move(callback)));
+}
+
+void H5vccCoreMetricComponentsImpl::OnPendingReportsReceived(
+    GetPendingReportsCallback callback,
+    std::vector<cobalt::browser::StabilityReport> manager_reports) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+
+  std::vector<mojom::StabilityReportPtr> reports;
+  for (const auto& r : manager_reports) {
+    auto report = mojom::StabilityReport::New();
+    report->cmc_join_uuid = r.cmc_join_uuid;
+    report->creation_time = r.creation_time;
+
+    switch (r.report_type) {
+      case cobalt::browser::StabilityReportType::kCrash:
+        report->report_type = mojom::StabilityReportType::kCrash;
+        break;
+      case cobalt::browser::StabilityReportType::kHangUnrecovered:
+        report->report_type = mojom::StabilityReportType::kHangUnrecovered;
+        break;
+      case cobalt::browser::StabilityReportType::kHangRecovered:
+        report->report_type = mojom::StabilityReportType::kHangRecovered;
+        break;
+    }
+
+    reports.push_back(std::move(report));
+  }
+
+  std::move(callback).Run(std::move(reports));
+}
+
+void H5vccCoreMetricComponentsImpl::AcknowledgeReports(
+    const std::vector<std::string>& acked_uuids,
+    AcknowledgeReportsCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+
+  cobalt::browser::CoreMetricComponentsManager::GetInstance()
+      ->AcknowledgeReports(acked_uuids, std::move(callback));
+}
+
+void H5vccCoreMetricComponentsImpl::MarkHangRecovered(
+    const std::string& cmc_join_uuid,
+    MarkHangRecoveredCallback callback) {
+  CHECK_CALLED_ON_VALID_THREAD(thread_checker_);
+
+  cobalt::browser::CoreMetricComponentsManager::GetInstance()
+      ->RecordHangRecovered(cmc_join_uuid);
+
+  std::move(callback).Run();
+}
+
+}  // namespace h5vcc_core_metric_components

--- a/cobalt/browser/h5vcc_core_metric_components/h5vcc_core_metric_components_impl.h
+++ b/cobalt/browser/h5vcc_core_metric_components/h5vcc_core_metric_components_impl.h
@@ -1,0 +1,71 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_H5VCC_CORE_METRIC_COMPONENTS_H5VCC_CORE_METRIC_COMPONENTS_IMPL_H_
+#define COBALT_BROWSER_H5VCC_CORE_METRIC_COMPONENTS_H5VCC_CORE_METRIC_COMPONENTS_IMPL_H_
+
+#include <string>
+#include <vector>
+
+#include "cobalt/browser/h5vcc_core_metric_components/public/mojom/h5vcc_core_metric_components.mojom.h"
+#include "base/memory/weak_ptr.h"
+#include "cobalt/common/cobalt_thread_checker.h"
+#include "content/public/browser/document_service.h"
+#include "mojo/public/cpp/bindings/pending_receiver.h"
+
+namespace content {
+class RenderFrameHost;
+}  // namespace content
+
+namespace cobalt {
+namespace browser {
+struct StabilityReport;
+}  // namespace browser
+}  // namespace cobalt
+
+namespace h5vcc_core_metric_components {
+
+class H5vccCoreMetricComponentsImpl
+    : public content::DocumentService<mojom::H5vccCoreMetricComponents> {
+ public:
+  static void Create(
+      content::RenderFrameHost* render_frame_host,
+      mojo::PendingReceiver<mojom::H5vccCoreMetricComponents> receiver);
+
+  H5vccCoreMetricComponentsImpl(const H5vccCoreMetricComponentsImpl&) = delete;
+  H5vccCoreMetricComponentsImpl& operator=(const H5vccCoreMetricComponentsImpl&) = delete;
+
+  // Mojom impl:
+  void GetPendingReports(GetPendingReportsCallback callback) override;
+  void AcknowledgeReports(const std::vector<std::string>& acked_uuids,
+                          AcknowledgeReportsCallback callback) override;
+  void MarkHangRecovered(const std::string& cmc_join_uuid,
+                         MarkHangRecoveredCallback callback) override;
+
+ private:
+  H5vccCoreMetricComponentsImpl(
+      content::RenderFrameHost& render_frame_host,
+      mojo::PendingReceiver<mojom::H5vccCoreMetricComponents> receiver);
+
+  void OnPendingReportsReceived(
+      GetPendingReportsCallback callback,
+      std::vector<cobalt::browser::StabilityReport> reports);
+
+  COBALT_THREAD_CHECKER(thread_checker_);
+  base::WeakPtrFactory<H5vccCoreMetricComponentsImpl> weak_factory_{this};
+};
+
+}  // namespace h5vcc_core_metric_components
+
+#endif  // COBALT_BROWSER_H5VCC_CORE_METRIC_COMPONENTS_H5VCC_CORE_METRIC_COMPONENTS_IMPL_H_

--- a/cobalt/browser/h5vcc_core_metric_components/public/mojom/BUILD.gn
+++ b/cobalt/browser/h5vcc_core_metric_components/public/mojom/BUILD.gn
@@ -1,0 +1,19 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//mojo/public/tools/bindings/mojom.gni")
+
+mojom("mojom") {
+  sources = [ "h5vcc_core_metric_components.mojom" ]
+}

--- a/cobalt/browser/h5vcc_core_metric_components/public/mojom/h5vcc_core_metric_components.mojom
+++ b/cobalt/browser/h5vcc_core_metric_components/public/mojom/h5vcc_core_metric_components.mojom
@@ -1,0 +1,35 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+module h5vcc_core_metric_components.mojom;
+
+enum StabilityReportType {
+  kCrash,
+  kHangUnrecovered,
+  kHangRecovered,
+};
+
+struct StabilityReport {
+  string cmc_join_uuid;
+  int64 creation_time;
+  StabilityReportType report_type;
+};
+
+interface H5vccCoreMetricComponents {
+  GetPendingReports() => (array<StabilityReport> reports);
+  AcknowledgeReports(array<string> acked_uuids) => ();
+  // FOR TESTING ONLY: Will be removed when we implement hang recovery
+  // detection in HangWatcher.
+  MarkHangRecovered(string cmc_join_uuid) => ();
+};

--- a/cobalt/browser/hang_watcher_delegate_impl.cc
+++ b/cobalt/browser/hang_watcher_delegate_impl.cc
@@ -18,8 +18,10 @@
 #include <optional>
 
 #include "base/feature_list.h"
+#include "cobalt/browser/core_metric_components_manager.h"
 #include "cobalt/browser/features.h"
 #include "cobalt/browser/global_features.h"
+
 namespace cobalt {
 namespace browser {
 
@@ -36,6 +38,7 @@ bool CobaltHangWatcherDelegate::IsHangReportingEnabled() {
   // until the proper Finch bridge is fully functional. If the setting isn't
   // explicitly provided, we fallback to the standard Chromium 'FeatureList'
   // which is backed by Finch.
+
   if (auto* global_features = GlobalFeatures::GetInstance()) {
     const auto& settings = global_features->GetSettings();
     auto it = settings.find("EnableHangReporting");
@@ -51,6 +54,10 @@ bool CobaltHangWatcherDelegate::IsHangReportingEnabled() {
   DLOG(INFO) << "CobaltHangWatcherDelegate: EnableHangReporting: using Finch";
 
   return base::FeatureList::IsEnabled(cobalt::features::kHangReporting);
+}
+
+void CobaltHangWatcherDelegate::OnHangStarted(const std::string& hang_uuid) {
+  CoreMetricComponentsManager::GetInstance()->RecordHangStarted(hang_uuid);
 }
 
 }  // namespace browser

--- a/cobalt/browser/hang_watcher_delegate_impl.h
+++ b/cobalt/browser/hang_watcher_delegate_impl.h
@@ -28,6 +28,7 @@ class CobaltHangWatcherDelegate : public base::HangWatcher::Delegate {
   static void Initialize();
 
   bool IsHangReportingEnabled() override;
+  void OnHangStarted(const std::string& hang_uuid) override;
 };
 
 }  // namespace browser

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -188,9 +188,6 @@ group("cobalt_shell_lib_deps") {
     public_deps += [ "//cobalt/android/oom_intervention" ]
   }
 
-  if (is_starboard || is_androidtv) {
-    public_deps += [ "//cobalt/browser:hang_watcher_delegate" ]
-  }
 }
 
 static_library("cobalt_shell_switches") {

--- a/starboard/crashpad_wrapper/BUILD.gn
+++ b/starboard/crashpad_wrapper/BUILD.gn
@@ -28,6 +28,8 @@ if (is_starboard && current_toolchain == starboard_toolchain) {
       "//starboard/elf_loader:evergreen_info",
       "//third_party/crashpad/crashpad/client",
       "//third_party/crashpad/crashpad/client:common",
+      "//third_party/crashpad/crashpad/snapshot",
+      "//third_party/crashpad/crashpad/util",
     ]
 
     data_deps = [ "//third_party/crashpad/crashpad/handler:crashpad_handler($native_toolchain)" ]

--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -21,8 +21,10 @@
 #include <vector>
 
 #include "base/files/file_path.h"
+#include "base/json/json_writer.h"
 #include "base/logging.h"
 #include "base/strings/stringprintf.h"
+#include "base/values.h"
 #include "build/build_config.h"
 #include "client/crash_report_database.h"
 #include "client/crashpad_client.h"
@@ -33,7 +35,10 @@
 #include "starboard/extension/crash_handler.h"
 #include "starboard/extension/loader_app_metrics.h"
 #include "starboard/system.h"
+#include "third_party/crashpad/crashpad/snapshot/minidump/process_snapshot_minidump.h"
 #include "third_party/crashpad/crashpad/snapshot/sanitized/sanitization_information.h"
+#include "third_party/crashpad/crashpad/util/file/file_reader.h"
+#include "third_party/crashpad/crashpad/util/posix/signals.h"
 #include "util/misc/capture_context.h"
 
 using starboard::kSystemPropertyMaxLength;
@@ -313,6 +318,85 @@ void DumpWithoutCrashingWrapper() {
   ::crashpad::NativeCPUContext context;
   ::crashpad::CaptureContext(&context);
   ::crashpad::CrashpadClient::DumpWithoutCrash(&context);
+}
+
+bool GetCompletedReports(char* out_buffer, int buffer_size) {
+  if (!out_buffer || buffer_size <= 0) {
+    return false;
+  }
+
+  const base::FilePath database_directory_path = GetDatabasePath();
+  if (database_directory_path.empty()) {
+    return false;
+  }
+
+  std::unique_ptr<::crashpad::CrashReportDatabase> database =
+      ::crashpad::CrashReportDatabase::Initialize(database_directory_path);
+  if (!database) {
+    return false;
+  }
+
+  std::vector<::crashpad::CrashReportDatabase::Report> completed_reports;
+  if (database->GetCompletedReports(&completed_reports) !=
+      ::crashpad::CrashReportDatabase::kNoError) {
+    LOG(ERROR) << "GetCompletedReports failed for database at "
+               << database_directory_path.value();
+    return false;
+  }
+
+  LOG(INFO) << "GetCompletedReports: Database path = "
+            << database_directory_path.value()
+            << ", Completed reports count = " << completed_reports.size();
+
+  base::Value::List reports_list;
+  for (const auto& report : completed_reports) {
+    base::Value::Dict report_dict;
+    report_dict.Set("crashpad_db_uuid", report.uuid.ToString());
+    report_dict.Set("creation_time", static_cast<double>(report.creation_time));
+    std::string cmc_join_uuid = "";
+    std::string cmc_report_type = "crash";
+
+    ::crashpad::FileReader reader;
+    if (reader.Open(report.file_path)) {
+      ::crashpad::ProcessSnapshotMinidump snapshot;
+      if (snapshot.Initialize(&reader)) {
+        const auto& annotations = snapshot.AnnotationsSimpleMap();
+        const auto* exception = snapshot.Exception();
+        bool is_simulated_hang = false;
+        if (exception && exception->Exception() == static_cast<uint32_t>(::crashpad::Signals::kSimulatedSigno)) {
+          is_simulated_hang = true;
+        }
+
+        auto hang_it = annotations.find("cmc_hang_uuid");
+        if (is_simulated_hang && hang_it != annotations.end() && !hang_it->second.empty()) {
+          cmc_report_type = "hang";
+          cmc_join_uuid = hang_it->second;
+        } else {
+          cmc_report_type = "crash";
+          auto crash_it = annotations.find("cmc_crash_uuid");
+          if (crash_it != annotations.end()) {
+            cmc_join_uuid = crash_it->second;
+          }
+        }
+      }
+    }
+
+    report_dict.Set("cmc_join_uuid", cmc_join_uuid);
+    report_dict.Set("cmc_report_type", cmc_report_type);
+    reports_list.Append(std::move(report_dict));
+  }
+
+  std::string json;
+  if (!base::JSONWriter::Write(reports_list, &json)) {
+    return false;
+  }
+
+  if (json.size() >= static_cast<size_t>(buffer_size)) {
+    return false;
+  }
+
+  memcpy(out_buffer, json.c_str(), json.size() + 1);
+  return true;
 }
 
 }  // namespace crashpad

--- a/starboard/crashpad_wrapper/wrapper.h
+++ b/starboard/crashpad_wrapper/wrapper.h
@@ -51,6 +51,26 @@ bool InsertCrashpadAnnotation(const char* key, const char* value);
 // Captures CPU context and triggers a non-crashing dump report.
 void DumpWithoutCrashingWrapper();
 
+// Retrieves all completed stability reports (crashes and hangs) currently
+// stored in the local Crashpad database.
+//
+// Populates |out_buffer| with a null-terminated JSON-serialized array of
+// dictionaries representing the reports.
+//
+// Example of the returned JSON array structure:
+// [
+//   {
+//     "crashpad_db_uuid": "b44678e7-3c5f-4b80-94d4-b7b18a667100",
+//     "creation_time": 1782250000.0,
+//     "cmc_report_type": "hang",
+//     "cmc_join_uuid": "fb8b78fa-c1ad-467d-afc2-4916a4a6b281"
+//   },
+//   ...
+// ]
+//
+// Returns true on success, or false if the serialization fails or if the
+// serialized string exceeds the size of |out_buffer|.
+bool GetCompletedReports(char* out_buffer, int buffer_size);
 }  // namespace crashpad
 
 #endif  // STARBOARD_CRASHPAD_WRAPPER_WRAPPER_H_

--- a/starboard/extension/core_metric_components.h
+++ b/starboard/extension/core_metric_components.h
@@ -1,0 +1,72 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_EXTENSION_CORE_METRIC_COMPONENTS_H_
+#define STARBOARD_EXTENSION_CORE_METRIC_COMPONENTS_H_
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define kCobaltExtensionCoreMetricComponentsName \
+  "dev.cobalt.extension.CoreMetricComponents"
+
+typedef struct CobaltExtensionCoreMetricComponentsApi {
+  // Name should be the string |kCobaltExtensionCoreMetricComponentsName|.
+  // This helps to validate that the extension API is correct.
+  const char* name;
+
+  // This specifies the version of the API that is implemented.
+  uint32_t version;
+
+  // The fields below this point were added in version 1 or later.
+
+  // Retrieves completed crash and hang reports from local storage (e.g., the
+  // Crashpad database) along with their metadata and annotations.
+  //
+  // Populates |out_buffer| with a null-terminated JSON-serialized array of
+  // dictionaries representing the reports up to |buffer_size| bytes.
+  //
+  // Example JSON payload structure:
+  // [
+  //   {
+  //     "crashpad_db_uuid": "b44678e7-3c5f-4b80-94d4-b7b18a667100",
+  //     "creation_time": 1782250000.0,
+  //     "cmc_report_type": "hang",
+  //     "cmc_join_uuid": "fb8b78fa-c1ad-467d-afc2-4916a4a6b281"
+  //   },
+  //   ...
+  // ]
+  //
+  // Mandatory keys for each dictionary element:
+  // - "creation_time" (number): The UNIX timestamp when the report was
+  //   captured.
+  // - "cmc_report_type" (string): The type of report ("crash" or "hang").
+  // - "cmc_join_uuid" (string): The Cobalt-generated session or hang ID.
+  //
+  // Implementations may append additional custom keys, which Cobalt
+  // will ignore.
+  // Returns true on success and false on failure.
+  bool (*GetCompletedReports)(char* out_buffer, int buffer_size);
+
+} CobaltExtensionCoreMetricComponentsApi;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // STARBOARD_EXTENSION_CORE_METRIC_COMPONENTS_H_

--- a/starboard/extension/extension_test.cc
+++ b/starboard/extension/extension_test.cc
@@ -17,6 +17,7 @@
 #include "starboard/extension/accessibility.h"
 #include "starboard/extension/configuration.h"
 #include "starboard/extension/crash_handler.h"
+#include "starboard/extension/core_metric_components.h"
 #include "starboard/extension/experimental/experimental_features.h"
 #include "starboard/extension/experimental/media_buffer_pool.h"
 #include "starboard/extension/features.h"
@@ -622,6 +623,26 @@ TEST(ExtensionTest, StarboardMediaBufferPoolExtension) {
   EXPECT_NE(extension_api->ShrinkToZero, nullptr);
   EXPECT_NE(extension_api->ExpandTo, nullptr);
   EXPECT_NE(extension_api->Write, nullptr);
+
+  const ExtensionApi* second_extension_api =
+      static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));
+  EXPECT_EQ(second_extension_api, extension_api)
+      << "Extension struct should be a singleton";
+}
+
+TEST(ExtensionTest, CoreMetricComponentsExtension) {
+  typedef CobaltExtensionCoreMetricComponentsApi ExtensionApi;
+  const char* kExtensionName = kCobaltExtensionCoreMetricComponentsName;
+
+  const ExtensionApi* extension_api =
+      static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));
+  if (!extension_api) {
+    return;
+  }
+
+  EXPECT_STREQ(extension_api->name, kExtensionName);
+  EXPECT_EQ(extension_api->version, 1u);
+  EXPECT_NE(extension_api->GetCompletedReports, nullptr);
 
   const ExtensionApi* second_extension_api =
       static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -231,6 +231,8 @@ static_library("starboard_platform_sources") {
     sources += [
       "//starboard/shared/starboard/crash_handler.cc",
       "//starboard/shared/starboard/crash_handler.h",
+      "//starboard/shared/starboard/core_metric_components.cc",
+      "//starboard/shared/starboard/core_metric_components.h",
     ]
   }
 

--- a/starboard/linux/shared/system_get_extensions.cc
+++ b/starboard/linux/shared/system_get_extensions.cc
@@ -35,9 +35,11 @@
 
 #if BUILDFLAG(USE_EVERGREEN)
 #include "starboard/extension/crash_handler.h"
+#include "starboard/extension/core_metric_components.h"
 #include "starboard/extension/platform_service.h"
 #include "starboard/linux/shared/platform_service.h"
 #include "starboard/shared/starboard/crash_handler.h"
+#include "starboard/shared/starboard/core_metric_components.h"
 #endif
 
 const void* SbSystemGetExtension(const char* name) {
@@ -58,6 +60,9 @@ const void* SbSystemGetExtension(const char* name) {
 #if BUILDFLAG(USE_EVERGREEN)
   if (strcmp(name, kCobaltExtensionCrashHandlerName) == 0) {
     return starboard::GetCrashHandlerApi();
+  }
+  if (strcmp(name, kCobaltExtensionCoreMetricComponentsName) == 0) {
+    return starboard::GetCoreMetricComponentsApi();
   }
 
   // TODO: b/371419798 - enable for non-evergreen builds once we've resolved the

--- a/starboard/shared/starboard/core_metric_components.cc
+++ b/starboard/shared/starboard/core_metric_components.cc
@@ -1,0 +1,36 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/core_metric_components.h"
+
+#include "starboard/crashpad_wrapper/wrapper.h"
+#include "starboard/extension/core_metric_components.h"
+
+namespace starboard {
+
+namespace {
+
+const CobaltExtensionCoreMetricComponentsApi kCoreMetricComponentsApi = {
+    kCobaltExtensionCoreMetricComponentsName,
+    1,
+    &crashpad::GetCompletedReports,
+};
+
+}  // namespace
+
+const void* GetCoreMetricComponentsApi() {
+  return &kCoreMetricComponentsApi;
+}
+
+}  // namespace starboard

--- a/starboard/shared/starboard/core_metric_components.h
+++ b/starboard/shared/starboard/core_metric_components.h
@@ -1,0 +1,24 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_STARBOARD_CORE_METRIC_COMPONENTS_H_
+#define STARBOARD_SHARED_STARBOARD_CORE_METRIC_COMPONENTS_H_
+
+namespace starboard {
+
+const void* GetCoreMetricComponentsApi();
+
+}  // namespace starboard
+
+#endif  // STARBOARD_SHARED_STARBOARD_CORE_METRIC_COMPONENTS_H_

--- a/third_party/blink/renderer/bindings/generated_in_modules.gni
+++ b/third_party/blink/renderer/bindings/generated_in_modules.gni
@@ -3226,6 +3226,8 @@ if (is_cobalt) {
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc.h",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc_accessibility.cc",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc_accessibility.h",
+    "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc_core_metric_components.cc",
+    "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc_core_metric_components.h",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc_experiments.cc",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc_experiments.h",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc_metrics.cc",
@@ -3251,6 +3253,8 @@ if (is_cobalt) {
   generated_dictionary_sources_in_modules += [
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_experiment_configuration.cc",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_experiment_configuration.h",
+    "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_stability_report.cc",
+    "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_stability_report.h",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_text_to_speech_change_event_init.cc",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_text_to_speech_change_event_init.h",
   ]
@@ -3259,6 +3263,8 @@ if (is_cobalt) {
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_h_5_vcc_metric_type.h",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_override_state.cc",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_override_state.h",
+    "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_stability_report_type.cc",
+    "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_stability_report_type.h",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_user_on_exit_strategy.cc",
     "$root_gen_dir/third_party/blink/renderer/bindings/modules/v8/v8_user_on_exit_strategy.h",
   ]

--- a/third_party/blink/renderer/bindings/idl_in_modules.gni
+++ b/third_party/blink/renderer/bindings/idl_in_modules.gni
@@ -1298,6 +1298,7 @@ if (is_cobalt) {
             "//third_party/blink/renderer/modules/cobalt/h5vcc_accessibility/h_5_vcc_accessibility.idl",
             "//third_party/blink/renderer/modules/cobalt/h5vcc_accessibility/text_to_speech_change_event.idl",
             "//third_party/blink/renderer/modules/cobalt/h5vcc_accessibility/text_to_speech_change_event_init.idl",
+            "//third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.idl",
             "//third_party/blink/renderer/modules/cobalt/h5vcc_experiments/h_5_vcc_experiments.idl",
             "//third_party/blink/renderer/modules/cobalt/h5vcc_metrics/h_5_vcc_metrics.idl",
             "//third_party/blink/renderer/modules/cobalt/h5vcc_metrics/metrics_event.idl",

--- a/third_party/blink/renderer/modules/cobalt/BUILD.gn
+++ b/third_party/blink/renderer/modules/cobalt/BUILD.gn
@@ -18,10 +18,13 @@ blink_modules_sources("h_5_vcc") {
   sources = [
     "cobalt_lifecycle_controller.cc",
     "cobalt_lifecycle_controller.h",
+    "h5vcc_core_metric_components/h_5_vcc_core_metric_components.cc",
+    "h5vcc_core_metric_components/h_5_vcc_core_metric_components.h",
     "h_5_vcc.cc",
     "h_5_vcc.h",
   ]
   deps = [
+    "//cobalt/browser/h5vcc_core_metric_components/public/mojom:mojom_blink",
     "//cobalt/browser/h5vcc_runtime/public/mojom:mojom_blink",
     "//cobalt/browser/lifecycle/public/mojom:mojom_blink",
     "//third_party/blink/renderer/modules/cobalt/crash_log",

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.cc
@@ -1,0 +1,130 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.h"
+
+#include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
+#include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
+#include "third_party/blink/renderer/core/frame/local_dom_window.h"
+
+namespace blink {
+
+H5vccCoreMetricComponents::H5vccCoreMetricComponents(LocalDOMWindow& window)
+    : ExecutionContextLifecycleObserver(window.GetExecutionContext()),
+      remote_h5vcc_core_metric_components_(window.GetExecutionContext()) {}
+
+void H5vccCoreMetricComponents::ContextDestroyed() {
+  remote_h5vcc_core_metric_components_.reset();
+}
+
+ScriptPromise<IDLSequence<StabilityReport>>
+H5vccCoreMetricComponents::getPendingReports(ScriptState* script_state,
+                                             ExceptionState& exception_state) {
+  EnsureRemoteIsBound();
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLSequence<StabilityReport>>>(
+      script_state, exception_state.GetContext());
+
+  remote_h5vcc_core_metric_components_->GetPendingReports(WTF::BindOnce(
+      [](ScriptPromiseResolver<IDLSequence<StabilityReport>>* resolver,
+         Vector<
+             h5vcc_core_metric_components::mojom::blink::StabilityReportPtr>
+             mojo_reports) {
+        HeapVector<Member<StabilityReport>> reports;
+        for (const auto& mojo_report : mojo_reports) {
+          auto* report = StabilityReport::Create();
+          report->setCmcJoinUuid(mojo_report->cmc_join_uuid);
+          report->setCreationTime(mojo_report->creation_time);
+
+          switch (mojo_report->report_type) {
+            case h5vcc_core_metric_components::mojom::blink::
+                StabilityReportType::kCrash:
+              report->setReportType(
+                  V8StabilityReportType(V8StabilityReportType::Enum::kCrash));
+              break;
+            case h5vcc_core_metric_components::mojom::blink::
+                StabilityReportType::kHangUnrecovered:
+              report->setReportType(V8StabilityReportType(
+                  V8StabilityReportType::Enum::kHangUnrecovered));
+              break;
+            case h5vcc_core_metric_components::mojom::blink::
+                StabilityReportType::kHangRecovered:
+              report->setReportType(V8StabilityReportType(
+                  V8StabilityReportType::Enum::kHangRecovered));
+              break;
+          }
+
+          reports.push_back(report);
+        }
+        resolver->Resolve(reports);
+      },
+      WrapPersistent(resolver)));
+
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLUndefined> H5vccCoreMetricComponents::acknowledgeReports(
+    ScriptState* script_state,
+    const Vector<String>& acked_uuids,
+    ExceptionState& exception_state) {
+  EnsureRemoteIsBound();
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
+      script_state, exception_state.GetContext());
+
+  remote_h5vcc_core_metric_components_->AcknowledgeReports(
+      acked_uuids, WTF::BindOnce(
+                       [](ScriptPromiseResolver<IDLUndefined>* resolver) {
+                         resolver->Resolve();
+                       },
+                       WrapPersistent(resolver)));
+
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLUndefined> H5vccCoreMetricComponents::markHangRecovered(
+    ScriptState* script_state,
+    const String& cmc_join_uuid,
+    ExceptionState& exception_state) {
+  EnsureRemoteIsBound();
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
+      script_state, exception_state.GetContext());
+
+  remote_h5vcc_core_metric_components_->MarkHangRecovered(
+      cmc_join_uuid,
+      WTF::BindOnce(
+          [](ScriptPromiseResolver<IDLUndefined>* resolver) {
+            resolver->Resolve();
+          },
+          WrapPersistent(resolver)));
+
+  return resolver->Promise();
+}
+
+void H5vccCoreMetricComponents::EnsureRemoteIsBound() {
+  DCHECK(GetExecutionContext());
+  if (remote_h5vcc_core_metric_components_.is_bound()) {
+    return;
+  }
+  auto task_runner =
+      GetExecutionContext()->GetTaskRunner(TaskType::kMiscPlatformAPI);
+  GetExecutionContext()->GetBrowserInterfaceBroker().GetInterface(
+      remote_h5vcc_core_metric_components_.BindNewPipeAndPassReceiver(task_runner));
+}
+
+void H5vccCoreMetricComponents::Trace(Visitor* visitor) const {
+  ScriptWrappable::Trace(visitor);
+  ExecutionContextLifecycleObserver::Trace(visitor);
+  visitor->Trace(remote_h5vcc_core_metric_components_);
+}
+
+}  // namespace blink

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.h
@@ -1,0 +1,64 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef THIRD_PARTY_BLINK_RENDERER_MODULES_COBALT_H5VCC_CORE_METRIC_COMPONENTS_H_5_VCC_CORE_METRIC_COMPONENTS_H_
+#define THIRD_PARTY_BLINK_RENDERER_MODULES_COBALT_H5VCC_CORE_METRIC_COMPONENTS_H_5_VCC_CORE_METRIC_COMPONENTS_H_
+
+#include "cobalt/browser/h5vcc_core_metric_components/public/mojom/h5vcc_core_metric_components.mojom-blink.h"
+#include "third_party/blink/renderer/bindings/core/v8/idl_types.h"
+#include "third_party/blink/renderer/bindings/core/v8/script_promise.h"
+#include "third_party/blink/renderer/bindings/core/v8/script_promise_resolver.h"
+#include "third_party/blink/renderer/bindings/modules/v8/v8_stability_report.h"
+#include "third_party/blink/renderer/bindings/modules/v8/v8_stability_report_type.h"
+#include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
+#include "third_party/blink/renderer/modules/modules_export.h"
+#include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
+#include "third_party/blink/renderer/platform/mojo/heap_mojo_remote.h"
+#include "third_party/blink/renderer/platform/wtf/text/wtf_string.h"
+#include "third_party/blink/renderer/platform/wtf/vector.h"
+
+namespace blink {
+
+class ExecutionContext;
+class LocalDOMWindow;
+class ScriptState;
+
+class MODULES_EXPORT H5vccCoreMetricComponents final
+    : public ScriptWrappable,
+      public ExecutionContextLifecycleObserver {
+  DEFINE_WRAPPERTYPEINFO();
+
+ public:
+  explicit H5vccCoreMetricComponents(LocalDOMWindow&);
+  ~H5vccCoreMetricComponents() override = default;
+
+  void ContextDestroyed() override;
+
+  // Web-exposed interface:
+  ScriptPromise<IDLSequence<StabilityReport>> getPendingReports(ScriptState*, ExceptionState&);
+  ScriptPromise<IDLUndefined> acknowledgeReports(ScriptState*, const Vector<String>& acked_uuids, ExceptionState&);
+  ScriptPromise<IDLUndefined> markHangRecovered(ScriptState*, const String& cmc_join_uuid, ExceptionState&);
+
+  void Trace(Visitor*) const override;
+
+ private:
+  void EnsureRemoteIsBound();
+
+  HeapMojoRemote<h5vcc_core_metric_components::mojom::blink::H5vccCoreMetricComponents>
+      remote_h5vcc_core_metric_components_;
+};
+
+}  // namespace blink
+
+#endif  // THIRD_PARTY_BLINK_RENDERER_MODULES_COBALT_H5VCC_CORE_METRIC_COMPONENTS_H_5_VCC_CORE_METRIC_COMPONENTS_H_

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.idl
@@ -1,0 +1,41 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+enum StabilityReportType {
+  "crash",
+  "hang_unrecovered",
+  "hang_recovered",
+};
+
+dictionary StabilityReport {
+  DOMString cmcJoinUuid;
+  long long creationTime;
+  StabilityReportType reportType;
+};
+
+[
+  Exposed=Window,
+  SecureContext
+]
+interface H5vccCoreMetricComponents {
+  [CallWith=ScriptState, RaisesException]
+  Promise<sequence<StabilityReport>> getPendingReports();
+
+  [CallWith=ScriptState, RaisesException]
+  Promise<undefined> acknowledgeReports(sequence<DOMString> ackedUuids);
+
+  // FOR TESTING ONLY: Will be removed when we implement hang recovery detection in hang watcher.
+  [CallWith=ScriptState, RaisesException]
+  Promise<undefined> markHangRecovered(DOMString cmcJoinUuid);
+};

--- a/third_party/blink/renderer/modules/cobalt/h_5_vcc.cc
+++ b/third_party/blink/renderer/modules/cobalt/h_5_vcc.cc
@@ -17,6 +17,7 @@
 #include "third_party/blink/renderer/core/frame/local_dom_window.h"
 #include "third_party/blink/renderer/modules/cobalt/crash_log/crash_log.h"
 #include "third_party/blink/renderer/modules/cobalt/h5vcc_accessibility/h_5_vcc_accessibility.h"
+#include "third_party/blink/renderer/modules/cobalt/h5vcc_core_metric_components/h_5_vcc_core_metric_components.h"
 #include "third_party/blink/renderer/modules/cobalt/h5vcc_experiments/h_5_vcc_experiments.h"
 #include "third_party/blink/renderer/modules/cobalt/h5vcc_metrics/h_5_vcc_metrics.h"
 #include "third_party/blink/renderer/modules/cobalt/h5vcc_runtime/h_5_vcc_runtime.h"
@@ -44,6 +45,7 @@ H5vcc::H5vcc(LocalDOMWindow& window)
     : Supplement<LocalDOMWindow>(window),
       crash_log_(MakeGarbageCollected<CrashLog>(window)),
       accessibility_(MakeGarbageCollected<H5vccAccessibility>(window)),
+      core_metric_components_(MakeGarbageCollected<H5vccCoreMetricComponents>(window)),
       experiments_(MakeGarbageCollected<H5vccExperiments>(window)),
       metrics_(MakeGarbageCollected<H5vccMetrics>(window)),
       system_(MakeGarbageCollected<H5vccSystem>(window)),
@@ -55,6 +57,7 @@ H5vcc::H5vcc(LocalDOMWindow& window)
 void H5vcc::Trace(Visitor* visitor) const {
   visitor->Trace(crash_log_);
   visitor->Trace(accessibility_);
+  visitor->Trace(core_metric_components_);
   visitor->Trace(experiments_);
   visitor->Trace(metrics_);
   visitor->Trace(system_);

--- a/third_party/blink/renderer/modules/cobalt/h_5_vcc.h
+++ b/third_party/blink/renderer/modules/cobalt/h_5_vcc.h
@@ -27,6 +27,7 @@ namespace blink {
 class CrashLog;
 class LocalDOMWindow;
 class H5vccAccessibility;
+class H5vccCoreMetricComponents;
 class H5vccExperiments;
 class H5vccMetrics;
 class H5vccSystem;
@@ -51,6 +52,7 @@ class MODULES_EXPORT H5vcc final : public ScriptWrappable,
   CrashLog* crashLog() { return crash_log_; }
 
   H5vccAccessibility* accessibility() { return accessibility_; }
+  H5vccCoreMetricComponents* coreMetricComponents() { return core_metric_components_; }
   H5vccExperiments* experiments() { return experiments_; }
 
   H5vccMetrics* metrics() { return metrics_; }
@@ -69,6 +71,7 @@ class MODULES_EXPORT H5vcc final : public ScriptWrappable,
  private:
   Member<CrashLog> crash_log_;
   Member<H5vccAccessibility> accessibility_;
+  Member<H5vccCoreMetricComponents> core_metric_components_;
   Member<H5vccExperiments> experiments_;
   Member<H5vccMetrics> metrics_;
   Member<H5vccSystem> system_;

--- a/third_party/blink/renderer/modules/cobalt/h_5_vcc.idl
+++ b/third_party/blink/renderer/modules/cobalt/h_5_vcc.idl
@@ -21,6 +21,7 @@
 interface H5vcc {
     readonly attribute CrashLog crashLog;
     readonly attribute H5vccAccessibility accessibility;
+    readonly attribute H5vccCoreMetricComponents coreMetricComponents;
     readonly attribute H5vccExperiments experiments;
     readonly attribute H5vccMetrics metrics;
     readonly attribute H5vccSystem system;


### PR DESCRIPTION
This is a proof of concept, for illustrative purposes only. It is meant
to accompany the design at go/cmc-storage-3p-mvp and will be rewritten
if we move forward with the design.
    
Some other components aside from CMC Storage are also roughly
implemented here, to aid with e2e testing of the storage component. This
would include the CMC web interface and corresponding Mojo interface,
for example.
    
The changes are not carefully guarded so builds for other platforms,
like ATV, are not expected to succeed.

#vibe-coded
    
Issue: 528362453