### PR TITLE
ci: Map GHA template variables to env vars and brace bash variables

### DIFF
--- a/.github/actions/api_leak_detector/action.yaml
+++ b/.github/actions/api_leak_detector/action.yaml
@@ -12,12 +12,11 @@ runs:
         CONFIG: ${{ matrix.config }}
       run: |
         set -x
-        if [ -z "${SB_API_VERSION}" ]; then
-          SB_API_VERSION_FLAG=""
-        else
-          SB_API_VERSION_FLAG="--sb_api_version=${SB_API_VERSION}"
+        FLAGS=()
+        if [ -n "${SB_API_VERSION}" ]; then
+          FLAGS+=("--sb_api_version=${SB_API_VERSION}")
         fi
-        python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check "${SB_API_VERSION_FLAG}"
+        python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check "${FLAGS[@]}"
         if [ "${CONFIG}" == "devel" ]; then
-          python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check "${SB_API_VERSION_FLAG}" -t nplb
+          python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check "${FLAGS[@]}" -t nplb
         fi

--- a/.github/actions/api_leak_detector/action.yaml
+++ b/.github/actions/api_leak_detector/action.yaml
@@ -12,11 +12,7 @@ runs:
         CONFIG: ${{ matrix.config }}
       run: |
         set -x
-        FLAGS=()
-        if [ -n "${SB_API_VERSION}" ]; then
-          FLAGS+=("--sb_api_version=${SB_API_VERSION}")
-        fi
-        python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check "${FLAGS[@]}"
+        python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check ${SB_API_VERSION:+--sb_api_version=${SB_API_VERSION}}
         if [ "${CONFIG}" == "devel" ]; then
-          python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check "${FLAGS[@]}" -t nplb
+          python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check ${SB_API_VERSION:+--sb_api_version=${SB_API_VERSION}} -t nplb
         fi

--- a/.github/actions/api_leak_detector/action.yaml
+++ b/.github/actions/api_leak_detector/action.yaml
@@ -6,14 +6,18 @@ runs:
   steps:
     - name: Run Detector
       shell: bash
+      env:
+        SB_API_VERSION: ${{ matrix.sb_api_version }}
+        PLATFORM: ${{ matrix.platform }}
+        CONFIG: ${{ matrix.config }}
       run: |
         set -x
-        if [ -z "${{matrix.sb_api_version}}"]; then
+        if [ -z "${SB_API_VERSION}" ]; then
           SB_API_VERSION_FLAG=""
         else
-          SB_API_VERSION_FLAG="--sb_api_version=${{matrix.sb_api_version}}"
+          SB_API_VERSION_FLAG="--sb_api_version=${SB_API_VERSION}"
         fi
-        python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p ${{ matrix.platform }} -c ${{matrix.config}} --submit-check ${SB_API_VERSION_FLAG}
-        if [ "${{matrix.config}}" == "devel" ]; then
-          python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p ${{ matrix.platform }} -c ${{matrix.config}} --submit-check ${SB_API_VERSION_FLAG} -t nplb
+        python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check "${SB_API_VERSION_FLAG}"
+        if [ "${CONFIG}" == "devel" ]; then
+          python3 cobalt/src/starboard/tools/api_leak_detector/api_leak_detector.py -p "${PLATFORM}" -c "${CONFIG}" --submit-check "${SB_API_VERSION_FLAG}" -t nplb
         fi

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -137,7 +137,7 @@ runs:
           CONFIG: ${{ matrix.config }}
         run: |
           set -ex
-          readarray -t test_targets < <(echo "${TEST_TARGETS_JSON}" | jq -r '.[]')
+          readarray -t test_targets < <(echo "${TEST_TARGETS_JSON:-[]}" | jq -r '.[]')
           time autoninja -C out/"${PLATFORM}_${CONFIG}" "${test_targets[@]}"
         shell: bash
       - name: Ninja build
@@ -149,7 +149,7 @@ runs:
           CONFIG: ${{ matrix.config }}
         run: |
           set -ex
-          readarray -t targets < <(echo "${TARGETS_JSON}" | jq -r '.[]')
+          readarray -t targets < <(echo "${TARGETS_JSON:-[]}" | jq -r '.[]')
           time autoninja -C out/"${PLATFORM}_${CONFIG}" "${targets[@]}"
           if [[ "${USE_SCCACHE}" == "true" ]]; then
             sccache --show-stats

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -97,7 +97,7 @@ runs:
           # TODO: b/382508397 - Currently, override with static test targets
           cp -av "${STATIC_TEST_TARGETS_JSON_FILE}" "${TEST_TARGETS_JSON_FILE}"
 
-          # gn desc out/${{ matrix.platform }}_${{ matrix.config }}/ "*" --format=json > gn_desc.json
+          # gn desc out/${PLATFORM}_${CONFIG}/ "*" --format=json > gn_desc.json
           # # Trim any warning gn printed before the json (all lines above the first curly brace).
           # sed -n '/^{/,$p' -i gn_desc.json
 

--- a/.github/actions/build/action.yaml
+++ b/.github/actions/build/action.yaml
@@ -30,26 +30,31 @@ runs:
       - name: GN gen
         env:
           ENABLE_SCCACHE: ${{ inputs.enable_sccache }}
+          PLATFORM: ${{ matrix.platform }}
+          CONFIG: ${{ matrix.config }}
+        working-directory: cobalt/src
         run: |
-          cd cobalt/src
           gn_flags=()
-          if [[ "${{ matrix.platform }}" == *"tvos"* ]]; then
+          if [[ "${PLATFORM}" == *"tvos"* ]]; then
             # TvOS does not use RBE unless it's sccache
             gn_flags+=(--no-rbe)
           fi
-          if [[ $ENABLE_SCCACHE == "true" ]]; then
+          if [[ "${ENABLE_SCCACHE}" == "true" ]]; then
             gn_flags+=(--use-sccache)
           fi
-          cobalt/build/gn.py -p ${{ matrix.platform }} -C ${{ matrix.config }} "${gn_flags[@]}"
+          cobalt/build/gn.py -p "${PLATFORM}" -C "${CONFIG}" "${gn_flags[@]}"
         shell: bash
       - name: Configure Siso Credential Helper
         shell: bash
         run: |
-          echo "SISO_CREDENTIAL_HELPER=gcloud" >> $GITHUB_ENV
+          echo "SISO_CREDENTIAL_HELPER=gcloud" >> "${GITHUB_ENV}"
       - name: List GN args
+        env:
+          PLATFORM: ${{ matrix.platform }}
+          CONFIG: ${{ matrix.config }}
+        working-directory: cobalt/src
         run: |
-          cd cobalt/src
-          gn args --list --short --overrides-only out/${{ matrix.platform }}_${{ matrix.config }}
+          gn args --list --short --overrides-only out/"${PLATFORM}_${CONFIG}"
         shell: bash
       - name: Get list of changed files
         if: github.event_name == 'pull_request'
@@ -78,18 +83,19 @@ runs:
           STATIC_TEST_TARGETS_JSON_FILE: cobalt/build/testing/targets/${{ matrix.platform }}/test_targets.json
           # TODO(b/382508397): Replace hardcoded list with dynamically generated one.
           DYN_TEST_TARGETS_JSON_FILE: out/${{ matrix.platform }}_${{ matrix.config }}/dyn_targets.json
+          TEST_TARGETS_JSON_FILE: ${{ inputs.test_targets_json_file }}
+        working-directory: cobalt/src
         run: |
           set -x
-          cd cobalt/src
 
           if [[ ! -f "${STATIC_TEST_TARGETS_JSON_FILE}" ]]; then
             echo "Static test targets file not found at ${STATIC_TEST_TARGETS_JSON_FILE}. Skipping step."
-            echo "test_targets_count=0" >> $GITHUB_OUTPUT
+            echo "test_targets_count=0" >> "${GITHUB_OUTPUT}"
             exit 0
           fi
 
           # TODO: b/382508397 - Currently, override with static test targets
-          cp -av "${STATIC_TEST_TARGETS_JSON_FILE}" "${{ inputs.test_targets_json_file }}"
+          cp -av "${STATIC_TEST_TARGETS_JSON_FILE}" "${TEST_TARGETS_JSON_FILE}"
 
           # gn desc out/${{ matrix.platform }}_${{ matrix.config }}/ "*" --format=json > gn_desc.json
           # # Trim any warning gn printed before the json (all lines above the first curly brace).
@@ -110,11 +116,11 @@ runs:
           #     --json-output > "${DYN_TEST_TARGETS_JSON_FILE}"
 
 
-          test_targets_json=$(jq -cr '[.[] | select(.target != null) | .target]' ${{ inputs.test_targets_json_file }})
-          echo "test_targets_json=${test_targets_json}" >> $GITHUB_OUTPUT
+          test_targets_json=$(jq -cr '[.[] | select(.target != null) | .target]' "${TEST_TARGETS_JSON_FILE}")
+          echo "test_targets_json=${test_targets_json}" >> "${GITHUB_OUTPUT}"
 
-          test_targets_count=$(echo ${test_targets_json} | jq -cr 'length')
-          echo "test_targets_count=${test_targets_count}" >> $GITHUB_OUTPUT
+          test_targets_count=$(echo "${test_targets_json}" | jq -cr 'length')
+          echo "test_targets_count=${test_targets_count}" >> "${GITHUB_OUTPUT}"
         shell: bash
       - name: Archive test target JSON
         uses: actions/upload-artifact@v4
@@ -124,22 +130,28 @@ runs:
       - name: Ninja build test targets
         if: ${{ matrix.config == 'devel' && fromJSON(steps.calculate-test-targets.outputs.test_targets_count || 0) > 0 }}
         id: build-test-targets
+        working-directory: cobalt/src
+        env:
+          TEST_TARGETS_JSON: ${{ steps.calculate-test-targets.outputs.test_targets_json }}
+          PLATFORM: ${{ matrix.platform }}
+          CONFIG: ${{ matrix.config }}
         run: |
           set -ex
-          cd cobalt/src
-          test_targets=$(echo '${{ steps.calculate-test-targets.outputs.test_targets_json }}' | jq -cr 'join(" ")')
-          time autoninja -C out/${{ matrix.platform }}_${{ matrix.config }} ${test_targets}
+          readarray -t test_targets < <(echo "${TEST_TARGETS_JSON}" | jq -r '.[]')
+          time autoninja -C out/"${PLATFORM}_${CONFIG}" "${test_targets[@]}"
         shell: bash
       - name: Ninja build
+        working-directory: cobalt/src
         env:
           TARGETS_JSON: ${{ inputs.targets }}
           USE_SCCACHE: ${{ inputs.enable_sccache }}
+          PLATFORM: ${{ matrix.platform }}
+          CONFIG: ${{ matrix.config }}
         run: |
           set -ex
-          cd cobalt/src
-          TARGETS=$(echo "${TARGETS_JSON}" | jq -cr '. | join(" ")')
-          time autoninja -C out/${{ matrix.platform }}_${{ matrix.config }} ${TARGETS}
-          if [[ $USE_SCCACHE == "true" ]]; then
+          readarray -t targets < <(echo "${TARGETS_JSON}" | jq -r '.[]')
+          time autoninja -C out/"${PLATFORM}_${CONFIG}" "${targets[@]}"
+          if [[ "${USE_SCCACHE}" == "true" ]]; then
             sccache --show-stats
           fi
         shell: bash

--- a/.github/actions/depot_tools/action.yaml
+++ b/.github/actions/depot_tools/action.yaml
@@ -45,13 +45,15 @@ runs:
 
     - name: Set CIPD Cache Directory
       if: steps.cache-path.outputs.path != ''
-      run: echo "CIPD_CACHE_DIR=${{ steps.cache-path.outputs.path }}/cipd-cache" >> ${GITHUB_ENV}
+      env:
+        CACHE_PATH: ${{ steps.cache-path.outputs.path }}
+      run: echo "CIPD_CACHE_DIR=${CACHE_PATH}/cipd-cache" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: Bootstrap Bundled python3
       run: |
-        # Must be run manually as $DEPOT_TOOLS_UPDATE is 0 in CI, skipping the bootstrap.
-        source ${GITHUB_WORKSPACE}/cobalt/depot_tools/bootstrap_python3 && bootstrap_python3
+        # Must be run manually as ${DEPOT_TOOLS_UPDATE} is 0 in CI, skipping the bootstrap.
+        source "${GITHUB_WORKSPACE}/cobalt/depot_tools/bootstrap_python3" && bootstrap_python3
       shell: bash
 
     - name: Disable Chromium client side build telemetry
@@ -79,12 +81,14 @@ runs:
 
     - name: Set target OS
       shell: bash
+      working-directory: cobalt
+      env:
+        PLATFORM: ${{ matrix.platform }}
       run: |
-        cd cobalt
         if ! grep -q "target_os" .gclient; then
-          if [[ "${{ matrix.platform }}" == *"android"* ]]; then
+          if [[ "${PLATFORM}" == *"android"* ]]; then
             echo "target_os=['android']" >> .gclient
