### PR TITLE
starboard/android: Refactor ResetConfig and log enable_flush_during_seek in decoders

### DIFF
--- a/starboard/android/shared/media_codec_audio_decoder.cc
+++ b/starboard/android/shared/media_codec_audio_decoder.cc
@@ -21,6 +21,8 @@
 #include "starboard/audio_sink.h"
 #include "starboard/common/check_op.h"
 #include "starboard/common/log.h"
+#include "starboard/common/media.h"
+#include "starboard/common/string.h"
 #include "third_party/jni_zero/jni_zero.h"
 
 // Can be locally set to |1| for verbose audio decoding.  Verbose audio
@@ -104,6 +106,11 @@ MediaCodecAudioDecoder::MediaCodecAudioDecoder(
   if (!result) {
     *error_message = result.error();
   }
+
+  SB_LOG(INFO) << "Created AudioDecoder for codec="
+               << GetMediaAudioCodecName(audio_stream_info_.codec)
+               << ", enable_flush_during_seek="
+               << ToString(enable_flush_during_seek_);
 }
 
 MediaCodecAudioDecoder::~MediaCodecAudioDecoder() {}

--- a/starboard/android/shared/media_codec_video_decoder.cc
+++ b/starboard/android/shared/media_codec_video_decoder.cc
@@ -269,15 +269,23 @@ class MediaCodecVideoDecoder::Sink : public VideoRendererSink {
   bool rendered_;
 };
 
+std::ostream& operator<<(std::ostream& os,
+                         const MediaCodecVideoDecoder::ResetConfig& config) {
+  return os << "{enable_flush_during_seek="
+            << ToString(config.enable_flush_during_seek)
+            << ", reset_delay_usec=" << config.reset_delay_usec
+            << ", flush_delay_usec=" << config.flush_delay_usec << "}";
+}
+
 NonNullResult<std::unique_ptr<MediaCodecVideoDecoder>>
 MediaCodecVideoDecoder::Create(JobQueue* job_queue,
                                const StreamConfig& stream_config,
                                const TunnelModeConfig& tunnel_mode_config,
                                const PipelineConfig& pipeline_config,
-                               const PlatformOptions& platform_options) {
+                               const ResetConfig& reset_config) {
   auto default_factory = std::make_unique<DefaultMediaCodecFactory>();
   return CreateInternal(std::move(default_factory), job_queue, stream_config,
-                        tunnel_mode_config, pipeline_config, platform_options);
+                        tunnel_mode_config, pipeline_config, reset_config);
 }
 
 // static
@@ -288,11 +296,11 @@ MediaCodecVideoDecoder::CreateForTesting(
     const StreamConfig& stream_config,
     const TunnelModeConfig& tunnel_mode_config,
     const PipelineConfig& pipeline_config,
-    const PlatformOptions& platform_options) {
+    const ResetConfig& reset_config) {
   SB_CHECK(media_codec_factory);
   return CreateInternal(std::move(media_codec_factory), job_queue,
                         stream_config, tunnel_mode_config, pipeline_config,
-                        platform_options);
+                        reset_config);
 }
 
 // static
@@ -303,12 +311,12 @@ MediaCodecVideoDecoder::CreateInternal(
     const StreamConfig& stream_config,
     const TunnelModeConfig& tunnel_mode_config,
     const PipelineConfig& pipeline_config,
-    const PlatformOptions& platform_options) {
+    const ResetConfig& reset_config) {
   std::string error_message;
   auto video_decoder = std::make_unique<MediaCodecVideoDecoder>(
       PassKey<MediaCodecVideoDecoder>(), std::move(media_codec_factory),
       job_queue, stream_config, tunnel_mode_config, pipeline_config,
-      platform_options, &error_message);
+      reset_config, &error_message);
 
   if (!error_message.empty()) {
     return Failure(error_message);
@@ -332,7 +340,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
     const StreamConfig& stream_config,
     const TunnelModeConfig& tunnel_mode_config,
     const PipelineConfig& pipeline_config,
-    const PlatformOptions& platform_options,
+    const ResetConfig& reset_config,
     std::string* error_message)
     : JobOwner(job_queue),
       video_codec_(stream_config.video_stream_info.codec),
@@ -344,7 +352,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
       require_software_codec_(
           IsSoftwareDecoderRequired(stream_config.max_video_capabilities)),
       force_big_endian_hdr_metadata_(
-          platform_options.force_big_endian_hdr_metadata),
+          pipeline_config.force_big_endian_hdr_metadata),
       tunnel_mode_audio_session_id_(tunnel_mode_config.audio_session_id),
       max_video_input_size_(pipeline_config.max_input_size),
       use_dual_threads_(pipeline_config.use_dual_threads),
@@ -353,13 +361,7 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
                               jni_zero::AttachCurrentThread(),
                               static_cast<jobject>(stream_config.surface_view))
                         : nullptr),
