### PR TITLE
[22.lts] Fix Debian Buster EOL

### DIFF
--- a/cobalt/renderer/renderer.gyp
+++ b/cobalt/renderer/renderer.gyp
@@ -140,7 +140,7 @@
           'action': [
             'python',
             '<(DEPTH)/tools/download_from_gcs.py',
-            '--bucket', 'lottie-coverage-testdata',
+            '--bucket', 'lottie-coverage-testdata-public',
             '--sha1', '<(sha_dir)',
             '--output', '<(out_dir)',
           ],

--- a/docker/linux/base/Dockerfile
+++ b/docker/linux/base/Dockerfile
@@ -19,6 +19,11 @@ FROM ${BASE_OS:-marketplace.gcr.io/google/debian10}:${BASE_OS_TAG:-latest}
 ENV PYTHONUNBUFFERED 1
 
 # === Install common dependencies
+RUN sed -i 's/deb.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i 's/security.debian.org/archive.debian.org/g' /etc/apt/sources.list \
+    && sed -i '/buster-updates/d' /etc/apt/sources.list \
+    && echo "Acquire::Check-Valid-Until \"false\";" > /etc/apt/apt.conf.d/99no-check-valid-until
+
 RUN apt update -qqy \
     && apt install -qqy --no-install-recommends \
         python-pip \

--- a/docker/linux/raspi/Dockerfile
+++ b/docker/linux/raspi/Dockerfile
@@ -38,7 +38,7 @@ RUN apt update -qqy \
 # Get the combined toolchains package.
 RUN cd /tmp \
     && curl --silent -O -J \
-    "https://storage.googleapis.com/cobalt-static-storage/${raspi_tools}" \
+    "https://storage.googleapis.com/cobalt-static-storage-public/${raspi_tools}" \
     && mkdir -p ${raspi_home} \
     && cd ${raspi_home} \
     && tar xjvf /tmp/${raspi_tools} --no-same-owner \

--- a/starboard/shared/starboard/player/BUILD.gn
+++ b/starboard/shared/starboard/player/BUILD.gn
@@ -60,7 +60,7 @@ action("player_download_test_data") {
 
   args = [
     "--bucket",
-    "cobalt-static-storage",
+    "cobalt-static-storage-public",
     "--sha1",
     sha1_dir,
     "--output",

--- a/starboard/shared/starboard/player/player.gyp
+++ b/starboard/shared/starboard/player/player.gyp
@@ -67,7 +67,7 @@
           'action': [
             'python',
             '<(DEPTH)/tools/download_from_gcs.py',
-            '--bucket', 'cobalt-static-storage',
+            '--bucket', 'cobalt-static-storage-public',
             '--sha1', '<(sha_dir)',
             '--output', '<(out_dir)',
           ],


### PR DESCRIPTION
Resolve Debian Buster EOL repository issues in Docker build and update GCS bucket references to use public mirrors.

- Redirect Buster sources to archive.debian.org and disable valid-until check in Dockerfile.
- Update GCS bucket references to `cobalt-static-storage-public` where necessary.
- Update Lottie testdata GCS bucket reference to `lottie-coverage-testdata-public`.

Bug: b/515513548
Bug: b/508470183
Bug: b/211897434