### PR TITLE
base: Fix closing #endif for BUILDFLAG(IS_APPLE) in time.h

### DIFF
--- a/base/time/time.h
+++ b/base/time/time.h
@@ -793,6 +793,7 @@ class BASE_EXPORT Time : public time_internal::TimeBase<Time> {
   static Time FromNSDate(NSDate* date);
   NSDate* ToNSDate() const;
 #endif
+#endif  // BUILDFLAG(IS_APPLE)
 
 #if BUILDFLAG(IS_WIN)
   static Time FromFileTime(FILETIME ft);
@@ -832,7 +833,6 @@ class BASE_EXPORT Time : public time_internal::TimeBase<Time> {
   static void ResetHighResolutionTimerUsage();
   static double GetHighResolutionTimerUsage();
 #endif  // BUILDFLAG(IS_WIN)
-#endif
 
   // Converts an exploded structure representing either the local time or UTC
   // into a Time class. Returns false on a failure when, for example, a day of


### PR DESCRIPTION
In base/time/time.h, the closing #endif for the BUILDFLAG(IS_APPLE) block was placed after the BUILDFLAG(IS_WIN) block, causing the Windows-only base::Time members to be nested inside BUILDFLAG(IS_APPLE).

This moves the #endif up to immediately close the BUILDFLAG(IS_APPLE) block before BUILDFLAG(IS_WIN).

Bug: 531900258
Bug: 534069287