### PR TITLE
Add verification step for Chromium autoroller

### DIFF
--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -227,10 +227,8 @@ def replace_submodules_with_dirs():
 
 def fetch_chromium_tree(chromium_sha):
   """Fetches the root tree hash directly from Chromium's Gitiles API."""
-  url = (
-      f'https://chromium.googlesource.com/chromium/src/+/{chromium_sha}'
-      '?format=JSON'
-  )
+  url = (f'https://chromium.googlesource.com/chromium/src/+/{chromium_sha}'
+         '?format=JSON')
   req = urllib.request.Request(url, headers={'User-Agent': 'cobalt-autoroller'})
 
   ctx = ssl.create_default_context()
@@ -291,10 +289,8 @@ def verify_chromium_commit(sha):
     return True
 
   diff_output = get_out(['git', 'diff', '--name-status', sha, 'HEAD']).strip()
-  log(
-      f'ERROR: Rolled-in tree ({current_tree}) differs from Chromium '
-      f'{upstream_sha} ({expected_tree})!'
-  )
+  log(f'ERROR: Rolled-in tree ({current_tree}) differs from Chromium '
+      f'{upstream_sha} ({expected_tree})!')
   if diff_output:
     log(f'Offending files:\n{diff_output}')
   return False
@@ -349,8 +345,7 @@ def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
   if not verify_chromium_commit(sha):
     raise RuntimeError(
         f'Verification failed: Rolled-in tree for {sha} does not match '
-        f'Chromium {sha}'
-    )
+        f'Chromium {sha}')
 
   replace_submodules_with_dirs()
 

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -278,7 +278,9 @@ def verify_chromium_commit(sha):
   try:
     expected_tree = fetch_chromium_tree(upstream_sha)
   except Exception as e:  # pylint: disable=broad-except
-    log(f'ERROR: Failed to query Gitiles for Chromium commit {upstream_sha}: {e}')
+    log(
+        f'ERROR: Failed to query Gitiles for Chromium commit {upstream_sha}: {e}'
+    )
     return False
 
   current_tree = get_out(['git', 'rev-parse', 'HEAD^{tree}']).strip()
@@ -344,10 +346,10 @@ def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
   log('Cherry picking Chromium...')
   run(['git', 'cherry-pick', sha])
 
-  assert verify_chromium_commit(sha), (
   if not verify_chromium_commit(sha):
     raise RuntimeError(
-        f'Verification failed: Rolled-in tree for {sha} does not match Chromium {sha}'
+        f'Verification failed: Rolled-in tree for {sha} does not match '
+        f'Chromium {sha}'
     )
 
   replace_submodules_with_dirs()

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -345,9 +345,10 @@ def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
   run(['git', 'cherry-pick', sha])
 
   assert verify_chromium_commit(sha), (
-      f'Verification failed: Rolled-in tree for {sha} does not match Chromium '
-      f'{sha}'
-  )
+  if not verify_chromium_commit(sha):
+    raise RuntimeError(
+        f'Verification failed: Rolled-in tree for {sha} does not match Chromium {sha}'
+    )
 
   replace_submodules_with_dirs()
 

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -226,7 +226,7 @@ def replace_submodules_with_dirs():
 
 
 def fetch_chromium_tree(chromium_sha):
-  """Fetches the expected root tree hash directly from Chromium's Gitiles API."""
+  """Fetches the root tree hash directly from Chromium's Gitiles API."""
   url = (
       f'https://chromium.googlesource.com/chromium/src/+/{chromium_sha}'
       '?format=JSON'
@@ -238,7 +238,9 @@ def fetch_chromium_tree(chromium_sha):
     with urllib.request.urlopen(req, context=ctx) as resp:
       text = resp.read().decode('utf-8')
   except (ssl.SSLCertVerificationError, urllib.error.URLError):
+    # pylint: disable=protected-access
     unverified_ctx = ssl._create_unverified_context()
+    # pylint: enable=protected-access
     with urllib.request.urlopen(req, context=unverified_ctx) as resp:
       text = resp.read().decode('utf-8')
 
@@ -258,7 +260,7 @@ def get_upstream_chromium_sha(cobalt_sha):
 
 
 def verify_chromium_commit(sha):
-  """Verifies that the current Git tree matches the expected Chromium commit tree.
+  """Verifies that current Git tree matches expected Chromium commit tree.
 
   Args:
     sha: The SHA of the commit in Cobalt being rolled in.
@@ -272,15 +274,13 @@ def verify_chromium_commit(sha):
     log(f'ERROR: No upstream Chromium commit SHA found in message of {sha}.')
     return False
 
-  log(
-      f'Verifying against upstream Chromium commit {upstream_sha} via Gitiles...'
-  )
+  log(f'Verifying against upstream Chromium commit {upstream_sha} via '
+      'Gitiles...')
   try:
     expected_tree = fetch_chromium_tree(upstream_sha)
   except Exception as e:  # pylint: disable=broad-except
-    log(
-        f'ERROR: Failed to query Gitiles for Chromium commit {upstream_sha}: {e}'
-    )
+    log(f'ERROR: Failed to query Gitiles for Chromium commit '
+        f'{upstream_sha}: {e}')
     return False
 
   current_tree = get_out(['git', 'rev-parse', 'HEAD^{tree}']).strip()

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -221,6 +221,30 @@ def replace_submodules_with_dirs():
     ])
 
 
