### PR TITLE
Add flash_rdk.py script for RDK device flashing

### DIFF
--- a/.agent/skills/cobalt-rdk-deploy/SKILL.md
+++ b/.agent/skills/cobalt-rdk-deploy/SKILL.md
@@ -1,19 +1,20 @@
 ---
 name: cobalt-rdk-deploy
 description: >-
-  Builds, deploys, runs, resets, and inspects logs for Cobalt on RDK devices using deploy_rdk.py. Use when compiling or launching Cobalt, running GTest suites, resetting active display sessions, or fetching journalctl logs from the target RDK box. Don't use for generic Linux, Android, or Raspberry Pi builds.
+  Builds, deploys, runs, resets, and inspects logs for Cobalt on RDK devices using deploy_rdk.py. Also handles flashing RDK system images via flash_rdk.py when explicitly requested. Use when compiling or launching Cobalt, running GTest suites, resetting display sessions, fetching journalctl logs, or flashing RDK boxes. Don't use for generic Linux, Android, or Raspberry Pi builds.
 ---
 
 # Cobalt RDK Deploy Skill
 
-A skill for building, deploying, running, and debugging Cobalt on RDK devices using the `deploy_rdk.py` CLI script.
+A skill for building, deploying, running, and debugging Cobalt on RDK devices using the `deploy_rdk.py` CLI script, and flashing system software using `flash_rdk.py`.
 
 ## Quick Start
 
-Create an alias for the deployment script:
+Create aliases for RDK scripts:
 
 ```bash
 alias deploy_rdk='python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py'
+alias flash_rdk='python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/flash_rdk.py'
 ```
 
 ## Execution Protocol
@@ -27,10 +28,17 @@ alias deploy_rdk='python3 starboard/contrib/rdk/src/third_party/starboard/rdk/ar
 
 3. **Avoid manual device interaction:** Do NOT run raw shell commands (via `adb shell` or `ssh`) directly on the target device to perform pre-flight checks (such as verifying device properties, OS versions, symlinks, or config status). The `deploy_rdk.py` script automatically manages all version checks, configuration switches, display resets, and reboots internally. Trust the script and execute your formulated command directly.
 
-4. **Identify the connection method:**
+4. **Flashing RDK Device System Software:**
+   - If (and ONLY if) the user explicitly asks to flash or update the RDK system image, use `flash_rdk.py`:
+     ```bash
+     flash_rdk --help
+     ```
+   - **IMPORTANT:** Do NOT refer to, mention, or suggest `flash_rdk.py` for general building, deployment, testing, resetting, or debugging tasks unless the user explicitly requests flashing or re-flashing the image / RDK box.
+
+5. **Identify the connection method:**
    - **ADB (Default):** The script defaults to ADB for device interaction.
    - **SSH/SCP:** If you need to target a remote device over SSH, check `--help` for the IP-based configuration flags (e.g., `--device-ip`).
 
-5. **Do NOT use `--no-rbe` by default:** Remote Build Execution (RBE) is enabled by default and must be used for compilation. Only pass the `--no-rbe` flag if RBE build commands fail.
+6. **Do NOT use `--no-rbe` by default:** Remote Build Execution (RBE) is enabled by default and must be used for compilation. Only pass the `--no-rbe` flag if RBE build commands fail.
 
