### PR TITLE
media: Move mime_type from ChunkDemuxerStream to config

### DIFF
--- a/media/base/audio_decoder_config.cc
+++ b/media/base/audio_decoder_config.cc
@@ -84,16 +84,6 @@ bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
   //    boundaries.
   // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
   //    container MIME strings differ while elementary video/audio parameters
-  //    remain identical.  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
-  // is intentionally excluded from Matches():
-  // 1. Matches() checks whether underlying hardware decoders require 
-  //    re-initialization based on elementary stream properties (codec,
-  //    profile, resolution, extra_data).
-  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
-  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
-  //    boundaries.
-  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
-  //    container MIME strings differ while elementary video/audio parameters
   //    remain identical.
   return (
       (codec() == config.codec()) &&

--- a/media/base/audio_decoder_config.cc
+++ b/media/base/audio_decoder_config.cc
@@ -74,6 +74,27 @@ bool AudioDecoderConfig::IsValidConfig() const {
 }
 
 bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
+  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
+  // is intentionally excluded from Matches():
+  // 1. Matches() checks whether underlying hardware decoders require 
+  //    re-initialization based on elementary stream properties (codec,
+  //    profile, resolution, extra_data).
+  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
+  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
+  //    boundaries.
+  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
+  //    container MIME strings differ while elementary video/audio parameters
+  //    remain identical.  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
+  // is intentionally excluded from Matches():
+  // 1. Matches() checks whether underlying hardware decoders require 
+  //    re-initialization based on elementary stream properties (codec,
+  //    profile, resolution, extra_data).
+  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
+  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
+  //    boundaries.
+  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
+  //    container MIME strings differ while elementary video/audio parameters
+  //    remain identical.
   return (
       (codec() == config.codec()) &&
       (bytes_per_channel() == config.bytes_per_channel()) &&

--- a/media/base/audio_decoder_config.cc
+++ b/media/base/audio_decoder_config.cc
@@ -73,26 +73,11 @@ bool AudioDecoderConfig::IsValidConfig() const {
          seek_preroll_ >= base::TimeDelta() && codec_delay_ >= 0;
 }
 
-bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)),
-  // `mime_type()` is intentionally omitted from Matches() to minimize risk to
-  // playback stability:
-  // 1. Matches() evaluates whether a stream config change requires tearing
-  //    down and re-initializing the underlying hardware decoder (SbPlayer /
-  //    MediaCodec).
-  // 2. The existing elementary stream fields compared below (codec, profile,
-  //    resolution, extra_data) already provide sufficient information to
-  //    detect any hardware-relevant format changes. Real format switches
-  //    (e.g., H.264 -> VP9) alter these elementary fields and correctly
-  //    trigger decoder re-initialization, making an additional `mime_type()`
-  //    comparison unnecessary.
-  // 3. Omitting `mime_type()` minimizes the risk of false-positive decoder
-  //    flushes: adding `mime_type()` introduces brand new behavior that is
-  //    risky. It's now possible that mime_type strings that didn't cause
-  //    Matches() to fail now do with this change, introducing new
-  //    regressions.
+// TODO(b/545325130): Explicitly signal SbPlayer of a changeType() call when
+// the config/mime_type is identical to the current config/mime_type.
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
   return (
       (codec() == config.codec()) &&
       (bytes_per_channel() == config.bytes_per_channel()) &&
@@ -108,6 +93,9 @@ bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
        config.should_discard_decoder_delay()) &&
       (target_output_channel_layout() ==
        config.target_output_channel_layout()) &&
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+      (mime_type() == config.mime_type()) &&
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
       (target_output_sample_format() == config.target_output_sample_format()));
 }
 