+def verify_chromium_commit(expected_sha):
+  """Verifies that the current Git tree matches the expected Chromium commit tree.
+
+  Args:
+    expected_sha: The SHA of the Chromium commit being rolled in.
+
+  Returns:
+    bool: True if the current tree matches the expected Chromium commit tree,
+      False otherwise.
+  """
+  expected_tree = get_out(['git', 'rev-parse', f'{expected_sha}^{{tree}}']).strip()
+  current_tree = get_out(['git', 'rev-parse', 'HEAD^{tree}']).strip()
+
+  if current_tree == expected_tree:
+    log(f'Verification passed: Tree {current_tree} matches Chromium {expected_sha}.')
+    return True
+
+  diff_output = get_out(
+      ['git', 'diff', '--name-status', expected_sha, 'HEAD']).strip()
+  log(f'ERROR: Rolled-in tree ({current_tree}) differs from Chromium {expected_sha} ({expected_tree})!')
+  log(f'Offending files:\n{diff_output}')
+  return False
+
+
 def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
                          autoroll_file):
   """Temporarily reverts Cobalt changes to apply a Chromium cherry-pick.
@@ -266,6 +290,10 @@ def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
 
   log('Cherry picking Chromium...')
   run(['git', 'cherry-pick', sha])
+
+  assert verify_chromium_commit(sha), (
+      f'Verification failed: Rolled-in tree for {sha} does not match Chromium {sha}'
+  )
 
   replace_submodules_with_dirs()
 

--- a/.github/scripts/autoroll_lts.py
+++ b/.github/scripts/autoroll_lts.py
@@ -3,11 +3,15 @@
 import argparse
 from collections import defaultdict
 import enum
+import json
 import os
 import re
 import shutil
+import ssl
 import subprocess
 import sys
+import urllib.error
+import urllib.request
 
 _COBALT_SUBMODULE_DIRS = [
     'net/third_party/quiche/src',
@@ -221,27 +225,76 @@ def replace_submodules_with_dirs():
     ])
 
 
-def verify_chromium_commit(expected_sha):
+def fetch_chromium_tree(chromium_sha):
+  """Fetches the expected root tree hash directly from Chromium's Gitiles API."""
+  url = (
+      f'https://chromium.googlesource.com/chromium/src/+/{chromium_sha}'
+      '?format=JSON'
+  )
+  req = urllib.request.Request(url, headers={'User-Agent': 'cobalt-autoroller'})
+
+  ctx = ssl.create_default_context()
+  try:
+    with urllib.request.urlopen(req, context=ctx) as resp:
+      text = resp.read().decode('utf-8')
+  except (ssl.SSLCertVerificationError, urllib.error.URLError):
+    unverified_ctx = ssl._create_unverified_context()
+    with urllib.request.urlopen(req, context=unverified_ctx) as resp:
+      text = resp.read().decode('utf-8')
+
+  # Gitiles JSON API responses prepend a 4-char anti-XSSI security prefix: )]}'
+  if text.startswith(")]}'"):
+    text = text[4:].lstrip()
+
+  data = json.loads(text)
+  return data['tree']
+
+
+def get_upstream_chromium_sha(cobalt_sha):
+  """Extracts the upstream Chromium commit SHA from the commit message body."""
+  body = get_out(['git', 'log', '-1', '--format=%B', cobalt_sha])
+  match = re.search(r'Update to commit ([0-9a-fA-F]{40})', body)
+  return match.group(1) if match else None
+
+
+def verify_chromium_commit(sha):
   """Verifies that the current Git tree matches the expected Chromium commit tree.
 
   Args:
-    expected_sha: The SHA of the Chromium commit being rolled in.
+    sha: The SHA of the commit in Cobalt being rolled in.
 
   Returns:
     bool: True if the current tree matches the expected Chromium commit tree,
       False otherwise.
   """
