### PR TITLE
feat: Add nativeStability.acknowledgeReports API

### DIFF
--- a/cobalt/browser/cobalt_browser_interface_binders.cc
+++ b/cobalt/browser/cobalt_browser_interface_binders.cc
@@ -181,9 +181,25 @@ void PopulateCobaltFrameBinders(
 
   binder_map->Add<h5vcc_storage::mojom::H5vccStorage>(
       base::BindRepeating(&h5vcc_storage::H5vccStorageImpl::Create));
+#if BUILDFLAG(USE_EVERGREEN)
   binder_map->Add<h5vcc_native_stability::mojom::H5vccNativeStability>(
       base::BindRepeating(
           &h5vcc_native_stability::H5vccNativeStabilityImpl::Create));
+#else
+  // For platforms not (yet) supporting native stability reporting, register
+  // a stub binder that ignores binding requests and drops the receiver. This
+  // prevents the browser from terminating the frame's Mojo broker if the
+  // interface is requested, while ensuring no disk I/O or state modification
+  // occurs on unsupported platforms.
+  binder_map->Add<h5vcc_native_stability::mojom::H5vccNativeStability>(
+      base::BindRepeating(
+          [](content::RenderFrameHost*,
+             mojo::PendingReceiver<
+                 h5vcc_native_stability::mojom::H5vccNativeStability>) {
+            VLOG(1) << "Ignoring H5vccNativeStability request for "
+                    << "non-Evergreen build.";
+          }));
+#endif
   binder_map->Add<media::mojom::PlatformWindowProvider>(
       base::BindRepeating(&BindPlatformWindowProvider));
   binder_map->Add<h5vcc_platform_service::mojom::H5vccPlatformServiceManager>(

--- a/cobalt/browser/h5vcc_native_stability/h5vcc_native_stability_impl.cc
+++ b/cobalt/browser/h5vcc_native_stability/h5vcc_native_stability_impl.cc
@@ -40,4 +40,11 @@ void H5vccNativeStabilityImpl::GetPendingReports(
   NativeStabilityManager::GetInstance()->GetPendingReports(std::move(callback));
 }
 
+void H5vccNativeStabilityImpl::AcknowledgeReports(
+    const std::vector<std::string>& native_stability_event_uuids,
+    AcknowledgeReportsCallback callback) {
+  NativeStabilityManager::GetInstance()->AcknowledgeReports(
+      native_stability_event_uuids, std::move(callback));
+}
+
 }  // namespace h5vcc_native_stability

--- a/cobalt/browser/h5vcc_native_stability/h5vcc_native_stability_impl.h
+++ b/cobalt/browser/h5vcc_native_stability/h5vcc_native_stability_impl.h
@@ -42,6 +42,9 @@ class H5vccNativeStabilityImpl
 
   // mojom::H5vccNativeStability implementation:
   void GetPendingReports(GetPendingReportsCallback callback) override;
+  void AcknowledgeReports(
+      const std::vector<std::string>& native_stability_event_uuids,
+      AcknowledgeReportsCallback callback) override;
 
  private:
   H5vccNativeStabilityImpl(

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
@@ -14,13 +14,25 @@
 
 #include "cobalt/browser/h5vcc_native_stability/native_stability_manager.h"
 
+#include <optional>
+#include <string>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
+#include "base/files/file.h"
+#include "base/files/file_path.h"
+#include "base/files/file_util.h"
+#include "base/files/important_file_writer.h"
 #include "base/functional/bind.h"
+#include "base/json/json_reader.h"
+#include "base/json/json_writer.h"
 #include "base/logging.h"
 #include "base/task/bind_post_task.h"
 #include "base/task/thread_pool.h"
 #include "base/uuid.h"
+#include "base/values.h"
+#include "starboard/configuration_constants.h"
 #include "starboard/extension/crash_handler.h"
 #include "starboard/extension/native_stability.h"
 #include "starboard/system.h"
@@ -28,6 +40,13 @@
 namespace h5vcc_native_stability {
 
 namespace {
+
+// TODO(b/528362453): Per the design doc, we should prune native stability JSON
+// storage at startup by removing entries for events no longer persisted by the
+// crash reporting system's own local storage.
+constexpr char kNativeStabilityDirName[] = "native_stability";
+constexpr char kAckedEventUuidsFileName[] = "acked_event_uuids.json";
+
 mojom::BaseReportDataPtr CreateBaseReportData(
     const SbNativeStabilityReport& sb_report) {
   auto base_data = mojom::BaseReportData::New();
@@ -36,6 +55,79 @@ mojom::BaseReportDataPtr CreateBaseReportData(
   base_data->event_time_sec = sb_report.event_time_s;
   return base_data;
 }
+
+std::unordered_set<std::string> ReadAckedUuidsFromDisk(
+    const base::FilePath& file_path) {
+  std::unordered_set<std::string> acked_uuids;
+  if (file_path.empty() || !base::PathExists(file_path)) {
+    return acked_uuids;
+  }
+
+  std::string file_content;
+  if (!base::ReadFileToString(file_path, &file_content)) {
+    LOG(WARNING) << "Failed to read acked UUIDs file: " << file_path.value();
+    return acked_uuids;
+  }
+
+  std::optional<base::Value::List> parsed_list =
+      base::JSONReader::ReadList(file_content);
+  if (!parsed_list) {
+    LOG(WARNING) << "Failed to parse acked UUIDs JSON list in: "
+                 << file_path.value();
+    return acked_uuids;
+  }
+
+  for (const auto& item : *parsed_list) {
+    if (item.is_string()) {
+      acked_uuids.insert(item.GetString());
+    } else {
+      LOG(WARNING) << "Skipping non-string item in acked UUIDs list: "
+                   << file_path.value();
+    }
+  }
+
+  return acked_uuids;
+}
+
+bool WriteAckedUuidsToDisk(const base::FilePath& file_path,
+                           const std::unordered_set<std::string>& acked_uuids) {
+  if (file_path.empty()) {
+    return false;
+  }
+
+  // We typically expect this directory to already exist but it may not, for
+  // example if this code path has never executed on a particular device or the
+  // system removed the directory.
+  base::FilePath dir_path = file_path.DirName();
+  base::File::Error error = base::File::FILE_OK;
+  if (!base::CreateDirectoryAndGetError(dir_path, &error)) {
+    LOG(ERROR) << "Failed to create " << kNativeStabilityDirName
+               << " directory: " << dir_path.value()
+               << ", error: " << base::File::ErrorToString(error);
+    return false;
+  }
+
+  base::Value::List list_of_uuids;
+  list_of_uuids.reserve(acked_uuids.size());
+  for (const auto& uuid : acked_uuids) {
+    list_of_uuids.Append(uuid);
+  }
+
+  std::optional<std::string> json = base::WriteJson(list_of_uuids);
+  if (!json) {
+    LOG(ERROR) << "Failed to serialize acked UUIDs list to JSON.";
+    return false;
+  }
+
+  if (!base::ImportantFileWriter::WriteFileAtomically(file_path, *json)) {
+    LOG(ERROR) << "Failed to write acked UUIDs atomically to: "
+               << file_path.value();
+    return false;
+  }
+
+  return true;
+}
+
 }  // namespace
 
 // static
@@ -51,9 +143,33 @@ void NativeStabilityManager::SetGetExtensionForTesting(
   get_extension_callback_for_testing_ = std::move(get_extension_callback);
 }
 
+void NativeStabilityManager::SetAckedUuidsFilePathForTesting(
+    base::FilePath file_path) {
+  acked_uuids_file_path_for_testing_ = std::move(file_path);
+}
+
 void NativeStabilityManager::ResetForTesting() {
   task_runner_ = nullptr;
   get_extension_callback_for_testing_.Reset();
+  acked_uuids_file_path_for_testing_.clear();
+}
+
+base::FilePath NativeStabilityManager::GetAckedUuidsFilePath() {
+  if (!acked_uuids_file_path_for_testing_.empty()) {
+    return acked_uuids_file_path_for_testing_;
+  }
+
+  // TODO(b/256864363): For more reliable storage, consider moving the native
+  // stability directory out of kSbSystemPathCacheDirectory.
+  std::vector<char> cache_dir(kSbFileMaxPath);
+  if (!SbSystemGetPath(kSbSystemPathCacheDirectory, cache_dir.data(),
+                       cache_dir.size())) {
+    LOG(ERROR) << "Failed to get kSbSystemPathCacheDirectory";
+    return base::FilePath();
+  }
+  return base::FilePath(cache_dir.data())
+      .Append(kNativeStabilityDirName)
+      .Append(kAckedEventUuidsFileName);
 }
 
 const void* NativeStabilityManager::GetExtension(const char* name) {
@@ -108,6 +224,10 @@ void NativeStabilityManager::GetPendingReportsOnTaskRunner(
     return;
   }
 
+  base::FilePath file_path = GetAckedUuidsFilePath();
+  std::unordered_set<std::string> acked_uuids =
+      ReadAckedUuidsFromDisk(file_path);
+
   // We want a number large enough that we avoid missing any reports in all but
   // the most extreme cases, but not so large that we waste significant memory
   // when allocating the buffer.
@@ -124,6 +244,12 @@ void NativeStabilityManager::GetPendingReportsOnTaskRunner(
 
   for (int i = 0; i < count; ++i) {
     const auto& sb_report = sb_reports[i];
+    std::string uuid(sb_report.native_stability_event_uuid);
+    if (!uuid.empty() && acked_uuids.contains(uuid)) {
+      VLOG(1) << "Skipping acknowledged native stability report UUID: " << uuid;
+      continue;
+    }
+
     if (sb_report.report_type == kSbNativeStabilityReportCrash) {
       auto crash_report = mojom::NativeCrashReport::New();
       crash_report->base = CreateBaseReportData(sb_report);
@@ -141,6 +267,46 @@ void NativeStabilityManager::GetPendingReportsOnTaskRunner(
   }
 
   std::move(callback).Run(std::move(results));
+}
+
+void NativeStabilityManager::AcknowledgeReports(
+    std::vector<std::string> native_stability_event_uuids,
+    base::OnceClosure callback) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!task_runner_) {
+    task_runner_ = base::ThreadPool::CreateSequencedTaskRunner(
+        {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+         base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN});
+  }
+  task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(&NativeStabilityManager::AcknowledgeReportsOnTaskRunner,
+                     base::Unretained(this),
+                     std::move(native_stability_event_uuids),
+                     base::BindPostTaskToCurrentDefault(std::move(callback))));
+}
+
+void NativeStabilityManager::AcknowledgeReportsOnTaskRunner(
+    std::vector<std::string> native_stability_event_uuids,
+    base::OnceClosure callback) {
+  base::FilePath file_path = GetAckedUuidsFilePath();
+  std::unordered_set<std::string> acked_uuids =
+      ReadAckedUuidsFromDisk(file_path);
+
+  bool changed = false;
+  for (const auto& uuid : native_stability_event_uuids) {
+    if (!uuid.empty() && acked_uuids.insert(uuid).second) {
+      changed = true;
+    }
+  }
+
+  if (changed) {
+    // It's simpler and safer to just overwrite the file with previously +
+    // currently acknowledged event UUIDs, rather than append to it.
+    WriteAckedUuidsToDisk(file_path, acked_uuids);
+  }
+
+  std::move(callback).Run();
 }
 
 }  // namespace h5vcc_native_stability

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
@@ -89,10 +89,11 @@ std::unordered_set<std::string> ReadAckedUuidsFromDisk(
   return acked_uuids;
 }
 
-bool WriteAckedUuidsToDisk(const base::FilePath& file_path,
+void WriteAckedUuidsToDisk(const base::FilePath& file_path,
                            const std::unordered_set<std::string>& acked_uuids) {
   if (file_path.empty()) {
-    return false;
+    LOG(ERROR) << "Failed to write acked UUIDs: file path is empty.";
+    return;
   }
 
   // We typically expect this directory to already exist but it may not, for
@@ -104,7 +105,7 @@ bool WriteAckedUuidsToDisk(const base::FilePath& file_path,
     LOG(ERROR) << "Failed to create " << kNativeStabilityDirName
                << " directory: " << dir_path.value()
                << ", error: " << base::File::ErrorToString(error);
-    return false;
+    return;
   }
 
   base::Value::List list_of_uuids;
@@ -116,16 +117,14 @@ bool WriteAckedUuidsToDisk(const base::FilePath& file_path,
   std::optional<std::string> json = base::WriteJson(list_of_uuids);
   if (!json) {
     LOG(ERROR) << "Failed to serialize acked UUIDs list to JSON.";
-    return false;
+    return;
   }
 
   if (!base::ImportantFileWriter::WriteFileAtomically(file_path, *json)) {
     LOG(ERROR) << "Failed to write acked UUIDs atomically to: "
                << file_path.value();
-    return false;
+    return;
   }
-
-  return true;
 }
 
 }  // namespace

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
@@ -68,6 +68,13 @@ class NativeStabilityManager {
   //
   // As with GetPendingReports(), disk I/O is offloaded to a background
   // ThreadPool task runner and callbacks are posted back to the UI sequence.
+  //
+  // Concurrent execution by different Cobalt processes will not produce invalid
+  // acknowledged state but could cause read-modify-write races with the last
+  // write winning.
+  // TODO(b/528362453): Consider implementing mutual process exclusion. Since
+  // this is most likely to occur with Cobalt processes running different web
+  // applications, we may do this by partitioning the file by web app.
   void AcknowledgeReports(std::vector<std::string> native_stability_event_uuids,
                           base::OnceClosure callback);
 

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
@@ -34,7 +34,9 @@ namespace h5vcc_native_stability {
 //
 // Threading Model:
 // Calls must originate on the UI sequence. Offloads blocking disk I/O to a
-// background task runner and posts response callbacks back to the UI sequence.
+// background SequencedTaskRunner and posts response callbacks back to the UI
+// sequence. Using a SequencedTaskRunner guarantees that disk operations execute
+// sequentially, preventing concurrent reads and writes.
 class NativeStabilityManager {
  public:
   static NativeStabilityManager* GetInstance();
@@ -47,7 +49,8 @@ class NativeStabilityManager {
   // with it.
   void ArmCrashUuidAnnotation();
 
-  // Asynchronously reads and summarizes stability reports stored on disk.
+  // Asynchronously reads and summarizes stability reports stored on disk that
+  // have not previously been acknowledged.
   //
   // Because reading files from disk is a blocking operation, the disk I/O is
   // offloaded to a background ThreadPool task runner to prevent blocking the
@@ -57,11 +60,25 @@ class NativeStabilityManager {
       base::OnceCallback<void(std::vector<mojom::NativeStabilityReportPtr>)>
           callback);
 
+  // Asynchronously acknowledges stability reports to exclude them from future
+  // calls to GetPendingReports().
+  //
+  // The provided UUIDs are persisted to disk so that their acknowledged status
+  // persists across application lifecycles.
+  //
+  // As with GetPendingReports(), disk I/O is offloaded to a background
+  // ThreadPool task runner and callbacks are posted back to the UI sequence.
+  void AcknowledgeReports(std::vector<std::string> native_stability_event_uuids,
+                          base::OnceClosure callback);
+
   using GetExtensionCallback =
       base::RepeatingCallback<const void*(const char*)>;
 
-  // Inject a custom Starboard extension getter callback for testing.
+  // Injects a custom Starboard extension getter callback for testing.
   void SetGetExtensionForTesting(GetExtensionCallback get_extension_callback);
+
+  // Injects a custom path for acked_event_uuids.json for testing.
+  void SetAckedUuidsFilePathForTesting(base::FilePath file_path);
 
   // Resets internal state for unit testing between test cases.
   void ResetForTesting();
@@ -77,11 +94,18 @@ class NativeStabilityManager {
       base::OnceCallback<void(std::vector<mojom::NativeStabilityReportPtr>)>
           callback);
 
+  void AcknowledgeReportsOnTaskRunner(
+      std::vector<std::string> native_stability_event_uuids,
+      base::OnceClosure callback);
+
+  base::FilePath GetAckedUuidsFilePath();
+
   const void* GetExtension(const char* name);
 
   scoped_refptr<base::SequencedTaskRunner> task_runner_;
 
   GetExtensionCallback get_extension_callback_for_testing_;
+  base::FilePath acked_uuids_file_path_for_testing_;
 
   SEQUENCE_CHECKER(sequence_checker_);
 };

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
@@ -63,11 +63,21 @@ void SetupStubExtension(
 
 class NativeStabilityManagerTest : public ::testing::Test {
  protected:
+  void SetUp() override {
+    // Overriding the acked UUIDs file path with a unique temporary directory
+    // for every test 1) isolates test storage and 2) ensures actual platform
+    // directories (e.g. kSbSystemPathCacheDirectory) are not used.
+    ASSERT_TRUE(temp_dir_.CreateUniqueTempDir());
+    NativeStabilityManager::GetInstance()->SetAckedUuidsFilePathForTesting(
+        temp_dir_.GetPath().Append("acked_event_uuids.json"));
+  }
+
   void TearDown() override {
     NativeStabilityManager::GetInstance()->ResetForTesting();
   }
 
   base::test::TaskEnvironment task_environment_;
+  base::ScopedTempDir temp_dir_;
 };
 
 TEST_F(NativeStabilityManagerTest, GetInstanceReturnsSingleton) {
@@ -266,12 +276,7 @@ TEST_F(NativeStabilityManagerTest, GetPendingReportsIgnoresUnknownReportType) {
 
 TEST_F(NativeStabilityManagerTest,
        AcknowledgedReportsFilteredByGetPendingReports) {
-  base::ScopedTempDir temp_dir;
-  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
-
   auto* manager = NativeStabilityManager::GetInstance();
-  manager->SetAckedUuidsFilePathForTesting(
-      temp_dir.GetPath().Append("acked_event_uuids.json"));
 
   SbNativeStabilityReport report1 = {};
   report1.report_type = kSbNativeStabilityReportCrash;

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
@@ -349,4 +349,58 @@ TEST_F(NativeStabilityManagerTest,
   }
 }
 
+TEST_F(NativeStabilityManagerTest,
+       AcknowledgingEmptyOrDuplicateUuidsHasNoEffect) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report1.native_stability_event_uuid, "uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report1});
+
+  // Acknowledge empty strings and duplicates alongside valid UUID.
+  base::RunLoop run_loop;
+  manager->AcknowledgeReports({"", "uuid-1", "uuid-1", ""},
+                              run_loop.QuitClosure());
+  run_loop.Run();
+
+  // Verify uuid-1 was acknowledged and no crash occurred.
+  base::RunLoop run_loop2;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        EXPECT_TRUE(reports.empty());
+        std::move(quit_closure).Run();
+      },
+      run_loop2.QuitClosure()));
+  run_loop2.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       GetPendingReportsIgnoresCorruptedAckedUuidsFile) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report1.native_stability_event_uuid, "uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report1});
+
+  // Write corrupted JSON to the acked UUIDs file path.
+  base::FilePath file_path =
+      temp_dir_.GetPath().Append("acked_event_uuids.json");
+  ASSERT_TRUE(base::WriteFile(file_path, "invalid json"));
+
+  // Verify GetPendingReports handles corrupt JSON gracefully and returns the
+  // pending report.
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        EXPECT_EQ(reports.size(), 1u);
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
 }  // namespace h5vcc_native_stability

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
@@ -18,8 +18,11 @@
 #include <cstring>
 #include <vector>
 
+#include "base/files/file_util.h"
+#include "base/files/scoped_temp_dir.h"
 #include "base/functional/bind.h"
 #include "base/run_loop.h"
+#include "base/strings/stringprintf.h"
 #include "base/test/task_environment.h"
 #include "cobalt/browser/h5vcc_native_stability/public/mojom/h5vcc_native_stability.mojom.h"
 #include "starboard/extension/native_stability.h"
@@ -176,6 +179,12 @@ TEST_F(NativeStabilityManagerTest,
       kStarboardExtensionNativeStabilityName,
       1,
       [](SbNativeStabilityReport* reports, int max_reports) -> int {
+        for (int i = 0; i < max_reports; ++i) {
+          reports[i].report_type = kSbNativeStabilityReportCrash;
+          std::string uuid = base::StringPrintf("crash-uuid-%05d", i);
+          std::strncpy(reports[i].native_stability_event_uuid, uuid.c_str(),
+                       sizeof(reports[i].native_stability_event_uuid) - 1);
+        }
         return 999;  // Return out-of-bounds count exceeding max_reports
       },
   };
@@ -194,7 +203,7 @@ TEST_F(NativeStabilityManagerTest,
          std::vector<mojom::NativeStabilityReportPtr> reports) {
         // Verify no crash occurred and count was clamped to kMaxNumReports
         // (128)
-        EXPECT_LE(reports.size(), 128u);
+        EXPECT_EQ(reports.size(), 128u);
         std::move(quit_closure).Run();
       },
       run_loop.QuitClosure()));
@@ -253,6 +262,86 @@ TEST_F(NativeStabilityManagerTest, GetPendingReportsIgnoresUnknownReportType) {
       },
       run_loop.QuitClosure()));
   run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
+       AcknowledgedReportsFilteredByGetPendingReports) {
+  base::ScopedTempDir temp_dir;
+  ASSERT_TRUE(temp_dir.CreateUniqueTempDir());
+
+  auto* manager = NativeStabilityManager::GetInstance();
+  manager->SetAckedUuidsFilePathForTesting(
+      temp_dir.GetPath().Append("acked_event_uuids.json"));
+
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report1.native_stability_event_uuid, "uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  report1.event_time_s = 1000;
+
+  SbNativeStabilityReport report2 = {};
+  report2.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report2.native_stability_event_uuid, "uuid-2",
+               sizeof(report2.native_stability_event_uuid) - 1);
+  report2.event_time_s = 2000;
+
+  SetupStubExtension(manager, {report1, report2});
+
+  // Verify initial call returns both reports.
+  {
+    base::RunLoop run_loop;
+    manager->GetPendingReports(base::BindOnce(
+        [](base::OnceClosure quit_closure,
+           std::vector<mojom::NativeStabilityReportPtr> reports) {
+          ASSERT_EQ(reports.size(), 2u);
+          std::move(quit_closure).Run();
+        },
+        run_loop.QuitClosure()));
+    run_loop.Run();
+  }
+
+  // Acknowledge uuid-1.
+  {
+    base::RunLoop run_loop;
+    manager->AcknowledgeReports({"uuid-1"}, run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  // Verify subsequent call returns only uuid-2.
+  {
+    base::RunLoop run_loop;
+    manager->GetPendingReports(base::BindOnce(
+        [](base::OnceClosure quit_closure,
+           std::vector<mojom::NativeStabilityReportPtr> reports) {
+          ASSERT_EQ(reports.size(), 1u);
+          EXPECT_EQ(
+              reports[0]->get_crash_report()->base->native_stability_event_uuid,
+              "uuid-2");
+          std::move(quit_closure).Run();
+        },
+        run_loop.QuitClosure()));
+    run_loop.Run();
+  }
+
+  // Acknowledge uuid-2 as well.
+  {
+    base::RunLoop run_loop;
+    manager->AcknowledgeReports({"uuid-2"}, run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  // Verify GetPendingReports returns no reports once all are acknowledged.
+  {
+    base::RunLoop run_loop;
+    manager->GetPendingReports(base::BindOnce(
+        [](base::OnceClosure quit_closure,
+           std::vector<mojom::NativeStabilityReportPtr> reports) {
+          EXPECT_TRUE(reports.empty());
+          std::move(quit_closure).Run();
+        },
+        run_loop.QuitClosure()));
+    run_loop.Run();
+  }
 }
 
 }  // namespace h5vcc_native_stability

--- a/cobalt/browser/h5vcc_native_stability/public/mojom/h5vcc_native_stability.mojom
+++ b/cobalt/browser/h5vcc_native_stability/public/mojom/h5vcc_native_stability.mojom
@@ -40,7 +40,12 @@ union NativeStabilityReport {
 // The browser process must provide an implementation of this interface in order
 // to enable web clients to retrieve pending native stability reports.
 interface H5vccNativeStability {
-  // Returns summary reports of native stability events that have been recorded
-  // by the native application or platform and persisted to disk.
+  // Returns summary reports of unacknowledged native stability events that have
+  // been recorded by the native application or platform and persisted to disk.
   GetPendingReports() => (array<NativeStabilityReport> reports);
+
+  // Acknowledges that the specified native stability event UUIDs have been
+  // processed by the web application. Acknowledged reports will not be
+  // returned in subsequent calls to GetPendingReports.
+  AcknowledgeReports(array<string> native_stability_event_uuids) => ();
 };

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.cc
@@ -136,7 +136,6 @@ void H5vccNativeStability::OnConnectionError() {
   for (auto& resolver : pending_promises) {
     resolver->Reject("Mojo connection error.");
   }
-  ongoing_requests_.clear();
 }
 
 void H5vccNativeStability::Trace(Visitor* visitor) const {

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.cc
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.cc
@@ -41,8 +41,26 @@ H5vccNativeStability::getPendingReports(ScriptState* script_state,
       ScriptPromiseResolver<IDLSequence<V8NativeStabilityReport>>>(
       script_state, exception_state.GetContext());
 
+  ongoing_requests_.insert(resolver);
   remote_native_stability_->GetPendingReports(
       WTF::BindOnce(&H5vccNativeStability::OnGetPendingReports,
+                    WrapPersistent(this), WrapPersistent(resolver)));
+
+  return resolver->Promise();
+}
+
+ScriptPromise<IDLUndefined> H5vccNativeStability::acknowledgeReports(
+    ScriptState* script_state,
+    const Vector<String>& native_stability_event_uuids,
+    ExceptionState& exception_state) {
+  EnsureReceiverIsBound();
+  auto* resolver = MakeGarbageCollected<ScriptPromiseResolver<IDLUndefined>>(
+      script_state, exception_state.GetContext());
+
+  ongoing_requests_.insert(resolver);
+  remote_native_stability_->AcknowledgeReports(
+      native_stability_event_uuids,
+      WTF::BindOnce(&H5vccNativeStability::OnAcknowledgeReports,
                     WrapPersistent(this), WrapPersistent(resolver)));
 
   return resolver->Promise();
@@ -65,6 +83,7 @@ void H5vccNativeStability::OnGetPendingReports(
     ScriptPromiseResolver<IDLSequence<V8NativeStabilityReport>>* resolver,
     Vector<h5vcc_native_stability::mojom::blink::NativeStabilityReportPtr>
         mojo_reports) {
+  ongoing_requests_.erase(resolver);
   HeapVector<Member<V8NativeStabilityReport>> result;
   for (const auto& mojo_report : mojo_reports) {
     if (mojo_report->is_crash_report()) {
@@ -87,6 +106,12 @@ void H5vccNativeStability::OnGetPendingReports(
   resolver->Resolve(std::move(result));
 }
 
+void H5vccNativeStability::OnAcknowledgeReports(
+    ScriptPromiseResolver<IDLUndefined>* resolver) {
+  ongoing_requests_.erase(resolver);
+  resolver->Resolve();
+}
+
 void H5vccNativeStability::EnsureReceiverIsBound() {
   DCHECK(GetExecutionContext());
 
@@ -98,11 +123,26 @@ void H5vccNativeStability::EnsureReceiverIsBound() {
       GetExecutionContext()->GetTaskRunner(TaskType::kMiscPlatformAPI);
   GetExecutionContext()->GetBrowserInterfaceBroker().GetInterface(
       remote_native_stability_.BindNewPipeAndPassReceiver(task_runner));
+  remote_native_stability_.set_disconnect_handler(WTF::BindOnce(
+      &H5vccNativeStability::OnConnectionError, WrapWeakPersistent(this)));
+}
+
+void H5vccNativeStability::OnConnectionError() {
+  remote_native_stability_.reset();
+  HeapHashSet<Member<ScriptPromiseResolverBase>> pending_promises;
+  // Script may execute during a call to Reject(). Swap these sets to prevent
+  // concurrent modification.
+  ongoing_requests_.swap(pending_promises);
+  for (auto& resolver : pending_promises) {
+    resolver->Reject("Mojo connection error.");
+  }
+  ongoing_requests_.clear();
 }
 
 void H5vccNativeStability::Trace(Visitor* visitor) const {
   ScriptWrappable::Trace(visitor);
   ExecutionContextLifecycleObserver::Trace(visitor);
+  visitor->Trace(ongoing_requests_);
   visitor->Trace(remote_native_stability_);
 }
 

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.h
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.h
@@ -22,6 +22,7 @@
 #include "third_party/blink/renderer/core/execution_context/execution_context_lifecycle_observer.h"
 #include "third_party/blink/renderer/modules/modules_export.h"
 #include "third_party/blink/renderer/platform/bindings/script_wrappable.h"
+#include "third_party/blink/renderer/platform/heap/collection_support/heap_hash_set.h"
 #include "third_party/blink/renderer/platform/mojo/heap_mojo_remote.h"
 
 namespace blink {
@@ -29,6 +30,7 @@ namespace blink {
 class ExecutionContext;
 class LocalDOMWindow;
 class ScriptState;
+class ScriptPromiseResolverBase;
 template <typename T>
 class ScriptPromiseResolver;
 
@@ -49,15 +51,25 @@ class MODULES_EXPORT H5vccNativeStability final
       ScriptState*,
       ExceptionState&);
 
+  ScriptPromise<IDLUndefined> acknowledgeReports(
+      ScriptState*,
+      const Vector<String>& native_stability_event_uuids,
+      ExceptionState&);
+
   void Trace(Visitor*) const override;
 
  private:
   void EnsureReceiverIsBound();
+  void OnConnectionError();
 
   void OnGetPendingReports(
       ScriptPromiseResolver<IDLSequence<V8NativeStabilityReport>>* resolver,
       Vector<h5vcc_native_stability::mojom::blink::NativeStabilityReportPtr>
           mojo_reports);
+
+  void OnAcknowledgeReports(ScriptPromiseResolver<IDLUndefined>* resolver);
+
+  HeapHashSet<Member<ScriptPromiseResolverBase>> ongoing_requests_;
 
   HeapMojoRemote<h5vcc_native_stability::mojom::blink::H5vccNativeStability>
       remote_native_stability_;

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.idl
@@ -40,11 +40,15 @@ typedef (NativeCrashReport or HangReport) NativeStabilityReport;
 ]
 interface H5vccNativeStability {
 
-  // Returns summary reports of native stability events that have been recorded
-  // by the native application or platform and persisted to disk.
+  // Returns summary reports of unacknowledged native stability events that
+  // have been recorded by the native application or platform and persisted
+  // to disk.
   [CallWith=ScriptState, RaisesException]
   Promise<sequence<NativeStabilityReport>> getPendingReports();
 
-  // TODO(b/528362453): Add |acknowledgeReports| API and update the comment for
-  // |getPendingReports| accordingly.
+  // Acknowledges native stability reports so that they will not be returned by
+  // future calls to getPendingReports().
+  [CallWith=ScriptState, RaisesException]
+  Promise<undefined> acknowledgeReports(
+      sequence<DOMString> nativeStabilityEventUuids);
 };

--- a/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.idl
+++ b/third_party/blink/renderer/modules/cobalt/h5vcc_native_stability/h_5_vcc_native_stability.idl
@@ -34,6 +34,9 @@ dictionary HangReport : BaseNativeStabilityReport {
 
 typedef (NativeCrashReport or HangReport) NativeStabilityReport;
 
+// Interface for querying and acknowledging native stability reports.
+// On platforms that do not support native stability reporting, calling these
+// APIs will result in promises rejected with "Mojo connection error".
 [
   Exposed=Window,
   SecureContext

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-native-stability/h5vcc-native-stability-acknowledgeReports.https.any.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-native-stability/h5vcc-native-stability-acknowledgeReports.https.any.js
@@ -1,0 +1,43 @@
+// META: global=window
+// META: script=/resources/test-only-api.js
+// META: script=resources/automation.js
+
+h5vcc_native_stability_test(async (t, fake) => {
+  assert_implements(window.h5vcc, 'window.h5vcc not supported');
+  assert_implements(
+    window.h5vcc.nativeStability,
+    'window.h5vcc.nativeStability not supported');
+
+  fake.stubReports([
+    {
+      crashReport: {
+        base: {
+          nativeStabilityEventUuid: 'crash-uuid-1',
+          eventTimeSec: 1700000000n,
+        }
+      }
+    },
+    {
+      crashReport: {
+        base: {
+          nativeStabilityEventUuid: 'crash-uuid-2',
+          eventTimeSec: 1700001000n,
+        }
+      }
+    }
+  ]);
+
+  let initialReports = await window.h5vcc.nativeStability.getPendingReports();
+  assert_equals(initialReports.length, 2);
+
+  // Acknowledge the first crash report.
+  let ackResult = await window.h5vcc.nativeStability.acknowledgeReports(
+    ['crash-uuid-1']);
+  assert_equals(
+    ackResult, undefined, 'acknowledgeReports should return undefined');
+
+  let remainingReports =
+    await window.h5vcc.nativeStability.getPendingReports();
+  assert_equals(remainingReports.length, 1);
+  assert_equals(remainingReports[0].nativeStabilityEventUuid, 'crash-uuid-2');
+}, 'exercises H5vccNativeStability.acknowledgeReports() filtering');

--- a/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-native-stability/resources/fake-h5vcc-native-stability-impl.js
+++ b/third_party/blink/web_tests/wpt_internal/cobalt/h5vcc-native-stability/resources/fake-h5vcc-native-stability-impl.js
@@ -11,6 +11,7 @@ class FakeH5vccNativeStabilityImpl {
     this.interceptor_.oninterfacerequest = e => this.bind(e.handle);
     this.receiver_ = new H5vccNativeStabilityReceiver(this);
     this.reports_ = [];
+    this.ackedUuids_ = [];
   }
 
   start() {
@@ -23,6 +24,7 @@ class FakeH5vccNativeStabilityImpl {
 
   reset() {
     this.reports_ = [];
+    this.ackedUuids_ = [];
   }
 
   // Added for stubbing getPendingReports() results in tests.
@@ -32,8 +34,19 @@ class FakeH5vccNativeStabilityImpl {
 
   async getPendingReports() {
     return {
-      reports: this.reports_
+      reports: this.reports_.filter(report => {
+        const uuid = report.crashReport?.base?.nativeStabilityEventUuid ||
+                     report.hangReport?.base?.nativeStabilityEventUuid;
+        return !uuid || !this.ackedUuids_.includes(uuid);
+      })
     };
+  }
+
+  async acknowledgeReports(uuids) {
+    if (uuids && Array.isArray(uuids)) {
+      this.ackedUuids_.push(...uuids);
+    }
+    return {};
   }
 
   bind(handle) {


### PR DESCRIPTION
This web API enables a web app to acknowledge native stability events as already handled so they are no longer returned by getPendingReports(). Acknowledged event UUIDs are persisted to disk so that the behavior survives across Cobalt app lifecycles; storage is managed by the NativeStabilityManager. More context can be found in the "High level" and "Storage 3P MVP" design docs.

To manage the scope of this PR, pruning of the persisted event UUIDs - discussed in the design doc - is left as a quick follow-up.

A stub Mojo binding is provided for the native stability interface for non-Evergreen platforms so that web requests on these platforms will result in rejected promises instead of any actual state changes.

A couple other small improvements are included:
* An existing unit test case is updated to remove noisy logs
* Handling of Mojo disconnection is added to the renderer impl.

Issue: 528362453