### PR TITLE
fix: Prevent DCHECK crash during browser tests shutdown

### DIFF
--- a/content/renderer/render_frame_impl.cc
+++ b/content/renderer/render_frame_impl.cc
@@ -329,12 +329,12 @@ constexpr base::TimeDelta kDelaySecondsForContentStateSync = base::Seconds(1);
 
 #if BUILDFLAG(CONTENT_ENABLE_LEGACY_IPC)
 using RoutingIDFrameMap = absl::flat_hash_map<int, RenderFrameImpl*>;
-static base::LazyInstance<RoutingIDFrameMap>::DestructorAtExit
+static base::LazyInstance<RoutingIDFrameMap>::Leaky
     g_routing_id_frame_map = LAZY_INSTANCE_INITIALIZER;
 #endif
 
 using FrameMap = absl::flat_hash_map<blink::WebFrame*, RenderFrameImpl*>;
-base::LazyInstance<FrameMap>::DestructorAtExit g_frame_map =
+static base::LazyInstance<FrameMap>::Leaky g_frame_map =
     LAZY_INSTANCE_INITIALIZER;
 
 // Please keep in sync with "RendererBlockedURLReason" in


### PR DESCRIPTION
Fix DCHECK crash on exit in browser tests

In single-process mode, the InProcessRendererThread is leaked.
Frame detachment tasks can run on this thread after AtExitManager
has destroyed g_frame_map, causing recreation and reregistration
with AtExitManager during destruction, which DCHECks.

Make g_frame_map and g_routing_id_frame_map Leaky to prevent
destruction and reregistration.

Also declare g_frame_map as static to give it internal linkage,
aligning with Chromium style.

Bug: 536986335
TAG: agy
CONV: b6d3f614-c305-4a7a-b0f6-9641f1a6abd2
