### PR TITLE
aosp: bundle a real font set with the cobalt app

### DIFF
--- a/.gn
+++ b/.gn
@@ -176,6 +176,7 @@ exec_script_allowlist += [
   "//starboard/build/config/sabi/BUILD.gn",
   "//starboard/build/platform_path.gni",
   "//starboard/content/fonts/BUILD.gn",
+  "//cobalt/aosp/modular_apk.gni",
 ]
 
 # TODO(cobalt, b/377295011): figure out a better long-term solution here, or

--- a/cobalt/aosp/modular_apk.gni
+++ b/cobalt/aosp/modular_apk.gni
@@ -14,6 +14,7 @@
 
 import("//build/config/android/rules.gni")
 import("//cobalt/android/manifest.gni")
+import("//starboard/content/fonts/variables.gni")
 
 template("modular_apk") {
   _name = invoker.module_name
@@ -30,23 +31,52 @@ template("modular_apk") {
     forward_variables_from(invoker, [ "testonly" ])
     disable_compression = true
 
-    renaming_sources = [
-      "$root_build_dir/app/${_name}/content/fonts/fonts.xml",
-      "$root_build_dir/app/${_name}/lib/${_lib_name}.lz4",
-    ]
-    renaming_destinations = [
-      "app/cobalt/content/fonts/fonts.xml",
-      "app/cobalt/lib/${_lib_name}.lz4",
-    ]
+    renaming_sources = [ "$root_build_dir/app/${_name}/lib/${_lib_name}.lz4" ]
+    renaming_destinations = [ "app/cobalt/lib/${_lib_name}.lz4" ]
 
-    deps = [
-      ":copy_${_name}_empty_fonts($default_toolchain)",
-      ":copy_${_name}_lib($default_toolchain)",
-    ]
+    deps = [ ":copy_${_name}_lib($default_toolchain)" ]
 
     if (_name == "cobalt") {
-      sources = [ "$root_build_dir/cobalt_shell.pak" ]
+      # Bundle a real, self-contained font set with the cobalt app so
+      # SkFontMgr_Cobalt has actual families
+      _fonts_root = "//starboard/content/fonts"
+      _font_config = "$_fonts_root/$source_font_config_dir/fonts.xml"
+      _font_files_dir = "$_fonts_root/$source_font_files_dir"
+
+      # Reuse the filtered fonts.xml produced by the shared fonts_xml action
+      renaming_sources += [ "$root_build_dir/fonts/fonts.xml" ]
+      renaming_destinations += [ "app/cobalt/content/fonts/fonts.xml" ]
+      deps += [ "$_fonts_root:fonts_xml($default_toolchain)" ]
+
+      # Enumerate the font files the package selects so each maps into the APK's
+      # content dir (the woff2 files themselves are checked-in sources).
+      _font_files = exec_script("$_fonts_root/scripts/filter_fonts.py",
+                                [
+                                      "-i",
+                                      rebase_path(_font_config, root_build_dir),
+                                      "-f",
+                                      _font_files_dir,
+                                    ] + package_categories,
+                                "trim list lines",
+                                [ _font_config ])
+      foreach(_font, _font_files) {
+        _font_file = get_path_info(_font, "file")
+        renaming_sources += [ "$_font_files_dir/$_font_file" ]
+        renaming_destinations += [ "app/cobalt/content/fonts/$_font_file" ]
+      }
+
+      # Package the resource pak under the content directory (like fonts), so
+      # cobalt can find it via base::DIR_ASSETS
+      renaming_sources += [ "$root_build_dir/cobalt_shell.pak" ]
+      renaming_destinations += [ "app/cobalt/content/cobalt_shell.pak" ]
+
       deps += [ "//cobalt/shell:pak($default_toolchain)" ]
+    } else {
+      # nplb and other non-rendering modules keep the empty placeholder fonts.xml.
+      renaming_sources +=
+          [ "$root_build_dir/app/${_name}/content/fonts/fonts.xml" ]
+      renaming_destinations += [ "app/cobalt/content/fonts/fonts.xml" ]
+      deps += [ ":copy_${_name}_empty_fonts($default_toolchain)" ]
     }
 
     if (_name == "nplb") {

--- a/starboard/aosp/arm/platform_configuration/configuration.gni
+++ b/starboard/aosp/arm/platform_configuration/configuration.gni
@@ -19,3 +19,10 @@ if (current_toolchain == default_toolchain) {
   import("//starboard/android/arm/platform_configuration/configuration.gni")
   sb_evergreen_compatible_use_libunwind = true
 }
+
+# The evergreen/modular config forces cobalt_font_package = "empty" and the
+# Android config uses "android_system"; neither bundles a usable, self-contained
+# font set. Cobalt's SkFontMgr_Cobalt aborts without real families
+# so ship the "limited" package.
+# cobalt/aosp/modular_apk.gni packages it into the cobalt APK.
+cobalt_font_package = "limited"


### PR DESCRIPTION
The evergreen/modular config forces cobalt_font_package = "empty" and androidtv uses "android_system"; Neither bundles a self-contained font set.

SkFontMgr_Cobalt aborts without real font families, so ship the "limited" font package.

Bug: 532068409