-          elif [[ "${{ matrix.platform }}" == *"tvos"* ]]; then
+          elif [[ "${PLATFORM}" == *"tvos"* ]]; then
             echo "target_os=['ios']" >> .gclient
           fi
         fi
@@ -92,12 +96,14 @@ runs:
 
     - name: Set target CPU
       shell: bash
+      working-directory: cobalt
+      env:
+        PLATFORM: ${{ matrix.platform }}
       run: |
-        cd cobalt
         if ! grep -q "target_cpu" .gclient; then
-          if [[ "${{ matrix.platform }}" == *"evergreen-arm64"* ]]; then
+          if [[ "${PLATFORM}" == *"evergreen-arm64"* ]]; then
             echo "target_cpu=['x64', 'arm64']" >> .gclient
-          elif [[ "${{ matrix.platform }}" == *"evergreen-arm"* ]]; then
+          elif [[ "${PLATFORM}" == *"evergreen-arm"* ]]; then
             echo "target_cpu=['x64', 'arm']" >> .gclient
           fi
         fi
@@ -108,14 +114,11 @@ runs:
       with:
         use_gcloud: ${{ inputs.use_gcloud }}
 
-    - name: Run gclient sync
+    - name: Clean dirty sub-repositories
       shell: bash
       if: inputs.run_sync == 'true'
-      env:
-        REF: ${{ github.sha }}
+      working-directory: cobalt/src
       run: |
-        cd cobalt/src
-
         # Remove after all workers have migrated to new siso directory
         if [ -d "../.cipd" ]; then
           if grep -r "infra/build/siso" "../.cipd" > /dev/null 2>&1; then
@@ -129,13 +132,19 @@ runs:
         git -c core.quotepath=false status --porcelain -unormal | while IFS= read -r line; do
           path="${line:3}"
           clean_path="${path%/}"
-          if [[ -d "$clean_path" && -d "$clean_path/.git" ]]; then
-            echo "Deleting conflicting sub-repo: $clean_path"
-            rm -rf "$clean_path"
+          if [[ -d "${clean_path}" && -d "${clean_path}/.git" ]]; then
+            echo "Deleting conflicting sub-repo: ${clean_path}"
+            rm -rf "${clean_path}"
           fi
         done
 
-        cd ..
+    - name: Run gclient sync
+      shell: bash
+      if: inputs.run_sync == 'true'
+      working-directory: cobalt
+      env:
+        REF: ${{ github.sha }}
+      run: |
         gclient sync \
           --verbose \
           --shallow \
@@ -147,7 +156,7 @@ runs:
 
     - name: Run gclient runhooks
       if: inputs.run_sync == 'true'
+      working-directory: cobalt
       run: |
-        cd cobalt
         gclient runhooks --verbose
       shell: bash

--- a/.github/actions/docker/action.yaml
+++ b/.github/actions/docker/action.yaml
@@ -27,33 +27,41 @@ runs:
     - name: Set Docker Build Vars
       env:
         DOCKER_SERVICE: ${{ inputs.docker_service }}
+        IS_PR: ${{ inputs.is_pr }}
+        PR_NUMBER: ${{ github.event.pull_request.number }}
       run: |
         # Set Docker Build Vars
         set -x
 
         # Set floating to either the PR number (for PRs) or the branch name (for post-submit).
-        FLOATING_TAG="${{ inputs.is_pr == 'true' && github.event.pull_request.number || github.ref_name }}"
+        if [[ "${IS_PR}" == "true" ]]; then
+          FLOATING_TAG="${PR_NUMBER}"
+        else
+          FLOATING_TAG="${GITHUB_REF_NAME}"
+        fi
         # Replace slashes with double underscore.
         FLOATING_TAG="${FLOATING_TAG//\//__}"
         # Remove url unsafe suffix from LTS branches.
         FLOATING_TAG="${FLOATING_TAG%.1[+,-]}"
 
-        echo "DOCKER_FLOATING_TAG=${FLOATING_TAG}" >> $GITHUB_ENV
+        echo "DOCKER_FLOATING_TAG=${FLOATING_TAG}" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: Login to GAR
+      env:
+        IS_PR: ${{ inputs.is_pr }}
       run: |
         # Login to GAR
         TOKEN_ENDPOINT="http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token"
-        ACCESS_TOKEN=$(curl -H 'Metadata-Flavor: Google' ${TOKEN_ENDPOINT} | jq -r .access_token)
+        ACCESS_TOKEN=$(curl -H 'Metadata-Flavor: Google' "${TOKEN_ENDPOINT}" | jq -r .access_token)
 
         # Login to GAR to be able to push images created by fork based PR workflows.
-        if [[ "${{ inputs.is_pr }}" == "true" ]]; then
-          printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
+        if [[ "${IS_PR}" == "true" ]]; then
+          printf "%s" "${ACCESS_TOKEN}" | docker login -u oauth2accesstoken --password-stdin https://us-central1-docker.pkg.dev
         fi
 
         # Login to Marketplace GAR to be able to pull base images.
-        printf ${ACCESS_TOKEN} | docker login -u oauth2accesstoken --password-stdin https://marketplace.gcr.io
+        printf "%s" "${ACCESS_TOKEN}" | docker login -u oauth2accesstoken --password-stdin https://marketplace.gcr.io
       shell: bash
 
     - name: Login to GitHub Docker Registry
@@ -74,9 +82,9 @@ runs:
       run: |
         # Pull Existing Docker Image
         set -x
-        DOCKER_COMPOSE_IMAGE="${GITHUB_DOCKER_REGISTRY_URL}/${{ github.repository }}/${DOCKER_SERVICE}"
+        DOCKER_COMPOSE_IMAGE="${GITHUB_DOCKER_REGISTRY_URL}/${GITHUB_REPOSITORY}/${DOCKER_SERVICE}"
 
-        if [[ "$IS_PR" == "true" ]]; then
+        if [[ "${IS_PR}" == "true" ]]; then
           if docker manifest inspect "${DOCKER_COMPOSE_IMAGE}:${DOCKER_CONTENT_SHA}"; then
             # A postsubmit image exists, use it.
             echo "Using existing ${DOCKER_COMPOSE_IMAGE}"
@@ -88,16 +96,16 @@ runs:
 
             if ! docker manifest inspect "${DOCKER_COMPOSE_IMAGE}:${DOCKER_CONTENT_SHA}"; then
               echo "::warning::No pre-built docker image found for tag ${DOCKER_CONTENT_SHA}."
-              echo "build_image=true" >> $GITHUB_OUTPUT
+              echo "build_image=true" >> "${GITHUB_OUTPUT}"
             fi
           fi
         fi
 
         # Tell builders which image tag to use.
-        echo "docker_tag=${DOCKER_COMPOSE_IMAGE}:${DOCKER_CONTENT_SHA}" >> $GITHUB_OUTPUT
+        echo "docker_tag=${DOCKER_COMPOSE_IMAGE}:${DOCKER_CONTENT_SHA}" >> "${GITHUB_OUTPUT}"
 
         # Make the compose image tag available to the build step below.
-        echo "DOCKER_COMPOSE_IMAGE=${DOCKER_COMPOSE_IMAGE}" >> $GITHUB_ENV
+        echo "DOCKER_COMPOSE_IMAGE=${DOCKER_COMPOSE_IMAGE}" >> "${GITHUB_ENV}"
       shell: bash
 
     - name: Build and Push Docker Image
@@ -110,7 +118,7 @@ runs:
         set -x
         docker compose build ${DOCKER_SERVICE}
 
-        # The compose build tags the built image with $DOCKER_COMPOSE_IMAGE. Add the Docker content sha and floating tag and push.
+        # The compose build tags the built image with ${DOCKER_COMPOSE_IMAGE}. Add the Docker content sha and floating tag and push.
         docker tag "${DOCKER_COMPOSE_IMAGE}" "${DOCKER_COMPOSE_IMAGE}:${DOCKER_CONTENT_SHA}"
         docker tag "${DOCKER_COMPOSE_IMAGE}" "${DOCKER_COMPOSE_IMAGE}:${DOCKER_FLOATING_TAG}"
         docker push --all-tags "${DOCKER_COMPOSE_IMAGE}"

--- a/.github/actions/gob_auth/action.yaml
+++ b/.github/actions/gob_auth/action.yaml
@@ -14,6 +14,7 @@ runs:
       env:
         METADATA_BASE_URL: 'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default'
         METADATA_HEADER: 'Metadata-Flavor: Google'
+        USE_GCLOUD: ${{ inputs.use_gcloud }}
       run: |
         if ! curl -s -m 2 -H "${METADATA_HEADER}" "${METADATA_BASE_URL}/email" > /dev/null; then
           echo "Metadata server not reachable. Skipping GoB authentication setup."
@@ -23,7 +24,7 @@ runs:
         SERVICE_ACCOUNT=$(curl -s -f -H "${METADATA_HEADER}" "${METADATA_BASE_URL}/email")
         ACCESS_TOKEN=$(curl -s -f -H "${METADATA_HEADER}" "${METADATA_BASE_URL}/token" | jq -r .access_token)
 
-        if [[ "${{ inputs.use_gcloud }}" == "true" ]]; then
+        if [[ "${USE_GCLOUD}" == "true" ]]; then
           gcloud config set account "${SERVICE_ACCOUNT}"
         fi
 
@@ -35,7 +36,7 @@ runs:
         echo "::add-mask::${ACCESS_TOKEN}"
         echo "Authenticating with ${SERVICE_ACCOUNT}"
 
-        GITCOOKIES_PATH="${{ runner.temp }}/gitcookies"
+        GITCOOKIES_PATH="${RUNNER_TEMP}/gitcookies"
         mkdir -p "$(dirname "${GITCOOKIES_PATH}")"
         (umask 077 && printf ".googlesource.com\tTRUE\t/\tTRUE\t2147483647\to\tgit-%s=%s\ngooglesource.com\tTRUE\t/\tTRUE\t2147483647\to\tgit-%s=%s\n" \
           "${SERVICE_ACCOUNT}" "${ACCESS_TOKEN}" "${SERVICE_ACCOUNT}" "${ACCESS_TOKEN}" > "${GITCOOKIES_PATH}")

--- a/.github/actions/internal_tests/action.yaml
+++ b/.github/actions/internal_tests/action.yaml
@@ -35,7 +35,7 @@ runs:
       uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set GCS Project Name
       run: |
-        echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
+        echo "PROJECT_NAME=$(gcloud config get-value project)" >> "${GITHUB_ENV}"
       shell: bash
     - name: Run Tests on ${{ matrix.platform }} Platform
       env:
@@ -58,6 +58,11 @@ runs:
         GITHUB_WORKFLOW: ${{ github.workflow }}
         TEST_TYPE: ${{ inputs.test_type }}
         TEST_RETRY_LEVEL: FAIL
+        TEST_TARGETS: ${{ inputs.test_targets }}
+        PLATFORM: ${{ matrix.platform }}
+        TEST_DIMENSIONS: ${{ inputs.test_dimensions }}
+        ARTIFACT_NAME: ${{ inputs.artifact_name }}
+        TEST_DEVICE_FAMILY: ${{ inputs.test_device_family }}
       run: |
         set -x
 
@@ -65,11 +70,11 @@ runs:
           --token ${GITHUB_TOKEN} \
           trigger \
           --test_type ${TEST_TYPE} \
-          --targets '${{ inputs.test_targets }}' \
+          --targets "${TEST_TARGETS}" \
           --retry_level ${TEST_RETRY_LEVEL} \
           --label ${TEST_TYPE} \
           --label github_${GITHUB_PR_NUMBER:-postsubmit} \
-          --label builder-${{ matrix.platform }} \
+          --label builder-${PLATFORM} \
           --label builder_url-${GITHUB_RUN_URL} \
           --label github \
           --label ${GITHUB_EVENT_NAME} \
@@ -79,13 +84,13 @@ runs:
           --label triggering_actor-${GITHUB_TRIGGERING_ACTOR} \
           --label sha-${GITHUB_SHA} \
           --label repository-${GITHUB_REPO} \
-          --label author-${GITHUB_PR_HEAD_USER_LOGIN:-$GITHUB_COMMIT_AUTHOR_USERNAME} \
-          --label author_id-${GITHUB_PR_HEAD_USER_ID:-$GITHUB_COMMIT_AUTHOR_EMAIL} \
+          --label author-${GITHUB_PR_HEAD_USER_LOGIN:-${GITHUB_COMMIT_AUTHOR_USERNAME}} \
+          --label author_id-${GITHUB_PR_HEAD_USER_ID:-${GITHUB_COMMIT_AUTHOR_EMAIL}} \
           --label branch:${GITHUB_REF_NAME} \
           --label target_branch:${GITHUB_BASE_REF} \
