### PR TITLE
android: Fix stray indentation in StarboardFeatures.java.tmpl

### DIFF
--- a/cobalt/android/java_templates/StarboardFeatures.java.tmpl
+++ b/cobalt/android/java_templates/StarboardFeatures.java.tmpl
@@ -12,15 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
- package dev.cobalt.features;
+package dev.cobalt.features;
 
- /**
-  * Contains features that are specific to Starboard code.
-  */
- public final class StarboardFeatures {{
+/**
+ * Contains features that are specific to Starboard code.
+ */
+public final class StarboardFeatures {{
 
- {NATIVE_FEATURES}
+{NATIVE_FEATURES}
 
-     // Prevents instantiation.
-     private StarboardFeatures() {{}}
- }}
+    // Prevents instantiation.
+    private StarboardFeatures() {{}}
+}}


### PR DESCRIPTION
Every line has been shifted right by one space since this file was added in dc87afaa7fb, so java_cpp_utils.ParseTemplateFile() can't find the package declaration and codegen fails with "Could not find java package." This stayed silent until https://crrev.com/c/6661359 (included in Chromium M139) turned a missing package into a hard build failure, which is what surfaces it now when building android-arm64.

Bug: 447651764