### PR TITLE
aosp: normalize if_indextoname behavior

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -349,6 +349,7 @@ static_library("starboard_platform") {
       "posix_emu/access.cc",
       "posix_emu/errno.cc",
       "posix_emu/file.cc",
+      "posix_emu/net_if.cc",
       "posix_emu/stat.cc",
     ]
 

--- a/starboard/android/shared/posix_emu/net_if.cc
+++ b/starboard/android/shared/posix_emu/net_if.cc
@@ -1,0 +1,31 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <errno.h>
+#include <net/if.h>
+
+extern "C" {
+
+char* __real_if_indextoname(unsigned int ifindex, char* ifname);
+
+char* __wrap_if_indextoname(unsigned int ifindex, char* ifname) {
+  char* res = __real_if_indextoname(ifindex, ifname);
+  if (res == nullptr && errno == ENODEV) {
+    // POSIX reports ENXIO for a nonexistent index; bionic reports ENODEV.
+    errno = ENXIO;
+  }
+  return res;
+}
+
+}  // extern "C"

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -23,6 +23,7 @@ config("platform_configuration") {
       "-Wl,--wrap=access",
       "-Wl,--wrap=close",
       "-Wl,--wrap=fstatat",
+      "-Wl,--wrap=if_indextoname",
       "-Wl,--wrap=open",
       "-Wl,--wrap=openat",
       "-Wl,--wrap=stat",


### PR DESCRIPTION
bionic's if_indextoname sets ENODEV for a nonexistent interface index, while POSIX expects ENXIO.

Bug: 532068409