### PR TITLE
android: Prevent false-positive post-seek frame drops

### DIFF
--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -42,6 +42,7 @@
 #include "starboard/decode_target.h"
 #include "starboard/drm.h"
 #include "starboard/shared/starboard/experimental_features.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/media_tracing.h"
 #include "starboard/shared/starboard/media/mime_type.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
@@ -378,6 +379,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
       ignore_mediacodec_callbacks_during_flushing_(
           pipeline_config.experimental_features.GetBool(
               kMediaIgnoreMediaCodecCallbacksDuringFlushing)),
+      ignore_stale_rendered_frames_after_seek_(
+          pipeline_config.experimental_features.GetBool(
+              kMediaIgnoreStaleRenderedFramesAfterSeek)),
       enable_trivial_optimizations_(
           pipeline_config.experimental_features.GetBool(
               kMediaEnableTrivialOptimizations)),
@@ -425,7 +429,8 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
 
   if (is_video_frame_tracker_enabled_) {
     video_frame_tracker_ = std::make_unique<VideoFrameTracker>(
-        max_pending_inputs_size_ + kVideoFrameTrackerMargin);
+        max_pending_inputs_size_ + kVideoFrameTrackerMargin,
+        ignore_stale_rendered_frames_after_seek_);
   }
 
   if (require_software_codec_) {
@@ -452,7 +457,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
                << "\", tunnel mode audio session id="
                << ToString(tunnel_mode_audio_session_id_)
                << ", is_video_frame_tracker_enabled="
-               << ToString(is_video_frame_tracker_enabled_);
+               << ToString(is_video_frame_tracker_enabled_)
+               << ", ignore_stale_rendered_frames_after_seek="
+               << ToString(ignore_stale_rendered_frames_after_seek_);
 }
 
 MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -42,6 +42,7 @@
 #include "starboard/decode_target.h"
 #include "starboard/drm.h"
 #include "starboard/shared/starboard/experimental_features.h"
+#include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/media_tracing.h"
 #include "starboard/shared/starboard/media/mime_type.h"
 #include "starboard/shared/starboard/player/filter/video_frame_internal.h"
@@ -370,6 +371,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
       ignore_mediacodec_callbacks_during_flushing_(
           pipeline_config.experimental_features.GetBool(
               kMediaIgnoreMediaCodecCallbacksDuringFlushing)),
+      ignore_stale_rendered_frames_after_seek_(
+          pipeline_config.experimental_features.GetBool(
+              kMediaIgnoreStaleRenderedFramesAfterSeek)),
       enable_trivial_optimizations_(
           pipeline_config.experimental_features.GetBool(
               kMediaEnableTrivialOptimizations)),
@@ -413,8 +417,8 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
   }
 
   if (is_video_frame_tracker_enabled_) {
-    video_frame_tracker_ =
-        std::make_unique<VideoFrameTracker>(kVideoFrameTrackerCapacity);
+    video_frame_tracker_ = std::make_unique<VideoFrameTracker>(
+        kVideoFrameTrackerCapacity, ignore_stale_rendered_frames_after_seek_);
   }
 
   if (require_software_codec_) {
@@ -440,7 +444,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
                << "\", tunnel mode audio session id="
                << ToString(tunnel_mode_audio_session_id_)
                << ", is_video_frame_tracker_enabled="
-               << ToString(is_video_frame_tracker_enabled_);
+               << ToString(is_video_frame_tracker_enabled_)
+               << ", ignore_stale_rendered_frames_after_seek="
+               << ToString(ignore_stale_rendered_frames_after_seek_);
 }
 
 MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -215,6 +215,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // Enable the workaround to ignore stale/dirty MediaCodec callback messages
   // queued on the main thread during a flush.
   const bool ignore_mediacodec_callbacks_during_flushing_;
