### PR TITLE
feat: Add pruning of native stability JSON storage

### DIFF
--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -238,13 +238,13 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
 #endif  // !BUILDFLAG(IS_ANDROIDTV)
 
 #if BUILDFLAG(USE_EVERGREEN)
-  // It would probably be harmless but confusing to add this annotation on
-  // platforms that do not support native stability tracking.
+  auto* native_stability_manager =
+      h5vcc_native_stability::NativeStabilityManager::GetInstance();
 
   // TODO: b/528362453 - Consider moving this to an earlier startup stage (e.g.
   // PreEarlyInitialization) to ensure early startup crashes are also tagged.
-  h5vcc_native_stability::NativeStabilityManager::GetInstance()
-      ->ArmCrashUuidAnnotation();
+  native_stability_manager->ArmCrashUuidAnnotation();
+  native_stability_manager->PruneStorage();
 #endif  // BUILDFLAG(USE_EVERGREEN)
 
   int result = ShellBrowserMainParts::PreMainMessageLoopRun();

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
@@ -41,11 +41,13 @@ namespace h5vcc_native_stability {
 
 namespace {
 
-// TODO(b/528362453): Per the design doc, we should prune native stability JSON
-// storage at startup by removing entries for events no longer persisted by the
-// crash reporting system's own local storage.
 constexpr char kNativeStabilityDirName[] = "native_stability";
 constexpr char kAckedEventUuidsFileName[] = "acked_event_uuids.json";
+
+// We want a number large enough that we avoid missing any reports in all but
+// the most extreme cases, but not so large that we waste significant memory
+// when allocating the buffer.
+constexpr int kMaxNumReports = 128;
 
 mojom::BaseReportDataPtr CreateBaseReportData(
     const SbNativeStabilityReport& sb_report) {
@@ -227,10 +229,6 @@ void NativeStabilityManager::GetPendingReportsOnTaskRunner(
   std::unordered_set<std::string> acked_uuids =
       ReadAckedUuidsFromDisk(file_path);
 
-  // We want a number large enough that we avoid missing any reports in all but
-  // the most extreme cases, but not so large that we waste significant memory
-  // when allocating the buffer.
-  constexpr int kMaxNumReports = 128;
   SbNativeStabilityReport sb_reports[kMaxNumReports];
   int count =
       native_stability_extension->ReadReports(sb_reports, kMaxNumReports);
@@ -318,6 +316,83 @@ void NativeStabilityManager::RecordHangRecovered(const std::string& hang_uuid) {
   // TODO(b/528362453): Implement persistent storage layer.
   LOG(INFO) << "Mock NativeStabilityManager::RecordHangRecovered for UUID: "
             << hang_uuid;
+}
+
+void NativeStabilityManager::PruneStorage(base::OnceClosure callback) {
+  DCHECK_CALLED_ON_VALID_SEQUENCE(sequence_checker_);
+  if (!task_runner_) {
+    task_runner_ = base::ThreadPool::CreateSequencedTaskRunner(
+        {base::MayBlock(), base::TaskPriority::USER_VISIBLE,
+         base::TaskShutdownBehavior::SKIP_ON_SHUTDOWN});
+  }
+  auto* native_stability_extension =
+      static_cast<const StarboardExtensionNativeStabilityApi*>(
+          GetExtension(kStarboardExtensionNativeStabilityName));
+  task_runner_->PostTask(
+      FROM_HERE,
+      base::BindOnce(
+          &NativeStabilityManager::PruneStorageOnTaskRunner,
+          base::Unretained(this), native_stability_extension,
+          callback ? base::BindPostTaskToCurrentDefault(std::move(callback))
+                   : base::OnceClosure()));
+}
+
+void NativeStabilityManager::PruneStorageOnTaskRunner(
+    const StarboardExtensionNativeStabilityApi* native_stability_extension,
+    base::OnceClosure callback) {
+  if (!native_stability_extension || native_stability_extension->version < 1 ||
+      !native_stability_extension->ReadReports) {
+    VLOG(1) << "NativeStability extension is not supported on this platform.";
+    if (callback) {
+      std::move(callback).Run();
+    }
+    return;
+  }
+
+  SbNativeStabilityReport sb_reports[kMaxNumReports];
+  int count =
+      native_stability_extension->ReadReports(sb_reports, kMaxNumReports);
+  if (count < 0) {
+    LOG(WARNING) << "NativeStability extension ReadReports returned error ("
+                 << count << "). Aborting storage pruning.";
+    if (callback) {
+      std::move(callback).Run();
+    }
+    return;
+  }
+  if (count > kMaxNumReports) {
+    LOG(WARNING) << "NativeStability extension ReadReports returned count ("
+                 << count << ") exceeding max buffer size (" << kMaxNumReports
+                 << "). Clamping result.";
+    count = kMaxNumReports;
+  }
+
+  std::unordered_set<std::string> starboard_report_ids;
+  for (int i = 0; i < count; ++i) {
+    std::string uuid(sb_reports[i].native_stability_event_uuid);
+    if (!uuid.empty()) {
+      starboard_report_ids.insert(uuid);
+    }
+  }
+
+  base::FilePath file_path = GetAckedUuidsFilePath();
+  std::unordered_set<std::string> acked_uuids =
+      ReadAckedUuidsFromDisk(file_path);
+
+  size_t removed = std::erase_if(
+      acked_uuids, [&starboard_report_ids](const std::string& uuid) {
+        return !starboard_report_ids.contains(uuid);
+      });
+
+  if (removed > 0) {
+    VLOG(1) << "Removed " << removed
+            << " obsolete native stability report UUID(s) from disk.";
+    WriteAckedUuidsToDisk(file_path, acked_uuids);
+  }
+
+  if (callback) {
+    std::move(callback).Run();
+  }
 }
 
 }  // namespace h5vcc_native_stability

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
@@ -229,18 +229,24 @@ void NativeStabilityManager::GetPendingReportsOnTaskRunner(
   std::unordered_set<std::string> acked_uuids =
       ReadAckedUuidsFromDisk(file_path);
 
-  SbNativeStabilityReport sb_reports[kMaxNumReports];
-  int count =
-      native_stability_extension->ReadReports(sb_reports, kMaxNumReports);
+  std::vector<SbNativeStabilityReport> sb_reports(kMaxNumReports);
+  int count = native_stability_extension->ReadReports(sb_reports.data(),
+                                                      kMaxNumReports);
+  if (count < 0) {
+    LOG(WARNING) << "NativeStability extension ReadReports returned error ("
+                 << count << ").";
+    std::move(callback).Run(std::move(results));
+    return;
+  }
   if (count > kMaxNumReports) {
     LOG(WARNING) << "NativeStability extension ReadReports returned count ("
                  << count << ") exceeding max buffer size (" << kMaxNumReports
                  << "). Clamping result.";
     count = kMaxNumReports;
   }
+  sb_reports.resize(count);
 
-  for (int i = 0; i < count; ++i) {
-    const auto& sb_report = sb_reports[i];
+  for (const auto& sb_report : sb_reports) {
     std::string uuid(sb_report.native_stability_event_uuid);
     if (!uuid.empty() && acked_uuids.contains(uuid)) {
       VLOG(1) << "Skipping acknowledged native stability report UUID: " << uuid;
@@ -349,9 +355,9 @@ void NativeStabilityManager::PruneStorageOnTaskRunner(
     return;
   }
 
-  SbNativeStabilityReport sb_reports[kMaxNumReports];
-  int count =
-      native_stability_extension->ReadReports(sb_reports, kMaxNumReports);
+  std::vector<SbNativeStabilityReport> sb_reports(kMaxNumReports);
+  int count = native_stability_extension->ReadReports(sb_reports.data(),
+                                                      kMaxNumReports);
   if (count < 0) {
     LOG(WARNING) << "NativeStability extension ReadReports returned error ("
                  << count << "). Aborting storage pruning.";
@@ -366,10 +372,11 @@ void NativeStabilityManager::PruneStorageOnTaskRunner(
                  << "). Clamping result.";
     count = kMaxNumReports;
   }
+  sb_reports.resize(count);
 
   std::unordered_set<std::string> starboard_report_ids;
-  for (int i = 0; i < count; ++i) {
-    std::string uuid(sb_reports[i].native_stability_event_uuid);
+  for (const auto& sb_report : sb_reports) {
+    std::string uuid(sb_report.native_stability_event_uuid);
     if (!uuid.empty()) {
       starboard_report_ids.insert(uuid);
     }

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.cc
@@ -16,6 +16,7 @@
 
 #include <optional>
 #include <string>
+#include <string_view>
 #include <unordered_set>
 #include <utility>
 #include <vector>
@@ -49,11 +50,19 @@ constexpr char kAckedEventUuidsFileName[] = "acked_event_uuids.json";
 // when allocating the buffer.
 constexpr int kMaxNumReports = 128;
 
+// Safely extracts the UUID string from an SbNativeStabilityReport, clamping to
+// the canonical 36-character UUID length and guarding against missing null
+// terminators in the C character array.
+std::string SafelyGetReportUuid(const SbNativeStabilityReport& report) {
+  std::string_view sv(report.native_stability_event_uuid,
+                      sizeof(report.native_stability_event_uuid) - 1);
+  return std::string(sv.substr(0, sv.find('\0')));
+}
+
 mojom::BaseReportDataPtr CreateBaseReportData(
     const SbNativeStabilityReport& sb_report) {
   auto base_data = mojom::BaseReportData::New();
-  base_data->native_stability_event_uuid =
-      sb_report.native_stability_event_uuid;
+  base_data->native_stability_event_uuid = SafelyGetReportUuid(sb_report);
   base_data->event_time_sec = sb_report.event_time_s;
   return base_data;
 }
@@ -247,7 +256,7 @@ void NativeStabilityManager::GetPendingReportsOnTaskRunner(
   sb_reports.resize(count);
 
   for (const auto& sb_report : sb_reports) {
-    std::string uuid(sb_report.native_stability_event_uuid);
+    std::string uuid = SafelyGetReportUuid(sb_report);
     if (!uuid.empty() && acked_uuids.contains(uuid)) {
       VLOG(1) << "Skipping acknowledged native stability report UUID: " << uuid;
       continue;
@@ -376,7 +385,7 @@ void NativeStabilityManager::PruneStorageOnTaskRunner(
 
   std::unordered_set<std::string> starboard_report_ids;
   for (const auto& sb_report : sb_reports) {
-    std::string uuid(sb_report.native_stability_event_uuid);
+    std::string uuid = SafelyGetReportUuid(sb_report);
     if (!uuid.empty()) {
       starboard_report_ids.insert(uuid);
     }

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager.h
@@ -81,6 +81,19 @@ class NativeStabilityManager {
   void AcknowledgeReports(std::vector<std::string> native_stability_event_uuids,
                           base::OnceClosure callback);
 
+  // Asynchronously removes acknowledged report UUIDs from disk if their
+  // corresponding stability reports are no longer stored on disk.
+  //
+  // Note that stability report storage is managed by the platform's crash
+  // reporting system, which is expected to implement its own pruning strategy.
+  // We prune by reflecting that system's state.
+  //
+  // As with GetPendingReports(), disk I/O is offloaded to a background
+  // ThreadPool task runner and |callback| is posted back to the UI sequence.
+  // The |callback| parameter is optional to accommodate fire-and-forget callers
+  // that do not require completion notification.
+  void PruneStorage(base::OnceClosure callback = base::OnceClosure());
+
   using GetExtensionCallback =
       base::RepeatingCallback<const void*(const char*)>;
 
@@ -106,6 +119,10 @@ class NativeStabilityManager {
 
   void AcknowledgeReportsOnTaskRunner(
       std::vector<std::string> native_stability_event_uuids,
+      base::OnceClosure callback);
+
+  void PruneStorageOnTaskRunner(
+      const StarboardExtensionNativeStabilityApi* native_stability_extension,
       base::OnceClosure callback);
 
   base::FilePath GetAckedUuidsFilePath();

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
@@ -296,6 +296,32 @@ TEST_F(NativeStabilityManagerTest, GetPendingReportsIgnoresUnknownReportType) {
 }
 
 TEST_F(NativeStabilityManagerTest,
+       GetPendingReportsClampsUuidWithoutNullTerminator) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  SbNativeStabilityReport report = {};
+  report.report_type = kSbNativeStabilityReportCrash;
+  // Fill all 37 bytes so there is no null terminator in the char array.
+  std::memset(report.native_stability_event_uuid, 'a',
+              sizeof(report.native_stability_event_uuid));
+
+  SetupStubExtension(manager, {report});
+
+  base::RunLoop run_loop;
+  manager->GetPendingReports(base::BindOnce(
+      [](base::OnceClosure quit_closure,
+         std::vector<mojom::NativeStabilityReportPtr> reports) {
+        ASSERT_EQ(reports.size(), 1u);
+        // Canonical UUIDs are at most 36 characters (leaving 1 byte for '\0').
+        EXPECT_EQ(
+            reports[0]->get_crash_report()->base->native_stability_event_uuid,
+            std::string(sizeof(report.native_stability_event_uuid) - 1, 'a'));
+        std::move(quit_closure).Run();
+      },
+      run_loop.QuitClosure()));
+  run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest,
        AcknowledgedReportsFilteredByGetPendingReports) {
   auto* manager = NativeStabilityManager::GetInstance();
 
@@ -597,6 +623,43 @@ TEST_F(NativeStabilityManagerTest,
 
   // Verify file was not created on disk.
   EXPECT_FALSE(base::PathExists(file_path));
+}
+
+TEST_F(NativeStabilityManagerTest,
+       PruneStorageClampsUuidWithoutNullTerminator) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  SbNativeStabilityReport report = {};
+  report.report_type = kSbNativeStabilityReportCrash;
+  // Fill all 37 bytes so there is no null terminator in the char array.
+  std::memset(report.native_stability_event_uuid, 'a',
+              sizeof(report.native_stability_event_uuid));
+
+  SetupStubExtension(manager, {report});
+
+  std::string clamped_uuid(sizeof(report.native_stability_event_uuid) - 1, 'a');
+  base::FilePath file_path =
+      temp_dir_.GetPath().Append("acked_event_uuids.json");
+
+  {
+    base::RunLoop run_loop;
+    manager->AcknowledgeReports({clamped_uuid}, run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{clamped_uuid}));
+
+  {
+    base::RunLoop run_loop;
+    manager->PruneStorage(run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  // Verify acked_event_uuids.json still contains the 36-character UUID. This
+  // proves that PruneStorage() clamped the UUID it found in the starboard
+  // stability report persisted on disk.
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{clamped_uuid}));
 }
 
 }  // namespace h5vcc_native_stability

--- a/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
+++ b/cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc
@@ -21,6 +21,7 @@
 #include "base/files/file_util.h"
 #include "base/files/scoped_temp_dir.h"
 #include "base/functional/bind.h"
+#include "base/json/json_reader.h"
 #include "base/run_loop.h"
 #include "base/strings/stringprintf.h"
 #include "base/test/task_environment.h"
@@ -57,6 +58,26 @@ void SetupStubExtension(
         }
         return nullptr;
       }));
+}
+
+std::unordered_set<std::string> ReadAckedUuidsFromDiskForTesting(
+    const base::FilePath& file_path) {
+  std::unordered_set<std::string> acked_uuids;
+  std::string file_content;
+  if (!base::ReadFileToString(file_path, &file_content)) {
+    return acked_uuids;
+  }
+  std::optional<base::Value::List> parsed_list =
+      base::JSONReader::ReadList(file_content);
+  if (!parsed_list) {
+    return acked_uuids;
+  }
+  for (const auto& item : *parsed_list) {
+    if (item.is_string()) {
+      acked_uuids.insert(item.GetString());
+    }
+  }
+  return acked_uuids;
 }
 
 }  // namespace
@@ -401,6 +422,181 @@ TEST_F(NativeStabilityManagerTest,
       },
       run_loop.QuitClosure()));
   run_loop.Run();
+}
+
+TEST_F(NativeStabilityManagerTest, PruneStorageRemovesObsoleteAckedUuids) {
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  base::FilePath file_path =
+      temp_dir_.GetPath().Append("acked_event_uuids.json");
+
+  {
+    base::RunLoop run_loop;
+    manager->AcknowledgeReports({"uuid-1", "uuid-2", "uuid-3"},
+                                run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{"uuid-1", "uuid-2", "uuid-3"}));
+
+  // Configure extension to only return report1 (simulating reports for uuid-2
+  // and uuid-3 having been pruned from local crash storage).
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report1.native_stability_event_uuid, "uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+  SetupStubExtension(manager, {report1});
+
+  // Prune storage against the updated crash storage state.
+  {
+    base::RunLoop run_loop;
+    manager->PruneStorage(run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  // Verify directly on disk that obsolete UUIDs ("uuid-2", "uuid-3") were
+  // removed, leaving only "uuid-1".
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{"uuid-1"}));
+}
+
+TEST_F(NativeStabilityManagerTest,
+       PruneStorageDoesNothingWhenExtensionNotImplemented) {
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  base::FilePath file_path =
+      temp_dir_.GetPath().Append("acked_event_uuids.json");
+
+  {
+    base::RunLoop run_loop;
+    manager->AcknowledgeReports({"uuid-1"}, run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{"uuid-1"}));
+
+  // Disable extension.
+  manager->SetGetExtensionForTesting(base::BindRepeating(
+      [](const char* name) -> const void* { return nullptr; }));
+
+  {
+    base::RunLoop run_loop;
+    manager->PruneStorage(run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  // Verify acked_event_uuids.json still contains exactly uuid-1.
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{"uuid-1"}));
+}
+
+TEST_F(NativeStabilityManagerTest,
+       PruneStorageDoesNothingWhenAllAckedUuidsAreStillPersisted) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report1.native_stability_event_uuid, "uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+
+  SbNativeStabilityReport report2 = {};
+  report2.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report2.native_stability_event_uuid, "uuid-2",
+               sizeof(report2.native_stability_event_uuid) - 1);
+
+  // Simulate persistence of both reports.
+  SetupStubExtension(manager, {report1, report2});
+
+  base::FilePath file_path =
+      temp_dir_.GetPath().Append("acked_event_uuids.json");
+
+  {
+    base::RunLoop run_loop;
+    manager->AcknowledgeReports({"uuid-1"}, run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{"uuid-1"}));
+
+  {
+    base::RunLoop run_loop;
+    manager->PruneStorage(run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  // Verify acked_event_uuids.json still contains exactly uuid-1.
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{"uuid-1"}));
+}
+
+TEST_F(NativeStabilityManagerTest,
+       PruneStorageDoesNothingWhenExtensionReturnsError) {
+  auto* manager = NativeStabilityManager::GetInstance();
+
+  base::FilePath file_path =
+      temp_dir_.GetPath().Append("acked_event_uuids.json");
+
+  {
+    base::RunLoop run_loop;
+    manager->AcknowledgeReports({"uuid-1"}, run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{"uuid-1"}));
+
+  static StarboardExtensionNativeStabilityApi s_error_api = {
+      kStarboardExtensionNativeStabilityName,
+      1,
+      [](SbNativeStabilityReport* reports, int max_reports) -> int {
+        return -1;
+      },
+  };
+
+  manager->SetGetExtensionForTesting(
+      base::BindRepeating([](const char* name) -> const void* {
+        if (std::strcmp(name, kStarboardExtensionNativeStabilityName) == 0) {
+          return &s_error_api;
+        }
+        return nullptr;
+      }));
+
+  {
+    base::RunLoop run_loop;
+    manager->PruneStorage(run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  // Verify acked_event_uuids.json still contains exactly uuid-1.
+  EXPECT_EQ(ReadAckedUuidsFromDiskForTesting(file_path),
+            (std::unordered_set<std::string>{"uuid-1"}));
+}
+
+TEST_F(NativeStabilityManagerTest,
+       PruneStorageDoesNothingWhenAckedUuidsFileDoesNotExist) {
+  auto* manager = NativeStabilityManager::GetInstance();
+  SbNativeStabilityReport report1 = {};
+  report1.report_type = kSbNativeStabilityReportCrash;
+  std::strncpy(report1.native_stability_event_uuid, "uuid-1",
+               sizeof(report1.native_stability_event_uuid) - 1);
+
+  SetupStubExtension(manager, {report1});
+
+  base::FilePath file_path =
+      temp_dir_.GetPath().Append("acked_event_uuids.json");
+  ASSERT_FALSE(base::PathExists(file_path));
+
+  // Prune storage when acked_event_uuids.json does not exist.
+  {
+    base::RunLoop run_loop;
+    manager->PruneStorage(run_loop.QuitClosure());
+    run_loop.Run();
+  }
+
+  // Verify file was not created on disk.
+  EXPECT_FALSE(base::PathExists(file_path));
 }
 
 }  // namespace h5vcc_native_stability


### PR DESCRIPTION
Pruning is done at app startup to reflect the state the platform's crash reporting system's own storage. This behavior is described in the 3P MVP design doc.

Only acked_event_uuids.json is pruned for now since other JSON storage has not yet been implemented.

Issue: 528362453