### PR TITLE
posix: Fix race condition in musl fclose during global flush

### DIFF
--- a/starboard/nplb/posix_compliance/posix_stdio_test.cc
+++ b/starboard/nplb/posix_compliance/posix_stdio_test.cc
@@ -13,10 +13,13 @@
 // limitations under the License.
 
 #include <errno.h>
+#include <pthread.h>
 #include <stdio.h>
 #include <sys/stat.h>
 
+#include <atomic>
 #include <string>
+#include <vector>
 
 #include "starboard/file.h"
 #include "starboard/nplb/file_helpers.h"
@@ -24,6 +27,25 @@
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace nplb {
+namespace {
+
+struct ConcurrentWorkerContext {
+  std::atomic<bool>* stop;
+};
+
+void* ConcurrentFcloseWorker(void* context) {
+  auto* ctx = static_cast<ConcurrentWorkerContext*>(context);
+  while (!ctx->stop->load(std::memory_order_relaxed)) {
+    FILE* file = fopen("/dev/null", "w");
+    if (file) {
+      fputs("testing concurrent fclose and fflush\n", file);
+      EXPECT_EQ(fclose(file), 0);
+    }
+  }
+  return nullptr;
+}
+
+}  // namespace
 
 TEST(PosixStdioTest, FopenFclose) {
   ScopedRandomFile random_file;
@@ -49,6 +71,38 @@ TEST(PosixStdioTest, FopenInvalidPath) {
   ASSERT_EQ(file, nullptr);
   // Expect errno to be set to ENOENT (No such file or directory)
   ASSERT_EQ(errno, ENOENT);
+}
+
+TEST(PosixStdioTest, ConcurrentFcloseAndFflushNull) {
+  constexpr int kNumThreads = 4;
+  constexpr int kIterations = 200;
+  std::atomic<bool> stop{false};
+  ConcurrentWorkerContext ctx{&stop};
+
+  std::vector<pthread_t> threads;
+  threads.reserve(kNumThreads);
+  bool creation_success = true;
+  for (int i = 0; i < kNumThreads; ++i) {
+    pthread_t thread;
+    if (pthread_create(&thread, nullptr, ConcurrentFcloseWorker, &ctx) == 0) {
+      threads.push_back(thread);
+    } else {
+      creation_success = false;
+      break;
+    }
+  }
+
+  if (creation_success) {
+    for (int i = 0; i < kIterations; ++i) {
+      EXPECT_EQ(fflush(nullptr), 0);
+    }
+  }
+
+  stop.store(true, std::memory_order_relaxed);
+  for (pthread_t thread : threads) {
+    EXPECT_EQ(pthread_join(thread, nullptr), 0);
+  }
+  ASSERT_TRUE(creation_success);
 }
 
 }  // namespace nplb

--- a/third_party/musl/src/internal/libc.c
+++ b/third_party/musl/src/internal/libc.c
@@ -1,6 +1,14 @@
 #include "libc.h"
 
+#if defined(STARBOARD)
+struct __libc __libc = {
+	.can_do_threads = 1,
+	.threaded = 1,
+	.need_locks = 1,
+};
+#else
 struct __libc __libc;
+#endif
 
 size_t __hwcap;
 char *__progname=0, *__progname_full=0;

--- a/third_party/musl/src/stdio/fclose.c
+++ b/third_party/musl/src/stdio/fclose.c
@@ -13,14 +13,6 @@ int fclose(FILE *f)
 	r |= f->close(f);
 	FUNLOCK(f);
 
-#if defined(STARBOARD)
-	if (f->lock >= 0) {
-		f->lock = -1;
-		pthread_mutex_destroy(&f->cond_mutex.mutex);
-		pthread_cond_destroy(&f->cond_mutex.cond);
-	}
-#endif
-
 	/* Past this point, f is closed and any further explict access
 	 * to it is undefined. However, it still exists as an entry in
 	 * the open file list and possibly in the thread's locked files
@@ -38,6 +30,14 @@ int fclose(FILE *f)
 	if (f->next) f->next->prev = f->prev;
 	if (*head == f) *head = f->next;
 	__ofl_unlock();
+
+#if defined(STARBOARD)
+	if (f->lock >= 0) {
+		f->lock = -1;
+		pthread_mutex_destroy(&f->cond_mutex.mutex);
+		pthread_cond_destroy(&f->cond_mutex.cond);
+	}
+#endif
 
 	free(f->getln_buf);
 	free(f);


### PR DESCRIPTION
Move Starboard pthread synchronization primitive teardown in `fclose()` to occur after unlinking the file handle from `ofl_head`.

Previously, destroying the mutex and condition variable before acquiring `__ofl_lock()` created a race window. Concurrent global stdio flushes, such as `fflush(nullptr)`, could encounter a `FILE` struct with destroyed synchronization primitives. When `fclose` subsequently freed the memory, the thread running `fflush` accessed freed memory, causing an indirect jump crash.

This also adds a unit test to stress concurrent `fclose` and global `fflush` calls across multiple threads.

Bug: 546094794