### PR TITLE
gpu: increase kMaxTextureUnits limit

### DIFF
--- a/gpu/command_buffer/service/gles2_cmd_decoder_passthrough.h
+++ b/gpu/command_buffer/service/gles2_cmd_decoder_passthrough.h
@@ -18,6 +18,7 @@
 #include "base/memory/raw_ptr.h"
 #include "base/memory/ref_counted.h"
 #include "build/build_config.h"
+#include "build/buildflag.h"
 #include "gpu/command_buffer/common/debug_marker_manager.h"
 #include "gpu/command_buffer/common/discardable_handle.h"
 #include "gpu/command_buffer/common/gles2_cmd_format.h"
@@ -577,7 +578,11 @@ class GPU_GLES2_EXPORT GLES2DecoderPassthroughImpl
 
   // Use a limit that is at least ANGLE's IMPLEMENTATION_MAX_ACTIVE_TEXTURES
   // constant
+#if BUILDFLAG(IS_STARBOARD)
+  static constexpr size_t kMaxTextureUnits = 96;
+#else
   static constexpr size_t kMaxTextureUnits = 64;
+#endif
   static constexpr size_t kNumTextureTypes =
       static_cast<size_t>(TextureTarget::kCount);
   std::array<std::array<BoundTexture, kMaxTextureUnits>, kNumTextureTypes>


### PR DESCRIPTION
Increase `kMaxTextureUnits` from 64 to 96 in `gles2_cmd_decoder_passthrough.h`, to match the RDK device hardware limits.

Prevents initialization failure of the passthrough command decoder. Guarded with `BUILDFLAG(IS_STARBOARD)`.

Bug: 516807166