### PR TITLE
cobalt: Fix typo in DialServerImpl

### DIFF
--- a/cobalt/browser/dial/dial_server_impl.h
+++ b/cobalt/browser/dial/dial_server_impl.h
@@ -59,7 +59,7 @@ class DialServerImpl final : public content::DocumentService<mojom::DialServer>,
           http_request_handler_callback,
       mojom::DialResponsePtr);
 
-  SEQUENCE_CHECKER(sequence_checker_;)
+  SEQUENCE_CHECKER(sequence_checker_);
 
   mojo::Remote<mojom::DialRequestHandler> request_handler_
       GUARDED_BY_CONTEXT(sequence_checker_);


### PR DESCRIPTION
This typo breaks non-debug builds, which also explains why it was not caught by bots or the usual devel/debug local builds.

Bug: 508769374