-      enable_flush_during_seek_(pipeline_config.enable_flush_during_seek),
-      reset_delay_usec_(android_get_device_api_level() < 34
-                            ? platform_options.reset_delay_usec
-                            : 0),
-      flush_delay_usec_(android_get_device_api_level() < 34
-                            ? platform_options.flush_delay_usec
-                            : 0),
+      reset_config_(reset_config),
       skip_flush_on_decoder_teardown_(
           pipeline_config.experimental_features.GetBool(
               kMediaSkipFlushOnDecoderTeardown)),
@@ -442,7 +444,8 @@ MediaCodecVideoDecoder::MediaCodecVideoDecoder(
                << "\", tunnel mode audio session id="
                << ToString(tunnel_mode_audio_session_id_)
                << ", is_video_frame_tracker_enabled="
-               << ToString(is_video_frame_tracker_enabled_);
+               << ToString(is_video_frame_tracker_enabled_)
+               << ", reset_config=" << reset_config_;
 }
 
 MediaCodecVideoDecoder::~MediaCodecVideoDecoder() {
@@ -869,8 +872,9 @@ Result<void> MediaCodecVideoDecoder::InitializeCodec(
       std::bind(&MediaCodecVideoDecoder::OnFrameRendered, this, _1),
       std::bind(&MediaCodecVideoDecoder::OnFirstTunnelFrameReady, this),
       tunnel_mode_audio_session_id_, is_video_frame_tracker_enabled_,
-      force_big_endian_hdr_metadata_, max_video_input_size_, flush_delay_usec_,
-      use_dual_threads_, skip_video_frames_over_60_fps_,
+      force_big_endian_hdr_metadata_, max_video_input_size_,
+      reset_config_.flush_delay_usec, use_dual_threads_,
+      skip_video_frames_over_60_fps_,
       ignore_mediacodec_callbacks_during_flushing_, enable_ndk_video_,
       enable_trivial_optimizations_);
   if (result) {
@@ -1210,11 +1214,11 @@ void MediaCodecVideoDecoder::ResetInternal(bool skip_flush) {
   // re-create |media_decoder_|. If |needs_fps_to_initialize_codec_| is true,
   // set video_fps_ to 0 will call InitializeCodec(),
   // which we do not need if flush the codec.
-  if (!enable_flush_during_seek_ || skip_flush || !media_decoder_ ||
-      !media_decoder_->Flush()) {
+  if (!reset_config_.enable_flush_during_seek || skip_flush ||
+      !media_decoder_ || !media_decoder_->Flush()) {
     TeardownCodec();
-    if (reset_delay_usec_ > 0) {
-      usleep(reset_delay_usec_);
+    if (reset_config_.reset_delay_usec > 0) {
+      usleep(reset_config_.reset_delay_usec);
     }
 
     // Note that |input_buffer_written_| may not be strictly accurate after

--- a/starboard/android/shared/media_codec_video_decoder.h
+++ b/starboard/android/shared/media_codec_video_decoder.h
@@ -74,13 +74,13 @@ class MediaCodecVideoDecoder : public VideoDecoder,
 
   struct PipelineConfig {
     int max_input_size = 0;
-    bool enable_flush_during_seek = false;
+    bool force_big_endian_hdr_metadata = false;
     bool use_dual_threads = true;
     ExperimentalFeatures experimental_features;
   };
 
-  struct PlatformOptions {
-    bool force_big_endian_hdr_metadata = false;
+  struct ResetConfig {
+    bool enable_flush_during_seek = false;
     int64_t reset_delay_usec = 0;
     int64_t flush_delay_usec = 0;
   };
@@ -92,7 +92,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
       const StreamConfig& stream_config,
       const TunnelModeConfig& tunnel_mode_config,
       const PipelineConfig& pipeline_config,
-      const PlatformOptions& platform_options);
+      const ResetConfig& reset_config);
 
   static NonNullResult<std::unique_ptr<MediaCodecVideoDecoder>>
   CreateForTesting(std::unique_ptr<MediaCodec::Factory> media_codec_factory,
@@ -100,7 +100,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
                    const StreamConfig& stream_config,
                    const TunnelModeConfig& tunnel_mode_config,
                    const PipelineConfig& pipeline_config,
-                   const PlatformOptions& platform_options);
+                   const ResetConfig& reset_config);
 
   static void SetVideoFramePoolEnabled(bool enabled);
 
@@ -111,7 +111,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
       const StreamConfig& stream_config,
       const TunnelModeConfig& tunnel_mode_config,
       const PipelineConfig& pipeline_config,
-      const PlatformOptions& platform_options,
+      const ResetConfig& reset_config,
       std::string* error_message);
 
   ~MediaCodecVideoDecoder() override;
@@ -202,9 +202,7 @@ class MediaCodecVideoDecoder : public VideoDecoder,
   // SurfaceView from AndroidOverlay passed from StarboardRenderer to SbPlayer.
   jni_zero::ScopedJavaGlobalRef<jobject> surface_view_;
 
-  const bool enable_flush_during_seek_;
-  const int64_t reset_delay_usec_;
-  const int64_t flush_delay_usec_;
+  const ResetConfig reset_config_;
   const bool skip_flush_on_decoder_teardown_;
 
   // Codec initialization will be delayed until the decoder receives enough
@@ -297,10 +295,13 @@ class MediaCodecVideoDecoder : public VideoDecoder,
       const StreamConfig& stream_config,
       const TunnelModeConfig& tunnel_mode_config,
       const PipelineConfig& pipeline_config,
-      const PlatformOptions& platform_options);
+      const ResetConfig& reset_config);
 
   const std::unique_ptr<VideoSurfaceTextureBridge> surface_texture_bridge_;
 };
