### PR TITLE
android: Add stdout file path helper for test runner logging

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
@@ -91,6 +91,7 @@ public class BaseStarboardBridge {
 
   private volatile boolean mApplicationStopped;
   private volatile boolean mApplicationStarted;
+  private String mStdoutFilePath;
 
   private long mAppStartTimestamp = 0;
 
@@ -270,6 +271,15 @@ public class BaseStarboardBridge {
   @CalledByNative
   protected void applicationStarted() {
     mApplicationStarted = true;
+  }
+
+  public void setStdoutFilePath(String path) {
+    mStdoutFilePath = path;
+  }
+
+  @CalledByNative
+  public String getStdoutFilePath() {
+    return mStdoutFilePath != null ? mStdoutFilePath : "";
   }
 
   @CalledByNative

--- a/cobalt/testing/browser_tests/browsertests_apk/src/org/chromium/content_browsertests_apk/ContentShellBrowserTestActivity.java
+++ b/cobalt/testing/browser_tests/browsertests_apk/src/org/chromium/content_browsertests_apk/ContentShellBrowserTestActivity.java
@@ -25,6 +25,7 @@ import dev.cobalt.util.Holder;
 
 import org.chromium.base.StrictModeContext;
 import org.chromium.base.library_loader.LibraryLoader;
+import org.chromium.build.gtest_apk.NativeTestIntent;
 import org.chromium.base.library_loader.LibraryProcessType;
 import org.chromium.content_public.browser.BrowserStartupController;
 import org.chromium.content_public.browser.BrowserStartupController.StartupCallback;
@@ -95,6 +96,14 @@ public abstract class ContentShellBrowserTestActivity extends NativeBrowserTestA
                         new String[0], // args
                         ""); // startDeepLink
         ((StarboardBridge.HostApplication) getApplication()).setStarboardBridge(mStarboardBridge);
+
+        Intent intent = getIntent();
+        if (intent != null) {
+            String stdoutFile = intent.getStringExtra(NativeTestIntent.EXTRA_STDOUT_FILE);
+            if (stdoutFile != null) {
+                mStarboardBridge.setStdoutFilePath(stdoutFile);
+            }
+        }
 
         Window wind = this.getWindow();
         wind.addFlags(WindowManager.LayoutParams.FLAG_DISMISS_KEYGUARD);

--- a/starboard/android/shared/base_starboard_bridge.cc
+++ b/starboard/android/shared/base_starboard_bridge.cc
@@ -256,6 +256,13 @@ void StarboardBridge::AppendArgs(JNIEnv* env,
   AppendJavaStringArrayToStringVector(env, args_java, args_vector);
 }
 
+std::string StarboardBridge::GetStdoutFilePath(JNIEnv* env) {
+  SB_DCHECK(env);
+  ScopedJavaLocalRef<jstring> path_java =
+      Java_BaseStarboardBridge_getStdoutFilePath(env, j_starboard_bridge_);
+  return ConvertJavaStringToUTF8(env, path_java);
+}
+
 ScopedJavaLocalRef<jintArray> StarboardBridge::GetSupportedHdrTypes(
     JNIEnv* env) {
   SB_DCHECK(env);

--- a/starboard/android/shared/starboard_bridge.h
+++ b/starboard/android/shared/starboard_bridge.h
@@ -40,6 +40,8 @@ class StarboardBridge {
 
   void AppendArgs(JNIEnv* env, std::vector<std::string>* args_vector);
 
+  std::string GetStdoutFilePath(JNIEnv* env);
+
   jni_zero::ScopedJavaLocalRef<jintArray> GetSupportedHdrTypes(JNIEnv* env);
 
   void RaisePlatformError(JNIEnv* env,


### PR DESCRIPTION
android: Add stdout file path helper for test runner logging

The browser tests does not currently extract the `NativeTestIntent.EXTRA_STDOUT_FILE` (`org.chromium.native_test.NativeTest.StdoutFile`) intent extra passed by Chromium's test runner (`local_device_gtest_run.py`), causing native test log output (`SbLogRaw`) to be routed to logcat instead of the host runner's output file.

This change adds `StarboardBridge.getStdoutFilePath()` JNI bridge so native C++ code can retrieve the log file path:
- **Test Activity (`ContentShellBrowserTestActivity`):** Extracts `NativeTestIntent.EXTRA_STDOUT_FILE` from intent extras upon Activity launch and calls `StarboardBridge.setStdoutFilePath(...)`.
- **Production Bridge (`BaseStarboardBridge`):** Holds the log path field and exposes `getStdoutFilePath()` over JNI without introducing test dependencies or intent extra parsing into production code.

Bug: 473909877
Bug: 425936227
Bug: 448156280