### PR TITLE
fix(tvos): use conditional validation for pipeline actions

### DIFF
--- a/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
@@ -26,7 +26,7 @@ build = common.build {
       }
     },
   ]
-  action = super.action + [
+  action = cond(super.has_attribute('action'), super.action, []) + [
     {
       define_artifacts = {
         regex = [

--- a/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
@@ -26,7 +26,7 @@ build = common.build {
       }
     },
   ]
-  action = cond(super.has_attribute('action'), super.action, []) + [
+  action = super.get('action', []) + [
     {
       define_artifacts = {
         regex = [


### PR DESCRIPTION
Fixes a GCL parsing error in the tvOS Kokoro build configuration.
  
### Rationale
The previous addition of `super.action` caused a crash during parsing because the parent `common.gcl` file does not define an `action` block to inherit from. 
  
This PR updates it to use conditional validation (`cond`), ensuring it safely appends to parent actions if they exist tomorrow, but doesn't crash today while they are absent.
  
### Changes
- Updated `action` block in `cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl` with safer inheritance logic.
  
Bug: 538697105