### PR TITLE
android: Enable ClearSurfaceView by default

### DIFF
--- a/media/base/starboard/experimental_features.h
+++ b/media/base/starboard/experimental_features.h
@@ -160,9 +160,6 @@ inline constexpr ExperimentalFeatureKey<bool> kMediaBypassMojoForMedia(
 inline constexpr ExperimentalFeatureKey<bool> kMediaEnableTrivialOptimizations(
     "Media.EnableTrivialOptimizations");
 
-inline constexpr ExperimentalFeatureKey<bool> kMediaForceClearSurfaceView(
-    "Media.ForceClearSurfaceView");
-
 inline constexpr ExperimentalFeatureKey<bool> kMediaForceDecodeToTexture(
     "Media.ForceDecodeToTexture");
 

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -808,17 +808,11 @@ void SbPlayerBridge::CreatePlayer() {
         &extension_features);
   }
 
-  const bool should_get_decode_target_graphics_context_provider =
-      output_mode_ == kSbPlayerOutputModeDecodeToTexture ||
-      experimental_features_.GetBool(kMediaForceClearSurfaceView);
-
   player_ = sbplayer_interface_->Create(
       window_, &creation_param, &SbPlayerBridge::DeallocateSampleCB,
       &SbPlayerBridge::DecoderStatusCB, &SbPlayerBridge::PlayerStatusCB,
       &SbPlayerBridge::PlayerErrorCB, this,
-      should_get_decode_target_graphics_context_provider
-          ? get_decode_target_graphics_context_provider_func_.Run()
-          : nullptr);
+      get_decode_target_graphics_context_provider_func_.Run());
 #if BUILDFLAG(COBALT_MEDIA_ENABLE_CVAL)
   cval_stats_->StopTimer(MediaTiming::SbPlayerCreate, pipeline_identifier_);
 #endif  // BUILDFLAG(COBALT_MEDIA_ENABLE_CVAL)

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -363,8 +363,6 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
       skip_flush_on_decoder_teardown_(
           pipeline_config.experimental_features.GetBool(
               kMediaSkipFlushOnDecoderTeardown)),
-      force_clear_surface_(pipeline_config.experimental_features.GetBool(
-          kMediaForceClearSurfaceView)),
       needs_fps_to_initialize_codec_(
           video_codec_ == kSbMediaVideoCodecAv1 &&
           MediaCapabilitiesCache::GetInstance()->IsAv18kCappedAt30()),
