### PR TITLE
ci: Trigger staging workflows on autoroll-chromium/main-to-staging PRs

### DIFF
--- a/.github/workflows/android_staging.yaml
+++ b/.github/workflows/android_staging.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, labeled, ready_for_review]
     branches:
       - staging
+      - autoroll-chromium/main-to-staging
   push:
     branches:
       - staging

--- a/.github/workflows/evergreen_staging.yaml
+++ b/.github/workflows/evergreen_staging.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, labeled, ready_for_review]
     branches:
       - staging
+      - autoroll-chromium/main-to-staging
   push:
     branches:
       - staging

--- a/.github/workflows/lint_staging.yaml
+++ b/.github/workflows/lint_staging.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, edited, reopened, synchronize]
     branches:
       - staging
+      - autoroll-chromium/main-to-staging
   push:
     branches:
       - staging

--- a/.github/workflows/linux_staging.yaml
+++ b/.github/workflows/linux_staging.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, labeled]
     branches:
       - staging
+      - autoroll-chromium/main-to-staging
   push:
     branches:
       - staging

--- a/.github/workflows/tvos_staging.yaml
+++ b/.github/workflows/tvos_staging.yaml
@@ -5,6 +5,7 @@ on:
     types: [opened, reopened, synchronize, labeled]
     branches:
       - staging
+      - autoroll-chromium/main-to-staging
   push:
     branches:
       - staging


### PR DESCRIPTION
Add `autoroll-chromium/main-to-staging` to the `pull_request` branches trigger across staging workflows (`android_staging.yaml`, `evergreen_staging.yaml`, `lint_staging.yaml`, `linux_staging.yaml`, and `tvos_staging.yaml`) so CI workflows automatically execute on pull requests targeting the autoroll branch.

TAG=agy
CONV=0be04d5a-f59a-498e-b2d1-79d785d28c2d
Bug: 541228840