### PR TITLE
cobalt: Build HangWatcherDelegateImpl unit tests conditionally

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -312,7 +312,6 @@ test("cobalt_unittests") {
     "//cobalt/browser/global_features_unittest.cc",
     "//cobalt/browser/h5vcc_metrics/histogram_fetcher_test.cc",
     "//cobalt/browser/h5vcc_runtime/deep_link_manager_unittest.cc",
-    "//cobalt/browser/hang_watcher_delegate_impl_unittest.cc",
     "//cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc",
     "//cobalt/browser/metrics/cobalt_enabled_state_provider_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_log_uploader_test.cc",
@@ -329,6 +328,10 @@ test("cobalt_unittests") {
     sources += [
       "//cobalt/tools/performance/memory/symbolize_in_process_heap_unittest.cc",
     ]
+  }
+
+  if (is_starboard || is_androidtv) {
+    sources += [ "//cobalt/browser/hang_watcher_delegate_impl_unittest.cc" ]
   }
 
   if (is_starboard) {


### PR DESCRIPTION
Follow-up to #11105. Use the same checks that determine if the main `hang_watcher_delegate_impl*` files are built to add the unit tests.

This fixes the tvOS `cobalt_unittests` build.

Bug: 517626586