### PR TITLE
Add switch to reduce thread stack sizes

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/coat/CommandLineOverrideHelper.java
@@ -121,6 +121,14 @@ public final class CommandLineOverrideHelper {
         paramOverrides.add("ReclaimPrepaintTilesWhenIdle");
         paramOverrides.add("ReclaimOldPrepaintTiles");
 
+        // Reduce default thread stacks from the platform default (1MB on
+        // bionic) to 256KB. High-risk threads are carved out explicitly:
+        // the in-process renderer and GPU main threads, and all Blink
+        // NonMainThreads. Both features are needed for full coverage --
+        // Starboard threads bypass base::PlatformThread entirely.
+        paramOverrides.add("ReduceAndroidThreadStackSize");
+        paramOverrides.add("ReduceStarboardThreadStackSize");
+
         return paramOverrides;
     }
 

--- a/third_party/blink/renderer/platform/scheduler/worker/non_main_thread_impl.cc
+++ b/third_party/blink/renderer/platform/scheduler/worker/non_main_thread_impl.cc
@@ -20,6 +20,7 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/threading/thread_restrictions.h"
 #include "base/time/default_tick_clock.h"
+#include "build/build_config.h"
 #include "mojo/public/cpp/bindings/direct_receiver.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/platform/task_type.h"
@@ -53,6 +54,18 @@ NonMainThreadImpl::NonMainThreadImpl(const ThreadCreationParams& params)
       supports_gc_(params.supports_gc) {
   base::SimpleThread::Options options;
   options.thread_type = params.base_thread_type;
+
+#if BUILDFLAG(IS_COBALT)
+  // When "ReduceAndroidThreadStackSize" is enabled, the default stack size for
+  // helper threads is reduced to 256KB to save virtual memory. Worker backing
+  // threads host their own V8 isolate, and V8Initializer::InitializeWorker()
+  // tells that isolate it has kWorkerMaxStackSize (500KB) available below the
+  // entry point. With a 256KB stack the isolate's stack guard would sit past
+  // the real stack bottom, turning a catchable RangeError into a SIGSEGV.
+  // Exclude all NonMainThreads from the reduction, matching the carve-outs in
+  // RenderProcessHostImpl and GpuProcessHost.
+  options.stack_size = 1024 * 1024;
+#endif
 
   base::MessagePumpType message_pump_type = base::MessagePumpType::DEFAULT;
   if (params.thread_type == ThreadType::kCompositorThread &&


### PR DESCRIPTION
Reduce default thread stack size to 256KB on Android and Starboard

Enables ReduceAndroidThreadStackSize and ReduceStarboardThreadStackSize
by default in Cobalt on Android TV. This reduces default helper thread stacks
(ThreadPool workers and Starboard threads) from 1MB (bionic default) to 256KB,
saving ~30MB of Virtual Memory (VA) on low-memory Android TV devices.

Includes a prerequisite carveout in NonMainThreadImpl constructor setting
options.stack_size = 1024 * 1024 for BUILDFLAG(IS_COBALT). Worker backing
threads host their own V8 isolate, which tells V8 it has kWorkerMaxStackSize
(500KB) available below the entry point. With a 256KB stack, V8's stack guard
sits past the real stack bottom, turning a catchable JS RangeError into a SIGSEGV.
Excluding NonMainThreads protects Web Workers and compositor threads while
allowing ThreadPool and Starboard threads to use 256KB stacks.

Verified on Android TV device (44061HFAG01AF5):
- 22+ helper thread stacks reduced to 256KB in smaps
- Process VmSize reduced by ~30.7 MB net VA
- Web Worker recursion depth test catches RangeError cleanly without SIGSEGV

Bug: 527182602
TAG=agy
CONV=82cfa6b3-025e-4a64-b88c-81503ac5417a