### PR TITLE
cobalt: Extract SbEventHandle into cobalt/app/sb_event_handle.cc

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -92,6 +92,28 @@ group("gn_all") {
   }
 }
 
+# Target containing the SbEventHandle implementation, kept separate from ":common"
+# so tests defining their own entry point/mock can omit it or link it as needed.
+static_library("sb_event_handle") {
+  sources = [ "app/sb_event_handle.cc" ]
+  deps = [
+    ":common",
+    "//base",
+    "//starboard:starboard_group",
+  ]
+}
+
+# Target containing the default app/cobalt.cc entry point.
+static_library("cobalt_app") {
+  sources = [ "app/cobalt.cc" ]
+  deps = [
+    ":common",
+    ":sb_event_handle",
+    "//base",
+    "//starboard:starboard_group",
+  ]
+}
+
 group("cobalt_browsertests") {
   testonly = true
 
@@ -188,11 +210,10 @@ if (is_ios && target_platform == "tvos") {
     cobalt_target_type = "executable"
   }
   target(cobalt_target_type, "cobalt") {
-    sources = [ "app/cobalt.cc" ]
-
     configs += [ "//build/config/gcc:rpath_for_built_shared_libraries" ]
 
     deps = [
+      ":cobalt_app",
       ":common",
       "//base",
       "//starboard:starboard_headers_only",

--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -12,44 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "base/functional/bind.h"
-#include "base/run_loop.h"
 #include "build/buildflag.h"
-#include "cobalt/app/app_event_delegate.h"
 #include "starboard/event.h"
-
-void SbEventHandle(const SbEvent* event) {
-  // This object's lifetime extends beyond the function's lifetime, until the
-  // function is called with kSbEventTypeStop at some time in the future.
-  // When the application is stopped, this object is destroyed and the pointer
-  // is reset to nullptr, to ensure that any spurious events received after the
-  // application is stopped are ignored.
-  static cobalt::AppEventDelegate* s_lifecycle_delegate =
-      new cobalt::AppEventDelegate();
-
-  if (!s_lifecycle_delegate) {
-    LOG(WARNING) << "Received spurious SbEventHandle(type = " << event->type
-                 << ") call after kSbEventTypeStop, ignoring.";
-    return;
-  }
-
-  if (event->type == kSbEventTypeStop) {
-    base::RunLoop run_loop;
-    s_lifecycle_delegate->SetQuitClosure(run_loop.QuitClosure());
-    s_lifecycle_delegate->HandleEvent(event);
-    run_loop.Run();
-
-    // Run pending tasks until idle before teardown.
-    base::RunLoop().RunUntilIdle();
-
-    // Start synchronous teardown.
-    s_lifecycle_delegate->DoTeardown();
-    delete s_lifecycle_delegate;
-    s_lifecycle_delegate = nullptr;
-  } else {
-    s_lifecycle_delegate->HandleEvent(event);
-  }
-}
 
 #if !BUILDFLAG(IS_COBALT_HERMETIC_BUILD)
 int main(int argc, char** argv) {

--- a/cobalt/app/sb_event_handle.cc
+++ b/cobalt/app/sb_event_handle.cc
@@ -18,8 +18,7 @@
 #include "cobalt/app/app_event_delegate.h"
 #include "starboard/event.h"
 
-extern "C" {
-__attribute__((weak)) void SbEventHandle(const SbEvent* event) {
+void SbEventHandle(const SbEvent* event) {
   // This object's lifetime extends beyond the function's lifetime, until the
   // function is called with kSbEventTypeStop at some time in the future.
   // When the application is stopped, this object is destroyed and the pointer
@@ -51,4 +50,3 @@ __attribute__((weak)) void SbEventHandle(const SbEvent* event) {
     s_lifecycle_delegate->HandleEvent(event);
   }
 }
-}  // extern "C"

--- a/cobalt/app/sb_event_handle.cc
+++ b/cobalt/app/sb_event_handle.cc
@@ -1,0 +1,54 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "base/functional/bind.h"
+#include "base/run_loop.h"
+#include "build/buildflag.h"
+#include "cobalt/app/app_event_delegate.h"
+#include "starboard/event.h"
+
+extern "C" {
+__attribute__((weak)) void SbEventHandle(const SbEvent* event) {
+  // This object's lifetime extends beyond the function's lifetime, until the
+  // function is called with kSbEventTypeStop at some time in the future.
+  // When the application is stopped, this object is destroyed and the pointer
+  // is reset to nullptr, to ensure that any spurious events received after the
+  // application is stopped are ignored.
+  static cobalt::AppEventDelegate* s_lifecycle_delegate =
+      new cobalt::AppEventDelegate();
+
+  if (!s_lifecycle_delegate) {
+    LOG(WARNING) << "Received spurious SbEventHandle(type = " << event->type
+                 << ") call after kSbEventTypeStop, ignoring.";
+    return;
+  }
+
+  if (event->type == kSbEventTypeStop) {
+    base::RunLoop run_loop;
+    s_lifecycle_delegate->SetQuitClosure(run_loop.QuitClosure());
+    s_lifecycle_delegate->HandleEvent(event);
+    run_loop.Run();
+
+    // Run pending tasks until idle before teardown.
+    base::RunLoop().RunUntilIdle();
+
+    // Start synchronous teardown.
+    s_lifecycle_delegate->DoTeardown();
+    delete s_lifecycle_delegate;
+    s_lifecycle_delegate = nullptr;
+  } else {
+    s_lifecycle_delegate->HandleEvent(event);
+  }
+}
+}  // extern "C"


### PR DESCRIPTION
Extract SbEventHandle into a separate static_library target so test binaries and custom entry points can link or mock SbEventHandle without pulling in the default app main().

Bug: 448156280