### PR TITLE
android: Remove unused GetVideoWindowSize

### DIFF
--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -186,17 +186,6 @@ void VideoSurfaceHolder::ReleaseVideoSurface() {
   }
 }
 
-bool VideoSurfaceHolder::GetVideoWindowSize(int* width, int* height) {
-  std::lock_guard lock(*GetViewSurfaceMutex());
-  if (g_native_video_window == NULL) {
-    return false;
-  } else {
-    *width = ANativeWindow_getWidth(g_native_video_window);
-    *height = ANativeWindow_getHeight(g_native_video_window);
-    return true;
-  }
-}
-
 void VideoSurfaceHolder::CleanUpVideoWindow(
     bool force_clear,
     SbDecodeTargetGraphicsContextProvider* gpu_provider) {

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -44,10 +44,6 @@ class VideoSurfaceHolder {
   // Release the surface to make the surface available for other holder.
   void ReleaseVideoSurface();
 
-  // Get the native window size. Return false if don't have available native
-  // window.
-  bool GetVideoWindowSize(int* width, int* height);
-
   // Cleans up the video surface. If |force_clear| is enabled, we will only
   // clear the video window, and post the clearing task to |gpu_provider|.
   // If |force_clear| is false, we will forcefully destroy the surface view,


### PR DESCRIPTION
The VideoSurfaceHolder::GetVideoWindowSize function is no longer used in
the codebase. This change removes its declaration and definition to
simplify further refactoring.

Bug: 538270075