### PR TITLE
starboard: Remove unnecessary starboard:: namespace prefixes

### DIFF
--- a/starboard/android/shared/application_android.cc
+++ b/starboard/android/shared/application_android.cc
@@ -62,7 +62,7 @@ ApplicationAndroid::ApplicationAndroid(
     const std::string& cache_dir,
     const std::string& native_library_dir)
     : Application(stubSbEventHandle) {
-  starboard::StarboardBridge::GetInstance()->SetStartupMilestone(6);
+  StarboardBridge::GetInstance()->SetStartupMilestone(6);
   SetCommandLine(std::move(command_line));
   // Initialize Time Zone early so that local time works correctly.
   // Called once here to help SbTimeZoneGet*Name()

--- a/starboard/android/shared/media_codec.cc
+++ b/starboard/android/shared/media_codec.cc
@@ -83,7 +83,7 @@ DefaultMediaCodecFactory::CreateVideoMediaCodec(
   if (decoder_name.empty()) {
     return Failure(
         FormatString("Failed to find decoder: mime=%s, mustSupportSecure=%s",
-                     mime, starboard::ToString(!!j_media_crypto).data()));
+                     mime, ToString(!!j_media_crypto).data()));
   }
 
   // We only use Java MediaCodec (JNI) for now.
@@ -138,30 +138,27 @@ FrameSize::FrameSize(Size display_size, bool has_crop_values)
 
 std::ostream& operator<<(std::ostream& os, const FrameSize& size) {
   return os << "{display_size=" << size.display_size
-            << ", has_crop_values=" << starboard::ToString(size.has_crop_values)
-            << "}";
+            << ", has_crop_values=" << ToString(size.has_crop_values) << "}";
 }
 
 std::ostream& operator<<(std::ostream& os,
                          const MediaCodec::VideoPlatformOptions& options) {
   return os << "{max_input_size=" << options.max_input_size
             << ", skip_video_frames_over_60_fps="
-            << starboard::ToString(options.skip_video_frames_over_60_fps)
+            << ToString(options.skip_video_frames_over_60_fps)
             << ", ignore_mediacodec_callbacks_during_flushing="
-            << starboard::ToString(
-                   options.ignore_mediacodec_callbacks_during_flushing)
+            << ToString(options.ignore_mediacodec_callbacks_during_flushing)
             << ", enable_frame_renderer_listener="
-            << starboard::ToString(options.enable_frame_renderer_listener)
-            << ", enable_low_latency="
-            << starboard::ToString(options.enable_low_latency)
+            << ToString(options.enable_frame_renderer_listener)
+            << ", enable_low_latency=" << ToString(options.enable_low_latency)
             << ", require_secured_decoder="
-            << starboard::ToString(options.require_secured_decoder)
+            << ToString(options.require_secured_decoder)
             << ", require_software_codec="
-            << starboard::ToString(options.require_software_codec)
+            << ToString(options.require_software_codec)
             << ", force_big_endian_hdr_metadata="
-            << starboard::ToString(options.force_big_endian_hdr_metadata)
+            << ToString(options.force_big_endian_hdr_metadata)
             << ", tunnel_mode_audio_session_id="
-            << starboard::ToString(options.tunnel_mode_audio_session_id) << "}";
+            << ToString(options.tunnel_mode_audio_session_id) << "}";
 }
 
 }  // namespace starboard


### PR DESCRIPTION
Eliminate unnecessary starboard:: qualifiers in files where the code
is already within the starboard namespace. This cleanup targets the
Android shared application and media codec implementations to improve
readability and adhere to standard C++ namespace usage.

Issue: 150410605