### PR TITLE
media: Improve IsSDRVideo MIME type check

### DIFF
--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -302,9 +302,8 @@ bool IsSDRVideo(const char* mime) {
   }
 
   SB_DCHECK_NE(video_codec, kSbMediaVideoCodecNone);
-  // TODO: Consider to consolidate the two IsSDRVideo() implementations by
-  //       calling IsSDRVideo(bit_depth, primary_id, transfer_id, matrix_id).
-  return bit_depth == 8;
+
+  return IsSDRVideo(bit_depth, primary_id, transfer_id, matrix_id);
 }
 
 int GetBytesPerSample(SbMediaAudioSampleType sample_type) {

--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -235,7 +235,7 @@ bool IsSDRVideo(int bit_depth,
                 SbMediaPrimaryId primary_id,
                 SbMediaTransferId transfer_id,
                 SbMediaMatrixId matrix_id) {
-  SB_DCHECK(bit_depth == 8 || bit_depth == 10);
+  SB_DCHECK(bit_depth == 8 || bit_depth == 10 || bit_depth == 12);
 
   if (bit_depth != 8) {
     return false;

--- a/starboard/shared/starboard/media/media_util_test.cc
+++ b/starboard/shared/starboard/media/media_util_test.cc
@@ -250,5 +250,39 @@ TEST(MediaUtilTest, Resolutions) {
   EXPECT_EQ(Resolution::k8k, Size(7680, 4320));
 }
 
+TEST(MediaUtilTest, IsSDRVideo) {
+  EXPECT_TRUE(IsSDRVideo(8, kSbMediaPrimaryIdBt709, kSbMediaTransferIdBt709,
+                         kSbMediaMatrixIdBt709));
+  EXPECT_TRUE(IsSDRVideo(8, kSbMediaPrimaryIdUnspecified,
+                         kSbMediaTransferIdUnspecified,
+                         kSbMediaMatrixIdUnspecified));
+  EXPECT_TRUE(IsSDRVideo(8, kSbMediaPrimaryIdSmpte170M,
+                         kSbMediaTransferIdSmpte170M,
+                         kSbMediaMatrixIdSmpte170M));
+
+  EXPECT_FALSE(IsSDRVideo(10, kSbMediaPrimaryIdBt709, kSbMediaTransferIdBt709,
+                          kSbMediaMatrixIdBt709));
+
+  EXPECT_FALSE(IsSDRVideo(8, kSbMediaPrimaryIdBt2020, kSbMediaTransferIdBt709,
+                          kSbMediaMatrixIdBt709));
+  EXPECT_FALSE(IsSDRVideo(8, kSbMediaPrimaryIdBt709,
+                          kSbMediaTransferIdSmpteSt2084,
+                          kSbMediaMatrixIdBt709));
+  EXPECT_FALSE(IsSDRVideo(8, kSbMediaPrimaryIdBt709, kSbMediaTransferIdBt709,
+                          kSbMediaMatrixIdBt2020NonconstantLuminance));
+}
+
+TEST(MediaUtilTest, IsSDRVideo_Mime) {
+  EXPECT_TRUE(IsSDRVideo("video/mp4; codecs=\"avc1.4d401e\""));
+  EXPECT_TRUE(IsSDRVideo("video/webm; codecs=\"vp9\""));
+  EXPECT_TRUE(IsSDRVideo("invalid_mime"));
+
+  EXPECT_FALSE(
+      IsSDRVideo("video/webm; codecs=\"vp09.02.51.10.01.09.16.09.01\""));
+
+  EXPECT_FALSE(
+      IsSDRVideo("video/webm; codecs=\"vp09.00.51.08.01.09.16.09.01\""));
+}
+
 }  // namespace
 }  // namespace starboard

--- a/starboard/shared/starboard/media/media_util_test.cc
+++ b/starboard/shared/starboard/media/media_util_test.cc
@@ -262,6 +262,8 @@ TEST(MediaUtilTest, IsSDRVideo) {
 
   EXPECT_FALSE(IsSDRVideo(10, kSbMediaPrimaryIdBt709, kSbMediaTransferIdBt709,
                           kSbMediaMatrixIdBt709));
+  EXPECT_FALSE(IsSDRVideo(12, kSbMediaPrimaryIdBt709, kSbMediaTransferIdBt709,
+                          kSbMediaMatrixIdBt709));
 
   EXPECT_FALSE(IsSDRVideo(8, kSbMediaPrimaryIdBt2020, kSbMediaTransferIdBt709,
                           kSbMediaMatrixIdBt709));
@@ -273,13 +275,26 @@ TEST(MediaUtilTest, IsSDRVideo) {
 }
 
 TEST(MediaUtilTest, IsSDRVideo_Mime) {
+  // Standard 8-bit AVC / H.264 stream without HDR colorimetry.
   EXPECT_TRUE(IsSDRVideo("video/mp4; codecs=\"avc1.4d401e\""));
+  // Short-form VP9 string where bit depth defaults to 8-bit and colorimetry
+  // defaults to BT.709.
   EXPECT_TRUE(IsSDRVideo("video/webm; codecs=\"vp9\""));
+  // Unrecognized or invalid MIME types fall back to assuming SDR video.
   EXPECT_TRUE(IsSDRVideo("invalid_mime"));
+  // 8-bit VP9 with explicitly specified BT.709 color primaries (01),
+  // transfer function (01), and matrix coefficients (01).
+  EXPECT_TRUE(
+      IsSDRVideo("video/webm; codecs=\"vp09.00.51.08.01.01.01.01.01\""));
 
+  // 10-bit depth (Profile 2 VP9) is HDR, not SDR.
   EXPECT_FALSE(
       IsSDRVideo("video/webm; codecs=\"vp09.02.51.10.01.09.16.09.01\""));
-
+  // 12-bit depth (Profile 3 VP9) is HDR, not SDR.
+  EXPECT_FALSE(
+      IsSDRVideo("video/webm; codecs=\"vp09.03.51.12.01.09.16.09.01\""));
+  // 8-bit depth VP9 paired with BT.2020 color primaries (09) and SMPTE ST 2084
+  // PQ transfer curve (16) is HDR, not SDR.
   EXPECT_FALSE(
       IsSDRVideo("video/webm; codecs=\"vp09.00.51.08.01.09.16.09.01\""));
 }


### PR DESCRIPTION
Consolidate the IsSDRVideo implementations by having the MIME-based
function call the version that takes explicit video parameters.
Previously, the MIME-based check only verified bit depth, ignoring
other color characteristics.

This change ensures that color primary, transfer function, and
matrix IDs are also considered when determining if a stream is SDR.
Unit tests have been added to verify correctness for both functions.

#vibe-coded

Bug: 534870554