### PR TITLE
Copy `libchrobalt.so` to Kokoro Artifacts Directory for Android builds

### DIFF
--- a/cobalt/devinfra/kokoro/bin/dind_build.sh
+++ b/cobalt/devinfra/kokoro/bin/dind_build.sh
@@ -115,5 +115,12 @@ pipeline () {
   else
     echo "Evergreen Loader (or Bootloader) is not configured."
   fi
+
+  # Copy libchrobalt.so to Kokoro Artifacts Directory for Android builds.
+  if [[ "${TARGET_PLATFORM}" =~ android ]]; then
+    echo "Copying libchrobalt.so to Kokoro Artifacts Directory..."
+    mkdir -p "${KOKORO_ARTIFACTS_DIR}/lib_export"
+    find "out/${TARGET_PLATFORM}_${CONFIG}" -type f -name "libchrobalt.so" -exec cp {} "${KOKORO_ARTIFACTS_DIR}/lib_export/" \;
+  fi
 }
 pipeline

--- a/cobalt/devinfra/kokoro/bin/dind_build.sh
+++ b/cobalt/devinfra/kokoro/bin/dind_build.sh
@@ -117,10 +117,13 @@ pipeline () {
   fi
 
   # Copy libchrobalt.so to Kokoro Artifacts Directory for Android builds.
-  if [[ "${TARGET_PLATFORM}" =~ android ]]; then
-    echo "Copying libchrobalt.so to Kokoro Artifacts Directory..."
-    mkdir -p "${KOKORO_ARTIFACTS_DIR}/lib_export"
-    find "out/${TARGET_PLATFORM}_${CONFIG}" -type f -name "libchrobalt.so" -exec cp {} "${KOKORO_ARTIFACTS_DIR}/lib_export/" \;
+  if [[ "${TARGET_PLATFORM}" =~ android ]] && [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
+    local build_out_dir="out/${TARGET_PLATFORM}_${CONFIG}"
+    if [[ -d "${build_out_dir}" ]]; then
+      echo "Copying libchrobalt.so to Kokoro Artifacts Directory..."
+      mkdir -p "${KOKORO_ARTIFACTS_DIR}/lib_export"
+      find "${build_out_dir}" -type f -name "libchrobalt.so" -exec cp {} "${KOKORO_ARTIFACTS_DIR}/lib_export/" \;
+    fi
   fi
 }
 pipeline

--- a/cobalt/devinfra/kokoro/bin/dind_build.sh
+++ b/cobalt/devinfra/kokoro/bin/dind_build.sh
@@ -117,7 +117,7 @@ pipeline () {
   fi
 
   # Copy libchrobalt.so to Kokoro Artifacts Directory for Android builds.
-  if [[ "${TARGET_PLATFORM}" =~ android ]] && [[ -n "${KOKORO_ARTIFACTS_DIR}" ]]; then
+  if [[ "${TARGET_PLATFORM}" =~ android ]] && [[ -n "${KOKORO_ARTIFACTS_DIR:-}" ]]; then
     local build_out_dir="out/${TARGET_PLATFORM}_${CONFIG}"
     if [[ -d "${build_out_dir}" ]]; then
       echo "Copying libchrobalt.so to Kokoro Artifacts Directory..."


### PR DESCRIPTION
Our post-submit kokoro architecture for Kimono relies on passing the `libchrobalt.so` binary from the parent compilation job to the child verification job. 

The script on the Kokoro VM, `dind_builder_runner.sh`, registers an EXIT trap to execute `cleanup.sh` as soon as the build finishes. The `cleanup.sh` script deletes untracked files in the workspace using `git clean -dfx` to save disk space. 

This PR modifies `dind_build.sh` to safely copy the compiled `libchrobalt.so` out of the Git workspace and into a dedicated lib_export directory inside `$KOKORO_ARTIFACTS_DIR` right after compilation completes.

Bug: 537027887