### PR TITLE
rdk: Only support --flag=val and boolean flags in deploy_rdk

### DIFF
--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -105,31 +105,31 @@ def run_command(
     check: bool = True,
     sleep_time: int = 0,
 ) -> str:
-  """Utility to run shell commands."""
-  if verbose:
-    cmd_str = command if isinstance(command, str) else " ".join(command)
-    print(f">>> Executing: {cmd_str}")
-
-  is_shell = isinstance(command, str)
-  process = subprocess.Popen(
-      command, shell=is_shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-  )
-  stdout_lines = []
-  for line in process.stdout:
-    print(line, end="", flush=True)
-    stdout_lines.append(line)
-  process.wait()
-  stdout = "".join(stdout_lines)
-
-  if check and process.returncode != 0:
-    sys.exit(process.returncode)
-
-  if sleep_time > 0:
+    """Utility to run shell commands."""
     if verbose:
-      print(f"Waiting {sleep_time} seconds...")
-    time.sleep(sleep_time)
+        cmd_str = command if isinstance(command, str) else " ".join(command)
+        print(f">>> Executing: {cmd_str}")
 
-  return stdout
+    is_shell = isinstance(command, str)
+    process = subprocess.Popen(
+        command, shell=is_shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    stdout_lines = []
+    for line in process.stdout:
+        print(line, end="", flush=True)
+        stdout_lines.append(line)
+    process.wait()
+    stdout = "".join(stdout_lines)
+
+    if check and process.returncode != 0:
+        sys.exit(process.returncode)
+
+    if sleep_time > 0:
+        if verbose:
+            print(f"Waiting {sleep_time} seconds...")
+        time.sleep(sleep_time)
+
+    return stdout
 
 
 def run_remote_command(
@@ -140,23 +140,23 @@ def run_remote_command(
     check: bool = True,
     sleep_time: int = 0,
 ) -> str:
-  """Runs command on remote device via ADB or SSH."""
-  if device_id:
-    adb_cmd = ["adb", "-s", device_id, "shell"]
-    if isinstance(command, str):
-      adb_cmd.append(command)
+    """Runs command on remote device via ADB or SSH."""
+    if device_id:
+        adb_cmd = ["adb", "-s", device_id, "shell"]
+        if isinstance(command, str):
+            adb_cmd.append(command)
+        else:
+            adb_cmd.extend(command)
+        return run_command(adb_cmd, verbose, check, sleep_time)
+    elif device_ip:
+        ssh_cmd = ["ssh", "-q", f"root@{device_ip}"]
+        if isinstance(command, str):
+            ssh_cmd.append(command)
+        else:
+            ssh_cmd.append(" ".join(command))
+        return run_command(ssh_cmd, verbose, check, sleep_time)
     else:
-      adb_cmd.extend(command)
-    return run_command(adb_cmd, verbose, check, sleep_time)
-  elif device_ip:
-    ssh_cmd = ["ssh", "-q", f"root@{device_ip}"]
-    if isinstance(command, str):
-      ssh_cmd.append(command)
-    else:
-      ssh_cmd.append(" ".join(command))
-    return run_command(ssh_cmd, verbose, check, sleep_time)
-  else:
-    raise ValueError("Either device_id or device_ip must be provided for remote command.")
+        raise ValueError("Either device_id or device_ip must be provided for remote command.")
 
 
 def push_to_device(
@@ -166,52 +166,52 @@ def push_to_device(
     device_ip: Optional[str] = None,
     verbose: bool = True,
 ) -> None:
-  """Pushes local file/directory to remote device via ADB or SCP."""
-  if device_id:
-    adb_cmd = ["adb", "-s", device_id, "push", str(local_path), remote_path]
-    run_command(adb_cmd, verbose=verbose)
-  elif device_ip:
-    scp_cmd = [
-        "scp",
-        "-q",
-        "-r",
-        str(local_path),
-        f"root@{device_ip}:{remote_path}",
-    ]
-    run_command(scp_cmd, verbose=verbose)
-  else:
-    raise ValueError("Either device_id or device_ip must be provided to push file.")
+    """Pushes local file/directory to remote device via ADB or SCP."""
+    if device_id:
+        adb_cmd = ["adb", "-s", device_id, "push", str(local_path), remote_path]
+        run_command(adb_cmd, verbose=verbose)
+    elif device_ip:
+        scp_cmd = [
+            "scp",
+            "-q",
+            "-r",
+            str(local_path),
+            f"root@{device_ip}:{remote_path}",
+        ]
+        run_command(scp_cmd, verbose=verbose)
+    else:
+        raise ValueError("Either device_id or device_ip must be provided to push file.")
 
 
 def configure_build(platform: str, config: str, out_dir: Path, no_rbe: bool = False) -> None:
-  """Runs GN configuration."""
-  print(f"=== Configuring {platform} ({config}) ===")
-  cmd = [
-      "python3", "cobalt/build/gn.py", "-p", platform, "-C", config,
-      "--out_directory",
-      str(out_dir)
-  ]
-  if no_rbe:
-    cmd.append("--no-rbe")
-  run_command(cmd)
+    """Runs GN configuration."""
+    print(f"=== Configuring {platform} ({config}) ===")
+    cmd = [
+        "python3", "cobalt/build/gn.py", "-p", platform, "-C", config,
+        "--out_directory",
+        str(out_dir)
+    ]
+    if no_rbe:
+        cmd.append("--no-rbe")
+    run_command(cmd)
 
 
 def build_targets(out_dir: Path, targets: List[str]) -> str:
-  """Builds the specified targets using autoninja."""
-  print(f"=== Building {' '.join(targets)} ===")
-  return run_command(["autoninja", "-C", str(out_dir)] + targets)
+    """Builds the specified targets using autoninja."""
+    print(f"=== Building {' '.join(targets)} ===")
+    return run_command(["autoninja", "-C", str(out_dir)] + targets)
 
 
 def deploy_only_lib(device_id: Optional[str], device_ip: Optional[str], out_dir: Path, remote_dir: str) -> None:
-  """Pushes libcobalt.lz4 directly to the device."""
-  local_lz4 = out_dir / "app/cobalt/lib/libcobalt.lz4"
-  if not local_lz4.exists():
-    print(f"Error: {local_lz4} not found.")
-    sys.exit(1)
+    """Pushes libcobalt.lz4 directly to the device."""
+    local_lz4 = out_dir / "app/cobalt/lib/libcobalt.lz4"
+    if not local_lz4.exists():
+        print(f"Error: {local_lz4} not found.")
+        sys.exit(1)
 
-  remote_lib_dir = f"{remote_dir}/app/cobalt/lib"
-  run_remote_command(f"mkdir -p {remote_lib_dir}", device_id, device_ip)
-  push_to_device(local_lz4, f"{remote_lib_dir}/libcobalt.lz4", device_id, device_ip)
+    remote_lib_dir = f"{remote_dir}/app/cobalt/lib"
+    run_remote_command(f"mkdir -p {remote_lib_dir}", device_id, device_ip)
+    push_to_device(local_lz4, f"{remote_lib_dir}/libcobalt.lz4", device_id, device_ip)
 
 
 def package_and_deploy(
@@ -222,56 +222,59 @@ def package_and_deploy(
     deps_file: Optional[Path],
     mode: str,
 ) -> None:
-  """Packages artifacts using runtime_deps and pushes to device."""
-  print("=== Packaging & Deploying artifacts ===")
-  archive_name = "archive.tar.gz"
+    """Packages artifacts using runtime_deps and pushes to device."""
+    print("=== Packaging & Deploying artifacts ===")
+    archive_name = "archive.tar.gz"
 
-  if deps_file and deps_file.exists():
-    tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "-T", str(deps_file)]
-    if mode == "plugin":
-      tar_cmd.append("libloader_app.so")
-    build_info = out_dir / "gen/build_info.json"
-    if build_info.exists():
-      tar_cmd.append("gen/build_info.json")
-  else:
-    if deps_file:
-      print(f"Warning: deps_file {deps_file} not found.")
-    print(f"Packaging everything in {out_dir}")
-    tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "."]
+    if deps_file and deps_file.exists():
+        tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "-T", str(deps_file)]
+        if mode == "plugin":
+            tar_cmd.append("libloader_app.so")
+        build_info = out_dir / "gen/build_info.json"
+        if build_info.exists():
+            tar_cmd.append("gen/build_info.json")
+    else:
+        if deps_file:
+            print(f"Warning: deps_file {deps_file} not found.")
+        print(f"Packaging everything in {out_dir}")
+        tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "."]
 
-  print(f"Packaging with: {' '.join(tar_cmd)}")
-  run_command(tar_cmd)
-  run_remote_command(f"mkdir -p {remote_dir}", device_id, device_ip)
-  push_to_device(archive_name, f"{remote_dir}/", device_id, device_ip)
-  Path(archive_name).unlink(missing_ok=True)
+    print(f"Packaging with: {' '.join(tar_cmd)}")
+    run_command(tar_cmd)
+    run_remote_command(f"mkdir -p {remote_dir}", device_id, device_ip)
+    push_to_device(archive_name, f"{remote_dir}/", device_id, device_ip)
+    Path(archive_name).unlink(missing_ok=True)
 
 
 def ensure_dolby_vision_policy(device_id: Optional[str], device_ip: Optional[str]) -> None:
-  """Ensures /sys/module/aml_media/parameters/dolby_vision_policy is set to 1."""
-  # TODO(b/532753892): Remove this workaround once the device driver is updated.
-  policy_file = "/sys/module/aml_media/parameters/dolby_vision_policy"
-  run_remote_command(f"echo 1 > {policy_file}", device_id, device_ip)
+    """Ensures /sys/module/aml_media/parameters/dolby_vision_policy is set to 1."""
+    # TODO(b/532753892): Remove this workaround once the device driver is updated.
+    policy_file = "/sys/module/aml_media/parameters/dolby_vision_policy"
+    run_remote_command(f"echo 1 > {policy_file}", device_id, device_ip)
 
 
 def _extract_flag_key(arg: str) -> str:
-  """Extracts option key from flag string (e.g. '--foo' from '--foo=val' or '--foo')."""
-  return arg.split("=", 1)[0]
+    """Extracts option key from flag string (e.g. '--foo' from '--foo=val' or '--foo')."""
+    return arg.split("=", 1)[0]
 
 
 def _filter_args_by_keys(base_args: List[str], override_args: List[str]) -> List[str]:
-  """Filters flags from base_args whose option keys match any flag in override_args."""
-  override_keys = {
-      _extract_flag_key(arg) for arg in override_args if arg.startswith("--")
-  }
-  return [
-      arg for arg in base_args
-      if not (arg.startswith("--") and _extract_flag_key(arg) in override_keys)
-  ]
+    """Filters flags from base_args whose option keys match any flag in override_args."""
+    override_keys = {
+        _extract_flag_key(arg)
+        for arg in override_args
+        if arg.startswith("--") and arg != "--"
+    }
+    return [
+        arg
+        for arg in base_args
+        if not (arg.startswith("--") and arg != "--" and _extract_flag_key(arg) in override_keys)
+    ]
 
 
 def _merge_args(base_args: List[str], override_args: List[str]) -> List[str]:
