### PR TITLE
cobalt: Disable NetworkServiceDedicatedThread feature in ShellTestBase

### DIFF
--- a/cobalt/shell/browser/shell_test_support.h
+++ b/cobalt/shell/browser/shell_test_support.h
@@ -22,12 +22,14 @@
 
 #include "base/command_line.h"
 #include "base/memory/raw_ptr.h"
+#include "base/test/scoped_feature_list.h"
 #include "build/build_config.h"
 #include "cobalt/shell/browser/shell.h"
 #include "cobalt/shell/browser/shell_platform_delegate.h"
 #include "content/browser/accessibility/browser_accessibility_state_impl.h"
 #include "content/public/browser/browser_accessibility_state.h"
 #include "content/public/browser/content_browser_client.h"
+#include "content/public/browser/network_service_instance.h"
 #include "content/public/browser/network_service_util.h"
 #include "content/public/common/content_client.h"
 #include "content/public/common/content_switches.h"
@@ -121,7 +123,23 @@ class ShellTestBase : public ::testing::Test {
  public:
   ShellTestBase()
       : task_environment_(content::BrowserTaskEnvironment::IO_MAINLOOP,
-                          base::test::TaskEnvironment::TimeSource::MOCK_TIME) {}
+                          base::test::TaskEnvironment::TimeSource::MOCK_TIME) {
+    // b/537618464: Using a separate thread for the NetworkService causes random
+    // crashes in tests using ShellTestBase. This also affects multiple upstream
+    // tests. It is unclear if it is related to the use of MOCK_TIME above or if
+    // it is just the fact that the tests create and destroy a
+    // BrowserTaskEnvironment too quickly.
+    //
+    // From https://chromium-review.googlesource.com/c/chromium/src/+/7656849:
+    // A short-term workaround for new tests to mitigate the integration
+    // issue between the dedicated `NetworkService` thread and
+    // `BrowserTaskEnvironment` (see crbug.com/493322520). If disabled,
+    // `NetworkService` will use IO thread instead. This is valid for these
+    // tests because they do not depend on whether the network service is
+    // running on a dedicated thread or the IO thread.
+    scoped_feature_list_.InitAndDisableFeature(
+        content::kNetworkServiceDedicatedThread);
+  }
   ~ShellTestBase() override = default;
 
   void SetUp() override {
@@ -244,6 +262,9 @@ class ShellTestBase : public ::testing::Test {
   std::unique_ptr<RenderViewHostTestEnabler> rvh_enabler_;
   raw_ptr<MockShellPlatformDelegate> platform_ = nullptr;
   std::unique_ptr<TestBrowserContext> browser_context_;
+
+ private:
+  base::test::ScopedFeatureList scoped_feature_list_;
 };
 
 }  // namespace content

--- a/cobalt/shell/browser/shell_test_support.h
+++ b/cobalt/shell/browser/shell_test_support.h
@@ -252,6 +252,7 @@ class ShellTestBase : public ::testing::Test {
   }
 
  protected:
+  base::test::ScopedFeatureList scoped_feature_list_;
   content::BrowserTaskEnvironment task_environment_;
   TestContentClient test_content_client_;
   TestContentBrowserClient test_content_browser_client_;
@@ -262,9 +263,6 @@ class ShellTestBase : public ::testing::Test {
   std::unique_ptr<RenderViewHostTestEnabler> rvh_enabler_;
   raw_ptr<MockShellPlatformDelegate> platform_ = nullptr;
   std::unique_ptr<TestBrowserContext> browser_context_;
-
- private:
-  base::test::ScopedFeatureList scoped_feature_list_;
 };
 
 }  // namespace content

--- a/content/browser/network_service_instance_impl.cc
+++ b/content/browser/network_service_instance_impl.cc
@@ -136,13 +136,6 @@ std::unique_ptr<network::NetworkService>& GetLocalNetworkService() {
   return service.GetOrCreateValue();
 }
 