-          --dimensions '${{ inputs.test_dimensions }}' \
-          --artifact_name '${{ inputs.artifact_name }}' \
-          --device_family '${{ inputs.test_device_family }}' \
+          --dimensions "${TEST_DIMENSIONS}" \
+          --artifact_name "${ARTIFACT_NAME}" \
+          --device_family "${TEST_DEVICE_FAMILY}" \
           --cobalt_path "${GCS_ARTIFACTS_PATH}" || {
             echo "Finished running tests..."
             echo "The test session failed. See logs for details."

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -41,7 +41,7 @@ runs:
       uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Set GCS Project Name
       run: |
-        echo "PROJECT_NAME=$(gcloud config get-value project)" >> $GITHUB_ENV
+        echo "PROJECT_NAME=$(gcloud config get-value project)" >> "${GITHUB_ENV}"
       shell: bash
     - name: Run Tests on ${{ matrix.platform }} Platform
       env:
@@ -65,6 +65,10 @@ runs:
         GITHUB_WORKFLOW: ${{ github.workflow }}
         TEST_ATTEMPTS: ${{ inputs.test_attempts }}
         TEST_TYPE: unit_test
+        PLATFORM: ${{ matrix.platform }}
+        TEST_DEVICE_FAMILY: ${{ inputs.test_device_family }}
+        TEST_DIMENSIONS: ${{ inputs.test_dimensions }}
+        GCS_RESULTS_PATH: ${{ inputs.gcs_results_path }}
       run: |
         set -x
 
@@ -73,12 +77,12 @@ runs:
           --token ${GITHUB_TOKEN} \
           trigger \
           --test_type ${TEST_TYPE} \
-          --device_family '${{ inputs.test_device_family }}' \
+          --device_family "${TEST_DEVICE_FAMILY}" \
           --targets "${TEST_TARGETS_JSON}" \
-          --filter_json_dir "${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}" \
+          --filter_json_dir "${GITHUB_WORKSPACE}/cobalt/testing/filters/${PLATFORM}" \
           --label chrobalt_on_device_test \
           --label github_${GITHUB_PR_NUMBER:-postsubmit} \
-          --label builder-${{ matrix.platform }} \
+          --label builder-${PLATFORM} \
           --label builder_url-${GITHUB_RUN_URL} \
           --label ${TEST_TYPE} \
           --label github \
@@ -89,14 +93,14 @@ runs:
           --label triggering_actor-${GITHUB_TRIGGERING_ACTOR} \
           --label sha-${GITHUB_SHA} \
           --label repository-${GITHUB_REPO} \
-          --label author-${GITHUB_PR_HEAD_USER_LOGIN:-$GITHUB_COMMIT_AUTHOR_USERNAME} \
-          --label author_id-${GITHUB_PR_HEAD_USER_ID:-$GITHUB_COMMIT_AUTHOR_EMAIL} \
+          --label author-${GITHUB_PR_HEAD_USER_LOGIN:-${GITHUB_COMMIT_AUTHOR_USERNAME}} \
+          --label author_id-${GITHUB_PR_HEAD_USER_ID:-${GITHUB_COMMIT_AUTHOR_EMAIL}} \
           --label branch:${GITHUB_REF_NAME} \
           --label target_branch:${GITHUB_BASE_REF} \
-          --dimensions '${{ inputs.test_dimensions }}' \
-          ${TEST_ATTEMPTS:+"--test_attempts" "$TEST_ATTEMPTS"} \
+          --dimensions "${TEST_DIMENSIONS}" \
+          ${TEST_ATTEMPTS:+"--test_attempts" "${TEST_ATTEMPTS}"} \
           --gcs_archive_path "${GCS_ARTIFACTS_PATH}" \
-          --gcs_result_path "${{ inputs.gcs_results_path }}" || {
+          --gcs_result_path "${GCS_RESULTS_PATH}" || {
             echo "Finished running tests..."
             echo "The test session failed. See logs for details."
             # Fail the job so it's easy to retrigger.
@@ -108,35 +112,37 @@ runs:
       if: always()
       env:
         TEST_TARGETS_JSON: ${{ inputs.test_targets_json }}
+        PLATFORM: ${{ matrix.platform }}
+        GCS_RESULTS_PATH: ${{ inputs.gcs_results_path }}
       run: |
         set -uxe
         shopt -s globstar nullglob
 
         test_output="${GITHUB_WORKSPACE}/results"
-        echo "test_output=${test_output}" >> $GITHUB_ENV
+        echo "test_output=${test_output}" >> "${GITHUB_ENV}"
 
         # Test results (xml and logs) must be in a subfolder in results_dir.
         # to be picked up by the test result processor.
-        mkdir -p "${test_output}/${{ matrix.platform }}"
-        gsutil -q cp -r "${{ inputs.gcs_results_path }}/" "${test_output}/${{ matrix.platform }}"
+        mkdir -p "${test_output}/${PLATFORM}"
+        gsutil -q cp -r "${GCS_RESULTS_PATH}/" "${test_output}/${PLATFORM}"
 
         # Check for missing result xml files.
         exit_code=0
-        readarray -t test_targets < <(echo "$TEST_TARGETS_JSON" | jq -r '.[]')
+        readarray -t test_targets < <(echo "${TEST_TARGETS_JSON}" | jq -r '.[]')
         for test_target_with_path in "${test_targets[@]}"; do
           # Trim path prefix (before :).
           test_target=${test_target_with_path#*:}
-          xml_files=("${test_output}"/${{ matrix.platform }}/**/"${test_target}"*.xml)
+          xml_files=("${test_output}/${PLATFORM}"/**/"${test_target}"*.xml)
           if [[ "${#xml_files[@]}" -eq 0 ]]; then
             # No matching XML results found. Check if the test target is filtered.
-            test_filter_file="${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}/${test_target}_filter.json"
+            test_filter_file="${GITHUB_WORKSPACE}/cobalt/testing/filters/${PLATFORM}/${test_target}_filter.json"
             if [ ! -f "${test_filter_file}" ] || [ "$(jq -cr '.failing_tests[0]' "${test_filter_file}")" != '*' ]; then
               echo "Test result xml is missing for ${test_target}."
 
               # Try to find the crashed test in the log and create a fake junit xml for it.
-              log_path=("${test_output}"/${{ matrix.platform }}/**/"${test_target}"_log.txt)
-              xml_path=("${test_output}"/${{ matrix.platform }}/1/"${test_target}"_testoutput.xml)
-              python3 ${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py "${log_path}" "${xml_path}"
+              log_path=("${test_output}/${PLATFORM}"/**/"${test_target}_log.txt")
+              xml_path=("${test_output}/${PLATFORM}/1/${test_target}_testoutput.xml")
+              python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py" "${log_path}" "${xml_path}"
               exit_code=1
             fi
           elif grep -e '<failure' -e '<error' ${xml_files}; then

--- a/.github/actions/on_device_tests/action.yaml
+++ b/.github/actions/on_device_tests/action.yaml
@@ -128,7 +128,7 @@ runs:
 
         # Check for missing result xml files.
         exit_code=0
-        readarray -t test_targets < <(echo "${TEST_TARGETS_JSON}" | jq -r '.[]')
+        readarray -t test_targets < <(echo "${TEST_TARGETS_JSON:-[]}" | jq -r '.[]')
         for test_target_with_path in "${test_targets[@]}"; do
           # Trim path prefix (before :).
           test_target=${test_target_with_path#*:}

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -46,29 +46,33 @@ runs:
     - name: Prepare Test Execution
       id: prepare-test-execution
       shell: bash
+      env:
+        PLATFORM: ${{ matrix.platform }}
+        CONFIG: ${{ matrix.config }}
+        SHARD: ${{ matrix.shard }}
       run: |
         set -x
         env
 
-        out_dir="${GITHUB_WORKSPACE}/out/${{ matrix.platform }}_${{ matrix.config }}"
+        out_dir="${GITHUB_WORKSPACE}/out/${PLATFORM}_${CONFIG}"
         # TODO: LD_LIBRARY_PATH should not include the starboard subdirectory.
         LD_LIBRARY_PATH="${out_dir}/starboard:${out_dir}"
-        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> $GITHUB_ENV
+        echo "LD_LIBRARY_PATH=${LD_LIBRARY_PATH}" >> "${GITHUB_ENV}"
 
         # TODO: b/467135717 - Remove this once tests don't have asan leaks.
         # Don't fail if only asan fails.
-        echo "ASAN_OPTIONS=exitcode=0" >> $GITHUB_ENV
+        echo "ASAN_OPTIONS=exitcode=0" >> "${GITHUB_ENV}"
 
         # Make results dir available to the archiving step below.
         results_dir="${GITHUB_WORKSPACE}/results"
-        echo "results_dir=${results_dir}" >> $GITHUB_ENV
+        echo "results_dir=${results_dir}" >> "${GITHUB_ENV}"
 
         # Test results (xml and logs) must be in a subfolder in results_dir
         # to be picked up by the test result processor.
         # This also prevents accidental overwriting when collecting results.
-        test_output="${results_dir}/shard_${{ matrix.shard }}"
-        mkdir -p ${test_output}
-        echo "test_output=${test_output}" >> $GITHUB_ENV
+        test_output="${results_dir}/shard_${SHARD}"
+        mkdir -p "${test_output}"
+        echo "test_output=${test_output}" >> "${GITHUB_ENV}"
 
     - name: Run GTest Suites
       if: ${{ inputs.test_type == 'gtest' }}
@@ -79,24 +83,25 @@ runs:
         GTEST_SHARD_INDEX: ${{ matrix.shard }}
         GTEST_TOTAL_SHARDS: ${{ inputs.num_gtest_shards }}
         TEST_EXECUTABLES_JSON: ${{ inputs.test_executables_json }}
+        PLATFORM: ${{ matrix.platform }}
       run: |
         set -x
 
         failed_suites=""
 
-        # Parse the JSON array into a space-separated string using jq.
-        test_executables=$(jq -nr --arg json "${TEST_EXECUTABLES_JSON:-[]}" '$json | fromjson | join(" ")')
+        # Parse the JSON array into a bash array using jq.
+        readarray -t test_executables < <(echo "${TEST_EXECUTABLES_JSON}" | jq -r '.[]')
 
-        for test_executable_path in ${test_executables}; do
+        for test_executable_path in "${test_executables[@]}"; do
           filename=$(basename "${test_executable_path}")
           test_executable="${filename%%.*}"
 
           echo "Running tests for suite: ${test_executable}"
 
           test_filter="*"
-          test_filter_json_dir="${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}/${test_executable}_filter.json"
-          if [ -f ${test_filter_json_dir} ]; then
-            test_filter=`jq -r '"-" + (.failing_tests | join(":"))' ${test_filter_json_dir}`
+          test_filter_json_dir="${GITHUB_WORKSPACE}/cobalt/testing/filters/${PLATFORM}/${test_executable}_filter.json"
+          if [ -f "${test_filter_json_dir}" ]; then
+            test_filter=$(jq -r '"-" + (.failing_tests | join(":"))' "${test_filter_json_dir}")
           fi
 
           echo "Test filter evaluated to: ${test_filter}"
@@ -115,21 +120,21 @@ runs:
           fi
 
           if [ "${test_filter}" == "-*" ]; then
-            echo "Skipped due to test filter." > ${log_path}
+            echo "Skipped due to test filter." > "${log_path}"
           else
             /usr/bin/xvfb-run -a --server-args="${XVFB_SERVER_ARGS}" \
-                stdbuf -i0 -o0 -e0 $ENTRYPOINT \
+                stdbuf -i0 -o0 -e0 "${ENTRYPOINT}" \
                 --single-process-tests \
                 --gtest_shard_index="${GTEST_SHARD_INDEX}" \
                 --gtest_total_shards="${GTEST_TOTAL_SHARDS}" \
                 --gtest_output="xml:${xml_path}" \
-                --gtest_filter="${test_filter}" 2>&1 | tee ${log_path} || {
+                --gtest_filter="${test_filter}" 2>&1 | tee "${log_path}" || {
               failed_suites="${failed_suites} ${test_executable}"
             }
 
-            if [[ ! -f ${xml_path} ]]; then
+            if [[ ! -f "${xml_path}" ]]; then
               # Test binary crashed. Generate a fake JUnit XML report with the last run test.
-              python3 ${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py "${log_path}" "${xml_path}"
+              python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py" "${log_path}" "${xml_path}"
             fi
           fi
         done
@@ -152,10 +157,10 @@ runs:
 
         failed_suites=""
 
-        # Parse the JSON array into a space-separated string using jq.
-        test_executables=$(jq -nr --arg json "${TEST_EXECUTABLES_JSON:-[]}" '$json | fromjson | join(" ")')
+        # Parse the JSON array into a bash array using jq.
+        readarray -t test_executables < <(echo "${TEST_EXECUTABLES_JSON}" | jq -r '.[]')
 
-        for test_executable_path in ${test_executables}; do
+        for test_executable_path in "${test_executables[@]}"; do
           test_executable=$(basename "${test_executable_path}")
 
           # JUnit tests are executed by their wrapper script "out/PLATFORM_CONFIG/bin/run_NAME".
@@ -177,13 +182,13 @@ runs:
           # also output JSON and then subsequently remove this conversion script after adopting JSON as a universal
           # test result format in our testing workflow.
           json_path="${test_output}/${test_executable_name}_result.json"
-          stdbuf -i0 -o0 -e0 ./${test_executable_path} --json-results-file="${json_path}" 2>&1 | tee ${log_path} || {
+          stdbuf -i0 -o0 -e0 ./"${test_executable_path}" --json-results-file="${json_path}" 2>&1 | tee "${log_path}" || {
             failed_suites="${failed_suites} ${test_executable_name}"
           }
-          if [[ -f ${json_path} ]]; then
-            python3 ${GITHUB_WORKSPACE}/.github/scripts/convert_json_to_junit_xml.py "${json_path}" "${xml_path}"
+          if [[ -f "${json_path}" ]]; then
+            python3 "${GITHUB_WORKSPACE}/.github/scripts/convert_json_to_junit_xml.py" "${json_path}" "${xml_path}"
           else
-            python3 ${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py "${log_path}" "${xml_path}"
+            python3 "${GITHUB_WORKSPACE}/.github/scripts/generate_crash_report.py" "${log_path}" "${xml_path}"
           fi
         done
 

--- a/.github/actions/on_host_tests/action.yaml
+++ b/.github/actions/on_host_tests/action.yaml
@@ -90,7 +90,7 @@ runs:
         failed_suites=""
 
         # Parse the JSON array into a bash array using jq.
-        readarray -t test_executables < <(echo "${TEST_EXECUTABLES_JSON}" | jq -r '.[]')
+        readarray -t test_executables < <(echo "${TEST_EXECUTABLES_JSON:-[]}" | jq -r '.[]')
 
         for test_executable_path in "${test_executables[@]}"; do
           filename=$(basename "${test_executable_path}")
@@ -158,7 +158,7 @@ runs:
         failed_suites=""
 
         # Parse the JSON array into a bash array using jq.
-        readarray -t test_executables < <(echo "${TEST_EXECUTABLES_JSON}" | jq -r '.[]')
+        readarray -t test_executables < <(echo "${TEST_EXECUTABLES_JSON:-[]}" | jq -r '.[]')
 
         for test_executable_path in "${test_executables[@]}"; do
           test_executable=$(basename "${test_executable_path}")

--- a/.github/actions/overlay_workspace/action.yaml
+++ b/.github/actions/overlay_workspace/action.yaml
@@ -27,6 +27,7 @@ runs:
       shell: bash
       env:
         REPO_URL: ${{ github.server_url }}/${{ github.repository }}.git
+        INPUT_PATH: ${{ inputs.path }}
       run: |
         # LOWER_DIR (Read-Only): The pristine golden workspace (tip of tree) on the node's SSD. All pods read from this.
         LOWER_DIR="/runner-cache/golden-workspace"
@@ -38,65 +39,65 @@ runs:
         WORK_DIR="/runner-cache/workspaces/${GITHUB_RUN_ID}_${GITHUB_RUN_ATTEMPT}/work"
 
         # MERGED_DIR: The directory the CI job actually sees and works in. It seamlessly combines LOWER_DIR and UPPER_DIR.
-        MERGED_DIR="${GITHUB_WORKSPACE}/${{ inputs.path }}"
+        MERGED_DIR="${GITHUB_WORKSPACE}/${INPUT_PATH}"
 
         # Failsafe cleanup: Unmount and delete any orphaned workspaces from cancelled jobs
         # Since this node only runs one pod at a time, we can safely wipe all workspaces.
         echo "Cleaning up any orphaned overlay workspaces..."
-        fusermount3 -u "$MERGED_DIR" || fusermount -u "$MERGED_DIR" || umount "$MERGED_DIR" || true
+        fusermount3 -u "${MERGED_DIR}" || fusermount -u "${MERGED_DIR}" || umount "${MERGED_DIR}" || true
         rm -rf /runner-cache/workspaces/*
 
         # Ensure the directories exist
-        mkdir -p "$UPPER_DIR" "$WORK_DIR" "$MERGED_DIR"
+        mkdir -p "${UPPER_DIR}" "${WORK_DIR}" "${MERGED_DIR}"
 
         # If the golden workspace does not exist or is corrupted (missing .runner_cache_ready), initialize it.
         # This will only happen once per node!
-        if [ ! -f "$LOWER_DIR/.runner_cache_ready" ]; then
+        if [ ! -f "${LOWER_DIR}/.runner_cache_ready" ]; then
           IS_CACHE_HOT="false"
-          echo "cache_hit=false" >> $GITHUB_OUTPUT
+          echo "cache_hit=false" >> "${GITHUB_OUTPUT}"
           echo "Golden workspace not found or corrupted. Creating it now. This will take time..."
 
           # Aggressively clean up any corrupted state from previous bad runs
-          rm -rf "$LOWER_DIR"
-          mkdir -p "$LOWER_DIR"
-          cd "$LOWER_DIR"
+          rm -rf "${LOWER_DIR}"
+          mkdir -p "${LOWER_DIR}"
+          cd "${LOWER_DIR}"
 
-          git clone "$REPO_URL" src
+          git clone "${REPO_URL}" src
           # Clone depot_tools
           git clone https://chromium.googlesource.com/chromium/tools/depot_tools.git depot_tools
-          export PATH="$LOWER_DIR/depot_tools:$PATH"
+          export PATH="${LOWER_DIR}/depot_tools:${PATH}"
 
           gclient config \
             --name=src \
-            --custom-var="rbe_instance=\"projects/cobalt-actions-prod/instances/default_instance\"" "$REPO_URL"
+            --custom-var="rbe_instance=\"projects/cobalt-actions-prod/instances/default_instance\"" "${REPO_URL}"
           echo "target_os=['android', 'linux']" >> .gclient
           echo "target_cpu=['x64', 'arm', 'arm64']" >> .gclient
           gclient sync -D --no-history
 
           # Create marker file to indicate the cache is fully populated and valid
-          touch "$LOWER_DIR/.runner_cache_ready"
+          touch "${LOWER_DIR}/.runner_cache_ready"
         else
           IS_CACHE_HOT="true"
-          echo "cache_hit=true" >> $GITHUB_OUTPUT
+          echo "cache_hit=true" >> "${GITHUB_OUTPUT}"
         fi
 
         echo "Logging workspace cache status to Cloud Logging..."
         LOG_PAYLOAD=$(jq -n \
-          --arg workflow "$GITHUB_WORKFLOW" \
-          --arg job "$GITHUB_JOB" \
-          --arg runner "$RUNNER_NAME" \
-          --arg run_id "$GITHUB_RUN_ID" \
-          --arg url "https://github.com/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID" \
-          --argjson cache_hit "$IS_CACHE_HOT" \
+          --arg workflow "${GITHUB_WORKFLOW}" \
+          --arg job "${GITHUB_JOB}" \
+          --arg runner "${RUNNER_NAME}" \
+          --arg run_id "${GITHUB_RUN_ID}" \
+          --arg url "https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}" \
+          --argjson cache_hit "${IS_CACHE_HOT}" \
           '{workflow: $workflow, job: $job, runner: $runner, run_id: $run_id, url: $url, cache_hit: $cache_hit}')
 
-        gcloud logging write github-actions-runners "$LOG_PAYLOAD" --payload-type=json || true
+        gcloud logging write github-actions-runners "${LOG_PAYLOAD}" --payload-type=json || true
 
         echo "Mounting OverlayFS..."
         # Depending on your runner's privilege, use sudo mount or fuse-overlayfs
-        fuse-overlayfs -o lowerdir="$LOWER_DIR",upperdir="$UPPER_DIR",workdir="$WORK_DIR" "$MERGED_DIR"
+        fuse-overlayfs -o lowerdir="${LOWER_DIR}",upperdir="${UPPER_DIR}",workdir="${WORK_DIR}" "${MERGED_DIR}"
 
         # Avoid git ownership errors inside the container
-        git config --global --add safe.directory "$MERGED_DIR"
-        git config --global --add safe.directory "$MERGED_DIR/src"
-        git config --global --add safe.directory "$MERGED_DIR/depot_tools"
+        git config --global --add safe.directory "${MERGED_DIR}"
+        git config --global --add safe.directory "${MERGED_DIR}/src"
+        git config --global --add safe.directory "${MERGED_DIR}/depot_tools"

--- a/.github/actions/print_logs/action.yaml
+++ b/.github/actions/print_logs/action.yaml
@@ -22,35 +22,43 @@ runs:
       if: inputs.symbolize == 'true'
       id: gcs-project
       run: |
-        echo "name=$(gcloud config get-value project)" >> $GITHUB_OUTPUT
+        echo "name=$(gcloud config get-value project)" >> "${GITHUB_OUTPUT}"
       shell: bash
     - name: Download Test Symbols
       if: inputs.symbolize == 'true'
       env:
         WORKFLOW: ${{ github.workflow }}
+        GCS_PROJECT_NAME: ${{ steps.gcs-project.outputs.name }}
+        PLATFORM: ${{ matrix.platform }}
+        CONFIG: ${{ matrix.config }}
       run: |
-        gsutil -m cp "gs://${{ steps.gcs-project.outputs.name }}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${{matrix.platform}}/symbols/*" \
-          "${GITHUB_WORKSPACE}/out/${{ matrix.platform }}_${{ matrix.config }}/lib.unstripped/
+        gsutil -m cp "gs://${GCS_PROJECT_NAME}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${PLATFORM}/symbols/*" \
+          "${GITHUB_WORKSPACE}/out/${PLATFORM}_${CONFIG}/lib.unstripped/"
       shell: bash
     - name: Print Logs and Test Summary
+      env:
+        LOG_GLOB: ${{ inputs.log_glob }}
+        SYMBOLIZE: ${{ inputs.symbolize }}
+        PLATFORM: ${{ matrix.platform }}
+        CONFIG: ${{ matrix.config }}
       run: |
         # Print logs and failing tests.
         # Enable globstar shell option for globstar paths e.g. /**/*.xml and
         # nullopt to returns empty string if the glob matches no files.
         shopt -s globstar nullglob
 
-        log_files=(${{ inputs.log_glob }})
+        log_files=(${LOG_GLOB})
         if [ ${#log_files[@]} -eq 0 ]; then
           echo "::error::No log files were collected. The tests probably failed to run."
           exit 1
         else
-          for log_file in ${log_files[@]}; do
-            if [ "${{ inputs.symbolize }}" == "true" ]; then
+          for log_file in "${log_files[@]}"; do
+            if [ "${SYMBOLIZE}" == "true" ]; then
               # TODO: stack.py fails import packages. Perhaps needs depot tools setup?
-              cat ../${log_file} | python3 third_party/android_platform/development/scripts/stack.py --pass-through --output-directory out/${{ matrix.platform }}_${{ matrix.config }}/
+              cat "../${log_file}" | python3 third_party/android_platform/development/scripts/stack.py --pass-through --output-directory out/"${PLATFORM}_${CONFIG}"/
             else
               echo "=== ${log_file} ==="
-              cat ${log_file}
+              cat "${log_file}"
             fi
           done
         fi

--- a/.github/actions/web_tests/action.yaml
+++ b/.github/actions/web_tests/action.yaml
@@ -16,31 +16,33 @@ runs:
         name: ${{ inputs.test_artifacts_key }}
     - name: Extract Artifacts
       shell: bash
+      working-directory: cobalt/src
       run: |
         set -x
         # The web tests fail when not run from the source folder. Use the existing checkout.
-        cd cobalt/src/
-        tar -I 'zstd -T0' -xf ${GITHUB_WORKSPACE}/test_artifacts.tar.zstd
+        tar -I 'zstd -T0' -xf "${GITHUB_WORKSPACE}/test_artifacts.tar.zstd"
     - name: Run Web Tests
       id: run-tests
       shell: bash
+      working-directory: cobalt/src
       env:
         TEST_PATH: wpt_internal/cobalt
+        PLATFORM: ${{ matrix.platform }}
+        CONFIG: ${{ matrix.config }}
       run: |
         set -x
         env
-        cd cobalt/src/
 
-        RESULTS_DIR="out/${{ matrix.platform}}_${{ matrix.config }}/layout-test-results"
-        echo "RESULTS_DIR=${RESULTS_DIR}" >> $GITHUB_ENV
+        RESULTS_DIR="out/${PLATFORM}_${CONFIG}/layout-test-results"
+        echo "RESULTS_DIR=${RESULTS_DIR}" >> "${GITHUB_ENV}"
 
         third_party/blink/tools/run_web_tests.py \
           --driver-logging \
           --additional-driver-flag="--no-sandbox" \
           --debug \
           --no-show-results \
-          --target ${{ matrix.platform}}_${{ matrix.config }} \
-          ${TEST_PATH}
+          --target "${PLATFORM}_${CONFIG}" \
+          "${TEST_PATH}"
 
         echo "Finished running tests..."
     - name: Archive Test Results

--- a/.github/workflows/autoroll_chromium.yaml
+++ b/.github/workflows/autoroll_chromium.yaml
@@ -73,40 +73,45 @@ jobs:
         id: pr_info
         env:
           GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
         run: |
           # Get the first commit SHA of the existing PR.
           # If the PR doesn't exist, it returns an empty string.
-          FIRST_SHA=$(gh pr list --head "autoroll-${{ matrix.branch.source }}-to-${{ matrix.branch.target }}" --state open --json commits --jq '.[0].commits[0].oid // ""')
-          echo "first_sha=$FIRST_SHA" >> "$GITHUB_OUTPUT"
+          FIRST_SHA=$(gh pr list --head "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --state open --json commits --jq '.[0].commits[0].oid // ""')
+          echo "first_sha=${FIRST_SHA}" >> "${GITHUB_OUTPUT}"
 
       - name: Set Up Depot Tools
         run: |
           DEPOT_TOOLS_TEMP="${RUNNER_TEMP}/depot_tools"
-          git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "$DEPOT_TOOLS_TEMP"
-          echo "$DEPOT_TOOLS_TEMP" >> $GITHUB_PATH
+          git clone --depth 1 https://chromium.googlesource.com/chromium/tools/depot_tools.git "${DEPOT_TOOLS_TEMP}"
+          echo "${DEPOT_TOOLS_TEMP}" >> "${GITHUB_PATH}"
           source "${DEPOT_TOOLS_TEMP}/bootstrap_python3" && bootstrap_python3
 
       - name: Cherry Pick Merged PRs
         id: autoroll
         env:
           MAX_COMMITS: ${{ inputs.max_commits || 1 }}
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          AUTOROLL_FILE: ${{ matrix.branch.autoroll }}
+          FIRST_SHA: ${{ steps.pr_info.outputs.first_sha }}
         run: |
           set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll_chromium.py" \
-            --source-branch "${{ matrix.branch.source }}" \
-            --autoroll-file "${{ matrix.branch.autoroll }}" \
-            --max-commits "${{ env.MAX_COMMITS }}" \
-            --existing-pr-sha "${{ steps.pr_info.outputs.first_sha }}")
+            --source-branch "${SOURCE_BRANCH}" \
+            --autoroll-file "${AUTOROLL_FILE}" \
+            --max-commits "${MAX_COMMITS}" \
+            --existing-pr-sha "${FIRST_SHA}")
 
           if [[ -n "${PR_LINKS}" ]]; then
-            echo "cherry_picked=true" >> "$GITHUB_OUTPUT"
+            echo "cherry_picked=true" >> "${GITHUB_OUTPUT}"
             {
               echo "pr_links<<EOF"
               echo "${PR_LINKS}"
               echo "EOF"
-            } >> "$GITHUB_OUTPUT"
+            } >> "${GITHUB_OUTPUT}"
           else
             echo "::warning::No commits to roll found."
           fi
@@ -118,6 +123,7 @@ jobs:
           TARGET_BRANCH: ${{ matrix.branch.target }}
           GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
           PR_LINKS: ${{ steps.autoroll.outputs.pr_links }}
+          AUTOROLL_FILE: ${{ matrix.branch.autoroll }}
         run: |
           set -x
 
@@ -133,16 +139,16 @@ jobs:
             echo "${PR_LINKS}"
           } > "${PR_BODY_FILE}"
 
-          if [[ -f "${{ matrix.branch.autoroll }}" ]] && grep -q "^CONFLICTED:" "${{ matrix.branch.autoroll }}"; then
+          if [[ -f "${AUTOROLL_FILE}" ]] && grep -q "^CONFLICTED:" "${AUTOROLL_FILE}"; then
             PR_TITLE="$(git log -1 --pretty=%s)"
             {
               echo ""
-              echo "⚠️ This PR has conflicts that must be resolved manually (don't forget to update the \`${{ matrix.branch.autoroll }}\` file). Use the following commands to checkout the branch locally and resolve the conflicts in a separate commit:"
+              echo "⚠️ This PR has conflicts that must be resolved manually (don't forget to update the \`${AUTOROLL_FILE}\` file). Use the following commands to checkout the branch locally and resolve the conflicts in a separate commit:"
               echo ""
               echo '```bash'
-              echo "gh pr checkout <pull_request_number> -R ${{ github.repository }}"
+              echo "gh pr checkout <pull_request_number> -R ${GITHUB_REPOSITORY}"
               echo ""
-              echo "# Resolve conflicts and update ${{ matrix.branch.autoroll }} then"
+              echo "# Resolve conflicts and update ${AUTOROLL_FILE} then"
               echo "git add <resolved_files>"
               echo ""
               echo "# Copy CONFLICTED commit's message and metadata"

--- a/.github/workflows/autoroll_main.yaml
+++ b/.github/workflows/autoroll_main.yaml
@@ -73,34 +73,40 @@ jobs:
         id: pr_info
         env:
           GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
         run: |
           # Get the first commit SHA of the existing PR.
           # If the PR doesn't exist, it returns an empty string.
-          FIRST_SHA=$(gh pr list --head "autoroll-${{ matrix.branch.source }}-to-${{ matrix.branch.target }}" --state open --json commits --jq '.[0].commits[0].oid // ""')
-          echo "first_sha=$FIRST_SHA" >> "$GITHUB_OUTPUT"
+          FIRST_SHA=$(gh pr list --head "autoroll-${SOURCE_BRANCH}-to-${TARGET_BRANCH}" --state open --json commits --jq '.[0].commits[0].oid // ""')
+          echo "first_sha=${FIRST_SHA}" >> "${GITHUB_OUTPUT}"
 
       - name: Cherry Pick Merged PRs
         id: autoroll
         env:
           MAX_COMMITS: ${{ inputs.max_commits || 10 }}
+          SOURCE_BRANCH: ${{ matrix.branch.source }}
+          TARGET_BRANCH: ${{ matrix.branch.target }}
+          AUTOROLL_FILE: ${{ matrix.branch.autoroll }}
+          FIRST_SHA: ${{ steps.pr_info.outputs.first_sha }}
         run: |
           set -x
 
           # Run the Python script to perform cherry-picks and get all PR links.
           PR_LINKS=$(python3 "${RUNNER_TEMP}/autoroll.py" \
-            --source-branch "${{ matrix.branch.source }}" \
-            --target-branch "${{ matrix.branch.target }}" \
-            --autoroll-file "${{ matrix.branch.autoroll }}" \
-            --max-commits "${{ env.MAX_COMMITS }}" \
-            --existing-pr-sha "${{ steps.pr_info.outputs.first_sha }}")
+            --source-branch "${SOURCE_BRANCH}" \
+            --target-branch "${TARGET_BRANCH}" \
+            --autoroll-file "${AUTOROLL_FILE}" \
+            --max-commits "${MAX_COMMITS}" \
+            --existing-pr-sha "${FIRST_SHA}")
 
           if [[ -n "${PR_LINKS}" ]]; then
-            echo "cherry_picked=true" >> "$GITHUB_OUTPUT"
+            echo "cherry_picked=true" >> "${GITHUB_OUTPUT}"
             {
               echo "pr_links<<EOF"
               echo "${PR_LINKS}"
               echo "EOF"
-            } >> "$GITHUB_OUTPUT"
+            } >> "${GITHUB_OUTPUT}"
           else
             echo "::warning::No commits to roll found."
           fi
@@ -112,6 +118,7 @@ jobs:
           TARGET_BRANCH: ${{ matrix.branch.target }}
           GITHUB_TOKEN: ${{ secrets.CHERRY_PICK_TOKEN }}
           PR_LINKS: ${{ steps.autoroll.outputs.pr_links }}
+          AUTOROLL_FILE: ${{ matrix.branch.autoroll }}
         run: |
           set -x
 
@@ -127,16 +134,16 @@ jobs:
             echo "${PR_LINKS}"
           } > "${PR_BODY_FILE}"
 
-          if [[ -f "${{ matrix.branch.autoroll }}" ]] && grep -q "^CONFLICTED:" "${{ matrix.branch.autoroll }}"; then
+          if [[ -f "${AUTOROLL_FILE}" ]] && grep -q "^CONFLICTED:" "${AUTOROLL_FILE}"; then
             PR_TITLE="$(git log -1 --pretty=%s)"
             {
               echo ""
-              echo "⚠️ This PR has conflicts that must be resolved manually (don't forget to update the \`${{ matrix.branch.autoroll }}\` file). Use the following commands to checkout the branch locally and resolve the conflicts in a separate commit:"
+              echo "⚠️ This PR has conflicts that must be resolved manually (don't forget to update the \`${AUTOROLL_FILE}\` file). Use the following commands to checkout the branch locally and resolve the conflicts in a separate commit:"
               echo ""
               echo '```bash'
-              echo "gh pr checkout <pull_request_number> -R ${{ github.repository }}"
+              echo "gh pr checkout <pull_request_number> -R ${GITHUB_REPOSITORY}"
               echo ""
-              echo "# Resolve conflicts and update ${{ matrix.branch.autoroll }} then"
+              echo "# Resolve conflicts and update ${AUTOROLL_FILE} then"
               echo "git add <resolved_files>"
               echo ""
               echo "# Copy CONFLICTED commit's message and metadata"

--- a/.github/workflows/diff_chromium_branches.yaml
+++ b/.github/workflows/diff_chromium_branches.yaml
@@ -44,11 +44,11 @@ jobs:
           # If upstream branches are provided as input, we are manually triggered
           if [[ -n "${UPSTREAM_BRANCHES}" ]]; then
             # If manually triggered, get branches from comma-separated branches from inputs
-            DIFF_LABELS=$(echo "$UPSTREAM_BRANCHES" | jq -r -R '[split(",") | map(trim)] | map("\"" + . + "\"") | join(",")')
+            DIFF_LABELS=$(echo "${UPSTREAM_BRANCHES}" | jq -r -R '[split(",") | map(trim)] | map("\"" + . + "\"") | join(",")')
           else
-            # If label or synchronize Get the upstream branches from labels prefixed with $DIFF_PREFIX
+            # If label or synchronize Get the upstream branches from labels prefixed with ${DIFF_PREFIX}
             DIFF_PREFIX=$(jq -r '.diff_label_prefix' "${GITHUB_WORKSPACE}/.github/config/chromium_diffing.json")
-            DIFF_LABELS=$(echo "$PR_LABELS" | jq -c -r --arg prefix "$DIFF_PREFIX" '[.[] | select(.name | startswith($prefix)) | .name | sub($prefix; "")] | map("\"" + . + "\"") | join(",")')
+            DIFF_LABELS=$(echo "${PR_LABELS}" | jq -c -r --arg prefix "${DIFF_PREFIX}" '[.[] | select(.name | startswith($prefix)) | .name | sub($prefix; "")] | map("\"" + . + "\"") | join(",")')
           fi
 
           # Selected all branches objects in the chromium_diffing.json that match the diff labels
@@ -62,30 +62,32 @@ jobs:
               UPSTREAM_BRANCHES=""
             fi
           fi
-          echo "upstream_branches=${UPSTREAM_BRANCHES}" >> "$GITHUB_OUTPUT"
+          echo "upstream_branches=${UPSTREAM_BRANCHES}" >> "${GITHUB_OUTPUT}"
       - name: Set downstream branch
         id: set-downstream-branch
         env:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           EVENT_ACTION: ${{ github.event.action }}
+          DOWNSTREAM_BRANCH_INPUT: ${{ inputs.downstream_branch }}
+          GITHUB_REF: ${{ github.ref }}
         shell: bash
         run: |
           set -eux
-          if [[ -n "${{ inputs.downstream_branch }}" ]]; then
+          if [[ -n "${DOWNSTREAM_BRANCH_INPUT}" ]]; then
             # Get the trimmed downstream branch directly from inputs
-            DOWNSTREAM_BRANCH=${{ inputs.downstream_branch }}
+            DOWNSTREAM_BRANCH="${DOWNSTREAM_BRANCH_INPUT}"
           else
             # Get the downstream branch from the labelled PR
-            DOWNSTREAM_BRANCH="${{ github.ref }}"
+            DOWNSTREAM_BRANCH="${GITHUB_REF}"
           fi
-          echo "downstream_branch=${DOWNSTREAM_BRANCH}" >> "$GITHUB_OUTPUT"
+          echo "downstream_branch=${DOWNSTREAM_BRANCH}" >> "${GITHUB_OUTPUT}"
       - name: Set code ownership
         id: set-code-ownership
         shell: bash
         run: |
           set -eux
           CODE_OWNERSHIP=$(jq -c .code_ownership "${GITHUB_WORKSPACE}/.github/config/chromium_diffing.json")
-          echo "code_ownership=${CODE_OWNERSHIP}" >> "$GITHUB_OUTPUT"
+          echo "code_ownership=${CODE_OWNERSHIP}" >> "${GITHUB_OUTPUT}"
     outputs:
       upstream_branches: ${{ steps.set-upstream-branches.outputs.upstream_branches }}
       downstream_branch: ${{ steps.set-downstream-branch.outputs.downstream_branch }}
@@ -110,9 +112,9 @@ jobs:
           CODE_OWNERSHIP: ${{ needs.initialize.outputs.code_ownership }}
         run: |
           set -eux
-          git fetch origin "$DOWNSTREAM_REF"
+          git fetch origin "${DOWNSTREAM_REF}"
           git config set diff.renameLimit 100000
-          EXCLUDE_PATHS_FOR_MAIN_DIFF=$(echo "$CODE_OWNERSHIP" | jq -r '
+          EXCLUDE_PATHS_FOR_MAIN_DIFF=$(echo "${CODE_OWNERSHIP}" | jq -r '
             .ours +
             .our_files +
             .our_owned_dep +
@@ -122,7 +124,7 @@ jobs:
             | map(":(exclude)" + .) | .[]
           ')
           # Diff downstream to checked out branch (upstream)
-          readarray -t EXCLUDE_PATHS_ARRAY <<< "$EXCLUDE_PATHS_FOR_MAIN_DIFF"
+          readarray -t EXCLUDE_PATHS_ARRAY <<< "${EXCLUDE_PATHS_FOR_MAIN_DIFF}"
           git diff HEAD..FETCH_HEAD -- . "${EXCLUDE_PATHS_ARRAY[@]}" > main_diff.diff
       - name: Check for downstream deletions in excluded folders
         env:
@@ -130,7 +132,7 @@ jobs:
           CODE_OWNERSHIP: ${{ needs.initialize.outputs.code_ownership }}
         run: |
           set -eux
-          DOWNSTREAM_OWNED_FOLDER_TO_CHECK=$(echo "$CODE_OWNERSHIP" | jq -r '
+          DOWNSTREAM_OWNED_FOLDER_TO_CHECK=$(echo "${CODE_OWNERSHIP}" | jq -r '
             .ours +
             .our_files +
             .our_owned_dep +
@@ -138,7 +140,7 @@ jobs:
             .updated
             | .[]
           ')
-          readarray -t PATHS_TO_CHECK_ARRAY <<< "$DOWNSTREAM_OWNED_FOLDER_TO_CHECK"
+          readarray -t PATHS_TO_CHECK_ARRAY <<< "${DOWNSTREAM_OWNED_FOLDER_TO_CHECK}"
           git diff --diff-filter=D HEAD..FETCH_HEAD -- "${PATHS_TO_CHECK_ARRAY[@]}" > downstream_removal.diff
       - name: Report Diffs
         run: |

--- a/.github/workflows/gemini-commit-message.yml
+++ b/.github/workflows/gemini-commit-message.yml
@@ -78,19 +78,25 @@ jobs:
       # --- Step 1: Get PR Diff ---
       - name: 'Get PR Diff'
         id: diff
+        env:
+          PR_URL_1: ${{ github.event.pull_request.url }}
+          PR_URL_2: ${{ github.event.issue.pull_request.url }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           set -eux
           # Logic: Concatenate both URLs. Since events are exclusive, one will be empty.
           # PR Event URL + Issue Comment URL
-          PR_API_URL="${{ github.event.pull_request.url }}${{ github.event.issue.pull_request.url }}"
+          PR_API_URL="${PR_URL_1}${PR_URL_2}"
 
-          diff_content=$(curl -fsSL -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" -H "Accept: application/vnd.github.v3.diff" "$PR_API_URL")
+          set +x
+          diff_content=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.diff" "${PR_API_URL}")
+          set -x
 
           {
             echo "diff_content<<EOF"
-            echo "$diff_content"
+            echo "${diff_content}"
             echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          } >> "${GITHUB_OUTPUT}"
 
       # --- Step 2: Call Gemini API ---
       - name: 'Generate Commit Message with Gemini'
@@ -108,11 +114,11 @@ jobs:
 
           # Use jq to safely combine the instructions with the variables
           json_payload=$(jq -n \
-            --arg instr "$PROMPT" \
-            --arg url "$PR_URL" \
-            --arg title "$PR_TITLE" \
-            --arg body "$PR_BODY" \
-            --arg diff "$PR_DIFF" \
+            --arg instr "${PROMPT}" \
+            --arg url "${PR_URL}" \
+            --arg title "${PR_TITLE}" \
+            --arg body "${PR_BODY}" \
+            --arg diff "${PR_DIFF}" \
             '{
               contents: [{
                 parts: [{
@@ -121,18 +127,20 @@ jobs:
               }]
             }')
 
+          set +x
           api_response=$(curl -s -X POST \
-            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=$GEMINI_SECRET" \
+            "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${GEMINI_SECRET}" \
             -H "Content-Type: application/json" \
-            -d "$json_payload")
+            -d "${json_payload}")
+          set -x
 
-          gemini_text_response=$(echo "$api_response" | jq -r '.candidates[0].content.parts[0].text // "Error: Could not parse a valid response from the Gemini API. Please check the API response logs in the workflow run."')
+          gemini_text_response=$(echo "${api_response}" | jq -r '.candidates[0].content.parts[0].text // "Error: Could not parse a valid response from the Gemini API. Please check the API response logs in the workflow run."')
 
           {
             echo "response<<EOF"
-            echo "$gemini_text_response"
+            echo "${gemini_text_response}"
             echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          } >> "${GITHUB_OUTPUT}"
 
       # --- Step 3: Post Comment ---
       - name: 'Post Commit Message as Comment'

--- a/.github/workflows/gemini-commit-message.yml
+++ b/.github/workflows/gemini-commit-message.yml
@@ -88,9 +88,7 @@ jobs:
           # PR Event URL + Issue Comment URL
           PR_API_URL="${PR_URL_1}${PR_URL_2}"
 
-          set +x
           diff_content=$(curl -fsSL -H "Authorization: Bearer ${GITHUB_TOKEN}" -H "Accept: application/vnd.github.v3.diff" "${PR_API_URL}")
-          set -x
 
           {
             echo "diff_content<<EOF"
@@ -127,12 +125,10 @@ jobs:
               }]
             }')
 
-          set +x
           api_response=$(curl -s -X POST \
             "https://generativelanguage.googleapis.com/v1beta/models/gemini-3-flash-preview:generateContent?key=${GEMINI_SECRET}" \
             -H "Content-Type: application/json" \
             -d "${json_payload}")
-          set -x
 
           gemini_text_response=$(echo "${api_response}" | jq -r '.candidates[0].content.parts[0].text // "Error: Could not parse a valid response from the Gemini API. Please check the API response logs in the workflow run."')
 

--- a/.github/workflows/gemini-commit-message.yml
+++ b/.github/workflows/gemini-commit-message.yml
@@ -157,13 +157,15 @@ jobs:
 
             1.  **Influence the Result:** Want to change the output? You can write **custom prompts or instructions** directly in the **Pull Request description**. The model uses that text to generate the message.
             2.  **Re-run the Generator:** Post a comment with: `/generate-commit-message`
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
         with:
           script: |
             const body = process.env.COMMENT_BODY;
+            const issueNumber = Number(process.env.PR_NUMBER || process.env.ISSUE_NUMBER || context.issue.number);
             github.rest.issues.createComment({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              // Logic: Concatenate numbers. One will be empty, leaving the correct ID.
-              issue_number: ${{ github.event.pull_request.number }}${{ github.event.issue.number }},
+              issue_number: issueNumber,
               body: body
             });

--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -135,23 +135,32 @@ jobs:
 
       - name: Comment on failure
         uses: actions/github-script@v8
+        env:
+          PR_NUMBER: ${{ steps.create-pr.outputs.pull-request-number }}
+          CHERRY_PICK_OUTCOME: ${{ steps.cherry-pick.outcome }}
         with:
           github-token: ${{ secrets.CHERRY_PICK_TOKEN }}
           script: |
-            if ('${{ steps.create-pr.outputs.pull-request-number }}' == '') {
+            const prNumber = process.env.PR_NUMBER;
+            const outcome = process.env.CHERRY_PICK_OUTCOME;
+            const branch = process.env.CHERRY_PICK_BRANCH;
+            const runUrl = `${context.serverUrl}/${context.repo.owner}/${context.repo.repo}/actions/runs/${context.runId}`;
+            const treeUrl = `https://github.com/${context.repo.owner}/${context.repo.repo}/tree/${branch}`;
+
+            if (!prNumber) {
               // Comment on the originating PR if creating a cherry pick PR failed.
               github.rest.issues.createComment({
                 issue_number: context.payload.number,
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: '> [!CAUTION]\n> Creating the cherry pick PR failed! Check the log at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.'
+                body: `> [!CAUTION]\n> Creating the cherry pick PR failed! Check the log at ${runUrl} for details.`
               });
-            } else if ('${{ steps.cherry-pick.outcome }}' == 'failure') {
+            } else if (outcome === 'failure') {
               // Comment on the new PR if the cherry pick failed.
               github.rest.issues.createComment({
-                issue_number: '${{ steps.create-pr.outputs.pull-request-number }}',
+                issue_number: parseInt(prNumber, 10),
                 owner: context.repo.owner,
                 repo: context.repo.repo,
-                body: '![MERGE CONFLICT CAT](https://services.google.com/fh/files/misc/merge_conflict_cat.png)\n> [!CAUTION]\n> There were merge conflicts while cherry picking! Check out [${{ env.CHERRY_PICK_BRANCH }}](${{ github.repository }}/tree/${{ env.CHERRY_PICK_BRANCH }}) and fix the conflicts before proceeding. Check the log at ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }} for details.'
+                body: `![MERGE CONFLICT CAT](https://services.google.com/fh/files/misc/merge_conflict_cat.png)\n> [!CAUTION]\n> There were merge conflicts while cherry picking! Check out [${branch}](${treeUrl}) and fix the conflicts before proceeding. Check the log at ${runUrl} for details.`
               });
             }

--- a/.github/workflows/label-cherry-pick.yaml
+++ b/.github/workflows/label-cherry-pick.yaml
@@ -35,28 +35,29 @@ jobs:
           LABEL_NAME: ${{ github.event.label.name }}
           BASE_REF: ${{ github.base_ref }}
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          if [[ $EVENT_ACTION == 'closed' ]]; then
+          if [[ ${EVENT_ACTION} == 'closed' ]]; then
             # Fetch live labels from the API to include auto-added ones
-            labels=$(gh pr view ${{ github.event.pull_request.number }} --repo ${{ github.repository }} --json labels --jq '.labels[].name')
+            labels=$(gh pr view ${PR_NUMBER} --repo ${GITHUB_REPOSITORY} --json labels --jq '.labels[].name')
           else
             # Or get the label that was added on the merged PR.
-            labels=$LABEL_NAME
+            labels=${LABEL_NAME}
           fi
 
           # This list must contain all cherry-pick destinations as file is used for all branches.
           branches=("main" "26.eap" "26.android" "25.lts.1+" "24.lts.1+" "23.lts.1+" "22.lts.1+" "21.lts.1+" "20.lts.1+" "19.lts.1+" "rc_11" "COBALT_9")
           filtered_branches=()
           for branch in "${branches[@]}"; do
-            if [[ $branch == $BASE_REF ]]; then
+            if [[ "${branch}" == "${BASE_REF}" ]]; then
               continue
             fi
-            if [[ ${labels[@]} =~ "cp-$branch" ]]; then
-              filtered_branches+=("$branch")
+            if [[ "${labels}" =~ "cp-${branch}" ]]; then
+              filtered_branches+=("${branch}")
             fi
           done
 
-          echo "target_branch=$(echo -n "${filtered_branches[@]}" | jq -cRs 'split(" ")')" >> $GITHUB_OUTPUT
+          echo "target_branch=$(echo -n "${filtered_branches[@]}" | jq -cRs 'split(" ")')" >> "${GITHUB_OUTPUT}"
 
   cherry_pick:
     runs-on: ubuntu-latest
@@ -93,9 +94,11 @@ jobs:
       - name: Cherry pick merge commit
         id: cherry-pick
         continue-on-error: true
+        env:
+          TARGET_BRANCH: ${{ matrix.target_branch }}
         run: |
           set -x
-          git fetch origin ${{ matrix.target_branch }}
+          git fetch origin "${TARGET_BRANCH}"
 
           set +e
           # Select the first parent as the mainline tree. This is necessary if

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -59,6 +59,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       GITHUB_PR_REPO_URL: ${{ github.event.pull_request.base.repo.url }}
       GITHUB_EVENT_NUMBER: ${{ github.event.number }}
+      PLATFORM: ${{ inputs.platform }}
     if: |
       github.event.action != 'labeled' ||
       (github.event.pull_request.merged == false && (github.event.label.name == 'runtest' || github.event.label.name == 'yts_playback_test'))
@@ -86,149 +87,151 @@ jobs:
         shell: bash
         run: |
           set -x
-          platforms=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -c '.platforms')
-          echo "platforms=${platforms}" >> $GITHUB_OUTPUT
+          platforms=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -c '.platforms')
+          echo "platforms=${platforms}" >> "${GITHUB_OUTPUT}"
       - name: Select build runners
         id: set-build-runners
         shell: bash
         run: |
           set -x
-          build_runners=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -c '.build_runners // ["self-hosted", "chrobalt-linux-runner"]' )
-          echo "build_runners=${build_runners}" >> $GITHUB_OUTPUT
+          build_runners=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -c '.build_runners // ["self-hosted", "chrobalt-linux-runner"]' )
+          echo "build_runners=${build_runners}" >> "${GITHUB_OUTPUT}"
       - name: Set build targets
         id: set-targets
         shell: bash
         run: |
           set -x
-          targets=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -cr '.targets')
-          echo "targets=${targets}" >> $GITHUB_OUTPUT
+          targets=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -cr '.targets')
+          echo "targets=${targets}" >> "${GITHUB_OUTPUT}"
       - name: Set build configs
         id: set-build-configs
         shell: bash
         run: |
           set -x
           # Attempt to load build configs from JSON. If not present use default.
-          build_configs=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -cr '.build_configs')
+          build_configs=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -cr '.build_configs')
           if [[ "${build_configs}" == "null" ]]; then
             build_configs='["devel", "qa", "gold"]'
           fi
-          echo "build_configs=${build_configs}" >> $GITHUB_OUTPUT
+          echo "build_configs=${build_configs}" >> "${GITHUB_OUTPUT}"
       - name: Set platform extra includes
         id: set-includes
         shell: bash
         run: |
           set -x
-          includes=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -c '.includes')
-          echo "includes=${includes}" >> $GITHUB_OUTPUT
+          includes=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -c '.includes')
+          echo "includes=${includes}" >> "${GITHUB_OUTPUT}"
       - name: Set Docker service
         id: set-docker-service
         shell: bash
         run: |
           set -x
-          docker_service=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -r '.docker_service // empty')
-          echo "docker_service=${docker_service}" >> $GITHUB_OUTPUT
+          docker_service=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -r '.docker_service // empty')
+          echo "docker_service=${docker_service}" >> "${GITHUB_OUTPUT}"
       - name: Set on-host tests
         id: set-test-on-host
         shell: bash
         run: |
           set -x
-          test_on_host=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_on_host')
-          echo "test_on_host=${test_on_host}" >> $GITHUB_OUTPUT
+          test_on_host=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_on_host')
+          echo "test_on_host=${test_on_host}" >> "${GITHUB_OUTPUT}"
       - name: Set on-device tests
         id: set-test-on-device
         shell: bash
         run: |
           set -x
-          test_on_device=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_on_device')
-          echo "test_on_device=${test_on_device}" >> $GITHUB_OUTPUT
+          test_on_device=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_on_device')
+          echo "test_on_device=${test_on_device}" >> "${GITHUB_OUTPUT}"
       - name: Set test package
         id: set-test-package
         shell: bash
         run: |
           set -x
-          test_package=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_package')
-          echo "test_package=${test_package}" >> $GITHUB_OUTPUT
+          test_package=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_package')
+          echo "test_package=${test_package}" >> "${GITHUB_OUTPUT}"
       - name: Set e2e tests
         id: set-test-e2e
         shell: bash
         run: |
           set -x
-          test_e2e=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_e2e')
-          echo "test_e2e=${test_e2e}" >> $GITHUB_OUTPUT
+          test_e2e=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_e2e')
+          echo "test_e2e=${test_e2e}" >> "${GITHUB_OUTPUT}"
       - name: Set YTS tests
         id: set-test-yts
         shell: bash
         run: |
           set -x
-          test_yts=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_yts')
-          echo "test_yts=${test_yts}" >> $GITHUB_OUTPUT
+          test_yts=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_yts')
+          echo "test_yts=${test_yts}" >> "${GITHUB_OUTPUT}"
       - name: Set YTS Playback tests
         id: set-test-yts-playback
         shell: bash
         run: |
           set -x
-          test_yts_playback=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_yts_playback')
-          echo "test_yts_playback=${test_yts_playback}" >> $GITHUB_OUTPUT
+          test_yts_playback=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_yts_playback')
+          echo "test_yts_playback=${test_yts_playback}" >> "${GITHUB_OUTPUT}"
       - name: Set Browser tests
         id: set-test-browser
         shell: bash
         run: |
           set -x
-          test_browser=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_browser')
-          echo "test_browser=${test_browser}" >> $GITHUB_OUTPUT
+          test_browser=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_browser')
+          echo "test_browser=${test_browser}" >> "${GITHUB_OUTPUT}"
       - name: Set YTS WPT tests
         id: set-test-yts-wpt
         shell: bash
         run: |
           set -x
-          test_yts_wpt=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_yts_wpt')
-          echo "test_yts_wpt=${test_yts_wpt}" >> $GITHUB_OUTPUT
+          test_yts_wpt=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_yts_wpt')
+          echo "test_yts_wpt=${test_yts_wpt}" >> "${GITHUB_OUTPUT}"
       - name: Set web tests
         id: set-web-tests
         shell: bash
         run: |
           set -x
-          web_tests=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.web_tests')
-          echo "web_tests=${web_tests}" >> $GITHUB_OUTPUT
+          web_tests=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.web_tests')
+          echo "web_tests=${web_tests}" >> "${GITHUB_OUTPUT}"
       - name: Set root target for unit tests
         id: set-test-root-target
         shell: bash
         run: |
           set -x
-          test_root_target=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_root_target')
-          echo "test_root_target=${test_root_target}" >> $GITHUB_OUTPUT
+          test_root_target=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_root_target')
+          echo "test_root_target=${test_root_target}" >> "${GITHUB_OUTPUT}"
       - name: Set E2E test device type
         id: set-test-device-family
         shell: bash
         run: |
           set -x
-          test_device_family=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_device_family // empty')
-          echo "test_device_family=${test_device_family}" >> $GITHUB_OUTPUT
+          test_device_family=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_device_family // empty')
+          echo "test_device_family=${test_device_family}" >> "${GITHUB_OUTPUT}"
       - name: Set YTS test targets
         id: set-yts-test-targets
         shell: bash
         run: |
           set -x
-          yts_test_targets=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -cr '.yts_test_targets // []')
-          echo "yts_test_targets=${yts_test_targets}" >> $GITHUB_OUTPUT
+          yts_test_targets=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -cr '.yts_test_targets // []')
+          echo "yts_test_targets=${yts_test_targets}" >> "${GITHUB_OUTPUT}"
       - name: Set YTS Playback test targets
         id: set-yts-playback-test-targets
         shell: bash
         run: |
           set -x
-          yts_playback_test_targets=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -cr '.yts_playback_test_targets // []')
-          echo "yts_playback_test_targets=${yts_playback_test_targets}" >> $GITHUB_OUTPUT
+          yts_playback_test_targets=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -cr '.yts_playback_test_targets // []')
+          echo "yts_playback_test_targets=${yts_playback_test_targets}" >> "${GITHUB_OUTPUT}"
       - name: Set Browser test targets
         id: set-browser-test-targets
         shell: bash
