### PR TITLE
starboard: Move app provisioning flag to DrmSystem

### DIFF
--- a/starboard/android/shared/drm_system.cc
+++ b/starboard/android/shared/drm_system.cc
@@ -20,7 +20,6 @@
 #include <utility>
 
 #include "starboard/android/shared/drm_session_id_mapper.h"
-#include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/android/shared/media_drm_bridge.h"
 #include "starboard/common/instance_counter.h"
@@ -55,7 +54,14 @@ constexpr int kSpontaneousDrmTicketId = kSbDrmTicketInvalid;
 
 DECLARE_INSTANCE_COUNTER(AndroidDrmSystem)
 
+std::atomic_bool g_app_provisioning_enabled = false;
+
 }  // namespace
+
+// static
+void DrmSystem::SetAppProvisioningEnabled(bool enabled) {
+  g_app_provisioning_enabled.store(enabled);
+}
 
 // static
 std::unique_ptr<DrmSystem> DrmSystem::Create(std::string_view key_system,
@@ -75,8 +81,7 @@ DrmSystem::DrmSystem(PassKey<DrmSystem>,
                      Callbacks callbacks)
     : Thread("DrmSystemThread"),
       key_system_(key_system),
-      enable_app_provisioning_(
-          MediaCapabilitiesCache::GetInstance()->IsAppProvisioningEnabled()),
+      enable_app_provisioning_(g_app_provisioning_enabled.load()),
       context_(context),
       callbacks_(callbacks),
       hdcp_lost_(false),

--- a/starboard/android/shared/drm_system.h
+++ b/starboard/android/shared/drm_system.h
@@ -48,6 +48,8 @@ class DrmSystem : public ::SbDrmSystemPrivate,
     SbDrmSessionUpdatedFunc session_updated;
     SbDrmSessionKeyStatusesChangedFunc key_statuses_changed;
   };
+  static void SetAppProvisioningEnabled(bool enabled);
+
   static std::unique_ptr<DrmSystem> Create(std::string_view key_system,
                                            void* context,
                                            Callbacks callbacks);

--- a/starboard/android/shared/media_capabilities_cache.h
+++ b/starboard/android/shared/media_capabilities_cache.h
@@ -226,10 +226,6 @@ class MediaCapabilitiesCache {
   bool IsEnabled() const { return is_enabled_; }
   void SetCacheEnabled(bool enabled) { is_enabled_ = enabled; }
   void SetAv1OptEnabled(bool enabled) { is_av1_opt_enabled_ = enabled; }
-  void SetAppProvisioningEnabled(bool enabled) {
-    is_app_provisioning_enabled_ = enabled;
-  }
-  bool IsAppProvisioningEnabled() const { return is_app_provisioning_enabled_; }
   void ClearCache() { capabilities_is_dirty_ = true; }
 
  protected:
@@ -277,7 +273,6 @@ class MediaCapabilitiesCache {
 
   std::atomic_bool is_enabled_{true};
   std::atomic_bool is_av1_opt_enabled_{false};
-  std::atomic_bool is_app_provisioning_enabled_{false};
   std::atomic_bool capabilities_is_dirty_{true};
 };
 

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -325,7 +325,7 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
         experimental_features.GetBool(kMediaVideoFrameImplPool));
 
     if (experimental_features.GetBool(kMediaEnableAppProvisioning)) {
-      MediaCapabilitiesCache::GetInstance()->SetAppProvisioningEnabled(true);
+      DrmSystem::SetAppProvisioningEnabled(true);
       SB_LOG(INFO) << "`enable_app_provisioning` is set to true.";
     }
     if (experimental_features.GetBool(kMediaEnableAv1StartupOptimization)) {


### PR DESCRIPTION
Relocate the management of the app provisioning enabled flag from the
MediaCapabilitiesCache to the DrmSystem class.

Managing this flag within MediaCapabilitiesCache is unnecessary and
falls outside its primary responsibility of caching media device
capabilities. This change ensures that DRM-specific configuration is
handled by the appropriate component.
This is to address https://github.com/youtube/cobalt/pull/11022#discussion_r3548961284

Issue: 532552802