-  expected_tree = get_out(['git', 'rev-parse', f'{expected_sha}^{{tree}}']).strip()
+  upstream_sha = get_upstream_chromium_sha(sha)
+  if not upstream_sha:
+    log(f'ERROR: No upstream Chromium commit SHA found in message of {sha}.')
+    return False
+
+  log(
+      f'Verifying against upstream Chromium commit {upstream_sha} via Gitiles...'
+  )
+  try:
+    expected_tree = fetch_chromium_tree(upstream_sha)
+  except Exception as e:  # pylint: disable=broad-except
+    log(f'ERROR: Failed to query Gitiles for Chromium commit {upstream_sha}: {e}')
+    return False
+
   current_tree = get_out(['git', 'rev-parse', 'HEAD^{tree}']).strip()
 
   if current_tree == expected_tree:
-    log(f'Verification passed: Tree {current_tree} matches Chromium {expected_sha}.')
+    log(f'Verification passed: Tree {current_tree} matches Chromium '
+        f'{upstream_sha}.')
     return True
 
-  diff_output = get_out(
-      ['git', 'diff', '--name-status', expected_sha, 'HEAD']).strip()
-  log(f'ERROR: Rolled-in tree ({current_tree}) differs from Chromium {expected_sha} ({expected_tree})!')
-  log(f'Offending files:\n{diff_output}')
+  diff_output = get_out(['git', 'diff', '--name-status', sha, 'HEAD']).strip()
+  log(
+      f'ERROR: Rolled-in tree ({current_tree}) differs from Chromium '
+      f'{upstream_sha} ({expected_tree})!'
+  )
+  if diff_output:
+    log(f'Offending files:\n{diff_output}')
   return False
 
 
@@ -292,7 +345,8 @@ def chromium_cherry_pick(previous_sha, sha, metadata, first_commit,
   run(['git', 'cherry-pick', sha])
 
   assert verify_chromium_commit(sha), (
-      f'Verification failed: Rolled-in tree for {sha} does not match Chromium {sha}'
+      f'Verification failed: Rolled-in tree for {sha} does not match Chromium '
+      f'{sha}'
   )
 
   replace_submodules_with_dirs()

--- a/.github/scripts/autoroll_lts_test.py
+++ b/.github/scripts/autoroll_lts_test.py
@@ -170,22 +170,35 @@ class TestAutorollLts(unittest.TestCase):
     sha = autoroll_lts.get_upstream_chromium_sha('cobalt_sha')
     self.assertEqual(sha, 'f600d0656fd5b5fe4a82981f533d31ed6939e2e4')
 
-  @patch('autoroll_lts.fetch_chromium_tree', return_value='tree_sha_match')
+  @patch(
+      'autoroll_lts.fetch_chromium_tree',
+      return_value='tree_sha_match',
+  )
   @patch(
       'autoroll_lts.get_upstream_chromium_sha',
-      return_value='upstream_sha_123')
+      return_value='upstream_sha_123',
+  )
   @patch('autoroll_lts.get_out')
   def test_verify_chromium_commit_with_upstream_success(
-      self, mock_get_out, unused_mock_upstream, unused_mock_fetch):
+      self,
+      mock_get_out,
+      unused_mock_upstream,
+      unused_mock_fetch,
+  ):
     """Test verify_chromium_commit succeeds when tree matches Chromium."""
     mock_get_out.return_value = 'tree_sha_match\n'
     with patch('sys.stderr'):
       result = autoroll_lts.verify_chromium_commit('cobalt_sha')
     self.assertTrue(result)
 
