### PR TITLE
chore(ci): disable git auto-maintenance to deflake autoroll

### DIFF
--- a/.github/workflows/autoroll_lts.yaml
+++ b/.github/workflows/autoroll_lts.yaml
@@ -46,6 +46,9 @@ jobs:
           git config --global user.name "GitHub Release Automation"
           git config --global user.email "github@google.com"
           git config --global submodule.recurse false
+          # Disable auto GC/maintenance to prevent shallow fetch errors.
+          git config --global maintenance.auto false
+          git config --global gc.auto 0
 
       - name: Prepare Cherry Pick Branch
         env:


### PR DESCRIPTION
Disable automatic git maintenance and GC to prevent 'fatal: shallow file has changed since we read it' errors during shallow fetches.

TAG=agy

CONV=6d619d1d-58d0-4583-b4de-2e5d30d9024b

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>