### PR TITLE
cobalt: Support image decode cache memory size limit

### DIFF
--- a/cc/base/switches.cc
+++ b/cc/base/switches.cc
@@ -115,6 +115,7 @@ const char kCCScrollAnimationDurationForTesting[] =
 
 #if BUILDFLAG(IS_COBALT)
 const char kCCImageCacheLimitItems[] = "cc-image-cache-limit-items";
+const char kCCImageCacheLimitBytes[] = "cc-image-cache-limit-bytes";
 const char kDecodedImageWorkingSetBudgetBytes[] =
     "decoded-image-working-set-budget-bytes";
 // Avoid reuse resource.

--- a/cc/base/switches.h
+++ b/cc/base/switches.h
@@ -69,6 +69,7 @@ CC_BASE_EXPORT extern const char kCCScrollAnimationDurationForTesting[];
 
 #if BUILDFLAG(IS_COBALT)
 CC_BASE_EXPORT extern const char kCCImageCacheLimitItems[];
+CC_BASE_EXPORT extern const char kCCImageCacheLimitBytes[];
 CC_BASE_EXPORT extern const char kDecodedImageWorkingSetBudgetBytes[];
 // Avoid reuse resource.
 CC_BASE_EXPORT extern const char kAvoidCCReuseResource[];

--- a/cc/paint/oop_pixeltest.cc
+++ b/cc/paint/oop_pixeltest.cc
@@ -151,7 +151,12 @@ class OopPixelTest : public testing::Test,
         raster_context_provider_->ContextCapabilities().max_texture_size;
     oop_image_cache_ = std::make_unique<GpuImageDecodeCache>(
         raster_context_provider_.get(), true, kRGBA_8888_SkColorType,
-        kWorkingSetSize, raster_max_texture_size, nullptr);
+        kWorkingSetSize, raster_max_texture_size,
+#if BUILDFLAG(IS_COBALT)
+        /*max_persistent_cache_items=*/2000,
+        /*max_persistent_cache_memory_size=*/std::numeric_limits<size_t>::max(),
+#endif
+        nullptr);
   }
 
   class RasterOptions {

--- a/cc/tiles/gpu_image_decode_cache.cc
+++ b/cc/tiles/gpu_image_decode_cache.cc
@@ -1227,6 +1227,10 @@ GpuImageDecodeCache::GpuImageDecodeCache(
     SkColorType color_type,
     size_t max_working_set_bytes,
     int max_texture_size,
+#if BUILDFLAG(IS_COBALT)
+    size_t max_persistent_cache_items,
+    size_t max_persistent_cache_memory_size,
+#endif
     RasterDarkModeFilter* const dark_mode_filter)
     : color_type_(color_type),
       use_transfer_cache_(use_transfer_cache),
@@ -1239,6 +1243,12 @@ GpuImageDecodeCache::GpuImageDecodeCache(
       persistent_cache_(PersistentCache::NO_AUTO_EVICT),
       max_working_set_bytes_(max_working_set_bytes),
       max_working_set_items_(kMaxItemsInWorkingSet),
+#if BUILDFLAG(IS_COBALT)
+      max_persistent_cache_items_(std::min<size_t>(
+          max_persistent_cache_items,
+          static_cast<size_t>(kNormalMaxItemsInCacheForGpu))),
+      max_persistent_cache_memory_size_(max_persistent_cache_memory_size),
+#endif
       dark_mode_filter_(dark_mode_filter) {
   if (base::SequencedTaskRunner::HasCurrentDefault()) {
     task_runner_ = base::SequencedTaskRunner::GetCurrentDefault();
@@ -2360,26 +2370,15 @@ bool GpuImageDecodeCache::ExceedsCacheLimits() const {
     items_limit = kSuspendedMaxItemsInCacheForGpu;
   } else {
 #if BUILDFLAG(IS_COBALT)
-    static const int normal_max_items = []() {
-      int limit = kNormalMaxItemsInCacheForGpu;
-      auto* command_line = base::CommandLine::ForCurrentProcess();
-      if (command_line->HasSwitch(switches::kCCImageCacheLimitItems)) {
-        std::string value = command_line->GetSwitchValueASCII(
-            switches::kCCImageCacheLimitItems);
-        int parsed_value;
-        if (base::StringToInt(value, &parsed_value) && parsed_value >= 0) {
-          limit = parsed_value;
-        }
-      }
-      return limit;
-    }();
-    items_limit = normal_max_items;
-#else
-    items_limit = kNormalMaxItemsInCacheForGpu;
-#endif
+    items_limit = max_persistent_cache_items_;
   }
-
+  return persistent_cache_.size() > items_limit ||
+         persistent_cache_memory_size_ > max_persistent_cache_memory_size_;
+#else // BUILDFLAG(IS_COBALT)
+    items_limit = kNormalMaxItemsInCacheForGpu;
+  }
   return persistent_cache_.size() > items_limit;
+#endif // BUILDFLAG(IS_COBALT)
 }
 
 void GpuImageDecodeCache::InsertTransferCacheEntry(

--- a/cc/tiles/gpu_image_decode_cache.h
+++ b/cc/tiles/gpu_image_decode_cache.h
@@ -152,6 +152,10 @@ class CC_EXPORT GpuImageDecodeCache
                                SkColorType color_type,
                                size_t max_working_set_bytes,
                                int max_texture_size,
+#if BUILDFLAG(IS_COBALT)
+                               size_t max_persistent_cache_items,
+                               size_t max_persistent_cache_memory_size,
+#endif
                                RasterDarkModeFilter* const dark_mode_filter);
   ~GpuImageDecodeCache() override;
 
@@ -983,6 +987,11 @@ class CC_EXPORT GpuImageDecodeCache
   size_t working_set_bytes_ GUARDED_BY(lock_) = 0;
   size_t working_set_items_ GUARDED_BY(lock_) = 0;
   bool aggressively_freeing_resources_ GUARDED_BY(lock_) = false;
+
+#if BUILDFLAG(IS_COBALT)
+  const size_t max_persistent_cache_items_;
+  const size_t max_persistent_cache_memory_size_;
+#endif
 
   // This field is not a raw_ptr<> because of incompatibilities with tracing
   // (TRACE_EVENT*), perfetto::TracedDictionary::Add and gmock/EXPECT_THAT.

--- a/cc/tiles/gpu_image_decode_cache_perftest.cc
+++ b/cc/tiles/gpu_image_decode_cache_perftest.cc
@@ -66,7 +66,12 @@ class GpuImageDecodeCachePerfTest
     ASSERT_EQ(result, gpu::ContextResult::kSuccess);
     cache_ = std::make_unique<GpuImageDecodeCache>(
         context_provider_.get(), UseTransferCache(), kRGBA_8888_SkColorType,
-        kCacheSize, MaxTextureSize(), nullptr);
+        kCacheSize, MaxTextureSize(),
+#if BUILDFLAG(IS_COBALT)
+        /*max_persistent_cache_items=*/2000,
+        /*max_persistent_cache_memory_size=*/std::numeric_limits<size_t>::max(),
+#endif
+        nullptr);
   }
 
  protected:

