### PR TITLE
Cherry pick PR #11822: remove setup cloud sdk

### DIFF
--- a/.github/actions/upload_test_artifacts/action.yaml
+++ b/.github/actions/upload_test_artifacts/action.yaml
@@ -142,9 +142,6 @@ runs:
         name: ${{ inputs.test_artifacts_key }}
         path: artifacts/*
         retention-days: 3
-    - name: Set up Cloud SDK
-      if: inputs.upload_on_device_test_artifacts == 'true' || inputs.upload_e2e_test_artifacts == 'true'
-      uses: isarkis/setup-gcloud@40dce7857b354839efac498d3632050f568090b6 # v1.1.1
     - name: Upload On-Device Test Artifacts to GCS
       if: inputs.upload_on_device_test_artifacts == 'true' || inputs.upload_e2e_test_artifacts == 'true'
       env:
@@ -168,6 +165,6 @@ runs:
              "${GITHUB_WORKSPACE}/artifacts/"
         fi
 
-        gsutil -m cp -r "${GITHUB_WORKSPACE}/artifacts/*" \
+        gcloud storage cp -r "${GITHUB_WORKSPACE}/artifacts/*" \
           "gs://${project_name}-test-artifacts/${WORKFLOW}/${GITHUB_RUN_NUMBER}/${PLATFORM}/"
       shell: bash


### PR DESCRIPTION
Refer to original PR: #11822

Fix the below network error:

```
Error: google-github-actions/setup-gcloud failed with: failed to retrieve versions from https://raw.githubusercontent.com/google-github-actions/setup-cloud-sdk/main/data/versions.json: request timeout: /google-github-actions/setup-cloud-sdk/main/data/versions.json
```

Also replace gsutil with gcloud storage, recommended by GCP.

Bug: 543494079
(cherry picked from commit b969b8befb2adc9c8d35e0a38b9836caab13fa22)