### PR TITLE
Revert "[CI] Disable E2E tests on RDK"

### DIFF
--- a/.github/config/evergreen-arm-hardfp-rdk.json
+++ b/.github/config/evergreen-arm-hardfp-rdk.json
@@ -6,7 +6,7 @@
   "test_package": true,
   "test_on_device": true,
   "test_device_family": "rdk",
-  "test_e2e": false,
+  "test_e2e": true,
   "test_root_target": "//cobalt:gn_all",
   "test_dimensions": {
     "device_type": "rdk",


### PR DESCRIPTION
evergreen: Reenable E2E tests on RDK

Reenable end-to-end testing for the Evergreen ARM hardfp RDK platform.
This change reverts the temporary disabling of these tests in the
GitHub CI configuration, restoring full validation coverage for this
target.

Bug: 11370