### PR TITLE
media: Allow extra MIME parameters in decodingInfo

### DIFF
--- a/third_party/blink/renderer/modules/media_capabilities/media_capabilities.cc
+++ b/third_party/blink/renderer/modules/media_capabilities/media_capabilities.cc
@@ -287,6 +287,19 @@ bool IsValidMimeType(const String& content_type,
 
   const auto& parameters = parsed_content_type.GetParameters();
 
+#if BUILDFLAG(IS_COBALT)
+  // Web applications may append Cobalt-specific parameters to MIME type strings
+  // in any order (e.g. enableflushduringseek=true, enableresetaudiodecoder=true).
+  // Check across all parameters rather than assuming 'codecs' is the first parameter.
+  if (parameters.ParameterCount() == 0)
+    return true;
+
+  for (const auto& param : parameters) {
+    if (EqualIgnoringASCIICase(param.name, kCodecsMimeTypeParam))
+      return true;
+  }
+  return false;
+#else  // BUILDFLAG(IS_COBALT)
   if (parameters.ParameterCount() > 1)
     return false;
 
@@ -294,6 +307,7 @@ bool IsValidMimeType(const String& content_type,
     return true;
 
   return EqualIgnoringASCIICase(parameters.begin()->name, kCodecsMimeTypeParam);
+#endif // BUILDFLAG(IS_COBALT)
 }
 
 bool IsValidMediaConfiguration(const MediaConfiguration* configuration) {

--- a/third_party/blink/renderer/modules/media_capabilities/media_capabilities_test.cc
+++ b/third_party/blink/renderer/modules/media_capabilities/media_capabilities_test.cc
@@ -654,6 +654,55 @@ TEST(MediaCapabilitiesTests, BasicAudio) {
   EXPECT_TRUE(info->powerEfficient());
 }
 
+#if BUILDFLAG(IS_COBALT)
+TEST(MediaCapabilitiesTests, CobaltExtraMimeParameters) {
+  test::TaskEnvironment task_environment;
+
+  // Test 'codecs' parameter in various position permutations (first, middle, last).
+  const char* const kValidCobaltMimeTypes[] = {
+      // codecs first
+      "audio/webm; codecs=\"opus\"; "
+      "enableflushduringseek=true; enableresetaudiodecoder=true",
+      // codecs in middle
+      "audio/webm; enableflushduringseek=true; "
+      "codecs=\"opus\"; enableresetaudiodecoder=true",
+      // codecs last
+      "audio/webm; enableflushduringseek=true; enableresetaudiodecoder=true; "
+      "codecs=\"opus\""};
+
+  for (const char* mime_type : kValidCobaltMimeTypes) {
+    MediaCapabilitiesTestContext context;
+
+    MediaDecodingConfiguration* decoding_config =
+        CreateAudioConfig<MediaDecodingConfiguration>(mime_type,
+                                                      "media-source");
+
+    MediaCapabilitiesInfo* info = DecodingInfo(decoding_config, &context);
+    EXPECT_TRUE(info->supported())
+        << "Failed for MIME type parameter order: " << mime_type;
+  }
+}
+
+TEST(MediaCapabilitiesTests, CobaltMissingCodecsWithParameters) {
+  test::TaskEnvironment task_environment;
+  MediaCapabilitiesTestContext context;
+
+  // MIME type with parameters, but NO codecs parameter (should fail validation).
+  const char kInvalidCobaltMimeType[] =
+      "audio/webm; enableflushduringseek=true; enableresetaudiodecoder=true";
+
+  MediaDecodingConfiguration* decoding_config =
+      CreateAudioConfig<MediaDecodingConfiguration>(kInvalidCobaltMimeType,
+                                                    "media-source");
+
+  context.GetMediaCapabilities()->decodingInfo(
+      context.GetScriptState(), decoding_config,
+      context.GetExceptionState());
+
+  EXPECT_TRUE(context.GetExceptionState().HadException());
+}
+#endif  // BUILDFLAG(IS_COBALT)
+
 // Other tests will assume these match. Test to be sure they stay in sync.
 TEST(MediaCapabilitiesTests, ConfigMatchesFeatures) {
   test::TaskEnvironment task_environment;


### PR DESCRIPTION
Cobalt web applications frequently append custom MIME parameters to
strings, such as enableflushduringseek. The default implementation
is restrictive, failing validation if multiple parameters are
present or if the codecs parameter is not in the primary position.

This ensures MediaCapabilities correctly handles extra parameters,
preventing valid media configurations from being rejected due to
platform-specific metadata.

Issue: 519196649
Issue: 537784933