### PR TITLE
cobalt: Add memory ablation study

### DIFF
--- a/cobalt/BUILD.gn
+++ b/cobalt/BUILD.gn
@@ -351,6 +351,7 @@ test("cobalt_unittests") {
     "//cobalt/browser/h5vcc_metrics/histogram_fetcher_test.cc",
     "//cobalt/browser/h5vcc_native_stability/native_stability_manager_unittest.cc",
     "//cobalt/browser/h5vcc_runtime/deep_link_manager_unittest.cc",
+    "//cobalt/browser/memory_ablation_unittest.cc",
     "//cobalt/browser/metrics/cobalt_detailed_metrics_delegate_unittest.cc",
     "//cobalt/browser/metrics/cobalt_enabled_state_provider_test.cc",
     "//cobalt/browser/metrics/cobalt_metrics_log_uploader_test.cc",

--- a/cobalt/browser/BUILD.gn
+++ b/cobalt/browser/BUILD.gn
@@ -34,6 +34,8 @@ source_set("browser") {
     "cobalt_web_contents_observer.h",
     "h5vcc_settings_impl.cc",
     "h5vcc_settings_impl.h",
+    "memory_ablation.cc",
+    "memory_ablation.h",
   ]
 
   if (is_androidtv) {

--- a/cobalt/browser/cobalt_browser_main_parts.cc
+++ b/cobalt/browser/cobalt_browser_main_parts.cc
@@ -28,6 +28,7 @@
 #include "build/buildflag.h"
 #include "cobalt/browser/global_features.h"
 #include "cobalt/browser/h5vcc_native_stability/native_stability_manager.h"
+#include "cobalt/browser/memory_ablation.h"
 #include "cobalt/browser/metrics/cobalt_detailed_metrics_delegate.h"
 #include "cobalt/browser/metrics/cobalt_metrics_service_client.h"
 #include "cobalt/browser/switches.h"
@@ -229,6 +230,8 @@ int CobaltBrowserMainParts::PreMainMessageLoopRun() {
 #endif
 
   cobalt::memory::CobaltMemoryAttributionManager::Get()->Start();
+
+  MaybeApplyMemoryAblation();
 
 #if !BUILDFLAG(IS_ANDROIDTV)
   auto* client = CobaltContentBrowserClient::Get();

--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -78,5 +78,12 @@ BASE_FEATURE(kEnablePictureInPicture,
 #endif  // BUILDFLAG(IS_ANDROID)
 );
 
+BASE_FEATURE(kCobaltNativeMemoryAblation,
+             "CobaltNativeMemoryAblation",
+             base::FEATURE_DISABLED_BY_DEFAULT);
+
+const base::FeatureParam<int> kMemoryAblationSizeMBParam{
+    &kCobaltNativeMemoryAblation, "ablation_size_mb", 0};
+
 }  // namespace features
 }  // namespace cobalt

--- a/cobalt/browser/features.cc
+++ b/cobalt/browser/features.cc
@@ -85,5 +85,8 @@ BASE_FEATURE(kCobaltNativeMemoryAblation,
 const base::FeatureParam<int> kMemoryAblationSizeMBParam{
     &kCobaltNativeMemoryAblation, "ablation_size_mb", 0};
 
+const base::FeatureParam<base::TimeDelta> kMemoryAblationDelayParam{
+    &kCobaltNativeMemoryAblation, "ablation_delay", base::Seconds(0)};
+
 }  // namespace features
 }  // namespace cobalt

--- a/cobalt/browser/features.h
+++ b/cobalt/browser/features.h
@@ -19,6 +19,7 @@
 
 #include "base/feature_list.h"
 #include "base/metrics/field_trial_params.h"
+#include "base/time/time.h"
 
 namespace cobalt {
 namespace features {
@@ -73,6 +74,9 @@ extern const base::Feature kCobaltNativeMemoryAblation;
 
 // Memory ablation size to allocate in Megabytes (default: 0).
 extern const base::FeatureParam<int> kMemoryAblationSizeMBParam;
+
+// Delay before performing memory ablation (default: 0s).
+extern const base::FeatureParam<base::TimeDelta> kMemoryAblationDelayParam;
 
 }  // namespace features
 }  // namespace cobalt

--- a/cobalt/browser/features.h
+++ b/cobalt/browser/features.h
@@ -68,6 +68,12 @@ extern const base::Feature kForceVideoSplashScreen;
 // Enables video Picture-in-Picture support.
 extern const base::Feature kEnablePictureInPicture;
 
+// Enables native memory ablation study to verify Finch and memory metrics.
+extern const base::Feature kCobaltNativeMemoryAblation;
+
+// Memory ablation size to allocate in Megabytes (default: 0).
+extern const base::FeatureParam<int> kMemoryAblationSizeMBParam;
+
 }  // namespace features
 }  // namespace cobalt
 

--- a/cobalt/browser/h5vcc_metrics/histogram_fetcher.cc
+++ b/cobalt/browser/h5vcc_metrics/histogram_fetcher.cc
@@ -14,9 +14,13 @@
 
 #include "cobalt/browser/h5vcc_metrics/histogram_fetcher.h"
 
+#include <unordered_map>
+
 #include "base/base64url.h"
 #include "base/logging.h"
