### PR TITLE
Cherry pick PR #11685: Update siso_version to milestone 141.0.7390.0.

### DIFF
--- a/.github/actions/depot_tools/action.yaml
+++ b/.github/actions/depot_tools/action.yaml
@@ -115,6 +115,16 @@ runs:
         REF: ${{ github.sha }}
       run: |
         cd cobalt/src
+
+        # Remove after all workers have migrated to new siso directory
+        if [ -d "../.cipd" ]; then
+          if grep -r "infra/build/siso" "../.cipd" > /dev/null 2>&1; then
+            echo "Deleting conflicting siso package."
+            rm -rf "third_party/siso/cipd"
+            rm -rf "../.cipd"
+          fi
+        fi
+
         # Identify and delete dirty sub-repositories
         git -c core.quotepath=false status --porcelain -unormal | while IFS= read -r line; do
           path="${line:3}"

--- a/DEPS
+++ b/DEPS
@@ -277,9 +277,12 @@ vars = {
   'screen_ai_windows_386': 'version:138.01',
 
   # siso CIPD package version.
-  # Cobalt: Only need for M138. Need a newer siso for building
-  # cobalt with gcloud credentials.
-  'siso_version': 'git_revision:080102c196eef824a444b70272cb6d645b6abe09',
+  # Cobalt: Update siso_version to milestone 141.0.7390.0, to support gcloud
+  # credentials. Remove after rebasing to 141.0.7390.0 or newer. Cobalt
+  # modifications to build/config/siso/configure_siso.py can also be removed
+  # in favor of setting the '--reapi_backend_config_path' argument to
+  # 'cobalt.star'
+  'siso_version': 'git_revision:8863265a67843154872be2be1fc0c37339691405',
 
   # download libaom test data
   'download_libaom_testdata': False,
@@ -2540,7 +2543,7 @@ deps = {
   'src/third_party/siso/cipd': {
     'packages': [
       {
-        'package': 'infra/build/siso/${{platform}}',
+        'package': 'build/siso/${{platform}}',
         'version': Var('siso_version'),
       }
     ],


### PR DESCRIPTION
Refer to original PR: #11685

A newer siso_version than what was found in m138 DEPS is needed to support gcloud creditions for tvos. The update further updates the siso_version to the 141.0.7390 milestone so that it aligns with Cobalt rebase work and informs rebasers which way to resolve merge conflicts.

Add step to gclient sync that deletes dirty CIPD directories.

Bug: 507872651
Bug: 542838743

(cherry picked from commit f0a43c251f716e7e10cb4e4bd80b95901a107e9c)