--- a/media/base/audio_decoder_config.cc
+++ b/media/base/audio_decoder_config.cc
@@ -74,17 +74,25 @@ bool AudioDecoderConfig::IsValidConfig() const {
 }
 
 bool AudioDecoderConfig::Matches(const AudioDecoderConfig& config) const {
-  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
-  // is intentionally excluded from Matches():
-  // 1. Matches() checks whether underlying hardware decoders require 
-  //    re-initialization based on elementary stream properties (codec,
-  //    profile, resolution, extra_data).
-  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
-  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
-  //    boundaries.
-  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
-  //    container MIME strings differ while elementary video/audio parameters
-  //    remain identical.
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)),
+  // `mime_type()` is intentionally omitted from Matches() to minimize risk to
+  // playback stability:
+  // 1. Matches() evaluates whether a stream config change requires tearing
+  //    down and re-initializing the underlying hardware decoder (SbPlayer /
+  //    MediaCodec).
+  // 2. The existing elementary stream fields compared below (codec, profile,
+  //    resolution, extra_data) already provide sufficient information to
+  //    detect any hardware-relevant format changes. Real format switches
+  //    (e.g., H.264 -> VP9) alter these elementary fields and correctly
+  //    trigger decoder re-initialization, making an additional `mime_type()`
+  //    comparison unnecessary.
+  // 3. Omitting `mime_type()` minimizes the risk of false-positive decoder
+  //    flushes: adding `mime_type()` introduces brand new behavior that is
+  //    risky. It's now possible that mime_type strings that didn't cause
+  //    Matches() to fail now do with this change, introducing new
+  //    regressions.
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   return (
       (codec() == config.codec()) &&
       (bytes_per_channel() == config.bytes_per_channel()) &&

--- a/media/base/audio_decoder_config.cc
+++ b/media/base/audio_decoder_config.cc
@@ -110,6 +110,9 @@ std::string AudioDecoderConfig::AsHumanReadableString() const {
     << base::ToString(should_discard_decoder_delay())
     << ", target_output_channel_layout: "
     << ChannelLayoutToString(target_output_channel_layout())
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+    << ", mime_type: " << mime_type()
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
     << ", target_output_sample_format: "
     << SampleFormatToString(target_output_sample_format());
   return s.str();

--- a/media/base/audio_decoder_config.h
+++ b/media/base/audio_decoder_config.h
@@ -126,6 +126,7 @@ class MEDIA_EXPORT AudioDecoderConfig {
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
  private:
   // WARNING: When modifying or adding any parameters, update the following:
   // - AudioDecoderConfig::AsHumanReadableString()

--- a/media/base/audio_decoder_config.h
+++ b/media/base/audio_decoder_config.h
@@ -126,7 +126,6 @@ class MEDIA_EXPORT AudioDecoderConfig {
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
  private:
   // WARNING: When modifying or adding any parameters, update the following:
   // - AudioDecoderConfig::AsHumanReadableString()
@@ -179,7 +178,6 @@ class MEDIA_EXPORT AudioDecoderConfig {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   std::string mime_type_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler
   // generated copy constructor and assignment operator. Since the extra data is
   // typically small, the performance impact is minimal.

--- a/media/base/audio_decoder_config.h
+++ b/media/base/audio_decoder_config.h
@@ -123,6 +123,7 @@ class MEDIA_EXPORT AudioDecoderConfig {
   }
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Mime_type string of the config.
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
@@ -178,7 +179,7 @@ class MEDIA_EXPORT AudioDecoderConfig {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   // Full mime string for the audio decoder config.
-  std::string mime_type_;
+  std::string mime_type_ = "";
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler
   // generated copy constructor and assignment operator. Since the extra data is

--- a/media/base/audio_decoder_config.h
+++ b/media/base/audio_decoder_config.h
@@ -176,6 +176,7 @@ class MEDIA_EXPORT AudioDecoderConfig {
   int channels_ = 0;
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Full mime string for the audio decoder config.
   std::string mime_type_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler

--- a/media/base/audio_decoder_config.h
+++ b/media/base/audio_decoder_config.h
@@ -122,6 +122,11 @@ class MEDIA_EXPORT AudioDecoderConfig {
     return target_output_sample_format_;
   }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
+  const std::string& mime_type() const { return mime_type_; }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
  private:
   // WARNING: When modifying or adding any parameters, update the following:
   // - AudioDecoderConfig::AsHumanReadableString()
@@ -170,6 +175,10 @@ class MEDIA_EXPORT AudioDecoderConfig {
   // Count of channels. By default derived from `channel_layout_`, but can also
   // be manually set in `SetChannelsForDiscrete()`;
   int channels_ = 0;
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  std::string mime_type_;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler
   // generated copy constructor and assignment operator. Since the extra data is

--- a/media/base/demuxer_stream.cc
+++ b/media/base/demuxer_stream.cc
@@ -45,12 +45,6 @@ const char* DemuxerStream::GetStatusName(Status status) {
 
 DemuxerStream::~DemuxerStream() = default;
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-std::string DemuxerStream::mime_type() const {
-  return "";
-}
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
 // Most DemuxerStream implementations don't specify liveness. Returns unknown
 // liveness by default.
 StreamLiveness DemuxerStream::liveness() const {

--- a/media/base/demuxer_stream.h
+++ b/media/base/demuxer_stream.h
@@ -69,9 +69,6 @@ class MEDIA_EXPORT DemuxerStream {
 
   using DecoderBufferVector = std::vector<scoped_refptr<DecoderBuffer>>;
   using ReadCB = base::OnceCallback<void(Status, DecoderBufferVector)>;
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  virtual std::string mime_type() const;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Request buffers to be returned via the provided callback.
   // The first parameter indicates the status of the read request.

--- a/media/base/mock_filters.cc
+++ b/media/base/mock_filters.cc
@@ -76,16 +76,6 @@ void MockDemuxerStream::set_liveness(StreamLiveness liveness) {
   liveness_ = liveness;
 }
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-std::string MockDemuxerStream::mime_type() const {
-  return mime_type_;
-}
-
-void MockDemuxerStream::set_mime_type(const std::string& mime_type) {
-  mime_type_ = mime_type;
-}
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
 MockVideoDecoder::MockVideoDecoder() : MockVideoDecoder(0) {}
 
 MockVideoDecoder::MockVideoDecoder(int decoder_id)

--- a/media/base/mock_filters.h
+++ b/media/base/mock_filters.h
@@ -221,16 +221,10 @@ class MockDemuxerStream : public DemuxerStream {
   VideoDecoderConfig video_decoder_config() override;
   MOCK_METHOD0(EnableBitstreamConverter, void());
   MOCK_METHOD0(SupportsConfigChanges, bool());
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  std::string mime_type() const override;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   void set_audio_decoder_config(const AudioDecoderConfig& config);
   void set_video_decoder_config(const VideoDecoderConfig& config);
   void set_liveness(StreamLiveness liveness);
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  void set_mime_type(const std::string& mime_type);
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
  private:
   Type type_ = DemuxerStream::Type::UNKNOWN;

--- a/media/base/video_decoder_config.cc
+++ b/media/base/video_decoder_config.cc
@@ -84,6 +84,17 @@ bool VideoDecoderConfig::IsValidConfig() const {
 }
 
 bool VideoDecoderConfig::Matches(const VideoDecoderConfig& config) const {
+  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
+  // is intentionally excluded from Matches():
+  // 1. Matches() checks whether underlying hardware decoders require 
+  //    re-initialization based on elementary stream properties (codec,
+  //    profile, resolution, extra_data).
+  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
+  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
+  //    boundaries.
+  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
+  //    container MIME strings differ while elementary video/audio parameters
+  //    remain identical.
   return codec() == config.codec() && profile() == config.profile() &&
          alpha_mode() == config.alpha_mode() &&
          video_transformation() == config.video_transformation() &&

--- a/media/base/video_decoder_config.cc
+++ b/media/base/video_decoder_config.cc
@@ -115,6 +115,9 @@ std::string VideoDecoderConfig::AsHumanReadableString() const {
     << ", encryption scheme: " << encryption_scheme()
     << ", rotation: " << VideoRotationToString(video_transformation().rotation)
     << ", flipped: " << video_transformation().mirrored
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+    << ", mime_type: " << mime_type()
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
     << ", color space: " << color_space_info().ToGfxColorSpace().ToString();
 
   if (hdr_metadata().has_value()) {

--- a/media/base/video_decoder_config.cc
+++ b/media/base/video_decoder_config.cc
@@ -84,17 +84,25 @@ bool VideoDecoderConfig::IsValidConfig() const {
 }
 
 bool VideoDecoderConfig::Matches(const VideoDecoderConfig& config) const {
-  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)), `mime_type()`
-  // is intentionally excluded from Matches():
-  // 1. Matches() checks whether underlying hardware decoders require 
-  //    re-initialization based on elementary stream properties (codec,
-  //    profile, resolution, extra_data).
-  // 2. Format transitions (e.g., MediaSource.changeType) are explicitly
-  //    signaled down the pipeline via DemuxerStream::kConfigChanged buffer
-  //    boundaries.
-  // 3. Omitting `mime_type()` prevents redundant hardware decoder teardowns if
-  //    container MIME strings differ while elementary video/audio parameters
-  //    remain identical.
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)),
+  // `mime_type()` is intentionally omitted from Matches() to minimize risk to
+  // playback stability:
+  // 1. Matches() evaluates whether a stream config change requires tearing
+  //    down and re-initializing the underlying hardware decoder (SbPlayer /
+  //    MediaCodec).
+  // 2. The existing elementary stream fields compared below (codec, profile,
+  //    resolution, extra_data) already provide sufficient information to
+  //    detect any hardware-relevant format changes. Real format switches
+  //    (e.g., H.264 -> VP9) alter these elementary fields and correctly
+  //    trigger decoder re-initialization, making an additional `mime_type()`
+  //    comparison unnecessary.
+  // 3. Omitting `mime_type()` minimizes the risk of false-positive decoder
+  //    flushes: adding `mime_type()` introduces brand new behavior that is
+  //    risky. It's now possible that mime_type strings that didn't cause
+  //    Matches() to fail now do with this change, introducing new
+  //    regressions.
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   return codec() == config.codec() && profile() == config.profile() &&
          alpha_mode() == config.alpha_mode() &&
          video_transformation() == config.video_transformation() &&

--- a/media/base/video_decoder_config.cc
+++ b/media/base/video_decoder_config.cc
@@ -83,26 +83,11 @@ bool VideoDecoderConfig::IsValidConfig() const {
          gfx::Rect(coded_size_).Contains(visible_rect_);
 }
 
-bool VideoDecoderConfig::Matches(const VideoDecoderConfig& config) const {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  // Note: On Starboard builds (BUILDFLAG(USE_STARBOARD_MEDIA)),
-  // `mime_type()` is intentionally omitted from Matches() to minimize risk to
-  // playback stability:
-  // 1. Matches() evaluates whether a stream config change requires tearing
-  //    down and re-initializing the underlying hardware decoder (SbPlayer /
-  //    MediaCodec).
-  // 2. The existing elementary stream fields compared below (codec, profile,
-  //    resolution, extra_data) already provide sufficient information to
-  //    detect any hardware-relevant format changes. Real format switches
-  //    (e.g., H.264 -> VP9) alter these elementary fields and correctly
-  //    trigger decoder re-initialization, making an additional `mime_type()`
-  //    comparison unnecessary.
-  // 3. Omitting `mime_type()` minimizes the risk of false-positive decoder
-  //    flushes: adding `mime_type()` introduces brand new behavior that is
-  //    risky. It's now possible that mime_type strings that didn't cause
-  //    Matches() to fail now do with this change, introducing new
-  //    regressions.
+// TODO(b/545325130): Explicitly signal SbPlayer of a changeType() call when
+// the config/mime_type is identical to the current config/mime_type.
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+bool VideoDecoderConfig::Matches(const VideoDecoderConfig& config) const {
   return codec() == config.codec() && profile() == config.profile() &&
          alpha_mode() == config.alpha_mode() &&
          video_transformation() == config.video_transformation() &&
@@ -113,6 +98,9 @@ bool VideoDecoderConfig::Matches(const VideoDecoderConfig& config) const {
          extra_data() == config.extra_data() &&
          encryption_scheme() == config.encryption_scheme() &&
          color_space_info() == config.color_space_info() &&
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+         mime_type() == config.mime_type() &&
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
          hdr_metadata() == config.hdr_metadata() && level() == config.level();
 }
 

--- a/media/base/video_decoder_config.h
+++ b/media/base/video_decoder_config.h
@@ -164,6 +164,11 @@ class MEDIA_EXPORT VideoDecoderConfig {
   // useful for decryptors that decrypts an encrypted stream to a clear stream.
   void SetIsEncrypted(bool is_encrypted);
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
+  const std::string& mime_type() const { return mime_type_; }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
  private:
   VideoCodec codec_ = VideoCodec::kUnknown;
   VideoCodecProfile profile_ = VIDEO_CODEC_PROFILE_UNKNOWN;
@@ -189,6 +194,10 @@ class MEDIA_EXPORT VideoDecoderConfig {
 
   VideoColorSpace color_space_info_;
   std::optional<gfx::HDRMetadata> hdr_metadata_;
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  std::string mime_type_;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler
   // generated copy constructor and assignment operator. Since the extra data is

--- a/media/base/video_decoder_config.h
+++ b/media/base/video_decoder_config.h
@@ -195,6 +195,7 @@ class MEDIA_EXPORT VideoDecoderConfig {
   std::optional<gfx::HDRMetadata> hdr_metadata_;
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Full mime string for the video decoder config.
   std::string mime_type_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler

--- a/media/base/video_decoder_config.h
+++ b/media/base/video_decoder_config.h
@@ -168,7 +168,6 @@ class MEDIA_EXPORT VideoDecoderConfig {
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
  private:
   VideoCodec codec_ = VideoCodec::kUnknown;
   VideoCodecProfile profile_ = VIDEO_CODEC_PROFILE_UNKNOWN;
@@ -198,7 +197,6 @@ class MEDIA_EXPORT VideoDecoderConfig {
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   std::string mime_type_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler
   // generated copy constructor and assignment operator. Since the extra data is
   // typically small, the performance impact is minimal.

--- a/media/base/video_decoder_config.h
+++ b/media/base/video_decoder_config.h
@@ -168,6 +168,7 @@ class MEDIA_EXPORT VideoDecoderConfig {
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
  private:
   VideoCodec codec_ = VideoCodec::kUnknown;
   VideoCodecProfile profile_ = VIDEO_CODEC_PROFILE_UNKNOWN;

--- a/media/base/video_decoder_config.h
+++ b/media/base/video_decoder_config.h
@@ -165,6 +165,7 @@ class MEDIA_EXPORT VideoDecoderConfig {
   void SetIsEncrypted(bool is_encrypted);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // Mime_type string of the config.
   void set_mime_type(std::string_view mime_type) { mime_type_ = mime_type; }
   const std::string& mime_type() const { return mime_type_; }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
@@ -197,7 +198,7 @@ class MEDIA_EXPORT VideoDecoderConfig {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   // Full mime string for the video decoder config.
-  std::string mime_type_;
+  std::string mime_type_ = "";
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   // Not using DISALLOW_COPY_AND_ASSIGN here intentionally to allow the compiler
   // generated copy constructor and assignment operator. Since the extra data is

--- a/media/base/video_decoder_config_unittest.cc
+++ b/media/base/video_decoder_config_unittest.cc
@@ -39,4 +39,22 @@ TEST(VideoDecoderConfigTest, SetProfile) {
   EXPECT_EQ(config.profile(), VP9PROFILE_PROFILE2);
 }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+TEST(VideoDecoderConfigTest, SetMimeTypeAndMatches) {
+  VideoDecoderConfig config1(VideoCodec::kVP9, VP9PROFILE_PROFILE0,
+                             VideoDecoderConfig::AlphaMode::kIsOpaque,
+                             VideoColorSpace(), kNoTransformation, kCodedSize,
+                             kVisibleRect, kNaturalSize, EmptyExtraData(),
+                             EncryptionScheme::kUnencrypted);
+  config1.set_mime_type("video/webm; codecs=\"vp9\"");
+  EXPECT_EQ(config1.mime_type(), "video/webm; codecs=\"vp9\"");
+
+  VideoDecoderConfig config2 = config1;
+  EXPECT_TRUE(config1.Matches(config2));
+
+  config2.set_mime_type("video/mp4; codecs=\"av01.0.09M.08\"");
+  EXPECT_FALSE(config1.Matches(config2));
+}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 }  // namespace media

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -857,7 +857,6 @@ ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
   CHECK(it != id_to_mime_map_.end());
   const std::string& mime_type = it->second;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
   source_state->Init(base::BindOnce(&ChunkDemuxer::OnSourceInitDone,
                                     base::Unretained(this), id),
 #if BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -102,18 +102,6 @@ bool ParseMimeType(const std::string& mime_type,
 
 namespace media {
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-ChunkDemuxerStream::ChunkDemuxerStream(const std::string& mime_type,
-                                       Type type,
-                                       MediaTrack::Id media_track_id)
-    : mime_type_(mime_type),
-      type_(type),
-      liveness_(StreamLiveness::kUnknown),
-      media_track_id_(media_track_id),
-      state_(UNINITIALIZED),
-      is_enabled_(true) {}
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
 ChunkDemuxerStream::ChunkDemuxerStream(Type type, MediaTrack::Id media_track_id)
     : type_(type),
       liveness_(StreamLiveness::kUnknown),
@@ -336,12 +324,6 @@ void ChunkDemuxerStream::UnmarkEndOfStream() {
 }
 
 // DemuxerStream methods.
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-std::string ChunkDemuxerStream::mime_type() const {
-  return mime_type_;
-}
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
 void ChunkDemuxerStream::Read(uint32_t count, ReadCB read_cb) {
   base::AutoLock auto_lock(lock_);
   DCHECK_NE(state_, UNINITIALIZED);
@@ -871,7 +853,9 @@ ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
   CHECK(insert_result.second);  // Only true if insertion succeeded.
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  const std::string& mime_type = id_to_mime_map_[id];
+  auto it = id_to_mime_map_.find(id);
+  CHECK(it != id_to_mime_map_.end());
+  const std::string& mime_type = it->second;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   source_state->Init(base::BindOnce(&ChunkDemuxer::OnSourceInitDone,
@@ -1661,15 +1645,8 @@ ChunkDemuxerStream* ChunkDemuxer::CreateDemuxerStream(
       NOTREACHED();
   }
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  auto iter = id_to_mime_map_.find(source_id);
-  std::string mime_type = iter != id_to_mime_map_.end() ? iter->second : "";
-  std::unique_ptr<ChunkDemuxerStream> stream =
-      std::make_unique<ChunkDemuxerStream>(mime_type, type, media_track_id);
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
   std::unique_ptr<ChunkDemuxerStream> stream =
       std::make_unique<ChunkDemuxerStream>(type, media_track_id);
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   DCHECK(track_id_to_demux_stream_map_.find(media_track_id) ==
          track_id_to_demux_stream_map_.end());
   track_id_to_demux_stream_map_[media_track_id] = stream.get();

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -870,8 +870,15 @@ ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
   CHECK(*insert_result.first == id);
   CHECK(insert_result.second);  // Only true if insertion succeeded.
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  const std::string& mime_type = id_to_mime_map_[id];
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   source_state->Init(base::BindOnce(&ChunkDemuxer::OnSourceInitDone,
                                     base::Unretained(this), id),
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+                     mime_type,
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
                      expected_codecs, encrypted_media_init_data_cb_);
 
   // TODO(wolenetz): Change to DCHECKs once less verification in release build

--- a/media/filters/chunk_demuxer.cc
+++ b/media/filters/chunk_demuxer.cc
@@ -756,9 +756,16 @@ ChunkDemuxer::Status ChunkDemuxer::AddId(
                        std::nullopt);
 }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+ChunkDemuxer::Status ChunkDemuxer::AddId(const std::string& id,
+                                         const std::string& content_type,
+                                         const std::string& codecs,
+                                         std::string_view mime_type) {
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
 ChunkDemuxer::Status ChunkDemuxer::AddId(const std::string& id,
                                          const std::string& content_type,
                                          const std::string& codecs) {
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   DVLOG(1) << __func__ << " id=" << id << " content_type=" << content_type
            << " codecs=" << codecs;
   base::AutoLock auto_lock(lock_);
@@ -780,8 +787,14 @@ ChunkDemuxer::Status ChunkDemuxer::AddId(const std::string& id,
     return ChunkDemuxer::kNotSupported;
   }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  return AddIdInternal(id, std::move(stream_parser),
+                       ExpectedCodecs(content_type, codecs),
+                       mime_type);
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
   return AddIdInternal(id, std::move(stream_parser),
                        ExpectedCodecs(content_type, codecs));
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 #if BUILDFLAG(ENABLE_HLS_DEMUXER)
@@ -816,16 +829,22 @@ ChunkDemuxer::Status ChunkDemuxer::AddId(const std::string& id,
   if (!ParseMimeType(mime_type, &type, &codecs)) {
     return kNotSupported;
   }
-  DCHECK(!base::Contains(id_to_mime_map_, id));
-  id_to_mime_map_[id] = mime_type;
-  return AddId(id, type, codecs);
+  return AddId(id, type, codecs, mime_type);
 }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
+    const std::string& id,
+    std::unique_ptr<media::StreamParser> stream_parser,
+    std::optional<std::string_view> expected_codecs,
+    std::string_view mime_type) {
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
 ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
     const std::string& id,
     std::unique_ptr<media::StreamParser> stream_parser,
     std::optional<std::string_view> expected_codecs) {
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   DVLOG(2) << __func__ << " id=" << id
            << " expected_codecs=" << expected_codecs.value_or("None");
   lock_.AssertAcquired();
@@ -852,11 +871,6 @@ ChunkDemuxer::Status ChunkDemuxer::AddIdInternal(
   CHECK(*insert_result.first == id);
   CHECK(insert_result.second);  // Only true if insertion succeeded.
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  auto it = id_to_mime_map_.find(id);
-  CHECK(it != id_to_mime_map_.end());
-  const std::string& mime_type = it->second;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   source_state->Init(base::BindOnce(&ChunkDemuxer::OnSourceInitDone,
                                     base::Unretained(this), id),
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
@@ -918,9 +932,6 @@ void ChunkDemuxer::RemoveId(const std::string& id) {
     CHECK(stream_found);
   }
   id_to_streams_map_.erase(id);
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  id_to_mime_map_.erase(id);
-#endif
 }
 
 Ranges<base::TimeDelta> ChunkDemuxer::GetBufferedRanges(

--- a/media/filters/chunk_demuxer.h
+++ b/media/filters/chunk_demuxer.h
@@ -272,9 +272,19 @@ class MEDIA_EXPORT ChunkDemuxer : public Demuxer {
   // the caller must provide valid, supported decoder configs; those overloads'
   // usage indicates that we intend to append WebCodecs encoded audio or video
   // chunks for this ID.
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // We pass a default parameter |mime_type| to the standard AddId() call,
+  // as this allows us to easily pass on the value instead of duplicating
+  // existing code.
+  [[nodiscard]] Status AddId(const std::string& id,
+                             const std::string& content_type,
+                             const std::string& codecs,
+                             std::string_view mime_type = "");
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
   [[nodiscard]] Status AddId(const std::string& id,
                              const std::string& content_type,
                              const std::string& codecs);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   [[nodiscard]] Status AddId(const std::string& id,
                              std::unique_ptr<AudioDecoderConfig> audio_config);
   [[nodiscard]] Status AddId(const std::string& id,
@@ -491,10 +501,20 @@ class MEDIA_EXPORT ChunkDemuxer : public Demuxer {
   // Helper for AddId's creation of FrameProcessor, and
   // SourceBufferState creation, initialization and tracking in
   // source_state_map_.
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  // The Starboard implementation of AddIdInternal() also accepts |mime_type|
+  // to pass to the SourceBufferState.
+  ChunkDemuxer::Status AddIdInternal(
+      const std::string& id,
+      std::unique_ptr<media::StreamParser> stream_parser,
+      std::optional<std::string_view> expected_codecs,
+      std::string_view mime_type = "");
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
   ChunkDemuxer::Status AddIdInternal(
       const std::string& id,
       std::unique_ptr<media::StreamParser> stream_parser,
       std::optional<std::string_view> expected_codecs);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   void ChangeState_Locked(State new_state);
 
@@ -617,9 +637,6 @@ class MEDIA_EXPORT ChunkDemuxer : public Demuxer {
       track_id_to_demux_stream_map_;
 
   bool supports_change_type_ = true;
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  std::map<std::string, std::string> id_to_mime_map_;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 }  // namespace media

--- a/media/filters/chunk_demuxer.h
+++ b/media/filters/chunk_demuxer.h
@@ -40,11 +40,6 @@ class MEDIA_EXPORT ChunkDemuxerStream : public DemuxerStream {
  public:
   using BufferQueue = base::circular_deque<scoped_refptr<StreamParserBuffer>>;
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  ChunkDemuxerStream(const std::string& mime_type,
-                     Type type,
-                     MediaTrack::Id media_track_id);
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   ChunkDemuxerStream(Type type, MediaTrack::Id media_track_id);
   ChunkDemuxerStream() = delete;
 
@@ -140,9 +135,6 @@ class MEDIA_EXPORT ChunkDemuxerStream : public DemuxerStream {
   void UnmarkEndOfStream();
 
   // DemuxerStream methods.
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  std::string mime_type() const override;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   void Read(uint32_t count, ReadCB read_cb) override;
   Type type() const override;
   StreamLiveness liveness() const override;
@@ -191,7 +183,6 @@ class MEDIA_EXPORT ChunkDemuxerStream : public DemuxerStream {
   GetPendingBuffers_Locked() EXCLUSIVE_LOCKS_REQUIRED(lock_);
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-  const std::string mime_type_;
   base::TimeDelta write_head_ GUARDED_BY(lock_);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/media/filters/source_buffer_state.cc
+++ b/media/filters/source_buffer_state.cc
@@ -155,7 +155,7 @@ SourceBufferState::~SourceBufferState() {
 
 void SourceBufferState::Init(StreamParser::InitCB init_cb,
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-                             const std::string& mime_type,
+                             std::string_view mime_type,
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
                              std::optional<std::string_view> expected_codecs,
                              const StreamParser::EncryptedMediaInitDataCB&

--- a/media/filters/source_buffer_state.cc
+++ b/media/filters/source_buffer_state.cc
@@ -154,12 +154,18 @@ SourceBufferState::~SourceBufferState() {
 }
 
 void SourceBufferState::Init(StreamParser::InitCB init_cb,
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+                             const std::string& mime_type,
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
                              std::optional<std::string_view> expected_codecs,
                              const StreamParser::EncryptedMediaInitDataCB&
                                  encrypted_media_init_data_cb) {
   DCHECK_EQ(state_, UNINITIALIZED);
   init_cb_ = std::move(init_cb);
   encrypted_media_init_data_cb_ = encrypted_media_init_data_cb;
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  mime_type_ = mime_type;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   state_ = PENDING_PARSER_CONFIG;
   InitializeParser(expected_codecs);
 }
@@ -666,6 +672,9 @@ bool SourceBufferState::OnNewConfigs(std::unique_ptr<MediaTracks> tracks) {
       }
 
       track->set_id(stream->media_track_id());
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+      audio_config.set_mime_type(mime_type_);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
       frame_processor_->OnPossibleAudioConfigUpdate(audio_config);
       success &= stream->UpdateAudioConfig(audio_config, allow_codec_changes,
                                            media_log_);
@@ -751,6 +760,9 @@ bool SourceBufferState::OnNewConfigs(std::unique_ptr<MediaTracks> tracks) {
       }
 
       track->set_id(stream->media_track_id());
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+      video_config.set_mime_type(mime_type_);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
       success &= stream->UpdateVideoConfig(video_config, allow_codec_changes,
                                            media_log_);
     } else {

--- a/media/filters/source_buffer_state.h
+++ b/media/filters/source_buffer_state.h
@@ -51,7 +51,7 @@ class MEDIA_EXPORT SourceBufferState {
 
   void Init(StreamParser::InitCB init_cb,
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-            const std::string& mime_type,
+            std::string_view mime_type,
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
             std::optional<std::string_view> expected_codecs,
             const StreamParser::EncryptedMediaInitDataCB&

--- a/media/filters/source_buffer_state.h
+++ b/media/filters/source_buffer_state.h
@@ -50,6 +50,9 @@ class MEDIA_EXPORT SourceBufferState {
   ~SourceBufferState();
 
   void Init(StreamParser::InitCB init_cb,
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+            const std::string& mime_type,
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
             std::optional<std::string_view> expected_codecs,
             const StreamParser::EncryptedMediaInitDataCB&
                 encrypted_media_init_data_cb);
@@ -298,6 +301,10 @@ class MEDIA_EXPORT SourceBufferState {
 
   std::vector<AudioCodec> expected_audio_codecs_;
   std::vector<VideoCodec> expected_video_codecs_;
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  std::string mime_type_;
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 };
 
 }  // namespace media

--- a/media/filters/source_buffer_state.h
+++ b/media/filters/source_buffer_state.h
@@ -301,7 +301,6 @@ class MEDIA_EXPORT SourceBufferState {
 
   std::vector<AudioCodec> expected_audio_codecs_;
   std::vector<VideoCodec> expected_video_codecs_;
-
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   std::string mime_type_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/filters/source_buffer_state_unittest.cc
+++ b/media/filters/source_buffer_state_unittest.cc
@@ -61,6 +61,10 @@ void AddVideoTrack(std::unique_ptr<MediaTracks>& t, VideoCodec codec, int id) {
                    MediaTrack::Language());
 }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+constexpr char kTestMimeType[] = "video/mp4; codecs=\"avc1.4d401f\"";
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 }  // namespace
 
 class SourceBufferStateTest : public ::testing::Test {
@@ -94,6 +98,9 @@ class SourceBufferStateTest : public ::testing::Test {
                       auto media_log) { new_config_cb_ = config_cb; });
     sbs->Init(base::BindOnce(&SourceBufferStateTest::SourceInitDone,
                              base::Unretained(this)),
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+              kTestMimeType,
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
               expected_codecs,
               base::BindRepeating(
                   &SourceBufferStateTest::StreamParserEncryptedInitData,
@@ -179,6 +186,9 @@ TEST_F(SourceBufferStateTest, InitSourceBufferWithRelaxedCodecChecks) {
   sbs->Init(
       base::BindOnce(&SourceBufferStateTest::SourceInitDone,
                      base::Unretained(this)),
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+      kTestMimeType,
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
       std::nullopt,
       base::BindRepeating(&SourceBufferStateTest::StreamParserEncryptedInitData,
                           base::Unretained(this)));
@@ -209,6 +219,10 @@ TEST_F(SourceBufferStateTest, InitSingleAudioTrack) {
   EXPECT_FOUND_CODEC_NAME(Audio, "vorbis");
   EXPECT_CALL(*this, MediaTracksUpdatedMock(_));
   EXPECT_TRUE(AppendDataAndReportTracks(sbs, std::move(tracks)));
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  EXPECT_EQ(demuxer_streams_[0]->audio_decoder_config().mime_type(),
+            kTestMimeType);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 TEST_F(SourceBufferStateTest, InitSingleVideoTrack) {
@@ -221,6 +235,10 @@ TEST_F(SourceBufferStateTest, InitSingleVideoTrack) {
   EXPECT_FOUND_CODEC_NAME(Video, "vp8");
   EXPECT_CALL(*this, MediaTracksUpdatedMock(_));
   EXPECT_TRUE(AppendDataAndReportTracks(sbs, std::move(tracks)));
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  EXPECT_EQ(demuxer_streams_[0]->video_decoder_config().mime_type(),
+            kTestMimeType);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 TEST_F(SourceBufferStateTest, InitMultipleTracks) {

--- a/media/mojo/clients/mojo_demuxer_stream_impl.cc
+++ b/media/mojo/clients/mojo_demuxer_stream_impl.cc
@@ -48,14 +48,7 @@ void MojoDemuxerStreamImpl::Initialize(InitializeCallback callback) {
       &remote_consumer_handle);
 
   std::move(callback).Run(stream_->type(), std::move(remote_consumer_handle),
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-                          audio_config, video_config,
-                          stream_->type() == media::DemuxerStream::AUDIO
-                              ? (audio_config ? audio_config->mime_type() : "")
-                              : (video_config ? video_config->mime_type() : ""));
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
                           audio_config, video_config);
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 }
 
 void MojoDemuxerStreamImpl::Read(uint32_t count, ReadCallback callback) {

--- a/media/mojo/clients/mojo_demuxer_stream_impl.cc
+++ b/media/mojo/clients/mojo_demuxer_stream_impl.cc
@@ -49,7 +49,10 @@ void MojoDemuxerStreamImpl::Initialize(InitializeCallback callback) {
 
   std::move(callback).Run(stream_->type(), std::move(remote_consumer_handle),
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
-                          audio_config, video_config, stream_->mime_type());
+                          audio_config, video_config,
+                          stream_->type() == media::DemuxerStream::AUDIO
+                              ? (audio_config ? audio_config->mime_type() : "")
+                              : (video_config ? video_config->mime_type() : ""));
 #else   // BUILDFLAG(USE_STARBOARD_MEDIA)
                           audio_config, video_config);
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
@@ -144,24 +144,6 @@ StreamLiveness MojoRendererBypassBridge::GetLiveness(
   return stream ? stream->liveness() : StreamLiveness::kUnknown;
 }
 
-std::string MojoRendererBypassBridge::GetMimeType(
-    DemuxerStream::Type type) const {
-  base::AutoLock auto_lock(lock_);
-  if (!active_) {
-    return "";
-  }
-  DemuxerStream* stream = GetStreamLocked(type);
-  if (!stream) {
-    return "";
-  }
-  if (type == DemuxerStream::AUDIO) {
-    return stream->audio_decoder_config().mime_type();
-  } else if (type == DemuxerStream::VIDEO) {
-    return stream->video_decoder_config().mime_type();
-  }
-  return "";
-}
-
 void MojoRendererBypassBridge::EnableBitstreamConverter(
     DemuxerStream::Type type) {
   if (!client_task_runner_->RunsTasksInCurrentSequence()) {

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.cc
@@ -151,7 +151,15 @@ std::string MojoRendererBypassBridge::GetMimeType(
     return "";
   }
   DemuxerStream* stream = GetStreamLocked(type);
-  return stream ? stream->mime_type() : "";
+  if (!stream) {
+    return "";
+  }
+  if (type == DemuxerStream::AUDIO) {
+    return stream->audio_decoder_config().mime_type();
+  } else if (type == DemuxerStream::VIDEO) {
+    return stream->video_decoder_config().mime_type();
+  }
+  return "";
 }
 
 void MojoRendererBypassBridge::EnableBitstreamConverter(

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge.h
@@ -86,7 +86,6 @@ class MojoRendererBypassBridge
   VideoDecoderConfig GetVideoConfig() const;
   bool SupportsConfigChanges(DemuxerStream::Type type) const;
   StreamLiveness GetLiveness(DemuxerStream::Type type) const;
-  std::string GetMimeType(DemuxerStream::Type type) const;
   void EnableBitstreamConverter(DemuxerStream::Type type);
 
  private:

--- a/media/mojo/common/starboard/mojo_renderer_bypass_bridge_unittest.cc
+++ b/media/mojo/common/starboard/mojo_renderer_bypass_bridge_unittest.cc
@@ -145,22 +145,6 @@ TEST_F(MojoRendererBypassBridgeTest, InvalidateWaitsForRead) {
   invalidate_finished.Wait();
 }
 
-TEST_F(MojoRendererBypassBridgeTest, GetMimeType) {
-  NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
-  NiceMock<MockDemuxerStream> video_stream(DemuxerStream::VIDEO);
-  audio_stream.set_mime_type("audio/mp4");
-  video_stream.set_mime_type("video/mp4");
-
-  bridge_->SetStreams(&audio_stream, &video_stream);
-
-  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::AUDIO), "audio/mp4");
-  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::VIDEO), "video/mp4");
-
-  bridge_->Invalidate();
-  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::AUDIO), "");
-  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::VIDEO), "");
-}
-
 TEST_F(MojoRendererBypassBridgeTest, EnableBitstreamConverter) {
   NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
   NiceMock<MockDemuxerStream> video_stream(DemuxerStream::VIDEO);
@@ -181,15 +165,12 @@ TEST_F(MojoRendererBypassBridgeTest, EnableBitstreamConverter) {
 TEST_F(MojoRendererBypassBridgeTest, UnknownStreamType) {
   NiceMock<MockDemuxerStream> audio_stream(DemuxerStream::AUDIO);
   NiceMock<MockDemuxerStream> video_stream(DemuxerStream::VIDEO);
-  audio_stream.set_mime_type("audio/mp4");
-  video_stream.set_mime_type("video/mp4");
 
   bridge_->SetStreams(&audio_stream, &video_stream);
 
   EXPECT_CALL(audio_stream, EnableBitstreamConverter()).Times(0);
   EXPECT_CALL(video_stream, EnableBitstreamConverter()).Times(0);
 
-  EXPECT_EQ(bridge_->GetMimeType(DemuxerStream::UNKNOWN), "");
   bridge_->EnableBitstreamConverter(DemuxerStream::UNKNOWN);
 
   bridge_->Invalidate();

--- a/media/mojo/mojom/audio_decoder_config_mojom_traits.cc
+++ b/media/mojo/mojom/audio_decoder_config_mojom_traits.cc
@@ -53,6 +53,13 @@ bool StructTraits<media::mojom::AudioDecoderConfigDataView,
   output->Initialize(codec, sample_format, channel_layout,
                      input.samples_per_second(), std::move(extra_data),
                      encryption_scheme, seek_preroll, input.codec_delay());
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  std::string mime_type;
+  if (!input.ReadMimeType(&mime_type))
+    return false;
+
+  output->set_mime_type(mime_type);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   output->set_profile(profile);
   output->set_target_output_channel_layout(target_output_channel_layout);
   output->set_target_output_sample_format(target_output_sample_format);

--- a/media/mojo/mojom/audio_decoder_config_mojom_traits.h
+++ b/media/mojo/mojom/audio_decoder_config_mojom_traits.h
@@ -70,6 +70,12 @@ struct StructTraits<media::mojom::AudioDecoderConfigDataView,
     return input.should_discard_decoder_delay();
   }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  static const std::string& mime_type(const media::AudioDecoderConfig& input) {
+    return input.mime_type();
+  }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   static bool Read(media::mojom::AudioDecoderConfigDataView input,
                    media::AudioDecoderConfig* output);
 };

--- a/media/mojo/mojom/audio_decoder_config_mojom_traits.h
+++ b/media/mojo/mojom/audio_decoder_config_mojom_traits.h
@@ -70,14 +70,14 @@ struct StructTraits<media::mojom::AudioDecoderConfigDataView,
     return input.should_discard_decoder_delay();
   }
 
+  static bool Read(media::mojom::AudioDecoderConfigDataView input,
+                   media::AudioDecoderConfig* output);
+
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   static const std::string& mime_type(const media::AudioDecoderConfig& input) {
     return input.mime_type();
   }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
-  static bool Read(media::mojom::AudioDecoderConfigDataView input,
-                   media::AudioDecoderConfig* output);
 };
 
 }  // namespace mojo

--- a/media/mojo/mojom/audio_decoder_config_mojom_traits.h
+++ b/media/mojo/mojom/audio_decoder_config_mojom_traits.h
@@ -70,14 +70,14 @@ struct StructTraits<media::mojom::AudioDecoderConfigDataView,
     return input.should_discard_decoder_delay();
   }
 
-  static bool Read(media::mojom::AudioDecoderConfigDataView input,
-                   media::AudioDecoderConfig* output);
-
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   static const std::string& mime_type(const media::AudioDecoderConfig& input) {
     return input.mime_type();
   }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
+  static bool Read(media::mojom::AudioDecoderConfigDataView input,
+                   media::AudioDecoderConfig* output);
 };
 
 }  // namespace mojo

--- a/media/mojo/mojom/audio_decoder_config_mojom_traits_unittest.cc
+++ b/media/mojo/mojom/audio_decoder_config_mojom_traits_unittest.cc
@@ -95,4 +95,19 @@ TEST(AudioDecoderConfigStructTraitsTest, TargetOutputChannelLayout) {
   EXPECT_EQ(output.target_output_sample_format(), kSampleFormatDts);
 }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+TEST(AudioDecoderConfigStructTraitsTest, WithMimeType) {
+  AudioDecoderConfig input;
+  input.Initialize(AudioCodec::kAAC, kSampleFormatU8, CHANNEL_LAYOUT_SURROUND,
+                   48000, EmptyExtraData(), EncryptionScheme::kUnencrypted,
+                   base::TimeDelta(), 0);
+  input.set_mime_type("audio/mp4; codecs=\"mp4a.40.2\"");
+  std::vector<uint8_t> data = mojom::AudioDecoderConfig::Serialize(&input);
+  AudioDecoderConfig output;
+  EXPECT_TRUE(mojom::AudioDecoderConfig::Deserialize(std::move(data), &output));
+  EXPECT_TRUE(output.Matches(input));
+  EXPECT_EQ(output.mime_type(), "audio/mp4; codecs=\"mp4a.40.2\"");
+}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 }  // namespace media

--- a/media/mojo/mojom/demuxer_stream.mojom
+++ b/media/mojo/mojom/demuxer_stream.mojom
@@ -23,18 +23,10 @@ interface DemuxerStream {
   // of the media::DecoderBuffer returned via DemuxerStream::Read(). Only the
   // config for |type| should be non-null, which is the initial config of the
   // stream.
-  [EnableIfNot=use_starboard_media]
   Initialize() => (Type type,
                    handle<data_pipe_consumer> pipe,
                    AudioDecoderConfig? audio_config,
                    VideoDecoderConfig? video_config);
-  
-  [EnableIf=use_starboard_media]
-  Initialize() => (Type type,
-                   handle<data_pipe_consumer> pipe,
-                   AudioDecoderConfig? audio_config,
-                   VideoDecoderConfig? video_config,
-                   string mime_type);
 
   // Requests multi DecoderBuffer from this stream for decoding and rendering.
   // See media::DemuxerStream::ReadCB for a general explanation of the fields.

--- a/media/mojo/mojom/media_types.mojom
+++ b/media/mojo/mojom/media_types.mojom
@@ -206,6 +206,8 @@ struct AudioDecoderConfig {
   ChannelLayout target_output_channel_layout;
   SampleFormat target_output_sample_format;
   bool should_discard_decoder_delay;
+  [EnableIf=use_starboard_media]
+  string mime_type;
 };
 
 // This defines a mojo transport format for media::VideoDecoderConfig.
@@ -224,6 +226,8 @@ struct VideoDecoderConfig {
   EncryptionScheme encryption_scheme;
   VideoColorSpace color_space_info;
   gfx.mojom.HDRMetadata? hdr_metadata;
+  [EnableIf=use_starboard_media]
+  string mime_type;
 };
 
 // Native struct media::SubsampleEntry;

--- a/media/mojo/mojom/video_decoder_config_mojom_traits.cc
+++ b/media/mojo/mojom/video_decoder_config_mojom_traits.cc
@@ -70,6 +70,14 @@ bool StructTraits<media::mojom::VideoDecoderConfigDataView,
   if (hdr_metadata)
     output->set_hdr_metadata(hdr_metadata.value());
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  std::string mime_type;
+  if (!input.ReadMimeType(&mime_type))
+    return false;
+
+  output->set_mime_type(mime_type);
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   if (!output->IsValidConfig())
     return false;
 

--- a/media/mojo/mojom/video_decoder_config_mojom_traits.h
+++ b/media/mojo/mojom/video_decoder_config_mojom_traits.h
@@ -81,6 +81,12 @@ struct StructTraits<media::mojom::VideoDecoderConfigDataView,
     return input.level();
   }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  static const std::string& mime_type(const media::VideoDecoderConfig& input) {
+    return input.mime_type();
+  }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
   static bool Read(media::mojom::VideoDecoderConfigDataView input,
                    media::VideoDecoderConfig* output);
 };

--- a/media/mojo/mojom/video_decoder_config_mojom_traits_unittest.cc
+++ b/media/mojo/mojom/video_decoder_config_mojom_traits_unittest.cc
@@ -160,4 +160,23 @@ TEST(VideoDecoderConfigStructTraitsTest,
       media::mojom::VideoDecoderConfig::Deserialize(std::move(data), &output));
 }
 
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+TEST(VideoDecoderConfigStructTraitsTest, ConvertVideoDecoderConfig_MimeType) {
+  VideoDecoderConfig input(VideoCodec::kVP8, VP8PROFILE_ANY,
+                           VideoDecoderConfig::AlphaMode::kIsOpaque,
+                           VideoColorSpace(), kNoTransformation, kCodedSize,
+                           kVisibleRect, kNaturalSize, EmptyExtraData(),
+                           EncryptionScheme::kUnencrypted);
+  input.set_mime_type("video/mp4; codecs=\"av01.0.09M.08\"");
+
+  std::vector<uint8_t> data =
+      media::mojom::VideoDecoderConfig::Serialize(&input);
+  VideoDecoderConfig output;
+  EXPECT_TRUE(
+      media::mojom::VideoDecoderConfig::Deserialize(std::move(data), &output));
+  EXPECT_TRUE(output.Matches(input));
+  EXPECT_EQ(output.mime_type(), "video/mp4; codecs=\"av01.0.09M.08\"");
+}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
+
 }  // namespace media

--- a/media/mojo/services/mojo_demuxer_stream_adapter.cc
+++ b/media/mojo/services/mojo_demuxer_stream_adapter.cc
@@ -73,20 +73,12 @@ void MojoDemuxerStreamAdapter::OnStreamReady(
     Type type,
     mojo::ScopedDataPipeConsumerHandle consumer_handle,
     const std::optional<AudioDecoderConfig>& audio_config,
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-    const std::optional<VideoDecoderConfig>& video_config,
-    const std::string& mime_type) {
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
     const std::optional<VideoDecoderConfig>& video_config) {
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   DVLOG(1) << __func__;
   DCHECK_EQ(UNKNOWN, type_);
   DCHECK(consumer_handle.is_valid());
 
   type_ = type;
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  mime_type_ = mime_type;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   mojo_decoder_buffer_reader_ =
       std::make_unique<MojoDecoderBufferReader>(std::move(consumer_handle));

--- a/media/mojo/services/mojo_demuxer_stream_adapter.cc
+++ b/media/mojo/services/mojo_demuxer_stream_adapter.cc
@@ -68,12 +68,6 @@ bool MojoDemuxerStreamAdapter::SupportsConfigChanges() {
   return true;
 }
 
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-std::string MojoDemuxerStreamAdapter::mime_type() const {
-  return mime_type_;
-}
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
-
 // TODO(xhwang): Pass liveness here.
 void MojoDemuxerStreamAdapter::OnStreamReady(
     Type type,

--- a/media/mojo/services/mojo_demuxer_stream_adapter.h
+++ b/media/mojo/services/mojo_demuxer_stream_adapter.h
@@ -49,9 +49,6 @@ class MEDIA_MOJO_EXPORT MojoDemuxerStreamAdapter : public DemuxerStream {
   Type type() const override;
   void EnableBitstreamConverter() override;
   bool SupportsConfigChanges() override;
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  std::string mime_type() const override;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
  private:
   void OnStreamReady(Type type,

--- a/media/mojo/services/mojo_demuxer_stream_adapter.h
+++ b/media/mojo/services/mojo_demuxer_stream_adapter.h
@@ -54,12 +54,7 @@ class MEDIA_MOJO_EXPORT MojoDemuxerStreamAdapter : public DemuxerStream {
   void OnStreamReady(Type type,
                      mojo::ScopedDataPipeConsumerHandle consumer_handle,
                      const std::optional<AudioDecoderConfig>& audio_config,
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-                     const std::optional<VideoDecoderConfig>& video_config,
-                     const std::string& mime_type);
-#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
                      const std::optional<VideoDecoderConfig>& video_config);
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   // The callback from |demuxer_stream_| that a read operation has completed.
   // |read_cb| is a callback from the client who invoked Read() on |this|.
@@ -90,9 +85,6 @@ class MEDIA_MOJO_EXPORT MojoDemuxerStreamAdapter : public DemuxerStream {
 
   Type type_ = Type::UNKNOWN;
   Status status_ = Status::kOk;
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-  std::string mime_type_;
-#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   size_t actual_read_count_ = 0;
 

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -73,8 +73,6 @@ class ProxyDemuxerStream : public DemuxerStream {
     return bridge_->SupportsConfigChanges(type_);
   }
 
-  std::string mime_type() const override { return bridge_->GetMimeType(type_); }
-
   void EnableBitstreamConverter() override {
     bridge_->EnableBitstreamConverter(type_);
   }

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -301,8 +301,13 @@ TEST_F(StarboardRendererWrapperTest, InitializeWithBypassBridge) {
       base::DoNothing());
   AddStream(DemuxerStream::AUDIO, false);
   AddStream(DemuxerStream::VIDEO, false);
-  streams_[0]->set_mime_type("audio/mp4");
-  streams_[1]->set_mime_type("video/mp4");
+  AudioDecoderConfig audio_config = streams_[0]->audio_decoder_config();
+  audio_config.set_mime_type("audio/mp4");
+  streams_[0]->set_audio_decoder_config(audio_config);
+
+  VideoDecoderConfig video_config = streams_[1]->video_decoder_config();
+  video_config.set_mime_type("video/mp4");
+  streams_[1]->set_video_decoder_config(video_config);
   bypass_bridge->SetStreams(streams_[0].get(), streams_[1].get());
   uint32_t bridge_id = 12345;
   BypassBridgeRegistry::Register(bridge_id, bypass_bridge);
@@ -451,8 +456,13 @@ TEST_F(StarboardRendererWrapperTest, TimerLifecycle) {
       base::DoNothing());
   AddStream(DemuxerStream::AUDIO, false);
   AddStream(DemuxerStream::VIDEO, false);
-  streams_[0]->set_mime_type("audio/mp4");
-  streams_[1]->set_mime_type("video/mp4");
+  AudioDecoderConfig audio_config = streams_[0]->audio_decoder_config();
+  audio_config.set_mime_type("audio/mp4");
+  streams_[0]->set_audio_decoder_config(audio_config);
+
+  VideoDecoderConfig video_config = streams_[1]->video_decoder_config();
+  video_config.set_mime_type("video/mp4");
+  streams_[1]->set_video_decoder_config(video_config);
   bypass_bridge->SetStreams(streams_[0].get(), streams_[1].get());
 
   uint32_t bridge_id = 12345;

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -398,8 +398,13 @@ TEST_F(StarboardRendererWrapperTest, ProxyDemuxerStreamDelegation) {
       base::DoNothing());
   AddStream(DemuxerStream::AUDIO, false);
   AddStream(DemuxerStream::VIDEO, false);
-  streams_[0]->set_mime_type("audio/mp4");
-  streams_[1]->set_mime_type("video/mp4");
+  AudioDecoderConfig audio_config = streams_[0]->audio_decoder_config();
+  audio_config.set_mime_type("audio/mp4");
+  streams_[0]->set_audio_decoder_config(audio_config);
+
+  VideoDecoderConfig video_config = streams_[1]->video_decoder_config();
+  video_config.set_mime_type("video/mp4");
+  streams_[1]->set_video_decoder_config(video_config);
   bypass_bridge->SetStreams(streams_[0].get(), streams_[1].get());
 
   uint32_t bridge_id = 12345;
@@ -428,15 +433,14 @@ TEST_F(StarboardRendererWrapperTest, ProxyDemuxerStreamDelegation) {
 
   ASSERT_NE(captured_media_resource, nullptr);
 
-  // Verify delegation of mime_type() and EnableBitstreamConverter() through
-  // proxy streams.
+  // Verify delegation of EnableBitstreamConverter() through proxy streams.
   EXPECT_CALL(*streams_[0], EnableBitstreamConverter());
   EXPECT_CALL(*streams_[1], EnableBitstreamConverter());
 
   auto proxy_streams = captured_media_resource->GetAllStreams();
   ASSERT_EQ(proxy_streams.size(), 2u);
-  EXPECT_EQ(proxy_streams[0]->mime_type(), "audio/mp4");
-  EXPECT_EQ(proxy_streams[1]->mime_type(), "video/mp4");
+  EXPECT_EQ(proxy_streams[0]->audio_decoder_config().mime_type(), "audio/mp4");
+  EXPECT_EQ(proxy_streams[1]->video_decoder_config().mime_type(), "video/mp4");
   proxy_streams[0]->EnableBitstreamConverter();
   proxy_streams[1]->EnableBitstreamConverter();
 }

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -333,9 +333,8 @@ void SbPlayerBridge::UpdateAudioConfig(const AudioDecoderConfig& audio_config) {
             << audio_config.AsHumanReadableString();
 
   audio_config_ = audio_config;
-  audio_mime_type_ = audio_config.mime_type();
   audio_stream_info_ = MediaAudioConfigToSbMediaAudioStreamInfo(
-      audio_config_, audio_mime_type_.c_str());
+      audio_config_, audio_config_.mime_type().c_str());
   LOG(INFO) << "Converted to SbMediaAudioStreamInfo -- " << audio_stream_info_;
 }
 
@@ -347,7 +346,6 @@ void SbPlayerBridge::UpdateVideoConfig(const VideoDecoderConfig& video_config) {
             << video_config.AsHumanReadableString();
 
   video_config_ = video_config;
-  video_mime_type_ = video_config_.mime_type();
   video_stream_info_.frame_width =
       static_cast<int>(video_config_.natural_size().width());
   video_stream_info_.frame_height =
@@ -356,8 +354,8 @@ void SbPlayerBridge::UpdateVideoConfig(const VideoDecoderConfig& video_config) {
       MediaVideoCodecToSbMediaVideoCodec(video_config_.codec());
   video_stream_info_.color_metadata = MediaToSbMediaColorMetadata(
       video_config_.color_space_info(), video_config_.hdr_metadata(),
-      video_mime_type_);
-  video_stream_info_.mime = video_mime_type_.c_str();
+      video_config_.mime_type());
+  video_stream_info_.mime = video_config_.mime_type().c_str();
   video_stream_info_.max_video_capabilities = max_video_capabilities_.c_str();
   LOG(INFO) << "Converted to SbMediaVideoStreamInfo -- " << video_stream_info_;
 }

--- a/media/starboard/sbplayer_bridge.cc
+++ b/media/starboard/sbplayer_bridge.cc
@@ -219,9 +219,7 @@ SbPlayerBridge::SbPlayerBridge(
     const GetDecodeTargetGraphicsContextProviderFunc&
         get_decode_target_graphics_context_provider_func,
     const AudioDecoderConfig& audio_config,
-    const std::string& audio_mime_type,
     const VideoDecoderConfig& video_config,
-    const std::string& video_mime_type,
     SbWindow window,
     SbDrmSystem drm_system,
     Host* host,
@@ -291,10 +289,10 @@ SbPlayerBridge::SbPlayerBridge(
   video_stream_info_.codec = kSbMediaVideoCodecNone;
 
   if (audio_config.IsValidConfig()) {
-    UpdateAudioConfig(audio_config, audio_mime_type);
+    UpdateAudioConfig(audio_config);
   }
   if (video_config.IsValidConfig()) {
-    UpdateVideoConfig(video_config, video_mime_type);
+    UpdateVideoConfig(video_config);
     SendColorSpaceHistogram();
   }
 
@@ -327,8 +325,7 @@ SbPlayerBridge::~SbPlayerBridge() {
   }
 }
 
-void SbPlayerBridge::UpdateAudioConfig(const AudioDecoderConfig& audio_config,
-                                       const std::string& mime_type) {
+void SbPlayerBridge::UpdateAudioConfig(const AudioDecoderConfig& audio_config) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
   DCHECK(audio_config.IsValidConfig());
 
@@ -336,14 +333,13 @@ void SbPlayerBridge::UpdateAudioConfig(const AudioDecoderConfig& audio_config,
             << audio_config.AsHumanReadableString();
 
   audio_config_ = audio_config;
-  audio_mime_type_ = mime_type;
+  audio_mime_type_ = audio_config.mime_type();
   audio_stream_info_ = MediaAudioConfigToSbMediaAudioStreamInfo(
       audio_config_, audio_mime_type_.c_str());
   LOG(INFO) << "Converted to SbMediaAudioStreamInfo -- " << audio_stream_info_;
 }
 
-void SbPlayerBridge::UpdateVideoConfig(const VideoDecoderConfig& video_config,
-                                       const std::string& mime_type) {
+void SbPlayerBridge::UpdateVideoConfig(const VideoDecoderConfig& video_config) {
   DCHECK(task_runner_->RunsTasksInCurrentSequence());
   DCHECK(video_config.IsValidConfig());
 
@@ -351,16 +347,16 @@ void SbPlayerBridge::UpdateVideoConfig(const VideoDecoderConfig& video_config,
             << video_config.AsHumanReadableString();
 
   video_config_ = video_config;
+  video_mime_type_ = video_config_.mime_type();
   video_stream_info_.frame_width =
       static_cast<int>(video_config_.natural_size().width());
   video_stream_info_.frame_height =
       static_cast<int>(video_config_.natural_size().height());
   video_stream_info_.codec =
       MediaVideoCodecToSbMediaVideoCodec(video_config_.codec());
-  video_stream_info_.color_metadata =
-      MediaToSbMediaColorMetadata(video_config_.color_space_info(),
-                                  video_config_.hdr_metadata(), mime_type);
-  video_mime_type_ = mime_type;
+  video_stream_info_.color_metadata = MediaToSbMediaColorMetadata(
+      video_config_.color_space_info(), video_config_.hdr_metadata(),
+      video_mime_type_);
   video_stream_info_.mime = video_mime_type_.c_str();
   video_stream_info_.max_video_capabilities = max_video_capabilities_.c_str();
   LOG(INFO) << "Converted to SbMediaVideoStreamInfo -- " << video_stream_info_;

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -104,9 +104,7 @@ class SbPlayerBridge {
                  const GetDecodeTargetGraphicsContextProviderFunc&
                      get_decode_target_graphics_context_provider_func,
                  const AudioDecoderConfig& audio_config,
-                 const std::string& audio_mime_type,
                  const VideoDecoderConfig& video_config,
-                 const std::string& video_mime_type,
                  SbWindow window,
                  SbDrmSystem drm_system,
                  Host* host,
@@ -129,10 +127,8 @@ class SbPlayerBridge {
 
   bool IsValid() const { return SbPlayerIsValid(player_); }
 
-  void UpdateAudioConfig(const AudioDecoderConfig& audio_config,
-                         const std::string& mime_type);
-  void UpdateVideoConfig(const VideoDecoderConfig& video_config,
-                         const std::string& mime_type);
+  void UpdateAudioConfig(const AudioDecoderConfig& audio_config);
+  void UpdateVideoConfig(const VideoDecoderConfig& video_config);
 
   void WriteBuffers(DemuxerStream::Type type,
                     const std::vector<scoped_refptr<DecoderBuffer>>& buffers);

--- a/media/starboard/sbplayer_bridge.h
+++ b/media/starboard/sbplayer_bridge.h
@@ -348,10 +348,6 @@ class SbPlayerBridge {
   // Keep track of the output mode we are supposed to output to.
   SbPlayerOutputMode output_mode_;
 
-  // Keep copies of the mime type strings instead of using the ones in the
-  // DemuxerStreams to ensure that the strings are always valid.
-  std::string audio_mime_type_;
-  std::string video_mime_type_;
   // A string of video maximum capabilities.
   std::string max_video_capabilities_;
 

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -706,9 +706,9 @@ void StarboardRenderer::CreatePlayerBridge() {
                     : invalid_video_config;
 
   const std::string audio_mime_type =
-      audio_stream_ ? audio_stream_->mime_type() : "";
+      audio_stream_ ? audio_stream_->audio_decoder_config().mime_type() : "";
   const std::string video_mime_type =
-      video_stream_ ? video_stream_->mime_type() : "";
+      video_stream_ ? video_stream_->video_decoder_config().mime_type() : "";
 
   std::string error_message;
 
@@ -828,12 +828,14 @@ void StarboardRenderer::UpdateDecoderConfig(DemuxerStream* stream) {
 
   if (stream->type() == DemuxerStream::AUDIO) {
     const AudioDecoderConfig& decoder_config = stream->audio_decoder_config();
-    player_bridge_->UpdateAudioConfig(decoder_config, stream->mime_type());
+    player_bridge_->UpdateAudioConfig(decoder_config,
+                                      decoder_config.mime_type());
   } else {
     DCHECK_EQ(stream->type(), DemuxerStream::VIDEO);
     const VideoDecoderConfig& decoder_config = stream->video_decoder_config();
 
-    player_bridge_->UpdateVideoConfig(decoder_config, stream->mime_type());
+    player_bridge_->UpdateVideoConfig(decoder_config,
+                                      decoder_config.mime_type());
 
     // TODO(b/375275033): Refine natural size change handling.
 #if 0

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -705,11 +705,6 @@ void StarboardRenderer::CreatePlayerBridge() {
       video_stream_ ? video_stream_->video_decoder_config()
                     : invalid_video_config;
 
-  const std::string audio_mime_type =
-      audio_stream_ ? audio_stream_->audio_decoder_config().mime_type() : "";
-  const std::string video_mime_type =
-      video_stream_ ? video_stream_->video_decoder_config().mime_type() : "";
-
   std::string error_message;
 
   DCHECK(!player_bridge_);
@@ -737,7 +732,7 @@ void StarboardRenderer::CreatePlayerBridge() {
     player_bridge_.reset(new SbPlayerBridge(
         GetSbPlayerInterface(), task_runner_,
         get_decode_target_graphics_context_provider_func_, audio_config,
-        audio_mime_type, video_config, video_mime_type,
+        video_config,
         // TODO(b/326497953): Support suspend/resume.
         // TODO(b/326508279): Support background mode.
         sb_window_, drm_system_, this,
@@ -828,14 +823,12 @@ void StarboardRenderer::UpdateDecoderConfig(DemuxerStream* stream) {
 
   if (stream->type() == DemuxerStream::AUDIO) {
     const AudioDecoderConfig& decoder_config = stream->audio_decoder_config();
-    player_bridge_->UpdateAudioConfig(decoder_config,
-                                      decoder_config.mime_type());
+    player_bridge_->UpdateAudioConfig(decoder_config);
   } else {
     DCHECK_EQ(stream->type(), DemuxerStream::VIDEO);
     const VideoDecoderConfig& decoder_config = stream->video_decoder_config();
 
-    player_bridge_->UpdateVideoConfig(decoder_config,
-                                      decoder_config.mime_type());
+    player_bridge_->UpdateVideoConfig(decoder_config);
 
     // TODO(b/375275033): Refine natural size change handling.
 #if 0


### PR DESCRIPTION
Refactor Starboard media MIME type storage from stream-level properties
(ChunkDemuxerStream / DemuxerStream) to configuration-level properties
on AudioDecoderConfig and VideoDecoderConfig.

This change is made in response to how MediaSource.changeType() operates.
During changeType(), format transitions (e.g., switching from H.264 "video/mp4"
to VP9 "video/webm") generate new AudioDecoderConfig and VideoDecoderConfig
instances for each stream segment. Storing mime_type on DemuxerStream caused
stream-level state to desynchronize from sample buffers and decoder configurations
during codec transitions. Moving mime_type onto AudioDecoderConfig and
VideoDecoderConfig binds container MIME strings directly to elementary codec
parameters, ensuring container details remain strictly synchronized with decoder
configurations across Mojo IPC and renderer bridges.

Key changes:
- AudioDecoderConfig & VideoDecoderConfig: Added `mime_type` fields, getters, setters,
  and updated Matches() and AsHumanReadableString() to use `mime_type` as well.
- Mojo IPC & Mojom: Added `mime_type` to Mojom decoder configs and simplified
  demuxer_stream.mojom by removing the redundant 5th `mime_type` parameter.
- ChunkDemuxer & SourceBufferState: Updated SourceBufferState to stamp `mime_type`
  onto configs in OnNewConfigs(), and hardened ChunkDemuxer map lookups.
- Starboard Renderer & SbPlayerBridge: Updated StarboardRenderer and SbPlayerBridge
  to read `mime_type` from configs and removed obsolete constructor string parameters.
- DemuxerStream & IPC Adapters: Removed legacy `mime_type()` stream getters, dead IPC
  fields, and obsolete GetMimeType() helpers from Mojo bypass bridges.

Bug: 543919264
