### PR TITLE
test: Make SbPlayerTestFixture call Queue::GetTimed() via RunTestBlockingAction

### DIFF
--- a/starboard/nplb/player_test_fixture.cc
+++ b/starboard/nplb/player_test_fixture.cc
@@ -613,9 +613,13 @@ void SbPlayerTestFixture::WriteEndOfStream(SbMediaType media_type) {
 void SbPlayerTestFixture::WaitAndProcessNextEvent(int64_t timeout) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
 
+  // RunTestBlockingAction() is necessary to prevent deadlocks during NPLB tests
+  // on platforms such as tvOS, where the main thread could be blocked waiting
+  // for a condition variable while worker threads are simultaneously blocked
+  // waiting for the main thread to handle application events.
   CallbackEvent event;
   starboard::RunTestBlockingAction(
-      [&]() { event = callback_event_queue_.GetTimed(timeout); });
+      [&] { event = callback_event_queue_.GetTimed(timeout); });
 
   // Ignore callback events for previous Seek().
   if (event.ticket != ticket_) {

--- a/starboard/nplb/player_test_fixture.cc
+++ b/starboard/nplb/player_test_fixture.cc
@@ -21,6 +21,7 @@
 #include "starboard/common/string.h"
 #include "starboard/common/time.h"
 #include "starboard/nplb/drm_helpers.h"
+#include "starboard/testing/test_runner.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace nplb {
@@ -612,7 +613,9 @@ void SbPlayerTestFixture::WriteEndOfStream(SbMediaType media_type) {
 void SbPlayerTestFixture::WaitAndProcessNextEvent(int64_t timeout) {
   SB_CHECK(thread_checker_.CalledOnValidThread());
 
-  auto event = callback_event_queue_.GetTimed(timeout);
+  CallbackEvent event;
+  starboard::RunTestBlockingAction(
+      [&]() { event = callback_event_queue_.GetTimed(timeout); });
 
   // Ignore callback events for previous Seek().
   if (event.ticket != ticket_) {


### PR DESCRIPTION
This makes some NPLB tests stop timing out on tvOS, as otherwise the main thread would be blocked waiting on the queue's condition variable while worker threads would be blocked on onApplicationMainThread() waiting for the main thread to process new events.

Bug: 535573341