### PR TITLE
starboard: Replace URL player config macro with tvOS buildflag

### DIFF
--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -168,7 +168,7 @@ GetStarboardExtensionExperimentalFeatures(
 SB_ONCE_INITIALIZE_FUNCTION(StatisticsWrapper, StatisticsWrapper::GetInstance);
 #endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_STARTUP_LATENCY_TRACKING)
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
 SbPlayerBridge::SbPlayerBridge(
     SbPlayerInterface* interface,
     const scoped_refptr<base::SequencedTaskRunner>& task_runner,
@@ -214,7 +214,7 @@ SbPlayerBridge::SbPlayerBridge(
                                        weak_factory_.GetWeakPtr()));
 #endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_SUSPEND_RESUME)
 }
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 SbPlayerBridge::SbPlayerBridge(
     SbPlayerInterface* interface,
@@ -266,10 +266,10 @@ SbPlayerBridge::SbPlayerBridge(
       ,
       surface_view_(surface_view)
 #endif  // BUILDFLAG(IS_ANDROID)
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
       ,
       is_url_based_(false)
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 #if BUILDFLAG(COBALT_MEDIA_ENABLE_CVAL)
       ,
       cval_stats_(&interface->cval_stats_),
@@ -373,9 +373,9 @@ void SbPlayerBridge::WriteBuffers(
     DemuxerStream::Type type,
     const std::vector<scoped_refptr<DecoderBuffer>>& buffers) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 #if BUILDFLAG(COBALT_MEDIA_ENABLE_SUSPEND_RESUME)
   if (allow_resume_after_suspend_) {
@@ -512,7 +512,7 @@ SbPlayerBridge::GetAudioConfigurations() {
   return configurations;
 }
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
 void SbPlayerBridge::GetUrlPlayerBufferedTimeRanges(
     TimeDelta* buffer_start_time,
     TimeDelta* buffer_length_time) {
@@ -600,7 +600,7 @@ void SbPlayerBridge::SetDrmSystem(SbDrmSystem drm_system) {
   drm_system_ = drm_system;
   sbplayer_interface_->SetUrlPlayerDrmSystem(player_, drm_system);
 }
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 void SbPlayerBridge::Suspend() {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
@@ -646,7 +646,7 @@ void SbPlayerBridge::Resume(SbWindow window) {
   decoder_buffer_cache_.StartResuming();
 #endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_SUSPEND_RESUME)
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   if (is_url_based_) {
     CreateUrlPlayer(url_);
     if (SbDrmSystemIsValid(drm_system_)) {
@@ -655,9 +655,9 @@ void SbPlayerBridge::Resume(SbWindow window) {
   } else {
     CreatePlayer();
   }
-#else   // SB_HAS(PLAYER_WITH_URL)
+#else   // BUILDFLAG(IS_IOS_TVOS)
   CreatePlayer();
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   if (SbPlayerIsValid(player_)) {
     state_ = kResuming;
@@ -665,7 +665,7 @@ void SbPlayerBridge::Resume(SbWindow window) {
   }
 }
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
 // static
 void SbPlayerBridge::EncryptedMediaInitDataEncounteredCB(
     SbPlayer player,
@@ -715,7 +715,7 @@ void SbPlayerBridge::CreateUrlPlayer(const std::string& url) {
 
   UpdateBounds();
 }
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 void SbPlayerBridge::CreatePlayer() {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
@@ -842,9 +842,9 @@ void SbPlayerBridge::CreatePlayer() {
 void SbPlayerBridge::WriteNextBuffersFromCache(DemuxerStream::Type type,
                                                int max_buffers_per_write) {
   DCHECK(state_ != kSuspended);
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   DCHECK(SbPlayerIsValid(player_));
 
@@ -875,9 +875,9 @@ void SbPlayerBridge::WriteBuffersInternal(
     const SbMediaAudioStreamInfo* audio_stream_info,
     const SbMediaVideoStreamInfo* video_stream_info) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   auto sample_type = DemuxerStreamTypeToSbMediaType(type);
   if (buffers.size() == 1 && buffers[0]->end_of_stream()) {
@@ -1112,9 +1112,9 @@ void SbPlayerBridge::OnDecoderStatus(SbPlayer player,
                                      SbMediaType type,
                                      SbPlayerDecoderState state,
                                      int ticket) {
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
   if (player_ != player || ticket != ticket_) {
@@ -1230,9 +1230,9 @@ void SbPlayerBridge::OnPlayerError(SbPlayer player,
 }
 
 void SbPlayerBridge::OnDeallocateSample(const void* sample_buffer) {
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   DCHECK(!is_url_based_);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
 
   if (enable_batched_buffer_deallocation_) {
@@ -1447,7 +1447,7 @@ void SbPlayerBridge::DeallocateSampleCB(SbPlayer player,
           sample_buffer));
 }
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
 SbPlayerOutputMode SbPlayerBridge::ComputeSbUrlPlayerOutputMode(
     SbPlayerOutputMode default_output_mode) {
   // Try to choose the output mode according to the passed in value of
@@ -1468,7 +1468,7 @@ SbPlayerOutputMode SbPlayerBridge::ComputeSbUrlPlayerOutputMode(
 
   return output_mode;
 }
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 SbPlayerOutputMode SbPlayerBridge::ComputeSbPlayerOutputMode(
     SbPlayerOutputMode default_output_mode) const {

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -29,6 +29,7 @@
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/time.h"
+#include "build/build_config.h"
 #include "media/base/audio_decoder_config.h"
 #include "media/base/decoder_buffer.h"
 #include "media/base/demuxer_stream.h"
@@ -77,7 +78,7 @@ class SbPlayerBridge {
   using GetDecodeTargetGraphicsContextProviderFunc =
       base::RepeatingCallback<SbDecodeTargetGraphicsContextProvider*()>;
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   using OnEncryptedMediaInitDataEncounteredCB = base::RepeatingCallback<
       void(const char*, const unsigned char*, unsigned)>;
   // Create an SbPlayerBridge with url-based player.
@@ -95,7 +96,7 @@ class SbPlayerBridge {
                  std::string pipeline_identifier
 #endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_CVAL)
   );
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
   using ExperimentalFeatures = StarboardRendererConfig::ExperimentalFeatures;
   // Create a SbPlayerBridge with normal player
   SbPlayerBridge(SbPlayerInterface* interface,
@@ -146,14 +147,14 @@ class SbPlayerBridge {
   void GetInfo(PlayerInfo* out_info);
   std::vector<SbMediaAudioConfiguration> GetAudioConfigurations();
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   void GetUrlPlayerBufferedTimeRanges(base::TimeDelta* buffer_start_time,
                                       base::TimeDelta* buffer_length_time);
   void GetVideoResolution(int* frame_width, int* frame_height);
   base::TimeDelta GetDuration();
   base::TimeDelta GetStartDate();
   void SetDrmSystem(SbDrmSystem drm_system);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   void Suspend();
   // TODO: This is temporary for supporting background media playback.
@@ -211,7 +212,7 @@ class SbPlayerBridge {
       absl::flat_hash_map<const DecoderBuffer::Allocator::Handle,
                           DecodingBuffer>;
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   OnEncryptedMediaInitDataEncounteredCB
       on_encrypted_media_init_data_encountered_cb_;
 
@@ -223,7 +224,7 @@ class SbPlayerBridge {
       unsigned int init_data_length);
 
   void CreateUrlPlayer(const std::string& url);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
   void CreatePlayer();
 
 #if BUILDFLAG(COBALT_MEDIA_ENABLE_SUSPEND_RESUME)
@@ -285,10 +286,10 @@ class SbPlayerBridge {
                                  void* context,
                                  const void* sample_buffer);
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   SbPlayerOutputMode ComputeSbUrlPlayerOutputMode(
       SbPlayerOutputMode default_output_mode);
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
   // Returns the output mode that should be used for a video with the given
   // specifications.
   SbPlayerOutputMode ComputeSbPlayerOutputMode(
@@ -298,9 +299,9 @@ class SbPlayerBridge {
   void SendColorSpaceHistogram() const;
 
 // The following variables are initialized in the ctor and never changed.
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   std::string url_;
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
   SbPlayerInterface* sbplayer_interface_;
   const scoped_refptr<base::SequencedTaskRunner> task_runner_;
   const GetDecodeTargetGraphicsContextProviderFunc
@@ -384,9 +385,9 @@ class SbPlayerBridge {
   base::Time first_video_sample_time_{};
   base::Time sb_player_state_presenting_time_{};
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   const bool is_url_based_;
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   // Used for Gathered Sample Write.
   bool pending_audio_eos_buffer_ = false;

--- a/media/starboard/sbplayer_interface.cc
+++ b/media/starboard/sbplayer_interface.cc
@@ -154,7 +154,7 @@ SbDecodeTarget DefaultSbPlayerInterface::GetCurrentFrame(SbPlayer player) {
   return current_frame;
 }
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
 SbPlayer DefaultSbPlayerInterface::CreateUrlPlayer(
     const char* url,
     SbWindow window,
@@ -188,7 +188,7 @@ void DefaultSbPlayerInterface::GetUrlPlayerExtraInfo(
     SbUrlPlayerExtraInfo* out_url_player_info) {
   SbUrlPlayerGetExtraInfo(player, out_url_player_info);
 }
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 bool DefaultSbPlayerInterface::GetAudioConfiguration(
     SbPlayer player,

--- a/media/starboard/sbplayer_interface.h
+++ b/media/starboard/sbplayer_interface.h
@@ -16,6 +16,7 @@
 #define MEDIA_STARBOARD_SBPLAYER_INTERFACE_H_
 
 #include "base/time/time.h"
+#include "build/build_config.h"
 #include "media/starboard/buildflags.h"
 #include "starboard/player.h"
 
@@ -26,9 +27,9 @@
 #include "cobalt/media/base/metrics_provider.h"
 #endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_UMA_METRICS)
 
-#if SB_HAS(PLAYER_WITH_URL)
-#include SB_URL_PLAYER_INCLUDE_PATH
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
+#include "starboard/tvos/shared/media/url_player.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 namespace media {
 
@@ -73,7 +74,7 @@ class SbPlayerInterface {
 
   virtual SbDecodeTarget GetCurrentFrame(SbPlayer player) = 0;
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   virtual SbPlayer CreateUrlPlayer(const char* url,
                                    SbWindow window,
                                    SbPlayerStatusFunc player_status_func,
@@ -88,7 +89,7 @@ class SbPlayerInterface {
   virtual void GetUrlPlayerExtraInfo(
       SbPlayer player,
       SbUrlPlayerExtraInfo* out_url_player_info) = 0;
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   virtual bool GetAudioConfiguration(
       SbPlayer player,
@@ -171,7 +172,7 @@ class DefaultSbPlayerInterface final : public SbPlayerInterface {
   void GetInfo(SbPlayer player, SbPlayerInfo* out_player_info) override;
   SbDecodeTarget GetCurrentFrame(SbPlayer player) override;
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   SbPlayer CreateUrlPlayer(const char* url,
                            SbWindow window,
                            SbPlayerStatusFunc player_status_func,
@@ -184,7 +185,7 @@ class DefaultSbPlayerInterface final : public SbPlayerInterface {
   void GetUrlPlayerExtraInfo(
       SbPlayer player,
       SbUrlPlayerExtraInfo* out_url_player_info) override;
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   bool GetAudioConfiguration(
       SbPlayer player,

--- a/media/starboard/starboard_renderer_unittest.cc
+++ b/media/starboard/starboard_renderer_unittest.cc
@@ -24,6 +24,7 @@
 #include "base/test/gmock_callback_support.h"
 #include "base/test/mock_callback.h"
 #include "base/test/task_environment.h"
+#include "build/build_config.h"
 #include "media/base/demuxer_stream.h"
 #include "media/base/media_util.h"
 #include "media/base/mock_filters.h"
@@ -93,7 +94,7 @@ class MockSbPlayerInterface : public SbPlayerInterface {
     return kSbDecodeTargetInvalid;
   }
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
   MOCK_METHOD6(CreateUrlPlayer,
                SbPlayer(const char*,
                         SbWindow,
@@ -108,7 +109,7 @@ class MockSbPlayerInterface : public SbPlayerInterface {
       SbPlayerOutputMode output_mode) override {
     return true;
   }
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
   bool GetAudioConfiguration(
       SbPlayer player,

--- a/starboard/nplb/url_player_create_test.cc
+++ b/starboard/nplb/url_player_create_test.cc
@@ -14,12 +14,13 @@
 
 #include <vector>
 
+#include "build/build_config.h"
 #include "starboard/decode_target.h"
 #include "starboard/player.h"
 
-#if SB_HAS(PLAYER_WITH_URL)
-#include "starboard/shared/uikit/url_player.h"
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
+#include "starboard/tvos/shared/media/url_player.h"
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 #include "starboard/window.h"
 #include "testing/gtest/include/gtest/gtest.h"
@@ -27,7 +28,7 @@
 namespace nplb {
 namespace {
 
-#if SB_HAS(PLAYER_WITH_URL)
+#if BUILDFLAG(IS_IOS_TVOS)
 
 const char kPlayerUrl[] = "about:blank";
 
@@ -159,7 +160,7 @@ TEST(SbPlayerUrlTest, MultiPlayer) {
   SbWindowDestroy(window);
 }
 
-#endif  // SB_HAS(PLAYER_WITH_URL)
+#endif  // BUILDFLAG(IS_IOS_TVOS)
 
 }  // namespace
 }  // namespace nplb

--- a/starboard/tvos/shared/configuration_public.h
+++ b/starboard/tvos/shared/configuration_public.h
@@ -32,12 +32,4 @@
 #define SB_IS_WCHAR_T_UTF16 1
 #endif
 
-// --- URLPlayer Configuration ------------------------------------------------
-
-// Enable URL-based player support (AVPlayer for HLS playback).
-#define SB_HAS_PLAYER_WITH_URL 1
-
-// Path to the URL player header, used by media/starboard/sbplayer_interface.h.
-#define SB_URL_PLAYER_INCLUDE_PATH "starboard/tvos/shared/media/url_player.h"
-
 #endif  // STARBOARD_TVOS_SHARED_CONFIGURATION_PUBLIC_H_


### PR DESCRIPTION
SB_HAS_PLAYER_WITH_URL is legacy Cobalt configuration that was only
defined for tvOS in configuration_public.h. In the Chromium
architecture, BUILDFLAG(IS_IOS_TVOS) is the standard way to gate
tvOS-specific code.

Replace all SB_HAS(PLAYER_WITH_URL) guards with BUILDFLAG(IS_IOS_TVOS)
across sbplayer_bridge, sbplayer_interface, starboard_renderer, and
url_player_create_test. Replace the indirect SB_URL_PLAYER_INCLUDE_PATH
include with the direct header path. Remove both definitions from
starboard/tvos/shared/configuration_public.h.

Required-For: #10698

Bug: 512045535