### PR TITLE
starboard: Disable LessAggressiveParkableString default

### DIFF
--- a/cobalt/app/cobalt_switch_defaults_starboard.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard.cc
@@ -87,7 +87,8 @@ const base::CommandLine::SwitchMap&
 CommandLinePreprocessor::GetCobaltParamSwitchDefaults() {
   static const base::CommandLine::SwitchMap kCobaltSwitchDefaults{
       // Disable Vulkan.
-      {::switches::kDisableFeatures, "Vulkan,MemoryCacheStrongReference"},
+      {::switches::kDisableFeatures,
+       "Vulkan,MemoryCacheStrongReference,LessAggressiveParkableString"},
       {::switches::kEnableFeatures,
        "LimitImageDecodeCacheSize:mb/24, "
        // When DefaultEnableANGLEValidation is disabled (e.g gold/qa), EGL

--- a/cobalt/app/cobalt_switch_defaults_starboard_test.cc
+++ b/cobalt/app/cobalt_switch_defaults_starboard_test.cc
@@ -54,7 +54,8 @@ TEST(CobaltSwitchDefaultsTest, MergeDisabledFeatures) {
   std::string disabled_features =
       GetSwitchValue(cmd_line_pxr, ::switches::kDisableFeatures);
   EXPECT_EQ(
-      std::string("PersistentOriginTrials,Vulkan,MemoryCacheStrongReference"),
+      std::string("PersistentOriginTrials,Vulkan,MemoryCacheStrongReference,"
+                  "LessAggressiveParkableString"),
       disabled_features);
 }
 


### PR DESCRIPTION
## Summary
Disable the `LessAggressiveParkableString` feature flag by default on Starboard platforms in `CommandLinePreprocessor::GetCobaltParamSwitchDefaults()`.

## Rationale & Details
Disabling `LessAggressiveParkableString` enables standard, more aggressive string compression and parking in Blink, yielding significant memory savings across private dirty memory, total resident memory, and CMA allocations during browsing and video playback on memory-constrained Starboard/TV devices.

Bug: b/545763186

---

## Benchmark Results (RDKLabs.tv)
A 5-run A/B comparison suite was executed on RDKLabs against the latest nightly build (`27.lts_20260811`):
- **Suite Dashboard:** https://rdklabs.tv/suites/suite-3905586d-6377-48fd-9476-371c088db482/visualization
- **Validation Instance 2:** https://rdklabs.tv/suites/suite-6e566cf5-31b9-4d90-8659-5ec26962f927/visualization

### Memory Delta Summary

| Benchmark Routine | Experiment Link | Private Dirty Delta | Total Resident Delta | CMA Delta | JS Heap Used Delta |
| :--- | :--- | :---: | :---: | :---: | :---: |
| **`browseBenchmark`** | [exp-512dc05a](https://rdklabs.tv/experiments/exp-512dc05a-03b2-4abe-a5c2-6f5fa60fb951/visualization) | **-3.29 MB (-1.9%)** (Max: **-7.90 MB**) | **-3.57 MB (-1.6%)** (Max: **-5.35 MB**) | **-23.38 MB (-5.6%)** (Max: **-28.84 MB**) | **-0.27 MB (-1.9%)** (Max: **-0.67 MB**) |
| **`watchBenchmark1080p`** | [exp-3729bb6b](https://rdklabs.tv/experiments/exp-3729bb6b-797b-4fb9-82a8-59cead9d65e7/visualization) | **-4.54 MB (-2.5%)** | **-4.30 MB (-1.8%)** | **-23.13 MB (-4.8%)** (Max: **-23.88 MB**) | Parity |
| **`shortsBenchmark`** | [exp-f19e1359](https://rdklabs.tv/experiments/exp-f19e1359-dae5-4da4-a192-cdd6336ead2c/visualization) | **-1.98 MB (-1.1%)** | **-1.88 MB (-0.8%)** | **-16.59 MB (-3.5%)** (Max: **-15.93 MB**) | **-0.05 MB** (Max: **-0.64 MB**) |
| **`browseWatchBenchmark`** | [exp-23dd77b3](https://rdklabs.tv/experiments/exp-23dd77b3-3e8d-45c8-b243-a8536476ce7c/visualization) | **-1.26 MB (-0.7%)** (Max: **-1.33 MB**) | **-0.69 MB (-0.3%)** (Max: **-0.78 MB**) | **-23.40 MB (-4.9%)** (Max: **-24.52 MB**) | **-0.22 MB (-1.4%)** |
| **`watchBenchmark4k`** | [exp-a7736ab7](https://rdklabs.tv/experiments/exp-a7736ab7-42ef-4b4b-a296-465f454b28ac/visualization) | Parity (+0.3%) | Parity (+0.3%) | Parity (-0.04 MB) | Parity |

0 regressions across 55 total job runs.
