### PR TITLE
android: Handle asynchronous native startup in WindowSurfaceBridge

### DIFF
--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
@@ -17,6 +17,7 @@ import android.widget.FrameLayout;
 
 import org.chromium.base.CommandLine;
 import org.chromium.base.Log;
+import org.chromium.content_public.browser.BrowserStartupController;
 import org.chromium.content_public.browser.WebContents;
 import org.chromium.ui.base.EventForwarder;
 import org.chromium.ui.base.WindowAndroid;
@@ -301,11 +302,27 @@ public class ContentViewRenderView extends FrameLayout {
         private SurfaceHolder mWindowSurfaceHolder;
 
         /**
-         * The last requested PixelFormat (e.g. TRANSLUCENT for overlay video mode, OPAQUE for normal).
-         * Preserved across surface destruction and recreation so newly created SurfaceHolders
-         * automatically inherit the desired format.
+         * The pending PixelFormat (e.g. TRANSLUCENT for overlay video mode, OPAQUE for normal).
+         * Buffered when setFormat() is called before the surface is ready, and consumed once
+         * the SurfaceHolder becomes available.
          */
-        private Integer mRequestedSurfaceFormat;
+        private Integer mPendingSurfaceFormat;
+
+        private static class SurfaceConfig {
+            public final int format;
+            public final int width;
+            public final int height;
+
+            public SurfaceConfig(int format, int width, int height) {
+                this.format = format;
+                this.width = width;
+                this.height = height;
+            }
+        }
+
+        private boolean mPendingSurfaceCreated;
+        private SurfaceConfig mPendingSurfaceConfig;
+        private boolean mIsObserverRegistered;
 
         private static Window getWindow(WindowAndroid windowAndroid) {
             if (windowAndroid == null || windowAndroid.getActivity() == null) {
@@ -331,23 +348,20 @@ public class ContentViewRenderView extends FrameLayout {
                 @Override
                 public void surfaceCreated(SurfaceHolder holder) {
                     mWindowSurfaceHolder = holder;
-                    if (mRequestedSurfaceFormat != null) {
-                        Log.i(TAG, "ContentViewRenderView: Applying pending format");
-                        mWindowSurfaceHolder.setFormat(mRequestedSurfaceFormat);
-                    }
-                    surfaceCallback.surfaceCreated(holder);
+                    mPendingSurfaceCreated = true;
                 }
 
                 @Override
                 public void surfaceChanged(
                         SurfaceHolder holder, int format, int width, int height) {
-                    mWindowSurfaceHolder = holder;
-                    surfaceCallback.surfaceChanged(holder, format, width, height);
+                    dispatchOrDeferSurfaceEvents(holder, new SurfaceConfig(format, width, height));
                 }
 
                 @Override
                 public void surfaceDestroyed(SurfaceHolder holder) {
                     mWindowSurfaceHolder = null;
+                    mPendingSurfaceCreated = false;
+                    mPendingSurfaceConfig = null;
                     surfaceCallback.surfaceDestroyed(holder);
                 }
 
@@ -357,6 +371,56 @@ public class ContentViewRenderView extends FrameLayout {
                         return;
                     }
                     ((SurfaceHolder.Callback2) surfaceCallback).surfaceRedrawNeeded(holder);
+                }
+
+                private void dispatchOrDeferSurfaceEvents(SurfaceHolder holder, SurfaceConfig config) {
+                    mWindowSurfaceHolder = holder;
+                    mPendingSurfaceConfig = config;
+
+                    if (BrowserStartupController.getInstance().isNativeStarted()) {
+                        dispatchPendingSurfaceEvents();
+                        return;
+                    }
+
+                    if (mIsObserverRegistered) {
+                        Log.i(TAG, "ContentViewRenderView: Startup observer already registered; updated pending config");
+                        return;
+                    }
+                    mIsObserverRegistered = true;
+
+                    Log.i(TAG, "ContentViewRenderView: Deferring surface events until native startup completes");
+                    // Native browser startup (Mojo initialization) is asynchronous and may still be in progress
+                    // during Activity creation, especially on slower devices. For details, see b/539880857.
+                    BrowserStartupController.getInstance().addStartupCompletedObserver(
+                            new BrowserStartupController.StartupCallback() {
+                                @Override
+                                public void onSuccess() {
+                                    dispatchPendingSurfaceEvents();
+                                }
+
+                                @Override
+                                public void onFailure() {}
+                            });
+                }
+
+                private void dispatchPendingSurfaceEvents() {
+                    if (mPendingSurfaceConfig == null || mWindowSurfaceHolder == null) {
+                        return;
+                    }
+
+                    if (mPendingSurfaceCreated) {
+                        mPendingSurfaceCreated = false;
+                        Log.i(TAG, "ContentViewRenderView: Native startup finished, dispatching surface events");
+                        applyPendingSurfaceFormat();
+                        surfaceCallback.surfaceCreated(mWindowSurfaceHolder);
+                    }
+
+                    surfaceCallback.surfaceChanged(
+                            mWindowSurfaceHolder,
+                            mPendingSurfaceConfig.format,
+                            mPendingSurfaceConfig.width,
+                            mPendingSurfaceConfig.height);
+                    mPendingSurfaceConfig = null;
                 }
             });
         }
