### PR TITLE
android: Limit ignored callbacks during flush

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -312,7 +312,7 @@ class MediaCodecBridge {
           @Override
           public void onInputBufferAvailable(MediaCodec codec, int index) {
             synchronized (mNativeBridgeLock) {
-              if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
+              if (mNativeMediaCodecBridge == 0) {
                 return;
               }
               MediaCodecBridgeJni.get()
@@ -346,7 +346,7 @@ class MediaCodecBridge {
           @Override
           public void onOutputFormatChanged(MediaCodec codec, MediaFormat format) {
             synchronized (mNativeBridgeLock) {
-              if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
+              if (mNativeMediaCodecBridge == 0) {
                 return;
               }
               mActiveFormat = new MediaFormatWrapper(format);
@@ -370,7 +370,7 @@ class MediaCodecBridge {
             @Override
             public void onFrameRendered(MediaCodec codec, long presentationTimeUs, long nanoTime) {
               synchronized (mNativeBridgeLock) {
-                if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
+                if (mNativeMediaCodecBridge == 0) {
                   return;
                 }
                 MediaCodecBridgeJni.get()
@@ -1082,7 +1082,7 @@ class MediaCodecBridge {
             @Override
             public void onFirstTunnelFrameReady(MediaCodec codec) {
               synchronized (mNativeBridgeLock) {
-                if (mNativeMediaCodecBridge == 0 || mIsFlushing) {
+                if (mNativeMediaCodecBridge == 0) {
                   return;
                 }
                 MediaCodecBridgeJni.get()


### PR DESCRIPTION
Update MediaCodecBridge to only ignore output buffer callbacks while
the codec is flushing.

Bug: 497004556