### PR TITLE
evergreen: Generate libcobalt.zst in builds

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -67,6 +67,7 @@ group("gn_all") {
       ":cobalt_loader",
       "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)",
       "//starboard/loader_app:loader_app($starboard_toolchain)",
+      "//starboard/tools/zstd_compress:zstd_compress_unittest($host_toolchain)",
     ]
   }
   if (is_starboard && build_updater_sandbox) {

--- a/cobalt/build/modular_executable.gni
+++ b/cobalt/build/modular_executable.gni
@@ -147,6 +147,7 @@ template("evergreen_final_target") {
       data_deps = [
         ":copy_${original_target_name}_content",
         ":copy_${original_target_name}_lib",
+        ":copy_${original_target_name}_zstd_lib",
         "//starboard/content/ssl:copy_ssl_certificates_prod_cobalt",
       ]
     }
@@ -192,6 +193,19 @@ template("evergreen_final_target") {
       inputs = [ "$root_out_dir/${lib_name}.so" ]
       outputs =
           [ "$root_out_dir/app/${original_target_name}/lib/${lib_name}.lz4" ]
+      args =
+          rebase_path(inputs, root_out_dir) + rebase_path(outputs, root_out_dir)
+      deps = [ ":${original_target_name}" ]
+      data_deps = deps  # Needed for the .runtime_deps file.
+    }
+
+    compiled_action("copy_${original_target_name}_zstd_lib") {
+      forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
+
+      tool = "//starboard/tools/zstd_compress"
+      inputs = [ "$root_out_dir/${lib_name}.so" ]
+      outputs =
+          [ "$root_out_dir/app/${original_target_name}/lib/${lib_name}.zst" ]
       args =
           rebase_path(inputs, root_out_dir) + rebase_path(outputs, root_out_dir)
       deps = [ ":${original_target_name}" ]

--- a/cobalt/build/testing/targets/evergreen-x64/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-x64/test_targets.json
@@ -201,11 +201,5 @@
     "executable": "out/evergreen-x64_devel/url_unittests_loader.py",
     "runs_on": "host",
     "test_type": "gtest"
-  },
-  {
-    "target": "clang_x64/zstd_compress_unittest",
-    "executable": "out/evergreen-x64_devel/clang_x64/zstd_compress_unittest",
-    "runs_on": "host",
-    "test_type": "gtest"
   }
 ]

--- a/cobalt/build/testing/targets/evergreen-x64/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-x64/test_targets.json
@@ -203,7 +203,7 @@
     "test_type": "gtest"
   },
   {
-    "target": "starboard/tools/zstd_compress:zstd_compress_unittest",
+    "target": "clang_x64/zstd_compress_unittest",
     "executable": "out/evergreen-x64_devel/clang_x64/zstd_compress_unittest",
     "runs_on": "host",
     "test_type": "gtest"

--- a/cobalt/build/testing/targets/evergreen-x64/test_targets.json
+++ b/cobalt/build/testing/targets/evergreen-x64/test_targets.json
@@ -201,5 +201,11 @@
     "executable": "out/evergreen-x64_devel/url_unittests_loader.py",
     "runs_on": "host",
     "test_type": "gtest"
+  },
+  {
+    "target": "starboard/tools/zstd_compress:zstd_compress_unittest",
+    "executable": "out/evergreen-x64_devel/clang_x64/zstd_compress_unittest",
+    "runs_on": "host",
+    "test_type": "gtest"
   }
 ]

