### PR TITLE
android: Use kPreferCustom for custom fonts.xml experiment

### DIFF
--- a/skia/ext/font_utils.cc
+++ b/skia/ext/font_utils.cc
@@ -78,7 +78,7 @@ static sk_sp<SkFontMgr> fontmgr_factory() {
     if (base::PathService::Get(base::DIR_ANDROID_APP_DATA, &app_data_dir)) {
       std::string xml_path = app_data_dir.Append("storage").Append("cobalt_android_fonts.xml").value();
       SkFontMgr_Android_CustomFonts custom_fonts;
-      custom_fonts.fSystemFontUse = SkFontMgr_Android_CustomFonts::kOnlyCustom;
+      custom_fonts.fSystemFontUse = SkFontMgr_Android_CustomFonts::kPreferCustom;
       custom_fonts.fBasePath = "/system/fonts/";
       custom_fonts.fFontsXml = xml_path.c_str();
       custom_fonts.fFallbackFontsXml = nullptr;

--- a/skia/ext/font_utils.cc
+++ b/skia/ext/font_utils.cc
@@ -90,6 +90,7 @@ static sk_sp<SkFontMgr> fontmgr_factory() {
         return SkFontMgr_New_Android(&custom_fonts);
       }
     }
+  }
 #endif // BUILDFLAG (IS_COBALT)
   if (base::FeatureList::IsEnabled(skia::kFontationsAndroidSystemFonts)) {
     return SkFontMgr_New_Android(nullptr, SkFontScanner_Make_Fontations());

--- a/skia/ext/font_utils.cc
+++ b/skia/ext/font_utils.cc
@@ -71,6 +71,7 @@ static sk_sp<SkFontMgr> fontmgr_factory() {
   return SkFontMgr_New_Cobalt();
 #else
 #if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_COBALT)
   // When Cobalt optimized font loading is enabled, configure Skia to use hermetic custom
   // XML font fallbacks (`cobalt_android_fonts.xml`) extracted into the app data directory.
   if (base::CommandLine::ForCurrentProcess()->HasSwitch("enable-optimized-font-loading")) {
@@ -89,7 +90,7 @@ static sk_sp<SkFontMgr> fontmgr_factory() {
         return SkFontMgr_New_Android(&custom_fonts);
       }
     }
-  }
+#endif // BUILDFLAG (IS_COBALT)
   if (base::FeatureList::IsEnabled(skia::kFontationsAndroidSystemFonts)) {
     return SkFontMgr_New_Android(nullptr, SkFontScanner_Make_Fontations());
   } else {

--- a/starboard/content/fonts/config/android/fonts.xml
+++ b/starboard/content/fonts/config/android/fonts.xml
@@ -214,7 +214,7 @@
         <font weight="400" style="normal">NotoSansTamilUI-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansTamilUI-Regular.otf</font>
         <font weight="700" style="normal">NotoSansTamilUI-Bold.ttf</font>
-        <font weight="400" style="normal">NotoSansTamilUI-Bold.otf</font>
+        <font weight="700" style="normal">NotoSansTamilUI-Bold.otf</font>
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Tamil UI" postscript_name="NotoSansTamilUI-Regular">NotoSansTamilUI-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Tamil UI Bold" postscript_name="NotoSansTamilUI-Bold">NotoSansTamilUI-VF.ttf</font>
     </family>

--- a/starboard/content/fonts/config/android/fonts.xml
+++ b/starboard/content/fonts/config/android/fonts.xml
@@ -140,16 +140,6 @@
     <family pages="0">
         <font weight="400" style="normal">Roboto-Regular.ttf</font>
     </family>
-    <!-- Alias generic families to sans-serif to prevent missing OS font lookups -->
-    <alias name="serif" to="sans-serif" />
-    <alias name="fantasy" to="sans-serif" />
-    <alias name="monospace" to="sans-serif" />
-    <alias name="sans-serif-monospace" to="sans-serif" />
-    <alias name="serif-monospace" to="sans-serif" />
-    <alias name="casual" to="sans-serif" />
-    <alias name="cursive" to="sans-serif" />
-    <alias name="sans-serif-smallcaps" to="sans-serif" />
-
     <!-- fallback fonts -->
     <!-- "Noto Naskh Arabic UI" is given a fallback priority so that, in spite
          of having a name, it will still be included as a fallback font.

--- a/starboard/content/fonts/config/android/fonts.xml
+++ b/starboard/content/fonts/config/android/fonts.xml
@@ -138,55 +138,35 @@
     <alias name="Helvetica" to="sans-serif" />
     <!-- This is the default font when Roboto is unavailable. -->
     <family pages="0">
-        <font weight="400" style="normal">Roboto-Regular-Subsetted.ttf</font>
+        <font weight="400" style="normal">Roboto-Regular.ttf</font>
     </family>
-    <family name="sans-serif-condensed">
-        <font weight="300" style="normal" font_name="Roboto Condensed Light" postscript_name="Roboto-Condensed-Light">RobotoCondensed-Light.ttf</font>
-        <font weight="300" style="italic" font_name="Roboto Condensed Light Italic" postscript_name="Roboto-Condensed-Light-Italic">RobotoCondensed-LightItalic.ttf</font>
-        <font weight="400" style="normal" font_name="Roboto Condensed Regular" postscript_name="Roboto-Condensed-Regular">RobotoCondensed-Regular.ttf</font>
-        <font weight="400" style="italic" font_name="Roboto Condensed Regular Italic" postscript_name="Roboto-Condensed-Regular-Italic">RobotoCondensed-Italic.ttf</font>
-        <font weight="700" style="normal" font_name="Roboto Condensed Bold" postscript_name="Roboto-Condensed-Bold">RobotoCondensed-Bold.ttf</font>
-        <font weight="700" style="italic" font_name="Roboto Condensed Bold Italic" postscript_name="Roboto-Condensed-Bold-Italic">RobotoCondensed-BoldItalic.ttf</font>
-    </family>
-    <family name="serif">
-        <font weight="400" style="normal" font_name="Noto Serif" postscript_name="NotoSerif">NotoSerif-Regular.ttf</font>
-        <font weight="400" style="italic" font_name="Noto Serif Italic" postscript_name="NotoSerif-Italic">NotoSerif-Italic.ttf</font>
-        <font weight="700" style="normal" font_name="Noto Serif Bold" postscript_name="NotoSerif-Bold">NotoSerif-Bold.ttf</font>
-        <font weight="700" style="italic" font_name="Noto Serif Bold Italic" postscript_name="NotoSerif-BoldItalic">NotoSerif-BoldItalic.ttf</font>
-    </family>
-    <alias name="fantasy" to="serif" />
-    <family name="monospace">
-        <font weight="400" style="normal" font_name="Droid Sans Mono" postscript_name="DroidSansMono">DroidSansMono.ttf</font>
-    </family>
-    <alias name="sans-serif-monospace" to="monospace" />
-    <family name="serif-monospace">
-        <font weight="400" style="normal" font_name="Cutive Mono" postscript_name="CutiveMono-Regular">CutiveMono.ttf</font>
-    </family>
-    <family name="casual">
-        <font weight="400" style="normal" font_name="Coming Soon" postscript_name="ComingSoon">ComingSoon.ttf</font>
-    </family>
-    <family name="cursive">
-        <font weight="400" style="normal" font_name="Dancing Script" postscript_name="DancingScript">DancingScript-Regular.ttf</font>
-        <font weight="700" style="normal" font_name="Dancing Script Bold" postscript_name="DancingScript-Bold">DancingScript-Bold.ttf</font>
-    </family>
-    <family name="sans-serif-smallcaps">
-        <font weight="400" style="normal" font_name="Carrois Gothic SC" postscript_name="CarroisGothicSC-Regular">CarroisGothicSC-Regular.ttf</font>
-    </family>
+    <!-- Alias generic families to sans-serif to prevent missing OS font lookups -->
+    <alias name="serif" to="sans-serif" />
+    <alias name="fantasy" to="sans-serif" />
+    <alias name="monospace" to="sans-serif" />
+    <alias name="sans-serif-monospace" to="sans-serif" />
+    <alias name="serif-monospace" to="sans-serif" />
+    <alias name="casual" to="sans-serif" />
+    <alias name="cursive" to="sans-serif" />
+    <alias name="sans-serif-smallcaps" to="sans-serif" />
+
     <!-- fallback fonts -->
     <!-- "Noto Naskh Arabic UI" is given a fallback priority so that, in spite
          of having a name, it will still be included as a fallback font.
     -->
-    <family fallback_priority="0" name="Noto Naskh Arabic UI">
+    <family lang="und-Arab">
+        <font weight="400" style="normal">NotoNaskhArabic-Regular.ttf</font>
+        <font weight="700" style="normal">NotoNaskhArabic-Bold.ttf</font>
         <font weight="400" style="normal">NotoNaskhArabicUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoNaskhArabicUI-Bold.ttf</font>
     </family>
-    <family>
+    <family lang="und-Ethi">
         <font weight="400" style="normal">NotoSansEthiopic-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansEthiopic-Bold.ttf</font>
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Ethiopic" postscript_name="NotoSansEthiopic-Regular">NotoSansEthiopic-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Ethiopic Bold" postscript_name="NotoSansEthiopic-Bold">NotoSansEthiopic-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Hebr">
         <font weight="400" style="normal">NotoSansHebrew-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansHebrew-Bold.ttf</font>
     </family>
@@ -194,7 +174,7 @@
         <font weight="400" style="normal">NotoSansThaiUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansThaiUI-Bold.ttf</font>
     </family>
-    <family>
+    <family lang="und-Armn">
         <font weight="400" style="normal">NotoSansArmenian-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansArmenian-Regular.otf</font>
         <font weight="700" style="normal">NotoSansArmenian-Bold.ttf</font>
@@ -202,7 +182,7 @@
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Armenian" postscript_name="NotoSansArmenian-Regular">NotoSansArmenian-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Armenian Bold" postscript_name="NotoSansArmenian-Bold">NotoSansArmenian-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Geor">
         <font weight="400" style="normal">NotoSansGeorgian-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansGeorgian-Regular.otf</font>
         <font weight="700" style="normal">NotoSansGeorgian-Bold.ttf</font>
@@ -210,7 +190,7 @@
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Georgian" postscript_name="NotoSansGeorgian-Regular">NotoSansGeorgian-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Georgian Bold" postscript_name="NotoSansGeorgian-Bold">NotoSansGeorgian-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Deva">
         <font weight="400" style="normal">NotoSansDevanagariUI-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansDevanagariUI-Regular.otf</font>
         <font weight="700" style="normal">NotoSansDevanagariUI-Bold.ttf</font>
@@ -219,26 +199,26 @@
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Devanagari UI Bold" postscript_name="NotoSansDevanagariUI-Bold">NotoSansDevanagariUI-VF.ttf</font>
     </family>
     <!-- Gujarati should come after Devanagari -->
-    <family>
+    <family lang="und-Gujr">
         <font weight="400" style="normal">NotoSansGujaratiUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansGujaratiUI-Bold.ttf</font>
     </family>
     <!-- Gurmukhi should come after Devanagari -->
-    <family>
+    <family lang="und-Guru">
         <font weight="400" style="normal">NotoSansGurmukhiUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansGurmukhiUI-Bold.ttf</font>
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Gurmukhi UI" postscript_name="NotoSansGurmukhiUI-Regular">NotoSansGurmukhiUI-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Gurmukhi UI Bold" postscript_name="NotoSansGurmukhiUI-Bold">NotoSansGurmukhiUI-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Taml">
         <font weight="400" style="normal">NotoSansTamilUI-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansTamilUI-Regular.otf</font>
         <font weight="700" style="normal">NotoSansTamilUI-Bold.ttf</font>
-        <font weight="700" style="normal">NotoSansTamilUI-Bold.otf</font>
+        <font weight="400" style="normal">NotoSansTamilUI-Bold.otf</font>
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Tamil UI" postscript_name="NotoSansTamilUI-Regular">NotoSansTamilUI-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Tamil UI Bold" postscript_name="NotoSansTamilUI-Bold">NotoSansTamilUI-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Mlym">
         <font weight="400" style="normal">NotoSansMalayalamUI-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansMalayalamUI-Regular.otf</font>
         <font weight="700" style="normal">NotoSansMalayalamUI-Bold.ttf</font>
@@ -246,7 +226,7 @@
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Malayalam UI" postscript_name="NotoSansMalayalamUI-Regular">NotoSansMalayalamUI-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Malayalam UI Bold" postscript_name="NotoSansMalayalamUI-Bold">NotoSansMalayalamUI-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Beng">
         <font weight="400" style="normal">NotoSansBengaliUI-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansBengaliUI-Regular.otf</font>
         <font weight="700" style="normal">NotoSansBengaliUI-Bold.ttf</font>
@@ -254,23 +234,23 @@
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Bengali UI" postscript_name="NotoSansBengaliUI-Regular">NotoSansBengaliUI-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Bengali UI Bold" postscript_name="NotoSansBengaliUI-Bold">NotoSansBengaliUI-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Telu">
         <font weight="400" style="normal">NotoSansTeluguUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansTeluguUI-Bold.ttf</font>
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Telugu UI" postscript_name="NotoSansTeluguUI-Regular">NotoSansTeluguUI-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Telugu UI Bold" postscript_name="NotoSansTeluguUI-Bold">NotoSansTeluguUI-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Knda">
         <font weight="400" style="normal">NotoSansKannadaUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansKannadaUI-Bold.ttf</font>
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Kannada UI" postscript_name="NotoSansKannadaUI-Regular">NotoSansKannadaUI-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Kannada UI Bold" postscript_name="NotoSansKannadaUI-Bold">NotoSansKannadaUI-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Orya">
         <font weight="400" style="normal">NotoSansOriyaUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansOriyaUI-Bold.ttf</font>
     </family>
-    <family>
+    <family lang="und-Sinh">
         <font weight="400" style="normal">NotoSansSinhala-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansSinhala-Regular.otf</font>
         <font weight="700" style="normal">NotoSansSinhala-Bold.ttf</font>
@@ -278,15 +258,15 @@
         <font weight="400" style="normal" tag_wght="400" font_name="Noto Sans Sinhala" postscript_name="NotoSansSinhala-Regular">NotoSansSinhala-VF.ttf</font>
         <font weight="700" style="normal" tag_wght="700" font_name="Noto Sans Sinhala Bold" postscript_name="NotoSansSinhala-Bold">NotoSansSinhala-VF.ttf</font>
     </family>
-    <family>
+    <family lang="und-Khmr">
         <font weight="400" style="normal">NotoSansKhmerUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansKhmerUI-Bold.ttf</font>
     </family>
-    <family>
+    <family lang="und-Lao">
         <font weight="400" style="normal">NotoSansLaoUI-Regular.ttf</font>
         <font weight="700" style="normal">NotoSansLaoUI-Bold.ttf</font>
     </family>
-    <family>
+    <family lang="und-Mymr">
         <font weight="400" style="normal">NotoSansMyanmarUI-Regular.ttf</font>
         <font weight="400" style="normal">NotoSansMyanmarUI-Regular.otf</font>
         <font weight="700" style="normal">NotoSansMyanmarUI-Bold.ttf</font>

--- a/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_iterator.cc
@@ -4,7 +4,9 @@
 
 #include "third_party/blink/renderer/platform/fonts/font_fallback_iterator.h"
 
+#include "base/command_line.h"
 #include "base/memory/values_equivalent.h"
+#include "build/build_config.h"
 #include "third_party/blink/renderer/platform/fonts/font_cache.h"
 #include "third_party/blink/renderer/platform/fonts/font_description.h"
 #include "third_party/blink/renderer/platform/fonts/font_fallback_list.h"
@@ -158,6 +160,15 @@ FontDataForRangeSet* FontFallbackIterator::Next(const HintCharList& hint_list) {
 
   if (fallback_stage_ == kFirstCandidateForNotdefGlyph) {
     fallback_stage_ = kOutOfLuck;
+#if BUILDFLAG(IS_ANDROID)
+    // Don't crash the application if first_candidate is null.
+    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+            "enable-optimized-font-loading")) {
+      if (first_candidate_)                                                                                                                  
+        return first_candidate_; 
+      return MakeGarbageCollected<FontDataForRangeSet>();
+    }
+#endif
     if (!first_candidate_)
       FontCache::CrashWithFontInfo(&font_description_);
     return first_candidate_;

--- a/third_party/blink/renderer/platform/fonts/font_fallback_iterator_test.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_iterator_test.cc
@@ -2,6 +2,12 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include "build/build_config.h"
+
+#if BUILDFLAG(IS_ANDROID)
+#include "base/command_line.h"
+#endif
+
 #include "third_party/blink/renderer/platform/fonts/font_fallback_iterator.h"
 
 #include "testing/gtest/include/gtest/gtest.h"
@@ -45,4 +51,28 @@ TEST_P(TestReset, TestResetWithFallbackPriority) {
   EXPECT_EQ(fallback_iterator_reset, fallback_iterator);
 }
 
+#if BUILDFLAG(IS_ANDROID)
+class FontFallbackIteratorTest : public FontTestBase {};
+
+TEST_F(FontFallbackIteratorTest, MissingFontFallbackDoesNotCrash) {
+  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+      "enable-optimized-font-loading");
+
+  FontDescription font_description;
+  font_description.SetGenericFamily(FontDescription::kSerifFamily);
+  Font font(font_description);
+
+  FontFallbackIterator iterator =
+      font.CreateFontFallbackIterator(FontFallbackPriority::kText);
+
+  FontFallbackIterator::HintCharList hint_list = {'X'};
+
+  while (iterator.HasNext()) {
+    FontDataForRangeSet* range_set = iterator.Next(hint_list);
+    if (!range_set || !range_set->HasFontData()) {
+      break;
+    }
+  }
+}
+#endif
 }  // namespace blink

