### PR TITLE
android/mic: return -1 from SbMicrophoneRead for a NULL buffer

### DIFF
--- a/starboard/android/shared/microphone_impl.cc
+++ b/starboard/android/shared/microphone_impl.cc
@@ -230,7 +230,13 @@ int SbMicrophoneImpl::Read(void* out_audio_data, int audio_data_size) {
     return -1;
   }
 
-  if (!out_audio_data || audio_data_size == 0 || state_ == kWaitPermission) {
+  // If reading audio_data_size bytes is expected, a null output
+  // buffer is an invalid argument.
+  if (audio_data_size > 0 && !out_audio_data) {
+    return -1;
+  }
+
+  if (audio_data_size == 0 || state_ == kWaitPermission) {
     // No data to be read.
     return 0;
   }

--- a/starboard/nplb/microphone_read_test.cc
+++ b/starboard/nplb/microphone_read_test.cc
@@ -119,7 +119,14 @@ TEST(SbMicrophoneReadTest, RainyDayAudioBufferIsNULL) {
 
     EXPECT_TRUE(SbMicrophoneOpen(microphone));
 
+    // If 0 bytes are expected, a null output buffer
+    // is not an issue
     int read_bytes = SbMicrophoneRead(microphone, NULL, 0);
+    EXPECT_EQ(read_bytes, 0);
+
+    // If reading audio_data_size bytes is expected, a null output
+    // buffer is an invalid argument.
+    read_bytes = SbMicrophoneRead(microphone, NULL, kBufferSize);
     EXPECT_EQ(read_bytes, -1);
 
     EXPECT_TRUE(SbMicrophoneClose(microphone));


### PR DESCRIPTION
Update SbMicrophoneImpl::Read logic and
SbMicrophoneReadTest.RainyDayAudioBufferIsNULL test expectations to
consider an output buffer an invalid argument when the size of bytes
expected to be read is valid.

Bug: 532068409