### PR TITLE
feat(tvos): export dynamic flags for downstream test integration

### DIFF
--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -149,7 +149,8 @@ EOF
 
   # Handshake: Tell Kokoro (Child Job) where the binary is
   # Create the folder directly under KOKORO_ARTIFACTS_DIR
-  mkdir -p "${KOKORO_ARTIFACTS_DIR}/build_vars"
+  local artifacts_dir="${KOKORO_ARTIFACTS_DIR:-.}"
+  mkdir -p "${artifacts_dir}/build_vars"
 
   # Use the script's own 'build_id' variable for consistency
   BIGSTORE_ROOT="/bigstore/${bucket}/kokoro/build/${TARGET_PLATFORM}_${CONFIG}/${build_id}"
@@ -157,10 +158,10 @@ EOF
   # Pass the main artifact to the lab test
   GCS_FILE_PATH="${BIGSTORE_ROOT}/cobalt_unittests.tar.gz"
 
-  # Write the file directly under KOKORO_ARTIFACTS_DIR
-  echo "--define=tvos_gunit_test_package=${GCS_FILE_PATH}" > "${KOKORO_ARTIFACTS_DIR}/build_vars/dynamic_flags.txt"
-  echo "Wrote dynamic flags to ${KOKORO_ARTIFACTS_DIR}/build_vars/dynamic_flags.txt:"
-  cat "${KOKORO_ARTIFACTS_DIR}/build_vars/dynamic_flags.txt"
+  # Write the file directly under artifacts_dir
+  echo "--define=tvos_gunit_test_package=${GCS_FILE_PATH}" > "${artifacts_dir}/build_vars/dynamic_flags.txt"
+  echo "Wrote dynamic flags to ${artifacts_dir}/build_vars/dynamic_flags.txt:"
+  cat "${artifacts_dir}/build_vars/dynamic_flags.txt"
 }
 
 

--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -146,6 +146,21 @@ EOF
       "${GSUTIL}" cp "${archive_file}" "${gcs_archive_path}"
     fi
   done
+
+  # Handshake: Tell Kokoro (Child Job) where the binary is
+  # Create the folder directly under KOKORO_ARTIFACTS_DIR
+  mkdir -p "${KOKORO_ARTIFACTS_DIR}/build_vars"
+
+  # Use the script's own 'build_id' variable for consistency
+  BIGSTORE_ROOT="/bigstore/${bucket}/kokoro/build/${TARGET_PLATFORM}_${CONFIG}/${build_id}"
+
+  # Pass the main artifact to the lab test
+  GCS_FILE_PATH="${BIGSTORE_ROOT}/cobalt_unittests.tar.gz"
+
+  # Write the file directly under KOKORO_ARTIFACTS_DIR
+  echo "--define=tvos_gunit_test_package=${GCS_FILE_PATH}" > "${KOKORO_ARTIFACTS_DIR}/build_vars/dynamic_flags.txt"
+  echo "Wrote dynamic flags to ${KOKORO_ARTIFACTS_DIR}/build_vars/dynamic_flags.txt:"
+  cat "${KOKORO_ARTIFACTS_DIR}/build_vars/dynamic_flags.txt"
 }
 
 

--- a/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
@@ -26,6 +26,15 @@ build = common.build {
       }
     },
   ]
+  action = [
+    {
+      define_artifacts = {
+        regex = [
+          'build_vars/dynamic_flags.txt',
+        ]
+      }
+    },
+  ]
   env_vars = super.env_vars + [
     {
       key = 'EXTRA_GN_ARGUMENTS'

--- a/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
@@ -26,7 +26,7 @@ build = common.build {
       }
     },
   ]
-  action = [
+  action = super.action + [
     {
       define_artifacts = {
         regex = [


### PR DESCRIPTION
  Added mechanism to pass dynamic build variables (like the GCS path of the built binary) to child Kokoro jobs.
  
  ### Rationale
  This completes the "Handshake" with the Google3/Piper side of the tvOS testing pipeline. The script now writes a `dynamic_flags.txt` file which is captured as an artifact and passed to the child test job, allowing Blaze to know exactly which binary instance to test.
  
  ### Changes
  - Appended flag generation to `presubmit_build_mac.sh`.
  - Added `define_artifacts` to `common.gcl` to preserve the flags file.

Bug: 538697105