### PR TITLE
nplb: page-align stack buffer for PosixThreadAttrTest.StackAddrAndSizeAttr

### DIFF
--- a/starboard/nplb/posix_compliance/posix_thread_attr_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_attr_test.cc
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <pthread.h>
+#include <memory>
 #include <stdlib.h>
 #include <unistd.h>
 

--- a/starboard/nplb/posix_compliance/posix_thread_attr_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_attr_test.cc
@@ -13,11 +13,12 @@
 // limitations under the License.
 
 #include <pthread.h>
-#include <memory>
 #include <stdlib.h>
+#include <string.h>
 #include <unistd.h>
 
-#include "build/build_config.h"
+#include <memory>
+
 #include "starboard/common/log.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -89,15 +90,11 @@ TEST(PosixThreadAttrTest, StackSizeAttr) {
 TEST(PosixThreadAttrTest, StackAddrAndSizeAttr) {
   pthread_attr_t attr;
   void* set_stack_addr = nullptr;
-#if BUILDFLAG(IS_STARBOARD)
-  // bionic's pthread_attr_setstack() requires a page-aligned stack base
+  // pthread_attr_setstack() may fail with EINVAL if the stack base does not
+  // meet implementation-defined alignment requirements, so page-align it.
   const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
   ASSERT_EQ(posix_memalign(&set_stack_addr, page_size, kStackSize), 0);
   std::unique_ptr<void, void (*)(void*)> stack_guard(set_stack_addr, std::free);
-#else   // BUILDFLAG(IS_STARBOARD)
-  std::array<char, kStackSize> stack_buffer;
-  set_stack_addr = static_cast<void*>(stack_buffer.data());
-#endif  // BUILDFLAG(IS_STARBOARD)
   void* ret_stack_addr = nullptr;
   size_t ret_stack_size = 0;
 

--- a/starboard/nplb/posix_compliance/posix_thread_attr_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_attr_test.cc
@@ -13,7 +13,12 @@
 // limitations under the License.
 
 #include <pthread.h>
+#include <stdlib.h>
+#include <unistd.h>
 
+#include <memory>
+
+#include "build/build_config.h"
 #include "starboard/common/log.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -84,8 +89,16 @@ TEST(PosixThreadAttrTest, StackSizeAttr) {
 // Test for setting and getting both stack address and size.
 TEST(PosixThreadAttrTest, StackAddrAndSizeAttr) {
   pthread_attr_t attr;
+  void* set_stack_addr = nullptr;
+#if BUILDFLAG(IS_STARBOARD)
+  // bionic's pthread_attr_setstack() requires a page-aligned stack base
+  const size_t page_size = static_cast<size_t>(sysconf(_SC_PAGESIZE));
+  ASSERT_EQ(posix_memalign(&set_stack_addr, page_size, kStackSize), 0);
+  std::unique_ptr<void, void (*)(void*)> stack_guard(set_stack_addr, std::free);
+#else   // BUILDFLAG(IS_STARBOARD)
   std::array<char, kStackSize> stack_buffer;
-  void* set_stack_addr = static_cast<void*>(stack_buffer.data());
+  set_stack_addr = static_cast<void*>(stack_buffer.data());
+#endif  // BUILDFLAG(IS_STARBOARD)
   void* ret_stack_addr = nullptr;
   size_t ret_stack_size = 0;
 

--- a/starboard/nplb/posix_compliance/posix_thread_attr_test.cc
+++ b/starboard/nplb/posix_compliance/posix_thread_attr_test.cc
@@ -17,8 +17,6 @@
 #include <stdlib.h>
 #include <unistd.h>
 
-#include <memory>
-
 #include "build/build_config.h"
 #include "starboard/common/log.h"
 #include "testing/gtest/include/gtest/gtest.h"


### PR DESCRIPTION
PosixThreadAttrTest.StackAddrAndSizeAttr is failing with EINVAL because
bionic's  pthread_attr_setstack() expects the buffer to be page-aligned:

__BIONIC_WEAK_FOR_NATIVE_BRIDGE
int pthread_attr_setstack(...)
  if ((stack_size & (page_size() - 1) || stack_size < PTHREAD_STACK_MIN)) {
    return EINVAL;
  }
  if (reinterpret_cast<uintptr_t>(stack_base) & (page_size() - 1)) {
    return EINVAL;
  }
  attr->stack_base = stack_base;
  attr->stack_size = stack_size;
  return 0;
}

Allocate the stack in the heap and use posix_memalign() to fulfill
bionic's restrictions.

Bug: 532068409