### PR TITLE
aosp: implement font directory paths in SbSystemGetPath

### DIFF
--- a/starboard/android/shared/system_get_path.cc
+++ b/starboard/android/shared/system_get_path.cc
@@ -22,15 +22,34 @@
 
 #include <cstring>
 
+#include "build/build_config.h"
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
+#include "starboard/elf_loader/evergreen_config.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 using ::starboard::g_app_assets_dir;
 using ::starboard::g_app_cache_dir;
 using ::starboard::g_app_files_dir;
 using ::starboard::g_app_lib_dir;
+
+#if BUILDFLAG(IS_STARBOARD)
+namespace {
+
+// Returns the base content path, which is the Evergreen content path when one
+// is configured, or the app's asset directory otherwise.
+const char* GetContentPath() {
+  const elf_loader::EvergreenConfig* evergreen_config =
+      elf_loader::EvergreenConfig::GetInstance();
+  if (evergreen_config && !evergreen_config->content_path_.empty()) {
+    return evergreen_config->content_path_.c_str();
+  }
+  return g_app_assets_dir;
+}
+
+}  // namespace
+#endif
 
 bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
   if (!out_path || !path_size) {
@@ -52,8 +71,18 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
 
     case kSbSystemPathFontConfigurationDirectory:
     case kSbSystemPathFontDirectory:
+#if BUILDFLAG(IS_STARBOARD)
+      if (starboard::strlcpy(path, GetContentPath(), kPathSize) >= kPathSize) {
+        return false;
+      }
+      if (starboard::strlcat(path, "/fonts", kPathSize) >= kPathSize) {
+        return false;
+      }
+      break;
+#else
       SB_NOTIMPLEMENTED();
       return false;
+#endif
 
     case kSbSystemPathStorageDirectory: {
       if (starboard::strlcpy(path, g_app_files_dir, kPathSize) >= kPathSize) {


### PR DESCRIPTION
kSbSystemPathFontDirectory and kSbSystemPathFontConfigurationDirectory returned SB_NOTIMPLEMENTED, failing FontsTest.

Packaged fonts live under the Evergreen content directory, so return EvergreenConfig::content_path_ + "/fonts".

Bug: 532068409