### PR TITLE
Disable AudioFrameDiscarder for passthrough audio to fix player crash

### DIFF
--- a/starboard/android/shared/audio_decoder.cc
+++ b/starboard/android/shared/audio_decoder.cc
@@ -78,6 +78,7 @@ AudioDecoder::AudioDecoder(const AudioStreamInfo& audio_stream_info,
       output_channel_count_(audio_stream_info.number_of_channels),
       drm_system_(static_cast<DrmSystem*>(drm_system)),
       enable_flush_during_seek_(enable_flush_during_seek) {
+  SupportedAudioCodecToMimeType(audio_stream_info_.codec, &is_passthrough_);
   if (!InitializeCodec()) {
     SB_LOG(ERROR) << "Failed to initialize audio decoder.";
   }
@@ -109,7 +110,9 @@ void AudioDecoder::Decode(const InputBuffers& input_buffers,
   SB_DCHECK(output_cb_);
   SB_DCHECK(media_decoder_);
 
-  audio_frame_discarder_.OnInputBuffers(input_buffers);
+  if (!is_passthrough_) {
+    audio_frame_discarder_.OnInputBuffers(input_buffers);
+  }
 
 #if STARBOARD_ANDROID_SHARED_AUDIO_DECODER_VERBOSE
   for (const auto& input_buffer : input_buffers) {
@@ -240,8 +243,10 @@ void AudioDecoder::ProcessOutputBuffer(
         dequeue_output_result.presentation_time_microseconds, size);
 
     memcpy(decoded_audio->data(), data, size);
-    audio_frame_discarder_.AdjustForDiscardedDurations(
-        audio_stream_info_.samples_per_second, &decoded_audio);
+    if (!is_passthrough_) {
+      audio_frame_discarder_.AdjustForDiscardedDurations(
+          audio_stream_info_.samples_per_second, &decoded_audio);
+    }
 
     {
       starboard::ScopedLock lock(decoded_audios_mutex_);
@@ -258,7 +263,9 @@ void AudioDecoder::ProcessOutputBuffer(
       starboard::ScopedLock lock(decoded_audios_mutex_);
       decoded_audios_.push(new DecodedAudio());
     }
-    audio_frame_discarder_.OnDecodedAudioEndOfStream();
+    if (!is_passthrough_) {
+      audio_frame_discarder_.OnDecodedAudioEndOfStream();
+    }
     Schedule(output_cb_);
   }
 

--- a/starboard/android/shared/audio_decoder.h
+++ b/starboard/android/shared/audio_decoder.h
@@ -79,6 +79,7 @@ class AudioDecoder
   const AudioStreamInfo audio_stream_info_;
   const SbMediaAudioSampleType sample_type_;
   const bool enable_flush_during_seek_;
+  bool is_passthrough_ = false;
 
   jint output_sample_rate_;
   jint output_channel_count_;

--- a/starboard/android/shared/audio_renderer_passthrough.cc
+++ b/starboard/android/shared/audio_renderer_passthrough.cc
@@ -605,7 +605,10 @@ void AudioRendererPassthrough::OnDecoderOutput() {
   SB_DCHECK(decoded_audio);
 
   if (!decoded_audio->is_end_of_stream()) {
-    SB_DCHECK(decoded_audio->size_in_bytes() > 0);
+    if (decoded_audio->size_in_bytes() == 0) {
+      SB_LOG(WARNING) << "Received empty decoded audio, ignoring.";
+      return;
+    }
     // We set |frames_per_input_buffer_| before adding first |decoded_audio|
     // into |decoded_audios_|. The usage of |frames_per_input_buffer_| in
     // UpdateStatusAndWriteData() from another thread only happens when there is


### PR DESCRIPTION
Audio passthrough (AC3/EAC3) sends compressed bitstream to AudioTrack.
Slicing compressed bitstream at arbitrary PCM frame boundaries is not
supported and corrupts the bitstream.

This CL disables AudioFrameDiscarder for passthrough audio in
AudioDecoder to avoid shrinking the DecodedAudio buffer size to 0.
It also adds a safeguard in AudioRendererPassthrough to ignore 0-size
buffers.

BUG: 337087689
TAG: agy
CONV: e878fab6-c975-409f-9390-f9d70ea68a27