-6. **Assume the toolchain is present:** Do NOT pre-emptively check for the cross-compilation toolchain (do not run `echo $RDK_HOME` or list directories to verify sysroots). Assume it is fully configured and present by default. Only troubleshoot the toolchain or run `--setup-toolchain` if the compilation step (`autoninja`) fails with compiler/toolchain errors, or if the user explicitly requests it.
+7. **Assume the toolchain is present:** Do NOT pre-emptively check for the cross-compilation toolchain (do not run `echo $RDK_HOME` or list directories to verify sysroots). Assume it is fully configured and present by default. Only troubleshoot the toolchain or run `--setup-toolchain` if the compilation step (`autoninja`) fails with compiler/toolchain errors, or if the user explicitly requests it.

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/flash_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/flash_rdk.py
@@ -1,0 +1,195 @@
+#!/usr/bin/env python3
+# Copyright 2026 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""RDK Flashing Script (ADB Prerequisite + USB Flashing).
+
+PREREQUISITES:
+--------------
+1. Connect RDK box via USB-C (OTG/ADB).
+2. Connect serial cable via Micro-USB.
+3. ADB must be working and detect the device ('adb devices' shows device).
+4. Burn tool (adnl_burn_pkg) and upgrade image (.img) downloaded locally.
+
+Usage:
+------
+  python3 flash_rdk.py -t /path/to/adnl_burn_pkg -i /path/to/aml_upgrade_package.img
+"""
+
+import argparse
+import os
+import re
+import shutil
+import subprocess
+import sys
+import time
+
+
+def check_and_reboot_adb():
+  """Checks if device is accessible via ADB and reboots it to update mode."""
+  print("[INFO] Checking for connected ADB devices...")
+  try:
+    result = subprocess.run(
+        ["adb", "devices"], capture_output=True, text=True, check=True
+    )
+  except FileNotFoundError:
+    sys.exit("[ERROR] 'adb' command not found. Please install Android platform tools / adb.")
+  except subprocess.CalledProcessError as e:
+    sys.exit(f"[ERROR] Failed to run 'adb devices': {e}")
+
+  devices = []
+  for line in result.stdout.splitlines()[1:]:
+    parts = line.strip().split()
+    if len(parts) >= 2 and parts[1] == "device":
+      devices.append(parts[0])
+
+  if not devices:
+    print("\n" + "=" * 70)
+    print("[ERROR] No ADB device detected.")
+    print("Prerequisite for flashing: The RDK box MUST be connected and")
+    print("accessible via ADB before flashing.")
+    print("\n>>> If your device is ALREADY in download/adnl mode, rerun with '-s':")
+    print("    python3 flash_rdk.py -s -t <tool_path> -i <image_path>")
+    print("\nOtherwise, please verify:")
+    print("  1. USB-C cable is firmly connected between RDK box and host.")
+    print("  2. The RDK box is powered on.")
+    print("  3. 'adb devices' lists your device.")
+    print("=" * 70 + "\n")
+    sys.exit(1)
+
+  target_dev = devices[0]
+  print(f"[INFO] Detected ADB device: {target_dev}")
+  print("[INFO] Rebooting RDK box into update/download mode via ADB...")
+
+  try:
+    subprocess.run(
+        ["adb", "-s", target_dev, "shell", "reboot", "update", "-f"],
+        capture_output=True,
+        timeout=10,
+    )
+  except Exception:
+    pass
+
+  try:
+    subprocess.run(
+        ["adb", "-s", target_dev, "reboot", "update"],
+        capture_output=True,
+        timeout=10,
+    )
+  except Exception:
+    pass
+
+  print("[INFO] Reboot update command sent successfully via ADB.")
+
+
+def flash_image(tool_path, image_file, erase=1, reboot=1):
+  """Runs the adnl_burn_pkg tool with binary-safe output reading."""
+  print("\n" + "=" * 70)
+  print(f"[FLASHING] Running {tool_path} with image {image_file}...")
+  print("=" * 70 + "\n")
+
+  try:
+    os.chmod(tool_path, 0o755)
+  except OSError:
+    pass
+
+  cmd = ["sudo", tool_path, "-r", str(reboot), "-e", str(erase), "-p", image_file]
+  print(f">>> Executing: {' '.join(cmd)}\n")
+
+  log_file = "flash_log.txt"
+  try:
+    with (
+        open(log_file, "w", encoding="utf-8", errors="replace") as log,
+        subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+        ) as proc,
+    ):
+      if proc.stdout is None:
+        sys.exit("[ERROR] Failed to capture stdout from flashing tool.")
+
+      # Read binary chunks to avoid any UTF-8 decoding crashes
+      buffer = b""
+      while True:
+        chunk = proc.stdout.read(128)
+        if not chunk:
+          if proc.poll() is not None:
+            break
+          time.sleep(0.02)
+          continue
+
+        buffer += chunk
+        while b"\n" in buffer or b"\r" in buffer:
+          delimiter_idx = -1
+          for i, byte_val in enumerate(buffer):
+            if byte_val in (ord(b"\n"), ord(b"\r")):
+              delimiter_idx = i
+              break
+
+          line_bytes = buffer[:delimiter_idx]
+          buffer = buffer[delimiter_idx + 1:]
+
+          line_str = line_bytes.decode("utf-8", errors="replace").strip()
+          if line_str:
+            log.write(line_str + "\n")
+            log.flush()
+            print(line_str, flush=True)
+
+      # Print any remaining buffer
+      if buffer:
+        remaining_str = buffer.decode("utf-8", errors="replace").strip()
+        if remaining_str:
+          log.write(remaining_str + "\n")
+          print(remaining_str, flush=True)
+
+      proc.wait()
+      if proc.returncode != 0:
+        sys.exit(f"\n[ERROR] Flashing failed with exit code {proc.returncode}. See {log_file} for details.")
+      else:
+        print("\n[SUCCESS] Flashing completed successfully!")
+  except Exception as e:
+    sys.exit(f"\n[ERROR] Failed to execute flashing tool: {e}")
+
+
+def main():
+  parser = argparse.ArgumentParser(description="Flash RDK box via ADB + USB")
+  parser.add_argument("-i", "--image", required=True, help="Path to aml_upgrade_package.img")
+  parser.add_argument("-t", "--tool", "--tool-path", dest="tool", required=True, help="Path to adnl_burn_pkg binary")
+  parser.add_argument("-e", "--erase", type=int, choices=[0, 1], default=1, help="Erase flash (default: 1)")
+  parser.add_argument("-r", "--reboot", type=int, choices=[0, 1], default=1, help="Reboot after burn (default: 1)")
+  parser.add_argument("-s", "--skip-reboot", action="store_true", help="Skip ADB reboot (if device is already in download mode)")
+  args = parser.parse_args()
+
+  image = os.path.abspath(os.path.expanduser(args.image))
+  if not os.path.exists(image):
+    sys.exit(f"[ERROR] Image file not found: {image}")
+
+  tool = os.path.abspath(os.path.expanduser(args.tool))
+  if not os.path.exists(tool):
+    sys.exit(f"[ERROR] Flashing tool not found at: {tool}")
+
+  print(f"[INFO] Using flashing tool: {tool}")
+
+  # 1. Require ADB and reboot device (unless skipped)
+  if not args.skip_reboot:
+    check_and_reboot_adb()
+    time.sleep(2)
+
+  # 2. Flash image over USB
+  flash_image(tool, image, erase=args.erase, reboot=args.reboot)
+
+
+if __name__ == "__main__":
+  main()

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/flash_rdk_test.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/flash_rdk_test.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+
+"""Unit tests for the flash_rdk script."""
+
+import os
+from pathlib import Path
+import sys
+import unittest
+from unittest import mock
+
+# Ensure local script directory takes precedence in sys.path
+_SCRIPT_DIR = str(Path(__file__).resolve().parent)
+if _SCRIPT_DIR not in sys.path:
+  sys.path.insert(0, _SCRIPT_DIR)
+sys.modules.pop("flash_rdk", None)
+
+import flash_rdk
+
+
+class TestFlashRdk(unittest.TestCase):
+  """Unit tests for flash_rdk.py."""
+
+  def setUp(self):
+    super().setUp()
+    self.mock_sub_run = mock.patch.object(flash_rdk.subprocess, "run").start()
+    self.mock_sub_popen = mock.patch.object(flash_rdk.subprocess, "Popen").start()
+
+    self.mock_proc = mock.MagicMock()
+    self.mock_proc.stdout.read.side_effect = [b"Burning %50\nComplete 100%\n", b""]
+    self.mock_proc.poll.return_value = 0
+    self.mock_proc.returncode = 0
+    self.mock_sub_popen.return_value.__enter__.return_value = self.mock_proc
+
+    mock.patch("os.path.exists", return_value=True).start()
+    mock.patch("os.chmod").start()
+    self.mock_exit = mock.patch("sys.exit", side_effect=SystemExit).start()
+
+  def tearDown(self):
+    mock.patch.stopall()
+    super().tearDown()
+
+  def test_check_and_reboot_adb_success(self):
+    """Verifies ADB detection and reboot command invocation."""
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\nGZ21090420700209\tdevice\n")
+      return mock.MagicMock(returncode=0, stdout="")
+
+    self.mock_sub_run.side_effect = sub_run_side_effect
+    flash_rdk.check_and_reboot_adb()
+
+    reboot_calls = [
+        call for call in self.mock_sub_run.call_args_list
+        if "reboot" in str(call)
+    ]
+    self.assertTrue(len(reboot_calls) >= 1)
+
+  def test_check_and_reboot_adb_no_device(self):
+    """Verifies that check_and_reboot_adb exits if no ADB device is attached."""
+    self.mock_sub_run.return_value = mock.MagicMock(returncode=0, stdout="List of devices attached\n\n")
+    with self.assertRaises(SystemExit):
+      flash_rdk.check_and_reboot_adb()
+
+  def test_flash_image_success(self):
+    """Verifies execution of the flashing tool and successful completion."""
+    with mock.patch.object(flash_rdk, "open", mock.mock_open(), create=True):
+      flash_rdk.flash_image("/path/to/tool", "/path/to/image.img", erase=1, reboot=1)
+
+    self.mock_sub_popen.assert_called_once()
+    self.mock_proc.wait.assert_called_once()
+
+
+if __name__ == "__main__":
+  unittest.main()


### PR DESCRIPTION
Add standalone flash_rdk.py script to automate flashing RDK system images via USB serial connection and ADB reboot on mac and linux

Bug: 502702565

Co-author : @haozheng-cobalt 

TAG=agy
CONV=feef26db-17fc-4e4f-8397-d35619834332