### PR TITLE
rdk: Export XDG_RUNTIME_DIR and WAYLAND_DISPLAY in deploy_rdk.py

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -275,6 +275,7 @@ def launch_on_device(
         remote_cmds += [
             "rdkDisplay create",
             "sleep 2",
+            "export XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0",
             f"./{test_name}_loader.py {xml_out}{gtest_filter}",
             "rdkDisplay remove",
             "sleep 2",
@@ -358,6 +359,7 @@ def launch_on_device(
             "sleep 2",
             "rdkDisplay create",
             "sleep 2",
+            "export XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0",
             f"./loader_app {' '.join(param)}" if param else "./loader_app",
             "rdkDisplay remove",
             "sleep 2",

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -275,8 +275,7 @@ def launch_on_device(
         remote_cmds += [
             "rdkDisplay create",
             "sleep 2",
-            "export XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0",
-            f"./{test_name}_loader.py {xml_out}{gtest_filter}",
+            f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./{test_name}_loader.py {xml_out}{gtest_filter}",
             "rdkDisplay remove",
             "sleep 2",
         ]
@@ -359,8 +358,7 @@ def launch_on_device(
             "sleep 2",
             "rdkDisplay create",
             "sleep 2",
-            "export XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0",
-            f"./loader_app {' '.join(param)}" if param else "./loader_app",
+            f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app {' '.join(param)}" if param else "XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app",
             "rdkDisplay remove",
             "sleep 2",
         ]


### PR DESCRIPTION
Set `XDG_RUNTIME_DIR=/run` and `WAYLAND_DISPLAY=test-0` in `deploy_rdk.py` test and loader launch sequences.

When running tests over non-interactive SSH sessions, login profiles are not sourced and `XDG_RUNTIME_DIR` / `WAYLAND_DISPLAY` are unset. This causes Essos/Westeros to log `error: XDG_RUNTIME_DIR not set in the environment.` and fall back to direct DRM (`isWayland 0`), which crashes EGL display initialization (`EGL_NOT_INITIALIZED (12289)`).

Exporting these variables ensures that client processes connect to the Wayland display socket created by `rdkDisplay create`.

Issue: 508253341