+        env:
+          TEST_BROWSER: ${{ steps.set-test-browser.outputs.test_browser }}
         run: |
           set -x
-          browser_test_targets=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -cr '.browser_test_targets // []')
-          echo "browser_test_targets=${browser_test_targets}" >> $GITHUB_OUTPUT
+          browser_test_targets=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -cr '.browser_test_targets // []')
+          echo "browser_test_targets=${browser_test_targets}" >> "${GITHUB_OUTPUT}"
 
           # Also export just the target strings for the results matrix.
           browser_test_targets_json=$(echo "${browser_test_targets}" | jq -c 'map(.target)')
-          echo "browser_test_targets_json=${browser_test_targets_json}" >> $GITHUB_OUTPUT
+          echo "browser_test_targets_json=${browser_test_targets_json}" >> "${GITHUB_OUTPUT}"
 
           # Centralize "should run browser tests" logic.
           # A platform "should run browser tests" only if the test_browser flag is
@@ -236,58 +239,58 @@ jobs:
           # platforms that may have the flag enabled but no defined tests, or
           # for host platforms (like Linux) where targets might be filtered out
           # based on the primary target list.
-          if [[ "${{ steps.set-test-browser.outputs.test_browser }}" == "true" && "${browser_test_targets_json}" != "[]" ]]; then
-            echo "run_browser_tests=true" >> $GITHUB_OUTPUT
+          if [[ "${TEST_BROWSER}" == "true" && "${browser_test_targets_json}" != "[]" ]]; then
+            echo "run_browser_tests=true" >> "${GITHUB_OUTPUT}"
           else
