### PR TITLE
starboard: Cancel pending sample job on PlayerWorker destruction

### DIFF
--- a/starboard/shared/starboard/player/player_worker.cc
+++ b/starboard/shared/starboard/player/player_worker.cc
@@ -79,6 +79,8 @@ PlayerWorker::~PlayerWorker() {
   ON_INSTANCE_RELEASED(PlayerWorker);
 
   job_thread_->ScheduleAndWait([this] {
+    job_thread_->RemoveJobByToken(&write_pending_sample_job_token_);
+
     handler_->Stop();
     handler_.reset();
 


### PR DESCRIPTION
Remove any scheduled write_pending_sample_job_token_ job when PlayerWorker is destroyed to prevent delayed pending sample writes from firing after handler teardown and logging false-alarm errors.

Issue: 542276633