### PR TITLE
rdk: Limit glibc M_ARENA_MAX to 2 in SbRunStarboardMain

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
@@ -30,6 +30,7 @@
 // limitations under the License.
 
 #include <gst/gst.h>
+#include <malloc.h>
 #include <signal.h>
 #include <sys/resource.h>
 
@@ -74,6 +75,16 @@ static void UninstallStopSignalHandlers() {
 }  // namespace starboard
 
 int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
+  // Set M_ARENA_MAX to 2 to limit fragmentation without single-arena lock contention.
+  mallopt(M_ARENA_MAX, 2);
+  // Return free memory at the top of the heap to the OS at 32 KB (vs 128 KB default).
+  mallopt(M_TRIM_THRESHOLD, 32768);
+  // Retain 32 KB resident padding after trimming (vs 128 KB default).
+  mallopt(M_TOP_PAD, 32768);
+  // Route >= 64 KB allocations via direct mmap/munmap (disabling dynamic threshold
+  // growth) to instantly return physical pages to the OS without VMA exhaustion.
+  mallopt(M_MMAP_THRESHOLD, 65536);
+
   tzset();
 
   rlimit stack_size;

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/run_starboard_main.cc
@@ -30,6 +30,8 @@
 // limitations under the License.
 
 #include <gst/gst.h>
+
+#include <malloc.h>
 #include <signal.h>
 #include <sys/resource.h>
 
@@ -93,6 +95,10 @@ static void UninstallStopSignalHandlers() {
 }  // namespace starboard
 
 int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
+
+  // Set M_ARENA_MAX to 2 to limit fragmentation without single-arena lock contention.
+  mallopt(M_ARENA_MAX, 2);
+
   tzset();
 
   rlimit stack_size;

--- a/starboard/linux/x64x11/run_starboard_main.cc
+++ b/starboard/linux/x64x11/run_starboard_main.cc
@@ -31,8 +31,18 @@
 #include "starboard/shared/x11/application_x11.h"
 
 int SbRunStarboardMain(int argc, char** argv, SbEventHandleCallback callback) {
-  // Set M_ARENA_MAX to a low value to slow memory growth due to fragmentation.
+  // Set M_ARENA_MAX to 2 to limit fragmentation without single-arena lock
+  // contention.
   mallopt(M_ARENA_MAX, 2);
+  // Return free memory at the top of the heap to the OS at 32 KB (vs 128 KB
+  // default).
+  mallopt(M_TRIM_THRESHOLD, 32768);
+  // Retain 32 KB resident padding after trimming (vs 128 KB default).
+  mallopt(M_TOP_PAD, 32768);
+  // Route >= 64 KB allocations via direct mmap/munmap (disabling dynamic
+  // threshold growth) to instantly return physical pages to the OS without VMA
+  // exhaustion.
+  mallopt(M_MMAP_THRESHOLD, 65536);
 
   tzset();
   starboard::InstallCrashSignalHandlers();


### PR DESCRIPTION
Configure glibc allocator knob M_ARENA_MAX to 2 in SbRunStarboardMain
 for RDK platforms, aligning with Linux x64x11.
    
 Limiting the maximum number of memory arenas reduces heap fragmentation
 and resident memory growth across threads without introducing lock
  contention. This will also reduce 3-4 MB memory usage.

Bug: 540878634