### PR TITLE
aosp: Package CA certificates and unify the cert lookup location

### DIFF
--- a/cobalt/aosp/modular_apk.gni
+++ b/cobalt/aosp/modular_apk.gni
@@ -14,6 +14,7 @@
 
 import("//build/config/android/rules.gni")
 import("//cobalt/android/manifest.gni")
+import("//starboard/content/ssl/certs.gni")
 
 template("modular_apk") {
   _name = invoker.module_name
@@ -43,6 +44,16 @@ template("modular_apk") {
       ":copy_${_name}_empty_fonts($default_toolchain)",
       ":copy_${_name}_lib($default_toolchain)",
     ]
+
+    # CA certificates, packaged under the content directory. resolves to the
+    # Evergreen content path (/cobalt/assets/app/cobalt/content). See the content-dir in
+    # system_get_path.cc. Package the certs at <content>/ssl/certs to match.
+    foreach(_cert, network_certs) {
+      _cert_file = get_path_info(_cert, "file")
+      renaming_sources += [ "$root_build_dir/ssl/certs/$_cert_file" ]
+      renaming_destinations += [ "app/cobalt/content/ssl/certs/$_cert_file" ]
+    }
+    deps += [ "//starboard/content/ssl:copy_ssl_certificates_evergreen($default_toolchain)" ]
 
     if (_name == "cobalt") {
       sources = [ "$root_build_dir/cobalt_shell.pak" ]

--- a/starboard/common/paths.cc
+++ b/starboard/common/paths.cc
@@ -74,6 +74,13 @@ std::string GetCACertificatesPath(const std::string& content_subdir) {
   std::string ca_certificates_path =
       GetCACertificatesPathFromSubdir(content_subdir);
   if (stat(ca_certificates_path.c_str(), &info) != 0) {
+    // Fall back to the content root, like the no-argument overload. On some
+    // platforms (e.g. Android, where the content directory resolves to the
+    // asset root) the certs are packaged at <content>/ssl/certs rather than
+    // <content>/<content_subdir>/ssl/certs.
+    ca_certificates_path = GetCACertificatesPathFromSubdir("");
+  }
+  if (stat(ca_certificates_path.c_str(), &info) != 0) {
     SB_LOG(ERROR) << "Failed to get CA certificates path";
     return "";
   }


### PR DESCRIPTION
Package the CA certs under the Evergreen content dir (<content>/ssl/certs) where net::TrustStoreInMemoryStarboard looks, and make GetCACertificatesPath() fall back to the content root when the per-subdir path is absent, so cert lookup works on Android's asset layout.

Bug: 532068409