+  const bool ignore_stale_rendered_frames_after_seek_;
   const bool enable_trivial_optimizations_;
   const bool enable_ndk_video_;
   const bool fix_need_more_input_backpressure_;

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -214,6 +214,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // Enable the workaround to ignore stale/dirty MediaCodec callback messages
   // queued on the main thread during a flush.
   const bool ignore_mediacodec_callbacks_during_flushing_;
+  const bool ignore_stale_rendered_frames_after_seek_;
   const bool enable_trivial_optimizations_;
   const bool enable_ndk_video_;
   const bool fix_need_more_input_backpressure_;

--- a/starboard/android/shared/video_frame_tracker.cc
+++ b/starboard/android/shared/video_frame_tracker.cc
@@ -124,6 +124,9 @@ void VideoFrameTracker::Seek(int64_t seek_to_time) {
 
   frames_to_be_rendered_.clear();
   seek_to_time_ = seek_to_time;
+  if (ignore_stale_rendered_frames_after_seek_) {
+    awaiting_first_frame_after_seek_ = true;
+  }
 }
 
 int VideoFrameTracker::UpdateAndGetDroppedFrames() {
@@ -163,11 +166,17 @@ void VideoFrameTracker::UpdateDroppedFrames() {
       if (std::abs(*to_render_timestamp - rendered_timestamp) <=
           kMaxAllowedSkew) {
         // This frame was rendered, remove it from frames_to_be_rendered_.
+        awaiting_first_frame_after_seek_ = false;
         to_render_timestamp = frames_to_be_rendered_.erase(to_render_timestamp);
       } else {
         // Here we know rendered_timestamp - *to_render_timestamp >
         // kMaxAllowedSkew, because the while loop condition guarantees
         // *to_render_timestamp - rendered_timestamp <= kMaxAllowedSkew.
+        if (awaiting_first_frame_after_seek_) {
+          // Ignore stale rendered frame callbacks from flushed pre-seek
+          // frames until the first post-seek frame match is found.
+          break;
+        }
         // The rendered frame is too far ahead. The to_render_timestamp frame
         // was dropped.
         SB_LOG(WARNING) << "Video frame dropped:" << *to_render_timestamp

--- a/starboard/android/shared/video_frame_tracker.h
+++ b/starboard/android/shared/video_frame_tracker.h
@@ -25,8 +25,12 @@ namespace starboard {
 
 class VideoFrameTracker {
  public:
-  explicit VideoFrameTracker(int max_pending_frames_size)
-      : max_pending_frames_size_(max_pending_frames_size) {}
+  explicit VideoFrameTracker(
+      int max_pending_frames_size,
+      bool ignore_stale_rendered_frames_after_seek = false)
+      : max_pending_frames_size_(max_pending_frames_size),
+        ignore_stale_rendered_frames_after_seek_(
+            ignore_stale_rendered_frames_after_seek) {}
 
   int64_t seek_to_time() const;
 
@@ -46,6 +50,8 @@ class VideoFrameTracker {
   std::list<int64_t> frames_to_be_rendered_;
 
   const int max_pending_frames_size_;
+  const bool ignore_stale_rendered_frames_after_seek_;
+  bool awaiting_first_frame_after_seek_ = false;
   int dropped_frames_ = 0;
   int64_t seek_to_time_ = 0;  // microseconds
 

--- a/starboard/android/shared/video_frame_tracker_test.cc
+++ b/starboard/android/shared/video_frame_tracker_test.cc
@@ -158,5 +158,62 @@ TEST(VideoFrameTrackerTest, UnorderedInputFramesAreHandled) {
   EXPECT_EQ(video_frame_tracker.UpdateAndGetDroppedFrames(), 0);
 }
 
+TEST(VideoFrameTrackerTest, StalePreSeekRenderedCallbacksAreIgnoredPostSeek) {
+  VideoFrameTracker video_frame_tracker(
+      /*max_pending_frames_size=*/100,
+      /*ignore_stale_rendered_frames_after_seek=*/true);
+
+  video_frame_tracker.OnInputBuffer(10000);
+  video_frame_tracker.OnInputBuffer(20000);
+  video_frame_tracker.OnFrameRendered(10000);
+
+  // Seek back to 0 (e.g. looping)
+  video_frame_tracker.Seek(0);
+
+  // Post-seek new stream input buffers queued starting at 0
+  video_frame_tracker.OnInputBuffer(0);
+  video_frame_tracker.OnInputBuffer(10000);
+  video_frame_tracker.OnInputBuffer(20000);
+
+  // A stale OnFrameRendered callback from pre-seek flushed stream arrives
+  video_frame_tracker.OnFrameRendered(20000);
+
+  // Should NOT count as dropped frame because stale callback is ignored
+  // post-seek
+  EXPECT_EQ(video_frame_tracker.UpdateAndGetDroppedFrames(), 0);
+
+  // Actual post-seek frames rendered
+  video_frame_tracker.OnFrameRendered(0);
+  video_frame_tracker.OnFrameRendered(10000);
+
+  EXPECT_EQ(video_frame_tracker.UpdateAndGetDroppedFrames(), 0);
+}
+
+TEST(VideoFrameTrackerTest,
+     StalePreSeekRenderedCallbackMatchingSecondFrameIsIgnoredPostSeek) {
+  VideoFrameTracker video_frame_tracker(
+      /*max_pending_frames_size=*/100,
+      /*ignore_stale_rendered_frames_after_seek=*/true);
+
+  video_frame_tracker.Seek(0);
+
+  // Post-seek stream: input frames 0, 10000, 20000
+  video_frame_tracker.OnInputBuffer(0);
+  video_frame_tracker.OnInputBuffer(10000);
+  video_frame_tracker.OnInputBuffer(20000);
+
+  // A stale OnFrameRendered callback from pre-seek flushed stream arrives
+  // with timestamp 10000 (matching the second expected frame). When checking
+  // only 1 frame post-seek, this is ignored as a stale pre-seek frame.
+  video_frame_tracker.OnFrameRendered(10000);
+  EXPECT_EQ(video_frame_tracker.UpdateAndGetDroppedFrames(), 0);
+
+  // When the actual first post-seek frame (0) is rendered, it unlocks normal
+  // tracking.
+  video_frame_tracker.OnFrameRendered(0);
+  video_frame_tracker.OnFrameRendered(10000);
+  EXPECT_EQ(video_frame_tracker.UpdateAndGetDroppedFrames(), 0);
+}
+
 }  // namespace
 }  // namespace starboard

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -212,6 +212,10 @@ inline constexpr ExperimentalFeatureKey<bool>
         "Media.IgnoreMediaCodecCallbacksDuringFlushing",
         true);
 
+inline constexpr ExperimentalFeatureKey<bool>
+    kMediaIgnoreStaleRenderedFramesAfterSeek(
+        "Media.IgnoreStaleRenderedFramesAfterSeek");
+
 inline constexpr ExperimentalFeatureKey<bool> kMediaNdkAudioTrack(
     "Media.NdkAudioTrack");
 

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -211,6 +211,10 @@ inline constexpr ExperimentalFeatureKey<bool>
     kMediaIgnoreMediaCodecCallbacksDuringFlushing(
         "Media.IgnoreMediaCodecCallbacksDuringFlushing");
 
+inline constexpr ExperimentalFeatureKey<bool>
+    kMediaIgnoreStaleRenderedFramesAfterSeek(
+        "Media.IgnoreStaleRenderedFramesAfterSeek");
+
 inline constexpr ExperimentalFeatureKey<bool> kMediaNdkAudioTrack(
     "Media.NdkAudioTrack");
 


### PR DESCRIPTION
This change introduces a mechanism to ignore stale rendered frame
callbacks that occur after a seek operation but before the first
post-seek frame is processed. This prevents false-positive frame drop
counts caused by callbacks from pre-seek flushed frames.

Issue: 401790323
Issue: 534774024