### PR TITLE
cobalt: Log memory pressure level in Blink

### DIFF
--- a/third_party/blink/renderer/platform/instrumentation/memory_pressure_listener.cc
+++ b/third_party/blink/renderer/platform/instrumentation/memory_pressure_listener.cc
@@ -29,6 +29,23 @@
 
 namespace blink {
 
+#if BUILDFLAG(IS_COBALT)
+namespace {
+const char* MemoryPressureLevelToString(
+    base::MemoryPressureListener::MemoryPressureLevel level) {
+  switch (level) {
+    case base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_NONE:
+      return "NONE";
+    case base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_MODERATE:
+      return "MODERATE";
+    case base::MemoryPressureListener::MEMORY_PRESSURE_LEVEL_CRITICAL:
+      return "CRITICAL";
+  }
+  return "UNKNOWN";
+}
+}  // namespace
+#endif  // BUILDFLAG(IS_COBALT)
+
 // Function defined in third_party/blink/public/web/blink.h.
 void DecommitFreeableMemory() {
   CHECK(IsMainThread());
@@ -124,8 +141,9 @@ void MemoryPressureListenerRegistry::OnMemoryPressure(
   TRACE_EVENT1("blink", "MemoryPressureListenerRegistry::onMemoryPressure",
                "level", level);
 #if BUILDFLAG(IS_COBALT)
-  LOG(INFO) << "Blink handling OnMemoryPressure";
-#endif
+  LOG(INFO) << "Blink handling OnMemoryPressure, level: " << level
+            << " (" << MemoryPressureLevelToString(level) << ")";
+#endif  // BUILDFLAG(IS_COBALT)
   CHECK(IsMainThread());
   for (auto& client : clients_)
     client->OnMemoryPressure(level);


### PR DESCRIPTION
Update the Blink memory pressure listener to include the specific
memory pressure level in the logs. This change provides better
visibility into system state when memory pressure events are
triggered in Cobalt, logging both the integer value and its
corresponding string representation.

Bug: 544527373