### PR TITLE
Separate main and chromium autorollers.

### DIFF
--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -1,0 +1,164 @@
+name: Autoroll Chromium
+
+on:
+  schedule:
+    - cron: '0 */4 * * *' # Every 4th hour.
+  workflow_dispatch:
+    inputs:
+      max_commits:
+        description: 'Max number of commits to include on a single PR'
+        type: number
+        default: 10
+
+permissions:
+  contents: read
+
+jobs:
+  autoroll:
+    runs-on: ubuntu-latest
+    env:
+      DEPOT_TOOLS_METRICS: 0
+      GIT_AUTHOR_NAME: "cobalt-github-releaser-bot"
+      GIT_AUTHOR_EMAIL: "95661244+cobalt-github-releaser-bot@users.noreply.github.com"
+      GIT_COMMITTER_NAME: "cobalt-github-releaser-bot"
+      GIT_COMMITTER_EMAIL: "95661244+cobalt-github-releaser-bot@users.noreply.github.com"
+    permissions:
+      contents: write
+      pull-requests: write
+    defaults:
+      run:
+        working-directory: src
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: [
+          {source: chromium/main, target: staging, autoroll: .github/AUTOROLL_CHROMIUM},
+        ]
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          path: src
+          ref: main
+          fetch-depth: 1000
+          token: ${{ secrets.CHERRY_PICK_TOKEN }}
+
+      - name: Prepare Cherry Pick Branch
+        env:
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
+          FETCH_DEPTH: 1000
+        run: |
+          set -x
+
+          git config --global submodule.recurse false
+
+          # Copy script from main branch.
+          git show main:.github/scripts/autoroll_lts.py > "${RUNNER_TEMP}/autoroll_lts.py"
+
+          git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules origin "${TARGET_BRANCH}:${TARGET_BRANCH}"
+
+          # Use existing branch from remote if it exists, otherwise start from target branch.
+          if git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules origin "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"; then
+            git checkout --no-recurse-submodules -B "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" FETCH_HEAD
+          else
+            git checkout --no-recurse-submodules -B "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" "${TARGET_BRANCH}" --no-track
+          fi
+
+          # Fetch enough history for source branch.
+          git fetch --depth="${FETCH_DEPTH}" --no-recurse-submodules origin "${SOURCE_BRANCH}:${SOURCE_BRANCH}"
+
+      - name: Get Existing PR Info
+        id: pr_info
+        env:
+          GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+        run: |
+          # Get the first commit SHA of the existing PR.
+          # If the PR doesn't exist, it returns an empty string.
+          FIRST_SHA=$(gh pr list --head "autoroll-${{ matrix.branch.source }}-to-${{ matrix.branch.target }}" --state open --json commits --jq '.[0].commits[0].oid // ""')
+          echo "first_sha=$FIRST_SHA" >> "$GITHUB_OUTPUT"
+
+      - name: Set Up Depot Tools
+        run: |
+          DEPOT_TOOLS_TEMP="${RUNNER_TEMP}/depot_tools"
+          git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "$DEPOT_TOOLS_TEMP"
+          echo "$DEPOT_TOOLS_TEMP" >> $GITHUB_PATH
+          source "${DEPOT_TOOLS_TEMP}/bootstrap_python3" && bootstrap_python3
+
+      - name: Cherry Pick Merged PRs
+        id: autoroll
+        env:
+          MAX_COMMITS: ${{ inputs.max_commits || 10 }}
+        run: |
+          set -x
+
+          # Run the Python script to perform cherry-picks and get all PR links.
+          PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_lts.py" \
+            --source-branch "${{ matrix.branch.source }}" \
+            --target-branch "${{ matrix.branch.target }}" \
+            --autoroll-file "${{ matrix.branch.autoroll }}" \
+            --max-commits "${{ env.MAX_COMMITS }}" \
+            --existing-pr-sha "${{ steps.pr_info.outputs.first_sha }}")
+
+          if [[ -n "${PR_LINKS}" ]]; then
+            echo "cherry_picked=true" >> "$GITHUB_OUTPUT"
+            {
+              echo "pr_links<<EOF"
+              echo "${PR_LINKS}"
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No commits to roll found."
+          fi
+
+      - name: Push and Create PR
+        if: steps.autoroll.outputs.pr_links != ''
+        env:
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
+          GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+          PR_LINKS: ${{ steps.autoroll.outputs.pr_links }}
+        run: |
+          set -x
+
+          git push origin "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"
+
+          PR_TITLE="Autoroll from ${SOURCE_BRANCH} to ${TARGET_BRANCH}"
+
+          PR_BODY_FILE=$(mktemp)
+          {
+            echo "Automated cherry-pick roll to ${TARGET_BRANCH}."
+            echo ""
+            echo "Original pull requests:"
+            echo "${PR_LINKS}"
+          } > "${PR_BODY_FILE}"
+
+          if [[ -f "${{ matrix.branch.autoroll }}" ]] && grep -q "^CONFLICTED:" "${{ matrix.branch.autoroll }}"; then
+            PR_TITLE="$(git log -1 --pretty=%s)"
+            {
+              echo ""
+              echo "⚠️ This PR has conflicts that must be resolved manually (don't forget to update the \`${{ matrix.branch.autoroll }}\` file). Use the following commands to checkout the branch locally and resolve the conflicts in a separate commit:"
+              echo ""
+              echo '```bash'
+              echo "gh pr checkout <pull_request_number> -R ${{ github.repository }}"
+              echo ""
+              echo "# Resolve conflicts and update ${{ matrix.branch.autoroll }} then"
+              echo "git add <resolved_files>"
+              echo ""
+              echo "# Copy CONFLICTED commit's message and metadata"
+              echo "# Replace CONFLICTED in title with RESOLVED"
+              echo "git commit -c <conflicted_sha>"
+              echo ""
+              echo "git push origin autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}"
+              echo '```'
+            } >> "${PR_BODY_FILE}"
+          fi
+
+          PR_STATE=$(gh pr view "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --json state --template '{{.state}}' 2>/dev/null || echo "NOT_FOUND")
+
+          if [[ "${PR_STATE}" == "OPEN" ]]; then
+            PR_NUMBER=$(gh pr view "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --json number --jq .number)
+            gh api -X PATCH "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" -f title="${PR_TITLE}" -f body="$(cat "${PR_BODY_FILE}")" --jq .html_url
+          else
+            gh pr create --base "${TARGET_BRANCH}" --head "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --title "${PR_TITLE}" --body-file "${PR_BODY_FILE}" --reviewer linxinan-yt,oxve,briantting
+          fi

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -1,4 +1,4 @@
-name: Autoroll LTS
+name: Autoroll Main
 
 on:
   schedule:
@@ -17,7 +17,6 @@ jobs:
   autoroll:
     runs-on: ubuntu-latest
     env:
-      DEPOT_TOOLS_METRICS: 0
       GIT_AUTHOR_NAME: "cobalt-github-releaser-bot"
       GIT_AUTHOR_EMAIL: "95661244+cobalt-github-releaser-bot@users.noreply.github.com"
       GIT_COMMITTER_NAME: "cobalt-github-releaser-bot"
@@ -34,7 +33,6 @@ jobs:
         branch: [
           {source: main, target: 27.lts, autoroll: .github/AUTOROLL},
           {source: main, target: staging, autoroll: .github/AUTOROLL},
-          {source: chromium/main, target: staging, autoroll: .github/AUTOROLL_CHROMIUM},
         ]
     steps:
       - name: Checkout code
@@ -43,6 +41,7 @@ jobs:
           path: src
           ref: main
           fetch-depth: 1000
+          filter: blob:none
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
 
       - name: Prepare Cherry Pick Branch
@@ -79,14 +78,6 @@ jobs:
           # If the PR doesn't exist, it returns an empty string.
           FIRST_SHA=$(gh pr list --head "autoroll-${{ matrix.branch.source }}-to-${{ matrix.branch.target }}" --state open --json commits --jq '.[0].commits[0].oid // ""')
           echo "first_sha=$FIRST_SHA" >> "$GITHUB_OUTPUT"
-
-      - name: Set Up Depot Tools
-        if: startsWith(matrix.branch.source, 'chromium/')
-        run: |
-          DEPOT_TOOLS_TEMP="${RUNNER_TEMP}/depot_tools"
-          git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "$DEPOT_TOOLS_TEMP"
-          echo "$DEPOT_TOOLS_TEMP" >> $GITHUB_PATH
-          source "${DEPOT_TOOLS_TEMP}/bootstrap_python3" && bootstrap_python3
 
       - name: Cherry Pick Merged PRs
         id: autoroll


### PR DESCRIPTION
This way each autoroller can be triggered independently and run fewer steps so that it may run faster. The yamls are the same but with the main yaml missing depot_tools setup and with a leaner blobless checkout.

Bug: 543555380