### PR TITLE
Add cross-platform PassthroughTimeTracker for passthrough audio media time reporting

### DIFF
--- a/starboard/android/shared/audio_decoder_passthrough.h
+++ b/starboard/android/shared/audio_decoder_passthrough.h
@@ -69,6 +69,9 @@ class AudioDecoderPassthrough : public AudioDecoder {
                            kSbMediaAudioFrameStorageTypePlanar,
                            input_buffer->timestamp(), input_buffer->size());
       memcpy(decoded_audio->data(), input_buffer->data(), input_buffer->size());
+      decoded_audio->set_discarded_durations(
+          input_buffer->audio_sample_info().discarded_duration_from_front,
+          input_buffer->audio_sample_info().discarded_duration_from_back);
       decoded_audios_.push(std::move(decoded_audio));
       output_cb_();
     }

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -306,6 +306,7 @@ void AudioRendererPassthrough::Seek(int64_t seek_to_time) {
   decoded_audio_writing_in_progress_ = nullptr;
   decoded_audio_writing_offset_ = 0;
   total_frames_written_on_audio_track_thread_ = 0;
+  time_tracker_.Reset(seek_to_time);
 }
 
 // This function can be called from *any* threads.
@@ -348,9 +349,9 @@ int64_t AudioRendererPassthrough::GetCurrentMediaTime(bool* is_playing,
     int64_t total_frames_played =
         frames_played + playback_head_position_when_stopped_;
     total_frames_played = std::min(total_frames_played, total_frames_written_);
-    playback_time =
-        audio_start_time + total_frames_played * 1'000'000LL /
-                               audio_stream_info_.samples_per_second;
+    playback_time = time_tracker_.GetCurrentMediaTime(
+        total_frames_played, audio_stream_info_.samples_per_second,
+        audio_start_time);
     return std::max(playback_time, seek_to_time_);
   }
 