+#include "base/metrics/bucket_ranges.h"
 #include "base/metrics/histogram.h"
+#include "base/metrics/sample_map.h"
 #include "base/metrics/sample_vector.h"
 #include "base/metrics/statistics_recorder.h"
 #include "components/metrics/metrics_log.h"
@@ -94,7 +98,65 @@ std::string HistogramFetcher::FetchHistograms(
   base::Base64UrlEncode(serialized_proto,
                         base::Base64UrlEncodePolicy::INCLUDE_PADDING,
                         &base64_encoded_proto);
+
+  LOG(INFO) << "[UMA Memory Footprint] last_histogram_samples_ size: "
+            << last_histogram_samples_.size() << " entries, "
+            << GetEstimatedMemoryUsage() << " bytes allocated.";
+
   return base64_encoded_proto;
+}
+
+size_t HistogramFetcher::GetEstimatedMemoryUsage() const {
+  size_t total_bytes = 0;
+
+  // Overhead of the std::map last_histogram_samples_ itself (approx. 48 bytes
+  // per node)
+  total_bytes += last_histogram_samples_.size() * 48;
+
+  // Build a map of name_hash to HistogramBase* to look up bucket counts safely
+  std::unordered_map<uint64_t, const base::HistogramBase*> histogram_map;
+  for (const base::HistogramBase* const histogram :
+       base::StatisticsRecorder::GetHistograms()) {
+    histogram_map[histogram->name_hash()] = histogram;
+  }
+
+  for (const auto& [hash, samples] : last_histogram_samples_) {
+    if (!samples) {
+      continue;
+    }
+
+    // base::HistogramSamples instance overhead
+    total_bytes += sizeof(*samples);
+
+    // Look up the corresponding histogram
+    auto it = histogram_map.find(hash);
+    if (it != histogram_map.end()) {
+      const base::HistogramBase* histogram = it->second;
+      base::HistogramType type = histogram->GetHistogramType();
+
+      if (type == base::HISTOGRAM || type == base::LINEAR_HISTOGRAM ||
+          type == base::BOOLEAN_HISTOGRAM || type == base::CUSTOM_HISTOGRAM) {
+        // Safe RTTI-free static_cast based on the type check
+        const base::Histogram* linear_histogram =
+            static_cast<const base::Histogram*>(histogram);
+        // Dynamic counts array (4 bytes per bucket count)
+        total_bytes += linear_histogram->bucket_count() *
+                       sizeof(base::HistogramBase::AtomicCount);
+      } else {
+        // Otherwise, it's a SPARSE_HISTOGRAM (uses std::map)
+        size_t entries_count = 0;
+        std::unique_ptr<base::SampleCountIterator> sample_it =
+            samples->Iterator();
+        while (!sample_it->Done()) {
+          entries_count++;
+          sample_it->Next();
+        }
+        // std::map node overhead (approx. 48 bytes per entry)
+        total_bytes += entries_count * 48;
+      }
+    }
+  }
+  return total_bytes;
 }
 
 }  // namespace h5vcc_metrics

--- a/cobalt/browser/h5vcc_metrics/histogram_fetcher.cc
+++ b/cobalt/browser/h5vcc_metrics/histogram_fetcher.cc
@@ -14,13 +14,9 @@
 
 #include "cobalt/browser/h5vcc_metrics/histogram_fetcher.h"
 
-#include <unordered_map>
-
 #include "base/base64url.h"
 #include "base/logging.h"
-#include "base/metrics/bucket_ranges.h"
 #include "base/metrics/histogram.h"
-#include "base/metrics/sample_map.h"
 #include "base/metrics/sample_vector.h"
 #include "base/metrics/statistics_recorder.h"
 #include "components/metrics/metrics_log.h"
@@ -98,65 +94,7 @@ std::string HistogramFetcher::FetchHistograms(
   base::Base64UrlEncode(serialized_proto,
                         base::Base64UrlEncodePolicy::INCLUDE_PADDING,
                         &base64_encoded_proto);
-
-  LOG(INFO) << "[UMA Memory Footprint] last_histogram_samples_ size: "
-            << last_histogram_samples_.size() << " entries, "
-            << GetEstimatedMemoryUsage() << " bytes allocated.";
-
   return base64_encoded_proto;
-}
-
-size_t HistogramFetcher::GetEstimatedMemoryUsage() const {
-  size_t total_bytes = 0;
-
-  // Overhead of the std::map last_histogram_samples_ itself (approx. 48 bytes
-  // per node)
-  total_bytes += last_histogram_samples_.size() * 48;
-
-  // Build a map of name_hash to HistogramBase* to look up bucket counts safely
-  std::unordered_map<uint64_t, const base::HistogramBase*> histogram_map;
-  for (const base::HistogramBase* const histogram :
-       base::StatisticsRecorder::GetHistograms()) {
-    histogram_map[histogram->name_hash()] = histogram;
-  }
-
-  for (const auto& [hash, samples] : last_histogram_samples_) {
-    if (!samples) {
-      continue;
-    }
-
-    // base::HistogramSamples instance overhead
-    total_bytes += sizeof(*samples);
-
-    // Look up the corresponding histogram
-    auto it = histogram_map.find(hash);
-    if (it != histogram_map.end()) {
-      const base::HistogramBase* histogram = it->second;
-      base::HistogramType type = histogram->GetHistogramType();
-
-      if (type == base::HISTOGRAM || type == base::LINEAR_HISTOGRAM ||
-          type == base::BOOLEAN_HISTOGRAM || type == base::CUSTOM_HISTOGRAM) {
-        // Safe RTTI-free static_cast based on the type check
-        const base::Histogram* linear_histogram =
-            static_cast<const base::Histogram*>(histogram);
-        // Dynamic counts array (4 bytes per bucket count)
-        total_bytes += linear_histogram->bucket_count() *
-                       sizeof(base::HistogramBase::AtomicCount);
-      } else {
-        // Otherwise, it's a SPARSE_HISTOGRAM (uses std::map)
-        size_t entries_count = 0;
-        std::unique_ptr<base::SampleCountIterator> sample_it =
-            samples->Iterator();
-        while (!sample_it->Done()) {
-          entries_count++;
-          sample_it->Next();
-        }
-        // std::map node overhead (approx. 48 bytes per entry)
-        total_bytes += entries_count * 48;
-      }
-    }
-  }
-  return total_bytes;
 }
 
 }  // namespace h5vcc_metrics

