### PR TITLE
android: Use INFO log for tunnel mode completion

### DIFF
--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -1091,7 +1091,7 @@ void MediaCodecVideoDecoder::TryToSignalPrerollForTunnelMode() {
   }
 
   if (tunnel_mode_prerolling_.exchange(false)) {
-    SB_LOG(ERROR) << "Tunnel mode preroll finished.";
+    SB_LOG(INFO) << "Tunnel mode preroll finished.";
     // TODO: Currently the decoder sends a dummy frame to the renderer to signal
     //       preroll finish.  We should investigate a better way for prerolling
     //       when the video is rendered directly by the decoder, maybe by always


### PR DESCRIPTION
When tunnel mode preroll finishes, the event is currently logged as an
error. Since this is an expected part of the playback process and not
an actual error condition, it should be logged as information instead.

Bug: 538270075