-  """Replaces flags in base_args with matching option keys from override_args, and appends override_args."""
-  return _filter_args_by_keys(base_args, override_args) + override_args
+    """Replaces flags in base_args with matching option keys from override_args, and appends override_args."""
+    return _filter_args_by_keys(base_args, override_args) + override_args
 
 
 def remove_duplicate_sb_args(
@@ -279,21 +282,21 @@ def remove_duplicate_sb_args(
     script_args: Optional[List[str]] = None,
     user_override_args: Optional[List[str]] = None,
 ) -> List[str]:
-  """Combines cobalt_json_args, script_args, and user_override_args with key deduplication.
+    """Combines cobalt_json_args, script_args, and user_override_args with key deduplication.
 
     Precedence order (highest to lowest):
       1. user_override_args (passed via --param)
       2. script_args (script-added flags e.g. --remote-debugging-port=9222)
       3. cobalt_json_args (pre-existing flags from WPEFramework cobalt.json / sbmainargs)
     """
-  script_args = script_args or []
-  user_override_args = user_override_args or []
+    script_args = script_args or []
+    user_override_args = user_override_args or []
 
-  # 1. Merge script_args with user_override_args
-  override_args = _merge_args(script_args, user_override_args)
+    # 1. Merge script_args with user_override_args
+    override_args = _merge_args(script_args, user_override_args)
 
-  # 2. Merge cobalt_json_args with override_args
-  return _merge_args(cobalt_json_args, override_args)
+    # 2. Merge cobalt_json_args with override_args
+    return _merge_args(cobalt_json_args, override_args)
 
 
 def launch_on_device(
@@ -307,593 +310,593 @@ def launch_on_device(
     param: Optional[List[str]] = None,
     deeplink: Optional[str] = None,
 ) -> None:
-  """Executes remote commands to launch Cobalt or tests."""
-  print("=== Launching on device ===")
-  remote_cmds = [f"cd {remote_dir}"]
+    """Executes remote commands to launch Cobalt or tests."""
+    print("=== Launching on device ===")
+    remote_cmds = [f"cd {remote_dir}"]
 
-  if extract_archive:
-    # Ensure unprivileged container users have access to extracted artifacts.
-    remote_cmds += [
-        "tar -xzf archive.tar.gz",
-        "rm archive.tar.gz",
-        f"chmod -R 777 {remote_dir}",
-    ]
-
-  if test_name:
-    remote_cmds += ["rdkDisplay remove || true", "sleep 2", "mkdir -p results"]
-    gtest_filter = ""
-    filter_file = (Path("cobalt/testing/filters") / PLATFORM /
-                   f"{test_name}_loader_filter.json")
-    if filter_file.exists():
-      with open(filter_file) as f:
-        fails = json.load(f).get("failing_tests", [])
-        if fails:
-          gtest_filter = f" --gtest_filter=-{':'.join(fails)}"
-
-    xml_out = f"--gtest_output=xml:{remote_dir}/results/{test_name}_loader.xml"
-    remote_cmds += [
-        "rdkDisplay create",
-        "sleep 2",
-        f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./{test_name}_loader.py {xml_out}{gtest_filter}",
-        "rdkDisplay remove",
-        "sleep 2",
-    ]
-  elif mode == "plugin":
-    if devtools:
-      print("[INFO] Enabling DevTools support...")
-
-    # Deactivate first to change config
-    deactivate_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.deactivate","params":{"callsign":"YouTube"}}'
-    run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{deactivate_json}'", device_id, device_ip)
-
-    # Get configuration
-    get_config_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.configuration@YouTube"}'
-    res_str = run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{get_config_json}'", device_id, device_ip)
-
-    rpc_deactivate = (
-        r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.deactivate\",'
-        r'\"params\":{\"callsign\":\"YouTube\"}}')
-    try:
-      res = json.loads(res_str.strip())
-      if "result" in res:
-        config = res["result"]
-        cobalt_json_args = config.get("sbmainargs", [])
-
-        script_args = []
-        if devtools:
-          script_args.append("--remote-debugging-port=9222")
-
-        user_override_args = param if param else []
-
-        config["sbmainargs"] = remove_duplicate_sb_args(
-            cobalt_json_args, script_args, user_override_args
-        )
-
-        # Set configuration
-        rpc_set_config = json.dumps({
-            "jsonrpc": "2.0",
-            "id": 1,
-            "method": "Controller.1.configuration@YouTube",
-            "params": config
-        })
-        run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{rpc_set_config}'", device_id, device_ip)
-        print("[INFO] DevTools configuration updated successfully.")
-    except Exception as e:
-      print(f"[WARNING] Failed to update DevTools configuration: {e}")
-
-    rpc_activate = (
-        r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.activate\",'
-        r'\"params\":{\"callsign\":\"YouTube\"}}')
-    remote_cmds += [
-        "rdkDisplay remove || true",
-        "sleep 2",
-        f"curl http://127.0.0.1:9998/jsonrpc -d '{rpc_deactivate}'",
-        "sleep 2",
-        f"curl -s http://127.0.0.1:9998/jsonrpc -d '{rpc_activate}'",
-    ]
-
-    if deeplink:
-      rpc_deeplink_json = json.dumps({
-          "jsonrpc": "2.0",
-          "id": 3,
-          "method": "YouTube.deeplink",
-          "params": deeplink
-      }).replace('"', r'\"')
-      remote_cmds.append(f"curl -X POST http://127.0.0.1:9998/jsonrpc -d '{rpc_deeplink_json}'")
-
-    if devtools:
-      print("[INFO] Setting up DevTools port forwarding...")
-      if device_id:
-        run_command(["adb", "-s", device_id, "forward", "tcp:9222", "tcp:9222"])
-      elif device_ip:
-        ssh_tunnel_cmd = [
-            "ssh",
-            "-q",
-            "-fN",
-            "-L",
-            "9222:localhost:9222",
-            f"root@{device_ip}",
+    if extract_archive:
+        # Ensure unprivileged container users have access to extracted artifacts.
+        remote_cmds += [
+            "tar -xzf archive.tar.gz",
+            "rm archive.tar.gz",
+            f"chmod -R 777 {remote_dir}",
         ]
-        try:
-          subprocess.Popen(ssh_tunnel_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-        except Exception as e:
-          print(f"[WARNING] Failed to start SSH tunnel: {e}")
-      print("[INFO] DevTools is enabled. Please open Chrome and navigate to 'chrome://inspect' (add 'localhost:9222' or the device IP to discover targets).")
-  else:
-    remote_cmds += [
-        "rdkDisplay remove || true",
-        "sleep 2",
-        "rdkDisplay create",
-        "sleep 2",
-        f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app {' '.join(param)}" if param else "XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app",
-        "rdkDisplay remove",
-        "sleep 2",
-    ]
 
-  full_cmd = " && ".join(remote_cmds)
-  output = run_remote_command(f"bash -l -c \"{full_cmd}\"", device_id, device_ip)
-  print(output)
-  if "ERROR_OPENING_FAILED" in output or "error" in output.lower():
-    print("\n[WARNING] Activation failed with error (e.g., ERROR_OPENING_FAILED).")
-    print("[WARNING] Please check the physical device state. It might be in setup/Out-of-Box Experience (OOBE) mode or not connected to a network.")
+    if test_name:
+        remote_cmds += ["rdkDisplay remove || true", "sleep 2", "mkdir -p results"]
+        gtest_filter = ""
+        filter_file = (Path("cobalt/testing/filters") / PLATFORM /
+                       f"{test_name}_loader_filter.json")
+        if filter_file.exists():
+            with open(filter_file) as f:
+                fails = json.load(f).get("failing_tests", [])
+                if fails:
+                    gtest_filter = f" --gtest_filter=-{':'.join(fails)}"
+
+        xml_out = f"--gtest_output=xml:{remote_dir}/results/{test_name}_loader.xml"
+        remote_cmds += [
+            "rdkDisplay create",
+            "sleep 2",
+            f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./{test_name}_loader.py {xml_out}{gtest_filter}",
+            "rdkDisplay remove",
+            "sleep 2",
+        ]
+    elif mode == "plugin":
+        if devtools:
+            print("[INFO] Enabling DevTools support...")
+
+        # Deactivate first to change config
+        deactivate_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.deactivate","params":{"callsign":"YouTube"}}'
+        run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{deactivate_json}'", device_id, device_ip)
+
+        # Get configuration
+        get_config_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.configuration@YouTube"}'
+        res_str = run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{get_config_json}'", device_id, device_ip)
+
+        rpc_deactivate = (
+            r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.deactivate\",'
+            r'\"params\":{\"callsign\":\"YouTube\"}}')
+        try:
+            res = json.loads(res_str.strip())
+            if "result" in res:
+                config = res["result"]
+                cobalt_json_args = config.get("sbmainargs", [])
+                
+                script_args = []
+                if devtools:
+                    script_args.append("--remote-debugging-port=9222")
+
+                user_override_args = param if param else []
+
+                config["sbmainargs"] = remove_duplicate_sb_args(
+                    cobalt_json_args, script_args, user_override_args
+                )
+
+                # Set configuration
+                rpc_set_config = json.dumps({
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "Controller.1.configuration@YouTube",
+                    "params": config
+                })
+                run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{rpc_set_config}'", device_id, device_ip)
+                print("[INFO] DevTools configuration updated successfully.")
+        except Exception as e:
+            print(f"[WARNING] Failed to update DevTools configuration: {e}")
+
+        rpc_activate = (
+            r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.activate\",'
+            r'\"params\":{\"callsign\":\"YouTube\"}}')
+        remote_cmds += [
+            "rdkDisplay remove || true",
+            "sleep 2",
+            f"curl http://127.0.0.1:9998/jsonrpc -d '{rpc_deactivate}'",
+            "sleep 2",
+            f"curl -s http://127.0.0.1:9998/jsonrpc -d '{rpc_activate}'",
+        ]
+
+        if deeplink:
+            rpc_deeplink_json = json.dumps({
+                "jsonrpc": "2.0",
+                "id": 3,
+                "method": "YouTube.deeplink",
+                "params": deeplink
+            }).replace('"', r'\"')
+            remote_cmds.append(f"curl -X POST http://127.0.0.1:9998/jsonrpc -d '{rpc_deeplink_json}'")
+
+        if devtools:
+            print("[INFO] Setting up DevTools port forwarding...")
+            if device_id:
+                run_command(["adb", "-s", device_id, "forward", "tcp:9222", "tcp:9222"])
+            elif device_ip:
+                ssh_tunnel_cmd = [
+                    "ssh",
+                    "-q",
+                    "-fN",
+                    "-L",
+                    "9222:localhost:9222",
+                    f"root@{device_ip}",
+                ]
+                try:
+                    subprocess.Popen(ssh_tunnel_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
+                except Exception as e:
+                    print(f"[WARNING] Failed to start SSH tunnel: {e}")
+            print("[INFO] DevTools is enabled. Please open Chrome and navigate to 'chrome://inspect' (add 'localhost:9222' or the device IP to discover targets).")
+    else:
+        remote_cmds += [
+            "rdkDisplay remove || true",
+            "sleep 2",
+            "rdkDisplay create",
+            "sleep 2",
+            f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app {' '.join(param)}" if param else "XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app",
+            "rdkDisplay remove",
+            "sleep 2",
+        ]
+
+    full_cmd = " && ".join(remote_cmds)
+    output = run_remote_command(f"bash -l -c \"{full_cmd}\"", device_id, device_ip)
+    print(output)
+    if "ERROR_OPENING_FAILED" in output or "error" in output.lower():
+        print("\n[WARNING] Activation failed with error (e.g., ERROR_OPENING_FAILED).")
+        print("[WARNING] Please check the physical device state. It might be in setup/Out-of-Box Experience (OOBE) mode or not connected to a network.")
 
 
 def parse_args() -> argparse.Namespace:
-  """Parses command line arguments."""
-  parser = argparse.ArgumentParser(
-      description="Build and deploy Cobalt to RDK.")
-  parser.add_argument(
-      "--mode",
-      choices=["executable", "plugin"],
-      default="plugin",
-      help="Deploy as standalone executable or plugin (default).",
-  )
-  parser.add_argument(
-      "--only-lib", action="store_true", help="Deploy only libcobalt.lz4.")
-  parser.add_argument(
-      "--tests",
-      type=str,
-      metavar="TEST_NAME",
-      help="Build and run a test (e.g., nplb).",
-  )
-  parser.add_argument(
-      "--device-ip",
-      type=str,
-      help="Target RDK device IP address (uses SSH/SCP instead of ADB).",
-  )
-  parser.add_argument(
-      "--config", type=str, help="Override default build configuration.")
-  parser.add_argument(
-      "--out-dir", type=str, help="Custom build output directory.")
-  parser.add_argument(
-      "--skip-build",
-      action="store_true",
-      help="Skip configure and build steps.",
-  )
-  parser.add_argument(
-      "--skip-deploy",
-      action="store_true",
-      help="Skip deployment step (assumes files are already on the device).",
-  )
-  parser.add_argument(
-      "--run", action="store_true", help="Run on device after build/deploy.")
-  parser.add_argument(
-      "--force-deploy",
-      action="store_true",
-      help="Force deployment even if up-to-date.",
-  )
-  parser.add_argument(
-      "--deeplink",
-      type=str,
-      dest="deeplink",
-      help="Deeplink parameter (e.g. v=dQw4w9WgXcQ) to pass to Cobalt when launching in plugin mode.",
-  )
-  parser.add_argument(
-      "--reset",
-      action="store_true",
-      help=(
-          "Run rdkDisplay remove and restart WPEFramework on the device. "
-          "Useful if the display is inactive or WPEFramework is stuck."),
-  )
-  parser.add_argument(
-      "--setup-toolchain",
-      action="store_true",
-      help="Download and install the RDK toolchain to RDK_HOME.",
-  )
-  parser.add_argument(
-      "--revert-c25",
-      action="store_true",
-      help="Revert the active Cobalt configuration on the device back to Cobalt 25.",
-  )
-  parser.add_argument(
-      "--no-rbe",
-      action="store_true",
-      help="Disable Remote Build Execution (RBE) in GN configuration.",
-  )
-  parser.add_argument(
-      "--logs",
-      action="store_true",
-      help="View system/Cobalt logs from the device.",
-  )
-  parser.add_argument(
-      "--follow",
-      action="store_true",
-      help="Follow log output in real-time (runs journalctl -f).",
-  )
-  parser.add_argument(
-      "--system-logs",
-      action="store_true",
-      help="View global OS/kernel/systemd logs from the device (runs raw journalctl).",
-  )
-  parser.add_argument(
-      "--param",
-      nargs=argparse.REMAINDER,
-      default=[],
-      help=(
-          "Additional runtime parameter(s) to pass to StarboardMain (must be specified last). "
-          "All arguments must start with '--' (positional arguments are not supported)."
-      ),
-  )
-  args = parser.parse_args()
+    """Parses command line arguments."""
+    parser = argparse.ArgumentParser(
+        description="Build and deploy Cobalt to RDK.")
+    parser.add_argument(
+        "--mode",
+        choices=["executable", "plugin"],
+        default="plugin",
+        help="Deploy as standalone executable or plugin (default).",
+    )
+    parser.add_argument(
+        "--only-lib", action="store_true", help="Deploy only libcobalt.lz4.")
+    parser.add_argument(
+        "--tests",
+        type=str,
+        metavar="TEST_NAME",
+        help="Build and run a test (e.g., nplb).",
+    )
+    parser.add_argument(
+        "--device-ip",
+        type=str,
+        help="Target RDK device IP address (uses SSH/SCP instead of ADB).",
+    )
+    parser.add_argument(
+        "--config", type=str, help="Override default build configuration.")
+    parser.add_argument(
+        "--out-dir", type=str, help="Custom build output directory.")
+    parser.add_argument(
+        "--skip-build",
+        action="store_true",
+        help="Skip configure and build steps.",
+    )
+    parser.add_argument(
+        "--skip-deploy",
+        action="store_true",
+        help="Skip deployment step (assumes files are already on the device).",
+    )
+    parser.add_argument(
+        "--run", action="store_true", help="Run on device after build/deploy.")
+    parser.add_argument(
+        "--force-deploy",
+        action="store_true",
+        help="Force deployment even if up-to-date.",
+    )
+    parser.add_argument(
+        "--deeplink",
+        type=str,
+        dest="deeplink",
+        help="Deeplink parameter (e.g. v=dQw4w9WgXcQ) to pass to Cobalt when launching in plugin mode.",
+    )
+    parser.add_argument(
+        "--reset",
+        action="store_true",
+        help=(
+            "Run rdkDisplay remove and restart WPEFramework on the device. "
+            "Useful if the display is inactive or WPEFramework is stuck."),
+    )
+    parser.add_argument(
+        "--setup-toolchain",
+        action="store_true",
+        help="Download and install the RDK toolchain to RDK_HOME.",
+    )
+    parser.add_argument(
+        "--revert-c25",
+        action="store_true",
+        help="Revert the active Cobalt configuration on the device back to Cobalt 25.",
+    )
+    parser.add_argument(
+        "--no-rbe",
+        action="store_true",
+        help="Disable Remote Build Execution (RBE) in GN configuration.",
+    )
+    parser.add_argument(
+        "--logs",
+        action="store_true",
+        help="View system/Cobalt logs from the device.",
+    )
+    parser.add_argument(
+        "--follow",
+        action="store_true",
+        help="Follow log output in real-time (runs journalctl -f).",
+    )
+    parser.add_argument(
+        "--system-logs",
+        action="store_true",
+        help="View global OS/kernel/systemd logs from the device (runs raw journalctl).",
+    )
+    parser.add_argument(
+        "--param",
+        nargs=argparse.REMAINDER,
+        default=[],
+        help=(
+            "Additional runtime parameter(s) to pass to StarboardMain (must be specified last). "
+            "All arguments must start with '--' (positional arguments are not supported)."
+        ),
+    )
+    args = parser.parse_args()
 
-  if args.param:
-    for arg in args.param:
-      if not arg.startswith("--"):
-        print(
-            f"Error: All arguments passed to --param must start with '--' (positional arguments are not supported). "
-            f"Positional argument '{arg}' is not supported."
-        )
-        sys.exit(1)
+    if args.param:
+        for arg in args.param:
+            if not arg.startswith("--"):
+                print(
+                    f"Error: All arguments passed to --param must start with '--' (positional arguments are not supported). "
+                    f"Positional argument '{arg}' is not supported."
+                )
+                sys.exit(1)
 
-  return args
+    return args
 
 
 def get_model_name(device_id: str) -> Optional[str]:
-  """Attempts to retrieve the model name from /etc/device.properties."""
-  try:
-    res = subprocess.run(
-        ["adb", "-s", device_id, "shell", "cat /etc/device.properties"],
-        capture_output=True, text=True, timeout=5
-    )
-    if res.returncode == 0:
-      for line in res.stdout.splitlines():
-        if "MODEL_NAME=" in line:
-          return line.split("=", 1)[1].strip().strip('"')
-  except Exception:
-    pass
-  return None
+    """Attempts to retrieve the model name from /etc/device.properties."""
+    try:
+        res = subprocess.run(
+            ["adb", "-s", device_id, "shell", "cat /etc/device.properties"],
+            capture_output=True, text=True, timeout=5
+        )
+        if res.returncode == 0:
+            for line in res.stdout.splitlines():
+                if "MODEL_NAME=" in line:
+                    return line.split("=", 1)[1].strip().strip('"')
+    except Exception:
+        pass
+    return None
 
 
 def is_rdk_device(device_id: str) -> bool:
-  """Checks if the device is an RDK device by checking if model is AH212."""
-  model = get_model_name(device_id)
-  return model is not None and model.lower() == "ah212"
+    """Checks if the device is an RDK device by checking if model is AH212."""
+    model = get_model_name(device_id)
+    return model is not None and model.lower() == "ah212"
 
 
 def get_device_id() -> str:
-  """Gets the target RDK device ID."""
-  try:
-    result = subprocess.run(
-        ["adb", "devices"],
-        capture_output=True,
-        text=True,
-        check=True
-    )
-  except (subprocess.CalledProcessError, FileNotFoundError) as e:
-    print(f"Error running 'adb devices': {e}")
-    sys.exit(1)
+    """Gets the target RDK device ID."""
+    try:
+        result = subprocess.run(
+            ["adb", "devices"],
+            capture_output=True,
+            text=True,
+            check=True
+        )
+    except (subprocess.CalledProcessError, FileNotFoundError) as e:
+        print(f"Error running 'adb devices': {e}")
+        sys.exit(1)
 
-  # Parse 'adb devices' output to collect online device serial IDs.
-  devices = []
-  for line in result.stdout.strip().split("\n")[1:]:
-    if not line.strip():
-      continue
-    parts = line.split()
-    if len(parts) >= 2 and parts[1] == "device":
-      devices.append(parts[0])
+    # Parse 'adb devices' output to collect online device serial IDs.
+    devices = []
+    for line in result.stdout.strip().split("\n")[1:]:
+        if not line.strip():
+            continue
+        parts = line.split()
+        if len(parts) >= 2 and parts[1] == "device":
+            devices.append(parts[0])
 
-  if not devices:
-    print("Error: No ADB devices connected.")
-    sys.exit(1)
+    if not devices:
+        print("Error: No ADB devices connected.")
+        sys.exit(1)
 
-  # Filter for RDK devices
-  rdk_devices = []
-  for dev in devices:
-    if is_rdk_device(dev):
-      rdk_devices.append(dev)
+    # Filter for RDK devices
+    rdk_devices = []
+    for dev in devices:
+        if is_rdk_device(dev):
+            rdk_devices.append(dev)
 
-  if not rdk_devices:
-    print(f"Error: None of the connected devices {devices} were identified as RDK (AH212).")
-    sys.exit(1)
+    if not rdk_devices:
+        print(f"Error: None of the connected devices {devices} were identified as RDK (AH212).")
+        sys.exit(1)
 
-  # Explicit assumption: if multiple devices are connected, the first one is picked.
-  if len(rdk_devices) > 1:
-    print(f"Note: Multiple RDK devices detected: {rdk_devices}. Picking the first one: {rdk_devices[0]}")
+    # Explicit assumption: if multiple devices are connected, the first one is picked.
+    if len(rdk_devices) > 1:
+        print(f"Note: Multiple RDK devices detected: {rdk_devices}. Picking the first one: {rdk_devices[0]}")
 
-  dev = rdk_devices[0]
-  print(f"Using RDK device: {dev} (AH212)")
-  return dev
+    dev = rdk_devices[0]
+    print(f"Using RDK device: {dev} (AH212)")
+    return dev
 
 
 def assert_software_version(device_id: Optional[str], device_ip: Optional[str], min_version_date: str) -> None:
-  """Asserts that the device software date is at least the min_version_date."""
-  try:
-    output = run_remote_command("cat /version.txt", device_id, device_ip, check=False)
-    if "imagename:" not in output:
-      print("Error: Could not read /version.txt from the device to verify system software version.")
-      print(f"Details: {output}")
-      sys.exit(1)
-
-    custom_version = None
-    for line in output.splitlines():
-      if "custom version:" in line.lower():
-        custom_version = line.split(":", 1)[1].strip()
-        break
-
-    if not custom_version:
-      print("Error: 'custom version' field not found in /version.txt.")
-      sys.exit(1)
-
-    # Extract date suffix from custom version (e.g. RDK_V6_AH212_20260330 -> 20260330)
-    parts = custom_version.split("_")
-    if not parts:
-      print(f"Error: Could not parse date from custom version: {custom_version}")
-      sys.exit(1)
-
-    date_str = parts[-1]
+    """Asserts that the device software date is at least the min_version_date."""
     try:
-      min_date = datetime.strptime(min_version_date, "%Y%m%d").date()
-    except ValueError:
-      print(f"Error: Invalid min_version_date format: {min_version_date}. Expected YYYYMMDD.")
-      sys.exit(1)
+        output = run_remote_command("cat /version.txt", device_id, device_ip, check=False)
+        if "imagename:" not in output:
+            print("Error: Could not read /version.txt from the device to verify system software version.")
+            print(f"Details: {output}")
+            sys.exit(1)
 
-    try:
-      device_date = datetime.strptime(date_str, "%Y%m%d").date()
-    except ValueError:
-      print(f"Error: Extracted version suffix '{date_str}' is not a valid YYYYMMDD calendar date.")
-      sys.exit(1)
+        custom_version = None
+        for line in output.splitlines():
+            if "custom version:" in line.lower():
+                custom_version = line.split(":", 1)[1].strip()
+                break
 
-    if device_date < min_date:
-      print(f"Error: Device system software version ({date_str}) is older than the required minimum version ({min_version_date}).")
-      sys.exit(1)
+        if not custom_version:
+            print("Error: 'custom version' field not found in /version.txt.")
+            sys.exit(1)
 
-    print(f"Device system software version verified: {date_str} (required: >= {min_version_date})")
+        # Extract date suffix from custom version (e.g. RDK_V6_AH212_20260330 -> 20260330)
+        parts = custom_version.split("_")
+        if not parts:
+            print(f"Error: Could not parse date from custom version: {custom_version}")
+            sys.exit(1)
 
-  except Exception as e:
-    print(f"Error checking software version: {e}")
-    sys.exit(1)
+        date_str = parts[-1]
+        try:
+            min_date = datetime.strptime(min_version_date, "%Y%m%d").date()
+        except ValueError:
+            print(f"Error: Invalid min_version_date format: {min_version_date}. Expected YYYYMMDD.")
+            sys.exit(1)
+
+        try:
+            device_date = datetime.strptime(date_str, "%Y%m%d").date()
+        except ValueError:
+            print(f"Error: Extracted version suffix '{date_str}' is not a valid YYYYMMDD calendar date.")
+            sys.exit(1)
+
+        if device_date < min_date:
+            print(f"Error: Device system software version ({date_str}) is older than the required minimum version ({min_version_date}).")
+            sys.exit(1)
+
+        print(f"Device system software version verified: {date_str} (required: >= {min_version_date})")
+
+    except Exception as e:
+        print(f"Error checking software version: {e}")
+        sys.exit(1)
 
 
 def check_and_switch_cobalt_version(device_id: Optional[str], device_ip: Optional[str]) -> None:
-  """Checks if Cobalt 26 is active on the device, otherwise switches and reboots."""
-  try:
-    current_target = run_remote_command(
-        "readlink /usr/lib/libloader_app.so", device_id, device_ip, check=False
-    ).strip()
+    """Checks if Cobalt 26 is active on the device, otherwise switches and reboots."""
+    try:
+        current_target = run_remote_command(
+            "readlink /usr/lib/libloader_app.so", device_id, device_ip, check=False
+        ).strip()
 
-    if current_target == "/data/out_cobalt/libloader_app.so":
-      print("Cobalt 26 configuration is already active on the device.")
-      return
+        if current_target == "/data/out_cobalt/libloader_app.so":
+            print("Cobalt 26 configuration is already active on the device.")
+            return
 
-    print("Cobalt configuration is not active. Running 'chCobalt custom_cobalt' on the device...")
-    run_remote_command("chCobalt custom_cobalt", device_id, device_ip)
+        print("Cobalt configuration is not active. Running 'chCobalt custom_cobalt' on the device...")
+        run_remote_command("chCobalt custom_cobalt", device_id, device_ip)
 
-    print("Device is being rebooted to apply changes...")
-    run_remote_command("bash -l -c 'reboot'", device_id, device_ip, check=False)
+        print("Device is being rebooted to apply changes...")
+        run_remote_command("bash -l -c 'reboot'", device_id, device_ip, check=False)
 
-    print("Waiting 30 seconds for the device to reboot...")
-    time.sleep(30)
+        print("Waiting 30 seconds for the device to reboot...")
+        time.sleep(30)
 
-    print("Attempting to reconnect to device...")
-    reconnected = False
-    for i in range(10): # try up to 10 times with 3 second intervals
-      out = run_remote_command("echo ok", device_id, device_ip, check=False, verbose=False).strip()
-      if out == "ok":
-        reconnected = True
-        break
-      print(f"Device not ready yet. Retrying in 3 seconds... ({i+1}/10)")
-      time.sleep(3)
+        print("Attempting to reconnect to device...")
+        reconnected = False
+        for i in range(10): # try up to 10 times with 3 second intervals
+            out = run_remote_command("echo ok", device_id, device_ip, check=False, verbose=False).strip()
+            if out == "ok":
+                reconnected = True
+                break
+            print(f"Device not ready yet. Retrying in 3 seconds... ({i+1}/10)")
+            time.sleep(3)
 
-    if not reconnected:
-      print("Error: Could not reconnect to the device after reboot.")
-      sys.exit(1)
+        if not reconnected:
+            print("Error: Could not reconnect to the device after reboot.")
+            sys.exit(1)
 
-    print("Reconnected to device successfully.")
+        print("Reconnected to device successfully.")
 
-  except Exception as e:
-    print(f"Error during Cobalt version switch: {e}")
-    sys.exit(1)
+    except Exception as e:
+        print(f"Error during Cobalt version switch: {e}")
+        sys.exit(1)
 
 
 def revert_to_cobalt_25(device_id: Optional[str], device_ip: Optional[str]) -> None:
-  """Reverts the active Cobalt configuration on the device back to Cobalt 25."""
-  target = run_remote_command(
-      "readlink /usr/lib/libloader_app.so", device_id, device_ip, check=False
-  ).strip()
+    """Reverts the active Cobalt configuration on the device back to Cobalt 25."""
+    target = run_remote_command(
+        "readlink /usr/lib/libloader_app.so", device_id, device_ip, check=False
+    ).strip()
 
-  if target != "/data/out_cobalt/libloader_app.so":
-    print("Cobalt 25 is already active on the device.")
-    return
+    if target != "/data/out_cobalt/libloader_app.so":
+        print("Cobalt 25 is already active on the device.")
+        return
 
-  print("Running 'chCobalt c25' on the device...")
-  run_remote_command("chCobalt c25", device_id, device_ip)
-  run_remote_command("bash -l -c 'reboot -f'", device_id, device_ip, check=False)
-  print("Revert to Cobalt 25 completed. The device is rebooting.")
+    print("Running 'chCobalt c25' on the device...")
+    run_remote_command("chCobalt c25", device_id, device_ip)
+    run_remote_command("bash -l -c 'reboot -f'", device_id, device_ip, check=False)
+    print("Revert to Cobalt 25 completed. The device is rebooting.")
 
 
 def is_toolchain_installed(rdk_home: Optional[str]) -> bool:
-  """Checks if the RDK toolchain is installed in the target path."""
-  return bool(rdk_home and os.path.exists(os.path.join(rdk_home, "sysroots")))
+    """Checks if the RDK toolchain is installed in the target path."""
+    return bool(rdk_home and os.path.exists(os.path.join(rdk_home, "sysroots")))
 
 
 def setup_toolchain() -> None:
-  """Downloads and installs the RDK toolchain."""
-  rdk_home = os.environ.get("RDK_HOME")
-  if not rdk_home:
-    print("Error: RDK_HOME environment variable is not set.")
-    print("Please add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain) and restart your shell.")
-    sys.exit(1)
+    """Downloads and installs the RDK toolchain."""
+    rdk_home = os.environ.get("RDK_HOME")
+    if not rdk_home:
+        print("Error: RDK_HOME environment variable is not set.")
+        print("Please add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain) and restart your shell.")
+        sys.exit(1)
 
-  if is_toolchain_installed(rdk_home):
-    print(f"RDK toolchain is already installed in: {rdk_home}. Skipping setup.")
-    return
+    if is_toolchain_installed(rdk_home):
+        print(f"RDK toolchain is already installed in: {rdk_home}. Skipping setup.")
+        return
 
-  url = "https://storage.googleapis.com/cobalt-static-storage-public/20250521_rdk-glibc-x86_64-arm-toolchain-2.0.sh"
-  print(f"=== Setting up toolchain in: {rdk_home} ===")
-  with tempfile.TemporaryDirectory() as tmp_dir:
-    installer_path = os.path.join(tmp_dir, "installer.sh")
-    run_command(f"wget {url} -O '{installer_path}'")
-    run_command(f"sh '{installer_path}' -d '{rdk_home}' -y")
+    url = "https://storage.googleapis.com/cobalt-static-storage-public/20250521_rdk-glibc-x86_64-arm-toolchain-2.0.sh"
+    print(f"=== Setting up toolchain in: {rdk_home} ===")
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        installer_path = os.path.join(tmp_dir, "installer.sh")
+        run_command(f"wget {url} -O '{installer_path}'")
+        run_command(f"sh '{installer_path}' -d '{rdk_home}' -y")
 
 
 def main() -> None:
-  """Main execution flow."""
-  args = parse_args()
+    """Main execution flow."""
+    args = parse_args()
 
-  if args.deeplink and (args.mode != "plugin" or args.tests):
-    print("Error: --deeplink is only supported when running in plugin mode (without --tests).")
-    sys.exit(1)
+    if args.deeplink and (args.mode != "plugin" or args.tests):
+        print("Error: --deeplink is only supported when running in plugin mode (without --tests).")
+        sys.exit(1)
 
-  if args.setup_toolchain:
-    setup_toolchain()
-    return
+    if args.setup_toolchain:
+        setup_toolchain()
+        return
 
-  device_ip = args.device_ip
-  device_id = None
-  if not device_ip:
-    device_id = get_device_id()
-
-  if args.revert_c25:
-    revert_to_cobalt_25(device_id, device_ip)
-    return
-
-  if args.logs or args.system_logs:
+    device_ip = args.device_ip
+    device_id = None
     if not device_ip:
-      cmd = ["adb", "-s", device_id, "shell", "journalctl"]
+        device_id = get_device_id()
+
+    if args.revert_c25:
+        revert_to_cobalt_25(device_id, device_ip)
+        return
+
+    if args.logs or args.system_logs:
+        if not device_ip:
+            cmd = ["adb", "-s", device_id, "shell", "journalctl"]
+        else:
+            cmd = ["ssh", "-q", f"root@{device_ip}", "journalctl"]
+        if args.logs:
+            cmd.extend([
+                "-t",
+                "YouTube",
+                "-t",
+                "Cobalt",
+                "-t",
+                "loader_app",
+                "-t",
+                "WPEFramework",
+            ])
+        if args.follow:
+            cmd.append("-f")
+        try:
+            run_command(cmd)
+        except KeyboardInterrupt:
+            print("\nLog streaming stopped.")
+        return
+
+    if args.reset:
+        print("=== Resetting display ===")
+        run_remote_command("bash -l -c 'rdkDisplay remove || true'", device_id, device_ip)
+        print("=== Restarting WPEFramework ===")
+        run_remote_command("systemctl restart wpeframework", device_id, device_ip, sleep_time=5)
+        print("=== Cleaning up DevTools ports on host ===")
+        # Always try to kill SSH tunnel on host
+        run_command(["pkill", "-f", "9222:localhost:9222"], check=False)
+        # Try to remove ADB forward if we have a device_id
+        if device_id:
+            run_command(["adb", "-s", device_id, "forward", "--remove", "tcp:9222"], check=False)
+        if not (args.run or args.tests or args.force_deploy):
+            print("=== Reset finished. ===")
+            return
+
+    assert_software_version(device_id, device_ip, MIN_SYSTEM_SOFTWARE_VERSION)
+    if args.mode == "plugin" and not args.tests:
+        check_and_switch_cobalt_version(device_id, device_ip)
+
+    # Setup Build Paths
+    config = args.config or ("devel" if args.tests else "qa")
+    out_dir = Path(args.out_dir or f"out/{PLATFORM}_{config}")
+
+    if args.tests:
+        targets = [f"{args.tests}_loader"]
+        remote_dir = TEST_REMOTE_DIR
+        deps_file = out_dir / f"{args.tests}_loader.runtime_deps"
+    elif args.only_lib:
+        targets = ["cobalt"]
+        remote_dir = DEFAULT_REMOTE_DIR if args.mode == "plugin" else EXECUTABLE_REMOTE_DIR
+        deps_file = None
     else:
-      cmd = ["ssh", "-q", f"root@{device_ip}", "journalctl"]
-    if args.logs:
-      cmd.extend([
-          "-t",
-          "YouTube",
-          "-t",
-          "Cobalt",
-          "-t",
-          "loader_app",
-          "-t",
-          "WPEFramework",
-      ])
-    if args.follow:
-      cmd.append("-f")
+        # Standard deployment uses cobalt_loader to generate the runtime_deps list.
+        targets = ["cobalt_loader", "loader_app"]
+        deps_file = out_dir / "cobalt_loader.runtime_deps"
+        
+        if args.mode == "plugin":
+            targets.append("loader_app_rdk_plugin")
+            remote_dir = DEFAULT_REMOTE_DIR
+        else:
+            remote_dir = EXECUTABLE_REMOTE_DIR
+
+    if not args.skip_build:
+        rdk_home = os.environ.get("RDK_HOME")
+        if not is_toolchain_installed(rdk_home):
+            print(f"Error: RDK toolchain is not set up in RDK_HOME ({rdk_home}).")
+            print("Please run this script with --setup-toolchain to download and install the toolchain.")
+            print("Also, make sure to add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain).")
+            sys.exit(1)
+
+        configure_build(PLATFORM, config, out_dir, args.no_rbe)
+        build_output = build_targets(out_dir, targets)
+        is_up_to_date = build_output and any(
+            msg in build_output for msg in ["Everything is up-to-date", "no work to do"])
+    else:
+        print("=== Skipping build step ===")
+        is_up_to_date = False
+
+    # Check if the remote directory exists on the device.
+    # If it doesn't, we must deploy even if the build is up-to-date.
+    remote_dir_exists = False
     try:
-      run_command(cmd)
-    except KeyboardInterrupt:
-      print("\nLog streaming stopped.")
-    return
+        out = run_remote_command(
+            f"[ -d {remote_dir} ] && echo yes || echo no",
+            device_id,
+            device_ip,
+            check=False,
+            verbose=False,
+        ).strip()
+        remote_dir_exists = (out == "yes")
+    except Exception as e:
+        print(f"[WARNING] Failed to check if remote directory exists: {e}")
 
-  if args.reset:
-    print("=== Resetting display ===")
-    run_remote_command("bash -l -c 'rdkDisplay remove || true'", device_id, device_ip)
-    print("=== Restarting WPEFramework ===")
-    run_remote_command("systemctl restart wpeframework", device_id, device_ip, sleep_time=5)
-    print("=== Cleaning up DevTools ports on host ===")
-    # Always try to kill SSH tunnel on host
-    run_command(["pkill", "-f", "9222:localhost:9222"], check=False)
-    # Try to remove ADB forward if we have a device_id
-    if device_id:
-      run_command(["adb", "-s", device_id, "forward", "--remove", "tcp:9222"], check=False)
-    if not (args.run or args.tests or args.force_deploy):
-      print("=== Reset finished. ===")
-      return
+    skip_deployment = args.skip_deploy or (is_up_to_date and not args.force_deploy and remote_dir_exists)
 
-  assert_software_version(device_id, device_ip, MIN_SYSTEM_SOFTWARE_VERSION)
-  if args.mode == "plugin" and not args.tests:
-    check_and_switch_cobalt_version(device_id, device_ip)
-
-  # Setup Build Paths
-  config = args.config or ("devel" if args.tests else "qa")
-  out_dir = Path(args.out_dir or f"out/{PLATFORM}_{config}")
-
-  if args.tests:
-    targets = [f"{args.tests}_loader"]
-    remote_dir = TEST_REMOTE_DIR
-    deps_file = out_dir / f"{args.tests}_loader.runtime_deps"
-  elif args.only_lib:
-    targets = ["cobalt"]
-    remote_dir = DEFAULT_REMOTE_DIR if args.mode == "plugin" else EXECUTABLE_REMOTE_DIR
-    deps_file = None
-  else:
-    # Standard deployment uses cobalt_loader to generate the runtime_deps list.
-    targets = ["cobalt_loader", "loader_app"]
-    deps_file = out_dir / "cobalt_loader.runtime_deps"
-
-    if args.mode == "plugin":
-      targets.append("loader_app_rdk_plugin")
-      remote_dir = DEFAULT_REMOTE_DIR
+    deployed_archive = False
+    if skip_deployment:
+        print("=== Skipping deployment ===")
+        if not args.run:
+            return
     else:
-      remote_dir = EXECUTABLE_REMOTE_DIR
+        if args.only_lib:
+            deploy_only_lib(device_id, device_ip, out_dir, remote_dir)
+        else:
+            package_and_deploy(device_id, device_ip, out_dir, remote_dir, deps_file, "executable" if args.tests else args.mode)
+            deployed_archive = True
 
-  if not args.skip_build:
-    rdk_home = os.environ.get("RDK_HOME")
-    if not is_toolchain_installed(rdk_home):
-      print(f"Error: RDK toolchain is not set up in RDK_HOME ({rdk_home}).")
-      print("Please run this script with --setup-toolchain to download and install the toolchain.")
-      print("Also, make sure to add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain).")
-      sys.exit(1)
+    if args.run:
+        ensure_dolby_vision_policy(device_id, device_ip)
+        launch_on_device(
+            device_id,
+            device_ip,
+            remote_dir,
+            deployed_archive,
+            args.tests,
+            "executable" if args.tests else args.mode,
+            config != "gold" and args.mode == "plugin" and not args.tests,
+            args.param,
+            args.deeplink,
+        )
 
-    configure_build(PLATFORM, config, out_dir, args.no_rbe)
-    build_output = build_targets(out_dir, targets)
-    is_up_to_date = build_output and any(
-        msg in build_output for msg in ["Everything is up-to-date", "no work to do"])
-  else:
-    print("=== Skipping build step ===")
-    is_up_to_date = False
-
-  # Check if the remote directory exists on the device.
-  # If it doesn't, we must deploy even if the build is up-to-date.
-  remote_dir_exists = False
-  try:
-    out = run_remote_command(
-        f"[ -d {remote_dir} ] && echo yes || echo no",
-        device_id,
-        device_ip,
-        check=False,
-        verbose=False,
-    ).strip()
-    remote_dir_exists = (out == "yes")
-  except Exception as e:
-    print(f"[WARNING] Failed to check if remote directory exists: {e}")
-
-  skip_deployment = args.skip_deploy or (is_up_to_date and not args.force_deploy and remote_dir_exists)
-
-  deployed_archive = False
-  if skip_deployment:
-    print("=== Skipping deployment ===")
-    if not args.run:
-      return
-  else:
-    if args.only_lib:
-      deploy_only_lib(device_id, device_ip, out_dir, remote_dir)
-    else:
-      package_and_deploy(device_id, device_ip, out_dir, remote_dir, deps_file, "executable" if args.tests else args.mode)
-      deployed_archive = True
-
-  if args.run:
-    ensure_dolby_vision_policy(device_id, device_ip)
-    launch_on_device(
-        device_id,
-        device_ip,
-        remote_dir,
-        deployed_archive,
-        args.tests,
-        "executable" if args.tests else args.mode,
-        config != "gold" and args.mode == "plugin" and not args.tests,
-        args.param,
-        args.deeplink,
-    )
-
-  print("=== Finished ===")
+    print("=== Finished ===")
 
 
 if __name__ == "__main__":
-  main()
+    main()

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -105,31 +105,31 @@ def run_command(
     check: bool = True,
     sleep_time: int = 0,
 ) -> str:
-    """Utility to run shell commands."""
+  """Utility to run shell commands."""
+  if verbose:
+    cmd_str = command if isinstance(command, str) else " ".join(command)
+    print(f">>> Executing: {cmd_str}")
+
+  is_shell = isinstance(command, str)
+  process = subprocess.Popen(
+      command, shell=is_shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+  )
+  stdout_lines = []
+  for line in process.stdout:
+    print(line, end="", flush=True)
+    stdout_lines.append(line)
+  process.wait()
+  stdout = "".join(stdout_lines)
+
+  if check and process.returncode != 0:
+    sys.exit(process.returncode)
+
+  if sleep_time > 0:
     if verbose:
-        cmd_str = command if isinstance(command, str) else " ".join(command)
-        print(f">>> Executing: {cmd_str}")
+      print(f"Waiting {sleep_time} seconds...")
+    time.sleep(sleep_time)
 
-    is_shell = isinstance(command, str)
-    process = subprocess.Popen(
-        command, shell=is_shell, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
-    )
-    stdout_lines = []
-    for line in process.stdout:
-        print(line, end="", flush=True)
-        stdout_lines.append(line)
-    process.wait()
-    stdout = "".join(stdout_lines)
-
-    if check and process.returncode != 0:
-        sys.exit(process.returncode)
-
-    if sleep_time > 0:
-        if verbose:
-            print(f"Waiting {sleep_time} seconds...")
-        time.sleep(sleep_time)
-
-    return stdout
+  return stdout
 
 
 def run_remote_command(
@@ -140,23 +140,23 @@ def run_remote_command(
     check: bool = True,
     sleep_time: int = 0,
 ) -> str:
-    """Runs command on remote device via ADB or SSH."""
-    if device_id:
-        adb_cmd = ["adb", "-s", device_id, "shell"]
-        if isinstance(command, str):
-            adb_cmd.append(command)
-        else:
-            adb_cmd.extend(command)
-        return run_command(adb_cmd, verbose, check, sleep_time)
-    elif device_ip:
-        ssh_cmd = ["ssh", "-q", f"root@{device_ip}"]
-        if isinstance(command, str):
-            ssh_cmd.append(command)
-        else:
-            ssh_cmd.append(" ".join(command))
-        return run_command(ssh_cmd, verbose, check, sleep_time)
+  """Runs command on remote device via ADB or SSH."""
+  if device_id:
+    adb_cmd = ["adb", "-s", device_id, "shell"]
+    if isinstance(command, str):
+      adb_cmd.append(command)
     else:
-        raise ValueError("Either device_id or device_ip must be provided for remote command.")
+      adb_cmd.extend(command)
+    return run_command(adb_cmd, verbose, check, sleep_time)
+  elif device_ip:
+    ssh_cmd = ["ssh", "-q", f"root@{device_ip}"]
+    if isinstance(command, str):
+      ssh_cmd.append(command)
+    else:
+      ssh_cmd.append(" ".join(command))
+    return run_command(ssh_cmd, verbose, check, sleep_time)
+  else:
+    raise ValueError("Either device_id or device_ip must be provided for remote command.")
 
 
 def push_to_device(
@@ -166,52 +166,52 @@ def push_to_device(
     device_ip: Optional[str] = None,
     verbose: bool = True,
 ) -> None:
-    """Pushes local file/directory to remote device via ADB or SCP."""
-    if device_id:
-        adb_cmd = ["adb", "-s", device_id, "push", str(local_path), remote_path]
-        run_command(adb_cmd, verbose=verbose)
-    elif device_ip:
-        scp_cmd = [
-            "scp",
-            "-q",
-            "-r",
-            str(local_path),
-            f"root@{device_ip}:{remote_path}",
-        ]
-        run_command(scp_cmd, verbose=verbose)
-    else:
-        raise ValueError("Either device_id or device_ip must be provided to push file.")
+  """Pushes local file/directory to remote device via ADB or SCP."""
+  if device_id:
+    adb_cmd = ["adb", "-s", device_id, "push", str(local_path), remote_path]
+    run_command(adb_cmd, verbose=verbose)
+  elif device_ip:
+    scp_cmd = [
+        "scp",
+        "-q",
+        "-r",
+        str(local_path),
+        f"root@{device_ip}:{remote_path}",
+    ]
+    run_command(scp_cmd, verbose=verbose)
+  else:
+    raise ValueError("Either device_id or device_ip must be provided to push file.")
 
 
 def configure_build(platform: str, config: str, out_dir: Path, no_rbe: bool = False) -> None:
-    """Runs GN configuration."""
-    print(f"=== Configuring {platform} ({config}) ===")
-    cmd = [
-        "python3", "cobalt/build/gn.py", "-p", platform, "-C", config,
-        "--out_directory",
-        str(out_dir)
-    ]
-    if no_rbe:
-        cmd.append("--no-rbe")
-    run_command(cmd)
+  """Runs GN configuration."""
+  print(f"=== Configuring {platform} ({config}) ===")
+  cmd = [
+      "python3", "cobalt/build/gn.py", "-p", platform, "-C", config,
+      "--out_directory",
+      str(out_dir)
+  ]
+  if no_rbe:
+    cmd.append("--no-rbe")
+  run_command(cmd)
 
 
 def build_targets(out_dir: Path, targets: List[str]) -> str:
-    """Builds the specified targets using autoninja."""
-    print(f"=== Building {' '.join(targets)} ===")
-    return run_command(["autoninja", "-C", str(out_dir)] + targets)
+  """Builds the specified targets using autoninja."""
+  print(f"=== Building {' '.join(targets)} ===")
+  return run_command(["autoninja", "-C", str(out_dir)] + targets)
 
 
 def deploy_only_lib(device_id: Optional[str], device_ip: Optional[str], out_dir: Path, remote_dir: str) -> None:
-    """Pushes libcobalt.lz4 directly to the device."""
-    local_lz4 = out_dir / "app/cobalt/lib/libcobalt.lz4"
-    if not local_lz4.exists():
-        print(f"Error: {local_lz4} not found.")
-        sys.exit(1)
+  """Pushes libcobalt.lz4 directly to the device."""
+  local_lz4 = out_dir / "app/cobalt/lib/libcobalt.lz4"
+  if not local_lz4.exists():
+    print(f"Error: {local_lz4} not found.")
+    sys.exit(1)
 
-    remote_lib_dir = f"{remote_dir}/app/cobalt/lib"
-    run_remote_command(f"mkdir -p {remote_lib_dir}", device_id, device_ip)
-    push_to_device(local_lz4, f"{remote_lib_dir}/libcobalt.lz4", device_id, device_ip)
+  remote_lib_dir = f"{remote_dir}/app/cobalt/lib"
+  run_remote_command(f"mkdir -p {remote_lib_dir}", device_id, device_ip)
+  push_to_device(local_lz4, f"{remote_lib_dir}/libcobalt.lz4", device_id, device_ip)
 
 
 def package_and_deploy(
@@ -222,71 +222,56 @@ def package_and_deploy(
     deps_file: Optional[Path],
     mode: str,
 ) -> None:
-    """Packages artifacts using runtime_deps and pushes to device."""
-    print("=== Packaging & Deploying artifacts ===")
-    archive_name = "archive.tar.gz"
+  """Packages artifacts using runtime_deps and pushes to device."""
+  print("=== Packaging & Deploying artifacts ===")
+  archive_name = "archive.tar.gz"
 
-    if deps_file and deps_file.exists():
-        tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "-T", str(deps_file)]
-        if mode == "plugin":
-            tar_cmd.append("libloader_app.so")
-        build_info = out_dir / "gen/build_info.json"
-        if build_info.exists():
-            tar_cmd.append("gen/build_info.json")
-    else:
-        if deps_file:
-            print(f"Warning: deps_file {deps_file} not found.")
-        print(f"Packaging everything in {out_dir}")
-        tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "."]
+  if deps_file and deps_file.exists():
+    tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "-T", str(deps_file)]
+    if mode == "plugin":
+      tar_cmd.append("libloader_app.so")
+    build_info = out_dir / "gen/build_info.json"
+    if build_info.exists():
+      tar_cmd.append("gen/build_info.json")
+  else:
+    if deps_file:
+      print(f"Warning: deps_file {deps_file} not found.")
+    print(f"Packaging everything in {out_dir}")
+    tar_cmd = ["tar", "-czvf", archive_name, "-C", str(out_dir), "."]
 
-    print(f"Packaging with: {' '.join(tar_cmd)}")
-    run_command(tar_cmd)
-    run_remote_command(f"mkdir -p {remote_dir}", device_id, device_ip)
-    push_to_device(archive_name, f"{remote_dir}/", device_id, device_ip)
-    Path(archive_name).unlink(missing_ok=True)
+  print(f"Packaging with: {' '.join(tar_cmd)}")
+  run_command(tar_cmd)
+  run_remote_command(f"mkdir -p {remote_dir}", device_id, device_ip)
+  push_to_device(archive_name, f"{remote_dir}/", device_id, device_ip)
+  Path(archive_name).unlink(missing_ok=True)
 
 
 def ensure_dolby_vision_policy(device_id: Optional[str], device_ip: Optional[str]) -> None:
-    """Ensures /sys/module/aml_media/parameters/dolby_vision_policy is set to 1."""
-    # TODO(b/532753892): Remove this workaround once the device driver is updated.
-    policy_file = "/sys/module/aml_media/parameters/dolby_vision_policy"
-    run_remote_command(f"echo 1 > {policy_file}", device_id, device_ip)
+  """Ensures /sys/module/aml_media/parameters/dolby_vision_policy is set to 1."""
+  # TODO(b/532753892): Remove this workaround once the device driver is updated.
+  policy_file = "/sys/module/aml_media/parameters/dolby_vision_policy"
+  run_remote_command(f"echo 1 > {policy_file}", device_id, device_ip)
 
 
 def _extract_flag_key(arg: str) -> str:
-    """Extracts option key from flag string (e.g. '--foo' from '--foo=val', '--foo val', or '--foo')."""
-    return arg.split("=", 1)[0].split()[0]
+  """Extracts option key from flag string (e.g. '--foo' from '--foo=val' or '--foo')."""
+  return arg.split("=", 1)[0]
 
 
 def _filter_args_by_keys(base_args: List[str], override_args: List[str]) -> List[str]:
-    """Filters flags from base_args whose option keys match any flag in override_args."""
-    override_keys = set()
-    for arg in override_args:
-        if arg.startswith("--"):
-            override_keys.add(_extract_flag_key(arg))
-
-    filtered_args = []
-    i = 0
-    while i < len(base_args):
-        arg = base_args[i]
-        if arg.startswith("--"):
-            key = _extract_flag_key(arg)
-            if key in override_keys:
-                # Key is overridden by override_args. Skip this flag.
-                if "=" not in arg and " " not in arg and (i + 1 < len(base_args)) and not base_args[i + 1].startswith("--"):
-                    i += 1  # Skip space-separated value item (e.g. '1' in '--foo 1' or '--foo', '1')
-            else:
-                filtered_args.append(arg)
-        else:
-            filtered_args.append(arg)
-        i += 1
-
-    return filtered_args
+  """Filters flags from base_args whose option keys match any flag in override_args."""
+  override_keys = {
+      _extract_flag_key(arg) for arg in override_args if arg.startswith("--")
+  }
+  return [
+      arg for arg in base_args
+      if not (arg.startswith("--") and _extract_flag_key(arg) in override_keys)
+  ]
 
 
 def _merge_args(base_args: List[str], override_args: List[str]) -> List[str]:
-    """Replaces flags in base_args with matching option keys from override_args, and appends override_args."""
-    return _filter_args_by_keys(base_args, override_args) + override_args
+  """Replaces flags in base_args with matching option keys from override_args, and appends override_args."""
+  return _filter_args_by_keys(base_args, override_args) + override_args
 
 
 def remove_duplicate_sb_args(
@@ -294,21 +279,21 @@ def remove_duplicate_sb_args(
     script_args: Optional[List[str]] = None,
     user_override_args: Optional[List[str]] = None,
 ) -> List[str]:
-    """Combines cobalt_json_args, script_args, and user_override_args with key deduplication.
+  """Combines cobalt_json_args, script_args, and user_override_args with key deduplication.
 
     Precedence order (highest to lowest):
       1. user_override_args (passed via --param)
       2. script_args (script-added flags e.g. --remote-debugging-port=9222)
       3. cobalt_json_args (pre-existing flags from WPEFramework cobalt.json / sbmainargs)
     """
-    script_args = script_args or []
-    user_override_args = user_override_args or []
+  script_args = script_args or []
+  user_override_args = user_override_args or []
 
-    # 1. Merge script_args with user_override_args
-    override_args = _merge_args(script_args, user_override_args)
+  # 1. Merge script_args with user_override_args
+  override_args = _merge_args(script_args, user_override_args)
 
-    # 2. Merge cobalt_json_args with override_args
-    return _merge_args(cobalt_json_args, override_args)
+  # 2. Merge cobalt_json_args with override_args
+  return _merge_args(cobalt_json_args, override_args)
 
 
 def launch_on_device(
@@ -322,593 +307,593 @@ def launch_on_device(
     param: Optional[List[str]] = None,
     deeplink: Optional[str] = None,
 ) -> None:
-    """Executes remote commands to launch Cobalt or tests."""
-    print("=== Launching on device ===")
-    remote_cmds = [f"cd {remote_dir}"]
+  """Executes remote commands to launch Cobalt or tests."""
+  print("=== Launching on device ===")
+  remote_cmds = [f"cd {remote_dir}"]
 
-    if extract_archive:
-        # Ensure unprivileged container users have access to extracted artifacts.
-        remote_cmds += [
-            "tar -xzf archive.tar.gz",
-            "rm archive.tar.gz",
-            f"chmod -R 777 {remote_dir}",
-        ]
+  if extract_archive:
+    # Ensure unprivileged container users have access to extracted artifacts.
+    remote_cmds += [
+        "tar -xzf archive.tar.gz",
+        "rm archive.tar.gz",
+        f"chmod -R 777 {remote_dir}",
+    ]
 
-    if test_name:
-        remote_cmds += ["rdkDisplay remove || true", "sleep 2", "mkdir -p results"]
-        gtest_filter = ""
-        filter_file = (Path("cobalt/testing/filters") / PLATFORM /
-                       f"{test_name}_loader_filter.json")
-        if filter_file.exists():
-            with open(filter_file) as f:
-                fails = json.load(f).get("failing_tests", [])
-                if fails:
-                    gtest_filter = f" --gtest_filter=-{':'.join(fails)}"
+  if test_name:
+    remote_cmds += ["rdkDisplay remove || true", "sleep 2", "mkdir -p results"]
+    gtest_filter = ""
+    filter_file = (Path("cobalt/testing/filters") / PLATFORM /
+                   f"{test_name}_loader_filter.json")
+    if filter_file.exists():
+      with open(filter_file) as f:
+        fails = json.load(f).get("failing_tests", [])
+        if fails:
+          gtest_filter = f" --gtest_filter=-{':'.join(fails)}"
 
-        xml_out = f"--gtest_output=xml:{remote_dir}/results/{test_name}_loader.xml"
-        remote_cmds += [
-            "rdkDisplay create",
-            "sleep 2",
-            f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./{test_name}_loader.py {xml_out}{gtest_filter}",
-            "rdkDisplay remove",
-            "sleep 2",
-        ]
-    elif mode == "plugin":
+    xml_out = f"--gtest_output=xml:{remote_dir}/results/{test_name}_loader.xml"
+    remote_cmds += [
+        "rdkDisplay create",
+        "sleep 2",
+        f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./{test_name}_loader.py {xml_out}{gtest_filter}",
+        "rdkDisplay remove",
+        "sleep 2",
+    ]
+  elif mode == "plugin":
+    if devtools:
+      print("[INFO] Enabling DevTools support...")
+
+    # Deactivate first to change config
+    deactivate_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.deactivate","params":{"callsign":"YouTube"}}'
+    run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{deactivate_json}'", device_id, device_ip)
+
+    # Get configuration
+    get_config_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.configuration@YouTube"}'
+    res_str = run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{get_config_json}'", device_id, device_ip)
+
+    rpc_deactivate = (
+        r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.deactivate\",'
+        r'\"params\":{\"callsign\":\"YouTube\"}}')
+    try:
+      res = json.loads(res_str.strip())
+      if "result" in res:
+        config = res["result"]
+        cobalt_json_args = config.get("sbmainargs", [])
+
+        script_args = []
         if devtools:
-            print("[INFO] Enabling DevTools support...")
+          script_args.append("--remote-debugging-port=9222")
 
-        # Deactivate first to change config
-        deactivate_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.deactivate","params":{"callsign":"YouTube"}}'
-        run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{deactivate_json}'", device_id, device_ip)
+        user_override_args = param if param else []
 
-        # Get configuration
-        get_config_json = '{"jsonrpc":"2.0","id":1,"method":"Controller.1.configuration@YouTube"}'
-        res_str = run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{get_config_json}'", device_id, device_ip)
+        config["sbmainargs"] = remove_duplicate_sb_args(
+            cobalt_json_args, script_args, user_override_args
+        )
 
-        rpc_deactivate = (
-            r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.deactivate\",'
-            r'\"params\":{\"callsign\":\"YouTube\"}}')
+        # Set configuration
+        rpc_set_config = json.dumps({
+            "jsonrpc": "2.0",
+            "id": 1,
+            "method": "Controller.1.configuration@YouTube",
+            "params": config
+        })
+        run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{rpc_set_config}'", device_id, device_ip)
+        print("[INFO] DevTools configuration updated successfully.")
+    except Exception as e:
+      print(f"[WARNING] Failed to update DevTools configuration: {e}")
+
+    rpc_activate = (
+        r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.activate\",'
+        r'\"params\":{\"callsign\":\"YouTube\"}}')
+    remote_cmds += [
+        "rdkDisplay remove || true",
+        "sleep 2",
+        f"curl http://127.0.0.1:9998/jsonrpc -d '{rpc_deactivate}'",
+        "sleep 2",
+        f"curl -s http://127.0.0.1:9998/jsonrpc -d '{rpc_activate}'",
+    ]
+
+    if deeplink:
+      rpc_deeplink_json = json.dumps({
+          "jsonrpc": "2.0",
+          "id": 3,
+          "method": "YouTube.deeplink",
+          "params": deeplink
+      }).replace('"', r'\"')
+      remote_cmds.append(f"curl -X POST http://127.0.0.1:9998/jsonrpc -d '{rpc_deeplink_json}'")
+
+    if devtools:
+      print("[INFO] Setting up DevTools port forwarding...")
+      if device_id:
+        run_command(["adb", "-s", device_id, "forward", "tcp:9222", "tcp:9222"])
+      elif device_ip:
+        ssh_tunnel_cmd = [
+            "ssh",
+            "-q",
+            "-fN",
+            "-L",
+            "9222:localhost:9222",
+            f"root@{device_ip}",
+        ]
         try:
-            res = json.loads(res_str.strip())
-            if "result" in res:
-                config = res["result"]
-                cobalt_json_args = config.get("sbmainargs", [])
-                
-                script_args = []
-                if devtools:
-                    script_args.append("--remote-debugging-port=9222")
-
-                user_override_args = param if param else []
-
-                config["sbmainargs"] = remove_duplicate_sb_args(
-                    cobalt_json_args, script_args, user_override_args
-                )
-
-                # Set configuration
-                rpc_set_config = json.dumps({
-                    "jsonrpc": "2.0",
-                    "id": 1,
-                    "method": "Controller.1.configuration@YouTube",
-                    "params": config
-                })
-                run_remote_command(f"curl -s http://127.0.0.1:9998/jsonrpc -d '{rpc_set_config}'", device_id, device_ip)
-                print("[INFO] DevTools configuration updated successfully.")
+          subprocess.Popen(ssh_tunnel_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
         except Exception as e:
-            print(f"[WARNING] Failed to update DevTools configuration: {e}")
+          print(f"[WARNING] Failed to start SSH tunnel: {e}")
+      print("[INFO] DevTools is enabled. Please open Chrome and navigate to 'chrome://inspect' (add 'localhost:9222' or the device IP to discover targets).")
+  else:
+    remote_cmds += [
+        "rdkDisplay remove || true",
+        "sleep 2",
+        "rdkDisplay create",
+        "sleep 2",
+        f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app {' '.join(param)}" if param else "XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app",
+        "rdkDisplay remove",
+        "sleep 2",
+    ]
 
-        rpc_activate = (
-            r'{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"Controller.1.activate\",'
-            r'\"params\":{\"callsign\":\"YouTube\"}}')
-        remote_cmds += [
-            "rdkDisplay remove || true",
-            "sleep 2",
-            f"curl http://127.0.0.1:9998/jsonrpc -d '{rpc_deactivate}'",
-            "sleep 2",
-            f"curl -s http://127.0.0.1:9998/jsonrpc -d '{rpc_activate}'",
-        ]
-
-        if deeplink:
-            rpc_deeplink_json = json.dumps({
-                "jsonrpc": "2.0",
-                "id": 3,
-                "method": "YouTube.deeplink",
-                "params": deeplink
-            }).replace('"', r'\"')
-            remote_cmds.append(f"curl -X POST http://127.0.0.1:9998/jsonrpc -d '{rpc_deeplink_json}'")
-
-        if devtools:
-            print("[INFO] Setting up DevTools port forwarding...")
-            if device_id:
-                run_command(["adb", "-s", device_id, "forward", "tcp:9222", "tcp:9222"])
-            elif device_ip:
-                ssh_tunnel_cmd = [
-                    "ssh",
-                    "-q",
-                    "-fN",
-                    "-L",
-                    "9222:localhost:9222",
-                    f"root@{device_ip}",
-                ]
-                try:
-                    subprocess.Popen(ssh_tunnel_cmd, stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL)
-                except Exception as e:
-                    print(f"[WARNING] Failed to start SSH tunnel: {e}")
-            print("[INFO] DevTools is enabled. Please open Chrome and navigate to 'chrome://inspect' (add 'localhost:9222' or the device IP to discover targets).")
-    else:
-        remote_cmds += [
-            "rdkDisplay remove || true",
-            "sleep 2",
-            "rdkDisplay create",
-            "sleep 2",
-            f"XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app {' '.join(param)}" if param else "XDG_RUNTIME_DIR=/run WAYLAND_DISPLAY=test-0 ./loader_app",
-            "rdkDisplay remove",
-            "sleep 2",
-        ]
-
-    full_cmd = " && ".join(remote_cmds)
-    output = run_remote_command(f"bash -l -c \"{full_cmd}\"", device_id, device_ip)
-    print(output)
-    if "ERROR_OPENING_FAILED" in output or "error" in output.lower():
-        print("\n[WARNING] Activation failed with error (e.g., ERROR_OPENING_FAILED).")
-        print("[WARNING] Please check the physical device state. It might be in setup/Out-of-Box Experience (OOBE) mode or not connected to a network.")
+  full_cmd = " && ".join(remote_cmds)
+  output = run_remote_command(f"bash -l -c \"{full_cmd}\"", device_id, device_ip)
+  print(output)
+  if "ERROR_OPENING_FAILED" in output or "error" in output.lower():
+    print("\n[WARNING] Activation failed with error (e.g., ERROR_OPENING_FAILED).")
+    print("[WARNING] Please check the physical device state. It might be in setup/Out-of-Box Experience (OOBE) mode or not connected to a network.")
 
 
 def parse_args() -> argparse.Namespace:
-    """Parses command line arguments."""
-    parser = argparse.ArgumentParser(
-        description="Build and deploy Cobalt to RDK.")
-    parser.add_argument(
-        "--mode",
-        choices=["executable", "plugin"],
-        default="plugin",
-        help="Deploy as standalone executable or plugin (default).",
-    )
-    parser.add_argument(
-        "--only-lib", action="store_true", help="Deploy only libcobalt.lz4.")
-    parser.add_argument(
-        "--tests",
-        type=str,
-        metavar="TEST_NAME",
-        help="Build and run a test (e.g., nplb).",
-    )
-    parser.add_argument(
-        "--device-ip",
-        type=str,
-        help="Target RDK device IP address (uses SSH/SCP instead of ADB).",
-    )
-    parser.add_argument(
-        "--config", type=str, help="Override default build configuration.")
-    parser.add_argument(
-        "--out-dir", type=str, help="Custom build output directory.")
-    parser.add_argument(
-        "--skip-build",
-        action="store_true",
-        help="Skip configure and build steps.",
-    )
-    parser.add_argument(
-        "--skip-deploy",
-        action="store_true",
-        help="Skip deployment step (assumes files are already on the device).",
-    )
-    parser.add_argument(
-        "--run", action="store_true", help="Run on device after build/deploy.")
-    parser.add_argument(
-        "--force-deploy",
-        action="store_true",
-        help="Force deployment even if up-to-date.",
-    )
-    parser.add_argument(
-        "--deeplink",
-        type=str,
-        dest="deeplink",
-        help="Deeplink parameter (e.g. v=dQw4w9WgXcQ) to pass to Cobalt when launching in plugin mode.",
-    )
-    parser.add_argument(
-        "--reset",
-        action="store_true",
-        help=(
-            "Run rdkDisplay remove and restart WPEFramework on the device. "
-            "Useful if the display is inactive or WPEFramework is stuck."),
-    )
-    parser.add_argument(
-        "--setup-toolchain",
-        action="store_true",
-        help="Download and install the RDK toolchain to RDK_HOME.",
-    )
-    parser.add_argument(
-        "--revert-c25",
-        action="store_true",
-        help="Revert the active Cobalt configuration on the device back to Cobalt 25.",
-    )
-    parser.add_argument(
-        "--no-rbe",
-        action="store_true",
-        help="Disable Remote Build Execution (RBE) in GN configuration.",
-    )
-    parser.add_argument(
-        "--logs",
-        action="store_true",
-        help="View system/Cobalt logs from the device.",
-    )
-    parser.add_argument(
-        "--follow",
-        action="store_true",
-        help="Follow log output in real-time (runs journalctl -f).",
-    )
-    parser.add_argument(
-        "--system-logs",
-        action="store_true",
-        help="View global OS/kernel/systemd logs from the device (runs raw journalctl).",
-    )
-    parser.add_argument(
-        "--param",
-        nargs=argparse.REMAINDER,
-        default=[],
-        help=(
-            "Additional runtime parameter(s) to pass to StarboardMain (must be specified last). "
-            "All arguments must start with '--' (positional arguments are not supported)."
-        ),
-    )
-    args = parser.parse_args()
+  """Parses command line arguments."""
+  parser = argparse.ArgumentParser(
+      description="Build and deploy Cobalt to RDK.")
+  parser.add_argument(
+      "--mode",
+      choices=["executable", "plugin"],
+      default="plugin",
+      help="Deploy as standalone executable or plugin (default).",
+  )
+  parser.add_argument(
+      "--only-lib", action="store_true", help="Deploy only libcobalt.lz4.")
+  parser.add_argument(
+      "--tests",
+      type=str,
+      metavar="TEST_NAME",
+      help="Build and run a test (e.g., nplb).",
+  )
+  parser.add_argument(
+      "--device-ip",
+      type=str,
+      help="Target RDK device IP address (uses SSH/SCP instead of ADB).",
+  )
+  parser.add_argument(
+      "--config", type=str, help="Override default build configuration.")
+  parser.add_argument(
+      "--out-dir", type=str, help="Custom build output directory.")
+  parser.add_argument(
+      "--skip-build",
+      action="store_true",
+      help="Skip configure and build steps.",
+  )
+  parser.add_argument(
+      "--skip-deploy",
+      action="store_true",
+      help="Skip deployment step (assumes files are already on the device).",
+  )
+  parser.add_argument(
+      "--run", action="store_true", help="Run on device after build/deploy.")
+  parser.add_argument(
+      "--force-deploy",
+      action="store_true",
+      help="Force deployment even if up-to-date.",
+  )
+  parser.add_argument(
+      "--deeplink",
+      type=str,
+      dest="deeplink",
+      help="Deeplink parameter (e.g. v=dQw4w9WgXcQ) to pass to Cobalt when launching in plugin mode.",
+  )
+  parser.add_argument(
+      "--reset",
+      action="store_true",
+      help=(
+          "Run rdkDisplay remove and restart WPEFramework on the device. "
+          "Useful if the display is inactive or WPEFramework is stuck."),
+  )
+  parser.add_argument(
+      "--setup-toolchain",
+      action="store_true",
+      help="Download and install the RDK toolchain to RDK_HOME.",
+  )
+  parser.add_argument(
+      "--revert-c25",
+      action="store_true",
+      help="Revert the active Cobalt configuration on the device back to Cobalt 25.",
+  )
+  parser.add_argument(
+      "--no-rbe",
+      action="store_true",
+      help="Disable Remote Build Execution (RBE) in GN configuration.",
+  )
+  parser.add_argument(
+      "--logs",
+      action="store_true",
+      help="View system/Cobalt logs from the device.",
+  )
+  parser.add_argument(
+      "--follow",
+      action="store_true",
+      help="Follow log output in real-time (runs journalctl -f).",
+  )
+  parser.add_argument(
+      "--system-logs",
+      action="store_true",
+      help="View global OS/kernel/systemd logs from the device (runs raw journalctl).",
+  )
+  parser.add_argument(
+      "--param",
+      nargs=argparse.REMAINDER,
+      default=[],
+      help=(
+          "Additional runtime parameter(s) to pass to StarboardMain (must be specified last). "
+          "All arguments must start with '--' (positional arguments are not supported)."
+      ),
+  )
+  args = parser.parse_args()
 
-    if args.param:
-        for arg in args.param:
-            if not arg.startswith("--"):
-                print(
-                    f"Error: All arguments passed to --param must start with '--' (positional arguments are not supported). "
-                    f"Positional argument '{arg}' is not supported."
-                )
-                sys.exit(1)
+  if args.param:
+    for arg in args.param:
+      if not arg.startswith("--"):
+        print(
+            f"Error: All arguments passed to --param must start with '--' (positional arguments are not supported). "
+            f"Positional argument '{arg}' is not supported."
+        )
+        sys.exit(1)
 
-    return args
+  return args
 
 
 def get_model_name(device_id: str) -> Optional[str]:
-    """Attempts to retrieve the model name from /etc/device.properties."""
-    try:
-        res = subprocess.run(
-            ["adb", "-s", device_id, "shell", "cat /etc/device.properties"],
-            capture_output=True, text=True, timeout=5
-        )
-        if res.returncode == 0:
-            for line in res.stdout.splitlines():
-                if "MODEL_NAME=" in line:
-                    return line.split("=", 1)[1].strip().strip('"')
-    except Exception:
-        pass
-    return None
+  """Attempts to retrieve the model name from /etc/device.properties."""
+  try:
+    res = subprocess.run(
+        ["adb", "-s", device_id, "shell", "cat /etc/device.properties"],
+        capture_output=True, text=True, timeout=5
+    )
+    if res.returncode == 0:
+      for line in res.stdout.splitlines():
+        if "MODEL_NAME=" in line:
+          return line.split("=", 1)[1].strip().strip('"')
+  except Exception:
+    pass
+  return None
 
 
 def is_rdk_device(device_id: str) -> bool:
-    """Checks if the device is an RDK device by checking if model is AH212."""
-    model = get_model_name(device_id)
-    return model is not None and model.lower() == "ah212"
+  """Checks if the device is an RDK device by checking if model is AH212."""
+  model = get_model_name(device_id)
+  return model is not None and model.lower() == "ah212"
 
 
 def get_device_id() -> str:
-    """Gets the target RDK device ID."""
-    try:
-        result = subprocess.run(
-            ["adb", "devices"],
-            capture_output=True,
-            text=True,
-            check=True
-        )
-    except (subprocess.CalledProcessError, FileNotFoundError) as e:
-        print(f"Error running 'adb devices': {e}")
-        sys.exit(1)
+  """Gets the target RDK device ID."""
+  try:
+    result = subprocess.run(
+        ["adb", "devices"],
+        capture_output=True,
+        text=True,
+        check=True
+    )
+  except (subprocess.CalledProcessError, FileNotFoundError) as e:
+    print(f"Error running 'adb devices': {e}")
+    sys.exit(1)
 
-    # Parse 'adb devices' output to collect online device serial IDs.
-    devices = []
-    for line in result.stdout.strip().split("\n")[1:]:
-        if not line.strip():
-            continue
-        parts = line.split()
-        if len(parts) >= 2 and parts[1] == "device":
-            devices.append(parts[0])
+  # Parse 'adb devices' output to collect online device serial IDs.
+  devices = []
+  for line in result.stdout.strip().split("\n")[1:]:
+    if not line.strip():
+      continue
+    parts = line.split()
+    if len(parts) >= 2 and parts[1] == "device":
+      devices.append(parts[0])
 
-    if not devices:
-        print("Error: No ADB devices connected.")
-        sys.exit(1)
+  if not devices:
+    print("Error: No ADB devices connected.")
+    sys.exit(1)
 
-    # Filter for RDK devices
-    rdk_devices = []
-    for dev in devices:
-        if is_rdk_device(dev):
-            rdk_devices.append(dev)
+  # Filter for RDK devices
+  rdk_devices = []
+  for dev in devices:
+    if is_rdk_device(dev):
+      rdk_devices.append(dev)
 
-    if not rdk_devices:
-        print(f"Error: None of the connected devices {devices} were identified as RDK (AH212).")
-        sys.exit(1)
+  if not rdk_devices:
+    print(f"Error: None of the connected devices {devices} were identified as RDK (AH212).")
+    sys.exit(1)
 
-    # Explicit assumption: if multiple devices are connected, the first one is picked.
-    if len(rdk_devices) > 1:
-        print(f"Note: Multiple RDK devices detected: {rdk_devices}. Picking the first one: {rdk_devices[0]}")
+  # Explicit assumption: if multiple devices are connected, the first one is picked.
+  if len(rdk_devices) > 1:
+    print(f"Note: Multiple RDK devices detected: {rdk_devices}. Picking the first one: {rdk_devices[0]}")
 
-    dev = rdk_devices[0]
-    print(f"Using RDK device: {dev} (AH212)")
-    return dev
+  dev = rdk_devices[0]
+  print(f"Using RDK device: {dev} (AH212)")
+  return dev
 
 
 def assert_software_version(device_id: Optional[str], device_ip: Optional[str], min_version_date: str) -> None:
-    """Asserts that the device software date is at least the min_version_date."""
+  """Asserts that the device software date is at least the min_version_date."""
+  try:
+    output = run_remote_command("cat /version.txt", device_id, device_ip, check=False)
+    if "imagename:" not in output:
+      print("Error: Could not read /version.txt from the device to verify system software version.")
+      print(f"Details: {output}")
+      sys.exit(1)
+
+    custom_version = None
+    for line in output.splitlines():
+      if "custom version:" in line.lower():
+        custom_version = line.split(":", 1)[1].strip()
+        break
+
+    if not custom_version:
+      print("Error: 'custom version' field not found in /version.txt.")
+      sys.exit(1)
+
+    # Extract date suffix from custom version (e.g. RDK_V6_AH212_20260330 -> 20260330)
+    parts = custom_version.split("_")
+    if not parts:
+      print(f"Error: Could not parse date from custom version: {custom_version}")
+      sys.exit(1)
+
+    date_str = parts[-1]
     try:
-        output = run_remote_command("cat /version.txt", device_id, device_ip, check=False)
-        if "imagename:" not in output:
-            print("Error: Could not read /version.txt from the device to verify system software version.")
-            print(f"Details: {output}")
-            sys.exit(1)
+      min_date = datetime.strptime(min_version_date, "%Y%m%d").date()
+    except ValueError:
+      print(f"Error: Invalid min_version_date format: {min_version_date}. Expected YYYYMMDD.")
+      sys.exit(1)
 
-        custom_version = None
-        for line in output.splitlines():
-            if "custom version:" in line.lower():
-                custom_version = line.split(":", 1)[1].strip()
-                break
+    try:
+      device_date = datetime.strptime(date_str, "%Y%m%d").date()
+    except ValueError:
+      print(f"Error: Extracted version suffix '{date_str}' is not a valid YYYYMMDD calendar date.")
+      sys.exit(1)
 
-        if not custom_version:
-            print("Error: 'custom version' field not found in /version.txt.")
-            sys.exit(1)
+    if device_date < min_date:
+      print(f"Error: Device system software version ({date_str}) is older than the required minimum version ({min_version_date}).")
+      sys.exit(1)
 
-        # Extract date suffix from custom version (e.g. RDK_V6_AH212_20260330 -> 20260330)
-        parts = custom_version.split("_")
-        if not parts:
-            print(f"Error: Could not parse date from custom version: {custom_version}")
-            sys.exit(1)
+    print(f"Device system software version verified: {date_str} (required: >= {min_version_date})")
 
-        date_str = parts[-1]
-        try:
-            min_date = datetime.strptime(min_version_date, "%Y%m%d").date()
-        except ValueError:
-            print(f"Error: Invalid min_version_date format: {min_version_date}. Expected YYYYMMDD.")
-            sys.exit(1)
-
-        try:
-            device_date = datetime.strptime(date_str, "%Y%m%d").date()
-        except ValueError:
-            print(f"Error: Extracted version suffix '{date_str}' is not a valid YYYYMMDD calendar date.")
-            sys.exit(1)
-
-        if device_date < min_date:
-            print(f"Error: Device system software version ({date_str}) is older than the required minimum version ({min_version_date}).")
-            sys.exit(1)
-
-        print(f"Device system software version verified: {date_str} (required: >= {min_version_date})")
-
-    except Exception as e:
-        print(f"Error checking software version: {e}")
-        sys.exit(1)
+  except Exception as e:
+    print(f"Error checking software version: {e}")
+    sys.exit(1)
 
 
 def check_and_switch_cobalt_version(device_id: Optional[str], device_ip: Optional[str]) -> None:
-    """Checks if Cobalt 26 is active on the device, otherwise switches and reboots."""
-    try:
-        current_target = run_remote_command(
-            "readlink /usr/lib/libloader_app.so", device_id, device_ip, check=False
-        ).strip()
-
-        if current_target == "/data/out_cobalt/libloader_app.so":
-            print("Cobalt 26 configuration is already active on the device.")
-            return
-
-        print("Cobalt configuration is not active. Running 'chCobalt custom_cobalt' on the device...")
-        run_remote_command("chCobalt custom_cobalt", device_id, device_ip)
-
-        print("Device is being rebooted to apply changes...")
-        run_remote_command("bash -l -c 'reboot'", device_id, device_ip, check=False)
-
-        print("Waiting 30 seconds for the device to reboot...")
-        time.sleep(30)
-
-        print("Attempting to reconnect to device...")
-        reconnected = False
-        for i in range(10): # try up to 10 times with 3 second intervals
-            out = run_remote_command("echo ok", device_id, device_ip, check=False, verbose=False).strip()
-            if out == "ok":
-                reconnected = True
-                break
-            print(f"Device not ready yet. Retrying in 3 seconds... ({i+1}/10)")
-            time.sleep(3)
-
-        if not reconnected:
-            print("Error: Could not reconnect to the device after reboot.")
-            sys.exit(1)
-
-        print("Reconnected to device successfully.")
-
-    except Exception as e:
-        print(f"Error during Cobalt version switch: {e}")
-        sys.exit(1)
-
-
-def revert_to_cobalt_25(device_id: Optional[str], device_ip: Optional[str]) -> None:
-    """Reverts the active Cobalt configuration on the device back to Cobalt 25."""
-    target = run_remote_command(
+  """Checks if Cobalt 26 is active on the device, otherwise switches and reboots."""
+  try:
+    current_target = run_remote_command(
         "readlink /usr/lib/libloader_app.so", device_id, device_ip, check=False
     ).strip()
 
-    if target != "/data/out_cobalt/libloader_app.so":
-        print("Cobalt 25 is already active on the device.")
-        return
+    if current_target == "/data/out_cobalt/libloader_app.so":
+      print("Cobalt 26 configuration is already active on the device.")
+      return
 
-    print("Running 'chCobalt c25' on the device...")
-    run_remote_command("chCobalt c25", device_id, device_ip)
-    run_remote_command("bash -l -c 'reboot -f'", device_id, device_ip, check=False)
-    print("Revert to Cobalt 25 completed. The device is rebooting.")
+    print("Cobalt configuration is not active. Running 'chCobalt custom_cobalt' on the device...")
+    run_remote_command("chCobalt custom_cobalt", device_id, device_ip)
+
+    print("Device is being rebooted to apply changes...")
+    run_remote_command("bash -l -c 'reboot'", device_id, device_ip, check=False)
+
+    print("Waiting 30 seconds for the device to reboot...")
+    time.sleep(30)
+
+    print("Attempting to reconnect to device...")
+    reconnected = False
+    for i in range(10): # try up to 10 times with 3 second intervals
+      out = run_remote_command("echo ok", device_id, device_ip, check=False, verbose=False).strip()
+      if out == "ok":
+        reconnected = True
+        break
+      print(f"Device not ready yet. Retrying in 3 seconds... ({i+1}/10)")
+      time.sleep(3)
+
+    if not reconnected:
+      print("Error: Could not reconnect to the device after reboot.")
+      sys.exit(1)
+
+    print("Reconnected to device successfully.")
+
+  except Exception as e:
+    print(f"Error during Cobalt version switch: {e}")
+    sys.exit(1)
+
+
+def revert_to_cobalt_25(device_id: Optional[str], device_ip: Optional[str]) -> None:
+  """Reverts the active Cobalt configuration on the device back to Cobalt 25."""
+  target = run_remote_command(
+      "readlink /usr/lib/libloader_app.so", device_id, device_ip, check=False
+  ).strip()
+
+  if target != "/data/out_cobalt/libloader_app.so":
+    print("Cobalt 25 is already active on the device.")
+    return
+
+  print("Running 'chCobalt c25' on the device...")
+  run_remote_command("chCobalt c25", device_id, device_ip)
+  run_remote_command("bash -l -c 'reboot -f'", device_id, device_ip, check=False)
+  print("Revert to Cobalt 25 completed. The device is rebooting.")
 
 
 def is_toolchain_installed(rdk_home: Optional[str]) -> bool:
-    """Checks if the RDK toolchain is installed in the target path."""
-    return bool(rdk_home and os.path.exists(os.path.join(rdk_home, "sysroots")))
+  """Checks if the RDK toolchain is installed in the target path."""
+  return bool(rdk_home and os.path.exists(os.path.join(rdk_home, "sysroots")))
 
 
 def setup_toolchain() -> None:
-    """Downloads and installs the RDK toolchain."""
-    rdk_home = os.environ.get("RDK_HOME")
-    if not rdk_home:
-        print("Error: RDK_HOME environment variable is not set.")
-        print("Please add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain) and restart your shell.")
-        sys.exit(1)
+  """Downloads and installs the RDK toolchain."""
+  rdk_home = os.environ.get("RDK_HOME")
+  if not rdk_home:
+    print("Error: RDK_HOME environment variable is not set.")
+    print("Please add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain) and restart your shell.")
+    sys.exit(1)
 
-    if is_toolchain_installed(rdk_home):
-        print(f"RDK toolchain is already installed in: {rdk_home}. Skipping setup.")
-        return
+  if is_toolchain_installed(rdk_home):
+    print(f"RDK toolchain is already installed in: {rdk_home}. Skipping setup.")
+    return
 
-    url = "https://storage.googleapis.com/cobalt-static-storage-public/20250521_rdk-glibc-x86_64-arm-toolchain-2.0.sh"
-    print(f"=== Setting up toolchain in: {rdk_home} ===")
-    with tempfile.TemporaryDirectory() as tmp_dir:
-        installer_path = os.path.join(tmp_dir, "installer.sh")
-        run_command(f"wget {url} -O '{installer_path}'")
-        run_command(f"sh '{installer_path}' -d '{rdk_home}' -y")
+  url = "https://storage.googleapis.com/cobalt-static-storage-public/20250521_rdk-glibc-x86_64-arm-toolchain-2.0.sh"
+  print(f"=== Setting up toolchain in: {rdk_home} ===")
+  with tempfile.TemporaryDirectory() as tmp_dir:
+    installer_path = os.path.join(tmp_dir, "installer.sh")
+    run_command(f"wget {url} -O '{installer_path}'")
+    run_command(f"sh '{installer_path}' -d '{rdk_home}' -y")
 
 
 def main() -> None:
-    """Main execution flow."""
-    args = parse_args()
+  """Main execution flow."""
+  args = parse_args()
 
-    if args.deeplink and (args.mode != "plugin" or args.tests):
-        print("Error: --deeplink is only supported when running in plugin mode (without --tests).")
-        sys.exit(1)
+  if args.deeplink and (args.mode != "plugin" or args.tests):
+    print("Error: --deeplink is only supported when running in plugin mode (without --tests).")
+    sys.exit(1)
 
-    if args.setup_toolchain:
-        setup_toolchain()
-        return
+  if args.setup_toolchain:
+    setup_toolchain()
+    return
 
-    device_ip = args.device_ip
-    device_id = None
+  device_ip = args.device_ip
+  device_id = None
+  if not device_ip:
+    device_id = get_device_id()
+
+  if args.revert_c25:
+    revert_to_cobalt_25(device_id, device_ip)
+    return
+
+  if args.logs or args.system_logs:
     if not device_ip:
-        device_id = get_device_id()
-
-    if args.revert_c25:
-        revert_to_cobalt_25(device_id, device_ip)
-        return
-
-    if args.logs or args.system_logs:
-        if not device_ip:
-            cmd = ["adb", "-s", device_id, "shell", "journalctl"]
-        else:
-            cmd = ["ssh", "-q", f"root@{device_ip}", "journalctl"]
-        if args.logs:
-            cmd.extend([
-                "-t",
-                "YouTube",
-                "-t",
-                "Cobalt",
-                "-t",
-                "loader_app",
-                "-t",
-                "WPEFramework",
-            ])
-        if args.follow:
-            cmd.append("-f")
-        try:
-            run_command(cmd)
-        except KeyboardInterrupt:
-            print("\nLog streaming stopped.")
-        return
-
-    if args.reset:
-        print("=== Resetting display ===")
-        run_remote_command("bash -l -c 'rdkDisplay remove || true'", device_id, device_ip)
-        print("=== Restarting WPEFramework ===")
-        run_remote_command("systemctl restart wpeframework", device_id, device_ip, sleep_time=5)
-        print("=== Cleaning up DevTools ports on host ===")
-        # Always try to kill SSH tunnel on host
-        run_command(["pkill", "-f", "9222:localhost:9222"], check=False)
-        # Try to remove ADB forward if we have a device_id
-        if device_id:
-            run_command(["adb", "-s", device_id, "forward", "--remove", "tcp:9222"], check=False)
-        if not (args.run or args.tests or args.force_deploy):
-            print("=== Reset finished. ===")
-            return
-
-    assert_software_version(device_id, device_ip, MIN_SYSTEM_SOFTWARE_VERSION)
-    if args.mode == "plugin" and not args.tests:
-        check_and_switch_cobalt_version(device_id, device_ip)
-
-    # Setup Build Paths
-    config = args.config or ("devel" if args.tests else "qa")
-    out_dir = Path(args.out_dir or f"out/{PLATFORM}_{config}")
-
-    if args.tests:
-        targets = [f"{args.tests}_loader"]
-        remote_dir = TEST_REMOTE_DIR
-        deps_file = out_dir / f"{args.tests}_loader.runtime_deps"
-    elif args.only_lib:
-        targets = ["cobalt"]
-        remote_dir = DEFAULT_REMOTE_DIR if args.mode == "plugin" else EXECUTABLE_REMOTE_DIR
-        deps_file = None
+      cmd = ["adb", "-s", device_id, "shell", "journalctl"]
     else:
-        # Standard deployment uses cobalt_loader to generate the runtime_deps list.
-        targets = ["cobalt_loader", "loader_app"]
-        deps_file = out_dir / "cobalt_loader.runtime_deps"
-        
-        if args.mode == "plugin":
-            targets.append("loader_app_rdk_plugin")
-            remote_dir = DEFAULT_REMOTE_DIR
-        else:
-            remote_dir = EXECUTABLE_REMOTE_DIR
-
-    if not args.skip_build:
-        rdk_home = os.environ.get("RDK_HOME")
-        if not is_toolchain_installed(rdk_home):
-            print(f"Error: RDK toolchain is not set up in RDK_HOME ({rdk_home}).")
-            print("Please run this script with --setup-toolchain to download and install the toolchain.")
-            print("Also, make sure to add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain).")
-            sys.exit(1)
-
-        configure_build(PLATFORM, config, out_dir, args.no_rbe)
-        build_output = build_targets(out_dir, targets)
-        is_up_to_date = build_output and any(
-            msg in build_output for msg in ["Everything is up-to-date", "no work to do"])
-    else:
-        print("=== Skipping build step ===")
-        is_up_to_date = False
-
-    # Check if the remote directory exists on the device.
-    # If it doesn't, we must deploy even if the build is up-to-date.
-    remote_dir_exists = False
+      cmd = ["ssh", "-q", f"root@{device_ip}", "journalctl"]
+    if args.logs:
+      cmd.extend([
+          "-t",
+          "YouTube",
+          "-t",
+          "Cobalt",
+          "-t",
+          "loader_app",
+          "-t",
+          "WPEFramework",
+      ])
+    if args.follow:
+      cmd.append("-f")
     try:
-        out = run_remote_command(
-            f"[ -d {remote_dir} ] && echo yes || echo no",
-            device_id,
-            device_ip,
-            check=False,
-            verbose=False,
-        ).strip()
-        remote_dir_exists = (out == "yes")
-    except Exception as e:
-        print(f"[WARNING] Failed to check if remote directory exists: {e}")
+      run_command(cmd)
+    except KeyboardInterrupt:
+      print("\nLog streaming stopped.")
+    return
 
-    skip_deployment = args.skip_deploy or (is_up_to_date and not args.force_deploy and remote_dir_exists)
+  if args.reset:
+    print("=== Resetting display ===")
+    run_remote_command("bash -l -c 'rdkDisplay remove || true'", device_id, device_ip)
+    print("=== Restarting WPEFramework ===")
+    run_remote_command("systemctl restart wpeframework", device_id, device_ip, sleep_time=5)
+    print("=== Cleaning up DevTools ports on host ===")
+    # Always try to kill SSH tunnel on host
+    run_command(["pkill", "-f", "9222:localhost:9222"], check=False)
+    # Try to remove ADB forward if we have a device_id
+    if device_id:
+      run_command(["adb", "-s", device_id, "forward", "--remove", "tcp:9222"], check=False)
+    if not (args.run or args.tests or args.force_deploy):
+      print("=== Reset finished. ===")
+      return
 
-    deployed_archive = False
-    if skip_deployment:
-        print("=== Skipping deployment ===")
-        if not args.run:
-            return
+  assert_software_version(device_id, device_ip, MIN_SYSTEM_SOFTWARE_VERSION)
+  if args.mode == "plugin" and not args.tests:
+    check_and_switch_cobalt_version(device_id, device_ip)
+
+  # Setup Build Paths
+  config = args.config or ("devel" if args.tests else "qa")
+  out_dir = Path(args.out_dir or f"out/{PLATFORM}_{config}")
+
+  if args.tests:
+    targets = [f"{args.tests}_loader"]
+    remote_dir = TEST_REMOTE_DIR
+    deps_file = out_dir / f"{args.tests}_loader.runtime_deps"
+  elif args.only_lib:
+    targets = ["cobalt"]
+    remote_dir = DEFAULT_REMOTE_DIR if args.mode == "plugin" else EXECUTABLE_REMOTE_DIR
+    deps_file = None
+  else:
+    # Standard deployment uses cobalt_loader to generate the runtime_deps list.
+    targets = ["cobalt_loader", "loader_app"]
+    deps_file = out_dir / "cobalt_loader.runtime_deps"
+
+    if args.mode == "plugin":
+      targets.append("loader_app_rdk_plugin")
+      remote_dir = DEFAULT_REMOTE_DIR
     else:
-        if args.only_lib:
-            deploy_only_lib(device_id, device_ip, out_dir, remote_dir)
-        else:
-            package_and_deploy(device_id, device_ip, out_dir, remote_dir, deps_file, "executable" if args.tests else args.mode)
-            deployed_archive = True
+      remote_dir = EXECUTABLE_REMOTE_DIR
 
-    if args.run:
-        ensure_dolby_vision_policy(device_id, device_ip)
-        launch_on_device(
-            device_id,
-            device_ip,
-            remote_dir,
-            deployed_archive,
-            args.tests,
-            "executable" if args.tests else args.mode,
-            config != "gold" and args.mode == "plugin" and not args.tests,
-            args.param,
-            args.deeplink,
-        )
+  if not args.skip_build:
+    rdk_home = os.environ.get("RDK_HOME")
+    if not is_toolchain_installed(rdk_home):
+      print(f"Error: RDK toolchain is not set up in RDK_HOME ({rdk_home}).")
+      print("Please run this script with --setup-toolchain to download and install the toolchain.")
+      print("Also, make sure to add it to your ~/.bashrc (e.g., export RDK_HOME=/workspaces/rdk/toolchain).")
+      sys.exit(1)
 
-    print("=== Finished ===")
+    configure_build(PLATFORM, config, out_dir, args.no_rbe)
+    build_output = build_targets(out_dir, targets)
+    is_up_to_date = build_output and any(
+        msg in build_output for msg in ["Everything is up-to-date", "no work to do"])
+  else:
+    print("=== Skipping build step ===")
+    is_up_to_date = False
+
+  # Check if the remote directory exists on the device.
+  # If it doesn't, we must deploy even if the build is up-to-date.
+  remote_dir_exists = False
+  try:
+    out = run_remote_command(
+        f"[ -d {remote_dir} ] && echo yes || echo no",
+        device_id,
+        device_ip,
+        check=False,
+        verbose=False,
+    ).strip()
+    remote_dir_exists = (out == "yes")
+  except Exception as e:
+    print(f"[WARNING] Failed to check if remote directory exists: {e}")
+
+  skip_deployment = args.skip_deploy or (is_up_to_date and not args.force_deploy and remote_dir_exists)
+
+  deployed_archive = False
+  if skip_deployment:
+    print("=== Skipping deployment ===")
+    if not args.run:
+      return
+  else:
+    if args.only_lib:
+      deploy_only_lib(device_id, device_ip, out_dir, remote_dir)
+    else:
+      package_and_deploy(device_id, device_ip, out_dir, remote_dir, deps_file, "executable" if args.tests else args.mode)
+      deployed_archive = True
+
+  if args.run:
+    ensure_dolby_vision_policy(device_id, device_ip)
+    launch_on_device(
+        device_id,
+        device_ip,
+        remote_dir,
+        deployed_archive,
+        args.tests,
+        "executable" if args.tests else args.mode,
+        config != "gold" and args.mode == "plugin" and not args.tests,
+        args.param,
+        args.deeplink,
+    )
+
+  print("=== Finished ===")
 
 
 if __name__ == "__main__":
-    main()
+  main()

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -18,62 +18,14 @@ This script handles the full lifecycle of building, packaging, deploying,
 and launching Cobalt (as a plugin or executable) or Cobalt tests on RDK.
 
 Usage Examples:
-  1. Build and deploy as Cobalt plugin (default: config: qa, out: out/evergreen-arm-hardfp-rdk_qa):
+  1. Build and deploy as Cobalt plugin (default: config: qa):
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
 
-  2. Deploy a pre-built package and run it:
-     python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --out-dir ~/Downloads/evergreen-arm-hardfp-rdk_qa/ --skip-build --run
-
-  3. Build, deploy, and RUN Cobalt plugin on device:
+  2. Build, deploy, and RUN Cobalt plugin or tests on device:
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run
-
-  4. Build, deploy, and RUN nplb tests on device (uses devel config):
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --tests nplb --run
 
-  5. Build and deploy as standalone executable (loader_app):
-     python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --mode executable
-
-  6. Force deploy and run even if artifacts are up-to-date:
-     python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run --force-deploy
-
-  7. Reset RDK display and restart WPEFramework (fixes stuck displays/frozen sessions):
-     python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --reset
-
-  8. Deploy only the libcobalt library:
-     python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --only-lib
-
-  9. View filtered application logs (YouTube/Cobalt):
-     python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --logs
-
-  10. Follow application logs in real-time (journalctl -f):
-      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --logs --follow
-
-  11. View raw global OS/system logs (journalctl):
-      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --system-logs
-
-  12. Build, deploy, and run Cobalt plugin with Chrome DevTools remote debugging enabled:
-      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run --devtools
-
-  13. Download and install cross-compilation toolchain:
-      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --setup-toolchain
-
-  14. Revert active Cobalt loader configuration to Cobalt 25:
-      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --revert-c25
-
-  15. Launch Cobalt plugin with a deep link (e.g. video ID or URL parameter):
-      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run --deeplink "v=dQw4w9WgXcQ"
-  
-  16. Run Cobalt executable with native in-process heap profiling:
-      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py \
-        --mode executable --run --config devel \
-        --param \
-          --enable-heap-profiling \
-          --memlog=all \
-          --memlog-stack-mode=native-with-thread-names \
-          --trace-startup=disabled-by-default-memory-infra \
-          --trace-startup-duration=15 \
-          --trace-startup-format=json \
-          --trace-startup-file=/tmp/trace_event.json
+  (For more complex workflows—such as deep-linking, profiling, DevTools, or log streaming—refer to the script arguments or ask an AI assistant.)
 """
 
 import argparse

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -263,12 +263,12 @@ def _filter_args_by_keys(base_args: List[str], override_args: List[str]) -> List
     override_keys = {
         _extract_flag_key(arg)
         for arg in override_args
-        if arg.startswith("--") and arg != "--"
+        if arg.startswith("--")
     }
     return [
         arg
         for arg in base_args
-        if not (arg.startswith("--") and arg != "--" and _extract_flag_key(arg) in override_keys)
+        if not (arg.startswith("--") and _extract_flag_key(arg) in override_keys)
     ]
 
 

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py
@@ -25,7 +25,7 @@ Usage Examples:
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --run
      python3 starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk.py --tests nplb --run
 
-  (For more complex workflows—such as deep-linking, profiling, DevTools, or log streaming—refer to the script arguments or ask an AI assistant.)
+  (For more complex workflows—such as deep-linking, profiling, DevTools, or log streaming—run the script with --help to see all available parameters.)
 """
 
 import argparse

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk_test.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk_test.py
@@ -34,574 +34,581 @@ _DEPLOY_RDK_PATH = _SCRIPT_DIR / "deploy_rdk.py"
 spec = importlib.util.spec_from_file_location("deploy_rdk", str(_DEPLOY_RDK_PATH))
 deploy_rdk = importlib.util.module_from_spec(spec)
 if spec.loader:
-  spec.loader.exec_module(deploy_rdk)
+    spec.loader.exec_module(deploy_rdk)
 
 
 class TestDeployRdk(unittest.TestCase):
-  """Unit tests for the deploy_rdk script."""
+    """Unit tests for the deploy_rdk script."""
 
-  def setUp(self):
-    """Sets up mocks for all system-level calls."""
-    super().setUp()
-    self.mock_run = mock.patch.object(deploy_rdk, "run_command").start()
-    def run_cmd_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
-      if "cat /version.txt" in cmd_str:
-        return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
-      return "Everything is up-to-date"
-    self.mock_run.side_effect = run_cmd_side_effect
+    def setUp(self):
+        """Sets up mocks for all system-level calls."""
+        super().setUp()
+        self.mock_run = mock.patch.object(deploy_rdk, "run_command").start()
+        def run_cmd_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            if "cat /version.txt" in cmd_str:
+                return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
+            return "Everything is up-to-date"
+        self.mock_run.side_effect = run_cmd_side_effect
 
-    self.mock_sub_run = mock.patch("subprocess.run").start()
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\ntest_device\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-      elif "cat /version.txt" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-      return mock.MagicMock(returncode=0, stdout="")
-    self.mock_sub_run.side_effect = sub_run_side_effect
+        self.mock_sub_run = mock.patch("subprocess.run").start()
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\ntest_device\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+            elif "cat /version.txt" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+            return mock.MagicMock(returncode=0, stdout="")
+        self.mock_sub_run.side_effect = sub_run_side_effect
 
-    # Mock filesystem and environment
-    mock.patch("time.sleep").start()
-    mock.patch("os.path.exists", return_value=True).start()
-    mock.patch("pathlib.Path.exists", return_value=True).start()
-    mock.patch("pathlib.Path.mkdir").start()
-    mock.patch("pathlib.Path.unlink").start()
-    mock.patch("os.remove").start()
-    mock.patch("os.makedirs").start()
-    self.mock_exit = mock.patch("sys.exit").start()
+        # Mock filesystem and environment
+        mock.patch("time.sleep").start()
+        mock.patch("os.path.exists", return_value=True).start()
+        mock.patch("pathlib.Path.exists", return_value=True).start()
+        mock.patch("pathlib.Path.mkdir").start()
+        mock.patch("pathlib.Path.unlink").start()
+        mock.patch("os.remove").start()
+        mock.patch("os.makedirs").start()
+        self.mock_exit = mock.patch("sys.exit").start()
 
-  def tearDown(self):
-    """Cleans up all active mocks."""
-    mock.patch.stopall()
-    super().tearDown()
+    def tearDown(self):
+        """Cleans up all active mocks."""
+        mock.patch.stopall()
+        super().tearDown()
 
-  def test_reset_only(self):
-    """Verifies --reset flag runs rdkDisplay remove and exits early."""
-    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-      deploy_rdk.main()
+    def test_reset_only(self):
+        """Verifies --reset flag runs rdkDisplay remove and exits early."""
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+            deploy_rdk.main()
 
-    found_reset = any(
-        "rdkDisplay remove" in str(call) for call in self.mock_run.call_args_list
-    )
-    self.assertTrue(found_reset, "rdkDisplay remove was not called for --reset")
+        found_reset = any(
+            "rdkDisplay remove" in str(call) for call in self.mock_run.call_args_list
+        )
+        self.assertTrue(found_reset, "rdkDisplay remove was not called for --reset")
 
-  def test_plugin_mode_packaging(self):
-    """Verifies targets and tar command for plugin mode."""
-    self.mock_run.side_effect = lambda *args, **kwargs: ""
+    def test_plugin_mode_packaging(self):
+        """Verifies targets and tar command for plugin mode."""
+        self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-    argv = ["deploy_rdk.py", "--mode", "plugin", "--force-deploy"]
-    with mock.patch("sys.argv", argv):
-      deploy_rdk.main()
+        argv = ["deploy_rdk.py", "--mode", "plugin", "--force-deploy"]
+        with mock.patch("sys.argv", argv):
+            deploy_rdk.main()
 
-    # Check targets built: cobalt_loader, loader_app and loader_app_rdk_plugin
-    build_call = next(call for call in self.mock_run.call_args_list
-                     if "autoninja" in str(call))
-    targets = build_call[0][0]
-    self.assertIn("cobalt_loader", targets)
-    self.assertIn("loader_app", targets)
-    self.assertIn("loader_app_rdk_plugin", targets)
+        # Check targets built: cobalt_loader, loader_app and loader_app_rdk_plugin
+        build_call = next(call for call in self.mock_run.call_args_list 
+                         if "autoninja" in str(call))
+        targets = build_call[0][0]
+        self.assertIn("cobalt_loader", targets)
+        self.assertIn("loader_app", targets)
+        self.assertIn("loader_app_rdk_plugin", targets)
 
-    # Check tar command: robust flag order -czvf, -T <deps_file>, then -C <out_dir>
-    tar_call = next(call for call in self.mock_run.call_args_list
-                   if "tar" in str(call))
-    tar_args = tar_call[0][0]
-    self.assertIn("-czvf", tar_args)
-    self.assertIn("-T", tar_args)
-    self.assertIn("-C", tar_args)
-    self.assertIn("cobalt_loader.runtime_deps", str(tar_args))
-    self.assertIn("libloader_app.so", tar_args)
+        # Check tar command: robust flag order -czvf, -T <deps_file>, then -C <out_dir>
+        tar_call = next(call for call in self.mock_run.call_args_list 
+                       if "tar" in str(call))
+        tar_args = tar_call[0][0]
+        self.assertIn("-czvf", tar_args)
+        self.assertIn("-T", tar_args)
+        self.assertIn("-C", tar_args)
+        self.assertIn("cobalt_loader.runtime_deps", str(tar_args))
+        self.assertIn("libloader_app.so", tar_args)
 
-  def test_executable_mode_packaging(self):
-    """Verifies targets and tar command for executable mode."""
-    self.mock_run.side_effect = lambda *args, **kwargs: ""
+    def test_executable_mode_packaging(self):
+        """Verifies targets and tar command for executable mode."""
+        self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-    argv = ["deploy_rdk.py", "--mode", "executable", "--force-deploy"]
-    with mock.patch("sys.argv", argv):
-      deploy_rdk.main()
+        argv = ["deploy_rdk.py", "--mode", "executable", "--force-deploy"]
+        with mock.patch("sys.argv", argv):
+            deploy_rdk.main()
 
-    # Check targets built: cobalt_loader and loader_app
-    build_call = next(call for call in self.mock_run.call_args_list
-                     if "autoninja" in str(call))
-    targets = build_call[0][0]
-    self.assertIn("cobalt_loader", targets)
-    self.assertIn("loader_app", targets)
-    self.assertNotIn("loader_app_rdk_plugin", targets)
+        # Check targets built: cobalt_loader and loader_app
+        build_call = next(call for call in self.mock_run.call_args_list 
+                         if "autoninja" in str(call))
+        targets = build_call[0][0]
+        self.assertIn("cobalt_loader", targets)
+        self.assertIn("loader_app", targets)
+        self.assertNotIn("loader_app_rdk_plugin", targets)
 
-    # Check tar command: robust flag order -czvf, -T <deps_file>, then -C <out_dir>
-    tar_call = next(call for call in self.mock_run.call_args_list
-                   if "tar" in str(call))
-    tar_args = tar_call[0][0]
-    self.assertIn("-czvf", tar_args)
-    self.assertIn("-T", tar_args)
-    self.assertIn("-C", tar_args)
-    self.assertIn("cobalt_loader.runtime_deps", str(tar_args))
-    self.assertNotIn("libloader_app.so", tar_args)
+        # Check tar command: robust flag order -czvf, -T <deps_file>, then -C <out_dir>
+        tar_call = next(call for call in self.mock_run.call_args_list 
+                       if "tar" in str(call))
+        tar_args = tar_call[0][0]
+        self.assertIn("-czvf", tar_args)
+        self.assertIn("-T", tar_args)
+        self.assertIn("-C", tar_args)
+        self.assertIn("cobalt_loader.runtime_deps", str(tar_args))
+        self.assertNotIn("libloader_app.so", tar_args)
 
-  def test_plugin_mode_launch(self):
-    """Verifies plugin mode uses deactivate -> sleep -> activate sequence."""
-    self.mock_run.side_effect = lambda *args, **kwargs: ""
+    def test_plugin_mode_launch(self):
+        """Verifies plugin mode uses deactivate -> sleep -> activate sequence."""
+        self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-    argv = ["deploy_rdk.py", "--mode", "plugin", "--run", "--force-deploy"]
-    with mock.patch("sys.argv", argv):
-      deploy_rdk.main()
+        argv = ["deploy_rdk.py", "--mode", "plugin", "--run", "--force-deploy"]
+        with mock.patch("sys.argv", argv):
+            deploy_rdk.main()
 
-    full_remote_cmd = ""
-    for call_args in self.mock_run.call_args_list:
-      cmd_arg = str(call_args[0][0])
-      if "Controller.1.activate" in cmd_arg:
-        full_remote_cmd = cmd_arg
-        break
+        full_remote_cmd = ""
+        for call_args in self.mock_run.call_args_list:
+            cmd_arg = str(call_args[0][0])
+            if "Controller.1.activate" in cmd_arg:
+                full_remote_cmd = cmd_arg
+                break
 
-    self.assertIn("Controller.1.deactivate", full_remote_cmd)
-    self.assertIn("Controller.1.activate", full_remote_cmd)
-    self.assertIn("YouTube", full_remote_cmd)
-    self.assertIn("bash -l -c", full_remote_cmd)
-    self.assertIn("/data/out_cobalt", full_remote_cmd)
+        self.assertIn("Controller.1.deactivate", full_remote_cmd)
+        self.assertIn("Controller.1.activate", full_remote_cmd)
+        self.assertIn("YouTube", full_remote_cmd)
+        self.assertIn("bash -l -c", full_remote_cmd)
+        self.assertIn("/data/out_cobalt", full_remote_cmd)
 
-  def test_plugin_mode_deeplink_launch(self):
-    """Verifies plugin mode activates YouTube and executes YouTube.deeplink JSON-RPC call."""
-    def run_cmd_mock(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
-      if "cat /version.txt" in cmd_str:
-        return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
-      elif "Controller.1.configuration@YouTube" in cmd_str:
-        return '{"jsonrpc":"2.0","id":1,"result":{"url":"https://www.youtube.com/tv","sbmainargs":[]}}'
-      return "Everything is up-to-date"
+    def test_plugin_mode_deeplink_launch(self):
+        """Verifies plugin mode activates YouTube and executes YouTube.deeplink JSON-RPC call."""
+        def run_cmd_mock(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            if "cat /version.txt" in cmd_str:
+                return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
+            elif "Controller.1.configuration@YouTube" in cmd_str:
+                return '{"jsonrpc":"2.0","id":1,"result":{"url":"https://www.youtube.com/tv","sbmainargs":[]}}'
+            return "Everything is up-to-date"
 
-    self.mock_run.side_effect = run_cmd_mock
+        self.mock_run.side_effect = run_cmd_mock
 
-    argv = ["deploy_rdk.py", "--mode", "plugin", "--run", "--force-deploy", "--deeplink", "v=dQw4w9WgXcQ"]
-    with mock.patch("sys.argv", argv):
-      deploy_rdk.main()
+        argv = ["deploy_rdk.py", "--mode", "plugin", "--run", "--force-deploy", "--deeplink", "v=dQw4w9WgXcQ"]
+        with mock.patch("sys.argv", argv):
+            deploy_rdk.main()
 
-    deeplink_call = next((call for call in self.mock_run.call_args_list
-                         if "YouTube.deeplink" in str(call)), None)
-    self.assertIsNotNone(deeplink_call)
-    self.assertIn("v=dQw4w9WgXcQ", str(deeplink_call[0][0]))
+        deeplink_call = next((call for call in self.mock_run.call_args_list 
+                             if "YouTube.deeplink" in str(call)), None)
+        self.assertIsNotNone(deeplink_call)
+        self.assertIn("v=dQw4w9WgXcQ", str(deeplink_call[0][0]))
 
-    activate_call = next((call for call in self.mock_run.call_args_list
-                         if "Controller.1.activate" in str(call)), None)
-    self.assertIsNotNone(activate_call)
+        activate_call = next((call for call in self.mock_run.call_args_list 
+                             if "Controller.1.activate" in str(call)), None)
+        self.assertIsNotNone(activate_call)
 
-  def test_deeplink_in_executable_mode_fails(self):
-    """Verifies --deeplink in executable mode fails and exits."""
-    argv = ["deploy_rdk.py", "--mode", "executable", "--run", "--deeplink", "v=123"]
-    with mock.patch("sys.argv", argv):
-      deploy_rdk.main()
+    def test_deeplink_in_executable_mode_fails(self):
+        """Verifies --deeplink in executable mode fails and exits."""
+        argv = ["deploy_rdk.py", "--mode", "executable", "--run", "--deeplink", "v=123"]
+        with mock.patch("sys.argv", argv):
+            deploy_rdk.main()
 
-    self.mock_exit.assert_called_once_with(1)
+        self.mock_exit.assert_called_once_with(1)
 
-  def test_executable_mode_remote_dir(self):
-    """Verifies executable mode uses the correct remote directory."""
-    self.mock_run.side_effect = lambda *args, **kwargs: ""
+    def test_executable_mode_remote_dir(self):
+        """Verifies executable mode uses the correct remote directory."""
+        self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-    argv = ["deploy_rdk.py", "--mode", "executable", "--run", "--force-deploy"]
-    with mock.patch("sys.argv", argv):
-      deploy_rdk.main()
+        argv = ["deploy_rdk.py", "--mode", "executable", "--run", "--force-deploy"]
+        with mock.patch("sys.argv", argv):
+            deploy_rdk.main()
 
-    found_executable_dir = False
-    for call_args in self.mock_run.call_args_list:
-      cmd_arg = str(call_args[0][0])
-      if "/data/out_loader_app_executable" in cmd_arg:
-        found_executable_dir = True
+        found_executable_dir = False
+        for call_args in self.mock_run.call_args_list:
+            cmd_arg = str(call_args[0][0])
+            if "/data/out_loader_app_executable" in cmd_arg:
+                found_executable_dir = True
 
-    self.assertTrue(
-        found_executable_dir,
-        "Executable mode did not use /data/out_loader_app_executable",
-    )
+        self.assertTrue(
+            found_executable_dir,
+            "Executable mode did not use /data/out_loader_app_executable",
+        )
 
-  def test_only_lib_flag(self):
-    """Verifies that --only-lib pushes the lz4 file to correct folder."""
-    self.mock_run.side_effect = lambda *args, **kwargs: ""
+    def test_only_lib_flag(self):
+        """Verifies that --only-lib pushes the lz4 file to correct folder."""
+        self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-    argv = ["deploy_rdk.py", "--only-lib", "--force-deploy"]
-    with mock.patch("sys.argv", argv):
-      deploy_rdk.main()
+        argv = ["deploy_rdk.py", "--only-lib", "--force-deploy"]
+        with mock.patch("sys.argv", argv):
+            deploy_rdk.main()
 
-    found_remote_dir = False
-    found_push = False
-    for call_args in self.mock_run.call_args_list:
-      cmd = call_args[0][0]
-      cmd_str = str(cmd)
-      if "mkdir -p /data/out_cobalt/app/cobalt/lib" in cmd_str:
-        found_remote_dir = True
-      if (
-          "push" in cmd_str
-          and "libcobalt.lz4" in cmd_str
-          and "/data/out_cobalt/app/cobalt/lib" in cmd_str
-      ):
-        found_push = True
+        found_remote_dir = False
+        found_push = False
+        for call_args in self.mock_run.call_args_list:
+            cmd = call_args[0][0]
+            cmd_str = str(cmd)
+            if "mkdir -p /data/out_cobalt/app/cobalt/lib" in cmd_str:
+                found_remote_dir = True
+            if (
+                "push" in cmd_str
+                and "libcobalt.lz4" in cmd_str
+                and "/data/out_cobalt/app/cobalt/lib" in cmd_str
+            ):
+                found_push = True
 
-    self.assertTrue(found_remote_dir, "Did not create remote lib directory")
-    self.assertTrue(found_push, "Did not push libcobalt.lz4 to correct folder")
+        self.assertTrue(found_remote_dir, "Did not create remote lib directory")
+        self.assertTrue(found_push, "Did not push libcobalt.lz4 to correct folder")
 
-  def test_revert_c25(self):
-    """Verifies --revert-c25 runs chCobalt c25 and reboot -f."""
-    self.mock_run.side_effect = None
-    self.mock_run.return_value = "/data/out_cobalt/libloader_app.so"
-    with mock.patch("sys.argv", ["deploy_rdk.py", "--revert-c25"]):
-      deploy_rdk.main()
+    def test_revert_c25(self):
+        """Verifies --revert-c25 runs chCobalt c25 and reboot -f."""
+        self.mock_run.side_effect = None
+        self.mock_run.return_value = "/data/out_cobalt/libloader_app.so"
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--revert-c25"]):
+            deploy_rdk.main()
 
-    calls = [str(c) for c in self.mock_run.call_args_list]
-    self.assertTrue(any("chCobalt c25" in c for c in calls), "chCobalt c25 not called")
-    self.assertTrue(any("reboot -f" in c for c in calls), "reboot -f not called")
+        calls = [str(c) for c in self.mock_run.call_args_list]
+        self.assertTrue(any("chCobalt c25" in c for c in calls), "chCobalt c25 not called")
+        self.assertTrue(any("reboot -f" in c for c in calls), "reboot -f not called")
 
-  def test_no_rbe_flag(self):
-    """Verifies --no-rbe flag passes --no-rbe to GN."""
-    self.mock_run.side_effect = lambda *args, **kwargs: ""
-    with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
-      with mock.patch("sys.argv", ["deploy_rdk.py", "--no-rbe", "--force-deploy"]):
-        deploy_rdk.main()
+    def test_no_rbe_flag(self):
+        """Verifies --no-rbe flag passes --no-rbe to GN."""
+        self.mock_run.side_effect = lambda *args, **kwargs: ""
+        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+            with mock.patch("sys.argv", ["deploy_rdk.py", "--no-rbe", "--force-deploy"]):
+                deploy_rdk.main()
 
-    gn_call = next(c for c in self.mock_run.call_args_list if "gn.py" in str(c))
-    self.assertIn("--no-rbe", gn_call[0][0])
+        gn_call = next(c for c in self.mock_run.call_args_list if "gn.py" in str(c))
+        self.assertIn("--no-rbe", gn_call[0][0])
 
 
 class TestDeployRdkDeviceDetection(unittest.TestCase):
-  """Unit tests for the device auto-detection logic in deploy_rdk script."""
+    """Unit tests for the device auto-detection logic in deploy_rdk script."""
 
-  def setUp(self):
-    super().setUp()
-    self.mock_run = mock.patch.object(deploy_rdk, "run_command").start()
-    def run_cmd_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
-      if "cat /version.txt" in cmd_str:
-        return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
-      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-        return "/data/out_cobalt/libloader_app.so\n"
-      return "Everything is up-to-date"
-    self.mock_run.side_effect = run_cmd_side_effect
+    def setUp(self):
+        super().setUp()
+        self.mock_run = mock.patch.object(deploy_rdk, "run_command").start()
+        def run_cmd_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            if "cat /version.txt" in cmd_str:
+                return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
+            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+                return "/data/out_cobalt/libloader_app.so\n"
+            return "Everything is up-to-date"
+        self.mock_run.side_effect = run_cmd_side_effect
 
-    self.mock_sub_run = mock.patch("subprocess.run").start()
+        self.mock_sub_run = mock.patch("subprocess.run").start()
 
-    # Mock filesystem
-    mock.patch("os.path.exists", return_value=True).start()
-    mock.patch("pathlib.Path.exists", return_value=True).start()
-    mock.patch("pathlib.Path.mkdir").start()
-    mock.patch("pathlib.Path.unlink").start()
-    mock.patch("os.remove").start()
-    mock.patch("os.makedirs").start()
+        # Mock filesystem
+        mock.patch("os.path.exists", return_value=True).start()
+        mock.patch("pathlib.Path.exists", return_value=True).start()
+        mock.patch("pathlib.Path.mkdir").start()
+        mock.patch("pathlib.Path.unlink").start()
+        mock.patch("os.remove").start()
+        mock.patch("os.makedirs").start()
 
-    # Ensure RDK_DEVICE_ID is NOT in env
-    self.env_patcher = mock.patch.dict(os.environ, {}, clear=True)
-    self.env_patcher.start()
+        # Ensure RDK_DEVICE_ID is NOT in env
+        self.env_patcher = mock.patch.dict(os.environ, {}, clear=True)
+        self.env_patcher.start()
 
-    self.mock_exit = mock.patch("sys.exit").start()
-    self.mock_exit.side_effect = SystemExit
+        self.mock_exit = mock.patch("sys.exit").start()
+        self.mock_exit.side_effect = SystemExit
 
-  def tearDown(self):
-    mock.patch.stopall()
-    super().tearDown()
+    def tearDown(self):
+        mock.patch.stopall()
+        super().tearDown()
 
-  def test_no_devices(self):
-    adb_devices_mock = mock.MagicMock(returncode=0, stdout="List of devices attached\n")
-    self.mock_sub_run.return_value = adb_devices_mock
+    def test_no_devices(self):
+        adb_devices_mock = mock.MagicMock(returncode=0, stdout="List of devices attached\n")
+        self.mock_sub_run.return_value = adb_devices_mock
 
-    with mock.patch("sys.argv", ["deploy_rdk.py"]):
-      with self.assertRaises(SystemExit):
-        deploy_rdk.main()
+        with mock.patch("sys.argv", ["deploy_rdk.py"]):
+            with self.assertRaises(SystemExit):
+                deploy_rdk.main()
 
-    self.mock_exit.assert_called_once_with(1)
+        self.mock_exit.assert_called_once_with(1)
 
-  def test_single_device(self):
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-      elif "cat /version.txt" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-      return mock.MagicMock(returncode=1, stdout="")
+    def test_single_device(self):
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+            elif "cat /version.txt" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+            return mock.MagicMock(returncode=1, stdout="")
 
-    self.mock_sub_run.side_effect = sub_run_side_effect
+        self.mock_sub_run.side_effect = sub_run_side_effect
 
-    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-      deploy_rdk.main()
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+            deploy_rdk.main()
 
-    reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
-    self.assertIn("only_device", reset_call[0][0])
-    self.assertEqual(deploy_rdk.get_model_name("only_device"), "AH212")
+        reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
+        self.assertIn("only_device", reset_call[0][0])
+        self.assertEqual(deploy_rdk.get_model_name("only_device"), "AH212")
 
-  def test_single_device_with_device_properties(self):
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\nDEVICE_NAME=ignore_this\n")
-      elif "cat /version.txt" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-      return mock.MagicMock(returncode=0, stdout="")
+    def test_single_device_with_device_properties(self):
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\nDEVICE_NAME=ignore_this\n")
+            elif "cat /version.txt" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+            return mock.MagicMock(returncode=0, stdout="")
 
-    self.mock_sub_run.side_effect = sub_run_side_effect
+        self.mock_sub_run.side_effect = sub_run_side_effect
 
-    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-      deploy_rdk.main()
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+            deploy_rdk.main()
 
-    reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
-    self.assertIn("only_device", reset_call[0][0])
-    self.assertEqual(deploy_rdk.get_model_name("only_device"), "AH212")
+        reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
+        self.assertIn("only_device", reset_call[0][0])
+        self.assertEqual(deploy_rdk.get_model_name("only_device"), "AH212")
 
-  def test_multiple_devices_one_with_rdk_properties(self):
-    # dev1 and dev2. dev2 has device.properties.
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        if "dev2" in cmd_str:
-          return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-        else:
-          return mock.MagicMock(returncode=1, stdout="")
-      elif "cat /version.txt" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-      return mock.MagicMock(returncode=1, stdout="")
+    def test_multiple_devices_one_with_rdk_properties(self):
+        # dev1 and dev2. dev2 has device.properties.
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                if "dev2" in cmd_str:
+                    return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+                else:
+                    return mock.MagicMock(returncode=1, stdout="")
+            elif "cat /version.txt" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+            return mock.MagicMock(returncode=1, stdout="")
 
-    self.mock_sub_run.side_effect = sub_run_side_effect
+        self.mock_sub_run.side_effect = sub_run_side_effect
 
-    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-      deploy_rdk.main()
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+            deploy_rdk.main()
 
-    reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
-    self.assertIn("dev2", reset_call[0][0])
+        reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
+        self.assertIn("dev2", reset_call[0][0])
 
-  def test_multiple_devices_multiple_rdk(self):
-    # Both are RDK devices (device.properties exists)
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-      elif "cat /version.txt" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-      return mock.MagicMock(returncode=1, stdout="")
+    def test_multiple_devices_multiple_rdk(self):
+        # Both are RDK devices (device.properties exists)
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+            elif "cat /version.txt" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+            return mock.MagicMock(returncode=1, stdout="")
 
-    self.mock_sub_run.side_effect = sub_run_side_effect
+        self.mock_sub_run.side_effect = sub_run_side_effect
 
-    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-      deploy_rdk.main()
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+            deploy_rdk.main()
 
-    reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
-    self.assertIn("dev1", reset_call[0][0])
+        reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
+        self.assertIn("dev1", reset_call[0][0])
 
-  def test_multiple_devices_no_rdk(self):
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=1, stdout="")
-      return mock.MagicMock(returncode=1, stdout="")
+    def test_multiple_devices_no_rdk(self):
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=1, stdout="")
+            return mock.MagicMock(returncode=1, stdout="")
 
-    self.mock_sub_run.side_effect = sub_run_side_effect
+        self.mock_sub_run.side_effect = sub_run_side_effect
 
-    with mock.patch("sys.argv", ["deploy_rdk.py"]):
-      with self.assertRaises(SystemExit):
-        deploy_rdk.main()
+        with mock.patch("sys.argv", ["deploy_rdk.py"]):
+            with self.assertRaises(SystemExit):
+                deploy_rdk.main()
 
-    self.mock_exit.assert_called_once_with(1)
+        self.mock_exit.assert_called_once_with(1)
 
-  @mock.patch("time.sleep")
-  def test_switch_cobalt_version_and_reboot(self, mock_sleep):
-    def sub_run_mock(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-      return mock.MagicMock(returncode=0, stdout="")
+    @mock.patch("time.sleep")
+    def test_switch_cobalt_version_and_reboot(self, mock_sleep):
+        def sub_run_mock(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+            return mock.MagicMock(returncode=0, stdout="")
 
-    self.mock_sub_run.side_effect = sub_run_mock
+        self.mock_sub_run.side_effect = sub_run_mock
 
-    def run_cmd_mock(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
-      if "cat /version.txt" in cmd_str:
-        return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
-      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-        return "/usr/lib/libloader_app_c25.so\n"
-      elif "echo ok" in cmd_str:
-        return "ok\n"
-      return "Everything is up-to-date"
+        def run_cmd_mock(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+            if "cat /version.txt" in cmd_str:
+                return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
+            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+                return "/usr/lib/libloader_app_c25.so\n"
+            elif "echo ok" in cmd_str:
+                return "ok\n"
+            return "Everything is up-to-date"
 
-    self.mock_run.side_effect = run_cmd_mock
+        self.mock_run.side_effect = run_cmd_mock
 
-    with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
-      with mock.patch("sys.argv", ["deploy_rdk.py", "--force-deploy"]):
-        deploy_rdk.main()
+        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+            with mock.patch("sys.argv", ["deploy_rdk.py", "--force-deploy"]):
+                deploy_rdk.main()
 
-    # Check that chCobalt custom_cobalt, reboot, and echo ok were called
-    run_calls = [str(call) for call in self.mock_run.call_args_list]
-    self.assertTrue(any("chCobalt custom_cobalt" in call for call in run_calls))
-    self.assertTrue(any("reboot" in call for call in run_calls))
-    self.assertTrue(any("echo ok" in call for call in run_calls))
+        # Check that chCobalt custom_cobalt, reboot, and echo ok were called
+        run_calls = [str(call) for call in self.mock_run.call_args_list]
+        self.assertTrue(any("chCobalt custom_cobalt" in call for call in run_calls))
+        self.assertTrue(any("reboot" in call for call in run_calls))
+        self.assertTrue(any("echo ok" in call for call in run_calls))
+        
+        # Check that sleep was called to wait for reboot
+        mock_sleep.assert_any_call(30)
 
-    # Check that sleep was called to wait for reboot
-    mock_sleep.assert_any_call(30)
+    def test_software_version_too_old(self):
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+            elif "cat /version.txt" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20251218\n")
+            return mock.MagicMock(returncode=1, stdout="")
 
-  def test_software_version_too_old(self):
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-      elif "cat /version.txt" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20251218\n")
-      return mock.MagicMock(returncode=1, stdout="")
+        self.mock_sub_run.side_effect = sub_run_side_effect
 
-    self.mock_sub_run.side_effect = sub_run_side_effect
+        with mock.patch("sys.argv", ["deploy_rdk.py"]):
+            with self.assertRaises(SystemExit):
+                deploy_rdk.main()
 
-    with mock.patch("sys.argv", ["deploy_rdk.py"]):
-      with self.assertRaises(SystemExit):
-        deploy_rdk.main()
+        self.mock_exit.assert_called_once_with(1)
 
-    self.mock_exit.assert_called_once_with(1)
+    def test_software_version_invalid_format(self):
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+            elif "cat /version.txt" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20269999\n")
+            return mock.MagicMock(returncode=1, stdout="")
 
-  def test_software_version_invalid_format(self):
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-      elif "cat /version.txt" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20269999\n")
-      return mock.MagicMock(returncode=1, stdout="")
+        self.mock_sub_run.side_effect = sub_run_side_effect
 
-    self.mock_sub_run.side_effect = sub_run_side_effect
+        with mock.patch("sys.argv", ["deploy_rdk.py"]):
+            with self.assertRaises(SystemExit):
+                deploy_rdk.main()
 
-    with mock.patch("sys.argv", ["deploy_rdk.py"]):
-      with self.assertRaises(SystemExit):
-        deploy_rdk.main()
+        self.mock_exit.assert_called_once_with(1)
 
-    self.mock_exit.assert_called_once_with(1)
+    def test_adb_devices_fails(self):
+        self.mock_sub_run.side_effect = subprocess.CalledProcessError(1, "adb devices")
 
-  def test_adb_devices_fails(self):
-    self.mock_sub_run.side_effect = subprocess.CalledProcessError(1, "adb devices")
+        with mock.patch("sys.argv", ["deploy_rdk.py"]):
+            with self.assertRaises(SystemExit):
+                deploy_rdk.main()
 
-    with mock.patch("sys.argv", ["deploy_rdk.py"]):
-      with self.assertRaises(SystemExit):
-        deploy_rdk.main()
-
-    self.mock_exit.assert_called_once_with(1)
-
-
+        self.mock_exit.assert_called_once_with(1)
 
 
-  @mock.patch("tempfile.TemporaryDirectory")
-  def test_setup_toolchain_uses_temporary_directory(self, mock_temp_dir):
-    mock_temp_dir.return_value.__enter__.return_value = "/tmp/mock_dir"
-    with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
-      with mock.patch("os.path.exists", return_value=False):
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--setup-toolchain"]):
-          deploy_rdk.main()
-    mock_temp_dir.assert_called_once()
 
-  def test_logs_streaming_handles_keyboard_interrupt(self):
-    self.mock_run.side_effect = KeyboardInterrupt
-    def sub_run_side_effect(cmd, *args, **kwargs):
-      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-      if "adb devices" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-      elif "cat /etc/device.properties" in cmd_str:
-        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-      return mock.MagicMock(returncode=0, stdout="")
-    self.mock_sub_run.side_effect = sub_run_side_effect
 
-    with mock.patch("sys.argv", ["deploy_rdk.py", "--logs"]):
-      try:
-        deploy_rdk.main()
-      except KeyboardInterrupt:
-        self.fail("KeyboardInterrupt was not caught by deploy_rdk --logs")
+    @mock.patch("tempfile.TemporaryDirectory")
+    def test_setup_toolchain_uses_temporary_directory(self, mock_temp_dir):
+        mock_temp_dir.return_value.__enter__.return_value = "/tmp/mock_dir"
+        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+            with mock.patch("os.path.exists", return_value=False):
+                with mock.patch("sys.argv", ["deploy_rdk.py", "--setup-toolchain"]):
+                    deploy_rdk.main()
+        mock_temp_dir.assert_called_once()
+
+    def test_logs_streaming_handles_keyboard_interrupt(self):
+        self.mock_run.side_effect = KeyboardInterrupt
+        def sub_run_side_effect(cmd, *args, **kwargs):
+            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+            if "adb devices" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+            elif "cat /etc/device.properties" in cmd_str:
+                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+            return mock.MagicMock(returncode=0, stdout="")
+        self.mock_sub_run.side_effect = sub_run_side_effect
+
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--logs"]):
+            try:
+                deploy_rdk.main()
+            except KeyboardInterrupt:
+                self.fail("KeyboardInterrupt was not caught by deploy_rdk --logs")
 
 
 class TestRemoveDuplicateSbArgs(unittest.TestCase):
-  """Unit tests for remove_duplicate_sb_args function."""
+    """Unit tests for remove_duplicate_sb_args function."""
 
-  def test_inline_key_value(self):
-    """Verifies deduplication of --key=value flags."""
-    sb_args = ["--url=https://old.com", "--v=1"]
-    new_args = ["--url=https://new.com"]
-    result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
-    self.assertEqual(result, ["--v=1", "--url=https://new.com"])
+    def test_inline_key_value(self):
+        """Verifies deduplication of --key=value flags."""
+        sb_args = ["--url=https://old.com", "--v=1"]
+        new_args = ["--url=https://new.com"]
+        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
+        self.assertEqual(result, ["--v=1", "--url=https://new.com"])
 
-  def test_valueless_boolean_flag(self):
-    """Verifies deduplication of valueless/boolean flags."""
-    sb_args = ["--enable-heap-profiling", "--v=1"]
-    new_args = ["--enable-heap-profiling"]
-    result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
-    self.assertEqual(result, ["--v=1", "--enable-heap-profiling"])
+    def test_valueless_boolean_flag(self):
+        """Verifies deduplication of valueless/boolean flags."""
+        sb_args = ["--enable-heap-profiling", "--v=1"]
+        new_args = ["--enable-heap-profiling"]
+        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
+        self.assertEqual(result, ["--v=1", "--enable-heap-profiling"])
 
-  def test_combined_inline_and_boolean_flags(self):
-    """Verifies deduplication when inline and boolean flags are present and overridden."""
-    sb_args = [
-        "--foo=old_inline",
-        "--bar",
-        "--keep=123",
-    ]
-    new_args = [
-        "--foo=new_inline",
-        "--bar",
-    ]
-    result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
-    expected = [
-        "--keep=123",
-        "--foo=new_inline",
-        "--bar",
-    ]
-    self.assertEqual(result, expected)
+    def test_combined_inline_and_boolean_flags(self):
+        """Verifies deduplication when inline and boolean flags are present and overridden."""
+        sb_args = [
+            "--foo=old_inline",
+            "--bar",
+            "--keep=123",
+        ]
+        new_args = [
+            "--foo=new_inline",
+            "--bar",
+        ]
+        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
+        expected = [
+            "--keep=123",
+            "--foo=new_inline",
+            "--bar",
+        ]
+        self.assertEqual(result, expected)
 
-  def test_positional_param_rejection(self):
-    """Verifies parse_args fails when positional arguments are passed to --param."""
-    argv = ["deploy_rdk.py", "--param", "www.youtube.com/tv"]
-    with mock.patch("sys.argv", argv):
-      with mock.patch("sys.exit") as mock_exit:
-        deploy_rdk.parse_args()
-        mock_exit.assert_called_once_with(1)
+    def test_double_dash_separator(self):
+        """Verifies that the double-dash separator '--' is not treated as a flag key and filtered out."""
+        sb_args = ["--v=1", "--", "positional_arg"]
+        new_args = ["--v=2"]
+        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
+        self.assertEqual(result, ["--", "positional_arg", "--v=2"])
 
-  def test_valid_param_flags(self):
-    """Verifies parse_args succeeds when valid -- flags are passed to --param."""
-    argv = ["deploy_rdk.py", "--param", "--url=www.youtube.com/tv", "--enable-heap-profiling"]
-    with mock.patch("sys.argv", argv):
-      args = deploy_rdk.parse_args()
-      self.assertEqual(args.param, ["--url=www.youtube.com/tv", "--enable-heap-profiling"])
+    def test_positional_param_rejection(self):
+        """Verifies parse_args fails when positional arguments are passed to --param."""
+        argv = ["deploy_rdk.py", "--param", "www.youtube.com/tv"]
+        with mock.patch("sys.argv", argv):
+            with mock.patch("sys.exit") as mock_exit:
+                deploy_rdk.parse_args()
+                mock_exit.assert_called_once_with(1)
 
-  def test_user_override_replaces_script_args(self):
-    """Verifies user override flags in --param replace script-added flags if keys collide."""
-    script_args = ["--remote-debugging-port=9222"]
-    user_override_args = ["--remote-debugging-port=9999"]
-    override_args = deploy_rdk.remove_duplicate_sb_args(script_args, user_override_args)
-    self.assertEqual(override_args, ["--remote-debugging-port=9999"])
+    def test_valid_param_flags(self):
+        """Verifies parse_args succeeds when valid -- flags are passed to --param."""
+        argv = ["deploy_rdk.py", "--param", "--url=www.youtube.com/tv", "--enable-heap-profiling"]
+        with mock.patch("sys.argv", argv):
+            args = deploy_rdk.parse_args()
+            self.assertEqual(args.param, ["--url=www.youtube.com/tv", "--enable-heap-profiling"])
 
-  def test_three_arg_precedence(self):
-    """Verifies remove_duplicate_sb_args correctly deduplicates across all 3 argument sources."""
-    cobalt_json_args = ["--v=1", "--remote-debugging-port=8080", "--url=https://old.com"]
-    script_args = ["--remote-debugging-port=9222"]
-    user_override_args = ["--remote-debugging-port=9999", "--enable-heap-profiling"]
+    def test_user_override_replaces_script_args(self):
+        """Verifies user override flags in --param replace script-added flags if keys collide."""
+        script_args = ["--remote-debugging-port=9222"]
+        user_override_args = ["--remote-debugging-port=9999"]
+        override_args = deploy_rdk.remove_duplicate_sb_args(script_args, user_override_args)
+        self.assertEqual(override_args, ["--remote-debugging-port=9999"])
 
-    result = deploy_rdk.remove_duplicate_sb_args(
-        cobalt_json_args, script_args, user_override_args
-    )
-    self.assertEqual(
-        result,
-        ["--v=1", "--url=https://old.com", "--remote-debugging-port=9999", "--enable-heap-profiling"]
-    )
+    def test_three_arg_precedence(self):
+        """Verifies remove_duplicate_sb_args correctly deduplicates across all 3 argument sources."""
+        cobalt_json_args = ["--v=1", "--remote-debugging-port=8080", "--url=https://old.com"]
+        script_args = ["--remote-debugging-port=9222"]
+        user_override_args = ["--remote-debugging-port=9999", "--enable-heap-profiling"]
+
+        result = deploy_rdk.remove_duplicate_sb_args(
+            cobalt_json_args, script_args, user_override_args
+        )
+        self.assertEqual(
+            result,
+            ["--v=1", "--url=https://old.com", "--remote-debugging-port=9999", "--enable-heap-profiling"]
+        )
 
 
 if __name__ == "__main__":
-  unittest.main()
+    unittest.main()

--- a/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk_test.py
+++ b/starboard/contrib/rdk/src/third_party/starboard/rdk/arm/scripts/deploy_rdk_test.py
@@ -34,605 +34,574 @@ _DEPLOY_RDK_PATH = _SCRIPT_DIR / "deploy_rdk.py"
 spec = importlib.util.spec_from_file_location("deploy_rdk", str(_DEPLOY_RDK_PATH))
 deploy_rdk = importlib.util.module_from_spec(spec)
 if spec.loader:
-    spec.loader.exec_module(deploy_rdk)
+  spec.loader.exec_module(deploy_rdk)
 
 
 class TestDeployRdk(unittest.TestCase):
-    """Unit tests for the deploy_rdk script."""
+  """Unit tests for the deploy_rdk script."""
 
-    def setUp(self):
-        """Sets up mocks for all system-level calls."""
-        super().setUp()
-        self.mock_run = mock.patch.object(deploy_rdk, "run_command").start()
-        def run_cmd_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
-            if "cat /version.txt" in cmd_str:
-                return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
-            return "Everything is up-to-date"
-        self.mock_run.side_effect = run_cmd_side_effect
+  def setUp(self):
+    """Sets up mocks for all system-level calls."""
+    super().setUp()
+    self.mock_run = mock.patch.object(deploy_rdk, "run_command").start()
+    def run_cmd_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+      if "cat /version.txt" in cmd_str:
+        return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
+      return "Everything is up-to-date"
+    self.mock_run.side_effect = run_cmd_side_effect
 
-        self.mock_sub_run = mock.patch("subprocess.run").start()
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\ntest_device\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-            elif "cat /version.txt" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-            return mock.MagicMock(returncode=0, stdout="")
-        self.mock_sub_run.side_effect = sub_run_side_effect
+    self.mock_sub_run = mock.patch("subprocess.run").start()
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\ntest_device\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+      elif "cat /version.txt" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+      return mock.MagicMock(returncode=0, stdout="")
+    self.mock_sub_run.side_effect = sub_run_side_effect
 
-        # Mock filesystem and environment
-        mock.patch("time.sleep").start()
-        mock.patch("os.path.exists", return_value=True).start()
-        mock.patch("pathlib.Path.exists", return_value=True).start()
-        mock.patch("pathlib.Path.mkdir").start()
-        mock.patch("pathlib.Path.unlink").start()
-        mock.patch("os.remove").start()
-        mock.patch("os.makedirs").start()
-        self.mock_exit = mock.patch("sys.exit").start()
+    # Mock filesystem and environment
+    mock.patch("time.sleep").start()
+    mock.patch("os.path.exists", return_value=True).start()
+    mock.patch("pathlib.Path.exists", return_value=True).start()
+    mock.patch("pathlib.Path.mkdir").start()
+    mock.patch("pathlib.Path.unlink").start()
+    mock.patch("os.remove").start()
+    mock.patch("os.makedirs").start()
+    self.mock_exit = mock.patch("sys.exit").start()
 
-    def tearDown(self):
-        """Cleans up all active mocks."""
-        mock.patch.stopall()
-        super().tearDown()
+  def tearDown(self):
+    """Cleans up all active mocks."""
+    mock.patch.stopall()
+    super().tearDown()
 
-    def test_reset_only(self):
-        """Verifies --reset flag runs rdkDisplay remove and exits early."""
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-            deploy_rdk.main()
+  def test_reset_only(self):
+    """Verifies --reset flag runs rdkDisplay remove and exits early."""
+    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+      deploy_rdk.main()
 
-        found_reset = any(
-            "rdkDisplay remove" in str(call) for call in self.mock_run.call_args_list
-        )
-        self.assertTrue(found_reset, "rdkDisplay remove was not called for --reset")
+    found_reset = any(
+        "rdkDisplay remove" in str(call) for call in self.mock_run.call_args_list
+    )
+    self.assertTrue(found_reset, "rdkDisplay remove was not called for --reset")
 
-    def test_plugin_mode_packaging(self):
-        """Verifies targets and tar command for plugin mode."""
-        self.mock_run.side_effect = lambda *args, **kwargs: ""
+  def test_plugin_mode_packaging(self):
+    """Verifies targets and tar command for plugin mode."""
+    self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-        argv = ["deploy_rdk.py", "--mode", "plugin", "--force-deploy"]
-        with mock.patch("sys.argv", argv):
-            deploy_rdk.main()
+    argv = ["deploy_rdk.py", "--mode", "plugin", "--force-deploy"]
+    with mock.patch("sys.argv", argv):
+      deploy_rdk.main()
 
-        # Check targets built: cobalt_loader, loader_app and loader_app_rdk_plugin
-        build_call = next(call for call in self.mock_run.call_args_list 
-                         if "autoninja" in str(call))
-        targets = build_call[0][0]
-        self.assertIn("cobalt_loader", targets)
-        self.assertIn("loader_app", targets)
-        self.assertIn("loader_app_rdk_plugin", targets)
+    # Check targets built: cobalt_loader, loader_app and loader_app_rdk_plugin
+    build_call = next(call for call in self.mock_run.call_args_list
+                     if "autoninja" in str(call))
+    targets = build_call[0][0]
+    self.assertIn("cobalt_loader", targets)
+    self.assertIn("loader_app", targets)
+    self.assertIn("loader_app_rdk_plugin", targets)
 
-        # Check tar command: robust flag order -czvf, -T <deps_file>, then -C <out_dir>
-        tar_call = next(call for call in self.mock_run.call_args_list 
-                       if "tar" in str(call))
-        tar_args = tar_call[0][0]
-        self.assertIn("-czvf", tar_args)
-        self.assertIn("-T", tar_args)
-        self.assertIn("-C", tar_args)
-        self.assertIn("cobalt_loader.runtime_deps", str(tar_args))
-        self.assertIn("libloader_app.so", tar_args)
+    # Check tar command: robust flag order -czvf, -T <deps_file>, then -C <out_dir>
+    tar_call = next(call for call in self.mock_run.call_args_list
+                   if "tar" in str(call))
+    tar_args = tar_call[0][0]
+    self.assertIn("-czvf", tar_args)
+    self.assertIn("-T", tar_args)
+    self.assertIn("-C", tar_args)
+    self.assertIn("cobalt_loader.runtime_deps", str(tar_args))
+    self.assertIn("libloader_app.so", tar_args)
 
-    def test_executable_mode_packaging(self):
-        """Verifies targets and tar command for executable mode."""
-        self.mock_run.side_effect = lambda *args, **kwargs: ""
+  def test_executable_mode_packaging(self):
+    """Verifies targets and tar command for executable mode."""
+    self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-        argv = ["deploy_rdk.py", "--mode", "executable", "--force-deploy"]
-        with mock.patch("sys.argv", argv):
-            deploy_rdk.main()
+    argv = ["deploy_rdk.py", "--mode", "executable", "--force-deploy"]
+    with mock.patch("sys.argv", argv):
+      deploy_rdk.main()
 
-        # Check targets built: cobalt_loader and loader_app
-        build_call = next(call for call in self.mock_run.call_args_list 
-                         if "autoninja" in str(call))
-        targets = build_call[0][0]
-        self.assertIn("cobalt_loader", targets)
-        self.assertIn("loader_app", targets)
-        self.assertNotIn("loader_app_rdk_plugin", targets)
+    # Check targets built: cobalt_loader and loader_app
+    build_call = next(call for call in self.mock_run.call_args_list
+                     if "autoninja" in str(call))
+    targets = build_call[0][0]
+    self.assertIn("cobalt_loader", targets)
+    self.assertIn("loader_app", targets)
+    self.assertNotIn("loader_app_rdk_plugin", targets)
 
-        # Check tar command: robust flag order -czvf, -T <deps_file>, then -C <out_dir>
-        tar_call = next(call for call in self.mock_run.call_args_list 
-                       if "tar" in str(call))
-        tar_args = tar_call[0][0]
-        self.assertIn("-czvf", tar_args)
-        self.assertIn("-T", tar_args)
-        self.assertIn("-C", tar_args)
-        self.assertIn("cobalt_loader.runtime_deps", str(tar_args))
-        self.assertNotIn("libloader_app.so", tar_args)
+    # Check tar command: robust flag order -czvf, -T <deps_file>, then -C <out_dir>
+    tar_call = next(call for call in self.mock_run.call_args_list
+                   if "tar" in str(call))
+    tar_args = tar_call[0][0]
+    self.assertIn("-czvf", tar_args)
+    self.assertIn("-T", tar_args)
+    self.assertIn("-C", tar_args)
+    self.assertIn("cobalt_loader.runtime_deps", str(tar_args))
+    self.assertNotIn("libloader_app.so", tar_args)
 
-    def test_plugin_mode_launch(self):
-        """Verifies plugin mode uses deactivate -> sleep -> activate sequence."""
-        self.mock_run.side_effect = lambda *args, **kwargs: ""
+  def test_plugin_mode_launch(self):
+    """Verifies plugin mode uses deactivate -> sleep -> activate sequence."""
+    self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-        argv = ["deploy_rdk.py", "--mode", "plugin", "--run", "--force-deploy"]
-        with mock.patch("sys.argv", argv):
-            deploy_rdk.main()
+    argv = ["deploy_rdk.py", "--mode", "plugin", "--run", "--force-deploy"]
+    with mock.patch("sys.argv", argv):
+      deploy_rdk.main()
 
-        full_remote_cmd = ""
-        for call_args in self.mock_run.call_args_list:
-            cmd_arg = str(call_args[0][0])
-            if "Controller.1.activate" in cmd_arg:
-                full_remote_cmd = cmd_arg
-                break
+    full_remote_cmd = ""
+    for call_args in self.mock_run.call_args_list:
+      cmd_arg = str(call_args[0][0])
+      if "Controller.1.activate" in cmd_arg:
+        full_remote_cmd = cmd_arg
+        break
 
-        self.assertIn("Controller.1.deactivate", full_remote_cmd)
-        self.assertIn("Controller.1.activate", full_remote_cmd)
-        self.assertIn("YouTube", full_remote_cmd)
-        self.assertIn("bash -l -c", full_remote_cmd)
-        self.assertIn("/data/out_cobalt", full_remote_cmd)
+    self.assertIn("Controller.1.deactivate", full_remote_cmd)
+    self.assertIn("Controller.1.activate", full_remote_cmd)
+    self.assertIn("YouTube", full_remote_cmd)
+    self.assertIn("bash -l -c", full_remote_cmd)
+    self.assertIn("/data/out_cobalt", full_remote_cmd)
 
-    def test_plugin_mode_deeplink_launch(self):
-        """Verifies plugin mode activates YouTube and executes YouTube.deeplink JSON-RPC call."""
-        def run_cmd_mock(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
-            if "cat /version.txt" in cmd_str:
-                return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
-            elif "Controller.1.configuration@YouTube" in cmd_str:
-                return '{"jsonrpc":"2.0","id":1,"result":{"url":"https://www.youtube.com/tv","sbmainargs":[]}}'
-            return "Everything is up-to-date"
+  def test_plugin_mode_deeplink_launch(self):
+    """Verifies plugin mode activates YouTube and executes YouTube.deeplink JSON-RPC call."""
+    def run_cmd_mock(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+      if "cat /version.txt" in cmd_str:
+        return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
+      elif "Controller.1.configuration@YouTube" in cmd_str:
+        return '{"jsonrpc":"2.0","id":1,"result":{"url":"https://www.youtube.com/tv","sbmainargs":[]}}'
+      return "Everything is up-to-date"
 
-        self.mock_run.side_effect = run_cmd_mock
+    self.mock_run.side_effect = run_cmd_mock
 
-        argv = ["deploy_rdk.py", "--mode", "plugin", "--run", "--force-deploy", "--deeplink", "v=dQw4w9WgXcQ"]
-        with mock.patch("sys.argv", argv):
-            deploy_rdk.main()
+    argv = ["deploy_rdk.py", "--mode", "plugin", "--run", "--force-deploy", "--deeplink", "v=dQw4w9WgXcQ"]
+    with mock.patch("sys.argv", argv):
+      deploy_rdk.main()
 
-        deeplink_call = next((call for call in self.mock_run.call_args_list 
-                             if "YouTube.deeplink" in str(call)), None)
-        self.assertIsNotNone(deeplink_call)
-        self.assertIn("v=dQw4w9WgXcQ", str(deeplink_call[0][0]))
+    deeplink_call = next((call for call in self.mock_run.call_args_list
+                         if "YouTube.deeplink" in str(call)), None)
+    self.assertIsNotNone(deeplink_call)
+    self.assertIn("v=dQw4w9WgXcQ", str(deeplink_call[0][0]))
 
-        activate_call = next((call for call in self.mock_run.call_args_list 
-                             if "Controller.1.activate" in str(call)), None)
-        self.assertIsNotNone(activate_call)
+    activate_call = next((call for call in self.mock_run.call_args_list
+                         if "Controller.1.activate" in str(call)), None)
+    self.assertIsNotNone(activate_call)
 
-    def test_deeplink_in_executable_mode_fails(self):
-        """Verifies --deeplink in executable mode fails and exits."""
-        argv = ["deploy_rdk.py", "--mode", "executable", "--run", "--deeplink", "v=123"]
-        with mock.patch("sys.argv", argv):
-            deploy_rdk.main()
+  def test_deeplink_in_executable_mode_fails(self):
+    """Verifies --deeplink in executable mode fails and exits."""
+    argv = ["deploy_rdk.py", "--mode", "executable", "--run", "--deeplink", "v=123"]
+    with mock.patch("sys.argv", argv):
+      deploy_rdk.main()
 
-        self.mock_exit.assert_called_once_with(1)
+    self.mock_exit.assert_called_once_with(1)
 
-    def test_executable_mode_remote_dir(self):
-        """Verifies executable mode uses the correct remote directory."""
-        self.mock_run.side_effect = lambda *args, **kwargs: ""
+  def test_executable_mode_remote_dir(self):
+    """Verifies executable mode uses the correct remote directory."""
+    self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-        argv = ["deploy_rdk.py", "--mode", "executable", "--run", "--force-deploy"]
-        with mock.patch("sys.argv", argv):
-            deploy_rdk.main()
+    argv = ["deploy_rdk.py", "--mode", "executable", "--run", "--force-deploy"]
+    with mock.patch("sys.argv", argv):
+      deploy_rdk.main()
 
-        found_executable_dir = False
-        for call_args in self.mock_run.call_args_list:
-            cmd_arg = str(call_args[0][0])
-            if "/data/out_loader_app_executable" in cmd_arg:
-                found_executable_dir = True
+    found_executable_dir = False
+    for call_args in self.mock_run.call_args_list:
+      cmd_arg = str(call_args[0][0])
+      if "/data/out_loader_app_executable" in cmd_arg:
+        found_executable_dir = True
 
-        self.assertTrue(
-            found_executable_dir,
-            "Executable mode did not use /data/out_loader_app_executable",
-        )
+    self.assertTrue(
+        found_executable_dir,
+        "Executable mode did not use /data/out_loader_app_executable",
+    )
 
-    def test_only_lib_flag(self):
-        """Verifies that --only-lib pushes the lz4 file to correct folder."""
-        self.mock_run.side_effect = lambda *args, **kwargs: ""
+  def test_only_lib_flag(self):
+    """Verifies that --only-lib pushes the lz4 file to correct folder."""
+    self.mock_run.side_effect = lambda *args, **kwargs: ""
 
-        argv = ["deploy_rdk.py", "--only-lib", "--force-deploy"]
-        with mock.patch("sys.argv", argv):
-            deploy_rdk.main()
+    argv = ["deploy_rdk.py", "--only-lib", "--force-deploy"]
+    with mock.patch("sys.argv", argv):
+      deploy_rdk.main()
 
-        found_remote_dir = False
-        found_push = False
-        for call_args in self.mock_run.call_args_list:
-            cmd = call_args[0][0]
-            cmd_str = str(cmd)
-            if "mkdir -p /data/out_cobalt/app/cobalt/lib" in cmd_str:
-                found_remote_dir = True
-            if (
-                "push" in cmd_str
-                and "libcobalt.lz4" in cmd_str
-                and "/data/out_cobalt/app/cobalt/lib" in cmd_str
-            ):
-                found_push = True
+    found_remote_dir = False
+    found_push = False
+    for call_args in self.mock_run.call_args_list:
+      cmd = call_args[0][0]
+      cmd_str = str(cmd)
+      if "mkdir -p /data/out_cobalt/app/cobalt/lib" in cmd_str:
+        found_remote_dir = True
+      if (
+          "push" in cmd_str
+          and "libcobalt.lz4" in cmd_str
+          and "/data/out_cobalt/app/cobalt/lib" in cmd_str
+      ):
+        found_push = True
 
-        self.assertTrue(found_remote_dir, "Did not create remote lib directory")
-        self.assertTrue(found_push, "Did not push libcobalt.lz4 to correct folder")
+    self.assertTrue(found_remote_dir, "Did not create remote lib directory")
+    self.assertTrue(found_push, "Did not push libcobalt.lz4 to correct folder")
 
-    def test_revert_c25(self):
-        """Verifies --revert-c25 runs chCobalt c25 and reboot -f."""
-        self.mock_run.side_effect = None
-        self.mock_run.return_value = "/data/out_cobalt/libloader_app.so"
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--revert-c25"]):
-            deploy_rdk.main()
+  def test_revert_c25(self):
+    """Verifies --revert-c25 runs chCobalt c25 and reboot -f."""
+    self.mock_run.side_effect = None
+    self.mock_run.return_value = "/data/out_cobalt/libloader_app.so"
+    with mock.patch("sys.argv", ["deploy_rdk.py", "--revert-c25"]):
+      deploy_rdk.main()
 
-        calls = [str(c) for c in self.mock_run.call_args_list]
-        self.assertTrue(any("chCobalt c25" in c for c in calls), "chCobalt c25 not called")
-        self.assertTrue(any("reboot -f" in c for c in calls), "reboot -f not called")
+    calls = [str(c) for c in self.mock_run.call_args_list]
+    self.assertTrue(any("chCobalt c25" in c for c in calls), "chCobalt c25 not called")
+    self.assertTrue(any("reboot -f" in c for c in calls), "reboot -f not called")
 
-    def test_no_rbe_flag(self):
-        """Verifies --no-rbe flag passes --no-rbe to GN."""
-        self.mock_run.side_effect = lambda *args, **kwargs: ""
-        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
-            with mock.patch("sys.argv", ["deploy_rdk.py", "--no-rbe", "--force-deploy"]):
-                deploy_rdk.main()
+  def test_no_rbe_flag(self):
+    """Verifies --no-rbe flag passes --no-rbe to GN."""
+    self.mock_run.side_effect = lambda *args, **kwargs: ""
+    with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+      with mock.patch("sys.argv", ["deploy_rdk.py", "--no-rbe", "--force-deploy"]):
+        deploy_rdk.main()
 
-        gn_call = next(c for c in self.mock_run.call_args_list if "gn.py" in str(c))
-        self.assertIn("--no-rbe", gn_call[0][0])
+    gn_call = next(c for c in self.mock_run.call_args_list if "gn.py" in str(c))
+    self.assertIn("--no-rbe", gn_call[0][0])
 
 
 class TestDeployRdkDeviceDetection(unittest.TestCase):
-    """Unit tests for the device auto-detection logic in deploy_rdk script."""
+  """Unit tests for the device auto-detection logic in deploy_rdk script."""
 
-    def setUp(self):
-        super().setUp()
-        self.mock_run = mock.patch.object(deploy_rdk, "run_command").start()
-        def run_cmd_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
-            if "cat /version.txt" in cmd_str:
-                return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
-            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-                return "/data/out_cobalt/libloader_app.so\n"
-            return "Everything is up-to-date"
-        self.mock_run.side_effect = run_cmd_side_effect
+  def setUp(self):
+    super().setUp()
+    self.mock_run = mock.patch.object(deploy_rdk, "run_command").start()
+    def run_cmd_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+      if "cat /version.txt" in cmd_str:
+        return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
+      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+        return "/data/out_cobalt/libloader_app.so\n"
+      return "Everything is up-to-date"
+    self.mock_run.side_effect = run_cmd_side_effect
 
-        self.mock_sub_run = mock.patch("subprocess.run").start()
+    self.mock_sub_run = mock.patch("subprocess.run").start()
 
-        # Mock filesystem
-        mock.patch("os.path.exists", return_value=True).start()
-        mock.patch("pathlib.Path.exists", return_value=True).start()
-        mock.patch("pathlib.Path.mkdir").start()
-        mock.patch("pathlib.Path.unlink").start()
-        mock.patch("os.remove").start()
-        mock.patch("os.makedirs").start()
+    # Mock filesystem
+    mock.patch("os.path.exists", return_value=True).start()
+    mock.patch("pathlib.Path.exists", return_value=True).start()
+    mock.patch("pathlib.Path.mkdir").start()
+    mock.patch("pathlib.Path.unlink").start()
+    mock.patch("os.remove").start()
+    mock.patch("os.makedirs").start()
 
-        # Ensure RDK_DEVICE_ID is NOT in env
-        self.env_patcher = mock.patch.dict(os.environ, {}, clear=True)
-        self.env_patcher.start()
+    # Ensure RDK_DEVICE_ID is NOT in env
+    self.env_patcher = mock.patch.dict(os.environ, {}, clear=True)
+    self.env_patcher.start()
 
-        self.mock_exit = mock.patch("sys.exit").start()
-        self.mock_exit.side_effect = SystemExit
+    self.mock_exit = mock.patch("sys.exit").start()
+    self.mock_exit.side_effect = SystemExit
 
-    def tearDown(self):
-        mock.patch.stopall()
-        super().tearDown()
+  def tearDown(self):
+    mock.patch.stopall()
+    super().tearDown()
 
-    def test_no_devices(self):
-        adb_devices_mock = mock.MagicMock(returncode=0, stdout="List of devices attached\n")
-        self.mock_sub_run.return_value = adb_devices_mock
+  def test_no_devices(self):
+    adb_devices_mock = mock.MagicMock(returncode=0, stdout="List of devices attached\n")
+    self.mock_sub_run.return_value = adb_devices_mock
 
-        with mock.patch("sys.argv", ["deploy_rdk.py"]):
-            with self.assertRaises(SystemExit):
-                deploy_rdk.main()
+    with mock.patch("sys.argv", ["deploy_rdk.py"]):
+      with self.assertRaises(SystemExit):
+        deploy_rdk.main()
 
-        self.mock_exit.assert_called_once_with(1)
+    self.mock_exit.assert_called_once_with(1)
 
-    def test_single_device(self):
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-            elif "cat /version.txt" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-            return mock.MagicMock(returncode=1, stdout="")
+  def test_single_device(self):
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+      elif "cat /version.txt" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+      return mock.MagicMock(returncode=1, stdout="")
 
-        self.mock_sub_run.side_effect = sub_run_side_effect
+    self.mock_sub_run.side_effect = sub_run_side_effect
 
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-            deploy_rdk.main()
+    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+      deploy_rdk.main()
 
-        reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
-        self.assertIn("only_device", reset_call[0][0])
-        self.assertEqual(deploy_rdk.get_model_name("only_device"), "AH212")
+    reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
+    self.assertIn("only_device", reset_call[0][0])
+    self.assertEqual(deploy_rdk.get_model_name("only_device"), "AH212")
 
-    def test_single_device_with_device_properties(self):
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\nDEVICE_NAME=ignore_this\n")
-            elif "cat /version.txt" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-            return mock.MagicMock(returncode=0, stdout="")
+  def test_single_device_with_device_properties(self):
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\nDEVICE_NAME=ignore_this\n")
+      elif "cat /version.txt" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+      return mock.MagicMock(returncode=0, stdout="")
 
-        self.mock_sub_run.side_effect = sub_run_side_effect
+    self.mock_sub_run.side_effect = sub_run_side_effect
 
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-            deploy_rdk.main()
+    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+      deploy_rdk.main()
 
-        reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
-        self.assertIn("only_device", reset_call[0][0])
-        self.assertEqual(deploy_rdk.get_model_name("only_device"), "AH212")
+    reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
+    self.assertIn("only_device", reset_call[0][0])
+    self.assertEqual(deploy_rdk.get_model_name("only_device"), "AH212")
 
-    def test_multiple_devices_one_with_rdk_properties(self):
-        # dev1 and dev2. dev2 has device.properties.
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                if "dev2" in cmd_str:
-                    return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-                else:
-                    return mock.MagicMock(returncode=1, stdout="")
-            elif "cat /version.txt" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-            return mock.MagicMock(returncode=1, stdout="")
+  def test_multiple_devices_one_with_rdk_properties(self):
+    # dev1 and dev2. dev2 has device.properties.
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        if "dev2" in cmd_str:
+          return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+        else:
+          return mock.MagicMock(returncode=1, stdout="")
+      elif "cat /version.txt" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+      return mock.MagicMock(returncode=1, stdout="")
 
-        self.mock_sub_run.side_effect = sub_run_side_effect
+    self.mock_sub_run.side_effect = sub_run_side_effect
 
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-            deploy_rdk.main()
+    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+      deploy_rdk.main()
 
-        reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
-        self.assertIn("dev2", reset_call[0][0])
+    reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
+    self.assertIn("dev2", reset_call[0][0])
 
-    def test_multiple_devices_multiple_rdk(self):
-        # Both are RDK devices (device.properties exists)
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-            elif "cat /version.txt" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
-            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
-            return mock.MagicMock(returncode=1, stdout="")
+  def test_multiple_devices_multiple_rdk(self):
+    # Both are RDK devices (device.properties exists)
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+      elif "cat /version.txt" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20260420\n")
+      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="/data/out_cobalt/libloader_app.so\n")
+      return mock.MagicMock(returncode=1, stdout="")
 
-        self.mock_sub_run.side_effect = sub_run_side_effect
+    self.mock_sub_run.side_effect = sub_run_side_effect
 
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
-            deploy_rdk.main()
+    with mock.patch("sys.argv", ["deploy_rdk.py", "--reset"]):
+      deploy_rdk.main()
 
-        reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
-        self.assertIn("dev1", reset_call[0][0])
+    reset_call = next(call for call in self.mock_run.call_args_list if "adb" in str(call))
+    self.assertIn("dev1", reset_call[0][0])
 
-    def test_multiple_devices_no_rdk(self):
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=1, stdout="")
-            return mock.MagicMock(returncode=1, stdout="")
+  def test_multiple_devices_no_rdk(self):
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\ndev1\tdevice\ndev2\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=1, stdout="")
+      return mock.MagicMock(returncode=1, stdout="")
 
-        self.mock_sub_run.side_effect = sub_run_side_effect
+    self.mock_sub_run.side_effect = sub_run_side_effect
 
-        with mock.patch("sys.argv", ["deploy_rdk.py"]):
-            with self.assertRaises(SystemExit):
-                deploy_rdk.main()
+    with mock.patch("sys.argv", ["deploy_rdk.py"]):
+      with self.assertRaises(SystemExit):
+        deploy_rdk.main()
 
-        self.mock_exit.assert_called_once_with(1)
+    self.mock_exit.assert_called_once_with(1)
 
-    @mock.patch("time.sleep")
-    def test_switch_cobalt_version_and_reboot(self, mock_sleep):
-        def sub_run_mock(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-            return mock.MagicMock(returncode=0, stdout="")
+  @mock.patch("time.sleep")
+  def test_switch_cobalt_version_and_reboot(self, mock_sleep):
+    def sub_run_mock(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+      return mock.MagicMock(returncode=0, stdout="")
 
-        self.mock_sub_run.side_effect = sub_run_mock
+    self.mock_sub_run.side_effect = sub_run_mock
 
-        def run_cmd_mock(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
-            if "cat /version.txt" in cmd_str:
-                return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
-            elif "readlink /usr/lib/libloader_app.so" in cmd_str:
-                return "/usr/lib/libloader_app_c25.so\n"
-            elif "echo ok" in cmd_str:
-                return "ok\n"
-            return "Everything is up-to-date"
+    def run_cmd_mock(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else str(cmd)
+      if "cat /version.txt" in cmd_str:
+        return "imagename: RDK_V6\ncustom version: RDK_V6_AH212_20260420\n"
+      elif "readlink /usr/lib/libloader_app.so" in cmd_str:
+        return "/usr/lib/libloader_app_c25.so\n"
+      elif "echo ok" in cmd_str:
+        return "ok\n"
+      return "Everything is up-to-date"
 
-        self.mock_run.side_effect = run_cmd_mock
+    self.mock_run.side_effect = run_cmd_mock
 
-        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
-            with mock.patch("sys.argv", ["deploy_rdk.py", "--force-deploy"]):
-                deploy_rdk.main()
+    with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+      with mock.patch("sys.argv", ["deploy_rdk.py", "--force-deploy"]):
+        deploy_rdk.main()
 
-        # Check that chCobalt custom_cobalt, reboot, and echo ok were called
-        run_calls = [str(call) for call in self.mock_run.call_args_list]
-        self.assertTrue(any("chCobalt custom_cobalt" in call for call in run_calls))
-        self.assertTrue(any("reboot" in call for call in run_calls))
-        self.assertTrue(any("echo ok" in call for call in run_calls))
-        
-        # Check that sleep was called to wait for reboot
-        mock_sleep.assert_any_call(30)
+    # Check that chCobalt custom_cobalt, reboot, and echo ok were called
+    run_calls = [str(call) for call in self.mock_run.call_args_list]
+    self.assertTrue(any("chCobalt custom_cobalt" in call for call in run_calls))
+    self.assertTrue(any("reboot" in call for call in run_calls))
+    self.assertTrue(any("echo ok" in call for call in run_calls))
 
-    def test_software_version_too_old(self):
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-            elif "cat /version.txt" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20251218\n")
-            return mock.MagicMock(returncode=1, stdout="")
+    # Check that sleep was called to wait for reboot
+    mock_sleep.assert_any_call(30)
 
-        self.mock_sub_run.side_effect = sub_run_side_effect
+  def test_software_version_too_old(self):
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+      elif "cat /version.txt" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20251218\n")
+      return mock.MagicMock(returncode=1, stdout="")
 
-        with mock.patch("sys.argv", ["deploy_rdk.py"]):
-            with self.assertRaises(SystemExit):
-                deploy_rdk.main()
+    self.mock_sub_run.side_effect = sub_run_side_effect
 
-        self.mock_exit.assert_called_once_with(1)
+    with mock.patch("sys.argv", ["deploy_rdk.py"]):
+      with self.assertRaises(SystemExit):
+        deploy_rdk.main()
 
-    def test_software_version_invalid_format(self):
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-            elif "cat /version.txt" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20269999\n")
-            return mock.MagicMock(returncode=1, stdout="")
+    self.mock_exit.assert_called_once_with(1)
 
-        self.mock_sub_run.side_effect = sub_run_side_effect
+  def test_software_version_invalid_format(self):
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+      elif "cat /version.txt" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="custom version: RDK_V6_AH212_20269999\n")
+      return mock.MagicMock(returncode=1, stdout="")
 
-        with mock.patch("sys.argv", ["deploy_rdk.py"]):
-            with self.assertRaises(SystemExit):
-                deploy_rdk.main()
+    self.mock_sub_run.side_effect = sub_run_side_effect
 
-        self.mock_exit.assert_called_once_with(1)
+    with mock.patch("sys.argv", ["deploy_rdk.py"]):
+      with self.assertRaises(SystemExit):
+        deploy_rdk.main()
 
-    def test_adb_devices_fails(self):
-        self.mock_sub_run.side_effect = subprocess.CalledProcessError(1, "adb devices")
+    self.mock_exit.assert_called_once_with(1)
 
-        with mock.patch("sys.argv", ["deploy_rdk.py"]):
-            with self.assertRaises(SystemExit):
-                deploy_rdk.main()
+  def test_adb_devices_fails(self):
+    self.mock_sub_run.side_effect = subprocess.CalledProcessError(1, "adb devices")
 
-        self.mock_exit.assert_called_once_with(1)
+    with mock.patch("sys.argv", ["deploy_rdk.py"]):
+      with self.assertRaises(SystemExit):
+        deploy_rdk.main()
 
-
+    self.mock_exit.assert_called_once_with(1)
 
 
-    @mock.patch("tempfile.TemporaryDirectory")
-    def test_setup_toolchain_uses_temporary_directory(self, mock_temp_dir):
-        mock_temp_dir.return_value.__enter__.return_value = "/tmp/mock_dir"
-        with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
-            with mock.patch("os.path.exists", return_value=False):
-                with mock.patch("sys.argv", ["deploy_rdk.py", "--setup-toolchain"]):
-                    deploy_rdk.main()
-        mock_temp_dir.assert_called_once()
 
-    def test_logs_streaming_handles_keyboard_interrupt(self):
-        self.mock_run.side_effect = KeyboardInterrupt
-        def sub_run_side_effect(cmd, *args, **kwargs):
-            cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
-            if "adb devices" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
-            elif "cat /etc/device.properties" in cmd_str:
-                return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
-            return mock.MagicMock(returncode=0, stdout="")
-        self.mock_sub_run.side_effect = sub_run_side_effect
 
-        with mock.patch("sys.argv", ["deploy_rdk.py", "--logs"]):
-            try:
-                deploy_rdk.main()
-            except KeyboardInterrupt:
-                self.fail("KeyboardInterrupt was not caught by deploy_rdk --logs")
+  @mock.patch("tempfile.TemporaryDirectory")
+  def test_setup_toolchain_uses_temporary_directory(self, mock_temp_dir):
+    mock_temp_dir.return_value.__enter__.return_value = "/tmp/mock_dir"
+    with mock.patch.dict(os.environ, {"RDK_HOME": "/mock/rdk/home"}):
+      with mock.patch("os.path.exists", return_value=False):
+        with mock.patch("sys.argv", ["deploy_rdk.py", "--setup-toolchain"]):
+          deploy_rdk.main()
+    mock_temp_dir.assert_called_once()
+
+  def test_logs_streaming_handles_keyboard_interrupt(self):
+    self.mock_run.side_effect = KeyboardInterrupt
+    def sub_run_side_effect(cmd, *args, **kwargs):
+      cmd_str = " ".join(cmd) if isinstance(cmd, list) else cmd
+      if "adb devices" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="List of devices attached\nonly_device\tdevice\n")
+      elif "cat /etc/device.properties" in cmd_str:
+        return mock.MagicMock(returncode=0, stdout="MODEL_NAME=AH212\n")
+      return mock.MagicMock(returncode=0, stdout="")
+    self.mock_sub_run.side_effect = sub_run_side_effect
+
+    with mock.patch("sys.argv", ["deploy_rdk.py", "--logs"]):
+      try:
+        deploy_rdk.main()
+      except KeyboardInterrupt:
+        self.fail("KeyboardInterrupt was not caught by deploy_rdk --logs")
 
 
 class TestRemoveDuplicateSbArgs(unittest.TestCase):
-    """Unit tests for remove_duplicate_sb_args function."""
+  """Unit tests for remove_duplicate_sb_args function."""
 
-    def test_inline_key_value(self):
-        """Verifies deduplication of --key=value flags."""
-        sb_args = ["--url=https://old.com", "--v=1"]
-        new_args = ["--url=https://new.com"]
-        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
-        self.assertEqual(result, ["--v=1", "--url=https://new.com"])
+  def test_inline_key_value(self):
+    """Verifies deduplication of --key=value flags."""
+    sb_args = ["--url=https://old.com", "--v=1"]
+    new_args = ["--url=https://new.com"]
+    result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
+    self.assertEqual(result, ["--v=1", "--url=https://new.com"])
 
-    def test_valueless_boolean_flag(self):
-        """Verifies deduplication of valueless/boolean flags."""
-        sb_args = ["--enable-heap-profiling", "--v=1"]
-        new_args = ["--enable-heap-profiling"]
-        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
-        self.assertEqual(result, ["--v=1", "--enable-heap-profiling"])
+  def test_valueless_boolean_flag(self):
+    """Verifies deduplication of valueless/boolean flags."""
+    sb_args = ["--enable-heap-profiling", "--v=1"]
+    new_args = ["--enable-heap-profiling"]
+    result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
+    self.assertEqual(result, ["--v=1", "--enable-heap-profiling"])
 
-    def test_space_separated_key_value(self):
-        """Verifies deduplication of space-separated --key value arguments."""
-        # When sb_args has space-separated key and value
-        sb_args = ["--bar", "old_val", "--v=1"]
-        new_args = ["--bar=new_val"]
-        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
-        self.assertEqual(result, ["--v=1", "--bar=new_val"])
+  def test_combined_inline_and_boolean_flags(self):
+    """Verifies deduplication when inline and boolean flags are present and overridden."""
+    sb_args = [
+        "--foo=old_inline",
+        "--bar",
+        "--keep=123",
+    ]
+    new_args = [
+        "--foo=new_inline",
+        "--bar",
+    ]
+    result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
+    expected = [
+        "--keep=123",
+        "--foo=new_inline",
+        "--bar",
+    ]
+    self.assertEqual(result, expected)
 
-        # When both sb_args and new_args use space-separated key and value
-        sb_args = ["--bar", "old_val", "--v=1"]
-        new_args = ["--bar", "new_val"]
-        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
-        self.assertEqual(result, ["--v=1", "--bar", "new_val"])
+  def test_positional_param_rejection(self):
+    """Verifies parse_args fails when positional arguments are passed to --param."""
+    argv = ["deploy_rdk.py", "--param", "www.youtube.com/tv"]
+    with mock.patch("sys.argv", argv):
+      with mock.patch("sys.exit") as mock_exit:
+        deploy_rdk.parse_args()
+        mock_exit.assert_called_once_with(1)
 
-    def test_all_three_flag_types_combined(self):
-        """Verifies deduplication when inline, valueless, and space-separated flags are all present and overridden."""
-        sb_args = [
-            "--foo=old_inline",
-            "--bar",
-            "--baz", "old_space_val",
-            "--keep=123",
-        ]
-        new_args = [
-            "--foo=new_inline",
-            "--bar",
-            "--baz=new_space_val",
-        ]
-        result = deploy_rdk.remove_duplicate_sb_args(sb_args, new_args)
-        expected = [
-            "--keep=123",
-            "--foo=new_inline",
-            "--bar",
-            "--baz=new_space_val",
-        ]
-        self.assertEqual(result, expected)
+  def test_valid_param_flags(self):
+    """Verifies parse_args succeeds when valid -- flags are passed to --param."""
+    argv = ["deploy_rdk.py", "--param", "--url=www.youtube.com/tv", "--enable-heap-profiling"]
+    with mock.patch("sys.argv", argv):
+      args = deploy_rdk.parse_args()
+      self.assertEqual(args.param, ["--url=www.youtube.com/tv", "--enable-heap-profiling"])
 
-    def test_single_string_space_arg(self):
-        """Verifies deduplication when arguments contain internal spaces like '--bar 1'."""
-        # Single string with space in sb_args overridden by equals syntax
-        res1 = deploy_rdk.remove_duplicate_sb_args(["--bar 1", "--v=1"], ["--bar=2"])
-        self.assertEqual(res1, ["--v=1", "--bar=2"])
+  def test_user_override_replaces_script_args(self):
+    """Verifies user override flags in --param replace script-added flags if keys collide."""
+    script_args = ["--remote-debugging-port=9222"]
+    user_override_args = ["--remote-debugging-port=9999"]
+    override_args = deploy_rdk.remove_duplicate_sb_args(script_args, user_override_args)
+    self.assertEqual(override_args, ["--remote-debugging-port=9999"])
 
-        # Equals syntax in sb_args overridden by single string with space
-        res2 = deploy_rdk.remove_duplicate_sb_args(["--bar=1", "--v=1"], ["--bar 2"])
-        self.assertEqual(res2, ["--v=1", "--bar 2"])
+  def test_three_arg_precedence(self):
+    """Verifies remove_duplicate_sb_args correctly deduplicates across all 3 argument sources."""
+    cobalt_json_args = ["--v=1", "--remote-debugging-port=8080", "--url=https://old.com"]
+    script_args = ["--remote-debugging-port=9222"]
+    user_override_args = ["--remote-debugging-port=9999", "--enable-heap-profiling"]
 
-        # Two-item space arg in sb_args overridden by single string with space
-        res3 = deploy_rdk.remove_duplicate_sb_args(["--bar", "1", "--v=1"], ["--bar 2"])
-        self.assertEqual(res3, ["--v=1", "--bar 2"])
-
-    def test_positional_param_rejection(self):
-        """Verifies parse_args fails when positional arguments are passed to --param."""
-        argv = ["deploy_rdk.py", "--param", "www.youtube.com/tv"]
-        with mock.patch("sys.argv", argv):
-            with mock.patch("sys.exit") as mock_exit:
-                deploy_rdk.parse_args()
-                mock_exit.assert_called_once_with(1)
-
-    def test_valid_param_flags(self):
-        """Verifies parse_args succeeds when valid -- flags are passed to --param."""
-        argv = ["deploy_rdk.py", "--param", "--url=www.youtube.com/tv", "--enable-heap-profiling"]
-        with mock.patch("sys.argv", argv):
-            args = deploy_rdk.parse_args()
-            self.assertEqual(args.param, ["--url=www.youtube.com/tv", "--enable-heap-profiling"])
-
-    def test_user_override_replaces_script_args(self):
-        """Verifies user override flags in --param replace script-added flags if keys collide."""
-        script_args = ["--remote-debugging-port=9222"]
-        user_override_args = ["--remote-debugging-port=9999"]
-        override_args = deploy_rdk.remove_duplicate_sb_args(script_args, user_override_args)
-        self.assertEqual(override_args, ["--remote-debugging-port=9999"])
-
-    def test_three_arg_precedence(self):
-        """Verifies remove_duplicate_sb_args correctly deduplicates across all 3 argument sources."""
-        cobalt_json_args = ["--v=1", "--remote-debugging-port=8080", "--url=https://old.com"]
-        script_args = ["--remote-debugging-port=9222"]
-        user_override_args = ["--remote-debugging-port=9999", "--enable-heap-profiling"]
-
-        result = deploy_rdk.remove_duplicate_sb_args(
-            cobalt_json_args, script_args, user_override_args
-        )
-        self.assertEqual(
-            result,
-            ["--v=1", "--url=https://old.com", "--remote-debugging-port=9999", "--enable-heap-profiling"]
-        )
+    result = deploy_rdk.remove_duplicate_sb_args(
+        cobalt_json_args, script_args, user_override_args
+    )
+    self.assertEqual(
+        result,
+        ["--v=1", "--url=https://old.com", "--remote-debugging-port=9999", "--enable-heap-profiling"]
+    )
 
 
 if __name__ == "__main__":
-    unittest.main()
+  unittest.main()


### PR DESCRIPTION
## Summary
Removes space-separated flag handling from deploy_rdk.py and only supports --flag=val and boolean --flag arguments. Updates unit tests accordingly.

## Details
- Simplify _extract_flag_key and _filter_args_by_keys to avoid parsing space-separated argument pairs.
- Only --flag=val and boolean --flag formats are supported for argument deduplication.
- Remove obsolete space-separated tests in deploy_rdk_test.py. All 29 unit tests pass.

Bug: 502702565