### PR TITLE
starboard: Consolidate EndsWith into common/string.h

### DIFF
--- a/starboard/android/shared/media_capabilities_cache.cc
+++ b/starboard/android/shared/media_capabilities_cache.cc
@@ -29,6 +29,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/common/once.h"
+#include "starboard/common/string.h"
 #include "starboard/shared/starboard/features.h"
 #include "starboard/shared/starboard/media/key_system_supportability_cache.h"
 #include "starboard/shared/starboard/media/mime_supportability_cache.h"
@@ -53,14 +54,6 @@ const jint HDR_TYPE_HLG = 3;
 const jint HDR_TYPE_HDR10_PLUS = 4;
 
 const char SECURE_DECODER_SUFFIX[] = ".secure";
-
-bool EndsWith(const std::string& str, const std::string& suffix) {
-  if (str.size() < suffix.size()) {
-    return false;
-  }
-  return strcmp(str.c_str() + (str.size() - suffix.size()), suffix.c_str()) ==
-         0;
-}
 
 Range ConvertJavaRangeToRange(JNIEnv* env, jobject j_range) {
   const auto j_range_ref = JavaParamRef<jobject>(env, j_range);

--- a/starboard/common/string.h
+++ b/starboard/common/string.h
@@ -28,6 +28,7 @@
 #include <optional>
 #include <sstream>
 #include <string>
+#include <string_view>
 #include <vector>
 
 #include "starboard/configuration.h"
@@ -145,6 +146,12 @@ inline std::vector<std::string> SplitString(const std::string& input,
   }
 
   return output;
+}
+
+// Returns true if `str` ends with `suffix`.
+inline bool EndsWith(std::string_view str, std::string_view suffix) {
+  return str.size() >= suffix.size() &&
+         str.compare(str.size() - suffix.size(), suffix.size(), suffix) == 0;
 }
 
 }  // namespace starboard

--- a/starboard/elf_loader/elf_loader_impl.cc
+++ b/starboard/elf_loader/elf_loader_impl.cc
@@ -18,6 +18,7 @@
 #include <string>
 
 #include "starboard/common/log.h"
+#include "starboard/common/string.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/elf_loader/elf.h"
 #include "starboard/elf_loader/elf_loader_constants.h"
@@ -30,17 +31,6 @@
 #include "starboard/system.h"
 
 namespace elf_loader {
-
-namespace {
-
-bool EndsWith(const std::string& s, const std::string& suffix) {
-  if (s.size() < suffix.size()) {
-    return false;
-  }
-  return strcmp(s.c_str() + (s.size() - suffix.size()), suffix.c_str()) == 0;
-}
-
-}  // namespace
 
 ElfLoaderImpl::ElfLoaderImpl() {
   SB_CHECK(kSbCanMapExecutableMemory)
@@ -57,11 +47,12 @@ bool ElfLoaderImpl::Load(const char* name,
   }
 
   std::unique_ptr<File> elf_file;
-  if (compression_type == CompressionType::kLz4 && EndsWith(name, kLz4Suffix)) {
+  if (compression_type == CompressionType::kLz4 &&
+      starboard::EndsWith(name, kLz4Suffix)) {
     elf_file.reset(new LZ4FileImpl());
     SB_LOG(INFO) << "Loading " << name << " using LZ4 decompression";
   } else if (compression_type == CompressionType::kZstd &&
-             EndsWith(name, kZstdSuffix)) {
+             starboard::EndsWith(name, kZstdSuffix)) {
     elf_file.reset(new ZstdFileImpl());
     SB_LOG(INFO) << "Loading " << name << " using Zstd decompression";
   } else {

--- a/starboard/loader_app/app_key_files.cc
+++ b/starboard/loader_app/app_key_files.cc
@@ -74,15 +74,6 @@ bool CreateAppKeyFile(const std::string& file_name_path) {
   return true;
 }
 
-namespace {
-bool EndsWith(const std::string& s, const std::string& suffix) {
-  if (s.size() < suffix.size()) {
-    return false;
-  }
-  return strcmp(s.c_str() + (s.size() - suffix.size()), suffix.c_str()) == 0;
-}
-}  // namespace
-
 bool AnyGoodAppKeyFile(const std::string& dir) {
   DIR* directory = opendir(dir.c_str());
 
@@ -111,7 +102,7 @@ bool AnyGoodAppKeyFile(const std::string& dir) {
     starboard::strlcpy(filename.data(), dirent->d_name, filename.size());
 
     if (!strncmp(kFilePrefix, filename.data(), sizeof(kFilePrefix) - 1) &&
-        EndsWith(filename.data(), kGoodFileSuffix)) {
+        starboard::EndsWith(filename.data(), kGoodFileSuffix)) {
       found = true;
       break;
     }


### PR DESCRIPTION
Consolidate multiple `EndsWith` helpers into a single `starboard::EndsWith` in
starboard/common/string.h.

Bug: 495203133