### PR TITLE
android: Add Java switch for buffering bypass

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -86,6 +86,10 @@ public class JavaSwitches {
   /** Avoid reuse resource. */
   public static final String AVOID_CC_REUSE_RESOURCE = "AvoidCCReuseResource";
 
+  /** flag to bypass BufferingBytesConsumer Oilpan heap buffering. */
+  public static final String COBALT_BYPASS_BUFFERING_BYTES_CONSUMER =
+      "CobaltBypassBufferingBytesConsumer";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
     StringJoiner jsFlags = new StringJoiner(";");
@@ -195,6 +199,11 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.AVOID_CC_REUSE_RESOURCE)) {
       extraCommandLineArgs.add("--avoid-cc-reuse-resource");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.COBALT_BYPASS_BUFFERING_BYTES_CONSUMER)) {
+      extraCommandLineArgs.add(
+          "--enable-features=" + JavaSwitches.COBALT_BYPASS_BUFFERING_BYTES_CONSUMER);
     }
 
     return extraCommandLineArgs;


### PR DESCRIPTION
Add the CobaltBypassBufferingBytesConsumer constant to JavaSwitches and
map it to the corresponding command line feature flag. This change
enables zero-copy pass-through of network fetch responses via Java
feature switches on Android, allowing the system to bypass Oilpan heap
buffering in BufferingBytesConsumer.

TAG=agy
CONV=753c0a7b-b76b-4d64-af6c-62ee2d4522e0
Issue: 532673378