### PR TITLE
Adds chromium_cherry_pick function to autoroller.

### DIFF
--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -10,12 +10,12 @@ import sys
 
 
 @enum.unique
-class CherryPickStatus(enum.Enum):
-  """Represents the outcome of a cherry-pick attempt."""
-  SUCCESS = 'success'  # Successfully cherry-picked and committed.
-  CONFLICTED = 'conflicted'  # Cherry-picked and committed with conflicts.
+class CommitStatus(enum.Enum):
+  """Represents the outcome of a commit attempt."""
+  SUCCESS = 'success'  # Successfully committed.
+  CONFLICTED = 'conflicted'  # Committed with conflicts.
   SKIPPED = 'skipped'  # The commit was already present or no action was needed.
-  FAILED = 'failed'  # The cherry-pick failed due to conflicts or other errors.
+  FAILED = 'failed'  # The commit failed due to conflicts or other errors.
 
 
 def log(msg):
@@ -175,28 +175,66 @@ def get_cherry_pick_metadata(sha, title, pr_num):
   return date, author, msg
 
 
-def cherry_pick(sha, title, pr_num, first_cherry_pick, autoroll_file):
-  """Attempts to cherry-pick a single commit.
+def get_submodule_root_dirs():
+  paths = get_out(
+      ['git', 'config', '--file', '.gitmodules', '--get-regexp', 'path'])
+
+  return sorted(
+      {line.split(' ', 1)[1].split('/')[0] for line in paths.splitlines()})
+
+
+def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
+                         autoroll_file):
+  """Temporarily reverts Cobalt before applying a Chromium cherry pick."""
+  log('Deleting everything...')
+  roots = get_submodule_root_dirs()
+  if roots:
+    run(['rm', '-rf', '--'] + roots)
+  run(['git', 'rm', '-rf', '--', '.'])
+  run(['git', 'clean', '-ffdx'])
+
+  log(f'Checking out clean Chromium state: {previous_sha}')
+  run(['git', 'checkout', previous_sha, '--', '.'])
+
+  log('Committing Cobalt revert...')
+  run(['git', 'add', '--', '.'])
+  run(['git', 'commit', '--no-verify', '-m', 'Reverting Cobalt.'])
+  cobalt_revert_sha = get_out(['git', 'rev-parse', 'HEAD']).strip()
+
+  log('Cherry picking Chromium...')
+  run(['git', 'cherry-pick', sha])
+
+  log('Reverting Cobalt revert...')
+  return revert(cobalt_revert_sha, metadata, first_commit, autoroll_file)
+
+
+def cherry_pick(sha, metadata, first_commit, autoroll_file):
+  return apply_and_commit('cherry-pick', sha, metadata, first_commit,
+                          autoroll_file)
+
+
+def revert(sha, metadata, first_commit, autoroll_file):
+  return apply_and_commit('revert', sha, metadata, first_commit, autoroll_file)
+
+
+def apply_and_commit(action, sha, metadata, first_commit, autoroll_file):
+  """Attempts to apply a single commit.
 
   Returns:
-    CherryPickStatus: Enum indicating the outcome of the operation.
-      - SUCCESS: Successfully cherry-picked and committed.
-      - CONFLICTED: Cherry-picked and committed with conflicts.
+    CommitStatus: Enum indicating the outcome of the operation.
+      - SUCCESS: Successfully committed.
+      - CONFLICTED: Committed with conflicts.
       - SKIPPED: The commit was already present or no action was needed.
