### PR TITLE
starboard: Use common AlignUp implementation from pointer_arithmetic.h

### DIFF
--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -31,6 +31,7 @@
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/common/media.h"
+#include "starboard/common/pointer_arithmetic.h"
 #include "starboard/common/ref_counted.h"
 #include "starboard/common/string.h"
 #include "starboard/media.h"

--- a/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
+++ b/starboard/shared/ffmpeg/ffmpeg_video_decoder_impl.cc
@@ -23,6 +23,7 @@
 #include <string>
 
 #include "starboard/common/check_op.h"
+#include "starboard/common/pointer_arithmetic.h"
 #include "starboard/common/string.h"
 #include "starboard/linux/shared/decode_target_internal.h"
 
@@ -35,11 +36,6 @@ namespace {
 // http://ffmpeg.org/doxygen/trunk/structAVFrame.html#aa52bfc6605f6a3059a0c3226cc0f6567
 // that the alignment on most modern desktop systems are 16 or 32.
 static const int kAlignment = 32;
-
-size_t AlignUp(size_t size, int alignment) {
-  SB_DCHECK_EQ((alignment & (alignment - 1)), 0);
-  return (size + alignment - 1) & ~(alignment - 1);
-}
 
 size_t GetYV12SizeInBytes(int32_t width, int32_t height) {
   return width * height * 3 / 2;

--- a/starboard/shared/starboard/media/media_util.cc
+++ b/starboard/shared/starboard/media/media_util.cc
@@ -382,8 +382,4 @@ int64_t AudioFramesToDuration(int frames, int samples_per_second) {
   return frames * 1'000'000LL / std::max(samples_per_second, 1);
 }
 
-int AlignUp(int value, int alignment) {
-  return (value + alignment - 1) / alignment * alignment;
-}
-
 }  // namespace starboard

--- a/starboard/shared/starboard/media/media_util.h
+++ b/starboard/shared/starboard/media/media_util.h
@@ -138,8 +138,6 @@ bool IsAudioSampleInfoSubstantiallyDifferent(const AudioStreamInfo& left,
 int AudioDurationToFrames(int64_t duration, int samples_per_second);
 int64_t AudioFramesToDuration(int frames, int samples_per_second);
 
-int AlignUp(int value, int alignment);
-
 }  // namespace starboard
 
 #endif  // STARBOARD_SHARED_STARBOARD_MEDIA_MEDIA_UTIL_H_

--- a/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
+++ b/starboard/shared/starboard/player/filter/audio_renderer_sink_impl.cc
@@ -19,6 +19,7 @@
 
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "starboard/common/pointer_arithmetic.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/shared/starboard/media/media_util.h"
 #include "starboard/shared/starboard/thread_checker.h"


### PR DESCRIPTION
Refactor video decoder, player components, and audio renderer sink to use the central starboard::AlignUp helper from pointer_arithmetic.h instead of duplicate local definitions.

Issue: 484299147