### PR TITLE
Fix build failure in KeepAliveURLLoaderService::FactoryContext on staging

### DIFF
--- a/content/browser/loader/keep_alive_url_loader_service.cc
+++ b/content/browser/loader/keep_alive_url_loader_service.cc
@@ -48,10 +48,11 @@ KeepAliveURLLoaderService::FactoryContext::FactoryContext(
     : factory(other->factory),
       weak_document_ptr(other->weak_document_ptr),
       ukm_source_id(other->ukm_source_id),
-      policy_container_host(other->policy_container_host),
+      policy_container_host(other->policy_container_host)
 #if BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
-      attribution_context(other->attribution_context) {}
+    , attribution_context(other->attribution_context)
 #endif  // BUILDFLAG(ENABLE_PRIVACY_SANDBOX_APIS) && CHROMIUM_MILESTONE_LE_138
+{}
 
 KeepAliveURLLoaderService::FactoryContext::~FactoryContext() = default;
 


### PR DESCRIPTION
Fixes C++ compilation syntax error in KeepAliveURLLoaderService::FactoryContext constructor when ENABLE_PRIVACY_SANDBOX_APIS is disabled.