### PR TITLE
media: Reset output surface on MediaCodec flush

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/media/MediaCodecBridge.java
@@ -41,8 +41,8 @@ import dev.cobalt.util.Log;
 import dev.cobalt.util.SynchronizedHolder;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.concurrent.atomic.AtomicInteger;
 import java.util.Locale;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.jni_zero.CalledByNative;
 import org.jni_zero.JNINamespace;
 import org.jni_zero.NativeMethods;
@@ -89,14 +89,17 @@ class MediaCodecBridge {
       return true;
     }
     // |mOperatingRate| won't be 0, but to be cautious we still add a check here.
-    if (!mSkipVideoFramesOver60Fps || mOperatingRate <= kMaxAcceptedOperatingRate || mOperatingRate == 0) {
+    if (!mSkipVideoFramesOver60Fps
+        || mOperatingRate <= kMaxAcceptedOperatingRate
+        || mOperatingRate == 0) {
       return false;
     }
     // Deterministically downsample to 60fps by picking one frame per 1/60s interval.
     // Some visual jitter may occur briefly when the playback rate changes.
     double frameIntervalUs = 1_000_000.0 / mOperatingRate;
     if (Math.floor(presentationTimeUs * kMaxAcceptedOperatingRate / 1_000_000.0)
-        == Math.floor((presentationTimeUs - frameIntervalUs) * kMaxAcceptedOperatingRate / 1_000_000.0)) {
+        == Math.floor(
+            (presentationTimeUs - frameIntervalUs) * kMaxAcceptedOperatingRate / 1_000_000.0)) {
       return true;
     }
     return false;
@@ -125,17 +128,17 @@ class MediaCodecBridge {
     return mActiveOutputBuffers.get();
   }
 
-   /** Wraps a {@link MediaFormat} object to expose its properties to native code */
-   // Copied from Chromium's MediaCodecBridge.java
-   // https://source.chromium.org/chromium/chromium/src/+/main:media/base/android/java/src/org/chromium/media/MediaCodecBridge.java;l=294-350;drc=6ac17d9d1b844a695209e865137466925fa1214f
-   // Here are changes made.
-   // - Exposes formatHasCropValues() to the native layer, which needs to call it.
-   // - Removes the methods that Cobalt do not use (e.g. colorStandrd).
-   // - Add @Nonnul annotation to mFormat. since it is not null.
-   // - Add safety checks for width() and height() to prevent a crash. Cobalt's native code
-   //   accesses the format immediately in the onOutputFormatChanged callback, which can be
-   //   before the dimension keys are available.
-   private static class MediaFormatWrapper {
+  /** Wraps a {@link MediaFormat} object to expose its properties to native code */
+  // Copied from Chromium's MediaCodecBridge.java
+  // https://source.chromium.org/chromium/chromium/src/+/main:media/base/android/java/src/org/chromium/media/MediaCodecBridge.java;l=294-350;drc=6ac17d9d1b844a695209e865137466925fa1214f
+  // Here are changes made.
+  // - Exposes formatHasCropValues() to the native layer, which needs to call it.
+  // - Removes the methods that Cobalt do not use (e.g. colorStandrd).
+  // - Add @Nonnul annotation to mFormat. since it is not null.
+  // - Add safety checks for width() and height() to prevent a crash. Cobalt's native code
+  //   accesses the format immediately in the onOutputFormatChanged callback, which can be
+  //   before the dimension keys are available.
+  private static class MediaFormatWrapper {
     @NonNull private final MediaFormat mFormat;
 
     private MediaFormatWrapper(MediaFormat format) {
@@ -145,9 +148,9 @@ class MediaCodecBridge {
     @CalledByNative("MediaFormatWrapper")
     private boolean formatHasCropValues() {
       return mFormat.containsKey(KEY_CROP_RIGHT)
-            && mFormat.containsKey(KEY_CROP_LEFT)
-            && mFormat.containsKey(KEY_CROP_BOTTOM)
-            && mFormat.containsKey(KEY_CROP_TOP);
+          && mFormat.containsKey(KEY_CROP_LEFT)
+          && mFormat.containsKey(KEY_CROP_BOTTOM)
+          && mFormat.containsKey(KEY_CROP_TOP);
     }
 
     @CalledByNative("MediaFormatWrapper")
@@ -721,11 +724,12 @@ class MediaCodecBridge {
         mFrameRateEstimator.reset();
       }
       if (mEnableIgnoreCallbacksDuringFlushing) {
-        mMainHandler.post(() -> {
-          synchronized (mNativeBridgeLock) {
-            mIsFlushing = false;
-          }
-        });
+        mMainHandler.post(
+            () -> {
+              synchronized (mNativeBridgeLock) {
+                mIsFlushing = false;
+              }
+            });
       }
     }
     return MediaCodecStatus.OK;
@@ -776,8 +780,8 @@ class MediaCodecBridge {
     MediaFormat format = null;
     try {
       format = mMediaCodec.get().getOutputFormat();
-    // Catches `RuntimeException` to handle any undocumented exceptions.
-    // See http://b/445694177#comment4 for details.
+      // Catches `RuntimeException` to handle any undocumented exceptions.
+      // See http://b/445694177#comment4 for details.
     } catch (RuntimeException e) {
       Log.e(TAG, "Failed to get output format", e);
       return null;
@@ -787,7 +791,7 @@ class MediaCodecBridge {
     // If the format is null, we crash the app for dev builds to enforce the API contract.
     // On release builds, we log the error and return null.
     if (format == null) {
-      assert(false);
+      assert (false);
       Log.e(TAG, "MediaCodec.getOutputFormat() returned null");
       return null;
     }
@@ -914,6 +918,20 @@ class MediaCodecBridge {
     } catch (IllegalStateException e) {
       // TODO: May need to report the error to the caller. crbug.com/356498.
       Log.e(TAG, "Failed to release output buffer", e);
+    }
+  }
+
+  @CalledByNative
+  private boolean setSurface(Surface surface) {
+    if (Build.VERSION.SDK_INT < Build.VERSION_CODES.M) {
+      return false;
+    }
+    try {
+      mMediaCodec.get().setOutputSurface(surface);
+      return true;
+    } catch (IllegalArgumentException | IllegalStateException e) {
+      Log.e(TAG, "Cannot set output surface", e);
+      return false;
     }
   }
 
@@ -1093,7 +1111,9 @@ class MediaCodecBridge {
             }
           };
       if (mEnableIgnoreCallbacksDuringFlushing) {
-        mMediaCodec.get().setOnFirstTunnelFrameReadyListener(mMainHandler, mFirstTunnelFrameReadyListener);
+        mMediaCodec
+            .get()
+            .setOnFirstTunnelFrameReadyListener(mMainHandler, mFirstTunnelFrameReadyListener);
       } else {
         mMediaCodec.get().setOnFirstTunnelFrameReadyListener(null, mFirstTunnelFrameReadyListener);
       }

--- a/starboard/android/shared/media_codec.h
+++ b/starboard/android/shared/media_codec.h
@@ -89,6 +89,7 @@ class MediaCodec {
     bool force_big_endian_hdr_metadata = false;
     std::optional<int> tunnel_mode_audio_session_id;
     bool enable_ndk_video = false;
+    bool set_output_surface_on_flush = false;
   };
 
   static constexpr int32_t kBufferFlagCodecConfig = 2;
@@ -171,6 +172,9 @@ class MediaCodec {
   virtual void SetPlaybackRate(double playback_rate) = 0;
   virtual bool Restart() = 0;
   virtual jint Flush() = 0;
+  virtual bool SetOutputSurface(const jni_zero::JavaRef<jobject>& j_surface) {
+    return false;
+  }
   virtual std::optional<FrameSize> GetOutputSize() = 0;
   virtual std::optional<AudioOutputFormatResult> GetAudioOutputFormat() = 0;
 };

--- a/starboard/android/shared/media_codec_bridge.cc
+++ b/starboard/android/shared/media_codec_bridge.cc
@@ -204,6 +204,12 @@ MediaCodecBridge::CreateVideoMediaCodec(
 
   std::unique_ptr<MediaCodecBridge> native_media_codec_bridge(
       new MediaCodecBridge(handler));
+  if (j_surface) {
+    native_media_codec_bridge->j_surface_.Reset(env, j_surface.obj());
+  }
+  native_media_codec_bridge->set_output_surface_on_flush_ =
+      platform_options.set_output_surface_on_flush;
+
   Java_MediaCodecBridge_createVideoMediaCodecBridge(
       env, reinterpret_cast<jlong>(native_media_codec_bridge.get()),
       ConvertUTF8ToJavaString(env, mime),
@@ -370,7 +376,33 @@ bool MediaCodecBridge::Restart() {
 
 jint MediaCodecBridge::Flush() {
   JNIEnv* env = AttachCurrentThread();
-  return Java_MediaCodecBridge_flush(env, j_media_codec_bridge_);
+  jint status = Java_MediaCodecBridge_flush(env, j_media_codec_bridge_);
+  // On some chipsets, output frames that were already sent to the display via
+  // ReleaseOutputBufferAtTimestamp remain trapped in hwcomposer's composition
+  // pipeline even after MediaCodec.flush(). Re-binding the output surface
+  // forces ANativeWindow and hwcomposer to disconnect/reconnect and purge all
+  // in-flight pre-seek overlay buffers, restoring trapped buffer slots to the
+  // free pool.
+  if (status == MEDIA_CODEC_OK && set_output_surface_on_flush_ && j_surface_) {
+    SetOutputSurface(j_surface_);
+  }
+  return status;
+}
+
+bool MediaCodecBridge::SetOutputSurface(
+    const jni_zero::JavaRef<jobject>& j_surface) {
+  if (!j_surface) {
+    return false;
+  }
+  JNIEnv* env = AttachCurrentThread();
+  if (!Java_MediaCodecBridge_setSurface(env, j_media_codec_bridge_,
+                                        j_surface)) {
+    return false;
+  }
+  if (j_surface_.obj() != j_surface.obj()) {
+    j_surface_.Reset(env, j_surface.obj());
+  }
+  return true;
 }
 
 std::optional<FrameSize> MediaCodecBridge::GetOutputSize() {

--- a/starboard/android/shared/media_codec_bridge.h
+++ b/starboard/android/shared/media_codec_bridge.h
@@ -92,6 +92,8 @@ class MediaCodecBridge : public MediaCodec {
   std::optional<FrameSize> GetOutputSize() override;
   std::optional<AudioOutputFormatResult> GetAudioOutputFormat() override;
 
+  bool SetOutputSurface(const jni_zero::JavaRef<jobject>& j_surface) override;
+
   // JNI callback entry points
   void OnMediaCodecError(
       JNIEnv* env,
@@ -114,6 +116,8 @@ class MediaCodecBridge : public MediaCodec {
  private:
   Handler* const handler_;
   jni_zero::ScopedJavaGlobalRef<jobject> j_media_codec_bridge_ = NULL;
+  jni_zero::ScopedJavaGlobalRef<jobject> j_surface_ = NULL;
+  bool set_output_surface_on_flush_ = false;
 
   MediaCodecBridge(const MediaCodecBridge&) = delete;
   void operator=(const MediaCodecBridge&) = delete;

--- a/starboard/android/shared/media_codec_decoder.cc
+++ b/starboard/android/shared/media_codec_decoder.cc
@@ -138,6 +138,7 @@ MediaCodecDecoder::CreateForVideo(
     bool use_dual_threads,
     bool skip_video_frames_over_60_fps,
     bool ignore_mediacodec_callbacks_during_flushing,
+    bool set_output_surface_on_flush,
     bool enable_ndk_video,
     bool enable_trivial_optimizations) {
   std::string error_message;
@@ -149,8 +150,8 @@ MediaCodecDecoder::CreateForVideo(
       enable_frame_renderer_listener, force_big_endian_hdr_metadata,
       max_video_input_size, flush_delay_usec, use_dual_threads,
       skip_video_frames_over_60_fps,
-      ignore_mediacodec_callbacks_during_flushing, enable_ndk_video,
-      enable_trivial_optimizations, &error_message);
+      ignore_mediacodec_callbacks_during_flushing, set_output_surface_on_flush,
+      enable_ndk_video, enable_trivial_optimizations, &error_message);
   if (!decoder->media_codec_bridge_) {
     return Failure(error_message);
   }
@@ -223,6 +224,7 @@ MediaCodecDecoder::MediaCodecDecoder(
     bool use_dual_threads,
     bool skip_video_frames_over_60_fps,
     bool ignore_mediacodec_callbacks_during_flushing,
+    bool set_output_surface_on_flush,
     bool enable_ndk_video,
     bool enable_trivial_optimizations,
     std::string* error_message)
@@ -259,7 +261,8 @@ MediaCodecDecoder::MediaCodecDecoder(
        ignore_mediacodec_callbacks_during_flushing,
        enable_frame_renderer_listener, require_secured_decoder,
        require_software_codec, force_big_endian_hdr_metadata,
-       tunnel_mode_audio_session_id, enable_ndk_video});
+       tunnel_mode_audio_session_id, enable_ndk_video,
+       set_output_surface_on_flush});
 
   if (media_codec_bridge) {
     media_codec_bridge_ = std::move(media_codec_bridge.value());

--- a/starboard/android/shared/media_codec_decoder.h
+++ b/starboard/android/shared/media_codec_decoder.h
@@ -106,6 +106,7 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
       bool use_dual_threads,
       bool skip_video_frames_over_60_fps,
       bool ignore_mediacodec_callbacks_during_flushing,
+      bool set_output_surface_on_flush,
       bool enable_ndk_video,
       bool enable_trivial_optimizations);
 
@@ -141,6 +142,7 @@ class MediaCodecDecoder final : private MediaCodec::Handler,
       bool use_dual_threads,
       bool skip_video_frames_over_60_fps,
       bool ignore_mediacodec_callbacks_during_flushing,
+      bool set_output_surface_on_flush,
       bool enable_ndk_video,
       bool enable_trivial_optimizations,
       std::string* error_message);

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -374,6 +374,9 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
       ignore_mediacodec_callbacks_during_flushing_(
           pipeline_config.experimental_features.GetBool(
               kMediaIgnoreMediaCodecCallbacksDuringFlushing)),
+      set_output_surface_on_flush_(
+          pipeline_config.experimental_features.GetBool(
+              kMediaSetOutputSurfaceOnFlush)),
       enable_trivial_optimizations_(
           pipeline_config.experimental_features.GetBool(
               kMediaEnableTrivialOptimizations)),
@@ -871,7 +874,8 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       tunnel_mode_audio_session_id_, is_video_frame_tracker_enabled_,
       force_big_endian_hdr_metadata_, max_video_input_size_, flush_delay_usec_,
       use_dual_threads_, skip_video_frames_over_60_fps_,
-      ignore_mediacodec_callbacks_during_flushing_, enable_ndk_video_,
+      ignore_mediacodec_callbacks_during_flushing_,
+      set_output_surface_on_flush_, enable_ndk_video_,
       enable_trivial_optimizations_);
   if (result) {
     media_decoder_ = std::move(result.value());

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -222,6 +222,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // Enable the workaround to ignore stale/dirty MediaCodec callback messages
   // queued on the main thread during a flush.
   const bool ignore_mediacodec_callbacks_during_flushing_;
+  const bool set_output_surface_on_flush_;
   const bool enable_trivial_optimizations_;
   const bool enable_ndk_video_;
   const bool fix_need_more_input_backpressure_;

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -201,6 +201,9 @@ inline constexpr ExperimentalFeatureKey<bool>
 
 inline constexpr ExperimentalFeatureKey<bool> kMediaNdkVideo("Media.NdkVideo");
 
+inline constexpr ExperimentalFeatureKey<bool> kMediaSetOutputSurfaceOnFlush(
+    "Media.SetOutputSurfaceOnFlush");
+
 inline constexpr ExperimentalFeatureKey<bool> kMediaSkipFlushOnDecoderTeardown(
     "Media.SkipFlushOnDecoderTeardown");
 


### PR DESCRIPTION
MediaCodec.flush() invalidates all dequeued output buffer indices.
On some hardware platforms, frames sent to the display can remain
trapped in the hardware composer pipeline even after a decoder flush.
This leads to orphaned memory and eventual playback failure because
buffer slots are not returned to the free pool.

This change introduces an experimental flag to re-bind the output
surface during the flush sequence. Re-binding the surface forces the
underlying system to purge in-flight buffers, ensuring valid cleanup
and restoring buffer slots to the free pool.

Issue: 542684956