### PR TITLE
Update memory benchmarks output files

### DIFF
--- a/cobalt/tools/performance/memory/rdk_kabuki_memory_benchmark.sh
+++ b/cobalt/tools/performance/memory/rdk_kabuki_memory_benchmark.sh
@@ -7,7 +7,7 @@
 readonly CALLSIGN="YouTube"
 readonly PROCESS_NAME="YouTube"
 readonly INTERVAL=1
-readonly OUTPUT_FILE="memory_test_results_kabuki_$(date +%Y%m%d).txt"
+readonly OUTPUT_FILE="memory_test_results_kabuki_$(date +%Y%m%d_%H%M%S).txt"
 # Delay to allow WPEFramework to process state changes and configuration updates
 readonly JSONRPC_DELAY=2
 

--- a/cobalt/tools/performance/memory/rdk_yttv_memory_benchmark.sh
+++ b/cobalt/tools/performance/memory/rdk_yttv_memory_benchmark.sh
@@ -7,7 +7,7 @@
 readonly CALLSIGN="YouTube"
 readonly PROCESS_NAME="YouTube"
 readonly INTERVAL=1
-readonly OUTPUT_FILE="memory_test_results_yttv_$(date +%Y%m%d).txt"
+readonly OUTPUT_FILE="memory_test_results_yttv_$(date +%Y%m%d_%H%M%S).txt"
 # Delay to allow WPEFramework to process state changes and configuration updates
 readonly JSONRPC_DELAY=2
 


### PR DESCRIPTION
Modify rdk_kabuki_memory_benchmark.sh and rdk_yttv_memory_benchmark.sh to append a timestamp to OUTPUT_FILE to prevent collisions. Also create a basic git skill piece of documentation.

Issue: 477961848
TAG=agy
CONV=cd22c0bb-b327-47bf-83f5-c7af5d192072