-  @patch('autoroll_lts.get_upstream_chromium_sha', return_value=None)
+  @patch(
+      'autoroll_lts.get_upstream_chromium_sha',
+      return_value=None,
+  )
   def test_verify_chromium_commit_missing_upstream_sha_fails(
-      self, unused_mock_upstream):
+      self,
+      unused_mock_upstream,
+  ):
     """Test verify_chromium_commit returns False if no upstream SHA is found."""
     with patch('sys.stderr'):
       result = autoroll_lts.verify_chromium_commit('cobalt_sha')
@@ -193,45 +206,75 @@ class TestAutorollLts(unittest.TestCase):
 
   @patch(
       'autoroll_lts.fetch_chromium_tree',
-      side_effect=RuntimeError('Network error'))
+      side_effect=RuntimeError('Network error'),
+  )
   @patch(
       'autoroll_lts.get_upstream_chromium_sha',
-      return_value='upstream_sha_123')
+      return_value='upstream_sha_123',
+  )
   def test_verify_chromium_commit_gitiles_error_fails(
-      self, unused_mock_upstream, unused_mock_fetch):
+      self,
+      unused_mock_upstream,
+      unused_mock_fetch,
+  ):
     """Test verify_chromium_commit returns False if Gitiles query fails."""
     with patch('sys.stderr'):
       result = autoroll_lts.verify_chromium_commit('cobalt_sha')
     self.assertFalse(result)
 
-  @patch('autoroll_lts.fetch_chromium_tree', return_value='tree_sha_expected')
+  @patch(
+      'autoroll_lts.fetch_chromium_tree',
+      return_value='tree_sha_expected',
+  )
   @patch(
       'autoroll_lts.get_upstream_chromium_sha',
-      return_value='upstream_sha_123')
+      return_value='upstream_sha_123',
+  )
   @patch('autoroll_lts.get_out')
   def test_verify_chromium_commit_failure(
-      self, mock_get_out, unused_mock_upstream, unused_mock_fetch):
+      self,
+      mock_get_out,
+      unused_mock_upstream,
+      unused_mock_fetch,
+  ):
     """Test verify_chromium_commit returns False when trees differ."""
     mock_get_out.side_effect = [
-        'tree_sha_different\n', 'M path/to/file.cc\n'
+        'tree_sha_different\n',
+        'M path/to/file.cc\n',
     ]
     with patch('sys.stderr'):
       result = autoroll_lts.verify_chromium_commit('cobalt_sha')
     self.assertFalse(result)
 
-  @patch('autoroll_lts.verify_chromium_commit', return_value=False)
+  @patch(
+      'autoroll_lts.verify_chromium_commit',
+      return_value=False,
+  )
   @patch('autoroll_lts.replace_submodules_with_dirs')
   @patch('autoroll_lts.remove_local_checkout')
   @patch('autoroll_lts.run')
-  @patch('autoroll_lts.get_out', return_value='fake_sha\n')
+  @patch(
+      'autoroll_lts.get_out',
+      return_value='fake_sha\n',
+  )
   def test_chromium_cherry_pick_assertion_error(
-      self, unused_mock_get_out, unused_mock_run, unused_mock_remove,
-      unused_mock_replace, unused_mock_verify):
+      self,
+      unused_mock_get_out,
+      unused_mock_run,
+      unused_mock_remove,
+      unused_mock_replace,
+      unused_mock_verify,
+  ):
     """Test chromium_cherry_pick raises AssertionError if verification fails."""
     with patch('sys.stderr'):
       with self.assertRaises(RuntimeError):
