### PR TITLE
aosp: create the basic machinery for starting-up and rendering the cobalt app

### DIFF
--- a/.gn
+++ b/.gn
@@ -176,6 +176,7 @@ exec_script_allowlist += [
   "//starboard/build/config/sabi/BUILD.gn",
   "//starboard/build/platform_path.gni",
   "//starboard/content/fonts/BUILD.gn",
+  "//cobalt/aosp/modular_apk.gni",
 ]
 
 # TODO(cobalt, b/377295011): figure out a better long-term solution here, or

--- a/cobalt/aosp/apk/app/java/dev/cobalt/app/MainActivity.java
+++ b/cobalt/aosp/apk/app/java/dev/cobalt/app/MainActivity.java
@@ -17,6 +17,9 @@ package dev.cobalt.app;
 import android.app.Activity;
 import android.app.Service;
 import android.os.Bundle;
+import android.view.Surface;
+import android.view.SurfaceHolder;
+import android.view.SurfaceView;
 import dev.cobalt.coat.BaseCobaltActivity;
 import dev.cobalt.coat.BaseStarboardBridge;
 import dev.cobalt.coat.CobaltService;
@@ -58,23 +61,71 @@ public class MainActivity extends BaseCobaltActivity {
   interface Natives {
     // Spawns the loader thread, whose main() runs the app loader.
     void startLoader();
+    // The dedicated graphics SurfaceView publishes its Surface to Starboard; its
+    // ANativeWindow backs the inner library's Ozone SbWindow (see main_activity.cc).
+    void nativeOnSurfaceCreated(Surface surface);
+    void nativeOnSurfaceDestroyed();
   }
+
+  // Starboard is booted exactly once, gated on the graphics surface existing.
+  private boolean mStarboardStarted;
 
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
 
     String startDeepLink = getIntentUrlAsString(getIntent());
-    if (getStarboardBridge() == null) {
+    boolean coldStart = getStarboardBridge() == null;
+    if (coldStart) {
       // Cold start - Instantiate the singleton BaseStarboardBridge.
       BaseStarboardBridge starboardBridge = createStarboardBridge(getArgs(), startDeepLink);
       ((BaseStarboardBridge.HostApplication) getApplication()).setStarboardBridge(starboardBridge);
-      // Spawn the loader thread.
-      MainActivityJni.get().startLoader();
     } else if (savedInstanceState == null) {
       // Warm start - Pass the deep link to the running Starboard app.
       getStarboardBridge().handleDeepLink(startDeepLink);
     }
+
+    // Platform AudioSink init is deferred together with the rest of the media subsystem.
+    // initializePlatformAudioSink() runs SbAudioSinkImpl's startup min-frames probe, whose render
+    // thread reads a Starboard FeatureList feature (kReleaseVideoFramesAfterAudioStarts) before
+    // anything initializes the list. The list lives in the loader (Android toolchain) and nplb's
+    // inner lib (Linux toolchain) can't seed it, so the probe aborts. The media/audio/player/drm
+    // nplb tests that actually need the sink are excluded via the gtest filter, so the sink isn't
+    // needed yet. Re-enable this (and initialize the FeatureList) when the media subsystem is
+    // brought up.
+    // getStarboardBridge().initializePlatformAudioSink();
+
+    // The inner libcobalt is Linux and renders through Ozone-Starboard, whose SbWindowCreate()
+    // needs a real on-screen ANativeWindow. Provide one via a dedicated graphics SurfaceView, and
+    // gate the native Starboard boot on surfaceCreated so SbWindowCreate() finds the surface
+    // synchronously (the x11/raspi modular platforms always have a display; here we wait for the
+    // Android view system to hand us one). Any state native code touches in startup must be
+    // initialized above first. The loader is spawned only on cold start (a warm start reuses the
+    // already-running Starboard process).
+    SurfaceView surfaceView = new SurfaceView(this);
+    surfaceView
+        .getHolder()
+        .addCallback(
+            new SurfaceHolder.Callback() {
+              @Override
+              public void surfaceCreated(SurfaceHolder holder) {
+                MainActivityJni.get().nativeOnSurfaceCreated(holder.getSurface());
+                if (coldStart && !mStarboardStarted) {
+                  mStarboardStarted = true;
+                  // Spawn the loader thread.
+                  MainActivityJni.get().startLoader();
+                }
+              }
+
+              @Override
+              public void surfaceChanged(SurfaceHolder holder, int format, int width, int height) {}
+
+              @Override
+              public void surfaceDestroyed(SurfaceHolder holder) {
+                MainActivityJni.get().nativeOnSurfaceDestroyed();
+              }
+            });
+    setContentView(surfaceView);
   }
 
   @Override

--- a/cobalt/aosp/modular_apk.gni
+++ b/cobalt/aosp/modular_apk.gni
@@ -14,6 +14,7 @@
 
 import("//build/config/android/rules.gni")
 import("//cobalt/android/manifest.gni")
+import("//starboard/content/fonts/variables.gni")
 import("//starboard/content/ssl/certs.gni")
 
 template("modular_apk") {
@@ -31,19 +32,10 @@ template("modular_apk") {
     forward_variables_from(invoker, [ "testonly" ])
     disable_compression = true
 
-    renaming_sources = [
-      "$root_build_dir/app/${_name}/content/fonts/fonts.xml",
-      "$root_build_dir/app/${_name}/lib/${_lib_name}.lz4",
-    ]
-    renaming_destinations = [
-      "app/cobalt/content/fonts/fonts.xml",
-      "app/cobalt/lib/${_lib_name}.lz4",
-    ]
+    renaming_sources = [ "$root_build_dir/app/${_name}/lib/${_lib_name}.lz4" ]
+    renaming_destinations = [ "app/cobalt/lib/${_lib_name}.lz4" ]
 
-    deps = [
-      ":copy_${_name}_empty_fonts($default_toolchain)",
-      ":copy_${_name}_lib($default_toolchain)",
-    ]
+    deps = [ ":copy_${_name}_lib($default_toolchain)" ]
 
     # CA certificates, packaged under the content directory. The inner library's
     # TLS trust store (net::TrustStoreInMemoryStarboard) reads
@@ -59,8 +51,46 @@ template("modular_apk") {
     deps += [ "//starboard/content/ssl:copy_ssl_certificates_evergreen($default_toolchain)" ]
 
     if (_name == "cobalt") {
-      sources = [ "$root_build_dir/cobalt_shell.pak" ]
+      # Bundle a real, self-contained font set with the cobalt app so
+      # SkFontMgr_Cobalt has actual families
+      _fonts_root = "//starboard/content/fonts"
+      _font_config = "$_fonts_root/$source_font_config_dir/fonts.xml"
+      _font_files_dir = "$_fonts_root/$source_font_files_dir"
+
+      # Reuse the filtered fonts.xml produced by the shared fonts_xml action
+      renaming_sources += [ "$root_build_dir/fonts/fonts.xml" ]
+      renaming_destinations += [ "app/cobalt/content/fonts/fonts.xml" ]
+      deps += [ "$_fonts_root:fonts_xml($default_toolchain)" ]
+
+      # Enumerate the font files the package selects so each maps into the APK's
+      # content dir (the woff2 files themselves are checked-in sources).
+      _font_files = exec_script("$_fonts_root/scripts/filter_fonts.py",
+                                [
+                                      "-i",
+                                      rebase_path(_font_config, root_build_dir),
+                                      "-f",
+                                      _font_files_dir,
+                                    ] + package_categories,
+                                "trim list lines",
+                                [ _font_config ])
+      foreach(_font, _font_files) {
+        _font_file = get_path_info(_font, "file")
+        renaming_sources += [ "$_font_files_dir/$_font_file" ]
+        renaming_destinations += [ "app/cobalt/content/fonts/$_font_file" ]
+      }
+
+      # Package the resource pak under the content directory (like fonts), so
+      # cobalt can find it via base::DIR_ASSETS
+      renaming_sources += [ "$root_build_dir/cobalt_shell.pak" ]
+      renaming_destinations += [ "app/cobalt/content/cobalt_shell.pak" ]
+
       deps += [ "//cobalt/shell:pak($default_toolchain)" ]
+    } else {
+      # nplb and other non-rendering modules keep the empty placeholder fonts.xml.
+      renaming_sources +=
+          [ "$root_build_dir/app/${_name}/content/fonts/fonts.xml" ]
+      renaming_destinations += [ "app/cobalt/content/fonts/fonts.xml" ]
+      deps += [ ":copy_${_name}_empty_fonts($default_toolchain)" ]
     }
 
     if (_name == "nplb") {

--- a/cobalt/aosp/modular_apk.gni
+++ b/cobalt/aosp/modular_apk.gni
@@ -14,6 +14,7 @@
 
 import("//build/config/android/rules.gni")
 import("//cobalt/android/manifest.gni")
+import("//starboard/content/ssl/certs.gni")
 
 template("modular_apk") {
   _name = invoker.module_name
@@ -43,6 +44,19 @@ template("modular_apk") {
       ":copy_${_name}_empty_fonts($default_toolchain)",
       ":copy_${_name}_lib($default_toolchain)",
     ]
+
+    # CA certificates, packaged under the content directory. The inner library's
+    # TLS trust store (net::TrustStoreInMemoryStarboard) reads
+    # base::DIR_EXE/ssl/certs; base::DIR_EXE resolves to
+    # SbSystemGetPath(kSbSystemPathContentDirectory), i.e. the Evergreen content
+    # path (/cobalt/assets/app/cobalt/content) — see the content-dir fix in
+    # system_get_path.cc — so package the certs at <content>/ssl/certs to match.
+    foreach(_cert, network_certs) {
+      _cert_file = get_path_info(_cert, "file")
+      renaming_sources += [ "$root_build_dir/ssl/certs/$_cert_file" ]
+      renaming_destinations += [ "app/cobalt/content/ssl/certs/$_cert_file" ]
+    }
+    deps += [ "//starboard/content/ssl:copy_ssl_certificates_evergreen($default_toolchain)" ]
 
     if (_name == "cobalt") {
       sources = [ "$root_build_dir/cobalt_shell.pak" ]

--- a/cobalt/app/cobalt.cc
+++ b/cobalt/app/cobalt.cc
@@ -18,6 +18,13 @@
 #include "cobalt/app/app_event_delegate.h"
 #include "starboard/event.h"
 
+namespace {
+// Probe callback for the SbEventSchedule capability check in SbEventHandle().
+// It is never actually invoked: the scheduled event is cancelled before the
+// Starboard loop gets a chance to dispatch it.
+void NoopScheduledEvent(void* /*context*/) {}
+}  // namespace
+
 void SbEventHandle(const SbEvent* event) {
   // This object's lifetime extends beyond the function's lifetime, until the
   // function is called with kSbEventTypeStop at some time in the future.
@@ -31,6 +38,33 @@ void SbEventHandle(const SbEvent* event) {
     LOG(WARNING) << "Received spurious SbEventHandle(type = " << event->type
                  << ") call after kSbEventTypeStop, ignoring.";
     return;
+  }
+
+  if (event->type == kSbEventTypeStart) {
+    // Most Starboard platforms run their own application event loop and pump
+    // Chromium via SbEventSchedule, so this callback must return for that loop
+    // to keep running. Some platforms (e.g. AOSP/Evergreen-on-Android) have no
+    // Starboard event loop and stub out SbEventSchedule; there, RunProcess()
+    // initializes the browser but nothing ever pumps it, leaving the app stuck
+    // in the started state without rendering. Detect that case by probing
+    // SbEventSchedule: when scheduling is unavailable, run the Chromium UI
+    // message loop here, in the started state. MessagePumpUIStarboard::Run() is
+    // self-contained (DoWork + wakeup_event_) and needs no SbEventSchedule.
+    // This blocks until the app stops.
+    SbEventId probe =
+        SbEventSchedule(&NoopScheduledEvent, nullptr, /*delay_usec=*/0);
+    if (probe == kSbEventIdInvalid) {
+      // No Starboard event loop drives this callback, so initialize the browser
+      // here before pumping: HandleEvent() -> OnStart() -> RunProcess() both sets
+      // up this thread's task environment (which base::RunLoop requires) and posts
+      // the initial browser work for the loop below to run.
+      s_lifecycle_delegate->HandleEvent(event);
+      base::RunLoop run_loop;
+      run_loop.Run();
+      return;
+    }
+    // The platform drives its own loop; drop the probe event and return.
+    SbEventCancel(probe);
   }
 
   if (event->type == kSbEventTypeStop) {

--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -77,6 +77,10 @@ CommandLinePreprocessor::GetCobaltToggleSwitches() {
       ::switches::kDisableAcceleratedVideoEncode,
       // Force to use dark mode.
       ::switches::kForceDarkMode,
+#if BUILDFLAG(IS_ANDROID)
+      // Force full-frame redraws until buffer preservation is wired up.
+      ::switches::kUIDisablePartialSwap,
+#endif
       // Hide scrollbars to avoid memory allocation.
       ::switches::kHideScrollbars,
   };

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -218,7 +218,6 @@ static_library("starboard_platform") {
     "player_set_video_surface_view.h",
 
     # TODO: b/374300500 - posix_emu things should not be used on Android anymore
-    # "posix_emu/dirent.cc",
     # "posix_emu/pthread.cc",
 
     "runtime_resource_overlay.cc",
@@ -349,6 +348,7 @@ static_library("starboard_platform") {
       "asset_manager.cc",
       "asset_manager.h",
       "posix_emu/access.cc",
+      "posix_emu/dirent.cc",
       "posix_emu/errno.cc",
       "posix_emu/file.cc",
       "posix_emu/net_if.cc",

--- a/starboard/android/shared/BUILD.gn
+++ b/starboard/android/shared/BUILD.gn
@@ -337,11 +337,15 @@ static_library("starboard_platform") {
       "//starboard/shared/stub/speech_synthesis_speak.cc",
       "//starboard/shared/stub/system_network_is_disconnected.cc",
       "//starboard/shared/stub/system_raise_platform_error.cc",
-      "//starboard/shared/stub/window_create.cc",
-      "//starboard/shared/stub/window_destroy.cc",
+
+      # Real Ozone window family for AOSP: the graphics SurfaceView feeds an
+      # ANativeWindow to window_surface.cc, which implements
+      # SbWindowCreate/Destroy/GetPlatformHandle/GetSize. The AndroidTV
+      # window_*.cc files can't be reused: SbWindowCreate/Destroy delegate to
+      # ApplicationAndroid (never instantiated on AOSP) and window_get_size.cc
+      # needs media/device-resolution bring-up AOSP lacks. Diagonal size stays
+      # stubbed for now.
       "//starboard/shared/stub/window_get_diagonal_size_in_inches.cc",
-      "//starboard/shared/stub/window_get_platform_handle.cc",
-      "//starboard/shared/stub/window_get_size.cc",
       "asset_manager.cc",
       "asset_manager.h",
       "posix_emu/access.cc",
@@ -349,6 +353,9 @@ static_library("starboard_platform") {
       "posix_emu/file.cc",
       "posix_emu/net_if.cc",
       "posix_emu/stat.cc",
+      "window_internal.h",
+      "window_surface.cc",
+      "window_surface.h",
     ]
 
     public_deps += [

--- a/starboard/android/shared/asset_manager.cc
+++ b/starboard/android/shared/asset_manager.cc
@@ -24,6 +24,8 @@
 #include <unistd.h>
 
 #include <mutex>
+#include <utility>
+#include <vector>
 
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/check_op.h"
@@ -144,6 +146,59 @@ int AssetManager::Close(int fd) {
 bool AssetManager::IsAssetFd(int fd) const {
   std::lock_guard scoped_lock(mutex_);
   return fd_to_internal_fd_map_.count(fd) == 1;
+}
+
+int AssetManager::OpenDirectory(const char* path) {
+  if (!path) {
+    return -1;
+  }
+
+  std::vector<std::string> entries = ListAndroidAssetDir(path);
+  if (entries.empty()) {
+    errno = ENOENT;
+    return -1;
+  }
+
+  // Reserve a real, unique fd so it can be closed like any other fd.
+  // It is never read but serves as a key to hold the directory entries
+  // and the open/closed state.
+  int fd = open("/dev/null", O_RDONLY);
+  if (fd < 0) {
+    return -1;
+  }
+
+  std::lock_guard scoped_lock(mutex_);
+  dir_fd_to_entries_map_[fd] = std::move(entries);
+  return fd;
+}
+
+int AssetManager::CloseDirectory(int fd) {
+  {
+    std::lock_guard scoped_lock(mutex_);
+    auto search = dir_fd_to_entries_map_.find(fd);
+    if (search == dir_fd_to_entries_map_.end()) {
+      return -1;
+    }
+    dir_fd_to_entries_map_.erase(search);
+  }  // Can't hold lock when calling close();
+  return close(fd);
+}
+
+bool AssetManager::IsAssetDirFd(int fd) const {
+  std::lock_guard scoped_lock(mutex_);
+  return dir_fd_to_entries_map_.count(fd) == 1;
+}
+
+bool AssetManager::GetDirectoryEntries(
+    int fd,
+    std::vector<std::string>* entries) const {
+  std::lock_guard scoped_lock(mutex_);
+  auto search = dir_fd_to_entries_map_.find(fd);
+  if (search == dir_fd_to_entries_map_.end()) {
+    return false;
+  }
+  *entries = search->second;
+  return true;
 }
 
 AssetManager::AssetManager() {

--- a/starboard/android/shared/asset_manager.h
+++ b/starboard/android/shared/asset_manager.h
@@ -19,6 +19,7 @@
 #include <mutex>
 #include <set>
 #include <string>
+#include <vector>
 
 namespace starboard {
 
@@ -29,6 +30,11 @@ class AssetManager {
   int Open(const char* path, int oflag);
   int Close(int fd);
   bool IsAssetFd(int fd) const;
+
+  int OpenDirectory(const char* path);
+  int CloseDirectory(int fd);
+  bool IsAssetDirFd(int fd) const;
+  bool GetDirectoryEntries(int fd, std::vector<std::string>* entries) const;
 
  private:
   AssetManager();
@@ -42,6 +48,8 @@ class AssetManager {
   uint64_t internal_fd_ = 0;                       // Guarded by |mutex_|.
   std::set<uint64_t> in_use_internal_fd_set_;      // Guarded by |mutex_|.
   std::map<int, uint64_t> fd_to_internal_fd_map_;  // Guarded by |mutex_|.
+  // Maps a reserved placeholder fd to the asset directory entries
+  std::map<int, std::vector<std::string>> dir_fd_to_entries_map_;
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/file_internal.cc
+++ b/starboard/android/shared/file_internal.cc
@@ -17,6 +17,10 @@
 #include <android/asset_manager_jni.h>
 #include <android/log.h>
 
+#include <vector>
+
+#include "base/android/jni_array.h"
+#include "base/android/jni_string.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
@@ -108,35 +112,36 @@ AAsset* OpenAndroidAsset(const char* path) {
   return AAssetManager_open(g_asset_manager, asset_path, AASSET_MODE_RANDOM);
 }
 
-AAssetDir* OpenAndroidAssetDir(const char* path) {
-  // Note that the asset directory will not be found if |path| points to a
-  // specific file instead of a directory. |path| should also not end with '/'.
-  if (!IsAndroidAssetPath(path) || g_asset_manager == NULL) {
-    return NULL;
+std::vector<std::string> ListAndroidAssetDir(const char* path) {
+  std::vector<std::string> names;
+  if (!IsAndroidAssetPath(path) || g_java_asset_manager.is_null()) {
+    return names;
   }
   const char* asset_path = path + strlen(g_app_assets_dir);
   if (*asset_path == '/') {
     asset_path++;
   }
-  AAssetDir* asset_directory =
-      AAssetManager_openDir(g_asset_manager, asset_path);
 
-  // AAssetManager_openDir() always returns a pointer to an initialized object,
-  // even if the given directory does not exist. To determine if the directory
-  // actually exists, AAssetDir_getNextFileName() is called to check for any
-  // files in the given directory. However, when iterating the contents of a
-  // directory, the NDK Asset Manager does not allow subdirectories to be seen.
-  // So this is not a 100% accurate way to determine if a directory actually
-  // exists and false negatives will be given for directories that contain
-  // subdirectories but no files in their immediate directory.
-  const char* file = AAssetDir_getNextFileName(asset_directory);
-  if (file == NULL) {
-    AAssetDir_close(asset_directory);
-    return NULL;
-  } else {
-    AAssetDir_rewind(asset_directory);
-    return asset_directory;
+  JNIEnv* env = jni_zero::AttachCurrentThread();
+  jni_zero::ScopedJavaLocalRef<jclass> asset_manager_class =
+      jni_zero::GetClass(env, "android/content/res/AssetManager");
+  jmethodID list_method =
+      jni_zero::MethodID::Get<jni_zero::MethodID::TYPE_INSTANCE>(
+          env, asset_manager_class.obj(), "list",
+          "(Ljava/lang/String;)[Ljava/lang/String;");
+  jni_zero::ScopedJavaLocalRef<jstring> j_asset_path =
+      base::android::ConvertUTF8ToJavaString(env, asset_path);
+  jni_zero::ScopedJavaLocalRef<jobjectArray> j_names =
+      jni_zero::ScopedJavaLocalRef<jobjectArray>::Adopt(
+          env,
+          static_cast<jobjectArray>(env->CallObjectMethod(
+              g_java_asset_manager.obj(), list_method, j_asset_path.obj())));
+  // On error, return "no entries".
+  if (jni_zero::ClearException(env) || j_names.is_null()) {
+    return names;
   }
+  base::android::AppendJavaStringArrayToStringVector(env, j_names, &names);
+  return names;
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/file_internal.h
+++ b/starboard/android/shared/file_internal.h
@@ -20,6 +20,7 @@
 #include <jni.h>
 
 #include <string>
+#include <vector>
 
 #include "starboard/android/shared/starboard_bridge.h"
 #include "starboard/shared/internal_only.h"
@@ -53,7 +54,8 @@ void SbFileAndroidTeardown();
 
 bool IsAndroidAssetPath(const char* path);
 AAsset* OpenAndroidAsset(const char* path);
-AAssetDir* OpenAndroidAssetDir(const char* path);
+
+std::vector<std::string> ListAndroidAssetDir(const char* path);
 
 }  // namespace starboard
 

--- a/starboard/android/shared/posix_emu/dirent.cc
+++ b/starboard/android/shared/posix_emu/dirent.cc
@@ -16,18 +16,64 @@
 #include <dirent.h>
 // clang-format on
 
-#include <android/asset_manager.h>
+#include <errno.h>
+#include <string.h>
 
-#include <map>
 #include <mutex>
+#include <set>
+#include <string>
+#include <utility>
+#include <vector>
 
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/string.h"
-#include "starboard/configuration_constants.h"
 
 using starboard::IsAndroidAssetPath;
-using starboard::OpenAndroidAsset;
-using starboard::OpenAndroidAssetDir;
+using starboard::ListAndroidAssetDir;
+
+namespace {
+
+// A helper structure used internally as a DIR replacement for asset paths.
+// It's used in the wrapped opendir/closedir/readdir/readdir_r.
+struct AndroidAssetDir {
+  std::vector<std::string> entries;
+  size_t index;
+  struct dirent entry;
+};
+
+// Registry of the DIR* handles created by the asset-path wrappers below.
+std::mutex& GetAssetDirMutex() {
+  static std::mutex* mutex = new std::mutex();
+  return *mutex;
+}
+
+std::set<const AndroidAssetDir*>& GetActiveAssetDirs() {
+  static std::set<const AndroidAssetDir*>* dirs =
+      new std::set<const AndroidAssetDir*>();
+  return *dirs;
+}
+
+void RegisterAssetDir(const AndroidAssetDir* dir) {
+  std::lock_guard lock(GetAssetDirMutex());
+  GetActiveAssetDirs().insert(dir);
+}
+
+bool UnregisterAssetDir(const AndroidAssetDir* dir) {
+  std::lock_guard lock(GetAssetDirMutex());
+  return GetActiveAssetDirs().erase(dir) > 0;
+}
+
+bool IsAssetDir(const AndroidAssetDir* dir) {
+  std::lock_guard lock(GetAssetDirMutex());
+  return GetActiveAssetDirs().count(dir) > 0;
+}
+
+void FillAssetDirent(const std::string& name, struct dirent* out) {
+  memset(out, 0, sizeof(*out));
+  starboard::strlcpy(out->d_name, name.c_str(), sizeof(out->d_name));
+}
+
+}  // namespace
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementations below exposed externally in pure C for emulation.
@@ -38,99 +84,37 @@ DIR* __real_opendir(const char* path);
 
 int __real_closedir(DIR* dir);
 
+struct dirent* __real_readdir(DIR* dir);
+
 int __real_readdir_r(DIR* __restrict dir,
                      struct dirent* __restrict dirent_buf,
                      struct dirent** __restrict dirent);
-
-// AAssetDir does not have a file descriptor so we must generate one
-// https://android.googlesource.com/platform/frameworks/base/+/master/native/android/asset_manager.cpp
-static int gen_fd() {
-  static int fd = 100;
-  fd++;
-  if (fd == 0x7FFFFFFF) {
-    fd = 100;
-  }
-  return fd;
-}
-
-std::mutex mutex_;
-static std::map<int, AAssetDir*>* asset_map = nullptr;
-
-static int handle_db_put(AAssetDir* assetDir) {
-  std::lock_guard scoped_lock(mutex_);
-  if (asset_map == nullptr) {
-    asset_map = new std::map<int, AAssetDir*>();
-  }
-
-  int fd = gen_fd();
-  // Go through the map and make sure there isn't duplicated index
-  // already.
-  while (asset_map->find(fd) != asset_map->end()) {
-    fd = gen_fd();
-  }
-  asset_map->insert({fd, assetDir});
-
-  return fd;
-}
-
-static AAssetDir* handle_db_get(int fd, bool erase) {
-  std::lock_guard scoped_lock(mutex_);
-  if (fd < 0) {
-    return nullptr;
-  }
-  if (asset_map == nullptr) {
-    return nullptr;
-  }
-
-  auto itr = asset_map->find(fd);
-  if (itr == asset_map->end()) {
-    return nullptr;
-  }
-
-  AAssetDir* asset_dir = itr->second;
-  if (erase) {
-    asset_map->erase(itr);
-  }
-  return asset_dir;
-}
-
-struct _PosixEmuAndroidAssetDir {
-  int64_t magic;
-  int fd;
-};
-
-constexpr int64_t kMagicNum = -1;
 
 DIR* __wrap_opendir(const char* path) {
   if (!IsAndroidAssetPath(path)) {
     return __real_opendir(path);
   }
 
-  AAssetDir* asset_dir = OpenAndroidAssetDir(path);
-  if (asset_dir) {
-    int descriptor = handle_db_put(asset_dir);
-    struct _PosixEmuAndroidAssetDir* retdir =
-        reinterpret_cast<_PosixEmuAndroidAssetDir*>(
-            malloc(sizeof(struct _PosixEmuAndroidAssetDir)));
-    retdir->magic = kMagicNum;
-    retdir->fd = descriptor;
-    return reinterpret_cast<DIR*>(retdir);
+  std::vector<std::string> entries = ListAndroidAssetDir(path);
+  if (entries.empty()) {
+    errno = ENOENT;
+    return NULL;
   }
-  return NULL;
+
+  AndroidAssetDir* retdir = new AndroidAssetDir();
+  retdir->entries = std::move(entries);
+  retdir->index = 0;
+  RegisterAssetDir(retdir);
+  return reinterpret_cast<DIR*>(retdir);
 }
 
 int __wrap_closedir(DIR* dir) {
   if (!dir) {
     return -1;
   }
-  struct _PosixEmuAndroidAssetDir* adir = (struct _PosixEmuAndroidAssetDir*)dir;
-  if (adir->magic == kMagicNum) {  // This is an Asset
-    int descriptor = adir->fd;
-    AAssetDir* asset_dir = handle_db_get(descriptor, true);
-    if (asset_dir != nullptr) {
-      AAssetDir_close(asset_dir);
-    }
-    free(adir);
+  AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+  if (UnregisterAssetDir(asset_dir)) {
+    delete asset_dir;
     return 0;
   }
   return __real_closedir(dir);
@@ -143,20 +127,36 @@ int __wrap_readdir_r(DIR* __restrict dir,
     return -1;
   }
 
-  struct _PosixEmuAndroidAssetDir* adir = (struct _PosixEmuAndroidAssetDir*)dir;
-  if (adir->magic == kMagicNum) {  // This is an Asset
-    int descriptor = adir->fd;
-    AAssetDir* asset_dir = handle_db_get(descriptor, false);
-    const char* file_name = AAssetDir_getNextFileName(asset_dir);
-    if (file_name == NULL) {
-      return -1;
+  AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+  if (IsAssetDir(asset_dir)) {
+    if (asset_dir->index >= asset_dir->entries.size()) {
+      *dirent = NULL;  // End of directory
+      return 0;
     }
+    FillAssetDirent(asset_dir->entries[asset_dir->index++], dirent_buf);
     *dirent = dirent_buf;
-    starboard::strlcpy((*dirent)->d_name, file_name, kSbFileMaxName);
     return 0;
   }
 
   return __real_readdir_r(dir, dirent_buf, dirent);
+}
+
+struct dirent* __wrap_readdir(DIR* dir) {
+  if (!dir) {
+    errno = EBADF;
+    return NULL;
+  }
+
+  AndroidAssetDir* asset_dir = reinterpret_cast<AndroidAssetDir*>(dir);
+  if (IsAssetDir(asset_dir)) {
+    if (asset_dir->index >= asset_dir->entries.size()) {
+      return NULL;
+    }
+    FillAssetDirent(asset_dir->entries[asset_dir->index++], &asset_dir->entry);
+    return &asset_dir->entry;
+  }
+
+  return __real_readdir(dir);
 }
 
 }  // extern "C"

--- a/starboard/android/shared/posix_emu/dirent.cc
+++ b/starboard/android/shared/posix_emu/dirent.cc
@@ -25,16 +25,18 @@
 #include <utility>
 #include <vector>
 
+#include "starboard/android/shared/asset_manager.h"
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/string.h"
 
+using starboard::AssetManager;
 using starboard::IsAndroidAssetPath;
 using starboard::ListAndroidAssetDir;
 
 namespace {
 
 // A helper structure used internally as a DIR replacement for asset paths.
-// It's used in the wrapped opendir/closedir/readdir/readdir_r.
+// It's used in the wrapped opendir/fdopendir/closedir/readdir/readdir_r.
 struct AndroidAssetDir {
   std::vector<std::string> entries;
   size_t index;
@@ -82,6 +84,8 @@ void FillAssetDirent(const std::string& name, struct dirent* out) {
 extern "C" {
 DIR* __real_opendir(const char* path);
 
+DIR* __real_fdopendir(int fd);
+
 int __real_closedir(DIR* dir);
 
 struct dirent* __real_readdir(DIR* dir);
@@ -100,6 +104,25 @@ DIR* __wrap_opendir(const char* path) {
     errno = ENOENT;
     return NULL;
   }
+
+  AndroidAssetDir* retdir = new AndroidAssetDir();
+  retdir->entries = std::move(entries);
+  retdir->index = 0;
+  RegisterAssetDir(retdir);
+  return reinterpret_cast<DIR*>(retdir);
+}
+
+DIR* __wrap_fdopendir(int fd) {
+  AssetManager* asset_manager = AssetManager::GetInstance();
+  if (!asset_manager->IsAssetDirFd(fd)) {
+    return __real_fdopendir(fd);
+  }
+
+  std::vector<std::string> entries;
+  asset_manager->GetDirectoryEntries(fd, &entries);
+  // The reserved fd is only a placeholder used as a key, it can be
+  // closed now that the entries have been already captured.
+  asset_manager->CloseDirectory(fd);
 
   AndroidAssetDir* retdir = new AndroidAssetDir();
   retdir->entries = std::move(entries);

--- a/starboard/android/shared/posix_emu/file.cc
+++ b/starboard/android/shared/posix_emu/file.cc
@@ -50,6 +50,9 @@ int __wrap_close(int fildes) {
   if (asset_manager->IsAssetFd(fildes)) {
     return asset_manager->Close(fildes);
   }
+  if (asset_manager->IsAssetDirFd(fildes)) {
+    return asset_manager->CloseDirectory(fildes);
+  }
   return __real_close(fildes);
 }
 
@@ -63,6 +66,10 @@ int __wrap_openat(int dirfd, const char* path, int oflag, ...) {
       return __real_openat(dirfd, path, oflag, mode);
     }
     return __real_openat(dirfd, path, oflag);
+  }
+  // handle asset paths
+  if ((oflag & O_DIRECTORY) == O_DIRECTORY) {
+    return AssetManager::GetInstance()->OpenDirectory(path);
   }
   return AssetManager::GetInstance()->Open(path, oflag);
 }

--- a/starboard/android/shared/posix_emu/stat.cc
+++ b/starboard/android/shared/posix_emu/stat.cc
@@ -20,8 +20,8 @@
 #include "starboard/android/shared/file_internal.h"
 
 using starboard::IsAndroidAssetPath;
+using starboard::ListAndroidAssetDir;
 using starboard::OpenAndroidAsset;
-using starboard::OpenAndroidAssetDir;
 
 ///////////////////////////////////////////////////////////////////////////////
 // Implementations below exposed externally in pure C for emulation.
@@ -58,13 +58,12 @@ int __wrap_fstatat(int dirfd, const char* path, struct stat* info, int flags) {
     return 0;
   }
 
-  if (AAssetDir* asset_dir = OpenAndroidAssetDir(path)) {
+  if (!ListAndroidAssetDir(path).empty()) {
     info->st_mode = S_IFDIR | S_IRUSR | S_IXUSR;  // Read-only, traversable dir.
     info->st_ctime = 0;
     info->st_atime = 0;
     info->st_mtime = 0;
     info->st_size = 0;
-    AAssetDir_close(asset_dir);
     return 0;
   }
 

--- a/starboard/android/shared/system_get_path.cc
+++ b/starboard/android/shared/system_get_path.cc
@@ -22,15 +22,34 @@
 
 #include <cstring>
 
+#include "build/build_config.h"
 #include "starboard/android/shared/file_internal.h"
 #include "starboard/common/log.h"
 #include "starboard/common/string.h"
+#include "starboard/elf_loader/evergreen_config.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 using ::starboard::g_app_assets_dir;
 using ::starboard::g_app_cache_dir;
 using ::starboard::g_app_files_dir;
 using ::starboard::g_app_lib_dir;
+
+#if BUILDFLAG(IS_STARBOARD)
+namespace {
+
+// Returns the base content path, which is the Evergreen content path when one
+// is configured, or the app's asset directory otherwise.
+const char* GetContentPath() {
+  const elf_loader::EvergreenConfig* evergreen_config =
+      elf_loader::EvergreenConfig::GetInstance();
+  if (evergreen_config && !evergreen_config->content_path_.empty()) {
+    return evergreen_config->content_path_.c_str();
+  }
+  return g_app_assets_dir;
+}
+
+}  // namespace
+#endif
 
 bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
   if (!out_path || !path_size) {
@@ -52,8 +71,18 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
 
     case kSbSystemPathFontConfigurationDirectory:
     case kSbSystemPathFontDirectory:
+#if BUILDFLAG(IS_STARBOARD)
+      if (starboard::strlcpy(path, GetContentPath(), kPathSize) >= kPathSize) {
+        return false;
+      }
+      if (starboard::strlcat(path, "/fonts", kPathSize) >= kPathSize) {
+        return false;
+      }
+      break;
+#else
       SB_NOTIMPLEMENTED();
       return false;
+#endif
 
     case kSbSystemPathStorageDirectory: {
       if (starboard::strlcpy(path, g_app_files_dir, kPathSize) >= kPathSize) {

--- a/starboard/android/shared/system_get_path.cc
+++ b/starboard/android/shared/system_get_path.cc
@@ -62,9 +62,16 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
 
   switch (path_id) {
     case kSbSystemPathContentDirectory: {
+#if BUILDFLAG(IS_STARBOARD)
+      // Use the Evergreen content path when one is configured
+      if (starboard::strlcat(path, GetContentPath(), kPathSize) >= kPathSize) {
+        return false;
+      }
+#else
       if (starboard::strlcat(path, g_app_assets_dir, kPathSize) >= kPathSize) {
         return false;
       }
+#endif
 
       break;
     }

--- a/starboard/android/shared/window_surface.cc
+++ b/starboard/android/shared/window_surface.cc
@@ -1,0 +1,97 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "starboard/android/shared/window_surface.h"
+
+#include <android/native_window.h>
+
+#include <mutex>
+
+#include "starboard/android/shared/window_internal.h"
+#include "starboard/common/log.h"
+#include "starboard/window.h"
+
+namespace {
+
+std::mutex g_window_mutex;
+ANativeWindow* g_native_window = nullptr;
+
+}  // namespace
+
+namespace starboard {
+namespace android {
+namespace shared {
+
+void SetWindowSurface(ANativeWindow* window) {
+  std::lock_guard<std::mutex> lock(g_window_mutex);
+  if (g_native_window) {
+    ANativeWindow_release(g_native_window);
+  }
+  g_native_window = window;
+}
+
+ANativeWindow* GetWindowSurface() {
+  std::lock_guard<std::mutex> lock(g_window_mutex);
+  return g_native_window;
+}
+
+}  // namespace shared
+}  // namespace android
+}  // namespace starboard
+
+SbWindow SbWindowCreate(const SbWindowOptions* options) {
+  ANativeWindow* native_window = starboard::android::shared::GetWindowSurface();
+  if (native_window == nullptr) {
+    // The app gates nativeStartStarboard() on surfaceCreated, so the surface
+    // should already be available. If it isn't, fail rather than hand back an
+    // invalid window silently masked downstream.
+    SB_LOG(ERROR) << "SbWindowCreate: no Android surface available.";
+    return kSbWindowInvalid;
+  }
+  SbWindow window = new SbWindowPrivate();
+  // The holder owns the ANativeWindow reference for the app's lifetime; the
+  // window only borrows it (released on surfaceDestroyed, not in
+  // SbWindowDestroy).
+  window->native_window = native_window;
+  return window;
+}
+
+bool SbWindowDestroy(SbWindow window) {
+  if (!SbWindowIsValid(window)) {
+    return false;
+  }
+  delete window;
+  return true;
+}
+
+void* SbWindowGetPlatformHandle(SbWindow window) {
+  if (!SbWindowIsValid(window)) {
+    return nullptr;
+  }
+  // EGLNativeWindowType and ANativeWindow* are the same on Android, so the
+  // Ozone layer can hand this straight to eglCreateWindowSurface().
+  return window->native_window;
+}
+
+bool SbWindowGetSize(SbWindow window, SbWindowSize* size) {
+  if (!SbWindowIsValid(window) || window->native_window == nullptr) {
+    return false;
+  }
+  size->width = ANativeWindow_getWidth(window->native_window);
+  size->height = ANativeWindow_getHeight(window->native_window);
+  // Assume square pixels; the device-resolution-aware ratio (AndroidTV's
+  // window_get_size.cc) needs media bring-up that AOSP doesn't have yet.
+  size->video_pixel_ratio = 1.0f;
+  return true;
+}

--- a/starboard/android/shared/window_surface.h
+++ b/starboard/android/shared/window_surface.h
@@ -1,0 +1,43 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef STARBOARD_ANDROID_SHARED_WINDOW_SURFACE_H_
+#define STARBOARD_ANDROID_SHARED_WINDOW_SURFACE_H_
+
+#include <android/native_window.h>
+
+namespace starboard {
+namespace android {
+namespace shared {
+
+// Holds the single on-screen ANativeWindow that backs the Starboard window on
+// AOSP. The Android app's graphics SurfaceView feeds it via JNI (see
+// MainActivity / android_main.cc): |window| comes from
+// ANativeWindow_fromSurface on surfaceCreated, and is cleared (nullptr) on
+// surfaceDestroyed.
+//
+// Ownership of |window| transfers to this holder; it releases the previous
+// window (if any) on each call. SbWindowCreate() reads it back via
+// GetWindowSurface(). Because the app gates nativeStartStarboard() on
+// surfaceCreated, the window is already set by the time SbWindowCreate() runs,
+// so no waiting is needed here (mirroring the synchronous create on the x11 /
+// raspi modular platforms, which always have a display available).
+void SetWindowSurface(ANativeWindow* window);
+ANativeWindow* GetWindowSurface();
+
+}  // namespace shared
+}  // namespace android
+}  // namespace starboard
+
+#endif  // STARBOARD_ANDROID_SHARED_WINDOW_SURFACE_H_

--- a/starboard/aosp/arm/platform_configuration/configuration.gni
+++ b/starboard/aosp/arm/platform_configuration/configuration.gni
@@ -19,3 +19,10 @@ if (current_toolchain == default_toolchain) {
   import("//starboard/android/arm/platform_configuration/configuration.gni")
   sb_evergreen_compatible_use_libunwind = true
 }
+
+# The evergreen/modular config forces cobalt_font_package = "empty" and the
+# Android config uses "android_system"; neither bundles a usable, self-contained
+# font set. Cobalt's SkFontMgr_Cobalt aborts without real families
+# so ship the "limited" package.
+# cobalt/aosp/modular_apk.gni packages it into the cobalt APK.
+cobalt_font_package = "limited"

--- a/starboard/aosp/shared/main_activity.cc
+++ b/starboard/aosp/shared/main_activity.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <android/native_window.h>
+#include <android/native_window_jni.h>
 #include <jni.h>
 #include <limits.h>
 #include <pthread.h>
@@ -23,6 +25,7 @@
 
 #include "cobalt/aosp/jni_headers/MainActivity_jni.h"
 #include "starboard/android/shared/starboard_bridge.h"
+#include "starboard/android/shared/window_surface.h"
 #include "starboard/common/log.h"
 #include "starboard/system.h"
 #include "third_party/jni_zero/jni_zero.h"
@@ -66,6 +69,24 @@ namespace starboard {
 
 void JNI_MainActivity_StartLoader(JNIEnv* env) {
   std::thread(StarboardMain).detach();
+}
+
+// The Android graphics SurfaceView hands its Surface to Starboard here. The app
+// only calls nativeStartStarboard() after surfaceCreated, so by the time the
+// inner library's Ozone window asks for it via SbWindowCreate() the
+// ANativeWindow is already published and the create is synchronous.
+void JNI_MainActivity_NativeOnSurfaceCreated(
+    JNIEnv* env,
+    const jni_zero::JavaParamRef<jobject>& surface) {
+  ANativeWindow* native_window = ANativeWindow_fromSurface(env, surface.obj());
+  SB_LOG(INFO) << "cobalt_loader: Starboard surface created, native_window="
+               << native_window;
+  starboard::android::shared::SetWindowSurface(native_window);
+}
+
+void JNI_MainActivity_NativeOnSurfaceDestroyed(JNIEnv*) {
+  SB_LOG(INFO) << "cobalt_loader: Starboard surface destroyed.";
+  starboard::android::shared::SetWindowSurface(nullptr);
 }
 
 }  // namespace starboard

--- a/starboard/aosp/shared/main_activity.cc
+++ b/starboard/aosp/shared/main_activity.cc
@@ -21,7 +21,6 @@
 #include <unistd.h>
 
 #include <string>
-#include <thread>
 #include <vector>
 
 #include "cobalt/aosp/jni_headers/MainActivity_jni.h"
@@ -35,7 +34,12 @@ int main(int argc, char** argv);
 
 namespace {
 
-void StarboardMain() {
+// Cobalt normally runs main() on the process's main thread, which has a large
+// (typically 8 MB) stack. Here it runs on a dedicated thread instead, and
+// bionic's default thread stack is only ~1 MB.
+constexpr size_t kStarboardMainStackSize = 8 * 1024 * 1024;
+
+void* StarboardMain(void* /*context*/) {
   pthread_setname_np(pthread_self(), "StarboardMain");
 
   JNIEnv* env = jni_zero::AttachCurrentThread();
@@ -67,6 +71,7 @@ void StarboardMain() {
   argv.push_back(nullptr);
 
   main(static_cast<int>(args.size()), argv.data());
+  return nullptr;
 }
 
 }  // namespace
@@ -74,7 +79,17 @@ void StarboardMain() {
 namespace starboard {
 
 void JNI_MainActivity_StartLoader(JNIEnv* env) {
-  std::thread(StarboardMain).detach();
+  pthread_attr_t attr;
+  pthread_attr_init(&attr);
+  pthread_attr_setstacksize(&attr, kStarboardMainStackSize);
+  pthread_attr_setdetachstate(&attr, PTHREAD_CREATE_DETACHED);
+
+  pthread_t thread;
+  if (pthread_create(&thread, &attr, &StarboardMain, nullptr) != 0) {
+    SB_LOG(ERROR) << "Failed to create StarboardMain thread";
+  }
+
+  pthread_attr_destroy(&attr);
 }
 
 // The Android graphics SurfaceView hands its Surface to Starboard here. The app

--- a/starboard/aosp/shared/main_activity.cc
+++ b/starboard/aosp/shared/main_activity.cc
@@ -17,6 +17,7 @@
 #include <jni.h>
 #include <limits.h>
 #include <pthread.h>
+#include <stdlib.h>
 #include <unistd.h>
 
 #include <string>
@@ -47,10 +48,15 @@ void StarboardMain() {
     if (chdir(files_dir) != 0) {
       SB_LOG(WARNING) << "cobalt_loader: chdir to " << files_dir << " failed";
     }
+    // point TMPDIR at the writable app files directory
+    setenv("TMPDIR", files_dir, 1);
   }
 
   std::vector<std::string> args;
   args.push_back("cobalt_loader");
+  // Don't use "/dev/shm" for shared memory; it does not exist on Android
+  // With this switch it falls back to GetTempDir()
+  args.push_back("--disable-dev-shm-usage");
   starboard::StarboardBridge::GetInstance()->AppendArgs(env, &args);
 
   std::vector<char*> argv;

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -22,10 +22,14 @@ config("platform_configuration") {
     ldflags = [
       "-Wl,--wrap=access",
       "-Wl,--wrap=close",
+      "-Wl,--wrap=closedir",
       "-Wl,--wrap=fstatat",
       "-Wl,--wrap=if_indextoname",
       "-Wl,--wrap=open",
+      "-Wl,--wrap=opendir",
       "-Wl,--wrap=openat",
+      "-Wl,--wrap=readdir",
+      "-Wl,--wrap=readdir_r",
       "-Wl,--wrap=stat",
     ]
   }

--- a/starboard/aosp/shared/platform_configuration/BUILD.gn
+++ b/starboard/aosp/shared/platform_configuration/BUILD.gn
@@ -23,6 +23,7 @@ config("platform_configuration") {
       "-Wl,--wrap=access",
       "-Wl,--wrap=close",
       "-Wl,--wrap=closedir",
+      "-Wl,--wrap=fdopendir",
       "-Wl,--wrap=fstatat",
       "-Wl,--wrap=if_indextoname",
       "-Wl,--wrap=open",

--- a/starboard/aosp/shared/run_starboard_main.cc
+++ b/starboard/aosp/shared/run_starboard_main.cc
@@ -35,12 +35,11 @@ extern "C" SB_EXPORT int SbRunStarboardMain(int argc,
   SbEvent start_event = {};
   start_event.type = kSbEventTypeStart;
   start_event.data = &start_data;
+  // AOSP has no Starboard event loop: the inner library pumps the Chromium UI
+  // message loop in the started state inside this callback (see
+  // cobalt/app/cobalt.cc), so this call does not return until the app stops. Do
+  // not send a Stop event here; that would tear the app down immediately.
   callback(&start_event);
-
-  SbEvent stop_event = {};
-  stop_event.type = kSbEventTypeStop;
-  stop_event.data = nullptr;
-  callback(&stop_event);
 
   return 0;
 }

--- a/starboard/common/paths.cc
+++ b/starboard/common/paths.cc
@@ -74,6 +74,13 @@ std::string GetCACertificatesPath(const std::string& content_subdir) {
   std::string ca_certificates_path =
       GetCACertificatesPathFromSubdir(content_subdir);
   if (stat(ca_certificates_path.c_str(), &info) != 0) {
+    // Fall back to the content root, like the no-argument overload. On some
+    // platforms (e.g. Android, where the content directory resolves to the
+    // asset root) the certs are packaged at <content>/ssl/certs rather than
+    // <content>/<content_subdir>/ssl/certs.
+    ca_certificates_path = GetCACertificatesPathFromSubdir("");
+  }
+  if (stat(ca_certificates_path.c_str(), &info) != 0) {
     SB_LOG(ERROR) << "Failed to get CA certificates path";
     return "";
   }

--- a/starboard/shared/modular/starboard_layer_posix_directory_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_directory_abi_wrappers.cc
@@ -34,13 +34,12 @@ int __abi_wrap_readdir_r(musl_dir* dirp,
   struct dirent* result = nullptr;
 // from POSIX.1-2008 readdir_r() was fully supported but emitting
 // a future deprecation warning. Marked as obsolecscent in POSIX.1-2024
-// TODO(b/374300500): add back posix emulation
 #if defined(_POSIX_VERSION) && (_POSIX_VERSION < 202406L) && defined(__clang__)
 #pragma clang diagnostic push
 #pragma clang diagnostic ignored "-Wdeprecated-declarations"
 #endif
   int retval = readdir_r(dirp->dir, &entry, &result);
-#if defined(_POSIX_VERSION) && (_POSIX_VERSION < 202405L) && defined(__clang__)
+#if defined(_POSIX_VERSION) && (_POSIX_VERSION < 202406L) && defined(__clang__)
 #pragma clang diagnostic pop
 #endif
   if (retval != 0) {


### PR DESCRIPTION
- Creates the SbWindow using the ANativeWindow published by the Java surface callbacks
- Includes fixes for assets lookup that were making the app abort
- Fixes the blank screen issue when cobalt app starts
- Correctly starts the starboard event loop