### PR TITLE
cobalt: Prefer bundle's YTApplicationURL to switches::kDefaultURL

### DIFF
--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -153,6 +153,10 @@ source_set("switches") {
     "//base",
     "//cobalt/shell:cobalt_shell_switches",
   ]
+
+  if (is_ios) {
+    deps += [ "//cobalt/browser/tvos:bundle_data" ]
+  }
 }
 
 source_set("global_features") {

--- a/cobalt/browser/switches.cc
+++ b/cobalt/browser/switches.cc
@@ -14,15 +14,31 @@
 
 #include "cobalt/browser/switches.h"
 
+#include "build/build_config.h"
 #include "cobalt/shell/common/shell_switches.h"
+
+#if BUILDFLAG(IS_IOS_TVOS)
+#include "cobalt/browser/tvos/bundle_data.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace cobalt {
 namespace switches {
 
 std::string GetInitialURL(const base::CommandLine& command_line) {
+  // The order of preference is as follows:
+  // 1. --url's value if specified
+  // 2. (tvOS-specific) YTApplicationURL from Info.plist if specified
+  // 3. ::switches::kDefaultURL
   if (command_line.HasSwitch(kInitialURL)) {
     return command_line.GetSwitchValueASCII(kInitialURL);
   }
+#if BUILDFLAG(IS_IOS_TVOS)
+  const auto yt_application_url =
+      BundleData::GetValueFromPlistAsString("YTApplicationURL");
+  if (yt_application_url.has_value()) {
+    return *yt_application_url;
+  }
+#endif  // BUILDFLAG(IS_IOS_TVOS)
   return ::switches::kDefaultURL;
 }
 

--- a/cobalt/browser/switches.cc
+++ b/cobalt/browser/switches.cc
@@ -33,8 +33,7 @@ std::string GetInitialURL(const base::CommandLine& command_line) {
     return command_line.GetSwitchValueASCII(kInitialURL);
   }
 #if BUILDFLAG(IS_IOS_TVOS)
-  const auto yt_application_url =
-      BundleData::GetValueFromPlistAsString("YTApplicationURL");
+  const auto yt_application_url = GetValueFromPlistAsString("YTApplicationURL");
   if (yt_application_url.has_value()) {
     return *yt_application_url;
   }

--- a/cobalt/browser/tvos/BUILD.gn
+++ b/cobalt/browser/tvos/BUILD.gn
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source_set("bundle_data") {
+  sources = [
+    "bundle_data.h",
+    "bundle_data.mm",
+  ]
+  deps = [ "//base" ]
+  frameworks = [ "Foundation.framework" ]
+}
+
 source_set("deep_link_support_tvos") {
   sources = [
     "deep_link_support_tvos.h",

--- a/cobalt/browser/tvos/bundle_data.h
+++ b/cobalt/browser/tvos/bundle_data.h
@@ -21,14 +21,10 @@
 
 namespace cobalt {
 
-class BundleData final {
- public:
-  // Retrieves a given value from the main bundle's Info.plist and returns it as
-  // an std::string if it exists and can be converted to an NSString*. Returns
-  // std::nullopt otherwise.
-  static std::optional<std::string> GetValueFromPlistAsString(
-      std::string_view key_name);
-};
+// Retrieves a given value from the main bundle's Info.plist and returns it as
+// an std::string if it exists and can be converted to an NSString*. Returns
+// std::nullopt otherwise.
+std::optional<std::string> GetValueFromPlistAsString(std::string_view key_name);
 
 }  // namespace cobalt
 

--- a/cobalt/browser/tvos/bundle_data.h
+++ b/cobalt/browser/tvos/bundle_data.h
@@ -1,0 +1,35 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_TVOS_BUNDLE_DATA_H_
+#define COBALT_BROWSER_TVOS_BUNDLE_DATA_H_
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace cobalt {
+
+class BundleData final {
+ public:
+  // Retrieves a given value from the main bundle's Info.plist and returns it as
+  // an std::string if it exists and can be converted to an NSString*. Returns
+  // std::nullopt otherwise.
+  static std::optional<std::string> GetValueFromPlistAsString(
+      std::string_view key_name);
+};
+
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_TVOS_BUNDLE_DATA_H_

--- a/cobalt/browser/tvos/bundle_data.mm
+++ b/cobalt/browser/tvos/bundle_data.mm
@@ -21,8 +21,7 @@
 
 namespace cobalt {
 
-// static
-std::optional<std::string> BundleData::GetValueFromPlistAsString(
+std::optional<std::string> GetValueFromPlistAsString(
     std::string_view key_name) {
   NSString* keyName = base::SysUTF8ToNSString(key_name);
   NSString* keyValue = base::apple::ObjCCast<NSString>(

--- a/cobalt/browser/tvos/bundle_data.mm
+++ b/cobalt/browser/tvos/bundle_data.mm
@@ -1,0 +1,36 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/tvos/bundle_data.h"
+
+#import <Foundation/Foundation.h>
+
+#include "base/apple/foundation_util.h"
+#include "base/strings/sys_string_conversions.h"
+
+namespace cobalt {
+
+// static
+std::optional<std::string> BundleData::GetValueFromPlistAsString(
+    std::string_view key_name) {
+  NSString* keyName = base::SysUTF8ToNSString(key_name);
+  NSString* keyValue = base::apple::ObjCCast<NSString>(
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:keyName]);
+  if (!keyValue) {
+    return std::nullopt;
+  }
+  return base::SysNSStringToUTF8(keyValue);
+}
+
+}  // namespace cobalt


### PR DESCRIPTION
This is apparently needed by the production build. Instead of only checking the --url argument and the first non-switch argument when deciding which URL to load, the order on tvOS is now:

1. A URL specified as a non-switch argument, if any
2. --url's value when set
3. YTApplicationURL from Info.plist when set
4. switches::kDefaultURL

Fixed: 535335075