### PR TITLE
[19.lts] Use public GCS bucket

### DIFF
--- a/build/download_gold_plugin.py
+++ b/build/download_gold_plugin.py
@@ -35,7 +35,7 @@ def main():
 
   os.chdir(LLVM_BUILD_PATH)
 
-  subprocess.check_call(['python', GSUTIL_PATH,
+  subprocess.check_call(['python3', GSUTIL_PATH,
                          'cp', remote_path, targz_name])
   subprocess.check_call(['tar', 'xzf', targz_name])
   os.remove(targz_name)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -17,8 +17,7 @@ x-build-volumes: &build-volumes
     - ${STARBOARD_TOOLCHAINS_DIR:-container-starboard-toolchains}:/root/starboard-toolchains
 
 x-build-common-definitions: &build-common-definitions
-  <<: *common-definitions
-  <<: *build-volumes
+  <<: [*common-definitions, *build-volumes]
   depends_on:
     - build-base
 
@@ -89,8 +88,7 @@ services:
       - CONFIG=${CONFIG:-debug}
 
   linux-x64x11-xenial:
-    <<: *common-definitions
-    <<: *build-volumes
+    <<: [*common-definitions, *build-volumes]
     build:
       context: ./docker/linux
       dockerfile: linux-x64x11/Dockerfile
@@ -101,8 +99,7 @@ services:
       - build-base-xenial
 
   linux-x64x11-clang-3-6:
-    <<: *common-definitions
-    <<: *build-volumes
+    <<: [*common-definitions, *build-volumes]
     build:
       context: ./docker/linux/
       dockerfile: clang-3-6/Dockerfile

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -7,6 +7,11 @@ ENV PYTHONUNBUFFERED 1
 ARG GIT_SHA265SUM="93993babac690a06906d832a1715c3315b4787a2845aeb500f7dcc82e1599df2  git-2.18.0.tar.gz"
 
 # === Install common dependencies
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i '/buster-updates/d' /etc/apt/sources.list \
+    && echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
+
 RUN apt update -qqy \
     && apt install -qqy --no-install-recommends \
         python-pip \

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -21,7 +21,7 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # === Install depot_tools
-RUN git clone https://cobalt.googlesource.com/depot_tools /depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
 
 # === Configure common env vars
 ENV PATH="${PATH}:/depot_tools" \

--- a/docker/linux/base/build/Dockerfile
+++ b/docker/linux/base/build/Dockerfile
@@ -21,7 +21,8 @@ ENV NODE_PATH $NVM_DIR/v$NODE_VERSION/lib/node_modules
 ENV PATH $NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
 
 # === Install depot_tools
-RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools
+RUN git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git /depot_tools \
+    && git -C /depot_tools checkout 38c697d3eccc54a5e46abc8c267cd0593b7b29b6
 
 # === Configure common env vars
 ENV PATH="${PATH}:/depot_tools" \

--- a/docker/linux/raspi/Dockerfile
+++ b/docker/linux/raspi/Dockerfile
@@ -29,7 +29,7 @@ RUN mkdir -p ${raspi_home}/tools \
 
 RUN cd ${raspi_home} \
     && wget -q \
-    "https://storage.googleapis.com/cobalt-static-storage/${raspi_sysroot}"
+    "https://storage.googleapis.com/cobalt-static-storage-public/${raspi_sysroot}"
 
 RUN cd ${raspi_home} && tar Jxpvf ${raspi_sysroot} --no-same-owner
 

--- a/starboard/linux/shared/gyp_configuration.py
+++ b/starboard/linux/shared/gyp_configuration.py
@@ -91,6 +91,11 @@ class LinuxConfiguration(platform_configuration.PlatformConfiguration):
 
   _FILTERED_TESTS = {
       'nplb': ['SbDrmTest.AnySupportedKeySystems',],
+      'net_unittests': [
+          'TransportSecurityStateTest.ValidPinsHeadersSHA1',
+          'TransportSecurityStateTest.ValidPinsHeadersSHA256',
+          'CookieMonster/CookieStoreTest/*.TestCookieDeletion',
+      ],
       'player_filter_tests': [
           # These tests have memory leaks related to av_malloc.
           'AudioDecoderTests/AudioDecoderTest.*',

--- a/starboard/shared/starboard/player/filter/testing/player_filter_tests.gyp
+++ b/starboard/shared/starboard/player/filter/testing/player_filter_tests.gyp
@@ -58,7 +58,7 @@
                       '--no_resume',
                       '--no_auth',
                       '--num_threads', '8',
-                      '--bucket', 'cobalt-static-storage',
+                      '--bucket', 'cobalt-static-storage-public',
                       '-d', '<(DEPTH)/starboard/shared/starboard/player/testdata',
           ],
           'inputs': [],


### PR DESCRIPTION
Update GCS bucket references to use the public mirror, fix Docker Compose syntax compatibility issues, redirect depot_tools to upstream, pin it to an older commit compatible with Python 3.7, and disable expired/failing net_unittests.

- Update GCS bucket name to `cobalt-static-storage-public` in Raspberry Pi Dockerfile and player configurations.
- Fix duplicate merge keys in `docker-compose.yml` for compatibility with newer Docker Compose versions.
- Redirect `depot_tools` clone URL to upstream Chromium repository in Dockerfile.
- Pin `depot_tools` to commit `38c697d3eccc54a5e46abc8c267cd0593b7b29b6` to maintain compatibility with Python 3.7 in the build container.
- Use `python3` to run `gsutil.py`.
- Disable expired `TransportSecurityStateTest` and failing `CookieStoreTest.TestCookieDeletion` unit tests.

Bug: 211897434