--- a/cobalt/browser/h5vcc_metrics/histogram_fetcher.h
+++ b/cobalt/browser/h5vcc_metrics/histogram_fetcher.h
@@ -42,6 +42,9 @@ class HistogramFetcher {
                               metrics::MetricsServiceClient* service_client);
 
  private:
+  // Returns the estimated memory usage of `last_histogram_samples_` in bytes.
+  size_t GetEstimatedMemoryUsage() const;
+
   // Stores the last snapshot of histogram samples.
   std::map<uint64_t, std::unique_ptr<base::HistogramSamples>>
       last_histogram_samples_;

--- a/cobalt/browser/h5vcc_metrics/histogram_fetcher.h
+++ b/cobalt/browser/h5vcc_metrics/histogram_fetcher.h
@@ -42,9 +42,6 @@ class HistogramFetcher {
                               metrics::MetricsServiceClient* service_client);
 
  private:
-  // Returns the estimated memory usage of `last_histogram_samples_` in bytes.
-  size_t GetEstimatedMemoryUsage() const;
-
   // Stores the last snapshot of histogram samples.
   std::map<uint64_t, std::unique_ptr<base::HistogramSamples>>
       last_histogram_samples_;

--- a/cobalt/browser/memory_ablation.cc
+++ b/cobalt/browser/memory_ablation.cc
@@ -15,12 +15,16 @@
 #include "cobalt/browser/memory_ablation.h"
 
 #include <memory>
+#include <new>
 #include <vector>
 
 #include "base/feature_list.h"
+#include "base/functional/bind.h"
 #include "base/logging.h"
 #include "base/metrics/histogram_functions.h"
 #include "base/no_destructor.h"
+#include "base/task/sequenced_task_runner.h"
+#include "base/task/thread_pool.h"
 #include "cobalt/browser/features.h"
 
 namespace cobalt {
@@ -33,35 +37,25 @@ std::vector<std::unique_ptr<char[]>>& GetAblatedMemoryStore() {
   return *store;
 }
 
-}  // namespace
+void StoreAblatedMemory(std::unique_ptr<char[]> buffer, int size_mb) {
+  GetAblatedMemoryStore().push_back(std::move(buffer));
+  LOG(INFO) << "Native memory ablation successfully allocated and dirtied "
+            << size_mb << " MB.";
+}
 