-// If this feature is enabled, the Network Service will run on its own thread
-// when running in-process; otherwise it will run on the IO thread.
-BASE_FEATURE(kNetworkServiceDedicatedThread,
-             "NetworkServiceDedicatedThread",
-             base::FEATURE_ENABLED_BY_DEFAULT
-);
-
 base::Thread& GetNetworkServiceDedicatedThread() {
   static base::NoDestructor<base::Thread> thread{"NetworkService"};
   DCHECK(base::FeatureList::IsEnabled(kNetworkServiceDedicatedThread));
@@ -546,6 +539,13 @@ base::StrictNumeric<uint64_t> GetNetLogMaximumFileSizeFromCommandLine(
 }
 
 }  // namespace
+
+// If this feature is enabled, the Network Service will run on its own thread
+// when running in-process; otherwise it will run on the IO thread.
+BASE_FEATURE(kNetworkServiceDedicatedThread,
+             "NetworkServiceDedicatedThread",
+             base::FEATURE_ENABLED_BY_DEFAULT
+);
 
 uint64_t GetNetLogMaximumFileSizeFromCommandLineForTesting(  // IN-TEST
     const base::CommandLine& command_line) {

--- a/content/public/browser/network_service_instance.h
+++ b/content/public/browser/network_service_instance.h
@@ -5,6 +5,7 @@
 #ifndef CONTENT_PUBLIC_BROWSER_NETWORK_SERVICE_INSTANCE_H_
 #define CONTENT_PUBLIC_BROWSER_NETWORK_SERVICE_INSTANCE_H_
 
+#include "base/feature_list.h"
 #include "base/functional/callback.h"
 #include "build/build_config.h"
 #include "content/common/content_export.h"
@@ -33,6 +34,10 @@ class NetworkService;
 }  // namespace network
 
 namespace content {
+
+// If this feature is enabled, the Network Service will run on its own thread
+// when running in-process; otherwise it will run on the IO thread.
+CONTENT_EXPORT BASE_DECLARE_FEATURE(kNetworkServiceDedicatedThread);
 
 // Returns a pointer to the NetworkService, creating / re-creating it as needed.
 // NetworkService will be running in-process if


### PR DESCRIPTION
Some CobaltWebContentsObserverTest tests (actually, anything using ShellTestBase) are flaky and crashing on at least tvOS and linux-x64x11 with stack traces that look like this:

```
[ RUN      ] CobaltWebContentsObserverTest.NoErrorOnSuccessfulNavigation
[7886:28835:ERROR:net/disk_cache/simple/simple_file_enumerator.cc:21] opendir /Users/runner/Library/Developer/CoreSimulator/Devices/868575AB-9453-4B6D-B97A-6F899DA2E538/data/Containers/Data/Application/F29C5305-15FC-4E49-9A22-019923480BF2/tmp/.org.chromium.Chromium.mFhsjC/Shared Dictionary/cache: No such file or directory (2)
[7886:28835:ERROR:net/disk_cache/simple/simple_index_file.cc:621] Could not reconstruct index from disk
[7886:28844:FATAL:base/task/thread_pool/task_tracker.cc:315] DCHECK failed: !shutdown_event_->IsSignaled(). posted_from: Close@net/extras/sqlite/sqlite_persistent_store_backend_base.cc:66
0   cobalt_unittests                    0x000000010729dc68 base::debug::CollectStackTrace(base::span<void const*, 18446744073709551615ul, void const**>) + 28
1   cobalt_unittests                    0x00000001072907b4 base::debug::StackTrace::StackTrace(unsigned long) + 224
2   cobalt_unittests                    0x00000001071e5398 logging::LogMessage::Flush() + 152
3   cobalt_unittests                    0x00000001071e5280 logging::LogMessage::~LogMessage() + 36
4   cobalt_unittests                    0x00000001071d459c logging::(anonymous namespace)::DCheckLogMessage::~DCheckLogMessage() + 76
5   cobalt_unittests                    0x00000001071d3e38 logging::CheckError::~CheckError() + 44
6   cobalt_unittests                    0x00000001071d3e98 logging::CheckError::~CheckError() + 12
7   cobalt_unittests                    0x000000010725c03c base::internal::TaskTracker::WillPostTask(base::internal::Task*, base::TaskShutdownBehavior) + 380
8   cobalt_unittests                    0x0000000107272f60 base::internal::ThreadPoolImpl::PostTaskWithSequence(base::internal::Task, scoped_refptr<base::internal::Sequence>) + 180
9   cobalt_unittests                    0x000000010726ec14 base::internal::PooledSequencedTaskRunner::PostDelayedTask(base::Location const&, base::OnceCallback<void ()>, base::TimeDelta) + 192
10  cobalt_unittests                    0x00000001072591dc base::TaskRunner::PostTask(base::Location const&, base::OnceCallback<void ()>) + 36
11  cobalt_unittests                    0x00000001082f0b9c net::SQLitePersistentStoreBackendBase::PostBackgroundTask(base::Location const&, base::OnceCallback<void ()>) + 108
12  cobalt_unittests                    0x00000001082f0e1c net::SQLitePersistentStoreBackendBase::Close() + 212
13  cobalt_unittests                    0x00000001082e9bbc net::SQLitePersistentSharedDictionaryStore::~SQLitePersistentSharedDictionaryStore() + 104
14  cobalt_unittests                    0x0000000108245c80 network::SharedDictionaryManagerOnDisk::~SharedDictionaryManagerOnDisk() + 108
15  cobalt_unittests                    0x0000000108245cd8 network::SharedDictionaryManagerOnDisk::~SharedDictionaryManagerOnDisk() + 12
16  cobalt_unittests                    0x00000001081ebb5c network::NetworkContext::~NetworkContext() + 1276
17  cobalt_unittests                    0x00000001081ebbe8 network::NetworkContext::~NetworkContext() + 12
18  cobalt_unittests                    0x0000000108204b3c network::NetworkService::OnNetworkContextConnectionClosed(network::NetworkContext*) + 244
19  cobalt_unittests                    0x0000000104c4cbdc base::OnceCallback<void (std::__Cr::optional<net::HttpServerResponseInfo>)>::Run(std::__Cr::optional<net::HttpServerResponseInfo>) && + 120
20  cobalt_unittests                    0x0000000104b9cd68 base::OnceCallback<void ()>::Run() && + 108
21  cobalt_unittests                    0x000000010740fcd0 mojo::InterfaceEndpointClient::NotifyError(std::__Cr::optional<mojo::DisconnectReason> const&) + 336
22  cobalt_unittests                    0x0000000107419098 mojo::internal::MultiplexRouter::ProcessNotifyErrorTask(mojo::internal::MultiplexRouter::Task*, mojo::internal::MultiplexRouter::ClientCallBehavior, base::SequencedTaskRunner*) + 476
23  cobalt_unittests                    0x0000000107416260 mojo::internal::MultiplexRouter::ProcessTasks(mojo::internal::MultiplexRouter::ClientCallBehavior, base::SequencedTaskRunner*) + 312
24  cobalt_unittests                    0x0000000107414e8c mojo::internal::MultiplexRouter::OnPipeConnectionError(bool) + 1168
25  cobalt_unittests                    0x0000000104b9cd68 base::OnceCallback<void ()>::Run() && + 108
26  cobalt_unittests                    0x0000000107408f20 mojo::Connector::HandleError(bool, bool) + 304
27  cobalt_unittests                    0x0000000107409968 mojo::Connector::OnWatcherHandleReady(char const*, unsigned int) + 100
28  cobalt_unittests                    0x0000000104dec800 base::RepeatingCallback<void (std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&)>::Run(std::__Cr::basic_string<char, std::__Cr::char_traits<char>, std::__Cr::allocator<char>> const&) const & + 136
29  cobalt_unittests                    0x0000000104e58d4c base::RepeatingCallback<void (net::MDnsTransaction::Result, net::RecordParsed const*)>::Run(net::MDnsTransaction::Result, net::RecordParsed const*) const & + 148
30  cobalt_unittests                    0x0000000107430050 mojo::SimpleWatcher::OnHandleReady(int, unsigned int, mojo::HandleSignalsState const&) + 244
31  cobalt_unittests                    0x0000000104b9cd68 base::OnceCallback<void ()>::Run() && + 108
32  cobalt_unittests                    0x0000000107229258 base::TaskAnnotator::RunTaskImpl(base::PendingTask&) + 300
33  cobalt_unittests                    0x000000010724ebd8 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWorkImpl(base::LazyNow*) + 1412
34  cobalt_unittests                    0x000000010724e420 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::DoWork() + 96
35  cobalt_unittests                    0x00000001072a5d90 base::MessagePumpCFRunLoopBase::RunWork() + 168
36  cobalt_unittests                    0x00000001072a4bb4 base::apple::CallWithEHFrame(void () block_pointer) + 16
37  cobalt_unittests                    0x00000001072a538c base::MessagePumpCFRunLoopBase::RunWorkSource(void*) + 68
38  CoreFoundation                      0x00000001807be13c __CFRUNLOOP_IS_CALLING_OUT_TO_A_SOURCE0_PERFORM_FUNCTION__ + 24
39  CoreFoundation                      0x00000001807be084 __CFRunLoopDoSource0 + 168
40  CoreFoundation                      0x00000001807bd81c __CFRunLoopDoSources0 + 220
41  CoreFoundation                      0x00000001807bc9f0 __CFRunLoopRun + 760
42  CoreFoundation                      0x00000001807b7c30 _CFRunLoopRunSpecificWithOptions + 496
43  Foundation                          0x0000000181b5a110 -[NSRunLoop(NSRunLoop) runMode:beforeDate:] + 208
44  cobalt_unittests                    0x00000001072a643c base::MessagePumpNSRunLoop::DoRun(base::MessagePump::Delegate*) + 156
45  cobalt_unittests                    0x00000001072a4c50 base::MessagePumpCFRunLoopBase::Run(base::MessagePump::Delegate*) + 140
46  cobalt_unittests                    0x000000010724f680 base::sequence_manager::internal::ThreadControllerWithMessagePumpImpl::Run(bool, base::TimeDelta) + 728
47  cobalt_unittests                    0x000000010720fda0 base::RunLoop::Run(base::Location const&) + 404
48  cobalt_unittests                    0x000000010727b58c base::Thread::Run(base::RunLoop*) + 148
49  cobalt_unittests                    0x000000010727b818 base::Thread::ThreadMain() + 556
50  cobalt_unittests                    0x0000000107290064 base::(anonymous namespace)::ThreadFunc(void*) + 152
51  libsystem_pthread.dylib             0x000000010bd3663c _pthread_start + 104
52  libsystem_pthread.dylib             0x000000010bd31a34 thread_start + 8
```

This is an issue that also affects upstream Chromium (see e.g. https://issues.chromium.org/issues/378048895 and
https://issues.chromium.org/issues/493322520). The cause looks related to the use of `BrowserTaskEnvironment` and how its destructor shuts down the main and IO threads but not the Network Service threads, which can lead to some race conditions and unexpected calls after shutdown.

Fix it by copying what https://crrev.com/c/7656849 did (disabling the use of a separate thread for the Network Service in tests) while the issue is not fixed upstream. This requires backporting port of
https://crrev.com/c/6681240 (landed in M140) to expose the kNetworkServiceDedicatedThread feature to other files.

Bug: 537618464