### PR TITLE
Add no-autoroll-conflicts pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -145,3 +145,10 @@ repos:
         entry: gn format
         language: system
         files: '.*\.gni?$'
+    -   id: no-autoroll-conflicts
+        name: Check for CONFLICT
+        description: Ensures autoroller is rolling.
+        entry: 'CONFLICT'
+        language: pygrep
+        types: [text]
+        files: ^\.github/AUTOROLL$


### PR DESCRIPTION
Introduce a new check for the presence of the CONFLICT string
in the AUTOROLL file to ensure the autoroller isn't blocked.

Bug: 522987128