@@ -370,7 +434,9 @@ public class ContentViewRenderView extends FrameLayout {
             }
             mWindow = null;
             mWindowSurfaceHolder = null;
-            mRequestedSurfaceFormat = null;
+            mPendingSurfaceFormat = null;
+            mPendingSurfaceConfig = null;
+            mPendingSurfaceCreated = false;
         }
 
         @Override
@@ -378,14 +444,23 @@ public class ContentViewRenderView extends FrameLayout {
             return null;
         }
 
-        @Override
-        protected void setFormat(int format) {
-            mRequestedSurfaceFormat = format;
+        private void applyPendingSurfaceFormat() {
+            if (mPendingSurfaceFormat == null) {
+                return;
+            }
             if (mWindowSurfaceHolder == null) {
                 Log.i(TAG, "ContentViewRenderView: surface is not ready yet. Will apply format later");
                 return;
             }
-            mWindowSurfaceHolder.setFormat(format);
+            Log.i(TAG, "ContentViewRenderView: Applying pending format");
+            mWindowSurfaceHolder.setFormat(mPendingSurfaceFormat);
+            mPendingSurfaceFormat = null;
+        }
+
+        @Override
+        protected void setFormat(int format) {
+            mPendingSurfaceFormat = format;
+            applyPendingSurfaceFormat();
         }
     }
 

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
@@ -308,6 +308,10 @@ public class ContentViewRenderView extends FrameLayout {
          */
         private Integer mPendingSurfaceFormat;
 
+        /**
+         * Simple data holder representing the surface configuration parameters.
+         * Instances are short-lived, immutable, and thread-safe.
+         */
         private static class SurfaceConfig {
             public final int format;
             public final int width;
@@ -320,9 +324,16 @@ public class ContentViewRenderView extends FrameLayout {
             }
         }
 
-        private boolean mPendingSurfaceCreated;
-        private SurfaceConfig mPendingSurfaceConfig;
-        private boolean mIsObserverRegistered;
+        private enum StartupState {
+            NOT_REGISTERED,
+            OBSERVER_REGISTERED,
+            NATIVE_STARTED,
+        }
+
+        private final java.util.List<Runnable> mPendingTasks = new java.util.ArrayList<>();
+        private boolean mIsSurfaceCreatedDispatched;
+        // Startup state is a one-way transition across native startup (do not reset in disconnect()).
+        private StartupState mStartupState = StartupState.NOT_REGISTERED;
 
         private static Window getWindow(WindowAndroid windowAndroid) {
             if (windowAndroid == null || windowAndroid.getActivity() == null) {
@@ -330,6 +341,36 @@ public class ContentViewRenderView extends FrameLayout {
             }
             Activity activity = windowAndroid.getActivity().get();
             return activity != null ? activity.getWindow() : null;
+        }
+
+        private void registerStartupListener() {
+            // Fast-path: if native is already started, don't wait or register.
+            if (BrowserStartupController.getInstance().isNativeStarted()) {
+                mStartupState = StartupState.NATIVE_STARTED;
+                return;
+            }
+
+            // BrowserStartupController is a singleton that fires startup completion only once,
+            // so we only need to register the observer once.
+            if (mStartupState != StartupState.NOT_REGISTERED) {
+                return;
+            }
+            mStartupState = StartupState.OBSERVER_REGISTERED;
+
+            BrowserStartupController.getInstance().addStartupCompletedObserver(
+                    new BrowserStartupController.StartupCallback() {
+                        @Override
+                        public void onSuccess() {
+                            Log.i(TAG, "ContentViewRenderView: Startup complete");
+                            while (!mPendingTasks.isEmpty()) {
+                                mPendingTasks.remove(0).run();
+                            }
+                            mStartupState = StartupState.NATIVE_STARTED;
+                        }
+
+                        @Override
+                        public void onFailure() {}
+                    });
         }
 
         @Override
@@ -344,24 +385,42 @@ public class ContentViewRenderView extends FrameLayout {
                 return;
             }
 
+            // Native browser startup (Mojo initialization) may still be in progress during Activity creation
+            // on slower devices. Listen for startup completion to safely drain surface events (b/539880857).
+            registerStartupListener();
+
             mWindow.takeSurface(new SurfaceHolder.Callback2() {
                 @Override
                 public void surfaceCreated(SurfaceHolder holder) {
                     mWindowSurfaceHolder = holder;
-                    mPendingSurfaceCreated = true;
+                    if (mStartupState != StartupState.NATIVE_STARTED) {
+                        mPendingTasks.add(() -> handleSurfaceCreated(holder));
+                        return;
+                    }
+                    handleSurfaceCreated(holder);
                 }
 
                 @Override
                 public void surfaceChanged(
                         SurfaceHolder holder, int format, int width, int height) {
-                    dispatchOrDeferSurfaceEvents(holder, new SurfaceConfig(format, width, height));
+                    mWindowSurfaceHolder = holder;
+                    SurfaceConfig config = new SurfaceConfig(format, width, height);
+                    if (mStartupState != StartupState.NATIVE_STARTED) {
+                        mPendingTasks.add(() -> handleSurfaceChanged(holder, config));
+                        return;
+                    }
+                    handleSurfaceChanged(holder, config);
                 }
 
                 @Override
                 public void surfaceDestroyed(SurfaceHolder holder) {
                     mWindowSurfaceHolder = null;
-                    mPendingSurfaceCreated = false;
-                    mPendingSurfaceConfig = null;
+                    mPendingTasks.clear();
+
+                    if (!mIsSurfaceCreatedDispatched) {
+                        return;
+                    }
+                    mIsSurfaceCreatedDispatched = false;
                     surfaceCallback.surfaceDestroyed(holder);
                 }
 
@@ -373,54 +432,16 @@ public class ContentViewRenderView extends FrameLayout {
                     ((SurfaceHolder.Callback2) surfaceCallback).surfaceRedrawNeeded(holder);
                 }
 
-                private void dispatchOrDeferSurfaceEvents(SurfaceHolder holder, SurfaceConfig config) {
-                    mWindowSurfaceHolder = holder;
-                    mPendingSurfaceConfig = config;
-
-                    if (BrowserStartupController.getInstance().isNativeStarted()) {
-                        dispatchPendingSurfaceEvents();
-                        return;
-                    }
-
-                    if (mIsObserverRegistered) {
-                        Log.i(TAG, "ContentViewRenderView: Startup observer already registered; updated pending config");
-                        return;
-                    }
-                    mIsObserverRegistered = true;
-
-                    Log.i(TAG, "ContentViewRenderView: Deferring surface events until native startup completes");
-                    // Native browser startup (Mojo initialization) is asynchronous and may still be in progress
-                    // during Activity creation, especially on slower devices. For details, see b/539880857.
-                    BrowserStartupController.getInstance().addStartupCompletedObserver(
-                            new BrowserStartupController.StartupCallback() {
-                                @Override
-                                public void onSuccess() {
-                                    dispatchPendingSurfaceEvents();
-                                }
-
-                                @Override
-                                public void onFailure() {}
-                            });
+                private void handleSurfaceCreated(SurfaceHolder holder) {
+                    Log.i(TAG, "ContentViewRenderView: Surface created");
+                    applyPendingSurfaceFormat();
+                    surfaceCallback.surfaceCreated(holder);
+                    mIsSurfaceCreatedDispatched = true;
                 }
 
-                private void dispatchPendingSurfaceEvents() {
-                    if (mPendingSurfaceConfig == null || mWindowSurfaceHolder == null) {
-                        return;
-                    }
-
-                    if (mPendingSurfaceCreated) {
-                        mPendingSurfaceCreated = false;
-                        Log.i(TAG, "ContentViewRenderView: Native startup finished, dispatching surface events");
-                        applyPendingSurfaceFormat();
-                        surfaceCallback.surfaceCreated(mWindowSurfaceHolder);
-                    }
-
+                private void handleSurfaceChanged(SurfaceHolder holder, SurfaceConfig config) {
                     surfaceCallback.surfaceChanged(
-                            mWindowSurfaceHolder,
-                            mPendingSurfaceConfig.format,
-                            mPendingSurfaceConfig.width,
-                            mPendingSurfaceConfig.height);
-                    mPendingSurfaceConfig = null;
+                            holder, config.format, config.width, config.height);
                 }
             });
         }
@@ -435,13 +456,19 @@ public class ContentViewRenderView extends FrameLayout {
             mWindow = null;
             mWindowSurfaceHolder = null;
             mPendingSurfaceFormat = null;
-            mPendingSurfaceConfig = null;
-            mPendingSurfaceCreated = false;
+            mPendingTasks.clear();
+            mIsSurfaceCreatedDispatched = false;
         }
 
         @Override
         protected SurfaceView getSurfaceView() {
             return null;
+        }
+
+        @Override
+        protected void setFormat(int format) {
+            mPendingSurfaceFormat = format;
+            applyPendingSurfaceFormat();
         }
 
         private void applyPendingSurfaceFormat() {
@@ -455,12 +482,6 @@ public class ContentViewRenderView extends FrameLayout {
             Log.i(TAG, "ContentViewRenderView: Applying pending format");
             mWindowSurfaceHolder.setFormat(mPendingSurfaceFormat);
             mPendingSurfaceFormat = null;
-        }
-
-        @Override
-        protected void setFormat(int format) {
-            mPendingSurfaceFormat = format;
-            applyPendingSurfaceFormat();
         }
     }
 

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
@@ -308,32 +308,9 @@ public class ContentViewRenderView extends FrameLayout {
          */
         private Integer mPendingSurfaceFormat;
 
-        /**
-         * Simple data holder representing the surface configuration parameters.
-         * Instances are short-lived, immutable, and thread-safe.
-         */
-        private static class SurfaceConfig {
-            public final int format;
-            public final int width;
-            public final int height;
-
-            public SurfaceConfig(int format, int width, int height) {
-                this.format = format;
-                this.width = width;
-                this.height = height;
-            }
-        }
-
-        private enum StartupState {
-            NOT_REGISTERED,
-            OBSERVER_REGISTERED,
-            NATIVE_STARTED,
-        }
-
         private final java.util.List<Runnable> mPendingTasks = new java.util.ArrayList<>();
+        private boolean mIsNativeStarted;
         private boolean mIsSurfaceCreatedDispatched;
-        // Startup state is a one-way transition across native startup (do not reset in disconnect()).
-        private StartupState mStartupState = StartupState.NOT_REGISTERED;
 
         private static Window getWindow(WindowAndroid windowAndroid) {
             if (windowAndroid == null || windowAndroid.getActivity() == null) {
@@ -346,16 +323,9 @@ public class ContentViewRenderView extends FrameLayout {
         private void registerStartupListener() {
             // Fast-path: if native is already started, don't wait or register.
             if (BrowserStartupController.getInstance().isNativeStarted()) {
-                mStartupState = StartupState.NATIVE_STARTED;
+                mIsNativeStarted = true;
                 return;
             }
-
-            // BrowserStartupController is a singleton that fires startup completion only once,
-            // so we only need to register the observer once.
-            if (mStartupState != StartupState.NOT_REGISTERED) {
-                return;
-            }
-            mStartupState = StartupState.OBSERVER_REGISTERED;
 
             BrowserStartupController.getInstance().addStartupCompletedObserver(
                     new BrowserStartupController.StartupCallback() {
@@ -365,11 +335,14 @@ public class ContentViewRenderView extends FrameLayout {
                             while (!mPendingTasks.isEmpty()) {
                                 mPendingTasks.remove(0).run();
                             }
-                            mStartupState = StartupState.NATIVE_STARTED;
+                            mIsNativeStarted = true;
                         }
 
                         @Override
-                        public void onFailure() {}
+                        public void onFailure() {
+                            Log.e(TAG, "ContentViewRenderView: Native startup failed; clearing pending tasks");
+                            mPendingTasks.clear();
+                        }
                     });
         }
 
@@ -393,7 +366,7 @@ public class ContentViewRenderView extends FrameLayout {
                 @Override
                 public void surfaceCreated(SurfaceHolder holder) {
                     mWindowSurfaceHolder = holder;
-                    if (mStartupState != StartupState.NATIVE_STARTED) {
+                    if (!mIsNativeStarted) {
                         mPendingTasks.add(() -> handleSurfaceCreated(holder));
                         return;
                     }
@@ -404,12 +377,12 @@ public class ContentViewRenderView extends FrameLayout {
                 public void surfaceChanged(
                         SurfaceHolder holder, int format, int width, int height) {
                     mWindowSurfaceHolder = holder;
-                    SurfaceConfig config = new SurfaceConfig(format, width, height);
-                    if (mStartupState != StartupState.NATIVE_STARTED) {
-                        mPendingTasks.add(() -> handleSurfaceChanged(holder, config));
+                    if (!mIsNativeStarted) {
+                        mPendingTasks.add(
+                                () -> surfaceCallback.surfaceChanged(holder, format, width, height));
                         return;
                     }
-                    handleSurfaceChanged(holder, config);
+                    surfaceCallback.surfaceChanged(holder, format, width, height);
                 }
 
                 @Override
@@ -437,11 +410,6 @@ public class ContentViewRenderView extends FrameLayout {
                     applyPendingSurfaceFormat();
                     surfaceCallback.surfaceCreated(holder);
                     mIsSurfaceCreatedDispatched = true;
-                }
-
-                private void handleSurfaceChanged(SurfaceHolder holder, SurfaceConfig config) {
-                    surfaceCallback.surfaceChanged(
-                            holder, config.format, config.width, config.height);
                 }
             });
         }


### PR DESCRIPTION
Window.takeSurface() takes direct ownership of the Activity's top-level Window, causing Android OS to fire surfaceCreated and surfaceChanged synchronously during Activity creation before BrowserStartupController initializes native Mojo thunks.

If surfaceCreated/surfaceChanged callbacks are forwarded immediately to C++ ContentViewRenderView before BrowserStartupController.startBrowserProcessesAsync() completes, native InitCompositor() is triggered prematurely, resulting in a fatal Mojo uninitialized crash (b/539880857).

This change checks BrowserStartupController.getInstance().isNativeStarted(). If native browser startup is in progress, WindowSurfaceBridge defers surface creation events and registers a BrowserStartupController.StartupCallback observer to dispatch the queued surface events safely once native Mojo initialization completes.

Issue: 539880857