--- a/cc/tiles/gpu_image_decode_cache_unittest.cc
+++ b/cc/tiles/gpu_image_decode_cache_unittest.cc
@@ -456,7 +456,12 @@ class GpuImageDecodeCacheTest
       RasterDarkModeFilter* const dark_mode_filter = nullptr) {
     return std::make_unique<GpuImageDecodeCache>(
         context_provider_.get(), use_transfer_cache_, color_type_,
-        memory_limit_bytes, max_texture_size_, dark_mode_filter);
+        memory_limit_bytes, max_texture_size_,
+#if BUILDFLAG(IS_COBALT)
+        /*max_persistent_cache_items=*/2000,
+        /*max_persistent_cache_memory_size=*/std::numeric_limits<size_t>::max(),
+#endif
+        dark_mode_filter);
   }
 
   // Returns dimensions for an image that will not fit in GPU memory and hence

--- a/cc/tiles/image_decode_cache_utils.cc
+++ b/cc/tiles/image_decode_cache_utils.cc
@@ -78,6 +78,44 @@ size_t ImageDecodeCacheUtils::GetWorkingSetBytesForImageDecode(
 #endif
 }
 
+#if BUILDFLAG(IS_COBALT)
+// static
+size_t ImageDecodeCacheUtils::GetPersistentCacheBudgetCount() {
+  static const size_t cobalt_decoded_image_persistent_cache_budget_count = []() {
+    size_t budget = 2000; // kNormalMaxItemsInCacheForGpu default
+    auto* command_line = base::CommandLine::ForCurrentProcess();
+    if (command_line->HasSwitch(switches::kCCImageCacheLimitItems)) {
+      std::string value = command_line->GetSwitchValueASCII(
+          switches::kCCImageCacheLimitItems);
+      int parsed_value;
+      if (base::StringToInt(value, &parsed_value) && parsed_value >= 0) {
+        budget = static_cast<size_t>(parsed_value);
+      }
+    }
+    return budget;
+  }();
+  return cobalt_decoded_image_persistent_cache_budget_count;
+}
+
+// static
+size_t ImageDecodeCacheUtils::GetPersistentCacheBudgetBytes() {
+  static const size_t cobalt_decoded_image_persistent_cache_budget_bytes = []() {
+    size_t budget = std::numeric_limits<size_t>::max();
+    auto* command_line = base::CommandLine::ForCurrentProcess();
+    if (command_line->HasSwitch(switches::kCCImageCacheLimitBytes)) {
+      std::string value = command_line->GetSwitchValueASCII(
+          switches::kCCImageCacheLimitBytes);
+      int64_t parsed_value;
+      if (base::StringToInt64(value, &parsed_value) && parsed_value >= 0) {
+        budget = static_cast<size_t>(parsed_value);
+      }
+    }
+    return budget;
+  }();
+  return cobalt_decoded_image_persistent_cache_budget_bytes;
+}
+#endif
+
 }  // namespace cc
 
 #endif  // CC_TILES_IMAGE_DECODE_CACHE_UTILS_CC_

