### PR TITLE
Merge Rust static libraries into cobalt.a on tvOS using GN

### DIFF
--- a/build/rust/rust_target.gni
+++ b/build/rust/rust_target.gni
@@ -474,6 +474,17 @@ template("rust_target") {
         }
       }
 
+      if (invoker.target_type == "rust_library") {
+        if (defined(output_dir)) {
+          _out_dir = output_dir
+        } else {
+          _out_dir = target_out_dir
+        }
+        metadata = {
+          rust_libraries = [ "$_out_dir/lib${output_name}.rlib" ]
+        }
+      }
+
       if (!_allow_unsafe) {
         configs += [ "//build/rust:forbid_unsafe" ]
       }

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -128,10 +128,10 @@ if (is_ios && target_platform == "tvos") {
     info_plist = cobalt_info_plist
   }
 
-  # Bundles the browser engine and starboard dependencies into a unified, non-thin
-  # static library for custom Apple TV application integration and CI packaging.
-  static_library("cobalt_archive") {
+  # The C++ archive containing all C++ dependencies.
+  static_library("cobalt_archive_internal") {
     complete_static_lib = true
+    output_name = "cobalt_archive_internal"
 
     configs -= [ "//build/config/compiler:thin_archive" ]
 
@@ -145,6 +145,36 @@ if (is_ios && target_platform == "tvos") {
       "//components/crash/core/app",
       "//content/public/app",
       "//starboard:starboard_group",
+    ]
+  }
+
+  # Collects the paths of all transitive Rust dependencies.
+  generated_file("cobalt_rust_libraries") {
+    outputs = [ "$target_gen_dir/cobalt_rust_libraries.txt" ]
+    data_keys = [ "rust_libraries" ]
+    rebase = root_build_dir
+    deps = [ ":cobalt_archive_internal" ]
+  }
+
+  # Merges C++ and Rust archives into a single libcobalt_archive.a.
+  action("cobalt_archive") {
+    script = "build/merge_archives.py"
+    outputs = [ "$target_out_dir/libcobalt_archive.a" ]
+    inputs = [
+      "$target_gen_dir/cobalt_rust_libraries.txt",
+      "$target_out_dir/libcobalt_archive_internal.a",
+    ]
+    deps = [
+      ":cobalt_archive_internal",
+      ":cobalt_rust_libraries",
+    ]
+    args = [
+      "--rust-libs-file",
+      rebase_path(inputs[0], root_build_dir),
+      "--cpp-lib",
+      rebase_path(inputs[1], root_build_dir),
+      "--output",
+      rebase_path(outputs[0], root_build_dir),
     ]
   }
 

--- a/cobalt/build/merge_archives.py
+++ b/cobalt/build/merge_archives.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Merge C++ and Rust archives into a single static library."""
+
+import argparse
+import os
+import subprocess
+import sys
+
+
+def main():
+  parser = argparse.ArgumentParser(description='Merge C++ and Rust archives.')
+  parser.add_argument(
+      '--rust-libs-file',
+      required=True,
+      help='File containing list of Rust libs.')
+  parser.add_argument(
+      '--cpp-lib', required=True, help='Path to C++ static library.')
+  parser.add_argument(
+      '--output', required=True, help='Path to output merged library.')
+  args = parser.parse_args()
+
+  try:
+    with open(args.rust_libs_file, 'r', encoding='utf-8') as f:
+      # Deduplicate while preserving order to avoid duplicate inputs to libtool
+      rust_libs = list(
+          dict.fromkeys([line.strip() for line in f if line.strip()]))
+  except IOError as e:
+    print(f'Error reading Rust libs file: {e}', file=sys.stderr)
+    return 1
+
+  # Convert paths to absolute to ensure compatibility with xcrun/libtool
+  abs_output = os.path.abspath(args.output)
+  abs_cpp_lib = os.path.abspath(args.cpp_lib)
+  abs_rust_libs = [os.path.abspath(lib) for lib in rust_libs]
+
+  # Use xcrun to guarantee we get Apple's libtool.
+  # We assume this script only runs on macOS since tvOS builds require macOS.
+  cmd = ['xcrun', 'libtool', '-static', '-o', abs_output, abs_cpp_lib
+        ] + abs_rust_libs
+
+  cmd_str = ' '.join(cmd)
+  print(f'Running: {cmd_str}')
+  result = subprocess.run(cmd, capture_output=True, text=True, check=False)
+  if result.returncode != 0:
+    print(
+        f'libtool failed:\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}',
+        file=sys.stderr)
+    return result.returncode
+
+  return 0
+
+
+if __name__ == '__main__':
+  sys.exit(main())

--- a/cobalt/build/merge_archives_test.py
+++ b/cobalt/build/merge_archives_test.py
@@ -1,0 +1,116 @@
+#!/usr/bin/env python3
+# Copyright 2026 The Cobalt Authors. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Tests the merge_archives module."""
+
+import os
+import sys
+import unittest
+from unittest.mock import mock_open, patch
+
+from cobalt.build import merge_archives
+
+
+class MergeArchivesTest(unittest.TestCase):
+
+  @patch('subprocess.run')
+  @patch(
+      'builtins.open',
+      new_callable=mock_open,
+      read_data='lib1.rlib\nlib2.rlib\nlib1.rlib\n')
+  def test_success_dedup(self, mock_file, mock_run):
+    mock_run.return_value.returncode = 0
+
+    test_args = [
+        'merge_archives.py', '--rust-libs-file', 'dummy_rust_libs.txt',
+        '--cpp-lib', 'libcpp.a', '--output', 'libout.a'
+    ]
+    with patch.object(sys, 'argv', test_args):
+      ret = merge_archives.main()
+
+    self.assertEqual(ret, 0)
+    mock_file.assert_called_once_with(
+        'dummy_rust_libs.txt', 'r', encoding='utf-8')
+
+    abs_out = os.path.abspath('libout.a')
+    abs_cpp = os.path.abspath('libcpp.a')
+    abs_lib1 = os.path.abspath('lib1.rlib')
+    abs_lib2 = os.path.abspath('lib2.rlib')
+
+    expected_cmd = [
+        'xcrun', 'libtool', '-static', '-o', abs_out, abs_cpp, abs_lib1,
+        abs_lib2
+    ]
+    mock_run.assert_called_once_with(
+        expected_cmd, capture_output=True, text=True, check=False)
+
+  @patch('subprocess.run')
+  @patch('builtins.open', new_callable=mock_open, read_data='')
+  def test_empty_rust_libs(self, mock_file, mock_run):
+    mock_run.return_value.returncode = 0
+
+    test_args = [
+        'merge_archives.py', '--rust-libs-file', 'dummy_rust_libs.txt',
+        '--cpp-lib', 'libcpp.a', '--output', 'libout.a'
+    ]
+    with patch.object(sys, 'argv', test_args):
+      ret = merge_archives.main()
+
+    self.assertEqual(ret, 0)
+    mock_file.assert_called_once_with(
+        'dummy_rust_libs.txt', 'r', encoding='utf-8')
+
+    abs_out = os.path.abspath('libout.a')
+    abs_cpp = os.path.abspath('libcpp.a')
+
+    expected_cmd = ['xcrun', 'libtool', '-static', '-o', abs_out, abs_cpp]
+    mock_run.assert_called_once_with(
+        expected_cmd, capture_output=True, text=True, check=False)
+
+  @patch('builtins.open', side_effect=IOError('Read error'))
+  def test_io_error(self, mock_file):
+    test_args = [
+        'merge_archives.py', '--rust-libs-file', 'dummy_rust_libs.txt',
+        '--cpp-lib', 'libcpp.a', '--output', 'libout.a'
+    ]
+    with patch.object(sys, 'argv', test_args):
+      with patch('sys.stderr'):
+        ret = merge_archives.main()
+
+    self.assertEqual(ret, 1)
+    mock_file.assert_called_once_with(
+        'dummy_rust_libs.txt', 'r', encoding='utf-8')
+
+  @patch('subprocess.run')
+  @patch('builtins.open', new_callable=mock_open, read_data='lib1.rlib\n')
+  def test_libtool_failure(self, mock_file, mock_run):
+    mock_run.return_value.returncode = 42
+    mock_run.return_value.stdout = 'some stdout'
+    mock_run.return_value.stderr = 'some error'
+
+    test_args = [
+        'merge_archives.py', '--rust-libs-file', 'dummy_rust_libs.txt',
+        '--cpp-lib', 'libcpp.a', '--output', 'libout.a'
+    ]
+    with patch.object(sys, 'argv', test_args):
+      with patch('sys.stderr'):
+        ret = merge_archives.main()
+
+    self.assertEqual(ret, 42)
+    mock_file.assert_called_once_with(
+        'dummy_rust_libs.txt', 'r', encoding='utf-8')
+
+
+if __name__ == '__main__':
+  unittest.main()


### PR DESCRIPTION
Merge Rust static libraries into cobalt.a on tvOS using GN

Replace the post-build script that parsed ninja files with a pure GN
solution.
1. Modify build/rust/rust_target.gni to collect rust_library paths via
   metadata.
2. Modify cobalt/BUILD.gn to collect these paths in a generated_file
   target and merge them using a new Python script.
3. Create cobalt/build/merge_archives.py to run libtool on macOS to
   merge the archives.

TAG=agy
CONV=410b9e8f-3f75-4cf3-83da-bf938d97e4e9