@@ -365,8 +366,9 @@ int64_t AudioRendererPassthrough::GetCurrentMediaTime(bool* is_playing,
 
   // TODO: This may cause time regression, because the unadjusted time will be
   //       returned on pause, after an adjusted time has been returned.
-  playback_time = audio_start_time + playback_head_position * 1'000'000LL /
-                                         audio_stream_info_.samples_per_second;
+  playback_time = time_tracker_.GetCurrentMediaTime(
+      playback_head_position, audio_stream_info_.samples_per_second,
+      audio_start_time);
 
   // When underlying AudioTrack is paused, we use returned playback time
   // directly. Note that we should not use |paused_| or |playback_rate_| here.
@@ -575,6 +577,12 @@ void AudioRendererPassthrough::UpdateStatusAndWriteData(
 
       if (decoded_audio_writing_offset_ ==
           decoded_audio_writing_in_progress_->size_in_bytes()) {
+        time_tracker_.OnBufferWritten(
+            total_frames_written_on_audio_track_thread_, sync_time,
+            frames_per_input_buffer_ * 1'000'000LL /
+                audio_stream_info_.samples_per_second,
+            decoded_audio_writing_in_progress_->discarded_duration_from_front(),
+            decoded_audio_writing_in_progress_->discarded_duration_from_back());
         total_frames_written_on_audio_track_thread_ += frames_per_input_buffer_;
         decoded_audio_writing_in_progress_ = nullptr;
         decoded_audio_writing_offset_ = 0;

--- a/starboard/android/shared/audio_renderer_passthrough.h
+++ b/starboard/android/shared/audio_renderer_passthrough.h
@@ -34,6 +34,7 @@
 #include "starboard/shared/starboard/player/filter/audio_renderer_internal.h"
 #include "starboard/shared/starboard/player/filter/common.h"
 #include "starboard/shared/starboard/player/filter/media_time_provider.h"
+#include "starboard/shared/starboard/player/filter/passthrough_time_tracker.h"
 #include "starboard/shared/starboard/player/input_buffer_internal.h"
 #include "starboard/shared/starboard/player/job_queue.h"
 #include "starboard/shared/starboard/player/job_thread.h"
@@ -148,6 +149,9 @@ class AudioRendererPassthrough : public AudioRenderer,
   // invalidated.
   std::unique_ptr<AudioTrackBridge> audio_track_bridge_;
   std::unique_ptr<JobThread> audio_track_thread_;
+
+  ::starboard::shared::starboard::player::filter::PassthroughTimeTracker
+      time_tracker_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -272,8 +272,11 @@ void MediaCodecAudioDecoder::ProcessOutputBuffer(
         dequeue_output_result.presentation_time_microseconds, size);
 
     memcpy(decoded_audio->data(), data, size);
-    audio_frame_discarder_.AdjustForDiscardedDurations(
-        audio_stream_info_.samples_per_second, &decoded_audio);
+    audio_frame_discarder_.AdjustOrSetDiscardedDurations(
+        audio_stream_info_.samples_per_second,
+        audio_stream_info_.codec == kSbMediaAudioCodecAc3 ||
+            audio_stream_info_.codec == kSbMediaAudioCodecEac3,
+        &decoded_audio);
 
     {
       std::lock_guard lock(decoded_audios_mutex_);

--- a/starboard/shared/starboard/player/decoded_audio_internal.cc
+++ b/starboard/shared/starboard/player/decoded_audio_internal.cc
@@ -316,6 +316,8 @@ scoped_refptr<DecodedAudio> DecodedAudio::Clone() const {
       channels(), sample_type(), storage_type(), timestamp(), size_in_bytes());
 
   memcpy(copy->data(), data(), size_in_bytes());
+  copy->set_discarded_durations(discarded_duration_from_front_,
+                                discarded_duration_from_back_);
 
   return copy;
 }

--- a/starboard/shared/starboard/player/decoded_audio_internal.h
+++ b/starboard/shared/starboard/player/decoded_audio_internal.h
@@ -62,6 +62,16 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
     return reinterpret_cast<const float*>(storage_.data() + offset_in_bytes_);
   }
   int size_in_bytes() const { return size_in_bytes_; }
+  int64_t discarded_duration_from_front() const {
+    return discarded_duration_from_front_;
+  }
+  int64_t discarded_duration_from_back() const {
+    return discarded_duration_from_back_;
+  }
+  void set_discarded_durations(int64_t from_front, int64_t from_back) {
+    discarded_duration_from_front_ = from_front;
+    discarded_duration_from_back_ = from_back;
+  }
 
   uint8_t* data() { return storage_.data() + offset_in_bytes_; }
   int16_t* data_as_int16() {
@@ -128,6 +138,8 @@ class DecodedAudio : public RefCountedThreadSafe<DecodedAudio> {
   // `storage_.data() + offset_in_bytes_`, `size_in_bytes_` bytes in total.
   int offset_in_bytes_ = 0;
   int size_in_bytes_ = 0;
+  int64_t discarded_duration_from_front_ = 0;
+  int64_t discarded_duration_from_back_ = 0;
 
   DecodedAudio(const DecodedAudio&) = delete;
   void operator=(const DecodedAudio&) = delete;

--- a/starboard/shared/starboard/player/filter/BUILD.gn
+++ b/starboard/shared/starboard/player/filter/BUILD.gn
@@ -50,6 +50,8 @@ static_library("filter_based_player_sources") {
     "//starboard/shared/starboard/player/filter/media_time_provider_impl.h",
     "//starboard/shared/starboard/player/filter/mock_audio_decoder.h",
     "//starboard/shared/starboard/player/filter/mock_audio_renderer_sink.h",
+    "//starboard/shared/starboard/player/filter/passthrough_time_tracker.cc",
+    "//starboard/shared/starboard/player/filter/passthrough_time_tracker.h",
     "//starboard/shared/starboard/player/filter/player_components.cc",
     "//starboard/shared/starboard/player/filter/player_components.h",
     "//starboard/shared/starboard/player/filter/punchout_video_renderer_sink.cc",

--- a/starboard/shared/starboard/player/filter/audio_frame_discarder.cc
+++ b/starboard/shared/starboard/player/filter/audio_frame_discarder.cc
@@ -40,6 +40,14 @@ void AudioFrameDiscarder::OnInputBuffers(const InputBuffers& input_buffers) {
 void AudioFrameDiscarder::AdjustForDiscardedDurations(
     int sample_rate,
     scoped_refptr<DecodedAudio>* decoded_audio) {
+  AdjustOrSetDiscardedDurations(sample_rate, /*is_passthrough=*/false,
+                                decoded_audio);
+}
+
+void AudioFrameDiscarder::AdjustOrSetDiscardedDurations(
+    int sample_rate,
+    bool is_passthrough,
+    scoped_refptr<DecodedAudio>* decoded_audio) {
   if (!decoded_audio || !*decoded_audio) {
     SB_LOG(ERROR) << "No input buffer to adjust.";
     SB_DCHECK(decoded_audio);
@@ -75,10 +83,16 @@ void AudioFrameDiscarder::AdjustForDiscardedDurations(
     return;
   }
 
-  (*decoded_audio)
-      ->AdjustForDiscardedDurations(sample_rate,
-                                    input_info.discarded_duration_from_front,
-                                    input_info.discarded_duration_from_back);
+  if (is_passthrough) {
+    (*decoded_audio)
+        ->set_discarded_durations(input_info.discarded_duration_from_front,
+                                  input_info.discarded_duration_from_back);
+  } else {
+    (*decoded_audio)
+        ->AdjustForDiscardedDurations(sample_rate,
+                                      input_info.discarded_duration_from_front,
+                                      input_info.discarded_duration_from_back);
+  }
   // `(*decoded_audio)->frames()` might be 0 here.  We don't set it to nullptr
   // in this case so the DecodedAudio instance is always valid (but might be
   // empty).

--- a/starboard/shared/starboard/player/filter/audio_frame_discarder.h
+++ b/starboard/shared/starboard/player/filter/audio_frame_discarder.h
@@ -36,6 +36,10 @@ class AudioFrameDiscarder {
   void OnInputBuffers(const InputBuffers& input_buffers);
   void AdjustForDiscardedDurations(int sample_rate,
                                    scoped_refptr<DecodedAudio>* decoded_audio);
+  void AdjustOrSetDiscardedDurations(
+      int sample_rate,
+      bool is_passthrough,
+      scoped_refptr<DecodedAudio>* decoded_audio);
   void OnDecodedAudioEndOfStream();
 
   void Reset();

--- a/starboard/shared/starboard/player/filter/passthrough_time_tracker.cc
+++ b/starboard/shared/starboard/player/filter/passthrough_time_tracker.cc
@@ -1,0 +1,125 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/filter/passthrough_time_tracker.h"
+
+#include <algorithm>
+
+#include "starboard/common/log.h"
+
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace player {
+namespace filter {
+
+void PassthroughTimeTracker::Reset(int64_t seek_to_time) {
+  std::lock_guard lock(mutex_);
+  buffer_queue_ = std::queue<BufferInfo>();
+  seek_to_time_ = seek_to_time;
+}
+
+void PassthroughTimeTracker::OnBufferWritten(
+    int64_t hardware_sample_offset,
+    int64_t pts,
+    int64_t duration_usec,
+    int64_t discarded_duration_from_front_usec,
+    int64_t discarded_duration_from_back_usec) {
+  if (duration_usec <= 0) {
+    SB_LOG(WARNING) << "PassthroughTimeTracker ignored buffer with duration "
+                    << duration_usec;
+    return;
+  }
+
+  std::lock_guard lock(mutex_);
+  // Estimate sample count from duration if needed, or caller passes exact
+  // offset. We assume duration_usec is proportional to samples written for this
+  // buffer.
+  buffer_queue_.push({
+      hardware_sample_offset,
+      /* hardware_sample_end = */ hardware_sample_offset +
+          (duration_usec * 48'000LL /
+           1'000'000LL),  // Will be adjusted by actual sample rate in
+                          // GetCurrentMediaTime if exact end needed, but we use
+                          // start + samples
+      pts,
+      duration_usec,
+      std::max<int64_t>(0, discarded_duration_from_front_usec),
+      std::max<int64_t>(0, discarded_duration_from_back_usec),
+  });
+}
+
+int64_t PassthroughTimeTracker::GetCurrentMediaTime(
+    int64_t playback_head_sample_position,
+    int sample_rate,
+    int64_t fallback_start_time) const {
+  std::lock_guard lock(mutex_);
+
+  if (sample_rate <= 0) {
+    return buffer_queue_.empty() ? fallback_start_time
+                                 : buffer_queue_.front().pts;
+  }
+
+  // Evict any buffers from the front that the hardware playhead has completely
+  // finished playing out of the speaker.
+  while (!buffer_queue_.empty()) {
+    const BufferInfo& front = buffer_queue_.front();
+    int64_t buffer_samples = front.duration_usec * sample_rate / 1'000'000LL;
+    if (buffer_samples <= 0) {
+      buffer_queue_.pop();
+      continue;
+    }
+    if (playback_head_sample_position >=
+        front.hardware_sample_start + buffer_samples) {
+      buffer_queue_.pop();
+    } else {
+      break;
+    }
+  }
+
+  if (buffer_queue_.empty()) {
+    return fallback_start_time;
+  }
+
+  const BufferInfo& active = buffer_queue_.front();
+  int64_t samples_into_buffer = std::max<int64_t>(
+      0, playback_head_sample_position - active.hardware_sample_start);
+  int64_t time_into_buffer = samples_into_buffer * 1'000'000LL / sample_rate;
+
+  // Handle front discard: while the trimmed preamble plays out of the speaker,
+  // clamp media time at the buffer's PTS.
+  if (time_into_buffer < active.discard_front_usec) {
+    return active.pts;
+  }
+  time_into_buffer -= active.discard_front_usec;
+
+  // Handle back discard: do not let media time overshoot the valid buffer
+  // duration.
+  int64_t valid_duration = active.duration_usec - active.discard_front_usec -
+                           active.discard_back_usec;
+  if (valid_duration < 0) {
+    valid_duration = 0;
+  }
+  if (time_into_buffer > valid_duration) {
+    time_into_buffer = valid_duration;
+  }
+
+  return active.pts + time_into_buffer;
+}
+
+}  // namespace filter
+}  // namespace player
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard

--- a/starboard/shared/starboard/player/filter/passthrough_time_tracker.h
+++ b/starboard/shared/starboard/player/filter/passthrough_time_tracker.h
@@ -1,0 +1,74 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_PASSTHROUGH_TIME_TRACKER_H_
+#define STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_PASSTHROUGH_TIME_TRACKER_H_
+
+#include <mutex>
+#include <queue>
+
+#include "starboard/shared/internal_only.h"
+
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace player {
+namespace filter {
+
+// Cross-platform helper for tracking media time and handling partial frame
+// discards (discarded_duration_from_front / discarded_duration_from_back) in
+// passthrough audio renderers, where compressed syncframes cannot be sliced
+// before sending to the audio sink.
+class PassthroughTimeTracker {
+ public:
+  void Reset(int64_t seek_to_time = 0);
+
+  // Called whenever the platform-specific renderer writes a syncframe to the
+  // audio sink. |hardware_sample_offset| is the total number of hardware
+  // samples sent to the sink before this buffer was written.
+  void OnBufferWritten(int64_t hardware_sample_offset,
+                       int64_t pts,
+                       int64_t duration_usec,
+                       int64_t discarded_duration_from_front_usec,
+                       int64_t discarded_duration_from_back_usec);
+
+  // Called by the platform renderer inside GetCurrentMediaTime().
+  // Takes the monotonically increasing hardware sample playhead from the audio
+  // sink and returns the exact adjusted media presentation time.
+  int64_t GetCurrentMediaTime(int64_t playback_head_sample_position,
+                              int sample_rate,
+                              int64_t fallback_start_time) const;
+
+ private:
+  struct BufferInfo {
+    int64_t hardware_sample_start;
+    int64_t hardware_sample_end;
+    int64_t pts;
+    int64_t duration_usec;
+    int64_t discard_front_usec;
+    int64_t discard_back_usec;
+  };
+
+  mutable std::mutex mutex_;
+  mutable std::queue<BufferInfo> buffer_queue_;
+  int64_t seek_to_time_ = 0;
+};
+
+}  // namespace filter
+}  // namespace player
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard
+
+#endif  // STARBOARD_SHARED_STARBOARD_PLAYER_FILTER_PASSTHROUGH_TIME_TRACKER_H_

--- a/starboard/shared/starboard/player/filter/testing/BUILD.gn
+++ b/starboard/shared/starboard/player/filter/testing/BUILD.gn
@@ -34,6 +34,7 @@ if (current_toolchain == starboard_toolchain) {
       "experimental_features_test.cc",
       "file_cache_reader_test.cc",
       "media_time_provider_impl_test.cc",
+      "passthrough_time_tracker_test.cc",
       "player_components_test.cc",
       "video_decoder_test.cc",
       "video_decoder_test_fixture.cc",
@@ -58,6 +59,11 @@ if (current_toolchain == starboard_toolchain) {
       "//starboard/shared/starboard/player/filter:filter_based_player_sources",
       "//starboard/testing:fake_graphics_context_provider",
     ]
+  }
+
+  target(_benchmark_type, "player_filter_tests_exe") {
+    testonly = true
+    deps = [ ":player_filter_tests" ]
   }
 
   target(_benchmark_type, "player_filter_benchmarks") {

--- a/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
@@ -396,10 +396,10 @@ vector<vector<const char*>> GetSupportedTests() {
   return test_params;
 }
 
-INSTANTIATE_TEST_CASE_P(AdaptiveAudioDecoderTests,
-                        AdaptiveAudioDecoderTest,
-                        Combine(ValuesIn(GetSupportedTests()), Bool()),
-                        GetAdaptiveAudioDecoderTestConfigName);
+INSTANTIATE_TEST_SUITE_P(AdaptiveAudioDecoderTests,
+                         AdaptiveAudioDecoderTest,
+                         Combine(ValuesIn(GetSupportedTests()), Bool()),
+                         GetAdaptiveAudioDecoderTestConfigName);
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
@@ -146,7 +146,7 @@ TEST_P(AudioFrameDiscarderTest, PartialAudio) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AudioFrameDiscarderTests,
     AudioFrameDiscarderTest,
     ValuesIn(

--- a/starboard/shared/starboard/player/filter/testing/passthrough_time_tracker_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/passthrough_time_tracker_test.cc
@@ -1,0 +1,168 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/player/filter/passthrough_time_tracker.h"
+
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace starboard {
+namespace shared {
+namespace starboard {
+namespace player {
+namespace filter {
+namespace {
+
+constexpr int kSampleRate = 48'000;
+// 1536 samples per AC-3 / E-AC-3 syncframe at 48kHz = exactly 32,000
+// microseconds.
+constexpr int kSyncframeSamples = 1536;
+constexpr int64_t kSyncframeDurationUsec = 32'000;
+
+class PassthroughTimeTrackerTest : public ::testing::Test {
+ protected:
+  PassthroughTimeTracker tracker_;
+};
+
+TEST_F(PassthroughTimeTrackerTest, InitialStateAndSeekReset) {
+  // Before any buffers are written, returns the fallback seek time.
+  tracker_.Reset(/*seek_to_time=*/10'000'000);
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(0, kSampleRate, 10'000'000),
+            10'000'000);
+}
+
+TEST_F(PassthroughTimeTrackerTest, NormalLinearPlaybackWithoutDiscards) {
+  // Write 3 consecutive syncframes without any discards.
+  // Buffer 0: [0 .. 1536] samples -> PTS 0
+  tracker_.OnBufferWritten(0, 0, kSyncframeDurationUsec, 0, 0);
+  // Buffer 1: [1536 .. 3072] samples -> PTS 32,000 us
+  tracker_.OnBufferWritten(kSyncframeSamples, kSyncframeDurationUsec,
+                           kSyncframeDurationUsec, 0, 0);
+  // Buffer 2: [3072 .. 4608] samples -> PTS 64,000 us
+  tracker_.OnBufferWritten(kSyncframeSamples * 2, kSyncframeDurationUsec * 2,
+                           kSyncframeDurationUsec, 0, 0);
+
+  // Playhead at 0 samples (start of Buffer 0) -> media time 0.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(0, kSampleRate, 0), 0);
+
+  // Playhead halfway through Buffer 0 (768 samples = 16ms) -> media time 16,000
+  // us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(kSyncframeSamples / 2, kSampleRate, 0),
+            16'000);
+
+  // Playhead at start of Buffer 1 (1536 samples) -> media time 32,000 us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(kSyncframeSamples, kSampleRate, 0),
+            32'000);
+
+  // Playhead halfway through Buffer 1 (2304 samples) -> media time 48,000 us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(
+                kSyncframeSamples + kSyncframeSamples / 2, kSampleRate, 0),
+            48'000);
+}
+
+TEST_F(PassthroughTimeTrackerTest,
+       FrontDiscardClampsMediaTimeUntilPreamblePlays) {
+  // Write a single syncframe whose first 10,000 us (480 samples) are trimmed
+  // preamble. The buffer's PTS on the media timeline is 100,000 us.
+  constexpr int64_t kDiscardFrontUsec = 10'000;
+  constexpr int kDiscardFrontSamples = 480;  // 10ms at 48kHz
+
+  tracker_.OnBufferWritten(0, 100'000, kSyncframeDurationUsec,
+                           kDiscardFrontUsec, 0);
+
+  // 1. Playhead at 0 samples: front discard padding begins playing out of
+  // speaker. Media time must stay clamped at the buffer's PTS (100,000 us)
+  // rather than running ahead.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(0, kSampleRate, 0), 100'000);
+
+  // 2. Playhead at 240 samples (5ms into front padding): still in trimmed
+  // region.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(240, kSampleRate, 0), 100'000);
+
+  // 3. Playhead at exactly 480 samples (10ms): front discard region finished!
+  // Valid audio starts playing out of speaker -> media time is exactly 100,000
+  // us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(kDiscardFrontSamples, kSampleRate, 0),
+            100'000);
+
+  // 4. Playhead at 960 samples (20ms total played -> 10ms into valid audio).
+  // Media time = PTS (100,000) + (20,000 played - 10,000 discarded) = 110,000
+  // us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(960, kSampleRate, 0), 110'000);
+}
+
+TEST_F(PassthroughTimeTrackerTest, BackDiscardClampsMediaTimeAtValidBufferEnd) {
+  // Write a syncframe whose last 8,000 us (384 samples) are discarded trailing
+  // padding.
+  constexpr int64_t kDiscardBackUsec = 8'000;
+
+  tracker_.OnBufferWritten(0, 200'000, kSyncframeDurationUsec, 0,
+                           kDiscardBackUsec);
+
+  // 1. Playhead 12ms into buffer: inside valid region -> 212,000 us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(12 * 48, kSampleRate, 0), 212'000);
+
+  // 2. Playhead at 24ms (exactly at valid end): media time reaches max valid
+  // PTS -> 224,000 us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(24 * 48, kSampleRate, 0), 224'000);
+
+  // 3. Playhead at 28ms (4ms into discarded back padding playing from speaker):
+  // Media time must NOT overshoot into unwanted timeline; stays clamped at
+  // 224,000 us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(28 * 48, kSampleRate, 0), 224'000);
+}
+
+TEST_F(PassthroughTimeTrackerTest, CombinedFrontAndBackDiscard) {
+  // A single syncframe where both front (6ms) and back (6ms) are discarded out
+  // of 32ms. Valid interval is from 6ms to 26ms (total 20ms valid duration).
+  constexpr int64_t kDiscardFrontUsec = 6'000;
+  constexpr int64_t kDiscardBackUsec = 6'000;
+
+  tracker_.OnBufferWritten(0, 300'000, kSyncframeDurationUsec,
+                           kDiscardFrontUsec, kDiscardBackUsec);
+
+  // During front discard (3ms in): clamped to PTS.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(3 * 48, kSampleRate, 0), 300'000);
+
+  // During valid middle (16ms total in -> 10ms valid audio played): PTS + 10ms.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(16 * 48, kSampleRate, 0), 310'000);
+
+  // During back discard (30ms total in -> past valid 20ms duration): clamped to
+  // PTS + 20ms.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(30 * 48, kSampleRate, 0), 320'000);
+}
+
+TEST_F(PassthroughTimeTrackerTest,
+       QueueEvictionEnsuresNoDriftAcrossMultipleBuffers) {
+  // Buffer 0 has a 10ms front discard.
+  tracker_.OnBufferWritten(0, 0, kSyncframeDurationUsec, 10'000, 0);
+  // Buffer 1 is a normal buffer following immediately on hardware sample 1536.
+  // Its PTS on the media timeline is 22,000 us (32ms minus the 10ms discarded
+  // in Buffer 0).
+  tracker_.OnBufferWritten(kSyncframeSamples, 22'000, kSyncframeDurationUsec, 0,
+                           0);
+
+  // When playhead advances to sample 2304 (halfway through Buffer 1):
+  // Buffer 0 should be evicted, and Buffer 1 calculates cleanly from its own
+  // PTS: 22,000 us + 16,000 us = 38,000 us.
+  EXPECT_EQ(tracker_.GetCurrentMediaTime(
+                kSyncframeSamples + kSyncframeSamples / 2, kSampleRate, 0),
+            38'000);
+}
+
+}  // namespace
+}  // namespace filter
+}  // namespace player
+}  // namespace starboard
+}  // namespace shared
+}  // namespace starboard


### PR DESCRIPTION
In passthrough audio renderers (AC-3 / E-AC-3 compressed bitstream), syncframes cannot be sliced or trimmed before being sent to the sink without breaking the bitstream syntax. Previously, AudioRendererPassthrough computed media time directly from unadjusted hardware playhead positions (playback_head_position), causing media time drift when partial frames were discarded (discarded_duration_from_front / discarded_duration_from_back).

This change introduces PassthroughTimeTracker (starboard/shared/starboard/player/filter/passthrough_time_tracker.h/.cc), a cross-platform helper class that:
- Anchors media time to each buffer's presentation timestamp (PTS) and tracks active playhead offsets within the buffer being played.
- Automatically clamps media time during trimmed front preambles and prevents overshoot during trailing padding.
- Evicts played buffers cleanly from its queue, preventing timestamp drift over long playbacks and seek operations.
- Integrates into DecodedAudio, AudioFrameDiscarder, AudioDecoderPassthrough, MediaCodecAudioDecoder (passthrough mode), and AudioRendererPassthrough so that all platforms implementing passthrough audio can use unified, tested discard handling without re-implementing ad-hoc math.
- Adds comprehensive unit tests (passthrough_time_tracker_test.cc) covering initial seek resets, linear playback, front/back discard clamping, and queue eviction.

TAG=agy
CONV=fcb691b9-e329-4923-bece-ec84ac2cfa58

Issue: 313719729