### PR TITLE
[rdk] Use dladdr() for GetExecutablePath to fix Crashpad pathing

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_path.cc
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/shared/system/system_get_path.cc
@@ -18,6 +18,7 @@
 #include <sys/types.h>
 #include <unistd.h>
 #include <dirent.h>
+#include <dlfcn.h>
 
 #include <cstdlib>
 #include <cstring>
@@ -61,24 +62,29 @@ bool GetEvergreenContentPathOverride(char* out_path, int path_size) {
 // executable in |out_path|, ensuring it is NULL-terminated. Returns success
 // status. The result being greater than |path_size| - 1 characters is a
 // failure. |out_path| may be written to in unsuccessful cases.
+//
+// NOTE: Depending on the environment, the executing module resolved here
+// can dynamically point to three distinct types:
+// 1. Plugin mode: The shared library file (e.g., libloader_app.so)
+// 2. Executable mode: The standalone executable (e.g., loader_app)
+// 3. Test mode: The native test binary (e.g., elf_loader_sandbox)
 bool GetExecutablePath(char* out_path, int path_size) {
   if (path_size < 1) {
     return false;
   }
 
-  char path[kSbFileMaxPath + 1];
-  ssize_t bytes_read = readlink("/proc/self/exe", path, kSbFileMaxPath);
-  if (bytes_read < 1) {
-    return false;
+  Dl_info info;
+  // Use dladdr to find the absolute path of the binary we are currently executing in.
+  if (dladdr(reinterpret_cast<void*>(&GetExecutablePath), &info) && info.dli_fname) {
+    std::vector<char> absolute_path(kSbFileMaxPath);
+    if (realpath(info.dli_fname, absolute_path.data()) != nullptr) {
+      if (starboard::strlcpy<char>(out_path, absolute_path.data(), path_size) < path_size) {
+        return true;
+      }
+    }
   }
 
-  path[bytes_read] = '\0';
-  if (bytes_read > path_size) {
-    return false;
-  }
-
-  starboard::strlcpy<char>(out_path, path, path_size);
-  return true;
+  return false;
 }
 
 // Places up to |path_size| - 1 characters of the path to the directory


### PR DESCRIPTION
starboard RDK: Use dladdr for executable path

In WPEFramework environments, the standard process executable link
points to the host daemon instead of the loaded Cobalt plugin. This
mismatch prevents Crashpad from locating its handler binary during
initialization. Resolving the path based on the memory layout of the
executing module ensures the correct directory is identified across
different deployment modes, including plugins and standalone tests.

Bug: 540925401
TAG=agy
CONV=d1544c3d-8271-4f8b-b3e6-9027a5dfb453