-      - FAILED: The cherry-pick failed due to conflicts or other errors.
+      - FAILED: The commit failed due to conflicts or other errors.
     unmerged_files: List of files with conflicts.
   """
-  date, author, msg = get_cherry_pick_metadata(sha, title, pr_num)
-
-  result = CherryPickStatus.SUCCESS
+  date, author, msg = metadata
+  result = CommitStatus.SUCCESS
   unmerged_files = None
 
-  cmd = ['git', 'cherry-pick', '--no-commit']
-  if len(get_out(['git', 'show', '-s', '--format=%P', sha]).split()) > 1:
-    cmd.append('--mainline=1')
-
+  # Apply
   try:
-    run(cmd + [sha])
+    run(['git', action, '--no-commit', sha])
   except subprocess.CalledProcessError:
     unmerged_files = get_unmerged_files()
     if resolve_conflicts(unmerged_files):
@@ -204,29 +242,30 @@ def cherry_pick(sha, title, pr_num, first_cherry_pick, autoroll_file):
     else:
       unmerged_files = list(unmerged_files)
 
-      if not first_cherry_pick:
+      if not first_commit:
         run(['git', 'reset', '--hard', 'HEAD'])
-        return CherryPickStatus.FAILED, unmerged_files
+        return CommitStatus.FAILED, unmerged_files
 
       run(['git', 'add', '--'] + unmerged_files)
       msg = f'CONFLICTED {msg}'
-      result = CherryPickStatus.CONFLICTED
+      result = CommitStatus.CONFLICTED
 
   # Check if there are changes to commit
   if not get_out(['git', 'diff', '--cached', '--name-only']).strip():
-    log('Cherry pick skipped.')
-    return CherryPickStatus.SKIPPED, unmerged_files
+    log('Commit skipped.')
+    return CommitStatus.SKIPPED, unmerged_files
 
   # Update autoroll file
   with open(autoroll_file, 'w', encoding='utf-8') as f:
-    if result == CherryPickStatus.CONFLICTED:
+    if result == CommitStatus.CONFLICTED:
       f.write(f'CONFLICTED:{sha}\n')
     else:
       f.write(f'{sha}\n')
   run(['git', 'add', '--', autoroll_file])
 
+  # Commit
   run([
-      'git', 'commit', '--no-verify', f'--author={author}', f'--date={date}',
+      'git', 'commit', '--no-verify', f'--date={date}', f'--author={author}',
       '-m', msg
   ])
   return result, unmerged_files
@@ -244,7 +283,7 @@ def main():
   autoroll_start = get_start_sha('HEAD', args.autoroll_file)
 
   if autoroll_start is None:
-    log('Autoroll branch has an unresolved CONFLICTED cherry pick.')
+    log('Autoroll branch has an unresolved CONFLICTED commit.')
     return
 
   # Commits in source but not in target
@@ -255,6 +294,7 @@ def main():
   shas_to_autoroll = {sha for sha, _, _ in commits_to_autoroll}
 
   commits_added = []
+  previous_sha = target_start
 
   for sha, title, pr_num in commits_to_target:
     if len(commits_added) >= args.max_commits:
@@ -266,25 +306,35 @@ def main():
     # Skip if already in autoroll
     if sha not in shas_to_autoroll:
       commits_added.append(identifier)
+      previous_sha = sha
       continue
 
-    # Cherry pick PR
-    first_cherry_pick = not commits_added
-    result, unmerged_files = cherry_pick(sha, title, pr_num, first_cherry_pick,
-                                         args.autoroll_file)
+    # Commit PR
+    metadata = get_cherry_pick_metadata(sha, title, pr_num)
+    first_commit = not commits_added
 
-    if result in (CherryPickStatus.SUCCESS, CherryPickStatus.CONFLICTED):
+    if args.source_branch.startswith('chromium/'):
+      result, unmerged_files = chromium_cherry_pick(previous_sha, sha, metadata,
+                                                    first_commit,
+                                                    args.autoroll_file)
+    else:
+      result, unmerged_files = cherry_pick(sha, metadata, first_commit,
+                                           args.autoroll_file)
+
+    if result in (CommitStatus.SUCCESS, CommitStatus.CONFLICTED):
       commits_added.append(identifier)
-      if result == CherryPickStatus.CONFLICTED:
+      if result == CommitStatus.CONFLICTED:
         commits_added.append('')
         commits_added.append('CONFLICTED files:')
         commits_added.append('```')
         commits_added.extend(unmerged_files)
         commits_added.append('```')
 
-    if result in (CherryPickStatus.FAILED, CherryPickStatus.CONFLICTED):
-      log(f'Reached CONFLICTED cherry pick ({sha}).')
+    if result in (CommitStatus.FAILED, CommitStatus.CONFLICTED):
+      log(f'Reached CONFLICTED commit ({sha}).')
       break
+
+    previous_sha = sha
 
   if commits_added:
     print('\n'.join(commits_added))

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -185,7 +185,25 @@ def get_submodule_root_dirs():
 
 def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
                          autoroll_file):
-  """Temporarily reverts Cobalt before applying a Chromium cherry pick."""
+  """Temporarily reverts Cobalt changes to apply a Chromium cherry-pick.
+
+  This function performs a "clean slate" cherry-pick by wiping the current
+  working directory, checking out the pure Chromium state at `previous_sha`,
+  and committing that as a temporary revert. It then applies the desired
+  Chromium `sha` and re-applies Cobalt's modifications over the result.
+
+  Args:
+    previous_sha: The SHA of the clean Chromium base before Cobalt changes were
+      applied.
+    sha: The SHA of the Chromium commit to be cherry-picked.
+    metadata: Metadata associated with the cherry-pick, passed to the final
+      conflicting revert call.
+    first_commit: boolean flag indicating if it's the first commit in the PR.
+    autoroll_file: Path to the file that tracks autoroll progress.
+
+  Returns:
+    CommitStatus and unmerged_files.
+  """
   log('Deleting everything...')
   roots = get_submodule_root_dirs()
   if roots:
@@ -198,7 +216,10 @@ def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
 
   log('Committing Cobalt revert...')
   run(['git', 'add', '--', '.'])
-  run(['git', 'commit', '--no-verify', '-m', 'Reverting Cobalt.'])
+  run([
+      'git', 'commit', '--no-verify', '-m',
+      'CONFLICTED Chromium Cherry pick: Reverting Cobalt.'
+  ])
   cobalt_revert_sha = get_out(['git', 'rev-parse', 'HEAD']).strip()
 
   log('Cherry picking Chromium...')
@@ -277,6 +298,7 @@ def main():
   p.add_argument('--target-branch', required=True)
   p.add_argument('--autoroll-file', required=True)
   p.add_argument('--max-commits', type=int, required=True)
+  p.add_argument('--existing-pr-sha', required=True)
   args = p.parse_args()
 
   target_start = get_start_sha(args.target_branch, args.autoroll_file)
@@ -285,6 +307,14 @@ def main():
   if autoroll_start is None:
     log('Autoroll branch has an unresolved CONFLICTED commit.')
     return
+
+  if args.existing_pr_sha:
+    commit_title = get_out(
+        ['git', 'log', '-1', args.existing_pr_sha, '--format=%s']).strip()
+    if commit_title.startswith('CONFLICTED'):
+      log('Autoroll branch has a resolved CONFLICTED commit. '
+          'Squash and merge before autoroll will continue.')
+      return
 
   # Commits in source but not in target
   commits_to_target = get_commits(args.source_branch, target_start)

--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -64,6 +64,16 @@ jobs:
           # Fetch enough history for source branch.
           git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules origin "${SOURCE_BRANCH}:${SOURCE_BRANCH}"
 
+      - name: Get Existing PR Info
+        id: pr_info
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+        run: |
+          # Get the first commit SHA of the existing PR.
+          # If the PR doesn't exist, it returns an empty string.
+          FIRST_SHA=$(gh pr view "autoroll-${{ matrix.branch.source }}-to-${{ matrix.branch.target }}" --json commits --jq '.commits[0].oid' 2>/dev/null || echo "")
+          echo "first_sha=$FIRST_SHA" >> "$GITHUB_OUTPUT"
+
       - name: Cherry Pick Merged PRs
         id: autoroll
         env:
@@ -77,6 +87,7 @@ jobs:
             --target-branch "${{ matrix.branch.target }}" \
             --autoroll-file "${{ matrix.branch.autoroll }}" \
             --max-commits "${{ env.MAX_COMMITS }}")
+            --existing-pr-sha "${{ steps.pr_info.outputs.first_sha }}")
 
           if [[ -n "${PR_LINKS}" ]]; then
             echo "cherry_picked=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
When autorolling from Chromium branches, the chromium_cherry_pick function is called which reverts all Cobalt changes to cleanly apply the Chromium cherry-pick before reapplying all Cobalt changes. This improves readability of direct Chromium cherry-pick conflicts.

Bug: 522987128