### PR TITLE
starboard: Replace per-target toolchain checks with file-level asserts

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -23,6 +23,8 @@ import("//testing/test.gni")
 # Configuration for overall Android Starboard Platform.
 ##########################################################
 
+assert(is_starboard_toolchain)
+
 config("starboard_platform_libs") {
   libs = [
     "EGL",
@@ -384,7 +386,7 @@ static_library("starboard_base_symbolize") {
     "//starboard:starboard_headers_only",
     "//starboard/common:common_headers_only",
   ]
-  if (is_starboard && current_toolchain == starboard_toolchain) {
+  if (is_starboard) {
     public_deps = [ "//starboard/elf_loader:evergreen_info" ]
   }
 

--- a/starboard/aosp/shared/BUILD.gn
+++ b/starboard/aosp/shared/BUILD.gn
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//starboard/build/config/toolchain_variables.gni")
+
+assert(is_starboard_toolchain)
+
 static_library("starboard_platform") {
   sources = [ "run_starboard_main.cc" ]
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/platform_configuration/configuration.gni
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/platform_configuration/configuration.gni
@@ -39,3 +39,5 @@ if (current_toolchain == default_toolchain &&
   sabi_path = "//starboard/sabi/arm/$rdk_arm_call_convention/sabi-v$sb_api_version.json"
 }
 
+# Avoid depending on imported configuration.
+starboard_level_final_executable_type = "executable"

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -111,7 +111,7 @@ if (rdk_enable_ocdm) {
 
 group("starboard_platform") {
   public_deps = [ ":starboard_platform_sources" ]
-  data_deps = [ ":rdk_cobalt_content" ]
+  data_deps = [ "cobalt/content:rdk_cobalt_content" ]
 }
 
 static_library("starboard_platform_sources") {
@@ -371,15 +371,6 @@ static_library("starboard_platform_sources") {
   if (sb_evergreen_compatible_use_libunwind) {
     deps = [ "//third_party/llvm-project/libunwind:unwind_starboard" ]
   }
-}
-
-group("rdk_cobalt_content") {
-  data_deps = [ ":rdk_cobalt_keymap($default_toolchain)" ]
-}
-
-copy("rdk_cobalt_keymap") {
-  sources = [ "cobalt/content/etc/keymapping.json" ]
-  outputs = [ "$root_out_dir/app/cobalt/content/etc/keymapping.json" ]
 }
 
 group("loader_app_rdk_plugin") {

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -29,8 +29,11 @@
 # limitations under the License.
 
 import("//starboard/build/config/linux/rdk/config_variables.gni")
+import("//starboard/build/config/toolchain_variables.gni")
 import("//build/config/linux/pkg_config.gni")
 import("$rdk_starboard_root/third_party/starboard/rdk/shared/build/rdk_toolchain.gni")
+
+assert(is_starboard_toolchain)
 
 declare_args() {
   rdk_enable_securityagent = true
@@ -383,7 +386,7 @@ group("loader_app_rdk_plugin") {
   data_deps = [":loader_app($starboard_toolchain)"]
 }
 
-if (is_starboard && current_toolchain == starboard_toolchain) {
+if (is_starboard) {
   if (starboard_level_final_executable_type == "shared_library") {
     group("loader_app") {
       deps = [ "//starboard/loader_app:loader_app" ]

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -111,7 +111,7 @@ if (rdk_enable_ocdm) {
 
 group("starboard_platform") {
   public_deps = [ ":starboard_platform_sources" ]
-  data_deps = [ "cobalt/content:rdk_cobalt_content" ]
+  data_deps = [ "cobalt:rdk_cobalt_content" ]
 }
 
 static_library("starboard_platform_sources") {
@@ -321,11 +321,7 @@ static_library("starboard_platform_sources") {
     ]
   }
 
-  if (!sb_is_modular || is_starboard) {
-    sources += [
-      "main_rdk.cc",
-    ]
-  }
+  sources += [ "main_rdk.cc" ]
 
   cflags = []
 
@@ -373,20 +369,8 @@ static_library("starboard_platform_sources") {
   }
 }
 
-group("loader_app_rdk_plugin") {
-  data_deps = [":loader_app($starboard_toolchain)"]
-}
-
-if (is_starboard) {
-  if (starboard_level_final_executable_type == "shared_library") {
-    group("loader_app") {
-      deps = [ "//starboard/loader_app:loader_app" ]
-    }
-  } else {
-    target("shared_library", "loader_app") {
-      output_dir = root_build_dir
-      deps = [ "//starboard/loader_app:loader_app_sources" ]
-      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
-    }
-  }
+shared_library("loader_app") {
+  output_dir = root_build_dir
+  deps = [ "//starboard/loader_app:loader_app_sources" ]
+  data_deps = [ "//starboard/content/fonts:copy_font_data" ]
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/cobalt/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/cobalt/BUILD.gn
@@ -12,11 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//starboard/build/config/linux/rdk/config_variables.gni")
+
+group("loader_app_rdk_plugin") {
+  data_deps = [ "$rdk_starboard_root/third_party/starboard/rdk/shared:loader_app($starboard_toolchain)" ]
+}
+
 group("rdk_cobalt_content") {
   data_deps = [ ":rdk_cobalt_keymap($default_toolchain)" ]
 }
 
 copy("rdk_cobalt_keymap") {
-  sources = [ "etc/keymapping.json" ]
+  sources = [ "content/etc/keymapping.json" ]
   outputs = [ "$root_out_dir/app/cobalt/content/etc/keymapping.json" ]
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/cobalt/content/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/cobalt/content/BUILD.gn
@@ -1,0 +1,22 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+group("rdk_cobalt_content") {
+  data_deps = [ ":rdk_cobalt_keymap($default_toolchain)" ]
+}
+
+copy("rdk_cobalt_keymap") {
+  sources = [ "etc/keymapping.json" ]
+  outputs = [ "$root_out_dir/app/cobalt/content/etc/keymapping.json" ]
+}

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -12,9 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//starboard/build/config/toolchain_variables.gni")
 import("//starboard/shared/starboard/media/media_tests.gni")
 import("//starboard/shared/starboard/player/buildfiles.gni")
 import("//starboard/shared/starboard/player/player_tests.gni")
+
+assert(is_starboard_toolchain)
 
 group("starboard_platform") {
   public_deps = [
@@ -52,7 +55,7 @@ static_library("starboard_base_symbolize") {
     "//starboard:starboard_headers_only",
     "//starboard/common:common_headers_only",
   ]
-  if (is_starboard && current_toolchain == starboard_toolchain) {
+  if (is_starboard) {
     public_deps = [ "//starboard/elf_loader:evergreen_info" ]
   }
 
@@ -304,21 +307,19 @@ static_library("starboard_platform_sources") {
   }
 }
 
-if (current_toolchain == starboard_toolchain) {
-  source_set("starboard_platform_tests") {
-    testonly = true
+source_set("starboard_platform_tests") {
+  testonly = true
 
-    sources = media_tests_sources + player_tests_sources +
-              [ "//starboard/shared/ffmpeg/ffmpeg_audio_decoder_test.cc" ]
+  sources = media_tests_sources + player_tests_sources +
+            [ "//starboard/shared/ffmpeg/ffmpeg_audio_decoder_test.cc" ]
 
-    configs += [ "//starboard/build/config:starboard_implementation" ]
+  configs += [ "//starboard/build/config:starboard_implementation" ]
 
-    deps = [
-      ":starboard_platform",
-      "//starboard:starboard_with_main",
-      "//starboard/shared/starboard/player/filter/testing:test_util",
-      "//testing/gmock",
-      "//testing/gtest",
-    ]
-  }
+  deps = [
+    ":starboard_platform",
+    "//starboard:starboard_with_main",
+    "//starboard/shared/starboard/player/filter/testing:test_util",
+    "//testing/gmock",
+    "//testing/gtest",
+  ]
 }


### PR DESCRIPTION
The platform BUILD.gn files for Android, AOSP, Linux and rdk are only ever evaluated in the Starboard toolchain. Make that explicit with a top-of-file `assert(is_starboard_toolchain)` and drop the now-redundant per-target `current_toolchain == starboard_toolchain` checks.

Move default_toolchain targets out of rdk's shared BUILD.gn, the one
exception, into their own file so that the invariant holds there too. Also simplify its `loader_app` target, to avoid an unneeded indirection to //starboard/loader_app:loader_app.

Bug: 495203133