### PR TITLE
feat(ci): add verbose mode to autoroll_lts.py

### DIFF
--- a/.github/scripts/autoroll.py
+++ b/.github/scripts/autoroll.py
@@ -16,7 +16,11 @@ def main():
   p.add_argument('--autoroll-file', required=True)
   p.add_argument('--max-commits', type=int, required=True)
   p.add_argument('--existing-pr-sha', required=True)
+  p.add_argument('--verbose', action='store_true')
   args = p.parse_args()
+
+  if args.verbose:
+    lib.VERBOSE = True
 
   target_start = lib.get_start_sha(args.target_branch, args.autoroll_file)
   autoroll_start = lib.get_start_sha('HEAD', args.autoroll_file)

--- a/.github/scripts/autoroll_chromium.py
+++ b/.github/scripts/autoroll_chromium.py
@@ -202,7 +202,11 @@ def main():
   p.add_argument('--autoroll-file', required=True)
   p.add_argument('--max-commits', type=int, required=True)
   p.add_argument('--existing-pr-sha', required=True)
+  p.add_argument('--verbose', action='store_true')
   args = p.parse_args()
+
+  if args.verbose:
+    lib.VERBOSE = True
 
   autoroll_start = lib.get_start_sha('HEAD', args.autoroll_file)
 

--- a/.github/scripts/autoroll_lib.py
+++ b/.github/scripts/autoroll_lib.py
@@ -3,9 +3,12 @@
 from collections import defaultdict
 import enum
 import re
+import shlex
 import shutil
 import subprocess
 import sys
+
+VERBOSE = False
 
 
 @enum.unique
@@ -27,6 +30,8 @@ def run(cmd, cwd=None):
 
 def git(*args, check=True, stdout=subprocess.PIPE, text=True, **kwargs):
   cmd = ['git'] + list(args)
+  if VERBOSE:
+    log(f'Running: {shlex.join(cmd)}')
   return subprocess.run(
       cmd, check=check, stdout=stdout, text=text, **kwargs).stdout
 

--- a/.github/scripts/autoroll_test.py
+++ b/.github/scripts/autoroll_test.py
@@ -39,6 +39,15 @@ class TestGitHelper(unittest.TestCase):
                                      text=True)
     self.assertEqual(res, 'output')
 
+  @patch('subprocess.run')
+  def test_git_verbose(self, mock_run):
+    lib.VERBOSE = True
+    mock_run.return_value = MagicMock(stdout='output')
+    with patch('autoroll_lib.log') as mock_log:
+      lib.git('status', 'args')
+      mock_log.assert_called_once_with('Running: git status args')
+    lib.VERBOSE = False
+
 
 class TestGetStartSha(unittest.TestCase):
   """Test cases for get_start_sha()."""
@@ -329,6 +338,21 @@ class TestAutorollMainFlow(unittest.TestCase):
                                                ('date', 'author', 'msg'), False,
                                                ('roll_file', 'sha2'))
       self.assertEqual('- #101\n- #102', mock_stdout.getvalue().strip())
+
+  @patch('autoroll_lib.get_start_sha')
+  @patch('sys.argv', [
+      'autoroll.py', '--source-branch', 'main', '--target-branch', '27.lts',
+      '--autoroll-file', 'roll_file', '--max-commits', '5', '--existing-pr-sha',
+      '', '--verbose'
+  ])
+  def test_main_verbose_flag(self, mock_get_start_sha):
+    mock_get_start_sha.return_value = None
+
+    lib.VERBOSE = False
+    with patch('sys.stderr'):
+      autoroll.main()
+    self.assertTrue(lib.VERBOSE)
+    lib.VERBOSE = False
 
 
 class TestChromiumSubmoduleAndCheckout(unittest.TestCase):

--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -98,7 +98,8 @@ jobs:
             --source-branch "${{ matrix.branch.source }}" \
             --autoroll-file "${{ matrix.branch.autoroll }}" \
             --max-commits "${{ env.MAX_COMMITS }}" \
-            --existing-pr-sha "${{ steps.pr_info.outputs.first_sha }}")
+            --existing-pr-sha "${{ steps.pr_info.outputs.first_sha }}" \
+            --verbose)
 
           if [[ -n "${PR_LINKS}" ]]; then
             echo "cherry_picked=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -92,7 +92,8 @@ jobs:
             --target-branch "${{ matrix.branch.target }}" \
             --autoroll-file "${{ matrix.branch.autoroll }}" \
             --max-commits "${{ env.MAX_COMMITS }}" \
-            --existing-pr-sha "${{ steps.pr_info.outputs.first_sha }}")
+            --existing-pr-sha "${{ steps.pr_info.outputs.first_sha }}" \
+            --verbose)
 
           if [[ -n "${PR_LINKS}" ]]; then
             echo "cherry_picked=true" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Add --verbose command-line flag and print git commands using shlex.join when verbose mode is enabled. Added unit tests for verbose mode.

TAG=agy
CONV=8174be7f-714e-4699-ab77-1de360084ccd

---

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>