### PR TITLE
aosp: wrap mkostemp

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -349,6 +349,8 @@ static_library("starboard_platform") {
       "posix_emu/file.cc",
       "posix_emu/net_if.cc",
       "posix_emu/stat.cc",
+      "posix_emu/stdlib.cc",
+      "posix_emu/unistd.cc",
     ]
 
     public_deps += [

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -354,6 +354,7 @@ static_library("starboard_platform") {
       "posix_emu/file.cc",
       "posix_emu/net_if.cc",
       "posix_emu/stat.cc",
+      "posix_emu/stdlib.cc",
     ]
 
     public_deps += [

--- a/starboard/android/shared/posix_emu/stdlib.cc
+++ b/starboard/android/shared/posix_emu/stdlib.cc
@@ -1,0 +1,60 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <fcntl.h>
+#include <stdint.h>
+#include <string.h>
+#include <time.h>
+#include <unistd.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// Implementations below exposed externally in pure C for emulation.
+///////////////////////////////////////////////////////////////////////////////
+
+extern "C" {
+
+// Reimplementation of musl's __randname.
+static void randname(char* tmpl) {
+  struct timespec ts;
+  clock_gettime(CLOCK_REALTIME, &ts);
+  unsigned long r =
+      ts.tv_sec + ts.tv_nsec + (unsigned long)((uintptr_t)tmpl) * 65537UL;
+  for (int i = 0; i < 6; i++, r >>= 5) {
+    tmpl[i] = 'A' + (r & 15) + (r & 16) * 2;
+  }
+}
+
+int __wrap_mkostemp(char* tmpl, int flags) {
+  size_t l = strlen(tmpl);
+  if (l < 6 || memcmp(tmpl + l - 6, "XXXXXX", 6)) {
+    errno = EINVAL;
+    return -1;
+  }
+
+  flags -= flags & O_ACCMODE;
+  int retries = 100;
+  do {
+    randname(tmpl + l - 6);
+    int fd = openat(AT_FDCWD, tmpl, flags | O_RDWR | O_CREAT | O_EXCL, 0600);
+    if (fd >= 0) {
+      return fd;
+    }
+  } while (--retries && errno == EEXIST);
+
+  memcpy(tmpl + l - 6, "XXXXXX", 6);
+  return -1;
+}
+
+}  // extern "C"

--- a/starboard/android/shared/posix_emu/stdlib.cc
+++ b/starboard/android/shared/posix_emu/stdlib.cc
@@ -1,0 +1,34 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fcntl.h>
+#include <stdlib.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// Implementations below exposed externally in pure C for emulation.
+///////////////////////////////////////////////////////////////////////////////
+
+extern "C" {
+
+int __real_mkostemp(char* tmpl, int flags);
+
+int __wrap_mkostemp(char* tmpl, int flags) {
+  // Bionic only accepts O_APPEND|O_CLOEXEC|O_DSYNC|O_RSYNC|O_SYNC here and
+  // supplies O_RDWR|O_CREAT|O_EXCL itself, while musl callers pass those in.
+  // Drop them; any other flag musl would forward to open() is still rejected.
+  flags &= ~(O_ACCMODE | O_CREAT | O_EXCL);
+  return __real_mkostemp(tmpl, flags);
+}
+
+}  // extern "C"

--- a/starboard/android/shared/posix_emu/unistd.cc
+++ b/starboard/android/shared/posix_emu/unistd.cc
@@ -1,0 +1,31 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <fcntl.h>
+#include <unistd.h>
+
+///////////////////////////////////////////////////////////////////////////////
+// Implementations below exposed externally in pure C for emulation.
+///////////////////////////////////////////////////////////////////////////////
+
+extern "C" {
+
+// POSIX leaves it implementation-defined whether link() follows a symbolic
+// link named by path1. Route through linkat() with a 0 flag (no-follow),
+// matching bionic's link().
+int __wrap_link(const char* path1, const char* path2) {
+  return linkat(AT_FDCWD, path1, AT_FDCWD, path2, 0);
+}
+
+}  // extern "C"

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -24,6 +24,7 @@ config("platform_configuration") {
       "-Wl,--wrap=close",
       "-Wl,--wrap=fstatat",
       "-Wl,--wrap=if_indextoname",
+      "-Wl,--wrap=mkostemp",
       "-Wl,--wrap=open",
       "-Wl,--wrap=openat",
       "-Wl,--wrap=stat",

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -25,6 +25,7 @@ config("platform_configuration") {
       "-Wl,--wrap=close",
       "-Wl,--wrap=fstatat",
       "-Wl,--wrap=if_indextoname",
+      "-Wl,--wrap=mkostemp",
       "-Wl,--wrap=open",
       "-Wl,--wrap=openat",
       "-Wl,--wrap=stat",


### PR DESCRIPTION
Bionic's implementation of these functions differs a bit from musl.

- mkostemp: bionic rejects a flags argument that includes the access mode or
  O_CREAT/O_EXCL with EINVAL, which musl callers pass.

Fixes the following nplb tests:
  - FileTempTest.MkostempBasicSuccess
  - FileTempTest.MkostempWithFlags
  - FileTempTest.MkostempNonExistentPath
  - FileTempTest.MkostempWriteFile

Bug: 53206840