### PR TITLE
android: Remove obsolete ForceClearSurfaceView setting from DirectWindowRendering

### DIFF
--- a/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
+++ b/cobalt/android/apk/app/src/main/java/dev/cobalt/util/JavaSwitches.java
@@ -275,7 +275,6 @@ public class JavaSwitches {
 
     if (javaSwitches.containsKey(JavaSwitches.DIRECT_WINDOW_RENDERING)) {
       extraCommandLineArgs.add("--use-window-surface-for-ui");
-      extraCommandLineArgs.add("--enable-h5vcc-settings=Media.ForceClearSurfaceView=1");
     }
 
     if (javaSwitches.containsKey(JavaSwitches.AREA_BASED_VIDEO_BUFFER_BUDGET)) {


### PR DESCRIPTION
In commit a4d698b84e45 ("android: Enable ClearSurfaceView by default"), clearing the surface view on Android was enabled by default and the ForceClearSurfaceView experimental feature was removed.

Remove the obsolete --enable-h5vcc-settings=Media.ForceClearSurfaceView=1 flag from the DirectWindowRendering Java switch.

Issue: 429021006
Issue: 542337082