### PR TITLE
android: Re-introduce feature flag for dual thread video decoding

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -628,7 +628,8 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         << "`kResetDelayUsec` is set to > 0, force a delay of "
         << reset_delay_usec << "us during Reset().";
 
-    bool use_dual_threads = true;
+    bool use_dual_threads =
+        FeatureList::IsEnabled(features::kCobaltUseDualThreadsForVideo);
     if (creation_parameters.audio_codec() != kSbMediaAudioCodecNone) {
       // `use_dual_threads` should be disabled if the libopus audio
       // decoder isn't used, as we want to limit the initial behavior to

--- a/starboard/extension/feature_config.h
+++ b/starboard/extension/feature_config.h
@@ -107,6 +107,12 @@ STARBOARD_FEATURE(kAreaBasedVideoBufferBudget,
                   "AreaBasedVideoBufferBudget",
                   false)
 
+// Set to true to enable dual thread video decoding.
+STARBOARD_FEATURE(kCobaltUseDualThreadsForVideo,
+                  "CobaltUseDualThreadsForVideo",
+                  false)
+
+
 // Set the following variable to true to enable av1 startup optimization.
 STARBOARD_FEATURE(kEnableAv1StartupOptimization,
                   "EnableAv1StartupOptimization",


### PR DESCRIPTION
Re-introduce the `CobaltUseDualThreadsForVideo` feature flag, defaulting to false, to disable dual-threaded video decoding by default. This is to mitigate a significant watch time regression observed in the Kimono canary update from 7.11 to 7.12.

Dual-threaded video decoding was enabled by default on Android TV in commit 78e8a4f0514. However, it appears to introduce performance issues (such as lock contention or thread starvation) on certain hardware profiles, leading to playback issues.

By defaulting to false, we revert the behavior back to single-threaded decoding, while maintaining the ability to enable it via Finch for validation or specific platforms.

BUG=none
TAG=agy
CONV=37270dff-389c-4d57-b9b7-711432e0acbc