### PR TITLE
ci: Checkout JUnit dependencies before downloading artifacts in on_host_tests

### DIFF
--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -27,10 +27,6 @@ runs:
       uses: ./.github/actions/depot_tools
       with:
         run_sync: 'false'
-    - name: Download Artifacts
-      uses: actions/download-artifact@v5
-      with:
-        name: ${{ inputs.test_artifacts_key }}
     - name: Checkout JUnit Dependencies
       if: inputs.test_type == 'junit'
       shell: bash
@@ -38,6 +34,10 @@ runs:
         git config --global --add safe.directory "${GITHUB_WORKSPACE}"
         git sparse-checkout add --skip-checks testing build third_party/catapult third_party/logdog
         git submodule update --init third_party/catapult
+    - name: Download Artifacts
+      uses: actions/download-artifact@v5
+      with:
+        name: ${{ inputs.test_artifacts_key }}
     - name: Extract Artifacts
       shell: bash
       run: |


### PR DESCRIPTION
Reorder Checkout JUnit Dependencies step to run prior to Download Artifacts in on_host_tests action. This prevents git sparse-checkout add from executing an index refresh after artifact download, which can purge untracked test_artifacts.tar.zstd before extraction.

Example failure: https://github.com/youtube/cobalt/actions/runs/30506594812/job/90762388801

Bug: 431780245