### PR TITLE
media: Support secondary DRM L1 video

### DIFF
--- a/cobalt/testing/filters/android-arm/starboard_platform_tests_filter.json
+++ b/cobalt/testing/filters/android-arm/starboard_platform_tests_filter.json
@@ -5,6 +5,6 @@
     "MimeUtilTest.ChecksSupportedMp3Containers",
     "MimeUtilTest.ChecksSupportedPcmContainers",
     "SbPlayerGetPreferredOutputModeTest.SecuredDrmRequiresPunchOut",
-    "SbPlayerGetPreferredOutputModeTest.SecuredDrmWithDecodeToTextureIsInvalid"
+    "SbPlayerGetPreferredOutputModeTest.SecuredDrmForSecondaryPlayerRequiresPunchOut"
   ]
 }

--- a/cobalt/testing/filters/android-arm64/starboard_platform_tests_filter.json
+++ b/cobalt/testing/filters/android-arm64/starboard_platform_tests_filter.json
@@ -5,6 +5,6 @@
     "MimeUtilTest.ChecksSupportedMp3Containers",
     "MimeUtilTest.ChecksSupportedPcmContainers",
     "SbPlayerGetPreferredOutputModeTest.SecuredDrmRequiresPunchOut",
-    "SbPlayerGetPreferredOutputModeTest.SecuredDrmWithDecodeToTextureIsInvalid"
+    "SbPlayerGetPreferredOutputModeTest.SecuredDrmForSecondaryPlayerRequiresPunchOut"
   ]
 }

