### PR TITLE
media: Inline Starboard handles in DecoderBuffer

### DIFF
--- a/media/base/decoder_buffer.cc
+++ b/media/base/decoder_buffer.cc
@@ -103,7 +103,27 @@ DecoderBuffer::DecoderBuffer(base::HeapArray<uint8_t> data)
 }
 
 DecoderBuffer::DecoderBuffer(std::unique_ptr<ExternalMemory> external_memory)
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+    // For Starboard builds, if the incoming ExternalMemory object wraps a Starboard
+    // media pool handle, adopt the raw handle inline into allocator_data_ and
+    // destroy the transient ExternalMemory wrapper struct immediately. This avoids
+    // storing long-lived heap wrapper objects for every sample frame (preventing RSS
+    // bloat) and eliminates pointer indirection on hot paths, leaving external_memory_
+    // as nullptr.
+    : allocator_data_([&]() -> std::optional<AllocatorData> {
+        if (external_memory &&
+            external_memory->handle() != Allocator::kInvalidHandle) {
+          DemuxerStream::Type type = external_memory->type();
+          size_t size = external_memory->Span().size();
+          Allocator::Handle handle = external_memory->ReleaseHandle();
+          return AllocatorData(type, handle, size);
+        }
+        return std::nullopt;
+      }()),
+      external_memory_(allocator_data_ ? nullptr : std::move(external_memory)) {}
+#else   // BUILDFLAG(USE_STARBOARD_MEDIA)
     : external_memory_(std::move(external_memory)) {}
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
 DecoderBuffer::DecoderBuffer(DemuxerStream::Type type, size_t size)
     : allocator_data_([&]() -> std::optional<AllocatorData> {

--- a/media/base/decoder_buffer.h
+++ b/media/base/decoder_buffer.h
@@ -92,6 +92,12 @@ class MEDIA_EXPORT DecoderBuffer
     virtual Allocator::Handle handle() const {
       return Allocator::kInvalidHandle;
     }
+    virtual Allocator::Handle ReleaseHandle() {
+      return Allocator::kInvalidHandle;
+    }
+    virtual DemuxerStream::Type type() const {
+      return DemuxerStream::UNKNOWN;
+    }
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
   };
 
@@ -428,6 +434,8 @@ class MEDIA_EXPORT DecoderBuffer
     size_t size = 0;
   };
   // Encoded data, allocated from DecoderBuffer::Allocator.
+  // Note: Must be declared before external_memory_ so constructor initializer lists
+  // can inspect allocator_data_ when initializing external_memory_.
   const std::optional<AllocatorData> allocator_data_;
 #endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 

--- a/media/starboard/starboard_media_external_memory_allocator.cc
+++ b/media/starboard/starboard_media_external_memory_allocator.cc
@@ -70,9 +70,17 @@ class StarboardPoolExternalMemory : public DecoderBuffer::ExternalMemory {
 
   DecoderBuffer::Allocator::Handle handle() const override { return handle_; }
 
+  DemuxerStream::Type type() const override { return type_; }
+
+  DecoderBuffer::Allocator::Handle ReleaseHandle() override {
+    DecoderBuffer::Allocator::Handle h = handle_;
+    handle_ = DecoderBuffer::Allocator::kInvalidHandle;
+    return h;
+  }
+
  private:
   DecoderBuffer::Allocator* const pool_;
-  const DecoderBuffer::Allocator::Handle handle_;
+  DecoderBuffer::Allocator::Handle handle_;
   const size_t size_;
   const base::span<const uint8_t> span_;
   const DemuxerStream::Type type_;


### PR DESCRIPTION
Update DecoderBuffer to extract Starboard media pool handles from
ExternalMemory wrappers during construction. This allows the
transient wrapper object to be destroyed immediately, reducing
RSS bloat caused by numerous heap-allocated objects for every
sample frame. It also eliminates pointer indirection on hot paths.

Issue: 378106931