### PR TITLE
aosp: register the LoaderAppMetrics extension

### DIFF
--- a/starboard/android/shared/system_get_extensions.cc
+++ b/starboard/android/shared/system_get_extensions.cc
@@ -42,6 +42,11 @@
 #include "starboard/extension/system_info.h"
 #include "starboard/shared/starboard/experimental_features.h"
 
+#if BUILDFLAG(IS_STARBOARD)
+#include "starboard/extension/loader_app_metrics.h"
+#include "starboard/shared/starboard/loader_app_metrics.h"
+#endif  // BUILDFLAG(IS_STARBOARD)
+
 const void* SbSystemGetExtension(const char* name) {
   if (strcmp(name, kCobaltExtensionPlatformServiceName) == 0) {
     return starboard::GetPlatformServiceApiAndroid();
@@ -90,5 +95,10 @@ const void* SbSystemGetExtension(const char* name) {
   if (strcmp(name, kStarboardExtensionSystemInfoName) == 0) {
     return starboard::GetSystemInfoApi();
   }
+#if BUILDFLAG(IS_STARBOARD)
+  if (strcmp(name, kStarboardExtensionLoaderAppMetricsName) == 0) {
+    return starboard::GetLoaderAppMetricsApi();
+  }
+#endif  // BUILDFLAG(IS_STARBOARD)
   return NULL;
 }


### PR DESCRIPTION
App metrics test fails because SbSystemGetExtension was returning NULL for kStarboardExtensionLoaderAppMetricsName, so return the proper registered extension.

Bug: 532068409