-        autoroll_lts.chromium_cherry_pick('prev_sha', 'sha123', ('d', 'a', 'm'),
-                                          True, '.github/AUTOROLL_CHROMIUM')
+        autoroll_lts.chromium_cherry_pick(
+            'prev_sha',
+            'sha123',
+            ('d', 'a', 'm'),
+            True,
+            '.github/AUTOROLL_CHROMIUM',
+        )
 
 
 class TestAutorollLtsMain(unittest.TestCase):

--- a/.github/scripts/autoroll_lts_test.py
+++ b/.github/scripts/autoroll_lts_test.py
@@ -222,7 +222,7 @@ class TestAutorollLts(unittest.TestCase):
       self, mock_get_out, mock_run, mock_remove, mock_replace, mock_verify):
     """Test chromium_cherry_pick raises AssertionError if verification fails."""
     with patch('sys.stderr'):
-      with self.assertRaises(AssertionError):
+      with self.assertRaises(RuntimeError):
         autoroll_lts.chromium_cherry_pick('prev_sha', 'sha123', ('d', 'a', 'm'),
                                           True, '.github/AUTOROLL_CHROMIUM')
 

--- a/.github/scripts/autoroll_lts_test.py
+++ b/.github/scripts/autoroll_lts_test.py
@@ -171,10 +171,12 @@ class TestAutorollLts(unittest.TestCase):
     self.assertEqual(sha, 'f600d0656fd5b5fe4a82981f533d31ed6939e2e4')
 
   @patch('autoroll_lts.fetch_chromium_tree', return_value='tree_sha_match')
-  @patch('autoroll_lts.get_upstream_chromium_sha', return_value='upstream_sha_123')
+  @patch(
+      'autoroll_lts.get_upstream_chromium_sha',
+      return_value='upstream_sha_123')
   @patch('autoroll_lts.get_out')
   def test_verify_chromium_commit_with_upstream_success(
-      self, mock_get_out, mock_upstream, mock_fetch):
+      self, mock_get_out, unused_mock_upstream, unused_mock_fetch):
     """Test verify_chromium_commit succeeds when tree matches Chromium."""
     mock_get_out.return_value = 'tree_sha_match\n'
     with patch('sys.stderr'):
@@ -183,7 +185,7 @@ class TestAutorollLts(unittest.TestCase):
 
   @patch('autoroll_lts.get_upstream_chromium_sha', return_value=None)
   def test_verify_chromium_commit_missing_upstream_sha_fails(
-      self, mock_upstream):
+      self, unused_mock_upstream):
     """Test verify_chromium_commit returns False if no upstream SHA is found."""
     with patch('sys.stderr'):
       result = autoroll_lts.verify_chromium_commit('cobalt_sha')
@@ -192,19 +194,23 @@ class TestAutorollLts(unittest.TestCase):
   @patch(
       'autoroll_lts.fetch_chromium_tree',
       side_effect=RuntimeError('Network error'))
-  @patch('autoroll_lts.get_upstream_chromium_sha', return_value='upstream_sha_123')
+  @patch(
+      'autoroll_lts.get_upstream_chromium_sha',
+      return_value='upstream_sha_123')
   def test_verify_chromium_commit_gitiles_error_fails(
-      self, mock_upstream, mock_fetch):
+      self, unused_mock_upstream, unused_mock_fetch):
     """Test verify_chromium_commit returns False if Gitiles query fails."""
     with patch('sys.stderr'):
       result = autoroll_lts.verify_chromium_commit('cobalt_sha')
     self.assertFalse(result)
 
   @patch('autoroll_lts.fetch_chromium_tree', return_value='tree_sha_expected')
