### PR TITLE
media: Correct misleading log level  (WARNING -> INFO)

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -61,6 +61,7 @@ class MediaCodecBridge {
   @GuardedBy("mNativeBridgeLock")
   private long mNativeMediaCodecBridge;
 
+  private final String mCodecName;
   private final SynchronizedHolder<MediaCodec, IllegalStateException> mMediaCodec =
       new SynchronizedHolder<>(() -> new IllegalStateException("MediaCodec was destroyed"));
 
@@ -276,6 +277,7 @@ class MediaCodecBridge {
   public MediaCodecBridge(
       long nativeMediaCodecBridge,
       MediaCodec mediaCodec,
+      String codecName,
       int tunnelModeAudioSessionId,
       boolean enableFrameRendererListener,
       boolean enableIgnoreCallbacksDuringFlushing) {
@@ -284,6 +286,7 @@ class MediaCodecBridge {
     }
     mNativeMediaCodecBridge = nativeMediaCodecBridge;
     mMediaCodec.set(mediaCodec);
+    mCodecName = codecName != null ? codecName : "unknown";
     mIsTunnelingPlayback = tunnelModeAudioSessionId != TunnelModeAudioSessionId.NONE;
     mEnableFrameRendererListener = enableFrameRendererListener;
     mEnableIgnoreCallbacksDuringFlushing = enableIgnoreCallbacksDuringFlushing;
@@ -470,6 +473,7 @@ class MediaCodecBridge {
         new MediaCodecBridge(
             nativeMediaCodecBridge,
             mediaCodec,
+            decoderName,
             tunnelModeAudioSessionId,
             enableFrameRendererListener,
             ignoreCodecCallbacksDuringFlushing);
@@ -738,30 +742,32 @@ class MediaCodecBridge {
       // We skip calling stop() on Android 11, as this version has a race condition
       // if an error occurs during stop(). See b/369372033 for details.
       if (android.os.Build.VERSION.SDK_INT == android.os.Build.VERSION_CODES.R) {
-        Log.w(TAG, "Skipping stop() during destruction to avoid Android 11 framework bug");
+        Log.i(
+            TAG,
+            "Skipping stop() during destruction to avoid Android 11 framework bug: codec="
+                + mCodecName);
       } else {
         try {
           mMediaCodec.get().stop();
         } catch (Exception e) {
-          Log.w(TAG, "Failed to stop MediaCodec. Proceeding with release", e);
+          Log.w(TAG, "Failed to stop MediaCodec: codec=" + mCodecName, e);
         }
       }
 
       try {
-        String codecName = mMediaCodec.get().getName();
-        Log.w(TAG, "Calling MediaCodec.release() on " + codecName);
+        Log.i(TAG, "Calling MediaCodec.release(): codec=" + mCodecName);
         mMediaCodec.get().release();
       } catch (Exception e) {
         // The MediaCodec is stuck in a wrong state, possibly due to losing
         // the surface.
-        Log.w(TAG, "Failed to release MediaCodec", e);
+        Log.w(TAG, "Failed to release MediaCodec: codec=" + mCodecName, e);
       }
       mMediaCodec.set(null);
     } catch (Throwable t) {
       // Catch Throwable (both Exception and Error) to prevent JNI crashes if the JVM
       // throws linkage errors (e.g., NoClassDefFoundError) during ClassLoader unloading
       // in teardown. See b/455621481.
-      Log.e(TAG, "Exception or Error during MediaCodecBridge release()", t);
+      Log.e(TAG, "Exception or Error during MediaCodecBridge release(): codec=" + mCodecName, t);
     }
   }
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridgeBuilder.java
@@ -56,6 +56,7 @@ class MediaCodecBridgeBuilder {
         new MediaCodecBridge(
             nativeMediaCodecBridge,
             mediaCodec,
+            decoderName,
             TunnelModeAudioSessionId.NONE,
             /*enableFrameRendererListener=*/false,
             /*enableIgnoreCallbacksDuringFlushing=*/false);


### PR DESCRIPTION
Change log levels from WARNING to INFO during MediaCodec destruction
since these are expected events in the teardown process. Also update
log messages to include the codec name to improve clarity when
interpreting logs from multiple codec instances.

```
BEFORE
08-03 13:14:25.751  6926  7024 W starboard_media: Skipping stop() during destruction to avoid Android 11 framework bug
08-03 13:14:25.752  6926  7024 W starboard_media: Calling MediaCodec.release() on c2.android.aac.decoder


AFTER
08-03 13:54:29.390  8175  8266 I starboard_media: Skipping stop() during destruction to avoid Android 11 framework bug: codec=c2.android.aac.decoder
08-03 13:54:29.390  8175  8266 I starboard_media: Calling MediaCodec.release(): codec=c2.android.aac.decoder
```

Issue: 542276633