### PR TITLE
android: Allow configuring V8 initial old space size

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -90,8 +90,7 @@ public final class CommandLineOverrideHelper {
 
         // Trades a little V8 performance for significant memory savings.
         paramOverrides.add("--optimize-for-size");
-        // Set initial old space size to 64MB and max old space size to 512MB.
-        paramOverrides.add("--initial-old-space-size=64");
+        // Set max old space size to 512MB.
         paramOverrides.add("--max-old-space-size=512");
 
         // Disable decommitting pooled pages to prevent virtual memory fragmentation.

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -103,6 +103,7 @@ public class JavaSwitches {
 
   /** Flag for enable go/cobalt-direct-window-rendering */
   public static final String DIRECT_WINDOW_RENDERING = "DirectWindowRendering";
+  public static final String V8_INITIAL_OLD_SPACE_SIZE = "V8InitialOldSpaceSize";
 
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
@@ -132,6 +133,13 @@ public class JavaSwitches {
         jsFlags.add("--flush-bytecode");
         jsFlags.add("--bytecode-old-time=" + oldTime);
       }
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE)) {
+      jsFlags.add("--initial-old-space-size="
+          + javaSwitches.get(JavaSwitches.V8_INITIAL_OLD_SPACE_SIZE).replaceAll("[^0-9]", ""));
+    } else {
+      jsFlags.add("--initial-old-space-size=64");
     }
 
     if (javaSwitches.containsKey(JavaSwitches.DISABLE_GPU_MEMORY_BUFFER_COMPOSITOR_RESOURCES)) {

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -43,7 +43,6 @@ public class CommandLineOverrideHelperTest {
     public void testDefaultJsFlagOverridesList() {
         String overrides = CommandLineOverrideHelper.getDefaultJsFlagOverridesList().toString();
         assertThat(overrides.contains("--optimize-for-size")).isTrue();
-        assertThat(overrides.contains("--initial-old-space-size=64")).isTrue();
         assertThat(overrides.contains("--max-old-space-size=512")).isTrue();
     }
 


### PR DESCRIPTION

- Define V8_INITIAL_OLD_SPACE_SIZE Java switch constant in JavaSwitches.java.
- Handle V8InitialOldSpaceSize in JavaSwitches.getExtraCommandLineArgs(), defaulting to 64MB if not provided.
- Remove hardcoded --initial-old-space-size=64 from static default list in CommandLineOverrideHelper.java.
- Update CommandLineOverrideHelperTest.java accordingly.

Bug: 540879465