-            echo "run_browser_tests=false" >> $GITHUB_OUTPUT
+            echo "run_browser_tests=false" >> "${GITHUB_OUTPUT}"
           fi
       - name: Set YTS WPT test targets
         id: set-yts-wpt-test-targets
         shell: bash
         run: |
           set -x
-          yts_wpt_test_targets=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -cr '.yts_wpt_test_targets // []')
-          echo "yts_wpt_test_targets=${yts_wpt_test_targets}" >> $GITHUB_OUTPUT
+          yts_wpt_test_targets=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -cr '.yts_wpt_test_targets // []')
+          echo "yts_wpt_test_targets=${yts_wpt_test_targets}" >> "${GITHUB_OUTPUT}"
       - name: Set E2E test targets
         id: set-e2e-test-targets
         shell: bash
         run: |
           set -x
-          e2e_test_targets=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -cr '.e2e_test_targets // []')
-          echo "e2e_test_targets=${e2e_test_targets}" >> $GITHUB_OUTPUT
+          e2e_test_targets=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -cr '.e2e_test_targets // []')
+          echo "e2e_test_targets=${e2e_test_targets}" >> "${GITHUB_OUTPUT}"
       - name: Set test device dimensions
         id: set-test-dimensions
         shell: bash
         run: |
           set -x
