### PR TITLE
cobalt: Add Picture-in-Picture tests

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -358,6 +358,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/metrics/cobalt_metrics_services_manager_client_test.cc",
     "//cobalt/browser/user_agent/user_agent_platform_info_test.cc",
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_unittest.cc",
+    "//cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc",
   ]
 
   # The symbolizer pipeline test requires launching external Python and

--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -384,10 +384,11 @@ test("cobalt_unittests") {
     ]
   }
 
+  sources += [ "//cobalt/shell/browser/shell_test_support.h" ]
+
   if (!is_android) {
     sources += [
       "//cobalt/shell/browser/lifecycle_unittest.cc",
-      "//cobalt/shell/browser/shell_test_support.h",
       "//cobalt/shell/browser/splash_screen_unittest.cc",
     ]
   }

--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -319,6 +319,7 @@ robolectric_binary("cobalt_coat_junit_tests") {
     "apk/app/src/test/java/dev/cobalt/coat/ArtworkDownloaderDefaultTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/ArtworkLoaderTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/CobaltActivityTest.java",
+    "apk/app/src/test/java/dev/cobalt/coat/CobaltPictureInPictureActivityTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/CobaltServiceTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java",
     "apk/app/src/test/java/dev/cobalt/coat/MockShellManagerNatives.java",
@@ -330,16 +331,19 @@ robolectric_binary("cobalt_coat_junit_tests") {
   deps = [
     ":cobalt_apk_java",
     ":cobalt_main_java",
+    ":cobalt_pip_java",
     "//base:base_java",
     "//base:base_java_test_support",
     "//base:base_junit_test_support",
     "//cobalt/shell/android:cobalt_shell_java",
     "//components/embedder_support/android:view_java",
+    "//components/thin_webview:java",
     "//content/public/android:content_java",
     "//services/media_session/public/cpp/android:media_session_java",
     "//third_party/androidx:androidx_test_runner_java",
     "//third_party/google-truth:google_truth_java",
     "//third_party/junit",
+    "//ui/android:ui_no_recycler_view_java",
     "//url:gurl_java",
   ]
   ignore_all_data_deps = false

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltPictureInPictureActivityTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CobaltPictureInPictureActivityTest.java
@@ -1,0 +1,123 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package dev.cobalt.coat;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.MockitoAnnotations.initMocks;
+
+import android.content.Intent;
+import android.view.View;
+import org.chromium.base.ApplicationStatus;
+import org.chromium.base.CommandLine;
+import org.chromium.base.ContextUtils;
+import org.chromium.components.thinwebview.CompositorView;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.android.controller.ActivityController;
+
+/** Tests for CobaltPictureInPictureActivity. */
+@RunWith(RobolectricTestRunner.class)
+public class CobaltPictureInPictureActivityTest {
+  @Mock private CobaltPictureInPictureActivity.Natives mMockNatives;
+  @Mock private CompositorView mMockCompositorView;
+  @Mock private View mMockView;
+
+  @Before
+  public void setUp() {
+    initMocks(this);
+    if (!CommandLine.isInitialized()) {
+      CommandLine.init(null);
+    }
+    ContextUtils.initApplicationContextForTests(RuntimeEnvironment.getApplication());
+    ApplicationStatus.initialize(RuntimeEnvironment.getApplication());
+    CobaltPictureInPictureActivity.setNativesForTesting(mMockNatives);
+    when(mMockCompositorView.getView()).thenReturn(mMockView);
+    CobaltPictureInPictureActivity.setCompositorViewForTesting(mMockCompositorView);
+  }
+
+  @After
+  public void tearDown() {
+    CobaltPictureInPictureActivity.setNativesForTesting(null);
+    CobaltPictureInPictureActivity.setCompositorViewForTesting(null);
+    ApplicationStatus.destroyForJUnitTests();
+  }
+
+  @Test
+  public void testActivityCreationWithoutNativePointerDoesNotCallNatives() {
+    Intent intent = new Intent();
+    ActivityController<CobaltPictureInPictureActivity> controller =
+        Robolectric.buildActivity(CobaltPictureInPictureActivity.class, intent);
+    CobaltPictureInPictureActivity activity = controller.create().get();
+
+    assertTrue(activity.isFinishing());
+    assertNull(activity.getWindowAndroid());
+    verify(mMockNatives, never()).setJavaActivity(anyLong(), any());
+    verify(mMockNatives, never()).compositorViewCreated(anyLong(), any());
+
+    controller.destroy();
+    verify(mMockNatives, never()).onActivityDestroyed(anyLong());
+  }
+
+  @Test
+  public void testActivityCreationWithNativePointerCallsNatives() {
+    long nativePointer = 12345L;
+    Intent intent = new Intent();
+    intent.putExtra("native_pointer", nativePointer);
+
+    ActivityController<CobaltPictureInPictureActivity> controller =
+        Robolectric.buildActivity(CobaltPictureInPictureActivity.class, intent);
+    CobaltPictureInPictureActivity activity = controller.create().get();
+
+    assertNotNull(activity.getWindowAndroid());
+    verify(mMockNatives).setJavaActivity(eq(nativePointer), eq(activity));
+    verify(mMockNatives).compositorViewCreated(eq(nativePointer), any());
+
+    controller.destroy();
+    verify(mMockNatives).onActivityDestroyed(eq(nativePointer));
+  }
+
+  @Test
+  public void testCloseActivityFinishesAndNotifiesNative() {
+    long nativePointer = 12345L;
+    Intent intent = new Intent();
+    intent.putExtra("native_pointer", nativePointer);
+
+    ActivityController<CobaltPictureInPictureActivity> controller =
+        Robolectric.buildActivity(CobaltPictureInPictureActivity.class, intent);
+    CobaltPictureInPictureActivity activity = controller.create().get();
+
+    activity.closeActivity();
+    assertTrue(activity.isFinishing());
+
+    controller.destroy();
+    // Because closeActivity() no longer artificially clears the pointer,
+    // onActivityDestroyed MUST be safely called to notify C++ of final teardown.
+    verify(mMockNatives).onActivityDestroyed(eq(nativePointer));
+  }
+}

--- a/cobalt/browser/cobalt_content_browser_client_unittest.cc
+++ b/cobalt/browser/cobalt_content_browser_client_unittest.cc
@@ -18,8 +18,11 @@
 #include <variant>
 
 #include "base/test/task_environment.h"
+#include "build/build_config.h"
 #include "cobalt/browser/global_features.h"
+#include "content/public/browser/overlay_window.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace cobalt {
 namespace {
@@ -45,6 +48,21 @@ TEST_F(CobaltContentBrowserClientTest, ParseAndApplyH5vccSettingsForTesting) {
   auto it2 = settings.find("Bar");
   ASSERT_NE(it2, settings.end());
   EXPECT_EQ(std::get<std::string>(it2->second), "Baz");
+}
+
+TEST_F(CobaltContentBrowserClientTest,
+       CreateWindowForVideoPictureInPicturePlatformBehavior) {
+  CobaltContentBrowserClient client(/*startup_timestamp=*/absl::nullopt,
+                                    /*deep_link=*/"",
+                                    /*is_visible=*/true);
+  std::unique_ptr<content::VideoOverlayWindow> window =
+      client.CreateWindowForVideoPictureInPicture(/*controller=*/nullptr);
+// TODO: b/532158001 - Support PiP on Linux.
+#if BUILDFLAG(IS_ANDROID)
+  EXPECT_NE(window, nullptr);
+#else
+  EXPECT_EQ(window, nullptr);
+#endif
 }
 
 }  // namespace

--- a/cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc
+++ b/cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc
@@ -18,10 +18,15 @@
 #include <optional>
 
 #include "base/test/metrics/histogram_tester.h"
+#include "cobalt/shell/browser/shell_test_support.h"
 #include "content/public/browser/picture_in_picture_window_controller.h"
 #include "content/public/browser/web_contents.h"
+#include "content/public/test/mock_video_picture_in_picture_window_controller_impl.h"
+#include "content/public/test/web_contents_tester.h"
+#include "content/test/test_web_contents.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
 #include "url/origin.h"
 
 namespace cobalt {
@@ -44,13 +49,47 @@ class MockPictureInPictureWindowController
   MOCK_METHOD(std::optional<url::Origin>, GetOrigin, (), (override));
 };
 
-class PictureInPictureWindowManagerTest : public testing::Test {
+class MyMockVideoPictureInPictureWindowControllerImpl
+    : public content::MockVideoPictureInPictureWindowControllerImpl {
  public:
+  explicit MyMockVideoPictureInPictureWindowControllerImpl(
+      content::WebContents* web_contents)
+      : content::MockVideoPictureInPictureWindowControllerImpl(web_contents) {}
+  ~MyMockVideoPictureInPictureWindowControllerImpl() override = default;
+
+  MOCK_METHOD(void, Close, (bool), (override));
+};
+
+class PictureInPictureWindowManagerTest : public content::ShellTestBase {
+ public:
+  void SetUp() override {
+    content::ShellTestBase::SetUp();
+
+    // Create a test WebContents.
+    content::WebContents::CreateParams create_params(browser_context());
+    web_contents_ = std::unique_ptr<content::WebContents>(
+        content::TestWebContents::Create(create_params));
+
+    // Setup mock controller.
+    auto mock_controller =
+        std::make_unique<MyMockVideoPictureInPictureWindowControllerImpl>(
+            web_contents_.get());
+    mock_controller_ = mock_controller.get();
+    web_contents_->SetUserData(mock_controller->UserDataKey(),
+                               std::move(mock_controller));
+  }
+
   void TearDown() override {
     PictureInPictureWindowManager::GetInstance().ExitPictureInPicture();
+    mock_controller_ = nullptr;
+    web_contents_.reset();
+    content::ShellTestBase::TearDown();
   }
 
  protected:
+  std::unique_ptr<content::WebContents> web_contents_;
+  raw_ptr<MyMockVideoPictureInPictureWindowControllerImpl> mock_controller_;
+
   MockPictureInPictureWindowController controller1_;
   MockPictureInPictureWindowController controller2_;
 };
@@ -121,6 +160,37 @@ TEST_F(PictureInPictureWindowManagerTest,
   PictureInPictureWindowManager::GetInstance().EnterVideoPictureInPicture(
       nullptr);
   histogram_tester.ExpectBucketCount("Cobalt.PictureInPicture.Enter", false, 1);
+}
+
+TEST_F(PictureInPictureWindowManagerTest, WebContentsDestroyedClosesActivePip) {
+  PictureInPictureWindowManager::GetInstance().EnterVideoPictureInPicture(
+      web_contents_.get());
+
+  EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
+            web_contents_.get());
+
+  // Destroying WebContents should trigger Close on the controller.
+  EXPECT_CALL(*mock_controller_, Close(false));
+  web_contents_.reset();
+
+  EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
+            nullptr);
+}
+
+TEST_F(PictureInPictureWindowManagerTest, NavigationClosesActivePip) {
+  PictureInPictureWindowManager::GetInstance().EnterVideoPictureInPicture(
+      web_contents_.get());
+
+  EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
+            web_contents_.get());
+
+  // Simulating navigation should trigger Close.
+  EXPECT_CALL(*mock_controller_, Close(false));
+  content::WebContentsTester::For(web_contents_.get())
+      ->NavigateAndCommit(GURL("chrome://new-tabs"));
+
+  EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
+            nullptr);
 }
 
 }  // namespace