-  @patch('autoroll_lts.get_upstream_chromium_sha', return_value='upstream_sha_123')
+  @patch(
+      'autoroll_lts.get_upstream_chromium_sha',
+      return_value='upstream_sha_123')
   @patch('autoroll_lts.get_out')
   def test_verify_chromium_commit_failure(
-      self, mock_get_out, mock_upstream, mock_fetch):
+      self, mock_get_out, unused_mock_upstream, unused_mock_fetch):
     """Test verify_chromium_commit returns False when trees differ."""
     mock_get_out.side_effect = [
         'tree_sha_different\n', 'M path/to/file.cc\n'
@@ -219,7 +225,8 @@ class TestAutorollLts(unittest.TestCase):
   @patch('autoroll_lts.run')
   @patch('autoroll_lts.get_out', return_value='fake_sha\n')
   def test_chromium_cherry_pick_assertion_error(
-      self, mock_get_out, mock_run, mock_remove, mock_replace, mock_verify):
+      self, unused_mock_get_out, unused_mock_run, unused_mock_remove,
+      unused_mock_replace, unused_mock_verify):
     """Test chromium_cherry_pick raises AssertionError if verification fails."""
     with patch('sys.stderr'):
       with self.assertRaises(RuntimeError):

--- a/.github/scripts/autoroll_lts_test.py
+++ b/.github/scripts/autoroll_lts_test.py
@@ -147,6 +147,39 @@ class TestAutorollLts(unittest.TestCase):
       with self.assertRaises(subprocess.CalledProcessError):
         autoroll_lts.cherry_pick('sha', '123', 'title')
 
+  @patch('autoroll_lts.get_out')
+  def test_verify_chromium_commit_success(self, mock_get_out):
+    """Test verify_chromium_commit returns True when trees match."""
+    mock_get_out.side_effect = ['tree_sha_1\n', 'tree_sha_1\n']
+    with patch('sys.stderr'):
+      result = autoroll_lts.verify_chromium_commit('chromium_sha_123')
+    self.assertTrue(result)
+    self.assertEqual(mock_get_out.call_count, 2)
+
+  @patch('autoroll_lts.get_out')
+  def test_verify_chromium_commit_failure(self, mock_get_out):
+    """Test verify_chromium_commit returns False when trees differ."""
+    mock_get_out.side_effect = [
+        'tree_sha_expected\n', 'tree_sha_actual\n', 'M path/to/file.cc\n'
+    ]
+    with patch('sys.stderr'):
+      result = autoroll_lts.verify_chromium_commit('chromium_sha_123')
+    self.assertFalse(result)
+    self.assertEqual(mock_get_out.call_count, 3)
+
+  @patch('autoroll_lts.verify_chromium_commit', return_value=False)
+  @patch('autoroll_lts.replace_submodules_with_dirs')
+  @patch('autoroll_lts.remove_local_checkout')
+  @patch('autoroll_lts.run')
+  @patch('autoroll_lts.get_out', return_value='fake_sha\n')
+  def test_chromium_cherry_pick_assertion_error(
+      self, mock_get_out, mock_run, mock_remove, mock_replace, mock_verify):
+    """Test chromium_cherry_pick raises AssertionError if verification fails."""
+    with patch('sys.stderr'):
+      with self.assertRaises(AssertionError):
+        autoroll_lts.chromium_cherry_pick('prev_sha', 'sha123', ('d', 'a', 'm'),
+                                          True, '.github/AUTOROLL_CHROMIUM')
+
 
 class TestAutorollLtsMain(unittest.TestCase):
   """Test cases for main() function argument parsing and defaults."""

--- a/.github/scripts/autoroll_lts_test.py
+++ b/.github/scripts/autoroll_lts_test.py
@@ -147,25 +147,71 @@ class TestAutorollLts(unittest.TestCase):
       with self.assertRaises(subprocess.CalledProcessError):
         autoroll_lts.cherry_pick('sha', '123', 'title')
 
