### PR TITLE
Disable Privacy Sandbox APIs and stub out components for Cobalt

### DIFF
--- a/cobalt/build/configs/cobalt.gni
+++ b/cobalt/build/configs/cobalt.gni
@@ -19,10 +19,10 @@ declare_args() {
 
   # This argument is not present in upstream Chromium, so we must declare it
   # here in a `.gni` file before it can be used in other GN files.
-  # We keep it enabled (true) for now until all components are gated.
+  # Defaulted to false to disable Privacy Sandbox components and reduce binary size.
   # TODO(b/505811196): Remove this argument once Cobalt rebased to the milestone
   # where the privacy sandbox components are fully removed.
-  enable_privacy_sandbox_apis = true
+  enable_privacy_sandbox_apis = false
 
   # Whether to enable the custom on-screen keyboard Web API and browser process
   # implementation.

--- a/content/browser/BUILD.gn
+++ b/content/browser/BUILD.gn
@@ -3774,10 +3774,24 @@ source_set("browser") {
                                          "browsing_topics/*",
                                          "attribution_reporting/*",
                                          "shared_storage/*",
+                                         "interest_group/*",
+                                         "private_aggregation/*",
+                                         "aggregation_service/*",
+                                         "devtools/auction_worklet_devtools_agent_host.*",
                                        ])
     sources = []
     sources = _filtered_sources
