### PR TITLE
tvOS: Remove extra debugging calls from shell_platform_delegate_ios.mm

### DIFF
--- a/cobalt/shell/browser/shell_platform_delegate_ios.mm
+++ b/cobalt/shell/browser/shell_platform_delegate_ios.mm
@@ -800,12 +800,10 @@ const char kAllTracingCategories[] = "*";
 #pragma mark - CobaltSearchResultsControllerFocusDelegate
 
 - (void)resultsDidLoseFocus {
-  LOG(ERROR) << __func__;
   [_platformOnScreenKeyboardDelegate keyboardFocused];
 }
 
 - (void)resultsDidReceiveFocus {
-  LOG(ERROR) << __func__;
   [_platformOnScreenKeyboardDelegate keyboardBlurred];
 }
 
@@ -844,7 +842,6 @@ const char kAllTracingCategories[] = "*";
           return;
         }
         searchResultLastString = searchString;
-        LOG(ERROR) << __func__;
         [weakDelegate keyboardTextChanged:[searchString copy]];
       });
 }


### PR DESCRIPTION
These extra `LOG()` calls were erroneously added in #10466 and are not necessary.

Bug: 507159713