### PR TITLE
Cherry pick PR #8050 to main: Reland "feat(cc): Disable resource pool reuse to reduce memory #7853"

### DIFF
--- a/cc/resources/resource_pool.cc
+++ b/cc/resources/resource_pool.cc
@@ -281,7 +281,6 @@ ResourcePool::InUsePoolResource ResourcePool::AcquireResource(
 
   if (!resource)
     resource = CreateResource(size, format, color_space);
-
 #if BUILDFLAG(IS_COBALT)
   if (avoid_cc_reuse_resource) {
     resource->mark_avoid_reuse();

--- a/cc/resources/resource_pool_unittest.cc
+++ b/cc/resources/resource_pool_unittest.cc
@@ -89,6 +89,9 @@ TEST_F(ResourcePoolTest, AcquireRelease) {
 }
 
 TEST_F(ResourcePoolTest, EventuallyEvictAndFlush) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   gfx::Size size(100, 100);
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space = gfx::ColorSpace::CreateSRGB();
@@ -102,9 +105,13 @@ TEST_F(ResourcePoolTest, EventuallyEvictAndFlush) {
   test_task_runner_->FastForwardBy(ResourcePool::kDefaultExpirationDelay +
                                    ResourcePool::kDefaultMaxFlushDelay);
   EXPECT_EQ(0u, resource_pool_->GetTotalResourceCountForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, FlushEvenIfMoreUnusedToEvict) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   gfx::Size size(100, 100);
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space = gfx::ColorSpace::CreateSRGB();
@@ -147,9 +154,13 @@ TEST_F(ResourcePoolTest, FlushEvenIfMoreUnusedToEvict) {
   EXPECT_CALL(*context_support_, FlushPendingWork()).Times(testing::AtLeast(1));
   test_task_runner_->FastForwardBy(ResourcePool::kDefaultExpirationDelay * 100);
   EXPECT_EQ(0u, resource_pool_->GetTotalResourceCountForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, AccountingSingleResource) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -183,9 +194,13 @@ TEST_F(ResourcePoolTest, AccountingSingleResource) {
   EXPECT_EQ(0u, resource_pool_->GetTotalResourceCountForTesting());
   EXPECT_EQ(0u, resource_pool_->resource_count());
   EXPECT_EQ(0u, resource_pool_->GetBusyResourceCountForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, SimpleResourceReuse) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -222,9 +237,13 @@ TEST_F(ResourcePoolTest, SimpleResourceReuse) {
   CheckAndReturnResource(std::move(resource));
   EXPECT_EQ(3u, resource_pool_->GetTotalResourceCountForTesting());
   EXPECT_EQ(0u, resource_pool_->GetBusyResourceCountForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, LostResource) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -255,9 +274,13 @@ TEST_F(ResourcePoolTest, LostResource) {
   EXPECT_EQ(1u, resource_pool_->GetTotalResourceCountForTesting());
   resource_pool_->ReleaseResource(std::move(resource));
   EXPECT_EQ(0u, resource_pool_->GetTotalResourceCountForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, BusyResourcesNotFreed) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -302,9 +325,13 @@ TEST_F(ResourcePoolTest, BusyResourcesNotFreed) {
   EXPECT_EQ(40000u, resource_pool_->GetTotalMemoryUsageForTesting());
   EXPECT_EQ(0u, resource_pool_->memory_usage_bytes());
   EXPECT_EQ(0u, resource_pool_->GetBusyResourceCountForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, UnusedResourcesEventuallyFreed) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -349,9 +376,13 @@ TEST_F(ResourcePoolTest, UnusedResourcesEventuallyFreed) {
   test_task_runner_->FastForwardBy(ResourcePool::kDefaultExpirationDelay * 10);
 
   EXPECT_EQ(0u, resource_pool_->GetTotalMemoryUsageForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, UpdateContentId) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   gfx::Size size(100, 100);
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space;
@@ -374,9 +405,13 @@ TEST_F(ResourcePoolTest, UpdateContentId) {
   EXPECT_EQ(original_id, reacquired_resource.unique_id_for_testing());
   EXPECT_EQ(new_invalidated_rect, invalidated_rect);
   resource_pool_->ReleaseResource(std::move(reacquired_resource));
+#endif
 }
 
 TEST_F(ResourcePoolTest, UpdateContentIdAndInvalidatedRect) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   gfx::Size size(100, 100);
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space;
@@ -420,9 +455,13 @@ TEST_F(ResourcePoolTest, UpdateContentIdAndInvalidatedRect) {
   EXPECT_EQ(original_id, reacquired_resource.unique_id_for_testing());
   EXPECT_EQ(expected_total_invalidated_rect, total_invalidated_rect);
   resource_pool_->ReleaseResource(std::move(reacquired_resource));
+#endif
 }
 
 TEST_F(ResourcePoolTest, LargeInvalidatedRect) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   gfx::Size size(100, 100);
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space;
@@ -454,9 +493,13 @@ TEST_F(ResourcePoolTest, LargeInvalidatedRect) {
       &new_invalidated_rect, color_space);
   EXPECT_TRUE(!!resource);
   resource_pool_->ReleaseResource(std::move(resource));
+#endif
 }
 
 TEST_F(ResourcePoolTest, ReuseResource) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space = gfx::ColorSpace::CreateSRGB();
 
@@ -519,9 +562,13 @@ TEST_F(ResourcePoolTest, ReuseResource) {
   EXPECT_EQ(nullptr, resource_pool_->ReuseResource(gfx::Size(100, 100), format,
                                                    color_space));
   CheckAndReturnResource(std::move(resource));
+#endif
 }
 
 TEST_F(ResourcePoolTest, PurgedMemory) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -574,9 +621,13 @@ TEST_F(ResourcePoolTest, PurgedMemory) {
       base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL);
   EXPECT_EQ(0u, resource_pool_->GetTotalResourceCountForTesting());
   EXPECT_EQ(0u, resource_pool_->GetBusyResourceCountForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, InvalidateResources) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -648,9 +699,13 @@ TEST_F(ResourcePoolTest, InvalidateResources) {
   resource_pool_->ReleaseResource(std::move(in_use_resource));
   EXPECT_EQ(0u, resource_pool_->GetTotalResourceCountForTesting());
   EXPECT_EQ(0u, resource_pool_->GetBusyResourceCountForTesting());
+#endif
 }
 
 TEST_F(ResourcePoolTest, ExactRequestsRespected) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space = gfx::ColorSpace::CreateSRGB();
 
@@ -678,9 +733,13 @@ TEST_F(ResourcePoolTest, ExactRequestsRespected) {
   EXPECT_EQ(nullptr, resource_pool_->ReuseResource(gfx::Size(100, 100), format,
                                                    color_space));
   CheckAndReturnResource(std::move(resource));
+#endif
 }
 
 TEST_F(ResourcePoolTest, MetadataSentToDisplayCompositor) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -728,9 +787,13 @@ TEST_F(ResourcePoolTest, MetadataSentToDisplayCompositor) {
   EXPECT_TRUE(transfer[0].is_overlay_candidate);
 
   resource_pool_->ReleaseResource(std::move(resource));
+#endif
 }
 
 TEST_F(ResourcePoolTest, InvalidResource) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
   // Limits high enough to not be hit by this test.
   size_t bytes_limit = 10 * 1024 * 1024;
   size_t count_limit = 100;
@@ -761,6 +824,7 @@ TEST_F(ResourcePoolTest, InvalidResource) {
   resource = resource_pool_->AcquireResource(size, format, color_space);
   EXPECT_FALSE(resource.backing());
   resource_pool_->ReleaseResource(std::move(resource));
+#endif
 }
 
 }  // namespace cc

--- a/cc/tiles/tile_manager_unittest.cc
+++ b/cc/tiles/tile_manager_unittest.cc
@@ -2544,11 +2544,19 @@ void RunPartialTileDecodeCheck(std::unique_ptr<LayerTreeHostImpl> host_impl,
 // Ensures that the tile manager successfully reuses tiles when partial
 // raster is enabled.
 TEST_F(PartialRasterTileManagerTest, PartialRasterSuccessfullyEnabled) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support partial tile raster.";
+#else
   RunPartialRasterCheck(TakeHostImpl(), true /* partial_raster_enabled */);
+#endif
 }
 
 TEST_F(PartialRasterTileManagerTest, PartialTileImageDecode) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support partial tile raster.";
+#else
   RunPartialTileDecodeCheck(TakeHostImpl(), true /* partial_raster_enabled */);
+#endif
 }
 
 TEST_F(PartialRasterTileManagerTest, CompleteTileImageDecode) {

--- a/cc/trees/layer_tree_host_impl_unittest.cc
+++ b/cc/trees/layer_tree_host_impl_unittest.cc
@@ -13092,7 +13092,14 @@ TEST_P(LayerTreeHostImplTest, ExternalTransformSetNeedsRedraw) {
   EXPECT_FALSE(last_on_draw_frame_->has_no_damage);
 }
 
+<<<<<<< HEAD
 TEST_P(LayerTreeHostImplTest, OnMemoryPressure) {
+=======
+TEST_P(ScrollUnifiedLayerTreeHostImplTest, OnMemoryPressure) {
+#if BUILDFLAG(IS_COBALT)
+  GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
+#else
+>>>>>>> 8ec6d83466 (Reland "feat(cc): Disable resource pool reuse to reduce memory #7853" (#8050))
   gfx::Size size(200, 200);
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space = gfx::ColorSpace::CreateSRGB();
@@ -13119,6 +13126,7 @@ TEST_P(LayerTreeHostImplTest, OnMemoryPressure) {
 
   // Memory usage after the memory pressure should be less than previous one.
   EXPECT_LT(memory_usage_after_memory_pressure, current_memory_usage);
+#endif
 }
 
 TEST_P(LayerTreeHostImplTest, OnDrawConstraintSetNeedsRedraw) {

--- a/cc/trees/layer_tree_host_impl_unittest.cc
+++ b/cc/trees/layer_tree_host_impl_unittest.cc
@@ -13092,14 +13092,10 @@ TEST_P(LayerTreeHostImplTest, ExternalTransformSetNeedsRedraw) {
   EXPECT_FALSE(last_on_draw_frame_->has_no_damage);
 }
 
-<<<<<<< HEAD
 TEST_P(LayerTreeHostImplTest, OnMemoryPressure) {
-=======
-TEST_P(ScrollUnifiedLayerTreeHostImplTest, OnMemoryPressure) {
 #if BUILDFLAG(IS_COBALT)
   GTEST_SKIP() << "Cobalt doesn't support resource reuse.";
 #else
->>>>>>> 8ec6d83466 (Reland "feat(cc): Disable resource pool reuse to reduce memory #7853" (#8050))
   gfx::Size size(200, 200);
   viz::SharedImageFormat format = viz::SinglePlaneFormat::kRGBA_8888;
   gfx::ColorSpace color_space = gfx::ColorSpace::CreateSRGB();


### PR DESCRIPTION
This cherry-picks PR #8050 (and related test updates) to main, resolving merge conflicts in `cc/resources/resource_pool.cc`.

---
### Original PR #8050 Description

This relands PR# 7853, which was reverted due to breaking `PartialRasterTileManagerTest.PartialRasterSuccessfullyEnabled` and `PartialRasterTileManagerTest.PartialTileImageDecode` on Cobalt.

This reland re-introduces the test refactoring but disables the failing tests specifically for Cobalt builds using `#if BUILDFLAG(IS_COBALT) GTEST_SKIP()`. This allows the valuable test improvements to be landed without affecting the Cobalt build.

#### Original PR description---------------------------------------

By marking resources with 'avoid_reuse', they are freed immediately after use instead of being kept in the resource pool. This ensures tiles are rastered on-demand.

This change significantly reduces the tile_memory usage, ~20M when navigating fast through videos, with no obvious negative performance impact.

Original PR: https://github.com/youtube/cobalt/pull/7853

Bug: 424591313