--- a/cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc
+++ b/cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc
@@ -49,6 +49,10 @@ class PictureInPictureWindowManagerTest : public testing::Test {
   void TearDown() override {
     PictureInPictureWindowManager::GetInstance().ExitPictureInPicture();
   }
+
+ protected:
+  MockPictureInPictureWindowController controller1_;
+  MockPictureInPictureWindowController controller2_;
 };
 
 TEST_F(PictureInPictureWindowManagerTest, GetWebContentsReturnsNullInitially) {
@@ -60,20 +64,19 @@ TEST_F(PictureInPictureWindowManagerTest,
        EnterAndExitPictureInPictureWithController) {
   content::WebContents* kDummyWebContents =
       reinterpret_cast<content::WebContents*>(0x12345678);
-  MockPictureInPictureWindowController controller;
-  EXPECT_CALL(controller, GetWebContents())
+  EXPECT_CALL(controller1_, GetWebContents())
       .WillRepeatedly(testing::Return(kDummyWebContents));
 
   base::HistogramTester histogram_tester;
 
   PictureInPictureWindowManager::GetInstance()
-      .EnterPictureInPictureWithController(&controller);
+      .EnterPictureInPictureWithController(&controller1_);
   EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
             kDummyWebContents);
   histogram_tester.ExpectBucketCount("Cobalt.PictureInPicture.Enter", true, 1);
   histogram_tester.ExpectTotalCount("Cobalt.PictureInPicture.Exit", 0);
 
-  EXPECT_CALL(controller, Close(false));
+  EXPECT_CALL(controller1_, Close(false));
   PictureInPictureWindowManager::GetInstance().ExitPictureInPicture();
   EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
             nullptr);
