### PR TITLE
aosp: resolve content paths from the Evergreen content dir

### DIFF
--- a/starboard/android/shared/system_get_path.cc
+++ b/starboard/android/shared/system_get_path.cc
@@ -62,9 +62,16 @@ bool SbSystemGetPath(SbSystemPathId path_id, char* out_path, int path_size) {
 
   switch (path_id) {
     case kSbSystemPathContentDirectory: {
+#if BUILDFLAG(IS_STARBOARD)
+      // Use the Evergreen content path when one is configured
+      if (starboard::strlcat(path, GetContentPath(), kPathSize) >= kPathSize) {
+        return false;
+      }
+#else
       if (starboard::strlcat(path, g_app_assets_dir, kPathSize) >= kPathSize) {
         return false;
       }
+#endif
 
       break;
     }


### PR DESCRIPTION
libcobalt locates its resources via base::DIR_EXE / base::DIR_ASSETS that maps to SbSystemGetPath(kSbSystemPathContentDirectory).

Some resources were unreachable, making cobalt abort:

- kSbSystemPathContentDirectory returned the raw asset root (g_app_assets_dir, "/cobalt/assets") instead of the configured Evergreen content path. SkFontMgr_Cobalt was looking for <content>/fonts at /cobalt/assets/fonts.

- cobalt_shell.pak was packaged at the assets root (assets/cobalt_shell.pak) while fonts/lib are placed under app/cobalt/content. Package the pak under the content directory too, so the pak and fonts.xml resolve from base::DIR_ASSETS.

Bug: 532068409