### PR TITLE
media: Refactor configurable decommit strategy

### DIFF
--- a/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
+++ b/media/starboard/bidirectional_fit_decoder_buffer_allocator_strategy.h
@@ -38,39 +38,20 @@ class BidirectionalFitDecoderBufferAllocatorStrategy
                                      allocation_increment) {}
 
   // Constructs a strategy with explicit decommit configurations.
-  // |enable_decommit_on_idle|: Whether to perform any decommits when idle.
-  // |retain_blocks|: Number of blocks to keep fully committed when idle.
-  // |conservative_decommit_blocks|: Number of blocks beyond retain blocks to
-  // lazily decommit (e.g. using MADV_FREE if supported). Any blocks beyond
-  // these are aggressively decommitted (e.g. using MADV_DONTNEED).
-  // |aggressive_decommit_on_suspend|: Whether to aggressively decommit all idle
-  // blocks when app is suspended.
-  // |allocate_with_page_alignment|: Whether fallback allocations align to page
-  // boundary. |memset_on_reclaim|: Whether to zero out fallback blocks on
-  // reclamation. |mark_as_cold_on_reclaim|: Whether to advise MADV_COLD on
-  // reclamation.
-  BidirectionalFitDecoderBufferAllocatorStrategy(
-      size_t initial_capacity,
-      size_t allocation_increment,
-      bool enable_decommit_on_idle,
-      size_t retain_blocks,
-      size_t conservative_decommit_blocks,
-      bool aggressive_decommit_on_suspend,
-      bool allocate_with_page_alignment,
-      bool memset_on_reclaim,
-      bool mark_as_cold_on_reclaim)
-      : fallback_allocator_(enable_decommit_on_idle,
-                            allocate_with_page_alignment),
+  explicit BidirectionalFitDecoderBufferAllocatorStrategy(
+      const DecoderBufferAllocator::Strategy::ExperimentConfig& config)
+      : fallback_allocator_(config.enable_decommit_on_idle,
+                            config.allocate_with_page_alignment),
         bidirectional_fit_allocator_(&fallback_allocator_,
-                                     initial_capacity,
+                                     config.initial_capacity,
                                      kSmallAllocationThreshold,
-                                     allocation_increment,
-                                     enable_decommit_on_idle,
-                                     retain_blocks,
-                                     conservative_decommit_blocks,
-                                     aggressive_decommit_on_suspend,
-                                     memset_on_reclaim,
-                                     mark_as_cold_on_reclaim) {}
+                                     config.allocation_increment,
+                                     config.enable_decommit_on_idle,
+                                     config.retain_blocks,
+                                     config.conservative_decommit_blocks,
+                                     config.aggressive_decommit_on_suspend,
+                                     config.memset_on_reclaim,
+                                     config.mark_as_cold_on_reclaim) {}
 
   void* Allocate(DemuxerStream::Type type, size_t size) override {
     return bidirectional_fit_allocator_.Allocate(size);

--- a/media/starboard/decoder_buffer_allocator.cc
+++ b/media/starboard/decoder_buffer_allocator.cc
@@ -317,22 +317,24 @@ base::expected<void, std::string> DecoderBufferAllocator::SetSetting(
     uint32_t unsigned_value = static_cast<uint32_t>(value);
     uint32_t flags = unsigned_value >> 24;
 
+    size_t block_size_mb = (unsigned_value >> 16) & 0xFF;
+
+    Strategy::ExperimentConfig strategy_config;
+    strategy_config.initial_capacity = block_size_mb * 1024 * 1024;
+    strategy_config.allocation_increment = block_size_mb * 1024 * 1024;
+    strategy_config.enable_decommit_on_idle = true;
+    strategy_config.retain_blocks = (unsigned_value >> 8) & 0xFF;
+    strategy_config.conservative_decommit_blocks = unsigned_value & 0xFF;
+    strategy_config.aggressive_decommit_on_suspend = (flags & 0x04) != 0;
+    strategy_config.allocate_with_page_alignment = (flags & 0x02) != 0;
+    strategy_config.memset_on_reclaim = (flags & 0x08) != 0;
+    strategy_config.mark_as_cold_on_reclaim = (flags & 0x10) != 0;
+
     bool enable_decommit_on_suspend = (flags & 0x01) != 0;
-    bool allocate_with_page_alignment = (flags & 0x02) != 0;
-    bool aggressive_decommit_on_suspend = (flags & 0x04) != 0;
-    bool memset_on_reclaim = (flags & 0x08) != 0;
-    bool mark_as_cold_on_reclaim = (flags & 0x10) != 0;
     bool periodic_decommit = (flags & 0x20) != 0;
 
-    int block_size_mb = (unsigned_value >> 16) & 0xFF;
-    int retain_blocks = (unsigned_value >> 8) & 0xFF;
-    int conservative_decommit_blocks = unsigned_value & 0xFF;
-
     EnableConfigurableDecommitStrategy(
-        block_size_mb * 1024 * 1024, retain_blocks,
-        conservative_decommit_blocks, enable_decommit_on_suspend,
-        allocate_with_page_alignment, aggressive_decommit_on_suspend,
-        memset_on_reclaim, mark_as_cold_on_reclaim, periodic_decommit);
+        strategy_config, enable_decommit_on_suspend, periodic_decommit);
     return base::ok();
   }
   if (name == "DecoderBuffer.EnableMediaBufferPoolAllocatorStrategy") {
@@ -360,27 +362,21 @@ void DecoderBufferAllocator::OnPeriodicDecommitTask(
 
 // static
 void DecoderBufferAllocator::EnableConfigurableDecommitStrategy(
-    int block_size,
-    int retain_blocks,
-    int conservative_decommit_blocks,
+    Strategy::ExperimentConfig strategy_config,
     bool enable_decommit_on_suspend,
-    bool allocate_with_page_alignment,
-    bool aggressive_decommit_on_suspend,
-    bool memset_on_reclaim,
-    bool mark_as_cold_on_reclaim,
     bool periodic_decommit) {
   auto* allocator = Get();
   CHECK(allocator);
   // Checking MADV_COLD support directly here simplifies experimental setup
   // without adding extra platform abstraction layers.
 #if !defined(MADV_COLD)
-  if (mark_as_cold_on_reclaim) {
+  if (strategy_config.mark_as_cold_on_reclaim) {
     LOG(INFO) << "mark_as_cold_on_reclaim is set, but MADV_COLD is not "
                  "defined. Resetting mark_as_cold_on_reclaim to false.";
-    mark_as_cold_on_reclaim = false;
+    strategy_config.mark_as_cold_on_reclaim = false;
   }
 #endif  // !defined(MADV_COLD)
-  if (aggressive_decommit_on_suspend) {
+  if (strategy_config.aggressive_decommit_on_suspend) {
     enable_decommit_on_suspend = true;
   }
   if (enable_decommit_on_suspend) {
@@ -393,10 +389,8 @@ void DecoderBufferAllocator::EnableConfigurableDecommitStrategy(
     allocator->EnablePeriodicDecommitLoop();
   }
   allocator->UpdateAllocatorStrategy(base::BindRepeating(
-      [](int block_size, int retain_blocks, int conservative_decommit_blocks,
-         bool enable_decommit_on_suspend, bool allocate_with_page_alignment,
-         bool aggressive_decommit_on_suspend, bool memset_on_reclaim,
-         bool mark_as_cold_on_reclaim, bool periodic_decommit,
+      [](const Strategy::ExperimentConfig& strategy_config,
+         bool enable_decommit_on_suspend, bool periodic_decommit,
          int initial_capacity, int allocation_unit)
           -> std::unique_ptr<DecoderBufferAllocator::Strategy> {
         LOG(INFO)
@@ -405,30 +399,27 @@ void DecoderBufferAllocator::EnableConfigurableDecommitStrategy(
             << "initial_capacity (" << initial_capacity
             << ") and allocation_unit (" << allocation_unit
             << ") are ignored. Using "
-            << "block_size: " << block_size << ", "
-            << "retain_blocks: " << retain_blocks << ", "
-            << "conservative_decommit_blocks: " << conservative_decommit_blocks
+            << "initial_capacity: " << strategy_config.initial_capacity << ", "
+            << "allocation_increment: " << strategy_config.allocation_increment
+            << ", "
+            << "retain_blocks: " << strategy_config.retain_blocks << ", "
+            << "conservative_decommit_blocks: "
+            << strategy_config.conservative_decommit_blocks
             << ", enable_decommit_on_suspend: "
             << ToString(enable_decommit_on_suspend)
             << ", allocate_with_page_alignment: "
-            << ToString(allocate_with_page_alignment)
+            << ToString(strategy_config.allocate_with_page_alignment)
             << ", aggressive_decommit_on_suspend: "
-            << ToString(aggressive_decommit_on_suspend)
-            << ", memset_on_reclaim: " << ToString(memset_on_reclaim)
+            << ToString(strategy_config.aggressive_decommit_on_suspend)
+            << ", memset_on_reclaim: "
+            << ToString(strategy_config.memset_on_reclaim)
             << ", mark_as_cold_on_reclaim: "
-            << ToString(mark_as_cold_on_reclaim)
+            << ToString(strategy_config.mark_as_cold_on_reclaim)
             << ", periodic_decommit: " << ToString(periodic_decommit);
 
-        return std::make_unique<DefaultReuseAllocatorStrategy>(
-            block_size, block_size, /*enable_decommit_on_idle=*/true,
-            retain_blocks, conservative_decommit_blocks,
-            aggressive_decommit_on_suspend, allocate_with_page_alignment,
-            memset_on_reclaim, mark_as_cold_on_reclaim);
+        return std::make_unique<DefaultReuseAllocatorStrategy>(strategy_config);
       },
-      block_size, retain_blocks, conservative_decommit_blocks,
-      enable_decommit_on_suspend, allocate_with_page_alignment,
-      aggressive_decommit_on_suspend, memset_on_reclaim,
-      mark_as_cold_on_reclaim, periodic_decommit));
+      strategy_config, enable_decommit_on_suspend, periodic_decommit));
 }
 
 // static

--- a/media/starboard/decoder_buffer_allocator.h
+++ b/media/starboard/decoder_buffer_allocator.h
@@ -16,6 +16,7 @@
 #define MEDIA_STARBOARD_DECODER_BUFFER_ALLOCATOR_H_
 
 #include <atomic>
+#include <cstddef>
 #include <memory>
 #include <sstream>
 #include <string>
@@ -46,6 +47,31 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   // mutex.
   class Strategy {
    public:
+    // Temporary configuration structure for experimental strategy parameters,
+    // allowing strategies to selectively adopt these settings.
+    struct ExperimentConfig {
+      // The initial capacity of the memory pool.
+      size_t initial_capacity = 0;
+      // The fallback allocation increment.
+      size_t allocation_increment = 0;
+      // Whether to perform any decommits when idle.
+      bool enable_decommit_on_idle = false;
+      // Number of blocks to keep fully committed when idle.
+      size_t retain_blocks = 0;
+      // Number of blocks beyond retain blocks to lazily decommit (e.g. using
+      // MADV_FREE if supported). Any blocks beyond these are aggressively
+      // decommitted (e.g. using MADV_DONTNEED).
+      size_t conservative_decommit_blocks = 0;
+      // Whether to aggressively decommit all idle blocks when app is suspended.
+      bool aggressive_decommit_on_suspend = false;
+      // Whether fallback allocations align to page boundary.
+      bool allocate_with_page_alignment = false;
+      // Whether to zero out fallback blocks on reclamation.
+      bool memset_on_reclaim = false;
+      // Whether to advise MADV_COLD on reclamation.
+      bool mark_as_cold_on_reclaim = false;
+    };
+
     virtual ~Strategy() {}
     virtual void* Allocate(DemuxerStream::Type type, size_t size) = 0;
     virtual void Free(DemuxerStream::Type type, void* p) = 0;
@@ -135,14 +161,8 @@ class DecoderBufferAllocator : public DecoderBuffer::Allocator,
   // Utility functions for h5vcc settings.
   // TODO(b/460292554): To be deprecated with h5vcc settings.
   static void EnableConfigurableDecommitStrategy(
-      int block_size,
-      int retain_blocks,
-      int conservative_decommit_blocks,
+      Strategy::ExperimentConfig strategy_config,
       bool enable_decommit_on_suspend,
-      bool allocate_with_page_alignment,
-      bool aggressive_decommit_on_suspend,
-      bool memset_on_reclaim,
-      bool mark_as_cold_on_reclaim,
       bool periodic_decommit);
   static void EnableMediaBufferPoolStrategy();
   static void EnableReleaseIdleMemory();


### PR DESCRIPTION
Refactor EnableConfigurableDecommitStrategy to use a nested Strategy::ExperimentConfig struct, reducing the number of boolean parameters and improving readability.

Bug: 454441375