### PR TITLE
cobalt: Handle early splash screen checks

### DIFF
--- a/cobalt/shell/common/shell_switches.cc
+++ b/cobalt/shell/common/shell_switches.cc
@@ -61,6 +61,12 @@ const char kSplashScreenShutdownDelayMs[] = "splash-screen-shutdown-delay-ms";
 const char kTestRegisterStandardScheme[] = "test-register-standard-scheme";
 
 bool ShouldCreateSplashScreen() {
+  // If the FeatureList isn't available yet, fall back to the feature's default
+  // state. This may happen during early startup.
+  if (!base::FeatureList::GetInstance()) {
+    return cobalt::features::kDisableSplashScreen.default_state ==
+           base::FEATURE_DISABLED_BY_DEFAULT;
+  }
   return !base::FeatureList::IsEnabled(cobalt::features::kDisableSplashScreen);
 }
 


### PR DESCRIPTION
Ensure ShouldCreateSplashScreen behaves correctly during early startup
when the FeatureList is not yet available. This prevents potential
instability or incorrect state detection when determining if the
splash screen should be displayed before the global feature state is
fully initialized.

This is a follow-up PR by https://github.com/youtube/cobalt/pull/11595 to
address the comments in https://github.com/youtube/cobalt/pull/11638#discussion_r3686141344.

Issue: 540461098