### PR TITLE
cobalt: Reset OnScreenKeyboardClient remote on disconnection

### DIFF
--- a/cobalt/browser/on_screen_keyboard/on_screen_keyboard_impl.cc
+++ b/cobalt/browser/on_screen_keyboard/on_screen_keyboard_impl.cc
@@ -54,6 +54,7 @@ void OnScreenKeyboardImpl::Bind(
 void OnScreenKeyboardImpl::RegisterClient(
     mojo::PendingRemote<mojom::OnScreenKeyboardClient> client) {
   on_screen_keyboard_client_.Bind(std::move(client));
+  on_screen_keyboard_client_.reset_on_disconnect();
 }
 
 void OnScreenKeyboardImpl::Show(const std::string& text,


### PR DESCRIPTION
Switching user profiles triggers a new navigation, which means and all previous Mojo connections from Blink are reset.

On the browser side, this was not being accounted for and `on_screen_keyboard_client_` remained bound (OnScreenKeyboardImpl is per-WebContents), leading to a crash in debug builds (in release builds search just stopped working).

Fixed: 540983932