### PR TITLE
Pass Java exception details to JS in PlatformService

### DIFF
--- a/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
+++ b/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
@@ -151,14 +151,21 @@ void PlatformServiceImpl::Send(base::span<const uint8_t> data,
                                       &invalid_state)));
 
   if (invalid_state) {
-    LOG(ERROR) << "Send failed: Starboard service in invalid state for "
-               << service_name_;
-    std::move(callback).Run(std::nullopt);  // Signal error to renderer
+    std::string error_message = "Starboard service in invalid state";
+    if (output_length > 0 && response_ptr) {
+      error_message = std::string(
+          reinterpret_cast<char*>(response_ptr.get()),
+          base::checked_cast<size_t>(output_length));
+    }
+    LOG(ERROR) << "Send failed: " << error_message << " for " << service_name_;
+    std::move(callback).Run(std::nullopt, error_message);
     return;
   }
 
-  std::move(callback).Run(base::span<const uint8_t>(
-      response_ptr.get(), base::checked_cast<size_t>(output_length)));
+  std::move(callback).Run(
+      base::span<const uint8_t>(response_ptr.get(),
+                                base::checked_cast<size_t>(output_length)),
+      std::nullopt);
 }
 
 void PlatformServiceImpl::OnDataReceivedFromStarboard(

--- a/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
+++ b/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
@@ -138,7 +138,8 @@ void PlatformServiceImpl::Send(base::span<const uint8_t> data,
   if (!api) {
     LOG(WARNING) << "The platform service extension is not implemented on this "
                  << "platform";
-    std::move(callback).Run(std::nullopt);  // Signal error to renderer
+    std::move(callback).Run(std::nullopt,
+                            "Platform service extension not implemented");
     return;
   }
 

--- a/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
+++ b/cobalt/browser/h5vcc_platform_service/platform_service_impl.cc
@@ -154,9 +154,8 @@ void PlatformServiceImpl::Send(base::span<const uint8_t> data,
   if (invalid_state) {
     std::string error_message = "Starboard service in invalid state";
     if (output_length > 0 && response_ptr) {
-      error_message = std::string(
-          reinterpret_cast<char*>(response_ptr.get()),
-          base::checked_cast<size_t>(output_length));
+      error_message = std::string(reinterpret_cast<char*>(response_ptr.get()),
+                                  base::checked_cast<size_t>(output_length));
     }
     LOG(ERROR) << "Send failed: " << error_message << " for " << service_name_;
     std::move(callback).Run(std::nullopt, error_message);

--- a/cobalt/browser/h5vcc_platform_service/public/mojom/h5vcc_platform_service.mojom
+++ b/cobalt/browser/h5vcc_platform_service/public/mojom/h5vcc_platform_service.mojom
@@ -45,7 +45,7 @@ interface PlatformService {
   // efficient transport, as the data and response data could be large.
   [Sync]
   Send(mojo_base.mojom.ReadOnlyBuffer data)
-      => (mojo_base.mojom.ReadOnlyBuffer? response_data);
+      => (mojo_base.mojom.ReadOnlyBuffer? response_data, string? error_message);
 };
 
 // Interface implemented by the renderer-side H5vccPlatformService to receive

--- a/starboard/android/shared/platform_service.cc
+++ b/starboard/android/shared/platform_service.cc
@@ -60,8 +60,10 @@ starboard::ResponseToClientInfo FromJniType<starboard::ResponseToClientInfo>(
     const JavaRef<jobject>& j_response) {
   starboard::ResponseToClientInfo info;
   if (base::android::HasException(env)) {
-    jni_zero::ScopedJavaLocalRef<jthrowable> throwable(
-        env, env->ExceptionOccurred());
+    jthrowable raw_throwable =
+        static_cast<jthrowable>(env->ExceptionOccurred());
+    auto throwable =
+        jni_zero::ScopedJavaLocalRef<jthrowable>::Adopt(env, raw_throwable);
     base::android::ClearException(env);
     std::string exception_info =
         base::android::GetJavaExceptionInfo(env, throwable);

--- a/starboard/android/shared/platform_service.cc
+++ b/starboard/android/shared/platform_service.cc
@@ -17,6 +17,7 @@
 #include <memory>
 #include <vector>
 
+#include "base/android/jni_android.h"
 #include "base/android/jni_array.h"
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/check_op.h"
@@ -58,6 +59,16 @@ starboard::ResponseToClientInfo FromJniType<starboard::ResponseToClientInfo>(
     JNIEnv* env,
     const JavaRef<jobject>& j_response) {
   starboard::ResponseToClientInfo info;
+  if (base::android::HasException(env)) {
+    jni_zero::ScopedJavaLocalRef<jthrowable> throwable(
+        env, env->ExceptionOccurred());
+    base::android::ClearException(env);
+    std::string exception_info =
+        base::android::GetJavaExceptionInfo(env, throwable);
+    info.data.assign(exception_info.begin(), exception_info.end());
+    info.invalid_state = true;
+    return info;
+  }
   if (!j_response) {
     info.invalid_state = true;
     return info;
@@ -156,10 +167,6 @@ void* Send(CobaltExtensionPlatformService service,
   *invalid_state = response_info.invalid_state;
   *output_length = response_info.data.size();
 
-  if (response_info.invalid_state) {
-    *output_length = 0;
-    return nullptr;
-  }
   if (response_info.data.empty()) {
     *output_length = 0;
     return nullptr;

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
@@ -175,7 +175,7 @@ DOMArrayBuffer* H5vccPlatformService::send(DOMArrayBuffer* data,
   }
 
   if (!response_data.has_value()) {
-    WTF::String msg = error_message.IsNull()
+    WTF::String msg = error_message.IsEmpty()
                           ? "Browser side could not send data to the service."
                           : error_message;
     exception_state.ThrowDOMException(DOMExceptionCode::kInvalidStateError,

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
@@ -159,8 +159,10 @@ DOMArrayBuffer* H5vccPlatformService::send(DOMArrayBuffer* data,
                                              ? data->ByteSpan()
                                              : base::span<const uint8_t>();
   std::optional<base::span<const uint8_t>> response_data;
+  WTF::String error_message;
 
-  bool mojo_result = platform_service_remote_->Send(input_data, &response_data);
+  bool mojo_result = platform_service_remote_->Send(input_data, &response_data,
+                                                    &error_message);
 
   if (!mojo_result) {
     exception_state.ThrowDOMException(DOMExceptionCode::kInvalidStateError,
@@ -173,9 +175,11 @@ DOMArrayBuffer* H5vccPlatformService::send(DOMArrayBuffer* data,
   }
 
   if (!response_data.has_value()) {
-    exception_state.ThrowDOMException(
-        DOMExceptionCode::kInvalidStateError,
-        "Browser side could not send data to the service.");
+    WTF::String msg = error_message.IsNull()
+                          ? "Browser side could not send data to the service."
+                          : error_message;
+    exception_state.ThrowDOMException(DOMExceptionCode::kInvalidStateError,
+                                      msg);
 
     // Since the API is marked [RaisesException] and this error path throws a
     // DOM exception, no value is actually returned to the JavaScript client.

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_platform_service/h_5_vcc_platform_service.cc
@@ -175,7 +175,7 @@ DOMArrayBuffer* H5vccPlatformService::send(DOMArrayBuffer* data,
   }
 
   if (!response_data.has_value()) {
-    WTF::String msg = error_message.IsEmpty()
+    WTF::String msg = error_message.empty()
                           ? "Browser side could not send data to the service."
                           : error_message;
     exception_state.ThrowDOMException(DOMExceptionCode::kInvalidStateError,


### PR DESCRIPTION
Updated PlatformService JNI and Mojo to capture Java exceptions during
receiveFromClient and propagate them back to the renderer process.
The Blink implementation now throws a DOMException containing the Java
exception message and stack trace, enabling better debugging via JS logs.

Bug: 534360029
TAG=agy
CONV=e5bd021a-7b5c-49e6-92df-e3c00a555578