### PR TITLE
cleanup: Remove build guard for new handler path

### DIFF
--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -78,7 +78,7 @@ base::FilePath GetPathToCrashpadHandlerBinary() {
 #if defined(OS_ANDROID)
   // Path to the extracted native library.
   handler_path.append("arm/libcrashpad_handler.so");
-#else  // defined(OS_ANDROID)
+#else   // defined(OS_ANDROID)
   handler_path.append("native_target/crashpad_handler");
 #endif  // defined(OS_ANDROID)
   return base::FilePath(handler_path.c_str());

--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -79,13 +79,7 @@ base::FilePath GetPathToCrashpadHandlerBinary() {
   // Path to the extracted native library.
   handler_path.append("arm/libcrashpad_handler.so");
 #else  // defined(OS_ANDROID)
-#if BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-  // TODO: b/406511608 - we probably want to be able to expect the binary to be
-  // in the executable directory itself, without the native_target subdir.
   handler_path.append("native_target/crashpad_handler");
-#else   // BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
-  handler_path.append("crashpad_handler");
-#endif  // BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS)
 #endif  // defined(OS_ANDROID)
   return base::FilePath(handler_path.c_str());
 }


### PR DESCRIPTION
The Crashpad handler executable is now expected to be under a "native_target" parent directory, which is itself alongside the loader app executable. This was originally thought of as a "hack" but we have sinced aligned on the decision to promote this path as our new stanard (see #9841).

Issue: 476394156