### PR TITLE
starboard: Return constexpr const char* from ToString(bool)

### DIFF
--- a/starboard/android/shared/media_codec.cc
+++ b/starboard/android/shared/media_codec.cc
@@ -116,7 +116,7 @@ DefaultMediaCodecFactory::CreateVideoMediaCodec(
   if (decoder_name.empty()) {
     return Failure(
         FormatString("Failed to find decoder: mime=%s, mustSupportSecure=%s",
-                     mime, ToString(!!j_media_crypto).data()));
+                     mime, ToString(!!j_media_crypto)));
   }
 
   if (CanUseNdkMediaCodec(platform_options, j_media_crypto, color_metadata)) {

--- a/starboard/common/string.h
+++ b/starboard/common/string.h
@@ -66,7 +66,7 @@ inline std::string ToString(const std::string& val) {
   return val;
 }
 
-inline std::string ToString(bool val) {
+constexpr const char* ToString(bool val) {
   return val ? "true" : "false";
 }
 


### PR DESCRIPTION
Modify ToString(bool) in starboard/common/string.h to return a
constexpr const char* instead of an inline std::string.

Returning a raw character pointer avoids heap allocations and
temporary string constructions when converting booleans. This
allows for compile-time evaluation and provides better
interoperability with both C-style formatters and C++ string
types.

Update the caller in MediaCodec::CreateVideoMediaCodec to reflect
the change in return type.

Issue: 545868819