### PR TITLE
chore(tvos): switch to file-specific genrule chaining for Kokoro

### DIFF
--- a/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
+++ b/cobalt/devinfra/kokoro/bin/presubmit_build_mac.sh
@@ -146,22 +146,6 @@ EOF
       "${GSUTIL}" cp "${archive_file}" "${gcs_archive_path}"
     fi
   done
-
-  # Handshake: Tell Kokoro (Child Job) where the binary is
-  # Create the folder directly under KOKORO_ARTIFACTS_DIR
-  local artifacts_dir="${KOKORO_ARTIFACTS_DIR:-.}"
-  mkdir -p "${artifacts_dir}/build_vars"
-
-  # Use the script's own 'build_id' variable for consistency
-  BIGSTORE_ROOT="/bigstore/${bucket}/kokoro/build/${TARGET_PLATFORM}_${CONFIG}/${build_id}"
-
-  # Pass the main artifact to the lab test
-  GCS_FILE_PATH="${BIGSTORE_ROOT}/cobalt_unittests.tar.gz"
-
-  # Write the file directly under artifacts_dir
-  echo "--define=tvos_gunit_test_package=${GCS_FILE_PATH}" > "${artifacts_dir}/build_vars/dynamic_flags.txt"
-  echo "Wrote dynamic flags to ${artifacts_dir}/build_vars/dynamic_flags.txt:"
-  cat "${artifacts_dir}/build_vars/dynamic_flags.txt"
 }
 
 

--- a/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
@@ -30,7 +30,7 @@ build = common.build {
     {
       define_artifacts = {
         regex = [
-          'build_vars/dynamic_flags.txt',
+          '**/*.tar.gz',
         ]
       }
     },


### PR DESCRIPTION
Switched to file-based Genrule handshake for tvOS downstream test integration.

Rationale: Reverts the custom flagfile injection logic (dynamic_flags.txt) which causes path resolution failures in hermetic BuildRabbit environments. Instead, establishing secure artifact exchange by natively capturing the built cobalt_unittests.tar.gz payload and letting standard Kokoro chaining move payloads safely to internal test harnesses.

Changes
- Removed custom handshake logic and flagfile generation from presubmit_build_mac.sh.
- Updated define_artifacts in common.gcl to natively capture all .tar.gz payloads.

Bug: 538697105