### PR TITLE
Add cobalt_shell.pak to loader_app data_deps

### DIFF
--- a/starboard/loader_app/BUILD.gn
+++ b/starboard/loader_app/BUILD.gn
@@ -71,7 +71,10 @@ if (is_starboard && current_toolchain == starboard_toolchain) {
     output_dir = root_build_dir
     if (target_cpu == "x64" || target_cpu == "arm" || target_cpu == "arm64") {
       deps = [ ":loader_app_sources" ]
-      data_deps = [ "//starboard/content/fonts:copy_font_data" ]
+      data_deps = [
+        "//cobalt/shell:pak",
+        "//starboard/content/fonts:copy_font_data",
+      ]
     }
   }
 } else {


### PR DESCRIPTION
Add //cobalt/shell:pak to data_deps of loader_app target in starboard/loader_app/BUILD.gn so that building loader_app automatically generates cobalt_shell.pak under root_build_dir for Cobalt 27 Evergreen deployment.

Bug: 532320452