### PR TITLE
android: Close Picture-in-Picture on backgrounding

### DIFF
--- a/cobalt/shell/browser/shell.cc
+++ b/cobalt/shell/browser/shell.cc
@@ -1162,6 +1162,19 @@ void Shell::OnVisibilityChanged(Visibility visibility) {
     // Retry the pending focus now that the window is visible in Aura.
     Focus();
   }
+
+  // When the OS backgrounds the app (resulting in Visibility::HIDDEN state),
+  // tearing down the PiP session from here ensures the
+  // VideoPictureInPictureWindowController pauses the video and destroys the UI
+  // overlay window.
+  // See: b/532272209
+  if (base::FeatureList::IsEnabled(cobalt::features::kEnablePictureInPicture) &&
+      visibility == content::Visibility::HIDDEN && web_contents() &&
+      web_contents()->HasPictureInPictureVideo()) {
+    content::PictureInPictureWindowController::
+        GetOrCreateVideoPictureInPictureController(web_contents())
+            ->Close(/*should_pause_video=*/true);
+  }
 }
 
 void Shell::LoadProgressChanged(double progress) {

--- a/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
+++ b/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
@@ -279,4 +279,30 @@ IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
   ASSERT_TRUE(NavigateToURL(shell(), next_url));
 }
 
+IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
+                       AppBackgroundExitsPictureInPicture) {
+  if (!IsPictureInPictureAvailable(shell())) {
+    GTEST_SKIP() << "Picture-in-Picture not available in this test environment";
+  }
+
+  GURL test_url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell(), test_url));
+  // The custom test shell client bypasses the creation of the Cobalt observer.
+  // We manually attach it here.
+  cobalt::CobaltWebContentsObserver observer(shell()->web_contents());
+  ASSERT_TRUE(ExecJs(shell(), kPictureInPictureScript));
+  ASSERT_TRUE(ExecJs(shell(), "addPictureInPictureEventListeners();"));
+  ASSERT_EQ(true, EvalJs(shell(), "play();"));
+  TitleWatcher enter_watcher(shell()->web_contents(), u"enterpictureinpicture");
+  ASSERT_EQ(true, EvalJs(shell(), "enterPictureInPicture();"));
+  EXPECT_EQ(u"enterpictureinpicture", enter_watcher.WaitAndGetTitle());
+  TitleWatcher exit_watcher(shell()->web_contents(), u"leavepictureinpicture");
+  // Simulating the app going to the background (e.g. user pressing Home
+  // button).
+  shell()->web_contents()->WasHidden();
+  EXPECT_EQ(u"leavepictureinpicture", exit_watcher.WaitAndGetTitle());
+  GURL cleanup_url = embedded_test_server()->GetURL("/title2.html");
+  ASSERT_TRUE(NavigateToURL(shell(), cleanup_url));
+}
+
 }  // namespace content


### PR DESCRIPTION
When the Android OS backgrounds the app, the visibility state changes
to hidden. Tearing down the Picture-in-Picture session at this point
ensures that the VideoPictureInPictureWindowController pauses the
video and destroys the UI overlay window.

Issue: 532272209