--- a/media/base/cdm_context.cc
+++ b/media/base/cdm_context.cc
@@ -51,6 +51,10 @@ MediaCryptoContext* CdmContext::GetMediaCryptoContext() {
 SbDrmSystem CdmContext::GetSbDrmSystem() {
   return kSbDrmSystemInvalid;
 }
+
+std::optional<std::string> CdmContext::GetKeySystem() const {
+  return std::nullopt;
+}
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 

--- a/media/base/cdm_context.h
+++ b/media/base/cdm_context.h
@@ -118,6 +118,7 @@ class MEDIA_EXPORT CdmContext {
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
   virtual SbDrmSystem GetSbDrmSystem();
+  virtual std::optional<std::string> GetKeySystem() const;
 #endif // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 #if BUILDFLAG(IS_FUCHSIA)

--- a/media/starboard/starboard_cdm.cc
+++ b/media/starboard/starboard_cdm.cc
@@ -94,6 +94,9 @@ StarboardCdm::StarboardCdm(
     const SessionKeysChangeCB& keys_change_cb,
     const SessionExpirationUpdateCB& expiration_update_cb)
     : task_runner_(base::SequencedTaskRunner::GetCurrentDefault()),
+      key_system_(cdm_config.key_system.empty()
+                      ? std::nullopt
+                      : std::make_optional(cdm_config.key_system)),
       sb_drm_(SbDrmCreateSystem(cdm_config.key_system.c_str(),
                                 this,
                                 OnSessionUpdateRequestGeneratedFunc,
@@ -274,6 +277,10 @@ CdmContext* StarboardCdm::GetCdmContext() {
 
 SbDrmSystem StarboardCdm::GetSbDrmSystem() {
   return sb_drm_;
+}
+
+std::optional<std::string> StarboardCdm::GetKeySystem() const {
+  return key_system_;
 }
 
 bool StarboardCdm::HasValidSbDrm() {

--- a/media/starboard/starboard_cdm.h
+++ b/media/starboard/starboard_cdm.h
@@ -76,6 +76,7 @@ class MEDIA_EXPORT StarboardCdm : public ContentDecryptionModule,
       EventCB event_cb) override;
 
   SbDrmSystem GetSbDrmSystem() override;
+  std::optional<std::string> GetKeySystem() const override;
 
   bool HasValidSbDrm();
 
@@ -172,6 +173,7 @@ class MEDIA_EXPORT StarboardCdm : public ContentDecryptionModule,
 
   // Default task runner.
   scoped_refptr<base::SequencedTaskRunner> const task_runner_;
+  const std::optional<std::string> key_system_;
   const SbDrmSystem sb_drm_;
   SessionMessageCB message_cb_;
   SessionClosedCB closed_cb_;

--- a/media/starboard/starboard_renderer.cc
+++ b/media/starboard/starboard_renderer.cc
@@ -270,20 +270,18 @@ void StarboardRenderer::Initialize(MediaResource* media_resource,
   state_ = STATE_INITIALIZING;
 
 #if BUILDFLAG(IS_ANDROID)
-  if (base::FeatureList::IsEnabled(media::kCobaltUsingAndroidOverlay)) {
+  if (base::FeatureList::IsEnabled(media::kCobaltUsingAndroidOverlay) ||
+      IsSecondaryVideoProtected()) {
+    CHECK(request_overlay_info_cb_);
+    CHECK(android_overlay_factory_cb_);
     // RequestOverlayInfoCB and create AndroidOverlay if the BASE feature is
-    // enabled.
-    if (request_overlay_info_cb_ && android_overlay_factory_cb_) {
-      LOG(INFO) << "Requesting AndroidOverlay for Video SurfaceView.";
-      // Set |restart_for_transitions| to false due to devices are
-      // isSetOutputSurfaceSupported() in
-      // media/base/android/java/src/org/chromium/media/MediaCodecUtil.java.
-      request_overlay_info_cb_.Run(/*restart_for_transitions=*/false);
-      return;
-    }
-    // When CobaltUsingAndroidOverlay is enabled, both request_overlay_info_cb_
-    // and android_overlay_factory_cb_ should not be null.
-    NOTREACHED();
+    // enabled or if secondary video requires DRM (L1).
+    // Set |restart_for_transitions| to false due to devices are
+    // isSetOutputSurfaceSupported() in
+    // media/base/android/java/src/org/chromium/media/MediaCodecUtil.java.
+    LOG(INFO) << "Requesting AndroidOverlay for Video SurfaceView.";
+    request_overlay_info_cb_.Run(/*restart_for_transitions=*/false);
+    return;
   }
 #endif  // BUILDFLAG(IS_ANDROID)
 
@@ -319,6 +317,27 @@ void StarboardRenderer::SetCdm(CdmContext* cdm_context,
 
   DCHECK(init_cb_);
   state_ = STATE_INITIALIZING;
+
+#if BUILDFLAG(IS_ANDROID)
+  if (base::FeatureList::IsEnabled(media::kCobaltUsingAndroidOverlay) ||
+      IsSecondaryVideoProtected()) {
+    CHECK(request_overlay_info_cb_);
+    CHECK(android_overlay_factory_cb_);
+    // RequestOverlayInfoCB and create AndroidOverlay if the BASE feature is
+    // enabled or if secondary video requires DRM (L1).
+    LOG(INFO)
+        << "Requesting AndroidOverlay for Video SurfaceView after CDM set.";
+    request_overlay_info_cb_.Run(/*restart_for_transitions=*/false);
+    return;
+  }
+#endif  // BUILDFLAG(IS_ANDROID)
+
+  if (get_sb_window_handle_cb_) {
+    // Get SbWindow from CobaltRenderContentClient.
+    get_sb_window_handle_cb_.Run();
+    return;
+  }
+
   CreatePlayerBridge();
 }
 
@@ -1168,6 +1187,14 @@ void StarboardRenderer::OnOverlayFailed(AndroidOverlay* overlay) {
         "StarboardRenderer::OnOverlayFailed() failed to create a "
         "valid AndroidOverlay"));
   }
+}
+
+bool StarboardRenderer::IsSecondaryVideoProtected() const {
+  if (max_video_capabilities_.empty() || !cdm_context_) {
+    return false;
+  }
+  const auto key_system = cdm_context_->GetKeySystem();
+  return key_system == "com.widevine" || key_system == "com.widevine.alpha";
 }
 #endif  // BUILDFLAG(IS_ANDROID)
 

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -194,6 +194,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   // AndroidOverlay callbacks.
   void OnOverlayReady(AndroidOverlay*);
   void OnOverlayFailed(AndroidOverlay*);
+  bool IsSecondaryVideoProtected() const;
 #endif  // BUILDFLAG(IS_ANDROID)
 
   int GetDefaultMaxBuffers(AudioCodec codec,

--- a/starboard/android/shared/player_get_preferred_output_mode.cc
+++ b/starboard/android/shared/player_get_preferred_output_mode.cc
@@ -68,17 +68,24 @@ SbPlayerOutputMode SbPlayerGetPreferredOutputMode(
   }
 
   if (max_video_capabilities && strlen(max_video_capabilities) > 0) {
-    // Sub players must use "decode-to-texture" on Android.
-    // Since hdr videos are not supported under "decode-to-texture" mode, reject
-    // it for sub players.
+    if (!is_sdr) {
+      SB_LOG(INFO)
+          << "Returning kSbPlayerOutputModeInvalid as HDR videos are not "
+             "supported for secondary player.";
+      return kSbPlayerOutputModeInvalid;
+    }
+    // Sub players prefer "decode-to-texture" on Android.
+    // If decode-to-texture is supported, use decode-to-texture.
     if (PlayerComponents::Factory::OutputModeSupported(
-            kSbPlayerOutputModeDecodeToTexture, codec, drm_system) &&
-        is_sdr) {
+            kSbPlayerOutputModeDecodeToTexture, codec, drm_system)) {
       return kSbPlayerOutputModeDecodeToTexture;
     }
-    SB_LOG_IF(INFO, !is_sdr)
-        << "Returning kSbPlayerOutputModeInvalid as HDR videos are not "
-           "supported under decode-to-texture.";
+    // Fall back to punch-out mode if supported (e.g., for Widevine L1 DRM).
+    if (PlayerComponents::Factory::OutputModeSupported(
+            kSbPlayerOutputModePunchOut, codec, drm_system)) {
+      SB_LOG(INFO) << "Falling back to punch out mode";
+      return kSbPlayerOutputModePunchOut;
+    }
     return kSbPlayerOutputModeInvalid;
   }
 

--- a/starboard/android/shared/player_get_preferred_output_mode_test.cc
+++ b/starboard/android/shared/player_get_preferred_output_mode_test.cc
@@ -120,7 +120,7 @@ TEST(SbPlayerGetPreferredOutputModeTest, SecuredDrmRequiresPunchOut) {
 }
 
 TEST(SbPlayerGetPreferredOutputModeTest,
-     SecuredDrmWithDecodeToTextureIsInvalid) {
+     SecuredDrmForSecondaryPlayerRequiresPunchOut) {
   SbPlayerCreationParam creation_param = GetSdrPlaybackParam();
 
   SbDrmSystem drm_system = CreateDummyDrmSystem("com.widevine");
@@ -132,11 +132,11 @@ TEST(SbPlayerGetPreferredOutputModeTest,
 
   creation_param.output_mode = kSbPlayerOutputModePunchOut;
   auto preferred_output_mode = SbPlayerGetPreferredOutputMode(&creation_param);
-  EXPECT_EQ(preferred_output_mode, kSbPlayerOutputModeInvalid);
+  EXPECT_EQ(preferred_output_mode, kSbPlayerOutputModePunchOut);
 
   creation_param.output_mode = kSbPlayerOutputModeDecodeToTexture;
   preferred_output_mode = SbPlayerGetPreferredOutputMode(&creation_param);
-  EXPECT_EQ(preferred_output_mode, kSbPlayerOutputModeInvalid);
+  EXPECT_EQ(preferred_output_mode, kSbPlayerOutputModePunchOut);
 
   SbDrmDestroySystem(drm_system);
 }


### PR DESCRIPTION
Enable DRM L1 support for secondary video players by exposing the
key system through CdmContext. This allows StarboardRenderer to
identify Widevine usage and request the necessary AndroidOverlay for
secure playback. The Android player logic is also updated to allow
secondary players to use punch-out mode as a fallback when
decode-to-texture is unavailable or incompatible with DRM
requirements.

Issue: 441085937
Issue: 543600365