### PR TITLE
aosp: Add GN rules to build APKs

### DIFF
--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -144,7 +144,7 @@ runs:
           fi
         shell: bash
       - name: Archive Android APKs
-        if: startsWith(matrix.platform, 'android') && matrix.config == 'qa'
+        if: (startsWith(matrix.platform, 'android') || startsWith(matrix.platform, 'aosp')) && matrix.config == 'qa'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.platform }} APKs

--- a/.github/config/aosp-arm.json
+++ b/.github/config/aosp-arm.json
@@ -10,7 +10,7 @@
     "gold"
   ],
   "targets": [
-    "buildflag_header_h"
+    "nplb_loader"
   ],
   "includes": [
     {

--- a/.github/config/aosp-arm.json
+++ b/.github/config/aosp-arm.json
@@ -10,6 +10,7 @@
     "gold"
   ],
   "targets": [
+    "cobalt:gn_all",
     "nplb_loader"
   ],
   "includes": [

--- a/.github/config/aosp-arm.json
+++ b/.github/config/aosp-arm.json
@@ -10,8 +10,7 @@
     "gold"
   ],
   "targets": [
-    "cobalt:gn_all",
-    "nplb_loader"
+    "cobalt:gn_all"
   ],
   "includes": [
     {

--- a/base/BUILD.gn
+++ b/base/BUILD.gn
@@ -4788,6 +4788,11 @@ if (is_android) {
     ]
   }
 
+  if (is_cobalt && is_partner_toolchain) {
+    java_group("base_java") {
+      public_deps = [ "//copied_base/base:base_java" ]
+    }
+  } else {
   android_library("base_java") {
     srcjar_deps = [
       ":base_android_java_enums_srcjar",
@@ -4900,6 +4905,7 @@ if (is_android) {
         "android/proguard/remove_logging.flags",
       ]
     }
+  }
   }
 
   generate_jni("metrics_jni") {

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -166,7 +166,7 @@ if (is_ios && target_platform == "tvos") {
 
     outputs = [ "{{bundle_resources_dir}}/{{source_file_part}}" ]
   }
-} else if (!is_android) {
+} else if (!is_androidtv) {
   if (is_cobalt_hermetic_build) {
     cobalt_target_type = "modular_executable"
   } else {

--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -1,9 +1,8 @@
 import("//build/config/android/config.gni")
 import("//build/config/android/rules.gni")
+import("//cobalt/android/manifest.gni")
 import("//third_party/icu/config.gni")
 import("//third_party/jni_zero/jni_zero.gni")
-
-cobalt_manifest = "$target_gen_dir/cobalt_manifest/AndroidManifest.xml"
 
 jinja_template("cobalt_manifest") {
   input = "//cobalt/shell/android/shell_apk/AndroidManifest.xml.jinja2"
@@ -31,7 +30,6 @@ generate_jni("jni_headers") {
     "apk/app/src/main/java/dev/cobalt/coat/CobaltService.java",
     "apk/app/src/main/java/dev/cobalt/coat/CobaltSystemConfigChangeReceiver.java",
     "apk/app/src/main/java/dev/cobalt/coat/CobaltTextToSpeechHelper.java",
-    "apk/app/src/main/java/dev/cobalt/coat/PlatformError.java",
     "apk/app/src/main/java/dev/cobalt/coat/ResourceOverlay.java",
     "apk/app/src/main/java/dev/cobalt/coat/javabridge/HTMLMediaElementExtension.java",
     "apk/app/src/main/java/dev/cobalt/features/StarboardFeatureList.java",
@@ -53,6 +51,10 @@ generate_jni("jni_headers") {
       "apk/app/src/main/java/dev/cobalt/browser/crashannotator/CrashAnnotatorImplFirstParty.java",
     ]
   }
+
+  if (!is_starboard) {
+    sources += [ "apk/app/src/main/java/dev/cobalt/coat/PlatformError.java" ]
+  }
 }
 
 generate_jni("browser_jni_headers") {
@@ -72,21 +74,9 @@ android_library("cobalt_browser_java") {
 android_library("cobalt_main_java") {
   resources_package = "dev.cobalt.coat"
   deps = [
-    ":cobalt_browser_java",
     "//base:base_java",
-    "//base:process_launcher_java",
-    "//base/version_info/android:version_constants_java",
     "//build/android:build_java",
-    "//cobalt/shell/android:cobalt_shell_assets",
-    "//cobalt/shell/android:cobalt_shell_java",
     "//cobalt/shell/android:cobalt_shell_java_resources",
-    "//cobalt/shell/android:cobalt_shell_jni_headers",
-    "//components/embedder_support/android:view_java",
-    "//content/public/android:content_java",
-    "//media/capture/video/android:capture_java",
-    "//net/android:net_java",
-    "//services/media_session/public/cpp/android:media_session_java",
-    "//services/media_session/public/mojom:mojom_java",
     "//third_party/android_deps:com_google_code_findbugs_jsr305_java",
     "//third_party/android_deps:google_play_services_ads_identifier_java",
     "//third_party/android_deps:google_play_services_basement_java",
@@ -95,8 +85,6 @@ android_library("cobalt_main_java") {
     "//third_party/androidx:androidx_customview_customview_java",
     "//third_party/androidx:androidx_media_media_java",
     "//third_party/jni_zero:jni_zero_java",
-    "//ui/android:ui_java",
-    "//url:gurl_java",
   ]
 
   if (!use_evergreen) {
@@ -117,17 +105,11 @@ android_library("cobalt_main_java") {
 
   sources = [
     "apk/app/src/main/java/dev/cobalt/coat/AdvertisingId.java",
-    "apk/app/src/main/java/dev/cobalt/coat/ArtworkDownloader.java",
-    "apk/app/src/main/java/dev/cobalt/coat/ArtworkDownloaderDefault.java",
-    "apk/app/src/main/java/dev/cobalt/coat/ArtworkLoader.java",
     "apk/app/src/main/java/dev/cobalt/coat/AudioPermissionRequester.java",
     "apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java",
     "apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java",
     "apk/app/src/main/java/dev/cobalt/coat/CaptionSettings.java",
-    "apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java",
-    "apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java",
     "apk/app/src/main/java/dev/cobalt/coat/CobaltHttpHelper.java",
-    "apk/app/src/main/java/dev/cobalt/coat/CobaltMediaSession.java",
     "apk/app/src/main/java/dev/cobalt/coat/CobaltService.java",
     "apk/app/src/main/java/dev/cobalt/coat/CobaltSystemConfigChangeReceiver.java",
     "apk/app/src/main/java/dev/cobalt/coat/CobaltTextToSpeechHelper.java",
@@ -139,10 +121,7 @@ android_library("cobalt_main_java") {
     "apk/app/src/main/java/dev/cobalt/coat/KeyboardUtils.java",
     "apk/app/src/main/java/dev/cobalt/coat/NetworkStatus.java",
     "apk/app/src/main/java/dev/cobalt/coat/NullCobaltFactory.java",
-    "apk/app/src/main/java/dev/cobalt/coat/PlatformError.java",
     "apk/app/src/main/java/dev/cobalt/coat/ResourceOverlay.java",
-    "apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java",
-    "apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java",
     "apk/app/src/main/java/dev/cobalt/coat/javabridge/AmatiDeviceInspector.java",
     "apk/app/src/main/java/dev/cobalt/coat/javabridge/CobaltJavaScriptAndroidObject.java",
     "apk/app/src/main/java/dev/cobalt/coat/javabridge/CobaltJavaScriptInterface.java",
@@ -180,6 +159,41 @@ android_library("cobalt_main_java") {
       "apk/app/src/main/java/dev/cobalt/browser/CobaltInterfaceRegistrar.java",
       "apk/app/src/main/java/dev/cobalt/browser/crashannotator/CrashAnnotatorImplFactory.java",
       "apk/app/src/main/java/dev/cobalt/browser/crashannotator/CrashAnnotatorImplFirstParty.java",
+    ]
+  }
+
+  if (is_starboard) {
+    # TODO(https://crbug.com/534656433): Temporary StarboardBridge stub to fix
+    # a symbol resolution error on BaseStarboardBridge and CobaltService.
+    sources +=
+        [ "//cobalt/aosp/apk/app/java/dev/cobalt/coat/StarboardBridge.java" ]
+  } else {
+    sources += [
+      "apk/app/src/main/java/dev/cobalt/coat/ArtworkDownloader.java",
+      "apk/app/src/main/java/dev/cobalt/coat/ArtworkDownloaderDefault.java",
+      "apk/app/src/main/java/dev/cobalt/coat/ArtworkLoader.java",
+      "apk/app/src/main/java/dev/cobalt/coat/CobaltA11yHelper.java",
+      "apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java",
+      "apk/app/src/main/java/dev/cobalt/coat/CobaltMediaSession.java",
+      "apk/app/src/main/java/dev/cobalt/coat/PlatformError.java",
+      "apk/app/src/main/java/dev/cobalt/coat/StarboardBridge.java",
+      "apk/app/src/main/java/dev/cobalt/coat/VolumeStateReceiver.java",
+    ]
+    deps += [
+      ":cobalt_browser_java",
+      "//base:process_launcher_java",
+      "//base/version_info/android:version_constants_java",
+      "//cobalt/shell/android:cobalt_shell_assets",
+      "//cobalt/shell/android:cobalt_shell_java",
+      "//cobalt/shell/android:cobalt_shell_jni_headers",
+      "//components/embedder_support/android:view_java",
+      "//content/public/android:content_java",
+      "//media/capture/video/android:capture_java",
+      "//net/android:net_java",
+      "//services/media_session/public/cpp/android:media_session_java",
+      "//services/media_session/public/mojom:mojom_java",
+      "//ui/android:ui_java",
+      "//url:gurl_java",
     ]
   }
 }

--- a/cobalt/android/manifest.gni
+++ b/cobalt/android/manifest.gni
@@ -12,23 +12,5 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-static_library("starboard_platform") {
-  sources = [ "run_starboard_main.cc" ]
-
-  configs += [ "//starboard/build/config:starboard_implementation" ]
-
-  public_deps = [ "//starboard/android/shared:starboard_platform" ]
-}
-
-source_set("aosp_loader_glue") {
-  sources = [
-    "main_activity.cc",
-    "starboard_library_loader.cc",
-  ]
-
-  deps = [
-    "//base",
-    "//cobalt/aosp:jni_headers",
-    "//starboard:starboard_group",
-  ]
-}
+cobalt_manifest =
+    "$root_gen_dir/cobalt/android/cobalt_manifest/AndroidManifest.xml"

--- a/cobalt/aosp/BUILD.gn
+++ b/cobalt/aosp/BUILD.gn
@@ -1,0 +1,41 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/config/android/abi.gni")
+import("//build/config/android/rules.gni")
+import("//build/config/sysroot.gni")
+import("//third_party/jni_zero/jni_zero.gni")
+
+copy("copy_libcpp_shared") {
+  sources = [ "$sysroot/usr/lib/$android_abi_target/libc++_shared.so" ]
+  outputs = [ "$root_build_dir/libc++_shared.so" ]
+}
+
+generate_jni("jni_headers") {
+  sources = [ "apk/app/java/dev/cobalt/app/MainActivity.java" ]
+}
+
+android_library("cobalt_apk_java") {
+  resources_package = "dev.cobalt.coat"
+
+  sources = [
+    "apk/app/java/dev/cobalt/app/CobaltApplication.java",
+    "apk/app/java/dev/cobalt/app/MainActivity.java",
+  ]
+  deps = [
+    "//cobalt/android:cobalt_main_java",
+    "//third_party/jni_zero:jni_zero_java",
+  ]
+  srcjar_deps = [ ":jni_headers" ]
+}

--- a/cobalt/aosp/apk/app/java/dev/cobalt/app/CobaltApplication.java
+++ b/cobalt/aosp/apk/app/java/dev/cobalt/app/CobaltApplication.java
@@ -1,0 +1,33 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.app;
+
+import android.app.Application;
+import dev.cobalt.coat.BaseStarboardBridge;
+
+/** Android Application hosting the Starboard application. */
+public class CobaltApplication extends Application implements BaseStarboardBridge.HostApplication {
+  BaseStarboardBridge mStarboardBridge;
+
+  @Override
+  public void setStarboardBridge(BaseStarboardBridge starboardBridge) {
+    mStarboardBridge = starboardBridge;
+  }
+
+  @Override
+  public BaseStarboardBridge getStarboardBridge() {
+    return mStarboardBridge;
+  }
+}

--- a/cobalt/aosp/apk/app/java/dev/cobalt/app/MainActivity.java
+++ b/cobalt/aosp/apk/app/java/dev/cobalt/app/MainActivity.java
@@ -1,0 +1,95 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.app;
+
+import android.app.Activity;
+import android.app.Service;
+import android.os.Bundle;
+import dev.cobalt.coat.BaseCobaltActivity;
+import dev.cobalt.coat.BaseStarboardBridge;
+import dev.cobalt.coat.CobaltService;
+import dev.cobalt.libraries.services.clientloginfo.ClientLogInfoModule;
+import dev.cobalt.util.Holder;
+import org.jni_zero.JNINamespace;
+import org.jni_zero.NativeMethods;
+
+/**
+ * Main Activity for the "Cobalt on AOSP" app.
+ *
+ * <p>The lifecycle is handled by the base class. MainActivity loads the evergreen loader library,
+ * creates the BaseStarboardBridge, and spawns the native Starboard thread.
+ */
+@JNINamespace("starboard")
+public class MainActivity extends BaseCobaltActivity {
+
+  static {
+    // Each aosp apk ships exactly one app loader under its natural name
+    // via android_apk shared_libraries: libloader_app.so for the production
+    // app or libelf_loader_sandbox.so for everything else. Load whichever is
+    // present.
+    UnsatisfiedLinkError loadError = null;
+    for (String lib : new String[] {"loader_app", "elf_loader_sandbox"}) {
+      try {
+        System.loadLibrary(lib);
+        loadError = null;
+        break;
+      } catch (UnsatisfiedLinkError e) {
+        loadError = e;
+      }
+    }
+    if (loadError != null) {
+      throw loadError;
+    }
+  }
+
+  @NativeMethods
+  interface Natives {
+    // Spawns the loader thread, whose main() runs the app loader.
+    void startLoader();
+  }
+
+  @Override
+  protected void onCreate(Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    String startDeepLink = getIntentUrlAsString(getIntent());
+    if (getStarboardBridge() == null) {
+      // Cold start - Instantiate the singleton BaseStarboardBridge.
+      BaseStarboardBridge starboardBridge = createStarboardBridge(getArgs(), startDeepLink);
+      ((BaseStarboardBridge.HostApplication) getApplication()).setStarboardBridge(starboardBridge);
+    } else {
+      // Warm start - Pass the deep link to the running Starboard app.
+      getStarboardBridge().handleDeepLink(startDeepLink);
+    }
+
+    // Spawn the loader thread.
+    MainActivityJni.get().startLoader();
+  }
+
+  @Override
+  protected BaseStarboardBridge createStarboardBridge(String[] args, String startDeepLink) {
+    Holder<Activity> activityHolder = new Holder<>();
+    Holder<Service> serviceHolder = new Holder<>();
+    BaseStarboardBridge bridge =
+        new BaseStarboardBridge(
+            getApplicationContext(), activityHolder, serviceHolder, args, startDeepLink);
+
+    CobaltService.Factory clientLogInfoFactory =
+        new ClientLogInfoModule().provideFactory(getApplicationContext());
+    bridge.registerCobaltService(clientLogInfoFactory);
+
+    return bridge;
+  }
+}

--- a/cobalt/aosp/apk/app/java/dev/cobalt/app/MainActivity.java
+++ b/cobalt/aosp/apk/app/java/dev/cobalt/app/MainActivity.java
@@ -69,13 +69,12 @@ public class MainActivity extends BaseCobaltActivity {
       // Cold start - Instantiate the singleton BaseStarboardBridge.
       BaseStarboardBridge starboardBridge = createStarboardBridge(getArgs(), startDeepLink);
       ((BaseStarboardBridge.HostApplication) getApplication()).setStarboardBridge(starboardBridge);
-    } else {
+      // Spawn the loader thread.
+      MainActivityJni.get().startLoader();
+    } else if (savedInstanceState == null) {
       // Warm start - Pass the deep link to the running Starboard app.
       getStarboardBridge().handleDeepLink(startDeepLink);
     }
-
-    // Spawn the loader thread.
-    MainActivityJni.get().startLoader();
   }
 
   @Override

--- a/cobalt/aosp/apk/app/java/dev/cobalt/coat/StarboardBridge.java
+++ b/cobalt/aosp/apk/app/java/dev/cobalt/coat/StarboardBridge.java
@@ -1,0 +1,36 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.coat;
+
+import android.app.Activity;
+import android.app.Service;
+import android.content.Context;
+import dev.cobalt.util.Holder;
+
+/**
+ * TODO(https://crbug.com/534656433): Temporary StarboardBridge stub to fix a symbol resolution
+ * error on BaseStarboardBridge and CobaltService.
+ */
+public class StarboardBridge extends BaseStarboardBridge {
+
+  public StarboardBridge(
+      Context appContext,
+      Holder<Activity> activityHolder,
+      Holder<Service> serviceHolder,
+      String[] args,
+      String startDeepLink) {
+    super(appContext, activityHolder, serviceHolder, args, startDeepLink);
+  }
+}

--- a/cobalt/aosp/modular_apk.gni
+++ b/cobalt/aosp/modular_apk.gni
@@ -50,21 +50,8 @@ template("modular_apk") {
     }
 
     if (_name == "nplb") {
-      _file_tests_data = [
-        "dir_with_files/file11",
-        "dir_with_files/file12",
-        "dir_with_only_subdir/dir_with_files/file21",
-        "dir_with_only_subdir/dir_with_files/file22",
-        "file01",
-        "file_with_long_name_and_contents_for_seek_testing_1234567890",
-      ]
-      foreach(_f, _file_tests_data) {
-        renaming_sources +=
-            [ "$root_build_dir/test/starboard/nplb/file_tests/$_f" ]
-        renaming_destinations += [ "test/starboard/nplb/file_tests/$_f" ]
-      }
       deps += [
-        "//starboard/nplb/testdata/file_tests:nplb_file_tests_data($default_toolchain)",
+        "//starboard/nplb/testdata/file_tests:nplb_file_tests_data_assets",
         "//starboard/shared/starboard/player:player_test_data_assets",
       ]
     }

--- a/cobalt/aosp/modular_apk.gni
+++ b/cobalt/aosp/modular_apk.gni
@@ -1,0 +1,96 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import("//build/config/android/rules.gni")
+import("//cobalt/android/manifest.gni")
+
+template("modular_apk") {
+  _name = invoker.module_name
+  _lib_name = invoker.lib_name
+
+  if (_name == "cobalt") {
+    _loader = "//starboard/loader_app"
+  } else {
+    _loader = "//starboard/elf_loader:elf_loader_sandbox"
+  }
+
+  _assets_target = "${target_name}__assets"
+  android_assets(_assets_target) {
+    forward_variables_from(invoker, [ "testonly" ])
+    disable_compression = true
+
+    renaming_sources = [
+      "$root_build_dir/app/${_name}/content/fonts/fonts.xml",
+      "$root_build_dir/app/${_name}/lib/${_lib_name}.lz4",
+    ]
+    renaming_destinations = [
+      "app/cobalt/content/fonts/fonts.xml",
+      "app/cobalt/lib/${_lib_name}.lz4",
+    ]
+
+    deps = [
+      ":copy_${_name}_empty_fonts($default_toolchain)",
+      ":copy_${_name}_lib($default_toolchain)",
+    ]
+
+    if (_name == "cobalt") {
+      sources = [ "$root_build_dir/cobalt_shell.pak" ]
+      deps += [ "//cobalt/shell:pak($default_toolchain)" ]
+    }
+
+    if (_name == "nplb") {
+      _file_tests_data = [
+        "dir_with_files/file11",
+        "dir_with_files/file12",
+        "dir_with_only_subdir/dir_with_files/file21",
+        "dir_with_only_subdir/dir_with_files/file22",
+        "file01",
+        "file_with_long_name_and_contents_for_seek_testing_1234567890",
+      ]
+      foreach(_f, _file_tests_data) {
+        renaming_sources +=
+            [ "$root_build_dir/test/starboard/nplb/file_tests/$_f" ]
+        renaming_destinations += [ "test/starboard/nplb/file_tests/$_f" ]
+      }
+      deps += [
+        "//starboard/nplb/testdata/file_tests:nplb_file_tests_data($default_toolchain)",
+        "//starboard/shared/starboard/player:player_test_data_assets",
+      ]
+    }
+  }
+
+  android_apk(target_name) {
+    forward_variables_from(invoker, [ "testonly" ])
+    apk_name = _name
+    android_manifest = cobalt_manifest
+    android_manifest_dep = "//cobalt/android:cobalt_manifest"
+    include_size_info = is_official_build
+
+    deps = [
+      ":$_assets_target",
+      "//cobalt/aosp:cobalt_apk_java",
+      "//cobalt/aosp:copy_libcpp_shared",
+      "//components/crash/core/app:chrome_crashpad_handler_named_as_so($native_toolchain)",
+    ]
+
+    loadable_modules = [
+      "$root_build_dir/libc++_shared.so",
+      "$root_build_dir/native_target/libchrome_crashpad_handler.so",
+    ]
+    shared_libraries = [ _loader ]
+
+    srcjar_deps =
+        [ get_label_info(_loader, "label_no_toolchain") + "__jni_registration" ]
+  }
+}

--- a/cobalt/build/configs/aosp-arm/args.gn
+++ b/cobalt/build/configs/aosp-arm/args.gn
@@ -3,3 +3,4 @@ import("//cobalt/build/configs/evergreen-x64/args.gn")
 target_cpu = "arm"
 starboard_target_platform = "aosp-arm"
 arm_float_abi = "softfp"
+use_errorprone_java_compiler = false

--- a/cobalt/build/modular_executable.gni
+++ b/cobalt/build/modular_executable.gni
@@ -13,9 +13,53 @@
 # limitations under the License.
 
 import("//build/compiled_action.gni")
+import("//starboard/build/platform_path.gni")
 import("//starboard/content/fonts/variables.gni")
 import("//third_party/icu/config.gni")
-import("//tools/v8_context_snapshot/v8_context_snapshot.gni")
+
+if (is_android) {
+  import("//cobalt/aosp/modular_apk.gni")
+}
+
+_is_aosp =
+    string_replace(starboard_path, "starboard/aosp/", "", 1) != starboard_path
+
+# Targets not working on Android.
+_failing_android_targets = [
+  "app_shell_unittests",
+  "browser_tests",
+  "caspian_unittests",
+  "captured_sites_interactive_tests",
+  "content_shell",
+  "cronet_sample_test",
+  "cronet_tests",
+  "cronet_unittests",
+  "enterprise_companion_integration_tests",
+  "enterprise_companion_tests",
+  "extensions_browsertests",
+  "extensions_unittests",
+  "gl_lpm_shader_to_string_unittest",
+  "headless_browsertests",
+  "headless_unittests",
+  "interactive_ui_tests",
+  "leveldb_db_bench",
+  "leveldb_db_bench_log",
+  "load_library_perf_tests",
+  "message_center_unittests",
+  "pdf_ink_reader_fuzzer",
+  "pdf_unittests",
+  "pdfium_xfa_lpm_unittest",
+  "single_file_tar_reader_fuzzer",
+  "sync_integration_tests",
+  "sync_performance_tests",
+  "updater_tests",
+  "updater_tests_system",
+  "views_perftests",
+  "views_unittests",
+  "web_application_fuzztests",
+  "wm_unittests",
+  "xr_browser_tests_binary",
+]
 
 template("loader_final_target") {
   original_target_name = target_name
@@ -78,87 +122,85 @@ set_defaults("modular_executable") {
 
 template("evergreen_final_target") {
   original_target_name = target_name
-  test_lib_name = string_replace(original_target_name, "lib", "", 1)
-  if (original_target_name == "lib${test_lib_name}" ||
-      (defined(invoker.output_prefix_override) &&
-       invoker.output_prefix_override)) {
-    lib_name = original_target_name
-  } else {
-    lib_name = "lib${original_target_name}"
-  }
+  lib_name = invoker.lib_name
 
-  group("${original_target_name}_loader") {
-    testonly = true
-    data_deps = [
-      ":${original_target_name}_loaded_content",
-      ":${original_target_name}_runfile_gen",
-      "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)",
-      "//starboard/loader_app($starboard_toolchain)",
-    ]
-    deps = [ "//starboard/loader_app($starboard_toolchain)" ]
-    write_runtime_deps = "$root_build_dir/${target_name}.runtime_deps"
-  }
+  if (current_toolchain == default_toolchain) {
+    group("${original_target_name}_loader") {
+      testonly = true
+      data_deps = [
+        ":${original_target_name}_loaded_content",
+        ":${original_target_name}_runfile_gen",
+        "//starboard/elf_loader:elf_loader_sandbox($starboard_toolchain)",
+        "//starboard/loader_app($starboard_toolchain)",
+      ]
 
-  group("${original_target_name}_loaded_content") {
-    forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
-    data_deps = [
-      ":copy_${original_target_name}_content",
-      ":copy_${original_target_name}_lib",
-      "//starboard/content/ssl:copy_ssl_certificates_prod_cobalt",
-    ]
-  }
+      if (_is_aosp && filter_include([ original_target_name ],
+                                     _failing_android_targets) == []) {
+        data_deps += [ ":${original_target_name}_apk($starboard_toolchain)" ]
+      }
 
-  action("${original_target_name}_runfile_gen") {
-    script = "//starboard/build/util/generate_runfile.py"
-    outputs = [ "$root_out_dir/${original_target_name}_loader.py" ]
-    args = [
-      "--output",
-      rebase_path(outputs[0]),
-      "--library",
-      lib_name,
-    ]
-  }
-
-  copy("copy_${original_target_name}_content") {
-    forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
-    sources = [ "$root_out_dir/cobalt_shell.pak" ]
-
-    if (icu_use_data_file) {
-      sources += [ "$root_out_dir/icudtl.dat" ]
+      write_runtime_deps = "$root_build_dir/${target_name}.runtime_deps"
     }
 
-    outputs = [
-      "$root_out_dir/app/${original_target_name}/content/{{source_file_part}}",
-    ]
-    deps = [
-      "//cobalt/shell:pak",
-      "//third_party/icu:icudata",
-    ]
-    data_deps = [ ":copy_${original_target_name}_empty_fonts" ]
-  }
+    group("${original_target_name}_loaded_content") {
+      forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
+      data_deps = [
+        ":copy_${original_target_name}_content",
+        ":copy_${original_target_name}_lib",
+        "//starboard/content/ssl:copy_ssl_certificates_prod_cobalt",
+      ]
+    }
 
-  copy("copy_${original_target_name}_empty_fonts") {
-    forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
-    sources = [ "//starboard/content/fonts/$source_font_config_dir/fonts.xml" ]
-    outputs =
-        [ "$root_out_dir/app/${original_target_name}/content/fonts/fonts.xml" ]
-  }
+    action("${original_target_name}_runfile_gen") {
+      script = "//starboard/build/util/generate_runfile.py"
+      outputs = [ "$root_out_dir/${original_target_name}_loader.py" ]
+      args = [
+        "--output",
+        rebase_path(outputs[0]),
+        "--library",
+        lib_name,
+      ]
+    }
 
-  compiled_action("copy_${original_target_name}_lib") {
-    forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
+    copy("copy_${original_target_name}_content") {
+      sources = [ "$root_out_dir/cobalt_shell.pak" ]
 
-    tool = "//starboard/tools/lz4_compress"
-    inputs = [ "$root_out_dir/${lib_name}.so" ]
-    outputs =
-        [ "$root_out_dir/app/${original_target_name}/lib/${lib_name}.lz4" ]
-    args =
-        rebase_path(inputs, root_out_dir) + rebase_path(outputs, root_out_dir)
-    deps = [ ":${original_target_name}" ]
-    data_deps = deps  # Needed for the .runtime_deps file.
-  }
+      if (icu_use_data_file) {
+        sources += [ "$root_out_dir/icudtl.dat" ]
+      }
 
-  shared_library(original_target_name) {
-    forward_variables_from(invoker, "*")
+      outputs = [ "$root_out_dir/app/${original_target_name}/content/{{source_file_part}}" ]
+      deps = [
+        "//cobalt/shell:pak",
+        "//third_party/icu:icudata",
+      ]
+      data_deps = [ ":copy_${original_target_name}_empty_fonts" ]
+    }
+
+    copy("copy_${original_target_name}_empty_fonts") {
+      sources =
+          [ "//starboard/content/fonts/$source_font_config_dir/fonts.xml" ]
+      outputs = [
+        "$root_out_dir/app/${original_target_name}/content/fonts/fonts.xml",
+      ]
+    }
+
+    compiled_action("copy_${original_target_name}_lib") {
+      forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
+
+      tool = "//starboard/tools/lz4_compress"
+      inputs = [ "$root_out_dir/${lib_name}.so" ]
+      outputs =
+          [ "$root_out_dir/app/${original_target_name}/lib/${lib_name}.lz4" ]
+      args =
+          rebase_path(inputs, root_out_dir) + rebase_path(outputs, root_out_dir)
+      deps = [ ":${original_target_name}" ]
+      data_deps = deps  # Needed for the .runtime_deps file.
+    }
+
+    shared_library(original_target_name) {
+      forward_variables_from(invoker, "*", [ "lib_name" ])
+    }
   }
 }
 
@@ -168,12 +210,32 @@ set_defaults("evergreen_final_target") {
 }
 
 template("modular_executable") {
-  if (sb_is_evergreen) {
-    target_type = "evergreen_final_target"
+  _name = target_name
+  _test_lib_name = string_replace(_name, "lib", "", 1)
+  if (_name == "lib${_test_lib_name}" ||
+      (defined(invoker.output_prefix_override) &&
+       invoker.output_prefix_override)) {
+    _lib_name = _name
   } else {
-    target_type = "loader_final_target"
+    _lib_name = "lib${_name}"
   }
-  target(target_type, target_name) {
-    forward_variables_from(invoker, "*")
+
+  if (is_android) {
+    not_needed(invoker, "*", [ "testonly" ])
+    modular_apk("${_name}_apk") {
+      forward_variables_from(invoker, [ "testonly" ])
+      module_name = _name
+      lib_name = _lib_name
+    }
+  } else if (sb_is_evergreen) {
+    target("evergreen_final_target", _name) {
+      forward_variables_from(invoker, "*")
+      lib_name = _lib_name
+    }
+  } else {
+    not_needed([ "_lib_name" ])
+    target("loader_final_target", _name) {
+      forward_variables_from(invoker, "*")
+    }
   }
 }

--- a/cobalt/build/testing/targets/aosp-arm/test_targets.json
+++ b/cobalt/build/testing/targets/aosp-arm/test_targets.json
@@ -1,1 +1,8 @@
-[]
+[
+  {
+    "target": "starboard/nplb:nplb_loader",
+    "executable": "out/aosp-arm_devel/apks/nplb.apk",
+    "runs_on": "device",
+    "test_type": "gtest"
+  }
+]

--- a/cobalt/updater/version_manifest/BUILD.gn
+++ b/cobalt/updater/version_manifest/BUILD.gn
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 copy("copy_version_manifest") {
-  install_content = true
   sources = [ "manifest.json" ]
   outputs = [ "$root_out_dir/manifest.json" ]
 }

--- a/copied_base/base/BUILD.gn
+++ b/copied_base/base/BUILD.gn
@@ -4376,9 +4376,6 @@ if (is_android) {
   }
 
   android_library("base_java") {
-    # TODO(https://crbug.com/495203133): reenable after fixing Java warnings.
-    enable_errorprone = false
-
     srcjar_deps = [
       ":base_android_java_enums_srcjar",
       ":base_jni",

--- a/copied_base/base/BUILD.gn
+++ b/copied_base/base/BUILD.gn
@@ -4376,6 +4376,9 @@ if (is_android) {
   }
 
   android_library("base_java") {
+    # TODO(https://crbug.com/495203133): reenable after fixing Java warnings.
+    enable_errorprone = false
+
     srcjar_deps = [
       ":base_android_java_enums_srcjar",
       ":base_jni",

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -219,7 +219,6 @@ static_library("starboard_platform") {
 
     # TODO: b/374300500 - posix_emu things should not be used on Android anymore
     # "posix_emu/dirent.cc",
-    # "posix_emu/errno.cc",
     # "posix_emu/pthread.cc",
 
     "runtime_resource_overlay.cc",
@@ -318,19 +317,35 @@ static_library("starboard_platform") {
     ]
   }
 
-  if (is_starboard && current_toolchain == starboard_toolchain) {
+  if (is_starboard) {
     sources -= [
       "crash_handler.cc",
       "crash_handler.h",
+      "system_platform_error.cc",
     ]
     sources += [
       "//starboard/shared/starboard/crash_handler.cc",
       "//starboard/shared/starboard/crash_handler.h",
       "//starboard/shared/starboard/loader_app_metrics.cc",
       "//starboard/shared/starboard/loader_app_metrics.h",
+
+      # TODO(https://crbug.com/495203133): Symbols required on AOSP. The
+      # missing implementations are not not needed for the current set of
+      # passing nplb tests.
+      "//starboard/shared/stub/speech_synthesis_cancel.cc",
+      "//starboard/shared/stub/speech_synthesis_is_supported.cc",
+      "//starboard/shared/stub/speech_synthesis_speak.cc",
+      "//starboard/shared/stub/system_network_is_disconnected.cc",
+      "//starboard/shared/stub/system_raise_platform_error.cc",
+      "//starboard/shared/stub/window_create.cc",
+      "//starboard/shared/stub/window_destroy.cc",
+      "//starboard/shared/stub/window_get_diagonal_size_in_inches.cc",
+      "//starboard/shared/stub/window_get_platform_handle.cc",
+      "//starboard/shared/stub/window_get_size.cc",
       "asset_manager.cc",
       "asset_manager.h",
       "posix_emu/access.cc",
+      "posix_emu/errno.cc",
       "posix_emu/file.cc",
       "posix_emu/stat.cc",
     ]

--- a/starboard/aosp/shared/BUILD.gn
+++ b/starboard/aosp/shared/BUILD.gn
@@ -30,5 +30,6 @@ source_set("aosp_loader_glue") {
     "//base",
     "//cobalt/aosp:jni_headers",
     "//starboard:starboard_group",
+    "//starboard/android/shared:starboard_platform",
   ]
 }

--- a/starboard/aosp/shared/BUILD.gn
+++ b/starboard/aosp/shared/BUILD.gn
@@ -29,7 +29,6 @@ source_set("aosp_loader_glue") {
   deps = [
     "//base",
     "//cobalt/aosp:jni_headers",
-    "//starboard:starboard_group",
     "//starboard/android/shared:starboard_platform",
   ]
 }

--- a/starboard/aosp/shared/main_activity.cc
+++ b/starboard/aosp/shared/main_activity.cc
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 #include <jni.h>
+#include <pthread.h>
 
 #include <string>
+#include <thread>
 #include <vector>
 
-#include "base/threading/platform_thread.h"
 #include "cobalt/aosp/jni_headers/MainActivity_jni.h"
 #include "starboard/android/shared/starboard_bridge.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -26,34 +27,30 @@ int main(int argc, char** argv);
 
 namespace {
 
-class StarboardMainDelegate : public base::PlatformThread::Delegate {
- public:
-  void ThreadMain() override {
-    base::PlatformThread::SetName("StarboardMain");
+void StarboardMain() {
+  pthread_setname_np(pthread_self(), "StarboardMain");
 
-    JNIEnv* env = jni_zero::AttachCurrentThread();
-    std::vector<std::string> args;
-    args.push_back("cobalt_loader");
-    starboard::StarboardBridge::GetInstance()->AppendArgs(env, &args);
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+  std::vector<std::string> args;
+  args.push_back("cobalt_loader");
+  starboard::StarboardBridge::GetInstance()->AppendArgs(env, &args);
 
-    std::vector<char*> argv;
-    argv.reserve(args.size() + 1);
-    for (std::string& arg : args) {
-      argv.push_back(arg.data());
-    }
-    argv.push_back(nullptr);
-
-    main(static_cast<int>(args.size()), argv.data());
+  std::vector<char*> argv;
+  argv.reserve(args.size() + 1);
+  for (std::string& arg : args) {
+    argv.push_back(arg.data());
   }
-};
+  argv.push_back(nullptr);
+
+  main(static_cast<int>(args.size()), argv.data());
+}
 
 }  // namespace
 
 namespace starboard {
 
 void JNI_MainActivity_StartLoader(JNIEnv* env) {
-  static StarboardMainDelegate delegate;
-  base::PlatformThread::CreateNonJoinable(0, &delegate);
+  std::thread(StarboardMain).detach();
 }
 
 }  // namespace starboard

--- a/starboard/aosp/shared/main_activity.cc
+++ b/starboard/aosp/shared/main_activity.cc
@@ -1,0 +1,59 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <jni.h>
+
+#include <string>
+#include <vector>
+
+#include "base/threading/platform_thread.h"
+#include "cobalt/aosp/jni_headers/MainActivity_jni.h"
+#include "starboard/android/shared/starboard_bridge.h"
+#include "third_party/jni_zero/jni_zero.h"
+
+int main(int argc, char** argv);
+
+namespace {
+
+class StarboardMainDelegate : public base::PlatformThread::Delegate {
+ public:
+  void ThreadMain() override {
+    base::PlatformThread::SetName("StarboardMain");
+
+    JNIEnv* env = jni_zero::AttachCurrentThread();
+    std::vector<std::string> args;
+    args.push_back("cobalt_loader");
+    starboard::StarboardBridge::GetInstance()->AppendArgs(env, &args);
+
+    std::vector<char*> argv;
+    argv.reserve(args.size() + 1);
+    for (std::string& arg : args) {
+      argv.push_back(arg.data());
+    }
+    argv.push_back(nullptr);
+
+    main(static_cast<int>(args.size()), argv.data());
+  }
+};
+
+}  // namespace
+
+namespace starboard {
+
+void JNI_MainActivity_StartLoader(JNIEnv* env) {
+  static StarboardMainDelegate delegate;
+  base::PlatformThread::CreateNonJoinable(0, &delegate);
+}
+
+}  // namespace starboard

--- a/starboard/aosp/shared/run_starboard_main.cc
+++ b/starboard/aosp/shared/run_starboard_main.cc
@@ -12,14 +12,35 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <stdint.h>
+
 #include "starboard/event.h"
 
-namespace starboard::aosp::shared {
+extern "C" void SbEventCancel(SbEventId /*event_id*/) {}
 
-extern "C" int SbRunStarboardMain(int argc,
-                                  char** argv,
-                                  SbEventHandleCallback callback) {
-  // TODO(crbug.com/495203133): to be implemented.
+extern "C" SbEventId SbEventSchedule(SbEventCallback /*callback*/,
+                                     void* /*context*/,
+                                     int64_t /*delay_usec*/) {
+  return kSbEventIdInvalid;
 }
 
-}  // namespace starboard::aosp::shared
+extern "C" SB_EXPORT int SbRunStarboardMain(int argc,
+                                            char** argv,
+                                            SbEventHandleCallback callback) {
+  SbEventStartData start_data = {};
+  start_data.argument_values = argv;
+  start_data.argument_count = argc;
+  start_data.link = nullptr;
+
+  SbEvent start_event = {};
+  start_event.type = kSbEventTypeStart;
+  start_event.data = &start_data;
+  callback(&start_event);
+
+  SbEvent stop_event = {};
+  stop_event.type = kSbEventTypeStop;
+  stop_event.data = nullptr;
+  callback(&stop_event);
+
+  return 0;
+}

--- a/starboard/aosp/shared/starboard_library_loader.cc
+++ b/starboard/aosp/shared/starboard_library_loader.cc
@@ -1,0 +1,26 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <jni.h>
+
+#include "base/android/base_jni_onload.h"
+#include "base/android/jni_android.h"
+
+JNI_EXPORT jint JNI_OnLoad(JavaVM* vm, void* /*reserved*/) {
+  base::android::InitVM(vm);
+  if (!base::android::OnJNIOnLoadInit()) {
+    return -1;
+  }
+  return JNI_VERSION_1_4;
+}

--- a/starboard/build/config/starboard_executable.gni
+++ b/starboard/build/config/starboard_executable.gni
@@ -1,0 +1,61 @@
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+if (is_android) {
+  import("//third_party/jni_zero/jni_zero.gni")
+}
+
+template("starboard_executable") {
+  if (is_android) {
+    _target_type = "shared_library_with_jni"
+  } else {
+    _target_type = starboard_level_final_executable_type
+  }
+
+  target(_target_type, target_name) {
+    forward_variables_from(invoker, "*", TESTONLY_AND_VISIBILITY)
+    forward_variables_from(invoker, TESTONLY_AND_VISIBILITY)
+
+    if (is_android) {
+      java_targets = [
+        "//cobalt/android:cobalt_main_java",
+        "//cobalt/aosp:cobalt_apk_java",
+      ]
+      remove_uncalled_jni = true
+
+      configs -= [ "//build/config/android:hide_all_but_jni_onload" ]
+      configs += [ "//build/config/android:hide_all_but_jni" ]
+
+      if (!defined(deps)) {
+        deps = []
+      }
+      deps += [ "//starboard/aosp/shared:aosp_loader_glue" ]
+    } else {
+      output_dir = root_build_dir
+      if (_target_type != "executable") {
+        metadata = {
+          shared_libraries = [ "$root_build_dir/lib${target_name}.so" ]
+        }
+      }
+    }
+  }
+}
+
+set_defaults("starboard_executable") {
+  if (!is_android && starboard_level_final_executable_type == "executable") {
+    configs = default_executable_configs
+  } else {
+    configs = default_shared_library_configs
+  }
+}

--- a/starboard/elf_loader/BUILD.gn
+++ b/starboard/elf_loader/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//cobalt/build/configs/hacks.gni")
+import("//starboard/build/config/starboard_executable.gni")
 
 _elf_loader_sources = [
   "dynamic_section.cc",
@@ -71,31 +72,30 @@ static_library("elf_loader") {
 
 # TODO: b/309493306 - Stop building evergreen targets for all non-evergreen platforms.
 if (current_toolchain == starboard_toolchain) {
-  target(starboard_level_final_executable_type, "elf_loader_sandbox") {
+  starboard_executable("elf_loader_sandbox") {
     testonly = true
-    output_dir = root_build_dir
-
     sources = [ "elf_loader_sandbox.cc" ]
     configs += [ ":elf_loader_config" ]
 
-    data_deps = [ "//starboard/content/fonts:copy_font_data" ]
     deps = [
       ":constants",
       ":elf_loader",
       ":evergreen_info",
       ":sabi_string",
       "//starboard:starboard_group",
-      "//starboard/content/fonts:copy_font_data",
     ]
 
     if (is_android) {
       deps += [ "//starboard/android/shared:test_support" ]
-    }
-
-    if (is_starboard && use_crashpad) {
-      deps += [ "//starboard/crashpad_wrapper" ]
     } else {
-      deps += [ "//starboard/crashpad_wrapper:wrapper_stub" ]
+      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+      deps += [ "//starboard/content/fonts:copy_font_data" ]
+
+      if (is_starboard && use_crashpad) {
+        deps += [ "//starboard/crashpad_wrapper" ]
+      } else {
+        deps += [ "//starboard/crashpad_wrapper:wrapper_stub" ]
+      }
     }
   }
 }

--- a/starboard/elf_loader/BUILD.gn
+++ b/starboard/elf_loader/BUILD.gn
@@ -89,7 +89,6 @@ if (current_toolchain == starboard_toolchain) {
       deps += [ "//starboard/android/shared:test_support" ]
     } else {
       data_deps = [ "//starboard/content/fonts:copy_font_data" ]
-      deps += [ "//starboard/content/fonts:copy_font_data" ]
 
       if (is_starboard && use_crashpad) {
         deps += [ "//starboard/crashpad_wrapper" ]

--- a/starboard/elf_loader/BUILD.gn
+++ b/starboard/elf_loader/BUILD.gn
@@ -89,12 +89,12 @@ if (current_toolchain == starboard_toolchain) {
       deps += [ "//starboard/android/shared:test_support" ]
     } else {
       data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+    }
 
-      if (is_starboard && use_crashpad) {
-        deps += [ "//starboard/crashpad_wrapper" ]
-      } else {
-        deps += [ "//starboard/crashpad_wrapper:wrapper_stub" ]
-      }
+    if (is_starboard && use_crashpad) {
+      deps += [ "//starboard/crashpad_wrapper" ]
+    } else {
+      deps += [ "//starboard/crashpad_wrapper:wrapper_stub" ]
     }
   }
 }

--- a/starboard/elf_loader/elf_loader_sandbox.cc
+++ b/starboard/elf_loader/elf_loader_sandbox.cc
@@ -33,6 +33,15 @@
 #include "starboard/shared/starboard/features_test_util.h"
 #endif
 
+namespace {
+
+bool EndsWith(const std::string& s, const std::string& suffix) {
+  return s.size() >= suffix.size() &&
+         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+}
+
+}  // namespace
+
 elf_loader::ElfLoader g_elf_loader;
 
 void (*g_sb_event_func)(const SbEvent*) = NULL;
@@ -51,9 +60,15 @@ void LoadLibraryAndInitialize(const std::string& library_path,
                   << "=path/to/content/relative/to/loader/content.";
     return;
   }
+
+  auto compression_type = elf_loader::CompressionType::kNone;
+  if (EndsWith(library_path, elf_loader::kLz4Suffix)) {
+    compression_type = elf_loader::CompressionType::kLz4;
+  } else if (EndsWith(library_path, elf_loader::kZstdSuffix)) {
+    compression_type = elf_loader::CompressionType::kZstd;
+  }
   if (!g_elf_loader.Load(library_path, content_path, /*is_relative_path=*/true,
-                         /*custom_get_extension=*/nullptr,
-                         elf_loader::CompressionType::kLz4)) {
+                         /*custom_get_extension=*/nullptr, compression_type)) {
     SB_NOTREACHED() << "Failed to load library at '"
                     << g_elf_loader.GetLibraryPath() << "'.";
     return;

--- a/starboard/elf_loader/elf_loader_sandbox.cc
+++ b/starboard/elf_loader/elf_loader_sandbox.cc
@@ -33,15 +33,6 @@
 #include "starboard/shared/starboard/features_test_util.h"
 #endif
 
-namespace {
-
-bool EndsWith(const std::string& s, const std::string& suffix) {
-  return s.size() >= suffix.size() &&
-         s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
-}
-
-}  // namespace
-
 elf_loader::ElfLoader g_elf_loader;
 
 void (*g_sb_event_func)(const SbEvent*) = NULL;
@@ -62,9 +53,9 @@ void LoadLibraryAndInitialize(const std::string& library_path,
   }
 
   auto compression_type = elf_loader::CompressionType::kNone;
-  if (EndsWith(library_path, elf_loader::kLz4Suffix)) {
+  if (starboard::EndsWith(library_path, elf_loader::kLz4Suffix)) {
     compression_type = elf_loader::CompressionType::kLz4;
-  } else if (EndsWith(library_path, elf_loader::kZstdSuffix)) {
+  } else if (starboard::EndsWith(library_path, elf_loader::kZstdSuffix)) {
     compression_type = elf_loader::CompressionType::kZstd;
   }
   if (!g_elf_loader.Load(library_path, content_path, /*is_relative_path=*/true,

--- a/starboard/elf_loader/elf_loader_sandbox.cc
+++ b/starboard/elf_loader/elf_loader_sandbox.cc
@@ -51,7 +51,9 @@ void LoadLibraryAndInitialize(const std::string& library_path,
                   << "=path/to/content/relative/to/loader/content.";
     return;
   }
-  if (!g_elf_loader.Load(library_path, content_path, true)) {
+  if (!g_elf_loader.Load(library_path, content_path, /*is_relative_path=*/true,
+                         /*custom_get_extension=*/nullptr,
+                         elf_loader::CompressionType::kLz4)) {
     SB_NOTREACHED() << "Failed to load library at '"
                     << g_elf_loader.GetLibraryPath() << "'.";
     return;

--- a/starboard/loader_app/BUILD.gn
+++ b/starboard/loader_app/BUILD.gn
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import("//cobalt/build/configs/hacks.gni")
+import("//starboard/build/config/starboard_executable.gni")
 import("//third_party/protobuf/proto_library.gni")
 
 _common_loader_app_sources = [
@@ -67,8 +68,7 @@ if (is_starboard && current_toolchain == starboard_toolchain) {
     ]
   }
 
-  target(starboard_level_final_executable_type, "loader_app") {
-    output_dir = root_build_dir
+  starboard_executable("loader_app") {
     if (target_cpu == "x64" || target_cpu == "arm" || target_cpu == "arm64") {
       deps = [ ":loader_app_sources" ]
       data_deps = [ "//starboard/content/fonts:copy_font_data" ]

--- a/starboard/nplb/testdata/file_tests/BUILD.gn
+++ b/starboard/nplb/testdata/file_tests/BUILD.gn
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+if (is_android && !is_androidtv) {
+  import("//build/config/android/rules.gni")
+}
+
 copy("nplb_file_tests_data") {
   sources = [
     "dir_with_files/file11",
@@ -25,4 +29,21 @@ copy("nplb_file_tests_data") {
   subdir = "starboard/nplb/file_tests"
 
   outputs = [ "$sb_static_contents_output_data_dir/test/$subdir/{{source_target_relative}}" ]
+}
+
+if (is_android && !is_androidtv) {
+  # Android internal_rules.gni forces the use of "_assets" suffix.
+  android_assets("nplb_file_tests_data_assets") {
+    testonly = true
+    disable_compression = true
+
+    renaming_sources = get_target_outputs(":nplb_file_tests_data")
+    renaming_destinations = []
+    foreach(_output, renaming_sources) {
+      renaming_destinations +=
+          [ rebase_path(_output, sb_static_contents_output_data_dir) ]
+    }
+
+    deps = [ ":nplb_file_tests_data" ]
+  }
 }

--- a/starboard/shared/starboard/player/BUILD.gn
+++ b/starboard/shared/starboard/player/BUILD.gn
@@ -14,6 +14,10 @@
 
 import("//starboard/shared/starboard/player/testdata/sha1_files.gni")
 
+if (is_android && !is_androidtv) {
+  import("//build/config/android/rules.gni")
+}
+
 static_library("video_dmp") {
   check_includes = false
   sources = [
@@ -32,7 +36,10 @@ static_library("video_dmp") {
 }
 
 action("player_download_test_data") {
-  visibility = [ ":player_test_data" ]
+  visibility = [
+    ":player_test_data",
+    ":player_test_data_assets",
+  ]
 
   if (enable_install_targets) {
     install_content = true
@@ -93,5 +100,23 @@ if (is_apple) {
   group("player_test_data") {
     testonly = true
     data_deps = [ ":player_download_test_data" ]
+  }
+}
+
+if (is_android && !is_androidtv) {
+  # Android internal_rules.gni forces the use of "_assets" suffix.
+  android_assets("player_test_data_assets") {
+    testonly = true
+    disable_compression = true
+
+    renaming_sources = get_target_outputs(":player_download_test_data")
+    renaming_destinations = []
+    foreach(_dmp, renaming_sources) {
+      renaming_destinations +=
+          [ "test/starboard/shared/starboard/player/testdata/" +
+            get_path_info(_dmp, "file") ]
+    }
+
+    deps = [ ":player_download_test_data" ]
   }
 }


### PR DESCRIPTION
Add the build rules that package a modular executable into an Android APK for
the AOSP platform. This allows to create APKs for all test and
modular_executable targets so that building <target>_loader builds
<target>.apk.

The APK bundles the evergreen loader as its native library (loader_app for
cobalt and  elf_loader_sandbox for tests) with the lz4-compressed inner library
and its content as assets; MainActivity loads the loader and spawns the
Starboard thread through a jni_zero binding.

Most of the Java code is reused from AndroidTV, being the main exception
separate MainActivity and CobaltApplication classes.

Some non-working targets are currently excluded.

Bug: 495203133