### PR TITLE
media: Fix microphone recording regression

### DIFF
--- a/media/audio/android/starboard_audio_input_stream.cc
+++ b/media/audio/android/starboard_audio_input_stream.cc
@@ -286,6 +286,12 @@ void StarboardAudioInputStream::ReadBufferQueue() {
   base::AutoLock lock(lock_);
 
   if (!started_ || !callback_) {
+    if (simple_buffer_queue_) {
+      (*simple_buffer_queue_)->Enqueue(simple_buffer_queue_,
+                                       audio_data_[active_buffer_index_].get(),
+                                       buffer_size_bytes_);
+      active_buffer_index_ = (active_buffer_index_ + 1) % kMaxNumOfBuffersInQueue;
+    }
     return;
   }
 

--- a/media/audio/android/starboard_audio_input_stream.cc
+++ b/media/audio/android/starboard_audio_input_stream.cc
@@ -286,7 +286,7 @@ void StarboardAudioInputStream::ReadBufferQueue() {
   base::AutoLock lock(lock_);
 
   if (!started_ || !callback_) {
-    if (simple_buffer_queue_) {
+    if (simple_buffer_queue_ && *simple_buffer_queue_) {
       (*simple_buffer_queue_)->Enqueue(simple_buffer_queue_,
                                        audio_data_[active_buffer_index_].get(),
                                        buffer_size_bytes_);
@@ -306,7 +306,7 @@ void StarboardAudioInputStream::ReadBufferQueue() {
                     /*volume=*/0.0,
                     /*audio_glitch_info=*/{});
 
-  if (simple_buffer_queue_) {
+  if (simple_buffer_queue_ && *simple_buffer_queue_) {
     (*simple_buffer_queue_)->Enqueue(simple_buffer_queue_,
                                      audio_data_[active_buffer_index_].get(),
                                      buffer_size_bytes_);


### PR DESCRIPTION
PR (#11124) refactored StarboardAudioInputStream::ReadBufferQueue
to hold lock_ across OnData() to prevent teardown race conditions. However, it
introduced an early return (`if (!started_ || !callback_) return;`) right at the top
of ReadBufferQueue().

This fix ensures ReadBufferQueue() always re-enqueues popped buffers back into
simple_buffer_queue_ when `!started_ || !callback_`, keeping the recording loop
alive while waiting for Start().

Bug: 535089082