### PR TITLE
Load SSL root certificates to avoid runtime wipe crashes

### DIFF
--- a/net/cert/internal/trust_store_in_memory_starboard.cc
+++ b/net/cert/internal/trust_store_in_memory_starboard.cc
@@ -16,19 +16,16 @@
 
 #include <dirent.h>
 
-#include "base/files/file.h"
 #include "base/files/file_path.h"
+#include "base/files/file_util.h"
 #include "base/logging.h"
 #include "base/notreached.h"
 #include "base/path_service.h"
 #include "base/time/time.h"
-#include "net/cert/internal/trust_store_in_memory_starboard.h"
 #include "net/cert/x509_certificate.h"
 #include "net/cert/x509_util.h"
 #include "starboard/common/string.h"
 #include "starboard/configuration_constants.h"
-#include "third_party/boringssl/src/include/openssl/digest.h"
-#include "third_party/boringssl/src/include/openssl/sha.h"
 #include "third_party/boringssl/src/include/openssl/x509.h"
 #include "third_party/boringssl/src/pki/cert_errors.h"
 #include "third_party/boringssl/src/pki/pem.h"
@@ -36,30 +33,11 @@
 namespace net {
 
 namespace {
-// PEM encoded DER cert is usually around or less than 2000 bytes long.
-const short kCertBufferSize = 8 * 1024;
 // Each certificate file name is 8 bit hash + ".0" suffix.
 const short kCertFileNameLength = 10;
 const char kCertificateHeader[] = "CERTIFICATE";
 const char kSSLDirName[] = "ssl";
 const char kCertsDirName[] = "certs";
-
-// Essentially an X509_NAME_hash without using X509_NAME. We did not use the
-// boringSSL function directly because net does not store certs with X509
-// struct anymore and converting binary certs to X509_NAME is slightly
-// expensive.
-unsigned long CertNameHash(const void* data, size_t length) {
-  unsigned long ret = 0;
-  unsigned char md[SHA_DIGEST_LENGTH];
-  if (!EVP_Digest(data, length, md, NULL, EVP_sha1(), NULL)) {
-    return 0;
-  }
-
-  ret = (((unsigned long)md[0]) | ((unsigned long)md[1] << 8L) |
-         ((unsigned long)md[2] << 16L) | ((unsigned long)md[3] << 24L)) &
-        0xffffffffL;
-  return ret;
-}
 
 base::FilePath GetCertificateDirPath() {
   base::FilePath cert_path;
@@ -68,7 +46,7 @@ base::FilePath GetCertificateDirPath() {
   return cert_path;
 }
 
-std::unordered_set<std::string> GetCertNamesOnDisk() {
+std::vector<std::shared_ptr<const bssl::ParsedCertificate>> GetAllCertsOnDisk() {
   DIR* sb_certs_directory = opendir(GetCertificateDirPath().value().c_str());
   if (!sb_certs_directory) {
 // Unit tests, for example, do not use production certificates.
@@ -78,9 +56,10 @@ std::unordered_set<std::string> GetCertNamesOnDisk() {
     DLOG(WARNING) << "ssl/certs directory is not valid, no root certificates"
                      " will be loaded";
 #endif
-    return std::unordered_set<std::string>();
+    return {};
   }
-  std::unordered_set<std::string> trusted_certs_on_disk;
+  
+  std::vector<std::shared_ptr<const bssl::ParsedCertificate>> certs;
   std::vector<char> dir_entry(kSbFileMaxName);
 
   struct dirent dirent_buffer;
@@ -102,103 +81,57 @@ std::unordered_set<std::string> GetCertNamesOnDisk() {
     if (strlen(dir_entry.data()) != kCertFileNameLength) {
       continue;
     }
-    trusted_certs_on_disk.emplace(dir_entry.data());
+    
+    base::FilePath cert_path = GetCertificateDirPath().Append(dir_entry.data());
+    std::string cert_buffer;
+    if (!base::ReadFileToString(cert_path, &cert_buffer)) {
+      DLOG(ERROR) << "Failed to read cert file: " << cert_path;
+      continue;
+    }
+    bssl::PEMTokenizer pem_tokenizer(cert_buffer, {kCertificateHeader});
+    if (!pem_tokenizer.GetNext()) {
+      DLOG(ERROR) << "Failed to parse PEM from cert file: " << cert_path;
+      continue;
+    }
+    std::string decoded(pem_tokenizer.data());
+    auto crypto_buffer = x509_util::CreateCryptoBuffer(decoded);
+    if (!crypto_buffer) {
+      DLOG(ERROR) << "Failed to create crypto buffer for " << cert_path;
+      continue;
+    }
+    bssl::CertErrors errors;
+    auto parsed = bssl::ParsedCertificate::Create(
+        std::move(crypto_buffer), x509_util::DefaultParseCertificateOptions(),
+        &errors);
+    if (!parsed) {
+      LOG(ERROR) << "Failed to parse certificate " << cert_path << ": "
+                 << errors.ToDebugString();
+    } else {
+      certs.push_back(parsed);
+    }
   }
   closedir(sb_certs_directory);
-  return trusted_certs_on_disk;
+  return certs;
 }
 }  // namespace
 
-std::shared_ptr<const bssl::ParsedCertificate>
-TrustStoreInMemoryStarboard::TryLoadCert(std::string_view cert_name) const {
-  auto hash = CertNameHash(cert_name.data(), cert_name.length());
-  char cert_file_name[256];
-  snprintf(cert_file_name, 256, "%08lx.%d", hash, 0);
-
-  if (trusted_cert_names_on_disk_.find(cert_file_name) ==
-      trusted_cert_names_on_disk_.end()) {
-    // The requested certificate is not found.
-    return nullptr;
+TrustStoreInMemoryStarboard::TrustStoreInMemoryStarboard() {
+  for (const auto& cert : GetAllCertsOnDisk()) {
+    underlying_trust_store_.AddTrustAnchor(cert);
   }
-
-  char cert_buffer[kCertBufferSize];
-  base::FilePath cert_path = GetCertificateDirPath().Append(cert_file_name);
-  base::File cert_file(
-      cert_path, base::File::Flags::FLAG_OPEN | base::File::Flags::FLAG_READ);
-  // The file was in certs directory when we iterated the directory at startup,
-  // opening it should not fail.
-  if (!cert_file.IsValid()) {
-    DLOG(ERROR) << "Failed to open cert file: " << cert_path;
-    return nullptr;
-  }
-  int cert_size = cert_file.ReadAtCurrentPos(cert_buffer, kCertBufferSize);
-  if (cert_size < 0) {
-    DLOG(ERROR) << "Failed to read cert file: " << cert_path;
-    return nullptr;
-  }
-  bssl::PEMTokenizer pem_tokenizer(std::string_view(cert_buffer, cert_size),
-                                   {kCertificateHeader});
-  if (!pem_tokenizer.GetNext()) {
-    DLOG(ERROR) << "Failed to parse PEM from cert file: " << cert_path;
-    return nullptr;
-  }
-  std::string decoded(pem_tokenizer.data());
-  auto crypto_buffer = x509_util::CreateCryptoBuffer(decoded);
-  if (!crypto_buffer) {
-    DLOG(ERROR) << "Failed to create crypto buffer for " << cert_path;
-    return nullptr;
-  }
-  bssl::CertErrors errors;
-  auto parsed = bssl::ParsedCertificate::Create(
-      std::move(crypto_buffer), x509_util::DefaultParseCertificateOptions(),
-      &errors);
-  if (!parsed) {
-    LOG(ERROR) << "Failed to parse certificate " << cert_path << ": "
-               << errors.ToDebugString();
-  }
-  return parsed;
 }
-
-TrustStoreInMemoryStarboard::TrustStoreInMemoryStarboard()
-    : trusted_cert_names_on_disk_(GetCertNamesOnDisk()) {}
 
 TrustStoreInMemoryStarboard::~TrustStoreInMemoryStarboard() = default;
 
 void TrustStoreInMemoryStarboard::SyncGetIssuersOf(
     const bssl::ParsedCertificate* cert,
     bssl::ParsedCertificateList* issuers) {
-  DCHECK(issuers);
-  DCHECK(issuers->empty());
-  base::AutoLock scoped_lock(load_mutex_);
-  // Look up the request certificate first in the trust store in memory.
   underlying_trust_store_.SyncGetIssuersOf(cert, issuers);
-  if (issuers->empty()) {
-    // If the requested certificate is not found, compute certificate hash name
-    // and see if the certificate is stored on disk.
-    auto parsed_cert = TryLoadCert(cert->normalized_issuer().AsStringView());
-    if (parsed_cert.get()) {
-      issuers->push_back(parsed_cert);
-      underlying_trust_store_.AddTrustAnchor(parsed_cert);
-    }
-  }
 }
 
 bssl::CertificateTrust TrustStoreInMemoryStarboard::GetTrust(
     const bssl::ParsedCertificate* cert) {
-  base::AutoLock scoped_lock(load_mutex_);
-  // Loop up the request certificate first in the trust store in memory.
-  bssl::CertificateTrust trust = underlying_trust_store_.GetTrust(cert);
-  if (trust.HasUnspecifiedTrust()) {
-    // If the requested certificate is not found, compute certificate hash name
-    // and see if the certificate is stored on disk.
-    auto parsed_cert = TryLoadCert(cert->normalized_subject().AsStringView());
-    if (parsed_cert.get()) {
-      trust = bssl::CertificateTrust::ForTrustAnchor();
-      const_cast<TrustStoreInMemoryStarboard*>(this)
-          ->underlying_trust_store_.AddTrustAnchor(parsed_cert);
-    }
-  }
-  return trust;
+  return underlying_trust_store_.GetTrust(cert);
 }
 
 std::vector<net::PlatformTrustStore::CertWithTrust>

--- a/net/cert/internal/trust_store_in_memory_starboard.cc
+++ b/net/cert/internal/trust_store_in_memory_starboard.cc
@@ -110,8 +110,7 @@ std::unordered_set<std::string> GetCertNamesOnDisk() {
 }  // namespace
 
 std::shared_ptr<const bssl::ParsedCertificate>
-TrustStoreInMemoryStarboard::TryLoadCert(
-    const std::string_view& cert_name) const {
+TrustStoreInMemoryStarboard::TryLoadCert(std::string_view cert_name) const {
   auto hash = CertNameHash(cert_name.data(), cert_name.length());
   char cert_file_name[256];
   snprintf(cert_file_name, 256, "%08lx.%d", hash, 0);
@@ -129,20 +128,34 @@ TrustStoreInMemoryStarboard::TryLoadCert(
   // The file was in certs directory when we iterated the directory at startup,
   // opening it should not fail.
   if (!cert_file.IsValid()) {
-    NOTREACHED() << "ssl/certs/" << cert_path << " failed to open.";
+    DLOG(ERROR) << "Failed to open cert file: " << cert_path;
+    return nullptr;
   }
   int cert_size = cert_file.ReadAtCurrentPos(cert_buffer, kCertBufferSize);
+  if (cert_size < 0) {
+    DLOG(ERROR) << "Failed to read cert file: " << cert_path;
+    return nullptr;
+  }
   bssl::PEMTokenizer pem_tokenizer(std::string_view(cert_buffer, cert_size),
                                    {kCertificateHeader});
-  pem_tokenizer.GetNext();
+  if (!pem_tokenizer.GetNext()) {
+    DLOG(ERROR) << "Failed to parse PEM from cert file: " << cert_path;
+    return nullptr;
+  }
   std::string decoded(pem_tokenizer.data());
-  DCHECK(!pem_tokenizer.GetNext());
   auto crypto_buffer = x509_util::CreateCryptoBuffer(decoded);
+  if (!crypto_buffer) {
+    DLOG(ERROR) << "Failed to create crypto buffer for " << cert_path;
+    return nullptr;
+  }
   bssl::CertErrors errors;
   auto parsed = bssl::ParsedCertificate::Create(
       std::move(crypto_buffer), x509_util::DefaultParseCertificateOptions(),
       &errors);
-  CHECK(parsed) << errors.ToDebugString();
+  if (!parsed) {
+    LOG(ERROR) << "Failed to parse certificate " << cert_path << ": "
+               << errors.ToDebugString();
+  }
   return parsed;
 }
 

--- a/net/cert/internal/trust_store_in_memory_starboard.h
+++ b/net/cert/internal/trust_store_in_memory_starboard.h
@@ -24,7 +24,7 @@
 
 namespace net {
 
-// Wrapper around TrustStoreInMemory to lazily load trusted root certificates.
+// Wrapper around TrustStoreInMemory to eagerly load trusted root certificates.
 class NET_EXPORT TrustStoreInMemoryStarboard : public PlatformTrustStore {
  public:
   TrustStoreInMemoryStarboard();
@@ -45,25 +45,11 @@ class NET_EXPORT TrustStoreInMemoryStarboard : public PlatformTrustStore {
   // Returns true if the trust store contains the given ParsedCertificate
   // (matches by DER).
   bool Contains(const bssl::ParsedCertificate* cert) const {
-    base::AutoLock scoped_lock(load_mutex_);
     return underlying_trust_store_.Contains(cert);
   }
 
  private:
   bssl::TrustStoreInMemory underlying_trust_store_;
-
-  // Given a certificate's canonical name, try to load this cert from trusted
-  // certs on disk if it is found.
-  std::shared_ptr<const bssl::ParsedCertificate> TryLoadCert(
-      std::string_view cert_name) const;
-
-  // The memory trust store can be accessed by multiple threads, in Chromium,
-  // the synchronization issue is solved by initializing trust store at startup
-  // and passing constant reference to consumers. Cobalt loads certs lazily and
-  // therefore guards the underlying_trust_store_ with mutex.
-  mutable base::Lock load_mutex_;
-
-  const std::unordered_set<std::string> trusted_cert_names_on_disk_;
 };
 
 }  // namespace net

--- a/net/cert/internal/trust_store_in_memory_starboard.h
+++ b/net/cert/internal/trust_store_in_memory_starboard.h
@@ -55,7 +55,7 @@ class NET_EXPORT TrustStoreInMemoryStarboard : public PlatformTrustStore {
   // Given a certificate's canonical name, try to load this cert from trusted
   // certs on disk if it is found.
   std::shared_ptr<const bssl::ParsedCertificate> TryLoadCert(
-      const std::string_view& cert_name) const;
+      std::string_view cert_name) const;
 
   // The memory trust store can be accessed by multiple threads, in Chromium,
   // the synchronization issue is solved by initializing trust store at startup


### PR DESCRIPTION
This pull request loads the SSL root certificates at startup directly into the bssl trust store. It also safely guards TryLoadCert against triggering NOTREACHED() if a certificate file fails to load at runtime.

This is a new issue with C26/C27 because we switched to 2-slot, one system image, and one installation slot. When the app is updated from system image and runs the package from the installation slot, right before it downloads an update, it'll wipe the installation slot including its own certs, which caused the issue. But before C26, there're 3 slots in total, and the updater doesn't wipe its own slot.

On the other hand, the core content (cobalt_shell.pak) and UI fonts (SkFileMemoryChunkStream) are safe from this wipe because they use base::MemoryMappedFile and hold a persistent FILE* handle, which the OS honors natively.

Issue: 535681824
Issue: 533843031