### PR TITLE
ci: Remove remaining setup-gcloud actions

### DIFF
--- a/.github/actions/linux_browser_tests/action.yaml
+++ b/.github/actions/linux_browser_tests/action.yaml
@@ -26,9 +26,6 @@ runs:
         name: ${{ inputs.test_artifacts_key }}
         path: artifacts
 
-    - name: Set Up Cloud SDK
-      uses: google-github-actions/setup-gcloud@v2
-
     - name: Run Browser Tests (Linux)
       shell: bash
       env:

--- a/.github/workflows/tvos.yaml
+++ b/.github/workflows/tvos.yaml
@@ -119,13 +119,11 @@ jobs:
           exit 1
 
   download-artifacts:
-    # TODO(b/519669027): consider odt-runner for fetching the artifacts.
     needs: [get-sha, wait-for-kokoro-build, get-targets]
-    runs-on: [self-hosted, chrobalt-linux-runner]
+    runs-on: [self-hosted, odt-runner]
+    container:
+      image: ghcr.io/youtube/cobalt/linux:main
     steps:
-      - name: Set Up Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
-
       - name: Download Artifacts from GCS
         env:
           INVOCATION_ID: ${{ needs.wait-for-kokoro-build.outputs.invocation_id }}


### PR DESCRIPTION
Remove the google-github-actions/setup-gcloud action from the Linux
browser tests and tvOS workflows. `gcloud` is used from the docker image
instead.

Bug: 543494079