### PR TITLE
android: Clean up Cobalt Android startup logic

### DIFF
--- a/base/message_loop/message_pump_android.cc
+++ b/base/message_loop/message_pump_android.cc
@@ -4,6 +4,8 @@
 
 #include "base/message_loop/message_pump_android.h"
 
+#include "build/build_config.h"
+
 #include <android/looper.h>
 #include <errno.h>
 #include <fcntl.h>
@@ -21,6 +23,9 @@
 #include "base/android/input_hint_checker.h"
 #include "base/android/jni_android.h"
 #include "base/android/scoped_java_ref.h"
+#if BUILDFLAG(IS_COBALT)
+#include "base/auto_reset.h"
+#endif
 #include "base/check.h"
 #include "base/check_op.h"
 #include "base/message_loop/io_watcher.h"
@@ -390,6 +395,9 @@ void MessagePumpAndroid::OnDelayedLooperCallback() {
 }
 
 void MessagePumpAndroid::DoDelayedLooperWork() {
+  if (!delegate_) {
+    return;
+  }
   delayed_scheduled_time_.reset();
 
   Delegate::NextWorkInfo next_work_info = delegate_->DoWork();
@@ -442,6 +450,9 @@ void MessagePumpAndroid::OnNonDelayedLooperCallback() {
 }
 
 void MessagePumpAndroid::DoNonDelayedLooperWork(bool do_idle_work) {
+  if (!delegate_) {
+    return;
+  }
   // Note: We can't skip DoWork() even if |do_idle_work| is true here (i.e. no
   // additional ScheduleWork() since yielding to native) as delayed tasks might
   // have come in and we need to re-sample |next_work_info|.
@@ -521,7 +532,33 @@ void MessagePumpAndroid::DoNonDelayedLooperWork(bool do_idle_work) {
 }
 
 void MessagePumpAndroid::Run(Delegate* delegate) {
+#if BUILDFLAG(IS_COBALT)
+  // In standard Chromium on Android, the main UI thread message loop is driven
+  // entirely by Java's Looper, so calling RunLoop::Run() hits NOTREACHED().
+  // However, in Cobalt builds on Android, synchronous lifecycle events
+  // (e.g. HandleEvent for Conceal or Freeze) require executing nested run loops
+  // on the UI thread to ensure internal C++ tasks (such as concealing web
+  // contents, flushing storage, and releasing media resources) complete fully
+  // before returning control to the operating system.
+  //
+  // Here, we pump only Chromium's internal C++ task queue via delegate_->DoWork()
+  // without re-entering Android's native kernel looper (ALooper_pollOnce),
+  // which avoids libutils.so re-entrancy crashes while guaranteeing clean,
+  // synchronous completion of Chromium tasks.
+  SetDelegate(delegate);
+
+  base::AutoReset<bool> auto_reset_quit(&quit_, false);
+  while (!ShouldQuit()) {
+    Delegate::NextWorkInfo next_work_info = delegate_->DoWork();
+    if (ShouldQuit()) break;
+    if (next_work_info.is_immediate()) continue;
+    delegate_->DoIdleWork();
+    if (ShouldQuit()) break;
+    base::PlatformThread::Sleep(base::Milliseconds(5));
+  }
+#else
   NOTREACHED() << "Unexpected call to Run()";
+#endif
 }
 
 void MessagePumpAndroid::Attach(Delegate* delegate) {
@@ -551,6 +588,14 @@ void MessagePumpAndroid::Quit() {
   read(delayed_fd_, &value, sizeof(value));
   // Clear the eventfd.
   read(non_delayed_fd_, &value, sizeof(value));
+
+#if BUILDFLAG(IS_COBALT)
+  // When a nested RunLoop calls Quit, it shouldn't destroy the outer
+  // attached run_loop_.
+  if (base::RunLoop::IsNestedOnCurrentThread()) {
+    return;
+  }
+#endif
 
   if (run_loop_) {
     run_loop_->AfterRun();

--- a/cobalt/android/cobalt_library_loader.cc
+++ b/cobalt/android/cobalt_library_loader.cc
@@ -26,6 +26,5 @@ JNI_EXPORT jint JNI_OnLoad(JavaVM* vm, void* reserved) {
   if (!content::android::OnJNIOnLoadInit()) {
     return -1;
   }
-  content::SetContentMainDelegate(new cobalt::CobaltMainDelegate());
   return JNI_VERSION_1_4;
 }

--- a/content/app/android/library_loader_hooks.cc
+++ b/content/app/android/library_loader_hooks.cc
@@ -54,7 +54,13 @@ bool LibraryLoaded(base::android::LibraryProcessType library_process_type) {
   // Content Schemes need to be registered as early as possible after the
   // CommandLine has been initialized to allow java and tests to use GURL before
   // running ContentMain.
+#if BUILDFLAG(IS_COBALT)
+  // For Cobalt Android: We disable this early eager call to prevent a Catch-22 crash
+  // where it reaches for GetContentClient() before the AppEventRunner creates the
+  // delegate. It will instead be safely called later by ContentMainRunnerImpl::Initialize().
+#else
   RegisterContentSchemes();
+#endif
   return true;
 }
 

--- a/content/browser/browser_main_loop.cc
+++ b/content/browser/browser_main_loop.cc
@@ -912,7 +912,7 @@ void BrowserMainLoop::CreateStartupTasks() {
   startup_task_runner_->AddTask(std::move(intercept_main_message_loop_run));
 #endif
 
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_COBALT)
   startup_task_runner_->StartRunningTasksAsync();
 #else
   startup_task_runner_->RunAllTasksNow();

--- a/content/browser/browser_main_loop.h
+++ b/content/browser/browser_main_loop.h
@@ -172,7 +172,7 @@ class CONTENT_EXPORT BrowserMainLoop {
     return media_keys_listener_manager_.get();
   }
 
-#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_STARBOARD)
+#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_COBALT)
   // Cobalt: Expose on Starboard for passive updates. Note this will not be
   // null for the preload/background state.
 

--- a/content/browser/network_service_instance_impl.cc
+++ b/content/browser/network_service_instance_impl.cc
@@ -724,7 +724,7 @@ base::CallbackListSubscription RegisterNetworkServiceProcessGoneHandler(
   return GetProcessGoneHandlersList().Add(std::move(handler));
 }
 
-#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_STARBOARD)
+#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_COBALT)
 net::NetworkChangeNotifier* GetNetworkChangeNotifier() {
   return BrowserMainLoop::GetInstance()->network_change_notifier();
 }

--- a/content/public/app/content_main.h
+++ b/content/public/app/content_main.h
@@ -104,7 +104,9 @@ CONTENT_EXPORT int RunContentProcess(ContentMainParams params,
 // This should only be called once before ContentMainRunner actually running.
 // The ownership of |delegate| is transferred.
 CONTENT_EXPORT void SetContentMainDelegate(ContentMainDelegate* delegate);
-#else
+#endif
+
+#if !BUILDFLAG(IS_ANDROID) || BUILDFLAG(IS_COBALT)
 // ContentMain should be called from the embedder's main() function to do the
 // initial setup for every process. The embedder has a chance to customize
 // startup using the ContentMainDelegate interface. The embedder can also pass

--- a/content/public/browser/network_service_instance.h
+++ b/content/public/browser/network_service_instance.h
@@ -49,7 +49,7 @@ CONTENT_EXPORT network::mojom::NetworkService* GetNetworkService();
 
 // Only on ChromeOS since it's only used there.
 // Cobalt: Used on Starboard as well.
-#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_STARBOARD)
+#if BUILDFLAG(IS_CHROMEOS) || BUILDFLAG(IS_COBALT)
 // Returns the global NetworkChangeNotifier instance.
 CONTENT_EXPORT net::NetworkChangeNotifier* GetNetworkChangeNotifier();
 #endif


### PR DESCRIPTION
android: Clean up Cobalt Android startup logic

Update legacy IS_STARBOARD macros to IS_COBALT in browser and network service headers. Configure MessagePumpAndroid to support nested run loops synchronously on Android to handle lifecycle events without re-entering the native looper.

This change also prevents initialization crashes by guarding against early delegate calls during library loading and ensures browser startup tasks run synchronously.

Bug: 338274026

BUG=b/338274026
TAG=agy
CONV=006ddb93-1731-4dba-b801-1f6fb67f1fd4