### PR TITLE
android: Assert legacy WebContents methods unused

### DIFF
--- a/content/browser/web_contents/web_contents_android.cc
+++ b/content/browser/web_contents/web_contents_android.cc
@@ -466,8 +466,12 @@ jint WebContentsAndroid::GetVisibility(JNIEnv* env) {
 
 void WebContentsAndroid::UpdateWebContentsVisibility(JNIEnv* env,
                                                      jint visibility) {
+#if BUILDFLAG(IS_COBALT)
+  LOG(FATAL) << __func__ << " should never be called in Cobalt.";
+#else
   web_contents_->UpdateWebContentsVisibility(
       static_cast<Visibility>(visibility));
+#endif
 }
 
 RenderWidgetHostViewAndroid*
@@ -496,11 +500,19 @@ void WebContentsAndroid::ResumeLoadingCreatedWebContents(JNIEnv* env) {
 }
 
 void WebContentsAndroid::OnFreeze(JNIEnv* env) {
+#if BUILDFLAG(IS_COBALT)
+  LOG(FATAL) << __func__ << " should never be called in Cobalt.";
+#else
   web_contents_->SetPageFrozen(true);
+#endif
 }
 
 void WebContentsAndroid::OnResume(JNIEnv* env) {
+#if BUILDFLAG(IS_COBALT)
+  LOG(FATAL) << __func__ << " should never be called in Cobalt.";
+#else
   web_contents_->SetPageFrozen(false);
+#endif
 }
 
 void WebContentsAndroid::SetPrimaryMainFrameImportance(JNIEnv* env,
@@ -510,7 +522,11 @@ void WebContentsAndroid::SetPrimaryMainFrameImportance(JNIEnv* env,
 }
 
 void WebContentsAndroid::SuspendAllMediaPlayers(JNIEnv* env) {
+#if BUILDFLAG(IS_COBALT)
+  LOG(FATAL) << __func__ << " should never be called in Cobalt.";
+#else
   web_contents_->media_web_contents_observer()->SuspendAllMediaPlayers();
+#endif
 }
 
 void WebContentsAndroid::SetAudioMuted(JNIEnv* env, jboolean mute) {
@@ -902,9 +918,13 @@ void WebContentsAndroid::OnScaleFactorChanged(JNIEnv* env) {
 }
 
 void WebContentsAndroid::SetFocus(JNIEnv* env, jboolean focused) {
+#if BUILDFLAG(IS_COBALT)
+  LOG(FATAL) << __func__ << " should never be called in Cobalt.";
+#else
   WebContentsViewAndroid* view =
       static_cast<WebContentsViewAndroid*>(web_contents_->GetView());
   view->SetFocus(focused);
+#endif
 }
 
 bool WebContentsAndroid::IsBeingDestroyed(JNIEnv* env) {


### PR DESCRIPTION
android: Assert legacy WebContents methods unused

Add LOG(FATAL) assertions to legacy WebContentsAndroid methods to ensure they are never invoked directly in Cobalt builds. This includes UpdateWebContentsVisibility, OnFreeze, OnResume, SetFocus, and SuspendAllMediaPlayers. Since Cobalt manages its own lifecycle and media state, these standard Chromium Android paths are unsupported and must be unreachable.

Bug: 338274026

BUG=b/338274026
TAG=agy
CONV=006ddb93-1731-4dba-b801-1f6fb67f1fd4