### PR TITLE
android: Prevent stale timestamp latching on flush

### DIFF
--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -279,6 +279,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       // flush. This avoids using a stale value from before the reset, which
       // could lead to incorrect frame consumption calculations.
       last_playback_head_position = -1;
+      is_flushed_ = true;
       flush_requested_ = false;
       continue;
     }
@@ -301,9 +302,14 @@ void AudioTrackAudioSink::AudioThreadFunc() {
     // player updates playback head positions when |audio_track_| doesn't stop.
     audio_track_play_state = audio_track_->GetPlayState();
 
+    if (audio_track_play_state == AudioTrack::PlayState::kPlaying) {
+      is_flushed_ = false;
+    }
+
     bool should_update_media_time =
         (audio_track_play_state == AudioTrack::PlayState::kPlaying ||
-         audio_track_play_state == AudioTrack::PlayState::kPaused);
+         (audio_track_play_state == AudioTrack::PlayState::kPaused &&
+          !is_flushed_));
     if (should_update_media_time) {
       playback_head_position =
           audio_track_->GetAudioTimestamp(&frames_consumed_at);

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -189,6 +189,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
 
   volatile bool quit_ = false;
   std::atomic_bool flush_requested_{false};
+  std::atomic_bool is_flushed_{false};
   // Guaranteed to be non-null.
   const std::unique_ptr<Thread> audio_out_thread_;
 

--- a/starboard/android/shared/audio_track_audio_sink_type_test.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type_test.cc
@@ -148,5 +148,58 @@ TEST_F(AudioTrackAudioSinkTest, PauseAndResumePlayback) {
   EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
 }
 
+TEST_F(AudioTrackAudioSinkTest, FlushAndResumePlayback) {
+  AudioTrackAudioSinkType type;
+  auto fake_track = std::make_unique<FakeAudioTrack>(
+      2, 48000, kSbMediaAudioSampleTypeFloat32);
+  FakeAudioTrack* track_ptr = fake_track.get();
+
+  AudioTrackAudioSinkType::Callbacks callbacks{
+      UpdateSourceStatusCB,
+      ConsumeFramesCB,
+      /*error=*/nullptr,
+  };
+
+  auto sink = AudioTrackAudioSink::CreateForTesting(
+      &type, 2, 48000, kSbMediaAudioSampleTypeFloat32, frame_buffers_, 1024,
+      512, callbacks, 0,
+      /*tunnel_mode_audio_session_id=*/std::nullopt,
+      /*allow_audio_writing_on_pause=*/false, std::move(fake_track), this);
+
+  ASSERT_NE(sink, nullptr);
+  int elapsed_ms = 0;
+  while (track_ptr->play_state() != AudioTrack::PlayState::kPlaying &&
+         elapsed_ms < 1000) {
+    usleep(10'000);
+    elapsed_ms += 10;
+  }
+  EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
+
+  // Pause source status and trigger flush during seek reset.
+  is_playing_ = false;
+  EXPECT_TRUE(sink->Flush());
+
+  // Wait for sink thread to process flush and transition to paused state.
+  elapsed_ms = 0;
+  while (track_ptr->play_state() != AudioTrack::PlayState::kStopped &&
+         track_ptr->play_state() != AudioTrack::PlayState::kPaused &&
+         elapsed_ms < 1000) {
+    usleep(10'000);
+    elapsed_ms += 10;
+  }
+  EXPECT_TRUE(track_ptr->play_state() == AudioTrack::PlayState::kStopped ||
+              track_ptr->play_state() == AudioTrack::PlayState::kPaused);
+
+  // Resume playback.
+  is_playing_ = true;
+  elapsed_ms = 0;
+  while (track_ptr->play_state() != AudioTrack::PlayState::kPlaying &&
+         elapsed_ms < 1000) {
+    usleep(10'000);
+    elapsed_ms += 10;
+  }
+  EXPECT_EQ(track_ptr->play_state(), AudioTrack::PlayState::kPlaying);
+}
+
 }  // namespace
 }  // namespace starboard


### PR DESCRIPTION
Prevent the audio sink from updating media time using stale timestamps
when the AudioTrack is paused immediately following a flush. This
scenario typically occurs during seek operations. By ensuring stale
values from before the reset are not latched, the sink avoids
incorrectly calculating frame consumption.

Issue: 330793785