### PR TITLE
copied_base: BACKPORT: Rename WCHAR_T_IS_UTF* to WCHAR_T_IS_*_BIT

### DIFF
--- a/copied_base/base/i18n/icu_string_conversions_unittest.cc
+++ b/copied_base/base/i18n/icu_string_conversions_unittest.cc
@@ -32,9 +32,9 @@ namespace {
 // This is to help write tests for functions with std::u16string params until
 // the C++ 0x UTF-16 literal is well-supported by compilers.
 std::u16string BuildString16(const wchar_t* s) {
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
   return WideToUTF16(s);
-#elif defined(WCHAR_T_IS_UTF32)
+#elif defined(WCHAR_T_IS_32_BIT)
   std::u16string u16;
   while (*s != 0) {
     DCHECK_LE(static_cast<unsigned int>(*s), 0xFFFFu);
@@ -99,9 +99,9 @@ static const struct {
      L"\x00A5\x00A8", nullptr},
     // Chinese (GB18030) : A 4 byte sequence mapped to plane 2 (U+20000)
     {"gb18030", "\x95\x32\x82\x36\xD2\xBB", OnStringConversionError::FAIL, true,
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
      L"\xD840\xDC00\x4E00",
-#elif defined(WCHAR_T_IS_UTF32)
+#elif defined(WCHAR_T_IS_32_BIT)
      L"\x20000\x4E00",
 #endif
      L"\xD840\xDC00\x4E00"},

--- a/copied_base/base/i18n/rtl_unittest.cc
+++ b/copied_base/base/i18n/rtl_unittest.cc
@@ -31,65 +31,76 @@ TEST_F(RTLTest, GetFirstStrongCharacterDirection) {
     const wchar_t* text;
     TextDirection direction;
   } cases[] = {
-    // Test pure LTR string.
-    { L"foo bar", LEFT_TO_RIGHT },
-    // Test pure RTL string.
-    { L"\x05d0\x05d1\x05d2 \x05d3\x0d4\x05d5", RIGHT_TO_LEFT},
-    // Test bidi string in which the first character with strong directionality
-    // is a character with type L.
-    { L"foo \x05d0 bar", LEFT_TO_RIGHT },
-    // Test bidi string in which the first character with strong directionality
-    // is a character with type R.
-    { L"\x05d0 foo bar", RIGHT_TO_LEFT },
-    // Test bidi string which starts with a character with weak directionality
-    // and in which the first character with strong directionality is a
-    // character with type L.
-    { L"!foo \x05d0 bar", LEFT_TO_RIGHT },
-    // Test bidi string which starts with a character with weak directionality
-    // and in which the first character with strong directionality is a
-    // character with type R.
-    { L",\x05d0 foo bar", RIGHT_TO_LEFT },
-    // Test bidi string in which the first character with strong directionality
-    // is a character with type LRE.
-    { L"\x202a \x05d0 foo  bar", LEFT_TO_RIGHT },
-    // Test bidi string in which the first character with strong directionality
-    // is a character with type LRO.
-    { L"\x202d \x05d0 foo  bar", LEFT_TO_RIGHT },
-    // Test bidi string in which the first character with strong directionality
-    // is a character with type RLE.
-    { L"\x202b foo \x05d0 bar", RIGHT_TO_LEFT },
-    // Test bidi string in which the first character with strong directionality
-    // is a character with type RLO.
-    { L"\x202e foo \x05d0 bar", RIGHT_TO_LEFT },
-    // Test bidi string in which the first character with strong directionality
-    // is a character with type AL.
-    { L"\x0622 foo \x05d0 bar", RIGHT_TO_LEFT },
-    // Test a string without strong directionality characters.
-    { L",!.{}", LEFT_TO_RIGHT },
-    // Test empty string.
-    { L"", LEFT_TO_RIGHT },
-    // Test characters in non-BMP (e.g. Phoenician letters. Please refer to
-    // http://demo.icu-project.org/icu-bin/ubrowse?scr=151&b=10910 for more
-    // information).
-    {
-#if defined(WCHAR_T_IS_UTF32)
-      L" ! \x10910" L"abc 123",
-#elif defined(WCHAR_T_IS_UTF16)
-      L" ! \xd802\xdd10" L"abc 123",
+      // Test pure LTR string.
+      {L"foo bar", LEFT_TO_RIGHT},
+      // Test pure RTL string.
+      {L"\x05d0\x05d1\x05d2 \x05d3\x0d4\x05d5", RIGHT_TO_LEFT},
+      // Test bidi string in which the first character with strong
+      // directionality
+      // is a character with type L.
+      {L"foo \x05d0 bar", LEFT_TO_RIGHT},
+      // Test bidi string in which the first character with strong
+      // directionality
+      // is a character with type R.
+      {L"\x05d0 foo bar", RIGHT_TO_LEFT},
+      // Test bidi string which starts with a character with weak directionality
+      // and in which the first character with strong directionality is a
+      // character with type L.
+      {L"!foo \x05d0 bar", LEFT_TO_RIGHT},
+      // Test bidi string which starts with a character with weak directionality
+      // and in which the first character with strong directionality is a
+      // character with type R.
+      {L",\x05d0 foo bar", RIGHT_TO_LEFT},
+      // Test bidi string in which the first character with strong
+      // directionality
+      // is a character with type LRE.
+      {L"\x202a \x05d0 foo  bar", LEFT_TO_RIGHT},
+      // Test bidi string in which the first character with strong
+      // directionality
+      // is a character with type LRO.
+      {L"\x202d \x05d0 foo  bar", LEFT_TO_RIGHT},
+      // Test bidi string in which the first character with strong
+      // directionality
+      // is a character with type RLE.
+      {L"\x202b foo \x05d0 bar", RIGHT_TO_LEFT},
+      // Test bidi string in which the first character with strong
+      // directionality
+      // is a character with type RLO.
+      {L"\x202e foo \x05d0 bar", RIGHT_TO_LEFT},
+      // Test bidi string in which the first character with strong
+      // directionality
+      // is a character with type AL.
+      {L"\x0622 foo \x05d0 bar", RIGHT_TO_LEFT},
+      // Test a string without strong directionality characters.
+      {L",!.{}", LEFT_TO_RIGHT},
+      // Test empty string.
+      {L"", LEFT_TO_RIGHT},
+      // Test characters in non-BMP (e.g. Phoenician letters. Please refer to
+      // http://demo.icu-project.org/icu-bin/ubrowse?scr=151&b=10910 for more
+      // information).
+      {
+#if defined(WCHAR_T_IS_32_BIT)
+          L" ! \x10910"
+          L"abc 123",
+#elif defined(WCHAR_T_IS_16_BIT)
+          L" ! \xd802\xdd10"
+          L"abc 123",
 #else
 #error wchar_t should be either UTF-16 or UTF-32
 #endif
-      RIGHT_TO_LEFT },
-    {
-#if defined(WCHAR_T_IS_UTF32)
-      L" ! \x10401" L"abc 123",
-#elif defined(WCHAR_T_IS_UTF16)
-      L" ! \xd801\xdc01" L"abc 123",
+          RIGHT_TO_LEFT},
+      {
+#if defined(WCHAR_T_IS_32_BIT)
+          L" ! \x10401"
+          L"abc 123",
+#elif defined(WCHAR_T_IS_16_BIT)
+          L" ! \xd801\xdc01"
+          L"abc 123",
 #else
 #error wchar_t should be either UTF-16 or UTF-32
 #endif
-      LEFT_TO_RIGHT },
-   };
+          LEFT_TO_RIGHT},
+  };
 
   for (auto& i : cases)
     EXPECT_EQ(i.direction,
@@ -105,53 +116,57 @@ TEST_F(RTLTest, GetLastStrongCharacterDirection) {
     const wchar_t* text;
     TextDirection direction;
   } cases[] = {
-    // Test pure LTR string.
-    { L"foo bar", LEFT_TO_RIGHT },
-    // Test pure RTL string.
-    { L"\x05d0\x05d1\x05d2 \x05d3\x0d4\x05d5", RIGHT_TO_LEFT},
-    // Test bidi string in which the last character with strong directionality
-    // is a character with type L.
-    { L"foo \x05d0 bar", LEFT_TO_RIGHT },
-    // Test bidi string in which the last character with strong directionality
-    // is a character with type R.
-    { L"\x05d0 foo bar \x05d3", RIGHT_TO_LEFT },
-    // Test bidi string which ends with a character with weak directionality
-    // and in which the last character with strong directionality is a
-    // character with type L.
-    { L"!foo \x05d0 bar!", LEFT_TO_RIGHT },
-    // Test bidi string which ends with a character with weak directionality
-    // and in which the last character with strong directionality is a
-    // character with type R.
-    { L",\x05d0 foo bar \x05d1,", RIGHT_TO_LEFT },
-    // Test bidi string in which the last character with strong directionality
-    // is a character with type AL.
-    { L"\x0622 foo \x05d0 bar \x0622", RIGHT_TO_LEFT },
-    // Test a string without strong directionality characters.
-    { L",!.{}", LEFT_TO_RIGHT },
-    // Test empty string.
-    { L"", LEFT_TO_RIGHT },
-    // Test characters in non-BMP (e.g. Phoenician letters. Please refer to
-    // http://demo.icu-project.org/icu-bin/ubrowse?scr=151&b=10910 for more
-    // information).
-    {
-#if defined(WCHAR_T_IS_UTF32)
-       L"abc 123" L" ! \x10910 !",
-#elif defined(WCHAR_T_IS_UTF16)
-       L"abc 123" L" ! \xd802\xdd10 !",
+      // Test pure LTR string.
+      {L"foo bar", LEFT_TO_RIGHT},
+      // Test pure RTL string.
+      {L"\x05d0\x05d1\x05d2 \x05d3\x0d4\x05d5", RIGHT_TO_LEFT},
+      // Test bidi string in which the last character with strong directionality
+      // is a character with type L.
+      {L"foo \x05d0 bar", LEFT_TO_RIGHT},
+      // Test bidi string in which the last character with strong directionality
+      // is a character with type R.
+      {L"\x05d0 foo bar \x05d3", RIGHT_TO_LEFT},
+      // Test bidi string which ends with a character with weak directionality
+      // and in which the last character with strong directionality is a
+      // character with type L.
+      {L"!foo \x05d0 bar!", LEFT_TO_RIGHT},
+      // Test bidi string which ends with a character with weak directionality
+      // and in which the last character with strong directionality is a
+      // character with type R.
+      {L",\x05d0 foo bar \x05d1,", RIGHT_TO_LEFT},
+      // Test bidi string in which the last character with strong directionality
+      // is a character with type AL.
+      {L"\x0622 foo \x05d0 bar \x0622", RIGHT_TO_LEFT},
+      // Test a string without strong directionality characters.
+      {L",!.{}", LEFT_TO_RIGHT},
+      // Test empty string.
+      {L"", LEFT_TO_RIGHT},
+      // Test characters in non-BMP (e.g. Phoenician letters. Please refer to
+      // http://demo.icu-project.org/icu-bin/ubrowse?scr=151&b=10910 for more
+      // information).
+      {
+#if defined(WCHAR_T_IS_32_BIT)
+          L"abc 123"
+          L" ! \x10910 !",
+#elif defined(WCHAR_T_IS_16_BIT)
+          L"abc 123"
+          L" ! \xd802\xdd10 !",
 #else
 #error wchar_t should be either UTF-16 or UTF-32
 #endif
-      RIGHT_TO_LEFT },
-    {
-#if defined(WCHAR_T_IS_UTF32)
-       L"abc 123" L" ! \x10401 !",
-#elif defined(WCHAR_T_IS_UTF16)
-       L"abc 123" L" ! \xd801\xdc01 !",
+          RIGHT_TO_LEFT},
+      {
+#if defined(WCHAR_T_IS_32_BIT)
+          L"abc 123"
+          L" ! \x10401 !",
+#elif defined(WCHAR_T_IS_16_BIT)
+          L"abc 123"
+          L" ! \xd801\xdc01 !",
 #else
 #error wchar_t should be either UTF-16 or UTF-32
 #endif
-      LEFT_TO_RIGHT },
-   };
+          LEFT_TO_RIGHT},
+  };
 
   for (auto& i : cases)
     EXPECT_EQ(i.direction,
@@ -163,73 +178,77 @@ TEST_F(RTLTest, GetStringDirection) {
     const wchar_t* text;
     TextDirection direction;
   } cases[] = {
-    // Test pure LTR string.
-    { L"foobar", LEFT_TO_RIGHT },
-    { L".foobar", LEFT_TO_RIGHT },
-    { L"foo, bar", LEFT_TO_RIGHT },
-    // Test pure LTR with strong directionality characters of type LRE.
-    { L"\x202a\x202a", LEFT_TO_RIGHT },
-    { L".\x202a\x202a", LEFT_TO_RIGHT },
-    { L"\x202a, \x202a", LEFT_TO_RIGHT },
-    // Test pure LTR with strong directionality characters of type LRO.
-    { L"\x202d\x202d", LEFT_TO_RIGHT },
-    { L".\x202d\x202d", LEFT_TO_RIGHT },
-    { L"\x202d, \x202d", LEFT_TO_RIGHT },
-    // Test pure LTR with various types of strong directionality characters.
-    { L"foo \x202a\x202d", LEFT_TO_RIGHT },
-    { L".\x202d foo \x202a", LEFT_TO_RIGHT },
-    { L"\x202a, \x202d foo", LEFT_TO_RIGHT },
-    // Test pure RTL with strong directionality characters of type R.
-    { L"\x05d0\x05d0", RIGHT_TO_LEFT },
-    { L".\x05d0\x05d0", RIGHT_TO_LEFT },
-    { L"\x05d0, \x05d0", RIGHT_TO_LEFT },
-    // Test pure RTL with strong directionality characters of type RLE.
-    { L"\x202b\x202b", RIGHT_TO_LEFT },
-    { L".\x202b\x202b", RIGHT_TO_LEFT },
-    { L"\x202b, \x202b", RIGHT_TO_LEFT },
-    // Test pure RTL with strong directionality characters of type RLO.
-    { L"\x202e\x202e", RIGHT_TO_LEFT },
-    { L".\x202e\x202e", RIGHT_TO_LEFT },
-    { L"\x202e, \x202e", RIGHT_TO_LEFT },
-    // Test pure RTL with strong directionality characters of type AL.
-    { L"\x0622\x0622", RIGHT_TO_LEFT },
-    { L".\x0622\x0622", RIGHT_TO_LEFT },
-    { L"\x0622, \x0622", RIGHT_TO_LEFT },
-    // Test pure RTL with various types of strong directionality characters.
-    { L"\x05d0\x202b\x202e\x0622", RIGHT_TO_LEFT },
-    { L".\x202b\x202e\x0622\x05d0", RIGHT_TO_LEFT },
-    { L"\x0622\x202e, \x202b\x05d0", RIGHT_TO_LEFT },
-    // Test bidi strings.
-    { L"foo \x05d0 bar", UNKNOWN_DIRECTION },
-    { L"\x202b foo bar", UNKNOWN_DIRECTION },
-    { L"!foo \x0622 bar", UNKNOWN_DIRECTION },
-    { L"\x202a\x202b", UNKNOWN_DIRECTION },
-    { L"\x202e\x202d", UNKNOWN_DIRECTION },
-    { L"\x0622\x202a", UNKNOWN_DIRECTION },
-    { L"\x202d\x05d0", UNKNOWN_DIRECTION },
-    // Test a string without strong directionality characters.
-    { L",!.{}", LEFT_TO_RIGHT },
-    // Test empty string.
-    { L"", LEFT_TO_RIGHT },
-    {
-#if defined(WCHAR_T_IS_UTF32)
-      L" ! \x10910" L"abc 123",
-#elif defined(WCHAR_T_IS_UTF16)
-      L" ! \xd802\xdd10" L"abc 123",
+      // Test pure LTR string.
+      {L"foobar", LEFT_TO_RIGHT},
+      {L".foobar", LEFT_TO_RIGHT},
+      {L"foo, bar", LEFT_TO_RIGHT},
+      // Test pure LTR with strong directionality characters of type LRE.
+      {L"\x202a\x202a", LEFT_TO_RIGHT},
+      {L".\x202a\x202a", LEFT_TO_RIGHT},
+      {L"\x202a, \x202a", LEFT_TO_RIGHT},
+      // Test pure LTR with strong directionality characters of type LRO.
+      {L"\x202d\x202d", LEFT_TO_RIGHT},
+      {L".\x202d\x202d", LEFT_TO_RIGHT},
+      {L"\x202d, \x202d", LEFT_TO_RIGHT},
+      // Test pure LTR with various types of strong directionality characters.
+      {L"foo \x202a\x202d", LEFT_TO_RIGHT},
+      {L".\x202d foo \x202a", LEFT_TO_RIGHT},
+      {L"\x202a, \x202d foo", LEFT_TO_RIGHT},
+      // Test pure RTL with strong directionality characters of type R.
+      {L"\x05d0\x05d0", RIGHT_TO_LEFT},
+      {L".\x05d0\x05d0", RIGHT_TO_LEFT},
+      {L"\x05d0, \x05d0", RIGHT_TO_LEFT},
+      // Test pure RTL with strong directionality characters of type RLE.
+      {L"\x202b\x202b", RIGHT_TO_LEFT},
+      {L".\x202b\x202b", RIGHT_TO_LEFT},
+      {L"\x202b, \x202b", RIGHT_TO_LEFT},
+      // Test pure RTL with strong directionality characters of type RLO.
+      {L"\x202e\x202e", RIGHT_TO_LEFT},
+      {L".\x202e\x202e", RIGHT_TO_LEFT},
+      {L"\x202e, \x202e", RIGHT_TO_LEFT},
+      // Test pure RTL with strong directionality characters of type AL.
+      {L"\x0622\x0622", RIGHT_TO_LEFT},
+      {L".\x0622\x0622", RIGHT_TO_LEFT},
+      {L"\x0622, \x0622", RIGHT_TO_LEFT},
+      // Test pure RTL with various types of strong directionality characters.
+      {L"\x05d0\x202b\x202e\x0622", RIGHT_TO_LEFT},
+      {L".\x202b\x202e\x0622\x05d0", RIGHT_TO_LEFT},
+      {L"\x0622\x202e, \x202b\x05d0", RIGHT_TO_LEFT},
+      // Test bidi strings.
+      {L"foo \x05d0 bar", UNKNOWN_DIRECTION},
+      {L"\x202b foo bar", UNKNOWN_DIRECTION},
+      {L"!foo \x0622 bar", UNKNOWN_DIRECTION},
+      {L"\x202a\x202b", UNKNOWN_DIRECTION},
+      {L"\x202e\x202d", UNKNOWN_DIRECTION},
+      {L"\x0622\x202a", UNKNOWN_DIRECTION},
+      {L"\x202d\x05d0", UNKNOWN_DIRECTION},
+      // Test a string without strong directionality characters.
+      {L",!.{}", LEFT_TO_RIGHT},
+      // Test empty string.
+      {L"", LEFT_TO_RIGHT},
+      {
+#if defined(WCHAR_T_IS_32_BIT)
+          L" ! \x10910"
+          L"abc 123",
+#elif defined(WCHAR_T_IS_16_BIT)
+          L" ! \xd802\xdd10"
+          L"abc 123",
 #else
 #error wchar_t should be either UTF-16 or UTF-32
 #endif
-      UNKNOWN_DIRECTION },
-    {
-#if defined(WCHAR_T_IS_UTF32)
-      L" ! \x10401" L"abc 123",
-#elif defined(WCHAR_T_IS_UTF16)
-      L" ! \xd801\xdc01" L"abc 123",
+          UNKNOWN_DIRECTION},
+      {
+#if defined(WCHAR_T_IS_32_BIT)
+          L" ! \x10401"
+          L"abc 123",
+#elif defined(WCHAR_T_IS_16_BIT)
+          L" ! \xd801\xdc01"
+          L"abc 123",
 #else
 #error wchar_t should be either UTF-16 or UTF-32
 #endif
-      LEFT_TO_RIGHT },
-   };
+          LEFT_TO_RIGHT},
+  };
 
   for (auto& i : cases)
     EXPECT_EQ(i.direction, GetStringDirection(WideToUTF16(i.text)));

--- a/copied_base/base/strings/string_util.cc
+++ b/copied_base/base/strings/string_util.cc
@@ -235,7 +235,7 @@ bool IsStringASCII(StringPiece16 str) {
   return internal::DoIsStringASCII(str.data(), str.length());
 }
 
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
 bool IsStringASCII(WStringPiece str) {
   return internal::DoIsStringASCII(str.data(), str.length());
 }

--- a/copied_base/base/strings/string_util.h
+++ b/copied_base/base/strings/string_util.h
@@ -345,7 +345,7 @@ BASE_EXPORT bool IsStringUTF8AllowingNoncharacters(StringPiece str);
 BASE_EXPORT bool IsStringASCII(StringPiece str);
 BASE_EXPORT bool IsStringASCII(StringPiece16 str);
 
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
 BASE_EXPORT bool IsStringASCII(WStringPiece str);
 #endif
 

--- a/copied_base/base/strings/string_util_perftest.cc
+++ b/copied_base/base/strings/string_util_perftest.cc
@@ -35,7 +35,7 @@ TEST(StringUtilTest, DISABLED_IsStringASCIIPerf) {
       size_t non_ascii_pos = str_length * non_ascii_loc / 2 + 2;
       MeasureIsStringASCII<std::string>(str_length, non_ascii_pos);
       MeasureIsStringASCII<std::u16string>(str_length, non_ascii_pos);
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
       MeasureIsStringASCII<std::basic_string<wchar_t>>(str_length,
                                                        non_ascii_pos);
 #endif

--- a/copied_base/base/strings/string_util_unittest.cc
+++ b/copied_base/base/strings/string_util_unittest.cc
@@ -351,7 +351,7 @@ TEST(StringUtilTest, TruncateUTF8ToByteSize) {
   EXPECT_EQ(output.compare(""), 0);
 }
 
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
 TEST(StringUtilTest, as_wcstr) {
   char16_t rw_buffer[10] = {};
   static_assert(
@@ -410,7 +410,7 @@ TEST(StringUtilTest, as_u16cstr) {
       std::is_same<const char16_t*, decltype(as_u16cstr(piece))>::value, "");
   EXPECT_EQ(static_cast<const void*>(piece.data()), as_u16cstr(piece));
 }
-#endif  // defined(WCHAR_T_IS_UTF16)
+#endif  // defined(WCHAR_T_IS_16_BIT)
 
 TEST(StringUtilTest, TrimWhitespace) {
   std::u16string output;  // Allow contents to carry over to next testcase
@@ -571,7 +571,7 @@ TEST(StringUtilTest, IsStringASCII) {
     }
   }
 
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
   {
     const size_t string_length = wchar_ascii.length();
     for (size_t len = 0; len < string_length; ++len) {
@@ -589,7 +589,7 @@ TEST(StringUtilTest, IsStringASCII) {
       }
     }
   }
-#endif  // WCHAR_T_IS_UTF32
+#endif  // WCHAR_T_IS_32_BIT
 }
 
 TEST(StringUtilTest, ConvertASCII) {

--- a/copied_base/base/strings/sys_string_conversions_unittest.cc
+++ b/copied_base/base/strings/sys_string_conversions_unittest.cc
@@ -13,7 +13,7 @@
 #include "build/build_config.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
-#ifdef WCHAR_T_IS_UTF32
+#ifdef WCHAR_T_IS_32_BIT
 static const std::wstring kSysWideOldItalicLetterA = L"\x10300";
 #else
 static const std::wstring kSysWideOldItalicLetterA = L"\xd800\xdf00";
@@ -137,29 +137,31 @@ TEST(SysStrings, SysNativeMBToWide) {
 }
 
 static const wchar_t* const kConvertRoundtripCases[] = {
-  L"Google Video",
-  // "网页 图片 资讯更多 »"
-  L"\x7f51\x9875\x0020\x56fe\x7247\x0020\x8d44\x8baf\x66f4\x591a\x0020\x00bb",
-  //  "Παγκόσμιος Ιστός"
-  L"\x03a0\x03b1\x03b3\x03ba\x03cc\x03c3\x03bc\x03b9"
-  L"\x03bf\x03c2\x0020\x0399\x03c3\x03c4\x03cc\x03c2",
-  // "Поиск страниц на русском"
-  L"\x041f\x043e\x0438\x0441\x043a\x0020\x0441\x0442"
-  L"\x0440\x0430\x043d\x0438\x0446\x0020\x043d\x0430"
-  L"\x0020\x0440\x0443\x0441\x0441\x043a\x043e\x043c",
-  // "전체서비스"
-  L"\xc804\xccb4\xc11c\xbe44\xc2a4",
+    L"Google Video",
+    // "网页 图片 资讯更多 »"
+    L"\x7f51\x9875\x0020\x56fe\x7247\x0020\x8d44\x8baf\x66f4\x591a\x0020\x00bb",
+    //  "Παγκόσμιος Ιστός"
+    L"\x03a0\x03b1\x03b3\x03ba\x03cc\x03c3\x03bc\x03b9"
+    L"\x03bf\x03c2\x0020\x0399\x03c3\x03c4\x03cc\x03c2",
+    // "Поиск страниц на русском"
+    L"\x041f\x043e\x0438\x0441\x043a\x0020\x0441\x0442"
+    L"\x0440\x0430\x043d\x0438\x0446\x0020\x043d\x0430"
+    L"\x0020\x0440\x0443\x0441\x0441\x043a\x043e\x043c",
+    // "전체서비스"
+    L"\xc804\xccb4\xc11c\xbe44\xc2a4",
 
-  // Test characters that take more than 16 bits. This will depend on whether
-  // wchar_t is 16 or 32 bits.
-#if defined(WCHAR_T_IS_UTF16)
-  L"\xd800\xdf00",
-  // ?????  (Mathematical Alphanumeric Symbols (U+011d40 - U+011d44 : A,B,C,D,E)
-  L"\xd807\xdd40\xd807\xdd41\xd807\xdd42\xd807\xdd43\xd807\xdd44",
-#elif defined(WCHAR_T_IS_UTF32)
-  L"\x10300",
-  // ?????  (Mathematical Alphanumeric Symbols (U+011d40 - U+011d44 : A,B,C,D,E)
-  L"\x11d40\x11d41\x11d42\x11d43\x11d44",
+// Test characters that take more than 16 bits. This will depend on whether
+// wchar_t is 16 or 32 bits.
+#if defined(WCHAR_T_IS_16_BIT)
+    L"\xd800\xdf00",
+    // ?????  (Mathematical Alphanumeric Symbols (U+011d40 - U+011d44 :
+    // A,B,C,D,E)
+    L"\xd807\xdd40\xd807\xdd41\xd807\xdd42\xd807\xdd43\xd807\xdd44",
+#elif defined(WCHAR_T_IS_32_BIT)
+    L"\x10300",
+    // ?????  (Mathematical Alphanumeric Symbols (U+011d40 - U+011d44 :
+    // A,B,C,D,E)
+    L"\x11d40\x11d41\x11d42\x11d43\x11d44",
 #endif
 };
 

--- a/copied_base/base/strings/utf_string_conversion_utils.cc
+++ b/copied_base/base/strings/utf_string_conversion_utils.cc
@@ -51,7 +51,7 @@ bool ReadUnicodeCharacter(const char16_t* src,
   return IsValidCodepoint(*code_point);
 }
 
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
 bool ReadUnicodeCharacter(const wchar_t* src,
                           size_t src_len,
                           size_t* char_index,
@@ -62,7 +62,7 @@ bool ReadUnicodeCharacter(const wchar_t* src,
   // Validate the value.
   return IsValidCodepoint(*code_point);
 }
-#endif  // defined(WCHAR_T_IS_UTF32)
+#endif  // defined(WCHAR_T_IS_32_BIT)
 
 // WriteUnicodeCharacter -------------------------------------------------------
 

--- a/copied_base/base/strings/utf_string_conversion_utils.h
+++ b/copied_base/base/strings/utf_string_conversion_utils.h
@@ -59,13 +59,13 @@ BASE_EXPORT bool ReadUnicodeCharacter(const char16_t* src,
                                       size_t* char_index,
                                       base_icu::UChar32* code_point);
 
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
 // Reads UTF-32 character. The usage is the same as the 8-bit version above.
 BASE_EXPORT bool ReadUnicodeCharacter(const wchar_t* src,
                                       size_t src_len,
                                       size_t* char_index,
                                       base_icu::UChar32* code_point);
-#endif  // defined(WCHAR_T_IS_UTF32)
+#endif  // defined(WCHAR_T_IS_32_BIT)
 
 // WriteUnicodeCharacter -------------------------------------------------------
 
@@ -79,7 +79,7 @@ BASE_EXPORT size_t WriteUnicodeCharacter(base_icu::UChar32 code_point,
 BASE_EXPORT size_t WriteUnicodeCharacter(base_icu::UChar32 code_point,
                                          std::u16string* output);
 
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
 // Appends the given UTF-32 character to the given 32-bit string.  Returns the
 // number of 32-bit values written.
 inline size_t WriteUnicodeCharacter(base_icu::UChar32 code_point,
@@ -88,7 +88,7 @@ inline size_t WriteUnicodeCharacter(base_icu::UChar32 code_point,
   output->push_back(static_cast<wchar_t>(code_point));
   return 1;
 }
-#endif  // defined(WCHAR_T_IS_UTF32)
+#endif  // defined(WCHAR_T_IS_32_BIT)
 
 // Generalized Unicode converter -----------------------------------------------
 

--- a/copied_base/base/strings/utf_string_conversions.cc
+++ b/copied_base/base/strings/utf_string_conversions.cc
@@ -41,7 +41,7 @@ struct SizeCoefficient<char16_t, char> {
   static constexpr int value = 3;
 };
 
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
 template <>
 struct SizeCoefficient<wchar_t, char> {
   // UTF-8 uses at most 4 codeunits per character.
@@ -53,7 +53,7 @@ struct SizeCoefficient<wchar_t, char16_t> {
   // UTF-16 uses at most 2 codeunits per character.
   static constexpr int value = 2;
 };
-#endif  // defined(WCHAR_T_IS_UTF32)
+#endif  // defined(WCHAR_T_IS_32_BIT)
 
 template <typename SrcChar, typename DestChar>
 constexpr int size_coefficient_v =
@@ -161,7 +161,7 @@ bool DoUTFConversion(const char16_t* src,
   return success;
 }
 
-#if defined(WCHAR_T_IS_UTF32)
+#if defined(WCHAR_T_IS_32_BIT)
 
 template <typename DestChar>
 bool DoUTFConversion(const wchar_t* src,
@@ -184,7 +184,7 @@ bool DoUTFConversion(const wchar_t* src,
   return success;
 }
 
-#endif  // defined(WCHAR_T_IS_UTF32)
+#endif  // defined(WCHAR_T_IS_32_BIT)
 
 // UTFConversion --------------------------------------------------------------
 // Function template for generating all UTF conversions.
@@ -245,7 +245,7 @@ std::string UTF16ToUTF8(StringPiece16 utf16) {
 
 // UTF-16 <-> Wide -------------------------------------------------------------
 
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
 // When wide == UTF-16 the conversions are a NOP.
 
 bool WideToUTF16(const wchar_t* src, size_t src_len, std::u16string* output) {
@@ -266,7 +266,7 @@ std::wstring UTF16ToWide(StringPiece16 utf16) {
   return std::wstring(utf16.begin(), utf16.end());
 }
 
-#elif defined(WCHAR_T_IS_UTF32)
+#elif defined(WCHAR_T_IS_32_BIT)
 
 bool WideToUTF16(const wchar_t* src, size_t src_len, std::u16string* output) {
   return UTFConversion(base::WStringPiece(src, src_len), output);
@@ -292,7 +292,7 @@ std::wstring UTF16ToWide(StringPiece16 utf16) {
   return ret;
 }
 
-#endif  // defined(WCHAR_T_IS_UTF32)
+#endif  // defined(WCHAR_T_IS_32_BIT)
 
 // UTF-8 <-> Wide --------------------------------------------------------------
 
@@ -310,7 +310,7 @@ std::wstring UTF8ToWide(StringPiece utf8) {
   return ret;
 }
 
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
 // Easy case since we can use the "utf" versions we already wrote above.
 
 bool WideToUTF8(const wchar_t* src, size_t src_len, std::string* output) {
@@ -321,7 +321,7 @@ std::string WideToUTF8(WStringPiece wide) {
   return UTF16ToUTF8(StringPiece16(as_u16cstr(wide), wide.size()));
 }
 
-#elif defined(WCHAR_T_IS_UTF32)
+#elif defined(WCHAR_T_IS_32_BIT)
 
 bool WideToUTF8(const wchar_t* src, size_t src_len, std::string* output) {
   return UTFConversion(WStringPiece(src, src_len), output);
@@ -335,7 +335,7 @@ std::string WideToUTF8(WStringPiece wide) {
   return ret;
 }
 
-#endif  // defined(WCHAR_T_IS_UTF32)
+#endif  // defined(WCHAR_T_IS_32_BIT)
 
 std::u16string ASCIIToUTF16(StringPiece ascii) {
   DCHECK(IsStringASCII(ascii)) << ascii;
@@ -347,7 +347,7 @@ std::string UTF16ToASCII(StringPiece16 utf16) {
   return std::string(utf16.begin(), utf16.end());
 }
 
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
 std::wstring ASCIIToWide(StringPiece ascii) {
   DCHECK(IsStringASCII(ascii)) << ascii;
   return std::wstring(ascii.begin(), ascii.end());
@@ -357,6 +357,6 @@ std::string WideToASCII(WStringPiece wide) {
   DCHECK(IsStringASCII(wide)) << wide;
   return std::string(wide.begin(), wide.end());
 }
-#endif  // defined(WCHAR_T_IS_UTF16)
+#endif  // defined(WCHAR_T_IS_16_BIT)
 
 }  // namespace base

--- a/copied_base/base/strings/utf_string_conversions.h
+++ b/copied_base/base/strings/utf_string_conversions.h
@@ -54,7 +54,7 @@ BASE_EXPORT bool UTF16ToUTF8(const char16_t* src,
 // beforehand.
 [[nodiscard]] BASE_EXPORT std::string UTF16ToASCII(StringPiece16 utf16);
 
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
 // This converts an ASCII string, typically a hardcoded constant, to a wide
 // string.
 [[nodiscard]] BASE_EXPORT std::wstring ASCIIToWide(StringPiece ascii);
@@ -62,7 +62,7 @@ BASE_EXPORT bool UTF16ToUTF8(const char16_t* src,
 // Converts to 7-bit ASCII by truncating. The result must be known to be ASCII
 // beforehand.
 [[nodiscard]] BASE_EXPORT std::string WideToASCII(WStringPiece wide);
-#endif  // defined(WCHAR_T_IS_UTF16)
+#endif  // defined(WCHAR_T_IS_16_BIT)
 
 // The conversion functions in this file should not be used to convert string
 // literals. Instead, the corresponding prefixes (e.g. u"" for UTF16 or L"" for

--- a/copied_base/base/strings/utf_string_conversions_unittest.cc
+++ b/copied_base/base/strings/utf_string_conversions_unittest.cc
@@ -16,29 +16,31 @@ namespace base {
 namespace {
 
 const wchar_t* const kConvertRoundtripCases[] = {
-  L"Google Video",
-  // "网页 图片 资讯更多 »"
-  L"\x7f51\x9875\x0020\x56fe\x7247\x0020\x8d44\x8baf\x66f4\x591a\x0020\x00bb",
-  //  "Παγκόσμιος Ιστός"
-  L"\x03a0\x03b1\x03b3\x03ba\x03cc\x03c3\x03bc\x03b9"
-  L"\x03bf\x03c2\x0020\x0399\x03c3\x03c4\x03cc\x03c2",
-  // "Поиск страниц на русском"
-  L"\x041f\x043e\x0438\x0441\x043a\x0020\x0441\x0442"
-  L"\x0440\x0430\x043d\x0438\x0446\x0020\x043d\x0430"
-  L"\x0020\x0440\x0443\x0441\x0441\x043a\x043e\x043c",
-  // "전체서비스"
-  L"\xc804\xccb4\xc11c\xbe44\xc2a4",
+    L"Google Video",
+    // "网页 图片 资讯更多 »"
+    L"\x7f51\x9875\x0020\x56fe\x7247\x0020\x8d44\x8baf\x66f4\x591a\x0020\x00bb",
+    //  "Παγκόσμιος Ιστός"
+    L"\x03a0\x03b1\x03b3\x03ba\x03cc\x03c3\x03bc\x03b9"
+    L"\x03bf\x03c2\x0020\x0399\x03c3\x03c4\x03cc\x03c2",
+    // "Поиск страниц на русском"
+    L"\x041f\x043e\x0438\x0441\x043a\x0020\x0441\x0442"
+    L"\x0440\x0430\x043d\x0438\x0446\x0020\x043d\x0430"
+    L"\x0020\x0440\x0443\x0441\x0441\x043a\x043e\x043c",
+    // "전체서비스"
+    L"\xc804\xccb4\xc11c\xbe44\xc2a4",
 
-  // Test characters that take more than 16 bits. This will depend on whether
-  // wchar_t is 16 or 32 bits.
-#if defined(WCHAR_T_IS_UTF16)
-  L"\xd800\xdf00",
-  // ?????  (Mathematical Alphanumeric Symbols (U+011d40 - U+011d44 : A,B,C,D,E)
-  L"\xd807\xdd40\xd807\xdd41\xd807\xdd42\xd807\xdd43\xd807\xdd44",
-#elif defined(WCHAR_T_IS_UTF32)
-  L"\x10300",
-  // ?????  (Mathematical Alphanumeric Symbols (U+011d40 - U+011d44 : A,B,C,D,E)
-  L"\x11d40\x11d41\x11d42\x11d43\x11d44",
+// Test characters that take more than 16 bits. This will depend on whether
+// wchar_t is 16 or 32 bits.
+#if defined(WCHAR_T_IS_16_BIT)
+    L"\xd800\xdf00",
+    // ?????  (Mathematical Alphanumeric Symbols (U+011d40 - U+011d44 :
+    // A,B,C,D,E)
+    L"\xd807\xdd40\xd807\xdd41\xd807\xdd42\xd807\xdd43\xd807\xdd44",
+#elif defined(WCHAR_T_IS_32_BIT)
+    L"\x10300",
+    // ?????  (Mathematical Alphanumeric Symbols (U+011d40 - U+011d44 :
+    // A,B,C,D,E)
+    L"\x11d40\x11d41\x11d42\x11d43\x11d44",
 #endif
 };
 
@@ -87,10 +89,10 @@ TEST(UTFStringConversionsTest, ConvertUTF8ToWide) {
     {"\xed\xb0\x80", L"\xfffd\xfffd\xfffd", false},
     // Non-BMP characters. The second is a non-character regarded as valid.
     // The result will either be in UTF-16 or UTF-32.
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
     {"A\xF0\x90\x8C\x80z", L"A\xd800\xdf00z", true},
     {"A\xF4\x8F\xBF\xBEz", L"A\xdbff\xdffez", true},
-#elif defined(WCHAR_T_IS_UTF32)
+#elif defined(WCHAR_T_IS_32_BIT)
     {"A\xF0\x90\x8C\x80z", L"A\x10300z", true},
     {"A\xF4\x8F\xBF\xBEz", L"A\x10fffez", true},
 #endif
@@ -117,7 +119,7 @@ TEST(UTFStringConversionsTest, ConvertUTF8ToWide) {
   EXPECT_EQ('B', converted[0]);
 }
 
-#if defined(WCHAR_T_IS_UTF16)
+#if defined(WCHAR_T_IS_16_BIT)
 // This test is only valid when wchar_t == UTF-16.
 TEST(UTFStringConversionsTest, ConvertUTF16ToUTF8) {
   struct WideToUTF8Case {
@@ -147,7 +149,7 @@ TEST(UTFStringConversionsTest, ConvertUTF16ToUTF8) {
   }
 }
 
-#elif defined(WCHAR_T_IS_UTF32)
+#elif defined(WCHAR_T_IS_32_BIT)
 // This test is only valid when wchar_t == UTF-32.
 TEST(UTFStringConversionsTest, ConvertUTF32ToUTF8) {
   struct WideToUTF8Case {
@@ -177,7 +179,7 @@ TEST(UTFStringConversionsTest, ConvertUTF32ToUTF8) {
     EXPECT_EQ(expected, converted);
   }
 }
-#endif  // defined(WCHAR_T_IS_UTF32)
+#endif  // defined(WCHAR_T_IS_32_BIT)
 
 TEST(UTFStringConversionsTest, ConvertMultiString) {
   static char16_t multi16[] = {'f',  'o', 'o', '\0', 'b',  'a', 'r',


### PR DESCRIPTION
This is a backport of https://crrev.com/c/5007648 (present since M121) to copied_base. This upstream CL changed some macro names, but the version in copied_base was still using the old names and the macro checks were failing.

The main goal with this backport is getting M139 to build in the staging branch after `enable_base_tracing` was removed, but the fix itself can go directly to the main branch. Example M139 failure:

```
"python3" "../../build/toolchain/gcc_link_wrapper.py" --output="native_target/crashpad_handler" -- ../../third_party/llvm-build/Release+Asserts/bin/clang++ -Werror -fuse-ld=lld -Wl,--fatal-warnings -Wl,--build-id=fast -fPIC -Wl,-z,noexecstack -Wl,-z,relro -Wl,-z,now -Wl,--icf=all -Wl,--color-diagnostics -Wl,--undefined-version -Wl,--no-call-graph-profile-sort --target=x86_64-unknown-linux-gnu -no-canonical-prefixes -Wl,--gc-sections -Wl,--gdb-index -Wl,-z,defs -Wl,--as-needed --sysroot=../../build/linux/debian_bullseye_amd64-sysroot -Wl,--error-limit=0 -fuse-ld=lld -rdynamic -pie -Wl,--disable-new-dtags -Wl,-rpath=/home/rakuco/src/cobalt/src/out/evergreen-x64_debug/starboard -o "native_target/crashpad_handler" -Wl,--start-group @"native_target/crashpad_handler.rsp" -Wl,--end-group   ../../third_party/llvm-build/Release+Asserts/lib/clang/21/lib/x86_64-unknown-linux-gnu/libclang_rt.builtins.a -latomic -lEGL -lGLESv2 -lasound -ldl -lpthread -lrt -Wl,--start-group  -Wl,--end-group
build step: native_target_link "./native_target/crashpad_handler"
siso_rule: clang/link
stderr:
ld.lld: error: base/string_piece.o: DWARF unit at offset 0x00000000 has unsupported version 0, supported are 2-5
ld.lld: error: undefined symbol: base::WideToUTF8[abi:cxx11](base::BasicStringPiece<wchar_t, std::char_traits<wchar_t>>)
```

Bug: 543232095

---

Original commit message:

The name was misleading since the strings are not UTF at all. Strings in Chromium generally can hold any bit pattern that fits in the given size, and commonly do when they are non-constant data.

Change-Id: Ie97588340f2b6b7f9c9cb3c28f31ed21dd5fb660
Reviewed-on: https://chromium-review.googlesource.com/c/chromium/src/+/5007648
Cr-Commit-Position: refs/heads/main@{#1221176}