-size_t MaybeApplyMemoryAblation() {
-  const bool is_enabled =
-      base::FeatureList::IsEnabled(features::kCobaltNativeMemoryAblation);
-  base::UmaHistogramBoolean("Cobalt.Features.NativeMemoryAblation.Enabled",
-                            is_enabled);
-
-  if (!is_enabled) {
-    return 0;
-  }
-
-  const int size_mb = features::kMemoryAblationSizeMBParam.Get();
-  base::UmaHistogramMemoryLargeMB(
-      "Cobalt.Features.NativeMemoryAblation.AllocatedMB", size_mb);
-
-  if (size_mb <= 0) {
-    LOG(INFO) << "Native memory ablation is enabled but ablation_size_mb is "
-              << size_mb << ". No memory allocated.";
-    return 0;
-  }
-
-  LOG(WARNING) << "Applying native memory ablation: allocating and dirtying "
-               << size_mb << " MB of RAM.";
-
+void DoMemoryAblationInBackground(
+    int size_mb,
+    scoped_refptr<base::SequencedTaskRunner> reply_runner) {
   const size_t bytes_to_allocate = static_cast<size_t>(size_mb) * 1024 * 1024;
   constexpr size_t kPageSize = 4096;
 
-  auto buffer = std::make_unique<char[]>(bytes_to_allocate);
+  auto buffer =
+      std::unique_ptr<char[]>(new (std::nothrow) char[bytes_to_allocate]);
+  if (!buffer) {
+    LOG(ERROR) << "Failed to allocate " << size_mb
+               << " MB for native memory ablation (OOM).";
+    return;
+  }
 
   // Touch each 4096-byte page using a volatile pointer so the compiler does
   // not optimize away the writes and the OS actually commits physical RAM pages
@@ -71,10 +65,59 @@ size_t MaybeApplyMemoryAblation() {
     raw_ptr[i] = static_cast<char>(i & 0xFF);
   }
 
-  GetAblatedMemoryStore().push_back(std::move(buffer));
-  LOG(INFO) << "Native memory ablation successfully allocated " << size_mb
-            << " MB.";
-  return static_cast<size_t>(size_mb);
+  if (reply_runner && reply_runner->RunsTasksInCurrentSequence()) {
+    StoreAblatedMemory(std::move(buffer), size_mb);
+  } else if (reply_runner) {
+    reply_runner->PostTask(
+        FROM_HERE,
+        base::BindOnce(&StoreAblatedMemory, std::move(buffer), size_mb));
+  } else {
+    StoreAblatedMemory(std::move(buffer), size_mb);
+  }
+}
+
+}  // namespace
+
+void MaybeApplyMemoryAblation() {
+  const bool is_enabled =
+      base::FeatureList::IsEnabled(features::kCobaltNativeMemoryAblation);
+  base::UmaHistogramBoolean("Cobalt.Features.NativeMemoryAblation.Enabled",
+                            is_enabled);
+
+  if (!is_enabled) {
+    return;
+  }
+
+  const int size_mb = features::kMemoryAblationSizeMBParam.Get();
+  base::UmaHistogramMemoryLargeMB(
+      "Cobalt.Features.NativeMemoryAblation.AllocatedMB", size_mb);
+
+  if (size_mb <= 0) {
+    LOG(INFO) << "Native memory ablation is enabled but ablation_size_mb is "
+              << size_mb << ". No memory allocated.";
+    return;
+  }
+
+  if (size_mb > kMaxAblationSizeMB) {
+    LOG(ERROR) << "Requested ablation size " << size_mb
+               << " MB exceeds maximum allowable limit (" << kMaxAblationSizeMB
+               << " MB). Ablation skipped.";
+    return;
+  }
+
+  LOG(WARNING) << "Dispatching native memory ablation: allocating and dirtying "
+               << size_mb << " MB of RAM in background.";
+
+  scoped_refptr<base::SequencedTaskRunner> reply_runner =
+      base::SequencedTaskRunner::HasCurrentDefault()
+          ? base::SequencedTaskRunner::GetCurrentDefault()
+          : nullptr;
+
+  base::ThreadPool::PostTask(
+      FROM_HERE,
+      {base::TaskPriority::BEST_EFFORT,
+       base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
+      base::BindOnce(&DoMemoryAblationInBackground, size_mb, reply_runner));
 }
 
 }  // namespace cobalt

--- a/cobalt/browser/memory_ablation.cc
+++ b/cobalt/browser/memory_ablation.cc
@@ -1,0 +1,80 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/memory_ablation.h"
+
+#include <memory>
+#include <vector>
+
+#include "base/feature_list.h"
+#include "base/logging.h"
+#include "base/metrics/histogram_functions.h"
+#include "base/no_destructor.h"
+#include "cobalt/browser/features.h"
+
+namespace cobalt {
+
+namespace {
+
+// Holds allocated buffers alive for the duration of the process.
+std::vector<std::unique_ptr<char[]>>& GetAblatedMemoryStore() {
+  static base::NoDestructor<std::vector<std::unique_ptr<char[]>>> store;
+  return *store;
+}
+
+}  // namespace
+
+size_t MaybeApplyMemoryAblation() {
+  const bool is_enabled =
+      base::FeatureList::IsEnabled(features::kCobaltNativeMemoryAblation);
+  base::UmaHistogramBoolean("Cobalt.Features.NativeMemoryAblation.Enabled",
+                            is_enabled);
+
+  if (!is_enabled) {
+    return 0;
+  }
+
+  const int size_mb = features::kMemoryAblationSizeMBParam.Get();
+  base::UmaHistogramMemoryLargeMB(
+      "Cobalt.Features.NativeMemoryAblation.AllocatedMB", size_mb);
+
+  if (size_mb <= 0) {
+    LOG(INFO) << "Native memory ablation is enabled but ablation_size_mb is "
+              << size_mb << ". No memory allocated.";
+    return 0;
+  }
+
+  LOG(WARNING) << "Applying native memory ablation: allocating and dirtying "
+               << size_mb << " MB of RAM.";
+
+  const size_t bytes_to_allocate = static_cast<size_t>(size_mb) * 1024 * 1024;
+  constexpr size_t kPageSize = 4096;
+
+  auto buffer = std::make_unique<char[]>(bytes_to_allocate);
+
+  // Touch each 4096-byte page using a volatile pointer so the compiler does
+  // not optimize away the writes and the OS actually commits physical RAM pages
+  // (RSS).
+  volatile char* raw_ptr = buffer.get();
+  for (size_t i = 0; i < bytes_to_allocate; i += kPageSize) {
+    raw_ptr[i] = static_cast<char>(i & 0xFF);
+  }
+
+  GetAblatedMemoryStore().push_back(std::move(buffer));
+  LOG(INFO) << "Native memory ablation successfully allocated " << size_mb
+            << " MB.";
+  return static_cast<size_t>(size_mb);
+}
+
+}  // namespace cobalt

