### PR TITLE
android: Remove unused "disabledynamicprerollframecount" MIME parameter

### DIFF
--- a/starboard/android/shared/max_media_codec_output_buffers_lookup_table.cc
+++ b/starboard/android/shared/max_media_codec_output_buffers_lookup_table.cc
@@ -62,27 +62,16 @@ int MaxMediaCodecOutputBuffersLookupTable::GetMaxOutputVideoBuffers(
   std::lock_guard scoped_lock(mutex_);
 
   auto iter = lookup_table_.find(format);
-  if (iter == lookup_table_.end() || !enable_) {
+  if (iter == lookup_table_.end()) {
     return -1;
-  } else {
-    return iter->second;
   }
-}
-
-void MaxMediaCodecOutputBuffersLookupTable::SetEnabled(bool enable) {
-  std::lock_guard scoped_lock(mutex_);
-
-  enable_ = enable;
+  return iter->second;
 }
 
 void MaxMediaCodecOutputBuffersLookupTable::UpdateMaxOutputBuffers(
     const VideoOutputFormat& format,
     int max_num_of_frames) {
   std::lock_guard scoped_lock(mutex_);
-
-  if (!enable_) {
-    return;
-  }
 
   int max_output_buffer_record = lookup_table_[format];
   if (max_num_of_frames > max_output_buffer_record) {

--- a/starboard/android/shared/max_media_codec_output_buffers_lookup_table.cc
+++ b/starboard/android/shared/max_media_codec_output_buffers_lookup_table.cc
@@ -14,11 +14,10 @@
 
 #include "starboard/android/shared/max_media_codec_output_buffers_lookup_table.h"
 
-#include <sstream>
+#include <ostream>
 
 #include "starboard/common/log.h"
 #include "starboard/common/once.h"
-#include "starboard/common/string.h"
 
 namespace starboard {
 
@@ -62,27 +61,16 @@ int MaxMediaCodecOutputBuffersLookupTable::GetMaxOutputVideoBuffers(
   std::lock_guard scoped_lock(mutex_);
 
   auto iter = lookup_table_.find(format);
-  if (iter == lookup_table_.end() || !enable_) {
+  if (iter == lookup_table_.end()) {
     return -1;
-  } else {
-    return iter->second;
   }
-}
-
-void MaxMediaCodecOutputBuffersLookupTable::SetEnabled(bool enable) {
-  std::lock_guard scoped_lock(mutex_);
-
-  enable_ = enable;
+  return iter->second;
 }
 
 void MaxMediaCodecOutputBuffersLookupTable::UpdateMaxOutputBuffers(
     const VideoOutputFormat& format,
     int max_num_of_frames) {
   std::lock_guard scoped_lock(mutex_);
-
-  if (!enable_) {
-    return;
-  }
 
   int max_output_buffer_record = lookup_table_[format];
   if (max_num_of_frames > max_output_buffer_record) {

--- a/starboard/android/shared/max_media_codec_output_buffers_lookup_table.h
+++ b/starboard/android/shared/max_media_codec_output_buffers_lookup_table.h
@@ -50,8 +50,6 @@ class MaxMediaCodecOutputBuffersLookupTable {
 
   int GetMaxOutputVideoBuffers(const VideoOutputFormat& format) const;
 
-  void SetEnabled(bool enable);
-
   void UpdateMaxOutputBuffers(const VideoOutputFormat& format,
                               int max_num_of_frames);
 
@@ -60,8 +58,6 @@ class MaxMediaCodecOutputBuffersLookupTable {
       const MaxMediaCodecOutputBuffersLookupTable& table);
 
  private:
-  bool enable_ = true;
-
   mutable std::mutex mutex_;
   std::map<VideoOutputFormat, int> lookup_table_;
 };

--- a/starboard/android/shared/max_media_codec_output_buffers_lookup_table.h
+++ b/starboard/android/shared/max_media_codec_output_buffers_lookup_table.h
@@ -15,11 +15,9 @@
 #ifndef STARBOARD_ANDROID_SHARED_MAX_MEDIA_CODEC_OUTPUT_BUFFERS_LOOKUP_TABLE_H_
 #define STARBOARD_ANDROID_SHARED_MAX_MEDIA_CODEC_OUTPUT_BUFFERS_LOOKUP_TABLE_H_
 
-#include <functional>
 #include <iosfwd>
 #include <map>
 #include <mutex>
-#include <string>
 
 #include "starboard/common/size.h"
 #include "starboard/media.h"
@@ -50,8 +48,6 @@ class MaxMediaCodecOutputBuffersLookupTable {
 
   int GetMaxOutputVideoBuffers(const VideoOutputFormat& format) const;
 
-  void SetEnabled(bool enable);
-
   void UpdateMaxOutputBuffers(const VideoOutputFormat& format,
                               int max_num_of_frames);
 
@@ -60,8 +56,6 @@ class MaxMediaCodecOutputBuffersLookupTable {
       const MaxMediaCodecOutputBuffersLookupTable& table);
 
  private:
-  bool enable_ = true;
-
   mutable std::mutex mutex_;
   std::map<VideoOutputFormat, int> lookup_table_;
 };

--- a/starboard/android/shared/media_is_video_supported.cc
+++ b/starboard/android/shared/media_is_video_supported.cc
@@ -16,7 +16,6 @@
 #include "starboard/shared/starboard/media/media_support_internal.h"
 // clang-format on
 
-#include "starboard/android/shared/max_media_codec_output_buffers_lookup_table.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/common/size.h"
@@ -78,14 +77,6 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
     }
     if (mime_type->GetParamBoolValue("disablecache", false)) {
       MediaCapabilitiesCache::GetInstance()->SetCacheEnabled(false);
-    }
-
-    if (!mime_type->ValidateBoolParameter("disabledynamicprerollframecount")) {
-      return false;
-    }
-    if (mime_type->GetParamBoolValue("disabledynamicprerollframecount",
-                                     false)) {
-      MaxMediaCodecOutputBuffersLookupTable::GetInstance()->SetEnabled(false);
     }
   }
 

--- a/starboard/android/shared/media_is_video_supported.cc
+++ b/starboard/android/shared/media_is_video_supported.cc
@@ -18,7 +18,6 @@
 
 #include <android/api-level.h>
 
-#include "starboard/android/shared/max_media_codec_output_buffers_lookup_table.h"
 #include "starboard/android/shared/media_capabilities_cache.h"
 #include "starboard/android/shared/media_common.h"
 #include "starboard/common/size.h"
@@ -66,14 +65,6 @@ bool MediaIsVideoSupported(SbMediaVideoCodec video_codec,
             "softwaredecoder",
             "allowed|disallowed|preferred|unpreferred|required")) {
       return false;
-    }
-
-    if (!mime_type->ValidateBoolParameter("disabledynamicprerollframecount")) {
-      return false;
-    }
-    if (mime_type->GetParamBoolValue("disabledynamicprerollframecount",
-                                     false)) {
-      MaxMediaCodecOutputBuffersLookupTable::GetInstance()->SetEnabled(false);
     }
   }
 


### PR DESCRIPTION
The disabledynamicprerollframecount MIME parameter was originally
introduced to manually toggle MaxMediaCodecOutputBuffersLookupTable
during video preroll optimization experimentation. It is no longer
used in the YouTube Web Player or any Starboard tests/benchmarks.

This change removes the parameter's validation and handling from
media_is_video_supported.cc, along with the unused SetEnabled()
functionality in MaxMediaCodecOutputBuffersLookupTable.

Issue: 545881570