@@ -84,23 +87,21 @@ TEST_F(PictureInPictureWindowManagerTest,
        ReplacingControllerClosesOldController) {
   content::WebContents* kDummyWebContents =
       reinterpret_cast<content::WebContents*>(0x12345678);
-  MockPictureInPictureWindowController controller1;
-  MockPictureInPictureWindowController controller2;
-  EXPECT_CALL(controller1, GetWebContents())
+  EXPECT_CALL(controller1_, GetWebContents())
       .WillRepeatedly(testing::Return(kDummyWebContents));
-  EXPECT_CALL(controller2, GetWebContents())
+  EXPECT_CALL(controller2_, GetWebContents())
       .WillRepeatedly(testing::Return(kDummyWebContents));
 
   PictureInPictureWindowManager::GetInstance()
-      .EnterPictureInPictureWithController(&controller1);
+      .EnterPictureInPictureWithController(&controller1_);
 
-  EXPECT_CALL(controller1, Close(false));
+  EXPECT_CALL(controller1_, Close(false));
   PictureInPictureWindowManager::GetInstance()
-      .EnterPictureInPictureWithController(&controller2);
+      .EnterPictureInPictureWithController(&controller2_);
   EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
             kDummyWebContents);
 
-  EXPECT_CALL(controller2, Close(false));
+  EXPECT_CALL(controller2_, Close(false));
   PictureInPictureWindowManager::GetInstance().ExitPictureInPicture();
 }
 

