### PR TITLE
Fix IAMF specific box parsing bug in MP4 demuxer

### DIFF
--- a/media/formats/mp4/box_definitions.cc
+++ b/media/formats/mp4/box_definitions.cc
@@ -1591,7 +1591,9 @@ bool IamfSpecificBox::Parse(BoxReader* reader) {
   uint32_t config_obus_size;
   RCHECK(ReadLeb128Value(reader, &config_obus_size));
 
-  base::span<const uint8_t> buffer(reader->buffer(), config_obus_size);
+  RCHECK(reader->HasBytes(config_obus_size));
+  base::span<const uint8_t> buffer(reader->buffer() + reader->pos(),
+                                   config_obus_size);
   ia_descriptors.assign(buffer.begin(), buffer.end());
 
   RCHECK(reader->SkipBytes(config_obus_size));


### PR DESCRIPTION
The IamfSpecificBox::Parse method previously sliced the buffer from the
start of the box header instead of the current reader position. This
resulted in the IAMF configuration OBUs being parsed incorrectly
because the offset from previous reads within the box was not being
respected.

Issue: 537956110