### PR TITLE
media: Use safe GetDeviceApiLevel helper and API constants in media_codec

### DIFF
--- a/starboard/android/shared/media_codec.cc
+++ b/starboard/android/shared/media_codec.cc
@@ -14,8 +14,6 @@
 
 #include "starboard/android/shared/media_codec.h"
 
-#include <android/api-level.h>
-
 #include <memory>
 #include <optional>
 #include <string>
@@ -55,7 +53,7 @@ bool CanUseNdkMediaCodec(
     return false;
   }
   // NDK AMediaCodec requires API level >= 28.
-  if (android_get_device_api_level() < 28) {
+  if (GetDeviceApiLevel() < kAndroidApiLevelPie) {
     return false;
   }
 
@@ -172,7 +170,7 @@ NonNullResult<std::unique_ptr<MediaCodec>> MediaCodec::CreateVideoMediaCodec(
 
 // static
 bool MediaCodec::IsFrameRenderedCallbackEnabled() {
-  return android_get_device_api_level() >= 34;
+  return GetDeviceApiLevel() >= kAndroidApiLevelU;
 }
 
 FrameSize::FrameSize() : FrameSize(Size(), /*has_crop_values=*/false) {}

--- a/starboard/android/shared/media_common.h
+++ b/starboard/android/shared/media_common.h
@@ -15,6 +15,10 @@
 #ifndef STARBOARD_ANDROID_SHARED_MEDIA_COMMON_H_
 #define STARBOARD_ANDROID_SHARED_MEDIA_COMMON_H_
 
+#include <android/api-level.h>
+#include <sys/system_properties.h>
+
+#include <cstdlib>
 #include <cstring>
 #include <optional>
 
@@ -25,6 +29,24 @@
 #include "starboard/shared/starboard/player/filter/audio_frame_tracker.h"
 
 namespace starboard {
+
+constexpr int kAndroidApiLevelPie = 28;
+constexpr int kAndroidApiLevelU = 34;
+
+inline int GetDeviceApiLevel() {
+#if __ANDROID_API__ >= 24
+  return ::android_get_device_api_level();
+#else
+  static int api_level = []() {
+    char sdk_version_str[PROP_VALUE_MAX] = {0};
+    if (__system_property_get("ro.build.version.sdk", sdk_version_str) > 0) {
+      return atoi(sdk_version_str);
+    }
+    return __ANDROID_API__;
+  }();
+  return api_level;
+#endif
+}
 
 inline bool IsWidevineL1(const char* key_system) {
   return strcmp(key_system, "com.widevine") == 0 ||


### PR DESCRIPTION
Replace direct calls to android_get_device_api_level() with a
centralized GetDeviceApiLevel() helper. This wrapper ensures
compatibility by handling potential null function pointers on older
Android versions. Additionally, replace hardcoded API level integers
with named constants to improve code maintainability and clarity.

This was caught in https://github.com/youtube/cobalt/pull/11544.

Issue: 515461431