### PR TITLE
android: Add java switch to expand http cache types

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -35,7 +35,7 @@ public class JavaSwitches {
   public static final String ENABLE_OPTIMIZED_V8_CODE_CACHE = "EnableOptimizedV8CodeCache";
 
   /** flag to allow caching CSS and WebAssembly resources in the HTTP disk cache. */
-  public static final String ENABLE_EXPANDED_HTTP_CACHE_TYPES = "EnableExpandedHttpCacheTypes";
+  public static final String ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE = "EnableWasmAndCssForHttpCache";
 
   /** flag to re-enable freeze and resume events */
   public static final String ENABLE_FREEZE = "EnableFreeze";
@@ -198,8 +198,8 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--enable-optimized-v8-code-cache");
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.ENABLE_EXPANDED_HTTP_CACHE_TYPES)) {
-      extraCommandLineArgs.add("--enable-expanded-http-cache-types");
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE)) {
+      extraCommandLineArgs.add("--enable-css-and-wasm-for-http-cache");
     }
 
     if (jsFlags.length() > 0) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -33,6 +33,9 @@ public class JavaSwitches {
 
   public static final String ENABLE_OPTIMIZED_FONT_LOADING = "EnableOptimizedFontLoading";
   public static final String ENABLE_OPTIMIZED_V8_CODE_CACHE = "EnableOptimizedV8CodeCache";
+  
+  /** flag to allow caching CSS and WebAssembly resources in the HTTP disk cache. */
+  public static final String ENABLE_EXPANDED_HTTP_CACHE_TYPES = "EnableExpandedHttpCacheTypes";
 
   /** flag to re-enable freeze and resume events */
   public static final String ENABLE_FREEZE = "EnableFreeze";
@@ -193,6 +196,10 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_OPTIMIZED_V8_CODE_CACHE)) {
       extraCommandLineArgs.add("--enable-optimized-v8-code-cache");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_EXPANDED_HTTP_CACHE_TYPES)) {
+      extraCommandLineArgs.add("--enable-expanded-http-cache-types");
     }
 
     if (jsFlags.length() > 0) {

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -35,7 +35,7 @@ public class JavaSwitches {
   public static final String ENABLE_OPTIMIZED_V8_CODE_CACHE = "EnableOptimizedV8CodeCache";
 
   /** flag to allow caching CSS and WebAssembly resources in the HTTP disk cache. */
-  public static final String ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE = "EnableWasmAndCssForHttpCache";
+  public static final String ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE = "EnableCssAndWasmForHttpCache";
 
   /** flag to re-enable freeze and resume events */
   public static final String ENABLE_FREEZE = "EnableFreeze";

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -33,7 +33,7 @@ public class JavaSwitches {
 
   public static final String ENABLE_OPTIMIZED_FONT_LOADING = "EnableOptimizedFontLoading";
   public static final String ENABLE_OPTIMIZED_V8_CODE_CACHE = "EnableOptimizedV8CodeCache";
-  
+
   /** flag to allow caching CSS and WebAssembly resources in the HTTP disk cache. */
   public static final String ENABLE_EXPANDED_HTTP_CACHE_TYPES = "EnableExpandedHttpCacheTypes";
 

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -3998,11 +3998,12 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
     bool is_html = (mime_type == "text/html");
     bool is_js = base::EndsWith(mime_type, "javascript", base::CompareCase::SENSITIVE)
         || base::EndsWith(mime_type, "ecmascript", base::CompareCase::SENSITIVE);
-    bool is_expanded_type = false;
-    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
-            "enable-expanded-http-cache-types")) {
-      is_expanded_type = (mime_type == "text/css" || mime_type == "application/wasm");
-    }
+    static const bool enable_expanded_types =
+        base::CommandLine::ForCurrentProcess()->HasSwitch(
+            "enable-expanded-http-cache-types");
+    bool is_expanded_type =
+        enable_expanded_types &&
+        (mime_type == "text/css" || mime_type == "application/wasm");
     if (!is_html && !is_js && !is_expanded_type) {
       return true; // Do not write to cache / doom existing entry
     }

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -3991,13 +3991,19 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
   }
 
 #if BUILDFLAG(IS_COBALT)
-  // Only allow HTML and JS/ECMAScript in Cobalt's HTTP cache.
+  // Only allow HTML and JS/ECMAScript in Cobalt's HTTP cache by default.
+  // When --enable-expanded-http-cache-types is passed, also allow CSS and WASM.
   std::string mime_type;
   if (headers.GetMimeType(&mime_type)) {
     bool is_html = (mime_type == "text/html");
     bool is_js = base::EndsWith(mime_type, "javascript", base::CompareCase::SENSITIVE)
         || base::EndsWith(mime_type, "ecmascript", base::CompareCase::SENSITIVE);
-    if (!is_html && !is_js) {
+    bool is_expanded_type = false;
+    if (base::CommandLine::ForCurrentProcess()->HasSwitch(
+            "enable-expanded-http-cache-types")) {
+      is_expanded_type = (mime_type == "text/css" || mime_type == "application/wasm");
+    }
+    if (!is_html && !is_js && !is_expanded_type) {
       return true; // Do not write to cache / doom existing entry
     }
   } else {

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -3992,19 +3992,19 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
 
 #if BUILDFLAG(IS_COBALT)
   // Only allow HTML and JS/ECMAScript in Cobalt's HTTP cache by default.
-  // When --enable-expanded-http-cache-types is passed, also allow CSS and WASM.
+  // When --enable-css-and-wasm-for-http-cache is passed, also allow CSS and WASM.
   std::string mime_type;
   if (headers.GetMimeType(&mime_type)) {
     bool is_html = (mime_type == "text/html");
     bool is_js = base::EndsWith(mime_type, "javascript", base::CompareCase::SENSITIVE)
         || base::EndsWith(mime_type, "ecmascript", base::CompareCase::SENSITIVE);
-    static const bool enable_expanded_types =
+    static const bool enable_css_and_wasm =
         base::CommandLine::ForCurrentProcess()->HasSwitch(
-            "enable-expanded-http-cache-types");
-    bool is_expanded_type =
-        enable_expanded_types &&
+            "enable-css-and-wasm-for-http-cache");
+    bool is_css_or_wasm =
+        enable_css_and_wasm &&
         (mime_type == "text/css" || mime_type == "application/wasm");
-    if (!is_html && !is_js && !is_expanded_type) {
+    if (!is_html && !is_js && !is_css_or_wasm) {
       return true; // Do not write to cache / doom existing entry
     }
   } else {


### PR DESCRIPTION
This PR introduces the EnableExpandedHttpCacheTypes switch. When enabled, the HTTP cache will also cache CSS/WASM (currently only caching HTTP/JS).  This is closer to existing C25 behavior for caching.                       

Bug: 542406016