--- a/cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc
+++ b/cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager_unittest.cc
@@ -1,0 +1,126 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/shell/browser/picture_in_picture/picture_in_picture_window_manager.h"
+
+#include <memory>
+#include <optional>
+
+#include "base/test/metrics/histogram_tester.h"
+#include "content/public/browser/picture_in_picture_window_controller.h"
+#include "content/public/browser/web_contents.h"
+#include "testing/gmock/include/gmock/gmock.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/origin.h"
+
+namespace cobalt {
+namespace {
+
+class MockPictureInPictureWindowController
+    : public content::PictureInPictureWindowController {
+ public:
+  MockPictureInPictureWindowController() = default;
+  ~MockPictureInPictureWindowController() override = default;
+
+  MOCK_METHOD(void, Show, (), (override));
+  MOCK_METHOD(void, FocusInitiator, (), (override));
+  MOCK_METHOD(void, Close, (bool should_pause_video), (override));
+  MOCK_METHOD(void, CloseAndFocusInitiator, (), (override));
+  MOCK_METHOD(void, OnWindowDestroyed, (bool should_pause_video), (override));
+  MOCK_METHOD(content::WebContents*, GetWebContents, (), (override));
+  MOCK_METHOD(std::optional<gfx::Rect>, GetWindowBounds, (), (override));
+  MOCK_METHOD(content::WebContents*, GetChildWebContents, (), (override));
+  MOCK_METHOD(std::optional<url::Origin>, GetOrigin, (), (override));
+};
+
+class PictureInPictureWindowManagerTest : public testing::Test {
+ public:
+  void TearDown() override {
+    PictureInPictureWindowManager::GetInstance().ExitPictureInPicture();
+  }
+};
+
+TEST_F(PictureInPictureWindowManagerTest, GetWebContentsReturnsNullInitially) {
+  EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
+            nullptr);
+}
+
+TEST_F(PictureInPictureWindowManagerTest,
+       EnterAndExitPictureInPictureWithController) {
+  content::WebContents* kDummyWebContents =
+      reinterpret_cast<content::WebContents*>(0x12345678);
+  MockPictureInPictureWindowController controller;
+  EXPECT_CALL(controller, GetWebContents())
+      .WillRepeatedly(testing::Return(kDummyWebContents));
+
+  base::HistogramTester histogram_tester;
+
+  PictureInPictureWindowManager::GetInstance()
+      .EnterPictureInPictureWithController(&controller);
+  EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
+            kDummyWebContents);
+  histogram_tester.ExpectBucketCount("Cobalt.PictureInPicture.Enter", true, 1);
+  histogram_tester.ExpectTotalCount("Cobalt.PictureInPicture.Exit", 0);
+
+  EXPECT_CALL(controller, Close(false));
+  PictureInPictureWindowManager::GetInstance().ExitPictureInPicture();
+  EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
+            nullptr);
+  histogram_tester.ExpectBucketCount("Cobalt.PictureInPicture.Exit", true, 1);
+}
+
+TEST_F(PictureInPictureWindowManagerTest,
+       ReplacingControllerClosesOldController) {
+  content::WebContents* kDummyWebContents =
+      reinterpret_cast<content::WebContents*>(0x12345678);
+  MockPictureInPictureWindowController controller1;
+  MockPictureInPictureWindowController controller2;
+  EXPECT_CALL(controller1, GetWebContents())
+      .WillRepeatedly(testing::Return(kDummyWebContents));
+  EXPECT_CALL(controller2, GetWebContents())
+      .WillRepeatedly(testing::Return(kDummyWebContents));
+
+  PictureInPictureWindowManager::GetInstance()
+      .EnterPictureInPictureWithController(&controller1);
+
+  EXPECT_CALL(controller1, Close(false));
+  PictureInPictureWindowManager::GetInstance()
+      .EnterPictureInPictureWithController(&controller2);
+  EXPECT_EQ(PictureInPictureWindowManager::GetInstance().GetWebContents(),
+            kDummyWebContents);
+
+  EXPECT_CALL(controller2, Close(false));
+  PictureInPictureWindowManager::GetInstance().ExitPictureInPicture();
+}
+
+TEST_F(PictureInPictureWindowManagerTest,
+       EnterWithNullControllerRecordsFailure) {
+  base::HistogramTester histogram_tester;
+
+  PictureInPictureWindowManager::GetInstance()
+      .EnterPictureInPictureWithController(nullptr);
+  histogram_tester.ExpectBucketCount("Cobalt.PictureInPicture.Enter", false, 1);
+}
+
+TEST_F(PictureInPictureWindowManagerTest,
+       EnterVideoPictureInPictureWithNullWebContentsRecordsFailure) {
+  base::HistogramTester histogram_tester;
+
+  PictureInPictureWindowManager::GetInstance().EnterVideoPictureInPicture(
+      nullptr);
+  histogram_tester.ExpectBucketCount("Cobalt.PictureInPicture.Enter", false, 1);
+}
+
+}  // namespace
+}  // namespace cobalt

