### PR TITLE
android: Add java switch to defer V8 Cache Write

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -32,6 +32,9 @@ public class JavaSwitches {
   public static final String ENABLE_OPTIMIZED_FONT_LOADING = "EnableOptimizedFontLoading";
   public static final String ENABLE_OPTIMIZED_V8_CODE_CACHE = "EnableOptimizedV8CodeCache";
 
+  /** flag to enable deferred V8 bytecode serialization in background/idle */
+  public static final String DEFER_V8_CODE_CACHE_WRITE = "DeferV8CodeCacheWrite";
+
   /** flag to allow caching CSS and WebAssembly resources in the HTTP disk cache. */
   public static final String ENABLE_CSS_AND_WASM_FOR_HTTP_CACHE = "EnableCssAndWasmForHttpCache";
 
@@ -212,6 +215,10 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--enable-optimized-v8-code-cache");
     }
 
+    if (javaSwitches.containsKey(JavaSwitches.DEFER_V8_CODE_CACHE_WRITE)) {
+      extraCommandLineArgs.add("--defer-v8-code-cache-write");
+    }
+
     if (javaSwitches.containsKey(JavaSwitches.ENABLE_GPU_SHADER_DISK_CACHE)) {
       extraCommandLineArgs.add("--enable-gpu-shader-disk-cache");
     }
@@ -266,7 +273,8 @@ public class JavaSwitches {
       extraCommandLineArgs.add("--enable-features=AreaBasedVideoBufferBudget");
     }
 
-    if (javaSwitches.containsKey(JavaSwitches.ALLOW_CRITICAL_MEMORY_PRESSURE_HANDLING_IN_FOREGROUND)) {
+    if (javaSwitches.containsKey(
+        JavaSwitches.ALLOW_CRITICAL_MEMORY_PRESSURE_HANDLING_IN_FOREGROUND)) {
       extraCommandLineArgs.add("--allow-critical-memory-pressure-handling-in-foreground");
     }
 

--- a/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
+++ b/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
@@ -25,6 +25,10 @@
 
 #include "third_party/blink/renderer/bindings/core/v8/v8_script_runner.h"
 
+#if BUILDFLAG(IS_COBALT)
+#include "base/command_line.h"
+#endif
+
 #include "base/feature_list.h"
 #include "base/metrics/histogram_functions.h"
 #include "build/build_config.h"
@@ -649,9 +653,17 @@ ScriptEvaluationResult V8ScriptRunner::CompileAndRunScript(
           cache_handler) {
         cache_handler->WillProduceCodeCache();
       }
+#if BUILDFLAG(IS_COBALT)
+      if (produce_cache_options ==
+              V8CodeCache::ProduceCacheOptions::kProduceCodeCache &&
+          (execution_context->IsServiceWorkerGlobalScope() ||
+           base::CommandLine::ForCurrentProcess()->HasSwitch(
+               "defer-v8-code-cache-write"))) {
+#else
       if (produce_cache_options ==
               V8CodeCache::ProduceCacheOptions::kProduceCodeCache &&
           execution_context->IsServiceWorkerGlobalScope()) {
+#endif
         static constexpr base::TimeDelta kCacheCodeOnIdleDelay =
             base::Milliseconds(1);
         // TODO(crbug.com/40202028): Consider scheduling idle tasks via

--- a/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
+++ b/third_party/blink/renderer/bindings/core/v8/v8_script_runner.cc
@@ -654,11 +654,13 @@ ScriptEvaluationResult V8ScriptRunner::CompileAndRunScript(
         cache_handler->WillProduceCodeCache();
       }
 #if BUILDFLAG(IS_COBALT)
+      static const bool defer_v8_code_cache_write =
+          base::CommandLine::ForCurrentProcess()->HasSwitch(
+              "defer-v8-code-cache-write");
       if (produce_cache_options ==
               V8CodeCache::ProduceCacheOptions::kProduceCodeCache &&
           (execution_context->IsServiceWorkerGlobalScope() ||
-           base::CommandLine::ForCurrentProcess()->HasSwitch(
-               "defer-v8-code-cache-write"))) {
+           defer_v8_code_cache_write)) {
 #else
       if (produce_cache_options ==
               V8CodeCache::ProduceCacheOptions::kProduceCodeCache &&


### PR DESCRIPTION
This PR adds a java switch to defers the serialization of V8 bytecode to the disk. 

On cold startup, the serialization to disk of V8 code after it's been parsed and compiled into bytecode can compete with more important threads. This PR posts it to a DelayedTask instead, allowing other work to be done on startup and allowing us to get to FirstContentfulPaint faster.                                                                           

Local testing with ADT-4: Unblocked ~240ms of execution time from the main thread during boot, allowing UI to render sooner.                                                                 


Bug: 544849876