### PR TITLE
media: Fix member destruction order in StarboardRendererWrapper

### DIFF
--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -178,11 +178,6 @@ StarboardRendererWrapper::StarboardRendererWrapper(
     )
     :
 #endif  // BUILDFLAG(IS_ANDROID)
-      renderer_extension_receiver_(
-          this,
-          std::move(traits.renderer_extension_receiver)),
-      client_extension_remote_(std::move(traits.client_extension_remote),
-                               traits.task_runner),
       video_geometry_setter_service_(traits.video_geometry_setter_service),
       overlay_plane_id_(traits.overlay_plane_id),
       renderer_(
@@ -199,7 +194,12 @@ StarboardRendererWrapper::StarboardRendererWrapper(
           ,
           std::move(traits.android_overlay_factory_cb)
 #endif  // BUILDFLAG(IS_ANDROID)
-      ) {
+              ),
+      renderer_extension_receiver_(
+          this,
+          std::move(traits.renderer_extension_receiver)),
+      client_extension_remote_(std::move(traits.client_extension_remote),
+                               traits.task_runner) {
   DETACH_FROM_THREAD(thread_checker_);
   base::SequenceBound<StarboardGpuFactoryImpl> gpu_factory_impl(
       traits.gpu_task_runner,

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -158,20 +158,16 @@ class StarboardRendererWrapper
   void StartMediaTimePollingIfNeeded();
   void StopMediaTimePolling();
 
-  mojo::Receiver<RendererExtension> renderer_extension_receiver_;
-  mojo::Remote<ClientExtension> client_extension_remote_;
+  THREAD_CHECKER(thread_checker_);
+
   cobalt::media::VideoGeometrySetterService* video_geometry_setter_service_;
   const base::UnguessableToken overlay_plane_id_;
   mojom::CommandBufferIdPtr command_buffer_id_;
   base::SequenceBound<StarboardGpuFactory> gpu_factory_;
   scoped_refptr<base::SingleThreadTaskRunner> gpu_task_runner_;
-  // |renderer_| must be declared after |gpu_task_runner_| as |renderer|'s dtor
-  // may make use of |gpu_task_runner_|.
-  StarboardRenderer renderer_;
 
   SbDecodeTargetGraphicsContextProvider
       decode_target_graphics_context_provider_ = {};
-
   bool is_gpu_factory_initialized_ = false;
   scoped_refptr<VideoFrame> current_frame_;
   scoped_refptr<gpu::ClientSharedImage> current_shared_image_;
@@ -184,15 +180,20 @@ class StarboardRendererWrapper
 
   raw_ptr<StarboardRenderer> test_renderer_;
   raw_ptr<base::SequenceBound<StarboardGpuFactory>> test_gpu_factory_;
+  double playback_rate_ = 0.0;
 
+  // NOTE: Members are destroyed in reverse order of declaration.
+  // |renderer_| is destroyed before |gpu_task_runner_|, frames, and proxy
+  // resources, but after Mojo receivers/remotes disconnect.
+  StarboardRenderer renderer_;
+
+  mojo::Receiver<RendererExtension> renderer_extension_receiver_;
+  mojo::Remote<ClientExtension> client_extension_remote_;
   mojo::Remote<cobalt::media::mojom::VideoGeometryChangeSubscriber>
       video_geometry_change_subcriber_remote_;
   mojo::Receiver<cobalt::media::mojom::VideoGeometryChangeClient>
       video_geometry_change_client_receiver_{this};
-
-  double playback_rate_ = 0.0;
   base::RepeatingTimer time_update_timer_;
-  THREAD_CHECKER(thread_checker_);
 
   // NOTE: Do not add member variables after weak_factory_
   // It should be the first one destroyed among all members.


### PR DESCRIPTION
Reorder member variables in StarboardRendererWrapper to ensure a safe
destruction sequence. C++ destroys class members in the reverse order
of their declaration. Moving the renderer declaration ensures it is
destroyed before the GPU task runner and media resources it depends
on, but after Mojo interfaces disconnect to prevent incoming calls
during teardown.

Issue: 540418402