### PR TITLE
Add CobaltMemoryMetricsHelper to extract live memory breakdown metrics for non-official builds

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -330,6 +330,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/h5vcc_runtime/deep_link_manager_unittest.cc",
     "//cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc",
     "//cobalt/browser/metrics/cobalt_enabled_state_provider_test.cc",
+    "//cobalt/browser/metrics/cobalt_memory_metrics_helper_unittest.cc",
     "//cobalt/browser/metrics/cobalt_metrics_log_uploader_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_service_client_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_services_manager_client_test.cc",

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -330,13 +330,17 @@ test("cobalt_unittests") {
     "//cobalt/browser/h5vcc_runtime/deep_link_manager_unittest.cc",
     "//cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc",
     "//cobalt/browser/metrics/cobalt_enabled_state_provider_test.cc",
-    "//cobalt/browser/metrics/cobalt_memory_metrics_helper_unittest.cc",
     "//cobalt/browser/metrics/cobalt_metrics_log_uploader_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_service_client_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_services_manager_client_test.cc",
     "//cobalt/browser/user_agent/user_agent_platform_info_test.cc",
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_unittest.cc",
   ]
+
+  if (!is_official_build) {
+    sources +=
+        [ "//cobalt/browser/metrics/cobalt_memory_metrics_helper_unittest.cc" ]
+  }
 
   # The symbolizer pipeline test requires launching external Python and
   # llvm-symbolizer processes, which is not supported on Starboard and

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -207,8 +207,6 @@ source_set("metrics") {
     "metrics/cobalt_enabled_state_provider.h",
     "metrics/cobalt_memory_metrics_emitter.cc",
     "metrics/cobalt_memory_metrics_emitter.h",
-    "metrics/cobalt_memory_metrics_helper.cc",
-    "metrics/cobalt_memory_metrics_helper.h",
     "metrics/cobalt_metrics_log_uploader.cc",
     "metrics/cobalt_metrics_log_uploader.h",
     "metrics/cobalt_metrics_service_client.cc",
@@ -216,6 +214,12 @@ source_set("metrics") {
     "metrics/cobalt_metrics_services_manager_client.cc",
     "metrics/cobalt_metrics_services_manager_client.h",
   ]
+  if (!is_official_build) {
+    sources += [
+      "metrics/cobalt_memory_metrics_helper.cc",
+      "metrics/cobalt_memory_metrics_helper.h",
+    ]
+  }
   deps = [
     ":features",
     "//cobalt/browser/h5vcc_metrics/public/mojom",

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -207,6 +207,8 @@ source_set("metrics") {
     "metrics/cobalt_enabled_state_provider.h",
     "metrics/cobalt_memory_metrics_emitter.cc",
     "metrics/cobalt_memory_metrics_emitter.h",
+    "metrics/cobalt_memory_metrics_helper.cc",
+    "metrics/cobalt_memory_metrics_helper.h",
     "metrics/cobalt_metrics_log_uploader.cc",
     "metrics/cobalt_metrics_log_uploader.h",
     "metrics/cobalt_metrics_service_client.cc",

--- a/cobalt/browser/metrics/cobalt_memory_metrics_helper.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_helper.cc
@@ -16,21 +16,29 @@
 
 #include <iterator>
 #include <memory>
+#include <optional>
+#include <string_view>
+#include <vector>
 
 #include "base/metrics/histogram_base.h"
 #include "base/metrics/histogram_samples.h"
 #include "base/metrics/statistics_recorder.h"
+#include "base/strings/string_util.h"
 
 namespace cobalt {
 
 namespace {
 
-// UMA Memory.Experimental.Browser2.* histograms record values in KiB
-// (Kilobytes). Convert KiB to bytes for consistent DevTools byte reporting.
-constexpr uint64_t kBytesPerKiB = 1024;
+// All Cobalt memory breakdown histograms (emitted in
+// cobalt_memory_metrics_emitter.cc and peak_gpu_memory_callback.cc via
+// base::UmaHistogramMemoryLargeMB) store values in MiB (Mebibytes). We convert
+// MiB to bytes (1 MiB = 1,048,576 bytes) for consistent DevTools byte
+// reporting.
+constexpr uint64_t kBytesPerMiB = 1024 * 1024;
 
-bool IsKiBHistogram(const std::string& metric_name) {
-  return metric_name.rfind("Memory.Experimental.Browser2.", 0) == 0 ||
+bool IsMiBHistogram(std::string_view metric_name) {
+  return base::StartsWith(metric_name, "Memory.Experimental.Browser2.",
+                          base::CompareCase::SENSITIVE) ||
          metric_name == "Memory.Browser.ResidentSet" ||
          metric_name == "Memory.Browser.PrivateMemoryFootprint" ||
          metric_name == "Memory.Browser.LibChrobaltRss" ||
@@ -39,13 +47,7 @@ bool IsKiBHistogram(const std::string& metric_name) {
 
 }  // namespace
 
-constexpr const char* CobaltMemoryMetricsHelper::kMemoryBreakdownMetricNames[];
-
-std::optional<uint64_t> CobaltMemoryMetricsHelper::GetMetricValueBytes(
-    const std::string& metric_name) {
-#if defined(OFFICIAL_BUILD)
-  return std::nullopt;
-#else
+std::optional<uint64_t> GetMetricValueBytes(std::string_view metric_name) {
   base::HistogramBase* histogram =
       base::StatisticsRecorder::FindHistogram(metric_name);
   if (!histogram) {
@@ -54,23 +56,41 @@ std::optional<uint64_t> CobaltMemoryMetricsHelper::GetMetricValueBytes(
 
   std::unique_ptr<base::HistogramSamples> samples =
       histogram->SnapshotSamples();
-  if (!samples || samples->TotalCount() == 0) {
+  int64_t total_count = samples ? samples->TotalCount() : 0;
+  if (!samples || total_count <= 0) {
     return std::nullopt;
   }
 
-  uint64_t raw_sum = static_cast<uint64_t>(samples->sum());
-  if (IsKiBHistogram(metric_name)) {
-    return raw_sum * kBytesPerKiB;
+  int64_t target_count = (total_count + 1) / 2;
+  int64_t accumulated_count = 0;
+  uint64_t p50_value = 0;
+
+  // Compute p50 (median) sample from accumulated bucket samples, mirroring
+  // the field percentile calculation in
+  // cobalt/tools/uma/interpret_uma_histogram.py (which uses the bucket upper
+  // bound max/high).
+  for (std::unique_ptr<base::SampleCountIterator> it = samples->Iterator();
+       !it->Done(); it->Next()) {
+    base::HistogramBase::Sample32 min;
+    int64_t max;
+    base::HistogramBase::Count32 count;
+    it->Get(&min, &max, &count);
+    accumulated_count += count;
+    if (accumulated_count >= target_count) {
+      p50_value = static_cast<uint64_t>(max);
+      break;
+    }
   }
 
-  return raw_sum;
-#endif
+  if (IsMiBHistogram(metric_name)) {
+    return p50_value * kBytesPerMiB;
+  }
+
+  return p50_value;
 }
 
-std::vector<MemoryBreakdownMetric>
-CobaltMemoryMetricsHelper::GetMemoryBreakdown() {
+std::optional<std::vector<MemoryBreakdownMetric>> GetMemoryBreakdown() {
   std::vector<MemoryBreakdownMetric> breakdown;
-#if !defined(OFFICIAL_BUILD)
   breakdown.reserve(std::size(kMemoryBreakdownMetricNames));
 
   for (const char* metric_name : kMemoryBreakdownMetricNames) {
@@ -79,7 +99,11 @@ CobaltMemoryMetricsHelper::GetMemoryBreakdown() {
       breakdown.push_back({metric_name, value.value()});
     }
   }
-#endif
+
+  if (breakdown.empty()) {
+    return std::nullopt;
+  }
+
   return breakdown;
 }
 

--- a/cobalt/browser/metrics/cobalt_memory_metrics_helper.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_helper.cc
@@ -1,0 +1,86 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/metrics/cobalt_memory_metrics_helper.h"
+
+#include <iterator>
+#include <memory>
+
+#include "base/metrics/histogram_base.h"
+#include "base/metrics/histogram_samples.h"
+#include "base/metrics/statistics_recorder.h"
+
+namespace cobalt {
+
+namespace {
+
+// UMA Memory.Experimental.Browser2.* histograms record values in KiB
+// (Kilobytes). Convert KiB to bytes for consistent DevTools byte reporting.
+constexpr uint64_t kBytesPerKiB = 1024;
+
+bool IsKiBHistogram(const std::string& metric_name) {
+  return metric_name.rfind("Memory.Experimental.Browser2.", 0) == 0 ||
+         metric_name == "Memory.Browser.ResidentSet" ||
+         metric_name == "Memory.Browser.PrivateMemoryFootprint" ||
+         metric_name == "Memory.Browser.LibChrobaltRss" ||
+         metric_name == "Memory.GPU.PeakMemoryUsage2.PageLoad";
+}
+
+}  // namespace
+
+constexpr const char* CobaltMemoryMetricsHelper::kMemoryBreakdownMetricNames[];
+
+std::optional<uint64_t> CobaltMemoryMetricsHelper::GetMetricValueBytes(
+    const std::string& metric_name) {
+#if defined(OFFICIAL_BUILD)
+  return std::nullopt;
+#else
+  base::HistogramBase* histogram =
+      base::StatisticsRecorder::FindHistogram(metric_name);
+  if (!histogram) {
+    return std::nullopt;
+  }
+
+  std::unique_ptr<base::HistogramSamples> samples =
+      histogram->SnapshotSamples();
+  if (!samples || samples->TotalCount() == 0) {
+    return std::nullopt;
+  }
+
+  uint64_t raw_sum = static_cast<uint64_t>(samples->sum());
+  if (IsKiBHistogram(metric_name)) {
+    return raw_sum * kBytesPerKiB;
+  }
+
+  return raw_sum;
+#endif
+}
+
+std::vector<MemoryBreakdownMetric>
+CobaltMemoryMetricsHelper::GetMemoryBreakdown() {
+  std::vector<MemoryBreakdownMetric> breakdown;
+#if !defined(OFFICIAL_BUILD)
+  breakdown.reserve(std::size(kMemoryBreakdownMetricNames));
+
+  for (const char* metric_name : kMemoryBreakdownMetricNames) {
+    auto value = GetMetricValueBytes(metric_name);
+    if (value.has_value()) {
+      breakdown.push_back({metric_name, value.value()});
+    }
+  }
+#endif
+  return breakdown;
+}
+
+}  // namespace cobalt

--- a/cobalt/browser/metrics/cobalt_memory_metrics_helper.h
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_helper.h
@@ -17,7 +17,7 @@
 
 #include <cstdint>
 #include <optional>
-#include <string>
+#include <string_view>
 #include <vector>
 
 namespace cobalt {
@@ -27,34 +27,40 @@ struct MemoryBreakdownMetric {
   uint64_t value_bytes;
 };
 
-// Helper class for extracting live Cobalt/Chromium memory breakdown metrics
-// from base::StatisticsRecorder. Aligns with go/kimono-memory-metrics.
-class CobaltMemoryMetricsHelper {
- public:
-  // Standard memory breakdown metrics tracked in PLX / Kimono telemetry
-  // configs.
-  static constexpr const char* kMemoryBreakdownMetricNames[] = {
-      "Memory.Browser.ResidentSet",
-      "Memory.Browser.PrivateMemoryFootprint",
-      "Memory.Experimental.Browser2.Malloc",
-      "Memory.Experimental.Browser2.PartitionAlloc",
-      "Memory.Experimental.Browser2.V8",
-      "Memory.Experimental.Browser2.BlinkGC",
-      "Memory.Experimental.Browser2.Skia",
-      "Memory.Browser.LibChrobaltRss",
-      "Memory.Experimental.Browser2.CodeOther",
-      "Memory.Experimental.Browser2.Fonts",
-      "Memory.Experimental.Browser2.Stacks",
-      "Memory.GPU.PeakMemoryUsage2.PageLoad"};
+// Helper functions for extracting live Cobalt/Chromium memory breakdown metrics
+// from base::StatisticsRecorder. Aligns with go/kimono-memory-metrics and
+// mirrors the field p50 (median) metric calculation in
+// interpret_uma_histogram.py. Used by Blink CDP Performance domain
+// (InspectorPerformanceAgent::getMetrics) and DevTools memory breakdown
+// inspection.
+//
+// Threading Model:
+// These non-member functions are thread-safe and can be called from any thread
+// or TaskRunner, as they rely on the thread-safe base::StatisticsRecorder.
 
-  // Query a single metric by histogram name. Returns value in bytes if found.
-  static std::optional<uint64_t> GetMetricValueBytes(
-      const std::string& metric_name);
+// Standard memory breakdown metrics tracked in PLX / Kimono telemetry
+// configs.
+constexpr const char* kMemoryBreakdownMetricNames[] = {
+    "Memory.Browser.ResidentSet",
+    "Memory.Browser.PrivateMemoryFootprint",
+    "Memory.Experimental.Browser2.Malloc",
+    "Memory.Experimental.Browser2.PartitionAlloc",
+    "Memory.Experimental.Browser2.V8",
+    "Memory.Experimental.Browser2.BlinkGC",
+    "Memory.Experimental.Browser2.Skia",
+    "Memory.Browser.LibChrobaltRss",
+    "Memory.Experimental.Browser2.CodeOther",
+    "Memory.Experimental.Browser2.Fonts",
+    "Memory.Experimental.Browser2.Stacks",
+    "Memory.Experimental.Browser2.JavaHeap",
+    "Memory.GPU.PeakMemoryUsage2.PageLoad"};
 
-  // Queries all target memory breakdown metrics currently present in
-  // StatisticsRecorder.
-  static std::vector<MemoryBreakdownMetric> GetMemoryBreakdown();
-};
+// Query a single metric by histogram name. Returns value in bytes if found.
+std::optional<uint64_t> GetMetricValueBytes(std::string_view metric_name);
+
+// Queries all target memory breakdown metrics currently present in
+// StatisticsRecorder. Returns std::nullopt if no metrics are recorded.
+std::optional<std::vector<MemoryBreakdownMetric>> GetMemoryBreakdown();
 
 }  // namespace cobalt
 

--- a/cobalt/browser/metrics/cobalt_memory_metrics_helper.h
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_helper.h
@@ -1,0 +1,61 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_METRICS_COBALT_MEMORY_METRICS_HELPER_H_
+#define COBALT_BROWSER_METRICS_COBALT_MEMORY_METRICS_HELPER_H_
+
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace cobalt {
+
+struct MemoryBreakdownMetric {
+  const char* name;
+  uint64_t value_bytes;
+};
+
+// Helper class for extracting live Cobalt/Chromium memory breakdown metrics
+// from base::StatisticsRecorder. Aligns with go/kimono-memory-metrics.
+class CobaltMemoryMetricsHelper {
+ public:
+  // Standard memory breakdown metrics tracked in PLX / Kimono telemetry
+  // configs.
+  static constexpr const char* kMemoryBreakdownMetricNames[] = {
+      "Memory.Browser.ResidentSet",
+      "Memory.Browser.PrivateMemoryFootprint",
+      "Memory.Experimental.Browser2.Malloc",
+      "Memory.Experimental.Browser2.PartitionAlloc",
+      "Memory.Experimental.Browser2.V8",
+      "Memory.Experimental.Browser2.BlinkGC",
+      "Memory.Experimental.Browser2.Skia",
+      "Memory.Browser.LibChrobaltRss",
+      "Memory.Experimental.Browser2.CodeOther",
+      "Memory.Experimental.Browser2.Fonts",
+      "Memory.Experimental.Browser2.Stacks",
+      "Memory.GPU.PeakMemoryUsage2.PageLoad"};
+
+  // Query a single metric by histogram name. Returns value in bytes if found.
+  static std::optional<uint64_t> GetMetricValueBytes(
+      const std::string& metric_name);
+
+  // Queries all target memory breakdown metrics currently present in
+  // StatisticsRecorder.
+  static std::vector<MemoryBreakdownMetric> GetMemoryBreakdown();
+};
+
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_METRICS_COBALT_MEMORY_METRICS_HELPER_H_

--- a/cobalt/browser/metrics/cobalt_memory_metrics_helper_unittest.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_helper_unittest.cc
@@ -18,6 +18,7 @@
 #include <vector>
 
 #include "base/metrics/histogram.h"
+#include "base/metrics/histogram_functions.h"
 #include "base/metrics/statistics_recorder.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
@@ -26,44 +27,44 @@ namespace cobalt {
 class CobaltMemoryMetricsHelperTest : public ::testing::Test {
  protected:
   void SetUp() override {
-    // No special initialization required for StatisticsRecorder.
+    statistics_recorder_ =
+        base::StatisticsRecorder::CreateTemporaryForTesting();
   }
+
+  std::unique_ptr<base::StatisticsRecorder> statistics_recorder_;
 };
 
 TEST_F(CobaltMemoryMetricsHelperTest, HandlesUnrecordedHistogram) {
-  auto result = CobaltMemoryMetricsHelper::GetMetricValueBytes(
-      "Memory.Experimental.Browser2.NonExistentTestMetric");
+  auto result =
+      GetMetricValueBytes("Memory.Experimental.Browser2.NonExistentTestMetric");
   EXPECT_FALSE(result.has_value());
 }
 
 TEST_F(CobaltMemoryMetricsHelperTest, RetrievesRecordedHistogramInBytes) {
   const char* test_histogram_name = "Memory.Experimental.Browser2.Malloc";
 
-  base::HistogramBase* histogram = base::Histogram::FactoryGet(
-      test_histogram_name, 1, 1000000, 50, base::HistogramBase::kNoFlags);
-  histogram->Add(1024);  // 1024 KiB = 1 MB
+  base::UmaHistogramMemoryLargeMB(test_histogram_name, 16);  // 16 MiB
 
-  auto result =
-      CobaltMemoryMetricsHelper::GetMetricValueBytes(test_histogram_name);
+  auto result = GetMetricValueBytes(test_histogram_name);
   ASSERT_TRUE(result.has_value());
-  EXPECT_EQ(result.value(), 1024u * 1024u);  // 1,048,576 Bytes
+  EXPECT_GE(result.value(), 10u * 1024u * 1024u);
+  EXPECT_LE(result.value(), 20u * 1024u * 1024u);
 }
 
 TEST_F(CobaltMemoryMetricsHelperTest,
        GetMemoryBreakdownReturnsRecordedMetrics) {
   const char* metric_name = "Memory.Browser.ResidentSet";
-  base::HistogramBase* histogram = base::Histogram::FactoryGet(
-      metric_name, 1, 1000000, 50, base::HistogramBase::kNoFlags);
-  histogram->Add(2048);  // 2048 KiB
+  base::UmaHistogramMemoryLargeMB(metric_name, 32);  // 32 MiB
 
-  std::vector<MemoryBreakdownMetric> breakdown =
-      CobaltMemoryMetricsHelper::GetMemoryBreakdown();
+  auto breakdown = GetMemoryBreakdown();
+  ASSERT_TRUE(breakdown.has_value());
 
   bool found_resident_set = false;
-  for (const auto& entry : breakdown) {
+  for (const auto& entry : breakdown.value()) {
     if (std::string(entry.name) == metric_name) {
       found_resident_set = true;
-      EXPECT_GE(entry.value_bytes, 2048u * 1024u);
+      EXPECT_GE(entry.value_bytes, 20u * 1024u * 1024u);
+      EXPECT_LE(entry.value_bytes, 45u * 1024u * 1024u);
     }
   }
   EXPECT_TRUE(found_resident_set);

--- a/cobalt/browser/metrics/cobalt_memory_metrics_helper_unittest.cc
+++ b/cobalt/browser/metrics/cobalt_memory_metrics_helper_unittest.cc
@@ -1,0 +1,72 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/metrics/cobalt_memory_metrics_helper.h"
+
+#include <string>
+#include <vector>
+
+#include "base/metrics/histogram.h"
+#include "base/metrics/statistics_recorder.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+
+class CobaltMemoryMetricsHelperTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    // No special initialization required for StatisticsRecorder.
+  }
+};
+
+TEST_F(CobaltMemoryMetricsHelperTest, HandlesUnrecordedHistogram) {
+  auto result = CobaltMemoryMetricsHelper::GetMetricValueBytes(
+      "Memory.Experimental.Browser2.NonExistentTestMetric");
+  EXPECT_FALSE(result.has_value());
+}
+
+TEST_F(CobaltMemoryMetricsHelperTest, RetrievesRecordedHistogramInBytes) {
+  const char* test_histogram_name = "Memory.Experimental.Browser2.Malloc";
+
+  base::HistogramBase* histogram = base::Histogram::FactoryGet(
+      test_histogram_name, 1, 1000000, 50, base::HistogramBase::kNoFlags);
+  histogram->Add(1024);  // 1024 KiB = 1 MB
+
+  auto result =
+      CobaltMemoryMetricsHelper::GetMetricValueBytes(test_histogram_name);
+  ASSERT_TRUE(result.has_value());
+  EXPECT_EQ(result.value(), 1024u * 1024u);  // 1,048,576 Bytes
+}
+
+TEST_F(CobaltMemoryMetricsHelperTest,
+       GetMemoryBreakdownReturnsRecordedMetrics) {
+  const char* metric_name = "Memory.Browser.ResidentSet";
+  base::HistogramBase* histogram = base::Histogram::FactoryGet(
+      metric_name, 1, 1000000, 50, base::HistogramBase::kNoFlags);
+  histogram->Add(2048);  // 2048 KiB
+
+  std::vector<MemoryBreakdownMetric> breakdown =
+      CobaltMemoryMetricsHelper::GetMemoryBreakdown();
+
+  bool found_resident_set = false;
+  for (const auto& entry : breakdown) {
+    if (std::string(entry.name) == metric_name) {
+      found_resident_set = true;
+      EXPECT_GE(entry.value_bytes, 2048u * 1024u);
+    }
+  }
+  EXPECT_TRUE(found_resident_set);
+}
+
+}  // namespace cobalt


### PR DESCRIPTION
Introduce CobaltMemoryMetricsHelper to extract live memory breakdown
metrics from the base::StatisticsRecorder. This helper facilitates
retrieving memory usage data from various internal histograms, including
resident set size and private memory footprint.

For specific histograms reported in KiB, the helper converts the values
to bytes to ensure consistent reporting across tools. This
functionality is restricted to non-official builds to support debugging
and internal telemetry analysis.

Bug: 530302534