### PR TITLE
media: Fix missing mime type in mojo bypass

### DIFF
--- a/media/base/mock_filters.cc
+++ b/media/base/mock_filters.cc
@@ -76,6 +76,16 @@ void MockDemuxerStream::set_liveness(StreamLiveness liveness) {
   liveness_ = liveness;
 }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+std::string MockDemuxerStream::mime_type() const {
+  return mime_type_;
+}
+
+void MockDemuxerStream::set_mime_type(const std::string& mime_type) {
+  mime_type_ = mime_type;
+}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 MockVideoDecoder::MockVideoDecoder() : MockVideoDecoder(0) {}
 
 MockVideoDecoder::MockVideoDecoder(int decoder_id)

--- a/media/base/mock_filters.h
+++ b/media/base/mock_filters.h
@@ -221,16 +221,25 @@ class MockDemuxerStream : public DemuxerStream {
   VideoDecoderConfig video_decoder_config() override;
   MOCK_METHOD0(EnableBitstreamConverter, void());
   MOCK_METHOD0(SupportsConfigChanges, bool());
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  std::string mime_type() const override;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   void set_audio_decoder_config(const AudioDecoderConfig& config);
   void set_video_decoder_config(const VideoDecoderConfig& config);
   void set_liveness(StreamLiveness liveness);
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  void set_mime_type(const std::string& mime_type);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
  private:
   Type type_ = DemuxerStream::Type::UNKNOWN;
   StreamLiveness liveness_ = StreamLiveness::kUnknown;
   AudioDecoderConfig audio_decoder_config_;
   VideoDecoderConfig video_decoder_config_;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  std::string mime_type_;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 class MockVideoDecoder : public VideoDecoder {

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
@@ -80,7 +80,7 @@ bool MojoRendererBypassBridge::Read(DemuxerStream::Type type,
       std::move(read_cb).Run(DemuxerStream::kAborted, {});
       return false;
     }
-    stream = (type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_);
+    stream = GetStreamLocked(type);
     if (stream) {
       in_flight_reads_++;
     }
@@ -129,8 +129,7 @@ bool MojoRendererBypassBridge::SupportsConfigChanges(
   if (!active_) {
     return false;
   }
-  DemuxerStream* stream =
-      (type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_);
+  DemuxerStream* stream = GetStreamLocked(type);
   return stream ? stream->SupportsConfigChanges() : false;
 }
 
@@ -140,9 +139,31 @@ StreamLiveness MojoRendererBypassBridge::GetLiveness(
   if (!active_) {
     return StreamLiveness::kUnknown;
   }
-  DemuxerStream* stream =
-      (type == DemuxerStream::AUDIO ? audio_stream_ : video_stream_);
+  DemuxerStream* stream = GetStreamLocked(type);
   return stream ? stream->liveness() : StreamLiveness::kUnknown;
+}
+
+std::string MojoRendererBypassBridge::GetMimeType(
+    DemuxerStream::Type type) const {
+  base::AutoLock auto_lock(lock_);
+  if (!active_) {
+    return "";
+  }
+  DemuxerStream* stream = GetStreamLocked(type);
+  return stream ? stream->mime_type() : "";
+}
+
+void MojoRendererBypassBridge::EnableBitstreamConverter(
+    DemuxerStream::Type type) {
+  base::AutoLock auto_lock(lock_);
+  if (!active_) {
+    return;
+  }
+  DemuxerStream* stream = GetStreamLocked(type);
+  if (!stream) {
+    return;
+  }
+  stream->EnableBitstreamConverter();
 }
 
 void MojoRendererBypassBridge::RunTimeUpdateOnClientThread(
@@ -171,6 +192,17 @@ void MojoRendererBypassBridge::DecrementInFlightReads() {
   if (in_flight_reads_ == 0) {
     cond_var_.Signal();
   }
+}
+
+DemuxerStream* MojoRendererBypassBridge::GetStreamLocked(
+    DemuxerStream::Type type) const {
+  if (type == DemuxerStream::AUDIO) {
+    return audio_stream_;
+  }
+  if (type == DemuxerStream::VIDEO) {
+    return video_stream_;
+  }
+  return nullptr;
 }
 
 // static

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
@@ -86,6 +86,8 @@ class MojoRendererBypassBridge
   VideoDecoderConfig GetVideoConfig() const;
   bool SupportsConfigChanges(DemuxerStream::Type type) const;
   StreamLiveness GetLiveness(DemuxerStream::Type type) const;
+  std::string GetMimeType(DemuxerStream::Type type) const;
+  void EnableBitstreamConverter(DemuxerStream::Type type);
 
  private:
   friend class base::RefCountedThreadSafe<MojoRendererBypassBridge>;
@@ -100,6 +102,8 @@ class MojoRendererBypassBridge
                   DemuxerStream::Status status,
                   DemuxerStream::DecoderBufferVector buffers);
   void DecrementInFlightReads();
+  DemuxerStream* GetStreamLocked(DemuxerStream::Type type) const
+      EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
   const scoped_refptr<base::SequencedTaskRunner> client_task_runner_;
   const TimeUpdateCB time_update_cb_;

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge_unittest.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge_unittest.cc
@@ -145,5 +145,55 @@ TEST_F(MojoRendererBypassBridgeTest, InvalidateWaitsForRead) {
   invalidate_finished.Wait();
 }
 
+TEST_F(MojoRendererBypassBridgeTest, GetMimeType) {
+  NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
+  NiceMock<MockDemuxerStream> video_stream(DemuxerStream::VIDEO);
+  audio_stream.set_mime_type("audio/mp4");
+  video_stream.set_mime_type("video/mp4");
+
+  bridge_->SetStreams(&audio_stream, &video_stream);
+
+  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::AUDIO), "audio/mp4");
+  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::VIDEO), "video/mp4");
+
+  bridge_->Invalidate();
+  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::AUDIO), "");
+  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::VIDEO), "");
+}
+
+TEST_F(MojoRendererBypassBridgeTest, EnableBitstreamConverter) {
+  NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
+  NiceMock<MockDemuxerStream> video_stream(DemuxerStream::VIDEO);
+
+  bridge_->SetStreams(&audio_stream, &video_stream);
+
+  EXPECT_CALL(audio_stream, EnableBitstreamConverter()).Times(1);
+  EXPECT_CALL(video_stream, EnableBitstreamConverter()).Times(1);
+
+  bridge_->EnableBitstreamConverter(DemuxerStream::AUDIO);
+  bridge_->EnableBitstreamConverter(DemuxerStream::VIDEO);
+
+  bridge_->Invalidate();
+  // Should be a no-op when inactive.
+  bridge_->EnableBitstreamConverter(DemuxerStream::AUDIO);
+}
+
+TEST_F(MojoRendererBypassBridgeTest, UnknownStreamType) {
+  NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
+  NiceMock<MockDemuxerStream> video_stream(DemuxerStream::VIDEO);
+  audio_stream.set_mime_type("audio/mp4");
+  video_stream.set_mime_type("video/mp4");
+
+  bridge_->SetStreams(&audio_stream, &video_stream);
+
+  EXPECT_CALL(audio_stream, EnableBitstreamConverter()).Times(0);
+  EXPECT_CALL(video_stream, EnableBitstreamConverter()).Times(0);
+
+  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::UNKNOWN), "");
+  bridge_->EnableBitstreamConverter(DemuxerStream::UNKNOWN);
+
+  bridge_->Invalidate();
+}
+
 }  // namespace
 }  // namespace media

--- a/media/mojo/services/mojo_renderer_service.cc
+++ b/media/mojo/services/mojo_renderer_service.cc
@@ -59,7 +59,13 @@ class ProxyDemuxerStream : public DemuxerStream {
     return bridge_->SupportsConfigChanges(type_);
   }
 
-  void EnableBitstreamConverter() override {}
+  std::string mime_type() const override {
+    return bridge_->GetMimeType(type_);
+  }
+
+  void EnableBitstreamConverter() override {
+    bridge_->EnableBitstreamConverter(type_);
+  }
 
  private:
   scoped_refptr<MojoRendererBypassBridge> bridge_;


### PR DESCRIPTION
Ensure that the MIME type and bitstream converter settings are correctly
propagated when using the Mojo renderer bypass. This change adds the
necessary plumbing to the MojoRendererBypassBridge and updates the
ProxyDemuxerStream to retrieve this information from the bridge.
MockDemuxerStream is also updated to support these properties in tests.

Issue: 513254071