-  @patch('autoroll_lts.get_out')
-  def test_verify_chromium_commit_success(self, mock_get_out):
-    """Test verify_chromium_commit returns True when trees match."""
-    mock_get_out.side_effect = ['tree_sha_1\n', 'tree_sha_1\n']
-    with patch('sys.stderr'):
-      result = autoroll_lts.verify_chromium_commit('chromium_sha_123')
-    self.assertTrue(result)
-    self.assertEqual(mock_get_out.call_count, 2)
+  @patch('urllib.request.urlopen')
+  def test_fetch_chromium_tree(self, mock_urlopen):
+    """Test fetch_chromium_tree strips XSSI prefix and parses JSON."""
+    mock_resp = MagicMock()
+    mock_resp.read.return_value = (
+        b")]}\'\n{\"commit\": \"sha123\", \"tree\": \"tree_sha_gitiles\"}"
+    )
+    mock_resp.__enter__.return_value = mock_resp
+    mock_urlopen.return_value = mock_resp
+
+    tree = autoroll_lts.fetch_chromium_tree('sha123')
+    self.assertEqual(tree, 'tree_sha_gitiles')
 
   @patch('autoroll_lts.get_out')
-  def test_verify_chromium_commit_failure(self, mock_get_out):
+  def test_get_upstream_chromium_sha(self, mock_get_out):
+    """Test get_upstream_chromium_sha extracts SHA from commit body."""
+    mock_get_out.return_value = (
+        'Update to m139 branch point.\n\n'
+        'Update to commit f600d0656fd5b5fe4a82981f533d31ed6939e2e4.\n'
+    )
+    sha = autoroll_lts.get_upstream_chromium_sha('cobalt_sha')
+    self.assertEqual(sha, 'f600d0656fd5b5fe4a82981f533d31ed6939e2e4')
+
+  @patch('autoroll_lts.fetch_chromium_tree', return_value='tree_sha_match')
+  @patch('autoroll_lts.get_upstream_chromium_sha', return_value='upstream_sha_123')
+  @patch('autoroll_lts.get_out')
+  def test_verify_chromium_commit_with_upstream_success(
+      self, mock_get_out, mock_upstream, mock_fetch):
+    """Test verify_chromium_commit succeeds when tree matches Chromium."""
+    mock_get_out.return_value = 'tree_sha_match\n'
+    with patch('sys.stderr'):
+      result = autoroll_lts.verify_chromium_commit('cobalt_sha')
+    self.assertTrue(result)
+
+  @patch('autoroll_lts.get_upstream_chromium_sha', return_value=None)
+  def test_verify_chromium_commit_missing_upstream_sha_fails(
+      self, mock_upstream):
+    """Test verify_chromium_commit returns False if no upstream SHA is found."""
+    with patch('sys.stderr'):
+      result = autoroll_lts.verify_chromium_commit('cobalt_sha')
+    self.assertFalse(result)
+
+  @patch(
+      'autoroll_lts.fetch_chromium_tree',
+      side_effect=RuntimeError('Network error'))
+  @patch('autoroll_lts.get_upstream_chromium_sha', return_value='upstream_sha_123')
+  def test_verify_chromium_commit_gitiles_error_fails(
+      self, mock_upstream, mock_fetch):
+    """Test verify_chromium_commit returns False if Gitiles query fails."""
+    with patch('sys.stderr'):
+      result = autoroll_lts.verify_chromium_commit('cobalt_sha')
+    self.assertFalse(result)
+
+  @patch('autoroll_lts.fetch_chromium_tree', return_value='tree_sha_expected')
+  @patch('autoroll_lts.get_upstream_chromium_sha', return_value='upstream_sha_123')
+  @patch('autoroll_lts.get_out')
+  def test_verify_chromium_commit_failure(
+      self, mock_get_out, mock_upstream, mock_fetch):
     """Test verify_chromium_commit returns False when trees differ."""
     mock_get_out.side_effect = [
-        'tree_sha_expected\n', 'tree_sha_actual\n', 'M path/to/file.cc\n'
+        'tree_sha_different\n', 'M path/to/file.cc\n'
     ]
     with patch('sys.stderr'):
-      result = autoroll_lts.verify_chromium_commit('chromium_sha_123')
+      result = autoroll_lts.verify_chromium_commit('cobalt_sha')
     self.assertFalse(result)
-    self.assertEqual(mock_get_out.call_count, 3)
 
   @patch('autoroll_lts.verify_chromium_commit', return_value=False)
   @patch('autoroll_lts.replace_submodules_with_dirs')

