### PR TITLE
ci: Allow 'Fix' and 'Fixes' prefixes in check-bug-id lint workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -118,6 +118,6 @@ jobs:
         uses: gsactions/commit-message-checker@16fa2d5de096ae0d35626443bcd24f1e756cafee
         with:
           accessToken: ${{ secrets.GITHUB_TOKEN }}
-          pattern: '^(Bug|Fixed|Issue): \d+$'
+          pattern: '^(Bug|Fix|Fixed|Fixes|Issue): \d+$'
           flags: 'gm'
           error: 'PR title or description should include at least one bug ID.'


### PR DESCRIPTION
Update the check-bug-id workflow in .github/workflows/lint.yaml to accept Fix: and Fixes: prefixes in commit messages and PR descriptions in addition to Bug:, Fixed:, and Issue:.

Bug: 546235128