### PR TITLE
build: Preserve cpuinfo subtree line endings

### DIFF
--- a/third_party/cpuinfo/.gitattributes
+++ b/third_party/cpuinfo/.gitattributes
@@ -1,0 +1,2 @@
+# src/ is an imported subtree; keep upstream line endings byte-for-byte.
+src/** -text


### PR DESCRIPTION
Disable text normalization for the third_party/cpuinfo/src subtree to
ensure upstream CRLF line endings are preserved byte-for-byte. The
repository-wide LF normalization rule currently conflicts with these
imported files, causing them to appear as modified in git status
indefinitely. This occurs because the index hash, filtered through
the clean rule, never matches the working tree content.
Mark the imported tree -text so git leaves those blobs alone.

For example, without this, deleting one of the files and restoring it leaves it modified:

    $ rm third_party/cpuinfo/src/src/arm/windows/init.c
    $ git checkout -- third_party/cpuinfo/src/src/arm/windows/init.c
    $ git status --short
    M third_party/cpuinfo/src/src/arm/windows/init.c

Bug: 544755085