### PR TITLE
drm: Fix crash due to empty session_id access

### DIFF
--- a/media/starboard/starboard_cdm.cc
+++ b/media/starboard/starboard_cdm.cc
@@ -307,31 +307,30 @@ void StarboardCdm::OnSessionUpdateRequestGenerated(
     // Called back as a result of |SbDrmGenerateSessionUpdateRequest|.
 
     // Restore the context of |GenerateSessionUpdateRequest|.
-    auto session_update_request_iterator =
+    auto session_update_request_it =
         ticket_to_session_update_request_map_.find(ticket);
-    if (session_update_request_iterator ==
+    if (session_update_request_it ==
         ticket_to_session_update_request_map_.end()) {
       LOG(INFO) << "Unknown session update request ticket: " << ticket << ".";
       return;
     }
 
-    auto session_request = std::move(session_update_request_iterator->second);
-
-    if (session_id) {
-      session_list_.push_back(session_id.value());
-      promises_.ResolvePromise(session_request.promise_id, session_id.value());
-    } else {
+    auto session_request = std::move(session_update_request_it->second);
+    ticket_to_session_update_request_map_.erase(session_update_request_it);
+    if (!session_id) {
       // Failure during request generation.
-      LOG(INFO) << "Calling session update request callback on drm system ("
-                << sb_drm_ << "), status: " << status
-                << ", error message: " << error_message;
+      LOG(ERROR)
+          << "Failure during session update request generation on drm system ("
+          << sb_drm_ << "), status: " << status
+          << ", error message: " << error_message;
       promises_.RejectPromise(session_request.promise_id,
                               CdmPromise::Exception::INVALID_STATE_ERROR, 0,
                               "Failure during request generation.");
+      return;
     }
 
-    ticket_to_session_update_request_map_.erase(
-        session_update_request_iterator);
+    session_list_.push_back(session_id.value());
+    promises_.ResolvePromise(session_request.promise_id, session_id.value());
 
   } else {
     // Called back spontaneously by the underlying DRM system.


### PR DESCRIPTION
drm: Fix crash on empty session ID access

The StarboardCdm class was experiencing a crash due to a bad optional
access in OnSessionUpdateRequestGenerated. This occurs when the
underlying media session fails to generate a request, resulting in an
empty session ID being passed to the callback.

This was observed on RDK, while accessing videos on channel
https://www.youtube.com/@bodedrmchannel2958

Crash reported:
```
   std::__Cr::__libcpp_verbose_abort() [0xf38898ad]
   std::__Cr::__throw_bad_optional_access() [0xf017b16f]
   media::StarboardCdm::OnSessionUpdateRequestGenerated() [0xf05f69e1]
   base::internal::DecayedFunctorTraits<>::Invoke<>() [0xf05f741f]
   base::internal::Invoker<>::RunOnce() [0xf05f7381]
```

```
WPEProcess[4798]: [OCDM][Widevine]generateRequest failed
WPEProcess[4798]: [OCDM][Widevine]exists? cert.bin: false
WPEProcess[4798]: [OCDM][Widevine]generateRequest failed
WPEFramework[4798]: [ERROR:../../../cdm/src/cdm.cpp(676):generateRequest] No such session:
WPEProcess[4798]: [OCDM][Widevine]exists? cert.bin: false
WPEProcess[4798]: [OCDM][Widevine]generateRequest failed
WPEFramework[4798]: [ERROR:../../../cdm/src/cdm.cpp(676):generateRequest] No such session:
WPEProcess[4798]: [OCDM][Widevine]exists? cert.bin: false`
```

Bug: 532716116
Change-Id: I8a8e836e001d6038f3d901a4821fb93f1b761b71