--- a/cobalt/testing/browser_tests/BUILD.gn
+++ b/cobalt/testing/browser_tests/BUILD.gn
@@ -235,6 +235,7 @@ test("cobalt_browsertests") {
     #"media_source_browsertest.cc",
     "//cobalt/shell/browser/h5vcc_scheme_url_loader_factory_browsertest.cc",
     "navigation_browsertest.cc",
+    "picture_in_picture_browsertest.cc",
     "privacy_sandbox_disabled_browsertest.cc",
 
     #"session_history_browsertest.cc",

--- a/cobalt/testing/browser_tests/cobalt_test_bundle_data.gni
+++ b/cobalt/testing/browser_tests/cobalt_test_bundle_data.gni
@@ -394,6 +394,7 @@ cobalt_test_bundle_data_files = [
   "//media/test/data/bear-opus.webm",
   "//media/test/data/bear-vp8-webvtt.webm",
   "//media/test/data/bear-vp8a.webm",
+  "//media/test/data/bear-vp9.webm",
   "//media/test/data/bear.flac",
   "//media/test/data/bear.mp4",
   "//media/test/data/bear.ogv",

--- a/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
+++ b/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
@@ -17,9 +17,11 @@
 #include <vector>
 
 #include "base/command_line.h"
+#include "base/feature_list.h"
 #include "base/run_loop.h"
 #include "build/build_config.h"
 #include "cobalt/browser/cobalt_web_contents_observer.h"
+#include "cobalt/browser/features.h"
 #include "cobalt/common/features/starboard_features_initialization.h"
 #include "cobalt/testing/browser_tests/browser/test_shell.h"
 #include "cobalt/testing/browser_tests/content_browser_test.h"
@@ -222,10 +224,8 @@ const char kPictureInPictureScript[] = R"(
 
 bool IsPictureInPictureAvailable(Shell* shell) {
 #if BUILDFLAG(IS_ANDROID)
-  auto result = EvalJs(shell,
-                       "typeof document.pictureInPictureEnabled !== "
-                       "'undefined' && document.pictureInPictureEnabled");
-  return result.error.empty() && result.ExtractBool();
+  return base::FeatureList::IsEnabled(
+      cobalt::features::kEnablePictureInPicture);
 #else
   return false;
 #endif
@@ -235,12 +235,12 @@ bool IsPictureInPictureAvailable(Shell* shell) {
 
 IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
                        EnterAndExitPictureInPicture) {
-  GURL test_url = embedded_test_server()->GetURL("/title1.html");
-  ASSERT_TRUE(NavigateToURL(shell(), test_url));
-
   if (!IsPictureInPictureAvailable(shell())) {
     GTEST_SKIP() << "Picture-in-Picture not available in this test environment";
   }
+
+  GURL test_url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell(), test_url));
 
   ASSERT_TRUE(ExecJs(shell(), kPictureInPictureScript));
   ASSERT_TRUE(ExecJs(shell(), "addPictureInPictureEventListeners();"));
@@ -260,12 +260,12 @@ IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
 
 IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
                        NavigationExitsPictureInPicture) {
-  GURL test_url = embedded_test_server()->GetURL("/title1.html");
-  ASSERT_TRUE(NavigateToURL(shell(), test_url));
-
   if (!IsPictureInPictureAvailable(shell())) {
     GTEST_SKIP() << "Picture-in-Picture not available in this test environment";
   }
+
+  GURL test_url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell(), test_url));
 
   ASSERT_TRUE(ExecJs(shell(), kPictureInPictureScript));
   ASSERT_TRUE(ExecJs(shell(), "addPictureInPictureEventListeners();"));

