### PR TITLE
cobalt: Limit Finch histogram max to avoid overflow

### DIFF
--- a/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
+++ b/cobalt/browser/h5vcc_experiments/h5vcc_experiments_impl.cc
@@ -106,7 +106,7 @@ void H5vccExperimentsImpl::SetExperimentState(
     if (time_since_last_write.is_positive()) {
       base::UmaHistogramCustomTimes("Cobalt.Finch.TimeBetweenWrites",
                                     time_since_last_write, base::Hours(1),
-                                    base::Days(30), 50);
+                                    base::Days(24), 50);
     }
   }
 


### PR DESCRIPTION
Reduce the maximum duration for the Cobalt.Finch.TimeBetweenWrites
histogram from 30 days to 24 days. This change prevents a potential
integer overflow that can occur when recording these metrics over
extended periods.

Bug: 515520976