### PR TITLE
android: Add java switch to tune http and v8 caches

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -37,6 +37,9 @@ public class JavaSwitches {
   /** flag to allow caching CSS and WebAssembly resources in the HTTP disk cache. */
   public static final String ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE = "EnableCssAndWasmForHttpCache";
 
+  /** flag to enable aggressive HTTP disk cache and V8 generated code cache tuning exclusions. */
+  public static final String ENABLE_HTTP_AND_V8_CACHE_TUNING = "EnableHttpAndV8CacheTuning";
+
   /** flag to re-enable freeze and resume events */
   public static final String ENABLE_FREEZE = "EnableFreeze";
 
@@ -203,6 +206,10 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE)) {
       extraCommandLineArgs.add("--enable-css-and-wasm-for-http-cache");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.ENABLE_HTTP_AND_V8_CACHE_TUNING)) {
+      extraCommandLineArgs.add("--enable-http-and-v8-cache-tuning");
     }
 
     if (jsFlags.length() > 0) {

--- a/content/browser/code_cache/generated_code_cache.cc
+++ b/content/browser/code_cache/generated_code_cache.cc
@@ -480,13 +480,21 @@ void GeneratedCodeCache::WriteEntry(const GURL& url,
     return;
 
 #if BUILDFLAG(IS_COBALT)
-  if (cache_type_ == CodeCacheType::kJavaScript &&
-      base::CommandLine::ForCurrentProcess()->HasSwitch(
-          "enable-optimized-v8-code-cache")) {
-    // Only store V8 bytecode for substantial scripts (>= 1 KB) where bytecode
-    // caching actually saves meaningful CPU compilation time.
-    constexpr size_t kMinBytecodeSizeForCobaltCache = 1024;
-    if (data.size() < kMinBytecodeSizeForCobaltCache) {
+  if (cache_type_ == CodeCacheType::kJavaScript) {
+    // We skip caching below experimental thresholds (1KB, 16KB) to preserve
+    // cache slots for heavy core bundles. Cache switch evaluations statically
+    // once per runtime process to avoid redundant map lookups.
+    static const size_t kMinBytecodeSize = [] {
+      auto* command_line = base::CommandLine::ForCurrentProcess();
+      if (command_line->HasSwitch("enable-http-and-v8-cache-tuning")) {
+        return 16384;
+      }
+      if (command_line->HasSwitch("enable-optimized-v8-code-cache")) {
+        return 1024;
+      }
+      return 0;
+    }();
+    if (data.size() < kMinBytecodeSize) {
       return;
     }
   }

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -4046,7 +4046,7 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
 
     // Exclude micro-resources (< 512B) where socket read beats eMMC IO overhead.
     int64_t len = headers.GetContentLength();
-    if (len > 0 && len < 512) {
+    if (len >= 0 && len < 512) {
       return true;
     }
   }

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -17,6 +17,7 @@
 #include <string_view>
 #include <type_traits>
 #include <utility>
+#include <vector>
 
 #include "base/auto_reset.h"
 #include "base/check.h"
@@ -3991,25 +3992,63 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
   }
 
 #if BUILDFLAG(IS_COBALT)
-  // Only allow HTML and JS/ECMAScript in Cobalt's HTTP cache by default.
-  // When --enable-css-and-wasm-for-http-cache is passed, also allow CSS and WASM.
   std::string mime_type;
-  if (headers.GetMimeType(&mime_type)) {
-    bool is_html = (mime_type == "text/html");
-    bool is_js = base::EndsWith(mime_type, "javascript", base::CompareCase::SENSITIVE)
-        || base::EndsWith(mime_type, "ecmascript", base::CompareCase::SENSITIVE);
-    static const bool enable_css_and_wasm =
-        base::CommandLine::ForCurrentProcess()->HasSwitch(
-            "enable-css-and-wasm-for-http-cache");
-    bool is_css_or_wasm =
-        enable_css_and_wasm &&
-        (mime_type == "text/css" || mime_type == "application/wasm");
-    if (!is_html && !is_js && !is_css_or_wasm) {
-      return true; // Do not write to cache / doom existing entry
+  if (!headers.GetMimeType(&mime_type)) {
+    return true;  // Reject unknown MIME types.
+  }
+
+  // Cache command line evaluations statically once per process runtime to avoid
+  // redundant map lookups and string comparisons on every transaction.
+  static const bool enable_css_and_wasm_caching =
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          "enable-css-and-wasm-for-http-cache");
+  static const bool enable_cache_tuning =
+      base::CommandLine::ForCurrentProcess()->HasSwitch(
+          "enable-http-and-v8-cache-tuning");
+
+  // Maintain a consolidated list of accepted asset MIME types (exact or suffix).
+  std::vector<std::string_view> accepted_asset_types = {
+      "text/html",
+      "javascript",
+      "ecmascript",
+  };
+  if (enable_css_and_wasm_caching) {
+    accepted_asset_types.push_back("text/css");
+    accepted_asset_types.push_back("application/wasm");
+  }
+
+  bool is_accepted_mime_type = false;
+  for (std::string_view type : accepted_asset_types) {
+    if (mime_type == type ||
+        base::EndsWith(mime_type, type, base::CompareCase::SENSITIVE)) {
+      is_accepted_mime_type = true;
+      break;
     }
-  } else {
-    // If we cannot determine the MIME type, err on the side of caution and do not cache.
-    return true;
+  }
+
+  if (!is_accepted_mime_type) {
+    return true;  // Do not write to cache / doom existing entry
+  }
+
+  if (enable_cache_tuning) {
+    // Exclude Ad Impression Pings & Telemetry reporting endpoints.
+    for (std::string_view excluded :
+         {"/api/stats/ads", "/pagead/", "/ptracking", "eligibility_check"}) {
+      if (request_->url.spec().find(excluded) != std::string::npos) {
+        return true;
+      }
+    }
+
+    // Exclude HTTP error status codes (< 200 or >= 400) and Captive Portals.
+    if (headers.response_code() < 200 || headers.response_code() >= 400) {
+      return true;
+    }
+
+    // Exclude micro-resources (< 512B) where socket read beats eMMC IO overhead.
+    int64_t len = headers.GetContentLength();
+    if (len > 0 && len < 512) {
+      return true;
+    }
   }
 #endif
 

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -35,6 +35,7 @@
 #include "base/memory/stack_allocated.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/metrics/histogram_macros.h"
+#include "base/no_destructor.h"
 #include "base/pickle.h"
 #include "base/strings/string_util.h"  // For EqualsCaseInsensitiveASCII.
 #include "base/task/single_thread_task_runner.h"
@@ -4007,7 +4008,7 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
           "enable-http-and-v8-cache-tuning");
 
   // Maintain a consolidated list of accepted asset MIME types (exact or suffix).
-  static const std::vector<std::string_view> accepted_asset_types = [] {
+  static const base::NoDestructor<std::vector<std::string_view>> accepted_asset_types([] {
     std::vector<std::string_view> types = {
         "text/html",
         "javascript",
@@ -4018,10 +4019,10 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
       types.push_back("application/wasm");
     }
     return types;
-  }();
+  }());
 
   bool is_accepted_mime_type = false;
-  for (std::string_view type : accepted_asset_types) {
+  for (std::string_view type : *accepted_asset_types) {
     if (mime_type == type ||
         base::EndsWith(mime_type, type, base::CompareCase::SENSITIVE)) {
       is_accepted_mime_type = true;

--- a/net/http/http_cache_transaction.cc
+++ b/net/http/http_cache_transaction.cc
@@ -4007,15 +4007,18 @@ bool HttpCache::Transaction::UpdateAndReportCacheability(
           "enable-http-and-v8-cache-tuning");
 
   // Maintain a consolidated list of accepted asset MIME types (exact or suffix).
-  std::vector<std::string_view> accepted_asset_types = {
-      "text/html",
-      "javascript",
-      "ecmascript",
-  };
-  if (enable_css_and_wasm_caching) {
-    accepted_asset_types.push_back("text/css");
-    accepted_asset_types.push_back("application/wasm");
-  }
+  static const std::vector<std::string_view> accepted_asset_types = [] {
+    std::vector<std::string_view> types = {
+        "text/html",
+        "javascript",
+        "ecmascript",
+    };
+    if (enable_css_and_wasm_caching) {
+      types.push_back("text/css");
+      types.push_back("application/wasm");
+    }
+    return types;
+  }();
 
   bool is_accepted_mime_type = false;
   for (std::string_view type : accepted_asset_types) {


### PR DESCRIPTION
This PR adds `--enable-http-and-v8-cache-tuning` to enable more selective caching for the HTTP and V8 caches. 

For V8, scripts less than 16KB will not be cached.

For HTTP, exclusions include one-time scripts such as `/api/stats/ads`, `/pagead/`, `/ptracking`, and `eligibility_check`. The HTTP cache allowed MIME types has also been consolidated to a list that includes HTML, JS/ECMAScript, and then conditionally CSS/WASM based on experiment flags. 

Bug: 542408303