### PR TITLE
android: Remove shell close call in destroy

### DIFF
--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ShellManager.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ShellManager.java
@@ -15,7 +15,6 @@
 package dev.cobalt.shell;
 
 import android.content.Context;
-import dev.cobalt.shell.ContentViewRenderView;
 import org.chromium.base.ThreadUtils;
 import org.chromium.build.annotations.Initializer;
 import org.chromium.build.annotations.NullMarked;
@@ -28,190 +27,188 @@ import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
 
-/**
- * Copied from org.chromium.content_shell.ShellManager.
- * Container and generator of ShellViews.
- */
+/** Copied from org.chromium.content_shell.ShellManager. Container and generator of ShellViews. */
 @JNINamespace("content")
 @NullMarked
 public class ShellManager {
-    private static final String TAG = "cobalt";
-    private WindowAndroid mWindow;
-    private @Nullable Shell mActiveShell;
+  private static final String TAG = "cobalt";
+  private WindowAndroid mWindow;
+  private @Nullable Shell mActiveShell;
 
-    private Shell.@Nullable OnWebContentsReadyListener mNextWebContentsReadyListener;
+  private Shell.@Nullable OnWebContentsReadyListener mNextWebContentsReadyListener;
 
-    // The target for all content rendering.
-    private @Nullable ContentViewRenderView mContentViewRenderView;
+  // The target for all content rendering.
+  private @Nullable ContentViewRenderView mContentViewRenderView;
 
-    private Context mContext;
+  private Context mContext;
 
-    private boolean mIsActivityVisible;
+  private boolean mIsActivityVisible;
 
+  /** Constructor for inflating via XML. */
+  public ShellManager(final Context context) {
+    mContext = context;
+    if (sNatives == null) {
+      sNatives = ShellManagerJni.get();
+    }
+    sNatives.init(this);
+  }
+
+  public void onActivityVisible(boolean visible) {
+    mIsActivityVisible = visible;
+    if (mActiveShell != null) {
+      mActiveShell.onActivityVisible(visible);
+    }
+  }
+
+  public Context getContext() {
+    return mContext;
+  }
+
+  /**
+   * @param window The window used to generate all shells.
+   */
+  @Initializer
+  public void setWindow(WindowAndroid window) {
+    assert window != null;
+    mWindow = window;
+    mContentViewRenderView = new ContentViewRenderView(getContext());
+    mContentViewRenderView.onNativeLibraryLoaded(window);
+  }
+
+  /**
+   * @return The window used to generate all shells.
+   */
+  public WindowAndroid getWindow() {
+    return mWindow;
+  }
+
+  /** Get the ContentViewRenderView. */
+  public @Nullable ContentViewRenderView getContentViewRenderView() {
+    return mContentViewRenderView;
+  }
+
+  /**
+   * @return The currently visible shell view or null if one is not showing.
+   */
+  public @Nullable Shell getActiveShell() {
+    return mActiveShell;
+  }
+
+  /**
+   * Creates a new shell pointing to the specified URL.
+   *
+   * @param url The URL the shell should load upon creation.
+   */
+  public void launchShell(String url) {
+    // Calls the overloaded method with a null listener.
+    launchShell(url, /* deepLinkUrl= */ "", /* listener= */ null);
+  }
+
+  /**
+   * Creates a new shell pointing to the specified URL.
+   *
+   * @param url The URL the shell should load upon creation.
+   * @param deepLinkUrl The URL from the DeepLink URL.
+   * @param listener The listener to be notified when WebContents is ready.
+   */
+  public void launchShell(
+      String url, String deepLinkUrl, Shell.OnWebContentsReadyListener listener) {
+    ThreadUtils.assertOnUiThread();
+    mNextWebContentsReadyListener = listener;
+    Shell previousShell = mActiveShell;
+    sNatives.launchShell(url, deepLinkUrl);
+    if (previousShell != null) previousShell.close();
+  }
+
+  @CalledByNative
+  private Object createShell(long nativeShellPtr) {
+    if (mContentViewRenderView == null) {
+      mContentViewRenderView = new ContentViewRenderView(getContext());
+      mContentViewRenderView.onNativeLibraryLoaded(mWindow);
+    }
+
+    Shell shellView = new Shell(getContext());
+    shellView.initialize(nativeShellPtr, mWindow);
+    shellView.onActivityVisible(mIsActivityVisible);
+    shellView.setWebContentsReadyListener(mNextWebContentsReadyListener);
+    mNextWebContentsReadyListener = null;
+
+    // TODO(tedchoc): Allow switching back to these inactive shells.
+    if (mActiveShell != null) removeShell(mActiveShell);
+
+    showShell(shellView);
+    return shellView;
+  }
+
+  @RequiresNonNull("mContentViewRenderView")
+  private void showShell(Shell shellView) {
+    if (mActiveShell != null) {
+      mActiveShell.setContentViewRenderView(null);
+    }
+    shellView.setContentViewRenderView(mContentViewRenderView);
+    mActiveShell = shellView;
+    WebContents webContents = mActiveShell.getWebContents();
+    if (webContents != null) {
+      mContentViewRenderView.setCurrentWebContents(webContents);
+      if (mIsActivityVisible) {
+        webContents.updateWebContentsVisibility(Visibility.VISIBLE);
+      }
+    }
+  }
+
+  @CalledByNative
+  private void removeShell(Shell shellView) {
+    if (shellView == mActiveShell) mActiveShell = null;
+    shellView.setContentViewRenderView(null);
+  }
+
+  /**
+   * Destroys the Shell manager and associated components. Always called at activity exit, and
+   * potentially called by native in cases where we need to control the timing of
+   * mContentViewRenderView destruction. Must handle being called twice.
+   */
+  @CalledByNative
+  public void destroy() {
+    // Remove active shell (Currently single shell support only available).
+    if (mActiveShell != null) {
+      removeShell(mActiveShell);
+    }
+    if (mContentViewRenderView != null) {
+      mContentViewRenderView.destroy();
+      mContentViewRenderView = null;
+    }
+  }
+
+  private static Natives sNatives;
+
+  public static void setNativesForTesting(Natives natives) {
+    sNatives = natives;
+  }
+
+  /** Interface for the native implementation of ShellManager. */
+  @NativeMethods
+  public interface Natives {
     /**
-     * Constructor for inflating via XML.
+     * Creates the native ShellManager object.
+     *
+     * @param shellManagerInstance The Java instance of the ShellManager.
      */
-    public ShellManager(final Context context) {
-        mContext = context;
-        if (sNatives == null) {
-            sNatives = ShellManagerJni.get();
-        }
-        sNatives.init(this);
-    }
-
-    public void onActivityVisible(boolean visible) {
-        mIsActivityVisible = visible;
-        if (mActiveShell != null) {
-            mActiveShell.onActivityVisible(visible);
-        }
-    }
-
-    public Context getContext() {
-        return mContext;
-    }
-
-    /**
-     * @param window The window used to generate all shells.
-     */
-    @Initializer
-    public void setWindow(WindowAndroid window) {
-        assert window != null;
-        mWindow = window;
-        mContentViewRenderView = new ContentViewRenderView(getContext());
-        mContentViewRenderView.onNativeLibraryLoaded(window);
-    }
-
-    /**
-     * @return The window used to generate all shells.
-     */
-    public WindowAndroid getWindow() {
-        return mWindow;
-    }
-
-    /**
-     * Get the ContentViewRenderView.
-     */
-    public @Nullable ContentViewRenderView getContentViewRenderView() {
-        return mContentViewRenderView;
-    }
-
-    /**
-     * @return The currently visible shell view or null if one is not showing.
-     */
-    public @Nullable Shell getActiveShell() {
-        return mActiveShell;
-    }
+    void init(Object shellManagerInstance);
 
     /**
      * Creates a new shell pointing to the specified URL.
+     *
      * @param url The URL the shell should load upon creation.
+     * @param deepLinkUrl The topic URL from the DeepLink URL.
      */
-    public void launchShell(String url) {
-        // Calls the overloaded method with a null listener.
-        launchShell(url, /* deepLinkUrl= */ "", /* listener= */ null);
-    }
+    void launchShell(String url, String deepLinkUrl);
 
     /**
-     * Creates a new shell pointing to the specified URL.
-     * @param url The URL the shell should load upon creation.
-     * @param deepLinkUrl The URL from the DeepLink URL.
-     * @param listener The listener to be notified when WebContents is ready.
+     * Appends the migration status parameter to the given URL.
+     *
+     * @param url The URL to append the migration status to.
+     * @return The updated URL.
      */
-    public void launchShell(String url, String deepLinkUrl, Shell.OnWebContentsReadyListener listener) {
-        ThreadUtils.assertOnUiThread();
-        mNextWebContentsReadyListener = listener;
-        Shell previousShell = mActiveShell;
-        sNatives.launchShell(url, deepLinkUrl);
-        if (previousShell != null) previousShell.close();
-    }
-
-    @CalledByNative
-    private Object createShell(long nativeShellPtr) {
-        if (mContentViewRenderView == null) {
-            mContentViewRenderView = new ContentViewRenderView(getContext());
-            mContentViewRenderView.onNativeLibraryLoaded(mWindow);
-        }
-
-        Shell shellView = new Shell(getContext());
-        shellView.initialize(nativeShellPtr, mWindow);
-        shellView.onActivityVisible(mIsActivityVisible);
-        shellView.setWebContentsReadyListener(mNextWebContentsReadyListener);
-        mNextWebContentsReadyListener = null;
-
-        // TODO(tedchoc): Allow switching back to these inactive shells.
-        if (mActiveShell != null) removeShell(mActiveShell);
-
-        showShell(shellView);
-        return shellView;
-    }
-
-    @RequiresNonNull("mContentViewRenderView")
-    private void showShell(Shell shellView) {
-        if (mActiveShell != null) {
-            mActiveShell.setContentViewRenderView(null);
-        }
-        shellView.setContentViewRenderView(mContentViewRenderView);
-        mActiveShell = shellView;
-        WebContents webContents = mActiveShell.getWebContents();
-        if (webContents != null) {
-            mContentViewRenderView.setCurrentWebContents(webContents);
-            if (mIsActivityVisible) {
-                webContents.updateWebContentsVisibility(Visibility.VISIBLE);
-            }
-        }
-    }
-
-    @CalledByNative
-    private void removeShell(Shell shellView) {
-        if (shellView == mActiveShell) mActiveShell = null;
-        shellView.setContentViewRenderView(null);
-    }
-
-    /**
-     * Destroys the Shell manager and associated components.
-     * Always called at activity exit, and potentially called by native in cases where we need to
-     * control the timing of mContentViewRenderView destruction. Must handle being called twice.
-     */
-    @CalledByNative
-    public void destroy() {
-        // Remove active shell (Currently single shell support only available).
-        if (mActiveShell != null) {
-            mActiveShell.close();
-            removeShell(mActiveShell);
-        }
-        if (mContentViewRenderView != null) {
-            mContentViewRenderView.destroy();
-            mContentViewRenderView = null;
-        }
-    }
-
-    private static Natives sNatives;
-
-    public static void setNativesForTesting(Natives natives) {
-        sNatives = natives;
-    }
-
-    /**
-     * Interface for the native implementation of ShellManager.
-     */
-    @NativeMethods
-    public interface Natives {
-        /**
-         * Creates the native ShellManager object.
-         * @param shellManagerInstance The Java instance of the ShellManager.
-         */
-        void init(Object shellManagerInstance);
-        /**
-         * Creates a new shell pointing to the specified URL.
-         * @param url The URL the shell should load upon creation.
-         * @param deepLinkUrl The topic URL from the DeepLink URL.
-         */
-        void launchShell(String url, String deepLinkUrl);
-        /**
-         * Appends the migration status parameter to the given URL.
-         * @param url The URL to append the migration status to.
-         * @return The updated URL.
-         */
-        String appendMigrationStatus(String url);
-    }
+    String appendMigrationStatus(String url);
+  }
 }


### PR DESCRIPTION
Remove the mActiveShell.close() call in the ShellManager destroy
method. This call was identified as a source of crashes while the
application is in the background. The shell remains properly detached
through removeShell(). 

Bug: 534798847