### PR TITLE
feat: Add Sb extension for native stability events

### DIFF
--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -38,6 +38,12 @@
 #include "components/metrics_services_manager/metrics_services_manager.h"
 #include "content/public/browser/browser_thread.h"
 #include "content/public/browser/resource_coordinator_service.h"
+
+#if BUILDFLAG(USE_EVERGREEN)
+#include "starboard/extension/native_stability.h"
+#include "starboard/system.h"
+#endif
+
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/client_process_impl.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/memory_instrumentation_features.h"
@@ -230,6 +236,31 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
   client->SetUserAgentCrashAnnotation();
 
 #endif  // !BUILDFLAG(IS_ANDROIDTV)
+
+#if BUILDFLAG(USE_EVERGREEN)
+  // TODO: b/528362453 - This startup extension query is for debugging and to
+  // serve as an example of how to invoke the NativeStability extension.
+  // Remove this block once the NativeStabilityManager singleton is added to
+  // the browser to query the extension to respond to web app requests.
+  auto native_stability_extension =
+      static_cast<const CobaltExtensionNativeStabilityApi*>(
+          SbSystemGetExtension(kCobaltExtensionNativeStabilityName));
+  if (native_stability_extension && native_stability_extension->version >= 1 &&
+      native_stability_extension->ReadReports) {
+    constexpr int max_num_reports = 16;  // A somewhat arbitrary, large number
+    SbNativeStabilityReport reports[max_num_reports];
+    int count =
+        native_stability_extension->ReadReports(reports, max_num_reports);
+    LOG(INFO) << "=== NativeStability extension query at startup returned "
+              << count << " reports ===";
+    for (int i = 0; i < count; ++i) {
+      LOG(INFO) << "Report [" << i
+                << "]: event_uuid=" << reports[i].native_stability_event_uuid
+                << ", event_time_s=" << reports[i].event_time_s
+                << ", type=" << static_cast<int>(reports[i].report_type);
+    }
+  }
+#endif
 
   int result = ShellBrowserMainParts::PreMainMessageLoopRun();
 

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -261,6 +261,9 @@ if (current_toolchain == starboard_toolchain) {
     if (sb_filter_based_player) {
       deps += [ "//starboard/shared/starboard/player/filter/testing:player_filter_tests" ]
     }
+    if (use_evergreen) {
+      deps += [ "//starboard/crashpad_wrapper:crashpad_wrapper_test" ]
+    }
     if (is_starboard) {
       deps += [
         "//starboard/elf_loader:elf_loader_test",

--- a/starboard/BUILD.gn
+++ b/starboard/BUILD.gn
@@ -261,7 +261,7 @@ if (current_toolchain == starboard_toolchain) {
     if (sb_filter_based_player) {
       deps += [ "//starboard/shared/starboard/player/filter/testing:player_filter_tests" ]
     }
-    if (use_evergreen) {
+    if (use_evergreen && use_crashpad) {
       deps += [ "//starboard/crashpad_wrapper:crashpad_wrapper_test" ]
     }
     if (is_starboard) {

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/BUILD.gn
@@ -290,6 +290,13 @@ static_library("starboard_platform_sources") {
     "window/window_internal.cc",
   ]
 
+  if (use_evergreen) {
+    sources += [
+      "//starboard/shared/starboard/native_stability.cc",
+      "//starboard/shared/starboard/native_stability.h",
+    ]
+  }
+
   # TODO: b/495477543 - Fix speech synthesis for executable type loader_app cobalt launch.
   if (starboard_level_final_executable_type == "executable") {
     sources -= ["speech/speech_synthesis_is_supported.cc",]

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
@@ -50,6 +50,11 @@
 #include "starboard/shared/starboard/loader_app_metrics.h"
 #endif
 
+#if BUILDFLAG(USE_EVERGREEN)
+#include "starboard/extension/native_stability.h"
+#include "starboard/shared/starboard/native_stability.h"
+#endif
+
 const void* SbSystemGetExtension(const char* name) {
 #if BUILDFLAG(IS_STARBOARD)
   const elf_loader::EvergreenConfig* evergreen_config =
@@ -66,6 +71,11 @@ const void* SbSystemGetExtension(const char* name) {
   }
   if (strcmp(name, kStarboardExtensionLoaderAppMetricsName) == 0) {
     return starboard::GetLoaderAppMetricsApi();
+  }
+#endif
+#if BUILDFLAG(USE_EVERGREEN)
+  if (strcmp(name, kCobaltExtensionNativeStabilityName) == 0) {
+    return starboard::GetNativeStabilityApi();
   }
 #endif
   if (strcmp(name, kCobaltExtensionConfigurationName) == 0) {

--- a/starboard/crashpad_wrapper/BUILD.gn
+++ b/starboard/crashpad_wrapper/BUILD.gn
@@ -28,9 +28,28 @@ if (is_starboard && current_toolchain == starboard_toolchain) {
       "//starboard/elf_loader:evergreen_info",
       "//third_party/crashpad/crashpad/client",
       "//third_party/crashpad/crashpad/client:common",
+      "//third_party/crashpad/crashpad/snapshot",
+      "//third_party/crashpad/crashpad/util",
     ]
 
     data_deps = [ "//third_party/crashpad/crashpad/handler:crashpad_handler($native_toolchain)" ]
+  }
+
+  source_set("crashpad_wrapper_test") {
+    testonly = true
+    sources = [ "wrapper_test.cc" ]
+
+    deps = [
+      ":crashpad_wrapper",
+      "//base",
+      "//testing/gmock",
+      "//testing/gtest",
+      "//third_party/crashpad/crashpad/client",
+      "//third_party/crashpad/crashpad/minidump",
+      "//third_party/crashpad/crashpad/snapshot",
+      "//third_party/crashpad/crashpad/snapshot:test_support",
+      "//third_party/crashpad/crashpad/util",
+    ]
   }
 }
 

--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 
 #include <map>
+#include <memory>
 #include <optional>
 #include <vector>
 
@@ -54,7 +55,7 @@ const char kNativeStabilityHangUuidKey[] = "native_stability_hang_uuid";
 
 namespace {
 
-base::FilePath* g_database_path_override_for_testing = nullptr;
+std::unique_ptr<base::FilePath> g_database_path_override_for_testing;
 
 // TODO: Get evergreen information from installation.
 const std::string kCrashpadVersion = "1.0.0.0";
@@ -441,11 +442,11 @@ int ReadReports(SbNativeStabilityReport* reports, int max_num_reports) {
 namespace internal {
 
 void SetDatabasePathForTesting(const base::FilePath& path) {
-  delete g_database_path_override_for_testing;
   if (path.empty()) {
-    g_database_path_override_for_testing = nullptr;
+    g_database_path_override_for_testing.reset();
   } else {
-    g_database_path_override_for_testing = new base::FilePath(path);
+    g_database_path_override_for_testing =
+        std::make_unique<base::FilePath>(path);
   }
 }
 

--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -404,6 +404,11 @@ int ReadReports(SbNativeStabilityReport* reports, int max_num_reports) {
 
   std::vector<::crashpad::CrashReportDatabase::Report> all_reports;
 
+  // We generally expect to find zero pending reports and certainly don't expect
+  // to find many: just after the Crashpad handler snapshots a crash, it
+  // attempts to upload the report - or declines to do so because of client-side
+  // throttling - and in all cases, including throttled or failed uploads, then
+  // moves the report from |pending| to |completed|.
   std::vector<::crashpad::CrashReportDatabase::Report> pending_reports;
   if (database->GetPendingReports(&pending_reports) ==
       ::crashpad::CrashReportDatabase::kNoError) {

--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -18,6 +18,7 @@
 #include <sys/stat.h>
 
 #include <map>
+#include <optional>
 #include <vector>
 
 #include "base/files/file_path.h"
@@ -32,8 +33,12 @@
 #include "starboard/configuration_constants.h"
 #include "starboard/extension/crash_handler.h"
 #include "starboard/extension/loader_app_metrics.h"
+#include "starboard/extension/native_stability.h"
 #include "starboard/system.h"
+#include "third_party/crashpad/crashpad/snapshot/minidump/process_snapshot_minidump.h"
 #include "third_party/crashpad/crashpad/snapshot/sanitized/sanitization_information.h"
+#include "third_party/crashpad/crashpad/util/file/file_reader.h"
+#include "third_party/crashpad/crashpad/util/posix/signals.h"
 #include "util/misc/capture_context.h"
 
 using starboard::kSystemPropertyMaxLength;
@@ -44,8 +49,13 @@ const char kCrashpadVersionKey[] = "ver";
 const char kCrashpadProductKey[] = "prod";
 const char kCrashpadUserAgentStringKey[] = "user_agent_string";
 const char kCrashpadCertScopeKey[] = "cert_scope";
+const char kNativeStabilityCrashUuidKey[] = "native_stability_crash_uuid";
+const char kNativeStabilityHangUuidKey[] = "native_stability_hang_uuid";
 
 namespace {
+
+base::FilePath* g_database_path_override_for_testing = nullptr;
+
 // TODO: Get evergreen information from installation.
 const std::string kCrashpadVersion = "1.0.0.0";
 #if BUILDFLAG(COBALT_IS_RELEASE_BUILD)
@@ -85,6 +95,10 @@ base::FilePath GetPathToCrashpadHandlerBinary() {
 }
 
 base::FilePath GetDatabasePath() {
+  if (g_database_path_override_for_testing) {
+    return *g_database_path_override_for_testing;
+  }
+
   std::vector<char> cache_directory_path(kSbFileMaxPath);
   if (!SbSystemGetPath(kSbSystemPathCacheDirectory, cache_directory_path.data(),
                        kSbFileMaxPath)) {
@@ -210,6 +224,65 @@ void RecordStatus(CrashpadInstallationStatus status) {
   }
 }
 
+std::optional<SbNativeStabilityReport> ParseReportFromMinidump(
+    const ::crashpad::CrashReportDatabase::Report& report) {
+  ::crashpad::FileReader reader;
+  if (!reader.Open(report.file_path)) {
+    return std::nullopt;
+  }
+
+  ::crashpad::ProcessSnapshotMinidump snapshot;
+  if (!snapshot.Initialize(&reader)) {
+    return std::nullopt;
+  }
+
+  const std::map<std::string, std::string>& annotations =
+      snapshot.AnnotationsSimpleMap();
+  const ::crashpad::ExceptionSnapshot* exception = snapshot.Exception();
+  // Non-crashing minidumps captured for hangs via DumpWithoutCrashing have the
+  // exception code set to kSimulatedSigno, distinguishing them from actual
+  // signal-driven process crashes.
+  bool is_hang = exception && exception->Exception() ==
+                                  static_cast<uint32_t>(
+                                      ::crashpad::Signals::kSimulatedSigno);
+
+  std::string event_uuid;
+  SbNativeStabilityReportType report_type = kSbNativeStabilityReportUnknown;
+  if (is_hang) {
+    report_type = kSbNativeStabilityReportHang;
+    auto hang_uuid_it = annotations.find(kNativeStabilityHangUuidKey);
+    if (hang_uuid_it != annotations.end()) {
+      event_uuid = hang_uuid_it->second;
+    }
+  } else {
+    report_type = kSbNativeStabilityReportCrash;
+    auto crash_uuid_it = annotations.find(kNativeStabilityCrashUuidKey);
+    if (crash_uuid_it != annotations.end()) {
+      event_uuid = crash_uuid_it->second;
+    }
+  }
+
+  constexpr size_t kExpectedUuidLength =
+      sizeof(SbNativeStabilityReport::native_stability_event_uuid) - 1;
+  if (event_uuid.size() != kExpectedUuidLength) {
+    return std::nullopt;
+  }
+
+  timeval snapshot_time{};
+  snapshot.SnapshotTime(&snapshot_time);
+
+  SbNativeStabilityReport native_stability_report{};
+  native_stability_report.event_time_s =
+      static_cast<int64_t>(snapshot_time.tv_sec);
+  native_stability_report.report_type = report_type;
+
+  memcpy(native_stability_report.native_stability_event_uuid,
+         event_uuid.c_str(), kExpectedUuidLength);
+  native_stability_report.native_stability_event_uuid[kExpectedUuidLength] =
+      '\0';
+  return native_stability_report;
+}
+
 }  // namespace
 
 void InstallCrashpadHandler(const std::string& ca_certificates_path) {
@@ -290,6 +363,14 @@ void InstallCrashpadHandler(const std::string& ca_certificates_path) {
         &DumpWithoutCrashingWrapper);
   }
 
+  auto native_stability_extension =
+      static_cast<const CobaltExtensionNativeStabilityApi*>(
+          SbSystemGetExtension(kCobaltExtensionNativeStabilityName));
+  if (native_stability_extension && native_stability_extension->version >= 1 &&
+      native_stability_extension->RegisterReadReportsCallback) {
+    native_stability_extension->RegisterReadReportsCallback(&ReadReports);
+  }
+
   RecordStatus(CrashpadInstallationStatus::kSucceeded);
 }
 
@@ -308,5 +389,61 @@ void DumpWithoutCrashingWrapper() {
   ::crashpad::CaptureContext(&context);
   ::crashpad::CrashpadClient::DumpWithoutCrash(&context);
 }
+
+int ReadReports(SbNativeStabilityReport* reports, int max_num_reports) {
+  const base::FilePath database_directory_path = GetDatabasePath();
+  if (!reports || max_num_reports <= 0 || database_directory_path.empty()) {
+    return -1;
+  }
+
+  std::unique_ptr<::crashpad::CrashReportDatabase> database =
+      ::crashpad::CrashReportDatabase::Initialize(database_directory_path);
+  if (!database) {
+    return -1;
+  }
+
+  std::vector<::crashpad::CrashReportDatabase::Report> all_reports;
+
+  std::vector<::crashpad::CrashReportDatabase::Report> pending_reports;
+  if (database->GetPendingReports(&pending_reports) ==
+      ::crashpad::CrashReportDatabase::kNoError) {
+    all_reports.insert(all_reports.end(), pending_reports.begin(),
+                       pending_reports.end());
+  }
+
+  std::vector<::crashpad::CrashReportDatabase::Report> completed_reports;
+  if (database->GetCompletedReports(&completed_reports) ==
+      ::crashpad::CrashReportDatabase::kNoError) {
+    all_reports.insert(all_reports.end(), completed_reports.begin(),
+                       completed_reports.end());
+  }
+
+  int count = 0;
+  for (const auto& report : all_reports) {
+    if (count >= max_num_reports) {
+      break;
+    }
+    std::optional<SbNativeStabilityReport> sb_native_stability_report =
+        ParseReportFromMinidump(report);
+    if (sb_native_stability_report.has_value()) {
+      reports[count++] = sb_native_stability_report.value();
+    }
+  }
+
+  return count;
+}
+
+namespace internal {
+
+void SetDatabasePathForTesting(const base::FilePath& path) {
+  delete g_database_path_override_for_testing;
+  if (path.empty()) {
+    g_database_path_override_for_testing = nullptr;
+  } else {
+    g_database_path_override_for_testing = new base::FilePath(path);
+  }
+}
+
+}  // namespace internal
 
 }  // namespace crashpad

--- a/starboard/crashpad_wrapper/wrapper.h
+++ b/starboard/crashpad_wrapper/wrapper.h
@@ -18,6 +18,11 @@
 #include <string>
 
 #include "starboard/elf_loader/evergreen_info.h"  // nogncheck
+#include "starboard/extension/native_stability.h"
+
+namespace base {
+class FilePath;
+}  // namespace base
 
 namespace crashpad {
 
@@ -32,6 +37,12 @@ extern const char kCrashpadUserAgentStringKey[];
 
 // The key name used in Crashpad for the cert_scope annotation.
 extern const char kCrashpadCertScopeKey[];
+
+// The key name used in Crashpad for the native stability crash UUID.
+extern const char kNativeStabilityCrashUuidKey[];
+
+// The key name used in Crashpad for the native stability hang UUID.
+extern const char kNativeStabilityHangUuidKey[];
 
 // Installs a signal handler to handle a crash. The signal handler will launch a
 // Crashpad handler process in response to a crash.
@@ -50,6 +61,16 @@ bool InsertCrashpadAnnotation(const char* key, const char* value);
 
 // Captures CPU context and triggers a non-crashing dump report.
 void DumpWithoutCrashingWrapper();
+
+// Reads up to |max_num_reports| stability reports (crashes and hangs)
+// currently stored in the local Crashpad database (both pending and completed).
+// Returns the number of reports read, or -1 on failure.
+int ReadReports(SbNativeStabilityReport* reports, int max_num_reports);
+
+namespace internal {
+// Sets the global database path override for testing.
+void SetDatabasePathForTesting(const base::FilePath& path);
+}  // namespace internal
 
 }  // namespace crashpad
 

--- a/starboard/crashpad_wrapper/wrapper_test.cc
+++ b/starboard/crashpad_wrapper/wrapper_test.cc
@@ -1,0 +1,223 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/crashpad_wrapper/wrapper.h"
+
+#include <sys/time.h>
+
+#include <csignal>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/files/file_path.h"
+#include "base/files/scoped_temp_dir.h"
+#include "starboard/extension/native_stability.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/crashpad/crashpad/client/crash_report_database.h"
+#include "third_party/crashpad/crashpad/minidump/minidump_file_writer.h"
+#include "third_party/crashpad/crashpad/snapshot/test/test_cpu_context.h"
+#include "third_party/crashpad/crashpad/snapshot/test/test_exception_snapshot.h"
+#include "third_party/crashpad/crashpad/snapshot/test/test_process_snapshot.h"
+#include "third_party/crashpad/crashpad/snapshot/test/test_system_snapshot.h"
+#include "third_party/crashpad/crashpad/snapshot/test/test_thread_snapshot.h"
+#include "third_party/crashpad/crashpad/util/misc/uuid.h"
+#include "third_party/crashpad/crashpad/util/posix/signals.h"
+
+namespace crashpad {
+namespace {
+
+constexpr char kTestCrashUuid[] = "12345678-1234-1234-1234-123456789abc";
+constexpr char kTestHangUuid[] = "abcdef87-4321-4321-4321-cba987654321";
+
+class CrashpadWrapperTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    internal::SetDatabasePathForTesting(temp_dir_.GetPath());
+    db_ = CrashReportDatabase::Initialize(temp_dir_.GetPath());
+    ASSERT_TRUE(db_);
+  }
+
+  void TearDown() override {
+    internal::SetDatabasePathForTesting(base::FilePath());
+  }
+
+  base::FilePath db_path() const { return temp_dir_.GetPath(); }
+
+  void AddReportToDatabase(const std::string& annotation_key,
+                           const std::string& uuid_val,
+                           int64_t timestamp_sec,
+                           bool is_hang,
+                           bool is_completed = false) {
+    std::unique_ptr<CrashReportDatabase::NewReport> new_report;
+    ASSERT_EQ(db_->PrepareNewCrashReport(&new_report),
+              CrashReportDatabase::kNoError);
+
+    test::TestProcessSnapshot snapshot;
+    timeval snapshot_time{};
+    snapshot_time.tv_sec = static_cast<time_t>(timestamp_sec);
+    snapshot.SetSnapshotTime(snapshot_time);
+    snapshot.SetAnnotationsSimpleMap({{annotation_key, uuid_val}});
+
+    auto system_snapshot = std::make_unique<test::TestSystemSnapshot>();
+    // MinidumpFileWriter requires OS, architecture, and thread CPU context to
+    // be populated to serialize a valid minidump payload. Hardcoding X86_64 and
+    // Linux is portable across all Evergreen architectures because Crashpad's
+    // synthetic test snapshot writers compile and run on all target platforms,
+    // and ReadReports only parses minidump annotations and timestamps.
+    system_snapshot->SetCPUArchitecture(kCPUArchitectureX86_64);
+    system_snapshot->SetOperatingSystem(SystemSnapshot::kOperatingSystemLinux);
+    snapshot.SetSystem(std::move(system_snapshot));
+
+    // Crashpad requires the exception snapshot thread ID to match an existing
+    // thread in the process snapshot thread list.
+    constexpr uint64_t kArbitraryThreadId = 1001;
+    // A non-zero seed initializes CPU context registers with non-zero dummy
+    // data to satisfy Crashpad context serialization checks.
+    constexpr uint32_t kArbitraryContextSeed = 1;
+
+    auto thread_snapshot = std::make_unique<test::TestThreadSnapshot>();
+    thread_snapshot->SetThreadID(kArbitraryThreadId);
+    test::InitializeCPUContextX86_64(thread_snapshot->MutableContext(),
+                                     kArbitraryContextSeed);
+    snapshot.AddThread(std::move(thread_snapshot));
+
+    auto exception = std::make_unique<test::TestExceptionSnapshot>();
+    exception->SetThreadID(kArbitraryThreadId);
+    if (is_hang) {
+      exception->SetException(
+          static_cast<uint32_t>(::crashpad::Signals::kSimulatedSigno));
+    } else {
+      exception->SetException(SIGSEGV);
+    }
+    test::InitializeCPUContextX86_64(exception->MutableContext(),
+                                     kArbitraryContextSeed);
+    snapshot.SetException(std::move(exception));
+
+    MinidumpFileWriter minidump;
+    minidump.InitializeFromSnapshot(&snapshot);
+    ASSERT_TRUE(minidump.WriteEverything(new_report->Writer()));
+
+    UUID uuid;
+    ASSERT_EQ(db_->FinishedWritingCrashReport(std::move(new_report), &uuid),
+              CrashReportDatabase::kNoError);
+
+    if (is_completed) {
+      std::unique_ptr<const CrashReportDatabase::UploadReport> upload_report;
+      ASSERT_EQ(db_->GetReportForUploading(uuid, &upload_report),
+                CrashReportDatabase::kNoError);
+      ASSERT_EQ(db_->RecordUploadComplete(std::move(upload_report), "id_1"),
+                CrashReportDatabase::kNoError);
+    }
+  }
+
+ private:
+  base::ScopedTempDir temp_dir_;
+  std::unique_ptr<CrashReportDatabase> db_;
+};
+
+TEST_F(CrashpadWrapperTest, NullReportsBufferReturnsError) {
+  EXPECT_EQ(ReadReports(nullptr, 1), -1);
+}
+
+TEST_F(CrashpadWrapperTest, NonPositiveMaxReportsReturnsError) {
+  SbNativeStabilityReport reports[1];
+  EXPECT_EQ(ReadReports(reports, 0), -1);
+  EXPECT_EQ(ReadReports(reports, -1), -1);
+}
+
+TEST_F(CrashpadWrapperTest, EmptyDatabaseReturnsZero) {
+  SbNativeStabilityReport reports[1];
+  EXPECT_EQ(ReadReports(reports, 1), 0);
+}
+
+TEST_F(CrashpadWrapperTest, ReadsPendingCrashReport) {
+  constexpr int64_t kTestTimestampSec = 100000;
+  AddReportToDatabase(kNativeStabilityCrashUuidKey, kTestCrashUuid,
+                      kTestTimestampSec, /*is_hang=*/false,
+                      /*is_completed=*/false);
+
+  SbNativeStabilityReport reports[1]{};
+  int count = ReadReports(reports, 1);
+  EXPECT_EQ(count, 1);
+  EXPECT_EQ(reports[0].report_type, kSbNativeStabilityReportCrash);
+  EXPECT_STREQ(reports[0].native_stability_event_uuid, kTestCrashUuid);
+  EXPECT_EQ(reports[0].event_time_s, kTestTimestampSec);
+}
+
+TEST_F(CrashpadWrapperTest, ReadsPendingHangReport) {
+  constexpr int64_t kTestTimestampSec = 200000;
+  AddReportToDatabase(kNativeStabilityHangUuidKey, kTestHangUuid,
+                      kTestTimestampSec, /*is_hang=*/true,
+                      /*is_completed=*/false);
+
+  SbNativeStabilityReport reports[1]{};
+  int count = ReadReports(reports, 1);
+  EXPECT_EQ(count, 1);
+  EXPECT_EQ(reports[0].report_type, kSbNativeStabilityReportHang);
+  EXPECT_STREQ(reports[0].native_stability_event_uuid, kTestHangUuid);
+  EXPECT_EQ(reports[0].event_time_s, kTestTimestampSec);
+}
+
+TEST_F(CrashpadWrapperTest, ReadsCompletedCrashReport) {
+  constexpr int64_t kTestTimestampSec = 300000;
+  AddReportToDatabase(kNativeStabilityCrashUuidKey, kTestCrashUuid,
+                      kTestTimestampSec, /*is_hang=*/false,
+                      /*is_completed=*/true);
+
+  SbNativeStabilityReport reports[1]{};
+  int count = ReadReports(reports, 1);
+  EXPECT_EQ(count, 1);
+  EXPECT_EQ(reports[0].report_type, kSbNativeStabilityReportCrash);
+  EXPECT_STREQ(reports[0].native_stability_event_uuid, kTestCrashUuid);
+  EXPECT_EQ(reports[0].event_time_s, kTestTimestampSec);
+}
+
+TEST_F(CrashpadWrapperTest, ReadsCompletedHangReport) {
+  constexpr int64_t kTestTimestampSec = 400000;
+  AddReportToDatabase(kNativeStabilityHangUuidKey, kTestHangUuid,
+                      kTestTimestampSec, /*is_hang=*/true,
+                      /*is_completed=*/true);
+
+  SbNativeStabilityReport reports[1]{};
+  int count = ReadReports(reports, 1);
+  EXPECT_EQ(count, 1);
+  EXPECT_EQ(reports[0].report_type, kSbNativeStabilityReportHang);
+  EXPECT_STREQ(reports[0].native_stability_event_uuid, kTestHangUuid);
+  EXPECT_EQ(reports[0].event_time_s, kTestTimestampSec);
+}
+
+TEST_F(CrashpadWrapperTest, IgnoresReportWithInvalidUuidLength) {
+  AddReportToDatabase(kNativeStabilityCrashUuidKey, "invalid-uuid-too-short",
+                      100000, /*is_hang=*/false, /*is_completed=*/false);
+
+  SbNativeStabilityReport reports[1]{};
+  EXPECT_EQ(ReadReports(reports, 1), 0);
+}
+
+TEST_F(CrashpadWrapperTest, MaxNumReportsCapTruncatesOutputCount) {
+  AddReportToDatabase(kNativeStabilityCrashUuidKey, kTestCrashUuid, 100000,
+                      /*is_hang=*/false, /*is_completed=*/false);
+  AddReportToDatabase(kNativeStabilityHangUuidKey, kTestHangUuid, 200000,
+                      /*is_hang=*/true, /*is_completed=*/false);
+
+  SbNativeStabilityReport reports[1]{};
+  EXPECT_EQ(ReadReports(reports, 1), 1);
+}
+
+}  // namespace
+}  // namespace crashpad

--- a/starboard/extension/extension_test.cc
+++ b/starboard/extension/extension_test.cc
@@ -29,6 +29,7 @@
 #include "starboard/extension/loader_app_metrics.h"
 #include "starboard/extension/media_session.h"
 #include "starboard/extension/memory_mapped_file.h"
+#include "starboard/extension/native_stability.h"
 #include "starboard/extension/platform_info.h"
 #include "starboard/extension/platform_service.h"
 #include "starboard/extension/player_configuration.h"
@@ -622,6 +623,27 @@ TEST(ExtensionTest, StarboardMediaBufferPoolExtension) {
   EXPECT_NE(extension_api->ShrinkToZero, nullptr);
   EXPECT_NE(extension_api->ExpandTo, nullptr);
   EXPECT_NE(extension_api->Write, nullptr);
+
+  const ExtensionApi* second_extension_api =
+      static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));
+  EXPECT_EQ(second_extension_api, extension_api)
+      << "Extension struct should be a singleton";
+}
+
+TEST(ExtensionTest, NativeStabilityExtension) {
+  typedef CobaltExtensionNativeStabilityApi ExtensionApi;
+  const char* kExtensionName = kCobaltExtensionNativeStabilityName;
+
+  const ExtensionApi* extension_api =
+      static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));
+  if (!extension_api) {
+    return;
+  }
+
+  EXPECT_STREQ(extension_api->name, kExtensionName);
+  EXPECT_EQ(extension_api->version, 1u);
+  EXPECT_NE(extension_api->ReadReports, nullptr);
+  EXPECT_NE(extension_api->RegisterReadReportsCallback, nullptr);
 
   const ExtensionApi* second_extension_api =
       static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));

--- a/starboard/extension/native_stability.h
+++ b/starboard/extension/native_stability.h
@@ -1,0 +1,74 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_EXTENSION_NATIVE_STABILITY_H_
+#define STARBOARD_EXTENSION_NATIVE_STABILITY_H_
+
+#include <stdint.h>
+
+#include "starboard/configuration.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define kCobaltExtensionNativeStabilityName \
+  "dev.cobalt.extension.NativeStability"
+
+typedef enum SbNativeStabilityReportType {
+  kSbNativeStabilityReportUnknown = 0,
+  kSbNativeStabilityReportCrash = 1,
+  kSbNativeStabilityReportHang = 2,
+} SbNativeStabilityReportType;
+
+typedef struct SbNativeStabilityReport {
+  // A null-terminated string holding the 36-character canonical
+  // representation of a UUID (formatted as 8-4-4-4-12 hex characters with
+  // hyphens) plus 1 byte for the null terminator.
+  char native_stability_event_uuid[37];
+  int64_t event_time_s;
+  SbNativeStabilityReportType report_type;
+} SbNativeStabilityReport;
+
+typedef int (*ReadReportsCallback)(SbNativeStabilityReport* reports,
+                                   int max_num_reports);
+
+typedef struct CobaltExtensionNativeStabilityApi {
+  // Name should be the string |kCobaltExtensionNativeStabilityName|.
+  // This helps to validate that the extension API is correct.
+  const char* name;
+
+  // This specifies the version of the API that is implemented.
+  uint32_t version;
+
+  // The fields below this point were added in version 1 or later.
+
+  // Reads crash and hang reports from local storage (e.g., the Crashpad
+  // database) along with their metadata and annotations.
+  //
+  // Populates |reports| with up to |max_num_reports| stability reports.
+  // Returns the number of reports populated, or -1 on failure.
+  int (*ReadReports)(SbNativeStabilityReport* reports, int max_num_reports);
+
+  // Registers the provided callback to be called by the extension's
+  // |ReadReports| implementation. This is used to delegate to an injected
+  // dependency to avoid dependency cycles.
+  void (*RegisterReadReportsCallback)(ReadReportsCallback callback);
+} CobaltExtensionNativeStabilityApi;
+
+#ifdef __cplusplus
+}  // extern "C"
+#endif
+
+#endif  // STARBOARD_EXTENSION_NATIVE_STABILITY_H_

--- a/starboard/linux/shared/BUILD.gn
+++ b/starboard/linux/shared/BUILD.gn
@@ -231,6 +231,8 @@ static_library("starboard_platform_sources") {
     sources += [
       "//starboard/shared/starboard/crash_handler.cc",
       "//starboard/shared/starboard/crash_handler.h",
+      "//starboard/shared/starboard/native_stability.cc",
+      "//starboard/shared/starboard/native_stability.h",
     ]
   }
 

--- a/starboard/linux/shared/system_get_extensions.cc
+++ b/starboard/linux/shared/system_get_extensions.cc
@@ -35,9 +35,11 @@
 
 #if BUILDFLAG(USE_EVERGREEN)
 #include "starboard/extension/crash_handler.h"
+#include "starboard/extension/native_stability.h"
 #include "starboard/extension/platform_service.h"
 #include "starboard/linux/shared/platform_service.h"
 #include "starboard/shared/starboard/crash_handler.h"
+#include "starboard/shared/starboard/native_stability.h"
 #endif
 
 const void* SbSystemGetExtension(const char* name) {
@@ -58,6 +60,9 @@ const void* SbSystemGetExtension(const char* name) {
 #if BUILDFLAG(USE_EVERGREEN)
   if (strcmp(name, kCobaltExtensionCrashHandlerName) == 0) {
     return starboard::GetCrashHandlerApi();
+  }
+  if (strcmp(name, kCobaltExtensionNativeStabilityName) == 0) {
+    return starboard::GetNativeStabilityApi();
   }
 
   // TODO: b/371419798 - enable for non-evergreen builds once we've resolved the

--- a/starboard/shared/starboard/native_stability.cc
+++ b/starboard/shared/starboard/native_stability.cc
@@ -1,0 +1,60 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/shared/starboard/native_stability.h"
+
+#include <pthread.h>
+
+#include "starboard/common/check_op.h"
+#include "starboard/extension/native_stability.h"
+
+namespace starboard {
+
+namespace {
+
+ReadReportsCallback g_read_reports_callback = nullptr;
+pthread_mutex_t g_read_reports_callback_mutex = PTHREAD_MUTEX_INITIALIZER;
+
+int ReadReports(SbNativeStabilityReport* reports, int max_num_reports) {
+  int result = -1;
+
+  SB_CHECK_EQ(pthread_mutex_lock(&g_read_reports_callback_mutex), 0);
+  if (g_read_reports_callback) {
+    result = g_read_reports_callback(reports, max_num_reports);
+  }
+  SB_CHECK_EQ(pthread_mutex_unlock(&g_read_reports_callback_mutex), 0);
+
+  return result;
+}
+
+void RegisterReadReportsCallback(ReadReportsCallback callback) {
+  SB_CHECK_EQ(pthread_mutex_lock(&g_read_reports_callback_mutex), 0);
+  g_read_reports_callback = callback;
+  SB_CHECK_EQ(pthread_mutex_unlock(&g_read_reports_callback_mutex), 0);
+}
+
+const CobaltExtensionNativeStabilityApi kNativeStabilityApi = {
+    kCobaltExtensionNativeStabilityName,
+    1,
+    &ReadReports,
+    &RegisterReadReportsCallback,
+};
+
+}  // namespace
+
+const void* GetNativeStabilityApi() {
+  return &kNativeStabilityApi;
+}
+
+}  // namespace starboard

--- a/starboard/shared/starboard/native_stability.cc
+++ b/starboard/shared/starboard/native_stability.cc
@@ -27,15 +27,14 @@ ReadReportsCallback g_read_reports_callback = nullptr;
 pthread_mutex_t g_read_reports_callback_mutex = PTHREAD_MUTEX_INITIALIZER;
 
 int ReadReports(SbNativeStabilityReport* reports, int max_num_reports) {
-  int result = -1;
-
   SB_CHECK_EQ(pthread_mutex_lock(&g_read_reports_callback_mutex), 0);
-  if (g_read_reports_callback) {
-    result = g_read_reports_callback(reports, max_num_reports);
-  }
+  ReadReportsCallback callback = g_read_reports_callback;
   SB_CHECK_EQ(pthread_mutex_unlock(&g_read_reports_callback_mutex), 0);
 
-  return result;
+  if (callback) {
+    return callback(reports, max_num_reports);
+  }
+  return -1;
 }
 
 void RegisterReadReportsCallback(ReadReportsCallback callback) {

--- a/starboard/shared/starboard/native_stability.h
+++ b/starboard/shared/starboard/native_stability.h
@@ -1,0 +1,24 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_SHARED_STARBOARD_NATIVE_STABILITY_H_
+#define STARBOARD_SHARED_STARBOARD_NATIVE_STABILITY_H_
+
+namespace starboard {
+
+const void* GetNativeStabilityApi();
+
+}  // namespace starboard
+
+#endif  // STARBOARD_SHARED_STARBOARD_NATIVE_STABILITY_H_


### PR DESCRIPTION
This change adds the Starboard extension and 3P implementation proposed in go/cmc-storage-3p-mvp-design, and a temporary usage example in the Cobalt layer.

Based on offline discussion after the design review, this implementation refers to crashes, hangs, etc. as Native Stability (events) rather than Core Metric Components.

#vibe-coded

Issue: 528362453