### PR TITLE
[24.lts] Upgrade upload-artifact to v4

### DIFF
--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -152,13 +152,13 @@ runs:
         unzip ${COBALT_XMLS_FILENAME} -d ${RESULT_PATH}
       shell: bash
     - name: Archive Unit Test Logs
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always() && env.TEST_TYPE == 'unit_test'
       with:
         name: Device logs
         path: ${{ env.COBALT_LOGS_DIR }}/
     - name: Archive Unit Test Results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: always() && env.TEST_TYPE == 'unit_test'
       with:
         name: unit-test-results

--- a/.github/actions/on_host_test/action.yaml
+++ b/.github/actions/on_host_test/action.yaml
@@ -98,7 +98,7 @@ runs:
     # results.
     #
     # - name: Archive unit test results
-    #  uses: actions/upload-artifact@v3
+    #  uses: actions/upload-artifact@v4
     #  if: always() && steps.run-tests.outputs.test_type == 'unit_tests'
     #  with:
     #    name: unit-test-reports


### PR DESCRIPTION
Update GitHub Actions in the CI workflows to use v4 of the upload-artifact action. This update ensures compatibility with the current GitHub platform and improves the reliability and speed of artifact handling during on-device and host-based testing.

Bug: 392611572