### PR TITLE
media: Add missing utility header

### DIFF
--- a/media/mojo/clients/mojo_renderer.cc
+++ b/media/mojo/clients/mojo_renderer.cc
@@ -4,6 +4,8 @@
 
 #include "media/mojo/clients/mojo_renderer.h"
 
+#include <utility>
+
 #include "base/functional/bind.h"
 #include "base/functional/callback_helpers.h"
 #include "base/location.h"


### PR DESCRIPTION
Include the utility header in mojo_renderer.cc to provide definitions
for standard library utilities such as std::move. This header was
likely omitted in a previous change, leading to potential compilation
failures in environments where it is not transitively included.

This was removed during the refactor bypass bridge in
https://github.com/youtube/cobalt/pull/11262.

Issue: 513254071