-    deps -= [ "//components/browsing_topics/common:common" ]
+    deps -= [
+      "//components/browsing_topics/common:common",
+      "//content/browser/aggregation_service/proto:aggregatable_report_proto",
+      "//content/browser/attribution_reporting:attribution_reporting_proto",
+      "//content/browser/attribution_reporting:internals_mojo_bindings",
+      "//content/browser/attribution_reporting:mojo_bindings",
+      "//content/browser/attribution_reporting:registration_result_mojom",
+      "//content/browser/interest_group:interest_group_proto",
+      "//content/browser/private_aggregation:mojo_bindings",
+      "//content/browser/private_aggregation/proto:private_aggregation_budgets_proto",
+    ]
   }
 
   if (is_cobalt) {

--- a/content/browser/browser_interface_binders.cc
+++ b/content/browser/browser_interface_binders.cc
@@ -44,7 +44,9 @@
 #include "content/browser/image_capture/image_capture_impl.h"
 #include "content/browser/indexed_db/indexed_db_internals.mojom.h"
 #include "content/browser/indexed_db/indexed_db_internals_ui.h"
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/interest_group/ad_auction_service_impl.h"
+#endif
 #include "content/browser/keyboard_lock/keyboard_lock_service_impl.h"
 #include "content/browser/loader/content_security_notifier.h"
 #include "content/browser/media/media_web_contents_observer.h"
@@ -54,8 +56,10 @@
 #include "content/browser/picture_in_picture/picture_in_picture_service_impl.h"
 #include "content/browser/preloading/anchor_element_interaction_host_impl.h"
 #include "content/browser/preloading/speculation_rules/speculation_host_impl.h"
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/private_aggregation/private_aggregation_internals.mojom.h"
 #include "content/browser/private_aggregation/private_aggregation_internals_ui.h"
+#endif
 #include "content/browser/process_internals/process_internals.mojom.h"
 #include "content/browser/process_internals/process_internals_ui.h"
 #include "content/browser/quota/quota_context.h"
@@ -1244,10 +1248,12 @@ void PopulateBinderMapWithContext(
       base::BindRepeating(&ContentIndexServiceImpl::CreateForFrame));
   map->Add<blink::mojom::KeyboardLockService>(
       base::BindRepeating(&KeyboardLockServiceImpl::CreateMojoService));
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   if (base::FeatureList::IsEnabled(network::features::kInterestGroupStorage)) {
     map->Add<blink::mojom::AdAuctionService>(
         base::BindRepeating(&AdAuctionServiceImpl::CreateMojoService));
   }
+#endif
   map->Add<blink::mojom::MediaSessionService>(
       base::BindRepeating(&MediaSessionServiceImpl::Create));
   map->Add<blink::mojom::PictureInPictureService>(
@@ -1261,10 +1267,10 @@ void PopulateBinderMapWithContext(
   map->Add<device::mojom::VRService>(
       base::BindRepeating(&EmptyBinderForFrame<device::mojom::VRService>));
 #endif
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   RegisterWebUIControllerInterfaceBinder<
       private_aggregation_internals::mojom::Factory,
       PrivateAggregationInternalsUI>(map);
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   RegisterWebUIControllerInterfaceBinder<attribution_internals::mojom::Factory,
                                          AttributionInternalsUI>(map);
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138

--- a/content/browser/devtools/devtools_agent_host_impl.cc
+++ b/content/browser/devtools/devtools_agent_host_impl.cc
@@ -185,7 +185,9 @@ DevToolsAgentHost::List DevToolsAgentHost::GetOrCreateAll() {
   RenderFrameDevToolsAgentHost::AddAllAgentHosts(&result);
   WebContentsDevToolsAgentHost::AddAllAgentHosts(&result);
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   AuctionWorkletDevToolsAgentHostManager::GetInstance().GetAll(&result);
+#endif
   MojomDevToolsAgentHost::GetAll(&result);
 
 #if DCHECK_IS_ON()

--- a/content/browser/devtools/frame_auto_attacher.cc
+++ b/content/browser/devtools/frame_auto_attacher.cc
@@ -191,6 +191,7 @@ void FrameAutoAttacher::UpdateAutoAttach(base::OnceClosure callback) {
       // This is similar to frames and pages above.
       ReattachServiceWorkers();
     }
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
     if (render_frame_host_ && !observing_auction_worklets_) {
       observing_auction_worklets_ = true;
       DebuggableAuctionWorkletTracker::GetInstance()->AddObserver(this);
@@ -199,11 +200,13 @@ void FrameAutoAttacher::UpdateAutoAttach(base::OnceClosure callback) {
       observing_shared_storage_worklets_ = true;
       SharedStorageWorkletDevToolsManager::GetInstance()->AddObserver(this);
     }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   } else {
     if (observing_service_workers_) {
       ServiceWorkerDevToolsManager::GetInstance()->RemoveObserver(this);
       observing_service_workers_ = false;
     }
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
     if (observing_auction_worklets_) {
       DebuggableAuctionWorkletTracker::GetInstance()->RemoveObserver(this);
       observing_auction_worklets_ = false;
@@ -212,6 +215,7 @@ void FrameAutoAttacher::UpdateAutoAttach(base::OnceClosure callback) {
       SharedStorageWorkletDevToolsManager::GetInstance()->RemoveObserver(this);
       observing_shared_storage_worklets_ = false;
     }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   }
   RendererAutoAttacherBase::UpdateAutoAttach(std::move(callback));
 }
@@ -238,6 +242,7 @@ void FrameAutoAttacher::WorkerDestroyed(ServiceWorkerDevToolsAgentHost* host) {
 
 void FrameAutoAttacher::AuctionWorkletCreated(DebuggableAuctionWorklet* worklet,
                                               bool& should_pause_on_start) {
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   if (!render_frame_host_)
     return;
   if (!AuctionWorkletDevToolsAgentHost::IsRelevantTo(render_frame_host_,
@@ -249,6 +254,7 @@ void FrameAutoAttacher::AuctionWorkletCreated(DebuggableAuctionWorklet* worklet,
                          .GetOrCreateFor(worklet)
                          .get(),
                      should_pause_on_start);
+#endif
 }
 
 void FrameAutoAttacher::SharedStorageWorkletCreated(
@@ -320,11 +326,13 @@ void FrameAutoAttacher::UpdateFrames() {
           return RenderFrameHost::FrameIterationAction::kSkipChildren;
         });
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
     AuctionWorkletDevToolsAgentHostManager::GetInstance().GetAllForFrame(
         render_frame_host_, &new_auction_worklet_hosts);
 
     SharedStorageWorkletDevToolsManager::GetInstance()->GetAllForFrame(
         render_frame_host_, &new_shared_storage_worklet_hosts);
+#endif
   }
 
   DispatchSetAttachedTargetsOfType(new_hosts, DevToolsAgentHost::kTypeFrame);

--- a/content/browser/devtools/frame_auto_attacher.h
+++ b/content/browser/devtools/frame_auto_attacher.h
@@ -56,8 +56,10 @@ class FrameAutoAttacher : public protocol::RendererAutoAttacherBase,
  private:
   raw_ptr<RenderFrameHostImpl> render_frame_host_ = nullptr;
   bool observing_service_workers_ = false;
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   bool observing_auction_worklets_ = false;
   bool observing_shared_storage_worklets_ = false;
+#endif
 };
 
 }  // namespace content

--- a/content/browser/devtools/protocol/storage_handler.cc
+++ b/content/browser/devtools/protocol/storage_handler.cc
@@ -1113,6 +1113,7 @@ void StorageHandler::OnInterestGroupAccessed(
 }
 
 namespace {
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 void SendGetInterestGroup(
     std::unique_ptr<StorageHandler::GetInterestGroupDetailsCallback> callback,
     std::optional<SingleStorageInterestGroup> storage_group) {
@@ -1131,7 +1132,7 @@ void SendGetInterestGroup(
   callback->sendSuccess(
       std::make_unique<base::Value::Dict>(std::move(ig_serialization)));
 }
-
+#endif
 }  // namespace
 
 void StorageHandler::GetInterestGroupDetails(
@@ -1159,9 +1160,11 @@ void StorageHandler::GetInterestGroupDetails(
   url::Origin owner_origin = url::Origin::Create(GURL(owner_origin_string));
   DCHECK(!owner_origin.opaque());
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   manager->GetInterestGroup(
       owner_origin, name,
       base::BindOnce(&SendGetInterestGroup, std::move(callback)));
+#endif
 }
 
 Response StorageHandler::SetInterestGroupTracking(bool enable) {
@@ -2606,11 +2609,13 @@ Response StorageHandler::SetProtectedAudienceKAnonymity(
   if (!manager) {
     return Response::ServerError("Protected Audience not enabled");
   }
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   manager->UpdateKAnonymity(
       blink::InterestGroupKey(std::move(owner_origin), in_group_name),
       /*positive_hashed_keys=*/std::move(hashes),
       /*update_time=*/base::Time::Now(),
       /*replace_existing_values=*/true);
+#endif
   return Response::Success();
 }
 

--- a/content/browser/fenced_frame/fenced_frame_reporter.cc
+++ b/content/browser/fenced_frame/fenced_frame_reporter.cc
@@ -879,6 +879,7 @@ void FencedFrameReporter::RemoveObserverForTesting(
 void FencedFrameReporter::OnForEventPrivateAggregationRequestsReceived(
     std::map<std::string, FinalizedPrivateAggregationRequests>
         private_aggregation_event_map) {
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   for (auto& [event_type, requests] : private_aggregation_event_map) {
     FinalizedPrivateAggregationRequests& destination_vector =
         private_aggregation_event_map_[event_type];
@@ -890,10 +891,12 @@ void FencedFrameReporter::OnForEventPrivateAggregationRequestsReceived(
   for (const std::string& pa_event_type : received_pa_events_) {
     SendPrivateAggregationRequestsForEventInternal(pa_event_type);
   }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 void FencedFrameReporter::SendPrivateAggregationRequestsForEvent(
     const std::string& pa_event_type) {
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   if (!private_aggregation_manager_) {
     // `private_aggregation_manager_` is nullptr when private aggregation
     // feature flag is disabled, but a compromised renderer might still send
@@ -907,10 +910,12 @@ void FencedFrameReporter::SendPrivateAggregationRequestsForEvent(
   received_pa_events_.emplace(pa_event_type);
 
   SendPrivateAggregationRequestsForEventInternal(pa_event_type);
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 void FencedFrameReporter::SendPrivateAggregationRequestsForEventInternal(
     const std::string& pa_event_type) {
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   DCHECK(private_aggregation_manager_);
   DCHECK(winner_origin_.has_value() &&
          winner_origin_.value().scheme() == url::kHttpsScheme);
@@ -932,6 +937,7 @@ void FencedFrameReporter::SendPrivateAggregationRequestsForEventInternal(
   // requests more than once. As a result, receiving the same event type
   // multiple times only triggers sending the event's requests once.
   private_aggregation_event_map_.erase(it);
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 const std::vector<blink::FencedFrame::ReportingDestination>

--- a/content/browser/loader/subresource_proxying_url_loader.cc
+++ b/content/browser/loader/subresource_proxying_url_loader.cc
@@ -34,12 +34,12 @@ SubresourceProxyingURLLoader::SubresourceProxyingURLLoader(
         std::make_unique<BrowsingTopicsURLLoaderInterceptor>(
             document, resource_request_));
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   if (resource_request_.ad_auction_headers) {
     interceptors_.push_back(std::make_unique<AdAuctionURLLoaderInterceptor>(
         document, resource_request_));
   }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   // Make a copy of `resource_request`, because we may need to modify the
   // request.

--- a/content/browser/renderer_host/navigation_request.cc
+++ b/content/browser/renderer_host/navigation_request.cc
@@ -243,8 +243,10 @@ base::TimeDelta g_commit_timeout = kDefaultCommitTimeout;
 constexpr base::TimeDelta kCompositorLockTimeout = base::Milliseconds(150);
 #endif
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 const char kSecSharedStorageWritableRequestHeaderKey[] =
     "Sec-Shared-Storage-Writable";
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
 constexpr char kNavigationRequestScope[] = "NavigationRequestScope";
 
@@ -2059,7 +2061,6 @@ NavigationRequest::NavigationRequest(
       headers.SetHeader(kBrowsingTopicsRequestHeaderKey,
                         *topics_header_value_result.header_value);
     }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
     if (has_ad_auction_headers_attribute_ &&
         IsAdAuctionHeadersEligibleForNavigation(
@@ -2067,6 +2068,7 @@ NavigationRequest::NavigationRequest(
       ad_auction_headers_eligible_ = true;
       headers.SetHeader(kAdAuctionRequestHeaderKey, "?1");
     }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   }
 
   begin_params_->headers = headers.ToString();
@@ -5798,7 +5800,6 @@ void NavigationRequest::OnRedirectChecksComplete(
     modified_headers.SetHeader(kBrowsingTopicsRequestHeaderKey,
                                *topics_header_value_result.header_value);
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   if (ad_auction_headers_eligible_) {
     // Redirects are ineligible for ad auction headers.
@@ -5825,6 +5826,7 @@ void NavigationRequest::OnRedirectChecksComplete(
       }
     }
   }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   // Removes all Client Hints from the request, that were passed on from the
   // previous one.
@@ -6432,7 +6434,6 @@ void NavigationRequest::CommitNavigation() {
           browsing_topics::ApiCallerSource::kIframeAttribute);
     }
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   if (ad_auction_headers_eligible_) {
     ProcessAdAuctionResponseHeaders(origin_to_commit, *GetRenderFrameHost(),
@@ -6440,6 +6441,7 @@ void NavigationRequest::CommitNavigation() {
   } else if (has_ad_auction_headers_attribute_) {
     RemoveAdAuctionResponseHeaders(response() ? response()->headers : nullptr);
   }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   RenderFrameHostImpl* old_frame_host =
       frame_tree_node_->render_manager()->current_frame_host();

--- a/content/browser/renderer_host/navigator.cc
+++ b/content/browser/renderer_host/navigator.cc
@@ -16,7 +16,9 @@
 #include "base/time/time.h"
 #include "base/types/optional_util.h"
 #include "content/browser/child_process_security_policy_impl.h"
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/interest_group/interest_group_features.h"
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/process_lock.h"
 #include "content/browser/renderer_host/debug_urls.h"
 #include "content/browser/renderer_host/frame_tree.h"
@@ -596,11 +598,13 @@ void Navigator::DidNavigate(
 
   // Reset the old frame host's weak pointer to auction initiator page when it
   // is a cross-document navigation and the frame does not go into bfcache.
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   if ((base::FeatureList::IsEnabled(features::kDetectInconsistentPageImpl)) &&
       !was_within_same_document && old_frame_host &&
       !old_frame_host->IsInBackForwardCache()) {
     old_frame_host->set_auction_initiator_page(nullptr);
   }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   // The main frame, same site, and cross-site navigation checks for user
   // activation mirror the checks in DocumentLoader::CommitNavigation() (note:

--- a/content/browser/renderer_host/render_frame_host_impl.cc
+++ b/content/browser/renderer_host/render_frame_host_impl.cc
@@ -97,7 +97,9 @@
 #include "content/browser/guest_page_holder_impl.h"
 #include "content/browser/idle/idle_manager_impl.h"
 #include "content/browser/installedapp/installed_app_provider_impl.h"
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/interest_group/ad_auction_document_data.h"
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/loader/file_url_loader_factory.h"
 #include "content/browser/loader/keep_alive_url_loader_service.h"
 #include "content/browser/loader/navigation_early_hints_manager.h"
@@ -15460,6 +15462,7 @@ bool RenderFrameHostImpl::DidCommitNavigationInternal(
                 ->GetValueIgnoringVisibility());
       }
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
       if (fenced_frame_properties->ad_auction_data().has_value()) {
         AdAuctionDocumentData::CreateForCurrentDocument(
             this,
@@ -15470,6 +15473,7 @@ bool RenderFrameHostImpl::DidCommitNavigationInternal(
                 ->GetValueIgnoringVisibility()
                 .interest_group_name);
       }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
     }
 
     // Continue observing the events for the committed navigation.

--- a/content/browser/storage_partition_impl.cc
+++ b/content/browser/storage_partition_impl.cc
@@ -52,12 +52,12 @@
 #endif
 #include "components/services/storage/storage_service_impl.h"
 #include "components/variations/net/variations_http_headers.h"
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/aggregation_service/aggregation_service.h"
 #include "content/browser/aggregation_service/aggregation_service_impl.h"
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_manager.h"
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/attribution_reporting/attribution_manager_impl.h"
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/background_fetch/background_fetch_context.h"
 #include "content/browser/blob_storage/blob_registry_wrapper.h"
 #include "content/browser/blob_storage/chrome_blob_storage_context.h"
@@ -101,8 +101,10 @@
 #include "content/browser/notifications/platform_notification_context_impl.h"
 #include "content/browser/payments/payment_app_context_impl.h"
 #include "content/browser/preloading/prerender/prerender_final_status.h"
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/private_aggregation/private_aggregation_manager.h"
 #include "content/browser/private_aggregation/private_aggregation_manager_impl.h"
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/push_messaging/push_messaging_context.h"
 #include "content/browser/quota/quota_context.h"
 #include "content/browser/renderer_host/frame_tree_node.h"
@@ -1552,8 +1554,10 @@ void StoragePartitionImpl::Initialize(
 
   font_access_manager_ = FontAccessManager::Create();
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   aggregation_service_ =
       std::make_unique<AggregationServiceImpl>(is_in_memory(), path, this);
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
   if (is_in_memory()) {
@@ -1579,11 +1583,13 @@ void StoragePartitionImpl::Initialize(
   }
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   if (base::FeatureList::IsEnabled(blink::features::kPrivateAggregationApi)) {
     private_aggregation_manager_ =
         std::make_unique<PrivateAggregationManagerImpl>(is_in_memory(), path,
                                                         this);
   }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 void StoragePartitionImpl::OnStorageServiceDisconnected() {
@@ -1940,7 +1946,11 @@ ContentIndexContextImpl* StoragePartitionImpl::GetContentIndexContext() {
 
 AggregationService* StoragePartitionImpl::GetAggregationService() {
   DCHECK(initialized_);
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   return aggregation_service_.get();
+#else
+  return nullptr;
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 leveldb_proto::ProtoDatabaseProvider*
@@ -1975,13 +1985,21 @@ storage::SharedStorageManager* StoragePartitionImpl::GetSharedStorageManager() {
 PrivateAggregationManager*
 StoragePartitionImpl::GetPrivateAggregationManager() {
   DCHECK(initialized_);
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   return private_aggregation_manager_.get();
+#else
+  return nullptr;
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 PrivateAggregationDataModel*
 StoragePartitionImpl::GetPrivateAggregationDataModel() {
   DCHECK(initialized_);
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   return private_aggregation_manager_.get();
+#else
+  return nullptr;
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 }
 
 CookieDeprecationLabelManager*
@@ -2817,14 +2835,12 @@ void StoragePartitionImpl::ClearDataImpl(
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
       interest_group_manager_.get(),
       attribution_manager_.get(),
-#else
-      nullptr,
-      nullptr,
-#endif
       aggregation_service_.get(), private_aggregation_manager_.get(),
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
       shared_storage_manager_.get(),
 #else
+      nullptr,
+      nullptr,
+      nullptr, nullptr,
       nullptr,
 #endif
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
@@ -3209,7 +3225,6 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
               CreateTaskCompletionClosure(TracingDataType::kConversions)));
     }
   }
-#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   if (aggregation_service &&
       (remove_mask_ & REMOVE_DATA_MASK_AGGREGATION_SERVICE)) {
@@ -3237,7 +3252,6 @@ void StoragePartitionImpl::DataDeletionHelper::ClearDataOnUIThread(
             CreateTaskCompletionClosure(TracingDataType::kPrivateAggregation)));
   }
 
-#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   if (base::FeatureList::IsEnabled(network::features::kSharedStorageAPI) &&
       shared_storage_manager &&
       (remove_mask_ & REMOVE_DATA_MASK_SHARED_STORAGE)) {
@@ -3611,11 +3625,13 @@ void StoragePartitionImpl::OverrideSharedStorageHeaderObserverForTesting(
 }
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 void StoragePartitionImpl::OverrideAggregationServiceForTesting(
     std::unique_ptr<AggregationService> aggregation_service) {
   DCHECK(initialized_);
   aggregation_service_ = std::move(aggregation_service);
 }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 void StoragePartitionImpl::OverrideAttributionManagerForTesting(
@@ -3625,12 +3641,14 @@ void StoragePartitionImpl::OverrideAttributionManagerForTesting(
 }
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 void StoragePartitionImpl::OverridePrivateAggregationManagerForTesting(
     std::unique_ptr<PrivateAggregationManagerImpl>
         private_aggregation_manager) {
   DCHECK(initialized_);
   private_aggregation_manager_ = std::move(private_aggregation_manager);
 }
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
 void StoragePartitionImpl::OverrideDeviceBoundSessionManagerForTesting(
     std::unique_ptr<network::mojom::DeviceBoundSessionManager>

--- a/content/browser/storage_partition_impl.h
+++ b/content/browser/storage_partition_impl.h
@@ -830,7 +830,9 @@ class CONTENT_EXPORT StoragePartitionImpl
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   std::unique_ptr<InterestGroupManagerImpl> interest_group_manager_;
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   std::unique_ptr<AggregationService> aggregation_service_;
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #if BUILDFLAG(ENABLE_LIBRARY_CDMS)
   std::unique_ptr<CdmStorageManager> cdm_storage_manager_;
 #endif  // BUILDFLAG(ENABLE_LIBRARY_CDMS)
@@ -851,7 +853,9 @@ class CONTENT_EXPORT StoragePartitionImpl
   std::unique_ptr<SharedStorageHeaderObserver> shared_storage_header_observer_;
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   std::unique_ptr<PrivateAggregationManagerImpl> private_aggregation_manager_;
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 
   std::unique_ptr<CookieDeprecationLabelManagerImpl>
       cookie_deprecation_label_manager_;

--- a/content/browser/webui/content_web_ui_configs.cc
+++ b/content/browser/webui/content_web_ui_configs.cc
@@ -25,7 +25,9 @@
 #include "content/browser/media/media_internals_ui.h"
 #include "content/browser/metrics/histograms_internals_ui.h"
 #include "content/browser/network/network_errors_listing_ui.h"
+#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/private_aggregation/private_aggregation_internals_ui.h"
+#endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
 #include "content/browser/process_internals/process_internals_ui.h"
 #include "content/browser/quota/quota_internals_ui.h"
 #include "content/browser/service_worker/service_worker_internals_ui.h"
@@ -48,6 +50,7 @@ void RegisterContentWebUIConfigs() {
   auto& map = WebUIConfigMap::GetInstance();
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   map.AddWebUIConfig(std::make_unique<AttributionInternalsUIConfig>());
+  map.AddWebUIConfig(std::make_unique<PrivateAggregationInternalsUIConfig>());
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
   map.AddWebUIConfig(std::make_unique<GpuInternalsUIConfig>());
   map.AddWebUIConfig(
@@ -55,7 +58,6 @@ void RegisterContentWebUIConfigs() {
   map.AddWebUIConfig(std::make_unique<MediaInternalsUIConfig>());
   map.AddWebUIConfig(std::make_unique<HistogramsInternalsUIConfig>());
   map.AddWebUIConfig(std::make_unique<NetworkErrorsListingUIConfig>());
-  map.AddWebUIConfig(std::make_unique<PrivateAggregationInternalsUIConfig>());
   map.AddWebUIConfig(std::make_unique<ProcessInternalsUIConfig>());
   map.AddWebUIConfig(std::make_unique<QuotaInternalsUIConfig>());
   map.AddWebUIConfig(std::make_unique<ServiceWorkerInternalsUIConfig>());

--- a/content/test/BUILD.gn
+++ b/content/test/BUILD.gn
@@ -802,11 +802,26 @@ static_library("test_support") {
   }
 
   if (!enable_privacy_sandbox_apis) {
-    sources -= [
-      "../browser/browsing_topics/test_util.cc",
-      "../browser/browsing_topics/test_util.h",
-      "../public/test/browsing_topics_test_util.cc",
-      "../public/test/browsing_topics_test_util.h",
+    _filtered_sources = filter_exclude(sources, [
+      "../browser/browsing_topics/*",
+      "../browser/attribution_reporting/*",
+      "../browser/shared_storage/*",
+      "../browser/interest_group/*",
+      "../browser/private_aggregation/*",
+      "../browser/aggregation_service/*",
+      "../public/test/*browsing_topics*",
+      "../public/test/*shared_storage*",
+      "../public/test/*attribution*",
+      "../public/test/*interest_group*",
+      "../public/test/*private_aggregation*",
+      "../public/test/*aggregation_service*",
+    ])
+    sources = []
+    sources = _filtered_sources
+
+    deps -= [
+      "//content/browser/attribution_reporting:mojo_bindings",
+      "//content/browser/attribution_reporting:registration_result_mojom",
     ]
   }
 

--- a/third_party/blink/renderer/bindings/bindings.gni
+++ b/third_party/blink/renderer/bindings/bindings.gni
@@ -316,6 +316,16 @@ if (is_cobalt) {
       "*v8_private_aggregation*",
       "*private_attribution*",
       "*storage_access*",
+      "*ad_auction*",
+      "*navigator_auction*",
+      "*protected_audience*",
+      "*interest_group*",
+      "*auction*",
+      "*v8_ad_*",
+      "*v8_ads.*",
+      "*view_or_click_counts*",
+      "*adproperties*",
+      "*fencedframeconfig*",
     ]
   }
 }

--- a/third_party/blink/renderer/bindings/core/v8/BUILD.gn
+++ b/third_party/blink/renderer/bindings/core/v8/BUILD.gn
@@ -5,6 +5,7 @@
 import("//testing/libfuzzer/fuzzer_test.gni")
 import("//third_party/blink/renderer/bindings/generated_in_core.gni")
 import("//third_party/blink/renderer/core/core.gni")
+import("//third_party/blink/renderer/bindings/bindings.gni")
 
 visibility = [ "//third_party/blink/renderer/*" ]
 
@@ -22,6 +23,13 @@ blink_core_sources("v8") {
             generated_observable_array_sources_in_core +
             generated_sync_iterator_sources_in_core +
             generated_typedef_sources_in_core + generated_union_sources_in_core
+
+  if (is_cobalt) {
+    _filtered_core_sources =
+        filter_exclude(sources, cobalt_bindings_exclude_patterns)
+    sources = []
+    sources = _filtered_core_sources
+  }
 
   deps = [
     ":generated",
@@ -46,6 +54,13 @@ source_set("testing") {
             generated_enumeration_sources_for_testing_in_core +
             generated_interface_sources_for_testing_in_core +
             generated_union_sources_for_testing_in_core
+
+  if (is_cobalt) {
+    _filtered_core_sources =
+        filter_exclude(sources, cobalt_bindings_exclude_patterns)
+    sources = []
+    sources = _filtered_core_sources
+  }
 
   deps = [
     ":generated",

--- a/third_party/blink/renderer/bindings/idl_in_modules.gni
+++ b/third_party/blink/renderer/bindings/idl_in_modules.gni
@@ -1441,20 +1441,21 @@ if (enable_compute_pressure) {
 
 # If in the future privacy sandbox components are removed from the code base, we should
 # delete this if block.
-if (!enable_privacy_sandbox_apis) {
-  _filtered_static_idl_files = filter_exclude(
-      static_idl_files_in_modules,
-      [
-        "//third_party/blink/renderer/modules/browsing_topics/*",
-        "//third_party/blink/renderer/modules/private_attribution/*",
-        "//third_party/blink/renderer/modules/shared_storage/*",
-        "//third_party/blink/renderer/modules/storage_access/*",
-        "//third_party/blink/renderer/modules/locks/shared_storage_worklet_navigator_locks.idl",
-        "//third_party/blink/renderer/modules/permissions/top_level_storage_access_permission_descriptor.idl",
-      ])
-  static_idl_files_in_modules = []
-  static_idl_files_in_modules = _filtered_static_idl_files
-}
+  if (!enable_privacy_sandbox_apis) {
+    _filtered_static_idl_files = filter_exclude(
+        static_idl_files_in_modules,
+        [
+          "//third_party/blink/renderer/modules/browsing_topics/*",
+          "//third_party/blink/renderer/modules/private_attribution/*",
+          "//third_party/blink/renderer/modules/shared_storage/*",
+          "//third_party/blink/renderer/modules/storage_access/*",
+          "//third_party/blink/renderer/modules/locks/shared_storage_worklet_navigator_locks.idl",
+          "//third_party/blink/renderer/modules/permissions/top_level_storage_access_permission_descriptor.idl",
+          "//third_party/blink/renderer/modules/ad_auction/*",
+        ])
+    static_idl_files_in_modules = []
+    static_idl_files_in_modules = _filtered_static_idl_files
+  }
 
 # Statically-defined (not runtime-generated) IDL files in 'modules' component.
 # These IDL definitions are used only for testing.
@@ -1494,4 +1495,15 @@ if (!use_webrtc_peer_connection) {
           [ "//third_party/blink/renderer/modules/peerconnection/testing/*" ])
   static_idl_files_in_modules_for_testing = []
   static_idl_files_in_modules_for_testing = _filtered_testing_idl
+}
+
+if (!enable_privacy_sandbox_apis) {
+  _filtered_static_idl_files_for_testing = filter_exclude(
+      static_idl_files_in_modules_for_testing,
+      [
+        "//third_party/blink/renderer/modules/ad_auction/testing/*",
+      ])
+  static_idl_files_in_modules_for_testing = []
+  static_idl_files_in_modules_for_testing =
+      _filtered_static_idl_files_for_testing
 }

--- a/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
+++ b/third_party/blink/renderer/bindings/modules/v8/BUILD.gn
@@ -32,17 +32,11 @@ blink_modules_sources("v8") {
     sources = _hardware_filtered
   }
 
-  if (!use_webrtc_peer_connection) {
-    _rtc_filtered =
-        filter_exclude(sources, cobalt_bindings_exclude_patterns)
-    sources = []
-    sources = _rtc_filtered
-  }
-
   if (is_cobalt) {
     _filtered_cobalt_sources = filter_exclude(
         sources,
-        cobalt_webgpu_exclude_patterns + cobalt_ai_exclude_patterns)
+        cobalt_webgpu_exclude_patterns + cobalt_ai_exclude_patterns +
+            cobalt_bindings_exclude_patterns)
     sources = []
     sources = _filtered_cobalt_sources
   }
@@ -70,7 +64,7 @@ source_set("testing") {
             generated_interface_sources_for_testing_in_modules +
             generated_interface_extra_sources_for_testing_in_modules
 
-  if (!use_webrtc_peer_connection) {
+  if (is_cobalt) {
     _filtered_sources =
         filter_exclude(sources, cobalt_bindings_exclude_patterns)
     sources = []

--- a/third_party/blink/renderer/modules/BUILD.gn
+++ b/third_party/blink/renderer/modules/BUILD.gn
@@ -175,13 +175,13 @@ component("modules") {
     "//third_party/blink/renderer/modules/xr",
   ]
 
-  # If in the future privacy sandbox components are removed from the code base, ignore this if block.
   if (!enable_privacy_sandbox_apis) {
     sub_modules -= [
       "//third_party/blink/renderer/modules/browsing_topics",
       "//third_party/blink/renderer/modules/private_attribution",
       "//third_party/blink/renderer/modules/shared_storage",
       "//third_party/blink/renderer/modules/storage_access",
+      "//third_party/blink/renderer/modules/ad_auction",
     ]
   }
 
@@ -317,12 +317,17 @@ source_set("modules_testing") {
     "speech/testing/internals_speech_synthesis.cc",
     "speech/testing/internals_speech_synthesis.h",
     "speech/testing/mojom_speech_synthesis_mock.cc",
-    "speech/testing/mojom_speech_synthesis_mock.h",
     "vibration/testing/internals_vibration.cc",
     "vibration/testing/internals_vibration.h",
     "webaudio/testing/internals_web_audio.cc",
     "webaudio/testing/internals_web_audio.h",
   ]
+
+  if (!enable_privacy_sandbox_apis) {
+    _ad_auction_testing_filtered_sources = filter_exclude(sources, [ "ad_auction/testing/*" ])
+    sources = []
+    sources = _ad_auction_testing_filtered_sources
+  }
 
   if (enable_compute_pressure) {
     sources += [
@@ -826,10 +831,12 @@ source_set("unit_tests") {
     "//v8",
   ]
 
-  # If in the future privacy sandbox components are removed from the code base, ignore this if block.
   if (!enable_privacy_sandbox_apis) {
     sources -= [ "shared_storage/shared_storage_worklet_unittest.cc" ]
-    deps -= [ "//third_party/blink/renderer/modules/storage_access:unit_tests" ]
+    deps -= [
+      "//third_party/blink/renderer/modules/storage_access:unit_tests",
+      "//third_party/blink/renderer/modules/ad_auction:unit_tests",
+    ]
   }
 
   if (is_cobalt) {

--- a/third_party/blink/renderer/modules/ad_auction/BUILD.gn
+++ b/third_party/blink/renderer/modules/ad_auction/BUILD.gn
@@ -4,38 +4,40 @@
 
 import("//third_party/blink/renderer/modules/modules.gni")
 
-blink_modules_sources("ad_auction") {
-  sources = [
-    "ads.cc",
-    "ads.h",
-    "join_leave_queue.h",
-    "navigator_auction.cc",
-    "navigator_auction.h",
-    "protected_audience.cc",
-    "protected_audience.h",
-    "validate_blink_interest_group.cc",
-    "validate_blink_interest_group.h",
-  ]
+if (enable_privacy_sandbox_apis) {
+  blink_modules_sources("ad_auction") {
+    sources = [
+      "ads.cc",
+      "ads.h",
+      "join_leave_queue.h",
+      "navigator_auction.cc",
+      "navigator_auction.h",
+      "protected_audience.cc",
+      "protected_audience.h",
+      "validate_blink_interest_group.cc",
+      "validate_blink_interest_group.h",
+    ]
 
-  deps = [ "//third_party/blink/renderer/modules/geolocation:geolocation" ]
-}
+    deps = [ "//third_party/blink/renderer/modules/geolocation:geolocation" ]
+  }
 
-source_set("unit_tests") {
-  testonly = true
-  sources = [
-    "join_leave_queue_test.cc",
-    "validate_blink_interest_group_test.cc",
-  ]
+  source_set("unit_tests") {
+    testonly = true
+    sources = [
+      "join_leave_queue_test.cc",
+      "validate_blink_interest_group_test.cc",
+    ]
 
-  deps = [
-    "//base",
-    "//mojo/public/cpp/test_support:test_utils",
-    "//testing/gmock",
-    "//testing/gtest",
-    "//third_party/blink/public:test_headers",
-    "//third_party/blink/public/common:headers",
-    "//third_party/blink/renderer/modules:modules",
-    "//third_party/blink/renderer/platform:test_support",
-    "//url",
-  ]
+    deps = [
+      "//base",
+      "//mojo/public/cpp/test_support:test_utils",
+      "//testing/gmock",
+      "//testing/gtest",
+      "//third_party/blink/public:test_headers",
+      "//third_party/blink/public/common:headers",
+      "//third_party/blink/renderer/modules:modules",
+      "//third_party/blink/renderer/platform:test_support",
+      "//url",
+    ]
+  }
 }


### PR DESCRIPTION
Sets default `enable_privacy_sandbox_apis = false` for Cobalt builds in `cobalt/build/configs/cobalt.gni`. Instead of scattering `#if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS)` across hundreds of callsites, this change:
1. Excludes Privacy Sandbox and Ad Measurement implementations (`browsing_topics`, `attribution_reporting`, `shared_storage`, `interest_group`, `private_aggregation`, `aggregation_service`, and Blink `ad_auction`) in `content/browser/BUILD.gn` and `third_party/blink/` when `enable_privacy_sandbox_apis = false`.
2. Stubs out entrypoint getters on `content::StoragePartitionImpl` (`GetInterestGroupManager`, `GetAttributionManager`, `GetSharedStorageManager`, `GetAggregationService`, `GetPrivateAggregationManager`) to return `nullptr` when disabled.
3. Guards official LTO and DevTools/WebUI registration sites (`StorageHandler`, `FencedFrameReporter`, `NavigationRequest`, `Navigator`, `FrameAutoAttacher`, `DevToolsAgentHostImpl`, `SubresourceProxyingURLLoader`, `RenderFrameHostImpl`).

Binary Size Impact:
* Android ARM Gold (`out/android-arm_gold/apks/Cobalt.apk`):
  - Before: 87,279,199 bytes
  - After:  85,899,662 bytes
  - Savings: -1,379,537 bytes (-1.38 MB / -1,347 KB)

* Evergreen x64 QA (`out/evergreen-x64_qa/libcobalt.so` stripped):
  - Before: 165,116,912 bytes
  - After:  163,954,768 bytes
  - Savings: -1,162,144 bytes (-1.16 MB / -1,135 KB)

TAG=agy
CONV=9625e46e-38a4-48ef-8631-4a3534817dea