+
+std::ostream& operator<<(std::ostream& os,
+                         const MediaCodecVideoDecoder::ResetConfig& config);
 
 }  // namespace starboard
 

--- a/starboard/android/shared/media_codec_video_decoder_test.cc
+++ b/starboard/android/shared/media_codec_video_decoder_test.cc
@@ -65,12 +65,12 @@ class MediaCodecVideoDecoderTest : public ::testing::Test {
     MediaCodecVideoDecoder::TunnelModeConfig tunnel_config;
     MediaCodecVideoDecoder::PipelineConfig pipeline_config;
     pipeline_config.experimental_features = std::move(experimental_features);
-    MediaCodecVideoDecoder::PlatformOptions platform_options;
+    MediaCodecVideoDecoder::ResetConfig reset_config;
 
     auto result = MediaCodecVideoDecoder::CreateForTesting(
         std::move(factory),  // Transfer ownership
         &job_queue_, stream_config, tunnel_config, pipeline_config,
-        platform_options);
+        reset_config);
 
     ASSERT_TRUE(result);
     decoder_ = std::move(result.value());

--- a/starboard/android/shared/player_components_factory.cc
+++ b/starboard/android/shared/player_components_factory.cc
@@ -390,10 +390,6 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
             video_mime_type->GetParamBoolValue("enableflushduringseek", false);
       }
     }
-    SB_LOG_IF(INFO, enable_flush_during_seek)
-        << "`kForceFlushDecoderDuringReset` is set to true, force flushing"
-        << " audio passthrough decoder during Reset().";
-
     SB_LOG(INFO) << "Creating passthrough components.";
     // TODO: Enable tunnel mode for passthrough
     auto audio_renderer = AudioRendererPassthrough::Create(
@@ -643,9 +639,12 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
     bool force_big_endian_hdr_metadata = false;
     bool enable_flush_during_seek =
         ShouldEnableFlushDuringSeek(experimental_features);
-    int64_t flush_delay_usec = features::kFlushDelayUsec.Get();
-    int64_t reset_delay_usec = features::kResetDelayUsec.Get();
-
+    int64_t flush_delay_usec = android_get_device_api_level() < 34
+                                   ? features::kFlushDelayUsec.Get()
+                                   : 0;
+    int64_t reset_delay_usec = android_get_device_api_level() < 34
+                                   ? features::kResetDelayUsec.Get()
+                                   : 0;
     if (creation_parameters.video_codec() != kSbMediaVideoCodecNone &&
         !creation_parameters.video_mime().empty()) {
       // Use mime param to determine endianness of HDR metadata. If param is
@@ -666,16 +665,6 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
       }
     }
 
-    SB_LOG_IF(INFO, enable_flush_during_seek)
-        << "`kForceFlushDecoderDuringReset` is set to true, force flushing"
-        << " video decoder during Reset().";
-    SB_LOG_IF(INFO, flush_delay_usec > 0)
-        << "`kFlushDelayUsec` is set to > 0, force a delay of "
-        << flush_delay_usec << "us during Flush().";
-    SB_LOG_IF(INFO, reset_delay_usec > 0)
-        << "`kResetDelayUsec` is set to > 0, force a delay of "
-        << reset_delay_usec << "us during Reset().";
-
     bool use_dual_threads = ShouldUseDualThreads(
         creation_parameters.audio_codec(), creation_parameters.drm_system(),
         experimental_features, force_platform_opus_decoder_);
@@ -688,9 +677,9 @@ class PlayerComponentsFactory : public PlayerComponents::Factory {
          creation_parameters.surface_view(),
          creation_parameters.max_video_capabilities()},
         {tunnel_mode_audio_session_id, force_secure_pipeline_under_tunnel_mode},
-        {max_video_input_size, enable_flush_during_seek, use_dual_threads,
+        {max_video_input_size, force_big_endian_hdr_metadata, use_dual_threads,
          experimental_features},
-        {force_big_endian_hdr_metadata, reset_delay_usec, flush_delay_usec});
+        {enable_flush_during_seek, reset_delay_usec, flush_delay_usec});
   }
 
   bool IsTunnelModeSupported(const CreationParameters& creation_parameters,


### PR DESCRIPTION
Refactor decoder reset and seek configuration into ResetConfig in MediaCodecVideoDecoder and consolidate reset delay and flush options. Move force_big_endian_hdr_metadata into PipelineConfig.

Remove misleading factory-level SB_LOG_IF messages and log enable_flush_during_seek and reset configuration directly in the MediaCodecVideoDecoder and MediaCodecAudioDecoder constructors for clearer observability.

TAG=agy
CONV=a5fc7e5c-16af-47ee-bd3d-5bc1cd1f9736