### PR TITLE
cobalt: Replace banned absl:: classes with std:: counterparts in media/starboard and cobalt

### DIFF
--- a/cobalt/android/oom_intervention/oom_intervention_tab_helper.h
+++ b/cobalt/android/oom_intervention/oom_intervention_tab_helper.h
@@ -15,6 +15,8 @@
 #ifndef COBALT_ANDROID_OOM_INTERVENTION_OOM_INTERVENTION_TAB_HELPER_H_
 #define COBALT_ANDROID_OOM_INTERVENTION_OOM_INTERVENTION_TAB_HELPER_H_
 
+#include <optional>
+
 #include "base/memory/raw_ptr.h"
 #include "base/memory/unsafe_shared_memory_region.h"
 #include "base/memory/weak_ptr.h"
@@ -26,7 +28,6 @@
 #include "mojo/public/cpp/bindings/receiver.h"
 #include "mojo/public/cpp/bindings/remote.h"
 #include "services/service_manager/public/cpp/interface_provider.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "third_party/blink/public/mojom/oom_intervention/oom_intervention.mojom.h"
 
 namespace content {
@@ -80,7 +81,7 @@ class OomInterventionTabHelper
   void ResetInterfaces();
 
   bool navigation_started_ = false;
-  absl::optional<base::TimeTicks> near_oom_detected_time_;
+  std::optional<base::TimeTicks> near_oom_detected_time_;
   base::OneShotTimer renderer_detection_timer_;
 
   mojo::Remote<blink::mojom::OomIntervention> intervention_;

--- a/cobalt/app/app_event_delegate_unittest.cc
+++ b/cobalt/app/app_event_delegate_unittest.cc
@@ -16,6 +16,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -59,7 +60,7 @@ class MockAppEventRunner : public AppEventRunner {
   MOCK_METHOD(void, InitializeSystem, (), (override));
   MOCK_METHOD(void,
               CreateMainDelegate,
-              (absl::optional<int64_t> startup_timestamp,
+              (std::optional<int64_t> startup_timestamp,
                bool is_visible,
                const char* initial_deep_link),
               (override));

--- a/cobalt/app/app_event_runner.cc
+++ b/cobalt/app/app_event_runner.cc
@@ -17,6 +17,7 @@
 #include <array>
 #include <cstddef>
 #include <cstdio>
+#include <optional>
 #include <sstream>
 #include <string>
 #include <vector>
@@ -100,7 +101,7 @@ class AppEventRunnerImpl : public AppEventRunner,
     exit_manager_ = std::make_unique<base::AtExitManager>();
   }
 
-  void CreateMainDelegate(absl::optional<int64_t> startup_timestamp,
+  void CreateMainDelegate(std::optional<int64_t> startup_timestamp,
                           bool is_visible,
                           const char* initial_deep_link) override {
     content_main_delegate_ = std::make_unique<cobalt::CobaltMainDelegate>(
@@ -338,7 +339,7 @@ class AppEventRunnerImpl : public AppEventRunner,
   }
 
  private:
-  int Run(absl::optional<int64_t> startup_timestamp,
+  int Run(std::optional<int64_t> startup_timestamp,
           bool is_visible,
           int argc,
           const char** argv,

--- a/cobalt/app/app_event_runner.h
+++ b/cobalt/app/app_event_runner.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -25,7 +26,6 @@
 #include "cobalt/app/cobalt_main_delegate.h"
 #include "content/public/app/content_main.h"
 #include "starboard/event.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace cobalt {
 
@@ -49,7 +49,7 @@ class AppEventRunner {
   virtual void InitializeSystem() = 0;
 
   // Creates the main delegate for the content process.
-  virtual void CreateMainDelegate(absl::optional<int64_t> startup_timestamp,
+  virtual void CreateMainDelegate(std::optional<int64_t> startup_timestamp,
                                   bool is_visible,
                                   const char* initial_deep_link) = 0;
 

--- a/cobalt/app/cobalt_main_delegate.cc
+++ b/cobalt/app/cobalt_main_delegate.cc
@@ -66,11 +66,10 @@
 
 namespace cobalt {
 
-CobaltMainDelegate::CobaltMainDelegate(
-    absl::optional<int64_t> startup_timestamp,
-    const char* initial_deep_link,
-    bool is_content_browsertests,
-    bool is_visible)
+CobaltMainDelegate::CobaltMainDelegate(std::optional<int64_t> startup_timestamp,
+                                       const char* initial_deep_link,
+                                       bool is_content_browsertests,
+                                       bool is_visible)
     : content::ShellMainDelegate(),
       startup_timestamp_(startup_timestamp),
       is_visible_(is_visible),

--- a/cobalt/app/cobalt_main_delegate.h
+++ b/cobalt/app/cobalt_main_delegate.h
@@ -31,7 +31,6 @@
 #include "content/public/browser/content_browser_client.h"
 #include "content/public/gpu/content_gpu_client.h"
 #include "content/public/renderer/content_renderer_client.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace content {
 class ContentUtilityClient;
@@ -42,7 +41,7 @@ namespace cobalt {
 class CobaltMainDelegate : public content::ShellMainDelegate {
  public:
   explicit CobaltMainDelegate(
-      absl::optional<int64_t> startup_timestamp = absl::nullopt,
+      std::optional<int64_t> startup_timestamp = std::nullopt,
       const char* initial_deep_link = nullptr,
       bool is_content_browsertests = false,
       bool is_visible = true);
@@ -75,7 +74,7 @@ class CobaltMainDelegate : public content::ShellMainDelegate {
   ~CobaltMainDelegate() override;
 
  private:
-  absl::optional<int64_t> startup_timestamp_;
+  std::optional<int64_t> startup_timestamp_;
   bool is_visible_;
   std::unique_ptr<content::BrowserMainRunner> main_runner_;
   std::unique_ptr<CobaltContentBrowserClient> browser_client_;

--- a/cobalt/browser/cobalt_browser_interface_binders.cc
+++ b/cobalt/browser/cobalt_browser_interface_binders.cc
@@ -14,6 +14,8 @@
 
 #include "cobalt/browser/cobalt_browser_interface_binders.h"
 
+#include <optional>
+
 #include "base/functional/bind.h"
 #include "cobalt/browser/cobalt_content_browser_client.h"
 #include "cobalt/browser/crash_annotator/public/mojom/crash_annotator.mojom.h"
@@ -97,7 +99,7 @@ void ForwardToJavaFrame(content::RenderFrameHost* render_frame_host,
 #endif  // BUILDFLAG(IS_ANDROIDTV)
 
 void PopulateCobaltFrameBinders(
-    absl::optional<int64_t> app_startup_timestamp,
+    std::optional<int64_t> app_startup_timestamp,
     content::RenderFrameHost* render_frame_host,
     mojo::BinderMapWithContext<content::RenderFrameHost*>* binder_map) {
 // We want to use the Java Mojo implementation for 1P ATV only.

--- a/cobalt/browser/cobalt_browser_interface_binders.h
+++ b/cobalt/browser/cobalt_browser_interface_binders.h
@@ -15,8 +15,9 @@
 #ifndef COBALT_BROWSER_COBALT_BROWSER_INTERFACE_BINDERS_H_
 #define COBALT_BROWSER_COBALT_BROWSER_INTERFACE_BINDERS_H_
 
+#include <optional>
+
 #include "mojo/public/cpp/bindings/binder_map.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace content {
 class RenderFrameHost;
@@ -26,7 +27,7 @@ namespace cobalt {
 
 // Registers binders for Cobalt-specific, document-scoped Mojo interfaces.
 void PopulateCobaltFrameBinders(
-    absl::optional<int64_t> app_startup_timestamp,
+    std::optional<int64_t> app_startup_timestamp,
     content::RenderFrameHost* render_frame_host,
     mojo::BinderMapWithContext<content::RenderFrameHost*>* binder_map);
 

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -224,7 +224,7 @@ blink::UserAgentMetadata GetCobaltUserAgentMetadata() {
 }
 
 CobaltContentBrowserClient::CobaltContentBrowserClient(
-    absl::optional<int64_t> startup_timestamp,
+    std::optional<int64_t> startup_timestamp,
     const std::string& deep_link,
     bool is_visible)
     : startup_timestamp_(startup_timestamp),

--- a/cobalt/browser/cobalt_content_browser_client.h
+++ b/cobalt/browser/cobalt_content_browser_client.h
@@ -13,9 +13,9 @@
 // limitations under the License.
 
 #ifndef COBALT_BROWSER_COBALT_CONTENT_BROWSER_CLIENT_H_
-#include "third_party/abseil-cpp/absl/types/optional.h"
 #define COBALT_BROWSER_COBALT_CONTENT_BROWSER_CLIENT_H_
 
+#include <optional>
 #include <string_view>
 
 #include "cobalt/browser/client_hint_headers/cobalt_trusted_url_loader_header_client.h"
@@ -65,7 +65,7 @@ void ParseAndApplyH5vccSettingsForTesting(std::string_view settings_value,
 // a demo around Content.
 class CobaltContentBrowserClient : public content::ShellContentBrowserClient {
  public:
-  explicit CobaltContentBrowserClient(absl::optional<int64_t> startup_timestamp,
+  explicit CobaltContentBrowserClient(std::optional<int64_t> startup_timestamp,
                                       const std::string& deep_link,
                                       bool is_visible = true);
 
@@ -160,7 +160,7 @@ class CobaltContentBrowserClient : public content::ShellContentBrowserClient {
   void DispatchEvent(const std::string&, base::OnceClosure);
   void OnSbWindowCreated(SbWindow window);
   void OnSbWindowDestroyed(SbWindow window);
-  const absl::optional<int64_t> startup_timestamp_;
+  const std::optional<int64_t> startup_timestamp_;
   const std::string deep_link_;
   bool is_visible_;
 

--- a/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.cc
+++ b/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.cc
@@ -14,6 +14,8 @@
 
 #include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
 
+#include <string_view>
+
 #include "base/strings/strcat.h"
 #include "base/strings/string_util.h"
 #include "third_party/abseil-cpp/absl/strings/match.h"
@@ -22,22 +24,22 @@ namespace cobalt {
 
 namespace {
 
-bool MatchStartsWith(absl::string_view name, absl::string_view pattern) {
+bool MatchStartsWith(std::string_view name, std::string_view pattern) {
   return absl::StartsWith(name, pattern);
 }
 
-bool MatchContains(absl::string_view name, absl::string_view pattern) {
+bool MatchContains(std::string_view name, std::string_view pattern) {
   return absl::StrContains(name, pattern);
 }
 
-bool MatchEndsWith(absl::string_view name, absl::string_view pattern) {
+bool MatchEndsWith(std::string_view name, std::string_view pattern) {
   return absl::EndsWith(name, pattern);
 }
 
 struct CategoryPattern {
   const char* label;
   const char* pattern;
-  bool (*match_func)(absl::string_view, absl::string_view);
+  bool (*match_func)(std::string_view, std::string_view);
 };
 
 // Ordered by probability/impact for early exit optimization.
@@ -78,9 +80,9 @@ CobaltDetailedMetricsDelegate::CobaltDetailedMetricsDelegate() = default;
 CobaltDetailedMetricsDelegate::~CobaltDetailedMetricsDelegate() = default;
 
 void CobaltDetailedMetricsDelegate::OnSmapsEntry(
-    absl::string_view name,
+    std::string_view name,
     const memory_instrumentation::SmapsMetrics& metrics) {
-  absl::string_view label = "other";
+  std::string_view label = "other";
 
   if (name.empty()) {
     label = "anonymous_other";

--- a/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h
+++ b/cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h
@@ -17,11 +17,11 @@
 
 #include <cstdint>
 #include <string>
+#include <string_view>
 
 #include "base/containers/flat_map.h"
 #include "base/synchronization/lock.h"
 #include "services/resource_coordinator/public/cpp/memory_instrumentation/detailed_metrics_delegate.h"
-#include "third_party/abseil-cpp/absl/strings/string_view.h"
 
 namespace cobalt {
 
@@ -35,7 +35,7 @@ class CobaltDetailedMetricsDelegate
 
   // DetailedMetricsDelegate implementation.
   void OnSmapsEntry(
-      absl::string_view name,
+      std::string_view name,
       const memory_instrumentation::SmapsMetrics& metrics) override;
   void GetAndResetStats(base::flat_map<std::string, uint64_t>* stats) override;
 

--- a/cobalt/browser/performance/performance_impl.cc
+++ b/cobalt/browser/performance/performance_impl.cc
@@ -32,7 +32,7 @@ using ::starboard::StarboardBridge;
 namespace performance {
 
 PerformanceImpl::PerformanceImpl(
-    absl::optional<int64_t> app_startup_timestamp,
+    std::optional<int64_t> app_startup_timestamp,
     content::RenderFrameHost& render_frame_host,
     mojo::PendingReceiver<mojom::CobaltPerformance> receiver)
     : content::DocumentService<mojom::CobaltPerformance>(render_frame_host,
@@ -40,7 +40,7 @@ PerformanceImpl::PerformanceImpl(
       app_startup_timestamp_(app_startup_timestamp) {}
 
 void PerformanceImpl::Create(
-    absl::optional<int64_t> app_startup_timestamp,
+    std::optional<int64_t> app_startup_timestamp,
     content::RenderFrameHost* render_frame_host,
     mojo::PendingReceiver<mojom::CobaltPerformance> receiver) {
   new PerformanceImpl(app_startup_timestamp, *render_frame_host,

--- a/cobalt/browser/performance/performance_impl.h
+++ b/cobalt/browser/performance/performance_impl.h
@@ -15,10 +15,11 @@
 #ifndef COBALT_BROWSER_PERFORMANCE_PERFORMANCE_IMPL_H_
 #define COBALT_BROWSER_PERFORMANCE_PERFORMANCE_IMPL_H_
 
+#include <optional>
+
 #include "cobalt/browser/performance/public/mojom/performance.mojom.h"
 #include "content/public/browser/document_service.h"
 #include "mojo/public/cpp/bindings/pending_receiver.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace content {
 class RenderFrameHost;
@@ -34,7 +35,7 @@ class PerformanceImpl
  public:
   // Creates a PerformanceImpl. The PerformanceImpl is bound to the
   // receiver and its lifetime is scoped to the render_frame_host.
-  static void Create(absl::optional<int64_t> app_startup_timestamp,
+  static void Create(std::optional<int64_t> app_startup_timestamp,
                      content::RenderFrameHost* render_frame_host,
                      mojo::PendingReceiver<mojom::CobaltPerformance> receiver);
 
@@ -49,10 +50,10 @@ class PerformanceImpl
   void GetAppStartupTimeStamp(GetAppStartupTimeStampCallback callback) override;
 
  private:
-  PerformanceImpl(absl::optional<int64_t> app_startup_timestamp,
+  PerformanceImpl(std::optional<int64_t> app_startup_timestamp,
                   content::RenderFrameHost& render_frame_host,
                   mojo::PendingReceiver<mojom::CobaltPerformance> receiver);
-  absl::optional<int64_t> app_startup_timestamp_;
+  std::optional<int64_t> app_startup_timestamp_;
 };
 
 }  // namespace performance

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager.cc
@@ -15,6 +15,7 @@
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -794,7 +795,7 @@ Task MigrationManager::LocalStorageTask(
 
           LOG(INFO) << "Put for key: " << key_str;
           shared_state->storage_area->Put(
-              key, value, absl::nullopt, "migration",
+              key, value, std::nullopt, "migration",
               base::BindOnce(
                   [](base::RepeatingClosure barrier, std::string key_str,
                      scoped_refptr<MigrationState> state,

--- a/cobalt/shell/browser/migrate_storage_record/migration_manager_unittest.cc
+++ b/cobalt/shell/browser/migrate_storage_record/migration_manager_unittest.cc
@@ -15,6 +15,7 @@
 #include "cobalt/shell/browser/migrate_storage_record/migration_manager.h"
 
 #include <numeric>
+#include <optional>
 
 #include "base/base_paths.h"
 #include "base/command_line.h"
@@ -38,7 +39,6 @@
 #include "services/network/test/test_cookie_manager.h"
 #include "testing/gmock/include/gmock/gmock.h"
 #include "testing/gtest/include/gtest/gtest.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "third_party/blink/public/common/storage_key/storage_key.h"
 #include "third_party/blink/public/mojom/dom_storage/storage_area.mojom.h"
 #include "url/gurl.h"
@@ -93,7 +93,7 @@ class MockStorageArea : public blink::mojom::StorageArea {
                        observer) override {}
   void Put(const std::vector<uint8_t>& key,
            const std::vector<uint8_t>& value,
-           const absl::optional<std::vector<uint8_t>>& client_old_value,
+           const std::optional<std::vector<uint8_t>>& client_old_value,
            const std::string& source,
            PutCallback callback) override {
     put_call_count_++;
@@ -106,7 +106,7 @@ class MockStorageArea : public blink::mojom::StorageArea {
     }
   }
   void Delete(const std::vector<uint8_t>& key,
-              const absl::optional<std::vector<uint8_t>>& client_old_value,
+              const std::optional<std::vector<uint8_t>>& client_old_value,
               const std::string& source,
               DeleteCallback callback) override {}
   void DeleteAll(

--- a/cobalt/testing/browser_tests/browser/shell_content_browser_test_client.cc
+++ b/cobalt/testing/browser_tests/browser/shell_content_browser_test_client.cc
@@ -14,6 +14,7 @@
 
 #include "cobalt/testing/browser_tests/browser/shell_content_browser_test_client.h"
 
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -108,7 +109,7 @@ class ShellControllerImpl : public mojom::ShellController {
     if (command_line.HasSwitch(name)) {
       std::move(callback).Run(command_line.GetSwitchValueASCII(name));
     } else {
-      std::move(callback).Run(absl::nullopt);
+      std::move(callback).Run(std::nullopt);
     }
   }
 

--- a/cobalt/testing/browser_tests/content_browser_test_content_browser_client.cc
+++ b/cobalt/testing/browser_tests/content_browser_test_content_browser_client.cc
@@ -14,6 +14,7 @@
 
 #include "cobalt/testing/browser_tests/content_browser_test_content_browser_client.h"
 
+#include <optional>
 #include <string_view>
 
 #include "base/test/task_environment.h"
@@ -56,7 +57,7 @@ void ContentBrowserTestContentBrowserClient::
     RegisterBrowserInterfaceBindersForFrame(
         RenderFrameHost* render_frame_host,
         mojo::BinderMapWithContext<RenderFrameHost*>* map) {
-  cobalt::PopulateCobaltFrameBinders(absl::nullopt, render_frame_host, map);
+  cobalt::PopulateCobaltFrameBinders(std::nullopt, render_frame_host, map);
   ShellContentBrowserClient::RegisterBrowserInterfaceBindersForFrame(
       render_frame_host, map);
 }

--- a/cobalt/testing/browser_tests/frame_tree_browsertest.cc
+++ b/cobalt/testing/browser_tests/frame_tree_browsertest.cc
@@ -14,6 +14,8 @@
 
 #include "content/browser/renderer_host/frame_tree.h"
 
+#include <optional>
+
 #include "base/command_line.h"
 #include "base/strings/strcat.h"
 #include "base/strings/stringprintf.h"
@@ -69,8 +71,8 @@ EvalJsResult GetOriginFromRenderer(FrameTreeNode* node) {
 // Expect that frame_name, id and src match the node's values.
 void ExpectAttributesEq(FrameTreeNode* node,
                         const std::string& frame_name,
-                        const absl::optional<std::string> id,
-                        const absl::optional<std::string> src) {
+                        const std::optional<std::string> id,
+                        const std::optional<std::string> src) {
   EXPECT_EQ(frame_name, node->frame_name());
   EXPECT_EQ(id, node->html_id());
   EXPECT_EQ(src, node->html_src());
@@ -135,7 +137,7 @@ IN_PROC_BROWSER_TEST_F(FrameTreeBrowserTest, DISABLED_FrameTreeShape2) {
 
   // Check that the root node is properly created.
   ASSERT_EQ(3UL, root->child_count());
-  ExpectAttributesEq(root, std::string(), absl::nullopt, absl::nullopt);
+  ExpectAttributesEq(root, std::string(), std::nullopt, std::nullopt);
 
   ASSERT_EQ(2UL, root->child_at(0)->child_count());
   ExpectAttributesEq(root->child_at(0), "1-1-name", "1-1-id", "1-1.html");
@@ -154,7 +156,7 @@ IN_PROC_BROWSER_TEST_F(FrameTreeBrowserTest, DISABLED_FrameTreeShape2) {
 
   root = wc->GetPrimaryFrameTree().root();
   EXPECT_EQ(0UL, root->child_count());
-  ExpectAttributesEq(root, std::string(), absl::nullopt, absl::nullopt);
+  ExpectAttributesEq(root, std::string(), std::nullopt, std::nullopt);
 }
 
 // Frame attributes of iframe elements are correctly tracked in FrameTree.
@@ -169,7 +171,7 @@ IN_PROC_BROWSER_TEST_F(FrameTreeBrowserTest,
 
   // Check that the root node is properly created.
   ASSERT_EQ(3UL, root->child_count());
-  ExpectAttributesEq(root, std::string(), absl::nullopt, absl::nullopt);
+  ExpectAttributesEq(root, std::string(), std::nullopt, std::nullopt);
 
   ASSERT_EQ(2UL, root->child_at(0)->child_count());
   ExpectAttributesEq(root->child_at(0), "1-1-name", "1-1-id", "1-1.html");
@@ -199,7 +201,7 @@ IN_PROC_BROWSER_TEST_F(FrameTreeBrowserTest, DISABLED_FrameNameVSWindowName) {
 
   // Check that the root node is properly created.
   ASSERT_EQ(3UL, root->child_count());
-  EXPECT_EQ(absl::nullopt, root->html_name());
+  EXPECT_EQ(std::nullopt, root->html_name());
   EXPECT_EQ(std::string(), root->frame_name());
 
   ASSERT_EQ(2UL, root->child_at(0)->child_count());
@@ -271,7 +273,7 @@ IN_PROC_BROWSER_TEST_F(FrameTreeBrowserTest, DISABLED_InsertFrameInTree) {
 
   // Check that the root node is properly created.
   ASSERT_EQ(3UL, root->child_count());
-  ExpectAttributesEq(root, std::string(), absl::nullopt, absl::nullopt);
+  ExpectAttributesEq(root, std::string(), std::nullopt, std::nullopt);
 
   ASSERT_EQ(2UL, root->child_at(0)->child_count());
   ExpectAttributesEq(root->child_at(0), "1-1-name", "1-1-id", "1-1.html");

--- a/cobalt/testing/browser_tests/granular_memory_browsertest.cc
+++ b/cobalt/testing/browser_tests/granular_memory_browsertest.cc
@@ -2,6 +2,8 @@
 // Use of this source code is governed by a BSD-style license that can be
 // found in the LICENSE file.
 
+#include <string_view>
+
 #include "base/files/file_util.h"
 #include "base/run_loop.h"
 #include "base/threading/thread_restrictions.h"
@@ -60,7 +62,7 @@ class TestDetailedMetricsDelegate
   ~TestDetailedMetricsDelegate() override = default;
 
   void OnSmapsEntry(
-      absl::string_view name,
+      std::string_view name,
       const memory_instrumentation::SmapsMetrics& metrics) override {
     stats_["Test"] += metrics.pss_kb;
     total_pss_kb_ += metrics.pss_kb;

--- a/cobalt/testing/browser_tests/media_session_browsertest.cc
+++ b/cobalt/testing/browser_tests/media_session_browsertest.cc
@@ -14,6 +14,8 @@
 
 #include "content/public/browser/media_session.h"
 
+#include <optional>
+
 #include "base/command_line.h"
 #include "base/containers/contains.h"
 #include "base/functional/callback_helpers.h"
@@ -40,7 +42,6 @@
 #include "services/media_session/public/cpp/features.h"
 #include "services/media_session/public/cpp/test/audio_focus_test_util.h"
 #include "services/media_session/public/cpp/test/mock_media_session.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace content {
 
@@ -83,7 +84,7 @@ class MediaImageGetterHelper {
   }
 
   base::RunLoop run_loop_;
-  absl::optional<SkBitmap> bitmap_;
+  std::optional<SkBitmap> bitmap_;
 };
 
 // Integration tests for content::MediaSession that do not take into

--- a/cobalt/testing/browser_tests/site_per_process_browsertest.cc
+++ b/cobalt/testing/browser_tests/site_per_process_browsertest.cc
@@ -22,6 +22,7 @@
 #include <list>
 #include <map>
 #include <memory>
+#include <optional>
 #include <set>
 #include <string>
 #include <tuple>
@@ -360,15 +361,15 @@ void FocusFrame(FrameTreeNode* frame) {
 }
 
 bool ConvertJSONToPoint(const std::string& str, gfx::PointF* point) {
-  absl::optional<base::Value> value = base::JSONReader::Read(str);
+  std::optional<base::Value> value = base::JSONReader::Read(str);
   if (!value.has_value()) {
     return false;
   }
   if (!value->is_dict()) {
     return false;
   }
-  absl::optional<double> x = value->GetDict().FindDouble("x");
-  absl::optional<double> y = value->GetDict().FindDouble("y");
+  std::optional<double> x = value->GetDict().FindDouble("x");
+  std::optional<double> y = value->GetDict().FindDouble("y");
   if (!x.has_value()) {
     return false;
   }
@@ -389,7 +390,7 @@ CreateParsedPermissionsPolicyDeclaration(
     blink::mojom::PermissionsPolicyFeature feature,
     const std::vector<GURL>& origins,
     bool match_all_origins = false,
-    const absl::optional<GURL> self_if_matches = absl::nullopt) {
+    const std::optional<GURL> self_if_matches = std::nullopt) {
   blink::ParsedPermissionsPolicyDeclaration declaration;
 
   declaration.feature = feature;
@@ -414,7 +415,7 @@ blink::ParsedPermissionsPolicy CreateParsedPermissionsPolicy(
     const std::vector<blink::mojom::PermissionsPolicyFeature>& features,
     const std::vector<GURL>& origins,
     bool match_all_origins = false,
-    const absl::optional<GURL> self_if_matches = absl::nullopt) {
+    const std::optional<GURL> self_if_matches = std::nullopt) {
   blink::ParsedPermissionsPolicy result;
   result.reserve(features.size());
   for (const auto& feature : features) {
@@ -4817,7 +4818,7 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
     std::ignore = params->associated_interface_provider_remote
                       .InitWithNewEndpointAndPassReceiver();
     params->previous_frame_token = previous_frame_token;
-    params->opener_frame_token = absl::nullopt;
+    params->opener_frame_token = std::nullopt;
     params->parent_frame_token =
         shell()->web_contents()->GetPrimaryMainFrame()->GetFrameToken();
     params->frame_owner_properties = blink::mojom::FrameOwnerProperties::New();
@@ -4883,7 +4884,7 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
       node->current_frame_host()->GetFrameToken();
   int widget_routing_id =
       node->current_frame_host()->GetRenderWidgetHost()->GetRoutingID();
-  absl::optional<blink::FrameToken> parent_frame_token =
+  std::optional<blink::FrameToken> parent_frame_token =
       node->parent()
           ->frame_tree_node()
           ->render_manager()
@@ -4908,10 +4909,10 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
     std::ignore = params->interface_broker.InitWithNewPipeAndPassReceiver();
     std::ignore = params->associated_interface_provider_remote
                       .InitWithNewEndpointAndPassReceiver();
-    params->previous_frame_token = absl::nullopt;
-    params->opener_frame_token = absl::nullopt;
+    params->previous_frame_token = std::nullopt;
+    params->opener_frame_token = std::nullopt;
     params->parent_frame_token = parent_frame_token;
-    params->previous_sibling_frame_token = absl::nullopt;
+    params->previous_sibling_frame_token = std::nullopt;
     params->frame_owner_properties = blink::mojom::FrameOwnerProperties::New();
     params->widget_params = mojom::CreateFrameWidgetParams::New();
     params->widget_params->routing_id = widget_routing_id;
@@ -6086,8 +6087,8 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
   std::unique_ptr<NavigationEntryImpl> restored_entry =
       NavigationEntryImpl::FromNavigationEntry(
           NavigationController::CreateNavigationEntry(
-              main_url, Referrer(), /* initiator_origin= */ absl::nullopt,
-              /* initiator_base_url= */ absl::nullopt,
+              main_url, Referrer(), /* initiator_origin= */ std::nullopt,
+              /* initiator_base_url= */ std::nullopt,
               ui::PAGE_TRANSITION_RELOAD, false, std::string(),
               controller.GetBrowserContext(),
               nullptr /* blob_url_loader_factory */));
@@ -6202,8 +6203,8 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
   std::unique_ptr<NavigationEntryImpl> restored_entry =
       NavigationEntryImpl::FromNavigationEntry(
           NavigationController::CreateNavigationEntry(
-              main_url, Referrer(), /* initiator_origin= */ absl::nullopt,
-              /* initiator_base_url= */ absl::nullopt,
+              main_url, Referrer(), /* initiator_origin= */ std::nullopt,
+              /* initiator_base_url= */ std::nullopt,
               ui::PAGE_TRANSITION_RELOAD, false, std::string(),
               controller.GetBrowserContext(),
               nullptr /* blob_url_loader_factory */));
@@ -6311,8 +6312,8 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTest,
   std::unique_ptr<NavigationEntryImpl> restored_entry =
       NavigationEntryImpl::FromNavigationEntry(
           NavigationController::CreateNavigationEntry(
-              main_url, Referrer(), /* initiator_origin= */ absl::nullopt,
-              /* initiator_base_url= */ absl::nullopt,
+              main_url, Referrer(), /* initiator_origin= */ std::nullopt,
+              /* initiator_base_url= */ std::nullopt,
               ui::PAGE_TRANSITION_RELOAD, false, std::string(),
               controller.GetBrowserContext(),
               nullptr /* blob_url_loader_factory */));
@@ -12134,8 +12135,8 @@ class SitePerProcessBrowserTouchActionTest : public SitePerProcessBrowserTest {
       RenderWidgetHostViewBase* rwhv_root,
       RenderWidgetHostViewBase* rwhv_child,
       const gfx::Point& event_position,
-      absl::optional<cc::TouchAction>& effective_touch_action,
-      absl::optional<cc::TouchAction>& allowed_touch_action) {
+      std::optional<cc::TouchAction>& effective_touch_action,
+      std::optional<cc::TouchAction>& allowed_touch_action) {
     InputEventAckWaiter ack_observer(
         rwhv_child->GetRenderWidgetHost(),
         base::BindRepeating([](blink::mojom::InputEventResultSource source,
@@ -12349,8 +12350,8 @@ IN_PROC_BROWSER_TEST_P(SitePerProcessBrowserTouchActionTest,
 
   WaitForTouchActionUpdated(root_thread_observer.get(),
                             child_thread_observer.get());
-  absl::optional<cc::TouchAction> effective_touch_action;
-  absl::optional<cc::TouchAction> allowed_touch_action;
+  std::optional<cc::TouchAction> effective_touch_action;
+  std::optional<cc::TouchAction> allowed_touch_action;
   cc::TouchAction expected_touch_action = cc::TouchAction::kPan;
   // Gestures are filtered by the intersection of touch-action values of the
   // touched element and all its ancestors up to the one that implements the
@@ -12431,8 +12432,8 @@ IN_PROC_BROWSER_TEST_F(
   // Child should inherit effective touch action none from root.
   WaitForTouchActionUpdated(root_thread_observer.get(),
                             child_thread_observer.get());
-  absl::optional<cc::TouchAction> effective_touch_action;
-  absl::optional<cc::TouchAction> allowed_touch_action;
+  std::optional<cc::TouchAction> effective_touch_action;
+  std::optional<cc::TouchAction> allowed_touch_action;
   cc::TouchAction expected_touch_action = cc::TouchAction::kPan;
   GetTouchActionsForChild(router, rwhv_root, rwhv_child, point_inside_child,
                           effective_touch_action, allowed_touch_action);
@@ -12521,8 +12522,8 @@ IN_PROC_BROWSER_TEST_P(
   // Child should inherit effective touch action none from root.
   WaitForTouchActionUpdated(root_thread_observer.get(),
                             child_thread_observer.get());
-  absl::optional<cc::TouchAction> effective_touch_action;
-  absl::optional<cc::TouchAction> allowed_touch_action;
+  std::optional<cc::TouchAction> effective_touch_action;
+  std::optional<cc::TouchAction> allowed_touch_action;
   cc::TouchAction expected_touch_action =
       cc::TouchAction::kPan | cc::TouchAction::kInternalPanXScrolls |
       cc::TouchAction::kInternalNotWritable;

--- a/cobalt/testing/browser_tests/web_contents_impl_browsertest.cc
+++ b/cobalt/testing/browser_tests/web_contents_impl_browsertest.cc
@@ -15,6 +15,7 @@
 #include "content/browser/web_contents/web_contents_impl.h"
 
 #include <array>
+#include <optional>
 #include <tuple>
 #include <utility>
 #include <vector>
@@ -116,7 +117,6 @@
 #include "services/network/public/cpp/features.h"
 #include "services/network/public/mojom/web_client_hints_types.mojom.h"
 #include "testing/gmock/include/gmock/gmock.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "third_party/blink/public/common/client_hints/client_hints.h"
 #include "third_party/blink/public/common/features.h"
 #include "third_party/blink/public/common/page/page_zoom.h"
@@ -3054,7 +3054,7 @@ IN_PROC_BROWSER_TEST_F(WebContentsImplBrowserTestClientHintsEnabled,
   blink::UserAgentOverride ua_override;
   ua_override.ua_string_override = "x";
   // Do NOT set `ua_metadata_override`, so the UA-CH headers are *removed*
-  ua_override.ua_metadata_override = absl::nullopt;
+  ua_override.ua_metadata_override = std::nullopt;
   UserAgentInjector injector(shell()->web_contents(), ua_override);
   EXPECT_TRUE(NavigateToURL(shell(), http2_server.GetURL("/empty.html")));
 
@@ -3108,7 +3108,7 @@ class WebContentsImplBrowserTestReduceAcceptLanguageOn
   void VerifyPersistAndGetReduceAcceptLanguage(
       const GURL& url,
       const std::string& persist_lang,
-      const absl::optional<std::string>& expect_lang) {
+      const std::optional<std::string>& expect_lang) {
     ReduceAcceptLanguageControllerDelegate* delegate =
         ShellContentBrowserClient::Get()
             ->browser_context()
@@ -3116,7 +3116,7 @@ class WebContentsImplBrowserTestReduceAcceptLanguageOn
 
     url::Origin origin = url::Origin::Create(url);
     delegate->PersistReducedLanguage(origin, persist_lang);
-    const absl::optional<std::string>& language =
+    const std::optional<std::string>& language =
         delegate->GetReducedLanguage(origin);
     EXPECT_EQ(expect_lang, language);
 
@@ -3153,7 +3153,7 @@ IN_PROC_BROWSER_TEST_F(WebContentsImplBrowserTestReduceAcceptLanguageOn,
                                           /*expect_lang=*/test_lang);
   VerifyPersistAndGetReduceAcceptLanguage(/*url=*/GURL("ws://example.com/"),
                                           /*persist_lang=*/test_lang,
-                                          /*expect_lang=*/absl::nullopt);
+                                          /*expect_lang=*/std::nullopt);
 }
 
 IN_PROC_BROWSER_TEST_F(WebContentsImplBrowserTest,
@@ -3437,7 +3437,7 @@ class UpdateTargetURLWaiter : public WebContentsDelegate {
     }
   }
 
-  absl::optional<GURL> updated_target_url_;
+  std::optional<GURL> updated_target_url_;
   scoped_refptr<MessageLoopRunner> runner_;
 };
 
@@ -3718,8 +3718,8 @@ IN_PROC_BROWSER_TEST_F(WebContentsImplBrowserTest, MAYBE_TitleUpdateOnRestore) {
   std::unique_ptr<NavigationEntryImpl> restored_entry =
       NavigationEntryImpl::FromNavigationEntry(
           NavigationController::CreateNavigationEntry(
-              main_url, Referrer(), /* initiator_origin= */ absl::nullopt,
-              /* initiator_base_url= */ absl::nullopt,
+              main_url, Referrer(), /* initiator_origin= */ std::nullopt,
+              /* initiator_base_url= */ std::nullopt,
               ui::PAGE_TRANSITION_RELOAD, false, std::string(),
               controller.GetBrowserContext(),
               nullptr /* blob_url_loader_factory */));
@@ -5378,7 +5378,7 @@ IN_PROC_BROWSER_TEST_F(WebContentsImplBrowserTest,
   EXPECT_EQ(shell()->web_contents()->GetThemeColor(), 0xFFFF0000u);
 
   EXPECT_TRUE(NavigateToURL(shell(), url_b));
-  EXPECT_EQ(shell()->web_contents()->GetThemeColor(), absl::nullopt);
+  EXPECT_EQ(shell()->web_contents()->GetThemeColor(), std::nullopt);
 
   shell()->web_contents()->GetController().GoBack();
   EXPECT_TRUE(WaitForLoadStop(shell()->web_contents()));
@@ -5700,7 +5700,7 @@ IN_PROC_BROWSER_TEST_F(WebContentsImplBrowserTest,
       clipboard_paste_data,
       base::BindLambdaForTesting(
           [&web_contents](
-              absl::optional<ClipboardPasteData> clipboard_paste_data) {
+              std::optional<ClipboardPasteData> clipboard_paste_data) {
             EXPECT_TRUE(clipboard_paste_data.has_value());
             EXPECT_TRUE(web_contents->ShouldIgnoreUnresponsiveRenderer());
           }));
@@ -6183,7 +6183,7 @@ class MediaWaiter : public WebContentsObserver {
   void WaitForMediaDestroyed() { media_destroyed_loop_.Run(); }
 
  private:
-  absl::optional<MediaPlayerId> started_media_id_;
+  std::optional<MediaPlayerId> started_media_id_;
   base::RunLoop media_started_playing_loop_;
   base::RunLoop media_destroyed_loop_;
 };

--- a/cobalt/updater/updater_module.cc
+++ b/cobalt/updater/updater_module.cc
@@ -14,6 +14,7 @@
 
 #include "cobalt/updater/updater_module.h"
 
+#include <optional>
 #include <utility>
 #include <vector>
 
@@ -44,7 +45,6 @@
 #include "starboard/common/file.h"
 #include "starboard/configuration_constants.h"
 #include "starboard/extension/installation_manager.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 
 namespace {
 

--- a/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
@@ -14,6 +14,8 @@
 
 #include "media/mojo/clients/starboard/starboard_renderer_client.h"
 
+#include <optional>
+
 #include "base/functional/callback_helpers.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/test/gmock_callback_support.h"
@@ -68,7 +70,7 @@ class FakeMojomRenderer : public mojom::Renderer {
   MOCK_METHOD1(SetPlaybackRate, void(double));
   void SetVolume(float volume) override {}
   MOCK_METHOD2(SetCdm,
-               void(const absl::optional<base::UnguessableToken>&,
+               void(const std::optional<base::UnguessableToken>&,
                     SetCdmCallback));
   void SetLatencyHint(std::optional<::base::TimeDelta> latency_hint) override {}
 };
@@ -130,7 +132,7 @@ class MockRendererClientStarboard : public RendererClient {
   MOCK_METHOD1(OnVideoConfigChange, void(const VideoDecoderConfig&));
   MOCK_METHOD1(OnVideoNaturalSizeChange, void(const gfx::Size&));
   MOCK_METHOD1(OnVideoOpacityChange, void(bool));
-  MOCK_METHOD1(OnVideoFrameRateChange, void(absl::optional<int>));
+  MOCK_METHOD1(OnVideoFrameRateChange, void(std::optional<int>));
   MOCK_METHOD0(IsVideoStreamAvailable, bool());
 };
 

--- a/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
+++ b/media/mojo/services/starboard/gpu_mojo_media_client_starboard.cc
@@ -12,6 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <optional>
+
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/single_thread_task_runner.h"
 #include "gpu/config/gpu_finch_features.h"
@@ -45,7 +47,7 @@ class GpuMojoMediaClientStarboard final : public GpuMojoMediaClient {
     return nullptr;
   }
 
-  absl::optional<SupportedVideoDecoderConfigs>
+  std::optional<SupportedVideoDecoderConfigs>
   GetPlatformSupportedVideoDecoderConfigs() final {
     return {};
   }

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.cc
@@ -305,7 +305,7 @@ void StarboardRendererWrapper::SetCdm(CdmContext* cdm_context,
 }
 
 void StarboardRendererWrapper::SetLatencyHint(
-    absl::optional<base::TimeDelta> latency_hint) {
+    std::optional<base::TimeDelta> latency_hint) {
   DCHECK_CALLED_ON_VALID_THREAD(thread_checker_);
   GetRenderer()->SetLatencyHint(latency_hint);
 }

--- a/media/mojo/services/starboard/starboard_renderer_wrapper.h
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper.h
@@ -16,6 +16,7 @@
 #define MEDIA_MOJO_SERVICES_STARBOARD_STARBOARD_RENDERER_WRAPPER_H_
 
 #include <functional>
+#include <optional>
 #include <vector>
 
 #include "base/memory/raw_ptr.h"
@@ -92,7 +93,7 @@ class StarboardRendererWrapper
   void SetPlaybackRate(double playback_rate) override;
   void SetVolume(float volume) override;
   void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
-  void SetLatencyHint(absl::optional<base::TimeDelta> latency_hint) override;
+  void SetLatencyHint(std::optional<base::TimeDelta> latency_hint) override;
   base::TimeDelta GetMediaTime() override;
   RendererType GetRendererType() override;
 

--- a/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
+++ b/media/mojo/services/starboard/starboard_renderer_wrapper_unittest.cc
@@ -15,6 +15,7 @@
 #include "media/mojo/services/starboard/starboard_renderer_wrapper.h"
 
 #include <memory>
+#include <optional>
 #include <vector>
 
 #include "base/functional/bind.h"
@@ -94,7 +95,7 @@ class MockStarboardRenderer : public StarboardRenderer {
                void(MediaResource* media_resource,
                     RendererClient* client,
                     PipelineStatusCallback& init_cb));
-  MOCK_METHOD1(SetLatencyHint, void(absl::optional<TimeDelta>));
+  MOCK_METHOD1(SetLatencyHint, void(std::optional<TimeDelta>));
   MOCK_METHOD1(SetPreservesPitch, void(bool));
   MOCK_METHOD1(SetWasPlayedWithUserActivation, void(bool));
   void Flush(base::OnceClosure flush_cb) override { OnFlush(flush_cb); }

--- a/media/starboard/starboard_renderer.h
+++ b/media/starboard/starboard_renderer.h
@@ -15,6 +15,7 @@
 #ifndef MEDIA_STARBOARD_STARBOARD_RENDERER_H_
 #define MEDIA_STARBOARD_STARBOARD_RENDERER_H_
 
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -34,7 +35,6 @@
 #include "media/base/starboard/starboard_renderer_config.h"
 #include "media/base/starboard/starboard_rendering_mode.h"
 #include "media/starboard/sbplayer_bridge.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/gfx/color_space.h"
 
 #if BUILDFLAG(IS_ANDROID)
@@ -78,7 +78,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
                   RendererClient* client,
                   PipelineStatusCallback init_cb) override;
   void SetCdm(CdmContext* cdm_context, CdmAttachedCB cdm_attached_cb) override;
-  void SetLatencyHint(absl::optional<TimeDelta> latency_hint) override {
+  void SetLatencyHint(std::optional<TimeDelta> latency_hint) override {
     // TODO(b/380935131): Consider to implement `LatencyHint` for SbPlayer.
     NOTIMPLEMENTED();
   }
@@ -236,7 +236,7 @@ class MEDIA_EXPORT StarboardRenderer : public Renderer,
   raw_ptr<DemuxerStream> audio_stream_ = nullptr;
   raw_ptr<DemuxerStream> video_stream_ = nullptr;
   // TODO(b/375274109): Investigate whether we should call
-  //                    `void OnVideoFrameRateChange(absl::optional<int> fps)`
+  //                    `void OnVideoFrameRateChange(std::optional<int> fps)`
   //                    on `client_`?
   raw_ptr<RendererClient> client_ = nullptr;
   PaintVideoHoleFrameCallback paint_video_hole_frame_cb_;

--- a/media/starboard/starboard_utils.cc
+++ b/media/starboard/starboard_utils.cc
@@ -289,7 +289,7 @@ ENUM_EQ(kSbMediaRangeIdDerived, gfx::ColorSpace::RangeID::DERIVED);
 
 SbMediaColorMetadata MediaToSbMediaColorMetadata(
     const VideoColorSpace& color_space,
-    const absl::optional<gfx::HDRMetadata>& hdr_metadata,
+    const std::optional<gfx::HDRMetadata>& hdr_metadata,
     const std::string& mime_type) {
   SbMediaColorMetadata sb_media_color_metadata = {};
 

--- a/media/starboard/starboard_utils.h
+++ b/media/starboard/starboard_utils.h
@@ -15,6 +15,8 @@
 #ifndef MEDIA_STARBOARD_STARBOARD_UTILS_H_
 #define MEDIA_STARBOARD_STARBOARD_UTILS_H_
 
+#include <optional>
+
 #include "media/base/audio_codecs.h"
 #include "media/base/audio_decoder_config.h"
 #include "media/base/decoder_buffer.h"
@@ -23,7 +25,6 @@
 #include "media/base/video_decoder_config.h"
 #include "starboard/drm.h"
 #include "starboard/media.h"
-#include "third_party/abseil-cpp/absl/types/optional.h"
 #include "ui/gfx/hdr_metadata.h"
 
 namespace media {
@@ -44,7 +45,7 @@ void FillDrmSampleInfo(const scoped_refptr<DecoderBuffer>& buffer,
 
 SbMediaColorMetadata MediaToSbMediaColorMetadata(
     const VideoColorSpace& color_space,
-    const absl::optional<gfx::HDRMetadata>& hdr_metadata,
+    const std::optional<gfx::HDRMetadata>& hdr_metadata,
     const std::string& mime_type);
 
 // Extract the value of "codecs" parameter from |mime_type|. It will return


### PR DESCRIPTION
Replace all remaining occurrences of absl::optional and
absl::string_view with their std:: counterparts in the media/ and
cobalt/ directories. Those classes are banned[1]

This change aligns the codebase with the Chromium style guide and
Cobalt's coding standards, leveraging standard library features now
available in the C++ environment.

---
[1] 
- https://github.com/chromium/chromium/blob/main/styleguide/c%2B%2B/c++-features.md#optional-banned
- https://github.com/chromium/chromium/blob/main/styleguide/c%2B%2B/c++-features.md#string_view-banned


Issue: 487283136