-          test_dimensions=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_dimensions')
-          echo "test_dimensions=${test_dimensions}" >> $GITHUB_OUTPUT
+          test_dimensions=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_dimensions')
+          echo "test_dimensions=${test_dimensions}" >> "${GITHUB_OUTPUT}"
       - name: Set test attempts
         id: set-test-attempts
         shell: bash
         run: |
           set -x
-          test_attempts=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.test_attempts // empty')
-          echo "test_attempts=${test_attempts}" >> $GITHUB_OUTPUT
+          test_attempts=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.test_attempts // empty')
+          echo "test_attempts=${test_attempts}" >> "${GITHUB_OUTPUT}"
       - name: Set number of on-host unit test shards
         id: set-gtest-shards
         shell: bash
         run: |
           set -x
           # Retrieve number of shards from config. If not specified, default to 1 shard with `echo 1`.
-          num_gtest_shards=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.num_gtest_shards // 1' )
-          echo "num_gtest_shards=${num_gtest_shards}" >> $GITHUB_OUTPUT
+          num_gtest_shards=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.num_gtest_shards // 1' )
+          echo "num_gtest_shards=${num_gtest_shards}" >> "${GITHUB_OUTPUT}"
 
           # Create a zero-indexed list of shards for use by matrix, e.g. [0,1,2,3,4,5].
           gtest_shards="[$(seq -s, 0 1 $((${num_gtest_shards} - 1)))]"
