### PR TITLE
ci: Remove "executable" lines from tvOS' test_targets.json

### DIFF
--- a/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json
+++ b/cobalt/build/testing/targets/tvos-arm64-simulator/test_targets.json
@@ -4,13 +4,11 @@
   },
   {
     "target": "base:base_perftests",
-    "executable": "out/arm64-simulator_devel/bin/base_perftests",
     "runs_on": "host",
     "test_type": "gtest"
   },
   {
     "target": "base:base_unittests",
-    "executable": "out/arm64-simulator_devel/bin/base_unittests",
     "runs_on": "host",
     "test_type": "gtest"
   },


### PR DESCRIPTION
The files referenced by those entries do not exist, and since #10905 CI invokes the generated targets differently anyway.

Bug: 519669027
Bug: 432823450