### PR TITLE
nplb: Increase NPLB vertical video tolerance

### DIFF
--- a/starboard/nplb/vertical_video_test.cc
+++ b/starboard/nplb/vertical_video_test.cc
@@ -162,8 +162,8 @@ TEST_P(VerticalVideoTest, WriteSamples) {
   ASSERT_NO_FATAL_FAILURE(player_fixture.WaitForPlayerEndOfStream());
 
   int64_t end_media_time = player_fixture.GetCurrentMediaTime();
-  const int64_t kMediaTimeAllowance = 100'000;  // 100ms
-  EXPECT_NEAR(end_media_time, kDurationToPlay, kMediaTimeAllowance);
+  const int64_t kDurationDifferenceAllowance = 500'000;  // 500ms
+  EXPECT_NEAR(end_media_time, kDurationToPlay, kDurationDifferenceAllowance);
 }
 
 TEST_P(VerticalVideoTest, Seek) {
@@ -198,8 +198,8 @@ TEST_P(VerticalVideoTest, Seek) {
   ASSERT_NO_FATAL_FAILURE(player_fixture.WaitForPlayerEndOfStream());
 
   int64_t end_media_time = player_fixture.GetCurrentMediaTime();
-  const int64_t kMediaTimeAllowance = 100'000;  // 100ms.
-  EXPECT_NEAR(end_media_time, kDurationToPlay, kMediaTimeAllowance);
+  const int64_t kDurationDifferenceAllowance = 500'000;  // 500ms.
+  EXPECT_NEAR(end_media_time, kDurationToPlay, kDurationDifferenceAllowance);
 }
 
 std::vector<SbPlayerTestConfig> GetSupportedTestConfigs() {


### PR DESCRIPTION
Relax the allowed difference between expected and actual media duration
from 100ms to 500ms in vertical video tests. This change aligns these
tests with similar NPLB test cases.

The previous 100ms threshold was too strict for Linux modular builds, which would fail to meet the timing requirement
consistently when running the full test suite.

Issue: 537819670