--- a/cc/tiles/image_decode_cache_utils.h
+++ b/cc/tiles/image_decode_cache_utils.h
@@ -21,6 +21,11 @@ class CC_EXPORT ImageDecodeCacheUtils {
   // Returns budget bytes for decoded images that may be different depending
   // whether it's for renderer or for the ui compositor.
   static size_t GetWorkingSetBytesForImageDecode(bool for_renderer);
+
+#if BUILDFLAG(IS_COBALT)
+  static size_t GetPersistentCacheBudgetCount();
+  static size_t GetPersistentCacheBudgetBytes();
+#endif
 };
 
 }  // namespace cc

--- a/cc/trees/layer_tree_host_impl.cc
+++ b/cc/trees/layer_tree_host_impl.cc
@@ -244,6 +244,10 @@ class LayerTreeHostImpl::ImageDecodeCacheHolder {
       const RasterCapabilities& raster_caps,
       scoped_refptr<viz::RasterContextProvider> worker_context_provider,
       size_t decoded_image_working_set_budget_bytes,
+#if BUILDFLAG(IS_COBALT)
+      size_t decoded_image_persistent_cache_budget_count,
+      size_t decoded_image_persistent_cache_budget_bytes,
+#endif
       RasterDarkModeFilter* dark_mode_filter) {
     if (raster_caps.use_gpu_rasterization) {
       auto color_type = viz::ToClosestSkColorType(raster_caps.tile_format);
@@ -251,6 +255,10 @@ class LayerTreeHostImpl::ImageDecodeCacheHolder {
           worker_context_provider.get(),
           /*use_transfer_cache=*/true, color_type,
           decoded_image_working_set_budget_bytes, raster_caps.max_texture_size,
+#if BUILDFLAG(IS_COBALT)
+          decoded_image_persistent_cache_budget_count,
+          decoded_image_persistent_cache_budget_bytes,
+#endif
           dark_mode_filter);
     } else {
       image_decode_cache_ = std::make_unique<SoftwareImageDecodeCache>(
@@ -4198,7 +4206,12 @@ void LayerTreeHostImpl::CreateTileManagerResources() {
   DCHECK(!settings_.trees_in_viz_in_viz_process);
   image_decode_cache_holder_ = std::make_unique<ImageDecodeCacheHolder>(
       raster_caps(), layer_tree_frame_sink_->worker_context_provider(),
-      settings_.decoded_image_working_set_budget_bytes, dark_mode_filter_);
+      settings_.decoded_image_working_set_budget_bytes,
+#if BUILDFLAG(IS_COBALT)
+      settings_.decoded_image_persistent_cache_budget_count,
+      settings_.decoded_image_persistent_cache_budget_bytes,
+#endif
+      dark_mode_filter_);
 
   if (raster_caps().use_gpu_rasterization) {
     pending_raster_queries_ = std::make_unique<RasterQueryQueue>(

--- a/cc/trees/layer_tree_settings.h
+++ b/cc/trees/layer_tree_settings.h
@@ -114,6 +114,12 @@ class CC_EXPORT LayerTreeSettings {
   size_t decoded_image_working_set_budget_bytes =
       ImageDecodeCacheUtils::GetWorkingSetBytesForImageDecode(
           /*for_renderer=*/false);
+#if BUILDFLAG(IS_COBALT)
+  size_t decoded_image_persistent_cache_budget_count =
+      ImageDecodeCacheUtils::GetPersistentCacheBudgetCount();
+  size_t decoded_image_persistent_cache_budget_bytes =
+      ImageDecodeCacheUtils::GetPersistentCacheBudgetBytes();
+#endif
   int max_preraster_distance_in_screen_pixels = 1000;
   bool use_rgba_4444 = false;
 

--- a/content/renderer/webgraphicscontext3d_provider_impl.cc
+++ b/content/renderer/webgraphicscontext3d_provider_impl.cc
@@ -9,6 +9,9 @@
 #include "build/build_config.h"
 #include "cc/paint/paint_image.h"
 #include "cc/tiles/gpu_image_decode_cache.h"
+#if BUILDFLAG(IS_COBALT)
+#include "cc/tiles/image_decode_cache_utils.h"
+#endif
 #include "content/public/common/content_switches.h"
 #include "gpu/command_buffer/client/context_support.h"
 #include "gpu/command_buffer/client/gl_helper.h"
@@ -185,7 +188,12 @@ cc::ImageDecodeCache* WebGraphicsContext3DProviderImpl::ImageDecodeCache(
       color_type,
       std::make_unique<cc::GpuImageDecodeCache>(
           provider_.get(), use_transfer_cache, color_type, kMaxWorkingSetBytes,
-          provider_->ContextCapabilities().max_texture_size, nullptr));
+          provider_->ContextCapabilities().max_texture_size,
+#if BUILDFLAG(IS_COBALT)
+          cc::ImageDecodeCacheUtils::GetPersistentCacheBudgetCount(),
+          cc::ImageDecodeCacheUtils::GetPersistentCacheBudgetBytes(),
+#endif
+          nullptr));
   DCHECK(insertion_result.second);
   cache_iterator = insertion_result.first;
   return cache_iterator->second.get();

--- a/third_party/blink/renderer/platform/widget/compositing/layer_tree_settings.cc
+++ b/third_party/blink/renderer/platform/widget/compositing/layer_tree_settings.cc
@@ -532,6 +532,12 @@ cc::LayerTreeSettings GenerateLayerTreeSettings(
   settings.decoded_image_working_set_budget_bytes =
       cc::ImageDecodeCacheUtils::GetWorkingSetBytesForImageDecode(
           /*for_renderer=*/true);
+#if BUILDFLAG(IS_COBALT)
+  settings.decoded_image_persistent_cache_budget_count =
+      cc::ImageDecodeCacheUtils::GetPersistentCacheBudgetCount();
+  settings.decoded_image_persistent_cache_budget_bytes =
+      cc::ImageDecodeCacheUtils::GetPersistentCacheBudgetBytes();
+#endif
 
   if (using_low_memory_policy) {
     // RGBA_4444 textures are only enabled:


### PR DESCRIPTION
Adds support for configuring a maximum memory size limit for GPU image decode persistent cache in Cobalt, alongside the existing item count limit.

- Introduced command-line flag `cc-image-cache-limit-bytes`.
- Added `GetPersistentCacheBudgetCount()` and `GetPersistentCacheBudgetBytes()` to `ImageDecodeCacheUtils` under `BUILDFLAG(IS_COBALT)`.
- Plumbed persistent cache budget count and byte limits through `LayerTreeSettings` and `LayerTreeHostImpl` into `GpuImageDecodeCache`.
- Updated `GpuImageDecodeCache::ExceedsCacheLimits()` to check both item count and byte memory limits.

Bug: 545216717