### PR TITLE
Support heap profiler on 3P devel and debug builds

### DIFF
--- a/starboard/build/config/modular/BUILD.gn
+++ b/starboard/build/config/modular/BUILD.gn
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import("//build/config/compiler/compiler.gni")
 import("//starboard/build/config/sanitizers.gni")
 
 config("modular") {
@@ -78,9 +79,6 @@ config("modular") {
       # Default visibility to hidden, to enable dead stripping.
       "-fvisibility=hidden",
       "-fno-exceptions",
-
-      # Disable usage of frame pointers.
-      "-fomit-frame-pointer",
       "-fno-strict-aliasing",  # See http://crbug.com/32204
       "-fno-use-cxa-atexit",
 
@@ -92,6 +90,12 @@ config("modular") {
       #         ^~~~~~~~~~~~~~~~~~~~~~~~~~~
       "-Wno-sign-compare",
     ]
+
+    if (!is_official_build || can_unwind_with_frame_pointers) {
+      cflags += [ "-fno-omit-frame-pointer" ]
+    } else {
+      cflags += [ "-fomit-frame-pointer" ]
+    }
   }
 
   if (use_asan) {

--- a/starboard/build/config/modular/arm/BUILD.gn
+++ b/starboard/build/config/modular/arm/BUILD.gn
@@ -26,4 +26,9 @@ config("arm") {
     # Force char to be signed.
     "-fsigned-char",
   ]
+
+  # Force ARM 32-bit mode (-marm) instead of Thumb-2 mode for non-official builds.
+  if (!is_official_build) {
+    cflags += [ "-marm" ]
+  }
 }


### PR DESCRIPTION
Enable heap profiling support for debug and devel build types. This
includes configuring GN flags to enable profiling, disabling ARM
thumb mode, and ensuring unwind tables are not excluded.

Bug: 537412550