### PR TITLE
media: Introduce SbMediaInterface

### DIFF
--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -38,7 +38,6 @@
 #include "media/mojo/clients/starboard/starboard_renderer_client_factory.h"
 #include "media/starboard/starboard_media_external_memory_allocator.h"
 #include "mojo/public/cpp/bindings/generic_pending_receiver.h"
-#include "starboard/media.h"
 #include "starboard/player.h"
 #include "third_party/blink/public/common/thread_safe_browser_interface_broker_proxy.h"
 #include "third_party/blink/public/platform/browser_interface_broker_proxy.h"

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -34,6 +34,7 @@
 #include "media/base/media_switches.h"
 #include "media/base/renderer_factory.h"
 #include "media/base/starboard/experimental_features.h"
+#include "media/base/starboard/sbmedia_interface.h"
 #include "media/mojo/clients/starboard/starboard_renderer_client_factory.h"
 #include "media/starboard/starboard_media_external_memory_allocator.h"
 #include "mojo/public/cpp/bindings/generic_pending_receiver.h"
@@ -277,7 +278,8 @@ bool CobaltContentRendererClient::IsDecoderSupportedAudioType(
   std::string mime = GetMimeFromAudioType(type);
   SbMediaSupportType support_type = kSbMediaSupportTypeNotSupported;
   if (!mime.empty()) {
-    support_type = SbMediaCanPlayMimeAndKeySystem(mime.c_str(), "");
+    support_type =
+        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(mime, "");
   }
   bool result = support_type != kSbMediaSupportTypeNotSupported;
   LOG(INFO) << __func__ << "(" << type.codec << ") -> "
@@ -290,7 +292,8 @@ bool CobaltContentRendererClient::IsDecoderSupportedVideoType(
   std::string mime = GetMimeFromVideoType(type);
   SbMediaSupportType support_type = kSbMediaSupportTypeNotSupported;
   if (!mime.empty()) {
-    support_type = SbMediaCanPlayMimeAndKeySystem(mime.c_str(), "");
+    support_type =
+        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(mime, "");
   }
   bool result = support_type != kSbMediaSupportTypeNotSupported;
   LOG(INFO) << __func__ << "(" << type.codec << ") -> "

--- a/cobalt/renderer/cobalt_content_renderer_client.cc
+++ b/cobalt/renderer/cobalt_content_renderer_client.cc
@@ -277,8 +277,8 @@ bool CobaltContentRendererClient::IsDecoderSupportedAudioType(
   std::string mime = GetMimeFromAudioType(type);
   SbMediaSupportType support_type = kSbMediaSupportTypeNotSupported;
   if (!mime.empty()) {
-    support_type =
-        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(mime, "");
+    support_type = ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
+        mime.c_str(), "");
   }
   bool result = support_type != kSbMediaSupportTypeNotSupported;
   LOG(INFO) << __func__ << "(" << type.codec << ") -> "
@@ -291,8 +291,8 @@ bool CobaltContentRendererClient::IsDecoderSupportedVideoType(
   std::string mime = GetMimeFromVideoType(type);
   SbMediaSupportType support_type = kSbMediaSupportTypeNotSupported;
   if (!mime.empty()) {
-    support_type =
-        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(mime, "");
+    support_type = ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
+        mime.c_str(), "");
   }
   bool result = support_type != kSbMediaSupportTypeNotSupported;
   LOG(INFO) << __func__ << "(" << type.codec << ") -> "

--- a/media/base/BUILD.gn
+++ b/media/base/BUILD.gn
@@ -482,15 +482,17 @@ source_set("base") {
 
   if (is_cobalt && use_starboard_media) {
     sources += [
-        "starboard/demuxer_memory_limit_starboard.cc",
-        "starboard/experimental_features.cc",
-        "starboard/experimental_features.h",
-        "starboard/renderer_factory_traits.h",
-        "starboard/ipc_param_traits.cc",
-        "starboard/ipc_param_traits.h",
-        "starboard/starboard_renderer_config.cc",
-        "starboard/starboard_renderer_config.h",
-        "starboard/starboard_rendering_mode.h"
+      "starboard/demuxer_memory_limit_starboard.cc",
+      "starboard/experimental_features.cc",
+      "starboard/experimental_features.h",
+      "starboard/ipc_param_traits.cc",
+      "starboard/ipc_param_traits.h",
+      "starboard/renderer_factory_traits.h",
+      "starboard/sbmedia_interface.cc",
+      "starboard/sbmedia_interface.h",
+      "starboard/starboard_renderer_config.cc",
+      "starboard/starboard_renderer_config.h",
+      "starboard/starboard_rendering_mode.h",
     ]
 
     deps += [

--- a/media/base/mime_util_internal.cc
+++ b/media/base/mime_util_internal.cc
@@ -452,7 +452,8 @@ void MimeUtil::AddContainerWithCodecs(std::string mime_type, CodecSet codecs) {
 bool MimeUtil::IsSupportedMediaMimeType(std::string_view mime_type) const {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   SbMediaSupportType support_type =
-      GetSbMediaInterface()->CanPlayMimeAndKeySystem(mime_type, "");
+      GetSbMediaInterface()->CanPlayMimeAndKeySystem(
+          std::string(mime_type).c_str(), "");
   bool result = support_type != kSbMediaSupportTypeNotSupported;
   DVLOG(1) << __func__ << "(" << mime_type << ") -> "
            << base::ToString(result);
@@ -561,7 +562,8 @@ SupportsType MimeUtil::IsSupportedMediaFormat(
       << __func__ << "can be used for non encrypted formats only in Chrobalt";
 
   SbMediaSupportType support_type =
-      GetSbMediaInterface()->CanPlayMimeAndKeySystem(mime_type, "");
+      GetSbMediaInterface()->CanPlayMimeAndKeySystem(
+          std::string(mime_type).c_str(), "");
   DVLOG(1) << __func__ << "(" << mime_type << ") -> " << support_type;
   switch (support_type) {
     case kSbMediaSupportTypeNotSupported:

--- a/media/base/mime_util_internal.cc
+++ b/media/base/mime_util_internal.cc
@@ -35,7 +35,6 @@
 #include "build/build_config.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "media/base/starboard/sbmedia_interface.h"
-#include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace media::internal {

--- a/media/base/mime_util_internal.cc
+++ b/media/base/mime_util_internal.cc
@@ -34,6 +34,7 @@
 
 #include "build/build_config.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/base/starboard/sbmedia_interface.h"
 #include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
@@ -452,7 +453,7 @@ void MimeUtil::AddContainerWithCodecs(std::string mime_type, CodecSet codecs) {
 bool MimeUtil::IsSupportedMediaMimeType(std::string_view mime_type) const {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   SbMediaSupportType support_type =
-      SbMediaCanPlayMimeAndKeySystem(mime_type.data(), "");
+      GetSbMediaInterface()->CanPlayMimeAndKeySystem(mime_type, "");
   bool result = support_type != kSbMediaSupportTypeNotSupported;
   DVLOG(1) << __func__ << "(" << mime_type << ") -> "
            << base::ToString(result);
@@ -561,7 +562,7 @@ SupportsType MimeUtil::IsSupportedMediaFormat(
       << __func__ << "can be used for non encrypted formats only in Chrobalt";
 
   SbMediaSupportType support_type =
-      SbMediaCanPlayMimeAndKeySystem(mime_type.data(), "");
+      GetSbMediaInterface()->CanPlayMimeAndKeySystem(mime_type, "");
   DVLOG(1) << __func__ << "(" << mime_type << ") -> " << support_type;
   switch (support_type) {
     case kSbMediaSupportTypeNotSupported:

--- a/media/base/starboard/sbmedia_interface.cc
+++ b/media/base/starboard/sbmedia_interface.cc
@@ -1,0 +1,101 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "media/base/starboard/sbmedia_interface.h"
+
+#include <atomic>
+#include <string>
+
+#include "base/check.h"
+#include "base/no_destructor.h"
+
+namespace media {
+
+namespace {
+
+std::atomic<SbMediaInterface*> g_sbmedia_interface_for_testing{nullptr};
+
+}  // namespace
+
+SbMediaSupportType DefaultSbMediaInterface::CanPlayMimeAndKeySystem(
+    std::string_view mime,
+    std::string_view key_system) const {
+  return SbMediaCanPlayMimeAndKeySystem(std::string(mime).c_str(),
+                                        std::string(key_system).c_str());
+}
+
+bool DefaultSbMediaInterface::CanChangeType(std::string_view current_mime,
+                                            std::string_view new_mime) const {
+  return SbMediaCanChangeType(std::string(current_mime).c_str(),
+                              std::string(new_mime).c_str());
+}
+
+int DefaultSbMediaInterface::GetAudioOutputCount() const {
+  return SbMediaGetAudioOutputCount();
+}
+
+bool DefaultSbMediaInterface::GetAudioConfiguration(
+    int output_index,
+    SbMediaAudioConfiguration* out_configuration) const {
+  DCHECK(out_configuration);
+  if (!out_configuration) {
+    return false;
+  }
+  return SbMediaGetAudioConfiguration(output_index, out_configuration);
+}
+
+int DefaultSbMediaInterface::GetBufferAllocationUnit() const {
+  return SbMediaGetBufferAllocationUnit();
+}
+
+int DefaultSbMediaInterface::GetAudioBufferBudget() const {
+  return SbMediaGetAudioBufferBudget();
+}
+
+int64_t DefaultSbMediaInterface::GetBufferGarbageCollectionDurationThreshold()
+    const {
+  return SbMediaGetBufferGarbageCollectionDurationThreshold();
+}
+
+int DefaultSbMediaInterface::GetInitialBufferCapacity() const {
+  return SbMediaGetInitialBufferCapacity();
+}
+
+bool DefaultSbMediaInterface::IsBufferPoolAllocateOnDemand() const {
+  return SbMediaIsBufferPoolAllocateOnDemand();
+}
+
+int DefaultSbMediaInterface::GetVideoBufferBudget(SbMediaVideoCodec codec,
+                                                  int resolution_width,
+                                                  int resolution_height,
+                                                  int bits_per_pixel) const {
+  return SbMediaGetVideoBufferBudget(codec, resolution_width, resolution_height,
+                                     bits_per_pixel);
+}
+
+SbMediaInterface* GetSbMediaInterface() {
+  SbMediaInterface* testing_interface =
+      g_sbmedia_interface_for_testing.load(std::memory_order_acquire);
+  if (testing_interface) {
+    return testing_interface;
+  }
+  static base::NoDestructor<DefaultSbMediaInterface> default_interface;
+  return default_interface.get();
+}
+
+void SetSbMediaInterfaceForTesting(SbMediaInterface* interface) {
+  g_sbmedia_interface_for_testing.store(interface, std::memory_order_release);
+}
+
+}  // namespace media

--- a/media/base/starboard/sbmedia_interface.cc
+++ b/media/base/starboard/sbmedia_interface.cc
@@ -15,7 +15,6 @@
 #include "media/base/starboard/sbmedia_interface.h"
 
 #include <atomic>
-#include <string>
 
 #include "base/check.h"
 #include "base/no_destructor.h"
@@ -29,16 +28,14 @@ std::atomic<SbMediaInterface*> g_sbmedia_interface_for_testing{nullptr};
 }  // namespace
 
 SbMediaSupportType DefaultSbMediaInterface::CanPlayMimeAndKeySystem(
-    std::string_view mime,
-    std::string_view key_system) const {
-  return SbMediaCanPlayMimeAndKeySystem(std::string(mime).c_str(),
-                                        std::string(key_system).c_str());
+    const char* mime,
+    const char* key_system) const {
+  return SbMediaCanPlayMimeAndKeySystem(mime, key_system);
 }
 
-bool DefaultSbMediaInterface::CanChangeType(std::string_view current_mime,
-                                            std::string_view new_mime) const {
-  return SbMediaCanChangeType(std::string(current_mime).c_str(),
-                              std::string(new_mime).c_str());
+bool DefaultSbMediaInterface::CanChangeType(const char* current_mime,
+                                            const char* new_mime) const {
+  return SbMediaCanChangeType(current_mime, new_mime);
 }
 
 int DefaultSbMediaInterface::GetAudioOutputCount() const {

--- a/media/base/starboard/sbmedia_interface.h
+++ b/media/base/starboard/sbmedia_interface.h
@@ -1,0 +1,107 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_BASE_STARBOARD_SBMEDIA_INTERFACE_H_
+#define MEDIA_BASE_STARBOARD_SBMEDIA_INTERFACE_H_
+
+#include <stdint.h>
+
+#include <string_view>
+
+#include "media/base/media_export.h"
+#include "starboard/media.h"
+
+namespace media {
+
+// SbMediaInterface abstracts the Starboard media C APIs to facilitate testing
+// and mocking of media features.
+//
+// Lifetime and ownership:
+// The production instance is a global singleton that is created on demand and
+// lives for the lifetime of the process. Custom test implementations can be
+// injected via SetSbMediaInterfaceForTesting().
+//
+// Threading model:
+// Implementations must be thread-safe and callable from any thread.
+class MEDIA_EXPORT SbMediaInterface {
+ public:
+  SbMediaInterface(const SbMediaInterface&) = delete;
+  SbMediaInterface& operator=(const SbMediaInterface&) = delete;
+
+  virtual ~SbMediaInterface() = default;
+
+  virtual SbMediaSupportType CanPlayMimeAndKeySystem(
+      std::string_view mime,
+      std::string_view key_system) const = 0;
+  virtual bool CanChangeType(std::string_view current_mime,
+                             std::string_view new_mime) const = 0;
+  virtual int GetAudioOutputCount() const = 0;
+  virtual bool GetAudioConfiguration(
+      int output_index,
+      SbMediaAudioConfiguration* out_configuration) const = 0;
+  virtual int GetBufferAllocationUnit() const = 0;
+  virtual int GetAudioBufferBudget() const = 0;
+  virtual int64_t GetBufferGarbageCollectionDurationThreshold() const = 0;
+  virtual int GetInitialBufferCapacity() const = 0;
+  virtual bool IsBufferPoolAllocateOnDemand() const = 0;
+  virtual int GetVideoBufferBudget(SbMediaVideoCodec codec,
+                                   int resolution_width,
+                                   int resolution_height,
+                                   int bits_per_pixel) const = 0;
+
+ protected:
+  SbMediaInterface() = default;
+};
+
+// DefaultSbMediaInterface is the production implementation of SbMediaInterface
+// that forwards all calls directly to the corresponding Starboard C functions.
+//
+// Lifetime and ownership:
+// Managed as a base::NoDestructor static singleton in GetSbMediaInterface().
+//
+// Threading model:
+// Thread-safe as it delegates to thread-safe Starboard C APIs.
+class MEDIA_EXPORT DefaultSbMediaInterface final : public SbMediaInterface {
+ public:
+  SbMediaSupportType CanPlayMimeAndKeySystem(
+      std::string_view mime,
+      std::string_view key_system) const override;
+  bool CanChangeType(std::string_view current_mime,
+                     std::string_view new_mime) const override;
+  int GetAudioOutputCount() const override;
+  bool GetAudioConfiguration(
+      int output_index,
+      SbMediaAudioConfiguration* out_configuration) const override;
+  int GetBufferAllocationUnit() const override;
+  int GetAudioBufferBudget() const override;
+  int64_t GetBufferGarbageCollectionDurationThreshold() const override;
+  int GetInitialBufferCapacity() const override;
+  bool IsBufferPoolAllocateOnDemand() const override;
+  int GetVideoBufferBudget(SbMediaVideoCodec codec,
+                           int resolution_width,
+                           int resolution_height,
+                           int bits_per_pixel) const override;
+};
+
+// Returns a pointer to the global SbMediaInterface instance.
+// By default, this returns a DefaultSbMediaInterface instance.
+MEDIA_EXPORT SbMediaInterface* GetSbMediaInterface();
+
+// Sets a custom SbMediaInterface for testing. Pass nullptr to restore the
+// default.
+MEDIA_EXPORT void SetSbMediaInterfaceForTesting(SbMediaInterface* interface);
+
+}  // namespace media
+
+#endif  // MEDIA_BASE_STARBOARD_SBMEDIA_INTERFACE_H_

--- a/media/base/starboard/sbmedia_interface.h
+++ b/media/base/starboard/sbmedia_interface.h
@@ -17,8 +17,6 @@
 
 #include <stdint.h>
 
-#include <string_view>
-
 #include "media/base/media_export.h"
 #include "starboard/media.h"
 
@@ -42,10 +40,10 @@ class MEDIA_EXPORT SbMediaInterface {
   virtual ~SbMediaInterface() = default;
 
   virtual SbMediaSupportType CanPlayMimeAndKeySystem(
-      std::string_view mime,
-      std::string_view key_system) const = 0;
-  virtual bool CanChangeType(std::string_view current_mime,
-                             std::string_view new_mime) const = 0;
+      const char* mime,
+      const char* key_system) const = 0;
+  virtual bool CanChangeType(const char* current_mime,
+                             const char* new_mime) const = 0;
   virtual int GetAudioOutputCount() const = 0;
   virtual bool GetAudioConfiguration(
       int output_index,
@@ -75,10 +73,10 @@ class MEDIA_EXPORT SbMediaInterface {
 class MEDIA_EXPORT DefaultSbMediaInterface final : public SbMediaInterface {
  public:
   SbMediaSupportType CanPlayMimeAndKeySystem(
-      std::string_view mime,
-      std::string_view key_system) const override;
-  bool CanChangeType(std::string_view current_mime,
-                     std::string_view new_mime) const override;
+      const char* mime,
+      const char* key_system) const override;
+  bool CanChangeType(const char* current_mime,
+                     const char* new_mime) const override;
   int GetAudioOutputCount() const override;
   bool GetAudioConfiguration(
       int output_index,
@@ -98,8 +96,7 @@ class MEDIA_EXPORT DefaultSbMediaInterface final : public SbMediaInterface {
 // By default, this returns a DefaultSbMediaInterface instance.
 MEDIA_EXPORT SbMediaInterface* GetSbMediaInterface();
 
-// Sets a custom SbMediaInterface for testing. Pass nullptr to restore the
-// default.
+// Sets a custom SbMediaInterface for testing.
 MEDIA_EXPORT void SetSbMediaInterfaceForTesting(SbMediaInterface* interface);
 
 }  // namespace media

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -35,7 +35,6 @@
 #include "starboard/common/external_metadata_reuse_allocator_base.h"
 #include "starboard/common/log.h"
 #include "starboard/configuration.h"
-#include "starboard/media.h"
 
 namespace media {
 

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -24,6 +24,7 @@
 #include "base/types/expected.h"
 #include "build/build_config.h"
 #include "media/base/media_switches.h"
+#include "media/base/starboard/sbmedia_interface.h"
 #include "media/base/video_codecs.h"
 #include "media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h"
 #include "media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.h"
@@ -68,9 +69,10 @@ base::expected<void, std::string> ProcessEnableOnlySetting(
 }  // namespace
 
 DecoderBufferAllocator::DecoderBufferAllocator()
-    : DecoderBufferAllocator(SbMediaIsBufferPoolAllocateOnDemand(),
-                             SbMediaGetInitialBufferCapacity(),
-                             SbMediaGetBufferAllocationUnit()) {}
+    : DecoderBufferAllocator(
+          GetSbMediaInterface()->IsBufferPoolAllocateOnDemand(),
+          GetSbMediaInterface()->GetInitialBufferCapacity(),
+          GetSbMediaInterface()->GetBufferAllocationUnit()) {}
 
 DecoderBufferAllocator::DecoderBufferAllocator(
     bool is_memory_pool_allocated_on_demand,
@@ -218,7 +220,7 @@ void DecoderBufferAllocator::Write(Handle handle,
 base::TimeDelta
 DecoderBufferAllocator::GetBufferGarbageCollectionDurationThreshold() const {
   return base::Microseconds(
-      SbMediaGetBufferGarbageCollectionDurationThreshold());
+      GetSbMediaInterface()->GetBufferGarbageCollectionDurationThreshold());
 }
 
 size_t DecoderBufferAllocator::GetAllocatedMemory() const {

--- a/media/starboard/decoder_buffer_memory_info.cc
+++ b/media/starboard/decoder_buffer_memory_info.cc
@@ -14,6 +14,7 @@
 
 #include "media/starboard/decoder_buffer_memory_info.h"
 
+#include "media/base/starboard/sbmedia_interface.h"
 #include "media/base/video_codecs.h"
 #include "media/starboard/starboard_utils.h"
 #include "starboard/media.h"
@@ -22,15 +23,15 @@
 namespace media {
 
 int GetAudioDecoderBufferLimitBytes() {
-  return SbMediaGetAudioBufferBudget();
+  return GetSbMediaInterface()->GetAudioBufferBudget();
 }
 
 int GetVideoDecoderBufferLimitBytes(VideoCodec codec,
                                     const gfx::Size& resolution,
                                     int bits_per_pixel) {
-  return SbMediaGetVideoBufferBudget(MediaVideoCodecToSbMediaVideoCodec(codec),
-                                     resolution.width(), resolution.height(),
-                                     bits_per_pixel);
+  return GetSbMediaInterface()->GetVideoBufferBudget(
+      MediaVideoCodecToSbMediaVideoCodec(codec), resolution.width(),
+      resolution.height(), bits_per_pixel);
 }
 
 }  // namespace media

--- a/media/starboard/decoder_buffer_memory_info.cc
+++ b/media/starboard/decoder_buffer_memory_info.cc
@@ -17,7 +17,6 @@
 #include "media/base/starboard/sbmedia_interface.h"
 #include "media/base/video_codecs.h"
 #include "media/starboard/starboard_utils.h"
-#include "starboard/media.h"
 #include "ui/gfx/geometry/size.h"
 
 namespace media {

--- a/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
+++ b/media/starboard/media_buffer_pool_decoder_buffer_allocator_strategy.cc
@@ -16,6 +16,7 @@
 
 #include "base/logging.h"
 #include "media/base/demuxer_stream.h"
+#include "media/base/starboard/sbmedia_interface.h"
 
 namespace media {
 
@@ -31,13 +32,13 @@ MediaBufferPoolDecoderBufferAllocatorStrategy::
       video_buffer_allocation_increment_(video_buffer_allocation_increment),
       audio_fallback_allocator_(/*enable_decommit_on_idle=*/false,
                                 /*enable_page_alignment=*/false),
-      audio_allocator_(
-          &audio_fallback_allocator_,
-          // Pre-allocate sufficient capacity for audio buffers to
-          // avoid expansions in most scenarios.
-          SbMediaGetAudioBufferBudget() + kAudioAllocationIncrement,
-          kSmallAllocationThreshold,
-          kAudioAllocationIncrement),
+      audio_allocator_(&audio_fallback_allocator_,
+                       // Pre-allocate sufficient capacity for audio buffers to
+                       // avoid expansions in most scenarios.
+                       GetSbMediaInterface()->GetAudioBufferBudget() +
+                           kAudioAllocationIncrement,
+                       kSmallAllocationThreshold,
+                       kAudioAllocationIncrement),
       video_allocator_(new MediaBufferPoolBidirectionalReuseAllocator(
           media_buffer_pool_,
           video_buffer_initial_capacity,

--- a/third_party/blink/renderer/core/html/media/html_media_element.cc
+++ b/third_party/blink/renderer/core/html/media/html_media_element.cc
@@ -130,6 +130,7 @@
 #include "build/build_config.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "base/strings/string_util.h"
+#include "media/base/starboard/sbmedia_interface.h"
 #include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
@@ -306,8 +307,11 @@ bool CanLoadURL(const KURL& url, const String& content_type_str) {
   if (content_mime_type != "application/octet-stream" ||
       content_type_codecs.empty()) {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+    auto ascii = content_type_str.Ascii();
     SbMediaSupportType support_type =
-        SbMediaCanPlayMimeAndKeySystem(content_type_str.Ascii().c_str(), "");
+        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
+            std::string_view(ascii.data() ? ascii.data() : "", ascii.length()),
+            "");
     MIMETypeRegistry::SupportsType result;
     switch (support_type) {
       case kSbMediaSupportTypeNotSupported:
@@ -420,8 +424,11 @@ MIMETypeRegistry::SupportsType HTMLMediaElement::GetSupportsType(
               << "\' is unsupported.";
     result = MIMETypeRegistry::kNotSupported;
   } else {
-    const SbMediaSupportType support_type =
-        SbMediaCanPlayMimeAndKeySystem(content_type.Raw().Ascii().c_str(), "");
+    auto ascii = content_type.Raw().Ascii();
+    SbMediaSupportType support_type =
+        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
+            std::string_view(ascii.data() ? ascii.data() : "", ascii.length()),
+            "");
     switch (support_type) {
       case kSbMediaSupportTypeNotSupported:
         result = MIMETypeRegistry::kNotSupported;

--- a/third_party/blink/renderer/core/html/media/html_media_element.cc
+++ b/third_party/blink/renderer/core/html/media/html_media_element.cc
@@ -309,8 +309,7 @@ bool CanLoadURL(const KURL& url, const String& content_type_str) {
     auto ascii = content_type_str.Ascii();
     SbMediaSupportType support_type =
         ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
-            std::string_view(ascii.data() ? ascii.data() : "", ascii.length()),
-            "");
+            std::string_view(ascii.c_str(), ascii.length()), "");
     MIMETypeRegistry::SupportsType result;
     switch (support_type) {
       case kSbMediaSupportTypeNotSupported:
@@ -426,8 +425,7 @@ MIMETypeRegistry::SupportsType HTMLMediaElement::GetSupportsType(
     auto ascii = content_type.Raw().Ascii();
     SbMediaSupportType support_type =
         ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
-            std::string_view(ascii.data() ? ascii.data() : "", ascii.length()),
-            "");
+            std::string_view(ascii.c_str(), ascii.length()), "");
     switch (support_type) {
       case kSbMediaSupportTypeNotSupported:
         result = MIMETypeRegistry::kNotSupported;

--- a/third_party/blink/renderer/core/html/media/html_media_element.cc
+++ b/third_party/blink/renderer/core/html/media/html_media_element.cc
@@ -308,8 +308,8 @@ bool CanLoadURL(const KURL& url, const String& content_type_str) {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
     auto ascii = content_type_str.Ascii();
     SbMediaSupportType support_type =
-        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
-            std::string_view(ascii.c_str(), ascii.length()), "");
+        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(ascii.c_str(),
+                                                                "");
     MIMETypeRegistry::SupportsType result;
     switch (support_type) {
       case kSbMediaSupportTypeNotSupported:
@@ -424,8 +424,8 @@ MIMETypeRegistry::SupportsType HTMLMediaElement::GetSupportsType(
   } else {
     auto ascii = content_type.Raw().Ascii();
     SbMediaSupportType support_type =
-        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
-            std::string_view(ascii.c_str(), ascii.length()), "");
+        ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(ascii.c_str(),
+                                                                "");
     switch (support_type) {
       case kSbMediaSupportTypeNotSupported:
         result = MIMETypeRegistry::kNotSupported;

--- a/third_party/blink/renderer/core/html/media/html_media_element.cc
+++ b/third_party/blink/renderer/core/html/media/html_media_element.cc
@@ -131,7 +131,6 @@
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "base/strings/string_util.h"
 #include "media/base/starboard/sbmedia_interface.h"
-#include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #ifndef LOG_MEDIA_EVENTS

--- a/third_party/blink/renderer/modules/mediasource/media_source.cc
+++ b/third_party/blink/renderer/modules/mediasource/media_source.cc
@@ -604,8 +604,7 @@ bool MediaSource::IsTypeSupportedInternal(ExecutionContext* context,
   auto ascii = type.Ascii();
   SbMediaSupportType support_type =
       ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
-          std::string_view(ascii.data() ? ascii.data() : "", ascii.length()),
-          "");
+          std::string_view(ascii.c_str(), ascii.length()), "");
   return support_type != kSbMediaSupportTypeNotSupported;
 #else
   // 2. If type does not contain a valid MIME type string, then return false.

--- a/third_party/blink/renderer/modules/mediasource/media_source.cc
+++ b/third_party/blink/renderer/modules/mediasource/media_source.cc
@@ -62,6 +62,7 @@
 // For BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "build/build_config.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/base/starboard/sbmedia_interface.h"
 #include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
@@ -601,8 +602,11 @@ bool MediaSource::IsTypeSupportedInternal(ExecutionContext* context,
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   // Interupt Chromium's IsTypeSupported() from here for better performance.
+  auto ascii = type.Ascii();
   SbMediaSupportType support_type =
-      SbMediaCanPlayMimeAndKeySystem(type.Ascii().c_str(), "");
+      ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
+          std::string_view(ascii.data() ? ascii.data() : "", ascii.length()),
+          "");
   return support_type != kSbMediaSupportTypeNotSupported;
 #else
   // 2. If type does not contain a valid MIME type string, then return false.

--- a/third_party/blink/renderer/modules/mediasource/media_source.cc
+++ b/third_party/blink/renderer/modules/mediasource/media_source.cc
@@ -63,7 +63,6 @@
 #include "build/build_config.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "media/base/starboard/sbmedia_interface.h"
-#include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 using blink::WebMediaSource;

--- a/third_party/blink/renderer/modules/mediasource/media_source.cc
+++ b/third_party/blink/renderer/modules/mediasource/media_source.cc
@@ -603,8 +603,8 @@ bool MediaSource::IsTypeSupportedInternal(ExecutionContext* context,
   // Interupt Chromium's IsTypeSupported() from here for better performance.
   auto ascii = type.Ascii();
   SbMediaSupportType support_type =
-      ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
-          std::string_view(ascii.c_str(), ascii.length()), "");
+      ::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(ascii.c_str(),
+                                                              "");
   return support_type != kSbMediaSupportTypeNotSupported;
 #else
   // 2. If type does not contain a valid MIME type string, then return false.

--- a/third_party/blink/renderer/platform/media/key_system_config_selector.cc
+++ b/third_party/blink/renderer/platform/media/key_system_config_selector.cc
@@ -33,6 +33,7 @@
 // For BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "build/build_config.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/base/starboard/sbmedia_interface.h"
 #include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
@@ -423,7 +424,8 @@ bool KeySystemConfigSelector::IsSupportedContentType(
   // robustness algorithm).
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   const std::string full_mime = container_lower + "; codecs=\"" + codecs + "\"";
-  if (SbMediaCanPlayMimeAndKeySystem(full_mime.c_str(), key_system.c_str()) ==
+  if (::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
+          full_mime, key_system) ==
       kSbMediaSupportTypeNotSupported) {
     LOG(INFO) << __func__ << "(" << full_mime << " and " << key_system
               << ") are unsupported.";

--- a/third_party/blink/renderer/platform/media/key_system_config_selector.cc
+++ b/third_party/blink/renderer/platform/media/key_system_config_selector.cc
@@ -424,7 +424,7 @@ bool KeySystemConfigSelector::IsSupportedContentType(
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   const std::string full_mime = container_lower + "; codecs=\"" + codecs + "\"";
   if (::media::GetSbMediaInterface()->CanPlayMimeAndKeySystem(
-          full_mime, key_system) ==
+          full_mime.c_str(), key_system.c_str()) ==
       kSbMediaSupportTypeNotSupported) {
     LOG(INFO) << __func__ << "(" << full_mime << " and " << key_system
               << ") are unsupported.";

--- a/third_party/blink/renderer/platform/media/key_system_config_selector.cc
+++ b/third_party/blink/renderer/platform/media/key_system_config_selector.cc
@@ -34,7 +34,6 @@
 #include "build/build_config.h"
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
 #include "media/base/starboard/sbmedia_interface.h"
-#include "starboard/media.h"  // nogncheck
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 namespace blink {


### PR DESCRIPTION
Introduce SbMediaInterface and DefaultSbMediaInterface to wrap the
Starboard media C API. This mirrors the SbPlayerInterface pattern and
allows media features like custom MIME types and HDR10+ to be tested or
mocked without modifying the public Starboard C API/ABI.

All call sites across Cobalt, Blink, and the media stack are updated to
invoke media::GetSbMediaInterface() instead of calling SbMedia C
functions directly. A thread-safe setter is provided for testing.

Bug: 531137547