### PR TITLE
Remove unneeded filter: blob:none from autoroller.

### DIFF
--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -41,7 +41,6 @@ jobs:
           path: src
           ref: main
           fetch-depth: 1000
-          filter: blob:none
           token: ${{ secrets.CHERRY_PICK_TOKEN }}
 
       - name: Prepare Cherry Pick Branch


### PR DESCRIPTION
This ends up slowing down the checkout rather than speeding it up.

Bug: 543555380