### PR TITLE
cobalt: Convert splash screen switches to features

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -152,7 +152,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
 
     boolean enableSplashScreen = metaData.getBoolean(META_DATA_ENABLE_SPLASH_SCREEN, true);
     if (!enableSplashScreen) {
-      args.add("--disable-splash-screen");
+      args.add("--enable-features=DisableSplashScreen");
     }
 
     String enableFeatures = metaData.getString(META_DATA_ENABLE_FEATURES);

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java
@@ -129,7 +129,7 @@ public class CobaltActivityTest {
     when(metaData.getString("cobalt.ENABLE_FEATURES")).thenReturn(null);
     String[] args = new String[] {"--arg1"};
     String[] result = CobaltActivity.appendArgsFromMetaData(metaData, args);
-    assertArrayEquals(new String[] {"--arg1", "--disable-splash-screen"}, result);
+    assertArrayEquals(new String[] {"--arg1", "--enable-features=DisableSplashScreen"}, result);
   }
 
   @Test

--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -63,5 +63,13 @@ BASE_FEATURE(kInMemoryUpdatesMemoryBuffer,
 const base::FeatureParam<int> kInMemoryUpdatesMemoryBufferParam{
     &kInMemoryUpdatesMemoryBuffer, "memory_buffer_bytes", 35 * 1024 * 1024};
 
+BASE_FEATURE(kDisableSplashScreen,
+             "DisableSplashScreen",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+BASE_FEATURE(kForceVideoSplashScreen,
+             "ForceVideoSplashScreen",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
 }  // namespace features
 }  // namespace cobalt

--- a/cobalt/browser/features.h
+++ b/cobalt/browser/features.h
@@ -62,6 +62,12 @@ extern const base::Feature kInMemoryUpdatesMemoryBuffer;
 // Sets the memory buffer size in bytes.
 extern const base::FeatureParam<int> kInMemoryUpdatesMemoryBufferParam;
 
+// Disables showing the splash screen.
+extern const base::Feature kDisableSplashScreen;
+
+// Forces the display of a video as the splash screen.
+extern const base::Feature kForceVideoSplashScreen;
+
 }  // namespace features
 }  // namespace cobalt
 

--- a/cobalt/shell/BUILD.gn
+++ b/cobalt/shell/BUILD.gn
@@ -200,10 +200,11 @@ static_library("cobalt_shell_switches") {
     "common/shell_switches.h",
   ]
   deps = [ "//base" ]
+  public_deps = [ "//cobalt/browser:features" ]
 }
 
 static_library("cobalt_shell_lib") {
-  deps = []
+  deps = [ "//cobalt/browser:features" ]
 
   public_deps = [
     ":cobalt_shell_lib_deps",

--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -25,6 +25,7 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/feature_list.h"
 #include "base/functional/callback_helpers.h"
 #include "base/location.h"
 #include "base/no_destructor.h"
@@ -35,6 +36,7 @@
 #include "base/strings/utf_string_conversions.h"
 #include "base/task/bind_post_task.h"
 #include "build/build_config.h"
+#include "cobalt/browser/features.h"
 #include "cobalt/browser/switches.h"
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
 #include "cobalt/shell/browser/shell_content_browser_client.h"
@@ -217,8 +219,8 @@ Shell::Shell(std::unique_ptr<WebContents> web_contents,
       splash_state_(STATE_SPLASH_SCREEN_UNINITIALIZED),
       splash_topic_(topic),
       skip_for_testing_(skip_for_testing),
-      is_video_splash_screen_(base::CommandLine::ForCurrentProcess()->HasSwitch(
-          switches::kForceVideoSplashScreen)) {
+      is_video_splash_screen_(base::FeatureList::IsEnabled(
+          cobalt::features::kForceVideoSplashScreen)) {
   if (should_set_delegate) {
     web_contents_->SetDelegate(this);
   }

--- a/cobalt/shell/common/shell_switches.cc
+++ b/cobalt/shell/common/shell_switches.cc
@@ -15,6 +15,8 @@
 #include "cobalt/shell/common/shell_switches.h"
 
 #include "base/command_line.h"
+#include "base/feature_list.h"
+#include "cobalt/browser/features.h"
 
 namespace switches {
 
@@ -28,9 +30,6 @@ const char kContentShellUserDataDir[] = "user-data-dir";
 // The directory breakpad should store minidumps in.
 const char kCrashDumpsDir[] = "crash-dumps-dir";
 
-// Disables showing splash screen.
-const char kDisableSplashScreen[] = "disable-splash-screen";
-
 // Disables the check for the system font when specified.
 const char kDisableSystemFontCheck[] = "disable-system-font-check";
 
@@ -39,9 +38,6 @@ const char kContentShellHostWindowSize[] = "content-shell-host-window-size";
 
 // Hides toolbar from content_shell's host window.
 const char kContentShellHideToolbar[] = "content-shell-hide-toolbar";
-
-// Forces the display of a video as the splash screen.
-const char kForceVideoSplashScreen[] = "force-video-splash-screen";
 
 // Enables APIs guarded with the [IsolatedContext] IDL attribute for the given
 // comma-separated list of origins.
@@ -65,9 +61,7 @@ const char kSplashScreenShutdownDelayMs[] = "splash-screen-shutdown-delay-ms";
 const char kTestRegisterStandardScheme[] = "test-register-standard-scheme";
 
 bool ShouldCreateSplashScreen() {
-  const base::CommandLine* command_line =
-      base::CommandLine::ForCurrentProcess();
-  return !command_line->HasSwitch(kDisableSplashScreen);
+  return !base::FeatureList::IsEnabled(cobalt::features::kDisableSplashScreen);
 }
 
 }  // namespace switches

--- a/cobalt/shell/common/shell_switches.h
+++ b/cobalt/shell/common/shell_switches.h
@@ -31,11 +31,9 @@ inline constexpr size_t kMaxSplashContentSize = 10 * 1024 * 1024;
 
 extern const char kContentShellUserDataDir[];
 extern const char kCrashDumpsDir[];
-extern const char kDisableSplashScreen[];
 extern const char kDisableSystemFontCheck[];
 extern const char kContentShellHostWindowSize[];
 extern const char kContentShellHideToolbar[];
-extern const char kForceVideoSplashScreen[];
 extern const char kIsolatedContextOrigins[];
 extern const char kOmitDeviceAuthenticationQueryParameters[];
 extern const char kRemoteDebuggingAddress[];
@@ -43,7 +41,7 @@ extern const char kSplashScreenShutdownDelayMs[];
 extern const char kTestRegisterStandardScheme[];
 
 // Checks if the splash screen should be created.
-// Returns false if kDisableSplashScreen is present.
+// Returns false if kDisableSplashScreen feature is enabled.
 bool ShouldCreateSplashScreen();
 
 }  // namespace switches


### PR DESCRIPTION
Migrate the splash screen configuration from legacy command-line
switches to the base::Feature system. This change replaces
--disable-splash-screen and --force-video-splash-screen with
standard Chromium feature flags.

This transition enables better alignment with Chromium's feature
infrastructure and allows for more flexible control over splash
screen behavior across different platforms.

Issue: 540461098