--- a/cobalt/browser/memory_ablation.cc
+++ b/cobalt/browser/memory_ablation.cc
@@ -14,6 +14,7 @@
 
 #include "cobalt/browser/memory_ablation.h"
 
+#include <atomic>
 #include <memory>
 #include <new>
 #include <vector>
@@ -31,16 +32,18 @@ namespace cobalt {
 
 namespace {
 
+std::atomic_bool g_was_applied{false};
+
 // Holds allocated buffers alive for the duration of the process.
 std::vector<std::unique_ptr<char[]>>& GetAblatedMemoryStore() {
   static base::NoDestructor<std::vector<std::unique_ptr<char[]>>> store;
   return *store;
 }
 
-void StoreAblatedMemory(std::unique_ptr<char[]> buffer, int size_mb) {
+void StoreAblatedMemory(std::unique_ptr<char[]> buffer) {
   GetAblatedMemoryStore().push_back(std::move(buffer));
-  LOG(INFO) << "Native memory ablation successfully allocated and dirtied "
-            << size_mb << " MB.";
+  base::UmaHistogramEnumeration("Cobalt.Features.NativeMemoryAblation.Result",
+                                NativeMemoryAblationResult::kSuccess);
 }
 
 void DoMemoryAblationInBackground(
@@ -52,6 +55,8 @@ void DoMemoryAblationInBackground(
   auto buffer =
       std::unique_ptr<char[]>(new (std::nothrow) char[bytes_to_allocate]);
   if (!buffer) {
+    base::UmaHistogramEnumeration("Cobalt.Features.NativeMemoryAblation.Result",
+                                  NativeMemoryAblationResult::kOomFailure);
     LOG(ERROR) << "Failed to allocate " << size_mb
                << " MB for native memory ablation (OOM).";
     return;
@@ -66,19 +71,22 @@ void DoMemoryAblationInBackground(
   }
 
   if (reply_runner && reply_runner->RunsTasksInCurrentSequence()) {
-    StoreAblatedMemory(std::move(buffer), size_mb);
+    StoreAblatedMemory(std::move(buffer));
   } else if (reply_runner) {
     reply_runner->PostTask(
-        FROM_HERE,
-        base::BindOnce(&StoreAblatedMemory, std::move(buffer), size_mb));
+        FROM_HERE, base::BindOnce(&StoreAblatedMemory, std::move(buffer)));
   } else {
-    StoreAblatedMemory(std::move(buffer), size_mb);
+    StoreAblatedMemory(std::move(buffer));
   }
 }
 
 }  // namespace
 
 void MaybeApplyMemoryAblation() {
+  if (g_was_applied.exchange(true)) {
+    return;
+  }
+
   const bool is_enabled =
       base::FeatureList::IsEnabled(features::kCobaltNativeMemoryAblation);
   base::UmaHistogramBoolean("Cobalt.Features.NativeMemoryAblation.Enabled",
@@ -93,12 +101,12 @@ void MaybeApplyMemoryAblation() {
       "Cobalt.Features.NativeMemoryAblation.AllocatedMB", size_mb);
 
   if (size_mb <= 0) {
-    LOG(INFO) << "Native memory ablation is enabled but ablation_size_mb is "
-              << size_mb << ". No memory allocated.";
     return;
   }
 
   if (size_mb > kMaxAblationSizeMB) {
+    base::UmaHistogramEnumeration("Cobalt.Features.NativeMemoryAblation.Result",
+                                  NativeMemoryAblationResult::kExceedsMaxLimit);
     LOG(ERROR) << "Requested ablation size " << size_mb
                << " MB exceeds maximum allowable limit (" << kMaxAblationSizeMB
                << " MB). Ablation skipped.";
@@ -118,6 +126,11 @@ void MaybeApplyMemoryAblation() {
       {base::TaskPriority::BEST_EFFORT,
        base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
       base::BindOnce(&DoMemoryAblationInBackground, size_mb, reply_runner));
+}
+
+void ResetMemoryAblationForTesting() {
+  g_was_applied.store(false);
+  GetAblatedMemoryStore().clear();
 }
 
 }  // namespace cobalt

--- a/cobalt/browser/memory_ablation.cc
+++ b/cobalt/browser/memory_ablation.cc
@@ -26,6 +26,7 @@
 #include "base/no_destructor.h"
 #include "base/task/sequenced_task_runner.h"
 #include "base/task/thread_pool.h"
+#include "base/time/time.h"
 #include "cobalt/browser/features.h"
 
 namespace cobalt {
@@ -113,19 +114,19 @@ void MaybeApplyMemoryAblation() {
     return;
   }
 
-  LOG(WARNING) << "Dispatching native memory ablation: allocating and dirtying "
-               << size_mb << " MB of RAM in background.";
+  const base::TimeDelta delay = features::kMemoryAblationDelayParam.Get();
 
   scoped_refptr<base::SequencedTaskRunner> reply_runner =
       base::SequencedTaskRunner::HasCurrentDefault()
           ? base::SequencedTaskRunner::GetCurrentDefault()
           : nullptr;
 
-  base::ThreadPool::PostTask(
+  base::ThreadPool::PostDelayedTask(
       FROM_HERE,
       {base::TaskPriority::BEST_EFFORT,
        base::TaskShutdownBehavior::CONTINUE_ON_SHUTDOWN},
-      base::BindOnce(&DoMemoryAblationInBackground, size_mb, reply_runner));
+      base::BindOnce(&DoMemoryAblationInBackground, size_mb, reply_runner),
+      delay);
 }
 
 void ResetMemoryAblationForTesting() {

--- a/cobalt/browser/memory_ablation.h
+++ b/cobalt/browser/memory_ablation.h
@@ -15,15 +15,17 @@
 #ifndef COBALT_BROWSER_MEMORY_ABLATION_H_
 #define COBALT_BROWSER_MEMORY_ABLATION_H_
 
-#include <stddef.h>
-
 namespace cobalt {
+
+// Maximum allowed native memory ablation size in Megabytes (256 MB) to prevent
+// extreme memory allocations or integer overflow on resource-constrained
+// devices.
+constexpr int kMaxAblationSizeMB = 256;
 
 // Checks if the native memory ablation Finch feature is enabled and,
 // if so, allocates and commits (dirties) the requested amount of native memory
-// to hold for the lifetime of the process.
-// Returns the number of Megabytes allocated, or 0 if disabled/not allocated.
-size_t MaybeApplyMemoryAblation();
+// on a background thread to hold for the lifetime of the process.
+void MaybeApplyMemoryAblation();
 
 }  // namespace cobalt
 

--- a/cobalt/browser/memory_ablation.h
+++ b/cobalt/browser/memory_ablation.h
@@ -34,7 +34,8 @@ enum class NativeMemoryAblationResult {
 
 // Checks if the native memory ablation Finch feature is enabled and,
 // if so, allocates and commits (dirties) the requested amount of native memory
-// on a background thread to hold for the lifetime of the process.
+// on a background thread after an optional delay to hold for the lifetime of
+// the process.
 // Strictly executes at most once per application lifetime.
 void MaybeApplyMemoryAblation();
 

--- a/cobalt/browser/memory_ablation.h
+++ b/cobalt/browser/memory_ablation.h
@@ -1,0 +1,30 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef COBALT_BROWSER_MEMORY_ABLATION_H_
+#define COBALT_BROWSER_MEMORY_ABLATION_H_
+
+#include <stddef.h>
+
+namespace cobalt {
+
+// Checks if the native memory ablation Finch feature is enabled and,
+// if so, allocates and commits (dirties) the requested amount of native memory
+// to hold for the lifetime of the process.
+// Returns the number of Megabytes allocated, or 0 if disabled/not allocated.
+size_t MaybeApplyMemoryAblation();
+
+}  // namespace cobalt
+
+#endif  // COBALT_BROWSER_MEMORY_ABLATION_H_

--- a/cobalt/browser/memory_ablation.h
+++ b/cobalt/browser/memory_ablation.h
@@ -22,10 +22,24 @@ namespace cobalt {
 // devices.
 constexpr int kMaxAblationSizeMB = 256;
 
+// Outcome of native memory ablation allocation attempt.
+// These values are persisted to logs. Entries should not be renumbered and
+// numeric values should never be reused.
+enum class NativeMemoryAblationResult {
+  kSuccess = 0,
+  kOomFailure = 1,
+  kExceedsMaxLimit = 2,
+  kMaxValue = kExceedsMaxLimit,
+};
+
 // Checks if the native memory ablation Finch feature is enabled and,
 // if so, allocates and commits (dirties) the requested amount of native memory
 // on a background thread to hold for the lifetime of the process.
+// Strictly executes at most once per application lifetime.
 void MaybeApplyMemoryAblation();
+
+// Resets internal state for unit testing.
+void ResetMemoryAblationForTesting();
 
 }  // namespace cobalt
 

--- a/cobalt/browser/memory_ablation_unittest.cc
+++ b/cobalt/browser/memory_ablation_unittest.cc
@@ -14,49 +14,80 @@
 
 #include "cobalt/browser/memory_ablation.h"
 
+#include <string>
+
+#include "base/strings/string_number_conversions.h"
 #include "base/test/metrics/histogram_tester.h"
 #include "base/test/scoped_feature_list.h"
+#include "base/test/task_environment.h"
 #include "cobalt/browser/features.h"
 #include "testing/gtest/include/gtest/gtest.h"
 
 namespace cobalt {
 namespace {
 
-TEST(MemoryAblationTest, DisabledByDefault) {
-  base::HistogramTester histogram_tester;
+class MemoryAblationTest : public ::testing::Test {
+ protected:
+  base::test::TaskEnvironment task_environment_;
+  base::HistogramTester histogram_tester_;
+};
+
+TEST_F(MemoryAblationTest, DisabledByDefault) {
   base::test::ScopedFeatureList scoped_feature_list;
   scoped_feature_list.InitAndDisableFeature(
       features::kCobaltNativeMemoryAblation);
 
-  EXPECT_EQ(MaybeApplyMemoryAblation(), 0u);
-  histogram_tester.ExpectUniqueSample(
+  MaybeApplyMemoryAblation();
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.Enabled", false, 1);
+  histogram_tester_.ExpectTotalCount(
+      "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 0);
 }
 
-TEST(MemoryAblationTest, EnabledWithZeroSize) {
-  base::HistogramTester histogram_tester;
+TEST_F(MemoryAblationTest, EnabledWithZeroSize) {
   base::test::ScopedFeatureList scoped_feature_list;
   scoped_feature_list.InitAndEnableFeatureWithParameters(
       features::kCobaltNativeMemoryAblation, {{"ablation_size_mb", "0"}});
 
-  EXPECT_EQ(MaybeApplyMemoryAblation(), 0u);
-  histogram_tester.ExpectUniqueSample(
+  MaybeApplyMemoryAblation();
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
-  histogram_tester.ExpectUniqueSample(
+  histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 0, 1);
 }
 
-TEST(MemoryAblationTest, EnabledWithAllocatedSize) {
-  base::HistogramTester histogram_tester;
+TEST_F(MemoryAblationTest, EnabledWithAllocatedSize) {
   base::test::ScopedFeatureList scoped_feature_list;
   scoped_feature_list.InitAndEnableFeatureWithParameters(
       features::kCobaltNativeMemoryAblation, {{"ablation_size_mb", "1"}});
 
-  EXPECT_EQ(MaybeApplyMemoryAblation(), 1u);
-  histogram_tester.ExpectUniqueSample(
+  MaybeApplyMemoryAblation();
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
-  histogram_tester.ExpectUniqueSample(
+  histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 1, 1);
+}
+
+TEST_F(MemoryAblationTest, EnabledWithExceedingMaxSize) {
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      features::kCobaltNativeMemoryAblation,
+      {{"ablation_size_mb", base::NumberToString(kMaxAblationSizeMB + 1)}});
+
+  MaybeApplyMemoryAblation();
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.AllocatedMB",
+      kMaxAblationSizeMB + 1, 1);
 }
 
 }  // namespace

--- a/cobalt/browser/memory_ablation_unittest.cc
+++ b/cobalt/browser/memory_ablation_unittest.cc
@@ -1,0 +1,63 @@
+// Copyright 2026 The Cobalt Authors. All Rights Reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "cobalt/browser/memory_ablation.h"
+
+#include "base/test/metrics/histogram_tester.h"
+#include "base/test/scoped_feature_list.h"
+#include "cobalt/browser/features.h"
+#include "testing/gtest/include/gtest/gtest.h"
+
+namespace cobalt {
+namespace {
+
+TEST(MemoryAblationTest, DisabledByDefault) {
+  base::HistogramTester histogram_tester;
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndDisableFeature(
+      features::kCobaltNativeMemoryAblation);
+
+  EXPECT_EQ(MaybeApplyMemoryAblation(), 0u);
+  histogram_tester.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Enabled", false, 1);
+}
+
+TEST(MemoryAblationTest, EnabledWithZeroSize) {
+  base::HistogramTester histogram_tester;
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      features::kCobaltNativeMemoryAblation, {{"ablation_size_mb", "0"}});
+
+  EXPECT_EQ(MaybeApplyMemoryAblation(), 0u);
+  histogram_tester.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
+  histogram_tester.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 0, 1);
+}
+
+TEST(MemoryAblationTest, EnabledWithAllocatedSize) {
+  base::HistogramTester histogram_tester;
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      features::kCobaltNativeMemoryAblation, {{"ablation_size_mb", "1"}});
+
+  EXPECT_EQ(MaybeApplyMemoryAblation(), 1u);
+  histogram_tester.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
+  histogram_tester.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 1, 1);
+}
+
+}  // namespace
+}  // namespace cobalt

--- a/cobalt/browser/memory_ablation_unittest.cc
+++ b/cobalt/browser/memory_ablation_unittest.cc
@@ -32,7 +32,8 @@ class MemoryAblationTest : public ::testing::Test {
 
   void TearDown() override { ResetMemoryAblationForTesting(); }
 
-  base::test::TaskEnvironment task_environment_;
+  base::test::TaskEnvironment task_environment_{
+      base::test::TaskEnvironment::TimeSource::MOCK_TIME};
   base::HistogramTester histogram_tester_;
 };
 
@@ -80,6 +81,35 @@ TEST_F(MemoryAblationTest, EnabledWithAllocatedSize) {
       "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
   histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 1, 1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Result",
+      NativeMemoryAblationResult::kSuccess, 1);
+}
+
+TEST_F(MemoryAblationTest, EnabledWithDelayedExecution) {
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      features::kCobaltNativeMemoryAblation,
+      {{"ablation_size_mb", "1"}, {"ablation_delay", "5s"}});
+
+  MaybeApplyMemoryAblation();
+  task_environment_.RunUntilIdle();
+
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 1, 1);
+  // Task should not have run yet because of 5s delay.
+  histogram_tester_.ExpectTotalCount(
+      "Cobalt.Features.NativeMemoryAblation.Result", 0);
+
+  // Fast-forward by 4 seconds (still not run).
+  task_environment_.FastForwardBy(base::Seconds(4));
+  histogram_tester_.ExpectTotalCount(
+      "Cobalt.Features.NativeMemoryAblation.Result", 0);
+
+  // Fast-forward by remaining 1 second (now runs).
+  task_environment_.FastForwardBy(base::Seconds(1));
   histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.Result",
       NativeMemoryAblationResult::kSuccess, 1);

--- a/cobalt/browser/memory_ablation_unittest.cc
+++ b/cobalt/browser/memory_ablation_unittest.cc
@@ -28,6 +28,10 @@ namespace {
 
 class MemoryAblationTest : public ::testing::Test {
  protected:
+  void SetUp() override { ResetMemoryAblationForTesting(); }
+
+  void TearDown() override { ResetMemoryAblationForTesting(); }
+
   base::test::TaskEnvironment task_environment_;
   base::HistogramTester histogram_tester_;
 };
@@ -44,6 +48,8 @@ TEST_F(MemoryAblationTest, DisabledByDefault) {
       "Cobalt.Features.NativeMemoryAblation.Enabled", false, 1);
   histogram_tester_.ExpectTotalCount(
       "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 0);
+  histogram_tester_.ExpectTotalCount(
+      "Cobalt.Features.NativeMemoryAblation.Result", 0);
 }
 
 TEST_F(MemoryAblationTest, EnabledWithZeroSize) {
@@ -58,6 +64,8 @@ TEST_F(MemoryAblationTest, EnabledWithZeroSize) {
       "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
   histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 0, 1);
+  histogram_tester_.ExpectTotalCount(
+      "Cobalt.Features.NativeMemoryAblation.Result", 0);
 }
 
 TEST_F(MemoryAblationTest, EnabledWithAllocatedSize) {
@@ -72,6 +80,9 @@ TEST_F(MemoryAblationTest, EnabledWithAllocatedSize) {
       "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
   histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 1, 1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Result",
+      NativeMemoryAblationResult::kSuccess, 1);
 }
 
 TEST_F(MemoryAblationTest, EnabledWithExceedingMaxSize) {
@@ -88,6 +99,31 @@ TEST_F(MemoryAblationTest, EnabledWithExceedingMaxSize) {
   histogram_tester_.ExpectUniqueSample(
       "Cobalt.Features.NativeMemoryAblation.AllocatedMB",
       kMaxAblationSizeMB + 1, 1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Result",
+      NativeMemoryAblationResult::kExceedsMaxLimit, 1);
+}
+
+TEST_F(MemoryAblationTest, ExecutesAtMostOnce) {
+  base::test::ScopedFeatureList scoped_feature_list;
+  scoped_feature_list.InitAndEnableFeatureWithParameters(
+      features::kCobaltNativeMemoryAblation, {{"ablation_size_mb", "1"}});
+
+  MaybeApplyMemoryAblation();
+  task_environment_.RunUntilIdle();
+
+  // Call second time within same app lifetime
+  MaybeApplyMemoryAblation();
+  task_environment_.RunUntilIdle();
+
+  // Histograms should only have 1 sample
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Enabled", true, 1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.AllocatedMB", 1, 1);
+  histogram_tester_.ExpectUniqueSample(
+      "Cobalt.Features.NativeMemoryAblation.Result",
+      NativeMemoryAblationResult::kSuccess, 1);
 }
 
 }  // namespace

--- a/tools/metrics/histograms/metadata/cobalt/enums.xml
+++ b/tools/metrics/histograms/metadata/cobalt/enums.xml
@@ -60,6 +60,12 @@ https://chromium.googlesource.com/chromium/src.git/+/HEAD/tools/metrics/histogra
   <int value="4" label="Timeout"/>
 </enum>
 
+<enum name="NativeMemoryAblationResult">
+  <int value="0" label="Success"/>
+  <int value="1" label="Allocation Failed (OOM)"/>
+  <int value="2" label="Exceeds Max Limit"/>
+</enum>
+
 <enum name="SentinelWriteResult">
   <int value="0" label="Success"/>
   <int value="1" label="Empty Path"/>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -53,6 +53,24 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.Features.NativeMemoryAblation.AllocatedMB" units="MB"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the amount of native memory allocated in megabytes when the native
+    memory ablation Finch feature is enabled.
+  </summary>
+</histogram>
+
+<histogram name="Cobalt.Features.NativeMemoryAblation.Enabled" enum="Boolean"
+    expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records whether the native memory ablation Finch feature is enabled. Used to
+    verify experiment arm rollout for Finch validation.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.Features.TestFinchFeature" enum="Boolean"
     expires_after="never">
   <owner>yijiazhang@google.com</owner>

--- a/tools/metrics/histograms/metadata/cobalt/histograms.xml
+++ b/tools/metrics/histograms/metadata/cobalt/histograms.xml
@@ -71,6 +71,14 @@ Always run the pretty print utility on this file after editing:
   </summary>
 </histogram>
 
+<histogram name="Cobalt.Features.NativeMemoryAblation.Result"
+    enum="NativeMemoryAblationResult" expires_after="never">
+  <owner>yijiazhang@google.com</owner>
+  <summary>
+    Records the outcome of the native memory ablation allocation attempt.
+  </summary>
+</histogram>
+
 <histogram name="Cobalt.Features.TestFinchFeature" enum="Boolean"
     expires_after="never">
   <owner>yijiazhang@google.com</owner>


### PR DESCRIPTION
Introduce a mechanism to perform native memory ablation studies via
Finch. This allows Cobalt to allocate and dirty a configurable amount
of memory at startup to facilitate the verification of memory metrics
and the impact of memory pressure on performance in experiment arms.

The allocation is held for the duration of the process. This update
also includes telemetry for the ablation state

Bug: 543418301