--- a/.github/scripts/autoroll_lts_test.py
+++ b/.github/scripts/autoroll_lts_test.py
@@ -123,7 +123,8 @@ class TestAutorollLts(unittest.TestCase):
     mock_run.side_effect = side_effect
 
     with patch('sys.stderr'):
-      result = autoroll_lts.cherry_pick('sha', '123', 'title')
+      result = autoroll_lts.cherry_pick('sha', ('date', 'author', 'title'),
+                                        True, '.github/AUTOROLL')
 
     self.assertTrue(result)
 
@@ -145,15 +146,15 @@ class TestAutorollLts(unittest.TestCase):
 
     with patch('sys.stderr'):
       with self.assertRaises(subprocess.CalledProcessError):
-        autoroll_lts.cherry_pick('sha', '123', 'title')
+        autoroll_lts.cherry_pick('sha', ('date', 'author', 'title'), True,
+                                 '.github/AUTOROLL')
 
   @patch('urllib.request.urlopen')
   def test_fetch_chromium_tree(self, mock_urlopen):
     """Test fetch_chromium_tree strips XSSI prefix and parses JSON."""
     mock_resp = MagicMock()
     mock_resp.read.return_value = (
-        b")]}\'\n{\"commit\": \"sha123\", \"tree\": \"tree_sha_gitiles\"}"
-    )
+        b")]}\'\n{\"commit\": \"sha123\", \"tree\": \"tree_sha_gitiles\"}")
     mock_resp.__enter__.return_value = mock_resp
     mock_urlopen.return_value = mock_resp
 
@@ -165,8 +166,7 @@ class TestAutorollLts(unittest.TestCase):
     """Test get_upstream_chromium_sha extracts SHA from commit body."""
     mock_get_out.return_value = (
         'Update to m139 branch point.\n\n'
-        'Update to commit f600d0656fd5b5fe4a82981f533d31ed6939e2e4.\n'
-    )
+        'Update to commit f600d0656fd5b5fe4a82981f533d31ed6939e2e4.\n')
     sha = autoroll_lts.get_upstream_chromium_sha('cobalt_sha')
     self.assertEqual(sha, 'f600d0656fd5b5fe4a82981f533d31ed6939e2e4')
 
@@ -349,7 +349,7 @@ class TestAutorollLtsGetPrSetAndCommits(unittest.TestCase):
   @patch('autoroll_lts.get_out')
   def test_get_commits_with_start(self, mock_get_out):
     mock_get_out.return_value = 'sha1 Commit 1\nsha2 Commit 2\n'
-    commits = autoroll_lts.get_commits('main', '27.lts', 'start_sha')
+    commits = autoroll_lts.get_commits('main', 'start_sha')
     mock_get_out.assert_called_once_with([
         'git', 'rev-list', '--oneline', '--reverse', 'main', '^27.lts',
         'start_sha^..main'
@@ -359,7 +359,7 @@ class TestAutorollLtsGetPrSetAndCommits(unittest.TestCase):
   @patch('autoroll_lts.get_out')
   def test_get_commits_without_start(self, mock_get_out):
     mock_get_out.return_value = 'sha1 Commit 1\n'
-    commits = autoroll_lts.get_commits('main', '27.lts', '')
+    commits = autoroll_lts.get_commits('main', '')
     mock_get_out.assert_called_once_with(
         ['git', 'rev-list', '--oneline', '--reverse', 'main', '^27.lts'])
     self.assertEqual(commits, ['sha1 Commit 1'])


### PR DESCRIPTION
ci: Add verification step for Chromium autoroller

Implement a tree verification mechanism in the LTS autoroll script to
ensure the resulting Git tree after a Chromium cherry-pick exactly
matches the expected upstream tree. This provides a validation layer
to catch silent regressions or merge errors during automation.

The script now compares tree SHAs, logs file-level differences upon
failure, and asserts that the verification passes before committing
the changes.

Test: https://github.com/youtube/cobalt/actions/runs/30947124488/job/92119762848
Bug: 505073626