### PR TITLE
starboard: Fix integer overflow in AudioTrack sink

### DIFF
--- a/starboard/android/shared/audio_track_audio_sink_type.cc
+++ b/starboard/android/shared/audio_track_audio_sink_type.cc
@@ -261,10 +261,10 @@ void AudioTrackAudioSink::AudioThreadFunc() {
 
   SB_LOG(INFO) << "AudioTrackAudioSink thread started.";
 
-  int accumulated_written_frames = 0;
+  int64_t accumulated_written_frames = 0;
   int64_t last_playback_head_event_at = -1;  // microseconds
 
-  int last_playback_head_position = 0;
+  int64_t last_playback_head_position = 0;
 
   bool release_frames_after_audio_starts = features::FeatureList::IsEnabled(
       features::kReleaseVideoFramesAfterAudioStarts);
@@ -284,7 +284,7 @@ void AudioTrackAudioSink::AudioThreadFunc() {
       continue;
     }
 
-    int playback_head_position = 0;
+    int64_t playback_head_position = 0;
     int64_t frames_consumed_at = 0;
     if (audio_track_->GetAndResetHasAudioDeviceChanged()) {
       SB_LOG(INFO) << "Audio device changed, raising a capability changed "
@@ -515,7 +515,7 @@ void AudioTrackAudioSink::ReportError(bool capability_changed,
   }
 }
 
-int64_t AudioTrackAudioSink::GetFramesDurationUs(int frames) const {
+int64_t AudioTrackAudioSink::GetFramesDurationUs(int64_t frames) const {
   return frames * 1'000'000LL / sampling_frequency_hz_;
 }
 

--- a/starboard/android/shared/audio_track_audio_sink_type.h
+++ b/starboard/android/shared/audio_track_audio_sink_type.h
@@ -169,7 +169,7 @@ class AudioTrackAudioSink : public SbAudioSinkImpl {
 
   void ReportError(bool capability_changed, const std::string& error_message);
 
-  int64_t GetFramesDurationUs(int frames) const;
+  int64_t GetFramesDurationUs(int64_t frames) const;
 
   const raw_ptr<Type> type_;
   const int channels_;


### PR DESCRIPTION
Update accumulated_written_frames, last_playback_head_position, and
playback_head_position to use 64-bit integers in AudioTrackAudioSink.
At a 48kHz sampling rate, 32-bit signed integers overflow after
approximately 12.4 hours of continuous playback, which can cause
incorrect playback head reporting and audio sync issues.

Also update GetFramesDurationUs to accept int64_t to maintain type
consistency and prevent narrowing.

Note that this doesn't resolve all integer size issues across the audio
pipeline as the Java AudioTrackBridge is still tracking the playback
position using 32 bits integer, which will be resolve in b/539224216.

Bug: 539224216