### PR TITLE
android: Use Shell.TAG in Android shell classes

### DIFF
--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ContentViewRenderView.java
@@ -4,6 +4,8 @@
 
 package dev.cobalt.shell;
 
+import static dev.cobalt.shell.Shell.TAG;
+
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.PixelFormat;
@@ -32,7 +34,6 @@ import org.jni_zero.NativeMethods;
  */
 @JNINamespace("cobalt")
 public class ContentViewRenderView extends FrameLayout {
-    private static final String TAG = "cobalt";
 
     // The native side of this object.
     private long mNativeContentViewRenderView;

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/Shell.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/Shell.java
@@ -60,7 +60,7 @@ public class Shell {
         void onWebContentsReady();
     }
 
-    private static final String TAG = "cobalt";
+    public static final String TAG = "cobalt";
     private static final long COMPLETED_PROGRESS_TIMEOUT_MS = 200;
 
     // Stylus handwriting: Setting this ime option instructs stylus writing service to restrict

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/ShellManager.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/ShellManager.java
@@ -35,7 +35,6 @@ import org.jni_zero.NativeMethods;
 @JNINamespace("content")
 @NullMarked
 public class ShellManager {
-    private static final String TAG = "cobalt";
     private WindowAndroid mWindow;
     private @Nullable Shell mActiveShell;
 

--- a/cobalt/shell/android/java/src/dev/cobalt/shell/StartupGuard.java
+++ b/cobalt/shell/android/java/src/dev/cobalt/shell/StartupGuard.java
@@ -1,5 +1,7 @@
 package dev.cobalt.shell;
 
+import static dev.cobalt.shell.Shell.TAG;
+
 import android.os.Handler;
 import android.os.Looper;
 import android.util.Log;
@@ -30,7 +32,6 @@ public class StartupGuard {
         private static final StartupGuard INSTANCE = new StartupGuard();
     }
 
-    private static final String TAG = "cobalt";
 
     // Private constructor prevents direct instantiation from other classes
     private StartupGuard() {


### PR DESCRIPTION
This change consolidates the log TAG definition within the Android
shell package. By making Shell.TAG public and using static imports
in other classes like StartupGuard and ContentViewRenderView, we
remove redundant string literal definitions. This ensures
consistency in logging across these related components.

Issue: 539950432