### PR TITLE
media: Update VideoBufferSizeClampMB to 4K HDR

### DIFF
--- a/media/base/demuxer_memory_limit.h
+++ b/media/base/demuxer_memory_limit.h
@@ -28,8 +28,8 @@ MEDIA_EXPORT size_t GetDemuxerMemoryLimit(DemuxerType demuxer_type);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 MEDIA_EXPORT void Set720pVideoBufferSizeClamp(int size_mb);
-MEDIA_EXPORT size_t GetVideoBufferSizeClamp();
-MEDIA_EXPORT void SetVideoBufferSizeClamp(int size_mb);
+MEDIA_EXPORT size_t Get4KHDRVideoBufferSizeClamp();
+MEDIA_EXPORT void Set4KHDRVideoBufferSizeClamp(int size_mb);
 #endif
 
 namespace internal {

--- a/media/base/starboard/demuxer_memory_limit_starboard.cc
+++ b/media/base/starboard/demuxer_memory_limit_starboard.cc
@@ -31,11 +31,11 @@ namespace media {
 namespace {
 
 // |g_720p_video_buffer_size_clamp_bytes| and
-// |g_video_buffer_size_clamp_bytes| are process-wide, and are currently set by
-// h5vcc flags.
+// |g_4K_HDR_video_buffer_clamp_bytes| are process-wide, and are currently set
+// by h5vcc flags.
 std::atomic<size_t> g_720p_video_buffer_size_clamp_bytes{
     std::numeric_limits<size_t>::max()};
-std::atomic<size_t> g_video_buffer_size_clamp_bytes{
+std::atomic<size_t> g_4K_HDR_video_buffer_clamp_bytes{
     std::numeric_limits<size_t>::max()};
 
 int GetBitsPerPixel(const VideoDecoderConfig& video_config) {
@@ -72,17 +72,18 @@ void Set720pVideoBufferSizeClamp(int size_mb) {
       static_cast<size_t>(size_mb) * 1024 * 1024;
 }
 
-size_t GetVideoBufferSizeClamp() {
-  return g_video_buffer_size_clamp_bytes.load();
+size_t Get4KHDRVideoBufferSizeClamp() {
+  return g_4K_HDR_video_buffer_clamp_bytes.load();
 }
 
-void SetVideoBufferSizeClamp(int size_mb) {
+void Set4KHDRVideoBufferSizeClamp(int size_mb) {
   // We convert the value from MBs to bytes, as the values returned by
   // GetVideoDecoderBufferLimitBytes's return value is in bytes.
   CHECK_GT(size_mb, 0);
   // Prevent overflow bugs by setting the limit to 4 GiB.
   CHECK_LT(size_mb, 4096);
-  g_video_buffer_size_clamp_bytes = static_cast<size_t>(size_mb) * 1024 * 1024;
+  g_4K_HDR_video_buffer_clamp_bytes =
+      static_cast<size_t>(size_mb) * 1024 * 1024;
 }
 
 size_t GetDemuxerStreamAudioMemoryLimit(
@@ -111,7 +112,17 @@ size_t GetDemuxerStreamVideoMemoryLimit(
                                             GetBitsPerPixel(*video_config));
   }
 
-  return std::min(limit, g_video_buffer_size_clamp_bytes.load());
+  const size_t clamp = g_4K_HDR_video_buffer_clamp_bytes.load();
+  if (clamp != std::numeric_limits<size_t>::max() && video_config) {
+    const gfx::Size resolution = video_config->visible_rect().size();
+    const bool is_4k_hdr = resolution.width() <= 3840 &&
+                           resolution.height() <= 2160 &&
+                           GetBitsPerPixel(*video_config) > 8;
+    if (is_4k_hdr) {
+      return std::min(limit, clamp);
+    }
+  }
+  return limit;
 }
 
 size_t GetDemuxerMemoryLimit(DemuxerType demuxer_type) {

--- a/media/filters/source_buffer_stream.cc
+++ b/media/filters/source_buffer_stream.cc
@@ -1862,7 +1862,7 @@ bool SourceBufferStream::UpdateVideoConfig(const VideoDecoderConfig& config,
         << __func__
         << ": Skipping updating memory limit as memory limit was overridden.";
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-    if (GetVideoBufferSizeClamp() != std::numeric_limits<size_t>::max()) {
+    if (Get4KHDRVideoBufferSizeClamp() != std::numeric_limits<size_t>::max()) {
       LOG(WARNING)
           << "Experiment VideoBufferSizeClamp is active but ignored as memory limit was overridden.";
     }

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_settings/h_5_vcc_settings.cc
@@ -193,7 +193,7 @@ ScriptPromise<IDLUndefined> H5vccSettings::set(
   if (name == "Media.VideoBufferSizeClampMb") {
     return ProcessSettingAsPositiveInt(
         script_state, exception_context, name, *value, [](int int_value) {
-          ::media::SetVideoBufferSizeClamp(int_value);
+          ::media::Set4KHDRVideoBufferSizeClamp(int_value);
           return true;
         });
   }


### PR DESCRIPTION
This PR renames the already existing `g_video_buffer_size_clamp_bytes`  value to `g_4K_HDR_video_buffer_clamp_bytes`, to better reflect the actual use of the variable. Functionally, this variable only worked on 4k HDR clamps, but the naming implied otherwise. The name of the functions that set and get this value are also updated to better reflect this.

We also update the logic of the clamp to ensure that 8k playbacks are not affected by it. This helps prevent unexpected regressions for 8k playback.

Bug: 416105795