### PR TITLE
media: Check low latency capability before enabling

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -481,8 +481,15 @@ class MediaCodecBridge {
 
     if (enableLowLatency) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-        Log.i(TAG, "Enabling low-latency playback.");
-        mediaFormat.setInteger(MediaFormat.KEY_LOW_LATENCY, 1);
+        if (codecCapabilities.isFeatureSupported(CodecCapabilities.FEATURE_LowLatency)) {
+          Log.i(TAG, "Enabling low-latency playback.");
+          mediaFormat.setInteger(MediaFormat.KEY_LOW_LATENCY, 1);
+        } else {
+          Log.w(
+              TAG,
+              "Low-latency playback requested but FEATURE_LowLatency is not supported by "
+                  + decoderName);
+        }
       } else {
         Log.i(
             TAG,


### PR DESCRIPTION
Query CodecCapabilities.FEATURE_LowLatency before setting MediaFormat.KEY_LOW_LATENCY to 1. This prevents passing unsupported configurations to decoders on devices that don't support low latency playback.

Bug: 305091565