### PR TITLE
android: Disable fontsrclocalmatching by default

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -135,6 +135,9 @@ public final class CommandLineOverrideHelper {
         // For details, see http://b/478022126#comment6.
         paramOverrides.add("UseAAudioInput");
 
+        // Disable FontSrcLocalMatching lookup table.
+        paramOverrides.add("FontSrcLocalMatching");
+
         return paramOverrides;
     }
 

--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -88,9 +88,6 @@ public class JavaSwitches {
   public static final String COBALT_DYNAMIC_MOJO_PIPE_MEDIA_SIZE =
       "CobaltDynamicMojoPipeMediaSize";
 
-  /** flag to disable FontSrcLocalMatching lookup table. */
-  public static final String DISABLE_FONT_SRC_LOCAL_MATCHING = "DisableFontSrcLocalMatching";
-
   /** Avoid reuse resource. */
   public static final String AVOID_CC_REUSE_RESOURCE = "AvoidCCReuseResource";
 
@@ -201,10 +198,6 @@ public class JavaSwitches {
     if (featureParams.length() > 0) {
       extraCommandLineArgs.add(
           "--enable-features=SmallerInterestArea:" + featureParams.toString());
-    }
-
-    if (javaSwitches.containsKey(JavaSwitches.DISABLE_FONT_SRC_LOCAL_MATCHING)) {
-      extraCommandLineArgs.add("--disable-features=FontSrcLocalMatching");
     }
 
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_OPTIMIZED_FONT_LOADING)) {


### PR DESCRIPTION
This will disable FontSrcLocalMatching on android by default, as experiment results show a decrease in Kabuki app start latency since Cobalt/YouTube TV primarily uses a fixed set of system fonts, and rarely needs to match arbitrary local fonts by name.

Bug: 524080375