### PR TITLE
android: Add RequestStop helper to send test completion signal

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
@@ -288,6 +288,7 @@ public class BaseStarboardBridge {
   }
 
   /* Immediate shutdown, used at least by StandalonePlayerActivity. */
+  @CalledByNative
   public void requestStop(int errorLevel) {
     applicationStopping();
     Activity activity = mActivityHolder.get();

--- a/starboard/android/shared/base_starboard_bridge.cc
+++ b/starboard/android/shared/base_starboard_bridge.cc
@@ -315,6 +315,11 @@ SB_EXPORT_ANDROID void StarboardBridge::CloseApp(JNIEnv* env) {
   return Java_BaseStarboardBridge_closeApp(env, j_starboard_bridge_);
 }
 
+void StarboardBridge::RequestStop(JNIEnv* env, jint error_level) {
+  SB_CHECK(env);
+  Java_BaseStarboardBridge_requestStop(env, j_starboard_bridge_, error_level);
+}
+
 std::string StarboardBridge::GetTimeZoneId(JNIEnv* env) {
   SB_DCHECK(env);
   ScopedJavaLocalRef<jstring> timezone_id_java =

--- a/starboard/android/shared/starboard_bridge.h
+++ b/starboard/android/shared/starboard_bridge.h
@@ -65,6 +65,7 @@ class StarboardBridge {
   double GetScreenDiagonal(JNIEnv* env);
 
   void CloseApp(JNIEnv* env);
+  void RequestStop(JNIEnv* env, jint error_level);
 
   std::string GetTimeZoneId(JNIEnv* env);
 

--- a/starboard/android/shared/system_request_stop.cc
+++ b/starboard/android/shared/system_request_stop.cc
@@ -16,10 +16,18 @@
 #include "starboard/system.h"
 // clang-format on
 
+#include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/common/log.h"
+#include "third_party/jni_zero/jni_zero.h"
 
 void SbSystemRequestStop(int error_level) {
-  // TODO: b/450024477 - Implement this method when AOSP is used.
-  SB_LOG(WARNING) << __func__ << "(error_level=" << error_level
-                  << ") is called, but it's ignored on Android";
+  SB_LOG(INFO) << __func__ << ": error_level=" << error_level;
+  starboard::StarboardBridge* bridge =
+      starboard::StarboardBridge::GetInstance();
+  if (!bridge) {
+    SB_LOG(WARNING) << "StarboardBridge instance is null, ignoring RequestStop";
+    return;
+  }
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+  bridge->RequestStop(env, error_level);
 }


### PR DESCRIPTION
android: Add RequestStop helper to send test completion signal

Wire SbSystemRequestStop to call StarboardBridge.requestStop over JNI, allowing test execution runners to signal test completion and finish the test activity.

Bug: 473909877
Bug: 425936227
Bug: 448156280