### PR TITLE
media: Force 16kHz mono for audio fastpath

### DIFF
--- a/base/sync_socket_posix.cc
+++ b/base/sync_socket_posix.cc
@@ -179,7 +179,9 @@ size_t SyncSocket::Peek() {
   ssize_t number_chars = recv(handle_.get(), buffer.data(), buffer.size(),
                               MSG_PEEK | MSG_TRUNC | MSG_DONTWAIT);
   if (number_chars < 0) {
-    PLOG(ERROR) << "recv failed in SyncSocket::Peek";
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+      PLOG(ERROR) << "recv failed in SyncSocket::Peek";
+    }
     return 0;
   }
   return checked_cast<size_t>(number_chars);

--- a/content/browser/renderer_host/media/audio_input_device_manager.cc
+++ b/content/browser/renderer_host/media/audio_input_device_manager.cc
@@ -9,6 +9,7 @@
 
 #include "base/command_line.h"
 #include "base/functional/bind.h"
+#include "base/logging.h"
 #include "base/functional/callback.h"
 #include "base/metrics/histogram_macros.h"
 #include "base/observer_list.h"
@@ -109,6 +110,7 @@ void AudioInputDeviceManager::UnregisterListener(
 
 base::UnguessableToken AudioInputDeviceManager::Open(
     const blink::MediaStreamDevice& device) {
+  LOG(INFO) << "SAMSUNG DEBUG - AudioInputDeviceManager::Open called";
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
   // Generate a new id for this device.
   auto session_id = base::UnguessableToken::Create();

--- a/content/browser/renderer_host/media/media_stream_dispatcher_host.cc
+++ b/content/browser/renderer_host/media/media_stream_dispatcher_host.cc
@@ -8,6 +8,7 @@
 
 #include "base/check_op.h"
 #include "base/command_line.h"
+#include "base/logging.h"
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/task/bind_post_task.h"
@@ -422,6 +423,7 @@ void MediaStreamDispatcherHost::GenerateStreams(
     bool user_gesture,
     blink::mojom::StreamSelectionInfoPtr audio_stream_selection_info_ptr,
     GenerateStreamsCallback callback) {
+  LOG(INFO) << "SAMSUNG DEBUG - MediaStreamDispatcherHost::GenerateStreams called";
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   const absl::optional<bad_message::BadMessageReason> bad_message =
@@ -472,6 +474,7 @@ void MediaStreamDispatcherHost::DoGenerateStreams(
     blink::mojom::StreamSelectionInfoPtr audio_stream_selection_info_ptr,
     GenerateStreamsCallback callback,
     GenerateStreamsUIThreadCheckResult ui_check_result) {
+  LOG(INFO) << "SAMSUNG DEBUG - MediaStreamDispatcherHost::DoGenerateStreams called";
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
 
   if (!ui_check_result.request_allowed) {

--- a/content/browser/renderer_host/media/media_stream_manager.cc
+++ b/content/browser/renderer_host/media/media_stream_manager.cc
@@ -1787,6 +1787,7 @@ void MediaStreamManager::GenerateStreams(
     DeviceCaptureConfigurationChangeCallback
         device_capture_configuration_change_cb,
     DeviceCaptureHandleChangeCallback device_capture_handle_change_cb) {
+  LOG(INFO) << "SAMSUNG DEBUG - MediaStreamManager::GenerateStreams called";
   DCHECK_CURRENTLY_ON(BrowserThread::IO);
   SendLogMessage(GetGenerateStreamsLogString(render_process_id, render_frame_id,
                                              requester_id, page_request_id));

--- a/media/audio/audio_input_device.cc
+++ b/media/audio/audio_input_device.cc
@@ -477,6 +477,9 @@ void AudioInputDevice::AudioThreadCallback::Process(uint32_t pending_data) {
   const base::TimeTicks now_time = base::TimeTicks::Now();
   DCHECK_GE(now_time, capture_time);
 
+  LOG(INFO) << "SAMSUNG DEBUG - Renderer Received: " << audio_bus->frames()
+            << " frames @ " << audio_parameters_.sample_rate() << "Hz";
+
   AudioGlitchInfo glitch_info{
       .duration = base::Microseconds(buffer->params.glitch_duration_us),
       .count = buffer->params.glitch_count};

--- a/media/audio/starboard/audio_manager_starboard.cc
+++ b/media/audio/starboard/audio_manager_starboard.cc
@@ -110,9 +110,10 @@ AudioParameters AudioManagerStarboard::GetPreferredOutputStreamParameters(
 AudioInputStream* AudioManagerStarboard::MakeInputStream(
     const AudioParameters& params,
     const std::string& device_id) {
-  SB_LOG(INFO) << "AudioManagerStarboard::MakeInputStream() - rate="
-               << params.sample_rate() << ", channels=" << params.channels()
-               << ", format=" << params.format();
+  SB_LOG(INFO)
+      << "SAMSUNG DEBUG - AudioManagerStarboard::MakeInputStream() - rate="
+      << params.sample_rate() << ", channels=" << params.channels()
+      << ", format=" << params.format();
   return new AudioInputStreamStarboard(this, params);
 }
 

--- a/media/webrtc/audio_processor.cc
+++ b/media/webrtc/audio_processor.cc
@@ -626,6 +626,8 @@ AudioParameters AudioProcessor::GetDefaultOutputFormat(
 #if BUILDFLAG(IS_CASTOS) || BUILDFLAG(IS_CAST_ANDROID)
                                    std::min(media::kAudioProcessingSampleRateHz,
                                             input_format.sample_rate())
+#elif BUILDFLAG(IS_COBALT)
+                                   input_format.sample_rate()                                   
 #else
                                    media::kAudioProcessingSampleRateHz
 #endif

--- a/media/webrtc/audio_processor.cc
+++ b/media/webrtc/audio_processor.cc
@@ -627,7 +627,7 @@ AudioParameters AudioProcessor::GetDefaultOutputFormat(
                                    std::min(media::kAudioProcessingSampleRateHz,
                                             input_format.sample_rate())
 #elif BUILDFLAG(IS_COBALT)
-                                   input_format.sample_rate()                                   
+                                   input_format.sample_rate()
 #else
                                    media::kAudioProcessingSampleRateHz
 #endif

--- a/third_party/blink/renderer/modules/media/audio/mojo_audio_input_ipc.cc
+++ b/third_party/blink/renderer/modules/media/audio/mojo_audio_input_ipc.cc
@@ -8,6 +8,7 @@
 
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
+#include "base/logging.h"
 #include "base/metrics/histogram_macros.h"
 #include "media/audio/audio_device_description.h"
 #include "media/mojo/common/input_error_code_converter.h"
@@ -112,6 +113,7 @@ void MojoAudioInputIPC::StreamCreated(
     media::mojom::blink::ReadOnlyAudioDataPipePtr data_pipe,
     bool initially_muted,
     const absl::optional<base::UnguessableToken>& stream_id) {
+  LOG(INFO) << "SAMSUNG DEBUG - MojoAudioInputIPC::StreamCreated called";
   DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
   DCHECK(delegate_);
   DCHECK(!stream_);

--- a/third_party/blink/renderer/modules/mediastream/media_devices.cc
+++ b/third_party/blink/renderer/modules/mediastream/media_devices.cc
@@ -7,6 +7,7 @@
 #include <utility>
 
 #include "base/guid.h"
+#include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
 #include "build/build_config.h"
 #include "mojo/public/cpp/bindings/remote.h"
@@ -409,6 +410,7 @@ ScriptPromise MediaDevices::getUserMedia(
     ScriptState* script_state,
     const UserMediaStreamConstraints* options,
     ExceptionState& exception_state) {
+  LOG(INFO) << "SAMSUNG DEBUG - MediaDevices::getUserMedia called";
   // This timeout of base::Seconds(8) is an initial value and based on the data
   // in Media.MediaDevices.GetUserMedia.Latency, it should be iterated upon.
   auto* resolver = MakeGarbageCollected<
@@ -436,6 +438,8 @@ ScriptPromise MediaDevices::SendUserMediaRequest(
     ScriptPromiseResolverWithTracker<UserMediaRequestResult>* resolver,
     const MediaStreamConstraints* options,
     ExceptionState& exception_state) {
+  LOG(INFO) << "SAMSUNG DEBUG - MediaDevices::SendUserMediaRequest called, media_type="
+            << static_cast<int>(media_type);
   DCHECK(!exception_state.HadException());
 
   ScriptState* script_state = resolver->GetScriptState();

--- a/third_party/blink/renderer/modules/mediastream/user_media_processor.cc
+++ b/third_party/blink/renderer/modules/mediastream/user_media_processor.cc
@@ -581,6 +581,7 @@ UserMediaRequest* UserMediaProcessor::CurrentRequest() {
 
 void UserMediaProcessor::ProcessRequest(UserMediaRequest* request,
                                         base::OnceClosure callback) {
+  LOG(INFO) << "SAMSUNG DEBUG - UserMediaProcessor::ProcessRequest called";
   DCHECK(!request_completed_cb_);
   DCHECK(!current_request_info_);
   request_completed_cb_ = std::move(callback);
@@ -600,6 +601,7 @@ void UserMediaProcessor::ProcessRequest(UserMediaRequest* request,
 }
 
 void UserMediaProcessor::SetupAudioInput() {
+  LOG(INFO) << "SAMSUNG DEBUG - UserMediaProcessor::SetupAudioInput called";
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   DCHECK(current_request_info_);
   DCHECK(current_request_info_->request()->Audio());
@@ -943,6 +945,7 @@ void UserMediaProcessor::SelectVideoContentSettings() {
 void UserMediaProcessor::GenerateStreamForCurrentRequestInfo(
     absl::optional<base::UnguessableToken> requested_audio_capture_session_id,
     blink::mojom::StreamSelectionStrategy strategy) {
+  LOG(INFO) << "SAMSUNG DEBUG - UserMediaProcessor::GenerateStreamForCurrentRequestInfo called";
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   DCHECK(current_request_info_);
   SendLogMessage(base::StringPrintf(

--- a/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
+++ b/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
@@ -34,9 +34,15 @@ WebAudioMediaStreamAudioSink::WebAudioMediaStreamAudioSink(
   // do not have one and they will inject their own |sink_params_| for testing.
   WebLocalFrame* const web_frame = WebLocalFrame::FrameForCurrentContext();
   if (web_frame) {
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+    sink_params_.Reset(media::AudioParameters::AUDIO_PCM_LOW_LATENCY,
+                       media::ChannelLayoutConfig::Mono(),
+                       context_sample_rate, kWebAudioRenderBufferSize);
+#else
     sink_params_.Reset(media::AudioParameters::AUDIO_PCM_LOW_LATENCY,
                        media::ChannelLayoutConfig::Stereo(),
                        context_sample_rate, kWebAudioRenderBufferSize);
+#endif
   }
   // Connect the source provider to the track as a sink.
   WebMediaStreamAudioSink::AddToAudioTrack(
@@ -116,7 +122,7 @@ void WebAudioMediaStreamAudioSink::OnData(
 
 void WebAudioMediaStreamAudioSink::SetClient(
     WebAudioSourceProviderClient* client) {
-  NOTREACHED();
+  LOG(INFO) << "SAMSUNG DEBUG - WebAudioMediaStreamAudioSink::SetClient called with " << client;
 }
 
 void WebAudioMediaStreamAudioSink::ProvideInput(
@@ -147,10 +153,11 @@ void WebAudioMediaStreamAudioSink::ProvideInput(
     return;
 
   LOG(INFO) << "SAMSUNG DEBUG - Sink ProvideInput: " << number_of_frames
-            << " frames. FIFO Level: " << (fifo_ ? (int)fifo_->frames() : -1);
-
+            << " frames. FIFO Level: " << (fifo_ ? (int)fifo_->frames() : -1)
+            << ", calling Convert";
   is_enabled_ = true;
   audio_converter_->Convert(output_wrapper_.get());
+  LOG(INFO) << "SAMSUNG DEBUG - Sink ProvideInput: Convert returned";
 }
 
 // |lock_| needs to be acquired before this function is called. It's called by

--- a/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
+++ b/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
@@ -15,7 +15,7 @@
 #include "third_party/blink/renderer/platform/media/web_audio_source_provider_client.h"
 
 namespace {
-static const size_t kMaxNumberOfAudioFifoBuffers = 10;
+static const size_t kMaxNumberOfAudioFifoBuffers = 50;
 }
 
 namespace blink {

--- a/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
+++ b/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
@@ -107,6 +107,7 @@ void WebAudioMediaStreamAudioSink::OnData(
   } else {
     // This can happen if the data in FIFO is too slowly consumed or
     // WebAudio stops consuming data.
+    LOG(INFO) << "SAMSUNG DEBUG - Sink FIFO full (Level: " << fifo_->frames() << "). Dropped " << audio_bus.frames() << " frames.";
     DVLOG(3) << "Local source provicer FIFO is full" << fifo_->frames();
     TRACE_EVENT0(TRACE_DISABLED_BY_DEFAULT("mediastream"),
                  "WebAudioMediaStreamAudioSink::OnData FIFO full");
@@ -145,6 +146,9 @@ void WebAudioMediaStreamAudioSink::ProvideInput(
   if (!audio_converter_)
     return;
 
+  LOG(INFO) << "SAMSUNG DEBUG - Sink ProvideInput: " << number_of_frames
+            << " frames. FIFO Level: " << (fifo_ ? (int)fifo_->frames() : -1);
+
   is_enabled_ = true;
   audio_converter_->Convert(output_wrapper_.get());
 }
@@ -164,6 +168,8 @@ double WebAudioMediaStreamAudioSink::ProvideInput(
   if (fifo_->frames() >= audio_bus->frames()) {
     fifo_->Consume(audio_bus, 0, audio_bus->frames());
   } else {
+    LOG(INFO) << "SAMSUNG DEBUG - Sink Starvation! FIFO has " << fifo_->frames()
+              << ", need " << audio_bus->frames();
     audio_bus->Zero();
     TRACE_EVENT1(TRACE_DISABLED_BY_DEFAULT("mediastream"),
                  "WebAudioMediaStreamAudioSink::ProvideInput underrun",

--- a/third_party/blink/renderer/modules/webaudio/audio_context.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_context.cc
@@ -193,6 +193,14 @@ AudioContext* AudioContext::Create(Document& document,
     }
   }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  if (!sample_rate.has_value() || sample_rate.value() != 16000.0f) {
+    LOG(INFO) << "Cobalt: Force-setting sample rate to 16000";
+    sample_rate = 16000.0f;
+  }
+  sink_descriptor = WebAudioSinkDescriptor(frame_token);
+#endif
+
   // Validate options before trying to construct the actual context.
   if (sample_rate.has_value() &&
       !audio_utilities::IsValidAudioBufferSampleRate(sample_rate.value())) {

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
@@ -14,9 +14,11 @@ namespace blink {
 
 namespace {
 
+#if !BUILDFLAG(USE_STARBOARD_MEDIA)
 // Default to stereo. This could change depending on the format of the
 // MediaStream's audio track.
 constexpr unsigned kDefaultNumberOfOutputChannels = 2;
+#endif
 
 }  // namespace
 
@@ -28,7 +30,13 @@ MediaStreamAudioSourceHandler::MediaStreamAudioSourceHandler(
                    node.context()->sampleRate()),
       audio_source_provider_(std::move(audio_source_provider)) {
   SendLogMessage(String::Format("%s", __func__));
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  AddOutput(1);
+  SetInternalChannelCountMode(ChannelCountMode::kExplicit);
+  channel_count_ = 1;
+#else
   AddOutput(kDefaultNumberOfOutputChannels);
+#endif
 
   Initialize();
 }

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
@@ -102,8 +102,13 @@ MediaStreamAudioSourceNode* MediaStreamAudioSourceNode::Create(
       MakeGarbageCollected<MediaStreamAudioSourceNode>(
           context, media_stream, audio_track, std::move(provider));
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Initializes the node with the mono output channel.
+  node->SetFormat(1, context.sampleRate());
+#else
   // Initializes the node with the stereo output channel.
   node->SetFormat(2, context.sampleRate());
+#endif
 
   // Lets the context know this source node started.
   context.NotifySourceNodeStartedProcessing(node);


### PR DESCRIPTION
Backport some performance changes from Cobalt 27.

Forces 16kHz mono throughout WebAudio to bypass resample and mixer

Bug: 479656309