--- a/starboard/tools/file_utils/BUILD.gn
+++ b/starboard/tools/file_utils/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright 2022 The Cobalt Authors. All Rights Reserved.
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,10 @@
 # limitations under the License.
 
 if (current_toolchain == host_toolchain) {
-  executable("lz4_compress") {
-    sources = [ "lz4_compress.cc" ]
-    deps = [
-      "//starboard/tools/file_utils:file_utils",
-      "//third_party/lz4_lib:lz4",
+  source_set("file_utils") {
+    sources = [
+      "file_utils.cc",
+      "file_utils.h",
     ]
   }
 }

--- a/starboard/tools/file_utils/BUILD.gn
+++ b/starboard/tools/file_utils/BUILD.gn
@@ -12,11 +12,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (current_toolchain == host_toolchain) {
-  source_set("file_utils") {
-    sources = [
-      "file_utils.cc",
-      "file_utils.h",
-    ]
-  }
+assert(current_toolchain == host_toolchain,
+       "Starboard tools should only be built for the host toolchain")
+
+source_set("file_utils") {
+  sources = [
+    "file_utils.cc",
+    "file_utils.h",
+  ]
 }

--- a/starboard/tools/file_utils/file_utils.cc
+++ b/starboard/tools/file_utils/file_utils.cc
@@ -43,6 +43,11 @@ bool ReadFile(const char* file_path, std::vector<char>& buffer) {
   }
   rewind(file);
   const size_t file_size = static_cast<size_t>(file_size_signed);
+  if (file_size == 0) {
+    std::cerr << "File is empty: " << file_path << "\n";
+    fclose(file);
+    return false;
+  }
 
   buffer.resize(file_size);
   size_t result;
@@ -59,6 +64,11 @@ bool ReadFile(const char* file_path, std::vector<char>& buffer) {
 }
 
 bool WriteFile(const char* file_path, const std::vector<char>& buffer) {
+  if (buffer.empty()) {
+    std::cerr << "Buffer is empty for " << file_path << "\n";
+    return false;
+  }
+
   FILE* file;
   if ((file = fopen(file_path, "wb")) == nullptr) {
     std::cerr << "Failed to open " << file_path << "\n";

--- a/starboard/tools/file_utils/file_utils.cc
+++ b/starboard/tools/file_utils/file_utils.cc
@@ -1,0 +1,82 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/tools/file_utils/file_utils.h"
+
+#include <stdio.h>
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace starboard {
+namespace tools {
+
+bool ReadFile(const char* file_path, std::vector<char>& buffer) {
+  FILE* file;
+  if ((file = fopen(file_path, "rb")) == nullptr) {
+    std::cerr << "Failed to open " << file_path << "\n";
+    return false;
+  }
+
+  if (fseek(file, 0L, SEEK_END) != 0) {
+    std::cerr << "Failed to seek in " << file_path << "\n";
+    fclose(file);
+    return false;
+  }
+  std::int64_t file_size_signed;
+  if ((file_size_signed = ftell(file)) == -1L) {
+    std::cerr << "Failed to get size of " << file_path << "\n";
+    fclose(file);
+    return false;
+  }
+  rewind(file);
+  const size_t file_size = static_cast<size_t>(file_size_signed);
+
+  buffer.resize(file_size);
+  size_t result;
+  if ((result = fread(buffer.data(), sizeof(char), file_size, file)) !=
+      file_size) {
+    std::cerr << "Expected to read " << file_size << " bytes from " << file_path
+              << " but only read " << result << "\n";
+    fclose(file);
+    return false;
+  }
+
+  fclose(file);
+  return true;
+}
+
+bool WriteFile(const char* file_path, const std::vector<char>& buffer) {
+  FILE* file;
+  if ((file = fopen(file_path, "wb")) == nullptr) {
+    std::cerr << "Failed to open " << file_path << "\n";
+    return false;
+  }
+
+  size_t result;
+  if ((result = fwrite(buffer.data(), sizeof(char), buffer.size(), file)) !=
+      buffer.size()) {
+    std::cerr << "Expected to write " << buffer.size() << " bytes to "
+              << file_path << " but only wrote " << result << "\n";
+    fclose(file);
+    return false;
+  }
+
+  fclose(file);
+  return true;
+}
+
+}  // namespace tools
+}  // namespace starboard

--- a/starboard/tools/file_utils/file_utils.cc
+++ b/starboard/tools/file_utils/file_utils.cc
@@ -21,7 +21,6 @@
 #include <vector>
 
 namespace starboard {
-namespace tools {
 
 bool ReadFile(const char* file_path, std::vector<char>& buffer) {
   FILE* file;
@@ -88,5 +87,4 @@ bool WriteFile(const char* file_path, const std::vector<char>& buffer) {
   return true;
 }
 
-}  // namespace tools
 }  // namespace starboard

--- a/starboard/tools/file_utils/file_utils.h
+++ b/starboard/tools/file_utils/file_utils.h
@@ -1,0 +1,29 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_TOOLS_FILE_UTILS_FILE_UTILS_H_
+#define STARBOARD_TOOLS_FILE_UTILS_FILE_UTILS_H_
+
+#include <vector>
+
+namespace starboard {
+namespace tools {
+
+bool ReadFile(const char* file_path, std::vector<char>& buffer);
+bool WriteFile(const char* file_path, const std::vector<char>& buffer);
+
+}  // namespace tools
+}  // namespace starboard
+
+#endif  // STARBOARD_TOOLS_FILE_UTILS_FILE_UTILS_H_

--- a/starboard/tools/file_utils/file_utils.h
+++ b/starboard/tools/file_utils/file_utils.h
@@ -18,12 +18,10 @@
 #include <vector>
 
 namespace starboard {
-namespace tools {
 
 bool ReadFile(const char* file_path, std::vector<char>& buffer);
 bool WriteFile(const char* file_path, const std::vector<char>& buffer);
 
-}  // namespace tools
 }  // namespace starboard
 
 #endif  // STARBOARD_TOOLS_FILE_UTILS_FILE_UTILS_H_

--- a/starboard/tools/lz4_compress/BUILD.gn
+++ b/starboard/tools/lz4_compress/BUILD.gn
@@ -12,12 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-if (current_toolchain == host_toolchain) {
-  executable("lz4_compress") {
-    sources = [ "lz4_compress.cc" ]
-    deps = [
-      "//starboard/tools/file_utils:file_utils",
-      "//third_party/lz4_lib:lz4",
-    ]
-  }
+assert(current_toolchain == host_toolchain,
+       "Starboard tools should only be built for the host toolchain")
+
+executable("lz4_compress") {
+  sources = [ "lz4_compress.cc" ]
+  deps = [
+    "//starboard/tools/file_utils",
+    "//third_party/lz4_lib:lz4",
+  ]
 }

--- a/starboard/tools/lz4_compress/lz4_compress.cc
+++ b/starboard/tools/lz4_compress/lz4_compress.cc
@@ -20,49 +20,12 @@
 // in the Loader Application expects. Ad hoc users wanting more flexibility
 // should use the official LZ4 CLI instead.
 
-#include <stdio.h>
-
-#include <cstdint>
 #include <iostream>
 #include <vector>
 
+#include "starboard/tools/file_utils/file_utils.h"
 #include "third_party/lz4_lib/lz4frame.h"
 #include "third_party/lz4_lib/lz4hc.h"
-
-bool ReadFile(const char* file_path, std::vector<char>& buffer) {
-  FILE* file;
-  if ((file = fopen(file_path, "rb")) == NULL) {
-    std::cerr << "Failed to open " << file_path << "\n";
-    return false;
-  }
-
-  if (fseek(file, 0L, SEEK_END) != 0) {
-    std::cerr << "Failed to seek in " << file_path << "\n";
-    fclose(file);
-    return false;
-  }
-  std::int64_t file_size_signed;
-  if ((file_size_signed = ftell(file)) == -1L) {
-    std::cerr << "Failed to get size of " << file_path << "\n";
-    fclose(file);
-    return false;
-  }
-  rewind(file);
-  const size_t file_size = static_cast<size_t>(file_size_signed);
-
-  buffer.resize(file_size);
-  size_t result;
-  if ((result = fread(buffer.data(), sizeof(char), file_size, file)) !=
-      file_size) {
-    std::cerr << "Expected to read " << file_size << " bytes from " << file_path
-              << " but only read " << result << "\n";
-    fclose(file);
-    return false;
-  }
-
-  fclose(file);
-  return true;
-}
 
 bool Compress(std::vector<char>& src_buffer, std::vector<char>& dst_buffer) {
   // Based on experimentation these preferences yield a high compression ratio
@@ -90,50 +53,26 @@ bool Compress(std::vector<char>& src_buffer, std::vector<char>& dst_buffer) {
   return true;
 }
 
-bool WriteFile(const char* file_path, std::vector<char>& buffer) {
-  FILE* file;
-  if ((file = fopen(file_path, "wb")) == NULL) {
-    std::cerr << "Failed to open " << file_path << "\n";
-    return false;
-  }
-
-  size_t result;
-  if ((result = fwrite(buffer.data(), sizeof(char), buffer.size(), file)) !=
-      buffer.size()) {
-    std::cerr << "Expected to write " << buffer.size() << " bytes to "
-              << file_path << " but only wrote " << result << "\n";
-    fclose(file);
-    return false;
-  }
-
-  fclose(file);
-  return true;
-}
-
 int main(int argc, char* argv[]) {
   if (argc != 3) {
-    std::cerr << "Usage: lz4_compress <source> <destination>"
-              << "\n";
+    std::cerr << "Usage: lz4_compress <source> <destination>\n";
     return 1;
   }
 
   std::vector<char> src_buffer;
-  if (!ReadFile(argv[1], src_buffer)) {
-    std::cerr << "Failed to read the src file"
-              << "\n";
+  if (!starboard::tools::ReadFile(argv[1], src_buffer)) {
+    std::cerr << "Failed to read the src file\n";
     return 1;
   }
 
   std::vector<char> dst_buffer;
   if (!Compress(src_buffer, dst_buffer)) {
-    std::cerr << "Failed to compress"
-              << "\n";
+    std::cerr << "Failed to compress\n";
     return 1;
   }
 
-  if (!WriteFile(argv[2], dst_buffer)) {
-    std::cerr << "Failed to write the dst file"
-              << "\n";
+  if (!starboard::tools::WriteFile(argv[2], dst_buffer)) {
+    std::cerr << "Failed to write the dst file\n";
     return 1;
   }
 

--- a/starboard/tools/lz4_compress/lz4_compress.cc
+++ b/starboard/tools/lz4_compress/lz4_compress.cc
@@ -60,7 +60,7 @@ int main(int argc, char* argv[]) {
   }
 
   std::vector<char> src_buffer;
-  if (!starboard::tools::ReadFile(argv[1], src_buffer)) {
+  if (!starboard::ReadFile(argv[1], src_buffer)) {
     std::cerr << "Failed to read the src file\n";
     return 1;
   }
@@ -71,7 +71,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  if (!starboard::tools::WriteFile(argv[2], dst_buffer)) {
+  if (!starboard::WriteFile(argv[2], dst_buffer)) {
     std::cerr << "Failed to write the dst file\n";
     return 1;
   }

--- a/starboard/tools/zstd_compress/BUILD.gn
+++ b/starboard/tools/zstd_compress/BUILD.gn
@@ -1,4 +1,4 @@
-# Copyright 2022 The Cobalt Authors. All Rights Reserved.
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,11 +13,30 @@
 # limitations under the License.
 
 if (current_toolchain == host_toolchain) {
-  executable("lz4_compress") {
-    sources = [ "lz4_compress.cc" ]
+  source_set("zstd_compress_lib") {
+    sources = [
+      "zstd_compress.cc",
+      "zstd_compress.h",
+    ]
+    deps = [ "//third_party/zstd:compress" ]
+  }
+
+  executable("zstd_compress") {
+    sources = [ "zstd_compress_main.cc" ]
     deps = [
+      ":zstd_compress_lib",
       "//starboard/tools/file_utils:file_utils",
-      "//third_party/lz4_lib:lz4",
+    ]
+  }
+
+  executable("zstd_compress_unittest") {
+    testonly = true
+    sources = [ "zstd_compress_unittest.cc" ]
+    deps = [
+      ":zstd_compress_lib",
+      "//testing/gtest",
+      "//testing/gtest:gtest_main",
+      "//third_party/zstd:decompress",
     ]
   }
 }

--- a/starboard/tools/zstd_compress/BUILD.gn
+++ b/starboard/tools/zstd_compress/BUILD.gn
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//testing/test.gni")
+
 if (current_toolchain == host_toolchain) {
   source_set("zstd_compress_lib") {
     sources = [
@@ -29,13 +31,12 @@ if (current_toolchain == host_toolchain) {
     ]
   }
 
-  executable("zstd_compress_unittest") {
+  test("zstd_compress_unittest") {
     testonly = true
     sources = [ "zstd_compress_unittest.cc" ]
     deps = [
       ":zstd_compress_lib",
       "//testing/gtest",
-      "//testing/gtest:gtest_main",
       "//third_party/zstd:decompress",
     ]
   }

--- a/starboard/tools/zstd_compress/BUILD.gn
+++ b/starboard/tools/zstd_compress/BUILD.gn
@@ -31,6 +31,7 @@ if (current_toolchain == host_toolchain) {
     ]
   }
 
+  # TODO: b/535249762 - Run this unit test target in CI.
   test("zstd_compress_unittest") {
     testonly = true
     sources = [ "zstd_compress_unittest.cc" ]

--- a/starboard/tools/zstd_compress/BUILD.gn
+++ b/starboard/tools/zstd_compress/BUILD.gn
@@ -12,34 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+assert(current_toolchain == host_toolchain,
+       "Starboard tools should only be built for the host toolchain")
+
 import("//testing/test.gni")
 
-if (current_toolchain == host_toolchain) {
-  source_set("zstd_compress_lib") {
-    sources = [
-      "zstd_compress.cc",
-      "zstd_compress.h",
-    ]
-    deps = [ "//third_party/zstd:compress" ]
-  }
+source_set("zstd_compress_lib") {
+  sources = [
+    "zstd_compress.cc",
+    "zstd_compress.h",
+  ]
+  deps = [ "//third_party/zstd:compress" ]
+}
 
-  executable("zstd_compress") {
-    sources = [ "zstd_compress_main.cc" ]
-    deps = [
-      ":zstd_compress_lib",
-      "//starboard/tools/file_utils:file_utils",
-    ]
-  }
+executable("zstd_compress") {
+  sources = [ "zstd_compress_main.cc" ]
+  deps = [
+    ":zstd_compress_lib",
+    "//starboard/tools/file_utils",
+  ]
+}
 
-  # TODO: b/535249762 - Run this unit test target in CI.
-  test("zstd_compress_unittest") {
-    testonly = true
-    sources = [ "zstd_compress_unittest.cc" ]
-    deps = [
-      ":zstd_compress_lib",
-      "//testing/gtest",
-      "//testing/gtest:gtest_main",
-      "//third_party/zstd:decompress",
-    ]
-  }
+# TODO: b/535249762 - Run this unit test target in CI.
+test("zstd_compress_unittest") {
+  testonly = true
+  sources = [ "zstd_compress_unittest.cc" ]
+  deps = [
+    ":zstd_compress_lib",
+    "//testing/gtest",
+    "//testing/gtest:gtest_main",
+    "//third_party/zstd:decompress",
+  ]
 }

--- a/starboard/tools/zstd_compress/BUILD.gn
+++ b/starboard/tools/zstd_compress/BUILD.gn
@@ -38,6 +38,7 @@ if (current_toolchain == host_toolchain) {
     deps = [
       ":zstd_compress_lib",
       "//testing/gtest",
+      "//testing/gtest:gtest_main",
       "//third_party/zstd:decompress",
     ]
   }

--- a/starboard/tools/zstd_compress/zstd_compress.cc
+++ b/starboard/tools/zstd_compress/zstd_compress.cc
@@ -1,0 +1,77 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/tools/zstd_compress/zstd_compress.h"
+
+#include <iostream>
+#include <vector>
+
+#include "third_party/zstd/src/lib/zstd.h"
+
+namespace starboard {
+namespace tools {
+namespace zstd_compress {
+
+bool Compress(const std::vector<char>& src_buffer,
+              std::vector<char>& dst_buffer) {
+  if (src_buffer.empty()) {
+    std::cerr << "Source buffer is empty\n";
+    return false;
+  }
+
+  ZSTD_CCtx* cctx = ZSTD_createCCtx();
+  if (!cctx) {
+    std::cerr << "Failed to create ZSTD_CCtx\n";
+    return false;
+  }
+
+  dst_buffer.clear();
+  const size_t total_size = src_buffer.size();
+
+  for (int i = 0; i < kNumFrames; ++i) {
+    size_t chunk_start =
+        (total_size * static_cast<size_t>(i)) / static_cast<size_t>(kNumFrames);
+    size_t chunk_end = (total_size * static_cast<size_t>(i + 1)) /
+                       static_cast<size_t>(kNumFrames);
+    size_t chunk_size = chunk_end - chunk_start;
+
+    if (chunk_size == 0) {
+      continue;
+    }
+
+    size_t bound = ZSTD_compressBound(chunk_size);
+    std::vector<char> frame_buf(bound);
+
+    size_t encoded_size = ZSTD_compressCCtx(cctx, frame_buf.data(), bound,
+                                            src_buffer.data() + chunk_start,
+                                            chunk_size, kCompressionLevel);
+
+    if (ZSTD_isError(encoded_size)) {
+      std::cerr << "ZSTD_compressCCtx failed: "
+                << ZSTD_getErrorName(encoded_size) << "\n";
+      ZSTD_freeCCtx(cctx);
+      return false;
+    }
+
+    dst_buffer.insert(dst_buffer.end(), frame_buf.data(),
+                      frame_buf.data() + encoded_size);
+  }
+
+  ZSTD_freeCCtx(cctx);
+  return !dst_buffer.empty();
+}
+
+}  // namespace zstd_compress
+}  // namespace tools
+}  // namespace starboard

--- a/starboard/tools/zstd_compress/zstd_compress.cc
+++ b/starboard/tools/zstd_compress/zstd_compress.cc
@@ -39,13 +39,15 @@ bool Compress(const std::vector<char>& src_buffer,
   dst_buffer.clear();
   const size_t total_size = src_buffer.size();
 
-  for (int i = 0; i < kNumFrames; ++i) {
-    size_t chunk_start =
-        (total_size * static_cast<size_t>(i)) / static_cast<size_t>(kNumFrames);
-    size_t chunk_end = (total_size * static_cast<size_t>(i + 1)) /
-                       static_cast<size_t>(kNumFrames);
-    size_t chunk_size = chunk_end - chunk_start;
+  // We'll create |remainder| chunks of |base_chunk_size| + 1 bytes, and
+  // |kNumFrames| - |remainder| chunks of |base_chunk_size| bytes.
+  const size_t base_chunk_size = total_size / kNumFrames;
+  const size_t remainder = total_size % kNumFrames;
 
+  size_t chunk_start = 0;
+  for (int i = 0; i < kNumFrames; ++i) {
+    size_t chunk_size =
+        base_chunk_size + (static_cast<size_t>(i) < remainder ? 1 : 0);
     if (chunk_size == 0) {
       continue;
     }
@@ -66,6 +68,7 @@ bool Compress(const std::vector<char>& src_buffer,
 
     dst_buffer.insert(dst_buffer.end(), frame_buf.data(),
                       frame_buf.data() + encoded_size);
+    chunk_start += chunk_size;
   }
 
   ZSTD_freeCCtx(cctx);

--- a/starboard/tools/zstd_compress/zstd_compress.cc
+++ b/starboard/tools/zstd_compress/zstd_compress.cc
@@ -20,7 +20,6 @@
 #include "third_party/zstd/src/lib/zstd.h"
 
 namespace starboard {
-namespace tools {
 namespace zstd_compress {
 
 bool Compress(const std::vector<char>& src_buffer,
@@ -76,5 +75,4 @@ bool Compress(const std::vector<char>& src_buffer,
 }
 
 }  // namespace zstd_compress
-}  // namespace tools
 }  // namespace starboard

--- a/starboard/tools/zstd_compress/zstd_compress.h
+++ b/starboard/tools/zstd_compress/zstd_compress.h
@@ -1,0 +1,37 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_TOOLS_ZSTD_COMPRESS_ZSTD_COMPRESS_H_
+#define STARBOARD_TOOLS_ZSTD_COMPRESS_ZSTD_COMPRESS_H_
+
+#include <vector>
+
+namespace starboard {
+namespace tools {
+namespace zstd_compress {
+
+constexpr int kNumFrames = 64;
+constexpr int kCompressionLevel = 3;
+
+// Compresses src_buffer into dst_buffer across kNumFrames independent
+// Zstandard frames, of ~evenly divided uncompressed source size, using
+// kCompressionLevel.
+bool Compress(const std::vector<char>& src_buffer,
+              std::vector<char>& dst_buffer);
+
+}  // namespace zstd_compress
+}  // namespace tools
+}  // namespace starboard
+
+#endif  // STARBOARD_TOOLS_ZSTD_COMPRESS_ZSTD_COMPRESS_H_

--- a/starboard/tools/zstd_compress/zstd_compress.h
+++ b/starboard/tools/zstd_compress/zstd_compress.h
@@ -18,7 +18,6 @@
 #include <vector>
 
 namespace starboard {
-namespace tools {
 namespace zstd_compress {
 
 constexpr int kNumFrames = 64;
@@ -31,7 +30,6 @@ bool Compress(const std::vector<char>& src_buffer,
               std::vector<char>& dst_buffer);
 
 }  // namespace zstd_compress
-}  // namespace tools
 }  // namespace starboard
 
 #endif  // STARBOARD_TOOLS_ZSTD_COMPRESS_ZSTD_COMPRESS_H_

--- a/starboard/tools/zstd_compress/zstd_compress_main.cc
+++ b/starboard/tools/zstd_compress/zstd_compress_main.cc
@@ -31,7 +31,7 @@ int main(int argc, char* argv[]) {
   }
 
   std::vector<char> dst_buffer;
-  if (!starboard::tools::zstd_compress::Compress(src_buffer, dst_buffer)) {
+  if (!starboard::zstd_compress::Compress(src_buffer, dst_buffer)) {
     std::cerr << "Failed to compress\n";
     return 1;
   }

--- a/starboard/tools/zstd_compress/zstd_compress_main.cc
+++ b/starboard/tools/zstd_compress/zstd_compress_main.cc
@@ -1,0 +1,45 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <iostream>
+#include <vector>
+
+#include "starboard/tools/file_utils/file_utils.h"
+#include "starboard/tools/zstd_compress/zstd_compress.h"
+
+int main(int argc, char* argv[]) {
+  if (argc != 3) {
+    std::cerr << "Usage: zstd_compress <source> <destination>\n";
+    return 1;
+  }
+
+  std::vector<char> src_buffer;
+  if (!starboard::tools::ReadFile(argv[1], src_buffer)) {
+    std::cerr << "Failed to read the src file\n";
+    return 1;
+  }
+
+  std::vector<char> dst_buffer;
+  if (!starboard::tools::zstd_compress::Compress(src_buffer, dst_buffer)) {
+    std::cerr << "Failed to compress\n";
+    return 1;
+  }
+
+  if (!starboard::tools::WriteFile(argv[2], dst_buffer)) {
+    std::cerr << "Failed to write the dst file\n";
+    return 1;
+  }
+
+  return 0;
+}

--- a/starboard/tools/zstd_compress/zstd_compress_main.cc
+++ b/starboard/tools/zstd_compress/zstd_compress_main.cc
@@ -25,7 +25,7 @@ int main(int argc, char* argv[]) {
   }
 
   std::vector<char> src_buffer;
-  if (!starboard::tools::ReadFile(argv[1], src_buffer)) {
+  if (!starboard::ReadFile(argv[1], src_buffer)) {
     std::cerr << "Failed to read the src file\n";
     return 1;
   }
@@ -36,7 +36,7 @@ int main(int argc, char* argv[]) {
     return 1;
   }
 
-  if (!starboard::tools::WriteFile(argv[2], dst_buffer)) {
+  if (!starboard::WriteFile(argv[2], dst_buffer)) {
     std::cerr << "Failed to write the dst file\n";
     return 1;
   }

--- a/starboard/tools/zstd_compress/zstd_compress_unittest.cc
+++ b/starboard/tools/zstd_compress/zstd_compress_unittest.cc
@@ -21,7 +21,6 @@
 #include "third_party/zstd/src/lib/zstd.h"
 
 namespace starboard {
-namespace tools {
 namespace zstd_compress {
 namespace {
 
@@ -91,5 +90,4 @@ TEST(ZstdCompressTest, DecompressesToOriginalData) {
 
 }  // namespace
 }  // namespace zstd_compress
-}  // namespace tools
 }  // namespace starboard

--- a/starboard/tools/zstd_compress/zstd_compress_unittest.cc
+++ b/starboard/tools/zstd_compress/zstd_compress_unittest.cc
@@ -1,0 +1,95 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/tools/zstd_compress/zstd_compress.h"
+
+#include <string>
+#include <vector>
+
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/zstd/src/lib/zstd.h"
+
+namespace starboard {
+namespace tools {
+namespace zstd_compress {
+namespace {
+
+std::vector<char> CreateTestData(size_t size) {
+  std::vector<char> data;
+  data.reserve(size);
+  for (size_t i = 0; i < size; ++i) {
+    data.push_back(static_cast<char>('A' + (i % 26)));
+  }
+  return data;
+}
+
+TEST(ZstdCompressTest, EmptyInputFails) {
+  std::vector<char> src;
+  std::vector<char> dst;
+  EXPECT_FALSE(Compress(src, dst));
+}
+
+TEST(ZstdCompressTest, CompressesIntoCorrectNumberOfFrames) {
+  // Use a size proportional to kNumFrames (>= kNumFrames) to guarantee every
+  // frame receives at least 1 byte and all kNumFrames frames are constructed.
+  const size_t test_data_size = kNumFrames * 1000;
+  std::vector<char> src = CreateTestData(test_data_size);
+  std::vector<char> dst;
+
+  ASSERT_TRUE(Compress(src, dst));
+  EXPECT_FALSE(dst.empty());
+
+  size_t offset = 0;
+  int frame_count = 0;
+  size_t total_decompressed_size = 0;
+
+  while (offset < dst.size()) {
+    size_t remaining = dst.size() - offset;
+    size_t compressed_frame_size =
+        ZSTD_findFrameCompressedSize(dst.data() + offset, remaining);
+    ASSERT_FALSE(ZSTD_isError(compressed_frame_size));
+
+    unsigned long long decompressed_frame_size =
+        ZSTD_getFrameContentSize(dst.data() + offset, compressed_frame_size);
+    ASSERT_NE(decompressed_frame_size, ZSTD_CONTENTSIZE_ERROR);
+    ASSERT_NE(decompressed_frame_size, ZSTD_CONTENTSIZE_UNKNOWN);
+
+    total_decompressed_size += static_cast<size_t>(decompressed_frame_size);
+    offset += compressed_frame_size;
+    frame_count++;
+  }
+
+  EXPECT_EQ(frame_count, kNumFrames);
+  EXPECT_EQ(total_decompressed_size, src.size());
+}
+
+TEST(ZstdCompressTest, DecompressesToOriginalData) {
+  const size_t test_data_size = kNumFrames * 1000;
+  std::vector<char> src = CreateTestData(test_data_size);
+  std::vector<char> dst;
+
+  ASSERT_TRUE(Compress(src, dst));
+
+  std::vector<char> decompressed(src.size());
+  size_t result = ZSTD_decompress(decompressed.data(), decompressed.size(),
+                                  dst.data(), dst.size());
+  ASSERT_FALSE(ZSTD_isError(result));
+  EXPECT_EQ(result, src.size());
+  EXPECT_EQ(decompressed, src);
+}
+
+}  // namespace
+}  // namespace zstd_compress
+}  // namespace tools
+}  // namespace starboard


### PR DESCRIPTION
A compiled action is added to generate libcobalt.zst alongside libcobalt.lz4, under app/cobalt/lib/. The action runs a new, custom tool that leverages the Zstandard library to compress libcobalt.so into a file comprising 64 Zstandard frames. The frames are for now evenly divided based on uncompressed source size. We may later consider constructing ELF segment-aware frames, as recommended in go/zstd-for-evergreen, but ZstdFileImpl does not require this.

Common File I/O functions are factored out from lz4_compress.cc so they can be shared by the LZ4 and Zstandard tools.

Only the build changes are made for now; changes to package.json files, to include libcobalt.zst in release artifacts, will be made later.

#vibe-coded

Issue: 534315298