### PR TITLE
cobalt: Load empty URL in SplashScreenTest.PreloadSkipsSplashScreen

### DIFF
--- a/cobalt/shell/browser/splash_screen_unittest.cc
+++ b/cobalt/shell/browser/splash_screen_unittest.cc
@@ -400,9 +400,9 @@ TEST_F(SplashScreenTest, PreloadSkipsSplashScreen) {
   InitializeShell(false /* is_visible */);
 
   // Attempt to create a window with a splash screen requested.
-  Shell* shell = Shell::CreateNewWindow(
-      browser_context(), GURL("about:blank"), nullptr, gfx::Size(),
-      true /* create_splash_screen_web_contents */);
+  Shell* shell =
+      Shell::CreateNewWindow(browser_context(), GURL(), nullptr, gfx::Size(),
+                             true /* create_splash_screen_web_contents */);
 
   // Verify that the main contents exist but the splash screen was skipped.
   ASSERT_NE(shell->web_contents(), nullptr);


### PR DESCRIPTION
Instead of creating a new window with "about:blank", pass an empty GURL object to `Shell::CreateNewWindow()` instead.

Passing a non-empty URL causes `CreateNewWindow()` to call `LoadURL()`, which ultimately calls a number of `ShellPlatformDelegate` methods on tvOS that are not mocked (or even virtual). Since the actual URL here is not relevant, just pass an empty GURL to avoid having `LoadURL()` be called altogether.

This fixes a cobalt_unittests failure on tvOS.

Bug: 447660888
Bug: 535573341