### PR TITLE
media: Track buffer pool on-demand allocation

### DIFF
--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -21,6 +21,7 @@
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
 #include "base/logging.h"
+#include "base/metrics/histogram_functions.h"
 #include "base/types/expected.h"
 #include "build/build_config.h"
 #include "media/base/media_switches.h"
@@ -81,6 +82,9 @@ DecoderBufferAllocator::DecoderBufferAllocator(
       allocation_unit_(allocation_unit) {
   DCHECK_GE(initial_capacity_, 0);
   DCHECK_GE(allocation_unit_, 0);
+
+  base::UmaHistogramBoolean("Cobalt.Media.IsBufferPoolAllocateOnDemand",
+                            is_memory_pool_allocated_on_demand_);
 
   if (is_memory_pool_allocated_on_demand_) {
     LOG(INFO) << "Allocated decoder buffer pool on demand.";

--- a/media/starboard/decoder_buffer_allocator_test.cc
+++ b/media/starboard/decoder_buffer_allocator_test.cc
@@ -27,6 +27,7 @@
 #include "base/logging.h"
 #include "base/strings/string_number_conversions.h"
 #include "base/strings/string_split.h"
+#include "base/test/metrics/histogram_tester.h"
 #include "base/time/time.h"
 #include "media/base/demuxer_stream.h"
 #include "media/base/test_data_util.h"
@@ -258,6 +259,25 @@ INSTANTIATE_TEST_SUITE_P(DecoderBufferAllocatorTests,
                            std::replace(name.begin(), name.end(), '/', '_');
                            return name;
                          });
+
+TEST(DecoderBufferAllocatorNonParameterizedTest,
+     IsBufferPoolAllocateOnDemandMetric) {
+  base::HistogramTester histogram_tester;
+
+  {
+    DecoderBufferAllocator allocator(
+        /*is_memory_pool_allocated_on_demand=*/true, 0, 0);
+    histogram_tester.ExpectBucketCount(
+        "Cobalt.Media.IsBufferPoolAllocateOnDemand", true, 1);
+  }
+
+  {
+    DecoderBufferAllocator allocator(
+        /*is_memory_pool_allocated_on_demand=*/false, 1024, 1024);
+    histogram_tester.ExpectBucketCount(
+        "Cobalt.Media.IsBufferPoolAllocateOnDemand", false, 1);
+  }
+}
 
 }  // namespace
 }  // namespace media

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -233,6 +233,17 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.Media.IsBufferPoolAllocateOnDemand" enum="Boolean"
+    expires_after="never">
+  <owner>sideboard@google.com</owner>
+  <owner>cobalt-media-team@google.com</owner>
+  <summary>
+    Records whether the Starboard media buffer pool is allocated on demand as
+    reported by SbMediaIsBufferPoolAllocateOnDemand(). Recorded during
+    DecoderBufferAllocator initialization.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.Network.CumulativePlatformErrorRaised" units="count"
     expires_after="never">
   <owner>charleykim@google.com</owner>


### PR DESCRIPTION
Add a boolean UMA histogram Cobalt.Media.IsBufferPoolAllocateOnDemand
to track the number of partner platforms that enable on-demand
allocation of the MediaSource buffer pool.

This metric is recorded during DecoderBufferAllocator initialization
and reflects the state reported by the Starboard function
SbMediaIsBufferPoolAllocateOnDemand().

Bug: 538230431
TAG=agy
CONV=3bc3dc39-bbcb-489f-b335-3b032071e01a