### PR TITLE
android: Disable PiP support for 3P builds

### DIFF
--- a/cobalt/android/BUILD.gn
+++ b/cobalt/android/BUILD.gn
@@ -79,8 +79,6 @@ android_library("cobalt_main_java") {
     "//cobalt/shell/android:cobalt_shell_java_resources",
     "//cobalt/shell/android:cobalt_shell_jni_headers",
     "//components/embedder_support/android:view_java",
-    "//components/thin_webview:factory_java",
-    "//components/thin_webview:java",
     "//content/public/android:content_java",
     "//media/capture/video/android:capture_java",
     "//net/android:net_java",
@@ -234,9 +232,11 @@ android_library("cobalt_apk_java") {
 
   deps = [
     ":cobalt_main_java",
-    ":cobalt_pip_java",
     "//base:base_java",
   ]
+  if (is_android && !is_androidtv) {
+    deps += [ ":cobalt_pip_java" ]
+  }
 
   sources = [
     "apk/app/src/app/java/dev/cobalt/app/CobaltApplication.java",

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -43,7 +43,7 @@ source_set("browser") {
     ]
   }
 
-  if (is_android) {
+  if (is_android && !is_androidtv) {
     sources += [
       "android/overlay/cobalt_video_overlay_window.cc",
       "android/overlay/cobalt_video_overlay_window.h",
@@ -116,12 +116,15 @@ source_set("browser") {
   if (is_android) {
     deps += [
       "//cobalt/android:jni_headers",
-      "//cobalt/android:pip_jni_headers",
       "//components/embedder_support/android:web_contents_delegate",
       "//components/thin_webview",
       "//components/thin_webview/internal",
       "//ui/android",
     ]
+  }
+
+  if (is_android && !is_androidtv) {
+    deps += [ "//cobalt/android:pip_jni_headers" ]
   }
 
   if (is_androidtv) {

--- a/cobalt/browser/cobalt_content_browser_client.cc
+++ b/cobalt/browser/cobalt_content_browser_client.cc
@@ -288,11 +288,11 @@ CobaltContentBrowserClient::CreateWindowForVideoPictureInPicture(
   // TODO: b/532158001 - Support PiP on Linux.
   // PiP is currently only supported on Android. On other platforms, calling
   // Create() allocates a dummy object that leaks memory, so we return nullptr.
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_ANDROIDTV)
   return content::VideoOverlayWindow::Create(controller);
-#else   // BUILDFLAG(IS_ANDROID)
+#else   // BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_ANDROIDTV)
   return nullptr;
-#endif  // BUILDFLAG(IS_ANDROID)
+#endif  // BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_ANDROIDTV)
 }
 
 std::unique_ptr<content::BrowserMainParts>

--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -71,11 +71,11 @@ BASE_FEATURE(kForceVideoSplashScreen,
 
 BASE_FEATURE(kEnablePictureInPicture,
              "PictureInPicture",
-#if BUILDFLAG(IS_ANDROID)
+#if BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_ANDROIDTV)
              base::FEATURE_ENABLED_BY_DEFAULT
-#else   // BUILDFLAG(IS_ANDROID)
+#else   // BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_ANDROIDTV)
              base::FEATURE_DISABLED_BY_DEFAULT
-#endif  // BUILDFLAG(IS_ANDROID)
+#endif  // BUILDFLAG(IS_ANDROID) && !BUILDFLAG(IS_ANDROIDTV)
 );
 
 }  // namespace features

--- a/starboard/build/config/starboard_executable.gni
+++ b/starboard/build/config/starboard_executable.gni
@@ -33,6 +33,7 @@ template("starboard_executable") {
         "//cobalt/aosp:cobalt_apk_java",
       ]
       remove_uncalled_jni = true
+      add_stubs_for_missing_jni = true
 
       configs -= [ "//build/config/android:hide_all_but_jni_onload" ]
       configs += [ "//build/config/android:hide_all_but_jni" ]

--- a/third_party/android_sdk/BUILD.gn
+++ b/third_party/android_sdk/BUILD.gn
@@ -74,7 +74,7 @@ if (enable_java_templates) {
       jar_deps = [ "//third_party/android_sdk/window_extensions:androidx_window_extensions" ]
       deps =
           [ "//third_party/androidx:androidx_annotation_annotation_jvm_java" ]
-      input_jars_paths = [ "$root_build_dir/obj/third_party/android_sdk/window_extensions/androidx_window_extensions_java.turbine.jar" ]
+      input_jars_paths = [ "$root_out_dir/obj/third_party/android_sdk/window_extensions/androidx_window_extensions_java.turbine.jar" ]
     }
   }
 }

--- a/third_party/blink/public/mojom/BUILD.gn
+++ b/third_party/blink/public/mojom/BUILD.gn
@@ -1190,7 +1190,7 @@ mojom("android_mojo_bindings") {
   # generating the snapshot for android, blink is compiled with
   # current_os="linux" and target_os="android". Using target_os is necessary as
   # we need to compile in the same way as would happen when current_os="android".
-  if (target_os_is_android) {
+  if (is_android) {
     sources += [ "remote_objects/remote_objects.mojom" ]
 
     # Direct deps (instead of transitive deps) are necessary for java targets.


### PR DESCRIPTION
Modify build configurations and feature flags to disable
Picture-in-Picture (PiP) support for 3P partner (AOSP) builds.
PiP-related dependencies, source files, and JNI headers are now
conditionally included only for 1P Android builds. This change
resolves AOSP check errors on partner builds.

Issue: 445194225