### PR TITLE
starboard: Fix deprecated INSTANTIATE_TEST_CASE_P

### DIFF
--- a/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/adaptive_audio_decoder_test.cc
@@ -396,10 +396,10 @@ vector<vector<const char*>> GetSupportedTests() {
   return test_params;
 }
 
-INSTANTIATE_TEST_CASE_P(AdaptiveAudioDecoderTests,
-                        AdaptiveAudioDecoderTest,
-                        Combine(ValuesIn(GetSupportedTests()), Bool()),
-                        GetAdaptiveAudioDecoderTestConfigName);
+INSTANTIATE_TEST_SUITE_P(AdaptiveAudioDecoderTests,
+                         AdaptiveAudioDecoderTest,
+                         Combine(ValuesIn(GetSupportedTests()), Bool()),
+                         GetAdaptiveAudioDecoderTestConfigName);
 
 }  // namespace
 

--- a/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/audio_frame_discarder_test.cc
@@ -146,7 +146,7 @@ TEST_P(AudioFrameDiscarderTest, PartialAudio) {
   }
 }
 
-INSTANTIATE_TEST_CASE_P(
+INSTANTIATE_TEST_SUITE_P(
     AudioFrameDiscarderTests,
     AudioFrameDiscarderTest,
     ValuesIn(


### PR DESCRIPTION
INSTANTIATE_TEST_CASE_P is deprecated in current GoogleTest and
produces a deprecation warning, so switch these remaining call sites to
INSTANTIATE_TEST_SUITE_P to keep starboard_unittests building for
android builds.

Bug: 542940859