### PR TITLE
nplb: relax rules for checking modes of created directories

### DIFF
--- a/starboard/nplb/file_helpers.cc
+++ b/starboard/nplb/file_helpers.cc
@@ -171,6 +171,12 @@ bool DirectoryExists(const char* path) {
   return stat(path, &info) == 0 && S_ISDIR(info.st_mode);
 }
 
+bool PermissionsAreSubsetOf(mode_t st_mode, mode_t requested) {
+  const mode_t kPermissionMask = S_IRWXU | S_IRWXG | S_IRWXO;  // 0777
+  const mode_t actual = st_mode & kPermissionMask;
+  return (actual & requested) == actual;
+}
+
 ScopedTempDir::ScopedTempDir() {
   std::string temp_dir = GetTempDir();
   if (temp_dir.empty()) {

--- a/starboard/nplb/file_helpers.h
+++ b/starboard/nplb/file_helpers.h
@@ -16,6 +16,7 @@
 #define STARBOARD_NPLB_FILE_HELPERS_H_
 
 #include <fcntl.h>
+#include <sys/stat.h>
 #include <unistd.h>
 
 #include <string>
@@ -25,6 +26,15 @@ namespace nplb {
 
 constexpr mode_t kUserRwx = S_IRUSR | S_IWUSR | S_IXUSR;
 constexpr mode_t kUserRw = S_IRUSR | S_IWUSR;
+
+// Returns whether the permission bits reported by stat() in st_mode are a
+// subset of the requested creation mode.
+// The comparison is restricted to the standard rw permission bits (0777)
+// because extra mode bits may be set independently of the requested mode.
+// e.g.: on Android the app's data/cache directory tree carries the setgid
+// bit, so the kernel propagates S_ISGID to every directory created under it
+// (fs/inode.c:inode_init_owner()), on top of the mode passed to mkdir().
+bool PermissionsAreSubsetOf(mode_t st_mode, mode_t requested);
 
 // Gets the temporary directory in which ScopedRandomFile places its files.
 std::string GetTempDir();

--- a/starboard/nplb/posix_compliance/posix_mkdir_test.cc
+++ b/starboard/nplb/posix_compliance/posix_mkdir_test.cc
@@ -72,7 +72,7 @@ TEST_F(PosixMkdirTest, SuccessfulCreation) {
 
   // The requested mode is masked by the process's umask. We can only check
   // that the resulting permissions are a subset of the requested ones.
-  EXPECT_EQ((sb.st_mode & ~S_IFMT) & mode, (sb.st_mode & ~S_IFMT));
+  EXPECT_TRUE(PermissionsAreSubsetOf(sb.st_mode, mode));
 
   // Verify the directory is empty (contains only "." and "..").
   DIR* dirp = opendir(dir_path.c_str());


### PR DESCRIPTION
nplb: relax rules for checking modes of created directories

On Android the app's data/cache directory tree carries the setgid bit, so the
kernel propagates S_ISGID (setgid, 02000) to every directory created under it.
stat() then reports e.g. 02700 instead of 0700, on top of the requested mode.

mkdir() call sites either ignore the returned mode or check only S_ISDIR, so
this change only relaxes the mode checking in the nplb tests instead of
creating a mkdir wrapper for stripping S_ISGID that would interfere with
Android's group model.

Bug: 53206840