### PR TITLE
media: Allow capability checks on worker threads

### DIFF
--- a/cobalt/renderer/BUILD.gn
+++ b/cobalt/renderer/BUILD.gn
@@ -48,13 +48,18 @@ source_set("renderer") {
 
 test("cobalt_renderer_unittests") {
   testonly = true
-  sources = [ "cobalt_render_frame_observer_unittest.cc" ]
+  sources = [
+    "cobalt_content_renderer_client_unittest.cc",
+    "cobalt_render_frame_observer_unittest.cc",
+  ]
   deps = [
     ":renderer",
     "//base/test:run_all_unittests",
     "//base/test:test_support",
+    "//media",
     "//testing/gmock",
     "//testing/gtest",
     "//third_party/blink/renderer/modules/exported:test_support",
+    "//v8",
   ]
 }

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -271,7 +271,6 @@ CobaltContentRendererClient::GetSupportedKeySystems(
 
 bool CobaltContentRendererClient::IsDecoderSupportedAudioType(
     const ::media::AudioType& type) {
-  CHECK(content::RenderThread::IsMainThread());
   std::string mime = GetMimeFromAudioType(type);
   SbMediaSupportType support_type = kSbMediaSupportTypeNotSupported;
   if (!mime.empty()) {
@@ -285,7 +284,6 @@ bool CobaltContentRendererClient::IsDecoderSupportedAudioType(
 
 bool CobaltContentRendererClient::IsDecoderSupportedVideoType(
     const ::media::VideoType& type) {
-  CHECK(content::RenderThread::IsMainThread());
   std::string mime = GetMimeFromVideoType(type);
   SbMediaSupportType support_type = kSbMediaSupportTypeNotSupported;
   if (!mime.empty()) {

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -219,7 +219,6 @@ void CobaltContentRendererClient::RenderThreadStarted() {
 }
 
 void AddStarboardCmaKeySystems(::media::KeySystemInfos* key_system_infos) {
-  CHECK(content::RenderThread::IsMainThread());
   ::media::SupportedCodecs codecs = GetStarboardEmeSupportedCodecs();
 
   using Robustness = cdm::WidevineKeySystemInfo::Robustness;
@@ -262,7 +261,6 @@ std::unique_ptr<::media::KeySystemSupportRegistration>
 CobaltContentRendererClient::GetSupportedKeySystems(
     content::RenderFrame* render_frame,
     ::media::GetSupportedKeySystemsCB cb) {
-  CHECK(content::RenderThread::IsMainThread());
   ::media::KeySystemInfos key_systems;
   AddStarboardCmaKeySystems(&key_systems);
   std::move(cb).Run(std::move(key_systems));

--- a/cobalt/renderer/cobalt_content_renderer_client.h
+++ b/cobalt/renderer/cobalt_content_renderer_client.h
@@ -58,11 +58,16 @@ class CobaltContentRendererClient : public content::ContentRendererClient {
   // ContentRendererClient implementation.
   void RenderFrameCreated(content::RenderFrame* render_frame) override;
   void RenderThreadStarted() override;
+
+  // Thread safety: The following media capability query methods can be called
+  // from any thread (main thread or worker threads, e.g., when MSE is used in
+  // worker).
   virtual std::unique_ptr<::media::KeySystemSupportRegistration>
   GetSupportedKeySystems(content::RenderFrame* render_frame,
                          ::media::GetSupportedKeySystemsCB cb) override;
   bool IsDecoderSupportedAudioType(const ::media::AudioType& type) override;
   bool IsDecoderSupportedVideoType(const ::media::VideoType& type) override;
+
   ::media::ExternalMemoryAllocator* GetMediaAllocator() override;
   // JS Injection hook
   void RunScriptsAtDocumentStart(content::RenderFrame* render_frame) override;

--- a/cobalt/renderer/cobalt_content_renderer_client_unittest.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client_unittest.cc
@@ -1,0 +1,53 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/renderer/cobalt_content_renderer_client.h"
+
+#include "base/functional/bind.h"
+#include "base/functional/callback.h"
+#include "base/run_loop.h"
+#include "base/task/thread_pool.h"
+#include "base/test/task_environment.h"
+#include "media/base/audio_codecs.h"
+#include "media/base/video_codecs.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace {
+
+TEST(CobaltContentRendererClientTest, MediaQueriesCallableFromWorkerThread) {
+  base::test::TaskEnvironment task_environment;
+  CobaltContentRendererClient client;
+
+  base::RunLoop run_loop;
+  base::ThreadPool::PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          [](CobaltContentRendererClient* client,
+             base::OnceClosure quit_closure) {
+            client->IsDecoderSupportedAudioType({::media::AudioCodec::kAAC});
+            client->IsDecoderSupportedVideoType({::media::VideoCodec::kH264});
+            client->GetSupportedKeySystems(
+                /*render_frame=*/nullptr,
+                base::BindRepeating([](::media::KeySystemInfos key_systems) {
+                  EXPECT_FALSE(key_systems.empty());
+                }));
+            std::move(quit_closure).Run();
+          },
+          base::Unretained(&client), run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+}  // namespace
+}  // namespace cobalt


### PR DESCRIPTION
Remove the main-thread requirement for media decoder support checks
within the renderer client. This change allows capability queries
to be performed from dedicated worker threads, which is necessary
for supporting Media Source Extensions (MSE) in workers.

The underlying Starboard calls are thread-safe and stateless, making
the main-thread enforcement unnecessary.

http://go/px-cobalt-mse-in-workers

Bug: 537351773