### PR TITLE
android: Rename ResetVideoSurface to RecreateVideoSurface

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseCobaltActivity.java
@@ -223,7 +223,7 @@ public abstract class BaseCobaltActivity extends Activity {
    * TODO(https://crbug.com/495203133): move the implementation from CobaltActivity here when
    * bringing up Cobalt on AOSP.
    */
-  public void resetVideoSurface() {}
+  public void recreateVideoSurface() {}
 
   public void setVideoSurfaceBounds(final int x, final int y, final int width, final int height) {}
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/BaseStarboardBridge.java
@@ -599,10 +599,10 @@ public class BaseStarboardBridge {
 
   @SuppressWarnings("unused")
   @CalledByNative
-  public void resetVideoSurface() {
+  public void recreateVideoSurface() {
     Activity activity = mActivityHolder.get();
     if (activity instanceof BaseCobaltActivity) {
-      ((BaseCobaltActivity) activity).resetVideoSurface();
+      ((BaseCobaltActivity) activity).recreateVideoSurface();
     }
   }
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CobaltActivity.java
@@ -542,7 +542,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
       Log.i(TAG, "Use AndroidOverlay for Video SurfaceView.");
     } else if (mForceCreateNewVideoSurfaceView) {
       Log.w(TAG, "Force to create a new video surface.");
-      createNewSurfaceView();
+      recreateSurfaceView();
     }
 
     AudioOutputManager.addAudioDeviceListener(this);
@@ -804,7 +804,8 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
     getStarboardBridge().onRequestPermissionsResult(requestCode, permissions, grantResults);
   }
 
-  public void resetVideoSurface() {
+  @Override
+  public void recreateVideoSurface() {
     if (mIsCobaltUsingAndroidOverlay) {
       return;
     }
@@ -812,7 +813,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
         new Runnable() {
           @Override
           public void run() {
-            createNewSurfaceView();
+            recreateSurfaceView();
           }
         });
   }
@@ -852,7 +853,7 @@ public abstract class CobaltActivity extends BaseCobaltActivity {
         });
   }
 
-  private void createNewSurfaceView() {
+  private void recreateSurfaceView() {
     if (mIsCobaltUsingAndroidOverlay) {
       return;
     }

--- a/starboard/android/shared/base_starboard_bridge.cc
+++ b/starboard/android/shared/base_starboard_bridge.cc
@@ -371,9 +371,10 @@ ScopedJavaLocalRef<jobject> StarboardBridge::GetAudioPermissionRequester(
       env, j_starboard_bridge_);
 }
 
-void StarboardBridge::ResetVideoSurface(JNIEnv* env) {
+void StarboardBridge::RecreateVideoSurface(JNIEnv* env) {
   SB_DCHECK(env);
-  return Java_BaseStarboardBridge_resetVideoSurface(env, j_starboard_bridge_);
+  return Java_BaseStarboardBridge_recreateVideoSurface(env,
+                                                       j_starboard_bridge_);
 }
 
 void StarboardBridge::SetVideoSurfaceBounds(JNIEnv* env,

--- a/starboard/android/shared/starboard_bridge.h
+++ b/starboard/android/shared/starboard_bridge.h
@@ -84,7 +84,7 @@ class StarboardBridge {
   jni_zero::ScopedJavaLocalRef<jobject> GetAudioPermissionRequester(
       JNIEnv* env);
 
-  void ResetVideoSurface(JNIEnv* env);
+  void RecreateVideoSurface(JNIEnv* env);
   void SetVideoSurfaceBounds(JNIEnv* env, int x, int y, int width, int height);
 
   jni_zero::ScopedJavaLocalRef<jobject> GetAudioOutputManager(JNIEnv* env);

--- a/starboard/android/shared/video_window.cc
+++ b/starboard/android/shared/video_window.cc
@@ -212,8 +212,8 @@ void VideoSurfaceHolder::CleanUpVideoWindow(
     return;
   }
 
-  StarboardBridge::GetInstance()->ResetVideoSurface(env);
-  SB_LOG(INFO) << "Video surface has been reset (default behavior).";
+  StarboardBridge::GetInstance()->RecreateVideoSurface(env);
+  SB_LOG(INFO) << "Video surface has been recreated (default behavior).";
 }
 
 }  // namespace starboard


### PR DESCRIPTION
Renames `resetVideoSurface` to `recreateVideoSurface` across the Java and
Starboard C++/JNI layer.

The implementation tears down the existing VideoSurfaceView and attaches
a newly instantiated view to the layout rather than resetting properties
or state on an existing surface. Renaming to recreateVideoSurface (and
internal helper recreateSurfaceView) accurately reflects this behavior.

It also make clear distinction from `ClearupVideoWindow` vs `RecreateVideoSurface`

Previously,  `ResetVideoSurface` vs `ClearupVideoWindow`

Now, `RecreateVideoSurface` vs `ClearupVideoWindow`

Issue: 429021006