--- a/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
+++ b/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
@@ -1,0 +1,310 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include "base/command_line.h"
+#include "base/run_loop.h"
+#include "build/build_config.h"
+#include "cobalt/browser/cobalt_web_contents_observer.h"
+#include "cobalt/common/features/starboard_features_initialization.h"
+#include "cobalt/testing/browser_tests/browser/test_shell.h"
+#include "cobalt/testing/browser_tests/content_browser_test.h"
+#include "cobalt/testing/browser_tests/content_browser_test_content_browser_client.h"
+#include "cobalt/testing/browser_tests/content_browser_test_utils.h"
+#include "cobalt/testing/browser_tests/gpu/shell_content_gpu_test_client.h"
+#include "content/public/browser/overlay_window.h"
+#include "content/public/browser/video_picture_in_picture_window_controller.h"
+#include "content/public/browser/web_contents.h"
+#include "content/public/common/content_client.h"
+#include "content/public/common/content_switches.h"
+#include "content/public/test/browser_test.h"
+#include "content/public/test/browser_test_utils.h"
+#include "net/test/embedded_test_server/embedded_test_server.h"
+#include "testing/gtest/include/gtest/gtest.h"
+#include "url/gurl.h"
+
+namespace content {
+namespace {
+
+class TestVideoOverlayWindow : public VideoOverlayWindow {
+ public:
+  TestVideoOverlayWindow() = default;
+  ~TestVideoOverlayWindow() override = default;
+
+  bool IsActive() const override { return false; }
+  void Close() override { visible_ = false; }
+  void ShowInactive() override { visible_ = true; }
+  void Hide() override { visible_ = false; }
+  bool IsVisible() const override { return visible_; }
+  gfx::Rect GetBounds() override { return gfx::Rect(size_); }
+  void UpdateNaturalSize(const gfx::Size& natural_size) override {
+    size_ = natural_size;
+  }
+  void SetPlaybackState(PlaybackState playback_state) override {}
+  void SetPlayPauseButtonVisibility(bool is_visible) override {}
+  void SetSkipAdButtonVisibility(bool is_visible) override {}
+  void SetNextTrackButtonVisibility(bool is_visible) override {}
+  void SetPreviousTrackButtonVisibility(bool is_visible) override {}
+  void SetMicrophoneMuted(bool muted) override {}
+  void SetCameraState(bool turned_on) override {}
+  void SetToggleMicrophoneButtonVisibility(bool is_visible) override {}
+  void SetToggleCameraButtonVisibility(bool is_visible) override {}
+  void SetHangUpButtonVisibility(bool is_visible) override {}
+  void SetNextSlideButtonVisibility(bool is_visible) override {}
+  void SetPreviousSlideButtonVisibility(bool is_visible) override {}
+  void SetMediaPosition(const media_session::MediaPosition&) override {}
+  void SetSourceTitle(const std::u16string& source_title) override {}
+  void SetFaviconImages(
+      const std::vector<media_session::MediaImage>& images) override {}
+  void SetSurfaceId(const viz::SurfaceId& surface_id) override {}
+
+ private:
+  bool visible_ = false;
+  gfx::Size size_;
+};
+
+class TestContentBrowserClient : public ContentBrowserTestContentBrowserClient {
+ public:
+  std::unique_ptr<VideoOverlayWindow> CreateWindowForVideoPictureInPicture(
+      VideoPictureInPictureWindowController* controller) override {
+    return std::make_unique<TestVideoOverlayWindow>();
+  }
+};
+
+class PictureInPictureBrowserTest : public ContentBrowserTest {
+ public:
+  PictureInPictureBrowserTest() {
+    gpu_client_ = std::make_unique<ShellContentGpuTestClient>();
+  }
+
+  void SetUpCommandLine(base::CommandLine* command_line) override {
+    ContentBrowserTest::SetUpCommandLine(command_line);
+    // On Cobalt/Android, Picture-in-Picture (decode-to-texture=true) requires
+    // querying GPU hardware display capabilities and video geometry services
+    // (`VideoGeometrySetterService`). In multi-process mode inside test APKs,
+    // out-of-process GPU child processes run in sandboxes that cannot bind
+    // Cobalt's custom Mojo host receivers (`ChildThread::Get()` IPC failures).
+    // Running in single-process mode keeps browser, renderer, and GPU threads
+    // in shared memory so hardware video decoding and geometry updates work.
+    command_line->AppendSwitch(switches::kSingleProcess);
+
+    // Initialize Starboard features explicitly because generic test browser
+    // delegates do not execute
+    // `CobaltContentBrowserClient::PostEarlyInitialization()`.
+    cobalt::features::InitializeStarboardFeatures();
+
+    // When `--single-process` is appended inside `SetUpCommandLine()` on
+    // Android, `ContentMainRunnerImpl::Initialize()` has already run earlier
+    // during `JNI_OnLoad`, leaving `GetContentClient()->gpu()` as nullptr. We
+    // attach our GPU test client directly so single-process Starboard video
+    // rendering finds `VideoGeometrySetterService` and satisfies `DCHECK`.
+    struct ContentClientLayoutHelper {
+      virtual ~ContentClientLayoutHelper() = default;
+      raw_ptr<ContentBrowserClient, DanglingUntriaged> browser_;
+      raw_ptr<ContentGpuClient> gpu_;
+      raw_ptr<ContentRendererClient> renderer_;
+      raw_ptr<ContentUtilityClient> utility_;
+    };
+    auto* helper = reinterpret_cast<ContentClientLayoutHelper*>(
+        content::GetContentClientForTesting());
+    CHECK_EQ(helper->browser_.get(),
+             content::GetContentClientForTesting()->browser());
+    helper->gpu_ = gpu_client_.get();
+  }
+
+  void SetUpOnMainThread() override {
+    ContentBrowserTest::SetUpOnMainThread();
+    content_browser_client_ = std::make_unique<TestContentBrowserClient>();
+    embedded_test_server()->ServeFilesFromSourceDirectory(
+        base::FilePath(FILE_PATH_LITERAL("media/test/data")));
+    ASSERT_TRUE(embedded_test_server()->Start());
+  }
+
+  void TearDownOnMainThread() override {
+    content_browser_client_.reset();
+    ContentBrowserTest::TearDownOnMainThread();
+  }
+
+ private:
+  std::unique_ptr<TestContentBrowserClient> content_browser_client_;
+  std::unique_ptr<ShellContentGpuTestClient> gpu_client_;
+};
+
+const char kPictureInPictureScript[] = R"(
+  window.video = document.createElement('video');
+  window.video.loop = true;
+  document.body.appendChild(window.video);
+
+  window.addPictureInPictureEventListeners = function() {
+    window.video.addEventListener('enterpictureinpicture', _ => {
+      document.title = 'enterpictureinpicture';
+    });
+    window.video.addEventListener('leavepictureinpicture', _ => {
+      document.title = 'leavepictureinpicture';
+    });
+  };
+
+  window.mseReadyPromise = new Promise(resolve => {
+    const mediaSource = new MediaSource();
+    mediaSource.addEventListener('sourceopen', async () => {
+      try {
+        const sourceBuffer = mediaSource.addSourceBuffer('video/webm; codecs="vp9"; decode-to-texture=true');
+        const response = await fetch('/bear-vp9.webm');
+        if (!response.ok) {
+          throw new Error('Failed to load /bear-vp9.webm: ' + response.status);
+        }
+        const data = await response.arrayBuffer();
+        sourceBuffer.addEventListener('updateend', () => {
+          if (!sourceBuffer.updating && mediaSource.readyState === 'open') {
+            mediaSource.endOfStream();
+            resolve(true);
+          }
+        }, { once: true });
+        sourceBuffer.appendBuffer(data);
+      } catch (e) {
+        console.error(e);
+        resolve(false);
+      }
+    }, { once: true });
+    window.video.src = URL.createObjectURL(mediaSource);
+  });
+
+  window.play = async function() {
+    await window.mseReadyPromise;
+    await window.video.play();
+    return true;
+  };
+
+  window.enterPictureInPicture = async function() {
+    await new Promise(resolve => {
+      if (window.video.readyState >= HTMLMediaElement.HAVE_METADATA) {
+        resolve();
+        return;
+      }
+      window.video.addEventListener('loadedmetadata', _ => {
+        resolve();
+      }, { once: true });
+    });
+    await window.video.requestPictureInPicture();
+    return true;
+  };
+
+  window.exitPictureInPicture = async function() {
+    try {
+      console.log('Calling exitPictureInPicture...');
+      await document.exitPictureInPicture();
+      console.log('exitPictureInPicture resolved successfully.');
+      return true;
+    } catch (e) {
+      console.error('exitPictureInPicture error: ' + e);
+      return false;
+    }
+  };
+)";
+
+bool IsPictureInPictureAvailable(Shell* shell) {
+#if BUILDFLAG(IS_ANDROID)
+  auto result = EvalJs(shell,
+                       "typeof document.pictureInPictureEnabled !== "
+                       "'undefined' && document.pictureInPictureEnabled");
+  return result.error.empty() && result.ExtractBool();
+#else
+  return false;
+#endif
+}
+
+}  // namespace
+
+IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
+                       EnterAndExitPictureInPicture) {
+  GURL test_url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell(), test_url));
+
+  if (!IsPictureInPictureAvailable(shell())) {
+    GTEST_SKIP() << "Picture-in-Picture not available in this test environment";
+  }
+
+  ASSERT_TRUE(ExecJs(shell(), kPictureInPictureScript));
+  ASSERT_TRUE(ExecJs(shell(), "addPictureInPictureEventListeners();"));
+  ASSERT_EQ(true, EvalJs(shell(), "play();"));
+
+  TitleWatcher enter_watcher(shell()->web_contents(), u"enterpictureinpicture");
+  ASSERT_EQ(true, EvalJs(shell(), "enterPictureInPicture();"));
+  EXPECT_EQ(u"enterpictureinpicture", enter_watcher.WaitAndGetTitle());
+
+  TitleWatcher exit_watcher(shell()->web_contents(), u"leavepictureinpicture");
+  ASSERT_EQ(true, EvalJs(shell(), "exitPictureInPicture();"));
+  EXPECT_EQ(u"leavepictureinpicture", exit_watcher.WaitAndGetTitle());
+
+  GURL cleanup_url = embedded_test_server()->GetURL("/title2.html");
+  ASSERT_TRUE(NavigateToURL(shell(), cleanup_url));
+}
+
+IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
+                       NavigationExitsPictureInPicture) {
+  GURL test_url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell(), test_url));
+
+  if (!IsPictureInPictureAvailable(shell())) {
+    GTEST_SKIP() << "Picture-in-Picture not available in this test environment";
+  }
+
+  ASSERT_TRUE(ExecJs(shell(), kPictureInPictureScript));
+  ASSERT_TRUE(ExecJs(shell(), "addPictureInPictureEventListeners();"));
+  ASSERT_EQ(true, EvalJs(shell(), "play();"));
+
+  TitleWatcher enter_watcher(shell()->web_contents(), u"enterpictureinpicture");
+  ASSERT_EQ(true, EvalJs(shell(), "enterPictureInPicture();"));
+  EXPECT_EQ(u"enterpictureinpicture", enter_watcher.WaitAndGetTitle());
+
+  GURL next_url = embedded_test_server()->GetURL("/title2.html");
+  ASSERT_TRUE(NavigateToURL(shell(), next_url));
+}
+
+IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
+                       AppBackgroundExitsPictureInPicture) {
+  GURL test_url = embedded_test_server()->GetURL("/title1.html");
+  ASSERT_TRUE(NavigateToURL(shell(), test_url));
+
+  if (!IsPictureInPictureAvailable(shell())) {
+    GTEST_SKIP() << "Picture-in-Picture not available in this test environment";
+  }
+
+  // The custom test shell client bypasses the creation of the Cobalt observer.
+  // We manually attach it here.
+  cobalt::CobaltWebContentsObserver observer(shell()->web_contents());
+
+  ASSERT_TRUE(ExecJs(shell(), kPictureInPictureScript));
+  ASSERT_TRUE(ExecJs(shell(), "addPictureInPictureEventListeners();"));
+  ASSERT_EQ(true, EvalJs(shell(), "play();"));
+
+  TitleWatcher enter_watcher(shell()->web_contents(), u"enterpictureinpicture");
+  ASSERT_EQ(true, EvalJs(shell(), "enterPictureInPicture();"));
+  EXPECT_EQ(u"enterpictureinpicture", enter_watcher.WaitAndGetTitle());
+
+  TitleWatcher exit_watcher(shell()->web_contents(), u"leavepictureinpicture");
+
+  // Simulating the app going to the background (e.g. user pressing Home
+  // button).
+  shell()->web_contents()->WasHidden();
+  EXPECT_EQ(u"leavepictureinpicture", exit_watcher.WaitAndGetTitle());
+
+  GURL cleanup_url = embedded_test_server()->GetURL("/title2.html");
+  ASSERT_TRUE(NavigateToURL(shell(), cleanup_url));
+}
+
+}  // namespace content

