### PR TITLE
cobalt: enable zero-copy from Oilpan heap

### DIFF
--- a/third_party/blink/common/features.cc
+++ b/third_party/blink/common/features.cc
@@ -445,6 +445,14 @@ BASE_FEATURE(kClientHintsXRFormFactor,
              "ClientHintsXRFormFactor",
              base::FEATURE_DISABLED_BY_DEFAULT);
 
+#if BUILDFLAG(IS_COBALT)
+// Enables zero-copy pass-through of network fetch responses in Cobalt by
+// bypassing BufferingBytesConsumer Oilpan heap buffering.
+BASE_FEATURE(kCobaltBypassBufferingBytesConsumer,
+             "CobaltBypassBufferingBytesConsumer",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+#endif  // BUILDFLAG(IS_COBALT)
+
 // Enable legacy `viewport-width` client hint.
 BASE_FEATURE(kClientHintsViewportWidth_DEPRECATED,
              "ClientHintsViewportWidth_DEPRECATED",

--- a/third_party/blink/public/common/features.h
+++ b/third_party/blink/public/common/features.h
@@ -233,6 +233,10 @@ BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kClientHintsViewportWidth_DEPRECATED);
 
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kClientHintsXRFormFactor);
 
+#if BUILDFLAG(IS_COBALT)
+BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kCobaltBypassBufferingBytesConsumer);
+#endif  // BUILDFLAG(IS_COBALT)
+
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE(kCompressParkableStrings);
 BLINK_COMMON_EXPORT BASE_DECLARE_FEATURE_PARAM(int,
                                                kMaxDiskDataAllocatorCapacityMB);

--- a/third_party/blink/renderer/core/fetch/fetch_manager.cc
+++ b/third_party/blink/renderer/core/fetch/fetch_manager.cc
@@ -809,6 +809,9 @@ void FetchManager::Loader::DidReceiveCachedMetadata(mojo_base::BigBuffer data) {
 
 void FetchManager::Loader::DidStartLoadingResponseBody(BytesConsumer& body) {
   if (GetFetchRequestData()->Integrity().empty() &&
+#if BUILDFLAG(IS_COBALT)
+      !base::FeatureList::IsEnabled(features::kCobaltBypassBufferingBytesConsumer) &&
+#endif  // BUILDFLAG(IS_COBALT)
       !response_has_no_store_header_) {
     // BufferingBytesConsumer reads chunks from |bytes_consumer| as soon as
     // they get available to relieve backpressure.  Buffering starts after


### PR DESCRIPTION
Introduce the CobaltBypassBufferingBytesConsumer feature flag to enable
zero-copy pass-through of network fetch responses. By bypassing the
BufferingBytesConsumer, Cobalt can avoid unnecessary buffering on the
Oilpan heap, reducing memory pressure and improving data transfer
efficiency for fetch operations.

Issue: 532673378