@@ -451,9 +449,8 @@ MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {
   TeardownCodec();
   // The video surface must be reset after tunnel mode playbacks. This prevents
   // video distortion on some platforms. For details, see http://b/182610842.
-  bool force_clear =
-      !tunnel_mode_audio_session_id_.has_value() && force_clear_surface_;
-  CleanUpVideoWindow(force_clear, decode_target_graphics_context_provider_);
+  bool force_reset = tunnel_mode_audio_session_id_.has_value();
+  CleanUpVideoWindow(force_reset, decode_target_graphics_context_provider_);
 }
 
 scoped_refptr<VideoRendererSink> MediaCodecVideoDecoder::GetSink() {

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -449,8 +449,11 @@ MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {
   TeardownCodec();
   // The video surface must be reset after tunnel mode playbacks. This prevents
   // video distortion on some platforms. For details, see http://b/182610842.
-  bool force_reset = tunnel_mode_audio_session_id_.has_value();
-  CleanUpVideoWindow(force_reset, decode_target_graphics_context_provider_);
+  if (tunnel_mode_audio_session_id_.has_value()) {
+    ResetVideoSurface();
+  } else {
+    CleanUpVideoSurface(decode_target_graphics_context_provider_);
+  }
 }
 
 scoped_refptr<VideoRendererSink> MediaCodecVideoDecoder::GetSink() {

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -207,10 +207,6 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   const int64_t flush_delay_usec_;
   const bool skip_flush_on_decoder_teardown_;
 
-  // By default, we reset the surface view after every playback. This flag
-  // enables clearing the surface view, instead of resetting it.
-  const bool force_clear_surface_;
-
   // Codec initialization will be delayed until the decoder receives enough
   // inputs to estimate video fps when |needs_fps_to_initialize_codec_| is true.
   const bool needs_fps_to_initialize_codec_;

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -186,8 +186,7 @@ void VideoSurfaceHolder::ReleaseVideoSurface() {
   }
 }
 
-void VideoSurfaceHolder::CleanUpVideoWindow(
-    bool force_reset,
+void VideoSurfaceHolder::CleanUpVideoSurface(
     SbDecodeTargetGraphicsContextProvider* gpu_provider) {
   // Lock *GetViewSurfaceMutex() here, to avoid releasing g_native_video_window
   // during painting.
@@ -198,22 +197,25 @@ void VideoSurfaceHolder::CleanUpVideoWindow(
     return;
   }
 
-  JNIEnv* env = AttachCurrentThread();
-  if (!env) {
-    SB_LOG(INFO) << "Tried to clean up video window when JNIEnv was null.";
-    return;
-  }
-
-  if (force_reset) {
-    StarboardBridge::GetInstance()->ResetVideoSurface(env);
-    SB_LOG(INFO) << "Video surface has been reset.";
-    return;
-  }
-
   SB_CHECK(gpu_provider);
   gpu_provider->gles_context_runner(gpu_provider, &ClearNativeWindow,
                                     g_native_video_window);
   SB_LOG(INFO) << "Video surface has been cleared.";
+}
+
+void VideoSurfaceHolder::ResetVideoSurface() {
+  // Lock *GetViewSurfaceMutex() here, to avoid releasing g_native_video_window
+  // during painting.
+  std::lock_guard lock(*GetViewSurfaceMutex());
+
+  JNIEnv* env = AttachCurrentThread();
+  if (!env) {
+    SB_LOG(INFO) << "Tried to reset video window when JNIEnv was null.";
+    return;
+  }
+
+  StarboardBridge::GetInstance()->ResetVideoSurface(env);
+  SB_LOG(INFO) << "Video surface has been reset.";
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -187,7 +187,7 @@ void VideoSurfaceHolder::ReleaseVideoSurface() {
 }
 
 void VideoSurfaceHolder::CleanUpVideoWindow(
-    bool force_clear,
+    bool force_reset,
     SbDecodeTargetGraphicsContextProvider* gpu_provider) {
   // Lock *GetViewSurfaceMutex() here, to avoid releasing g_native_video_window
   // during painting.
@@ -204,16 +204,16 @@ void VideoSurfaceHolder::CleanUpVideoWindow(
     return;
   }
 
-  if (force_clear) {
-    SB_CHECK(gpu_provider);
-    gpu_provider->gles_context_runner(gpu_provider, &ClearNativeWindow,
-                                      g_native_video_window);
-    SB_LOG(INFO) << "Video surface has been cleared.";
+  if (force_reset) {
+    StarboardBridge::GetInstance()->ResetVideoSurface(env);
+    SB_LOG(INFO) << "Video surface has been reset.";
     return;
   }
 
-  StarboardBridge::GetInstance()->ResetVideoSurface(env);
-  SB_LOG(INFO) << "Video surface has been reset (default behavior).";
+  SB_CHECK(gpu_provider);
+  gpu_provider->gles_context_runner(gpu_provider, &ClearNativeWindow,
+                                    g_native_video_window);
+  SB_LOG(INFO) << "Video surface has been cleared.";
 }
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -44,11 +44,11 @@ class VideoSurfaceHolder {
   // Release the surface to make the surface available for other holder.
   void ReleaseVideoSurface();
 
-  // Cleans up the video surface. If |force_reset| is enabled, we will destroy
-  // the video window. Otherwise, we will clear the video window, posting the
-  // task to |gpu_provider|.
-  void CleanUpVideoWindow(bool force_reset,
-                          SbDecodeTargetGraphicsContextProvider* gpu_provider);
+  // Cleans up the video surface, and posts the task to |gpu_provider|.
+  void CleanUpVideoSurface(SbDecodeTargetGraphicsContextProvider* gpu_provider);
+
+  // Reset the video surface by re-creating video surface.
+  void ResetVideoSurface();
 };
 
 }  // namespace starboard

--- a/starboard/android/shared/video_window.h
+++ b/starboard/android/shared/video_window.h
@@ -44,13 +44,11 @@ class VideoSurfaceHolder {
   // Release the surface to make the surface available for other holder.
   void ReleaseVideoSurface();
 
-  // Cleans up the video surface. If |force_clear| is enabled, we will only
-  // clear the video window, and post the clearing task to |gpu_provider|.
-  // If |force_clear| is false, we will forcefully destroy the surface view,
-  // which will then be recreated.
-  void CleanUpVideoWindow(
-      bool force_clear,
-      SbDecodeTargetGraphicsContextProvider* gpu_provider = nullptr);
+  // Cleans up the video surface. If |force_reset| is enabled, we will destroy
+  // the video window. Otherwise, we will clear the video window, posting the
+  // task to |gpu_provider|.
+  void CleanUpVideoWindow(bool force_reset,
+                          SbDecodeTargetGraphicsContextProvider* gpu_provider);
 };
 
 }  // namespace starboard

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -189,9 +189,6 @@ inline constexpr ExperimentalFeatureKey<bool>
 inline constexpr ExperimentalFeatureKey<bool> kMediaFlushAudioTrackDuringSeek(
     "Media.FlushAudioTrackDuringSeek");
 
-inline constexpr ExperimentalFeatureKey<bool> kMediaForceClearSurfaceView(
-    "Media.ForceClearSurfaceView");
-
 inline constexpr ExperimentalFeatureKey<bool> kMediaForceDualThreads(
     "Media.ForceDualThreads");
 


### PR DESCRIPTION
This change makes clearing the surface view on Android the default behavior. Previously, resetting the surface view was the default behavior, but experimentation has proven that clearing the surface view to be the better option.

This change:

- Removes the experimentation code for ForceClearSurfaceView, as it is no longer needed.
- Change `sbplayer_bridge.cc` to always send the `decode_target_graphics_context_provider_func_` to SbPlayer. This allows the SbPlayer to post the clear surface task.
- Change the behavior of `CleanUpVideoWindow` to have clearing to be the default case, and resetting the surface view to be an early exit case.


Bug: 429021006