### PR TITLE
rdk: Unfilter passing window/graphics tests in nplb_loader_filter.json

### DIFF
--- a/cobalt/testing/filters/evergreen-arm-hardfp-rdk/nplb_loader_filter.json
+++ b/cobalt/testing/filters/evergreen-arm-hardfp-rdk/nplb_loader_filter.json
@@ -49,7 +49,6 @@
     "SbSystemGetPropertyTest.ReturnsRequired",
     "SbSystemSymbolizeTest.SunnyDay",
     "SbTimeZoneGetNameTest.IsIANAFormat",
-    "SbWindowGetSizeTest.SunnyDay",
     "VerticalVideoTests/VerticalVideoTest.*"
   ]
 }


### PR DESCRIPTION
Unfilter `SbWindowGetSizeTest.SunnyDay` from `nplb_loader_filter.json`.

With the Wayland display environment export fix (PR #11486), Wayland window size queries and EGL display initialization succeed on RDK.