-          echo "gtest_shards=${gtest_shards}" >> $GITHUB_OUTPUT
+          echo "gtest_shards=${gtest_shards}" >> "${GITHUB_OUTPUT}"
       - name: Set enable sccache
         id: set-enable-sccache
         shell: bash
         run: |
           set -x
-          enable_sccache=$(cat ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json | jq -rc '.enable_sccache')
-          echo "enable_sccache=${enable_sccache}" >> $GITHUB_OUTPUT
+          enable_sccache=$(cat "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json" | jq -rc '.enable_sccache')
+          echo "enable_sccache=${enable_sccache}" >> "${GITHUB_OUTPUT}"
       - name: Set Docker files checksum
         id: set-docker-hash
         env:
@@ -297,7 +300,7 @@ jobs:
           set -x
           read -r -a docker_files <<< "${DOCKER_FILES}"
           docker_content_sha=$(find "${docker_files[@]}" -type f -exec sha256sum -b {} + | LC_ALL=C sort | sha256sum | head -c 64)
-          echo "docker_content_sha=${docker_content_sha}" >> "$GITHUB_OUTPUT"
+          echo "docker_content_sha=${docker_content_sha}" >> "${GITHUB_OUTPUT}"
       - name: Generate Expected Test Targets Json
         id: generate-expected-test-targets-json
         env:
@@ -308,14 +311,14 @@ jobs:
           run_on_device_test="false"
           expected_tests="[]"
 
-          first_platform=$(jq -r '.platforms[0]' ${GITHUB_WORKSPACE}/.github/config/${{ inputs.platform }}.json)
+          first_platform=$(jq -r '.platforms[0]' "${GITHUB_WORKSPACE}/.github/config/${PLATFORM}.json")
           test_targets_json_file="cobalt/build/testing/targets/${first_platform}/test_targets.json"
 
-          if [ -f "$test_targets_json_file" ]; then
-            if [[ "$TEST_ON_DEVICE" == "true" && (
-                  "$IS_NON_DRAFT_PULL_REQUEST" == "true" ||
-                  "$RUN_ODT_ON_NIGHTLY" == "true" ||
-                  "$RUN_ODT_ON_PUSH" == "true" ) ]]; then
+          if [ -f "${test_targets_json_file}" ]; then
+            if [[ "${TEST_ON_DEVICE}" == "true" && (
+                  "${IS_NON_DRAFT_PULL_REQUEST}" == "true" ||
+                  "${RUN_ODT_ON_NIGHTLY}" == "true" ||
+                  "${RUN_ODT_ON_PUSH}" == "true" ) ]]; then
               run_on_device_test="true"
             fi
 
