### PR TITLE
Fix missing topic splash screen on cold start

### DIFF
--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -509,6 +509,8 @@ Shell* Shell::CreateNewWindow(BrowserContext* browser_context,
   GURL link_url;
   if (!deep_link.empty()) {
     link_url = GURL(deep_link);
+  } else if (url.is_valid()) {
+    link_url = url;
   } else if (base::CommandLine::ForCurrentProcess()->HasSwitch(
                  cobalt::switches::kInitialURL)) {
     link_url = GURL(base::CommandLine::ForCurrentProcess()->GetSwitchValueASCII(


### PR DESCRIPTION
Check url when deep_link is empty so the splash topic matches the page being loaded.

Shell::CreateNewWindow previously ignored the startup url parameter when checking for topic deep links.
On platforms where the startup URL is passed as a positional arg, this left splash_topic_ empty and showed the default splash screen instead of music_splash.

Bug: 535206265