### PR TITLE
media: Backport webaudio fixes to Cobalt26

### DIFF
--- a/base/sync_socket_posix.cc
+++ b/base/sync_socket_posix.cc
@@ -179,7 +179,9 @@ size_t SyncSocket::Peek() {
   ssize_t number_chars = recv(handle_.get(), buffer.data(), buffer.size(),
                               MSG_PEEK | MSG_TRUNC | MSG_DONTWAIT);
   if (number_chars < 0) {
-    PLOG(ERROR) << "recv failed in SyncSocket::Peek";
+    if (errno != EAGAIN && errno != EWOULDBLOCK) {
+      PLOG(ERROR) << "recv failed in SyncSocket::Peek";
+    }
     return 0;
   }
   return checked_cast<size_t>(number_chars);

--- a/media/webrtc/audio_processor.cc
+++ b/media/webrtc/audio_processor.cc
@@ -626,6 +626,8 @@ AudioParameters AudioProcessor::GetDefaultOutputFormat(
 #if BUILDFLAG(IS_CASTOS) || BUILDFLAG(IS_CAST_ANDROID)
                                    std::min(media::kAudioProcessingSampleRateHz,
                                             input_format.sample_rate())
+#elif BUILDFLAG(IS_COBALT)
+                                   input_format.sample_rate()
 #else
                                    media::kAudioProcessingSampleRateHz
 #endif

--- a/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
+++ b/third_party/blink/renderer/modules/mediastream/webaudio_media_stream_audio_sink.cc
@@ -15,7 +15,11 @@
 #include "third_party/blink/renderer/platform/media/web_audio_source_provider_client.h"
 
 namespace {
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+static const size_t kMaxNumberOfAudioFifoBuffers = 50;
+#else
 static const size_t kMaxNumberOfAudioFifoBuffers = 10;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 namespace blink {
@@ -35,7 +39,11 @@ WebAudioMediaStreamAudioSink::WebAudioMediaStreamAudioSink(
   WebLocalFrame* const web_frame = WebLocalFrame::FrameForCurrentContext();
   if (web_frame) {
     sink_params_.Reset(media::AudioParameters::AUDIO_PCM_LOW_LATENCY,
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+                       media::ChannelLayoutConfig::Mono(),
+#else
                        media::ChannelLayoutConfig::Stereo(),
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
                        context_sample_rate, kWebAudioRenderBufferSize);
   }
   // Connect the source provider to the track as a sink.

--- a/third_party/blink/renderer/modules/webaudio/audio_context.cc
+++ b/third_party/blink/renderer/modules/webaudio/audio_context.cc
@@ -193,6 +193,14 @@ AudioContext* AudioContext::Create(Document& document,
     }
   }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  if (!sample_rate.has_value() || sample_rate.value() != 16000.0f) {
+    LOG(INFO) << "Cobalt: Force-setting sample rate to 16000";
+    sample_rate = 16000.0f;
+  }
+  sink_descriptor = WebAudioSinkDescriptor(frame_token);
+#endif
+
   // Validate options before trying to construct the actual context.
   if (sample_rate.has_value() &&
       !audio_utilities::IsValidAudioBufferSampleRate(sample_rate.value())) {

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
@@ -15,6 +15,9 @@ namespace blink {
 namespace {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+// Cobalt/Starboard performance tweak. We forces mono here for our use case of
+// recording from a microphone. Otherwise the webaudio graph upmixes to stereo
+// which is ultimately downmixed again, and which has significant overhead.
 constexpr unsigned kDefaultNumberOfOutputChannels = 1;
 #else
 // Default to stereo. This could change depending on the format of the

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_handler.cc
@@ -14,9 +14,13 @@ namespace blink {
 
 namespace {
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+constexpr unsigned kDefaultNumberOfOutputChannels = 1;
+#else
 // Default to stereo. This could change depending on the format of the
 // MediaStream's audio track.
 constexpr unsigned kDefaultNumberOfOutputChannels = 2;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 }  // namespace
 
@@ -29,6 +33,10 @@ MediaStreamAudioSourceHandler::MediaStreamAudioSourceHandler(
       audio_source_provider_(std::move(audio_source_provider)) {
   SendLogMessage(String::Format("%s", __func__));
   AddOutput(kDefaultNumberOfOutputChannels);
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  SetInternalChannelCountMode(ChannelCountMode::kExplicit);
+  channel_count_ = kDefaultNumberOfOutputChannels;
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   Initialize();
 }

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
@@ -103,7 +103,10 @@ MediaStreamAudioSourceNode* MediaStreamAudioSourceNode::Create(
           context, media_stream, audio_track, std::move(provider));
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  // Initializes the node with the mono output channel.
+  // Initializes the node with the mono output channel. this is a performance
+  // optimization to avoid upmixing from mono recording (which is ultimately
+  // discarded). It has to match kDefaultNumberOfOutputChannels defined in
+  // ./media_stream_audio_source_handler.cc
   node->SetFormat(1, context.sampleRate());
 #else
   // Initializes the node with the stereo output channel.

--- a/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
+++ b/third_party/blink/renderer/modules/webaudio/media_stream_audio_source_node.cc
@@ -102,8 +102,13 @@ MediaStreamAudioSourceNode* MediaStreamAudioSourceNode::Create(
       MakeGarbageCollected<MediaStreamAudioSourceNode>(
           context, media_stream, audio_track, std::move(provider));
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Initializes the node with the mono output channel.
+  node->SetFormat(1, context.sampleRate());
+#else
   // Initializes the node with the stereo output channel.
   node->SetFormat(2, context.sampleRate());
+#endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Lets the context know this source node started.
   context.NotifySourceNodeStartedProcessing(node);


### PR DESCRIPTION
This PR backports some essential WebAudio performance fixes from:
https://github.com/youtube/cobalt/pull/9978

It forces a 16kHz sample rate and mono channel layout across the WebAudio
pipeline (to match the recording settings) when Starboard media is enabled.
This optimization bypasses unnecessary resampling and mixing stages, 
reducing CPU load and latency, which are essential when capturing from the 
microphone on a resource constrained device.

Additionally, increase the maximum number of audio FIFO buffers to
improve playback stability and introduce diagnostic logging to monitor
audio stream health.

Bug: 479656309