### PR TITLE
starboard: Remove dead needResetSurface allowlist and JNI code

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/VideoSurfaceView.java
@@ -18,14 +18,11 @@ import static dev.cobalt.media.Log.TAG;
 
 import android.content.Context;
 import android.graphics.Color;
-import android.os.Build;
 import android.util.AttributeSet;
 import android.view.Surface;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import dev.cobalt.util.Log;
-import java.util.HashSet;
-import java.util.Set;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
 
@@ -38,21 +35,9 @@ public class VideoSurfaceView extends SurfaceView {
   @NativeMethods
   interface Natives {
     void onVideoSurfaceChanged(Surface surface);
-    void setNeedResetSurface();
   }
 
   private static Surface sCurrentSurface = null;
-
-  private static final Set<String> sNeedResetSurfaceList = new HashSet<>();
-
-  static {
-    sNeedResetSurfaceList.add("Nexus Player");
-
-    // Reset video surface on nexus player to avoid b/159073388.
-    if (sNeedResetSurfaceList.contains(Build.MODEL)) {
-      // VideoSurfaceViewJni.get().setNeedResetSurface();
-    }
-  }
 
   public VideoSurfaceView(Context context) {
     super(context);

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -59,11 +59,6 @@ scoped_refptr<SurfaceDestroyNotifier>& GetGlobalSurfaceDestroyNotifier() {
   return *notifier;
 }
 
-// Global boolean to indicate if we need to reset SurfaceView after playing
-// vertical video.
-// TODO: b/521503666 - Revisit to see if we need this variable or not.
-bool g_reset_surface_on_clear_window = false;
-
 void ClearNativeWindow(void* raw_context) {
   ANativeWindow* native_window = static_cast<ANativeWindow*>(raw_context);
   EGLDisplay display = eglGetDisplay(EGL_DEFAULT_DISPLAY);
@@ -173,10 +168,6 @@ void JNI_VideoSurfaceView_OnVideoSurfaceChanged(
   if (notifier_to_notify) {
     notifier_to_notify->Notify();
   }
-}
-
-void JNI_VideoSurfaceView_SetNeedResetSurface(JNIEnv* env) {
-  g_reset_surface_on_clear_window = true;
 }
 
 void SurfaceDestroyNotifier::Disconnect() {


### PR DESCRIPTION
This code is no longer used. Surface resetting (resetVideoSurface) was enabled by default across all Android devices in PR #4498, and the redundant allowlist and aspect ratio checks were subsequently refactored and removed in PR #10253.

- https://github.com/youtube/cobalt/pull/4498
- https://github.com/youtube/cobalt/pull/10253

Issue: 413418478