### PR TITLE
Use std::optional for MeasureUsedSwapMemory

### DIFF
--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -77,19 +77,20 @@ void PerformanceImpl::MeasureUsedCpuMemory(
 void PerformanceImpl::MeasureUsedSwapMemory(
     MeasureUsedSwapMemoryCallback callback) {
 #if BUILDFLAG(IS_IOS_TVOS)
-  // TODO: b/497682329 - vm_swap_bytes does not exist on tvOS.
-  std::move(callback).Run(0);
+  // vm_swap_bytes does not exist on tvOS.
+  std::move(callback).Run(std::nullopt);
 #else
   base::ThreadPool::PostTaskAndReplyWithResult(
       FROM_HERE, {base::MayBlock(), base::TaskPriority::USER_VISIBLE},
-      base::BindOnce([]() -> uint64_t {
+      base::BindOnce([]() -> std::optional<uint64_t> {
         auto process_metrics = base::ProcessMetrics::CreateProcessMetrics(
             base::GetCurrentProcessHandle());
         if (!process_metrics) {
-          return 0;
+          return std::nullopt;
         }
         auto info = process_metrics->GetMemoryInfo();
-        return info.has_value() ? info->vm_swap_bytes : 0;
+        return info.has_value() ? std::make_optional(info->vm_swap_bytes)
+                                : std::nullopt;
       }),
       std::move(callback));
 #endif  // BUILDFLAG(IS_IOS_TVOS)

--- a/cobalt/browser/performance/public/mojom/performance.mojom
+++ b/cobalt/browser/performance/public/mojom/performance.mojom
@@ -26,7 +26,7 @@ interface CobaltPerformance {
 
   // Get the amount of virtual memory that has been swapped out to disk in bytes.
   [Sync]
-  MeasureUsedSwapMemory() => (uint64 bytes);
+  MeasureUsedSwapMemory() => (uint64? bytes);
 
   // Get the amount of virtual memory currently allocated to the process in bytes.
   [Sync]

--- a/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
+++ b/third_party/blink/renderer/core/cobalt/performance/performance_extensions.cc
@@ -58,9 +58,9 @@ uint64_t PerformanceExtensions::measureUsedCpuMemory(ScriptState* script_state,
 
 uint64_t PerformanceExtensions::measureUsedSwapMemory(ScriptState* script_state,
                                                       const Performance&) {
-  uint64_t used_swap_memory = 0;
+  std::optional<uint64_t> used_swap_memory = std::nullopt;
   BindRemotePerformance(script_state)->MeasureUsedSwapMemory(&used_swap_memory);
-  return used_swap_memory;
+  return used_swap_memory.value_or(0);
 }
 
 uint64_t PerformanceExtensions::measureReservedVirtualMemory(


### PR DESCRIPTION
This changes the return type of MeasureUsedSwapMemory to std::optional, allowing the swap memory value to be unavailable on platforms where it cannot be measured, such as tvOS.

Bug: 497682329