### PR TITLE
aosp: fix asset directory enumeration for readdir* and fdopendir

### DIFF
--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -218,7 +218,6 @@ static_library("starboard_platform") {
     "player_set_video_surface_view.h",
 
     # TODO: b/374300500 - posix_emu things should not be used on Android anymore
-    # "posix_emu/dirent.cc",
     # "posix_emu/pthread.cc",
 
     "runtime_resource_overlay.cc",
@@ -345,6 +344,7 @@ static_library("starboard_platform") {
       "asset_manager.cc",
       "asset_manager.h",
       "posix_emu/access.cc",
+      "posix_emu/dirent.cc",
       "posix_emu/errno.cc",
       "posix_emu/file.cc",
       "posix_emu/net_if.cc",

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -222,7 +222,6 @@ static_library("starboard_platform") {
     "player_settings.h",
 
     # TODO: b/374300500 - posix_emu things should not be used on Android anymore
-    # "posix_emu/dirent.cc",
     # "posix_emu/pthread.cc",
 
     "runtime_resource_overlay.cc",
@@ -350,6 +349,7 @@ static_library("starboard_platform") {
       "asset_manager.h",
       "posix_emu/access.cc",
       "posix_emu/alarm.cc",
+      "posix_emu/dirent.cc",
       "posix_emu/errno.cc",
       "posix_emu/file.cc",
       "posix_emu/net_if.cc",

--- a/starboard/android/shared/asset_manager.cc
+++ b/starboard/android/shared/asset_manager.cc
@@ -24,6 +24,8 @@
 #include <unistd.h>
 
 #include <mutex>
+#include <utility>
+#include <vector>
 
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/check_op.h"
@@ -144,6 +146,59 @@ int AssetManager::Close(int fd) {
 bool AssetManager::IsAssetFd(int fd) const {
   std::lock_guard scoped_lock(mutex_);
   return fd_to_internal_fd_map_.count(fd) == 1;
+}
+
+int AssetManager::OpenDirectory(const char* path) {
+  if (!path) {
+    return -1;
+  }
+
+  std::vector<std::string> entries = ListAndroidAssetDir(path);
+  if (entries.empty()) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  // Reserve a real, unique fd so it can be closed like any other fd.
+  // It is never read but serves as a key to hold the directory entries
+  // and the open/closed state.
+  int fd = open("/dev/null", O_RDONLY);
+  if (fd < 0) {
+    return -1;
+  }
+
+  std::lock_guard scoped_lock(mutex_);
+  dir_fd_to_entries_map_[fd] = std::move(entries);
+  return fd;
+}
+
+int AssetManager::CloseDirectory(int fd) {
+  {
+    std::lock_guard scoped_lock(mutex_);
+    auto search = dir_fd_to_entries_map_.find(fd);
+    if (search == dir_fd_to_entries_map_.end()) {
+      return -1;
+    }
+    dir_fd_to_entries_map_.erase(search);
+  }  // Can't hold lock when calling close();
+  return close(fd);
+}
+
+bool AssetManager::IsAssetDirFd(int fd) const {
+  std::lock_guard scoped_lock(mutex_);
+  return dir_fd_to_entries_map_.count(fd) == 1;
+}
+
+bool AssetManager::GetDirectoryEntries(
+    int fd,
+    std::vector<std::string>* entries) const {
+  std::lock_guard scoped_lock(mutex_);
+  auto search = dir_fd_to_entries_map_.find(fd);
+  if (search == dir_fd_to_entries_map_.end()) {
+    return false;
+  }
+  *entries = search->second;
+  return true;
 }
 
 AssetManager::AssetManager() {

--- a/starboard/android/shared/asset_manager.cc
+++ b/starboard/android/shared/asset_manager.cc
@@ -24,6 +24,8 @@
 #include <unistd.h>
 
 #include <mutex>
+#include <utility>
+#include <vector>
 
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/check_op.h"
@@ -49,6 +51,7 @@ int AssetManager::Open(const char* path, int oflag) {
       return open(fallback_path.c_str(), oflag);
     }
     SB_LOG(WARNING) << "Asset path not found within package: " << path;
+    errno = ENOENT;
     return -1;
   }
 
@@ -106,6 +109,68 @@ int AssetManager::Close(int fd) {
 bool AssetManager::IsAssetFd(int fd) const {
   std::lock_guard scoped_lock(mutex_);
   return fd_to_internal_fd_map_.count(fd) == 1;
+}
+
+int AssetManager::OpenDirectory(const char* path) {
+  if (!path) {
+    return -1;
+  }
+
+  std::vector<std::string> entries = ListAndroidAssetDir(path);
+  if (entries.empty()) {
+    // An empty listing means either the path doesn't exist or it names a file.
+    // If we manage to open it as an asset it means it's a file and ENOTDIR
+    // should be reported.
+    AAsset* asset = OpenAndroidAsset(path);
+    if (asset) {
+      AAsset_close(asset);
+      errno = ENOTDIR;
+    } else {
+      errno = ENOENT;
+    }
+    return -1;
+  }
+
+  // Reserve a real, unique fd so it can be closed like any other fd.
+  // It is never read but serves as a key to hold the directory entries
+  // and the open/closed state.
+  int fd = open("/dev/null", O_RDONLY);
+  if (fd < 0) {
+    return -1;
+  }
+
+  std::lock_guard scoped_lock(mutex_);
+  dir_fd_to_entries_map_[fd] = std::move(entries);
+  return fd;
+}
+
+int AssetManager::CloseDirectory(int fd) {
+  {
+    std::lock_guard scoped_lock(mutex_);
+    auto search = dir_fd_to_entries_map_.find(fd);
+    if (search == dir_fd_to_entries_map_.end()) {
+      return -1;
+    }
+    dir_fd_to_entries_map_.erase(search);
+  }  // Can't hold lock when calling close();
+  return close(fd);
+}
+
+bool AssetManager::IsAssetDirFd(int fd) const {
+  std::lock_guard scoped_lock(mutex_);
+  return dir_fd_to_entries_map_.count(fd) == 1;
+}
+
+bool AssetManager::GetDirectoryEntries(
+    int fd,
+    std::vector<std::string>* entries) const {
+  std::lock_guard scoped_lock(mutex_);
+  auto search = dir_fd_to_entries_map_.find(fd);
+  if (search == dir_fd_to_entries_map_.end()) {
+    return false;
+  }
+  *entries = search->second;
+  return true;
 }
 
 void AssetManager::RegisterAssetDir(const DIR* dir) {

--- a/starboard/android/shared/asset_manager.cc
+++ b/starboard/android/shared/asset_manager.cc
@@ -108,6 +108,21 @@ bool AssetManager::IsAssetFd(int fd) const {
   return fd_to_internal_fd_map_.count(fd) == 1;
 }
 
+void AssetManager::RegisterAssetDir(const DIR* dir) {
+  std::lock_guard scoped_lock(mutex_);
+  asset_dir_set_.insert(dir);
+}
+
+bool AssetManager::UnregisterAssetDir(const DIR* dir) {
+  std::lock_guard scoped_lock(mutex_);
+  return asset_dir_set_.erase(dir) > 0;
+}
+
+bool AssetManager::IsAssetDir(const DIR* dir) const {
+  std::lock_guard scoped_lock(mutex_);
+  return asset_dir_set_.count(dir) == 1;
+}
+
 AssetManager::AssetManager() {
   const int kPathSize = PATH_MAX / 2;
   char path[kPathSize] = {0};

--- a/starboard/android/shared/asset_manager.h
+++ b/starboard/android/shared/asset_manager.h
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <vector>
 
 namespace starboard {
 
@@ -29,6 +30,11 @@ class AssetManager {
   int Open(const char* path, int oflag);
   int Close(int fd);
   bool IsAssetFd(int fd) const;
+
+  int OpenDirectory(const char* path);
+  int CloseDirectory(int fd);
+  bool IsAssetDirFd(int fd) const;
+  bool GetDirectoryEntries(int fd, std::vector<std::string>* entries) const;
 
  private:
   AssetManager();
@@ -42,6 +48,8 @@ class AssetManager {
   uint64_t internal_fd_ = 0;                       // Guarded by |mutex_|.
   std::set<uint64_t> in_use_internal_fd_set_;      // Guarded by |mutex_|.
   std::map<int, uint64_t> fd_to_internal_fd_map_;  // Guarded by |mutex_|.
+  // Maps a reserved placeholder fd to the asset directory entries
+  std::map<int, std::vector<std::string>> dir_fd_to_entries_map_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/asset_manager.h
+++ b/starboard/android/shared/asset_manager.h
@@ -15,6 +15,8 @@
 #ifndef STARBOARD_ANDROID_SHARED_ASSET_MANAGER_H_
 #define STARBOARD_ANDROID_SHARED_ASSET_MANAGER_H_
 
+#include <dirent.h>
+
 #include <map>
 #include <mutex>
 #include <set>
@@ -30,6 +32,12 @@ class AssetManager {
   int Close(int fd);
   bool IsAssetFd(int fd) const;
 
+  // Tracks the DIR handles the asset-path dirent wrappers hand out, so they can
+  // be told apart from handles returned by the real opendir()/fdopendir().
+  void RegisterAssetDir(const DIR* dir);
+  bool UnregisterAssetDir(const DIR* dir);
+  bool IsAssetDir(const DIR* dir) const;
+
  private:
   AssetManager();
   ~AssetManager() { ClearTempDir(); }
@@ -42,6 +50,7 @@ class AssetManager {
   uint64_t internal_fd_ = 0;                       // Guarded by |mutex_|.
   std::set<uint64_t> in_use_internal_fd_set_;      // Guarded by |mutex_|.
   std::map<int, uint64_t> fd_to_internal_fd_map_;  // Guarded by |mutex_|.
+  std::set<const DIR*> asset_dir_set_;             // Guarded by |mutex_|.
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/asset_manager.h
+++ b/starboard/android/shared/asset_manager.h
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <vector>
 
 namespace starboard {
 
@@ -31,6 +32,11 @@ class AssetManager {
   int Open(const char* path, int oflag);
   int Close(int fd);
   bool IsAssetFd(int fd) const;
+
+  int OpenDirectory(const char* path);
+  int CloseDirectory(int fd);
+  bool IsAssetDirFd(int fd) const;
+  bool GetDirectoryEntries(int fd, std::vector<std::string>* entries) const;
 
   // Tracks the DIR handles the asset-path dirent wrappers hand out, so they can
   // be told apart from handles returned by the real opendir()/fdopendir().
@@ -50,7 +56,10 @@ class AssetManager {
   uint64_t internal_fd_ = 0;                       // Guarded by |mutex_|.
   std::set<uint64_t> in_use_internal_fd_set_;      // Guarded by |mutex_|.
   std::map<int, uint64_t> fd_to_internal_fd_map_;  // Guarded by |mutex_|.
-  std::set<const DIR*> asset_dir_set_;             // Guarded by |mutex_|.
+  // Maps a reserved placeholder fd to the asset directory entries.
+  // Guarded by |mutex_|.
+  std::map<int, std::vector<std::string>> dir_fd_to_entries_map_;
+  std::set<const DIR*> asset_dir_set_;  // Guarded by |mutex_|.
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -17,6 +17,10 @@
 #include <android/asset_manager_jni.h>
 #include <android/log.h>
 
+#include <vector>
+
+#include "base/android/jni_array.h"
+#include "base/android/jni_string.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
@@ -108,35 +112,36 @@ AAsset* OpenAndroidAsset(const char* path) {
   return AAssetManager_open(g_asset_manager, asset_path, AASSET_MODE_RANDOM);
 }
 
-AAssetDir* OpenAndroidAssetDir(const char* path) {
-  // Note that the asset directory will not be found if |path| points to a
-  // specific file instead of a directory. |path| should also not end with '/'.
-  if (!IsAndroidAssetPath(path) || g_asset_manager == NULL) {
-    return NULL;
+std::vector<std::string> ListAndroidAssetDir(const char* path) {
+  std::vector<std::string> names;
+  if (!IsAndroidAssetPath(path) || g_java_asset_manager.is_null()) {
+    return names;
   }
   const char* asset_path = path + strlen(g_app_assets_dir);
   if (*asset_path == '/') {
     asset_path++;
   }
-  AAssetDir* asset_directory =
-      AAssetManager_openDir(g_asset_manager, asset_path);
 
-  // AAssetManager_openDir() always returns a pointer to an initialized object,
-  // even if the given directory does not exist. To determine if the directory
-  // actually exists, AAssetDir_getNextFileName() is called to check for any
-  // files in the given directory. However, when iterating the contents of a
-  // directory, the NDK Asset Manager does not allow subdirectories to be seen.
-  // So this is not a 100% accurate way to determine if a directory actually
-  // exists and false negatives will be given for directories that contain
-  // subdirectories but no files in their immediate directory.
-  const char* file = AAssetDir_getNextFileName(asset_directory);
-  if (file == NULL) {
-    AAssetDir_close(asset_directory);
-    return NULL;
-  } else {
-    AAssetDir_rewind(asset_directory);
-    return asset_directory;
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+  jni_zero::ScopedJavaLocalRef<jclass> asset_manager_class =
+      jni_zero::GetClass(env, "android/content/res/AssetManager");
+  jmethodID list_method =
+      jni_zero::MethodID::Get<jni_zero::MethodID::TYPE_INSTANCE>(
+          env, asset_manager_class.obj(), "list",
+          "(Ljava/lang/String;)[Ljava/lang/String;");
+  jni_zero::ScopedJavaLocalRef<jstring> j_asset_path =
+      base::android::ConvertUTF8ToJavaString(env, asset_path);
+  jni_zero::ScopedJavaLocalRef<jobjectArray> j_names =
+      jni_zero::ScopedJavaLocalRef<jobjectArray>::Adopt(
+          env,
+          static_cast<jobjectArray>(env->CallObjectMethod(
+              g_java_asset_manager.obj(), list_method, j_asset_path.obj())));
+  // On error, return "no entries".
+  if (jni_zero::ClearException(env) || j_names.is_null()) {
+    return names;
   }
+  base::android::AppendJavaStringArrayToStringVector(env, j_names, &names);
+  return names;
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -20,6 +20,10 @@
 
 #include <string>
 
+#include <vector>
+
+#include "base/android/jni_array.h"
+#include "base/android/jni_string.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
@@ -113,35 +117,36 @@ AAsset* OpenAndroidAsset(const char* path) {
   return AAssetManager_open(g_asset_manager, asset_path, AASSET_MODE_RANDOM);
 }
 
-AAssetDir* OpenAndroidAssetDir(const char* path) {
-  // Note that the asset directory will not be found if |path| points to a
-  // specific file instead of a directory. |path| should also not end with '/'.
-  if (!IsAndroidAssetPath(path) || g_asset_manager == NULL) {
-    return NULL;
+std::vector<std::string> ListAndroidAssetDir(const char* path) {
+  std::vector<std::string> names;
+  if (!IsAndroidAssetPath(path) || g_java_asset_manager.is_null()) {
+    return names;
   }
   const char* asset_path = path + strlen(g_app_assets_dir);
   if (*asset_path == '/') {
     asset_path++;
   }
-  AAssetDir* asset_directory =
-      AAssetManager_openDir(g_asset_manager, asset_path);
 
-  // AAssetManager_openDir() always returns a pointer to an initialized object,
-  // even if the given directory does not exist. To determine if the directory
-  // actually exists, AAssetDir_getNextFileName() is called to check for any
-  // files in the given directory. However, when iterating the contents of a
-  // directory, the NDK Asset Manager does not allow subdirectories to be seen.
-  // So this is not a 100% accurate way to determine if a directory actually
-  // exists and false negatives will be given for directories that contain
-  // subdirectories but no files in their immediate directory.
-  const char* file = AAssetDir_getNextFileName(asset_directory);
-  if (file == NULL) {
-    AAssetDir_close(asset_directory);
-    return NULL;
-  } else {
-    AAssetDir_rewind(asset_directory);
-    return asset_directory;
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+  jni_zero::ScopedJavaLocalRef<jclass> asset_manager_class =
+      jni_zero::GetClass(env, "android/content/res/AssetManager");
+  jmethodID list_method =
+      jni_zero::MethodID::Get<jni_zero::MethodID::TYPE_INSTANCE>(
+          env, asset_manager_class.obj(), "list",
+          "(Ljava/lang/String;)[Ljava/lang/String;");
+  jni_zero::ScopedJavaLocalRef<jstring> j_asset_path =
+      base::android::ConvertUTF8ToJavaString(env, asset_path);
+  jni_zero::ScopedJavaLocalRef<jobjectArray> j_names =
+      jni_zero::ScopedJavaLocalRef<jobjectArray>::Adopt(
+          env,
+          static_cast<jobjectArray>(env->CallObjectMethod(
+              g_java_asset_manager.obj(), list_method, j_asset_path.obj())));
+  // On error, return "no entries".
+  if (jni_zero::ClearException(env) || j_names.is_null()) {
+    return names;
   }
+  base::android::AppendJavaStringArrayToStringVector(env, j_names, &names);
+  return names;
 }
 
 // NOTE: While Cobalt now provides a mechanism for loading system fonts through

--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -19,7 +19,6 @@
 #include <string.h>
 
 #include <string>
-
 #include <vector>
 
 #include "base/android/jni_array.h"

--- a/starboard/android/shared/file_internal.h
+++ b/starboard/android/shared/file_internal.h
@@ -20,6 +20,7 @@
 #include <jni.h>
 
 #include <string>
+#include <vector>
 
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/shared/internal_only.h"
@@ -53,7 +54,8 @@ void SbFileAndroidTeardown();
 
 bool IsAndroidAssetPath(const char* path);
 AAsset* OpenAndroidAsset(const char* path);
-AAssetDir* OpenAndroidAssetDir(const char* path);
+
+std::vector<std::string> ListAndroidAssetDir(const char* path);
 
 }  // namespace starboard
 

--- a/starboard/android/shared/file_internal.h
+++ b/starboard/android/shared/file_internal.h
@@ -20,6 +20,7 @@
 #include <jni.h>
 
 #include <string>
+#include <vector>
 
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/shared/internal_only.h"
@@ -57,7 +58,8 @@ void SbFileAndroidTeardown();
 
 bool IsAndroidAssetPath(const char* path);
 AAsset* OpenAndroidAsset(const char* path);
-AAssetDir* OpenAndroidAssetDir(const char* path);
+
+std::vector<std::string> ListAndroidAssetDir(const char* path);
 
 // Returns the fallback for the given asset path, or an empty string if none.
 std::string FallbackPath(const std::string& path);

--- a/starboard/android/shared/posix_emu/dirent.cc
+++ b/starboard/android/shared/posix_emu/dirent.cc
@@ -16,18 +16,64 @@
 #include <dirent.h>
 // clang-format on
 
-#include <android/asset_manager.h>
+#include <errno.h>
+#include <string.h>
 
-#include <map>
 #include <mutex>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/string.h"
-#include "starboard/configuration_constants.h"
 
 using starboard::IsAndroidAssetPath;
-using starboard::OpenAndroidAsset;
-using starboard::OpenAndroidAssetDir;
+using starboard::ListAndroidAssetDir;
+
+namespace {
+
+// A helper structure used internally as a DIR replacement for asset paths.
+// It's used in the wrapped opendir/closedir/readdir/readdir_r.
+struct AndroidAssetDir {
+  std::vector<std::string> entries;
+  size_t index;
+  struct dirent entry;
+};
+
+// Registry of the DIR* handles created by the asset-path wrappers below.
+std::mutex& GetAssetDirMutex() {
+  static std::mutex* mutex = new std::mutex();
+  return *mutex;
+}
+
+std::set<const AndroidAssetDir*>& GetActiveAssetDirs() {
+  static std::set<const AndroidAssetDir*>* dirs =
+      new std::set<const AndroidAssetDir*>();
+  return *dirs;
+}
+
+void RegisterAssetDir(const AndroidAssetDir* dir) {
+  std::lock_guard lock(GetAssetDirMutex());
+  GetActiveAssetDirs().insert(dir);
+}
+
+bool UnregisterAssetDir(const AndroidAssetDir* dir) {
+  std::lock_guard lock(GetAssetDirMutex());
+  return GetActiveAssetDirs().erase(dir) > 0;
+}
+
+bool IsAssetDir(const AndroidAssetDir* dir) {
+  std::lock_guard lock(GetAssetDirMutex());
+  return GetActiveAssetDirs().count(dir) > 0;
+}
+
+void FillAssetDirent(const std::string& name, struct dirent* out) {
+  memset(out, 0, sizeof(*out));
+  starboard::strlcpy(out->d_name, name.c_str(), sizeof(out->d_name));
+}
+
+}  // namespace
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementations below exposed externally in pure C for emulation.
@@ -38,99 +84,37 @@ DIR* __real_opendir(const char* path);
 
 int __real_closedir(DIR* dir);
 
+struct dirent* __real_readdir(DIR* dir);
+
 int __real_readdir_r(DIR* __restrict dir,
                      struct dirent* __restrict dirent_buf,
                      struct dirent** __restrict dirent);
-
-// AAssetDir does not have a file descriptor so we must generate one
-// https://android.googlesource.com/platform/frameworks/base/+/master/native/android/asset_manager.cpp
-static int gen_fd() {
-  static int fd = 100;
-  fd++;
-  if (fd == 0x7FFFFFFF) {
-    fd = 100;
-  }
-  return fd;
-}
-
-std::mutex mutex_;
-static std::map<int, AAssetDir*>* asset_map = nullptr;
-
-static int handle_db_put(AAssetDir* assetDir) {
-  std::lock_guard scoped_lock(mutex_);
-  if (asset_map == nullptr) {
-    asset_map = new std::map<int, AAssetDir*>();
-  }
-
-  int fd = gen_fd();
-  // Go through the map and make sure there isn't duplicated index
-  // already.
-  while (asset_map->find(fd) != asset_map->end()) {
-    fd = gen_fd();
-  }
-  asset_map->insert({fd, assetDir});
-
-  return fd;
-}
-
-static AAssetDir* handle_db_get(int fd, bool erase) {
-  std::lock_guard scoped_lock(mutex_);
-  if (fd < 0) {
-    return nullptr;
-  }
-  if (asset_map == nullptr) {
-    return nullptr;
-  }
-
-  auto itr = asset_map->find(fd);
-  if (itr == asset_map->end()) {
-    return nullptr;
-  }
-
-  AAssetDir* asset_dir = itr->second;
-  if (erase) {
-    asset_map->erase(itr);
-  }
-  return asset_dir;
-}
-
-struct _PosixEmuAndroidAssetDir {
-  int64_t magic;
-  int fd;
-};
-
-constexpr int64_t kMagicNum = -1;
 
 DIR* __wrap_opendir(const char* path) {
   if (!IsAndroidAssetPath(path)) {
     return __real_opendir(path);
   }
 
-  AAssetDir* asset_dir = OpenAndroidAssetDir(path);
-  if (asset_dir) {
-    int descriptor = handle_db_put(asset_dir);
-    struct _PosixEmuAndroidAssetDir* retdir =
-        reinterpret_cast<_PosixEmuAndroidAssetDir*>(
-            malloc(sizeof(struct _PosixEmuAndroidAssetDir)));
-    retdir->magic = kMagicNum;
-    retdir->fd = descriptor;
-    return reinterpret_cast<DIR*>(retdir);
+  std::vector<std::string> entries = ListAndroidAssetDir(path);
+  if (entries.empty()) {
+    errno = ENOENT;
+    return NULL;
   }
-  return NULL;
+
+  AndroidAssetDir* retdir = new AndroidAssetDir();
+  retdir->entries = std::move(entries);
+  retdir->index = 0;
+  RegisterAssetDir(retdir);
+  return reinterpret_cast<DIR*>(retdir);
 }
 
 int __wrap_closedir(DIR* dir) {
   if (!dir) {
     return -1;
   }
-  struct _PosixEmuAndroidAssetDir* adir = (struct _PosixEmuAndroidAssetDir*)dir;
-  if (adir->magic == kMagicNum) {  // This is an Asset
-    int descriptor = adir->fd;
-    AAssetDir* asset_dir = handle_db_get(descriptor, true);
-    if (asset_dir != nullptr) {
-      AAssetDir_close(asset_dir);
-    }
-    free(adir);
+  AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+  if (UnregisterAssetDir(asset_dir)) {
+    delete asset_dir;
     return 0;
   }
   return __real_closedir(dir);
@@ -143,20 +127,36 @@ int __wrap_readdir_r(DIR* __restrict dir,
     return -1;
   }
 
-  struct _PosixEmuAndroidAssetDir* adir = (struct _PosixEmuAndroidAssetDir*)dir;
-  if (adir->magic == kMagicNum) {  // This is an Asset
-    int descriptor = adir->fd;
-    AAssetDir* asset_dir = handle_db_get(descriptor, false);
-    const char* file_name = AAssetDir_getNextFileName(asset_dir);
-    if (file_name == NULL) {
-      return -1;
+  AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+  if (IsAssetDir(asset_dir)) {
+    if (asset_dir->index >= asset_dir->entries.size()) {
+      *dirent = NULL;  // End of directory
+      return 0;
     }
+    FillAssetDirent(asset_dir->entries[asset_dir->index++], dirent_buf);
     *dirent = dirent_buf;
-    starboard::strlcpy((*dirent)->d_name, file_name, kSbFileMaxName);
     return 0;
   }
 
   return __real_readdir_r(dir, dirent_buf, dirent);
+}
+
+struct dirent* __wrap_readdir(DIR* dir) {
+  if (!dir) {
+    errno = EBADF;
+    return NULL;
+  }
+
+  AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+  if (IsAssetDir(asset_dir)) {
+    if (asset_dir->index >= asset_dir->entries.size()) {
+      return NULL;
+    }
+    FillAssetDirent(asset_dir->entries[asset_dir->index++], &asset_dir->entry);
+    return &asset_dir->entry;
+  }
+
+  return __real_readdir(dir);
 }
 
 }  // extern "C"

--- a/starboard/android/shared/posix_emu/dirent.cc
+++ b/starboard/android/shared/posix_emu/dirent.cc
@@ -25,16 +25,18 @@
 #include <utility>
 #include <vector>
 
+#include "starboard/android/shared/asset_manager.h"
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/string.h"
 
+using starboard::AssetManager;
 using starboard::IsAndroidAssetPath;
 using starboard::ListAndroidAssetDir;
 
 namespace {
 
 // A helper structure used internally as a DIR replacement for asset paths.
-// It's used in the wrapped opendir/closedir/readdir/readdir_r.
+// It's used in the wrapped opendir/fdopendir/closedir/readdir/readdir_r.
 struct AndroidAssetDir {
   std::vector<std::string> entries;
   size_t index;
@@ -82,6 +84,8 @@ void FillAssetDirent(const std::string& name, struct dirent* out) {
 extern "C" {
 DIR* __real_opendir(const char* path);
 
+DIR* __real_fdopendir(int fd);
+
 int __real_closedir(DIR* dir);
 
 struct dirent* __real_readdir(DIR* dir);
@@ -100,6 +104,25 @@ DIR* __wrap_opendir(const char* path) {
     errno = ENOENT;
     return NULL;
   }
+
+  AndroidAssetDir* retdir = new AndroidAssetDir();
+  retdir->entries = std::move(entries);
+  retdir->index = 0;
+  RegisterAssetDir(retdir);
+  return reinterpret_cast<DIR*>(retdir);
+}
+
+DIR* __wrap_fdopendir(int fd) {
+  AssetManager* asset_manager = AssetManager::GetInstance();
+  if (!asset_manager->IsAssetDirFd(fd)) {
+    return __real_fdopendir(fd);
+  }
+
+  std::vector<std::string> entries;
+  asset_manager->GetDirectoryEntries(fd, &entries);
+  // The reserved fd is only a placeholder used as a key, it can be
+  // closed now that the entries have been already captured.
+  asset_manager->CloseDirectory(fd);
 
   AndroidAssetDir* retdir = new AndroidAssetDir();
   retdir->entries = std::move(entries);

--- a/starboard/android/shared/posix_emu/dirent.cc
+++ b/starboard/android/shared/posix_emu/dirent.cc
@@ -29,17 +29,40 @@
 
 using starboard::AssetManager;
 using starboard::IsAndroidAssetPath;
-using starboard::ListAndroidAssetDir;
 
 namespace {
 
 // A helper structure used internally as a DIR replacement for asset paths.
-// It's used in the wrapped opendir/closedir/readdir/readdir_r.
+// It's used in the wrapped opendir/fdopendir/closedir/readdir/readdir_r.
 struct AndroidAssetDir {
   std::vector<std::string> entries;
   size_t index;
   struct dirent entry;
+  // The AssetManager directory descriptor this handle owns. It is only a
+  // placeholder used as a map key, but AssetManager::OpenDirectory() reserves a
+  // real descriptor, so it stays open until __wrap_closedir() releases it.
+  int fd;
 };
+
+// Wraps an AssetManager directory descriptor in the DIR handle from
+// __wrap_opendir()/__wrap_fdopendir().
+DIR* MakeAssetDir(AssetManager* asset_manager, int fd) {
+  std::vector<std::string> entries;
+  if (!asset_manager->GetDirectoryEntries(fd, &entries)) {
+    // fd stopped being an asset directory between the caller's check and
+    // this point, so nothing to enumerate and nothing to close.
+    errno = EBADF;
+    return NULL;
+  }
+
+  AndroidAssetDir* retdir = new AndroidAssetDir();
+  retdir->entries = std::move(entries);
+  retdir->index = 0;
+  retdir->fd = fd;
+  DIR* dir = reinterpret_cast<DIR*>(retdir);
+  asset_manager->RegisterAssetDir(dir);
+  return dir;
+}
 
 void FillAssetDirent(const std::string& name, struct dirent* out) {
   memset(out, 0, sizeof(*out));
@@ -55,6 +78,8 @@ void FillAssetDirent(const std::string& name, struct dirent* out) {
 extern "C" {
 DIR* __real_opendir(const char* path);
 
+DIR* __real_fdopendir(int fd);
+
 int __real_closedir(DIR* dir);
 
 struct dirent* __real_readdir(DIR* dir);
@@ -68,28 +93,34 @@ DIR* __wrap_opendir(const char* path) {
     return __real_opendir(path);
   }
 
-  std::vector<std::string> entries = ListAndroidAssetDir(path);
-  if (entries.empty()) {
-    errno = ENOENT;
+  AssetManager* asset_manager = AssetManager::GetInstance();
+  // OpenDirectory() sets errno to ENOTDIR or ENOENT on failure.
+  int fd = asset_manager->OpenDirectory(path);
+  if (fd < 0) {
     return NULL;
   }
+  return MakeAssetDir(asset_manager, fd);
+}
 
-  AndroidAssetDir* retdir = new AndroidAssetDir();
-  retdir->entries = std::move(entries);
-  retdir->index = 0;
-  DIR* dir = reinterpret_cast<DIR*>(retdir);
-  AssetManager::GetInstance()->RegisterAssetDir(dir);
-  return dir;
+DIR* __wrap_fdopendir(int fd) {
+  AssetManager* asset_manager = AssetManager::GetInstance();
+  if (!asset_manager->IsAssetDirFd(fd)) {
+    return __real_fdopendir(fd);
+  }
+
+  return MakeAssetDir(asset_manager, fd);
 }
 
 int __wrap_closedir(DIR* dir) {
   if (!dir) {
     return -1;
   }
-  if (AssetManager::GetInstance()->UnregisterAssetDir(dir)) {
+  AssetManager* asset_manager = AssetManager::GetInstance();
+  if (asset_manager->UnregisterAssetDir(dir)) {
     AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+    int result = asset_manager->CloseDirectory(asset_dir->fd);
     delete asset_dir;
-    return 0;
+    return result;
   }
   return __real_closedir(dir);
 }

--- a/starboard/android/shared/posix_emu/dirent.cc
+++ b/starboard/android/shared/posix_emu/dirent.cc
@@ -16,18 +16,37 @@
 #include <dirent.h>
 // clang-format on
 
-#include <android/asset_manager.h>
+#include <errno.h>
+#include <string.h>
 
-#include <map>
-#include <mutex>
+#include <string>
+#include <utility>
+#include <vector>
 
+#include "starboard/android/shared/asset_manager.h"
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/string.h"
-#include "starboard/configuration_constants.h"
 
+using starboard::AssetManager;
 using starboard::IsAndroidAssetPath;
-using starboard::OpenAndroidAsset;
-using starboard::OpenAndroidAssetDir;
+using starboard::ListAndroidAssetDir;
+
+namespace {
+
+// A helper structure used internally as a DIR replacement for asset paths.
+// It's used in the wrapped opendir/closedir/readdir/readdir_r.
+struct AndroidAssetDir {
+  std::vector<std::string> entries;
+  size_t index;
+  struct dirent entry;
+};
+
+void FillAssetDirent(const std::string& name, struct dirent* out) {
+  memset(out, 0, sizeof(*out));
+  starboard::strlcpy(out->d_name, name.c_str(), sizeof(out->d_name));
+}
+
+}  // namespace
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementations below exposed externally in pure C for emulation.
@@ -38,99 +57,38 @@ DIR* __real_opendir(const char* path);
 
 int __real_closedir(DIR* dir);
 
+struct dirent* __real_readdir(DIR* dir);
+
 int __real_readdir_r(DIR* __restrict dir,
                      struct dirent* __restrict dirent_buf,
                      struct dirent** __restrict dirent);
-
-// AAssetDir does not have a file descriptor so we must generate one
-// https://android.googlesource.com/platform/frameworks/base/+/master/native/android/asset_manager.cpp
-static int gen_fd() {
-  static int fd = 100;
-  fd++;
-  if (fd == 0x7FFFFFFF) {
-    fd = 100;
-  }
-  return fd;
-}
-
-std::mutex mutex_;
-static std::map<int, AAssetDir*>* asset_map = nullptr;
-
-static int handle_db_put(AAssetDir* assetDir) {
-  std::lock_guard scoped_lock(mutex_);
-  if (asset_map == nullptr) {
-    asset_map = new std::map<int, AAssetDir*>();
-  }
-
-  int fd = gen_fd();
-  // Go through the map and make sure there isn't duplicated index
-  // already.
-  while (asset_map->find(fd) != asset_map->end()) {
-    fd = gen_fd();
-  }
-  asset_map->insert({fd, assetDir});
-
-  return fd;
-}
-
-static AAssetDir* handle_db_get(int fd, bool erase) {
-  std::lock_guard scoped_lock(mutex_);
-  if (fd < 0) {
-    return nullptr;
-  }
-  if (asset_map == nullptr) {
-    return nullptr;
-  }
-
-  auto itr = asset_map->find(fd);
-  if (itr == asset_map->end()) {
-    return nullptr;
-  }
-
-  AAssetDir* asset_dir = itr->second;
-  if (erase) {
-    asset_map->erase(itr);
-  }
-  return asset_dir;
-}
-
-struct _PosixEmuAndroidAssetDir {
-  int64_t magic;
-  int fd;
-};
-
-constexpr int64_t kMagicNum = -1;
 
 DIR* __wrap_opendir(const char* path) {
   if (!IsAndroidAssetPath(path)) {
     return __real_opendir(path);
   }
 
-  AAssetDir* asset_dir = OpenAndroidAssetDir(path);
-  if (asset_dir) {
-    int descriptor = handle_db_put(asset_dir);
-    struct _PosixEmuAndroidAssetDir* retdir =
-        reinterpret_cast<_PosixEmuAndroidAssetDir*>(
-            malloc(sizeof(struct _PosixEmuAndroidAssetDir)));
-    retdir->magic = kMagicNum;
-    retdir->fd = descriptor;
-    return reinterpret_cast<DIR*>(retdir);
+  std::vector<std::string> entries = ListAndroidAssetDir(path);
+  if (entries.empty()) {
+    errno = ENOENT;
+    return NULL;
   }
-  return NULL;
+
+  AndroidAssetDir* retdir = new AndroidAssetDir();
+  retdir->entries = std::move(entries);
+  retdir->index = 0;
+  DIR* dir = reinterpret_cast<DIR*>(retdir);
+  AssetManager::GetInstance()->RegisterAssetDir(dir);
+  return dir;
 }
 
 int __wrap_closedir(DIR* dir) {
   if (!dir) {
     return -1;
   }
-  struct _PosixEmuAndroidAssetDir* adir = (struct _PosixEmuAndroidAssetDir*)dir;
-  if (adir->magic == kMagicNum) {  // This is an Asset
-    int descriptor = adir->fd;
-    AAssetDir* asset_dir = handle_db_get(descriptor, true);
-    if (asset_dir != nullptr) {
-      AAssetDir_close(asset_dir);
-    }
-    free(adir);
+  if (AssetManager::GetInstance()->UnregisterAssetDir(dir)) {
+    AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+    delete asset_dir;
     return 0;
   }
   return __real_closedir(dir);
@@ -140,23 +98,40 @@ int __wrap_readdir_r(DIR* __restrict dir,
                      struct dirent* __restrict dirent_buf,
                      struct dirent** __restrict dirent) {
   if (!dir) {
-    return -1;
+    // readdir_r() reports failure by returning an error number, not -1.
+    return EBADF;
   }
 
-  struct _PosixEmuAndroidAssetDir* adir = (struct _PosixEmuAndroidAssetDir*)dir;
-  if (adir->magic == kMagicNum) {  // This is an Asset
-    int descriptor = adir->fd;
-    AAssetDir* asset_dir = handle_db_get(descriptor, false);
-    const char* file_name = AAssetDir_getNextFileName(asset_dir);
-    if (file_name == NULL) {
-      return -1;
+  if (AssetManager::GetInstance()->IsAssetDir(dir)) {
+    AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+    if (asset_dir->index >= asset_dir->entries.size()) {
+      *dirent = NULL;  // End of directory
+      return 0;
     }
+    FillAssetDirent(asset_dir->entries[asset_dir->index++], dirent_buf);
     *dirent = dirent_buf;
-    starboard::strlcpy((*dirent)->d_name, file_name, kSbFileMaxName);
     return 0;
   }
 
   return __real_readdir_r(dir, dirent_buf, dirent);
+}
+
+struct dirent* __wrap_readdir(DIR* dir) {
+  if (!dir) {
+    errno = EBADF;
+    return NULL;
+  }
+
+  if (AssetManager::GetInstance()->IsAssetDir(dir)) {
+    AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+    if (asset_dir->index >= asset_dir->entries.size()) {
+      return NULL;
+    }
+    FillAssetDirent(asset_dir->entries[asset_dir->index++], &asset_dir->entry);
+    return &asset_dir->entry;
+  }
+
+  return __real_readdir(dir);
 }
 
 }  // extern "C"

--- a/starboard/android/shared/posix_emu/file.cc
+++ b/starboard/android/shared/posix_emu/file.cc
@@ -50,6 +50,9 @@ int __wrap_close(int fildes) {
   if (asset_manager->IsAssetFd(fildes)) {
     return asset_manager->Close(fildes);
   }
+  if (asset_manager->IsAssetDirFd(fildes)) {
+    return asset_manager->CloseDirectory(fildes);
+  }
   return __real_close(fildes);
 }
 
@@ -63,6 +66,10 @@ int __wrap_openat(int dirfd, const char* path, int oflag, ...) {
       return __real_openat(dirfd, path, oflag, mode);
     }
     return __real_openat(dirfd, path, oflag);
+  }
+  // handle asset paths
+  if ((oflag & O_DIRECTORY) == O_DIRECTORY) {
+    return AssetManager::GetInstance()->OpenDirectory(path);
   }
   return AssetManager::GetInstance()->Open(path, oflag);
 }

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -20,8 +20,8 @@
 #include "starboard/android/shared/file_internal.h"
 
 using starboard::IsAndroidAssetPath;
+using starboard::ListAndroidAssetDir;
 using starboard::OpenAndroidAsset;
-using starboard::OpenAndroidAssetDir;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementations below exposed externally in pure C for emulation.
@@ -58,13 +58,12 @@ int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags) {
     return 0;
   }
 
-  if (AAssetDir* asset_dir = OpenAndroidAssetDir(path)) {
+  if (!ListAndroidAssetDir(path).empty()) {
     info->st_mode = S_IFDIR | S_IRUSR | S_IXUSR;  // Read-only, traversable dir.
     info->st_ctime = 0;
     info->st_atime = 0;
     info->st_mtime = 0;
     info->st_size = 0;
-    AAssetDir_close(asset_dir);
     return 0;
   }
 

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -27,8 +27,8 @@
 using starboard::FallbackPath;
 #endif
 using starboard::IsAndroidAssetPath;
+using starboard::ListAndroidAssetDir;
 using starboard::OpenAndroidAsset;
-using starboard::OpenAndroidAssetDir;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementations below exposed externally in pure C for emulation.
@@ -80,13 +80,12 @@ int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags) {
     return 0;
   }
 
-  if (AAssetDir* asset_dir = OpenAndroidAssetDir(path)) {
+  if (!ListAndroidAssetDir(path).empty()) {
     info->st_mode = S_IFDIR | S_IRUSR | S_IXUSR;  // Read-only, traversable dir.
     info->st_ctime = 0;
     info->st_atime = 0;
     info->st_mtime = 0;
     info->st_size = 0;
-    AAssetDir_close(asset_dir);
     return 0;
   }
 

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -22,10 +22,14 @@ config("platform_configuration") {
     ldflags = [
       "-Wl,--wrap=access",
       "-Wl,--wrap=close",
+      "-Wl,--wrap=closedir",
       "-Wl,--wrap=fstatat",
       "-Wl,--wrap=if_indextoname",
       "-Wl,--wrap=open",
+      "-Wl,--wrap=opendir",
       "-Wl,--wrap=openat",
+      "-Wl,--wrap=readdir",
+      "-Wl,--wrap=readdir_r",
       "-Wl,--wrap=stat",
     ]
   }

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -23,6 +23,7 @@ config("platform_configuration") {
       "-Wl,--wrap=access",
       "-Wl,--wrap=close",
       "-Wl,--wrap=closedir",
+      "-Wl,--wrap=fdopendir",
       "-Wl,--wrap=fstatat",
       "-Wl,--wrap=if_indextoname",
       "-Wl,--wrap=open",

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -23,10 +23,14 @@ config("platform_configuration") {
       "-Wl,--wrap=access",
       "-Wl,--wrap=alarm",
       "-Wl,--wrap=close",
+      "-Wl,--wrap=closedir",
       "-Wl,--wrap=fstatat",
       "-Wl,--wrap=if_indextoname",
       "-Wl,--wrap=open",
+      "-Wl,--wrap=opendir",
       "-Wl,--wrap=openat",
+      "-Wl,--wrap=readdir",
+      "-Wl,--wrap=readdir_r",
       "-Wl,--wrap=stat",
     ]
   }

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -24,6 +24,7 @@ config("platform_configuration") {
       "-Wl,--wrap=alarm",
       "-Wl,--wrap=close",
       "-Wl,--wrap=closedir",
+      "-Wl,--wrap=fdopendir",
       "-Wl,--wrap=fstatat",
       "-Wl,--wrap=if_indextoname",
       "-Wl,--wrap=open",

--- a/starboard/nplb/posix_compliance/posix_directory_open_test.cc
+++ b/starboard/nplb/posix_compliance/posix_directory_open_test.cc
@@ -21,6 +21,7 @@
 */
 
 #include <dirent.h>
+#include <errno.h>
 #include <sys/stat.h>
 
 #include <string>
@@ -99,6 +100,33 @@ TEST(PosixDirectoryOpenTest, FailsRegularFile) {
   EXPECT_FALSE(directory != NULL);
   if (directory != NULL) {
     closedir(directory);
+  }
+}
+
+// ENOTDIR: The path names a file rather than a directory, for static content.
+TEST(PosixDirectoryOpenTest, FailsRegularFileStaticContent) {
+  for (auto path : GetFileTestsFilePaths()) {
+    errno = 0;
+    DIR* directory = opendir(path.c_str());
+    EXPECT_EQ(directory, nullptr) << path;
+    EXPECT_EQ(errno, ENOTDIR) << path;
+    if (directory != NULL) {
+      closedir(directory);
+    }
+  }
+}
+
+// ENOENT: The path does not exist, for static content.
+TEST(PosixDirectoryOpenTest, FailsMissingStaticContent) {
+  for (auto dir_path : GetFileTestsDirectoryPaths()) {
+    std::string path = dir_path + kSbFileSepChar + "does_not_exist";
+    errno = 0;
+    DIR* directory = opendir(path.c_str());
+    EXPECT_EQ(directory, nullptr) << path;
+    EXPECT_EQ(errno, ENOENT) << path;
+    if (directory != NULL) {
+      closedir(directory);
+    }
   }
 }
 

--- a/starboard/nplb/posix_compliance/posix_file_openat_test.cc
+++ b/starboard/nplb/posix_compliance/posix_file_openat_test.cc
@@ -120,6 +120,47 @@ TEST(PosixFileOpenatTest, FailsNotADirectory) {
   close(file_fd);
 }
 
+// ENOTDIR: O_DIRECTORY is set and path resolves to a non-directory file.
+TEST(PosixFileOpenatTest, FailsPathIsNotADirectory) {
+  ScopedRandomFile random_file(ScopedRandomFile::kCreate);
+
+  errno = 0;
+  int fd =
+      openat(AT_FDCWD, random_file.filename().c_str(), O_RDONLY | O_DIRECTORY);
+  EXPECT_EQ(fd, -1);
+  EXPECT_EQ(errno, ENOTDIR);
+  if (fd >= 0) {
+    close(fd);
+  }
+}
+
+// ENOTDIR: same as above, for static content.
+TEST(PosixFileOpenatTest, FailsPathIsNotADirectoryStaticContent) {
+  for (auto path : GetFileTestsFilePaths()) {
+    errno = 0;
+    int fd = openat(AT_FDCWD, path.c_str(), O_RDONLY | O_DIRECTORY);
+    EXPECT_EQ(fd, -1) << path;
+    EXPECT_EQ(errno, ENOTDIR) << path;
+    if (fd >= 0) {
+      close(fd);
+    }
+  }
+}
+
+// ENOENT: Path does not exist, for static content.
+TEST(PosixFileOpenatTest, FailsNoEntityStaticContent) {
+  for (auto dir_path : GetFileTestsDirectoryPaths()) {
+    std::string path = dir_path + kSbFileSepChar + "does_not_exist";
+    errno = 0;
+    int fd = openat(AT_FDCWD, path.c_str(), O_RDONLY);
+    EXPECT_EQ(fd, -1) << path;
+    EXPECT_EQ(errno, ENOENT) << path;
+    if (fd >= 0) {
+      close(fd);
+    }
+  }
+}
+
 // ENOENT: Path does not exist.
 TEST(PosixFileOpenatTest, FailsNoEntity) {
   ScopedTempDir temp_dir;

--- a/starboard/shared/modular/starboard_layer_posix_directory_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_directory_abi_wrappers.cc
@@ -34,13 +34,12 @@ int __abi_wrap_readdir_r(musl_dir* dirp,
   struct dirent* result = nullptr;
 // from POSIX.1-2008 readdir_r() was fully supported but emitting
 // a future deprecation warning. Marked as obsolecscent in POSIX.1-2024
-// TODO(b/374300500): add back posix emulation
 #if defined(_POSIX_VERSION) && (_POSIX_VERSION < 202406L) && defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
   int retval = readdir_r(dirp->dir, &entry, &result);
-#if defined(_POSIX_VERSION) && (_POSIX_VERSION < 202405L) && defined(__clang__)
+#if defined(_POSIX_VERSION) && (_POSIX_VERSION < 202406L) && defined(__clang__)
 #pragma clang diagnostic pop
 #endif
   if (retval != 0) {


### PR DESCRIPTION
Re-enable posix_emu directory functions emulation for and fix asset
subdirectory enumeration.

AAssetManager_openDir + AAssetDir_getNextFileName can't see
subdirectories which results in some tests that expect subdirs to be
enumerated to fail, such as PosixDirectoryOpenTest.SunnyDayStaticContent
and PosixDirectoryGetNextTest.SunnyDayStaticContent (and the
StaticContent stat tests).

Instead, use AssetManager.list() via JNI that can enumerate
subdirectories.

Also use the new enumeration function to fix fdopendir behavior.

Bug: 532068409