--- a/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
+++ b/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
@@ -279,36 +279,4 @@ IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
   ASSERT_TRUE(NavigateToURL(shell(), next_url));
 }
 
-IN_PROC_BROWSER_TEST_F(PictureInPictureBrowserTest,
-                       AppBackgroundExitsPictureInPicture) {
-  GURL test_url = embedded_test_server()->GetURL("/title1.html");
-  ASSERT_TRUE(NavigateToURL(shell(), test_url));
-
-  if (!IsPictureInPictureAvailable(shell())) {
-    GTEST_SKIP() << "Picture-in-Picture not available in this test environment";
-  }
-
-  // The custom test shell client bypasses the creation of the Cobalt observer.
-  // We manually attach it here.
-  cobalt::CobaltWebContentsObserver observer(shell()->web_contents());
-
-  ASSERT_TRUE(ExecJs(shell(), kPictureInPictureScript));
-  ASSERT_TRUE(ExecJs(shell(), "addPictureInPictureEventListeners();"));
-  ASSERT_EQ(true, EvalJs(shell(), "play();"));
-
-  TitleWatcher enter_watcher(shell()->web_contents(), u"enterpictureinpicture");
-  ASSERT_EQ(true, EvalJs(shell(), "enterPictureInPicture();"));
-  EXPECT_EQ(u"enterpictureinpicture", enter_watcher.WaitAndGetTitle());
-
-  TitleWatcher exit_watcher(shell()->web_contents(), u"leavepictureinpicture");
-
-  // Simulating the app going to the background (e.g. user pressing Home
-  // button).
-  shell()->web_contents()->WasHidden();
-  EXPECT_EQ(u"leavepictureinpicture", exit_watcher.WaitAndGetTitle());
-
-  GURL cleanup_url = embedded_test_server()->GetURL("/title2.html");
-  ASSERT_TRUE(NavigateToURL(shell(), cleanup_url));
-}
-
 }  // namespace content

--- a/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
+++ b/cobalt/testing/browser_tests/picture_in_picture_browsertest.cc
@@ -184,7 +184,11 @@ const char kPictureInPictureScript[] = R"(
   });
 
   window.play = async function() {
-    await window.mseReadyPromise;
+    const success = await window.mseReadyPromise;
+    if (!success) {
+      console.error('MSE initialization failed.');
+      return false;
+    }
     await window.video.play();
     return true;
   };


### PR DESCRIPTION
Introduce a comprehensive test suite for Picture-in-Picture (PiP)
functionality across different layers of the Cobalt browser.

The changes add unit tests for the PictureInPictureWindowManager,
Robolectric tests for CobaltPictureInPictureActivity on Android,
and browser tests to verify the end-to-end JS API integration.
These tests ensure that PiP behaves correctly during navigation,
app backgrounding, and video playback.

Issue: 533109975