### PR TITLE
android: Fix broken AudioFocus

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -135,6 +135,14 @@ public final class CommandLineOverrideHelper {
     // Disable FontSrcLocalMatching lookup table.
     paramOverrides.add("FontSrcLocalMatching");
 
+    // Disable deferring audio focus until audible for Starboard/Cobalt:
+    // 1. Cobalt runs on living-room/TV devices where playback is user-initiated
+    // and should acquire audio focus immediately.
+    // 2. Starboard renders audio directly to native audio sinks, bypassing
+    // Chromium's AudioStreamMonitor, so WebContents is never reported as
+    // audible, meaning deferred audio focus is never executed.
+    paramOverrides.add("DeferAudioFocusUntilAudible");
+
     return paramOverrides;
   }
 

--- a/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
+++ b/cobalt/android/apk/app/src/test/java/dev/cobalt/coat/CommandLineOverrideHelperTest.java
@@ -58,6 +58,7 @@ public class CommandLineOverrideHelperTest {
     String overrides = CommandLineOverrideHelper.getDefaultDisableFeatureOverridesList().toString();
     assertThat(overrides.contains("PartitionAllocBackupRefPtr")).isTrue();
     assertThat(overrides.contains("UseAAudioInput")).isTrue();
+    assertThat(overrides.contains("DeferAudioFocusUntilAudible")).isTrue();
   }
 
   @Test

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -641,15 +641,7 @@ BASE_FEATURE(kDedicatedMediaServiceThread,
 // background apps on android, where focus is typically exclusive.
 BASE_FEATURE(kDeferAudioFocusUntilAudible,
              "DeferAudioFocusUntilAudible",
-#if BUILDFLAG(USE_STARBOARD_MEDIA)
-// Disabled for Starboard/Cobalt for the following reasons:
-// 1. Cobalt runs on living-room/TV devices where playback is user-initiated and
-//    should acquire audio focus immediately.
-// 2. Starboard renders audio directly to native audio sinks, bypassing
-//    Chromium's AudioStreamMonitor, so WebContents is never reported as
-//    audible, meaning deferred audio focus is never executed.
-             base::FEATURE_DISABLED_BY_DEFAULT
-#elif BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID)
              base::FEATURE_ENABLED_BY_DEFAULT
 #else
              base::FEATURE_DISABLED_BY_DEFAULT

--- a/media/base/media_switches.cc
+++ b/media/base/media_switches.cc
@@ -641,7 +641,15 @@ BASE_FEATURE(kDedicatedMediaServiceThread,
 // background apps on android, where focus is typically exclusive.
 BASE_FEATURE(kDeferAudioFocusUntilAudible,
              "DeferAudioFocusUntilAudible",
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+// Disabled for Starboard/Cobalt for the following reasons:
+// 1. Cobalt runs on living-room/TV devices where playback is user-initiated and
+//    should acquire audio focus immediately.
+// 2. Starboard renders audio directly to native audio sinks, bypassing
+//    Chromium's AudioStreamMonitor, so WebContents is never reported as
+//    audible, meaning deferred audio focus is never executed.
+             base::FEATURE_DISABLED_BY_DEFAULT
+#elif BUILDFLAG(IS_ANDROID)
              base::FEATURE_ENABLED_BY_DEFAULT
 #else
              base::FEATURE_DISABLED_BY_DEFAULT


### PR DESCRIPTION
In Cobalt 27 (Chromium M138 rebase), audio focus acquisition broke due to
upstream change: https://source.chromium.org/chromium/chromium/src/+/2f389a545e01f038fd91a57ea2960480bde1f803,
which enabled kDeferAudioFocusUntilAudible by default on Android.

While this feature was designed to prevent silent autoplaying media from
stealing focus on mobile browsers, it causes audio focus requests to be
permanently deferred in Cobalt because:
 1. Cobalt runs on living-room/TV devices where media playback is
     user-initiated and intended to acquire audio focus immediately.
  2. Starboard renders media audio directly to native audio sinks
     (e.g., AudioTrack / AAudio), bypassing Chromium's AudioStreamMonitor,
     so WebContents is never reported as audible to Chromium's browser
     process.

Issue: 542680307