### PR TITLE
configuration: Call starboard extension for CobaltUserOnExitStrategy

### DIFF
--- a/cobalt/configuration/configuration.cc
+++ b/cobalt/configuration/configuration.cc
@@ -19,7 +19,6 @@
 
 #include "base/memory/singleton.h"
 #include "base/notreached.h"
-#include "build/build_config.h"
 #include "starboard/system.h"
 
 namespace cobalt {
@@ -44,9 +43,6 @@ Configuration::Configuration() {
 }
 
 Configuration::UserOnExitStrategy Configuration::CobaltUserOnExitStrategy() {
-#if BUILDFLAG(IS_ANDROID)
-  return Configuration::UserOnExitStrategy::kMinimize;
-#else
   constexpr char kStop[] = "stop";
   constexpr char kSuspend[] = "suspend";
   constexpr char kNoExit[] = "noexit";
@@ -68,7 +64,6 @@ Configuration::UserOnExitStrategy Configuration::CobaltUserOnExitStrategy() {
   }
   LOG(ERROR) << "Invalid CobaltUserOnExitStrategy: " << strategy;
   return Configuration::UserOnExitStrategy::kClose;
-#endif
 }
 
 int Configuration::CobaltLocalTypefaceCacheSizeInBytes() {

--- a/cobalt/configuration/configuration.cc
+++ b/cobalt/configuration/configuration.cc
@@ -19,6 +19,7 @@
 
 #include "base/memory/singleton.h"
 #include "base/notreached.h"
+#include "build/build_config.h"
 #include "starboard/system.h"
 
 namespace cobalt {
@@ -43,6 +44,9 @@ Configuration::Configuration() {
 }
 
 Configuration::UserOnExitStrategy Configuration::CobaltUserOnExitStrategy() {
+#if BUILDFLAG(IS_ANDROID)
+  return Configuration::UserOnExitStrategy::kMinimize;
+#else
   constexpr char kStop[] = "stop";
   constexpr char kSuspend[] = "suspend";
   constexpr char kNoExit[] = "noexit";
@@ -62,8 +66,9 @@ Configuration::UserOnExitStrategy Configuration::CobaltUserOnExitStrategy() {
   } else if (strategy == kNoExit) {
     return Configuration::UserOnExitStrategy::kNoExit;
   }
-  NOTREACHED() << "Invalid CobaltUserOnExitStrategy: " << strategy;
+  LOG(ERROR) << "Invalid CobaltUserOnExitStrategy: " << strategy;
   return Configuration::UserOnExitStrategy::kClose;
+#endif
 }
 
 int Configuration::CobaltLocalTypefaceCacheSizeInBytes() {

--- a/cobalt/configuration/configuration.cc
+++ b/cobalt/configuration/configuration.cc
@@ -15,10 +15,10 @@
 #include "cobalt/configuration/configuration.h"
 
 #include <string>
+#include <string_view>
 
 #include "base/memory/singleton.h"
 #include "base/notreached.h"
-#include "build/build_config.h"
 #include "starboard/system.h"
 
 namespace cobalt {
@@ -43,12 +43,27 @@ Configuration::Configuration() {
 }
 
 Configuration::UserOnExitStrategy Configuration::CobaltUserOnExitStrategy() {
-// TODO(b/385357645): fix calling the configuratino extension function.
-#if BUILDFLAG(IS_ANDROID)
-  return Configuration::UserOnExitStrategy::kMinimize;
-#else
+  constexpr char kStop[] = "stop";
+  constexpr char kSuspend[] = "suspend";
+  constexpr char kNoExit[] = "noexit";
+
+  if (!configuration_api_ || !configuration_api_->CobaltUserOnExitStrategy) {
+    return Configuration::UserOnExitStrategy::kClose;
+  }
+  const char* strategy_str = configuration_api_->CobaltUserOnExitStrategy();
+  if (!strategy_str) {
+    return Configuration::UserOnExitStrategy::kClose;
+  }
+  std::string_view strategy = strategy_str;
+  if (strategy == kStop) {
+    return Configuration::UserOnExitStrategy::kClose;
+  } else if (strategy == kSuspend) {
+    return Configuration::UserOnExitStrategy::kMinimize;
+  } else if (strategy == kNoExit) {
+    return Configuration::UserOnExitStrategy::kNoExit;
+  }
+  NOTREACHED() << "Invalid CobaltUserOnExitStrategy: " << strategy;
   return Configuration::UserOnExitStrategy::kClose;
-#endif
 }
 
 int Configuration::CobaltLocalTypefaceCacheSizeInBytes() {


### PR DESCRIPTION
Call the Starboard extension function `CobaltUserOnExitStrategy` in `Configuration::CobaltUserOnExitStrategy` to retrieve the platform-defined user exit strategy instead of hardcoding a platform-based exit strategy.

Bug: 385357645

TAG=agy
CONV=8dfb4693-8786-4c64-94a3-061ca9fcc64f