### PR TITLE
[android] Add DisableLessAggressiveParkableString Java switch

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -111,6 +111,13 @@ public class JavaSwitches {
   public static final String ALLOW_CRITICAL_MEMORY_PRESSURE_HANDLING_IN_FOREGROUND =
       "AllowCriticalMemoryPressureHandlingInForeground";
 
+  /**
+   * Flag to disable LessAggressiveParkableString feature to unpause foreground compression and use
+   * a 2-second aging interval.
+   */
+  public static final String DISABLE_LESS_AGGRESSIVE_PARKABLE_STRING =
+      "DisableLessAggressiveParkableString";
+
   public static List<String> getExtraCommandLineArgs(Map<String, String> javaSwitches) {
     List<String> extraCommandLineArgs = new ArrayList<>();
     StringJoiner jsFlags = new StringJoiner(";");
@@ -276,6 +283,10 @@ public class JavaSwitches {
     if (javaSwitches.containsKey(
         JavaSwitches.ALLOW_CRITICAL_MEMORY_PRESSURE_HANDLING_IN_FOREGROUND)) {
       extraCommandLineArgs.add("--allow-critical-memory-pressure-handling-in-foreground");
+    }
+
+    if (javaSwitches.containsKey(JavaSwitches.DISABLE_LESS_AGGRESSIVE_PARKABLE_STRING)) {
+      extraCommandLineArgs.add("--disable-features=LessAggressiveParkableString");
     }
 
     return extraCommandLineArgs;

--- a/third_party/blink/renderer/platform/bindings/parkable_string_manager.cc
+++ b/third_party/blink/renderer/platform/bindings/parkable_string_manager.cc
@@ -15,6 +15,7 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/time.h"
 #include "base/trace_event/memory_allocator_dump.h"
+#include "build/buildflag.h"
 #include "base/trace_event/process_memory_dump.h"
 #include "base/trace_event/trace_event.h"
 #include "third_party/blink/public/common/features.h"
@@ -174,6 +175,15 @@ base::TimeDelta ParkableStringManager::AgingInterval() {
              ? kLessAggressiveAgingInterval
              : kAgingInterval;
 }
+
+#if BUILDFLAG(IS_COBALT)
+// static
+base::TimeDelta ParkableStringManager::FirstParkingDelay() {
+  return base::FeatureList::IsEnabled(features::kLessAggressiveParkableString)
+             ? kFirstParkingDelay
+             : kCobaltFirstParkingDelay;
+}
+#endif
 
 scoped_refptr<ParkableStringImpl> ParkableStringManager::Add(
     scoped_refptr<StringImpl>&& string,
@@ -450,7 +460,11 @@ void ParkableStringManager::ScheduleAgingTaskIfNeeded() {
   // Delay the first aging tick, since this renderer may be short-lived, we do
   // not want to waste CPU time compressing memory that is going away soon.
   if (!first_string_aging_was_delayed_) {
+#if BUILDFLAG(IS_COBALT)
+    delay = FirstParkingDelay();
+#else
     delay = kFirstParkingDelay;
+#endif
     first_string_aging_was_delayed_ = true;
   }
 

--- a/third_party/blink/renderer/platform/bindings/parkable_string_manager.h
+++ b/third_party/blink/renderer/platform/bindings/parkable_string_manager.h
@@ -15,6 +15,7 @@
 #include "base/task/single_thread_task_runner.h"
 #include "base/time/time.h"
 #include "base/trace_event/memory_dump_provider.h"
+#include "build/buildflag.h"
 #include "third_party/blink/renderer/platform/bindings/parkable_string.h"
 #include "third_party/blink/renderer/platform/disk_data_allocator.h"
 #include "third_party/blink/renderer/platform/platform_export.h"
@@ -80,6 +81,9 @@ class PLATFORM_EXPORT ParkableStringManager : public RAILModeObserver {
   static bool ShouldPark(const StringImpl& string);
 
   static base::TimeDelta AgingInterval();
+#if BUILDFLAG(IS_COBALT)
+  static base::TimeDelta FirstParkingDelay();
+#endif
 
   // According to UMA data (as of 2021-11-09) ~70% of renderers exist for less
   // than 60 seconds. Using this as a delay of the first parking attempts
@@ -91,6 +95,16 @@ class PLATFORM_EXPORT ParkableStringManager : public RAILModeObserver {
   // of a parkable string but it does not indicate a higher chance of the
   // renderer staying alive for a long time.
   constexpr static base::TimeDelta kFirstParkingDelay{base::Seconds(60)};
+
+#if BUILDFLAG(IS_COBALT)
+  // For Cobalt, the web application runs in a single dedicated process that is
+  // long-lived. Initial bootstrap scripts and page templates are loaded within
+  // the first few seconds of launch. Reducing the initial parking delay to 10
+  // seconds avoids CPU contention during bootstrap while allowing unreferenced
+  // startup string memory to be reclaimed promptly rather than lingering for a
+  // full minute.
+  constexpr static base::TimeDelta kCobaltFirstParkingDelay{base::Seconds(10)};
+#endif
 
   static const char* kAllocatorDumpName;
 


### PR DESCRIPTION
Expose DisableLessAggressiveParkableString in JavaSwitches.java to allow disabling LessAggressiveParkableString feature via Kimono/server configs, enabling foreground string compression and a 2s aging interval.

Bug: 544754813