### PR TITLE
feat: Enable system libcurl for crashpad in cobalt

### DIFF
--- a/starboard/build/config/base_configuration.gni
+++ b/starboard/build/config/base_configuration.gni
@@ -140,4 +140,8 @@ declare_args() {
   # TODO: b/406511608 - remove once crashpad builds and behaves as expected on
   # all Early Access Program platforms.
   use_crashpad = use_evergreen
+
+  # Platforms can set this to true to use system libcurl for Crashpad HTTP
+  # crash report uploads. Defaults to false.
+  use_system_libcurl_for_crashpad = false
 }

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/platform_configuration/configuration.gni
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/platform_configuration/configuration.gni
@@ -58,3 +58,5 @@ size_config_path =
 if (is_starboard) {
   sb_evergreen_compatible_use_libunwind = true
 }
+
+use_system_libcurl_for_crashpad = true

--- a/starboard/linux/shared/platform_configuration/configuration.gni
+++ b/starboard/linux/shared/platform_configuration/configuration.gni
@@ -35,3 +35,4 @@ platform_tests_path =
     "//starboard/linux/shared:starboard_platform_tests($starboard_toolchain)"
 
 sb_enable_cast_codec_tests = true
+use_system_libcurl_for_crashpad = true

--- a/third_party/crashpad/crashpad/util/BUILD.gn
+++ b/third_party/crashpad/crashpad/util/BUILD.gn
@@ -702,6 +702,14 @@ crashpad_static_library("net") {
     }
   } else if (crashpad_http_transport_impl == "libcurl") {
     sources += [ "net/http_transport_libcurl.cc" ]
+    if (use_system_libcurl_for_crashpad) {
+      # TODO: b/446904324 - Cobalt: Consider an alternative rather than relying
+      # on these on old libcurl headers from the deprecated breakpad library.
+      include_dirs = [
+        "//third_party/breakpad/breakpad/src",
+        "//third_party/breakpad/breakpad/src/third_party",
+      ]
+    }
   }
 }
 

--- a/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
+++ b/third_party/crashpad/crashpad/util/net/http_transport_libcurl.cc
@@ -34,6 +34,14 @@
 #include "util/net/http_body.h"
 #include "util/numeric/safe_assignment.h"
 
+#if BUILDFLAG(IS_NATIVE_TOOLCHAIN)
+// Breakpad's bundled curl.h predates libcurl 7.21.6, which introduced
+// CURLOPT_ACCEPT_ENCODING as an alias for CURLOPT_ENCODING.
+#ifndef CURLOPT_ACCEPT_ENCODING
+#define CURLOPT_ACCEPT_ENCODING CURLOPT_ENCODING
+#endif
+#endif
+
 namespace crashpad {
 
 namespace {
@@ -345,6 +353,10 @@ HTTPTransportLibcurl::HTTPTransportLibcurl() : HTTPTransport() {}
 HTTPTransportLibcurl::~HTTPTransportLibcurl() {}
 
 bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
+#if BUILDFLAG(IS_NATIVE_TOOLCHAIN)
+  LOG(INFO) << "HTTPTransportLibcurl::ExecuteSynchronously executing crash report upload via libcurl";
+#endif
+
   DCHECK(body_stream());
 
   response_body->clear();
@@ -394,10 +406,19 @@ bool HTTPTransportLibcurl::ExecuteSynchronously(std::string* response_body) {
 
   TRY_CURL_EASY_SETOPT(curl.get(), CURLOPT_URL, url().c_str());
 
+#if BUILDFLAG(IS_NATIVE_TOOLCHAIN)
+  if (!root_ca_certificates_directory_path().empty()) {
+    TRY_CURL_EASY_SETOPT(
+        curl.get(),
+        CURLOPT_CAPATH,
+        root_ca_certificates_directory_path().value().c_str());
+  }
+#else   // BUILDFLAG(IS_NATIVE_TOOLCHAIN)
   if (!root_ca_certificate_path().empty()) {
     TRY_CURL_EASY_SETOPT(
         curl.get(), CURLOPT_CAINFO, root_ca_certificate_path().value().c_str());
   }
+#endif  // BUILDFLAG(IS_NATIVE_TOOLCHAIN)
 
   constexpr int kMillisecondsPerSecond = 1E3;
   TRY_CURL_EASY_SETOPT(curl.get(),

--- a/third_party/crashpad/crashpad/util/net/tls.gni
+++ b/third_party/crashpad/crashpad/util/net/tls.gni
@@ -19,14 +19,13 @@ if (is_cobalt) {
 }
 
 declare_args() {
-  # Cobalt comment: we're still exploring, in b/446904324, whether we can use
-  # libcurl. For now will keep the c25 status quo and use raw sockets with
-  # BoringSSL as the backend.
-  if (crashpad_is_fuchsia || crashpad_is_android ||
-      (is_cobalt && is_native_toolchain)) {
+  if (crashpad_is_fuchsia || crashpad_is_android) {
     crashpad_http_transport_impl = "socket"
-  } else if (crashpad_is_linux) {
+  } else if (use_system_libcurl_for_crashpad ||
+             (crashpad_is_linux && !is_cobalt)) {
     crashpad_http_transport_impl = "libcurl"
+  } else if (crashpad_is_linux || is_cobalt) {
+    crashpad_http_transport_impl = "socket"
   } else {
     crashpad_http_transport_impl = ""
   }


### PR DESCRIPTION
This is a draft for testing and would likely be changed in a few ways if we ultimately decide to move forward with it (for example, to use libcurl headers from somewhere other than breakpad).

This change allows Evergreen platforms to opt in, at build time, to use system libcurl instead of raw sockets (with BoringSSL backend) for Crashpad uploads. libcurl should be more resilient since it implements things like the "Happy Eyeballs" algorithm. This change also opts in our linux and rdk reference platforms.

Issue: 446904324