### PR TITLE
Implement HangWatcher UUID tracking and NSE recovery reporting

### DIFF
--- a/base/threading/hang_watcher.cc
+++ b/base/threading/hang_watcher.cc
@@ -29,12 +29,14 @@
 #include "base/time/default_tick_clock.h"
 #include "base/time/time.h"
 #include "base/trace_event/base_tracing.h"
+#include "base/uuid.h"
 #include "build/build_config.h"
 
 #if BUILDFLAG(IS_STARBOARD)
 #include <inttypes.h>
 
 #include "starboard/extension/crash_handler.h"
+#include "starboard/extension/native_stability.h"
 #include "starboard/system.h"
 #endif
 
@@ -607,6 +609,9 @@ void HangWatcher::InitializeOnMainThread(ProcessType process_type,
 }
 
 void HangWatcher::UninitializeOnMainThreadForTesting() {
+#if BUILDFLAG(IS_COBALT)
+  g_hang_reporting_enabled.store(true, std::memory_order_relaxed);
+#endif
   g_use_hang_watcher.store(false, std::memory_order_relaxed);
   g_threadpool_log_level.store(LoggingLevel::kNone, std::memory_order_relaxed);
   g_io_thread_log_level.store(LoggingLevel::kNone, std::memory_order_relaxed);
@@ -897,7 +902,14 @@ void HangWatcher::Run() {
 #endif
     Wait();
 
-    if (!IsWatchListEmpty() &&
+    bool has_work = !IsWatchListEmpty();
+#if BUILDFLAG(IS_COBALT)
+    // If the watch list is empty but we have an active hang UUID, we still
+    // have work to do (cleaning up the recovery state).
+    has_work = has_work || !active_hang_uuid_.empty();
+#endif
+
+    if (has_work &&
         g_keep_monitoring.load(std::memory_order_relaxed)) {
       Monitor();
       if (after_monitor_closure_for_testing_) {
@@ -1157,6 +1169,83 @@ HangWatcher::WatchStateSnapShot HangWatcher::GrabWatchStateSnapshotForTesting()
   return snapshot;
 }
 
+#if BUILDFLAG(IS_COBALT)
+void HangWatcher::RecordHangStarted() {
+  DCHECK_CALLED_ON_VALID_THREAD(hang_watcher_thread_checker_);
+  if (!g_hang_reporting_enabled.load(std::memory_order_relaxed)) {
+    return;
+  }
+  if (!active_hang_uuid_.empty()) {
+    return;
+  }
+
+  active_hang_uuid_ = base::Uuid::GenerateRandomV4().AsLowercaseString();
+  std::string uuid_to_report = active_hang_uuid_;
+
+  {
+    base::AutoUnlock auto_unlock(watch_state_lock_);
+    auto* delegate = g_hang_watcher_delegate.load(std::memory_order_acquire);
+    if (delegate) {
+      delegate->RecordHangStarted(uuid_to_report);
+    }
+  }
+
+#if BUILDFLAG(IS_STARBOARD)
+  auto* crash_ext = static_cast<const CobaltExtensionCrashHandlerApi*>(
+      SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
+  if (crash_ext && crash_ext->version >= 2 && crash_ext->SetString) {
+    crash_ext->SetString(kNativeStabilityHangUuidKey, uuid_to_report.c_str());
+  }
+#endif
+}
+
+void HangWatcher::CheckAndRecordHangRecovered() {
+  DCHECK_CALLED_ON_VALID_THREAD(hang_watcher_thread_checker_);
+
+  if (active_hang_uuid_.empty()) {
+    return;
+  }
+
+  bool any_thread_hung = false;
+  base::TimeTicks now = base::TimeTicks::Now();
+
+  // We iterate over the watch states to determine if ANY thread is currently
+  // physically hung. Note: We are ALREADY inside HangWatcher::Monitor(), so
+  // watch_state_lock_ is currently held by the caller. We do not need to
+  // acquire or release it here for the iteration.
+  for (const auto& watch_state : watch_states_) {
+    if (watch_state->GetDeadline() <= now) {
+      any_thread_hung = true;
+      break;
+    }
+  }
+
+  if (!any_thread_hung) {
+    std::string uuid_to_report = active_hang_uuid_;
+    active_hang_uuid_.clear();
+
+    {
+      // Unlock before calling out to the delegate to prevent deadlocks with
+      // embedder code.
+      base::AutoUnlock auto_unlock(watch_state_lock_);
+
+      auto* delegate = g_hang_watcher_delegate.load(std::memory_order_acquire);
+      if (delegate) {
+        delegate->RecordHangRecovered(uuid_to_report);
+      }
+    }
+
+#if BUILDFLAG(IS_STARBOARD)
+    auto* crash_ext = static_cast<const CobaltExtensionCrashHandlerApi*>(
+        SbSystemGetExtension(kCobaltExtensionCrashHandlerName));
+    if (crash_ext && crash_ext->version >= 2 && crash_ext->SetString) {
+      crash_ext->SetString(kNativeStabilityHangUuidKey, "");
+    }
+#endif
+  }
+}
+#endif
+
 void HangWatcher::Monitor() {
   DCHECK_CALLED_ON_VALID_THREAD(hang_watcher_thread_checker_);
 
@@ -1172,6 +1261,9 @@ void HangWatcher::Monitor() {
   // If all threads unregistered since this function was invoked there's
   // nothing to do anymore.
   if (watch_states_.empty()) {
+#if BUILDFLAG(IS_COBALT)
+    CheckAndRecordHangRecovered();
+#endif
     return;
   }
 
@@ -1180,6 +1272,10 @@ void HangWatcher::Monitor() {
 
   if (watch_state_snapshot_.IsActionable()) {
     DoDumpWithoutCrashing(watch_state_snapshot_);
+  } else {
+#if BUILDFLAG(IS_COBALT)
+    CheckAndRecordHangRecovered();
+#endif
   }
 
   watch_state_snapshot_.Clear();
@@ -1304,6 +1400,9 @@ void HangWatcher::DoDumpWithoutCrashing(
   base::TimeTicks latest_expired_deadline =
       watch_state_snapshot.GetHighestDeadline();
 
+#if BUILDFLAG(IS_COBALT)
+  RecordHangStarted();
+#endif
   if (on_hang_closure_for_testing_) {
     on_hang_closure_for_testing_.Run();
   } else {

--- a/base/threading/hang_watcher.h
+++ b/base/threading/hang_watcher.h
@@ -144,6 +144,8 @@ class BASE_EXPORT HangWatcher : public DelegateSimpleThread::Delegate {
   class BASE_EXPORT Delegate {
    public:
     virtual ~Delegate() = default;
+    virtual void RecordHangStarted(const std::string& hang_uuid) {}
+    virtual void RecordHangRecovered(const std::string& hang_uuid) {}
     // Returns true if hang reporting should be enabled
     // potentially overriding default settings.
     virtual bool IsHangReportingEnabled() = 0;
@@ -396,6 +398,19 @@ class BASE_EXPORT HangWatcher : public DelegateSimpleThread::Delegate {
   // invokes the appropriate closure if so.
   void Monitor() LOCKS_EXCLUDED(watch_state_lock_);
 
+#if BUILDFLAG(IS_COBALT)
+  // Checks if any previously hung threads have recovered. If all threads have
+  // resumed, it notifies the delegate and clears the active hang UUID.
+  void CheckAndRecordHangRecovered()
+      EXCLUSIVE_LOCKS_REQUIRED(watch_state_lock_);
+
+  // Generates a new UUID, saves it as the active hang UUID, and notifies the
+  // delegate and Crashpad that a new hang incident has begun.
+  // NOTE: RecordHang() is the upstream Chromium method that simply triggers
+  // DumpWithoutCrashing(). RecordHangStarted() is Cobalt-specific for NSE.
+  void RecordHangStarted() EXCLUSIVE_LOCKS_REQUIRED(watch_state_lock_);
+#endif
+
   // Record the hang crash dump and perform the necessary housekeeping before
   // and after.
   void DoDumpWithoutCrashing(const WatchStateSnapShot& watch_state_snapshot)
@@ -431,6 +446,15 @@ class BASE_EXPORT HangWatcher : public DelegateSimpleThread::Delegate {
   // Snapshot to be reused across hang captures. The point of keeping it
   // around is reducing allocations during capture.
   WatchStateSnapShot watch_state_snapshot_
+      GUARDED_BY_CONTEXT(hang_watcher_thread_checker_);
+
+  // Communicates the unique hang identifier from RecordHangStarted() to a
+  // subsequent execution of CheckAndRecordHangRecovered().
+  // NOTE: Even if multiple threads hang simultaneously (or in an overlapping
+  // cascade), they all share this single UUID. The UUID is only cleared when
+  // *all* threads recover. This prevents extreme deadlocks from overflowing
+  // Crashpad's annotation limits and NSE events overreporting.
+  std::string active_hang_uuid_
       GUARDED_BY_CONTEXT(hang_watcher_thread_checker_);
 
   base::DelegateSimpleThread thread_;

--- a/base/threading/hang_watcher_unittest.cc
+++ b/base/threading/hang_watcher_unittest.cc
@@ -1171,6 +1171,387 @@ TEST_F(WatchHangsInScopeBlockingTest, MAYBE_NewScopeDoesNotBlockDuringCapture) {
   continue_capture_.Signal();
 }
 
+#if BUILDFLAG(IS_COBALT)
+class MockHangWatcherDelegate : public HangWatcher::Delegate {
+ public:
+  MOCK_METHOD(bool, IsHangReportingEnabled, (), (override));
+  MOCK_METHOD(void, RecordHangStarted, (const std::string&), (override));
+  MOCK_METHOD(void, RecordHangRecovered, (const std::string&), (override));
+  MOCK_METHOD(std::optional<base::TimeDelta>, GetHangWatchTime, (), (override));
+  MOCK_METHOD(std::optional<base::TimeDelta>,
+              GetHangWatchMonitoringPeriod,
+              (),
+              (override));
+  MOCK_METHOD(std::optional<bool>,
+              IsThreadDumpingEnabled,
+              (base::HangWatcher::ThreadType),
+              (override));
+};
+
+class HangWatcherCobaltTest : public testing::Test {
+ public:
+  const base::TimeDelta kTimeout = base::Seconds(10);
+  const base::TimeDelta kHangTime = kTimeout + base::Seconds(1);
+
+  HangWatcherCobaltTest() {
+    feature_list_.InitWithFeaturesAndParameters(kFeatureAndParams, {});
+    HangWatcher::InitializeOnMainThread(
+        HangWatcher::ProcessType::kBrowserProcess, /*emit_crashes=*/true);
+  }
+
+  void StartHangWatcher(MockHangWatcherDelegate* mock_delegate) {
+    HangWatcher::SetDelegate(mock_delegate);
+    hang_watcher_ = std::make_unique<HangWatcher>();
+    hang_watcher_->SetAfterMonitorClosureForTesting(base::BindRepeating(
+        &WaitableEvent::Signal, base::Unretained(&monitor_event_)));
+    hang_watcher_->SetMonitoringPeriodForTesting(kVeryLongDelta);
+    hang_watcher_->Start();
+  }
+
+  void TearDown() override {
+    hang_watcher_.reset();
+    HangWatcher::SetDelegate(nullptr);
+    HangWatcher::UninitializeOnMainThreadForTesting();
+  }
+
+  void SetDefaultDelegateExpectations(MockHangWatcherDelegate& mock_delegate,
+                                      bool reporting_enabled = true) {
+    EXPECT_CALL(mock_delegate, IsHangReportingEnabled())
+        .WillRepeatedly(testing::Return(reporting_enabled));
+    EXPECT_CALL(mock_delegate, GetHangWatchTime())
+        .WillRepeatedly(testing::Return(std::nullopt));
+    EXPECT_CALL(mock_delegate, GetHangWatchMonitoringPeriod())
+        .WillRepeatedly(testing::Return(std::nullopt));
+    EXPECT_CALL(mock_delegate, IsThreadDumpingEnabled(testing::_))
+        .WillRepeatedly(testing::Return(std::nullopt));
+  }
+
+  void TriggerMonitorAndWait() {
+    hang_watcher_->SignalMonitorEventForTesting();
+    monitor_event_.Wait();
+    monitor_event_.Reset();
+  }
+
+ protected:
+  WaitableEvent monitor_event_;
+  base::test::ScopedFeatureList feature_list_;
+  test::SingleThreadTaskEnvironment task_environment_{
+      test::TaskEnvironment::TimeSource::MOCK_TIME};
+  std::unique_ptr<HangWatcher> hang_watcher_;
+};
+
+// Scenario: Single Thread Hang
+// 1. Main thread registers.
+// 2. Main thread hangs.
+// 3. Monitor generates a single UUID and calls RecordHangStarted.
+// 4. Main thread recovers (scope is destroyed).
+// 5. Monitor sees 0 hung threads, calls RecordHangRecovered with the same UUID.
+TEST_F(HangWatcherCobaltTest, NseHangUuidTracking) {
+  testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
+  StartHangWatcher(&mock_delegate);
+
+  SetDefaultDelegateExpectations(mock_delegate);
+
+  std::string captured_uuid;
+  EXPECT_CALL(mock_delegate, RecordHangStarted(testing::_))
+      .WillOnce(testing::SaveArg<0>(&captured_uuid));
+
+  hang_watcher_->SetOnHangClosureForTesting(base::BindRepeating([] {}));
+
+  auto unregister_thread_closure =
+      HangWatcher::RegisterThread(base::HangWatcher::ThreadType::kMainThread);
+
+  {
+    // Advance time so that the deadline is > 0 (TimeTicks()).
+    task_environment_.FastForwardBy(base::Seconds(1));
+    WatchHangsInScope expires_instantly(base::TimeDelta{});
+    task_environment_.FastForwardBy(kHangTime);
+
+    TriggerMonitorAndWait();
+
+    // Hang is detected and RecordHangStarted is called on the mock delegate.
+    ASSERT_FALSE(captured_uuid.empty());
+
+    // Verify persistent hang: Another monitor event should NOT trigger
+    // RecordHangRecovered or RecordHangStarted again while the thread is still
+    // stuck.
+    EXPECT_CALL(mock_delegate, RecordHangRecovered(testing::_)).Times(0);
+    TriggerMonitorAndWait();
+    testing::Mock::VerifyAndClearExpectations(&mock_delegate);
+
+    // Re-apply repeated expectations because VerifyAndClearExpectations()
+    // cleared them
+    EXPECT_CALL(mock_delegate, IsHangReportingEnabled())
+        .WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(mock_delegate, GetHangWatchTime())
+        .WillRepeatedly(testing::Return(std::nullopt));
+    EXPECT_CALL(mock_delegate, GetHangWatchMonitoringPeriod())
+        .WillRepeatedly(testing::Return(std::nullopt));
+    EXPECT_CALL(mock_delegate, IsThreadDumpingEnabled(testing::_))
+        .WillRepeatedly(testing::Return(std::nullopt));
+
+    // Now expect the recovery when the scope is destroyed.
+    EXPECT_CALL(mock_delegate, RecordHangRecovered(captured_uuid)).Times(1);
+  }
+
+  // The scope is destroyed, so the hang is recovered.
+  // Trigger another monitor loop.
+  TriggerMonitorAndWait();
+}
+
+// Scenario: Simultaneous Concurrent Hangs
+// 1. Thread A and Thread B both hang at the exact same time.
+// 2. Monitor detects both in a single snapshot, generates ONE UUID, and calls
+// RecordHangStarted.
+// 3. Thread A recovers. Thread B is still hung.
+// 4. Monitor fires again. RecordHangRecovered is NOT called because Thread B is
+// still stuck.
+// 5. Thread B recovers.
+// 6. Monitor sees 0 hung threads, calls RecordHangRecovered with the original
+// UUID.
+TEST_F(HangWatcherCobaltTest, MultipleHangsSingleUuid) {
+  testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
+  StartHangWatcher(&mock_delegate);
+
+  SetDefaultDelegateExpectations(mock_delegate);
+
+  std::string captured_uuid;
+  EXPECT_CALL(mock_delegate, RecordHangStarted(testing::_))
+      .WillOnce(testing::SaveArg<0>(&captured_uuid));
+
+  hang_watcher_->SetOnHangClosureForTesting(base::BindRepeating([] {}));
+
+  auto unregister_thread_closure =
+      HangWatcher::RegisterThread(base::HangWatcher::ThreadType::kMainThread);
+
+  base::WaitableEvent unblock_thread_1;
+  base::WaitableEvent unblock_thread_2;
+  BlockingThread thread_1(&unblock_thread_1, kTimeout);
+  BlockingThread thread_2(&unblock_thread_2, kTimeout);
+
+  thread_1.StartAndWaitForScopeEntered();
+  thread_2.StartAndWaitForScopeEntered();
+
+  // Reset monitor event because thread registration triggers Monitor().
+  monitor_event_.Reset();
+
+  {
+    // Fast forward past the timeout threshold.
+    task_environment_.FastForwardBy(kHangTime);
+
+    // Trigger monitor event. Both threads are hung. RecordHangStarted should be
+    // called exactly once.
+    TriggerMonitorAndWait();
+
+    ASSERT_FALSE(captured_uuid.empty());
+
+    // Recover thread_1.
+    unblock_thread_1.Signal();
+    thread_1.Join();
+
+    // Trigger monitor event again. thread_2 is still hung, so no recovery
+    // should be signaled yet.
+    EXPECT_CALL(mock_delegate, RecordHangRecovered(testing::_)).Times(0);
+    TriggerMonitorAndWait();
+    testing::Mock::VerifyAndClearExpectations(&mock_delegate);
+
+    // Re-apply expectations
+    EXPECT_CALL(mock_delegate, IsHangReportingEnabled())
+        .WillRepeatedly(testing::Return(true));
+    EXPECT_CALL(mock_delegate, GetHangWatchTime())
+        .WillRepeatedly(testing::Return(std::nullopt));
+    EXPECT_CALL(mock_delegate, GetHangWatchMonitoringPeriod())
+        .WillRepeatedly(testing::Return(std::nullopt));
+    EXPECT_CALL(mock_delegate, IsThreadDumpingEnabled(testing::_))
+        .WillRepeatedly(testing::Return(std::nullopt));
+
+    // Recover thread_2. This is the last hung thread.
+    EXPECT_CALL(mock_delegate, RecordHangRecovered(captured_uuid)).Times(1);
+    unblock_thread_2.Signal();
+    thread_2.Join();
+
+    TriggerMonitorAndWait();
+  }
+}
+
+TEST_F(HangWatcherCobaltTest, ReportingDisabledNoEvents) {
+  testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
+  StartHangWatcher(&mock_delegate);
+
+  // Explicitly disable reporting.
+  SetDefaultDelegateExpectations(mock_delegate, false);
+  HangWatcher::UpdateConfiguration();
+
+  // Assert that these are never called.
+  EXPECT_CALL(mock_delegate, RecordHangStarted(testing::_)).Times(0);
+  EXPECT_CALL(mock_delegate, RecordHangRecovered(testing::_)).Times(0);
+
+  hang_watcher_->SetOnHangClosureForTesting(base::BindRepeating([] {}));
+
+  auto unregister_thread_closure =
+      HangWatcher::RegisterThread(base::HangWatcher::ThreadType::kMainThread);
+
+  {
+    // Induce a hang.
+    task_environment_.FastForwardBy(base::Seconds(1));
+    WatchHangsInScope expires_instantly(base::TimeDelta{});
+    task_environment_.FastForwardBy(kHangTime);
+
+    TriggerMonitorAndWait();
+  }
+
+  // Scope destroyed, hang recovers.
+  TriggerMonitorAndWait();
+}
+
+// Scenario: Sequential Distinct Hangs
+// 1. Thread A hangs. Monitor generates UUID #1 and calls RecordHangStarted.
+// 2. Thread A recovers. Monitor calls RecordHangRecovered(UUID #1).
+// 3. Time passes. System is healthy.
+// 4. Thread B (or Thread A again) hangs. Monitor generates UUID #2 and calls
+// RecordHangStarted.
+// 5. Thread B recovers. Monitor calls RecordHangRecovered(UUID #2).
+// 6. Asserts that UUID #1 and UUID #2 are strictly different.
+TEST_F(HangWatcherCobaltTest, SequentialDistinctHangs) {
+  testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
+  StartHangWatcher(&mock_delegate);
+
+  SetDefaultDelegateExpectations(mock_delegate);
+
+  std::string first_uuid;
+  std::string second_uuid;
+
+  EXPECT_CALL(mock_delegate, RecordHangStarted(testing::_))
+      .WillOnce(testing::SaveArg<0>(&first_uuid));
+
+  hang_watcher_->SetOnHangClosureForTesting(base::BindRepeating([] {}));
+
+  auto unregister_thread_closure =
+      HangWatcher::RegisterThread(base::HangWatcher::ThreadType::kMainThread);
+
+  // --- First Hang ---
+  {
+    task_environment_.FastForwardBy(base::Seconds(1));
+    WatchHangsInScope expires_instantly(base::TimeDelta{});
+    task_environment_.FastForwardBy(kHangTime);
+
+    TriggerMonitorAndWait();
+
+    EXPECT_CALL(mock_delegate, RecordHangRecovered(testing::_)).Times(1);
+  }
+
+  TriggerMonitorAndWait();
+  testing::Mock::VerifyAndClearExpectations(&mock_delegate);
+
+  // --- Second Hang ---
+  SetDefaultDelegateExpectations(mock_delegate);
+  EXPECT_CALL(mock_delegate, RecordHangStarted(testing::_))
+      .WillOnce(testing::SaveArg<0>(&second_uuid));
+
+  {
+    task_environment_.FastForwardBy(base::Seconds(1));
+    WatchHangsInScope expires_instantly(base::TimeDelta{});
+    task_environment_.FastForwardBy(kHangTime);
+
+    TriggerMonitorAndWait();
+
+    EXPECT_CALL(mock_delegate, RecordHangRecovered(testing::_)).Times(1);
+  }
+
+  TriggerMonitorAndWait();
+  testing::Mock::VerifyAndClearExpectations(&mock_delegate);
+
+  EXPECT_NE(first_uuid, second_uuid);
+}
+
+// Scenario: Staggered / Overlapping Hangs
+// 1. Thread A hangs. Monitor generates ONE UUID and calls RecordHangStarted.
+// 2. Time passes. Thread B hangs.
+// 3. Thread A recovers. Thread B is still hung.
+// 4. Monitor detects Thread B has a newer deadline than Thread A's snapshot.
+//    It triggers a *second* Crashpad dump, but retains the existing UUID and
+//    does NOT call RecordHangStarted again.
+// 5. Thread B recovers.
+// 6. Monitor sees 0 hung threads, calls RecordHangRecovered with the original
+// UUID.
+TEST_F(HangWatcherCobaltTest, OverlappingHangsSingleUuid) {
+  testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
+  StartHangWatcher(&mock_delegate);
+
+  SetDefaultDelegateExpectations(mock_delegate);
+
+  std::string captured_uuid;
+  EXPECT_CALL(mock_delegate, RecordHangStarted(testing::_))
+      .WillOnce(testing::SaveArg<0>(&captured_uuid));
+
+  hang_watcher_->SetOnHangClosureForTesting(base::BindRepeating([] {}));
+
+  auto unregister_thread_closure =
+      HangWatcher::RegisterThread(base::HangWatcher::ThreadType::kMainThread);
+
+  base::WaitableEvent unblock_thread_a;
+  base::WaitableEvent unblock_thread_b;
+  BlockingThread thread_a(&unblock_thread_a, kTimeout);
+  BlockingThread thread_b(&unblock_thread_b, kTimeout);
+
+  thread_a.StartAndWaitForScopeEntered();
+
+  // Reset monitor event because thread registration triggers Monitor().
+  monitor_event_.Reset();
+
+  // --- First Hang (Thread A) ---
+  {
+    // Fast forward past the timeout threshold.
+    task_environment_.FastForwardBy(kHangTime);
+
+    // Trigger monitor event. Thread A is hung. RecordHangStarted should be
+    // called exactly once.
+    TriggerMonitorAndWait();
+
+    ASSERT_FALSE(captured_uuid.empty());
+  }
+
+  // Now start Thread B so its deadline is later than Thread A's deadline.
+  thread_b.StartAndWaitForScopeEntered();
+  monitor_event_.Reset();
+
+  // Fast forward so Thread B hangs too.
+  task_environment_.FastForwardBy(kHangTime);
+
+  // --- Thread A Recovers, Thread B is still hung ---
+  unblock_thread_a.Signal();
+  thread_a.Join();
+
+  // Trigger monitor event. Thread A is recovered, Thread B is hung.
+  // Because Thread B's deadline is newer than Thread A's (which set the
+  // threshold), IsActionable() will be true, meaning another dump is generated.
+  // However, because active_hang_uuid_ is not empty, RecordHangStarted will NOT
+  // be called again. RecordHangRecovered should also NOT be called because
+  // Thread B is still hung.
+  EXPECT_CALL(mock_delegate, RecordHangRecovered(testing::_)).Times(0);
+  TriggerMonitorAndWait();
+  testing::Mock::VerifyAndClearExpectations(&mock_delegate);
+
+  // Re-apply expectations
+  EXPECT_CALL(mock_delegate, IsHangReportingEnabled())
+      .WillRepeatedly(testing::Return(true));
+  EXPECT_CALL(mock_delegate, GetHangWatchTime())
+      .WillRepeatedly(testing::Return(std::nullopt));
+  EXPECT_CALL(mock_delegate, GetHangWatchMonitoringPeriod())
+      .WillRepeatedly(testing::Return(std::nullopt));
+  EXPECT_CALL(mock_delegate, IsThreadDumpingEnabled(testing::_))
+      .WillRepeatedly(testing::Return(std::nullopt));
+
+  // --- Thread B Recovers ---
+  EXPECT_CALL(mock_delegate, RecordHangRecovered(captured_uuid)).Times(1);
+  unblock_thread_b.Signal();
+  thread_b.Join();
+
+  TriggerMonitorAndWait();
+}
+
+#endif
+
 namespace internal {
 namespace {
 
@@ -1372,5 +1753,106 @@ TEST_F(HangWatchDeadlineTest, SetDeadlineWipesFlags) {
 }
 
 }  // namespace internal
+
+#if BUILDFLAG(IS_COBALT)
+TEST_F(HangWatcherCobaltTest, AlternatingHangsSingleUuid) {
+  // Edge case: "on the first run of Monitor(), the snapshot is actionable
+  // because thread x is hung but then on the second run of Monitor(), the
+  // snapshot is actionable because (only) thread y is hung."
+  testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
+  StartHangWatcher(&mock_delegate);
+
+  SetDefaultDelegateExpectations(mock_delegate);
+
+  std::string captured_uuid;
+  EXPECT_CALL(mock_delegate, RecordHangStarted(testing::_))
+      .WillOnce(testing::SaveArg<0>(&captured_uuid));
+
+  hang_watcher_->SetOnHangClosureForTesting(base::BindRepeating([] {}));
+
+  // Keep the main thread registered so watch_states_ is never empty,
+  // ensuring Monitor() is always invoked when triggered.
+  auto unregister_thread_closure =
+      HangWatcher::RegisterThread(base::HangWatcher::ThreadType::kMainThread);
+
+  base::WaitableEvent unblock_thread_a;
+  base::WaitableEvent unblock_thread_b;
+  BlockingThread thread_a(&unblock_thread_a, kTimeout);
+  BlockingThread thread_b(&unblock_thread_b, kTimeout);
+
+  thread_a.StartAndWaitForScopeEntered();
+  monitor_event_.Reset();
+  
+  // Advance time so thread A and thread B have different deadlines.
+  task_environment_.FastForwardBy(kTimeout / 2);
+
+  thread_b.StartAndWaitForScopeEntered();
+  monitor_event_.Reset();
+
+  // Thread A hangs.
+  task_environment_.FastForwardBy(kTimeout / 2 + base::Seconds(1));
+  TriggerMonitorAndWait();  // Actionable for A. Dump taken.
+
+  // Thread A recovers.
+  unblock_thread_a.Signal();
+  thread_a.Join();
+
+  // Thread B hangs.
+  task_environment_.FastForwardBy(kTimeout / 2);
+
+  // Thread B is now actionable. Monitor runs.
+  // Because IsActionable() is true, the `else` block is skipped.
+  // So CheckAndRecordHangRecovered is skipped.
+  TriggerMonitorAndWait();
+
+  // Thread B recovers.
+  unblock_thread_b.Signal();
+  thread_b.Join();
+
+  // Monitor runs. IsActionable() is false.
+  // CheckAndRecordHangRecovered runs.
+  // It will check if any threads are hung. None are.
+  // So it fires RecordHangRecovered.
+  EXPECT_CALL(mock_delegate, RecordHangRecovered(captured_uuid)).Times(1);
+  TriggerMonitorAndWait();
+
+  testing::Mock::VerifyAndClearExpectations(&mock_delegate);
+}
+
+TEST_F(HangWatcherCobaltTest, ThreadUnregistersWhileHung) {
+  testing::StrictMock<MockHangWatcherDelegate> mock_delegate;
+  StartHangWatcher(&mock_delegate);
+
+  SetDefaultDelegateExpectations(mock_delegate);
+
+  std::string captured_uuid;
+  EXPECT_CALL(mock_delegate, RecordHangStarted(testing::_))
+      .WillOnce(testing::SaveArg<0>(&captured_uuid));
+
+  hang_watcher_->SetOnHangClosureForTesting(base::BindRepeating([] {}));
+
+  base::WaitableEvent unblock_thread_a;
+  BlockingThread thread_a(&unblock_thread_a, kTimeout);
+
+  thread_a.StartAndWaitForScopeEntered();
+  monitor_event_.Reset();
+
+  // Thread A hangs.
+  task_environment_.FastForwardBy(kHangTime);
+  TriggerMonitorAndWait();  // Actionable for A. Dump taken.
+
+  // The unregistration of Thread A will now synchronously trigger RecordHangRecovered
+  // when Monitor() runs because the watch list becomes empty.
+  EXPECT_CALL(mock_delegate, RecordHangRecovered(captured_uuid)).Times(1);
+
+  // Thread A unblocks and unregisters
+  unblock_thread_a.Signal();
+  thread_a.Join();
+
+  TriggerMonitorAndWait();
+
+  testing::Mock::VerifyAndClearExpectations(&mock_delegate);
+}
+#endif  // BUILDFLAG(IS_COBALT)
 
 }  // namespace base

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -234,6 +234,7 @@ if (is_starboard || is_androidtv) {
     deps = [
       ":global_features",
       "//base",
+      "//cobalt/browser/h5vcc_native_stability:h5vcc_native_stability",
     ]
   }
 }

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
@@ -308,4 +308,16 @@ void NativeStabilityManager::AcknowledgeReportsOnTaskRunner(
   std::move(callback).Run();
 }
 
+void NativeStabilityManager::RecordHangStarted(const std::string& hang_uuid) {
+  // TODO(b/528362453): Implement persistent storage layer.
+  LOG(INFO) << "Mock NativeStabilityManager::RecordHangStarted for UUID: "
+            << hang_uuid;
+}
+
+void NativeStabilityManager::RecordHangRecovered(const std::string& hang_uuid) {
+  // TODO(b/528362453): Implement persistent storage layer.
+  LOG(INFO) << "Mock NativeStabilityManager::RecordHangRecovered for UUID: "
+            << hang_uuid;
+}
+
 }  // namespace h5vcc_native_stability

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
@@ -49,6 +49,9 @@ class NativeStabilityManager {
   // with it.
   void ArmCrashUuidAnnotation();
 
+  void RecordHangStarted(const std::string& hang_uuid);
+  void RecordHangRecovered(const std::string& hang_uuid);
+
   // Asynchronously reads and summarizes stability reports stored on disk that
   // have not previously been acknowledged.
   //

--- a/cobalt/browser/hang_watcher_delegate_impl.cc
+++ b/cobalt/browser/hang_watcher_delegate_impl.cc
@@ -21,8 +21,11 @@
 #include "base/feature_list.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_util.h"
+#include "base/task/thread_pool/thread_pool_instance.h"
 #include "cobalt/browser/features.h"
 #include "cobalt/browser/global_features.h"
+#include "cobalt/browser/h5vcc_native_stability/native_stability_manager.h"
+
 namespace cobalt {
 namespace browser {
 
@@ -46,7 +49,17 @@ CobaltHangWatcherDelegate::CobaltHangWatcherDelegate(
 // the Chromium TaskEnvironment and thread pool are ready, causing a FATAL
 // crash.
 GlobalFeatures* CobaltHangWatcherDelegate::GetGlobalFeatures() {
-  return global_features_ ? global_features_ : GlobalFeatures::GetInstance();
+  if (global_features_) {
+    return global_features_;
+  }
+
+  // GlobalFeatures::GetInstance() may require ThreadPool to initialize or
+  // access settings. We must ensure it's available to avoid crashes during
+  // early startup or shutdown.
+  if (!base::ThreadPoolInstance::Get()) {
+    return nullptr;
+  }
+  return GlobalFeatures::GetInstance();
 }
 
 std::optional<int64_t> CobaltHangWatcherDelegate::GetIntSetting(
@@ -134,6 +147,22 @@ std::optional<bool> CobaltHangWatcherDelegate::IsThreadDumpingEnabled(
   }
 
   return std::nullopt;
+}
+
+void CobaltHangWatcherDelegate::RecordHangStarted(
+    const std::string& hang_uuid) {
+  auto* nsm = h5vcc_native_stability::NativeStabilityManager::GetInstance();
+  if (nsm) {
+    nsm->RecordHangStarted(hang_uuid);
+  }
+}
+
+void CobaltHangWatcherDelegate::RecordHangRecovered(
+    const std::string& hang_uuid) {
+  auto* nsm = h5vcc_native_stability::NativeStabilityManager::GetInstance();
+  if (nsm) {
+    nsm->RecordHangRecovered(hang_uuid);
+  }
 }
 
 }  // namespace browser

--- a/cobalt/browser/hang_watcher_delegate_impl.h
+++ b/cobalt/browser/hang_watcher_delegate_impl.h
@@ -37,6 +37,8 @@ class CobaltHangWatcherDelegate : public base::HangWatcher::Delegate {
   std::optional<base::TimeDelta> GetHangWatchMonitoringPeriod() override;
   std::optional<bool> IsThreadDumpingEnabled(
       base::HangWatcher::ThreadType thread_type) override;
+  void RecordHangStarted(const std::string& hang_uuid) override;
+  void RecordHangRecovered(const std::string& hang_uuid) override;
 
  private:
   GlobalFeatures* GetGlobalFeatures();


### PR DESCRIPTION
cobalt: Implement hang UUIDs and recovery tracking

Introduce UUID-based tracking for thread hangs within HangWatcher to
better identify unique hang incidents. This enables the
NativeStabilityManager to correlate hang reports and track whether a
process successfully recovers from a frozen state.

HangWatcher now generates a unique ID upon detecting a hang and
injects it into Crashpad annotations via Starboard. It also monitors
thread deadlines to detect recovery, notifying the delegate when
all threads have resumed execution.

Bug: 528364110