### PR TITLE
[tvOS] Add main.mm source to cobalt_archive static_library

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -135,6 +135,8 @@ if (is_ios && target_platform == "tvos") {
 
     configs -= [ "//build/config/compiler:thin_archive" ]
 
+    sources = [ "app/tvos/main.mm" ]
+
     deps = [
       ":common",
       "//base",


### PR DESCRIPTION
In older versions of Cobalt, the Starboard abstraction exposed an Objective-C clean C-style interface function (SBDUIKitApplicationMain) that allowed us to have a main.m file directly within the production app.

However, in Cobalt 27, main.mm is tightly coupled with Chromium's C++ internals (e.g. base::AtExitManager, CobaltAppDelegate, content::ContentMainRunner). If we were to compile main.mm in google3, we would have to import and maintain hundreds of transitive header files from Chromium, Cobalt, and Starboard, introducing a high ABI mismatch risk and build complexity. Therefore, main.mm needs to be packaged directly inside cobalt.a.

Bug: 536992394