--- a/third_party/blink/renderer/platform/fonts/font_fallback_iterator_test.cc
+++ b/third_party/blink/renderer/platform/fonts/font_fallback_iterator_test.cc
@@ -5,7 +5,7 @@
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_ANDROID)
-#include "base/command_line.h"
+#include "base/test/scoped_command_line.h"
 #endif
 
 #include "third_party/blink/renderer/platform/fonts/font_fallback_iterator.h"
@@ -55,7 +55,8 @@ TEST_P(TestReset, TestResetWithFallbackPriority) {
 class FontFallbackIteratorTest : public FontTestBase {};
 
 TEST_F(FontFallbackIteratorTest, MissingFontFallbackDoesNotCrash) {
-  base::CommandLine::ForCurrentProcess()->AppendSwitch(
+  base::test::ScopedCommandLine scoped_command_line;
+  scoped_command_line.GetProcessCommandLine()->AppendSwitch(
       "enable-optimized-font-loading");
 
   FontDescription font_description;


### PR DESCRIPTION
#11082 introduced a [crash](https://primes.corp.google.com/products/5063451/metrics/crashes/clusters/1000000002825382810?sortBy=2&sortOrder=2&duration_seconds=2592000&source=8595118275&reportType=JAVA,NATIVE&measure=reports&trendsTab=overview&timeGranularity=daily) when using a custom fonts.xml file. 

This PR changes `SkFontMgr_Android_CustomFonts::fSystemFontUse` from `kOnlyCustom` to `kPreferCustom` so Skia automatically falls back to Android's native system font manager (/etc/fonts.xml) when custom XML paths are missing or unmapped.   

It also guards `FontFallbackIterator::Next` to safely return an empty `FontDataForRangeSet` instead of invoking `FontCache::CrashWithFontInfo` when `first_candidate_` is `null`.                                                          

Also updating the custom fonts.xml to correct the default fallback font to Roboto-Regular.ttf and add explicit BCP-47 `lang="und-..."` attributes and legacy .otf/.ttf filenames to global script families. Unused generic font families (such as serif, monospace, and sans-serif-condensed) and cross-family aliases were removed from fonts.xml because their font files (e.g., RobotoCondensed, NotoSerif) are not bundled in the Cobalt Android APK. Using `kPreferCustom`, omitting these unbundled family declarations allows Skia to fall back to Android's native `/system/fonts/` if those styles are requested.

Bug: 539964574
Bug: 517249177