### PR TITLE
cobalt: Skip overlap checks for non-drawing layers

### DIFF
--- a/third_party/blink/renderer/platform/graphics/compositing/paint_artifact_compositor.cc
+++ b/third_party/blink/renderer/platform/graphics/compositing/paint_artifact_compositor.cc
@@ -777,7 +777,12 @@ void PaintArtifactCompositor::Layerizer::LayerizeGroup(
         pending_layers_.pop_back();
         break;
       }
-      if (new_layer.MightOverlap(candidate_layer)) {
+#if BUILDFLAG(IS_COBALT)
+    if (candidate_layer.DrawsContent() &&
+          new_layer.MightOverlap(candidate_layer)) {
+#else  // BUILDFLAG(IS_COBALT)
+    if (new_layer.MightOverlap(candidate_layer)) {
+#endif  // BUILDFLAG(IS_COBALT)
         new_layer.SetCompositingTypeToOverlap();
         break;
       }


### PR DESCRIPTION
In PaintArtifactCompositor, checking for overlap against candidate
layers that do not draw content leads to unnecessary compositing
promotions. Guarding the MightOverlap check behind DrawsContent
allows better layer merging and reduces memory footprint for these
unnecessary promotions.


Bug: 543871357