### PR TITLE
media: Skip MojoDemuxerStream on bypass bridge

### DIFF
--- a/media/mojo/clients/starboard/starboard_renderer_client.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client.cc
@@ -18,6 +18,7 @@
 
 #include "base/feature_list.h"
 #include "base/functional/bind.h"
+#include "base/no_destructor.h"
 #include "base/time/time.h"
 #include "base/unguessable_token.h"
 #include "build/build_config.h"
@@ -26,6 +27,7 @@
 #include "media/base/media_switches.h"
 #include "media/base/video_frame.h"
 #include "media/mojo/clients/mojo_renderer.h"
+#include "media/mojo/common/starboard/empty_media_resource.h"
 #include "media/renderers/video_overlay_factory.h"
 #include "media/video/gpu_video_accelerator_factories.h"
 #include "mojo/public/cpp/bindings/callback_helpers.h"
@@ -437,7 +439,10 @@ void StarboardRendererClient::OnExtensionBypassInitialized(
     }
     return;
   }
-  MojoRendererWrapper::Initialize(media_resource, client, std::move(init_cb));
+  static base::NoDestructor<EmptyMediaResource> empty_media_resource;
+  MojoRendererWrapper::Initialize(
+      bypass_bridge_ ? empty_media_resource.get() : media_resource, client,
+      std::move(init_cb));
 }
 
 void StarboardRendererClient::InitAndConstructMojoRenderer(

--- a/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
+++ b/media/mojo/clients/starboard/starboard_renderer_client_unittest.cc
@@ -52,17 +52,24 @@ namespace {
 struct FakeMojomRendererCallRecord {
   bool initialize_with_bypass_bridge_called = false;
   uint32_t last_bypass_bridge_id = 0;
+  std::optional<size_t> last_stream_count;
 };
 
 class FakeMojomRenderer : public mojom::Renderer {
  public:
-  FakeMojomRenderer() = default;
+  explicit FakeMojomRenderer(FakeMojomRendererCallRecord* record = nullptr)
+      : record_(record) {}
   ~FakeMojomRenderer() override = default;
 
   void Initialize(
       mojo::PendingAssociatedRemote<mojom::RendererClient>,
-      std::optional<std::vector<mojo::PendingRemote<mojom::DemuxerStream>>>,
+      std::optional<std::vector<mojo::PendingRemote<mojom::DemuxerStream>>>
+          streams,
       InitializeCallback cb) override {
+    if (record_) {
+      record_->last_stream_count =
+          streams ? std::make_optional(streams->size()) : std::nullopt;
+    }
     std::move(cb).Run(true);
   }
   MOCK_METHOD1(Flush, void(FlushCallback));
@@ -73,6 +80,9 @@ class FakeMojomRenderer : public mojom::Renderer {
                void(const std::optional<base::UnguessableToken>&,
                     SetCdmCallback));
   void SetLatencyHint(std::optional<::base::TimeDelta> latency_hint) override {}
+
+ private:
+  FakeMojomRendererCallRecord* record_ = nullptr;
 };
 
 class FakeStarboardRendererExtension
@@ -158,7 +168,7 @@ class StarboardRendererClientTest : public ::testing::Test {
                                          bool bypass_mojo_for_media = false) {
     mojo::PendingRemote<mojom::Renderer> renderer_remote;
     mojo::MakeSelfOwnedReceiver(
-        std::make_unique<FakeMojomRenderer>(),
+        std::make_unique<FakeMojomRenderer>(&fake_mojom_renderer_record_),
         renderer_remote.InitWithNewPipeAndPassReceiver());
 
     mojo::PendingRemote<mojom::StarboardRendererExtension>
@@ -218,6 +228,7 @@ TEST_F(StarboardRendererClientTest, InitializeWithGpuFactories) {
   starboard_renderer_client_->UpdateStarboardRenderingMode(
       StarboardRenderingMode::kPunchOut);
   task_environment_.RunUntilIdle();
+  EXPECT_GT(fake_mojom_renderer_record_.last_stream_count.value_or(0), 0u);
 }
 
 TEST_F(StarboardRendererClientTest, InitializeWithoutGpuFactories) {
@@ -305,6 +316,8 @@ TEST_F(StarboardRendererClientTest, InitializeWithBypassBridge) {
   task_environment_.RunUntilIdle();
 
   EXPECT_TRUE(fake_mojom_renderer_record_.initialize_with_bypass_bridge_called);
+  EXPECT_EQ(fake_mojom_renderer_record_.last_stream_count,
+            std::optional<size_t>(0));
   uint32_t bridge_id = fake_mojom_renderer_record_.last_bypass_bridge_id;
   EXPECT_NE(bridge_id, 0u);
 

--- a/media/mojo/common/BUILD.gn
+++ b/media/mojo/common/BUILD.gn
@@ -27,6 +27,7 @@ source_set("common") {
 
   if (is_cobalt && use_starboard_media) {
     sources += [
+      "starboard/empty_media_resource.h",
       "starboard/mojo_renderer_bypass_bridge.cc",
       "starboard/mojo_renderer_bypass_bridge.h",
     ]

--- a/media/mojo/common/starboard/empty_media_resource.h
+++ b/media/mojo/common/starboard/empty_media_resource.h
@@ -1,0 +1,47 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MEDIA_MOJO_COMMON_STARBOARD_EMPTY_MEDIA_RESOURCE_H_
+#define MEDIA_MOJO_COMMON_STARBOARD_EMPTY_MEDIA_RESOURCE_H_
+
+#include <vector>
+
+#include "media/base/demuxer_stream.h"
+#include "media/base/media_resource.h"
+
+namespace media {
+
+// Empty media resource passed to MojoRenderer or MojoRendererService to avoid
+// creating unused MojoDemuxerStreamImpl / MediaResourceShim instances and
+// message pipes when the bypass bridge is active.
+//
+// Lifetime and Ownership:
+// This class can be instantiated as a global static (e.g., base::NoDestructor)
+// or owned via std::unique_ptr<MediaResource>. When passed to a Renderer, its
+// lifetime must match or exceed the lifetime of the Renderer.
+//
+// Threading Model:
+// This class is stateless and thread-safe, and its methods can be safely
+// called from any thread.
+class EmptyMediaResource : public MediaResource {
+ public:
+  EmptyMediaResource() = default;
+  ~EmptyMediaResource() override = default;
+
+  std::vector<DemuxerStream*> GetAllStreams() override { return {}; }
+};
+
+}  // namespace media
+
+#endif  // MEDIA_MOJO_COMMON_STARBOARD_EMPTY_MEDIA_RESOURCE_H_

--- a/media/mojo/services/mojo_renderer_service.cc
+++ b/media/mojo/services/mojo_renderer_service.cc
@@ -18,6 +18,7 @@
 #include "media/mojo/services/mojo_cdm_service_context.h"
 
 #if BUILDFLAG(USE_STARBOARD_MEDIA)
+#include "media/mojo/common/starboard/empty_media_resource.h"
 #include "media/mojo/services/starboard/starboard_renderer_wrapper.h"
 #endif
 
@@ -66,6 +67,17 @@ void MojoRendererService::Initialize(
 
   client_.Bind(std::move(client));
   state_ = STATE_INITIALIZING;
+
+#if BUILDFLAG(USE_STARBOARD_MEDIA)
+  if (streams.has_value() && streams->empty()) {
+    media_resource_ = std::make_unique<EmptyMediaResource>();
+    renderer_->Initialize(
+        media_resource_.get(), this,
+        base::BindOnce(&MojoRendererService::OnRendererInitializeDone,
+                       weak_this_, std::move(callback)));
+    return;
+  }
+#endif  // BUILDFLAG(USE_STARBOARD_MEDIA)
 
   DCHECK(streams.has_value());
   media_resource_ = std::make_unique<MediaResourceShim>(


### PR DESCRIPTION
When the Starboard bypass bridge is active, the Mojo renderer does not
require media streams to be piped through Mojo. Previously, these
streams and their associated message pipes were still being created,
leading to unnecessary resource allocation.

This change introduces an empty media resource for use when the bypass
bridge is enabled. This avoids the creation of unused
MojoDemuxerStream instances and their corresponding Mojo message pipes,
reducing overhead during initialization.

Issue: 513254071