### PR TITLE
starboard/elf_loader: Export missing symbols for 32-bit ARM Evergreen

### DIFF
--- a/starboard/elf_loader/exported_symbols.cc
+++ b/starboard/elf_loader/exported_symbols.cc
@@ -29,6 +29,7 @@
 #include <errno.h>
 #include <fcntl.h>
 #include <ifaddrs.h>
+#include <link.h>
 #include <malloc.h>
 #include <net/if.h>
 #include <netdb.h>
@@ -87,6 +88,10 @@
 #include "starboard/system.h"
 #include "starboard/time_zone.h"
 #include "starboard/window.h"
+
+extern "C" int __cxa_thread_atexit_impl(void (*func)(void*),
+                                        void* obj,
+                                        void* dso_symbol);
 
 #define REGISTER_SYMBOL(s)                        \
   do {                                            \
@@ -278,6 +283,8 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_SYMBOL(write);
 
   // Linux APIs
+  REGISTER_SYMBOL(__cxa_thread_atexit_impl);
+  REGISTER_SYMBOL(dl_iterate_phdr);
   REGISTER_SYMBOL(recvmmsg);
   REGISTER_WRAPPER(ioctl_FIONREAD);
 
@@ -292,6 +299,7 @@ ExportedSymbols::ExportedSymbols() {
   REGISTER_WRAPPER(access);
   REGISTER_WRAPPER(bind);
   REGISTER_WRAPPER(chmod);
+  REGISTER_WRAPPER(__clock_gettime64);
   REGISTER_WRAPPER(clock_gettime);
   REGISTER_WRAPPER(closedir);
   REGISTER_WRAPPER(clock_nanosleep);

--- a/starboard/shared/modular/starboard_layer_posix_time_abi_wrappers.cc
+++ b/starboard/shared/modular/starboard_layer_posix_time_abi_wrappers.cc
@@ -18,6 +18,11 @@
 
 #include "starboard/shared/modular/starboard_layer_posix_errno_abi_wrappers.h"
 
+int __abi_wrap___clock_gettime64(int /* clockid_t */ musl_clock_id,
+                                 struct musl_timespec* mts) {
+  return __abi_wrap_clock_gettime(musl_clock_id, mts);
+}
+
 int __abi_wrap_clock_gettime(int /* clockid_t */ musl_clock_id,
                              struct musl_timespec* mts) {
   if (!mts) {

--- a/starboard/shared/modular/starboard_layer_posix_time_abi_wrappers.h
+++ b/starboard/shared/modular/starboard_layer_posix_time_abi_wrappers.h
@@ -182,6 +182,9 @@ inline int musl_nanosleep_flags_to_nanosleep_flags(int musl_flags) {
   }
 }
 
+SB_EXPORT int __abi_wrap___clock_gettime64(int /* clockid_t */ musl_clock_id,
+                                           struct musl_timespec* mts);
+
 SB_EXPORT int __abi_wrap_clock_gettime(int /* clockid_t */ musl_clock_id,
                                        struct musl_timespec* mts);
 

--- a/starboard/tools/api_leak_detector/evergreen/arm64_dev_manifest
+++ b/starboard/tools/api_leak_detector/evergreen/arm64_dev_manifest
@@ -1,7 +1,5 @@
 # Manifest of Leaking Files
 
-# b/512577414 - This is currently allowed in dev builds since it is used by the Rust symbolizer.
-dl_iterate_phdr
+# This file was auto-generated using api_leak_detector.py.
 
 TLS init function for v8::internal::trap_handler::g_thread_in_wasm_code
-__cxa_thread_atexit_impl

--- a/starboard/tools/api_leak_detector/evergreen/arm_dev_manifest
+++ b/starboard/tools/api_leak_detector/evergreen/arm_dev_manifest
@@ -1,8 +1,5 @@
 # Manifest of Leaking Files
 
-# b/512577414 - This is currently allowed in dev builds since it is used by the Rust symbolizer.
-dl_iterate_phdr
+# This file was auto-generated using api_leak_detector.py.
 
 TLS init function for v8::internal::trap_handler::g_thread_in_wasm_code
-__clock_gettime64
-__cxa_thread_atexit_impl

--- a/starboard/tools/api_leak_detector/evergreen/arm_manifest
+++ b/starboard/tools/api_leak_detector/evergreen/arm_manifest
@@ -3,4 +3,3 @@
 # This file was auto-generated using api_leak_detector.py.
 
 TLS init function for v8::internal::trap_handler::g_thread_in_wasm_code
-__clock_gettime64

--- a/starboard/tools/api_leak_detector/evergreen/x64_dev_manifest
+++ b/starboard/tools/api_leak_detector/evergreen/x64_dev_manifest
@@ -1,7 +1,5 @@
 # Manifest of Leaking Files
 
-# b/512577414 - This is currently allowed in dev builds since it is used by the Rust symbolizer.
-dl_iterate_phdr
+# This file was auto-generated using api_leak_detector.py.
 
 TLS init function for v8::internal::trap_handler::g_thread_in_wasm_code
-__cxa_thread_atexit_impl


### PR DESCRIPTION
## Description

Evergreen modules on 32-bit ARM platforms fail to load under `elf_loader` when strong undefined symbols are not exported in the `elf_loader` symbol map.

Analysis of `libupdate_client_unittests.so` on `evergreen-arm-hardfp-rdk` revealed the dynamic symbol gap:
- `dl_iterate_phdr` (strong undefined import required by unwinding and libc routines)
- `__cxa_thread_atexit_impl` (helper for thread_local destructors)
- `__clock_gettime64` (time64 musl redirect on 32-bit ARM)

This patch exports:
1. `dl_iterate_phdr` via `<link.h>` and `REGISTER_SYMBOL`.
   *(Known limitation: the system implementation will not enumerate the manually-mapped Evergreen module itself).*
2. `__cxa_thread_atexit_impl` via forward declaration and `REGISTER_SYMBOL`.
3. `__clock_gettime64` mapped to `&__abi_wrap_clock_gettime`.

Measured dynamic imports verification (`comm -23 imports.txt exports.txt`) confirms **0** remaining missing symbols.

Bug: 446745795