### PR TITLE
starboard: Set audio usage and content type on NdkAudioTrack

### DIFF
--- a/starboard/android/shared/aaudio_loader.cc
+++ b/starboard/android/shared/aaudio_loader.cc
@@ -57,6 +57,9 @@ bool LoadSymbols() {
                  StreamBuilder_SetDataCallback);
   RESOLVE_SYMBOL(AAudioStreamBuilder_setBufferCapacityInFrames,
                  StreamBuilder_SetBufferCapacityInFrames);
+  RESOLVE_SYMBOL(AAudioStreamBuilder_setUsage, StreamBuilder_SetUsage);
+  RESOLVE_SYMBOL(AAudioStreamBuilder_setContentType,
+                 StreamBuilder_SetContentType);
   RESOLVE_SYMBOL(AAudioStreamBuilder_openStream, StreamBuilder_OpenStream);
   RESOLVE_SYMBOL(AAudioStream_close, Stream_Close);
   RESOLVE_SYMBOL(AAudioStream_requestStart, Stream_RequestStart);
@@ -104,6 +107,10 @@ void (*AAudio::StreamBuilder_SetDataCallback)(AAudioStreamBuilder*,
                                               void*) = nullptr;
 void (*AAudio::StreamBuilder_SetBufferCapacityInFrames)(AAudioStreamBuilder*,
                                                         int32_t) = nullptr;
+void (*AAudio::StreamBuilder_SetUsage)(AAudioStreamBuilder*,
+                                       aaudio_usage_t) = nullptr;
+void (*AAudio::StreamBuilder_SetContentType)(AAudioStreamBuilder*,
+                                             aaudio_content_type_t) = nullptr;
 aaudio_result_t (*AAudio::StreamBuilder_OpenStream)(AAudioStreamBuilder*,
                                                     AAudioStream**) = nullptr;
 aaudio_result_t (*AAudio::Stream_Close)(AAudioStream*) = nullptr;

--- a/starboard/android/shared/aaudio_loader.h
+++ b/starboard/android/shared/aaudio_loader.h
@@ -56,6 +56,11 @@ class AAudio {
   static void (*StreamBuilder_SetBufferCapacityInFrames)(
       AAudioStreamBuilder* builder,
       int32_t numFrames);
+  static void (*StreamBuilder_SetUsage)(AAudioStreamBuilder* builder,
+                                        aaudio_usage_t usage);
+  static void (*StreamBuilder_SetContentType)(
+      AAudioStreamBuilder* builder,
+      aaudio_content_type_t contentType);
   static aaudio_result_t (*StreamBuilder_OpenStream)(
       AAudioStreamBuilder* builder,
       AAudioStream** stream);

--- a/starboard/android/shared/ndk_audio_track.cc
+++ b/starboard/android/shared/ndk_audio_track.cc
@@ -75,7 +75,11 @@ std::unique_ptr<NdkAudioTrack> NdkAudioTrack::Create(
   AAudio::StreamBuilder_SetSampleRate(builder, sampling_frequency_hz);
   AAudio::StreamBuilder_SetChannelCount(builder, channels);
   AAudio::StreamBuilder_SetFormat(builder, AAUDIO_FORMAT_PCM_FLOAT);
-
+  AAudio::StreamBuilder_SetUsage(
+      builder, is_web_audio ? AAUDIO_USAGE_NOTIFICATION : AAUDIO_USAGE_MEDIA);
+  AAudio::StreamBuilder_SetContentType(
+      builder,
+      is_web_audio ? AAUDIO_CONTENT_TYPE_MUSIC : AAUDIO_CONTENT_TYPE_MOVIE);
   std::optional<int> preferred_frames;
   if (preferred_buffer_size_in_bytes > 0) {
     preferred_frames =


### PR DESCRIPTION
Align `NdkAudioTrack` stream builder configuration with `AudioTrackBridge`
to ensure consistent audio behavior on Android. This change sets the
AAudio stream usage and content type based on whether the source is
WebAudio, matching the logic used in other audio paths.

Issue: 428008986