### PR TITLE
starboard: Add default value support to ExperimentalFeatureKey

### DIFF
--- a/media/base/starboard/experimental_features.h
+++ b/media/base/starboard/experimental_features.h
@@ -48,7 +48,7 @@ class MEDIA_EXPORT ExperimentalFeatureKey {
  public:
   using ValueType = T;
   using DefaultValueType =
-      std::conditional_t<std::is_same_v<T, std::string>, std::string_view, T>;
+      std::conditional_t<std::is_same_v<T, std::string>, const char*, T>;
 
   template <size_t N>
   constexpr explicit ExperimentalFeatureKey(const char (&key)[N])
@@ -99,8 +99,7 @@ class MEDIA_EXPORT ExperimentalFeatures {
   std::optional<T> Get(const ExperimentalFeatureKey<T>& key) const {
     auto it = settings_.find(key.key());
     if (it != settings_.end()) {
-      auto val = GetValue<T>(it->second);
-      if (val.has_value()) {
+      if (auto val = GetValue<T>(it->second); val.has_value()) {
         return val;
       }
     }

--- a/media/base/starboard/experimental_features.h
+++ b/media/base/starboard/experimental_features.h
@@ -47,15 +47,26 @@ template <typename T>
 class MEDIA_EXPORT ExperimentalFeatureKey {
  public:
   using ValueType = T;
+  using DefaultValueType =
+      std::conditional_t<std::is_same_v<T, std::string>, std::string_view, T>;
 
   template <size_t N>
   constexpr explicit ExperimentalFeatureKey(const char (&key)[N])
-      : key_(key, N - 1) {}
+      : key_(key, N - 1), default_value_(std::nullopt) {}
+
+  template <size_t N>
+  constexpr explicit ExperimentalFeatureKey(const char (&key)[N],
+                                            DefaultValueType default_value)
+      : key_(key, N - 1), default_value_(default_value) {}
 
   constexpr std::string_view key() const { return key_; }
+  constexpr const std::optional<DefaultValueType>& default_value() const {
+    return default_value_;
+  }
 
  private:
   std::string_view key_;
+  std::optional<DefaultValueType> default_value_;
 };
 
 // Encapsulates a key-value mapping of experimental feature settings configured
@@ -79,7 +90,7 @@ class MEDIA_EXPORT ExperimentalFeatures {
   ~ExperimentalFeatures();
 
   // Returns the boolean value for the given key, falling back to false if the
-  // key is missing or unset.
+  // key is missing or unset and has no default value.
   bool GetBool(const ExperimentalFeatureKey<bool>& key) const {
     return Get(key).value_or(false);
   }
@@ -87,10 +98,16 @@ class MEDIA_EXPORT ExperimentalFeatures {
   template <typename T>
   std::optional<T> Get(const ExperimentalFeatureKey<T>& key) const {
     auto it = settings_.find(key.key());
-    if (it == settings_.end()) {
-      return std::nullopt;
+    if (it != settings_.end()) {
+      auto val = GetValue<T>(it->second);
+      if (val.has_value()) {
+        return val;
+      }
     }
-    return GetValue<T>(it->second);
+    if (key.default_value().has_value()) {
+      return T(*key.default_value());
+    }
+    return std::nullopt;
   }
 
   const Map& settings() const { return settings_; }

--- a/media/base/starboard/experimental_features.h
+++ b/media/base/starboard/experimental_features.h
@@ -90,7 +90,7 @@ class MEDIA_EXPORT ExperimentalFeatures {
   ~ExperimentalFeatures();
 
   // Returns the boolean value for the given key, falling back to false if the
-  // key is missing or unset and has no default value.
+  // key is missing or is unset with no default value.
   bool GetBool(const ExperimentalFeatureKey<bool>& key) const {
     return Get(key).value_or(false);
   }

--- a/media/base/starboard/experimental_features_unittest.cc
+++ b/media/base/starboard/experimental_features_unittest.cc
@@ -22,9 +22,21 @@ namespace {
 constexpr ExperimentalFeatureKey<bool> kFooFeatureA("Foo.FeatureA");
 constexpr ExperimentalFeatureKey<bool> kFooFeatureB("Foo.FeatureB");
 constexpr ExperimentalFeatureKey<bool> kFooFeatureC("Foo.FeatureC");
+constexpr ExperimentalFeatureKey<bool> kFooFeatureDefaultFalse(
+    "Foo.FeatureDefaultFalse",
+    false);
+constexpr ExperimentalFeatureKey<bool> kFooFeatureDefaultTrue(
+    "Foo.FeatureDefaultTrue",
+    true);
 constexpr ExperimentalFeatureKey<int> kFooIntFeature("Foo.IntFeature");
+constexpr ExperimentalFeatureKey<int> kFooIntFeatureDefault(
+    "Foo.IntFeatureDefault",
+    100);
 constexpr ExperimentalFeatureKey<std::string> kFooStringFeature(
     "Foo.StringFeature");
+constexpr ExperimentalFeatureKey<std::string> kFooStringFeatureDefault(
+    "Foo.StringFeatureDefault",
+    "default_str");
 
 TEST(ExperimentalFeaturesTest, GetBool) {
   ExperimentalFeatures::Map map;
@@ -79,11 +91,50 @@ TEST(ExperimentalFeaturesTest, MissingKeyReturnsNullopt) {
 TEST(ExperimentalFeaturesTest, TypeMismatchReturnsNullopt) {
   ExperimentalFeatures::Map map;
   map["Foo.IntFeature"] = std::string("not_an_int");
+  map["Foo.IntFeatureDefault"] = std::string("not_an_int");
   map["Foo.StringFeature"] = static_cast<int64_t>(123);
   ExperimentalFeatures settings(map);
 
   EXPECT_EQ(settings.Get(kFooIntFeature), std::nullopt);
+  EXPECT_EQ(settings.Get(kFooIntFeatureDefault), std::optional<int>(100));
   EXPECT_EQ(settings.Get(kFooStringFeature), std::nullopt);
+}
+
+TEST(ExperimentalFeaturesTest, DefaultValuesWhenMissingOrUnset) {
+  ExperimentalFeatures settings;
+
+  EXPECT_FALSE(settings.GetBool(kFooFeatureDefaultFalse));
+  EXPECT_TRUE(settings.GetBool(kFooFeatureDefaultTrue));
+  EXPECT_EQ(settings.Get(kFooFeatureDefaultFalse), std::optional<bool>(false));
+  EXPECT_EQ(settings.Get(kFooFeatureDefaultTrue), std::optional<bool>(true));
+  EXPECT_EQ(settings.Get(kFooIntFeatureDefault), std::optional<int>(100));
+  EXPECT_EQ(settings.Get(kFooStringFeatureDefault),
+            std::optional<std::string>("default_str"));
+}
+
+TEST(ExperimentalFeaturesTest, SettingOverridesDefaultValue) {
+  ExperimentalFeatures::Map map;
+  map["Foo.FeatureDefaultFalse"] = static_cast<int64_t>(1);
+  map["Foo.FeatureDefaultTrue"] = static_cast<int64_t>(0);
+  map["Foo.IntFeatureDefault"] = static_cast<int64_t>(200);
+  map["Foo.StringFeatureDefault"] = std::string("custom_str");
+  ExperimentalFeatures settings(map);
+
+  EXPECT_TRUE(settings.GetBool(kFooFeatureDefaultFalse));
+  EXPECT_FALSE(settings.GetBool(kFooFeatureDefaultTrue));
+  EXPECT_EQ(settings.Get(kFooFeatureDefaultFalse), std::optional<bool>(true));
+  EXPECT_EQ(settings.Get(kFooFeatureDefaultTrue), std::optional<bool>(false));
+  EXPECT_EQ(settings.Get(kFooIntFeatureDefault), std::optional<int>(200));
+  EXPECT_EQ(settings.Get(kFooStringFeatureDefault),
+            std::optional<std::string>("custom_str"));
+}
+
+TEST(ExperimentalFeaturesTest, IntSentinelFallsBackToDefault) {
+  ExperimentalFeatures::Map map;
+  map["Foo.IntFeatureDefault"] = static_cast<int64_t>(0);
+  ExperimentalFeatures settings(map);
+
+  EXPECT_EQ(settings.Get(kFooIntFeatureDefault), std::optional<int>(100));
 }
 
 }  // namespace

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -47,13 +47,26 @@ template <typename T>
 class ExperimentalFeatureKey {
  public:
   using ValueType = T;
+  using DefaultValueType =
+      std::conditional_t<std::is_same_v<T, std::string>, std::string_view, T>;
+
   template <size_t N>
   constexpr explicit ExperimentalFeatureKey(const char (&key)[N])
-      : key_(key, N - 1) {}
+      : key_(key, N - 1), default_value_(std::nullopt) {}
+
+  template <size_t N>
+  constexpr explicit ExperimentalFeatureKey(const char (&key)[N],
+                                            DefaultValueType default_value)
+      : key_(key, N - 1), default_value_(default_value) {}
+
   constexpr std::string_view key() const { return key_; }
+  constexpr const std::optional<DefaultValueType>& default_value() const {
+    return default_value_;
+  }
 
  private:
   std::string_view key_;
+  std::optional<DefaultValueType> default_value_;
 };
 
 // Container for experimental feature settings stored per-thread in Starboard.
@@ -70,7 +83,7 @@ class ExperimentalFeatures {
   ~ExperimentalFeatures() = default;
 
   // Returns the boolean value for the given key, falling back to false if the
-  // key is missing or unset.
+  // key is missing or unset and has no default value.
   bool GetBool(const ExperimentalFeatureKey<bool>& key) const {
     return Get(key).value_or(false);
   }
@@ -78,10 +91,15 @@ class ExperimentalFeatures {
   template <typename T>
   std::optional<T> Get(const ExperimentalFeatureKey<T>& key) const {
     auto it = settings_.find(key.key());
-    if (it == settings_.end()) {
-      return std::nullopt;
+    if (it != settings_.end()) {
+      if (auto val = GetValue<T>(it->second); val.has_value()) {
+        return val;
+      }
     }
-    return GetValue<T>(it->second);
+    if (key.default_value().has_value()) {
+      return T(*key.default_value());
+    }
+    return std::nullopt;
   }
 
   friend std::ostream& operator<<(std::ostream& os,

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -48,7 +48,7 @@ class ExperimentalFeatureKey {
  public:
   using ValueType = T;
   using DefaultValueType =
-      std::conditional_t<std::is_same_v<T, std::string>, std::string_view, T>;
+      std::conditional_t<std::is_same_v<T, std::string>, const char*, T>;
 
   template <size_t N>
   constexpr explicit ExperimentalFeatureKey(const char (&key)[N])

--- a/starboard/shared/starboard/experimental_features.h
+++ b/starboard/shared/starboard/experimental_features.h
@@ -83,7 +83,7 @@ class ExperimentalFeatures {
   ~ExperimentalFeatures() = default;
 
   // Returns the boolean value for the given key, falling back to false if the
-  // key is missing or unset and has no default value.
+  // key is missing or is unset with no default value.
   bool GetBool(const ExperimentalFeatureKey<bool>& key) const {
     return Get(key).value_or(false);
   }

--- a/starboard/shared/starboard/player/filter/testing/experimental_features_test.cc
+++ b/starboard/shared/starboard/player/filter/testing/experimental_features_test.cc
@@ -24,8 +24,19 @@ namespace starboard {
 namespace {
 
 constexpr ExperimentalFeatureKey<bool> kTestBoolKey("Test.BoolKey");
+constexpr ExperimentalFeatureKey<bool> kTestBoolKeyDefaultFalse(
+    "Test.BoolKeyDefaultFalse",
+    false);
+constexpr ExperimentalFeatureKey<bool> kTestBoolKeyDefaultTrue(
+    "Test.BoolKeyDefaultTrue",
+    true);
 constexpr ExperimentalFeatureKey<int> kTestIntKey("Test.IntKey");
+constexpr ExperimentalFeatureKey<int> kTestIntKeyDefault("Test.IntKeyDefault",
+                                                         100);
 constexpr ExperimentalFeatureKey<std::string> kTestStringKey("Test.StringKey");
+constexpr ExperimentalFeatureKey<std::string> kTestStringKeyDefault(
+    "Test.StringKeyDefault",
+    "default_str");
 
 TEST(StarboardExperimentalFeaturesTest, BasicGetters) {
   ExperimentalFeatures::Map map;
@@ -61,10 +72,49 @@ TEST(StarboardExperimentalFeaturesTest, IntOutOfBoundsReturnsNullopt) {
 TEST(StarboardExperimentalFeaturesTest, MissingKeysAndTypeMismatch) {
   ExperimentalFeatures::Map map;
   map["Test.IntKey"] = std::string("not_an_int");
+  map["Test.IntKeyDefault"] = std::string("not_an_int");
   ExperimentalFeatures features(map);
 
   EXPECT_EQ(features.Get(kTestBoolKey), std::nullopt);
   EXPECT_EQ(features.Get(kTestIntKey), std::nullopt);
+  EXPECT_EQ(features.Get(kTestIntKeyDefault), std::optional<int>(100));
+}
+
+TEST(StarboardExperimentalFeaturesTest, DefaultValuesWhenMissingOrUnset) {
+  ExperimentalFeatures features;
+
+  EXPECT_FALSE(features.GetBool(kTestBoolKeyDefaultFalse));
+  EXPECT_TRUE(features.GetBool(kTestBoolKeyDefaultTrue));
+  EXPECT_EQ(features.Get(kTestBoolKeyDefaultFalse), std::optional<bool>(false));
+  EXPECT_EQ(features.Get(kTestBoolKeyDefaultTrue), std::optional<bool>(true));
+  EXPECT_EQ(features.Get(kTestIntKeyDefault), std::optional<int>(100));
+  EXPECT_EQ(features.Get(kTestStringKeyDefault),
+            std::optional<std::string>("default_str"));
+}
+
+TEST(StarboardExperimentalFeaturesTest, SettingOverridesDefaultValue) {
+  ExperimentalFeatures::Map map;
+  map["Test.BoolKeyDefaultFalse"] = static_cast<int64_t>(1);
+  map["Test.BoolKeyDefaultTrue"] = static_cast<int64_t>(0);
+  map["Test.IntKeyDefault"] = static_cast<int64_t>(200);
+  map["Test.StringKeyDefault"] = std::string("custom_str");
+  ExperimentalFeatures features(map);
+
+  EXPECT_TRUE(features.GetBool(kTestBoolKeyDefaultFalse));
+  EXPECT_FALSE(features.GetBool(kTestBoolKeyDefaultTrue));
+  EXPECT_EQ(features.Get(kTestBoolKeyDefaultFalse), std::optional<bool>(true));
+  EXPECT_EQ(features.Get(kTestBoolKeyDefaultTrue), std::optional<bool>(false));
+  EXPECT_EQ(features.Get(kTestIntKeyDefault), std::optional<int>(200));
+  EXPECT_EQ(features.Get(kTestStringKeyDefault),
+            std::optional<std::string>("custom_str"));
+}
+
+TEST(StarboardExperimentalFeaturesTest, IntSentinelFallsBackToDefault) {
+  ExperimentalFeatures::Map map;
+  map["Test.IntKeyDefault"] = static_cast<int64_t>(0);
+  ExperimentalFeatures features(map);
+
+  EXPECT_EQ(features.Get(kTestIntKeyDefault), std::optional<int>(100));
 }
 
 TEST(StarboardExperimentalFeaturesTest, OutputStreamOperatorFormatsCorrectly) {


### PR DESCRIPTION
Add optional default value support to ExperimentalFeatureKey in both starboard/shared/starboard/experimental_features.h and media/base/starboard/experimental_features.h.

When experimental features are missing from settings, unset by sentinel, or type-mismatched, ExperimentalFeatures::Get falls back to the key's default value if specified, or std::nullopt otherwise.

Issue: 543888537