### PR TITLE
tvOS: Provide a wrapper for retrieving values from Info.plist

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -107,8 +107,8 @@ if (is_ios && target_platform == "tvos") {
     deps = [
       ":common",
       "//base",
-      "//cobalt/browser/tvos/intents:yt_intents",
       "//cobalt/browser/tvos:bundle_data",
+      "//cobalt/browser/tvos/intents:yt_intents",
       "//cobalt/shell:cobalt_shell_app",
       "//cobalt/shell:cobalt_shell_lib",
       "//components/crash/core/app",

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -107,7 +107,7 @@ if (is_ios && target_platform == "tvos") {
     deps = [
       ":common",
       "//base",
-      "//cobalt/browser/tvos:bundle_data",
+      "//cobalt/browser/tvos:plist_info",
       "//cobalt/browser/tvos/intents:yt_intents",
       "//cobalt/shell:cobalt_shell_app",
       "//cobalt/shell:cobalt_shell_lib",
@@ -141,7 +141,7 @@ if (is_ios && target_platform == "tvos") {
     deps = [
       ":common",
       "//base",
-      "//cobalt/browser/tvos:bundle_data",
+      "//cobalt/browser/tvos:plist_info",
       "//cobalt/browser/tvos/intents:yt_intents",
       "//cobalt/shell:cobalt_shell_lib",
       "//components/crash/core/app",

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -141,6 +141,7 @@ if (is_ios && target_platform == "tvos") {
     deps = [
       ":common",
       "//base",
+      "//cobalt/browser/tvos:bundle_data",
       "//cobalt/browser/tvos/intents:yt_intents",
       "//cobalt/shell:cobalt_shell_lib",
       "//components/crash/core/app",

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -108,6 +108,7 @@ if (is_ios && target_platform == "tvos") {
       ":common",
       "//base",
       "//cobalt/browser/tvos/intents:yt_intents",
+      "//cobalt/browser/tvos:bundle_data",
       "//cobalt/shell:cobalt_shell_app",
       "//cobalt/shell:cobalt_shell_lib",
       "//components/crash/core/app",

--- a/cobalt/app/tvos/main.mm
+++ b/cobalt/app/tvos/main.mm
@@ -29,6 +29,7 @@
 #include "cobalt/app/cobalt_main_delegate.h"
 #include "cobalt/app/cobalt_switch_defaults.h"
 #include "cobalt/browser/h5vcc_runtime/deep_link_manager.h"
+#include "cobalt/browser/tvos/bundle_data.h"
 #include "cobalt/shell/browser/shell.h"
 #include "components/crash/core/app/crashpad.h"
 #include "content/public/app/content_main.h"
@@ -173,12 +174,10 @@ static const char** g_argv = nullptr;
     willFinishLaunchingWithOptions:(NSDictionary*)launchOptions {
   base::CommandLine original_cmd_line(g_argc, g_argv);
   if (!original_cmd_line.HasSwitch(cobalt::switches::kInitialURL)) {
-    NSString* keyValue = base::apple::ObjCCast<NSString>(
-        [[NSBundle mainBundle] objectForInfoDictionaryKey:@"YTApplicationURL"]);
-    if (keyValue) {
-      const std::string plist_url = base::SysNSStringToUTF8(keyValue);
+    const auto plistUrl = cobalt::GetValueFromPlistAsString("YTApplicationURL");
+    if (plistUrl.has_value()) {
       original_cmd_line.AppendSwitchNative(cobalt::switches::kInitialURL,
-                                           plist_url);
+                                           *plistUrl);
     }
   }
 

--- a/cobalt/app/tvos/main.mm
+++ b/cobalt/app/tvos/main.mm
@@ -29,7 +29,7 @@
 #include "cobalt/app/cobalt_main_delegate.h"
 #include "cobalt/app/cobalt_switch_defaults.h"
 #include "cobalt/browser/h5vcc_runtime/deep_link_manager.h"
-#include "cobalt/browser/tvos/bundle_data.h"
+#include "cobalt/browser/tvos/plist_info.h"
 #include "cobalt/shell/browser/shell.h"
 #include "components/crash/core/app/crashpad.h"
 #include "content/public/app/content_main.h"

--- a/cobalt/browser/tvos/BUILD.gn
+++ b/cobalt/browser/tvos/BUILD.gn
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+source_set("bundle_data") {
+  sources = [
+    "bundle_data.h",
+    "bundle_data.mm",
+  ]
+  deps = [ "//base" ]
+  frameworks = [ "Foundation.framework" ]
+}
+
 source_set("deep_link_support_tvos") {
   sources = [
     "deep_link_support_tvos.h",
@@ -19,6 +28,7 @@ source_set("deep_link_support_tvos") {
   ]
 
   deps = [
+    ":bundle_data",
     "//base",
     "//cobalt/browser/h5vcc_runtime:deep_link_manager",
   ]

--- a/cobalt/browser/tvos/BUILD.gn
+++ b/cobalt/browser/tvos/BUILD.gn
@@ -12,10 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-source_set("bundle_data") {
+source_set("plist_info") {
   sources = [
-    "bundle_data.h",
-    "bundle_data.mm",
+    "plist_info.h",
+    "plist_info.mm",
   ]
   deps = [ "//base" ]
   frameworks = [ "Foundation.framework" ]
@@ -28,7 +28,7 @@ source_set("deep_link_support_tvos") {
   ]
 
   deps = [
-    ":bundle_data",
+    ":plist_info",
     "//base",
     "//cobalt/browser/h5vcc_runtime:deep_link_manager",
   ]

--- a/cobalt/browser/tvos/deep_link_support_tvos.mm
+++ b/cobalt/browser/tvos/deep_link_support_tvos.mm
@@ -14,7 +14,12 @@
 
 #import "cobalt/browser/tvos/deep_link_support_tvos.h"
 
+#include <string_view>
+
+#include "base/strings/strcat.h"
+#include "base/strings/sys_string_conversions.h"
 #include "cobalt/browser/h5vcc_runtime/deep_link_manager.h"
+#include "cobalt/browser/tvos/bundle_data.h"
 
 @implementation DeepLinkSupportTvos
 
@@ -24,22 +29,21 @@
     return;
   }
 
-  static constexpr NSString* const kYTApplicationURLKey = @"YTApplicationURL";
-  NSString* urlBase =
-      [[NSBundle mainBundle] objectForInfoDictionaryKey:kYTApplicationURLKey];
+  const auto urlBase = cobalt::GetValueFromPlistAsString("YTApplicationURL");
   if (!urlBase) {
     LOG(WARNING) << "YTApplicationURL not in plist, ignoring AppIntent.";
     return;
   }
 
-  static constexpr NSString* const kSearchUrlAction =
-      @"?launch=voice&vs=11&va=search&vaa=";
-  static constexpr NSString* const kPlayUrlAction =
-      @"?launch=voice&vs=11&va=play&vaa=";
-  NSString* urlAction = isSearch ? kSearchUrlAction : kPlayUrlAction;
+  static constexpr std::string_view kSearchUrlAction =
+      "?launch=voice&vs=11&va=search&vaa=";
+  static constexpr std::string_view kPlayUrlAction =
+      "?launch=voice&vs=11&va=play&vaa=";
+  const std::string_view urlAction =
+      isSearch ? kSearchUrlAction : kPlayUrlAction;
 
-  const std::string deep_link = [[NSString
-      stringWithFormat:@"%@%@%@", urlBase, urlAction, query] UTF8String];
+  const std::string deep_link =
+      base::StrCat({*urlBase, urlAction, base::SysNSStringToUTF8(query)});
   auto* manager = cobalt::browser::DeepLinkManager::GetInstance();
   manager->OnDeepLink(deep_link);
 }

--- a/cobalt/browser/tvos/deep_link_support_tvos.mm
+++ b/cobalt/browser/tvos/deep_link_support_tvos.mm
@@ -19,7 +19,7 @@
 #include "base/strings/strcat.h"
 #include "base/strings/sys_string_conversions.h"
 #include "cobalt/browser/h5vcc_runtime/deep_link_manager.h"
-#include "cobalt/browser/tvos/bundle_data.h"
+#include "cobalt/browser/tvos/plist_info.h"
 
 @implementation DeepLinkSupportTvos
 

--- a/cobalt/browser/tvos/plist_info.h
+++ b/cobalt/browser/tvos/plist_info.h
@@ -1,0 +1,31 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_TVOS_PLIST_INFO_H_
+#define COBALT_BROWSER_TVOS_PLIST_INFO_H_
+
+#include <optional>
+#include <string>
+#include <string_view>
+
+namespace cobalt {
+
+// Retrieves a given value from the main bundle's Info.plist and returns it as
+// an std::string if it exists and can be converted to an NSString*. Returns
+// std::nullopt otherwise.
+std::optional<std::string> GetValueFromPlistAsString(std::string_view key_name);
+
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_TVOS_PLIST_INFO_H_

--- a/cobalt/browser/tvos/plist_info.mm
+++ b/cobalt/browser/tvos/plist_info.mm
@@ -1,0 +1,35 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/tvos/plist_info.h"
+
+#import <Foundation/Foundation.h>
+
+#include "base/apple/foundation_util.h"
+#include "base/strings/sys_string_conversions.h"
+
+namespace cobalt {
+
+std::optional<std::string> GetValueFromPlistAsString(
+    std::string_view key_name) {
+  NSString* keyName = base::SysUTF8ToNSString(key_name);
+  NSString* keyValue = base::apple::ObjCCast<NSString>(
+      [[NSBundle mainBundle] objectForInfoDictionaryKey:keyName]);
+  if (!keyValue) {
+    return std::nullopt;
+  }
+  return base::SysNSStringToUTF8(keyValue);
+}
+
+}  // namespace cobalt


### PR DESCRIPTION
There are variations of this code available in the tree, but none of them are as generic as what we need. The idea is to perform the NSString* to std::string conversion transparently and return an `std::optional<std::string>`.

Use the wrapper in a few places to show how it should be called. While here:

* s/plist_url/plistUrl/ in Objective-C++ code to adhere to the coding style.
* Use std::string_view instead of NSStrings* in the deep link handling code now that it calls `cobalt::GetValueFromPlistAsString()`.

Fixed: 537214612