### PR TITLE
ci: Build and run cobalt_unittests on tvOS

### DIFF
--- a/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json
+++ b/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json
@@ -23,5 +23,5 @@
     "target": "cobalt:cobalt_unittests",
     "runs_on": "host",
     "test_type": "gtest"
-  },
+  }
 ]

--- a/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json
+++ b/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json
@@ -18,5 +18,10 @@
     "target": "cobalt/testing/browser_tests:cobalt_browsertests",
     "runs_on": "host",
     "test_type": "browsertest"
-  }
+  },
+  {
+    "target": "cobalt:cobalt_unittests",
+    "runs_on": "host",
+    "test_type": "gtest"
+  },
 ]

--- a/cobalt/testing/filters/tvos-arm64-simulator/cobalt_unittests_filter.json
+++ b/cobalt/testing/filters/tvos-arm64-simulator/cobalt_unittests_filter.json
@@ -1,0 +1,6 @@
+{
+  "comment": "SplashScreenTest.PreloadSkipsSplashScreen depends on PR #11435.",
+  "failing_tests": [
+    "SplashScreenTest.PreloadSkipsSplashScreen"
+  ]
+}


### PR DESCRIPTION
Temporarily skip one of the tests while #11435 (or any other fix) does not land.

Bug: 535573341