### PR TITLE
Add artifact regex for tvOS builds

### DIFF
--- a/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
+++ b/cobalt/devinfra/kokoro/build/tvos/arm64/common.gcl
@@ -31,6 +31,7 @@ build = common.build {
       define_artifacts = {
         regex = [
           '**/*.tar.gz',
+          '**/*.zip',
         ]
       }
     },


### PR DESCRIPTION
tvos: Include zip files in build artifacts

Update the Kokoro artifact configuration for tvOS to include zip
files. This ensures that Apple and tvOS deployment bundles are
properly captured during the build process.

Bug: 538697105