### PR TITLE
fix: Preserve siginfo when Crashpad re-raises sig

### DIFF
--- a/third_party/crashpad/crashpad/util/posix/signals.cc
+++ b/third_party/crashpad/crashpad/util/posix/signals.cc
@@ -321,12 +321,13 @@ void Signals::RestoreHandlerAndReraiseSignalOnReturn(
 #if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
 
   // TODO: b/406511608 - Cobalt: Re-enable if we decide to install Crashpad
-  // signal handlers from the Cobalt layer in hermetic builds.
-#if BUILDFLAG(IS_LINUX) && BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) && \
-    !BUILDFLAG(IS_STARBOARD_TOOLCHAIN)
-  // Falls through to the raise() logic below, avoiding compiler errors
-  // resulting from the syscall.
-#else
+  // signal handlers from the Cobalt layer in hermetic builds. For now in
+  // hermetic builds, we properly re-raise signals with siginfo in Starboard
+  // toolchain-built loader app, from which the Crashpad signal handlers are
+  // actually installed, and bypass the syscall in the Cobalt layer where it
+  // 1) is not needed and 2) introduces compiler errors.
+#if !BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) || \
+    BUILDFLAG(IS_STARBOARD_TOOLCHAIN)
   int retval = syscall(SYS_rt_tgsigqueueinfo,
                        getpid(),
                        syscall(SYS_gettid),
@@ -344,8 +345,8 @@ void Signals::RestoreHandlerAndReraiseSignalOnReturn(
   if (errno != EPERM) {
     _exit(kFailureExitCode);
   }
-#endif  // BUILDFLAG(IS_LINUX) && BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) && \
-        // !BUILDFLAG(IS_STARBOARD_TOOLCHAIN)
+#endif  // !BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) || \
+        // BUILDFLAG(IS_STARBOARD_TOOLCHAIN)
 
 #endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID) ||
         // BUILDFLAG(IS_CHROMEOS)

--- a/third_party/crashpad/crashpad/util/posix/signals.cc
+++ b/third_party/crashpad/crashpad/util/posix/signals.cc
@@ -318,12 +318,15 @@ void Signals::RestoreHandlerAndReraiseSignalOnReturn(
   // signals that do not re-raise autonomously), such as signals delivered via
   // kill() and asynchronous hardware faults such as SEGV_MTEAERR, which would
   // otherwise be lost when re-raising the signal via raise().
-// TODO: (cobalt b/406511608) Re-enable if we decide to install Crashpad signal
-// handlers from the Cobalt layer in hermetic builds.
-#if BUILDFLAG(IS_LINUX) &&                       \
-    (!BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) || \
-     BUILDFLAG(IS_STARBOARD_TOOLCHAIN)) ||       \
-    BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
+#if BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
+
+  // TODO: b/406511608 - Cobalt: Re-enable if we decide to install Crashpad
+  // signal handlers from the Cobalt layer in hermetic builds.
+#if BUILDFLAG(IS_LINUX) && BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) && \
+    !BUILDFLAG(IS_STARBOARD_TOOLCHAIN)
+  // Falls through to the raise() logic below, avoiding compiler errors
+  // resulting from the syscall.
+#else
   int retval = syscall(SYS_rt_tgsigqueueinfo,
                        getpid(),
                        syscall(SYS_gettid),
@@ -341,10 +344,11 @@ void Signals::RestoreHandlerAndReraiseSignalOnReturn(
   if (errno != EPERM) {
     _exit(kFailureExitCode);
   }
-#endif  // BUILDFLAG(IS_LINUX) &&
-        // (!BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) ||
-        //  BUILDFLAG(IS_STARBOARD_TOOLCHAIN)) ||
-        // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
+#endif  // BUILDFLAG(IS_LINUX) && BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) && \
+        // !BUILDFLAG(IS_STARBOARD_TOOLCHAIN)
+
+#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID) ||
+        // BUILDFLAG(IS_CHROMEOS)
 
   // Explicitly re-raise the signal if it will not re-raise itself. Because
   // signal handlers normally execute with their signal blocked, this raise()

--- a/third_party/crashpad/crashpad/util/posix/signals.cc
+++ b/third_party/crashpad/crashpad/util/posix/signals.cc
@@ -318,8 +318,12 @@ void Signals::RestoreHandlerAndReraiseSignalOnReturn(
   // signals that do not re-raise autonomously), such as signals delivered via
   // kill() and asynchronous hardware faults such as SEGV_MTEAERR, which would
   // otherwise be lost when re-raising the signal via raise().
-// TODO: (cobalt b/406511608) Re-enable once we use crashpad in hermetic builds.
-#if BUILDFLAG(IS_LINUX) && !BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) || BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
+// TODO: (cobalt b/406511608) Re-enable if we decide to install Crashpad signal
+// handlers from the Cobalt layer in hermetic builds.
+#if BUILDFLAG(IS_LINUX) &&                       \
+    (!BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) || \
+     BUILDFLAG(IS_STARBOARD_TOOLCHAIN)) ||       \
+    BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
   int retval = syscall(SYS_rt_tgsigqueueinfo,
                        getpid(),
                        syscall(SYS_gettid),
@@ -337,8 +341,10 @@ void Signals::RestoreHandlerAndReraiseSignalOnReturn(
   if (errno != EPERM) {
     _exit(kFailureExitCode);
   }
-#endif  // BUILDFLAG(IS_LINUX) || BUILDFLAG(IS_ANDROID) ||
-        // BUILDFLAG(IS_CHROMEOS)
+#endif  // BUILDFLAG(IS_LINUX) &&
+        // (!BUILDFLAG(ENABLE_COBALT_HERMETIC_HACKS) ||
+        //  BUILDFLAG(IS_STARBOARD_TOOLCHAIN)) ||
+        // BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_CHROMEOS)
 
   // Explicitly re-raise the signal if it will not re-raise itself. Because
   // signal handlers normally execute with their signal blocked, this raise()


### PR DESCRIPTION
We still wan to avoid building this code path when building libcobalt (with the default toolchain) in hermetic builds, as it introduces a compilation error. But we should build it when building the loader app with the starboard toolchain, so that signals are properly re-raised, with siginfo information, after they are handled by Crashpad. This information may be useful for other signal handlers on the system, for example for b/481094002.

Issue: 476394156