### PR TITLE
starboard: Rename new NativeStability extension

### DIFF
--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -243,8 +243,8 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
   // Remove this block once the NativeStabilityManager singleton is added to
   // the browser to query the extension to respond to web app requests.
   auto native_stability_extension =
-      static_cast<const CobaltExtensionNativeStabilityApi*>(
-          SbSystemGetExtension(kCobaltExtensionNativeStabilityName));
+      static_cast<const StarboardExtensionNativeStabilityApi*>(
+          SbSystemGetExtension(kStarboardExtensionNativeStabilityName));
   if (native_stability_extension && native_stability_extension->version >= 1 &&
       native_stability_extension->ReadReports) {
     constexpr int max_num_reports = 16;  // A somewhat arbitrary, large number

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_extensions.cc
@@ -74,7 +74,7 @@ const void* SbSystemGetExtension(const char* name) {
   }
 #endif
 #if BUILDFLAG(USE_EVERGREEN)
-  if (strcmp(name, kCobaltExtensionNativeStabilityName) == 0) {
+  if (strcmp(name, kStarboardExtensionNativeStabilityName) == 0) {
     return starboard::GetNativeStabilityApi();
   }
 #endif

--- a/starboard/crashpad_wrapper/wrapper.cc
+++ b/starboard/crashpad_wrapper/wrapper.cc
@@ -365,8 +365,8 @@ void InstallCrashpadHandler(const std::string& ca_certificates_path) {
   }
 
   auto native_stability_extension =
-      static_cast<const CobaltExtensionNativeStabilityApi*>(
-          SbSystemGetExtension(kCobaltExtensionNativeStabilityName));
+      static_cast<const StarboardExtensionNativeStabilityApi*>(
+          SbSystemGetExtension(kStarboardExtensionNativeStabilityName));
   if (native_stability_extension && native_stability_extension->version >= 1 &&
       native_stability_extension->RegisterReadReportsCallback) {
     native_stability_extension->RegisterReadReportsCallback(&ReadReports);

--- a/starboard/extension/extension_test.cc
+++ b/starboard/extension/extension_test.cc
@@ -631,8 +631,8 @@ TEST(ExtensionTest, StarboardMediaBufferPoolExtension) {
 }
 
 TEST(ExtensionTest, NativeStabilityExtension) {
-  typedef CobaltExtensionNativeStabilityApi ExtensionApi;
-  const char* kExtensionName = kCobaltExtensionNativeStabilityName;
+  typedef StarboardExtensionNativeStabilityApi ExtensionApi;
+  const char* kExtensionName = kStarboardExtensionNativeStabilityName;
 
   const ExtensionApi* extension_api =
       static_cast<const ExtensionApi*>(SbSystemGetExtension(kExtensionName));

--- a/starboard/extension/native_stability.h
+++ b/starboard/extension/native_stability.h
@@ -23,8 +23,8 @@
 extern "C" {
 #endif
 
-#define kCobaltExtensionNativeStabilityName \
-  "dev.cobalt.extension.NativeStability"
+#define kStarboardExtensionNativeStabilityName \
+  "dev.starboard.extension.NativeStability"
 
 typedef enum SbNativeStabilityReportType {
   kSbNativeStabilityReportUnknown = 0,
@@ -44,8 +44,8 @@ typedef struct SbNativeStabilityReport {
 typedef int (*ReadReportsCallback)(SbNativeStabilityReport* reports,
                                    int max_num_reports);
 
-typedef struct CobaltExtensionNativeStabilityApi {
-  // Name should be the string |kCobaltExtensionNativeStabilityName|.
+typedef struct StarboardExtensionNativeStabilityApi {
+  // Name should be the string |kStarboardExtensionNativeStabilityName|.
   // This helps to validate that the extension API is correct.
   const char* name;
 
@@ -65,7 +65,7 @@ typedef struct CobaltExtensionNativeStabilityApi {
   // |ReadReports| implementation. This is used to delegate to an injected
   // dependency to avoid dependency cycles.
   void (*RegisterReadReportsCallback)(ReadReportsCallback callback);
-} CobaltExtensionNativeStabilityApi;
+} StarboardExtensionNativeStabilityApi;
 
 #ifdef __cplusplus
 }  // extern "C"

--- a/starboard/linux/shared/system_get_extensions.cc
+++ b/starboard/linux/shared/system_get_extensions.cc
@@ -61,7 +61,7 @@ const void* SbSystemGetExtension(const char* name) {
   if (strcmp(name, kCobaltExtensionCrashHandlerName) == 0) {
     return starboard::GetCrashHandlerApi();
   }
-  if (strcmp(name, kCobaltExtensionNativeStabilityName) == 0) {
+  if (strcmp(name, kStarboardExtensionNativeStabilityName) == 0) {
     return starboard::GetNativeStabilityApi();
   }
 

--- a/starboard/nplb/nplb_evergreen_compat_tests/native_stability_test.cc
+++ b/starboard/nplb/nplb_evergreen_compat_tests/native_stability_test.cc
@@ -27,8 +27,8 @@ namespace nplb {
 namespace {
 
 TEST(NativeStabilityTest, VerifyNativeStabilityExtension) {
-  auto extension = static_cast<const CobaltExtensionNativeStabilityApi*>(
-      SbSystemGetExtension(kCobaltExtensionNativeStabilityName));
+  auto extension = static_cast<const StarboardExtensionNativeStabilityApi*>(
+      SbSystemGetExtension(kStarboardExtensionNativeStabilityName));
 
   ASSERT_NE(extension, nullptr)
       << "Please update your platform's SbSystemGetExtension() implementation "

--- a/starboard/shared/starboard/native_stability.cc
+++ b/starboard/shared/starboard/native_stability.cc
@@ -43,8 +43,8 @@ void RegisterReadReportsCallback(ReadReportsCallback callback) {
   SB_CHECK_EQ(pthread_mutex_unlock(&g_read_reports_callback_mutex), 0);
 }
 
-const CobaltExtensionNativeStabilityApi kNativeStabilityApi = {
-    kCobaltExtensionNativeStabilityName,
+const StarboardExtensionNativeStabilityApi kNativeStabilityApi = {
+    kStarboardExtensionNativeStabilityName,
     1,
     &ReadReports,
     &RegisterReadReportsCallback,


### PR DESCRIPTION
The struct and the identifier are both renamed to use "Starboard" instead of "Cobalt". This is our preference since b/150221489.

This would normally be a breaking change but it's ok since this is a brand new extension that is not yet on any production devices.

Issue: 528362453