@@ -341,7 +344,7 @@ jobs:
           {
             echo "run_on_device_test=${run_on_device_test}"
             echo "expected_tests_json=${expected_tests}"
-          } >> $GITHUB_OUTPUT
+          } >> "${GITHUB_OUTPUT}"
         shell: bash
     outputs:
       platforms: ${{ steps.set-platforms.outputs.platforms }}
@@ -478,9 +481,9 @@ jobs:
             # We want temp folder to be on tmpfs which makes workloads faster.
             # However, dind container ends up having / folder mounted on overlay
             # filesystem, whereas /__w which contains Cobalt source code is on tmpfs.
-            echo "TMPDIR=/__w/_temp" >> $GITHUB_ENV
+            echo "TMPDIR=/__w/_temp" >> "${GITHUB_ENV}"
           else
-            echo "TMPDIR=${{ runner.temp }}" >> $GITHUB_ENV
+            echo "TMPDIR=${RUNNER_TEMP}" >> "${GITHUB_ENV}"
           fi
       - name: Restore CI Essentials
         uses: actions/checkout@v4
@@ -907,23 +910,26 @@ jobs:
         id: extract-target-name
         env:
           test_target_with_path: ${{ matrix.test_info.target }}
-        run: echo "test_target=${test_target_with_path#*:}" >> $GITHUB_OUTPUT
+        run: echo "test_target=${test_target_with_path#*:}" >> "${GITHUB_OUTPUT}"
         shell: bash
       - name: Check if ${{ matrix.test_info.target }} is skipped in test filters
         id: filter
+        env:
+          TEST_TARGET: ${{ steps.extract-target-name.outputs.test_target }}
+          PLATFORM: ${{ matrix.platform }}
         run: |
           set -x
           # Get first entry in test filters file.
           test_filter=""
-          test_target="${{ steps.extract-target-name.outputs.test_target }}"
-          test_filter_json_dir="${GITHUB_WORKSPACE}/cobalt/testing/filters/${{ matrix.platform }}/${test_target}_filter.json"
-          if [ -f ${test_filter_json_dir} ]; then
-            test_filter="$(jq -cr '.failing_tests[0]' ${test_filter_json_dir})"
+          test_target="${TEST_TARGET}"
+          test_filter_json_dir="${GITHUB_WORKSPACE}/cobalt/testing/filters/${PLATFORM}/${test_target}_filter.json"
+          if [ -f "${test_filter_json_dir}" ]; then
+            test_filter="$(jq -cr '.failing_tests[0]' "${test_filter_json_dir}")"
             if [ "${test_filter}" = '*' ]; then
               echo "${test_target} was skipped due to test filter."
-              echo "skipped=true" >> $GITHUB_OUTPUT
+              echo "skipped=true" >> "${GITHUB_OUTPUT}"
             else
-              echo "skipped=false" >> $GITHUB_OUTPUT
+              echo "skipped=false" >> "${GITHUB_OUTPUT}"
             fi
           fi
         shell: bash
@@ -987,7 +993,7 @@ jobs:
         id: extract-target-name
         env:
           test_target_with_path: ${{ matrix.test_target }}
-        run: echo "test_target=${test_target_with_path#*:}" >> $GITHUB_OUTPUT
+        run: echo "test_target=${test_target_with_path#*:}" >> "${GITHUB_OUTPUT}"
         shell: bash
       - name: Download Test Results
         uses: actions/download-artifact@v5

--- a/.github/workflows/outside_collaborator.yaml
+++ b/.github/workflows/outside_collaborator.yaml
@@ -21,15 +21,16 @@ jobs:
         PR_AUTHOR_LOGIN: ${{ github.event.pull_request.user.login }}
         REPO_NAME: ${{ github.event.repository.full_name }}
         PR_NUMBER: ${{ github.event.number }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        PERMISSION_LEVEL=$(curl -s -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
-          "https://api.github.com/repos/$REPO_NAME/collaborators/$PR_AUTHOR_LOGIN/permission" | jq -r .role_name)
+        PERMISSION_LEVEL=$(curl -s -H "Authorization: token ${GITHUB_TOKEN}" \
+          "https://api.github.com/repos/${REPO_NAME}/collaborators/${PR_AUTHOR_LOGIN}/permission" | jq -r .role_name)
 
-        if [ "$PERMISSION_LEVEL" == "none" ] || [ "$PERMISSION_LEVEL" == "read" ]; then
+        if [ "${PERMISSION_LEVEL}" == "none" ] || [ "${PERMISSION_LEVEL}" == "read" ]; then
           echo "PR author is an outside collaborator. Adding label..."
 
-          curl -s -X POST -H "Authorization: token ${{ secrets.GITHUB_TOKEN }}" \
+          curl -s -X POST -H "Authorization: token ${GITHUB_TOKEN}" \
             -H "Accept: application/vnd.github.v3+json" \
             -d '["outside collaborator"]' \
-            "https://api.github.com/repos/$REPO_NAME/issues/$PR_NUMBER/labels"
+            "https://api.github.com/repos/${REPO_NAME}/issues/${PR_NUMBER}/labels"
         fi

--- a/.github/workflows/sync_chromium_branches.yaml
+++ b/.github/workflows/sync_chromium_branches.yaml
@@ -23,6 +23,9 @@ jobs:
           {milestone: m138, branch_num: 7204},
           {milestone: m144, branch_num: 7559},
         ]
+    env:
+      BRANCH_NUM: ${{ matrix.branch.branch_num }}
+      MILESTONE: ${{ matrix.branch.milestone }}
     steps:
       # Attempt to checkout our Chromium reference, if missing, create a new branch
       - uses: actions/checkout@v4
@@ -45,33 +48,33 @@ jobs:
           git config --global user.email "github@google.com"
           # Add Chromium remote and pull the upstream branch.
           git remote add upstream https://chromium.googlesource.com/chromium/src
-          git fetch --depth=1 upstream "refs/branch-heads/${{ matrix.branch.branch_num }}:refs/remotes/branch/${{ matrix.branch.branch_num }}"
+          git fetch --depth=1 upstream "refs/branch-heads/${BRANCH_NUM}:refs/remotes/branch/${BRANCH_NUM}"
       - name: Create missing Chromium branch
         if: steps.checkout.outcome == 'failure'
         run: |
-          git checkout "refs/remotes/branch/${{ matrix.branch.branch_num }}"
+          git checkout "refs/remotes/branch/${BRANCH_NUM}"
           ORIGINAL_TREE_HASH=$(git rev-parse "HEAD^{tree}")
           ORIGINAL_COMMIT_HASH=$(git rev-parse HEAD)
-          NEW_ROOT_COMMIT_HASH=$(git commit-tree "${ORIGINAL_TREE_HASH}" -m "First commit for ${{ matrix.branch.milestone }}.")
-          git checkout -b "chromium/${{ matrix.branch.milestone }}" "${NEW_ROOT_COMMIT_HASH}"
+          NEW_ROOT_COMMIT_HASH=$(git commit-tree "${ORIGINAL_TREE_HASH}" -m "First commit for ${MILESTONE}.")
+          git checkout -b "chromium/${MILESTONE}" "${NEW_ROOT_COMMIT_HASH}"
           git commit --amend --no-edit -c "${ORIGINAL_COMMIT_HASH}"
-          git push --set-upstream origin "chromium/${{ matrix.branch.milestone }}"
+          git push --set-upstream origin "chromium/${MILESTONE}"
       - name: Create upstream diff
         run: |
-          git diff HEAD "branch/${{ matrix.branch.branch_num }}" --binary > chromium_diff.patch
+          git diff HEAD "branch/${BRANCH_NUM}" --binary > chromium_diff.patch
       - name: Apply and Push upstream diff
         id: push_diff
         run: |
           if [ -s chromium_diff.patch ]; then
             echo "Applying diff..."
             git apply --index chromium_diff.patch
-            git commit -m "Rebase refresh on $(date +'%Y-%m-%d') for ${{ matrix.branch.milestone }}."
+            git commit -m "Rebase refresh on $(date +'%Y-%m-%d') for ${MILESTONE}."
 
-            git push --force origin "chromium/${{ matrix.branch.milestone }}"
+            git push --force origin "chromium/${MILESTONE}"
             DIFF_COMMIT_HASH=$(git rev-parse HEAD)
-            echo "main_cherry_pick=true" >> "$GITHUB_OUTPUT"
-            echo "main_cherry_pick_hash=${DIFF_COMMIT_HASH}" >> "$GITHUB_OUTPUT"
+            echo "main_cherry_pick=true" >> "${GITHUB_OUTPUT}"
+            echo "main_cherry_pick_hash=${DIFF_COMMIT_HASH}" >> "${GITHUB_OUTPUT}"
           else
             echo "No diff to apply."
-            echo "main_cherry_pick=false" >> "$GITHUB_OUTPUT"
+            echo "main_cherry_pick=false" >> "${GITHUB_OUTPUT}"
           fi

--- a/.github/workflows/tvos.yaml
+++ b/.github/workflows/tvos.yaml
@@ -30,9 +30,9 @@ jobs:
           PUSH_SHA: ${{ github.sha }}
         run: |
           if [ "${EVENT_NAME}" = "pull_request" ]; then
-            echo "sha=${PR_SHA}" >> "$GITHUB_OUTPUT"
+            echo "sha=${PR_SHA}" >> "${GITHUB_OUTPUT}"
           else
-            echo "sha=${PUSH_SHA}" >> "$GITHUB_OUTPUT"
+            echo "sha=${PUSH_SHA}" >> "${GITHUB_OUTPUT}"
           fi
 
   get-targets:
@@ -56,10 +56,12 @@ jobs:
 
       - name: Convert Targets to Short Names
         id: short-targets
+        env:
+          TEST_TARGETS_JSON: ${{ steps.parse-targets.outputs.test_targets_json }}
         run: |
-          targets=$(echo '${{ steps.parse-targets.outputs.test_targets_json }}' | jq -cr 'map(split(":")[-1])')
+          targets=$(echo "${TEST_TARGETS_JSON}" | jq -cr 'map(split(":")[-1])')
           echo "Targets found: ${targets}"
-          echo "targets=${targets}" >> "$GITHUB_OUTPUT"
+          echo "targets=${targets}" >> "${GITHUB_OUTPUT}"
 
   wait-for-kokoro-build:
     needs: get-sha
@@ -99,7 +101,7 @@ jobs:
 
               if [[ "${state}" == "success" ]]; then
                 echo "Kokoro build succeeded!"
-                echo "invocation_id=${invocation_id}" >> "$GITHUB_OUTPUT"
+                echo "invocation_id=${invocation_id}" >> "${GITHUB_OUTPUT}"
                 exit 0
               elif [[ "${state}" == "failure" || "${state}" == "error" ]]; then
                 echo "Kokoro build failed with state: ${state}"
@@ -169,19 +171,21 @@ jobs:
 
       - name: Filter
         id: filter
+        env:
+          TARGET: ${{ matrix.target }}
         run: |
           test_filter=""
-          filter_file="cobalt/testing/filters/tvos-arm64-simulator/${{ matrix.target }}_filter.json"
+          filter_file="cobalt/testing/filters/tvos-arm64-simulator/${TARGET}_filter.json"
           if [[ -f "${filter_file}" ]]; then
             test_filter="$(jq -cr '.failing_tests[0]' "${filter_file}")"
             if [[ "${test_filter}" == '*' ]]; then
-              echo "${{ matrix.target }} was skipped due to test filter."
-              echo "skipped=true" >> "$GITHUB_OUTPUT"
+              echo "${TARGET} was skipped due to test filter."
+              echo "skipped=true" >> "${GITHUB_OUTPUT}"
             else
-              echo "skipped=false" >> "$GITHUB_OUTPUT"
+              echo "skipped=false" >> "${GITHUB_OUTPUT}"
             fi
           else
-            echo "skipped=false" >> "$GITHUB_OUTPUT"
+            echo "skipped=false" >> "${GITHUB_OUTPUT}"
           fi
         shell: bash
 
@@ -248,11 +252,13 @@ jobs:
     name: tvos_tests_passing
     steps:
       - name: Check test results
+        env:
+          RUN_TESTS_RESULT: ${{ needs.run-tests.result }}
         run: |
-          if [[ "${{ needs.run-tests.result }}" == "success" ]]; then
+          if [[ "${RUN_TESTS_RESULT}" == "success" ]]; then
             echo "All tvOS tests passed successfully!"
             exit 0
           else
-            echo "tvOS test job failed with result: ${{ needs.run-tests.result }}"
+            echo "tvOS test job failed with result: ${RUN_TESTS_RESULT}"
             exit 1
           fi


### PR DESCRIPTION
Map GHA expression template variables (matrix, inputs, github context) to step-level environment variables to prevent command injection.

Standardize bash environment variable references to use curly braces (${VAR}).

Use bash arrays (readarray) for list iteration instead of space-separated strings. Replaced cd commands with GHA working-directory attribute where possible. Quote GHA default environment variables (GITHUB_ENV, GITHUB_OUTPUT, GITHUB_PATH, GITHUB_WORKSPACE). Disable trace output (set +x) when API keys are used in curl.

TAG=agy
CONV=3631585a-1f0f-442f-9b8e-96a5a4f5fae4

Bug: 546190339