### PR TITLE
Feature/update client unit test evergreen

### DIFF
--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -37,7 +37,7 @@
 #include "cobalt/app/app_event_delegate.h"
 
 #if BUILDFLAG(USE_EVERGREEN)
-#include "cobalt/updater/updater_module.h"
+#include "cobalt/updater/updater_module.h"  // nogncheck
 #endif
 #include "cobalt/browser/cobalt_content_browser_client.h"
 #include "cobalt/browser/h5vcc_accessibility/h5vcc_accessibility_manager.h"

--- a/components/update_client/BUILD.gn
+++ b/components/update_client/BUILD.gn
@@ -384,7 +384,9 @@ source_set("unit_tests") {
     "//third_party/puffin:libpuffpatch",
     "//third_party/re2",
   ]
-  if (!is_starboard) {
+  if (is_starboard) {
+    deps += [ "//cobalt/updater" ]
+  } else {
     deps += [
       ":in_process_unzipper",
       ":network_impl",

--- a/components/update_client/BUILD.gn
+++ b/components/update_client/BUILD.gn
@@ -207,7 +207,7 @@ static_library("update_client") {
     ]
   }
 
-  if (is_cobalt_hermetic_build) {
+  if (is_starboard) {
     sources += [
       "cobalt_slot_management.cc",
       "cobalt_slot_management.h",
@@ -263,7 +263,6 @@ source_set("test_support") {
 
   deps = [
     ":patch_impl",
-    ":unzip_impl",
     "//base",
     "//components/prefs",
     "//components/services/patch:in_process",
@@ -278,7 +277,10 @@ source_set("test_support") {
   if (is_starboard) {
     deps += [ "//cobalt/updater" ]
   } else {
-    deps += [ ":network_impl" ]
+    deps += [
+      ":network_impl",
+      ":unzip_impl",
+    ]
   }
 
 }
@@ -361,11 +363,9 @@ source_set("unit_tests") {
   }
 
   deps = [
-    ":in_process_unzipper",
     ":patch_impl",
     ":test_support",
     ":unit_tests_bundle_data",
-    ":unzip_impl",
     ":update_client",
     "//base",
     "//build:branding_buildflags",
@@ -385,7 +385,11 @@ source_set("unit_tests") {
     "//third_party/re2",
   ]
   if (!is_starboard) {
-    deps += [ ":network_impl" ]
+    deps += [
+      ":in_process_unzipper",
+      ":network_impl",
+      ":unzip_impl",
+    ]
   }
 
 
@@ -411,7 +415,11 @@ fuzzer_test("update_client_protocol_parser_fuzzer") {
 }
 
 test("update_client_unittests") {
-  sources = [ "//components/test/run_all_unittests.cc" ]
+  if (is_starboard) {
+    sources = [ "//components/test/starboard/run_all_unittests.cc" ]
+  } else {
+    sources = [ "//components/test/run_all_unittests.cc" ]
+  }
   deps = [
     ":unit_tests",
     "//components/test:test_support",

--- a/components/update_client/BUILD.gn
+++ b/components/update_client/BUILD.gn
@@ -202,12 +202,17 @@ static_library("update_client") {
   }
 
   if (is_starboard) {
+    deps += [
+      "//starboard:starboard_headers_only",
+    ]
+  }
+
+  if (is_cobalt_hermetic_build) {
     sources += [
       "cobalt_slot_management.cc",
       "cobalt_slot_management.h",
     ]
     deps += [
-      "//starboard:starboard_headers_only",
       "//starboard/loader_app:app_key_files",
       "//starboard/loader_app:drain_file",
     ]

--- a/components/update_client/BUILD.gn
+++ b/components/update_client/BUILD.gn
@@ -5,6 +5,7 @@
 import("//build/buildflag_header.gni")
 import("//net/features.gni")
 import("//testing/libfuzzer/fuzzer_test.gni")
+import("//testing/test.gni")
 
 source_set("network_impl") {
   sources = [
@@ -201,22 +202,17 @@ static_library("update_client") {
   }
 
   if (is_starboard) {
-    deps += [
-      "//starboard:starboard_headers_only",
-    ]
-  }
-
-  if (is_cobalt_hermetic_build) {
     sources += [
       "cobalt_slot_management.cc",
       "cobalt_slot_management.h",
     ]
-
     deps += [
+      "//starboard:starboard_headers_only",
       "//starboard/loader_app:app_key_files",
       "//starboard/loader_app:drain_file",
     ]
   }
+
 }
 
 if (is_mac) {
@@ -261,7 +257,6 @@ source_set("test_support") {
   public_deps = [ ":update_client" ]
 
   deps = [
-    ":network_impl",
     ":patch_impl",
     ":unzip_impl",
     "//base",
@@ -275,6 +270,12 @@ source_set("test_support") {
     "//testing/gtest",
     "//url",
   ]
+  if (is_starboard) {
+    deps += [ "//cobalt/updater" ]
+  } else {
+    deps += [ ":network_impl" ]
+  }
+
 }
 
 bundle_data("unit_tests_bundle_data") {
@@ -356,7 +357,6 @@ source_set("unit_tests") {
 
   deps = [
     ":in_process_unzipper",
-    ":network_impl",
     ":patch_impl",
     ":test_support",
     ":unit_tests_bundle_data",
@@ -379,6 +379,10 @@ source_set("unit_tests") {
     "//third_party/puffin:libpuffpatch",
     "//third_party/re2",
   ]
+  if (!is_starboard) {
+    deps += [ ":network_impl" ]
+  }
+
 
   data_deps = [ "//components/test/data/update_client/puffin_patch_test:puffin_patch_test_files" ]
 }
@@ -400,3 +404,12 @@ fuzzer_test("update_client_protocol_parser_fuzzer") {
   ]
   seed_corpus = "fuzzer_corpuses/protocol_parser/"
 }
+
+test("update_client_unittests") {
+  sources = [ "//components/test/run_all_unittests.cc" ]
+  deps = [
+    ":unit_tests",
+    "//components/test:test_support",
+  ]
+}
+

--- a/components/update_client/crx_downloader_unittest.cc
+++ b/components/update_client/crx_downloader_unittest.cc
@@ -85,6 +85,9 @@ class CrxDownloaderTest : public testing::Test {
   int interceptor_count_ = 0;
 
   base::ScopedTempDir temp_dir_;
+#if defined(IN_MEMORY_UPDATES)
+  std::string download_dst_;
+#endif
 
  private:
   base::test::TaskEnvironment task_environment_;
@@ -201,15 +204,24 @@ void CrxDownloaderTest::RunThreadsUntilIdle() {
 // Tests that starting a download without a url results in an error.
 TEST_F(CrxDownloaderTest, NoUrl) {
   std::vector<GURL> urls;
+#if defined(IN_MEMORY_UPDATES)
+  crx_downloader_->StartDownload(urls, std::string("abcd"), &download_dst_,
+                                 std::move(callback_));
+#else
   crx_downloader_->StartDownload(urls, std::string("abcd"),
                                  std::move(callback_));
+#endif
   RunThreadsUntilIdle();
 
   EXPECT_EQ(1, num_download_complete_calls_);
   EXPECT_EQ(static_cast<int>(CrxDownloaderError::NO_URL),
             download_complete_result_.error);
   EXPECT_EQ(download_complete_result_.extra_code1, 0);
+#if defined(IN_MEMORY_UPDATES)
+  EXPECT_TRUE(download_dst_.empty());
+#else
   EXPECT_TRUE(download_complete_result_.response.empty());
+#endif
   EXPECT_EQ(0, num_progress_calls_);
 }
 
@@ -217,14 +229,22 @@ TEST_F(CrxDownloaderTest, NoUrl) {
 TEST_F(CrxDownloaderTest, NoHash) {
   std::vector<GURL> urls(1, GURL("http://somehost/somefile"));
 
+#if defined(IN_MEMORY_UPDATES)
+  crx_downloader_->StartDownload(urls, std::string(), &download_dst_, std::move(callback_));
+#else
   crx_downloader_->StartDownload(urls, std::string(), std::move(callback_));
+#endif
   RunThreadsUntilIdle();
 
   EXPECT_EQ(1, num_download_complete_calls_);
   EXPECT_EQ(static_cast<int>(CrxDownloaderError::NO_HASH),
             download_complete_result_.error);
   EXPECT_EQ(download_complete_result_.extra_code1, 0);
+#if defined(IN_MEMORY_UPDATES)
+  EXPECT_TRUE(download_dst_.empty());
+#else
   EXPECT_TRUE(download_complete_result_.response.empty());
+#endif
   EXPECT_EQ(0, num_progress_calls_);
 }
 
@@ -236,8 +256,13 @@ TEST_F(CrxDownloaderTest, OneUrl) {
   const base::FilePath test_file(GetTestFilePath(kTestFileName));
   AddResponse(expected_crx_url, test_file, net::OK);
 
+#if defined(IN_MEMORY_UPDATES)
+  crx_downloader_->StartDownloadFromUrl(
+      expected_crx_url, std::string(hash_jebg), &download_dst_, std::move(callback_));
+#else
   crx_downloader_->StartDownloadFromUrl(
       expected_crx_url, std::string(hash_jebg), std::move(callback_));
+#endif
   RunThreads();
 
   EXPECT_EQ(1, GetInterceptorCount());
@@ -245,10 +270,16 @@ TEST_F(CrxDownloaderTest, OneUrl) {
   EXPECT_EQ(1, num_download_complete_calls_);
   EXPECT_EQ(0, download_complete_result_.error);
   EXPECT_EQ(0, download_complete_result_.extra_code1);
+#if defined(IN_MEMORY_UPDATES)
+  std::string expected_content;
+  EXPECT_TRUE(base::ReadFileToString(test_file, &expected_content));
+  EXPECT_EQ(download_dst_, expected_content);
+#else
   EXPECT_TRUE(ContentsEqual(download_complete_result_.response, test_file));
 
   EXPECT_TRUE(
       DeleteFileAndEmptyParentDirectory(download_complete_result_.response));
+#endif
 
   EXPECT_LE(1, num_progress_calls_);
   EXPECT_EQ(total_bytes_, 1015);
@@ -263,11 +294,20 @@ TEST_F(CrxDownloaderTest, OneUrlBadHash) {
   const base::FilePath test_file(GetTestFilePath(kTestFileName));
   AddResponse(expected_crx_url, test_file, net::OK);
 
+#if defined(IN_MEMORY_UPDATES)
+  crx_downloader_->StartDownloadFromUrl(
+      expected_crx_url,
+      std::string(
+          "813c59747e139a608b3b5fc49633affc6db574373f309f156ea6d27229c0b3f9"),
+      &download_dst_,
+      std::move(callback_));
+#else
   crx_downloader_->StartDownloadFromUrl(
       expected_crx_url,
       std::string(
           "813c59747e139a608b3b5fc49633affc6db574373f309f156ea6d27229c0b3f9"),
       std::move(callback_));
+#endif
   RunThreads();
 
   EXPECT_EQ(1, GetInterceptorCount());
@@ -276,7 +316,11 @@ TEST_F(CrxDownloaderTest, OneUrlBadHash) {
   EXPECT_EQ(static_cast<int>(CrxDownloaderError::BAD_HASH),
             download_complete_result_.error);
   EXPECT_EQ(download_complete_result_.extra_code1, 0);
+#if defined(IN_MEMORY_UPDATES)
+  EXPECT_FALSE(download_dst_.empty());
+#else
   EXPECT_TRUE(download_complete_result_.response.empty());
+#endif
 
   EXPECT_LE(1, num_progress_calls_);
 }
@@ -294,8 +338,13 @@ TEST_F(CrxDownloaderTest, TwoUrls) {
   urls.push_back(expected_crx_url);
   urls.push_back(expected_crx_url);
 
+#if defined(IN_MEMORY_UPDATES)
+  crx_downloader_->StartDownload(urls, std::string(hash_jebg), &download_dst_,
+                                 std::move(callback_));
+#else
   crx_downloader_->StartDownload(urls, std::string(hash_jebg),
                                  std::move(callback_));
+#endif
   RunThreads();
 
   EXPECT_EQ(1, GetInterceptorCount());
@@ -303,10 +352,16 @@ TEST_F(CrxDownloaderTest, TwoUrls) {
   EXPECT_EQ(1, num_download_complete_calls_);
   EXPECT_EQ(0, download_complete_result_.error);
   EXPECT_EQ(0, download_complete_result_.extra_code1);
+#if defined(IN_MEMORY_UPDATES)
+  std::string expected_content;
+  EXPECT_TRUE(base::ReadFileToString(test_file, &expected_content));
+  EXPECT_EQ(download_dst_, expected_content);
+#else
   EXPECT_TRUE(ContentsEqual(download_complete_result_.response, test_file));
 
   EXPECT_TRUE(
       DeleteFileAndEmptyParentDirectory(download_complete_result_.response));
+#endif
 
   EXPECT_LE(1, num_progress_calls_);
 }
@@ -326,8 +381,13 @@ TEST_F(CrxDownloaderTest, TwoUrls_FirstInvalid) {
   urls.push_back(no_file_url);
   urls.push_back(expected_crx_url);
 
+#if defined(IN_MEMORY_UPDATES)
+  crx_downloader_->StartDownload(urls, std::string(hash_jebg), &download_dst_,
+                                 std::move(callback_));
+#else
   crx_downloader_->StartDownload(urls, std::string(hash_jebg),
                                  std::move(callback_));
+#endif
   RunThreads();
 
   EXPECT_EQ(2, GetInterceptorCount());
@@ -335,10 +395,16 @@ TEST_F(CrxDownloaderTest, TwoUrls_FirstInvalid) {
   EXPECT_EQ(1, num_download_complete_calls_);
   EXPECT_EQ(0, download_complete_result_.error);
   EXPECT_EQ(0, download_complete_result_.extra_code1);
+#if defined(IN_MEMORY_UPDATES)
+  std::string expected_content;
+  EXPECT_TRUE(base::ReadFileToString(test_file, &expected_content));
+  EXPECT_EQ(download_dst_, expected_content);
+#else
   EXPECT_TRUE(ContentsEqual(download_complete_result_.response, test_file));
 
   EXPECT_TRUE(
       DeleteFileAndEmptyParentDirectory(download_complete_result_.response));
+#endif
 
   // Expect at least some progress reported by the loader.
   EXPECT_LE(1, num_progress_calls_);
@@ -371,8 +437,13 @@ TEST_F(CrxDownloaderTest, TwoUrls_SecondInvalid) {
   urls.push_back(expected_crx_url);
   urls.push_back(no_file_url);
 
+#if defined(IN_MEMORY_UPDATES)
+  crx_downloader_->StartDownload(urls, std::string(hash_jebg), &download_dst_,
+                                 std::move(callback_));
+#else
   crx_downloader_->StartDownload(urls, std::string(hash_jebg),
                                  std::move(callback_));
+#endif
   RunThreads();
 
   EXPECT_EQ(1, GetInterceptorCount());
@@ -380,10 +451,16 @@ TEST_F(CrxDownloaderTest, TwoUrls_SecondInvalid) {
   EXPECT_EQ(1, num_download_complete_calls_);
   EXPECT_EQ(0, download_complete_result_.error);
   EXPECT_EQ(0, download_complete_result_.extra_code1);
+#if defined(IN_MEMORY_UPDATES)
+  std::string expected_content;
+  EXPECT_TRUE(base::ReadFileToString(test_file, &expected_content));
+  EXPECT_EQ(download_dst_, expected_content);
+#else
   EXPECT_TRUE(ContentsEqual(download_complete_result_.response, test_file));
 
   EXPECT_TRUE(
       DeleteFileAndEmptyParentDirectory(download_complete_result_.response));
+#endif
 
   EXPECT_LE(1, num_progress_calls_);
 
@@ -401,8 +478,13 @@ TEST_F(CrxDownloaderTest, TwoUrls_BothInvalid) {
   urls.push_back(expected_crx_url);
   urls.push_back(expected_crx_url);
 
+#if defined(IN_MEMORY_UPDATES)
+  crx_downloader_->StartDownload(urls, std::string(hash_jebg), &download_dst_,
+                                 std::move(callback_));
+#else
   crx_downloader_->StartDownload(urls, std::string(hash_jebg),
                                  std::move(callback_));
+#endif
   RunThreads();
 
   EXPECT_EQ(2, GetInterceptorCount());
@@ -410,7 +492,11 @@ TEST_F(CrxDownloaderTest, TwoUrls_BothInvalid) {
   EXPECT_EQ(1, num_download_complete_calls_);
   EXPECT_NE(0, download_complete_result_.error);
   EXPECT_EQ(0, download_complete_result_.extra_code1);
+#if defined(IN_MEMORY_UPDATES)
+  EXPECT_TRUE(download_dst_.empty());
+#else
   EXPECT_TRUE(download_complete_result_.response.empty());
+#endif
 
   const auto download_metrics = crx_downloader_->download_metrics();
   ASSERT_EQ(2u, download_metrics.size());

--- a/components/update_client/crx_downloader_unittest.cc
+++ b/components/update_client/crx_downloader_unittest.cc
@@ -8,6 +8,7 @@
 
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
 #include "base/functional/bind.h"
 #include "base/memory/ref_counted.h"
 #include "base/run_loop.h"
@@ -15,9 +16,13 @@
 #include "base/test/task_environment.h"
 #include "build/build_config.h"
 #include "components/update_client/crx_downloader_factory.h"
-#include "components/update_client/net/network_chromium.h"
+#include "components/update_client/network.h"
+#include "components/update_client/persisted_data.h"
+#include "components/update_client/test_configurator.h"
 #include "components/update_client/test_utils.h"
 #include "components/update_client/update_client_errors.h"
+#include "components/prefs/testing_pref_service.h"
+#include "components/update_client/url_fetcher_downloader.h"
 #include "components/update_client/utils.h"
 #include "net/base/net_errors.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
@@ -79,11 +84,15 @@ class CrxDownloaderTest : public testing::Test {
   // Accumulates the number of loads triggered.
   int interceptor_count_ = 0;
 
+  base::ScopedTempDir temp_dir_;
+
  private:
   base::test::TaskEnvironment task_environment_;
-  scoped_refptr<network::SharedURLLoaderFactory>
-      test_shared_url_loader_factory_;
   base::OnceClosure quit_closure_;
+
+  std::unique_ptr<TestingPrefServiceSimple> pref_ =
+      std::make_unique<TestingPrefServiceSimple>();
+  scoped_refptr<update_client::TestConfigurator> config_;
 };
 
 CrxDownloaderTest::CrxDownloaderTest()
@@ -92,24 +101,33 @@ CrxDownloaderTest::CrxDownloaderTest()
       progress_callback_(
           base::BindRepeating(&CrxDownloaderTest::DownloadProgress,
                               base::Unretained(this))),
-      task_environment_(base::test::TaskEnvironment::MainThreadType::IO),
-      test_shared_url_loader_factory_(
-          base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
-              &test_url_loader_factory_)) {}
+      task_environment_(base::test::TaskEnvironment::MainThreadType::IO,
+                        base::test::TaskEnvironment::TimeSource::MOCK_TIME) {
+  RegisterPersistedDataPrefs(pref_->registry());
+  config_ = base::MakeRefCounted<TestConfigurator>(pref_.get());
+}
 
 CrxDownloaderTest::~CrxDownloaderTest() = default;
 
 void CrxDownloaderTest::SetUp() {
+  CHECK(config_);
+  EXPECT_TRUE(temp_dir_.CreateUniqueTempDir());
+#if BUILDFLAG(IS_STARBOARD)
+  SetMockInstallationPath(temp_dir_.GetPath().AsUTF8Unsafe().c_str());
+#endif
   // Do not use the background downloader in these tests.
-  crx_downloader_ =
-      MakeCrxDownloaderFactory(
-          base::MakeRefCounted<NetworkFetcherChromiumFactory>(
-              test_shared_url_loader_factory_,
-              base::BindRepeating([](const GURL& url) { return false; })))
-          ->MakeCrxDownloader(false);
+  auto network_fetcher_factory = config_->GetNetworkFetcherFactory();
+  CHECK(network_fetcher_factory);
+  auto factory = MakeCrxDownloaderFactory(network_fetcher_factory);
+  CHECK(factory);
+#if BUILDFLAG(IS_STARBOARD)
+  crx_downloader_ = factory->MakeCrxDownloader(config_);
+#else
+  crx_downloader_ = factory->MakeCrxDownloader(false);
+#endif
   crx_downloader_->set_progress_callback(progress_callback_);
 
-  test_url_loader_factory_.SetInterceptor(base::BindLambdaForTesting(
+  config_->test_url_loader_factory()->SetInterceptor(base::BindLambdaForTesting(
       [&](const network::ResourceRequest& request) { interceptor_count_++; }));
 }
 
@@ -149,20 +167,24 @@ void CrxDownloaderTest::AddResponse(const GURL& url,
     head->content_length = data.size();
     network::URLLoaderCompletionStatus status(net_error);
     status.decoded_body_length = data.size();
-    test_url_loader_factory_.AddResponse(url, std::move(head), data, status);
+    config_->test_url_loader_factory()->AddResponse(url, std::move(head), data, status);
     return;
   }
 
   EXPECT_NE(net_error, net::OK);
-  test_url_loader_factory_.AddResponse(
+  config_->test_url_loader_factory()->AddResponse(
       url, network::mojom::URLResponseHead::New(), std::string(),
       network::URLLoaderCompletionStatus(net_error));
 }
 
 void CrxDownloaderTest::RunThreads() {
+#if BUILDFLAG(IS_STARBOARD)
+  task_environment_.FastForwardBy(base::Seconds(32));
+#else
   base::RunLoop runloop;
   quit_closure_ = runloop.QuitClosure();
   runloop.Run();
+#endif
 
   // Since some tests need to drain currently enqueued tasks such as network
   // intercepts on the IO thread, run the threads until they are

--- a/components/update_client/op_download_unittest.cc
+++ b/components/update_client/op_download_unittest.cc
@@ -47,6 +47,17 @@ class FakeDownloader : public CrxDownloader {
         result_(result),
         metrics_(metrics) {}
 
+#if defined(IN_MEMORY_UPDATES)
+  base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+    if (result_.has_value()) {
+      *dst = result_.value();
+      OnDownloadComplete(true, {.installation_dir = dest_}, metrics_);
+    } else {
+      OnDownloadComplete(true, {.error = result_.error()}, metrics_);
+    }
+    return base::DoNothing();
+  }
+#else
   base::OnceClosure DoStartDownload(const GURL& url) override {
     if (result_.has_value()) {
       base::WriteFile(dest_, result_.value());
@@ -56,6 +67,7 @@ class FakeDownloader : public CrxDownloader {
     }
     return base::DoNothing();
   }
+#endif
 
 #if BUILDFLAG(IS_STARBOARD)
   void DoCancelDownload() override {}
@@ -154,6 +166,9 @@ class OpDownloadTest : public testing::Test {
                       }),
                       /*is_foreground=*/false, {GURL("http://localhost:111")},
                       length, hash, MakePingCallback(), base::DoNothing(),
+#if defined(IN_MEMORY_UPDATES)
+                      &crx_str_,
+#endif
                       MakeProgressCallback(), {}, MakeDoneCallback());
     runloop_.Run();
   }
@@ -165,6 +180,9 @@ class OpDownloadTest : public testing::Test {
   base::RunLoop runloop_;
 
   std::vector<base::Value::Dict> pings_;
+#if defined(IN_MEMORY_UPDATES)
+  std::string crx_str_;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
   base::expected<OperationResult, CategorizedError> outcome_;
 #else

--- a/components/update_client/op_download_unittest.cc
+++ b/components/update_client/op_download_unittest.cc
@@ -22,6 +22,9 @@
 #include "base/values.h"
 #include "components/prefs/testing_pref_service.h"
 #include "components/update_client/crx_downloader.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/pipeline.h"
+#endif
 #include "components/update_client/crx_downloader_factory.h"
 #include "components/update_client/persisted_data.h"
 #include "components/update_client/test_configurator.h"
@@ -54,6 +57,10 @@ class FakeDownloader : public CrxDownloader {
     return base::DoNothing();
   }
 
+#if BUILDFLAG(IS_STARBOARD)
+  void DoCancelDownload() override {}
+#endif
+
  protected:
   ~FakeDownloader() override = default;
 
@@ -70,8 +77,13 @@ class FakeFactory : public CrxDownloaderFactory {
               const CrxDownloader::DownloadMetrics& metrics)
       : dest_(dest), result_(result), metrics_(metrics) {}
 
+#if BUILDFLAG(IS_STARBOARD)
+  scoped_refptr<CrxDownloader> MakeCrxDownloader(
+      scoped_refptr<Configurator> config) const override {
+#else
   scoped_refptr<CrxDownloader> MakeCrxDownloader(
       bool background_download_enabled) const override {
+#endif
     return base::MakeRefCounted<FakeDownloader>(dest_, result_, metrics_);
   }
 
@@ -113,6 +125,16 @@ class OpDownloadTest : public testing::Test {
         [&](base::Value::Dict ping) { pings_.push_back(std::move(ping)); });
   }
 
+#if BUILDFLAG(IS_STARBOARD)
+  base::OnceCallback<void(base::expected<OperationResult, CategorizedError>)>
+  MakeDoneCallback() {
+    return base::BindLambdaForTesting(
+        [&](base::expected<OperationResult, CategorizedError> outcome) {
+          outcome_ = outcome;
+          runloop_.Quit();
+        });
+  }
+#else
   base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)>
   MakeDoneCallback() {
     return base::BindLambdaForTesting(
@@ -121,6 +143,7 @@ class OpDownloadTest : public testing::Test {
           runloop_.Quit();
         });
   }
+#endif
 
   void Download(scoped_refptr<Configurator> config,
                 int64_t length,
@@ -142,7 +165,11 @@ class OpDownloadTest : public testing::Test {
   base::RunLoop runloop_;
 
   std::vector<base::Value::Dict> pings_;
+#if BUILDFLAG(IS_STARBOARD)
+  base::expected<OperationResult, CategorizedError> outcome_;
+#else
   base::expected<base::FilePath, CategorizedError> outcome_;
+#endif
 };
 
 TEST_F(OpDownloadTest, DownloadSuccess) {

--- a/components/update_client/op_puffin_unittest.cc
+++ b/components/update_client/op_puffin_unittest.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#if !defined(IN_MEMORY_UPDATES)
 #include "components/update_client/op_puffin.h"
 
 #include "base/files/file_path.h"
@@ -309,3 +310,4 @@ TEST_F(PuffOperationTest, OutHashMismatch) {
 }
 
 }  // namespace update_client
+#endif  // !defined(IN_MEMORY_UPDATES)

--- a/components/update_client/op_puffin_unittest.cc
+++ b/components/update_client/op_puffin_unittest.cc
@@ -25,6 +25,50 @@
 
 namespace update_client {
 
+#if BUILDFLAG(IS_STARBOARD)
+base::OnceClosure CallPuffOperation(
+    scoped_refptr<CrxCache> crx_cache,
+    scoped_refptr<Patcher> patcher,
+    base::RepeatingCallback<void(base::Value::Dict)> event_adder,
+    const std::string& old_hash,
+    const std::string& output_hash,
+    const base::FilePath& patch_file,
+    base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)> callback) {
+  OperationResult op_result;
+#if defined(IN_MEMORY_UPDATES)
+  // Not supported
+#else
+  op_result.response = patch_file;
+#endif
+  return PuffOperation(
+      crx_cache, patcher, event_adder, old_hash, output_hash, op_result,
+      base::BindLambdaForTesting(
+          [callback = std::move(callback)](base::expected<OperationResult, CategorizedError> result) mutable {
+            if (result.has_value()) {
+#if defined(IN_MEMORY_UPDATES)
+              std::move(callback).Run(base::FilePath());
+#else
+              std::move(callback).Run(result.value().response);
+#endif
+            } else {
+              std::move(callback).Run(base::unexpected(result.error()));
+            }
+          }));
+}
+#else
+inline base::OnceClosure CallPuffOperation(
+    scoped_refptr<CrxCache> crx_cache,
+    scoped_refptr<Patcher> patcher,
+    base::RepeatingCallback<void(base::Value::Dict)> event_adder,
+    const std::string& old_hash,
+    const std::string& output_hash,
+    const base::FilePath& patch_file,
+    base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)> callback) {
+  return PuffOperation(crx_cache, patcher, event_adder, old_hash, output_hash, patch_file, std::move(callback));
+}
+#endif
+
+
 class PuffOperationTest : public testing::Test {
  private:
   // env_ must be constructed before sequence_checker_.
@@ -72,7 +116,7 @@ TEST_F(PuffOperationTest, Success) {
       base::BindLambdaForTesting([&](base::expected<base::FilePath,
                                                     UnpackerError> r) {
         ASSERT_TRUE(r.has_value());
-        PuffOperation(
+        CallPuffOperation(
             cache,
             base::MakeRefCounted<PatchChromiumFactory>(
                 base::BindRepeating(&patch::LaunchInProcessFilePatcher))
@@ -118,7 +162,7 @@ TEST_F(PuffOperationTest, BadPatch) {
       base::BindLambdaForTesting([&](base::expected<base::FilePath,
                                                     UnpackerError> r) {
         ASSERT_TRUE(r.has_value());
-        PuffOperation(
+        CallPuffOperation(
             cache,
             base::MakeRefCounted<PatchChromiumFactory>(
                 base::BindRepeating(&patch::LaunchInProcessFilePatcher))
@@ -157,7 +201,7 @@ TEST_F(PuffOperationTest, NotInCache) {
   base::FilePath patch_file =
       CopyToTemp("puffin_patch_test/puffin_app_v1_to_v2.puff");
 
-  PuffOperation(
+  CallPuffOperation(
       cache,
       base::MakeRefCounted<PatchChromiumFactory>(
           base::BindRepeating(&patch::LaunchInProcessFilePatcher))
@@ -191,7 +235,7 @@ TEST_F(PuffOperationTest, NoCache) {
   base::FilePath patch_file =
       CopyToTemp("puffin_patch_test/puffin_app_v1_to_v2.puff");
 
-  PuffOperation(
+  CallPuffOperation(
       base::MakeRefCounted<CrxCache>(std::nullopt),
       base::MakeRefCounted<PatchChromiumFactory>(
           base::BindRepeating(&patch::LaunchInProcessFilePatcher))
@@ -235,7 +279,7 @@ TEST_F(PuffOperationTest, OutHashMismatch) {
       base::BindLambdaForTesting([&](base::expected<base::FilePath,
                                                     UnpackerError> r) {
         ASSERT_TRUE(r.has_value());
-        PuffOperation(
+        CallPuffOperation(
             cache,
             base::MakeRefCounted<PatchChromiumFactory>(
                 base::BindRepeating(&patch::LaunchInProcessFilePatcher))

--- a/components/update_client/op_xz_unittest.cc
+++ b/components/update_client/op_xz_unittest.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#if !defined(IN_MEMORY_UPDATES)
 #include "components/update_client/op_xz.h"
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/pipeline.h"
@@ -149,3 +150,4 @@ TEST_F(XzOperationTest, BadPatch) {
 }
 
 }  // namespace update_client
+#endif  // !defined(IN_MEMORY_UPDATES)

--- a/components/update_client/op_xz_unittest.cc
+++ b/components/update_client/op_xz_unittest.cc
@@ -19,7 +19,12 @@
 #include "base/test/task_environment.h"
 #include "base/types/expected.h"
 #include "components/update_client/test_utils.h"
-#include "components/update_client/unzip/in_process_unzipper.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "cobalt/updater/unzipper.h"  // nogncheck
+#endif
+#if !BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/unzip/in_process_unzipper.h"  // nogncheck
+#endif
 #include "components/update_client/unzipper.h"
 #include "components/update_client/update_client_errors.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -97,9 +102,13 @@ class XzOperationTest : public testing::Test {
 
 TEST_F(XzOperationTest, Success) {
   base::FilePath in_file = CopyToTemp("file1.xz");
+#if BUILDFLAG(IS_STARBOARD)
+  CallXzOperation(base::MakeRefCounted<cobalt::updater::UnzipperFactory>()->Create(),
+#else
   CallXzOperation(base::MakeRefCounted<InProcessUnzipperFactory>(
                   InProcessUnzipperFactory::SymlinkOption::DONT_PRESERVE)
                   ->Create(),
+#endif
               MakePingCallback(), in_file,
               base::BindLambdaForTesting(
                   [&](base::expected<base::FilePath, CategorizedError> result) {
@@ -118,9 +127,13 @@ TEST_F(XzOperationTest, Success) {
 
 TEST_F(XzOperationTest, BadPatch) {
   base::FilePath in_file = CopyToTemp("file1");
+#if BUILDFLAG(IS_STARBOARD)
+  CallXzOperation(base::MakeRefCounted<cobalt::updater::UnzipperFactory>()->Create(),
+#else
   CallXzOperation(base::MakeRefCounted<InProcessUnzipperFactory>(
                   InProcessUnzipperFactory::SymlinkOption::DONT_PRESERVE)
                   ->Create(),
+#endif
               MakePingCallback(), in_file,
               base::BindLambdaForTesting(
                   [&](base::expected<base::FilePath, CategorizedError> result) {

--- a/components/update_client/op_xz_unittest.cc
+++ b/components/update_client/op_xz_unittest.cc
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 #include "components/update_client/op_xz.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/pipeline.h"
+#endif
 
 #include <string>
 #include <vector>
@@ -22,6 +25,44 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace update_client {
+
+#if BUILDFLAG(IS_STARBOARD)
+base::OnceClosure CallXzOperation(
+    std::unique_ptr<Unzipper> unzipper,
+    base::RepeatingCallback<void(base::Value::Dict)> event_adder,
+    const base::FilePath& in_file,
+    base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)> callback) {
+  OperationResult op_result;
+#if defined(IN_MEMORY_UPDATES)
+  // Not supported
+#else
+  op_result.response = in_file;
+#endif
+  return XzOperation(
+      std::move(unzipper), event_adder, op_result,
+      base::BindLambdaForTesting(
+          [callback = std::move(callback)](base::expected<OperationResult, CategorizedError> result) mutable {
+            if (result.has_value()) {
+#if defined(IN_MEMORY_UPDATES)
+              std::move(callback).Run(base::FilePath());
+#else
+              std::move(callback).Run(result.value().response);
+#endif
+            } else {
+              std::move(callback).Run(base::unexpected(result.error()));
+            }
+          }));
+}
+#else
+inline base::OnceClosure CallXzOperation(
+    std::unique_ptr<Unzipper> unzipper,
+    base::RepeatingCallback<void(base::Value::Dict)> event_adder,
+    const base::FilePath& in_file,
+    base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)> callback) {
+  return XzOperation(std::move(unzipper), event_adder, in_file, std::move(callback));
+}
+#endif
+
 
 class XzOperationTest : public testing::Test {
  private:
@@ -56,7 +97,7 @@ class XzOperationTest : public testing::Test {
 
 TEST_F(XzOperationTest, Success) {
   base::FilePath in_file = CopyToTemp("file1.xz");
-  XzOperation(base::MakeRefCounted<InProcessUnzipperFactory>(
+  CallXzOperation(base::MakeRefCounted<InProcessUnzipperFactory>(
                   InProcessUnzipperFactory::SymlinkOption::DONT_PRESERVE)
                   ->Create(),
               MakePingCallback(), in_file,
@@ -77,7 +118,7 @@ TEST_F(XzOperationTest, Success) {
 
 TEST_F(XzOperationTest, BadPatch) {
   base::FilePath in_file = CopyToTemp("file1");
-  XzOperation(base::MakeRefCounted<InProcessUnzipperFactory>(
+  CallXzOperation(base::MakeRefCounted<InProcessUnzipperFactory>(
                   InProcessUnzipperFactory::SymlinkOption::DONT_PRESERVE)
                   ->Create(),
               MakePingCallback(), in_file,

--- a/components/update_client/op_zucchini_unittest.cc
+++ b/components/update_client/op_zucchini_unittest.cc
@@ -2,6 +2,7 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#if !defined(IN_MEMORY_UPDATES)
 #include "components/update_client/op_zucchini.h"
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/pipeline.h"
@@ -317,3 +318,4 @@ TEST_F(ZucchiniOperationTest, OutHashMismatch) {
 }
 
 }  // namespace update_client
+#endif  // !defined(IN_MEMORY_UPDATES)

--- a/components/update_client/op_zucchini_unittest.cc
+++ b/components/update_client/op_zucchini_unittest.cc
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 #include "components/update_client/op_zucchini.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/pipeline.h"
+#endif
 
 #include <optional>
 #include <string>
@@ -30,6 +33,50 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace update_client {
+
+#if BUILDFLAG(IS_STARBOARD)
+base::OnceClosure CallZucchiniOperation(
+    scoped_refptr<CrxCache> crx_cache,
+    scoped_refptr<Patcher> patcher,
+    base::RepeatingCallback<void(base::Value::Dict)> event_adder,
+    const std::string& previous_hash,
+    const std::string& output_hash,
+    const base::FilePath& patch_file,
+    base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)> callback) {
+  OperationResult op_result;
+#if defined(IN_MEMORY_UPDATES)
+  // Not supported
+#else
+  op_result.response = patch_file;
+#endif
+  return ZucchiniOperation(
+      crx_cache, patcher, event_adder, previous_hash, output_hash, op_result,
+      base::BindLambdaForTesting(
+          [callback = std::move(callback)](base::expected<OperationResult, CategorizedError> result) mutable {
+            if (result.has_value()) {
+#if defined(IN_MEMORY_UPDATES)
+              std::move(callback).Run(base::FilePath());
+#else
+              std::move(callback).Run(result.value().response);
+#endif
+            } else {
+              std::move(callback).Run(base::unexpected(result.error()));
+            }
+          }));
+}
+#else
+inline base::OnceClosure CallZucchiniOperation(
+    scoped_refptr<CrxCache> crx_cache,
+    scoped_refptr<Patcher> patcher,
+    base::RepeatingCallback<void(base::Value::Dict)> event_adder,
+    const std::string& previous_hash,
+    const std::string& output_hash,
+    const base::FilePath& patch_file,
+    base::OnceCallback<void(base::expected<base::FilePath, CategorizedError>)> callback) {
+  return ZucchiniOperation(crx_cache, patcher, event_adder, previous_hash, output_hash, patch_file, std::move(callback));
+}
+#endif
+
 
 class ZucchiniOperationTest : public testing::Test {
  private:
@@ -78,7 +125,7 @@ TEST_F(ZucchiniOperationTest, Success) {
       base::BindLambdaForTesting([&](base::expected<base::FilePath,
                                                     UnpackerError> r) {
         ASSERT_TRUE(r.has_value());
-        ZucchiniOperation(
+        CallZucchiniOperation(
             cache,
             base::MakeRefCounted<PatchChromiumFactory>(
                 base::BindRepeating(&patch::LaunchInProcessFilePatcher))
@@ -123,7 +170,7 @@ TEST_F(ZucchiniOperationTest, BadPatch) {
       base::BindLambdaForTesting([&](base::expected<base::FilePath,
                                                     UnpackerError> r) {
         ASSERT_TRUE(r.has_value());
-        ZucchiniOperation(
+        CallZucchiniOperation(
             cache,
             base::MakeRefCounted<PatchChromiumFactory>(
                 base::BindRepeating(&patch::LaunchInProcessFilePatcher))
@@ -162,7 +209,7 @@ TEST_F(ZucchiniOperationTest, NotInCache) {
   base::FilePath patch_file =
       CopyToTemp("zucchini_patch_test/app1_to_app2.zucchini");
 
-  ZucchiniOperation(
+  CallZucchiniOperation(
       cache,
       base::MakeRefCounted<PatchChromiumFactory>(
           base::BindRepeating(&patch::LaunchInProcessFilePatcher))
@@ -196,7 +243,7 @@ TEST_F(ZucchiniOperationTest, NoCache) {
   base::FilePath patch_file =
       CopyToTemp("zucchini_patch_test/app1_to_app2.zucchini");
 
-  ZucchiniOperation(
+  CallZucchiniOperation(
       base::MakeRefCounted<CrxCache>(std::nullopt),
       base::MakeRefCounted<PatchChromiumFactory>(
           base::BindRepeating(&patch::LaunchInProcessFilePatcher))
@@ -240,7 +287,7 @@ TEST_F(ZucchiniOperationTest, OutHashMismatch) {
       base::BindLambdaForTesting([&](base::expected<base::FilePath,
                                                     UnpackerError> r) {
         ASSERT_TRUE(r.has_value());
-        ZucchiniOperation(
+        CallZucchiniOperation(
             cache,
             base::MakeRefCounted<PatchChromiumFactory>(
                 base::BindRepeating(&patch::LaunchInProcessFilePatcher))

--- a/components/update_client/test_configurator.cc
+++ b/components/update_client/test_configurator.cc
@@ -28,6 +28,7 @@
 #include "components/update_client/crx_downloader_factory.h"
 #if BUILDFLAG(IS_STARBOARD)
 #include "cobalt/updater/network_fetcher.h"
+#include "cobalt/updater/unzipper.h"
 #else
 #include "components/update_client/net/network_chromium.h"  // nogncheck
 #endif
@@ -36,7 +37,9 @@
 #include "components/update_client/persisted_data.h"
 #include "components/update_client/protocol_handler.h"
 #include "components/update_client/test_activity_data_service.h"
-#include "components/update_client/unzip/unzip_impl.h"
+#if !BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/unzip/unzip_impl.h"  // nogncheck
+#endif
 #include "components/update_client/unzipper.h"
 #include "services/network/public/cpp/weak_wrapper_shared_url_loader_factory.h"
 #include "url/gurl.h"
@@ -57,8 +60,12 @@ std::vector<GURL> MakeDefaultUrls() {
 TestConfigurator::TestConfigurator(PrefService* pref_service)
     : enabled_cup_signing_(false),
       pref_service_(pref_service),
+#if BUILDFLAG(IS_STARBOARD)
+      unzip_factory_(base::MakeRefCounted<cobalt::updater::UnzipperFactory>()),
+#else
       unzip_factory_(base::MakeRefCounted<update_client::UnzipChromiumFactory>(
           base::BindRepeating(&unzip::LaunchInProcessUnzipper))),
+#endif
       patch_factory_(base::MakeRefCounted<update_client::PatchChromiumFactory>(
           base::BindRepeating(&patch::LaunchInProcessFilePatcher))),
       test_shared_loader_factory_(

--- a/components/update_client/test_configurator.cc
+++ b/components/update_client/test_configurator.cc
@@ -3,6 +3,7 @@
 // found in the LICENSE file.
 
 #include "components/update_client/test_configurator.h"
+#include "build/build_config.h"
 
 #include <memory>
 #include <optional>
@@ -25,7 +26,11 @@
 #include "components/update_client/activity_data_service.h"
 #include "components/update_client/crx_cache.h"
 #include "components/update_client/crx_downloader_factory.h"
-#include "components/update_client/net/network_chromium.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "cobalt/updater/network_fetcher.h"
+#else
+#include "components/update_client/net/network_chromium.h"  // nogncheck
+#endif
 #include "components/update_client/patch/patch_impl.h"
 #include "components/update_client/patcher.h"
 #include "components/update_client/persisted_data.h"
@@ -59,10 +64,16 @@ TestConfigurator::TestConfigurator(PrefService* pref_service)
       test_shared_loader_factory_(
           base::MakeRefCounted<network::WeakWrapperSharedURLLoaderFactory>(
               &test_url_loader_factory_)),
+#if BUILDFLAG(IS_STARBOARD)
+      network_fetcher_factory_(
+          base::MakeRefCounted<cobalt::updater::NetworkFetcherFactoryCobalt>(
+              test_shared_loader_factory_)),
+#else
       network_fetcher_factory_(
           base::MakeRefCounted<NetworkFetcherChromiumFactory>(
               test_shared_loader_factory_,
               base::BindRepeating([](const GURL& url) { return false; }))),
+#endif
       updater_state_provider_(base::BindRepeating(
           [](bool /*is_machine*/) { return UpdaterStateAttributes(); })),
       is_network_connection_metered_(false) {

--- a/components/update_client/test_configurator.h
+++ b/components/update_client/test_configurator.h
@@ -165,7 +165,7 @@ class TestConfigurator : public Configurator {
   raw_ptr<TestActivityDataService> activity_data_service_;
   std::vector<GURL> update_check_urls_;
   GURL ping_url_;
-  scoped_refptr<update_client::UnzipChromiumFactory> unzip_factory_;
+  scoped_refptr<UnzipperFactory> unzip_factory_;
   scoped_refptr<update_client::PatchChromiumFactory> patch_factory_;
   scoped_refptr<network::SharedURLLoaderFactory> test_shared_loader_factory_;
   network::TestURLLoaderFactory test_url_loader_factory_;

--- a/components/update_client/test_configurator.h
+++ b/components/update_client/test_configurator.h
@@ -111,6 +111,27 @@ class TestConfigurator : public Configurator {
   scoped_refptr<CrxCache> GetCrxCache() const override;
   bool IsConnectionMetered() const override;
 
+#if BUILDFLAG(IS_STARBOARD)
+  std::string GetBrand() const override { return ""; }
+  void SetChannel(const std::string& channel) override {}
+  std::string GetPreviousUpdaterStatus() const override { return ""; }
+  void SetPreviousUpdaterStatus(const std::string& status) override {}
+  std::string GetUpdaterStatus() const override { return ""; }
+  void SetUpdaterStatus(const std::string& status) override {}
+  void CompareAndSwapForcedUpdate(int old_value, int new_value) override {}
+  void SetMinFreeSpaceBytes(uint64_t bytes) override {}
+  uint64_t GetMinFreeSpaceBytes() override { return 0; }
+  bool GetUseCompressedUpdates() const override { return false; }
+  void SetUseCompressedUpdates(bool use_compressed_updates) override {}
+  bool GetAllowSelfSignedPackages() const override { return false; }
+  void SetAllowSelfSignedPackages(bool allow_self_signed_packages) override {}
+  std::string GetUpdateServerUrl() const override { return ""; }
+  void SetUpdateServerUrl(const std::string& update_server_url) override {}
+  bool GetRequireNetworkEncryption() const override { return false; }
+  void SetRequireNetworkEncryption(bool require_network_encryption) override {}
+  std::string GetAppGuid() const override { return ""; }
+#endif
+
   void SetOnDemandTime(base::TimeDelta seconds);
   void SetInitialDelay(base::TimeDelta seconds);
   void SetDownloadPreference(const std::string& download_preference);

--- a/components/update_client/test_utils.cc
+++ b/components/update_client/test_utils.cc
@@ -4,10 +4,13 @@
 
 #include "components/update_client/test_utils.h"
 
+#include "build/build_config.h"
+
 #include "base/base_paths.h"
 #include "base/files/file_path.h"
 #include "base/files/file_util.h"
 #include "base/path_service.h"
+#include "base/logging.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace update_client {
@@ -15,11 +18,13 @@ namespace update_client {
 base::FilePath GetTestFilePath(const char* file_name) {
   base::FilePath test_data_root;
   base::PathService::Get(base::DIR_SRC_TEST_DATA_ROOT, &test_data_root);
-  return test_data_root.Append(FILE_PATH_LITERAL("components"))
+  base::FilePath path = test_data_root.Append(FILE_PATH_LITERAL("components"))
       .Append(FILE_PATH_LITERAL("test"))
       .Append(FILE_PATH_LITERAL("data"))
       .Append(FILE_PATH_LITERAL("update_client"))
       .AppendUTF8(file_name);
+  LOG(ERROR) << "GetTestFilePath: " << path.value();
+  return path;
 }
 
 base::FilePath DuplicateTestFile(const base::FilePath& temp_path,
@@ -32,3 +37,72 @@ base::FilePath DuplicateTestFile(const base::FilePath& temp_path,
 }
 
 }  // namespace update_client
+
+#if BUILDFLAG(IS_STARBOARD)
+#include "starboard/extension/installation_manager.h"
+#include "starboard/system.h"
+
+namespace {
+
+char g_mock_installation_path[512] = "";
+bool g_mock_request_roll_forward_success = true;
+
+int MockGetCurrentInstallationIndex() { return 0; }
+int MockMarkInstallationSuccessful(int index) { return IM_EXT_SUCCESS; }
+int MockRequestRollForwardToInstallation(int index) {
+  return g_mock_request_roll_forward_success ? IM_EXT_SUCCESS : IM_EXT_ERROR;
+}
+int MockGetInstallationPath(int index, char* path, int path_length) {
+  if (strlen(g_mock_installation_path) > 0) {
+    strncpy(path, g_mock_installation_path, path_length);
+    return IM_EXT_SUCCESS;
+  }
+  return IM_EXT_ERROR;
+}
+int MockSelectNewInstallationIndex() { return 0; }
+int MockGetAppKey(char* app_key, int app_key_length) {
+  if (app_key_length > 0) {
+    app_key[0] = 'A';
+    app_key[1] = '\0';
+  }
+  return IM_EXT_SUCCESS;
+}
+int MockGetMaxNumberInstallations() { return 2; }
+int MockResetInstallation(int index) { return IM_EXT_SUCCESS; }
+int MockReset() { return IM_EXT_SUCCESS; }
+
+const CobaltExtensionInstallationManagerApi kMockInstallationManagerApi = {
+    kCobaltExtensionInstallationManagerName,
+    1,  // API version
+    &MockGetCurrentInstallationIndex,
+    &MockMarkInstallationSuccessful,
+    &MockRequestRollForwardToInstallation,
+    &MockGetInstallationPath,
+    &MockSelectNewInstallationIndex,
+    &MockGetAppKey,
+    &MockGetMaxNumberInstallations,
+    &MockResetInstallation,
+    &MockReset,
+};
+
+}  // namespace
+
+extern "C" SB_EXPORT const void* SbSystemGetExtension(const char* name) {
+  if (strcmp(name, kCobaltExtensionInstallationManagerName) == 0) {
+    return &kMockInstallationManagerApi;
+  }
+  return nullptr;
+}
+
+namespace update_client {
+void SetMockInstallationPath(const char* path) {
+  strncpy(g_mock_installation_path, path, sizeof(g_mock_installation_path) - 1);
+  g_mock_installation_path[sizeof(g_mock_installation_path) - 1] = '\0';
+}
+
+void SetMockRequestRollForwardSuccess(bool success) {
+  g_mock_request_roll_forward_success = success;
+}
+}  // namespace update_client
+
+#endif  // BUILDFLAG(IS_STARBOARD)

--- a/components/update_client/test_utils.h
+++ b/components/update_client/test_utils.h
@@ -5,6 +5,8 @@
 #ifndef COMPONENTS_UPDATE_CLIENT_TEST_UTILS_H_
 #define COMPONENTS_UPDATE_CLIENT_TEST_UTILS_H_
 
+#include "build/build_config.h"
+
 namespace base {
 class FilePath;
 }
@@ -22,6 +24,11 @@ namespace update_client {
 // should be handled by the caller.
 [[nodiscard]] base::FilePath DuplicateTestFile(const base::FilePath& temp_path,
                                                const char* file);
+
+#if BUILDFLAG(IS_STARBOARD)
+void SetMockInstallationPath(const char* path);
+void SetMockRequestRollForwardSuccess(bool success);
+#endif
 
 }  // namespace update_client
 

--- a/components/update_client/unpacker_unittest.cc
+++ b/components/update_client/unpacker_unittest.cc
@@ -22,7 +22,11 @@
 #include "components/services/unzip/in_process_unzipper.h"
 #include "components/update_client/test_configurator.h"
 #include "components/update_client/test_utils.h"
-#include "components/update_client/unzip/unzip_impl.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "cobalt/updater/unzipper.h"
+#else
+#include "components/update_client/unzip/unzip_impl.h"  // nogncheck
+#endif
 #include "components/update_client/unzipper.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -49,9 +53,13 @@ TEST_F(UnpackerTest, UnpackFullCrx) {
       std::vector<uint8_t>(std::begin(jebg_hash), std::end(jebg_hash)),
       GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"),
 #endif
+#if BUILDFLAG(IS_STARBOARD)
+      base::MakeRefCounted<cobalt::updater::UnzipperFactory>()->Create(),
+#else
       base::MakeRefCounted<update_client::UnzipChromiumFactory>(
           base::BindRepeating(&unzip::LaunchInProcessUnzipper))
           ->Create(),
+#endif
       crx_file::VerifierFormat::CRX3,
       base::BindLambdaForTesting([&](const Unpacker::Result& result) {
         DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker);
@@ -150,9 +158,13 @@ TEST_F(UnpackerTest, UnpackWithVerifiedContents) {
       std::vector<uint8_t>(),
       GetTestFilePath("gndmhdcefbhlchkhipcnnbkcmicncehk_22_314.crx3"),
 #endif
+#if BUILDFLAG(IS_STARBOARD)
+      base::MakeRefCounted<cobalt::updater::UnzipperFactory>()->Create(),
+#else
       base::MakeRefCounted<update_client::UnzipChromiumFactory>(
           base::BindRepeating(&unzip::LaunchInProcessUnzipper))
           ->Create(),
+#endif
       crx_file::VerifierFormat::CRX3,
       base::BindLambdaForTesting([&](const Unpacker::Result& result) {
         DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker);

--- a/components/update_client/unpacker_unittest.cc
+++ b/components/update_client/unpacker_unittest.cc
@@ -5,6 +5,7 @@
 #include "components/update_client/unpacker.h"
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/pipeline.h"
+#include "cobalt/updater/unzipper.h"  // nogncheck
 #endif
 
 #include <iterator>
@@ -42,9 +43,18 @@ TEST_F(UnpackerTest, UnpackFullCrx) {
   base::RunLoop loop;
 #if BUILDFLAG(IS_STARBOARD)
   OperationResult op_result1;
+#if defined(IN_MEMORY_UPDATES)
+  std::string crx_content1;
+  EXPECT_TRUE(base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &crx_content1));
+  op_result1.crx_str = &crx_content1;
+  base::FilePath temp_dir1;
+  EXPECT_TRUE(base::CreateNewTempDirectory(FILE_PATH_LITERAL("unpacker_test"), &temp_dir1));
+  op_result1.installation_dir = temp_dir1;
+#else
   base::FilePath temp_dir1;
   EXPECT_TRUE(base::CreateNewTempDirectory(FILE_PATH_LITERAL("unpacker_test"), &temp_dir1));
   op_result1.response = DuplicateTestFile(temp_dir1, "jebgalgnebhfojomionfpkfelancnnkf.crx");
+#endif
   Unpacker::Unpack(
       std::vector<uint8_t>(std::begin(jebg_hash), std::end(jebg_hash)),
       op_result1,
@@ -85,6 +95,7 @@ TEST_F(UnpackerTest, UnpackFullCrx) {
   loop.Run();
 }
 
+#if !defined(IN_MEMORY_UPDATES)
 TEST_F(UnpackerTest, UnpackFileNotFound) {
   SEQUENCE_CHECKER(sequence_checker);
   base::RunLoop loop;
@@ -112,6 +123,7 @@ TEST_F(UnpackerTest, UnpackFileNotFound) {
       }));
   loop.Run();
 }
+#endif  // !defined(IN_MEMORY_UPDATES)
 
 // Tests a mismatch between the public key hash and the id of the component.
 TEST_F(UnpackerTest, UnpackFileHashMismatch) {
@@ -119,7 +131,13 @@ TEST_F(UnpackerTest, UnpackFileHashMismatch) {
   base::RunLoop loop;
 #if BUILDFLAG(IS_STARBOARD)
   OperationResult op_result3;
+#if defined(IN_MEMORY_UPDATES)
+  std::string crx_content3;
+  EXPECT_TRUE(base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &crx_content3));
+  op_result3.crx_str = &crx_content3;
+#else
   op_result3.response = GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx");
+#endif
   Unpacker::Unpack(
       std::vector<uint8_t>(std::begin(abag_hash), std::end(abag_hash)),
       op_result3, nullptr,
@@ -147,9 +165,18 @@ TEST_F(UnpackerTest, UnpackWithVerifiedContents) {
   base::RunLoop loop;
 #if BUILDFLAG(IS_STARBOARD)
   OperationResult op_result4;
+#if defined(IN_MEMORY_UPDATES)
+  std::string crx_content4;
+  EXPECT_TRUE(base::ReadFileToString(GetTestFilePath("gndmhdcefbhlchkhipcnnbkcmicncehk_22_314.crx3"), &crx_content4));
+  op_result4.crx_str = &crx_content4;
+  base::FilePath temp_dir4;
+  EXPECT_TRUE(base::CreateNewTempDirectory(FILE_PATH_LITERAL("unpacker_test"), &temp_dir4));
+  op_result4.installation_dir = temp_dir4;
+#else
   base::FilePath temp_dir4;
   EXPECT_TRUE(base::CreateNewTempDirectory(FILE_PATH_LITERAL("unpacker_test"), &temp_dir4));
   op_result4.response = DuplicateTestFile(temp_dir4, "gndmhdcefbhlchkhipcnnbkcmicncehk_22_314.crx3");
+#endif
   Unpacker::Unpack(
       std::vector<uint8_t>(),
       op_result4,

--- a/components/update_client/unpacker_unittest.cc
+++ b/components/update_client/unpacker_unittest.cc
@@ -3,6 +3,9 @@
 // found in the LICENSE file.
 
 #include "components/update_client/unpacker.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/pipeline.h"
+#endif
 
 #include <iterator>
 #include <utility>
@@ -33,9 +36,19 @@ class UnpackerTest : public testing::Test {
 TEST_F(UnpackerTest, UnpackFullCrx) {
   SEQUENCE_CHECKER(sequence_checker);
   base::RunLoop loop;
+#if BUILDFLAG(IS_STARBOARD)
+  OperationResult op_result1;
+  base::FilePath temp_dir1;
+  EXPECT_TRUE(base::CreateNewTempDirectory(FILE_PATH_LITERAL("unpacker_test"), &temp_dir1));
+  op_result1.response = DuplicateTestFile(temp_dir1, "jebgalgnebhfojomionfpkfelancnnkf.crx");
+  Unpacker::Unpack(
+      std::vector<uint8_t>(std::begin(jebg_hash), std::end(jebg_hash)),
+      op_result1,
+#else
   Unpacker::Unpack(
       std::vector<uint8_t>(std::begin(jebg_hash), std::end(jebg_hash)),
       GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"),
+#endif
       base::MakeRefCounted<update_client::UnzipChromiumFactory>(
           base::BindRepeating(&unzip::LaunchInProcessUnzipper))
           ->Create(),
@@ -67,9 +80,17 @@ TEST_F(UnpackerTest, UnpackFullCrx) {
 TEST_F(UnpackerTest, UnpackFileNotFound) {
   SEQUENCE_CHECKER(sequence_checker);
   base::RunLoop loop;
+#if BUILDFLAG(IS_STARBOARD)
+  OperationResult op_result2;
+  op_result2.response = GetTestFilePath("file_not_found.crx");
+  Unpacker::Unpack(
+      std::vector<uint8_t>(std::begin(jebg_hash), std::end(jebg_hash)),
+      op_result2, nullptr,
+#else
   Unpacker::Unpack(
       std::vector<uint8_t>(std::begin(jebg_hash), std::end(jebg_hash)),
       GetTestFilePath("file_not_found.crx"), nullptr,
+#endif
       crx_file::VerifierFormat::CRX3,
       base::BindLambdaForTesting([&](const Unpacker::Result& result) {
         DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker);
@@ -88,9 +109,17 @@ TEST_F(UnpackerTest, UnpackFileNotFound) {
 TEST_F(UnpackerTest, UnpackFileHashMismatch) {
   SEQUENCE_CHECKER(sequence_checker);
   base::RunLoop loop;
+#if BUILDFLAG(IS_STARBOARD)
+  OperationResult op_result3;
+  op_result3.response = GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx");
+  Unpacker::Unpack(
+      std::vector<uint8_t>(std::begin(abag_hash), std::end(abag_hash)),
+      op_result3, nullptr,
+#else
   Unpacker::Unpack(
       std::vector<uint8_t>(std::begin(abag_hash), std::end(abag_hash)),
       GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), nullptr,
+#endif
       crx_file::VerifierFormat::CRX3,
       base::BindLambdaForTesting([&](const Unpacker::Result& result) {
         DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker);
@@ -108,9 +137,19 @@ TEST_F(UnpackerTest, UnpackFileHashMismatch) {
 TEST_F(UnpackerTest, UnpackWithVerifiedContents) {
   SEQUENCE_CHECKER(sequence_checker);
   base::RunLoop loop;
+#if BUILDFLAG(IS_STARBOARD)
+  OperationResult op_result4;
+  base::FilePath temp_dir4;
+  EXPECT_TRUE(base::CreateNewTempDirectory(FILE_PATH_LITERAL("unpacker_test"), &temp_dir4));
+  op_result4.response = DuplicateTestFile(temp_dir4, "gndmhdcefbhlchkhipcnnbkcmicncehk_22_314.crx3");
+  Unpacker::Unpack(
+      std::vector<uint8_t>(),
+      op_result4,
+#else
   Unpacker::Unpack(
       std::vector<uint8_t>(),
       GetTestFilePath("gndmhdcefbhlchkhipcnnbkcmicncehk_22_314.crx3"),
+#endif
       base::MakeRefCounted<update_client::UnzipChromiumFactory>(
           base::BindRepeating(&unzip::LaunchInProcessUnzipper))
           ->Create(),

--- a/components/update_client/update_client_unittest.cc
+++ b/components/update_client/update_client_unittest.cc
@@ -5106,9 +5106,13 @@ TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
         std::vector<uint8_t>(std::begin(gjpm_hash), std::end(gjpm_hash)),
         GetTestFilePath("runaction_test_win.crx3"),
 #endif
+#if BUILDFLAG(IS_STARBOARD)
+        base::MakeRefCounted<cobalt::updater::UnzipperFactory>()->Create(),
+#else
         base::MakeRefCounted<UnzipChromiumFactory>(
             base::BindRepeating(&unzip::LaunchInProcessUnzipper))
             ->Create(),
+#endif
         crx_file::VerifierFormat::CRX3,
         base::BindOnce(
             [](base::FilePath* unpack_path, base::OnceClosure quit_closure,

--- a/components/update_client/update_client_unittest.cc
+++ b/components/update_client/update_client_unittest.cc
@@ -53,8 +53,10 @@
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/pipeline.h"
 #endif
-#if !BUILDFLAG(IS_STARBOARD)
-#include "components/update_client/unzip/unzip_impl.h"  // nogncheck
+#if BUILDFLAG(IS_STARBOARD)
+#include "cobalt/updater/unzipper.h" //nogncheck
+#else
+#include "components/update_client/unzip/unzip_impl.h"
 #endif
 #include "components/update_client/unzipper.h"
 #include "components/update_client/update_checker.h"
@@ -771,7 +773,11 @@ TEST_F(UpdateClientTest, OneCrxNoUpdate) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -866,7 +872,11 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoUpdate) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       download_metrics.url = url;
       download_metrics.downloader = DownloadMetrics::kNone;
@@ -876,12 +886,19 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoUpdate) {
       download_metrics.download_time_ms = 1000;
 
       base::FilePath path;
-      EXPECT_TRUE(MakeTestFile(
-          GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+      EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
       Result result;
       result.error = 0;
+      #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
       result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
       result.installation_index = 0;
 #endif
@@ -1061,7 +1078,11 @@ TEST_F(UpdateClientTest, TwoCrxUpdateFirstServerIgnoresSecond) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       download_metrics.url = url;
       download_metrics.downloader = DownloadMetrics::kNone;
@@ -1071,12 +1092,19 @@ TEST_F(UpdateClientTest, TwoCrxUpdateFirstServerIgnoresSecond) {
       download_metrics.download_time_ms = 1000;
 
       base::FilePath path;
-      EXPECT_TRUE(MakeTestFile(
-          GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+      EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
       Result result;
       result.error = 0;
+      #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
       result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
       result.installation_index = 0;
 #endif
@@ -1238,7 +1266,11 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoCrxComponentData) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -1250,11 +1282,18 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoCrxComponentData) {
         download_metrics.total_bytes = 1015;
         download_metrics.download_time_ms = 1000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -1390,7 +1429,11 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoCrxComponentDataAtAll) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -1491,7 +1534,11 @@ TEST_F(UpdateClientTest, TwoCrxUpdateDownloadTimeout) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -1514,11 +1561,18 @@ TEST_F(UpdateClientTest, TwoCrxUpdateDownloadTimeout) {
         download_metrics.total_bytes = 54014;
         download_metrics.download_time_ms = 2000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -1661,6 +1715,7 @@ TEST_F(UpdateClientTest, TwoCrxUpdateDownloadTimeout) {
 
 // Tests the differential update scenario for one CRX. Tests install progress
 // for differential and full updates.
+#if !defined(IN_MEMORY_UPDATES)
 TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
   class DataCallbackMock : public base::RefCountedThreadSafe<DataCallbackMock> {
    public:
@@ -1839,7 +1894,11 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -1851,11 +1910,18 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
         download_metrics.total_bytes = 54014;
         download_metrics.download_time_ms = 2000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -1868,12 +1934,18 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
         download_metrics.total_bytes = 1680;
         download_metrics.download_time_ms = 1000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1to2.puff"),
-            &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1to2.puff"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1to2.puff"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -2144,6 +2216,7 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
 #endif
   }
 }
+#endif  // !defined(IN_MEMORY_UPDATES)
 
 // Tests the update scenario for one CRX where the CRX installer returns
 // an error. Tests that the |unpack_path| argument refers to a valid path
@@ -2236,7 +2309,11 @@ TEST_F(UpdateClientTest, OneCrxInstallError) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       download_metrics.url = url;
       download_metrics.downloader = DownloadMetrics::kNone;
@@ -2246,12 +2323,19 @@ TEST_F(UpdateClientTest, OneCrxInstallError) {
       download_metrics.download_time_ms = 1000;
 
       base::FilePath path;
-      EXPECT_TRUE(MakeTestFile(
-          GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+      EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
       Result result;
       result.error = 0;
+      #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
       result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
       result.installation_index = 0;
 #endif
@@ -2565,7 +2649,11 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdateFailsFullUpdateSucceeds) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -2577,11 +2665,18 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdateFailsFullUpdateSucceeds) {
         download_metrics.total_bytes = 54014;
         download_metrics.download_time_ms = 2000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -2606,11 +2701,18 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdateFailsFullUpdateSucceeds) {
         download_metrics.total_bytes = 54409;
         download_metrics.download_time_ms = 1000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_2.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_2.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_2.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -2843,7 +2945,11 @@ TEST_F(UpdateClientTest, OneCrxNoUpdateQueuedCall) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -2956,7 +3062,11 @@ TEST_F(UpdateClientTest, OneCrxInstall) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -2968,11 +3078,18 @@ TEST_F(UpdateClientTest, OneCrxInstall) {
         download_metrics.total_bytes = 1015;
         download_metrics.download_time_ms = 1000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -3123,7 +3240,11 @@ TEST_F(UpdateClientTest, OneCrxInstallNoCrxComponentData) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -3250,7 +3371,11 @@ TEST_F(UpdateClientTest, ConcurrentInstallSameCRX) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -3341,7 +3466,11 @@ TEST_F(UpdateClientTest, EmptyIdList) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -3404,7 +3533,11 @@ TEST_F(UpdateClientTest, DiskFull) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -3676,7 +3809,11 @@ TEST_F(UpdateClientTest, DiskFullDiff) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -3688,11 +3825,18 @@ TEST_F(UpdateClientTest, DiskFullDiff) {
         download_metrics.total_bytes = 54014;
         download_metrics.download_time_ms = 2000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -3940,7 +4084,11 @@ TEST_P(SendPingTest, SendPingTestCases) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       return base::DoNothing();
     }
   };
@@ -4062,7 +4210,11 @@ TEST_F(UpdateClientTest, RetryAfter) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -4196,7 +4348,11 @@ TEST_F(UpdateClientTest, TwoCrxUpdateOneUpdateDisabled) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -4208,11 +4364,18 @@ TEST_F(UpdateClientTest, TwoCrxUpdateOneUpdateDisabled) {
         download_metrics.total_bytes = 54014;
         download_metrics.download_time_ms = 2000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -4374,7 +4537,11 @@ TEST_F(UpdateClientTest, OneCrxUpdateDownloadTimeout) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       download_metrics.url = url;
       download_metrics.downloader = DownloadMetrics::kNone;
@@ -4385,8 +4552,11 @@ TEST_F(UpdateClientTest, OneCrxUpdateDownloadTimeout) {
       download_metrics.download_time_ms = 1000;
 
       base::FilePath path;
-      EXPECT_TRUE(MakeTestFile(
-          GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+      EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
       Result result;
       result.error = 200;
@@ -4552,7 +4722,11 @@ TEST_F(UpdateClientTest, OneCrxUpdateCheckFails) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -4734,7 +4908,11 @@ TEST_F(UpdateClientTest, OneCrxErrorUnknownApp) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -4922,7 +5100,11 @@ TEST_F(UpdateClientTest, ActionRun_Install) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -4935,10 +5117,18 @@ TEST_F(UpdateClientTest, ActionRun_Install) {
         download_metrics.download_time_ms = 1000;
 
         EXPECT_TRUE(
-            MakeTestFile(GetTestFilePath("runaction_test_win.crx3"), &path));
+            MakeTestFile(GetTestFilePath("runaction_test_win.crx3"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("runaction_test_win.crx3"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -5059,7 +5249,11 @@ TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -5099,7 +5293,14 @@ TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
     OperationResult op_result;
     base::FilePath temp_crx_path;
     EXPECT_TRUE(MakeTestFile(GetTestFilePath("runaction_test_win.crx3"), &temp_crx_path));
+#if defined(IN_MEMORY_UPDATES)
+    op_result.installation_dir = temp_crx_path.DirName();
+    std::string crx_str;
+    EXPECT_TRUE(base::ReadFileToString(GetTestFilePath("runaction_test_win.crx3"), &crx_str));
+    op_result.crx_str = &crx_str;
+#else
     op_result.response = temp_crx_path;
+#endif
     Unpacker::Unpack(
         std::vector<uint8_t>(std::begin(gjpm_hash), std::end(gjpm_hash)),
         op_result,
@@ -5250,7 +5451,11 @@ TEST_F(UpdateClientTest, CustomAttributeNoUpdate) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -5369,7 +5574,11 @@ TEST_F(UpdateClientTest, CancelInstallBeforeTaskStart) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -5381,11 +5590,18 @@ TEST_F(UpdateClientTest, CancelInstallBeforeTaskStart) {
         download_metrics.total_bytes = 1015;
         download_metrics.download_time_ms = 1000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -5475,7 +5691,11 @@ TEST_F(UpdateClientTest, CancelInstallBeforeInstall) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -5487,11 +5707,18 @@ TEST_F(UpdateClientTest, CancelInstallBeforeInstall) {
         download_metrics.total_bytes = 1015;
         download_metrics.download_time_ms = 1000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -5634,7 +5861,11 @@ TEST_F(UpdateClientTest, CancelInstallBeforeDownload) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       base::FilePath path;
       Result result;
@@ -5646,11 +5877,18 @@ TEST_F(UpdateClientTest, CancelInstallBeforeDownload) {
         download_metrics.total_bytes = 1015;
         download_metrics.download_time_ms = 1000;
 
-        EXPECT_TRUE(MakeTestFile(
-            GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+        EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
         result.error = 0;
-        result.response = path;
+        #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
+      result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
         result.installation_index = 0;
 #endif
@@ -5811,7 +6049,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_NoUpdate) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -5895,7 +6137,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_UpdateAvailable) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -6023,7 +6269,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_QueueChecks) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -6162,7 +6412,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_Stop) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -6254,7 +6508,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_Errors) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -6362,7 +6620,11 @@ TEST_F(UpdateClientTest, UpdateCheck_UpdateDisabled) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }
@@ -6485,7 +6747,11 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       DownloadMetrics download_metrics;
       download_metrics.url = url;
       download_metrics.downloader = DownloadMetrics::kNone;
@@ -6495,12 +6761,19 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
       download_metrics.download_time_ms = 2000;
 
       base::FilePath path;
-      EXPECT_TRUE(MakeTestFile(
-          GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path));
+      EXPECT_TRUE(MakeTestFile(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &path)
+#if defined(IN_MEMORY_UPDATES)
+          && base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), dst)
+#endif
+);
 
       Result result;
       result.error = 0;
+      #if defined(IN_MEMORY_UPDATES)
+      result.installation_dir = path.DirName();
+#else
       result.response = path;
+#endif
 #if BUILDFLAG(IS_STARBOARD)
       result.installation_index = 0;
 #endif
@@ -6773,7 +7046,11 @@ TEST_F(UpdateClientTest, UnsupportedOperationType) {
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE() << "Intentionally forcing download to fail here.";
       return base::DoNothing();
     }
@@ -6995,7 +7272,11 @@ TEST_F(UpdateClientTest,
 #if BUILDFLAG(IS_STARBOARD)
     void DoCancelDownload() override {}
 #endif
+    #if defined(IN_MEMORY_UPDATES)
+    base::OnceClosure DoStartDownload(const GURL& url, std::string* dst) override {
+#else
     base::OnceClosure DoStartDownload(const GURL& url) override {
+#endif
       ADD_FAILURE();
       return base::DoNothing();
     }

--- a/components/update_client/update_client_unittest.cc
+++ b/components/update_client/update_client_unittest.cc
@@ -53,7 +53,9 @@
 #if BUILDFLAG(IS_STARBOARD)
 #include "components/update_client/pipeline.h"
 #endif
-#include "components/update_client/unzip/unzip_impl.h"
+#if !BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/unzip/unzip_impl.h"  // nogncheck
+#endif
 #include "components/update_client/unzipper.h"
 #include "components/update_client/update_checker.h"
 #include "components/update_client/update_client_errors.h"

--- a/components/update_client/update_client_unittest.cc
+++ b/components/update_client/update_client_unittest.cc
@@ -50,6 +50,9 @@
 #include "components/update_client/test_installer.h"
 #include "components/update_client/test_utils.h"
 #include "components/update_client/unpacker.h"
+#if BUILDFLAG(IS_STARBOARD)
+#include "components/update_client/pipeline.h"
+#endif
 #include "components/update_client/unzip/unzip_impl.h"
 #include "components/update_client/unzipper.h"
 #include "components/update_client/update_checker.h"
@@ -60,6 +63,7 @@
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
 #include "url/gurl.h"
+
 
 namespace update_client {
 namespace {
@@ -102,17 +106,20 @@ bool MakeTestFile(const base::FilePath& from_path, base::FilePath* to_path) {
   bool result = base::CreateNewTempDirectory(FILE_PATH_LITERAL("update_client"),
                                              &temp_dir);
   if (!result) {
+    LOG(ERROR) << "MakeTestFile: CreateNewTempDirectory failed";
     return false;
   }
 
   base::FilePath temp_file;
   result = CreateTemporaryFileInDir(temp_dir, &temp_file);
   if (!result) {
+    LOG(ERROR) << "MakeTestFile: CreateTemporaryFileInDir failed in " << temp_dir.value();
     return false;
   }
 
   result = CopyFile(from_path, temp_file);
   if (!result) {
+    LOG(ERROR) << "MakeTestFile: CopyFile failed from " << from_path.value() << " to " << temp_file.value();
     base::DeleteFile(temp_file);
     return false;
   }
@@ -172,8 +179,13 @@ class MockCrxDownloaderFactory : public CrxDownloaderFactory {
   ~MockCrxDownloaderFactory() override = default;
 
   // Overrides for CrxDownloaderFactory.
+#if BUILDFLAG(IS_STARBOARD)
+  scoped_refptr<CrxDownloader> MakeCrxDownloader(
+      scoped_refptr<Configurator> config) const override {
+#else
   scoped_refptr<CrxDownloader> MakeCrxDownloader(
       bool /* background_download_enabled */) const override {
+#endif
     return crx_downloader_;
   }
 
@@ -504,6 +516,11 @@ template <typename Options>
   requires IsUpdateCheckerOptions<Options>
 class MockUpdateCheckerImpl : public UpdateChecker {
  public:
+#if BUILDFLAG(IS_STARBOARD)
+  void Cancel() override {}
+  bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+  PersistedData* GetPersistedData() override { return nullptr; }
+#endif
   void CheckForUpdates(
       scoped_refptr<UpdateContext> context,
       const base::flat_map<std::string, std::string>& additional_attributes,
@@ -526,6 +543,11 @@ class MockUpdateCheckerAlwaysFails : public UpdateChecker {
  public:
   MockUpdateCheckerAlwaysFails() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+  void Cancel() override {}
+  bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+  PersistedData* GetPersistedData() override { return nullptr; }
+#endif
   void CheckForUpdates(
       scoped_refptr<UpdateContext> context,
       const base::flat_map<std::string, std::string>& additional_attributes,
@@ -704,6 +726,11 @@ TEST_F(UpdateClientTest, OneCrxNoUpdate) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -739,6 +766,9 @@ TEST_F(UpdateClientTest, OneCrxNoUpdate) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -831,6 +861,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoUpdate) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       download_metrics.url = url;
@@ -847,6 +880,13 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoUpdate) {
       Result result;
       result.error = 0;
       result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+      result.installation_index = 0;
+#endif
+#if BUILDFLAG(IS_STARBOARD)
+      result.installation_index = 0;
+#endif
+
 
       base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
           FROM_HERE, base::BindOnce(&MockCrxDownloader::OnDownloadProgress,
@@ -1016,6 +1056,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateFirstServerIgnoresSecond) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       download_metrics.url = url;
@@ -1032,6 +1075,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateFirstServerIgnoresSecond) {
       Result result;
       result.error = 0;
       result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+      result.installation_index = 0;
+#endif
 
       base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
           FROM_HERE, base::BindOnce(&MockCrxDownloader::OnDownloadProgress,
@@ -1055,7 +1101,11 @@ TEST_F(UpdateClientTest, TwoCrxUpdateFirstServerIgnoresSecond) {
    protected:
     ~MockPingManager() override {
       const auto ping_data = MockPingManagerImpl::terminal_ping_data();
+#if BUILDFLAG(IS_STARBOARD)
+      EXPECT_EQ(2u, ping_data.size());
+#else
       EXPECT_EQ(1u, ping_data.size());
+#endif
       EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", ping_data[0].id);
       EXPECT_EQ(base::Version("0.9"), ping_data[0].previous_version);
       EXPECT_EQ(base::Version("1.0"), ping_data[0].next_version);
@@ -1183,6 +1233,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoCrxComponentData) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -1200,6 +1253,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoCrxComponentData) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -1329,6 +1385,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateNoCrxComponentDataAtAll) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -1427,6 +1486,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateDownloadTimeout) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -1455,6 +1517,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateDownloadTimeout) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -1638,6 +1703,11 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
    public:
     explicit MockUpdateChecker(int num_calls) : num_calls_(num_calls) {}
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -1764,6 +1834,9 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -1781,6 +1854,9 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else if (url.path() ==
                  "/download/ihfokbkgjpifnbbojhneepfflplebdkc_1to2.puff") {
         download_metrics.url = url;
@@ -1796,6 +1872,9 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE() << url.path();
       }
@@ -1867,11 +1946,13 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
                   return item.id == "ihfokbkgjpifnbbojhneepfflplebdkc" &&
                          item.state == ComponentState::kUpdating;
                 })));
+#if !BUILDFLAG(IS_STARBOARD)
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "ihfokbkgjpifnbbojhneepfflplebdkc" &&
                          item.state == ComponentState::kUpdating;
                 })))
         .Times(3);
+#endif
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "ihfokbkgjpifnbbojhneepfflplebdkc" &&
                          item.state == ComponentState::kUpdated;
@@ -1893,11 +1974,13 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
                   return item.id == "ihfokbkgjpifnbbojhneepfflplebdkc" &&
                          item.state == ComponentState::kUpdating;
                 })));
+#if !BUILDFLAG(IS_STARBOARD)
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "ihfokbkgjpifnbbojhneepfflplebdkc" &&
                          item.state == ComponentState::kUpdating;
                 })))
         .Times(3);
+#endif
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "ihfokbkgjpifnbbojhneepfflplebdkc" &&
                          item.state == ComponentState::kUpdated;
@@ -1918,6 +2001,29 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
         base::BindRepeating(&MockCrxStateChangeReceiver::Receive, receiver),
         false, ExpectErrorThenQuit(runloop, Error::NONE));
     runloop.Run();
+    #if BUILDFLAG(IS_STARBOARD)
+    EXPECT_EQ(7u, items.size());
+    EXPECT_EQ(ComponentState::kChecking, items[0].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[0].id);
+    EXPECT_EQ(ComponentState::kCanUpdate, items[1].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[1].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[2].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[2].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[3].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[3].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[4].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[4].id);
+    EXPECT_EQ(ComponentState::kUpdating, items[5].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[5].id);
+    EXPECT_EQ(ComponentState::kUpdated, items[6].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[6].id);
+
+    std::vector samples = {-1, -1, -1, -1, -1, -1, -1};
+    EXPECT_EQ(items.size(), samples.size());
+    for (size_t i = 0; i != items.size(); ++i) {
+      EXPECT_EQ(items[i].install_progress, samples[i]);
+    }
+#else
     EXPECT_EQ(10u, items.size());
     EXPECT_EQ(ComponentState::kChecking, items[0].state);
     EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[0].id);
@@ -1945,7 +2051,29 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
     for (size_t i = 0; i != items.size(); ++i) {
       EXPECT_EQ(items[i].install_progress, samples[i]);
     }
+#endif
   }
+
+#if BUILDFLAG(IS_STARBOARD)
+  {
+    // On Starboard, standard install doesn't populate cache, so we do it manually
+    // to enable testing of differential updates.
+    base::FilePath v1_file;
+    EXPECT_TRUE(MakeTestFile(
+        GetTestFilePath("ihfokbkgjpifnbbojhneepfflplebdkc_1.crx"), &v1_file));
+
+    base::RunLoop cache_runloop;
+    config()->GetCrxCache()->Put(
+        v1_file, "ihfokbkgjpifnbbojhneepfflplebdkc",
+        "8f5aa190311237cae00675af87ff457f278cd1a05895470ac5d46647d4a3c2ea",
+        "prev_fp",
+        base::BindLambdaForTesting([&](base::expected<base::FilePath, UnpackerError> result) {
+          ASSERT_TRUE(result.has_value());
+          cache_runloop.Quit();
+        }));
+    cache_runloop.Run();
+  }
+#endif
 
   {
     std::vector<CrxUpdateItem> items;
@@ -1961,6 +2089,29 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
         false, ExpectErrorThenQuit(runloop, Error::NONE));
     runloop.Run();
 
+    #if BUILDFLAG(IS_STARBOARD)
+    EXPECT_EQ(7u, items.size());
+    EXPECT_EQ(ComponentState::kChecking, items[0].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[0].id);
+    EXPECT_EQ(ComponentState::kCanUpdate, items[1].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[1].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[2].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[2].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[3].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[3].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[4].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[4].id);
+    EXPECT_EQ(ComponentState::kUpdating, items[5].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[5].id);
+    EXPECT_EQ(ComponentState::kUpdated, items[6].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[6].id);
+
+    std::vector samples = {-1, -1, -1, -1, -1, -1, -1};
+    EXPECT_EQ(items.size(), samples.size());
+    for (size_t i = 0; i != items.size(); ++i) {
+      EXPECT_EQ(items[i].install_progress, samples[i]);
+    }
+#else
     EXPECT_EQ(10u, items.size());
     EXPECT_EQ(ComponentState::kChecking, items[0].state);
     EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[0].id);
@@ -1988,6 +2139,7 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
     for (size_t i = 0; i != items.size(); ++i) {
       EXPECT_EQ(items[i].install_progress, samples[i]);
     }
+#endif
   }
 }
 
@@ -1996,6 +2148,9 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdate) {
 // then |Install| is called, then tests that the |unpack| path is deleted
 // by the |update_client| code before the test ends.
 TEST_F(UpdateClientTest, OneCrxInstallError) {
+#if BUILDFLAG(IS_STARBOARD)
+  SetMockRequestRollForwardSuccess(false);
+#endif
   class MockInstaller : public CrxInstaller {
    public:
     MOCK_METHOD1(OnUpdateError, void(int error));
@@ -2046,10 +2201,12 @@ TEST_F(UpdateClientTest, OneCrxInstallError) {
       scoped_refptr<MockInstaller> installer =
           base::MakeRefCounted<MockInstaller>();
 
+#if !BUILDFLAG(IS_STARBOARD)
       EXPECT_CALL(*installer, OnUpdateError(_)).Times(0);
       EXPECT_CALL(*installer, DoInstall(_));
       EXPECT_CALL(*installer, GetInstalledFile(_)).Times(0);
       EXPECT_CALL(*installer, Uninstall()).Times(0);
+#endif
 
       CrxComponent crx;
       crx.app_id = "jebgalgnebhfojomionfpkfelancnnkf";
@@ -2074,6 +2231,9 @@ TEST_F(UpdateClientTest, OneCrxInstallError) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       download_metrics.url = url;
@@ -2090,6 +2250,9 @@ TEST_F(UpdateClientTest, OneCrxInstallError) {
       Result result;
       result.error = 0;
       result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+      result.installation_index = 0;
+#endif
 
       base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
           FROM_HERE, base::BindOnce(&MockCrxDownloader::OnDownloadProgress,
@@ -2121,14 +2284,22 @@ TEST_F(UpdateClientTest, OneCrxInstallError) {
                 CrxDownloaderError::NONE);
 
       EXPECT_EQ(ping_data[1].pipeline_id, "pipe1");  // crx3
+#if BUILDFLAG(IS_STARBOARD)
+      EXPECT_EQ(ping_data[1].error_category, ErrorCategory::kInstall);
+#else
       EXPECT_EQ(ping_data[1].error_category, ErrorCategory::kInstaller);
+#endif
       EXPECT_EQ(static_cast<InstallError>(ping_data[1].error_code),
                 InstallError::GENERIC_ERROR);
 
       EXPECT_EQ(ping_data[2].id, "jebgalgnebhfojomionfpkfelancnnkf");
       EXPECT_EQ(ping_data[2].previous_version, base::Version("0.9"));
       EXPECT_EQ(ping_data[2].next_version, base::Version("1.0"));
+#if BUILDFLAG(IS_STARBOARD)
+      EXPECT_EQ(ping_data[2].error_category, ErrorCategory::kInstall);
+#else
       EXPECT_EQ(ping_data[2].error_category, ErrorCategory::kInstaller);
+#endif
       EXPECT_EQ(static_cast<InstallError>(ping_data[2].error_code),
                 InstallError::GENERIC_ERROR);
     }
@@ -2192,6 +2363,10 @@ TEST_F(UpdateClientTest, OneCrxInstallError) {
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[4].id);
   EXPECT_EQ(ComponentState::kUpdateError, items[5].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[5].id);
+
+#if BUILDFLAG(IS_STARBOARD)
+  SetMockRequestRollForwardSuccess(true);
+#endif
 }
 
 // Tests the fallback from differential to full update scenario for one CRX.
@@ -2235,6 +2410,11 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdateFailsFullUpdateSucceeds) {
    public:
     explicit MockUpdateChecker(int num_calls) : num_calls_(num_calls) {}
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -2380,6 +2560,9 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdateFailsFullUpdateSucceeds) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -2397,6 +2580,9 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdateFailsFullUpdateSucceeds) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else if (url.path() ==
                  "/download/ihfokbkgjpifnbbojhneepfflplebdkc_1to2.puff") {
         // A download error is injected on this execution path.
@@ -2423,6 +2609,9 @@ TEST_F(UpdateClientTest, OneCrxDiffUpdateFailsFullUpdateSucceeds) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       }
 
       base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
@@ -2610,6 +2799,11 @@ TEST_F(UpdateClientTest, OneCrxNoUpdateQueuedCall) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -2644,6 +2838,9 @@ TEST_F(UpdateClientTest, OneCrxNoUpdateQueuedCall) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -2754,6 +2951,9 @@ TEST_F(UpdateClientTest, OneCrxInstall) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -2771,6 +2971,9 @@ TEST_F(UpdateClientTest, OneCrxInstall) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -2838,11 +3041,16 @@ TEST_F(UpdateClientTest, OneCrxInstall) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdating;
                 })));
+#if BUILDFLAG(IS_STARBOARD)
+    EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
+                  return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
+                         item.state == ComponentState::kUpdated;
+                })));
+#else
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdated;
                 })))
-
         .WillOnce([](const CrxUpdateItem& item) {
           ASSERT_TRUE(item.component);
           const auto* test_installer =
@@ -2851,6 +3059,7 @@ TEST_F(UpdateClientTest, OneCrxInstall) {
           EXPECT_EQ("--arg1 --arg2",
                     test_installer->install_params()->arguments);
         });
+#endif
   }
 
   std::vector<CrxUpdateItem> items;
@@ -2909,6 +3118,9 @@ TEST_F(UpdateClientTest, OneCrxInstallNoCrxComponentData) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -2994,6 +3206,11 @@ TEST_F(UpdateClientTest, ConcurrentInstallSameCRX) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -3028,6 +3245,9 @@ TEST_F(UpdateClientTest, ConcurrentInstallSameCRX) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -3116,6 +3336,9 @@ TEST_F(UpdateClientTest, EmptyIdList) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -3176,6 +3399,9 @@ TEST_F(UpdateClientTest, DiskFull) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -3295,6 +3521,11 @@ TEST_F(UpdateClientTest, DiskFullDiff) {
    public:
     explicit MockUpdateChecker(int num_calls) : num_calls_(num_calls) {}
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -3440,6 +3671,9 @@ TEST_F(UpdateClientTest, DiskFullDiff) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -3457,6 +3691,9 @@ TEST_F(UpdateClientTest, DiskFullDiff) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -3574,6 +3811,29 @@ TEST_F(UpdateClientTest, DiskFullDiff) {
         false, ExpectErrorThenQuit(runloop, Error::NONE));
     runloop.Run();
 
+    #if BUILDFLAG(IS_STARBOARD)
+    EXPECT_EQ(7u, items.size());
+    EXPECT_EQ(ComponentState::kChecking, items[0].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[0].id);
+    EXPECT_EQ(ComponentState::kCanUpdate, items[1].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[1].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[2].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[2].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[3].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[3].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[4].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[4].id);
+    EXPECT_EQ(ComponentState::kUpdating, items[5].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[5].id);
+    EXPECT_EQ(ComponentState::kUpdated, items[6].state);
+    EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[6].id);
+
+    std::vector samples = {-1, -1, -1, -1, -1, -1, -1};
+    EXPECT_EQ(items.size(), samples.size());
+    for (size_t i = 0; i != items.size(); ++i) {
+      EXPECT_EQ(items[i].install_progress, samples[i]);
+    }
+#else
     EXPECT_EQ(10u, items.size());
     EXPECT_EQ(ComponentState::kChecking, items[0].state);
     EXPECT_EQ("ihfokbkgjpifnbbojhneepfflplebdkc", items[0].id);
@@ -3601,6 +3861,7 @@ TEST_F(UpdateClientTest, DiskFullDiff) {
     for (size_t i = 0; i != items.size(); ++i) {
       EXPECT_EQ(items[i].install_progress, samples[i]);
     }
+#endif
   }
 
   {
@@ -3674,6 +3935,9 @@ TEST_P(SendPingTest, SendPingTestCases) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       return base::DoNothing();
     }
@@ -3746,6 +4010,11 @@ TEST_F(UpdateClientTest, RetryAfter) {
     explicit MockUpdateChecker(int num_calls) : num_calls_(num_calls) {}
 
    private:
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -3788,6 +4057,9 @@ TEST_F(UpdateClientTest, RetryAfter) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -3919,6 +4191,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateOneUpdateDisabled) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -3936,6 +4211,9 @@ TEST_F(UpdateClientTest, TwoCrxUpdateOneUpdateDisabled) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -4091,6 +4369,9 @@ TEST_F(UpdateClientTest, OneCrxUpdateDownloadTimeout) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       download_metrics.url = url;
@@ -4237,6 +4518,11 @@ TEST_F(UpdateClientTest, OneCrxUpdateCheckFails) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -4261,6 +4547,9 @@ TEST_F(UpdateClientTest, OneCrxUpdateCheckFails) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -4273,7 +4562,13 @@ TEST_F(UpdateClientTest, OneCrxUpdateCheckFails) {
         : MockPingManagerImpl(config) {}
 
    protected:
-    ~MockPingManager() override { EXPECT_TRUE(ping_data().empty()); }
+    ~MockPingManager() override {
+#if BUILDFLAG(IS_STARBOARD)
+      EXPECT_EQ(1u, ping_data().size());
+#else
+      EXPECT_TRUE(ping_data().empty());
+#endif
+    }
   };
 
   SetMockCrxDownloader<MockCrxDownloader>();
@@ -4379,6 +4674,11 @@ TEST_F(UpdateClientTest, OneCrxErrorUnknownApp) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -4429,6 +4729,9 @@ TEST_F(UpdateClientTest, OneCrxErrorUnknownApp) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -4441,7 +4744,13 @@ TEST_F(UpdateClientTest, OneCrxErrorUnknownApp) {
         : MockPingManagerImpl(config) {}
 
    protected:
-    ~MockPingManager() override { EXPECT_TRUE(ping_data().empty()); }
+    ~MockPingManager() override {
+#if BUILDFLAG(IS_STARBOARD)
+      EXPECT_EQ(4u, ping_data().size());
+#else
+      EXPECT_TRUE(ping_data().empty());
+#endif
+    }
   };
 
   SetMockCrxDownloader<MockCrxDownloader>();
@@ -4534,6 +4843,11 @@ TEST_F(UpdateClientTest, ActionRun_Install) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -4603,6 +4917,9 @@ TEST_F(UpdateClientTest, ActionRun_Install) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -4620,6 +4937,9 @@ TEST_F(UpdateClientTest, ActionRun_Install) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -4734,6 +5054,9 @@ TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -4770,9 +5093,19 @@ TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
     base::RunLoop runloop;
     base::OnceClosure quit_closure = runloop.QuitClosure();
 
+#if BUILDFLAG(IS_STARBOARD)
+    OperationResult op_result;
+    base::FilePath temp_crx_path;
+    EXPECT_TRUE(MakeTestFile(GetTestFilePath("runaction_test_win.crx3"), &temp_crx_path));
+    op_result.response = temp_crx_path;
+    Unpacker::Unpack(
+        std::vector<uint8_t>(std::begin(gjpm_hash), std::end(gjpm_hash)),
+        op_result,
+#else
     Unpacker::Unpack(
         std::vector<uint8_t>(std::begin(gjpm_hash), std::end(gjpm_hash)),
         GetTestFilePath("runaction_test_win.crx3"),
+#endif
         base::MakeRefCounted<UnzipChromiumFactory>(
             base::BindRepeating(&unzip::LaunchInProcessUnzipper))
             ->Create(),
@@ -4791,6 +5124,7 @@ TEST_F(UpdateClientTest, ActionRun_NoUpdate) {
   }
 
   EXPECT_FALSE(unpack_path.empty());
+  LOG(INFO) << "ActionRun_NoUpdate: unpack_path = " << unpack_path.value();
   EXPECT_TRUE(base::DirectoryExists(unpack_path));
   std::optional<int64_t> file_size = base::GetFileSize(
       unpack_path.Append(FILE_PATH_LITERAL("ChromeRecovery.crx3")));
@@ -4866,6 +5200,11 @@ TEST_F(UpdateClientTest, CustomAttributeNoUpdate) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -4902,6 +5241,9 @@ TEST_F(UpdateClientTest, CustomAttributeNoUpdate) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -5018,6 +5360,9 @@ TEST_F(UpdateClientTest, CancelInstallBeforeTaskStart) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -5035,6 +5380,9 @@ TEST_F(UpdateClientTest, CancelInstallBeforeTaskStart) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -5118,6 +5466,9 @@ TEST_F(UpdateClientTest, CancelInstallBeforeInstall) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -5135,6 +5486,9 @@ TEST_F(UpdateClientTest, CancelInstallBeforeInstall) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -5165,9 +5519,14 @@ TEST_F(UpdateClientTest, CancelInstallBeforeInstall) {
       EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", ping_data[0].id);
       EXPECT_EQ(base::Version("0.0"), ping_data[0].previous_version);
       EXPECT_EQ(base::Version("1.0"), ping_data[0].next_version);
+#if BUILDFLAG(IS_STARBOARD)
+      EXPECT_EQ(ErrorCategory::kNone, ping_data[0].error_category);
+      EXPECT_EQ(0, ping_data[0].error_code);
+#else
       EXPECT_EQ(ErrorCategory::kService, ping_data[0].error_category);
       EXPECT_EQ(static_cast<int>(ServiceError::CANCELLED),
                 ping_data[0].error_code);
+#endif
     }
   };
 
@@ -5196,10 +5555,12 @@ TEST_F(UpdateClientTest, CancelInstallBeforeInstall) {
                 })))
         .Times(AtLeast(1))
         .WillRepeatedly([&cancel] { cancel.Run(); });
+#if !BUILDFLAG(IS_STARBOARD)
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdateError;
                 })));
+#endif
   }
 
   std::vector<CrxUpdateItem> items;
@@ -5215,17 +5576,23 @@ TEST_F(UpdateClientTest, CancelInstallBeforeInstall) {
       ExpectErrorThenQuit(runloop_, Error::NONE));
   runloop_.Run();
 
-  EXPECT_EQ(5u, items.size());
+#if BUILDFLAG(IS_STARBOARD)
+  ASSERT_EQ(3u, items.size());
+#else
+  ASSERT_EQ(5u, items.size());
+#endif
   EXPECT_EQ(ComponentState::kChecking, items[0].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[0].id);
   EXPECT_EQ(ComponentState::kCanUpdate, items[1].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[1].id);
   EXPECT_EQ(ComponentState::kDownloading, items[2].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[2].id);
+#if !BUILDFLAG(IS_STARBOARD)
   EXPECT_EQ(ComponentState::kDownloading, items[3].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[3].id);
   EXPECT_EQ(ComponentState::kUpdateError, items[4].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[4].id);
+#endif
 }
 
 // Tests cancellation of an install before the download.
@@ -5258,6 +5625,9 @@ TEST_F(UpdateClientTest, CancelInstallBeforeDownload) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       base::FilePath path;
@@ -5275,6 +5645,9 @@ TEST_F(UpdateClientTest, CancelInstallBeforeDownload) {
 
         result.error = 0;
         result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+        result.installation_index = 0;
+#endif
       } else {
         ADD_FAILURE();
       }
@@ -5331,10 +5704,12 @@ TEST_F(UpdateClientTest, CancelInstallBeforeDownload) {
                          item.state == ComponentState::kCanUpdate;
                 })))
         .WillOnce([&cancel] { cancel.Run(); });
+#if !BUILDFLAG(IS_STARBOARD)
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdateError;
                 })));
+#endif
   }
 
   std::vector<CrxUpdateItem> items;
@@ -5350,13 +5725,19 @@ TEST_F(UpdateClientTest, CancelInstallBeforeDownload) {
       ExpectErrorThenQuit(runloop_, Error::NONE));
   runloop_.Run();
 
-  EXPECT_EQ(3u, items.size());
+#if BUILDFLAG(IS_STARBOARD)
+  ASSERT_EQ(2u, items.size());
+#else
+  ASSERT_EQ(3u, items.size());
+#endif
   EXPECT_EQ(ComponentState::kChecking, items[0].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[0].id);
   EXPECT_EQ(ComponentState::kCanUpdate, items[1].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[1].id);
+#if !BUILDFLAG(IS_STARBOARD)
   EXPECT_EQ(ComponentState::kUpdateError, items[2].state);
   EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[2].id);
+#endif
 }
 
 TEST_F(UpdateClientTest, CheckForUpdate_NoUpdate) {
@@ -5381,6 +5762,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_NoUpdate) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -5416,6 +5802,9 @@ TEST_F(UpdateClientTest, CheckForUpdate_NoUpdate) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -5497,6 +5886,9 @@ TEST_F(UpdateClientTest, CheckForUpdate_UpdateAvailable) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -5582,6 +5974,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_QueueChecks) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -5617,6 +6014,9 @@ TEST_F(UpdateClientTest, CheckForUpdate_QueueChecks) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -5713,6 +6113,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_Stop) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -5748,6 +6153,9 @@ TEST_F(UpdateClientTest, CheckForUpdate_Stop) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -5818,6 +6226,11 @@ TEST_F(UpdateClientTest, CheckForUpdate_Errors) {
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -5832,6 +6245,9 @@ TEST_F(UpdateClientTest, CheckForUpdate_Errors) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -5937,6 +6353,9 @@ TEST_F(UpdateClientTest, UpdateCheck_UpdateDisabled) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();
@@ -6057,6 +6476,9 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       DownloadMetrics download_metrics;
       download_metrics.url = url;
@@ -6073,6 +6495,9 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
       Result result;
       result.error = 0;
       result.response = path;
+#if BUILDFLAG(IS_STARBOARD)
+      result.installation_index = 0;
+#endif
 
       base::SequencedTaskRunner::GetCurrentDefault()->PostTask(
           FROM_HERE, base::BindOnce(&MockCrxDownloader::OnDownloadProgress,
@@ -6136,11 +6561,13 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdating;
                 })));
+#if !BUILDFLAG(IS_STARBOARD)
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdating;
                 })))
         .Times(2);
+#endif
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdateError;
@@ -6154,15 +6581,24 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kCanUpdate;
                 })));
+#if BUILDFLAG(IS_STARBOARD)
+    EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
+                  return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
+                         item.state == ComponentState::kDownloading;
+                })))
+        .Times(2);
+#endif
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdating;
                 })));
+#if !BUILDFLAG(IS_STARBOARD)
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdating;
                 })))
         .Times(3);
+#endif
     EXPECT_CALL(observer, OnEvent(Truly([](const CrxUpdateItem& item) {
                   return item.id == "jebgalgnebhfojomionfpkfelancnnkf" &&
                          item.state == ComponentState::kUpdated;
@@ -6170,6 +6606,9 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
   }
 
   const std::vector<std::string> ids = {"jebgalgnebhfojomionfpkfelancnnkf"};
+#if BUILDFLAG(IS_STARBOARD)
+  SetMockRequestRollForwardSuccess(false);
+#endif
   {
     std::vector<CrxUpdateItem> items;
     auto receiver = base::MakeRefCounted<MockCrxStateChangeReceiver>();
@@ -6184,6 +6623,27 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
         false, ExpectErrorThenQuit(runloop, Error::NONE));
     runloop.Run();
 
+#if BUILDFLAG(IS_STARBOARD)
+    EXPECT_EQ(6u, items.size());
+    EXPECT_EQ(ComponentState::kChecking, items[0].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[0].id);
+    EXPECT_EQ(ComponentState::kCanUpdate, items[1].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[1].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[2].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[2].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[3].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[3].id);
+    EXPECT_EQ(ComponentState::kUpdating, items[4].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[4].id);
+    EXPECT_EQ(ComponentState::kUpdateError, items[5].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[5].id);
+
+    std::vector samples = {-1, -1, -1, -1, -1, -1};
+    EXPECT_EQ(items.size(), samples.size());
+    for (size_t i = 0; i != items.size(); ++i) {
+      EXPECT_EQ(items[i].install_progress, samples[i]);
+    }
+#else
     EXPECT_EQ(8u, items.size());
     EXPECT_EQ(ComponentState::kChecking, items[0].state);
     EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[0].id);
@@ -6207,7 +6667,12 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
     for (size_t i = 0; i != items.size(); ++i) {
       EXPECT_EQ(items[i].install_progress, samples[i]);
     }
+#endif
   }
+
+#if BUILDFLAG(IS_STARBOARD)
+  SetMockRequestRollForwardSuccess(true);
+#endif
 
   {
     std::vector<CrxUpdateItem> items;
@@ -6223,6 +6688,27 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
         false, ExpectErrorThenQuit(runloop, Error::NONE));
     runloop.Run();
 
+#if BUILDFLAG(IS_STARBOARD)
+    EXPECT_EQ(6u, items.size());
+    EXPECT_EQ(ComponentState::kChecking, items[0].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[0].id);
+    EXPECT_EQ(ComponentState::kCanUpdate, items[1].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[1].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[2].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[2].id);
+    EXPECT_EQ(ComponentState::kDownloading, items[3].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[3].id);
+    EXPECT_EQ(ComponentState::kUpdating, items[4].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[4].id);
+    EXPECT_EQ(ComponentState::kUpdated, items[5].state);
+    EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[5].id);
+
+    std::vector samples = {-1, -1, -1, -1, -1, -1};
+    EXPECT_EQ(items.size(), samples.size());
+    for (size_t i = 0; i != items.size(); ++i) {
+      EXPECT_EQ(items[i].install_progress, samples[i]);
+    }
+#else
     EXPECT_EQ(7u, items.size());
     EXPECT_EQ(ComponentState::kChecking, items[0].state);
     EXPECT_EQ("jebgalgnebhfojomionfpkfelancnnkf", items[0].id);
@@ -6244,6 +6730,7 @@ TEST_F(UpdateClientTest, OneCrxCachedUpdate) {
     for (size_t i = 0; i != items.size(); ++i) {
       EXPECT_EQ(items[i].install_progress, samples[i]);
     }
+#endif
   }
 }
 
@@ -6277,6 +6764,9 @@ TEST_F(UpdateClientTest, UnsupportedOperationType) {
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE() << "Intentionally forcing download to fail here.";
       return base::DoNothing();
@@ -6378,6 +6868,11 @@ TEST_F(UpdateClientTest,
    public:
     MockUpdateChecker() = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void Cancel() override {}
+    bool SkipUpdate(const CobaltExtensionInstallationManagerApi* installation_api) override { return false; }
+    PersistedData* GetPersistedData() override { return nullptr; }
+#endif
     void CheckForUpdates(
         scoped_refptr<UpdateContext> context,
         const base::flat_map<std::string, std::string>& additional_attributes,
@@ -6491,6 +6986,9 @@ TEST_F(UpdateClientTest,
    private:
     ~MockCrxDownloader() override = default;
 
+#if BUILDFLAG(IS_STARBOARD)
+    void DoCancelDownload() override {}
+#endif
     base::OnceClosure DoStartDownload(const GURL& url) override {
       ADD_FAILURE();
       return base::DoNothing();

--- a/components/update_client/utils_unittest.cc
+++ b/components/update_client/utils_unittest.cc
@@ -27,6 +27,38 @@
 
 namespace update_client {
 
+#if defined(IN_MEMORY_UPDATES)
+TEST(UpdateClientUtils, VerifyHash256) {
+  std::string content;
+  EXPECT_TRUE(base::ReadFileToString(GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"), &content));
+  EXPECT_TRUE(VerifyHash256(
+      &content,
+      std::string(
+          "7ab32f071cd9b5ef8e0d7913be161f532d98b3e9fa284a7cd8059c3409ce0498")));
+
+  std::string empty_content;
+  // Note: GetTestFilePath might return a path that doesn't exist if "empty_file" is not in test data.
+  // But assuming it exists as in original test.
+  EXPECT_TRUE(base::ReadFileToString(GetTestFilePath("empty_file"), &empty_content));
+  EXPECT_TRUE(VerifyHash256(
+      &empty_content,
+      std::string(
+          "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855")));
+
+  EXPECT_FALSE(
+      VerifyHash256(&content,
+                        std::string("")));
+
+  EXPECT_FALSE(
+      VerifyHash256(&content,
+                        std::string("abcd")));
+
+  EXPECT_FALSE(VerifyHash256(
+      &content,
+      std::string(
+          "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
+}
+#else
 TEST(UpdateClientUtils, VerifyFileHash256) {
   EXPECT_TRUE(VerifyFileHash256(
       GetTestFilePath("jebgalgnebhfojomionfpkfelancnnkf.crx"),
@@ -51,6 +83,7 @@ TEST(UpdateClientUtils, VerifyFileHash256) {
       std::string(
           "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa")));
 }
+#endif
 
 // Tests that the brand matches ^[a-zA-Z]{4}?$
 TEST(UpdateClientUtils, IsValidBrand) {


### PR DESCRIPTION
Adapt and enable components/update_client unit tests for Evergreen platforms to verify in-memory update pipeline behaviors.

Unit test:
`autoninja -C out/evergreen-x64_debug/update_client_unittests && out/evergreen-x64_debug/update_client_unittests
`
Bug: 446745795