### PR TITLE
cobalt: Reduce V8 initial old space size from 64MB to 16MB

### DIFF
--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -126,8 +126,8 @@ CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
        "--no-decommit-pooled-pages "
        // Enable memory saving mode with little v8 performance tradeoff.
        "--optimize-for-size "
-       // Set initial old space size to 64MB and max old space size to 512MB.
-       "--initial-old-space-size=64 "
+       // Set initial old space size to 16MB and max old space size to 512MB.
+       "--initial-old-space-size=16 "
        "--max-old-space-size=512 "
        // Disable v8 optimizing compilers (turbofan, maglev, sparkplug).
        "--disable-optimizing-compilers "


### PR DESCRIPTION
Through both local testing and AlphaEvolve, further reducing initial-old-space-size from 64MB to 16MB brings ~10MB average memory saving with no observed performance regressions in local testing. Making this change in 3p defaults while waiting for production data validation.

Bug: 540879465