### PR TITLE
Set Dolby Vision policy to 1 before running on RDK

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -231,6 +231,13 @@ def package_and_deploy(
     Path(archive_name).unlink(missing_ok=True)
 
 
+def ensure_dolby_vision_policy(device_id: Optional[str], device_ip: Optional[str]) -> None:
+    """Ensures /sys/module/aml_media/parameters/dolby_vision_policy is set to 1."""
+    # TODO(b/532753892): Remove this workaround once the device driver is updated.
+    policy_file = "/sys/module/aml_media/parameters/dolby_vision_policy"
+    run_remote_command(f"echo 1 > {policy_file}", device_id, device_ip)
+
+
 def launch_on_device(
     device_id: Optional[str],
     device_ip: Optional[str],
@@ -781,6 +788,7 @@ def main() -> None:
             deployed_archive = True
 
     if args.run:
+        ensure_dolby_vision_policy(device_id, device_ip)
         launch_on_device(
             device_id,
             device_ip,


### PR DESCRIPTION
This PR adds a workaround to configure the Dolby Vision policy on Amlogic RDK devices before launching Cobalt.

### Changes:
- Adds `ensure_dolby_vision_policy` to unconditionally write `1` to `/sys/module/aml_media/parameters/dolby_vision_policy` before running Cobalt.
- Works in both **ADB** and **SSH** connection modes.
- Adds a TODO referencing bug 532753892 to remove this workaround once the device driver is updated.

Bug: 532753892

TAG=agy
CONV=e3d4c794-091a-4ae7-8cd1-810eebeb07ee