### PR TITLE
media: Refine configurable decommit strategies

### DIFF
--- a/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
@@ -45,14 +45,20 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
   // these are aggressively decommitted (e.g. using MADV_DONTNEED).
   // |aggressive_decommit_on_suspend|: Whether to aggressively decommit all idle
   // blocks when app is suspended.
+  // |allocate_with_page_alignment|: Whether fallback allocations align to page
+  // boundary. |memset_on_reclaim|: Whether to zero out fallback blocks on
+  // reclamation. |mark_as_cold_on_reclaim|: Whether to advise MADV_COLD on
+  // reclamation.
   BidirectionalFitDecoderBufferAllocatorStrategy(
       size_t initial_capacity,
       size_t allocation_increment,
       bool enable_decommit_on_idle,
       size_t retain_blocks,
       size_t conservative_decommit_blocks,
-      bool aggressive_decommit_on_suspend = false,
-      bool allocate_with_page_alignment = true)
+      bool aggressive_decommit_on_suspend,
+      bool allocate_with_page_alignment,
+      bool memset_on_reclaim,
+      bool mark_as_cold_on_reclaim)
       : fallback_allocator_(enable_decommit_on_idle,
                             allocate_with_page_alignment),
         bidirectional_fit_allocator_(&fallback_allocator_,
@@ -62,7 +68,9 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
                                      enable_decommit_on_idle,
                                      retain_blocks,
                                      conservative_decommit_blocks,
-                                     aggressive_decommit_on_suspend) {}
+                                     aggressive_decommit_on_suspend,
+                                     memset_on_reclaim,
+                                     mark_as_cold_on_reclaim) {}
 
   void* Allocate(DemuxerStream::Type type, size_t size) override {
     return bidirectional_fit_allocator_.Allocate(size);
@@ -84,6 +92,10 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
 
   void DecommitAllDecommitableBlocks() override {
     bidirectional_fit_allocator_.DecommitAllDecommitableBlocks();
+  }
+
+  void TryToDecommitOneBlock(int cadence) override {
+    bidirectional_fit_allocator_.TryToDecommitOneBlock(cadence);
   }
 
  private:

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -14,6 +14,8 @@
 
 #include "media/starboard/decoder_buffer_allocator.h"
 
+#include <sys/mman.h>  // For MADV_COLD
+
 #include <algorithm>
 
 #include "base/feature_list.h"
@@ -37,6 +39,8 @@
 namespace media {
 
 namespace {
+
+constexpr base::TimeDelta kDefaultPeriodicDecommitInterval = base::Seconds(5);
 
 // The current default AllocatorStrategy is EmbeddedMetadataReuseAllocatorBase.
 // To see more context as to why this is the case, see b/487332929.
@@ -88,6 +92,8 @@ DecoderBufferAllocator::DecoderBufferAllocator(
 }
 
 DecoderBufferAllocator::~DecoderBufferAllocator() {
+  StopPeriodicDecommitLoop();
+
   base::AutoLock scoped_lock(mutex_);
 
   if (strategy_) {
@@ -120,7 +126,7 @@ void DecoderBufferAllocator::ReleaseIdleMemory() {
 }
 
 void DecoderBufferAllocator::DecommitAllDecommitableBlocks() {
-  if (!decommit_on_suspend_enabled_.load(std::memory_order_relaxed)) {
+  if (!decommit_on_suspend_enabled_.load(std::memory_order_acquire)) {
     return;
   }
   base::AutoLock scoped_lock(mutex_);
@@ -253,7 +259,10 @@ void DecoderBufferAllocator::UpdateAllocatorStrategy(
 base::expected<void, std::string> DecoderBufferAllocator::SetSetting(
     const std::string& name,
     int value) {
-  if (name == "DecoderBuffer.EnableConfigurableDecommitStrategy") {
+  // Temporarily accept both setting names to support backward-compatible
+  // experiment rollouts before transitioning to the V2 format.
+  if (name == "DecoderBuffer.EnableConfigurableDecommitStrategy" ||
+      name == "DecoderBuffer.EnableConfigurableDecommitStrategyV2") {
     if (value <= 0) {
       // Explicitly allow non-positive values as placebo.
       return base::ok();
@@ -268,12 +277,21 @@ base::expected<void, std::string> DecoderBufferAllocator::SetSetting(
     // ideal, but it simplifies experiment setup in the current framework.
     //
     // - flags (8 bits):
-    //   - aggressive_decommit_on_suspend (bit 24): When set (LSB is non-zero),
-    //     enables aggressive MADV_DONTNEED decommit on all idle blocks when
-    //     app suspends/hides.
-    //   - allocate_with_page_alignment (bit 25): When set (second bit is
+    //   - enable_decommit_on_suspend (bit 24): When set (bit 24 is non-zero),
+    //     enables decommit on all idle blocks when app suspends/hides.
+    //   - allocate_with_page_alignment (bit 25): When set (bit 25 is
     //     non-zero), forces new OS block allocations to be page-aligned and
     //     rounded up to page sizes. Default is true.
+    //   - aggressive_decommit_on_suspend (bit 26): When set (bit 26 is
+    //     non-zero), aggressively decommits all idle blocks (ignoring retain
+    //     window) on suspend.
+    //   - memset_on_reclaim (bit 27): When set (bit 27 is non-zero),
+    //     memsets reclaimed blocks to 0.
+    //   - mark_as_cold_on_reclaim (bit 28): When set (bit 28 is non-zero),
+    //     uses MADV_COLD on reclaimed blocks.
+    //   - periodic_decommit (bit 29): When set (bit 29 is non-zero),
+    //     periodically decommits idle blocks in the background via
+    //     base::ThreadPool.
     // - block_size (8 bits): Specifies both the initial pool capacity and the
     //   fallback allocation increment.
     // - retain_blocks (8 bits): Specifies the first `retain_blocks` blocks of
@@ -297,15 +315,24 @@ base::expected<void, std::string> DecoderBufferAllocator::SetSetting(
     // Note: A value of 0 or less will not enable this feature (handled as a
     // placebo).
     uint32_t unsigned_value = static_cast<uint32_t>(value);
-    bool aggressive_decommit_on_suspend = ((unsigned_value >> 24) & 0x01) != 0;
-    bool allocate_with_page_alignment = ((unsigned_value >> 24) & 0x02) != 0;
+    uint32_t flags = unsigned_value >> 24;
+
+    bool enable_decommit_on_suspend = (flags & 0x01) != 0;
+    bool allocate_with_page_alignment = (flags & 0x02) != 0;
+    bool aggressive_decommit_on_suspend = (flags & 0x04) != 0;
+    bool memset_on_reclaim = (flags & 0x08) != 0;
+    bool mark_as_cold_on_reclaim = (flags & 0x10) != 0;
+    bool periodic_decommit = (flags & 0x20) != 0;
+
     int block_size_mb = (unsigned_value >> 16) & 0xFF;
     int retain_blocks = (unsigned_value >> 8) & 0xFF;
     int conservative_decommit_blocks = unsigned_value & 0xFF;
+
     EnableConfigurableDecommitStrategy(
         block_size_mb * 1024 * 1024, retain_blocks,
-        conservative_decommit_blocks, aggressive_decommit_on_suspend,
-        allocate_with_page_alignment);
+        conservative_decommit_blocks, enable_decommit_on_suspend,
+        allocate_with_page_alignment, aggressive_decommit_on_suspend,
+        memset_on_reclaim, mark_as_cold_on_reclaim, periodic_decommit);
     return base::ok();
   }
   if (name == "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy") {
@@ -320,22 +347,56 @@ base::expected<void, std::string> DecoderBufferAllocator::SetSetting(
 }
 
 // static
+void DecoderBufferAllocator::OnPeriodicDecommitTask(
+    scoped_refptr<PeriodicDecommitState> state) {
+  state->RunIfValid([](DecoderBufferAllocator* allocator) {
+    base::AutoLock scoped_lock(allocator->mutex_);
+    if (allocator->strategy_) {
+      allocator->strategy_->TryToDecommitOneBlock(/*cadence=*/1);
+    }
+    allocator->SchedulePeriodicDecommitTask_Locked();
+  });
+}
+
+// static
 void DecoderBufferAllocator::EnableConfigurableDecommitStrategy(
     int block_size,
     int retain_blocks,
     int conservative_decommit_blocks,
+    bool enable_decommit_on_suspend,
+    bool allocate_with_page_alignment,
     bool aggressive_decommit_on_suspend,
-    bool allocate_with_page_alignment) {
+    bool memset_on_reclaim,
+    bool mark_as_cold_on_reclaim,
+    bool periodic_decommit) {
   auto* allocator = Get();
   CHECK(allocator);
+  // Checking MADV_COLD support directly here simplifies experimental setup
+  // without adding extra platform abstraction layers.
+#if !defined(MADV_COLD)
+  if (mark_as_cold_on_reclaim) {
+    LOG(INFO) << "mark_as_cold_on_reclaim is set, but MADV_COLD is not "
+                 "defined. Resetting mark_as_cold_on_reclaim to false.";
+    mark_as_cold_on_reclaim = false;
+  }
+#endif  // !defined(MADV_COLD)
   if (aggressive_decommit_on_suspend) {
+    enable_decommit_on_suspend = true;
+  }
+  if (enable_decommit_on_suspend) {
     // This optimization is enable only, and isn't expected to be disabled.
     allocator->decommit_on_suspend_enabled_.store(true,
-                                                  std::memory_order_relaxed);
+                                                  std::memory_order_release);
+  }
+  if (periodic_decommit) {
+    // This feature is enable only, and isn't expected to be disabled.
+    allocator->EnablePeriodicDecommitLoop();
   }
   allocator->UpdateAllocatorStrategy(base::BindRepeating(
       [](int block_size, int retain_blocks, int conservative_decommit_blocks,
-         bool aggressive_decommit_on_suspend, bool allocate_with_page_alignment,
+         bool enable_decommit_on_suspend, bool allocate_with_page_alignment,
+         bool aggressive_decommit_on_suspend, bool memset_on_reclaim,
+         bool mark_as_cold_on_reclaim, bool periodic_decommit,
          int initial_capacity, int allocation_unit)
           -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
         LOG(INFO)
@@ -347,18 +408,27 @@ void DecoderBufferAllocator::EnableConfigurableDecommitStrategy(
             << "block_size: " << block_size << ", "
             << "retain_blocks: " << retain_blocks << ", "
             << "conservative_decommit_blocks: " << conservative_decommit_blocks
+            << ", enable_decommit_on_suspend: "
+            << ToString(enable_decommit_on_suspend)
+            << ", allocate_with_page_alignment: "
+            << ToString(allocate_with_page_alignment)
             << ", aggressive_decommit_on_suspend: "
             << ToString(aggressive_decommit_on_suspend)
-            << ", allocate_with_page_alignment: "
-            << ToString(allocate_with_page_alignment);
+            << ", memset_on_reclaim: " << ToString(memset_on_reclaim)
+            << ", mark_as_cold_on_reclaim: "
+            << ToString(mark_as_cold_on_reclaim)
+            << ", periodic_decommit: " << ToString(periodic_decommit);
 
         return std::make_unique<DefaultReuseAllocatorStrategy>(
             block_size, block_size, /*enable_decommit_on_idle=*/true,
             retain_blocks, conservative_decommit_blocks,
-            aggressive_decommit_on_suspend, allocate_with_page_alignment);
+            aggressive_decommit_on_suspend, allocate_with_page_alignment,
+            memset_on_reclaim, mark_as_cold_on_reclaim);
       },
       block_size, retain_blocks, conservative_decommit_blocks,
-      aggressive_decommit_on_suspend, allocate_with_page_alignment));
+      enable_decommit_on_suspend, allocate_with_page_alignment,
+      aggressive_decommit_on_suspend, memset_on_reclaim,
+      mark_as_cold_on_reclaim, periodic_decommit));
 }
 
 // static
@@ -417,6 +487,42 @@ void DecoderBufferAllocator::EnsureStrategyIsCreated() {
 
   LOG(INFO) << "Allocated " << initial_capacity_
             << " bytes for decoder buffer pool.";
+}
+
+void DecoderBufferAllocator::EnablePeriodicDecommitLoop() {
+  base::AutoLock scoped_lock(mutex_);
+  if (periodic_decommit_state_) {
+    return;
+  }
+  periodic_decommit_state_ = base::MakeRefCounted<PeriodicDecommitState>(this);
+  SchedulePeriodicDecommitTask_Locked();
+}
+
+void DecoderBufferAllocator::StopPeriodicDecommitLoop() {
+  scoped_refptr<PeriodicDecommitState> state_to_detach;
+  {
+    base::AutoLock scoped_lock(mutex_);
+    state_to_detach = std::move(periodic_decommit_state_);
+  }
+  if (state_to_detach) {
+    state_to_detach->Detach();
+  }
+}
+
+void DecoderBufferAllocator::SchedulePeriodicDecommitTask_Locked() {
+  mutex_.AssertAcquired();
+
+  if (!periodic_decommit_state_) {
+    return;
+  }
+
+  base::ThreadPool::PostDelayedTask(
+      FROM_HERE,
+      {base::TaskPriority::BEST_EFFORT,
+       base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN},
+      base::BindOnce(&DecoderBufferAllocator::OnPeriodicDecommitTask,
+                     periodic_decommit_state_),
+      kDefaultPeriodicDecommitInterval);
 }
 
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -22,7 +22,10 @@
 
 #include "base/compiler_specific.h"
 #include "base/functional/callback.h"
+#include "base/memory/raw_ptr.h"
+#include "base/memory/ref_counted.h"
 #include "base/synchronization/lock.h"
+#include "base/task/thread_pool.h"
 #include "base/thread_annotations.h"
 #include "base/time/time.h"
 #include "base/types/expected.h"
@@ -52,6 +55,7 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
     virtual size_t GetAllocated() const = 0;
 
     virtual void DecommitAllDecommitableBlocks() = 0;
+    virtual void TryToDecommitOneBlock(int cadence) {}
   };
 
   using StrategyCreateCB =
@@ -89,18 +93,64 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
                                                       int value);
 
  private:
+  // Thread-safe state container for periodic decommit tasks running on
+  // ThreadPool.
+  //
+  // Holds a pointer to the owner DecoderBufferAllocator. Allows background
+  // tasks to run safely on ThreadPool without dangling pointer risks during
+  // teardown.
+  class PeriodicDecommitState final
+      : public base::RefCountedThreadSafe<PeriodicDecommitState> {
+   public:
+    explicit PeriodicDecommitState(DecoderBufferAllocator* allocator)
+        : allocator_(allocator) {}
+
+    PeriodicDecommitState(const PeriodicDecommitState&) = delete;
+    PeriodicDecommitState& operator=(const PeriodicDecommitState&) = delete;
+
+    void Detach() {
+      base::AutoLock lock(lock_);
+      allocator_ = nullptr;
+    }
+
+    template <typename Task>
+    void RunIfValid(Task task) {
+      base::AutoLock lock(lock_);
+      if (allocator_) {
+        task(allocator_);
+      }
+    }
+
+   private:
+    friend class base::RefCountedThreadSafe<PeriodicDecommitState>;
+    ~PeriodicDecommitState() = default;
+
+    base::Lock lock_;
+    raw_ptr<DecoderBufferAllocator> allocator_ GUARDED_BY(lock_) = nullptr;
+  };
+
+  static void OnPeriodicDecommitTask(
+      scoped_refptr<PeriodicDecommitState> state);
+
   // Utility functions for h5vcc settings.
   // TODO(b/460292554): To be deprecated with h5vcc settings.
   static void EnableConfigurableDecommitStrategy(
       int block_size,
       int retain_blocks,
       int conservative_decommit_blocks,
+      bool enable_decommit_on_suspend,
+      bool allocate_with_page_alignment,
       bool aggressive_decommit_on_suspend,
-      bool allocate_with_page_alignment);
+      bool memset_on_reclaim,
+      bool mark_as_cold_on_reclaim,
+      bool periodic_decommit);
   static void EnableMediaBufferPoolStrategy();
   static void EnableReleaseIdleMemory();
 
   void EnsureStrategyIsCreated() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
+  void EnablePeriodicDecommitLoop();
+  void StopPeriodicDecommitLoop();
+  void SchedulePeriodicDecommitTask_Locked() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
 
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   void TryFlushAllocationLog_Locked() EXCLUSIVE_LOCKS_REQUIRED(mutex_);
@@ -119,6 +169,8 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   bool has_pending_release_ GUARDED_BY(mutex_) = false;
   bool should_release_idle_memory_ GUARDED_BY(mutex_) = false;
   StrategyCreateCB experimental_strategy_create_cb_ GUARDED_BY(mutex_);
+  scoped_refptr<PeriodicDecommitState> periodic_decommit_state_
+      GUARDED_BY(mutex_);
 
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
   // The following variables are used for comprehensive logging of allocation

--- a/media/starboard/starboard_memory_allocator.h
+++ b/media/starboard/starboard_memory_allocator.h
@@ -36,6 +36,8 @@ namespace media {
 
 using starboard::AlignDown;
 using starboard::AlignUp;
+using starboard::Allocator;
+using DecommitMode = starboard::Allocator::DecommitMode;
 
 // StarboardMemoryAllocator is an allocator that allocates and frees memory
 // using posix_memalign() and free().
@@ -70,7 +72,7 @@ class StarboardMemoryAllocator : public starboard::Allocator {
   }
   void Free(void* memory) override { free(memory); }
 
-  void Decommit(void* memory, size_t size, bool conservative) override {
+  void Decommit(void* memory, size_t size, DecommitMode mode) override {
 #if !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
     CHECK(enable_decommit_);
 #endif  // !BUILDFLAG(COBALT_IS_RELEASE_BUILD)
@@ -82,12 +84,21 @@ class StarboardMemoryAllocator : public starboard::Allocator {
 
     if (aligned_start < aligned_end) {
       size_t aligned_size = aligned_end - aligned_start;
+
+      if (mode == DecommitMode::kCold) {
+#if defined(MADV_COLD)
+        madvise(aligned_start, aligned_size, MADV_COLD);
+#endif  // defined(MADV_COLD)
+        return;
+      }
+
       // MADV_FREE is not supported on all kernel versions/configurations. If it
       // fails, fallback to MADV_DONTNEED to ensure memory is still decommitted.
-      if (conservative &&
+      if (mode == DecommitMode::kConservative &&
           madvise(aligned_start, aligned_size, MADV_FREE) == 0) {
         return;
       }
+
       madvise(aligned_start, aligned_size, MADV_DONTNEED);
     }
   }

--- a/starboard/common/allocator.h
+++ b/starboard/common/allocator.h
@@ -29,6 +29,12 @@ namespace starboard {
 // through derived classes.
 class Allocator {
  public:
+  enum class DecommitMode {
+    kCold,          // Mark inactive/cold (e.g. MADV_COLD).
+    kConservative,  // Soft/lazy decommit (e.g. MADV_FREE).
+    kAggressive,    // Immediate decommit (e.g. MADV_DONTNEED).
+  };
+
   // Using a minimum value for alignment keeps things rounded and aligned
   // and help us avoid creating tiny and/or badly misaligned free blocks.  Also
   // ensures even for a 0-byte request will get a unique block.
@@ -77,9 +83,9 @@ class Allocator {
 
   // Hints to the allocator that the physical memory backing this range is no
   // longer needed, but the virtual address space should remain reserved.
-  // When |conservative| is true, the allocator may use a softer decommit
-  // option like MADV_FREE if supported.
-  virtual void Decommit(void* memory, size_t size, bool conservative) {}
+  // |mode| specifies whether the decommit operation should mark memory as cold,
+  // conservative (e.g. MADV_FREE), or aggressive (e.g. MADV_DONTNEED).
+  virtual void Decommit(void* memory, size_t size, DecommitMode mode) {}
 
   // Returns the allocator's total capacity for allocations.  It will always
   // be true that GetSize() <= GetCapacity(), though it is possible for

--- a/starboard/common/bidirectional_fit_reuse_allocator.h
+++ b/starboard/common/bidirectional_fit_reuse_allocator.h
@@ -62,7 +62,9 @@ class BidirectionalFitReuseAllocator : public UnderlyingReuseAllocator {
                                  bool enable_decommit_on_idle,
                                  size_t retain_blocks,
                                  size_t conservative_decommit_blocks,
-                                 bool aggressive_decommit_on_suspend = false)
+                                 bool aggressive_decommit_on_suspend,
+                                 bool memset_on_reclaim,
+                                 bool mark_as_cold_on_reclaim)
       : UnderlyingReuseAllocator(fallback_allocator,
                                  initial_capacity,
                                  allocation_increment,
@@ -70,7 +72,9 @@ class BidirectionalFitReuseAllocator : public UnderlyingReuseAllocator {
                                  enable_decommit_on_idle,
                                  retain_blocks,
                                  conservative_decommit_blocks,
-                                 aggressive_decommit_on_suspend),
+                                 aggressive_decommit_on_suspend,
+                                 memset_on_reclaim,
+                                 mark_as_cold_on_reclaim),
         small_allocation_threshold_(small_allocation_threshold) {}
 
   FreeBlockIterator FindFreeBlock(size_t size,

--- a/starboard/common/bidirectional_fit_reuse_allocator_test.cc
+++ b/starboard/common/bidirectional_fit_reuse_allocator_test.cc
@@ -94,7 +94,9 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
       FixedNoFreeAllocator::FreeWithSize(memory, size);
     }
 
-    void Decommit(void* memory, size_t size, bool conservative) override {
+    void Decommit(void* memory,
+                  size_t size,
+                  Allocator::DecommitMode mode) override {
       auto it = active_allocations_.find(memory);
       EXPECT_NE(it, active_allocations_.end())
           << "Decommitting a pointer not allocated by this fallback allocator.";
@@ -103,14 +105,14 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
             << "Decommit size does not exactly match the allocated size.";
       }
 
-      decommits.push_back({memory, size, conservative});
+      decommits.push_back({memory, size, mode});
       decommit_count++;
     }
 
     struct DecommitRecord {
       void* memory;
       size_t size;
-      bool conservative;
+      Allocator::DecommitMode mode;
     };
 
     int decommit_count;
@@ -125,11 +127,12 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
     std::ignore = posix_memalign(&tmp, Allocator::kMinAlignment, kBufferSize);
     buffer_.reset(static_cast<uint8_t*>(tmp));
 
-    std::unique_ptr<FixedNoFreeAllocator> fallback_allocator(
-        new FixedNoFreeAllocator(buffer_.get(), kBufferSize));
-    allocator_.reset(new BidirectionalFitReuseAllocator<ReuseAllocatorBase>(
-        fallback_allocator.get(), initial_capacity, small_allocation_threshold,
-        allocation_increment));
+    auto fallback_allocator =
+        std::make_unique<FixedNoFreeAllocator>(buffer_.get(), kBufferSize);
+    allocator_ =
+        std::make_unique<BidirectionalFitReuseAllocator<ReuseAllocatorBase>>(
+            fallback_allocator.get(), initial_capacity,
+            small_allocation_threshold, allocation_increment);
 
     fallback_allocator_.swap(fallback_allocator);
   }
@@ -138,16 +141,20 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
     std::ignore = posix_memalign(&tmp, Allocator::kMinAlignment, kBufferSize);
     buffer_.reset(static_cast<uint8_t*>(tmp));
 
-    std::unique_ptr<MockDecommitAllocator> fallback_allocator(
-        new MockDecommitAllocator(buffer_.get(), kBufferSize));
+    auto fallback_allocator =
+        std::make_unique<MockDecommitAllocator>(buffer_.get(), kBufferSize);
 
     // Store pointer before move/swap
     mock_fallback_allocator_ = fallback_allocator.get();
 
-    allocator_.reset(new BidirectionalFitReuseAllocator<ReuseAllocatorBase>(
-        mock_fallback_allocator_, 0, 0, 0, true,
-        /*retain_blocks=*/0,
-        /*conservative_decommit_blocks=*/0));
+    allocator_ =
+        std::make_unique<BidirectionalFitReuseAllocator<ReuseAllocatorBase>>(
+            mock_fallback_allocator_, 0, 0, 0, true,
+            /*retain_blocks=*/0,
+            /*conservative_decommit_blocks=*/0,
+            /*aggressive_decommit_on_suspend=*/false,
+            /*memset_on_reclaim=*/false,
+            /*mark_as_cold_on_reclaim=*/false);
 
     fallback_allocator_.reset(fallback_allocator.release());
   }
@@ -159,15 +166,19 @@ class BidirectionalFitReuseAllocatorTest : public ::testing::Test {
     std::ignore = posix_memalign(&tmp, Allocator::kMinAlignment, kBufferSize);
     buffer_.reset(static_cast<uint8_t*>(tmp));
 
-    std::unique_ptr<MockDecommitAllocator> fallback_allocator(
-        new MockDecommitAllocator(buffer_.get(), kBufferSize));
+    auto fallback_allocator =
+        std::make_unique<MockDecommitAllocator>(buffer_.get(), kBufferSize);
 
     // Store pointer before move/swap
     mock_fallback_allocator_ = fallback_allocator.get();
 
-    allocator_.reset(new BidirectionalFitReuseAllocator<ReuseAllocatorBase>(
-        mock_fallback_allocator_, 0, 0, 0, true, retain_blocks,
-        conservative_decommit_blocks));
+    allocator_ =
+        std::make_unique<BidirectionalFitReuseAllocator<ReuseAllocatorBase>>(
+            mock_fallback_allocator_, 0, 0, 0, true, retain_blocks,
+            conservative_decommit_blocks,
+            /*aggressive_decommit_on_suspend=*/false,
+            /*memset_on_reclaim=*/false,
+            /*mark_as_cold_on_reclaim=*/false);
 
     fallback_allocator_.reset(fallback_allocator.release());
   }
@@ -456,7 +467,7 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, DecommitOnBatchedFree) {
   size_t total_decommitted_size = 0;
   for (const auto& decommit : this->mock_fallback_allocator_->decommits) {
     total_decommitted_size += decommit.size;
-    EXPECT_FALSE(decommit.conservative);
+    EXPECT_EQ(decommit.mode, Allocator::DecommitMode::kAggressive);
   }
   EXPECT_GE(total_decommitted_size, kBlockSize * kNumBlocks);
 }
@@ -511,15 +522,15 @@ TYPED_TEST(BidirectionalFitReuseAllocatorTest, TieredDecommit) {
 
     if (ptr2 >= fallback_ptr && ptr2 < fallback_ptr + fallback_size) {
       found_block2 = true;
-      EXPECT_TRUE(decommit.conservative);
+      EXPECT_EQ(decommit.mode, Allocator::DecommitMode::kConservative);
     }
     if (ptr3 >= fallback_ptr && ptr3 < fallback_ptr + fallback_size) {
       found_block3 = true;
-      EXPECT_TRUE(decommit.conservative);
+      EXPECT_EQ(decommit.mode, Allocator::DecommitMode::kConservative);
     }
     if (ptr4 >= fallback_ptr && ptr4 < fallback_ptr + fallback_size) {
       found_block4 = true;
-      EXPECT_FALSE(decommit.conservative);
+      EXPECT_EQ(decommit.mode, Allocator::DecommitMode::kAggressive);
     }
   }
 

--- a/starboard/common/embedded_metadata_reuse_allocator_base.cc
+++ b/starboard/common/embedded_metadata_reuse_allocator_base.cc
@@ -196,7 +196,7 @@ void* EmbeddedMetadataReuseAllocatorBase::Allocate(size_t size,
       static_cast<uint8_t*>(allocated_block.address()) + sizeof(BlockMetadata);
 
   AddAllocatedBlock(allocated_block);
-  TryToDecommitOneBlock();
+  TryToDecommitOneBlock(/*cadence=*/100);
 
   return user_address;
 }
@@ -396,7 +396,9 @@ EmbeddedMetadataReuseAllocatorBase::EmbeddedMetadataReuseAllocatorBase(
           /*enable_decommit_on_idle=*/false,
           /*retain_blocks=*/0,
           /*conservative_decommit_blocks=*/0,
-          /*aggressive_decommit_on_suspend=*/false) {}
+          /*aggressive_decommit_on_suspend=*/false,
+          /*memset_on_reclaim=*/false,
+          /*mark_as_cold_on_reclaim=*/false) {}
 
 EmbeddedMetadataReuseAllocatorBase::EmbeddedMetadataReuseAllocatorBase(
     Allocator* fallback_allocator,
@@ -406,12 +408,16 @@ EmbeddedMetadataReuseAllocatorBase::EmbeddedMetadataReuseAllocatorBase(
     bool enable_decommit_on_idle,
     size_t retain_blocks,
     size_t conservative_decommit_blocks,
-    bool aggressive_decommit_on_suspend)
+    bool aggressive_decommit_on_suspend,
+    bool memset_on_reclaim,
+    bool mark_as_cold_on_reclaim)
     : ReuseAllocatorBase(fallback_allocator,
                          max_capacity,
                          retain_blocks,
                          conservative_decommit_blocks,
-                         aggressive_decommit_on_suspend),
+                         aggressive_decommit_on_suspend,
+                         memset_on_reclaim,
+                         mark_as_cold_on_reclaim),
       allocation_increment_(allocation_increment),
       enable_decommit_on_idle_(enable_decommit_on_idle) {
   if (initial_capacity > 0) {

--- a/starboard/common/embedded_metadata_reuse_allocator_base.h
+++ b/starboard/common/embedded_metadata_reuse_allocator_base.h
@@ -124,15 +124,16 @@ class EmbeddedMetadataReuseAllocatorBase : public ReuseAllocatorBase {
                                      size_t initial_capacity,
                                      size_t allocation_increment,
                                      size_t max_capacity);
-  EmbeddedMetadataReuseAllocatorBase(
-      Allocator* fallback_allocator,
-      size_t initial_capacity,
-      size_t allocation_increment,
-      size_t max_capacity,
-      bool enable_decommit_on_idle,
-      size_t retain_blocks,
-      size_t conservative_decommit_blocks,
-      bool aggressive_decommit_on_suspend = false);
+  EmbeddedMetadataReuseAllocatorBase(Allocator* fallback_allocator,
+                                     size_t initial_capacity,
+                                     size_t allocation_increment,
+                                     size_t max_capacity,
+                                     bool enable_decommit_on_idle,
+                                     size_t retain_blocks,
+                                     size_t conservative_decommit_blocks,
+                                     bool aggressive_decommit_on_suspend,
+                                     bool memset_on_reclaim,
+                                     bool mark_as_cold_on_reclaim);
   ~EmbeddedMetadataReuseAllocatorBase() override;
 
   // The inherited class should implement this function to inform the base

--- a/starboard/common/external_metadata_reuse_allocator_base.cc
+++ b/starboard/common/external_metadata_reuse_allocator_base.cc
@@ -175,7 +175,7 @@ void* ExternalMetadataReuseAllocatorBase::Allocate(size_t size,
   }
   void* user_address = AlignUp(allocated_block.address(), alignment);
   AddAllocatedBlock(user_address, allocated_block);
-  TryToDecommitOneBlock();
+  TryToDecommitOneBlock(/*cadence=*/100);
 
   return user_address;
 }
@@ -315,7 +315,9 @@ ExternalMetadataReuseAllocatorBase::ExternalMetadataReuseAllocatorBase(
           /*enable_decommit_on_idle=*/false,
           /*retain_blocks=*/0,
           /*conservative_decommit_blocks=*/0,
-          /*aggressive_decommit_on_suspend=*/false) {}
+          /*aggressive_decommit_on_suspend=*/false,
+          /*memset_on_reclaim=*/false,
+          /*mark_as_cold_on_reclaim=*/false) {}
 
 ExternalMetadataReuseAllocatorBase::ExternalMetadataReuseAllocatorBase(
     Allocator* fallback_allocator,
@@ -325,12 +327,16 @@ ExternalMetadataReuseAllocatorBase::ExternalMetadataReuseAllocatorBase(
     bool enable_decommit_on_idle,
     size_t retain_blocks,
     size_t conservative_decommit_blocks,
-    bool aggressive_decommit_on_suspend)
+    bool aggressive_decommit_on_suspend,
+    bool memset_on_reclaim,
+    bool mark_as_cold_on_reclaim)
     : ReuseAllocatorBase(fallback_allocator,
                          max_capacity,
                          retain_blocks,
                          conservative_decommit_blocks,
-                         aggressive_decommit_on_suspend),
+                         aggressive_decommit_on_suspend,
+                         memset_on_reclaim,
+                         mark_as_cold_on_reclaim),
       allocation_increment_(allocation_increment),
       enable_decommit_on_idle_(enable_decommit_on_idle) {
   if (initial_capacity > 0) {

--- a/starboard/common/external_metadata_reuse_allocator_base.h
+++ b/starboard/common/external_metadata_reuse_allocator_base.h
@@ -122,15 +122,16 @@ class ExternalMetadataReuseAllocatorBase : public ReuseAllocatorBase {
                                      size_t initial_capacity,
                                      size_t allocation_increment,
                                      size_t max_capacity);
-  ExternalMetadataReuseAllocatorBase(
-      Allocator* fallback_allocator,
-      size_t initial_capacity,
-      size_t allocation_increment,
-      size_t max_capacity,
-      bool enable_decommit_on_idle,
-      size_t retain_blocks,
-      size_t conservative_decommit_blocks,
-      bool aggressive_decommit_on_suspend = false);
+  ExternalMetadataReuseAllocatorBase(Allocator* fallback_allocator,
+                                     size_t initial_capacity,
+                                     size_t allocation_increment,
+                                     size_t max_capacity,
+                                     bool enable_decommit_on_idle,
+                                     size_t retain_blocks,
+                                     size_t conservative_decommit_blocks,
+                                     bool aggressive_decommit_on_suspend,
+                                     bool memset_on_reclaim,
+                                     bool mark_as_cold_on_reclaim);
   ~ExternalMetadataReuseAllocatorBase() override;
 
   // The inherited class should implement this function to inform the base

--- a/starboard/common/reuse_allocator_base.cc
+++ b/starboard/common/reuse_allocator_base.cc
@@ -14,7 +14,9 @@
 
 #include "starboard/common/reuse_allocator_base.h"
 
+#include <algorithm>
 #include <cstddef>
+#include <cstring>
 #include <utility>
 
 #include "starboard/common/check_op.h"
@@ -27,12 +29,16 @@ ReuseAllocatorBase::ReuseAllocatorBase(Allocator* fallback_allocator,
                                        size_t max_capacity,
                                        size_t retain_blocks,
                                        size_t conservative_decommit_blocks,
-                                       bool aggressive_decommit_on_suspend)
+                                       bool aggressive_decommit_on_suspend,
+                                       bool memset_on_reclaim,
+                                       bool mark_as_cold_on_reclaim)
     : fallback_allocator_(fallback_allocator),
       max_capacity_(max_capacity),
       retain_blocks_(retain_blocks),
       conservative_decommit_blocks_(conservative_decommit_blocks),
-      aggressive_decommit_on_suspend_(aggressive_decommit_on_suspend) {
+      aggressive_decommit_on_suspend_(aggressive_decommit_on_suspend),
+      memset_on_reclaim_(memset_on_reclaim),
+      mark_as_cold_on_reclaim_(mark_as_cold_on_reclaim) {
   SB_DCHECK(fallback_allocator_);
 }
 
@@ -45,7 +51,7 @@ ReuseAllocatorBase::~ReuseAllocatorBase() {
 void ReuseAllocatorBase::DecommitAllDecommitableBlocks() {
   if (aggressive_decommit_on_suspend_) {
     // Aggressively decommit all idle blocks (including retained and
-    // lazily-freed blocks) with MADV_DONTNEED (conservative=false). This
+    // lazily-freed blocks) with MADV_DONTNEED (kAggressive). This
     // instantly drops the process RSS to prevent the OS Out-Of-Memory killer
     // from terminating the app in background/suspended states.
     for (auto& fallback_block : fallback_allocations_) {
@@ -53,7 +59,7 @@ void ReuseAllocatorBase::DecommitAllDecommitableBlocks() {
           fallback_block.state != kIdleDecommitted) {
         fallback_allocator_->Decommit(fallback_block.address,
                                       fallback_block.size,
-                                      /*conservative=*/false);
+                                      DecommitMode::kAggressive);
         fallback_block.state = kIdleDecommitted;
       }
     }
@@ -66,11 +72,11 @@ void ReuseAllocatorBase::DecommitAllDecommitableBlocks() {
          it != fallback_allocations_.rend(); ++it) {
       if (it->state == kIdlePendingDecommit) {
         fallback_allocator_->Decommit(it->address, it->size,
-                                      /*conservative=*/false);
+                                      DecommitMode::kAggressive);
         it->state = kIdleDecommitted;
       } else if (it->state == kIdlePendingFree) {
         fallback_allocator_->Decommit(it->address, it->size,
-                                      /*conservative=*/true);
+                                      DecommitMode::kConservative);
         it->state = kIdleFreed;
       }
     }
@@ -112,9 +118,23 @@ std::pair<void*, intptr_t> ReuseAllocatorBase::AllocateFallbackBlock(
 void ReuseAllocatorBase::ReclaimFallbackBlocks() {
   SB_LOG(INFO) << "Allocator reached idle state, reclaiming "
                << fallback_allocations_.size() << " fallback allocations.";
-  allocation_counter_ = 0;
+  block_decommit_attempt_count_ = 0;
   for (size_t i = 0; i < fallback_allocations_.size(); ++i) {
     auto& fallback_block = fallback_allocations_[i];
+
+    // Do nothing if the block has already been decommitted or freed.
+    if (fallback_block.state == kIdleDecommitted ||
+        fallback_block.state == kIdleFreed) {
+      continue;
+    }
+
+    if (fallback_block.state == kActiveInUse && memset_on_reclaim_) {
+      memset(fallback_block.address, 0, fallback_block.size);
+    }
+    if (fallback_block.state == kActiveInUse && mark_as_cold_on_reclaim_) {
+      fallback_allocator_->Decommit(fallback_block.address, fallback_block.size,
+                                    DecommitMode::kCold);
+    }
     if (i < retain_blocks_) {
       fallback_block.state = kIdleRetained;
     } else if (i < retain_blocks_ + conservative_decommit_blocks_) {
@@ -127,23 +147,25 @@ void ReuseAllocatorBase::ReclaimFallbackBlocks() {
   }
 }
 
-void ReuseAllocatorBase::TryToDecommitOneBlock() {
+// TODO(b/454441375): Move this to be in sync with the declaration order.
+void ReuseAllocatorBase::TryToDecommitOneBlock(int cadence) {
   if (!has_pending_decommits_) {
     return;
   }
-  ++allocation_counter_;
-  if (allocation_counter_ % 100 == 0) {
+  const size_t effective_cadence = static_cast<size_t>(std::max(1, cadence));
+  ++block_decommit_attempt_count_;
+  if (block_decommit_attempt_count_ % effective_cadence == 0) {
     for (auto it = fallback_allocations_.rbegin();
          it != fallback_allocations_.rend(); ++it) {
       if (it->state == kIdlePendingDecommit) {
         fallback_allocator_->Decommit(it->address, it->size,
-                                      /*conservative=*/false);
+                                      DecommitMode::kAggressive);
         it->state = kIdleDecommitted;
         return;
       }
       if (it->state == kIdlePendingFree) {
         fallback_allocator_->Decommit(it->address, it->size,
-                                      /*conservative=*/true);
+                                      DecommitMode::kConservative);
         it->state = kIdleFreed;
         return;
       }

--- a/starboard/common/reuse_allocator_base.h
+++ b/starboard/common/reuse_allocator_base.h
@@ -46,12 +46,20 @@ class ReuseAllocatorBase : public Allocator {
   // suspend).
   void DecommitAllDecommitableBlocks();
 
+  // Attempts to decommit a single pending idle block, amortized by `cadence`.
+  // When `cadence == 1`, it immediately decommits a pending block.
+  void TryToDecommitOneBlock(int cadence);
+
  protected:
+  // TODO(b/454441375): Refactor positional boolean parameters into an Options
+  // struct to prevent argument ordering mistakes.
   ReuseAllocatorBase(Allocator* fallback_allocator,
                      size_t max_capacity,
                      size_t retain_blocks,
                      size_t conservative_decommit_blocks,
-                     bool aggressive_decommit_on_suspend = false);
+                     bool aggressive_decommit_on_suspend,
+                     bool memset_on_reclaim,
+                     bool mark_as_cold_on_reclaim);
   ~ReuseAllocatorBase() override;
 
   bool CapacityExceeded() const {
@@ -73,9 +81,6 @@ class ReuseAllocatorBase : public Allocator {
 
   // Reclaims all backing allocations to the base idle pool (subclass-driven).
   void ReclaimFallbackBlocks();
-
-  // Step counter to amortize decommits across sequential active allocations.
-  void TryToDecommitOneBlock();
 
   // Enumerates fallback backing allocations. Templated to allow zero-cost
   // compiler inlining for capturing lambdas and avoid std::function overhead.
@@ -129,6 +134,12 @@ class ReuseAllocatorBase : public Allocator {
   // Whether to aggressively decommit all idle blocks on app suspend.
   const bool aggressive_decommit_on_suspend_ = false;
 
+  // Whether to memset fallback memory blocks to 0 when reclaimed.
+  const bool memset_on_reclaim_ = false;
+
+  // Whether to mark fallback memory blocks cold (MADV_COLD) when reclaimed.
+  const bool mark_as_cold_on_reclaim_ = false;
+
   // A list of all backing memory blocks allocated from the fallback allocator.
   // We keep track of this so we can decommit on idle and free them upon
   // destruction.
@@ -138,8 +149,8 @@ class ReuseAllocatorBase : public Allocator {
   // allocator.
   size_t capacity_ = 0;
 
-  // Counter to amortize decommits over multiple allocations.
-  size_t allocation_counter_ = 0;
+  // Counter to amortize decommits over multiple allocation attempts.
+  size_t block_decommit_attempt_count_ = 0;
 
   // Set to true when idle reclamation stages blocks for decommit.
   bool has_pending_decommits_ = false;


### PR DESCRIPTION
Add support for configurable decommit flags in DecoderBufferAllocator,
including memset_on_reclaim, mark_as_cold_on_reclaim,
periodic_decommit, and separate enable_decommit_on_suspend and
aggressive_decommit_on_suspend flags.

Ensure allocate_with_page_alignment remains on bit 25 for backwards
compatibility, with aggressive_decommit_on_suspend moved to bit 26.
Reset mark_as_cold_on_reclaim to false with an info log when MADV_COLD is
unsupported on the target platform. Use TryToDecommitOneBlock for periodic
decommit tasks.

Avoid lock inversion deadlock when stopping periodic decommit loop.
Fix block_decommit_attempt_count_ identifier in ReuseAllocatorBase.
Update allocator docstrings for DecommitMode and new strategy flags.
Support EnableConfigurableDecommitStrategyV2 setting alias for rollout.

Bug: 454441375